### PR TITLE
feat(#1421): device-side auto-lock 측정 인프라

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   AppState,
   Modal,
@@ -70,6 +70,18 @@ import type { NearestStationResult } from '../../../shared/types/station';
 import { useTheme, spacing, radius, typography } from '../../../shared/theme';
 import { useBarometer } from '../../../shared/hooks/useBarometer';
 import { useLowPowerMode } from '../../../shared/hooks/useLowPowerMode';
+// #1421 — PR-AutoLock-1 측정 인프라. DebugModal이 SSOT consensus → stability buffer → direction verify
+// → inferAutoLockCandidate 결과를 dump에 노출. 동작 변경 0: lock 산출/sync 호출 없음.
+import { createConsensusStabilityBuffer } from '../../nearest-station/utils/consensusStabilityBuffer';
+import { verifyTrainDirection } from '../../nearest-station/utils/verifyTrainDirection';
+import {
+  inferAutoLockCandidate,
+  type DeviceAutoLockCandidate,
+} from '../../nearest-station/utils/inferAutoLockCandidate';
+import type {
+  ConsensusStabilitySnapshot,
+} from '../../nearest-station/utils/consensusStabilityBuffer';
+import type { VerifyTrainDirectionResult } from '../../nearest-station/utils/verifyTrainDirection';
 
 /**
  * #1215 (D9) — DebugModal 상태 가시화 신규 prop 묶음.
@@ -98,6 +110,32 @@ export interface SleepDebugState {
   sleepMode: boolean;
   /** shouldSuppressBySleepRule의 isFirstHop 입력 — 첫 hop 향하는 중인가. */
   firstHopApproaching: boolean;
+}
+
+/**
+ * #1421 — PR-AutoLock-1 측정 인프라. DebugModal에 노출할 device-side auto-lock 산출 상태 스냅샷.
+ *
+ * 본 PR은 측정만 — lock 산출/sync 호출 X. 모든 필드는 SSOT consensus → stability → direction
+ * 검증 → inferAutoLockCandidate 파이프라인의 현재 상태를 그대로 시각화한다.
+ *
+ * candidate null 사유는 다음 한 줄에 명시:
+ *   - 'no-ssot'           : surface/underground SSOT 둘 다 미합의 (Tier 1 신호 부재)
+ *   - 'stability-pending' : SSOT 합의되었으나 stability buffer threshold 미달
+ *   - 'direction-mismatch': SSOT + stability 통과했으나 trainCode 방향이 route와 불일치
+ *   - null                : candidate 산출됨
+ */
+export interface AutoLockDebugMeta {
+  /** SSOT 활성 — surface 또는 underground. */
+  surfaceSSOTActive: boolean;
+  undergroundSSOTActive: boolean;
+  /** Stability buffer 현재 snapshot. */
+  stability: ConsensusStabilitySnapshot;
+  /** verifyTrainDirection 결과 — SSOT 미합의 시 null. */
+  direction: VerifyTrainDirectionResult | null;
+  /** 최종 산출 후보 — 3 게이트 모두 통과 시 non-null. */
+  candidate: DeviceAutoLockCandidate | null;
+  /** candidate=null 시 사유. candidate 있으면 null. */
+  nullReason: 'no-ssot' | 'stability-pending' | 'direction-mismatch' | null;
 }
 
 const UNKNOWN_LABEL = '—';
@@ -399,6 +437,12 @@ interface BuildDumpArgs {
    * 미전달 시 `Date.now()` 사용. 테스트에서 결정적 출력 확보용.
    */
   nowMs?: number;
+  /**
+   * #1421 — Auto-lock Candidate 측정 스냅샷. 미전달 시 섹션은 (n/a) 표기.
+   * DebugModalInner가 매 render에서 useFusedNearestStation SSOT + stability buffer + direction을
+   * 계산해 주입한다. 본 PR은 측정만 — 동작 변경 없음.
+   */
+  autoLockMeta?: AutoLockDebugMeta;
 }
 
 /** dump 본체에서 사용하는 single builder 시그니처 — 본문 줄 배열을 반환. */
