### PR TITLE
fix(#1385): boardingPrompt displayed wire-up — receive + response listener에 logBoardingPromptFired 추가

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -24,6 +24,7 @@ import { unregisterAlarmRefreshTask } from '../src/features/alarm/tasks/alarmRef
 import { stopVibration } from '../src/features/alarm/utils/alarmSound';
 import { setupBoardingPromptCategory } from '../src/features/alarm/utils/notificationCategory';
 import { useBoardingPromptResponder } from '../src/features/alarm/hooks/useBoardingPromptResponder';
+import { useBoardingPromptDisplayLogger } from '../src/features/alarm/hooks/useBoardingPromptDisplayLogger';
 import { useStateRehydration } from '../src/shared/hooks/useStateRehydration';
 import { useLaunchTripReconciliation } from '../src/features/alarm/hooks/useLaunchTripReconciliation';
 import { fetchArrivalInfo } from '../src/features/arrival/api/arrivalApi';
@@ -90,6 +91,10 @@ function RootContent() {
     destinationId,
     expectedDurationMs: FALLBACK_BOARDING_DURATION_MINUTES * 60_000,
   });
+
+  // #1385 — boardingPrompt displayed 카운트. FG에서 actionable notification 수신 시 즉시
+  // alarm log에 fired 1건 적재한다. responder의 cold-start 보완과 dedup된다.
+  useBoardingPromptDisplayLogger();
 
   // #899 (Seam C) — trip-bound 상태 단일 hydration seam. AppState 'active' 진입 시
   // destination/customOrigin/tripOrigin/lock을 storage에서 재수화하고, BG silent push가

