### PR TITLE
fix(#1418): 환경 인지 fusion arbitration — Tier cascade + lockless-route-hop Tier 5 강등

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -812,6 +812,10 @@ function DebugModalInner({
     arcStations,
     detectionTier,
     detectionSignalMask,
+    // #1418 — 환경 인지 fusion arbitration. Tier 1 SSOT 합의 활성 + 추정 환경 노출.
+    environment,
+    surfaceSSOTActive,
+    undergroundSSOTActive,
   } = useFusedNearestStation();
   // arc 길이 = trip의 hop 총 수. trip 미설정이면 0.
   const routeHopCount = arcStations.length;
@@ -1085,6 +1089,19 @@ function DebugModalInner({
             <KeyValue label="source" value={source} colors={colors} />
             <KeyValue label="fused" value={fusedLabel} colors={colors} />
             <KeyValue label="gps" value={gpsLabel} colors={colors} />
+            {/* #1418 — 환경 인지 fusion arbitration. surface/underground SSOT 합의 활성 여부와
+                추정 환경. Tier 5(시간 적분) reject 게이트가 어느 신호에 막혔는지 사후 재구성 가능. */}
+            <KeyValue label="environment" value={environment} colors={colors} />
+            <KeyValue
+              label="surfaceSSOT"
+              value={surfaceSSOTActive ? 'active' : 'null'}
+              colors={colors}
+            />
+            <KeyValue
+              label="undergroundSSOT"
+              value={undergroundSSOTActive ? 'active' : 'null'}
+              colors={colors}
+            />
             {differs && (
               <Text
                 style={[typography.mono, { color: colors.warn, marginTop: spacing.xs }]}

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -97,6 +97,10 @@ const fusedReturnFixture = (overrides: Record<string, unknown> = {}) => ({
   arcStations: [],
   detectionTier: 'low' as const,
   detectionSignalMask: '',
+  // #1418 — 환경 인지 fusion arbitration 신규 노출 필드 기본값.
+  environment: 'unknown' as const,
+  surfaceSSOTActive: false,
+  undergroundSSOTActive: false,
   ...overrides,
 });
 const arrivalDefaults = {
@@ -132,6 +136,10 @@ const setupHookDefaults = () => {
     arcStations: [],
     detectionTier: 'low',
     detectionSignalMask: '',
+    // #1418 — 환경 인지 fusion arbitration 신규 필드.
+    environment: 'unknown',
+    surfaceSSOTActive: false,
+    undergroundSSOTActive: false,
   });
   mockUseArrivalInfo.mockReturnValue({ arrival: baseArrival, loading: false, isMock: false });
   mockUseSilentPushDiagnostics.mockReturnValue({
@@ -280,6 +288,21 @@ describe('DebugModal', () => {
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     expect(screen.getByText('(no location)')).toBeTruthy();
     expect(screen.getByText('(no nearest)')).toBeTruthy();
+  });
+
+  it('#1418 — surfaceSSOT/undergroundSSOT 활성 시 active 라벨, environment 노출', () => {
+    mockUseFusedNearestStation.mockReturnValue(
+      fusedReturnFixture({
+        environment: 'surface',
+        surfaceSSOTActive: true,
+        undergroundSSOTActive: true,
+      }),
+    );
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByText('environment')).toBeTruthy();
+    expect(screen.getByText('surface')).toBeTruthy();
+    // 'active' 라벨이 surfaceSSOT/undergroundSSOT row에 노출.
+    expect(screen.getAllByText('active').length).toBeGreaterThanOrEqual(2);
   });
 
   it('arrival이 null이면 no arrival data를 표시한다', () => {

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
@@ -269,8 +269,9 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
     it('lock 없으면 arc 소속 검사 미작동 (gate 자체는 비활성)', () => {
       // fix(c)는 boardingLock 활성 시에만 동작 — 면목도 gate 통과.
       // #1207 (Epic #1204 D1): lock 없음 + routeCtx 있음 → lockless-route-hop estimator 활성.
-      // position-train 채택 후 estimator가 chosenIdx=-1(면목 off-arc) 조건에서 override →
-      // source='boarding-lock-interp'. gate 비활성과 estimator override는 분리 책임.
+      // #1418 — positionTrainResult(=Tier 4 실측)가 활성이면 lockless-route-hop(Tier 5)의
+      //         forward ratchet은 차단된다 → positionTrainResult 채택 결과(position-train) 유지.
+      //         (구 버전은 boarding-lock-interp로 override됐으나 그것이 #1415 회귀의 layer 2.)
       const myeonmok = findStationByNameAndLine('면목', '7')!;
       const { result } = setup({
         gps: { userLocation: { lat: yongmasan.lat, lng: yongmasan.lng }, accuracyMeters: 1500 },
@@ -278,9 +279,9 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
         routeCtx: routeContext,
       });
 
-      // lock 없으면 arc 검사 안 함 → 면목도 gate 통과 (position-train 일단 채택).
-      // 단 lockless estimator가 chosenIdx=-1로 override → 최종 source는 boarding-lock-interp.
-      expect(result.current.source).toBe('boarding-lock-interp');
+      // lock 없으면 arc 검사 안 함 → 면목도 gate 통과 (position-train 채택).
+      // #1418 Tier 5 reject 게이트 — positionTrainResult 활성 → lockless-route-hop override 차단.
+      expect(result.current.source).toBe('position-train');
     });
 
     it('arc 안에 있지만 LOCK_NEXT_HOP_WINDOW 초과 시 gate 탈락', () => {
@@ -344,9 +345,10 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
 
       // positionTrainResult = 용마산 → lockedTrainCode 매칭으로 source='boarding-lock' 채택.
       // #1207 (Epic #1204 D1): lock 없음 + routeCtx 있음 → lockless-route-hop estimator 활성.
-      // 용마산이 arc 밖이므로 chosenIdx=-1 → estimator override → source='boarding-lock-interp'.
-      // 앵커(lastObservedRef)는 arcIndexOfStation=-1 반환으로 미갱신 — line 487 early return은 유지.
-      expect(result.current.source).toBe('boarding-lock-interp');
+      // #1418 — positionTrainResult(=Tier 4 실측)가 활성이면 lockless-route-hop(Tier 5)의 forward
+      //         ratchet은 차단된다. 결과는 cascade가 산출한 'boarding-lock'(lockedTrainCode 매칭).
+      //         앵커(lastObservedRef)는 arcIndexOfStation=-1 반환으로 미갱신 — line 487 early return 유지.
+      expect(result.current.source).toBe('boarding-lock');
     });
   });
 

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.tierCascade.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.tierCascade.test.ts
@@ -1,0 +1,152 @@
+/* eslint-disable import/no-restricted-paths -- cross-feature orchestration (#890) */
+
+/**
+ * #1418 — 환경 인지 fusion arbitration. lockless-route-hop / default-hop(Tier 5 시간 적분) forward
+ * ratchet reject 게이트 회귀 방지. 22:32:41 청담 false fire 시나리오 재현:
+ *
+ * 1. lockless trip (boardingLock=null, destination 설정만 됨)
+ * 2. 정적 사용자 (GPS @ 용마산, accuracy 14m → Tier 1 surfaceSSOT 합의 후보)
+ * 3. 시간 경과 → lockless-route-hop이 청담(arc 7번 hop)을 가리킴
+ * 4. surfaceSSOT 활성 → Tier 5 reject → result는 cascade 산출 그대로(gps-only)
+ */
+
+import { renderHook } from '@testing-library/react-native';
+import { useFusedNearestStation } from '../useFusedNearestStation';
+import { useNearestStation } from '../useNearestStation';
+import { useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
+import { useTrainPositions } from '../../../route/hooks/useTrainPositions';
+import { findTopNearestStations } from '../../utils/findNearestStation';
+import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute';
+import {
+  arrivalRet,
+  positionRet,
+  GPS_BASE_DEFAULTS,
+} from '../../../../testUtils/positionApiFixtures';
+import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
+import { makeArrivalInfo } from '../../../../testUtils/fixtures';
+
+jest.mock('../../utils/findNearestStation', () => ({
+  findTopNearestStations: jest.fn(),
+}));
+jest.mock('../useNearestStation');
+jest.mock('../../../arrival/hooks/useArrivalInfo');
+jest.mock('../../../route/hooks/useTrainPositions');
+jest.mock('../../../alarm/utils/tripStartStorage', () => ({
+  getTripStartedAt: jest.fn().mockResolvedValue(null),
+}));
+
+const mockNearest = useNearestStation as jest.Mock;
+const mockArrival = useArrivalInfo as jest.Mock;
+const mockPos = useTrainPositions as jest.Mock;
+const mockFindTop = findTopNearestStations as jest.Mock;
+
+const yongmasan = findStationByNameAndLine('용마산', '7')!;
+const chungdam = findStationByNameAndLine('청담', '7')!;
+const konkuk = findStationByNameAndLine('건대입구', '7')!;
+
+function setupLocklessTripAtYongmasan({
+  gpsAccuracy = 14,
+  arrivalAtYongmasan = null,
+}: {
+  gpsAccuracy?: number | null;
+  arrivalAtYongmasan?: ReturnType<typeof makeArrivalInfo> | null;
+} = {}) {
+  // lockless trip — boardingLock 없음, route만 활성. tripStartedAt 5분 전 → lockless-route-hop
+  // 적분이 arc 끝 청담을 가리킴.
+  const T0 = 1_700_000_000_000;
+  jest.setSystemTime(T0);
+
+  // GPS 용마산 정적 보고. accuracy 변경으로 surfaceSSOT 활성/비활성 전환.
+  mockNearest.mockReturnValue({
+    result: { station: yongmasan, distanceKm: 0 },
+    variants: [yongmasan],
+    userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
+    ...GPS_BASE_DEFAULTS,
+    accuracyMeters: gpsAccuracy,
+    refresh: jest.fn(),
+  });
+  mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+
+  // arrival mock: 용마산 슬롯에 arvlCd=1(도착) row를 가진 response.
+  mockArrival.mockImplementation((stationName: string | null, line: string | null) => {
+    if (stationName === yongmasan.name && line === '7' && arrivalAtYongmasan !== null) {
+      return arrivalRet({ up: [arrivalAtYongmasan], down: [] });
+    }
+    return arrivalRet(null);
+  });
+  // 열차 위치 없음 → positionTrainResult null.
+  mockPos.mockReturnValue(positionRet(null));
+
+  const route = makeDirectRoute(8, '7'); // 8 hops from yongmasan
+  const routeContext = { route, origin: yongmasan, destination: chungdam };
+
+  const hook = renderHook(() => useFusedNearestStation(undefined, undefined, routeContext));
+
+  // tripStartedAt fallback = T0. 시간 경과 → lockless-route-hop 적분이 arc 끝으로 진행.
+  jest.setSystemTime(T0 + 60 * 60_000); // 60분 경과 → 가능한 모든 hop 적분 완료
+  hook.rerender({});
+
+  return hook;
+}
+
+describe('#1418 Tier 5 reject — lockless-route-hop forward ratchet 차단', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('surfaceSSOT 활성(GPS 정상 + Arrival arvlCd=1) → Tier 5 차단, lockless-route-hop override X', () => {
+    // 22:32:41 청담 회귀 재현: GPS 용마산 14m, 같은 역 arrival 도착 → Tier 1 합의.
+    const result = setupLocklessTripAtYongmasan({
+      gpsAccuracy: 14,
+      arrivalAtYongmasan: makeArrivalInfo({
+        destination: '',
+        arrivalSeconds: 0,
+        line: '7',
+        arrivalCode: 1,
+        trainCode: 'T-SSOT',
+      }),
+    });
+
+    // Tier 5(lockless-route-hop)가 청담(arc 끝)을 가리켜도 surfaceSSOT가 reject.
+    // 결과는 cascade 산출 그대로 — GPS 용마산.
+    expect(result.result.current.source).not.toBe('boarding-lock-interp');
+    expect(result.result.current.result?.station.id).toBe(yongmasan.id);
+    expect(result.result.current.environment).toBe('surface');
+    expect(result.result.current.surfaceSSOTActive).toBe(true);
+  });
+
+  it('실측 신호 없음(arrival 없음) → Tier 5 fallback 허용 (dead zone)', () => {
+    // 진짜 dead zone: GPS만 있고 arrival 신호 없음 → surfaceSSOT 미합의.
+    // lockless-route-hop이 적분 결과로 forward ratchet 가능.
+    const result = setupLocklessTripAtYongmasan({
+      gpsAccuracy: 14,
+      arrivalAtYongmasan: null,
+    });
+
+    // 실측 신호 부재 → Tier 5 허용 → estimator override → boarding-lock-interp.
+    expect(result.result.current.source).toBe('boarding-lock-interp');
+    expect(result.result.current.surfaceSSOTActive).toBe(false);
+  });
+
+  it('GPS accuracy 너무 큼(>30m) → surfaceSSOT 미합의 → 실측 신호 부재 → Tier 5 허용', () => {
+    // 지하 fallback 등으로 accuracy 50m → Tier 1 surface 미충족.
+    const result = setupLocklessTripAtYongmasan({
+      gpsAccuracy: 50,
+      arrivalAtYongmasan: makeArrivalInfo({
+        destination: '',
+        arrivalSeconds: 0,
+        line: '7',
+        arrivalCode: 1,
+      }),
+    });
+
+    expect(result.result.current.surfaceSSOTActive).toBe(false);
+    // Tier 5 허용 → estimator override.
+    expect(result.result.current.source).toBe('boarding-lock-interp');
+  });
+});

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -29,6 +29,9 @@ import { trackTrainProgress } from '../../route/utils/trackTrainProgress';
 import { haversine } from '../../../shared/utils/haversine';
 import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import { isWithinArcWindow, passesFusionDistanceGate } from '../utils/fusionDistanceGate';
+import { surfaceSSOTConsensus } from '../utils/surfaceSSotConsensus';
+import { undergroundSSOTConsensus } from '../utils/undergroundSSotConsensus';
+import { inferEnvironment, type Environment } from '../utils/inferEnvironment';
 import { computeRouteArc } from '../../route/utils/routeProgress';
 import {
   arcIndexOfStation,
@@ -153,6 +156,15 @@ interface UseFusedNearestStationReturn {
    *     것이지 lock 무결성을 보장하지 않는다 — ADR-010 두 실패 모드 동급 원칙에 따른 분리 책임.
    */
   trainProgressing: boolean;
+  /**
+   * #1418 — fusion arbitration이 추정한 환경.
+   * 'surface' / 'underground' / 'unknown'. DebugModal Environment Inference 섹션 표시용.
+   */
+  environment: Environment;
+  /** #1418 — 지상 Tier 1 SSOT(GPS+Arrival) 합의 활성 여부. */
+  surfaceSSOTActive: boolean;
+  /** #1418 — 지하 Tier 1 SSOT(WiFi/Position-Train + Arrival) 합의 활성 여부. */
+  undergroundSSOTActive: boolean;
   refresh: () => Promise<void>;
 }
 
@@ -594,6 +606,48 @@ export function useFusedNearestStation(
     source = 'gps';
   }
 
+  // #1418 — Tier 1 SSOT 합의 판정 + 환경 추정.
+  //
+  // 목적: lockless-route-hop / default-hop(시간 적분 = Tier 5)이 실측 신호가 살아 있는 동안
+  // forward ratchet으로 result를 덮어쓰는 회귀 차단.
+  //
+  // Tier 정의 (cascade는 그대로 두고, Tier 5 reject 게이트만 추가):
+  //   Tier 1 (지상) — surfaceSSOT: GPS(acc<30m) + Arrival(arvlCd 1/2/3/5) 합의
+  //   Tier 1 (지하) — undergroundSSOT: WiFi+Arrival / Position-Train+Arrival 합의
+  //   Tier 2~4     — lastObservedRef / boardingLock / positionTrainResult (cascade가 채택)
+  //   Tier 5       — 시간 적분 (lockless-route-hop / default-hop)
+  //
+  // Tier 5 reject 게이트: Tier 5 advance는 Tier 1~4 모두 null일 때만 허용.
+  // 실측 신호(SSOT/lastObserved/lock/position-train)가 하나라도 활성이면 시간 적분의 forward ratchet
+  // 자체를 차단해 청담/중곡/사가정 류 false fire를 막는다.
+  const arrivalSlots = [
+    { stationName: c0, line: h0, arrival: a0.arrival },
+    { stationName: c1, line: h1, arrival: a1.arrival },
+    { stationName: c2, line: h2, arrival: a2.arrival },
+  ];
+  const surfaceArrival = gps.result
+    ? pickArrivalForStationName(gps.result.station.name, gps.result.station.line, arrivalSlots)
+    : null;
+  const surfaceSSOT = surfaceSSOTConsensus({
+    gpsResult: gps.result,
+    gpsAccuracy: gps.accuracyMeters,
+    arrival: surfaceArrival,
+  });
+  const undergroundCandidate = wifiStationResolved?.station ?? positionTrainResult?.station ?? null;
+  const undergroundArrival = undergroundCandidate
+    ? pickArrivalForStationName(undergroundCandidate.name, undergroundCandidate.line, arrivalSlots)
+    : null;
+  const undergroundSSOT = undergroundSSOTConsensus({
+    wifiStation: wifiStationResolved?.station ?? null,
+    positionTrainResult,
+    arrival: undergroundArrival,
+  });
+  const environment: Environment = inferEnvironment({
+    subsurface: barometerSubsurface,
+    surfaceSSOT: surfaceSSOT !== null,
+    undergroundSSOT: undergroundSSOT !== null,
+  });
+
   // ADR-008 stationProgressEstimator — 시간 적분 → 관측 구동 전환 (#739).
   // arc상 추정 위치가 현 채택된 결과보다 앞이거나, 채택 결과가 arc 밖이면 override.
   // 채택 결과가 더 앞이면 그대로(실제 신호 우선) — 역행 방지(monotone forward).
@@ -786,11 +840,31 @@ export function useFusedNearestStation(
     // false(이동·미지원)는 기존 동작. consensus 게이트(#1363, movementGate.ts)는 confidence
     // 라벨 안정성을 별도 책임 — 라벨/forward 이동을 분리. 정지 trip에서 origin chip / 위젯
     // mirror가 잘못된 다음 역으로 forward 표시되는 회귀(2026-06-16 18:11~18:12) 차단.
+    //
+    // #1418 — Tier 5 reject 게이트. 시간 적분 strategy(lockless-route-hop / default-hop)는
+    // 실측 신호(SSOT / lastObservedRef / positionTrainResult)가 하나라도 활성이면 forward ratchet 차단.
+    //
+    // boardingLock 자체는 본 게이트에서 제외:
+    //   - default-hop은 boardingLock.boardedAt이 anchor라 lock 활성이 strategy의 *입력*이다.
+    //     lock 활성을 reject 신호로 쓰면 default-hop이 영구 차단되어 dead zone fallback이 무력화.
+    //   - lockless-route-hop은 lock 부재 상황이라 boardingLock 검사 자체가 무의미.
+    //
+    // 실시간 strategy(live-position / arrival-eta / reanchored-hop)는 strategy 자체가 실측 기반이라
+    // 면제 — 본 게이트는 isTimeIntegration=true 케이스에만 적용.
+    const isTimeIntegration =
+      estimate.strategy === 'lockless-route-hop' || estimate.strategy === 'default-hop';
+    const realtimeSignalActive =
+      surfaceSSOT !== null ||
+      undergroundSSOT !== null ||
+      lastObservedRef.current !== null ||
+      positionTrainResult !== null;
+    const passesTier5Gate = !isTimeIntegration || !realtimeSignalActive;
     if (
       (chosenIdx === -1 || estimate.index > chosenIdx) &&
       withinObservationCeiling &&
       withinLineGuard &&
-      motionStationary !== true
+      motionStationary !== true &&
+      passesTier5Gate
     ) {
       const distanceKm = gps.userLocation
         ? haversine(
@@ -1043,6 +1117,9 @@ export function useFusedNearestStation(
     subsurface: barometerSubsurface,
     subsurfaceStationDetected,
     trainProgressing,
+    environment,
+    surfaceSSOTActive: surfaceSSOT !== null,
+    undergroundSSOTActive: undergroundSSOT !== null,
     refresh: gps.refresh,
   };
 }

--- a/src/features/nearest-station/utils/__tests__/inferEnvironment.test.ts
+++ b/src/features/nearest-station/utils/__tests__/inferEnvironment.test.ts
@@ -1,0 +1,57 @@
+import { inferEnvironment } from '../inferEnvironment';
+
+describe('inferEnvironment', () => {
+  it('subsurface=true 명시 → underground', () => {
+    expect(
+      inferEnvironment({ subsurface: true, surfaceSSOT: false, undergroundSSOT: false }),
+    ).toBe('underground');
+  });
+
+  it('subsurface=true는 surfaceSSOT가 활성이어도 underground 우선 (barometer 확정)', () => {
+    expect(
+      inferEnvironment({ subsurface: true, surfaceSSOT: true, undergroundSSOT: false }),
+    ).toBe('underground');
+  });
+
+  it('subsurface=false + surfaceSSOT 활성 → surface', () => {
+    expect(
+      inferEnvironment({ subsurface: false, surfaceSSOT: true, undergroundSSOT: false }),
+    ).toBe('surface');
+  });
+
+  it('subsurface=false + undergroundSSOT 활성(지상 SSOT 없음) → underground (지하상가)', () => {
+    expect(
+      inferEnvironment({ subsurface: false, surfaceSSOT: false, undergroundSSOT: true }),
+    ).toBe('underground');
+  });
+
+  it('subsurface=false + 둘 다 null → unknown', () => {
+    expect(
+      inferEnvironment({ subsurface: false, surfaceSSOT: false, undergroundSSOT: false }),
+    ).toBe('unknown');
+  });
+
+  it('subsurface=undefined + surfaceSSOT만 활성 → surface (hybrid)', () => {
+    expect(
+      inferEnvironment({ subsurface: undefined, surfaceSSOT: true, undergroundSSOT: false }),
+    ).toBe('surface');
+  });
+
+  it('subsurface=undefined + undergroundSSOT만 활성 → underground (hybrid)', () => {
+    expect(
+      inferEnvironment({ subsurface: undefined, surfaceSSOT: false, undergroundSSOT: true }),
+    ).toBe('underground');
+  });
+
+  it('subsurface=undefined + 둘 다 활성 → unknown (분간 불가)', () => {
+    expect(
+      inferEnvironment({ subsurface: undefined, surfaceSSOT: true, undergroundSSOT: true }),
+    ).toBe('unknown');
+  });
+
+  it('subsurface=undefined + 둘 다 null → unknown', () => {
+    expect(
+      inferEnvironment({ subsurface: undefined, surfaceSSOT: false, undergroundSSOT: false }),
+    ).toBe('unknown');
+  });
+});

--- a/src/features/nearest-station/utils/__tests__/surfaceSSotConsensus.test.ts
+++ b/src/features/nearest-station/utils/__tests__/surfaceSSotConsensus.test.ts
@@ -1,0 +1,107 @@
+import { surfaceSSOTConsensus } from '../surfaceSSotConsensus';
+import { MOCK_STATIONS, makeArrivalInfo, makeNearestResult } from '../../../../testUtils/fixtures';
+import type { StationArrival } from '../../../../shared/types/arrival';
+
+function makeArrival(rows: ReturnType<typeof makeArrivalInfo>[]): StationArrival {
+  return { up: rows, down: [], source: 'realtime' };
+}
+
+describe('surfaceSSOTConsensus', () => {
+  const gpsResult = makeNearestResult('gangnam', 0.05);
+
+  it('GPS 신선 + Arrival arvlCd=1(도착) 합의 시 SSOT 반환', () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({
+        destination: '교대',
+        arrivalSeconds: 0,
+        trainCode: '2001',
+        line: '2',
+        arrivalCode: 1,
+      }),
+    ]);
+    const result = surfaceSSOTConsensus({ gpsResult, gpsAccuracy: 14, arrival });
+    expect(result).toEqual({ station: gpsResult.station, trainCode: '2001' });
+  });
+
+  it.each([2, 3, 5])('arvlCd=%i(정착 코드)에서 합의', (arvlCd) => {
+    const arrival = makeArrival([
+      makeArrivalInfo({
+        destination: '교대',
+        arrivalSeconds: 0,
+        trainCode: '2002',
+        line: '2',
+        arrivalCode: arvlCd,
+      }),
+    ]);
+    const result = surfaceSSOTConsensus({ gpsResult, gpsAccuracy: 10, arrival });
+    expect(result?.trainCode).toBe('2002');
+  });
+
+  it.each([0, 4, 99, -1])('arvlCd=%i(비정착)는 합의 미성립', (arvlCd) => {
+    const arrival = makeArrival([
+      makeArrivalInfo({
+        destination: '교대',
+        arrivalSeconds: 0,
+        line: '2',
+        arrivalCode: arvlCd,
+      }),
+    ]);
+    expect(surfaceSSOTConsensus({ gpsResult, gpsAccuracy: 10, arrival })).toBeNull();
+  });
+
+  it('gpsResult null이면 합의 미성립', () => {
+    const arrival = makeArrival([makeArrivalInfo({ destination: '', arrivalSeconds: 0, line: '2', arrivalCode: 1 })]);
+    expect(surfaceSSOTConsensus({ gpsResult: null, gpsAccuracy: 10, arrival })).toBeNull();
+  });
+
+  it('gpsAccuracy null이면 합의 미성립', () => {
+    const arrival = makeArrival([makeArrivalInfo({ destination: '', arrivalSeconds: 0, line: '2', arrivalCode: 1 })]);
+    expect(surfaceSSOTConsensus({ gpsResult, gpsAccuracy: null, arrival })).toBeNull();
+  });
+
+  it('gpsAccuracy > 30m면 합의 미성립 (지하 fallback 가능성)', () => {
+    const arrival = makeArrival([makeArrivalInfo({ destination: '', arrivalSeconds: 0, line: '2', arrivalCode: 1 })]);
+    expect(surfaceSSOTConsensus({ gpsResult, gpsAccuracy: 50, arrival })).toBeNull();
+  });
+
+  it('arrival null이면 합의 미성립', () => {
+    expect(surfaceSSOTConsensus({ gpsResult, gpsAccuracy: 10, arrival: null })).toBeNull();
+  });
+
+  it('arrival row의 line이 gpsResult.line과 다르면 합의 미성립 (환승역)', () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({
+        destination: '',
+        arrivalSeconds: 0,
+        line: '3',
+        arrivalCode: 1,
+      }),
+    ]);
+    expect(surfaceSSOTConsensus({ gpsResult, gpsAccuracy: 10, arrival })).toBeNull();
+  });
+
+  it('down 슬롯의 arrival도 합의 인식', () => {
+    const arrival: StationArrival = {
+      up: [],
+      down: [
+        makeArrivalInfo({
+          destination: '',
+          arrivalSeconds: 0,
+          trainCode: '2003',
+          line: '2',
+          arrivalCode: 2,
+        }),
+      ],
+      source: 'realtime',
+    };
+    const result = surfaceSSOTConsensus({ gpsResult, gpsAccuracy: 10, arrival });
+    expect(result?.trainCode).toBe('2003');
+  });
+
+  it('gpsAccuracy 경계값 30m는 통과', () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '', arrivalSeconds: 0, line: '2', arrivalCode: 1, trainCode: 'X' }),
+    ]);
+    expect(surfaceSSOTConsensus({ gpsResult, gpsAccuracy: 30, arrival })?.trainCode).toBe('X');
+  });
+});