@@ -624,6 +668,67 @@ function buildCountersSection(args: BuildDumpArgs): string[] {
 }
 
 /**
+ * #1421 — Auto-lock Candidate 섹션. SSOT/stability/direction/candidate 4개 라인으로
+ * device-side auto-lock 측정 상태를 dump.
+ *
+ * meta 미전달 시 (n/a) — 호출자가 측정 비활성 또는 SSOT 객체 미주입.
+ */
+function buildAutoLockSection(args: BuildDumpArgs): string[] {
+  const m = args.autoLockMeta;
+  if (!m) return ['(n/a)'];
+  const ssotLine = `ssot=${formatSSOTLabel(m.surfaceSSOTActive, m.undergroundSSOTActive)}`;
+  const stabilityLine = `stability=${m.stability.stable ? 'stable' : 'pending'} count=${m.stability.count} stationId=${m.stability.stationId ?? UNKNOWN_LABEL}`;
+  const directionLine = m.direction
+    ? `direction=${m.direction.matched ? 'matched' : 'mismatch'} reason=${m.direction.reason}`
+    : `direction=${UNKNOWN_LABEL}`;
+  const candidateLine = m.candidate
+    ? `candidate=trainCode=${m.candidate.candidate.trainCode} line=${m.candidate.candidate.line} source=${m.candidate.source}`
+    : `candidate=null reason=${m.nullReason ?? UNKNOWN_LABEL}`;
+  return [ssotLine, stabilityLine, directionLine, candidateLine];
+}
+
+function formatSSOTLabel(surface: boolean, underground: boolean): string {
+  if (surface && underground) return 'surface+underground';
+  if (surface) return 'surface';
+  if (underground) return 'underground';
+  return 'none';
+}
+
+/**
+ * #1421 — arrival에서 trainCode에 매칭되는 row의 destination(종착명) 반환.
+ * 매칭 없으면 null. verifyTrainDirection 입력 trainTerminalStationName 산출용.
+ */
+function findArrivalTerminal(
+  arrival: import('../../../shared/types/arrival').StationArrival | null,
+  trainCode: string,
+): string | null {
+  if (!arrival) return null;
+  const allRows = [...arrival.up, ...arrival.down];
+  for (const row of allRows) {
+    if (row.trainCode === trainCode) return row.destination || null;
+  }
+  return null;
+}
+
+/**
+ * #1421 — candidate=null 사유 분류. 4단 cascade 중 첫 미달 게이트를 노출.
+ */
+function computeAutoLockNullReason(
+  hasSSOT: boolean,
+  stable: boolean,
+  directionMatched: boolean,
+  hasCandidate: boolean,
+): AutoLockDebugMeta['nullReason'] {
+  if (hasCandidate) return null;
+  if (!hasSSOT) return 'no-ssot';
+  if (!stable) return 'stability-pending';
+  if (!directionMatched) return 'direction-mismatch';
+  /* istanbul ignore next -- 3 게이트 모두 통과면 hasCandidate=true가 보장됨 — buildCandidate
+     실패는 lineToSubwayId null 케이스로 valid LineNumber에서 도달 불능. 방어 fallback. */
+  return null;
+}
+
+/**
  * #1346 — Share dump SSOT.
  *
  * 출력 형식: `## ${title}` + 본문 줄 + 다음 섹션 사이 빈 줄.
@@ -684,6 +789,8 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
   { title: 'Boarding Prompt Acceptance', build: buildBoardingPromptAcceptanceSection },
   // #1413 — reason별 누적 + 마지막 발생 시각.
   { title: 'Counters', build: buildCountersSection },
+  // #1421 — PR-AutoLock-1 측정 인프라. SSOT consensus → stability → direction → candidate 4줄.
+  { title: 'Auto-lock Candidate', build: buildAutoLockSection },
 ];
 
 function buildDumpText(args: BuildDumpArgs): string {
@@ -816,6 +923,9 @@ function DebugModalInner({
     environment,
     surfaceSSOTActive,
     undergroundSSOTActive,
+    // #1421 — PR-AutoLock-1 측정 인프라. SSOT 객체 직접 받아 inferAutoLockCandidate에 전달.
+    surfaceSSOT,
+    undergroundSSOT,
   } = useFusedNearestStation();
   // arc 길이 = trip의 hop 총 수. trip 미설정이면 0.
   const routeHopCount = arcStations.length;
@@ -889,6 +999,54 @@ function DebugModalInner({
       },
     [sleepProp, sleepMode, locklessTrip, currentHopIndex],
   );
+
+  // #1421 — PR-AutoLock-1 측정 인프라.
+  // DebugModal 인스턴스마다 buffer 1개 — 모달이 열린 동안만 누적된다(관찰자 효과 최소화).
+  const stabilityBufferRef = useRef(createConsensusStabilityBuffer());
+  // 매 render에서 SSOT 활성 시 stationId를 push, 비활성이면 null no-op.
+  // useEffect 대신 render-time 호출 — buffer는 effect에 의존하지 않는 순수 push (의존성: SSOT 객체 ref).
+  const activeSSOT = surfaceSSOT ?? undergroundSSOT;
+  const stability = stabilityBufferRef.current.push(activeSSOT?.station.id ?? null);
+
+  // 방향 검증: SSOT trainCode와 동일 trainCode arrival row를 찾아 그 row의 destination(종착명)을
+  // trainTerminalStationName으로 사용. 같은 trainCode가 arrival에 없으면 null → no-terminal.
+  const trainTerminalStationName = activeSSOT
+    ? findArrivalTerminal(arrival, activeSSOT.trainCode)
+    : null;
+  // arcStations 빈 경우 verifyTrainDirection이 routeStations.length=0으로 즉시 no-route 반환 →
+  // currentIdx/destinationIdx 입력은 사용되지 않는다. 0 fallback은 dead branch라 -1 그대로 전달.
+  const currentIdx = result
+    ? arcStations.findIndex((s) => s.id === result.station.id)
+    : -1;
+  const destinationIdx = arcStations.length - 1;
+  const direction = activeSSOT
+    ? verifyTrainDirection({
+        routeStations: arcStations,
+        currentIdx,
+        destinationIdx,
+        trainTerminalStationName,
+      })
+    : null;
+
+  const candidate = inferAutoLockCandidate({
+    surfaceSSOT,
+    undergroundSSOT,
+    stabilityStable: stability.stable,
+    directionMatched: direction?.matched ?? false,
+  });
+  const autoLockMeta: AutoLockDebugMeta = {
+    surfaceSSOTActive: surfaceSSOT !== null,
+    undergroundSSOTActive: undergroundSSOT !== null,
+    stability,
+    direction,
+    candidate,
+    nullReason: computeAutoLockNullReason(
+      surfaceSSOT !== null || undergroundSSOT !== null,
+      stability.stable,
+      direction?.matched ?? false,
+      candidate !== null,
+    ),
+  };
 
   const [logs, setLogs] = useState<AlarmLogEntry[]>([]);
   const [fusionLogs, setFusionLogs] = useState<readonly FusionDebugEntry[]>(() =>
@@ -988,6 +1146,8 @@ function DebugModalInner({
       // #1413 — UI에만 노출되던 BoardingLock/Estimator/Boarding Prompt(+Acceptance)/Counters를 share에 포함.
       boardingLock: lock,
       estimatorLog: estimatorLogs,
+      // #1421 — PR-AutoLock-1 측정 인프라. SSOT/stability/direction/candidate 4줄.
+      autoLockMeta,
     });
     void Share.share({ message });
   }, [
@@ -1025,6 +1185,8 @@ function DebugModalInner({
     // #1413 — BoardingLock/Estimator 신규 캡쳐.
     lock,
     estimatorLogs,
+    // #1421 — auto-lock meta는 render-time 산출. 의존성으로 추가해 stability flip 시 share 갱신.
+    autoLockMeta,
   ]);
 
   return (
@@ -1670,6 +1832,9 @@ export const __test__ = {
   formatOptionalNumber,
   formatOptionalTs,
   UNKNOWN_LABEL,
+  // #1421 — Auto-lock 측정 인프라 내부 헬퍼. 호출자는 DebugModal 자체에서 render-time 산출.
+  findArrivalTerminal,
+  computeAutoLockNullReason,
 };
 
 const styles = StyleSheet.create({

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -77,6 +77,7 @@ import { verifyTrainDirection } from '../../nearest-station/utils/verifyTrainDir
 import {
   inferAutoLockCandidate,
   type DeviceAutoLockCandidate,
+  type InferAutoLockCandidateInput,
 } from '../../nearest-station/utils/inferAutoLockCandidate';
 import type {
   ConsensusStabilitySnapshot,
@@ -678,13 +679,17 @@ function buildAutoLockSection(args: BuildDumpArgs): string[] {
   if (!m) return ['(n/a)'];
   const ssotLine = `ssot=${formatSSOTLabel(m.surfaceSSOTActive, m.undergroundSSOTActive)}`;
   const stabilityLine = `stability=${m.stability.stable ? 'stable' : 'pending'} count=${m.stability.count} stationId=${m.stability.stationId ?? UNKNOWN_LABEL}`;
-  const directionLine = m.direction
-    ? `direction=${m.direction.matched ? 'matched' : 'mismatch'} reason=${m.direction.reason}`
-    : `direction=${UNKNOWN_LABEL}`;
+  const directionLine = formatDirectionLine(m.direction);
   const candidateLine = m.candidate
     ? `candidate=trainCode=${m.candidate.candidate.trainCode} line=${m.candidate.candidate.line} source=${m.candidate.source}`
     : `candidate=null reason=${m.nullReason ?? UNKNOWN_LABEL}`;
   return [ssotLine, stabilityLine, directionLine, candidateLine];
+}
+
+function formatDirectionLine(direction: VerifyTrainDirectionResult | null): string {
+  if (!direction) return `direction=${UNKNOWN_LABEL}`;
+  const matchLabel = direction.matched ? 'matched' : 'mismatch';
+  return `direction=${matchLabel} reason=${direction.reason}`;
 }
 
 function formatSSOTLabel(surface: boolean, underground: boolean): string {
@@ -726,6 +731,58 @@ function computeAutoLockNullReason(
   /* istanbul ignore next -- 3 게이트 모두 통과면 hasCandidate=true가 보장됨 — buildCandidate
      실패는 lineToSubwayId null 케이스로 valid LineNumber에서 도달 불능. 방어 fallback. */
   return null;
