### PR TITLE
feat(#1389): frontend inline callsite + 미커버 test (PR-3b)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -108,6 +108,19 @@ jest.mock('../../utils/boardingLockStorage', () => ({
   getBoardingLock: () => mockGetBoardingLock(),
 }));
 
+// #1389 — FG fire 정합성 게이트 helper. 기본 allow — 기존 fire 테스트 동작 보존.
+// 차단 시나리오만 본 PR 신규 describe에서 disallowed override.
+const mockEvaluateLocalFireConsistency = jest.fn(() => ({ allowed: true } as
+  | { allowed: true }
+  | { allowed: false }));
+const mockResolveTargetLine = jest.fn((_target: string, _arc, near) =>
+  near?.line ?? '',
+);
+jest.mock('../../utils/localFireConsistencyGate', () => ({
+  evaluateLocalFireConsistency: (input: unknown) => mockEvaluateLocalFireConsistency(),
+  resolveTargetLine: (...args: unknown[]) => mockResolveTargetLine(args[0] as string, args[1] as never, args[2] as never),
+}));
+
 const mockAwaitInitialScheduledAlarmDrain = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../utils/scheduledAlarmReceiver', () => ({
   awaitInitialScheduledAlarmDrain: () => mockAwaitInitialScheduledAlarmDrain(),
@@ -182,6 +195,8 @@ describe('useStationAlarm', () => {
     mockGetBoardingLock.mockResolvedValue(null);
     mockFindFgArvlCdFireSignal.mockReturnValue(null);
     mockAwaitInitialScheduledAlarmDrain.mockResolvedValue(undefined);
+    // #1389 — 정합성 게이트 기본 allow (clearAllMocks가 impl 지움).
+    mockEvaluateLocalFireConsistency.mockReturnValue({ allowed: true });
   });
 
   it('does not evaluate when route is null', () => {
@@ -3861,6 +3876,133 @@ describe('useStationAlarm', () => {
       resolvers.forEach((r) => r(null));
       for (let i = 0; i < 8; i++) await Promise.resolve();
 
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  // #1389 — 5개 callsite의 정합성 게이트 disallow 경로 검증.
+  // helper 본체는 localFireConsistencyGate.test.ts에서 분기별로 검증. 본 describe는 callsite에서
+  // helper false 반환 시 fire site가 정상 차단되는지(early return)만 확인.
+  describe('#1389 정합성 게이트 callsite 차단', () => {
+    beforeEach(() => {
+      mockEvaluateLocalFireConsistency.mockReturnValue({ allowed: false });
+    });
+
+    it('phase ETA: consistency=false → fire skip', async () => {
+      const route = makeDirectRoute(1, '2');
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+      // helper false → sendAlarmNotification 호출 안 됨
+      await new Promise((r) => setTimeout(r, 30));
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    it('API imminent: consistency=false → fire skip', async () => {
+      const route = makeDirectRoute(1, '2');
+      mockIsImminentByArrivalCode.mockReturnValue(true);
+      mockUseArrivalInfo.mockReturnValue({
+        arrival: {
+          destination: [
+            {
+              stationName: '강남',
+              arrivalCode: '0',
+              barvlDt: '60',
+              trainCode: 'T-1',
+              ord: 1,
+            },
+          ],
+        },
+        loading: false,
+        isMock: false,
+      });
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: makeStation('S1', '역삼'),
+            accuracyMeters: 30,
+            speedMps: 10,
+            userLocation: { lat: destination.lat, lng: destination.lng },
+          }),
+        ),
+      );
+      await new Promise((r) => setTimeout(r, 30));
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    it('station-passed (GPS): consistency=false → station-passed fire skip', async () => {
+      const route = makeDirectRoute(2, '2');
+      const station = makeStation('S2', '역삼');
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockEvaluateAlarmPhase.mockReturnValue(null);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: station,
+            accuracyMeters: 30,
+          }),
+        ),
+      );
+      await new Promise((r) => setTimeout(r, 30));
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('fast-path arvlcd: consistency=false → station-passed fire skip', async () => {
+      // 기존 fast path test의 onRouteStation/route/dummyArrival 셋업을 모방해 effect 진입 보장.
+      const localRoute = makeDirectRoute(3, '2');
+      const onRoute: Station = makeStation('s-onroute', '역삼');
+      const dummy = { up: [], down: [] } as unknown as Parameters<
+        typeof useStationAlarm
+      >[0]['currentStationArrival'];
+      mockFindFgArvlCdFireSignal.mockReturnValue({
+        candidateStation: onRoute,
+        boardingLine: '2',
+        signalCode: 0,
+      });
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockGetBoardingLock.mockResolvedValue({
+        destinationId: 'D1',
+        trainCode: 'T-1',
+        boardingStationId: '1-001',
+        boardingLine: '2',
+        boardedAt: 1_750_000_000_000,
+        expectedDurationMs: 600_000,
+      });
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: localRoute,
+            destination,
+            nearestStation: onRoute,
+            speedMps: 5,
+            accuracyMeters: 50,
+            currentStationArrival: dummy,
+          }),
+        ),
+      );
+      await new Promise((r) => setTimeout(r, 30));
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('subsurface station-passed: consistency=false → fire skip', async () => {
+      const route = makeDirectRoute(2, '2');
+      const station = makeStation('S2', '역삼');
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockGetBoardingLock.mockResolvedValue(null);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: station,
+            subsurfaceStationDetected: true,
+          }),
+        ),
+      );
+      await new Promise((r) => setTimeout(r, 30));
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
   });

--- a/src/features/alarm/hooks/__tests__/useTripBoundAlarmScheduler.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useTripBoundAlarmScheduler.test.tsx
@@ -4,7 +4,7 @@
  */
 import { AppState, type NativeEventSubscription } from 'react-native';
 import { renderHook, waitFor } from '@testing-library/react-native';
-import { useTripBoundAlarmScheduler } from '../useTripBoundAlarmScheduler';
+import { useTripBoundAlarmScheduler, resolveBoardingStation } from '../useTripBoundAlarmScheduler';
 import type { ScheduledTripBoundAlarm } from '../../utils/tripBoundScheduler';
 import {
   cancelTripBoundAlarms,
@@ -550,6 +550,41 @@ describe('useTripBoundAlarmScheduler', () => {
     unmount();
     expect(remove).toHaveBeenCalled();
     spy.mockRestore();
+  });
+});
+
+// #1389 — resolveBoardingStation helper. lock=null / 매핑 실패 / 매핑 성공 3분기.
+describe('resolveBoardingStation (#1389)', () => {
+  // helper는 getStationById를 stationRoute에서 import — 실제 stations.json 데이터 조회.
+
+  it('lock === null → null 반환 (lockless / 컨텍스트 부재)', () => {
+    expect(resolveBoardingStation(null)).toBeNull();
+  });
+
+  it('lock 있으나 boardingStationId가 stations.json에 없음 → null (graceful)', () => {
+    const lock: BoardingLock = {
+      destinationId: 'dest-1',
+      trainCode: 'T-1',
+      boardingStationId: 'non-existent-id',
+      boardingLine: '2',
+      boardedAt: 1_750_000_000_000,
+      expectedDurationMs: 600_000,
+    };
+    expect(resolveBoardingStation(lock)).toBeNull();
+  });
+
+  it('lock + getStationById 매핑 성공 → { stationName, line } 반환', () => {
+    // stations.json에 존재하는 id를 사용 — '1-001' (소요산, line 1).
+    const lock: BoardingLock = {
+      destinationId: 'dest-1',
+      trainCode: 'T-1',
+      boardingStationId: '1-001',
+      boardingLine: '1',
+      boardedAt: 1_750_000_000_000,
+      expectedDurationMs: 600_000,
+    };
+    const result = resolveBoardingStation(lock);
+    expect(result).toEqual({ stationName: '소요산', line: '1' });
   });
 });
 

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -58,6 +58,11 @@ import type { BoardingLock } from '../../../shared/types/boardingLock';
 import type { LineNumber } from '../../../shared/types/station';
 import { isStationPassedFirstHop, shouldSuppressBySleepRule } from '../utils/shouldSuppressBySleepRule';
 import { evaluateMovement, MOVEMENT_TO_ALARM_LOG_REASON } from '../../nearest-station/utils/movementGate';
+// #1389 — FG fire site 공통 정합성 게이트 helper. silentPushTask / scheduler와 동일 SSOT.
+import {
+  evaluateLocalFireConsistency,
+  resolveTargetLine,
+} from '../utils/localFireConsistencyGate';
 import type { PositionStability } from '../../nearest-station/utils/positionStaticDetector';
 import { useSettingsStore } from '../../settings/store/useSettingsStore';
 import { useAlarmEventStore } from '../store/useAlarmEventStore';
