### PR TITLE
fix(#1337): trip-ended alert payload BG 핸들러 (PR1 device 절반)

### DIFF
--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -2070,6 +2070,118 @@ describe('silentPushTask', () => {
           });
         });
       });
+
+      // #1337 PR1 — backend가 alert payload(`aps.alert`)로 trip-ended를 발사하면
+      // iOS가 killed 앱에도 시스템 banner를 직접 표시한다. 디바이스는 surface skip하되
+      // sentinel/cleanup/ack는 silent path와 동일하게 수행. dedup용 pushId 기록은 유지.
+      describe('#1337 PR1 — alert payload trip-ended path', () => {
+        function alertTripEndedPayload(extra: Record<string, unknown> = {}) {
+          return {
+            data: {
+              data: {
+                data: { kind: 'trip-ended', reason: 'eta-missing', ...extra },
+                dataString: null,
+              },
+              // alert payload는 Swift transformer가 notification을 non-null로 채운다.
+              notification: { request: { content: { title: '안내 종료', body: '경로 안내를 종료했어요' } } },
+              aps: { alert: { title: '안내 종료', body: '경로 안내를 종료했어요' }, sound: 'default' },
+            },
+          };
+        }
+
+        it('alert payload → sendTripEndedNotification 호출 안 함(OS가 banner 표시)', async () => {
+          await handleSilentPush(alertTripEndedPayload({ pushId: 'a-uuid', reason: 'expired' }));
+          expect(mockSendTripEndedNotification).not.toHaveBeenCalled();
+        });
+
+        it('alert payload → setTripEndedSentinel 호출(silent path와 동일)', async () => {
+          await handleSilentPush(alertTripEndedPayload({ pushId: 'a-uuid' }));
+          expect(mockSetTripEndedSentinel).toHaveBeenCalledTimes(1);
+          expect(mockSetTripEndedSentinel).toHaveBeenCalledWith(expect.any(Number));
+        });
+
+        it('alert payload → runTripBoundCleanups 호출(active trip clear)', async () => {
+          await handleSilentPush(alertTripEndedPayload({ pushId: 'a-uuid' }));
+          expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+        });
+
+        it('alert payload → triggerTripEndRecall도 cleanup 이전에 호출', async () => {
+          const callOrder: string[] = [];
+          mockTriggerTripEndRecall.mockImplementation(async () => {
+            callOrder.push('trigger');
+            return { uploaded: false };
+          });
+          mockRunTripBoundCleanups.mockImplementation(async () => {
+            callOrder.push('cleanup');
+          });
+          await handleSilentPush(alertTripEndedPayload({ pushId: 'a-uuid' }));
+          expect(callOrder).toEqual(['trigger', 'cleanup']);
+        });
+
+        it('alert payload → pushId를 FIRED_PUSH_IDS에 기록(silent backstop race dedup)', async () => {
+          await handleSilentPush(alertTripEndedPayload({ pushId: 'a-uuid' }));
+          expect(mockAddFiredPushId).toHaveBeenCalledWith('a-uuid');
+        });
+
+        it('alert payload + pushId 없으면 dedup 기록 skip — 나머지 흐름은 동일', async () => {
+          await handleSilentPush(alertTripEndedPayload());
+          expect(mockAddFiredPushId).not.toHaveBeenCalled();
+          expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+          expect(mockSetTripEndedSentinel).toHaveBeenCalledTimes(1);
+        });
+
+        it('alert payload + 동일 pushId 재도달 → dedup hasFiredPushId 경로는 surface가 아니라 skip 게이트만 적용; addFiredPushId는 무조건 호출', async () => {
+          // alert path는 surface가 없으므로 hasFiredPushId 체크는 surfaceTripEnded에서만 의미가 있다.
+          // 여기서는 pushId 기록이 idempotent하다는 사실(addFiredPushId 중복 호출 허용)을 검증.
+          mockHasFiredPushId.mockResolvedValue(true);
+          await handleSilentPush(alertTripEndedPayload({ pushId: 'a-uuid' }));
+          expect(mockSendTripEndedNotification).not.toHaveBeenCalled();
+          expect(mockAddFiredPushId).toHaveBeenCalledWith('a-uuid');
+        });
+
+        it.each([
+          ['eta-missing'],
+          ['destination-arrived'],
+          ['expired'],
+          ['push-unrecoverable'],
+        ])('alert payload reason=%s → surface skip + cleanup/sentinel 진행', async (reason) => {
+          await handleSilentPush(alertTripEndedPayload({ pushId: 'a-uuid', reason }));
+          expect(mockSendTripEndedNotification).not.toHaveBeenCalled();
+          expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+          expect(mockSetTripEndedSentinel).toHaveBeenCalledTimes(1);
+        });
+
+        it('alert payload → ack(fired, trip-ended:reason) 전송(silent path와 동일)', async () => {
+          await handleSilentPush(alertTripEndedPayload({ pushId: 'a-uuid', reason: 'destination-arrived' }));
+          expect(mockSendPushAck).toHaveBeenCalledWith({
+            pushId: 'a-uuid',
+            token: DEFAULT_APNS_TOKEN,
+            outcome: 'fired',
+            reason: 'trip-ended:destination-arrived',
+          });
+        });
+
+        it('alert payload + tripToken mismatch → cleanup/sentinel/surface 모두 skip(token-mismatch ack)', async () => {
+          (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+            if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+            if (key === ACTIVE_TRIP_KEY) return 'NEW-TRIP-TOKEN';
+            return null;
+          });
+          await handleSilentPush(
+            alertTripEndedPayload({ pushId: 'a-uuid', tripToken: 'OLD-TRIP-TOKEN' }),
+          );
+          expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+          expect(mockSetTripEndedSentinel).not.toHaveBeenCalled();
+          expect(mockSendTripEndedNotification).not.toHaveBeenCalled();
+          expect(mockAddFiredPushId).not.toHaveBeenCalled();
+          expect(mockSendPushAck).toHaveBeenCalledWith({
+            pushId: 'a-uuid',
+            token: DEFAULT_APNS_TOKEN,
+            outcome: 'fired',
+            reason: expect.stringContaining('token-mismatch') as unknown as string,
+          });
+        });
+      });
     });
 
     describe('#746 dismiss silence 게이트 (BG silent push)', () => {

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -213,6 +213,22 @@ interface NotificationBackgroundTaskData {
 }
 
 /**
+ * #1337 — APNs alert payload 여부 판정.
+ *
+ * Swift `BackgroundEventTransformer`가 `aps.alert`를 동반한 push를 받으면
+ * `taskData.data.notification`을 non-null로 채워 BG task에 전달한다(silent push는 null).
+ * trip-ended는 #1337 PR1에서 silent→alert로 전환됐고, alert 수신 시 iOS가 시스템 banner를
+ * 직접 표시하므로 디바이스가 `presentTripEndedNotification`을 추가 발사하면 중복이 된다.
+ * 이 판정 함수는 surface skip 게이트 단일 출처(SSOT).
+ *
+ * Swift transformer 출력 위치는 `taskData.data.notification`(L202 기존 주석과 동일).
+ */
+function isAlertPayload(input: NotificationBackgroundTaskData): boolean {
+  const data = asPlainObject(input.data);
+  return data != null && data.notification != null;
+}
+
+/**
  * payload 안에서 fields 레이어를 찾는다.
  *   - `taskData.data.data` (production: backend가 `data: { fields }` 발사 → Swift 변환 후 한 단계 더 nested)
  *   - `taskData.data` (backend가 flat payload 발사 시)
@@ -577,8 +593,12 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     // ack outcome='fired'는 backend pendingPushes 입장에서는 "처리 완료, alert fallback 발사 마라"
     // 신호. trip-ended는 alert fallback 대상이 아니지만 호환을 위해 일반 silent push와 같은 의미로 ack.
     if (payload.kind === 'trip-ended') {
+      // #1337 PR1 — backend가 alert payload(`aps.alert`)로 발사하면 iOS가 killed 앱에도
+      // 시스템 banner를 직접 표시한다. 디바이스가 `presentTripEndedNotification`을 또 발사하면
+      // 중복이 되므로 alert path에서는 surface를 skip한다(cleanup/sentinel/ack는 그대로).
+      const isAlert = isAlertPayload(input);
       logger.info(
-        `trip-ended received: reason=${payload.reason} tripToken=${payload.tripToken?.slice(0, 8) ?? 'unknown'} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
+        `trip-ended received: reason=${payload.reason} tripToken=${payload.tripToken?.slice(0, 8) ?? 'unknown'} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'} alert=${isAlert}`,
       );
       // race 가드(#868 P1-2). 신규 backend는 tripToken을 항상 보냄. 구버전(undefined)은
       // 호환 위해 cleanup 진행 — race 가능성은 있지만 backend 배포 후 사라짐.
@@ -605,12 +625,17 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
       // #899 (Seam C) — BG에서는 zustand store에 접근 불가. FG 복귀 시점에
       // useStateRehydration이 이 sentinel을 보고 destination/lock store도 reset.
       await setTripEndedSentinel(receivedAt);
-      // #1323 — trip 종료 user-facing surface. backend trip-ended push는 silent라
-      // 수신해도 알림이 뜨지 않아 사용자가 종료를 인지하지 못했다(실기기 회귀).
-      // backend가 모든 종료 경로(도착/환승 후 도착/eta-missing/만료)에서 동일 push를
-      // 발사하므로, 여기서 reason-gated 알림 1회 present로 BG/취침/환승 종료를 모두 커버.
-      // 동일 push 재전송(backend retry) 시 pushId 기준 dedup으로 중복 알림 차단.
-      await surfaceTripEnded(payload.reason, payload.pushId);
+      // #1323 — trip 종료 user-facing surface. running/backgrounded 앱 backstop 경로.
+      // #1337 PR1 — alert payload는 iOS가 시스템 banner를 직접 표시하므로 surface skip;
+      // 단 동일 pushId의 silent backstop이 race로 도달해도 중복 surface 안 되도록 dedup store에는 기록.
+      if (isAlert) {
+        if (payload.pushId) await addFiredPushId(payload.pushId);
+      } else {
+        // backend가 모든 종료 경로(도착/환승 후 도착/eta-missing/만료)에서 동일 push를
+        // 발사하므로, 여기서 reason-gated 알림 1회 present로 BG/취침/환승 종료를 모두 커버.
+        // 동일 push 재전송(backend retry) 시 pushId 기준 dedup으로 중복 알림 차단.
+        await surfaceTripEnded(payload.reason, payload.pushId);
+      }
       ackOutcome(payload.pushId, apnsToken, 'fired', `trip-ended:${payload.reason}`);
       return;
     }


### PR DESCRIPTION
Closes #1337

> **이 PR은 #1337 PR1의 device 절반입니다.** backend(alert payload 전환)는 #1337의 별도 PR을 참조하세요. 둘 다 머지되어야 killed-app trip-ended 알림이 동작합니다.

## 배경
앱 강제종료(killed) 상태에서는 iOS가 silent push(`content-available`)를 앱에 전달하지 않아 trip-ended 로컬 알림이 발화되지 않았다(#1337 root cause). 해결: backend가 alert payload로 전환 → iOS가 killed 앱에도 시스템 banner를 직접 표시. 디바이스는 sentinel 기록만 담당.

## Wire contract (backend PR1과 byte-level fixed)
alert payload:
```json
{
  "aps": { "alert": { "title": "안내 종료", "body": "경로 안내를 종료했어요" }, "sound": "default" },
  "data": { "pushId": "<uuid>", "kind": "trip-ended", "tripToken": "<token>", "reason": "expired|eta-missing|destination|push-unrecoverable", "sentAt": <epoch_ms> }
}
```
기존 silent payload(`aps.content-available: 1`)와 구분: `aps.alert` 존재 여부.

## 변경
`src/features/alarm/tasks/silentPushTask.ts`:
- `isAlertPayload(input)` SSOT 추가 — Swift `BackgroundEventTransformer`가 alert 동반 시 `taskData.data.notification`을 non-null로 채우는 동작을 활용.
- trip-ended 분기 진입 직후 `isAlert` 판정. alert이면 `surfaceTripEnded` 호출 skip (OS가 banner 표시), pushId는 `addFiredPushId`로 dedup store에 기록(silent backstop race 차단).
- 그 외 흐름(`triggerTripEndRecall` → `runTripBoundCleanups` → `setTripEndedSentinel` → `ackOutcome`)은 alert/silent 동일.
- 기존 silent payload(`content-available`) path는 그대로 — running 앱 backstop 보존, transition 안전.
- 다른 push kind(intermediate / reschedule / boarding-lock) path는 미변경.

`src/features/alarm/tasks/__tests__/silentPushTask.test.ts`:
- 신규 describe "#1337 PR1 — alert payload trip-ended path" 추가.
- 시나리오: alert 수신 → surface skip / sentinel 호출 / cleanup 호출 / recall→cleanup 순서 / pushId dedup 기록 / pushId 없을 때 dedup skip / hasFiredPushId true여도 addFiredPushId 호출 / reason 4종 matrix / ack reason 보존 / tripToken mismatch 시 cleanup·sentinel·surface·dedup 모두 skip.
- 기존 #1323 silent path 회귀 0건 (기존 187개 모두 통과).

## Acceptance check
- [x] alert payload(`aps.alert` + `data.kind === 'trip-ended'`) 수신 시 `presentTripEndedNotification` 호출 안 함 (테스트 확인).
- [x] alert payload 수신 시 sentinel 기록 + active trip clear (테스트 확인).
- [x] pushId dedup 기록 → 동일 pushId silent backstop 도달 시 surface 중복 차단.
- [x] tripToken mismatch 시 alert path도 cleanup/sentinel/surface 모두 skip.
- [x] 기존 silent payload path 동작 회귀 0건.
- [x] `npm run type-check` 통과.
- [x] `npm test` 통과 (286 suites / 5526 tests, coverage 100% lines/functions/branches/statements).
- [x] `npm run lint` 통과.

## 후속
- backend PR1 (#1337의 다른 PR)이 같이 머지되어야 동작.
- 실기기 검증 (killed → trip 자동 종료 → 시스템 banner 표시 + 다음 FG 진입 시 store reset)은 두 PR 머지 후 사용자 책임.