### PR TITLE
fix(#1370): L4 trip-ended push 수신 즉시 OS queue cancel

### DIFF
--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -1,6 +1,10 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Notifications from 'expo-notifications';
-import { TRIP_BOUND_CLEANUPS, runTripBoundCleanups } from '../tripBoundCleanups';
+import {
+  TRIP_BOUND_CLEANUPS,
+  runTripBoundCleanups,
+  cancelTripBoundOsQueue,
+} from '../tripBoundCleanups';
 import {
   DESTINATION_KEY,
   ROUTE_KEY,
@@ -106,6 +110,48 @@ describe('tripBoundCleanups', () => {
   it('runTripBoundCleanups: AsyncStorage가 reject해도 reject를 던지지 않는다 (graceful)', async () => {
     (AsyncStorage.removeItem as jest.Mock).mockRejectedValue(new Error('boom'));
     await expect(runTripBoundCleanups()).resolves.toBeUndefined();
+  });
+
+  it('#1370 L4 — cancelTripBoundOsQueue: bl:/tba: 사전 예약을 OS 큐에서 cancel한다 (종착역 burst 차단)', async () => {
+    // backend trip-ended push 수신 즉시 호출되는 정밀 helper. storage는 건드리지 않고
+    // OS queue 두 채널만 우선 cancel — race window 차단.
+    const blIds = ['bl:T-7172:0:early:용마산', 'bl:T-7172:0:imminent:용마산'];
+    await AsyncStorage.setItem(SCHEDULED_NOTIFICATIONS_KEY, JSON.stringify(blIds));
+    (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue([
+      { identifier: 'tba:imminent:용마산' },
+    ]);
+    (Notifications.cancelScheduledNotificationAsync as jest.Mock).mockResolvedValue(undefined);
+    (Notifications.dismissNotificationAsync as jest.Mock).mockResolvedValue(undefined);
+
+    await cancelTripBoundOsQueue();
+
+    const cancelled = (Notifications.cancelScheduledNotificationAsync as jest.Mock).mock.calls.map(
+      (c) => c[0] as string,
+    );
+    expect(cancelled).toContain('bl:T-7172:0:early:용마산');
+    expect(cancelled).toContain('bl:T-7172:0:imminent:용마산');
+    expect(cancelled).toContain('tba:imminent:용마산');
+  });
+
+  it('#1370 L4 — cancelTripBoundOsQueue: 한쪽 채널이 reject해도 다른 채널은 실행되고 호출자에 reject 전파 안 함', async () => {
+    // 두 cancel은 독립적 — allSettled로 묶여 한쪽 실패가 다른 쪽 또는 호출자(trip-ended handler)에
+    // 전파되면 안 된다.
+    await AsyncStorage.setItem(
+      SCHEDULED_NOTIFICATIONS_KEY,
+      JSON.stringify(['bl:T-7172:0:imminent:용마산']),
+    );
+    (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockRejectedValue(
+      new Error('boom'),
+    );
+    (Notifications.cancelScheduledNotificationAsync as jest.Mock).mockResolvedValue(undefined);
+    (Notifications.dismissNotificationAsync as jest.Mock).mockResolvedValue(undefined);
+
+    await expect(cancelTripBoundOsQueue()).resolves.toBeUndefined();
+    // bl 채널은 정상 cancel 호출됐어야 함.
+    const cancelled = (Notifications.cancelScheduledNotificationAsync as jest.Mock).mock.calls.map(
+      (c) => c[0] as string,
+    );
+    expect(cancelled).toContain('bl:T-7172:0:imminent:용마산');
   });
 
   it('runTripBoundCleanups: 한 항목이 reject해도 나머지 항목이 모두 실행된다', async () => {

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -95,5 +95,23 @@ export function runTripBoundCleanups(): Promise<void> {
   return Promise.allSettled(TRIP_BOUND_CLEANUPS.map((cleanup) => cleanup())).then(noop);
 }
 
+/**
+ * #1370 L4 — OS scheduled notification queue만 즉시 cancel하는 정밀 helper.
+ *
+ * 종착역 도착 silent push 수신 시 ROUTE_KEY/DESTINATION_KEY 등 storage 정리에 앞서
+ * OS 큐의 `bl:` / `tba:` 사전 예약 알람을 우선 제거해 burst fire race를 좁힌다.
+ * runTripBoundCleanups 전체 흐름은 그대로 유지하며(triggerTripEndRecall은 ROUTE_KEY를
+ * 읽어야 해 storage 정리는 그 뒤에 와야 함), 본 helper는 storage를 건드리지 않는다.
+ *
+ * 멱등 — runTripBoundCleanups가 후속에서 동일 OS API를 다시 호출해도 이미 비어 있어 안전.
+ * 두 cancel은 독립적이라 allSettled로 묶어 한쪽 실패가 다른 쪽 실행을 막지 않도록 한다.
+ */
+export function cancelTripBoundOsQueue(): Promise<void> {
+  return Promise.allSettled([
+    purgeBoardingLockSchedulerQueue(),
+    cancelTripBoundAlarms(),
+  ]).then(noop);
+}
+
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 function noop(): void {}

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -37,8 +37,11 @@ jest.mock('../../utils/alarmLog', () => ({
 
 // #868 — trip-ended payload 수신 시 trip-bound storage cleanup.
 const mockRunTripBoundCleanups = jest.fn().mockResolvedValue(undefined);
+// #1370 L4 — trip-ended 수신 즉시 OS queue cancel.
+const mockCancelTripBoundOsQueue = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../store/tripBoundCleanups', () => ({
   runTripBoundCleanups: () => mockRunTripBoundCleanups(),
+  cancelTripBoundOsQueue: () => mockCancelTripBoundOsQueue(),
 }));
 
 // #899 (Seam C) — trip-ended 분기는 FG 복귀를 위한 sentinel을 작성한다.
@@ -272,6 +275,10 @@ describe('silentPushTask', () => {
     mockRescheduleHopForLock.mockResolvedValue({ cancelled: 1, scheduled: 1 });
     // #918 A3 PR4 — tba reschedule 기본 graceful.
     mockRescheduleTripBoundAlarm.mockResolvedValue({ cancelled: 0, scheduled: 0 });
+    // #1370 L4 — trip-ended OS queue cancel 기본 graceful (mockImplementation 잔류 차단).
+    mockCancelTripBoundOsQueue.mockResolvedValue(undefined);
+    // #919 / #1370 — clearAllMocks가 mockImplementation을 reset하지 않으므로 명시 복구.
+    mockRunTripBoundCleanups.mockResolvedValue(undefined);
     // #1355 D1 — cross-channel cancel 기본 0건.
     mockCancelTbaByStationPhase.mockResolvedValue(0);
     mockCancelBlByStationPhase.mockResolvedValue(0);
@@ -2141,6 +2148,40 @@ describe('silentPushTask', () => {
 
         expect(mockTriggerTripEndRecall).toHaveBeenCalledTimes(1);
         expect(callOrder).toEqual(['trigger', 'cleanup']);
+      });
+
+      // #1370 L4 — 종착역 도착 시 device 로컬 OS queue burst fire 차단.
+      // trip-ended push 수신 즉시 cancelTripBoundOsQueue를 호출해 race window를 좁힌다.
+      // triggerTripEndRecall은 network upload로 수 초 stall 가능 — 그 전에 OS 큐 cancel 진행.
+      it('#1370 L4 — trip-ended 수신 즉시 cancelTripBoundOsQueue 호출 (trigger/cleanup *이전*)', async () => {
+        const callOrder: string[] = [];
+        mockCancelTripBoundOsQueue.mockImplementation(async () => {
+          callOrder.push('os-cancel');
+        });
+        mockTriggerTripEndRecall.mockImplementation(async () => {
+          callOrder.push('trigger');
+          return { uploaded: false };
+        });
+        mockRunTripBoundCleanups.mockImplementation(async () => {
+          callOrder.push('cleanup');
+        });
+
+        await handleSilentPush(tripEndedPayload({ reason: 'destination-arrived' }));
+
+        expect(mockCancelTripBoundOsQueue).toHaveBeenCalledTimes(1);
+        expect(callOrder).toEqual(['os-cancel', 'trigger', 'cleanup']);
+      });
+
+      it('#1370 L4 — tripToken mismatch 시 OS queue cancel도 호출 안 함 (다른 trip의 push)', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          if (key === ACTIVE_TRIP_KEY) return 'NEW-TRIP-TOKEN';
+          return null;
+        });
+        await handleSilentPush(
+          tripEndedPayload({ pushId: 'te-uuid', tripToken: 'OLD-TRIP-TOKEN' }),
+        );
+        expect(mockCancelTripBoundOsQueue).not.toHaveBeenCalled();
       });
 
       it('#919 — tripToken mismatch로 cleanup skip 시 recall trigger도 호출 안 함', async () => {

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -45,7 +45,7 @@ import {
   logSilentPushSkipped,
   type AlarmLogReason,
 } from '../utils/alarmLog';
-import { runTripBoundCleanups } from '../store/tripBoundCleanups';
+import { runTripBoundCleanups, cancelTripBoundOsQueue } from '../store/tripBoundCleanups';
 import { setTripEndedSentinel } from '../utils/tripEndedSentinel';
 import { triggerTripEndRecall } from '../utils/triggerTripEndRecall';
 import { evaluateDismissSilence } from '../utils/dismissSilenceGate';
@@ -624,6 +624,15 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
         sentAt: payload.sentAt,
         receivedAt,
       });
+      // #1370 L4 — OS scheduled queue burst fire 차단. 종착역 도착 시 backend trip-ended push가
+      // 도달할 때 device 로컬 OS queue(`bl:`/`tba:`)에 잔존한 사전 예약 알람이 동시에 발사돼
+      // 사용자가 "용마산 도착 후 한꺼번에 받음"으로 인지하는 회귀.
+      //
+      // runTripBoundCleanups가 결국 OS queue를 cancel하지만, 그 전에 triggerTripEndRecall이
+      // routeStops 구성 + network upload로 수 초 stall할 수 있어 race window가 열린다.
+      // OS queue cancel만 별도 helper로 분리해 trip-ended 진입 즉시 호출 — recall/cleanup 흐름은
+      // 그대로 유지. cancel 자체는 멱등하므로 runTripBoundCleanups의 중복 cancel은 안전 통과.
+      await cancelTripBoundOsQueue();
       // #919 — trip-end recall KPI upload. *반드시* cleanup 전에 호출해야 한다 — trigger가
       // ROUTE_KEY/DESTINATION_KEY/TRIP_STARTED_AT_KEY를 읽어 routeStops를 구성하기 때문.
       // trigger는 throw하지 않으므로 후속 cleanup/sentinel 흐름 차단 없음.


### PR DESCRIPTION
## 요약

#1370 RCA 중 **L4 (종착역 burst fire)** 만 fix. L1/L2/L3/L5는 다른 PR.

2026-06-16 오후 trip (성수→건대→용마산) 회귀: 용마산 도착 시 backend `cleanupTripWithLa('destination-arrived')` trip-ended push와 device 로컬 OS queue 3건 (`bl:7172:0:early:용마산`, `bl:7172:0:imminent:용마산`, `tba:imminent:용마산`) 이 동시 발사 → 사용자 "용마산 도착 후 한꺼번에 받음" 인지.

근본 원인: 기존에도 trip-ended 분기 끝에서 `runTripBoundCleanups()`가 OS 큐 cancel을 수행했지만, **그 전에 `triggerTripEndRecall()`(network upload — 수 초 stall 가능)이 await됨** → 이 stall window 동안 OS 큐 항목이 자체 ETA에 fire되는 race.

## 변경

- `silentPushTask.ts` — trip-ended 분기 진입 직후 `cancelTripBoundOsQueue()` 즉시 호출 (recall/cleanup *이전*)
- `tripBoundCleanups.ts` — OS 큐만 정밀 cancel하는 helper 신규 추가
  - `purgeBoardingLockSchedulerQueue` (bl:) + `cancelTripBoundAlarms` (tba:) 를 `Promise.allSettled` 로 묶음
  - storage(ROUTE_KEY 등)는 건드리지 않아 `triggerTripEndRecall`이 그 뒤 routeStops 구성 가능
  - 멱등 — 후속 `runTripBoundCleanups`의 중복 cancel은 안전 통과

## 테스트

- `tripBoundCleanups.test.ts` — bl:/tba: 두 채널 모두 cancel + 한쪽 reject 시 graceful
- `silentPushTask.test.ts` — trip-ended 진입 시 `os-cancel → trigger → cleanup` 순서 보장 + tripToken mismatch 시 os-cancel 호출 안 됨
- type-check / 100% coverage 통과

## 관련

Refs #1370 (L4)