### PR TITLE
fix(#1337): trip-ended silent push를 alert push로 전환 (killed 앱 즉시 표시)

### DIFF
--- a/backend/alarm-worker/src/__tests__/alertContent.test.ts
+++ b/backend/alarm-worker/src/__tests__/alertContent.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { buildAlertContent } from '../alertContent';
+import {
+  buildAlertContent,
+  TRIP_ENDED_ALERT_BODY,
+  TRIP_ENDED_ALERT_TITLE,
+} from '../alertContent';
 import type { AlarmPhase } from '../alarm';
 
 describe('buildAlertContent (#570 P2d)', () => {
@@ -57,5 +61,16 @@ describe('buildAlertContent (#570 P2d)', () => {
       title: '도착 임박',
       body: '곧 Apgujeong에 도착합니다. 하차 준비하세요!',
     });
+  });
+});
+
+// #1337 — trip-ended alert push 본문 상수. 디바이스 ko.json과 byte-identical 보장.
+// 어긋나면 banner에 silent push 시점 본문과 다른 문구가 떠 운영 사고 직결.
+describe('TRIP_ENDED_ALERT_* 상수 (#1337)', () => {
+  it('TRIP_ENDED_ALERT_TITLE === ko.json route.tripEndedTitle', () => {
+    expect(TRIP_ENDED_ALERT_TITLE).toBe('안내 종료');
+  });
+  it('TRIP_ENDED_ALERT_BODY === ko.json route.tripEndedBody', () => {
+    expect(TRIP_ENDED_ALERT_BODY).toBe('경로 안내를 종료했어요');
   });
 });

--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -9,8 +9,10 @@ import {
   sendLiveActivityUpdate,
   sendReschedulePush,
   sendSilentPush,
+  sendTripEndedAlertPush,
   type ApnsConfig,
 } from '../apns';
+import { TRIP_ENDED_ALERT_BODY, TRIP_ENDED_ALERT_TITLE } from '../alertContent';
 
 let privateKeyPem = '';
 
@@ -627,5 +629,102 @@ describe('sendBoardingPromptPush (#819)', () => {
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
     expect(result).toEqual({ ok: false, status: 410, reason: 'BadDeviceToken' });
+  });
+});
+
+// #1337 — trip-ended를 silent → alert로 전환. killed 앱에 OS banner로 즉시 표시.
+// headers/payload는 PR2 디바이스 핸들러와 byte-level 정렬 (kind='trip-ended', tripToken, reason, sentAt, pushId).
+describe('sendTripEndedAlertPush (#1337)', () => {
+  beforeEach(() => resetApnsJwtCache());
+
+  it('posts alert-type headers + aps.alert(trip-ended 본문) + aps.sound + data byte-level contract', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const result = await sendTripEndedAlertPush({
+      deviceToken: 'devicetoken-hex',
+      pushId: 'pid-end-1',
+      reason: 'destination-arrived',
+      sentAt: 1_700_000_000_000,
+      tripToken: 'trip-abc',
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result.ok).toBe(true);
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[0]).toBe(`https://${TEST_HOST}/3/device/devicetoken-hex`);
+    const headers = call[1].headers as Record<string, string>;
+    expect(headers['apns-topic']).toBe('com.example.app');
+    expect(headers['apns-push-type']).toBe('alert');
+    expect(headers['apns-priority']).toBe('10');
+    expect(headers['content-type']).toBe('application/json');
+    const body = JSON.parse(call[1].body as string);
+    expect(body.aps.alert).toEqual({
+      title: TRIP_ENDED_ALERT_TITLE,
+      body: TRIP_ENDED_ALERT_BODY,
+    });
+    expect(body.aps.sound).toBe('default');
+    expect(body.data).toEqual({
+      pushId: 'pid-end-1',
+      kind: 'trip-ended',
+      tripToken: 'trip-abc',
+      reason: 'destination-arrived',
+      sentAt: 1_700_000_000_000,
+    });
+  });
+
+  it.each<{ reason: 'eta-missing' | 'expired' | 'push-unrecoverable' | 'destination-arrived' }>([
+    { reason: 'eta-missing' },
+    { reason: 'expired' },
+    { reason: 'push-unrecoverable' },
+    { reason: 'destination-arrived' },
+  ])('reason=$reason 가 data에 그대로 전달된다', async ({ reason }) => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await sendTripEndedAlertPush({
+      deviceToken: 't',
+      pushId: 'p',
+      reason,
+      sentAt: 0,
+      tripToken: 'trip-x',
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.data.reason).toBe(reason);
+  });
+
+  it('returns parseApnsError result on 4xx with JSON reason', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
+    );
+    const result = await sendTripEndedAlertPush({
+      deviceToken: 't',
+      pushId: 'p',
+      reason: 'expired',
+      sentAt: 0,
+      tripToken: 'trip-x',
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ ok: false, status: 400, reason: 'BadDeviceToken' });
+  });
+
+  it('returns parseApnsError result on 5xx with non-json body (reason undefined)', async () => {
+    const fetchImpl = vi.fn(async () => new Response('upstream broken', { status: 503 }));
+    const result = await sendTripEndedAlertPush({
+      deviceToken: 't',
+      pushId: 'p',
+      reason: 'eta-missing',
+      sentAt: 0,
+      tripToken: 'trip-x',
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(503);
+    expect(result.reason).toBeUndefined();
   });
 });