+}
+
+/**
+ * #1421 — PR-AutoLock-1 측정 파이프라인. DebugModalInner의 render-time 산출 로직을
+ * 순수 함수로 분리 — SSOT 활성 cascade, stability push, direction verify, candidate 산출까지
+ * 한 곳에 모은다. DebugModalInner는 1줄 호출로 cognitive complexity 유지.
+ */
+function buildAutoLockMeta(input: {
+  readonly surfaceSSOT: InferAutoLockCandidateInput['surfaceSSOT'];
+  readonly undergroundSSOT: InferAutoLockCandidateInput['undergroundSSOT'];
+  readonly arrival: Parameters<typeof findArrivalTerminal>[0];
+  readonly result: NearestStationResult | null;
+  readonly arcStations: Parameters<typeof verifyTrainDirection>[0]['routeStations'];
+  readonly stabilityBuffer: ReturnType<typeof createConsensusStabilityBuffer>;
+}): AutoLockDebugMeta {
+  const { surfaceSSOT, undergroundSSOT, arrival, result, arcStations, stabilityBuffer } = input;
+  const activeSSOT = surfaceSSOT ?? undergroundSSOT;
+  const stability = stabilityBuffer.push(activeSSOT?.station.id ?? null);
+  const trainTerminalStationName = activeSSOT
+    ? findArrivalTerminal(arrival, activeSSOT.trainCode)
+    : null;
+  const currentIdx = result
+    ? arcStations.findIndex((s) => s.id === result.station.id)
+    : -1;
+  const destinationIdx = arcStations.length - 1;
+  const direction = activeSSOT
+    ? verifyTrainDirection({
+        routeStations: arcStations,
+        currentIdx,
+        destinationIdx,
+        trainTerminalStationName,
+      })
+    : null;
+  const candidate = inferAutoLockCandidate({
+    surfaceSSOT,
+    undergroundSSOT,
+    stabilityStable: stability.stable,
+    directionMatched: direction?.matched ?? false,
+  });
+  return {
+    surfaceSSOTActive: surfaceSSOT !== null,
+    undergroundSSOTActive: undergroundSSOT !== null,
+    stability,
+    direction,
+    candidate,
+    nullReason: computeAutoLockNullReason(
+      surfaceSSOT !== null || undergroundSSOT !== null,
+      stability.stable,
+      direction?.matched ?? false,
+      candidate !== null,
+    ),
+  };
 }
 
 /**
@@ -1000,53 +1057,17 @@ function DebugModalInner({
     [sleepProp, sleepMode, locklessTrip, currentHopIndex],
   );
 
-  // #1421 — PR-AutoLock-1 측정 인프라.
-  // DebugModal 인스턴스마다 buffer 1개 — 모달이 열린 동안만 누적된다(관찰자 효과 최소화).
+  // #1421 — PR-AutoLock-1 측정 인프라. buffer는 모달이 열린 동안만 누적(관찰자 효과 최소화).
+  // 산출 로직은 `buildAutoLockMeta`에 위임 — DebugModalInner는 호출 1줄.
   const stabilityBufferRef = useRef(createConsensusStabilityBuffer());
-  // 매 render에서 SSOT 활성 시 stationId를 push, 비활성이면 null no-op.
-  // useEffect 대신 render-time 호출 — buffer는 effect에 의존하지 않는 순수 push (의존성: SSOT 객체 ref).
-  const activeSSOT = surfaceSSOT ?? undergroundSSOT;
-  const stability = stabilityBufferRef.current.push(activeSSOT?.station.id ?? null);
-
-  // 방향 검증: SSOT trainCode와 동일 trainCode arrival row를 찾아 그 row의 destination(종착명)을
-  // trainTerminalStationName으로 사용. 같은 trainCode가 arrival에 없으면 null → no-terminal.
-  const trainTerminalStationName = activeSSOT
-    ? findArrivalTerminal(arrival, activeSSOT.trainCode)
-    : null;
-  // arcStations 빈 경우 verifyTrainDirection이 routeStations.length=0으로 즉시 no-route 반환 →
-  // currentIdx/destinationIdx 입력은 사용되지 않는다. 0 fallback은 dead branch라 -1 그대로 전달.
-  const currentIdx = result
-    ? arcStations.findIndex((s) => s.id === result.station.id)
-    : -1;
-  const destinationIdx = arcStations.length - 1;
-  const direction = activeSSOT
-    ? verifyTrainDirection({
-        routeStations: arcStations,
-        currentIdx,
-        destinationIdx,
-        trainTerminalStationName,
-      })
-    : null;
-
-  const candidate = inferAutoLockCandidate({
+  const autoLockMeta = buildAutoLockMeta({
     surfaceSSOT,
     undergroundSSOT,
-    stabilityStable: stability.stable,
-    directionMatched: direction?.matched ?? false,
+    arrival,
+    result,
+    arcStations,
+    stabilityBuffer: stabilityBufferRef.current,
   });
-  const autoLockMeta: AutoLockDebugMeta = {
-    surfaceSSOTActive: surfaceSSOT !== null,
-    undergroundSSOTActive: undergroundSSOT !== null,
-    stability,
-    direction,
-    candidate,
-    nullReason: computeAutoLockNullReason(
-      surfaceSSOT !== null || undergroundSSOT !== null,
-      stability.stable,
-      direction?.matched ?? false,
-      candidate !== null,
-    ),
-  };
 
   const [logs, setLogs] = useState<AlarmLogEntry[]>([]);
   const [fusionLogs, setFusionLogs] = useState<readonly FusionDebugEntry[]>(() =>

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -101,6 +101,9 @@ const fusedReturnFixture = (overrides: Record<string, unknown> = {}) => ({
   environment: 'unknown' as const,
   surfaceSSOTActive: false,
   undergroundSSOTActive: false,
+  // #1421 — PR-AutoLock-1 측정 인프라 신규 노출 필드 기본값.
+  surfaceSSOT: null,
+  undergroundSSOT: null,
   ...overrides,
 });
 const arrivalDefaults = {
@@ -140,6 +143,9 @@ const setupHookDefaults = () => {
     environment: 'unknown',
     surfaceSSOTActive: false,
     undergroundSSOTActive: false,
+    // #1421 — PR-AutoLock-1 측정 인프라.
+    surfaceSSOT: null,
+    undergroundSSOT: null,
   });
   mockUseArrivalInfo.mockReturnValue({ arrival: baseArrival, loading: false, isMock: false });
   mockUseSilentPushDiagnostics.mockReturnValue({
@@ -303,6 +309,59 @@ describe('DebugModal', () => {
     expect(screen.getByText('surface')).toBeTruthy();
     // 'active' 라벨이 surfaceSSOT/undergroundSSOT row에 노출.
     expect(screen.getAllByText('active').length).toBeGreaterThanOrEqual(2);
+  });
+
+  // #1421 — render-time auto-lock 측정 인프라가 SSOT 객체를 받아 share dump에 흘러간다.
+  it('#1421 — surfaceSSOT 객체 활성 시 share dump의 Auto-lock 섹션에 ssot=surface 노출', async () => {
+    const ssot = { station: baseResult.station, trainCode: 'U1' };
+    mockUseFusedNearestStation.mockReturnValue(
+      fusedReturnFixture({
+        surfaceSSOTActive: true,
+        surfaceSSOT: ssot,
+      }),
+    );
+    const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    fireEvent.press(screen.getByTestId('debug-share-dump'));
+    await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+    const msg = shareSpy.mock.calls[0][0].message;
+    expect(msg).toContain('## Auto-lock Candidate');
+    expect(msg).toContain('ssot=surface');
+    // arcStations 빈 fixture → verifyTrainDirection이 no-route 반환 (matched=false).
+    expect(msg).toContain('direction=mismatch reason=no-route');
+    shareSpy.mockRestore();
+  });
+
+  it('#1421 — undergroundSSOT 객체만 활성 시 ssot=underground 노출', async () => {
+    const ssot = { station: baseResult.station, trainCode: 'U1' };
+    mockUseFusedNearestStation.mockReturnValue(
+      fusedReturnFixture({
+        undergroundSSOTActive: true,
+        undergroundSSOT: ssot,
+        surfaceSSOT: null,
+      }),
+    );
+    const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    fireEvent.press(screen.getByTestId('debug-share-dump'));
+    await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+    const msg = shareSpy.mock.calls[0][0].message;
+    expect(msg).toContain('ssot=underground');
+    shareSpy.mockRestore();
+  });
+
+  it('#1421 — SSOT 모두 null이면 ssot=none, candidate=null reason=no-ssot', async () => {
+    const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    fireEvent.press(screen.getByTestId('debug-share-dump'));
+    await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+    const msg = shareSpy.mock.calls[0][0].message;
+    expect(msg).toContain('ssot=none');
+    expect(msg).toContain('candidate=null reason=no-ssot');
+    shareSpy.mockRestore();
   });
 
   it('arrival이 null이면 no arrival data를 표시한다', () => {
@@ -2350,6 +2409,8 @@ describe('DebugModal share SSOT (#1346)', () => {
     expect(dump).toContain('## Boarding Prompt');
     expect(dump).toContain('## Boarding Prompt Acceptance');
     expect(dump).toContain('## Counters');
+    // #1421 — PR-AutoLock-1 측정 인프라.
+    expect(dump).toContain('## Auto-lock Candidate');
     // suppressed reason 없으면 Gates 헤더 자체 생략(omitIfEmpty=true).
     expect(dump).not.toContain('## Gates');
   });
@@ -2638,6 +2699,171 @@ describe('DebugModal share SSOT (#1346)', () => {
     });
   });
 
+  // #1421 — PR-AutoLock-1 측정 인프라. SSOT/stability/direction/candidate 4줄 dump.
+  describe('#1421 Auto-lock Candidate 섹션', () => {
+    const STABLE_SNAPSHOT = { stable: true, stationId: '0201', count: 3 };
+    const PENDING_SNAPSHOT = { stable: false, stationId: '0201', count: 1 };
+    const EMPTY_SNAPSHOT = { stable: false, stationId: null, count: 0 };
+    const FORWARD = { matched: true, reason: 'forward' as const };
+    const REVERSE = { matched: false, reason: 'reverse' as const };
+    const SAMPLE_CANDIDATE = {
+      candidate: { trainCode: '2001', line: '2', subwayId: '1002' },
+      source: 'device-ssot' as const,
+      stationId: '0201',
+    };
+
+    it('autoLockMeta 미전달 시 (n/a) 출력', () => {
+      const dump = __test__.buildDumpText(makeSsotArgs());
+      const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
+      expect(section).toContain('(n/a)');
+    });
+
+    it('SSOT none + stability empty → ssot=none, candidate=null reason=no-ssot', () => {
+      const dump = __test__.buildDumpText(
+        makeSsotArgs({
+          autoLockMeta: {
+            surfaceSSOTActive: false,
+            undergroundSSOTActive: false,
+            stability: EMPTY_SNAPSHOT,
+            direction: null,
+            candidate: null,
+            nullReason: 'no-ssot',
+          },
+        }),
+      );
+      const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
+      expect(section).toContain('ssot=none');
+      expect(section).toContain('stability=pending count=0');
+      expect(section).toContain('candidate=null reason=no-ssot');
+    });
+
+    it('surface SSOT 활성 + stability pending → reason=stability-pending', () => {
+      const dump = __test__.buildDumpText(
+        makeSsotArgs({
+          autoLockMeta: {
+            surfaceSSOTActive: true,
+            undergroundSSOTActive: false,
+            stability: PENDING_SNAPSHOT,
+            direction: FORWARD,
+            candidate: null,
+            nullReason: 'stability-pending',
+          },
+        }),
+      );
+      const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
+      expect(section).toContain('ssot=surface');
+      expect(section).toContain('stability=pending count=1 stationId=0201');
+      expect(section).toContain('direction=matched reason=forward');
+      expect(section).toContain('reason=stability-pending');
+    });
+
+    it('underground SSOT 활성 + 모든 게이트 통과 → candidate 노출', () => {
+      const dump = __test__.buildDumpText(
+        makeSsotArgs({
+          autoLockMeta: {
+            surfaceSSOTActive: false,
+            undergroundSSOTActive: true,
+            stability: STABLE_SNAPSHOT,
+            direction: FORWARD,
+            candidate: SAMPLE_CANDIDATE,
+            nullReason: null,
+          },
+        }),
+      );
+      const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
+      expect(section).toContain('ssot=underground');
+      expect(section).toContain('stability=stable count=3');
+      expect(section).toContain('candidate=trainCode=2001 line=2 source=device-ssot');
+    });
+
+    it('두 SSOT 모두 활성이면 ssot=surface+underground', () => {
+      const dump = __test__.buildDumpText(
+        makeSsotArgs({
+          autoLockMeta: {
+            surfaceSSOTActive: true,
+            undergroundSSOTActive: true,
+            stability: STABLE_SNAPSHOT,
+            direction: FORWARD,
+            candidate: SAMPLE_CANDIDATE,
+            nullReason: null,
+          },
+        }),
+      );
+      const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
+      expect(section).toContain('ssot=surface+underground');
+    });
+
+    it('direction mismatch → reason=direction-mismatch', () => {
+      const dump = __test__.buildDumpText(
+        makeSsotArgs({
+          autoLockMeta: {
+            surfaceSSOTActive: true,
+            undergroundSSOTActive: false,
+            stability: STABLE_SNAPSHOT,
+            direction: REVERSE,
+            candidate: null,
+            nullReason: 'direction-mismatch',
+          },
+        }),
+      );
+      const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
+      expect(section).toContain('direction=mismatch reason=reverse');
+      expect(section).toContain('reason=direction-mismatch');
+    });
+
+    it('direction=null (SSOT 미합의)이면 direction=—', () => {
+      const dump = __test__.buildDumpText(
+        makeSsotArgs({
+          autoLockMeta: {
+            surfaceSSOTActive: false,
+            undergroundSSOTActive: false,
+            stability: EMPTY_SNAPSHOT,
+            direction: null,
+            candidate: null,
+            nullReason: 'no-ssot',
+          },
+        }),
+      );
+      const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
+      expect(section).toContain('direction=—');
+    });
+
+    it('stability stationId=null이면 stationId=— (빈 buffer)', () => {
+      const dump = __test__.buildDumpText(
+        makeSsotArgs({
+          autoLockMeta: {
+            surfaceSSOTActive: false,
+            undergroundSSOTActive: false,
+            stability: EMPTY_SNAPSHOT,
+            direction: null,
+            candidate: null,
+            nullReason: 'no-ssot',
+          },
+        }),
+      );
+      const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
+      expect(section).toContain('stationId=—');
+    });
+
+    it('nullReason=null + candidate=null 동시(방어 fallback) → reason=—', () => {
+      // 호출자가 inconsistent state 주입 시 graceful 표기 보장 (cascade 어디서도 분류 안 됐을 때).
+      const dump = __test__.buildDumpText(
+        makeSsotArgs({
+          autoLockMeta: {
+            surfaceSSOTActive: false,
+            undergroundSSOTActive: false,
+            stability: EMPTY_SNAPSHOT,
+            direction: null,
+            candidate: null,
+            nullReason: null,
+          },
+        }),
+      );
+      const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
+      expect(section).toContain('candidate=null reason=—');
+    });
+  });
+
   it('DebugModal share button: fusion log buffer가 share 텍스트에 흐른다 (#1346)', async () => {
     const { pushFusionDebugEntry, clearFusionDebugEntries } = jest.requireActual(
       '../../../nearest-station/utils/fusionDebugBuffer',
@@ -2665,6 +2891,77 @@ describe('DebugModal share SSOT (#1346)', () => {
     expect(msg).toContain('용마산(7)');
     shareSpy.mockRestore();
     clearFusionDebugEntries();
+  });
+});
+
+// #1421 — Auto-lock 측정 인프라 내부 헬퍼. DebugModalInner의 render-time 산출 로직 단위 검증.
+describe('DebugModal helpers — #1421 auto-lock', () => {
+  const { findArrivalTerminal, computeAutoLockNullReason } = __test__;
+
+  describe('findArrivalTerminal', () => {
+    it('arrival null이면 null 반환', () => {
+      expect(findArrivalTerminal(null, 'X')).toBeNull();
+    });
+
+    it('matching trainCode의 destination 반환 (up 슬롯)', () => {
+      const arrival: StationArrival = {
+        up: [
+          { ...arrivalDefaults, destination: '한성대입구', arrivalSeconds: 30, statusMessage: '', trainCode: 'T1', arrivalMinutes: 1 },
+        ],
+        down: [],
+      };
+      expect(findArrivalTerminal(arrival, 'T1')).toBe('한성대입구');
+    });
+
+    it('matching trainCode의 destination 반환 (down 슬롯)', () => {
+      const arrival: StationArrival = {
+        up: [],
+        down: [
+          { ...arrivalDefaults, destination: '오이도', arrivalSeconds: 60, statusMessage: '', trainCode: 'T2', arrivalMinutes: 1 },
+        ],
+      };
+      expect(findArrivalTerminal(arrival, 'T2')).toBe('오이도');
+    });
+
+    it('matching trainCode 없으면 null', () => {
+      const arrival: StationArrival = {
+        up: [{ ...arrivalDefaults, destination: '한성대입구', arrivalSeconds: 30, statusMessage: '', trainCode: 'T1', arrivalMinutes: 1 }],
+        down: [],
+      };
+      expect(findArrivalTerminal(arrival, 'OTHER')).toBeNull();
+    });
+
+    it('destination이 빈 문자열이면 null (falsy fallback)', () => {
+      const arrival: StationArrival = {
+        up: [{ ...arrivalDefaults, destination: '', arrivalSeconds: 30, statusMessage: '', trainCode: 'T1', arrivalMinutes: 1 }],
+        down: [],
+      };
+      expect(findArrivalTerminal(arrival, 'T1')).toBeNull();
+    });
+  });
+
+  describe('computeAutoLockNullReason', () => {
+    it('candidate 있으면 null 반환', () => {
+      expect(computeAutoLockNullReason(true, true, true, true)).toBeNull();
+    });
+
+    it('SSOT 없으면 no-ssot', () => {
+      expect(computeAutoLockNullReason(false, false, false, false)).toBe('no-ssot');
+    });
+
+    it('SSOT 있고 stable 아니면 stability-pending', () => {
+      expect(computeAutoLockNullReason(true, false, false, false)).toBe('stability-pending');
+    });
+
+    it('SSOT + stable이지만 direction 미일치면 direction-mismatch', () => {
+      expect(computeAutoLockNullReason(true, true, false, false)).toBe('direction-mismatch');
+    });
+
+    it('3 게이트 모두 통과 + hasCandidate=false (inconsistent state) → fallback null', () => {
+      // buildCandidate가 lineToSubwayId null 반환 시 도달 가능 — valid LineNumber에선 미도달.
+      // 방어 fallback 분기 자체를 검증.
+      expect(computeAutoLockNullReason(true, true, true, false)).toBeNull();
+    });
   });
 });
 

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -2700,6 +2700,7 @@ describe('DebugModal share SSOT (#1346)', () => {
   });
 
   // #1421 — PR-AutoLock-1 측정 인프라. SSOT/stability/direction/candidate 4줄 dump.
+  // CPD 회피 (lesson_sonarcloud_dup_prevention): it.each + factory + wrapper 패턴.
   describe('#1421 Auto-lock Candidate 섹션', () => {
     const STABLE_SNAPSHOT = { stable: true, stationId: '0201', count: 3 };
     const PENDING_SNAPSHOT = { stable: false, stationId: '0201', count: 1 };
@@ -2712,155 +2713,135 @@ describe('DebugModal share SSOT (#1346)', () => {
       stationId: '0201',
     };
 
-    it('autoLockMeta 미전달 시 (n/a) 출력', () => {
-      const dump = __test__.buildDumpText(makeSsotArgs());
-      const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
-      expect(section).toContain('(n/a)');
-    });
-
-    it('SSOT none + stability empty → ssot=none, candidate=null reason=no-ssot', () => {
+    type AutoLockMeta = NonNullable<Parameters<typeof __test__.buildDumpText>[0]['autoLockMeta']>;
+    const dumpAutoLockSection = (meta?: AutoLockMeta): string => {
       const dump = __test__.buildDumpText(
-        makeSsotArgs({
-          autoLockMeta: {
-            surfaceSSOTActive: false,
-            undergroundSSOTActive: false,
-            stability: EMPTY_SNAPSHOT,
-            direction: null,
-            candidate: null,
-            nullReason: 'no-ssot',
-          },
-        }),
+        makeSsotArgs(meta ? { autoLockMeta: meta } : undefined),
       );
-      const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
-      expect(section).toContain('ssot=none');
-      expect(section).toContain('stability=pending count=0');
-      expect(section).toContain('candidate=null reason=no-ssot');
-    });
+      return dump.slice(dump.indexOf('## Auto-lock Candidate'));
+    };
 
-    it('surface SSOT 활성 + stability pending → reason=stability-pending', () => {
-      const dump = __test__.buildDumpText(
-        makeSsotArgs({
-          autoLockMeta: {
-            surfaceSSOTActive: true,
-            undergroundSSOTActive: false,
-            stability: PENDING_SNAPSHOT,
-            direction: FORWARD,
-            candidate: null,
-            nullReason: 'stability-pending',
-          },
-        }),
-      );
-      const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
-      expect(section).toContain('ssot=surface');
-      expect(section).toContain('stability=pending count=1 stationId=0201');
-      expect(section).toContain('direction=matched reason=forward');
-      expect(section).toContain('reason=stability-pending');
-    });
-
-    it('underground SSOT 활성 + 모든 게이트 통과 → candidate 노출', () => {
-      const dump = __test__.buildDumpText(
-        makeSsotArgs({
-          autoLockMeta: {
-            surfaceSSOTActive: false,
-            undergroundSSOTActive: true,
-            stability: STABLE_SNAPSHOT,
-            direction: FORWARD,
-            candidate: SAMPLE_CANDIDATE,
-            nullReason: null,
-          },
-        }),
-      );
-      const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
-      expect(section).toContain('ssot=underground');
-      expect(section).toContain('stability=stable count=3');
-      expect(section).toContain('candidate=trainCode=2001 line=2 source=device-ssot');
-    });
-
-    it('두 SSOT 모두 활성이면 ssot=surface+underground', () => {
-      const dump = __test__.buildDumpText(
-        makeSsotArgs({
-          autoLockMeta: {
-            surfaceSSOTActive: true,
-            undergroundSSOTActive: true,
-            stability: STABLE_SNAPSHOT,
-            direction: FORWARD,
-            candidate: SAMPLE_CANDIDATE,
-            nullReason: null,
-          },
-        }),
-      );
-      const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
-      expect(section).toContain('ssot=surface+underground');
-    });
-
-    it('direction mismatch → reason=direction-mismatch', () => {
-      const dump = __test__.buildDumpText(
-        makeSsotArgs({
-          autoLockMeta: {
-            surfaceSSOTActive: true,
-            undergroundSSOTActive: false,
-            stability: STABLE_SNAPSHOT,
-            direction: REVERSE,
-            candidate: null,
-            nullReason: 'direction-mismatch',
-          },
-        }),
-      );
-      const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
-      expect(section).toContain('direction=mismatch reason=reverse');
-      expect(section).toContain('reason=direction-mismatch');
-    });
-
-    it('direction=null (SSOT 미합의)이면 direction=—', () => {
-      const dump = __test__.buildDumpText(
-        makeSsotArgs({
-          autoLockMeta: {
-            surfaceSSOTActive: false,
-            undergroundSSOTActive: false,
-            stability: EMPTY_SNAPSHOT,
-            direction: null,
-            candidate: null,
-            nullReason: 'no-ssot',
-          },
-        }),
-      );
-      const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
-      expect(section).toContain('direction=—');
-    });
-
-    it('stability stationId=null이면 stationId=— (빈 buffer)', () => {
-      const dump = __test__.buildDumpText(
-        makeSsotArgs({
-          autoLockMeta: {
-            surfaceSSOTActive: false,
-            undergroundSSOTActive: false,
-            stability: EMPTY_SNAPSHOT,
-            direction: null,
-            candidate: null,
-            nullReason: 'no-ssot',
-          },
-        }),
-      );
-      const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
-      expect(section).toContain('stationId=—');
-    });
-
-    it('nullReason=null + candidate=null 동시(방어 fallback) → reason=—', () => {
-      // 호출자가 inconsistent state 주입 시 graceful 표기 보장 (cascade 어디서도 분류 안 됐을 때).
-      const dump = __test__.buildDumpText(
-        makeSsotArgs({
-          autoLockMeta: {
-            surfaceSSOTActive: false,
-            undergroundSSOTActive: false,
-            stability: EMPTY_SNAPSHOT,
-            direction: null,
-            candidate: null,
-            nullReason: null,
-          },
-        }),
-      );
-      const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
-      expect(section).toContain('candidate=null reason=—');
+    it.each<{
+      readonly name: string;
+      readonly meta: AutoLockMeta | undefined;
+      readonly contains: readonly string[];
+    }>([
+      {
+        name: 'autoLockMeta 미전달 시 (n/a) 출력',
+        meta: undefined,
+        contains: ['(n/a)'],
+      },
+      {
+        name: 'SSOT none + stability empty → ssot=none, candidate=null reason=no-ssot',
+        meta: {
+          surfaceSSOTActive: false,
+          undergroundSSOTActive: false,
+          stability: EMPTY_SNAPSHOT,
+          direction: null,
+          candidate: null,
+          nullReason: 'no-ssot',
+        },
+        contains: ['ssot=none', 'stability=pending count=0', 'candidate=null reason=no-ssot'],
+      },
+      {
+        name: 'surface SSOT 활성 + stability pending → reason=stability-pending',
+        meta: {
+          surfaceSSOTActive: true,
+          undergroundSSOTActive: false,
+          stability: PENDING_SNAPSHOT,
+          direction: FORWARD,
+          candidate: null,
+          nullReason: 'stability-pending',
+        },
+        contains: [
+          'ssot=surface',
+          'stability=pending count=1 stationId=0201',
+          'direction=matched reason=forward',
+          'reason=stability-pending',
+        ],
+      },
+      {
+        name: 'underground SSOT 활성 + 모든 게이트 통과 → candidate 노출',
+        meta: {
+          surfaceSSOTActive: false,
+          undergroundSSOTActive: true,
+          stability: STABLE_SNAPSHOT,
+          direction: FORWARD,
+          candidate: SAMPLE_CANDIDATE,
+          nullReason: null,
+        },
+        contains: [
+          'ssot=underground',
+          'stability=stable count=3',
+          'candidate=trainCode=2001 line=2 source=device-ssot',
+        ],
+      },
+      {
+        name: '두 SSOT 모두 활성이면 ssot=surface+underground',
+        meta: {
+          surfaceSSOTActive: true,
+          undergroundSSOTActive: true,
+          stability: STABLE_SNAPSHOT,
+          direction: FORWARD,
+          candidate: SAMPLE_CANDIDATE,
+          nullReason: null,
+        },
+        contains: ['ssot=surface+underground'],
+      },
+      {
+        name: 'direction mismatch → reason=direction-mismatch',
+        meta: {
+          surfaceSSOTActive: true,
+          undergroundSSOTActive: false,
+          stability: STABLE_SNAPSHOT,
+          direction: REVERSE,
+          candidate: null,
+          nullReason: 'direction-mismatch',
+        },
+        contains: ['direction=mismatch reason=reverse', 'reason=direction-mismatch'],
+      },
+      {
+        name: 'direction=null (SSOT 미합의)이면 direction=—',
+        meta: {
+          surfaceSSOTActive: false,
+          undergroundSSOTActive: false,
+          stability: EMPTY_SNAPSHOT,
+          direction: null,
+          candidate: null,
+          nullReason: 'no-ssot',
+        },
+        contains: ['direction=—'],
+      },
+      {
+        name: 'stability stationId=null이면 stationId=— (빈 buffer)',
+        meta: {
+          surfaceSSOTActive: false,
+          undergroundSSOTActive: false,
+          stability: EMPTY_SNAPSHOT,
+          direction: null,
+          candidate: null,
+          nullReason: 'no-ssot',
+        },
+        contains: ['stationId=—'],
+      },
+      {
+        // 호출자가 inconsistent state 주입 시 graceful 표기 보장 (cascade 어디서도 분류 안 됐을 때).
+        name: 'nullReason=null + candidate=null 동시(방어 fallback) → reason=—',
+        meta: {
+          surfaceSSOTActive: false,
+          undergroundSSOTActive: false,
+          stability: EMPTY_SNAPSHOT,
+          direction: null,
+          candidate: null,
+          nullReason: null,
+        },
+        contains: ['candidate=null reason=—'],
+      },
+    ])('$name', ({ meta, contains }) => {
+      const section = dumpAutoLockSection(meta);
+      for (const expected of contains) {
+        expect(section).toContain(expected);
+      }
     });
   });
 

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -165,6 +165,13 @@ interface UseFusedNearestStationReturn {
   surfaceSSOTActive: boolean;
   /** #1418 — 지하 Tier 1 SSOT(WiFi/Position-Train + Arrival) 합의 활성 여부. */
   undergroundSSOTActive: boolean;
