### PR TITLE
feat(#1355): D1 — silent push reschedule cross-channel cancel

### DIFF
--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -123,14 +123,20 @@ jest.mock('../../utils/boardingLockStorage', () => ({
 
 // #698 — reschedule silent push 분기에서 호출. mock으로 호출 인자/횟수만 검증.
 const mockRescheduleHopForLock = jest.fn();
+// #1355 D1 — cross-channel cancel helper.
+const mockCancelBlByStationPhase = jest.fn();
 jest.mock('../../utils/boardingLockScheduler', () => ({
   rescheduleHopForLock: (...args: unknown[]) => mockRescheduleHopForLock(...args),
+  cancelBlByStationPhase: (...args: unknown[]) => mockCancelBlByStationPhase(...args),
 }));
 
 // #918 A3 PR4 — tba 채널 reschedule. mock으로 호출 인자/횟수만 검증.
 const mockRescheduleTripBoundAlarm = jest.fn();
+// #1355 D1 — cross-channel cancel helper.
+const mockCancelTbaByStationPhase = jest.fn();
 jest.mock('../../utils/tripBoundScheduler', () => ({
   rescheduleTripBoundAlarm: (...args: unknown[]) => mockRescheduleTripBoundAlarm(...args),
+  cancelTbaByStationPhase: (...args: unknown[]) => mockCancelTbaByStationPhase(...args),
 }));
 
 const mockGetDismissSilence = jest.fn();
@@ -262,6 +268,11 @@ describe('silentPushTask', () => {
     mockTriggerTripEndRecall.mockResolvedValue({ uploaded: false });
     // #698 — 기본 graceful: 1건 cancel + 1건 schedule. 개별 테스트에서 override.
     mockRescheduleHopForLock.mockResolvedValue({ cancelled: 1, scheduled: 1 });
+    // #918 A3 PR4 — tba reschedule 기본 graceful.
+    mockRescheduleTripBoundAlarm.mockResolvedValue({ cancelled: 0, scheduled: 0 });
+    // #1355 D1 — cross-channel cancel 기본 0건.
+    mockCancelTbaByStationPhase.mockResolvedValue(0);
+    mockCancelBlByStationPhase.mockResolvedValue(0);
     // #1323 — trip-ended surface 기본값. dedup은 기본 미발사(false).
     mockSendTripEndedNotification.mockResolvedValue(undefined);
     mockHasFiredPushId.mockResolvedValue(false);
@@ -1800,6 +1811,77 @@ describe('silentPushTask', () => {
             expect(mockRescheduleTripBoundAlarm).toHaveBeenCalledTimes(1);
             const tbaArg = mockRescheduleTripBoundAlarm.mock.calls[0][0];
             expect(tbaArg.occurrenceIdx).toBeUndefined();
+          });
+        });
+
+        // #1355 D1 — silent push reschedule cross-channel cancel.
+        // bl reschedule → 반대 채널(tba) 같은 station+phase 사전 예약 cancel,
+        // tba reschedule → 반대 채널(bl) 같은 station+phase 사전 예약 cancel.
+        // payload 한 건당 ALARM_PHASES(early + imminent) 모두에 대해 1회씩 호출되도록 fan-out.
+        describe('cross-channel cancel (#1355 D1)', () => {
+          it('applyRescheduleBl 진입 시 같은 station+phase의 tba 사전 예약을 phase별 1회씩 cancel', async () => {
+            setStorage();
+            await handleSilentPush(
+              reschedulePayload({
+                newArrivalTimeEpoch: 9_999_999_999_999,
+                channels: ['bl'],
+              }),
+            );
+            // ALARM_PHASES = [early, imminent] → 2회 호출, 모두 nextStation='사가정' 대상.
+            expect(mockCancelTbaByStationPhase).toHaveBeenCalledTimes(2);
+            expect(mockCancelTbaByStationPhase).toHaveBeenNthCalledWith(1, '사가정', 'early');
+            expect(mockCancelTbaByStationPhase).toHaveBeenNthCalledWith(2, '사가정', 'imminent');
+            // 반대 채널(bl) cancel은 호출되지 않아야 함 (정밀성).
+            expect(mockCancelBlByStationPhase).not.toHaveBeenCalled();
+          });
+
+          it('applyRescheduleTba 진입 시 같은 station+phase의 bl 사전 예약을 phase별 1회씩 cancel', async () => {
+            setStorage();
+            await handleSilentPush(
+              reschedulePayload({
+                newArrivalTimeEpoch: 9_999_999_999_999,
+                channels: ['tba'],
+              }),
+            );
+            expect(mockCancelBlByStationPhase).toHaveBeenCalledTimes(2);
+            expect(mockCancelBlByStationPhase).toHaveBeenNthCalledWith(1, '사가정', 'early');
+            expect(mockCancelBlByStationPhase).toHaveBeenNthCalledWith(2, '사가정', 'imminent');
+            // 반대 채널(tba) cancel은 호출되지 않아야 함.
+            expect(mockCancelTbaByStationPhase).not.toHaveBeenCalled();
+          });
+
+          it('bl skip path(lock 없음)에서는 cross-cancel도 미호출 (정밀성)', async () => {
+            // lock null이면 applyRescheduleBl는 cross-cancel 전에 early-return.
+            // 다른 station/phase의 사전 예약이 잘못 cancel되지 않도록 보장.
+            setStorage({ lock: null });
+            await handleSilentPush(
+              reschedulePayload({
+                newArrivalTimeEpoch: 9_999_999_999_999,
+                channels: ['bl'],
+              }),
+            );
+            expect(mockRescheduleHopForLock).not.toHaveBeenCalled();
+            expect(mockCancelTbaByStationPhase).not.toHaveBeenCalled();
+            expect(mockCancelBlByStationPhase).not.toHaveBeenCalled();
+          });
+
+          it('반대 채널 사전 예약이 없을 때 safe no-op (helper 0 반환에 대해 throw 없이 진행)', async () => {
+            setStorage();
+            // helper가 0건 cancel 반환 — 정상 reschedule 흐름이 그대로 이어져야 함.
+            mockCancelTbaByStationPhase.mockResolvedValue(0);
+            mockCancelBlByStationPhase.mockResolvedValue(0);
+            await handleSilentPush(
+              reschedulePayload({
+                newArrivalTimeEpoch: 9_999_999_999_999,
+                channels: ['bl', 'tba'],
+              }),
+            );
+            // 두 채널 모두 reschedule이 정상 진행됨.
+            expect(mockRescheduleHopForLock).toHaveBeenCalledTimes(1);
+            expect(mockRescheduleTripBoundAlarm).toHaveBeenCalledTimes(1);
+            // 각 reschedule이 두 phase에 대해 cross-cancel을 호출.
+            expect(mockCancelTbaByStationPhase).toHaveBeenCalledTimes(2);
+            expect(mockCancelBlByStationPhase).toHaveBeenCalledTimes(2);
           });
         });
       });

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -57,8 +57,15 @@ import {
   checkSilentPushLocationGate,
   type GateSkipReason,
 } from '../utils/silentPushLocationGate';
-import { rescheduleHopForLock } from '../utils/boardingLockScheduler';
-import { rescheduleTripBoundAlarm } from '../utils/tripBoundScheduler';
+import {
+  rescheduleHopForLock,
+  cancelBlByStationPhase,
+} from '../utils/boardingLockScheduler';
+import {
+  rescheduleTripBoundAlarm,
+  cancelTbaByStationPhase,
+} from '../utils/tripBoundScheduler';
+import { ALARM_PHASES } from '../utils/alarmPhases';
 import { ROUTE_KEY } from '../../../shared/constants/storageKeys';
 import type { Route } from '../../../shared/utils/stationRoute';
 import { alarmKey, type AlarmEvent } from '../utils/stationAlarm';
@@ -728,15 +735,7 @@ async function applyReschedule(
     }
     // tba 채널 (#918 A3 PR4) — lock-free trip-bound 사전 예약 정정.
     if (channels.includes('tba')) {
-      await rescheduleTripBoundAlarm({
-        stationName: payload.nextStation,
-        newArrivalMs: payload.newArrivalTimeEpoch,
-        route,
-        destinationName,
-        now: receivedAt,
-        // #1193 — 중복역 trip은 backend가 occurrenceIdx를 명시. 미지정 시 0(첫 등장).
-        occurrenceIdx: payload.occurrenceIdx,
-      });
+      await applyRescheduleTba(payload, route, destinationName, receivedAt);
     }
   } catch (e) {
     logger.error('reschedule apply 실패:', e);
@@ -764,6 +763,12 @@ async function applyRescheduleBl(
     );
     return;
   }
+  // #1355 D1 — cross-channel cancel: 같은 station+phase의 `tba:` 사전 예약 제거.
+  // bl 채널이 정정 신호의 source-of-truth가 되므로 반대 채널의 stale 항목이 OS 큐에 잔존해
+  // 같은 ETA에 중복 banner fire되는 회귀를 차단한다.
+  for (const phase of ALARM_PHASES) {
+    await cancelTbaByStationPhase(payload.nextStation, phase.id);
+  }
   await rescheduleHopForLock({
     lock,
     route,
@@ -771,6 +776,31 @@ async function applyRescheduleBl(
     nextStation: payload.nextStation,
     newArrivalMs: payload.newArrivalTimeEpoch,
     now: receivedAt,
+  });
+}
+
+/**
+ * tba(trip-bound) 채널 정정 — lock 의존 없음. cross-channel `bl:` 사전 예약을 먼저 cleanup하고
+ * `rescheduleTripBoundAlarm`에 위임한다.
+ */
+async function applyRescheduleTba(
+  payload: RescheduleSilentPushPayload,
+  route: NonNullable<Route>,
+  destinationName: string,
+  receivedAt: number,
+): Promise<void> {
+  // #1355 D1 — cross-channel cancel: 같은 station+phase의 `bl:` 사전 예약 제거.
+  for (const phase of ALARM_PHASES) {
+    await cancelBlByStationPhase(payload.nextStation, phase.id);
+  }
+  await rescheduleTripBoundAlarm({
+    stationName: payload.nextStation,
+    newArrivalMs: payload.newArrivalTimeEpoch,
+    route,
+    destinationName,
+    now: receivedAt,
+    // #1193 — 중복역 trip은 backend가 occurrenceIdx를 명시. 미지정 시 0(첫 등장).
+    occurrenceIdx: payload.occurrenceIdx,
   });
 }
 

--- a/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
@@ -5,6 +5,7 @@ import {
   advanceHopWindow,
   boardingLockAlarmIdentifier,
   cancelAllHopsForLock,
+  cancelBlByStationPhase,
   clearRegisteredBlRouteSig,
   getRegisteredBlRouteSig,
   parseBoardingLockAlarmIdentifier,
@@ -326,6 +327,96 @@ describe('cancelAllHopsForLock', () => {
     mockedDismiss.mockRejectedValueOnce(new Error('not delivered'));
     await expect(cancelAllHopsForLock(lock)).resolves.toBeUndefined();
     expect(mockedCancel).toHaveBeenCalled();
+  });
+});
+
+// #1355 D1 — silent push reschedule cross-channel cancel helper.
+describe('cancelBlByStationPhase (#1355 D1)', () => {
+  const mockedGetAll =
+    Notifications.getAllScheduledNotificationsAsync as jest.MockedFunction<
+      typeof Notifications.getAllScheduledNotificationsAsync
+    >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('같은 stationName + phase의 `bl:` 사전 예약만 cancel하고 추적 큐에서 제거', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'bl:T-100:0:early:강남' },
+      { identifier: 'bl:T-100:0:imminent:강남' },
+      { identifier: 'bl:T-100:1:early:사가정' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+
+    const cancelled = await cancelBlByStationPhase('강남', 'early');
+
+    expect(cancelled).toBe(1);
+    expect(mockedCancel).toHaveBeenCalledTimes(1);
+    expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:early:강남');
+    expect(mockedRemove).toHaveBeenCalledWith(['bl:T-100:0:early:강남']);
+  });
+
+  it('반대 prefix(`tba:`/`alarm:`)는 건드리지 않는다 (정밀성)', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:early:강남' },
+      { identifier: 'alarm:early:강남' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+
+    const cancelled = await cancelBlByStationPhase('강남', 'early');
+
+    expect(cancelled).toBe(0);
+    expect(mockedCancel).not.toHaveBeenCalled();
+    expect(mockedRemove).not.toHaveBeenCalled();
+  });
+
+  it('다른 trainCode/hopIndex라도 같은 station+phase면 모두 cancel — cross-channel은 lock 식별 무시', async () => {
+    // 환승/lock 전환 race로 같은 station+phase의 다른 trainCode 잔재가 있을 수 있다.
+    // cross-channel 정정 시점에서는 모두 stale.
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'bl:T-100:0:early:강남' },
+      { identifier: 'bl:T-200:3:early:강남' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+
+    const cancelled = await cancelBlByStationPhase('강남', 'early');
+
+    expect(cancelled).toBe(2);
+    expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:early:강남');
+    expect(mockedCancel).toHaveBeenCalledWith('bl:T-200:3:early:강남');
+  });
+
+  it('다른 phase는 보존', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'bl:T-100:0:imminent:강남' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+
+    const cancelled = await cancelBlByStationPhase('강남', 'early');
+
+    expect(cancelled).toBe(0);
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('parse 실패 identifier는 graceful skip', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'bl:malformed' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+
+    const cancelled = await cancelBlByStationPhase('강남', 'early');
+
+    expect(cancelled).toBe(0);
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('OS 큐가 비어 있으면 safe no-op (cancel/remove 미호출)', async () => {
+    mockedGetAll.mockResolvedValue([]);
+    const cancelled = await cancelBlByStationPhase('강남', 'early');
+    expect(cancelled).toBe(0);
+    expect(mockedCancel).not.toHaveBeenCalled();
+    expect(mockedRemove).not.toHaveBeenCalled();
   });
 });
 

--- a/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
@@ -450,56 +450,41 @@ describe('cancelTbaByStationPhase (#1355 D1)', () => {
     expect(mockedCancel).toHaveBeenCalledWith('tba:early:강남');
   });
 
-  it('반대 prefix(`bl:`/`alarm:`)는 건드리지 않는다 (정밀성)', async () => {
-    mockedGetAll.mockResolvedValue([
-      { identifier: 'bl:T1:0:early:강남' },
-      { identifier: 'alarm:early:강남' },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ] as any);
-
+  it.each([
+    {
+      name: '반대 prefix(`bl:`/`alarm:`)는 건드리지 않는다 (정밀성)',
+      ids: ['bl:T1:0:early:강남', 'alarm:early:강남'],
+      expectedCancelled: 0,
+      expectedCalls: [] as string[],
+    },
+    {
+      name: '다른 station/phase는 보존',
+      ids: ['tba:imminent:강남', 'tba:early:사가정'],
+      expectedCancelled: 0,
+      expectedCalls: [],
+    },
+    {
+      name: '중복역(:n suffix)도 같은 stationName이면 모두 cancel — cross-channel은 모든 occurrence stale',
+      ids: ['tba:early:강남', 'tba:early:강남:1'],
+      expectedCancelled: 2,
+      expectedCalls: ['tba:early:강남', 'tba:early:강남:1'],
+    },
+    {
+      name: 'parse 실패 identifier는 graceful skip',
+      ids: ['tba:malformed'],
+      expectedCancelled: 0,
+      expectedCalls: [],
+    },
+  ])('$name', async ({ ids, expectedCancelled, expectedCalls }) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockedGetAll.mockResolvedValue(ids.map((identifier) => ({ identifier })) as any);
     const cancelled = await cancelTbaByStationPhase('강남', 'early');
-
-    expect(cancelled).toBe(0);
-    expect(mockedCancel).not.toHaveBeenCalled();
-  });
-
-  it('다른 station/phase는 보존', async () => {
-    mockedGetAll.mockResolvedValue([
-      { identifier: 'tba:imminent:강남' }, // 다른 phase
-      { identifier: 'tba:early:사가정' }, // 다른 station
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ] as any);
-
-    const cancelled = await cancelTbaByStationPhase('강남', 'early');
-
-    expect(cancelled).toBe(0);
-    expect(mockedCancel).not.toHaveBeenCalled();
-  });
-
-  it('중복역(:n suffix)도 같은 stationName이면 모두 cancel — cross-channel은 모든 occurrence stale', async () => {
-    mockedGetAll.mockResolvedValue([
-      { identifier: 'tba:early:강남' }, // occurrenceIdx=0
-      { identifier: 'tba:early:강남:1' }, // occurrenceIdx=1
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ] as any);
-
-    const cancelled = await cancelTbaByStationPhase('강남', 'early');
-
-    expect(cancelled).toBe(2);
-    expect(mockedCancel).toHaveBeenCalledWith('tba:early:강남');
-    expect(mockedCancel).toHaveBeenCalledWith('tba:early:강남:1');
-  });
-
-  it('parse 실패 identifier는 graceful skip', async () => {
-    mockedGetAll.mockResolvedValue([
-      { identifier: 'tba:malformed' }, // parseTripBoundAlarmIdentifier가 null 반환
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ] as any);
-
-    const cancelled = await cancelTbaByStationPhase('강남', 'early');
-
-    expect(cancelled).toBe(0);
-    expect(mockedCancel).not.toHaveBeenCalled();
+    expect(cancelled).toBe(expectedCancelled);
+    if (expectedCalls.length === 0) {
+      expect(mockedCancel).not.toHaveBeenCalled();
+    } else {
+      for (const id of expectedCalls) expect(mockedCancel).toHaveBeenCalledWith(id);
+    }
   });
 
   it('OS 큐가 비어 있으면 safe no-op', async () => {

--- a/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
@@ -4,6 +4,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   TRIPBOUND_WINDOW_SIZE,
   TRIP_BOUND_ALARM_PREFIX,
+  cancelTbaByStationPhase,
   cancelTripBoundAlarms,
   clearRegisteredTripRouteSig,
   deriveTripBoundStops,
@@ -425,6 +426,87 @@ describe('cancelTripBoundAlarms', () => {
     await cancelTripBoundAlarms();
     expect(removeSpy).toHaveBeenCalledWith(TRIP_BOUND_ROUTE_SIG_KEY);
     removeSpy.mockRestore();
+  });
+});
+
+// #1355 D1 — silent push reschedule cross-channel cancel helper.
+describe('cancelTbaByStationPhase (#1355 D1)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('같은 stationName + phaseId의 `tba:` 사전 예약만 cancel', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:early:강남' },
+      { identifier: 'tba:imminent:강남' },
+      { identifier: 'tba:early:사가정' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+
+    const cancelled = await cancelTbaByStationPhase('강남', 'early');
+
+    expect(cancelled).toBe(1);
+    expect(mockedCancel).toHaveBeenCalledTimes(1);
+    expect(mockedCancel).toHaveBeenCalledWith('tba:early:강남');
+  });
+
+  it('반대 prefix(`bl:`/`alarm:`)는 건드리지 않는다 (정밀성)', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'bl:T1:0:early:강남' },
+      { identifier: 'alarm:early:강남' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+
+    const cancelled = await cancelTbaByStationPhase('강남', 'early');
+
+    expect(cancelled).toBe(0);
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('다른 station/phase는 보존', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:imminent:강남' }, // 다른 phase
+      { identifier: 'tba:early:사가정' }, // 다른 station
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+
+    const cancelled = await cancelTbaByStationPhase('강남', 'early');
+
+    expect(cancelled).toBe(0);
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('중복역(:n suffix)도 같은 stationName이면 모두 cancel — cross-channel은 모든 occurrence stale', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:early:강남' }, // occurrenceIdx=0
+      { identifier: 'tba:early:강남:1' }, // occurrenceIdx=1
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+
+    const cancelled = await cancelTbaByStationPhase('강남', 'early');
+
+    expect(cancelled).toBe(2);
+    expect(mockedCancel).toHaveBeenCalledWith('tba:early:강남');
+    expect(mockedCancel).toHaveBeenCalledWith('tba:early:강남:1');
+  });
+
+  it('parse 실패 identifier는 graceful skip', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:malformed' }, // parseTripBoundAlarmIdentifier가 null 반환
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+
+    const cancelled = await cancelTbaByStationPhase('강남', 'early');
+
+    expect(cancelled).toBe(0);
+    expect(mockedCancel).not.toHaveBeenCalled();
+  });
+
+  it('OS 큐가 비어 있으면 safe no-op', async () => {
+    mockedGetAll.mockResolvedValue([]);
+    const cancelled = await cancelTbaByStationPhase('강남', 'early');
+    expect(cancelled).toBe(0);
+    expect(mockedCancel).not.toHaveBeenCalled();
   });
 });
 

