### PR TITLE
fix(#1325): getApproachLine 현재역 미서비스 노선 라벨 누출 방어 가드

### DIFF
--- a/src/features/route/utils/__tests__/approachLine.test.ts
+++ b/src/features/route/utils/__tests__/approachLine.test.ts
@@ -87,7 +87,8 @@ describe('getApproachLine', () => {
 
   describe('Route 기반 (우선순위 2)', () => {
     it('direct route → route.line', () => {
-      expect(getApproachLine(makeDirect('7'), null, makeStation('2'))).toBe('7');
+      // 군자는 7호선 정차역 → #1325 가드 통과 (currentStation이 후보 line 서비스).
+      expect(getApproachLine(makeDirect('7'), null, makeStation('7', { name: '군자' }))).toBe('7');
     });
 
     it('transfer route, stopsToTransfer > 0 → fromLine (환승 전)', () => {
@@ -142,6 +143,34 @@ describe('getApproachLine', () => {
 
     it('route null + lock null + station null → null', () => {
       expect(getApproachLine(null, null, null)).toBeNull();
+    });
+  });
+
+  describe('현재역 line 검증 가드 (#1325)', () => {
+    it('후보 line을 현재역이 실제 서비스하면 그대로 반환', () => {
+      // 신당은 2,6호선 정차 → boardingLine 6호선이면 검증 통과.
+      const lock = makeLock('6');
+      const station = makeStation('2', { name: '신당' });
+      expect(getApproachLine(null, lock, station)).toBe('6');
+    });
+
+    it('후보 line을 현재역이 서비스 안 하면 currentStation.line으로 fallback (잘못 탑승/데시싱크)', () => {
+      // 신당은 2,6호선만 정차(7호선 없음). desync route의 7호선 leg가 새도 신당 라벨로 안 씀.
+      const lock = makeLock('7');
+      const station = makeStation('2', { name: '신당' });
+      expect(getApproachLine(null, lock, station)).toBe('2');
+    });
+
+    it('route 파생 line(transfer fromLine)도 현재역 미서비스면 fallback', () => {
+      // makeTransfer fromLine 7호선이 신당으로 새는 케이스를 route 경로로도 커버.
+      const route = makeTransfer('7', '5', 3);
+      const station = makeStation('6', { name: '신당' });
+      expect(getApproachLine(route, null, station)).toBe('6');
+    });
+
+    it('후보 line 존재 + currentStation null → 검증 스킵, 후보 그대로 반환', () => {
+      // currentStation이 없으면 검증할 대상이 없어 기존 동작 유지.
+      expect(getApproachLine(null, makeLock('7'), null)).toBe('7');
     });
   });
 });

--- a/src/features/route/utils/approachLine.ts
+++ b/src/features/route/utils/approachLine.ts
@@ -1,4 +1,4 @@
-import type { Route } from '../../../shared/utils/stationRoute';
+import { findStationByNameAndLine, type Route } from '../../../shared/utils/stationRoute';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
 import type { LineNumber, Station } from '../../../shared/types/station';
 
@@ -17,12 +17,29 @@ import type { LineNumber, Station } from '../../../shared/types/station';
  * stopsToTransfer===0의 의미 모호성(환승역 정확 도착 vs 환승 완료)은 BoardingLock이 있으면 1번에서
  * 해소된다. lock 없는 케이스는 "transferring or transferred"로 추정 → toLine 안내가 더 유용
  * (사용자가 다음 leg arrivals를 봐야 함).
+ *
+ * #1325 방어 가드: route/lock에서 산출한 line이 currentStation이 실제 정차하는 노선이 아니면
+ * (잘못 탑승 / route 데시싱크로 다른 leg line이 샘) 현재역 라벨로 쓰지 않고 currentStation.line으로
+ * fallback한다. upstream fusion(#1317)을 고치기 전에도 혼동 라벨을 차단하는 독립 가드.
  */
 export function getApproachLine(
   route: Route,
   boardingLock: BoardingLock | null,
   currentStation: Station | null,
 ): LineNumber | null {
+  const candidate = resolveCandidateLine(route, boardingLock);
+
+  if (candidate && currentStation) {
+    return findStationByNameAndLine(currentStation.name, candidate)
+      ? candidate
+      : currentStation.line;
+  }
+
+  return candidate ?? currentStation?.line ?? null;
+}
+
+/** route + BoardingLock SSOT로 우선순위에 따라 노선을 산출한다 (검증 전 raw 후보). */
+function resolveCandidateLine(route: Route, boardingLock: BoardingLock | null): LineNumber | null {
   if (boardingLock) return boardingLock.boardingLine;
 
   if (route) {
@@ -40,5 +57,5 @@ export function getApproachLine(
     if (last) return last.toLine;
   }
 
-  return currentStation?.line ?? null;
+  return null;
 }


### PR DESCRIPTION
## 배경
환승역에서 잘못 탑승하거나 route가 데시싱크되면, route leg나 BoardingLock의 노선(예: 7호선 leg)이 현재역 헤더 라벨로 새어 들어가 **현재역이 정차하지 않는 노선**이 표시되는 회귀(신당=2·6호선에 7호선 라벨). 데이터는 정상 — runtime line 해석 결함(#1317 fusion 오인 + #1324 계열 desync)의 증상.

## 변경
- `getApproachLine`이 route/BoardingLock에서 산출한 후보 노선을 그대로 쓰지 않고, `findStationByNameAndLine(currentStation.name, candidate)`로 **현재역이 실제 그 노선을 정차하는지 검증** (Option B 방어 가드).
- 미서비스 노선이면 `currentStation.line`으로 fallback → 혼동 라벨 차단.
- `currentStation`이 null이면 검증 스킵 (기존 동작 유지).
- 후보 산출 우선순위(lock → route leg → null)는 `resolveCandidateLine`로 분리, 검증 지점 단일화. 시그니처 변경 없음.
- upstream fusion(#1317) 수정 전에도 독립적으로 라벨 누출을 막는 surgical 가드.

## 범위
- `src/features/route/utils/approachLine.ts` + 테스트만. (데이터/HomeScreen 미변경)

## 테스트
- `approachLine.ts` 100% 커버리지 (lines/branches/functions/statements).
- 추가 케이스: 후보 노선 서비스 → 반환 / 미서비스 → currentStation.line fallback / route 파생 line 누출 fallback / currentStation null → 검증 스킵.
- 기존 `direct route` 테스트의 물리적으로 불가능한 fixture(천호=7호선)를 실제 7호선 정차역(군자)으로 교정.
- 전체 스위트 5480 tests green, `npm run type-check` 통과.

Closes #1325