### PR TITLE
fix(#1367): cross-station 다중 알림 — dedupKey occurrence + backend dedup + cross-channel 통합

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -6,6 +6,7 @@ import type { WindowedMetrics } from '../positionSeries';
 import {
   ARVLCD_FIRE_DEDUP_TTL_SEC,
   ARVLCD_FIRE_KEY_PREFIX,
+  SAME_PHASE_STATION_DEDUP_WINDOW_MS,
   FALLBACK_ADVANCE_GRACE_CYCLES,
   FALLBACK_HOP_SEC,
   MAX_CONSECUTIVE_ETA_MISSING,
@@ -4397,5 +4398,63 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
     expect(stats.arvlCdFireSuccess).toBe(0);
     expect(stats.arvlCdFireMismatch).toBe(0); // 게이트 위 차단이라 fire 경로 미진입
     expect(getStationPassedCalls(apnsFetch)).toHaveLength(0);
+  });
+
+  // #1367 — cross-station 동시 fire 차단. 같은 trip에서 직전 다른 station의 fire가 있고
+  // SAME_PHASE_STATION_DEDUP_WINDOW_MS 안이면 다음 station의 fire를 보류한다 (client 동시 banner 차단).
+  it('#1367 cross-station — 직전 다른 station fire 후 윈도우 내 다음 station fire는 dedup', async () => {
+    const tripWithRecentFire = makeLockTrip({
+      lastFiredStation: { stationName: '건대입구', epochMs: NOW - 1_000 },
+    });
+    const { stats, apnsFetch } = await runArvlScheduled({
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      trip: tripWithRecentFire,
+      pushId: 'p-arvl-cross',
+    });
+    expect(stats.arvlCdFireSuccess).toBe(0);
+    expect(stats.arvlCdFireDedup).toBe(1);
+    expect(getStationPassedCalls(apnsFetch)).toHaveLength(0);
+  });
+
+  it('#1367 cross-station — 윈도우 밖(SAME_PHASE_STATION_DEDUP_WINDOW_MS+1)이면 정상 fire', async () => {
+    const tripOldFire = makeLockTrip({
+      lastFiredStation: {
+        stationName: '건대입구',
+        epochMs: NOW - SAME_PHASE_STATION_DEDUP_WINDOW_MS - 1,
+      },
+    });
+    const { stats } = await runArvlScheduled({
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      trip: tripOldFire,
+      pushId: 'p-arvl-cross-ok',
+    });
+    expect(stats.arvlCdFireSuccess).toBe(1);
+    expect(stats.arvlCdFireDedup).toBe(0);
+  });
+
+  it('#1367 cross-station — 같은 station(직전과 동일)은 cross-station 게이트와 무관 — per-(token,trainCode,station,arvlCd) 게이트가 처리', async () => {
+    // 같은 station이지만 다른 arvlCd면 cross-station 게이트는 통과 (per-arvlCd dedup KV는 별 entry).
+    const tripSameStation = makeLockTrip({
+      lastFiredStation: { stationName: '중곡', epochMs: NOW - 1_000 },
+    });
+    const { stats } = await runArvlScheduled({
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      trip: tripSameStation,
+      pushId: 'p-arvl-cross-same',
+    });
+    // cross-station 분기는 stationName이 같으면 무시 — fire 진행.
+    expect(stats.arvlCdFireSuccess).toBe(1);
+  });
+
+  it('#1367 cross-station — fire 성공 시 trip.lastFiredStation을 stamp하여 다음 cycle dedup 활성화', async () => {
+    const { stats, kv } = await runArvlScheduled({
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      pushId: 'p-arvl-stamp',
+    });
+    expect(stats.arvlCdFireSuccess).toBe(1);
+    const raw = await kv.get('trip:arvl-tok');
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.lastFiredStation).toEqual({ stationName: '중곡', epochMs: NOW });
   });
 });

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -378,6 +378,9 @@ app.post('/trips', async (c) => {
         ...incoming,
         waypoints: existing.waypoints,
         lastFiredPhase: existing.lastFiredPhase,
+        // #1367 — cross-station dedup marker는 token 단위로 보존돼야 같은 trip 재등록 race에서
+        // 윈도우 안 fire가 다시 통과하지 않는다.
+        lastFiredStation: existing.lastFiredStation,
         lastEtaSeconds: existing.lastEtaSeconds,
         apnsEnv: existing.apnsEnv ?? incoming.apnsEnv,
         // #916 follow-up A — server-set auto-lock 보존.
@@ -1448,6 +1451,17 @@ export function validateTrip(input: unknown): Trip | null {
     lastFiredPhase: obj.lastFiredPhase === 'early' || obj.lastFiredPhase === 'imminent'
       ? obj.lastFiredPhase
       : undefined,
+    // #1367 — cross-station dedup marker 복원. 두 필드가 모두 valid해야 채택 (KV 직렬화 신뢰).
+    lastFiredStation:
+      obj.lastFiredStation !== null &&
+      typeof obj.lastFiredStation === 'object' &&
+      typeof obj.lastFiredStation.stationName === 'string' &&
+      typeof obj.lastFiredStation.epochMs === 'number'
+        ? {
+            stationName: obj.lastFiredStation.stationName,
+            epochMs: obj.lastFiredStation.epochMs,
+          }
+        : undefined,
     lastEtaSeconds: typeof obj.lastEtaSeconds === 'number' ? obj.lastEtaSeconds : undefined,
     apnsEnv: obj.apnsEnv === 'sandbox' || obj.apnsEnv === 'production' ? obj.apnsEnv : undefined,
     boardingLock: parseBoardingLock(obj.boardingLock),

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -603,6 +603,14 @@ export const FALLBACK_ADVANCE_GRACE_CYCLES = 1;
 export const ARVLCD_FIRE_DEDUP_TTL_SEC = 60 * 60;
 
 /**
+ * #1367 — cross-station 동일 phase 다중 banner 차단 윈도우(ms).
+ * 짧은 cron 간격(60s)에서 hop이 advance한 직후 다음 hop의 첫 fire가 즉시 또 발사되어 device에서
+ * "같은 분에 두 알림" 패턴이 발생하던 회귀(이슈 evidence) 차단용. 윈도우 안이면 한 번만 통과한다.
+ * 60s 이상 hop이 진행됐다면 정상 시퀀스이므로 통과 — 사용자 가치 손실 없음.
+ */
+export const SAME_PHASE_STATION_DEDUP_WINDOW_MS = 45_000;
+
+/**
  * #917 A2 — 매역 알림 dedup KV key prefix.
  * Key 형식: `${prefix}${token}|${trainCode}|${stationName}|${arvlCd}`
  *
@@ -696,6 +704,27 @@ export async function fireArvlCdStationPush(
     });
     return { dirty: false };
   }
+
+  // #1367 — cross-station 동시 fire 차단. 같은 trip에서 이전 station-passed push로부터
+  // SAME_PHASE_STATION_DEDUP_WINDOW_MS 이내에 *다른* station 발사는 보류 (client 채널 2 banner 회귀 차단).
+  // 같은 station 재발사는 위 per-(token,trainCode,station,arvlCd) 게이트가 처리하므로 여기선 다른 station만 본다.
+  const lastFired = trip.lastFiredStation;
+  if (
+    lastFired !== undefined &&
+    lastFired.stationName !== waypoint.stationName &&
+    now - lastFired.epochMs < SAME_PHASE_STATION_DEDUP_WINDOW_MS
+  ) {
+    stats.arvlCdFireDedup += 1;
+    log('arvlcd-fire: cross-station dedup skip', {
+      token: trip.token.slice(0, 8),
+      trainCode: lock.trainCode,
+      station: waypoint.stationName,
+      previousStation: lastFired.stationName,
+      sinceMs: now - lastFired.epochMs,
+      arvlCd,
+    });
+    return { dirty: false };
+  }
   const pushId = generatePushId();
   log('arvlcd-fire: station-passed push', {
     token: trip.token.slice(0, 8),
@@ -758,6 +787,9 @@ export async function fireArvlCdStationPush(
   stats.pushed += 1;
   // dedup stamp — 같은 cycle에서 Seoul API 갱신 지연으로 같은 신호가 재노출돼도 차단.
   await env.TRIPS.put(key, '1', { expirationTtl: ARVLCD_FIRE_DEDUP_TTL_SEC });
+  // #1367 — cross-station dedup용 마지막 fire 마커. 성공 시에만 stamp(실패는 다음 cycle 재시도 허용).
+  trip.lastFiredStation = { stationName: waypoint.stationName, epochMs: now };
+  dirty = true;
   return { dirty };
 }
 

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -86,6 +86,14 @@ export interface Trip {
   alarmAtEpochMs: number;
   /** 마지막으로 발사한 phase. dedup용. */
   lastFiredPhase?: 'early' | 'imminent';
+  /**
+   * #1367 — cross-station 동시 fire 차단용. 마지막 station-passed (arvlCd) push의 (stationName,
+   * epoch ms). 같은 cron tick 또는 짧은 윈도우(SAME_PHASE_STATION_DEDUP_WINDOW_MS) 안에
+   * 다른 station의 동일 신호가 도달해도 client 채널에서 두 banner가 동시기로 뜨지 않도록
+   * backend side에서 한 번 더 게이트한다. 이전 PR들의 per-station `arvlCdFireKey` dedup은
+   * 같은 (token, trainCode, station, arvlCd) 조합 재발사만 막아 cross-station은 통과시킨다.
+   */
+  lastFiredStation?: { stationName: string; epochMs: number };
   /** 마지막 폴링 시 관측 ETA(seconds). 변동 감지용. */
   lastEtaSeconds?: number;
   /**

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../shared/utils/stationRoute';
 import type { Route } from '../../../shared/utils/stationRoute';
 import type { Station } from '../../../shared/types/station';
-import { alarmKey, evaluateAlarmPhase, type AlarmEvent } from '../utils/stationAlarm';
+import { alarmKey, parseAlarmKey, evaluateAlarmPhase, type AlarmEvent } from '../utils/stationAlarm';
 import { resolveAlarmDirection } from '../utils/alarmDirection';
 import { distanceMetersBetween, estimateEtaSeconds } from '../../../shared/utils/stationEta';
 import { resolveNextTarget } from '../utils/stationPipeline';
@@ -260,11 +260,10 @@ function inferHopIndexFromFiredAlarms(
 ): number {
   let maxIdx = -1;
   for (const key of firedAlarms) {
-    const sep = key.indexOf(':');
-    /* istanbul ignore next — alarmKey()가 항상 `${phaseId}:${stationName}` 형식이라 sep=-1는 도달 불가, 잘못된 key 데이터 방어용 */
-    if (sep === -1) continue;
-    const stationName = key.slice(sep + 1);
-    const idx = arcStations.findIndex((s) => isSameStationName(s.name, stationName));
+    const parsed = parseAlarmKey(key);
+    /* istanbul ignore next — alarmKey()가 항상 `${phaseId}:${stationName}[#occ]` 형식이라 parsed=null은 도달 불가, 잘못된 key 데이터 방어용 */
+    if (!parsed) continue;
+    const idx = arcStations.findIndex((s) => isSameStationName(s.name, parsed.stationName));
     if (idx > maxIdx) maxIdx = idx;
   }
   if (maxIdx === -1) return -1;

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -1275,6 +1275,44 @@ describe('silentPushTask', () => {
         });
       });
 
