### PR TITLE
feat(#1354): A1 — scheduledAlarmReceiver suppress 시 OS scheduled queue cancel

### DIFF
--- a/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
+++ b/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
@@ -5,6 +5,7 @@ import { AppState } from 'react-native';
 jest.mock('expo-notifications', () => ({
   addNotificationReceivedListener: jest.fn(),
   getPresentedNotificationsAsync: jest.fn(),
+  cancelScheduledNotificationAsync: jest.fn(),
 }));
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
@@ -86,6 +87,7 @@ const mockSetFiredAlarms = setFiredAlarms as jest.Mock;
 const mockSetLastFiredAlarmStationName = setLastFiredAlarmStationName as jest.Mock;
 const mockAddListener = Notifications.addNotificationReceivedListener as jest.Mock;
 const mockGetPresented = Notifications.getPresentedNotificationsAsync as jest.Mock;
+const mockCancelScheduled = Notifications.cancelScheduledNotificationAsync as jest.Mock;
 const mockAsyncGetItem = AsyncStorage.getItem as jest.Mock;
 
 const DEST_JSON = JSON.stringify({ id: 'dest-1', name: '강남' });
@@ -150,6 +152,8 @@ beforeEach(async () => {
   mockSetLastFiredAlarmStationName.mockResolvedValue(undefined);
   mockGetPresented.mockResolvedValue([]);
   mockAsyncGetItem.mockResolvedValue(DEST_JSON);
+  mockCancelScheduled.mockReset();
+  mockCancelScheduled.mockResolvedValue(undefined);
   // 모든 케이스 공통: addNotificationReceivedListener 기본 핸들. 콜백 캡쳐가 필요한 케이스는 mockImplementationOnce로 override.
   mockAddListener.mockReturnValue({ remove: jest.fn() });
 });
@@ -815,5 +819,96 @@ describe('bl: fire-time 재검증 (#1282)', () => {
       expect(blChannel.registeredSigMock).not.toHaveBeenCalled();
       handle.remove();
     });
+  });
+});
+
+// #1354 — suppress 결정 시 OS scheduled queue cancel. 안 그러면 같은 identifier가 잔존해
+// 다음 ETA마다 다시 fire → 영구 misfire 재발 (dump A/B evidence).
+describe('#1354 suppress 시 OS scheduled queue cancel', () => {
+  beforeEach(() => {
+    setStorageMap({
+      'subway-now:destination': DEST_JSON,
+      'subway-now:route': ROUTE_JSON,
+    });
+  });
+
+  it('reconcileScheduledAlarmDelivery suppress 시 cancelScheduledNotificationAsync(identifier) 1회 호출', async () => {
+    mockGetRegisteredTripRouteSig.mockResolvedValueOnce('SIG-OLD');
+    mockRouteSignature.mockReturnValueOnce('SIG-NEW');
+
+    await reconcileScheduledAlarmDelivery('tba:imminent:강남');
+
+    expect(mockCancelScheduled).toHaveBeenCalledTimes(1);
+    expect(mockCancelScheduled).toHaveBeenCalledWith('tba:imminent:강남');
+  });
+
+  it('drainDeliveredScheduledAlarms 5건 중 3건 suppress 시 cancel 3회 + accepted 2건', async () => {
+    // 첫 3건 suppress (sig mismatch), 마지막 2건 pass.
+    mockGetRegisteredTripRouteSig
+      .mockResolvedValueOnce('SIG-OLD') // suppress
+      .mockResolvedValueOnce('SIG-OLD') // suppress
+      .mockResolvedValueOnce('SIG-OLD') // suppress
+      .mockResolvedValueOnce('SIG-A') // pass
+      .mockResolvedValueOnce('SIG-A'); // pass
+    mockRouteSignature
+      .mockReturnValueOnce('SIG-NEW')
+      .mockReturnValueOnce('SIG-NEW')
+      .mockReturnValueOnce('SIG-NEW')
+      .mockReturnValueOnce('SIG-A')
+      .mockReturnValueOnce('SIG-A');
+    mockGetPresented.mockResolvedValueOnce([
+      { date: 1, request: { identifier: 'tba:early:성수' } },
+      { date: 2, request: { identifier: 'tba:imminent:성수' } },
+      { date: 3, request: { identifier: 'tba:early:왕십리' } },
+      { date: 4, request: { identifier: 'tba:imminent:강남' } },
+      { date: 5, request: { identifier: 'tba:early:시청' } },
+    ]);
+    mockGetFiredAlarms.mockResolvedValueOnce(new Set());
+
+    const handle = registerScheduledAlarmListener();
+    await awaitInitialScheduledAlarmDrain();
+
+    expect(mockCancelScheduled).toHaveBeenCalledTimes(3);
+    expect(mockCancelScheduled).toHaveBeenCalledWith('tba:early:성수');
+    expect(mockCancelScheduled).toHaveBeenCalledWith('tba:imminent:성수');
+    expect(mockCancelScheduled).toHaveBeenCalledWith('tba:early:왕십리');
+    // accepted 2건만 fired set에 적재.
+    expect(mockSetFiredAlarms).toHaveBeenCalledWith(
+      'dest-1',
+      new Set(['imminent:강남', 'early:시청']),
+    );
+    handle.remove();
+  });
+
+  it("'pass' 경로에는 cancel 호출 0회 (회귀 가드)", async () => {
+    // reconcile pass.
+    await reconcileScheduledAlarmDelivery('tba:early:강남');
+    expect(mockCancelScheduled).not.toHaveBeenCalled();
+
+    // drain pass.
+    mockGetPresented.mockResolvedValueOnce([
+      { date: 1, request: { identifier: 'tba:early:강남' } },
+      { date: 2, request: { identifier: 'alarm:imminent:시청' } },
+    ]);
+    mockGetFiredAlarms.mockResolvedValueOnce(new Set());
+
+    const handle = registerScheduledAlarmListener();
+    await awaitInitialScheduledAlarmDrain();
+
+    expect(mockCancelScheduled).not.toHaveBeenCalled();
+    handle.remove();
+  });
+
+  it('기존 fired set / lastStationName 동작은 회귀 없음 (suppress된 항목은 fired set/lastStationName에 영향 X)', async () => {
+    mockGetRegisteredTripRouteSig.mockResolvedValueOnce('SIG-OLD');
+    mockRouteSignature.mockReturnValueOnce('SIG-NEW');
+
+    await reconcileScheduledAlarmDelivery('tba:imminent:강남');
+
+    // suppress 시 fired set/lastStationName 갱신 없음.
+    expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+    expect(mockSetLastFiredAlarmStationName).not.toHaveBeenCalled();
+    // cancel만 발생.
+    expect(mockCancelScheduled).toHaveBeenCalledWith('tba:imminent:강남');
   });
 });

