### PR TITLE
fix(#1321): trip 삭제+재생성 race로 stale 사전예약 알림 잔존 차단

### DIFF
--- a/src/features/alarm/store/__tests__/tripBoundCleanupsAudit.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanupsAudit.test.ts
@@ -99,8 +99,20 @@ const otherStation: Station = {
   lng: 127.0366,
 };
 
+// #1321 — setDestination chain(triggerTripEndRecall → runTripBoundCleanups → setTripStartedAt)이
+// tripTransitionQueue에 직렬화돼 시작이 한 microtask 늦고 단계 사이 .catch가 microtask를 더한다.
+// 넉넉히 flush해 chain을 끝까지 진행시킨다(주 store 테스트의 flushMicrotasks와 동일 패턴).
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 30; i += 1) {
+    await Promise.resolve();
+  }
+}
+
 describe('#1176 tripBoundCleanups audit — lockless ↔ lock 전이 회귀 가드', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    // #1321 — 직전 테스트가 enqueue한 tripTransitionQueue chain이 남아 있으면 다음 테스트의
+    // (clear된) mock으로 늦게 발사돼 호출 카운트를 오염시킨다. clearAllMocks 전에 먼저 drain.
+    await flushMicrotasks();
     jest.clearAllMocks();
     (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
     (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
@@ -138,10 +150,8 @@ describe('#1176 tripBoundCleanups audit — lockless ↔ lock 전이 회귀 가�
   it('case 5a: setDestination(null) (trip 종료) — triggerTripEndRecall → runTripBoundCleanups 순서로 호출되고 setTripStartedAt은 호출되지 않는다', async () => {
     useDestinationStore.setState({ destination: station });
     useDestinationStore.getState().setDestination(null);
-    // chain은 마이크로태스크 — flush.
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    // #1321 — chain이 tripTransitionQueue에 enqueue돼 한 microtask 늦게 시작하므로 넉넉히 flush.
+    await flushMicrotasks();
 
     expect(mockTriggerTripEndRecall).toHaveBeenCalledTimes(1);
     expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
@@ -152,11 +162,9 @@ describe('#1176 tripBoundCleanups audit — lockless ↔ lock 전이 회귀 가�
   it('case 5b: setDestination(switch) (목적지 교체) — runTripBoundCleanups + setTripStartedAt 모두 호출된다', async () => {
     useDestinationStore.setState({ destination: station });
     useDestinationStore.getState().setDestination(otherStation);
-    // chain은 triggerTripEndRecall → runTripBoundCleanups → setTripStartedAt 3단 await.
-    // 각 단계 사이에 .catch가 끼어 추가 마이크로태스크가 필요하므로 넉넉히 flush.
-    for (let i = 0; i < 8; i += 1) {
-      await Promise.resolve();
-    }
+    // #1321 — chain은 triggerTripEndRecall → runTripBoundCleanups → setTripStartedAt 3단 await이며
+    // tripTransitionQueue 직렬화로 시작이 한 hop 늦다. 넉넉히 flush해 끝까지 진행시킨다.
+    await flushMicrotasks();
 
     expect(mockTriggerTripEndRecall).toHaveBeenCalledTimes(1);
     expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);

--- a/src/features/route/store/__tests__/useDestinationStore.test.ts
+++ b/src/features/route/store/__tests__/useDestinationStore.test.ts
@@ -49,7 +49,10 @@ const mockStation2: Station = {
 };
 
 describe('useDestinationStore', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    // #1321 — setDestination chain은 tripTransitionQueue에 직렬화된다. 직전 테스트의 잔여
+    // chain이 현재 테스트의 (clear된) mock으로 늦게 발사돼 카운트를 오염시키지 않도록 먼저 drain.
+    await flushMicrotasks();
     useDestinationStore.setState({
       destination: null,
       recentDestinations: [],
@@ -718,6 +721,64 @@ describe('useDestinationStore', () => {
     useDestinationStore.getState().setDestination(mockStation);
     await flushMicrotasks();
     expect(useDestinationStore.getState().destination?.id).toBe('2-022');
+  });
+
+  // ── #1321 delete→recreate race: cleanup 직렬화 ──
+
+  it('setDestination(#1321): delete 직후 recreate 시 옛 cleanup이 끝난 뒤에야 새 tripStart 기록', async () => {
+    // 시나리오: setDestination(null)(delete)로 옛 route cleanup이 in-flight인 동안
+    // setDestination(mockStation2)(recreate)가 곧바로 들어온다. 직렬화가 없으면 recreate의
+    // setTripStartedAt이 delete cleanup 도중에 실행돼 hook이 옛 알람과 interleave한 채 새
+    // route를 preschedule → revalidate-route-sig-mismatch 폭주. 직렬화가 있으면 delete의
+    // cleanup이 완전히 settle한 뒤에만 recreate cleanup + setTripStartedAt이 시작된다.
+    useDestinationStore.setState({ destination: mockStation });
+
+    const order: string[] = [];
+    let triggerCount = 0;
+    (triggerTripEndRecall as jest.Mock).mockImplementation(async () => {
+      order.push(`trigger#${++triggerCount}`);
+      return { uploaded: false };
+    });
+    (setTripStartedAt as jest.Mock).mockImplementation(async () => {
+      order.push('setTripStartedAt');
+    });
+    // delete leg cleanup(첫 removeItem 진입)을 deferred로 묶어 interleave 창을 강제한다.
+    let releaseDeleteCleanup: () => void = () => undefined;
+    const deleteCleanupGate = new Promise<void>((resolve) => {
+      releaseDeleteCleanup = resolve;
+    });
+    let removeItemCalls = 0;
+    (AsyncStorage.removeItem as jest.Mock).mockImplementation(async () => {
+      removeItemCalls += 1;
+      // 첫 cleanup leg(delete)의 첫 removeItem만 gate에 묶고 마커 기록.
+      if (removeItemCalls === 1) {
+        order.push('delete-cleanup-start');
+        await deleteCleanupGate;
+        order.push('delete-cleanup-end');
+      }
+      return undefined;
+    });
+
+    // delete → recreate를 동기적으로 연달아 호출 (사용자가 빠르게 삭제+재생성).
+    useDestinationStore.getState().setDestination(null);
+    useDestinationStore.getState().setDestination(mockStation2);
+
+    // delete cleanup이 gate에서 멈춘 상태로 microtask를 일부 흘려보낸다 — 직렬화가 없으면
+    // 이 시점에 recreate의 setTripStartedAt이 이미 기록됐을 것.
+    await flushMicrotasks();
+    expect(order).not.toContain('setTripStartedAt');
+
+    // delete cleanup 완료 → 큐가 recreate chain을 진행.
+    releaseDeleteCleanup();
+    await flushMicrotasks();
+
+    // 직렬화 보장: delete cleanup이 끝난 뒤에야 recreate의 setTripStartedAt이 실행된다.
+    const deleteEndIdx = order.indexOf('delete-cleanup-end');
+    const setTripIdx = order.indexOf('setTripStartedAt');
+    expect(deleteEndIdx).toBeGreaterThanOrEqual(0);
+    expect(setTripIdx).toBeGreaterThan(deleteEndIdx);
+    // recreate(2번째 transition)에서만 tripStart를 기록 (delete는 null이라 미기록).
+    expect(order.filter((o) => o === 'setTripStartedAt')).toHaveLength(1);
   });
 
   describe('trip breadcrumb', () => {

--- a/src/features/route/store/useDestinationStore.ts
+++ b/src/features/route/store/useDestinationStore.ts
@@ -28,6 +28,22 @@ import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb
 const noop = (): void => {};
 
 /**
+ * #1321 — trip transition(목적지 switch/null) cleanup 직렬화 큐.
+ *
+ * setDestination은 동기 액션이라 cleanup chain(triggerTripEndRecall → runTripBoundCleanups →
+ * setTripStartedAt)을 fire-and-forget으로 띄운다. 사용자가 trip을 삭제(setDestination(null))한 직후
+ * 곧바로 재생성(setDestination(newStation))하면 두 chain이 interleave한다:
+ *   - delete chain의 runTripBoundCleanups(옛 `tba:`/`bl:` 사전 예약 cancel)가 아직 in-flight인 동안
+ *   - recreate chain이 setTripStartedAt을 기록 → hook들이 새 route를 preschedule
+ * → 옛 알람이 잔존하거나 새/옛 cancel 순서가 비결정적 → 매 cron마다 revalidate-route-sig-mismatch 폭주.
+ *
+ * 연속 transition을 이 promise에 chain해 직렬화한다. recreate의 cleanup + setTripStartedAt은
+ * 직전 delete의 cleanup이 완전히 settle한 뒤에야 시작되므로, hook이 새 trip을 preschedule할 시점에는
+ * 옛 알람이 이미 정리돼 있고 이후 어떤 cleanup도 새 알람을 쓸어가지 않는다.
+ */
+let tripTransitionQueue: Promise<unknown> = Promise.resolve();
+
+/**
  * Destination/route 상태 store — ADR 후속 Step 6 (#892).
  *
  * 책임:
@@ -111,7 +127,11 @@ export const useDestinationStore = create<DestinationState>((set, get) => ({
       //    LAST_FIRED_ALARM_STATION_NAME_KEY, #746 dismissSilence 등 누락 사례 재발 방지.)
       // 3) 새 trip(station != null)이면 새 tripStart를 기록 — cleanup이 직전에 이전 키를 제거했으니
       //    여기서 set하면 다음 trip 측정 가능. station === null(trip 종료) 경로에서는 set 안 함.
-      triggerTripEndRecall()
+      // #1321 — delete→recreate race 차단: tripTransitionQueue에 chain해 직렬화한다.
+      // 직전 transition(예: delete)의 cleanup이 완전히 끝난 뒤에야 이번 transition(예: recreate)의
+      // cleanup + setTripStartedAt이 시작된다.
+      tripTransitionQueue = tripTransitionQueue
+        .then(() => triggerTripEndRecall())
         .catch(noop)
         .then(() => runTripBoundCleanups())
         .catch(noop)


### PR DESCRIPTION
## 배경
2026-06-15 오후 실기기 trip에서 트립 삭제+재생성을 반복한 뒤 옛 route(성수/명동/동대문역사문화공원)의 사전예약 알림이 계속 살아남아 매 cron마다 `revalidate-route-sig-mismatch`로 suppress(114~138건)되는 회귀.

## Root cause (cross-layer 정정)
cancellation 코드는 이미 존재한다(3경로: `runTripBoundCleanups` → `purgeBoardingLockSchedulerQueue`+`cancelTripBoundAlarms`, `useTripBoundAlarmScheduler`, #1264/#1282). 실제 결함은 **delete→recreate RACE**:

- `useDestinationStore.setDestination`의 cleanup chain(`triggerTripEndRecall → runTripBoundCleanups → setTripStartedAt`)이 **un-awaited fire-and-forget**.
- 사용자가 삭제(`setDestination(null)`) 직후 곧바로 재생성(`setDestination(newStation)`)하면 두 chain이 interleave한다 — delete chain의 옛 `tba:`/`bl:` 사전예약 cancel이 아직 in-flight인 동안 recreate chain이 `setTripStartedAt`을 기록 → hook들이 새 route를 preschedule → 옛 알람 잔존 + sig-mismatch 폭주.
- per-hook routeSig 가드는 delete leg(prev=null)에서 ref를 null로 리셋하므로 recreate가 `prev===null`이라 cancel을 SKIP → 양쪽 가드가 race를 막지 못함.

## 변경
- `src/features/route/store/useDestinationStore.ts` — cleanup chain을 모듈 레벨 `tripTransitionQueue` promise에 chain해 **연속 transition을 직렬화**. recreate의 cleanup + `setTripStartedAt`은 직전 delete의 cleanup이 완전히 settle한 뒤에야 시작된다. hook이 새 trip을 preschedule할 시점엔 옛 알람이 이미 정리돼 있고 이후 어떤 cleanup도 새 알람을 쓸어가지 않는다.
- `setDestination` 시그니처(`void`)·호출부 변경 없음. 순수 device-side(backend 무관). #1282/#1264와 complementary (그들=switch-path prev≠null / 이건 prev=null delete-recreate race).

## 테스트
- `useDestinationStore.test.ts` — delete 직후 recreate race 재현 테스트 추가. gate로 delete cleanup을 in-flight 상태로 묶은 뒤, 직렬화가 없으면 그 시점에 recreate의 `setTripStartedAt`이 이미 실행됐음을 검증(실제로 미직렬화 코드에서 빨갛게 실패함 → 회귀 가드 유효).
- 직렬화로 chain 시작이 1 microtask 늦어지는 데 맞춰 `tripBoundCleanupsAudit.test.ts`의 flush를 조정하고, 모듈 큐가 테스트 간 leak되지 않도록 `beforeEach` drain 가드 추가.
- `npm test` 100% 커버리지 통과(5465 passed), `npm run type-check` 통과.

## Acceptance (issue 기준)
- [x] route 재생성 후 옛 route 대상 prescheduled 알림이 새 tripStart 기록 이전에 정리되도록 보장 (직렬화).
- [x] 재생성 시 이전 schedule cancel이 새 preschedule 이전에 완료 — 단위 테스트로 가드.
- [ ] revalidate-route-sig-mismatch 누적 급감 — 실기기 1주 재발 0건 확인 필요(Epic #1204 close 조건).

Closes #1321