### PR TITLE
fix(#1386): lock-active fallback advance — motion=stationary 가드 추가

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1616,6 +1616,153 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
       expect(stored.waypoints[0].stationName).toBe('군자');
       expect(stored.consecutiveEtaMissing).toBe(0);
     });
+
+    // #1386 — lock-active vanish fallback motion 게이트.
+    // hop 시간 경과 + fallbackTrigger 도달 상태에서 device motion에 따른 분기 검증.
+    describe('#1386 motion gate (stationary 보류, walking/automotive/unknown 진행)', () => {
+      it('motion=stationary → fallback advance 보류 + station-passed push X (카운터 누적)', async () => {
+        // 사용자 정지 trip — backend가 hop 시간만 보고 false station-passed를 발사하던 회귀 차단.
+        const kv = new InMemoryKV();
+        await putTrip(
+          kv as unknown as KVNamespace,
+          makeLockTrip({
+            consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+            lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
+          }),
+        );
+        await seedLocklessMotionSeries(kv, 'lock-tok', 'stationary');
+        const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+        const stats = await runScheduled(makeEnv(kv), {
+          seoul: makeSeoulCombo([], []),
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW,
+          generatePushId: () => 'p1386-stationary',
+        });
+        expect(stats.vanishFallbackMotionGateBlocked).toBe(1);
+        expect(stats.vanishFallbackFired).toBe(0);
+        // station-passed push가 발사되지 않아야 함
+        const stationPassedCalls = apnsFetch.mock.calls.filter((c) => {
+          const body = JSON.parse((c[1] as RequestInit).body as string);
+          return body.data?.phase === 'imminent';
+        });
+        expect(stationPassedCalls.length).toBe(0);
+        const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
+        // waypoint 유지 — advance 안 됨
+        expect(stored.waypoints[0].stationName).toBe('중곡');
+        expect(stored.boardingLock).toBeDefined();
+        // 카운터 누적 유지 — motion 회복 시 다음 cycle에서 정상 advance, 회복 안 되면 auto-end가 종료 보장
+        expect(stored.consecutiveEtaMissing).toBe(FALLBACK_TRIGGER);
+      });
+
+      it('motion=walking → fallback advance 진행 (waypoint shift)', async () => {
+        // 사용자가 실제로 걷는 중 — hop 시간 경과 시 advance 허용.
+        const kv = new InMemoryKV();
+        await putTrip(
+          kv as unknown as KVNamespace,
+          makeLockTrip({
+            consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+            lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
+          }),
+        );
+        await seedLocklessMotionSeries(kv, 'lock-tok', 'walking');
+        const stats = await runScheduled(makeEnv(kv), {
+          seoul: makeSeoulCombo([], []),
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: makeOkFetch() as unknown as typeof fetch,
+          now: () => NOW,
+          generatePushId: () => 'p1386-walking',
+        });
+        expect(stats.vanishFallbackMotionGateBlocked).toBe(0);
+        expect(stats.vanishFallbackFired).toBe(1);
+        const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
+        expect(stored.waypoints[0].stationName).toBe('군자');
+        expect(stored.consecutiveEtaMissing).toBe(0);
+      });
+
+      it('motion=automotive → fallback advance 진행 (waypoint shift)', async () => {
+        // 사용자가 실제로 이동 중 — hop 시간 경과 시 advance 허용.
+        const kv = new InMemoryKV();
+        await putTrip(
+          kv as unknown as KVNamespace,
+          makeLockTrip({
+            consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+            lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
+          }),
+        );
+        await seedLocklessMotionSeries(kv, 'lock-tok', 'automotive');
+        const stats = await runScheduled(makeEnv(kv), {
+          seoul: makeSeoulCombo([], []),
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: makeOkFetch() as unknown as typeof fetch,
+          now: () => NOW,
+          generatePushId: () => 'p1386-auto',
+        });
+        expect(stats.vanishFallbackMotionGateBlocked).toBe(0);
+        expect(stats.vanishFallbackFired).toBe(1);
+        const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
+        expect(stored.waypoints[0].stationName).toBe('군자');
+      });
+
+      it('motion=unknown (센서 미지원) → fallback advance 진행 (트레이드오프: lockless보다 약한 보수)', async () => {
+        // 권한 거절/센서 미지원 사용자가 freeze되지 않도록 unknown은 기존 동작 유지.
+        // positive stationary 신호가 있을 때만 게이트가 진입한다는 정책 점검.
+        const kv = new InMemoryKV();
+        await putTrip(
+          kv as unknown as KVNamespace,
+          makeLockTrip({
+            consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+            lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
+          }),
+        );
+        await seedLocklessMotionSeries(kv, 'lock-tok', 'unknown');
+        const stats = await runScheduled(makeEnv(kv), {
+          seoul: makeSeoulCombo([], []),
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: makeOkFetch() as unknown as typeof fetch,
+          now: () => NOW,
+          generatePushId: () => 'p1386-unknown',
+        });
+        expect(stats.vanishFallbackMotionGateBlocked).toBe(0);
+        expect(stats.vanishFallbackFired).toBe(1);
+        const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
+        expect(stored.waypoints[0].stationName).toBe('군자');
+      });
+
+      it('hop 시간 미경과 → motion 게이트 진입 전 (lock release 경로 유지)', async () => {
+        // 게이트는 hopElapsed 분기 안에서만 평가 — 미경과면 motion=stationary여도 lock release.
+        // #1370 L3 동작과 충돌하지 않음 점검.
+        const kv = new InMemoryKV();
+        await putTrip(
+          kv as unknown as KVNamespace,
+          makeLockTrip({
+            consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+            lastTrackedArrivalEpoch: LAST_EPOCH_NOT_ELAPSED,
+            locklessStationPassed: false,
+          }),
+        );
+        await seedLocklessMotionSeries(kv, 'lock-tok', 'stationary');
+        const stats = await runScheduled(makeEnv(kv), {
+          seoul: makeSeoulCombo([], []),
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: makeOkFetch() as unknown as typeof fetch,
+          now: () => NOW,
+          generatePushId: () => 'p1386-not-elapsed',
+        });
+        // motion gate 미진입
+        expect(stats.vanishFallbackMotionGateBlocked).toBe(0);
+        // lock release + lockless takeover 경로 활성
+        expect(stats.vanishLocklessTakeover).toBe(1);
+        const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
+        expect(stored.boardingLock).toBeUndefined();
+        expect(stored.locklessStationPassed).toBe(true);
+      });
+    });
   });
 
   it('advances waypoint and resets baseline when trainCode arrived (arvlCd=1)', async () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1679,42 +1679,22 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
         expect(stored.consecutiveEtaMissing).toBe(FALLBACK_TRIGGER);
       });
 
