### PR TITLE
chore(#1327): production 빌드 추정-근거 debug 문구 게이팅

### DIFF
--- a/src/features/alarm/utils/__tests__/notificationSource.test.ts
+++ b/src/features/alarm/utils/__tests__/notificationSource.test.ts
@@ -6,6 +6,11 @@ import {
 } from '../notificationSource';
 import type { FusionSource } from '../../../../shared/types/fusion';
 
+const mockIsDebugModalEnabled = jest.fn();
+jest.mock('../../../../shared/constants/debugFlags', () => ({
+  isDebugModalEnabled: () => mockIsDebugModalEnabled(),
+}));
+
 describe('resolveNotificationSource', () => {
   it.each<[FusionSource, NotificationSource]>([
     ['boarding-lock', 'positionTrain'],
@@ -42,12 +47,25 @@ describe('notificationSourceI18nKey', () => {
 });
 
 describe('shouldDiscloseNotificationSource', () => {
-  it.each<[NotificationSource, boolean]>([
-    ['gpsOnly', true],
-    ['uncertain', true],
-    ['positionTrain', false],
-    ['routeProgress', false],
-  ])('%s → %s (사용자 자백 대상 여부)', (key, expected) => {
-    expect(shouldDiscloseNotificationSource(key)).toBe(expected);
+  describe('debug 빌드(isDebugModalEnabled=true)', () => {
+    beforeEach(() => mockIsDebugModalEnabled.mockReturnValue(true));
+    it.each<[NotificationSource, boolean]>([
+      ['gpsOnly', true],
+      ['uncertain', true],
+      ['positionTrain', false],
+      ['routeProgress', false],
+    ])('%s → %s (사용자 자백 대상 여부)', (key, expected) => {
+      expect(shouldDiscloseNotificationSource(key)).toBe(expected);
+    });
+  });
+
+  describe('production 빌드(isDebugModalEnabled=false) — #1327', () => {
+    beforeEach(() => mockIsDebugModalEnabled.mockReturnValue(false));
+    it.each<NotificationSource>(['gpsOnly', 'uncertain', 'positionTrain', 'routeProgress'])(
+      '%s → false (추정-근거 debug 문구 미노출)',
+      (key) => {
+        expect(shouldDiscloseNotificationSource(key)).toBe(false);
+      },
+    );
   });
 });

--- a/src/features/alarm/utils/notificationSource.ts
+++ b/src/features/alarm/utils/notificationSource.ts
@@ -1,4 +1,5 @@
 import type { FusionSource } from '../../../shared/types/fusion';
+import { isDebugModalEnabled } from '../../../shared/constants/debugFlags';
 
 /**
  * 사용자에게 노출되는 데이터 출처 그룹 (#327 Phase B).
@@ -60,7 +61,12 @@ export function notificationSourceI18nKey(key: NotificationSource): SourceI18nKe
  * gpsOnly/uncertain은 신뢰도가 낮아 사용자가 의심해야 하므로 표시.
  *
  * 모든 표면(SourceBadge / 알람 본문 suffix / LA sourceLabel)에서 이 룰을 공유한다.
+ *
+ * #1327: "추정-근거" 자백은 개발용 진단 정보다. production 빌드(debug flag 없음)에서는 항상 false로
+ * 게이팅해 노출하지 않고, debug 빌드(__DEV__ 또는 EXPO_PUBLIC_DEBUG_MODAL=true)에서만 기존 룰대로
+ * 노출한다. 단일 chokepoint이므로 3개 표면이 동시에 게이팅된다.
  */
 export function shouldDiscloseNotificationSource(key: NotificationSource): boolean {
+  if (!isDebugModalEnabled()) return false;
   return key === 'gpsOnly' || key === 'uncertain';
 }


### PR DESCRIPTION
## 배경
production 빌드에서 알림·현재역 탭에 개발용 "추정-근거" 안내 문구(예: "GPS 추정", "위치 확인 중")가 노출됐다. 진단용 정보라 일반 사용자에게는 숨겨야 한다. Epic #1204 wave 3, main 릴리스 전 처리.

## Root cause
`shouldDiscloseNotificationSource`(`notificationSource.ts:64`)가 gpsOnly/uncertain → true로 **debug 게이트 없이** 항상 노출. 3개 표면이 모두 이 함수를 chokepoint로 사용:
- `SourceBadge.tsx:36` (현재역 탭 badge)
- `stationNotification.ts:39` (알림 본문 suffix)
- `stationNotification.ts:331` (Live Activity sourceLabel)

## 변경
- 단일 chokepoint에 `if (!isDebugModalEnabled()) return false;` 게이트 추가.
  - production(debug flag 없음) → 항상 false → 3개 표면 동시 미노출.
  - debug 빌드(`__DEV__` 또는 `EXPO_PUBLIC_DEBUG_MODAL=true`) → 기존 룰 유지.
- 네이티브 LA 위젯은 `data.sourceLabel`이 채워질 때만 렌더 → production에서 라벨 자체를 수신 안 함(누출 경로 없음).

## 테스트
- `debugFlags` 모킹으로 debug(true)/production(false) 양 경로 커버.
- `notificationSource.ts` 커버리지 100%, type-check 통과.
- SourceBadge·stationNotification 기존 스위트(jest `__DEV__=true`) 회귀 0건.
- 코드 리뷰(code-review 에이전트) 통과 — P1/P2/P3 0건, 네이티브 누출 경로까지 검증.

## Acceptance
- production: 추정-근거 debug 문구 미노출. ✅
- debug(`EXPO_PUBLIC_DEBUG_MODAL=true`): 기존대로 노출 유지. ✅

Closes #1327