--- a/src/features/alarm/hooks/__tests__/useBoardingPromptDisplayLogger.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptDisplayLogger.test.ts
@@ -1,0 +1,167 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration test — Phase 5 file-level disable opt-in.
+ * (#1385)
+ */
+import * as Notifications from 'expo-notifications';
+import { renderHook } from '@testing-library/react-native';
+import {
+  useBoardingPromptDisplayLogger,
+  wasBoardingPromptDisplayed,
+  markBoardingPromptDisplayed,
+  __resetBoardingPromptDisplayedDedup,
+} from '../useBoardingPromptDisplayLogger';
+import { BOARDING_PROMPT_CATEGORY } from '../../utils/notificationCategory';
+
+jest.mock('expo-notifications', () => ({
+  addNotificationReceivedListener: jest.fn(),
+}));
+jest.mock('../../utils/alarmLog', () => ({
+  logBoardingPromptFired: jest.fn(),
+}));
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const { logBoardingPromptFired } = jest.requireMock('../../utils/alarmLog');
+
+const VALID_DATA = {
+  kind: 'boarding-prompt',
+  originStation: '강남',
+  line: '2',
+  tripToken: 'tok',
+};
+
+function makeNotification(overrides: {
+  identifier?: string;
+  categoryIdentifier?: string | null;
+  data?: unknown;
+}) {
+  return {
+    request: {
+      identifier: overrides.identifier ?? 'noti-1',
+      content: {
+        // null/undefined를 그대로 전달해야 "categoryIdentifier 미수신" 케이스를 시뮬레이션할 수 있다.
+        categoryIdentifier:
+          'categoryIdentifier' in overrides
+            ? overrides.categoryIdentifier
+            : BOARDING_PROMPT_CATEGORY,
+        data: overrides.data ?? VALID_DATA,
+      },
+    },
+  };
+}
+
+describe('useBoardingPromptDisplayLogger (#1385)', () => {
+  let registeredHandler: ((notification: any) => void) | null = null;
+  const subscriptionRemove = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    registeredHandler = null;
+    __resetBoardingPromptDisplayedDedup();
+    (Notifications.addNotificationReceivedListener as jest.Mock).mockImplementation(
+      (handler) => {
+        registeredHandler = handler;
+        return { remove: subscriptionRemove };
+      },
+    );
+  });
+
+  it('FG receive listener를 등록한다', () => {
+    renderHook(() => useBoardingPromptDisplayLogger());
+    expect(Notifications.addNotificationReceivedListener).toHaveBeenCalledTimes(1);
+    expect(registeredHandler).not.toBeNull();
+  });
+
+  it('unmount 시 subscription remove', () => {
+    const { unmount } = renderHook(() => useBoardingPromptDisplayLogger());
+    unmount();
+    expect(subscriptionRemove).toHaveBeenCalled();
+  });
+
+  it('BOARDING_PROMPT category notification 수신 시 logBoardingPromptFired 호출', () => {
+    renderHook(() => useBoardingPromptDisplayLogger());
+    registeredHandler!(makeNotification({ identifier: 'n-1' }));
+    expect(logBoardingPromptFired).toHaveBeenCalledTimes(1);
+    expect(logBoardingPromptFired).toHaveBeenCalledWith({
+      originStation: '강남',
+      line: '2',
+    });
+    expect(wasBoardingPromptDisplayed('n-1')).toBe(true);
+  });
+
+  it('같은 identifier 재수신 시 dedup — logBoardingPromptFired 추가 호출 없음', () => {
+    renderHook(() => useBoardingPromptDisplayLogger());
+    registeredHandler!(makeNotification({ identifier: 'n-1' }));
+    registeredHandler!(makeNotification({ identifier: 'n-1' }));
+    expect(logBoardingPromptFired).toHaveBeenCalledTimes(1);
+  });
+
+  it('다른 identifier는 별도 1건씩 적재', () => {
+    renderHook(() => useBoardingPromptDisplayLogger());
+    registeredHandler!(makeNotification({ identifier: 'n-1' }));
+    registeredHandler!(makeNotification({ identifier: 'n-2' }));
+    expect(logBoardingPromptFired).toHaveBeenCalledTimes(2);
+  });
+
+  it('다른 categoryIdentifier → no-op', () => {
+    renderHook(() => useBoardingPromptDisplayLogger());
+    registeredHandler!(
+      makeNotification({ categoryIdentifier: 'OTHER_CATEGORY' }),
+    );
+    expect(logBoardingPromptFired).not.toHaveBeenCalled();
+  });
+
+  it('categoryIdentifier null (Android 등) → no-op', () => {
+    renderHook(() => useBoardingPromptDisplayLogger());
+    registeredHandler!(makeNotification({ categoryIdentifier: null }));
+    expect(logBoardingPromptFired).not.toHaveBeenCalled();
+  });
+
+  it('payload schema 미일치(kind 다름) → no-op', () => {
+    renderHook(() => useBoardingPromptDisplayLogger());
+    registeredHandler!(
+      makeNotification({ data: { kind: 'reschedule' } }),
+    );
+    expect(logBoardingPromptFired).not.toHaveBeenCalled();
+  });
+
+  it('identifier 누락 → no-op', () => {
+    renderHook(() => useBoardingPromptDisplayLogger());
+    registeredHandler!(
+      makeNotification({ identifier: '' }),
+    );
+    expect(logBoardingPromptFired).not.toHaveBeenCalled();
+  });
+
+  it('listener 콜백 내부 예외 — swallow (throw 안 함)', () => {
+    renderHook(() => useBoardingPromptDisplayLogger());
+    // request.content 접근 시 throw 케이스
+    expect(() =>
+      registeredHandler!({
+        get request() {
+          throw new Error('boom');
+        },
+      }),
+    ).not.toThrow();
+    expect(logBoardingPromptFired).not.toHaveBeenCalled();
+  });
+
+  it('helper — markBoardingPromptDisplayed가 dedup set에 반영된다', () => {
+    expect(wasBoardingPromptDisplayed('m-1')).toBe(false);
+    markBoardingPromptDisplayed('m-1');
+    expect(wasBoardingPromptDisplayed('m-1')).toBe(true);
+  });
+
+  it('helper — __resetBoardingPromptDisplayedDedup이 set을 비운다', () => {
+    markBoardingPromptDisplayed('m-2');
+    expect(wasBoardingPromptDisplayed('m-2')).toBe(true);
+    __resetBoardingPromptDisplayedDedup();
+    expect(wasBoardingPromptDisplayed('m-2')).toBe(false);
+  });
+});

