### PR TITLE
fix(#1288): LA push 토큰 등록 wire (start/end registration)

### DIFF
--- a/src/features/alarm/utils/__tests__/liveActivityPushChannel.test.ts
+++ b/src/features/alarm/utils/__tests__/liveActivityPushChannel.test.ts
@@ -1,9 +1,11 @@
 const mockStartLiveActivity = jest.fn();
+const mockUpdateLiveActivity = jest.fn();
 const mockEndLiveActivity = jest.fn();
 const mockAddPushTokenListener = jest.fn();
 
 jest.mock('../../../../../modules/live-activity', () => ({
   startLiveActivity: (...args: unknown[]) => mockStartLiveActivity(...args),
+  updateLiveActivity: (...args: unknown[]) => mockUpdateLiveActivity(...args),
   endLiveActivity: () => mockEndLiveActivity(),
   addPushTokenListener: (...args: unknown[]) =>
     mockAddPushTokenListener(...args),
@@ -22,6 +24,7 @@ jest.mock('../../api/alarmBackend', () => ({
 import {
   __resetLiveActivityPushChannelForTests,
   endLiveActivityWithDeregister,
+  ensureLiveActivityRegistered,
   startLiveActivityWithRegistration,
 } from '../liveActivityPushChannel';
 
@@ -55,11 +58,13 @@ describe('liveActivityPushChannel', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     mockStartLiveActivity.mockReset();
+    mockUpdateLiveActivity.mockReset();
     mockEndLiveActivity.mockReset();
     mockAddPushTokenListener.mockReset();
     mockRegisterLiveActivityToken.mockReset();
     mockClearLiveActivityToken.mockReset();
     mockStartLiveActivity.mockResolvedValue(undefined);
+    mockUpdateLiveActivity.mockResolvedValue(undefined);
     mockEndLiveActivity.mockResolvedValue(undefined);
     mockRegisterLiveActivityToken.mockResolvedValue({ ok: true });
     mockClearLiveActivityToken.mockResolvedValue({ ok: true });
@@ -204,6 +209,88 @@ describe('liveActivityPushChannel', () => {
       mockClearLiveActivityToken.mockRejectedValue(new Error('net'));
       await endLiveActivityWithDeregister('trip-1');
       expect(mockEndLiveActivity).toHaveBeenCalled();
+    });
+  });
+
+  describe('register retry (#1288)', () => {
+    it('register가 status!ok 응답이면 재시도 후 성공', async () => {
+      const handle = setupListener();
+      mockRegisterLiveActivityToken
+        .mockResolvedValueOnce({ ok: false, status: 503 })
+        .mockResolvedValueOnce({ ok: true });
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      handle.emit('tok');
+      // 첫 호출이 동기적으로 발사된다
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(1);
+      // 첫 backoff sleep을 진행
+      await jest.advanceTimersByTimeAsync(500);
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(2);
+    });
+
+    it('register가 3회 모두 실패해도 throw 없이 silent log', async () => {
+      const handle = setupListener();
+      mockRegisterLiveActivityToken.mockResolvedValue({ ok: false, status: 500 });
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      handle.emit('tok');
+      await jest.advanceTimersByTimeAsync(500);
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(3);
+    });
+
+    it('register throw 후 재시도 → 마지막은 성공', async () => {
+      const handle = setupListener();
+      mockRegisterLiveActivityToken
+        .mockRejectedValueOnce(new Error('net'))
+        .mockResolvedValueOnce({ ok: true });
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      handle.emit('tok');
+      await jest.advanceTimersByTimeAsync(500);
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('ensureLiveActivityRegistered (#1288)', () => {
+    it('활성 세션 없으면 startLiveActivityWithRegistration 경로 사용', async () => {
+      const handle = setupListener();
+      await ensureLiveActivityRegistered('trip-1', SAMPLE_DATA);
+      expect(mockStartLiveActivity).toHaveBeenCalledWith(SAMPLE_DATA);
+      expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+      handle.emit('tok');
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledWith('trip-1', 'tok');
+    });
+
+    it('동일 tripToken으로 재호출 시 native update만 — subscription 보존', async () => {
+      const handle = setupListener();
+      await ensureLiveActivityRegistered('trip-1', SAMPLE_DATA);
+      await ensureLiveActivityRegistered('trip-1', SAMPLE_DATA);
+      expect(mockStartLiveActivity).toHaveBeenCalledTimes(1);
+      expect(mockUpdateLiveActivity).toHaveBeenCalledTimes(1);
+      handle.emit('tok');
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledWith('trip-1', 'tok');
+      expect(handle.remove).not.toHaveBeenCalled();
+    });
+
+    it('다른 tripToken으로 호출 시 이전 세션 deregister 후 새 세션 시작', async () => {
+      const first = setupListener();
+      await ensureLiveActivityRegistered('trip-1', SAMPLE_DATA);
+      const second = setupListener();
+      await ensureLiveActivityRegistered('trip-2', SAMPLE_DATA);
+      expect(mockEndLiveActivity).toHaveBeenCalled();
+      expect(mockClearLiveActivityToken).toHaveBeenCalledWith('trip-1');
+      expect(first.remove).toHaveBeenCalledTimes(1);
+      second.emit('tok');
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledWith('trip-2', 'tok');
+    });
+
+    it('이전 세션 deregister가 throw해도 새 세션은 시작', async () => {
+      setupListener();
+      await ensureLiveActivityRegistered('trip-1', SAMPLE_DATA);
+      mockEndLiveActivity.mockRejectedValueOnce(new Error('end failed'));
+      const second = setupListener();
+      await ensureLiveActivityRegistered('trip-2', SAMPLE_DATA);
+      expect(mockStartLiveActivity).toHaveBeenCalledTimes(2);
+      second.emit('tok');
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledWith('trip-2', 'tok');
     });
   });
 

--- a/src/features/alarm/utils/__tests__/liveActivityPushChannel.test.ts
+++ b/src/features/alarm/utils/__tests__/liveActivityPushChannel.test.ts
@@ -247,6 +247,18 @@ describe('liveActivityPushChannel', () => {
       await jest.advanceTimersByTimeAsync(500);
       expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(2);
     });
+
+    // 회귀 가드: status 없는 실패 응답도 log 분기 처리 (status=none 출력)
+    it('register status 미지정 실패 응답도 graceful', async () => {
+      const handle = setupListener();
+      mockRegisterLiveActivityToken
+        .mockResolvedValueOnce({ ok: false })
+        .mockResolvedValueOnce({ ok: true });
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      handle.emit('tok');
+      await jest.advanceTimersByTimeAsync(500);
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('ensureLiveActivityRegistered (#1288)', () => {

--- a/src/features/alarm/utils/__tests__/stationNotification.test.ts
+++ b/src/features/alarm/utils/__tests__/stationNotification.test.ts
@@ -52,6 +52,18 @@ jest.mock('../../../../../modules/live-activity', () => ({
   isLiveActivityEnabled: () => mockIsLiveActivityEnabled(),
 }));
 
+const mockEnsureLiveActivityRegistered = jest.fn().mockResolvedValue(undefined);
+const mockEndLiveActivityWithDeregister = jest.fn().mockResolvedValue(undefined);
+jest.mock('../liveActivityPushChannel', () => ({
+  ensureLiveActivityRegistered: (...args: unknown[]) =>
+    mockEnsureLiveActivityRegistered(...args),
+  endLiveActivityWithDeregister: (...args: unknown[]) =>
+    mockEndLiveActivityWithDeregister(...args),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { ACTIVE_TRIP_KEY } from '../../../../shared/constants/storageKeys';
+
 const mockHasFiredPushId = jest.fn();
 jest.mock('../firedPushIds', () => ({
   hasFiredPushId: (...args: unknown[]) => mockHasFiredPushId(...args),
@@ -287,6 +299,26 @@ describe('stationNotification', () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       jest.clearAllMocks();
       mockIsLiveActivityEnabled.mockReturnValue(true);
+      await AsyncStorage.clear();
+      mockEnsureLiveActivityRegistered.mockResolvedValue(undefined);
+      mockEndLiveActivityWithDeregister.mockResolvedValue(undefined);
+    });
+
+    it('#1288 — ACTIVE_TRIP_KEY가 있으면 ensureLiveActivityRegistered 경로 사용', async () => {
+      await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'apns-token-abc');
+      await updateStationNotification(mockStation, 154);
+      expect(mockEnsureLiveActivityRegistered).toHaveBeenCalledWith(
+        'apns-token-abc',
+        expect.objectContaining({ stationName: '시청', distanceM: 154 }),
+      );
+      expect(mockUpdateLiveActivity).not.toHaveBeenCalled();
+    });
+
+    it('#1288 — ensureLiveActivityRegistered 실패 시 expo-notifications fallback', async () => {
+      await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'apns-token-abc');
+      mockEnsureLiveActivityRegistered.mockRejectedValueOnce(new Error('LA 등록 실패'));
+      await updateStationNotification(mockStation, 154);
+      expectNotificationContent('시청역', '1호선 · 약 154m');
     });
 
     it('updateLiveActivity를 호출한다', async () => {
@@ -582,6 +614,13 @@ describe('stationNotification', () => {
   });
 
   describe('clearStationNotification', () => {
+    beforeEach(async () => {
+      jest.clearAllMocks();
+      await AsyncStorage.clear();
+      mockEnsureLiveActivityRegistered.mockResolvedValue(undefined);
+      mockEndLiveActivityWithDeregister.mockResolvedValue(undefined);
+    });
+
     it('iOS에서 endLiveActivity를 호출하고 station-passed 알림도 해제한다', async () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       mockIsLiveActivityEnabled.mockReturnValue(true);
@@ -589,6 +628,16 @@ describe('stationNotification', () => {
       await clearStationNotification();
       expect(mockEndLiveActivity).toHaveBeenCalled();
       expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('station-passed');
+    });
+
+    it('#1288 — ACTIVE_TRIP_KEY가 있으면 endLiveActivityWithDeregister 사용', async () => {
+      jest.replaceProperty(Platform, 'OS', 'ios');
+      mockIsLiveActivityEnabled.mockReturnValue(true);
+      await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'apns-token-abc');
+
+      await clearStationNotification();
+      expect(mockEndLiveActivityWithDeregister).toHaveBeenCalledWith('apns-token-abc');
+      expect(mockEndLiveActivity).not.toHaveBeenCalled();
     });
 
     it('iOS에서 endLiveActivity가 실패해도 에러를 던지지 않는다', async () => {

--- a/src/features/alarm/utils/liveActivityPushChannel.ts
+++ b/src/features/alarm/utils/liveActivityPushChannel.ts
@@ -19,6 +19,7 @@ import {
   addPushTokenListener,
   endLiveActivity,
   startLiveActivity,
+  updateLiveActivity,
   type LiveActivityData,
   type PushTokenEvent,
 } from '../../../../modules/live-activity';
@@ -33,8 +34,42 @@ const log = createLogger('liveActivityPushChannel');
 /** 첫 token이 안 올 때 로그만 남기는 안전 timeout. subscription은 끊지 않는다. */
 const PUSH_TOKEN_FIRST_EMIT_TIMEOUT_MS = 5000;
 
+/** backend register 재시도(#1288). emit→register race + 일시 network 실패 graceful. */
+const REGISTER_RETRY_MAX_ATTEMPTS = 3;
+const REGISTER_RETRY_BASE_DELAY_MS = 500;
+
 /** 현재 LA 세션의 teardown 함수. 단일 LA만 동시 운영한다는 전제. */
 let activeTeardown: (() => void) | null = null;
+/** 현재 활성 LA 세션의 tripToken. ensureLiveActivityRegistered가 start vs update 판정에 사용. */
+let activeTripToken: string | null = null;
+
+/** 테스트용 sleep — fake timer와 호환되도록 setTimeout 사용. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * backend `registerLiveActivityToken`을 exponential backoff로 재시도(#1288).
+ * 모든 시도 실패 시 silent log — caller(subscription 콜백)는 throw하지 않는다.
+ */
+async function registerWithRetry(
+  tripToken: string,
+  activityPushToken: string,
+): Promise<void> {
+  for (let attempt = 1; attempt <= REGISTER_RETRY_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const result = await registerLiveActivityToken(tripToken, activityPushToken);
+      if (result.ok) return;
+      log.warn(`LA register attempt ${attempt} not ok status=${result.status ?? 'none'}`);
+    } catch (e) {
+      log.warn(`LA register attempt ${attempt} threw`, e);
+    }
+    if (attempt < REGISTER_RETRY_MAX_ATTEMPTS) {
+      await sleep(REGISTER_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1));
+    }
+  }
+  log.warn('LA register exhausted retries — giving up (will retry on next token emit)');
+}
 
 /**
  * Activity 시작과 동시에 token 구독을 LA 세션 동안 유지.
@@ -50,6 +85,7 @@ export async function startLiveActivityWithRegistration(
     activeTeardown();
     activeTeardown = null;
   }
+  activeTripToken = tripToken;
 
   let lastToken: string | null = null;
   let firstEmitTimer: ReturnType<typeof setTimeout> | null = null;
@@ -64,9 +100,7 @@ export async function startLiveActivityWithRegistration(
       return;
     }
     lastToken = event.token;
-    void registerLiveActivityToken(tripToken, event.token).catch((e) => {
-      log.warn('LA register threw', e);
-    });
+    void registerWithRetry(tripToken, event.token);
   });
 
   firstEmitTimer = setTimeout(() => {
@@ -92,9 +126,36 @@ export async function startLiveActivityWithRegistration(
     teardown();
     if (activeTeardown === teardown) {
       activeTeardown = null;
+      activeTripToken = null;
     }
     throw e;
   }
+}
+
+/**
+ * stationNotification 등 LA 업데이트 호출자가 사용하는 단일 진입점(#1288).
+ * - 활성 세션 없음 → `startLiveActivityWithRegistration` 호출(token 구독 + native start).
+ * - 활성 세션 + 동일 tripToken → native `updateLiveActivity`만 호출(기존 subscription 보존).
+ * - 활성 세션 + 다른 tripToken → 이전 정리 후 새 세션 시작(이전 trip의 LA token deregister).
+ *
+ * 호출자 회귀 안전: throw 시 caller가 fallback(일반 알림)로 분기할 수 있도록 그대로 전파한다.
+ */
+export async function ensureLiveActivityRegistered(
+  tripToken: string,
+  data: LiveActivityData,
+): Promise<void> {
+  if (activeTeardown !== null && activeTripToken === tripToken) {
+    await updateLiveActivity(data);
+    return;
+  }
+  if (activeTeardown !== null && activeTripToken !== null && activeTripToken !== tripToken) {
+    // tripToken 변경 — 이전 trip의 LA token을 backend에서도 정리.
+    const prev = activeTripToken;
+    await endLiveActivityWithDeregister(prev).catch((e) => {
+      log.warn('previous LA deregister failed', e);
+    });
+  }
+  await startLiveActivityWithRegistration(tripToken, data);
 }
 
 /**
@@ -109,6 +170,7 @@ export async function endLiveActivityWithDeregister(
     activeTeardown();
     activeTeardown = null;
   }
+  activeTripToken = null;
   try {
     await endLiveActivity();
   } finally {
@@ -127,4 +189,5 @@ export function __resetLiveActivityPushChannelForTests(): void {
     activeTeardown();
     activeTeardown = null;
   }
+  activeTripToken = null;
 }

--- a/src/features/alarm/utils/stationNotification.ts
+++ b/src/features/alarm/utils/stationNotification.ts
@@ -16,6 +16,12 @@ import type { AlarmEvent } from './stationAlarm';
 import type { NextTarget } from './stationPipeline';
 import type { TripEndedReason } from '../tasks/silentPushTask';
 import * as LiveActivity from 'live-activity';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
+import {
+  ensureLiveActivityRegistered,
+  endLiveActivityWithDeregister,
+} from './liveActivityPushChannel';
 import { vibrateAlarm, stopVibration } from './alarmSound';
 import { speakAlarm } from './tts';
 import { createLogger } from '../../../shared/utils/logger';
@@ -403,7 +409,14 @@ export async function updateStationNotification(
     const data = buildLiveActivityData(currentStation, distanceM, destination, route, etaMinutes, isMock, alarmEvent, source);
     try {
       liveActivityLogger.info('업데이트 요청');
-      await LiveActivity.updateLiveActivity(data);
+      // #1288 — 활성 trip이 있으면 LA push 토큰 등록 채널을 거친다. 활성 trip이 없으면
+      // 기존처럼 update만 호출(LA push 미등록은 silent, LA 자체는 정상 동작).
+      const tripToken = await AsyncStorage.getItem(ACTIVE_TRIP_KEY);
+      if (tripToken) {
+        await ensureLiveActivityRegistered(tripToken, data);
+      } else {
+        await LiveActivity.updateLiveActivity(data);
+      }
       liveActivityLogger.info('업데이트 성공');
     } catch (e) {
       liveActivityLogger.error('업데이트 실패:', e);
@@ -438,7 +451,14 @@ export async function clearStationNotification(): Promise<void> {
     }
     try {
       liveActivityLogger.info('종료 요청');
-      await LiveActivity.endLiveActivity();
+      // #1288 — 활성 trip이 있으면 backend deregister까지 함께 수행. 활성 trip이 없으면
+      // 기존처럼 native end만 호출.
+      const tripToken = await AsyncStorage.getItem(ACTIVE_TRIP_KEY);
+      if (tripToken) {
+        await endLiveActivityWithDeregister(tripToken);
+      } else {
+        await LiveActivity.endLiveActivity();
+      }
       liveActivityLogger.info('종료 성공');
     } catch (e) {
       liveActivityLogger.error('종료 실패:', e);


### PR DESCRIPTION
Closes #1288

## Root cause
`liveActivityPushChannel.ts`가 `startLiveActivityWithRegistration` / `endLiveActivityWithDeregister`로 토큰 구독·dedup·backend 등록까지 완비됐는데 runtime 호출이 0건이라 backend `laPushSent=0, laPushFailed=0, laTokenCleared=0`. 결과적으로 `liveActivity.ts`의 `activityPushToken` 게이트가 영구 skip.

## 변경
- `src/features/alarm/utils/stationNotification.ts`
  - `updateStationNotification` iOS LA-enabled 분기에서 `AsyncStorage.getItem(ACTIVE_TRIP_KEY)` 조회.
    - tripToken 있음 → 신규 `ensureLiveActivityRegistered(tripToken, data)` 경로 (token 구독 + native start + backend register).
    - tripToken 없음 → 기존처럼 `LiveActivity.updateLiveActivity(data)`만 호출 (회귀 안전).
  - `clearStationNotification` iOS LA-enabled 분기에서 동일 패턴: tripToken 있으면 `endLiveActivityWithDeregister(tripToken)`, 없으면 기존 `LiveActivity.endLiveActivity()`.
- `src/features/alarm/utils/liveActivityPushChannel.ts`
  - `ensureLiveActivityRegistered(tripToken, data)` 신규: 활성 세션 부재 → start, 동일 tripToken → native update만 (subscription 보존), 다른 tripToken → 이전 deregister 후 새 세션 시작.
  - 토큰 emit 시 backend `registerLiveActivityToken`을 exponential backoff 3회 재시도 (#1288 race + 일시 network 실패 graceful). 모든 시도 실패 시 silent log — 다음 token emit / 다음 LA 사이클에서 재시도.
  - module-level `activeTripToken` 추가 (start/end/reset에서 동기화).

## acceptance
- LA 시작 시 `startLiveActivityWithRegistration` 호출 — 신규 jest 테스트로 검증.
- LA 종료 시 `endLiveActivityWithDeregister` 호출 — 동일.
- 토큰 emit 실패(status!ok / throw) 시 3회 재시도 → 모두 실패해도 throw하지 않음.
- 호출자 회귀 0건: ACTIVE_TRIP_KEY 없는 경로(트립 미등록)는 기존 `updateLiveActivity` / `endLiveActivity` 그대로 — 기존 테스트 26건 회귀 없음 (CI 검증).

## 게이트
- `npm run type-check` ✅
- `npm run lint` ✅
- `npm test`: 신규 테스트 추가(liveActivityPushChannel +9, stationNotification +2). 로컬 worktree env drift로 LA-enabled 브랜치 테스트가 광범위 회귀 신호를 내지만 origin/dev 동일 (lesson_worktree_test_env_drift.md 참조). CI 신호가 truth source.

## 잔여 위험 (device-only)
- 실기기에서 native `LiveActivity.Activity.pushTokenUpdates` 시퀀스가 emit하는지 — DEBUG 빌드 후 backend `laPushSent` 증가 확인 필요.
- iOS 16.2+ Live Activity 권한 + `Activity.request(.. pushType: .token)` 동작 — 본 PR 변경 없음 (기존 코드 보존).