### PR TITLE
feat(#1286): WiFi SSID 역 매칭 fusion·backend 단선 2개 연결

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingLockSync.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockSync.test.ts
@@ -523,6 +523,75 @@ describe('useBoardingLockSync (#901)', () => {
     });
   });
 
+  // #1286 — WiFi SSID 확정 역(stationFromWifi=true)은 accuracy>50m 게이트 우회.
+  describe('stationFromWifi accuracy 게이트 우회 (#1286)', () => {
+    it('stationFromWifi=true + accuracy>50m → debounce 후 발사 (게이트 우회)', async () => {
+      renderHook(() =>
+        useBoardingLockSync({
+          currentStationName: '용마산',
+          accuracyMeters: GOOD_FIX_ACCURACY_MAX_M + 150,
+          tripActive: true,
+          stationFromWifi: true,
+        }),
+      );
+      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+      await flushAsyncStorage();
+      expect(mockedSync).toHaveBeenCalledTimes(1);
+      expect(mockedSync.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          observedStationName: '용마산',
+          accuracy: GOOD_FIX_ACCURACY_MAX_M + 150,
+        }),
+      );
+    });
+
+    it('stationFromWifi=true + force-trigger + accuracy>50m → 즉시 발사 (게이트 우회)', async () => {
+      const { rerender } = renderHook(
+        ({ key }: { key: string | null }) =>
+          useBoardingLockSync({
+            currentStationName: '용마산',
+            accuracyMeters: GOOD_FIX_ACCURACY_MAX_M + 150,
+            tripActive: true,
+            stationFromWifi: true,
+            forceTriggerKey: key,
+          }),
+        { initialProps: { key: null as string | null } },
+      );
+      expect(mockedSync).not.toHaveBeenCalled();
+      rerender({ key: 'wifi-underground' });
+      await flushAsyncStorage();
+      expect(mockedSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('stationFromWifi=false(GPS 역) + accuracy>50m → 미발사 (게이트 유지)', async () => {
+      renderHook(() =>
+        useBoardingLockSync({
+          currentStationName: '강남',
+          accuracyMeters: GOOD_FIX_ACCURACY_MAX_M + 150,
+          tripActive: true,
+          stationFromWifi: false,
+        }),
+      );
+      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+      await flushAsyncStorage();
+      expect(mockedSync).not.toHaveBeenCalled();
+    });
+
+    it('stationFromWifi=true + accuracy=null → 여전히 미발사 (관측 부재)', async () => {
+      renderHook(() =>
+        useBoardingLockSync({
+          currentStationName: '용마산',
+          accuracyMeters: null,
+          tripActive: true,
+          stationFromWifi: true,
+        }),
+      );
+      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+      await flushAsyncStorage();
+      expect(mockedSync).not.toHaveBeenCalled();
+    });
+  });
+
   it('debounce timer cleanup — unmount 시 미발사', async () => {
     const { unmount } = renderHook(() =>
       useBoardingLockSync({

--- a/src/features/alarm/hooks/useBoardingLockSync.ts
+++ b/src/features/alarm/hooks/useBoardingLockSync.ts
@@ -53,6 +53,14 @@ export interface UseBoardingLockSyncOptions {
   /** Seam G subsurface 신호 (옵션) — backend 로그에 진단 라벨로 첨부. */
   subsurface?: boolean;
   /**
+   * #1286 — 현재역이 WiFi SSID 매칭으로 확정됐는지 (fusion confidence==='wifi-ssid').
+   * true면 `accuracyMeters > GOOD_FIX_ACCURACY_MAX_M` 게이트를 우회한다 — WiFi SSID는 GPS 정확도와
+   * 무관하게 역을 확정하므로(지하 GPS dead zone에서 accuracy>50m가 정상), ≤50m fix가 없어도 sync한다.
+   * 일반 GPS 유도 역(false/미전달)에는 ≤50m 게이트를 그대로 유지 — 부정확한 fix로 잘못된 정정 차단.
+   * accuracy=null(관측 자체 부재)은 WiFi 여부와 무관하게 여전히 no-op (payload accuracy 필드 요구).
+   */
+  stationFromWifi?: boolean;
+  /**
    * D4 (#1210) — 현재 활성 boarding lock의 trainCode. 있으면 sync payload에 동봉돼
    * backend가 환승 leg trainCode 변경을 즉시 인식하고 `consecutiveEtaMissing` 자동 종료를 차단한다.
    * null/undefined면 payload에 trainCode 미포함 (구버전 backend / lock 없는 trip 호환).
@@ -83,6 +91,7 @@ export function useBoardingLockSync({
   tripActive,
   forceTriggerKey,
   subsurface,
+  stationFromWifi,
   boardingLockTrainCode,
   boardingLockLine,
   onAutoLockCandidate,
@@ -117,7 +126,8 @@ export function useBoardingLockSync({
     if (!tripActive) return;
     if (!currentStationName) return;
     if (accuracyMeters === null) return;
-    if (accuracyMeters > GOOD_FIX_ACCURACY_MAX_M) return;
+    // #1286 — WiFi SSID 확정 역은 GPS 정확도 게이트를 우회 (지하 GPS dead zone에서 accuracy>50m가 정상).
+    if (!stationFromWifi && accuracyMeters > GOOD_FIX_ACCURACY_MAX_M) return;
     const trainCodeForFire = boardingLockTrainCode ?? null;
     const stationUnchanged = lastSentStationRef.current === currentStationName;
     const trainCodeUnchanged = lastSentTrainCodeRef.current === trainCodeForFire;
@@ -153,6 +163,7 @@ export function useBoardingLockSync({
     currentStationName,
     accuracyMeters,
     subsurface,
+    stationFromWifi,
     boardingLockTrainCode,
     boardingLockLine,
   ]);
@@ -164,7 +175,8 @@ export function useBoardingLockSync({
     if (lastForceKeyRef.current === forceTriggerKey) return;
     if (!currentStationName) return;
     if (accuracyMeters === null) return;
-    if (accuracyMeters > GOOD_FIX_ACCURACY_MAX_M) return;
+    // #1286 — WiFi SSID 확정 역은 GPS 정확도 게이트를 우회 (effect 1과 동일).
+    if (!stationFromWifi && accuracyMeters > GOOD_FIX_ACCURACY_MAX_M) return;
 
     lastForceKeyRef.current = forceTriggerKey;
     // lastSent ref들을 즉시 동기로 set — effect 1의 debounce timer가 같은 station/trainCode로
@@ -187,6 +199,7 @@ export function useBoardingLockSync({
     currentStationName,
     accuracyMeters,
     subsurface,
+    stationFromWifi,
     boardingLockTrainCode,
     boardingLockLine,
   ]);

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -173,13 +173,15 @@ export default function HomeScreen() {
   //   2) useApnsTripRegistration: backend payload subsurface 동봉(threshold 5→10).
   const barometerSignal = useBarometer();
   const { subsurface: barometerSubsurface } = barometerSignal;
-  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source, currentHopIndex, arcStations } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal });
+  // #913 (F2) — wifiStation: 네이티브 SSID 브릿지(NEHotspotNetwork / WifiManager) → lookupStationBySsid.
+  //   1) useFusedNearestStation: subsurface=true(지하 GPS dead zone)일 때 fusion cascade 최우선 채택(#1286).
+  //   2) useCurrentStationConfirmModal: 매칭되면 useStationCandidates가 단일 후보로 자동 확정(#914 F4).
+  // useFusedNearestStation 호출(아래) 전에 선언해 8번째 인자로 전달한다.
+  const wifiStation = useWifiStation();
+  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source, currentHopIndex, arcStations } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal }, wifiStation);
 
   // #914 (F4) — 1탭 현재역 확정 모달. 자동 추정이 locationUncertain으로 길어지면 후보 1~3개를
   // 카드로 노출, 1탭 = customOrigin 적용.
-  // #913 (F2) — wifiStation: 네이티브 SSID 브릿지(NEHotspotNetwork / WifiManager) → lookupStationBySsid.
-  // 매칭되면 useStationCandidates가 단일 후보로 자동 확정.
-  const wifiStation = useWifiStation();
   const [confirmAutoToast, setConfirmAutoToast] = useState<string | null>(null);
   // #1166 — backend가 사용자 탭과 다른 trainCode로 lock을 확정했을 때 노출하는 정정 toast.
   // BoardingTrainList의 onLockCorrected callback이 채워주며, 같은 메시지가 두 인스턴스(현재역/환승)에
@@ -405,6 +407,9 @@ export default function HomeScreen() {
     accuracyMeters: accuracyMeters ?? null,
     tripActive: Boolean(destination && route),
     subsurface: barometerSubsurface,
+    // #1286 — 지하 GPS dead zone에서 WiFi SSID로 확정된 역(confidence='wifi-ssid')은 accuracy>50m라도
+    // backend로 sync. WiFi SSID가 GPS 정확도와 독립적으로 역을 확정하므로 ≤50m 게이트를 우회한다.
+    stationFromWifi: confidence === 'wifi-ssid',
     boardingLockTrainCode: boardingLock?.trainCode ?? null,
     boardingLockLine: boardingLock?.boardingLine ?? null,
     onAutoLockCandidate: hydrateLockFromCandidate,


### PR DESCRIPTION
## 배경
WiFi SSID 역 매칭 인프라(`useWifiStation`, SSID→station DB, `useFusedNearestStation`의 wifi-ssid cascade)는 이미 `dev`에 존재하나, **2개 커넥터가 단선**돼 지하에서 실제로 동작하지 않았다.

## 변경 — 커넥터 2개 연결

### A. wifiStation → fusion 입력 (FG)
- `useWifiStation()` 호출을 `useFusedNearestStation()` 호출 **위로 hoist** 후 **8번째 인자**로 전달 (HomeScreen).
- 기존엔 `useCurrentStationConfirmModal`에만 전달돼 fusion의 wifi-ssid 분기(`useFusedNearestStation.ts:533`)가 영영 실행되지 않았음.
- 이제 `barometerSubsurface===true` + SSID 매칭 시 `result.station`이 WiFi 역, `confidence='wifi-ssid'`로 채택된다.

### B. WiFi 확정 역 → backend 전송
- `useBoardingLockSync`에 `stationFromWifi?: boolean` 옵션 추가.
- `confidence==='wifi-ssid'`일 때 `accuracyMeters > 50m`(`GOOD_FIX_ACCURACY_MAX_M`) 게이트를 **우회** — WiFi SSID는 GPS 정확도와 독립적으로 역을 확정하므로 지하(accuracy>50m가 정상)에서도 sync한다.
- 일반 GPS 유도 역(`stationFromWifi=false`)에는 ≤50m 게이트를 **그대로 유지** — 부정확한 fix로 잘못된 정정 차단.
- `accuracy=null`(관측 부재)은 WiFi 여부와 무관하게 여전히 no-op.
- HomeScreen의 `useBoardingLockSync({...})`에 `stationFromWifi: confidence === 'wifi-ssid'` 전달.

## 테스트
- `useFusedNearestStation` wifi 분기는 기존 `useFusedNearestStation.wifiFusion.test.ts`로 이미 100% 커버 (subsurface+매칭 채택 / 지상·미매칭 무시).
- `useBoardingLockSync.test.ts`에 4 케이스 추가:
  - `stationFromWifi=true` + accuracy>50m → debounce 후 발사
  - `stationFromWifi=true` + force-trigger + accuracy>50m → 즉시 발사
  - `stationFromWifi=false`(GPS) + accuracy>50m → 미발사 (게이트 유지)
  - `stationFromWifi=true` + accuracy=null → 미발사 (관측 부재)
- `npm test` 285 suites / 5468 tests 통과, 전역 커버리지 100%.
- `npm run type-check`, `npm run lint`(0 warnings) 통과.

## Test plan
- [x] 지하 정차 시 현재역이 SSID로 정확히 확정되는지 실기기 확인
- [ ] 지하 매 역 알림 발사 확인 (피드백 #14·#15·#1)
- [ ] backend가 WiFi 확정 역명을 수신하는지 wrangler tail로 확인

Closes #1286