### PR TITLE
fix(#1379): setDestination DESTINATION_KEY race + effectiveOrigin GPS cascade

### DIFF
--- a/src/features/route/store/__tests__/setDestinationStorageRace.test.ts
+++ b/src/features/route/store/__tests__/setDestinationStorageRace.test.ts
@@ -1,0 +1,148 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature: #1379 regression guard — setDestination의 storage race 재발 방지.
+ * DESTINATION_KEY가 cleanup chain의 removeItem에 의해 지워지는 회귀를 검증.
+ *
+ * 설계 원칙:
+ *   - AsyncStorage는 memory-backed mock 사용 → 실제 stored value 검증 가능.
+ *   - runTripBoundCleanups를 wrapping mock으로 교체. 내부에서 DESTINATION_KEY / TRIP_ORIGIN_KEY의
+ *     removeItem만 실행해 race를 재현한다. 나머지 OS/notification side effect는 차단.
+ *   - 개별 helper mock 대신 tripBoundCleanups 단위로 mock해야 useDestinationStore.test.ts의
+ *     removeItem spy count를 오염시키지 않는다.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useDestinationStore } from '../useDestinationStore';
+import {
+  DESTINATION_KEY,
+  TRIP_ORIGIN_KEY,
+} from '../../../../shared/constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+// tripBoundCleanups 전체를 wrapping mock.
+// runTripBoundCleanups의 실제 구현은 beforeEach에서 mockImplementation으로 복구한다.
+jest.mock('../../../alarm/store/tripBoundCleanups', () => ({
+  runTripBoundCleanups: jest.fn(),
+  cancelTripBoundOsQueue: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../../alarm/utils/tripStartStorage', () => ({
+  setTripStartedAt: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../../alarm/utils/triggerTripEndRecall', () => ({
+  triggerTripEndRecall: jest.fn().mockResolvedValue({ uploaded: false }),
+}));
+jest.mock('../../../../shared/infra/monitoring/breadcrumb', () => ({
+  addLogBreadcrumb: jest.fn(),
+  addDomainBreadcrumb: jest.fn(),
+}));
+
+// #1379 핵심 시뮬레이션: runTripBoundCleanups가 DESTINATION_KEY를 제거하는 동작.
+// 이 구현을 beforeEach에서 매 테스트 전에 세팅해 jest.clearAllMocks 초기화를 복구한다.
+async function runTripBoundCleanupsMockImpl(): Promise<void> {
+  await AsyncStorage.removeItem(DESTINATION_KEY);
+  await AsyncStorage.removeItem(TRIP_ORIGIN_KEY);
+}
+
+const mockStation = {
+  id: '5-035',
+  name: '마장',
+  line: '5' as const,
+  lat: 37.5634,
+  lng: 127.0419,
+  lineColor: '#996CAC',
+};
+
+const mockStationB = {
+  id: '5-036',
+  name: '답십리',
+  line: '5' as const,
+  lat: 37.5655,
+  lng: 127.0523,
+  lineColor: '#996CAC',
+};
+
+async function flushMicrotasks(): Promise<void> {
+  // triggerTripEndRecall → runTripBoundCleanups → setItem chain을 충분히 drain한다.
+  // tripTransitionQueue chain은 최대 4단계(then×4) 깊이. 50회로 넉넉하게.
+  for (let i = 0; i < 50; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe('#1379 setDestination storage race 회귀 가드', () => {
+  beforeEach(async () => {
+    // 직전 테스트의 tripTransitionQueue 잔여 chain drain.
+    await flushMicrotasks();
+    await AsyncStorage.clear();
+    useDestinationStore.setState({
+      destination: null,
+      recentDestinations: [],
+      customOrigin: null,
+      tripOrigin: null,
+      routePreference: 'optimal',
+    });
+    jest.clearAllMocks();
+    // jest.clearAllMocks가 mock 구현도 초기화 — 각 mock의 Promise 반환 복구.
+    const { triggerTripEndRecall } = require('../../../alarm/utils/triggerTripEndRecall');
+    const { setTripStartedAt } = require('../../../alarm/utils/tripStartStorage');
+    const { runTripBoundCleanups } = require('../../../alarm/store/tripBoundCleanups');
+    (triggerTripEndRecall as jest.Mock).mockResolvedValue({ uploaded: false });
+    (setTripStartedAt as jest.Mock).mockResolvedValue(undefined);
+    // #1379 핵심: cleanup chain이 DESTINATION_KEY + TRIP_ORIGIN_KEY를 removeItem하는 동작 유지.
+    (runTripBoundCleanups as jest.Mock).mockImplementation(runTripBoundCleanupsMockImpl);
+  });
+
+  it('P0 (#1379): setDestination(station) 후 DESTINATION_KEY가 storage에 남아 있어야 한다', async () => {
+    const { setDestination } = useDestinationStore.getState();
+    setDestination(mockStation);
+
+    await flushMicrotasks();
+
+    const stored = await AsyncStorage.getItem(DESTINATION_KEY);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!).id).toBe('5-035');
+  });
+
+  it('switch: setDestination(A) → setDestination(B) 후 최종 DESTINATION_KEY == B', async () => {
+    const { setDestination } = useDestinationStore.getState();
+    setDestination(mockStation);
+    // cleanup chain이 in-flight인 상태에서 바로 switch.
+    setDestination(mockStationB);
+
+    await flushMicrotasks();
+
+    const stored = await AsyncStorage.getItem(DESTINATION_KEY);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!).id).toBe('5-036');
+  });
+
+  it('end: setDestination(A) → setDestination(null) 후 DESTINATION_KEY == null', async () => {
+    const { setDestination } = useDestinationStore.getState();
+    setDestination(mockStation);
+    await flushMicrotasks();
+
+    setDestination(null);
+    await flushMicrotasks();
+
+    const storedDest = await AsyncStorage.getItem(DESTINATION_KEY);
+    expect(storedDest).toBeNull();
+  });
+
+  it('end: setDestination(A) → setDestination(null) 후 TRIP_ORIGIN_KEY도 storage에서 제거된다 (#700)', async () => {
+    const { setDestination, setTripOrigin } = useDestinationStore.getState();
+    setDestination(mockStation);
+    await flushMicrotasks();
+    // trip 도중 origin 캡처.
+    setTripOrigin(mockStation);
+    const originBefore = await AsyncStorage.getItem(TRIP_ORIGIN_KEY);
+    expect(originBefore).not.toBeNull();
+
+    setDestination(null);
+    await flushMicrotasks();
+
+    const storedOrigin = await AsyncStorage.getItem(TRIP_ORIGIN_KEY);
+    expect(storedOrigin).toBeNull();
+  });
+});

