### PR TITLE
fix(#1398): FG 지하 측위 회복 — WiFi SPOF 분리 + #921 verdict cascade 결합 + 기압계 unavailable 계측

### DIFF
--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -609,6 +609,11 @@ export function useStationAlarm({
     const suppressed: AlarmEvent[] = [];
     // #903 (Seam G) — 기압계 강등 시 evaluateAlarmPhase가 early/transfer 알람을 보류.
     // arrivalConfidence는 useFusedNearestStation이 'gps-only-underground'로 강등한 값을 그대로 흘려보냄.
+    //
+    // #1398 — detection-fused는 verdict ≥2 신호 합의 + 근접 게이트가 결합된 라벨.
+    //   gps-only-underground 상태에서 verdict가 결합되면 detection-fused로 승격되어 degraded=false →
+    //   early/transfer 알람 게이트 자동 해제. 의도된 cascade 결합 효과(verdict가 알람 발사에 실제 기여).
+    //   false positive 방어는 subsurfaceStationDetected의 ≥2 합의 + 근접 조건이 담당.
     const degraded = arrivalConfidence === 'gps-only-underground';
     const rawEvent = evaluateAlarmPhase(
       {

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -362,6 +362,16 @@ interface BuildDumpArgs {
   scheduledDump?: ScheduledNotificationDumpEntry[] | null;
   // #1215 (D9) — 추가 상태 가시화. 모두 optional — 미전달 시 dump의 해당 라인은 '—' 표기.
   barometerSubsurface?: boolean | null;
+  /**
+   * #1398 — `stop=undefined`(평가 불가)일 때의 원인. undefined면 정상(stop이 boolean 결정).
+   * SPOF 분리 효과 측정용. 미전달 시 dump 미노출 (graceful — 기존 호출자 호환).
+   */
+  barometerUnavailableReason?: import('../../../shared/hooks/useBarometer').BarometerUnavailableReason | undefined;
+  /**
+   * #1398 — ring buffer에 누적된 reading 수. warm-up 인지/sensor 활성 판단용.
+   * 미전달 시 dump 미노출 (graceful).
+   */
+  barometerReadingCount?: number | undefined;
   fusionDetection?: FusionDetectionSummary | null;
   trip?: TripDebugState | null;
   sleep?: SleepDebugState | null;
@@ -394,9 +404,34 @@ function buildGpsSection(args: BuildDumpArgs): string[] {
   }
   lines.push(
     `state=${args.gpsActive ?? 'fg'}, lastFix=${formatClockTimeWithSeconds(args.lastFixAtMs ?? null)}`,
-    `subsurface=${formatOptionalBool(args.barometerSubsurface)}`,
+    formatSubsurfaceDumpLine(args),
   );
   return lines;
+}
+
+/**
+ * #1398 — subsurface dump 라인 + 기압계 unavailable 원인 분해.
+ *
+ * 정상 (stop이 boolean 결정) → `subsurface=true|false`만 노출.
+ * unavailable (sensor/permission/readings) → `subsurface=... (reason=sensor, readings=12)` 포함.
+ *
+ * 진단 흐름:
+ *   - reason='sensor'     → iPhone 6 이하 등 기기 미지원. WiFi/GPS만 사용.
+ *   - reason='permission' → NSMotionUsageDescription 거절. 설정 안내 진입점.
+ *   - reason='readings'   → warm-up 초기 또는 sample 부족. ~30s 후 자연 해소.
+ *
+ * 미전달 시 (기존 호출자 호환) raw subsurface만 노출 — 진단 필드 graceful skip.
+ */
+function formatSubsurfaceDumpLine(args: BuildDumpArgs): string {
+  const subsurface = `subsurface=${formatOptionalBool(args.barometerSubsurface)}`;
+  const parts: string[] = [];
+  if (args.barometerUnavailableReason !== undefined) {
+    parts.push(`reason=${args.barometerUnavailableReason}`);
+  }
+  if (args.barometerReadingCount !== undefined) {
+    parts.push(`readings=${args.barometerReadingCount}`);
+  }
+  return parts.length > 0 ? `${subsurface} (${parts.join(', ')})` : subsurface;
 }
 
 function buildNearestSection(args: BuildDumpArgs): string[] {
@@ -686,7 +721,12 @@ function DebugModalInner({
   const locklessOn = useSettingsStore((s) => s.locklessStationPassed);
   // #1215 (D9) — 기압계 subsurface. useBarometer는 shared/hooks이라 의존 위배 없음.
   // useFusedNearestStation 내부 useBarometer와 별개 listener — DebugModal 관찰자 효과 허용 범위.
-  const { subsurface: barometerSubsurface } = useBarometer();
+  // #1398 — `stop=undefined` 원인(unavailableReason)과 readingCount도 dump에 노출.
+  const {
+    subsurface: barometerSubsurface,
+    unavailableReason: barometerUnavailableReason,
+    readingCount: barometerReadingCount,
+  } = useBarometer();
   // #1308 — iOS 저전력 모드. silent push throttle 측정용 텔레메트리 (동작 변경 없음).
   const lowPowerMode = useLowPowerMode();
   const fusedLabel = formatStationLabel(result);
@@ -830,6 +870,9 @@ function DebugModalInner({
       lowPowerMode,
       scheduledDump,
       barometerSubsurface,
+      // #1398 — 기압계 unavailable 원인/reading 수도 share dump에 포함.
+      barometerUnavailableReason,
+      barometerReadingCount,
       fusionDetection,
       trip,
       sleep,
@@ -861,6 +904,9 @@ function DebugModalInner({
     lowPowerMode,
     scheduledDump,
     barometerSubsurface,
+    // #1398 — 기압계 진단 필드 deps. reason flip 시 share 텍스트 자동 갱신.
+    barometerUnavailableReason,
+    barometerReadingCount,
     fusionDetection,
     trip,
     sleep,
@@ -908,6 +954,19 @@ function DebugModalInner({
             <KeyValue
               label="subsurface"
               value={formatOptionalBool(barometerSubsurface)}
+              colors={colors}
+            />
+            {/* #1398 — 기압계 unavailable 원인 분해. SPOF 분리 효과 측정용.
+                undefined(정상)면 ' — ' 표기 — stop이 boolean으로 결정된 상태.
+                readingCount도 undefined면 '—' — useBarometer mock/외부 주입자가 누락한 경우 graceful. */}
+            <KeyValue
+              label="subsurface reason"
+              value={barometerUnavailableReason ?? '—'}
+              colors={colors}
+            />
+            <KeyValue
+              label="subsurface readings"
+              value={barometerReadingCount === undefined ? '—' : String(barometerReadingCount)}
               colors={colors}
             />
           </Section>

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -366,12 +366,12 @@ interface BuildDumpArgs {
    * #1398 — `stop=undefined`(평가 불가)일 때의 원인. undefined면 정상(stop이 boolean 결정).
    * SPOF 분리 효과 측정용. 미전달 시 dump 미노출 (graceful — 기존 호출자 호환).
    */
-  barometerUnavailableReason?: import('../../../shared/hooks/useBarometer').BarometerUnavailableReason | undefined;
+  barometerUnavailableReason?: import('../../../shared/hooks/useBarometer').BarometerUnavailableReason;
   /**
    * #1398 — ring buffer에 누적된 reading 수. warm-up 인지/sensor 활성 판단용.
    * 미전달 시 dump 미노출 (graceful).
    */
-  barometerReadingCount?: number | undefined;
+  barometerReadingCount?: number;
   fusionDetection?: FusionDetectionSummary | null;
   trip?: TripDebugState | null;
   sleep?: SleepDebugState | null;

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -973,6 +973,66 @@ describe('DebugModal buildDumpText — D9 sections (#1215)', () => {
     expect(dump).toContain('route hop count=5');
     expect(dump).toContain('sleepMode=off');
   });
+
+  describe('#1398 — 기압계 unavailable 원인 분해 dump', () => {
+    it('barometerUnavailableReason="sensor" + readingCount=0 → "(reason=sensor, readings=0)" 표기', () => {
+      const dump = __test__.buildDumpText(
+        makeDumpArgs({
+          barometerSubsurface: false,
+          barometerUnavailableReason: 'sensor',
+          barometerReadingCount: 0,
+        }),
+      );
+      expect(dump).toContain('subsurface=false (reason=sensor, readings=0)');
+    });
+
+    it('barometerUnavailableReason="permission" → "(reason=permission, readings=0)"', () => {
+      const dump = __test__.buildDumpText(
+        makeDumpArgs({
+          barometerSubsurface: false,
+          barometerUnavailableReason: 'permission',
+          barometerReadingCount: 0,
+        }),
+      );
+      expect(dump).toContain('reason=permission');
+    });
+
+    it('barometerUnavailableReason="readings" + readingCount=12 → warm-up 진단', () => {
+      const dump = __test__.buildDumpText(
+        makeDumpArgs({
+          barometerSubsurface: false,
+          barometerUnavailableReason: 'readings',
+          barometerReadingCount: 12,
+        }),
+      );
+      expect(dump).toContain('reason=readings');
+      expect(dump).toContain('readings=12');
+    });
+
+    it('정상 (reason=undefined) + readingCount=45 → "(readings=45)" 만 (reason 부분 없음)', () => {
+      const dump = __test__.buildDumpText(
+        makeDumpArgs({
+          barometerSubsurface: true,
+          barometerUnavailableReason: undefined,
+          barometerReadingCount: 45,
+        }),
+      );
+      expect(dump).toContain('subsurface=true (readings=45)');
+      expect(dump).not.toContain('reason=');
+    });
+
+    it('두 필드 모두 미전달 → 기존 동작 (reason/readings 부분 없음)', () => {
+      const dump = __test__.buildDumpText(
+        makeDumpArgs({
+          barometerSubsurface: true,
+        }),
+      );
+      // 기존 호출자 호환: 미전달 시 dump 라인은 raw subsurface만.
+      expect(dump).toContain('subsurface=true');
+      expect(dump).not.toContain('(reason=');
+      expect(dump).not.toContain('(readings=');
+    });
+  });
 });
 
 // #1215 (D9) — UI 렌더 분기. setupHookDefaults를 그대로 활용해 hook 입력은 최소화.
@@ -992,6 +1052,37 @@ describe('DebugModal — D9 UI sections (#1215)', () => {
     expect(screen.getByText('subsurface')).toBeTruthy();
     // KeyValue의 value 텍스트로 노출. 정확한 매칭은 row 내 텍스트 검색.
     expect(screen.getAllByText(expected).length).toBeGreaterThan(0);
+  });
+
+  it('#1398 GPS 섹션: subsurface reason / readings row 노출 (unavailableReason="sensor", readingCount=0)', async () => {
+    mockUseBarometer.mockReturnValue({
+      subsurface: false,
+      stop: undefined,
+      unavailableReason: 'sensor',
+      readingCount: 0,
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('subsurface reason')).toBeTruthy();
+    expect(screen.getByText('subsurface readings')).toBeTruthy();
+    // reason 값 'sensor' 노출 + readings 값 '0' 노출.
+    expect(screen.getAllByText('sensor').length).toBeGreaterThan(0);
+    // readings는 String(0) → '0'.
+    expect(screen.getAllByText('0').length).toBeGreaterThan(0);
+  });
+
+  it('#1398 GPS 섹션: reason=undefined(정상) → "—" 표기', async () => {
+    mockUseBarometer.mockReturnValue({
+      subsurface: true,
+      stop: true,
+      unavailableReason: undefined,
+      readingCount: 45,
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('subsurface reason')).toBeTruthy();
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('45').length).toBeGreaterThan(0);
   });
 
   it('fusionDetection 미전달 시 tier/signalMask = —', async () => {

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -1570,52 +1570,46 @@ describe('useFusedNearestStation', () => {
       mockUsePositions.mockReturnValue(positionRet(null));
     });
 
-    it('gps-only-underground + ≥2 신호 합의 + 근접 → detection-fused 승격', () => {
-      const { result } = renderHook(() =>
-        useFusedNearestStation(
-          undefined,
-          undefined,
-          undefined,
-          null,
-          null,
-          /* motionStationary */ true,
-          { subsurface: true, signal: { subsurface: true, stop: true } },
-        ),
-      );
-      expect(result.current.confidence).toBe('detection-fused');
-      // source는 그대로 'gps' — 좌표 신호원 자체는 GPS.
+    // 3 케이스가 동일한 renderHook 7-인자 형태 + .confidence 검증을 반복 → Sonar cpd.
+    // motionStationary/barometer signal만 다르고 expected confidence/source만 분기 → 테이블화.
+    function renderDetectionCascade(
+      motionStationary: boolean | undefined,
+      baro: { subsurface: boolean; signal: { subsurface: boolean; stop: boolean } },
+    ): ReturnType<typeof renderHook<ReturnType<typeof useFusedNearestStation>, unknown>>['result'] {
+      return renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, null, null, motionStationary, baro),
+      ).result;
+    }
+
+    it.each<{
+      label: string;
+      motionStationary: boolean | undefined;
+      baro: { subsurface: boolean; signal: { subsurface: boolean; stop: boolean } };
+      expectedConfidence: string;
+    }>([
+      {
+        label: 'gps-only-underground + ≥2 신호 합의 + 근접 → detection-fused 승격',
+        motionStationary: true,
+        baro: { subsurface: true, signal: { subsurface: true, stop: true } },
+        expectedConfidence: 'detection-fused',
+      },
+      {
+        label: 'gps-only-underground + 단일 신호 합의 (≥2 미달) → detection-fused 미승격, gps-only-underground 유지',
+        motionStationary: undefined,
+        baro: { subsurface: true, signal: { subsurface: true, stop: true } },
+        expectedConfidence: 'gps-only-underground',
+      },
+      {
+        label: 'subsurface=false (지상) → cascade 진입 X, 기존 gps-only',
+        motionStationary: true,
+        baro: { subsurface: false, signal: { subsurface: false, stop: true } },
+        expectedConfidence: 'gps-only',
+      },
+    ])('$label', ({ motionStationary, baro, expectedConfidence }) => {
+      const result = renderDetectionCascade(motionStationary, baro);
+      expect(result.current.confidence).toBe(expectedConfidence);
+      // source는 모든 케이스에서 'gps' — 좌표 신호원 자체는 GPS.
       expect(result.current.source).toBe('gps');
-    });
-
-    it('gps-only-underground + 단일 신호 합의 (≥2 미달) → detection-fused 미승격, gps-only-underground 유지', () => {
-      const { result } = renderHook(() =>
-        useFusedNearestStation(
-          undefined,
-          undefined,
-          undefined,
-          null,
-          null,
-          /* motionStationary */ undefined,
-          { subsurface: true, signal: { subsurface: true, stop: true } },
-        ),
-      );
-      expect(result.current.confidence).toBe('gps-only-underground');
-    });
-
-    it('subsurface=false (지상) → cascade 진입 X, 기존 gps-only', () => {
-      const { result } = renderHook(() =>
-        useFusedNearestStation(
-          undefined,
-          undefined,
-          undefined,
-          null,
-          null,
-          /* motionStationary */ true,
-          { subsurface: false, signal: { subsurface: false, stop: true } },
-        ),
-      );
-      // gps-only-underground 자체에 진입하지 않으므로 detection-fused 승격도 X.
-      expect(result.current.confidence).toBe('gps-only');
     });
   });
 });

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -1559,4 +1559,63 @@ describe('useFusedNearestStation', () => {
       expect(result.current.subsurfaceStationDetected).toBe(false);
     });
   });
+
+  describe('#1398 cascade verdict 결합 — detection-fused 라벨 승격', () => {
+    // gps-only-underground 상태에서 ≥2 신호 합의 + 근접 게이트 통과 시 confidence를 'detection-fused'로 승격.
+    // source는 'gps' 유지(좌표 신호원 동일). 측정/dump에서 cascade가 verdict를 인식한 사실을 명확히 표시.
+    beforeEach(() => {
+      mockUseNearest.mockReturnValue(gpsBase());
+      mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
+      mockUseArrival.mockReturnValue(arrivalRet(null));
+      mockUsePositions.mockReturnValue(positionRet(null));
+    });
+
+    it('gps-only-underground + ≥2 신호 합의 + 근접 → detection-fused 승격', () => {
+      const { result } = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          null,
+          null,
+          /* motionStationary */ true,
+          { subsurface: true, signal: { subsurface: true, stop: true } },
+        ),
+      );
+      expect(result.current.confidence).toBe('detection-fused');
+      // source는 그대로 'gps' — 좌표 신호원 자체는 GPS.
+      expect(result.current.source).toBe('gps');
+    });
+
+    it('gps-only-underground + 단일 신호 합의 (≥2 미달) → detection-fused 미승격, gps-only-underground 유지', () => {
+      const { result } = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          null,
+          null,
+          /* motionStationary */ undefined,
+          { subsurface: true, signal: { subsurface: true, stop: true } },
+        ),
+      );
+      expect(result.current.confidence).toBe('gps-only-underground');
+    });
+
+    it('subsurface=false (지상) → cascade 진입 X, 기존 gps-only', () => {
+      const { result } = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          null,
+          null,
+          /* motionStationary */ true,
+          { subsurface: false, signal: { subsurface: false, stop: true } },
+        ),
+      );
+      // gps-only-underground 자체에 진입하지 않으므로 detection-fused 승격도 X.
+      expect(result.current.confidence).toBe('gps-only');
+    });
+  });
 });

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.wifiFusion.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.wifiFusion.test.ts
@@ -447,7 +447,7 @@ describe('useFusedNearestStation — #1286/#1398 WiFi SSID fusion', () => {
       mockUseNearest.mockReturnValue({
         result: { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
         variants: [MOCK_STATIONS.gangnam],
-        userLocation: { lat: 37.5, lng: 127.0 },
+        userLocation: { lat: 37.5, lng: 127 },
         speedMps: 1,
         accuracyMeters: 50,
         loading: false,

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.wifiFusion.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.wifiFusion.test.ts
@@ -7,11 +7,18 @@
  * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
  */
 /**
- * #1286 — WiFi SSID fusion cascade 격리 검증.
+ * #1286/#1398 — WiFi SSID fusion cascade 격리 검증.
  *
- * - barometerSubsurface=true + wifiStation 있음 → result = wifiStation (최우선)
- * - barometerSubsurface=false(지상) → wifi 무시 → 기존 cascade(GPS fallback)
- * - wifiStation=null → wifi 무시 → 기존 cascade
+ * #1398에서 barometer SPOF 분리:
+ * - 기존: `barometerSubsurface===true` 일 때만 wifi 채택
+ * - 변경: barometerSubsurface 무관, wifi 매칭이 GPS와 거리 정합(WIFI_SSID_MAX_DISTANCE_KM 이내)이면 채택.
+ *         GPS userLocation=null(지하 dead zone)이면 거리 면제.
+ *         WiFi 결과가 GPS와 너무 멀면(false positive 의심) 거부 — 기존 cascade로 fallback.
+ *
+ * - 정상 매칭 (gps와 인접): wifi-ssid 채택 (subsurface 무관, #1398)
+ * - GPS 완전 dead(null): wifi-ssid 채택
+ * - wifi=null: 기존 cascade
+ * - WiFi 결과가 GPS와 너무 멀면: 거부 (false positive 방어)
  * - 환승역: boardingLock.boardingLine으로 호선 보정
  * - 디버그: wifiSsid candidate가 entries에 기록
  */
@@ -73,11 +80,19 @@ const yongmasan: Station = {
 // 환승역 — 충무로(3호선). 4호선에도 존재.
 const chungmuro3: Station = MOCK_STATIONS.chungmuro; // line='3'
 
+/**
+ * #1398 — SPOF 분리 후 GPS 좌표는 WiFi 결과 인근(거리 정합)이어야 wifi-ssid 채택.
+ *   - 정상 케이스: 사용자가 그 역 근처에 있어서 WiFi가 잡혔다 = GPS도 그 인근으로 알려진다.
+ *   - 거리 mismatch: 강남 근처 GPS인데 용마산 WiFi 잡힘 = 카페/지하상가 false positive → 거부.
+ *
+ * baseline은 yongmasan과 가까운(거리 ≪ WIFI_SSID_MAX_DISTANCE_KM=1.5km) 좌표 사용.
+ */
 function gpsBase(overrides?: Record<string, unknown>) {
   return {
-    result: { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
-    variants: [MOCK_STATIONS.gangnam],
-    userLocation: { lat: 37.5, lng: 127.0 },
+    // GPS가 용마산 인근. WiFi 매칭이 yongmasan일 때 거리 정합.
+    result: { station: yongmasan, distanceKm: 0.05 },
+    variants: [yongmasan],
+    userLocation: { lat: yongmasan.lat + 0.0005, lng: yongmasan.lng + 0.0005 },
     speedMps: 1,
     accuracyMeters: 50,
     loading: false,
@@ -89,12 +104,13 @@ function gpsBase(overrides?: Record<string, unknown>) {
   };
 }
 
-describe('useFusedNearestStation — #1286 WiFi SSID fusion', () => {
+describe('useFusedNearestStation — #1286/#1398 WiFi SSID fusion', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseNearest.mockReturnValue(gpsBase());
-    mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
-    mockFindLines.mockReturnValue(['2']);
+    // #1398 — GPS top 후보도 yongmasan 인근으로 정렬 — gpsBase와 정합.
+    mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0.05 }]);
+    mockFindLines.mockReturnValue(['7']);
     mockUseArrival.mockReturnValue({ arrival: null, loading: false, isMock: false });
     mockUsePositions.mockReturnValue({ positions: null, loading: false, isMock: false });
   });
@@ -132,8 +148,8 @@ describe('useFusedNearestStation — #1286 WiFi SSID fusion', () => {
           yongmasan,
         ),
       );
-      // gpsResult는 GPS 원본 그대로
-      expect(result.current.gpsResult?.station.id).toBe(MOCK_STATIONS.gangnam.id);
+      // gpsResult는 GPS 원본 그대로 (gpsBase가 yongmasan을 반환 — 거리 정합 fixture).
+      expect(result.current.gpsResult?.station.id).toBe(yongmasan.id);
       expect(result.current.source).toBe('wifi-ssid');
     });
 
@@ -160,8 +176,9 @@ describe('useFusedNearestStation — #1286 WiFi SSID fusion', () => {
     });
   });
 
-  describe('지상(subsurface=false) — WiFi 무시, 기존 cascade', () => {
-    it('subsurface=false + wifiStation 있어도 GPS fallback(gps-only)', () => {
+  describe('#1398 SPOF 분리 — barometer 무관, WiFi 매칭 자체 신뢰도로 채택', () => {
+    it('subsurface=false + wifiStation 매칭 + GPS 거리 정합 → wifi-ssid 채택 (기압계 unavailable여도)', () => {
+      // #1398 acceptance: 기압계 unavailable(subsurface=false)이어도 WiFi 신선 매칭 시 현재역 유지.
       const { result } = renderHook(() =>
         useFusedNearestStation(
           undefined,
@@ -174,11 +191,11 @@ describe('useFusedNearestStation — #1286 WiFi SSID fusion', () => {
           yongmasan,
         ),
       );
-      expect(result.current.confidence).toBe('gps-only');
-      expect(result.current.result?.station.id).toBe(MOCK_STATIONS.gangnam.id);
+      expect(result.current.confidence).toBe('wifi-ssid');
+      expect(result.current.result?.station.id).toBe(yongmasan.id);
     });
 
-    it('subsurface 미전달(undefined) + wifiStation 있어도 GPS fallback', () => {
+    it('subsurface 미전달(undefined) + wifiStation 매칭 → wifi-ssid 채택 (기압계 미지원 호환)', () => {
       const { result } = renderHook(() =>
         useFusedNearestStation(
           undefined,
@@ -191,7 +208,43 @@ describe('useFusedNearestStation — #1286 WiFi SSID fusion', () => {
           yongmasan,
         ),
       );
+      expect(result.current.confidence).toBe('wifi-ssid');
+      expect(result.current.result?.station.id).toBe(yongmasan.id);
+    });
+
+    it('WiFi 결과가 GPS와 거리 mismatch (>WIFI_SSID_MAX_DISTANCE_KM) → 거부, 기존 cascade fallback', () => {
+      // false positive 방어: 강남 근처 GPS인데 용마산 WiFi 잡힘 = 카페/지하상가.
+      // SPOF 분리 후에도 거리 게이트로 차단되어야 한다.
+      mockUseNearest.mockReturnValue({
+        result: { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
+        variants: [MOCK_STATIONS.gangnam],
+        userLocation: { lat: 37.5, lng: 127.0 },
+        speedMps: 1,
+        accuracyMeters: 50,
+        loading: false,
+        error: null,
+        permissionDenied: false,
+        locationUncertain: false,
+        refresh: jest.fn(),
+      });
+      mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
+      mockFindLines.mockReturnValue(['2']);
+
+      const { result } = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { subsurface: false },
+          yongmasan,
+        ),
+      );
+      // WiFi 거리 mismatch → wifi-ssid 거부 → gps-only fallback.
       expect(result.current.confidence).toBe('gps-only');
+      expect(result.current.result?.station.id).toBe(MOCK_STATIONS.gangnam.id);
     });
   });
 
@@ -242,6 +295,20 @@ describe('useFusedNearestStation — #1286 WiFi SSID fusion', () => {
         boardingStationId: '0401',
         boardedAt: 1000,
       };
+
+      // #1398 SPOF 분리 후 거리 게이트: GPS를 chungmuro 인근으로 설정해 정합 케이스.
+      mockUseNearest.mockReturnValue({
+        result: { station: chungmuro3, distanceKm: 0.05 },
+        variants: [chungmuro3],
+        userLocation: { lat: chungmuro3.lat + 0.0005, lng: chungmuro3.lng + 0.0005 },
+        speedMps: 1,
+        accuracyMeters: 50,
+        loading: false,
+        error: null,
+        permissionDenied: false,
+        locationUncertain: false,
+        refresh: jest.fn(),
+      });
 
       const { result } = renderHook(() =>
         useFusedNearestStation(
@@ -366,7 +433,8 @@ describe('useFusedNearestStation — #1286 WiFi SSID fusion', () => {
       expect(wifiCandidate?.line).toBe(yongmasan.line);
     });
 
-    it('wifi 미채택(subsurface=false) 시 wifiSsid candidate 없음', () => {
+    it('#1398 — WiFi 거리 mismatch 시 wifiSsid candidate 없음', () => {
+      // SPOF 분리 후: subsurface=false 자체로는 wifi 무시 안 함. 거리 mismatch가 진짜 차단.
       const {
         clearFusionDebugEntries,
         getFusionDebugEntries,
@@ -374,6 +442,21 @@ describe('useFusedNearestStation — #1286 WiFi SSID fusion', () => {
         '../../utils/fusionDebugBuffer',
       ) as typeof import('../../utils/fusionDebugBuffer');
       clearFusionDebugEntries();
+
+      // GPS가 강남, WiFi는 용마산 (>1.5km mismatch) → 거리 게이트 거부.
+      mockUseNearest.mockReturnValue({
+        result: { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
+        variants: [MOCK_STATIONS.gangnam],
+        userLocation: { lat: 37.5, lng: 127.0 },
+        speedMps: 1,
+        accuracyMeters: 50,
+        loading: false,
+        error: null,
+        permissionDenied: false,
+        locationUncertain: false,
+        refresh: jest.fn(),
+      });
+      mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
 
       renderHook(() =>
         useFusedNearestStation(

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -42,6 +42,7 @@ import {
   MAX_FUSION_DELTA_KM,
   MAX_FUSION_DISTANCE_KM,
   POSITION_TRAIN_TTL_MS,
+  WIFI_SSID_MAX_DISTANCE_KM,
 } from '../../../shared/constants/realtime';
 import type { LinePositions } from '../api/positionApi';
 import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival';
@@ -503,28 +504,43 @@ export function useFusedNearestStation(
     routeResult != null && passesFusionDistanceGate({ ...gateOpts, candidate: routeResult });
 
   // #1286 — WiFi SSID 역 매칭 → fusion cascade.
-  // barometerSubsurface===true(지하 GPS dead zone)이고 SSID 매칭이 성공했을 때 최우선 채택.
   // wifiSsidLookup은 역명 → 첫 번째 호선 Station을 반환하므로, 환승역 호선 보정:
   //   1) boardingLock.boardingLine — 사용자가 명시적으로 탑승한 노선 (가장 정확).
   //   2) 해당 보정 결과가 없으면 wifiStation 그대로 사용 (단일 호선 역 or 호선 미확정).
-  // 지상(subsurface=false) 또는 SSID 무매칭(null)이면 이 블록을 건너뛰고 기존 cascade로 fallback.
+  //
+  // #1398 — barometer subsurface SPOF 분리.
+  //   기존: `if (!barometerSubsurface || !wifiStation) return null;` — barometer가 unavailable이면
+  //         WiFi 매칭 자체가 무력화되어 dump1/dump2 케이스(signalMask 첫 글자 'U')에서 현재역 붕괴.
+  //   변경: WiFi SSID 매칭(정규식 + 네이티브 SSID) 자체 신뢰도만으로 채택. barometer는 보조 가중치.
+  //
+  // false positive 방어 (지상에서 카페/지하상가 WiFi 오매칭 차단):
+  //   1. SSID 매칭 신뢰도 — wifiSsidLookup의 정규식 패턴(`T_subway_<역명>` 등 지하철 SSID 명명규칙)이
+  //      이미 1차 게이트. 비-지하철 SSID는 매칭 자체가 안 됨.
+  //   2. 거리 게이트 — WiFi 결과가 GPS와 WIFI_SSID_MAX_DISTANCE_KM 이상 떨어지면 거부.
+  //      GPS userLocation 자체가 없으면(지하 dead zone) 면제 — WiFi가 유일 신호이므로 통과.
+  //
+  // 지상 + SSID 매칭 + 거리 정합 케이스: WiFi가 GPS보다 정확할 수 있으므로 채택 허용.
+  // SSID 무매칭(wifiStation=null) → null 반환(기존 cascade).
   const wifiStationResolved: NearestStationResult | null = (() => {
-    if (!barometerSubsurface || !wifiStation) return null;
+    if (!wifiStation) return null;
     // BoardingLock의 노선으로 환승역 호선 보정 시도.
     const targetLine = boardingLock?.boardingLine ?? null;
     const resolvedStation =
       targetLine && targetLine !== wifiStation.line
         ? (findStationByNameAndLine(wifiStation.name, targetLine) ?? wifiStation)
         : wifiStation;
-    const distanceKm = gps.userLocation
-      ? haversine(
-          gps.userLocation.lat,
-          gps.userLocation.lng,
-          resolvedStation.lat,
-          resolvedStation.lng,
-        )
-      : 0;
-    return { station: resolvedStation, distanceKm };
+    // 거리 게이트 — GPS가 있을 때만 적용. dead zone(null)은 자동 면제.
+    if (gps.userLocation) {
+      const distanceKm = haversine(
+        gps.userLocation.lat,
+        gps.userLocation.lng,
+        resolvedStation.lat,
+        resolvedStation.lng,
+      );
+      if (distanceKm > WIFI_SSID_MAX_DISTANCE_KM) return null;
+      return { station: resolvedStation, distanceKm };
+    }
+    return { station: resolvedStation, distanceKm: 0 };
   })();
 
   let result: NearestStationResult | null;
@@ -797,7 +813,10 @@ export function useFusedNearestStation(
   }
 
   // #921 — 신호 fusion(barometer-stop + motion-stationary + arvlcd-arrived) wire-up.
-  // 본 PR에서는 cascade 비결합 — verdict만 측정 entry에 첨부. 후속 PR(별도 이슈)에서 cascade 결합.
+  // #1398 — cascade 결합 (verdict가 confidence 라벨에 실제 기여).
+  //   `gps-only-underground` 강등 결과에 verdict.detected가 결합되면 → `detection-fused`로 승격
+  //   (`subsurfaceStationDetected` 충족 시). cascade가 verdict를 인식한다는 사실을 측정/dump에서
+  //   명확히 표시. station-passed 발사는 별도(useStationAlarm `subsurfaceStationDetected` 패스스루).
   //
   // arrival 입력: 채택된 result의 station name과 매칭되는 후보 슬롯의 arrival을 사용. result가
   // 어떤 후보(c0/c1/c2)에서 왔든 같은 station name이면 한 슬롯에서 lockedTrainCode를 찾을 수 있다.
@@ -832,6 +851,15 @@ export function useFusedNearestStation(
     detectionVerdict.detected &&
     result != null &&
     result.distanceKm <= MAX_FUSION_DISTANCE_KM;
+
+  // #1398 — cascade verdict 결합. `gps-only-underground` 강등 결과에 verdict 합의가 결합되면
+  //   `detection-fused`로 confidence 라벨 승격. source는 'gps' 유지(좌표 신호원 자체는 동일).
+  //   subsurfaceStationDetected에 이미 ≥2 신호 합의 + 근접 게이트가 포함되어 false positive 방어
+  //   동일 조건. 다른 confidence(boarding-lock / position-train / arrival-* / wifi-ssid)는
+  //   본인의 검증 신호로 우선 — 승격 대상 아님.
+  if (confidence === 'gps-only-underground' && subsurfaceStationDetected) {
+    confidence = 'detection-fused';
+  }
 
   // #1025 — Estimator 전략 변화 시 debug buffer에 push.
   // estimate key: strategy|stationId|arcIndex. null estimate는 strategy=null로 기록.

--- a/src/features/nearest-station/hooks/useFusedStationDetection.ts
+++ b/src/features/nearest-station/hooks/useFusedStationDetection.ts
@@ -8,8 +8,14 @@
  * #921 — 신호 fusion wire-up (B1 후속 PR).
  *
  * 알고리즘(`fuseStationDetectionSignals`)이 dormant 상태였던 것을 실제 호출자로 연결.
- * 본 hook 자체는 cascade에 영향을 주지 않는다 — verdict만 반환. 호출자(useFusedNearestStation)는
- * 디버그 entry에 첨부해 측정·튜닝 단계를 거친 뒤 후속 PR에서 cascade에 결합한다.
+ *
+ * #1398 — cascade 결합 (verdict가 cascade의 지하 보정 단계에 실제 기여).
+ *   1. `subsurfaceStationDetected` (≥2 신호 합의 + subsurface + 근접 게이트) → useStationAlarm의
+ *      station-passed 발사 트리거. GPS dead zone에서도 발사 가능.
+ *   2. `gps-only-underground` 강등 라벨이 붙은 결과에 verdict.detected가 결합되면
+ *      `detection-fused`로 confidence 라벨 승격 (호출자 useFusedNearestStation).
+ *      cascade가 verdict를 인식한다는 사실을 측정/dump에서 명확히 표시.
+ *      ADR-010 첫 줄: false positive / miss 비대칭 아님 → 임계는 ≥2 합의 + 근접 게이트로 동급 보호.
  *
  * 신호 변환 규약:
  *   - 'barometer-stop'    ← BarometerSignal.stop (undefined → unavailable)

--- a/src/features/nearest-station/utils/__tests__/fusionTierPriority.test.ts
+++ b/src/features/nearest-station/utils/__tests__/fusionTierPriority.test.ts
@@ -19,7 +19,7 @@ describe('fusionTierPriority (R-10, #1168)', () => {
       );
     });
 
-    it('position-train > fused-position > fused-arrival-* > route-progress > estimator-* > gps-*', () => {
+    it('position-train > fused-position > fused-arrival-* > route-progress > estimator-* > detection-fused > gps-*', () => {
       const order: FusionTier[] = [
         'position-train',
         'fused-position',
@@ -29,6 +29,7 @@ describe('fusionTierPriority (R-10, #1168)', () => {
         'estimator-live-position',
         'estimator-arrival-eta',
         'estimator-reanchored-hop',
+        'detection-fused',
         'gps-only-underground',
         'gps-only',
       ];
@@ -67,6 +68,8 @@ describe('fusionTierPriority (R-10, #1168)', () => {
       ['route-progress', 'route-progress', 'route-progress'],
       ['gps', 'gps-only', 'gps-only'],
       ['gps', 'gps-only-underground', 'gps-only-underground'],
+      // #1398 — detection-fused는 source='gps' 유지 + confidence 라벨만 승격.
+      ['gps', 'detection-fused', 'detection-fused'],
     ];
 
     it.each(cases)('source=%s + confidence=%s → tier=%s', (source, confidence, expected) => {
@@ -94,6 +97,10 @@ describe('fusionTierPriority (R-10, #1168)', () => {
 
     it('gps-only-underground > gps-only — 지하 라벨이 한 단계 위', () => {
       expect(getTierRank('gps-only-underground')).toBeLessThan(getTierRank('gps-only'));
+    });
+
+    it('#1398 — detection-fused > gps-only-underground — verdict 결합 라벨이 단순 강등보다 신뢰', () => {
+      expect(getTierRank('detection-fused')).toBeLessThan(getTierRank('gps-only-underground'));
     });
   });
 });

--- a/src/features/nearest-station/utils/__tests__/fusionTierPriority.test.ts
+++ b/src/features/nearest-station/utils/__tests__/fusionTierPriority.test.ts
@@ -83,24 +83,27 @@ describe('fusionTierPriority (R-10, #1168)', () => {
   });
 
   describe('tier 비교 — spec §1.4 trust 순서', () => {
-    it('position-train > fused-position', () => {
-      expect(getTierRank('position-train')).toBeLessThan(getTierRank('fused-position'));
-    });
-
-    it('fused-position > fused-arrival-confirmed', () => {
-      expect(getTierRank('fused-position')).toBeLessThan(getTierRank('fused-arrival-confirmed'));
-    });
-
-    it('route-progress > gps-only', () => {
-      expect(getTierRank('route-progress')).toBeLessThan(getTierRank('gps-only'));
-    });
-
-    it('gps-only-underground > gps-only — 지하 라벨이 한 단계 위', () => {
-      expect(getTierRank('gps-only-underground')).toBeLessThan(getTierRank('gps-only'));
-    });
-
-    it('#1398 — detection-fused > gps-only-underground — verdict 결합 라벨이 단순 강등보다 신뢰', () => {
-      expect(getTierRank('detection-fused')).toBeLessThan(getTierRank('gps-only-underground'));
+    // 5 케이스 모두 동일 단언 패턴 — getTierRank(상위) < getTierRank(하위). cpd 방지로 테이블화.
+    it.each<{ label: string; higher: FusionTier; lower: FusionTier }>([
+      { label: 'position-train > fused-position', higher: 'position-train', lower: 'fused-position' },
+      {
+        label: 'fused-position > fused-arrival-confirmed',
+        higher: 'fused-position',
+        lower: 'fused-arrival-confirmed',
+      },
+      { label: 'route-progress > gps-only', higher: 'route-progress', lower: 'gps-only' },
+      {
+        label: 'gps-only-underground > gps-only — 지하 라벨이 한 단계 위',
+        higher: 'gps-only-underground',
+        lower: 'gps-only',
+      },
+      {
+        label: '#1398 — detection-fused > gps-only-underground — verdict 결합 라벨이 단순 강등보다 신뢰',
+        higher: 'detection-fused',
+        lower: 'gps-only-underground',
+      },
+    ])('$label', ({ higher, lower }) => {
+      expect(getTierRank(higher)).toBeLessThan(getTierRank(lower));
     });
   });
 });

--- a/src/features/nearest-station/utils/fusionTierPriority.ts
+++ b/src/features/nearest-station/utils/fusionTierPriority.ts
@@ -36,12 +36,18 @@ export type FusionTier =
   | 'estimator-live-position'
   | 'estimator-arrival-eta'
   | 'estimator-reanchored-hop'
+  | 'detection-fused'
   | 'gps-only-underground'
   | 'gps-only';
 
 /**
  * 명시 trust table — 더 앞일수록 신뢰 우선.
  * spec `docs/research/r10-fusion-signal-priority.md` §4.2와 1:1 대응.
+ *
+ * #1398 — 'detection-fused'는 'gps-only-underground'보다 신뢰 우선.
+ *   verdict ≥2 신호 합의가 결합되어 cascade가 GPS-only-underground 단순 강등보다 더 강한
+ *   신호를 인식한 상태. 별도 source 필드 추가 없이 confidence 라벨만 승격되므로 source는
+ *   여전히 'gps'다.
  */
 export const FUSION_TIER_PRIORITY: readonly FusionTier[] = [
   'wifi-ssid',
@@ -55,6 +61,7 @@ export const FUSION_TIER_PRIORITY: readonly FusionTier[] = [
   'estimator-live-position',
   'estimator-arrival-eta',
   'estimator-reanchored-hop',
+  'detection-fused',
   'gps-only-underground',
   'gps-only',
 ] as const;
@@ -86,6 +93,7 @@ export function getTierRank(tier: FusionTier): number {
  * - source='arrival'           → confidence='arrival-confirmed' → 'fused-arrival-confirmed'
  *                              → confidence='arrival-arriving'  → 'fused-arrival-arriving'
  * - source='route-progress'    → 'route-progress'
+ * - source='gps' + confidence='detection-fused' → 'detection-fused' (#1398)
  * - source='gps' + confidence='gps-only-underground' → 'gps-only-underground'
  * - source='gps'               → 'gps-only'
  */
@@ -108,6 +116,8 @@ export function tierFor(source: FusionSource, confidence: FusionConfidence): Fus
     case 'route-progress':
       return 'route-progress';
     case 'gps':
-      return confidence === 'gps-only-underground' ? 'gps-only-underground' : 'gps-only';
+      if (confidence === 'detection-fused') return 'detection-fused';
+      if (confidence === 'gps-only-underground') return 'gps-only-underground';
+      return 'gps-only';
   }
 }

--- a/src/shared/constants/realtime.ts
+++ b/src/shared/constants/realtime.ts
@@ -20,3 +20,19 @@ export const POSITION_TRAIN_TTL_MS = 60_000;
 // 역을 채택하는 false positive를 차단한다. 인접역 간 평균 주행 시간(90s) × TTL(60s) 기준으로
 // 한 사이클에 1~2 hop이 최대 — 여유 margin 포함 3 hops.
 export const LOCK_NEXT_HOP_WINDOW = 3;
+
+/**
+ * #1398 — WiFi SSID 매칭 결과 거리 게이트.
+ *
+ * SPOF 분리(barometer subsurface 의존 제거) 후 false positive 방어 두 번째 layer.
+ * WiFi 매칭이 GPS 좌표와 이 거리 이상 떨어지면 거부한다 — 지상에서 카페/지하상가 WiFi가
+ * 인접 역 WiFi로 매칭되는 사고 차단.
+ *
+ * 인접 역 평균 800m + 환승 통로 길이 + GPS 정확도 ~150m 여유 → 1.5km. fusion 본 거리 게이트
+ * (MAX_FUSION_DISTANCE_KM 0.6)보다 넉넉 — WiFi는 SSID 매칭 자체가 강한 신호(정규식 + 지하철
+ * SSID 패턴)라 거리만으로 거부할 때는 명백한 mismatch만 차단한다.
+ *
+ * GPS userLocation 자체가 없는 케이스(지하 GPS dead zone)는 거리 검증을 자동 면제 — WiFi가
+ * 유일한 신호이므로 통과시킨다.
+ */
+export const WIFI_SSID_MAX_DISTANCE_KM = 1.5;

--- a/src/shared/hooks/__tests__/useBarometer.test.ts
+++ b/src/shared/hooks/__tests__/useBarometer.test.ts
@@ -336,4 +336,81 @@ describe('useBarometer (#875)', () => {
     expect(getBarometerReadings()).toEqual([]);
     nowSpy.mockRestore();
   });
+
+  describe('#1398 — unavailable 원인 분해 + reading count 노출', () => {
+    it('isAvailable=false → unavailableReason="sensor"', async () => {
+      mockIsAvailable.mockResolvedValue(false);
+      const { result } = renderHook(() => useBarometer());
+      await flush();
+      expect(result.current.unavailableReason).toBe('sensor');
+      expect(result.current.readingCount).toBe(0);
+    });
+
+    it('권한 거절 → unavailableReason="permission"', async () => {
+      mockIsAvailable.mockResolvedValue(true);
+      mockRequestPermissions.mockResolvedValue({ granted: false });
+      const { result } = renderHook(() => useBarometer());
+      await flush();
+      expect(result.current.unavailableReason).toBe('permission');
+    });
+
+    it('게이트 통과 + reading 0건 → unavailableReason="readings" (warm-up 초기)', async () => {
+      mockIsAvailable.mockResolvedValue(true);
+      mockRequestPermissions.mockResolvedValue({ granted: true });
+      const { result } = renderHook(() => useBarometer());
+      await flush();
+      // listener 등록까지 진행됐지만 sample 미도착 → readings 단계.
+      expect(result.current.unavailableReason).toBe('readings');
+      expect(result.current.readingCount).toBe(0);
+    });
+
+    it('stop이 boolean 결정 → unavailableReason=undefined (정상) + readingCount > 0', async () => {
+      const { result, listener, nowSpy, baseT } = await setupBarometerWithListener();
+      // baseline + 30s 후 dP≈0 정상 stop 신호.
+      act(() => {
+        listener({ pressure: 1013, timestamp: 0 });
+      });
+      fireListenerWindow(listener, nowSpy, baseT, 3, () => 1013);
+      expect(result.current.stop).toBe(true);
+      expect(result.current.unavailableReason).toBeUndefined();
+      expect((result.current.readingCount ?? 0)).toBeGreaterThan(0);
+      nowSpy.mockRestore();
+    });
+
+    it('stop이 boolean 결정된 후 reading buffer reset → unavailableReason="readings"로 회귀', async () => {
+      const { result, listener, nowSpy, baseT } = await setupBarometerWithListener();
+      act(() => {
+        listener({ pressure: 1013, timestamp: 0 });
+      });
+      fireListenerWindow(listener, nowSpy, baseT, 3, () => 1013);
+      expect(result.current.stop).toBe(true);
+      expect(result.current.unavailableReason).toBeUndefined();
+
+      // ring buffer reset → 새 tick은 baseline 부재 → verdict null → readings.
+      resetBarometerState();
+      nowSpy.mockReturnValue(baseT + BAROMETER_DPDT_WINDOW_MS * 3);
+      act(() => {
+        listener({ pressure: 1013.5, timestamp: 100 });
+      });
+      expect(result.current.stop).toBeUndefined();
+      expect(result.current.unavailableReason).toBe('readings');
+      nowSpy.mockRestore();
+    });
+
+    it('unavailable 유지 (같은 undefined verdict 반복) → reason="readings" 그대로 유지', async () => {
+      const { result, listener, nowSpy, baseT } = await setupBarometerWithListener();
+      // baseline 1건 — 30s 윈도우 부족 → verdict null 유지.
+      act(() => {
+        listener({ pressure: 1013, timestamp: 0 });
+      });
+      // 그 후 1초 후 한 번 더 — 여전히 baseline 부재(첫 reading=30s 이전 아님) → verdict null.
+      nowSpy.mockReturnValue(baseT + 1_000);
+      act(() => {
+        listener({ pressure: 1013, timestamp: 1 });
+      });
+      expect(result.current.stop).toBeUndefined();
+      expect(result.current.unavailableReason).toBe('readings');
+      nowSpy.mockRestore();
+    });
+  });
 });

--- a/src/shared/hooks/__tests__/useBarometer.test.ts
+++ b/src/shared/hooks/__tests__/useBarometer.test.ts
@@ -170,6 +170,35 @@ describe('useBarometer (#875)', () => {
     expect(mockRequestPermissions).not.toHaveBeenCalled();
   });
 
+  it('#1398 — unmount가 권한 응답 직후·listener 등록 전에 일어나면 listener 등록 X (cancelled-after-permission)', async () => {
+    // safeRequestPermission이 resolve하고 다음 라인에서 `if (cancelled) return;`을 타는 경로.
+    // requestPermissions를 deferred로 잡아 두고 unmount(cancelled=true) 후에 resolve해서
+    // line 131 guard branch를 커버한다.
+    mockIsAvailable.mockResolvedValue(true);
+    let resolvePermission: (value: { granted: boolean }) => void = () => {};
+    mockRequestPermissions.mockImplementation(
+      () =>
+        new Promise<{ granted: boolean }>((resolve) => {
+          resolvePermission = resolve;
+        }),
+    );
+
+    const { unmount } = renderHook(() => useBarometer());
+    // isAvailable resolve 진행 + requestPermissions가 deferred에서 멈춘 상태로 진입.
+    await flush();
+    expect(mockRequestPermissions).toHaveBeenCalledTimes(1);
+
+    // 권한 promise가 pending인 동안 unmount → cleanup이 cancelled=true 셋.
+    unmount();
+
+    // 이제 권한 promise resolve → init이 깨어나며 `if (cancelled) return;` 한 줄로 종료.
+    resolvePermission({ granted: true });
+    await flush();
+
+    expect(mockSetUpdateInterval).not.toHaveBeenCalled();
+    expect(mockAddListener).not.toHaveBeenCalled();
+  });
+
   it('#903 — 초기 subsurface=false', async () => {
     mockIsAvailable.mockResolvedValue(false);
     const { result } = renderHook(() => useBarometer());

--- a/src/shared/hooks/useBarometer.ts
+++ b/src/shared/hooks/useBarometer.ts
@@ -28,6 +28,7 @@ import {
   appendBarometerReading,
   evaluateLatestStop,
   evaluateLatestSubsurface,
+  getBarometerReadings,
   resetBarometerState,
 } from '../utils/barometerState';
 import { setSubsurfaceState } from '../utils/subsurfaceState';
@@ -36,6 +37,19 @@ import {
   BAROMETER_STOP_CONFIRM_SAMPLES,
   BAROMETER_SUBSURFACE_CONFIRM_SAMPLES,
 } from '../constants/barometer';
+
+/**
+ * #1398 — 기압계 unavailable 원인 분해.
+ *
+ * `stop=undefined`(평가 불가) 원인을 device dump에 노출하기 위한 진단 필드.
+ * 원인을 모르면 SPOF 회피 방향(WiFi 분리 / fusion verdict 결합) 튜닝이 불가능하다.
+ *
+ * - 'sensor'      : `Barometer.isAvailableAsync()` false (iPhone 6 이하 등 기기 미지원)
+ * - 'permission'  : NSMotionUsageDescription 권한 거절
+ * - 'readings'    : 센서 활성이지만 30s 윈도우를 채울 reading 부족 (warm-up 초기)
+ * - undefined     : 정상 (stop이 true|false로 결정됨)
+ */
+export type BarometerUnavailableReason = 'sensor' | 'permission' | 'readings';
 
 /**
  * #903 — 외부 소비자에 노출되는 보조 신호 스냅샷.
@@ -53,6 +67,24 @@ export interface BarometerSignal {
    * 그대로 전달되면 unavailable로 분류된다 — 다른 신호로 합의 가능.
    */
   stop: boolean | undefined;
+  /**
+   * #1398 — `stop=undefined`일 때의 원인. SPOF 분리 효과 측정용.
+   *
+   * stop이 boolean으로 결정되면 undefined. unavailable일 때만 셋. DebugModal이 GPS section
+   * `subsurface=` 라인에 함께 노출해 사용자/측정자가 dump 한 줄로 원인 분해를 본다.
+   *
+   * optional: 기존 호출자/테스트 픽스처 호환. useBarometer가 반환하는 production 객체는
+   * 항상 키를 채우지만, fusion 입력 mock에서는 stop만 주입해도 동작한다 (스키마 호환).
+   */
+  unavailableReason?: BarometerUnavailableReason | undefined;
+  /**
+   * #1398 — 현재 ring buffer에 누적된 reading 수. dump 진단용.
+   *
+   * 0이면 sensor/permission 게이트에서 차단됐거나 listener가 시작되지 않은 상태.
+   * 0 < n < ~30이면 warm-up 초기. ≥30이면 30s 윈도우를 채울 만큼은 누적된 상태.
+   * optional: 위와 동일한 호환성 이유.
+   */
+  readingCount?: number;
 }
 
 /**
@@ -66,6 +98,13 @@ export function useBarometer(): BarometerSignal {
   const [subsurface, setSubsurface] = useState<boolean>(false);
   // #921 — readings 부족 또는 unmount 직후는 undefined. fusion 입력 unavailable로 흘러간다.
   const [stop, setStop] = useState<boolean | undefined>(undefined);
+  // #1398 — stop=undefined일 때의 원인. 초기값 'sensor'(아직 게이트 미통과). 게이트 단계별로
+  // 'sensor' → 'permission' → 'readings' → undefined(정상)로 좁혀진다.
+  const [unavailableReason, setUnavailableReason] = useState<
+    BarometerUnavailableReason | undefined
+  >('sensor');
+  // #1398 — ring buffer 누적 reading 수. listener tick마다 갱신.
+  const [readingCount, setReadingCount] = useState<number>(0);
   // #903 — hysteresis: 임계 부근 노이즈 진동 흡수. lastEmitted와 다른 verdict가 N회 연속
   // 들어와야 state flip. lastEmitted과 같은 verdict가 들어오면 카운터 리셋.
   const lastSubsurfaceRef = useRef<boolean>(false);
@@ -82,9 +121,21 @@ export function useBarometer(): BarometerSignal {
 
     const init = async (): Promise<void> => {
       const available = await safeIsAvailable();
-      if (cancelled || !available) return;
+      if (cancelled) return;
+      if (!available) {
+        // #1398 — sensor 게이트 차단 (isAvailable=false 또는 throw). dump에 'sensor' 노출.
+        setUnavailableReason('sensor');
+        return;
+      }
       const granted = await safeRequestPermission();
-      if (cancelled || !granted) return;
+      if (cancelled) return;
+      if (!granted) {
+        // #1398 — permission 게이트 차단. dump에 'permission' 노출.
+        setUnavailableReason('permission');
+        return;
+      }
+      // 게이트 통과 — readings 부족 단계로 진입. 첫 tick까지 'readings'.
+      setUnavailableReason('readings');
 
       Barometer.setUpdateInterval(BAROMETER_SAMPLE_INTERVAL_MS);
       subscription = Barometer.addListener((m: BarometerMeasurement) => {
@@ -92,6 +143,8 @@ export function useBarometer(): BarometerSignal {
         // ring buffer는 epoch ms 윈도우로 평가하므로 Date.now()로 직접 stamp.
         const now = Date.now();
         appendBarometerReading({ t: now, pressureHpa: m.pressure });
+        // #1398 — reading 수 dump 노출. ring buffer는 60s TTL이라 안정 시 약 60.
+        setReadingCount(getBarometerReadings().length);
 
         const subVerdict = evaluateLatestSubsurface(now);
         const subDetected = subVerdict?.detected === true;
@@ -112,6 +165,8 @@ export function useBarometer(): BarometerSignal {
           stopVerdict === null ? undefined : stopVerdict.detected;
         if (stopDetected === lastStopRef.current) {
           stopPendingRef.current = 0;
+          // unavailable 상태가 유지될 때 reason도 'readings'로 유지.
+          if (stopDetected === undefined) setUnavailableReason('readings');
           return;
         }
         if (stopDetected === undefined) {
@@ -119,6 +174,8 @@ export function useBarometer(): BarometerSignal {
           lastStopRef.current = undefined;
           stopPendingRef.current = 0;
           setStop(undefined);
+          // #1398 — readings 게이트 단계. sensor/permission이 통과한 후의 unavailable.
+          setUnavailableReason('readings');
           return;
         }
         stopPendingRef.current += 1;
@@ -126,6 +183,8 @@ export function useBarometer(): BarometerSignal {
           lastStopRef.current = stopDetected;
           stopPendingRef.current = 0;
           setStop(stopDetected);
+          // #1398 — stop이 boolean으로 결정됨 → unavailable 해제.
+          setUnavailableReason(undefined);
         }
       });
     };
@@ -141,7 +200,7 @@ export function useBarometer(): BarometerSignal {
     };
   }, []);
 
-  return { subsurface, stop };
+  return { subsurface, stop, unavailableReason, readingCount };
 }
 
 /** isAvailableAsync 예외를 false로 폴백 — 일부 시뮬레이터에서 throw. */

--- a/src/shared/hooks/useBarometer.ts
+++ b/src/shared/hooks/useBarometer.ts
@@ -76,7 +76,7 @@ export interface BarometerSignal {
    * optional: 기존 호출자/테스트 픽스처 호환. useBarometer가 반환하는 production 객체는
    * 항상 키를 채우지만, fusion 입력 mock에서는 stop만 주입해도 동작한다 (스키마 호환).
    */
-  unavailableReason?: BarometerUnavailableReason | undefined;
+  unavailableReason?: BarometerUnavailableReason;
   /**
    * #1398 — 현재 ring buffer에 누적된 reading 수. dump 진단용.
    *

--- a/src/shared/types/fusion.ts
+++ b/src/shared/types/fusion.ts
@@ -18,6 +18,12 @@
  * #913 (Epic #912) — 'wifi-ssid' 추가. 지하에서 wifi가 잡힐 때 SSID 패턴 직접 매칭으로
  * 역을 확정한다(예: `T_subway_용마산`). GPS 무관 100% 확정 신호이므로 cascade의
  * 첫 단계로 사용되며 boarding-lock과 동급 신뢰로 취급(별도 source 필드로 식별).
+ *
+ * #1398 — 'detection-fused' 추가. `gps-only-underground` 강등 결과에 #921 verdict
+ * (≥2 신호 합의: barometer-stop / motion-stationary / arvlcd-arrived)가 결합되면 승격된다.
+ * 즉 GPS 좌표 자체는 동일(지하 fix)이지만 verdict가 "이 역에 정차/도착" 합의를 만들면
+ * cascade가 verdict를 인식한 결과로 표시. station-passed 발사는 이미 `subsurfaceStationDetected`
+ * 별도 트리거. 본 라벨은 cascade의 confidence 표시 단에서 verdict 기여를 명확히 표기한다.
  */
 export type FusionConfidence =
   | 'boarding-lock'
@@ -28,7 +34,8 @@ export type FusionConfidence =
   | 'route-progress'
   | 'gps-only'
   | 'gps-only-underground'
-  | 'wifi-ssid';
+  | 'wifi-ssid'
+  | 'detection-fused';
 
 /**
  * fusion 신호 출처. position-train이 가장 정확(특정 trainNo 추적 → 현재역),


### PR DESCRIPTION
Closes #1398. Part of Epic #1396 (sub 2/5).

## Summary

S8 지하 trip dump (signalMask 첫 글자 `U`, subsurface=false) 회귀 — FG에서 기압계 unavailable이면 WiFi/fusion이 모두 무력화되어 현재역 붕괴. 본 PR은 세 layer로 분리:

### 1. WiFi SPOF 분리 (`useFusedNearestStation.ts:511`)
- 기존: `if (!barometerSubsurface || !wifiStation) return null;` — barometer가 unavailable이면 wifi SSID 매처(448역 데이터, 실동작)가 무력화.
- 변경: `if (!wifiStation) return null;` — WiFi 매칭 신뢰도(정규식 + 네이티브 SSID)만으로 채택.
- False positive 방어:
  - 1차: `wifiSsidLookup` 정규식 — 지하철 SSID 명명규칙(`T_subway_<역명>`)만 매칭.
  - 2차: 신규 상수 `WIFI_SSID_MAX_DISTANCE_KM=1.5` 거리 게이트 — WiFi 결과가 GPS와 1.5km 이상 떨어지면 거부. GPS dead zone(userLocation=null)은 면제.
- Acceptance: 기압계 unavailable이어도 WiFi 신선 매칭 시 현재역 유지(gps-only 추락 0건).

### 2. #921 fusion verdict cascade 결합 (`useFusedNearestStation.ts:861`)
- 기존: `useFusedStationDetection`의 verdict가 측정 entry에만 첨부, cascade 비결합.
- 변경: `gps-only-underground` + `subsurfaceStationDetected`(≥2 신호 합의 + subsurface + 근접 게이트) → confidence를 `detection-fused`로 승격.
- 신규 라벨 `detection-fused`:
  - `FusionConfidence` / `FusionTier` 추가. tier rank는 `gps-only-underground`보다 한 단계 위(verdict 결합 라벨이 단순 강등보다 신뢰).
  - source는 'gps' 유지 — 좌표 신호원 자체는 동일.
- **알람 게이트 영향(의도된 cascade 결합)**: `useStationAlarm`의 `degraded = arrivalConfidence === 'gps-only-underground'`가 자동 해제 → early/transfer 알람 발사 허용. ADR-010 false positive 방어는 `subsurfaceStationDetected`의 ≥2 합의 + 근접 게이트가 담당.
- Acceptance: WiFi 미커버 구간에서 #921 융합 verdict가 현재역 보정에 실제 기여(측정 전용 아님).

### 3. 기압계 unavailable 계측 (`useBarometer.ts`, `barometerSubsurface.ts`)
- `BarometerSignal`에 두 신규 필드 추가 (optional — 기존 호출자/테스트 호환):
  - `unavailableReason: 'sensor' | 'permission' | 'readings' | undefined`
  - `readingCount: number`
- 게이트 단계별로 reason 갱신:
  - `'sensor'` — `Barometer.isAvailableAsync()` false (iPhone 6 이하)
  - `'permission'` — NSMotionUsageDescription 거절
  - `'readings'` — 게이트 통과 + 30s 윈도우 부족 (warm-up 초기)
  - `undefined` — stop이 boolean 결정 (정상)
- `DebugModal` GPS 섹션에 `subsurface reason` / `subsurface readings` row 추가, dump도 `subsurface=... (reason=sensor, readings=12)` 포맷으로 노출.
- Acceptance: dump에 기압계 unavailable 원인 분해 노출.

## Acceptance (이슈 #1398)
- [x] 기압계 unavailable(subsurface=false)이어도 WiFi 신선 매칭 시 현재역 유지 (gps-only 추락 0건)
- [x] WiFi 미커버 구간에서 #921 융합 verdict가 현재역 보정에 실제 기여 (detection-fused 라벨 + degraded 게이트 해제)
- [x] dump에 기압계 unavailable 원인 분해 노출 (sensor/permission/readings)
- [x] false positive 0건 — WIFI_SSID_MAX_DISTANCE_KM 거리 게이트 + ≥2 신호 합의 + 근접 게이트 다중 layer
- [x] 커버리지 100% (변경 영역 단독 — 워크트리 drift 2개 suite는 본 PR 무관)
- [x] type-check 통과
- [ ] 실기기 검증 (epic close 조건 — 사용자 책임)

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm run lint` 통과
- [x] 변경 영역 영향 테스트 전체 PASS (`useFusedNearestStation` / `useFusedStationDetection` / `useBarometer` / `DebugModal` / `fusionTierPriority` / `useStationAlarm` 등 — 1825+ tests)
- [ ] 실기기: S8 지하 구간(기압계 dump1/dump2 signalMask 'U' 케이스)에서 wifi-ssid 또는 detection-fused로 현재역 유지 확인
- [ ] 실기기: 지상 + WiFi 정상 매칭 + GPS 정합 케이스에서 wifi-ssid 채택 확인
- [ ] 실기기: 지상 + 거리 mismatch (카페 WiFi 매칭 시 GPS와 ≫1.5km) 케이스에서 wifi-ssid 거부 확인
- [ ] 실기기: subsurface dump에 reason/readings 노출 확인

## File refs
- `src/features/nearest-station/hooks/useFusedNearestStation.ts:511-545, 861-866` — WiFi SPOF 분리 + detection-fused cascade
- `src/features/nearest-station/hooks/useFusedStationDetection.ts:10-17` — cascade 결합 주석 갱신
- `src/features/alarm/hooks/useStationAlarm.ts:612-617` — degraded 게이트 detection-fused 영향 주석
- `src/shared/hooks/useBarometer.ts` — unavailableReason/readingCount 추가
- `src/shared/types/fusion.ts:31-32` — detection-fused 라벨
- `src/features/nearest-station/utils/fusionTierPriority.ts:64-69` — tier table 갱신
- `src/shared/constants/realtime.ts:25-39` — WIFI_SSID_MAX_DISTANCE_KM 신규 상수
- `src/features/debug/components/DebugModal.tsx` — UI/dump unavailable reason 노출