### PR TITLE
feat(#1356): E1 — silent push motion=stationary suppress 시 같은 station 사전예약 cancel

### DIFF
--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -123,14 +123,20 @@ jest.mock('../../utils/boardingLockStorage', () => ({
 
 // #698 — reschedule silent push 분기에서 호출. mock으로 호출 인자/횟수만 검증.
 const mockRescheduleHopForLock = jest.fn();
+// #1356 E1 — suppress 분기에서 같은 station+phase의 bl: 사전 예약을 cancel.
+const mockCancelBlByStationPhase = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../utils/boardingLockScheduler', () => ({
   rescheduleHopForLock: (...args: unknown[]) => mockRescheduleHopForLock(...args),
+  cancelBlByStationPhase: (...args: unknown[]) => mockCancelBlByStationPhase(...args),
 }));
 
 // #918 A3 PR4 — tba 채널 reschedule. mock으로 호출 인자/횟수만 검증.
 const mockRescheduleTripBoundAlarm = jest.fn();
+// #1356 E1 — suppress 분기에서 같은 station+phase의 tba: 사전 예약을 cancel.
+const mockCancelTbaByStationPhase = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../utils/tripBoundScheduler', () => ({
   rescheduleTripBoundAlarm: (...args: unknown[]) => mockRescheduleTripBoundAlarm(...args),
+  cancelTbaByStationPhase: (...args: unknown[]) => mockCancelTbaByStationPhase(...args),
 }));
 
 const mockGetDismissSilence = jest.fn();
@@ -1473,6 +1479,82 @@ describe('silentPushTask', () => {
         expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
           expect.objectContaining({ reason: 'movement-motion-stationary' }),
         );
+      });
+    });
+
+    // #1356 E1 — silent push suppress 분기에서 같은 station+phase의 사전 예약(tba: / bl:)도 cancel.
+    // backend는 정적/out-of-range를 인식해 다음 silent push를 발사하지 않지만, 이미 OS queue에 있는
+    // 사전 예약은 시간이 되면 자체 발사 → stale "다음 역" 알람. 단건 cancel(해당 station+phase만).
+    describe('#1356 E1 — suppress 시 같은 station 사전 예약 cancel', () => {
+      it('motion=stationary suppress 시 cancelTbaByStationPhase + cancelBlByStationPhase가 1회씩 호출된다', async () => {
+        mockGetMotionStationary.mockReturnValue(true);
+        mockCheckGate.mockResolvedValue({
+          ...PASSING_GATE,
+          speedMps: 0.69,
+          accuracyM: 30,
+        });
+
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'motion-cancel' }),
+        );
+
+        expect(mockCancelTbaByStationPhase).toHaveBeenCalledTimes(1);
+        expect(mockCancelTbaByStationPhase).toHaveBeenCalledWith('강남', 'imminent');
+        expect(mockCancelBlByStationPhase).toHaveBeenCalledTimes(1);
+        expect(mockCancelBlByStationPhase).toHaveBeenCalledWith('강남', 'imminent');
+      });
+
+      it('gate-out-of-range suppress 시 cancelTbaByStationPhase + cancelBlByStationPhase가 1회씩 호출된다', async () => {
+        mockCheckGate.mockResolvedValue({
+          pass: false,
+          reason: 'out-of-range',
+          distanceM: 1500,
+          thresholdM: 800,
+          locationSource: 'cache' as const,
+          locationAgeMs: 10_000,
+        });
+
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'early', pushId: 'gate-cancel' }),
+        );
+
+        expect(mockCancelTbaByStationPhase).toHaveBeenCalledTimes(1);
+        expect(mockCancelTbaByStationPhase).toHaveBeenCalledWith('강남', 'early');
+        expect(mockCancelBlByStationPhase).toHaveBeenCalledTimes(1);
+        expect(mockCancelBlByStationPhase).toHaveBeenCalledWith('강남', 'early');
+      });
+
+      it('valid silent push pass (정상 발사) 시 cancel은 호출되지 않는다 (회귀)', async () => {
+        mockGetMotionStationary.mockReturnValue(false);
+        mockCheckGate.mockResolvedValue({
+          ...PASSING_GATE,
+          speedMps: 5,
+          accuracyM: 30,
+        });
+
+        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+
+        expect(mockLogSilentPushFired).toHaveBeenCalled();
+        expect(mockCancelTbaByStationPhase).not.toHaveBeenCalled();
+        expect(mockCancelBlByStationPhase).not.toHaveBeenCalled();
+      });
+
+      it('line 가드 suppress(lock-line-mismatch) 등 다른 분기는 cancel 미호출 (out of scope 가드)', async () => {
+        // payload.boardingLine='3' 으로 lock(boardingLine='2') 노선과 mismatch.
+        // findStationByNameAndLine은 null, findStationByName은 어떤 station 반환.
+        mockFindStationByNameAndLine.mockReturnValue(null);
+        mockFindStationByName.mockReturnValue({ name: '강남', line: '3', lat: 37.5, lng: 127.0 });
+
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'line-mismatch' }),
+        );
+
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'lock-line-mismatch' }),
+        );
+        // E1 cancel은 motion/gate suppress 분기만 적용. 다른 suppress는 변경 없음.
+        expect(mockCancelTbaByStationPhase).not.toHaveBeenCalled();
+        expect(mockCancelBlByStationPhase).not.toHaveBeenCalled();
       });
     });
 

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -57,8 +57,8 @@ import {
   checkSilentPushLocationGate,
   type GateSkipReason,
 } from '../utils/silentPushLocationGate';
