### PR TITLE
feat(#1339): launch reconciliation으로 trip-ended 누락 backstop (PR2 device)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -25,6 +25,7 @@ import { stopVibration } from '../src/features/alarm/utils/alarmSound';
 import { setupBoardingPromptCategory } from '../src/features/alarm/utils/notificationCategory';
 import { useBoardingPromptResponder } from '../src/features/alarm/hooks/useBoardingPromptResponder';
 import { useStateRehydration } from '../src/shared/hooks/useStateRehydration';
+import { useLaunchTripReconciliation } from '../src/features/alarm/hooks/useLaunchTripReconciliation';
 import { fetchArrivalInfo } from '../src/features/arrival/api/arrivalApi';
 import { FALLBACK_BOARDING_DURATION_MINUTES } from '../src/shared/constants/boardingLock';
 import { initSentryIfOptedIn } from '../src/shared/infra/monitoring/sentryInit';
@@ -94,6 +95,11 @@ function RootContent() {
   // destination/customOrigin/tripOrigin/lock을 storage에서 재수화하고, BG silent push가
   // trip-ended sentinel을 남겼다면 destination/lock store를 reset해 stale UI를 차단.
   useStateRehydration();
+
+  // #1339 PR2 — silent push 누락(killed-app + push 미도달 등) backstop.
+  // cold-launch 시 backend `GET /trips/:tripToken/status`로 trip 종료 여부 확인 후
+  // 누락된 user-facing notification + sentinel을 복구한다. sentinel이 이미 있으면 no-op.
+  useLaunchTripReconciliation();
 
   useEffect(() => {
     loadLocalePreference();

--- a/src/features/alarm/api/__tests__/tripStatus.test.ts
+++ b/src/features/alarm/api/__tests__/tripStatus.test.ts
@@ -1,0 +1,144 @@
+import { fetchTripStatus } from '../tripStatus';
+
+function jsonResponse(body: unknown, status: number = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+describe('fetchTripStatus', () => {
+  it('200 active → { status: active, endedAt: null, endReason: null }', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(
+      jsonResponse({ tripToken: 'tk', status: 'active', endedAt: null, endReason: null }),
+    );
+    const result = await fetchTripStatus('tk', 'https://api.test.dev', fetchImpl);
+    expect(result).toEqual({ status: 'active', endedAt: null, endReason: null });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe('https://api.test.dev/trips/tk/status');
+    expect(init.method).toBe('GET');
+  });
+
+  it('200 ended → endedAt/endReason 반환 (destination → destination-arrived 정규화)', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(
+      jsonResponse({
+        tripToken: 'tk',
+        status: 'ended',
+        endedAt: 1_700_000_000_000,
+        endReason: 'destination',
+      }),
+    );
+    const result = await fetchTripStatus('tk', 'https://api.test.dev/', fetchImpl);
+    expect(result).toEqual({
+      status: 'ended',
+      endedAt: 1_700_000_000_000,
+      endReason: 'destination-arrived',
+    });
+  });
+
+  it.each([
+    ['expired'],
+    ['eta-missing'],
+    ['push-unrecoverable'],
+  ])('200 ended endReason=%s는 동일 enum 유지', async (reason) => {
+    const fetchImpl = jest.fn().mockResolvedValue(
+      jsonResponse({ tripToken: 'tk', status: 'ended', endedAt: 1, endReason: reason }),
+    );
+    const result = await fetchTripStatus('tk', 'https://api.test.dev', fetchImpl);
+    expect(result?.endReason).toBe(reason);
+  });
+
+  it('200 ended endReason이 알 수 없는 값이면 unknown', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(
+      jsonResponse({ tripToken: 'tk', status: 'ended', endedAt: 1, endReason: 'mystery' }),
+    );
+    const result = await fetchTripStatus('tk', 'https://api.test.dev', fetchImpl);
+    expect(result?.endReason).toBe('unknown');
+  });
+
+  it('200 ended endReason 타입 비-string → unknown', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(
+      jsonResponse({ tripToken: 'tk', status: 'ended', endedAt: 1, endReason: 42 }),
+    );
+    const result = await fetchTripStatus('tk', 'https://api.test.dev', fetchImpl);
+    expect(result?.endReason).toBe('unknown');
+  });
+
+  it('200 ended endedAt 누락/비-number → Date.now() fallback', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-06-15T00:00:00Z'));
+    const fetchImpl = jest.fn().mockResolvedValue(
+      jsonResponse({ tripToken: 'tk', status: 'ended', endReason: 'expired' }),
+    );
+    const result = await fetchTripStatus('tk', 'https://api.test.dev', fetchImpl);
+    expect(result?.endedAt).toBe(Date.now());
+    jest.useRealTimers();
+  });
+
+  it('404 → null', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(jsonResponse({ error: 'trip_not_found' }, 404));
+    const result = await fetchTripStatus('tk', 'https://api.test.dev', fetchImpl);
+    expect(result).toBeNull();
+  });
+
+  it('410 → null', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(
+      jsonResponse({ tripToken: 'tk', status: 'expired-retention' }, 410),
+    );
+    const result = await fetchTripStatus('tk', 'https://api.test.dev', fetchImpl);
+    expect(result).toBeNull();
+  });
+
+  it('500 → throw', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(jsonResponse({}, 500));
+    await expect(fetchTripStatus('tk', 'https://api.test.dev', fetchImpl)).rejects.toThrow();
+  });
+
+  it('네트워크 에러 → throw', async () => {
+    const fetchImpl = jest.fn().mockRejectedValue(new Error('network'));
+    await expect(fetchTripStatus('tk', 'https://api.test.dev', fetchImpl)).rejects.toThrow('network');
+  });
+
+  it('알 수 없는 status body → throw', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(jsonResponse({ tripToken: 'tk' }));
+    await expect(fetchTripStatus('tk', 'https://api.test.dev', fetchImpl)).rejects.toThrow();
+  });
+
+  it('tripToken은 URL encode된다', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(
+      jsonResponse({ tripToken: 'a/b', status: 'active', endedAt: null, endReason: null }),
+    );
+    await fetchTripStatus('a/b', 'https://api.test.dev', fetchImpl);
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://api.test.dev/trips/a%2Fb/status');
+  });
+
+  it('타임아웃 초과 시 abort 호출 → 네트워크 에러로 throw', async () => {
+    jest.useFakeTimers();
+    const fetchImpl = jest.fn().mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise<Response>((_, reject) => {
+          init.signal?.addEventListener('abort', () =>
+            reject(Object.assign(new Error('aborted'), { name: 'AbortError' })),
+          );
+        }),
+    );
+    const pending = fetchTripStatus('tk', 'https://api.test.dev', fetchImpl);
+    jest.advanceTimersByTime(5001);
+    await expect(pending).rejects.toThrow();
+    jest.useRealTimers();
+  });
+
+  it('fetchImpl 미지정 시 global fetch 사용', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue(
+      jsonResponse({ tripToken: 'tk', status: 'active', endedAt: null, endReason: null }),
+    );
+    try {
+      const result = await fetchTripStatus('tk', 'https://api.test.dev');
+      expect(result?.status).toBe('active');
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+});

