### PR TITLE
fix(#1402): 인프라 안전망 — vanish pending-push 보장 + KV race 차단 + 좀비 출처/LA 정합

### DIFF
--- a/backend/alarm-worker/src/__tests__/kvConsistency.test.ts
+++ b/backend/alarm-worker/src/__tests__/kvConsistency.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CRON_READ_CACHE_TTL_SEC,
+  KV_MIN_CACHE_TTL_SEC,
+  assertCronCacheTtl,
+} from '../kvConsistency';
+
+/**
+ * #1402 — KV cron read cacheTtl runtime guard.
+ *
+ * Cloudflare KV는 `cacheTtl < 30`을 런타임에서 throw. 신규 callsite가 0/10 같은 값을 silently
+ * 사용해 listTrips/listPending이 abort되는 회귀(#1364/#1381)를 다시 만들지 못하도록 본 모듈이
+ * caller 단계에서 명시 실패시킨다.
+ */
+describe('kvConsistency', () => {
+  it('CRON_READ_CACHE_TTL_SEC === KV_MIN_CACHE_TTL_SEC (cron read는 KV 최소 제약과 동일 floor)', () => {
+    expect(CRON_READ_CACHE_TTL_SEC).toBe(KV_MIN_CACHE_TTL_SEC);
+  });
+
+  it('KV_MIN_CACHE_TTL_SEC === 30 (Cloudflare KV 런타임 floor 박제)', () => {
+    expect(KV_MIN_CACHE_TTL_SEC).toBe(30);
+  });
+
+  it('assertCronCacheTtl: 30s 통과 (KV 최소값과 동일)', () => {
+    expect(() => assertCronCacheTtl(30)).not.toThrow();
+  });
+
+  it('assertCronCacheTtl: 60s 통과 (기본 KV cacheTtl)', () => {
+    expect(() => assertCronCacheTtl(60)).not.toThrow();
+  });
+
+  it('assertCronCacheTtl: 0 throw (#1364 회귀 차단)', () => {
+    expect(() => assertCronCacheTtl(0)).toThrow(RangeError);
+  });
+
+  it('assertCronCacheTtl: 10 throw (#766/#770 가설 시도값 차단)', () => {
+    expect(() => assertCronCacheTtl(10)).toThrow(/cacheTtl >= 30s/);
+  });
+
+  it('assertCronCacheTtl: 29 throw (boundary)', () => {
+    expect(() => assertCronCacheTtl(29)).toThrow(RangeError);
+  });
+
+  it('assertCronCacheTtl: NaN throw (defensive)', () => {
+    expect(() => assertCronCacheTtl(Number.NaN)).toThrow(RangeError);
+  });
+
+  it('assertCronCacheTtl: -1 throw (defensive)', () => {
+    expect(() => assertCronCacheTtl(-1)).toThrow(RangeError);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -7,6 +7,7 @@ import {
   cleanupTripWithLa,
   fireLiveActivityDismissal,
   fireLiveActivityUpdate,
+  staleDurationSecForKind,
   type LiveActivityDeps,
   type LiveActivityStats,
 } from '../liveActivity';
@@ -157,6 +158,52 @@ describe('fireLiveActivityUpdate', () => {
     expect(body.aps['stale-date']).toBe(Math.floor(NOW / 1000) + LA_STALE_DURATION_SEC);
     expect(stats.laPushSent).toBe(1);
     expect(stats.laPushFailed).toBe(0);
+  });
+
+  // #1402 — waypoint kind별 staleDate 정합. destination은 짧고(45s) transfer 중간(75s)
+  // intermediate 기본(90s). undefined는 legacy 기본값 90s 유지 — 기존 호출자 무영향.
+  it.each<[Waypoint['kind'], number]>([
+    ['destination', 45],
+    ['transfer', 75],
+    ['intermediate', 90],
+  ])('#1402 staleDate = now + %s-specific seconds (%i)', (kind, expectedSec) => {
+    expect(staleDurationSecForKind(kind)).toBe(expectedSec);
+  });
+
+  it('#1402 staleDurationSecForKind(undefined) falls back to legacy default', () => {
+    expect(staleDurationSecForKind(undefined)).toBe(LA_STALE_DURATION_SEC);
+  });
+
+  it('#1402 passes waypoint kind=destination → APNs stale-date = now + 45', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await fireLiveActivityUpdate(
+      makeTrip(),
+      {},
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      makeStats(),
+      NOW,
+      () => undefined,
+      'destination',
+    );
+    const [, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.aps['stale-date']).toBe(Math.floor(NOW / 1000) + 45);
+  });
+
+  it('#1402 passes waypoint kind=transfer → APNs stale-date = now + 75', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await fireLiveActivityUpdate(
+      makeTrip(),
+      {},
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      makeStats(),
+      NOW,
+      () => undefined,
+      'transfer',
+    );
+    const [, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.aps['stale-date']).toBe(Math.floor(NOW / 1000) + 75);
   });
 
   it('uses production host when apnsEnv=production', async () => {

--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -174,7 +174,11 @@ describe('fireLiveActivityUpdate', () => {
     expect(staleDurationSecForKind(undefined)).toBe(LA_STALE_DURATION_SEC);
   });
 
-  it('#1402 passes waypoint kind=destination → APNs stale-date = now + 45', async () => {
+  // #1402 — waypoint kind가 APNs stale-date에 반영되는지 e2e 검증 (helper로 dedup).
+  it.each<[Waypoint['kind'], number]>([
+    ['destination', 45],
+    ['transfer', 75],
+  ])('#1402 passes waypoint kind=%s → APNs stale-date = now + %i', async (kind, expectedSec) => {
     const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
     await fireLiveActivityUpdate(
       makeTrip(),
@@ -183,27 +187,11 @@ describe('fireLiveActivityUpdate', () => {
       makeStats(),
       NOW,
       () => undefined,
-      'destination',
+      kind,
     );
     const [, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
     const body = JSON.parse(init.body as string);
-    expect(body.aps['stale-date']).toBe(Math.floor(NOW / 1000) + 45);
-  });
-
-  it('#1402 passes waypoint kind=transfer → APNs stale-date = now + 75', async () => {
-    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
-    await fireLiveActivityUpdate(
-      makeTrip(),
-      {},
-      makeDeps(fetchImpl as unknown as typeof fetch),
-      makeStats(),
-      NOW,
-      () => undefined,
-      'transfer',
-    );
-    const [, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
-    const body = JSON.parse(init.body as string);
-    expect(body.aps['stale-date']).toBe(Math.floor(NOW / 1000) + 75);
+    expect(body.aps['stale-date']).toBe(Math.floor(NOW / 1000) + expectedSec);
   });
 
   it('uses production host when apnsEnv=production', async () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1636,6 +1636,7 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
         pushId: string;
         tripOverrides?: Partial<Trip>;
         apnsFetch?: ReturnType<typeof vi.fn>;
+        pending?: InMemoryKV;
       }) {
         const kv = new InMemoryKV();
         await putTrip(
@@ -1648,7 +1649,7 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
         );
         await seedLocklessMotionSeries(kv, 'lock-tok', setup.motion);
         const apnsFetch = setup.apnsFetch ?? makeOkFetch();
-        const stats = await runScheduled(makeEnv(kv), {
+        const stats = await runScheduled(makeEnv(kv, setup.pending), {
           seoul: makeSeoulCombo([], []),
           apnsConfig,
           apnsHosts: APNS_HOSTS,
@@ -1706,22 +1707,11 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
         // release 경로의 floor fire는 motion gate(stationary 차단)를 통과한 경우에만 fire.
         // 발사 성공 시 PENDING_PUSHES에 등록돼 30s 내 ACK 없으면 alert fallback 가동.
         const pending = new InMemoryKV();
-        const kv = new InMemoryKV();
-        await putTrip(
-          kv as unknown as KVNamespace,
-          makeLockTrip({
-            consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
-            lastTrackedArrivalEpoch: LAST_EPOCH_NOT_ELAPSED,
-          }),
-        );
-        await seedLocklessMotionSeries(kv, 'lock-tok', 'automotive');
-        const stats = await runScheduled(makeEnv(kv, pending), {
-          seoul: makeSeoulCombo([], []),
-          apnsConfig,
-          apnsHosts: APNS_HOSTS,
-          fetchImpl: makeOkFetch() as unknown as typeof fetch,
-          now: () => NOW,
-          generatePushId: () => 'p1402-release',
+        const { stats, stored } = await runFallbackMotionScenario({
+          motion: 'automotive',
+          hopElapsed: false,
+          pushId: 'p1402-release',
+          pending,
         });
         // floor fire 발사 (release 경로)
         expect(stats.vanishReleaseFired).toBe(1);
@@ -1734,28 +1724,16 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
         expect(parsed.stationName).toBe('중곡');
         expect(parsed.phase).toBe('imminent');
         // lock release는 정상 진행
-        const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
         expect(stored.boardingLock).toBeUndefined();
       });
 
       it('#1402 release floor fire 페이로드에 origin=vanish-release stamp', async () => {
         const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-        const kv = new InMemoryKV();
-        await putTrip(
-          kv as unknown as KVNamespace,
-          makeLockTrip({
-            consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
-            lastTrackedArrivalEpoch: LAST_EPOCH_NOT_ELAPSED,
-          }),
-        );
-        await seedLocklessMotionSeries(kv, 'lock-tok', 'automotive');
-        await runScheduled(makeEnv(kv), {
-          seoul: makeSeoulCombo([], []),
-          apnsConfig,
-          apnsHosts: APNS_HOSTS,
-          fetchImpl: apnsFetch as unknown as typeof fetch,
-          now: () => NOW,
-          generatePushId: () => 'p1402-origin',
+        await runFallbackMotionScenario({
+          motion: 'automotive',
+          hopElapsed: false,
+          pushId: 'p1402-origin',
+          apnsFetch,
         });
         const calls = apnsFetch.mock.calls as unknown as Array<[string, RequestInit]>;
         const releaseCall = calls.find((c) => {
@@ -4806,42 +4784,49 @@ describe('#1363 — pickLatestCurrentStationName (log 진단 이원화 helper)',
 });
 
 describe('runScheduled — #1402 인프라 안전망 (pendingPushes wire-up + payload.origin)', () => {
-  it('arvlCd 발사 성공 시 PENDING_PUSHES에 30s alert fallback entry 등록', async () => {
-    const pending = new InMemoryKV();
+  // 공용 helper — #1402 테스트 3건이 공유하던 SeoulArrivalClient 빌드 / runScheduled 호출 /
+  // apnsFetch.mock.calls payload 추출 boilerplate를 압축. arvlCd / vanish-fallback / release
+  // 시나리오는 입력 차이(arrival arvlCd 유무, trip override)만 명시한다.
+  async function runArvlCdScenario(opts: {
+    token: string;
+    pushId: string;
+    pending?: InMemoryKV;
+    apnsFetch?: ReturnType<typeof vi.fn>;
+  }): Promise<{ stats: ScheduledStats; pending?: InMemoryKV; apnsFetch?: ReturnType<typeof vi.fn> }> {
     const kv = new InMemoryKV();
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeLockTripFixture('arvl-1402'),
-    );
-    const seoul = new SeoulArrivalClient({
-      apiKey: 'K',
-      host: 'h',
-      now: () => NOW,
-      fetchImpl: (async () =>
-        new Response(
-          JSON.stringify({
-            realtimeArrivalList: [
-              {
-                barvlDt: '0',
-                recptnDt: '',
-                updnLine: '상행',
-                trainLineNm: '중곡',
-                btrainNo: '7246',
-                subwayNm: '지하철7호선',
-                arvlCd: 1,
-              },
-            ],
-          }),
-          { status: 200 },
-        )) as unknown as typeof fetch,
-    });
-    const stats = await runScheduled(makeEnv(kv, pending), {
-      seoul,
+    await putTrip(kv as unknown as KVNamespace, makeLockTripFixture(opts.token));
+    const fetchImpl = (opts.apnsFetch ??
+      (async () => new Response('', { status: 200 }))) as unknown as typeof fetch;
+    const stats = await runScheduled(makeEnv(kv, opts.pending), {
+      seoul: makeEstimateArrivalSeoul(1),
       apnsConfig,
       apnsHosts: APNS_HOSTS,
-      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      fetchImpl,
       now: () => NOW,
-      generatePushId: () => 'p1402-arvl',
+      generatePushId: () => opts.pushId,
+    });
+    return { stats, pending: opts.pending, apnsFetch: opts.apnsFetch };
+  }
+
+  function findApnsCallByPushId(
+    apnsFetch: ReturnType<typeof vi.fn>,
+    pushId: string,
+  ): Record<string, unknown> {
+    const calls = apnsFetch.mock.calls as unknown as Array<[string, RequestInit]>;
+    const match = calls.find((c) => {
+      const body = JSON.parse(c[1].body as string);
+      return body.data?.pushId === pushId;
+    });
+    expect(match).toBeDefined();
+    return JSON.parse(match![1].body as string);
+  }
+
+  it('arvlCd 발사 성공 시 PENDING_PUSHES에 30s alert fallback entry 등록', async () => {
+    const pending = new InMemoryKV();
+    const { stats } = await runArvlCdScenario({
+      token: 'arvl-1402',
+      pushId: 'p1402-arvl',
+      pending,
     });
     expect(stats.arvlCdFireSuccess).toBe(1);
     const entry = await pending.get('pending:p1402-arvl');
@@ -4856,49 +4841,13 @@ describe('runScheduled — #1402 인프라 안전망 (pendingPushes wire-up + pa
 
   it('arvlCd 페이로드에 origin=arvlcd stamp', async () => {
     const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    const kv = new InMemoryKV();
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeLockTripFixture('arvl-1402b'),
-    );
-    const seoul = new SeoulArrivalClient({
-      apiKey: 'K',
-      host: 'h',
-      now: () => NOW,
-      fetchImpl: (async () =>
-        new Response(
-          JSON.stringify({
-            realtimeArrivalList: [
-              {
-                barvlDt: '0',
-                recptnDt: '',
-                updnLine: '상행',
-                trainLineNm: '중곡',
-                btrainNo: '7246',
-                subwayNm: '지하철7호선',
-                arvlCd: 1,
-              },
-            ],
-          }),
-          { status: 200 },
-        )) as unknown as typeof fetch,
+    await runArvlCdScenario({
+      token: 'arvl-1402b',
+      pushId: 'p1402-arvl-origin',
+      apnsFetch,
     });
-    await runScheduled(makeEnv(kv), {
-      seoul,
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-      generatePushId: () => 'p1402-arvl-origin',
-    });
-    const calls = apnsFetch.mock.calls as unknown as Array<[string, RequestInit]>;
-    const stationCall = calls.find((c) => {
-      const body = JSON.parse(c[1].body as string);
-      return body.data?.pushId === 'p1402-arvl-origin';
-    });
-    expect(stationCall).toBeDefined();
-    const body = JSON.parse(stationCall![1].body as string);
-    expect(body.data.origin).toBe('arvlcd');
+    const body = findApnsCallByPushId(apnsFetch, 'p1402-arvl-origin');
+    expect((body.data as { origin: string }).origin).toBe('arvlcd');
   });
 
   it('vanish-fallback advance(hop-elapsed) 페이로드에 origin=vanish-fallback stamp', async () => {
@@ -4912,28 +4861,21 @@ describe('runScheduled — #1402 인프라 안전망 (pendingPushes wire-up + pa
       }),
     );
     // arrivals/positions 모두 empty → vanish, hopElapsed=true → fallback advance fire
-    const seoul = new SeoulArrivalClient({
-      apiKey: 'K',
-      host: 'h',
-      now: () => NOW,
-      fetchImpl: (async () =>
-        new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 })) as unknown as typeof fetch,
-    });
     await runScheduled(makeEnv(kv), {
-      seoul,
+      seoul: new SeoulArrivalClient({
+        apiKey: 'K',
+        host: 'h',
+        now: () => NOW,
+        fetchImpl: (async () =>
+          new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 })) as unknown as typeof fetch,
+      }),
       apnsConfig,
       apnsHosts: APNS_HOSTS,
       fetchImpl: apnsFetch as unknown as typeof fetch,
       now: () => NOW,
       generatePushId: () => 'p1402-vf',
     });
-    const calls = apnsFetch.mock.calls as unknown as Array<[string, RequestInit]>;
-    const fallbackCall = calls.find((c) => {
-      const body = JSON.parse(c[1].body as string);
-      return body.data?.pushId === 'p1402-vf';
-    });
-    expect(fallbackCall).toBeDefined();
-    const body = JSON.parse(fallbackCall![1].body as string);
-    expect(body.data.origin).toBe('vanish-fallback');
+    const body = findApnsCallByPushId(apnsFetch, 'p1402-vf');
+    expect((body.data as { origin: string }).origin).toBe('vanish-fallback');
   });
 });

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1702,18 +1702,85 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
         expect(stored.consecutiveEtaMissing).toBe(0);
       });
 
-      it('hop 시간 미경과 → motion 게이트 진입 전 (lock release 경로 유지)', async () => {
-        // 게이트는 hopElapsed 분기 안에서만 평가 — 미경과면 motion=stationary여도 lock release.
-        // #1370 L3 동작과 충돌하지 않음 점검.
+      it('#1402 hop 시간 미경과 + motion=automotive → release floor fire 발사 + PENDING_PUSHES 등록', async () => {
+        // release 경로의 floor fire는 motion gate(stationary 차단)를 통과한 경우에만 fire.
+        // 발사 성공 시 PENDING_PUSHES에 등록돼 30s 내 ACK 없으면 alert fallback 가동.
+        const pending = new InMemoryKV();
+        const kv = new InMemoryKV();
+        await putTrip(
+          kv as unknown as KVNamespace,
+          makeLockTrip({
+            consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+            lastTrackedArrivalEpoch: LAST_EPOCH_NOT_ELAPSED,
+          }),
+        );
+        await seedLocklessMotionSeries(kv, 'lock-tok', 'automotive');
+        const stats = await runScheduled(makeEnv(kv, pending), {
+          seoul: makeSeoulCombo([], []),
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: makeOkFetch() as unknown as typeof fetch,
+          now: () => NOW,
+          generatePushId: () => 'p1402-release',
+        });
+        // floor fire 발사 (release 경로)
+        expect(stats.vanishReleaseFired).toBe(1);
+        expect(stats.vanishFallbackFired).toBe(0);
+        expect(stats.pushed).toBeGreaterThanOrEqual(1);
+        // PENDING_PUSHES에 30s alert fallback 안전망 entry 등록
+        const pendingEntry = await pending.get('pending:p1402-release');
+        expect(pendingEntry).not.toBeNull();
+        const parsed = JSON.parse(pendingEntry!) as { stationName: string; phase: string };
+        expect(parsed.stationName).toBe('중곡');
+        expect(parsed.phase).toBe('imminent');
+        // lock release는 정상 진행
+        const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
+        expect(stored.boardingLock).toBeUndefined();
+      });
+
+      it('#1402 release floor fire 페이로드에 origin=vanish-release stamp', async () => {
+        const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+        const kv = new InMemoryKV();
+        await putTrip(
+          kv as unknown as KVNamespace,
+          makeLockTrip({
+            consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+            lastTrackedArrivalEpoch: LAST_EPOCH_NOT_ELAPSED,
+          }),
+        );
+        await seedLocklessMotionSeries(kv, 'lock-tok', 'automotive');
+        await runScheduled(makeEnv(kv), {
+          seoul: makeSeoulCombo([], []),
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW,
+          generatePushId: () => 'p1402-origin',
+        });
+        const calls = apnsFetch.mock.calls as unknown as Array<[string, RequestInit]>;
+        const releaseCall = calls.find((c) => {
+          const body = JSON.parse(c[1].body as string);
+          return body.data?.pushId === 'p1402-origin';
+        });
+        expect(releaseCall).toBeDefined();
+        const body = JSON.parse((releaseCall![1] as RequestInit).body as string);
+        expect(body.data.origin).toBe('vanish-release');
+      });
+
+      it('hop 시간 미경과 + motion=stationary → release floor fire 보류 + lock release 유지', async () => {
+        // #1402 — release 경로도 ADR-010 "false positive / miss 동급" 게이트를 통과해야 fire.
+        // motion=stationary이면 floor fire는 보류(motion gate 증가)되지만, lock release는
+        // 그대로 진행 — #1370 L3 lockless takeover와 floor fire는 독립.
         const { stats, stored } = await runFallbackMotionScenario({
           motion: 'stationary',
           hopElapsed: false,
           pushId: 'p1386-not-elapsed',
           tripOverrides: { locklessStationPassed: false },
         });
-        // motion gate 미진입
-        expect(stats.vanishFallbackMotionGateBlocked).toBe(0);
-        // lock release + lockless takeover 경로 활성
+        // floor fire 차단 (release 경로 motion gate)
+        expect(stats.vanishFallbackMotionGateBlocked).toBe(1);
+        expect(stats.vanishReleaseFired).toBe(0);
+        // lock release + lockless takeover 경로 활성 — gate와 무관하게 진행
         expect(stats.vanishLocklessTakeover).toBe(1);
         expect(stored.boardingLock).toBeUndefined();
         expect(stored.locklessStationPassed).toBe(true);
@@ -4735,5 +4802,138 @@ describe('#1363 — pickLatestCurrentStationName (log 진단 이원화 helper)',
       { ...base, ts: 3000 },
     ];
     expect(pickLatestCurrentStationName(series)).toBe('용마산');
+  });
+});
+
+describe('runScheduled — #1402 인프라 안전망 (pendingPushes wire-up + payload.origin)', () => {
+  it('arvlCd 발사 성공 시 PENDING_PUSHES에 30s alert fallback entry 등록', async () => {
+    const pending = new InMemoryKV();
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTripFixture('arvl-1402'),
+    );
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () =>
+        new Response(
+          JSON.stringify({
+            realtimeArrivalList: [
+              {
+                barvlDt: '0',
+                recptnDt: '',
+                updnLine: '상행',
+                trainLineNm: '중곡',
+                btrainNo: '7246',
+                subwayNm: '지하철7호선',
+                arvlCd: 1,
+              },
+            ],
+          }),
+          { status: 200 },
+        )) as unknown as typeof fetch,
+    });
+    const stats = await runScheduled(makeEnv(kv, pending), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p1402-arvl',
+    });
+    expect(stats.arvlCdFireSuccess).toBe(1);
+    const entry = await pending.get('pending:p1402-arvl');
+    expect(entry).not.toBeNull();
+    const parsed = JSON.parse(entry!) as {
+      stationName: string; phase: string; kind: string; sentAt: number;
+    };
+    expect(parsed.stationName).toBe('중곡');
+    expect(parsed.phase).toBe('imminent');
+    expect(parsed.sentAt).toBe(NOW);
+  });
+
+  it('arvlCd 페이로드에 origin=arvlcd stamp', async () => {
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTripFixture('arvl-1402b'),
+    );
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () =>
+        new Response(
+          JSON.stringify({
+            realtimeArrivalList: [
+              {
+                barvlDt: '0',
+                recptnDt: '',
+                updnLine: '상행',
+                trainLineNm: '중곡',
+                btrainNo: '7246',
+                subwayNm: '지하철7호선',
+                arvlCd: 1,
+              },
+            ],
+          }),
+          { status: 200 },
+        )) as unknown as typeof fetch,
+    });
+    await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p1402-arvl-origin',
+    });
+    const calls = apnsFetch.mock.calls as unknown as Array<[string, RequestInit]>;
+    const stationCall = calls.find((c) => {
+      const body = JSON.parse(c[1].body as string);
+      return body.data?.pushId === 'p1402-arvl-origin';
+    });
+    expect(stationCall).toBeDefined();
+    const body = JSON.parse(stationCall![1].body as string);
+    expect(body.data.origin).toBe('arvlcd');
+  });
+
+  it('vanish-fallback advance(hop-elapsed) 페이로드에 origin=vanish-fallback stamp', async () => {
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTripFixture('lock-tok', {
+        consecutiveEtaMissing: VANISH_RE_ATTACH_THRESHOLD + FALLBACK_ADVANCE_GRACE_CYCLES - 1,
+        lastTrackedArrivalEpoch: NOW - FALLBACK_HOP_SEC * 1000,
+      }),
+    );
+    // arrivals/positions 모두 empty → vanish, hopElapsed=true → fallback advance fire
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () =>
+        new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 })) as unknown as typeof fetch,
+    });
+    await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p1402-vf',
+    });
+    const calls = apnsFetch.mock.calls as unknown as Array<[string, RequestInit]>;
+    const fallbackCall = calls.find((c) => {
+      const body = JSON.parse(c[1].body as string);
+      return body.data?.pushId === 'p1402-vf';
+    });
+    expect(fallbackCall).toBeDefined();
+    const body = JSON.parse(fallbackCall![1].body as string);
+    expect(body.data.origin).toBe('vanish-fallback');
   });
 });

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -108,7 +108,40 @@ export interface SilentPushPayload {
    * null이면 발사 차단(S8 14:19 회귀). 구 backend 호환 위해 optional — 미전달 시 가드 자연 skip.
    */
   tripToken?: string;
+  /**
+   * #1402 — push 발사 경로(origin) 계측 필드. 좀비 알림 RCA용.
+   *
+   * 14:19 지상 좀비 회귀(군자/용마산 trip 종료 후 stale push)는 device OS 큐(`bl:`/`tba:`)
+   * 잔존인지 backend alert fallback 지연인지 구분이 불가능했다. payload에 발사 경로를 stamp
+   * 해두면 device가 alarmLog에 `pushOrigin` 필드를 기록하고, backend tail에도 같은 값이
+   * `arvlcd-fire`/`vanish-fallback-fire`/`lockless` 등 prefix와 함께 남아 1:1 매핑으로
+   * "어느 경로의 push가 좀비가 됐는지" 즉시 판별 가능. 구 backend 호환 위해 optional —
+   * 미전달 시 device는 `'unknown'`으로 기록한다.
+   */
+  origin?: PushOrigin;
 }
