### PR TITLE
fix(#1326): 탑승 열차 목록 빈값 회귀 수정

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -157,6 +157,52 @@ describe('useBoardingLockController', () => {
     });
   });
 
+  describe('boardingListArrivals (#1326)', () => {
+    it('방향 필터 결과가 있으면 directionalArrivals 그대로 — 방향 필터 유지', () => {
+      mockResolveTripDirection.mockReturnValue('up');
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      expect(result.current.boardingListArrivals).toEqual([upTrain]);
+    });
+
+    it('방향 필터가 빈 쪽을 고르면 반대 방향으로 폴백 — "선택할 열차 없음" 회귀 차단', () => {
+      mockResolveTripDirection.mockReturnValue('up');
+      const onlyDown: StationArrival = { up: [], down: [downTrain] };
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: onlyDown }),
+      );
+      // 엄격 list(Gate 1용)는 그대로 비어있고, UI list만 폴백으로 노출된다.
+      expect(result.current.directionalArrivals).toEqual([]);
+      expect(result.current.boardingListArrivals).toEqual([downTrain]);
+    });
+
+    it('arrival null이면 빈 배열', () => {
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: null }),
+      );
+      expect(result.current.boardingListArrivals).toEqual([]);
+    });
+
+    it('양방향 모두 비면 빈 목록 — 진짜 도착 없음(empty-state)', () => {
+      mockResolveTripDirection.mockReturnValue('up');
+      const empty: StationArrival = { up: [], down: [] };
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: empty }),
+      );
+      expect(result.current.boardingListArrivals).toEqual([]);
+    });
+
+    it('폴백 시에도 음수 arrivalSeconds(지나간 열차)는 제외', () => {
+      mockResolveTripDirection.mockReturnValue('up');
+      const passed = makeTrain({ trainCode: 'PASSED', arrivalSeconds: -10 });
+      const future = makeTrain({ trainCode: 'FUTURE', arrivalSeconds: 180 });
+      const onlyDownMixed: StationArrival = { up: [], down: [passed, future] };
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: onlyDownMixed }),
+      );
+      expect(result.current.boardingListArrivals).toEqual([future]);
+    });
+  });
+
   describe('createLockFromTrain', () => {
     beforeEach(() => {
       jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -49,8 +49,17 @@ export interface UseBoardingLockControllerInputs {
 
 export interface UseBoardingLockControllerResult {
   lock: BoardingLock | null;
-  /** route 진행 방향으로 필터된 도착 list. 방향 미상이면 up+down 합집합. */
+  /**
+   * route 진행 방향으로 필터된 도착 list. 방향 미상이면 up+down 합집합.
+   * hydrateLockFromCandidate Gate 1(#1014)의 방향 일치 검증에 쓰이므로 방향 엄격성을 유지한다.
+   */
   directionalArrivals: ArrivalInfo[];
+  /**
+   * BoardingTrainList(사용자 직접 선택) 전용 도착 list — #1326.
+   * directionalArrivals가 비어도(방향 필터가 populated side를 거름) 반대 방향 열차가 있으면 합쳐 노출한다.
+   * 양쪽 모두 비어야 빈 목록. 빈 list "선택할 열차 없음" 회귀를 막되 Gate 1 엄격성은 건드리지 않는다.
+   */
+  boardingListArrivals: ArrivalInfo[];
   /** 사용자가 도착 list에서 열차 탭 시 호출. lock 생성을 위한 컨텍스트가 부족하면 no-op. */
   createLockFromTrain: (train: ArrivalInfo) => void;
   /**
@@ -76,6 +85,14 @@ const VALID_LINES: ReadonlyArray<LineNumber> = [
 function asLineNumber(raw: string): LineNumber | null {
   return (VALID_LINES as ReadonlyArray<string>).includes(raw) ? (raw as LineNumber) : null;
 }
+
+/**
+ * 도착 list 필터 술어 — #897 (Seam A). arrivalSeconds 음수(이미 지나간 열차)만 제외하고 임박(0초)은
+ * 유지한다. 0초 행이 useArrivalCountdown tick으로 사라지면 사용자가 다음 차를 같은 차로 오인하는 회귀가
+ * 있어 음수만 차단. 음수 train은 createLockFromTrain에서도 의미가 없어 #666 가드를 갈음한다.
+ * directionalArrivals / boardingListArrivals 두 파생값이 같은 정책을 공유하는 SSOT.
+ */
+const isReachable = (train: ArrivalInfo): boolean => train.arrivalSeconds >= 0;
 
 /**
  * BoardingLock 제어 hook (#584 PR B).
@@ -138,14 +155,23 @@ export function useBoardingLockController({
 
   const directionalArrivals = useMemo<ArrivalInfo[]>(() => {
     if (!arrival) return [];
-    // #897 (Seam A): 임박(arrivalSeconds=0) 열차도 list에 유지 — useArrivalCountdown tick으로 0초가
-    // 되어 행이 사라지면 사용자가 다음 차를 같은 차로 오인하는 회귀가 발생. 음수(이미 지나간)만 차단.
-    // 음수 train은 createLockFromTrain에서도 의미가 없어 #666 가드를 갈음한다.
-    const reachable = (t: ArrivalInfo): boolean => t.arrivalSeconds >= 0;
-    if (direction === 'up') return arrival.up.filter(reachable);
-    if (direction === 'down') return arrival.down.filter(reachable);
-    return [...arrival.up, ...arrival.down].filter(reachable);
+    if (direction === 'up') return arrival.up.filter(isReachable);
+    if (direction === 'down') return arrival.down.filter(isReachable);
+    return [...arrival.up, ...arrival.down].filter(isReachable);
   }, [arrival, direction]);
+
+  // #1326: BoardingTrainList 전용 — 방향 필터 결과가 비면 빈 목록 대신 양방향 합집합으로 폴백.
+  //
+  // directionalArrivals는 hydrateLockFromCandidate Gate 1(#1014)의 false-positive 방어용이라 방향을
+  // 엄격히 유지해야 한다. 하지만 사용자가 직접 탭하는 BoardingTrainList에서는 resolveTripDirection이
+  // (환승역/환상선/index 기반 한계로) 잘못된 방향을 골라 그 쪽 arrival이 비면 "선택할 열차 없음"이 뜨는
+  // 회귀가 있었다. 도착 열차가 실제로 존재하면 빈 목록을 피하는 게 우선이므로, 방향 필터 결과가 비면
+  // 반대 방향까지 합쳐 노출한다. 양쪽 모두 비면 그대로 빈 목록(진짜 도착 없음 → 컴포넌트 empty-state).
+  const boardingListArrivals = useMemo<ArrivalInfo[]>(() => {
+    if (directionalArrivals.length > 0) return directionalArrivals;
+    if (!arrival) return [];
+    return [...arrival.up, ...arrival.down].filter(isReachable);
+  }, [directionalArrivals, arrival]);
 
   const createLockFromTrain = useCallback(
     (train: ArrivalInfo) => {
@@ -267,6 +293,7 @@ export function useBoardingLockController({
   return {
     lock,
     directionalArrivals,
+    boardingListArrivals,
     createLockFromTrain,
     hydrateLockFromCandidate,
     releaseLock: release,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -274,7 +274,7 @@ export default function HomeScreen() {
   // #797: 환승역에서 nearest.station.line이 trip 방향과 어긋나는 회귀 차단.
   // BoardingLock(사용자 선택) > Route(구조적 SSOT) > station.line fallback.
   const approachLine = getApproachLine(route, fusionBoardingLock, effectiveOrigin);
-  // D7 (#1213) ETA provider SSOT — 현재역 BoardingTrainList(via directionalArrivals)와
+  // D7 (#1213) ETA provider SSOT — 현재역 BoardingTrainList(via boardingListArrivals)와
   // 정상 Arrival 표시(EditorialArrivalRow via ArrivalDirectionGroup)는 둘 다 아래 `arrival`을
   // 출처로 사용한다. 절대 시각 anchor도 arrivalAt(item)으로 통일(#897 Seam A). 따라서 두 surface의
   // ETA는 같은 시점에 항상 동일해야 한다. 회귀 게이트: etaProviderConsistency.test.ts.
@@ -402,7 +402,7 @@ export default function HomeScreen() {
   // alarm/Fusion과의 wiring은 후속 PR C/D에서 활성화된다.
   const {
     lock: boardingLock,
-    directionalArrivals,
+    boardingListArrivals,
     createLockFromTrain,
     hydrateLockFromCandidate,
     releaseLock: releaseBoardingLock,
@@ -805,7 +805,7 @@ export default function HomeScreen() {
       {/* line이 정해져야 list를 렌더 가능 — line null이면 모달 자체를 띄우지 않음 (빈 sheet 회피). */}
       <MisBoardingReselectModal
         visible={misBoardingModalVisible && effectiveOrigin?.line != null}
-        arrivals={directionalArrivals}
+        arrivals={boardingListArrivals}
         line={effectiveOrigin?.line ?? null}
         onSelect={handleMisBoardingReselect}
         onClose={handleMisBoardingModalClose}
@@ -998,7 +998,9 @@ export default function HomeScreen() {
                             if (i === 0 && stop.mark === 'filled' && boardingLock) {
                               // #897 Seam A: lock.trainCode 매칭 train의 잔여 ETA → 지연 칩 계산 input.
                               // 매칭 없으면 undefined → 칩 미노출 (graceful).
-                              const matchedTrain = directionalArrivals.find(
+                              // #1326: 표시 전용 lookup이라 boardingListArrivals 사용(Gate 1 무관). 방향 폴백
+                              //   list에서 탭한 lock도 매칭돼 지연 칩이 살아난다(strict면 폴백 시 영구 미노출).
+                              const matchedTrain = boardingListArrivals.find(
                                 (t) => t.trainCode === boardingLock.trainCode,
                               );
                               return (
@@ -1040,7 +1042,7 @@ export default function HomeScreen() {
                               // 사용자가 BoardingTrainList에서 열차를 탭해야 lock이 생성되고, 이후 폴링에서 칩이 활성화된다.
                               return (
                                 <BoardingTrainList
-                                  arrivals={directionalArrivals}
+                                  arrivals={boardingListArrivals}
                                   // #797: approachLine 우선 — 환승역에서 effectiveOrigin.line이 trip 방향과
                                   // 어긋날 때 BoardingLock·route SSOT로 정확한 호선 표시.
                                   line={approachLine ?? effectiveOrigin.line}


### PR DESCRIPTION
## 배경
2026-06-15 오후 트립에서 13:24 열차 탑승 시 **탑승 열차 목록이 비어 선택할 열차가 없음**(빈 목록). Epic #1204 wave 3.

## Root cause
`BoardingTrainList`는 `useBoardingLockController`의 `directionalArrivals`로 채워진다. `directionalArrivals`는 `resolveTripDirection`가 유도한 진행 방향(up/down)으로 도착 list를 필터하는데, 이 함수는 환승역/환상선/index 기반 한계로 **populated 되지 않은 쪽 방향을 확정적으로 고를 수 있다**(`tripDirection.ts:26-27`). 그러면 반대 방향에 열차가 있어도 빈 목록이 된다.

## 설계 제약
`directionalArrivals`는 소비처가 둘이다:
1. UI `BoardingTrainList` (빈 목록 회귀 — 본 이슈)
2. `hydrateLockFromCandidate` Gate 1 (#1014): backend auto-lock(silent push)이 **방향 불일치 열차로 잘못 잠기는** false positive를 막는 방어선. 방향 엄격성을 풀면 ADR-014(lock 정확도)를 위반한다.

→ `directionalArrivals`는 **건드리지 않고**, UI 전용 파생값 `boardingListArrivals`를 신설했다.

## 변경
- `boardingListArrivals`: `directionalArrivals`가 비면(방향 필터가 populated side를 거름) 양방향 reachable 합집합으로 폴백. 양쪽 모두 비어야 빈 목록 → 진짜 도착 없음일 때만 empty-state.
- HomeScreen 선택 list 2곳(MisBoardingReselectModal·BoardingTrainList) + 지연칩 lookup을 `boardingListArrivals`로 전환. Gate 1과 지연칩 lookup은 방향 무관 표시 전용이라 안전.
- `isReachable` 술어(#897 "음수=지나간 열차" 정책) 모듈 스코프 SSOT 추출.

## 테스트
- `useBoardingLockController.test.tsx`에 `boardingListArrivals` describe 5케이스 추가(폴백 코어 + Gate 1 strict 보존 단언 + null/양쪽 빈/음수 제외).
- 대상 파일 커버리지 100%, type-check 통과.
- 코드 리뷰(code-review 에이전트) 통과 — P1/P2 0건.

## 잔여
- HomeScreen은 coverage 제외(E2E + 수동 검증). 실기기에서 환승역 탑승 목록 노출 확인 필요.

Closes #1326