--- a/src/features/alarm/api/tripStatus.ts
+++ b/src/features/alarm/api/tripStatus.ts
@@ -1,0 +1,119 @@
+/**
+ * Trip status reconciliation client (#1339 PR2 device).
+ *
+ * Backend GET `/trips/:tripToken/status` 호출. PR2 backend(#1341)가 추가한 endpoint로,
+ * 디바이스가 cold-launch / FG 복귀 시 trip이 backend 측에서 이미 종료됐는지(예: silent
+ * push 누락 / kill-app 동안 종료) 확인하는 backstop.
+ *
+ * 응답 contract:
+ *   200 `{ status: 'active', endedAt: null, endReason: null }` → 아직 살아있음.
+ *   200 `{ status: 'ended', endedAt: number, endReason: TripStatusEndReason }` → 자동 종료.
+ *   404 → KV에서 trip/marker 모두 사라짐 (정리 대상).
+ *   410 → ended record는 있지만 retention 만료 (정리 대상).
+ *
+ * 본 함수는 trip 자체가 정리 대상인지 caller가 판별할 수 있도록
+ *  - active/ended는 객체 반환
+ *  - 404/410은 null 반환 (정리만)
+ *  - 네트워크 에러는 throw — caller가 silent fail 처리.
+ *
+ * Backend endReason은 'destination' / 'expired' / 'eta-missing' / 'push-unrecoverable' contract.
+ * 디바이스 `TripEndedReason`은 'destination-arrived' / 'expired' / 'eta-missing' / 'push-unrecoverable'
+ * / 'unknown'. backend 'destination'를 디바이스 'destination-arrived'로 정규화한다 —
+ * 알 수 없는 값은 'unknown'.
+ */
+
+import type { TripEndedReason } from '../tasks/silentPushTask';
+
+/** active/ended 응답 (200) — null이면 trip이 사라진 것(404/410). */
+export interface TripStatusResult {
+  status: 'active' | 'ended';
+  /** ended일 때만 epoch ms. active는 null. */
+  endedAt: number | null;
+  /** ended일 때만 reason. active는 null. */
+  endReason: TripEndedReason | null;
+}
+
+const REQUEST_TIMEOUT_MS = 5000;
+
+type FetchImpl = typeof fetch;
+
+function normalizeBaseUrl(base: string): string {
+  return base.replace(/\/$/, '');
+}
+
+function normalizeEndReason(raw: unknown): TripEndedReason {
+  if (typeof raw !== 'string') return 'unknown';
+  if (raw === 'destination') return 'destination-arrived';
+  if (
+    raw === 'eta-missing' ||
+    raw === 'expired' ||
+    raw === 'push-unrecoverable'
+  ) {
+    return raw;
+  }
+  return 'unknown';
+}
+
+async function fetchWithTimeout(
+  fetchImpl: FetchImpl,
+  input: string,
+  init: RequestInit,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetchImpl(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Trip status를 backend에 조회한다.
+ *
+ * @param tripToken — 디바이스가 register 시 사용한 tripToken.
+ * @param baseUrl — alarm backend base URL (trailing slash 무관).
+ * @param fetchImpl — 기본 `fetch`. 테스트 주입용.
+ *
+ * @returns
+ *   - 200 → `{ status, endedAt, endReason }`.
+ *   - 404/410 → `null`.
+ *
+ * @throws 네트워크 에러 / 5xx / 기타 비정상 응답.
+ */
+export async function fetchTripStatus(
+  tripToken: string,
+  baseUrl: string,
+  fetchImpl: FetchImpl = fetch,
+): Promise<TripStatusResult | null> {
+  const url = `${normalizeBaseUrl(baseUrl)}/trips/${encodeURIComponent(tripToken)}/status`;
+  const res = await fetchWithTimeout(fetchImpl, url, { method: 'GET' });
+
+  if (res.status === 404 || res.status === 410) {
+    return null;
+  }
+  if (!res.ok) {
+    throw new Error(`trip status fetch failed: ${res.status}`);
+  }
+
+  const body = (await res.json()) as {
+    status?: unknown;
+    endedAt?: unknown;
+    endReason?: unknown;
+  };
+
+  if (body.status === 'active') {
+    return { status: 'active', endedAt: null, endReason: null };
+  }
+  if (body.status === 'ended') {
+    const endedAt = typeof body.endedAt === 'number' && Number.isFinite(body.endedAt)
+      ? body.endedAt
+      : Date.now();
+    return {
+      status: 'ended',
+      endedAt,
+      endReason: normalizeEndReason(body.endReason),
+    };
+  }
+  throw new Error(`trip status fetch: unexpected body`);
+}

--- a/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
@@ -1,0 +1,162 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { ACTIVE_TRIP_KEY } from '../../../../shared/constants/storageKeys';
+import {
+  runLaunchTripReconciliation,
+  useLaunchTripReconciliation,
+} from '../useLaunchTripReconciliation';
+
+const mockFetchTripStatus = jest.fn();
+jest.mock('../../api/tripStatus', () => ({
+  fetchTripStatus: (...args: unknown[]) => mockFetchTripStatus(...args),
+}));
+
+const mockGetSentinel = jest.fn();
+const mockSetSentinel = jest.fn();
+jest.mock('../../utils/tripEndedSentinel', () => ({
+  getTripEndedSentinel: (...args: unknown[]) => mockGetSentinel(...args),
+  setTripEndedSentinel: (...args: unknown[]) => mockSetSentinel(...args),
+  clearTripEndedSentinel: jest.fn(),
+}));
+
+const mockSendTripEnded = jest.fn();
+jest.mock('../../utils/stationNotification', () => ({
+  sendTripEndedNotification: (...args: unknown[]) => mockSendTripEnded(...args),
+}));
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  await AsyncStorage.clear();
+  mockGetSentinel.mockResolvedValue(null);
+  mockSetSentinel.mockResolvedValue(undefined);
+  mockSendTripEnded.mockResolvedValue(undefined);
+  process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+});
+
+afterEach(() => {
+  delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+});
+
+describe('runLaunchTripReconciliation', () => {
+  it('URL 미설정 → skip (fetch 호출 없음)', async () => {
+    delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    await runLaunchTripReconciliation();
+    expect(mockFetchTripStatus).not.toHaveBeenCalled();
+  });
+
+  it('ACTIVE_TRIP_KEY 부재 → skip', async () => {
+    await runLaunchTripReconciliation();
+    expect(mockFetchTripStatus).not.toHaveBeenCalled();
+  });
+
+  it('sentinel 기록 있음 → fetch skip', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    mockGetSentinel.mockResolvedValue(1_700_000_000_000);
+    await runLaunchTripReconciliation();
+    expect(mockFetchTripStatus).not.toHaveBeenCalled();
+    expect(mockSendTripEnded).not.toHaveBeenCalled();
+  });
+
+  it('status ended → notification + sentinel + active trip clear', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    mockFetchTripStatus.mockResolvedValue({
+      status: 'ended',
+      endedAt: 1_700_000_000_000,
+      endReason: 'destination-arrived',
+    });
+    await runLaunchTripReconciliation();
+    expect(mockFetchTripStatus).toHaveBeenCalledWith('tk', 'https://api.test.dev');
+    expect(mockSendTripEnded).toHaveBeenCalledWith('destination-arrived');
+    expect(mockSetSentinel).toHaveBeenCalledWith(1_700_000_000_000);
+    expect(await AsyncStorage.getItem(ACTIVE_TRIP_KEY)).toBeNull();
+  });
+
+  it('status ended + endedAt null → Date.now() fallback', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-06-15T00:00:00Z'));
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    mockFetchTripStatus.mockResolvedValue({
+      status: 'ended',
+      endedAt: null,
+      endReason: 'unknown',
+    });
+    await runLaunchTripReconciliation();
+    expect(mockSetSentinel).toHaveBeenCalledWith(Date.now());
+    jest.useRealTimers();
+  });
+
+  it('status ended + endReason null → unknown fallback', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    mockFetchTripStatus.mockResolvedValue({
+      status: 'ended',
+      endedAt: 1,
+      endReason: null,
+    });
+    await runLaunchTripReconciliation();
+    expect(mockSendTripEnded).toHaveBeenCalledWith('unknown');
+  });
+
+  it('status active → 변경 없음', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    mockFetchTripStatus.mockResolvedValue({
+      status: 'active',
+      endedAt: null,
+      endReason: null,
+    });
+    await runLaunchTripReconciliation();
+    expect(mockSendTripEnded).not.toHaveBeenCalled();
+    expect(mockSetSentinel).not.toHaveBeenCalled();
+    expect(await AsyncStorage.getItem(ACTIVE_TRIP_KEY)).toBe('tk');
+  });
+
+  it('404/410 (null) → active trip clear만, notification X', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    mockFetchTripStatus.mockResolvedValue(null);
+    await runLaunchTripReconciliation();
+    expect(mockSendTripEnded).not.toHaveBeenCalled();
+    expect(mockSetSentinel).not.toHaveBeenCalled();
+    expect(await AsyncStorage.getItem(ACTIVE_TRIP_KEY)).toBeNull();
+  });
+
+  it('네트워크 에러 → silent fail (throw 없음, 상태 변경 없음)', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    mockFetchTripStatus.mockRejectedValue(new Error('network'));
+    await expect(runLaunchTripReconciliation()).resolves.toBeUndefined();
+    expect(mockSendTripEnded).not.toHaveBeenCalled();
+    expect(mockSetSentinel).not.toHaveBeenCalled();
+    expect(await AsyncStorage.getItem(ACTIVE_TRIP_KEY)).toBe('tk');
+  });
+
+  it('내부 예외(setTripEndedSentinel 실패 등) → silent fail', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    mockSetSentinel.mockRejectedValueOnce(new Error('boom'));
+    mockFetchTripStatus.mockResolvedValue({
+      status: 'ended',
+      endedAt: 1,
+      endReason: 'expired',
+    });
+    await expect(runLaunchTripReconciliation()).resolves.toBeUndefined();
+  });
+});
+
+describe('useLaunchTripReconciliation', () => {
+  it('마운트 시 1회 reconciliation 실행', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    mockFetchTripStatus.mockResolvedValue({
+      status: 'active',
+      endedAt: null,
+      endReason: null,
+    });
+    renderHook(() => useLaunchTripReconciliation());
+    await waitFor(() => expect(mockFetchTripStatus).toHaveBeenCalledTimes(1));
+  });
+});