@@ -335,6 +340,12 @@ export interface UseStationAlarmInputs {
    * 미전달/false면 기존 동작 유지(graceful fallback).
    */
   subsurfaceStationDetected?: boolean;
+  /**
+   * #1389 — 정합성 게이트 입력. WiFi SSID 매칭으로 확정된 현재역.
+   * 호출자가 `useWifiStation()` 결과를 그대로 전달. null이면 WiFi 확증 없음 → 게이트가 다른 신호로 평가.
+   * 미전달이면 게이트의 WiFi 분기는 자연 skip(허용 fallback).
+   */
+  wifiStation?: Station | null;
 }
 
 export function useStationAlarm({
@@ -354,6 +365,7 @@ export function useStationAlarm({
   currentHopIndex = null,
   arcStations,
   subsurfaceStationDetected = false,
+  wifiStation = null,
 }: UseStationAlarmInputs): void {
   const firedAlarmsRef = useRef<Set<string>>(new Set());
   // #699: firedAlarmsRef의 내용이 어느 destinationId에 속하는지 추적.
@@ -670,6 +682,22 @@ export function useStationAlarm({
         });
         return;
       }
+      // #1389 — 정합성 게이트. target line은 arcStations에서 동일 이름 stop의 line 사용
+      // (arcStations 미전달 시 nearestStation.line fallback — 같은 라인 가정).
+      const targetLine = resolveTargetLine(rawEvent.stationName, arcStations, nearestStation);
+      const consistency = evaluateLocalFireConsistency({
+        targetStationName: rawEvent.stationName,
+        targetLine,
+        source: 'fg',
+        kind: rawEvent.type,
+        phaseId: rawEvent.phaseId,
+        nearestStation,
+        motionStationary,
+        wifiStation,
+        arcStations,
+        now: Date.now(),
+      });
+      if (!consistency.allowed) return;
       void fireAndLog(rawEvent, 'eta', route, destination);
     }
   }, [
@@ -696,6 +724,9 @@ export function useStationAlarm({
     // #903 — degraded 평가는 arrivalConfidence에서 파생. 지하 진입으로 'gps-only'→
     // 'gps-only-underground' 단독 전환 시(다른 deps 정적) 본 effect 재실행되어 차단 정책 즉시 반영.
     arrivalConfidence,
+    // #1389 — 정합성 게이트 신호 변경 시 재평가 (wifi 매칭, arc 갱신, nearest 갱신).
+    wifiStation?.name,
+    arcStations,
   ]);
 
   // #396: 도착정보 API 신호로 imminent 발사.
@@ -762,6 +793,21 @@ export function useStationAlarm({
       return;
     }
 
+    // #1389 — 정합성 게이트. destination line은 destination.line.
+    const consistency = evaluateLocalFireConsistency({
+      targetStationName: destination.name,
+      targetLine: destination.line,
+      source: 'fg',
+      kind: 'destination',
+      phaseId: 'imminent',
+      nearestStation,
+      motionStationary,
+      wifiStation,
+      arcStations,
+      now: Date.now(),
+    });
+    if (!consistency.allowed) return;
+
     const rawEvent: AlarmEvent = { phaseId: 'imminent', type: 'destination', stationName: destination.name };
     // #699: setFiredAlarms 영속화 완료를 await — silent push BG 핸들러가 같은 imminent를
     // 재발사하지 않도록 storage가 sync된 후 다음 cycle 진입.
@@ -771,6 +817,7 @@ export function useStationAlarm({
     route,
     destination?.id,
     destination?.name,
+    destination?.line,
     destinationArrival,
     trackedTrainCode,
     setAlarmEvent,
@@ -785,6 +832,9 @@ export function useStationAlarm({
     userLocation?.lng,
     // #903 — 위 ETA effect와 동일 사유. degraded 단독 전환에 본 API-신호 effect도 즉시 반응.
     arrivalConfidence,
+    // #1389 — 정합성 게이트 신호 변경 시 재평가.
+    wifiStation?.name,
+    arcStations,
   ]);
 
   // Station-passed 알림 효과: 경로상 역 변경 시 dedup된 per-station 알림.
@@ -878,6 +928,21 @@ export function useStationAlarm({
         return;
       }
 
+      // #1389 — 정합성 게이트. station-passed의 target은 candidateStation 자체.
+      // arrivalConfirmed(arrival API 강신호)에서도 정합성은 적용 — WiFi/motion 모순은 신호 종류 무관.
+      const consistency = evaluateLocalFireConsistency({
+        targetStationName: candidateStation.name,
+        targetLine: candidateStation.line,
+        source: 'fg',
+        kind: 'station-passed',
+        nearestStation,
+        motionStationary,
+        wifiStation,
+        arcStations,
+        now: Date.now(),
+      });
+      if (!consistency.allowed) return;
+
       // #746 — dismiss silence 게이트 + dispatch는 helper로 통합 (Sonar cpd 회피).
       // userLocation 없이도 시간 조건만 평가 가능 — null 좌표 그대로 전달.
       // #1236 — sleep 룰 게이트는 helper 내부에서 처리. lock은 IIFE에서 async fetch.
@@ -911,6 +976,7 @@ export function useStationAlarm({
     destination?.id,
     destination?.name,
     nearestStation?.id,
+    nearestStation?.line,
     hydrationPhase,
     accuracyOk,
     arrivalConfirmed,
@@ -921,6 +987,9 @@ export function useStationAlarm({
     userLocation?.lng,
     currentHopIndex,
     arcStations,
+    // #1389 — 정합성 게이트 신호 변경 시 재평가.
+    motionStationary,
+    wifiStation?.name,
   ]);
 
   // #917 A2 follow-up — FG fast path: lock.trainCode가 currentStationArrival의 row에
@@ -1007,6 +1076,20 @@ export function useStationAlarm({
         }
       }
 
+      // #1389 — 정합성 게이트. arvlcd 강신호도 device 신호와 모순 시 차단.
+      const consistency = evaluateLocalFireConsistency({
+        targetStationName: candidateStation.name,
+        targetLine: candidateStation.line,
+        source: 'fg-arvlcd',
+        kind: 'station-passed',
+        nearestStation,
+        motionStationary,
+        wifiStation,
+        arcStations,
+        now: Date.now(),
+      });
+      if (!consistency.allowed) return;
+
       // #746 silence gate + dispatch는 helper로 통합 (Sonar cpd 회피).
       // lastNotifiedStationId 공유 dedup. cancelled 재확인 — getBoardingLock 후 effect cleanup 가능.
       // #1236 — sleep 룰 게이트 context. lock은 위에서 이미 fetch.
@@ -1050,6 +1133,9 @@ export function useStationAlarm({
     currentHopIndex,
     // #1266 — fast-path hop window 게이트 입력. arcStations 변화 시(환승 후 leg 전환 등) 재평가.
     arcStations,
+    // #1389 — 정합성 게이트 신호 변경 시 재평가.
+    motionStationary,
+    wifiStation?.name,
   ]);
 
   // #1290/#1298 — subsurface verdict 기반 station-passed 발사.
@@ -1074,6 +1160,21 @@ export function useStationAlarm({
     const capturedDestinationName = destination.name;
 
     let cancelled = false;
+    // #1389 — 정합성 게이트. subsurfaceStationDetected는 fusion이 이미 ≥2 신호 합의로 통과시킨 상태라
+    // 게이트가 추가로 모순(wifi != target 등)을 잡으면 fusion 결정과 부딪힌다. 그러나 정합성은 모든 fire
+    // site에 동일 적용이 spec(#1389)이라 본 경로도 예외 없이 평가 — 거의 항상 allow가 기대값.
+    const consistency = evaluateLocalFireConsistency({
+      targetStationName: candidateStation.name,
+      targetLine: candidateStation.line,
+      source: 'fg',
+      kind: 'station-passed',
+      nearestStation,
+      motionStationary,
+      wifiStation,
+      arcStations,
+      now: Date.now(),
+    });
+    if (!consistency.allowed) return;
     void (async () => {
       const lock = await getBoardingLock();
       if (cancelled) return;
@@ -1105,11 +1206,16 @@ export function useStationAlarm({
     destination?.id,
     destination?.name,
     nearestStation?.id,
+    nearestStation?.line,
     dismissSilence,
     clearDismissSilenceAction,
     userLocation?.lat,
     userLocation?.lng,
     notificationSource,
     currentHopIndex,
+    // #1389 — 정합성 게이트 신호 변경 시 재평가.
+    motionStationary,
+    wifiStation?.name,
+    arcStations,
   ]);
 }

--- a/src/features/alarm/hooks/useTripBoundAlarmScheduler.ts
+++ b/src/features/alarm/hooks/useTripBoundAlarmScheduler.ts
@@ -17,10 +17,28 @@ import {
   setRegisteredTripRouteSig,
   topUpTripBoundWindow,
 } from '../utils/tripBoundScheduler';
+import { getStationById } from '../../../shared/utils/stationRoute';
 import { getTripStartedAt } from '../utils/tripStartStorage';
 import { createLogger } from '../../../shared/utils/logger';
 
 const logger = createLogger('useTripBoundAlarmScheduler');
+
+/**
+ * #1389 — preschedule 정합성 게이트 입력 normalization.
+ *
+ * lock 있음 + getStationById 매핑 성공 → { stationName, line } 전달 (helper 평가).
+ * lock 없음 또는 매핑 실패 → null (helper 자연 fallback 허용).
+ *
+ * 본 함수는 export — useTripBoundAlarmScheduler 단독 테스트에서 직접 호출해 모든 분기 커버.
+ */
+export function resolveBoardingStation(
+  lock: BoardingLock | null,
+): { stationName: string; line: string } | null {
+  if (lock === null) return null;
+  const station = getStationById(lock.boardingStationId);
+  if (!station) return null;
+  return { stationName: station.name, line: lock.boardingLine as string };
+}
 
 export interface UseTripBoundAlarmSchedulerInputs {
   /** 현재 trip의 boarding lock. 있으면 `boardedAt`을 startTime으로 사용. */
@@ -122,11 +140,14 @@ export function useTripBoundAlarmScheduler({
         return;
       }
       const { routeStops, estimatedHopTimesMs } = deriveTripBoundStops(route, destinationName);
+      // #1389 — 정합성 게이트 입력. lock 있으면 boardingStation 결정 시도, 없거나 매핑 실패면 null → helper fallback 허용.
+      const boardingStation = resolveBoardingStation(lock);
       await prescheduleStationAlerts({
         routeStops,
         estimatedHopTimesMs,
         startTime: tripStart,
         windowSize: TRIPBOUND_WINDOW_SIZE,
+        boardingStation,
       });
       // #918 A3 PR2 (#729 흡수): fire-time 재검증을 위해 route signature 영속화.
       // canSchedule=true 경로는 hasRouteAndDest=true → routeSignature는 항상 string 반환 → nextSig non-null.

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -24,6 +24,8 @@ const mockLogSilentPushTripEndedReceived = jest.fn();
 const mockLogSilentPushFired = jest.fn();
 const mockLogSilentPushSkipped = jest.fn();
 const mockFlushAlarmLog = jest.fn().mockResolvedValue(undefined);
+// #1389 — consistency block log.
+const mockLogLocalFireConsistencyBlocked = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
   logSilentPushReceived: (...args: unknown[]) => mockLogSilentPushReceived(...args),
   logSilentPushRescheduleReceived: (...args: unknown[]) =>
@@ -32,7 +34,27 @@ jest.mock('../../utils/alarmLog', () => ({
     mockLogSilentPushTripEndedReceived(...args),
   logSilentPushFired: (...args: unknown[]) => mockLogSilentPushFired(...args),
   logSilentPushSkipped: (...args: unknown[]) => mockLogSilentPushSkipped(...args),
+  logLocalFireConsistencyBlocked: (...args: unknown[]) =>
+    mockLogLocalFireConsistencyBlocked(...args),
   flushAlarmLog: () => mockFlushAlarmLog(),
+}));
+
+// #1389 — silent push 정합성 게이트 helper. 기본 allow — 기존 테스트 동작 보존.
+// 차단 시나리오만 본 PR 신규 describe에서 disallowed override.
+const mockEvaluateSilentPushConsistency = jest.fn(() =>
+  Promise.resolve({ allowed: true } as
+    | { allowed: true }
+    | {
+        allowed: false;
+        reason:
+          | 'wifi-mismatch'
+          | 'motion-stationary-far-behind'
+          | 'device-station-mismatch'
+          | 'device-ahead-of-target';
+      }),
+);
+jest.mock('../../utils/silentPushConsistencyGate', () => ({
+  evaluateSilentPushConsistency: () => mockEvaluateSilentPushConsistency(),
 }));
 
 // #868 — trip-ended payload 수신 시 trip-bound storage cleanup.
@@ -264,6 +286,8 @@ describe('silentPushTask', () => {
     jest.clearAllMocks();
     mockScheduleNotificationAsync.mockResolvedValue('id');
     mockCheckGate.mockResolvedValue(PASSING_GATE);
+    // #1389 — 기본 consistency=allow (clearAllMocks가 impl 지움).
+    mockEvaluateSilentPushConsistency.mockResolvedValue({ allowed: true });
     mockGetSubsurfaceState.mockResolvedValue(false);
     mockGetFiredAlarms.mockResolvedValue(new Set<string>());
     mockSetFiredAlarms.mockResolvedValue(undefined);
@@ -1650,6 +1674,83 @@ describe('silentPushTask', () => {
         expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
           expect.objectContaining({ reason: 'movement-motion-stationary' }),
         );
+      });
+    });
+
+    // #1389 — silent push 정합성 게이트가 차단(allowed=false) 반환 시 ack=skipped + cancel + return.
+    // helper 본문은 silentPushConsistencyGate에서 별도 테스트. 본 describe는 callsite 흡수 경로(라우팅) 검증.
+    describe('#1389 정합성 게이트 (consistency)', () => {
+      beforeEach(() => {
+        mockLogLocalFireConsistencyBlocked.mockClear();
+        mockEvaluateSilentPushConsistency.mockResolvedValue({ allowed: true });
+        // 이전 #728 test에서 mockGetMotionStationary가 true로 set된 상태가 jest.clearAllMocks로 reset되지
+        // 않으므로 명시적으로 false로 reset — consistency 게이트 도달 전 motion gate를 통과시켜야 함.
+        mockGetMotionStationary.mockReturnValue(false);
+      });
+
+      it('consistency=disallowed(wifi-mismatch) → log + ack skipped + cancel TBA/BL + return', async () => {
+        mockEvaluateSilentPushConsistency.mockResolvedValueOnce({
+          allowed: false,
+          reason: 'wifi-mismatch',
+        });
+
+        await handleSilentPush(
+          payload({
+            kind: 'destination',
+            phase: 'imminent',
+            pushId: 'consistency-skip',
+          }),
+        );
+
+        expect(mockLogLocalFireConsistencyBlocked).toHaveBeenCalledWith({
+          source: 'silent-push-skipped',
+          stationName: '강남',
+          reason: 'wifi-mismatch',
+          kind: 'destination',
+          phaseId: 'imminent',
+        });
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          ackCall('consistency-skip', 'skipped', 'consistency-wifi-mismatch'),
+        );
+        expect(mockCancelTbaByStationPhase).toHaveBeenCalledWith('강남', 'imminent');
+        expect(mockCancelBlByStationPhase).toHaveBeenCalledWith('강남', 'imminent');
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogSilentPushFired).not.toHaveBeenCalled();
+      });
+
+      it('kind=intermediate일 때는 log에 kind="station-passed"로 매핑', async () => {
+        mockEvaluateSilentPushConsistency.mockResolvedValueOnce({
+          allowed: false,
+          reason: 'device-station-mismatch',
+        });
+
+        await handleSilentPush(
+          payload({
+            kind: 'intermediate',
+            phase: 'imminent',
+            pushId: 'consistency-int',
+          }),
+        );
+
+        expect(mockLogLocalFireConsistencyBlocked).toHaveBeenCalledWith(
+          expect.objectContaining({
+            reason: 'device-station-mismatch',
+            kind: 'station-passed',
+            phaseId: 'imminent',
+          }),
+        );
+      });
+
+      it('consistency=allowed → 통상 발사 경로로 진행', async () => {
+        // 기본 mockResolvedValue가 allowed=true — handler가 정상 발사.
+        await handleSilentPush(
+          payload({
+            kind: 'destination',
+            phase: 'imminent',
+            pushId: 'consistency-allow',
+          }),
+        );
+        expect(mockLogLocalFireConsistencyBlocked).not.toHaveBeenCalled();
       });
     });
 

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -52,6 +52,9 @@ import { evaluateDismissSilence } from '../utils/dismissSilenceGate';
 import { clearDismissSilence, getDismissSilence } from '../utils/dismissSilenceStorage';
 import { evaluateMovement, MOVEMENT_TO_ALARM_LOG_REASON } from '../../nearest-station/utils/movementGate';
 import { getCurrentMotionStationary } from '../../nearest-station/utils/motionActivity';
+// #1389 — 정합성 게이트. silent push 수신 시점 device 신호와 target 간 모순 차단.
+import { evaluateSilentPushConsistency } from '../utils/silentPushConsistencyGate';
+import { logLocalFireConsistencyBlocked } from '../utils/alarmLog';
 import { addFiredPushId, hasFiredPushId } from '../utils/firedPushIds';
 import {
   checkSilentPushLocationGate,
@@ -1036,6 +1039,32 @@ async function fireWithGate(
       `movement skip: reason=${movementReason} speed=${gate.speedMps ?? '-'} accuracy=${gate.accuracyM ?? '-'}`,
     );
     // #1356 E1 — motion=stationary suppress 동안 같은 station 사전 예약도 cancel. (gate 분기와 동일 의도)
+    await cancelTbaByStationPhase(payload.nextWaypoint, payload.phase);
+    await cancelBlByStationPhase(payload.nextWaypoint, payload.phase);
+    return;
+  }
+
+  // #1389 — 정합성 게이트. motion/WiFi 신호가 명백히 target과 다른 device를 가리키면 차단.
+  // arcStations/currentStationName은 BG 컨텍스트에서 비싸므로 hops=null fallback — WiFi vs motion-stationary
+  // 모순만 검출. backend가 헛 push를 보낸 evidence(20:06:54 중곡 imminent)를 차단하는 핵심 사이트.
+  // guardLine은 위 line-mismatch 가드에서 이미 산출된 target line — 재사용.
+  const consistencyResult = await evaluateSilentPushConsistency({
+    targetStationName: payload.nextWaypoint,
+    targetLine: guardLine ?? payload.occupiedLine ?? '',
+    motionStationary,
+  });
+  if (!consistencyResult.allowed) {
+    logLocalFireConsistencyBlocked({
+      source: 'silent-push-skipped',
+      stationName: payload.nextWaypoint,
+      reason: consistencyResult.reason,
+      kind: payload.kind === 'intermediate' ? 'station-passed' : payload.kind,
+      phaseId: payload.phase,
+    });
+    ackOutcome(payload.pushId, apnsToken, 'skipped', `consistency-${consistencyResult.reason}`);
+    logger.info(
+      `consistency skip: reason=${consistencyResult.reason} target=${payload.nextWaypoint}`,
+    );
     await cancelTbaByStationPhase(payload.nextWaypoint, payload.phase);
     await cancelBlByStationPhase(payload.nextWaypoint, payload.phase);
     return;

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -58,6 +58,7 @@ import {
   logBoardingPromptAutoLock,
   countBoardingPromptAutoLockOutcomes,
   logScheduleSkipped,
+  logLocalFireConsistencyBlocked,
   ALARM_LOG_BUFFER_SIZE,
   type AlarmLogEntry,
   type AlarmLogStamp,
@@ -1750,6 +1751,56 @@ describe('alarmLog', () => {
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved = JSON.parse(savedJson);
       expect(saved[0].stationName).toBe('bl');
+    });
+  });
+
+  // #1389 — local fire consistency block log.
+  describe('logLocalFireConsistencyBlocked', () => {
+    it.each([
+      ['wifi-mismatch', 'consistency-wifi-mismatch'],
+      ['motion-stationary-far-behind', 'consistency-motion-stationary-far-behind'],
+      ['device-station-mismatch', 'consistency-device-station-mismatch'],
+      ['device-ahead-of-target', 'consistency-device-ahead-of-target'],
+    ])('reason=%s → mappedReason=%s 로 기록', async (reason, mapped) => {
+      logLocalFireConsistencyBlocked({
+        source: 'silent-push-skipped',
+        stationName: '중곡',
+        reason: reason as
+          | 'wifi-mismatch'
+          | 'motion-stationary-far-behind'
+          | 'device-station-mismatch'
+          | 'device-ahead-of-target',
+        kind: 'station-passed',
+        phaseId: 'imminent',
+      });
+      await flushAlarmLog();
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'silent-push-skipped',
+        outcome: 'suppressed',
+        reason: mapped,
+        stationName: '중곡',
+        kind: 'station-passed',
+        phaseId: 'imminent',
+      });
+    });
+
+    it('burst dedup — 동일 reason+stationName 연속 호출은 첫 1건만 기록', async () => {
+      logLocalFireConsistencyBlocked({
+        source: 'fg',
+        stationName: '중곡',
+        reason: 'motion-stationary-far-behind',
+      });
+      logLocalFireConsistencyBlocked({
+        source: 'fg',
+        stationName: '중곡',
+        reason: 'motion-stationary-far-behind',
+      });
+      await flushAlarmLog();
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved = JSON.parse(savedJson);
+      expect(saved).toHaveLength(1);
     });
   });
 

--- a/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
@@ -37,6 +37,13 @@ const mockGetCurrentMotionStationary = jest.fn<boolean, []>(() => false);
 jest.mock('../../../nearest-station/utils/motionActivity', () => ({
   getCurrentMotionStationary: () => mockGetCurrentMotionStationary(),
 }));
+
+// #1389 — preschedule 정합성 게이트 helper. 기본 true (allow) — 기존 테스트 동작 보존.
+// 차단 시나리오만 본 PR 신규 describe에서 false override.
+const mockEvaluatePreScheduleConsistency = jest.fn<Promise<boolean>, [unknown]>(() => Promise.resolve(true));
+jest.mock('../preScheduleConsistencyGate', () => ({
+  evaluatePreScheduleConsistency: (input: unknown) => mockEvaluatePreScheduleConsistency(input),
+}));
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn(),
   setItem: jest.fn(),
@@ -1014,5 +1021,56 @@ describe('scheduleHopsForLock #1357 (S1) motion gate', () => {
     });
     expect(ids).toEqual([]);
     expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+});
+
+// #1389 — preschedule 정합성 게이트가 차단(false) 반환 시 schedule이 [] 반환되는지 검증.
+// helper 자체 분기는 preScheduleConsistencyGate.test.ts에서 평가 — 본 describe는 callsite의 흡수 경로만 본다.
+describe('scheduleHopsForLock #1389 consistency gate', () => {
+  it('consistency gate가 false 반환 시 schedule을 skip하고 [] 반환', async () => {
+    mockEvaluatePreScheduleConsistency.mockResolvedValueOnce(false);
+    const ids = await scheduleHopsForLock({
+      lock,
+      route: directRoute,
+      destinationName: '강남',
+      now: NOW,
+    });
+    expect(ids).toEqual([]);
+    expect(mockedSchedule).not.toHaveBeenCalled();
+    expect(mockedAdd).not.toHaveBeenCalled();
+  });
+
+  it('boardingStationId가 stations.json에 없으면 helper에 boardingStation=null 전달 (graceful)', async () => {
+    // lock.boardingStationId='stn-A'는 stations.json에 없는 임의 id — getStationById null 반환.
+    await scheduleHopsForLock({
+      lock,
+      route: directRoute,
+      destinationName: '강남',
+      now: NOW,
+    });
+    expect(mockEvaluatePreScheduleConsistency).toHaveBeenCalledWith(
+      expect.objectContaining({ boardingStation: null, channel: 'bl' }),
+    );
+  });
+
+  it('boardingStationId가 stations.json에 있으면 helper에 { stationName, line } 전달', async () => {
+    // '1-001' = 소요산, line 1 (stations.json에 존재).
+    const lockWithRealId: BoardingLock = {
+      ...lock,
+      boardingStationId: '1-001',
+      boardingLine: '1',
+    };
+    await scheduleHopsForLock({
+      lock: lockWithRealId,
+      route: directRoute,
+      destinationName: '강남',
+      now: NOW,
+    });
+    expect(mockEvaluatePreScheduleConsistency).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boardingStation: { stationName: '소요산', line: '1' },
+        channel: 'bl',
+      }),
+    );
   });
 });

--- a/src/features/alarm/utils/__tests__/localFireConsistencyGate.test.ts
+++ b/src/features/alarm/utils/__tests__/localFireConsistencyGate.test.ts
@@ -1,0 +1,124 @@
+/**
+ * #1389 — FG fire 정합성 게이트 helper 단독 테스트.
+ *
+ * useStationAlarm의 4개 fire effect가 공유하는 helper. 본 테스트는 차단/허용 분기를 직접 검증.
+ * hook 단위 테스트(useStationAlarm.test.ts)는 helper를 mock해 callsite 흡수 경로만 검증.
+ */
+import type { Station } from '../../../../shared/types/station';
+import {
+  evaluateLocalFireConsistency,
+  resolveTargetLine,
+} from '../localFireConsistencyGate';
+
+const mockAppendAlarmLog = jest.fn();
+jest.mock('../alarmLog', () => ({
+  logLocalFireConsistencyBlocked: (input: unknown) => mockAppendAlarmLog(input),
+}));
+
+const NOW = 1_750_000_000_000;
+
+const stationFor = (name: string, line: Station['line'] = '7'): Station => ({
+  id: `${line}-${name}`,
+  name,
+  line,
+  lineColor: '#000000',
+  lat: 37.5,
+  lng: 127,
+});
+
+describe('resolveTargetLine (#1389)', () => {
+  const target = '중곡';
+  const arc = [stationFor('용마산', '7'), stationFor('중곡', '7'), stationFor('군자', '7')];
+
+  it('arcStations에서 매칭 시 그 line 반환', () => {
+    expect(resolveTargetLine(target, arc, null)).toBe('7');
+  });
+
+  it('arcStations 미전달 + nearestStation 있으면 nearestStation.line', () => {
+    expect(resolveTargetLine(target, undefined, stationFor('A', '2'))).toBe('2');
+  });
+
+  it('arcStations에서 매칭 실패 + nearestStation 있으면 nearestStation.line fallback', () => {
+    expect(resolveTargetLine('없는역', arc, stationFor('A', '5'))).toBe('5');
+  });
+
+  it('arcStations 미전달 + nearestStation null → 빈 문자열', () => {
+    expect(resolveTargetLine(target, undefined, null)).toBe('');
+  });
+});
+
+describe('evaluateLocalFireConsistency (#1389)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const baseInput = {
+    targetStationName: '중곡',
+    targetLine: '7' as const,
+    source: 'fg' as const,
+    kind: 'station-passed' as const,
+    phaseId: 'imminent' as const,
+    nearestStation: null,
+    motionStationary: undefined,
+    wifiStation: null,
+    arcStations: undefined,
+    now: NOW,
+  };
+
+  it('모든 신호 null/unknown → 허용 (지하 보호)', () => {
+    expect(evaluateLocalFireConsistency(baseInput)).toEqual({ allowed: true });
+    expect(mockAppendAlarmLog).not.toHaveBeenCalled();
+  });
+
+  it('WiFi 일치 → 허용 (강 확증)', () => {
+    expect(
+      evaluateLocalFireConsistency({
+        ...baseInput,
+        wifiStation: stationFor('중곡', '7'),
+      }),
+    ).toEqual({ allowed: true });
+  });
+
+  it('WiFi != target + motion=stationary → 차단 + log', () => {
+    const result = evaluateLocalFireConsistency({
+      ...baseInput,
+      wifiStation: stationFor('용마산', '7'),
+      motionStationary: true,
+    });
+    expect(result).toEqual({ allowed: false });
+    expect(mockAppendAlarmLog).toHaveBeenCalledWith({
+      source: 'fg',
+      stationName: '중곡',
+      reason: 'wifi-mismatch',
+      kind: 'station-passed',
+      phaseId: 'imminent',
+    });
+  });
+
+  it('device가 target보다 2 hop 이상 뒤 → device-station-mismatch 차단', () => {
+    const arc = [stationFor('용마산', '7'), stationFor('중곡', '7'), stationFor('군자', '7')];
+    const result = evaluateLocalFireConsistency({
+      ...baseInput,
+      targetStationName: '군자',
+      nearestStation: stationFor('용마산', '7'),
+      motionStationary: false,
+      arcStations: arc,
+    });
+    expect(result).toEqual({ allowed: false });
+    expect(mockAppendAlarmLog).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'device-station-mismatch' }),
+    );
+  });
+
+  it('source=fg-arvlcd로 log source 그대로 전파', () => {
+    evaluateLocalFireConsistency({
+      ...baseInput,
+      source: 'fg-arvlcd',
+      wifiStation: stationFor('용마산', '7'),
+      motionStationary: true,
+    });
+    expect(mockAppendAlarmLog).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'fg-arvlcd' }),
+    );
+  });
+});