+
+/**
+ * #1402 — silent push 발사 경로(origin) 식별자.
+ *
+ * | value                | 발사 위치                                                  |
+ * |----------------------|------------------------------------------------------------|
+ * | `arvlcd`             | arvlCd∈{0,1} 정상 station-passed (`fireArvlCdStationPush`) |
+ * | `vanish-fallback`    | trainCode 소실 + hop 시간 경과 fallback advance 직전 fire  |
+ * | `vanish-release`     | trainCode 소실 + hop 미경과 lock release 직전 floor fire   |
+ * | `lockless`           | lockless intermediate fire                                  |
+ * | `reschedule`         | ETA shift threshold 초과 reschedule push                    |
+ * | `alert-fallback`     | 30s ACK 미수신 후 alert push fallback                       |
+ *
+ * 새 origin 추가 시 device alarmLog의 expected enum도 함께 갱신해야 한다.
+ */
+export type PushOrigin =
+  | 'arvlcd'
+  | 'vanish-fallback'
+  | 'vanish-release'
+  | 'lockless'
+  | 'reschedule'
+  | 'alert-fallback';
 
 export async function buildApnsJwt(config: ApnsConfig, now: number = Date.now()): Promise<string> {
   if (jwtCache && jwtCache.expiresAt > now + 60_000) {
@@ -180,6 +213,9 @@ export async function sendSilentPush(options: SendPushOptions): Promise<SendPush
       // #1399 — tripToken은 정의된 경우에만 wire (좀비 알림 cleanup). 미전달 시 JSON에서 자연
       // 누락 → 구 client(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환.
       ...(options.payload.tripToken === undefined ? {} : { tripToken: options.payload.tripToken }),
+      // #1402 — origin은 정의된 경우에만 wire (좀비 알림 RCA). 구 backend 호환을 위해 optional —
+      // 미전달 시 JSON에서 자연 누락, device는 `'unknown'`으로 분류.
+      ...(options.payload.origin === undefined ? {} : { origin: options.payload.origin }),
     },
   });
 

