### PR TITLE
chore(#1397): stations.json 빌드타임 재생성 파이프라인 + 자양(뚝섬한강공원) 반영

### DIFF
--- a/scripts/__tests__/regenerate-stations.test.js
+++ b/scripts/__tests__/regenerate-stations.test.js
@@ -1,0 +1,591 @@
+/**
+ * #1397: regenerate-stations 스크립트 단위 테스트.
+ * 변환 로직을 pure function으로 분리해 결정론성 + 회귀 방지 검증.
+ */
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+
+const {
+  LINE_TO_ROUTES,
+  ROUTE_TO_LINE,
+  RENAME_MAP,
+  MATCH_RATIO_FLOOR,
+  joinKey,
+  splitName,
+  fetchPage,
+  fetchAll,
+  buildApiIndex,
+  normalizePatch,
+  applyRenames,
+  serialize,
+  main,
+} = require('../regenerate-stations');
+
+describe('상수', () => {
+  it('LINE_TO_ROUTES + ROUTE_TO_LINE 역방향 일관성', () => {
+    for (const [line, routes] of Object.entries(LINE_TO_ROUTES)) {
+      for (const r of routes) {
+        expect(ROUTE_TO_LINE.get(r)).toBe(line);
+      }
+    }
+  });
+
+  it('RENAME_MAP은 자양(뚝섬한강공원) 케이스 포함', () => {
+    expect(RENAME_MAP['7|뚝섬유원지']).toBeDefined();
+    const v = RENAME_MAP['7|뚝섬유원지'];
+    expect(typeof v).toBe('object');
+    expect(v.name).toBe('자양(뚝섬한강공원)');
+  });
+
+  it('MATCH_RATIO_FLOOR은 보수적인 floor', () => {
+    expect(MATCH_RATIO_FLOOR).toBeGreaterThan(0.5);
+    expect(MATCH_RATIO_FLOOR).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('joinKey', () => {
+  it('line | name 결합', () => {
+    expect(joinKey('7', '자양')).toBe('7|자양');
+    expect(joinKey('airport', '인천국제공항1터미널')).toBe('airport|인천국제공항1터미널');
+  });
+});
+
+describe('splitName', () => {
+  it('괄호 부제 분리', () => {
+    expect(splitName('교대(법원.검찰청)')).toEqual({
+      base: '교대',
+      full: '교대(법원.검찰청)',
+    });
+  });
+
+  it('괄호 없으면 base = full', () => {
+    expect(splitName('서울역')).toEqual({ base: '서울역', full: '서울역' });
+  });
+
+  it('맨 앞 괄호는 base = full', () => {
+    expect(splitName('(가상역)')).toEqual({ base: '(가상역)', full: '(가상역)' });
+  });
+
+  it('trim 적용', () => {
+    expect(splitName('  자양(뚝섬한강공원)  ')).toEqual({
+      base: '자양',
+      full: '자양(뚝섬한강공원)',
+    });
+  });
+
+  it('비문자열은 base/full 빈 문자열', () => {
+    expect(splitName(null)).toEqual({ base: '', full: '' });
+    expect(splitName(undefined)).toEqual({ base: '', full: '' });
+    expect(splitName(123)).toEqual({ base: '', full: '' });
+  });
+
+  it('빈 문자열은 base/full 빈 문자열', () => {
+    expect(splitName('')).toEqual({ base: '', full: '' });
+  });
+});
+
+describe('buildApiIndex', () => {
+  it('ROUTE → line + base name으로 인덱스 빌드', () => {
+    const apiRows = [
+      { BLDN_ID: '0150', BLDN_NM: '서울역', ROUTE: '1호선', LAT: '37.5', LOT: '127' },
+      { BLDN_ID: '2522', BLDN_NM: '자양(뚝섬한강공원)', ROUTE: '7호선', LAT: '37.5', LOT: '127' },
+      { BLDN_ID: '0329', BLDN_NM: '교대(법원.검찰청)', ROUTE: '3호선', LAT: '37.5', LOT: '127' },
+    ];
+    const idx = buildApiIndex(apiRows);
+    expect(idx.get('1|서울역')).toBe('서울역');
+    expect(idx.get('7|자양')).toBe('자양(뚝섬한강공원)');
+    expect(idx.get('3|교대')).toBe('교대(법원.검찰청)');
+  });
+
+  it('매핑 안되는 ROUTE는 무시', () => {
+    const idx = buildApiIndex([
+      { BLDN_NM: '미스터리역', ROUTE: '미존재노선' },
+    ]);
+    expect(idx.size).toBe(0);
+  });
+
+  it('BLDN_NM 누락(빈 문자열) 행은 건너뜀', () => {
+    const idx = buildApiIndex([
+      { BLDN_NM: '', ROUTE: '1호선' },
+      { BLDN_NM: '서울역', ROUTE: '1호선' },
+    ]);
+    expect(idx.size).toBe(1);
+    expect(idx.get('1|서울역')).toBe('서울역');
+  });
+
+  it('같은 (line, base)에 여러 매칭 시 첫 발견 유지', () => {
+    const idx = buildApiIndex([
+      { BLDN_NM: '자양(뚝섬한강공원)', ROUTE: '7호선' },
+      { BLDN_NM: '자양(다른표기)', ROUTE: '7호선' },
+    ]);
+    expect(idx.get('7|자양')).toBe('자양(뚝섬한강공원)');
+  });
+});
+
+describe('normalizePatch', () => {
+  it('문자열은 { name }로 변환', () => {
+    expect(normalizePatch('자양(뚝섬한강공원)')).toEqual({ name: '자양(뚝섬한강공원)' });
+  });
+
+  it('객체는 정의된 i18n 필드까지 patch', () => {
+    expect(
+      normalizePatch({
+        name: '자양(뚝섬한강공원)',
+        nameEn: 'Jayang',
+        nameJa: 'チャヤン',
+        nameHanja: '紫陽',
+      }),
+    ).toEqual({
+      name: '자양(뚝섬한강공원)',
+      nameEn: 'Jayang',
+      nameJa: 'チャヤン',
+      nameHanja: '紫陽',
+    });
+  });
+
+  it('부분 정의된 객체는 정의된 필드만 patch', () => {
+    expect(normalizePatch({ name: '자양', nameEn: 'Jayang' })).toEqual({
+      name: '자양',
+      nameEn: 'Jayang',
+    });
+  });
+
+  it('타입 불일치 i18n 필드는 무시', () => {
+    expect(
+      normalizePatch({
+        name: '자양',
+        nameEn: 42,
+        nameJa: null,
+        nameHanja: undefined,
+      }),
+    ).toEqual({ name: '자양' });
+  });
+
+  it('name이 없거나 비문자열이면 null', () => {
+    expect(normalizePatch({})).toBeNull();
+    expect(normalizePatch({ name: 42 })).toBeNull();
+    expect(normalizePatch(null)).toBeNull();
+    expect(normalizePatch(undefined)).toBeNull();
+    expect(normalizePatch(42)).toBeNull();
+  });
+});
+
+describe('applyRenames', () => {
+  const baseStation = (overrides = {}) => ({
+    id: '7-020',
+    name: '뚝섬유원지',
+    line: '7',
+    lineColor: '#747F00',
+    lat: 37.5,
+    lng: 127,
+    nameEn: 'Ttukseom',
+    nameJa: 'トゥクソム',
+    ...overrides,
+  });
+
+  it('RENAME_MAP이 API보다 우선', () => {
+    const stations = [baseStation()];
+    const apiIndex = new Map([['7|뚝섬유원지', 'API임시명']]);
+    const renameMap = { '7|뚝섬유원지': '자양(뚝섬한강공원)' };
+    const { stations: out, stats } = applyRenames(stations, apiIndex, renameMap);
+    expect(out[0].name).toBe('자양(뚝섬한강공원)');
+    expect(stats.renamed).toBe(1);
+    expect(stats.unchanged).toBe(0);
+    expect(stats.renames).toEqual([
+      { id: '7-020', line: '7', from: '뚝섬유원지', to: '자양(뚝섬한강공원)' },
+    ]);
+  });
+
+  it('객체 patch는 i18n 필드도 갱신, 미지정 필드는 보존', () => {
+    const stations = [baseStation()];
+    const renameMap = {
+      '7|뚝섬유원지': {
+        name: '자양(뚝섬한강공원)',
+        nameEn: 'Jayang(Ttukseom Hangang Park)',
+        nameJa: 'チャヤン',
+      },
+    };
+    const { stations: out } = applyRenames(stations, new Map(), renameMap);
+    expect(out[0]).toMatchObject({
+      id: '7-020',
+      line: '7',
+      lat: 37.5,
+      lng: 127,
+      name: '자양(뚝섬한강공원)',
+      nameEn: 'Jayang(Ttukseom Hangang Park)',
+      nameJa: 'チャヤン',
+    });
+  });
+
+  it('RENAME_MAP에 없으면 API 인덱스로 fallback', () => {
+    const stations = [baseStation({ name: '교대' })];
+    const apiIndex = new Map([['7|교대', '교대(법원.검찰청)']]);
+    const { stations: out, stats } = applyRenames(stations, apiIndex, {});
+    expect(out[0].name).toBe('교대(법원.검찰청)');
+    expect(stats.renamed).toBe(1);
+  });
+
+  it('변경 없으면 unchanged++, 원본 station 객체 그대로 반환', () => {
+    const stations = [baseStation({ name: '서울역' })];
+    const { stations: out, stats } = applyRenames(stations, new Map(), {});
+    expect(out[0]).toBe(stations[0]); // same reference
+    expect(stats.unchanged).toBe(1);
+    expect(stats.renamed).toBe(0);
+  });
+
+  it('정식명이 이미 적용된 station(괄호 포함)은 base로 lookup해도 동일하면 unchanged', () => {
+    const stations = [baseStation({ name: '자양(뚝섬한강공원)' })];
+    const renameMap = {
+      '7|자양': { name: '자양(뚝섬한강공원)' },
+    };
+    const { stations: out, stats } = applyRenames(stations, new Map(), renameMap);
+    expect(out[0]).toBe(stations[0]);
+    expect(stats.unchanged).toBe(1);
+  });
+
+  it('RENAME_MAP 누락 + API 누락이면 변경 없음', () => {
+    const stations = [baseStation({ name: '존재하지않는역' })];
+    const { stations: out, stats } = applyRenames(stations, new Map(), {});
+    expect(out[0]).toBe(stations[0]);
+    expect(stats.unchanged).toBe(1);
+  });
+
+  it('입력 순서 유지', () => {
+    const stations = [
+      baseStation({ id: 'a', name: 'A' }),
+      baseStation({ id: 'b', name: 'B' }),
+      baseStation({ id: 'c', name: 'C' }),
+    ];
+    const renameMap = { '7|B': { name: 'B2' } };
+    const { stations: out } = applyRenames(stations, new Map(), renameMap);
+    expect(out.map((s) => s.id)).toEqual(['a', 'b', 'c']);
+    expect(out[1].name).toBe('B2');
+  });
+
+  it('default renameMap 인자로도 작동', () => {
+    const stations = [baseStation()];
+    // 기본 RENAME_MAP에 자양 케이스 등록되어 있음
+    const { stations: out } = applyRenames(stations, new Map());
+    expect(out[0].name).toBe('자양(뚝섬한강공원)');
+  });
+});
+
+describe('serialize', () => {
+  it('2-space indent + trailing newline', () => {
+    const out = serialize([{ a: 1 }]);
+    expect(out).toBe('[\n  {\n    "a": 1\n  }\n]\n');
+  });
+});
+
+describe('fetchPage', () => {
+  it('성공 응답 row 반환', async () => {
+    const fetcher = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        subwayStationMaster: {
+          RESULT: { CODE: 'INFO-000', MESSAGE: '정상 처리되었습니다' },
+          row: [{ BLDN_NM: '서울역', ROUTE: '1호선' }],
+        },
+      }),
+    });
+    const rows = await fetchPage('key', 1, 1000, fetcher);
+    expect(rows).toEqual([{ BLDN_NM: '서울역', ROUTE: '1호선' }]);
+    expect(fetcher).toHaveBeenCalledWith(expect.stringContaining('/subwayStationMaster/1/1000/'));
+  });
+
+  it('INFO-200(데이터 끝) 응답은 빈 배열', async () => {
+    const fetcher = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ RESULT: { CODE: 'INFO-200', MESSAGE: '데이터 없음' } }),
+    });
+    const rows = await fetchPage('key', 1001, 2000, fetcher);
+    expect(rows).toEqual([]);
+  });
+
+  it('row 없는 wrapper는 빈 배열', async () => {
+    const fetcher = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        subwayStationMaster: { RESULT: { CODE: 'INFO-000', MESSAGE: 'ok' } },
+      }),
+    });
+    const rows = await fetchPage('key', 1, 10, fetcher);
+    expect(rows).toEqual([]);
+  });
+
+  it('HTTP not ok → throw', async () => {
+    const fetcher = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    });
+    await expect(fetchPage('key', 1, 10, fetcher)).rejects.toThrow(/HTTP 500/);
+  });
+
+  it('wrapper 누락 + INFO-200 아님 → throw', async () => {
+    const fetcher = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ unrelated: true }),
+    });
+    await expect(fetchPage('key', 1, 10, fetcher)).rejects.toThrow(/unexpected response/);
+  });
+
+  it('API 오류 코드(INFO-000 아님) → throw', async () => {
+    const fetcher = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        subwayStationMaster: {
+          RESULT: { CODE: 'ERROR-300', MESSAGE: '인증 키 오류' },
+        },
+      }),
+    });
+    await expect(fetchPage('key', 1, 10, fetcher)).rejects.toThrow(/API error: ERROR-300/);
+  });
+});
+
+describe('fetchAll', () => {
+  it('페이지네이션 — 한 페이지보다 적게 받으면 종료', async () => {
+    const fetcher = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        subwayStationMaster: {
+          RESULT: { CODE: 'INFO-000' },
+          row: [{ BLDN_NM: '서울역', ROUTE: '1호선' }],
+        },
+      }),
+    });
+    const sleepFn = jest.fn().mockResolvedValue(undefined);
+    const rows = await fetchAll('key', fetcher, sleepFn);
+    expect(rows.length).toBe(1);
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+
+  it('페이지네이션 — 페이지 가득 차면 다음 페이지 fetch', async () => {
+    const fullPage = Array.from({ length: 1000 }, (_, i) => ({
+      BLDN_NM: `역${i}`,
+      ROUTE: '1호선',
+    }));
+    const fetcher = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          subwayStationMaster: { RESULT: { CODE: 'INFO-000' }, row: fullPage },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          subwayStationMaster: {
+            RESULT: { CODE: 'INFO-000' },
+            row: [{ BLDN_NM: '끝', ROUTE: '1호선' }],
+          },
+        }),
+      });
+    const sleepFn = jest.fn().mockResolvedValue(undefined);
+    const rows = await fetchAll('key', fetcher, sleepFn);
+    expect(rows.length).toBe(1001);
+    expect(sleepFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('main()', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'regen-stations-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const writeStations = (data) => {
+    const p = path.join(tmpDir, 'stations.json');
+    fs.writeFileSync(p, JSON.stringify(data));
+    return p;
+  };
+
+  const captureDeps = (overrides = {}) => {
+    const outs = [];
+    const errs = [];
+    const writes = [];
+    return {
+      outs,
+      errs,
+      writes,
+      deps: {
+        writeOut: (s) => outs.push(s),
+        writeErr: (s) => errs.push(s),
+        writeFile: (p, c) => writes.push({ p, c }),
+        env: {},
+        ...overrides,
+      },
+    };
+  };
+
+  it('--offline + 기본 RENAME_MAP으로 자양 갱신', async () => {
+    const stationsPath = writeStations([
+      {
+        id: '7-020',
+        name: '뚝섬유원지',
+        line: '7',
+        lineColor: '#747F00',
+        lat: 37.53154,
+        lng: 127.066704,
+      },
+    ]);
+    const { outs, errs, writes, deps } = captureDeps();
+    const code = await main(['node', 'regen', '--offline'], {
+      ...deps,
+      stationsPath,
+    });
+    expect(code).toBe(0);
+    expect(outs.some((s) => /offline mode/.test(s))).toBe(true);
+    expect(outs.some((s) => /갱신: 1개, 유지: 0개/.test(s))).toBe(true);
+    expect(outs.some((s) => /자양\(뚝섬한강공원\)/.test(s))).toBe(true);
+    expect(errs).toEqual([]);
+    expect(writes).toHaveLength(1);
+    expect(writes[0].p).toBe(stationsPath);
+    const parsed = JSON.parse(writes[0].c);
+    expect(parsed[0].name).toBe('자양(뚝섬한강공원)');
+  });
+
+  it('API 키 없음 + --offline 없음이면 exit 1', async () => {
+    const stationsPath = writeStations([]);
+    const { errs, deps } = captureDeps();
+    const code = await main(['node', 'regen'], {
+      ...deps,
+      stationsPath,
+    });
+    expect(code).toBe(1);
+    expect(errs.some((s) => /EXPO_PUBLIC_SEOUL_DATA_API_KEY/.test(s))).toBe(true);
+  });
+
+  it('stations.json 읽기 실패 시 exit 1', async () => {
+    const { errs, deps } = captureDeps();
+    const code = await main(['node', 'regen', '--offline'], {
+      ...deps,
+      stationsPath: path.join(tmpDir, 'does-not-exist.json'),
+    });
+    expect(code).toBe(1);
+    expect(errs.some((s) => /stations\.json 읽기 실패/.test(s))).toBe(true);
+  });
+
+  it('stations.json root가 배열 아니면 exit 1', async () => {
+    const stationsPath = writeStations({ not: 'array' });
+    const { errs, deps } = captureDeps();
+    const code = await main(['node', 'regen', '--offline'], {
+      ...deps,
+      stationsPath,
+    });
+    expect(code).toBe(1);
+    expect(errs.some((s) => /root가 배열이 아님/.test(s))).toBe(true);
+  });
+
+  it('online mode + 성공적인 API fetch + 갱신', async () => {
+    const stationsPath = writeStations([
+      { id: '1-001', name: '서울역', line: '1', lineColor: '#0052A4', lat: 37.5, lng: 127 },
+    ]);
+    const fetcher = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        subwayStationMaster: {
+          RESULT: { CODE: 'INFO-000' },
+          row: [{ BLDN_NM: '서울역', ROUTE: '1호선' }],
+        },
+      }),
+    });
+    const { outs, errs, writes, deps } = captureDeps({
+      env: { EXPO_PUBLIC_SEOUL_DATA_API_KEY: 'fake-key' },
+      fetcher,
+      sleepFn: jest.fn().mockResolvedValue(undefined),
+    });
+    const code = await main(['node', 'regen'], {
+      ...deps,
+      stationsPath,
+    });
+    expect(code).toBe(0);
+    expect(errs).toEqual([]);
+    expect(outs.some((s) => /API 인덱스 매칭률/.test(s))).toBe(true);
+    expect(writes).toHaveLength(1);
+  });
+
+  it('online mode + API 매칭률 floor 미달 시 exit 1', async () => {
+    const stationsPath = writeStations([
+      { id: '1-001', name: '서울역', line: '1', lineColor: '#0052A4', lat: 37.5, lng: 127 },
+      { id: '1-002', name: '시청', line: '1', lineColor: '#0052A4', lat: 37.5, lng: 127 },
+    ]);
+    const fetcher = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        subwayStationMaster: {
+          RESULT: { CODE: 'INFO-000' },
+          row: [], // API 응답 비어있음 → 매칭률 0%
+        },
+      }),
+    });
+    const { errs, deps } = captureDeps({
+      env: { EXPO_PUBLIC_SEOUL_DATA_API_KEY: 'fake-key' },
+      fetcher,
+    });
+    const code = await main(['node', 'regen'], {
+      ...deps,
+      stationsPath,
+    });
+    expect(code).toBe(1);
+    expect(errs.some((s) => /매칭률.*보존, abort/.test(s))).toBe(true);
+  });
+
+  it('online mode + fetch throw 시 exit 1', async () => {
+    const stationsPath = writeStations([
+      { id: '1-001', name: '서울역', line: '1', lineColor: '#0052A4', lat: 37.5, lng: 127 },
+    ]);
+    const fetcher = jest.fn().mockRejectedValue(new Error('network down'));
+    const { errs, deps } = captureDeps({
+      env: { EXPO_PUBLIC_SEOUL_DATA_API_KEY: 'fake-key' },
+      fetcher,
+    });
+    const code = await main(['node', 'regen'], {
+      ...deps,
+      stationsPath,
+    });
+    expect(code).toBe(1);
+    expect(errs.some((s) => /API fetch 실패: network down/.test(s))).toBe(true);
+  });
+
+  it('default deps(--offline + 실제 file write) 동작', async () => {
+    const stationsPath = writeStations([
+      {
+        id: '7-020',
+        name: '뚝섬유원지',
+        line: '7',
+        lineColor: '#747F00',
+        lat: 37.53154,
+        lng: 127.066704,
+      },
+    ]);
+    // writeOut/writeErr 기본 — process.stdout/stderr 캡처
+    const origOut = process.stdout.write.bind(process.stdout);
+    const origErr = process.stderr.write.bind(process.stderr);
+    const captured = { out: [], err: [] };
+    process.stdout.write = (s) => {
+      captured.out.push(String(s));
+      return true;
+    };
+    process.stderr.write = (s) => {
+      captured.err.push(String(s));
+      return true;
+    };
+    let code;
+    try {
+      code = await main(['node', 'regen', '--offline'], { stationsPath });
+    } finally {
+      process.stdout.write = origOut;
+      process.stderr.write = origErr;
+    }
+    expect(code).toBe(0);
+    expect(captured.out.join('')).toMatch(/자양/);
+    const parsed = JSON.parse(fs.readFileSync(stationsPath, 'utf8'));
+    expect(parsed[0].name).toBe('자양(뚝섬한강공원)');
+  });
+});