--- a/src/features/alarm/utils/__tests__/preScheduleConsistencyGate.test.ts
+++ b/src/features/alarm/utils/__tests__/preScheduleConsistencyGate.test.ts
@@ -1,0 +1,132 @@
+/**
+ * #1389 — preschedule 정합성 게이트 helper 단독 테스트.
+ *
+ * boardingLockScheduler / tripBoundScheduler가 공유하는 helper이므로
+ * helper 단독 테스트로 차단/허용 분기를 평가한다.
+ * 두 호출자는 별도 테스트에서 helper return false → return [] 경로만 검증.
+ */
+import type { Station } from '../../../../shared/types/station';
+import { evaluatePreScheduleConsistency } from '../preScheduleConsistencyGate';
+
+const mockGetCurrentWifiSsid = jest.fn<Promise<string | null>, []>();
+jest.mock('../../../nearest-station/utils/wifiSsidNative', () => ({
+  getCurrentWifiSsid: () => mockGetCurrentWifiSsid(),
+}));
+
+const mockLookupStationBySsid = jest.fn<Station | null, [string | null]>();
+jest.mock('../../../nearest-station/utils/wifiSsidLookup', () => ({
+  lookupStationBySsid: (ssid: string | null) => mockLookupStationBySsid(ssid),
+}));
+
+const mockAppendAlarmLog = jest.fn();
+jest.mock('../alarmLog', () => ({
+  logLocalFireConsistencyBlocked: (input: unknown) => mockAppendAlarmLog(input),
+}));
+
+const mockLoggerInfo = jest.fn();
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: (...args: unknown[]) => mockLoggerInfo(...args),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const stationFor = (name: string, line: Station['line'] = '7'): Station => ({
+  id: `${line}-${name}`,
+  name,
+  line,
+  lineColor: '#000000',
+  lat: 37.5,
+  lng: 127,
+});
+
+describe('evaluatePreScheduleConsistency (#1389)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentWifiSsid.mockResolvedValue(null);
+    mockLookupStationBySsid.mockReturnValue(null);
+  });
+
+  it('boardingStation=null → allow (lockless / 컨텍스트 부재)', async () => {
+    const result = await evaluatePreScheduleConsistency({
+      boardingStation: null,
+      motionStationary: false,
+      channel: 'bl',
+      destinationName: '강남',
+    });
+    expect(result).toBe(true);
+    expect(mockAppendAlarmLog).not.toHaveBeenCalled();
+  });
+
+  it('WiFi 미상 + motion=false → helper의 unknown 신호 fallback (allow)', async () => {
+    const result = await evaluatePreScheduleConsistency({
+      boardingStation: { stationName: '중곡', line: '7' },
+      motionStationary: false,
+      channel: 'tba',
+      destinationName: '강남',
+    });
+    expect(result).toBe(true);
+    expect(mockAppendAlarmLog).not.toHaveBeenCalled();
+  });
+
+  it('WiFi 매칭 동일역 → allow (강 확증)', async () => {
+    mockGetCurrentWifiSsid.mockResolvedValue('Subway_중곡');
+    mockLookupStationBySsid.mockReturnValue(stationFor('중곡', '7'));
+    const result = await evaluatePreScheduleConsistency({
+      boardingStation: { stationName: '중곡', line: '7' },
+      motionStationary: false,
+      channel: 'bl',
+      destinationName: '강남',
+    });
+    expect(result).toBe(true);
+  });
+
+  it('WiFi != target + motion=stationary → block (wifi-mismatch) + log', async () => {
+    mockGetCurrentWifiSsid.mockResolvedValue('Subway_용마산');
+    mockLookupStationBySsid.mockReturnValue(stationFor('용마산', '7'));
+    const result = await evaluatePreScheduleConsistency({
+      boardingStation: { stationName: '중곡', line: '7' },
+      motionStationary: true,
+      channel: 'bl',
+      destinationName: '강남',
+    });
+    expect(result).toBe(false);
+    expect(mockAppendAlarmLog).toHaveBeenCalledWith({
+      source: 'bg-scheduled',
+      stationName: '중곡',
+      reason: 'wifi-mismatch',
+    });
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      expect.stringContaining('channel=bl reason=wifi-mismatch destination=강남'),
+    );
+  });
+
+  it('channel=tba + destinationName 미상 → log에 unknown 출력', async () => {
+    mockGetCurrentWifiSsid.mockResolvedValue('Subway_용마산');
+    mockLookupStationBySsid.mockReturnValue(stationFor('용마산', '7'));
+    const result = await evaluatePreScheduleConsistency({
+      boardingStation: { stationName: '중곡', line: '7' },
+      motionStationary: true,
+      channel: 'tba',
+      destinationName: undefined,
+    });
+    expect(result).toBe(false);
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      expect.stringContaining('channel=tba reason=wifi-mismatch destination=unknown'),
+    );
+  });
+
+  it('getCurrentWifiSsid throw → graceful (WiFi 미상으로 처리, allow)', async () => {
+    mockGetCurrentWifiSsid.mockRejectedValue(new Error('native bridge unavailable'));
+    const result = await evaluatePreScheduleConsistency({
+      boardingStation: { stationName: '중곡', line: '7' },
+      motionStationary: false,
+      channel: 'bl',
+      destinationName: '강남',
+    });
+    expect(result).toBe(true);
+    expect(mockAppendAlarmLog).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/alarm/utils/__tests__/silentPushConsistencyGate.test.ts
+++ b/src/features/alarm/utils/__tests__/silentPushConsistencyGate.test.ts
@@ -1,0 +1,75 @@
+/**
+ * #1389 — silent push 정합성 게이트 helper 단독 테스트.
+ *
+ * silentPushTask BG 컨텍스트의 WiFi/motion 신호 수집 + helper 호출 패턴을 검증.
+ */
+import type { Station } from '../../../../shared/types/station';
+import { evaluateSilentPushConsistency } from '../silentPushConsistencyGate';
+
+const mockGetCurrentWifiSsid = jest.fn<Promise<string | null>, []>();
+jest.mock('../../../nearest-station/utils/wifiSsidNative', () => ({
+  getCurrentWifiSsid: () => mockGetCurrentWifiSsid(),
+}));
+
+const mockLookupStationBySsid = jest.fn<Station | null, [string | null]>();
+jest.mock('../../../nearest-station/utils/wifiSsidLookup', () => ({
+  lookupStationBySsid: (ssid: string | null) => mockLookupStationBySsid(ssid),
+}));
+
+const stationFor = (name: string, line: Station['line'] = '7'): Station => ({
+  id: `${line}-${name}`,
+  name,
+  line,
+  lineColor: '#000000',
+  lat: 37.5,
+  lng: 127,
+});
+
+describe('evaluateSilentPushConsistency (#1389)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentWifiSsid.mockResolvedValue(null);
+    mockLookupStationBySsid.mockReturnValue(null);
+  });
+
+  it('WiFi 미상 + motion=false → unknown 신호로 자연 allow', async () => {
+    const result = await evaluateSilentPushConsistency({
+      targetStationName: '중곡',
+      targetLine: '7',
+      motionStationary: false,
+    });
+    expect(result).toEqual({ allowed: true });
+  });
+
+  it('WiFi 매칭 target 동일역 → 강 확증 allow', async () => {
+    mockGetCurrentWifiSsid.mockResolvedValue('Subway_중곡');
+    mockLookupStationBySsid.mockReturnValue(stationFor('중곡', '7'));
+    const result = await evaluateSilentPushConsistency({
+      targetStationName: '중곡',
+      targetLine: '7',
+      motionStationary: false,
+    });
+    expect(result).toEqual({ allowed: true });
+  });
+
+  it('WiFi != target + motion=stationary → wifi-mismatch로 block', async () => {
+    mockGetCurrentWifiSsid.mockResolvedValue('Subway_용마산');
+    mockLookupStationBySsid.mockReturnValue(stationFor('용마산', '7'));
+    const result = await evaluateSilentPushConsistency({
+      targetStationName: '중곡',
+      targetLine: '7',
+      motionStationary: true,
+    });
+    expect(result).toEqual({ allowed: false, reason: 'wifi-mismatch' });
+  });
+
+  it('getCurrentWifiSsid throw → graceful (WiFi 미상으로 처리, allow)', async () => {
+    mockGetCurrentWifiSsid.mockRejectedValue(new Error('native bridge unavailable'));
+    const result = await evaluateSilentPushConsistency({
+      targetStationName: '중곡',
+      targetLine: '7',
+      motionStationary: false,
+    });
+    expect(result).toEqual({ allowed: true });
+  });
+});

