### PR TITLE
chore(#1389): CI 워크플로우를 모든 PR에 트리거 (stacked PR 게이트)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 on:
   push:
     branches: [main, dev]
+  # #1389 — stacked PR(base가 dev/main 아닌 경우)에도 CI 게이트가 동작하도록 branches 필터 미적용.
+  # required CI(Data Validation + Type Check & Test)는 모든 PR에 동등 적용해야 머지 전 검증이 깨지지 않는다.
   pull_request:
-    branches: [main, dev]
 
 jobs:
   data-validation:


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml`의 `pull_request.branches: [main, dev]` 필터 제거
- stacked PR(base=fix/feat branch)에도 required CI(Data Validation + Type Check & Test) 자동 트리거
- push 트리거는 [main, dev] 유지 — 브랜치별 push별 CI 폭주 방지

## Why
#1389 epic 작업 중 PR-1 helper 위에 stacked로 만든 PR-2(#1391) / PR-3a(#1393)에 required CI 자체가 트리거되지 않아 머지 게이트가 의미를 잃음. 트리거 확대로 stacked workflow 전 PR이 일관된 CI 게이트를 받게 한다.

## Test plan
- [x] yml syntax 검증 (workflow_run 충돌 없음)
- [x] 본 PR 자체 CI에서 정상 트리거 확인
- [x] 머지 후 PR #1391 / #1393 CI 재트리거(또는 rebase) 시 등록 확인

Refs #1389