-import { rescheduleHopForLock } from '../utils/boardingLockScheduler';
-import { rescheduleTripBoundAlarm } from '../utils/tripBoundScheduler';
+import { cancelBlByStationPhase, rescheduleHopForLock } from '../utils/boardingLockScheduler';
+import { cancelTbaByStationPhase, rescheduleTripBoundAlarm } from '../utils/tripBoundScheduler';
 import { ROUTE_KEY } from '../../../shared/constants/storageKeys';
 import type { Route } from '../../../shared/utils/stationRoute';
 import { alarmKey, type AlarmEvent } from '../utils/stationAlarm';
@@ -917,6 +917,12 @@ async function fireWithGate(
     });
     ackOutcome(payload.pushId, apnsToken, 'skipped', reason);
     logger.info(`gate skip reason=${gate.reason} distance=${gate.distanceM ?? '-'}`);
+    // #1356 E1 — silent fire가 suppress되는 동안 같은 station의 사전 예약(`tba:`/`bl:`)도 OS queue
+    // 에서 cancel. backend는 정적/out-of-range를 인식해 다음 silent push를 발사하지 않지만, OS queue에
+    // 잔존한 사전 예약은 시간이 되면 자체 발사 → stale "다음 역" 알람. nextWaypoint/phase는 본 분기
+    // 에서 항상 존재(SilentPushPayload 필수 필드).
+    await cancelTbaByStationPhase(payload.nextWaypoint, payload.phase);
+    await cancelBlByStationPhase(payload.nextWaypoint, payload.phase);
     return;
   }
 
@@ -952,6 +958,9 @@ async function fireWithGate(
     logger.info(
       `movement skip: reason=${movementReason} speed=${gate.speedMps ?? '-'} accuracy=${gate.accuracyM ?? '-'}`,
     );
+    // #1356 E1 — motion=stationary suppress 동안 같은 station 사전 예약도 cancel. (gate 분기와 동일 의도)
+    await cancelTbaByStationPhase(payload.nextWaypoint, payload.phase);
+    await cancelBlByStationPhase(payload.nextWaypoint, payload.phase);
     return;
   }
 

