### PR TITLE
chore(#1348): DebugModal share SSOT enumerate + setDestination caller trace

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -45,6 +45,7 @@ import { useBoardingLockStore } from '../../../features/alarm/store/useBoardingL
 import { isBoardingLockExpired } from '../../../shared/types/boardingLock';
 import {
   clearEstimatorEntries,
+  formatEstimatorLine,
   getEstimatorEntries,
   subscribeEstimatorDebug,
   type EstimatorDebugEntry,
@@ -52,10 +53,12 @@ import {
 import { SILENT_PUSH_LABELS, buildSilentPushCountValue } from '../../../shared/constants/labels';
 import {
   clearFusionDebugEntries,
+  formatFusionDebugLine,
   getFusionDebugEntries,
   subscribeFusionDebug,
   type FusionDebugEntry,
 } from '../../../features/nearest-station/utils/fusionDebugBuffer';
+import { getRegisteredDebugBuffers } from '../../../shared/utils/debugBufferRegistry';
 import {
   dumpScheduledNotifications,
   formatScheduledNotificationLine,
@@ -146,45 +149,6 @@ function formatLogLine(entry: AlarmLogEntry): string {
   if (entry.expectedStationAtFire) parts.push(`exp=${entry.expectedStationAtFire}`);
   if (entry.actualLastNotifiedStation) parts.push(`last=${entry.actualLastNotifiedStation}`);
   return parts.join(' | ');
-}
-
-/** candidates key → 짧은 접두어. 새 key가 늘면 여기 한 줄만 추가하면 됨. */
-const CANDIDATE_SHORT: Record<string, string> = {
-  positionTrain: 'pt',
-  fused: 'fu',
-  route: 'rt',
-  gps: 'gp',
-};
-
-function formatFusionDebugLine(entry: FusionDebugEntry): string {
-  const time = formatTime(entry.ts);
-  if (entry.kind === 'gps') {
-    const station = entry.nearestStation
-      ? `${entry.nearestStation}(${entry.nearestLine ?? '-'})`
-      : '-';
-    const d = entry.nearestDistanceKm != null ? `${Math.round(entry.nearestDistanceKm * 1000)}m` : '-';
-    const acc = entry.accuracyMeters != null ? `${Math.round(entry.accuracyMeters)}m` : '-';
-    const reason = entry.dropReason ? ` reason=${entry.dropReason}` : '';
-    return `${time} | ${entry.event} | ${station} d=${d} acc=${acc}${reason}`;
-  }
-  if (entry.kind === 'sticky') {
-    const acc = entry.accuracyMeters != null ? `${Math.round(entry.accuracyMeters)}m` : '-';
-    const sp = entry.speedMps != null ? `${entry.speedMps.toFixed(1)}m/s` : '-';
-    return `${time} | sticky:${entry.event} | ${entry.stationName}(${entry.line}) acc=${acc} sp=${sp}`;
-  }
-  const station = entry.stationName ? `${entry.stationName}(${entry.line ?? '-'})` : '-';
-  const d = entry.distanceKm != null ? `${Math.round(entry.distanceKm * 1000)}m` : '-';
-  const acc =
-    entry.gpsAccuracyAtPushMeters != null ? `${Math.round(entry.gpsAccuracyAtPushMeters)}m` : '-';
-  const cand = entry.candidates
-    .map((c) => {
-      const base = `${CANDIDATE_SHORT[c.key] ?? c.key}=${c.stationName}`;
-      // boarding-lock 매칭 표기 — positionTrain candidate에 lockMatch=true가 찍히면 한눈에 식별.
-      return c.extra?.lockMatch === true ? `${base}[LOCK]` : base;
-    })
-    .join(' ');
-  const candPart = cand.length > 0 ? cand : '-';
-  return `${time} | src=${entry.source} conf=${entry.confidence} | ${station} d=${d} acc=${acc} | ${candPart}`;
 }
 
 /**
@@ -442,6 +406,22 @@ function buildDumpText(args: {
     );
   }
   lines.push('');
+  // #1348 — debug buffer registry SSOT enumerate.
+  // fusionDebugBuffer / estimatorDebugBuffer 등 in-memory ring buffer가 module import 시점에
+  // self-register돼 있다. 신규 buffer 추가 시 buffer 측에서 `registerDebugBuffer` 한 줄만
+  // 호출하면 자동 share dump에 포함된다 — 본 share 함수는 수정 불필요.
+  for (const source of getRegisteredDebugBuffers()) {
+    const sourceLines = source.dumpLines();
+    if (sourceLines.length === 0) {
+      lines.push(`## ${source.key} (0)`, '(empty)', '');
+    } else {
+      lines.push(
+        `## ${source.key} (${sourceLines.length})`,
+        ...[...sourceLines].reverse(),
+        '',
+      );
+    }
+  }
   // #1019 — ## Gates
   const reasonLine = formatReasonCountsLine(args.logs);
   if (reasonLine) {
@@ -1171,17 +1151,6 @@ function BoardingLockSection({
       )}
     </Section>
   );
-}
-
-/** Estimator 엔트리를 한 줄 텍스트로 포맷 (#1025). */
-export function formatEstimatorLine(entry: EstimatorDebugEntry): string {
-  const time = formatTime(entry.ts);
-  const strategy = entry.strategy ?? 'none';
-  const station = entry.stationName
-    ? `${entry.stationName}(${entry.stationLine ?? '-'})`
-    : '-';
-  const idx = entry.arcIndex != null ? `idx=${entry.arcIndex}` : 'idx=-';
-  return `${time} | ${strategy} | ${station} ${idx}`;
 }
 
 /** Gates 섹션 — gate 7종 + movement 6종 reason 분포 (#1025). */

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -6,6 +6,14 @@ import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
 import { useSettingsStore } from '../../../settings/store/useSettingsStore';
 import { useDestinationStore } from '../../../route/store/useDestinationStore';
 import type { AlarmLogEntry } from '../../../../features/alarm/utils/alarmLog';
+import {
+  clearFusionDebugEntries,
+  pushFusionDebugEntry,
+} from '../../../nearest-station/utils/fusionDebugBuffer';
+import {
+  clearEstimatorEntries,
+  pushEstimatorEntry,
+} from '../../../route/utils/estimatorDebugBuffer';
 import type { Station, NearestStationResult } from '../../../../shared/types/station';
 import type { StationArrival } from '../../../../shared/types/arrival';
 
@@ -872,6 +880,55 @@ describe('DebugModal helpers', () => {
     });
     expect(line).not.toContain('acc=');
     expect(line).not.toContain('age=');
+  });
+
+  // #1348 — share dump SSOT: registry에 self-register된 fusion/estimator buffer가 자동 enumerate.
+  describe('buildDumpText debug buffer registry (#1348)', () => {
+    beforeEach(() => {
+      clearFusionDebugEntries();
+      clearEstimatorEntries();
+    });
+
+    it('등록된 fusion log buffer는 share dump에 자동 포함된다', () => {
+      pushFusionDebugEntry({
+        kind: 'fusion',
+        ts: 0,
+        source: 'gps',
+        confidence: 'gps-only',
+        stationName: '용마산',
+        line: '7',
+        distanceKm: 0.05,
+        gpsAccuracyAtPushMeters: 30,
+        candidates: [],
+      });
+      const dump = __test__.buildDumpText(makeDumpArgs());
+      expect(dump).toContain('## Fusion log (1)');
+      expect(dump).toContain('용마산(7)');
+    });
+
+    it('등록된 estimator buffer는 share dump에 자동 포함된다', () => {
+      pushEstimatorEntry({
+        ts: 0,
+        strategy: 'live-position',
+        stationName: '강남',
+        stationLine: '2',
+        arcIndex: 1,
+      });
+      const dump = __test__.buildDumpText(makeDumpArgs());
+      expect(dump).toContain('## Estimator State (1)');
+      expect(dump).toContain('강남(2)');
+      expect(dump).toContain('idx=1');
+    });
+
+    it('비어있는 buffer는 (empty) placeholder로 표기 — load 안 함과 구분', () => {
+      const dump = __test__.buildDumpText(makeDumpArgs());
+      expect(dump).toContain('## Fusion log (0)');
+      expect(dump).toContain('## Estimator State (0)');
+      // section body는 '(empty)' — 빈 buffer를 명시.
+      const fusionIdx = dump.indexOf('## Fusion log (0)');
+      const after = dump.slice(fusionIdx, fusionIdx + 100);
+      expect(after).toContain('(empty)');
+    });
   });
 });
 

