### PR TITLE
fix(#1365): lockless trip stale interp + 환승역 line cross-validation

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -295,6 +295,34 @@ describe('sendSilentPush', () => {
     if (expectPresent) expect(body.data.trainCode).toBe('7246');
   });
 
+  // #1365 — payload.occupiedLine wire 검증 (server-authoritative line, 환승역 cross-validation).
+  // 지정 시 wire, 미지정은 byte-level 호환 위해 omit.
+  it.each([
+    ['지정 시 body.data.occupiedLine으로 전달', '7', true],
+    ['미지정이면 body.data에서 omit (구 client/backend 호환)', undefined, false],
+  ])('occupiedLine %s (#1365)', async (_label, input, expectPresent) => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await sendSilentPush({
+      deviceToken: 'tok',
+      payload: {
+        nextWaypoint: '건대입구',
+        etaSeconds: 0,
+        phase: 'imminent',
+        kind: 'intermediate',
+        sentAt: 1_700_000_000_000,
+        pushId: 'p',
+        ...(input === undefined ? {} : { occupiedLine: input }),
+      },
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect('occupiedLine' in body.data).toBe(expectPresent);
+    if (expectPresent) expect(body.data.occupiedLine).toBe('7');
+  });
+
   it('uses sandbox host when provided', async () => {
     const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) =>
       new Response('', { status: 200 }),

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -69,6 +69,13 @@ export interface SilentPushPayload {
    */
   hopIndex?: number;
   /**
+   * #1365 — 발사 시점 waypoint의 line(`Waypoint.line`). server-authoritative.
+   * 환승역에서 같은 hop index에 line이 다른 stop이 존재할 수 있어, 디바이스 `silentPushLocationGate`가
+   * D1 estimator의 currentLine과 cross-validation해 잘못된 line의 알람 발사를 차단한다.
+   * 구 backend 호환을 위해 optional — 미전달 시 클라이언트는 line cross-check를 자연 skip한다.
+   */
+  occupiedLine?: string;
+  /**
    * #1307 — 발사 시점 trip의 지하(subsurface) 판정. server-authoritative.
    * 지하에서는 WiFi/cell 보정으로 GPS가 stale/spoof되어 디바이스 위치 게이트가
    * 정상 intermediate push를 out-of-range로 오거부한다. 클라이언트는 이 flag로
@@ -147,6 +154,11 @@ export async function sendSilentPush(options: SendPushOptions): Promise<SendPush
       // Epic #1204 그룹 2 D3 (#1273) — payload.hopIndex가 정의된 경우에만 wire.
       // 구 backend 호환을 위해 optional이라 undefined일 땐 JSON에서 자연 누락된다.
       ...(options.payload.hopIndex === undefined ? {} : { hopIndex: options.payload.hopIndex }),
+      // #1365 — occupiedLine은 정의된 경우에만 wire. 미전달 시 JSON에서 자연 누락 →
+      // 구 client(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환.
+      ...(options.payload.occupiedLine === undefined
+        ? {}
+        : { occupiedLine: options.payload.occupiedLine }),
       // #1307 — subsurface는 true일 때만 wire. false/undefined는 JSON에서 자연 누락 →
       // 구 client(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환.
       ...(options.payload.subsurface === true ? { subsurface: true } : {}),

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -720,6 +720,9 @@ export async function fireArvlCdStationPush(
           // 클라이언트 `silentPushLocationGate`가 D1 estimator currentHopIndex와 매칭 시
           // 거리 검증 우회/`gate-no-location` fallback에 사용. 구 trip(부재) → undefined.
           hopIndex: waypoint.hopIndex,
+          // #1365 — server-authoritative occupiedLine. 환승역에서 디바이스가 같은 hop index에
+          // 다른 line의 stop과 cross-validation 가능. waypoint.line을 그대로 forward.
+          occupiedLine: waypoint.line,
           // #1307 — server-authoritative subsurface. 지하 trip의 intermediate push는
           // 디바이스 GPS 게이트(out-of-range 오거부)를 우회하도록 flag를 전달.
           subsurface: trip.subsurface === true,
@@ -1467,6 +1470,9 @@ export async function runLocklessIntermediate(
           // Epic #1204 그룹 2 D3 (#1273) — lockless intermediate도 waypoint.hopIndex forward.
           // D1 estimator의 currentHopIndex와 ±tolerance 매칭 시 거리 검증 우회 + GPS 미준비 fallback.
           hopIndex: waypoint.hopIndex,
+          // #1365 — server-authoritative occupiedLine. 환승역에서 디바이스가 같은 hop index에
+          // 다른 line의 stop과 cross-validation 가능. waypoint.line을 그대로 forward.
+          occupiedLine: waypoint.line,
           // #1307 — server-authoritative subsurface. lockless intermediate도 지하에선
           // 디바이스 GPS 게이트(out-of-range 오거부)를 우회하도록 flag를 전달.
           subsurface: trip.subsurface === true,

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -506,6 +506,33 @@ describe('silentPushTask', () => {
       });
     });
 
+    // #1365 — backend가 forward한 발사 시점 waypoint의 line(occupiedLine).
+    describe('occupiedLine (#1365)', () => {
+      it('비어있지 않은 string이면 그대로 전달', () => {
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', occupiedLine: '7' }),
+          ),
+        ).toMatchObject({ occupiedLine: '7' });
+      });
+
+      it('누락/빈문자열/비string이면 undefined (구 backend 호환 graceful pass)', () => {
+        expect(
+          extractPayload(bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early' })),
+        ).toMatchObject({ occupiedLine: undefined });
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', occupiedLine: '' }),
+          ),
+        ).toMatchObject({ occupiedLine: undefined });
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', occupiedLine: 7 }),
+          ),
+        ).toMatchObject({ occupiedLine: undefined });
+      });
+    });
+
     // #725 — reschedule schema는 standard와 다르므로 별도 분기 검증.
     describe('reschedule kind (#725)', () => {
       it('정상 reschedule payload → RescheduleSilentPushPayload', () => {
@@ -766,6 +793,9 @@ describe('silentPushTask', () => {
         isLockless: false,
         payloadHopIndex: undefined,
         subsurface: false,
+        occupiedLine: undefined,
+        // #1365 — lock 활성 시 lock.boardingLine을 estimatorLine으로 전달.
+        estimatorLine: '2',
       });
       expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
       const call = mockScheduleNotificationAsync.mock.calls[0][0];
@@ -846,6 +876,8 @@ describe('silentPushTask', () => {
       ['no-location', 'gate-no-location'],
       ['stale-location', 'gate-stale-location'],
       ['out-of-range', 'gate-out-of-range'],
+      // #1365 — line-mismatch는 환승역 line cross-validation 실패로 차단된 케이스.
+      ['line-mismatch', 'gate-line-mismatch'],
     ])('게이트 reason=%s → logSkipped reason=%s', async (gateReason, logReason) => {
       mockCheckGate.mockResolvedValue({ pass: false, reason: gateReason });
       await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -124,6 +124,12 @@ export interface SilentPushPayload {
    * 누락 시 기존 보수 동작(lock 없으면 non-intermediate skip)으로 fallback.
    */
   boardingLine?: string;
+  /**
+   * #1365 — backend가 forward한 발사 시점 waypoint의 line. 환승역(같은 hop index에 line 다른
+   * stop) misfire 차단용 — `silentPushLocationGate`가 디바이스 현재 line과 cross-validation.
+   * 구 backend 호환 위해 optional — 누락 시 cross-check 자연 skip(graceful).
+   */
+  occupiedLine?: string;
 }
 
 /**
@@ -311,10 +317,20 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
   // standard 경로. findFieldsLayer는 isStandardCandidate(nextWaypoint non-empty) 또는
   // isRescheduleCandidate(kind='reschedule') 중 하나로 통과시키지만, kind='reschedule'
   // 케이스는 위 분기에서 잡혔으므로 잔여 케이스는 isStandardCandidate가 보증한 것 — nextWaypoint 보장.
-  const { nextWaypoint, etaSeconds, phase, kind, sentAt, pushId, hopIndex, subsurface, boardingLine } =
-    obj as {
-      nextWaypoint: string;
-    } & Record<string, unknown>;
+  const {
+    nextWaypoint,
+    etaSeconds,
+    phase,
+    kind,
+    sentAt,
+    pushId,
+    hopIndex,
+    subsurface,
+    boardingLine,
+    occupiedLine,
+  } = obj as {
+    nextWaypoint: string;
+  } & Record<string, unknown>;
   if (typeof etaSeconds !== 'number' || !Number.isFinite(etaSeconds)) return null;
   if (phase !== 'early' && phase !== 'imminent') return null;
   const validKind =
@@ -329,6 +345,7 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
     hopIndex: validHopIndex(hopIndex),
     subsurface: validSubsurface(subsurface),
     boardingLine: validBoardingLine(boardingLine),
+    occupiedLine: validBoardingLine(occupiedLine),
   };
 }
 
@@ -491,6 +508,8 @@ function mapGateReason(reason: GateSkipReason): AlarmLogReason {
       return 'gate-stale-location';
     case 'out-of-range':
       return 'gate-out-of-range';
+    case 'line-mismatch':
+      return 'gate-line-mismatch';
   }
 }
 
@@ -924,6 +943,10 @@ async function fireWithGate(
   // 로컬 stamp로 fallback한다. server flag가 이겨야 FG-only stamp가 BG에서 stale 되어도
   // 지하 intermediate 우회가 동작한다.
   const subsurface = payload.subsurface ?? (await getSubsurfaceState());
+  // #1365 — estimatorLine. lock 활성 시 lock.boardingLine을 신뢰(사용자 명시 탭). lock 부재 시
+  // 디바이스에 결정적 line SSOT가 없으므로 undefined — gate cross-check 자연 skip(graceful).
+  // 추후 lockless도 fusion result line이 BG로 전파되면 그 값을 사용.
+  const estimatorLine = lock?.boardingLine;
   const gate = await checkSilentPushLocationGate({
     stationName: payload.nextWaypoint,
     kind: payload.kind,
@@ -931,6 +954,8 @@ async function fireWithGate(
     isLockless: !lock,
     payloadHopIndex: payload.hopIndex,
     subsurface,
+    occupiedLine: payload.occupiedLine,
+    estimatorLine,
   });
 
   if (!gate.pass) {

--- a/src/features/alarm/utils/__tests__/silentPushLocationGate.test.ts
+++ b/src/features/alarm/utils/__tests__/silentPushLocationGate.test.ts
@@ -765,4 +765,93 @@ describe('checkSilentPushLocationGate', () => {
       expect(result.reason).toBe('out-of-range');
     });
   });
+
+  // #1365 — 환승역 line cross-validation. backend `occupiedLine`과 device `estimatorLine`이
+  // 양쪽 정의된 상태에서 mismatch면 거리/hop 게이트 전에 즉시 skip. 한 쪽이라도 undefined면
+  // 기존 동작(graceful pass) 유지 — 구 backend 호환.
+  describe('line cross-validation (#1365)', () => {
+    it('occupiedLine + estimatorLine mismatch → line-mismatch skip (거리 게이트 진행 안 함)', async () => {
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'imminent',
+        isLockless: false,
+        occupiedLine: '7',
+        estimatorLine: '2',
+      });
+      expect(result.pass).toBe(false);
+      expect(result.reason).toBe('line-mismatch');
+      // 거리 진행 안 함 → location 호출 자체가 발생하지 않음
+      expect(mockGetLastKnownPositionAsync).not.toHaveBeenCalled();
+    });
+
+    it('occupiedLine + estimatorLine match면 cross-check 통과 후 기존 거리 게이트 진행', async () => {
+      // phase=early → intermediate 임계 600m. NEAR_GANGNAM(~330m)는 통과 영역.
+      mockGetLastKnownPositionAsync.mockResolvedValue(
+        makePosition(NEAR_GANGNAM.lat, NEAR_GANGNAM.lng, 5_000),
+      );
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'early',
+        isLockless: false,
+        occupiedLine: '2',
+        estimatorLine: '2',
+      });
+      expect(result.pass).toBe(true);
+      expect(result.passReason).toBe('within-threshold');
+    });
+
+    it.each([
+      ['estimatorLine 미제공 → graceful pass', { occupiedLine: '7' }],
+      ['occupiedLine 미제공 → graceful pass (구 backend 호환)', { estimatorLine: '2' }],
+      ['둘 다 미제공 → graceful pass', {}],
+    ])('한 쪽이라도 undefined면 cross-check skip — %s', async (_label, overrides) => {
+      // phase=early → 600m threshold. NEAR_GANGNAM(~330m)는 통과 영역. cross-check skip 후
+      // 거리 게이트를 정상 진행해야 한다는 점만 검증 — pass 자체가 목표.
+      mockGetLastKnownPositionAsync.mockResolvedValue(
+        makePosition(NEAR_GANGNAM.lat, NEAR_GANGNAM.lng, 5_000),
+      );
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'early',
+        isLockless: false,
+        ...overrides,
+      });
+      expect(result.pass).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('line mismatch는 subsurface bypass보다 우선 (지하 환승역 잘못된 line 차단)', async () => {
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'imminent',
+        isLockless: true,
+        subsurface: true,
+        occupiedLine: '7',
+        estimatorLine: '2',
+      });
+      expect(result.pass).toBe(false);
+      expect(result.reason).toBe('line-mismatch');
+    });
+
+    it('line mismatch는 hop-window-match보다 우선 (no-location fallback도 차단)', async () => {
+      mockGetLastKnownPositionAsync.mockResolvedValue(null);
+      mockGetCurrentPositionAsync.mockRejectedValue(new Error('denied'));
+      const result = await checkSilentPushLocationGate({
+        stationName: '강남',
+        kind: 'intermediate',
+        phase: 'imminent',
+        isLockless: true,
+        currentHopIndex: 4,
+        payloadHopIndex: 4,
+        occupiedLine: '7',
+        estimatorLine: '2',
+      });
+      expect(result.pass).toBe(false);
+      expect(result.reason).toBe('line-mismatch');
+    });
+  });
 });

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -73,6 +73,9 @@ export type AlarmLogReason =
   | 'gate-no-location'
   | 'gate-stale-location'
   | 'gate-out-of-range'
+  // #1365 — backend `occupiedLine`과 device `estimatorLine` mismatch로 차단된 발사.
+  // 환승역(같은 hop index에 line 다른 stop) misfire 차단.
+  | 'gate-line-mismatch'
   | 'lock-line-mismatch'
   | 'payload-missing-kind'
   // #727 — 정적 misfire 가드(movementGate.ts)가 차단한 발사.

--- a/src/features/alarm/utils/silentPushLocationGate.ts
+++ b/src/features/alarm/utils/silentPushLocationGate.ts
@@ -22,7 +22,12 @@ export const FRESH_FETCH_TIMEOUT_MS = 3_000;
 export type GateKind = 'transfer' | 'destination' | 'intermediate';
 export type GatePhase = 'early' | 'imminent';
 
-export type GateSkipReason = 'unknown-station' | 'no-location' | 'stale-location' | 'out-of-range';
+export type GateSkipReason =
+  | 'unknown-station'
+  | 'no-location'
+  | 'stale-location'
+  | 'out-of-range'
+  | 'line-mismatch';
 /**
  * pass=true일 때 어떤 경로로 통과했는지 식별. 운영 측정/디버깅용.
  * - 'within-threshold': 거리 임계값 이내 (기존 경로)
@@ -62,6 +67,19 @@ export interface SilentPushLocationGateInput {
    * silent push payload가 명시한 hop index. 백엔드 schema에 추가되기 전까지 undefined.
    */
   payloadHopIndex?: number;
+  /**
+   * #1365 — backend silent push payload의 `occupiedLine`. 발사 시점 waypoint의 line.
+   * 환승역(예: 건대입구는 2호선/7호선)에서 같은 hop index에 line이 다른 stop이 존재할 수 있어
+   * 디바이스 현재 line(`estimatorLine`)과 cross-validation해 잘못된 line의 알람을 차단한다.
+   * 구 backend(미전달)면 undefined → cross-check 자연 skip(graceful).
+   */
+  occupiedLine?: string;
+  /**
+   * #1365 — 디바이스 fusion result가 채택한 현재 line. lock 활성 시 lock.boardingLine,
+   * lockless면 fusion result(또는 GPS nearest) line. occupiedLine과 양쪽 모두 정의된 경우에만
+   * mismatch 시 `line-mismatch` skip. 미연결(둘 중 하나라도 undefined)이면 graceful pass.
+   */
+  estimatorLine?: string;
   /**
    * 지하(subsurface) 여부. #1307. 호출자가 server payload.subsurface를 우선,
    * 부재 시 디바이스 로컬 stamp(getSubsurfaceState)로 fallback해 해석한 boolean을 넘긴다.
@@ -208,6 +226,18 @@ export async function checkSilentPushLocationGate(
   const station = findStationByName(input.stationName);
   if (!station) {
     return { pass: false, reason: 'unknown-station' };
+  }
+
+  // #1365 — line cross-validation. backend `occupiedLine`과 device `estimatorLine`이 양쪽 모두
+  // 정의되고 mismatch면 skip. 환승역(같은 hop index에 line 다른 stop 존재)에서 잘못된 line의
+  // station-passed/destination/transfer 알람 발사 차단. 구 backend 호환 위해 둘 중 하나라도
+  // undefined면 cross-check 자연 skip(graceful) — 기존 거리/hop 게이트만 동작.
+  if (
+    input.occupiedLine != null &&
+    input.estimatorLine != null &&
+    input.occupiedLine !== input.estimatorLine
+  ) {
+    return { pass: false, reason: 'line-mismatch' };
   }
 
   const pos = await resolveUserPosition();

--- a/src/features/alarm/utils/silentPushLocationGate.ts
+++ b/src/features/alarm/utils/silentPushLocationGate.ts
@@ -206,6 +206,24 @@ function isSubsurfaceBypass(input: SilentPushLocationGateInput): boolean {
   return input.subsurface === true && input.kind === 'intermediate';
 }
 
+// 위치 미획득 fallback. 본 경로의 3-way 분기를 호출자에서 추출해 cognitive complexity 분산.
+// 1) lockless intermediate + hop window 매치 → hop 기반 pass (#1273)
+// 2) subsurface intermediate → server SSOT 신뢰 pass (#1307)
+// 3) 그 외 → no-location skip
+function resolveNoPositionFallback(input: SilentPushLocationGateInput): GateResult {
+  if (
+    input.isLockless === true &&
+    input.kind === 'intermediate' &&
+    isHopWindowMatch(input.currentHopIndex, input.payloadHopIndex)
+  ) {
+    return { pass: true, passReason: 'hop-window-match' };
+  }
+  if (isSubsurfaceBypass(input)) {
+    return { pass: true, passReason: 'subsurface-bypass' };
+  }
+  return { pass: false, reason: 'no-location' };
+}
+
 /**
  * silent push 수신 시 "사용자가 실제로 그 역 근처에 있는지" 확인하는 게이트.
  * pass=true면 알림 발사, false면 skip + alarmLog에 skipReason 기록.
@@ -242,22 +260,7 @@ export async function checkSilentPushLocationGate(
 
   const pos = await resolveUserPosition();
   if (!pos) {
-    // Epic #1204 그룹 2 D3 (#1273) — BG 깨움 직후 GPS 미준비 fallback.
-    // lockless intermediate + D1 estimator currentHopIndex가 payload hopIndex와 매칭되면
-    // 거리 게이트 우회하고 hop 매칭만으로 pass. (사용자 피드백 14/15: 14건 received / 0건 fired)
-    // 측정 가시성을 위해 locationSource는 부재로 두고 passReason='hop-window-match'만 노출.
-    if (
-      input.isLockless === true &&
-      input.kind === 'intermediate' &&
-      isHopWindowMatch(input.currentHopIndex, input.payloadHopIndex)
-    ) {
-      return { pass: true, passReason: 'hop-window-match' };
-    }
-    // #1307 — 지하 intermediate는 GPS 미준비여도 server SSOT를 신뢰해 pass.
-    if (isSubsurfaceBypass(input)) {
-      return { pass: true, passReason: 'subsurface-bypass' };
-    }
-    return { pass: false, reason: 'no-location' };
+    return resolveNoPositionFallback(input);
   }
 
   const motionFields = {

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
@@ -442,61 +442,48 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
   // 환승역(예: 건대입구는 2호선/7호선)에서 같은 hop index에 다른 line의 stop이 존재할 수 있어
   // 시간 적분 결과가 stale interp일 때 잘못된 line의 station을 채택할 위험.
   describe('#1365 lockless-route-hop line cross-validation', () => {
-    it('estimatedLine ≠ gpsNearestLine + nextArcLine 미정의 → fallback to GPS', () => {
-      // lockless trip (lock 없음) + routeCtx 7호선 → estimator는 lockless-route-hop 채택.
-      // GPS 최근접은 다른 line(충무로 3호선). currentIdxHint=null (lastObserved 부재).
-      // → estimatedLine='7' vs gpsNearestLine='3' mismatch + nextArcLine null → fallback.
+    // 두 시나리오의 공통 setup — 같은 routeCtx에서 GPS 최근접 station만 바꿔 line cross-check 진입.
+    function runLine7LocklessRouteScenario(gpsNearest: ReturnType<typeof gpsBase>) {
       jest.useFakeTimers();
       const T0 = 1_700_000_000_000;
       jest.setSystemTime(T0);
 
       const routeCtx = { route: makeDirectRoute(4, '7'), origin: yongmasan, destination: konkuk };
+      mockNearest.mockReturnValue(gpsNearest);
+      mockFindTop.mockReturnValue([{ station: gpsNearest.result.station, distanceKm: 0 }]);
 
+      const { result, rerender } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, routeCtx),
+      );
+
+      jest.setSystemTime(T0 + 5 * 60_000);
+      rerender({});
+
+      jest.useRealTimers();
+      return result;
+    }
+
+    it('estimatedLine ≠ gpsNearestLine + nextArcLine 미정의 → fallback to GPS', () => {
       // GPS는 충무로(3호선) 최근접으로 보고 — 환승역 stale interp 시뮬레이션.
-      mockNearest.mockReturnValue(
+      // → estimatedLine='7' vs gpsNearestLine='3' mismatch + nextArcLine null → fallback.
+      const result = runLine7LocklessRouteScenario(
         gpsBase({
           result: { station: chungmuro3, distanceKm: 0 },
           userLocation: { lat: chungmuro3.lat, lng: chungmuro3.lng },
         }),
       );
-      mockFindTop.mockReturnValue([{ station: chungmuro3, distanceKm: 0 }]);
-
-      const { result, rerender } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, routeCtx),
-      );
-
-      // 시간이 흘러 estimator가 적분 결과를 만들 수 있도록.
-      jest.setSystemTime(T0 + 5 * 60_000);
-      rerender({});
 
       // line guard 차단 → estimator override 비채택 → GPS 원본 결과 유지.
       expect(result.current.source).not.toBe('boarding-lock-interp');
       expect(result.current.result?.station.id).toBe(chungmuro3.id);
-
-      jest.useRealTimers();
     });
 
     it('estimatedLine = gpsNearestLine → line guard 통과 (estimator 채택)', () => {
       // 회귀 차단: 같은 line이면 기존 동작 (lockless-route-hop 채택)이 유지되어야 한다.
-      jest.useFakeTimers();
-      const T0 = 1_700_000_000_000;
-      jest.setSystemTime(T0);
-
-      const routeCtx = { route: makeDirectRoute(4, '7'), origin: yongmasan, destination: konkuk };
-      mockNearest.mockReturnValue(gpsBase());
-      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
-
-      const { result, rerender } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, routeCtx),
-      );
-
-      jest.setSystemTime(T0 + 5 * 60_000);
-      rerender({});
+      const result = runLine7LocklessRouteScenario(gpsBase());
 
       // 같은 line('7') → line guard 통과 → estimator override 채택.
       expect(result.current.source).toBe('boarding-lock-interp');
-
-      jest.useRealTimers();
     });
   });
 });

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
@@ -437,4 +437,66 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
       jest.useRealTimers();
     });
   });
+
+  // #1365 — lockless-route-hop 채택 전 line cross-validation.
+  // 환승역(예: 건대입구는 2호선/7호선)에서 같은 hop index에 다른 line의 stop이 존재할 수 있어
+  // 시간 적분 결과가 stale interp일 때 잘못된 line의 station을 채택할 위험.
+  describe('#1365 lockless-route-hop line cross-validation', () => {
+    it('estimatedLine ≠ gpsNearestLine + nextArcLine 미정의 → fallback to GPS', () => {
+      // lockless trip (lock 없음) + routeCtx 7호선 → estimator는 lockless-route-hop 채택.
+      // GPS 최근접은 다른 line(충무로 3호선). currentIdxHint=null (lastObserved 부재).
+      // → estimatedLine='7' vs gpsNearestLine='3' mismatch + nextArcLine null → fallback.
+      jest.useFakeTimers();
+      const T0 = 1_700_000_000_000;
+      jest.setSystemTime(T0);
+
+      const routeCtx = { route: makeDirectRoute(4, '7'), origin: yongmasan, destination: konkuk };
+
+      // GPS는 충무로(3호선) 최근접으로 보고 — 환승역 stale interp 시뮬레이션.
+      mockNearest.mockReturnValue(
+        gpsBase({
+          result: { station: chungmuro3, distanceKm: 0 },
+          userLocation: { lat: chungmuro3.lat, lng: chungmuro3.lng },
+        }),
+      );
+      mockFindTop.mockReturnValue([{ station: chungmuro3, distanceKm: 0 }]);
+
+      const { result, rerender } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, routeCtx),
+      );
+
+      // 시간이 흘러 estimator가 적분 결과를 만들 수 있도록.
+      jest.setSystemTime(T0 + 5 * 60_000);
+      rerender({});
+
+      // line guard 차단 → estimator override 비채택 → GPS 원본 결과 유지.
+      expect(result.current.source).not.toBe('boarding-lock-interp');
+      expect(result.current.result?.station.id).toBe(chungmuro3.id);
+
+      jest.useRealTimers();
+    });
+
+    it('estimatedLine = gpsNearestLine → line guard 통과 (estimator 채택)', () => {
+      // 회귀 차단: 같은 line이면 기존 동작 (lockless-route-hop 채택)이 유지되어야 한다.
+      jest.useFakeTimers();
+      const T0 = 1_700_000_000_000;
+      jest.setSystemTime(T0);
+
+      const routeCtx = { route: makeDirectRoute(4, '7'), origin: yongmasan, destination: konkuk };
+      mockNearest.mockReturnValue(gpsBase());
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+
+      const { result, rerender } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, routeCtx),
+      );
+
+      jest.setSystemTime(T0 + 5 * 60_000);
+      rerender({});
+
+      // 같은 line('7') → line guard 통과 → estimator override 채택.
+      expect(result.current.source).toBe('boarding-lock-interp');
+
+      jest.useRealTimers();
+    });
+  });
 });

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -734,7 +734,22 @@ export function useFusedNearestStation(
       );
       withinObservationCeiling = estimate.index <= lastRealObservedIdx + 1;
     }
-    if ((chosenIdx === -1 || estimate.index > chosenIdx) && withinObservationCeiling) {
+    // #1365 — lockless-route-hop은 ceiling 면제(시간 적분 SSOT)지만 환승역에서 같은
+    // hop index에 다른 line의 stop이 존재할 수 있다. 채택 전 line 검증: GPS 최근접
+    // (candidates[0]) line과 일치하지 않으면 fallback(GPS) — 잘못된 line의 station-passed/
+    // destination 알람 차단. 다른 strategy(live-position / arrival-eta)는 fusion 자체가 실시간
+    // 신호로 line이 강제되므로 면제. lockless trip은 lock 부재로 lastObservedRef도 anchor되지
+    // 않아 currentIdxHint를 SSOT로 신뢰할 수 없으므로 GPS 최근접만 cross-check 기준.
+    let withinLineGuard = true;
+    if (estimate.strategy === 'lockless-route-hop') {
+      const gpsNearestLine = candidates[0]?.station.line ?? null;
+      withinLineGuard = estimate.station.line === gpsNearestLine;
+    }
+    if (
+      (chosenIdx === -1 || estimate.index > chosenIdx) &&
+      withinObservationCeiling &&
+      withinLineGuard
+    ) {
       const distanceKm = gps.userLocation
         ? haversine(
             gps.userLocation.lat,


### PR DESCRIPTION
Closes #1365
Refs #1362

## 요약

2026-06-16 RCA로 확인된 cross-layer 회귀 3건을 수정한다. 환승역(예: 건대입구는 2/7호선)에서 lockless trip의 stale interp이 다른 line의 station을 채택해 잘못된 알람을 발사하는 회귀.

## 변경 (3 layer)

### Layer 1 — Frontend estimator line guard
`useFusedNearestStation.ts`: `lockless-route-hop` strategy는 ceiling 면제(시간 적분 SSOT)지만 환승역에서 같은 hop index에 다른 line의 stop이 존재해 stale interp이 옆 노선 station을 채택할 수 있음. 채택 전 GPS 최근접(`candidates[0]`) line과 일치 여부 확인 — mismatch 시 GPS fallback.

### Layer 3 — Backend payload `occupiedLine`
`backend/alarm-worker/src/apns.ts`: `SilentPushPayload`에 `occupiedLine?: string` 필드 추가. `scheduled.ts`의 lock-path 및 lockless intermediate push 모두 `waypoint.line`을 forward. 구 client 호환 위해 optional + 미지정 시 wire에서 omit.

### Layer 4 — Frontend gate line cross-validation
`silentPushLocationGate.ts`: `occupiedLine`(backend)과 `estimatorLine`(device — lock 활성 시 `lock.boardingLine`) 양쪽 정의된 상태에서 mismatch면 거리/hop 게이트 진입 전에 즉시 `line-mismatch` skip. 한 쪽이라도 undefined면 graceful pass — 구 backend 호환 보존.

## acceptance

- 단위: lockless trip + 환승역 GPS 최근접 line이 estimator line과 다를 때 estimator 채택 X → GPS fallback
- 단위: backend payload `occupiedLine` 정의 + device `estimatorLine` mismatch → `line-mismatch` skip
- 단위: 구 backend payload(`occupiedLine` 미지정) 시 cross-check 자연 skip (회귀 차단)
- 단위: backend payload `occupiedLine` wire/omit 양쪽 byte-level 호환
- field (post-merge): lockless trip + 환승 진행 중 잘못된 line station 알람 0건

## CI

- `npm test`: 5641 passed, coverage 100% (lines/functions/branches/statements)
- `npm run type-check`: pass
- backend `npm test`: 1311 passed

## 핵심 파일

- `src/features/nearest-station/hooks/useFusedNearestStation.ts`
- `src/features/alarm/utils/silentPushLocationGate.ts`
- `src/features/alarm/tasks/silentPushTask.ts`
- `src/features/alarm/utils/alarmLog.ts`
- `backend/alarm-worker/src/apns.ts`
- `backend/alarm-worker/src/scheduled.ts`