### PR TITLE
fix(#1315): lockless intermediate 발사를 감지된 trainCode에 바인딩

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -28,7 +28,7 @@ import {
 } from '../scheduled';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from '../seoul';
 import { putTrip } from '../trips';
-import type { BoardingLockMeta, Env, Trip, Waypoint } from '../types';
+import type { BoardingLockMeta, Env, PositionPoint, Trip, Waypoint } from '../types';
 import { InMemoryKV } from './inMemoryKv';
 
 let apnsConfig: ApnsConfig;
@@ -238,6 +238,28 @@ async function seedHappyGateSeries(kv: InMemoryKV, token: string): Promise<void>
     { lat: 0, lng: 0.0008, accuracy: 10, ts: NOW, motion: 'automotive' },
   ];
   await kv.put(`pos:${token}`, JSON.stringify(series));
+}
+
+// #1315 — lockless motion 게이트 테스트 공용 3-sample series. 게이트는 posMetrics.motion만 읽으므로
+// motion을 파라미터로 받고, nearestStationDistanceM이 있으면 phaseState stamp(dirty)도 발생시킨다.
+async function seedLocklessMotionSeries(
+  kv: InMemoryKV,
+  token: string,
+  motion: PositionPoint['motion'],
+  nearestStationDistanceM?: number,
+): Promise<void> {
+  const base = (ts: number, lng: number) => ({
+    lat: 0,
+    lng,
+    accuracy: 10,
+    ts,
+    motion,
+    ...(nearestStationDistanceM === undefined ? {} : { nearestStationDistanceM }),
+  });
+  await kv.put(
+    `pos:${token}`,
+    JSON.stringify([base(NOW - 40_000, 0), base(NOW - 20_000, 0.0002), base(NOW, 0.0004)]),
+  );
 }
 
 // #916 auto-lock 테스트용 trip 시드. promptGeoContext + promptDisplay + waypoints 9단 게이트 통과 형태.
