### PR TITLE
fix(#1345): useStickyStation same-lock guard로 emit cascade 차단

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useStickyStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useStickyStation.test.ts
@@ -16,6 +16,7 @@ import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { useStickyStation, type StickyFixInput, type StickyMotionInput } from '../useStickyStation';
 import {
   STICKY_DEGRADED_UNLOCK_COUNT,
+  STICKY_LOCK_CONSECUTIVE_COUNT,
   STICKY_TTL_MS,
 } from '../../../../shared/constants/stickyStation';
 import { STICKY_STATION_KEY } from '../../../../shared/constants/storageKeys';
@@ -433,5 +434,152 @@ describe('useStickyStation (#876)', () => {
     rerender({ fix: fixAt(null) });
     rerender({ fix: fixAt(null) });
     expect(result.current.locked).toBeNull();
+  });
+
+  // #1345 — same-lock guard. lock된 상태에서 같은 candidate가 N회 도달할 때마다 발생하던
+  // emit/write/setLocked cascade(9시간 ~16만회 발화) 차단. lockedAtRef는 silent 갱신.
+  describe('#1345 — same-lock guard (emit cascade 차단)', () => {
+    // lock 직후 spy를 clear해서 후속 cascade만 측정한다.
+    // pushSpy/setSpy는 spy 객체가 누적될 수 있어 매 it 시작 시 mockClear로 초기화 보장.
+    const lockSeoulAndClear = async (
+      pushSpy: jest.SpyInstance,
+      setSpy: jest.SpyInstance,
+    ) => {
+      pushSpy.mockClear();
+      setSpy.mockClear();
+      const hook = renderSticky({ fix: fixAt(seoul) });
+      await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+      hook.rerender({ fix: fixAt(seoul) });
+      hook.rerender({ fix: fixAt(seoul) });
+      await waitFor(() => expect(hook.result.current.locked?.id).toBe(seoul.id));
+      // 첫 lock의 emit 1회 검증 후 spy clear (이후 측정은 cascade만).
+      expect(
+        pushSpy.mock.calls.filter(
+          ([entry]) => entry?.kind === 'sticky' && entry?.event === 'locked',
+        ),
+      ).toHaveLength(1);
+      pushSpy.mockClear();
+      setSpy.mockClear();
+      return hook;
+    };
+
+    it('lock 후 같은 station 후속 N회 → emit/write/setLocked 추가 0회', async () => {
+      const pushSpy = jest.spyOn(fusionDebugBuffer, 'pushFusionDebugEntry');
+      const setSpy = jest.spyOn(AsyncStorage, 'setItem');
+      const { result, rerender } = await lockSeoulAndClear(pushSpy, setSpy);
+      // lock 직후 reference로 stable 비교용 captured.
+      const stationRef = result.current.locked;
+
+      // 같은 candidate를 N*2회 추가 → 같은 lock이 유지되고 cascade emit 0회.
+      for (let i = 0; i < STICKY_LOCK_CONSECUTIVE_COUNT * 2; i += 1) {
+        rerender({ fix: fixAt(seoul) });
+      }
+      expect(result.current.locked).toBe(stationRef); // setLocked 안 호출 → 같은 ref
+      const lockedEvents = pushSpy.mock.calls.filter(
+        ([entry]) => entry?.kind === 'sticky' && entry?.event === 'locked',
+      );
+      expect(lockedEvents).toHaveLength(0);
+      const setItemCalls = setSpy.mock.calls.filter(
+        ([key]) => key === STICKY_STATION_KEY,
+      );
+      expect(setItemCalls).toHaveLength(0);
+    });
+
+    it('lock 후 신호 단절(나쁜 fix) → 같은 station 복귀 N회 → cascade 0회 (재lock emit 없음)', async () => {
+      const pushSpy = jest.spyOn(fusionDebugBuffer, 'pushFusionDebugEntry');
+      const setSpy = jest.spyOn(AsyncStorage, 'setItem');
+      const { result, rerender } = await lockSeoulAndClear(pushSpy, setSpy);
+
+      // 신호 단절(accuracy>50m) → candidateCountRef 리셋.
+      rerender({ fix: fixAt(seoul, { accuracy: 80 }) });
+      // 같은 station 좋은 fix N회 복귀 → guard 작동, emit 추가 0회.
+      for (let i = 0; i < STICKY_LOCK_CONSECUTIVE_COUNT; i += 1) {
+        rerender({ fix: fixAt(seoul) });
+      }
+      expect(result.current.locked?.id).toBe(seoul.id);
+      const lockedEvents = pushSpy.mock.calls.filter(
+        ([entry]) => entry?.kind === 'sticky' && entry?.event === 'locked',
+      );
+      expect(lockedEvents).toHaveLength(0);
+      const setItemCalls = setSpy.mock.calls.filter(
+        ([key]) => key === STICKY_STATION_KEY,
+      );
+      expect(setItemCalls).toHaveLength(0);
+    });
+
+    it('same-lock guard에서 lockedAtRef silent 갱신 → TTL renewal 동작 (30분 직전엔 unlock 안 됨)', async () => {
+      const pushSpy = jest.spyOn(fusionDebugBuffer, 'pushFusionDebugEntry');
+      const setSpy = jest.spyOn(AsyncStorage, 'setItem');
+      const realNow = Date.now();
+      jest.setSystemTime(realNow);
+      const { result, rerender } = await lockSeoulAndClear(pushSpy, setSpy);
+
+      // TTL 직전 시점(29분)에서 같은 station N회 → guard가 lockedAtRef를 갱신.
+      jest.setSystemTime(realNow + STICKY_TTL_MS - 60_000);
+      for (let i = 0; i < STICKY_LOCK_CONSECUTIVE_COUNT; i += 1) {
+        rerender({ fix: fixAt(seoul) });
+      }
+      // renew 직후로부터 29분 경과(원 lockedAt 기준 ~58분) → renewal이 동작했다면 unlock 안 됨.
+      jest.setSystemTime(realNow + STICKY_TTL_MS * 2 - 120_000);
+      rerender({ fix: fixAt(seoul) });
+      expect(result.current.locked?.id).toBe(seoul.id);
+      const ttlEvents = pushSpy.mock.calls.filter(
+        ([entry]) => entry?.kind === 'sticky' && entry?.event === 'unlocked-ttl',
+      );
+      expect(ttlEvents).toHaveLength(0);
+    });
+
+    it('same-lock guard 후 better-fix(다른 station N회) → 기존 unlock-better-fix + 새 lock 정상 emit', async () => {
+      const pushSpy = jest.spyOn(fusionDebugBuffer, 'pushFusionDebugEntry');
+      const setSpy = jest.spyOn(AsyncStorage, 'setItem');
+      const { result, rerender } = await lockSeoulAndClear(pushSpy, setSpy);
+
+      // 같은 station N회 (guard 작동, cascade 차단)
+      for (let i = 0; i < STICKY_LOCK_CONSECUTIVE_COUNT; i += 1) {
+        rerender({ fix: fixAt(seoul) });
+      }
+      // 다른 station(seoulNearby) N회 → 정상 better-fix 갱신.
+      for (let i = 0; i < STICKY_LOCK_CONSECUTIVE_COUNT; i += 1) {
+        rerender({ fix: fixAt(seoulNearby) });
+      }
+      await waitFor(() => expect(result.current.locked?.id).toBe(seoulNearby.id));
+      const betterFixEvents = pushSpy.mock.calls.filter(
+        ([entry]) => entry?.kind === 'sticky' && entry?.event === 'unlocked-better-fix',
+      );
+      expect(betterFixEvents).toHaveLength(1);
+      const newLockedEvents = pushSpy.mock.calls.filter(
+        ([entry]) =>
+          entry?.kind === 'sticky' && entry?.event === 'locked' && entry?.stationName === '서울역인접',
+      );
+      expect(newLockedEvents).toHaveLength(1);
+    });
+
+    it('same-lock guard에서 movedAwayCountRef 리셋 → 이전 누적이 leak 안 됨', async () => {
+      const pushSpy = jest.spyOn(fusionDebugBuffer, 'pushFusionDebugEntry');
+      const setSpy = jest.spyOn(AsyncStorage, 'setItem');
+      const { result, rerender } = await lockSeoulAndClear(pushSpy, setSpy);
+
+      // 저품질 far fix를 (N-1)회 — moved-away 누적은 임계 미만.
+      const movedFixes = [gunja, konkuk];
+      for (let i = 0; i < STICKY_DEGRADED_UNLOCK_COUNT - 1; i += 1) {
+        rerender({ fix: degradedFixAt(movedFixes[i % movedFixes.length]) });
+      }
+      expect(result.current.locked?.id).toBe(seoul.id);
+
+      // 같은 station(seoul) 좋은 fix N회 → guard 발동 시 movedAwayCountRef = 0 으로 리셋.
+      for (let i = 0; i < STICKY_LOCK_CONSECUTIVE_COUNT; i += 1) {
+        rerender({ fix: fixAt(seoul) });
+      }
+
+      // 다시 저품질 far fix를 (N-1)회 — 누적이 leak되지 않았다면 임계 미만이라 unlock 안 됨.
+      for (let i = 0; i < STICKY_DEGRADED_UNLOCK_COUNT - 1; i += 1) {
+        rerender({ fix: degradedFixAt(movedFixes[i % movedFixes.length]) });
+      }
+      expect(result.current.locked?.id).toBe(seoul.id);
+      const movedAwayEvents = pushSpy.mock.calls.filter(
+        ([entry]) => entry?.kind === 'sticky' && entry?.event === 'unlocked-moved-away',
+      );
+      expect(movedAwayEvents).toHaveLength(0);
+    });
   });
 });

