### PR TITLE
fix(#1351): trip-ended backstop cleanup — launch reconciliation + sentinel rehydration에 cleanup 추가

### DIFF
--- a/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
@@ -24,6 +24,16 @@ jest.mock('../../utils/stationNotification', () => ({
   sendTripEndedNotification: (...args: unknown[]) => mockSendTripEnded(...args),
 }));
 
+const mockTriggerTripEndRecall = jest.fn();
+jest.mock('../../utils/triggerTripEndRecall', () => ({
+  triggerTripEndRecall: (...args: unknown[]) => mockTriggerTripEndRecall(...args),
+}));
+
+const mockRunTripBoundCleanups = jest.fn();
+jest.mock('../../store/tripBoundCleanups', () => ({
+  runTripBoundCleanups: (...args: unknown[]) => mockRunTripBoundCleanups(...args),
+}));
+
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),
@@ -39,6 +49,8 @@ beforeEach(async () => {
   mockGetSentinel.mockResolvedValue(null);
   mockSetSentinel.mockResolvedValue(undefined);
   mockSendTripEnded.mockResolvedValue(undefined);
+  mockTriggerTripEndRecall.mockResolvedValue({ uploaded: false });
+  mockRunTripBoundCleanups.mockResolvedValue(undefined);
   process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
 });
 
@@ -67,7 +79,7 @@ describe('runLaunchTripReconciliation', () => {
     expect(mockSendTripEnded).not.toHaveBeenCalled();
   });
 
