### PR TITLE
fix(#1425): POST /trips trip-ended retention 안 재등록 차단

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -3287,3 +3287,70 @@ describe('POST /trips — #1366 boardingLock metadata cross-validation', () => {
     ).toBe(true);
   });
 });
+
+// #1425 — POST /trips trip-ended retention 안 같은 token 재등록 차단.
+// silent push `trip-ended:eta-missing` 후 device 자동 재시도/재하이드레이션이 backend에 도달하면
+// 기존 코드는 `getTrip()`만 확인(=null, 이미 삭제됨)하고 무조건 새 trip을 만들어 → backend
+// auto-revive → dedup state reset → false fire 회귀. retention(1h) 안에서는 race로 간주하고 reject.
+describe('POST /trips — #1425 trip-recently-ended reject', () => {
+  function seedTripEnded(
+    env: Env,
+    token: string,
+    endedAt: number,
+    endReason: 'expired' | 'eta-missing' | 'destination' | 'push-unrecoverable' = 'eta-missing',
+  ): void {
+    const kv = env.TRIPS as unknown as InMemoryKV;
+    kv.store.set(`tripStatus:${token}`, {
+      value: JSON.stringify({ endedAt, endReason }),
+    });
+  }
+
+  it('rejects re-register with 400 + body when same token is recently ended (within retention)', async () => {
+    const env = makeKvEnv();
+    seedTripEnded(env, 'tok', Date.now() - 5_000, 'eta-missing');
+
+    const res = await post('/trips', base(), env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: 'trip-recently-ended',
+      reason: 'eta-missing',
+    });
+  });
+
+  it('does not create the trip KV entry when rejected', async () => {
+    const env = makeKvEnv();
+    seedTripEnded(env, 'tok', Date.now() - 5_000, 'eta-missing');
+
+    await post('/trips', base(), env);
+    // trip:<token> KV는 작성되지 않아야 한다 — auto-revive 차단.
+    expect(await env.TRIPS.get('trip:tok')).toBeNull();
+  });
+
+  it('accepts re-register when retention window has elapsed (> 1h)', async () => {
+    const env = makeKvEnv();
+    // 1h 1s 전에 종료된 마커 — retention 윈도우 밖이므로 정상 등록.
+    seedTripEnded(env, 'tok', Date.now() - (60 * 60 * 1000 + 1_000), 'eta-missing');
+
+    const res = await post('/trips', base(), env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, token: 'tok' });
+    expect(await env.TRIPS.get('trip:tok')).not.toBeNull();
+  });
+
+  it('accepts re-register when no trip-ended marker exists (default behavior preserved)', async () => {
+    const env = makeKvEnv();
+    const res = await post('/trips', base(), env);
+    expect(res.status).toBe(200);
+    expect(await env.TRIPS.get('trip:tok')).not.toBeNull();
+  });
+
+  it('does not affect a different token when one token is recently ended', async () => {
+    const env = makeKvEnv();
+    seedTripEnded(env, 'ended-token', Date.now() - 5_000, 'destination');
+
+    // 다른 token으로 등록 → 정상 처리되어야 함 (token 단위 격리).
+    const res = await post('/trips', { ...base(), token: 'fresh-token' }, env);
+    expect(res.status).toBe(200);
+    expect(await env.TRIPS.get('trip:fresh-token')).not.toBeNull();
+  });
+});

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -350,6 +350,34 @@ app.post('/trips', async (c) => {
   //   1) boardingLock.trainCode가 양쪽 모두 같으면 같은 세션 (cold restart 후 createdAt이 바뀌어도 OK)
   //   2) trainCode가 한쪽이라도 없으면 createdAt drift 5s 이내일 때만 같은 세션 (lock 등록 전 단계)
   //   3) 그 외 (다른 trainCode 또는 큰 drift) → 새 세션, 전면 교체
+  // #1425 — trip-ended retention(1시간) 안에 같은 token 재등록 차단.
+  // silent push `trip-ended:eta-missing`(scheduled.ts:878) 후 device가 자동 재시도(또는
+  // BG 5h 후 FG 복귀 시 useStateRehydration 보조 trigger)로 같은 token POST하면 기존 코드는
+  // `getTrip()` 결과(=null, 이미 삭제됨)만 확인하고 무조건 새 trip으로 처리 → backend auto-revive
+  // → dedup state reset → false fire 회귀.
+  //
+  // 사용자 명시 액션 trip(boardingPrompt 응답 / BoardingTrainList 직접 탭 / 새 목적지)은 client
+  // 정책상 새 token으로 생성되므로 영향 없다. 같은 token 재등록 = device race or 자동 재시도 =
+  // reject가 정확.
+  //
+  // `Date.now()` 기준 — device 시계 drift 위험을 피하려면 backend wall clock 사용해야 한다.
+  const recentlyEnded = await readTripEndedStatus(c.env.TRIPS, incoming.token);
+  if (recentlyEnded && Date.now() - recentlyEnded.endedAt < TRIP_STATUS_RETENTION_MS) {
+    console.log(
+      JSON.stringify({
+        msg: 'trip-recently-ended: reject re-register (#1425)',
+        tokenPrefix: tokenPrefix(incoming.token),
+        endedAt: recentlyEnded.endedAt,
+        endReason: recentlyEnded.endReason,
+        ageMs: Date.now() - recentlyEnded.endedAt,
+      }),
+    );
+    return c.json(
+      { error: 'trip-recently-ended', reason: recentlyEnded.endReason },
+      400,
+    );
+  }
+
   const existing = await getTrip(c.env.TRIPS, incoming.token);
   const isSameSession = existing !== null && evaluateSameSession(existing, incoming);
   // #916 follow-up B — auto-prompt dedup 마커 보존. boardingPromptState와 달리 isSameSession=false


### PR DESCRIPTION
## Summary
- POST /trips handler가 `getTrip()`만 확인하고 `readTripEndedStatus()` 체크 X → `trip-ended:eta-missing` 후 같은 token 재등록을 무조건 accept → backend trip auto-revive → dedup state reset → false fire 회귀 (5h latency 케이스 포함).
- retention(1h) 안에서는 같은 token 재등록 400 `trip-recently-ended` reject. 사용자 명시 액션 trip은 새 token으로 와야 함 (이미 client 정책).

## 정책
- retention 안에서 reject: race로 간주 (device 자동 재시도 차단)
- retention 경과: 정상 새 trip 등록 허용
- 다른 token: 영향 없음
- `Date.now()` 기준: device 시계 drift 위험 차단 — backend wall clock 사용

## 변경 파일
- `backend/alarm-worker/src/index.ts` POST /trips handler L353 직전에 `readTripEndedStatus` + `TRIP_STATUS_RETENTION_MS` 체크 추가 (import는 이미 존재)
- `backend/alarm-worker/src/__tests__/index.test.ts` describe block `POST /trips — #1425 trip-recently-ended reject` 추가 (5 케이스)

## Test plan
- [x] 단위 테스트 5건 (retention 안/밖, 동일/다른 token, ended 상태 유무) — 5/5 pass
- [x] backend 전체 테스트 회귀 X — 1427/1427 pass
- [ ] 1주 wrangler tail 측정 — `trip-recently-ended` 응답 빈도 + 명시 액션 trip auto-start 0건
- [ ] 실기기 — 08:45 trip-ended 패턴 시나리오 false fire 회귀 0건

Closes #1425