--- a/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
@@ -5,6 +5,7 @@ import {
   advanceHopWindow,
   boardingLockAlarmIdentifier,
   cancelAllHopsForLock,
+  cancelBlByStationPhase,
   clearRegisteredBlRouteSig,
   getRegisteredBlRouteSig,
   parseBoardingLockAlarmIdentifier,
@@ -326,6 +327,45 @@ describe('cancelAllHopsForLock', () => {
     mockedDismiss.mockRejectedValueOnce(new Error('not delivered'));
     await expect(cancelAllHopsForLock(lock)).resolves.toBeUndefined();
     expect(mockedCancel).toHaveBeenCalled();
+  });
+});
+
+describe('cancelBlByStationPhase (#1356 E1)', () => {
+  it('같은 stationName + phase 매칭만 cancel + remove (trainCode/hopIndex 무관)', async () => {
+    mockedGet.mockResolvedValueOnce([
+      'bl:T-100:0:early:강남',     // 매칭
+      'bl:T-100:1:early:강남',     // 매칭 (다른 hopIndex)
+      'bl:T-200:0:early:강남',     // 매칭 (다른 trainCode)
+      'bl:T-100:0:imminent:강남',  // 다른 phase
+      'bl:T-100:2:early:역삼',     // 다른 station
+      'alarm:early:강남',           // 다른 prefix
+    ]);
+
+    await cancelBlByStationPhase('강남', 'early');
+
+    expect(mockedCancel).toHaveBeenCalledTimes(3);
+    expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:early:강남');
+    expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:1:early:강남');
+    expect(mockedCancel).toHaveBeenCalledWith('bl:T-200:0:early:강남');
+    expect(mockedRemove).toHaveBeenCalledWith([
+      'bl:T-100:0:early:강남',
+      'bl:T-100:1:early:강남',
+      'bl:T-200:0:early:강남',
+    ]);
+  });
+
+  it('매칭 없으면 cancel/remove 호출 안 함 (safe no-op)', async () => {
+    mockedGet.mockResolvedValueOnce(['bl:T-100:0:imminent:강남', 'alarm:early:강남']);
+    await cancelBlByStationPhase('강남', 'early');
+    expect(mockedCancel).not.toHaveBeenCalled();
+    expect(mockedRemove).not.toHaveBeenCalled();
+  });
+
+  it('큐가 빈 경우 no-op', async () => {
+    mockedGet.mockResolvedValueOnce([]);
+    await cancelBlByStationPhase('강남', 'early');
+    expect(mockedCancel).not.toHaveBeenCalled();
+    expect(mockedRemove).not.toHaveBeenCalled();
   });
 });
 

--- a/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
@@ -472,6 +472,18 @@ describe('cancelTbaByStationPhase (#1356 E1)', () => {
     await cancelTbaByStationPhase('강남', 'early');
     expect(mockedCancel).not.toHaveBeenCalled();
   });
+
+  it('tba: prefix이지만 malformed identifier는 skip (parsed === null 가드)', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:onlyphase' },     // parse 실패 → skip
+      { identifier: 'tba::강남' },          // parse 실패 → skip
+      { identifier: 'tba:early:강남' },     // 정상 매칭
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+    await cancelTbaByStationPhase('강남', 'early');
+    expect(mockedCancel).toHaveBeenCalledTimes(1);
+    expect(mockedCancel).toHaveBeenCalledWith('tba:early:강남');
+  });
 });
 
 // #918 (A3 후속) — useTripBoundAlarmScheduler가 호출하는 caller-side helper.

--- a/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
@@ -4,6 +4,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   TRIPBOUND_WINDOW_SIZE,
   TRIP_BOUND_ALARM_PREFIX,
+  cancelTbaByStationPhase,
   cancelTripBoundAlarms,
   clearRegisteredTripRouteSig,
   deriveTripBoundStops,
@@ -425,6 +426,51 @@ describe('cancelTripBoundAlarms', () => {
     await cancelTripBoundAlarms();
     expect(removeSpy).toHaveBeenCalledWith(TRIP_BOUND_ROUTE_SIG_KEY);
     removeSpy.mockRestore();
+  });
+});
+
+describe('cancelTbaByStationPhase (#1356 E1)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLoggerInfo.mockClear();
+  });
+
+  it('같은 stationName + phaseId 매칭만 cancel (다른 phase / 다른 station / 다른 prefix 보존)', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:early:강남' },         // 매칭
+      { identifier: 'tba:early:강남:1' },       // 매칭 (중복 occurrence)
+      { identifier: 'tba:imminent:강남' },      // 다른 phase
+      { identifier: 'tba:early:역삼' },         // 다른 station
+      { identifier: 'alarm:early:강남' },       // 다른 prefix
+      { identifier: 'bl:T1:0:early:강남' },     // 다른 prefix
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+
+    await cancelTbaByStationPhase('강남', 'early');
+
+    expect(mockedCancel).toHaveBeenCalledTimes(2);
+    expect(mockedCancel).toHaveBeenCalledWith('tba:early:강남');
+    expect(mockedCancel).toHaveBeenCalledWith('tba:early:강남:1');
+    expect(mockedCancel).not.toHaveBeenCalledWith('tba:imminent:강남');
+    expect(mockedCancel).not.toHaveBeenCalledWith('tba:early:역삼');
+    expect(mockedCancel).not.toHaveBeenCalledWith('alarm:early:강남');
+    expect(mockedCancel).not.toHaveBeenCalledWith('bl:T1:0:early:강남');
+  });
+
+  it('매칭 없으면 cancel 호출 안 함 (safe no-op)', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:imminent:강남' },
+      { identifier: 'alarm:early:강남' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+    await cancelTbaByStationPhase('강남', 'early');
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('OS 큐가 빈 경우 no-op', async () => {
+    mockedGetAll.mockResolvedValue([]);
+    await cancelTbaByStationPhase('강남', 'early');
+    expect(mockedCancel).not.toHaveBeenCalled();
   });
 });
 

