### PR TITLE
feat(#1339): GET /trips/:tripToken/status endpoint (PR2 backend)

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -2830,6 +2830,11 @@ describe('GET /trips/:tripToken/status (#1339 launch reconciliation)', () => {
     await post('/trips', base(), env);
     const got = await getStatus(env, 'tok');
     const body = (await got.json()) as Record<string, unknown>;
-    expect(Object.keys(body).sort()).toEqual(['endReason', 'endedAt', 'status', 'tripToken']);
+    expect(Object.keys(body).sort((a, b) => a.localeCompare(b))).toEqual([
+      'endReason',
+      'endedAt',
+      'status',
+      'tripToken',
+    ]);
   });
 });

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -2760,3 +2760,76 @@ describe('GET /admin/telemetry/regressions (#1261)', () => {
     expect(body.counts['8'].today).toBe(3);
   });
 });
+
+describe('GET /trips/:tripToken/status (#1339 launch reconciliation)', () => {
+  async function getStatus(env: Env, token: string): Promise<Response> {
+    return app.fetch(
+      new Request(`http://example.com/trips/${token}/status`, { method: 'GET' }),
+      env,
+    );
+  }
+
+  it('returns active when the trip exists in KV', async () => {
+    const env = makeKvEnv();
+    const res = await post('/trips', base(), env);
+    expect(res.status).toBe(200);
+
+    const got = await getStatus(env, 'tok');
+    expect(got.status).toBe(200);
+    expect(await got.json()).toEqual({
+      tripToken: 'tok',
+      status: 'active',
+      endedAt: null,
+      endReason: null,
+    });
+  });
+
+  it('returns ended with endedAt + endReason when a recent status marker exists', async () => {
+    const env = makeKvEnv();
+    const kv = env.TRIPS as unknown as InMemoryKV;
+    const endedAt = Date.now() - 5_000;
+    kv.store.set('tripStatus:abc', {
+      value: JSON.stringify({ endedAt, endReason: 'destination' }),
+    });
+
+    const res = await getStatus(env, 'abc');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      tripToken: 'abc',
+      status: 'ended',
+      endedAt,
+      endReason: 'destination',
+    });
+  });
+
+  it('returns 404 when neither the trip nor a status marker exists', async () => {
+    const env = makeKvEnv();
+    const res = await getStatus(env, 'missing');
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'trip_not_found' });
+  });
+
+  it('returns 410 expired-retention when the marker is older than the retention window', async () => {
+    const env = makeKvEnv();
+    const kv = env.TRIPS as unknown as InMemoryKV;
+    const endedAt = Date.now() - 60 * 60 * 1000 - 1_000; // > 1h
+    kv.store.set('tripStatus:old', {
+      value: JSON.stringify({ endedAt, endReason: 'expired' }),
+    });
+
+    const res = await getStatus(env, 'old');
+    expect(res.status).toBe(410);
+    expect(await res.json()).toEqual({
+      tripToken: 'old',
+      status: 'expired-retention',
+    });
+  });
+
+  it('emits only the documented response fields', async () => {
+    const env = makeKvEnv();
+    await post('/trips', base(), env);
+    const got = await getStatus(env, 'tok');
+    const body = (await got.json()) as Record<string, unknown>;
+    expect(Object.keys(body).sort()).toEqual(['endReason', 'endedAt', 'status', 'tripToken']);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -392,4 +392,83 @@ describe('cleanupTripWithLa', () => {
     expect(logs).toContain('trip-ended push failed');
     expect(await kv.get('trip:devtoken')).toBeNull();
   });
+
+  // #1339 — launch reconciliation 백스톱. cleanupTripWithLa가 reason과 함께 호출되면
+  // 모든 trip-ended 경로(scheduled.ts의 4 발사 지점)가 자동으로 status marker를 KV에 적재한다.
+  describe('writes trip-ended status marker for launch reconciliation (#1339)', () => {
+    const reasonMatrix = [
+      { reason: 'expired' as const, expected: 'expired' },
+      { reason: 'eta-missing' as const, expected: 'eta-missing' },
+      { reason: 'destination-arrived' as const, expected: 'destination' },
+      { reason: 'push-unrecoverable' as const, expected: 'push-unrecoverable' },
+    ];
+
+    for (const { reason, expected } of reasonMatrix) {
+      it(`writes status=${expected} when cleanup called with reason ${reason}`, async () => {
+        const kv = new InMemoryKV();
+        const trip = makeTrip({ activityPushToken: undefined });
+        await kv.put('trip:devtoken', JSON.stringify(trip));
+        const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+        const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+        await cleanupTripWithLa(
+          trip,
+          env,
+          makeDeps(fetchImpl as unknown as typeof fetch),
+          makeStats(),
+          NOW,
+          () => undefined,
+          reason,
+        );
+        const raw = kv.store.get('tripStatus:devtoken');
+        expect(raw).toBeDefined();
+        expect(JSON.parse(raw!.value)).toEqual({ endedAt: NOW, endReason: expected });
+        // trip 자체는 여전히 삭제됨.
+        expect(await kv.get('trip:devtoken')).toBeNull();
+      });
+    }
+
+    it('does not write a marker when reason is omitted (HTTP DELETE path)', async () => {
+      const kv = new InMemoryKV();
+      const trip = makeTrip({ activityPushToken: undefined });
+      await kv.put('trip:devtoken', JSON.stringify(trip));
+      const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+      await cleanupTripWithLa(
+        trip,
+        env,
+        makeDeps(vi.fn() as unknown as typeof fetch),
+        makeStats(),
+        NOW,
+        () => undefined,
+      );
+      expect(kv.store.has('tripStatus:devtoken')).toBe(false);
+    });
+
+    it('logs but does not throw when status write fails (cleanup continues)', async () => {
+      // KV.put이 throw하는 broken 환경. cleanup 흐름은 끝까지 진행돼야 한다.
+      const kv = new InMemoryKV();
+      const trip = makeTrip({ activityPushToken: undefined });
+      await kv.put('trip:devtoken', JSON.stringify(trip));
+      const brokenKv = {
+        get: kv.get.bind(kv),
+        put: vi.fn(async (key: string) => {
+          if (key.startsWith('tripStatus:')) throw new Error('kv down');
+          return undefined;
+        }),
+        delete: kv.delete.bind(kv),
+        list: kv.list.bind(kv),
+      };
+      const env = { TRIPS: brokenKv as unknown as KVNamespace } as Env;
+      const logs: string[] = [];
+      await cleanupTripWithLa(
+        trip,
+        env,
+        makeDeps(vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch),
+        makeStats(),
+        NOW,
+        (msg) => logs.push(msg),
+        'expired',
+      );
+      expect(logs).toContain('trip-status write failed');
+    });
+  });
 });

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -466,7 +466,11 @@ describe('runScheduled', () => {
       now: () => NOW + 10_000,
     });
     expect(stats.polled).toBe(0);
