### PR TITLE
fix(#1413): DebugModal Share dump 누락 6개 섹션 추가

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -42,7 +42,11 @@ import {
   exportRecentDays,
 } from '../../../features/alarm/utils/boardingPromptMonitor';
 import { useBoardingLockStore } from '../../../features/alarm/store/useBoardingLockStore';
-import { isBoardingLockExpired } from '../../../shared/types/boardingLock';
+import {
+  BOARDING_LOCK_EXPIRY_FACTOR,
+  isBoardingLockExpired,
+  type BoardingLock,
+} from '../../../shared/types/boardingLock';
 import {
   clearEstimatorEntries,
   getEstimatorEntries,
@@ -381,6 +385,20 @@ interface BuildDumpArgs {
    * 미전달 시 (empty)로 출력 — 단위 테스트에서 fusion log를 다루지 않는 경우 호환.
    */
   fusionLog?: readonly FusionDebugEntry[];
+  /**
+   * #1413 — BoardingLock 섹션 dump 입력. lock 활성/trainCode/boardingLine/expiresAt.
+   * 미전달이면 lock=null과 동일(active=no)로 출력.
+   */
+  boardingLock?: BoardingLock | null;
+  /**
+   * #1413 — Estimator State buffer entries. 미전달/빈 배열은 (empty)로 출력.
+   */
+  estimatorLog?: readonly EstimatorDebugEntry[];
+  /**
+   * #1413 — boardingPrompt 카운터·acceptance / Counters 등 시간 기반 집계의 기준 시각.
+   * 미전달 시 `Date.now()` 사용. 테스트에서 결정적 출력 확보용.
+   */
+  nowMs?: number;
 }
 
 /** dump 본체에서 사용하는 single builder 시그니처 — 본문 줄 배열을 반환. */
@@ -535,6 +553,77 @@ function buildFusionLogSection(args: BuildDumpArgs): string[] {
 }
 
 /**
+ * #1413 — BoardingLock 섹션. UI BoardingLockSection과 동일 필드를 dump key=value 형태로.
+ * lock 없으면 `active=no` 1줄만.
+ */
+function buildBoardingLockSection(args: BuildDumpArgs): string[] {
+  const lock = args.boardingLock ?? null;
+  const now = args.nowMs ?? Date.now();
+  const active = lock !== null && !isBoardingLockExpired(lock, now);
+  const lines: string[] = [`active=${active ? 'yes' : 'no'}`];
+  if (lock) {
+    lines.push(
+      `trainCode=${lock.trainCode}`,
+      `line=${lock.boardingLine}`,
+      `expiresAt=${formatAt(lock.boardedAt + lock.expectedDurationMs * BOARDING_LOCK_EXPIRY_FACTOR)}`,
+      `boardedAt=${formatAt(lock.boardedAt)}`,
+    );
+    if (lock.hydratedFromSentinel) lines.push('sentinel=yes');
+  }
+  return lines;
+}
+
+/**
+ * #1413 — Estimator State 섹션. Fusion log와 동일 컨벤션 (빈 buffer=(empty), 최신이 위).
+ */
+function buildEstimatorSection(args: BuildDumpArgs): string[] {
+  const entries = args.estimatorLog ?? [];
+  if (entries.length === 0) return ['(empty)'];
+  return [...entries].reverse().map(formatEstimatorLine);
+}
+
+/**
+ * #1413 — Boarding Prompt 발사 빈도 카운터 (5m / 1h / all).
+ */
+function buildBoardingPromptSection(args: BuildDumpArgs): string[] {
+  const counts = countBoardingPromptByWindow(args.logs, args.nowMs ?? Date.now());
+  return BOARDING_PROMPT_WINDOWS.map(({ key, label }) => `boardingPrompt(${label})=${counts[key]}`);
+}
+
+/**
+ * #1413 — Boarding Prompt Acceptance dashboard.
+ * displayed/responded/boarded/dismissed + 응답률·탑승률 + 최근 7일 시계열.
+ */
+function buildBoardingPromptAcceptanceSection(args: BuildDumpArgs): string[] {
+  const stats = computeBoardingPromptMonitor(args.logs);
+  const rows = exportRecentDays(stats, RECENT_DAYS, args.nowMs ?? Date.now());
+  const lines: string[] = [
+    `displayed=${stats.displayed}`,
+    `responded=${stats.responded}`,
+    `boarded=${stats.boarded}`,
+    `dismissed=${stats.dismissed}`,
+    `responseRate=${formatRatePct(stats.responseRatePct)}`,
+    `boardedRate=${formatRatePct(stats.boardedRatePct)}`,
+    `recent ${RECENT_DAYS}d (day / disp / resp / brd / dis):`,
+  ];
+  for (const row of rows) {
+    lines.push(
+      `${row.dayKey} | ${row.displayed} / ${row.responded} / ${row.boarded} / ${row.dismissed}`,
+    );
+  }
+  return lines;
+}
+
+/**
+ * #1413 — Counters 섹션. reason별 누적 + 마지막 발생 시각.
+ */
+function buildCountersSection(args: BuildDumpArgs): string[] {
+  const counters = summarizeAlarmLogCounters(args.logs);
+  if (counters.length === 0) return ['(empty)'];
+  return counters.map(({ reason, count, lastTs }) => `${reason}=${count}x (${formatTime(lastTs)})`);
+}
+
+/**
  * #1346 — Share dump SSOT.
  *
  * 출력 형식: `## ${title}` + 본문 줄 + 다음 섹션 사이 빈 줄.
@@ -570,6 +659,14 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
     suffix: (args) => (args.scheduledDump == null ? '' : ` (${args.scheduledDump.length})`),
   },
   { title: 'Gates', build: buildGatesSection, omitIfEmpty: true },
+  // #1413 — BoardingLock dump. lock vs lockless 구분이 dump 본문만으로 확인 가능해야 한다.
+  { title: 'BoardingLock', build: buildBoardingLockSection },
+  // #1413 — Estimator buffer. lockless trip 진행도 사후 재구성용.
+  {
+    title: 'Estimator State',
+    build: buildEstimatorSection,
+    suffix: (args) => ` (${args.estimatorLog?.length ?? 0})`,
+  },
   {
     title: 'Alarm log',
     build: buildAlarmLogSection,
@@ -581,6 +678,12 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
     build: buildFusionLogSection,
     suffix: (args) => ` (${args.fusionLog?.length ?? 0})`,
   },
+  // #1413 — boardingPrompt 발사 빈도 카운터(5m/1h/all).
+  { title: 'Boarding Prompt', build: buildBoardingPromptSection },
+  // #1413 — boardingPrompt acceptance dashboard (displayed/responded/rates + 7일 시계열).
+  { title: 'Boarding Prompt Acceptance', build: buildBoardingPromptAcceptanceSection },
+  // #1413 — reason별 누적 + 마지막 발생 시각.
+  { title: 'Counters', build: buildCountersSection },
 ];
 
 function buildDumpText(args: BuildDumpArgs): string {
@@ -878,6 +981,9 @@ function DebugModalInner({
       sleep,
       // #1346 — fusion log entries를 share에 포함. sticky cascade 같은 회귀 사후 재구성용.
       fusionLog: fusionLogs,
+      // #1413 — UI에만 노출되던 BoardingLock/Estimator/Boarding Prompt(+Acceptance)/Counters를 share에 포함.
+      boardingLock: lock,
+      estimatorLog: estimatorLogs,
     });
     void Share.share({ message });
   }, [
@@ -912,6 +1018,9 @@ function DebugModalInner({
     sleep,
     // #1346 — fusion log 신규 캡쳐.
     fusionLogs,
+    // #1413 — BoardingLock/Estimator 신규 캡쳐.
+    lock,
+    estimatorLogs,
   ]);
 
   return (
@@ -1320,7 +1429,7 @@ function BoardingLockSection({
           <KeyValue
             label="expiresAt"
             value={formatAt(
-              lock.boardedAt + lock.expectedDurationMs * 1.5,
+              lock.boardedAt + lock.expectedDurationMs * BOARDING_LOCK_EXPIRY_FACTOR,
             )}
             colors={colors}
           />

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -2321,6 +2321,12 @@ describe('DebugModal share SSOT (#1346)', () => {
     expect(dump).toContain('## Scheduled queue');
     expect(dump).toContain('## Alarm log');
     expect(dump).toContain('## Fusion log');
+    // #1413 — UI에만 노출되던 5개 섹션이 share dump에 포함되어야 한다.
+    expect(dump).toContain('## BoardingLock');
+    expect(dump).toContain('## Estimator State');
+    expect(dump).toContain('## Boarding Prompt');
+    expect(dump).toContain('## Boarding Prompt Acceptance');
+    expect(dump).toContain('## Counters');
     // suppressed reason 없으면 Gates 헤더 자체 생략(omitIfEmpty=true).
     expect(dump).not.toContain('## Gates');
   });
@@ -2394,13 +2400,219 @@ describe('DebugModal share SSOT (#1346)', () => {
     );
     expect(dump).toContain('## Fusion log (3)');
     // 최신(ts3) 먼저 — Alarm log와 동일 정렬.
-    const fusionSection = dump.slice(dump.indexOf('## Fusion log'));
+    // #1413 — Fusion log 뒤에 추가된 섹션과 격리 위해 다음 `## ` 헤더까지로 자른다.
+    const fusionStart = dump.indexOf('## Fusion log');
+    const nextHeader = dump.indexOf('\n## ', fusionStart + 1);
+    const fusionSection = nextHeader === -1 ? dump.slice(fusionStart) : dump.slice(fusionStart, nextHeader);
     expect(fusionSection).toContain('src=position-train');
     expect(fusionSection).toContain('gps-fix');
     expect(fusionSection).toContain('sticky:locked');
     // 본문 라인 3건 — 헤더 다음의 줄 수가 3.
     const bodyLines = fusionSection.split('\n').slice(1).filter((l) => l.length > 0);
     expect(bodyLines).toHaveLength(3);
+  });
+
+  // #1413 — 누락된 5개 섹션이 dump 본문에 정확한 값으로 흐르는지 검증.
+  describe('#1413 누락 섹션', () => {
+    it('BoardingLock: lock=null이면 active=no만 출력', () => {
+      const dump = __test__.buildDumpText(makeSsotArgs());
+      const section = dump.slice(dump.indexOf('## BoardingLock'));
+      expect(section).toContain('active=no');
+      expect(section).not.toContain('trainCode=');
+    });
+
+    it('BoardingLock: lock 활성이면 trainCode/line/expiresAt/boardedAt 노출', () => {
+      const boardedAt = new Date('2026-06-17T13:00:00Z').getTime();
+      const dump = __test__.buildDumpText(
+        makeSsotArgs({
+          nowMs: boardedAt + 60_000,
+          boardingLock: {
+            trainCode: '7152',
+            boardingLine: '7',
+            boardedAt,
+            expectedDurationMs: 30 * 60 * 1000,
+            boardingStationId: '728',
+            destinationId: '2-022',
+          },
+        }),
+      );
+      const section = dump.slice(
+        dump.indexOf('## BoardingLock'),
+        dump.indexOf('## Estimator State'),
+      );
+      expect(section).toContain('active=yes');
+      expect(section).toContain('trainCode=7152');
+      expect(section).toContain('line=7');
+      expect(section).toContain('expiresAt=');
+      expect(section).toContain('boardedAt=');
+      expect(section).not.toContain('sentinel=yes');
+    });
+
+    it('BoardingLock: hydratedFromSentinel=true면 sentinel=yes 라인 추가', () => {
+      const boardedAt = new Date('2026-06-17T13:00:00Z').getTime();
+      const dump = __test__.buildDumpText(
+        makeSsotArgs({
+          nowMs: boardedAt + 60_000,
+          boardingLock: {
+            trainCode: '7152',
+            boardingLine: '7',
+            boardedAt,
+            expectedDurationMs: 30 * 60 * 1000,
+            boardingStationId: '728',
+            destinationId: '2-022',
+            hydratedFromSentinel: { destinationId: 'FREE_TRIP_SENTINEL', sentinelAt: 0 },
+          },
+        }),
+      );
+      const section = dump.slice(
+        dump.indexOf('## BoardingLock'),
+        dump.indexOf('## Estimator State'),
+      );
+      expect(section).toContain('sentinel=yes');
+    });
+
+    it('BoardingLock: lock 만료되었으면 active=no', () => {
+      const boardedAt = new Date('2026-06-17T13:00:00Z').getTime();
+      // expectedDurationMs * 1.5 = 45분. 1시간 후면 만료.
+      const dump = __test__.buildDumpText(
+        makeSsotArgs({
+          nowMs: boardedAt + 60 * 60 * 1000,
+          boardingLock: {
+            trainCode: '7152',
+            boardingLine: '7',
+            boardedAt,
+            expectedDurationMs: 30 * 60 * 1000,
+            boardingStationId: '728',
+            destinationId: '2-022',
+          },
+        }),
+      );
+      const section = dump.slice(
+        dump.indexOf('## BoardingLock'),
+        dump.indexOf('## Estimator State'),
+      );
+      expect(section).toContain('active=no');
+      // 만료여도 lock 본문은 출력 — 진단용.
+      expect(section).toContain('trainCode=7152');
+    });
+
+    it('Estimator State: 빈 buffer면 (empty) + 카운트 0', () => {
+      const dump = __test__.buildDumpText(makeSsotArgs());
+      expect(dump).toContain('## Estimator State (0)');
+      const section = dump.slice(
+        dump.indexOf('## Estimator State'),
+        dump.indexOf('## Alarm log'),
+      );
+      expect(section).toContain('(empty)');
+    });
+
+    it('Estimator State: 2건 데이터 → 최신이 위 (Fusion log와 동일 컨벤션)', () => {
+      const ts1 = new Date('2026-06-17T13:00:00Z').getTime();
+      const ts2 = new Date('2026-06-17T13:00:10Z').getTime();
+      const dump = __test__.buildDumpText(
+        makeSsotArgs({
+          estimatorLog: [
+            { ts: ts1, strategy: 'default-hop', stationName: '용마산', stationLine: '7', arcIndex: 0 },
+            { ts: ts2, strategy: 'reanchored-hop', stationName: '사가정', stationLine: '7', arcIndex: 1 },
+          ],
+        }),
+      );
+      expect(dump).toContain('## Estimator State (2)');
+      const section = dump.slice(
+        dump.indexOf('## Estimator State'),
+        dump.indexOf('## Alarm log'),
+      );
+      const lines = section.split('\n').filter((l) => l.includes('idx='));
+      expect(lines).toHaveLength(2);
+      // 최신(reanchored-hop / 사가정)이 위쪽.
+      expect(lines[0]).toContain('reanchored-hop');
+      expect(lines[1]).toContain('default-hop');
+    });
+
+    it('Boarding Prompt: 5m/1h/all 카운터를 dump에 노출', () => {
+      const now = new Date('2026-06-17T13:00:00Z').getTime();
+      const dump = __test__.buildDumpText(
+        makeSsotArgs({
+          nowMs: now,
+          logs: [
+            // 1m 전 fired (5m, 1h, all 모두 +1)
+            { ts: now - 60_000, source: 'boarding-prompt', outcome: 'fired', stationName: '7·용마산' },
+            // 30m 전 fired (1h, all +1)
+            { ts: now - 30 * 60_000, source: 'boarding-prompt', outcome: 'fired', stationName: '7·중곡' },
+          ],
+        }),
+      );
+      const section = dump.slice(
+        dump.indexOf('## Boarding Prompt\n'),
+        dump.indexOf('## Boarding Prompt Acceptance'),
+      );
+      expect(section).toContain('boardingPrompt(5m)=1');
+      expect(section).toContain('boardingPrompt(1h)=2');
+      expect(section).toContain('boardingPrompt(all)=2');
+    });
+
+    it('Boarding Prompt Acceptance: 응답률·탑승률 + 최근 7일 시계열', () => {
+      const now = new Date('2026-06-17T13:00:00Z').getTime();
+      const dump = __test__.buildDumpText(
+        makeSsotArgs({
+          nowMs: now,
+          logs: [
+            // 2 displayed, 1 boarded, 0 dismissed → responseRate=50%, boardedRate=100%
+            { ts: now - 60_000, source: 'boarding-prompt', outcome: 'fired', stationName: '7·용마산' },
+            { ts: now - 90_000, source: 'boarding-prompt', outcome: 'fired', stationName: '7·중곡' },
+            { ts: now - 30_000, source: 'boarding-prompt', outcome: 'received', reason: 'response-boarded' },
+          ],
+        }),
+      );
+      const section = dump.slice(
+        dump.indexOf('## Boarding Prompt Acceptance'),
+        dump.indexOf('## Counters'),
+      );
+      expect(section).toContain('displayed=2');
+      expect(section).toContain('responded=1');
+      expect(section).toContain('boarded=1');
+      expect(section).toContain('dismissed=0');
+      expect(section).toContain('responseRate=50.0%');
+      expect(section).toContain('boardedRate=100.0%');
+      expect(section).toContain('recent 7d (day / disp / resp / brd / dis):');
+      // 7일치 → 7줄 노출 (모두 출력, 0건 포함).
+      const dayLines = section.split('\n').filter((l) => /^\d{4}-\d{2}-\d{2} \|/.test(l));
+      expect(dayLines).toHaveLength(7);
+    });
+
+    it('Boarding Prompt Acceptance: displayed=0이면 rate 모두 — 표기', () => {
+      const dump = __test__.buildDumpText(makeSsotArgs());
+      const section = dump.slice(
+        dump.indexOf('## Boarding Prompt Acceptance'),
+        dump.indexOf('## Counters'),
+      );
+      expect(section).toContain('displayed=0');
+      expect(section).toContain('responseRate=—');
+      expect(section).toContain('boardedRate=—');
+    });
+
+    it('Counters: 비어있으면 (empty) 출력', () => {
+      const dump = __test__.buildDumpText(makeSsotArgs());
+      const section = dump.slice(dump.indexOf('## Counters'));
+      expect(section).toContain('(empty)');
+    });
+
+    it('Counters: reason별 누적 + 마지막 발생 시각 출력', () => {
+      const ts1 = new Date('2026-06-17T13:00:00Z').getTime();
+      const ts2 = new Date('2026-06-17T13:00:10Z').getTime();
+      const dump = __test__.buildDumpText(
+        makeSsotArgs({
+          logs: [
+            { ts: ts1, source: 'bg', outcome: 'suppressed', reason: 'gate-out-of-range' },
+            { ts: ts2, source: 'bg', outcome: 'suppressed', reason: 'gate-out-of-range' },
+            { ts: ts2, source: 'fg', outcome: 'suppressed', reason: 'movement-static-speed' },
+          ],
+        }),
+      );
+      const section = dump.slice(dump.indexOf('## Counters'));
+      expect(section).toContain('gate-out-of-range=2x');
+      expect(section).toContain('movement-static-speed=1x');
+    });
   });
 
   it('DebugModal share button: fusion log buffer가 share 텍스트에 흐른다 (#1346)', async () => {


### PR DESCRIPTION
## Summary
- UI에만 노출되던 5개 섹션을 Share dump 텍스트에도 추가
  - BoardingLock, Estimator State, Boarding Prompt, Boarding Prompt Acceptance, Counters
- `BOARDING_LOCK_EXPIRY_FACTOR` 상수 사용으로 dump/UI 만료 시각 계산 SSOT 통합
- 11개 테스트 추가, coverage 100% 유지

## 회귀 evidence
2026-06-17 사용자 trip dump (텍스트-EAD4F155E36D-1.txt) 분석 중 발견:
- `received=0/fired=0`만으로는 lock vs lockless 구분 불가 → BoardingLock 섹션 필요
- boardingPrompt acceptance counter가 dump에 없어 응답률·탑승률 텍스트 기반 분석 불가
- Counters 누락 → reason별 누적 추세 dump만으로 추적 불가

이 PR은 #1389 통합 정합성 게이트 evidence 수집 prerequisite — origin 출처 분리 acceptance 측정을 위해 dump가 모든 채널 데이터를 포함해야 한다.

## Test plan
- [x] `npm test` — 5891/5891 pass, coverage 100%
- [x] `npm run type-check` — pass
- [x] `npm run lint` — pass
- [x] code-reviewer agent 실행 (1.5 magic number 지적 반영)
- [ ] 사용자 실기기 Share dump → 6개 섹션 모두 노출 확인

Closes #1413