### PR TITLE
feat(#1357): S1 — preschedule 시점 motion gate (정적 trip 시작 시 사전예약 skip)

### DIFF
--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -57,6 +57,7 @@ import {
   countBoardingPromptByWindow,
   logBoardingPromptAutoLock,
   countBoardingPromptAutoLockOutcomes,
+  logScheduleSkipped,
   ALARM_LOG_BUFFER_SIZE,
   type AlarmLogEntry,
   type AlarmLogStamp,
@@ -1720,6 +1721,35 @@ describe('alarmLog', () => {
         outcome: 'received',
         reason,
       });
+    });
+  });
+
+  describe('logScheduleSkipped (#1357 S1)', () => {
+    beforeEach(() => {
+      resetAlarmLogForTest();
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    });
+
+    it('channel + destinationName을 stationName 슬롯에 인코딩해 적재', async () => {
+      logScheduleSkipped({ channel: 'tba', reason: 'motion-stationary', destinationName: '강남' });
+      await flushAlarmLog();
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved = JSON.parse(savedJson);
+      expect(saved).toHaveLength(1);
+      expect(saved[0]).toMatchObject({
+        source: 'bg-scheduled',
+        outcome: 'suppressed',
+        reason: 'schedule-skipped-motion-stationary',
+        stationName: 'tba:강남',
+      });
+    });
+
+    it('channel=bl + destinationName 미상이면 channel만 stationName으로 기록', async () => {
+      logScheduleSkipped({ channel: 'bl', reason: 'motion-stationary' });
+      await flushAlarmLog();
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved = JSON.parse(savedJson);
+      expect(saved[0].stationName).toBe('bl');
     });
   });
 

--- a/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
@@ -935,17 +935,17 @@ describe('scheduleHopsForLock #1357 (S1) motion gate', () => {
       destinationName: '강남',
       now: NOW,
     });
-    const { getAlarmLog } = jest.requireActual('../alarmLog');
-    const entries = await getAlarmLog();
-    const skips = entries.filter(
-      (e: { reason?: string }) => e.reason === 'schedule-skipped-motion-stationary',
+    const entries = await jest.requireActual('../alarmLog').getAlarmLog();
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          reason: 'schedule-skipped-motion-stationary',
+          source: 'bg-scheduled',
+          outcome: 'suppressed',
+          stationName: 'bl:강남',
+        }),
+      ]),
     );