-    expect(kv.store.size).toBe(0);
+    // #1339 — trip 자체는 삭제되지만 launch reconciliation을 위한 tripStatus marker가 남는다.
+    expect(kv.store.has('trip:tok')).toBe(false);
+    const statusEntry = kv.store.get('tripStatus:tok');
+    expect(statusEntry).toBeDefined();
+    expect(JSON.parse(statusEntry!.value)).toMatchObject({ endReason: 'expired' });
   });
 
   // #640 — BoardingLock 게이트. 사용자가 열차를 선택하지 않은 trip(lock 부재)은

--- a/backend/alarm-worker/src/__tests__/tripStatus.test.ts
+++ b/backend/alarm-worker/src/__tests__/tripStatus.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import {
+  TRIP_STATUS_RETENTION_MS,
+  TRIP_STATUS_TTL_SEC,
+  readTripEndedStatus,
+  toTripStatusEndReason,
+  tripStatusKey,
+  writeTripEndedStatus,
+} from '../tripStatus';
+import { InMemoryKV } from './inMemoryKv';
+
+describe('tripStatusKey', () => {
+  it('prefixes the token with tripStatus:', () => {
+    expect(tripStatusKey('abc')).toBe('tripStatus:abc');
+  });
+});
+
+describe('toTripStatusEndReason', () => {
+  it('shortens destination-arrived to destination', () => {
+    expect(toTripStatusEndReason('destination-arrived')).toBe('destination');
+  });
+
+  it('passes through other reasons unchanged', () => {
+    expect(toTripStatusEndReason('expired')).toBe('expired');
+    expect(toTripStatusEndReason('eta-missing')).toBe('eta-missing');
+    expect(toTripStatusEndReason('push-unrecoverable')).toBe('push-unrecoverable');
+  });
+});
+
+describe('writeTripEndedStatus', () => {
+  it('persists endedAt + mapped endReason in JSON form', async () => {
+    const kv = new InMemoryKV();
+    await writeTripEndedStatus(
+      kv as unknown as KVNamespace,
+      'tok',
+      'destination-arrived',
+      1_000_000,
+    );
+    const raw = kv.store.get(tripStatusKey('tok'));
+    expect(raw).toBeDefined();
+    expect(JSON.parse(raw!.value)).toEqual({
+      endedAt: 1_000_000,
+      endReason: 'destination',
+    });
+  });
+
+  it('writes with the long TTL retention horizon', async () => {
+    const kv = new InMemoryKV();
+    const before = Date.now();
+    await writeTripEndedStatus(kv as unknown as KVNamespace, 'tok', 'expired', before);
+    const entry = kv.store.get(tripStatusKey('tok'))!;
+    // expiresAt = now + TRIP_STATUS_TTL_SEC * 1000 (in-memory KV records absolute deadline)
+    const after = Date.now();
+    expect(entry.expiresAt).toBeGreaterThanOrEqual(before + TRIP_STATUS_TTL_SEC * 1000);
+    expect(entry.expiresAt).toBeLessThanOrEqual(after + TRIP_STATUS_TTL_SEC * 1000);
+  });
+});
+
+describe('readTripEndedStatus', () => {
+  it('returns null when no record exists', async () => {
+    const kv = new InMemoryKV();
+    const got = await readTripEndedStatus(kv as unknown as KVNamespace, 'tok');
+    expect(got).toBeNull();
+  });
+
+  it('returns parsed record after write', async () => {
+    const kv = new InMemoryKV();
+    await writeTripEndedStatus(kv as unknown as KVNamespace, 'tok', 'eta-missing', 500);
+    const got = await readTripEndedStatus(kv as unknown as KVNamespace, 'tok');
+    expect(got).toEqual({ endedAt: 500, endReason: 'eta-missing' });
+  });
+
+  it('returns null when stored JSON is malformed', async () => {
+    const kv = new InMemoryKV();
+    kv.store.set(tripStatusKey('tok'), { value: '{not-json' });
+    const got = await readTripEndedStatus(kv as unknown as KVNamespace, 'tok');
+    expect(got).toBeNull();
+  });
+
+  it('returns null when endedAt is missing', async () => {
+    const kv = new InMemoryKV();
+    kv.store.set(tripStatusKey('tok'), {
+      value: JSON.stringify({ endReason: 'expired' }),
+    });
+    expect(await readTripEndedStatus(kv as unknown as KVNamespace, 'tok')).toBeNull();
+  });
+
+  it('returns null when endReason is unknown', async () => {
+    const kv = new InMemoryKV();
+    kv.store.set(tripStatusKey('tok'), {
+      value: JSON.stringify({ endedAt: 1, endReason: 'made-up' }),
+    });
+    expect(await readTripEndedStatus(kv as unknown as KVNamespace, 'tok')).toBeNull();
+  });
+});
+
+describe('constants', () => {
+  it('retention is 1 hour', () => {
+    expect(TRIP_STATUS_RETENTION_MS).toBe(60 * 60 * 1000);
+  });
+
+  it('TTL well exceeds retention so 410 is observable before record disappears', () => {
+    expect(TRIP_STATUS_TTL_SEC * 1000).toBeGreaterThan(TRIP_STATUS_RETENTION_MS);
+  });
+});

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -76,6 +76,10 @@ import {
   writeRegressionDataPoints,
 } from './regressionTelemetry';
 import { getTrip, putTrip } from './trips';
