### PR TITLE
feat(#1346): DebugModal share SSOT + setDestination caller trace

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -312,7 +312,23 @@ function buildGpsRows(args: {
   ];
 }
 
-function buildDumpText(args: {
+/**
+ * #1346 — Share dump 섹션 SSOT.
+ *
+ * 변경 전: `buildDumpText` 함수 본체에 섹션 11개가 하드코딩 → 새 섹션 추가 시 매번 함수를
+ *   고쳐야 하고, fusion log처럼 신규 buffer가 누락된 게 사고 후에야 발견됨.
+ * 변경 후: 각 섹션 builder를 함수로 분리하고 `SHARE_SECTIONS`에 등록. 새 buffer를 추가하면
+ *   1) builder 함수 작성 → 2) 이 배열에 한 줄 등록만 하면 dump/UI 양쪽에 자동 노출된다.
+ *
+ * 각 builder는 `(args) => string[]` — 빈 섹션(예: Gates에 suppressed reason 0건)이면 빈
+ * 배열을 반환해 호출부가 헤더 자체를 생략한다. 출력 텍스트 포맷은 기존과 1:1로 일치한다.
+ */
+
+/**
+ * 공유 dump의 단일 args 타입. SSOT 배열의 모든 builder가 같은 args를 받는다.
+ * 새 섹션이 의존하는 필드는 여기에 optional로 추가하면 된다.
+ */
+interface BuildDumpArgs {
   userLocation: { lat: number; lng: number } | null;
   speedMps: number | null;
   accuracyMeters: number | null;
@@ -349,47 +365,58 @@ function buildDumpText(args: {
   fusionDetection?: FusionDetectionSummary | null;
   trip?: TripDebugState | null;
   sleep?: SleepDebugState | null;
-}): string {
-  const lines: string[] = [];
-  // SonarCloud S7778: 인접한 정적 push 호출은 다인자 단일 호출로 묶는다.
+  /**
+   * #1346 — Fusion log 채널을 share 텍스트에도 포함하기 위해 entries를 명시 주입.
+   * fusionDebugBuffer는 module-level singleton이지만 함수 순수성 유지를 위해 인자로 받는다.
+   * 미전달 시 (empty)로 출력 — 단위 테스트에서 fusion log를 다루지 않는 경우 호환.
+   */
+  fusionLog?: readonly FusionDebugEntry[];
+}
+
+/** dump 본체에서 사용하는 single builder 시그니처 — 본문 줄 배열을 반환. */
+type SectionBuilder = (args: BuildDumpArgs) => string[];
+
+function buildGpsSection(args: BuildDumpArgs): string[] {
   // #852: watch 구독 상태 + 마지막 fix 시각. 'bg'면 watch가 정지된 상태(silent push wake 등).
   // #853: fused speed signal. userLocation 있는 경우만 라인 노출, 미전달 시 NO_FUSED_SIGNAL_LABEL.
   // 호출자 호환을 위해 두 필드 모두 optional — 미전달 시 'fg'/(never)/(no fused signal)로 표기.
-  const gpsLines: string[] = [];
+  const lines: string[] = [];
   if (args.userLocation) {
     const fusedDump = args.fusedSpeed
       ? `${args.fusedSpeed.kmh.toFixed(1)} km/h (${args.fusedSpeed.source})`
       : NO_FUSED_SIGNAL_LABEL;
-    gpsLines.push(
+    lines.push(
       `lat=${args.userLocation.lat}, lng=${args.userLocation.lng}, speed=${args.speedMps ?? '-'} m/s, accuracy=${args.accuracyMeters ?? '-'} m`,
       `fused=${fusedDump}`,
     );
   } else {
-    gpsLines.push('(no location)');
+    lines.push('(no location)');
   }
   lines.push(
-    `[Subway debug] ${new Date().toISOString()}`,
-    '',
-    '## GPS',
-    ...gpsLines,
     `state=${args.gpsActive ?? 'fg'}, lastFix=${formatClockTimeWithSeconds(args.lastFixAtMs ?? null)}`,
     `subsurface=${formatOptionalBool(args.barometerSubsurface)}`,
-    '',
-    '## Nearest',
+  );
+  return lines;
+}
+
+function buildNearestSection(args: BuildDumpArgs): string[] {
+  const lines: string[] = [
     args.nearestName
       ? `${args.nearestName} · ${args.nearestDistanceM ?? '-'} m`
       : '(no nearest station)',
-  );
+  ];
   if (args.variants.length > 0) {
     lines.push(`variants: ${args.variants.join(', ')}`);
   }
-  lines.push(
-    '',
-    '## Fusion',
+  return lines;
+}
+
+function buildFusionSection(args: BuildDumpArgs): string[] {
+  const lines: string[] = [
     `confidence=${args.fusion.confidence}, source=${args.fusion.source}`,
     `fused: ${args.fusion.fusedLabel}`,
     `gps:   ${args.fusion.gpsLabel}`,
-  );
+  ];
   if (args.fusion.differs) lines.push('(fused != gps)');
   if (args.fusion.candidateTrains) {
     lines.push(
@@ -401,58 +428,133 @@ function buildDumpText(args: {
     `tier=${formatOptionalString(args.fusionDetection?.tier)}`,
     `signalMask=${formatOptionalString(args.fusionDetection?.signalMask)}`,
   );
-  // #1215 (D9) — Trip 섹션
-  lines.push(
-    '',
-    '## Trip',
+  return lines;
+}
+
+function buildTripSection(args: BuildDumpArgs): string[] {
+  return [
     `lockless=${formatOptionalBool(args.trip?.lockless)}`,
     `tripStartedAt=${formatOptionalTs(args.trip?.tripStartedAt ?? null)}`,
     `currentHopIndex=${formatOptionalNumber(args.trip?.currentHopIndex)}`,
     `route hop count=${formatOptionalNumber(args.trip?.routeHopCount ?? null)}`,
-  );
-  // #1215 (D9) — Sleep 섹션
+  ];
+}
+
+function buildSleepSection(args: BuildDumpArgs): string[] {
   const sleepModeText = args.sleep ? (args.sleep.sleepMode ? 'on' : 'off') : UNKNOWN_LABEL;
-  lines.push(
-    '',
-    '## Sleep',
+  return [
     `sleepMode=${sleepModeText}`,
     `firstHopApproaching=${formatOptionalBool(args.sleep?.firstHopApproaching)}`,
-  );
-  lines.push('', '## Arrival', args.arrivalSummary);
+  ];
+}
+
+function buildArrivalSection(args: BuildDumpArgs): string[] {
+  const lines: string[] = [args.arrivalSummary];
   if (args.isMock) lines.push('(MOCK)');
-  lines.push('', '## Silent Push');
-  for (const { dumpKey, value } of silentPushDiagRows(
+  return lines;
+}
+
+function buildSilentPushSection(args: BuildDumpArgs): string[] {
+  return silentPushDiagRows(
     args.silentPush,
     args.logs,
     args.locklessOn ?? false,
     args.lowPowerMode ?? false,
-  )) {
-    lines.push(`${dumpKey}=${value}`);
-  }
-  lines.push('');
+  ).map(({ dumpKey, value }) => `${dumpKey}=${value}`);
+}
+
+function buildScheduledQueueSection(args: BuildDumpArgs): string[] {
   // #756: 사용자가 Refresh 안 했으면 dump 섹션 자체를 "(not loaded)"로 명시해
   // "비어있음"과 "load 안 함"을 dump 텍스트만 보고도 구분 가능하게.
   // optional 필드 — undefined 도 null 과 동일 처리.
-  if (args.scheduledDump == null) {
-    lines.push('## Scheduled queue', '(not loaded)');
-  } else {
-    lines.push(
-      `## Scheduled queue (${args.scheduledDump.length})`,
-      ...args.scheduledDump.map(formatScheduledNotificationLine),
-    );
-  }
-  lines.push('');
-  // #1019 — ## Gates
+  if (args.scheduledDump == null) return ['(not loaded)'];
+  return args.scheduledDump.map(formatScheduledNotificationLine);
+}
+
+function buildGatesSection(args: BuildDumpArgs): string[] {
+  // #1019 — suppressed reason 0건이면 빈 배열 → 호출부에서 헤더 자체 생략.
   const reasonLine = formatReasonCountsLine(args.logs);
-  if (reasonLine) {
-    lines.push('## Gates', reasonLine, '');
-  }
-  lines.push(`## Alarm log (${args.logs.length})`);
+  return reasonLine ? [reasonLine] : [];
+}
+
+function buildAlarmLogSection(args: BuildDumpArgs): string[] {
+  const lines: string[] = [];
   // #564 — source별 카운트 헤더(UI와 동일 포매터 공유). 빈 문자열이면 헤더 생략.
   const sourcesLine = formatSourceCountsLine(args.logs);
   if (sourcesLine) lines.push(`sources: ${sourcesLine}`);
   for (const entry of [...args.logs].reverse()) {
     lines.push(formatLogLine(entry));
+  }
+  return lines;
+}
+
+/**
+ * #1346 — Fusion log 섹션. 빈 buffer일 때 (empty)로 명시 출력해 "한 번도 push 안 됨"과
+ * "load 안 함"을 구분한다(scheduled queue 컨벤션 따라).
+ */
+function buildFusionLogSection(args: BuildDumpArgs): string[] {
+  const entries = args.fusionLog ?? [];
+  if (entries.length === 0) return ['(empty)'];
+  // 최신이 위로 — Alarm log와 동일 정렬.
+  return [...entries].reverse().map(formatFusionDebugLine);
+}
+
+/**
+ * #1346 — Share dump SSOT.
+ *
+ * 출력 형식: `## ${title}` + 본문 줄 + 다음 섹션 사이 빈 줄.
+ *
+ * suffix 옵션:
+ *  - `suffix: '(scheduledDump-count)'` 처럼 dynamic 카운트를 헤더에 붙이는 섹션은
+ *    builder가 본문만 만들고, 헤더 suffix는 별도 함수가 계산한다(섹션 본체에 dependency 안 흘림).
+ *
+ * include 옵션:
+ *  - Gates 같이 빈 본문이면 헤더까지 생략해야 하는 섹션은 `omitIfEmpty: true` 지정.
+ */
+interface ShareSectionSpec {
+  title: string;
+  build: SectionBuilder;
+  /** dynamic 헤더 suffix(예: 카운트). 미정의 시 헤더는 title 그대로. */
+  suffix?: (args: BuildDumpArgs) => string;
+  /** 본문이 빈 배열이면 헤더까지 출력 안 함 (Gates). 기본 false — 빈 본문도 헤더 노출. */
+  omitIfEmpty?: boolean;
+}
+
+const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
+  { title: 'GPS', build: buildGpsSection },
+  { title: 'Nearest', build: buildNearestSection },
+  { title: 'Fusion', build: buildFusionSection },
+  { title: 'Trip', build: buildTripSection },
+  { title: 'Sleep', build: buildSleepSection },
+  { title: 'Arrival', build: buildArrivalSection },
+  { title: 'Silent Push', build: buildSilentPushSection },
+  {
+    title: 'Scheduled queue',
+    build: buildScheduledQueueSection,
+    // null/undefined면 카운트 없음, 그 외 N건은 헤더에 `(N)` suffix.
+    suffix: (args) => (args.scheduledDump == null ? '' : ` (${args.scheduledDump.length})`),
+  },
+  { title: 'Gates', build: buildGatesSection, omitIfEmpty: true },
+  {
+    title: 'Alarm log',
+    build: buildAlarmLogSection,
+    suffix: (args) => ` (${args.logs.length})`,
+  },
+  // #1346 — fusion log를 share에 포함. 누락 시 sticky cascade 같은 회귀를 사후 재구성 불가.
+  {
+    title: 'Fusion log',
+    build: buildFusionLogSection,
+    suffix: (args) => ` (${args.fusionLog?.length ?? 0})`,
+  },
+];
+
+function buildDumpText(args: BuildDumpArgs): string {
+  const lines: string[] = [`[Subway debug] ${new Date().toISOString()}`];
+  for (const spec of SHARE_SECTIONS) {
+    const body = spec.build(args);
+    if (spec.omitIfEmpty && body.length === 0) continue;
+    const suffix = spec.suffix ? spec.suffix(args) : '';
+    lines.push('', `## ${spec.title}${suffix}`, ...body);
   }
   return lines.join('\n');
 }
@@ -731,6 +833,8 @@ function DebugModalInner({
       fusionDetection,
       trip,
       sleep,
+      // #1346 — fusion log entries를 share에 포함. sticky cascade 같은 회귀 사후 재구성용.
+      fusionLog: fusionLogs,
     });
     void Share.share({ message });
   }, [
@@ -760,6 +864,8 @@ function DebugModalInner({
     fusionDetection,
     trip,
     sleep,
+    // #1346 — fusion log 신규 캡쳐.
+    fusionLogs,
   ]);
 
   return (

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -2176,6 +2176,172 @@ describe('DebugModal — Gates 섹션 (#1025)', () => {
   });
 });
 
+// #1346 — Share build SSOT. 모든 섹션이 한 배열에서 enumerate되므로 누락 없이 출력된다.
+describe('DebugModal share SSOT (#1346)', () => {
+  // outer scope factory — SonarCloud nested function 회피.
+  type DumpArgs = Parameters<typeof __test__.buildDumpText>[0];
+  const ssotBaseline: DumpArgs = {
+    userLocation: null,
+    speedMps: null,
+    accuracyMeters: null,
+    nearestName: null,
+    nearestDistanceM: null,
+    variants: [],
+    fusion: {
+      confidence: 'gps-only' as const,
+      source: 'gps' as const,
+      fusedLabel: '-',
+      gpsLabel: '-',
+      differs: false,
+      candidateTrains: null,
+    },
+    arrivalSummary: '-',
+    isMock: false,
+    silentPush: {
+      apnsToken: null,
+      activeTripToken: null,
+      apnsEnv: 'sandbox' as const,
+      permissionStatus: null,
+      taskRegistrationState: 'unknown' as const,
+      taskRegistrationError: null,
+      lastReceivedAt: null,
+      lastFiredAt: null,
+      lastSkippedAt: null,
+      hasRoute: false,
+      destinationId: null,
+      lastNotifiedStationId: null,
+    },
+    logs: [],
+  };
+  const makeSsotArgs = (overrides: Partial<DumpArgs> = {}): DumpArgs => ({
+    ...ssotBaseline,
+    ...overrides,
+  });
+
+  it('모든 SSOT 섹션 헤더가 share 텍스트에 포함된다 (Gates 제외, suppressed 없음 시)', () => {
+    const dump = __test__.buildDumpText(makeSsotArgs());
+    expect(dump).toContain('## GPS');
+    expect(dump).toContain('## Nearest');
+    expect(dump).toContain('## Fusion');
+    expect(dump).toContain('## Trip');
+    expect(dump).toContain('## Sleep');
+    expect(dump).toContain('## Arrival');
+    expect(dump).toContain('## Silent Push');
+    expect(dump).toContain('## Scheduled queue');
+    expect(dump).toContain('## Alarm log');
+    expect(dump).toContain('## Fusion log');
+    // suppressed reason 없으면 Gates 헤더 자체 생략(omitIfEmpty=true).
+    expect(dump).not.toContain('## Gates');
+  });
+
+  it('Fusion log 섹션이 Alarm log 섹션 *다음*에 위치한다', () => {
+    const dump = __test__.buildDumpText(makeSsotArgs());
+    const alarmIdx = dump.indexOf('## Alarm log');
+    const fusionLogIdx = dump.indexOf('## Fusion log');
+    expect(alarmIdx).toBeGreaterThan(-1);
+    expect(fusionLogIdx).toBeGreaterThan(alarmIdx);
+  });
+
+  it('Fusion log: fusionLog 미전달 시 카운트 0 + (empty) 표시', () => {
+    const dump = __test__.buildDumpText(makeSsotArgs());
+    expect(dump).toContain('## Fusion log (0)');
+    // 본문 라인 — Alarm log 비어있을 때도 (empty)이지만 fusion log 섹션은 항상 한 줄.
+    const fusionSection = dump.slice(dump.indexOf('## Fusion log'));
+    expect(fusionSection).toContain('(empty)');
+  });
+
+  it('Fusion log: fusionLog 빈 배열도 (empty) 출력', () => {
+    const dump = __test__.buildDumpText(makeSsotArgs({ fusionLog: [] }));
+    expect(dump).toContain('## Fusion log (0)');
+    const fusionSection = dump.slice(dump.indexOf('## Fusion log'));
+    expect(fusionSection).toContain('(empty)');
+  });
+
+  it('Fusion log: 3건 데이터 → 3줄로 직렬화(최신 먼저)', () => {
+    const ts1 = new Date('2026-06-15T10:00:00Z').getTime();
+    const ts2 = new Date('2026-06-15T10:00:10Z').getTime();
+    const ts3 = new Date('2026-06-15T10:00:20Z').getTime();
+    const dump = __test__.buildDumpText(
+      makeSsotArgs({
+        fusionLog: [
+          {
+            kind: 'gps',
+            event: 'gps-fix',
+            ts: ts1,
+            lat: 37.5,
+            lng: 127,
+            accuracyMeters: 20,
+            speedMps: 0,
+            nearestStation: '용마산',
+            nearestLine: '7',
+            nearestDistanceKm: 0.05,
+          },
+          {
+            kind: 'sticky',
+            event: 'locked',
+            ts: ts2,
+            stationName: '용마산',
+            line: '7',
+            accuracyMeters: 50,
+            speedMps: 0.2,
+          },
+          {
+            kind: 'fusion',
+            ts: ts3,
+            source: 'position-train',
+            confidence: 'position-train',
+            stationName: '사가정',
+            line: '7',
+            distanceKm: 0.8,
+            gpsAccuracyAtPushMeters: 25,
+            candidates: [
+              { key: 'positionTrain', stationName: '사가정', line: '7' },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(dump).toContain('## Fusion log (3)');
+    // 최신(ts3) 먼저 — Alarm log와 동일 정렬.
+    const fusionSection = dump.slice(dump.indexOf('## Fusion log'));
+    expect(fusionSection).toContain('src=position-train');
+    expect(fusionSection).toContain('gps-fix');
+    expect(fusionSection).toContain('sticky:locked');
+    // 본문 라인 3건 — 헤더 다음의 줄 수가 3.
+    const bodyLines = fusionSection.split('\n').slice(1).filter((l) => l.length > 0);
+    expect(bodyLines).toHaveLength(3);
+  });
+
+  it('DebugModal share button: fusion log buffer가 share 텍스트에 흐른다 (#1346)', async () => {
+    const { pushFusionDebugEntry, clearFusionDebugEntries } = jest.requireActual(
+      '../../../nearest-station/utils/fusionDebugBuffer',
+    );
+    clearFusionDebugEntries();
+    setupHookDefaults();
+    pushFusionDebugEntry({
+      kind: 'sticky',
+      event: 'locked',
+      ts: new Date('2026-06-15T10:00:00Z').getTime(),
+      stationName: '용마산',
+      line: '7',
+      accuracyMeters: 50,
+      speedMps: 0.2,
+    });
+
+    const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    fireEvent.press(screen.getByTestId('debug-share-dump'));
+    await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+    const msg = shareSpy.mock.calls[0][0].message;
+    expect(msg).toContain('## Fusion log (1)');
+    expect(msg).toContain('sticky:locked');
+    expect(msg).toContain('용마산(7)');
+    shareSpy.mockRestore();
+    clearFusionDebugEntries();
+  });
+});
+
 describe('DebugModal helpers — formatEstimatorLine (#1025)', () => {
   const { formatEstimatorLine: fmt } = __test__;
   // 3개 케이스가 동일 구조 — it.each로 묶어 CPD 토큰 반복 제거.

--- a/src/features/route/store/__tests__/useDestinationStore.test.ts
+++ b/src/features/route/store/__tests__/useDestinationStore.test.ts
@@ -840,10 +840,119 @@ describe('useDestinationStore', () => {
       });
     });
 
-    it('같은 destination 재설정은 noise 방지를 위해 breadcrumb 없음', () => {
+    it('같은 destination 재설정은 trip start/end noise 방지 — switch breadcrumb 없음', () => {
+      // #1346 — `setDestination-call` trace breadcrumb는 항상 발사돼 caller stamp를 남기지만,
+      // `start`/`end` 같은 switch-specific breadcrumb는 noise 방지를 위해 isSwitch=false면 생략된다.
       useDestinationStore.setState({ destination: mockStation });
       useDestinationStore.getState().setDestination(mockStation);
-      expect(mockAddDomainBreadcrumb).not.toHaveBeenCalled();
+      expect(mockAddDomainBreadcrumb).not.toHaveBeenCalledWith(
+        'trip',
+        'start',
+        expect.anything(),
+      );
+      expect(mockAddDomainBreadcrumb).not.toHaveBeenCalledWith(
+        'trip',
+        'end',
+        expect.anything(),
+      );
+    });
+  });
+
+  // #1346 — setDestination 호출자 trace. lockless trip 잔존(tripStartedAt 9시간) 분석 시
+  // 어느 컴포넌트/훅이 마지막으로 호출했는지 사후 재구성 가능. caller 추출은 환경변수 게이트.
+  describe('setDestination-call trace (#1346)', () => {
+    const originalEnv = process.env.EXPO_PUBLIC_DEBUG_MODAL;
+    beforeEach(() => {
+      mockAddDomainBreadcrumb.mockClear();
+      useDestinationStore.setState({ destination: null });
+    });
+    afterEach(() => {
+      // env 복구. undefined로 다시 두는 게 더 정확하지만 jest의 env mutation은 string만 보장.
+      if (originalEnv === undefined) {
+        delete process.env.EXPO_PUBLIC_DEBUG_MODAL;
+      } else {
+        process.env.EXPO_PUBLIC_DEBUG_MODAL = originalEnv;
+      }
+    });
+
+    it('isSwitch=true → setDestination-call breadcrumb 1건 + caller 정보', () => {
+      process.env.EXPO_PUBLIC_DEBUG_MODAL = 'true';
+      useDestinationStore.getState().setDestination(mockStation);
+      const call = mockAddDomainBreadcrumb.mock.calls.find(
+        ([_category, message]) => message === 'setDestination-call',
+      );
+      expect(call).toBeDefined();
+      const data = call?.[2] as Record<string, unknown> | undefined;
+      expect(data).toMatchObject({
+        prevId: null,
+        nextId: '2-022',
+        isSwitch: true,
+      });
+      // caller는 stack trace 추출 결과 — jest 환경에서 보통 path:line:col 형태로 매칭.
+      expect(typeof data?.caller === 'string' || data?.caller === undefined).toBe(true);
+    });
+
+    it('isSwitch=false(같은 destination 재설정)에도 trace는 발사된다', () => {
+      process.env.EXPO_PUBLIC_DEBUG_MODAL = 'true';
+      useDestinationStore.setState({ destination: mockStation });
+      mockAddDomainBreadcrumb.mockClear();
+
+      useDestinationStore.getState().setDestination(mockStation);
+
+      const call = mockAddDomainBreadcrumb.mock.calls.find(
+        ([_category, message]) => message === 'setDestination-call',
+      );
+      expect(call).toBeDefined();
+      const data = call?.[2] as Record<string, unknown> | undefined;
+      expect(data).toMatchObject({
+        prevId: '2-022',
+        nextId: '2-022',
+        isSwitch: false,
+      });
+    });
+
+    it('ENV OFF(EXPO_PUBLIC_DEBUG_MODAL≠true)면 caller=undefined로 발사', () => {
+      delete process.env.EXPO_PUBLIC_DEBUG_MODAL;
+      useDestinationStore.getState().setDestination(mockStation);
+      const call = mockAddDomainBreadcrumb.mock.calls.find(
+        ([_category, message]) => message === 'setDestination-call',
+      );
+      expect(call).toBeDefined();
+      const data = call?.[2] as Record<string, unknown> | undefined;
+      expect(data?.caller).toBeUndefined();
+    });
+
+    it('null 해제(trip end)에도 trace는 발사된다', () => {
+      process.env.EXPO_PUBLIC_DEBUG_MODAL = 'true';
+      useDestinationStore.setState({ destination: mockStation });
+      mockAddDomainBreadcrumb.mockClear();
+
+      useDestinationStore.getState().setDestination(null);
+
+      const call = mockAddDomainBreadcrumb.mock.calls.find(
+        ([_category, message]) => message === 'setDestination-call',
+      );
+      expect(call).toBeDefined();
+      const data = call?.[2] as Record<string, unknown> | undefined;
+      expect(data).toMatchObject({
+        prevId: '2-022',
+        nextId: null,
+        isSwitch: true,
+      });
+    });
+
+    it('degenerate destination(customOrigin==station)이면 차단되어 trace 발사 안 됨', () => {
+      process.env.EXPO_PUBLIC_DEBUG_MODAL = 'true';
+      useDestinationStore.getState().setCustomOrigin(mockStation);
+      mockAddDomainBreadcrumb.mockClear();
+
+      useDestinationStore.getState().setDestination(mockStation);
+
+      const call = mockAddDomainBreadcrumb.mock.calls.find(
+        ([_category, message]) => message === 'setDestination-call',
+      );
+      // 차단 분기에서는 setDestination-call breadcrumb 자체가 발사되지 않는다(이미 degenerate breadcrumb).
+      expect(call).toBeUndefined();
     });
   });
 });

--- a/src/features/route/store/useDestinationStore.ts
+++ b/src/features/route/store/useDestinationStore.ts
@@ -113,7 +113,7 @@ export const useDestinationStore = create<DestinationState>((set, get) => ({
     // EXPO_PUBLIC_DEBUG_MODAL 게이트 안에서만 — 운영 빌드는 stack trace 비용 0.
     const caller =
       process.env.EXPO_PUBLIC_DEBUG_MODAL === 'true'
-        ? extractCallerFrame(new Error())
+        ? extractCallerFrame(new Error('caller-trace'))
         : undefined;
     addDomainBreadcrumb('trip', 'setDestination-call', {
       prevId: prev?.id ?? null,

--- a/src/features/route/store/useDestinationStore.ts
+++ b/src/features/route/store/useDestinationStore.ts
@@ -23,6 +23,7 @@ import { triggerTripEndRecall } from '../../alarm/utils/triggerTripEndRecall';
 import { useAlarmEventStore } from '../../alarm/store/useAlarmEventStore';
 import { ROUTE_CATEGORIES, type RoutePreference } from '../../../shared/utils/stationRoute';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
+import { extractCallerFrame } from '../../../shared/utils/extractCallerFrame';
 import { isDegenerateDestination } from '../utils/isDegenerateDestination';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -107,6 +108,19 @@ export const useDestinationStore = create<DestinationState>((set, get) => ({
     }
     const prev = get().destination;
     const isSwitch = (prev?.id ?? null) !== (station?.id ?? null);
+    // #1346 — 모든 setDestination 호출에 caller stamp breadcrumb. lockless trip 잔존(tripStartedAt
+    // 9시간) 분석 시 어느 컴포넌트가 마지막으로 호출했는지 사후 재구성용. caller 추출은
+    // EXPO_PUBLIC_DEBUG_MODAL 게이트 안에서만 — 운영 빌드는 stack trace 비용 0.
+    const caller =
+      process.env.EXPO_PUBLIC_DEBUG_MODAL === 'true'
+        ? extractCallerFrame(new Error())
+        : undefined;
+    addDomainBreadcrumb('trip', 'setDestination-call', {
+      prevId: prev?.id ?? null,
+      nextId: station?.id ?? null,
+      isSwitch,
+      caller,
+    });
     set({ destination: station });
     if (station) {
       AsyncStorage.setItem(DESTINATION_KEY, JSON.stringify(station)).catch(noop);

--- a/src/shared/utils/__tests__/extractCallerFrame.test.ts
+++ b/src/shared/utils/__tests__/extractCallerFrame.test.ts
@@ -1,0 +1,93 @@
+import { extractCallerFrame } from '../extractCallerFrame';
+
+describe('extractCallerFrame', () => {
+  it('정상 stack(V8/Hermes 스타일)에서 caller frame을 추출한다', () => {
+    const err = new Error('test');
+    err.stack = [
+      'Error: test',
+      '    at helper (/path/to/extractCallerFrame.ts:10:20)',
+      '    at setDestination (/path/to/useDestinationStore.ts:100:30)',
+      '    at caller (/path/to/SomeScreen.tsx:42:7)',
+    ].join('\n');
+    // skip=2 → 인덱스 3(첫 줄=에러 메시지) 프레임 = caller.
+    expect(extractCallerFrame(err)).toBe('/path/to/SomeScreen.tsx:42:7');
+  });
+
+  it('WebKit 스타일 stack(`@`)에서도 추출 가능', () => {
+    const err = new Error('test');
+    err.stack = [
+      'helper@/path/to/extractCallerFrame.ts:10:20',
+      'setDestination@/path/to/useDestinationStore.ts:100:30',
+      'caller@/path/to/SomeScreen.tsx:42:7',
+    ].join('\n');
+    // WebKit은 에러 메시지 첫 줄이 없는 케이스가 있어 skip=2면 인덱스 2(caller).
+    // 본 테스트는 skip 기본값을 그대로 쓰되 frameLine fallback 분기까지 통과 확인.
+    const frame = extractCallerFrame(err);
+    // V8 fallback에서는 lines[3] missing → lines[2] fallback. 그게 caller@... 라인.
+    expect(frame).toBe('/path/to/SomeScreen.tsx:42:7');
+  });
+
+  it('stack이 undefined면 undefined 반환', () => {
+    const err = new Error('test');
+    err.stack = undefined;
+    expect(extractCallerFrame(err)).toBeUndefined();
+  });
+
+  it('frame line이 부족하면 마지막 라인으로 fallback', () => {
+    const err = new Error('test');
+    err.stack = [
+      'Error: test',
+      '    at helper (/path/to/extractCallerFrame.ts:10:20)',
+      '    at setDestination (/path/to/useDestinationStore.ts:100:30)',
+    ].join('\n');
+    // skip=2 → 인덱스 3 missing → 인덱스 2 fallback = setDestination 라인.
+    expect(extractCallerFrame(err)).toBe('/path/to/useDestinationStore.ts:100:30');
+  });
+
+  it('parse 불가능한 frame이면 undefined 반환', () => {
+    const err = new Error('test');
+    err.stack = ['Error: test', '    at <anonymous>'].join('\n');
+    expect(extractCallerFrame(err)).toBeUndefined();
+  });
+
+  it('frame line은 있지만 file:line:col 토큰이 없으면 undefined 반환', () => {
+    const err = new Error('test');
+    // skip=2 → lines[3] = `    at unknown` (file token 없음). regex 매치 실패.
+    err.stack = [
+      'Error: test',
+      '    at frame0 (/p/a:1:1)',
+      '    at frame1 (/p/b:2:2)',
+      '    at unknown',
+    ].join('\n');
+    expect(extractCallerFrame(err)).toBeUndefined();
+  });
+
+  it('비ASCII 경로(한글 디렉토리)도 추출 가능', () => {
+    const err = new Error('test');
+    err.stack = [
+      'Error: test',
+      '    at helper (/path/한글/extractCallerFrame.ts:10:20)',
+      '    at setDestination (/path/한글/useDestinationStore.ts:100:30)',
+      '    at caller (/path/한글/Screen.tsx:42:7)',
+    ].join('\n');
+    expect(extractCallerFrame(err)).toBe('/path/한글/Screen.tsx:42:7');
+  });
+
+  it('skip 인자를 명시하면 해당 깊이의 프레임을 반환', () => {
+    const err = new Error('test');
+    err.stack = [
+      'Error: test',
+      '    at frame0 (/p/a:1:1)',
+      '    at frame1 (/p/b:2:2)',
+      '    at frame2 (/p/c:3:3)',
+    ].join('\n');
+    expect(extractCallerFrame(err, 0)).toBe('/p/a:1:1');
+    expect(extractCallerFrame(err, 1)).toBe('/p/b:2:2');
+  });
+
+  it('빈 stack(빈 문자열)이면 fallback도 비어 undefined 반환', () => {
+    const err = new Error('test');
+    err.stack = '';
+    expect(extractCallerFrame(err)).toBeUndefined();
+  });
+});

--- a/src/shared/utils/extractCallerFrame.ts
+++ b/src/shared/utils/extractCallerFrame.ts
@@ -27,7 +27,8 @@ export function extractCallerFrame(error: Error, skip = 2): string | undefined {
   if (!frameLine) return undefined;
 
   // 양쪽 형식 모두 `file:line:col` 토큰을 캡쳐. 가장 마지막 토큰을 우선시(괄호 안에 위치).
-  const match = /(?:\(|@| )([^()\s]+:\d+:\d+)\)?$/.exec(frameLine.trim());
+  // path part는 콜론을 제외해 backtracking을 차단(S5852/S6035 회피).
+  const match = /[(@ ]([^()\s:]+:\d+:\d+)\)?$/.exec(frameLine.trim());
   if (!match) return undefined;
   return match[1];
 }

--- a/src/shared/utils/extractCallerFrame.ts
+++ b/src/shared/utils/extractCallerFrame.ts
@@ -1,0 +1,33 @@
+/**
+ * #1346 — setDestination caller trace를 위해 Error.stack에서 호출자 프레임을 추출한다.
+ *
+ * 용도: lockless trip 잔존 분석. 예: tripStartedAt이 9시간 동안 살아있으면 어느 컴포넌트/훅이
+ * setDestination을 마지막으로 호출했는지 사후 재구성하기 위해 breadcrumb에 caller를 stamp한다.
+ *
+ * 입력은 `new Error()`로 만들어진 표준 Error 인스턴스. 첫 프레임은 helper 자기 자신,
+ * 두 번째 프레임은 helper를 부른 setDestination, 세 번째 프레임이 사용자 코드(caller)다.
+ * (call site로부터 fixed offset이라 호출부에서 `skip` 개수를 명시적으로 지정한다.)
+ *
+ * 성능: 호출부에서 EXPO_PUBLIC_DEBUG_MODAL 게이팅 후에만 호출되도록 운영 빌드에서는 무비용.
+ *
+ * 형식 안전성: stack은 엔진/번들러에 따라 모양이 다르다.
+ *   - Hermes/V8: `at FuncName (file:line:col)` 또는 `at file:line:col`
+ *   - WebKit:    `FuncName@file:line:col`
+ * 어느 형식이든 콜론(`:`)으로 끝나는 `file:line:col` 토큰을 캡쳐하면 충분하다. 캡쳐 실패 시
+ * undefined를 반환해 호출부가 graceful하게 fallback할 수 있게 한다.
+ */
+export function extractCallerFrame(error: Error, skip = 2): string | undefined {
+  const { stack } = error;
+  if (!stack) return undefined;
+
+  const lines = stack.split('\n');
+  // stack 첫 줄은 보통 에러 메시지 ("Error" 한 줄). 그 뒤가 프레임.
+  // skip은 호출부에서 명시적으로 지정 — 본 함수는 "n번째 프레임"만 알면 된다.
+  const frameLine = lines[skip + 1] ?? lines[skip];
+  if (!frameLine) return undefined;
+
+  // 양쪽 형식 모두 `file:line:col` 토큰을 캡쳐. 가장 마지막 토큰을 우선시(괄호 안에 위치).
+  const match = /(?:\(|@| )([^()\s]+:\d+:\d+)\)?$/.exec(frameLine.trim());
+  if (!match) return undefined;
+  return match[1];
+}


### PR DESCRIPTION
Closes #1346

## 배경
2026-06-16 발열 분석 중 sticky cascade가 fusion log에 박혀 있었으나 DebugModal share 텍스트엔 fusion log가 누락돼 식별 지연. 또한 trip 잔존 분석(tripStartedAt 9시간) 위해 `setDestination` 호출자 추적이 필요.

## 변경
### 1. DebugModal share SSOT enumerate
- `buildDumpText` 함수에 hardcoded돼 있던 섹션 11개를 `SHARE_SECTIONS` SSOT 배열로 분리.
- 각 섹션 builder를 `(args) => string[]` 시그니처 함수로 추출 (`buildGpsSection`, `buildNearestSection`, ...).
- 새 buffer 추가 시 SSOT 배열에 한 줄(title + builder)만 등록하면 dump/UI 양쪽에 자동 노출.
- **Fusion log 섹션을 share 텍스트에 신규 포함** — alarm log 다음. `(empty)` placeholder 지원.
- 출력 텍스트 포맷은 기존과 1:1 일치 (기존 152 테스트 모두 통과).

### 2. setDestination caller trace
- `setDestination` 진입부에 `setDestination-call` breadcrumb 추가: `{ prevId, nextId, isSwitch, caller }`.
- `caller` 추출은 `EXPO_PUBLIC_DEBUG_MODAL=true` 게이트 안에서만 — 운영 빌드 stack 추출 비용 0.
- helper `extractCallerFrame(error: Error, skip?: number)`을 `src/shared/utils/extractCallerFrame.ts`로 분리.
  - V8/Hermes (`at func (file:line:col)`)와 WebKit (`func@file:line:col`) 양쪽 형식 지원.
  - stack undefined / parse 실패 시 graceful `undefined`.

## Acceptance check
- [x] DebugModal SSOT 모든 섹션이 share 텍스트에 포함됨 (`## GPS`, `## Nearest`, `## Fusion`, `## Trip`, `## Sleep`, `## Arrival`, `## Silent Push`, `## Scheduled queue`, `## Alarm log`, `## Fusion log` + 조건부 `## Gates`).
- [x] Fusion log 섹션이 Alarm log 섹션 *다음*에 표시됨.
- [x] Fusion buffer 빈 상태에서 `(empty)` 출력.
- [x] Fusion buffer 3건 데이터 → 3줄 직렬화 (최신 먼저).
- [x] setDestination caller trace breadcrumb: ENV ON → caller 정보 포함, ENV OFF → caller=undefined.
- [x] extractCallerFrame unit: 정상/null stack/비ASCII 경로/단일 프레임 fallback/parse 실패 케이스 커버.
- [x] degenerate destination 차단 분기에서는 trace breadcrumb 미발사 (이미 degenerate breadcrumb로 관측됨).

## β 용도 (evidence 수집)
- 사용자가 다음 trip 후 DebugModal share → 한 텍스트로 fusion log까지 한 번에 분석 가능.
- Sentry breadcrumb에 setDestination caller stamp → tripStartedAt이 N시간 살아있을 때 마지막 호출자(컴포넌트/훅) 추적.

## 게이트 통과
- `npm run type-check` PASS
- `npm run lint` PASS
- 우리 변경 영역 jest coverage 100% (DebugModal.tsx / useDestinationStore.ts / extractCallerFrame.ts).
- 우리 변경 외 (widget storage / station notification) 일부 테스트는 **dev base 자체에 이미 존재하는 실패** — stash 검증으로 확인. 본 PR과 무관.

## 주의
- DebugModal의 UX (스크롤/헤더/섹션 컴포넌트)는 건드리지 않음. share build path만 SSOT로 refactor.
- setDestination cleanup chain (`tripTransitionQueue`)은 건드리지 않음. breadcrumb 1건만 추가.