### PR TITLE
fix(#1370): L5 silent push 도달률 observability — ack stamping

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1134,6 +1134,14 @@ describe('validatePushAck (#566 P2a)', () => {
     const ack = validatePushAck({ pushId: 'p1', token: 'tok', outcome: 'skipped', reason: 123 });
     expect(ack).toEqual({ pushId: 'p1', token: 'tok', outcome: 'skipped' });
   });
+
+  it('#1370 L5 — accepts received outcome', () => {
+    expect(validatePushAck({ pushId: 'p1', token: 'tok', outcome: 'received' })).toEqual({
+      pushId: 'p1',
+      token: 'tok',
+      outcome: 'received',
+    });
+  });
 });
 
 describe('POST /push/ack (#566 P2a)', () => {
@@ -1198,6 +1206,63 @@ describe('POST /push/ack (#566 P2a)', () => {
     const res = await post('/push/ack', { pushId: 'p1', token: 'tok', outcome: 'fired' }, env);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, deleted: false, reason: 'not-found' });
+  });
+
+  describe('#1370 L5 — received outcome', () => {
+    it('token 매칭 시 stamped=true, pending entry는 보존', async () => {
+      await kv.put(
+        pendingKey('p1'),
+        JSON.stringify({
+          pushId: 'p1',
+          token: 'real-token',
+          stationName: '어린이대공원',
+          phase: 'early',
+        }),
+      );
+      const env = makeEnv({ PENDING_PUSHES: kv as unknown as KVNamespace });
+      const res = await post(
+        '/push/ack',
+        { pushId: 'p1', token: 'real-token', outcome: 'received' },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true, stamped: true });
+      // pending entry는 보존 — fired/skipped 후속 ack가 P2c fallback 결정에 사용.
+      expect(kv.store.has(pendingKey('p1'))).toBe(true);
+      // received: stamp 적재.
+      expect(kv.store.has('received:p1')).toBe(true);
+    });
+
+    it('token 불일치 시 stamped=false, reason=token-mismatch', async () => {
+      await kv.put(
+        pendingKey('p1'),
+        JSON.stringify({ pushId: 'p1', token: 'real-token', stationName: '강남', phase: 'early' }),
+      );
+      const env = makeEnv({ PENDING_PUSHES: kv as unknown as KVNamespace });
+      const res = await post(
+        '/push/ack',
+        { pushId: 'p1', token: 'attacker', outcome: 'received' },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        ok: true,
+        stamped: false,
+        reason: 'token-mismatch',
+      });
+      expect(kv.store.has('received:p1')).toBe(false);
+    });
+
+    it('PENDING_PUSHES 미바인딩 시 stamped=false, reason=not-found', async () => {
+      const env = makeEnv();
+      const res = await post(
+        '/push/ack',
+        { pushId: 'p1', token: 'tok', outcome: 'received' },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true, stamped: false, reason: 'not-found' });
+    });
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/pendingPushes.test.ts
+++ b/backend/alarm-worker/src/__tests__/pendingPushes.test.ts
@@ -3,11 +3,15 @@ import {
   ackPending,
   buildAlarmKey,
   getPending,
+  getReceivedStamp,
   listPending,
   pendingKey,
   PENDING_TTL_SEC,
   putPending,
+  receivedKey,
+  RECEIVED_TTL_SEC,
   removePending,
+  stampReceived,
   type PendingPush,
 } from '../pendingPushes';
 
@@ -155,6 +159,98 @@ describe('pendingPushes (#566 P2a)', () => {
         deleted: false,
         reason: 'not-found',
       });