--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -33,7 +33,18 @@ jest.mock('../../../../shared/utils/stationLookup', () => ({
 jest.mock('../../utils/alarmLog', () => ({
   logBoardingPromptAutoLock: jest.fn(),
   logBoardingPromptResponded: jest.fn(),
+  logBoardingPromptFired: jest.fn(),
 }));
+jest.mock('../useBoardingPromptDisplayLogger', () => {
+  const seen = new Set<string>();
+  return {
+    wasBoardingPromptDisplayed: jest.fn((id: string) => seen.has(id)),
+    markBoardingPromptDisplayed: jest.fn((id: string) => {
+      seen.add(id);
+    }),
+    __resetMockDedup: () => seen.clear(),
+  };
+});
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),
@@ -61,10 +72,15 @@ jest.mock('../../store/useBoardingLockStore', () => {
 });
 
 const { findStationByNameAndLine } = jest.requireMock('../../../../shared/utils/stationLookup');
-const { logBoardingPromptAutoLock, logBoardingPromptResponded } = jest.requireMock('../../utils/alarmLog');
+const {
+  logBoardingPromptAutoLock,
+  logBoardingPromptResponded,
+  logBoardingPromptFired,
+} = jest.requireMock('../../utils/alarmLog');
 const { __mockCreateLock: createLockMock } = jest.requireMock(
   '../../store/useBoardingLockStore',
 );
+const displayLoggerMock = jest.requireMock('../useBoardingPromptDisplayLogger');
 
 type UpEntry = StationArrival['up'][number];
 
@@ -327,6 +343,7 @@ describe('useBoardingPromptResponder hook wiring', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     registeredHandler = null;
+    displayLoggerMock.__resetMockDedup();
     (Notifications.addNotificationResponseReceivedListener as jest.Mock).mockImplementation(
       (handler) => {
         registeredHandler = handler;
@@ -394,6 +411,112 @@ describe('useBoardingPromptResponder hook wiring', () => {
     // hook의 비동기 handleResponse 처리 후 검증
     await new Promise((r) => setTimeout(r, 0));
     expect(createLockMock).toHaveBeenCalled();
+  });
+});
+
+describe('useBoardingPromptResponder #1385 — cold-start fired 보완 + dedup', () => {
+  let registeredHandler: ((response: any) => void) | null = null;
+
+  function makeResponse(overrides: {
+    identifier?: string;
+    categoryIdentifier?: string | null | undefined;
+    data?: unknown;
+    actionIdentifier?: string;
+  }) {
+    return {
+      actionIdentifier:
+        overrides.actionIdentifier ?? Notifications.DEFAULT_ACTION_IDENTIFIER,
+      notification: {
+        request: {
+          identifier: overrides.identifier ?? 'noti-cold-1',
+          content: {
+            categoryIdentifier:
+              overrides.categoryIdentifier === undefined
+                ? 'BOARDING_PROMPT'
+                : overrides.categoryIdentifier,
+            data:
+              overrides.data ?? {
+                kind: 'boarding-prompt',
+                originStation: '강남',
+                line: '2',
+                tripToken: 'tok',
+              },
+          },
+        },
+      },
+    };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    registeredHandler = null;
+    displayLoggerMock.__resetMockDedup();
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({
+      id: 'S1',
+      line: '2',
+      name: '강남',
+    });
+    (Notifications.addNotificationResponseReceivedListener as jest.Mock).mockImplementation(
+      (handler) => {
+        registeredHandler = handler;
+        return { remove: jest.fn() };
+      },
+    );
+    renderHook(() =>
+      useBoardingPromptResponder({
+        fetchArrivalsForStation: async () => null,
+        destinationId: 'dst',
+        expectedDurationMs: 600_000,
+      }),
+    );
+  });
+
+  it('FG receive 못 잡은 cold-start 응답 → logBoardingPromptFired 호출 후 logBoardingPromptResponded', async () => {
+    await registeredHandler!(makeResponse({}));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(logBoardingPromptFired).toHaveBeenCalledWith({
+      originStation: '강남',
+      line: '2',
+    });
+    expect(logBoardingPromptResponded).toHaveBeenCalled();
+  });
+
+  it('FG receive 가 먼저 적재 → response 진입 시 dedup으로 fired 추가 호출 없음', async () => {
+    // FG receive가 이미 적재한 상태를 시뮬레이션.
+    displayLoggerMock.markBoardingPromptDisplayed('noti-cold-1');
+    await registeredHandler!(makeResponse({ identifier: 'noti-cold-1' }));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(logBoardingPromptFired).not.toHaveBeenCalled();
+    // responded는 dedup과 무관하게 호출되어야 한다.
+    expect(logBoardingPromptResponded).toHaveBeenCalled();
+  });
+
+  it('categoryIdentifier null (Android 등)이어도 payload 일치 시 cold-start fired 적재', async () => {
+    await registeredHandler!(makeResponse({ categoryIdentifier: null }));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(logBoardingPromptFired).toHaveBeenCalledTimes(1);
+  });
+
+  it('categoryIdentifier가 BOARDING_PROMPT가 아니고 payload만 일치 → cold-start fired 적재 안 함', async () => {
+    await registeredHandler!(makeResponse({ categoryIdentifier: 'OTHER_CATEGORY' }));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(logBoardingPromptFired).not.toHaveBeenCalled();
+    // payload는 valid → responded는 정상 처리.
+    expect(logBoardingPromptResponded).toHaveBeenCalled();
+  });
+
+  it('identifier 누락 → cold-start fired 적재 skip (responded는 정상)', async () => {
+    await registeredHandler!(makeResponse({ identifier: '' }));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(logBoardingPromptFired).not.toHaveBeenCalled();
+    expect(logBoardingPromptResponded).toHaveBeenCalled();
+  });
+
+  it('같은 response identifier 재진입 → fired 1건만 (dedup)', async () => {
+    await registeredHandler!(makeResponse({ identifier: 'dup-1' }));
+    await registeredHandler!(makeResponse({ identifier: 'dup-1' }));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(logBoardingPromptFired).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/features/alarm/hooks/useBoardingPromptDisplayLogger.ts
+++ b/src/features/alarm/hooks/useBoardingPromptDisplayLogger.ts
@@ -1,0 +1,92 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: 이 파일은 의도적으로 여러 features의 hook/util을 조합하는
+ * orchestrator 역할이라 직접 import가 본질적이다. Phase 5 enforce 모드에서 file-level disable로
+ * 옵트인 처리.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+/**
+ * #1385 — boardingPrompt displayed wire-up.
+ *
+ * #1021에서 추가된 `logBoardingPromptFired`가 production 호출자가 없어 DebugModal
+ * "Boarding Prompt" 카운터와 acceptance dashboard(displayed 의존)가 영원히 0/null로
+ * 표시되던 dead-wire 버그를 잡는다.
+ *
+ *   1) FG에서 notification 수신 시 `addNotificationReceivedListener` 콜백 → categoryIdentifier가
+ *      BOARDING_PROMPT_CATEGORY면 `logBoardingPromptFired` 호출 + dedup set 등록.
+ *   2) BG cold-start로 FG receive를 못 잡은 케이스는 `useBoardingPromptResponder`의 response
+ *      listener에서 dedup set 체크 후 보완 적재 (이 파일이 export하는 helper 사용).
+ *
+ * dedup key는 `notification.request.identifier`. set은 모듈 스코프 in-memory — 앱 재시작 시
+ * reset되지만 fired entry는 영구 alarm log AsyncStorage에 적재되므로 누적 손실 없음.
+ */
+
+import { useEffect } from 'react';
+import * as Notifications from 'expo-notifications';
+import { BOARDING_PROMPT_CATEGORY } from '../utils/notificationCategory';
+import { logBoardingPromptFired } from '../utils/alarmLog';
+import { extractBoardingPromptPayload } from './useBoardingPromptResponder';
+import { createLogger } from '../../../shared/utils/logger';
+
+const log = createLogger('boardingPromptDisplayLogger');
+
+/**
+ * 모듈 스코프 dedup set. `useBoardingPromptDisplayLogger` (FG receive) 와
+ * `useBoardingPromptResponder` (response — cold-start 보완) 가 공유한다.
+ * 같은 notification.request.identifier로 fired가 이미 적재됐는지 확인 후 1건만 적재.
+ */
+const displayedIdentifiers = new Set<string>();
+
+/**
+ * 같은 notification에 대해 displayed 적재가 이미 이루어졌는지 확인.
+ * `useBoardingPromptResponder`가 cold-start 보완 시 이 helper로 dedup 체크.
+ */
+export function wasBoardingPromptDisplayed(identifier: string): boolean {
+  return displayedIdentifiers.has(identifier);
+}
+
+/**
+ * displayed 적재가 완료됐음을 dedup set에 기록.
+ * `useBoardingPromptResponder`가 cold-start fired를 추가 적재한 직후 호출.
+ */
+export function markBoardingPromptDisplayed(identifier: string): void {
+  displayedIdentifiers.add(identifier);
+}
+
+/** 테스트 격리용 — dedup set을 비운다. production 코드에서는 호출하지 않는다. */
+export function __resetBoardingPromptDisplayedDedup(): void {
+  displayedIdentifiers.clear();
+}
+
+/**
+ * FG receive listener — BOARDING_PROMPT category notification 수신 시 displayed 적재.
+ *
+ * app/_layout.tsx에서 useBoardingPromptResponder 옆에 같이 호출한다. deps 없음.
+ */
+export function useBoardingPromptDisplayLogger(): void {
+  useEffect(() => {
+    const sub = Notifications.addNotificationReceivedListener((notification) => {
+      try {
+        const request = notification.request;
+        const content = request.content;
+        // iOS에서만 categoryIdentifier가 채워진다 (Android는 무시). BOARDING_PROMPT 외 카테고리는 skip.
+        if (content.categoryIdentifier !== BOARDING_PROMPT_CATEGORY) return;
+        // payload schema 검증 — 형식이 다른 push가 같은 category를 재사용해도 displayed 오적재 차단.
+        const payload = extractBoardingPromptPayload(content.data);
+        if (!payload) return;
+        const identifier = request.identifier;
+        if (typeof identifier !== 'string' || identifier.length === 0) return;
+        if (displayedIdentifiers.has(identifier)) return;
+        displayedIdentifiers.add(identifier);
+        logBoardingPromptFired({
+          originStation: payload.originStation,
+          line: payload.line,
+        });
+      } catch (err) {
+        // listener 콜백은 절대 throw 금지 — 오작동 시 silent log만.
+        log.warn('boarding-prompt displayed 적재 실패', err as Error);
+      }
+    });
+    return () => sub.remove();
+  }, []);
+}

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -28,13 +28,22 @@ import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival'
 import { dismissBoardingPrompt } from '../../nearest-station/api/positionUpload';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import { pickAutoTrainCodeFromArrivals } from '../utils/boardingPromptAutoLock';
-import { logBoardingPromptAutoLock, logBoardingPromptResponded } from '../utils/alarmLog';
+import {
+  logBoardingPromptAutoLock,
+  logBoardingPromptFired,
+  logBoardingPromptResponded,
+} from '../utils/alarmLog';
 import {
   BOARDING_PROMPT_ACTION_BOARDED,
   BOARDING_PROMPT_ACTION_NOT_BOARDED,
+  BOARDING_PROMPT_CATEGORY,
 } from '../utils/notificationCategory';
 import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import { createLogger } from '../../../shared/utils/logger';
+import {
+  markBoardingPromptDisplayed,
+  wasBoardingPromptDisplayed,
+} from './useBoardingPromptDisplayLogger';
 
 const log = createLogger('boardingPromptResponder');
 
@@ -87,10 +96,28 @@ export function useBoardingPromptResponder(deps: UseBoardingPromptResponderDeps)
 
   useEffect(() => {
     const sub = Notifications.addNotificationResponseReceivedListener((response) => {
-      const payload = extractBoardingPromptPayload(
-        response.notification.request.content.data,
-      );
+      const request = response.notification.request;
+      const payload = extractBoardingPromptPayload(request.content.data);
       if (!payload) return;
+      // #1385 — BG cold-start fired 보완. FG receive listener가 못 잡은 케이스(killed-app 상태에서
+      // prompt 표시 → 사용자가 곧장 응답)에서도 displayed 카운트를 살린다. dedup은
+      // notification.request.identifier 기준 — FG receive가 먼저 적재했으면 skip.
+      const identifier = request.identifier;
+      if (typeof identifier === 'string' && identifier.length > 0) {
+        const isBoardingPromptCategory =
+          request.content.categoryIdentifier === BOARDING_PROMPT_CATEGORY;
+        // categoryIdentifier 미수신 OS(예: Android)에서도 payload schema가 일치하면 fired 적재.
+        const shouldLog =
+          (isBoardingPromptCategory || request.content.categoryIdentifier == null) &&
+          !wasBoardingPromptDisplayed(identifier);
+        if (shouldLog) {
+          markBoardingPromptDisplayed(identifier);
+          logBoardingPromptFired({
+            originStation: payload.originStation,
+            line: payload.line,
+          });
+        }
+      }
       void handleResponse(response.actionIdentifier, payload, {
         ...deps,
         createLock,


### PR DESCRIPTION
Closes #1385

## RCA (요약)

PR #1021에서 `logBoardingPromptFired` 함수 + DebugModal "Boarding Prompt" 카운터 + acceptance dashboard(`boardingPromptMonitor.displayed` 의존)를 추가했지만 **실제 prompt 표시 시점에 함수를 호출하는 listener wire-up이 누락**.

```
grep -rn "logBoardingPromptFired" src/
  ↳ alarmLog.ts:940              (정의)
  ↳ alarmLog.test.ts:1578        (unit test만)
  ↳ boardingPromptMonitor.ts:9   (주석)
  ↳ production 호출자: 0건
```

결과: 사용자가 prompt를 받고 응답해도 `displayed=0` 고정 → `responseRatePct` / `boardedRatePct` 영원히 `null` → epic #1008 B3 (boardingPrompt 정확도 acceptance) 측정 인프라가 zero data.

## 변경 요약

### 신규 — `src/features/alarm/hooks/useBoardingPromptDisplayLogger.ts`
- `Notifications.addNotificationReceivedListener` 등록
- `notification.request.content.categoryIdentifier === BOARDING_PROMPT_CATEGORY` + payload schema 일치 + `request.identifier` 유효 → dedup set 체크 후 `logBoardingPromptFired` 호출
- dedup set은 모듈 스코프 `Set<string>`. `wasBoardingPromptDisplayed` / `markBoardingPromptDisplayed` helper export → responder 공유
- listener 콜백 내부 예외는 swallow (절대 throw 안 함)

### 수정 — `src/features/alarm/hooks/useBoardingPromptResponder.ts`
- response listener 진입 시 BOARDING_PROMPT category 확인 + dedup set 체크 → `markBoardingPromptDisplayed` + `logBoardingPromptFired` 호출 (cold-start 보완)
- categoryIdentifier 미수신 OS(Android 등)에서도 payload schema 일치 시 적재
- 그 후 기존 `handleResponse` 호출 (`logBoardingPromptResponded`까지 정상 동작)

### 수정 — `app/_layout.tsx`
- `useBoardingPromptDisplayLogger()` 호출을 `useBoardingPromptResponder` 옆에 추가

## Acceptance 자동화 결과

자동화 (PR 머지 게이트)

- [x] FG에서 BOARDING_PROMPT category notification 수신 시 `logBoardingPromptFired` 호출 → unit test 검증
- [x] BG cold-start response listener 진입 시도 동일 entry 적재 (dedup 작동) → unit test 검증
- [x] FG receive + 같은 notification response → fired 1건만 (dedup) → unit test 검증
- [x] coverage 100% — `useBoardingPromptDisplayLogger.ts` 및 `useBoardingPromptResponder.ts` 모두 statements/branches/functions/lines = 100
- [x] `npm run type-check` pass
- [x] `npm run lint` pass

실기기 (close 게이트, 1주)

- [ ] BoardingPrompt 받은 trip에서 DebugModal "Boarding Prompt" 5m/1h/all 카운트 ≥ 1
- [ ] `responseRatePct` / `boardedRatePct` 가 null이 아닌 숫자로 표시
- [ ] 같은 trip에서 FG/BG 전환 시 dedup 정상 작동 (중복 카운트 0)

## 영향 범위

- frontend 한정. backend / Cloudflare Worker 변경 없음.
- 기존 동작에 추가만 — `handleResponse` / `logBoardingPromptResponded` 흐름 보존.

## 참고

- 메모리: DebugModal wire-up audit 결과 유일한 dead-wire
- 관련 PR: #1021 (boardingPromptMonitor), #1167 (autolock outcome), #1170 (acceptance dashboard)