--- a/src/features/nearest-station/hooks/__tests__/useStickyStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useStickyStation.test.ts
@@ -463,6 +463,21 @@ describe('useStickyStation (#876)', () => {
       return hook;
     };
 
+    // cascade 차단 검증: locked emit 0 + AsyncStorage setItem 0.
+    const expectStickyCascadeSuppressed = (
+      pushSpy: jest.SpyInstance,
+      setSpy: jest.SpyInstance,
+    ) => {
+      const lockedEvents = pushSpy.mock.calls.filter(
+        ([entry]) => entry?.kind === 'sticky' && entry?.event === 'locked',
+      );
+      expect(lockedEvents).toHaveLength(0);
+      const setItemCalls = setSpy.mock.calls.filter(
+        ([key]) => key === STICKY_STATION_KEY,
+      );
+      expect(setItemCalls).toHaveLength(0);
+    };
+
     it('lock 후 같은 station 후속 N회 → emit/write/setLocked 추가 0회', async () => {
       const pushSpy = jest.spyOn(fusionDebugBuffer, 'pushFusionDebugEntry');
       const setSpy = jest.spyOn(AsyncStorage, 'setItem');
@@ -475,14 +490,7 @@ describe('useStickyStation (#876)', () => {
         rerender({ fix: fixAt(seoul) });
       }
       expect(result.current.locked).toBe(stationRef); // setLocked 안 호출 → 같은 ref
-      const lockedEvents = pushSpy.mock.calls.filter(
-        ([entry]) => entry?.kind === 'sticky' && entry?.event === 'locked',
-      );
-      expect(lockedEvents).toHaveLength(0);
-      const setItemCalls = setSpy.mock.calls.filter(
-        ([key]) => key === STICKY_STATION_KEY,
-      );
-      expect(setItemCalls).toHaveLength(0);
+      expectStickyCascadeSuppressed(pushSpy, setSpy);
     });
 
     it('lock 후 신호 단절(나쁜 fix) → 같은 station 복귀 N회 → cascade 0회 (재lock emit 없음)', async () => {
@@ -497,14 +505,7 @@ describe('useStickyStation (#876)', () => {
         rerender({ fix: fixAt(seoul) });
       }
       expect(result.current.locked?.id).toBe(seoul.id);
-      const lockedEvents = pushSpy.mock.calls.filter(
-        ([entry]) => entry?.kind === 'sticky' && entry?.event === 'locked',
-      );
-      expect(lockedEvents).toHaveLength(0);
-      const setItemCalls = setSpy.mock.calls.filter(
-        ([key]) => key === STICKY_STATION_KEY,
-      );
-      expect(setItemCalls).toHaveLength(0);
+      expectStickyCascadeSuppressed(pushSpy, setSpy);
     });
 
     it('same-lock guard에서 lockedAtRef silent 갱신 → TTL renewal 동작 (30분 직전엔 unlock 안 됨)', async () => {

--- a/src/features/nearest-station/hooks/useStickyStation.ts
+++ b/src/features/nearest-station/hooks/useStickyStation.ts
@@ -282,6 +282,18 @@ export function useStickyStation(
 
     if (candidateCountRef.current < STICKY_LOCK_CONSECUTIVE_COUNT) return;
 
+    // Same-lock guard (#1345): 같은 station 재lock은 no-op.
+    // useNearestStation:449-462 inline object literal로 fix/motion ref가 매 렌더 새로 생성돼
+    // effect가 매번 실행되고, locked 상태에서 같은 candidate가 N회 도달할 때마다
+    // emit/write/setLocked cascade가 발생(9시간 ~16만회). lockedAtRef는 TTL renewal 의도로
+    // silent 갱신하고 카운터만 리셋해 cascade는 차단한다.
+    if (locked && locked.id === candidate.station.id) {
+      lockedAtRef.current = now;
+      candidateCountRef.current = 0;
+      movedAwayCountRef.current = 0;
+      return;
+    }
+
     // N회 연속 좋은 fix 도달. lock 신규 생성 또는 better-fix로 갱신.
     if (locked && locked.id !== candidate.station.id) {
       emitMetric('unlocked-better-fix', locked, fixMeta);

--- a/src/features/nearest-station/hooks/useStickyStation.ts
+++ b/src/features/nearest-station/hooks/useStickyStation.ts
@@ -287,7 +287,7 @@ export function useStickyStation(
     // effect가 매번 실행되고, locked 상태에서 같은 candidate가 N회 도달할 때마다
     // emit/write/setLocked cascade가 발생(9시간 ~16만회). lockedAtRef는 TTL renewal 의도로
     // silent 갱신하고 카운터만 리셋해 cascade는 차단한다.
-    if (locked && locked.id === candidate.station.id) {
+    if (locked?.id === candidate.station.id) {
       lockedAtRef.current = now;
       candidateCountRef.current = 0;
       movedAwayCountRef.current = 0;


### PR DESCRIPTION
## Closes #1345 (Epic #1204)

## 문제
9시간 trip 후 사용자 발열·배터리 빠른 소모. DebugModal FUSION LOG에서 `sticky:locked | 용마산(7) acc=6m`이 **초당 5~8회 발화** 확인. 9시간 평균 5/sec = **~16만회**.

## Root cause
- `useNearestStation.ts:449-462` — `useStickyStation`에 inline object literal 전달 → 매 렌더마다 새 reference.
- `useStickyStation.ts` 평가 effect는 `[fix, motion, locked, ...]` 의존성으로 매 렌더 실행됨.
- 같은 candidate가 N회 도달할 때마다 `count = 0` 리셋 후 `emit('locked')` + `AsyncStorage.setItem` + `logger.info` + `setLocked` cascade가 3 렌더마다 반복.

## 변경
**선택지 b — sticky 내부 same-lock guard (권장안)**

`useStickyStation.ts` count≥N 도달 분기 진입 시 `locked && locked.id === candidate.station.id`면:
- `lockedAtRef.current = now` (TTL renewal 보존 — silent 갱신)
- `candidateCountRef.current = 0` (다음 N 카운트 후 재평가 가능)
- `movedAwayCountRef.current = 0` (leak 방지)
- `emit` / `writePersistedLock` / `setLocked` / `logger.info` 모두 skip → early return

기존 분기(신규 lock / better-fix 갱신) 동작 유지. UX 변화 0.

**옵션 a (inline obj useMemo)는 본 PR 범위 밖**. `useNearestStation:449-462` inline literal은 별 follow-up.

## Acceptance check
- [x] 단위: 같은 station이 candidate로 계속 들어와도 `emitMetric('locked')`은 첫 lock 시 1회만, 이후 추가 호출 0회.
- [x] 단위: 다른 station 후보가 N회 연속이면 기존대로 `unlocked-better-fix` + 새 `locked` emit.
- [x] 단위: GPS 신호 단절(나쁜 fix) 후 같은 station으로 복귀해도 cascade 0회 (same-lock guard 작동).
- [x] 단위: same-lock guard에서 `lockedAtRef`만 silent 갱신 → TTL renewal 의도 보존.
- [x] 단위: `movedAwayCountRef` 리셋 → 이전 누적이 leak 안 됨.
- [x] 커버리지 100% (useStickyStation.ts).
- [ ] 실기기: 정지 상태 5분간 fusion log에 `sticky:locked` 0건 (사용자 검증 필요).

## 회귀 가드
- 기존 `useStickyStation.test.ts` 33개 케이스 모두 통과(unlock distance/motion/ttl/better-fix/moved-away, hydrate, releaseLock, D6 등).
- `useNearestStation.test.ts` 72개 케이스 모두 통과.

## 게이트
- type-check: PASS
- lint: PASS  
- `useStickyStation.ts` 커버리지 100% (statements/branches/funcs/lines)

## 트레이드오프
- UX 변화 0. fusion 결과 동일, 단순 cascade 차단.
- TTL renewal 의도 보존(silent 갱신 분리).

## 참고
- Epic #1204
- 메모리: project_2026_06_16_sticky_cascade (사용자 보유)
- 후속(β, 본 PR 범위 외): 좀비 `tba:` 알람 + `tripStartedAt` 9시간 잔존 — 필드검증 evidence 후 별 이슈.