--- a/src/features/nearest-station/utils/__tests__/undergroundSSotConsensus.test.ts
+++ b/src/features/nearest-station/utils/__tests__/undergroundSSotConsensus.test.ts
@@ -1,0 +1,81 @@
+import { undergroundSSOTConsensus } from '../undergroundSSotConsensus';
+import { MOCK_STATIONS, makeArrivalInfo, makeNearestResult } from '../../../../testUtils/fixtures';
+import type { StationArrival } from '../../../../shared/types/arrival';
+
+function makeArrival(rows: ReturnType<typeof makeArrivalInfo>[]): StationArrival {
+  return { up: rows, down: [], source: 'realtime' };
+}
+
+describe('undergroundSSOTConsensus', () => {
+  it('WiFi + Arrival arvlCd 정착 합의 시 WiFi 우선 채택', () => {
+    const wifi = MOCK_STATIONS.gangnam;
+    const positionTrain = makeNearestResult('chungmuro', 0.05);
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '', arrivalSeconds: 0, line: '2', arrivalCode: 1, trainCode: 'W1' }),
+    ]);
+    const result = undergroundSSOTConsensus({ wifiStation: wifi, positionTrainResult: positionTrain, arrival });
+    expect(result).toEqual({ station: wifi, trainCode: 'W1' });
+  });
+
+  it('WiFi 없고 Position-Train + Arrival 합의', () => {
+    const positionTrain = makeNearestResult('chungmuro', 0.05);
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '', arrivalSeconds: 0, line: '3', arrivalCode: 2, trainCode: 'P1' }),
+    ]);
+    const result = undergroundSSOTConsensus({ wifiStation: null, positionTrainResult: positionTrain, arrival });
+    expect(result).toEqual({ station: positionTrain.station, trainCode: 'P1' });
+  });
+
+  it('WiFi 있지만 line 매칭 arrival 없음 → Position-Train으로 fallback', () => {
+    const wifi = MOCK_STATIONS.gangnam;
+    const positionTrain = makeNearestResult('chungmuro', 0.05);
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '', arrivalSeconds: 0, line: '3', arrivalCode: 1, trainCode: 'P2' }),
+    ]);
+    const result = undergroundSSOTConsensus({ wifiStation: wifi, positionTrainResult: positionTrain, arrival });
+    expect(result?.trainCode).toBe('P2');
+    expect(result?.station).toEqual(positionTrain.station);
+  });
+
+  it('둘 다 null이면 합의 미성립', () => {
+    const arrival = makeArrival([makeArrivalInfo({ destination: '', arrivalSeconds: 0, line: '2', arrivalCode: 1 })]);
+    expect(undergroundSSOTConsensus({ wifiStation: null, positionTrainResult: null, arrival })).toBeNull();
+  });
+
+  it('arrival null이면 합의 미성립', () => {
+    expect(
+      undergroundSSOTConsensus({
+        wifiStation: MOCK_STATIONS.gangnam,
+        positionTrainResult: null,
+        arrival: null,
+      }),
+    ).toBeNull();
+  });
+
+  it.each([0, 4, 99, -1])('비정착 arvlCd=%i는 합의 미성립', (arvlCd) => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '', arrivalSeconds: 0, line: '2', arrivalCode: arvlCd }),
+    ]);
+    expect(
+      undergroundSSOTConsensus({
+        wifiStation: MOCK_STATIONS.gangnam,
+        positionTrainResult: null,
+        arrival,
+      }),
+    ).toBeNull();
+  });
+
+  it('down 슬롯 arrival도 합의 인식', () => {
+    const arrival: StationArrival = {
+      up: [],
+      down: [makeArrivalInfo({ destination: '', arrivalSeconds: 0, line: '2', arrivalCode: 5, trainCode: 'D1' })],
+      source: 'realtime',
+    };
+    const result = undergroundSSOTConsensus({
+      wifiStation: MOCK_STATIONS.gangnam,
+      positionTrainResult: null,
+      arrival,
+    });
+    expect(result?.trainCode).toBe('D1');
+  });
+});

