### PR TITLE
fix(#1363): sticky cascade emit 16만회 + fusion consensus gate + /position diag 이원화

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1591,6 +1591,41 @@ describe('POST /position (#819)', () => {
       expect(stored[0].nearestStationDistanceM).toBeUndefined();
     });
   });
+
+  describe('#1363 — currentStationName 옵션 필드 (log 진단 이원화)', () => {
+    const BASE_POS = { token: 'tok-csn', lat: 1, lng: 2, accuracy: 5, ts: 1234, motion: 'walking' as const };
+
+    it('정상 문자열 → point.currentStationName에 set (waypoint와 구분된 log 라벨용)', async () => {
+      const env = makeKvEnv();
+      const res = await post('/position', { ...BASE_POS, currentStationName: '강남' }, env);
+      expect(res.status).toBe(200);
+      const stored = JSON.parse((await env.TRIPS.get('pos:tok-csn'))!) as Array<Record<string, unknown>>;
+      expect(stored[0].currentStationName).toBe('강남');
+    });
+
+    it('빈 문자열 → undefined로 graceful skip (payload 거부 X)', async () => {
+      const env = makeKvEnv();
+      const res = await post('/position', { ...BASE_POS, currentStationName: '' }, env);
+      expect(res.status).toBe(200);
+      const stored = JSON.parse((await env.TRIPS.get('pos:tok-csn'))!) as Array<Record<string, unknown>>;
+      expect(stored[0].currentStationName).toBeUndefined();
+    });
+
+    it('non-string → undefined로 graceful skip', async () => {
+      const env = makeKvEnv();
+      const res = await post('/position', { ...BASE_POS, currentStationName: 123 }, env);
+      expect(res.status).toBe(200);
+      const stored = JSON.parse((await env.TRIPS.get('pos:tok-csn'))!) as Array<Record<string, unknown>>;
+      expect(stored[0].currentStationName).toBeUndefined();
+    });
+
+    it('필드 없음 → undefined (회귀 없음)', async () => {
+      const env = makeKvEnv();
+      await post('/position', BASE_POS, env);
+      const stored = JSON.parse((await env.TRIPS.get('pos:tok-csn'))!) as Array<Record<string, unknown>>;
+      expect(stored[0].currentStationName).toBeUndefined();
+    });
+  });
 });
 
 describe('POST /boarding-prompt/dismiss (#819)', () => {

--- a/backend/alarm-worker/src/__tests__/positionSeries.test.ts
+++ b/backend/alarm-worker/src/__tests__/positionSeries.test.ts
@@ -427,6 +427,50 @@ describe('positionSeries — nearestStationDistanceM field validation (#825)', (
   });
 });
 
