### PR TITLE
fix(#1382): lock-interp forward ratchet — motion=stationary 시 보류

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
@@ -486,4 +486,64 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
       expect(result.current.source).toBe('boarding-lock-interp');
     });
   });
+
+  // #1382 — lock-interp adoption 게이트에 motion=stationary 가드 추가.
+  // 정지 trip에서 시간 적분 forward ratchet 보류. consensus 게이트(#1363)와 분리 책임.
+  describe('#1382 lock-interp forward ratchet — motion=stationary 보류', () => {
+    function runLockedScenario(motionStationary: boolean | undefined) {
+      jest.useFakeTimers();
+      const T0 = 1_700_000_000_000;
+      jest.setSystemTime(T0);
+
+      const routeCtx = { route: makeDirectRoute(4, '7'), origin: yongmasan, destination: konkuk };
+      const lock = makeLock({
+        trainCode: 'T-MOTION',
+        boardingStationId: yongmasan.id,
+        boardingLine: '7',
+        boardedAt: T0,
+        expectedDurationMs: 600_000,
+      });
+
+      mockNearest.mockReturnValue(gpsBase());
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+
+      const { result, rerender } = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          routeCtx,
+          'T-MOTION',
+          lock,
+          motionStationary,
+        ),
+      );
+
+      // 90s 후 default-hop이 forward로 ratchet 가능한 상태.
+      jest.setSystemTime(T0 + 90_000);
+      rerender({});
+
+      jest.useRealTimers();
+      return result;
+    }
+
+    it('motionStationary=true → forward ratchet 보류 (lock-interp 미채택)', () => {
+      // estimator는 다음 hop을 가리키지만, 사용자가 명시적 정지 상태.
+      // 게이트 차단 → result/source가 boarding-lock-interp로 승격되지 않음.
+      const result = runLockedScenario(true);
+      expect(result.current.source).not.toBe('boarding-lock-interp');
+    });
+
+    it('motionStationary=undefined(warmup) → 기존 ratchet 동작 유지', () => {
+      // motion warmup 상태(fg-hydrate 직후 ~30s)는 기존 동작 유지 — 정지 신호 미확정.
+      const result = runLockedScenario(undefined);
+      expect(result.current.source).toBe('boarding-lock-interp');
+    });
+
+    it('motionStationary=false → 기존 ratchet 동작 유지 (이동 또는 미지원)', () => {
+      // motion 신호가 이동 중이라고 보고하거나 디바이스 미지원으로 false fallback.
+      // forward ratchet 정상.
+      const result = runLockedScenario(false);
+      expect(result.current.source).toBe('boarding-lock-interp');
+    });
+  });
 });

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
@@ -100,6 +100,35 @@ function setup({
   return renderHook(() => useFusedNearestStation(undefined, undefined, routeCtx, trainCode, lock));
 }
 
+// #1382 — motion=stationary 게이트 시나리오. lock 활성 + 90s 경과(default-hop forward ratchet 가능).
+function runLockedMotionScenario(motionStationary: boolean | undefined) {
+  jest.useFakeTimers();
+  const T0 = 1_700_000_000_000;
+  jest.setSystemTime(T0);
+
+  const routeCtx = { route: makeDirectRoute(4, '7'), origin: yongmasan, destination: konkuk };
+  const lock = makeLock({
+    trainCode: 'T-MOTION',
+    boardingStationId: yongmasan.id,
+    boardingLine: '7',
+    boardedAt: T0,
+    expectedDurationMs: 600_000,
+  });
+
+  mockNearest.mockReturnValue(gpsBase());
+  mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+
+  const { result, rerender } = renderHook(() =>
+    useFusedNearestStation(undefined, undefined, routeCtx, 'T-MOTION', lock, motionStationary),
+  );
+
+  jest.setSystemTime(T0 + 90_000);
+  rerender({});
+
+  jest.useRealTimers();
+  return result;
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockArrival.mockReturnValue(arrivalRet(null));
@@ -490,59 +519,23 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
   // #1382 — lock-interp adoption 게이트에 motion=stationary 가드 추가.
   // 정지 trip에서 시간 적분 forward ratchet 보류. consensus 게이트(#1363)와 분리 책임.
   describe('#1382 lock-interp forward ratchet — motion=stationary 보류', () => {
-    function runLockedScenario(motionStationary: boolean | undefined) {
-      jest.useFakeTimers();
-      const T0 = 1_700_000_000_000;
-      jest.setSystemTime(T0);
-
-      const routeCtx = { route: makeDirectRoute(4, '7'), origin: yongmasan, destination: konkuk };
-      const lock = makeLock({
-        trainCode: 'T-MOTION',
-        boardingStationId: yongmasan.id,
-        boardingLine: '7',
-        boardedAt: T0,
-        expectedDurationMs: 600_000,
-      });
-
-      mockNearest.mockReturnValue(gpsBase());
-      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
-
-      const { result, rerender } = renderHook(() =>
-        useFusedNearestStation(
-          undefined,
-          undefined,
-          routeCtx,
-          'T-MOTION',
-          lock,
-          motionStationary,
-        ),
-      );
-
-      // 90s 후 default-hop이 forward로 ratchet 가능한 상태.
-      jest.setSystemTime(T0 + 90_000);
-      rerender({});
-
-      jest.useRealTimers();
-      return result;
-    }
-
     it('motionStationary=true → forward ratchet 보류 (lock-interp 미채택)', () => {
       // estimator는 다음 hop을 가리키지만, 사용자가 명시적 정지 상태.
       // 게이트 차단 → result/source가 boarding-lock-interp로 승격되지 않음.
-      const result = runLockedScenario(true);
+      const result = runLockedMotionScenario(true);
       expect(result.current.source).not.toBe('boarding-lock-interp');
     });
 
     it('motionStationary=undefined(warmup) → 기존 ratchet 동작 유지', () => {
       // motion warmup 상태(fg-hydrate 직후 ~30s)는 기존 동작 유지 — 정지 신호 미확정.
-      const result = runLockedScenario(undefined);
+      const result = runLockedMotionScenario(undefined);
       expect(result.current.source).toBe('boarding-lock-interp');
     });
 
     it('motionStationary=false → 기존 ratchet 동작 유지 (이동 또는 미지원)', () => {
       // motion 신호가 이동 중이라고 보고하거나 디바이스 미지원으로 false fallback.
       // forward ratchet 정상.
-      const result = runLockedScenario(false);
+      const result = runLockedMotionScenario(false);
       expect(result.current.source).toBe('boarding-lock-interp');
     });
   });

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
@@ -100,33 +100,49 @@ function setup({
   return renderHook(() => useFusedNearestStation(undefined, undefined, routeCtx, trainCode, lock));
 }
 
-// #1382 — motion=stationary 게이트 시나리오. lock 활성 + 90s 경과(default-hop forward ratchet 가능).
-function runLockedMotionScenario(motionStationary: boolean | undefined) {
+// Lock-interp / lockless estimator 공통 시나리오:
+// fake timer T0에서 1회 render → elapsedMs 진행 후 rerender → result 반환.
+// lock 활성/lockless / motion 신호 / 경과시간 차이만 옵션으로 받는다.
+const ESTIMATOR_T0 = 1_700_000_000_000;
+function runEstimatorScenario(opts: {
+  lock?: BoardingLock;
+  trainCode?: string;
+  motionStationary?: boolean;
+  elapsedMs?: number;
+} = {}) {
+  const { lock, trainCode, motionStationary, elapsedMs = 90_000 } = opts;
+
   jest.useFakeTimers();
-  const T0 = 1_700_000_000_000;
-  jest.setSystemTime(T0);
+  jest.setSystemTime(ESTIMATOR_T0);
 
   const routeCtx = { route: makeDirectRoute(4, '7'), origin: yongmasan, destination: konkuk };
-  const lock = makeLock({
-    trainCode: 'T-MOTION',
-    boardingStationId: yongmasan.id,
-    boardingLine: '7',
-    boardedAt: T0,
-    expectedDurationMs: 600_000,
-  });
-
   mockNearest.mockReturnValue(gpsBase());
   mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
 
   const { result, rerender } = renderHook(() =>
-    useFusedNearestStation(undefined, undefined, routeCtx, 'T-MOTION', lock, motionStationary),
+    useFusedNearestStation(undefined, undefined, routeCtx, trainCode, lock, motionStationary),
   );
 
-  jest.setSystemTime(T0 + 90_000);
+  jest.setSystemTime(ESTIMATOR_T0 + elapsedMs);
   rerender({});
 
   jest.useRealTimers();
   return result;
+}
+
+// #1382 — lock 활성 + 90s 경과 + motion 옵션.
+function runLockedMotionScenario(motionStationary: boolean | undefined) {
+  return runEstimatorScenario({
+    lock: makeLock({
+      trainCode: 'T-MOTION',
+      boardingStationId: yongmasan.id,
+      boardingLine: '7',
+      boardedAt: ESTIMATOR_T0,
+      expectedDurationMs: 600_000,
+    }),
+    trainCode: 'T-MOTION',
+    motionStationary,
+  });
 }
 
 beforeEach(() => {
@@ -400,33 +416,14 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
     });
 
     it('lock 없음 + routeCtx + 시간 경과 → lockless-route-hop이 arc hop time lookup closure 호출', () => {
-      // lock 없음 + routeCtx 있음 → 첫 render에 locklessTripStartRef 캡처.
-      // 시간 경과 후 rerender → hopsElapsedFrom이 hopTimeMsForHop 호출 → arc 노선 lookup 실행.
+      // lock 없음 + routeCtx 있음 → 첫 render에 locklessTripStartRef 캡처(=T0).
+      // 5분 경과 → hopsElapsedFrom이 0번 hop의 시작 노선('7') lookup → hopTimeMsForHop 호출.
       // Closure 내부 (segmentLine = arc[fromIdx].line) 경로 커버.
-      jest.useFakeTimers();
-      const T0 = 1_700_000_000_000;
-      jest.setSystemTime(T0);
-
-      const routeCtx = { route: makeDirectRoute(4, '7'), origin: yongmasan, destination: konkuk };
-
-      mockNearest.mockReturnValue(gpsBase());
-      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
-      // 열차 위치 없음 → trainProgress null → positionTrainResult null.
-      // mockPos는 beforeEach에서 null로 설정됨.
-
-      const { result, rerender } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, routeCtx),
-      );
-
-      // 첫 render 시 tripStartedAt = T0 캡처.
-      // 5분 경과 → hopsElapsedFrom이 0번 hop의 시작 노선('7') lookup → hopTimeMsAt 호출.
-      jest.setSystemTime(T0 + 5 * 60_000);
-      rerender({});
+      // (mockPos는 beforeEach에서 null → trainProgress null → positionTrainResult null.)
+      const result = runEstimatorScenario({ elapsedMs: 5 * 60_000 });
 
       // lock 없음 + estimator 채택 → boarding-lock-interp.
       expect(result.current.source).toBe('boarding-lock-interp');
-
-      jest.useRealTimers();
     });
   });
 