--- a/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
@@ -38,6 +38,14 @@ jest.mock('../../../nearest-station/utils/motionActivity', () => ({
   getCurrentMotionStationary: () => mockGetCurrentMotionStationary(),
 }));
 
+// #1389 — preschedule 정합성 게이트 helper. 기본 true (allow) — 기존 테스트 동작 보존.
+const mockEvaluatePreScheduleConsistency = jest.fn<Promise<boolean>, [unknown]>(() =>
+  Promise.resolve(true),
+);
+jest.mock('../preScheduleConsistencyGate', () => ({
+  evaluatePreScheduleConsistency: (input: unknown) => mockEvaluatePreScheduleConsistency(input),
+}));
+
 const mockLoggerWarn = jest.fn();
 const mockLoggerInfo = jest.fn();
 jest.mock('../../../../shared/utils/logger', () => ({
@@ -1171,5 +1179,43 @@ describe('prescheduleStationAlerts #1357 (S1) motion gate', () => {
     // 1건 + count=2 (burst inline counter) — share dump에서 시도 횟수가 보존됨을 확인.
     expect(skips).toHaveLength(1);
     expect(skips[0].count).toBe(2);
+  });
+});
+
+// #1389 — preschedule 정합성 게이트가 차단(false) 반환 시 schedule이 [] 반환되는지 검증.
+// helper 자체 분기는 preScheduleConsistencyGate.test.ts에서 평가 — 본 describe는 callsite 흡수 경로만.
+describe('prescheduleStationAlerts #1389 consistency gate', () => {
+  beforeEach(() => {
+    setupIosFakeTimers();
+    mockEvaluatePreScheduleConsistency.mockResolvedValue(true);
+  });
+  afterEach(teardownFakeTimers);
+
+  it('consistency gate가 false 반환 시 schedule을 skip하고 [] 반환', async () => {
+    mockEvaluatePreScheduleConsistency.mockResolvedValueOnce(false);
+    const result = await prescheduleWith({
+      boardingStation: { stationName: '중곡', line: '7' },
+    });
+    expect(result).toEqual([]);
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('boardingStation 미전달 → helper에 null 전달 (lockless / 컨텍스트 부재)', async () => {
+    await prescheduleWith();
+    expect(mockEvaluatePreScheduleConsistency).toHaveBeenCalledWith(
+      expect.objectContaining({ boardingStation: null, channel: 'tba' }),
+    );
+  });
+
+  it('boardingStation 전달 → helper에 그대로 전달 (channel=tba)', async () => {
+    await prescheduleWith({
+      boardingStation: { stationName: '중곡', line: '7' },
+    });
+    expect(mockEvaluatePreScheduleConsistency).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boardingStation: { stationName: '중곡', line: '7' },
+        channel: 'tba',
+      }),
+    );
   });
 });

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -148,7 +148,17 @@ export type AlarmLogReason =
   // #1357 (S1) — preschedule 진입 시 motion=stationary 확정으로 사전예약 schedule을 skip한 경우.
   // boardingLock/lockless 양쪽 path 공통. OS scheduleNotificationAsync 0회로 정적 trip 시작의
   // 첫 banner 발사를 차단한다. share dump에서 'schedule-skipped-motion-stationary' 카운트로 추적.
