### PR TITLE
fix(#1370): L2 vanish fallback station-passed push + L3 lockless 인계

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -2632,7 +2632,6 @@ describe('verifyBoardingLockPersisted (#1364)', () => {
 describe('POST /boarding-lock/sync verification failure (#1364)', () => {
   it('putTrip이 전부 drop돼 stale snapshot 반환 → 1회 retry 후 503', async () => {
     const inner = new InMemoryKV();
-    const FUTURE_LOCK = Date.now() + 30 * 60 * 1000;
     // 초기 trip을 직접 KV에 적재 (POST /trips 우회) — lock TTL refresh 전 값으로 두어
     // sync handler가 expiresAt을 갱신하려 putTrip 시도 → wrapper put이 drop → verification 실패.
     const initial = {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1404,6 +1404,147 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
       // lock release → isBoardingLockActive=false
       expect(stored.boardingLock).toBeUndefined();
       expect(stored.consecutiveEtaMissing).toBe(0);
+      // #1370 L3 — lockless 인계가 실제로 작동하도록 강제 enable + stat 기록
+      expect(stored.locklessStationPassed).toBe(true);
+    });
+
+    it('#1370 L2 — fallback advance 직전 station-passed silent push 발사 (intermediate)', async () => {
+      // hop 시간 경과 + intermediate waypoint(중곡) — advanceBoardingLockWaypoint 호출 전에
+      // station-passed silent push가 발사되어야 한다.
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({
+          consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+          lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
+        }),
+      );
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeSeoulCombo([], []),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p1370-l2',
+      });
+      // push 발사 검증
+      expect(stats.vanishFallbackFired).toBe(1);
+      expect(stats.pushed).toBeGreaterThanOrEqual(1);
+      expect(apnsFetch).toHaveBeenCalled();
+      const calls = apnsFetch.mock.calls as unknown as Array<[string, RequestInit]>;
+      const stationPassedCall = calls.find((c) => {
+        const body = JSON.parse(c[1].body as string);
+        return body.data?.nextWaypoint === '중곡' && body.data?.phase === 'imminent';
+      });
+      expect(stationPassedCall).toBeDefined();
+      // waypoint shift 확인
+      const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
+      expect(stored.waypoints[0].stationName).toBe('군자');
+    });
+
+    it('#1370 L2 — destination waypoint는 station-passed push 발사 안 함', async () => {
+      // destination kind는 cleanupTripWithLa 내부에서 trip-ended push가 발사되므로
+      // 추가 station-passed push 발사를 차단해야 한다.
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({
+          waypoints: [{ stationName: '군자', line: '7', kind: 'destination' }],
+          consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+          lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
+        }),
+      );
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeSeoulCombo([], []),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: makeOkFetch() as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p1370-l2-dest',
+      });
+      expect(stats.vanishFallbackFired).toBe(0);
+    });
+
+    it('#1370 L2 — vanish fallback push dedup (같은 station 두 번 발사 안 됨)', async () => {
+      // 같은 waypoint에 대해 다시 vanish fallback이 trigger돼도 dedup KV로 차단.
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({
+          consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+          lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
+        }),
+      );
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const deps = {
+        seoul: makeSeoulCombo([], []),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p1370-dup',
+      };
+      await runScheduled(makeEnv(kv), deps);
+      const callsAfterFirst = apnsFetch.mock.calls.length;
+      // 두 번째 cycle도 같은 station에 fallback이 trigger되도록 trip을 다시 set up
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({
+          consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+          lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
+        }),
+      );
+      const stats2 = await runScheduled(makeEnv(kv), deps);
+      // dedup → push 추가 발사 X
+      expect(stats2.vanishFallbackFired).toBe(0);
+      expect(apnsFetch.mock.calls.length).toBe(callsAfterFirst);
+    });
+
+    it('#1370 L2 — push 실패 시 dedup KV stamp 안 함 (다음 cycle 재시도 허용)', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({
+          consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+          lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
+        }),
+      );
+      // 503 retryable failure
+      const apnsFetch = vi.fn(async () => new Response('{"reason":"InternalServerError"}', { status: 503 }));
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeSeoulCombo([], []),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p1370-fail',
+      });
+      expect(stats.vanishFallbackFired).toBe(0);
+      expect(stats.errors).toBeGreaterThanOrEqual(1);
+    });
+
+    it('#1370 L3 — lock release 시 locklessStationPassed 강제 enable + stat 기록', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({
+          consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+          lastTrackedArrivalEpoch: LAST_EPOCH_NOT_ELAPSED,
+          locklessStationPassed: false,
+        }),
+      );
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeSeoulCombo([], []),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: makeOkFetch() as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p1370-l3',
+      });
+      const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
+      expect(stored.locklessStationPassed).toBe(true);
+      expect(stats.vanishLocklessTakeover).toBe(1);
     });
 
     it('lastTrackedArrivalEpoch 없음 → fallback 미발동, 기존 auto-end 경로 유지', async () => {

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -1465,16 +1465,7 @@ export function validateTrip(input: unknown): Trip | null {
       ? obj.lastFiredPhase
       : undefined,
     // #1367 — cross-station dedup marker 복원. 두 필드가 모두 valid해야 채택 (KV 직렬화 신뢰).
-    lastFiredStation:
-      obj.lastFiredStation !== null &&
-      typeof obj.lastFiredStation === 'object' &&
-      typeof obj.lastFiredStation.stationName === 'string' &&
-      typeof obj.lastFiredStation.epochMs === 'number'
-        ? {
-            stationName: obj.lastFiredStation.stationName,
-            epochMs: obj.lastFiredStation.epochMs,
-          }
-        : undefined,
+    lastFiredStation: parseLastFiredStation(obj.lastFiredStation),
     lastEtaSeconds: typeof obj.lastEtaSeconds === 'number' ? obj.lastEtaSeconds : undefined,
     apnsEnv: obj.apnsEnv === 'sandbox' || obj.apnsEnv === 'production' ? obj.apnsEnv : undefined,
     boardingLock: parseBoardingLock(obj.boardingLock),
@@ -1525,6 +1516,17 @@ function parsePromptDisplay(raw: unknown): PromptDisplay | undefined {
   if (typeof o.originStation !== 'string' || o.originStation.length === 0) return undefined;
   if (typeof o.line !== 'string' || o.line.length === 0) return undefined;
   return { originStation: o.originStation, line: o.line };
+}
+
+/**
+ * #1367 — lastFiredStation marker 파싱. KV 직렬화 신뢰. 두 필드 모두 valid 시에만 채택.
+ */
+function parseLastFiredStation(raw: unknown): { stationName: string; epochMs: number } | undefined {
+  if (raw === null || typeof raw !== 'object') return undefined;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.stationName !== 'string') return undefined;
+  if (typeof o.epochMs !== 'number') return undefined;
+  return { stationName: o.stationName, epochMs: o.epochMs };
 }
 
 /**

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -688,6 +688,47 @@ export function evaluateArvlCdFireGate(
 }
 
 /**
+ * #1370 — station-passed imminent push payload 빌더. arvlCd path와 vanish-fallback path가
+ * 같은 payload 모양을 공유 (lock self-describing, subsurface flag, hopIndex forward 등). SonarCloud
+ * 중복 차단 + 새 필드 추가 시 단일 지점 갱신을 위해 헬퍼로 추출.
+ */
+interface BuildStationPassedImminentPayloadInputs {
+  trip: Trip;
+  waypoint: Waypoint;
+  lock: BoardingLockMeta;
+  pushId: string;
+  now: number;
+}
+function buildStationPassedImminentPayload(
+  inputs: BuildStationPassedImminentPayloadInputs,
+): Parameters<typeof sendSilentPush>[0]['payload'] {
+  const { trip, waypoint, lock, pushId, now } = inputs;
+  return {
+    nextWaypoint: waypoint.stationName,
+    // arvlCd∈{0,1}은 "지금 진입/도착" 신호 — eta는 사실상 0. vanish-fallback도 동일 의미.
+    etaSeconds: 0,
+    phase: 'imminent',
+    kind: waypoint.kind,
+    sentAt: now,
+    pushId,
+    // Epic #1204 그룹 2 D3 (#1273) — validateTrip stamp 결과를 forward.
+    // 클라이언트 `silentPushLocationGate`가 D1 estimator currentHopIndex와 매칭 시
+    // 거리 검증 우회/`gate-no-location` fallback에 사용. 구 trip(부재) → undefined.
+    hopIndex: waypoint.hopIndex,
+    // #1365 — server-authoritative occupiedLine. 환승역에서 디바이스가 같은 hop index에
+    // 다른 line의 stop과 cross-validation 가능. waypoint.line을 그대로 forward.
+    occupiedLine: waypoint.line,
+    // #1307 — server-authoritative subsurface. 지하 trip의 intermediate push는
+    // 디바이스 GPS 게이트(out-of-range 오거부)를 우회하도록 flag를 전달.
+    subsurface: trip.subsurface === true,
+    // #1322 — lock-path fire의 노선/열차를 self-describing으로 전달. 디바이스가 로컬 lock
+    // 없이도(지하 auto-lock hydration window) line sanity-guard를 돌려 발사할 수 있게 한다.
+    boardingLine: lock.line,
+    trainCode: lock.trainCode,
+  };
+}
+
+/**
  * #917 A2 — boardingLock trip에서 arvlCd∈{0,1} 신호 관측 시 매역 station-passed silent push 발사.
  *
  * 호출 시점: runTrainCodeTracking이 estimate.arrived=true를 얻은 직후 advanceBoardingLockWaypoint
@@ -765,29 +806,7 @@ export async function fireArvlCdStationPush(
     (host) =>
       sendSilentPush({
         deviceToken: trip.token,
-        payload: {
-          nextWaypoint: waypoint.stationName,
-          // arvlCd∈{0,1}은 "지금 진입/도착" 신호 — eta는 사실상 0.
-          etaSeconds: 0,
-          phase: 'imminent',
-          kind: waypoint.kind,
-          sentAt: now,
-          pushId,
-          // Epic #1204 그룹 2 D3 (#1273) — validateTrip stamp 결과를 forward.
-          // 클라이언트 `silentPushLocationGate`가 D1 estimator currentHopIndex와 매칭 시
-          // 거리 검증 우회/`gate-no-location` fallback에 사용. 구 trip(부재) → undefined.
-          hopIndex: waypoint.hopIndex,
-          // #1365 — server-authoritative occupiedLine. 환승역에서 디바이스가 같은 hop index에
-          // 다른 line의 stop과 cross-validation 가능. waypoint.line을 그대로 forward.
-          occupiedLine: waypoint.line,
-          // #1307 — server-authoritative subsurface. 지하 trip의 intermediate push는
-          // 디바이스 GPS 게이트(out-of-range 오거부)를 우회하도록 flag를 전달.
-          subsurface: trip.subsurface === true,
-          // #1322 — lock-path fire의 노선/열차를 self-describing으로 전달. 디바이스가 로컬 lock
-          // 없이도(지하 auto-lock hydration window) line sanity-guard를 돌려 발사할 수 있게 한다.
-          boardingLine: lock.line,
-          trainCode: lock.trainCode,
-        },
+        payload: buildStationPassedImminentPayload({ trip, waypoint, lock, pushId, now }),
         config: deps.apnsConfig,
         host,
         fetchImpl: deps.fetchImpl,
@@ -882,18 +901,7 @@ export async function fireVanishFallbackStationPush(
     (host) =>
       sendSilentPush({
         deviceToken: trip.token,
-        payload: {
-          nextWaypoint: waypoint.stationName,
-          etaSeconds: 0,
-          phase: 'imminent',
-          kind: waypoint.kind,
-          sentAt: now,
-          pushId,
-          hopIndex: waypoint.hopIndex,
-          subsurface: trip.subsurface === true,
-          boardingLine: lock.line,
-          trainCode: lock.trainCode,
-        },
+        payload: buildStationPassedImminentPayload({ trip, waypoint, lock, pushId, now }),
         config: deps.apnsConfig,
         host,
         fetchImpl: deps.fetchImpl,

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -240,6 +240,18 @@ export interface ScheduledStats extends LiveActivityStats {
    * 경로를 측정한다. #640 회귀(lock 없는 trip 발사) 방어 신호 — 정상 운영에서는 0이어야 한다.
    */
   arvlCdFireMismatch: number;
+  /**
+   * #1370 L2 — trainCode vanish 후 시간 기반 fallback advance 직전에 station-passed silent push가
+   * 발사된 누적 횟수. fallback path가 어린이대공원/군자/중곡 같은 intermediate를 "지났음" 신호 없이
+   * 통과하던 회귀(silent push 0건)를 닫는다.
+   */
+  vanishFallbackFired: number;
+  /**
+   * #1370 L3 — vanish 후 hop 시간 미경과로 lock release할 때 trip.locklessStationPassed가
+   * false였던 trip을 강제 enable해 lockless 인계 경로를 살린 횟수. 0이 아니면 사용자가 opt-in
+   * 토글 OFF였지만 vanish recovery로 매역 push가 복구된 trip 수.
+   */
+  vanishLocklessTakeover: number;
 }
 
 /**
@@ -295,6 +307,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     arvlCdFireSuccess: 0,
     arvlCdFireDedup: 0,
     arvlCdFireMismatch: 0,
+    vanishFallbackFired: 0,
+    vanishLocklessTakeover: 0,
   };
 
   for await (const trip of listTrips(env.TRIPS)) {
@@ -811,6 +825,105 @@ export async function fireArvlCdStationPush(
 }
 
 /**
+ * #1370 L2 — trainCode vanish 후 시간 기반 fallback advance 직전에 발사하는 station-passed silent push.
+ *
+ * arvlCd fire 경로와 모양은 같지만 SSOT가 다르다 — arvlCd∈{0,1}이 아니라 "trainCode 사라짐 + hop 시간
+ * 경과 = optimistic 통과"를 신호로 채택. 디바이스 payload는 `arvlCd=null` (vanish-fallback 표식)으로
+ * 보내되 phase/kind는 imminent + 원본 waypoint.kind. dedup key는 arvlCd path와 분리 namespace
+ * (`vanish:`)을 사용해 cross-pollute 차단.
+ *
+ * 실패 분기 정책: arvlCd path와 동일 — push 실패는 stats.errors++만 누적, trip 자체는 호출자
+ * (`advanceBoardingLockWaypoint`)가 계속 진행한다. 추가 cleanup 분기 없음.
+ */
+interface FireVanishFallbackStationPushInputs {
+  trip: Trip;
+  waypoint: Waypoint;
+  lock: BoardingLockMeta;
+  env: Env;
+  deps: ScheduledDeps;
+  stats: ScheduledStats;
+  now: number;
+  log: Logger;
+  generatePushId: () => string;
+}
+
+export const VANISH_FALLBACK_FIRE_KEY_PREFIX = 'vanish-fallback-fire:';
+
+export function vanishFallbackFireKey(
+  token: string,
+  trainCode: string,
+  stationName: string,
+): string {
+  return `${VANISH_FALLBACK_FIRE_KEY_PREFIX}${token}|${trainCode}|${stationName}`;
+}
+
+export async function fireVanishFallbackStationPush(
+  inputs: FireVanishFallbackStationPushInputs,
+): Promise<void> {
+  const { trip, waypoint, lock, env, deps, stats, now, log, generatePushId } = inputs;
+  const key = vanishFallbackFireKey(trip.token, lock.trainCode, waypoint.stationName);
+  const existing = await env.TRIPS.get(key);
+  if (existing !== null) {
+    log('vanish-fallback-fire: dedup skip', {
+      token: trip.token.slice(0, 8),
+      trainCode: lock.trainCode,
+      station: waypoint.stationName,
+    });
+    return;
+  }
+  const pushId = generatePushId();
+  log('vanish-fallback-fire: station-passed push', {
+    token: trip.token.slice(0, 8),
+    trainCode: lock.trainCode,
+    station: waypoint.stationName,
+    kind: waypoint.kind,
+  });
+  const heal = await sendWithEnvHeal(
+    (host) =>
+      sendSilentPush({
+        deviceToken: trip.token,
+        payload: {
+          nextWaypoint: waypoint.stationName,
+          etaSeconds: 0,
+          phase: 'imminent',
+          kind: waypoint.kind,
+          sentAt: now,
+          pushId,
+          hopIndex: waypoint.hopIndex,
+          subsurface: trip.subsurface === true,
+          boardingLine: lock.line,
+          trainCode: lock.trainCode,
+        },
+        config: deps.apnsConfig,
+        host,
+        fetchImpl: deps.fetchImpl,
+        now,
+      }),
+    trip.apnsEnv,
+    deps.apnsHosts,
+    log,
+    trip.token.slice(0, 8),
+  );
+  if (heal.correctedEnv) {
+    trip.apnsEnv = heal.correctedEnv;
+    stats.envCorrected += 1;
+  }
+  if (!heal.result.ok) {
+    stats.errors += 1;
+    log('vanish-fallback-fire: push failed', {
+      status: heal.result.status,
+      reason: heal.result.reason,
+      token: trip.token.slice(0, 8),
+    });
+    // dedup KV는 성공 시에만 stamp — 실패 push는 다음 cycle 재시도 허용.
+    return;
+  }
+  stats.pushed += 1;
+  stats.vanishFallbackFired += 1;
+  await env.TRIPS.put(key, '1', { expirationTtl: ARVLCD_FIRE_DEDUP_TTL_SEC });
+}
+
+/**
  * #902 Seam F — trainCode 사라짐 후 swap. previous+이번 미스 = VANISH_RE_ATTACH_THRESHOLD 도달 시 시도.
  * 같은 station에 같은 line 신규 trainCode가 보이면 activeLock 교체. 호출자는 swap 결과를 사용해 재estimate.
  * `runTrainCodeTracking`의 cognitive complexity 분담용 추출 (Sonar S3776).
@@ -868,9 +981,10 @@ interface HandleEtaMissingInputs {
   stats: ScheduledStats;
   now: number;
   log: Logger;
+  generatePushId: () => string;
 }
 async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
-  const { trip, waypoint, activeLock, env, deps, stats, now, log } = inputs;
+  const { trip, waypoint, activeLock, env, deps, stats, now, log, generatePushId } = inputs;
   stats.etaMissing += 1;
   const previousMissCount = trip.consecutiveEtaMissing ?? 0;
   const nextMissCount = previousMissCount + 1;
@@ -901,20 +1015,45 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
         lastTrackedArrivalEpoch: lastEpoch,
       });
       trip.consecutiveEtaMissing = 0;
+      // #1370 L2 — fallback advance 전에 station-passed silent push를 발사한다.
+      // advanceBoardingLockWaypoint는 LA update + (destination 시) trip-ended push만 발사하므로
+      // intermediate/transfer waypoint를 "지났다"는 신호가 사용자에게 도달하지 않는 회귀가 있었다
+      // (어린이대공원/군자/중곡 silent push 0건). vanish fallback도 ground truth 신호로 취급해
+      // arvlCd∈{0,1}과 동등하게 station-passed push를 발사한다.
+      if (waypoint.kind !== 'destination') {
+        await fireVanishFallbackStationPush({
+          trip,
+          waypoint,
+          lock: activeLock,
+          env,
+          deps,
+          stats,
+          now,
+          log,
+          generatePushId,
+        });
+      }
       await advanceBoardingLockWaypoint(trip, waypoint, env, deps, stats, now, log);
       return;
     }
     // hop 시간 미경과 → lock release해 lockless/boardingPrompt가 인계받도록.
     // isBoardingLockActive=false가 되는 즉시 다음 cycle의 evaluateAndMaybeFireBoardingPrompt 경로 복구.
+    // #1370 L3 — lock release 후 lockless 인계가 실제로 작동하려면 trip.locklessStationPassed가
+    // true여야 한다(`if (!isBoardingLockActive) → if (trip.locklessStationPassed && intermediate)`).
+    // OFF인 trip은 다음 cycle에서 lockMissing으로 spin하며 군자/중곡까지 push 0건. vanish fallback은
+    // 시스템이 trainCode를 잃은 상황이므로 lockless 인계를 강제 enable해 매역 push 경로를 복구한다.
     log('boarding-lock: trainCode vanished — releasing lock (hop time not yet elapsed)', {
       token: trip.token.slice(0, 8),
       trainCode: activeLock.trainCode,
       station: waypoint.stationName,
       consecutiveEtaMissing: nextMissCount,
       lastTrackedArrivalEpoch: lastEpoch,
+      locklessTakeoverEnabled: trip.locklessStationPassed !== true,
     });
     trip.boardingLock = undefined;
     trip.consecutiveEtaMissing = 0;
+    trip.locklessStationPassed = true;
+    stats.vanishLocklessTakeover += 1;
     await deleteProgress(env.TRIPS, trip.token);
     await putTrip(env.TRIPS, trip);
     return;
@@ -961,7 +1100,17 @@ export async function runTrainCodeTracking(
     }
   }
   if (estimate === null) {
-    await handleEtaMissing({ trip, waypoint, activeLock, env, deps, stats, now, log });
+    await handleEtaMissing({
+      trip,
+      waypoint,
+      activeLock,
+      env,
+      deps,
+      stats,
+      now,
+      log,
+      generatePushId,
+    });
     return;
   }
 


### PR DESCRIPTION
## 요약

`#1370` 7-layer 회귀의 **L2 + L3** layer 수정.

### L2 — trainCode vanish 후 fallback advance에서 station-passed push 손실

- `backend/alarm-worker/src/scheduled.ts:handleEtaMissing` 시간 기반 fallback advance 직전에 station-passed silent push를 발사한다.
- 기존엔 `advanceBoardingLockWaypoint`가 LA update + (destination에서만) trip-ended push만 발사 → intermediate/transfer waypoint를 "지났음" 신호 없이 통과 (어린이대공원/군자/중곡 silent push 0건).
- 신규 `fireVanishFallbackStationPush` 헬퍼: `arvlCd` fire 경로와 동일한 payload 모양(`phase=imminent`, `kind=waypoint.kind`, `boardingLine` / `trainCode` self-describing) + dedup key는 `vanish-fallback-fire:` 네임스페이스 분리.
- destination waypoint는 fire skip (cleanupTripWithLa의 trip-ended push와 중복 차단).

### L3 — lockless 인계 미작동

- hop 시간 미경과로 lock release할 때 `trip.locklessStationPassed = true`를 강제 enable.
- 기존엔 opt-in OFF trip이 다음 cycle에서 `lockMissing`으로 spin하며 군자/중곡까지 push 0건.
- vanish는 시스템이 trainCode를 잃은 비정상 상황이므로 lockless 인계 강제 enable로 매역 push 경로를 복구.

### 측정 인프라

`ScheduledStats`에 누적 카운터 2개 추가:
- `vanishFallbackFired` — L2 push 발사 성공 누적
- `vanishLocklessTakeover` — L3 강제 enable 누적

## 테스트

신규 5개:
- L2 intermediate fire (push payload + waypoint shift 검증)
- L2 destination skip (`vanishFallbackFired===0`)
- L2 dedup KV (같은 station 두 번 발사 안 함)
- L2 push 실패 시 dedup KV stamp 안 함 (재시도 허용)
- L3 `locklessStationPassed===true` + stat 기록

전체 1318 tests pass, `tsc --noEmit` clean.

## 범위 외

- L1 (apnsEnv detection) / L4 (device burst fire) / L5 (silent push observability)는 별도 agent.

## 검증 필요 (사용자 책임)

- 실기기: 환승 후 7호선 intermediate (어린이대공원/군자/중곡) silent push device received ≥ 1 per station
- 1주 production tail: `vanishFallbackFired` / `vanishLocklessTakeover` 누적 발생 + acceptance 회귀 0건

Refs #1370