+    });
+  });
+
+  describe('stampReceived / getReceivedStamp (#1370 L5)', () => {
+    it('receivedKey: received: 접두어를 붙인다', () => {
+      expect(receivedKey('abc-def')).toBe('received:abc-def');
+    });
+
+    it('RECEIVED_TTL_SEC = 3600 (1시간)', () => {
+      expect(RECEIVED_TTL_SEC).toBe(60 * 60);
+    });
+
+    it('token 매칭 시 stamp 적재 + pending entry는 보존 + stamped=true', async () => {
+      await putPending(
+        kv as unknown as KVNamespace,
+        makeEntry({ pushId: 'p1', token: 'devicetoken-hex', stationName: '강남', phase: 'early' }),
+      );
+      const result = await stampReceived(
+        kv as unknown as KVNamespace,
+        'p1',
+        'devicetoken-hex',
+        1_700_000_001_000,
+      );
+      expect(result).toEqual({ stamped: true });
+      expect(kv.store.has('pending:p1')).toBe(true);
+      const entry = kv.store.get('received:p1');
+      expect(entry).toBeDefined();
+      const parsed = JSON.parse(entry!.value) as { pushId: string; receivedAt: number; stationName: string; phase: string };
+      expect(parsed.pushId).toBe('p1');
+      expect(parsed.receivedAt).toBe(1_700_000_001_000);
+      expect(parsed.stationName).toBe('강남');
+      expect(parsed.phase).toBe('early');
+    });
+
+    it('token 불일치면 stamp 미적재 + reason=token-mismatch', async () => {
+      await putPending(
+        kv as unknown as KVNamespace,
+        makeEntry({ pushId: 'p1', token: 'real-token' }),
+      );
+      const result = await stampReceived(
+        kv as unknown as KVNamespace,
+        'p1',
+        'attacker',
+        Date.now(),
+      );
+      expect(result).toEqual({ stamped: false, reason: 'token-mismatch' });
+      expect(kv.store.has('received:p1')).toBe(false);
+    });
+
+    it('미존재 pushId는 reason=not-found', async () => {
+      const result = await stampReceived(
+        kv as unknown as KVNamespace,
+        'missing',
+        'tok',
+        Date.now(),
+      );
+      expect(result).toEqual({ stamped: false, reason: 'not-found' });
+    });
+
+    it('kv === undefined면 reason=not-found', async () => {
+      expect(await stampReceived(undefined, 'p1', 'tok', Date.now())).toEqual({
+        stamped: false,
+        reason: 'not-found',
+      });
+    });
+
+    it('getReceivedStamp: stamp 존재 시 parsed entry 반환', async () => {
+      await putPending(
+        kv as unknown as KVNamespace,
+        makeEntry({ pushId: 'p1', token: 'tok', stationName: '시청', phase: 'imminent' }),
+      );
+      await stampReceived(kv as unknown as KVNamespace, 'p1', 'tok', 1_700_000_500_000);
+      const stamp = await getReceivedStamp(kv as unknown as KVNamespace, 'p1');
+      expect(stamp).toEqual({
+        pushId: 'p1',
+        receivedAt: 1_700_000_500_000,
+        stationName: '시청',
+        phase: 'imminent',
+      });
+    });
+
+    it('getReceivedStamp: stamp 없으면 null', async () => {
+      expect(await getReceivedStamp(kv as unknown as KVNamespace, 'missing')).toBeNull();
+    });
+
+    it('getReceivedStamp: 손상된 JSON은 null', async () => {
+      await kv.put('received:p1', '{broken');
+      expect(await getReceivedStamp(kv as unknown as KVNamespace, 'p1')).toBeNull();
+    });
+
+    it('getReceivedStamp: kv === undefined면 null', async () => {
+      expect(await getReceivedStamp(undefined, 'p1')).toBeNull();
     });
   });
 });

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -39,7 +39,7 @@ import {
   type LiveActivityDeps,
   type LiveActivityStats,
 } from './liveActivity';
-import { ackPending } from './pendingPushes';
+import { ackPending, stampReceived } from './pendingPushes';
 import { appendPositionPoint } from './positionSeries';
 import { appendAccelSample, isAccelSummary } from './accelSeries';
 import { deleteProgress, getProgress, putProgress, type TripProgress } from './progress';
@@ -727,6 +727,18 @@ app.post('/push/ack', async (c) => {
   const ack = validatePushAck(body);
   if (!ack) return c.json({ error: 'invalid_payload' }, 400);
 
+  // #1370 L5 — `received` outcome은 도달률 측정용 stamp만 적재. pending entry는 보존해
+  //   후속 fired/skipped ack가 P2c fallback을 정상 차단할 수 있게 한다.
+  if (ack.outcome === 'received') {
+    const stampResult = await stampReceived(
+      c.env.PENDING_PUSHES,
+      ack.pushId,
+      ack.token,
+      Date.now(),
+    );
+    return c.json({ ok: true, ...stampResult });
+  }
+
   const result = await ackPending(c.env.PENDING_PUSHES, ack.pushId, ack.token);
   return c.json({ ok: true, ...result });
 });