--- a/src/features/alarm/utils/boardingLockScheduler.ts
+++ b/src/features/alarm/utils/boardingLockScheduler.ts
@@ -317,6 +317,36 @@ export async function cancelAllHopsForLock(lock: BoardingLock): Promise<void> {
 }
 
 /**
+ * #1356 E1 — 추적 큐에서 같은 station + phase의 `bl:` 사전 예약을 cancel + 큐에서 제거.
+ *
+ * silent push가 motion=stationary 또는 location gate 게이트에서 suppress될 때 호출. backend는
+ * 정적 상태를 인식해 silent push를 새로 발사하지 않지만, 이미 OS queue에 들어있는 같은 station의
+ * `bl:` 사전 예약은 시간이 되면 자체적으로 발사된다 — 그 stale fire를 차단한다.
+ *
+ * 매칭 대상: `bl:*:*:*:${stationName}` (trainCode/hopIndex 무관, phase 일치). lock identity가 바뀌어도
+ * 같은 station+phase 알람은 잘못된 fire이므로 정리. {@link parseBoardingLockAlarmIdentifier}로 station
+ * 매칭은 `isSameStationName`을 거쳐 노선별 부제(예: '서울대입구역(관악구청)') 차이도 수용한다.
+ */
+export async function cancelBlByStationPhase(
+  stationName: string,
+  phase: AlarmPhaseId,
+): Promise<void> {
+  const current = await getScheduledNotificationIds();
+  const toCancel = current.filter((id) => {
+    const parsed = parseBoardingLockAlarmIdentifier(id);
+    if (!parsed) return false;
+    if (parsed.phase !== phase) return false;
+    return isSameStationName(parsed.stationName, stationName);
+  });
+  if (toCancel.length === 0) return;
+  await cancelAndDismiss(toCancel);
+  await removeScheduledNotificationIds(toCancel);
+  logger.info(
+    `cancelled ${toCancel.length} bl alarms for station=${stationName} phase=${phase}`,
+  );
+}
+
+/**
  * 큐 전체를 비운다 — SCHEDULED_NOTIFICATIONS 키 안의 `bl:` prefix 항목만.
  * 마운트 시점 위생 처리용 (예: app restart 후 stale 큐 정리). cancelAllHopsForLock과 동일하게
  * 발사된 알람은 dismiss까지 시도한다.

--- a/src/features/alarm/utils/tripBoundScheduler.ts
+++ b/src/features/alarm/utils/tripBoundScheduler.ts
@@ -506,6 +506,42 @@ function findOccurrenceIndex(
   return -1;
 }
 
+/**
+ * #1356 E1 — 같은 station + phase의 `tba:` 사전 예약을 cancel.
+ *
+ * silent push가 motion=stationary 또는 location gate 게이트에서 suppress될 때 호출. backend는
+ * 정적 상태를 인식해 silent push를 새로 발사하지 않지만, 이미 OS queue에 들어있는 같은 station+phase
+ * 의 `tba:` 사전 예약은 시간이 되면 자체적으로 발사된다 — 그 stale fire를 차단한다.
+ *
+ * 매칭: `parsed.stationName`을 `isSameStationName`으로 stationName과 비교, `parsed.phaseId`와 phase
+ * 일치. 같은 station이 중복 등장하는 경우 모든 occurrence의 해당 phase가 cancel — 정지 상태에서 같은
+ * station의 사전 예약은 occurrence 관계없이 모두 stale.
+ *
+ * scheduler queue API(`getAllScheduledNotificationsAsync`)를 직접 조회. SCHEDULED_NOTIFICATIONS
+ * 추적 큐(`bl:` 용)와 별도 — `tba:`는 OS API에 단일 SSOT.
+ */
+export async function cancelTbaByStationPhase(
+  stationName: string,
+  phase: AlarmPhaseId,
+): Promise<void> {
+  const all = await Notifications.getAllScheduledNotificationsAsync();
+  let cancelled = 0;
+  for (const req of all) {
+    if (!req.identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) continue;
+    const parsed = parseTripBoundAlarmIdentifier(req.identifier);
+    if (parsed === null) continue;
+    if (parsed.phaseId !== phase) continue;
+    if (!isSameStationName(parsed.stationName, stationName)) continue;
+    await Notifications.cancelScheduledNotificationAsync(req.identifier);
+    cancelled++;
+  }
+  if (cancelled > 0) {
+    logger.info(
+      `cancelled ${cancelled} tba alarms for station=${stationName} phase=${phase}`,
+    );
+  }
+}
+
 export interface RescheduleTripBoundAlarmParams {
   /** 정정 대상 stop의 canonical 역명 (silent push payload.nextStation과 동일 비교). */
   stationName: string;


### PR DESCRIPTION
Closes #1356
Parent: #1353
선행: #1355 (D1, cross-channel cancel helper). **#1355 머지 후 진행** — 본 PR이 helper(`cancelTbaByStationPhase`, `cancelBlByStationPhase`)를 직접 export하므로 #1355와 머지 순서에 따라 conflict 가능 (signature는 의도적으로 동일).

## 변경

### `silentPushTask.fireWithGate` (suppress 분기 2곳)

- **gate-out-of-range / location gate suppress** — 같은 station+phase의 `tba:` / `bl:` 사전 예약 cancel
- **motion=stationary suppress** (CMMotionActivity) — 동일 cancel

`payload.nextWaypoint` + `payload.phase`는 `SilentPushPayload`의 필수 필드라 본 분기에서 항상 존재.

### `boardingLockScheduler.cancelBlByStationPhase` (신규 export)

- 추적 큐(`SCHEDULED_NOTIFICATIONS`)에서 `parseBoardingLockAlarmIdentifier` 통과 + `isSameStationName(parsed.stationName, stationName)` + `parsed.phase === phase` 항목만 cancel + dismiss + remove.
- trainCode/hopIndex 무관 — 정지 상태에서는 같은 station+phase의 모든 lock 알람이 stale.

### `tripBoundScheduler.cancelTbaByStationPhase` (신규 export)

- `getAllScheduledNotificationsAsync()`를 직접 조회 (`tba:`는 OS queue가 SSOT).
- `parsed.phaseId === phase` + `isSameStationName` 일치 항목만 cancel.
- 같은 station 중복 occurrence 모두 매칭 — 정지 중에는 occurrence 관계없이 stale.

## 단위 테스트

### `silentPushTask` (4건, acceptance)

- motion=stationary suppress 시 `cancelTbaByStationPhase` + `cancelBlByStationPhase` 1회씩 (강남, imminent)
- gate-out-of-range suppress 시 동일 호출 (강남, early)
- valid silent push 정상 발사 시 cancel 0회 (회귀)
- 다른 suppress 분기(`lock-line-mismatch`) 시 cancel 0회 (out of scope 가드)

### scheduler unit (6건)

- `cancelBlByStationPhase`: trainCode/hopIndex 무관 매칭 / 미매칭 no-op / 빈 큐 no-op
- `cancelTbaByStationPhase`: occurrence 중복 매칭 / 다른 phase·station·prefix 보존 / 미매칭 no-op / 빈 큐 no-op

## 회귀 보호 (out of scope)

- 후속 hop 일괄 cancel — 별도 이슈
- payload type 위반 케이스(stationName/phaseId 부재) — type-level로 도달 불가

## 검증

- `npm test` — 본 PR 추가/수정 333 tests 통과 (impact suite 3개). 사전 실패 2 suite(widgetStorage, stationNotification)는 dev 기준에서도 동일 — 본 PR과 무관.
- `npm run type-check` — 통과

## 필드 검증 (사용자 책임)

정적 5분+ trip:
1. lock active 상태로 5분 이상 정적 유지
2. backend silent push 수신 시점에 motion gate suppress 발생
3. dump 캡처 → 해당 station 사전예약 0건 (queue stale 0건)