-    expect(skips).toHaveLength(1);
-    expect(skips[0]).toMatchObject({
-      source: 'bg-scheduled',
-      outcome: 'suppressed',
-      stationName: 'bl:강남',
-    });
   });
 
   it('motion=false (이동 중)이면 정상 schedule 진행', async () => {

--- a/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
@@ -29,6 +29,13 @@ import {
 } from '../../../../testUtils/routeFixtures';
 
 jest.mock('expo-notifications');
+
+// #1357 (S1) — preschedule 진입 시 motion gate가 getCurrentMotionStationary()를 호출.
+// 기본 false(jest 환경에서 native module 부재 동등) — 기존 테스트 동작 보존.
+const mockGetCurrentMotionStationary = jest.fn<boolean, []>(() => false);
+jest.mock('../../../nearest-station/utils/motionActivity', () => ({
+  getCurrentMotionStationary: () => mockGetCurrentMotionStationary(),
+}));
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn(),
   setItem: jest.fn(),
@@ -115,6 +122,8 @@ beforeEach(() => {
   mockAsyncGetItem.mockResolvedValue(null);
   mockAsyncSetItem.mockResolvedValue(undefined);
   mockAsyncRemoveItem.mockResolvedValue(undefined);
+  // #1357 (S1) — motion 기본 false 복원 (clearAllMocks가 impl 지움).
+  mockGetCurrentMotionStationary.mockReturnValue(false);
   Object.defineProperty(Platform, 'OS', { configurable: true, value: 'ios' });
 });
 
@@ -896,5 +905,73 @@ describe('route-sig cleanup 통합 (#1282)', () => {
     mockedGet.mockResolvedValueOnce(queued);
     await run();
     expect(mockAsyncRemoveItem).toHaveBeenCalledWith('subway-now:boarding-lock-route-sig');
+  });
+});
+
+describe('scheduleHopsForLock #1357 (S1) motion gate', () => {
+  beforeEach(() => {
+    const { resetAlarmLogForTest } = jest.requireActual('../alarmLog');
+    resetAlarmLogForTest();
+  });
+
+  it('motion=stationary 확정이면 schedule을 skip하고 [] 반환', async () => {
+    mockGetCurrentMotionStationary.mockReturnValue(true);
+    const ids = await scheduleHopsForLock({
+      lock,
+      route: directRoute,
+      destinationName: '강남',
+      now: NOW,
+    });
+    expect(ids).toEqual([]);
+    expect(mockedSchedule).not.toHaveBeenCalled();
+    expect(mockedAdd).not.toHaveBeenCalled();
+  });
+
+  it('motion=stationary 시 alarm_log에 schedule-skipped-motion-stationary 적재 (channel=bl)', async () => {
+    mockGetCurrentMotionStationary.mockReturnValue(true);
+    await scheduleHopsForLock({
+      lock,
+      route: directRoute,
+      destinationName: '강남',
+      now: NOW,
+    });
+    const { getAlarmLog } = jest.requireActual('../alarmLog');
+    const entries = await getAlarmLog();
+    const skips = entries.filter(
+      (e: { reason?: string }) => e.reason === 'schedule-skipped-motion-stationary',
+    );
+    expect(skips).toHaveLength(1);
+    expect(skips[0]).toMatchObject({
+      source: 'bg-scheduled',
+      outcome: 'suppressed',
+      stationName: 'bl:강남',
+    });
+  });
+
+  it('motion=false (이동 중)이면 정상 schedule 진행', async () => {
+    mockGetCurrentMotionStationary.mockReturnValue(false);
+    const ids = await scheduleHopsForLock({
+      lock,
+      route: directRoute,
+      destinationName: '강남',
+      now: NOW,
+    });
+    expect(ids.length).toBeGreaterThan(0);
+    expect(mockedSchedule).toHaveBeenCalled();
+  });
+
+  it('sleepMode ON + motion=stationary면 motion gate가 먼저 동작 — sleep 별도 게이트 진입 전 skip', async () => {
+    // motion gate가 hop 루프 진입 전 차단하므로 sleep first-transfer 게이트와 무관.
+    // 본 테스트는 게이트 평가 순서 보장 — sleep flow는 기존 #632 describe에서 검증.
+    mockGetCurrentMotionStationary.mockReturnValue(true);
+    const ids = await scheduleHopsForLock({
+      lock,
+      route: transferRoute,
+      destinationName: '강남',
+      now: NOW,
+      sleepMode: true,
+    });
+    expect(ids).toEqual([]);
+    expect(mockedSchedule).not.toHaveBeenCalled();
   });
 });

--- a/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
@@ -1069,18 +1069,18 @@ describe('prescheduleStationAlerts #1357 (S1) motion gate', () => {
   it('motion=stationary 시 alarm_log에 schedule-skipped-motion-stationary 적재 (channel=tba)', async () => {
     mockGetCurrentMotionStationary.mockReturnValue(true);
     await prescheduleWith();
-    const { getAlarmLog } = jest.requireActual('../alarmLog');
-    const entries = await getAlarmLog();
-    const skips = entries.filter(
-      (e: { reason?: string }) => e.reason === 'schedule-skipped-motion-stationary',
+    const entries = await jest.requireActual('../alarmLog').getAlarmLog();
+    // channel:destinationName 인코딩 — defaultStops 마지막 stop이 '강남'.
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          reason: 'schedule-skipped-motion-stationary',
+          source: 'bg-scheduled',
+          outcome: 'suppressed',
+          stationName: 'tba:강남',
+        }),
+      ]),
     );