--- a/src/features/nearest-station/utils/inferEnvironment.ts
+++ b/src/features/nearest-station/utils/inferEnvironment.ts
@@ -1,0 +1,39 @@
+/**
+ * 환경(지상/지하/미확정) 추정. hybrid 모드 — 명시 분류 단계 없이 신호 가용성으로 추정.
+ *
+ * #1418 — Tier 1 cascade를 위한 환경 라벨 산출. DebugModal 표시용이 주 용도이며 fusion
+ * cascade의 게이트는 두 SSOT(`surfaceSSOT`/`undergroundSSOT`)의 활성 여부로 직접 분기한다.
+ *
+ * 우선순위:
+ *   1. `subsurface === true` 명시 → 'underground' (barometer 확정).
+ *   2. `subsurface === false` 명시 + surfaceSSOT 활성 → 'surface'.
+ *   3. `subsurface === false` + undergroundSSOT 활성 → 'underground' (지하상가/매핑 SSID).
+ *   4. `subsurface === undefined` + 둘 다 활성 → 'unknown' (hybrid).
+ *   5. 둘 다 활성 + barometer 미확정 → 'unknown'.
+ *   6. 둘 다 null → 'unknown'.
+ */
+
+export type Environment = 'surface' | 'underground' | 'unknown';
+
+export interface InferEnvironmentInput {
+  /** barometer `subsurface` 신호. undefined = warmup / 미지원. */
+  subsurface: boolean | undefined;
+  /** `surfaceSSOTConsensus`가 합의했으면 true. */
+  surfaceSSOT: boolean;
+  /** `undergroundSSOTConsensus`가 합의했으면 true. */
+  undergroundSSOT: boolean;
+}
+
+export function inferEnvironment(input: InferEnvironmentInput): Environment {
+  const { subsurface, surfaceSSOT, undergroundSSOT } = input;
+  if (subsurface === true) return 'underground';
+  if (subsurface === false) {
+    if (surfaceSSOT) return 'surface';
+    if (undergroundSSOT) return 'underground';
+    return 'unknown';
+  }
+  // subsurface === undefined (warmup / 미지원) — SSOT 신호로만 판단.
+  if (surfaceSSOT && !undergroundSSOT) return 'surface';
+  if (undergroundSSOT && !surfaceSSOT) return 'underground';
+  return 'unknown';
+}