--- a/src/features/alarm/utils/boardingLockScheduler.ts
+++ b/src/features/alarm/utils/boardingLockScheduler.ts
@@ -317,6 +317,40 @@ export async function cancelAllHopsForLock(lock: BoardingLock): Promise<void> {
 }
 
 /**
+ * #1355 D1 — silent push reschedule cross-channel cancel.
+ *
+ * 같은 (stationName, phaseId)에 해당하는 `bl:` 사전 예약을 모두 cancel한다. 반대 채널(`tba:`)의
+ * `applyRescheduleTba`가 진입 시점에 호출 — 한쪽 채널이 정정될 때 다른 채널의 stale 사전 예약이
+ * OS 큐에 잔존해 ETA 도달 시 중복 banner fire되는 회귀를 차단한다.
+ *
+ * stationName 비교는 `isSameStationName`(canonical 정규화)로 표기 차이를 흡수한다.
+ * trainCode/hopIndex는 무시 — cross-channel 정정 시점에서 lock 식별이 불필요하다
+ * (해당 (stationName, phaseId)에 대응하는 모든 `bl:` 항목이 stale).
+ *
+ * OS queue cancel + 추적 큐(SCHEDULED_NOTIFICATIONS)에서 제거. 매칭이 없으면 safe no-op.
+ */
+export async function cancelBlByStationPhase(
+  stationName: string,
+  phaseId: AlarmPhaseId,
+): Promise<number> {
+  const all = await Notifications.getAllScheduledNotificationsAsync();
+  const toCancel: string[] = [];
+  for (const req of all) {
+    if (!req.identifier.startsWith(BOARDING_LOCK_ALARM_PREFIX)) continue;
+    const parsed = parseBoardingLockAlarmIdentifier(req.identifier);
+    if (parsed === null) continue;
+    if (parsed.phase !== phaseId) continue;
+    if (!isSameStationName(parsed.stationName, stationName)) continue;
+    toCancel.push(req.identifier);
+  }
+  if (toCancel.length > 0) {
+    await cancelAndDismiss(toCancel);
+    await removeScheduledNotificationIds(toCancel);
+  }
+  return toCancel.length;
+}
+
+/**
  * 큐 전체를 비운다 — SCHEDULED_NOTIFICATIONS 키 안의 `bl:` prefix 항목만.
  * 마운트 시점 위생 처리용 (예: app restart 후 stale 큐 정리). cancelAllHopsForLock과 동일하게
  * 발사된 알람은 dismiss까지 시도한다.

--- a/src/features/alarm/utils/tripBoundScheduler.ts
+++ b/src/features/alarm/utils/tripBoundScheduler.ts
@@ -675,6 +675,37 @@ export async function rescheduleTripBoundAlarm(
 }
 
 /**
+ * #1355 D1 — silent push reschedule cross-channel cancel.
+ *
+ * 같은 (stationName, phaseId)에 해당하는 `tba:` 사전 예약을 모두 cancel한다. 반대 채널(`bl:`)의
+ * `applyRescheduleBl`가 진입 시점에 호출 — 한쪽 채널이 정정될 때 다른 채널의 stale 사전 예약이
+ * OS 큐에 잔존해 ETA 도달 시 중복 banner fire되는 회귀를 차단한다.
+ *
+ * stationName 비교는 `isSameStationName`(canonical 정규화)로 표기 차이를 흡수한다.
+ * occurrenceIdx는 무시 — 같은 stationName + phaseId의 모든 occurrence를 cancel한다
+ * (cross-channel 정정 시 동일 stop의 모든 occurrence가 stale로 간주되는 게 안전).
+ *
+ * 매칭되는 항목이 없으면 safe no-op(0건 cancel).
+ */
+export async function cancelTbaByStationPhase(
+  stationName: string,
+  phaseId: AlarmPhaseId,
+): Promise<number> {
+  const all = await Notifications.getAllScheduledNotificationsAsync();
+  let cancelled = 0;
+  for (const req of all) {
+    if (!req.identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) continue;
+    const parsed = parseTripBoundAlarmIdentifier(req.identifier);
+    if (parsed === null) continue;
+    if (parsed.phaseId !== phaseId) continue;
+    if (!isSameStationName(parsed.stationName, stationName)) continue;
+    await Notifications.cancelScheduledNotificationAsync(req.identifier);
+    cancelled++;
+  }
+  return cancelled;
+}
+
+/**
  * trip 종료(release / 목적지 도착 / 사용자 취소) 시 호출 — `tba:` prefix를 가진 모든 사전
  * 예약 알람을 OS 큐에서 제거한다. 다른 prefix(alarm:, bl:)는 건드리지 않는다.
  *


### PR DESCRIPTION
Closes #1355
Parent: #1353

## 변경 사항

### 1. cross-channel cancel helper 추가
- `src/features/alarm/utils/tripBoundScheduler.ts`: `cancelTbaByStationPhase(stationName, phaseId)` export
- `src/features/alarm/utils/boardingLockScheduler.ts`: `cancelBlByStationPhase(stationName, phaseId)` export

각 helper는 `getAllScheduledNotificationsAsync`로 OS 큐를 조회해 prefix + canonical station name (`isSameStationName`) + phase가 모두 일치하는 identifier만 cancel. `bl:` 쪽은 추적 큐(`SCHEDULED_NOTIFICATIONS`)에서도 함께 제거한다.

### 2. silent push reschedule에서 cross-cancel 적용
- `silentPushTask.ts` `applyRescheduleBl` 진입 (lock + trainCode 검증 통과 후) → `ALARM_PHASES` 각 phase에 대해 `cancelTbaByStationPhase(nextStation, phase.id)` 호출 → `rescheduleHopForLock`
- `applyRescheduleTba` 신설 (기존 inline 호출을 함수로 분리) → `cancelBlByStationPhase` 대칭 호출 → `rescheduleTripBoundAlarm`

## 효과 (dump A 가정)

```
before: tba:early:성수 / tba:imminent:성수 / bl:7423:1:early:성수 / bl:7423:1:imminent:성수   (4건)
after (bl reschedule):  bl:7423:1:early:성수 / bl:7423:1:imminent:성수                       (2건)
```

## audit 결과
- `tba:` + `bl:` 동시 잔존을 의도하는 path(lock-handover 등)는 없음 — 정정 신호를 받은 채널이 SoT가 되어야 함. 무조건 cross-cancel 적용.
- bl-skip path (lock 없음 / trainCode mismatch)에서는 cross-cancel도 호출하지 않음 — 잘못 cancel되는 회귀 방지 (정밀성 테스트 커버).

## 테스트
- `tripBoundScheduler.test.ts`: `cancelTbaByStationPhase` 6 케이스 (정확 매칭/반대 prefix 불간섭/다른 station·phase 보존/중복역 occurrence 모두 cancel/parse 실패 graceful/빈 큐 safe no-op)
- `boardingLockScheduler.test.ts`: `cancelBlByStationPhase` 6 케이스 (동일 + 추적 큐 제거 검증 + 다른 trainCode/hopIndex 모두 cancel)
- `silentPushTask.test.ts` `cross-channel cancel (#1355 D1)` 4 케이스:
  - bl reschedule 시 tba를 phase별 1회씩 cancel (early/imminent)
  - tba reschedule 시 bl를 phase별 1회씩 cancel
  - bl skip path (lock 없음) → cross-cancel 미호출 (정밀성)
  - 반대 채널 사전 예약 없을 때 safe no-op

## CI
- `npm run type-check` pass
- 변경 파일 3건 모두 coverage 100% (stmts/branches/funcs/lines)
- 변경 무관한 widgetStorage 테스트는 base dev에서도 동일하게 실패 (사전 회귀, 본 PR 범위 외)

## 회귀 확인 항목 (수동)
- 정상 reschedule 동작 (단일 채널) 회귀 0 — 기존 reschedule 테스트 모두 PASS
- lock handover (lockless → lock active) 시나리오 회귀 0 — cross-cancel이 lock 식별을 무시하므로 새로운 lock 알람 예약 후 fire는 영향 없음