### PR TITLE
feat(#1389): backend inline 정합성 게이트 (5 사이트)

### DIFF
--- a/backend/alarm-worker/src/__tests__/pushConsistencyContext.test.ts
+++ b/backend/alarm-worker/src/__tests__/pushConsistencyContext.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import type { BoardingLockMeta, PositionPoint } from '../types';
+import {
+  buildPushConsistencyContextFromSeries,
+  computeDeviceHopsBehindTarget,
+  extractDeviceSignal,
+} from '../pushConsistencyContext';
+
+const NOW = 1_750_000_000_000;
+
+const mkPoint = (overrides: Partial<PositionPoint> = {}): PositionPoint => ({
+  lat: 0,
+  lng: 0,
+  accuracy: 10,
+  ts: NOW,
+  motion: 'walking',
+  ...overrides,
+});
+
+describe('extractDeviceSignal (#1389)', () => {
+  it('빈 시리즈는 motion=unknown / currentStationName=null / lastUpdateMs=0', () => {
+    const signal = extractDeviceSignal([], NOW);
+    expect(signal).toEqual({
+      currentStationName: null,
+      motion: 'unknown',
+      wifiStation: null,
+      lastUpdateMs: 0,
+    });
+  });
+
+  it('가장 최근 sample의 motion + lastUpdateMs를 사용 (motion=automotive, ts=NOW)', () => {
+    const series: PositionPoint[] = [
+      mkPoint({ ts: NOW - 60_000, motion: 'walking' }),
+      mkPoint({ ts: NOW - 30_000, motion: 'automotive' }),
+      mkPoint({ ts: NOW, motion: 'automotive' }),
+    ];
+    const signal = extractDeviceSignal(series, NOW);
+    // motion은 evaluateWindow 최빈값. 최근 3개 중 automotive 2건 → automotive.
+    expect(signal.motion).toBe('automotive');
+    expect(signal.lastUpdateMs).toBe(NOW);
+    expect(signal.wifiStation).toBeNull();
+  });
+
+  it('currentStationName: 가장 최근 stamp부터 backward backfill', () => {
+    const series: PositionPoint[] = [
+      mkPoint({ ts: NOW - 60_000, currentStationName: '용마산' }),
+      mkPoint({ ts: NOW - 30_000 }), // stamp 없음
+      mkPoint({ ts: NOW }), // stamp 없음
+    ];
+    const signal = extractDeviceSignal(series, NOW);
+    expect(signal.currentStationName).toBe('용마산');
+  });
+
+  it('가장 최근 sample에 currentStationName이 있으면 그 값을 사용', () => {
+    const series: PositionPoint[] = [
+      mkPoint({ ts: NOW - 60_000, currentStationName: '용마산' }),
+      mkPoint({ ts: NOW, currentStationName: '중곡' }),
+    ];
+    const signal = extractDeviceSignal(series, NOW);
+    expect(signal.currentStationName).toBe('중곡');
+  });
+
+  it('stamp가 한 번도 없으면 currentStationName=null (게이트 #4/§5 허용 fallback)', () => {
+    const series: PositionPoint[] = [
+      mkPoint({ ts: NOW - 30_000, motion: 'stationary' }),
+      mkPoint({ ts: NOW, motion: 'stationary' }),
+    ];
+    const signal = extractDeviceSignal(series, NOW);
+    expect(signal.currentStationName).toBeNull();
+    expect(signal.motion).toBe('stationary');
+  });
+
+  it('빈 string은 stamp 없음으로 처리 (graceful)', () => {
+    const series: PositionPoint[] = [
+      mkPoint({ ts: NOW - 30_000, currentStationName: '' }),
+      mkPoint({ ts: NOW }),
+    ];
+    const signal = extractDeviceSignal(series, NOW);
+    expect(signal.currentStationName).toBeNull();
+  });
+});
+
+describe('computeDeviceHopsBehindTarget (#1389)', () => {
+  const lock: Pick<BoardingLockMeta, 'segmentStations'> = {
+    segmentStations: ['용마산', '중곡', '군자', '어린이대공원'],
+  };
+
+  it('device == target → 0', () => {
+    const hops = computeDeviceHopsBehindTarget(
+      lock,
+      { stationName: '중곡', line: '7' },
+      '중곡',
+    );
+    expect(hops).toBe(0);
+  });
+
+  it('device 1 hop behind target → 1', () => {
+    const hops = computeDeviceHopsBehindTarget(
+      lock,
+      { stationName: '중곡', line: '7' },
+      '용마산',
+    );
+    expect(hops).toBe(1);
+  });
+
+  it('device 2 hops behind target → 2', () => {
+    const hops = computeDeviceHopsBehindTarget(
+      lock,
+      { stationName: '군자', line: '7' },
+      '용마산',
+    );
+    expect(hops).toBe(2);
+  });
+
+  it('device ahead of target → 음수 (-1)', () => {
+    const hops = computeDeviceHopsBehindTarget(
+      lock,
+      { stationName: '용마산', line: '7' },
+      '중곡',
+    );
+    expect(hops).toBe(-1);
+  });
+
+  it('lock 부재 → null (fallback)', () => {
+    const hops = computeDeviceHopsBehindTarget(
+      undefined,
+      { stationName: '중곡', line: '7' },
+      '용마산',
+    );
+    expect(hops).toBeNull();
+  });
+
+  it('currentStationName=null → null (산출 불가)', () => {
+    const hops = computeDeviceHopsBehindTarget(
+      lock,
+      { stationName: '중곡', line: '7' },
+      null,
+    );
+    expect(hops).toBeNull();
+  });
+
+  it('device가 segmentStations에 없으면 → null', () => {
+    const hops = computeDeviceHopsBehindTarget(
+      lock,
+      { stationName: '중곡', line: '7' },
+      '강남',
+    );
+    expect(hops).toBeNull();
+  });
+
+  it('target이 segmentStations에 없으면 → null', () => {
+    const hops = computeDeviceHopsBehindTarget(
+      lock,
+      { stationName: '강남', line: '2' },
+      '용마산',
+    );
+    expect(hops).toBeNull();
+  });
+});
+
+describe('buildPushConsistencyContextFromSeries (#1389)', () => {
+  const lock: Pick<BoardingLockMeta, 'segmentStations'> = {
+    segmentStations: ['용마산', '중곡', '군자'],
+  };
+
+  it('정지 trip + device 1 hop behind → motion=stationary + hops=1', () => {
+    const series: PositionPoint[] = [
+      mkPoint({ ts: NOW - 40_000, motion: 'stationary', currentStationName: '용마산' }),
+      mkPoint({ ts: NOW - 20_000, motion: 'stationary', currentStationName: '용마산' }),
+      mkPoint({ ts: NOW, motion: 'stationary', currentStationName: '용마산' }),
+    ];
+    const ctx = buildPushConsistencyContextFromSeries(
+      series,
+      lock,
+      { stationName: '중곡', line: '7' },
+      NOW,
+    );
+    expect(ctx.device.motion).toBe('stationary');
+    expect(ctx.device.currentStationName).toBe('용마산');
+    expect(ctx.trip.deviceHopsBehindTarget).toBe(1);
+  });
+
+  it('lock 부재 → hops=null (lockless 경로)', () => {
+    const series: PositionPoint[] = [
+      mkPoint({ ts: NOW, motion: 'walking', currentStationName: '용마산' }),
+    ];
+    const ctx = buildPushConsistencyContextFromSeries(
+      series,
+      undefined,
+      { stationName: '중곡', line: '7' },
+      NOW,
+    );
+    expect(ctx.trip.deviceHopsBehindTarget).toBeNull();
+    expect(ctx.device.currentStationName).toBe('용마산');
+  });
+});

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -17,6 +17,7 @@ import {
   estimateArrivalFromPosition,
   estimateBoardingLockArrival,
   evaluateArvlCdFireGate,
+  evaluatePushConsistencyForSite,
   flipApnsEnv,
   maybeCountDrift,
   pickActiveWaypoint,
@@ -4730,5 +4731,496 @@ describe('#1363 — pickLatestCurrentStationName (log 진단 이원화 helper)',
       { ...base, ts: 3000 },
     ];
     expect(pickLatestCurrentStationName(series)).toBe('용마산');
+  });
+});
+
+/**
+ * #1389 — backend 발사 사이트(arvlCd / vanish-fallback / reschedule / lockless-intermediate /
+ * boarding-prompt) 통합 정합성 게이트 (PR-2).
+ *
+ * 각 사이트별로 (a) 정합성 위반 시 push 발사 0건 + 카운터 증가, (b) 정상 trip 회귀 0건을 검증.
+ *
+ * 정합성 위반 시드 패턴:
+ *   - positionSeries: motion='stationary' + currentStationName='용마산' (target='중곡'으로 1 hop behind)
+ *   - lock.segmentStations=['용마산', '중곡', '군자'] → device 1 hop behind target
+ *   - 결과: reason='motion-stationary-far-behind' 차단
+ *
+ * 정상 trip 시드 패턴:
+ *   - positionSeries: motion='automotive' + currentStationName='중곡' (target='중곡' 일치)
+ *   - 결과: allowed → 기존 fire path 회귀 0건
+ */
+describe('runScheduled — #1389 push consistency gate (5 fire sites)', () => {
+  // segmentStations 공용 — 용마산→중곡→군자 leg.
+  const SEG = ['용마산', '중곡', '군자'];
+
+  /** target=중곡 기준 1 hop behind + stationary 시드 (정합성 위반 케이스). */
+  async function seedStationaryBehindSeries(kv: InMemoryKV, token: string): Promise<void> {
+    const series: PositionPoint[] = [
+      { lat: 0, lng: 0, accuracy: 10, ts: NOW - 40_000, motion: 'stationary', currentStationName: '용마산' },
+      { lat: 0, lng: 0, accuracy: 10, ts: NOW - 20_000, motion: 'stationary', currentStationName: '용마산' },
+      { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion: 'stationary', currentStationName: '용마산' },
+    ];
+    await kv.put(`pos:${token}`, JSON.stringify(series));
+  }
+
+  /** target=중곡 기준 device==target + automotive 시드 (정상 trip 케이스). */
+  async function seedMovingAtTargetSeries(kv: InMemoryKV, token: string): Promise<void> {
+    const series: PositionPoint[] = [
+      { lat: 0, lng: 0, accuracy: 10, ts: NOW - 40_000, motion: 'automotive', currentStationName: '중곡' },
+      { lat: 0, lng: 0, accuracy: 10, ts: NOW - 20_000, motion: 'automotive', currentStationName: '중곡' },
+      { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion: 'automotive', currentStationName: '중곡' },
+    ];
+    await kv.put(`pos:${token}`, JSON.stringify(series));
+  }
+
+  /** 7호선 용마산→중곡→군자 leg + arvlCd lock fixture. */
+  function makeArvlFireTrip(): Trip {
+    return makeLockTripFixture('cons-arvl-tok', {
+      boardingLock: makeBoardingLock({ segmentStations: SEG }),
+    });
+  }
+
+  describe('Site 1: arvlCd fire', () => {
+    it('정합성 위반(motion=stationary, device 1 hop behind) → push 0건 + pushConsistencyBlocked++', async () => {
+      const trip = makeArvlFireTrip();
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, trip);
+      await seedStationaryBehindSeries(kv, trip.token);
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeArvlCdFireSeoul('중곡', 0, 1),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p-cons-arvl-blocked',
+      });
+      expect(stats.arvlCdFireSuccess).toBe(0);
+      expect(stats.pushConsistencyBlocked).toBeGreaterThanOrEqual(1);
+      expect(stats.pushConsistencyBlockedByReason['motion-stationary-far-behind']).toBeGreaterThanOrEqual(1);
+      expect(getArvlCdStationPassedCalls(apnsFetch)).toHaveLength(0);
+      // dedup KV stamp 없음 — 다음 cycle 재시도 허용.
+      expect(await kv.get(arvlCdFireKey('cons-arvl-tok', '7246', '중곡', 1))).toBeNull();
+    });
+
+    it('정상 trip(motion=automotive, device==target) → 발사 1건 (회귀 0건)', async () => {
+      const trip = makeArvlFireTrip();
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, trip);
+      await seedMovingAtTargetSeries(kv, trip.token);
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeArvlCdFireSeoul('중곡', 0, 1),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p-cons-arvl-ok',
+      });
+      expect(stats.arvlCdFireSuccess).toBe(1);
+      expect(stats.pushConsistencyBlocked).toBe(0);
+      expect(getArvlCdStationPassedCalls(apnsFetch)).toHaveLength(1);
+    });
+  });
+
+  describe('Site 2: vanish-fallback fire', () => {
+    /**
+     * #1370 L2 fallback advance를 트리거: lastTrackedArrivalEpoch + FALLBACK_HOP_SEC 경과 + Seoul arrivals 빈 응답
+     * + consecutiveEtaMissing이 fallbackTrigger 도달.
+     */
+    function makeVanishTrip(consecutiveMissOverride?: number): Trip {
+      const fallbackTrigger = VANISH_RE_ATTACH_THRESHOLD + FALLBACK_ADVANCE_GRACE_CYCLES;
+      return makeLockTripFixture('cons-vanish-tok', {
+        boardingLock: makeBoardingLock({ segmentStations: SEG }),
+        lastTrackedArrivalEpoch: NOW - (FALLBACK_HOP_SEC + 10) * 1000,
+        consecutiveEtaMissing: consecutiveMissOverride ?? fallbackTrigger - 1,
+      });
+    }
+
+    function emptyArrivalsSeoul(): SeoulArrivalClient {
+      return new SeoulArrivalClient({
+        apiKey: 'K',
+        host: 'h',
+        now: () => NOW,
+        fetchImpl: (async () =>
+          new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 })) as unknown as typeof fetch,
+      });
+    }
+
+    it('정합성 위반(stationary 가드 이미 #1386이 차단) → 정합성 게이트 진입 전 motion 가드가 먼저 막음', async () => {
+      // 이 케이스는 #1386 motion 가드가 fire 함수 진입 전(handleEtaMissing 안)에서 advance를 막으므로
+      // 정합성 게이트는 호출되지 않는다. vanishFallbackMotionGateBlocked가 증가하는 것이 정상.
+      const trip = makeVanishTrip();
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, trip);
+      await seedStationaryBehindSeries(kv, trip.token);
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: emptyArrivalsSeoul(),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      expect(stats.vanishFallbackFired).toBe(0);
+      expect(stats.vanishFallbackMotionGateBlocked).toBeGreaterThanOrEqual(1);
+      expect(getArvlCdStationPassedCalls(apnsFetch)).toHaveLength(0);
+    });
+
+    it('정합성 게이트 §10 차단(motion=automotive + device 2 hops behind target) → vanish-fallback fire 0건 + pushConsistencyBlocked++', async () => {
+      // device=용마산, target=군자 → hops=2. motion=automotive로 #1386 motion 가드 통과,
+      // 정합성 게이트 §10(hops>=2 device-station-mismatch) 차단.
+      const segLong = ['용마산', '중곡', '군자', '어린이대공원'];
+      const trip = makeLockTripFixture('cons-vanish-mismatch', {
+        boardingLock: makeBoardingLock({ segmentStations: segLong }),
+        lastTrackedArrivalEpoch: NOW - (FALLBACK_HOP_SEC + 10) * 1000,
+        consecutiveEtaMissing: VANISH_RE_ATTACH_THRESHOLD + FALLBACK_ADVANCE_GRACE_CYCLES - 1,
+        waypoints: [
+          // target=군자(intermediate) — fire 호출 가능. destination kind는 호출 전 분기 차단.
+          { stationName: '군자', line: '7', kind: 'intermediate' },
+          { stationName: '어린이대공원', line: '7', kind: 'destination' },
+        ],
+      });
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, trip);
+      const series: PositionPoint[] = [
+        { lat: 0, lng: 0, accuracy: 10, ts: NOW - 40_000, motion: 'automotive', currentStationName: '용마산' },
+        { lat: 0, lng: 0, accuracy: 10, ts: NOW - 20_000, motion: 'automotive', currentStationName: '용마산' },
+        { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion: 'automotive', currentStationName: '용마산' },
+      ];
+      await kv.put(`pos:${trip.token}`, JSON.stringify(series));
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: emptyArrivalsSeoul(),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      expect(stats.vanishFallbackFired).toBe(0);
+      expect(stats.pushConsistencyBlocked).toBeGreaterThanOrEqual(1);
+      expect(stats.pushConsistencyBlockedByReason['device-station-mismatch']).toBeGreaterThanOrEqual(1);
+    });
+
+    it('회귀 0건(motion=unknown + hops=1) — 정합성 게이트 §9 allow → vanish-fallback fire 발사 정상', async () => {
+      // motion=unknown은 #1386 가드 통과 + 정합성 게이트 §9 (hops==1 && motion!=stationary) allow.
+      // 즉 옳은 trip의 fallback advance가 차단되지 않음을 보장.
+      const trip = makeLockTripFixture('cons-vanish-ok', {
+        boardingLock: makeBoardingLock({ segmentStations: SEG }),
+        lastTrackedArrivalEpoch: NOW - (FALLBACK_HOP_SEC + 10) * 1000,
+        consecutiveEtaMissing: VANISH_RE_ATTACH_THRESHOLD + FALLBACK_ADVANCE_GRACE_CYCLES - 1,
+        waypoints: [
+          { stationName: '중곡', line: '7', kind: 'intermediate' },
+          { stationName: '군자', line: '7', kind: 'destination' },
+        ],
+      });
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, trip);
+      const series: PositionPoint[] = [
+        { lat: 0, lng: 0, accuracy: 10, ts: NOW - 40_000, motion: 'unknown', currentStationName: '용마산' },
+        { lat: 0, lng: 0, accuracy: 10, ts: NOW - 20_000, motion: 'unknown', currentStationName: '용마산' },
+        { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion: 'unknown', currentStationName: '용마산' },
+      ];
+      await kv.put(`pos:${trip.token}`, JSON.stringify(series));
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: emptyArrivalsSeoul(),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      expect(stats.vanishFallbackFired).toBe(1);
+      // 정합성 게이트는 합법적인 advance를 차단하지 않음 (회귀 0건 보장).
+      expect(stats.pushConsistencyBlocked).toBe(0);
+    });
+  });
+
+  describe('Site 3: reschedule push', () => {
+    it('정합성 위반(motion=stationary, device 1 hop behind) → reschedule push 0건 + 카운터 증가', async () => {
+      const trip = makeLockTripFixture('cons-resched-tok', {
+        boardingLock: makeBoardingLock({ segmentStations: SEG }),
+        lastTrackedArrivalEpoch: NOW + 120 * 1000, // 임계 초과 변동 보장 baseline
+      });
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, trip);
+      await seedStationaryBehindSeries(kv, trip.token);
+      // arvlCd=null + arrival 30s — estimate.arrived=false 경로 → maybeReschedulePush 호출.
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeArvlCdFireSeoul('중곡', 30, null),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      expect(stats.pushConsistencyBlocked).toBeGreaterThanOrEqual(1);
+      // reschedule push 발사 0건. 다른 경로 push(LA 등)는 통과될 수 있으므로 전체 pushed가 아닌 reschedule 직접 검증은 어려움 —
+      // 대신 정합성 차단 reason 검증으로 차단을 확정.
+      expect(stats.pushConsistencyBlockedByReason['motion-stationary-far-behind']).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('Site 4: lockless-intermediate fire', () => {
+    it('정합성 위반(WiFi mismatch + stationary 합성) → 차단', async () => {
+      // lockless 경로는 lock=undefined → hops=null → 기본 fallback 허용. 그러나 motion 가드 자체가 stationary 차단.
+      // 본 사이트의 정합성 게이트 보강은 주로 'WiFi mismatch' 보강 — 본 PR에서 WiFi는 항상 null이라
+      // 본 테스트는 motion 가드가 lockless 경로에서도 정합성 차단을 작동시키는지 확인하는 형태.
+      const trip = makeTrip({
+        token: 'cons-lockless-tok',
+        waypoints: [
+          { stationName: '강남', line: '2', kind: 'intermediate' },
+          { stationName: '역삼', line: '2', kind: 'destination' },
+        ],
+        locklessStationPassed: true,
+      });
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, trip);
+      // 사용자가 강남 1 hop 전(currentStationName='용마산') + stationary — motion 가드가 먼저 차단.
+      // 본 테스트는 회귀 0건 확인(차단되어 발사가 일어나지 않음).
+      const series: PositionPoint[] = [
+        { lat: 0, lng: 0, accuracy: 10, ts: NOW - 40_000, motion: 'stationary', currentStationName: '용마산' },
+        { lat: 0, lng: 0, accuracy: 10, ts: NOW - 20_000, motion: 'stationary', currentStationName: '용마산' },
+        { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion: 'stationary', currentStationName: '용마산' },
+      ];
+      await kv.put(`pos:${trip.token}`, JSON.stringify(series));
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeSeoul([
+          {
+            destination: '강남행',
+            arrivalSeconds: 30,
+            trainCode: '7246',
+            isUp: true,
+            subwayNm: '지하철2호선',
+            arvlCd: 1,
+          },
+        ]),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      // motion 가드가 stationary를 먼저 차단 → 정합성 게이트는 호출 안 됨.
+      // (lockless 경로의 정합성 게이트는 lock=undefined → hops=null fallback이라 본 시나리오는 motion만 활성)
+      expect(stats.locklessIntermediateFired).toBe(0);
+      expect(stats.locklessMotionGateBlocked).toBeGreaterThanOrEqual(1);
+      expect(stats.pushConsistencyBlocked).toBe(0);
+    });
+  });
+
+  describe('Site 5: boarding-prompt fire', () => {
+    // 9단 게이트 happy path(seedHappyGateSeries)는 origin=(0,0), motion=automotive로 시드되어 있어
+    // 정합성 게이트의 currentStationName이 부재(seed에 미스탬프). currentStationName=null + motion=automotive
+    // → 정합성 게이트 #4(모든 신호 null이 아님 — motion!=unknown) 통과 후 hops=null → §5 fallback allow.
+    // 따라서 happy path는 회귀 0건 (정합성 게이트가 발사를 막지 않음).
+    it('happy 9단 게이트 통과 trip → 정합성 게이트 통과 + boardingPromptFired 회귀 0건', async () => {
+      const kv = new InMemoryKV();
+      const trip = makePromptTrip();
+      await putTrip(kv as unknown as KVNamespace, trip);
+      await seedHappyGateSeries(kv, trip.token);
+      // attemptAutoLock이 사용하는 arrivals — 빈 응답으로 auto-lock 실패시켜 prompt fallback 경로 진입.
+      const seoul = new SeoulArrivalClient({
+        apiKey: 'K',
+        host: 'h',
+        now: () => NOW,
+        fetchImpl: (async () =>
+          new Response(JSON.stringify({ realtimeArrivalList: [] }), {
+            status: 200,
+          })) as unknown as typeof fetch,
+      });
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul,
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      // happy path에서 정합성 게이트가 prompt를 차단하지 않음.
+      expect(stats.pushConsistencyBlocked).toBe(0);
+    });
+  });
+
+  it('ScheduledStats 초기값 — pushConsistencyBlocked=0, reason 4개 모두 0', async () => {
+    const kv = new InMemoryKV();
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.pushConsistencyBlocked).toBe(0);
+    expect(stats.pushConsistencyBlockedByReason).toEqual({
+      'wifi-mismatch': 0,
+      'motion-stationary-far-behind': 0,
+      'device-station-mismatch': 0,
+      'device-ahead-of-target': 0,
+    });
+  });
+});
+
+/**
+ * #1389 — evaluatePushConsistencyForSite (사이트 공통 wrapper) unit test.
+ *
+ * 각 fire site는 본 wrapper를 호출해 stats 카운터 누적 + log 발사를 통일한다.
+ * runScheduled integration 테스트로 cover하기 어려운 edge(extraLog override 방어,
+ * lock=undefined 경로, allow 경로 무카운트) 검증.
+ */
+describe('evaluatePushConsistencyForSite (#1389 wrapper)', () => {
+  function makeStats(): ScheduledStats {
+    return {
+      scanned: 0,
+      polled: 0,
+      pushed: 0,
+      errors: 0,
+      etaMissing: 0,
+      envCorrected: 0,
+      lockMissing: 0,
+      locklessIntermediateFired: 0,
+      locklessMotionGateBlocked: 0,
+      laPushSent: 0,
+      laPushFailed: 0,
+      laTokenCleared: 0,
+      boardingPromptEvaluated: 0,
+      boardingPromptFired: 0,
+      boardingPromptBlocked: 0,
+      phaseImminentBlocked: 0,
+      kalmanReset: 0,
+      kalmanDriftWarning: 0,
+      autoLockSuccess: 0,
+      autoLockFalsePositive: 0,
+      boardingPromptAutoDeduped: 0,
+      arvlCdFireSuccess: 0,
+      arvlCdFireDedup: 0,
+      arvlCdFireMismatch: 0,
+      vanishFallbackFired: 0,
+      vanishLocklessTakeover: 0,
+      vanishFallbackMotionGateBlocked: 0,
+      pushConsistencyBlocked: 0,
+      pushConsistencyBlockedByReason: {
+        'wifi-mismatch': 0,
+        'motion-stationary-far-behind': 0,
+        'device-station-mismatch': 0,
+        'device-ahead-of-target': 0,
+      },
+    };
+  }
+
+  const target = { stationName: '중곡', line: '7' };
+  const lock = { segmentStations: ['용마산', '중곡', '군자', '어린이대공원'] };
+
+  it('차단(motion=stationary + hops=1) → result.allowed=false + stats 누적 + log 발사', () => {
+    const stats = makeStats();
+    const logs: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const log = (msg: string, meta?: Record<string, unknown>) => {
+      logs.push({ msg, meta });
+    };
+    const series: PositionPoint[] = [
+      { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion: 'stationary', currentStationName: '용마산' },
+    ];
+    const result = evaluatePushConsistencyForSite({
+      siteName: 'test-site',
+      trip: { token: 'wrap-tok-aaaaaaaa' },
+      lock,
+      target,
+      series,
+      stats,
+      now: NOW,
+      log,
+    });
+    expect(result.allowed).toBe(false);
+    if (result.allowed === false) {
+      expect(result.reason).toBe('motion-stationary-far-behind');
+    }
+    expect(stats.pushConsistencyBlocked).toBe(1);
+    expect(stats.pushConsistencyBlockedByReason['motion-stationary-far-behind']).toBe(1);
+    expect(logs).toHaveLength(1);
+    expect(logs[0].msg).toBe('push-consistency: blocked');
+    expect(logs[0].meta).toMatchObject({
+      site: 'test-site',
+      reason: 'motion-stationary-far-behind',
+      token: 'wrap-tok',
+      target,
+    });
+  });
+
+  it('허용(motion=automotive + hops=0) → result.allowed=true + 카운터/log 무변동', () => {
+    const stats = makeStats();
+    const logs: Array<{ msg: string }> = [];
+    const log = (msg: string) => {
+      logs.push({ msg });
+    };
+    const series: PositionPoint[] = [
+      { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion: 'automotive', currentStationName: '중곡' },
+    ];
+    const result = evaluatePushConsistencyForSite({
+      siteName: 'test-site',
+      trip: { token: 'wrap-tok-allow' },
+      lock,
+      target,
+      series,
+      stats,
+      now: NOW,
+      log,
+    });
+    expect(result.allowed).toBe(true);
+    expect(stats.pushConsistencyBlocked).toBe(0);
+    expect(stats.pushConsistencyBlockedByReason['motion-stationary-far-behind']).toBe(0);
+    expect(logs).toHaveLength(0);
+  });
+
+  it('extraLog override 방어 — 호출자가 site/reason/token 키를 넣어도 wrapper 기본 값이 우선', () => {
+    const stats = makeStats();
+    const logs: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const log = (msg: string, meta?: Record<string, unknown>) => {
+      logs.push({ msg, meta });
+    };
+    const series: PositionPoint[] = [
+      { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion: 'stationary', currentStationName: '용마산' },
+    ];
+    evaluatePushConsistencyForSite({
+      siteName: 'test-site',
+      trip: { token: 'wrap-tok-override' },
+      lock,
+      target,
+      series,
+      stats,
+      now: NOW,
+      log,
+      extraLog: {
+        site: 'EVIL-OVERRIDE',
+        reason: 'EVIL-REASON',
+        token: 'EVIL-TOKEN',
+        customField: 'preserved',
+      },
+    });
+    expect(logs[0].meta).toMatchObject({
+      site: 'test-site', // 호출자 override 무시
+      reason: 'motion-stationary-far-behind',
+      token: 'wrap-tok',
+      customField: 'preserved', // 충돌하지 않는 키는 보존
+    });
+  });
+
+  it('lock=undefined → hops=null fallback → §5 allow (lockless 경로 회귀 0건)', () => {
+    const stats = makeStats();
+    const log = () => undefined;
+    const series: PositionPoint[] = [
+      { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion: 'walking', currentStationName: '강남' },
+    ];
+    const result = evaluatePushConsistencyForSite({
+      siteName: 'lockless-test',
+      trip: { token: 'no-lock' },
+      lock: undefined,
+      target,
+      series,
+      stats,
+      now: NOW,
+      log,
+    });
+    expect(result.allowed).toBe(true);
+    expect(stats.pushConsistencyBlocked).toBe(0);
   });
 });

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -4749,37 +4749,61 @@ describe('#1363 — pickLatestCurrentStationName (log 진단 이원화 helper)',
  *   - positionSeries: motion='automotive' + currentStationName='중곡' (target='중곡' 일치)
  *   - 결과: allowed → 기존 fire path 회귀 0건
  */
+
+// #1389 — describe 외부의 file-scope helpers (SonarCloud: avoid nested function declarations).
+const CONSISTENCY_SEG = ['용마산', '중곡', '군자'];
+
+/** target=중곡 기준 1 hop behind + stationary 시드 (정합성 위반 케이스). */
+async function seedStationaryBehindSeries(kv: InMemoryKV, token: string): Promise<void> {
+  const series: PositionPoint[] = [
+    { lat: 0, lng: 0, accuracy: 10, ts: NOW - 40_000, motion: 'stationary', currentStationName: '용마산' },
+    { lat: 0, lng: 0, accuracy: 10, ts: NOW - 20_000, motion: 'stationary', currentStationName: '용마산' },
+    { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion: 'stationary', currentStationName: '용마산' },
+  ];
+  await kv.put(`pos:${token}`, JSON.stringify(series));
+}
+
+/** target=중곡 기준 device==target + automotive 시드 (정상 trip 케이스). */
+async function seedMovingAtTargetSeries(kv: InMemoryKV, token: string): Promise<void> {
+  const series: PositionPoint[] = [
+    { lat: 0, lng: 0, accuracy: 10, ts: NOW - 40_000, motion: 'automotive', currentStationName: '중곡' },
+    { lat: 0, lng: 0, accuracy: 10, ts: NOW - 20_000, motion: 'automotive', currentStationName: '중곡' },
+    { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion: 'automotive', currentStationName: '중곡' },
+  ];
+  await kv.put(`pos:${token}`, JSON.stringify(series));
+}
+
+/** 7호선 용마산→중곡→군자 leg + arvlCd lock fixture. */
+function makeArvlFireTrip(): Trip {
+  return makeLockTripFixture('cons-arvl-tok', {
+    boardingLock: makeBoardingLock({ segmentStations: CONSISTENCY_SEG }),
+  });
+}
+
+/**
+ * #1370 L2 fallback advance를 트리거: lastTrackedArrivalEpoch + FALLBACK_HOP_SEC 경과 + Seoul arrivals 빈 응답
+ * + consecutiveEtaMissing이 fallbackTrigger 도달.
+ */
+function makeVanishTrip(consecutiveMissOverride?: number): Trip {
+  const fallbackTrigger = VANISH_RE_ATTACH_THRESHOLD + FALLBACK_ADVANCE_GRACE_CYCLES;
+  return makeLockTripFixture('cons-vanish-tok', {
+    boardingLock: makeBoardingLock({ segmentStations: CONSISTENCY_SEG }),
+    lastTrackedArrivalEpoch: NOW - (FALLBACK_HOP_SEC + 10) * 1000,
+    consecutiveEtaMissing: consecutiveMissOverride ?? fallbackTrigger - 1,
+  });
+}
+
+function emptyArrivalsSeoul(): SeoulArrivalClient {
+  return new SeoulArrivalClient({
+    apiKey: 'K',
+    host: 'h',
+    now: () => NOW,
+    fetchImpl: (async () =>
+      new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 })) as unknown as typeof fetch,
+  });
+}
+
 describe('runScheduled — #1389 push consistency gate (5 fire sites)', () => {
-  // segmentStations 공용 — 용마산→중곡→군자 leg.
-  const SEG = ['용마산', '중곡', '군자'];
-
-  /** target=중곡 기준 1 hop behind + stationary 시드 (정합성 위반 케이스). */
-  async function seedStationaryBehindSeries(kv: InMemoryKV, token: string): Promise<void> {
-    const series: PositionPoint[] = [
-      { lat: 0, lng: 0, accuracy: 10, ts: NOW - 40_000, motion: 'stationary', currentStationName: '용마산' },
-      { lat: 0, lng: 0, accuracy: 10, ts: NOW - 20_000, motion: 'stationary', currentStationName: '용마산' },
-      { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion: 'stationary', currentStationName: '용마산' },
-    ];
-    await kv.put(`pos:${token}`, JSON.stringify(series));
-  }
-
-  /** target=중곡 기준 device==target + automotive 시드 (정상 trip 케이스). */
-  async function seedMovingAtTargetSeries(kv: InMemoryKV, token: string): Promise<void> {
-    const series: PositionPoint[] = [
-      { lat: 0, lng: 0, accuracy: 10, ts: NOW - 40_000, motion: 'automotive', currentStationName: '중곡' },
-      { lat: 0, lng: 0, accuracy: 10, ts: NOW - 20_000, motion: 'automotive', currentStationName: '중곡' },
-      { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion: 'automotive', currentStationName: '중곡' },
-    ];
-    await kv.put(`pos:${token}`, JSON.stringify(series));
-  }
-
-  /** 7호선 용마산→중곡→군자 leg + arvlCd lock fixture. */
-  function makeArvlFireTrip(): Trip {
-    return makeLockTripFixture('cons-arvl-tok', {
-      boardingLock: makeBoardingLock({ segmentStations: SEG }),
-    });
-  }
-
   describe('Site 1: arvlCd fire', () => {
     it('정합성 위반(motion=stationary, device 1 hop behind) → push 0건 + pushConsistencyBlocked++', async () => {
       const trip = makeArvlFireTrip();
@@ -4824,29 +4848,6 @@ describe('runScheduled — #1389 push consistency gate (5 fire sites)', () => {
   });
 
   describe('Site 2: vanish-fallback fire', () => {
-    /**
-     * #1370 L2 fallback advance를 트리거: lastTrackedArrivalEpoch + FALLBACK_HOP_SEC 경과 + Seoul arrivals 빈 응답
-     * + consecutiveEtaMissing이 fallbackTrigger 도달.
-     */
-    function makeVanishTrip(consecutiveMissOverride?: number): Trip {
-      const fallbackTrigger = VANISH_RE_ATTACH_THRESHOLD + FALLBACK_ADVANCE_GRACE_CYCLES;
-      return makeLockTripFixture('cons-vanish-tok', {
-        boardingLock: makeBoardingLock({ segmentStations: SEG }),
-        lastTrackedArrivalEpoch: NOW - (FALLBACK_HOP_SEC + 10) * 1000,
-        consecutiveEtaMissing: consecutiveMissOverride ?? fallbackTrigger - 1,
-      });
-    }
-
-    function emptyArrivalsSeoul(): SeoulArrivalClient {
-      return new SeoulArrivalClient({
-        apiKey: 'K',
-        host: 'h',
-        now: () => NOW,
-        fetchImpl: (async () =>
-          new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 })) as unknown as typeof fetch,
-      });
-    }
-
     it('정합성 위반(stationary 가드 이미 #1386이 차단) → 정합성 게이트 진입 전 motion 가드가 먼저 막음', async () => {
       // 이 케이스는 #1386 motion 가드가 fire 함수 진입 전(handleEtaMissing 안)에서 advance를 막으므로
       // 정합성 게이트는 호출되지 않는다. vanishFallbackMotionGateBlocked가 증가하는 것이 정상.
@@ -4906,7 +4907,7 @@ describe('runScheduled — #1389 push consistency gate (5 fire sites)', () => {
       // motion=unknown은 #1386 가드 통과 + 정합성 게이트 §9 (hops==1 && motion!=stationary) allow.
       // 즉 옳은 trip의 fallback advance가 차단되지 않음을 보장.
       const trip = makeLockTripFixture('cons-vanish-ok', {
-        boardingLock: makeBoardingLock({ segmentStations: SEG }),
+        boardingLock: makeBoardingLock({ segmentStations: CONSISTENCY_SEG }),
         lastTrackedArrivalEpoch: NOW - (FALLBACK_HOP_SEC + 10) * 1000,
         consecutiveEtaMissing: VANISH_RE_ATTACH_THRESHOLD + FALLBACK_ADVANCE_GRACE_CYCLES - 1,
         waypoints: [
@@ -4939,7 +4940,7 @@ describe('runScheduled — #1389 push consistency gate (5 fire sites)', () => {
   describe('Site 3: reschedule push', () => {
     it('정합성 위반(motion=stationary, device 1 hop behind) → reschedule push 0건 + 카운터 증가', async () => {
       const trip = makeLockTripFixture('cons-resched-tok', {
-        boardingLock: makeBoardingLock({ segmentStations: SEG }),
+        boardingLock: makeBoardingLock({ segmentStations: CONSISTENCY_SEG }),
         lastTrackedArrivalEpoch: NOW + 120 * 1000, // 임계 초과 변동 보장 baseline
       });
       const kv = new InMemoryKV();
@@ -5068,51 +5069,52 @@ describe('runScheduled — #1389 push consistency gate (5 fire sites)', () => {
  * runScheduled integration 테스트로 cover하기 어려운 edge(extraLog override 방어,
  * lock=undefined 경로, allow 경로 무카운트) 검증.
  */
-describe('evaluatePushConsistencyForSite (#1389 wrapper)', () => {
-  function makeStats(): ScheduledStats {
-    return {
-      scanned: 0,
-      polled: 0,
-      pushed: 0,
-      errors: 0,
-      etaMissing: 0,
-      envCorrected: 0,
-      lockMissing: 0,
-      locklessIntermediateFired: 0,
-      locklessMotionGateBlocked: 0,
-      laPushSent: 0,
-      laPushFailed: 0,
-      laTokenCleared: 0,
-      boardingPromptEvaluated: 0,
-      boardingPromptFired: 0,
-      boardingPromptBlocked: 0,
-      phaseImminentBlocked: 0,
-      kalmanReset: 0,
-      kalmanDriftWarning: 0,
-      autoLockSuccess: 0,
-      autoLockFalsePositive: 0,
-      boardingPromptAutoDeduped: 0,
-      arvlCdFireSuccess: 0,
-      arvlCdFireDedup: 0,
-      arvlCdFireMismatch: 0,
-      vanishFallbackFired: 0,
-      vanishLocklessTakeover: 0,
-      vanishFallbackMotionGateBlocked: 0,
-      pushConsistencyBlocked: 0,
-      pushConsistencyBlockedByReason: {
-        'wifi-mismatch': 0,
-        'motion-stationary-far-behind': 0,
-        'device-station-mismatch': 0,
-        'device-ahead-of-target': 0,
-      },
-    };
-  }
+// #1389 wrapper unit test 공용 fixture — describe 외부(SonarCloud: avoid nested function declarations).
+function makeWrapperStats(): ScheduledStats {
+  return {
+    scanned: 0,
+    polled: 0,
+    pushed: 0,
+    errors: 0,
+    etaMissing: 0,
+    envCorrected: 0,
+    lockMissing: 0,
+    locklessIntermediateFired: 0,
+    locklessMotionGateBlocked: 0,
+    laPushSent: 0,
+    laPushFailed: 0,
+    laTokenCleared: 0,
+    boardingPromptEvaluated: 0,
+    boardingPromptFired: 0,
+    boardingPromptBlocked: 0,
+    phaseImminentBlocked: 0,
+    kalmanReset: 0,
+    kalmanDriftWarning: 0,
+    autoLockSuccess: 0,
+    autoLockFalsePositive: 0,
+    boardingPromptAutoDeduped: 0,
+    arvlCdFireSuccess: 0,
+    arvlCdFireDedup: 0,
+    arvlCdFireMismatch: 0,
+    vanishFallbackFired: 0,
+    vanishLocklessTakeover: 0,
+    vanishFallbackMotionGateBlocked: 0,
+    pushConsistencyBlocked: 0,
+    pushConsistencyBlockedByReason: {
+      'wifi-mismatch': 0,
+      'motion-stationary-far-behind': 0,
+      'device-station-mismatch': 0,
+      'device-ahead-of-target': 0,
+    },
+  };
+}
 
+describe('evaluatePushConsistencyForSite (#1389 wrapper)', () => {
   const target = { stationName: '중곡', line: '7' };
   const lock = { segmentStations: ['용마산', '중곡', '군자', '어린이대공원'] };
 
   it('차단(motion=stationary + hops=1) → result.allowed=false + stats 누적 + log 발사', () => {
-    const stats = makeStats();
+    const stats = makeWrapperStats();
     const logs: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
     const log = (msg: string, meta?: Record<string, unknown>) => {
       logs.push({ msg, meta });
@@ -5147,7 +5149,7 @@ describe('evaluatePushConsistencyForSite (#1389 wrapper)', () => {
   });
 
   it('허용(motion=automotive + hops=0) → result.allowed=true + 카운터/log 무변동', () => {
-    const stats = makeStats();
+    const stats = makeWrapperStats();
     const logs: Array<{ msg: string }> = [];
     const log = (msg: string) => {
       logs.push({ msg });
@@ -5172,7 +5174,7 @@ describe('evaluatePushConsistencyForSite (#1389 wrapper)', () => {
   });
 
   it('extraLog override 방어 — 호출자가 site/reason/token 키를 넣어도 wrapper 기본 값이 우선', () => {
-    const stats = makeStats();
+    const stats = makeWrapperStats();
     const logs: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
     const log = (msg: string, meta?: Record<string, unknown>) => {
       logs.push({ msg, meta });
@@ -5205,7 +5207,7 @@ describe('evaluatePushConsistencyForSite (#1389 wrapper)', () => {
   });
 
   it('lock=undefined → hops=null fallback → §5 allow (lockless 경로 회귀 0건)', () => {
-    const stats = makeStats();
+    const stats = makeWrapperStats();
     const log = () => undefined;
     const series: PositionPoint[] = [
       { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion: 'walking', currentStationName: '강남' },

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -14,6 +14,7 @@ import {
   SUBSURFACE_ETA_MISSING_TOLERANCE,
   VANISH_RE_ATTACH_THRESHOLD,
   arvlCdFireKey,
+  createInitialScheduledStats,
   estimateArrivalFromPosition,
   estimateBoardingLockArrival,
   evaluateArvlCdFireGate,
@@ -4803,21 +4804,39 @@ function emptyArrivalsSeoul(): SeoulArrivalClient {
   });
 }
 
+/**
+ * #1389 fire site integration helper — kv setup + putTrip + (옵션 series seed) + runScheduled를 1줄로.
+ * Sonar CPD 방지(각 사이트별로 동일 boilerplate 반복 차단). 호출자는 trip + seoul + 선택적 seed 함수만 전달.
+ */
+async function runConsistencyCycle(input: {
+  trip: Trip;
+  seoul: SeoulArrivalClient;
+  seedSeries?: (kv: InMemoryKV, token: string) => Promise<void>;
+  pushId?: string;
+}): Promise<{ stats: ScheduledStats; kv: InMemoryKV; apnsFetch: ReturnType<typeof vi.fn> }> {
+  const kv = new InMemoryKV();
+  await putTrip(kv as unknown as KVNamespace, input.trip);
+  if (input.seedSeries) await input.seedSeries(kv, input.trip.token);
+  const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+  const stats = await runScheduled(makeEnv(kv), {
+    seoul: input.seoul,
+    apnsConfig,
+    apnsHosts: APNS_HOSTS,
+    fetchImpl: apnsFetch as unknown as typeof fetch,
+    now: () => NOW,
+    ...(input.pushId ? { generatePushId: () => input.pushId! } : {}),
+  });
+  return { stats, kv, apnsFetch };
+}
+
 describe('runScheduled — #1389 push consistency gate (5 fire sites)', () => {
   describe('Site 1: arvlCd fire', () => {
     it('정합성 위반(motion=stationary, device 1 hop behind) → push 0건 + pushConsistencyBlocked++', async () => {
-      const trip = makeArvlFireTrip();
-      const kv = new InMemoryKV();
-      await putTrip(kv as unknown as KVNamespace, trip);
-      await seedStationaryBehindSeries(kv, trip.token);
-      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-      const stats = await runScheduled(makeEnv(kv), {
+      const { stats, kv, apnsFetch } = await runConsistencyCycle({
+        trip: makeArvlFireTrip(),
         seoul: makeArvlCdFireSeoul('중곡', 0, 1),
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
-        now: () => NOW,
-        generatePushId: () => 'p-cons-arvl-blocked',
+        seedSeries: seedStationaryBehindSeries,
+        pushId: 'p-cons-arvl-blocked',
       });
       expect(stats.arvlCdFireSuccess).toBe(0);
       expect(stats.pushConsistencyBlocked).toBeGreaterThanOrEqual(1);
@@ -4828,18 +4847,11 @@ describe('runScheduled — #1389 push consistency gate (5 fire sites)', () => {
     });
 
     it('정상 trip(motion=automotive, device==target) → 발사 1건 (회귀 0건)', async () => {
-      const trip = makeArvlFireTrip();
-      const kv = new InMemoryKV();
-      await putTrip(kv as unknown as KVNamespace, trip);
-      await seedMovingAtTargetSeries(kv, trip.token);
-      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-      const stats = await runScheduled(makeEnv(kv), {
+      const { stats, apnsFetch } = await runConsistencyCycle({
+        trip: makeArvlFireTrip(),
         seoul: makeArvlCdFireSeoul('중곡', 0, 1),
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
-        now: () => NOW,
-        generatePushId: () => 'p-cons-arvl-ok',
+        seedSeries: seedMovingAtTargetSeries,
+        pushId: 'p-cons-arvl-ok',
       });
       expect(stats.arvlCdFireSuccess).toBe(1);
       expect(stats.pushConsistencyBlocked).toBe(0);
@@ -4848,20 +4860,27 @@ describe('runScheduled — #1389 push consistency gate (5 fire sites)', () => {
   });
 
   describe('Site 2: vanish-fallback fire', () => {
+    /** motion 지정 + (선택) device currentStationName으로 vanish fallback 시리즈 시드. */
+    function seedVanishSeries(
+      motion: PositionPoint['motion'],
+      deviceStation: string,
+    ): (kv: InMemoryKV, token: string) => Promise<void> {
+      return async (kv, token) => {
+        const series: PositionPoint[] = [
+          { lat: 0, lng: 0, accuracy: 10, ts: NOW - 40_000, motion, currentStationName: deviceStation },
+          { lat: 0, lng: 0, accuracy: 10, ts: NOW - 20_000, motion, currentStationName: deviceStation },
+          { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion, currentStationName: deviceStation },
+        ];
+        await kv.put(`pos:${token}`, JSON.stringify(series));
+      };
+    }
+
     it('정합성 위반(stationary 가드 이미 #1386이 차단) → 정합성 게이트 진입 전 motion 가드가 먼저 막음', async () => {
-      // 이 케이스는 #1386 motion 가드가 fire 함수 진입 전(handleEtaMissing 안)에서 advance를 막으므로
-      // 정합성 게이트는 호출되지 않는다. vanishFallbackMotionGateBlocked가 증가하는 것이 정상.
-      const trip = makeVanishTrip();
-      const kv = new InMemoryKV();
-      await putTrip(kv as unknown as KVNamespace, trip);
-      await seedStationaryBehindSeries(kv, trip.token);
-      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-      const stats = await runScheduled(makeEnv(kv), {
+      // #1386 motion 가드가 fire 함수 진입 전(handleEtaMissing)에서 advance를 막아 정합성 게이트는 호출 안 됨.
+      const { stats, apnsFetch } = await runConsistencyCycle({
+        trip: makeVanishTrip(),
         seoul: emptyArrivalsSeoul(),
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
-        now: () => NOW,
+        seedSeries: seedStationaryBehindSeries,
       });
       expect(stats.vanishFallbackFired).toBe(0);
       expect(stats.vanishFallbackMotionGateBlocked).toBeGreaterThanOrEqual(1);
@@ -4871,9 +4890,10 @@ describe('runScheduled — #1389 push consistency gate (5 fire sites)', () => {
     it('정합성 게이트 §10 차단(motion=automotive + device 2 hops behind target) → vanish-fallback fire 0건 + pushConsistencyBlocked++', async () => {
       // device=용마산, target=군자 → hops=2. motion=automotive로 #1386 motion 가드 통과,
       // 정합성 게이트 §10(hops>=2 device-station-mismatch) 차단.
-      const segLong = ['용마산', '중곡', '군자', '어린이대공원'];
       const trip = makeLockTripFixture('cons-vanish-mismatch', {
-        boardingLock: makeBoardingLock({ segmentStations: segLong }),
+        boardingLock: makeBoardingLock({
+          segmentStations: ['용마산', '중곡', '군자', '어린이대공원'],
+        }),
         lastTrackedArrivalEpoch: NOW - (FALLBACK_HOP_SEC + 10) * 1000,
         consecutiveEtaMissing: VANISH_RE_ATTACH_THRESHOLD + FALLBACK_ADVANCE_GRACE_CYCLES - 1,
         waypoints: [
@@ -4882,21 +4902,10 @@ describe('runScheduled — #1389 push consistency gate (5 fire sites)', () => {
           { stationName: '어린이대공원', line: '7', kind: 'destination' },
         ],
       });
-      const kv = new InMemoryKV();
-      await putTrip(kv as unknown as KVNamespace, trip);
-      const series: PositionPoint[] = [
-        { lat: 0, lng: 0, accuracy: 10, ts: NOW - 40_000, motion: 'automotive', currentStationName: '용마산' },
-        { lat: 0, lng: 0, accuracy: 10, ts: NOW - 20_000, motion: 'automotive', currentStationName: '용마산' },
-        { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion: 'automotive', currentStationName: '용마산' },
-      ];
-      await kv.put(`pos:${trip.token}`, JSON.stringify(series));
-      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-      const stats = await runScheduled(makeEnv(kv), {
+      const { stats } = await runConsistencyCycle({
+        trip,
         seoul: emptyArrivalsSeoul(),
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
-        now: () => NOW,
+        seedSeries: seedVanishSeries('automotive', '용마산'),
       });
       expect(stats.vanishFallbackFired).toBe(0);
       expect(stats.pushConsistencyBlocked).toBeGreaterThanOrEqual(1);
@@ -4905,7 +4914,6 @@ describe('runScheduled — #1389 push consistency gate (5 fire sites)', () => {
 
     it('회귀 0건(motion=unknown + hops=1) — 정합성 게이트 §9 allow → vanish-fallback fire 발사 정상', async () => {
       // motion=unknown은 #1386 가드 통과 + 정합성 게이트 §9 (hops==1 && motion!=stationary) allow.
-      // 즉 옳은 trip의 fallback advance가 차단되지 않음을 보장.
       const trip = makeLockTripFixture('cons-vanish-ok', {
         boardingLock: makeBoardingLock({ segmentStations: CONSISTENCY_SEG }),
         lastTrackedArrivalEpoch: NOW - (FALLBACK_HOP_SEC + 10) * 1000,
@@ -4915,24 +4923,12 @@ describe('runScheduled — #1389 push consistency gate (5 fire sites)', () => {
           { stationName: '군자', line: '7', kind: 'destination' },
         ],
       });
-      const kv = new InMemoryKV();
-      await putTrip(kv as unknown as KVNamespace, trip);
-      const series: PositionPoint[] = [
-        { lat: 0, lng: 0, accuracy: 10, ts: NOW - 40_000, motion: 'unknown', currentStationName: '용마산' },
-        { lat: 0, lng: 0, accuracy: 10, ts: NOW - 20_000, motion: 'unknown', currentStationName: '용마산' },
-        { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion: 'unknown', currentStationName: '용마산' },
-      ];
-      await kv.put(`pos:${trip.token}`, JSON.stringify(series));
-      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-      const stats = await runScheduled(makeEnv(kv), {
+      const { stats } = await runConsistencyCycle({
+        trip,
         seoul: emptyArrivalsSeoul(),
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
-        now: () => NOW,
+        seedSeries: seedVanishSeries('unknown', '용마산'),
       });
       expect(stats.vanishFallbackFired).toBe(1);
-      // 정합성 게이트는 합법적인 advance를 차단하지 않음 (회귀 0건 보장).
       expect(stats.pushConsistencyBlocked).toBe(0);
     });
   });
@@ -4943,30 +4939,21 @@ describe('runScheduled — #1389 push consistency gate (5 fire sites)', () => {
         boardingLock: makeBoardingLock({ segmentStations: CONSISTENCY_SEG }),
         lastTrackedArrivalEpoch: NOW + 120 * 1000, // 임계 초과 변동 보장 baseline
       });
-      const kv = new InMemoryKV();
-      await putTrip(kv as unknown as KVNamespace, trip);
-      await seedStationaryBehindSeries(kv, trip.token);
       // arvlCd=null + arrival 30s — estimate.arrived=false 경로 → maybeReschedulePush 호출.
-      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-      const stats = await runScheduled(makeEnv(kv), {
+      const { stats } = await runConsistencyCycle({
+        trip,
         seoul: makeArvlCdFireSeoul('중곡', 30, null),
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
-        now: () => NOW,
+        seedSeries: seedStationaryBehindSeries,
       });
       expect(stats.pushConsistencyBlocked).toBeGreaterThanOrEqual(1);
-      // reschedule push 발사 0건. 다른 경로 push(LA 등)는 통과될 수 있으므로 전체 pushed가 아닌 reschedule 직접 검증은 어려움 —
-      // 대신 정합성 차단 reason 검증으로 차단을 확정.
       expect(stats.pushConsistencyBlockedByReason['motion-stationary-far-behind']).toBeGreaterThanOrEqual(1);
     });
   });
 
   describe('Site 4: lockless-intermediate fire', () => {
-    it('정합성 위반(WiFi mismatch + stationary 합성) → 차단', async () => {
-      // lockless 경로는 lock=undefined → hops=null → 기본 fallback 허용. 그러나 motion 가드 자체가 stationary 차단.
-      // 본 사이트의 정합성 게이트 보강은 주로 'WiFi mismatch' 보강 — 본 PR에서 WiFi는 항상 null이라
-      // 본 테스트는 motion 가드가 lockless 경로에서도 정합성 차단을 작동시키는지 확인하는 형태.
+    it('motion 가드가 stationary를 차단 → 정합성 게이트는 호출 안 됨 (회귀 0건)', async () => {
+      // lockless 경로는 lock=undefined → hops=null → 정합성 게이트 §5 fallback allow.
+      // 본 시나리오는 motion 가드만 활성. 정합성 게이트가 motion 차단을 우회하지 않음을 보장.
       const trip = makeTrip({
         token: 'cons-lockless-tok',
         waypoints: [
@@ -4975,35 +4962,19 @@ describe('runScheduled — #1389 push consistency gate (5 fire sites)', () => {
         ],
         locklessStationPassed: true,
       });
-      const kv = new InMemoryKV();
-      await putTrip(kv as unknown as KVNamespace, trip);
-      // 사용자가 강남 1 hop 전(currentStationName='용마산') + stationary — motion 가드가 먼저 차단.
-      // 본 테스트는 회귀 0건 확인(차단되어 발사가 일어나지 않음).
-      const series: PositionPoint[] = [
-        { lat: 0, lng: 0, accuracy: 10, ts: NOW - 40_000, motion: 'stationary', currentStationName: '용마산' },
-        { lat: 0, lng: 0, accuracy: 10, ts: NOW - 20_000, motion: 'stationary', currentStationName: '용마산' },
-        { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion: 'stationary', currentStationName: '용마산' },
-      ];
-      await kv.put(`pos:${trip.token}`, JSON.stringify(series));
-      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-      const stats = await runScheduled(makeEnv(kv), {
-        seoul: makeSeoul([
-          {
-            destination: '강남행',
-            arrivalSeconds: 30,
-            trainCode: '7246',
-            isUp: true,
-            subwayNm: '지하철2호선',
-            arvlCd: 1,
-          },
-        ]),
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
-        now: () => NOW,
+      const arrivedSignal: ArrivalEntry = {
+        destination: '강남행',
+        arrivalSeconds: 30,
+        trainCode: '7246',
+        isUp: true,
+        subwayNm: '지하철2호선',
+        arvlCd: 1,
+      };
+      const { stats } = await runConsistencyCycle({
+        trip,
+        seoul: makeSeoul([arrivedSignal]),
+        seedSeries: seedStationaryBehindSeries,
       });
-      // motion 가드가 stationary를 먼저 차단 → 정합성 게이트는 호출 안 됨.
-      // (lockless 경로의 정합성 게이트는 lock=undefined → hops=null fallback이라 본 시나리오는 motion만 활성)
       expect(stats.locklessIntermediateFired).toBe(0);
       expect(stats.locklessMotionGateBlocked).toBeGreaterThanOrEqual(1);
       expect(stats.pushConsistencyBlocked).toBe(0);
@@ -5013,32 +4984,13 @@ describe('runScheduled — #1389 push consistency gate (5 fire sites)', () => {
   describe('Site 5: boarding-prompt fire', () => {
     // 9단 게이트 happy path(seedHappyGateSeries)는 origin=(0,0), motion=automotive로 시드되어 있어
     // 정합성 게이트의 currentStationName이 부재(seed에 미스탬프). currentStationName=null + motion=automotive
-    // → 정합성 게이트 #4(모든 신호 null이 아님 — motion!=unknown) 통과 후 hops=null → §5 fallback allow.
-    // 따라서 happy path는 회귀 0건 (정합성 게이트가 발사를 막지 않음).
+    // → §4 통과 → hops=null → §5 fallback allow. happy path 회귀 0건.
     it('happy 9단 게이트 통과 trip → 정합성 게이트 통과 + boardingPromptFired 회귀 0건', async () => {
-      const kv = new InMemoryKV();
-      const trip = makePromptTrip();
-      await putTrip(kv as unknown as KVNamespace, trip);
-      await seedHappyGateSeries(kv, trip.token);
-      // attemptAutoLock이 사용하는 arrivals — 빈 응답으로 auto-lock 실패시켜 prompt fallback 경로 진입.
-      const seoul = new SeoulArrivalClient({
-        apiKey: 'K',
-        host: 'h',
-        now: () => NOW,
-        fetchImpl: (async () =>
-          new Response(JSON.stringify({ realtimeArrivalList: [] }), {
-            status: 200,
-          })) as unknown as typeof fetch,
+      const { stats } = await runConsistencyCycle({
+        trip: makePromptTrip(),
+        seoul: emptyArrivalsSeoul(),
+        seedSeries: seedHappyGateSeries,
       });
-      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-      const stats = await runScheduled(makeEnv(kv), {
-        seoul,
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
-        now: () => NOW,
-      });
-      // happy path에서 정합성 게이트가 prompt를 차단하지 않음.
       expect(stats.pushConsistencyBlocked).toBe(0);
     });
   });
@@ -5069,52 +5021,12 @@ describe('runScheduled — #1389 push consistency gate (5 fire sites)', () => {
  * runScheduled integration 테스트로 cover하기 어려운 edge(extraLog override 방어,
  * lock=undefined 경로, allow 경로 무카운트) 검증.
  */
-// #1389 wrapper unit test 공용 fixture — describe 외부(SonarCloud: avoid nested function declarations).
-function makeWrapperStats(): ScheduledStats {
-  return {
-    scanned: 0,
-    polled: 0,
-    pushed: 0,
-    errors: 0,
-    etaMissing: 0,
-    envCorrected: 0,
-    lockMissing: 0,
-    locklessIntermediateFired: 0,
-    locklessMotionGateBlocked: 0,
-    laPushSent: 0,
-    laPushFailed: 0,
-    laTokenCleared: 0,
-    boardingPromptEvaluated: 0,
-    boardingPromptFired: 0,
-    boardingPromptBlocked: 0,
-    phaseImminentBlocked: 0,
-    kalmanReset: 0,
-    kalmanDriftWarning: 0,
-    autoLockSuccess: 0,
-    autoLockFalsePositive: 0,
-    boardingPromptAutoDeduped: 0,
-    arvlCdFireSuccess: 0,
-    arvlCdFireDedup: 0,
-    arvlCdFireMismatch: 0,
-    vanishFallbackFired: 0,
-    vanishLocklessTakeover: 0,
-    vanishFallbackMotionGateBlocked: 0,
-    pushConsistencyBlocked: 0,
-    pushConsistencyBlockedByReason: {
-      'wifi-mismatch': 0,
-      'motion-stationary-far-behind': 0,
-      'device-station-mismatch': 0,
-      'device-ahead-of-target': 0,
-    },
-  };
-}
-
 describe('evaluatePushConsistencyForSite (#1389 wrapper)', () => {
   const target = { stationName: '중곡', line: '7' };
   const lock = { segmentStations: ['용마산', '중곡', '군자', '어린이대공원'] };
 
   it('차단(motion=stationary + hops=1) → result.allowed=false + stats 누적 + log 발사', () => {
-    const stats = makeWrapperStats();
+    const stats = createInitialScheduledStats();
     const logs: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
     const log = (msg: string, meta?: Record<string, unknown>) => {
       logs.push({ msg, meta });
@@ -5149,7 +5061,7 @@ describe('evaluatePushConsistencyForSite (#1389 wrapper)', () => {
   });
 
   it('허용(motion=automotive + hops=0) → result.allowed=true + 카운터/log 무변동', () => {
-    const stats = makeWrapperStats();
+    const stats = createInitialScheduledStats();
     const logs: Array<{ msg: string }> = [];
     const log = (msg: string) => {
       logs.push({ msg });
@@ -5174,7 +5086,7 @@ describe('evaluatePushConsistencyForSite (#1389 wrapper)', () => {
   });
 
   it('extraLog override 방어 — 호출자가 site/reason/token 키를 넣어도 wrapper 기본 값이 우선', () => {
-    const stats = makeWrapperStats();
+    const stats = createInitialScheduledStats();
     const logs: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
     const log = (msg: string, meta?: Record<string, unknown>) => {
       logs.push({ msg, meta });
@@ -5207,7 +5119,7 @@ describe('evaluatePushConsistencyForSite (#1389 wrapper)', () => {
   });
 
   it('lock=undefined → hops=null fallback → §5 allow (lockless 경로 회귀 0건)', () => {
-    const stats = makeWrapperStats();
+    const stats = createInitialScheduledStats();
     const log = () => undefined;
     const series: PositionPoint[] = [
       { lat: 0, lng: 0, accuracy: 10, ts: NOW, motion: 'walking', currentStationName: '강남' },

--- a/backend/alarm-worker/src/metrics.catalog.json
+++ b/backend/alarm-worker/src/metrics.catalog.json
@@ -156,6 +156,13 @@
       "format": "histogram",
       "display": "numeric",
       "description": "#1174 Epic C B5 — server BffProgressResponse.waypointIndex와 local stationProgressEstimator(Stage 1-3) 결과의 arc-index 차이 절댓값(|serverIdx - estimatorIdx|, 단위=hop). 1주 baseline 운영으로 P50/P95 산출 → B5(server progress) optional→required 승격 시 P95 임계 결정 근거. Phase 4 결정 게이트 아님 — 운영 측정 KPI(운영 임계는 P95 baseline 확정 후 별도 const로 카탈로그에 추가)."
+    },
+    {
+      "key": "pushConsistencyBlocked",
+      "constantName": "PUSH_CONSISTENCY_BLOCKED",
+      "format": "rate",
+      "display": "percentage",
+      "description": "#1389 — backend 발사 사이트(arvlCd / vanish-fallback / reschedule / lockless-intermediate / boarding-prompt)에서 evaluatePushConsistency가 차단(allowed=false)한 비율. hit=차단된 push 수, total=평가된 push 수. 사용자 device 신호(currentStationName / motion / WiFi)와 backend target waypoint가 모순될 때 차단. reason별 sub-counter는 stats(pushConsistencyBlockedByReason)로 분리 적재. 운영 KPI(Phase 4 결정 게이트 아님) — 정지 trip false push 회귀 차단 효과 측정."
     }
   ]
 }

--- a/backend/alarm-worker/src/pushConsistencyContext.ts
+++ b/backend/alarm-worker/src/pushConsistencyContext.ts
@@ -1,0 +1,113 @@
+/**
+ * #1389 — backend 발사 사이트가 `evaluatePushConsistency`에 넘기는 입력을 만들어 주는 어댑터 helper.
+ *
+ * 두 가지 책임만 가진다(SRP):
+ *   1. `extractDeviceSignal(series, now)` — backend가 KV에 저장해 둔 `PositionPoint[]`에서
+ *      가장 최근 sample을 골라 `DeviceSignal`(currentStationName / motion / lastUpdateMs)로 변환.
+ *      WiFi는 #1286 device 업로드 전까지 backend에 신호가 없으므로 항상 `null`.
+ *   2. `computeDeviceHopsBehindTarget(lock, target, currentStationName)` — boardingLock의
+ *      `segmentStations`(현재 leg 정차 시퀀스)에서 device 현재역 ↔ target waypoint 사이의 hop 차이를 산출.
+ *      - 0       : device가 target과 같음
+ *      - 양수    : device가 target보다 N hop behind
+ *      - 음수    : device가 target보다 N hop ahead
+ *      - `null`  : 둘 중 하나라도 segment에서 찾지 못함 → helper가 fallback(허용)으로 처리
+ *
+ * fire site는 위 두 helper로 (DeviceSignal, TripContext)를 만들고 `evaluatePushConsistency`로 평가만 한다.
+ * helper는 backend 전용 (frontend mirror는 device 자체 신호를 직접 가지므로 동일 추출 helper가 필요 없음).
+ */
+
+import type { PositionPoint, BoardingLockMeta } from './types';
+import { evaluateWindow } from './positionSeries';
+import type { DeviceSignal, PushTarget, TripContext } from './pushConsistency';
+
+/**
+ * positionSeries에서 가장 최근 sample 기준으로 DeviceSignal을 만든다.
+ *
+ *  - currentStationName : 가장 최근에 `currentStationName` 필드를 stamp한 sample의 값.
+ *                          stamp가 한 번도 없으면 null. `scheduled.ts:pickLatestCurrentStationName`과
+ *                          같은 의미(가장 최근부터 backward backfill).
+ *  - motion             : 최근 6개 sample의 최빈값(positionSeries.evaluateWindow). 빈 시리즈는 'unknown'.
+ *  - wifiStation        : 현재 backend에는 신호가 없어 항상 null (#1286 frontend 업로드 후 갱신).
+ *  - lastUpdateMs       : 가장 마지막 sample의 `ts`. 시리즈가 비면 0 (= now와 비교 시 항상 stale → 게이트 허용).
+ */
+export function extractDeviceSignal(
+  series: readonly PositionPoint[],
+  now: number,
+): DeviceSignal {
+  // currentStationName — 가장 최근부터 backfill.
+  let currentStationName: string | null = null;
+  for (let i = series.length - 1; i >= 0; i--) {
+    const name = series[i].currentStationName;
+    if (typeof name === 'string' && name.length > 0) {
+      currentStationName = name;
+      break;
+    }
+  }
+
+  // motion — 기존 positionSeries.evaluateWindow가 최근 6개 sample 최빈값 산출.
+  // 빈 시리즈에서도 'unknown'으로 graceful — 게이트 분기 #4(모든 signal null)에 그대로 매핑.
+  const metrics = evaluateWindow(series, now);
+
+  // lastUpdateMs — 가장 마지막 sample의 ts. 빈 시리즈는 0 (게이트 #3 stale 분기 → 허용).
+  const last = series[series.length - 1];
+  const lastUpdateMs = last ? last.ts : 0;
+
+  return {
+    currentStationName,
+    motion: metrics.motion,
+    wifiStation: null,
+    lastUpdateMs,
+  };
+}
+
+/**
+ * BoardingLock의 `segmentStations`(현재 leg 정차 시퀀스)에서 device 현재역 ↔ target 사이의
+ * hop 차이를 산출. lock 부재 시 `null` 반환 — 호출자가 lock 없는 경로(lockless 등)에서는
+ * 이 helper 대신 다른 산출 방법을 쓰거나 trip context를 null로 두고 fallback 허용해야 한다.
+ *
+ *  - 0 : device == target
+ *  - >0 : device가 target보다 N hop behind
+ *  - <0 : device가 target보다 N hop ahead
+ *  - null : currentStationName이 null, 또는 segmentStations에서 둘 중 하나라도 못 찾음
+ */
+export function computeDeviceHopsBehindTarget(
+  lock: Pick<BoardingLockMeta, 'segmentStations'> | undefined,
+  target: PushTarget,
+  currentStationName: string | null,
+): number | null {
+  if (!lock || currentStationName === null) return null;
+  const segmentStations = lock.segmentStations;
+  const deviceIdx = segmentStations.indexOf(currentStationName);
+  const targetIdx = segmentStations.indexOf(target.stationName);
+  if (deviceIdx < 0 || targetIdx < 0) return null;
+  return targetIdx - deviceIdx;
+}
+
+/**
+ * fire site 1줄 호출용 — series + lock + target에서 (DeviceSignal, TripContext)를 모두 만든다.
+ * 일반 패턴:
+ *
+ * ```ts
+ * const ctx = await buildPushConsistencyContext(env.TRIPS, trip.token, lock, target, now);
+ * const result = evaluatePushConsistency(ctx.device, target, ctx.trip, now);
+ * if (!result.allowed) { ... return; }
+ * ```
+ *
+ * 사이트가 이미 series를 다른 용도(fusion 등)로 읽었으면 `extractDeviceSignal` + `computeDeviceHopsBehindTarget`을
+ * 각자 직접 호출해 KV read를 절약할 수 있다 (lockless/boarding-prompt 경로).
+ */
+export interface PushConsistencyContext {
+  device: DeviceSignal;
+  trip: TripContext;
+}
+
+export function buildPushConsistencyContextFromSeries(
+  series: readonly PositionPoint[],
+  lock: Pick<BoardingLockMeta, 'segmentStations'> | undefined,
+  target: PushTarget,
+  now: number,
+): PushConsistencyContext {
+  const device = extractDeviceSignal(series, now);
+  const hops = computeDeviceHopsBehindTarget(lock, target, device.currentStationName);
+  return { device, trip: { deviceHopsBehindTarget: hops } };
+}

--- a/backend/alarm-worker/src/pushConsistencyContext.ts
+++ b/backend/alarm-worker/src/pushConsistencyContext.ts
@@ -49,7 +49,7 @@ export function extractDeviceSignal(
   const metrics = evaluateWindow(series, now);
 
   // lastUpdateMs — 가장 마지막 sample의 ts. 빈 시리즈는 0 (게이트 #3 stale 분기 → 허용).
-  const last = series[series.length - 1];
+  const last = series.at(-1);
   const lastUpdateMs = last ? last.ts : 0;
 
   return {

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -344,11 +344,12 @@ export interface ScheduledDeps {
   generatePushId?: () => string;
 }
 
-export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<ScheduledStats> {
-  const now = deps.now?.() ?? Date.now();
-  const log = deps.log ?? (() => undefined);
-  const generatePushId = deps.generatePushId ?? (() => crypto.randomUUID());
-  const stats: ScheduledStats = {
+/**
+ * #1389 — `ScheduledStats` 빈 초기값 생성. runScheduled 시작 시점 + 테스트 wrapper에서 공유한다
+ * (SonarCloud CPD 방지). 새 카운터 추가 시 본 함수 1곳만 갱신하면 invariant 자동 동기화.
+ */
+export function createInitialScheduledStats(): ScheduledStats {
+  return {
     scanned: 0,
     polled: 0,
     pushed: 0,
@@ -384,6 +385,13 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       'device-ahead-of-target': 0,
     },
   };
+}
+
+export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<ScheduledStats> {
+  const now = deps.now?.() ?? Date.now();
+  const log = deps.log ?? (() => undefined);
+  const generatePushId = deps.generatePushId ?? (() => crypto.randomUUID());
+  const stats: ScheduledStats = createInitialScheduledStats();
 
   for await (const trip of listTrips(env.TRIPS)) {
     stats.scanned += 1;

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -57,6 +57,12 @@ import type {
   Waypoint,
 } from './types';
 import { RESCHEDULE_CHANNELS_DEFAULT } from './types';
+import {
+  evaluatePushConsistency,
+  type ConsistencyResult,
+  type PushTarget,
+} from './pushConsistency';
+import { buildPushConsistencyContextFromSeries } from './pushConsistencyContext';
 
 // pickApnsHost / flipApnsEnv는 ./apnsHost로 이동 (liveActivity.ts와 공유 SSOT, #482).
 // 외부(테스트 / index.ts 등)가 scheduled.ts 경유로 import하던 호환성 유지를 위해 re-export.
@@ -289,7 +295,30 @@ export interface ScheduledStats extends LiveActivityStats {
    * 발사하던 회귀(2026-06-16 용마산 정지 trip)를 차단한다.
    */
   vanishFallbackMotionGateBlocked: number;
+  /**
+   * #1389 — backend 발사 사이트(arvlCd / vanish-fallback / reschedule / lockless-intermediate /
+   * boarding-prompt)에서 `evaluatePushConsistency`가 차단한 누적 횟수. device의 currentStationName /
+   * motion / WiFi 와 target waypoint가 모순(예: motion=stationary + device 2 hop behind)일 때 발사 차단.
+   * 정지 trip false push 회귀(2026-06-16 용마산 → 중곡) 1차 방어 신호 — 0이 아니면 그만큼 헛 push가 막혔다는 뜻.
+   */
+  pushConsistencyBlocked: number;
+  /**
+   * #1389 — `pushConsistencyBlocked`의 reason별 분포. helper(`pushConsistency.ts`)가 산출하는
+   * 4가지 reason 카운트를 분리해 운영 triage(차단의 dominant 원인이 무엇인지)에 사용한다.
+   * `pushConsistencyBlocked = sum(reasons)`가 invariant. 타입은 helper의 `ConsistencyResult`에서
+   * derive해 drift 차단(reason union을 helper와 stats가 따로 선언하지 않음).
+   */
+  pushConsistencyBlockedByReason: Record<PushConsistencyBlockReason, number>;
 }
+
+/**
+ * #1389 — `pushConsistencyBlockedByReason` 키 타입. helper의 reason union을 derive해 한쪽만 갱신했을 때
+ * type 충돌로 잡히도록 한다(reason 추가/제거 시 stats 키도 자동 추가/제거 필요).
+ */
+export type PushConsistencyBlockReason = Extract<
+  ConsistencyResult,
+  { allowed: false }
+>['reason'];
 
 /**
  * BoardingLock이 활성 상태인지 (#640 게이트).
@@ -347,6 +376,13 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     vanishFallbackFired: 0,
     vanishLocklessTakeover: 0,
     vanishFallbackMotionGateBlocked: 0,
+    pushConsistencyBlocked: 0,
+    pushConsistencyBlockedByReason: {
+      'wifi-mismatch': 0,
+      'motion-stationary-far-behind': 0,
+      'device-station-mismatch': 0,
+      'device-ahead-of-target': 0,
+    },
   };
 
   for await (const trip of listTrips(env.TRIPS)) {
@@ -433,6 +469,63 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     seoulCalls: deps.seoul.stats.callCount,
   });
   return stats;
+}
+
+/**
+ * #1389 — 발사 사이트 공통 정합성 게이트.
+ *
+ * 모든 backend 발사 사이트가 동일한 평가/카운터/로그 형식을 갖도록 1 helper에서 처리한다.
+ * 차단 시 `stats.pushConsistencyBlocked` + reason별 sub-counter 증가 + 표준 log 발사.
+ * 호출자는 반환된 `ConsistencyResult`로 분기만 한다.
+ *
+ *   ```ts
+ *   const series = await readSeries(env.TRIPS, trip.token);
+ *   const decision = evaluatePushConsistencyForSite({
+ *     siteName: 'arvlcd-fire',
+ *     trip, lock, target, series, stats, now, log,
+ *   });
+ *   if (!decision.allowed) return;
+ *   ```
+ *
+ * lock 없는 경로(boarding-prompt / lockless)는 `lock=undefined`로 호출 — `TripContext`가
+ * `deviceHopsBehindTarget=null`로 평가돼 helper §5 fallback(허용)이 적용된다(false positive 차단 X,
+ * lockless trip을 갑자기 다 막지 않도록).
+ */
+interface EvaluatePushConsistencyForSiteInputs {
+  siteName: string;
+  trip: Pick<Trip, 'token'>;
+  lock: Pick<BoardingLockMeta, 'segmentStations'> | undefined;
+  target: PushTarget;
+  series: readonly PositionPoint[];
+  stats: ScheduledStats;
+  now: number;
+  log: Logger;
+  extraLog?: Record<string, unknown>;
+}
+
+export function evaluatePushConsistencyForSite(
+  inputs: EvaluatePushConsistencyForSiteInputs,
+): ConsistencyResult {
+  const { siteName, trip, lock, target, series, stats, now, log, extraLog } = inputs;
+  const ctx = buildPushConsistencyContextFromSeries(series, lock, target, now);
+  const result = evaluatePushConsistency(ctx.device, target, ctx.trip, now);
+  if (!result.allowed) {
+    stats.pushConsistencyBlocked += 1;
+    stats.pushConsistencyBlockedByReason[result.reason] += 1;
+    // extraLog를 먼저 spread해 호출자가 임의 키로 정합성 진단 필드(site/reason/token/target/...)를
+    // 덮어쓰지 못하도록 한다 (P1 — 진단 log 오염 차단).
+    log('push-consistency: blocked', {
+      ...(extraLog ?? {}),
+      site: siteName,
+      reason: result.reason,
+      token: trip.token.slice(0, 8),
+      target,
+      deviceStation: ctx.device.currentStationName,
+      motion: ctx.device.motion,
+      hops: ctx.trip.deviceHopsBehindTarget,
+    });
+  }
+  return result;
 }
 
 /**
@@ -832,6 +925,24 @@ export async function fireArvlCdStationPush(
     });
     return { dirty: false };
   }
+  // #1389 — 발사 직전 정합성 게이트. device positionSeries(currentStationName/motion)와 target waypoint가
+  // 모순일 때 차단(false positive 1차 방어). lock segmentStations가 있어 hops 산출 가능.
+  const series = await readSeries(env.TRIPS, trip.token);
+  const consistency = evaluatePushConsistencyForSite({
+    siteName: 'arvlcd-fire',
+    trip,
+    lock,
+    target: { stationName: waypoint.stationName, line: waypoint.line },
+    series,
+    stats,
+    now,
+    log,
+    extraLog: { trainCode: lock.trainCode, arvlCd, kind: waypoint.kind },
+  });
+  if (!consistency.allowed) {
+    // 차단 시 dedup KV는 stamp하지 않는다 — 다음 cycle에 motion이 회복되면 정상 발사 허용.
+    return { dirty: false };
+  }
   const pushId = generatePushId();
   log('arvlcd-fire: station-passed push', {
     token: trip.token.slice(0, 8),
@@ -926,6 +1037,25 @@ export async function fireVanishFallbackStationPush(
       trainCode: lock.trainCode,
       station: waypoint.stationName,
     });
+    return;
+  }
+  // #1389 — vanish fallback도 #1386 motion 가드 위에 정합성 게이트 추가 보강. lock 활성 trip이므로
+  // segmentStations로 device hops 산출. motion 가드가 stationary만 보지만 정합성 게이트는
+  // device-station-mismatch / device-ahead-of-target까지 잡는다.
+  const series = await readSeries(env.TRIPS, trip.token);
+  const consistency = evaluatePushConsistencyForSite({
+    siteName: 'vanish-fallback-fire',
+    trip,
+    lock,
+    target: { stationName: waypoint.stationName, line: waypoint.line },
+    series,
+    stats,
+    now,
+    log,
+    extraLog: { trainCode: lock.trainCode, kind: waypoint.kind },
+  });
+  if (!consistency.allowed) {
+    // dedup KV 미stamp — 다음 cycle 재시도 허용.
     return;
   }
   const pushId = generatePushId();
@@ -1468,6 +1598,25 @@ export async function maybeReschedulePush(
     return { cleanedUp: false };
   }
 
+  // #1389 — 정합성 게이트. reschedule push는 device 사전예약(`bl:`/`tba:`)을 정정하므로
+  // device가 명백히 target과 다른 위치를 확증할 때만 차단해야 한다(false positive 방어 우선).
+  // lastTrackedArrivalEpoch는 갱신하지 않아 다음 cycle 재발사 허용.
+  const series = await readSeries(env.TRIPS, trip.token);
+  const consistency = evaluatePushConsistencyForSite({
+    siteName: 'reschedule',
+    trip,
+    lock,
+    target: { stationName: waypoint.stationName, line: waypoint.line },
+    series,
+    stats,
+    now,
+    log,
+    extraLog: { trainCode: lock.trainCode, newArrivalTimeEpoch: newArrivalEpoch },
+  });
+  if (!consistency.allowed) {
+    return { cleanedUp: false };
+  }
+
   const pushId = generatePushId();
   log('reschedule push', {
     token: trip.token.slice(0, 8),
@@ -1717,6 +1866,24 @@ export async function runLocklessIntermediate(
       motion: fusion.posMetrics.motion,
       arvlCd: signal.arvlCd,
     });
+    if (dirty) await putTrip(env.TRIPS, trip);
+    return;
+  }
+  // #1389 — 정합성 게이트. lockless는 lock 부재라 segmentStations 없이 평가 — TripContext.hops=null
+  // fallback(허용). 하지만 WiFi mismatch / 모순 신호(stationary가 아닌데 WiFi !=) 는 평가됨.
+  // 추가로 motion=stationary는 이미 위 게이트가 잡았지만 WiFi mismatch(motion=stationary)는 보강 차단.
+  const locklessConsistency = evaluatePushConsistencyForSite({
+    siteName: 'lockless-intermediate',
+    trip,
+    lock: undefined,
+    target: { stationName: waypoint.stationName, line: waypoint.line },
+    series: fusion.series,
+    stats,
+    now,
+    log,
+    extraLog: { arvlCd: signal.arvlCd, kind: waypoint.kind },
+  });
+  if (!locklessConsistency.allowed) {
     if (dirty) await putTrip(env.TRIPS, trip);
     return;
   }
@@ -2017,6 +2184,30 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       await putTrip(env.TRIPS, trip);
       return;
     }
+  }
+
+  // #1389 — 9단 게이트 + auto-lock 실패 후 정합성 게이트 추가 보강. boarding-prompt의 target은
+  // 출발역(originStation). lock 부재라 hops=null fallback이지만, device가 명백히 다른 station을
+  // 확증(WiFi mismatch + stationary)하면 차단. 사용자가 출발역과 다른 곳에 있는데 "탑승했냐?" 묻는 헛 push 방어.
+  // fusion이 이미 series 읽었으므로 추가 KV read 없이 재사용.
+  const promptConsistency = evaluatePushConsistencyForSite({
+    siteName: 'boarding-prompt',
+    trip,
+    lock: undefined,
+    target: { stationName: display.originStation, line: display.line },
+    series: fusion.series,
+    stats,
+    now,
+    log,
+    extraLog: { originStation: display.originStation },
+  });
+  if (!promptConsistency.allowed) {
+    // boardingPromptEvaluated는 이미 +1 됐다. 운영 KPI invariant
+    // (evaluated = fired + blocked + autoLockSuccess + autoDeduped + consistency-blocked) 유지를 위해
+    // 정합성 차단도 boardingPromptBlocked에 카운트한다(상세 reason은 push-consistency:blocked log 참조).
+    stats.boardingPromptBlocked += 1;
+    if (dirty) await putTrip(env.TRIPS, trip);
+    return;
   }
 
   // 9단 통과 — alert push 발사.

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -515,7 +515,7 @@ export function evaluatePushConsistencyForSite(
     // extraLog를 먼저 spread해 호출자가 임의 키로 정합성 진단 필드(site/reason/token/target/...)를
     // 덮어쓰지 못하도록 한다 (P1 — 진단 log 오염 차단).
     log('push-consistency: blocked', {
-      ...(extraLog ?? {}),
+      ...extraLog,
       site: siteName,
       reason: result.reason,
       token: trip.token.slice(0, 8),


### PR DESCRIPTION
## Summary

#1389 epic의 **PR-2** — backend `scheduled.ts`의 5개 push 발사 사이트에 `evaluatePushConsistency` 정합성 게이트를 inline 적용. 사용자 device 신호(currentStationName / motion)가 backend target waypoint와 모순일 때 push 발사를 차단해 2026-06-16 용마산 정지 → 중곡 헛 push 회귀를 1차 방어한다.

> stacked on: PR #1390 (`fix/#1389-push-consistency-helper`)
>
> PR-1 머지 후 별도 rebase 진행 — Closes는 PR-3/PR-4 통합 시.

## 적용 사이트 (5곳)

| Site | 함수 | 정책 |
|---|---|---|
| 1 | `fireArvlCdStationPush` | lock-active arvlCd path. 차단 시 dedup KV 미stamp → 다음 cycle 재시도 |
| 2 | `fireVanishFallbackStationPush` | #1370 L2 fallback. #1386 motion 가드 위 §10 device-station-mismatch 보강 |
| 3 | `maybeReschedulePush` | reschedule silent push. lastTrackedArrivalEpoch 미갱신 → 다음 cycle 재평가 |
| 4 | `runLocklessIntermediate` | lockless intermediate. lock=undefined hops=null fallback (WiFi wire 후 활성) |
| 5 | `evaluateAndMaybeFireBoardingPrompt` | 9단 게이트 후 추가 보강. 차단 시 `boardingPromptBlocked++`로 KPI invariant 유지 |

## Helper 추출 (재사용성)

- `pushConsistencyContext.ts` — `extractDeviceSignal` + `computeDeviceHopsBehindTarget` + `buildPushConsistencyContextFromSeries` (positionSeries → DeviceSignal/TripContext, 1곳에서 추출).
- `evaluatePushConsistencyForSite` — 사이트 공통 wrapper. 평가/카운터/log 표준화. extraLog override 방어(P1).

## 카운터

- `pushConsistencyBlocked` — 차단 총합 (catalog 등록 → AE 적재 가능).
- `pushConsistencyBlockedByReason` — 4개 reason별 분포(`wifi-mismatch` / `motion-stationary-far-behind` / `device-station-mismatch` / `device-ahead-of-target`). 타입은 helper `ConsistencyResult` union에서 derive해 drift 차단.

## 검증

- `npx vitest run` — backend 1409 tests pass (이전 1380 + 신규 29: helper 16, wrapper 4, integration 5, 기타 4).
- `npx tsc --noEmit` (backend) — 신규 type 에러 0건 (line 1672 기존 2개는 base에 있는 사고).
- `npm run type-check` (frontend) — pass.
- reviewer agent 1차 + P1 3건 반영: extraLog 방어, boardingPrompt stat invariant, vanish-fallback 정합성 차단 직접 테스트.

## Test plan

- [ ] PR-1 (#1390) 머지 후 rebase로 base=dev 전환
- [ ] backend CI(`Type Check & Test`) 통과 확인
- [ ] 실기기 1주 회귀 측정 — `pushConsistencyBlocked` AE 적재 확인 후 PR-3/PR-4 진행
- [ ] 정지 trip 시나리오 재현 시 backend push 0건 확인

Refs #1389