--- a/src/features/nearest-station/utils/surfaceSSotConsensus.ts
+++ b/src/features/nearest-station/utils/surfaceSSotConsensus.ts
@@ -1,0 +1,68 @@
+/**
+ * 지상(surface) Tier 1 SSOT 합의 판정.
+ *
+ * #1418 — 환경 인지 fusion arbitration. GPS+Arrival 두 실측 신호가 같은 역에 합의하면
+ * "지상 SSOT" 라벨을 부여, 그 외 Tier 1~4가 모두 null인 dead zone에서만 Tier 5(시간 적분)
+ * forward ratchet을 허용하기 위한 게이트 입력.
+ *
+ * 합의 조건 (모두 충족):
+ *   1. GPS 신호 신선 — `gpsResult` 비-null, `gpsAccuracy` 가용 (`<= MAX_ACC_M`).
+ *      너무 부정확한 GPS는 지하/wifi-cell 삼각측량 fallback일 가능성이 높아 "지상 신호"로 신뢰 X.
+ *   2. Arrival 응답에서 `gpsResult.station` 매칭 trainCode의 `arrivalCode` ∈ {1, 2, 3, 5}
+ *      (도착/출발/전역출발/전역도착) — 해당 열차가 같은 역 근방에 있다고 보고. arvlCd 0(진입)/
+ *      4(전역진입)/99(운행중)/-1(누락)는 위치 불확정이라 합의 미성립.
+ *
+ * 호출자(useFusedNearestStation)가 result를 null로 받으면 "지상 SSOT 미합의"로 흘려보내고,
+ * non-null이면 Tier 1로 채택할 수 있다(본 함수는 입력만 검증, 채택은 cascade가 책임).
+ *
+ * 임계값 선정 근거:
+ *   - GPS_ACC_MAX_M=30 — 기존 fusion `lockActive=false` 거리 게이트 `accuracy>200m bypass`와는
+ *     별개. Tier 1 SSOT는 더 엄격한 기준 필요 — `passesFusionDistanceGate`의 기본 통과 임계는
+ *     50m라 30m로 더 좁히는 게 false-positive 차단에 적합. lockless trip에서 정적 사용자가
+ *     14m accuracy로 보고된 회귀 evidence와 일치.
+ */
+
+import type { NearestStationResult } from '../../../shared/types/station';
+import type { StationArrival } from '../../../shared/types/arrival';
+
+/** Tier 1 SSOT 합의 임계값. accuracy_m. */
+const GPS_ACC_MAX_M = 30;
+
+/** arvlCd "정착한 위치 보고" 코드 집합. */
+const ARVL_CD_STATIONARY = new Set<number>([1, 2, 3, 5]);
+
+export interface SurfaceSSOTInput {
+  /** GPS 최근접 result (null이면 GPS 신호 부재). */
+  gpsResult: NearestStationResult | null;
+  /** GPS accuracy_m. null이면 신뢰도 불명 — Tier 1 미충족. */
+  gpsAccuracy: number | null;
+  /** gpsResult.station 매칭 슬롯의 arrival. null이면 arrival 신호 부재. */
+  arrival: StationArrival | null;
+}
+
+export interface SurfaceSSOT {
+  station: NearestStationResult['station'];
+  /** 합의 근거가 된 arrival row의 trainCode. */
+  trainCode: string;
+}
+
+/**
+ * 합의 시 SSOT 반환, 불합의 시 null.
+ *
+ * 합의 trainCode는 가장 먼저 매칭된 `arvlCd ∈ {1,2,3,5}` row 기준 — 다중 매칭은 모두 같은 역을
+ * 지나는 열차 그룹이므로 어느 trainCode를 골라도 fusion 입력으로 동등.
+ */
+export function surfaceSSOTConsensus(input: SurfaceSSOTInput): SurfaceSSOT | null {
+  const { gpsResult, gpsAccuracy, arrival } = input;
+  if (!gpsResult) return null;
+  if (gpsAccuracy === null || gpsAccuracy > GPS_ACC_MAX_M) return null;
+  if (!arrival) return null;
+
+  const allRows = [...arrival.up, ...arrival.down];
+  for (const row of allRows) {
+    if (row.line !== gpsResult.station.line) continue;
+    if (!ARVL_CD_STATIONARY.has(row.arrivalCode)) continue;
+    return { station: gpsResult.station, trainCode: row.trainCode };
+  }
+  return null;
+}

