### PR TITLE
fix(#1364): BoardingLock — KV consistency race (read-after-write + cron cacheTtl=0)

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -8,6 +8,7 @@ import {
   validateLiveActivityRegister,
   validatePushAck,
   validateTrip,
+  verifyBoardingLockPersisted,
 } from '../index';
 import { progressKey, type TripProgress } from '../progress';
 import { pendingKey } from '../pendingPushes';
@@ -2089,15 +2090,23 @@ describe('POST /boarding-lock/sync (#901)', () => {
       env,
     );
     expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body).toEqual({
-      ok: true,
-      advanced: true,
-      currentWaypoint: '역삼',
-      nextStation: '역삼',
-      // #916 — tripWithLock fixture에 boardingLock이 미리 설정돼 있으므로 candidate로 노출.
-      autoLockCandidate: { trainCode: 'T-1', line: '2', subwayId: '1002' },
-    });
+    const body = (await res.json()) as {
+      ok: boolean;
+      advanced: boolean;
+      currentWaypoint: string | null;
+      nextStation: string | null;
+      autoLockCandidate: { trainCode: string; line: string; subwayId: string; expiresAt: number };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.advanced).toBe(true);
+    expect(body.currentWaypoint).toBe('역삼');
+    expect(body.nextStation).toBe('역삼');
+    // #916 — tripWithLock fixture에 boardingLock이 미리 설정돼 있으므로 candidate로 노출.
+    // #1364 P1 — expiresAt도 함께 노출 (client local store 동기화용).
+    expect(body.autoLockCandidate.trainCode).toBe('T-1');
+    expect(body.autoLockCandidate.line).toBe('2');
+    expect(body.autoLockCandidate.subwayId).toBe('1002');
+    expect(typeof body.autoLockCandidate.expiresAt).toBe('number');
     const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
     expect(stored.waypoints.map((w: { stationName: string }) => w.stationName)).toEqual([
       '역삼',
@@ -2271,9 +2280,13 @@ describe('POST /boarding-lock/sync (#901)', () => {
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
-      autoLockCandidate: { trainCode: string; line: string; subwayId: string } | null;
+      autoLockCandidate: { trainCode: string; line: string; subwayId: string; expiresAt: number } | null;
     };
-    expect(body.autoLockCandidate).toEqual({ trainCode: 'T-1', line: '2', subwayId: '1002' });
+    // #1364 P1 — autoLockCandidate에 expiresAt 포함 (client TTL 동기화).
+    expect(body.autoLockCandidate?.trainCode).toBe('T-1');
+    expect(body.autoLockCandidate?.line).toBe('2');
+    expect(body.autoLockCandidate?.subwayId).toBe('1002');
+    expect(typeof body.autoLockCandidate?.expiresAt).toBe('number');
   });
 
   it('boardingLock 없는 trip → autoLockCandidate=null', async () => {
@@ -2452,6 +2465,154 @@ describe('POST /boarding-lock/sync (#901)', () => {
       const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
       expect(stored.boardingLock).toBeUndefined();
     });
+  });
+
+  // #1364 — read-after-write verification + expiresAt response field.
+  //
+  // sync handler가 putTrip 후 cacheTtl=0으로 KV propagation을 확인한다. 정상 path는 1회로
+  // 통과해야 하며, verification failure 경로는 verifyBoardingLockPersisted 단위 테스트로 커버.
+  describe('read-after-write verification (#1364)', () => {
+    it('정상 path → 200 + autoLockCandidate.expiresAt 노출', async () => {
+      const env = makeKvEnv();
+      await post('/trips', tripWithLock(), env);
+      const res = await post(
+        '/boarding-lock/sync',
+        { token: 'tok-sync', observedStationName: '신촌', observedAtMs: 1, accuracy: 5 },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        autoLockCandidate: { expiresAt: number };
+      };
+      // refresh 후 expiresAt이 LOCK_TTL_REFRESH_MS 이상 미래 (P1 response sync).
+      expect(body.autoLockCandidate.expiresAt).toBeGreaterThan(Date.now());
+    });
+  });
+});
+
+// #1364 — verifyBoardingLockPersisted 단위 테스트 (sync handler retry/5xx 게이트의 분기).
+describe('verifyBoardingLockPersisted (#1364)', () => {
+  function lockedTrip(expiresAt: number) {
+    return {
+      token: 'tok-v',
+      route: { type: 'direct' as const, line: '2', stops: 3 },
+      destination: 'dst',
+      waypoints: [{ stationName: '강남', line: '2', kind: 'destination' as const }],
+      expiresAt: Date.now() + 3600_000,
+      createdAt: Date.now(),
+      alarmAtEpochMs: Date.now() + 1800_000,
+      boardingLock: {
+        trainCode: 'T-1',
+        line: '2',
+        subwayId: '1002',
+        selectedDepartureTime: 1,
+        segmentStations: ['강남'],
+        expiresAt,
+      },
+    };
+  }
+
+  it('KV에 동일 expiresAt 저장됨 → true', async () => {
+    const kv = new InMemoryKV();
+    const trip = lockedTrip(Date.now() + 60_000);
+    await kv.put('trip:tok-v', JSON.stringify(trip));
+    expect(await verifyBoardingLockPersisted(kv as unknown as KVNamespace, trip)).toBe(true);
+  });
+
+  it('KV의 expiresAt이 expected보다 작음(stale) → false', async () => {
+    const kv = new InMemoryKV();
+    const expected = lockedTrip(Date.now() + 120_000);
+    const stale = lockedTrip(Date.now() + 30_000);
+    await kv.put('trip:tok-v', JSON.stringify(stale));
+    expect(await verifyBoardingLockPersisted(kv as unknown as KVNamespace, expected)).toBe(false);
+  });
+
+  it('KV에 trip 자체가 없음 → false', async () => {
+    const kv = new InMemoryKV();
+    const expected = lockedTrip(Date.now() + 60_000);
+    expect(await verifyBoardingLockPersisted(kv as unknown as KVNamespace, expected)).toBe(false);
+  });
+
+  it('expected가 lock 없는 trip → KV에 trip만 있으면 true (lock 검증 생략)', async () => {
+    const kv = new InMemoryKV();
+    const expected = lockedTrip(Date.now() + 60_000);
+    delete (expected as { boardingLock?: unknown }).boardingLock;
+    await kv.put('trip:tok-v', JSON.stringify(expected));
+    expect(await verifyBoardingLockPersisted(kv as unknown as KVNamespace, expected)).toBe(true);
+  });
+
+  it('expected는 lock 있는데 KV trip은 lock 없음 → false', async () => {
+    const kv = new InMemoryKV();
+    const expected = lockedTrip(Date.now() + 60_000);
+    const noLock = { ...expected, boardingLock: undefined };
+    await kv.put('trip:tok-v', JSON.stringify(noLock));
+    expect(await verifyBoardingLockPersisted(kv as unknown as KVNamespace, expected)).toBe(false);
+  });
+
+  it('verify는 cacheTtl=0으로 origin 조회', async () => {
+    const kv = new InMemoryKV();
+    const trip = lockedTrip(Date.now() + 60_000);
+    await kv.put('trip:tok-v', JSON.stringify(trip));
+    const spy = vi.spyOn(kv, 'get');
+    await verifyBoardingLockPersisted(kv as unknown as KVNamespace, trip);
+    expect(spy).toHaveBeenCalledWith('trip:tok-v', { cacheTtl: 0 });
+  });
+});
+
+// #1364 — sync verification failure → 503 + retry path.
+// stale snapshot을 반환하는 fake KV로 verification 분기 검증.
+describe('POST /boarding-lock/sync verification failure (#1364)', () => {
+  it('putTrip이 전부 drop돼 stale snapshot 반환 → 1회 retry 후 503', async () => {
+    const inner = new InMemoryKV();
+    const FUTURE_LOCK = Date.now() + 30 * 60 * 1000;
+    // 초기 trip을 직접 KV에 적재 (POST /trips 우회) — lock TTL refresh 전 값으로 두어
+    // sync handler가 expiresAt을 갱신하려 putTrip 시도 → wrapper put이 drop → verification 실패.
+    const initial = {
+      token: 'tok-503',
+      route: { type: 'direct' as const, line: '2', stops: 3 },
+      destination: 'dst',
+      waypoints: [
+        { stationName: '강남', line: '2', kind: 'intermediate' as const },
+        { stationName: '역삼', line: '2', kind: 'destination' as const },
+      ],
+      expiresAt: FUTURE,
+      alarmAtEpochMs: FUTURE - 30 * 60 * 1000,
+      boardingLock: {
+        trainCode: 'T-1',
+        line: '2',
+        subwayId: '1002',
+        selectedDepartureTime: 1,
+        segmentStations: ['강남', '역삼'],
+        // 짧은 expiresAt — sync가 LOCK_TTL_REFRESH_MS로 연장하려 한다.
+        expiresAt: Date.now() + 60_000,
+      },
+    };
+    await inner.put('trip:tok-503', JSON.stringify(initial));
+
+    // Wrapper: get/list만 inner로 위임, put은 silently drop. retry까지 모두 실패하게 한다.
+    const putCalls: number[] = [];
+    const kv = {
+      get: (key: string, opts?: { cacheTtl?: number }) => inner.get(key, opts),
+      put: () => {
+        putCalls.push(1);
+        return Promise.resolve();
+      },
+      delete: (key: string) => inner.delete(key),
+      list: (opts?: { prefix?: string; cursor?: string }) => inner.list(opts),
+    };
+    const env = makeEnv({ TRIPS: kv as unknown as Env['TRIPS'] });
+
+    const res = await post(
+      '/boarding-lock/sync',
+      { token: 'tok-503', observedStationName: '강남', observedAtMs: 1, accuracy: 5 },
+      env,
+    );
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { ok: boolean; reason: string };
+    expect(body.ok).toBe(false);
+    expect(body.reason).toBe('sync-verification-failed');
+    // retry로 putTrip이 두 번(원래 + retry) 호출됐어야 함.
+    expect(putCalls.length).toBeGreaterThanOrEqual(2);
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/trips.test.ts
+++ b/backend/alarm-worker/src/__tests__/trips.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it } from 'vitest';
-import { deleteTrip, getTrip, listTrips, putTrip, tripKey } from '../trips';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearStaleBoardingLock, deleteTrip, getTrip, listTrips, putTrip, tripKey } from '../trips';
 import type { Trip } from '../types';
 import { InMemoryKV } from './inMemoryKv';
 
@@ -69,5 +69,97 @@ describe('trips KV CRUD', () => {
       tokens.push(t.token);
     }
     expect(tokens).toEqual(['good']);
+  });
+
+  // #1364 — cron read는 cacheTtl=0으로 origin 조회를 강제해 propagation 지연 회피.
+  it('listTrips passes cacheTtl=0 to kv.get (#1364 stale read 방어)', async () => {
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ token: 'a' }));
+    const spy = vi.spyOn(kv, 'get');
+    for await (const _t of listTrips(kv as unknown as KVNamespace)) {
+      // consume
+    }
+    const tripGetCall = spy.mock.calls.find(([key]) => key === 'trip:a');
+    expect(tripGetCall?.[1]).toEqual({ cacheTtl: 0 });
+  });
+
+  // #1364 — getTrip은 caller가 cacheTtl 지정 가능. read-after-write verification 경로.
+  it('getTrip forwards cacheTtl option to kv.get when provided (#1364)', async () => {
+    await putTrip(kv as unknown as KVNamespace, makeTrip());
+    const spy = vi.spyOn(kv, 'get');
+    await getTrip(kv as unknown as KVNamespace, 'tok-1', { cacheTtl: 0 });
+    expect(spy).toHaveBeenCalledWith('trip:tok-1', { cacheTtl: 0 });
+  });
+
+  it('getTrip omits options arg when cacheTtl not specified (default KV cache)', async () => {
+    await putTrip(kv as unknown as KVNamespace, makeTrip());
+    const spy = vi.spyOn(kv, 'get');
+    await getTrip(kv as unknown as KVNamespace, 'tok-1');
+    expect(spy).toHaveBeenCalledWith('trip:tok-1');
+  });
+
+  // #1364 Layer 4 — stale lock auto-clear (line mismatch).
+  describe('clearStaleBoardingLock (#1364 Layer 4)', () => {
+    function lockedTrip(lockLine: string, headLine: string): Trip {
+      return makeTrip({
+        waypoints: [{ stationName: '강남', line: headLine, kind: 'destination' }],
+        boardingLock: {
+          trainCode: 'T-1',
+          line: lockLine,
+          subwayId: '1002',
+          selectedDepartureTime: 1,
+          segmentStations: ['강남'],
+          expiresAt: Date.now() + 60_000,
+        },
+      });
+    }
+
+    it('lock.line === waypoints[0].line → 그대로 유지', () => {
+      const trip = lockedTrip('2', '2');
+      expect(clearStaleBoardingLock(trip).boardingLock).toBeDefined();
+    });
+
+    it('lock.line !== waypoints[0].line → boardingLock 제거', () => {
+      const trip = lockedTrip('2', '7');
+      expect(clearStaleBoardingLock(trip).boardingLock).toBeUndefined();
+    });
+
+    it('lock 없는 trip → no-op', () => {
+      const trip = makeTrip();
+      expect(clearStaleBoardingLock(trip)).toBe(trip);
+    });
+
+    it('waypoints 비어 있으면 no-op (정리 책임은 cleanup path)', () => {
+      const trip = lockedTrip('2', '2');
+      const empty = { ...trip, waypoints: [] };
+      expect(clearStaleBoardingLock(empty).boardingLock).toBeDefined();
+    });
+  });
+
+  // #1364 — cron read 경로(listTrips)는 stale lock을 자동 정리.
+  it('listTrips auto-clears stale boardingLock on line mismatch (#1364)', async () => {
+    const trip: Trip = {
+      token: 'tok-stale',
+      route: { type: 'direct', line: '2', stops: 5 },
+      destination: '0228',
+      waypoints: [{ stationName: '강남', line: '7', kind: 'destination' }],
+      expiresAt: Date.now() + 60 * 60 * 1000,
+      createdAt: Date.now(),
+      alarmAtEpochMs: Date.now() + 30 * 60 * 1000,
+      boardingLock: {
+        trainCode: 'T-1',
+        line: '2',
+        subwayId: '1002',
+        selectedDepartureTime: 1,
+        segmentStations: ['강남'],
+        expiresAt: Date.now() + 60_000,
+      },
+    };
+    await putTrip(kv as unknown as KVNamespace, trip);
+    const yielded: Trip[] = [];
+    for await (const t of listTrips(kv as unknown as KVNamespace)) {
+      yielded.push(t);
+    }
+    expect(yielded).toHaveLength(1);
+    expect(yielded[0].boardingLock).toBeUndefined();
   });
 });

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -948,6 +948,20 @@ app.post('/boarding-lock/sync', async (c) => {
 
   await putTrip(c.env.TRIPS, working);
 
+  // #1364 — read-after-write verification. Workers KV는 region간 eventually consistent —
+  // PUT 직후 다른 region replica가 옛 값을 반환하면 다음 cron(43~60s 후)이 stale
+  // `boardingLock.expiresAt`을 읽어 false-negative "lock missing or expired"가 발생한다(#765 회귀).
+  // cacheTtl=0으로 origin 조회 강제. 1회 retry 후에도 propagation 확인 실패 시 5xx 반환 —
+  // client가 다음 fix에서 재시도해 데이터 정합성 회복 기회를 확보한다.
+  const verifyOk = await verifyBoardingLockPersisted(c.env.TRIPS, working);
+  if (!verifyOk) {
+    await putTrip(c.env.TRIPS, working);
+    const retryOk = await verifyBoardingLockPersisted(c.env.TRIPS, working);
+    if (!retryOk) {
+      return c.json({ ok: false, reason: 'sync-verification-failed' }, 503);
+    }
+  }
+
   const head = working.waypoints[0];
   return c.json({
     ok: true,
@@ -957,17 +971,39 @@ app.post('/boarding-lock/sync', async (c) => {
     // #916 A1 — cron auto-lock(또는 사용자 명시 lock)이 trip에 부착돼 있으면 그 메타를
     // candidate로 노출. client가 이 값으로 boardingLock UI/state를 hydrate한다.
     // segmentStations/expiresAt 등 내부 필드는 client가 트래킹할 필요가 없어 공개 표면 최소화.
+    // #1364 P1 — `expiresAt`을 노출해 client local store가 backend 갱신값과 동기화되도록 한다.
     autoLockCandidate: working.boardingLock
       ? {
           trainCode: working.boardingLock.trainCode,
           line: working.boardingLock.line,
           subwayId: working.boardingLock.subwayId,
+          expiresAt: working.boardingLock.expiresAt,
           // W1 (#1271): client motion gate 우회 hint — swap 발생 시에만 첨부.
           ...(transferSwapApplied ? { from: 'transfer-swap' as const } : {}),
         }
       : null,
   });
 });
+
+/**
+ * #1364 — KV `putTrip` 직후 boardingLock이 실제로 propagation됐는지 확인.
+ *
+ * `cacheTtl: 0`으로 origin 조회를 강제하고, 다음 두 조건이 모두 만족할 때 true:
+ *   1) 저장한 trip이 read되어야 함 (lock 없는 trip은 lock 검증 생략)
+ *   2) `boardingLock.expiresAt`이 기대치 이상(propagation 완료)
+ *
+ * lock이 없는 trip의 경우 verification은 "trip 자체가 read 가능한가"만 본다.
+ */
+export async function verifyBoardingLockPersisted(
+  kv: KVNamespace,
+  expected: Trip,
+): Promise<boolean> {
+  const verified = await getTrip(kv, expected.token, { cacheTtl: 0 });
+  if (!verified) return false;
+  if (!expected.boardingLock) return true;
+  if (!verified.boardingLock) return false;
+  return verified.boardingLock.expiresAt >= expected.boardingLock.expiresAt;
+}
 
 /** Seam E 정정으로 lock TTL을 연장하는 길이. cron 주기 60s × 30 cycles 마진. */
 export const LOCK_TTL_REFRESH_MS = 30 * 60 * 1000;

--- a/backend/alarm-worker/src/trips.ts
+++ b/backend/alarm-worker/src/trips.ts
@@ -10,12 +10,19 @@ import type { Trip } from './types';
 const TRIP_PREFIX = 'trip:';
 
 /**
- * cron read의 KV cacheTtl (#766/#770). Workers KV의 기본 cacheTtl=60s에 의해 PUT 직후 옛 캐시가
- * 60s까지 유지되는 stale read가 cron의 boardingLock 누락 회귀 root cause였다 (#765 진단 로그).
- * Cloudflare Workers KV의 cacheTtl 최소값은 30s — 그보다 작으면 런타임에서 `Invalid cache_ttl` 던짐(#770).
- * cron 주기 자체가 60s이므로 30s 단축으로도 첫 cron 사이클의 stale window가 사라진다.
+ * cron read의 KV cacheTtl (#1364, 구 #766/#770).
+ *
+ * #765 evidence: sync handler `putTrip` 직후 다음 cron(43~60s 후)의 `kv.get`이 옛 캐시를
+ * 읽어 `boardingLock.expiresAt`이 갱신 전 값으로 노출 → `isBoardingLockActive` false-negative
+ * → "lock missing or expired" 회귀.
+ *
+ * #1364 deep RCA: cacheTtl=30s 단축으로 첫 cron 사이클의 캐시 window는 사라졌으나, KV의
+ * region간 eventually-consistent propagation(최대 60s)은 별개 윈도우 — 30s 캐시가 만료돼도
+ * 다른 region replica가 아직 옛 값을 반환할 수 있다. cron read를 cacheTtl=0으로 두어
+ * 매 사이클 origin 조회를 강제하고, sync handler 측에서 read-after-write verification으로
+ * propagation을 능동 확인한다 (index.ts /boarding-lock/sync).
  */
-const CRON_READ_CACHE_TTL_SEC = 30;
+const CRON_READ_CACHE_TTL_SEC = 0;
 
 export function tripKey(token: string): string {
   return `${TRIP_PREFIX}${token}`;
@@ -26,10 +33,27 @@ export async function putTrip(kv: KVNamespace, trip: Trip): Promise<void> {
   await kv.put(tripKey(trip.token), JSON.stringify(trip), { expirationTtl: ttlSec });
 }
 
-export async function getTrip(kv: KVNamespace, token: string): Promise<Trip | null> {
-  const raw = await kv.get(tripKey(token));
+/**
+ * #1364 — getTrip은 caller가 cacheTtl을 지정해 stale read window를 명시 제어한다.
+ *
+ * 기본(미지정): 기본 KV cacheTtl(60s) 사용. read 경로 일반.
+ * `cacheTtl: 0`: read-after-write verification 경로 — sync handler가 putTrip 직후
+ *   propagation 확인 시 사용. origin 조회 강제로 stale snapshot 차단.
+ */
+export async function getTrip(
+  kv: KVNamespace,
+  token: string,
+  options?: { cacheTtl?: number },
+): Promise<Trip | null> {
+  const raw =
+    options?.cacheTtl !== undefined
+      ? await kv.get(tripKey(token), { cacheTtl: options.cacheTtl })
+      : await kv.get(tripKey(token));
   if (!raw) return null;
   try {
+    // 주의: stale lock auto-clear는 `listTrips` (cron) 경로에만 적용한다.
+    // sync handler는 payload trainCode로 lock을 swap해 line mismatch를 해소하므로
+    // 여기서 미리 제거하면 swap 기회가 사라진다.
     return JSON.parse(raw) as Trip;
   } catch {
     return null;
@@ -45,16 +69,37 @@ export async function* listTrips(kv: KVNamespace): AsyncGenerator<Trip> {
   do {
     const result = await kv.list({ prefix: TRIP_PREFIX, cursor });
     for (const key of result.keys) {
-      // #766 — cacheTtl=10s로 PUT 직후 옛 캐시 read 차단. 기본 60s는 cron이 boardingLock 갱신을
-      // 다음 사이클까지 못 보는 회귀(#765 evidence)를 유발했다.
+      // #1364 — cron read cacheTtl=0. 30s 캐시 + KV propagation 60s 합쳐 90s stale window가
+      // cron(*/1) 한 사이클 안에 들어가 false-negative "lock missing or expired"를 발생시켰다.
+      // 매 cron 사이클 origin 조회로 propagation 지연을 회피한다.
       const raw = await kv.get(key.name, { cacheTtl: CRON_READ_CACHE_TTL_SEC });
       if (!raw) continue;
       try {
-        yield JSON.parse(raw) as Trip;
+        const parsed = JSON.parse(raw) as Trip;
+        yield clearStaleBoardingLock(parsed);
       } catch {
         // 손상된 엔트리는 스킵 (TTL로 자동 정리됨)
       }
     }
     cursor = result.list_complete ? undefined : result.cursor;
   } while (cursor);
+}
+
+/**
+ * #1364 Layer 4 — stale lock auto-clear.
+ *
+ * `boardingLock.line`이 현재 첫 waypoint의 line과 다르면 환승 시점에 끊긴 옛 leg의 lock이
+ * KV에 남아 있는 상황 (trainCode swap이 누락됐거나 환승 직후 sync 실패). cron이 이 lock을
+ * 활성으로 오인하면 잘못된 line의 trainCode를 추적하는 loop가 발생한다 (08:33-35 evidence,
+ * `trainCode 7056 not found 3 cycle`).
+ *
+ * Read 시점에 line mismatch면 lock을 제거해 다음 cron 사이클에 lockless 경로(또는
+ * boarding-prompt evaluation)로 복귀시킨다.
+ */
+export function clearStaleBoardingLock(trip: Trip): Trip {
+  if (!trip.boardingLock) return trip;
+  const head = trip.waypoints[0];
+  if (!head) return trip;
+  if (trip.boardingLock.line === head.line) return trip;
+  return { ...trip, boardingLock: undefined };
 }


### PR DESCRIPTION
Closes #1364
Parent: #1362

## Summary
#1364 deep RCA에서 확정된 **Layer 2 (P0 ROOT)**: KV eventually consistent write + cron stale read race를 차단한다.

- **Layer 3 (P0 infra)**: `listTrips` cron read를 `cacheTtl=30` → `cacheTtl=0`. KV 캐시 + region propagation 합쳐 최대 90s window가 cron 한 사이클에 들어가는 false-negative 차단.
- **Layer 2 (P0 backend)**: `/boarding-lock/sync` handler가 `putTrip` 직후 `cacheTtl: 0`으로 read-after-write verification. 실패 시 1회 retry → 그래도 실패면 `503 sync-verification-failed` (client는 다음 fix에서 재시도).
- **Layer 2 (P1 response)**: response `autoLockCandidate`에 `expiresAt` 노출. client local boardingLock store가 backend 갱신값으로 동기화 → cross-layer TTL drift 해소.
- **Layer 4 (stale lock auto-clear)**: `listTrips`가 `boardingLock.line !== waypoints[0].line`이면 lock을 자동 제거. 환승 직후 line mismatch로 trainCode loop가 발생하던 08:33-35 evidence(`trainCode 7056 not found 3 cycle`) 차단.

## Changes
- `backend/alarm-worker/src/trips.ts`
  - `getTrip(kv, token, { cacheTtl })` — optional cacheTtl 추가
  - `listTrips` — cron read `cacheTtl=0` + stream에서 `clearStaleBoardingLock` 적용
  - `clearStaleBoardingLock(trip)` export
- `backend/alarm-worker/src/index.ts`
  - `/boarding-lock/sync` — `putTrip` 직후 verification + retry + 503 분기
  - response `autoLockCandidate.expiresAt` 추가
  - `verifyBoardingLockPersisted(kv, expected)` export
- 단위/통합 테스트 (총 +18 케이스)

## Test plan
- [x] `backend/alarm-worker`: 1309 tests passed
- [x] `npm test` (RN): 5629 tests passed, 100% coverage
- [x] `npm run type-check`: pass
- [x] `npx tsc --noEmit` (backend): pass
- [ ] field: 다음 실기기 trip 1시간 동안 `lock missing or expired` 로그 < 1% (사용자 검증)
- [ ] 1주 production: 동일 metric 0 회귀

## Notes
- `getTrip(token)` 시그니처 backward-compatible: cacheTtl 미지정 시 기본 KV 캐시 사용.
- sync handler에서 `clearStaleBoardingLock`을 미적용한 이유: payload trainCode로 `applyBoardingLockTrainCodeSwap`이 line mismatch를 해소하므로, 미리 제거하면 swap 기회 손실. cron read 경로에만 적용.
- Layer 1 (Frontend TTL/sync trigger)와 Layer 3 (cron 주기 30s 단축 / DurableObject 전환)는 후속 PR 분리 — 본 PR의 P0 변경으로 race window 자체가 사라져 우선순위 낮아짐.