--- a/src/features/nearest-station/utils/__tests__/fusionDebugBuffer.test.ts
+++ b/src/features/nearest-station/utils/__tests__/fusionDebugBuffer.test.ts
@@ -1,11 +1,13 @@
 import {
   FUSION_DEBUG_BUFFER_CAPACITY,
   clearFusionDebugEntries,
+  formatFusionDebugLine,
   getFusionDebugEntries,
   pushFusionDebugEntry,
   subscribeFusionDebug,
   type FusionDebugEntry,
 } from '../fusionDebugBuffer';
+import { getRegisteredDebugBuffers } from '../../../../shared/utils/debugBufferRegistry';
 
 function makeFusionEntry(overrides: Partial<FusionDebugEntry> = {}): FusionDebugEntry {
   return {
@@ -71,6 +73,163 @@ describe('fusionDebugBuffer', () => {
     unsub();
     pushFusionDebugEntry(makeFusionEntry());
     expect(listener).toHaveBeenCalledTimes(3);
+  });
+
+  // #1348 — formatter SSOT (DebugModal UI + share dump 양쪽에서 공유).
+  describe('formatFusionDebugLine (#1348)', () => {
+    it('fusion 결정 엔트리 — src/conf/station/distance/acc/candidates 포함', () => {
+      const entry = makeFusionEntry({
+        ts: new Date('2026-06-16T12:00:00Z').getTime(),
+        source: 'position-train',
+        confidence: 'boarding-lock',
+        stationName: '용마산',
+        line: '7',
+        distanceKm: 0.123,
+        gpsAccuracyAtPushMeters: 45,
+        candidates: [
+          { key: 'positionTrain', stationName: '용마산', line: '7', extra: { lockMatch: true } },
+          { key: 'fused', stationName: '중곡', line: '7' },
+        ],
+      });
+      const line = formatFusionDebugLine(entry);
+      expect(line).toMatch(/src=position-train/);
+      expect(line).toMatch(/conf=boarding-lock/);
+      expect(line).toMatch(/용마산\(7\)/);
+      // distance: 0.123km → 123m
+      expect(line).toMatch(/d=123m/);
+      // accuracy: 45m
+      expect(line).toMatch(/acc=45m/);
+      // candidate short form + LOCK marker
+      expect(line).toMatch(/pt=용마산\[LOCK\]/);
+      expect(line).toMatch(/fu=중곡/);
+    });
+
+    it('gps-drop 엔트리 — dropReason 포함', () => {
+      const entry: FusionDebugEntry = {
+        kind: 'gps',
+        event: 'gps-drop',
+        ts: new Date('2026-06-16T12:00:00Z').getTime(),
+        lat: 37.5,
+        lng: 127.0,
+        accuracyMeters: 1500,
+        speedMps: null,
+        nearestStation: null,
+        nearestLine: null,
+        nearestDistanceKm: null,
+        dropReason: 'low-accuracy-display',
+      };
+      const line = formatFusionDebugLine(entry);
+      expect(line).toMatch(/gps-drop/);
+      expect(line).toMatch(/reason=low-accuracy-display/);
+      // nearest 없음 — '-' 표기.
+      expect(line).toMatch(/\| - d=- acc=1500m/);
+    });
+
+    it('gps-fix 엔트리 — nearest 정보', () => {
+      const entry: FusionDebugEntry = {
+        kind: 'gps',
+        event: 'gps-fix',
+        ts: new Date('2026-06-16T12:00:00Z').getTime(),
+        lat: 37.5,
+        lng: 127.0,
+        accuracyMeters: 20,
+        speedMps: 0,
+        nearestStation: '용마산',
+        nearestLine: '7',
+        nearestDistanceKm: 0.03,
+      };
+      const line = formatFusionDebugLine(entry);
+      expect(line).toMatch(/용마산\(7\)/);
+      expect(line).toMatch(/d=30m/);
+      expect(line).toMatch(/acc=20m/);
+      // dropReason 없으면 reason= 표기도 없음.
+      expect(line).not.toMatch(/reason=/);
+    });
+
+    it('sticky 엔트리 — locked/unlocked event 포함', () => {
+      const entry: FusionDebugEntry = {
+        kind: 'sticky',
+        event: 'locked',
+        ts: new Date('2026-06-16T12:00:00Z').getTime(),
+        stationName: '강남',
+        line: '2',
+        accuracyMeters: 15,
+        speedMps: 8.5,
+      };
+      const line = formatFusionDebugLine(entry);
+      expect(line).toMatch(/sticky:locked/);
+      expect(line).toMatch(/강남\(2\)/);
+      expect(line).toMatch(/acc=15m/);
+      expect(line).toMatch(/sp=8\.5m\/s/);
+    });
+
+    it('fusion 결정 엔트리에서 candidates 비어있으면 - 표기', () => {
+      const entry = makeFusionEntry({ candidates: [] });
+      const line = formatFusionDebugLine(entry);
+      expect(line).toMatch(/\| -$/);
+    });
+
+    it('fusion 결정 엔트리에서 line null이면 - 표기', () => {
+      const entry = makeFusionEntry({
+        stationName: '용마산',
+        line: null,
+        distanceKm: null,
+        gpsAccuracyAtPushMeters: null,
+      });
+      const line = formatFusionDebugLine(entry);
+      expect(line).toMatch(/용마산\(-\)/);
+      expect(line).toMatch(/d=-/);
+      expect(line).toMatch(/acc=-/);
+    });
+
+    it('fusion 결정 엔트리에서 stationName null이면 - 표기', () => {
+      const entry = makeFusionEntry({ stationName: null, line: null });
+      const line = formatFusionDebugLine(entry);
+      // station 자리에 -
+      expect(line).toMatch(/\| - d=/);
+    });
+
+    it('sticky 엔트리에서 accuracy/speed null이면 - 표기', () => {
+      const entry: FusionDebugEntry = {
+        kind: 'sticky',
+        event: 'unlocked-ttl',
+        ts: 0,
+        stationName: '강남',
+        line: '2',
+        accuracyMeters: null,
+        speedMps: null,
+      };
+      const line = formatFusionDebugLine(entry);
+      expect(line).toMatch(/acc=-/);
+      expect(line).toMatch(/sp=-/);
+    });
+
+    it('알 수 없는 candidate key는 그대로 표시 (확장성)', () => {
+      const entry = makeFusionEntry({
+        candidates: [
+          { key: 'wifiSsid', stationName: '잠실', line: '2' },
+        ],
+      });
+      const line = formatFusionDebugLine(entry);
+      expect(line).toMatch(/wifiSsid=잠실/);
+    });
+  });
+
+  describe('registerDebugBuffer wiring (#1348)', () => {
+    it('module import 시 share dump registry에 등록된다', () => {
+      const sources = getRegisteredDebugBuffers();
+      const fusion = sources.find((s) => s.key === 'Fusion log');
+      expect(fusion).toBeDefined();
+    });
+
+    it('등록된 dumpLines가 현재 buffer 엔트리들을 포맷한다', () => {
+      pushFusionDebugEntry(makeFusionEntry({ stationName: 'X', line: '1' }));
+      const sources = getRegisteredDebugBuffers();
+      const fusion = sources.find((s) => s.key === 'Fusion log');
+      const lines = fusion?.dumpLines() ?? [];
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatch(/X\(1\)/);
+    });
   });
 
   it('accepts gps-fix and gps-drop entries', () => {

--- a/src/features/nearest-station/utils/fusionDebugBuffer.ts
+++ b/src/features/nearest-station/utils/fusionDebugBuffer.ts
@@ -1,5 +1,7 @@
 import type { FusionConfidence, FusionSource } from './pickFusedStation';
 import { createDebugBuffer } from '../../../shared/utils/createDebugBuffer';
+import { registerDebugBuffer } from '../../../shared/utils/debugBufferRegistry';
+import { formatLineTime } from '../../../shared/utils/formatTime';
 
 // 측정 인프라(#443): fusion 결정/GPS fix 이벤트를 in-memory ring buffer에 보관.
 // 외부 도구(Metro/Xcode) 없이 DebugModal에서 사후 재구성하기 위한 채널.
@@ -106,3 +108,48 @@ export function clearFusionDebugEntries(): void {
 export function subscribeFusionDebug(listener: () => void): () => void {
   return db.subscribe(listener);
 }
+
+/** candidates key → 짧은 접두어. 새 key 추가 시 여기 한 줄만. */
+const CANDIDATE_SHORT: Record<string, string> = {
+  positionTrain: 'pt',
+  fused: 'fu',
+  route: 'rt',
+  gps: 'gp',
+};
+
+/** #1348 — fusion 엔트리 한 줄 텍스트 포맷. share dump / UI 양쪽 SSOT. */
+export function formatFusionDebugLine(entry: FusionDebugEntry): string {
+  const time = formatLineTime(entry.ts);
+  if (entry.kind === 'gps') {
+    const station = entry.nearestStation
+      ? `${entry.nearestStation}(${entry.nearestLine ?? '-'})`
+      : '-';
+    const d = entry.nearestDistanceKm != null ? `${Math.round(entry.nearestDistanceKm * 1000)}m` : '-';
+    const acc = entry.accuracyMeters != null ? `${Math.round(entry.accuracyMeters)}m` : '-';
+    const reason = entry.dropReason ? ` reason=${entry.dropReason}` : '';
+    return `${time} | ${entry.event} | ${station} d=${d} acc=${acc}${reason}`;
+  }
+  if (entry.kind === 'sticky') {
+    const acc = entry.accuracyMeters != null ? `${Math.round(entry.accuracyMeters)}m` : '-';
+    const sp = entry.speedMps != null ? `${entry.speedMps.toFixed(1)}m/s` : '-';
+    return `${time} | sticky:${entry.event} | ${entry.stationName}(${entry.line}) acc=${acc} sp=${sp}`;
+  }
+  const station = entry.stationName ? `${entry.stationName}(${entry.line ?? '-'})` : '-';
+  const d = entry.distanceKm != null ? `${Math.round(entry.distanceKm * 1000)}m` : '-';
+  const acc =
+    entry.gpsAccuracyAtPushMeters != null ? `${Math.round(entry.gpsAccuracyAtPushMeters)}m` : '-';
+  const cand = entry.candidates
+    .map((c) => {
+      const base = `${CANDIDATE_SHORT[c.key] ?? c.key}=${c.stationName}`;
+      return c.extra?.lockMatch === true ? `${base}[LOCK]` : base;
+    })
+    .join(' ');
+  const candPart = cand.length > 0 ? cand : '-';
+  return `${time} | src=${entry.source} conf=${entry.confidence} | ${station} d=${d} acc=${acc} | ${candPart}`;
+}
+
+// #1348 — share dump SSOT 등록. module import 시점에 한 번 호출돼 자동 enumerate.
+registerDebugBuffer({
+  key: 'Fusion log',
+  dumpLines: () => getFusionDebugEntries().map(formatFusionDebugLine),
+});

--- a/src/features/route/store/__tests__/useDestinationStore.test.ts
+++ b/src/features/route/store/__tests__/useDestinationStore.test.ts
@@ -106,9 +106,12 @@ describe('useDestinationStore', () => {
       'subway-now:destination',
       expect.anything(),
     );
-    expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('trip', 'degenerate-destination-blocked', {
-      station: '강남',
-    });
+    // #1348 — degenerate 거부 breadcrumb에 caller 첨부. 본 테스트는 station만 확인 (caller는 별도 case).
+    expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith(
+      'trip',
+      'degenerate-destination-blocked',
+      expect.objectContaining({ station: '강남' }),
+    );
   });
 
   it('setDestination(#1324): customOrigin과 다른 역은 정상 설정된다', () => {
@@ -825,25 +828,62 @@ describe('useDestinationStore', () => {
       useDestinationStore.setState({ destination: null });
     });
 
-    it('새 destination 지정 시 trip/start breadcrumb', () => {
+    it('새 destination 지정 시 trip/start breadcrumb (#1348 caller 첨부)', () => {
       useDestinationStore.getState().setDestination(mockStation);
-      expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('trip', 'start', {
-        destination: mockStation.name,
-      });
+      expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith(
+        'trip',
+        'start',
+        expect.objectContaining({
+          destination: mockStation.name,
+          // #1348 — caller stack은 captureCallerStack 결과 (배열 또는 null).
+          caller: expect.anything(),
+        }),
+      );
+      // caller가 setDestination 내부 frame을 포함하지 않아야 한다 (helper self-skip).
+      const callerArg = (mockAddDomainBreadcrumb.mock.calls[0][2] as { caller: unknown }).caller;
+      if (callerArg !== null) {
+        expect(callerArg).toBeInstanceOf(Array);
+        for (const frame of callerArg as string[]) {
+          expect(frame).not.toMatch(/captureCallerStack/);
+        }
+      }
     });
 
-    it('destination=null 해제 시 trip/end breadcrumb', () => {
+    it('destination=null 해제 시 trip/end breadcrumb (#1348 caller 첨부)', () => {
       useDestinationStore.setState({ destination: mockStation });
       useDestinationStore.getState().setDestination(null);
-      expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('trip', 'end', {
-        reason: 'user-clear',
-      });
+      expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith(
+        'trip',
+        'end',
+        expect.objectContaining({
+          reason: 'user-clear',
+          caller: expect.anything(),
+        }),
+      );
     });
 
     it('같은 destination 재설정은 noise 방지를 위해 breadcrumb 없음', () => {
       useDestinationStore.setState({ destination: mockStation });
       useDestinationStore.getState().setDestination(mockStation);
       expect(mockAddDomainBreadcrumb).not.toHaveBeenCalled();
+    });
+
+    // #1348 — degenerate destination 거부도 caller stack을 첨부해 호출 경로 추적 가능해야 한다.
+    it('degenerate destination 거부 시 caller 첨부 breadcrumb', () => {
+      const { setDestination, setCustomOrigin } = useDestinationStore.getState();
+      setCustomOrigin(mockStation);
+      mockAddDomainBreadcrumb.mockClear();
+
+      setDestination(mockStation);
+
+      expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith(
+        'trip',
+        'degenerate-destination-blocked',
+        expect.objectContaining({
+          station: mockStation.name,
+          caller: expect.anything(),
+        }),
+      );
     });
   });
 });

--- a/src/features/route/store/useDestinationStore.ts
+++ b/src/features/route/store/useDestinationStore.ts
@@ -23,6 +23,7 @@ import { triggerTripEndRecall } from '../../alarm/utils/triggerTripEndRecall';
 import { useAlarmEventStore } from '../../alarm/store/useAlarmEventStore';
 import { ROUTE_CATEGORIES, type RoutePreference } from '../../../shared/utils/stationRoute';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
+import { captureCallerStack } from '../../../shared/utils/captureCallerStack';
 import { isDegenerateDestination } from '../utils/isDegenerateDestination';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -95,6 +96,10 @@ export const useDestinationStore = create<DestinationState>((set, get) => ({
   routePreference: 'optimal' as RoutePreference,
 
   setDestination: (station: Station | null) => {
+    // #1348 — caller stack 캡처. setDestination은 사용자 action 빈도(hot path 아님)라
+    // Error 생성 비용이 무시 가능. 직접 탭 / hook 자동 호출 / silent push reconcile 등
+    // 진입 경로를 사후 재구성하기 위함(예: 14:36:46 미식별 호출 evidence).
+    const caller = captureCallerStack();
     // #1324 — 목적지 == 출발역이면 degenerate trip(0-waypoint → 방향 null → 빈 탑승목록)이
     // 생성된다. UX 경계(DestinationPicker.onSelect)에서 effectiveOrigin(=customOrigin ∪ GPS)을
     // 기준으로 우선 차단하지만, store가 권위적으로 아는 customOrigin과 같은 역을 목적지로
@@ -102,6 +107,7 @@ export const useDestinationStore = create<DestinationState>((set, get) => ({
     if (station && isDegenerateDestination(get().customOrigin, station)) {
       addDomainBreadcrumb('trip', 'degenerate-destination-blocked', {
         station: station.name,
+        caller,
       });
       return;
     }
@@ -123,10 +129,11 @@ export const useDestinationStore = create<DestinationState>((set, get) => ({
     if (isSwitch) {
       // 도메인 이벤트 breadcrumb — trip start(새 destination 지정) / end(null로 해제).
       // 같은 destination 재설정은 isSwitch=false로 여기 진입하지 않으므로 noise 방지됨.
+      // #1348 — caller stack을 첨부해 evidence 수집(미식별 호출 추적용).
       if (station) {
-        addDomainBreadcrumb('trip', 'start', { destination: station.name });
+        addDomainBreadcrumb('trip', 'start', { destination: station.name, caller });
       } else {
-        addDomainBreadcrumb('trip', 'end', { reason: 'user-clear' });
+        addDomainBreadcrumb('trip', 'end', { reason: 'user-clear', caller });
       }
       // #919 + cleanup + 새 trip 기록을 순서대로 chain. 각 단계는 자체 catch를 가져
       // 한 단계 실패가 다음 단계를 막지 않도록 한다 — 측정 인프라가 cleanup의 critical

--- a/src/features/route/utils/__tests__/estimatorDebugBuffer.test.ts
+++ b/src/features/route/utils/__tests__/estimatorDebugBuffer.test.ts
@@ -4,7 +4,9 @@ import {
   clearEstimatorEntries,
   subscribeEstimatorDebug,
   ESTIMATOR_DEBUG_BUFFER_CAPACITY,
+  formatEstimatorLine,
 } from '../estimatorDebugBuffer';
+import { getRegisteredDebugBuffers } from '../../../../shared/utils/debugBufferRegistry';
 
 function makeEntry(ts: number) {
   return {
@@ -83,5 +85,68 @@ describe('estimatorDebugBuffer', () => {
     const entries = getEstimatorEntries();
     expect(entries).toHaveLength(1);
     expect(entries[0].strategy).toBeNull();
+  });
+
+  // #1348 — formatter SSOT (DebugModal UI + share dump 양쪽에서 공유).
+  describe('formatEstimatorLine (#1348)', () => {
+    it('strategy + station + arcIndex 포함', () => {
+      const line = formatEstimatorLine({
+        ts: new Date('2026-06-16T12:00:00Z').getTime(),
+        strategy: 'live-position',
+        stationName: '강남',
+        stationLine: '2',
+        arcIndex: 3,
+      });
+      expect(line).toMatch(/live-position/);
+      expect(line).toMatch(/강남\(2\)/);
+      expect(line).toMatch(/idx=3/);
+    });
+
+    it('strategy null이면 none으로 표기', () => {
+      const line = formatEstimatorLine({
+        ts: 0,
+        strategy: null,
+        stationName: null,
+        stationLine: null,
+        arcIndex: null,
+      });
+      expect(line).toMatch(/\| none \| - idx=-/);
+    });
+
+    it('stationLine null이면 - 표기', () => {
+      const line = formatEstimatorLine({
+        ts: 0,
+        strategy: 'live-position',
+        stationName: '강남',
+        stationLine: null,
+        arcIndex: 0,
+      });
+      expect(line).toMatch(/강남\(-\)/);
+      expect(line).toMatch(/idx=0/);
+    });
+  });
+
+  describe('registerDebugBuffer wiring (#1348)', () => {
+    it('module import 시 share dump registry에 등록된다', () => {
+      const sources = getRegisteredDebugBuffers();
+      const est = sources.find((s) => s.key === 'Estimator State');
+      expect(est).toBeDefined();
+    });
+
+    it('등록된 dumpLines가 현재 buffer 엔트리들을 포맷한다', () => {
+      pushEstimatorEntry({
+        ts: 0,
+        strategy: 'live-position',
+        stationName: '잠실',
+        stationLine: '2',
+        arcIndex: 2,
+      });
+      const sources = getRegisteredDebugBuffers();
+      const est = sources.find((s) => s.key === 'Estimator State');
+      const lines = est?.dumpLines() ?? [];
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatch(/잠실\(2\)/);
+      expect(lines[0]).toMatch(/idx=2/);
+    });
   });
 });

--- a/src/features/route/utils/estimatorDebugBuffer.ts
+++ b/src/features/route/utils/estimatorDebugBuffer.ts
@@ -4,6 +4,8 @@
  */
 import type { StationProgressStrategy } from './stationProgressEstimator';
 import { createDebugBuffer } from '../../../shared/utils/createDebugBuffer';
+import { registerDebugBuffer } from '../../../shared/utils/debugBufferRegistry';
+import { formatLineTime } from '../../../shared/utils/formatTime';
 
 export const ESTIMATOR_DEBUG_BUFFER_CAPACITY = 50;
 
@@ -32,3 +34,20 @@ export function clearEstimatorEntries(): void {
 export function subscribeEstimatorDebug(cb: () => void): () => void {
   return db.subscribe(cb);
 }
+
+/** #1348 — estimator 엔트리 한 줄 텍스트 포맷. share dump / UI 양쪽 SSOT. */
+export function formatEstimatorLine(entry: EstimatorDebugEntry): string {
+  const time = formatLineTime(entry.ts);
+  const strategy = entry.strategy ?? 'none';
+  const station = entry.stationName
+    ? `${entry.stationName}(${entry.stationLine ?? '-'})`
+    : '-';
+  const idx = entry.arcIndex != null ? `idx=${entry.arcIndex}` : 'idx=-';
+  return `${time} | ${strategy} | ${station} ${idx}`;
+}
+
+// #1348 — share dump SSOT 등록. module import 시점에 한 번 호출돼 자동 enumerate.
+registerDebugBuffer({
+  key: 'Estimator State',
+  dumpLines: () => getEstimatorEntries().map(formatEstimatorLine),
+});

--- a/src/shared/utils/__tests__/captureCallerStack.test.ts
+++ b/src/shared/utils/__tests__/captureCallerStack.test.ts
@@ -1,0 +1,53 @@
+import { captureCallerStack } from '../captureCallerStack';
+
+describe('captureCallerStack (#1348)', () => {
+  it('caller frame 배열을 반환한다 — 기본 5 frame', () => {
+    const stack = captureCallerStack();
+    expect(stack).not.toBeNull();
+    // V8/Hermes 모두 caller stack은 최소 1 frame 이상.
+    expect(Array.isArray(stack)).toBe(true);
+    expect((stack as string[]).length).toBeGreaterThan(0);
+    // 본 함수 자체 frame은 제외돼야 한다 — captureCallerStack 문자열이 첫 frame에
+    // 포함되면 self skip 실패.
+    expect((stack as string[])[0]).not.toMatch(/captureCallerStack/);
+  });
+
+  it('maxFrames로 보존 수를 제한할 수 있다', () => {
+    const stack = captureCallerStack(2);
+    expect(stack).not.toBeNull();
+    expect((stack as string[]).length).toBeLessThanOrEqual(2);
+  });
+
+  it('Error.stack이 undefined인 환경에서는 null 반환', () => {
+    // V8/Hermes는 new Error() 인스턴스에 직접 stack을 설정 — prototype 우회는 안 통한다.
+    // Error 생성자 자체를 spy해 stack이 undefined인 Error를 반환하도록 한다 (Hermes RN 환경 시뮬레이션).
+    const original = global.Error;
+    class NoStackError extends original {
+      constructor(message?: string) {
+        super(message);
+        this.stack = undefined;
+      }
+    }
+    (global as { Error: typeof Error }).Error = NoStackError as unknown as typeof Error;
+    try {
+      expect(captureCallerStack()).toBeNull();
+    } finally {
+      (global as { Error: typeof Error }).Error = original;
+    }
+  });
+
+  it('호출자가 깊을수록 frame이 늘어난다 — 단순 unit (서로 다른 depth에서 길이만 비교)', () => {
+    function inner(): string[] | null {
+      return captureCallerStack(10);
+    }
+    function outer(): string[] | null {
+      return inner();
+    }
+    const shallow = inner();
+    const deep = outer();
+    expect(shallow).not.toBeNull();
+    expect(deep).not.toBeNull();
+    // 더 깊이 호출하면 frame이 최소 같거나 많다.
+    expect((deep as string[]).length).toBeGreaterThanOrEqual((shallow as string[]).length);
+  });
+});

--- a/src/shared/utils/__tests__/debugBufferRegistry.test.ts
+++ b/src/shared/utils/__tests__/debugBufferRegistry.test.ts
@@ -1,0 +1,47 @@
+import {
+  __resetDebugBufferRegistryForTests,
+  getRegisteredDebugBuffers,
+  registerDebugBuffer,
+} from '../debugBufferRegistry';
+
+describe('debugBufferRegistry (#1348)', () => {
+  beforeEach(() => {
+    __resetDebugBufferRegistryForTests();
+  });
+
+  it('등록된 buffer source를 등록 순서대로 반환한다', () => {
+    registerDebugBuffer({ key: 'A', dumpLines: () => ['a1', 'a2'] });
+    registerDebugBuffer({ key: 'B', dumpLines: () => ['b1'] });
+    const sources = getRegisteredDebugBuffers();
+    expect(sources.map((s) => s.key)).toEqual(['A', 'B']);
+    expect(sources[0].dumpLines()).toEqual(['a1', 'a2']);
+    expect(sources[1].dumpLines()).toEqual(['b1']);
+  });
+
+  it('동일 key 재등록 시 마지막 등록이 우선 (테스트용 mock 대체)', () => {
+    registerDebugBuffer({ key: 'A', dumpLines: () => ['orig'] });
+    registerDebugBuffer({ key: 'A', dumpLines: () => ['mock'] });
+    const sources = getRegisteredDebugBuffers();
+    expect(sources).toHaveLength(1);
+    expect(sources[0].dumpLines()).toEqual(['mock']);
+  });
+
+  it('빈 registry는 빈 배열 반환', () => {
+    expect(getRegisteredDebugBuffers()).toEqual([]);
+  });
+
+  it('새 source 추가 시 enumerate 결과에 자동 포함된다 (확장성)', () => {
+    registerDebugBuffer({ key: 'Existing', dumpLines: () => [] });
+    expect(getRegisteredDebugBuffers().map((s) => s.key)).toEqual(['Existing']);
+    // 후속 등록.
+    registerDebugBuffer({ key: 'New', dumpLines: () => ['n1'] });
+    expect(getRegisteredDebugBuffers().map((s) => s.key)).toEqual(['Existing', 'New']);
+  });
+
+  it('__resetDebugBufferRegistryForTests로 초기화된다', () => {
+    registerDebugBuffer({ key: 'Temp', dumpLines: () => [] });
+    expect(getRegisteredDebugBuffers()).toHaveLength(1);
+    __resetDebugBufferRegistryForTests();
+    expect(getRegisteredDebugBuffers()).toHaveLength(0);
+  });
+});

--- a/src/shared/utils/__tests__/formatTime.test.ts
+++ b/src/shared/utils/__tests__/formatTime.test.ts
@@ -1,4 +1,9 @@
-import { formatArrivalTime, formatClockTime, formatClockTimeWithSeconds } from '../formatTime';
+import {
+  formatArrivalTime,
+  formatClockTime,
+  formatClockTimeWithSeconds,
+  formatLineTime,
+} from '../formatTime';
 
 describe('formatArrivalTime', () => {
   it('0초 이하이면 "곧 도착"을 반환한다', () => {
@@ -49,5 +54,18 @@ describe('formatClockTimeWithSeconds (#852)', () => {
   it('두 자리 시/분/초를 그대로 표기', () => {
     const d = new Date(2026, 5, 3, 14, 30, 45);
     expect(formatClockTimeWithSeconds(d.getTime())).toBe('14:30:45');
+  });
+});
+
+describe('formatLineTime (#1348)', () => {
+  it('HH:mm:ss en-GB 포맷', () => {
+    const d = new Date(2026, 5, 16, 14, 36, 46);
+    // en-GB locale은 24h HH:mm:ss로 안정.
+    expect(formatLineTime(d.getTime())).toBe('14:36:46');
+  });
+
+  it('한 자리 시/분/초도 두 자리로 패딩 (en-GB 표준)', () => {
+    const d = new Date(2026, 5, 16, 3, 5, 7);
+    expect(formatLineTime(d.getTime())).toBe('03:05:07');
   });
 });

--- a/src/shared/utils/captureCallerStack.ts
+++ b/src/shared/utils/captureCallerStack.ts
@@ -1,0 +1,35 @@
+/**
+ * #1348 — caller stack을 짧은 문자열 배열로 추출.
+ *
+ * 용도: setDestination 같은 cross-feature 액션의 진입점에서 "누가 호출했는가"를
+ * domain breadcrumb data에 첨부해 evidence 수집. JS의 V8/Hermes 양쪽 stack 포맷
+ * (`at fn (file:line)` / `at file:line`)을 그대로 둔다 — 원본을 보존해야 사후 재구성
+ * 시 frame 정보가 손실되지 않는다.
+ *
+ * 보존 frame 수는 호출자가 명시. 기본 5 — 호출 깊이 5단계 정도면 사용자 액션 → 컴포넌트
+ * → store action 경로가 잡힌다. caller stack 자체 frame과 `Error: caller-trace` 헤더는
+ * skip 후 반환.
+ */
+
+const DEFAULT_FRAME_COUNT = 5;
+
+/**
+ * 현재 호출 지점의 caller stack 일부를 가져온다.
+ *
+ * - `Error.stack`이 undefined(테스트 환경 mock 등)면 null 반환 — breadcrumb에서 자연스러운
+ *   "정보 없음" 분기로 처리 가능.
+ * - 반환은 trim된 frame 문자열 배열. `Error: caller-trace` 메시지 라인과 본 함수 자체 frame은 제외.
+ *
+ * V8/Hermes는 환경에 따라 inline 최적화로 본 함수 frame을 누락하기도 한다. `captureCallerStack`
+ * 문자열을 포함하는 frame을 모두 필터링해 self-skip을 robust하게 처리.
+ *
+ * @param maxFrames 보존할 frame 수 (default 5)
+ */
+export function captureCallerStack(maxFrames: number = DEFAULT_FRAME_COUNT): string[] | null {
+  const stack = new Error('caller-trace').stack;
+  if (!stack) return null;
+  const lines = stack.split('\n').map((line) => line.trim());
+  // line[0]은 `Error: caller-trace` 메시지(V8/Hermes 공통). 그 외 frame 라인만 추려서 self frame 필터.
+  const frames = lines.slice(1).filter((line) => line.length > 0 && !line.includes('captureCallerStack'));
+  return frames.slice(0, maxFrames);
+}

--- a/src/shared/utils/debugBufferRegistry.ts
+++ b/src/shared/utils/debugBufferRegistry.ts
@@ -1,0 +1,57 @@
+/**
+ * #1348 — DebugModal "Share dump" SSOT registry.
+ *
+ * 배경:
+ *   기존 `buildDumpText`는 alarm log만 enumerate. fusionDebugBuffer / estimatorDebugBuffer
+ *   등 in-memory ring buffer는 UI 섹션에는 표시되지만 share 출력에는 누락 — sticky cascade
+ *   같은 발열 root cause를 single-source(alarm log)로는 못 잡았던 사고가 발단.
+ *
+ *   대안 1: buildDumpText에 buffer마다 매개변수를 추가 — 새 buffer가 늘 때마다 share 함수
+ *           서명 + 호출자 + 본문을 동시에 손대야 한다. 정확히 이번 사고의 재발 패턴.
+ *   대안 2(채택): buffer 측이 module-eager에 registry에 dump callable을 등록. share는 registry를
+ *           순회만 한다. 새 buffer 추가 시 한 줄(`registerDebugBuffer`)이면 share에 자동 포함.
+ *
+ * 책임 분리:
+ *   - registry는 `{ key, dump }` 쌍의 ordered 모음(등록 순서 보존)만 관리.
+ *   - 포맷은 share 호출자(buildDumpText)가 결정 — 본 파일은 "어떤 buffer가 dump 가능한가"에만 관여.
+ */
+
+export interface DebugBufferSource {
+  /** dump 섹션 제목 (예: 'Fusion log', 'Estimator State'). */
+  readonly key: string;
+  /**
+   * 섹션 본문을 줄별로 반환. 빈 배열이면 호출자가 "(empty)" 같은 placeholder로 처리.
+   * 본 함수 내부에서 throw하지 않을 것 — registry 순회 도중 한 source 실패가
+   * 다른 source를 막지 않아야 한다. 호출자에서 추가 가드 없이 신뢰하도록 계약.
+   */
+  dumpLines(): readonly string[];
+}
+
+/**
+ * Module-eager singleton — buffer 모듈이 import만 되면 자동으로 등록된다.
+ * insertion order(=등록 순서)를 보존하기 위해 Map 사용. 같은 key 재등록 시 마지막 등록이 우선.
+ */
+const registry = new Map<string, DebugBufferSource>();
+
+/**
+ * buffer source 등록. 모듈 top-level에서 호출해 import 시점에 자동 등록되게 한다.
+ *
+ * 동일 key 재등록은 마지막 등록이 우선 — 테스트에서 mock dump 주입 시 유용.
+ */
+export function registerDebugBuffer(source: DebugBufferSource): void {
+  registry.set(source.key, source);
+}
+
+/**
+ * 등록된 모든 buffer source를 등록 순서대로 반환. 호출자가 enumerate해 share dump 구성.
+ */
+export function getRegisteredDebugBuffers(): readonly DebugBufferSource[] {
+  return [...registry.values()];
+}
+
+/**
+ * 테스트 전용 — registry를 초기화. production code에서는 호출 금지.
+ */
+export function __resetDebugBufferRegistryForTests(): void {
+  registry.clear();
+}

--- a/src/shared/utils/formatTime.ts
+++ b/src/shared/utils/formatTime.ts
@@ -32,3 +32,12 @@ export function formatClockTimeWithSeconds(epochMs: number | null): string {
   const ss = String(d.getSeconds()).padStart(2, '0');
   return `${hh}:${mm}:${ss}`;
 }
+
+/**
+ * #1348 — debug buffer 라인 포맷용 짧은 시각(`HH:mm:ss`). en-GB locale로 데이터셋 무관 안정.
+ * formatClockTimeWithSeconds는 (never) 분기가 있어 epoch ms가 항상 유효한 buffer 라인에는 부적합.
+ */
+export function formatLineTime(epochMs: number): string {
+  const d = new Date(epochMs);
+  return d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}


### PR DESCRIPTION
Closes #1348

## 왜 (요약)

2026-06-16 발열 root cause(useStickyStation cascade) 진단 후속. 다음 필드검증 evidence 수집의 prerequisite.

### 1) DebugModal share에 fusion log buffer가 누락돼 있었음
이번 sticky cascade 진단도 alarm log 단독으로는 root cause를 못 잡았고 fusion log를 별도로 확인해서야 발견. share dump 출력에는 alarm log만 enumerate, fusion/estimator buffer는 UI에만 표시되고 share에는 빠짐.

→ **registry 패턴**으로 buffer 모듈이 module-eager에 self-register. share 함수는 registry를 순회만 — 새 buffer 추가 시 `registerDebugBuffer` 한 줄이면 자동 포함.

### 2) setDestination caller 미식별
사용자 trip에서 `useDestinationStore.setDestination`이 14:36:46에 호출됐는데 caller가 미식별(사용자는 UI action 0건 확인). 직접 탭 / hook / silent push reconcile 어느 경로인지 불명.

→ `captureCallerStack`으로 setDestination 진입 시점에 caller stack을 캡처해 `addDomainBreadcrumb` data에 첨부. trip start / trip end / degenerate-blocked 모든 경로.

## 주요 변경

- **`src/shared/utils/debugBufferRegistry.ts`** (신규) — registry 패턴 SSOT. `{ key, dumpLines }` 형태.
- **`src/shared/utils/captureCallerStack.ts`** (신규) — `new Error().stack`을 frame 배열로 추출. V8/Hermes inline 최적화 대응으로 helper 이름 frame self-filter.
- **`src/shared/utils/formatTime.ts`** — `formatLineTime` 추가. buffer 라인 시각 포맷 SSOT.
- **`fusionDebugBuffer.ts`** + **`estimatorDebugBuffer.ts`** — line formatter를 buffer 모듈로 이전 + registry 등록.
- **`DebugModal.tsx`** — `buildDumpText`에 registry enumerate 추가. 자체 정의 formatter 제거(buffer 모듈에서 import).
- **`useDestinationStore.ts`** — setDestination 진입 시 caller 캡처 + 3개 breadcrumb에 첨부.

## 매핑 (Acceptance)

- [x] share 출력에 fusion log + estimator log + alarm log 모두 enumerate
- [x] 새 buffer 추가 시 registry 한 줄로 자동 포함 (registry 패턴)
- [x] setDestination 호출 시 caller stack이 domain breadcrumb data에 기록 (3개 분기 모두)
- [x] hot path가 아닌 setDestination 진입 시점만 캡처 (사용자 액션 빈도)
- [x] 변경 파일 100% coverage (lines/functions/branches/statements)
- [x] type-check PASS
- [x] lint(`import/no-restricted-paths`) PASS — `src/shared/`는 features/screens import 없음

## Test plan

- [x] `npm run type-check` PASS
- [x] `npm run lint` PASS
- [x] 변경 파일 100% coverage (270 tests pass)
- [ ] device evidence — 다음 trip 발생 시 share dump에 fusion log 섹션 + breadcrumb caller stack이 노출되는지 실기기 확인
- [ ] caller stack이 V8/Hermes 환경에서 helper 이름 frame을 누락하지 않고 caller만 추리는지 RN 빌드에서 검증

## 컨텍스트

- 발열 root cause 진단 메모: `memory/project_2026_06_16_sticky_cascade.md`
- 진단 방법론 lesson: `memory/lesson_check_fusion_log_with_alarm_log.md` (alarm 단독 분석 금지)
- 관련 PR: α(#1347 sticky guard, in-progress) / β(zombie cleanup, evidence 후)