### PR TITLE
chore(#1410): canonicalStationName 테스트 헬퍼 도입

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,7 @@ perf/#이슈번호-대상         예: perf/#139-map-clustering
 - 테마 의존 컴포넌트는 `renderWithTheme` (`src/testUtils/renderWithTheme.tsx`) 사용
 - 인터벌 테스트는 `jest.useFakeTimers()` 사용
 - barrel re-export 파일(`**/index.ts`)은 `collectCoverageFrom`에서 제외
+- 역명 hardcoding 금지 — base name(예: `'교대'`) assertion은 `canonicalStationName(base, line)` (`src/testUtils/canonicalStationName.ts`) 사용. stations.json BLDN_NM drift(#1410) 자동 흡수.
 
 ## 디렉토리 경계 룰 (ESLint)
 

--- a/src/testUtils/__tests__/canonicalStationName.test.ts
+++ b/src/testUtils/__tests__/canonicalStationName.test.ts
@@ -1,0 +1,32 @@
+import { canonicalStationName } from '../canonicalStationName';
+
+describe('canonicalStationName', () => {
+  it('정확 매칭이 있으면 그대로 반환한다 (괄호 없는 역)', () => {
+    expect(canonicalStationName('잠실나루', '2')).toBe('잠실나루');
+  });
+
+  it('base name으로 정식 표기(괄호 부제 포함)를 룩업한다', () => {
+    expect(canonicalStationName('교대', '2')).toBe('교대(법원.검찰청)');
+    expect(canonicalStationName('잠실', '2')).toBe('잠실(송파구청)');
+    expect(canonicalStationName('광화문', '5')).toBe('광화문(세종문화회관)');
+  });
+
+  it('같은 base가 여러 line에 있을 때 line별로 다른 정식명을 반환한다', () => {
+    // 교대는 2호선/3호선 환승역 — 두 line 모두 동일 정식 표기.
+    expect(canonicalStationName('교대', '2')).toBe('교대(법원.검찰청)');
+    expect(canonicalStationName('교대', '3')).toBe('교대(법원.검찰청)');
+  });
+
+  it('RENAME_MAP 박제된 케이스(7호선 자양)를 base로도 룩업할 수 있다', () => {
+    expect(canonicalStationName('자양', '7')).toBe('자양(뚝섬한강공원)');
+  });
+
+  it('stations.json에 없는 base는 base 그대로 fallback 한다', () => {
+    expect(canonicalStationName('존재하지않는역', '1')).toBe('존재하지않는역');
+  });
+
+  it('base 매칭은 line 일치 시에만 동작한다 (cross-line leak 방지)', () => {
+    // 교대는 2/3호선에만 존재. 1호선으로 찾으면 fallback.
+    expect(canonicalStationName('교대', '1')).toBe('교대');
+  });
+});

--- a/src/testUtils/canonicalStationName.ts
+++ b/src/testUtils/canonicalStationName.ts
@@ -1,0 +1,17 @@
+import { findStationByNameAndLine } from '../shared/utils/stationLookup';
+import type { LineNumber } from '../shared/types/station';
+
+/**
+ * 테스트에서 base name(예: '교대')으로 정식 표기(예: '교대(법원.검찰청)')를 룩업.
+ *
+ * stations.json은 Seoul Open API BLDN_NM 정식 표기를 SSOT로 사용하므로,
+ * 테스트가 base 문자열을 hardcoding하면 파이프라인 재실행마다 drift 발생.
+ * 이 헬퍼는 production `findStationByNameAndLine`(stationLookup.ts, #1405)에
+ * 위임하여 normalize + alias(예: 자양↔뚝섬유원지) + 괄호 부제 fallback 등
+ * canonical 매칭 규칙을 그대로 공유한다 — 테스트와 production 의미 정합성 1곳에서 보장.
+ *
+ * 매칭 실패 시 base 그대로 반환 (테스트 fallback).
+ */
+export function canonicalStationName(base: string, line: LineNumber): string {
+  return findStationByNameAndLine(base, line)?.name ?? base;
+}


### PR DESCRIPTION
Closes #1410

## 변경

### 1. `src/testUtils/canonicalStationName.ts` (신규)

base name(예: `'교대'`)으로 stations.json의 정식 표기(예: `'교대(법원.검찰청)'`)를 룩업하는 테스트 헬퍼.

production `findStationByNameAndLine`(stationLookup.ts, #1405)에 위임 — normalize + alias(예: 자양↔뚝섬유원지) + 괄호 부제 fallback canonical 매칭 규칙을 **1곳에서** 공유.

### 2. 단위 테스트 6 case
- exact 매칭 (괄호 없는 역) — 잠실나루
- 괄호 부제 정식 표기 룩업 — 교대/잠실/광화문
- 같은 base 다중 line — 교대 2호선/3호선
- RENAME_MAP alias — 자양↔뚝섬유원지
- stations.json 미존재 시 base fallback
- cross-line leak 방지 (line 일치 시에만 매칭)

### 3. `CLAUDE.md` 테스트 규칙 1줄
역명 hardcoding 금지, `canonicalStationName(base, line)` 사용 의무화.

## 배경 (PR #1409 사고)

`scripts/regenerate-stations.js` 파이프라인이 Seoul Open API BLDN_NM 정식 표기를 가져오면서 ~60개 역명이 base → 괄호 부제 포함으로 drift. 테스트 12개 파일·30+ case에서 hardcoded `'교대'`, `'잠실'` mechanical 교체 필요 — 30+분 비용.

이 헬퍼로 신규 테스트부터 drift-proof. 기존 테스트는 일괄 마이그레이션하지 않음 — 다음 drift 사고 시 만지는 파일만 점진 교체 (Surgical Changes 원칙).

## 코드 리뷰 P1 반영

초안은 헬퍼 안에서 매칭 규칙을 재구현했으나 production helper의 normalize+alias 축이 빠져 비대칭 → P1-1 지적. production 함수로 위임하는 1줄 구현으로 수정.

## acceptance

- [x] `canonicalStationName('교대', '2')` → `'교대(법원.검찰청)'`
- [x] `canonicalStationName('잠실나루', '2')` → `'잠실나루'` (괄호 없는 역 그대로)
- [x] `canonicalStationName('존재안함', '1')` → `'존재안함'` (fallback)
- [x] 같은 base 다중 line: 교대 2/3호선 각각 정식명 반환
- [x] cross-line scoping: 교대 1호선은 fallback
- [x] coverage 100% (5880 tests passing)
- [x] type-check clean