+describe('positionSeries — currentStationName field validation (#1363)', () => {
+  it('currentStationName 정상값(비어있지 않은 string) → series에 정상 적재', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const raw = JSON.stringify([
+      { lat: 37.5, lng: 127.0, accuracy: 5, ts: 1000, motion: 'walking', currentStationName: '강남' },
+    ]);
+    await kv.put('pos:tok', raw);
+    const series = await readSeries(kv, 'tok');
+    expect(series).toHaveLength(1);
+    expect(series[0].currentStationName).toBe('강남');
+  });
+
+  it('빈 문자열 → filter됨 (graceful 거부 — 의미 없는 라벨)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const raw = JSON.stringify([
+      { lat: 37.5, lng: 127.0, accuracy: 5, ts: 1000, motion: 'walking', currentStationName: '' },
+    ]);
+    await kv.put('pos:tok', raw);
+    const series = await readSeries(kv, 'tok');
+    expect(series).toHaveLength(0);
+  });
+
+  it('non-string 타입 → filter됨', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const raw = JSON.stringify([
+      { lat: 37.5, lng: 127.0, accuracy: 5, ts: 1000, motion: 'walking', currentStationName: 123 },
+    ]);
+    await kv.put('pos:tok', raw);
+    const series = await readSeries(kv, 'tok');
+    expect(series).toHaveLength(0);
+  });
+
+  it('필드 부재 → 정상 적재 (옵션)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const raw = JSON.stringify([
+      { lat: 37.5, lng: 127.0, accuracy: 5, ts: 1000, motion: 'walking' },
+    ]);
+    await kv.put('pos:tok', raw);
+    const series = await readSeries(kv, 'tok');
+    expect(series).toHaveLength(1);
+    expect(series[0].currentStationName).toBeUndefined();
+  });
+});
+
 describe('cosineDirection', () => {
   it('같은 방향 → 1', () => {
     // 동→서 두 vector 동일 방향

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -21,6 +21,7 @@ import {
   pickActiveWaypoint,
   pickApnsHost,
   pickBestArrivalSignal,
+  pickLatestCurrentStationName,
   resolveEtaMissingThreshold,
   runScheduled,
   type ScheduledDeps,
@@ -4397,5 +4398,39 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
     expect(stats.arvlCdFireSuccess).toBe(0);
     expect(stats.arvlCdFireMismatch).toBe(0); // 게이트 위 차단이라 fire 경로 미진입
     expect(getStationPassedCalls(apnsFetch)).toHaveLength(0);
+  });
+});
+
+
+describe('#1363 — pickLatestCurrentStationName (log 진단 이원화 helper)', () => {
+  const base = { lat: 37.5, lng: 127.0, accuracy: 10, ts: 1000, motion: 'walking' } as const;
+
+  it('빈 시리즈 → undefined', () => {
+    expect(pickLatestCurrentStationName([])).toBeUndefined();
+  });
+
+  it('어떤 sample도 currentStationName이 없으면 → undefined', () => {
+    const series: PositionPoint[] = [
+      { ...base, ts: 1000 },
+      { ...base, ts: 2000 },
+    ];
+    expect(pickLatestCurrentStationName(series)).toBeUndefined();
+  });
+
+  it('가장 최근 sample에 있으면 그대로 반환', () => {
+    const series: PositionPoint[] = [
+      { ...base, ts: 1000 },
+      { ...base, ts: 2000, currentStationName: '강남' },
+    ];
+    expect(pickLatestCurrentStationName(series)).toBe('강남');
+  });
+
+  it('최근 sample이 누락하면 직전 sample에서 backfill', () => {
+    const series: PositionPoint[] = [
+      { ...base, ts: 1000, currentStationName: '용마산' },
+      { ...base, ts: 2000 },
+      { ...base, ts: 3000 },
+    ];
+    expect(pickLatestCurrentStationName(series)).toBe('용마산');
   });
 });

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -782,6 +782,12 @@ export function validatePositionPayload(input: unknown): PositionUploadPayload |
     obj.nearestStationDistanceM >= 0
       ? obj.nearestStationDistanceM
       : undefined;
+  // #1363 — diag log 이원화. 클라가 산출한 사용자 현재역 이름. log 라벨링 전용(게이트 입력 X).
+  // 빈 문자열은 omit으로 강등 (graceful).
+  const currentStationName =
+    typeof obj.currentStationName === 'string' && obj.currentStationName.length > 0
+      ? obj.currentStationName
+      : undefined;
   return {
     token: obj.token,
     point: {
@@ -792,6 +798,7 @@ export function validatePositionPayload(input: unknown): PositionUploadPayload |
       motion,
       ...(hasPair ? { mapMatchedLine, mapMatchedArcM } : {}),
       ...(nearestStationDistanceM !== undefined ? { nearestStationDistanceM } : {}),
+      ...(currentStationName !== undefined ? { currentStationName } : {}),
     },
     accelSummary,
   };

--- a/backend/alarm-worker/src/positionSeries.ts
+++ b/backend/alarm-worker/src/positionSeries.ts
@@ -122,6 +122,11 @@ function isPositionPoint(value: unknown): value is PositionPoint {
     if (!Number.isFinite(o.nearestStationDistanceM)) return false;
     if (o.nearestStationDistanceM < 0) return false;
   }
+  // #1363 — currentStationName은 옵션. 값이 있다면 비어있지 않은 string 필수 (graceful).
+  if (o.currentStationName !== undefined) {
+    if (typeof o.currentStationName !== 'string') return false;
+    if (o.currentStationName.length === 0) return false;
+  }
   return true;
 }
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -383,6 +383,20 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
   return stats;
 }
 