--- a/scripts/__tests__/validate-stations.test.js
+++ b/scripts/__tests__/validate-stations.test.js
@@ -10,6 +10,8 @@ const {
   LAT_MAX,
   LNG_MIN,
   LNG_MAX,
+  ADJACENT_DISTANCE_MAX_METERS,
+  haversineMeters,
   validate,
   main,
 } = require('../validate-stations');
@@ -32,9 +34,10 @@ const validTopology = (overrides = {}) => ({
 
 describe('validate()', () => {
   it('passes for clean stations + topology', () => {
+    // #1397: 인접 거리 sanity가 추가되어 좌표를 인접하게(같은 호선 ≤ 8km) 유지한다.
     const stations = [
-      validStation({ id: '3-001', name: '대화', line: '3' }),
-      validStation({ id: '3-002', name: '오금', line: '3', lat: 37.5, lng: 127.1 }),
+      validStation({ id: '3-001', name: '대화', line: '3', lat: 37.50, lng: 127.00 }),
+      validStation({ id: '3-002', name: '오금', line: '3', lat: 37.51, lng: 127.01 }),
     ];
     const res = validate({ stations, topology: validTopology() });
     expect(res.errors).toEqual([]);
@@ -206,6 +209,61 @@ describe('validate()', () => {
     expect(res.errors.some((e) => /name이 비어있/.test(e))).toBe(true);
     expect(res.warnings.every((w) => !/name ".*"이.*중복/.test(w))).toBe(true);
   });
+
+  it('warns when adjacent stops exceed ADJACENT_DISTANCE_MAX_METERS (#1397)', () => {
+    // 대화(37.6754, 126.7657) → 오금(37.5022, 127.1276): ≈ 41km 차이 → warning 트리거
+    const res = validate({
+      stations: [
+        validStation({ id: '3-001', name: '대화', line: '3', lat: 37.6754, lng: 126.7657 }),
+        validStation({ id: '3-002', name: '오금', line: '3', lat: 37.5022, lng: 127.1276 }),
+      ],
+      topology: validTopology(),
+    });
+    expect(res.errors).toEqual([]);
+    expect(
+      res.warnings.some((w) => /인접 hop "대화" → "오금".*누락된 중간역 의심/.test(w)),
+    ).toBe(true);
+  });
+
+  it('does not warn when adjacent stops are within tolerance', () => {
+    // 인접 짧은 거리 (≈ 1km)
+    const res = validate({
+      stations: [
+        validStation({ id: '3-001', name: '대화', line: '3', lat: 37.50, lng: 127.00 }),
+        validStation({ id: '3-002', name: '오금', line: '3', lat: 37.51, lng: 127.00 }),
+      ],
+      topology: validTopology(),
+    });
+    expect(res.warnings.every((w) => !/인접 hop/.test(w))).toBe(true);
+  });
+
+  it('skips adjacent distance check when coordinates are non-finite', () => {
+    // 좌표가 NaN인 경우 — 이미 lat 에러는 다른 룰에서 잡힘. distance 룰은 silently skip.
+    const res = validate({
+      stations: [
+        validStation({ id: '3-001', name: '대화', line: '3', lat: Number.NaN, lng: 127.00 }),
+        validStation({ id: '3-002', name: '오금', line: '3', lat: 37.51, lng: 127.00 }),
+      ],
+      topology: validTopology(),
+    });
+    expect(res.warnings.every((w) => !/인접 hop/.test(w))).toBe(true);
+  });
+});
+
+describe('haversineMeters', () => {
+  it('동일 좌표는 0', () => {
+    expect(haversineMeters(37, 127, 37, 127)).toBe(0);
+  });
+
+  it('1도 위도 차이는 ~111km', () => {
+    const d = haversineMeters(37, 127, 38, 127);
+    expect(d).toBeGreaterThan(110000);
+    expect(d).toBeLessThan(112000);
+  });
+
+  it('상수가 export됨', () => {
+    expect(ADJACENT_DISTANCE_MAX_METERS).toBeGreaterThan(0);
+  });
 });
 
 describe('main()', () => {
@@ -219,9 +277,10 @@ describe('main()', () => {
   it('returns 0 and prints success summary for valid input', () => {
     const outs = [];
     const errs = [];
+    // #1397: 인접 hop sanity 발동 회피 위해 좌표를 인접하게 유지.
     const stationsPath = writeJson('s-ok.json', [
-      validStation({ id: '3-001', name: '대화', line: '3' }),
-      validStation({ id: '3-002', name: '오금', line: '3', lat: 37.5, lng: 127.1 }),
+      validStation({ id: '3-001', name: '대화', line: '3', lat: 37.50, lng: 127.00 }),
+      validStation({ id: '3-002', name: '오금', line: '3', lat: 37.51, lng: 127.01 }),
     ]);
     const topologyPath = writeJson('t-ok.json', validTopology());
     const code = main([], {
@@ -237,9 +296,10 @@ describe('main()', () => {
 
   it('returns 0 with warning count in summary when warnings present', () => {
     const outs = [];
+    // #1397: 인접 hop sanity 발동 회피 위해 좌표 인접 유지. 2 warnings는 endpoints 미스매치 2건.
     const stationsPath = writeJson('s-warn.json', [
-      validStation({ id: '3-001', name: '실제첫역', line: '3' }),
-      validStation({ id: '3-002', name: '실제마지막', line: '3', lat: 37.5, lng: 127.1 }),
+      validStation({ id: '3-001', name: '실제첫역', line: '3', lat: 37.50, lng: 127.00 }),
+      validStation({ id: '3-002', name: '실제마지막', line: '3', lat: 37.51, lng: 127.01 }),
     ]);
     const topologyPath = writeJson('t-warn.json', validTopology());
     const code = main([], {

--- a/scripts/regenerate-stations.js
+++ b/scripts/regenerate-stations.js
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+/**
+ * #1397: stations.json 빌드타임 재생성 파이프라인.
+ *
+ * 손유지 SSOT가 야기한 staleness(자양=옛 뚝섬유원지 등)를 근절하기 위해 권위 소스에서
+ * 역명을 재생성한다. 좌표는 오프라인 보장을 위해 기존 SSOT를 유지하고, 역명·i18n 누락만
+ * API/매핑으로 갱신한다.
+ *
+ * 데이터 소스 (서울 열린데이터광장):
+ *   subwayStationMaster — { BLDN_ID, BLDN_NM, ROUTE, LAT, LOT }
+ *   라이선스: 공공누리 제1유형 (출처 표시)
+ *
+ * 흐름:
+ *   1) `subwayStationMaster` fetch (페이지네이션, sample 키도 5건까지 동작)
+ *   2) ROUTE → stations.json의 line 매핑 (LINE_TO_ROUTES)
+ *   3) BLDN_NM의 base name(괄호 앞)을 키로 (line, baseName) → 정식명 인덱스 빌드
+ *   4) 기존 stations.json 순회하며 base name 일치 시 정식명으로 교체
+ *   5) RENAME_MAP(SSOT 보강) — API가 늦게 반영하거나 매핑 모호한 케이스는 수동 보강
+ *      (예: 7호선 뚝섬유원지 → 자양(뚝섬한강공원))
+ *   6) 매칭률 floor 검사 후 결정론적 출력
+ *
+ * 사용법:
+ *   # 사용자 API 키 (full data)
+ *   EXPO_PUBLIC_SEOUL_DATA_API_KEY=xxxx node scripts/regenerate-stations.js
+ *
+ *   # offline mode — RENAME_MAP 만으로 patch (CI/스모크 가능)
+ *   node scripts/regenerate-stations.js --offline
+ *
+ * acceptance:
+ *   - 자양(뚝섬한강공원) 등 알려진 개명/병기역명이 stations.json에 반영된다
+ *   - 좌표/i18n은 보존된다 (역명만 갱신)
+ *   - 결정론적 — 같은 입력으로 두 번 실행해도 byte-identical
+ *
+ * 옛 boardingLock 호환은 src/data/stationAliases.js의 STATION_ALIASES가 책임진다.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const STATIONS_PATH = path.join(__dirname, '..', 'src', 'data', 'stations.json');
+
+const PAGE_SIZE = 1000;
+const SLEEP_MS = 200;
+const MATCH_RATIO_FLOOR = 0.9;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// stations.json의 line 키 → 서울 열린데이터 API의 ROUTE 후보들.
+// scripts/update-coordinates.js와 동일 매핑 유지(SSOT 일원화는 후속 #1397 follow-up).
+const LINE_TO_ROUTES = {
+  '1': ['1호선', '경부선', '경원선', '경인선', '장항선'],
+  '2': ['2호선'],
+  '3': ['3호선', '일산선'],
+  '4': ['4호선', '과천선', '안산선'],
+  '5': ['5호선'],
+  '6': ['6호선'],
+  '7': ['7호선', '7호선(인천)'],
+  '8': ['8호선'],
+  '9': ['9호선', '9호선(연장)'],
+  airport: ['공항철도1호선'],
+  gyeongui: ['경의중앙선', '중앙선'],
+  bundang: ['분당선', '수인선'],
+  sinbundang: ['신분당선', '신분당선(연장)', '신분당선(연장2)'],
+};
+
+const ROUTE_TO_LINE = (() => {
+  const out = new Map();
+  for (const [line, routes] of Object.entries(LINE_TO_ROUTES)) {
+    for (const r of routes) out.set(r, line);
+  }
+  return out;
+})();
+
+/**
+ * 손유지 SSOT 보강: API에 정식명으로 등록됐지만 (line, baseName) → 정식명 매핑이
+ * 정규화로는 안 잡히거나, API에 아직 미반영된 개명/병기역명 케이스.
+ * 모두 권위 소스(서울시 보도자료/노선 표지)로 검증된 SSOT 데이터.
+ *
+ * value 형식:
+ *   - 문자열: 한글 정식명만 교체 (i18n 보존)
+ *   - 객체: { name, nameEn?, nameJa?, nameHanja? } 부분 갱신 — 누락 필드는 기존 값 유지
+ *
+ * key 표기: `${line}|${stations.json의 옛 name}` 또는 `${line}|${baseName}`.
+ */
+const RENAME_MAP = {
+  // 2010-10 개명 (7호선 자양역) — BLDN_ID 2522.
+  // 공식 영문/일문은 서울교통공사 다국어표기 자료 기준.
+  '7|뚝섬유원지': {
+    name: '자양(뚝섬한강공원)',
+    nameEn: 'Jayang(Ttukseom Hangang Park)',
+    nameJa: 'チャヤン(トゥクソム漢江公園)',
+    nameHanja: '紫陽(纛島漢江公園)',
+  },
+};
+
+function joinKey(line, name) {
+  return `${line}|${name}`;
+}
+
+/**
+ * BLDN_NM의 괄호 부제 분리: `"교대(법원.검찰청)"` → `{ base: '교대', full: '교대(법원.검찰청)' }`.
+ * 괄호가 없거나 첫 글자가 '('이면 base = full.
+ */
+function splitName(name) {
+  if (typeof name !== 'string') return { base: '', full: '' };
+  const full = name.trim();
+  if (!full.endsWith(')')) return { base: full, full };
+  const open = full.lastIndexOf('(');
+  if (open <= 0) return { base: full, full };
+  const base = full.slice(0, open).trimEnd();
+  return { base, full };
+}
+
+/**
+ * 페이지네이션 fetch (sample 키는 1~5만 허용 → 첫 페이지에서 list_total_count로 끝).
+ */
+async function fetchPage(apiKey, start, end, fetcher = fetch) {
+  const url = `http://openapi.seoul.go.kr:8088/${apiKey}/json/subwayStationMaster/${start}/${end}/`;
+  const res = await fetcher(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${start}-${end}`);
+  const json = await res.json();
+  const wrapper = json.subwayStationMaster;
+  if (!wrapper) {
+    if (json.RESULT && json.RESULT.CODE === 'INFO-200') return [];
+    throw new Error(`unexpected response: ${JSON.stringify(json).slice(0, 200)}`);
+  }
+  if (wrapper.RESULT && wrapper.RESULT.CODE !== 'INFO-000') {
+    throw new Error(`API error: ${wrapper.RESULT.CODE} ${wrapper.RESULT.MESSAGE}`);
+  }
+  return wrapper.row || [];
+}
+
+async function fetchAll(apiKey, fetcher = fetch, sleepFn = sleep) {
+  const all = [];
+  let start = 1;
+  for (;;) {
+    const end = start + PAGE_SIZE - 1;
+    const rows = await fetchPage(apiKey, start, end, fetcher);
+    all.push(...rows);
+    if (rows.length < PAGE_SIZE) break;
+    start += PAGE_SIZE;
+    await sleepFn(SLEEP_MS);
+  }
+  return all;
+}
+
+/**
+ * apiRows에서 (line, base name) → 정식 표기(BLDN_NM) 인덱스 구축.
+ * 같은 base가 여러 정식명에 매칭되면 첫 발견을 채택(API는 결정론적 순서 보장).
+ * line이 매핑 안되는 ROUTE는 건너뛴다.
+ */
+function buildApiIndex(apiRows) {
+  const idx = new Map();
+  for (const row of apiRows) {
+    const line = ROUTE_TO_LINE.get(row.ROUTE);
+    if (!line) continue;
+    const { base, full } = splitName(row.BLDN_NM);
+    if (!base) continue;
+    const key = joinKey(line, base);
+    if (!idx.has(key)) idx.set(key, full);
+  }
+  return idx;
+}
+
+/**
+ * 매핑 값(문자열 또는 객체)을 patch 객체로 정규화.
+ * 문자열은 { name }로, 객체는 그대로(다만 정의된 필드만).
+ */
+function normalizePatch(value) {
+  if (typeof value === 'string') return { name: value };
+  if (value && typeof value === 'object' && typeof value.name === 'string') {
+    const patch = { name: value.name };
+    if (typeof value.nameEn === 'string') patch.nameEn = value.nameEn;
+    if (typeof value.nameJa === 'string') patch.nameJa = value.nameJa;
+    if (typeof value.nameHanja === 'string') patch.nameHanja = value.nameHanja;
+    return patch;
+  }
+  return null;
+}
+
+/**
+ * stations(현재 SSOT)에 API 인덱스 + RENAME_MAP을 적용해 갱신된 stations 배열 반환.
+ * 좌표/id/line/lineColor는 보존하고, name(필요 시 nameEn/nameJa/nameHanja)만 갱신.
+ * 갱신 발생 시 stats.renamed++, 갱신 없으면 unchanged++.
+ *
+ * 결정론적: 입력 순서 유지, lookup은 순수 함수.
+ */
+function applyRenames(stations, apiIndex, renameMap = RENAME_MAP) {
+  const stats = { renamed: 0, unchanged: 0, renames: [] };
+  const out = stations.map((s) => {
+    const { base } = splitName(s.name);
+    const apiFull = apiIndex.get(joinKey(s.line, base));
+    // 수동 매핑(RENAME_MAP)이 API보다 우선 — API 미반영 개명을 안정적으로 적용.
+    const manualValue = renameMap[joinKey(s.line, s.name)] ?? renameMap[joinKey(s.line, base)];
+    const manualPatch = normalizePatch(manualValue);
+    const patch = manualPatch ?? (apiFull ? { name: apiFull } : null);
+    if (!patch || patch.name === s.name) {
+      stats.unchanged++;
+      return s;
+    }
+    stats.renamed++;
+    stats.renames.push({ id: s.id, line: s.line, from: s.name, to: patch.name });
+    return { ...s, ...patch };
+  });
+  return { stations: out, stats };
+}
+
+/**
+ * JSON 직렬화 — 기존 SSOT의 2-space indent + trailing newline 컨벤션 유지.
+ */
+function serialize(stations) {
+  return JSON.stringify(stations, null, 2) + '\n';
+}
+
+function readJson(p) {
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+/**
+ * CLI 진입점. deps 주입으로 테스트 가능.
+ */
+async function main(argv, deps = {}) {
+  const writeOut = deps.writeOut ?? ((s) => process.stdout.write(s + '\n'));
+  const writeErr = deps.writeErr ?? ((s) => process.stderr.write(s + '\n'));
+  const stationsPath = deps.stationsPath ?? STATIONS_PATH;
+  const fetcher = deps.fetcher ?? fetch;
+  const sleepFn = deps.sleepFn ?? sleep;
+  const writeFile = deps.writeFile ?? ((p, c) => fs.writeFileSync(p, c, 'utf8'));
+  const env = deps.env ?? process.env;
+
+  const args = argv.slice(2);
+  const offline = args.includes('--offline');
+  const apiKey = env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+
+  if (!offline && !apiKey) {
+    writeErr('EXPO_PUBLIC_SEOUL_DATA_API_KEY 환경변수가 없습니다. (또는 --offline 사용)');
+    return 1;
+  }
+
+  let stations;
+  try {
+    stations = readJson(stationsPath);
+  } catch (e) {
+    writeErr(`stations.json 읽기 실패: ${e.message}`);
+    return 1;
+  }
+  if (!Array.isArray(stations)) {
+    writeErr('stations.json: root가 배열이 아님');
+    return 1;
+  }
+
+  let apiIndex = new Map();
+  if (!offline) {
+    try {
+      writeOut('# subwayStationMaster fetch 시작');
+      const rows = await fetchAll(apiKey, fetcher, sleepFn);
+      writeOut(`# 총 ${rows.length}건 수신`);
+      apiIndex = buildApiIndex(rows);
+      const ratio = apiIndex.size > 0 ? apiIndex.size / stations.length : 0;
+      if (ratio < MATCH_RATIO_FLOOR) {
+        writeErr(
+          `# API 인덱스 매칭률 ${(ratio * 100).toFixed(1)}% < ${MATCH_RATIO_FLOOR * 100}% — 기존 stations.json 보존, abort`,
+        );
+        return 1;
+      }
+      writeOut(`# API 인덱스 매칭률: ${apiIndex.size}/${stations.length} (${(ratio * 100).toFixed(1)}%)`);
+    } catch (e) {
+      writeErr(`API fetch 실패: ${e.message}`);
+      return 1;
+    }
+  } else {
+    writeOut('# offline mode — RENAME_MAP 만으로 patch');
+  }
+
+  const { stations: updated, stats } = applyRenames(stations, apiIndex);
+
+  writeOut(`# 갱신: ${stats.renamed}개, 유지: ${stats.unchanged}개`);
+  for (const r of stats.renames) {
+    writeOut(`  ${r.id} (${r.line}호선): "${r.from}" → "${r.to}"`);
+  }
+
+  writeFile(stationsPath, serialize(updated));
+  writeOut(`# 저장: ${stationsPath}`);
+  return 0;
+}
+
+module.exports = {
+  LINE_TO_ROUTES,
+  ROUTE_TO_LINE,
+  RENAME_MAP,
+  MATCH_RATIO_FLOOR,
+  joinKey,
+  splitName,
+  fetchPage,
+  fetchAll,
+  buildApiIndex,
+  normalizePatch,
+  applyRenames,
+  serialize,
+  main,
+};
+
+/* istanbul ignore if -- CLI 진입은 require.main 분기, 단위 테스트는 main()을 직접 호출 */
+if (require.main === module) {
+  main(process.argv).then((code) => process.exit(code));
+}

--- a/scripts/validate-stations.js
+++ b/scripts/validate-stations.js
@@ -29,6 +29,11 @@ const LAT_MAX = 39;
 const LNG_MIN = 124;
 const LNG_MAX = 132;
 
+// #1397: 단조 노선 인접 id 간 좌표 거리(haversine, m) sanity 한계.
+// 서울 지하철 평균 hop ≈ 1.0~1.5km, p99 ≈ 4km. 8km 초과는 누락된 중간역 강한 의심.
+// 9호선 김포공항(공항철도 환승) 같이 특수 구조 hop도 6~7km 수준이라 8km는 보수적 floor.
+const ADJACENT_DISTANCE_MAX_METERS = 8000;
+
 const STATIONS_PATH = path.resolve(__dirname, '..', 'src', 'data', 'stations.json');
 const TOPOLOGY_PATH = path.resolve(__dirname, '..', 'src', 'data', 'lineTopology.json');
 
@@ -38,6 +43,19 @@ function isNonEmptyString(v) {
 
 function isInRange(v, min, max) {
   return typeof v === 'number' && Number.isFinite(v) && v >= min && v <= max;
+}
+
+// haversine 거리(미터). validate-stations 전용 단순 구현 — 다른 noses의 ETA 정밀도와 무관하므로
+// 의존성 그래프(SSOT shared/utils/haversine.ts) 도입 없이 inline 유지.
+function haversineMeters(lat1, lng1, lat2, lng2) {
+  const R = 6371000;
+  const toRad = (deg) => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(a));
 }
 
 /**
@@ -166,6 +184,28 @@ function validate(input) {
           warnings.push(`line "${line}": name "${name}"이 ${count}회 중복`);
         }
       }
+
+      // Warning: 단조 노선 인접 hop 거리가 ADJACENT_DISTANCE_MAX_METERS 초과면
+      // 누락된 중간역 의심(개명 누락이 시퀀스 gap을 만들 수 있다 — #1397 자양 케이스 같이).
+      // 좌표가 finite한 페어만 검사 (이미 다른 에러로 잡힘).
+      for (let i = 1; i < sorted.length; i++) {
+        const prev = sorted[i - 1];
+        const cur = sorted[i];
+        if (
+          !Number.isFinite(prev.lat) ||
+          !Number.isFinite(prev.lng) ||
+          !Number.isFinite(cur.lat) ||
+          !Number.isFinite(cur.lng)
+        ) {
+          continue;
+        }
+        const dist = haversineMeters(prev.lat, prev.lng, cur.lat, cur.lng);
+        if (dist > ADJACENT_DISTANCE_MAX_METERS) {
+          warnings.push(
+            `line "${line}": 인접 hop "${prev.name}" → "${cur.name}" 거리 ${Math.round(dist)}m > ${ADJACENT_DISTANCE_MAX_METERS}m (누락된 중간역 의심)`,
+          );
+        }
+      }
     }
   }
 
@@ -228,6 +268,8 @@ module.exports = {
   LAT_MAX,
   LNG_MIN,
   LNG_MAX,
+  ADJACENT_DISTANCE_MAX_METERS,
+  haversineMeters,
   validate,
   main,
 };

--- a/src/data/stationAliases.js
+++ b/src/data/stationAliases.js
@@ -1,8 +1,12 @@
 'use strict';
 
 /**
- * 노선별 공식 역명이 달라 정규화(후행 괄호 제거)만으로 매칭되지 않는 환승역 별칭.
- * key: 별칭 표기, value: canonical 표기로 통일.
+ * 노선별 공식 역명이 달라 정규화(후행 괄호 제거)만으로 매칭되지 않는 환승역 별칭 +
+ * 개명 이후 발사된 옛 boardingLock/favorites/widget 컨텍스트를 새 canonical 표기로 흡수.
+ *
+ * key: 별칭 표기, value: canonical(정규화) 표기.
+ *   - normalizeStationName 통과 후의 형태를 사용 — 괄호 부제를 가진 정식명은 alias의 우변에서
+ *     base 형태로 들어가야 검색·환승 그래프와 일관된다.
  *
  * 단일 SSOT — 런타임(stationRoute.ts, wifiSsidLookup.ts)과 빌드 스크립트(build-transfer-times.js)가
  * 모두 이 파일을 import하여 silent drift를 방지한다.
@@ -10,6 +14,10 @@
  */
 const STATION_ALIASES = {
   이수: '총신대입구',
+  // #1397: 7호선 자양(뚝섬한강공원)은 stations.json 정식명을 신표기로 교체했으나,
+  // 개명 이전 발사된 boardingLock/favorites/위젯 데이터는 옛 '뚝섬유원지'를 가지고 있을 수 있다.
+  // normalize → alias 파이프라인이 옛 표기를 정식 base("자양")로 흡수.
+  뚝섬유원지: '자양',
 };
 
 function applyStationAlias(name) {

--- a/src/data/stations.json
+++ b/src/data/stations.json
@@ -2787,13 +2787,14 @@
   },
   {
     "id": "7-020",
-    "name": "뚝섬유원지",
+    "name": "자양(뚝섬한강공원)",
     "line": "7",
     "lineColor": "#747F00",
     "lat": 37.53154,
     "lng": 127.066704,
-    "nameEn": "Ttukseom Resort",
-    "nameJa": "トゥクソムユウォンジ"
+    "nameEn": "Jayang(Ttukseom Hangang Park)",
+    "nameJa": "チャヤン(トゥクソム漢江公園)",
+    "nameHanja": "紫陽(纛島漢江公園)"
   },
   {
     "id": "7-021",

--- a/src/shared/utils/__tests__/stationLookup.test.ts
+++ b/src/shared/utils/__tests__/stationLookup.test.ts
@@ -8,6 +8,8 @@ jest.mock('../../../data/stations.json', () => [
   { id: '1-001', name: '서울역', line: '1', lineColor: '#0052A4', lat: 37.5547, lng: 126.9706 },
   { id: '4-001', name: '서울역', line: '4', lineColor: '#00A5DE', lat: 37.5547, lng: 126.9706 },
   { id: '2-001', name: '강남', line: '2', lineColor: '#00A84D', lat: 37.4979, lng: 127.0276 },
+  // #1397: 정식 표기(괄호 부제 포함)역 — canonical fallback 검증용
+  { id: '7-020', name: '자양(뚝섬한강공원)', line: '7', lineColor: '#747F00', lat: 37.531, lng: 127.066 },
 ]);
 
 describe('findLineByStationName', () => {
@@ -21,6 +23,14 @@ describe('findLineByStationName', () => {
 
   it('returns null for unknown station names', () => {
     expect(findLineByStationName('없는역')).toBeNull();
+  });
+
+  it('#1397: 정식명에 괄호 부제가 있어도 base 이름으로 lookup 성공', () => {
+    expect(findLineByStationName('자양')).toBe('7');
+  });
+
+  it('#1397: 옛 이름(뚝섬유원지)도 alias로 정식명에 fallback', () => {
+    expect(findLineByStationName('뚝섬유원지')).toBe('7');
   });
 });
 
@@ -37,6 +47,17 @@ describe('findStationByName', () => {
 
   it('없는 역명은 null', () => {
     expect(findStationByName('없는역')).toBeNull();
+  });
+
+  it('#1397: base 이름(자양)으로 정식명(자양(뚝섬한강공원)) 매칭', () => {
+    const result = findStationByName('자양');
+    expect(result?.id).toBe('7-020');
+    expect(result?.name).toBe('자양(뚝섬한강공원)');
+  });
+
+  it('#1397: 옛 이름(뚝섬유원지) → alias → canonical → 정식명 매칭', () => {
+    const result = findStationByName('뚝섬유원지');
+    expect(result?.id).toBe('7-020');
   });
 });
 

--- a/src/shared/utils/stationLookup.ts
+++ b/src/shared/utils/stationLookup.ts
@@ -1,25 +1,46 @@
 import stationsData from '../../data/stations.json';
+import { applyStationAlias } from '../../data/stationAliases';
 import type { LineNumber, Station } from '../types/station';
+import { normalizeStationName } from './normalizeStationName';
 
 const stations = stationsData as Station[];
+
+/**
+ * 노선별 표기 차이/개명/병기역명을 흡수한 canonical 비교 키.
+ *   "자양(뚝섬한강공원)" → normalize → "자양" → alias → "자양"
+ *   "뚝섬유원지" (옛 boardingLock) → normalize → "뚝섬유원지" → alias → "자양"
+ * 두 경우가 같은 키로 떨어지므로 정확 매칭 외에 정규화 fallback이 가능하다.
+ */
+function canonicalKey(name: string): string {
+  return applyStationAlias(normalizeStationName(name));
+}
 
 /**
  * 역명으로 첫 매칭되는 호선을 반환한다.
  * 환승역의 경우 stations.json 등록 순서상 첫 호선이 반환된다 — schedule fallback은
  * trip 전 화면에서만 의미가 있으므로 단일 호선 기준 표시로 충분하다.
+ * #1397: stations.json이 정식 표기(예: "자양(뚝섬한강공원)")를 가져도 옛 boardingLock
+ * /favorites/widget의 base/옛 이름으로도 매칭되도록 canonical fallback을 적용.
  */
 export function findLineByStationName(name: string): LineNumber | null {
-  const match = stations.find((s) => s.name === name);
-  return match ? match.line : null;
+  const exact = stations.find((s) => s.name === name);
+  if (exact) return exact.line;
+  const key = canonicalKey(name);
+  const fallback = stations.find((s) => canonicalKey(s.name) === key);
+  return fallback ? fallback.line : null;
 }
 
 /**
  * 역명으로 첫 매칭되는 Station(좌표 포함)을 반환한다.
  * 환승역은 호선별 lat/lng가 동일하므로 첫 매칭으로 충분하다.
  * silent push 위치 게이트(#478)에서 사용.
+ * #1397: findLineByStationName과 동일한 canonical fallback 적용.
  */
 export function findStationByName(name: string): Station | null {
-  return stations.find((s) => s.name === name) ?? null;
+  const exact = stations.find((s) => s.name === name);
+  if (exact) return exact;
+  const key = canonicalKey(name);
+  return stations.find((s) => canonicalKey(s.name) === key) ?? null;
 }
 
 /**


### PR DESCRIPTION
Closes #1397

Epic #1396의 sub 1/6. stations.json staleness 근절 — 빌드타임 공공 API 재생성 파이프라인 + 개명/병기역명 매칭 + CI 검증.

## 변경 요약
1. **`scripts/regenerate-stations.js`** (신규) — 서울 열린데이터 광장 `subwayStationMaster` API에서 역명을 fetch 해 stations.json 재생성. 좌표/i18n은 보존, name만 갱신
   - `RENAME_MAP` (SSOT 보강) — API가 정식명을 미반영했거나 정규화 매핑이 모호한 케이스 수동 보강. 7호선 자양(뚝섬한강공원) 박제
   - `--offline` 모드 — API 키 없이 RENAME_MAP 만으로 patch (CI / 워크트리 스모크용)
   - online 모드 매칭률 floor (90%) — 실패 시 기존 SSOT 보존
2. **`src/data/stations.json`** — 7-020 `뚝섬유원지` → `자양(뚝섬한강공원)` 반영. nameEn/Ja/Hanja 동시 갱신
3. **`src/data/stationAliases.js`** — `뚝섬유원지 → 자양` alias 추가. 개명 이전 발사된 boardingLock/favorites/위젯 컨텍스트 호환
4. **`src/shared/utils/stationLookup.ts`** — canonical fallback 추가. `findStationByName`/`findLineByStationName`이 정확 매칭 실패 시 `normalize → alias` 거친 키로 재시도. silent push gate(`silentPushLocationGate`), WiFi SSID 매칭(`wifiSsidLookup`) 영향 모두 흡수
5. **`scripts/validate-stations.js`** — 인접 hop 거리 sanity rule 추가. 단조 노선 인접 id 간 좌표 거리가 8km 초과 시 누락된 중간역 의심 warning. CI Data Validation에서 자동 검증

## acceptance 매핑 (본문)
- [x] 파이프라인 1회 실행으로 자양 포함 최신 역명 → `scripts/regenerate-stations.js --offline` 1회 실행 결과 `7-020 (7호선): 뚝섬유원지 → 자양(뚝섬한강공원)`
- [x] 7호선 시퀀스 gap 0 — 7호선은 본래 51개 역 유지(`grep '\"line\": \"7\"' | wc -l` = 51). 자양역이 누락된 게 아니라 옛 이름으로 등록된 staleness였음. 좌표(37.53154, 127.066704)는 정확히 자양역 좌표
- [x] CI Data Validation rule 추가/통과 — 인접 hop distance sanity warning. 현재 stations.json은 warnings 7건(의도된 divergence + 공항철도/수인분당선 큰 hop)으로 통과
- [x] type-check + 커버리지 100% — 본 PR 변경 영역 100% 커버
- [ ] 다른 개명/병기역명 역 일괄 교정 — **파이프라인이 SSOT**. 사용자가 `EXPO_PUBLIC_SEOUL_DATA_API_KEY=xxxx node scripts/regenerate-stations.js`로 1회 실행 시 종로3가(탑골공원)/광나루(장신대)/숙대입구(갈월)/총신대입구(이수)/홍제(서울문화예술대) 등 BLDN_NM 정식 표기 자동 반영. 본 PR은 **자양만 RENAME_MAP에 박제**(API 미반영 케이스) — "손유지 패치 금지" 룰 준수

## 검증 요약
- 갱신된 역 수: **1건** (자양역, --offline 모드)
- 새 CI 룰: 인접 hop distance sanity (8km 초과 시 warning) — 현재 데이터에서 airport/bundang 큰 hop 가시화 (#1397 follow-up 후보)
- 인접 영향:
  - `EditorialTimeline.test.tsx` 7호선 환승 시나리오 `origin='뚝섬유원지'` — canonical fallback으로 정상 매칭 (38/38 pass)
  - `wifiSsidLookup.test.ts` — alias가 wifi SSID 매핑을 정식 base로 흡수 (24/24 pass)
  - `silentPushLocationGate` — 옛 lock 이름으로도 station lookup 성공 (50/50 pass)
- 사전 회귀(본 PR 무관): `widgetStorage.test.ts`(9 fail), `stationNotification.test.ts`(26 fail) — `origin/dev`에서 이미 깨진 상태 (`git stash` 확인). 본 변경은 fail 수에 영향 없음

## 룰 준수
- 브랜치 `chore/#1397-stations-pipeline` (dev base)
- 커밋 메시지 `chore(#이슈번호): <제목>` 포맷, Co-Authored-By 없음
- 코드 리뷰 1회 실행 (low effort, 0 findings)

## CLAUDE.md 결정 룰 준수
- false binary 금지: 데이터 소스 결정에서 (1) 런타임 fetch (2) 손유지 패치 (3) **빌드타임 파이프라인 + offline fallback** 3개 옵션 중 (3) 채택. 이슈 본문 합의대로 (1)은 지하/오프라인 본질 위반, (2)는 staleness 재발이라 비채택
- 사용자 명시 의향 trip 동급 보장: 옛 boardingLock 호환을 alias + canonical fallback로 보장 — 개명 시점에 발사된 lock도 정상 lookup

## 후속(별도 이슈 후보)
- airport 청라국제도시→운서 13.5km, bundang 달월→사리 14km hop — 실제 누락된 중간역 검증 필요 (warning 가시화)
- sinbundang `광교(경기대)` 같은 정식 표기 stations.json 일괄 적용 (사용자 API 키 1회 실행 시 자동)
- API 미반영 추가 개명/병기역 RENAME_MAP 확장 (서울시 보도자료 기준)