### PR TITLE
fix(#1399): 하이브리드 floor — vanish destination 인계 + lockless kind 가드 제거 + 사전예약 floor 확장 + 좀비 cleanup

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1443,9 +1443,13 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
       expect(stored.waypoints[0].stationName).toBe('군자');
     });
 
-    it('#1370 L2 — destination waypoint는 station-passed push 발사 안 함', async () => {
-      // destination kind는 cleanupTripWithLa 내부에서 trip-ended push가 발사되므로
-      // 추가 station-passed push 발사를 차단해야 한다.
+    it('#1399 — destination waypoint도 vanish fallback station-passed push 발사 (하차 알림 floor 보장)', async () => {
+      // #1370 L2 시점에는 destination skip이었으나 #1399에서 destination 포함으로 확장.
+      // cleanupTripWithLa의 trip-ended push는 alert path로 system banner를 띄우지만, vanish
+      // 상황(지하 + backend trainCode 누락)에서 trip-ended가 cleanup race로 지연/소실되면
+      // 사용자가 종착역 하차 알림을 받지 못한다(S6/S8 13:54·14:10 군자/용마산 하차 누락 회귀).
+      // station-passed imminent push를 destination에도 발사해 device 측 banner 경로(채널 2)도
+      // 확보 — surface 중복은 device pushId/firedPushIds dedup으로 흡수.
       const kv = new InMemoryKV();
       await putTrip(
         kv as unknown as KVNamespace,
@@ -1461,9 +1465,10 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
         apnsHosts: APNS_HOSTS,
         fetchImpl: makeOkFetch() as unknown as typeof fetch,
         now: () => NOW,
-        generatePushId: () => 'p1370-l2-dest',
+        generatePushId: () => 'p1399-dest',
       });
-      expect(stats.vanishFallbackFired).toBe(0);
+      // destination도 vanish fallback fire 1회 발사 (#1399).
+      expect(stats.vanishFallbackFired).toBe(1);
     });
 
     it('#1370 L2 — vanish fallback push dedup (같은 station 두 번 발사 안 됨)', async () => {

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -99,6 +99,15 @@ export interface SilentPushPayload {
    * optional — 미전달 시 wire에서 누락.
    */
   trainCode?: string;
+  /**
+   * #1399 — 좀비 알림 cleanup. push 발사 시점의 active trip token.
+   * 디바이스가 `ACTIVE_TRIP_KEY`와 비교해 mismatch 시 발사 차단(만료 token push drop).
+   *
+   * 사용 시나리오: backend vanish + GPS 동결 + trip 종료 → trip-ended cleanup → 지상 재진입 시
+   * OS queue/네트워크에 잔존하던 stale silent push가 늦게 도착해도 active token이 다른 trip이거나
+   * null이면 발사 차단(S8 14:19 회귀). 구 backend 호환 위해 optional — 미전달 시 가드 자연 skip.
+   */
+  tripToken?: string;
 }
 
 export async function buildApnsJwt(config: ApnsConfig, now: number = Date.now()): Promise<string> {
@@ -168,6 +177,9 @@ export async function sendSilentPush(options: SendPushOptions): Promise<SendPush
         ? {}
         : { boardingLine: options.payload.boardingLine }),
       ...(options.payload.trainCode === undefined ? {} : { trainCode: options.payload.trainCode }),
+      // #1399 — tripToken은 정의된 경우에만 wire (좀비 알림 cleanup). 미전달 시 JSON에서 자연
+      // 누락 → 구 client(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환.
+      ...(options.payload.tripToken === undefined ? {} : { tripToken: options.payload.tripToken }),
     },
   });
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -763,6 +763,10 @@ function buildStationPassedImminentPayload(
     // 없이도(지하 auto-lock hydration window) line sanity-guard를 돌려 발사할 수 있게 한다.
     boardingLine: lock.line,
     trainCode: lock.trainCode,
+    // #1399 — 좀비 알림 cleanup. push 발사 시점의 active trip token을 stamp해 device가
+    // ACTIVE_TRIP_KEY와 비교해 만료 token push를 drop. trip-ended cleanup 후 늦게 도착한
+    // stale silent push 차단(S8 14:19 좀비 회귀).
+    tripToken: trip.token,
   };
 }
 
@@ -1090,19 +1094,25 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
       // intermediate/transfer waypoint를 "지났다"는 신호가 사용자에게 도달하지 않는 회귀가 있었다
       // (어린이대공원/군자/중곡 silent push 0건). vanish fallback도 ground truth 신호로 취급해
       // arvlCd∈{0,1}과 동등하게 station-passed push를 발사한다.
-      if (waypoint.kind !== 'destination') {
-        await fireVanishFallbackStationPush({
-          trip,
-          waypoint,
-          lock: activeLock,
-          env,
-          deps,
-          stats,
-          now,
-          log,
-          generatePushId,
-        });
-      }
+      //
+      // #1399 — destination/transfer 포함 모든 kind에 대해 발사. 기존엔 destination을 skip해
+      // advanceBoardingLockWaypoint의 trip-ended push만 사용자에게 도달했으나, 그 경로는
+      // alert payload(`aps.alert`)로 system banner를 띄우는 데에 의존한다. vanish 상황(지하 +
+      // backend trainCode 누락)에서 trip-ended가 trip token 검증/cleanup race로 지연/소실되면
+      // 사용자는 종착역 하차 알림을 받지 못한다. station-passed imminent push를 destination에도
+      // 발사해 device 측 banner 발사 경로(채널 2)도 확보한다. surface 중복은 device 측
+      // pushId/firedPushIds dedup으로 흡수.
+      await fireVanishFallbackStationPush({
+        trip,
+        waypoint,
+        lock: activeLock,
+        env,
+        deps,
+        stats,
+        now,
+        log,
+        generatePushId,
+      });
       await advanceBoardingLockWaypoint(trip, waypoint, env, deps, stats, now, log);
       return;
     }