--- a/src/features/alarm/hooks/useLaunchTripReconciliation.ts
+++ b/src/features/alarm/hooks/useLaunchTripReconciliation.ts
@@ -1,0 +1,117 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: launch reconciliation은 alarm 슬라이스의 client(fetchTripStatus)와
+ * notification(sendTripEndedNotification)·sentinel(tripEndedSentinel) + route 슬라이스의
+ * destination/lock store를 한 곳에서 묶어 처리하는 본질적 orchestrator. useStateRehydration과
+ * 동형이라 file-level disable 패턴을 따른다 (ADR Phase 5).
+ */
+/**
+ * Launch reconciliation hook (#1339 PR2 device).
+ *
+ * Backstop for PR1(#1340) trip-ended alert push. backend trip-ended push가 어떤 이유로든
+ * 디바이스에 도달하지 못한 경우(killed-app + push 누락, 권한 변경 등) 다음 cold-launch
+ * 시점에 디바이스가 backend `GET /trips/:tripToken/status`로 명시적으로 확인하고 정리한다.
+ *
+ * 흐름:
+ *   1) ACTIVE_TRIP_KEY 조회. 없으면 미트립 — skip.
+ *   2) tripEndedSentinel 확인. 이미 기록 있음 = silent push가 잘 도달한 케이스 — skip.
+ *   3) `fetchTripStatus` 호출.
+ *      - status='ended' → notification 발사 + sentinel 기록 + active trip clear.
+ *        useStateRehydration이 sentinel을 보고 destination/lock store reset을 수행한다.
+ *      - null(404/410) → active trip clear만. notification은 발사하지 않는다 (이미 정리됨,
+ *        과거 notification은 다른 채널로 도달했을 가능성 또는 retention 만료).
+ *      - status='active' → 변경 없음.
+ *   4) 네트워크 에러 → silent fail. 다음 launch에서 재시도.
+ *
+ * 멱등성: sentinel이 기록되면 step 2에서 skip되므로 같은 trip에 대해 notification은 최대 1회.
+ *
+ * 호출 시점: app/_layout.tsx에서 마운트 1회. cold-launch backstop이라 AppState 'active'
+ * 재진입 시 반복 fetch는 불필요 (silent push가 살아있다면 그쪽이 우선).
+ */
+
+import { useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
+import {
+  getTripEndedSentinel,
+  setTripEndedSentinel,
+} from '../utils/tripEndedSentinel';
+import { sendTripEndedNotification } from '../utils/stationNotification';
+import { fetchTripStatus } from '../api/tripStatus';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('useLaunchTripReconciliation');
+
+function getBackendUrl(): string | null {
+  const url = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+  if (!url) return null;
+  return url;
+}
+
+/**
+ * 한 번의 reconciliation 사이클. 마운트 시 1회 호출.
+ *
+ * 모든 분기에서 throw하지 않는다 — launch path를 차단하지 않기 위함. 실패는 로그로만 남고
+ * 다음 launch에서 재시도된다.
+ */
+export async function runLaunchTripReconciliation(): Promise<void> {
+  try {
+    const baseUrl = getBackendUrl();
+    if (!baseUrl) {
+      logger.info('skip — ALARM_BACKEND_URL not set');
+      return;
+    }
+
+    const tripToken = await AsyncStorage.getItem(ACTIVE_TRIP_KEY);
+    if (!tripToken) {
+      return;
+    }
+
+    const sentinel = await getTripEndedSentinel();
+    if (sentinel !== null) {
+      logger.info('skip — sentinel already recorded');
+      return;
+    }
+
+    let result;
+    try {
+      result = await fetchTripStatus(tripToken, baseUrl);
+    } catch (e) {
+      // 네트워크 에러는 silent fail — 다음 launch에서 재시도.
+      logger.warn('fetchTripStatus 실패 — 다음 launch에서 재시도', e);
+      return;
+    }
+
+    if (result === null) {
+      // 404/410 — trip이 backend에 이미 없다. active trip 키만 정리.
+      logger.info('trip missing on backend — clear active trip key');
+      await AsyncStorage.removeItem(ACTIVE_TRIP_KEY);
+      return;
+    }
+
+    if (result.status === 'active') {
+      // backend 기준 살아있음 — 디바이스 상태도 그대로 유지.
+      return;
+    }
+
+    // status === 'ended'. silent push miss를 backstop으로 복구.
+    const endedAt = result.endedAt ?? Date.now();
+    const reason = result.endReason ?? 'unknown';
+    logger.info(
+      `trip ended on backend — surface notification reason=${reason} endedAt=${endedAt}`,
+    );
+    await sendTripEndedNotification(reason);
+    await setTripEndedSentinel(endedAt);
+    await AsyncStorage.removeItem(ACTIVE_TRIP_KEY);
+  } catch (e) {
+    logger.warn('reconciliation 실패 (graceful)', e);
+  }
+}
+
+/**
+ * 마운트 시 1회 reconciliation 실행. cold-launch trip-ended backstop.
+ */
+export function useLaunchTripReconciliation(): void {
+  useEffect(() => {
+    void runLaunchTripReconciliation();
+  }, []);
+}


### PR DESCRIPTION
## Summary

PR1(#1340/#1342) trip-ended alert push의 device-side backstop. silent push가 어떤 이유로든 도달하지 못한 killed-app 케이스(권한 변경, push 누락 등)에서 cold-launch 시점에 디바이스가 backend `GET /trips/:tripToken/status`로 명시적으로 상태 확인 + 누락된 user-facing notification/sentinel 복구.

- `src/features/alarm/api/tripStatus.ts` — `fetchTripStatus` 클라이언트. 200 active/ended는 `{status, endedAt, endReason}`, 404/410은 `null` (정리 대상), 네트워크 에러는 throw. backend contract endReason `'destination'`을 device `'destination-arrived'`로 정규화.
- `src/features/alarm/hooks/useLaunchTripReconciliation.ts` — 마운트 1회 reconciliation hook. ACTIVE_TRIP_KEY 부재 / sentinel 기록 있음 / URL 미설정 → skip. `status='ended'` → `sendTripEndedNotification` + `setTripEndedSentinel` + ACTIVE_TRIP_KEY 정리 (`useStateRehydration`이 sentinel을 보고 store reset). `null`(404/410) → ACTIVE_TRIP_KEY 정리만 (notification X). 네트워크 에러 silent fail.
- `app/_layout.tsx` — hook 마운트.

## Acceptance

- [x] `fetchTripStatus` 200 active / 200 ended / 404 / 410 / 5xx / 네트워크 에러 분기 unit 커버.
- [x] backend endReason `'destination'` → device `'destination-arrived'` 정규화 단위 검증.
- [x] reconciliation hook: sentinel 기록 있음 시 fetch skip + notification X.
- [x] reconciliation hook: status='ended' → notification 발사 + sentinel 기록 + active trip clear.
- [x] reconciliation hook: 404/410 → active trip clear만 (notification X).
- [x] reconciliation hook: 네트워크 에러 silent fail (throw 없음, 상태 변경 없음).
- [x] `npm run type-check` PASS.
- [x] `npm run lint` PASS.
- [x] 신규 파일 coverage 100% (lines/funcs/branches/statements) 확인.

## Test plan

- [ ] dev에서 trip 등록 후 alarm-worker 측에서 강제 종료 → 디바이스 kill → 재실행 시 trip-ended notification 1회 발사 + ACTIVE_TRIP_KEY 정리 확인.
- [ ] silent push가 정상 도달한 trip 종료 경우 cold-launch 시 sentinel 기록으로 인해 중복 notification 발사되지 않음 확인.
- [ ] ALARM_BACKEND_URL 미설정 dev 환경에서 launch 시 no-op 확인.

## Notes

- 본 PR worktree 환경에서 `npm test` 실행 시 `widgetStorage` / `stationNotification` 테스트가 33건 실패하나 origin/dev 상태에서도 동일 실패(메모리 `lesson_worktree_test_env_drift.md`의 "격리 worktree 거짓 신호" 패턴). 신규 파일 자체는 100% coverage + 26 PASS. CI 환경에서 재검증 필요.
- Re-reference Closes #1339 — PR1(#1342) 머지로 이미 close됐을 수 있으나 추적용.

Closes #1339