--- a/src/features/alarm/utils/scheduledAlarmReceiver.ts
+++ b/src/features/alarm/utils/scheduledAlarmReceiver.ts
@@ -205,7 +205,13 @@ export async function reconcileScheduledAlarmDelivery(
   const parsed = parseAlarmIdentifier(identifier);
   if (!parsed) return;
 
-  if ((await revalidateByPrefix(parsed)) === 'suppress') return;
+  if ((await revalidateByPrefix(parsed)) === 'suppress') {
+    // #1354 — suppress 시 OS scheduled queue에 동일 identifier가 남아 다음 ETA에 또
+    // 발사되어 정적 misfire가 영구 재발한다. 사전 예약은 fire-and-forget이므로 명시 cancel 필요.
+    // cancelScheduledNotificationAsync는 이미 발사된 항목에도 안전 (tripBoundScheduler.ts:681).
+    await Notifications.cancelScheduledNotificationAsync(identifier);
+    return;
+  }
 
   const destinationId = await getCurrentDestinationId();
   // destinationId가 없으면 이미 trip이 종료/변경된 알람의 잔여 발화 — 상태 갱신 스킵.
@@ -246,7 +252,12 @@ async function drainDeliveredScheduledAlarms(): Promise<void> {
   for (const n of presented) {
     const parsed = parseAlarmIdentifier(n.request.identifier);
     if (!parsed) continue;
-    if ((await revalidateByPrefix(parsed)) === 'suppress') continue;
+    if ((await revalidateByPrefix(parsed)) === 'suppress') {
+      // #1354 — drain 경로도 reconcile과 동형으로 suppress 시 OS queue cancel. 같은 identifier를
+      // OS가 보존하면 다음 ETA마다 재발사되어 영구 misfire 재발.
+      await Notifications.cancelScheduledNotificationAsync(n.request.identifier);
+      continue;
+    }
     accepted.push(parsed);
   }
 


### PR DESCRIPTION
Closes #1354
Parent: #1353

## 변경

`src/features/alarm/utils/scheduledAlarmReceiver.ts` 두 곳의 suppress 분기에 OS scheduled queue cancel 추가.

- `reconcileScheduledAlarmDelivery` (단건 FG 수신/콜백 경로) — `await Notifications.cancelScheduledNotificationAsync(identifier)`
- `drainDeliveredScheduledAlarms` (BG 발사분 FG 복귀 drain 경로) — `await Notifications.cancelScheduledNotificationAsync(n.request.identifier)`

## 왜

이슈 evidence (dump A 2026-06-15 01:04, dump B 2026-06-15 02:04):
- 사전예약 `tba:imminent:성수` 등이 Scheduled queue에 잔존
- `revalidate-route-sig-mismatch`로 suppress 결정
- OS queue엔 그대로 → 다음 ETA마다 재발사 → 영구 misfire 재발

`cancelScheduledNotificationAsync`는 이미 발사된 항목에도 안전 (`tripBoundScheduler.ts:681` 주석 명시) → idempotent.

## 단위 테스트 (Acceptance)

`src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts`에 4건 추가:

1. `reconcileScheduledAlarmDelivery` suppress 시 `cancelScheduledNotificationAsync(identifier)` 1회 호출
2. `drainDeliveredScheduledAlarms` 5건 중 3건 suppress 시 cancel 3회 + accepted 2건만 fired set 적재
3. `'pass'` 경로에는 cancel 호출 0회 (회귀 가드 — reconcile/drain 모두)
4. suppress 시 fired set/lastStationName 갱신 회귀 없음

전체 51 test pass (target file). 사전 존재하던 widget/stationNotification 실패는 본 PR과 무관(origin/dev 동일 재현).

## Out of scope

- `alarm:` prefix는 BoardingLock SSOT 신뢰로 revalidation 없음 → 본 변경 무관
- `tba:` / `bl:` scheduler 본체(`prescheduleStationAlerts`, `scheduleHopsForLock`) — S1
- cross-channel cancel helper — D1

## 필드 검증 (사용자 영역)

dump A 시나리오 재현:
1. trip 시작 + 5분 이상 정적
2. ETA 도달 시점에 사전예약 fire 시도 → suppress
3. 다음 dump → Scheduled queue stale entry 0건 확인
4. `tba:` / `bl:` 양 채널 검증