--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -637,26 +637,44 @@ describe('sendBoardingPromptPush (#819)', () => {
 describe('sendTripEndedAlertPush (#1337)', () => {
   beforeEach(() => resetApnsJwtCache());
 
+  type TripEndedReason = 'eta-missing' | 'expired' | 'push-unrecoverable' | 'destination-arrived';
+  type TripEndedOverrides = Partial<{
+    deviceToken: string;
+    pushId: string;
+    reason: TripEndedReason;
+    sentAt: number;
+    tripToken: string;
+  }>;
+  const runTripEndedAlertPush = (fetchImpl: ReturnType<typeof vi.fn>, o: TripEndedOverrides = {}) =>
+    sendTripEndedAlertPush({
+      deviceToken: o.deviceToken ?? 't',
+      pushId: o.pushId ?? 'p',
+      reason: o.reason ?? 'expired',
+      sentAt: o.sentAt ?? 0,
+      tripToken: o.tripToken ?? 'trip-x',
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
   it('posts alert-type headers + aps.alert(trip-ended 본문) + aps.sound + data byte-level contract', async () => {
     const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
-    const result = await sendTripEndedAlertPush({
+    const result = await runTripEndedAlertPush(fetchImpl, {
       deviceToken: 'devicetoken-hex',
       pushId: 'pid-end-1',
       reason: 'destination-arrived',
       sentAt: 1_700_000_000_000,
       tripToken: 'trip-abc',
-      config: makeConfig(),
-      host: TEST_HOST,
-      fetchImpl: fetchImpl as unknown as typeof fetch,
     });
     expect(result.ok).toBe(true);
     const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
     expect(call[0]).toBe(`https://${TEST_HOST}/3/device/devicetoken-hex`);
-    const headers = call[1].headers as Record<string, string>;
-    expect(headers['apns-topic']).toBe('com.example.app');
-    expect(headers['apns-push-type']).toBe('alert');
-    expect(headers['apns-priority']).toBe('10');
-    expect(headers['content-type']).toBe('application/json');
+    expect(call[1].headers).toMatchObject({
+      'apns-topic': 'com.example.app',
+      'apns-push-type': 'alert',
+      'apns-priority': '10',
+      'content-type': 'application/json',
+    });
     const body = JSON.parse(call[1].body as string);
     expect(body.aps.alert).toEqual({
       title: TRIP_ENDED_ALERT_TITLE,
@@ -672,23 +690,14 @@ describe('sendTripEndedAlertPush (#1337)', () => {
     });
   });
 
-  it.each<{ reason: 'eta-missing' | 'expired' | 'push-unrecoverable' | 'destination-arrived' }>([
+  it.each<{ reason: TripEndedReason }>([
     { reason: 'eta-missing' },
     { reason: 'expired' },
     { reason: 'push-unrecoverable' },
     { reason: 'destination-arrived' },
   ])('reason=$reason 가 data에 그대로 전달된다', async ({ reason }) => {
     const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
-    await sendTripEndedAlertPush({
-      deviceToken: 't',
-      pushId: 'p',
-      reason,
-      sentAt: 0,
-      tripToken: 'trip-x',
-      config: makeConfig(),
-      host: TEST_HOST,
-      fetchImpl: fetchImpl as unknown as typeof fetch,
-    });
+    await runTripEndedAlertPush(fetchImpl, { reason });
     const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
     const body = JSON.parse(call[1].body as string);
     expect(body.data.reason).toBe(reason);
@@ -698,31 +707,13 @@ describe('sendTripEndedAlertPush (#1337)', () => {
     const fetchImpl = vi.fn(async () =>
       new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
     );
-    const result = await sendTripEndedAlertPush({
-      deviceToken: 't',
-      pushId: 'p',
-      reason: 'expired',
-      sentAt: 0,
-      tripToken: 'trip-x',
-      config: makeConfig(),
-      host: TEST_HOST,
-      fetchImpl: fetchImpl as unknown as typeof fetch,
-    });
+    const result = await runTripEndedAlertPush(fetchImpl, { reason: 'expired' });
     expect(result).toEqual({ ok: false, status: 400, reason: 'BadDeviceToken' });
   });
 
   it('returns parseApnsError result on 5xx with non-json body (reason undefined)', async () => {
     const fetchImpl = vi.fn(async () => new Response('upstream broken', { status: 503 }));
-    const result = await sendTripEndedAlertPush({
-      deviceToken: 't',
-      pushId: 'p',
-      reason: 'eta-missing',
-      sentAt: 0,
-      tripToken: 'trip-x',
-      config: makeConfig(),
-      host: TEST_HOST,
-      fetchImpl: fetchImpl as unknown as typeof fetch,
-    });
+    const result = await runTripEndedAlertPush(fetchImpl, { reason: 'eta-missing' });
     expect(result.ok).toBe(false);
     expect(result.status).toBe(503);
     expect(result.reason).toBeUndefined();

--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -393,7 +393,7 @@ describe('cleanupTripWithLa', () => {
     expect(await kv.get('trip:devtoken')).toBeNull();
   });
 
-  // #1337 — KV `tripEndedAlert:{tripToken}` set-if-absent gate. 같은 trip의 cleanup이 race로
+  // #1337 — KV `tripEndedAlert:{tripToken}:{createdAt}` set-if-absent gate. 같은 trip의 cleanup이 race로
   // 두 번 호출돼도 alert가 1회만 발사된다. 실패 push는 stamp X → 다음 cycle 재시도 허용.
   describe('trip-ended alert KV dedup gate (#1337)', () => {
     it('success 시 dedup stamp 저장 → 동일 trip 재 cleanup 호출 시 alert push skip', async () => {
@@ -413,7 +413,7 @@ describe('cleanupTripWithLa', () => {
         'eta-missing',
       );
       expect(fetchImpl).toHaveBeenCalledTimes(1);
-      expect(await kv.get('tripEndedAlert:devtoken')).toBe('1');
+      expect(await kv.get(`tripEndedAlert:devtoken:${NOW}`)).toBe('1');
 
       // 2차 cleanup (예: 동일 cron 사이클 내 race) — dedup으로 push skip
       const trip2 = makeTrip({ activityPushToken: undefined });
@@ -451,7 +451,7 @@ describe('cleanupTripWithLa', () => {
       );
       // env-heal 1차+retry 둘 다 호출되지만 둘 다 실패.
       expect(fetchImpl).toHaveBeenCalledTimes(2);
-      expect(await kv.get('tripEndedAlert:devtoken')).toBeNull();
+      expect(await kv.get(`tripEndedAlert:devtoken:${NOW}`)).toBeNull();
     });
 
     it('throw 발생 시 dedup stamp 저장 X', async () => {
@@ -471,9 +471,50 @@ describe('cleanupTripWithLa', () => {
         () => undefined,
         'expired',
       );
-      expect(await kv.get('tripEndedAlert:devtoken')).toBeNull();
+      expect(await kv.get(`tripEndedAlert:devtoken:${NOW}`)).toBeNull();
       // throw 흡수 후 cleanup 흐름 계속 → trip 삭제됨
       expect(await kv.get('trip:devtoken')).toBeNull();
+    });
+
+    // 회귀 가드: trip.token = device APNs token 이라 같은 디바이스의 후속 trip이 동일 token을
+    // 재사용한다. dedup key가 token만으로 구성되면 trip A 종료 후 곧이어 시작한 trip B의 종료
+    // alert가 stale stamp에 막혀 사라진다(#1337 acceptance 회귀). (token, createdAt) 페어로
+    // trip-instance 단위 격리하는지 검증.
+    it('동일 device(token)의 다른 trip-instance(createdAt) 는 dedup 안 됨 (각자 alert 발사)', async () => {
+      const kv = new InMemoryKV();
+      const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+
+      // Trip A: createdAt=NOW
+      const tripA = makeTrip({ activityPushToken: undefined, createdAt: NOW });
+      await kv.put('trip:devtoken', JSON.stringify(tripA));
+      await cleanupTripWithLa(
+        tripA,
+        env,
+        makeDeps(fetchImpl as unknown as typeof fetch),
+        makeStats(),
+        NOW,
+        () => undefined,
+        'destination-arrived',
+      );
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+      // Trip B: same token, 다른 createdAt (예: 1분 뒤 새 trip 등록)
+      const tripB = makeTrip({ activityPushToken: undefined, createdAt: NOW + 60_000 });
+      await kv.put('trip:devtoken', JSON.stringify(tripB));
+      await cleanupTripWithLa(
+        tripB,
+        env,
+        makeDeps(fetchImpl as unknown as typeof fetch),
+        makeStats(),
+        NOW + 60_000,
+        () => undefined,
+        'eta-missing',
+      );
+      // Trip B의 alert도 발사돼야 함 (총 2회)
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(await kv.get(`tripEndedAlert:devtoken:${NOW}`)).toBe('1');
+      expect(await kv.get(`tripEndedAlert:devtoken:${NOW + 60_000}`)).toBe('1');
     });
   });
 });

--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -392,4 +392,88 @@ describe('cleanupTripWithLa', () => {
     expect(logs).toContain('trip-ended push failed');
     expect(await kv.get('trip:devtoken')).toBeNull();
   });
+
+  // #1337 — KV `tripEndedAlert:{tripToken}` set-if-absent gate. 같은 trip의 cleanup이 race로
+  // 두 번 호출돼도 alert가 1회만 발사된다. 실패 push는 stamp X → 다음 cycle 재시도 허용.
+  describe('trip-ended alert KV dedup gate (#1337)', () => {
+    it('success 시 dedup stamp 저장 → 동일 trip 재 cleanup 호출 시 alert push skip', async () => {
+      const kv = new InMemoryKV();
+      const trip = makeTrip({ activityPushToken: undefined });
+      await kv.put('trip:devtoken', JSON.stringify(trip));
+      const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      // 1차 cleanup
+      await cleanupTripWithLa(
+        trip,
+        env,
+        makeDeps(fetchImpl as unknown as typeof fetch),
+        makeStats(),
+        NOW,
+        () => undefined,
+        'eta-missing',
+      );
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      expect(await kv.get('tripEndedAlert:devtoken')).toBe('1');
+
+      // 2차 cleanup (예: 동일 cron 사이클 내 race) — dedup으로 push skip
+      const trip2 = makeTrip({ activityPushToken: undefined });
+      await kv.put('trip:devtoken', JSON.stringify(trip2));
+      const logs: string[] = [];
+      await cleanupTripWithLa(
+        trip2,
+        env,
+        makeDeps(fetchImpl as unknown as typeof fetch),
+        makeStats(),
+        NOW,
+        (msg) => logs.push(msg),
+        'destination-arrived',
+      );
+      expect(fetchImpl).toHaveBeenCalledTimes(1); // 그대로 1회
+      expect(logs).toContain('trip-ended alert: dedup skip');
+    });
+
+    it('실패 push (양쪽 host 모두 reject) 시 dedup stamp 저장 X → 다음 사이클 재시도 허용', async () => {
+      const kv = new InMemoryKV();
+      const trip = makeTrip({ activityPushToken: undefined });
+      await kv.put('trip:devtoken', JSON.stringify(trip));
+      const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+      const fetchImpl = vi.fn(
+        async () => new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
+      );
+      await cleanupTripWithLa(
+        trip,
+        env,
+        makeDeps(fetchImpl as unknown as typeof fetch),
+        makeStats(),
+        NOW,
+        () => undefined,
+        'eta-missing',
+      );
+      // env-heal 1차+retry 둘 다 호출되지만 둘 다 실패.
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(await kv.get('tripEndedAlert:devtoken')).toBeNull();
+    });
+
+    it('throw 발생 시 dedup stamp 저장 X', async () => {
+      const kv = new InMemoryKV();
+      const trip = makeTrip({ activityPushToken: undefined });
+      await kv.put('trip:devtoken', JSON.stringify(trip));
+      const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+      const fetchImpl = vi.fn(async () => {
+        throw new Error('network down');
+      });
+      await cleanupTripWithLa(
+        trip,
+        env,
+        makeDeps(fetchImpl as unknown as typeof fetch),
+        makeStats(),
+        NOW,
+        () => undefined,
+        'expired',
+      );
+      expect(await kv.get('tripEndedAlert:devtoken')).toBeNull();
+      // throw 흡수 후 cleanup 흐름 계속 → trip 삭제됨
+      expect(await kv.get('trip:devtoken')).toBeNull();
+    });
+  });
 });

--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -10,7 +10,7 @@ import {
   type LiveActivityDeps,
   type LiveActivityStats,
 } from '../liveActivity';
-import type { ApnsEnv, Env, Trip, Waypoint } from '../types';
+import type { ApnsEnv, Env, Trip, TripEndedReason, Waypoint } from '../types';
 import { InMemoryKV } from './inMemoryKv';
 
 let apnsConfig: ApnsConfig;
@@ -396,84 +396,66 @@ describe('cleanupTripWithLa', () => {
   // #1337 — KV `tripEndedAlert:{tripToken}:{createdAt}` set-if-absent gate. 같은 trip의 cleanup이 race로
   // 두 번 호출돼도 alert가 1회만 발사된다. 실패 push는 stamp X → 다음 cycle 재시도 허용.
   describe('trip-ended alert KV dedup gate (#1337)', () => {
-    it('success 시 dedup stamp 저장 → 동일 trip 재 cleanup 호출 시 alert push skip', async () => {
+    type FetchFn = ReturnType<typeof vi.fn>;
+    const arrange = async (fetchImpl: FetchFn, tripOverrides: Partial<Trip> = {}) => {
       const kv = new InMemoryKV();
-      const trip = makeTrip({ activityPushToken: undefined });
+      const trip = makeTrip({ activityPushToken: undefined, ...tripOverrides });
       await kv.put('trip:devtoken', JSON.stringify(trip));
       const env = { TRIPS: kv as unknown as KVNamespace } as Env;
-      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
-      // 1차 cleanup
-      await cleanupTripWithLa(
-        trip,
-        env,
-        makeDeps(fetchImpl as unknown as typeof fetch),
+      return { kv, trip, env, fetchImpl };
+    };
+    const runCleanup = (
+      ctx: { trip: Trip; env: Env; fetchImpl: FetchFn },
+      reason: TripEndedReason,
+      log: (message: string, meta?: Record<string, unknown>) => void = () => undefined,
+      atNow: number = NOW,
+    ) =>
+      cleanupTripWithLa(
+        ctx.trip,
+        ctx.env,
+        makeDeps(ctx.fetchImpl as unknown as typeof fetch),
         makeStats(),
-        NOW,
-        () => undefined,
-        'eta-missing',
+        atNow,
+        log,
+        reason,
       );
-      expect(fetchImpl).toHaveBeenCalledTimes(1);
-      expect(await kv.get(`tripEndedAlert:devtoken:${NOW}`)).toBe('1');
 
-      // 2차 cleanup (예: 동일 cron 사이클 내 race) — dedup으로 push skip
+    it('success 시 dedup stamp 저장 → 동일 trip 재 cleanup 호출 시 alert push skip', async () => {
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      const ctx = await arrange(fetchImpl);
+      await runCleanup(ctx, 'eta-missing');
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      expect(await ctx.kv.get(`tripEndedAlert:devtoken:${NOW}`)).toBe('1');
+
+      // 2차 cleanup (동일 cron 사이클 내 race) — dedup으로 push skip
       const trip2 = makeTrip({ activityPushToken: undefined });
-      await kv.put('trip:devtoken', JSON.stringify(trip2));
+      await ctx.kv.put('trip:devtoken', JSON.stringify(trip2));
       const logs: string[] = [];
-      await cleanupTripWithLa(
-        trip2,
-        env,
-        makeDeps(fetchImpl as unknown as typeof fetch),
-        makeStats(),
-        NOW,
-        (msg) => logs.push(msg),
-        'destination-arrived',
-      );
-      expect(fetchImpl).toHaveBeenCalledTimes(1); // 그대로 1회
+      await runCleanup({ ...ctx, trip: trip2 }, 'destination-arrived', (m) => logs.push(m));
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
       expect(logs).toContain('trip-ended alert: dedup skip');
     });
 
     it('실패 push (양쪽 host 모두 reject) 시 dedup stamp 저장 X → 다음 사이클 재시도 허용', async () => {
-      const kv = new InMemoryKV();
-      const trip = makeTrip({ activityPushToken: undefined });
-      await kv.put('trip:devtoken', JSON.stringify(trip));
-      const env = { TRIPS: kv as unknown as KVNamespace } as Env;
       const fetchImpl = vi.fn(
         async () => new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
       );
-      await cleanupTripWithLa(
-        trip,
-        env,
-        makeDeps(fetchImpl as unknown as typeof fetch),
-        makeStats(),
-        NOW,
-        () => undefined,
-        'eta-missing',
-      );
+      const ctx = await arrange(fetchImpl);
+      await runCleanup(ctx, 'eta-missing');
       // env-heal 1차+retry 둘 다 호출되지만 둘 다 실패.
       expect(fetchImpl).toHaveBeenCalledTimes(2);
-      expect(await kv.get(`tripEndedAlert:devtoken:${NOW}`)).toBeNull();
+      expect(await ctx.kv.get(`tripEndedAlert:devtoken:${NOW}`)).toBeNull();
     });
 
     it('throw 발생 시 dedup stamp 저장 X', async () => {
-      const kv = new InMemoryKV();
-      const trip = makeTrip({ activityPushToken: undefined });
-      await kv.put('trip:devtoken', JSON.stringify(trip));
-      const env = { TRIPS: kv as unknown as KVNamespace } as Env;
       const fetchImpl = vi.fn(async () => {
         throw new Error('network down');
       });
-      await cleanupTripWithLa(
-        trip,
-        env,
-        makeDeps(fetchImpl as unknown as typeof fetch),
-        makeStats(),
-        NOW,
-        () => undefined,
-        'expired',
-      );
-      expect(await kv.get(`tripEndedAlert:devtoken:${NOW}`)).toBeNull();
+      const ctx = await arrange(fetchImpl);
+      await runCleanup(ctx, 'expired');
+      expect(await ctx.kv.get(`tripEndedAlert:devtoken:${NOW}`)).toBeNull();
       // throw 흡수 후 cleanup 흐름 계속 → trip 삭제됨
-      expect(await kv.get('trip:devtoken')).toBeNull();
+      expect(await ctx.kv.get('trip:devtoken')).toBeNull();
     });
 
     // 회귀 가드: trip.token = device APNs token 이라 같은 디바이스의 후속 trip이 동일 token을
@@ -481,40 +463,20 @@ describe('cleanupTripWithLa', () => {
     // alert가 stale stamp에 막혀 사라진다(#1337 acceptance 회귀). (token, createdAt) 페어로
     // trip-instance 단위 격리하는지 검증.
     it('동일 device(token)의 다른 trip-instance(createdAt) 는 dedup 안 됨 (각자 alert 발사)', async () => {
-      const kv = new InMemoryKV();
-      const env = { TRIPS: kv as unknown as KVNamespace } as Env;
       const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
-
       // Trip A: createdAt=NOW
-      const tripA = makeTrip({ activityPushToken: undefined, createdAt: NOW });
-      await kv.put('trip:devtoken', JSON.stringify(tripA));
-      await cleanupTripWithLa(
-        tripA,
-        env,
-        makeDeps(fetchImpl as unknown as typeof fetch),
-        makeStats(),
-        NOW,
-        () => undefined,
-        'destination-arrived',
-      );
+      const ctxA = await arrange(fetchImpl, { createdAt: NOW });
+      await runCleanup(ctxA, 'destination-arrived');
       expect(fetchImpl).toHaveBeenCalledTimes(1);
 
       // Trip B: same token, 다른 createdAt (예: 1분 뒤 새 trip 등록)
       const tripB = makeTrip({ activityPushToken: undefined, createdAt: NOW + 60_000 });
-      await kv.put('trip:devtoken', JSON.stringify(tripB));
-      await cleanupTripWithLa(
-        tripB,
-        env,
-        makeDeps(fetchImpl as unknown as typeof fetch),
-        makeStats(),
-        NOW + 60_000,
-        () => undefined,
-        'eta-missing',
-      );
+      await ctxA.kv.put('trip:devtoken', JSON.stringify(tripB));
+      await runCleanup({ ...ctxA, trip: tripB }, 'eta-missing', undefined, NOW + 60_000);
       // Trip B의 alert도 발사돼야 함 (총 2회)
       expect(fetchImpl).toHaveBeenCalledTimes(2);
-      expect(await kv.get(`tripEndedAlert:devtoken:${NOW}`)).toBe('1');
-      expect(await kv.get(`tripEndedAlert:devtoken:${NOW + 60_000}`)).toBe('1');
+      expect(await ctxA.kv.get(`tripEndedAlert:devtoken:${NOW}`)).toBe('1');
+      expect(await ctxA.kv.get(`tripEndedAlert:devtoken:${NOW + 60_000}`)).toBe('1');
     });
   });
 

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -466,7 +466,10 @@ describe('runScheduled', () => {
       now: () => NOW + 10_000,
     });
     expect(stats.polled).toBe(0);
-    expect(kv.store.size).toBe(0);
+    // #1337 — alert push 성공 시 dedup key(`tripEndedAlert:{tripToken}` TTL 1h)가 KV에 남는다.
+    // trip 객체 자체는 삭제됐는지 따로 단언한다.
+    expect(await kv.get('trip:tok')).toBeNull();
+    expect(await kv.get('tripEndedAlert:tok')).toBe('1');
   });
 
   // #640 — BoardingLock 게이트. 사용자가 열차를 선택하지 않은 trip(lock 부재)은
@@ -2107,16 +2110,17 @@ describe('runScheduled — Live Activity push integration (#586 D / #612)', () =
   });
 });
 
-// #868 — server-side trip auto-end 경로에서 클라 state sync용 trip-ended silent push가 발사되는지.
-// LA dismissal과 별개 budget(분당 0~1건)이라 trip 종료 cleanup 1건당 1회 발사가 기대 동작.
-describe('runScheduled — trip-ended silent push (#868)', () => {
-  /** APNs silent push (trip-ended kind) 호출만 추출 — LA push와 분리해 단언. */
+// #1337 — server-side trip auto-end 경로에서 클라 state sync용 trip-ended alert push가 발사되는지.
+// 구 #868 silent push는 force-quit 앱 미전달 사고(#1337)로 alert 전환. LA dismissal과 별개 budget
+// (분당 0~1건)이라 trip 종료 cleanup 1건당 1회 발사가 기대 동작이며 KV dedup이 1회를 보장한다.
+describe('runScheduled — trip-ended alert push (#1337)', () => {
+  /** APNs alert push (trip-ended kind) 호출만 추출 — LA push와 분리해 단언. */
   function getTripEndedCalls(
     fetchImpl: ReturnType<typeof vi.fn>,
   ): [string, RequestInit][] {
     return (fetchImpl.mock.calls as unknown as [string, RequestInit][]).filter((c) => {
       const headers = (c[1]?.headers ?? {}) as Record<string, string>;
-      if (headers['apns-push-type'] !== 'background') return false;
+      if (headers['apns-push-type'] !== 'alert') return false;
       try {
         const body = JSON.parse(c[1]?.body as string) as { data?: { kind?: string } };
         return body?.data?.kind === 'trip-ended';
@@ -2189,8 +2193,16 @@ describe('runScheduled — trip-ended silent push (#868)', () => {
     expect(data.pushId.length).toBeGreaterThan(0);
     // #868 P1-2 race 가드 — payload에 tripToken 포함되어야 클라가 ACTIVE_TRIP_KEY와 매칭 가능.
     expect(data.tripToken).toBe('end-tok');
+    // #1337 — alert push headers + KV dedup stamp.
+    const headers = (calls[0][1].headers ?? {}) as Record<string, string>;
+    expect(headers['apns-push-type']).toBe('alert');
+    expect(headers['apns-priority']).toBe('10');
+    const apsBody = JSON.parse(calls[0][1].body as string) as { aps: { alert: { title: string; body: string }; sound: string } };
+    expect(apsBody.aps.alert).toEqual({ title: '안내 종료', body: '경로 안내를 종료했어요' });
+    expect(apsBody.aps.sound).toBe('default');
     // trip은 KV에서 삭제돼야 함 (#706 cleanup).
     expect(await kv.get('trip:end-tok')).toBeNull();
+    expect(await kv.get('tripEndedAlert:end-tok')).toBe('1');
   });
 
   it('fires trip-ended push (reason=destination-arrived) when destination waypoint ARRIVED', async () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -456,7 +456,7 @@ describe('runScheduled', () => {
       makeTrip({ expiresAt: NOW + 5_000, alarmAtEpochMs: NOW - 1 }),
     );
     // expire 이전이지만 다음 시점은 expire 이후
-    // #868 — expired 경로는 trip-ended silent push도 발사 시도하므로 fetch mock 필요.
+    // #1337 — expired 경로는 trip-ended alert push도 발사 시도하므로 fetch mock 필요.
     const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
     const stats = await runScheduled(makeEnv(kv), {
       seoul: makeSeoul([]),
@@ -466,10 +466,10 @@ describe('runScheduled', () => {
       now: () => NOW + 10_000,
     });
     expect(stats.polled).toBe(0);
-    // #1337 — alert push 성공 시 dedup key(`tripEndedAlert:{tripToken}` TTL 1h)가 KV에 남는다.
+    // #1337 — alert push 성공 시 dedup key(`tripEndedAlert:{tripToken}:{createdAt}` TTL 10m)가 KV에 남는다.
     // trip 객체 자체는 삭제됐는지 따로 단언한다.
     expect(await kv.get('trip:tok')).toBeNull();
-    expect(await kv.get('tripEndedAlert:tok')).toBe('1');
+    expect(await kv.get(`tripEndedAlert:tok:${NOW}`)).toBe('1');
   });
 
   // #640 — BoardingLock 게이트. 사용자가 열차를 선택하지 않은 trip(lock 부재)은
@@ -2202,7 +2202,7 @@ describe('runScheduled — trip-ended alert push (#1337)', () => {
     expect(apsBody.aps.sound).toBe('default');
     // trip은 KV에서 삭제돼야 함 (#706 cleanup).
     expect(await kv.get('trip:end-tok')).toBeNull();
-    expect(await kv.get('tripEndedAlert:end-tok')).toBe('1');
+    expect(await kv.get(`tripEndedAlert:end-tok:${NOW}`)).toBe('1');
   });
 
   it('fires trip-ended push (reason=destination-arrived) when destination waypoint ARRIVED', async () => {

--- a/backend/alarm-worker/src/alertContent.ts
+++ b/backend/alarm-worker/src/alertContent.ts
@@ -12,6 +12,7 @@
  *   - transfer/early      ↔ ko.json notifications.transferEarlyTitle + alarms.earlyTransferBody
  *   - transfer/imminent   ↔ ko.json notifications.transferImminentTitle + alarms.imminentTransferBody
  *   - intermediate        ↔ ko.json route.intermediatePassedTitle + route.intermediatePassedBody
+ *   - trip-ended          ↔ ko.json route.tripEndedTitle + route.tripEndedBody
  *
  * 백엔드에는 i18next가 없고 사용자 locale도 알 수 없어 한국어 정적 문자열로 고정.
  * 영문 locale 지원이 필요해지면 디바이스 register 시점에 locale을 trip에 함께 저장하고
@@ -64,6 +65,14 @@ const ARRIVAL_BODY: Record<
 
 const INTERMEDIATE_TITLE = '역 통과';
 const intermediateBody = (s: string) => `${s}역을 지나고 있어요`;
+
+/**
+ * Trip-ended alert push 본문 상수 (#1337). server-side trip 종료를 killed 앱에도 즉시
+ * 표시하기 위해 silent → alert 전환(`sendTripEndedAlertPush`)할 때 사용한다.
+ * 디바이스 i18n(`ko.json` `route.tripEndedTitle` / `route.tripEndedBody`)과 byte-identical.
+ */
+export const TRIP_ENDED_ALERT_TITLE = '안내 종료';
+export const TRIP_ENDED_ALERT_BODY = '경로 안내를 종료했어요';
 
 export function buildAlertContent(input: AlertContentInput): AlertContent {
   if (input.kind === 'intermediate') {

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -7,11 +7,12 @@
 
 import { importPKCS8, SignJWT } from 'jose';
 import type { AlarmPhase } from './alarm';
+import { TRIP_ENDED_ALERT_BODY, TRIP_ENDED_ALERT_TITLE } from './alertContent';
 import type {
   BoardingPromptPushPayload,
   RescheduleChannel,
   ReschedulePushPayload,
-  TripEndedPushPayload,
+  TripEndedAlertPushPayload,
   TripEndedReason,
 } from './types';
 
@@ -299,13 +300,23 @@ export async function sendReschedulePush(
 }
 
 /**
- * Trip ended silent push (#868). server-side trip auto-end 시 클라이언트 state sync 신호.
+ * Trip ended alert push (#1337). server-side trip auto-end 시 사용자에게 즉시 표시되는 alert.
  *
- * silent push와 동일 헤더(background, priority 5)지만 payload의 `kind: 'trip-ended'`로 구분.
- * - alert fallback 대상이 아니다 — graceful loss 시 다음 FG 진입에서 trip 상태 재동기화 경로가 보강.
- * - 발사 비용은 trip 종료 1건당 1회로 극소 (분당 0~1건 수준) — APNs budget 영향 무시 가능.
+ * 구 silent push(`content-available: 1`, priority 5)는 force-quit된 앱에 전달되지 않아 killed
+ * 상태에서 "안내 종료" 알림이 누락됐다(#1337 evidence). alert push로 전환하면 OS가 직접 banner
+ * 를 띄워 killed 상태에서도 즉시 표시된다. running 앱은 OS banner를 보고, BG 핸들러가 `data`
+ * payload로 sentinel/dedup을 처리한다(디바이스 PR2 #1338).
+ *
+ * 헤더/payload:
+ *   - apns-push-type: alert  (silent은 background)
+ *   - apns-priority: 10      (silent은 5)
+ *   - aps.alert: { title, body } + aps.sound: 'default'
+ *   - data: { pushId, kind:'trip-ended', tripToken, reason, sentAt }
+ *
+ * dedup은 호출자(KV `tripEndedAlert:{tripToken}` 1h TTL)가 담당 — 같은 trip 종료가 cron
+ * 사이클마다 alert로 떠 노이즈가 되는 것을 1회 발사로 막는다.
  */
-export interface SendTripEndedPushOptions {
+export interface SendTripEndedAlertPushOptions {
   deviceToken: string;
   pushId: string;
   reason: TripEndedReason;
@@ -318,30 +329,36 @@ export interface SendTripEndedPushOptions {
   now?: number;
 }
 
-export async function sendTripEndedPush(
-  options: SendTripEndedPushOptions,
+export async function sendTripEndedAlertPush(
+  options: SendTripEndedAlertPushOptions,
 ): Promise<SendPushResult> {
   const jwt = await buildApnsJwt(options.config, options.now);
   const fetchImpl = options.fetchImpl ?? fetch;
   const url = `https://${options.host}/3/device/${options.deviceToken}`;
 
-  const payload: TripEndedPushPayload = {
+  const data: TripEndedAlertPushPayload = {
     pushId: options.pushId,
     kind: 'trip-ended',
+    tripToken: options.tripToken,
     reason: options.reason,
     sentAt: options.sentAt,
-    tripToken: options.tripToken,
   };
 
-  const body = JSON.stringify({ aps: { 'content-available': 1 }, data: payload });
+  const body = JSON.stringify({
+    aps: {
+      alert: { title: TRIP_ENDED_ALERT_TITLE, body: TRIP_ENDED_ALERT_BODY },
+      sound: 'default',
+    },
+    data,
+  });
 
   const response = await fetchImpl(url, {
     method: 'POST',
     headers: {
       authorization: `bearer ${jwt}`,
       'apns-topic': options.config.bundleId,
-      'apns-push-type': 'background',
-      'apns-priority': '5',
+      'apns-push-type': 'alert',
+      'apns-priority': '10',
       'content-type': 'application/json',
     },
     body,

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -15,7 +15,7 @@
 
 import {
   sendLiveActivityUpdate,
-  sendTripEndedPush,
+  sendTripEndedAlertPush,
   type LiveActivityContentState,
 } from './apns';
 import { pickApnsHost, sendWithEnvHeal } from './apnsHost';
@@ -173,11 +173,27 @@ export async function fireLiveActivityDismissal(
 }
 
 /**
+ * trip-ended alert push의 KV dedup 키. trip token 단위로 1회만 발사한다.
+ * cron이 expired/eta-missing/destination-arrived/push-unrecoverable 여러 경로로 동일 trip을
+ * 정리하려 시도할 수 있어도(예: HTTP DELETE 직전 cron이 한 번 더 발사하는 race) alert가 1건으로 묶인다.
+ *
+ * TTL 1h — trip의 자연 expiresAt이 1h 이내로 끝나기 때문에 그 윈도우만 보호하면 충분하고,
+ * 같은 token이 새 trip으로 재등록되는 흔치 않은 케이스도 1h 후 자연 해제된다.
+ */
+const TRIP_ENDED_ALERT_DEDUP_KEY_PREFIX = 'tripEndedAlert:';
+const TRIP_ENDED_ALERT_DEDUP_TTL_SEC = 60 * 60;
+
+function tripEndedAlertDedupKey(tripToken: string): string {
+  return `${TRIP_ENDED_ALERT_DEDUP_KEY_PREFIX}${tripToken}`;
+}
+
+/**
  * trip 정리 wrapper — LA dismissal(있을 때만) + deleteTrip을 단일 진입점으로.
  * scheduled.ts의 모든 deleteTrip 호출 + HTTP DELETE /trips/:token이 공유.
  *
- * #868 — reason 지정 시 trip-ended silent push 발사. server-side auto-end 경로(scheduled.ts의
- * cron 호출자)는 reason을 명시 전달해 클라 route/destination/lock state를 동기화한다.
+ * #1337 — reason 지정 시 trip-ended **alert** push 발사 (구 silent → alert 전환). server-side
+ * auto-end 경로(scheduled.ts의 cron 호출자)는 reason을 명시 전달해 killed 앱 사용자에게도 OS
+ * banner로 "안내 종료"를 즉시 표시하고 클라 route/destination/lock state를 동기화한다.
  * HTTP DELETE 경로는 reason 미지정 — 이미 사용자가 destination을 clear한 시점이라 push 불필요.
  *
  * push는 LA dismissal과 별개의 budget(분당 0~1건 trip 종료 수준)이라 LA push와 직렬 발사로 충분.
@@ -194,7 +210,7 @@ export async function cleanupTripWithLa(
 ): Promise<void> {
   await fireLiveActivityDismissal(trip, deps, stats, now, log);
   if (reason) {
-    await fireTripEndedPush(trip, reason, deps, now, log);
+    await fireTripEndedAlertPush(trip, reason, env, deps, now, log);
   }
   await deleteTrip(env.TRIPS, trip.token);
   // #705 — trip을 폐기할 때 progress entry도 함께 제거. TTL이 자연 만료를 보장하지만
@@ -203,17 +219,31 @@ export async function cleanupTripWithLa(
 }
 
 /**
- * trip-ended silent push 발사 (#868). LA dismissal과 직렬로 1회 발사.
- * 실패는 fire-and-forget 성격이지만 흐름 일관성을 위해 await — APNs latency는 cron 1 cycle 안에서 흡수.
- * fireLiveActivityDismissal과 마찬가지로 trip 상태 변경 없이 best-effort.
+ * trip-ended alert push 발사 (#1337). LA dismissal과 직렬로 1회 발사.
+ *
+ * KV `tripEndedAlert:{tripToken}` set-if-absent 게이트로 같은 trip의 종료 alert가 cron race로
+ * 중복 발사되는 것을 차단. 이미 발사 기록이 있으면 silent skip.
+ *
+ * 실패는 fire-and-forget 성격이지만 흐름 일관성을 위해 await — APNs latency는 cron 1 cycle 안에서
+ * 흡수. fireLiveActivityDismissal과 마찬가지로 trip 상태 변경 없이 best-effort.
  */
-async function fireTripEndedPush(
+async function fireTripEndedAlertPush(
   trip: Trip,
   reason: TripEndedReason,
+  env: Env,
   deps: LiveActivityDeps,
   now: number,
   log: Logger,
 ): Promise<void> {
+  const dedupKey = tripEndedAlertDedupKey(trip.token);
+  const existing = await env.TRIPS.get(dedupKey);
+  if (existing !== null) {
+    log('trip-ended alert: dedup skip', {
+      token: trip.token.slice(0, 8),
+      reason,
+    });
+    return;
+  }
   const pushId = crypto.randomUUID();
   // JWT 서명 / network reject 등의 throw가 cleanup 흐름을 차단하지 않도록 swallow.
   // trip-ended push는 graceful fail-soft — graceful loss 시 클라는 다음 FG hydrate에서 회복.
@@ -223,7 +253,7 @@ async function fireTripEndedPush(
     // trip은 곧 deleteTrip되므로 correctedEnv KV 반영은 불필요 — retry 성공만으로 충분(로그만 남김).
     const heal = await sendWithEnvHeal(
       (host) =>
-        sendTripEndedPush({
+        sendTripEndedAlertPush({
           deviceToken: trip.token,
           pushId,
           reason,
@@ -247,6 +277,8 @@ async function fireTripEndedPush(
         status: heal.result.status,
         pushReason: heal.result.reason,
       });
+      // 실패 시에는 dedup stamp를 남기지 않아 다음 cron cycle에서 재시도 허용.
+      return;
     }
   } catch (e) {
     log('trip-ended push threw', {
@@ -254,6 +286,9 @@ async function fireTripEndedPush(
       reason,
       error: String(e),
     });
+    return;
   }
+  // 성공 push만 dedup stamp — 같은 trip의 후속 cleanup race가 중복 alert를 발사하지 못하도록.
+  await env.TRIPS.put(dedupKey, '1', { expirationTtl: TRIP_ENDED_ALERT_DEDUP_TTL_SEC });
 }
 

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -173,18 +173,22 @@ export async function fireLiveActivityDismissal(
 }
 
 /**
- * trip-ended alert push의 KV dedup 키. trip token 단위로 1회만 발사한다.
- * cron이 expired/eta-missing/destination-arrived/push-unrecoverable 여러 경로로 동일 trip을
- * 정리하려 시도할 수 있어도(예: HTTP DELETE 직전 cron이 한 번 더 발사하는 race) alert가 1건으로 묶인다.
+ * trip-ended alert push의 KV dedup 키. (tripToken, createdAt) 단위로 1회만 발사한다.
  *
- * TTL 1h — trip의 자연 expiresAt이 1h 이내로 끝나기 때문에 그 윈도우만 보호하면 충분하고,
- * 같은 token이 새 trip으로 재등록되는 흔치 않은 케이스도 1h 후 자연 해제된다.
+ * `trip.token`은 device APNs token이라 같은 디바이스의 후속 trip이 동일 token을 재사용한다.
+ * dedup을 token만으로 잡으면 사용자가 trip A 종료 후 곧이어 시작한 trip B의 종료 alert가
+ * stale stamp에 막혀 사라진다(#1337 acceptance 회귀). createdAt까지 포함해 trip-instance 단위로
+ * 격리한다.
+ *
+ * TTL은 cron race(이전 cycle이 늦게 끝나는 동안 다음 cycle 시작) 윈도우만 보호하면 충분 →
+ * 10분으로 짧게 잡아 KV bloat도 줄인다. trip이 끝나면 곧 deleteTrip되므로 같은
+ * (token, createdAt) 페어가 10분 후에 다시 cleanup 대상이 될 가능성은 사실상 0.
  */
 const TRIP_ENDED_ALERT_DEDUP_KEY_PREFIX = 'tripEndedAlert:';
-const TRIP_ENDED_ALERT_DEDUP_TTL_SEC = 60 * 60;
+const TRIP_ENDED_ALERT_DEDUP_TTL_SEC = 10 * 60;
 
-function tripEndedAlertDedupKey(tripToken: string): string {
-  return `${TRIP_ENDED_ALERT_DEDUP_KEY_PREFIX}${tripToken}`;
+function tripEndedAlertDedupKey(tripToken: string, createdAt: number): string {
+  return `${TRIP_ENDED_ALERT_DEDUP_KEY_PREFIX}${tripToken}:${createdAt}`;
 }
 
 /**
@@ -235,7 +239,7 @@ async function fireTripEndedAlertPush(
   now: number,
   log: Logger,
 ): Promise<void> {
-  const dedupKey = tripEndedAlertDedupKey(trip.token);
+  const dedupKey = tripEndedAlertDedupKey(trip.token, trip.createdAt);
   const existing = await env.TRIPS.get(dedupKey);
   if (existing !== null) {
     log('trip-ended alert: dedup skip', {

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -326,24 +326,23 @@ export type TripEndedReason =
   | 'push-unrecoverable';
 
 /**
- * Trip ended silent push payload (#868).
- * backend가 server-side로 trip을 자동 종료(eta-missing/destination-arrived/expired/push-unrecoverable)
- * 했을 때 클라이언트의 route/destination/lock state를 동기화하기 위해 발사한다.
+ * Trip ended alert push payload (#1337). server-side trip 자동 종료 시 발사되는 alert push의
+ * `data` 필드. 구 silent push payload(`TripEndedPushPayload`)는 force-quit 앱에 전달되지 않아
+ * killed 상태 알림 누락 사고가 있어 alert로 전환됐다(#1337).
  *
- * client는 이 payload 수신 시 trip-bound storage(route, destination, boardingLock, activeTrip 등)를
- * 일괄 cleanup한다. cleanup만 하므로 alert fallback 대상이 아니며 pushId echo 의무도 없다 (graceful loss
- * 시에는 다음 FG 진입 시 useTripsBackendSync 등이 종국에는 hydrate로 복구).
+ * client BG 핸들러는 alert 수신 시(`aps.alert` 존재) OS가 이미 banner를 띄웠으므로 추가 로컬
+ * 알림을 발사하지 않고, `data.pushId`/`data.tripToken`을 sentinel/dedup에만 사용한다.
  *
  * `tripToken`은 race 가드용 — backend가 trip A에 대해 push를 발사한 후 APNs latency 동안
  * 사용자가 trip B를 새로 시작했다면, 클라는 tripToken과 현재 ACTIVE_TRIP_KEY를 비교해
  * 불일치 시 cleanup을 skip (trip B의 storage를 잘못 파괴하는 것을 방지).
  */
-export interface TripEndedPushPayload {
+export interface TripEndedAlertPushPayload {
   pushId: string;
   kind: 'trip-ended';
+  tripToken: string;
   reason: TripEndedReason;
   sentAt: number;
-  tripToken: string;
 }
 
 /** APNs 토큰 환경. sandbox는 dev/preview/internal 빌드, production은 App Store/TestFlight. */


### PR DESCRIPTION
Closes #1337

Epic #1204 후속. 결정문서: `tasks/issue-1337-decision-2026-06-15.md` (옵션 C — A+B 하이브리드 채택, 본 PR은 A 백엔드 부분만).

## 변경 요약

- **`backend/alarm-worker/src/apns.ts`**
  - 신규 `sendTripEndedAlertPush(options)` — `apns-push-type: alert`, `apns-priority: 10`, `aps.alert.{title, body}` + `aps.sound: 'default'`, `data: { pushId, kind: 'trip-ended', tripToken, reason, sentAt }`.
  - 구 `sendTripEndedPush`(silent, background, priority 5) 제거 — 호출자 일괄 전환되어 dead code.
- **`backend/alarm-worker/src/alertContent.ts`**
  - `TRIP_ENDED_ALERT_TITLE = '안내 종료'`, `TRIP_ENDED_ALERT_BODY = '경로 안내를 종료했어요'` (디바이스 `ko.json` `route.tripEndedTitle/Body`와 byte-identical).
  - 파일 헤더 sync 주석에 `trip-ended ↔ ko.json route.tripEnded*` 한 줄 추가.
- **`backend/alarm-worker/src/liveActivity.ts`**
  - `fireTripEndedPush` → `fireTripEndedAlertPush` 개명 + alert push 호출로 전환.
  - KV `tripEndedAlert:{tripToken}:{createdAt}` set-if-absent dedup gate (TTL 10분) 추가 — cron race로 같은 trip의 종료 alert가 중복 발사되는 것 차단.
  - **dedup key에 `createdAt` 포함**: `trip.token`이 device APNs token이라 같은 디바이스의 후속 trip이 동일 token을 재사용 → token 단독 키는 trip A 종료 후 짧은 시간 내 시작한 trip B의 종료 alert를 stale stamp로 차단해 acceptance 회귀를 일으킴. trip-instance 단위 격리.
  - 실패 push(양쪽 host 모두 reject) / throw 시에는 dedup stamp 저장 X → 다음 cycle 재시도 허용.
- **`backend/alarm-worker/src/types.ts`**
  - `TripEndedPushPayload` → `TripEndedAlertPushPayload` 개명 (필드 동일).
- **`backend/alarm-worker/src/scheduled.ts`**: 직접 수정 없음 — 4개 trip-ended 발사 지점(L305 expired / L878 eta-missing / L1049 destination-arrived / L1260 push-unrecoverable)이 모두 `cleanupTripWithLa` 단일 chokepoint를 경유해서 자동 전환됨. HTTP DELETE 경로(reason 미지정)는 그대로 push 미발사.

## Acceptance check

- [x] alert push 전환 (`apns-push-type: alert`, `apns-priority: 10`, `aps.alert.{title, body}`, `aps.sound: 'default'`)
- [x] payload `data` byte-level contract (`pushId`, `kind: 'trip-ended'`, `tripToken`, `reason`, `sentAt`)
- [x] KV dedup gate `tripEndedAlert:{tripToken}:{createdAt}` set-if-absent + 동일 trip race 시 1회만 발사
- [x] 같은 디바이스의 다른 trip-instance는 dedup으로 막히지 않음 (회귀 가드 테스트 추가)
- [x] 4개 reason path 모두 alert로 전환 (expired/eta-missing/destination-arrived/push-unrecoverable)
- [x] env-heal(`sendWithEnvHeal`) 적용 유지 — sandbox↔production host 1회 retry
- [x] 실패/throw 시 dedup stamp 저장 X → 다음 cron cycle 재시도 가능
- [x] `npm run type-check` (backend) pass
- [x] `npm test` (backend, 1270 tests) pass
- [x] `npm run type-check` (root) pass

## 디바이스 PR2 / 옵션 B는 별도

본 PR은 A의 백엔드 부분만. 디바이스 BG 핸들러에서 alert payload 수신 시 `presentTripEndedNotification` skip + sentinel 기록은 별도 PR(#1338 — 결정문서 작업분해 step 2). 옵션 B(launch reconciliation)는 별도 PR.

## 검증 갭

- 에이전트 PR이라 device-only 회귀(runtime/killed-app/위젯/LA)는 검증 불가. 사용자가 머지 전 결정 권한자.
- 실기기 acceptance(killed 상태 trip 종료 → 즉시 banner 표시)는 PR2 + 빌드 후 사용자 검증 필요.