-      it('motion=walking → fallback advance 진행 (waypoint shift)', async () => {
-        // 사용자가 실제로 걷는 중 — hop 시간 경과 시 advance 허용.
+      // walking/automotive — positive 비정지 신호 → advance 진행.
+      // unknown — 센서 미지원/권한 거절 사용자 freeze 방지 트레이드오프 (lockless보다 약한 보수).
+      it.each<[PositionPoint['motion'], string]>([
+        ['walking', 'p1386-walking'],
+        ['automotive', 'p1386-auto'],
+        ['unknown', 'p1386-unknown'],
+      ])('motion=%s → fallback advance 진행 (waypoint shift)', async (motion, pushId) => {
         const { stats, stored } = await runFallbackMotionScenario({
-          motion: 'walking',
+          motion,
           hopElapsed: true,
-          pushId: 'p1386-walking',
+          pushId,
         });
         expect(stats.vanishFallbackMotionGateBlocked).toBe(0);
         expect(stats.vanishFallbackFired).toBe(1);
         expect(stored.waypoints[0].stationName).toBe('군자');
         expect(stored.consecutiveEtaMissing).toBe(0);
-      });
-
-      it('motion=automotive → fallback advance 진행 (waypoint shift)', async () => {
-        // 사용자가 실제로 이동 중 — hop 시간 경과 시 advance 허용.
-        const { stats, stored } = await runFallbackMotionScenario({
-          motion: 'automotive',
-          hopElapsed: true,
-          pushId: 'p1386-auto',
-        });
-        expect(stats.vanishFallbackMotionGateBlocked).toBe(0);
-        expect(stats.vanishFallbackFired).toBe(1);
-        expect(stored.waypoints[0].stationName).toBe('군자');
-      });
-
-      it('motion=unknown (센서 미지원) → fallback advance 진행 (트레이드오프: lockless보다 약한 보수)', async () => {
-        // 권한 거절/센서 미지원 사용자가 freeze되지 않도록 unknown은 기존 동작 유지.
-        // positive stationary 신호가 있을 때만 게이트가 진입한다는 정책 점검.
-        const { stats, stored } = await runFallbackMotionScenario({
-          motion: 'unknown',
-          hopElapsed: true,
-          pushId: 'p1386-unknown',
-        });
-        expect(stats.vanishFallbackMotionGateBlocked).toBe(0);
-        expect(stats.vanishFallbackFired).toBe(1);
-        expect(stored.waypoints[0].stationName).toBe('군자');
       });
 
       it('hop 시간 미경과 → motion 게이트 진입 전 (lock release 경로 유지)', async () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1620,25 +1620,49 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
     // #1386 — lock-active vanish fallback motion 게이트.
     // hop 시간 경과 + fallbackTrigger 도달 상태에서 device motion에 따른 분기 검증.
     describe('#1386 motion gate (stationary 보류, walking/automotive/unknown 진행)', () => {
-      it('motion=stationary → fallback advance 보류 + station-passed push X (카운터 누적)', async () => {
-        // 사용자 정지 trip — backend가 hop 시간만 보고 false station-passed를 발사하던 회귀 차단.
+      /**
+       * #1386 motion 게이트 시나리오 표준 setup. 5개 케이스 공통 boilerplate
+       * (FALLBACK_TRIGGER - 1 lock trip + motion series seed + runScheduled wiring)을
+       * 단일 진입점으로 압축. 각 it은 motion/hopElapsed/추가 trip override만 명시한다.
+       */
+      async function runFallbackMotionScenario(setup: {
+        motion: PositionPoint['motion'];
+        hopElapsed: boolean;
+        pushId: string;
+        tripOverrides?: Partial<Trip>;
+        apnsFetch?: ReturnType<typeof vi.fn>;
+      }) {
         const kv = new InMemoryKV();
         await putTrip(
           kv as unknown as KVNamespace,
           makeLockTrip({
             consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
-            lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
+            lastTrackedArrivalEpoch: setup.hopElapsed ? LAST_EPOCH_ELAPSED : LAST_EPOCH_NOT_ELAPSED,
+            ...setup.tripOverrides,
           }),
         );
-        await seedLocklessMotionSeries(kv, 'lock-tok', 'stationary');
-        const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+        await seedLocklessMotionSeries(kv, 'lock-tok', setup.motion);
+        const apnsFetch = setup.apnsFetch ?? makeOkFetch();
         const stats = await runScheduled(makeEnv(kv), {
           seoul: makeSeoulCombo([], []),
           apnsConfig,
           apnsHosts: APNS_HOSTS,
           fetchImpl: apnsFetch as unknown as typeof fetch,
           now: () => NOW,
-          generatePushId: () => 'p1386-stationary',
+          generatePushId: () => setup.pushId,
+        });
+        const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
+        return { stats, stored, apnsFetch };
+      }
+
+      it('motion=stationary → fallback advance 보류 + station-passed push X (카운터 누적)', async () => {
+        // 사용자 정지 trip — backend가 hop 시간만 보고 false station-passed를 발사하던 회귀 차단.
+        const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+        const { stats, stored } = await runFallbackMotionScenario({
+          motion: 'stationary',
+          hopElapsed: true,
+          pushId: 'p1386-stationary',
+          apnsFetch,
         });
         expect(stats.vanishFallbackMotionGateBlocked).toBe(1);
         expect(stats.vanishFallbackFired).toBe(0);
@@ -1648,7 +1672,6 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
           return body.data?.phase === 'imminent';
         });
         expect(stationPassedCalls.length).toBe(0);
-        const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
         // waypoint 유지 — advance 안 됨
         expect(stored.waypoints[0].stationName).toBe('중곡');
         expect(stored.boardingLock).toBeDefined();
@@ -1658,107 +1681,55 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
 
       it('motion=walking → fallback advance 진행 (waypoint shift)', async () => {
         // 사용자가 실제로 걷는 중 — hop 시간 경과 시 advance 허용.
-        const kv = new InMemoryKV();
-        await putTrip(
-          kv as unknown as KVNamespace,
-          makeLockTrip({
-            consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
-            lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
-          }),
-        );
-        await seedLocklessMotionSeries(kv, 'lock-tok', 'walking');
-        const stats = await runScheduled(makeEnv(kv), {
-          seoul: makeSeoulCombo([], []),
-          apnsConfig,
-          apnsHosts: APNS_HOSTS,
-          fetchImpl: makeOkFetch() as unknown as typeof fetch,
-          now: () => NOW,
-          generatePushId: () => 'p1386-walking',
+        const { stats, stored } = await runFallbackMotionScenario({
+          motion: 'walking',
+          hopElapsed: true,
+          pushId: 'p1386-walking',
         });
         expect(stats.vanishFallbackMotionGateBlocked).toBe(0);
         expect(stats.vanishFallbackFired).toBe(1);
-        const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
         expect(stored.waypoints[0].stationName).toBe('군자');
         expect(stored.consecutiveEtaMissing).toBe(0);
       });
 
       it('motion=automotive → fallback advance 진행 (waypoint shift)', async () => {
         // 사용자가 실제로 이동 중 — hop 시간 경과 시 advance 허용.
-        const kv = new InMemoryKV();
-        await putTrip(
-          kv as unknown as KVNamespace,
-          makeLockTrip({
-            consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
-            lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
-          }),
-        );
-        await seedLocklessMotionSeries(kv, 'lock-tok', 'automotive');
-        const stats = await runScheduled(makeEnv(kv), {
-          seoul: makeSeoulCombo([], []),
-          apnsConfig,
-          apnsHosts: APNS_HOSTS,
-          fetchImpl: makeOkFetch() as unknown as typeof fetch,
-          now: () => NOW,
-          generatePushId: () => 'p1386-auto',
+        const { stats, stored } = await runFallbackMotionScenario({
+          motion: 'automotive',
+          hopElapsed: true,
+          pushId: 'p1386-auto',
         });
         expect(stats.vanishFallbackMotionGateBlocked).toBe(0);
         expect(stats.vanishFallbackFired).toBe(1);
-        const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
         expect(stored.waypoints[0].stationName).toBe('군자');
       });
 
       it('motion=unknown (센서 미지원) → fallback advance 진행 (트레이드오프: lockless보다 약한 보수)', async () => {
         // 권한 거절/센서 미지원 사용자가 freeze되지 않도록 unknown은 기존 동작 유지.
         // positive stationary 신호가 있을 때만 게이트가 진입한다는 정책 점검.
-        const kv = new InMemoryKV();
-        await putTrip(
-          kv as unknown as KVNamespace,
-          makeLockTrip({
-            consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
-            lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
-          }),
-        );
-        await seedLocklessMotionSeries(kv, 'lock-tok', 'unknown');
-        const stats = await runScheduled(makeEnv(kv), {
-          seoul: makeSeoulCombo([], []),
-          apnsConfig,
-          apnsHosts: APNS_HOSTS,
-          fetchImpl: makeOkFetch() as unknown as typeof fetch,
-          now: () => NOW,
-          generatePushId: () => 'p1386-unknown',
+        const { stats, stored } = await runFallbackMotionScenario({
+          motion: 'unknown',
+          hopElapsed: true,
+          pushId: 'p1386-unknown',
         });
         expect(stats.vanishFallbackMotionGateBlocked).toBe(0);
         expect(stats.vanishFallbackFired).toBe(1);
-        const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
         expect(stored.waypoints[0].stationName).toBe('군자');
       });
 
       it('hop 시간 미경과 → motion 게이트 진입 전 (lock release 경로 유지)', async () => {
         // 게이트는 hopElapsed 분기 안에서만 평가 — 미경과면 motion=stationary여도 lock release.
         // #1370 L3 동작과 충돌하지 않음 점검.
-        const kv = new InMemoryKV();
-        await putTrip(
-          kv as unknown as KVNamespace,
-          makeLockTrip({
-            consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
-            lastTrackedArrivalEpoch: LAST_EPOCH_NOT_ELAPSED,
-            locklessStationPassed: false,
-          }),
-        );
-        await seedLocklessMotionSeries(kv, 'lock-tok', 'stationary');
-        const stats = await runScheduled(makeEnv(kv), {
-          seoul: makeSeoulCombo([], []),
-          apnsConfig,
-          apnsHosts: APNS_HOSTS,
-          fetchImpl: makeOkFetch() as unknown as typeof fetch,
-          now: () => NOW,
-          generatePushId: () => 'p1386-not-elapsed',
+        const { stats, stored } = await runFallbackMotionScenario({
+          motion: 'stationary',
+          hopElapsed: false,
+          pushId: 'p1386-not-elapsed',
+          tripOverrides: { locklessStationPassed: false },
         });
         // motion gate 미진입
         expect(stats.vanishFallbackMotionGateBlocked).toBe(0);
         // lock release + lockless takeover 경로 활성
         expect(stats.vanishLocklessTakeover).toBe(1);
-        const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
         expect(stored.boardingLock).toBeUndefined();
         expect(stored.locklessStationPassed).toBe(true);
       });

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -131,6 +131,35 @@ export const LOCKLESS_ADVANCE_MOTION_MODES: ReadonlySet<PositionPoint['motion']>
 ]);
 
 /**
+ * #1315 — lockless 경로 motion 게이트(엄격). positive 이동(walking/automotive)일 때만 advance 허용.
+ * stationary/unknown은 보류. 정적 false advance + 알림 레이스 차단이 1차 목표.
+ */
+export function isAdvanceAllowedByMotion(motion: PositionPoint['motion']): boolean {
+  return LOCKLESS_ADVANCE_MOTION_MODES.has(motion);
+}
+
+/**
+ * #1386 — lock-active vanish fallback advance(`handleEtaMissing` time-based) 전용 motion 게이트.
+ *
+ * lockless 경로(`isAdvanceAllowedByMotion`)는 엄격(walking/automotive만 허용)이지만, 이 분기는
+ * trip이 한 번이라도 정상 추적된 적이 있고(`lastTrackedArrivalEpoch !== undefined`) hop 시간을
+ * 채웠다는 약한 ground truth가 이미 있다. 그래서 보수의 결을 다르게 잡는다:
+ *
+ * - `stationary` (사용자가 명확히 정지 중) → 보류 (false positive 1차 방어).
+ * - `walking` / `automotive` (실제 이동) → 진행 (기존 동작).
+ * - `unknown` (센서 미지원/권한 거절/샘플 없음) → 진행 (기존 동작 유지, 사용자 가시성 트레이드오프).
+ *   `unknown`까지 보류하면 motion 신호 없는 다수 사용자의 trip이 무한 freeze에 가까워지므로
+ *   기존 hop-elapsed advance를 유지한다. positive stationary 신호가 있는 경우만 게이트 진입.
+ *
+ * 트레이드오프(이슈 #1386): `unknown` 중 실제 정지인 케이스는 못 잡는다 — 대신 false negative
+ * (정상 이동 trip을 잘못 동결)를 피한다. 사용자가 진짜 정지일 땐 device가 stationary로 송신하므로
+ * (`backgroundLocationTask.ts:150` / `useFgPositionUpload.ts`) 실측 신호 도달 시 게이트 발동.
+ */
+export function isFallbackAdvanceBlockedByMotion(motion: PositionPoint['motion']): boolean {
+  return motion === 'stationary';
+}
+
+/**
  * trip별 etaMissing 임계 결정. subsurface=true면 늘려 잡고, 그 외엔 기본값.
  * 클라가 매 register POST에 기압계 신호를 동봉하므로 한 trip 내에서 지상→지하 전이 시
  * threshold가 자연 갱신된다(stale 가능 윈도우는 다음 register 까지 ≤ ALARM_TIME_BUCKET_MS).
@@ -252,6 +281,14 @@ export interface ScheduledStats extends LiveActivityStats {
    * 토글 OFF였지만 vanish recovery로 매역 push가 복구된 trip 수.
    */
   vanishLocklessTakeover: number;
+  /**
+   * #1386 — lock-active fallback advance(handleEtaMissing time-based) 진입 시점에 device
+   * positionSeries의 motion이 실제 이동(walking/automotive)이 아니어서 advance + station-passed
+   * push를 보류한 누적 횟수. lockless 경로(`locklessMotionGateBlocked`)와 동일 정책의
+   * lock-active 버전 — 사용자가 정지 중인데 backend가 hop 시간 적분만으로 false station-passed를
+   * 발사하던 회귀(2026-06-16 용마산 정지 trip)를 차단한다.
+   */
+  vanishFallbackMotionGateBlocked: number;
 }
 
 /**
@@ -309,6 +346,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     arvlCdFireMismatch: 0,
     vanishFallbackFired: 0,
     vanishLocklessTakeover: 0,
+    vanishFallbackMotionGateBlocked: 0,
   };
 
   for await (const trip of listTrips(env.TRIPS)) {
@@ -1013,6 +1051,29 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
   if (nextMissCount >= fallbackTrigger && lastEpoch !== undefined) {
     const hopElapsed = now >= lastEpoch + FALLBACK_HOP_SEC * 1000;
     if (hopElapsed) {
+      // #1386 — hop 시간이 경과했더라도 device motion이 명확히 stationary면 advance 보류.
+      // 2026-06-16 용마산 정지 trip 회귀: 사용자가 정지 중인데 backend가 hop 시간만 보고 false
+      // station-passed를 발사. lockless 경로(#1315)는 stationary/unknown 모두 보류로 더 엄격이지만,
+      // lock-active fallback은 한 번이라도 정상 추적된 trip이라 unknown(센서 미지원/권한 거절)을
+      // 보류하면 다수 사용자가 freeze. `stationary` 신호가 있을 때만 게이트 진입(이슈 #1386).
+      // 카운터(consecutiveEtaMissing)는 누적 유지 — motion이 회복되면 다음 cycle에서 정상 advance,
+      // 회복 안 되면 기존 auto-end 임계(`resolveEtaMissingThreshold`) 경로가 종료를 보장한다.
+      const positionSeries = await readSeries(env.TRIPS, trip.token);
+      const fallbackMotion = evaluateWindow(positionSeries, now).motion;
+      if (isFallbackAdvanceBlockedByMotion(fallbackMotion)) {
+        stats.vanishFallbackMotionGateBlocked += 1;
+        log('boarding-lock: vanish fallback motion gate blocked (not moving)', {
+          token: trip.token.slice(0, 8),
+          trainCode: activeLock.trainCode,
+          station: waypoint.stationName,
+          consecutiveEtaMissing: nextMissCount,
+          lastTrackedArrivalEpoch: lastEpoch,
+          motion: fallbackMotion,
+        });
+        trip.consecutiveEtaMissing = nextMissCount;
+        await putTrip(env.TRIPS, trip);
+        return;
+      }
       // hop 시간 경과 → optimistic waypoint advance.
       // advance 내부에서 destination 도착이면 cleanupTripWithLa, 그 외엔 waypoints.shift().
       log('boarding-lock: trainCode vanished — time-based waypoint advance fallback', {
@@ -1021,6 +1082,7 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
         station: waypoint.stationName,
         consecutiveEtaMissing: nextMissCount,
         lastTrackedArrivalEpoch: lastEpoch,
+        motion: fallbackMotion,
       });
       trip.consecutiveEtaMissing = 0;
       // #1370 L2 — fallback advance 전에 station-passed silent push를 발사한다.
@@ -1645,7 +1707,8 @@ export async function runLocklessIntermediate(
   // 역의 "아무 열차" 신호라 *사용자 열차*가 통과했다는 ground truth가 아니다. GPS motion이 실제
   // 이동(walking/automotive)을 positive하게 보일 때만 advance를 허용 — 정적/저신뢰(stationary/
   // unknown, 샘플 없음 포함)는 보류해 false positive(정적 false advance + 알림 레이스)를 차단한다.
-  if (!LOCKLESS_ADVANCE_MOTION_MODES.has(fusion.posMetrics.motion)) {
+  // #1386 — lock-active vanish fallback도 같은 헬퍼(`isAdvanceAllowedByMotion`)를 공유한다.
+  if (!isAdvanceAllowedByMotion(fusion.posMetrics.motion)) {
     stats.locklessMotionGateBlocked += 1;
     log('lockless: motion gate blocked (no trainCode, not moving)', {
       token: trip.token.slice(0, 8),


### PR DESCRIPTION
Closes #1386

## RCA

`backend/alarm-worker/src/scheduled.ts` `handleEtaMissing` time-based fallback이 device motion을 검사하지 않고 hop 시간만 보고 `advanceBoardingLockWaypoint` + `fireVanishFallbackStationPush`를 호출해, 사용자가 정지(`motion=stationary`) 중인 trip에 false station-passed silent push를 발사하던 회귀(2026-06-16 용마산 정지 trip evidence).

비교: 같은 파일 `runLocklessIntermediate` 경로는 `LOCKLESS_ADVANCE_MOTION_MODES`로 motion 가드가 있었으나, lock-active fallback 경로에는 동등 가드 없음.

## Fix

1. **`isAdvanceAllowedByMotion(motion)`** 헬퍼 추출 — 기존 lockless 게이트(walking/automotive만 허용)를 함수로 일반화. lockless 호출부 `LOCKLESS_ADVANCE_MOTION_MODES.has(...)` → `isAdvanceAllowedByMotion(...)`로 swap (semantics 동일).
2. **`isFallbackAdvanceBlockedByMotion(motion)`** 신규 — lock-active fallback 전용. `motion === 'stationary'` 일 때만 보류.
   - lockless는 stationary/unknown 모두 보류(엄격)이지만, fallback 분기는 trip이 한 번이라도 정상 추적된 적이 있어(`lastTrackedArrivalEpoch !== undefined`) 약한 ground truth가 있으므로 unknown은 허용 — 다수 사용자 freeze 회피 (이슈 #1386 정책).
3. **`handleEtaMissing` hopElapsed 분기**에 게이트 추가:
   - `readSeries(env.TRIPS, trip.token)` + `evaluateWindow(...).motion`으로 device 송신 latest motion 판정.
   - `stationary` 일 시 `stats.vanishFallbackMotionGateBlocked += 1`, `consecutiveEtaMissing` 누적 유지(`= nextMissCount`), `putTrip` 저장 후 early return.
   - motion 회복 시 다음 cycle에서 정상 advance, 회복 안 되면 기존 auto-end 임계(`resolveEtaMissingThreshold`) 경로가 종료 보장.
4. **신규 stat field** `ScheduledStats.vanishFallbackMotionGateBlocked` — 운영 측정 인프라.

## Acceptance 자동화 (PR 머지 게이트)

- [x] `npm run type-check` pass (tsc --noEmit clean).
- [x] `npm test` pass — 기존 1353 → 1358 (5 신규 케이스).
  - motion=stationary → fallback advance 보류 + 카운터 누적 + station-passed push 0건
  - motion=walking → fallback advance 진행 (waypoint shift)
  - motion=automotive → fallback advance 진행
  - motion=unknown (센서 미지원) → fallback advance 진행 (트레이드오프 명시)
  - hop 시간 미경과 → motion 게이트 진입 전, lock release 경로 유지 (#1370 L3 충돌 없음)
- [x] 기존 #1277 fallback 테스트(`subsurface trip도 advance`, `시간 경과 advance`, `#1370 L2 L3` 등)는 series 미시드(unknown) → 기존 동작 유지하므로 그대로 pass.

## 운영 검증 (close 게이트, 1주)

- [ ] 정지 상태 trip에서 false station-passed silent push 0건 (production tail `vanishFallbackFired` vs `vanishFallbackMotionGateBlocked` 비율 모니터링).
- [ ] 실제 이동 trip에서 fallback advance miss 회귀 0건 (trip 완료율 유지).
- [ ] hop time 가드 + motion 가드 동시 평가 — 한 쪽만 미적용 시나리오 없음.

## Refs

- 비교 코드: `scheduled.ts` lockless motion gate (#1315).
- 관련 fix: #1382 (frontend lock-interp motion guard, PR #1384) — 둘 결합으로 정지 trip false station-passed 발사 완전 차단.
- 도입 PR: #1370 L2 (`fireVanishFallbackStationPush`).

## 트레이드오프 (FLAG)

`motion=unknown` 케이스에서 실제 정지 사용자(센서 권한 거절)는 못 잡는다 — 정상 이동 trip false negative(잘못된 동결)를 피하기 위해. 이슈 #1386 정책 결정. frontend가 motion 송신을 누락하지 않는 한 stationary는 정확히 차단 (`backgroundLocationTask.ts:150`, `useFgPositionUpload.ts`).