-    expect(skips).toHaveLength(1);
-    expect(skips[0]).toMatchObject({
-      source: 'bg-scheduled',
-      outcome: 'suppressed',
-      // channel:destinationName 인코딩 — defaultStops 마지막 stop이 '강남'.
-      stationName: 'tba:강남',
-    });
   });
 
   it('motion=false (이동 중)이면 정상 schedule 진행', async () => {

--- a/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
@@ -29,6 +29,14 @@ import {
 
 jest.mock('expo-notifications');
 
+// #1357 (S1) — preschedule 진입 시 motion gate가 getCurrentMotionStationary()를 호출.
+// 기본은 false(jest 환경에서 native module 부재와 동등 — 기존 테스트 동작 보존).
+// motion=true 케이스만 본 PR S1 describe에서 override.
+const mockGetCurrentMotionStationary = jest.fn<boolean, []>(() => false);
+jest.mock('../../../nearest-station/utils/motionActivity', () => ({
+  getCurrentMotionStationary: () => mockGetCurrentMotionStationary(),
+}));
+
 const mockLoggerWarn = jest.fn();
 const mockLoggerInfo = jest.fn();
 jest.mock('../../../../shared/utils/logger', () => ({
@@ -86,6 +94,8 @@ const setupIosFakeTimers = () => {
   mockLoggerWarn.mockClear();
   mockLoggerInfo.mockClear();
   mockedSchedule.mockResolvedValue('id');
+  // #1357 (S1) — motion stationary 기본 false 복원 (clearAllMocks가 impl 지우므로).
+  mockGetCurrentMotionStationary.mockReturnValue(false);
   jest.replaceProperty(Platform, 'OS', 'ios');
   jest.useFakeTimers().setSystemTime(NOW);
 };
@@ -1035,5 +1045,72 @@ describe('topUpTripBoundWindow 중복역 occurrence 격리 (#1193)', () => {
     expect(mockedCancel).not.toHaveBeenCalledWith('tba:early:A:1');
     expect(mockedCancel).not.toHaveBeenCalledWith('tba:imminent:A:1');
     expect(r.cancelled).toBe(2);
+  });
+});
+
+describe('prescheduleStationAlerts #1357 (S1) motion gate', () => {
+  beforeEach(setupIosFakeTimers);
+  afterEach(teardownFakeTimers);
+
+  // alarmLog는 in-memory pending에 push만 — getAlarmLog가 pending까지 병합 반환하므로 별도 flush 불필요.
+  // 다른 describe와 isolation 보장 위해 매 테스트 시작 시 reset.
+  beforeEach(() => {
+    const { resetAlarmLogForTest } = jest.requireActual('../alarmLog');
+    resetAlarmLogForTest();
+  });
+
+  it('motion=stationary 확정이면 schedule을 skip하고 0건 반환', async () => {
+    mockGetCurrentMotionStationary.mockReturnValue(true);
+    const result = await prescheduleWith();
+    expect(result).toEqual([]);
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('motion=stationary 시 alarm_log에 schedule-skipped-motion-stationary 적재 (channel=tba)', async () => {
+    mockGetCurrentMotionStationary.mockReturnValue(true);
+    await prescheduleWith();
+    const { getAlarmLog } = jest.requireActual('../alarmLog');
+    const entries = await getAlarmLog();
+    const skips = entries.filter(
+      (e: { reason?: string }) => e.reason === 'schedule-skipped-motion-stationary',
+    );
+    expect(skips).toHaveLength(1);
+    expect(skips[0]).toMatchObject({
+      source: 'bg-scheduled',
+      outcome: 'suppressed',
+      // channel:destinationName 인코딩 — defaultStops 마지막 stop이 '강남'.
+      stationName: 'tba:강남',
+    });
+  });
+
+  it('motion=false (이동 중)이면 정상 schedule 진행', async () => {
+    mockGetCurrentMotionStationary.mockReturnValue(false);
+    const result = await prescheduleWith();
+    expect(result.length).toBeGreaterThan(0);
+    expect(mockedSchedule).toHaveBeenCalled();
+  });
+
+  it('motion=stationary + top-up 진입(startStopIndex>0)도 동일하게 skip', async () => {
+    mockGetCurrentMotionStationary.mockReturnValue(true);
+    const result = await prescheduleWith({ startStopIndex: 1, windowSize: 2 });
+    expect(result).toEqual([]);
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('motion=stationary 적재 entry는 burst counter로 같은 channel:dest를 dedup하지 않는다 (idempotent)', async () => {
+    // 같은 motion=stationary 상태로 2번 진입 시 inline counter 또는 별도 entry로 모두 측정돼야
+    // share dump에서 시도 횟수가 보존된다. appendAlarmLog의 burst inline counter 정책상 같은
+    // (source/reason/stationName) 연속 호출은 count++로 합쳐진다 — entry 1건 + count=2가 정상.
+    mockGetCurrentMotionStationary.mockReturnValue(true);
+    await prescheduleWith();
+    await prescheduleWith();
+    const { getAlarmLog } = jest.requireActual('../alarmLog');
+    const entries = await getAlarmLog();
+    const skips = entries.filter(
+      (e: { reason?: string }) => e.reason === 'schedule-skipped-motion-stationary',
+    );
+    // 1건 + count=2 (burst inline counter) — share dump에서 시도 횟수가 보존됨을 확인.
+    expect(skips).toHaveLength(1);
+    expect(skips[0].count).toBe(2);
   });
 });

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -141,7 +141,11 @@ export type AlarmLogReason =
   //   'response-boarded': [탑승] 또는 default 탭 액션.
   //   'response-dismissed': [미탑승] 또는 dismiss.
   | 'response-boarded'
-  | 'response-dismissed';
+  | 'response-dismissed'
+  // #1357 (S1) — preschedule 진입 시 motion=stationary 확정으로 사전예약 schedule을 skip한 경우.
+  // boardingLock/lockless 양쪽 path 공통. OS scheduleNotificationAsync 0회로 정적 trip 시작의
+  // 첫 banner 발사를 차단한다. share dump에서 'schedule-skipped-motion-stationary' 카운트로 추적.
+  | 'schedule-skipped-motion-stationary';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -900,6 +904,32 @@ export function logSuppressedTbaRevalidation(input: {
     reason: input.reason,
     stationName: input.stationName,
     phaseId: input.phaseId,
+  });
+}
+
+/**
+ * #1357 (S1) — preschedule 시점 motion gate가 사전예약을 skip한 1건 적재.
+ *
+ * `prescheduleStationAlerts` / `scheduleHopsForLock` 진입 직후 motion=stationary 확정 시 호출.
+ * source는 'bg-scheduled'로 통일(다른 preschedule path log와 동일 source).
+ * channel은 stationName 슬롯에 'tba'|'bl'로 인코딩해 두 path 분포를 같은 reason 카운터에서 구분 가능.
+ */
+export function logScheduleSkipped(input: {
+  channel: 'tba' | 'bl';
+  reason: 'motion-stationary';
+  destinationName?: string;
+}): void {
+  // channel + destinationName을 stationName 슬롯에 인코딩 — 새 컬럼 추가 없이 share dump 가시화.
+  // destinationName 미상이면 channel만 기록.
+  const stationName = input.destinationName
+    ? `${input.channel}:${input.destinationName}`
+    : input.channel;
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'bg-scheduled',
+    outcome: 'suppressed',
+    reason: 'schedule-skipped-motion-stationary',
+    stationName,
   });
 }
 

--- a/src/features/alarm/utils/boardingLockScheduler.ts
+++ b/src/features/alarm/utils/boardingLockScheduler.ts
@@ -15,8 +15,13 @@ import {
 import { createLogger } from '../../../shared/utils/logger';
 import { HOP_TIME_MS } from '../../../shared/constants/boardingLock';
 import { shouldSuppressBySleepRule } from './shouldSuppressBySleepRule';
-import { logSuppressedSleepFirstTransfer } from './alarmLog';
+import { logScheduleSkipped, logSuppressedSleepFirstTransfer } from './alarmLog';
 import { BOARDING_LOCK_ROUTE_SIG_KEY } from '../../../shared/constants/storageKeys';
+// #1357 (S1) — preschedule 진입 시 motion gate. tripBoundScheduler와 동일 패턴.
+// eslint-disable-next-line import/no-restricted-paths -- cross-feature movement gate SSOT.
+import { evaluateMovement, isStaticMovementResult } from '../../nearest-station/utils/movementGate';
+// eslint-disable-next-line import/no-restricted-paths -- BG motion 신호 단일 helper.
+import { getCurrentMotionStationary } from '../../nearest-station/utils/motionActivity';
 
 const logger = createLogger('BoardingLockScheduler');
 
@@ -269,6 +274,26 @@ export async function scheduleHopsForLock(params: ScheduleHopsParams): Promise<s
   const { lock, route, destinationName, now, windowSize = DEFAULT_WINDOW_SIZE, sleepMode = false } =
     params;
   const observedMs = now ?? lock.boardedAt;
+
+  // #1357 (S1) — preschedule 시점 motion gate. tripBoundScheduler와 동형.
+  // 정적 상태에서 사용자가 lock 활성(boardingPrompt 응답 / 직접 탭)했을 때 즉시 사전예약 OS local
+  // notification이 박혀 ETA 시각 첫 banner 발사되는 회귀를 차단. motion=stationary만 보고 결정 —
+  // motion=unknown / false면 schedule 진행(false negative 회피, ADR-010 동급 원칙).
+  // sleepMode 별도 게이트(shouldSkipFirstTransferForSleep)는 본 게이트 통과 후 hop 루프 안에서 적용.
+  const motionStationary = getCurrentMotionStationary();
+  const movement = evaluateMovement({}, undefined, undefined, motionStationary);
+  if (!movement.reliable && isStaticMovementResult(movement.reason)) {
+    logScheduleSkipped({
+      channel: 'bl',
+      reason: 'motion-stationary',
+      destinationName,
+    });
+    logger.info(
+      `scheduleHopsForLock skip reason=${movement.reason} trainCode=${lock.trainCode}`,
+    );
+    return [];
+  }
+
   const allTargets = resolveAllTargets(route, destinationName);
   const timings = computeHopTimings(lock, route, allTargets);
   const lastIdx = Math.min(windowSize, allTargets.length);

--- a/src/features/alarm/utils/tripBoundScheduler.ts
+++ b/src/features/alarm/utils/tripBoundScheduler.ts
@@ -190,7 +190,7 @@ export async function prescheduleStationAlerts(
   const motionStationary = getCurrentMotionStationary();
   const movement = evaluateMovement({}, undefined, undefined, motionStationary);
   if (!movement.reliable && isStaticMovementResult(movement.reason)) {
-    const destinationName = routeStops[routeStops.length - 1]?.stationName;
+    const destinationName = routeStops.at(-1)?.stationName;
     logScheduleSkipped({
       channel: 'tba',
       reason: 'motion-stationary',

--- a/src/features/alarm/utils/tripBoundScheduler.ts
+++ b/src/features/alarm/utils/tripBoundScheduler.ts
@@ -10,6 +10,12 @@ import { HOP_TIME_MS } from '../../../shared/constants/boardingLock';
 import { TRIP_BOUND_ROUTE_SIG_KEY } from '../../../shared/constants/storageKeys';
 import { createLogger } from '../../../shared/utils/logger';
 import { recordScheduledAlarm } from './prescheduledMetrics';
+// #1357 (S1) — preschedule 진입 시 motion gate. silentPushTask와 같은 evaluateMovement 재사용.
+// eslint-disable-next-line import/no-restricted-paths -- cross-feature movement gate SSOT (silentPushTask와 동일 패턴).
+import { evaluateMovement, isStaticMovementResult } from '../../nearest-station/utils/movementGate';
+// eslint-disable-next-line import/no-restricted-paths -- BG에서 motion 신호를 읽는 단일 helper.
+import { getCurrentMotionStationary } from '../../nearest-station/utils/motionActivity';
+import { logScheduleSkipped } from './alarmLog';
 
 const logger = createLogger('TripBoundScheduler');
 
@@ -168,6 +174,31 @@ export async function prescheduleStationAlerts(
     return [];
   }
   if (routeStops.length === 0) {
+    return [];
+  }
+
+  // #1357 (S1) — preschedule 시점 motion gate.
+  // 정적 trip 시작 시 즉시 ETA 시각 OS local notification이 박혀 첫 banner가 1회 발사되는 회귀를 차단.
+  // evaluateMovement에 loc={}(no-location 가드 우회용 빈 객체)을 넘기고 motion 신호만 평가한다 —
+  // preschedule path는 호출 시점에 GPS speed/accuracy를 신뢰성 있게 알기 어려워(BG cold restart 등)
+  // motion=stationary(CMMotionActivity 가속도계) 단일 신호로 결정한다.
+  //
+  // motion=unknown(권한 X / 미초기화) 또는 false면 reliable=true 또는 motion-warmup → schedule 진행
+  // (false negative 회피, ADR-010: false positive == miss 동급).
+  // sleepMode는 별도 gate(shouldSkipFirstTransferForSleep)에서 처리 — 본 게이트는 sleepMode 무관.
+  // top-up 진입(startStopIndex>0)도 동일 게이트 적용 — 정적 상태에서 추가 윈도우 채움도 차단.
+  const motionStationary = getCurrentMotionStationary();
+  const movement = evaluateMovement({}, undefined, undefined, motionStationary);
+  if (!movement.reliable && isStaticMovementResult(movement.reason)) {
+    const destinationName = routeStops[routeStops.length - 1]?.stationName;
+    logScheduleSkipped({
+      channel: 'tba',
+      reason: 'motion-stationary',
+      destinationName,
+    });
+    logger.info(
+      `preschedule skip reason=${movement.reason} stops=${routeStops.length} startStopIndex=${startStopIndex}`,
+    );
     return [];
   }
 

--- a/src/features/nearest-station/utils/__tests__/movementGate.test.ts
+++ b/src/features/nearest-station/utils/__tests__/movementGate.test.ts
@@ -1,6 +1,7 @@
 import {
   evaluateMovement,
   isFusionDowngradeTarget,
+  isStaticMovementResult,
   isStaticSpeedSignal,
   shouldDowngradeFusion,
   MOVEMENT_TO_ALARM_LOG_REASON,
@@ -508,6 +509,29 @@ describe('movementGate', () => {
           motionStationary: false,
         }),
       ).toBe(false);
+    });
+  });
+
+  describe('#1357 (S1) — isStaticMovementResult', () => {
+    it.each([
+      ['motion-stationary' as const],
+      ['static-speed' as const],
+      ['static-position' as const],
+    ])('정적 확정 reason "%s"에 대해 true', (reason) => {
+      expect(isStaticMovementResult(reason)).toBe(true);
+    });
+
+    it.each([
+      ['no-location' as const],
+      ['stale-timestamp' as const],
+      ['low-accuracy' as const],
+      ['motion-warmup' as const],
+    ])('정적 확정 아닌 reason "%s"에 대해 false', (reason) => {
+      expect(isStaticMovementResult(reason)).toBe(false);
+    });
+
+    it('reason=undefined(reliable=true 결과)에 대해 false', () => {
+      expect(isStaticMovementResult(undefined)).toBe(false);
     });
   });
 });

--- a/src/features/nearest-station/utils/movementGate.ts
+++ b/src/features/nearest-station/utils/movementGate.ts
@@ -78,6 +78,36 @@ export type MovementSignal =
   | ({ reliable: false; reason: MovementReason } & MovementSignalShared);
 
 /**
+ * #1357 (S1) — preschedule 시점 motion gate에서 "정적 확정" 신호를 판정하는 helper.
+ *
+ * 사전예약 schedule 진입 직후 호출자가 `evaluateMovement` 결과를 본 helper에 통과시켜
+ * `true`면 schedule을 skip한다. preschedule path는 OS local notification이 ETA 시점에
+ * OS 레벨로 발사되므로, JS가 fire 시점에 가로채지 못한다 — 진입 시점 차단이 유일한 게이트.
+ *
+ * 포함되는 reason (정적 확정 카테고리):
+ *   - `motion-stationary`: OS 가속도계(CMMotionActivity) 정적 신호 — 가장 강한 정적 증거
+ *   - `static-speed`: GPS speed < 0.5 m/s
+ *   - `static-position`: speed 미측정 + positionStability='static'
+ *
+ * 명시적으로 포함되지 않는 reason (신호 부재 / 다른 원인):
+ *   - `no-location`, `stale-timestamp`, `low-accuracy`: 신호 신뢰성 부족이지 정적 확정 아님
+ *   - `motion-warmup`: warmup window 한시 차단으로 정적 확정 아님 — preschedule은 진행
+ *
+ * 호출자가 가드 없이 reason에 접근하면 컴파일 에러 (discriminated union) — 미정의 reason
+ * 추가 시 본 helper도 함께 갱신해야 한다.
+ */
+const STATIC_MOVEMENT_REASONS = new Set<MovementReason>([
+  'motion-stationary',
+  'static-speed',
+  'static-position',
+]);
+
+export function isStaticMovementResult(reason: MovementReason | undefined): boolean {
+  if (reason === undefined) return false;
+  return STATIC_MOVEMENT_REASONS.has(reason);
+}
+
+/**
  * MovementReason → AlarmLogReason 매핑. 가드가 차단한 알람을 alarmLog에 적재할 때 사용.
  * 'movement-' 접두사로 일관 — 다른 gate-/dedup- reason과 시각적으로 구분.
  */


### PR DESCRIPTION
Closes #1357
Parent: #1353

선행 #1354/#1355/#1356 머지 후 진행 (직렬).

## Summary

- `prescheduleStationAlerts` / `scheduleHopsForLock` 진입 직후 `evaluateMovement` 평가
- motion=stationary 확정 시 OS `scheduleNotificationAsync` 호출 없이 사전예약 skip + `alarm_log`에 `schedule-skipped-motion-stationary` 적재
- motion=unknown/false면 기존 schedule 진행 (false negative 회피, ADR-010 동급 원칙)

## 분기 룰 (이슈 표 그대로)

| 케이스 | 동작 |
|---|---|
| boardingLock active + motion=stationary | skip (channel=bl) |
| lockless + motion=stationary | skip (channel=tba) |
| motion=unknown (CMMotionActivity 권한/미초기화) | schedule 진행 |
| motion=false (이동 중) | schedule 진행 |
| sleepMode on | 기존 동작 유지 (별도 게이트, 본 게이트 통과 후 hop 루프에서 적용) |

## 변경 파일

- `src/features/nearest-station/utils/movementGate.ts` — `isStaticMovementResult(reason)` helper 추가 (motion-stationary/static-speed/static-position만 true)
- `src/features/alarm/utils/alarmLog.ts` — 새 reason `schedule-skipped-motion-stationary` + `logScheduleSkipped({channel, reason, destinationName})` 헬퍼
- `src/features/alarm/utils/tripBoundScheduler.ts` — `prescheduleStationAlerts` 159행 진입 직후 motion gate
- `src/features/alarm/utils/boardingLockScheduler.ts` — `scheduleHopsForLock` 진입 직후 motion gate

## Acceptance 단위 테스트

- motion=stationary 확정 → schedule skip (boardingLock / lockless 양 path)
- motion=false → 정상 schedule 진행
- top-up 진입(startStopIndex>0)에서도 동일하게 skip
- `Notifications.scheduleNotificationAsync` 호출 0회 검증
- `alarm_log`에 `schedule-skipped-motion-stationary` + stationName 인코딩(`tba:강남` / `bl:강남`) 적재 검증
- 같은 motion=stationary 상태 연속 진입 시 burst counter로 count++ (시도 횟수 보존)
- `isStaticMovementResult`: 정적 3종 true, 부재/warmup 4종 false

## Test plan

- [x] `npm run type-check` 통과
- [x] 4개 affected 파일(tripBoundScheduler / boardingLockScheduler / alarmLog / movementGate) coverage 100%
- [x] 신규 + 기존 단위 테스트 모두 pass (337/337)
- [ ] 실기기: 정적 상태에서 lockless trip 시작 → dump의 Scheduled queue 0건 확인
- [ ] 실기기: 정적 상태에서 boardingLock 활성 → dump의 Scheduled queue `bl:` 0건 확인
- [ ] 실기기: 움직임 시작 후 backend silent push reschedule → 사전예약 정상 박힘 + valid sig + 첫 banner 정상 fire (false negative 0)
- [ ] 실기기: motion 권한 거부 사용자 → motion=false 고정 → 기존 schedule 동작 회귀 없음

## Out of scope

- Cross-channel cancel/suppress, FG arrival, station-passed path — 다른 PR 소관
- 정적 → 움직임 전환 시 reschedule trigger — 기존 backend silent push reschedule 인프라(`applyRescheduleBl` / `applyRescheduleTba`) 재활용으로 커버되며, 본 PR 변경 없음