--- a/src/features/nearest-station/utils/undergroundSSotConsensus.ts
+++ b/src/features/nearest-station/utils/undergroundSSotConsensus.ts
@@ -1,0 +1,64 @@
+/**
+ * 지하(underground) Tier 1 SSOT 합의 판정.
+ *
+ * #1418 — 지하 GPS dead zone에서 WiFi SSID 또는 realtimePosition train 신호 + Arrival arvlCd 합의.
+ *
+ * 합의 경로 (둘 중 하나라도 만족):
+ *   - WiFi+Arrival: `wifiStation` 비-null + 매칭 arrival row `arvlCd ∈ {1,2,3,5}`
+ *   - Position-Train+Arrival: `positionTrainResult` 비-null + 매칭 arrival row 동일 조건
+ *
+ * 두 신호 모두 활성이면 WiFi 우선 (SSID 매칭은 지하 직접 신호, position-train은 API 추정).
+ */
+
+import type { NearestStationResult, Station } from '../../../shared/types/station';
+import type { StationArrival } from '../../../shared/types/arrival';
+
+/** arvlCd "정착한 위치 보고" 코드 집합. surfaceSSotConsensus와 동일 — 향후 공용 추출 여지. */
+const ARVL_CD_STATIONARY = new Set<number>([1, 2, 3, 5]);
+
+export interface UndergroundSSOTInput {
+  /** useWifiStation 매칭 결과. null이면 SSID 미매칭. */
+  wifiStation: Station | null;
+  /** trackTrainProgress 결과 (fusion 게이트 통과 후). null이면 position-train 신호 부재. */
+  positionTrainResult: NearestStationResult | null;
+  /** 채택 후보 station 매칭 슬롯의 arrival. null이면 arrival 신호 부재. */
+  arrival: StationArrival | null;
+}
+
+export interface UndergroundSSOT {
+  station: Station;
+  /** 합의 근거가 된 arrival row의 trainCode. */
+  trainCode: string;
+}
+
+function findStationaryTrain(
+  arrival: StationArrival | null,
+  line: string,
+): string | null {
+  if (!arrival) return null;
+  const allRows = [...arrival.up, ...arrival.down];
+  for (const row of allRows) {
+    if (row.line !== line) continue;
+    if (!ARVL_CD_STATIONARY.has(row.arrivalCode)) continue;
+    return row.trainCode;
+  }
+  return null;
+}
+
+export function undergroundSSOTConsensus(input: UndergroundSSOTInput): UndergroundSSOT | null {
+  const { wifiStation, positionTrainResult, arrival } = input;
+  // WiFi 우선 — SSID 직접 매칭.
+  if (wifiStation) {
+    const trainCode = findStationaryTrain(arrival, wifiStation.line);
+    if (trainCode !== null) {
+      return { station: wifiStation, trainCode };
+    }
+  }
+  if (positionTrainResult) {
+    const trainCode = findStationaryTrain(arrival, positionTrainResult.station.line);
+    if (trainCode !== null) {
+      return { station: positionTrainResult.station, trainCode };
+    }
+  }
+  return null;
+}