@@ -1162,7 +1174,8 @@ async function maybeMirrorLockSyncProgress(
 interface PushAckPayload {
   pushId: string;
   token: string;
-  outcome: 'fired' | 'skipped';
+  // #1370 L5 — `received`는 도달률 stamp 전용. fired/skipped는 outcome 분리 후 pending entry 삭제.
+  outcome: 'received' | 'fired' | 'skipped';
   reason?: string;
 }
 
@@ -1171,7 +1184,9 @@ export function validatePushAck(input: unknown): PushAckPayload | null {
   const obj = input as Record<string, unknown>;
   if (typeof obj.pushId !== 'string' || obj.pushId.length === 0) return null;
   if (typeof obj.token !== 'string' || obj.token.length === 0) return null;
-  if (obj.outcome !== 'fired' && obj.outcome !== 'skipped') return null;
+  if (obj.outcome !== 'received' && obj.outcome !== 'fired' && obj.outcome !== 'skipped') {
+    return null;
+  }
   const out: PushAckPayload = { pushId: obj.pushId, token: obj.token, outcome: obj.outcome };
   if (typeof obj.reason === 'string') out.reason = obj.reason;
   return out;

--- a/backend/alarm-worker/src/pendingPushes.ts
+++ b/backend/alarm-worker/src/pendingPushes.ts
@@ -132,6 +132,79 @@ export async function removePending(
 }
 
 /**
+ * #1370 L5 — silent push 도달률 observability stamp.
+ *
+ * 디바이스가 push 수신 시점에 `outcome: 'received'`로 ack를 보내면 이 함수가 호출된다.
+ * outcome ack(fired/skipped)와 달리 pending entry를 삭제하지 않는다 — 게이트 평가가 아직
+ * 끝나지 않았기 때문(P2c fallback 결정은 이후 fired/skipped ack로 처리).
+ *
+ * 단순 KV stamp로 "이 pushId가 디바이스에 도달했다"는 사실만 기록한다. 백엔드 tail에는
+ * `reschedule push → 어린이대공원` 같은 pushed 이벤트가 남아 있고, 사용자/agent가 RCA 시
+ * `received:<pushId>` stamp 존재 여부로 pushed vs received를 1:1 비교할 수 있다.
+ *
+ * TTL 1h — 회귀 분석 윈도우. KV cacheTtl 최소값(30s)과 무관하게 stamp는 1h 보존.
+ */
+const RECEIVED_PREFIX = 'received:';
+export const RECEIVED_TTL_SEC = 60 * 60;
+
+export function receivedKey(pushId: string): string {
+  return `${RECEIVED_PREFIX}${pushId}`;
+}
+
+/**
+ * `outcome: 'received'` ack 처리 결과. 임의 echo 차단을 위해 outcome ack와 동일하게
+ * pending.token 매칭을 요구한다.
+ *  - `stamped: true` — pending entry 매칭 + stamp 적재
+ *  - `stamped: false, reason: 'not-found'` — pending entry 부재 (TTL 초과 / 잘못된 pushId)
+ *  - `stamped: false, reason: 'token-mismatch'` — 다른 디바이스가 임의 echo
+ */
+export interface ReceivedAckResult {
+  stamped: boolean;
+  reason?: 'not-found' | 'token-mismatch';
+}
+
+export async function stampReceived(
+  kv: KVNamespace | undefined,
+  pushId: string,
+  token: string,
+  receivedAt: number,
+): Promise<ReceivedAckResult> {
+  if (!kv) return { stamped: false, reason: 'not-found' };
+  const entry = await getPending(kv, pushId);
+  if (!entry) return { stamped: false, reason: 'not-found' };
+  if (entry.token !== token) return { stamped: false, reason: 'token-mismatch' };
+  await kv.put(
+    receivedKey(pushId),
+    JSON.stringify({ pushId, receivedAt, stationName: entry.stationName, phase: entry.phase }),
+    { expirationTtl: RECEIVED_TTL_SEC },
+  );
+  return { stamped: true };
+}
+
+/**
+ * #1370 L5 — RCA 시 `received:<pushId>` stamp 조회. stamp 부재 = push가 디바이스에
+ * 도달하지 않음(또는 도달 후 task 시작 전 OS suspend).
+ */
+export async function getReceivedStamp(
+  kv: KVNamespace | undefined,
+  pushId: string,
+): Promise<{ pushId: string; receivedAt: number; stationName: string; phase: AlarmPhase } | null> {
+  if (!kv) return null;
+  const raw = await kv.get(receivedKey(pushId));
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as {
+      pushId: string;
+      receivedAt: number;
+      stationName: string;
+      phase: AlarmPhase;
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * ACK 처리. caller가 device token도 함께 보내야 임의 pushId echo로 인한 fallback 무력화를 차단한다.
  * KV에 저장된 pending.token과 매칭하지 않으면 삭제하지 않는다.
  */

--- a/src/features/alarm/api/alarmBackend.ts
+++ b/src/features/alarm/api/alarmBackend.ts
@@ -324,7 +324,10 @@ export function registerActiveTrip(
 export interface PushAckPayload {
   pushId: string;
   token: string;
-  outcome: 'fired' | 'skipped';
+  // #1370 L5 — `received` outcome은 게이트 평가 전 push 도달 stamp만 기록한다.
+  //   backend는 pending entry를 삭제하지 않고 KV에 `received:<pushId>` stamp만 저장 →
+  //   RCA 시 pushed(backend tail) vs received(stamp) 1:1 비교 가능.
+  outcome: 'received' | 'fired' | 'skipped';
   reason?: string;
 }
 

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -1323,6 +1323,109 @@ describe('silentPushTask', () => {
       });
     });
 
+    describe('#1370 L5 — silent push 도달 stamp (received outcome)', () => {
+      it('standard payload + pushId + apnsToken 모두 있으면 gate 평가 전 received ack 발사', async () => {
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-recv' }),
+        );
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'p-recv',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'received',
+        });
+        // 후속 outcome(fired) ack도 그대로 발사 — 별개 호출.
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'p-recv',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'fired',
+        });
+      });
+
+      it('게이트 fail로 outcome=skipped여도 received ack는 먼저 발사', async () => {
+        mockCheckGate.mockResolvedValue({
+          pass: false,
+          reason: 'out-of-range',
+          distanceM: 5_000,
+          thresholdM: 400,
+        });
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-recv-skip' }),
+        );
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'p-recv-skip',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'received',
+        });
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'p-recv-skip',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'skipped',
+          reason: 'gate-out-of-range',
+        });
+      });
+
+      it('pushId 없으면 received ack도 skip (구 backend 호환)', async () => {
+        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+        expect(mockSendPushAck).not.toHaveBeenCalledWith(
+          expect.objectContaining({ outcome: 'received' }),
+        );
+      });
+
+      it('apnsToken null이면 received ack도 skip', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          if (key === APNS_TOKEN_KEY) return null;
+          return null;
+        });
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-no-tok' }),
+        );
+        expect(mockSendPushAck).not.toHaveBeenCalledWith(
+          expect.objectContaining({ outcome: 'received' }),
+        );
+      });
+
+      it('reschedule payload도 received ack 발사', async () => {
+        await handleSilentPush({
+          data: {
+            data: {
+              data: {
+                kind: 'reschedule',
+                nextStation: '사가정',
+                newArrivalTimeEpoch: Date.now() + 60_000,
+                trainCode: '7610',
+                pushId: 'rs-recv',
+              },
+            },
+          },
+        });
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'rs-recv',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'received',
+        });
+      });
+
+      it('trip-ended payload도 received ack 발사', async () => {
+        await handleSilentPush({
+          data: {
+            data: {
+              data: {
+                kind: 'trip-ended',
+                reason: 'expired',
+                pushId: 'te-recv',
+              },
+            },
+          },
+        });
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'te-recv',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'received',
+        });
+      });
+    });
+
     describe('#727 정적 misfire 가드 (movement)', () => {
       it('gate가 speed=0 노출하면 movement-static-speed로 skip + 발사 안 함', async () => {
         mockCheckGate.mockResolvedValue({

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -190,6 +190,18 @@ import {
 
 const DEFAULT_APNS_TOKEN = 'apns-tok-hex';
 
+// #1370 L5 — sendPushAck 호출 매칭 헬퍼. ack outcome별로 같은 token/pushId 페이로드를 반복 검증하는
+// 패턴이 다발해 SonarCloud 중복으로 잡힘. 호출 한 줄로 압축해 중복 차단.
+function ackCall(
+  pushId: string,
+  outcome: 'received' | 'fired' | 'skipped',
+  reason?: string,
+): { pushId: string; token: string; outcome: string; reason?: string } {
+  return reason === undefined
+    ? { pushId, token: DEFAULT_APNS_TOKEN, outcome }
+    : { pushId, token: DEFAULT_APNS_TOKEN, outcome, reason };
+}
+
 const destStation = { id: '0228', name: '강남', line: '2', lat: 37.5, lng: 127.0 };
 
 /**
@@ -1237,11 +1249,7 @@ describe('silentPushTask', () => {
         await handleSilentPush(
           payload({ kind: 'destination', phase: 'imminent', pushId: 'p-fire' }),
         );
-        expect(mockSendPushAck).toHaveBeenCalledWith({
-          pushId: 'p-fire',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'fired',
-        });
+        expect(mockSendPushAck).toHaveBeenCalledWith(ackCall('p-fire', 'fired'));
       });
 
       it('게이트 fail 시 sendPushAck(outcome=skipped, reason=게이트사유)', async () => {
@@ -1254,12 +1262,9 @@ describe('silentPushTask', () => {
         await handleSilentPush(
           payload({ kind: 'destination', phase: 'imminent', pushId: 'p-gate' }),
         );
-        expect(mockSendPushAck).toHaveBeenCalledWith({
-          pushId: 'p-gate',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'skipped',
-          reason: 'gate-out-of-range',
-        });
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          ackCall('p-gate', 'skipped', 'gate-out-of-range'),
+        );
       });
 
       it('FIRED_ALARMS dedup 시 sendPushAck(outcome=skipped, reason=dedup-already-fired)', async () => {
@@ -1267,12 +1272,9 @@ describe('silentPushTask', () => {
         await handleSilentPush(
           payload({ kind: 'destination', phase: 'imminent', pushId: 'p-dedup' }),
         );
-        expect(mockSendPushAck).toHaveBeenCalledWith({
-          pushId: 'p-dedup',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'skipped',
-          reason: 'dedup-already-fired',
-        });
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          ackCall('p-dedup', 'skipped', 'dedup-already-fired'),
+        );
       });
 
       it('payload-missing-kind 시 sendPushAck(outcome=skipped, reason=payload-missing-kind)', async () => {
@@ -1284,12 +1286,9 @@ describe('silentPushTask', () => {
             pushId: 'p-kind',
           }),
         });
-        expect(mockSendPushAck).toHaveBeenCalledWith({
-          pushId: 'p-kind',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'skipped',
-          reason: 'payload-missing-kind',
-        });
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          ackCall('p-kind', 'skipped', 'payload-missing-kind'),
+        );
       });
 
       it('pushId 누락(구 백엔드)이면 ACK skip', async () => {
@@ -1328,17 +1327,9 @@ describe('silentPushTask', () => {
         await handleSilentPush(
           payload({ kind: 'destination', phase: 'imminent', pushId: 'p-recv' }),
         );
-        expect(mockSendPushAck).toHaveBeenCalledWith({
-          pushId: 'p-recv',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'received',
-        });
+        expect(mockSendPushAck).toHaveBeenCalledWith(ackCall('p-recv', 'received'));
         // 후속 outcome(fired) ack도 그대로 발사 — 별개 호출.
-        expect(mockSendPushAck).toHaveBeenCalledWith({
-          pushId: 'p-recv',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'fired',
-        });
+        expect(mockSendPushAck).toHaveBeenCalledWith(ackCall('p-recv', 'fired'));
       });
 
       it('게이트 fail로 outcome=skipped여도 received ack는 먼저 발사', async () => {
@@ -1351,17 +1342,10 @@ describe('silentPushTask', () => {
         await handleSilentPush(
           payload({ kind: 'destination', phase: 'imminent', pushId: 'p-recv-skip' }),
         );
-        expect(mockSendPushAck).toHaveBeenCalledWith({
-          pushId: 'p-recv-skip',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'received',
-        });
-        expect(mockSendPushAck).toHaveBeenCalledWith({
-          pushId: 'p-recv-skip',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'skipped',
-          reason: 'gate-out-of-range',
-        });
+        expect(mockSendPushAck).toHaveBeenCalledWith(ackCall('p-recv-skip', 'received'));
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          ackCall('p-recv-skip', 'skipped', 'gate-out-of-range'),
+        );
       });
 
       it('pushId 없으면 received ack도 skip (구 backend 호환)', async () => {

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -517,7 +517,7 @@ function buildIntermediateContent(stationName: string): { title: string; body: s
 function ackOutcome(
   pushId: string | undefined,
   token: string | null,
-  outcome: 'fired' | 'skipped',
+  outcome: 'received' | 'fired' | 'skipped',
   reason?: string,
 ): void {
   if (!pushId || !token) return;
@@ -567,6 +567,19 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     const receivedAt = Date.now();
     addDomainBreadcrumb('push', 'silent-push', { kind: payload.kind ?? 'fire' });
     const apnsToken = await loadApnsToken();
+
+    // #1370 L5 — silent push 도달률 observability stamp.
+    //
+    // 게이트 평가 이전, payload가 유효한 시점에 도달 신호를 backend로 보낸다.
+    // backend는 KV에 `received:<pushId>` stamp만 적재하고 pending entry는 보존 — 후속
+    // fired/skipped ack가 P2c fallback 결정을 그대로 처리한다.
+    //
+    // 효과: backend tail의 `reschedule push → 어린이대공원` pushed 이벤트와 device received
+    // stamp를 1:1 비교 가능. stamp 부재 = APNs 전달 실패 또는 OS suspend로 task 미시작.
+    //
+    // pushId/token 둘 다 있어야 임의 echo 차단 정책을 지킬 수 있으므로 ackOutcome과 동일하게
+    // 누락 시 skip한다 (구 backend 호환 경로).
+    ackOutcome(payload.pushId, apnsToken, 'received');
 
     // reschedule 분기 (#725). 백엔드는 사전 예약 알람(#584) 시각을 정정하려고 이 push를 보낸다.
     // - 수신 신호는 받았다 알리고(`lastReceivedAt` 갱신)


### PR DESCRIPTION
## 요약 (L5 layer only)

#1370 RCA의 **L5 silent push 도달 observability 부재** 해결. L1~L4는 별도 PR/agent.

backend tail에는 `reschedule push → 어린이대공원` 같은 **pushed** 이벤트가 기록되지만, 디바이스 dump에는 `received=1` (건대만)이라 어린이대공원/군자/중곡 push 도달 여부를 비교 측정할 방법이 없었다. 회귀 RCA 시 "APNs 전달 실패"인지 "도달했지만 게이트 skip"인지 구분 불가.

## 변경

**device (`silentPushTask.ts`)**
- `extractPayload` 성공 직후, 모든 게이트 평가 전에 `outcome: 'received'` ack를 backend로 발사 (pushId/token 둘 다 있을 때만 — 구 backend 호환)
- 후속 `fired`/`skipped` ack는 그대로 작동 — 별개 호출
- standard / reschedule / trip-ended 3가지 payload 모두 적용

**device (`alarmBackend.ts`)**
- `PushAckPayload.outcome` union에 `'received'` 추가

**backend (`pendingPushes.ts`)**
- `stampReceived` 추가: `received:<pushId>` KV stamp (TTL 1h), pending entry는 **보존** (P2c fallback 결정용 fired/skipped ack가 이후 처리)
- token 매칭 검증으로 임의 echo 차단
- `getReceivedStamp` 추가: RCA 시 stamp 조회용

**backend (`index.ts` POST /push/ack)**
- `outcome=received`면 `stampReceived` 호출, 응답 `{ ok, stamped, reason? }`
- `fired`/`skipped`는 기존 `ackPending` 그대로 (pending entry 삭제)
- `validatePushAck`가 `'received'` outcome 허용

## 효과

- backend pushed events vs device received stamps **1:1 비교 가능**
- 다음 회귀 trip에서 어린이대공원/군자 silent push 도달 여부 즉시 식별
- stamp 부재 = APNs 전달 실패 또는 OS suspend로 BG task 미시작 → L1/L2 RCA 정밀화

## 테스트

- `npm test` — 5650 / 5650 pass, coverage 100%
- backend `vitest` — 1327 / 1327 pass
- `npm run type-check` pass

신규 테스트:
- silentPushTask: standard/reschedule/trip-ended 모두 received ack 발사, pushId 누락 / apnsToken null 시 skip
- pendingPushes: stampReceived token 매칭/불일치/not-found/kv 미바인딩 graceful + getReceivedStamp
- POST /push/ack: received outcome stamped=true, pending entry 보존, token-mismatch

## 범위 가이드

오버엔지 회피. observability 인프라 추가 없이 기존 `/push/ack` endpoint에 outcome enum 1개 + KV stamp 1개로 MVP.

Refs #1370