### PR TITLE
fix(#1416): 정적 FG fg fire path cascade 차단 — distanceInterval=5

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
@@ -226,7 +226,9 @@ describe('useNearestStation', () => {
     expect(Location.watchPositionAsync).toHaveBeenCalledTimes(2);
   });
 
-  it('watchPositionAsync에 High·distanceInterval:0·timeInterval:2000을 전달한다', async () => {
+  it('watchPositionAsync에 High·distanceInterval:5·timeInterval:2000을 전달한다', async () => {
+    // #1416 — surface는 distanceInterval=5(m)로 GPS jitter callback을 native에서 차단한다.
+    // BG task TRACKING_DISTANCE_INTERVAL_M=20m 패턴 검증 후 보수적 적용.
     mockGranted();
 
     renderHook(() => useNearestStation());
@@ -236,7 +238,7 @@ describe('useNearestStation', () => {
     expect(Location.watchPositionAsync).toHaveBeenCalledWith(
       {
         accuracy: Location.Accuracy.High,
-        distanceInterval: 0,
+        distanceInterval: 5,
         timeInterval: 2000,
       },
       expect.any(Function),
@@ -1265,7 +1267,7 @@ describe('useNearestStation — #1313 subsurface GPS throttle', () => {
   // 지상 기본값: High@2s. 지하 throttle: Balanced@12s. interval은 상수에서 가져와 매직넘버 회피.
   const SURFACE_OPTIONS = {
     accuracy: Location.Accuracy.High,
-    distanceInterval: 0,
+    distanceInterval: 5,
     timeInterval: FG_WATCH_SURFACE_TIME_INTERVAL_MS,
   };
   const SUBSURFACE_OPTIONS = {

--- a/src/features/nearest-station/hooks/useNearestStation.ts
+++ b/src/features/nearest-station/hooks/useNearestStation.ts
@@ -41,10 +41,13 @@ const MIN_DISTANCE_CHANGE_KM = 0.003; // 3m — UI 갱신을 자주 흘려보낸
 
 // #1313 — subsurface 여부로 갈리는 FG watch 옵션. accuracy 선택 + interval을 한 데이터로 묶어
 // startWatch가 throttle boolean만 보고 분기 없이 선택하게 한다(하드코딩 분기 회피).
-// distanceInterval:0은 두 모드 공통 — 시간 기반 샘플링만 쓰고 거리 게이트는 적용하지 않는다.
+// #1416 — surface는 distanceInterval=5(m)로 GPS jitter callback을 native 단에서 차단한다.
+// 정적 FG 21분에 ~170건 fg fire path cascade(gate-hop-window suppress)가 관측됐고, BG task가
+// TRACKING_DISTANCE_INTERVAL_M=20m 패턴으로 검증된 메커니즘이라 5m는 보수적 적용이다.
+// subsurface(distanceInterval=0)는 지하 indoor positioning에 매 fix가 필요하므로 유지한다.
 const FG_WATCH_OPTIONS_SURFACE: Location.LocationOptions = {
   accuracy: Location.Accuracy.High,
-  distanceInterval: 0,
+  distanceInterval: 5,
   timeInterval: FG_WATCH_SURFACE_TIME_INTERVAL_MS,
 };
 const FG_WATCH_OPTIONS_SUBSURFACE: Location.LocationOptions = {


### PR DESCRIPTION
## Summary

- 정적 FG 21분 측정에서 ~170건 `gate-hop-window` suppress cascade 관측. root cause는 `useNearestStation.ts:47` `distanceInterval: 0` → iOS Core Location distanceFilter 비활성 → GPS jitter(±10m)가 매 2초 callback → useStationAlarm 5 effect의 `userLocation?.lat/lng` primitive deps가 매번 변경 → effect 진입 → gate-hop-window suppress.
- 본 PR은 surface FG watch options의 `distanceInterval`을 0→5(m)로 변경해 native 단에서 jitter callback을 차단한다. subsurface(`distanceInterval: 0`)는 지하 indoor positioning에 매 fix가 필요해 그대로 유지.
- BG task가 이미 `TRACKING_DISTANCE_INTERVAL_M=20m` 패턴으로 검증된 메커니즘이라 5m는 보수적 적용.

Closes #1416

## 변경 파일

- `src/features/nearest-station/hooks/useNearestStation.ts` — `FG_WATCH_OPTIONS_SURFACE.distanceInterval: 0` → `5`. 주석에 #1416 컨텍스트 추가.
- `src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts` — surface assertion 2개 업데이트(`distanceInterval: 5`).

## PR-B(useStationAlarm short-circuit) 분리 결정

플랜 옵션 C(A+B)에서 옵션 A만 적용. 이유:

- 5 effect 모두 `route` / `destination?.id` / `destinationArrival` / `currentStationArrival` / `dismissSilence` / `currentHopIndex` / `arcStations` / `subsurfaceStationDetected` 등 stationId 외 다양한 reactive deps를 가짐.
- 플랜이 제안한 키 `${stationId}:${accuracyBucket}:${hydrationPhase}`는 이런 deps 변경 시 legitimate 재평가를 잘못 차단할 위험. 안전한 키는 사실상 모든 deps를 포함해야 하는데 그러면 React의 deps 배열과 중복.
- root cause인 GPS jitter 자체가 distanceInterval=5로 native에서 사라지므로 cascade의 95%+가 해소될 것으로 예상. 1주 실측 후 잔존 시 재진단.

## 테스트 결과

- `npm run type-check` — pass.
- `npx jest src/features/nearest-station src/features/alarm/hooks` — 1562/1562 pass.
- 사전 존재하는 로컬 jest 실패(`widgetStorage.test.ts`, `stationNotification.test.ts` — 35건)는 본 PR과 무관. dev 기준 동일하게 실패하며 CI는 green. (RN native module 로컬 환경 이슈)

## 잠재 위험

- 🟡 저속 보행(<1m/s) — 5m 이동까지 5~10초 callback 지연. 지하철 trip은 무영향(60km/h → 0.3초). 도보 환승 시 station 단위(800m 간격) 대비 0.6%로 미미.
- 🟢 sticky unlock 1km — 5m 해상도로 충분.
- 🟢 정적 판정 60m threshold — 5m sample로 robust.

## Test plan

- [ ] CI green (Type Check & Test + Data Validation)
- [ ] 사용자 실기기 정적 FG 30분 측정 — `gate-hop-window` suppress 카운트 <10건 (현재 ~170건)
- [ ] 사용자 실기기 도보 환승 1m/s — sticky unlock 정상, station detect 정상
- [ ] 사용자 실기기 지하철 정상 trip — 매역 알림 정상 fire
- [ ] 1주 alarm log ring buffer 정적 상태로 묻혀가지 않는지 관측