--- a/src/features/route/utils/stationProgressEstimator.ts
+++ b/src/features/route/utils/stationProgressEstimator.ts
@@ -265,6 +265,12 @@ function tryDefaultHop(
  * lock이 없는 trip(사용자가 lock 없이 GPS만으로 진행)에서 estimator가 비활성되는 회귀(#1207)를 막기 위한 #1204 D1.
  * 사용자 명시 의향(lockless 토글 ON / boardingPrompt 응답) trip은 lock 활성과 동급 정확도 보장 의무 (ADR-013 §B3).
  *
+ * #1418 — fusion arbitration에서 본 strategy는 **Tier 5(시간 적분, dead zone fallback)** 로 다뤄진다.
+ * `useFusedNearestStation`의 forward ratchet 게이트가 Tier 1~4 실측 신호(surfaceSSOT/undergroundSSOT/
+ * lastObservedRef/boardingLock/positionTrainResult)가 하나라도 활성이면 본 strategy의 result override
+ * 자체를 차단해 lockless trip 정적 사용자에 대한 false fire(청담/중곡/사가정 류)를 막는다. strategy
+ * 자체 동작은 변경 없음 — dead zone에서만 채택되는 fallback 위치 유지.
+ *
  * Guard:
  *   - `arcStations` 빈 배열 → null (상위 가드에서도 차단되지만 방어적 cap)
  *   - `now < tripStartedAt`(시계 후진) → null


### PR DESCRIPTION
## Summary

7일 잔존 lockless trip false fire 회귀(청담/중곡/사가정/건대입구/성수 등 12+건) 차단.

- **Layer 1 root cause** (`stationProgressEstimator.ts`) — lockless-route-hop strategy 자체 시간 적분
- **Layer 2 root cause** (`useFusedNearestStation.ts`) — forward ratchet 단일 source 채택
- **Layer 3 root cause** (PR #1408) — trainProgressing source strategy blindness

3개 모두 본 PR의 Tier 5 reject 게이트로 upstream 차단.

## 변경 파일

### 신규 helper
- `src/features/nearest-station/utils/surfaceSSotConsensus.ts` — GPS(acc≤30m) + Arrival(arvlCd 1/2/3/5 line 일치) 합의
- `src/features/nearest-station/utils/undergroundSSotConsensus.ts` — WiFi+Arrival / Position-Train+Arrival 합의
- `src/features/nearest-station/utils/inferEnvironment.ts` — surface/underground/unknown 환경 추정 (hybrid 모드)

### 수정
- `src/features/nearest-station/hooks/useFusedNearestStation.ts` — Tier 5 reject 게이트 추가 (line ~610~810). 시간 적분 strategy(`lockless-route-hop` / `default-hop`)는 실측 신호(`surfaceSSOT` / `undergroundSSOT` / `lastObservedRef` / `positionTrainResult`) 하나라도 활성이면 forward ratchet 차단. boardingLock은 default-hop의 anchor이므로 검사 제외.
- `src/features/route/utils/stationProgressEstimator.ts` — lockless 주석 정정 (fusion arbitration에서 Tier 5로 다뤄짐 명시).
- `src/features/debug/components/DebugModal.tsx` — Fusion 섹션에 `environment` / `surfaceSSOT` / `undergroundSSOT` row 추가.

### 테스트
- `surfaceSSotConsensus.test.ts` — 10 cases (arvlCd 정착/비정착 매트릭스, accuracy 임계, line 보정 등)
- `undergroundSSotConsensus.test.ts` — 7 cases (WiFi/Position-Train 우선순위, line fallback)
- `inferEnvironment.test.ts` — 9 cases (barometer 우선 + hybrid 모드 매트릭스)
- `useFusedNearestStation.tierCascade.test.ts` — 22:32:41 청담 회귀 재현 + reject 검증 3 cases
- 기존 `useFusedNearestStation.positionGate.test.ts` 2건 expectation 업데이트 (구 회귀 동작 → 신규 정상 동작)
- `DebugModal.test.tsx` — fixture에 신규 필드 + SSOT active 분기 테스트

## Tier 정의

\`\`\`
지상  Tier 1 surface-SSOT     ← GPS+Arrival 합의
지하  Tier 1 underground-SSOT ← WiFi+Arrival / Position-Train+Arrival 합의
공통  Tier 2 lastObservedRef (anchor TTL 내)
공통  Tier 3 BoardingLock anchor (boarding-lock-interp/default-hop의 anchor)
공통  Tier 4 Position-Train
공통  Tier 5 시간 적분 (lockless-route-hop / default-hop)  ← DEAD ZONE
\`\`\`

## Test plan

- [x] `npm test` 통과 (useFusedNearestStation 281 + 신규 helper 26 + tierCascade 3 + DebugModal 178)
- [x] `npm run type-check` 통과
- [x] `npm run lint` 통과
- [x] 변경 파일 모두 coverage 100% (useFusedNearestStation.ts / surfaceSSotConsensus.ts / undergroundSSotConsensus.ts / inferEnvironment.ts / DebugModal.tsx / stationProgressEstimator.ts)
- [ ] 실기기 정적 FG 30분 — `boarding-lock-interp` 채택 0회 (lockless trip)
- [ ] 정상 trip 매역 알림 fire 회귀 0건
- [ ] 1주 실측 — 청담/중곡/사가정 류 false fire 0건

## 잠재 위험

- **surfaceSSOT 임계값 acc≤30m** — 너무 엄격하면 정상 지상 trip에서도 Tier 5 fallback 되어 회귀. 기존 fusion 거리 게이트(`passesFusionDistanceGate` 기본 50m)보다 좁힌 의도는 false-positive 차단. 실측 trip evidence(14m accuracy)와 정합.
- **arvlCd 정착 코드 {1,2,3,5}** — arrival 응답이 stale이면 Tier 1 false positive 가능. arrival 자체 신선도 TTL은 호출자(useArrivalInfo) 책임.
- **boardingLock 검사 제외** — default-hop이 lock anchor 기반이라 의도적. lock+stale 적분으로 다음 hop을 과도 ratchet하는 별개 케이스는 #1382 motion-stationary 가드 + 기존 line guard로 분리 책임.

## 관련

- Issue: #1415 (본 fix)
- 메모리: \`memory/lesson_lockless_route_hop_time_integration_ssot_assumption.md\` 외 3건
- 직전 시도 PR: #1382 (motion), #1386 (motion-2nd), #1363 (consensus), #1408 (trainProgressing) — 모두 본 fix로 upstream 해결

Closes #1418