+/**
+ * #1363 — 시리즈에서 가장 최근 `currentStationName`을 추출. log 진단(`waypoint` vs
+ * `currentStation`) 이원화 용도. 클라가 stamp한 사용자 현재 추정역 이름이고, 가장 최근 sample이
+ * 누락한 경우 직전 sample에서 backfill한다(클라가 fix마다 매번 stamp하지 않는 케이스 대응).
+ * 시리즈 전체에서 stamp가 한 번도 없으면 undefined → log 키 자체 omit (graceful).
+ */
+export function pickLatestCurrentStationName(series: readonly PositionPoint[]): string | undefined {
+  for (let i = series.length - 1; i >= 0; i--) {
+    const name = series[i].currentStationName;
+    if (typeof name === 'string' && name.length > 0) return name;
+  }
+  return undefined;
+}
+
 /** runFusionStep 반환값 — boarding-prompt / lockless-intermediate 분기에서 공통 사용. */
 interface FusionStepResult {
   /** 원본 positionSeries (호출자가 evaluateBoardingPromptGates 등에 그대로 전달). */
@@ -1420,11 +1434,15 @@ export async function runLocklessIntermediate(
   }
   // #825 — high-confidence non-APPROACHING phase면 차단 (false positive 1차).
   // 신호 부재/낮은 신뢰는 기존 동작 그대로 (회귀 없음, #834 wire 전까지 자연 skip).
+  // #1363 — log 진단 이원화. `waypoint`(trip 다음 정거장) ↔ `currentStation`(사용자 추정 현재역)
+  // 혼동 방지. 클라가 송신한 latest point의 currentStationName을 추출(있으면), log object에 동시 적재.
+  const currentStationName = pickLatestCurrentStationName(fusion.series);
   if (!phaseAllowsImminentFiring(fusion.phaseState)) {
     stats.phaseImminentBlocked += 1;
     log('lockless: phase gate blocked', {
       token: trip.token.slice(0, 8),
-      station: waypoint.stationName,
+      waypoint: waypoint.stationName,
+      ...(currentStationName !== undefined ? { currentStation: currentStationName } : {}),
       phase: fusion.phaseState?.current,
       confidence: fusion.phaseState?.confidence,
     });
@@ -1439,7 +1457,8 @@ export async function runLocklessIntermediate(
     stats.locklessMotionGateBlocked += 1;
     log('lockless: motion gate blocked (no trainCode, not moving)', {
       token: trip.token.slice(0, 8),
-      station: waypoint.stationName,
+      waypoint: waypoint.stationName,
+      ...(currentStationName !== undefined ? { currentStation: currentStationName } : {}),
       motion: fusion.posMetrics.motion,
       arvlCd: signal.arvlCd,
     });
@@ -1449,7 +1468,8 @@ export async function runLocklessIntermediate(
   const pushId = generatePushId();
   log('lockless: station-passed push', {
     token: trip.token.slice(0, 8),
-    station: waypoint.stationName,
+    waypoint: waypoint.stationName,
+    ...(currentStationName !== undefined ? { currentStation: currentStationName } : {}),
     arvlCd: signal.arvlCd,
     etaSeconds: signal.etaSeconds,
   });

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -386,6 +386,13 @@ export interface PositionPoint {
    * (mapMatchedLine/ArcM과 동일 패턴).
    */
   nearestStationDistanceM?: number;
+  /**
+   * #1363 — 클라이언트가 산출한 "사용자 현재 추정 역" 이름. backend log 진단(`scheduled.ts`)에서
+   * `waypoint`(trip 다음 정거장)과 명시적으로 구분하기 위한 필드. backend는 게이트 결정에
+   * 사용하지 않고 log 라벨링에만 활용한다 — RCA 시 사용자 실제 위치 ↔ trip 목표 정거장의 혼동을
+   * 차단한다. 미전달 시 log에서 `currentStation` 키가 omit (graceful, 회귀 없음).
+   */
+  currentStationName?: string;
 }
 
 /**

--- a/src/features/alarm/hooks/__tests__/useFgPositionUpload.test.ts
+++ b/src/features/alarm/hooks/__tests__/useFgPositionUpload.test.ts
@@ -125,4 +125,25 @@ describe('useFgPositionUpload (#1280)', () => {
     await flushAsyncStorage();
     expect(mockedUpload).not.toHaveBeenCalled();
   });
+
+  describe('#1363 — currentStationName payload (log 진단 이원화)', () => {
+    it('currentStationName 전달 → payload에 그대로 송신', async () => {
+      renderUpload({ currentStationName: '강남' });
+      await flushAsyncStorage();
+      expect(mockedUpload.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ currentStationName: '강남' }),
+      );
+    });
+
+    it.each([
+      { label: 'null', value: null },
+      { label: 'undefined', value: undefined },
+      { label: '빈 문자열', value: '' },
+    ])('currentStationName=$label → payload omit (트래픽 절감)', async ({ value }) => {
+      renderUpload({ currentStationName: value });
+      await flushAsyncStorage();
+      const payload = mockedUpload.mock.calls[0][0];
+      expect(payload.currentStationName).toBeUndefined();
+    });
+  });
 });

--- a/src/features/alarm/hooks/useFgPositionUpload.ts
+++ b/src/features/alarm/hooks/useFgPositionUpload.ts
@@ -45,6 +45,11 @@ export interface UseFgPositionUploadOptions {
   tripActive: boolean;
   /** 모션 stationary 확정 여부(graceful false). payload.motion 산출용. */
   motionStationary?: boolean;
+  /**
+   * #1363 — 클라가 추정한 사용자 현재역 이름. payload `currentStationName`으로 송신되어 backend
+   * 진단 log가 `waypoint`(trip 다음 정거장)와 분리해 출력한다. 비어있으면 omit (graceful).
+   */
+  currentStationName?: string | null;
 }
 
 /**
@@ -58,6 +63,7 @@ export function useFgPositionUpload({
   accuracyMeters,
   tripActive,
   motionStationary,
+  currentStationName,
 }: UseFgPositionUploadOptions): void {
   // 마지막 업로드 시각(epoch ms). throttle 판정용. null = 미발사(첫 fix 즉시 발사).
   const lastUploadedAtRef = useRef<number | null>(null);
@@ -86,8 +92,10 @@ export function useFgPositionUpload({
       accuracy: accuracyMeters,
       ts: now,
       motionStationary: motionStationary === true,
+      // #1363 — backend log 진단 이원화용. null/빈 문자열은 fireUpload에서 omit.
+      currentStationName: currentStationName ?? undefined,
     });
-  }, [tripActive, userLocation, accuracyMeters, motionStationary]);
+  }, [tripActive, userLocation, accuracyMeters, motionStationary, currentStationName]);
 }
 
 interface FireUploadInput {
@@ -96,6 +104,8 @@ interface FireUploadInput {
   accuracy: number;
   ts: number;
   motionStationary: boolean;
+  /** #1363 — backend 진단 log 라벨링 전용. 비어있으면 payload에서 omit. */
+  currentStationName?: string;
 }
 
 /**
@@ -110,6 +120,7 @@ async function fireUpload(input: FireUploadInput): Promise<void> {
     return;
   }
   const motion: PositionMotion = input.motionStationary ? 'stationary' : 'unknown';
+  const stationName = input.currentStationName;
   void uploadPosition({
     token,
     lat: input.lat,
@@ -117,5 +128,9 @@ async function fireUpload(input: FireUploadInput): Promise<void> {
     accuracy: input.accuracy,
     ts: input.ts,
     motion,
+    // #1363 — 비어있으면 omit. 빈 문자열을 보내면 backend가 graceful drop하지만 트래픽 절감.
+    ...(typeof stationName === 'string' && stationName.length > 0
+      ? { currentStationName: stationName }
+      : {}),
   });
 }

--- a/src/features/nearest-station/api/positionUpload.ts
+++ b/src/features/nearest-station/api/positionUpload.ts
@@ -86,6 +86,14 @@ export interface PositionUploadPayload {
    * 음수/NaN/Infinity는 backend가 series 단계에서 거부.
    */
   nearestStationDistanceM?: number;
+  /**
+   * #1363 — 클라가 산출한 "사용자 현재 추정 역" 이름. backend 진단 log(`scheduled.ts`)가
+   * `waypoint`(trip 다음 정거장)와 명시적으로 구분해 출력하기 위한 라벨링 전용 필드.
+   * 게이트/푸시 결정에는 사용되지 않는다 — 야간 RCA에서 backend 로그가 `station=중곡`이
+   * 사용자 실제 위치인지 trip 목표 정거장인지 모호하던 회귀를 해소.
+   * undefined/빈 문자열은 backend가 graceful drop (회귀 없음).
+   */
+  currentStationName?: string;
 }
 
 export interface PositionUploadResult {

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.movementGuard.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.movementGuard.test.ts
@@ -90,12 +90,20 @@ describe('useFusedNearestStation — #727 fusion downgrade', () => {
     });
   });
 