+import {
+  TRIP_STATUS_RETENTION_MS,
+  readTripEndedStatus,
+} from './tripStatus';
 import { getQuotaStatus, incrementDailyRequestCount } from './quotaTracker';
 import type {
   AccelSummary,
@@ -1183,6 +1187,53 @@ export function validateLiveActivityRegister(
   }
   return { tripToken: obj.tripToken, activityPushToken: obj.activityPushToken };
 }
+
+/**
+ * Trip status — killed-app launch reconciliation (#1339, Epic #1204).
+ *
+ * 디바이스가 다음 launch에서 trip 상태를 backend에 질의 → ended 응답이면 alert/sentinel 누락
+ * 백스톱으로 stale route/destination/lock state를 자체 cleanup한다.
+ *
+ * 응답 모델:
+ *   200 active     — KV에 trip이 살아 있음
+ *   200 ended      — trip은 사라졌지만 종료 마커가 있고 retention(`TRIP_STATUS_RETENTION_MS`) 내
+ *   404            — trip도 마커도 없음 (등록된 적 없거나 KV TTL 자연 폐기)
+ *   410            — 마커는 있으나 retention 만료(expired-retention) — body로 사유 명시
+ *
+ * Privacy: tripToken은 디바이스가 자신의 token을 echo하는 케이스라 인증 없이 노출 가능 — 다른
+ * 디바이스의 token을 추측 brute-force할 risk는 사실상 0(UUID 공간).
+ */
+app.get('/trips/:tripToken/status', async (c) => {
+  const tripToken = c.req.param('tripToken');
+  if (!tripToken) return c.json({ error: 'missing_token' }, 400);
+
+  const now = Date.now();
+  const trip = await getTrip(c.env.TRIPS, tripToken);
+  if (trip) {
+    return c.json({
+      tripToken,
+      status: 'active' as const,
+      endedAt: null,
+      endReason: null,
+    });
+  }
+
+  const ended = await readTripEndedStatus(c.env.TRIPS, tripToken);
+  if (!ended) {
+    return c.json({ error: 'trip_not_found' }, 404);
+  }
+
+  if (now - ended.endedAt > TRIP_STATUS_RETENTION_MS) {
+    return c.json({ tripToken, status: 'expired-retention' as const }, 410);
+  }
+
+  return c.json({
+    tripToken,
+    status: 'ended' as const,
+    endedAt: ended.endedAt,
+    endReason: ended.endReason,
+  });
+});
 
 app.delete('/trips/:token', async (c) => {
   const token = c.req.param('token');

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -23,6 +23,7 @@ import { LINE_META } from './lineAlias';
 import { deleteProgress } from './progress';
 import { deleteTrip } from './trips';
 import type { ApnsEnv, Env, Trip, TripEndedReason, Waypoint } from './types';
+import { writeTripEndedStatus } from './tripStatus';
 
 /**
  * stale-date까지 클라이언트가 last content-state를 신뢰할 수 있는 시간(초).
@@ -195,6 +196,18 @@ export async function cleanupTripWithLa(
   await fireLiveActivityDismissal(trip, deps, stats, now, log);
   if (reason) {
     await fireTripEndedPush(trip, reason, deps, now, log);
+    // #1339 — launch reconciliation 백스톱. silent push가 누락된 killed-app 케이스에서
+    // 디바이스가 다음 launch 시 GET /trips/:token/status로 종료 사실을 확인하고 자체 cleanup한다.
+    // KV write 실패는 cleanup 흐름을 차단하지 않는다 — 본 push가 best-effort라면 retention도 best-effort.
+    try {
+      await writeTripEndedStatus(env.TRIPS, trip.token, reason, now);
+    } catch (e) {
+      log('trip-status write failed', {
+        token: trip.token.slice(0, 8),
+        reason,
+        error: String(e),
+      });
+    }
   }
   await deleteTrip(env.TRIPS, trip.token);
   // #705 — trip을 폐기할 때 progress entry도 함께 제거. TTL이 자연 만료를 보장하지만

--- a/backend/alarm-worker/src/tripStatus.ts
+++ b/backend/alarm-worker/src/tripStatus.ts
@@ -1,0 +1,100 @@
+/**
+ * Trip status retention KV (#1339, Epic #1204) — killed-app launch reconciliation 백스톱.
+ *
+ * iOS가 silent push로 trip-ended cleanup을 진행하지 못한 채 종료(앱 kill / push drop / 디바이스 OFF)된
+ * 케이스에서, 디바이스가 다음 launch 시 backend에 trip 상태를 조회해 stale route/destination/lock
+ * state를 자체 정리할 수 있도록 ended 마커를 1h TTL로 보존한다.
+ *
+ * Key: `tripStatus:<token>`
+ * Value: `{ endedAt: number, endReason: TripStatusEndReason }`
+ *
+ * 발사 진입점은 단일 — `cleanupTripWithLa` (liveActivity.ts). scheduled.ts의 4곳 trip-end
+ * 호출자(L305 expired / L878 eta-missing / L1049 destination-arrived / L1260 push-unrecoverable)
+ * 가 모두 그 wrapper를 통과한다. HTTP DELETE 경로는 reason 미지정이라 status 미기록 — 사용자
+ * 명시 종료는 디바이스가 이미 정리한 상태라 launch reconciliation 대상이 아니다.
+ */
+
+import type { TripEndedReason } from './types';
+
+const TRIP_STATUS_PREFIX = 'tripStatus:';
+
+/** 외부 응답에 노출하는 endReason — `destination-arrived` → `destination`로 축약 (contract). */
+export type TripStatusEndReason = 'expired' | 'eta-missing' | 'destination' | 'push-unrecoverable';
+
+export interface TripStatusRecord {
+  endedAt: number;
+  endReason: TripStatusEndReason;
+}
+
+/**
+ * 응답 contract retention 윈도우 — launch reconciliation은 최근 종료된 trip만 의미가 있다.
+ * `now - endedAt` 이 이 값을 넘으면 GET endpoint는 410(expired-retention)을 반환.
+ */
+export const TRIP_STATUS_RETENTION_MS = 60 * 60 * 1000;
+
+/**
+ * KV expirationTtl — 정확한 만료 응답을 위해 retention보다 충분히 길게 잡는다.
+ * `now - endedAt` 기반 410 판정과 별개로, KV가 자연 폐기되면 404로 떨어진다 (record 자체가 사라짐).
+ * 7d면 운영 디버깅 윈도우로도 충분.
+ */
+export const TRIP_STATUS_TTL_SEC = 7 * 24 * 60 * 60;
+
+export function tripStatusKey(token: string): string {
+  return `${TRIP_STATUS_PREFIX}${token}`;
+}
+
+/**
+ * TripEndedReason(내부 enum) → TripStatusEndReason(외부 contract) 매핑.
+ * 클라이언트 API 응답은 `destination`으로 축약 — `destination-arrived`는 backend 내부 식별자라
+ * 외부 노출 표면에는 단축형이 깔끔하다.
+ */
+export function toTripStatusEndReason(reason: TripEndedReason): TripStatusEndReason {
+  if (reason === 'destination-arrived') return 'destination';
+  return reason;
+}
+
+/**
+ * `cleanupTripWithLa`가 reason과 함께 호출될 때 trip 종료 마커를 KV에 기록한다.
+ * 호출은 graceful — KV write 실패는 cleanup 흐름을 차단하지 않는다 (라우트 핸들러에서 catch).
+ */
+export async function writeTripEndedStatus(
+  kv: KVNamespace,
+  token: string,
+  reason: TripEndedReason,
+  now: number,
+): Promise<void> {
+  const record: TripStatusRecord = {
+    endedAt: now,
+    endReason: toTripStatusEndReason(reason),
+  };
+  await kv.put(tripStatusKey(token), JSON.stringify(record), {
+    expirationTtl: TRIP_STATUS_TTL_SEC,
+  });
+}
+
+/**
+ * 저장된 trip 종료 마커 조회. JSON parse 실패 또는 schema 불일치 시 null 반환 — KV 손상 엔트리는
+ * 미존재와 동일하게 처리(launch reconciliation은 best-effort, fail-soft).
+ */
+export async function readTripEndedStatus(
+  kv: KVNamespace,
+  token: string,
+): Promise<TripStatusRecord | null> {
+  const raw = await kv.get(tripStatusKey(token));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<TripStatusRecord>;
+    if (typeof parsed.endedAt !== 'number') return null;
+    if (
+      parsed.endReason !== 'expired' &&
+      parsed.endReason !== 'eta-missing' &&
+      parsed.endReason !== 'destination' &&
+      parsed.endReason !== 'push-unrecoverable'
+    ) {
+      return null;
+    }
+    return { endedAt: parsed.endedAt, endReason: parsed.endReason };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
killed-app trip-ended **launch reconciliation의 backend 절반** (#1339, Epic #1204).
디바이스가 launch 시 backend에 trip 상태를 질의해 silent push 누락 case의 alert/sentinel 백스톱을 확보한다.

이 PR은 **PR2 backend 절반**이다. **device 절반(useTripStatusReconciliation 등)은 후속 PR에서.**
PR1 backend와의 충돌을 회피하기 위해 scheduled.ts의 4곳 trip-ended 발사 지점은 직접 수정하지 않고, 단일 wrapper `cleanupTripWithLa` (liveActivity.ts)에서 helper만 호출한다.

## Endpoint contract

`GET /trips/:tripToken/status`

| 응답 | 의미 | body |
| --- | --- | --- |
| 200 | trip이 KV에 활성 | `{ tripToken, status: "active", endedAt: null, endReason: null }` |
| 200 | trip은 종료되었고 retention(1h) 내 마커 존재 | `{ tripToken, status: "ended", endedAt, endReason }` |
| 404 | trip도 마커도 없음 (등록된 적 없거나 자연 폐기) | `{ error: "trip_not_found" }` |
| 410 | 마커는 있으나 retention 만료 | `{ tripToken, status: "expired-retention" }` |

`endReason`: `"expired" | "eta-missing" | "destination" | "push-unrecoverable"`
(내부 `TripEndedReason.destination-arrived` → 외부 `destination` 축약)

## 변경 내용

- **신규** `backend/alarm-worker/src/tripStatus.ts` — `tripStatus:<token>` KV CRUD + reason 매핑 + 상수
  - `TRIP_STATUS_RETENTION_MS = 1h` (응답 410 게이트)
  - `TRIP_STATUS_TTL_SEC = 7d` (KV 자연 만료 — retention보다 길게 잡아 410 응답 가능 윈도우 확보)
- `liveActivity.ts:cleanupTripWithLa` — reason 지정 시 `writeTripEndedStatus` 호출
  - scheduled.ts 4곳(L305 expired / L878 eta-missing / L1049 destination-arrived / L1260 push-unrecoverable) 모두 wrapper 통과 → 발사 지점 직접 수정 불필요 (PR1 backend와 conflict 회피)
  - KV write 실패는 graceful — log만 남기고 cleanup 흐름 계속
- `index.ts` — `GET /trips/:tripToken/status` 라우트 추가 (DELETE `/trips/:token`보다 먼저 등록해 dynamic shadowing 방지)

## Acceptance check

- [x] `npm run type-check` 통과
- [x] `npm test` — 1280/1280 pass (신규 tripStatus 12개 + index 라우트 5개 + liveActivity matrix 6개)
- [x] 4 reason matrix(expired / eta-missing / destination-arrived / push-unrecoverable) 모두 status write 검증
- [x] reason 미지정(HTTP DELETE 경로)은 status 미기록 검증
- [x] KV write throw 시 cleanup 흐름 graceful 진행 검증
- [x] retention 경계(`now - endedAt > 1h`) 410 응답 검증
- [x] 손상 JSON / 미존재는 404 검증
- [x] code-review (low effort) — findings (none)

## 주의 (PR1 conflict)

본 PR은 `scheduled.ts`를 건드리지 않는다. 단일 funnel `cleanupTripWithLa`에서 helper를 호출하므로 PR1 backend가 같은 4 지점을 수정해도 git 충돌이 발생하지 않는다.

Closes #1339 (단, #1339 close는 device 절반 PR까지 머지 후 사용자가 evidence 시나리오 1주 재발 0건 확인 후).