### PR TITLE
fix(#1419): boardingPrompt displayed BG drain — AppState active + 마운트 drain

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingPromptDisplayLogger.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptDisplayLogger.test.ts
@@ -1,9 +1,10 @@
 /* eslint-disable import/no-restricted-paths --
  * Cross-feature orchestration test — Phase 5 file-level disable opt-in.
- * (#1385)
+ * (#1385 / #1419)
  */
 import * as Notifications from 'expo-notifications';
-import { renderHook } from '@testing-library/react-native';
+import { AppState, type AppStateStatus } from 'react-native';
+import { renderHook, waitFor } from '@testing-library/react-native';
 import {
   useBoardingPromptDisplayLogger,
   wasBoardingPromptDisplayed,
@@ -14,6 +15,7 @@ import { BOARDING_PROMPT_CATEGORY } from '../../utils/notificationCategory';
 
 jest.mock('expo-notifications', () => ({
   addNotificationReceivedListener: jest.fn(),
+  getPresentedNotificationsAsync: jest.fn().mockResolvedValue([]),
 }));
 jest.mock('../../utils/alarmLog', () => ({
   logBoardingPromptFired: jest.fn(),
@@ -56,13 +58,16 @@ function makeNotification(overrides: {
   };
 }
 
-describe('useBoardingPromptDisplayLogger (#1385)', () => {
+describe('useBoardingPromptDisplayLogger (#1385 / #1419)', () => {
   let registeredHandler: ((notification: any) => void) | null = null;
+  let appStateHandler: ((state: AppStateStatus) => void) | null = null;
   const subscriptionRemove = jest.fn();
+  const appStateRemove = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
     registeredHandler = null;
+    appStateHandler = null;
     __resetBoardingPromptDisplayedDedup();
     (Notifications.addNotificationReceivedListener as jest.Mock).mockImplementation(
       (handler) => {
@@ -70,6 +75,16 @@ describe('useBoardingPromptDisplayLogger (#1385)', () => {
         return { remove: subscriptionRemove };
       },
     );
+    (Notifications.getPresentedNotificationsAsync as jest.Mock).mockResolvedValue([]);
+    jest
+      .spyOn(AppState, 'addEventListener')
+      .mockImplementation(((
+        _event: string,
+        handler: (state: AppStateStatus) => void,
+      ) => {
+        appStateHandler = handler;
+        return { remove: appStateRemove };
+      }) as unknown as typeof AppState.addEventListener);
   });
 
   it('FG receive listener를 등록한다', () => {
@@ -78,10 +93,11 @@ describe('useBoardingPromptDisplayLogger (#1385)', () => {
     expect(registeredHandler).not.toBeNull();
   });
 
-  it('unmount 시 subscription remove', () => {
+  it('unmount 시 subscription + AppState listener 둘 다 remove', () => {
     const { unmount } = renderHook(() => useBoardingPromptDisplayLogger());
     unmount();
     expect(subscriptionRemove).toHaveBeenCalled();
+    expect(appStateRemove).toHaveBeenCalled();
   });
 
   it('BOARDING_PROMPT category notification 수신 시 logBoardingPromptFired 호출', () => {
@@ -163,5 +179,75 @@ describe('useBoardingPromptDisplayLogger (#1385)', () => {
     expect(wasBoardingPromptDisplayed('m-2')).toBe(true);
     __resetBoardingPromptDisplayedDedup();
     expect(wasBoardingPromptDisplayed('m-2')).toBe(false);
+  });
+
+  // #1419 — BG 발사 drain (presented tray)
+  it('마운트 시 presented tray drain 1회 호출 + BOARDING_PROMPT 적재', async () => {
+    (Notifications.getPresentedNotificationsAsync as jest.Mock).mockResolvedValue([
+      makeNotification({ identifier: 'bg-1' }),
+    ]);
+    renderHook(() => useBoardingPromptDisplayLogger());
+    await waitFor(() => {
+      expect(logBoardingPromptFired).toHaveBeenCalledTimes(1);
+    });
+    expect(wasBoardingPromptDisplayed('bg-1')).toBe(true);
+  });
+
+  it('AppState active 진입 시 drain — BG로 받은 prompt가 displayed로 적재', async () => {
+    renderHook(() => useBoardingPromptDisplayLogger());
+    await waitFor(() => expect(appStateHandler).not.toBeNull());
+    (Notifications.getPresentedNotificationsAsync as jest.Mock).mockResolvedValue([
+      makeNotification({ identifier: 'bg-2' }),
+    ]);
+    appStateHandler!('active');
+    await waitFor(() => {
+      expect(logBoardingPromptFired).toHaveBeenCalledWith({ originStation: '강남', line: '2' });
+    });
+    expect(wasBoardingPromptDisplayed('bg-2')).toBe(true);
+  });
+
+  it('AppState background 진입 시에는 drain 안 함', async () => {
+    renderHook(() => useBoardingPromptDisplayLogger());
+    await waitFor(() => expect(appStateHandler).not.toBeNull());
+    (Notifications.getPresentedNotificationsAsync as jest.Mock).mockClear();
+    appStateHandler!('background');
+    expect(Notifications.getPresentedNotificationsAsync).not.toHaveBeenCalled();
+  });
+
+  it('drain — FG receive와 동일 identifier는 dedup으로 중복 적재 X', async () => {
+    renderHook(() => useBoardingPromptDisplayLogger());
+    await waitFor(() => expect(registeredHandler).not.toBeNull());
+    registeredHandler!(makeNotification({ identifier: 'dup-1' }));
+    expect(logBoardingPromptFired).toHaveBeenCalledTimes(1);
+    (Notifications.getPresentedNotificationsAsync as jest.Mock).mockResolvedValue([
+      makeNotification({ identifier: 'dup-1' }),
+    ]);
+    appStateHandler!('active');
+    await waitFor(() => {
+      // 추가 호출 없음 — 첫 호출 1회만 유지.
+      expect(logBoardingPromptFired).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('drain — BOARDING_PROMPT 외 category는 skip', async () => {
+    (Notifications.getPresentedNotificationsAsync as jest.Mock).mockResolvedValue([
+      makeNotification({ identifier: 'other-1', categoryIdentifier: 'OTHER_CATEGORY' }),
+    ]);
+    renderHook(() => useBoardingPromptDisplayLogger());
+    await waitFor(() => {
+      expect(Notifications.getPresentedNotificationsAsync).toHaveBeenCalled();
+    });
+    expect(logBoardingPromptFired).not.toHaveBeenCalled();
+  });
+
+  it('drain — getPresentedNotificationsAsync 예외 swallow', async () => {
+    (Notifications.getPresentedNotificationsAsync as jest.Mock).mockRejectedValue(
+      new Error('tray boom'),
+    );
+    expect(() => renderHook(() => useBoardingPromptDisplayLogger())).not.toThrow();
+    await waitFor(() => {
+      expect(Notifications.getPresentedNotificationsAsync).toHaveBeenCalled();
+    });
+    expect(logBoardingPromptFired).not.toHaveBeenCalled();
   });
 });

--- a/src/features/alarm/hooks/useBoardingPromptDisplayLogger.ts
+++ b/src/features/alarm/hooks/useBoardingPromptDisplayLogger.ts
@@ -6,7 +6,7 @@
  * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
  */
 /**
- * #1385 — boardingPrompt displayed wire-up.
+ * #1385 / #1419 — boardingPrompt displayed wire-up.
  *
  * #1021에서 추가된 `logBoardingPromptFired`가 production 호출자가 없어 DebugModal
  * "Boarding Prompt" 카운터와 acceptance dashboard(displayed 의존)가 영원히 0/null로
@@ -16,12 +16,17 @@
  *      BOARDING_PROMPT_CATEGORY면 `logBoardingPromptFired` 호출 + dedup set 등록.
  *   2) BG cold-start로 FG receive를 못 잡은 케이스는 `useBoardingPromptResponder`의 response
  *      listener에서 dedup set 체크 후 보완 적재 (이 파일이 export하는 helper 사용).
+ *   3) #1419 — BG 수신분은 addNotificationReceivedListener가 replay하지 않는다. AppState 'active'
+ *      진입 시 `getPresentedNotificationsAsync` 로 tray를 drain해 미적재 BOARDING_PROMPT를 흡수.
+ *      `scheduledAlarmReceiver.drainDeliveredScheduledAlarms`와 동형 패턴. 7일간 displayed=0
+ *      회귀의 root cause는 (2)에서 사용자가 응답 안 한 BG 수신분이 모두 누락되던 케이스.
  *
  * dedup key는 `notification.request.identifier`. set은 모듈 스코프 in-memory — 앱 재시작 시
  * reset되지만 fired entry는 영구 alarm log AsyncStorage에 적재되므로 누적 손실 없음.
  */
 
 import { useEffect } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
 import * as Notifications from 'expo-notifications';
 import { BOARDING_PROMPT_CATEGORY } from '../utils/notificationCategory';
 import { logBoardingPromptFired } from '../utils/alarmLog';
@@ -59,34 +64,73 @@ export function __resetBoardingPromptDisplayedDedup(): void {
 }
 
 /**
- * FG receive listener — BOARDING_PROMPT category notification 수신 시 displayed 적재.
+ * notification 1건에 대해 displayed 적재(+dedup). FG receive listener와 BG drain 양쪽이 공유.
+ *
+ * categoryIdentifier가 null인 케이스(Android 등)는 FG receive에서는 skip 하지만 drain에서는
+ * payload schema가 일치하면 적재한다. drain은 명시적으로 BOARDING_PROMPT만 필터링하므로
+ * 호출 전 caller가 category를 검증한다.
+ */
+function tryLogDisplayed(notification: Notifications.Notification): void {
+  try {
+    const request = notification.request;
+    const content = request.content;
+    if (content.categoryIdentifier !== BOARDING_PROMPT_CATEGORY) return;
+    const payload = extractBoardingPromptPayload(content.data);
+    if (!payload) return;
+    const identifier = request.identifier;
+    if (typeof identifier !== 'string' || identifier.length === 0) return;
+    if (displayedIdentifiers.has(identifier)) return;
+    displayedIdentifiers.add(identifier);
+    logBoardingPromptFired({
+      originStation: payload.originStation,
+      line: payload.line,
+    });
+  } catch (err) {
+    // listener/drain 콜백은 절대 throw 금지 — 오작동 시 silent log만.
+    log.warn('boarding-prompt displayed 적재 실패', err as Error);
+  }
+}
+
+/**
+ * #1419 — BG 발사 drain. presented tray에서 BOARDING_PROMPT_CATEGORY notification을 읽어
+ * 미적재 분만 displayed로 누적한다. AppState 'active' 진입 시점 + 마운트 시점에 호출한다.
+ *
+ * `scheduledAlarmReceiver.drainDeliveredScheduledAlarms`와 동형 — addNotificationReceivedListener는
+ * BG 수신분을 replay하지 않으므로 displayed 카운터가 0으로 굳는 회귀를 해결한다.
+ */
+async function drainPresentedBoardingPrompts(): Promise<void> {
+  let presented: Notifications.Notification[];
+  try {
+    presented = await Notifications.getPresentedNotificationsAsync();
+  } catch (err) {
+    log.warn('presented tray 조회 실패', err as Error);
+    return;
+  }
+  for (const n of presented) {
+    tryLogDisplayed(n);
+  }
+}
+
+/**
+ * FG receive listener + AppState 'active' drain — BOARDING_PROMPT category notification의
+ * displayed 카운터를 살린다.
  *
  * app/_layout.tsx에서 useBoardingPromptResponder 옆에 같이 호출한다. deps 없음.
  */
 export function useBoardingPromptDisplayLogger(): void {
   useEffect(() => {
     const sub = Notifications.addNotificationReceivedListener((notification) => {
-      try {
-        const request = notification.request;
-        const content = request.content;
-        // iOS에서만 categoryIdentifier가 채워진다 (Android는 무시). BOARDING_PROMPT 외 카테고리는 skip.
-        if (content.categoryIdentifier !== BOARDING_PROMPT_CATEGORY) return;
-        // payload schema 검증 — 형식이 다른 push가 같은 category를 재사용해도 displayed 오적재 차단.
-        const payload = extractBoardingPromptPayload(content.data);
-        if (!payload) return;
-        const identifier = request.identifier;
-        if (typeof identifier !== 'string' || identifier.length === 0) return;
-        if (displayedIdentifiers.has(identifier)) return;
-        displayedIdentifiers.add(identifier);
-        logBoardingPromptFired({
-          originStation: payload.originStation,
-          line: payload.line,
-        });
-      } catch (err) {
-        // listener 콜백은 절대 throw 금지 — 오작동 시 silent log만.
-        log.warn('boarding-prompt displayed 적재 실패', err as Error);
-      }
+      tryLogDisplayed(notification);
     });
-    return () => sub.remove();
+    // 마운트 시점에 1회 drain — cold start로 진입한 경우 tray에 이미 표시된 prompt를 흡수.
+    void drainPresentedBoardingPrompts();
+    const onAppStateChange = (state: AppStateStatus): void => {
+      if (state === 'active') void drainPresentedBoardingPrompts();
+    };
+    const appStateSub = AppState.addEventListener('change', onAppStateChange);
+    return () => {
+      sub.remove();
+      appStateSub.remove();
+    };
   }, []);
 }


### PR DESCRIPTION
Closes #1419

## 증상

7일간 BoardingLock 활성 trip 다수에도 `Boarding Prompt Acceptance` dashboard에 displayed/responded/boarded/dismissed 모두 0건.

## Root cause

`useBoardingPromptDisplayLogger` (#1385)는 `Notifications.addNotificationReceivedListener` 1개로만 displayed 적재 → FG 수신만 잡음. BG/lock 상태에서 도착한 boarding-prompt push는 다음과 같이 누락된다:

1. **FG 수신** — listener 발화 OK
2. **BG/lock 수신 → FG 복귀** — listener 발화 X (BG 수신분은 replay 안 됨)
3. **BG 수신 후 응답** — `useBoardingPromptResponder` 보완 path 발화

실기기 trip 대부분은 (2). 사용자가 BG에서 prompt를 보고 응답 없이 그대로 두는 경우 displayed/responded 모두 0이 됨.

## Fix

`scheduledAlarmReceiver.drainDeliveredScheduledAlarms` (lines 339-358)와 동형 패턴으로 AppState 'active' 진입 + 마운트 시점에 `getPresentedNotificationsAsync()`로 tray를 drain. 기존 dedup set으로 FG/response 경로와 중복 적재 차단.

## 변경 요약

- `useBoardingPromptDisplayLogger.ts` — receive listener를 `tryLogDisplayed` helper로 추출, `drainPresentedBoardingPrompts` 추가, 마운트 시점 1회 + AppState 'active' 진입 시 drain 호출
- 테스트 6건 추가:
  - 마운트 시 tray drain → BOARDING_PROMPT 적재
  - AppState 'active' → drain + displayed 카운트 증가
  - AppState 'background' → drain 호출 안 함
  - FG receive + drain dedup (동일 identifier 중복 X)
  - drain category filter (BOARDING_PROMPT 외 skip)
  - `getPresentedNotificationsAsync` 예외 swallow

## Acceptance

- `npm run type-check` 통과
- `useBoardingPromptDisplayLogger` 테스트 18/18 pass
- 1주 측정: BoardingLock 활성 trip이 발생한 날 displayed > 0

## 컨텍스트

- 메모리 박제: `project_2026_06_16_evening_double_fix.md` — "boardingPrompt acceptance displayed wire-up 누락" 명시
- 이전 PR #1387 (#1385): FG receive + response listener wire — 본 PR이 BG receive 드레인 보강

## 검증

- 사용자 책임: 실기기 trip 1주 측정 (epic close 룰 — PR 머지 ≠ close)