-  | 'schedule-skipped-motion-stationary';
+  | 'schedule-skipped-motion-stationary'
+  // #1389 — 정합성 게이트(`evaluatePushConsistency`)가 device 신호와 target 모순으로 차단한 발사.
+  // 4가지 reason을 단일 reason+suffix로 인코딩(stationName 슬롯에 reason 부착) 대신 reason 자체에 매핑.
+  //   'consistency-wifi-mismatch': WiFi != target && motion=stationary.
+  //   'consistency-motion-stationary-far-behind': hops==1 + motion=stationary.
+  //   'consistency-device-station-mismatch': hops>=2 (device가 target보다 2 hop 이상 뒤).
+  //   'consistency-device-ahead-of-target': hops<0 (device가 target보다 앞).
+  | 'consistency-wifi-mismatch'
+  | 'consistency-motion-stationary-far-behind'
+  | 'consistency-device-station-mismatch'
+  | 'consistency-device-ahead-of-target';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -933,6 +943,53 @@ export function logScheduleSkipped(input: {
     outcome: 'suppressed',
     reason: 'schedule-skipped-motion-stationary',
     stationName,
+  });
+}
+
+/**
+ * #1389 — 정합성 게이트(`evaluatePushConsistency`)가 차단한 fire 1건 적재.
+ *
+ * 4개 fire site(silentPushTask / boardingLockScheduler / tripBoundScheduler / useStationAlarm)가
+ * 공통 호출. reason은 helper가 반환한 4개 차단 사유 중 하나에 'consistency-' prefix 매핑.
+ *   - 'wifi-mismatch'                → 'consistency-wifi-mismatch'
+ *   - 'motion-stationary-far-behind' → 'consistency-motion-stationary-far-behind'
+ *   - 'device-station-mismatch'      → 'consistency-device-station-mismatch'
+ *   - 'device-ahead-of-target'       → 'consistency-device-ahead-of-target'
+ *
+ * source는 호출 path 식별: FG = 'fg', silent push = 'silent-push-skipped', schedule path = 'bg-scheduled'.
+ * isBurstDuplicate로 같은 reason+station 5초 내 중복 drop — FG polling cycle이 같은 정적 trip을
+ * 반복 평가해도 로그 버퍼를 잠식하지 않게 한다.
+ */
+export type PushConsistencyBlockReason =
+  | 'wifi-mismatch'
+  | 'motion-stationary-far-behind'
+  | 'device-station-mismatch'
+  | 'device-ahead-of-target';
+
+const CONSISTENCY_REASON_MAP: Record<PushConsistencyBlockReason, AlarmLogReason> = {
+  'wifi-mismatch': 'consistency-wifi-mismatch',
+  'motion-stationary-far-behind': 'consistency-motion-stationary-far-behind',
+  'device-station-mismatch': 'consistency-device-station-mismatch',
+  'device-ahead-of-target': 'consistency-device-ahead-of-target',
+};
+
+export function logLocalFireConsistencyBlocked(input: {
+  source: AlarmLogSource;
+  stationName: string;
+  reason: PushConsistencyBlockReason;
+  kind?: AlarmLogKind;
+  phaseId?: AlarmPhaseId;
+}): void {
+  const mappedReason = CONSISTENCY_REASON_MAP[input.reason];
+  if (isBurstDuplicate(mappedReason, input.stationName)) return;
+  appendAlarmLog({
+    ts: Date.now(),
+    source: input.source,
+    outcome: 'suppressed',
+    reason: mappedReason,
+    stationName: input.stationName,
+    kind: input.kind,
+    phaseId: input.phaseId,
   });
 }
 

