### PR TITLE
fix(#1322): self-describing push로 지하 lock-path silent push 발사

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -239,6 +239,60 @@ describe('sendSilentPush', () => {
     if (expectPresent) expect(body.data.subsurface).toBe(true);
   });
 
+  // #1322 — payload.boardingLine/trainCode wire 검증 (lock-path self-describing fire).
+  // 지정 시 wire, 미지정은 byte-level 호환 위해 omit.
+  it.each([
+    ['지정 시 body.data.boardingLine으로 전달', '7', true],
+    ['미지정이면 body.data에서 omit (구 client/backend 호환)', undefined, false],
+  ])('boardingLine %s (#1322)', async (_label, input, expectPresent) => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await sendSilentPush({
+      deviceToken: 'tok',
+      payload: {
+        nextWaypoint: '군자',
+        etaSeconds: 0,
+        phase: 'imminent',
+        kind: 'transfer',
+        sentAt: 1_700_000_000_000,
+        pushId: 'p',
+        ...(input === undefined ? {} : { boardingLine: input }),
+      },
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect('boardingLine' in body.data).toBe(expectPresent);
+    if (expectPresent) expect(body.data.boardingLine).toBe('7');
+  });
+
+  it.each([
+    ['지정 시 body.data.trainCode로 전달', '7246', true],
+    ['미지정이면 body.data에서 omit', undefined, false],
+  ])('trainCode %s (#1322)', async (_label, input, expectPresent) => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await sendSilentPush({
+      deviceToken: 'tok',
+      payload: {
+        nextWaypoint: '군자',
+        etaSeconds: 0,
+        phase: 'imminent',
+        kind: 'transfer',
+        sentAt: 1_700_000_000_000,
+        pushId: 'p',
+        ...(input === undefined ? {} : { trainCode: input }),
+      },
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect('trainCode' in body.data).toBe(expectPresent);
+    if (expectPresent) expect(body.data.trainCode).toBe('7246');
+  });
+
   it('uses sandbox host when provided', async () => {
     const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) =>
       new Response('', { status: 200 }),

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -4219,6 +4219,21 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
     if (expectPresent) expect(data.subsurface).toBe(true);
   });
 
+  // #1322 — lock-path fire는 boardingLine/trainCode를 self-describing으로 실어 보낸다.
+  // 디바이스가 로컬 lock 없이도 line sanity-guard를 돌려 transfer/destination push를 발사할 수 있게 한다.
+  it('payload.boardingLine/trainCode 포함 — lock.line/lock.trainCode가 그대로 forward (#1322)', async () => {
+    const { apnsFetch } = await runArvlScheduled({
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      pushId: 'p-arvl-line',
+    });
+    const data = parseStationPassedData(getStationPassedCalls(apnsFetch)[0]) as Record<
+      string,
+      unknown
+    >;
+    expect(data.boardingLine).toBe('7');
+    expect(data.trainCode).toBe('7246');
+  });
+
   it('arvlCd=0(ENTERING) → 매역 push 발사 (arvlCd=0 dedup key)', async () => {
     const { stats, kv } = await runArvlScheduled({
       seoul: makeArrivalSeoul('중곡', 0, 0),

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -77,6 +77,20 @@ export interface SilentPushPayload {
    * 클라이언트는 기존 거리 게이트로 동작.
    */
   subsurface?: boolean;
+  /**
+   * #1322 — lock-path fire의 boardingLock 노선(`BoardingLockMeta.line`). server-authoritative.
+   * 디바이스가 로컬 lock 없이도(지하 auto-lock hydration window 등) lock-path push(transfer/
+   * destination/imminent)의 line sanity-guard를 돌려 발사할 수 있게 한다. 이게 없으면 디바이스는
+   * 로컬 lock 부재 + non-intermediate push를 stale race로 보고 `lockless-non-intermediate` drop한다.
+   * 구 backend 호환 위해 optional — 미전달 시 wire에서 누락, 디바이스는 기존 보수 동작으로 fallback.
+   */
+  boardingLine?: string;
+  /**
+   * #1322 — lock-path fire의 boardingLock trainCode. server가 선택한 열차 식별자.
+   * boardingLine과 함께 디바이스에 어떤 열차/노선 발사인지 알린다(진단/로그용). 구 backend 호환 위해
+   * optional — 미전달 시 wire에서 누락.
+   */
+  trainCode?: string;
 }
 
 export async function buildApnsJwt(config: ApnsConfig, now: number = Date.now()): Promise<string> {
@@ -135,6 +149,12 @@ export async function sendSilentPush(options: SendPushOptions): Promise<SendPush
       // #1307 — subsurface는 true일 때만 wire. false/undefined는 JSON에서 자연 누락 →
       // 구 client(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환.
       ...(options.payload.subsurface === true ? { subsurface: true } : {}),
+      // #1322 — boardingLine/trainCode는 정의된 경우에만 wire (lock-path fire). 미전달 시
+      // JSON에서 자연 누락 → 구 client(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환.
+      ...(options.payload.boardingLine === undefined
+        ? {}
+        : { boardingLine: options.payload.boardingLine }),
+      ...(options.payload.trainCode === undefined ? {} : { trainCode: options.payload.trainCode }),
     },
   });
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -723,6 +723,10 @@ export async function fireArvlCdStationPush(
           // #1307 — server-authoritative subsurface. 지하 trip의 intermediate push는
           // 디바이스 GPS 게이트(out-of-range 오거부)를 우회하도록 flag를 전달.
           subsurface: trip.subsurface === true,
+          // #1322 — lock-path fire의 노선/열차를 self-describing으로 전달. 디바이스가 로컬 lock
+          // 없이도(지하 auto-lock hydration window) line sanity-guard를 돌려 발사할 수 있게 한다.
+          boardingLine: lock.line,
+          trainCode: lock.trainCode,
         },
         config: deps.apnsConfig,
         host,

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -451,6 +451,33 @@ describe('silentPushTask', () => {
       });
     });
 
+    // #1322 — backend lock-path fire가 실어 보내는 boardingLine(server-authoritative).
+    describe('boardingLine (#1322)', () => {
+      it('비어있지 않은 string이면 그대로 전달', () => {
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', boardingLine: '7' }),
+          ),
+        ).toMatchObject({ boardingLine: '7' });
+      });
+
+      it('누락/빈문자열/비string이면 undefined (lock 없을 때 보수 동작 fallback)', () => {
+        expect(
+          extractPayload(bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early' })),
+        ).toMatchObject({ boardingLine: undefined });
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', boardingLine: '' }),
+          ),
+        ).toMatchObject({ boardingLine: undefined });
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', boardingLine: 7 }),
+          ),
+        ).toMatchObject({ boardingLine: undefined });
+      });
+    });
+
     // #725 — reschedule schema는 standard와 다르므로 별도 분기 검증.
     describe('reschedule kind (#725)', () => {
       it('정상 reschedule payload → RescheduleSilentPushPayload', () => {
@@ -1086,6 +1113,94 @@ describe('silentPushTask', () => {
           expect.objectContaining({ subsurface: expected }),
         );
         expect(mockGetSubsurfaceState).toHaveBeenCalledTimes(stampQueried ? 1 : 0);
+      });
+    });
+
+    // #1322 — 로컬 lock 없이 payload.boardingLine(self-describing push)으로 line 가드 수행.
+    // 지하 auto-lock hydration window에서 backend lock-path push(transfer/destination)를 발사.
+    describe('#1322 — self-describing push (lock 없음 + payload.boardingLine)', () => {
+      // lockless opt-in 토글 상태를 세팅 — 이 분기들은 토글과 무관히 동작해야 함을 검증하기 위함.
+      function setLocklessToggle(value: boolean) {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          if (key === LOCKLESS_STATION_PASSED_KEY) return JSON.stringify(value);
+          return null;
+        });
+      }
+
+      beforeEach(() => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        setLocklessToggle(true);
+      });
+
+      it('lock 없음 + payload.boardingLine에 정차하는 transfer → line 가드 통과 후 발사', async () => {
+        // payload.boardingLine='7'에 nextWaypoint가 정차 → 정상 lock-path fire.
+        mockFindStationByNameAndLine.mockReturnValue({ id: 'stop-on-7', name: '강남', line: '7' });
+
+        await handleSilentPush(
+          payload({ kind: 'transfer', phase: 'imminent', boardingLine: '7', pushId: 'p-self' }),
+        );
+
+        expect(mockFindStationByNameAndLine).toHaveBeenCalledWith('강남', '7');
+        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+        expect(mockLogSilentPushFired).toHaveBeenCalled();
+      });
+
+      it('lock 없음 + payload.boardingLine line-mismatch → skip + ack(lock-line-mismatch)', async () => {
+        // line 7에는 없고 다른 line에만 존재 → mismatch.
+        mockFindStationByNameAndLine.mockReturnValue(null);
+        mockFindStationByName.mockReturnValue({ id: 'other', name: '강남', line: '2' });
+
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', boardingLine: '7', pushId: 'p-mm' }),
+        );
+
+        expect(mockFindStationByNameAndLine).toHaveBeenCalledWith('강남', '7');
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'lock-line-mismatch', kind: 'destination' }),
+        );
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'p-mm',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'skipped',
+          reason: 'lock-line-mismatch',
+        });
+      });
+
+      it('lock 없음 + payload.boardingLine + nextWaypoint가 stations.json 부재 → 가드 통과 후 발사', async () => {
+        // 양쪽 lookup 모두 null → graceful pass(일반 게이트로 위임), 게이트 통과 가정 → 발사.
+        mockFindStationByNameAndLine.mockReturnValue(null);
+        mockFindStationByName.mockReturnValue(null);
+
+        await handleSilentPush(payload({ kind: 'transfer', phase: 'imminent', boardingLine: '7' }));
+
+        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+        expect(mockLogSilentPushFired).toHaveBeenCalled();
+      });
+
+      it('lock 없음 + payload.boardingLine 통과 시 lockless opt-in 토글 미적용 (토글 OFF여도 발사)', async () => {
+        // 토글 OFF — backend가 lock을 보유한 lock-path fire이므로 lockless opt-in과 무관히 발사.
+        setLocklessToggle(false);
+        mockFindStationByNameAndLine.mockReturnValue({ id: 'stop-on-7', name: '강남', line: '7' });
+
+        await handleSilentPush(payload({ kind: 'transfer', phase: 'imminent', boardingLine: '7' }));
+
+        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+        expect(mockLogSilentPushFired).toHaveBeenCalled();
+      });
+
+      it('lock 없음 + payload.boardingLine 부재 + non-intermediate → 기존 보수 skip(lockless-non-intermediate)', async () => {
+        await handleSilentPush(
+          payload({ kind: 'transfer', phase: 'imminent', pushId: 'p-nolock-noline' }),
+        );
+
+        expect(mockFindStationByNameAndLine).not.toHaveBeenCalled();
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'lockless-non-intermediate', kind: 'transfer' }),
+        );
       });
     });
 

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -27,7 +27,7 @@ import * as Notifications from 'expo-notifications';
 import * as TaskManager from 'expo-task-manager';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import i18next from 'i18next';