@@ -1748,6 +1758,9 @@ export async function runLocklessIntermediate(
           // #1307 — server-authoritative subsurface. lockless intermediate도 지하에선
           // 디바이스 GPS 게이트(out-of-range 오거부)를 우회하도록 flag를 전달.
           subsurface: trip.subsurface === true,
+          // #1399 — 좀비 알림 cleanup. lockless intermediate push에도 tripToken stamp.
+          // trip-ended cleanup 후 늦게 도착한 stale push를 ACTIVE_TRIP_KEY mismatch로 drop.
+          tripToken: trip.token,
         },
         config: deps.apnsConfig,
         host,

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -189,6 +189,7 @@ import {
   DESTINATION_KEY,
   LOCKLESS_STATION_PASSED_KEY,
   ROUTE_KEY,
+  SLEEP_MODE_KEY,
 } from '../../../../shared/constants/storageKeys';
 
 const DEFAULT_APNS_TOKEN = 'apns-tok-hex';
@@ -206,6 +207,30 @@ function ackCall(
 }
 
 const destStation = { id: '0228', name: '강남', line: '2', lat: 37.5, lng: 127.0 };
+
+/**
+ * #1399 — silentPushTask 테스트는 AsyncStorage.getItem을 mockImplementation으로 분기시키는
+ * 패턴이 다발한다(SonarCloud cpd + nested function code smell). 하나의 헬퍼로 압축.
+ *
+ * - `DESTINATION_KEY` / `APNS_TOKEN_KEY`는 항상 기본값 반환(테스트 기본 환경).
+ * - 추가 key는 `overrides` 맵으로 주입. value가 `Error`면 해당 key 조회 시 throw(read 오류 시뮬).
+ * - 그 외 key는 null.
+ */
+const THROW = Symbol('throw');
+function setAsyncStorageMap(
+  overrides: Record<string, string | null | typeof THROW>,
+): void {
+  (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+    if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+    if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+    if (key in overrides) {
+      const v = overrides[key];
+      if (v === THROW) throw new Error('storage-fail');
+      return v;
+    }
+    return null;
+  });
+}
 
 /**
  * expo-notifications iOS BG task payload 모양을 그대로 재현 (#641).
@@ -1306,17 +1331,8 @@ describe('silentPushTask', () => {
 
     // #1399 — 좀비 알림 cleanup: tripToken stamp + ACTIVE_TRIP_KEY mismatch drop.
     describe('#1399 — tripToken mismatch 가드 (좀비 알림 cleanup)', () => {
-      function mockActiveTripToken(value: string | null) {
-        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
-          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
-          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
-          if (key === 'subway-now:active-trip') return value;
-          return null;
-        });
-      }
-
       it('payload.tripToken === ACTIVE_TRIP_KEY → 가드 통과 후 발사', async () => {
-        mockActiveTripToken('active-token-123');
+        setAsyncStorageMap({ [ACTIVE_TRIP_KEY]: 'active-token-123' });
         await handleSilentPush(
           payload({
             kind: 'destination',
@@ -1330,7 +1346,7 @@ describe('silentPushTask', () => {
       });
 
       it('payload.tripToken 다른 token → trip-token-mismatch skip', async () => {
-        mockActiveTripToken('active-token-NEW');
+        setAsyncStorageMap({ [ACTIVE_TRIP_KEY]: 'active-token-NEW' });
         await handleSilentPush(
           payload({
             kind: 'intermediate',
@@ -1349,7 +1365,7 @@ describe('silentPushTask', () => {
       });
 
       it('ACTIVE_TRIP_KEY null (이미 cleanup됨) + payload.tripToken 있음 → drop', async () => {
-        mockActiveTripToken(null);
+        setAsyncStorageMap({ [ACTIVE_TRIP_KEY]: null });
         await handleSilentPush(
           payload({
             kind: 'transfer',
@@ -1365,7 +1381,7 @@ describe('silentPushTask', () => {
       });
 
       it('payload.tripToken 미전달 (구 backend) → 가드 skip, 발사 진행', async () => {
-        mockActiveTripToken('active-token-x');
+        setAsyncStorageMap({ [ACTIVE_TRIP_KEY]: 'active-token-x' });
         // payload에 tripToken 미전달 → undefined → 가드 자연 skip.
         await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
         expect(mockScheduleNotificationAsync).toHaveBeenCalled();
@@ -1374,22 +1390,15 @@ describe('silentPushTask', () => {
 
     // #1399 — lockless 분기 sleep mode 회귀 차단.
     describe('#1399 — lockless sleep-first-transfer 가드', () => {
-      function mockSleepAndToggle(sleep: boolean, optedIn: boolean) {
-        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
-          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
-          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
-          if (key === LOCKLESS_STATION_PASSED_KEY) return JSON.stringify(optedIn);
-          if (key === 'subway-now:sleep-mode') return JSON.stringify(sleep);
-          return null;
-        });
-      }
-
       beforeEach(() => {
         mockGetBoardingLock.mockResolvedValue(null);
       });
 
       it('sleep ON + transfer + hopIndex=0 (first hop) → sleep-first-transfer skip', async () => {
-        mockSleepAndToggle(true, true);
+        setAsyncStorageMap({
+          [LOCKLESS_STATION_PASSED_KEY]: JSON.stringify(true),
+          [SLEEP_MODE_KEY]: JSON.stringify(true),
+        });
         await handleSilentPush(
           payload({ kind: 'transfer', phase: 'imminent', hopIndex: 0, pushId: 'p-sleep-tx' }),
         );
@@ -1403,7 +1412,10 @@ describe('silentPushTask', () => {
       });
 
       it('sleep ON + destination + hopIndex=0 → 통과 (destination은 절대 suppress 안 함)', async () => {
-        mockSleepAndToggle(true, true);
+        setAsyncStorageMap({
+          [LOCKLESS_STATION_PASSED_KEY]: JSON.stringify(true),
+          [SLEEP_MODE_KEY]: JSON.stringify(true),
+        });
         await handleSilentPush(
           payload({ kind: 'destination', phase: 'imminent', hopIndex: 0 }),
         );
@@ -1412,7 +1424,10 @@ describe('silentPushTask', () => {
       });
 
       it('sleep ON + transfer + hopIndex>0 → 통과 (first hop 아님)', async () => {
-        mockSleepAndToggle(true, true);
+        setAsyncStorageMap({
+          [LOCKLESS_STATION_PASSED_KEY]: JSON.stringify(true),
+          [SLEEP_MODE_KEY]: JSON.stringify(true),
+        });
         await handleSilentPush(
           payload({ kind: 'transfer', phase: 'imminent', hopIndex: 1 }),
         );
@@ -1420,7 +1435,10 @@ describe('silentPushTask', () => {
       });
 
       it('sleep OFF + transfer + hopIndex=0 → 통과', async () => {
-        mockSleepAndToggle(false, true);
+        setAsyncStorageMap({
+          [LOCKLESS_STATION_PASSED_KEY]: JSON.stringify(true),
+          [SLEEP_MODE_KEY]: JSON.stringify(false),
+        });
         await handleSilentPush(
           payload({ kind: 'transfer', phase: 'imminent', hopIndex: 0 }),
         );
@@ -1428,12 +1446,9 @@ describe('silentPushTask', () => {
       });
 
       it('SLEEP_MODE_KEY AsyncStorage read 오류 → 가드 자연 skip (안전 fallback)', async () => {
-        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
-          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
-          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
-          if (key === LOCKLESS_STATION_PASSED_KEY) return JSON.stringify(true);
-          if (key === 'subway-now:sleep-mode') throw new Error('storage-fail');
-          return null;
+        setAsyncStorageMap({
+          [LOCKLESS_STATION_PASSED_KEY]: JSON.stringify(true),
+          [SLEEP_MODE_KEY]: THROW,
         });
         await handleSilentPush(
           payload({ kind: 'transfer', phase: 'imminent', hopIndex: 0 }),
@@ -1443,14 +1458,8 @@ describe('silentPushTask', () => {
       });
 
       it('SLEEP_MODE_KEY 부재 (key 자체 없음) → 가드 자연 skip (기본 OFF)', async () => {
-        // SLEEP_MODE_KEY가 storage에 없음(getItem이 null 반환) → loadSleepModeFlag가 false return.
-        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
-          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
-          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
-          if (key === LOCKLESS_STATION_PASSED_KEY) return JSON.stringify(true);
-          // sleep key 없음 → null 반환
-          return null;
-        });
+        // SLEEP_MODE_KEY override 없음 → 기본 null 반환 → loadSleepModeFlag가 false return.
+        setAsyncStorageMap({ [LOCKLESS_STATION_PASSED_KEY]: JSON.stringify(true) });
         await handleSilentPush(
           payload({ kind: 'transfer', phase: 'imminent', hopIndex: 0 }),
         );

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -1071,26 +1071,13 @@ describe('silentPushTask', () => {
         kind: 'destination' | 'transfer' | 'intermediate';
         storage: LocklessStorage;
         pushId?: string;
-        reason: 'lockless-non-intermediate' | 'lockless-opt-out';
+        reason: 'lockless-opt-out';
         logKind: 'destination' | 'transfer' | 'station-passed';
       };
 
+      // #1399 — lockless kind 가드 제거. 사용자 명시 의향 trip(C 토글 ON)은 lock 활성 동급으로
+      // destination/transfer도 발사. opt-in 토글 OFF/부재/read fail 케이스만 skip(보수적 fallback).
       const skipCases: SkipCase[] = [
-        {
-          name: 'destination kind → lockless-non-intermediate + ack',
-          kind: 'destination',
-          storage: 'on',
-          pushId: 'p-dest',
-          reason: 'lockless-non-intermediate',
-          logKind: 'destination',
-        },
-        {
-          name: 'transfer kind → lockless-non-intermediate',
-          kind: 'transfer',
-          storage: 'on',
-          reason: 'lockless-non-intermediate',
-          logKind: 'transfer',
-        },
         {
           name: 'intermediate + 토글 OFF → lockless-opt-out + ack',
           kind: 'intermediate',
@@ -1112,6 +1099,22 @@ describe('silentPushTask', () => {
           storage: 'throw',
           reason: 'lockless-opt-out',
           logKind: 'station-passed',
+        },
+        {
+          name: 'transfer + 토글 OFF → lockless-opt-out (kind 무관, 토글 게이트만 적용)',
+          kind: 'transfer',
+          storage: 'off',
+          pushId: 'p-off-transfer',
+          reason: 'lockless-opt-out',
+          logKind: 'transfer',
+        },
+        {
+          name: 'destination + 토글 OFF → lockless-opt-out (kind 무관, 토글 게이트만 적용)',
+          kind: 'destination',
+          storage: 'off',
+          pushId: 'p-off-dest',
+          reason: 'lockless-opt-out',
+          logKind: 'destination',
         },
       ];
 
@@ -1137,6 +1140,24 @@ describe('silentPushTask', () => {
         mockGetBoardingLock.mockResolvedValue(null);
         mockLocklessStorage('on');
         await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent' }));
+        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+        expect(mockLogSilentPushFired).toHaveBeenCalled();
+      });
+
+      // #1399 — lockless destination/transfer 확장. 토글 ON 시 lock 활성 동급으로 발사 통과.
+      it('lock 없음 + destination + 토글 ON → 일반 게이트로 진행 후 발사 (#1399)', async () => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        mockLocklessStorage('on');
+        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+        expect(mockLogSilentPushFired).toHaveBeenCalled();
+      });
+
+      it('lock 없음 + transfer + 토글 ON + hopIndex>0 → 일반 게이트로 진행 후 발사 (#1399)', async () => {
+        mockGetBoardingLock.mockResolvedValue(null);
+        mockLocklessStorage('on');
+        // hopIndex=1 (first hop 아님) — sleep first-transfer 게이트 비적용.
+        await handleSilentPush(payload({ kind: 'transfer', phase: 'imminent', hopIndex: 1 }));
         expect(mockScheduleNotificationAsync).toHaveBeenCalled();
         expect(mockLogSilentPushFired).toHaveBeenCalled();
       });
@@ -1270,16 +1291,170 @@ describe('silentPushTask', () => {
         expect(mockLogSilentPushFired).toHaveBeenCalled();
       });
 
-      it('lock 없음 + payload.boardingLine 부재 + non-intermediate → 기존 보수 skip(lockless-non-intermediate)', async () => {
+      it('lock 없음 + payload.boardingLine 부재 + non-intermediate (#1399 토글 ON에서 발사 진행)', async () => {
+        // #1399 — kind 가드 제거. 토글 ON + lock 없음 + payload.boardingLine 부재면
+        // line 가드 우회(else 분기) → 일반 게이트로 진행 → 발사. 기존엔 lockless-non-intermediate skip이었음.
         await handleSilentPush(
           payload({ kind: 'transfer', phase: 'imminent', pushId: 'p-nolock-noline' }),
         );
 
         expect(mockFindStationByNameAndLine).not.toHaveBeenCalled();
+        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+        expect(mockLogSilentPushFired).toHaveBeenCalled();
+      });
+    });
+
+    // #1399 — 좀비 알림 cleanup: tripToken stamp + ACTIVE_TRIP_KEY mismatch drop.
+    describe('#1399 — tripToken mismatch 가드 (좀비 알림 cleanup)', () => {
+      function mockActiveTripToken(value: string | null) {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          if (key === 'subway-now:active-trip') return value;
+          return null;
+        });
+      }
+
+      it('payload.tripToken === ACTIVE_TRIP_KEY → 가드 통과 후 발사', async () => {
+        mockActiveTripToken('active-token-123');
+        await handleSilentPush(
+          payload({
+            kind: 'destination',
+            phase: 'imminent',
+            tripToken: 'active-token-123',
+            pushId: 'p-match',
+          }),
+        );
+        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+        expect(mockLogSilentPushFired).toHaveBeenCalled();
+      });
+
+      it('payload.tripToken 다른 token → trip-token-mismatch skip', async () => {
+        mockActiveTripToken('active-token-NEW');
+        await handleSilentPush(
+          payload({
+            kind: 'intermediate',
+            phase: 'imminent',
+            tripToken: 'stale-token-OLD',
+            pushId: 'p-stale',
+          }),
+        );
         expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
         expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'lockless-non-intermediate', kind: 'transfer' }),
+          expect.objectContaining({ reason: 'trip-token-mismatch', kind: 'station-passed' }),
         );
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          ackCall('p-stale', 'skipped', 'trip-token-mismatch'),
+        );
+      });
+
+      it('ACTIVE_TRIP_KEY null (이미 cleanup됨) + payload.tripToken 있음 → drop', async () => {
+        mockActiveTripToken(null);
+        await handleSilentPush(
+          payload({
+            kind: 'transfer',
+            phase: 'imminent',
+            tripToken: 'orphan-token',
+            pushId: 'p-orphan',
+          }),
+        );
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'trip-token-mismatch', kind: 'transfer' }),
+        );
+      });
+
+      it('payload.tripToken 미전달 (구 backend) → 가드 skip, 발사 진행', async () => {
+        mockActiveTripToken('active-token-x');
+        // payload에 tripToken 미전달 → undefined → 가드 자연 skip.
+        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+      });
+    });
+
+    // #1399 — lockless 분기 sleep mode 회귀 차단.
+    describe('#1399 — lockless sleep-first-transfer 가드', () => {
+      function mockSleepAndToggle(sleep: boolean, optedIn: boolean) {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          if (key === LOCKLESS_STATION_PASSED_KEY) return JSON.stringify(optedIn);
+          if (key === 'subway-now:sleep-mode') return JSON.stringify(sleep);
+          return null;
+        });
+      }
+
+      beforeEach(() => {
+        mockGetBoardingLock.mockResolvedValue(null);
+      });
+
+      it('sleep ON + transfer + hopIndex=0 (first hop) → sleep-first-transfer skip', async () => {
+        mockSleepAndToggle(true, true);
+        await handleSilentPush(
+          payload({ kind: 'transfer', phase: 'imminent', hopIndex: 0, pushId: 'p-sleep-tx' }),
+        );
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'sleep-first-transfer', kind: 'transfer' }),
+        );
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          ackCall('p-sleep-tx', 'skipped', 'sleep-first-transfer'),
+        );
+      });
+
+      it('sleep ON + destination + hopIndex=0 → 통과 (destination은 절대 suppress 안 함)', async () => {
+        mockSleepAndToggle(true, true);
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', hopIndex: 0 }),
+        );
+        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+        expect(mockLogSilentPushFired).toHaveBeenCalled();
+      });
+
+      it('sleep ON + transfer + hopIndex>0 → 통과 (first hop 아님)', async () => {
+        mockSleepAndToggle(true, true);
+        await handleSilentPush(
+          payload({ kind: 'transfer', phase: 'imminent', hopIndex: 1 }),
+        );
+        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+      });
+
+      it('sleep OFF + transfer + hopIndex=0 → 통과', async () => {
+        mockSleepAndToggle(false, true);
+        await handleSilentPush(
+          payload({ kind: 'transfer', phase: 'imminent', hopIndex: 0 }),
+        );
+        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+      });
+
+      it('SLEEP_MODE_KEY AsyncStorage read 오류 → 가드 자연 skip (안전 fallback)', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          if (key === LOCKLESS_STATION_PASSED_KEY) return JSON.stringify(true);
+          if (key === 'subway-now:sleep-mode') throw new Error('storage-fail');
+          return null;
+        });
+        await handleSilentPush(
+          payload({ kind: 'transfer', phase: 'imminent', hopIndex: 0 }),
+        );
+        // sleep=false fallback → 가드 비활성 → 정상 발사 흐름 진입.
+        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+      });
+
+      it('SLEEP_MODE_KEY 부재 (key 자체 없음) → 가드 자연 skip (기본 OFF)', async () => {
+        // SLEEP_MODE_KEY가 storage에 없음(getItem이 null 반환) → loadSleepModeFlag가 false return.
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          if (key === LOCKLESS_STATION_PASSED_KEY) return JSON.stringify(true);
+          // sleep key 없음 → null 반환
+          return null;
+        });
+        await handleSilentPush(
+          payload({ kind: 'transfer', phase: 'imminent', hopIndex: 0 }),
+        );
+        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
       });
     });
 

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -33,6 +33,7 @@ import {
   ACTIVE_TRIP_KEY,
   DESTINATION_KEY,
   LOCKLESS_STATION_PASSED_KEY,
+  SLEEP_MODE_KEY,
 } from '../../../shared/constants/storageKeys';
 import { sendPushAck } from '../api/alarmBackend';
 import { createLogger } from '../../../shared/utils/logger';
@@ -130,6 +131,17 @@ export interface SilentPushPayload {
    * 구 backend 호환 위해 optional — 누락 시 cross-check 자연 skip(graceful).
    */
   occupiedLine?: string;
