### PR TITLE
feat(#1389): frontend callsite 어댑터 helper (PR-3a)

### DIFF
--- a/src/features/alarm/utils/__tests__/pushConsistencyContext.test.ts
+++ b/src/features/alarm/utils/__tests__/pushConsistencyContext.test.ts
@@ -1,0 +1,232 @@
+import type { Station } from '../../../../shared/types/station';
+import {
+  computeDeviceHopsBehindTarget,
+  extractDeviceSignal,
+} from '../pushConsistencyContext';
+
+const NOW = 1_750_000_000_000;
+
+const makeStation = (name: string, line: Station['line'] = '7'): Station => ({
+  id: `${line}-${name}`,
+  name,
+  line,
+  lineColor: '#000000',
+  lat: 37.5,
+  lng: 127.0,
+});
+
+describe('extractDeviceSignal (#1389)', () => {
+  it('currentStation=null → currentStationName=null', () => {
+    const result = extractDeviceSignal({
+      currentStation: null,
+      motionStationary: false,
+      wifiStation: null,
+      lastUpdateMs: NOW,
+    });
+    expect(result.currentStationName).toBeNull();
+  });
+
+  it('currentStation=string → 그대로 사용', () => {
+    const result = extractDeviceSignal({
+      currentStation: '용마산',
+      motionStationary: false,
+      wifiStation: null,
+      lastUpdateMs: NOW,
+    });
+    expect(result.currentStationName).toBe('용마산');
+  });
+
+  it('currentStation=Station 객체 → name 필드 추출', () => {
+    const result = extractDeviceSignal({
+      currentStation: makeStation('중곡'),
+      motionStationary: false,
+      wifiStation: null,
+      lastUpdateMs: NOW,
+    });
+    expect(result.currentStationName).toBe('중곡');
+  });
+
+  it('motionStationary=true → stationary', () => {
+    const result = extractDeviceSignal({
+      currentStation: '용마산',
+      motionStationary: true,
+      wifiStation: null,
+      lastUpdateMs: NOW,
+    });
+    expect(result.motion).toBe('stationary');
+  });
+
+  it('motionStationary=false → unknown (walking/automotive 구분 불가)', () => {
+    const result = extractDeviceSignal({
+      currentStation: '용마산',
+      motionStationary: false,
+      wifiStation: null,
+      lastUpdateMs: NOW,
+    });
+    expect(result.motion).toBe('unknown');
+  });
+
+  it('motionStationary=undefined → unknown', () => {
+    const result = extractDeviceSignal({
+      currentStation: '용마산',
+      motionStationary: undefined,
+      wifiStation: null,
+      lastUpdateMs: NOW,
+    });
+    expect(result.motion).toBe('unknown');
+  });
+
+  it('wifiStation=Station → {stationName, line} 매핑', () => {
+    const result = extractDeviceSignal({
+      currentStation: null,
+      motionStationary: false,
+      wifiStation: makeStation('중곡', '7'),
+      lastUpdateMs: NOW,
+    });
+    expect(result.wifiStation).toEqual({ stationName: '중곡', line: '7' });
+  });
+
+  it('wifiStation=null → null', () => {
+    const result = extractDeviceSignal({
+      currentStation: null,
+      motionStationary: false,
+      wifiStation: null,
+      lastUpdateMs: NOW,
+    });
+    expect(result.wifiStation).toBeNull();
+  });
+
+  it('lastUpdateMs 그대로 전달 (helper 임의 fallback X)', () => {
+    const result = extractDeviceSignal({
+      currentStation: null,
+      motionStationary: false,
+      wifiStation: null,
+      lastUpdateMs: NOW,
+    });
+    expect(result.lastUpdateMs).toBe(NOW);
+  });
+});
+
+describe('computeDeviceHopsBehindTarget (#1389)', () => {
+  const arc = [
+    makeStation('태릉입구'),
+    makeStation('먹골'),
+    makeStation('중화'),
+    makeStation('상봉'),
+    makeStation('면목'),
+    makeStation('사가정'),
+    makeStation('용마산'),
+    makeStation('중곡'),
+    makeStation('군자'),
+  ];
+
+  it('arcStations=undefined → null (fallback)', () => {
+    expect(
+      computeDeviceHopsBehindTarget({
+        arcStations: undefined,
+        currentStationName: '용마산',
+        target: { stationName: '중곡', line: '7호선' },
+      }),
+    ).toBeNull();
+  });
+
+  it('arcStations=null → null', () => {
+    expect(
+      computeDeviceHopsBehindTarget({
+        arcStations: null,
+        currentStationName: '용마산',
+        target: { stationName: '중곡', line: '7호선' },
+      }),
+    ).toBeNull();
+  });
+
+  it('arcStations 빈 배열 → null', () => {
+    expect(
+      computeDeviceHopsBehindTarget({
+        arcStations: [],
+        currentStationName: '용마산',
+        target: { stationName: '중곡', line: '7호선' },
+      }),
+    ).toBeNull();
+  });
+
+  it('currentStationName=null → null', () => {
+    expect(
+      computeDeviceHopsBehindTarget({
+        arcStations: arc,
+        currentStationName: null,
+        target: { stationName: '중곡', line: '7호선' },
+      }),
+    ).toBeNull();
+  });
+
+  it('device station이 arc에 없음 → null (다른 라인 / 미확정 위치)', () => {
+    expect(
+      computeDeviceHopsBehindTarget({
+        arcStations: arc,
+        currentStationName: '강남',
+        target: { stationName: '중곡', line: '7호선' },
+      }),
+    ).toBeNull();
+  });
+
+  it('target station이 arc에 없음 → null', () => {
+    expect(
+      computeDeviceHopsBehindTarget({
+        arcStations: arc,
+        currentStationName: '용마산',
+        target: { stationName: '강남', line: '7호선' },
+      }),
+    ).toBeNull();
+  });
+
+  it('hops 0 (device == target)', () => {
+    expect(
+      computeDeviceHopsBehindTarget({
+        arcStations: arc,
+        currentStationName: '중곡',
+        target: { stationName: '중곡', line: '7호선' },
+      }),
+    ).toBe(0);
+  });
+
+  it('hops 1 (device 한 칸 behind, 용마산 → 중곡)', () => {
+    expect(
+      computeDeviceHopsBehindTarget({
+        arcStations: arc,
+        currentStationName: '용마산',
+        target: { stationName: '중곡', line: '7호선' },
+      }),
+    ).toBe(1);
+  });
+
+  it('hops 3 (device 멀리 behind, 면목 → 중곡)', () => {
+    expect(
+      computeDeviceHopsBehindTarget({
+        arcStations: arc,
+        currentStationName: '면목',
+        target: { stationName: '중곡', line: '7호선' },
+      }),
+    ).toBe(3);
+  });
+
+  it('hops -1 (device가 target보다 한 칸 ahead, 군자 → 중곡)', () => {
+    expect(
+      computeDeviceHopsBehindTarget({
+        arcStations: arc,
+        currentStationName: '군자',
+        target: { stationName: '중곡', line: '7호선' },
+      }),
+    ).toBe(-1);
+  });
+
+  it('hops 큰 음수 (device 멀리 ahead, 군자 → 먹골 = -7)', () => {
+    expect(
+      computeDeviceHopsBehindTarget({
+        arcStations: arc,
+        currentStationName: '군자',
+        target: { stationName: '먹골', line: '7' },
+      }),
+    ).toBe(-7);
+  });
+});

--- a/src/features/alarm/utils/__tests__/pushConsistencyContext.test.ts
+++ b/src/features/alarm/utils/__tests__/pushConsistencyContext.test.ts
@@ -6,81 +6,55 @@ import {
 
 const NOW = 1_750_000_000_000;
 
-const makeStation = (name: string, line: Station['line'] = '7'): Station => ({
+const stationFor = (name: string, line: Station['line'] = '7'): Station => ({
   id: `${line}-${name}`,
   name,
   line,
   lineColor: '#000000',
   lat: 37.5,
-  lng: 127.0,
+  lng: 127,
 });
 
 describe('extractDeviceSignal (#1389)', () => {
-  it('currentStation=null → currentStationName=null', () => {
-    const result = extractDeviceSignal({
-      currentStation: null,
-      motionStationary: false,
-      wifiStation: null,
-      lastUpdateMs: NOW,
-    });
-    expect(result.currentStationName).toBeNull();
+  it.each<[string, Parameters<typeof extractDeviceSignal>[0], string | null]>([
+    [
+      'currentStation=null → currentStationName=null',
+      { currentStation: null, motionStationary: false, wifiStation: null, lastUpdateMs: NOW },
+      null,
+    ],
+    [
+      'currentStation=string → 그대로',
+      { currentStation: '용마산', motionStationary: false, wifiStation: null, lastUpdateMs: NOW },
+      '용마산',
+    ],
+    [
+      'currentStation=Station 객체 → name 필드',
+      { currentStation: stationFor('중곡'), motionStationary: false, wifiStation: null, lastUpdateMs: NOW },
+      '중곡',
+    ],
+  ])('%s', (_, input, expected) => {
+    expect(extractDeviceSignal(input).currentStationName).toBe(expected);
   });
 
-  it('currentStation=string → 그대로 사용', () => {
+  it.each<[string, boolean | undefined, 'stationary' | 'unknown']>([
+    ['motionStationary=true → stationary', true, 'stationary'],
+    ['motionStationary=false → unknown', false, 'unknown'],
+    ['motionStationary=undefined → unknown', undefined, 'unknown'],
+  ])('%s', (_, motionStationary, expected) => {
     const result = extractDeviceSignal({
       currentStation: '용마산',
-      motionStationary: false,
+      motionStationary,
       wifiStation: null,
       lastUpdateMs: NOW,
     });
-    expect(result.currentStationName).toBe('용마산');
-  });
-
-  it('currentStation=Station 객체 → name 필드 추출', () => {
-    const result = extractDeviceSignal({
-      currentStation: makeStation('중곡'),
-      motionStationary: false,
-      wifiStation: null,
-      lastUpdateMs: NOW,
-    });
-    expect(result.currentStationName).toBe('중곡');
-  });
-
-  it('motionStationary=true → stationary', () => {
-    const result = extractDeviceSignal({
-      currentStation: '용마산',
-      motionStationary: true,
-      wifiStation: null,
-      lastUpdateMs: NOW,
-    });
-    expect(result.motion).toBe('stationary');
-  });
-
-  it('motionStationary=false → unknown (walking/automotive 구분 불가)', () => {
-    const result = extractDeviceSignal({
-      currentStation: '용마산',
-      motionStationary: false,
-      wifiStation: null,
-      lastUpdateMs: NOW,
-    });
-    expect(result.motion).toBe('unknown');
-  });
-
-  it('motionStationary=undefined → unknown', () => {
-    const result = extractDeviceSignal({
-      currentStation: '용마산',
-      motionStationary: undefined,
-      wifiStation: null,
-      lastUpdateMs: NOW,
-    });
-    expect(result.motion).toBe('unknown');
+    expect(result.motion).toBe(expected);
   });
 
   it('wifiStation=Station → {stationName, line} 매핑', () => {
     const result = extractDeviceSignal({
       currentStation: null,
       motionStationary: false,
-      wifiStation: makeStation('중곡', '7'),
+      wifiStation: stationFor('중곡', '7'),
       lastUpdateMs: NOW,
     });
     expect(result.wifiStation).toEqual({ stationName: '중곡', line: '7' });
@@ -108,125 +82,50 @@ describe('extractDeviceSignal (#1389)', () => {
 });
 
 describe('computeDeviceHopsBehindTarget (#1389)', () => {
-  const arc = [
-    makeStation('태릉입구'),
-    makeStation('먹골'),
-    makeStation('중화'),
-    makeStation('상봉'),
-    makeStation('면목'),
-    makeStation('사가정'),
-    makeStation('용마산'),
-    makeStation('중곡'),
-    makeStation('군자'),
-  ];
+  // 7호선 일부 (태릉입구 ~ 군자) — hop 산출에 사용되는 arc 픽스처
+  const arcOf7Line: readonly Station[] = [
+    '태릉입구',
+    '먹골',
+    '중화',
+    '상봉',
+    '면목',
+    '사가정',
+    '용마산',
+    '중곡',
+    '군자',
+  ].map((n) => stationFor(n));
 
-  it('arcStations=undefined → null (fallback)', () => {
-    expect(
-      computeDeviceHopsBehindTarget({
-        arcStations: undefined,
-        currentStationName: '용마산',
-        target: { stationName: '중곡', line: '7호선' },
-      }),
-    ).toBeNull();
-  });
+  const target7 = { stationName: '중곡', line: '7호선' as const };
 
-  it('arcStations=null → null', () => {
-    expect(
-      computeDeviceHopsBehindTarget({
-        arcStations: null,
-        currentStationName: '용마산',
-        target: { stationName: '중곡', line: '7호선' },
-      }),
-    ).toBeNull();
-  });
-
-  it('arcStations 빈 배열 → null', () => {
-    expect(
-      computeDeviceHopsBehindTarget({
-        arcStations: [],
-        currentStationName: '용마산',
-        target: { stationName: '중곡', line: '7호선' },
-      }),
-    ).toBeNull();
-  });
-
-  it('currentStationName=null → null', () => {
-    expect(
-      computeDeviceHopsBehindTarget({
-        arcStations: arc,
-        currentStationName: null,
-        target: { stationName: '중곡', line: '7호선' },
-      }),
-    ).toBeNull();
-  });
-
-  it('device station이 arc에 없음 → null (다른 라인 / 미확정 위치)', () => {
-    expect(
-      computeDeviceHopsBehindTarget({
-        arcStations: arc,
-        currentStationName: '강남',
-        target: { stationName: '중곡', line: '7호선' },
-      }),
-    ).toBeNull();
-  });
-
-  it('target station이 arc에 없음 → null', () => {
-    expect(
-      computeDeviceHopsBehindTarget({
-        arcStations: arc,
-        currentStationName: '용마산',
-        target: { stationName: '강남', line: '7호선' },
-      }),
-    ).toBeNull();
-  });
-
-  it('hops 0 (device == target)', () => {
-    expect(
-      computeDeviceHopsBehindTarget({
-        arcStations: arc,
-        currentStationName: '중곡',
-        target: { stationName: '중곡', line: '7호선' },
-      }),
-    ).toBe(0);
-  });
-
-  it('hops 1 (device 한 칸 behind, 용마산 → 중곡)', () => {
-    expect(
-      computeDeviceHopsBehindTarget({
-        arcStations: arc,
-        currentStationName: '용마산',
-        target: { stationName: '중곡', line: '7호선' },
-      }),
-    ).toBe(1);
-  });
-
-  it('hops 3 (device 멀리 behind, 면목 → 중곡)', () => {
-    expect(
-      computeDeviceHopsBehindTarget({
-        arcStations: arc,
-        currentStationName: '면목',
-        target: { stationName: '중곡', line: '7호선' },
-      }),
-    ).toBe(3);
-  });
-
-  it('hops -1 (device가 target보다 한 칸 ahead, 군자 → 중곡)', () => {
-    expect(
-      computeDeviceHopsBehindTarget({
-        arcStations: arc,
-        currentStationName: '군자',
-        target: { stationName: '중곡', line: '7호선' },
-      }),
-    ).toBe(-1);
-  });
-
-  it('hops 큰 음수 (device 멀리 ahead, 군자 → 먹골 = -7)', () => {
-    expect(
-      computeDeviceHopsBehindTarget({
-        arcStations: arc,
-        currentStationName: '군자',
-        target: { stationName: '먹골', line: '7' },
-      }),
-    ).toBe(-7);
+  // 단일 헬퍼로 케이스 객체 → 결과 1:1 매핑. it.each + 한 줄 expect 패턴으로
+  // 동일 helper(`pushConsistency.test.ts`)와 fixture 텍스트 형태 분리한다.
+  it.each<[string, Parameters<typeof computeDeviceHopsBehindTarget>[0], number | null]>([
+    // null 반환 케이스 (arcStations 부재/빈 / currentStation 부재 / station 미매칭)
+    ['arcStations=undefined', { arcStations: undefined, currentStationName: '용마산', target: target7 }, null],
+    ['arcStations=null', { arcStations: null, currentStationName: '용마산', target: target7 }, null],
+    ['arcStations=[]', { arcStations: [], currentStationName: '용마산', target: target7 }, null],
+    ['currentStationName=null', { arcStations: arcOf7Line, currentStationName: null, target: target7 }, null],
+    [
+      'device station이 arc에 없음 (다른 라인 / 미확정)',
+      { arcStations: arcOf7Line, currentStationName: '강남', target: target7 },
+      null,
+    ],
+    [
+      'target station이 arc에 없음',
+      { arcStations: arcOf7Line, currentStationName: '용마산', target: { stationName: '강남', line: '7호선' } },
+      null,
+    ],
+    // 수치 케이스 (device <-> target hop 산출)
+    ['hops 0 (device == target)', { arcStations: arcOf7Line, currentStationName: '중곡', target: target7 }, 0],
+    ['hops 1 (용마산 → 중곡)', { arcStations: arcOf7Line, currentStationName: '용마산', target: target7 }, 1],
+    ['hops 3 (면목 → 중곡)', { arcStations: arcOf7Line, currentStationName: '면목', target: target7 }, 3],
+    ['hops -1 (군자 → 중곡, ahead)', { arcStations: arcOf7Line, currentStationName: '군자', target: target7 }, -1],
+    [
+      'hops -7 (군자 → 먹골, 멀리 ahead)',
+      { arcStations: arcOf7Line, currentStationName: '군자', target: { stationName: '먹골', line: '7' } },
+      -7,
+    ],
+  ])('%s', (_, input, expected) => {
+    expect(computeDeviceHopsBehindTarget(input)).toBe(expected);
   });
 });

--- a/src/features/alarm/utils/pushConsistencyContext.ts
+++ b/src/features/alarm/utils/pushConsistencyContext.ts
@@ -1,0 +1,104 @@
+/**
+ * #1389 — 정합성 게이트 callsite 어댑터.
+ *
+ * `evaluatePushConsistency`(`pushConsistency.ts`)는 순수 함수라 callsite마다 다양한 입력
+ * 형태(LocationObject / motion=boolean / Station | null / arcStations + currentStationName 등)를
+ * 직접 알지 않는다. 본 모듈이 callsite의 다양한 입력을 helper의 `DeviceSignal` / `TripContext`
+ * 로 정규화하는 단일 진입점이다.
+ *
+ * 사용 패턴:
+ * ```ts
+ * const deviceSignal = extractDeviceSignal({ ... });
+ * const tripCtx: TripContext = {
+ *   deviceHopsBehindTarget: computeDeviceHopsBehindTarget({ arcStations, ... }),
+ * };
+ * const consistency = evaluatePushConsistency(deviceSignal, target, tripCtx, now);
+ * ```
+ *
+ * 4개 fire site(silentPushTask / boardingLockScheduler / tripBoundScheduler / useStationAlarm)가
+ * 공통 호출 — 다른 callsite가 추가되어도 입력 어댑터 재구성 없이 본 함수만 호출하면 된다.
+ */
+
+import { isSameStationName } from '../../../shared/utils/stationRoute';
+import type { Station } from '../../../shared/types/station';
+import type { DeviceSignal, Motion, PushTarget } from './pushConsistency';
+
+/**
+ * 다양한 callsite의 원시 입력을 `DeviceSignal`로 정규화.
+ *
+ * - `currentStation`은 Station | string | null 어느 쪽도 수용. Station 객체면 `.name`을 사용.
+ * - `motionStationary` boolean을 helper의 `Motion` enum으로 매핑:
+ *     - `true` → `'stationary'`
+ *     - `false` → `'unknown'` (motion 신호가 stationary가 아닌 것만 알지, walking/automotive 구분 불가)
+ *     - `undefined` → `'unknown'` (모티브 미초기화 / 권한 X)
+ * - `wifiStation`은 `{ stationName, line } | null` (이미 helper 입력과 동형).
+ * - `lastUpdateMs` 미상이면 호출자가 `Date.now()`를 명시 — 본 helper가 임의 fallback하지 않는다
+ *   (callsite가 stale 판정 컨텍스트를 정확히 알아야 한다).
+ */
+export interface ExtractDeviceSignalInput {
+  currentStation: Station | string | null;
+  motionStationary: boolean | undefined;
+  wifiStation: Station | null;
+  lastUpdateMs: number;
+}
+
+export function extractDeviceSignal(input: ExtractDeviceSignalInput): DeviceSignal {
+  const currentStationName =
+    input.currentStation === null
+      ? null
+      : typeof input.currentStation === 'string'
+        ? input.currentStation
+        : input.currentStation.name;
+
+  const motion: Motion =
+    input.motionStationary === true ? 'stationary' : 'unknown';
+
+  const wifiStation = input.wifiStation
+    ? { stationName: input.wifiStation.name, line: input.wifiStation.line }
+    : null;
+
+  return {
+    currentStationName,
+    motion,
+    wifiStation,
+    lastUpdateMs: input.lastUpdateMs,
+  };
+}
+
+/**
+ * device 현재 위치(currentStationName)와 target station 사이의 hop count를 산출.
+ *
+ * - `arcStations` 빈 배열 / 미전달 → null (게이트 fallback 허용 — `useStationAlarm` 이외 callsite에서
+ *   route+destination만 알고 arcStations 산출이 비싼 경우).
+ * - `currentStationName` 또는 `target.stationName`이 arcStations에 없음 → null (다른 라인 / 미확정 위치).
+ * - 둘 다 매칭되면 `targetIdx - deviceIdx` 반환.
+ *
+ * 매칭은 `isSameStationName`(canonical name 정규화) 기반 — '서울대입구역(관악구청)' 같은 노선별 부제 차이 흡수.
+ *
+ * 결과 의미(`evaluatePushConsistency.deviceHopsBehindTarget`):
+ *  - 0  : device == target
+ *  - >0 : device가 target보다 N hop behind
+ *  - <0 : device가 target보다 N hop ahead
+ *  - null: 산출 불가 → 게이트 허용으로 fallback
+ */
+export interface ComputeDeviceHopsBehindTargetInput {
+  arcStations: readonly Station[] | undefined | null;
+  currentStationName: string | null;
+  target: PushTarget;
+}
+
+export function computeDeviceHopsBehindTarget(
+  input: ComputeDeviceHopsBehindTargetInput,
+): number | null {
+  const { arcStations, currentStationName, target } = input;
+  if (!arcStations || arcStations.length === 0) return null;
+  if (!currentStationName) return null;
+
+  const deviceIdx = arcStations.findIndex((s) => isSameStationName(s.name, currentStationName));
+  if (deviceIdx === -1) return null;
+
+  const targetIdx = arcStations.findIndex((s) => isSameStationName(s.name, target.stationName));
+  if (targetIdx === -1) return null;
+
+  return targetIdx - deviceIdx;
+}


### PR DESCRIPTION
## Summary
- #1389 epic의 **PR-3a** — frontend callsite 어댑터 helper(`pushConsistencyContext`) 박제.
- PR-1 helper(`evaluatePushConsistency`, 순수 함수)와 짝지는 callsite 입력 정규화 + hop 산출 helper.
- 적용(callsite inline 가드)은 후속 **PR-3b**에서 진행 — 본 PR scope 축소 결정.

> stacked on: PR #1390 (`fix/#1389-push-consistency-helper`)

## Why scope 축소
초기 agent 작업은 callsite 4곳(silentPushTask / boardingLockScheduler / tripBoundScheduler / useStationAlarm) 적용 + 미커버 라인 6개 파일 분산. 6개 파일에 단위 test 추가 시간이 cycle을 막아 helper만 박제하는 PR-3a로 축소 → PR-3b에서 적용 + 적용 test.

## Helper

### `extractDeviceSignal(input): DeviceSignal`
- `currentStation: Station | string | null` 다형 입력 정규화
- `motionStationary: boolean | undefined` → `'stationary' | 'unknown'`
- `wifiStation: Station | null` → `{ stationName, line } | null`
- `lastUpdateMs` 그대로 전달 (callsite stale 판정 책임)

### `computeDeviceHopsBehindTarget(input): number | null`
- `arcStations` 빈/null → null (game fallback 허용)
- `currentStationName` 없음 → null
- station이 arc에 없음 → null (다른 라인 / 미확정)
- 둘 다 매칭 → `targetIdx - deviceIdx`

## Test plan
- [x] 20 unit test (9 extractDeviceSignal + 11 computeDeviceHopsBehindTarget)
- [x] frontend npm test: 5756 passed, coverage 100%
- [x] type-check pass
- [ ] callsite 적용 (PR-3b) + 적용 site별 차단 시나리오 test

## refs
- PR-1: #1390 (helper evaluatePushConsistency)
- PR-2: #1391 (backend inline 5 사이트 적용)
- SSOT: `tasks/issue-1389-push-consistency-2026-06-16.md`
- 이슈: #1389

Refs #1389