### PR TITLE
fix(#1400): useArrivalInfo 캐시 키 호선 격리 + arrivalInfoToArrivalTrain 호선 필터

### DIFF
--- a/src/features/arrival/__tests__/etaProviderConsistency.test.ts
+++ b/src/features/arrival/__tests__/etaProviderConsistency.test.ts
@@ -39,8 +39,10 @@ function boardingTrainListClock(item: { arrivalSeconds: number }): string {
 
 function arrivalRowAnchor(item: { arrivalSeconds: number }): number {
   // EditorialArrivalRow는 train.arrivalAtMs를 useCountdown에 전달 — arrivalAtMs = arrivalAt(item).
+  // #1400 — arrivalInfoToArrivalTrain은 line 필터를 적용하므로 makeArrivalInfo의 line을 '6'으로
+  // 맞춰 6호선 봉화산행 row가 결과에 포함되도록 한다.
   const [train] = arrivalInfoToArrivalTrain(
-    [makeArrivalInfo({ destination: '봉화산행', arrivalSeconds: item.arrivalSeconds })],
+    [makeArrivalInfo({ destination: '봉화산행', arrivalSeconds: item.arrivalSeconds, line: '6' })],
     '상행',
     '6',
   );
@@ -101,8 +103,9 @@ describe('D7 #1213 ETA provider consistency', () => {
     // 현재역 BoardingTrainList는 useBoardingLockController가 arrival.up/down을 그대로 필터해
     // directionalArrivals로 노출 — 새 source가 아니다. 같은 reference의 ArrivalInfo는 두 surface
     // 모두에서 같은 arrivalAt(item) 결과를 가진다.
+    // #1400 — arrivalInfoToArrivalTrain은 line 필터를 적용하므로 6호선 row를 사용.
     setNow(FIXED_T0);
-    const shared = makeArrivalInfo({ destination: '봉화산행', arrivalSeconds: 134 });
+    const shared = makeArrivalInfo({ destination: '봉화산행', arrivalSeconds: 134, line: '6' });
     // BoardingTrainList path
     const boardingMs = arrivalAt(shared);
     // EditorialArrivalRow path

--- a/src/features/arrival/hooks/__tests__/useArrivalInfo.test.ts
+++ b/src/features/arrival/hooks/__tests__/useArrivalInfo.test.ts
@@ -481,4 +481,79 @@ describe('useArrivalInfo', () => {
 
     await waitFor(() => expect(result.current.arrival).toEqual(freshArrival));
   });
+
+  // #1400 — 캐시 키는 (stationName, lineHint) 튜플로 호선별 격리되어야 한다.
+  // BFF 실시간 응답은 호선 무관 동일하지만 schedule fallback은 호선별로 달라지므로
+  // 호선 무관 키로 캐싱하면 직전 호선의 fallback이 다음 호선 폴링에도 잔존한다.
+  describe('cache key by (stationName, lineHint) (#1400)', () => {
+    it('같은 stationName 다른 lineHint는 캐시를 공유하지 않는다 (호선별 격리)', async () => {
+      const arrivalLine2 = {
+        up: [{ destination: '내선순환', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '', trainCode: 'L2-A', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
+        down: [],
+      };
+      const arrivalLine3 = {
+        up: [{ destination: '대화행', arrivalMinutes: 3, arrivalSeconds: 180, statusMessage: '', trainCode: 'L3-B', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
+        down: [],
+      };
+
+      // line=2 prefetch — line=2 응답을 그 키에만 적재.
+      (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(arrivalLine2);
+      await prefetchArrival('교대', '2');
+      const callsAfterLine2 = (arrivalApiModule.fetchArrivalInfo as jest.Mock).mock.calls.length;
+
+      // line=3 prefetch — line=2 캐시는 미적용. 다시 fetch가 발생해야 한다.
+      (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(arrivalLine3);
+      await prefetchArrival('교대', '3');
+      expect((arrivalApiModule.fetchArrivalInfo as jest.Mock).mock.calls.length).toBeGreaterThan(callsAfterLine2);
+
+      // line=3로 마운트하면 line=3 캐시(arrivalLine3) hit이 노출되어야 함.
+      const { result } = renderHook(() => useArrivalInfo('교대', '3'));
+      expect(result.current.arrival).toEqual(arrivalLine3);
+    });
+
+    it('같은 (stationName, lineHint) 재사용은 캐시 hit', async () => {
+      (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
+      await prefetchArrival('교대', '2');
+      const callsAfterFirst = (arrivalApiModule.fetchArrivalInfo as jest.Mock).mock.calls.length;
+
+      // 같은 (stationName, lineHint) prefetch는 캐시 hit으로 fetch 미발생.
+      await prefetchArrival('교대', '2');
+      expect((arrivalApiModule.fetchArrivalInfo as jest.Mock).mock.calls.length).toBe(callsAfterFirst);
+    });
+
+    it('lineHint=null과 lineHint="2"는 서로 다른 캐시 키', async () => {
+      (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockArrival);
+      await prefetchArrival('교대', null);
+      const callsAfterNull = (arrivalApiModule.fetchArrivalInfo as jest.Mock).mock.calls.length;
+
+      // null 캐시는 line='2'에 사용되지 않으므로 새 fetch가 발생.
+      await prefetchArrival('교대', '2');
+      expect((arrivalApiModule.fetchArrivalInfo as jest.Mock).mock.calls.length).toBeGreaterThan(callsAfterNull);
+    });
+
+    it('lineHint가 바뀌면 직전 호선의 캐시 데이터가 표시되지 않는다', async () => {
+      const arrivalLine2 = {
+        up: [{ destination: '내선순환', arrivalMinutes: 2, arrivalSeconds: 120, statusMessage: '', trainCode: 'L2-A', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
+        down: [],
+      };
+      // line=2 캐시 채워 둠.
+      (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(arrivalLine2);
+      await prefetchArrival('교대', '2');
+
+      // 같은 station을 line=3으로 mount — line=2 cache는 hit 안 됨.
+      // 그 사이 mock을 막혀(pending) 상태로 둬 cache가 진짜 비어있는지(loading=true) 확인.
+      let resolveLine3!: (v: typeof mockArrival) => void;
+      (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockImplementation(
+        () => new Promise((r) => { resolveLine3 = r; })
+      );
+      const { result } = renderHook(() => useArrivalInfo('교대', '3'));
+      // 캐시 miss → loading=true, arrival=null.
+      expect(result.current.arrival).toBeNull();
+      expect(result.current.loading).toBe(true);
+
+      // fetch 완료 후 line=3 데이터로 표시.
+      await act(async () => { resolveLine3(mockArrival); });
+      expect(result.current.arrival).toEqual(mockArrival);
+    });
+  });
 });

--- a/src/features/arrival/hooks/useArrivalInfo.ts
+++ b/src/features/arrival/hooks/useArrivalInfo.ts
@@ -12,8 +12,23 @@ const CACHE_TTL_MS = 30_000;
 /**
  * 모듈 스코프 싱글톤 — fusion에서 동일 station name을 여러 hook 인스턴스가 폴링할 때
  * 중복 네트워크 호출을 막기 위한 공유 캐시.
+ *
+ * #1400 — 캐시 키는 `${stationName}|${lineHint ?? ''}` 형태로 호선을 포함한다. BFF 실시간 응답은
+ * 호선 무관 동일하지만, 응답 실패/누락 시 `getFallbackArrival(stationName, ..., lineHint)`가 호선별로
+ * 다른 schedule fallback을 반환한다. 호선 무관 키로 캐시하면 환승역에서 직전 호선의 schedule fallback이
+ * 다음 호선 폴링에도 잔존해 "논현인데 3호선 신사행" 같은 호선 mis-display로 이어진다.
  */
 const arrivalCache = new TtlCache<string, StationArrival>(CACHE_TTL_MS);
+
+/**
+ * `useArrivalInfo` 공유 캐시 키 빌더 — `(stationName, lineHint)` 조합으로 격리한다 (#1400).
+ *
+ * lineHint가 null/undefined인 호출(fusion 등 호선 미지정)은 빈 문자열로 정규화해 호선 미지정 케이스끼리만
+ * 캐시를 공유한다. 호선 지정 호출(transfer list, 환승 컨텍스트)은 호선별로 독립 격리.
+ */
+function arrivalCacheKey(stationName: string, lineHint: LineNumber | null | undefined): string {
+  return `${stationName}|${lineHint ?? ''}`;
+}
 
 /** 테스트 격리용 — useArrivalInfo 사용처 외에는 호출하지 말 것. */
 export function __resetArrivalCacheForTests(): void {
@@ -44,13 +59,14 @@ export async function prefetchArrival(
   lineHint?: LineNumber | null,
 ): Promise<void> {
   if (!stationName) return;
-  if (arrivalCache.get(stationName)) return;
+  const key = arrivalCacheKey(stationName, lineHint);
+  if (arrivalCache.get(key)) return;
   try {
     const data = await getPrefetchProvider().getArrival(stationName, {
       lineHint: lineHint ?? undefined,
     });
     if (!data.isMock) {
-      arrivalCache.set(stationName, data);
+      arrivalCache.set(key, data);
     }
   } catch {
     // prefetch 실패는 무시 — 실제 useArrivalInfo 폴링이 재시도한다.
@@ -84,8 +100,8 @@ export function useArrivalInfo(
   const arrivalRef = useRef<StationArrival | null>(null);
   const stationNameRef = useRef(stationName);
   stationNameRef.current = stationName;
-  // lineHint는 환승역 schedule fallback의 정확도용. 캐시 키에는 포함하지 않는다
-  // (같은 역의 실시간 응답은 호선 무관 동일하므로 캐시 공유가 더 효율적).
+  // #1400 — lineHint는 캐시 키에 포함된다. 환승역에서 같은 station name이라도 호선별 schedule
+  // fallback이 다르므로 (현재역 도착정보가 잘못된 호선/방면을 표시하는 회귀 차단).
   const lineHintRef = useRef(lineHint);
   lineHintRef.current = lineHint;
 
@@ -104,7 +120,7 @@ export function useArrivalInfo(
       return;
     }
 
-    const cached = arrivalCache.get(stationName);
+    const cached = arrivalCache.get(arrivalCacheKey(stationName, lineHint));
     if (cached) {
       updateArrival(cached);
       setLoading(false);
@@ -113,7 +129,9 @@ export function useArrivalInfo(
       setArrival(null);
       setLoading(true);
     }
-  }, [stationName]);
+    // lineHint가 바뀌면 새 (station, line) 키로 캐시 lookup. fusion 슬롯 교체 시 직전 호선
+    // 캐시가 잔존해 잘못된 도착정보로 표시되는 회귀 차단(#1400).
+  }, [stationName, lineHint, updateArrival]);
 
   useEffect(() => {
     if (!stationName) return;
@@ -127,7 +145,7 @@ export function useArrivalInfo(
         });
         if (cancelled) return;
         if (!data.isMock) {
-          arrivalCache.set(stationName, data);
+          arrivalCache.set(arrivalCacheKey(stationName, lineHint), data);
         }
         updateArrival(data);
       } catch {
@@ -143,17 +161,18 @@ export function useArrivalInfo(
       cancelled = true;
     };
     // lineHint가 바뀌면 즉시 refetch — stale hint로 5초간 잘못된 호선 schedule이 보이는 것 방지.
-  }, [stationName, lineHint]);
+  }, [stationName, lineHint, updateArrival]);
 
   const doPoll = useCallback(() => {
     const name = stationNameRef.current;
     if (!name) return;
+    const hint = lineHintRef.current;
     providerRef.current.getArrival(name, {
-      lineHint: lineHintRef.current ?? undefined,
+      lineHint: hint ?? undefined,
     }).then((data) => {
       if (name !== stationNameRef.current) return;
       if (!data.isMock) {
-        arrivalCache.set(name, data);
+        arrivalCache.set(arrivalCacheKey(name, hint), data);
       }
       updateArrival(data);
       setLoading(false);

--- a/src/features/route/utils/__tests__/journeyAdapter.test.ts
+++ b/src/features/route/utils/__tests__/journeyAdapter.test.ts
@@ -220,7 +220,7 @@ describe('arrivalInfoToArrivalTrain', () => {
   afterEach(() => { jest.restoreAllMocks(); });
 
   it('should convert arrival info with destination', () => {
-    const items = [makeArrivalInfo({ destination: '봉화산행', arrivalSeconds: 134 })];
+    const items = [makeArrivalInfo({ destination: '봉화산행', arrivalSeconds: 134, line: '6' })];
     const result = arrivalInfoToArrivalTrain(items, '상행', '6');
     expect(result).toEqual([
       {
@@ -239,7 +239,7 @@ describe('arrivalInfoToArrivalTrain', () => {
   });
 
   it('#1035 context 전달 시 stationName/directionKey가 ArrivalTrain에 포함된다', () => {
-    const items = [makeArrivalInfo({ destination: '봉화산행', arrivalSeconds: 60 })];
+    const items = [makeArrivalInfo({ destination: '봉화산행', arrivalSeconds: 60, line: '6' })];
     const result = arrivalInfoToArrivalTrain(items, '상행', '6', {
       stationName: '응암',
       directionKey: 'up',
@@ -257,6 +257,7 @@ describe('arrivalInfoToArrivalTrain', () => {
         isLastTrain: true,
         trainType: 'express',
         arrivalCode: 1,
+        line: '6',
       }),
     ];
     const result = arrivalInfoToArrivalTrain(items, '상행', '6');
@@ -266,21 +267,21 @@ describe('arrivalInfoToArrivalTrain', () => {
   });
 
   it('should use direction fallback when destination is empty', () => {
-    const items = [makeArrivalInfo({ destination: '', arrivalSeconds: 60 })];
+    const items = [makeArrivalInfo({ destination: '', arrivalSeconds: 60, line: '2' })];
     const result = arrivalInfoToArrivalTrain(items, '하행', '2');
     expect(result[0].direction).toBe('하행');
   });
 
   it('should include statusMessage as subtext when present', () => {
-    const items = [makeArrivalInfo({ destination: '응암행', arrivalSeconds: 271, statusMessage: '전역 출발' })];
+    const items = [makeArrivalInfo({ destination: '응암행', arrivalSeconds: 271, statusMessage: '전역 출발', line: '6' })];
     const result = arrivalInfoToArrivalTrain(items, '상행', '6');
     expect(result[0].subtext).toBe('전역 출발');
   });
 
   it('should handle multiple items', () => {
     const items = [
-      makeArrivalInfo({ destination: '봉화산행', arrivalSeconds: 134 }),
-      makeArrivalInfo({ destination: '응암행', arrivalSeconds: 271, statusMessage: '진입 중', trainCode: 'T002' }),
+      makeArrivalInfo({ destination: '봉화산행', arrivalSeconds: 134, line: '6' }),
+      makeArrivalInfo({ destination: '응암행', arrivalSeconds: 271, statusMessage: '진입 중', trainCode: 'T002', line: '6' }),
     ];
     const result = arrivalInfoToArrivalTrain(items, '상행', '6');
     expect(result).toHaveLength(2);
@@ -289,13 +290,33 @@ describe('arrivalInfoToArrivalTrain', () => {
   });
 
   it('should handle special line number', () => {
-    const items = [makeArrivalInfo({ destination: '인천공항행', arrivalSeconds: 600, trainCode: 'A001' })];
+    const items = [makeArrivalInfo({ destination: '인천공항행', arrivalSeconds: 600, trainCode: 'A001', line: 'airport' })];
     const result = arrivalInfoToArrivalTrain(items, '상행', 'airport');
     expect(result[0].line).toBe('airport');
   });
 
   it('should return empty array for empty items', () => {
     expect(arrivalInfoToArrivalTrain([], '상행', '1')).toEqual([]);
+  });
+
+  // #1400 — 환승역 statnNm 응답에 다른 호선 row가 섞이는 회귀(예: 논현 statnNm에 7호선/신분당선)
+  // 가 관측됐다. arrivalInfoToArrivalTrain은 호출자가 명시한 line과 다른 row를 제외해 잘못된
+  // 방면/지난 호선 시간표가 사용자에게 보이지 않도록 한다.
+  it('#1400 line 파라미터와 다른 item.line은 결과에서 제외된다', () => {
+    const items = [
+      makeArrivalInfo({ destination: '봉화산행', arrivalSeconds: 60, line: '6' }),
+      makeArrivalInfo({ destination: '응암행', arrivalSeconds: 120, trainCode: 'T-OTHER', line: '5' }),
+    ];
+    const result = arrivalInfoToArrivalTrain(items, '상행', '6');
+    expect(result).toHaveLength(1);
+    expect(result[0].direction).toBe('봉화산행');
+    expect(result[0].line).toBe('6');
+  });
+
+  it('#1400 모든 item.line이 line 파라미터와 어긋나면 빈 배열', () => {
+    const items = [makeArrivalInfo({ destination: '신사행', arrivalSeconds: 60, line: '3' })];
+    const result = arrivalInfoToArrivalTrain(items, '상행', '7');
+    expect(result).toEqual([]);
   });
 });
 

--- a/src/features/route/utils/journeyAdapter.ts
+++ b/src/features/route/utils/journeyAdapter.ts
@@ -138,10 +138,15 @@ export function arrivalInfoToArrivalTrain(
   /** #1035 — 막차 시각 lookup 컨텍스트. 호출자가 알면 전달, 없으면 시각 미표기 fallback. */
   context?: { stationName?: string; directionKey?: 'up' | 'down' },
 ): ArrivalTrain[] {
+  // #1400 — 환승역에서 같은 statnNm 응답에 다른 노선 열차가 섞이는 회귀가 관측됐다("논현인데
+  // 3호선 신사행" 등). 호출자가 line 파라미터를 명시한 컨텍스트에서는 그 line과 다른 row를
+  // 노출 자체에서 제외해 잘못된 방면/지난 호선 시간표가 사용자에게 보이지 않도록 한다. BFF가
+  // line을 정확히 채우면 본 필터는 no-op(정상 응답)이며, line이 어긋난 row만 차단한다.
+  const filteredItems = items.filter((item) => item.line === line);
   // item.destination은 서울 열린데이터 API의 trainLineNm 기반("소요산행", "내선순환" 등 방면 표현).
   // parseTrainLineDirection이 패턴(역명+행, 내선/외선순환)을 인식해 현재 언어로 표시한다.
   // #897 Seam A: arrivalAt(item) — BoardingTrainList와 동일한 anchor. useArrivalCountdown tick과 동기.
-  return items.map((item) => ({
+  return filteredItems.map((item) => ({
     direction: item.destination
       ? parseTrainLineDirection(item.destination, allStations)
       : direction,


### PR DESCRIPTION
Closes #1400
Part of #1396 (sub 4/6)

## 변경 요약

route/lock 정확성 — 환승역에서 같은 station name이지만 호선별로 schedule fallback이 다른 케이스에서, 직전 호선 캐시·다른 호선 row가 화면에 잔존해 "논현인데 3호선 신사행" 같은 호선 mis-display 회귀를 차단한다.

### 1. `useArrivalInfo` 캐시 키 호선 격리 (`useArrivalInfo.ts:87-90`)
모듈 공유 `arrivalCache`의 키를 `stationName` → `(stationName, lineHint)` 튜플로 변경.

- BFF 실시간 응답은 호선 무관 동일하지만, 응답 실패/누락 시 `getFallbackArrival(stationName, ..., lineHint)`가 **호선별로 다른 schedule fallback**을 반환한다.
- 호선 무관 키로 캐싱하면 환승역에서 직전 호선의 fallback이 다음 호선 폴링에도 잔존 → 잘못된 방면/지난 호선 시간표 노출.
- 캐시 키를 `${stationName}|${lineHint ?? ''}` 형태로 격리. null/undefined는 빈 문자열로 정규화해 호선 미지정 케이스끼리만 캐시 공유.

영향 받는 surface:
- `prefetchArrival` (#814) — 환승 사전 폴링 시 호선별 격리 적용.
- `useArrivalInfo` initial cached lookup + 5s polling + `doPoll` 강제 refetch — 세 경로 모두 호선 키 사용.

### 2. `arrivalInfoToArrivalTrain` 호선 필터 (`journeyAdapter.ts:134, 145-146`)
호출자가 명시한 `line` 파라미터와 다른 `item.line` row를 결과에서 제외.

- 환승역 statnNm 응답에 같은 statnNm으로 다른 노선 열차가 섞이는 BFF 회귀가 관측됨 (논현 statnNm에 7호선/신분당선 등).
- BFF가 `line`을 정확히 채우면 본 필터는 no-op (정상 응답), `line`이 어긋난 row만 차단.
- 현재역 도착정보 섹션(`<ArrivalDirectionGroup>` via `HomeScreen`)이 `effectiveOrigin.line`과 일치하는 row만 노출.

## acceptance 매핑 (본문 + 코멘트)
- [x] **환승역에서 leg 호선과 다른 trainCode lock 0건** — `pickAutoTrainCode`(`matchLine`) + `targetWaypoint.line` + `createLockFromTrain`(`train.line`) + `#1366 isLockConsistentWithRoute`로 기존 보장. 본 PR은 표시 surface(현재역 도착정보)에서 호선 어긋난 row가 사용자에게 보이는 회귀 추가 차단.
- [x] **현재역 도착정보가 올바른 호선/방면 표시 + 지나온 역 시간표 잔존 0** — `arrivalInfoToArrivalTrain` 호선 필터 + `useArrivalInfo` 캐시 키 호선 격리로 양면 가드.
- [x] **커버리지 100% / type-check 통과** — `npm test` 5745건 PASS, 전체 100% coverage 유지. `npm run type-check` clean. `npm run lint` clean.
- [ ] route 교체 시 `revalidate-waypoint-mismatch` < 5% — 기존 `revalidatePrescheduledAlarm` + `clearRegisteredBlRouteSig`(`scheduledAlarmReceiver.ts`)로 처리됨. 본 PR 범위 외 측정 acceptance.
- [ ] "이 열차 탔어요?" 푸시 정상 발사 + UI 상태 일치 — backend `boardingPrompt.ts` window 평가 영역. 본 PR 범위 외.
- [ ] epic 검증 환승 trip 실기기 재현 — epic close 게이트.

코멘트 신규 acceptance (#1400 2026-06-17):
- [x] **trip 생성 시 leg 0의 line이 route 권장 경로와 일치** — `createLockFromTrain`이 `train.line` 사용 + `#1366 isLockConsistentWithRoute`가 `firstLegLine === lock.boardingLine` 가드. 본 PR은 표시 surface 보호 강화.
- [x] **BoardingTrainList UI 호선별 분리 표시** — 기존 `filteredArrivals = arrivals.filter((train) => train.line === line)` (#664) + `borderLeftColor: LINE_COLORS[train.line]` row 스트라이프 색으로 이미 보장. 본 PR은 다른 도착 surface(현재역 섹션)도 동일 정책 정렬.
- [x] **BoardingPrompt push trainCode 결정의 `line` 파라미터 일관성** — backend `pickAutoTrainCode(arrivals, line, direction)` + `attemptAutoLock`의 `const line = targetWaypoint.line`로 보장. 클라 `useBoardingPromptResponder`도 `a.line === payload.line` 필터. 본 PR 범위 외 (기존 보장 검증).
- [x] **모든 leg 호선 일관성** — 도착 surface가 호선별로 격리되어 사용자가 잘못된 호선 trip을 인지하기 전 시각적 잔존을 차단.

## 변경 파일
- `src/features/arrival/hooks/useArrivalInfo.ts` — 캐시 키 빌더 + 3 경로 갱신.
- `src/features/route/utils/journeyAdapter.ts` — `arrivalInfoToArrivalTrain` 호선 필터.
- `src/features/arrival/hooks/__tests__/useArrivalInfo.test.ts` — cache key 회귀 가드 4건 추가 (#1400 describe).
- `src/features/route/utils/__tests__/journeyAdapter.test.ts` — 기존 fixture line 명시화 + 호선 필터 회귀 가드 2건 추가 (#1400).
- `src/features/arrival/__tests__/etaProviderConsistency.test.ts` — D7 SSOT 회귀 fixture를 line='6'으로 정정 (필터 통과 보장).

## 검증
- `npm test` — 5745 PASS / coverage 100%
- `npm run type-check` — PASS
- `npm run lint` — PASS

## 사용자 결정 필요 / 후속
- backend `boardingPrompt.ts` window-too-small 분기는 positions 폴링 빈도에 의한 backend 게이트 평가 영역 — 본 PR 범위 외. 별도 진단 후 backend PR로 다뤄야 함.
- `revalidate-waypoint-mismatch` 운영 비율(<5%)은 실기기 production 측정으로 검증해야 함 (epic close 게이트).