--- a/src/features/alarm/utils/boardingLockScheduler.ts
+++ b/src/features/alarm/utils/boardingLockScheduler.ts
@@ -3,7 +3,7 @@ import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ALARM_PHASES, type AlarmPhaseId } from './alarmPhases';
 import { resolveAllTargets, type AlarmEvent, type CurrentTarget } from './stationAlarm';
-import { isSameStationName, type Route } from '../../../shared/utils/stationRoute';
+import { isSameStationName, type Route, getStationById } from '../../../shared/utils/stationRoute';
 import { buildAlarmContent } from './stationNotification';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
 import {
@@ -22,6 +22,8 @@ import { BOARDING_LOCK_ROUTE_SIG_KEY } from '../../../shared/constants/storageKe
 import { evaluateMovement, isStaticMovementResult } from '../../nearest-station/utils/movementGate';
 // eslint-disable-next-line import/no-restricted-paths -- BG motion 신호 단일 helper.
 import { getCurrentMotionStationary } from '../../nearest-station/utils/motionActivity';
+// #1389 — preschedule 시점 정합성 게이트. tripBoundScheduler와 공유 helper 사용.
+import { evaluatePreScheduleConsistency } from './preScheduleConsistencyGate';
 
 const logger = createLogger('BoardingLockScheduler');
 
@@ -293,6 +295,22 @@ export async function scheduleHopsForLock(params: ScheduleHopsParams): Promise<s
     );
     return [];
   }
