### PR TITLE
fix(#1381): cron read cacheTtl 0→30 (Cloudflare KV 최소 30s 제약)

### DIFF
--- a/backend/alarm-worker/src/__tests__/trips.test.ts
+++ b/backend/alarm-worker/src/__tests__/trips.test.ts
@@ -71,15 +71,39 @@ describe('trips KV CRUD', () => {
     expect(tokens).toEqual(['good']);
   });
 
-  // #1364 — cron read는 cacheTtl=0으로 origin 조회를 강제해 propagation 지연 회피.
-  it('listTrips passes cacheTtl=0 to kv.get (#1364 stale read 방어)', async () => {
+  // #766/#770/#1381 — cron read는 KV 최소 제약(30s)을 지키면서 첫 사이클 stale window를 차단.
+  it('listTrips passes cacheTtl=30 to kv.get (#1381 KV 최소 제약 준수)', async () => {
     await putTrip(kv as unknown as KVNamespace, makeTrip({ token: 'a' }));
     const spy = vi.spyOn(kv, 'get');
     for await (const _t of listTrips(kv as unknown as KVNamespace)) {
       // consume
     }
     const tripGetCall = spy.mock.calls.find(([key]) => key === 'trip:a');
-    expect(tripGetCall?.[1]).toEqual({ cacheTtl: 0 });
+    expect(tripGetCall?.[1]).toEqual({ cacheTtl: 30 });
+  });
+
+  // #1381 회귀 가드 — Cloudflare KV runtime은 cacheTtl<30 요청을 throw한다.
+  // production runtime을 mimic하는 InMemoryKV wrapping으로 listTrips가 throw 없이
+  // 완주하는지 확인 (CRON_READ_CACHE_TTL_SEC=0 회귀 시 즉시 fail).
+  it('listTrips does not violate Cloudflare KV cacheTtl>=30 constraint (#1381 회귀 가드)', async () => {
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ token: 'a' }));
+    const guardedKv = {
+      ...kv,
+      get: vi.fn(async (key: string, options?: { cacheTtl?: number }) => {
+        if (options?.cacheTtl !== undefined && options.cacheTtl < 30) {
+          throw new Error(
+            `KV GET failed: 400 Invalid cache_ttl of ${options.cacheTtl}. Cache TTL must be at least 30.`,
+          );
+        }
+        return kv.get(key, options);
+      }),
+      list: kv.list.bind(kv),
+    };
+    const tokens: string[] = [];
+    for await (const t of listTrips(guardedKv as unknown as KVNamespace)) {
+      tokens.push(t.token);
+    }
+    expect(tokens).toEqual(['a']);
   });
 
   // #1364 — getTrip은 caller가 cacheTtl 지정 가능. read-after-write verification 경로.

--- a/backend/alarm-worker/src/trips.ts
+++ b/backend/alarm-worker/src/trips.ts
@@ -10,19 +10,24 @@ import type { Trip } from './types';
 const TRIP_PREFIX = 'trip:';
 
 /**
- * cron read의 KV cacheTtl (#1364, 구 #766/#770).
+ * cron read의 KV cacheTtl (#766/#770 → #1364 → #1381).
  *
  * #765 evidence: sync handler `putTrip` 직후 다음 cron(43~60s 후)의 `kv.get`이 옛 캐시를
  * 읽어 `boardingLock.expiresAt`이 갱신 전 값으로 노출 → `isBoardingLockActive` false-negative
  * → "lock missing or expired" 회귀.
  *
- * #1364 deep RCA: cacheTtl=30s 단축으로 첫 cron 사이클의 캐시 window는 사라졌으나, KV의
- * region간 eventually-consistent propagation(최대 60s)은 별개 윈도우 — 30s 캐시가 만료돼도
- * 다른 region replica가 아직 옛 값을 반환할 수 있다. cron read를 cacheTtl=0으로 두어
- * 매 사이클 origin 조회를 강제하고, sync handler 측에서 read-after-write verification으로
- * propagation을 능동 확인한다 (index.ts /boarding-lock/sync).
+ * #1364 propagation 회피 의도: cron read를 origin 강제 조회하려 `cacheTtl=0`을 시도했으나
+ * Cloudflare KV runtime은 `cacheTtl < 30` 요청을 거절한다 — 매 cron 사이클 `Invalid
+ * cache_ttl of 0. Cache TTL must be at least 30.` throw로 `listTrips`가 첫 trip iterate
+ * 시점에 abort되어 silent push 발사 0건 회귀(#1381 evidence).
+ *
+ * Resolution: cron path는 KV 최소 제약(30s)을 준수하고, region propagation 정합성은
+ * sync handler가 책임진다 — `index.ts:/boarding-lock/sync`의 `verifyBoardingLockPersisted`
+ * 는 단일 키 read-after-write 검증이라 cacheTtl 제약 사이드를 다르게 다룬다.
+ * 본 상수는 `pendingPushes.ts:CRON_READ_CACHE_TTL_SEC(30)` /
+ * `progress.ts`(10/cron, 60/POST handler)와 일관한 cron-read 정책으로 정렬한다.
  */