@@ -434,36 +431,19 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
     it('interpolated estimate + positionTrainResult null → livePositionIdx=-1 분기 통과', () => {
       // boardingLock 활성 + 90s 경과 → estimator default-hop 채택 (isInterpolated=true).
       // 열차 위치 없음 → positionTrainResult null → line 564 ternary false branch(: -1) 실행.
-      jest.useFakeTimers();
-      const T0 = 1_700_000_000_000;
-      jest.setSystemTime(T0);
-
-      const routeCtx = { route: makeDirectRoute(4, '7'), origin: yongmasan, destination: konkuk };
-      const lock = makeLock({
+      // (mockPos는 beforeEach에서 null로 설정됨 → trainProgress null → positionTrainResult null.)
+      const result = runEstimatorScenario({
+        lock: makeLock({
+          trainCode: 'T-INTERP',
+          boardingStationId: yongmasan.id,
+          boardingLine: '7',
+          boardedAt: ESTIMATOR_T0,
+          expectedDurationMs: 600_000,
+        }),
         trainCode: 'T-INTERP',
-        boardingStationId: yongmasan.id,
-        boardingLine: '7',
-        boardedAt: T0,
-        expectedDurationMs: 600_000,
       });
 
-      mockNearest.mockReturnValue(gpsBase());
-      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
-      // 열차 위치 없음 → trainProgress null → positionTrainResult null.
-      // mockPos는 beforeEach에서 null로 설정됨.
-
-      const { result, rerender } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, routeCtx, 'T-INTERP', lock),
-      );
-
-      // 90s 후 default-hop이 중곡(arc idx 1)을 채택. positionTrainResult null.
-      // → line 564 positionTrainResult ? ... : -1 의 false branch 실행.
-      jest.setSystemTime(T0 + 90_000);
-      rerender({});
-
       expect(result.current.source).toBe('boarding-lock-interp');
-
-      jest.useRealTimers();
     });
   });
 

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -745,10 +745,15 @@ export function useFusedNearestStation(
       const gpsNearestLine = candidates[0]?.station.line ?? null;
       withinLineGuard = estimate.station.line === gpsNearestLine;
     }
