### PR TITLE
fix(#1423): boarding-lock/sync KV cacheTtl<30 회귀 — verifyBoardingLockPersisted 0→30 + audit

### DIFF
--- a/backend/alarm-worker/src/__tests__/inMemoryKv.ts
+++ b/backend/alarm-worker/src/__tests__/inMemoryKv.ts
@@ -1,19 +1,33 @@
+import { KV_MIN_CACHE_TTL_SEC } from '../kvConsistency';
+
 /**
  * Cloudflare KVNamespace의 in-memory test double.
  * 여러 테스트 파일이 공유 — 동일 코드 중복으로 Sonar duplication에 잡히지 않게 단일 정의.
  *
  * 의도적으로 KVNamespace 일부 메서드(get/put/delete/list)만 구현 —
  * 실제 KV의 완전한 호환이 아닌, 테스트가 사용하는 표면만 mimic.
+ *
+ * #1423 — 런타임 제약 시뮬레이션. Cloudflare KV는 `cacheTtl < 30` read를 400으로 throw하지만
+ * 과거 본 mock은 옵션을 silently 무시 → spec 위반이 spy/assertion만 통과해 production 회귀로
+ * 빠져나갔다 (lesson_test_mock_must_validate_runtime.md). 이제 `get`이 production CF KV와
+ * 동일한 메시지로 throw해 테스트 단계에서 잡힌다.
  */
 export class InMemoryKV {
   store = new Map<string, { value: string; expiresAt?: number }>();
 
   /**
-   * 실제 KV.get(key, options) 시그니처 호환 — 옵션은 cacheTtl 등 캐시 hint이고
-   * in-memory store는 캐싱 자체가 없어 무시한다. #766에서 cron paths가 cacheTtl을 전달하기
-   * 시작해 호환 인자가 필요해졌다.
+   * 실제 KV.get(key, options) 시그니처 호환. #1423 — Cloudflare KV runtime은 `cacheTtl < 30`
+   * 을 `Invalid cache_ttl of N. Cache TTL must be at least 30.` 400 throw로 거절한다.
+   * 본 mock도 동일하게 throw해야 caller가 production과 같은 실패 모드를 테스트할 수 있다.
+   * cacheTtl 미지정(undefined)은 통과 — KV 기본 60s가 적용되는 caller 시나리오.
    */
-  async get(key: string, _options?: { cacheTtl?: number }): Promise<string | null> {
+  async get(key: string, options?: { cacheTtl?: number }): Promise<string | null> {
+    if (options?.cacheTtl !== undefined && options.cacheTtl < KV_MIN_CACHE_TTL_SEC) {
+      // #1423 — production Cloudflare KV가 던지는 메시지와 동일 포맷.
+      throw new Error(
+        `KV GET failed: 400 Invalid cache_ttl of ${options.cacheTtl}. Cache TTL must be at least ${KV_MIN_CACHE_TTL_SEC}.`,
+      );
+    }
     const entry = this.store.get(key);
     if (!entry) return null;
     if (entry.expiresAt && entry.expiresAt < Date.now()) {

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../index';
 import { progressKey, type TripProgress } from '../progress';
 import { pendingKey } from '../pendingPushes';
+import { KV_MIN_CACHE_TTL_SEC } from '../kvConsistency';
 import type { AnalyticsEngineWriter, Env } from '../types';
 import { InMemoryKV } from './inMemoryKv';
 
@@ -2682,13 +2683,29 @@ describe('verifyBoardingLockPersisted (#1364)', () => {
     expect(await verifyBoardingLockPersisted(kv as unknown as KVNamespace, expected)).toBe(false);
   });
 
-  it('verify는 cacheTtl=0으로 origin 조회', async () => {
+  it('verify는 cacheTtl=KV_MIN_CACHE_TTL_SEC(30)으로 read (#1423: cacheTtl<30은 CF KV가 400 throw)', async () => {
     const kv = new InMemoryKV();
     const trip = lockedTrip(Date.now() + 60_000);
     await kv.put('trip:tok-v', JSON.stringify(trip));
     const spy = vi.spyOn(kv, 'get');
     await verifyBoardingLockPersisted(kv as unknown as KVNamespace, trip);
-    expect(spy).toHaveBeenCalledWith('trip:tok-v', { cacheTtl: 0 });
+    // #1423 회귀 가드 — 0/<30 절대 금지. 30은 KV 런타임 floor.
+    expect(spy).toHaveBeenCalledWith('trip:tok-v', { cacheTtl: KV_MIN_CACHE_TTL_SEC });
+  });
+
+  // #1423 — sync handler 통합 회귀 가드. 본 helper가 cacheTtl<30을 받으면 InMemoryKV가
+  // production CF KV와 동일하게 `Invalid cache_ttl` throw → 본 PR 이전엔 mock이 silently
+  // 통과해 회귀가 production으로 빠져나갔다.
+  it('mock InMemoryKV가 cacheTtl<30 throw 시뮬레이션 (lesson_test_mock_must_validate_runtime)', async () => {
+    const kv = new InMemoryKV();
+    await kv.put('trip:t', '{}');
+    await expect(kv.get('trip:t', { cacheTtl: 0 })).rejects.toThrow(/Invalid cache_ttl of 0/);
+    await expect(kv.get('trip:t', { cacheTtl: 15 })).rejects.toThrow(/Cache TTL must be at least 30/);
+    await expect(kv.get('trip:t', { cacheTtl: 29 })).rejects.toThrow(/Invalid cache_ttl of 29/);
+    // boundary + safe
+    await expect(kv.get('trip:t', { cacheTtl: 30 })).resolves.toBe('{}');
+    await expect(kv.get('trip:t', { cacheTtl: 60 })).resolves.toBe('{}');
+    await expect(kv.get('trip:t')).resolves.toBe('{}');
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/kvConsistency.test.ts
+++ b/backend/alarm-worker/src/__tests__/kvConsistency.test.ts
@@ -3,14 +3,17 @@ import {
   CRON_READ_CACHE_TTL_SEC,
   KV_MIN_CACHE_TTL_SEC,
   assertCronCacheTtl,
+  assertKvCacheTtl,
+  enforceCacheTtlFloor,
 } from '../kvConsistency';
 
 /**
- * #1402 — KV cron read cacheTtl runtime guard.
+ * #1402 + #1423 — KV cacheTtl runtime guard.
  *
  * Cloudflare KV는 `cacheTtl < 30`을 런타임에서 throw. 신규 callsite가 0/10 같은 값을 silently
- * 사용해 listTrips/listPending이 abort되는 회귀(#1364/#1381)를 다시 만들지 못하도록 본 모듈이
- * caller 단계에서 명시 실패시킨다.
+ * 사용해 listTrips/listPending이 abort되는 회귀(#1364/#1381)와 `verifyBoardingLockPersisted`
+ * 가 sync handler 전체를 실패시키는 회귀(#1423)를 다시 만들지 못하도록 본 모듈이 caller
+ * 단계에서 명시 실패시킨다.
  */
 describe('kvConsistency', () => {
   it('CRON_READ_CACHE_TTL_SEC === KV_MIN_CACHE_TTL_SEC (cron read는 KV 최소 제약과 동일 floor)', () => {
@@ -47,5 +50,83 @@ describe('kvConsistency', () => {
 
   it('assertCronCacheTtl: -1 throw (defensive)', () => {
     expect(() => assertCronCacheTtl(-1)).toThrow(RangeError);
+  });
+
+  // #1423 — `assertKvCacheTtl`은 일반 KV read 경로 (sync handler / POST handler 등) 가드.
+  // cron 경로 전용 `assertCronCacheTtl`과 의미가 다르고, undefined를 허용한다 (caller가
+  // 옵션을 명시하지 않으면 KV 기본 60s 적용).
+  describe('assertKvCacheTtl (#1423)', () => {
+    it('undefined 통과 (KV 기본 60s가 caller 단계에서 적용됨)', () => {
+      expect(() => assertKvCacheTtl(undefined)).not.toThrow();
+    });
+
+    it('30 통과 (boundary, KV 최소 제약)', () => {
+      expect(() => assertKvCacheTtl(30)).not.toThrow();
+    });
+
+    it('60 통과 (KV 기본값)', () => {
+      expect(() => assertKvCacheTtl(60)).not.toThrow();
+    });
+
+    it('0 throw (#1423 회귀 차단 — verifyBoardingLockPersisted cacheTtl=0)', () => {
+      expect(() => assertKvCacheTtl(0)).toThrow(RangeError);
+      expect(() => assertKvCacheTtl(0)).toThrow(/Invalid KV cacheTtl 0/);
+    });
+
+    it('15 throw', () => {
+      expect(() => assertKvCacheTtl(15)).toThrow(/cacheTtl >= 30s/);
+    });
+
+    it('29 throw (boundary)', () => {
+      expect(() => assertKvCacheTtl(29)).toThrow(RangeError);
+    });
+
+    it('NaN throw (defensive)', () => {
+      expect(() => assertKvCacheTtl(Number.NaN)).toThrow(RangeError);
+    });
+
+    it('-1 throw (defensive)', () => {
+      expect(() => assertKvCacheTtl(-1)).toThrow(RangeError);
+    });
+  });
+
+  // #1423 — `enforceCacheTtlFloor`는 잘못된 값 차단이 아니라 안전한 값으로 정정 (clamp).
+  // sync handler처럼 "가장 작은 안전한 cacheTtl을 원함"을 명시할 때 사용.
+  describe('enforceCacheTtlFloor (#1423)', () => {
+    it('undefined → floor (30)', () => {
+      expect(enforceCacheTtlFloor(undefined)).toBe(KV_MIN_CACHE_TTL_SEC);
+    });
+
+    it('0 → floor (30)', () => {
+      expect(enforceCacheTtlFloor(0)).toBe(KV_MIN_CACHE_TTL_SEC);
+    });
+
+    it('15 → floor (30)', () => {
+      expect(enforceCacheTtlFloor(15)).toBe(KV_MIN_CACHE_TTL_SEC);
+    });
+
+    it('29 → floor (30, boundary)', () => {
+      expect(enforceCacheTtlFloor(29)).toBe(KV_MIN_CACHE_TTL_SEC);
+    });
+
+    it('30 → 30 (passthrough)', () => {
+      expect(enforceCacheTtlFloor(30)).toBe(30);
+    });
+
+    it('60 → 60 (passthrough)', () => {
+      expect(enforceCacheTtlFloor(60)).toBe(60);
+    });
+
+    it('600 → 600 (passthrough, 큰 값은 그대로)', () => {
+      expect(enforceCacheTtlFloor(600)).toBe(600);
+    });
+
+    it('NaN → floor (30, defensive)', () => {
+      expect(enforceCacheTtlFloor(Number.NaN)).toBe(KV_MIN_CACHE_TTL_SEC);
+    });
+
+    it('-1 → floor (30, 음수는 floor로 정정)', () => {
+      expect(enforceCacheTtlFloor(-1)).toBe(KV_MIN_CACHE_TTL_SEC);
+    });
   });
 });

--- a/backend/alarm-worker/src/__tests__/trips.test.ts
+++ b/backend/alarm-worker/src/__tests__/trips.test.ts
@@ -107,11 +107,12 @@ describe('trips KV CRUD', () => {
   });
 
   // #1364 — getTrip은 caller가 cacheTtl 지정 가능. read-after-write verification 경로.
-  it('getTrip forwards cacheTtl option to kv.get when provided (#1364)', async () => {
+  // #1423 — caller가 명시한 cacheTtl은 `assertKvCacheTtl`이 KV 런타임 floor 검증 후 forward.
+  it('getTrip forwards cacheTtl=30 option to kv.get when provided (#1364/#1423)', async () => {
     await putTrip(kv as unknown as KVNamespace, makeTrip());
     const spy = vi.spyOn(kv, 'get');
-    await getTrip(kv as unknown as KVNamespace, 'tok-1', { cacheTtl: 0 });
-    expect(spy).toHaveBeenCalledWith('trip:tok-1', { cacheTtl: 0 });
+    await getTrip(kv as unknown as KVNamespace, 'tok-1', { cacheTtl: 30 });
+    expect(spy).toHaveBeenCalledWith('trip:tok-1', { cacheTtl: 30 });
   });
 
   it('getTrip omits options arg when cacheTtl not specified (default KV cache)', async () => {
@@ -119,6 +120,28 @@ describe('trips KV CRUD', () => {
     const spy = vi.spyOn(kv, 'get');
     await getTrip(kv as unknown as KVNamespace, 'tok-1');
     expect(spy).toHaveBeenCalledWith('trip:tok-1');
+  });
+
+  // #1423 — getTrip은 caller가 cacheTtl<30을 넘기면 caller 단계에서 RangeError throw.
+  // production CF KV가 `Invalid cache_ttl` 400 throw하는 시점보다 한 단계 앞서 root cause를
+  // 분명히 한다. `verifyBoardingLockPersisted`가 cacheTtl=0으로 호출해 sync handler 전체를
+  // 실패시킨 회귀를 caller 단계에서 차단.
+  it.each([
+    ['0 (#1423 evidence)', 0],
+    ['15 (잘못된 cron 시도값)', 15],
+    ['29 (boundary)', 29],
+  ])('getTrip throws RangeError when cacheTtl=%s (< 30)', async (_label, ttl) => {
+    await putTrip(kv as unknown as KVNamespace, makeTrip());
+    await expect(getTrip(kv as unknown as KVNamespace, 'tok-1', { cacheTtl: ttl })).rejects.toThrow(
+      /cacheTtl >= 30s/,
+    );
+  });
+
+  it('getTrip allows cacheTtl=30 (boundary, KV 최소값)', async () => {
+    await putTrip(kv as unknown as KVNamespace, makeTrip());
+    await expect(
+      getTrip(kv as unknown as KVNamespace, 'tok-1', { cacheTtl: 30 }),
+    ).resolves.not.toBeNull();
   });
 
   // #1364 Layer 4 — stale lock auto-clear (line mismatch).

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -75,6 +75,7 @@ import {
   validateRegressionUpload,
   writeRegressionDataPoints,
 } from './regressionTelemetry';
+import { KV_MIN_CACHE_TTL_SEC } from './kvConsistency';
 import { getTrip, putTrip } from './trips';
 import {
   TRIP_STATUS_RETENTION_MS,
@@ -1002,8 +1003,10 @@ app.post('/boarding-lock/sync', async (c) => {
   // #1364 — read-after-write verification. Workers KV는 region간 eventually consistent —
   // PUT 직후 다른 region replica가 옛 값을 반환하면 다음 cron(43~60s 후)이 stale
   // `boardingLock.expiresAt`을 읽어 false-negative "lock missing or expired"가 발생한다(#765 회귀).
-  // cacheTtl=0으로 origin 조회 강제. 1회 retry 후에도 propagation 확인 실패 시 5xx 반환 —
-  // client가 다음 fix에서 재시도해 데이터 정합성 회복 기회를 확보한다.
+  // #1423 — cacheTtl은 KV 런타임 floor(30s) 사용. "origin 조회 강제"를 위해 cacheTtl=0을 쓰면
+  // Cloudflare KV가 `Invalid cache_ttl of 0` 400 throw로 sync handler 전체 실패한다(#1364
+  // 회귀, #1383 cron path fix가 본 read-after-write 경로를 cover 못 함). 1회 retry 후에도
+  // propagation 확인 실패 시 5xx 반환 — client가 다음 fix에서 재시도해 데이터 정합성 회복 기회를 확보한다.
   const verifyOk = await verifyBoardingLockPersisted(c.env.TRIPS, working);
   if (!verifyOk) {
     await putTrip(c.env.TRIPS, working);
@@ -1039,7 +1042,17 @@ app.post('/boarding-lock/sync', async (c) => {
 /**
  * #1364 — KV `putTrip` 직후 boardingLock이 실제로 propagation됐는지 확인.
  *
- * `cacheTtl: 0`으로 origin 조회를 강제하고, 다음 두 조건이 모두 만족할 때 true:
+ * cacheTtl은 Cloudflare KV 런타임 최소값(`KV_MIN_CACHE_TTL_SEC` = 30)을 사용한다.
+ * #1423 — 과거 댓글이 "cacheTtl=0으로 origin 조회 강제"라 명시했지만, Cloudflare KV runtime은
+ * read 경로 종류와 무관하게 `cacheTtl < 30`을 거절(`Invalid cache_ttl of 0` 400). 본 함수에
+ * cacheTtl=0을 넣으면 sync handler 전체가 실패해 device가 lock sync 못 함(#1423 evidence).
+ *
+ * 30s cacheTtl 하에서도 propagation race는 충분히 흡수된다 — sync handler가 putTrip을 호출한
+ * 같은 region replica는 즉시 fresh 값을 반환하고, 다른 region이라도 30s window 안에 새 값으로
+ * 정렬된다. 1회 retry로 propagation 완료를 한 번 더 확인한 뒤 실패 시 503으로 client에 retry
+ * 신호를 보낸다.
+ *
+ * 다음 두 조건이 모두 만족할 때 true:
  *   1) 저장한 trip이 read되어야 함 (lock 없는 trip은 lock 검증 생략)
  *   2) `boardingLock.expiresAt`이 기대치 이상(propagation 완료)
  *
@@ -1049,7 +1062,8 @@ export async function verifyBoardingLockPersisted(
   kv: KVNamespace,
   expected: Trip,
 ): Promise<boolean> {
-  const verified = await getTrip(kv, expected.token, { cacheTtl: 0 });
+  // #1423 — cacheTtl=KV_MIN_CACHE_TTL_SEC (30). 0/<30은 CF KV가 400 throw.
+  const verified = await getTrip(kv, expected.token, { cacheTtl: KV_MIN_CACHE_TTL_SEC });
   if (!verified) return false;
   if (!expected.boardingLock) return true;
   if (!verified.boardingLock) return false;

--- a/backend/alarm-worker/src/kvConsistency.ts
+++ b/backend/alarm-worker/src/kvConsistency.ts
@@ -1,21 +1,27 @@
 /**
- * KV read consistency floor (#1402, refactor of #765/#766/#770/#1364/#1381).
+ * KV read consistency floor (#1402, refactor of #765/#766/#770/#1364/#1381 + #1423).
  *
  * Cloudflare KV는 read 시 `cacheTtl`이 `30` 미만이면 런타임에서 `Invalid cache_ttl of X.
  * Cache TTL must be at least 30.` 오류를 던진다. 과거 회귀(#1364 cacheTtl=0, #1381 후속)는
  * "cron 사이클에서 stale snapshot을 막으려" 0/10s를 시도하다가 listTrips/listPending이 첫
  * iterate 시점에 abort → 모든 silent push 발사가 멈추는 사고로 이어졌다.
  *
- * 본 모듈은 단일 상수(`CRON_READ_CACHE_TTL_SEC`)와 런타임 가드(`assertCronCacheTtl`)를
- * 제공해 신규 callsite가 같은 회귀를 다시 만들지 못하도록 강제한다. #1399 시간기반 floor
- * 전진과 #1400 cache-key 변경이 새 stale-read race를 도입하지 않는 안전벨트.
+ * #1423: 같은 함정이 sync handler `verifyBoardingLockPersisted`에서 재발 — 본 모듈이
+ * "read-after-write 검증 경로는 cacheTtl=0 허용"이라 잘못 명시했고, 그 결과 `index.ts:1052`가
+ * `getTrip(..., { cacheTtl: 0 })` 호출 → 모든 `/boarding-lock/sync` POST가 400 throw로 실패.
+ * Cloudflare KV runtime은 cron이든 read-after-write든 **모든** read 경로에서 동일하게
+ * cacheTtl < 30을 거절한다. "예외 허용" 영역은 존재하지 않는다.
  *
- * 사용처: `trips.ts:listTrips`, `pendingPushes.ts:listPending`, `scheduled.ts` progress read,
- * 그 외 cron 경로의 KV read는 모두 이 상수를 import해야 한다.
+ * 본 모듈은 단일 상수(`KV_MIN_CACHE_TTL_SEC`)와 런타임 가드(`assertKvCacheTtl`,
+ * `assertCronCacheTtl`)를 제공해 신규 callsite가 같은 회귀를 다시 만들지 못하도록 강제한다.
+ * 추가로 `enforceCacheTtlFloor(ttl)`는 안전한 default 값으로 clamp해 caller가 직접 floor를
+ * 의식할 필요 없이 안전한 값을 얻을 수 있게 한다.
  *
- * NOTE: read-after-write 검증 경로(예: `index.ts:/boarding-lock/sync`의
- * `verifyBoardingLockPersisted`)는 단일 키 origin 강제 조회로 별도 정책이라 본 가드를 거치지
- * 않는다 — `getTrip(..., { cacheTtl: 0 })` 같은 명시 호출은 read-after-write 한정으로 허용.
+ * 사용처:
+ *   - cron read: `trips.ts:listTrips`, `pendingPushes.ts:listPending`, `scheduled.ts` progress
+ *     read → `CRON_READ_CACHE_TTL_SEC` 상수 + `assertCronCacheTtl` 가드
+ *   - 일반 KV read (POST handler, sync handler 등): caller가 직접 cacheTtl 옵션을 넘기는
+ *     경우 `assertKvCacheTtl`로 검증 (또는 `enforceCacheTtlFloor`로 clamp).
  */
 
 /**
@@ -43,4 +49,42 @@ export function assertCronCacheTtl(ttlSec: number): void {
       `Invalid cron cacheTtl ${ttlSec}. Cloudflare KV requires cacheTtl >= ${KV_MIN_CACHE_TTL_SEC}s for cron reads. See kvConsistency.ts.`,
     );
   }
+}
+
+/**
+ * 일반 KV read의 cacheTtl이 Cloudflare 런타임 최소 제약을 만족하는지 검증 (#1423).
+ *
+ * `assertCronCacheTtl`은 "cron read는 30s가 정책"이라는 의미가 더 강하고, 본 함수는 단순히
+ * "Cloudflare KV runtime이 받아들이는 cacheTtl인지" 확인하는 범용 가드다. POST handler /
+ * sync handler / verification 경로 등에서 caller가 cacheTtl을 명시 전달할 때 사용한다.
+ *
+ * `undefined` (= 옵션 미전달, 기본 60s)는 통과. caller가 명시적으로 숫자를 넣을 때만 검증.
+ *
+ * @throws RangeError — `ttlSec`가 숫자인데 `KV_MIN_CACHE_TTL_SEC` 미만.
+ */
+export function assertKvCacheTtl(ttlSec: number | undefined): void {
+  if (ttlSec === undefined) return;
+  if (!Number.isFinite(ttlSec) || ttlSec < KV_MIN_CACHE_TTL_SEC) {
+    throw new RangeError(
+      `Invalid KV cacheTtl ${ttlSec}. Cloudflare KV requires cacheTtl >= ${KV_MIN_CACHE_TTL_SEC}s. See kvConsistency.ts.`,
+    );
+  }
+}
+
+/**
+ * cacheTtl을 KV 런타임 최소 제약 위로 clamp (#1423).
+ *
+ * 0이나 음수, 작은 값을 caller가 "origin 조회 의도"로 전달하더라도, Cloudflare KV는 어떤
+ * 시나리오에서도 cacheTtl < 30을 받지 않는다. `assertKvCacheTtl`이 "잘못된 값 차단"이라면
+ * 본 함수는 "안전한 값으로 정정". sync handler처럼 propagation race를 줄이고 싶은 caller가
+ * "가장 작은 안전한 cacheTtl"을 명시적으로 얻을 때 사용한다.
+ *
+ * @param ttlSec — caller 의도. NaN/음수/0/30 미만은 floor로 clamp. 30 이상은 그대로.
+ * @returns `max(ttlSec, KV_MIN_CACHE_TTL_SEC)`. NaN/undefined도 floor 반환.
+ */
+export function enforceCacheTtlFloor(ttlSec: number | undefined): number {
+  if (ttlSec === undefined || !Number.isFinite(ttlSec)) {
+    return KV_MIN_CACHE_TTL_SEC;
+  }
+  return Math.max(ttlSec, KV_MIN_CACHE_TTL_SEC);
 }

--- a/backend/alarm-worker/src/progress.ts
+++ b/backend/alarm-worker/src/progress.ts
@@ -19,6 +19,8 @@
  *     lastTrackedArrivalEpoch, lastLaPushEpoch)도 progress에 mirror해 race에 무관하게 유지.
  */
 
+import { assertKvCacheTtl } from './kvConsistency';
+
 const PROGRESS_PREFIX = 'progress:';
 
 export interface TripProgress {
@@ -45,8 +47,9 @@ export function progressKey(token: string): string {
 
 /**
  * caller가 KV `cacheTtl`을 지정하기 위한 옵션.
- * cron path는 cacheTtl=10s를 명시해 PUT 직후 stale read를 방지한다 (#766).
+ * cron path는 cacheTtl=30s를 명시해 PUT 직후 stale read를 방지한다 (#766/#770).
  * POST handler는 인자 없이 호출 — 기본 cacheTtl(60s)이 적용된다.
+ * #1423 — `cacheTtl < 30`은 `assertKvCacheTtl`이 caller 단계에서 RangeError throw.
  */
 export interface GetProgressOptions {
   cacheTtl?: number;
@@ -57,6 +60,8 @@ export async function getProgress(
   token: string,
   options?: GetProgressOptions,
 ): Promise<TripProgress | null> {
+  // #1423 — caller가 cacheTtl 명시했으면 floor 검증.
+  assertKvCacheTtl(options?.cacheTtl);
   const raw = await kv.get(progressKey(token), options);
   if (!raw) return null;
   try {

--- a/backend/alarm-worker/src/trips.ts
+++ b/backend/alarm-worker/src/trips.ts
@@ -1,4 +1,8 @@
-import { assertCronCacheTtl, CRON_READ_CACHE_TTL_SEC as SHARED_CRON_TTL } from './kvConsistency';
+import {
+  assertCronCacheTtl,
+  assertKvCacheTtl,
+  CRON_READ_CACHE_TTL_SEC as SHARED_CRON_TTL,
+} from './kvConsistency';
 import type { Trip } from './types';
 
 /**
@@ -22,11 +26,11 @@ const TRIP_PREFIX = 'trip:';
  * cache_ttl of 0. Cache TTL must be at least 30.` throw로 `listTrips`가 첫 trip iterate
  * 시점에 abort되어 silent push 발사 0건 회귀(#1381 evidence).
  *
- * Resolution: cron path는 KV 최소 제약(30s)을 준수하고, region propagation 정합성은
- * sync handler가 책임진다 — `index.ts:/boarding-lock/sync`의 `verifyBoardingLockPersisted`
- * 는 단일 키 read-after-write 검증이라 cacheTtl 제약 사이드를 다르게 다룬다.
- * 본 상수는 `pendingPushes.ts:CRON_READ_CACHE_TTL_SEC(30)` /
- * `progress.ts`(10/cron, 60/POST handler)와 일관한 cron-read 정책으로 정렬한다.
+ * Resolution: 모든 KV read 경로(cron / read-after-write)는 KV 최소 제약(30s)을 준수한다.
+ * #1423 — 과거 본 파일 주석이 "sync handler는 cacheTtl=0 허용"이라 명시해 `index.ts:1052`
+ * `verifyBoardingLockPersisted`가 같은 함정에 재발 (`/boarding-lock/sync` 전체 400 fail).
+ * 이제 `getTrip`은 caller가 `cacheTtl`을 명시할 때 `assertKvCacheTtl`로 floor 검증한다 —
+ * caller 단계에서 명시 실패시켜 다음 callsite가 같은 회귀를 못 만들도록 차단.
  */
 const CRON_READ_CACHE_TTL_SEC = SHARED_CRON_TTL;
 
@@ -40,17 +44,24 @@ export async function putTrip(kv: KVNamespace, trip: Trip): Promise<void> {
 }
 
 /**
- * #1364 — getTrip은 caller가 cacheTtl을 지정해 stale read window를 명시 제어한다.
+ * getTrip은 caller가 cacheTtl을 지정해 stale read window를 명시 제어한다.
  *
  * 기본(미지정): 기본 KV cacheTtl(60s) 사용. read 경로 일반.
- * `cacheTtl: 0`: read-after-write verification 경로 — sync handler가 putTrip 직후
- *   propagation 확인 시 사용. origin 조회 강제로 stale snapshot 차단.
+ * `cacheTtl: 30+`: read-after-write verification 경로 — sync handler가 putTrip 직후
+ *   propagation 확인 시 사용. 30s window 안에 region propagation이 정렬되며, retry로 한 번 더
+ *   확인 후 실패 시 503 반환.
+ *
+ * #1423 — `cacheTtl < 30`은 `assertKvCacheTtl`이 caller 단계에서 RangeError throw.
+ * Cloudflare KV runtime이 throw하는 `Invalid cache_ttl` 사고(#1364/#1381)는 첫 iterate
+ * 시점에서야 발생해 root cause가 가려지지만, 본 가드는 호출 자체를 막아 명시적으로 실패시킨다.
  */
 export async function getTrip(
   kv: KVNamespace,
   token: string,
   options?: { cacheTtl?: number },
 ): Promise<Trip | null> {
+  // #1423 — caller가 cacheTtl 명시했으면 floor 검증. undefined는 KV 기본(60s) 사용 → 통과.
+  assertKvCacheTtl(options?.cacheTtl);
   const raw =
     options?.cacheTtl !== undefined
       ? await kv.get(tripKey(token), { cacheTtl: options.cacheTtl })


### PR DESCRIPTION
## Summary

`/boarding-lock/sync` POST handler가 KV GET 호출 시 `cacheTtl: 0`을 사용해 Cloudflare KV runtime이 `Invalid cache_ttl of 0. Cache TTL must be at least 30.` 400 throw → device sync 실패하는 회귀(#1423) 수정. #1383(cron path fix)이 cover 못 한 read-after-write 경로 박제.

Closes #1423

## Evidence

Backend wrangler tail `tasks/wrangler-tail-20260617-222159-origin-verify-2026-06-17.jsonl`:

```
22:32:40 | POST boarding-lock/sync | Error: KV GET failed: 400 Invalid cache_ttl of 0. Cache TTL must be at least 30.
22:40:10 | POST boarding-lock/sync | Error: KV GET failed: 400 Invalid cache_ttl of 0. Cache TTL must be at least 30.
22:50:06 | POST boarding-lock/sync | Error: KV GET failed: 400 Invalid cache_ttl of 0. Cache TTL must be at least 30.
```

## Root cause

`index.ts:1052` `verifyBoardingLockPersisted`가 `getTrip(kv, expected.token, { cacheTtl: 0 })` 호출.

`kvConsistency.ts` 본문 주석이 다음과 같이 잘못 명시:
> "read-after-write 검증 경로는 단일 키 origin 강제 조회로 별도 정책이라 본 가드를 거치지 않는다 — `getTrip(..., { cacheTtl: 0 })` 같은 명시 호출은 read-after-write 한정으로 허용."

→ 사실: Cloudflare KV runtime은 **모든** read 경로에서 cacheTtl < 30을 거절한다. "예외 허용" 영역은 존재하지 않는다.

## Changes

### `verifyBoardingLockPersisted` (`backend/alarm-worker/src/index.ts`)
- `cacheTtl: 0` → `cacheTtl: KV_MIN_CACHE_TTL_SEC` (30)
- 잘못된 댓글 정정 + #1423 context 박제

### `kvConsistency.ts` 보강
- 모듈 본문 주석에서 "허용 영역" 표현 제거 + #1423 evidence 박제
- `assertKvCacheTtl(ttl)` 신규 — 일반 KV read 경로 (sync handler / POST handler 등) 가드. undefined 통과, 숫자<30 RangeError throw.
- `enforceCacheTtlFloor(ttl)` 신규 — 안전한 값으로 clamp. caller가 "가장 작은 안전한 cacheTtl"을 명시적으로 얻을 때 사용.

### `trips.ts:getTrip` defense-in-depth
- 옵션 forward 전에 `assertKvCacheTtl(options?.cacheTtl)` 호출 — caller 단계에서 명시 실패. Cloudflare KV runtime이 첫 read 시점에야 throw하는 사고를 호출 직전으로 앞당겨 root cause 가시화.

### `progress.ts:getProgress` defensive audit
- 동일 가드 추가 — 같은 패턴 재발 방지.

### `__tests__/inMemoryKv.ts` mock 보강 (lesson_test_mock_must_validate_runtime)
- `get(key, { cacheTtl })`가 `cacheTtl < 30` 시 production CF KV와 동일 메시지로 throw.
- 과거 mock은 옵션을 silently 무시 → spec 위반이 spy/assertion만 통과해 production 회귀로 빠져나갔다(#1364/#1423 공통 원인).

## Audit 결과

`backend/alarm-worker/src/` 전체 KV.get 호출 사이트 5건 검증:

| 위치 | cacheTtl | 결과 |
|---|---|---|
| `index.ts:1066` verifyBoardingLockPersisted | **0 → 30 (이번 PR)** | 수정 |
| `trips.ts:67` getTrip | caller forward (assertKvCacheTtl guard 통과 후) | 안전 |
| `trips.ts:94` listTrips | `CRON_READ_CACHE_TTL_SEC` (30) | 기존 안전 |
| `pendingPushes.ts:112` listPending | `CRON_READ_CACHE_TTL_SEC` (30) | 기존 안전 |
| `scheduled.ts:620,642` getProgress | `CRON_PROGRESS_CACHE_TTL_SEC` (30) | 기존 안전 |

KV.get 옵션 미지정(default 60s) callsite 9건(`kalmanFilter` / `tripStatus` / `accelSeries` / `regressionTelemetry` / `quotaTracker` / `positionSeries` / `feedback` / `pendingPushes` / `recallAlerts` / `feedbackAdmin`) — 모두 안전. 추가 fix 없음.

## Test plan
- [x] Backend `npm test` 1422 tests 통과 (이전 1400 + 신규 22).
- [x] `kvConsistency.test.ts`: assertKvCacheTtl 8 케이스 + enforceCacheTtlFloor 9 케이스.
- [x] `trips.test.ts`: getTrip cacheTtl<30 RangeError throw 3 케이스 + boundary.
- [x] `index.test.ts`: verifyBoardingLockPersisted spy가 cacheTtl=30 받는지 회귀 가드 + InMemoryKV mock runtime constraint 시뮬레이션 통합 테스트.
- [x] `inMemoryKv.ts`: cacheTtl<30 throw 시뮬레이션 박제.
- [ ] **실기기/wrangler tail 1주 측정 — `Invalid cache_ttl` 에러 0건 확인** (사용자, epic close 조건).

## 회귀 방지 (lesson 박제)

이 PR은 두 lesson을 코드 + mock 양쪽에 박제:

1. **lesson_cron_cachettl_runtime_constraint** — "Cloudflare KV cacheTtl 최소 30s 런타임 강제". 이번 PR로 sync handler까지 확장.

2. **lesson_test_mock_must_validate_runtime** — "Test mock은 production runtime 제약 시뮬레이션해야 한다." InMemoryKV가 cacheTtl<30 throw 시뮬레이션 → 같은 회귀를 테스트 단계에서 잡는다.

## Out of scope

- 실기기 검증: 사용자가 머지 후 wrangler tail로 1주 측정 (epic close 조건).
- 기존 scheduled.test.ts type-check 에러(line 1677, `RequestInit<CfProperties>`)는 본 PR 범위 밖이며 dev에서 이미 존재 (#1402 commit fe7512c 시점). 별도 chore 이슈로 분리 권장.