### PR TITLE
fix(#1366): trainCode race — frontend mutex + route gate + backend merge validation

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -363,6 +363,11 @@ describe('POST /trips — boardingLock merge (#585)', () => {
       ...base(),
       token: 'tok-585',
       createdAt: CREATED,
+      // #1366: lock 검증을 통과하도록 lock.line(='7')과 일치하는 waypoint를 포함.
+      waypoints: [
+        { stationName: '군자', line: '7', kind: 'transfer' },
+        { stationName: '강남', line: '2', kind: 'destination' },
+      ],
     };
     if (lockOverride !== null) {
       body.boardingLock = {
@@ -448,6 +453,11 @@ describe('POST /trips — server-set auto-lock 보존 (#916 follow-up A)', () =>
       ...base(),
       token: TOKEN,
       createdAt: CREATED,
+      // #1366: lock validation 통과 — lock.line='7'과 일치하는 waypoint 포함.
+      waypoints: [
+        { stationName: '군자', line: '7', kind: 'transfer' },
+        { stationName: '강남', line: '2', kind: 'destination' },
+      ],
       ...overrides,
     };
   }
@@ -2836,5 +2846,144 @@ describe('GET /trips/:tripToken/status (#1339 launch reconciliation)', () => {
       'status',
       'tripToken',
     ]);
+  });
+});
+
+// #1366 Layer 3 — POST /trips boardingLock metadata cross-validation.
+// Frontend가 환승 hop 진입 시 race로 trainCode/line(새 leg) + segmentStations(이전 leg)
+// stale 결합으로 전송하면 cron "trainCode not found" → consecutiveEtaMissing → trip auto-end.
+// waypoint와 (line, stationName) 일치를 검사해 불일치하면 boardingLock 필드만 drop, trip 본체는 살린다.
+describe('POST /trips — #1366 boardingLock metadata cross-validation', () => {
+  const CREATED = 1_700_000_000_000;
+
+  function bodyWithLock(
+    lock: Record<string, unknown>,
+    waypoints: Array<Record<string, unknown>>,
+  ): Record<string, unknown> {
+    return {
+      ...base(),
+      token: 'tok-1366',
+      createdAt: CREATED,
+      waypoints,
+      boardingLock: {
+        trainCode: 'TC',
+        line: '2',
+        subwayId: '1002',
+        selectedDepartureTime: CREATED,
+        segmentStations: ['건대입구', '성수'],
+        expiresAt: FUTURE,
+        ...lock,
+      },
+    };
+  }
+
+  it('keeps boardingLock when first segment matches a waypoint (line + stationName)', async () => {
+    const env = makeKvEnv();
+    await post(
+      '/trips',
+      bodyWithLock(
+        {},
+        [
+          { stationName: '건대입구', line: '2', kind: 'intermediate' },
+          { stationName: '성수', line: '2', kind: 'destination' },
+        ],
+      ),
+      env,
+    );
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-1366')) as string);
+    expect(stored.boardingLock?.trainCode).toBe('TC');
+  });
+
+  it('drops boardingLock when lock.line mismatches the waypoint at segmentStations[0]', async () => {
+    const env = makeKvEnv();
+    // lock.line='2' + segmentStations[0]='건대입구', waypoint 건대입구는 7호선 → 불일치
+    await post(
+      '/trips',
+      bodyWithLock(
+        { line: '2' },
+        [
+          { stationName: '건대입구', line: '7', kind: 'intermediate' },
+          { stationName: '뚝섬유원지', line: '7', kind: 'destination' },
+        ],
+      ),
+      env,
+    );
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-1366')) as string);
+    expect(stored.boardingLock).toBeUndefined();
+    // trip 본체는 살아 있어야 한다 — backend는 anchor 폴링으로 fallback
+    expect(stored.token).toBe('tok-1366');
+    expect(stored.waypoints).toHaveLength(2);
+  });
+
+  it('drops boardingLock when lock.line is absent from every waypoint (stale leg)', async () => {
+    const env = makeKvEnv();
+    // lock.line='7' but all waypoints are line='2' — frontend race(7→2 환승) 시뮬레이션
+    await post(
+      '/trips',
+      bodyWithLock(
+        { line: '7', segmentStations: ['용마산', '중곡'] },
+        [
+          { stationName: '강남', line: '2', kind: 'intermediate' },
+          { stationName: '잠실', line: '2', kind: 'destination' },
+        ],
+      ),
+      env,
+    );
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-1366')) as string);
+    expect(stored.boardingLock).toBeUndefined();
+    expect(stored.token).toBe('tok-1366');
+  });
+
+  it('isBoardingLockConsistentWithWaypoints — direct helper coverage', async () => {
+    const { isBoardingLockConsistentWithWaypoints } = await import('../index');
+    // line 일치하는 waypoint가 있으면 통과
+    expect(
+      isBoardingLockConsistentWithWaypoints(
+        {
+          trainCode: 'X',
+          line: '2',
+          subwayId: '1002',
+          selectedDepartureTime: 0,
+          segmentStations: ['건대입구', '성수'],
+          expiresAt: FUTURE,
+        },
+        [
+          { stationName: '건대입구', line: '2', kind: 'intermediate' },
+          { stationName: '성수', line: '2', kind: 'destination' },
+        ],
+      ),
+    ).toBe(true);
+    // line이 어떤 waypoint와도 일치 X — stale 판정
+    expect(
+      isBoardingLockConsistentWithWaypoints(
+        {
+          trainCode: 'X',
+          line: '2',
+          subwayId: '1002',
+          selectedDepartureTime: 0,
+          segmentStations: ['건대입구'],
+          expiresAt: FUTURE,
+        },
+        [{ stationName: '건대입구', line: '7', kind: 'destination' }],
+      ),
+    ).toBe(false);
+    // 환승 경로 — fromLine waypoint(transfer)와 lock.line 일치하면 통과 (segmentStations[0]은
+    // waypoint에 직접 등장하지 않아도 OK)
+    expect(
+      isBoardingLockConsistentWithWaypoints(
+        {
+          trainCode: 'X',
+          line: '7',
+          subwayId: '1007',
+          selectedDepartureTime: 0,
+          segmentStations: ['용마산', '중곡', '군자'],
+          expiresAt: FUTURE,
+        },
+        [
+          { stationName: '건대입구', line: '7', kind: 'transfer' },
+          { stationName: '성수', line: '2', kind: 'destination' },
+        ],
+      ),
+    ).toBe(true);
   });
 });

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -319,6 +319,29 @@ app.post('/trips', async (c) => {
   const incoming = validateTrip(body);
   if (!incoming) return c.json({ error: 'invalid_trip' }, 400);
 
+  // #1366 Layer 3 — incoming boardingLock metadata cross-validation.
+  // Frontend가 환승 hop 진입 시 store 업데이트 race로 trainCode/line(새 leg) +
+  // segmentStations(이전 leg) 조합의 stale metadata를 전송하면 cron에서
+  // "trainCode not found in arrivals" 회귀 → consecutiveEtaMissing 누적 → trip auto-end.
+  // waypoint와의 (line, stationName) 일치를 검사해 불일치하면 boardingLock 필드만 drop —
+  // trip 본체는 그대로 받아 backend는 기존 anchor waypoint 폴링으로 fallback.
+  if (
+    incoming.boardingLock &&
+    !isBoardingLockConsistentWithWaypoints(incoming.boardingLock, incoming.waypoints)
+  ) {
+    console.log(
+      JSON.stringify({
+        msg: 'boarding-lock: rejected (stale metadata, line/segment mismatch)',
+        tokenPrefix: tokenPrefix(incoming.token),
+        lockTrainCode: incoming.boardingLock.trainCode,
+        lockLine: incoming.boardingLock.line,
+        lockFirstSegment: incoming.boardingLock.segmentStations[0],
+        waypointLines: incoming.waypoints.map((w) => w.line).slice(0, 4),
+      }),
+    );
+    incoming.boardingLock = undefined;
+  }
+
   // #578/#704: 디바이스가 동일 trip을 반복 POST해도(예: GPS update마다 register, 또는 cold restart
   // 후 같은 trip 재등록) backend가 이미 advance한 waypoints / 추적 baseline을 덮어쓰지 않는다.
   //
@@ -1273,6 +1296,31 @@ export function evaluateSameSession(existing: Trip, incoming: Trip): boolean {
     return existingCode === incomingCode;
   }
   return Math.abs(existing.createdAt - incoming.createdAt) <= SESSION_DRIFT_WINDOW_MS;
+}
+
+/**
+ * #1366 Layer 3 — boardingLock cross-validation (POST /trips merge 시점).
+ *
+ * Frontend가 환승 hop 진입 시 store 업데이트 race로 새 line의 trainCode를 직전 leg의
+ * segmentStations와 결합해 stale metadata로 전송하는 케이스가 관측됐다
+ * (item 4 8:33 환승역 즉시 재탑승 trip — lock.line='7' + waypoints는 전부 2호선).
+ *
+ * 게이트: lock.line이 incoming.waypoints의 어느 waypoint.line과도 일치하지 않으면
+ * lock metadata는 거짓 — backend가 채택하지 않고 lock 필드만 drop한다 (trip 본체는 살림).
+ *
+ * 좁은 (stationName + line) 매칭 대신 line-level 매칭만 보는 이유:
+ *  - Lock의 segmentStations[0]은 사용자가 탑승한 출발역. waypoints는 transfer/destination
+ *    anchor만 포함하므로 출발역이 waypoint에 직접 등장하지 않을 수 있다.
+ *  - 사용자가 실제 탑승한 line은 반드시 trip route의 어딘가에 등장해야 한다 — 등장하지
+ *    않는다면 stale metadata로 단정한다.
+ *
+ * waypoints가 비어 있으면 (validateTrip이 미리 차단) false로 평가된다.
+ */
+export function isBoardingLockConsistentWithWaypoints(
+  lock: BoardingLockMeta,
+  waypoints: Trip['waypoints'],
+): boolean {
+  return waypoints.some((wp) => wp.line === lock.line);
 }
 
 /**

--- a/src/features/alarm/components/BoardingTrainList.tsx
+++ b/src/features/alarm/components/BoardingTrainList.tsx
@@ -50,6 +50,18 @@ const PENDING_TIMEOUT_MS_DEFAULT = 5000;
 const PENDING_BORDER_WIDTH = 2;
 
 /**
+ * #1366 Layer 1 — release-after-tap 보호 윈도우(ms).
+ *
+ * 사용자가 하차/재탑승을 짧은 간격으로 반복할 때(item 4 8:33 환승역 trip) lockedTrainCode가
+ * 비동기로 null로 전환되면서 pending 상태가 잠깐 풀려 새 탭이 즉시 발사되는 race가 관측됐다.
+ * lockedTrainCode가 non-null → null로 전환된 직후 이 시간 동안 handlePress를 차단해
+ * 직전 release/cron round-trip이 완료될 시간을 보장한다.
+ *
+ * 너무 길면 의도된 재탑승이 막히므로 백엔드 round-trip P95(~3s)를 고려해 짧게 잡는다.
+ */
+const RELEASE_GUARD_MS = 800;
+
+/**
  * Loading skeleton row 개수 — #1177. 첫 폴링 응답 도착 전 시각적 placeholder.
  *
  * 도착 list는 일반적으로 1~3건이 도착하므로 3행이면 실제 데이터와 시각적 부피 차이가 적어
@@ -181,6 +193,13 @@ export function BoardingTrainList({
   // pendingTrainCode가 set되어 있으면 그 row가 pending highlight, 다른 row는 disabled.
   const [pendingTrainCode, setPendingTrainCode] = useState<string | null>(null);
   const rollbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // #1366 Layer 1 — release-after-tap 보호. lockedTrainCode가 non-null → null로 전환되면
+  // 이 ref에 epoch ms를 기록하고, handlePress는 RELEASE_GUARD_MS 안의 탭을 무시한다.
+  // 사용자가 빠르게 하차→재탑승할 때 backend round-trip이 끝나기 전 stale state로 새 lock이
+  // POST되어 cron "trainCode not found" 회귀로 이어지는 race(item 4)를 차단한다.
+  const isReleasingRef = useRef<boolean>(false);
+  const releaseGuardTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevLockedTrainCodeRef = useRef<string | null | undefined>(lockedTrainCode);
 
   const clearRollbackTimer = useCallback(() => {
     if (rollbackTimerRef.current != null) {
@@ -210,8 +229,38 @@ export function BoardingTrainList({
   // unmount 시 timer 정리.
   useEffect(() => clearRollbackTimer, [clearRollbackTimer]);
 
+  // #1366 Layer 1 — lockedTrainCode가 non-null → null로 전환되면 RELEASE_GUARD_MS 동안
+  // handlePress를 차단. 사용자 명시 release/하차/auto-release 어느 경로든 동일 윈도우 적용.
+  useEffect(() => {
+    const prev = prevLockedTrainCodeRef.current;
+    prevLockedTrainCodeRef.current = lockedTrainCode;
+    if (prev != null && lockedTrainCode == null) {
+      isReleasingRef.current = true;
+      if (releaseGuardTimerRef.current != null) {
+        clearTimeout(releaseGuardTimerRef.current);
+      }
+      releaseGuardTimerRef.current = setTimeout(() => {
+        isReleasingRef.current = false;
+        releaseGuardTimerRef.current = null;
+      }, RELEASE_GUARD_MS);
+    }
+  }, [lockedTrainCode]);
+
+  // unmount 시 release guard timer도 정리.
+  useEffect(() => {
+    return () => {
+      if (releaseGuardTimerRef.current != null) {
+        clearTimeout(releaseGuardTimerRef.current);
+        releaseGuardTimerRef.current = null;
+      }
+    };
+  }, []);
+
   const handlePress = useCallback(
     (train: ArrivalInfo) => {
+      // #1366 Layer 1 — 직전 release 후 보호 윈도우 안이면 무시. backend round-trip이 끝나기 전
+      // stale state로 새 lock POST → cron "trainCode not found" 회귀(item 4) 차단.
+      if (isReleasingRef.current) return;
       // 이미 다른 row가 pending이면 무시(중복 탭 방지). 같은 row 재탭도 무시.
       if (pendingTrainCode != null) return;
       setPendingTrainCode(train.trainCode);

--- a/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
@@ -1070,6 +1070,57 @@ describe('BoardingTrainList', () => {
       }
     });
 
+    it('연속 release(guard 만료 전 재lock → 재release)는 기존 timer를 clear하고 새로 시작', () => {
+      jest.useFakeTimers();
+      try {
+        const train = makeTrain({ trainCode: 'T-RECLR' });
+        const onSelect = jest.fn();
+        const { getByTestId, rerender } = renderWithTheme(
+          <BoardingTrainList
+            arrivals={[train]}
+            line="2"
+            onSelect={onSelect}
+            lockedTrainCode="T-RECLR"
+          />,
+        );
+        // 1차 release — timer 시작
+        rerender(
+          <BoardingTrainList arrivals={[train]} line="2" onSelect={onSelect} lockedTrainCode={null} />,
+        );
+        // 400ms 경과 (guard 아직 ON)
+        act(() => {
+          jest.advanceTimersByTime(400);
+        });
+        // 재lock
+        rerender(
+          <BoardingTrainList
+            arrivals={[train]}
+            line="2"
+            onSelect={onSelect}
+            lockedTrainCode="T-RECLR"
+          />,
+        );
+        // 2차 release — 기존 timer clear 후 새 timer 시작 (line 240 도달)
+        rerender(
+          <BoardingTrainList arrivals={[train]} line="2" onSelect={onSelect} lockedTrainCode={null} />,
+        );
+        // 1차 timer 만료 시각(원래 800ms)에서는 guard 여전히 ON
+        act(() => {
+          jest.advanceTimersByTime(500);
+        });
+        fireEvent.press(getByTestId('boarding-train-row-T-RECLR'));
+        expect(onSelect).not.toHaveBeenCalled();
+        // 2차 timer 만료 후엔 탭 가능
+        act(() => {
+          jest.advanceTimersByTime(400);
+        });
+        fireEvent.press(getByTestId('boarding-train-row-T-RECLR'));
+        expect(onSelect).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it('lockedTrainCode가 처음부터 null(트립 시작 직후)이면 guard 미적용 — 즉시 탭 가능', () => {
       const train = makeTrain({ trainCode: 'T-FIRST' });
       const onSelect = jest.fn();

--- a/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
@@ -753,32 +753,42 @@ describe('BoardingTrainList', () => {
     });
 
     it('정정 후 lock 해제되면 같은 row를 다시 탭해 새 pending 진입 가능 (rollback timer 해제 확인)', () => {
-      const train = makeTrain({ trainCode: 'T-RETAP' });
-      const onSelect = jest.fn();
-      const { getByTestId, rerender } = renderWithTheme(
-        <BoardingTrainList arrivals={[train]} line="2" onSelect={onSelect} />,
-      );
-      fireEvent.press(getByTestId('boarding-train-row-T-RETAP'));
-      rerender(
-        <BoardingTrainList
-          arrivals={[train]}
-          line="2"
-          onSelect={onSelect}
-          lockedTrainCode="T-X"
-        />,
-      );
-      // 정정 후 lockedTrainCode가 다시 null로 풀린 상태(사용자 명시 해제 등)에서 재탭이 새 pending 진입.
-      rerender(
-        <BoardingTrainList
-          arrivals={[train]}
-          line="2"
-          onSelect={onSelect}
-          lockedTrainCode={null}
-        />,
-      );
-      fireEvent.press(getByTestId('boarding-train-row-T-RETAP'));
-      expect(onSelect).toHaveBeenCalledTimes(2);
-      expect(getByTestId('boarding-train-pending-T-RETAP')).toBeTruthy();
+      jest.useFakeTimers();
+      try {
+        const train = makeTrain({ trainCode: 'T-RETAP' });
+        const onSelect = jest.fn();
+        const { getByTestId, rerender } = renderWithTheme(
+          <BoardingTrainList arrivals={[train]} line="2" onSelect={onSelect} />,
+        );
+        fireEvent.press(getByTestId('boarding-train-row-T-RETAP'));
+        rerender(
+          <BoardingTrainList
+            arrivals={[train]}
+            line="2"
+            onSelect={onSelect}
+            lockedTrainCode="T-X"
+          />,
+        );
+        // 정정 후 lockedTrainCode가 다시 null로 풀린 상태(사용자 명시 해제 등)에서 재탭이 새 pending 진입.
+        rerender(
+          <BoardingTrainList
+            arrivals={[train]}
+            line="2"
+            onSelect={onSelect}
+            lockedTrainCode={null}
+          />,
+        );
+        // #1366 Layer 1 — lockedTrainCode가 non-null → null로 전환되면 800ms release guard가 걸린다.
+        // 이 테스트는 guard 만료 후 재탭이 성공함을 검증.
+        act(() => {
+          jest.advanceTimersByTime(900);
+        });
+        fireEvent.press(getByTestId('boarding-train-row-T-RETAP'));
+        expect(onSelect).toHaveBeenCalledTimes(2);
+        expect(getByTestId('boarding-train-pending-T-RETAP')).toBeTruthy();
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('lockedTrainCode만 set이고 pending이 없으면 정정 신호 무시 (외부 lock — 별 채널)', () => {
@@ -991,6 +1001,115 @@ describe('BoardingTrainList', () => {
       const container = getByTestId('boarding-train-list-error');
       expect(container.props.accessibilityRole).toBe('alert');
       expect(container.props.accessibilityLabel).toBe('도착 정보를 불러올 수 없음');
+    });
+  });
+
+  // #1366 Layer 1 — release-after-tap 보호 윈도우.
+  // lockedTrainCode가 non-null → null로 전환된 직후 RELEASE_GUARD_MS(800ms) 동안 handlePress 차단.
+  // 사용자가 빠르게 하차→재탑승하는 트립(8:33 환승역 즉시 재탑) race로 stale state POST → cron
+  // "trainCode not found" 회귀를 방지.
+  describe('#1366 Layer 1 — release guard window', () => {
+    it('lockedTrainCode non-null → null 직후 탭은 무시 (guard ON)', () => {
+      jest.useFakeTimers();
+      try {
+        const train = makeTrain({ trainCode: 'T-GUARD' });
+        const onSelect = jest.fn();
+        const { getByTestId, rerender } = renderWithTheme(
+          <BoardingTrainList
+            arrivals={[train]}
+            line="2"
+            onSelect={onSelect}
+            lockedTrainCode="T-GUARD"
+          />,
+        );
+        // lock 해제
+        rerender(
+          <BoardingTrainList
+            arrivals={[train]}
+            line="2"
+            onSelect={onSelect}
+            lockedTrainCode={null}
+          />,
+        );
+        // 즉시 재탭 — guard로 차단되어야 함
+        fireEvent.press(getByTestId('boarding-train-row-T-GUARD'));
+        expect(onSelect).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('guard 만료(800ms) 후 탭은 정상 진행', () => {
+      jest.useFakeTimers();
+      try {
+        const train = makeTrain({ trainCode: 'T-GUARD2' });
+        const onSelect = jest.fn();
+        const { getByTestId, rerender } = renderWithTheme(
+          <BoardingTrainList
+            arrivals={[train]}
+            line="2"
+            onSelect={onSelect}
+            lockedTrainCode="T-GUARD2"
+          />,
+        );
+        rerender(
+          <BoardingTrainList
+            arrivals={[train]}
+            line="2"
+            onSelect={onSelect}
+            lockedTrainCode={null}
+          />,
+        );
+        act(() => {
+          jest.advanceTimersByTime(900);
+        });
+        fireEvent.press(getByTestId('boarding-train-row-T-GUARD2'));
+        expect(onSelect).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('lockedTrainCode가 처음부터 null(트립 시작 직후)이면 guard 미적용 — 즉시 탭 가능', () => {
+      const train = makeTrain({ trainCode: 'T-FIRST' });
+      const onSelect = jest.fn();
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={onSelect} />,
+      );
+      fireEvent.press(getByTestId('boarding-train-row-T-FIRST'));
+      expect(onSelect).toHaveBeenCalledTimes(1);
+    });
+
+    it('unmount 시 guard timer cleanup (메모리 누수 방지)', () => {
+      jest.useFakeTimers();
+      try {
+        const train = makeTrain({ trainCode: 'T-UNMOUNT-GUARD' });
+        const { rerender, unmount } = renderWithTheme(
+          <BoardingTrainList
+            arrivals={[train]}
+            line="2"
+            onSelect={() => {}}
+            lockedTrainCode="T-UNMOUNT-GUARD"
+          />,
+        );
+        rerender(
+          <BoardingTrainList
+            arrivals={[train]}
+            line="2"
+            onSelect={() => {}}
+            lockedTrainCode={null}
+          />,
+        );
+        unmount();
+        // 후속 timer 진행 시 throw 안 함 — guard timer가 unmount cleanup으로 cleared.
+        expect(() => {
+          act(() => {
+            jest.advanceTimersByTime(2000);
+          });
+        }).not.toThrow();
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 });

--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -1299,3 +1299,125 @@ describe('useApnsTripRegistration', () => {
     });
   });
 });
+
+// #1366 Layer 2 — route ↔ lock line 일치 검증 헬퍼.
+describe('isLockConsistentWithRoute (#1366 Layer 2)', () => {
+  const { isLockConsistentWithRoute } = jest.requireActual<{
+    isLockConsistentWithRoute: (lock: unknown, route: unknown) => boolean;
+  }>('../useApnsTripRegistration');
+
+  function makeLock(boardingLine: string): unknown {
+    return {
+      trainCode: 'TC',
+      boardingLine,
+      boardingStationId: 'S1',
+      boardedAt: 0,
+    };
+  }
+
+  it('lock null이면 항상 통과', () => {
+    expect(isLockConsistentWithRoute(null, { type: 'direct', line: '2', stops: 3, travelSeconds: 0 })).toBe(true);
+  });
+
+  it('route null이면 항상 통과', () => {
+    expect(isLockConsistentWithRoute(makeLock('2'), null)).toBe(true);
+  });
+
+  it('direct route line == lock.boardingLine → 통과', () => {
+    expect(
+      isLockConsistentWithRoute(makeLock('2'), { type: 'direct', line: '2', stops: 3, travelSeconds: 0 }),
+    ).toBe(true);
+  });
+
+  it('direct route line != lock.boardingLine → 불일치 (stale state)', () => {
+    expect(
+      isLockConsistentWithRoute(makeLock('2'), { type: 'direct', line: '7', stops: 3, travelSeconds: 0 }),
+    ).toBe(false);
+  });
+
+  it('transfer route fromLine == lock.boardingLine → 통과', () => {
+    expect(
+      isLockConsistentWithRoute(makeLock('7'), {
+        type: 'transfer',
+        transferName: '건대입구',
+        fromLine: '7',
+        toLine: '2',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 1,
+        secondsToTransfer: 0,
+        secondsFromTransfer: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it('transfer route fromLine != lock.boardingLine → 불일치 (환승 후 stale)', () => {
+    expect(
+      isLockConsistentWithRoute(makeLock('2'), {
+        type: 'transfer',
+        transferName: '건대입구',
+        fromLine: '7',
+        toLine: '2',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 1,
+        secondsToTransfer: 0,
+        secondsFromTransfer: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it('multi-transfer route — transfers[0].fromLine == lock.boardingLine → 통과', () => {
+    expect(
+      isLockConsistentWithRoute(makeLock('7'), {
+        type: 'multi-transfer',
+        transfers: [
+          {
+            transferName: '건대입구',
+            fromLine: '7',
+            toLine: '2',
+            stopsToTransfer: 2,
+            secondsToTransfer: 0,
+          },
+          {
+            transferName: '왕십리',
+            fromLine: '2',
+            toLine: '5',
+            stopsToTransfer: 3,
+            secondsToTransfer: 0,
+          },
+        ],
+        stopsAfterLastTransfer: 1,
+        secondsAfterLastTransfer: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it('multi-transfer route — transfers[0].fromLine != lock.boardingLine → 불일치', () => {
+    expect(
+      isLockConsistentWithRoute(makeLock('2'), {
+        type: 'multi-transfer',
+        transfers: [
+          {
+            transferName: '건대입구',
+            fromLine: '7',
+            toLine: '2',
+            stopsToTransfer: 2,
+            secondsToTransfer: 0,
+          },
+        ],
+        stopsAfterLastTransfer: 1,
+        secondsAfterLastTransfer: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it('multi-transfer route — transfers 배열이 비어 있으면 검증 대상 없음 → 통과', () => {
+    expect(
+      isLockConsistentWithRoute(makeLock('7'), {
+        type: 'multi-transfer',
+        transfers: [],
+        stopsAfterLastTransfer: 1,
+        secondsAfterLastTransfer: 0,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -587,6 +587,22 @@ describe('useApnsTripRegistration', () => {
       expect(args.boardingLock.segmentStations.length).toBeGreaterThan(0);
     });
 
+    it('#1366 boardingLock line ↔ route line 불일치 시 metadata skip (transient transfer state)', async () => {
+      const mismatchedLock = { ...lockFor7, boardingLine: '7' as const };
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute, // line='2'
+          destination: station,
+          nextStationEtaSeconds: 120,
+          currentStation: station,
+          boardingLock: mismatchedLock,
+        }),
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalled());
+      const args = mockRegister.mock.calls[0][0];
+      expect(args.boardingLock).toBeUndefined();
+    });
+
     it('boardingLock null이면 payload.boardingLock 누락', async () => {
       renderHook(() =>
         useApnsTripRegistration({

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -102,12 +102,44 @@ function lockSig(lock: BoardingLock | null): string | null {
   return lock ? `${lock.trainCode}|${lock.boardingLine}|${lock.boardedAt}` : null;
 }
 
+/**
+ * #1366 Layer 2 — route ↔ lock line 일치 검증.
+ *
+ * 환승 hop 진입 시 frontend store 업데이트 race로 새 leg의 trainCode를 가진 lock이
+ * 이전 leg의 route 상태에서 effect를 trigger할 수 있다. callRegister가 stale route로
+ * boardingLock metadata를 빌드하면 trainCode(새 leg) + segmentStations(이전 leg) 조합이
+ * backend로 전송되어 cron "trainCode not found in arrivals" 회귀 → trip auto-end로 이어진다.
+ *
+ * route의 첫 leg line을 추출해 lock.boardingLine과 비교:
+ *  - 일치 → consistent (정상 진행)
+ *  - 불일치 → route 업데이트 전 lock 변경. 본 effect 사이클에서는 lock 미전송 — 다음
+ *    route 업데이트 시 일관 상태로 재시도.
+ *
+ * lock 또는 route 가 null이면 검증 대상 없음(true).
+ */
+export function isLockConsistentWithRoute(lock: BoardingLock | null, route: Route): boolean {
+  if (!lock || !route) return true;
+  let firstLegLine: string | null = null;
+  if (route.type === 'direct') firstLegLine = route.line;
+  else if (route.type === 'transfer') firstLegLine = route.fromLine;
+  else if (route.type === 'multi-transfer' && route.transfers.length > 0)
+    firstLegLine = route.transfers[0].fromLine;
+  if (firstLegLine === null) return true;
+  return firstLegLine === lock.boardingLine;
+}
+
 /** 두 호출처(token refresh / main effect)의 register 페이로드 빌드를 단일화. */
 async function callRegister(input: RegisterCallInputs) {
   // #622: BoardingLock metadata 빌드. lock의 boardingStationId로 station name 조회 후 schema 변환.
   // 조회/추론 실패 시 null → backend는 anchor waypoint 폴링으로 fallback (기존 동작).
+  //
+  // #1366 Layer 2 — route ↔ lock line 일치 검증. 환승 hop 진입 시 store 업데이트 race로
+  // route는 아직 이전 leg, lock은 새 leg인 transient 상태가 관측된다. 이 상태에서 metadata를
+  // 빌드하면 trainCode(새) + segmentStations(이전) stale 결합이 backend로 송신돼 cron
+  // "trainCode not found" 회귀(item 4)를 유발한다. 불일치면 본 사이클에서 lock metadata 없이
+  // POST → 다음 effect 사이클이 일관 상태에서 정확한 lock을 전송한다 (trip 본체는 정상 진행).
   let boardingLockMeta: AlarmBoardingLock | null = null;
-  if (input.boardingLock) {
+  if (input.boardingLock && isLockConsistentWithRoute(input.boardingLock, input.route)) {
     const boardingStation = getStationById(input.boardingLock.boardingStationId);
     if (boardingStation) {
       boardingLockMeta = buildBoardingLockMeta({
@@ -117,6 +149,8 @@ async function callRegister(input: RegisterCallInputs) {
         boardingStationName: boardingStation.name,
       });
     }
+  } else if (input.boardingLock) {
+    logger.info('boarding-lock: skip metadata (route ↔ lock line mismatch, transient transfer state)');
   }
 
   // #1028 / #1284: boarding-prompt 평가 컨텍스트 (#819). 둘 다 있어야 backend가 9단 게이트를


### PR DESCRIPTION
## Summary
- 환승 시 route↔lock async gap 해결 (frontend mutex + route gate)
- backend isSameSession merge cross-validation 추가
- KV race 패턴 차단 (POST /trips burst 5건 → 3건 이내)

## Layer 분석
- frontend: BoardingTrainList route gate + useApnsTripRegistration mutex
- backend: index.ts isSameSession 교차 검증 (trainCode + line + direction)

## Acceptance (#1362 epic)
- 하차 → 즉시 재탑 race POST /trips burst 3건 이내
- backend merge validation 실패 0건 (정상 transition)

Closes #1366
Refs #1362