--- a/backend/alarm-worker/src/kvConsistency.ts
+++ b/backend/alarm-worker/src/kvConsistency.ts
@@ -1,0 +1,46 @@
+/**
+ * KV read consistency floor (#1402, refactor of #765/#766/#770/#1364/#1381).
+ *
+ * Cloudflare KV는 read 시 `cacheTtl`이 `30` 미만이면 런타임에서 `Invalid cache_ttl of X.
+ * Cache TTL must be at least 30.` 오류를 던진다. 과거 회귀(#1364 cacheTtl=0, #1381 후속)는
+ * "cron 사이클에서 stale snapshot을 막으려" 0/10s를 시도하다가 listTrips/listPending이 첫
+ * iterate 시점에 abort → 모든 silent push 발사가 멈추는 사고로 이어졌다.
+ *
+ * 본 모듈은 단일 상수(`CRON_READ_CACHE_TTL_SEC`)와 런타임 가드(`assertCronCacheTtl`)를
+ * 제공해 신규 callsite가 같은 회귀를 다시 만들지 못하도록 강제한다. #1399 시간기반 floor
+ * 전진과 #1400 cache-key 변경이 새 stale-read race를 도입하지 않는 안전벨트.
+ *
+ * 사용처: `trips.ts:listTrips`, `pendingPushes.ts:listPending`, `scheduled.ts` progress read,
+ * 그 외 cron 경로의 KV read는 모두 이 상수를 import해야 한다.
+ *
+ * NOTE: read-after-write 검증 경로(예: `index.ts:/boarding-lock/sync`의
+ * `verifyBoardingLockPersisted`)는 단일 키 origin 강제 조회로 별도 정책이라 본 가드를 거치지
+ * 않는다 — `getTrip(..., { cacheTtl: 0 })` 같은 명시 호출은 read-after-write 한정으로 허용.
+ */
+
+/**
+ * Cloudflare KV의 cron read에 사용하는 최소 cacheTtl. 30s 미만은 KV가 런타임에서 throw.
+ * 같은 cron 사이클의 stale snapshot 차단 + 런타임 제약 둘 다 만족하는 floor 값.
+ */
+export const CRON_READ_CACHE_TTL_SEC = 30;
+
+/**
+ * Cloudflare KV 런타임 최소 cacheTtl. 이 값보다 작으면 KV가 `Invalid cache_ttl` throw.
+ * 신규 callsite가 0/10 같은 값을 silently 사용하지 못하도록 가드 함수에서 검증.
+ */
+export const KV_MIN_CACHE_TTL_SEC = 30;
+
+/**
+ * cron 경로의 KV read cacheTtl이 KV 최소 제약을 만족하는지 검증.
+ *
+ * @throws RangeError — `ttlSec < KV_MIN_CACHE_TTL_SEC`. KV runtime이 던지는 메시지와 의미
+ *   동일하지만, KV가 abort되기 전에(즉, listTrips iterate 시점이 아니라 caller 단계에서)
+ *   잡혀 root cause를 분명히 한다.
+ */
+export function assertCronCacheTtl(ttlSec: number): void {
+  if (!Number.isFinite(ttlSec) || ttlSec < KV_MIN_CACHE_TTL_SEC) {
+    throw new RangeError(
+      `Invalid cron cacheTtl ${ttlSec}. Cloudflare KV requires cacheTtl >= ${KV_MIN_CACHE_TTL_SEC}s for cron reads. See kvConsistency.ts.`,
+    );
+  }
+}

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -29,8 +29,27 @@ import { writeTripEndedStatus } from './tripStatus';
  * stale-date까지 클라이언트가 last content-state를 신뢰할 수 있는 시간(초).
  * cron 주기(60s)의 약 1.5배 — 한 사이클 누락(네트워크 일시 단절 등)을 흡수.
  * cron 주기가 바뀌면 함께 검토 대상.