-import type { Station } from '../../../shared/types/station';
+import type { LineNumber, Station } from '../../../shared/types/station';
 import {
   APNS_TOKEN_KEY,
   ACTIVE_TRIP_KEY,
@@ -109,6 +109,14 @@ export interface SilentPushPayload {
    * 지하 stale/spoof GPS로 인한 out-of-range 오거부를 막는다. 구 backend 호환 위해 optional.
    */
   subsurface?: boolean;
+  /**
+   * #1322 — backend lock-path fire가 실어 보내는 boardingLock 노선 (server-authoritative).
+   * 로컬 lock이 없을 때(지하 auto-lock hydration window) 이 line으로 sanity-guard를 돌려
+   * non-intermediate push도 발사한다 (`fireWithGate`). backend가 선택해 발사한 push이므로
+   * authoritative — 디바이스는 자체 lock 없이도 honor한다. 구 backend 호환 위해 optional —
+   * 누락 시 기존 보수 동작(lock 없으면 non-intermediate skip)으로 fallback.
+   */
+  boardingLine?: string;
 }
 
 /**
@@ -280,9 +288,10 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
   // standard 경로. findFieldsLayer는 isStandardCandidate(nextWaypoint non-empty) 또는
   // isRescheduleCandidate(kind='reschedule') 중 하나로 통과시키지만, kind='reschedule'
   // 케이스는 위 분기에서 잡혔으므로 잔여 케이스는 isStandardCandidate가 보증한 것 — nextWaypoint 보장.
-  const { nextWaypoint, etaSeconds, phase, kind, sentAt, pushId, hopIndex, subsurface } = obj as {
-    nextWaypoint: string;
-  } & Record<string, unknown>;
+  const { nextWaypoint, etaSeconds, phase, kind, sentAt, pushId, hopIndex, subsurface, boardingLine } =
+    obj as {
+      nextWaypoint: string;
+    } & Record<string, unknown>;
   if (typeof etaSeconds !== 'number' || !Number.isFinite(etaSeconds)) return null;
   if (phase !== 'early' && phase !== 'imminent') return null;
   const validKind =
@@ -296,7 +305,17 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
     pushId: validPushId(pushId),
     hopIndex: validHopIndex(hopIndex),
     subsurface: validSubsurface(subsurface),
+    boardingLine: validBoardingLine(boardingLine),
   };
+}
+
+/**
+ * #1322 — payload.boardingLine 검증. 비어있지 않은 string만 통과 (LineNumber 표기).
+ * backend는 lock-path fire에서만 wire하므로 누락/형식 오류는 undefined로 정규화 →
+ * `fireWithGate`가 lock 없을 때 기존 보수 동작(non-intermediate skip)으로 fallback.
+ */
+function validBoardingLine(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 /**
@@ -723,14 +742,19 @@ async function fireWithGate(
   payload: SilentPushPayload & { kind: NonNullable<SilentPushPayload['kind']> },
   apnsToken: string | null,
 ): Promise<void> {
-  // #707: BoardingLock 활성 시 nextWaypoint가 lock.boardingLine에 정차하는지 검증.
-  // 백엔드 SilentPushPayload(alarm-worker/src/apns.ts)는 line/expectedLine 필드를 보내지 않으므로
+  // #707/#1322: line sanity-guard. nextWaypoint가 boarding 노선에 정차하는지 검증한다.
+  // 노선 출처는 (1) 로컬 BoardingLock, 또는 (2) #1322 — backend lock-path fire가 실어 보낸
+  // payload.boardingLine (지하 auto-lock hydration window 등으로 로컬 lock이 없는 경우).
   // 환승역 등에서 같은 nextWaypoint name이 여러 line stop을 가질 수 있다 — stations.json 매칭으로
   // 다른 line stop만 존재하면 다른 leg/노선의 silent push로 판정해 차단.
   // station name 자체가 stations.json에 없으면 line 가드는 통과시키고 일반 게이트의 unknown-station로 위임.
   const lock = await getBoardingLock();
-  if (lock) {
-    const onBoardingLine = findStationByNameAndLine(payload.nextWaypoint, lock.boardingLine);
+  // guardLine 출처가 로컬 lock(LineNumber)이거나 wire payload(string)라 타입은 string으로 합쳐진다.
+  // findStationByNameAndLine은 `s.line === line` 엄격 비교라 LineNumber가 아닌 임의 문자열은
+  // 어떤 station에도 매칭되지 않아 안전하게 no-match(null)된다 → LineNumber로 좁혀도 무해.
+  const guardLine = (lock ? lock.boardingLine : payload.boardingLine) as LineNumber | undefined;
+  if (guardLine !== undefined) {
+    const onBoardingLine = findStationByNameAndLine(payload.nextWaypoint, guardLine);
     if (!onBoardingLine && findStationByName(payload.nextWaypoint)) {
       const logKind = payload.kind === 'intermediate' ? 'station-passed' : payload.kind;
       logSilentPushSkipped({
@@ -741,12 +765,15 @@ async function fireWithGate(
       });
       ackOutcome(payload.pushId, apnsToken, 'skipped', 'lock-line-mismatch');
       logger.info(
-        `lock line mismatch skip: nextWaypoint=${payload.nextWaypoint} boardingLine=${lock.boardingLine}`,
+        `lock line mismatch skip: nextWaypoint=${payload.nextWaypoint} boardingLine=${guardLine}`,
       );
       return;
     }
+    // #1322 — 로컬 lock 없이 payload.boardingLine만으로 통과한 경우: backend가 train을 선택해
+    // 발사한 lock-path push이므로 authoritative. lockless opt-in 토글은 lock 없는 trip 전용이라
+    // 적용하지 않고(backend lock 보유) line 가드 통과 후 바로 위치/movement 게이트로 진행한다.
   } else {
-    // #816 C — lock 없는 trip의 lockless 분기.
+    // #816 C — lock 없고 payload line도 없는 진짜 lockless 분기.
     // backend가 lockless trip의 station-passed(intermediate)만 발사하지만, race로 transfer/destination이
     // 도착하거나 토글 OFF로 변경된 직후의 push가 도달할 수 있어 client에서 추가 가드.
     //   1) intermediate가 아니면 skip (trainCode 없이 알람 위치 보장 불가)


### PR DESCRIPTION
## 배경

`군자 ×4 received/fired=0` — 지하에서 silent push는 수신되나 발사되지 않는 회귀.

#1315로 lockless trip이 trainCode를 바인딩하면서 backend가 lockless trip에도 **lock-path push**(kind `transfer`/`destination`/`imminent` — 즉 non-intermediate)를 정당하게 발사한다. 그러나 디바이스의 `/boarding-lock/sync`는 **good GPS(≤50m, 지상)일 때만** 실행되므로, 지하에서 backend가 auto-lock한 trip은 디바이스로 hydrate되지 않는다. 결과적으로 디바이스 `getBoardingLock()=null` → `fireWithGate`가 non-intermediate push를 stale race로 보고 `lockless-non-intermediate`로 drop한다.

backend는 authoritative(열차를 선택해 발사 결정함)이므로, 디바이스는 자체 lock 없이도 그 push를 honor해야 한다.

## 접근: push를 self-describing하게 만든다 (lock hydration 아님)

거부된 대안(디바이스가 로컬 BoardingLock을 재구성/저장하도록 push)을 쓰지 않고, push 자체에 노선 정보를 실어 보낸다.

- **backend payload**: `SilentPushPayload`에 optional `boardingLine`/`trainCode` 추가. `sentSilentPush`에서 정의된 경우에만 wire (구 backend/구 client와 byte-level 호환).
- **backend fire site**: lock-path fire(`fireArvlCdStationPush`)가 `lock.line`/`lock.trainCode`를 payload에 채운다.
- **device parsing**: `SilentPushPayload`/`extractStandardPayload`에 `boardingLine` 추가 + `validBoardingLine` 검증(비어있지 않은 string만).
- **device fire gate**: `fireWithGate`에서 로컬 lock이 없어도 `payload.boardingLine`이 있으면 그 노선으로 line sanity-guard를 돌려 발사한다. 로컬 lock도 payload line도 없을 때만 기존 보수 동작(`lockless-non-intermediate` skip)을 유지. lockless opt-out 토글 체크는 진짜 lockless 분기에 그대로 유지.

## 하위 호환

`boardingLine`/`trainCode`는 optional — 구 backend(필드 부재) → 디바이스는 기존 보수 동작으로 fallback, 구 디바이스는 새 필드 무시. 기존 intermediate/lockless 흐름에 영향 없음.

## 테스트

- backend `apns.test.ts`: `boardingLine`/`trainCode` wire 검증(지정 시 전달 / 미지정 시 omit).
- backend `scheduled.test.ts`: lock-path fire payload가 `lock.line`/`lock.trainCode`를 forward.
- device `silentPushTask.test.ts`:
  - `extractPayload` — `boardingLine` 검증(valid string 통과 / 누락·빈문자열·비string → undefined)
  - (a) 로컬 lock 없음 + payload.boardingLine 정차 → **발사**
  - (b) 로컬 lock 없음 + payload line 없음 → 기존대로 **skip**
  - (c) payload.boardingLine line-mismatch → **skip**(lock-line-mismatch)
  - payload.boardingLine 통과 시 lockless opt-in 토글 미적용(토글 OFF여도 발사) / stations.json 부재 시 graceful pass

프론트엔드 `npm test`(5471 tests, 100% coverage) + `npm run type-check` 통과. 백엔드 `npm test`(1254 tests) + tsc 통과.

Closes #1322