+    // #1382 — motion 명시 정지(true) 시 시간 적분 forward ratchet 보류. undefined(warmup) /
+    // false(이동·미지원)는 기존 동작. consensus 게이트(#1363, movementGate.ts)는 confidence
+    // 라벨 안정성을 별도 책임 — 라벨/forward 이동을 분리. 정지 trip에서 origin chip / 위젯
+    // mirror가 잘못된 다음 역으로 forward 표시되는 회귀(2026-06-16 18:11~18:12) 차단.
     if (
       (chosenIdx === -1 || estimate.index > chosenIdx) &&
       withinObservationCeiling &&
-      withinLineGuard
+      withinLineGuard &&
+      motionStationary !== true
     ) {
       const distanceKm = gps.userLocation
         ? haversine(


### PR DESCRIPTION
Closes #1382

## RCA 요약

`useFusedNearestStation.ts:748-752` lock-interp adoption 게이트가 `motionStationary` 신호를 보지 않아, 정지(motion=true) trip에서도 시간 적분이 forward ratchet 진행. consensus 게이트(#1363)는 confidence 라벨 안정성을 담당하며 motion 단독으로는 fusion source를 강등하지 않아 `boarding-lock-interp` 라벨이 유지되고, UI/위젯 mirror가 잘못된 다음 역(2026-06-16 18:11~18:12 evidence: 용마산 0m → 중곡 1113m)으로 forward 표시되는 회귀.

## Fix (옵션 B 채택)

`useFusedNearestStation.ts:748` 게이트 조건에 `motionStationary !== true` 추가.

- `motionStationary === true` → lock-interp 미채택, 직전 fusion(예: position-train / gps-only) 유지
- `motionStationary === undefined` (warmup, fg-hydrate 직후 ~30s) → 기존 ratchet 동작 보존
- `motionStationary === false` (이동 또는 device 미지원) → 기존 ratchet 동작 보존

옵션 A(consensus 게이트 약화)는 #1363 fu-jumping 회귀 위험으로 기각. 본 fix는 surgical — 라벨/forward 이동 책임 분리 유지.

## Acceptance 자동화 결과

- [x] 신규 unit test 3건 추가 (`useFusedNearestStation.positionGate.test.ts` `#1382` describe):
  - motionStationary=true → forward ratchet 보류 (lock-interp 미채택)
  - motionStationary=undefined(warmup) → 기존 ratchet 동작 유지
  - motionStationary=false → 기존 ratchet 동작 유지
- [x] frontend 5694 tests pass, coverage 100% (lines/functions/branches/statements)
- [x] type-check pass

## 실기기 close 게이트 (1주 todo)

- [ ] 정지 상태 trip(motion=true)에서 origin chip / 위젯 mirror 가 GPS 위치 그대로 표시 (시간 적분 forward 차단)
- [ ] 이동 trip에서 lock-interp ratchet 정상 진행 (회귀 없음)
- [ ] warmup 직후 trip에서 lock-interp ratchet 정상 (motion=undefined 보존)

## refs
- `src/features/nearest-station/hooks/useFusedNearestStation.ts:748-764`
- `src/features/nearest-station/utils/movementGate.ts:185-216` (#1363 consensus 게이트, 변경 없음)