+
+  // #1389 — 정합성 게이트 (preschedule 시점). WiFi가 boarding 노선과 다른 station을 확증할 때
+  // schedule을 거부. target은 boardingStation으로 평가 — 사용자가 거기 있는지 확인하는 의미.
+  // 결과 not-allowed면 전체 schedule 거부 (개별 hop별 분리 X — 사용자 자체가 잘못된 위치).
+  // helper의 fallback 정책상 WiFi 미상이면 자연 allow → graceful (지하/권한 X 등).
+  // boardingStationId → Station 매핑. 매핑 실패 시 boardingStation=null → helper가 자연 allow.
+  const boardingStationRecord = getStationById(lock.boardingStationId) ?? null;
+  const consistencyOk = await evaluatePreScheduleConsistency({
+    boardingStation: boardingStationRecord
+      ? { stationName: boardingStationRecord.name, line: lock.boardingLine as string }
+      : null,
+    motionStationary,
+    channel: 'bl',
+    destinationName,
+  });
+  if (!consistencyOk) return [];
 
   const allTargets = resolveAllTargets(route, destinationName);
   const timings = computeHopTimings(lock, route, allTargets);

--- a/src/features/alarm/utils/localFireConsistencyGate.ts
+++ b/src/features/alarm/utils/localFireConsistencyGate.ts
@@ -1,0 +1,90 @@
+/**
+ * #1389 — FG fire site 공통 정합성 게이트 평가 helper.
+ *
+ * useStationAlarm의 4개 fire effect (phase ETA / API imminent / GPS station-passed /
+ * FG arvlcd / subsurface) 가 fire 직전 호출. callsite는 결과(`allowed=false`)면 즉시 return.
+ *
+ * - `wifiStation` / `motionStationary` / `nearestStation` 은 hook props에서 추출 — 본 helper는
+ *   새 신호 입력을 책임지지 않는다 (현 PR scope).
+ * - `arcStations` 미전달이면 `computeDeviceHopsBehindTarget`가 null 반환 → 게이트 fallback 허용.
+ *
+ * fire site별로 `kind`/`phaseId` 메타데이터는 다르지만 정합성 평가 본문은 동일하므로 통합.
+ * 차단 시 helper가 `logLocalFireConsistencyBlocked` 적재 — caller는 boolean 결과만 사용.
+ */
+
+import type { Station } from '../../../shared/types/station';
+import { isSameStationName } from '../../../shared/utils/stationRoute';
+import { evaluatePushConsistency } from './pushConsistency';
+import {
+  extractDeviceSignal,
+  computeDeviceHopsBehindTarget,
+} from './pushConsistencyContext';
+import { logLocalFireConsistencyBlocked } from './alarmLog';
+
+/**
+ * #1389 — target stationName의 line을 추정.
+ *
+ * arcStations에서 같은 이름 stop을 찾아 그 line을 사용 (canonical name 정규화 비교).
+ * 없으면 nearestStation.line을 사용 — 사용자가 그 라인을 타고 target에 접근 중이라는 가정.
+ * 둘 다 없으면 빈 문자열 — 정합성 helper의 `stationLineEq`가 자연스럽게 mismatch 처리.
+ */
+export function resolveTargetLine(
+  targetStationName: string,
+  arcStations: readonly Station[] | undefined,
+  nearestStation: Station | null,
+): string {
+  if (arcStations) {
+    const match = arcStations.find((s) => isSameStationName(s.name, targetStationName));
+    if (match) return match.line;
+  }
+  return nearestStation?.line ?? '';
+}
+
+export interface LocalFireConsistencyInput {
+  targetStationName: string;
+  targetLine: string;
+  source: 'fg' | 'fg-arvlcd';
+  kind?: 'destination' | 'transfer' | 'station-passed';
+  phaseId?: 'early' | 'imminent';
+  nearestStation: Station | null;
+  motionStationary: boolean | undefined;
+  wifiStation: Station | null;
+  arcStations: readonly Station[] | undefined;
+  now: number;
+}
+
+/**
+ * FG fire 직전 정합성 게이트 평가.
+ *
+ * 반환:
+ *  - { allowed: true }: caller가 fire 진행
+ *  - { allowed: false }: caller가 즉시 return. helper가 log 적재 완료.
+ */
+export function evaluateLocalFireConsistency(
+  input: LocalFireConsistencyInput,
+): { allowed: true } | { allowed: false } {
+  const target = { stationName: input.targetStationName, line: input.targetLine };
+  const deviceSignal = extractDeviceSignal({
+    currentStation: input.nearestStation,
+    motionStationary: input.motionStationary,
+    wifiStation: input.wifiStation,
+    lastUpdateMs: input.now,
+  });
+  const tripCtx = {
+    deviceHopsBehindTarget: computeDeviceHopsBehindTarget({
+      arcStations: input.arcStations,
+      currentStationName: deviceSignal.currentStationName,
+      target,
+    }),
+  };
+  const result = evaluatePushConsistency(deviceSignal, target, tripCtx, input.now);
+  if (result.allowed) return { allowed: true };
+  logLocalFireConsistencyBlocked({
+    source: input.source,
+    stationName: target.stationName,
+    reason: result.reason,
+    kind: input.kind,
+    phaseId: input.phaseId,
+  });
+  return { allowed: false };
+}

--- a/src/features/alarm/utils/preScheduleConsistencyGate.ts
+++ b/src/features/alarm/utils/preScheduleConsistencyGate.ts
@@ -1,0 +1,85 @@
+/**
+ * #1389 — preschedule 시점 정합성 게이트 evaluator (boardingLockScheduler / tripBoundScheduler 공통).
+ *
+ * 두 호출자 모두 OS local notification 사전 예약 직전, WiFi가 boardingStation과 다른 station을
+ * 확증하면 schedule 거부해야 하는 동일 요구사항을 가진다. 본 helper가 두 호출자가 공유하는
+ * single source of truth — 호출자는 boardingStation 정보를 정규화해서 넘기기만 한다.
+ *
+ * 평가 본문은 `pushConsistency.evaluatePushConsistency`에 위임.
+ * 본 helper는 그 결과를 boolean으로 변환 + 차단 시 `logLocalFireConsistencyBlocked` 적재 + logger.info.
+ *
+ * 호출자가 boardingStation을 모르면(lockless / 컨텍스트 부재) `null`을 전달 — helper가 자연 allow.
+ * helper의 fallback 정책상 WiFi 미상(SSID 매핑 없음/권한 X)이면 자연 allow → graceful.
+ */
+
+// eslint-disable-next-line import/no-restricted-paths -- WiFi SSOT는 nearest-station feature.
+import { getCurrentWifiSsid } from '../../nearest-station/utils/wifiSsidNative';
+// eslint-disable-next-line import/no-restricted-paths -- WiFi → station 매핑 SSOT.
+import { lookupStationBySsid } from '../../nearest-station/utils/wifiSsidLookup';
+import { evaluatePushConsistency } from './pushConsistency';
+import { extractDeviceSignal } from './pushConsistencyContext';
+import { logLocalFireConsistencyBlocked } from './alarmLog';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('PreScheduleConsistencyGate');
+
+export interface PreScheduleConsistencyInput {
+  /**
+   * preschedule 시점에 사용자가 있어야 할 station. null이면 lockless / 컨텍스트 부재로
+   * 게이트 자연 allow.
+   */
+  boardingStation: { stationName: string; line: string } | null;
+  /** 진입 시점 motion=stationary 여부. helper의 motion 신호 입력으로 사용. */
+  motionStationary: boolean;
+  /** preschedule 호출 채널 — log 식별. boardingLockScheduler='bl', tripBoundScheduler='tba'. */
+  channel: 'bl' | 'tba';
+  /** 목적지 이름 — logger 식별용. 미상이면 'unknown'. */
+  destinationName: string | undefined;
+}
+
+/**
+ * preschedule 시점 정합성 게이트 평가.
+ *
+ * 반환:
+ *  - true: schedule 진행 (allow / boardingStation 없음 / WiFi 미상 / fresh signal 모두 정상)
+ *  - false: schedule 거부 (WiFi != target && motion=stationary 등 명백한 모순)
+ *
+ * 차단 시 `logLocalFireConsistencyBlocked` + logger.info — 호출자는 boolean 결과만 사용한다.
+ */
+export async function evaluatePreScheduleConsistency(
+  input: PreScheduleConsistencyInput,
+): Promise<boolean> {
+  if (!input.boardingStation) return true;
+
+  let wifiStation = null;
+  try {
+    const ssid = await getCurrentWifiSsid();
+    wifiStation = lookupStationBySsid(ssid);
+  } catch {
+    // graceful — WiFi 미상.
+  }
+
+  const deviceSignal = extractDeviceSignal({
+    currentStation: input.boardingStation.stationName,
+    motionStationary: input.motionStationary,
+    wifiStation,
+    lastUpdateMs: Date.now(),
+  });
+  const result = evaluatePushConsistency(
+    deviceSignal,
+    input.boardingStation,
+    { deviceHopsBehindTarget: null },
+    Date.now(),
+  );
+  if (result.allowed) return true;
+
+  logLocalFireConsistencyBlocked({
+    source: 'bg-scheduled',
+    stationName: input.boardingStation.stationName,
+    reason: result.reason,
+  });
+  logger.info(
+    `preschedule consistency skip channel=${input.channel} reason=${result.reason} destination=${input.destinationName ?? 'unknown'}`,
+  );
+  return false;
+}

