### PR TITLE
fix(#1324): 목적지 == 출발역 degenerate trip 차단

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -721,31 +721,23 @@ describe('POST /trips (#578 — preserve advance progress on re-register)', () =
     expect(finalTrip.subsurface).toBe(expectedSubsurface);
   });
 
-  it('returns 400 on invalid JSON', async () => {
-    const env = makeKvEnv();
-    const res = await post('/trips', 'not-json{', env);
-    expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({ error: 'invalid_json' });
-  });
-
-  it('returns 400 on invalid trip body', async () => {
-    const env = makeKvEnv();
-    const res = await post('/trips', { token: '' }, env);
-    expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({ error: 'invalid_trip' });
-  });
-
-  // #1324 — degenerate trip(출발역 == 목적지, 0-stop direct)은 등록 자체를 거부한다.
-  it('returns 400 on degenerate 0-stop direct route (#1324)', async () => {
-    const env = makeKvEnv();
-    const res = await post(
-      '/trips',
+  // POST /trips 거부 케이스 — 동일한 400 + error-code shape를 테이블로 검증(중복 제거).
+  // #1324 degenerate(0-stop direct) row는 KV에 trip이 쓰이지 않았는지까지 추가 확인한다.
+  it.each<[string, unknown, string, boolean]>([
+    ['invalid JSON', 'not-json{', 'invalid_json', false],
+    ['invalid trip body', { token: '' }, 'invalid_trip', false],
+    [
+      'degenerate 0-stop direct route (#1324)',
       tripBody({ route: { type: 'direct', line: '2', stops: 0 } }),
-      env,
-    );
+      'invalid_trip',
+      true,
+    ],
+  ])('returns 400 on %s', async (_name, body, expectedError, expectNoTrip) => {
+    const env = makeKvEnv();
+    const res = await post('/trips', body, env);
     expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({ error: 'invalid_trip' });
-    expect(await env.TRIPS.get('trip:tok-578')).toBeNull();
+    expect(await res.json()).toEqual({ error: expectedError });
+    if (expectNoTrip) expect(await env.TRIPS.get('trip:tok-578')).toBeNull();
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -86,6 +86,19 @@ describe('validateTrip', () => {
     expect(validateTrip({ ...base(), waypoints: [] })).toBeNull();
   });
 
+  // #1324 — degenerate trip(출발역 == 목적지)은 client가 `{ type: 'direct', stops: 0 }` 경로를
+  // 만든다 → 진행할 hop 없음 → 방향 null/빈 탑승목록/skip-cycle(사가정 trip 사고). backend 거부.
+  it('rejects degenerate 0-stop direct route (#1324)', () => {
+    expect(
+      validateTrip({ ...base(), route: { type: 'direct', line: '2', stops: 0 } }),
+    ).toBeNull();
+  });
+
+  it('accepts 1-stop direct route (#1324 — 인접역 trip은 정상)', () => {
+    const trip = validateTrip({ ...base(), route: { type: 'direct', line: '2', stops: 1 } });
+    expect(trip).not.toBeNull();
+  });
+
   it('rejects invalid waypoint kind', () => {
     expect(
       validateTrip({
@@ -720,6 +733,19 @@ describe('POST /trips (#578 — preserve advance progress on re-register)', () =
     const res = await post('/trips', { token: '' }, env);
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: 'invalid_trip' });
+  });
+
+  // #1324 — degenerate trip(출발역 == 목적지, 0-stop direct)은 등록 자체를 거부한다.
+  it('returns 400 on degenerate 0-stop direct route (#1324)', async () => {
+    const env = makeKvEnv();
+    const res = await post(
+      '/trips',
+      tripBody({ route: { type: 'direct', line: '2', stops: 0 } }),
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_trip' });
+    expect(await env.TRIPS.get('trip:tok-578')).toBeNull();
   });
 });
 

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -1262,6 +1262,13 @@ export function validateTrip(input: unknown): Trip | null {
   if (typeof obj.expiresAt !== 'number' || obj.expiresAt <= Date.now()) return null;
   if (typeof obj.alarmAtEpochMs !== 'number') return null;
 
+  // #1324 — degenerate trip 방어: 출발역 == 목적지면 client(stationRoute.findRoutes)가
+  // `{ type: 'direct', stops: 0 }` 경로를 만든다 — 진행할 hop이 없어 방향 null/빈 탑승목록/
+  // skip-cycle로 이어진다(사가정 trip 사고). frontend 경계가 1차 차단하지만, 0-stop direct
+  // 경로는 backend도 거부해 어떤 client에서도 이런 trip이 등록되지 않게 한다.
+  const route = obj.route as Record<string, unknown>;
+  if (route.type === 'direct' && route.stops === 0) return null;
+
   // waypoints 검증
   for (const w of obj.waypoints) {
     if (!w || typeof w !== 'object') return null;

--- a/src/features/route/store/__tests__/useDestinationStore.test.ts
+++ b/src/features/route/store/__tests__/useDestinationStore.test.ts
@@ -92,6 +92,34 @@ describe('useDestinationStore', () => {
     expect(destination).toBeNull();
   });
 
+  // #1324 — 목적지 == customOrigin(store가 권위적으로 아는 출발역)이면 degenerate trip을
+  // 만들지 않고 거부한다 (방향 null/빈 탑승목록 회귀 차단). breadcrumb로 관측 가능.
+  it('setDestination(#1324): customOrigin과 같은 역을 목적지로 지정하면 거부하고 상태 불변', () => {
+    const { setDestination, setCustomOrigin } = useDestinationStore.getState();
+    setCustomOrigin(mockStation);
+    jest.clearAllMocks();
+
+    setDestination(mockStation);
+
+    expect(useDestinationStore.getState().destination).toBeNull();
+    expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(
+      'subway-now:destination',
+      expect.anything(),
+    );
+    expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('trip', 'degenerate-destination-blocked', {
+      station: '강남',
+    });
+  });
+
+  it('setDestination(#1324): customOrigin과 다른 역은 정상 설정된다', () => {
+    const { setDestination, setCustomOrigin } = useDestinationStore.getState();
+    setCustomOrigin(mockStation);
+
+    setDestination(mockStation2);
+
+    expect(useDestinationStore.getState().destination?.id).toBe('2-021');
+  });
+
   it('setDestination: 역 설정 시 AsyncStorage에 저장하고 null 시 삭제한다', async () => {
     const { setDestination } = useDestinationStore.getState();
     setDestination(mockStation);
@@ -257,7 +285,17 @@ describe('useDestinationStore', () => {
     setCustomOrigin(mockStation2);
     expect(useDestinationStore.getState().customOrigin?.id).toBe('2-021');
 
-    setDestination(mockStation2);
+    // #1324 — 새 목적지는 customOrigin(역삼)과 달라야 한다(같으면 degenerate로 거부됨).
+    // switch 시 customOrigin이 클리어되는지 검증하려는 본 테스트 의도 유지.
+    const mockStation3: Station = {
+      id: '2-020',
+      name: '선릉',
+      line: '2',
+      lineColor: '#009D3E',
+      lat: 37.5045,
+      lng: 127.0492,
+    };
+    setDestination(mockStation3);
 
     expect(useDestinationStore.getState().customOrigin).toBeNull();
   });

--- a/src/features/route/store/useDestinationStore.ts
+++ b/src/features/route/store/useDestinationStore.ts
@@ -23,6 +23,7 @@ import { triggerTripEndRecall } from '../../alarm/utils/triggerTripEndRecall';
 import { useAlarmEventStore } from '../../alarm/store/useAlarmEventStore';
 import { ROUTE_CATEGORIES, type RoutePreference } from '../../../shared/utils/stationRoute';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
+import { isDegenerateDestination } from '../utils/isDegenerateDestination';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = (): void => {};
@@ -94,6 +95,16 @@ export const useDestinationStore = create<DestinationState>((set, get) => ({
   routePreference: 'optimal' as RoutePreference,
 
   setDestination: (station: Station | null) => {
+    // #1324 — 목적지 == 출발역이면 degenerate trip(0-waypoint → 방향 null → 빈 탑승목록)이
+    // 생성된다. UX 경계(DestinationPicker.onSelect)에서 effectiveOrigin(=customOrigin ∪ GPS)을
+    // 기준으로 우선 차단하지만, store가 권위적으로 아는 customOrigin과 같은 역을 목적지로
+    // 지정하는 모든 경로(최근 목적지 탭/맵 탭/프로그램적 호출)에 대한 방어선으로 여기서도 거부한다.
+    if (station && isDegenerateDestination(get().customOrigin, station)) {
+      addDomainBreadcrumb('trip', 'degenerate-destination-blocked', {
+        station: station.name,
+      });
+      return;
+    }
     const prev = get().destination;
     const isSwitch = (prev?.id ?? null) !== (station?.id ?? null);
     set({ destination: station });

--- a/src/features/route/utils/__tests__/isDegenerateDestination.test.ts
+++ b/src/features/route/utils/__tests__/isDegenerateDestination.test.ts
@@ -1,0 +1,40 @@
+import { isDegenerateDestination } from '../isDegenerateDestination';
+import { Station } from '../../../../shared/types/station';
+
+const gangnam: Station = {
+  id: '2-022',
+  name: '강남',
+  line: '2',
+  lineColor: '#009D3E',
+  lat: 37.4979,
+  lng: 127.0276,
+};
+
+const yeoksam: Station = {
+  id: '2-021',
+  name: '역삼',
+  line: '2',
+  lineColor: '#009D3E',
+  lat: 37.5006,
+  lng: 127.0365,
+};
+
+describe('isDegenerateDestination (#1324)', () => {
+  it('출발역과 목적지가 같은 id면 degenerate(true)', () => {
+    expect(isDegenerateDestination(gangnam, gangnam)).toBe(true);
+    // 같은 역이지만 다른 객체 참조라도 id 기준으로 판정.
+    expect(isDegenerateDestination({ ...gangnam }, gangnam)).toBe(true);
+  });
+
+  it('출발역과 목적지가 다른 역이면 false', () => {
+    expect(isDegenerateDestination(gangnam, yeoksam)).toBe(false);
+  });
+
+  it('origin이 null이면 비교 불가 → false(통과)', () => {
+    expect(isDegenerateDestination(null, gangnam)).toBe(false);
+  });
+
+  it('origin이 undefined여도 false(통과)', () => {
+    expect(isDegenerateDestination(undefined, gangnam)).toBe(false);
+  });
+});

--- a/src/features/route/utils/isDegenerateDestination.ts
+++ b/src/features/route/utils/isDegenerateDestination.ts
@@ -1,0 +1,16 @@
+import { Station } from '../../../shared/types/station';
+
+/**
+ * #1324 — 목적지가 출발역과 같으면 degenerate trip(0-waypoint → 방향 null → 빈 탑승목록 →
+ * skip-cycle)이 생성된다. 사가정 trip 사고. 목적지 지정 경계(DestinationPicker.onSelect /
+ * useDestinationStore.setDestination)에서 이 술어로 차단한다.
+ *
+ * `origin`이 null(아직 현재역 미확정)이면 비교 불가 → false(통과). 동일 역 판정은
+ * stations.json의 안정적 `id` 기준 — 표시명/노선 표기 차이에 영향받지 않는다.
+ */
+export function isDegenerateDestination(
+  origin: Station | null | undefined,
+  destination: Station,
+): boolean {
+  return origin != null && origin.id === destination.id;
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -59,6 +59,7 @@ import { CurrentStationConfirmModal } from '../features/nearest-station/componen
 import { MisBoardingBanner } from '../features/route/components/MisBoardingBanner';
 import { MisBoardingReselectModal } from '../features/route/components/MisBoardingReselectModal';
 import { ShareTripButton } from '../features/route/components/ShareTripButton';
+import { isDegenerateDestination } from '../features/route/utils/isDegenerateDestination';
 import { Toast } from '../shared/ui/Toast';
 import { useMisBoardingDetector } from '../features/route/hooks/useMisBoardingDetector';
 import { useTrainPositions } from '../features/route/hooks/useTrainPositions';
@@ -187,6 +188,8 @@ export default function HomeScreen() {
   // BoardingTrainList의 onLockCorrected callback이 채워주며, 같은 메시지가 두 인스턴스(현재역/환승)에
   // 공통 적용된다. dismiss는 Toast의 5초 timer 또는 사용자 tap.
   const [lockCorrectionToast, setLockCorrectionToast] = useState<string | null>(null);
+  // #1324 — 목적지 == 현재역(degenerate trip) 선택을 차단했을 때 노출하는 경고 toast.
+  const [sameOriginToast, setSameOriginToast] = useState<string | null>(null);
   const handleConfirmStation = useCallback(
     (station: Station) => {
       setCustomOrigin(station);
@@ -252,6 +255,22 @@ export default function HomeScreen() {
   const isCustomOrigin = customOrigin !== null;
   const effectiveOrigin = customOrigin ?? result?.station ?? null;
   useTripOrigin(destination, effectiveOrigin, setTripOrigin, tripOrigin);
+  const handleSameOriginToastDismiss = useCallback(() => setSameOriginToast(null), []);
+  // #1324 — 목적지 선택 단일 진입점. 현재역(effectiveOrigin)과 같은 역이면 degenerate trip을
+  // 만들지 않고 경고 toast만 노출한다. picker / 최근 목적지 tap 모두 이 핸들러를 거친다.
+  // 반환값: 목적지를 실제로 설정했으면 true(picker가 닫아야 함), 차단했으면 false(picker 유지).
+  const handleSelectDestination = useCallback(
+    (station: Station): boolean => {
+      if (isDegenerateDestination(effectiveOrigin, station)) {
+        setSameOriginToast(t('destinationPicker.sameAsOrigin'));
+        return false;
+      }
+      addRecentDestination(station);
+      setDestination(station);
+      return true;
+    },
+    [effectiveOrigin, t, addRecentDestination, setDestination],
+  );
   // #797: 환승역에서 nearest.station.line이 trip 방향과 어긋나는 회귀 차단.
   // BoardingLock(사용자 선택) > Route(구조적 SSOT) > station.line fallback.
   const approachLine = getApproachLine(route, fusionBoardingLock, effectiveOrigin);
@@ -1151,7 +1170,7 @@ export default function HomeScreen() {
                       >
                         <TouchableOpacity
                           style={styles.recentDestinationTapArea}
-                          onPress={() => setDestination(recent)}
+                          onPress={() => handleSelectDestination(recent)}
                           testID={`recent-destination-button-${recent.id}`}
                         >
                           <View style={styles.recentDestinationRow}>
@@ -1308,13 +1327,18 @@ export default function HomeScreen() {
         onDismiss={handleLockCorrectionToastDismiss}
         testID="lock-correction-toast"
       />
+      {/* #1324 — 목적지 == 현재역 차단 경고. 5초 자동 dismiss + tap 닫기. */}
+      <Toast
+        visible={sameOriginToast !== null}
+        message={sameOriginToast ?? ''}
+        onDismiss={handleSameOriginToastDismiss}
+        testID="same-origin-toast"
+      />
 
       <DestinationPicker
         visible={pickerVisible}
         onSelect={(station) => {
-          addRecentDestination(station);
-          setDestination(station);
-          setPickerVisible(false);
+          if (handleSelectDestination(station)) setPickerVisible(false);
         }}
         onClose={() => setPickerVisible(false)}
         favorites={favorites}

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -14,6 +14,8 @@ import { useTheme, spacing, radius } from '../shared/theme';
 import { useFavoritesStore } from '../features/favorites/store/useFavoritesStore';
 import { useDestinationStore } from '../features/route/store/useDestinationStore';
 import { LineBadge } from '../shared/ui/LineBadge';
+import { Toast } from '../shared/ui/Toast';
+import { isDegenerateDestination } from '../features/route/utils/isDegenerateDestination';
 import { getStationDisplayName } from '../shared/utils/stationDisplay';
 import { routeToCoordinates, type RouteCoordinatePath } from '../features/route/utils/routeToCoordinates';
 import type { Route } from '../shared/utils/stationRoute';
@@ -38,6 +40,8 @@ export default function MapScreen() {
   const favorites = useFavoritesStore((s) => s.favorites);
   const setSlotFavorite = useFavoritesStore((s) => s.setSlotFavorite);
   const [selectedStation, setSelectedStation] = useState<Station | null>(null);
+  // #1324 — 목적지 == 현재역(degenerate trip) 선택 차단 경고 toast.
+  const [sameOriginToast, setSameOriginToast] = useState<string | null>(null);
   const [focusStation, setFocusStation] = useState<Station | null>(null);
   const [focusNonce, setFocusNonce] = useState(0);
   const [recenterNonce, setRecenterNonce] = useState(0);
@@ -180,6 +184,11 @@ export default function MapScreen() {
             <TouchableOpacity
               style={[styles.selectionButton, { borderWidth: 1, borderColor: colors.accent }]}
               onPress={() => {
+                // #1324 — 현재역(customOrigin ∪ GPS)과 같은 역은 목적지로 설정하지 않는다.
+                if (isDegenerateDestination(customOrigin ?? result?.station ?? null, selectedStation)) {
+                  setSameOriginToast(t('destinationPicker.sameAsOrigin'));
+                  return;
+                }
                 addRecentDestination(selectedStation);
                 setDestination(selectedStation);
                 setSelectedStation(null);
@@ -216,6 +225,13 @@ export default function MapScreen() {
         </View>
       )}
 
+      {/* #1324 — 목적지 == 현재역 차단 경고. 5초 자동 dismiss + tap 닫기. */}
+      <Toast
+        visible={sameOriginToast !== null}
+        message={sameOriginToast ?? ''}
+        onDismiss={() => setSameOriginToast(null)}
+        testID="same-origin-toast"
+      />
     </SafeAreaView>
   );
 }

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -166,7 +166,8 @@
     "originTitle": "Choose current station",
     "searchPlaceholder": "Search station name",
     "assignSlot": "Add {{label}}",
-    "pendingSlot": "The next station you pick will be saved as {{label}}"
+    "pendingSlot": "The next station you pick will be saved as {{label}}",
+    "sameAsOrigin": "You can't set your current station as the destination"
   },
   "currentStationConfirm": {
     "title": "Confirm your current station",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -166,7 +166,8 @@
     "originTitle": "現在の駅を選択",
     "searchPlaceholder": "駅名を検索",
     "assignSlot": "{{label}}を追加",
-    "pendingSlot": "次に選ぶ駅を{{label}}として保存します"
+    "pendingSlot": "次に選ぶ駅を{{label}}として保存します",
+    "sameAsOrigin": "現在の駅は目的地に設定できません"
   },
   "currentStationConfirm": {
     "title": "現在の駅を確認してください",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -166,7 +166,8 @@
     "originTitle": "현재 역 선택",
     "searchPlaceholder": "역 이름 검색",
     "assignSlot": "{{label}} 추가",
-    "pendingSlot": "다음에 선택하는 역을 {{label}}로 저장합니다"
+    "pendingSlot": "다음에 선택하는 역을 {{label}}로 저장합니다",
+    "sameAsOrigin": "현재 역은 목적지로 설정할 수 없습니다"
   },
   "currentStationConfirm": {
     "title": "현재 역을 확인해 주세요",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -166,7 +166,8 @@
     "originTitle": "选择当前车站",
     "searchPlaceholder": "搜索车站名称",
     "assignSlot": "添加{{label}}",
-    "pendingSlot": "下次选择的车站将保存为{{label}}"
+    "pendingSlot": "下次选择的车站将保存为{{label}}",
+    "sameAsOrigin": "当前车站不能设为目的地"
   },
   "currentStationConfirm": {
     "title": "请确认当前车站",


### PR DESCRIPTION
## 배경
현재역 == 목적지로 trip을 만들면 0-waypoint → 방향 null → 빈 탑승목록 → skip-cycle인 degenerate trip이 생성된다(사가정 trip 사고). frontend/backend 어느 쪽에도 가드가 없었다.

이슈 정정 코멘트: **frontend-primary** — `DestinationPicker.onSelect`/`setDestination` 경계에서 `station.id === effectiveOrigin?.id`면 차단/경고. backend 0-waypoint reject는 방어.

## 변경 (양 레이어 가드)
- **순수 술어** `src/features/route/utils/isDegenerateDestination.ts` — `origin != null && origin.id === destination.id`. stations.json의 안정적 `id` 기준.
- **frontend (primary)**
  - `useDestinationStore.setDestination`: store가 권위적으로 아는 `customOrigin`과 같은 역을 목적지로 지정하면 거부 + `degenerate-destination-blocked` breadcrumb. 모든 경로(picker/최근목적지/맵 탭/프로그램적 호출)의 방어선.
  - `HomeScreen`: `handleSelectDestination` 단일 진입점 — `effectiveOrigin`(customOrigin ∪ GPS)과 같으면 경고 toast + 차단(picker 유지). picker onSelect / 최근 목적지 tap / 즐겨찾기 chip 모두 경유.
  - `MapScreen`: "목적지로 설정" 버튼에 동일 가드 + 경고 toast.
  - `destinationPicker.sameAsOrigin` i18n 4개 언어(ko/en/ja/zh).
- **backend (방어)**
  - `validateTrip`: 0-stop direct route(`{ type: 'direct', stops: 0 }` = 출발==목적지)를 거부 → `POST /trips`가 `invalid_trip` 400. 어떤 client에서도 degenerate 등록 차단.

## 테스트 (100%)
- `isDegenerateDestination`: 동일/상이/null/undefined origin 케이스.
- `useDestinationStore`: customOrigin == 목적지 거부(상태 불변 + breadcrumb) / 상이 시 정상 설정. 변경 파일 라인 100% 커버.
- backend `index.test.ts`: validateTrip 0-stop direct 거부 / 1-stop direct 정상(인접역 trip 회귀 가드) / POST 400 + KV 미기록.
- 기존 #702 customOrigin-clear 테스트가 우연히 degenerate 입력에 의존하던 부분을 제3 역으로 교정(의도 유지).

## 검증
- `npm test` (FE): 286 suites / 5482 tests pass, 글로벌 100% 커버리지 게이트 통과
- `npm run type-check` (FE): pass
- backend `vitest run`: 33 files / 1257 tests pass, `tsc --noEmit` pass
- ESLint: 변경 파일 0 error (디렉토리 경계 위반 없음)

Closes #1324