-const CRON_READ_CACHE_TTL_SEC = 0;
+const CRON_READ_CACHE_TTL_SEC = 30;
 
 export function tripKey(token: string): string {
   return `${TRIP_PREFIX}${token}`;
@@ -69,9 +74,9 @@ export async function* listTrips(kv: KVNamespace): AsyncGenerator<Trip> {
   do {
     const result = await kv.list({ prefix: TRIP_PREFIX, cursor });
     for (const key of result.keys) {
-      // #1364 — cron read cacheTtl=0. 30s 캐시 + KV propagation 60s 합쳐 90s stale window가
-      // cron(*/1) 한 사이클 안에 들어가 false-negative "lock missing or expired"를 발생시켰다.
-      // 매 cron 사이클 origin 조회로 propagation 지연을 회피한다.
+      // #766/#770/#1381 — cron read cacheTtl 30s. Cloudflare KV 최소 제약(<30 throw)을 지키면서
+      // 동시에 putTrip 직후 첫 cron 사이클의 옛 캐시 window를 차단한다. region propagation
+      // 정합성은 sync handler의 verifyBoardingLockPersisted가 read-after-write 검증으로 책임.
       const raw = await kv.get(key.name, { cacheTtl: CRON_READ_CACHE_TTL_SEC });
       if (!raw) continue;
       try {


### PR DESCRIPTION
Closes #1381

## RCA 요약

**증상:** 매 1분 cron 사이클 `outcome=exception`, silent push 발사 0건 → 모든 사용자 BG 알람 차단.

**Root cause:** \`trips.ts:25\` \`CRON_READ_CACHE_TTL_SEC = 0\` (PR #1364 / commit 477d5c4) 가 Cloudflare KV 런타임 제약 \`cacheTtl ≥ 30\` 위반.

**Cascade:** \`listTrips\` 첫 trip iterate 시 throw → \`for await\` 루프 uncaught → \`runScheduled()\` 전체 abort → 모든 활성 trip 폴링 안 됨 → silent push, BoardingLock 평가, station-passed/transfer/early/imminent push 0건.

**evidence:** \`tasks/scheduled-tail-20260616-181549.jsonl\` — `"KV GET failed: 400 Invalid cache_ttl of 0. Cache TTL must be at least 30."` 반복

## 변경

- \`trips.ts:25\`: \`CRON_READ_CACHE_TTL_SEC\` 0 → 30
- 댓글 갱신: #1364 의도와 KV runtime constraint 발견 기록. propagation 회피는 sync handler `verifyBoardingLockPersisted` 책임으로 정렬
- \`pendingPushes.ts(30)\` / \`progress.ts(10 cron / 60 POST)\`와 일관
- 회귀 가드: \`trips.test.ts\` mock KV에 cacheTtl validation throw 시뮬레이션 추가

## 30 vs 60 선택 근거

| 항목 | 30 | 60 |
|---|---|---|
| KV 최소 | ✅ | ✅ |
| stale window 최대 | 90s | 120s |
| cron 1분 sync | 2번 중 1번 cache miss | 1번 직전 만료 |
| 응답성 | 더 빠름 | 느림 |
| 프로젝트 일관성 | pendingPushes/progress와 동일 | 셋 다 변경 필요 |

→ **30** 채택. \`pendingPushes.ts:26\` / \`progress.ts\`와 일관 + 응답성 + #1364가 막으려던 race는 sync handler verification으로 별도 가드.

## Acceptance

### 자동화 (PR 머지 게이트)
- [x] backend 1353 tests pass
- [x] trips.test.ts 회귀 가드(cacheTtl<30 mock throw 시뮬레이션) 통과
- [x] type-check pass

### 운영 (close 게이트)
- [x] 배포 직후 backend tail \`outcome=ok\` 30분 (exception 0건)
- [x] device 실기기 trip silent push received ≥ 1