+  /**
+   * #1421 — PR-AutoLock-1 측정 인프라. SSOT 합의 객체 그대로 노출 (boolean만으로는 trainCode/
+   * stationId가 누락돼 device-side auto-lock candidate 산출이 불가). DebugModal Auto-lock 섹션이
+   * 직접 inferAutoLockCandidate에 넘긴다. 본 PR은 측정만 — lock 산출/sync 호출 없음.
+   */
+  surfaceSSOT: { station: import('../../../shared/types/station').Station; trainCode: string } | null;
+  undergroundSSOT: { station: import('../../../shared/types/station').Station; trainCode: string } | null;
   refresh: () => Promise<void>;
 }
 
@@ -1120,6 +1127,9 @@ export function useFusedNearestStation(
     environment,
     surfaceSSOTActive: surfaceSSOT !== null,
     undergroundSSOTActive: undergroundSSOT !== null,
+    // #1421 — DebugModal Auto-lock 측정 섹션이 SSOT 객체를 inferAutoLockCandidate에 직접 전달.
+    surfaceSSOT,
+    undergroundSSOT,
     refresh: gps.refresh,
   };
 }

--- a/src/features/nearest-station/utils/__tests__/consensusStabilityBuffer.test.ts
+++ b/src/features/nearest-station/utils/__tests__/consensusStabilityBuffer.test.ts
@@ -1,0 +1,96 @@
+/**
+ * #1421 — PR-AutoLock-1 측정 인프라.
+ *
+ * consensusStabilityBuffer 단위 테스트. Ring buffer size=5, threshold=3 기본값 경계 +
+ * stationId 변경/null reset / snapshot 조회 형태 검증.
+ */
+
+import { createConsensusStabilityBuffer } from '../consensusStabilityBuffer';
+
+describe('createConsensusStabilityBuffer', () => {
+  it('초기 snapshot은 stable=false, stationId=null, count=0', () => {
+    const buf = createConsensusStabilityBuffer();
+    expect(buf.snapshot()).toEqual({ stable: false, stationId: null, count: 0 });
+  });
+
+  it('동일 stationId 3건 연속 push 시 stable=true', () => {
+    const buf = createConsensusStabilityBuffer();
+    expect(buf.push('A').stable).toBe(false);
+    expect(buf.push('A').stable).toBe(false);
+    const third = buf.push('A');
+    expect(third.stable).toBe(true);
+    expect(third.stationId).toBe('A');
+    expect(third.count).toBe(3);
+  });
+
+  it('size=5 ring buffer — 5번째 항목 push 후에도 마지막 5건만 보존', () => {
+    const buf = createConsensusStabilityBuffer();
+    buf.push('A');
+    buf.push('A');
+    buf.push('B');
+    buf.push('B');
+    buf.push('B');
+    // 마지막 3건이 모두 B → stable=true(B)
+    expect(buf.snapshot()).toEqual({ stable: true, stationId: 'B', count: 3 });
+    // 6번째 push 시 가장 오래된 A가 밀려남.
+    const sixth = buf.push('B');
+    expect(sixth).toEqual({ stable: true, stationId: 'B', count: 4 });
+  });
+
+  it('majority vote — N=5 중 다수 station 결정', () => {
+    const buf = createConsensusStabilityBuffer();
+    buf.push('A');
+    buf.push('B');
+    buf.push('A');
+    buf.push('B');
+    buf.push('A'); // A=3, B=2 → stable(A)
+    expect(buf.snapshot()).toEqual({ stable: true, stationId: 'A', count: 3 });
+  });
+
+  it('동수면 stable=false', () => {
+    const buf = createConsensusStabilityBuffer();
+    buf.push('A');
+    buf.push('B');
+    buf.push('A');
+    buf.push('B');
+    // A=2, B=2 → 가장 많은 항목이 2건이라 threshold=3 미달.
+    expect(buf.snapshot().stable).toBe(false);
+  });
+
+  it('null push는 buffer에 기록되지 않는다 (신호 부재 = no-op)', () => {
+    const buf = createConsensusStabilityBuffer();
+    buf.push('A');
+    buf.push(null);
+    buf.push('A');
+    buf.push(null);
+    buf.push('A');
+    expect(buf.snapshot()).toEqual({ stable: true, stationId: 'A', count: 3 });
+  });
+
+  it('reset()은 buffer 비움', () => {
+    const buf = createConsensusStabilityBuffer();
+    buf.push('A');
+    buf.push('A');
+    buf.push('A');
+    buf.reset();
+    expect(buf.snapshot()).toEqual({ stable: false, stationId: null, count: 0 });
+  });
+
+  it('size=5 / threshold=3 커스터마이즈 (테스트 결정성 확보용)', () => {
+    const buf = createConsensusStabilityBuffer({ size: 3, threshold: 2 });
+    buf.push('A');
+    expect(buf.push('A').stable).toBe(true);
+  });
+
+  it('threshold=1이면 첫 push에서 stable=true', () => {
+    const buf = createConsensusStabilityBuffer({ size: 3, threshold: 1 });
+    expect(buf.push('A').stable).toBe(true);
+  });
+
+  it('size=1이면 마지막 1건만 보존', () => {
+    const buf = createConsensusStabilityBuffer({ size: 1, threshold: 1 });
+    buf.push('A');
+    const r = buf.push('B');
+    expect(r).toEqual({ stable: true, stationId: 'B', count: 1 });
+  });
+});