+  // #1363 — consensus 게이트(≥2 정적 신호). speed 단독으로는 더 이상 강등하지 않는다.
+  // useFusedNearestStation positional 인자(6): motionStationary. 6번째 인자로 합의 신호 추가.
   // 강등 동작은 confidence/source 한 쌍 결과만 본다. result 검증(gangnam으로 복원)은 첫 케이스만.
   it.each([
-    ['speed=0 + accuracy 정상 → 강등', 0, 50, null, 'gps-only', 'gps'],
-    ['speed=0.1 + accuracy 정상 + boarding-lock → 강등', 0.1, 30, 'T-1', 'gps-only', 'gps'],
-    ['speed=2 이동 중 → 유지', 2, 50, null, 'position-train', 'position-train'],
-    ['speed=0 + accuracy>100m 지하 noise → 유지', 0, 1500, null, 'position-train', 'position-train'],
+    // speed=0 + motion=true → 2 신호 합의 → 강등
+    ['speed=0 + motion=true 합의 → 강등', 0, 50, null, true, 'gps-only', 'gps'],
+    // speed=0.1 + motion=true + boarding-lock → 2 신호 합의 → 강등
+    ['speed=0.1 + motion=true + boarding-lock → 강등', 0.1, 30, 'T-1', true, 'gps-only', 'gps'],
+    // speed=2 이동 중 → 유지(정적 신호 0)
+    ['speed=2 이동 중 → 유지', 2, 50, null, false, 'position-train', 'position-train'],
+    // speed=0 단독(motion=undefined) → 1 신호 → 유지 (#1363 회귀 차단)
+    ['speed=0 단독(motion 미보고) → 유지 (consensus 미달)', 0, 50, null, undefined, 'position-train', 'position-train'],
+    // speed=0 + accuracy>100m 지하 noise → 유지(accuracy 가드)
+    ['speed=0 + motion=true + accuracy>100m → 유지', 0, 1500, null, true, 'position-train', 'position-train'],
   ])(
     '%s',
     (
@@ -103,13 +111,21 @@ describe('useFusedNearestStation — #727 fusion downgrade', () => {
       speed: number,
       accuracy: number,
       lockedTrainCode: string | null,
+      motionStationary: boolean | undefined,
       expectedConfidence: string,
       expectedSource: string,
     ) => {
       mockUseNearest.mockReturnValue(gpsBase(speed, accuracy));
 
       const { result } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, undefined, lockedTrainCode),
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          lockedTrainCode,
+          null,
+          motionStationary,
+        ),
       );
 
       expect(result.current.confidence).toBe(expectedConfidence);
@@ -120,21 +136,21 @@ describe('useFusedNearestStation — #727 fusion downgrade', () => {
   it('강등 시 result도 GPS 원본(강남)으로 복원', () => {
     mockUseNearest.mockReturnValue(gpsBase(0, 50));
 
-    const { result } = renderHook(() => useFusedNearestStation());
+    const { result } = renderHook(() =>
+      useFusedNearestStation(undefined, undefined, undefined, null, null, true),
+    );
 
     expect(result.current.result?.station.name).toBe(MOCK_STATIONS.gangnam.name);
   });
 
-  // #728 — motionStationary 신호로 speed=null 경로의 강등.
-  // useFusedNearestStation 6번째 positional 인자: motionStationary.
-  describe('#728 motionStationary downgrade', () => {
-    it('speed=null + motionStationary=true → 강등 (positionStability 없이)', () => {
+  // #728/#1363 — motionStationary + 추가 정적 신호 합의로 speed=null 경로의 강등.
+  describe('#728/#1363 motionStationary consensus downgrade', () => {
+    it('speed=null + motionStationary=true 단독은 강등 안 함 (#1363 consensus)', () => {
       mockUseNearest.mockReturnValue(gpsBase(null, 50));
       const { result } = renderHook(() =>
         useFusedNearestStation(undefined, undefined, undefined, null, null, true),
       );
-      expect(result.current.confidence).toBe('gps-only');
-      expect(result.current.source).toBe('gps');
+      expect(result.current.confidence).toBe('position-train');
     });
 
     it('speed=null + motionStationary=false → 유지', () => {

--- a/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
@@ -1031,6 +1031,23 @@ describe('useNearestStation — #876 sticky station integration', () => {
     expect(result.current.result?.distanceKm).toBeGreaterThan(5);
   });
 
+  // #876 — sticky.locked와 result.station이 같은 역이면 source='sticky'지만 result는 live 객체 그대로 반환.
+  it('sticky lock과 GPS 결과가 같은 역이면 source=sticky + result는 live 그대로', async () => {
+    // 강남 lock 미리 저장. GPS도 강남 좌표 → exposed memo의 same-station 분기 진입.
+    const gangnam = { id: '2-022', name: '강남', line: '2', lineColor: '#009D3E',
+      lat: 37.49799, lng: 127.027912 };
+    await AsyncStorage.setItem(
+      'subway-now:sticky-station',
+      JSON.stringify({ station: gangnam, lockedAt: Date.now() - 60_000 }),
+    );
+    mockGranted();
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+    simulateGps(37.4980, 127.0277, { accuracy: 20 });
+    await waitFor(() => expect(result.current.result?.station.name).toBe('강남'));
+    expect(result.current.source).toBe('sticky');
+  });
+
   // #1317 — 지도탭 "현재위치" 명시 탭은 sticky를 비우고 live 위치를 노출.
   it('requestCurrentLocation 호출 시 sticky를 비우고 live 위치로 복귀한다', async () => {
     // 효창공원앞 lock 미리 저장. GPS는 강남 → 초기엔 sticky override.
@@ -1362,5 +1379,66 @@ describe('useNearestStation — #1313 subsurface GPS throttle', () => {
     (AppState as { currentState: string }).currentState = 'active';
     await act(async () => { appStateCallback?.('active'); });
     await waitFor(() => expect(lastWatchOptions()).toEqual(SUBSURFACE_OPTIONS));
+  });
+});
+
+describe('useNearestStation — #1363 sticky input memo 안정성 (cascade 차단)', () => {
+  // useStickyStation에 전달되는 fix/motion object가 inline literal이면 매 render 새 ref가 되어
+  // sticky 평가 effect가 매 render 재실행 → 9시간 trip ~16만회 emit. useMemo로 안정화되면
+  // 입력 값이 동일한 한 같은 reference를 유지해야 한다.
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await AsyncStorage.clear();
+    appStateCallback = null;
+    watchCallback = null;
+    mockNoLastKnownLocation();
+    mockSubscription.remove.mockClear();
+    (Location.watchPositionAsync as jest.Mock).mockImplementation(
+      async (_options: unknown, callback: typeof watchCallback) => {
+        watchCallback = callback;
+        return mockSubscription;
+      },
+    );
+    mockGranted();
+  });
+
+  it('inputs 값이 그대로(같은 값)면 sticky 입력 fix/motion reference가 유지된다', async () => {
+    const spy = jest.spyOn(useStickyStationModule, 'useStickyStation');
+    const { rerender } = renderHook(
+      ({ sub, trip }: { sub: boolean; trip: boolean }) =>
+        useNearestStation({ barometerSubsurface: sub, tripActive: trip }),
+      { initialProps: { sub: false, trip: false } },
+    );
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+
+    const initialCallCount = spy.mock.calls.length;
+    const initialFixRef = spy.mock.calls[initialCallCount - 1][0];
+    const initialMotionRef = spy.mock.calls[initialCallCount - 1][1];
+
+    // 같은 inputs로 N번 rerender — memo 키가 안 바뀌므로 같은 ref여야 한다.
+    for (let i = 0; i < 5; i += 1) {
+      rerender({ sub: false, trip: false });
+    }
+    const lastCall = spy.mock.calls[spy.mock.calls.length - 1];
+    expect(lastCall[0]).toBe(initialFixRef);
+    expect(lastCall[1]).toBe(initialMotionRef);
+    spy.mockRestore();
+  });
+
+  it('inputs 값이 바뀌면 motion ref가 새로 생성된다 (정상 갱신)', async () => {
+    const spy = jest.spyOn(useStickyStationModule, 'useStickyStation');
+    const { rerender } = renderHook(
+      ({ sub }: { sub: boolean }) => useNearestStation({ barometerSubsurface: sub }),
+      { initialProps: { sub: false } },
+    );
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    const initialMotionRef = spy.mock.calls[spy.mock.calls.length - 1][1];
+
+    // subsurface=true로 변경 → memo deps 변경 → 새 ref.
+    rerender({ sub: true });
+    const nextMotionRef = spy.mock.calls[spy.mock.calls.length - 1][1];
+    expect(nextMotionRef).not.toBe(initialMotionRef);
+    expect(nextMotionRef).toEqual({ automotive: true, subsurface: true, tripActive: false });
+    spy.mockRestore();
   });
 });

--- a/src/features/nearest-station/hooks/useNearestStation.ts
+++ b/src/features/nearest-station/hooks/useNearestStation.ts
@@ -446,20 +446,26 @@ export function useNearestStation(
   // 지하 진입은 차/지하철 이동 확정과 동등한 unlock 트리거(사용자가 이미 지상 sticky를 떠나 이동 중).
   // CMMotionActivity native bridge가 자동차 신호를 노출하지 않아 sticky가 motion unlock 미작동
   // 상태였던 회귀 해소.
-  const sticky = useStickyStation(
-    {
-      candidate: result,
-      accuracyMeters,
-      speedMps,
-    },
-    {
+  // #1363 — sticky cascade emit 16만회 회귀 차단.
+  // useStickyStation 호출에 inline object literal을 그대로 넘기면 매 render마다 새 reference가
+  // 생성돼 effect deps([fix, motion, ...])가 매번 변경된 것으로 평가된다. 9시간 trip에서 약
+  // ~16만회 effect 재실행 → emit/AsyncStorage write/log churn. candidate identity(station.id)와
+  // 측정 가능한 숫자 신호로만 memo 키를 잡아 effect를 안정화한다.
+  const stickyFix = useMemo(
+    () => ({ candidate: result, accuracyMeters, speedMps }),
+    [result, accuracyMeters, speedMps],
+  );
+  const stickyMotion = useMemo(
+    () => ({
       automotive: inputs.barometerSubsurface === true,
       // D6 (#1212) — subsurface + tripActive를 sticky 게이트에 직접 전달.
       // automotive=subsurface 매핑은 유지하되, 지하 + trip 활성 조합에서는 unlock 보류.
       subsurface: inputs.barometerSubsurface === true,
       tripActive: inputs.tripActive === true,
-    },
+    }),
+    [inputs.barometerSubsurface, inputs.tripActive],
   );
+  const sticky = useStickyStation(stickyFix, stickyMotion);
 
   // #1317 — 지도탭 "현재위치" 명시 탭 경로. sticky lock을 즉시 비운 뒤 fresh GPS fix를 요청해
   // live fused 위치를 노출한다. refresh()만으로는 sticky override가 남아 현재역이 lock된 역

--- a/src/features/nearest-station/utils/__tests__/movementGate.test.ts
+++ b/src/features/nearest-station/utils/__tests__/movementGate.test.ts
@@ -198,39 +198,69 @@ describe('movementGate', () => {
   });
 
   describe('shouldDowngradeFusion', () => {
-    it('승격 라벨 + 정적 신호면 true', () => {
+    it('#1363 — 승격 라벨 + ≥2 정적 신호 합의면 true (consensus 게이트)', () => {
+      // speed + motionStationary 합의
       expect(
-        shouldDowngradeFusion({ confidence: 'position-train', speedMps: 0, accuracyM: 50 }),
+        shouldDowngradeFusion({
+          confidence: 'position-train',
+          speedMps: 0,
+          accuracyM: 50,
+          motionStationary: true,
+        }),
       ).toBe(true);
+      // speed + positionStability 합의
       expect(
-        shouldDowngradeFusion({ confidence: 'boarding-lock', speedMps: 0.1, accuracyM: 30 }),
+        shouldDowngradeFusion({
+          confidence: 'boarding-lock',
+          speedMps: 0.1,
+          accuracyM: 30,
+          positionStability: 'static',
+        }),
       ).toBe(true);
+      // motionStationary + positionStability 합의 (speed 미측정)
       expect(
         shouldDowngradeFusion({
           confidence: 'boarding-lock-interp',
-          speedMps: 0,
+          speedMps: null,
           accuracyM: 30,
+          motionStationary: true,
+          positionStability: 'static',
         }),
       ).toBe(true);
     });
 
-    it('#733 — arrival-arriving + 정적 신호면 true (snapshot 2 회귀 fix)', () => {
+    it('#1363 — single signal alone은 강등 안 함 (fu jumping 회귀 차단)', () => {
+      // speed 단독 — motion/positionStability 미보고(warmup) → 보류
+      expect(
+        shouldDowngradeFusion({ confidence: 'position-train', speedMps: 0, accuracyM: 50 }),
+      ).toBe(false);
+      // motionStationary 단독 — speed null + positionStability 미보고
       expect(
         shouldDowngradeFusion({
-          confidence: 'arrival-arriving',
-          speedMps: 0,
+          confidence: 'position-train',
+          speedMps: null,
           accuracyM: 50,
+          motionStationary: true,
         }),
-      ).toBe(true);
-    });
-
-    it('#733 — arrival-arriving + speed=null + positionStability=static이면 true', () => {
+      ).toBe(false);
+      // positionStability 단독 — speed null + motion 미보고
       expect(
         shouldDowngradeFusion({
           confidence: 'arrival-arriving',
           speedMps: null,
           accuracyM: 50,
           positionStability: 'static',
+        }),
+      ).toBe(false);
+    });
+
+    it('#733 — arrival-arriving + 합의 정적 신호면 true (snapshot 2 회귀 fix)', () => {
+      expect(
+        shouldDowngradeFusion({
+          confidence: 'arrival-arriving',
+          speedMps: 0,
+          accuracyM: 50,
+          motionStationary: true,
         }),
       ).toBe(true);
     });
@@ -239,38 +269,55 @@ describe('movementGate', () => {
       expect(
         shouldDowngradeFusion({ confidence: 'position-train', speedMps: 5, accuracyM: 50 }),
       ).toBe(false);
-      // accuracy noise → 정적 신호 인정 안 함
+      // accuracy noise → 정적 신호 인정 안 함 (합의 신호여도 차단)
       expect(
-        shouldDowngradeFusion({ confidence: 'position-train', speedMps: 0, accuracyM: 1500 }),
+        shouldDowngradeFusion({
+          confidence: 'position-train',
+          speedMps: 0,
+          accuracyM: 1500,
+          motionStationary: true,
+          positionStability: 'static',
+        }),
       ).toBe(false);
     });
 
     it('정적 신호여도 승격 라벨 아니면 false', () => {
       expect(
-        shouldDowngradeFusion({ confidence: 'gps-only', speedMps: 0, accuracyM: 50 }),
+        shouldDowngradeFusion({
+          confidence: 'gps-only',
+          speedMps: 0,
+          accuracyM: 50,
+          motionStationary: true,
+        }),
       ).toBe(false);
-      expect(
-        shouldDowngradeFusion({ confidence: 'arrival-confirmed', speedMps: 0, accuracyM: 50 }),
-      ).toBe(false);
-    });
-
-    it('#733 — 승격 라벨 + speed=null + positionStability 없으면 false (보수)', () => {
       expect(
         shouldDowngradeFusion({
-          confidence: 'position-train',
-          speedMps: null,
+          confidence: 'arrival-confirmed',
+          speedMps: 0,
           accuracyM: 50,
+          motionStationary: true,
         }),
       ).toBe(false);
     });
 
-    it('#733 — 승격 라벨 + speed=null + positionStability=moving이면 false', () => {
+    it('#1363 — positionStability=moving이면 정적 후보가 1개여도 false', () => {
       expect(
         shouldDowngradeFusion({
           confidence: 'position-train',
-          speedMps: null,
+          speedMps: 0,
           accuracyM: 50,
           positionStability: 'moving',
+        }),
+      ).toBe(false);
+    });
+
+    it('#1363 — motionStationary=false + speed 정적 단독은 false (consensus 미달)', () => {
+      expect(
+        shouldDowngradeFusion({
+          confidence: 'position-train',
+          speedMps: 0,
+          accuracyM: 50,
+          motionStationary: false,
         }),
       ).toBe(false);
     });
@@ -477,25 +524,27 @@ describe('movementGate', () => {
     });
   });
 
-  describe('#728 — shouldDowngradeFusion motionStationary', () => {
-    it('승격 라벨 + motionStationary=true (speed=null) → true', () => {
+  describe('#728/#1363 — shouldDowngradeFusion motionStationary + consensus', () => {
+    it('승격 라벨 + motionStationary=true + positionStability=static (speed=null) → true', () => {
       expect(
         shouldDowngradeFusion({
           confidence: 'position-train',
           speedMps: null,
           accuracyM: 50,
           motionStationary: true,
+          positionStability: 'static',
         }),
       ).toBe(true);
     });
 
-    it('승격 라벨 아니면 motionStationary=true여도 false', () => {
+    it('승격 라벨 아니면 합의 정적 신호여도 false', () => {
       expect(
         shouldDowngradeFusion({
           confidence: 'gps-only',
           speedMps: null,
           accuracyM: 50,
           motionStationary: true,
+          positionStability: 'static',
         }),
       ).toBe(false);
     });

--- a/src/features/nearest-station/utils/movementGate.ts
+++ b/src/features/nearest-station/utils/movementGate.ts
@@ -191,13 +191,33 @@ export function shouldDowngradeFusion(input: {
   motionStationary?: boolean;
 }): boolean {
   if (!isFusionDowngradeTarget(input.confidence)) return false;
-  return isStaticSpeedSignal(
-    input.speedMps,
-    input.accuracyM,
-    input.positionStability,
-    input.motionStationary,
-  );
+  // accuracy 가드: GPS lock이 끊긴 노이즈는 정적 신호로 보지 않는다(기존 정책 유지).
+  if (input.accuracyM != null && input.accuracyM > MAX_ACCURACY_M) return false;
+
+  // #1363 — single-signal downgrade 회귀(fu jumping) 차단. consensus 게이트(≥2 신호).
+  // 회귀 패턴: iOS에서 motion=null/unknown이 자주 발생 → 단일 신호(speed alone)로 fusion-elevated
+  // confidence(position-train / boarding-lock / arrival-arriving)가 gps-only로 강등됐다가 다음
+  // tick에 재승격 → 사용자 화면에서 현재역(fu)이 튄다.
+  //
+  // 합의 후보(독립 신호):
+  //   1. speedMps < STATIC_SPEED_THRESHOLD_MPS — GPS 속도 정적
+  //   2. motionStationary === true            — CMMotionActivity 정적
+  //   3. positionStability === 'static'       — 좌표 이력 60s 정적
+  // motionStationary === undefined / positionStability === undefined는 warmup으로 간주해 합의에
+  // 포함하지 않는다(neutral). 강등은 ≥2 합의 시에만 허용. positionStability === 'moving'이거나
+  // motionStationary === false는 명시 비-정적 신호로 합의 카운트를 차감하지 않지만, 어떤 정적
+  // 후보도 active하지 않으면 자연스럽게 강등 보류된다.
+  let staticSignalCount = 0;
+  if (typeof input.speedMps === 'number' && input.speedMps < STATIC_SPEED_THRESHOLD_MPS) {
+    staticSignalCount += 1;
+  }
+  if (input.motionStationary === true) staticSignalCount += 1;
+  if (input.positionStability === 'static') staticSignalCount += 1;
+  return staticSignalCount >= FUSION_DOWNGRADE_CONSENSUS_MIN;
 }
+
+/** #1363 — fusion downgrade 합의 최소 신호 수(2). 단일 신호 강등 회귀 차단. */
+export const FUSION_DOWNGRADE_CONSENSUS_MIN = 2;
 
 export interface LocationSignalInput {
   /** epoch ms — 없으면 stale-timestamp 검증 skip. */

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -441,6 +441,8 @@ export default function HomeScreen() {
     accuracyMeters: accuracyMeters ?? null,
     tripActive: Boolean(destination && route),
     motionStationary,
+    // #1363 — 사용자 추정 현재역 이름. backend 진단 log에서 trip waypoint와 명시 구분.
+    currentStationName: result?.station.name ?? null,
   });
   useBoardingLockScheduler({
     lock: boardingLock,


### PR DESCRIPTION
Closes #1363
Refs #1362

## Summary

2026-06-16 21:00 RCA(#1363) 3-layer 회귀를 한 PR에 묶어 수정.

### Layer 1 — Frontend sticky cascade emit 16만회 (P0)
- **회귀**: `useNearestStation:449`에서 `useStickyStation`에 inline object literal(`{ candidate, accuracyMeters, speedMps }`, `{ automotive, subsurface, tripActive }`)을 매 render 새 reference로 전달 → `useStickyStation` 평가 effect deps가 매 render 변경 → 9시간 trip에서 약 16만회 emit + AsyncStorage write + log churn (배터리/발열).
- **수정**: 두 입력 object를 `useMemo`로 안정화. 입력 값이 같으면 같은 reference 유지 → effect는 실제 값 변경 시만 재실행.

### Layer 2 — Frontend fusion `fu` jumping (single-signal downgrade)
- **회귀**: `shouldDowngradeFusion`이 단일 정적 신호(speed alone 또는 motion alone)로 fusion-elevated confidence(`position-train` / `boarding-lock` / `boarding-lock-interp` / `arrival-arriving`)를 `gps-only`로 강등. iOS에서 motion=null/unknown이 잦아 매 tick 강등→재승격 cascade → 화면 현재역(`fu`)이 용마산↔사가정↔중곡↔독섭으로 튐.
- **수정**: consensus 게이트(`FUSION_DOWNGRADE_CONSENSUS_MIN=2`). speed/motionStationary/positionStability 3 독립 신호 중 ≥2 합의 시에만 강등. `undefined`(warmup) 신호는 합의에 포함하지 않음.

### Layer 3 — Backend `/position` diag log 이원화
- **회귀**: `scheduled.ts` lockless 분기 log가 `station: waypoint.stationName`으로 적재 → RCA 시 backend log `station=중곡`이 user 실제 위치인지 trip 다음 waypoint인지 모호.
- **수정**:
  - `PositionUploadPayload`에 `currentStationName?: string` 추가
  - `useFgPositionUpload`가 `result?.station.name`을 송신
  - backend `validatePositionPayload` + `positionSeries` guard graceful 처리
  - `scheduled.ts` lockless 3개 log 분기에서 키를 `waypoint` + `currentStation`으로 명시 분리

## Test plan
- [x] `npm run type-check` pass
- [x] `npm test` — 5637 tests pass, 100% coverage (lines/branches/funcs/statements)
- [x] `npx vitest run` (backend alarm-worker) — 1321 tests pass
- [x] `npm run lint` — 0 warnings
- [ ] (사용자) 다음 trip 실기기 검증
  - fusion log에 sticky entry 비율 < 10% (#1363 acceptance)
  - backend log에서 `currentStation` ≠ `waypoint` 케이스 식별 가능
  - 1주 production: `emitMetric('locked')` 호출 빈도 99% 감소