### PR TITLE
fix(#1370): L1 apns env mismatch — !isSameSession 분기에서 corrected env 보존

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -680,6 +680,29 @@ describe('POST /trips (#578 — preserve advance progress on re-register)', () =
     expect(finalTrip.apnsEnv).toBe('production');
   });
 
+  // #1370 L1 — self-heal로 정정된 apnsEnv는 같은 token이면 새 session(환승 후 새 trainCode 등)에서도 보존.
+  // 보존 안 하면 매 새 session 첫 push마다 mismatch retry가 반복돼 첫 push latency + 일부 drop 위험.
+  it('preserves backend-corrected apnsEnv across new session re-register (#1370)', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripBody({ apnsEnv: 'production' }), env);
+    // backend self-heal로 sandbox로 정정된 상태 시뮬레이션
+    const existing = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    existing.apnsEnv = 'sandbox';
+    await env.TRIPS.put('trip:tok-578', JSON.stringify(existing));
+    // 환승 후 새 trainCode + createdAt drift → !isSameSession 분기. client는 다시 production 송신.
+    await post('/trips', tripBody({ createdAt: CREATED + 10_000, apnsEnv: 'production' }), env);
+    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    expect(finalTrip.apnsEnv).toBe('sandbox');
+  });
+
+  // existing 부재(brand-new token) 또는 existing.apnsEnv 부재(legacy trip) → incoming 값으로 fallback.
+  it('uses incoming apnsEnv on brand-new token (no existing trip)', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripBody({ apnsEnv: 'production' }), env);
+    const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    expect(finalTrip.apnsEnv).toBe('production');
+  });
+
   // #706 — re-register가 누적된 consecutiveEtaMissing을 0으로 지우면 자동 종료가 영원히 못 발동.
   it('preserves backend-accumulated consecutiveEtaMissing on same-session re-register', async () => {
     const env = makeKvEnv();

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -431,6 +431,12 @@ app.post('/trips', async (c) => {
         // 같은 token + window 안이면 auto-prompt dedup 마커는 보존. backend가 직전에 auto-lock 시도/
         // 발사한 trip 컨텍스트의 재발사 ping-pong을 차단한다.
         lastAutoPromptedAt: preservedLastAutoPromptedAt,
+        // #1370 L1 — corrected apnsEnv 보존. 같은 token = 같은 디바이스 = 같은 APNs env이므로
+        // session 경계(환승 후 새 trainCode 등)와 무관하게 self-heal로 정정된 env가 유지돼야 한다.
+        // 보존 안 하면 새 session 첫 push마다 mismatch retry가 반복돼 첫 push latency + 일부 drop 위험
+        // (#1370 evidence: 환승 후 7호선 매역 silent push 손실).
+        // existing 부재(brand-new token) 또는 existing.apnsEnv 부재(legacy trip)면 incoming 값으로 자연 fallback.
+        apnsEnv: existing?.apnsEnv ?? incoming.apnsEnv,
       };
 
   // #705 — progress KV가 우선. 같은 trainCode면 incoming.waypoints에서 shift된 만큼 잘라낸다.


### PR DESCRIPTION
## Summary

`#1370` L1 layer만 처리. (L2/L3/L4/L5는 별도 PR.)

### root cause
`POST /trips` `!isSameSession` 분기(환승 후 새 trainCode 또는 `createdAt` drift > 5s)에서 `existing.apnsEnv`가 `incoming` 전체에 덮여 **self-heal로 정정된 corrected env가 lost**.

```ts
// before
: {
    ...incoming,
    lastAutoPromptedAt: preservedLastAutoPromptedAt,
  }
```

→ client는 여전히 잘못된 `apnsEnv` (예: production)를 송신 → 매 새 leg 첫 push마다 backend `apns env mismatch — retry with opposite host` 반복 → 첫 push latency + 일부 drop 위험. 2026-06-16 오후 trip evidence(`tasks/scheduled-tail-20260616-132703.jsonl`)의 환승 후 7호선 매역 silent push 손실 패턴 중 L1 layer.

### fix

같은 `token` = 같은 디바이스 = 같은 APNs env이므로 session 경계와 무관하게 corrected env 유지:

```ts
: {
    ...incoming,
    lastAutoPromptedAt: preservedLastAutoPromptedAt,
    apnsEnv: existing?.apnsEnv ?? incoming.apnsEnv,
  }
```

- `existing` 부재 (brand-new token) → `incoming` 채택 (자연 fallback)
- `existing.apnsEnv` 부재 (legacy trip) → `incoming` 채택

### tests
`backend/alarm-worker/src/__tests__/index.test.ts`:
1. **새 session에서 corrected env 보존** — `createdAt` drift 10s + client가 `production` 재송신해도 backend가 `sandbox`로 정정한 값 유지
2. **brand-new token** — `existing` 없는 첫 등록 시 incoming 채택

기존 `same-session apnsEnv 보존` 테스트는 그대로 통과.

### checks
- `npm run type-check` ✅
- `npm test` ✅ (5644 tests, coverage 100%)
- backend `npm test` ✅ (1315 tests)

Refs #1370