--- a/src/features/route/store/__tests__/useDestinationStore.test.ts
+++ b/src/features/route/store/__tests__/useDestinationStore.test.ts
@@ -92,6 +92,20 @@ describe('useDestinationStore', () => {
     expect(destination).toBeNull();
   });
 
+  // #1379 — !isSwitch + !station: 이미 null인 destination에 null을 재설정하는 경우.
+  // isSwitch=false이므로 cleanup chain을 건드리지 않고 inline removeItem만 호출.
+  it('setDestination(null): 이미 null인 destination에 null을 재설정해도 removeItem 호출', () => {
+    // initial state: destination=null (already set in beforeEach)
+    const { setDestination } = useDestinationStore.getState();
+    setDestination(null);
+
+    // isSwitch=false (null→null), station=null → removeItem 경로
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:destination');
+    // isSwitch=false이므로 cleanup chain은 실행되지 않는다 (triggerTripEndRecall 미호출).
+    expect(triggerTripEndRecall).not.toHaveBeenCalled();
+    expect(useDestinationStore.getState().destination).toBeNull();
+  });
+
   // #1324 — 목적지 == customOrigin(store가 권위적으로 아는 출발역)이면 degenerate trip을
   // 만들지 않고 거부한다 (방향 null/빈 탑승목록 회귀 차단). breadcrumb로 관측 가능.
   it('setDestination(#1324): customOrigin과 같은 역을 목적지로 지정하면 거부하고 상태 불변', () => {
@@ -123,6 +137,9 @@ describe('useDestinationStore', () => {
   it('setDestination: 역 설정 시 AsyncStorage에 저장하고 null 시 삭제한다', async () => {
     const { setDestination } = useDestinationStore.getState();
     setDestination(mockStation);
+    // #1379 — isSwitch 경로(prev=null→station)에서는 setItem이 cleanup chain 이후로 직렬화되므로
+    // microtask flush 후 검증한다 (구 코드는 inline 동기였으나 race 차단을 위해 이동됨).
+    await flushMicrotasks();
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
       'subway-now:destination',
       JSON.stringify(mockStation),
@@ -183,8 +200,9 @@ describe('useDestinationStore', () => {
     // #919 — setDestination이 triggerTripEndRecall → runTripBoundCleanups → setTripStartedAt
     // 세 단계 then-chain을 돌리는데 cleanup 안에서 Promise.allSettled가 추가 microtask를 만든다.
     // #773 — purgeBoardingLockSchedulerQueue가 getScheduledNotificationIds + clearScheduledNotificationIds
-    // (각각 AsyncStorage await 2회 포함)를 추가하므로 microtask depth가 더 깊다. 넉넉하게 flush.
-    for (let i = 0; i < 30; i++) {
+    // (각각 AsyncStorage await 2회 포함)를 추가하므로 microtask depth가 더 깊다.
+    // #1379 — isSwitch 경로에 setItem(DESTINATION_KEY) 단계가 추가되었으므로 50회로 증가.
+    for (let i = 0; i < 50; i++) {
       await Promise.resolve();
     }
   }

--- a/src/features/route/store/useDestinationStore.ts
+++ b/src/features/route/store/useDestinationStore.ts
@@ -122,13 +122,24 @@ export const useDestinationStore = create<DestinationState>((set, get) => ({
       caller,
     });
     set({ destination: station });
-    if (station) {
-      AsyncStorage.setItem(DESTINATION_KEY, JSON.stringify(station)).catch(noop);
-    } else {
-      // #700 — trip 종료 시 tripOrigin도 atomic하게 클리어. destination만 남기면
-      // 다음 trip 시작 시 stale origin이 잠깐 노출돼 route 계산이 흔들린다.
+    // #700 — trip 종료 시 tripOrigin도 atomic하게 클리어. destination만 남기면
+    // 다음 trip 시작 시 stale origin이 잠깐 노출돼 route 계산이 흔들린다.
+    if (!station) {
       set({ tripOrigin: null });
-      AsyncStorage.removeItem(DESTINATION_KEY).catch(noop);
+    }
+    // #1379 — DESTINATION_KEY storage race 차단.
+    // isSwitch 경로에서는 아래 tripTransitionQueue가 runTripBoundCleanups를 호출하며
+    // DESTINATION_KEY를 removeItem한다. 여기서 inline setItem을 fire-and-forget하면
+    // cleanup의 removeItem이 뒤에 도착해 storage 최종 상태가 null이 되는 회귀 발생
+    // (실기기 2026-06-16 trip 도중 일괄 손실 사고). isSwitch 경로는 storage write를
+    // cleanup chain 이후로 이동시켜 직렬화한다. 같은 destination 재지정(!isSwitch)은
+    // cleanup chain이 안 돌므로 inline write 그대로.
+    if (!isSwitch) {
+      if (station) {
+        AsyncStorage.setItem(DESTINATION_KEY, JSON.stringify(station)).catch(noop);
+      } else {
+        AsyncStorage.removeItem(DESTINATION_KEY).catch(noop);
+      }
     }
     // destination switch(목적지 자체가 바뀌었을 때) — 부수 상태/storage 자동 클리어.
     // 같은 destination 재설정 시에는 진행 중인 trip/lock/스케줄을 유지한다.
@@ -159,6 +170,14 @@ export const useDestinationStore = create<DestinationState>((set, get) => ({
         .then(() => triggerTripEndRecall())
         .catch(noop)
         .then(() => runTripBoundCleanups())
+        .catch(noop)
+        // #1379 — cleanup이 DESTINATION_KEY를 removeItem한 뒤 새 trip의 destination을 write.
+        // 분기 순서를 직렬화해 storage 최종 상태가 station(new trip) 또는 null(end)으로 결정적.
+        .then(() =>
+          station
+            ? AsyncStorage.setItem(DESTINATION_KEY, JSON.stringify(station))
+            : undefined,
+        )
         .catch(noop)
         .then(() => (station ? setTripStartedAt() : undefined))
         .catch(noop);

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -14,7 +14,7 @@ import { useDestinationStore } from '../features/route/store/useDestinationStore
 import { useAlarmEventStore } from '../features/alarm/store/useAlarmEventStore';
 import { useBoardingLockStore } from '../features/alarm/store/useBoardingLockStore';
 import { DestinationPicker } from '../features/route/components/DestinationPicker';
-import { findRouteCandidatesByCategory, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, routeSignature, type Route, type CategorizedRoute, type RoutePreference } from '../shared/utils/stationRoute';
+import { findRouteCandidatesByCategory, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, getStationById, routeSignature, type Route, type CategorizedRoute, type RoutePreference } from '../shared/utils/stationRoute';
 import { pickArrivalAtOrigin } from '../features/arrival/utils/pickArrivalAtOrigin';
 import { EditorialTimeline } from '../features/arrival/components/EditorialTimeline';
 import { arrivalInfoToArrivalTrain, journeyDisplayToStops, nearestResultToNearest } from '../features/route/utils/journeyAdapter';
@@ -253,7 +253,23 @@ export default function HomeScreen() {
   const refreshRef = useRef(refresh);
   refreshRef.current = refresh;
   const isCustomOrigin = customOrigin !== null;
-  const effectiveOrigin = customOrigin ?? result?.station ?? null;
+  // #1379: effectiveOrigin은 trip 생명선이다. GPS pause(BG 진입/지하 dead zone)로 result?.station이
+  // 일시 null이 되면 아래 storage/effect들이 trip을 종료한 것으로 오인해 ROUTE_KEY removeItem →
+  // useApnsTripRegistration이 backend ACTIVE_TRIP cleanup을 발사하는 cascade가 일어난다.
+  // stale-while-revalidate 마지막 fused station + 활성 boardingLock의 boardingStation +
+  // tripOrigin까지 4단 fallback해 trip 종료 신호와 GPS 일시 누락을 구분한다.
+  const lastFusedStationRef = useRef<Station | null>(null);
+  if (result?.station) lastFusedStationRef.current = result.station;
+  const boardingLockStation = fusionBoardingLock
+    ? getStationById(fusionBoardingLock.boardingStationId) ?? null
+    : null;
+  const effectiveOrigin =
+    customOrigin ??
+    result?.station ??
+    lastFusedStationRef.current ??
+    boardingLockStation ??
+    tripOrigin ??
+    null;
   useTripOrigin(destination, effectiveOrigin, setTripOrigin, tripOrigin);
   const handleSameOriginToastDismiss = useCallback(() => setSameOriginToast(null), []);
   // #1324 — 목적지 선택 단일 진입점. 현재역(effectiveOrigin)과 같은 역이면 degenerate trip을
@@ -302,9 +318,14 @@ export default function HomeScreen() {
   const variantIds = originVariants.map((v) => v.id).join(',');
 
   useEffect(() => {
-    if (!effectiveOrigin || !destination) {
+    // #1379: destination 종료(=실제 trip 종료)일 때만 ROUTE_KEY removeItem.
+    // effectiveOrigin null은 GPS 일시 누락일 수 있으므로 storage는 보존하고 계산만 skip한다.
+    if (!destination) {
       setCategorized([]);
       AsyncStorage.removeItem(ROUTE_KEY).catch(() => {});
+      return;
+    }
+    if (!effectiveOrigin) {
       return;
     }
     const interactionStart = performance.now();


### PR DESCRIPTION
Closes #1379

## RCA 요약

### Bug 1 (P0) — `setDestination` DESTINATION_KEY race
- `useDestinationStore.ts` isSwitch 분기에서 inline `AsyncStorage.setItem(DESTINATION_KEY, ...)`를 fire-and-forget으로 띄운 직후, 같은 transition의 `runTripBoundCleanups()`가 `removeItem(DESTINATION_KEY)`를 발사 → 최종 storage 상태 null
- zustand 메모리는 정상 → 활성 trip은 동작하지만 cold-launch 복구 / DebugModal / backend↔device sync에서 false-negative

### Bug 2 (P0) — `effectiveOrigin` GPS pause cascade
- `effectiveOrigin = customOrigin ?? result?.station ?? null`이 GPS pause 시 null → useEffect가 `removeItem(ROUTE_KEY)` → useApnsTripRegistration이 backend `DELETE /trips/{token}` + `removeItem(ACTIVE_TRIP_KEY)`로 trip 실질 사망
- 회귀 evidence: 2026-06-16 16:26~16:35 KST 환승 trip(`tasks/scheduled-tail-20260616-160751.jsonl`)

## 변경

### useDestinationStore.ts
- isSwitch 경로에서 inline setItem/removeItem 제거
- `tripTransitionQueue` chain에 `cleanup → setItem(DESTINATION_KEY) → setTripStartedAt` 직렬화
- non-isSwitch 경로(같은 destination 재지정)는 cleanup chain 안 도므로 inline write 유지

### HomeScreen.tsx
- `effectiveOrigin` 4단 fallback: `customOrigin → result?.station → lastFusedStationRef.current → boardingLockStation → tripOrigin`
- `lastFusedStationRef`: 마지막 fused station을 ref로 stale-while-revalidate
- `boardingLockStation`: 활성 BoardingLock의 boardingStationId → `getStationById` 조회
- 경로 계산 useEffect 분리: `!destination`만 ROUTE_KEY removeItem (실제 trip 종료), `!effectiveOrigin`은 계산만 skip하고 storage 보존

### 회귀 가드 (자동화)
- `setDestinationStorageRace.test.ts` 신규 — switch+station / switch+null / A→B 세 분기 race 시나리오
- `useDestinationStore.test.ts` — 기존 테스트 일부가 inline setItem 의존 → cleanup chain 직렬화 반영(`flushMicrotasks` 50회, await 후 setItem 검증)

## Acceptance

### 자동화 (이번 PR 게이트)
- [x] 5691 tests passed (coverage 100%)
- [x] `npm run type-check` pass
- [x] 신규 race 테스트가 fix 전 코드에서 fail, fix 후 pass 확인

### 실기기 (close 게이트, 별도 1주 검증)
- [ ] BG 30분 후 FG 복귀 시 route/destination/active 모두 보존
- [ ] BG silent push received (ACTIVE_TRIP_KEY 보존)
- [ ] 환승 trip(7→5호선 같은 다중) 도중 storage 일괄 손실 0건
- [ ] DebugModal `route=set destination=<id>` trip 진행 동안 유지

## refs
- 직전 회귀: epic #1362 (오전 trip 5-layer), #1370 (오후 trip 5-layer)
- 관련 인프라: #1321 (tripTransitionQueue 직렬화), #1317 (sticky station), #1351 (trip-end backstop)