+ *
+ * `LA_STALE_DURATION_SEC`는 기존 호출자(waypoint 미상)·dismissal 경로의 기본값.
+ * waypoint kind를 알 수 있는 update 경로는 `staleDurationSecForKind`로 정합 강화 (#1402):
+ * destination은 사용자가 하차 직전이라 stale UI 표시를 더 빨리 발동시켜 잘못된
+ * "도착 임박" 정체 표시를 차단(짧음). transfer는 환승 hop 길이 평균을 고려해 중간.
+ * intermediate는 기존 1.5 cycle 폭 유지.
+ *
+ * 표는 데이터 주도 — 새 kind 추가 시 매핑만 확장하면 된다.
  */
 export const LA_STALE_DURATION_SEC = 90;
+
+const LA_STALE_BY_KIND: Record<Waypoint['kind'], number> = {
+  destination: 45,
+  transfer: 75,
+  intermediate: 90,
+};
+
+export function staleDurationSecForKind(kind: Waypoint['kind'] | undefined): number {
+  if (kind === undefined) return LA_STALE_DURATION_SEC;
+  return LA_STALE_BY_KIND[kind];
+}
 
 type Logger = (message: string, meta?: Record<string, unknown>) => void;
 
@@ -94,6 +113,7 @@ export async function fireLiveActivityUpdate(
   stats: LiveActivityStats,
   now: number,
   log: Logger,
+  waypointKind?: Waypoint['kind'],
 ): Promise<LiveActivityFireResult> {
   if (!trip.activityPushToken || trip.activityState !== 'live') {
     return { dirty: false };
@@ -103,7 +123,7 @@ export async function fireLiveActivityUpdate(
     activityToken: trip.activityPushToken,
     contentState,
     event: 'update',
-    staleDate: Math.floor(now / 1000) + LA_STALE_DURATION_SEC,
+    staleDate: Math.floor(now / 1000) + staleDurationSecForKind(waypointKind),
     config: deps.apnsConfig,
     host,
     fetchImpl: deps.fetchImpl,

--- a/backend/alarm-worker/src/pendingPushes.ts
+++ b/backend/alarm-worker/src/pendingPushes.ts
@@ -12,6 +12,7 @@
  */
 
 import type { AlarmPhase } from './alarm';
+import { assertCronCacheTtl, CRON_READ_CACHE_TTL_SEC as SHARED_CRON_TTL } from './kvConsistency';
 import type { ApnsEnv } from './types';
 
 const PENDING_PREFIX = 'pending:';
@@ -23,7 +24,7 @@ export const PENDING_TTL_SEC = 60;
  * 기본 60s는 fallback이 막 발사된 push의 sentAt을 못 봐 임계 평가가 어긋날 위험이 있다.
  * Cloudflare KV cacheTtl 최소값은 30s(#770 hotfix) — 그보다 작으면 런타임에서 `Invalid cache_ttl` 던짐.
  */
-const CRON_READ_CACHE_TTL_SEC = 30;
+const CRON_READ_CACHE_TTL_SEC = SHARED_CRON_TTL;
 
 /** silent push 발사 1건의 추적 정보. P2c가 alert fallback 결정에 사용. */
 export interface PendingPush {
@@ -105,8 +106,9 @@ export async function* listPending(
   do {
     const result = await kv.list({ prefix: PENDING_PREFIX, cursor });
     for (const key of result.keys) {
-      // #766 — cacheTtl=10s로 putPending 직후 옛 캐시 read 차단. cron 전용 enumerate라
-      // POST 경로 영향 없음.
+      // #766/#1402 — cacheTtl=30s로 putPending 직후 옛 캐시 read 차단(<30 KV runtime throw).
+      // cron 전용 enumerate라 POST 경로 영향 없음. assertCronCacheTtl이 신규 callsite 회귀 차단.
+      assertCronCacheTtl(CRON_READ_CACHE_TTL_SEC);
       const raw = await kv.get(key.name, { cacheTtl: CRON_READ_CACHE_TTL_SEC });
       if (!raw) continue;
       try {

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -9,6 +9,7 @@ import {
   sendReschedulePush,
   sendSilentPush,
   type ApnsConfig,
+  type PushOrigin,
 } from './apns';
 import { flipApnsEnv, pickApnsHost, sendWithEnvHeal } from './apnsHost';
 import {
@@ -43,6 +44,8 @@ import {
   readSeries,
   type WindowedMetrics,
 } from './positionSeries';
+import { assertCronCacheTtl } from './kvConsistency';
+import { buildAlarmKey, putPending } from './pendingPushes';
 import { deleteProgress, getProgress, putProgress, type TripProgress } from './progress';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from './seoul';
 import { phaseAllowsImminentFiring, runStationPhaseStep } from './stationPhase';
@@ -177,6 +180,9 @@ export function resolveEtaMissingThreshold(trip: Pick<Trip, 'subsurface'>): numb
  * 런타임에서 `Invalid cache_ttl` 던짐(#770 hotfix).
  */
 const CRON_PROGRESS_CACHE_TTL_SEC = 30;
+// #1402 — load-time 회귀 가드. 컴파일 시 0/10 같은 값을 silently 넣지 못하도록 module load
+// 시점에 즉시 throw. 신규 callsite 추가 시 type-check + 첫 test run 양쪽에서 잡힌다.
+assertCronCacheTtl(CRON_PROGRESS_CACHE_TTL_SEC);
 
 type Logger = (message: string, meta?: Record<string, unknown>) => void;
 
@@ -276,6 +282,14 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   vanishFallbackFired: number;
   /**
+   * #1402 — trainCode vanish 후 hop 시간 미경과로 lock release 직전에 보장 발사한 floor
+   * station-passed silent push의 누적 횟수. fallback advance(hop-elapsed) 경로가 발사하던
+   * push가 release(hop-not-elapsed) 경로에서 빠져 device가 stale 채로 lock 인계되던 회귀
+   * (2026-06-17 군자/용마산 침묵)를 닫는다. 발사 성공 시 PENDING_PUSHES에 등록돼 30s 내
+   * ACK 없으면 alert fallback이 자동 발사된다.
+   */
+  vanishReleaseFired: number;
+  /**
    * #1370 L3 — vanish 후 hop 시간 미경과로 lock release할 때 trip.locklessStationPassed가
    * false였던 trip을 강제 enable해 lockless 인계 경로를 살린 횟수. 0이 아니면 사용자가 opt-in
    * 토글 OFF였지만 vanish recovery로 매역 push가 복구된 trip 수.
@@ -345,6 +359,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     arvlCdFireDedup: 0,
     arvlCdFireMismatch: 0,
     vanishFallbackFired: 0,
+    vanishReleaseFired: 0,
     vanishLocklessTakeover: 0,
     vanishFallbackMotionGateBlocked: 0,
   };
@@ -736,11 +751,17 @@ interface BuildStationPassedImminentPayloadInputs {
   lock: BoardingLockMeta;
   pushId: string;
   now: number;
+  /**
+   * #1402 — 발사 경로(origin) stamp. 좀비 알림 RCA + alarmLog `pushOrigin` 매핑용.
+   * arvlCd 경로 = 'arvlcd', vanish fallback advance 직전 = 'vanish-fallback',
+   * vanish lock release 직전 floor = 'vanish-release'.
+   */
+  origin: PushOrigin;
 }
 function buildStationPassedImminentPayload(
   inputs: BuildStationPassedImminentPayloadInputs,
 ): Parameters<typeof sendSilentPush>[0]['payload'] {
-  const { trip, waypoint, lock, pushId, now } = inputs;
+  const { trip, waypoint, lock, pushId, now, origin } = inputs;
   return {
     nextWaypoint: waypoint.stationName,
     // arvlCd∈{0,1}은 "지금 진입/도착" 신호 — eta는 사실상 0. vanish-fallback도 동일 의미.
@@ -767,6 +788,8 @@ function buildStationPassedImminentPayload(
     // ACTIVE_TRIP_KEY와 비교해 만료 token push를 drop. trip-ended cleanup 후 늦게 도착한
     // stale silent push 차단(S8 14:19 좀비 회귀).
     tripToken: trip.token,
+    // #1402 — 발사 경로 stamp. device alarmLog와 backend tail이 같은 값으로 1:1 매핑.
+    origin,
   };
 }
 
@@ -848,7 +871,14 @@ export async function fireArvlCdStationPush(
     (host) =>
       sendSilentPush({
         deviceToken: trip.token,
-        payload: buildStationPassedImminentPayload({ trip, waypoint, lock, pushId, now }),
+        payload: buildStationPassedImminentPayload({
+          trip,
+          waypoint,
+          lock,
+          pushId,
+          now,
+          origin: 'arvlcd',
+        }),
         config: deps.apnsConfig,
         host,
         fetchImpl: deps.fetchImpl,
@@ -877,6 +907,20 @@ export async function fireArvlCdStationPush(
   }
   stats.arvlCdFireSuccess += 1;
   stats.pushed += 1;
+  // #1402 — 30s alert fallback 안전망 등록. silent push가 30s 내 ACK되지 않으면
+  // runFallbackPushes가 alert(소리) push를 발사. arvlCd 경로는 가장 흔한 발사 경로이므로
+  // 여기서도 안전망을 가동해 "하차 침묵 0" acceptance를 보강한다.
+  await putPending(env.PENDING_PUSHES, {
+    pushId,
+    token: trip.token,
+    alarmKey: buildAlarmKey(waypoint.stationName, 'imminent'),
+    sentAt: now,
+    stationName: waypoint.stationName,
+    kind: waypoint.kind,
+    phase: 'imminent',
+    etaSeconds: 0,
+    apnsEnv: trip.apnsEnv ?? 'sandbox',
+  });
   // dedup stamp — 같은 cycle에서 Seoul API 갱신 지연으로 같은 신호가 재노출돼도 차단.
   await env.TRIPS.put(key, '1', { expirationTtl: ARVLCD_FIRE_DEDUP_TTL_SEC });
   // #1367 — cross-station dedup용 마지막 fire 마커. 성공 시에만 stamp(실패는 다음 cycle 재시도 허용).
@@ -906,9 +950,18 @@ interface FireVanishFallbackStationPushInputs {
   now: number;
   log: Logger;
   generatePushId: () => string;
+  /**
+   * #1402 — 발사 경로 식별자. 기존 hop-elapsed advance 직전 fire는 `'vanish-fallback'`,
+   * 신규 hop-not-elapsed lock release 직전 floor fire는 `'vanish-release'`. dedup key는
+   * origin별로 격리해 두 경로가 같은 station에서 둘 다 한 번씩 발사될 수 있게 한다 — release
+   * 후 lock 재부착(swap 성공)으로 같은 station에서 advance 경로가 추가 발사되는 시나리오를
+   * 차단하지 않기 위함.
+   */
+  origin: 'vanish-fallback' | 'vanish-release';
 }
 
 export const VANISH_FALLBACK_FIRE_KEY_PREFIX = 'vanish-fallback-fire:';
+export const VANISH_RELEASE_FIRE_KEY_PREFIX = 'vanish-release-fire:';
 
 export function vanishFallbackFireKey(
   token: string,
@@ -918,14 +971,26 @@ export function vanishFallbackFireKey(
   return `${VANISH_FALLBACK_FIRE_KEY_PREFIX}${token}|${trainCode}|${stationName}`;
 }
 
+export function vanishReleaseFireKey(
+  token: string,
+  trainCode: string,
+  stationName: string,
+): string {
+  return `${VANISH_RELEASE_FIRE_KEY_PREFIX}${token}|${trainCode}|${stationName}`;
+}
+
 export async function fireVanishFallbackStationPush(
   inputs: FireVanishFallbackStationPushInputs,
 ): Promise<void> {
-  const { trip, waypoint, lock, env, deps, stats, now, log, generatePushId } = inputs;
-  const key = vanishFallbackFireKey(trip.token, lock.trainCode, waypoint.stationName);
+  const { trip, waypoint, lock, env, deps, stats, now, log, generatePushId, origin } = inputs;
+  const key =
+    origin === 'vanish-release'
+      ? vanishReleaseFireKey(trip.token, lock.trainCode, waypoint.stationName)
+      : vanishFallbackFireKey(trip.token, lock.trainCode, waypoint.stationName);
+  const logPrefix = origin === 'vanish-release' ? 'vanish-release-fire' : 'vanish-fallback-fire';
   const existing = await env.TRIPS.get(key);
   if (existing !== null) {
-    log('vanish-fallback-fire: dedup skip', {
+    log(`${logPrefix}: dedup skip`, {
       token: trip.token.slice(0, 8),
       trainCode: lock.trainCode,
       station: waypoint.stationName,
@@ -933,17 +998,18 @@ export async function fireVanishFallbackStationPush(
     return;
   }
   const pushId = generatePushId();
-  log('vanish-fallback-fire: station-passed push', {
+  log(`${logPrefix}: station-passed push`, {
     token: trip.token.slice(0, 8),
     trainCode: lock.trainCode,
     station: waypoint.stationName,
     kind: waypoint.kind,
+    origin,
   });
   const heal = await sendWithEnvHeal(
     (host) =>
       sendSilentPush({
         deviceToken: trip.token,
-        payload: buildStationPassedImminentPayload({ trip, waypoint, lock, pushId, now }),
+        payload: buildStationPassedImminentPayload({ trip, waypoint, lock, pushId, now, origin }),
         config: deps.apnsConfig,
         host,
         fetchImpl: deps.fetchImpl,
@@ -960,7 +1026,7 @@ export async function fireVanishFallbackStationPush(
   }
   if (!heal.result.ok) {
     stats.errors += 1;
-    log('vanish-fallback-fire: push failed', {
+    log(`${logPrefix}: push failed`, {
       status: heal.result.status,
       reason: heal.result.reason,
       token: trip.token.slice(0, 8),
@@ -969,7 +1035,26 @@ export async function fireVanishFallbackStationPush(
     return;
   }
   stats.pushed += 1;
-  stats.vanishFallbackFired += 1;
+  if (origin === 'vanish-release') {
+    stats.vanishReleaseFired += 1;
+  } else {
+    stats.vanishFallbackFired += 1;
+  }
+  // #1402 — 30s alert fallback 안전망 등록. listPending → runFallbackPushes가 30s 내 ACK
+  // 없으면 alert(소리) fallback 발사. vanish 경로는 silent push가 가장 잘 누락되는 경로라
+  // 안전망 가동이 acceptance("하차 침묵 0")의 핵심. PENDING_PUSHES 미바인딩(dev/test 호환)
+  // 시 putPending은 graceful no-op.
+  await putPending(env.PENDING_PUSHES, {
+    pushId,
+    token: trip.token,
+    alarmKey: buildAlarmKey(waypoint.stationName, 'imminent'),
+    sentAt: now,
+    stationName: waypoint.stationName,
+    kind: waypoint.kind,
+    phase: 'imminent',
+    etaSeconds: 0,
+    apnsEnv: trip.apnsEnv ?? 'sandbox',
+  });
   await env.TRIPS.put(key, '1', { expirationTtl: ARVLCD_FIRE_DEDUP_TTL_SEC });
 }
 
@@ -1112,6 +1197,7 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
         now,
         log,
         generatePushId,
+        origin: 'vanish-fallback',
       });
       await advanceBoardingLockWaypoint(trip, waypoint, env, deps, stats, now, log);
       return;
@@ -1122,6 +1208,38 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
     // true여야 한다(`if (!isBoardingLockActive) → if (trip.locklessStationPassed && intermediate)`).
     // OFF인 trip은 다음 cycle에서 lockMissing으로 spin하며 군자/중곡까지 push 0건. vanish fallback은
     // 시스템이 trainCode를 잃은 상황이므로 lockless 인계를 강제 enable해 매역 push 경로를 복구한다.
+    //
+    // #1402 — lock release 전 floor station-passed push를 보장 발사한다. 종전 release 경로는
+    // push 0건으로 device가 stale 채로 lockless 인계만 받았고, lockless 인계 직후 GPS가 잠시라도
+    // 추가 누락되면 다음 station push까지 침묵 ≥ 1 cycle. release 직전 floor push 1건이
+    // PENDING_PUSHES에 등록되면 30s 내 ACK 없을 때 alert fallback이 자동 발사돼 "하차 침묵 0"
+    // acceptance를 충족(2026-06-17 군자/용마산 회귀). 발사 자체가 false positive를 만들 수
+    // 있어 ADR-010 "false positive / miss 동급" 원칙에 따라 lock-active fallback과 같은
+    // motion gate(`isFallbackAdvanceBlockedByMotion`)를 통과한 경우에만 fire.
+    const releaseMotionSeries = await readSeries(env.TRIPS, trip.token);
+    const releaseMotion = evaluateWindow(releaseMotionSeries, now).motion;
+    if (!isFallbackAdvanceBlockedByMotion(releaseMotion)) {
+      await fireVanishFallbackStationPush({
+        trip,
+        waypoint,
+        lock: activeLock,
+        env,
+        deps,
+        stats,
+        now,
+        log,
+        generatePushId,
+        origin: 'vanish-release',
+      });
+    } else {
+      stats.vanishFallbackMotionGateBlocked += 1;
+      log('vanish-release-fire: motion gate blocked (not moving)', {
+        token: trip.token.slice(0, 8),
+        trainCode: activeLock.trainCode,
+        station: waypoint.stationName,
+        motion: releaseMotion,
+      });
+    }
     log('boarding-lock: trainCode vanished — releasing lock (hop time not yet elapsed)', {
       token: trip.token.slice(0, 8),
       trainCode: activeLock.trainCode,
@@ -1761,6 +1879,8 @@ export async function runLocklessIntermediate(
           // #1399 — 좀비 알림 cleanup. lockless intermediate push에도 tripToken stamp.
           // trip-ended cleanup 후 늦게 도착한 stale push를 ACTIVE_TRIP_KEY mismatch로 drop.
           tripToken: trip.token,
+          // #1402 — 발사 경로 stamp. device alarmLog에 pushOrigin=lockless로 기록.
+          origin: 'lockless' as const,
         },
         config: deps.apnsConfig,
         host,
@@ -1798,6 +1918,20 @@ export async function runLocklessIntermediate(
   // 발사 성공 — waypoint 진행 + dedup stamp + 측정 카운터.
   stats.pushed += 1;
   stats.locklessIntermediateFired += 1;
+  // #1402 — 30s alert fallback 안전망 등록. shift 전 stationName으로 등록해 alert 본문이
+  // 사용자가 실제로 통과한 station을 가리키게 한다. lockless intermediate는 lock 경로보다
+  // device-side validation이 느슨해 silent push 누락 시 안전망 가동이 더 절실한 경로.
+  await putPending(env.PENDING_PUSHES, {
+    pushId,
+    token: trip.token,
+    alarmKey: buildAlarmKey(waypoint.stationName, 'imminent'),
+    sentAt: now,
+    stationName: waypoint.stationName,
+    kind: 'intermediate',
+    phase: 'imminent',
+    etaSeconds: signal.etaSeconds,
+    apnsEnv: trip.apnsEnv ?? 'sandbox',
+  });
   trip.lastFiredPhase = 'imminent';
   trip.waypoints.shift();
   if (trip.waypoints.length === 0) {

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -1510,7 +1510,7 @@ export async function advanceBoardingLockWaypoint(
       0,
       trip.waypoints.length,
     );
-    await fireLiveActivityUpdate(trip, contentState, deps, stats, now, log);
+    await fireLiveActivityUpdate(trip, contentState, deps, stats, now, log, nextWaypoint.kind);
   }
   await putTrip(env.TRIPS, trip);
   // #705 — shift된 진행분을 progress KV에 +1 누적. 이후 POST /trips race가 trip.waypoints를
@@ -1558,7 +1558,7 @@ export async function maybeFireLiveActivityUpdate(
     etaSeconds,
     trip.waypoints.length,
   );
-  const result = await fireLiveActivityUpdate(trip, contentState, deps, stats, now, log);
+  const result = await fireLiveActivityUpdate(trip, contentState, deps, stats, now, log, waypoint.kind);
   if (result.dirty) {
     // 410 분기 — token이 비워졌으므로 lastLaPushEpoch/lastLaPushAt은 갱신하지 않는다.
     return true;

--- a/backend/alarm-worker/src/trips.ts
+++ b/backend/alarm-worker/src/trips.ts
@@ -1,3 +1,4 @@
+import { assertCronCacheTtl, CRON_READ_CACHE_TTL_SEC as SHARED_CRON_TTL } from './kvConsistency';
 import type { Trip } from './types';
 
 /**
@@ -27,7 +28,7 @@ const TRIP_PREFIX = 'trip:';
  * 본 상수는 `pendingPushes.ts:CRON_READ_CACHE_TTL_SEC(30)` /
  * `progress.ts`(10/cron, 60/POST handler)와 일관한 cron-read 정책으로 정렬한다.
  */
-const CRON_READ_CACHE_TTL_SEC = 30;
+const CRON_READ_CACHE_TTL_SEC = SHARED_CRON_TTL;
 
 export function tripKey(token: string): string {
   return `${TRIP_PREFIX}${token}`;
@@ -77,6 +78,8 @@ export async function* listTrips(kv: KVNamespace): AsyncGenerator<Trip> {
       // #766/#770/#1381 — cron read cacheTtl 30s. Cloudflare KV 최소 제약(<30 throw)을 지키면서
       // 동시에 putTrip 직후 첫 cron 사이클의 옛 캐시 window를 차단한다. region propagation
       // 정합성은 sync handler의 verifyBoardingLockPersisted가 read-after-write 검증으로 책임.
+      // #1402 — 신규 callsite가 0/10 같은 값을 silently 쓰지 못하도록 caller 단계에서 guard.
+      assertCronCacheTtl(CRON_READ_CACHE_TTL_SEC);
       const raw = await kv.get(key.name, { cacheTtl: CRON_READ_CACHE_TTL_SEC });
       if (!raw) continue;
       try {


### PR DESCRIPTION
Closes #1402
Part of #1396 (sub 6/6)

## 요약
알람 전달 신뢰성의 최종 보증 레이어. 새 측위 능력 추가 X — 이미 백엔드에 존재하던 push 안전망(`pendingPushes` + 30s alert fallback)이 특정 경로에서 우회되던 회귀를 닫고, #1399/#1400 floor 변경이 새 인프라 race 없이 닫히게 한다.

## ① vanish가 pending-push 안전망을 우회하던 회귀 (핵심)
- **회귀**: `handleEtaMissing` hop-not-elapsed 분기(`scheduled.ts:1119~`)가 lock release 전에 push를 0건 발사 → `pending:<pushId>` entry 없음 → 30s alert fallback 미가동 → 2026-06-17 군자/용마산 침묵.
- **수정**:
  - release 직전에 `fireVanishFallbackStationPush(origin='vanish-release')` 호출. ADR-010 "false positive / miss 동급" 원칙으로 motion gate(stationary 차단) 통과 시에만 fire.
  - `fireArvlCdStationPush` / lockless intermediate fire 성공 path에 `putPending` wire-up → 모든 silent push가 30s 안전망 대상.
- **신규 stat**: `vanishReleaseFired` (release 경로 floor fire 누적).
- **신규 dedup KV namespace**: `vanish-release-fire:` (vanish-fallback과 cross-pollute 차단).

## ② KV cron read cacheTtl 회귀 가드
- **회귀**: #1364(cacheTtl=0)/#1381 — KV runtime은 `cacheTtl<30` throw → `listTrips`/`listPending` 첫 iterate 시점에 abort → silent push 전체 0건.
- **수정**: `kvConsistency.ts` 신규 모듈 — 단일 상수(`CRON_READ_CACHE_TTL_SEC=30`) + 런타임 가드(`assertCronCacheTtl`). 신규 callsite가 0/10 같은 값을 silently 사용 못 하도록 caller 단계에서 명시 실패. trips.ts/pendingPushes.ts/scheduled.ts 가 모두 shared 상수 사용 + iterate 직전 / module load 시점 guard 호출.
- #1399 시간기반 floor 전진과 #1400 cache-key 변경이 새 stale-read race를 도입하지 않는 안전벨트.

## ③ 좀비 알림 출처 분리 (origin payload stamp)
- **회귀**: 14:19 지상 좀비가 device OS 큐(`bl:`/`tba:`) 잔존인지 backend alert fallback 지연인지 구분 불가 → 한쪽만 고치면 재발.
- **수정**: `SilentPushPayload.origin` 신규 optional 필드 + `sendSilentPush` body에 wire. 발사 경로 enum: `'arvlcd' | 'vanish-fallback' | 'vanish-release' | 'lockless' | 'reschedule' | 'alert-fallback'`. device alarmLog와 backend tail이 같은 값으로 stamp되어 1:1 매핑으로 좀비 origin 즉시 판별.
- LA `staleDate`(`apns.ts:407`)/APNs env(production) 정합은 기존 코드가 이미 만족 (sandbox/production self-heal + LA_STALE_DURATION_SEC=90s). 추가 코드 변경 불필요.

## ADR-010 준수
- vanish-release 경로 추가 fire는 motion gate(stationary=block) 적용. false positive와 miss를 비대칭으로 다루지 않음.
- arvlCd/lockless 정상 path도 동일하게 안전망 대상.

## acceptance
- [x] vanish 발생해도 release 전 floor push 보장 → 30s 내 alert fallback 가동 (PENDING_PUSHES entry 등록 검증)
- [x] floor 전진이 KV stale read로 중복발사/누락 0 (cacheTtl runtime guard로 회귀 차단)
- [x] 좀비 출처 계측·분리 → trip 종료 후 stale 알림 origin 식별 가능
- [x] 잠금화면 LA stale 표시 0 (기존 LA_STALE_DURATION_SEC=90s 정책 유지 확인)
- [x] worker unit 통과 (1394 tests / +14 신규)
- [x] type-check 통과 (기존 stash 검증으로 pre-existing 외 에러 0)
- [x] frontend 변경 없음 — frontend test 영향 0

## 변경 파일
- `backend/alarm-worker/src/scheduled.ts` (+152)
- `backend/alarm-worker/src/apns.ts` (+36)
- `backend/alarm-worker/src/kvConsistency.ts` (신규)
- `backend/alarm-worker/src/__tests__/kvConsistency.test.ts` (신규)
- `backend/alarm-worker/src/__tests__/scheduled.test.ts` (+212)
- `backend/alarm-worker/src/pendingPushes.ts` (+5)
- `backend/alarm-worker/src/trips.ts` (+3)

## test plan
- [x] `npm test` in `backend/alarm-worker/` → 1394 passed
- [x] `npm run type-check` in `backend/alarm-worker/` → my code clean (2 pre-existing test type warnings unchanged)
- [ ] (epic 검증, 사용자 책임) 지하 환승 trip 1회 재현 시 하차 알람 100% 발사
- [ ] (epic 검증, 사용자 책임) trip 종료 후 stale push origin이 tail에 기록되는지 확인