+      // #1367 — hopIndex>=1이면 alarmKey가 `phase:station#n` 형식이라 default(0) dedup과 collide하지 않는다.
+      it('#1367 hopIndex>=1 silent push는 default dedup key(`phase:station`)와 collide하지 않음 — 발사 진행', async () => {
+        mockGetFiredAlarms.mockResolvedValue(new Set(['imminent:강남']));
+        await handleSilentPush(
+          payload({
+            kind: 'destination',
+            phase: 'imminent',
+            pushId: 'p-hop-1',
+            hopIndex: 1,
+          }),
+        );
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'p-hop-1',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'fired',
+        });
+      });
+
+      // #1367 cross-channel — OS scheduled receiver가 hopIndex=2로 fire 후 fired set에 등록되어 있을 때
+      // 같은 hopIndex의 silent push가 도달하면 dedup 적중 (silent push + OS queue 통합 공간).
+      it('#1367 cross-channel — fired set에 `phase:station#n` 등록 시 같은 hopIndex silent push는 dedup', async () => {
+        mockGetFiredAlarms.mockResolvedValue(new Set(['imminent:강남#2']));
+        await handleSilentPush(
+          payload({
+            kind: 'destination',
+            phase: 'imminent',
+            pushId: 'p-cross-channel',
+            hopIndex: 2,
+          }),
+        );
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'p-cross-channel',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'skipped',
+          reason: 'dedup-already-fired',
+        });
+      });
+
       it('payload-missing-kind 시 sendPushAck(outcome=skipped, reason=payload-missing-kind)', async () => {
         await handleSilentPush({
           data: bgTaskData({

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -995,12 +995,19 @@ async function fireWithGate(
   }
 
   // FIRED_ALARMS dedup — destination scope. intermediate는 dedup 대상 아님(통과는 1회성).
-  // dedup 키는 alarmKey({phaseId, stationName}) — FG GPS 발화와 동일 출처 공유.
+  // dedup 키는 alarmKey({phaseId, stationName, occurrenceIdx}) — FG GPS·OS scheduled fire와 동일
+  // 출처 공유. #1367 — payload.hopIndex로 같은 stationName이 route에 중복 등장하는 trip에서
+  // hop별 dedup이 collide하지 않도록 occurrenceIdx로 분리. backend가 hopIndex를 보내지 않는 구
+  // 호환 분기는 occurrenceIdx=0 (legacy 동작 보존).
   const destinationId = await loadDestinationId();
   const dedupKey =
     payload.kind === 'intermediate'
       ? null
-      : alarmKey({ phaseId: payload.phase, stationName: payload.nextWaypoint });
+      : alarmKey({
+          phaseId: payload.phase,
+          stationName: payload.nextWaypoint,
+          occurrenceIdx: payload.hopIndex ?? 0,
+        });
 
   if (dedupKey && destinationId) {
     const fired = await getFiredAlarms(destinationId);

--- a/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
+++ b/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
@@ -54,6 +54,12 @@ jest.mock('../boardingLockScheduler', () => {
 const mockResolveAllTargets = jest.fn();
 jest.mock('../stationAlarm', () => ({
   resolveAllTargets: (...args: unknown[]) => mockResolveAllTargets(...args),
+  // #1367 — silent push 채널과 unified dedup key 공간. occurrenceIdx>0면 `#n` suffix.
+  alarmKey: ({ phaseId, stationName, occurrenceIdx }: { phaseId: string; stationName: string; occurrenceIdx?: number }) => {
+    const occ = occurrenceIdx ?? 0;
+    const base = `${phaseId}:${stationName}`;
+    return occ > 0 ? `${base}#${occ}` : base;
+  },
 }));
 
 const mockLogSuppressedTbaRevalidation = jest.fn();
@@ -284,6 +290,7 @@ describe('registerScheduledAlarmListener', () => {
     handle.remove();
   });
 
+
   it('destinationId 미설정이면 drain은 fired set 갱신을 스킵하고 lastStationName만 갱신한다 (#462)', async () => {
     mockAsyncGetItem.mockResolvedValue(null);
     mockGetPresented.mockResolvedValueOnce([
@@ -448,6 +455,17 @@ describe('tba: fire-time 재검증 (#918 A3 PR2)', () => {
       expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', new Set(['early:강남']));
       expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
       expect(mockLogSuppressedTbaRevalidation).not.toHaveBeenCalled();
+    });
+
+    // #1367 — occurrenceIdx>=1인 `tba:phase:station:n` identifier는 fired set에 `phase:station#n` 형식으로 등록.
+    // silent push 채널과 unified dedup key 공간 공유 → 같은 hopIndex의 silent push가 dedup 적중.
+    it('#1367 occurrenceIdx>=1 (`tba:phase:station:n`) → fired set에 `phase:station#n` 형식으로 등록', async () => {
+      mockGetFiredAlarms.mockResolvedValueOnce(new Set());
+
+      await reconcileScheduledAlarmDelivery('tba:early:강남:2');
+
+      expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', new Set(['early:강남#2']));
+      expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
     });
 
     it('tripStart 미존재 시 revalidate-no-trip 적재 후 상태 갱신 skip', async () => {
@@ -649,6 +667,21 @@ describe('tba: fire-time 재검증 (#918 A3 PR2)', () => {
       expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', new Set(['early:강남']));
       expect(mockGetTripStartedAt).not.toHaveBeenCalled();
       expect(mockLogSuppressedTbaRevalidation).not.toHaveBeenCalled();
+      handle.remove();
+    });
+
+    // #1367 — drain 경로도 occurrenceIdx>=1을 보존해 fired set에 `phase:station#n` 등록.
+    it('#1367 drain — `tba:phase:station:n` (n>=1) → fired set에 `phase:station#n` 형식 등록', async () => {
+      mockGetPresented.mockResolvedValueOnce([
+        { date: 1, request: { identifier: 'tba:early:강남:3' } },
+      ]);
+      mockGetFiredAlarms.mockResolvedValueOnce(new Set());
+
+      const handle = registerScheduledAlarmListener();
+      await awaitInitialScheduledAlarmDrain();
+
+      expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', new Set(['early:강남#3']));
+      expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
       handle.remove();
     });
 

--- a/src/features/alarm/utils/__tests__/stationAlarm.test.ts
+++ b/src/features/alarm/utils/__tests__/stationAlarm.test.ts
@@ -1,4 +1,4 @@
-import { alarmKey, evaluateAlarmPhase, resolveAllTargets, type AlarmEvent, type AlarmSource } from '../stationAlarm';
+import { alarmKey, parseAlarmKey, evaluateAlarmPhase, resolveAllTargets, type AlarmEvent, type AlarmSource } from '../stationAlarm';
 import type { TransferRoute, MultiTransferRoute } from '../../../../shared/utils/stationRoute';
 import type { LineNumber } from '../../../../shared/types/station';
 import {
@@ -62,6 +62,62 @@ describe('alarmKey', () => {
 
   it('differentiates phases for the same station', () => {
     expect(alarmKey({ phaseId: 'imminent', stationName: '강남' })).toBe('imminent:강남');
+  });
+
+  // #1367 — cross-station 다중 알림 방지: 같은 stationName이 route에 중복 등장하는 hop(순환선)을
+  // occurrenceIdx로 분리해 dedup이 collide하지 않게 한다. 0(default)은 legacy 형식 보존.
+  it('#1367 — occurrenceIdx=0 (default)에는 suffix를 붙이지 않는다 (legacy key 호환)', () => {
+    expect(alarmKey({ phaseId: 'early', stationName: '강남', occurrenceIdx: 0 })).toBe('early:강남');
+  });
+
+  it('#1367 — occurrenceIdx>=1이면 `#n` suffix로 hop별 dedup key 분리', () => {
+    expect(alarmKey({ phaseId: 'early', stationName: '강남', occurrenceIdx: 1 })).toBe('early:강남#1');
+    expect(alarmKey({ phaseId: 'imminent', stationName: '강남', occurrenceIdx: 2 })).toBe(
+      'imminent:강남#2',
+    );
+  });
+});
+
+describe('parseAlarmKey (#1367)', () => {
+  it('legacy key(`phase:station`)를 occurrenceIdx=0으로 정규화한다', () => {
+    expect(parseAlarmKey('early:강남')).toEqual({
+      phaseId: 'early',
+      stationName: '강남',
+      occurrenceIdx: 0,
+    });
+  });
+
+  it('`phase:station#n` 형식에서 occurrenceIdx를 추출한다', () => {
+    expect(parseAlarmKey('imminent:강남#2')).toEqual({
+      phaseId: 'imminent',
+      stationName: '강남',
+      occurrenceIdx: 2,
+    });
+  });
+
+  it('알람 round-trip: alarmKey → parseAlarmKey 일치', () => {
+    const input = { phaseId: 'early', stationName: '용마산', occurrenceIdx: 3 };
+    expect(parseAlarmKey(alarmKey(input))).toEqual(input);
+  });
+
+  it('잘못된 key(콜론 없음)는 null', () => {
+    expect(parseAlarmKey('invalid')).toBeNull();
+  });
+
+  it('`#` 뒤가 정수가 아니면 stationName 전체를 그대로 유지 (occurrenceIdx=0)', () => {
+    expect(parseAlarmKey('early:강남#abc')).toEqual({
+      phaseId: 'early',
+      stationName: '강남#abc',
+      occurrenceIdx: 0,
+    });
+  });
+
+  it('`#` 뒤가 음수면 0으로 fallback (방어)', () => {
+    expect(parseAlarmKey('early:강남#-1')).toEqual({
+      phaseId: 'early',
+      stationName: '강남#-1',
+      occurrenceIdx: 0,
+    });
   });
 });
 

--- a/src/features/alarm/utils/scheduledAlarmReceiver.ts
+++ b/src/features/alarm/utils/scheduledAlarmReceiver.ts
@@ -16,7 +16,7 @@ import {
   parseTripBoundAlarmIdentifier,
 } from './tripBoundScheduler';
 import { getTripStartedAt } from './tripStartStorage';
-import { resolveAllTargets } from './stationAlarm';
+import { alarmKey, resolveAllTargets } from './stationAlarm';
 import {
   parseBoardingLockAlarmIdentifier,
   routeSignature,
@@ -48,6 +48,12 @@ interface ParsedAlarmIdentifier {
   prefix: 'alarm' | 'tba' | 'bl';
   phaseId: string;
   stationName: string;
+  /**
+   * #1367 — 같은 stationName이 route에 중복 등장하는 trip(순환선)에서 hop별 dedup이 collide하지
+   * 않도록 보존되는 0-based occurrence. `tba:` parser만 suffix를 분리해 채우고, `alarm:`/`bl:`는
+   * occurrence 표기가 없으므로 항상 0 — silent push 채널과 통합 dedup key 공간을 공유한다.
+   */
+  occurrenceIdx: number;
 }
 
 /**
@@ -57,14 +63,25 @@ interface ParsedAlarmIdentifier {
 function parseAlarmIdentifier(identifier: string): ParsedAlarmIdentifier | null {
   if (identifier.startsWith(BOARDING_LOCK_ALARM_PREFIX)) {
     const p = parseBoardingLockAlarmIdentifier(identifier);
-    return p ? { prefix: 'bl', phaseId: p.phase, stationName: p.stationName } : null;
+    return p
+      ? { prefix: 'bl', phaseId: p.phase, stationName: p.stationName, occurrenceIdx: 0 }
+      : null;
   }
   if (identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) {
     const p = parseTripBoundAlarmIdentifier(identifier);
-    return p ? { prefix: 'tba', phaseId: p.phaseId, stationName: p.stationName } : null;
+    return p
+      ? {
+          prefix: 'tba',
+          phaseId: p.phaseId,
+          stationName: p.stationName,
+          occurrenceIdx: p.occurrenceIdx,
+        }
+      : null;
   }
   const p = parseScheduledAlarmIdentifier(identifier);
-  return p ? { prefix: 'alarm', phaseId: p.phaseId, stationName: p.stationName } : null;
+  return p
+    ? { prefix: 'alarm', phaseId: p.phaseId, stationName: p.stationName, occurrenceIdx: 0 }
+    : null;
 }
 
 function safeParseRoute(raw: string | null): Route {
@@ -218,7 +235,15 @@ export async function reconcileScheduledAlarmDelivery(
   // setLastFiredAlarmStationName은 trip 종속성이 약하므로 유지한다(다음 사이클 기준역 갱신용).
   if (destinationId) {
     const fired = await getFiredAlarms(destinationId);
-    fired.add(`${parsed.phaseId}:${parsed.stationName}`);
+    // #1367 — alarmKey()로 silent push 채널과 동일 dedup key 공간 공유. occurrenceIdx>0 OS scheduled
+    // 알람도 phaseId:station#n 형식으로 등록 → 후속 silent push가 같은 hop 발사 시 dedup 적중.
+    fired.add(
+      alarmKey({
+        phaseId: parsed.phaseId,
+        stationName: parsed.stationName,
+        occurrenceIdx: parsed.occurrenceIdx,
+      }),
+    );
     await setFiredAlarms(destinationId, fired);
   }
   await setLastFiredAlarmStationName(parsed.stationName);
@@ -267,7 +292,12 @@ async function drainDeliveredScheduledAlarms(): Promise<void> {
     const fired = await getFiredAlarms(destinationId);
     let firedChanged = false;
     for (const parsed of accepted) {
-      const key = `${parsed.phaseId}:${parsed.stationName}`;
+      // #1367 — unified dedup key (silent push와 동일 공간). occurrenceIdx>0면 `#n` suffix.
+      const key = alarmKey({
+        phaseId: parsed.phaseId,
+        stationName: parsed.stationName,
+        occurrenceIdx: parsed.occurrenceIdx,
+      });
       if (!fired.has(key)) {
         fired.add(key);
         firedChanged = true;

--- a/src/features/alarm/utils/stationAlarm.ts
+++ b/src/features/alarm/utils/stationAlarm.ts
@@ -8,8 +8,52 @@ import { ALARM_PHASES, type AlarmContext, type AlarmPhase, type AlarmPhaseId } f
 // 기존 호출자 호환을 위해 re-export 유지.
 export type { AlarmType, AlarmEvent };
 
-export function alarmKey(event: Pick<AlarmEvent, 'phaseId' | 'stationName'>): string {
-  return `${event.phaseId}:${event.stationName}`;
+/**
+ * #1367 — FIRED_ALARMS dedup key.
+ *
+ * 기본 형식: `${phaseId}:${stationName}` (FG GPS·OS scheduled의 default occurrenceIdx=0).
+ * `occurrenceIdx >= 1`인 경우 `:${stationName}#${n}` suffix를 붙여 같은 stationName이 route에
+ * 중복 등장하는 trip(2호선 순환 등)에서 hop별 dedup이 collide하지 않도록 분리한다. silent push
+ * (`payload.hopIndex`)와 OS scheduled identifier(`tba:phase:station[:n]`)의 occurrence 표기를
+ * 단일 dedup key 공간에 통합한다 — cross-channel(silent push + OS scheduled) 동일 hop fire가
+ * 한 번만 banner로 노출되도록 한다.
+ *
+ * 파싱 호환: `stationName`에 `#`은 stations.json에 등장하지 않으므로 `key.lastIndexOf('#')`로
+ * 안전하게 occurrence 분리 가능. occurrence 미포함 키(legacy)는 parser가 `#` 부재로 0 fallback.
+ */
+export interface AlarmKeyInput {
+  phaseId: string;
+  stationName: string;
+  occurrenceIdx?: number;
+}
+
+export function alarmKey(event: AlarmKeyInput): string {
+  const occ = event.occurrenceIdx ?? 0;
+  const base = `${event.phaseId}:${event.stationName}`;
+  return occ > 0 ? `${base}#${occ}` : base;
+}
+
+/**
+ * #1367 — alarmKey()의 역연산. parsed shape으로 phase/station/occurrenceIdx를 분리한다.
+ * `#` 없는 legacy key는 occurrenceIdx=0으로 정규화. 잘못된 key(phaseId 콜론 없음)는 null.
+ */
+export function parseAlarmKey(
+  key: string,
+): { phaseId: string; stationName: string; occurrenceIdx: number } | null {
+  const sep = key.indexOf(':');
+  if (sep === -1) return null;
+  const phaseId = key.slice(0, sep);
+  const rest = key.slice(sep + 1);
+  const hash = rest.lastIndexOf('#');
+  if (hash === -1) {
+    return { phaseId, stationName: rest, occurrenceIdx: 0 };
+  }
+  const suffix = rest.slice(hash + 1);
+  const occ = Number(suffix);
+  if (!Number.isInteger(occ) || occ < 0) {
+    return { phaseId, stationName: rest, occurrenceIdx: 0 };
+  }
+  return { phaseId, stationName: rest.slice(0, hash), occurrenceIdx: occ };
 }
 
 export interface CurrentTarget {


### PR DESCRIPTION
## Summary

#1362 후속 트립 evidence 기반 cross-station 다중 알림 회귀 3 layer 차단.

### Layer 1 — Client dedupKey scope (occurrence)
`alarmKey()`를 `occurrenceIdx`로 확장 → `phase:station` (legacy, occ=0) 또는 `phase:station#n` (occ>=1).
같은 stationName이 route에 중복 등장하는 hop(순환선)에서 hop별 dedup이 collide하지 않도록 분리.
`silentPushTask`는 `payload.hopIndex`를 occurrenceIdx로 사용한다.

### Layer 2 — Backend cross-station dedup
`trip.lastFiredStation = { stationName, epochMs }` 추가. `fireArvlCdStationPush`에서 직전 다른
station의 fire가 `SAME_PHASE_STATION_DEDUP_WINDOW_MS`(45s) 안에 있으면 다음 station fire 보류.
기존 per-(token, trainCode, station, arvlCd) `arvlCdFireKey` 게이트는 같은 station 재발사만 막아
cross-station 통과시켰던 회귀(이슈 evidence: 건대 + 성수 동시기) 차단.
POST /trips 동일 세션 merge 시 `lastFiredStation`을 보존해 token-refresh race에서 윈도우 안 fire가
다시 통과하지 않도록 함.

### Layer 4/5 — Cross-channel unified dedup
`scheduledAlarmReceiver`(`alarm:`/`tba:`/`bl:`)가 FIRED_ALARMS에 등록하는 key를 `alarmKey()`로 통합.
`tba:` identifier의 occurrence suffix(`:n`)가 parser → `parsed.occurrenceIdx` → fired set의 `#n` suffix로
보존되어, silent push 채널과 단일 dedup key 공간을 공유한다. OS scheduled fire 직후 같은 hop의
silent push가 도달하면 dedup 적중 → 동시 banner 차단.

### Out of scope (후속 별도 이슈 권장)
- Layer 2의 issue body 원안 "backend hop shift signal → client topUp/cancel" 큰 설계는 별도 작업.
  현 PR은 backend side에서 짧은 윈도우 cross-station fire만 차단(보수적).
- Layer 3 (`cancelAllPhasesForStation` helper)도 별도.

## Test plan

- [x] `npm test` — 5641건 pass, coverage 100%
- [x] `npm run type-check` — pass
- [x] `cd backend/alarm-worker && npm test` — 1313건 pass
- [x] 단위: alarmKey occurrenceIdx>=1 → `#n` suffix
- [x] 단위: parseAlarmKey round-trip + invalid handling
- [x] 단위: silentPushTask `hopIndex` dedup 분리 + cross-channel `phase:station#n` 적중
- [x] 단위: scheduledAlarmReceiver tba:occurrence>=1 → fired set `#n` 등록(reconcile + drain 두 경로)
- [x] 단위: backend cross-station 윈도우 내 dedup / 윈도우 밖 통과 / same-station 통과 / fire 성공 시 lastFiredStation stamp
- [ ] 실기기: 다음 trip에서 1분 이내 cross-station 동일 phase fire 0건 (사용자 검증)

Closes #1367
Refs #1362