-  it('status ended → notification + sentinel + active trip clear', async () => {
+  it('status ended → notification + recall + cleanup + sentinel + active trip clear', async () => {
     await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
     mockFetchTripStatus.mockResolvedValue({
       status: 'ended',
@@ -77,7 +89,33 @@ describe('runLaunchTripReconciliation', () => {
     await runLaunchTripReconciliation();
     expect(mockFetchTripStatus).toHaveBeenCalledWith('tk', 'https://api.test.dev');
     expect(mockSendTripEnded).toHaveBeenCalledWith('destination-arrived');
+    expect(mockTriggerTripEndRecall).toHaveBeenCalledTimes(1);
+    expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
     expect(mockSetSentinel).toHaveBeenCalledWith(1_700_000_000_000);
+    expect(await AsyncStorage.getItem(ACTIVE_TRIP_KEY)).toBeNull();
+  });
+
+  it('status ended — 호출 순서: sendTripEndedNotification → triggerTripEndRecall → runTripBoundCleanups → setTripEndedSentinel → removeItem(ACTIVE_TRIP_KEY)', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    mockFetchTripStatus.mockResolvedValue({
+      status: 'ended',
+      endedAt: 1_700_000_000_000,
+      endReason: 'destination-arrived',
+    });
+
+    // jest invocationCallOrder로 mock fn 호출 순서를 검증.
+    // ACTIVE_TRIP_KEY removeItem은 AsyncStorage 직접 호출이라 mock fn order에 잡히지 않으므로
+    // setSentinel 직후 storage가 비어 있음을 확인.
+    await runLaunchTripReconciliation();
+
+    const notifyOrder = mockSendTripEnded.mock.invocationCallOrder[0];
+    const recallOrder = mockTriggerTripEndRecall.mock.invocationCallOrder[0];
+    const cleanupOrder = mockRunTripBoundCleanups.mock.invocationCallOrder[0];
+    const sentinelOrder = mockSetSentinel.mock.invocationCallOrder[0];
+
+    expect(notifyOrder).toBeLessThan(recallOrder);
+    expect(recallOrder).toBeLessThan(cleanupOrder);
+    expect(cleanupOrder).toBeLessThan(sentinelOrder);
     expect(await AsyncStorage.getItem(ACTIVE_TRIP_KEY)).toBeNull();
   });
 
@@ -105,7 +143,7 @@ describe('runLaunchTripReconciliation', () => {
     expect(mockSendTripEnded).toHaveBeenCalledWith('unknown');
   });
 
-  it('status active → 변경 없음', async () => {
+  it('status active → 변경 없음 + cleanup/recall 호출 안 함 (회귀 0)', async () => {
     await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
     mockFetchTripStatus.mockResolvedValue({
       status: 'active',
@@ -114,15 +152,19 @@ describe('runLaunchTripReconciliation', () => {
     });
     await runLaunchTripReconciliation();
     expect(mockSendTripEnded).not.toHaveBeenCalled();
+    expect(mockTriggerTripEndRecall).not.toHaveBeenCalled();
+    expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
     expect(mockSetSentinel).not.toHaveBeenCalled();
     expect(await AsyncStorage.getItem(ACTIVE_TRIP_KEY)).toBe('tk');
   });
 
-  it('404/410 (null) → active trip clear만, notification X', async () => {
+  it('404/410 (null) → active trip clear만, notification/cleanup/recall X (기존 동작 유지)', async () => {
     await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
     mockFetchTripStatus.mockResolvedValue(null);
     await runLaunchTripReconciliation();
     expect(mockSendTripEnded).not.toHaveBeenCalled();
+    expect(mockTriggerTripEndRecall).not.toHaveBeenCalled();
+    expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
     expect(mockSetSentinel).not.toHaveBeenCalled();
     expect(await AsyncStorage.getItem(ACTIVE_TRIP_KEY)).toBeNull();
   });

--- a/src/features/alarm/hooks/useLaunchTripReconciliation.ts
+++ b/src/features/alarm/hooks/useLaunchTripReconciliation.ts
@@ -15,14 +15,22 @@
  *   1) ACTIVE_TRIP_KEY 조회. 없으면 미트립 — skip.
  *   2) tripEndedSentinel 확인. 이미 기록 있음 = silent push가 잘 도달한 케이스 — skip.
  *   3) `fetchTripStatus` 호출.
- *      - status='ended' → notification 발사 + sentinel 기록 + active trip clear.
- *        useStateRehydration이 sentinel을 보고 destination/lock store reset을 수행한다.
+ *      - status='ended' → notification 발사 + trip-end recall + storage cleanup + sentinel 기록 +
+ *        active trip clear. silent push handler와 같은 cleanup 시퀀스를 그대로 따라
+ *        사전예약/route/destination 잔존을 차단한다 (#1351 R1).
  *      - null(404/410) → active trip clear만. notification은 발사하지 않는다 (이미 정리됨,
  *        과거 notification은 다른 채널로 도달했을 가능성 또는 retention 만료).
  *      - status='active' → 변경 없음.
  *   4) 네트워크 에러 → silent fail. 다음 launch에서 재시도.
  *
  * 멱등성: sentinel이 기록되면 step 2에서 skip되므로 같은 trip에 대해 notification은 최대 1회.
+ * triggerTripEndRecall/runTripBoundCleanups 자체도 멱등이라 silent push handler와 중복 호출 안전.
+ *
+ * 호출 순서: sendTripEndedNotification → triggerTripEndRecall → runTripBoundCleanups →
+ * setTripEndedSentinel → removeItem(ACTIVE_TRIP_KEY). recall이 cleanup보다 먼저여야 한다 —
+ * cleanup이 ROUTE_KEY/DESTINATION_KEY/TRIP_ORIGIN_KEY/TRIP_STARTED_AT_KEY를 제거하므로
+ * 그 뒤에 recall이 돌면 입력이 비어 'empty'/'no-trip-start'로 skip된다
+ * (triggerTripEndRecall.ts 헤더 주석 명시).
  *
  * 호출 시점: app/_layout.tsx에서 마운트 1회. cold-launch backstop이라 AppState 'active'
  * 재진입 시 반복 fetch는 불필요 (silent push가 살아있다면 그쪽이 우선).
@@ -37,6 +45,8 @@ import {
 } from '../utils/tripEndedSentinel';
 import { sendTripEndedNotification } from '../utils/stationNotification';
 import { fetchTripStatus } from '../api/tripStatus';
+import { triggerTripEndRecall } from '../utils/triggerTripEndRecall';
+import { runTripBoundCleanups } from '../store/tripBoundCleanups';
 import { createLogger } from '../../../shared/utils/logger';
 
 const logger = createLogger('useLaunchTripReconciliation');
@@ -100,6 +110,12 @@ export async function runLaunchTripReconciliation(): Promise<void> {
       `trip ended on backend — surface notification reason=${reason} endedAt=${endedAt}`,
     );
     await sendTripEndedNotification(reason);
+    // #1351 R1 — silent push handler와 동일한 cleanup 시퀀스. alert payload trip-ended가
+    // BG handler를 호출하지 않아 cleanup이 누락된 경우 launch backstop으로 복구.
+    // recall은 cleanup이 storage를 비우기 전에 호출되어야 입력을 읽을 수 있다.
+    // 두 호출 모두 멱등 — silent push handler와 중복 호출 안전.
+    await triggerTripEndRecall();
+    await runTripBoundCleanups();
     await setTripEndedSentinel(endedAt);
     await AsyncStorage.removeItem(ACTIVE_TRIP_KEY);
   } catch (e) {

--- a/src/shared/hooks/__tests__/useStateRehydration.test.ts
+++ b/src/shared/hooks/__tests__/useStateRehydration.test.ts
@@ -25,6 +25,11 @@ jest.mock('../../infra/monitoring/breadcrumb', () => ({
   addDomainBreadcrumb: (...args: unknown[]) => mockAddDomainBreadcrumb(...args),
 }));
 
+const mockRunTripBoundCleanups = jest.fn();
+jest.mock('../../../features/alarm/store/tripBoundCleanups', () => ({
+  runTripBoundCleanups: (...args: unknown[]) => mockRunTripBoundCleanups(...args),
+}));
+
 // destination store cross-feature import는 storage helper 안에서 일어나므로 spy로 충분.
 // useDestinationStore.getState()를 그대로 사용한다 (실제 store)
 
@@ -32,6 +37,7 @@ const mockSetDestination = jest.fn();
 const mockLoadDestination = jest.fn();
 const mockLoadCustomOrigin = jest.fn();
 const mockLoadTripOrigin = jest.fn();
+const mockSetState = jest.fn();
 
 const mockReleaseLock = jest.fn();
 const mockLoadLock = jest.fn();
@@ -46,12 +52,16 @@ beforeEach(() => {
   mockLoadTripOrigin.mockResolvedValue(undefined);
   mockReleaseLock.mockResolvedValue(undefined);
   mockLoadLock.mockResolvedValue(undefined);
+  mockRunTripBoundCleanups.mockResolvedValue(undefined);
   jest.spyOn(useDestinationStore, 'getState').mockReturnValue({
     setDestination: mockSetDestination,
     loadDestination: mockLoadDestination,
     loadCustomOrigin: mockLoadCustomOrigin,
     loadTripOrigin: mockLoadTripOrigin,
   } as unknown as ReturnType<typeof useDestinationStore.getState>);
+  jest.spyOn(useDestinationStore, 'setState').mockImplementation((...args: unknown[]) => {
+    mockSetState(...args);
+  });
   jest.spyOn(useBoardingLockStore, 'getState').mockReturnValue({
     releaseLock: mockReleaseLock,
     loadLock: mockLoadLock,
@@ -86,23 +96,56 @@ describe('useStateRehydration', () => {
     });
   });
 
-  it('sentinel 없음 — store reset 호출 안 함', async () => {
+  it('sentinel 없음 — cleanup/store reset/lock release 모두 호출 안 함 (회귀 0)', async () => {
     mockGetSentinel.mockResolvedValue(null);
     mockAppState();
     renderHook(() => useStateRehydration());
     await waitFor(() => expect(mockLoadDestination).toHaveBeenCalled());
-    expect(mockSetDestination).not.toHaveBeenCalled();
+    expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+    expect(mockSetState).not.toHaveBeenCalled();
     expect(mockReleaseLock).not.toHaveBeenCalled();
     expect(mockClearSentinel).not.toHaveBeenCalled();
+    expect(mockAddDomainBreadcrumb).not.toHaveBeenCalledWith(
+      'trip',
+      'end',
+      expect.anything(),
+    );
   });
 
-  it('sentinel 있음 — setDestination(null) + releaseLock + sentinel clear', async () => {
+  it('sentinel 있음 — runTripBoundCleanups 직접 호출 + setState로 메모리 reset + breadcrumb + releaseLock + sentinel clear', async () => {
     mockGetSentinel.mockResolvedValue(1_700_000_000_000);
     mockAppState();
     renderHook(() => useStateRehydration());
     await waitFor(() => expect(mockClearSentinel).toHaveBeenCalled());
-    expect(mockSetDestination).toHaveBeenCalledWith(null);
+    // #1351 R2: setDestination(null)이 아니라 runTripBoundCleanups 직접 호출.
+    expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+    expect(mockSetDestination).not.toHaveBeenCalled();
+    // 메모리 store는 setState로 atomic reset.
+    expect(mockSetState).toHaveBeenCalledWith({
+      destination: null,
+      customOrigin: null,
+      tripOrigin: null,
+    });
+    expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('trip', 'end', {
+      reason: 'sentinel-rehydration',
+    });
     expect(mockReleaseLock).toHaveBeenCalled();
+  });
+
+  it('sentinel 있음 + prev destination null (isSwitch=false) — cleanup 정상 실행 (R2 핵심 회귀)', async () => {
+    // 이전 동작: setDestination(null)을 호출하면 store의 isSwitch가 false라서 cleanup chain이
+    // 실행되지 않았음. 새 동작은 runTripBoundCleanups를 직접 호출하므로 prev 상태 무관 cleanup 보장.
+    mockGetSentinel.mockResolvedValue(1_700_000_000_001);
+    // destination=null 기본 상태 (prev=null) 시뮬레이션 — 기본 mockReturnValue는 setDestination만
+    // 갖고 있어 prev 조회 불가하지만, runTripBoundCleanups가 store에 의존하지 않고 호출되는지가 핵심.
+    mockAppState();
+    renderHook(() => useStateRehydration());
+    await waitFor(() => expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1));
+    expect(mockSetState).toHaveBeenCalledWith({
+      destination: null,
+      customOrigin: null,
+      tripOrigin: null,
+    });
   });
 
   it("AppState 'active' 진입 시 재실행", async () => {
@@ -155,16 +198,22 @@ describe('useStateRehydration', () => {
     expect(app.remove).toHaveBeenCalled();
   });
 
-  it('active 진입에서도 sentinel 있으면 reset 호출', async () => {
+  it('active 진입에서도 sentinel 있으면 cleanup + setState reset 호출', async () => {
     const app = mockAppState();
     mockGetSentinel.mockResolvedValueOnce(null);
     renderHook(() => useStateRehydration());
     await waitFor(() => expect(mockLoadDestination).toHaveBeenCalled());
-    expect(mockSetDestination).not.toHaveBeenCalled();
+    expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+    expect(mockSetState).not.toHaveBeenCalled();
 
     mockGetSentinel.mockResolvedValueOnce(1_700_000_000_001);
     app.emit('active');
-    await waitFor(() => expect(mockSetDestination).toHaveBeenCalledWith(null));
+    await waitFor(() => expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1));
+    expect(mockSetState).toHaveBeenCalledWith({
+      destination: null,
+      customOrigin: null,
+      tripOrigin: null,
+    });
     expect(mockReleaseLock).toHaveBeenCalled();
   });
 });

--- a/src/shared/hooks/useStateRehydration.ts
+++ b/src/shared/hooks/useStateRehydration.ts
@@ -13,6 +13,7 @@ import {
   clearTripEndedSentinel,
   getTripEndedSentinel,
 } from '../../features/alarm/utils/tripEndedSentinel';
+import { runTripBoundCleanups } from '../../features/alarm/store/tripBoundCleanups';
 import { createLogger } from '../utils/logger';
 import { addDomainBreadcrumb } from '../infra/monitoring/breadcrumb';
 
@@ -57,9 +58,17 @@ async function runRehydration(trigger: 'mount' | 'active'): Promise<void> {
   const sentinel = await getTripEndedSentinel();
   if (sentinel !== null) {
     logger.info(`trigger=${trigger} trip-ended sentinel=${sentinel} → store reset`);
-    // setDestination(null)이 customOrigin/tripOrigin 메모리 동기화 + tripBoundCleanups
-    // 호출까지 atomic하게 처리한다 — storage는 이미 BG에서 cleanup됐지만 멱등.
-    useDestinationStore.getState().setDestination(null);
+    // #1351 R2 — 과거에는 setDestination(null)을 trigger로 사용했지만, prev=null인 경우
+    // isSwitch=false로 평가되어 cleanup chain이 실행되지 않는 버그가 있었다.
+    // isSwitch 의존 없이 storage cleanup을 직접 호출. 멱등이므로 Fix 1 / silent push handler와
+    // 중복 호출 안전. 메모리 store도 setState로 즉시 reset해 stale state가 노출되지 않게 한다.
+    await runTripBoundCleanups();
+    useDestinationStore.setState({
+      destination: null,
+      customOrigin: null,
+      tripOrigin: null,
+    });
+    addDomainBreadcrumb('trip', 'end', { reason: 'sentinel-rehydration' });
     await useBoardingLockStore.getState().releaseLock();
     await clearTripEndedSentinel();
   }


### PR DESCRIPTION
## 무엇을
- `useLaunchTripReconciliation`의 `status='ended'` branch에 `triggerTripEndRecall` + `runTripBoundCleanups` 추가
- `useStateRehydration`의 sentinel branch가 `setDestination(null)` 대신 `runTripBoundCleanups` 직접 호출 (`isSwitch=false` 케이스 cleanup 누락 해소)

## 왜
- backend trip-ended가 alert payload(#1342)로 발사되면 silent BG handler 호출 안 됨
- launch reconciliation backstop이 `ACTIVE_TRIP_KEY`만 cleanup하고 storage/사전예약 잔존 (R1)
- sentinel branch는 `setDestination(null)` 호출로 cleanup chain trigger 의도였으나 `prev=null`이면 `isSwitch=false`로 cleanup chain 실행 안 됨 (R2)
- 결과: 사전예약 fire 잔존 (정적인데 알람 옴), 앱 진입 시 trip 살아있음

상세 evidence + root cause는 #1351 본문 참조.

## 어떻게
- **Fix 1** (`useLaunchTripReconciliation.ts`): import 추가 + `sendTripEndedNotification` 직후 `triggerTripEndRecall` + `runTripBoundCleanups` 두 줄 추가. 호출 순서 `notify → recall → cleanup → sentinel → ACTIVE_TRIP_KEY` (recall이 cleanup 전이어야 storage를 읽음)
- **Fix 2** (`useStateRehydration.ts`): import 추가 + sentinel branch에서 `runTripBoundCleanups` 직접 호출 + `useDestinationStore.setState`로 메모리 reset + `addDomainBreadcrumb('trip', 'end', { reason: 'sentinel-rehydration' })`
- `setDestination(null)`의 isSwitch 의미 변경 X — surgical로 두 backstop만 fix (회귀 위험 / #1321 race 보호 유지)

## 테스트
- `useLaunchTripReconciliation.test.ts`: status='ended' branch에서 호출 순서 verify, `status='active'` / `null(404/410)`에서 cleanup 미호출 회귀 0건
- `useStateRehydration.test.ts`: sentinel 있을 때 `runTripBoundCleanups` 직접 호출 검증, `prev=null + sentinel set` 케이스 (isSwitch=false 무관)에서도 cleanup 호출, breadcrumb 발생, sentinel 없을 때 미호출
- `npm test` 변경 파일 100% coverage / `npm run type-check` PASS / `npm run lint` PASS

## Test plan
- [x] CI Type Check & Test
- [ ] 실기기: killed/잠금 trip-ended alert 수신 + 다음 launch → scheduled queue 0건 + destination=(none) + lockless=true + tripStartedAt=(none)
- [ ] 실기기: 정상 silent push trip-ended (회귀 0 확인)
- [ ] 실기기: 새 trip 시작 시 이전 잔존 사전예약 자동 cancel

Closes #1351