--- a/src/features/nearest-station/utils/__tests__/inferAutoLockCandidate.test.ts
+++ b/src/features/nearest-station/utils/__tests__/inferAutoLockCandidate.test.ts
@@ -1,0 +1,118 @@
+/**
+ * #1421 — PR-AutoLock-1 측정 인프라.
+ *
+ * inferAutoLockCandidate 단위 테스트. SSOT consensus (surface 또는 underground) + stability buffer
+ * stable + direction verified 3개 게이트가 모두 충족된 경우에만 AutoLockCandidate를 산출, 그 외 null.
+ *
+ * 본 PR은 측정만 — 실제 lock 산출 / sync 호출은 PR-AutoLock-2.
+ */
+
+import { inferAutoLockCandidate } from '../inferAutoLockCandidate';
+import { MOCK_STATIONS } from '../../../../testUtils/fixtures';
+import type { LineNumber, Station } from '../../../../shared/types/station';
+
+function station(name: string, line: LineNumber): Station {
+  return { id: `${line}-${name}`, name, line, lineColor: '#000', lat: 0, lng: 0 };
+}
+
+const routeStations: Station[] = [
+  station('A', '2'),
+  station('B', '2'),
+  station('C', '2'),
+];
+
+const surfaceSSOT = { station: MOCK_STATIONS.gangnam, trainCode: '2001' };
+
+describe('inferAutoLockCandidate', () => {
+  it('모든 게이트 통과 시 DeviceAutoLockCandidate 반환 (surface SSOT 경로)', () => {
+    const result = inferAutoLockCandidate({
+      surfaceSSOT,
+      undergroundSSOT: null,
+      stabilityStable: true,
+      directionMatched: true,
+    });
+    // source는 'device-ssot' 고정 (현 PR 측정 인프라).
+    expect(result?.candidate).toEqual({
+      trainCode: '2001',
+      line: '2',
+      subwayId: '1002',
+    });
+    expect(result?.source).toBe('device-ssot');
+    expect(result?.stationId).toBe(MOCK_STATIONS.gangnam.id);
+  });
+
+  it('underground SSOT만 활성 + 모든 게이트 통과', () => {
+    const result = inferAutoLockCandidate({
+      surfaceSSOT: null,
+      undergroundSSOT: { station: MOCK_STATIONS.chungmuro, trainCode: '3010' },
+      stabilityStable: true,
+      directionMatched: true,
+    });
+    expect(result?.candidate.trainCode).toBe('3010');
+    expect(result?.candidate.line).toBe('3');
+  });
+
+  it('두 SSOT 모두 활성이면 surface 우선', () => {
+    const result = inferAutoLockCandidate({
+      surfaceSSOT,
+      undergroundSSOT: { station: MOCK_STATIONS.chungmuro, trainCode: '3010' },
+      stabilityStable: true,
+      directionMatched: true,
+    });
+    expect(result?.candidate.trainCode).toBe('2001');
+    expect(result?.candidate.line).toBe('2');
+  });
+
+  it('두 SSOT 모두 null이면 null (SSOT 게이트 미충족)', () => {
+    const result = inferAutoLockCandidate({
+      surfaceSSOT: null,
+      undergroundSSOT: null,
+      stabilityStable: true,
+      directionMatched: true,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('stability stable=false면 null', () => {
+    const result = inferAutoLockCandidate({
+      surfaceSSOT,
+      undergroundSSOT: null,
+      stabilityStable: false,
+      directionMatched: true,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('direction matched=false면 null', () => {
+    const result = inferAutoLockCandidate({
+      surfaceSSOT,
+      undergroundSSOT: null,
+      stabilityStable: true,
+      directionMatched: false,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('inferAutoLockMeta — 게이트 입력 + reason 노출 (DebugModal 출력용)', () => {
+    const result = inferAutoLockCandidate({
+      surfaceSSOT,
+      undergroundSSOT: null,
+      stabilityStable: false,
+      directionMatched: true,
+    });
+    expect(result).toBeNull();
+    // null 사유는 호출자가 게이트 상태로 알 수 있음 — meta 함수 없이도 진단 가능.
+  });
+
+  it('routeStations 컨텍스트 없이도 SSOT+stability+direction만으로 작동 (pure)', () => {
+    // pure 함수: 호출자가 verifyTrainDirection 결과를 그대로 넘긴다.
+    const result = inferAutoLockCandidate({
+      surfaceSSOT: { station: routeStations[0], trainCode: 'T-A' },
+      undergroundSSOT: null,
+      stabilityStable: true,
+      directionMatched: true,
+    });
+    expect(result?.candidate.trainCode).toBe('T-A');
+    expect(result?.candidate.line).toBe('2');
+  });
+});

--- a/src/features/nearest-station/utils/__tests__/verifyTrainDirection.test.ts
+++ b/src/features/nearest-station/utils/__tests__/verifyTrainDirection.test.ts
@@ -1,0 +1,127 @@
+/**
+ * #1421 — PR-AutoLock-1 측정 인프라.
+ *
+ * verifyTrainDirection 단위 테스트. SSOT가 잡은 trainCode의 다음역(arrival 응답에서 추출)이
+ * route의 destination 쪽 방향과 일치하는지 검증한다 — false-positive auto-lock 방지의 2차 게이트.
+ *
+ * "방향 일치" 정의: arrival의 trainTerminalStationName(다음 종착)이 routeStations 위에서 currentIdx
+ * 기준 destinationIdx 쪽(forward)에 위치하면 matched=true. 반대 방향이면 matched=false.
+ * terminal이 routeStations 밖이면 unknown (matched=false, reason='terminal-out-of-route').
+ */
+
+import { canonicalStationName } from '../../../../testUtils/canonicalStationName';
+import { verifyTrainDirection } from '../verifyTrainDirection';
+import type { Station } from '../../../../shared/types/station';
+
+function makeStation(name: string, line: Station['line']): Station {
+  return { id: `${line}-${name}`, name, line, lineColor: '#000', lat: 0, lng: 0 };
+}
+
+const sampleRoute: Station[] = [
+  makeStation('교대-base-1', '2'),
+  makeStation('역삼-base-2', '2'),
+  makeStation('선릉-base-3', '2'),
+  makeStation('삼성-base-4', '2'),
+];
+
+describe('verifyTrainDirection', () => {
+  it('terminal이 destination 쪽(forward)이면 matched=true', () => {
+    const result = verifyTrainDirection({
+      routeStations: sampleRoute,
+      currentIdx: 1,
+      destinationIdx: 3,
+      trainTerminalStationName: '삼성-base-4',
+    });
+    expect(result.matched).toBe(true);
+    expect(result.reason).toBe('forward');
+  });
+
+  it('terminal이 currentIdx 그대로면 matched=true (정착 중)', () => {
+    const result = verifyTrainDirection({
+      routeStations: sampleRoute,
+      currentIdx: 1,
+      destinationIdx: 3,
+      trainTerminalStationName: '역삼-base-2',
+    });
+    expect(result.matched).toBe(true);
+    expect(result.reason).toBe('forward');
+  });
+
+  it('terminal이 destination 반대쪽이면 matched=false', () => {
+    const result = verifyTrainDirection({
+      routeStations: sampleRoute,
+      currentIdx: 2,
+      destinationIdx: 3,
+      trainTerminalStationName: '교대-base-1',
+    });
+    expect(result.matched).toBe(false);
+    expect(result.reason).toBe('reverse');
+  });
+
+  it('reverse 방향 route(destinationIdx < currentIdx) — terminal이 destination 쪽이면 matched=true', () => {
+    const result = verifyTrainDirection({
+      routeStations: sampleRoute,
+      currentIdx: 3,
+      destinationIdx: 0,
+      trainTerminalStationName: '교대-base-1',
+    });
+    expect(result.matched).toBe(true);
+    expect(result.reason).toBe('forward');
+  });
+
+  it('routeStations 밖의 terminal — matched=false, reason=terminal-out-of-route', () => {
+    const result = verifyTrainDirection({
+      routeStations: sampleRoute,
+      currentIdx: 1,
+      destinationIdx: 3,
+      trainTerminalStationName: '강남-not-in-route',
+    });
+    expect(result.matched).toBe(false);
+    expect(result.reason).toBe('terminal-out-of-route');
+  });
+
+  it('빈 routeStations — matched=false, reason=no-route', () => {
+    const result = verifyTrainDirection({
+      routeStations: [],
+      currentIdx: 0,
+      destinationIdx: 0,
+      trainTerminalStationName: '강남',
+    });
+    expect(result.matched).toBe(false);
+    expect(result.reason).toBe('no-route');
+  });
+
+  it('trainTerminalStationName이 null이면 matched=false, reason=no-terminal', () => {
+    const result = verifyTrainDirection({
+      routeStations: sampleRoute,
+      currentIdx: 1,
+      destinationIdx: 3,
+      trainTerminalStationName: null,
+    });
+    expect(result.matched).toBe(false);
+    expect(result.reason).toBe('no-terminal');
+  });
+
+  it('currentIdx == destinationIdx (도착) — matched=true (terminal 어디든 진행 방향 의미 X)', () => {
+    const result = verifyTrainDirection({
+      routeStations: sampleRoute,
+      currentIdx: 3,
+      destinationIdx: 3,
+      trainTerminalStationName: '교대-base-1',
+    });
+    expect(result.matched).toBe(true);
+    expect(result.reason).toBe('at-destination');
+  });
+
+  it('canonical name이 있는 케이스 — alias 흡수 (drift 회귀 방지)', () => {
+    // base name이 stations.json 정식 표기와 다를 수 있으므로 alias helper로 정규화.
+    const realRoute: Station[] = [makeStation(canonicalStationName('교대', '2'), '2')];
+    const result = verifyTrainDirection({
+      routeStations: realRoute,
+      currentIdx: 0,
+      destinationIdx: 0,
+      trainTerminalStationName: canonicalStationName('교대', '2'),
+    });
+    expect(result.matched).toBe(true);
+  });
+});

--- a/src/features/nearest-station/utils/consensusStabilityBuffer.ts
+++ b/src/features/nearest-station/utils/consensusStabilityBuffer.ts
@@ -1,0 +1,88 @@
+/**
+ * #1421 — PR-AutoLock-1 측정 인프라.
+ *
+ * Ring buffer 기반 stability 판정. SSOT consensus가 산출한 후보 stationId가 N=5 폴링 사이클 중
+ * threshold=3 회 이상 동일 station을 가리키면 "stable"으로 본다 — 1~2회 잘못된 신호로 lock 산출
+ * 회귀를 차단하는 1차 게이트.
+ *
+ * pure 함수 인터페이스: factory가 closure로 buffer를 들고, push/snapshot/reset 메서드만 노출.
+ * React/AsyncStorage 의존 없음. 호출 hook이 매 폴링마다 push, 결과의 `stable`을 inferAutoLockCandidate에 전달.
+ *
+ * 임계값 근거:
+ *   - size=5: 30s 폴링 기준 150s window — 한 역 정착 시간(평균 ~30~60s) 보다 길게, 정상 진행 trip이
+ *     stale stable 신호를 만들지 않도록.
+ *   - threshold=3: majority vote(5 중 다수). 단일 false consensus가 stable로 흘러가지 않게.
+ *
+ * null push는 buffer 미기록 — 신호 부재(예: arrival API 일시 실패)를 stable 카운트 깎는 사고로
+ * 해석하지 않는다. SSOT 합의 자체가 미성립인 경우 호출자가 결과를 사용하지 않으므로 안전.
+ */
+
+/** Buffer 크기 기본값 — 30s 폴링 × 5건 = 150s window. */
+const DEFAULT_SIZE = 5;
+/** Stable 판정 임계 — 다수결(5중 3). */
+const DEFAULT_THRESHOLD = 3;
+
+export interface ConsensusStabilityOptions {
+  size?: number;
+  threshold?: number;
+}
+
+export interface ConsensusStabilitySnapshot {
+  /** 가장 많이 카운트된 station이 threshold 이상 — auto-lock 산출 게이트 입력. */
+  stable: boolean;
+  /** 다수 station id. count < threshold면 stable=false이지만 가장 많은 station을 노출(디버깅용). */
+  stationId: string | null;
+  /** 다수 station의 buffer 내 카운트. */
+  count: number;
+}
+
+export interface ConsensusStabilityBuffer {
+  /** stationId 신호를 buffer에 기록 (null은 no-op). 결과는 push 직후 snapshot. */
+  push(stationId: string | null): ConsensusStabilitySnapshot;
+  /** 마지막 push 결과 재조회 (DebugModal 출력용). */
+  snapshot(): ConsensusStabilitySnapshot;
+  /** Buffer 비우기 (trip end 등). */
+  reset(): void;
+}
+
+function computeSnapshot(
+  entries: readonly string[],
+  threshold: number,
+): ConsensusStabilitySnapshot {
+  if (entries.length === 0) return { stable: false, stationId: null, count: 0 };
+  const counts = new Map<string, number>();
+  for (const id of entries) counts.set(id, (counts.get(id) ?? 0) + 1);
+  let topId: string | null = null;
+  let topCount = 0;
+  for (const [id, c] of counts) {
+    if (c > topCount) {
+      topCount = c;
+      topId = id;
+    }
+  }
+  return { stable: topCount >= threshold, stationId: topId, count: topCount };
+}
+
+export function createConsensusStabilityBuffer(
+  options: ConsensusStabilityOptions = {},
+): ConsensusStabilityBuffer {
+  const size = options.size ?? DEFAULT_SIZE;
+  const threshold = options.threshold ?? DEFAULT_THRESHOLD;
+  let entries: string[] = [];
+
+  return {
+    push(stationId) {
+      if (stationId !== null) {
+        entries.push(stationId);
+        if (entries.length > size) entries = entries.slice(entries.length - size);
+      }
+      return computeSnapshot(entries, threshold);
+    },
+    snapshot() {
+      return computeSnapshot(entries, threshold);
+    },
+    reset() {
+      entries = [];
+    },
+  };
+}

--- a/src/features/nearest-station/utils/inferAutoLockCandidate.ts
+++ b/src/features/nearest-station/utils/inferAutoLockCandidate.ts
@@ -1,0 +1,75 @@
+/**
+ * #1421 — PR-AutoLock-1 측정 인프라.
+ *
+ * SSOT consensus + stability buffer + direction verify 3개 게이트 결과를 받아 device-side
+ * auto-lock candidate를 산출. 본 PR은 측정만 — useBoardingLockStore.createLock 호출도, backend
+ * `/boarding-lock/sync` 발사도 없다. PR-AutoLock-2가 결과를 lock 산출에 연결.
+ *
+ * 입력 결합 정의:
+ *   1) SSOT 게이트: surface 또는 underground 중 적어도 하나의 consensus가 활성 (둘 다 활성이면
+ *      surface 우선 — 지상 GPS+Arrival이 가장 신뢰도 높은 신호).
+ *   2) Stability 게이트: consensusStabilityBuffer가 N=3 이상 동일 stationId 합의 (stable=true).
+ *   3) Direction 게이트: verifyTrainDirection이 route의 destination 쪽 방향과 일치 확인.
+ *
+ * 모든 게이트 통과 시 `DeviceAutoLockCandidate` 반환. 셋 중 하나라도 미달이면 null.
+ *
+ * `DeviceAutoLockCandidate`는 backend가 발급하는 기존 `AutoLockCandidate` (boardingLockSync.ts)와
+ * 의미가 분리된다:
+ *   - 기존: backend cron이 9-AND 게이트 통과 후 발급한 candidate. response payload type.
+ *   - 본 type: device가 Tier 1 SSOT 직접 잡고 산출한 측정 후보. PR-AutoLock-2에서 sync payload에
+ *     `source: 'device-ssot'`로 노출 예정.
+ * 호환을 위해 내부에 기존 `AutoLockCandidate`를 그대로 포함하고(`candidate` 필드), 메타데이터
+ * 필드(source/stationId)는 본 type에만 있다.
+ */
+
+import { lineToSubwayId } from '../../../shared/constants/lineApiNames';
+import type { AutoLockCandidate } from '../api/boardingLockSync';
+import type { Station } from '../../../shared/types/station';
+
+/** 측정 인프라가 채택한 candidate의 source 라벨. PR-AutoLock-2 sync payload와 정합. */
+export type DeviceAutoLockSource = 'device-ssot';
+
+export interface DeviceAutoLockCandidate {
+  /** Backend `AutoLockCandidate`와 동일 형태 — PR-AutoLock-2에서 sync payload에 그대로 전달. */
+  candidate: AutoLockCandidate;
+  /** PR-AutoLock-2 sync payload `source` 필드. 본 PR에서는 측정 라벨로만 사용. */
+  source: DeviceAutoLockSource;
+  /** SSOT가 합의한 stationId — DebugModal/메트릭에서 stable_match 시각화용. */
+  stationId: string;
+}
+
+export interface InferAutoLockCandidateInput {
+  /** surfaceSSOTConsensus 결과. null이면 surface 경로 미충족. */
+  surfaceSSOT: { station: Station; trainCode: string } | null;
+  /** undergroundSSOTConsensus 결과. null이면 underground 경로 미충족. */
+  undergroundSSOT: { station: Station; trainCode: string } | null;
+  /** consensusStabilityBuffer.push().stable. */
+  stabilityStable: boolean;
+  /** verifyTrainDirection.matched. */
+  directionMatched: boolean;
+}
+
+function buildCandidate(
+  ssot: { station: Station; trainCode: string },
+): DeviceAutoLockCandidate | null {
+  const subwayId = lineToSubwayId(ssot.station.line);
+  /* istanbul ignore next -- LineNumber 모두 LINE_TO_SUBWAY_ID에 등록. valid 입력 하에서 미도달. */
+  if (!subwayId) return null;
+  return {
+    candidate: { trainCode: ssot.trainCode, line: ssot.station.line, subwayId },
+    source: 'device-ssot',
+    stationId: ssot.station.id,
+  };
+}
+
+export function inferAutoLockCandidate(
+  input: InferAutoLockCandidateInput,
+): DeviceAutoLockCandidate | null {
+  const { surfaceSSOT, undergroundSSOT, stabilityStable, directionMatched } = input;
+  if (!stabilityStable) return null;
+  if (!directionMatched) return null;
+  // surface 우선 — GPS+Arrival 직접 신호가 가장 신뢰도 높음.
+  if (surfaceSSOT) return buildCandidate(surfaceSSOT);
+  if (undergroundSSOT) return buildCandidate(undergroundSSOT);
+  return null;
+}

--- a/src/features/nearest-station/utils/verifyTrainDirection.ts
+++ b/src/features/nearest-station/utils/verifyTrainDirection.ts
@@ -1,0 +1,76 @@
+/**
+ * #1421 — PR-AutoLock-1 측정 인프라.
+ *
+ * SSOT consensus가 잡은 trainCode의 종착(다음 진행) 방향이 사용자 route의 destination 쪽과
+ * 일치하는지 검증한다. false-positive auto-lock 2차 게이트 — 같은 역 반대 방향 열차를 lock
+ * 잡지 않게 차단.
+ *
+ * 판정 로직:
+ *   1) routeStations 비공/`trainTerminalStationName` null이면 미충족.
+ *   2) currentIdx == destinationIdx (이미 도착) → 진행 방향 의미 없어 matched=true (at-destination).
+ *   3) terminal이 routeStations에 없으면 미충족 (terminal-out-of-route).
+ *   4) destinationIdx > currentIdx: terminalIdx >= currentIdx → forward. 작으면 reverse.
+ *      destinationIdx < currentIdx: terminalIdx <= currentIdx → forward. 크면 reverse.
+ *
+ * pure: React/네트워크 의존 없음. 호출자가 SSOT 산출과 route store 컨텍스트를 인자로 전달.
+ */
+
+import type { Station } from '../../../shared/types/station';
+
+export type VerifyTrainDirectionReason =
+  | 'forward'
+  | 'reverse'
+  | 'at-destination'
+  | 'terminal-out-of-route'
+  | 'no-route'
+  | 'no-terminal';
+
+export interface VerifyTrainDirectionInput {
+  /** 탑승 → 목적지 순서로 정렬된 route arc 전체. */
+  routeStations: readonly Station[];
+  /** 현재 위치의 routeStations 인덱스 (SSOT 합의 결과 station 기준). */
+  currentIdx: number;
+  /** route 도착역의 routeStations 인덱스. */
+  destinationIdx: number;
+  /**
+   * 합의된 trainCode의 종착역 이름. 다음역 자체보다 종착이 방향 검증에 단조롭다 — 한 번 잘못
+   * 시작한 trip 회복 시 다음역만 보면 같은 역이 매번 잡혀도 종착 비교는 안정적.
+   */
+  trainTerminalStationName: string | null;
+}
+
+export interface VerifyTrainDirectionResult {
+  matched: boolean;
+  reason: VerifyTrainDirectionReason;
+}
+
+function isForwardOnRoute(
+  routeStations: readonly Station[],
+  currentIdx: number,
+  destinationIdx: number,
+  terminalIdx: number,
+): boolean {
+  // destinationIdx > currentIdx → route는 인덱스 증가 방향. terminal이 currentIdx 이상이면 forward.
+  if (destinationIdx > currentIdx) return terminalIdx >= currentIdx;
+  // destinationIdx < currentIdx → route는 인덱스 감소 방향. terminal이 currentIdx 이하면 forward.
+  /* istanbul ignore next -- destinationIdx === currentIdx는 호출 전 'at-destination'로 분기,
+     >= 미만 케이스 두 분기는 위 두 if로 망라. 안전을 위한 false fallback. */
+  return terminalIdx <= currentIdx;
+}
+
+export function verifyTrainDirection(
+  input: VerifyTrainDirectionInput,
+): VerifyTrainDirectionResult {
+  const { routeStations, currentIdx, destinationIdx, trainTerminalStationName } = input;
+  if (routeStations.length === 0) return { matched: false, reason: 'no-route' };
+  if (trainTerminalStationName === null) return { matched: false, reason: 'no-terminal' };
+  if (currentIdx === destinationIdx) return { matched: true, reason: 'at-destination' };
+
+  const terminalIdx = routeStations.findIndex((s) => s.name === trainTerminalStationName);
+  if (terminalIdx === -1) return { matched: false, reason: 'terminal-out-of-route' };
+
+  const forward = isForwardOnRoute(routeStations, currentIdx, destinationIdx, terminalIdx);
+  return forward
+    ? { matched: true, reason: 'forward' }
+    : { matched: false, reason: 'reverse' };
+}


### PR DESCRIPTION
## Summary
- PR-AutoLock chain 1단계 (3-PR 중 PR-AutoLock-1) — 측정 인프라
- 신규 helper 3개: consensusStabilityBuffer / verifyTrainDirection / inferAutoLockCandidate
- PR #1424의 SSOT consensus helper 재사용 (surface/underground SSOT 객체 직접 노출)
- DebugModal에 `## Auto-lock Candidate` 섹션 추가 (ssot/stability/direction/candidate 4줄)
- 동작 변경 0. lock 산출/sync 호출 X. 측정/관측만.

## 5 메트릭 (1주 측정 acceptance)
1. Tier 1 SSOT consensus 활성 빈도 (trip의 %)
2. Stability 통과율 (N=3 연속 / 전체)
3. 방향 검증 통과율
4. Backend autoLock과 시간 차
5. 충돌 빈도 (device vs backend)

## Test plan
- [ ] 단위 테스트 (커버리지 100% 유지)
- [ ] DebugModal Share dump에 `## Auto-lock Candidate` 섹션 노출 확인
- [ ] 1주 실측 — 위 5 메트릭 dump 수집 (PR-AutoLock-2 진행 기준)

Closes 조건: 1주 측정 통과 시 PR-AutoLock-2 진행 (issue body 참조).

Refs #1421