@@ -503,13 +525,21 @@ describe('runScheduled', () => {
      *     (lockMissing 게이트 등으로 Seoul 호출 자체가 일어나면 안 되는 시나리오용)
      *   - 배열 (빈 배열 포함): makeSeoul로 실제 응답 — 빈 배열은 etaMissing 트리거
      */
+    // #1315 — lockless bare-arvlCd advance는 GPS motion이 walking/automotive일 때만 허용된다.
+    // 발사를 기대하는 케이스는 `motion='automotive'`(default)로 이동 series를 시드한다. 정적
+    // (false advance 회귀)을 검증하는 케이스는 'stationary' / 'unknown' 또는 'none'(series 미시드)을 준다.
     async function runLocklessCycle(input: {
       trip: Trip;
       arrivals?: ArrivalEntry[];
       apnsOk?: boolean;
+      motion?: PositionPoint['motion'] | 'none';
     }) {
       const kv = new InMemoryKV();
       await putTrip(kv as unknown as KVNamespace, input.trip);
+      const motion = input.motion ?? 'automotive';
+      if (motion !== 'none') {
+        await seedLocklessMotionSeries(kv, input.trip.token, motion);
+      }
       const seoulFetch = vi.fn();
       const seoul = input.arrivals
         ? makeSeoul(input.arrivals)
@@ -727,6 +757,8 @@ describe('runScheduled', () => {
         locklessStationPassed: true,
       });
       await putTrip(kv as unknown as KVNamespace, trip);
+      // #1315 — bare-arvlCd advance는 motion=walking/automotive에서만 허용 → 이동 series 시드.
+      await seedLocklessMotionSeries(kv, trip.token, 'automotive');
       const seoul = makeSeoul([ARVL_ARRIVED]);
       const apnsFetch = vi.fn(async () => new Response('', { status: 200 }) as unknown as Response);
       await runScheduled(makeEnv(kv), {
@@ -740,6 +772,257 @@ describe('runScheduled', () => {
       const progress = JSON.parse(progressRaw as string);
       expect(progress.lockless).toBe(true);
       expect(progress.shiftedCount).toBe(2);
+    });
+
+    // #1315 — trainCode 미확보 cycle의 보수 motion 게이트 + trainCode 바인딩.
+    // 정적(용마산 false advance 회귀)에서는 waypoint 역의 "아무 열차" arvlCd가 와도 advance 안 함.
+    describe('#1315 — trainCode 바인딩 + 보수 motion 게이트', () => {
+      async function storedFirstWaypoint(kv: InMemoryKV): Promise<string> {
+        const raw = await (kv as unknown as KVNamespace).get('trip:tok');
+        return JSON.parse(raw as string).waypoints[0].stationName;
+      }
+
+      // 다른 열차(trainCode=9999, arvlCd=ARRIVED)가 다음 waypoint에 도착 — 사용자 열차 아님.
+      const OTHER_TRAIN_ARRIVED: ArrivalEntry = { ...ARVL_ARRIVED, trainCode: '9999' };
+
+      // 보수 게이트 케이스: motion이 실제 이동(walking/automotive)이면 발사, 그 외(stationary/
+      // unknown/series 미시드)면 보류. arrivals는 모두 ARRIVED(=bare arvlCd 신호) — trainCode 바인딩
+      // 불가(promptGeoContext 부재) 상태에서 motion만으로 advance 여부가 갈리는지 검증.
+      type MotionGateCase = {
+        label: string;
+        motion: PositionPoint['motion'] | 'none';
+        fires: boolean;
+      };
+      const motionGateCases: MotionGateCase[] = [
+        { label: 'stationary → advance 안 함', motion: 'stationary', fires: false },
+        { label: 'unknown → advance 안 함', motion: 'unknown', fires: false },
+        { label: 'series 미시드(unknown) → advance 안 함', motion: 'none', fires: false },
+        { label: 'automotive → 발사', motion: 'automotive', fires: true },
+        { label: 'walking → 발사', motion: 'walking', fires: true },
+      ];
+
+      it.each(motionGateCases)(
+        'trainCode 미확보 + 다른 열차 ARRIVED + motion=$motion → $label',
+        async ({ motion, fires }) => {
+          const { kv, stats, apnsFetch } = await runLocklessCycle({
+            trip: intermediateTrip(),
+            arrivals: [OTHER_TRAIN_ARRIVED],
+            apnsOk: fires,
+            motion,
+          });
+          expect(stats.locklessIntermediateFired).toBe(fires ? 1 : 0);
+          expect(stats.pushed).toBe(fires ? 1 : 0);
+          expect(stats.locklessMotionGateBlocked).toBe(fires ? 0 : 1);
+          // 발사 안 하면 첫 waypoint(강남) 유지 — multi/단일 advance 모두 차단.
+          expect(await storedFirstWaypoint(kv)).toBe(fires ? '역삼' : '강남');
+          if (fires) {
+            expect(apnsFetch).toHaveBeenCalled();
+          } else {
+            expect(apnsFetch).not.toHaveBeenCalled();
+          }
+        },
+      );
+
+      // 레이스 가드: 정적 상태에서 연속 2 cycle 모두 bare-arvlCd가 와도 advance 0건.
+      // (2026-06-15 군자→어린이대공원→건대입구 44초 레이스의 근원 — 정적인데 다중 advance.)
+      it('정적 상태 연속 2 cycle → 다중 waypoint advance 0건 (레이스 차단)', async () => {
+        const kv = new InMemoryKV();
+        const trip = makeTrip({
+          waypoints: [
+            { stationName: '군자', line: '2', kind: 'intermediate' },
+            { stationName: '어린이대공원', line: '2', kind: 'intermediate' },
+            { stationName: '건대입구', line: '2', kind: 'destination' },
+          ],
+          locklessStationPassed: true,
+        });
+        await putTrip(kv as unknown as KVNamespace, trip);
+        await seedLocklessMotionSeries(kv, trip.token, 'stationary');
+        const seoul = makeSeoul([OTHER_TRAIN_ARRIVED]);
+        const apnsFetch = vi.fn();
+        const deps = {
+          seoul,
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW,
+        };
+        await runScheduled(makeEnv(kv), deps);
+        await runScheduled(makeEnv(kv), deps);
+        expect(apnsFetch).not.toHaveBeenCalled();
+        expect(await storedFirstWaypoint(kv)).toBe('군자');
+      });
+
+      // motion 게이트 보류 시에도 phase 분류 결과(dirty)는 persist — nearestStationDistanceM이 있어
+      // phaseState가 stamp된 cycle에서 정적이라 advance는 보류하되 trip은 저장돼야 한다.
+      it('정적 + phaseState stamp → advance 보류 + trip에 stationPhase 저장', async () => {
+        const kv = new InMemoryKV();
+        const trip = intermediateTrip();
+        await putTrip(kv as unknown as KVNamespace, trip);
+        // 정거장 30m + 정지 → DWELLING(confidence<0.7, phase 게이트 통과) + motion=stationary.
+        await seedLocklessMotionSeries(kv, trip.token, 'stationary', 30);
+        const apnsFetch = vi.fn();
+        const stats = await runScheduled(makeEnv(kv), {
+          seoul: makeSeoul([OTHER_TRAIN_ARRIVED]),
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW,
+        });
+        expect(stats.locklessMotionGateBlocked).toBe(1);
+        expect(stats.locklessIntermediateFired).toBe(0);
+        expect(apnsFetch).not.toHaveBeenCalled();
+        const stored = JSON.parse((await (kv as unknown as KVNamespace).get('trip:tok')) as string);
+        expect(stored.stationPhase?.current).toBe('DWELLING');
+        expect(stored.waypoints[0].stationName).toBe('강남');
+      });
+
+      // trainCode 바인딩: 9단 게이트 통과(이동 + 단일 후보) → lock 부착, 이번 cycle은 station-passed
+      // 발사 안 함(다음 cron 사이클이 lock 경로로 *그 trainCode*만 추적 — lockless 안정성 핵심).
+      function geoLocklessTrip(overrides: Partial<Trip> = {}): Trip {
+        return makeTrip({
+          waypoints: [
+            { stationName: '역삼', line: '2', kind: 'intermediate' },
+            { stationName: '선릉', line: '2', kind: 'destination' },
+          ],
+          locklessStationPassed: true,
+          promptGeoContext: {
+            origin: { lat: 0, lng: 0 },
+            nextStation: { lat: 0, lng: 0.01 },
+            direction: 'up',
+          },
+          promptDisplay: { originStation: '강남', line: '2' },
+          ...overrides,
+        });
+      }
+
+      it('이동 + 단일 후보 trainCode → auto-lock 부착 + 이번 cycle 발사 안 함', async () => {
+        const { kv, stats, apnsFetch } = await runLocklessCycle({
+          trip: geoLocklessTrip(),
+          arrivals: [ARVL_ARRIVED], // trainCode=7246 단일 후보, arvlCd=ARRIVED.
+          apnsOk: false,
+          motion: 'automotive',
+        });
+        expect(stats.autoLockSuccess).toBe(1);
+        expect(stats.locklessIntermediateFired).toBe(0);
+        expect(apnsFetch).not.toHaveBeenCalled();
+        const stored = JSON.parse((await (kv as unknown as KVNamespace).get('trip:tok')) as string);
+        expect(stored.boardingLock?.trainCode).toBe('7246');
+        expect(stored.boardingLock?.autoLockedAt).toBe(NOW);
+        // 바인딩만 — waypoint는 아직 advance 안 함(다음 cycle lock 경로가 처리).
+        expect(stored.waypoints[0].stationName).toBe('역삼');
+      });
+
+      it('바인딩된 trainCode의 ARRIVED → 다음 cycle lock 경로(runTrainCodeTracking)가 그 열차로 추적', async () => {
+        // 1 cycle: 바인딩. 2 cycle: lock 활성 → trainCode 매칭 도착 시 매역 fire.
+        const kv = new InMemoryKV();
+        await putTrip(kv as unknown as KVNamespace, geoLocklessTrip());
+        await seedHappyGateSeries(kv, 'tok');
+        const apnsFetch = vi.fn(async () => new Response('', { status: 200 }) as unknown as Response);
+        const deps = {
+          seoul: makeSeoul([ARVL_ARRIVED]),
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW,
+        };
+        const first = await runScheduled(makeEnv(kv), deps);
+        expect(first.autoLockSuccess).toBe(1);
+        const second = await runScheduled(makeEnv(kv), deps);
+        // lock 활성이므로 lockMissing/lockless 경로가 아니라 trainCode 추적 경로로 polled.
+        expect(second.polled).toBe(1);
+        expect(second.lockMissing).toBe(0);
+        // trainCode=7246의 ARRIVED → 매역 arvlCd fire (lock 경로 SSOT).
+        expect(second.arvlCdFireSuccess).toBe(1);
+      });
+
+      it('promptGeoContext 부재면 바인딩 시도 안 함 → 이동 시 기존 bare-arvlCd 발사 유지', async () => {
+        const { stats } = await runLocklessCycle({
+          trip: intermediateTrip(), // geo 컨텍스트 없음.
+          arrivals: [ARVL_ARRIVED],
+          apnsOk: true,
+          motion: 'automotive',
+        });
+        expect(stats.autoLockSuccess).toBe(0);
+        expect(stats.locklessIntermediateFired).toBe(1);
+      });
+
+      it('geo 있음 + 9단 게이트 실패(정적) → 바인딩 안 함 + motion 게이트로 보류', async () => {
+        const { stats, apnsFetch } = await runLocklessCycle({
+          trip: geoLocklessTrip(),
+          arrivals: [ARVL_ARRIVED],
+          apnsOk: false,
+          motion: 'stationary', // 게이트 #8 motion-not-moving로 차단.
+        });
+        expect(stats.autoLockSuccess).toBe(0);
+        expect(stats.locklessIntermediateFired).toBe(0);
+        expect(stats.locklessMotionGateBlocked).toBe(1);
+        expect(apnsFetch).not.toHaveBeenCalled();
+      });
+
+      it('geo 있음 + 게이트 통과 + 후보 ambiguity → 바인딩 null, 이동이므로 bare-arvlCd 발사', async () => {
+        // 같은 방향(up) line-2 ARRIVED 후보 2개 → pickAutoTrainCode ambiguity → autoLock null.
+        const { stats } = await runLocklessCycle({
+          trip: geoLocklessTrip(),
+          arrivals: [
+            { ...ARVL_ARRIVED, trainCode: 'A1' },
+            { ...ARVL_ARRIVED, trainCode: 'A2' },
+          ],
+          apnsOk: true,
+          motion: 'automotive',
+        });
+        expect(stats.autoLockSuccess).toBe(0);
+        expect(stats.locklessIntermediateFired).toBe(1);
+      });
+
+      it('arvlCd=2(출발) 단일 후보 + origin 확인 → confidence trace를 TELEMETRY에 적재', async () => {
+        // RC1 confidence gate(arvlCd=2 branch) 평가 → trace set → recordAutoLockConfidence 호출.
+        const kv = new InMemoryKV();
+        await putTrip(kv as unknown as KVNamespace, geoLocklessTrip());
+        await seedHappyGateSeries(kv, 'tok');
+        // 역삼(next-waypoint): T2 arvlCd=2(출발). 강남(origin): 동일 T2 → confidence +2 → 통과.
+        const seoul = new SeoulArrivalClient({
+          apiKey: 'K',
+          host: 'h',
+          now: () => NOW,
+          fetchImpl: (async (url: string) => {
+            const station = decodeURIComponent(url).includes('강남') ? '강남' : '역삼';
+            return new Response(
+              JSON.stringify({
+                realtimeArrivalList: [
+                  {
+                    barvlDt: '30',
+                    recptnDt: '',
+                    updnLine: '상행',
+                    trainLineNm: station,
+                    btrainNo: 'T2',
+                    subwayNm: '지하철2호선',
+                    arvlCd: 2,
+                  },
+                ],
+              }),
+              { status: 200 },
+            );
+          }) as unknown as typeof fetch,
+        });
+        const points: { blobs?: string[]; doubles?: number[] }[] = [];
+        const env: Env = {
+          ...makeEnv(kv),
+          TELEMETRY: { writeDataPoint: (p) => points.push(p) },
+        };
+        const stats = await runScheduled(env, {
+          seoul,
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+          now: () => NOW,
+        });
+        expect(stats.autoLockSuccess).toBe(1);
+        // autoLockConfidenceBreakdown histogram이 적재됐는지(=recordAutoLockConfidence 호출) 확인.
+        const confidencePoints = points.filter((p) =>
+          p.blobs?.some((b) => b.includes('autoLockConfidenceBreakdown')),
+        );
+        expect(confidencePoints.length).toBeGreaterThan(0);
+      });
     });
   });
 });

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -107,6 +107,30 @@ export const MAX_CONSECUTIVE_ETA_MISSING = 5;
 export const SUBSURFACE_ETA_MISSING_TOLERANCE = 10;
 
 /**
+ * #1315 — lockless trip에서 trainCode를 확보하지 못한 cycle의 bare-arvlCd advance 보수 게이트.
+ *
+ * 배경(2026-06-15 trip): 사용자가 정적(용마산 근처)인데 backend가 waypoint 역의 "아무 열차"
+ * arvlCd=ARRIVED만 보고 다음 역으로 advance → false positive + 알림 레이스. `pickBestArrivalSignal`
+ * 은 trainCode를 바인딩하지 않으므로, 그 신호가 *사용자가 탄 열차*가 통과했다는 ground truth가
+ * 아니다(다른 열차/반대 방향일 수 있음).
+ *
+ * 정책(ADR-010 "false positive / miss 동급" + "나쁜 신호 거부" 실시간성 정책): trainCode
+ * 미확보 cycle에서는 GPS motion이 **실제 이동**(walking/automotive)을 positive하게 보일 때만
+ * bare-arvlCd advance를 허용한다. `stationary`/`unknown`(샘플 없음 포함)은 보류 — 사용자가
+ * 그 구간을 실제로 지났다는 독립 확증이 없다.
+ *
+ * 트레이드오프(PR 본문 FLAG): 지하(subsurface)에서 GPS가 끊겨 motion=unknown인 채로 사용자가
+ * 실제 이동 중이면 이 게이트가 정당한 advance를 miss한다. trainCode 바인딩(우선 경로)이 그 miss를
+ * 메우지만, 바인딩 자체가 9단 게이트(이동 필요)에 의존하므로 지하 정적 케이스는 여전히 사각이다.
+ * 임계 완화 대신 후속 보강(예: subsurface trainCode 추론)으로 결정 — 본 PR은 false positive
+ * 제거를 우선한다.
+ */
+export const LOCKLESS_ADVANCE_MOTION_MODES: ReadonlySet<PositionPoint['motion']> = new Set([
+  'walking',
+  'automotive',
+]);
+
+/**
  * trip별 etaMissing 임계 결정. subsurface=true면 늘려 잡고, 그 외엔 기본값.
  * 클라가 매 register POST에 기압계 신호를 동봉하므로 한 trip 내에서 지상→지하 전이 시
  * threshold가 자연 갱신된다(stale 가능 윈도우는 다음 register 까지 ≤ ALARM_TIME_BUCKET_MS).
@@ -151,6 +175,13 @@ export interface ScheduledStats extends LiveActivityStats {
    * (lockMissing은 토글 OFF로 게이트 차단된 trip만 카운트되도록 유지 — 두 stat은 disjoint.)
    */
   locklessIntermediateFired: number;
+  /**
+   * #1315 — lockless cycle에서 trainCode 미확보 + GPS motion이 실제 이동(walking/automotive)이
+   * 아니어서 bare-arvlCd advance를 보류한 누적 횟수 (`LOCKLESS_ADVANCE_MOTION_MODES` 게이트).
+   * false positive(정적 상태 잘못된 station-passed) 방어 효과 측정 — 정상 운영에서 0이 아니면
+   * trainCode 바인딩이 닿지 않는 lockless 정적 구간이 그만큼 있었다는 신호.
+   */
+  locklessMotionGateBlocked: number;
   /** #819 — boarding-prompt 게이트 평가가 한 번이라도 시도된 trip 수 (lockMissing 부분집합). */
   boardingPromptEvaluated: number;
   /** #819 — 9단 AND 게이트를 모두 통과해 alert push가 발사된 횟수 (측정 인프라). */
@@ -248,6 +279,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     envCorrected: 0,
     lockMissing: 0,
     locklessIntermediateFired: 0,
+    locklessMotionGateBlocked: 0,
     laPushSent: 0,
     laPushFailed: 0,
     laTokenCleared: 0,
@@ -1236,13 +1268,96 @@ export async function maybeReschedulePush(
 }
 
 /**
- * #816 C — lockless trip (사용자 opt-in)에서 intermediate waypoint 통과를 추적하고 station-passed
- * push를 발사한다. BoardingLock 없으니 trainCode 추적은 불가 — Seoul arrivals 중 best signal로
- * "그 역에 어느 열차가 진입/도착했다"만 판정한다.
+ * #1315 — lockless trip에서 탑승 열차의 trainCode를 확보해 `trip.boardingLock`을 부착 시도한다.
  *
- * 발사 조건:
+ * `evaluateAndMaybeFireBoardingPrompt`의 auto-lock 경로(#916 A1)와 동일한 9단 게이트
+ * (`evaluateBoardingPromptGates`) + `attemptAutoLock`을 재사용한다 — 게이트가 통과하는 시점
+ * (사용자가 실제 이동 중 + 단일 후보 trainCode)에만 lock을 합성한다. 부착 성공 시 다음 cron
+ * 사이클의 `isBoardingLockActive` 게이트가 trip을 `runTrainCodeTracking`으로 라우팅 →
+ * lock 경로와 동일하게 `arrivals.find(a => a.trainCode === lock.trainCode)`로 *그 열차*만 추적한다.
+ *
+ * 좌표 컨텍스트(`promptGeoContext`/`promptDisplay`) 부재 시 바인딩 자체가 불가하므로 false 반환
+ * (backend는 stations 좌표를 갖지 않아 게이트 평가 불가 — 기존 boarding-prompt 정책과 동일).
+ *
+ * 반환: lock을 부착하고 putTrip까지 완료했으면 true (호출자는 즉시 return — 이번 cycle은 발사 안 함).
+ * 부착 못 했으면 false (호출자는 기존 bare-arvlCd 경로로 진행하되 motion 게이트로 보수 차단).
+ *
+ * 본 함수는 `fusion`을 재사용해 중복 KV read를 피한다(arrivals fetch는 attemptAutoLock 내부 1회).
+ */
+async function maybeBindLocklessTrainCode(
+  trip: Trip,
+  waypoint: Waypoint,
+  fusion: FusionStepResult,
+  env: Env,
+  deps: ScheduledDeps,
+  stats: ScheduledStats,
+  now: number,
+  log: Logger,
+): Promise<boolean> {
+  const geo = trip.promptGeoContext;
+  const display = trip.promptDisplay;
+  if (!geo || !display) return false;
+
+  // 9단 AND 게이트 — 사용자가 실제 이동 중일 때만 통과 (정적/저신뢰는 false positive 차단).
+  // boarding-prompt 경로와 동일하게 fusion 결과(series/kalman/metrics)를 그대로 입력으로 전달.
+  const outcome = evaluateBoardingPromptGates({
+    series: fusion.series,
+    origin: geo.origin,
+    nextStation: geo.nextStation,
+    now,
+    promptState: trip.boardingPromptState,
+    kalmanKmh: fusion.kalmanKmh,
+    metrics: fusion.posMetrics,
+  });
+  if (!outcome.pass) return false;
+
+  const autoLockResult = await attemptAutoLock({
+    trip,
+    targetWaypoint: waypoint,
+    originStation: display.originStation,
+    direction: geo.direction,
+    seoul: deps.seoul,
+    now,
+    boardingPromptState: trip.boardingPromptState,
+    lastMotionAt: fusion.series[fusion.series.length - 1]?.ts,
+  });
+  if (autoLockResult.confidenceTrace && env.TELEMETRY) {
+    recordAutoLockConfidence(env.TELEMETRY, trip.token, autoLockResult.confidenceTrace);
+  }
+  const autoLock = autoLockResult.lock;
+  if (!autoLock) return false;
+
+  // boarding-prompt auto-lock 성공 블록과 동형 — lock 부착 + dedup 마커 + 카운터.
+  trip.boardingLock = autoLock;
+  trip.boardingPromptState = markPromptFired(now);
+  trip.lastAutoPromptedAt = now;
+  trip.consecutiveEtaMissing = 0;
+  stats.autoLockSuccess += 1;
+  log('lockless: auto-lock attached', {
+    token: trip.token.slice(0, 8),
+    trainCode: autoLock.trainCode,
+    line: autoLock.line,
+    originStation: display.originStation,
+  });
+  await putTrip(env.TRIPS, trip);
+  return true;
+}
+
+/**
+ * #816 C — lockless trip (사용자 opt-in)에서 intermediate waypoint 통과를 추적하고 station-passed
+ * push를 발사한다.
+ *
+ * #1315 — 우선 `maybeBindLocklessTrainCode`로 탑승 열차의 trainCode 확보를 시도한다(9단 게이트
+ * 통과 시). 확보되면 다음 cycle이 lock 경로(trainCode 매칭)로 *그 열차*만 추적 — lockless 안정성의
+ * 핵심. trainCode 미확보 cycle에서만 아래 bare-arvlCd 경로로 진행하되, GPS motion이 실제 이동
+ * (walking/automotive)을 보일 때만 advance를 허용한다(`LOCKLESS_ADVANCE_MOTION_MODES`). 정적/
+ * 저신뢰 cycle은 보류 — `pickBestArrivalSignal`의 "아무 열차" arvlCd는 *사용자 열차* ground truth가
+ * 아니므로 false positive(2026-06-15 용마산 정적 false advance) 차단.
+ *
+ * 발사 조건(trainCode 미확보 cycle):
  *   1. arrivals 중 best signal의 arvlCd가 ARRIVED(1) 또는 ENTERING(0)
- *   2. dedup: 같은 waypoint에서 이미 한 번 발사한 경우 (lastFiredPhase='imminent') skip
+ *   2. GPS motion ∈ {walking, automotive} (실제 이동 확증)
+ *   3. dedup: 같은 waypoint에서 이미 한 번 발사한 경우 (lastFiredPhase='imminent') skip
  *
  * 발사 성공 시: waypoint shift + lastFiredPhase reset + trip 저장. waypoint 0이면 trip cleanup.
  * 사양상 transfer/destination kind는 호출 전에 분기로 차단됨 — 이 함수는 intermediate에 한정.
@@ -1268,6 +1383,11 @@ export async function runLocklessIntermediate(
   if (fusion.phaseState) {
     trip.stationPhase = fusion.phaseState;
     dirty = true;
+  }
+  // #1315 — bare-arvlCd 발사 전에 탑승 열차 trainCode 확보를 우선 시도한다. 성공 시 lock이
+  // 부착되고(putTrip 완료) 다음 cron 사이클이 lock 경로로 *그 열차*만 추적 — 이번 cycle은 발사 안 함.
+  if (await maybeBindLocklessTrainCode(trip, waypoint, fusion, env, deps, stats, now, log)) {
+    return;
   }
   const arrivals = await deps.seoul.fetchArrivals(waypoint.stationName);
   const signal = pickBestArrivalSignal(arrivals, waypoint);
@@ -1303,6 +1423,21 @@ export async function runLocklessIntermediate(
       station: waypoint.stationName,
       phase: fusion.phaseState?.current,
       confidence: fusion.phaseState?.confidence,
+    });
+    if (dirty) await putTrip(env.TRIPS, trip);
+    return;
+  }
+  // #1315 — trainCode 미확보 cycle의 보수 게이트. `pickBestArrivalSignal`의 arvlCd는 waypoint
+  // 역의 "아무 열차" 신호라 *사용자 열차*가 통과했다는 ground truth가 아니다. GPS motion이 실제
+  // 이동(walking/automotive)을 positive하게 보일 때만 advance를 허용 — 정적/저신뢰(stationary/
+  // unknown, 샘플 없음 포함)는 보류해 false positive(정적 false advance + 알림 레이스)를 차단한다.
+  if (!LOCKLESS_ADVANCE_MOTION_MODES.has(fusion.posMetrics.motion)) {
+    stats.locklessMotionGateBlocked += 1;
+    log('lockless: motion gate blocked (no trainCode, not moving)', {
+      token: trip.token.slice(0, 8),
+      station: waypoint.stationName,
+      motion: fusion.posMetrics.motion,
+      arvlCd: signal.arvlCd,
     });
     if (dirty) await putTrip(env.TRIPS, trip);
     return;


### PR DESCRIPTION
Closes #1315

## 배경 / root cause
2026-06-15 오전 7→2호선 lockless-opt-in trip(탑승했으나 열차 미선택), 저품질 GPS. 정적(용마산 근처)인데 backend가 "중곡 도착" lockless push를 발사해 false advance → 44초 만에 군자→어린이대공원→건대입구 알림 레이스.

`runLocklessIntermediate`가 `pickBestArrivalSignal(arrivals, waypoint)`로 **waypoint 역의 아무 열차** arvlCd∈{ENTERING,ARRIVED}면 발사 — trainCode 바인딩이 없어 그 신호가 *사용자가 탄 열차*가 통과했다는 ground truth가 아니다(다른 열차/반대 방향일 수 있음). 대조적으로 lock 경로는 `arrivals.find(a => a.trainCode === lock.trainCode)`로 특정 열차만 매칭한다.

## WHY autoLock/boardingPrompt가 막혔나 (진단)
두 가지 독립 원인:

1. **구조적 (1차 원인)**: lockless-opt-in + intermediate trip의 디스패치(`scheduled.ts` `runScheduled` 루프)는 `runLocklessIntermediate`를 호출하고 즉시 `continue` → `evaluateAndMaybeFireBoardingPrompt`(= `attemptAutoLock`의 유일한 호출자)에 **도달하지 않는다**. 따라서 이 trip은 trainCode 바인딩을 *시도조차* 못 하고 bare-arvlCd 경로로 직행했다. tail의 `boarding-lock: skip cycle (lock missing)` + `locklessOptIn=true` ×9가 이를 뒷받침.

2. **게이트 (2차)**: 설령 autoLock에 도달했어도 9단 게이트(`evaluateBoardingPromptGates`)는 실제 이동을 요구한다 — #5 direction-cosine≥0.7, #7 fused≥5km/h, #8 motion∈{walking,automotive}. 디바이스가 정적(`movement-static-position` 반복)이라 `motion-not-moving`/`speed-too-low`로 **정당하게** 차단됐을 것이다. 이 게이트는 옳으므로 **완화하지 않았다**(ADR-010).

## 수정 내용
1. **trainCode 바인딩 (우선 경로)** — `runLocklessIntermediate`가 bare-arvlCd 발사 전에 `maybeBindLocklessTrainCode`를 호출. 9단 게이트 통과 시(이동 + 단일 후보 trainCode) `attemptAutoLock`을 **재사용**해 `boardingLock`을 합성·부착. 부착 성공 시 다음 cron 사이클의 `isBoardingLockActive` 게이트가 trip을 `runTrainCodeTracking`으로 라우팅 → lock 경로와 동일하게 `arrivals.find(a => a.trainCode === lock.trainCode)`로 **그 열차만** 추적. ("탑승은 했으나 lock 안 한 경우 = 탄 열차의 trainCode를 감지해 그 번호를 계속 따라간다"는 설계 의도 구현.)
2. **보수 fallback (trainCode 미확보)** — `pickBestArrivalSignal`의 "아무 열차" arvlCd로는 advance하지 않는다. GPS motion이 **실제 이동**(`LOCKLESS_ADVANCE_MOTION_MODES` = walking/automotive)을 positive하게 보일 때만 bare-arvlCd advance 허용. `stationary`/`unknown`(샘플 없음 포함)은 보류 — "나쁜 신호 거부" 실시간성 정책 + ADR-010 정합. 정적 false advance + 알림 레이스 제거.
3. `locklessMotionGateBlocked` stat 추가 (false positive 방어 측정 인프라) + `log('lockless: motion gate blocked ...')` (tail 가시성, 기존 `phase gate blocked`와 동형).

autoLock confidence threshold는 **변경하지 않았다** — 잘못된 열차 lock(false positive) 위험을 피하기 위해 기존 9단 게이트 + RC1 게이트를 그대로 재사용.

## ⚠️ FLAG — 별도 결정 필요 (ADR-014 / no-false-binary)
보수 motion 게이트는 **지하(subsurface)에서 GPS가 끊겨 motion=unknown인 채 사용자가 실제 이동 중인 정적 케이스**에서 정당한 advance를 miss할 수 있다. trainCode 바인딩(우선 경로)이 이 miss를 메우지만, 바인딩 자체가 9단 게이트(이동 필요)에 의존하므로 "지하 + GPS 끊김 + 바인딩 실패" 구간은 여전히 사각이다. ADR-010은 false positive와 miss를 동급으로 보므로, 본 PR은 임계 완화 대신 **false positive 제거를 우선**하고 이 트레이드오프를 다음 옵션으로 위임한다(머지 전 결정):

- **(A) 현행 유지** — 보수 motion 게이트. 지하 정적 케이스 advance miss 감수 (false positive 0).
- **(B) subsurface trainCode 추론 보강 (신규 작업)** — 지하에서 barometer/accel/positions 기반 trainCode 추론 경로를 추가해 motion=unknown이어도 바인딩 가능하게 함. miss와 false positive 모두 최소화하나 신규 작업 필요.
- **(C) subsurface일 때만 motion 게이트 완화 + 보조 확증** — `trip.subsurface=true` 구간에 한해 motion=unknown advance를 허용하되 phase/position 등 보조 신호로 확증. 부분 완화.

## 테스트 / 검증 (backend vitest)
- motion-stationary + 다른 열차(trainCode=9999) ARRIVED at next waypoint → advance 안 함 (`it.each`로 stationary/unknown/series-없음/automotive/walking 5케이스).
- 바인딩된 trainCode(7246)의 ARRIVED → 다음 cycle lock 경로(`runTrainCodeTracking`)가 그 열차로 매역 fire (`arvlCdFireSuccess=1`).
- trainCode 미확보(no geo / ambiguity) → 보수 보류 또는 이동 시 bare-arvlCd 발사.
- 정적 연속 2 cycle → 다중 waypoint advance 0건 (레이스 차단).
- 정적 + phaseState stamp → advance 보류 + trip에 stationPhase 저장 (dirty 경로).
- arvlCd=2 + origin 확인 → confidence trace TELEMETRY 적재.

**숫자**: backend 전체 1249 tests PASS (33 files), type-check clean. 변경 파일(`scheduled.ts`) 변경 라인 100% 커버(statement+branch). 기존 scheduled/autoLock/boardingPrompt 테스트 그대로 green.