--- a/src/features/alarm/utils/silentPushConsistencyGate.ts
+++ b/src/features/alarm/utils/silentPushConsistencyGate.ts
@@ -1,0 +1,59 @@
+/**
+ * #1389 — silent push 수신 시점 정합성 게이트 evaluator.
+ *
+ * silentPushTask가 fire 직전 호출. 분리 의도:
+ *   - 호출자(silentPushTask)는 result를 보고 ack/log/cancel 라우팅만 처리한다.
+ *   - 본 helper가 WiFi 신호 수집 + helper 호출 + 결과 반환에 집중.
+ *
+ * BG 컨텍스트:
+ *   - WiFi: 비동기 `getCurrentWifiSsid` + lookup. 실패 시 null (helper의 자연 fallback 허용).
+ *   - currentStationName: BG에선 fused nearest 부재 → null (helper의 hops=null fallback 경로 진입).
+ *   - lastUpdateMs: Date.now() — fresh 신호로 간주.
+ */
+
+// eslint-disable-next-line import/no-restricted-paths -- WiFi SSOT는 nearest-station feature.
+import { getCurrentWifiSsid } from '../../nearest-station/utils/wifiSsidNative';
+// eslint-disable-next-line import/no-restricted-paths -- WiFi → station 매핑 SSOT.
+import { lookupStationBySsid } from '../../nearest-station/utils/wifiSsidLookup';
+import {
+  evaluatePushConsistency,
+  type ConsistencyResult,
+} from './pushConsistency';
+import { extractDeviceSignal } from './pushConsistencyContext';
+
+export interface SilentPushConsistencyInput {
+  targetStationName: string;
+  targetLine: string;
+  motionStationary: boolean;
+}
+
+/**
+ * silent push 수신 시점 정합성 평가.
+ *
+ * `evaluatePushConsistency` 결과를 그대로 전달 — caller가 ack/log/cancel 처리.
+ */
+export async function evaluateSilentPushConsistency(
+  input: SilentPushConsistencyInput,
+): Promise<ConsistencyResult> {
+  let wifiStation = null;
+  try {
+    const ssid = await getCurrentWifiSsid();
+    wifiStation = lookupStationBySsid(ssid);
+  } catch {
+    // graceful — WiFi 미상이면 helper가 다른 신호로 평가.
+  }
+
+  const deviceSignal = extractDeviceSignal({
+    currentStation: null, // BG에서는 fused nearest station 부재 — hops=null fallback 경로.
+    motionStationary: input.motionStationary,
+    wifiStation,
+    lastUpdateMs: Date.now(),
+  });
+  const target = { stationName: input.targetStationName, line: input.targetLine };
+  return evaluatePushConsistency(
+    deviceSignal,
+    target,
+    { deviceHopsBehindTarget: null },
+    Date.now(),
+  );
+}

--- a/src/features/alarm/utils/tripBoundScheduler.ts
+++ b/src/features/alarm/utils/tripBoundScheduler.ts
@@ -15,6 +15,8 @@ import { recordScheduledAlarm } from './prescheduledMetrics';
 import { evaluateMovement, isStaticMovementResult } from '../../nearest-station/utils/movementGate';
 // eslint-disable-next-line import/no-restricted-paths -- BG에서 motion 신호를 읽는 단일 helper.
 import { getCurrentMotionStationary } from '../../nearest-station/utils/motionActivity';
+// #1389 — preschedule 시점 정합성 게이트. boardingLockScheduler와 공유 helper 사용.
+import { evaluatePreScheduleConsistency } from './preScheduleConsistencyGate';
 import { logScheduleSkipped } from './alarmLog';
 
 const logger = createLogger('TripBoundScheduler');
@@ -93,6 +95,11 @@ export interface PrescheduleParams {
    * 누적 오차가 쌓여 imminent가 실제 도착 시각과 어긋난다.
    */
   startStopIndex?: number;
+  /**
+   * #1389 — 정합성 게이트 입력. 사용자가 탑승 시점에 있어야 할 station (lock 있으면 boardingStation).
+   * 미전달이면 정합성 게이트 fallback 허용 (lockless / 진입 컨텍스트 부재).
+   */
+  boardingStation?: { stationName: string; line: string } | null;
 }
 
 export interface ScheduledTripBoundAlarm {
@@ -201,6 +208,16 @@ export async function prescheduleStationAlerts(
     );
     return [];
   }
+
+  // #1389 — 정합성 게이트 (preschedule 시점). boardingStation이 명시되었다면 WiFi 매칭 확인.
+  // boardingStation 미전달 시 게이트 자연 fallback (lockless / 진입 컨텍스트 부재).
+  const consistencyOk = await evaluatePreScheduleConsistency({
+    boardingStation: params.boardingStation ?? null,
+    motionStationary,
+    channel: 'tba',
+    destinationName: routeStops.at(-1)?.stationName,
+  });
+  if (!consistencyOk) return [];
 
   // window 상한 — 미지정이면 전체. 호출자가 명시한 음수/0이면 0 stop schedule(자연스럽게 no-op).
   // startStopIndex 음수 입력은 0으로 clamp — caller(top-up) bug 흡수.

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -417,6 +417,8 @@ export default function HomeScreen() {
     // D1 estimator(LocklessRouteHop 포함)의 현재 hop index와 arcStations를 그대로 전달.
     currentHopIndex,
     arcStations,
+    // #1389 — 정합성 게이트 입력. WiFi SSID 매칭 결과를 전달해 device 신호와 target 모순 차단.
+    wifiStation,
   });
 
   // #584 PR B — BoardingLock 진입점. UI 렌더링/lock 생성만 담당하며,


### PR DESCRIPTION
## Summary

#1389 epic의 frontend callsite 적용 + 미커버 test 보충 (PR-3b).

PR-3a (#1393, helper extraction) base 위에서 4 fire site에 정합성 게이트를 wire하고, 추출한 callsite helper들에 대한 단독 test로 coverage 100%를 채운다.

## 적용된 fire site (4개)

### FG (useStationAlarm)
- phase ETA fire
- API imminent fire (destination)
- GPS station-passed fire
- FG arvlcd fast-path station-passed fire
- subsurface verdict station-passed fire

### BG (silentPushTask)
- silent push 수신 시점 정합성 평가 → 차단 시 ack=skipped + cancelTba + cancelBl + return

### Preschedule
- boardingLockScheduler.scheduleHopsForLock — WiFi가 boardingStation과 다른 station 확증 시 schedule 거부
- tripBoundScheduler.prescheduleStationAlerts — useTripBoundAlarmScheduler가 boardingStation을 명시 전달, helper가 정합성 평가

## 공유 helper 추출 (testability + DRY)

callsite의 정합성 평가 로직을 3개 helper로 분리:

- `src/features/alarm/utils/localFireConsistencyGate.ts` — `evaluateLocalFireConsistency` + `resolveTargetLine` (useStationAlarm 5 callsite 공통)
- `src/features/alarm/utils/silentPushConsistencyGate.ts` — `evaluateSilentPushConsistency` (silentPushTask)
- `src/features/alarm/utils/preScheduleConsistencyGate.ts` — `evaluatePreScheduleConsistency` (boardingLockScheduler + tripBoundScheduler가 동일 helper 호출)

callsite는 helper 결과(`{allowed: boolean}`)로 fire 진행/차단만 결정 — 평가 로직은 helper SSOT.

## Test coverage 100% 강제 통과

- 신규 helper test 4개 (`localFireConsistencyGate.test.ts` / `silentPushConsistencyGate.test.ts` / `preScheduleConsistencyGate.test.ts` + `alarmLog.test.ts` 추가) — 차단/허용 분기를 helper에서 직접 검증.
- callsite test (useStationAlarm.test.ts / silentPushTask.test.ts / boardingLockScheduler.test.ts / tripBoundScheduler.test.ts / useTripBoundAlarmScheduler.test.tsx) — helper false 반환 시 fire/schedule이 early-return으로 차단되는지만 검증. helper SSOT 분리 + callsite 흡수 분리.
- 결과: 297 test suites / 5797 tests / 100% coverage / type-check / lint 모두 통과.

## alarmLog reason 4개 추가

`consistency-wifi-mismatch` / `consistency-motion-stationary-far-behind` / `consistency-device-station-mismatch` / `consistency-device-ahead-of-target` — share dump에서 차단 사유별 카운트 추적.

## Test plan

- [x] `npm test` — 297/297 test suites + 5797/5797 tests + coverage 100%
- [x] `npm run type-check`
- [x] `npm run lint`
- [ ] CI green (PR check)
- [ ] 실기기 검증 — PR-3 시리즈가 dev에 머지된 후 사용자 트립 회귀 확인

Closes #1389 (frontend portion).

## refs
- PR-3a (helper extraction, base): #1393
- PR-1 (evaluatePushConsistency core): #1390
- SSOT: `tasks/issue-1389-push-consistency-2026-06-16.md`