+  /**
+   * #1399 — backend가 push 발사 시점에 stamp한 active trip token (좀비 알림 cleanup).
+   * 디바이스는 `ACTIVE_TRIP_KEY`와 비교해 mismatch면 즉시 drop (현재 trip이 아님 — 만료 token push).
+   *
+   * 사용 시나리오: 백엔드 vanish + GPS 동결 + 트립 종료 → 종료 push 도착 → device cleanup →
+   * 지상 재진입 후 OS queue/네트워크에 잔존하던 stale silent push가 늦게 도착해도 active trip이
+   * 이미 다른 token이거나 null이면 본 가드가 발사를 차단한다 (S8 14:19 좀비 회귀).
+   *
+   * 구 backend 호환 위해 optional — 누락 시 가드 자연 skip(기존 동작 보존).
+   */
+  tripToken?: string;
 }
 
 /**
@@ -328,6 +340,7 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
     subsurface,
     boardingLine,
     occupiedLine,
+    tripToken,
   } = obj as {
     nextWaypoint: string;
   } & Record<string, unknown>;
@@ -346,7 +359,17 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
     subsurface: validSubsurface(subsurface),
     boardingLine: validBoardingLine(boardingLine),
     occupiedLine: validBoardingLine(occupiedLine),
+    tripToken: validTripToken(tripToken),
   };
+}
+
+/**
+ * #1399 — payload.tripToken 검증. 비어있지 않은 string만 통과.
+ * backend가 push 발사 시점의 active trip token을 stamp해 device가 좀비 알림 cleanup에 사용.
+ * 구 backend는 누락 → undefined → 가드 자연 skip(기존 동작 보존).
+ */
+function validTripToken(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 /**
@@ -559,6 +582,24 @@ async function loadApnsToken(): Promise<string | null> {
 async function loadLocklessOptIn(): Promise<boolean> {
   try {
     const raw = await AsyncStorage.getItem(LOCKLESS_STATION_PASSED_KEY);
+    if (!raw) return false;
+    return JSON.parse(raw) === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * #1399 — 취침 모드 토글 현재값을 AsyncStorage에서 읽는다.
+ * BG task에서는 zustand store에 접근 불가하므로 useSettingsStore.setSleepMode가 기록한 키를
+ * 직접 read. lockless transfer/destination 확장(#1399)으로 도입된 sleep mode 회귀 차단용.
+ * 값이 없거나 파싱 실패면 OFF(false) — default 보수적(false negative, sleep 미적용).
+ *
+ * `backgroundLocationTask`도 같은 키를 같은 방식으로 read한다 (`:101,129`).
+ */
+async function loadSleepModeFlag(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(SLEEP_MODE_KEY);
     if (!raw) return false;
     return JSON.parse(raw) === true;
   } catch {
@@ -872,6 +913,29 @@ async function fireWithGate(
   payload: SilentPushPayload & { kind: NonNullable<SilentPushPayload['kind']> },
   apnsToken: string | null,
 ): Promise<void> {
+  // #1399 — 좀비 알림 cleanup. backend가 push 발사 시점에 stamp한 active trip token이 device의
+  // ACTIVE_TRIP_KEY와 mismatch면 만료 token push로 판정해 drop. 시나리오: backend vanish + GPS
+  // 동결 + 트립 종료 → 종료 push 도착 → device cleanup → 지상 재진입 후 OS queue/네트워크에 잔존
+  // 하던 stale silent push가 늦게 도착해도 ACTIVE_TRIP_KEY가 null 또는 다른 token이면 발사 차단
+  // (S8 14:19 회귀). 구 backend(payload.tripToken 누락) 호환 — undefined면 가드 skip.
+  if (payload.tripToken !== undefined) {
+    const activeTripToken = await AsyncStorage.getItem(ACTIVE_TRIP_KEY);
+    if (activeTripToken === null || activeTripToken !== payload.tripToken) {
+      const logKind = payload.kind === 'intermediate' ? 'station-passed' : payload.kind;
+      logSilentPushSkipped({
+        stationName: payload.nextWaypoint,
+        kind: logKind,
+        phaseId: payload.phase,
+        reason: 'trip-token-mismatch',
+      });
+      ackOutcome(payload.pushId, apnsToken, 'skipped', 'trip-token-mismatch');
+      logger.info(
+        `trip-token mismatch skip: payload=${payload.tripToken.slice(0, 8)} active=${activeTripToken?.slice(0, 8) ?? 'null'} station=${payload.nextWaypoint}`,
+      );
+      return;
+    }
+  }
+
   // #707/#1322: line sanity-guard. nextWaypoint가 boarding 노선에 정차하는지 검증한다.
   // 노선 출처는 (1) 로컬 BoardingLock, 또는 (2) #1322 — backend lock-path fire가 실어 보낸
   // payload.boardingLine (지하 auto-lock hydration window 등으로 로컬 lock이 없는 경우).
@@ -906,33 +970,45 @@ async function fireWithGate(
     // #816 C — lock 없고 payload line도 없는 진짜 lockless 분기.
     // backend가 lockless trip의 station-passed(intermediate)만 발사하지만, race로 transfer/destination이
     // 도착하거나 토글 OFF로 변경된 직후의 push가 도달할 수 있어 client에서 추가 가드.
-    //   1) intermediate가 아니면 skip (trainCode 없이 알람 위치 보장 불가)
-    //   2) 토글 OFF면 skip (사용자 명시 동의 부재 → #640 회귀 차단)
-    // 둘 다 통과하면 line 가드 우회하고 일반 위치/movement 게이트로 진행.
-    if (payload.kind !== 'intermediate') {
-      logSilentPushSkipped({
-        stationName: payload.nextWaypoint,
-        kind: payload.kind,
-        phaseId: payload.phase,
-        reason: 'lockless-non-intermediate',
-      });
-      ackOutcome(payload.pushId, apnsToken, 'skipped', 'lockless-non-intermediate');
-      logger.info(
-        `lockless skip non-intermediate: kind=${payload.kind} station=${payload.nextWaypoint}`,
-      );
-      return;
-    }
+    //
+    // #1399 — kind 가드 제거. 사용자 명시 의향 trip(C 토글 ON / boardingPrompt 응답 /
+    // BoardingTrainList 직접 탭)은 lock 활성과 동급 정확도 보장 의무(ADR-013 §B3, ADR-014).
+    // 기존 `payload.kind !== 'intermediate'` skip은 lockless trip에서 destination/transfer 도착
+    // 알림을 구조적으로 차단했다 (S6/S8 14:10 군자/용마산 하차 알림 누락 회귀). lock 가드는
+    // 옵트인(loadLocklessOptIn) + 후속 line/위치/movement 게이트만으로도 충분 — kind 자체로
+    // 막지 않는다. backend도 본 PR에서 lockless destination/transfer를 발사하도록 함께 확장.
     const optedIn = await loadLocklessOptIn();
     if (!optedIn) {
+      const logKind = payload.kind === 'intermediate' ? 'station-passed' : payload.kind;
       logSilentPushSkipped({
         stationName: payload.nextWaypoint,
-        kind: 'station-passed',
+        kind: logKind,
         phaseId: payload.phase,
         reason: 'lockless-opt-out',
       });
       ackOutcome(payload.pushId, apnsToken, 'skipped', 'lockless-opt-out');
       logger.info(`lockless skip opt-out: station=${payload.nextWaypoint}`);
       return;
+    }
+    // #1399 — lockless transfer/destination 확장으로 도입된 sleep mode 회귀 차단.
+    // 기존 lockless 분기는 `intermediate`만 통과해 sleep + first transfer suppress 정책이 자연
+    // 비활성이었다. 이제 lockless에서 transfer/destination이 도달할 수 있으므로 BG에서도 sleep
+    // 정책을 명시 적용한다. `destination`은 절대 통과(종착역 놓치지 않게 — shouldSuppressBySleepRule
+    // 정책과 일치). `transfer`만 sleep 게이트 진입. lockless 첫 hop 판정은 payload.hopIndex===0으로
+    // 산출 — backend `runLocklessIntermediate`/vanish-fallback이 forward한 절대 시퀀스 SSOT.
+    if (payload.kind === 'transfer' && payload.hopIndex === 0) {
+      const sleepMode = await loadSleepModeFlag();
+      if (sleepMode) {
+        logSilentPushSkipped({
+          stationName: payload.nextWaypoint,
+          kind: payload.kind,
+          phaseId: payload.phase,
+          reason: 'sleep-first-transfer',
+        });
+        ackOutcome(payload.pushId, apnsToken, 'skipped', 'sleep-first-transfer');
+        logger.info(`lockless skip sleep-first-transfer: station=${payload.nextWaypoint}`);
+        return;
+      }
     }
   }
 

--- a/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
@@ -210,12 +210,25 @@ describe('scheduleHopsForLock', () => {
     expect(ids).toContain('bl:T-100:1:imminent:오금');
   });
 
-  it('multi-transfer: windowSize 3으로 잘림 — 4번째 waypoint(목적지)는 예약 안 됨', async () => {
+  it('multi-transfer: windowSize 기본=10이라 4 waypoint 모두 예약됨 (#1399)', async () => {
     await scheduleHopsForLock({ lock, route: multiRoute, destinationName: '온수' });
-    // targets = 교대, 약수, 한강진, 온수. window=3 → 온수 skip
+    // targets = 교대, 약수, 한강진, 온수. window=10 (#1399) → 모두 예약 → destination floor 보장.
     const ids = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
     expect(ids.some((id) => id.includes(':2:'))).toBe(true); // 한강진(idx=2)
-    expect(ids.some((id) => id.includes(':3:'))).toBe(false); // 온수(idx=3) skip
+    expect(ids.some((id) => id.includes(':3:'))).toBe(true); // 온수(idx=3) destination도 floor
+  });
+
+  it('multi-transfer: windowSize=3으로 명시 시 4번째 waypoint(목적지) skip', async () => {
+    // 기존 windowSize=3 동작 보존 — 명시 지정 시 그대로 적용. (advance 시 다음 hop 채워짐 가정 흐름)
+    await scheduleHopsForLock({
+      lock,
+      route: multiRoute,
+      destinationName: '온수',
+      windowSize: 3,
+    });
+    const ids = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
+    expect(ids.some((id) => id.includes(':2:'))).toBe(true);
+    expect(ids.some((id) => id.includes(':3:'))).toBe(false);
   });
 
   it('windowSize 인자로 더 작게 지정 가능', async () => {

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -148,7 +148,10 @@ export type AlarmLogReason =
   // #1357 (S1) — preschedule 진입 시 motion=stationary 확정으로 사전예약 schedule을 skip한 경우.
   // boardingLock/lockless 양쪽 path 공통. OS scheduleNotificationAsync 0회로 정적 trip 시작의
   // 첫 banner 발사를 차단한다. share dump에서 'schedule-skipped-motion-stationary' 카운트로 추적.
-  | 'schedule-skipped-motion-stationary';
+  | 'schedule-skipped-motion-stationary'
+  // #1399 — backend가 push에 stamp한 tripToken이 device ACTIVE_TRIP_KEY와 mismatch.
+  // 좀비 알림 cleanup: trip 종료 후 늦게 도착한 stale silent push 발사 차단(S8 14:19 회귀).
+  | 'trip-token-mismatch';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.

--- a/src/features/alarm/utils/boardingLockScheduler.ts
+++ b/src/features/alarm/utils/boardingLockScheduler.ts
@@ -47,8 +47,23 @@ const PHASE_INTERRUPTION: Record<AlarmPhaseId, 'active' | 'timeSensitive'> = {
   imminent: 'timeSensitive',
 };
 
-/** Per-Hop Adaptive Scheduling: 한 번에 큐에 두는 waypoint 수 (iOS 64 한도 안전). */
-const DEFAULT_WINDOW_SIZE = 3;
+/**
+ * Per-Hop Adaptive Scheduling: 한 번에 큐에 두는 waypoint 수 (iOS 64 한도 안전).
+ *
+ * #1399 — 3 → 10. 기존 3은 lock 활성 trip의 "다음 3 hop"만 floor로 깔아 destination/transfer 까지
+ * 사전 예약이 도달하지 못했다 (S6/S8 14:10 군자/용마산 vanish + GPS 동결 시 device floor 부족).
+ * 10으로 확장하면 평균 환승 trip(편당 hop 5~8)의 destination 까지 사전 예약이 깔린다.
+ *
+ * iOS 한도(64) 분배:
+ *  - bl:  10 stop × 2 phase = 20개
+ *  - tba: 20 stop × 2 phase = 40개 (TRIPBOUND_WINDOW_SIZE)
+ *  - 시스템 silent push delivery(1~2건) ≈ 4개
+ *  - 합 ≈ 64 — 안전 마진 좁지만 advance 시 cancel/refill로 rolling 유지.
+ *
+ * advance 시 `advanceHopWindow`가 다음 windowSize 만큼 채워 floor가 항상 유지된다. backend
+ * silent push가 끊겨도 device 측 OS local notification이 시간기반으로 매역/하차 알림을 발사한다.
+ */
+const DEFAULT_WINDOW_SIZE = 10;
 
 export interface BoardingLockAlarmIdParts {
   trainCode: string;


### PR DESCRIPTION
Part of #1396 (sub 3/6). Closes #1399.

## 변경 4개 (본문 그대로)

### 1. 시간기반 인계 확장 — backend vanish-fallback에서 destination 포함 발사
- `backend/alarm-worker/src/scheduled.ts:1093` — destination skip 가드 제거. 이제 vanish + hop 시간 경과 시 destination/transfer/intermediate 모든 kind에 대해 `fireVanishFallbackStationPush` 호출 → device 측 banner 발사 채널 확보.
- 기존엔 `advanceBoardingLockWaypoint`의 `cleanupTripWithLa` trip-ended push만 의존. vanish 상황(지하 + backend trainCode 누락)에서 trip-ended가 race로 지연/소실되면 종착역 하차 알림 누락(S6/S8 13:54·14:10 군자/용마산 회귀).

### 2. lockless kind 필터 제거 — frontend 사용자 명시 의향 trip 동급 보장
- `src/features/alarm/tasks/silentPushTask.ts:912` — lockless 분기의 `payload.kind !== 'intermediate'` skip 제거. lock 가드는 옵트인(`loadLocklessOptIn`) + 후속 line/위치/movement 게이트만으로 충분.
- ADR-013 §B3, ADR-014: C 토글 ON / boardingPrompt 응답 / BoardingTrainList 직접 탭 = lock 활성과 동급 정확도 보장 의무.
- backend `runLocklessIntermediate`는 여전히 intermediate만 발사 (별도 PR로 확장 검토). 본 변경은 device 측 방어선 완화로 future backend 확장에 대비.

### 3. 온디바이스 예약 floor 활성화 — windowSize 3 → 10
- `src/features/alarm/utils/boardingLockScheduler.ts:51` — `DEFAULT_WINDOW_SIZE = 10`. iOS 64 한도 분배: bl 20개 + tba 40개 + 시스템 ≈ 64.
- 평균 환승 trip(편당 hop 5~8)의 destination까지 사전 예약 floor 깔림. backend silent push가 끊겨도 device OS local notification이 시간기반으로 매역/하차 알림 발사.
- `advanceHopWindow`가 advance 시 다음 windowSize만큼 채워 floor 유지.

### 4. 좀비 알림 cleanup — tripToken stamp + ACTIVE_TRIP_KEY mismatch drop
- `backend/alarm-worker/src/apns.ts` `SilentPushPayload.tripToken` 추가 (optional).
- `backend/alarm-worker/src/scheduled.ts` `buildStationPassedImminentPayload` (vanish-fallback + arvlCd path 공유) + `runLocklessIntermediate` 모두 `trip.token` stamp.
- `src/features/alarm/tasks/silentPushTask.ts` `fireWithGate` 진입 즉시 `ACTIVE_TRIP_KEY` 비교 — null 또는 mismatch면 발사 차단 (`trip-token-mismatch` reason).
- `runTripBoundCleanups` (#1370 L4)가 ACTIVE_TRIP_KEY를 정리해놓은 후 늦게 도착한 stale push가 발사를 시도해도 본 가드가 차단 → 지상 재진입 시 좀비 알림 0건(S8 14:19 회귀).
- `src/features/alarm/utils/alarmLog.ts` `AlarmLogReason` 'trip-token-mismatch' 신규.

## 취침 회귀 점검 결과 (본문 요청)

- `shouldSuppressBySleepRule.ts:69-71` `isStationPassedFirstHop`은 lockless에서 `currentHopIndex === 0`을 사용 (stationPipeline 경로). 본 PR의 device 변경(silentPushTask)이 stationPipeline 흐름에 영향을 주지 않음 → 기존 lockless first-hop suppress 정책 그대로.
- **신규 도입**: silentPushTask 자체에 `payload.kind === 'transfer' && payload.hopIndex === 0`일 때 `loadSleepModeFlag()` 확인 → sleep ON이면 `sleep-first-transfer` reason으로 skip. 본 PR이 lockless에서 transfer 발사를 허용한 결과로 도입된 회귀 차단 게이트.
- `destination`은 절대 통과 (종착역 놓치지 않게 — `shouldSuppressBySleepRule` 정책과 일치).
- 테스트 케이스 5개로 검증: sleep ON + transfer hopIndex=0 → skip / destination hopIndex=0 → 통과 / transfer hopIndex=1 → 통과 / sleep OFF → 통과 / SLEEP_MODE_KEY read 오류 → 안전 fallback(가드 비활성).

## acceptance 매핑

- [x] trainCode vanish 시 destination/transfer 하차 알림 floor 발사 — 변경 1번 (backend vanish-fallback destination 포함) + 변경 3번 (device 사전예약 floor).
- [x] GPS 동결 + 백엔드 vanish 동시에도 매역/하차 floor 유지 — 변경 3번 (device OS local notification이 시간기반으로 발사).
- [x] trip 종료 후 좀비 알림 0건 — 변경 4번 (tripToken stamp + ACTIVE_TRIP_KEY mismatch drop).
- [x] 하차 알림 재발사(중복) 0건 — 기존 firedPushIds dedup + #1400 trainline-consistency 흐름 보존.
- [x] worker unit + client 커버리지 100% / type-check 통과 — frontend 5812/5812 · backend 1380/1380 · type-check clean.
- [x] 취침 ON × lockless × first hop suppress 회귀 0건 — 위 점검 결과 참조.

## 트레이드오프 (본문 그대로)

시간기반 floor는 실제 지연 미반영(정밀↓) ↔ 커버리지↑. 백엔드 실시간이 신호 회복 시 즉시 보정. Always 권한(연속 BG 측위) 비채택 — 온보딩 약속 + 지하 GPS 무의미.

## 검증

- `npm test` (frontend 5812/5812, 100% coverage)
- `npm run type-check` (frontend clean)
- `cd backend/alarm-worker && npm test` (1380/1380)
- 실기기 검증은 사용자 영역 (CLAUDE.md 룰 — epic close 조건은 실기기 1주 재발 0건).