### PR TITLE
fix(#1422): scheduled queue dump 시각 추출 트리거 속성명 정정

### DIFF
--- a/src/features/alarm/utils/__tests__/scheduledNotificationsDump.test.ts
+++ b/src/features/alarm/utils/__tests__/scheduledNotificationsDump.test.ts
@@ -12,14 +12,63 @@ const mockGetAll = Notifications.getAllScheduledNotificationsAsync as jest.Mocke
   typeof Notifications.getAllScheduledNotificationsAsync
 >;
 
-function makeRequest(overrides: {
+/**
+ * scheduleNotificationAsync({ trigger: { type: DATE, date: ... } })로 등록해도 iOS native는
+ * UNTimeIntervalNotificationTrigger로 변환하고 dump 시점에 `EXNotificationSerializer`가
+ * `{ type: 'timeInterval', seconds, repeats }` 형태로 직렬화한다.
+ * 본 helper는 production OS 동작을 그대로 시뮬레이션 (#1422 — `lesson_test_mock_must_validate_runtime`).
+ *
+ * `fireAtMs`(절대 시각)를 받아 dump 호출 시점(`nowMs`)으로부터의 잔여 초로 환산해 mock.
+ */
+function makeTimeIntervalRequest(args: {
   identifier: string;
-  triggerValue?: number | Date | null;
-  triggerType?: string;
+  fireAtMs: number;
+  nowMs: number;
   title?: string;
   body?: string;
 }): Notifications.NotificationRequest {
-  const { identifier, triggerValue, triggerType = 'date', title, body } = overrides;
+  const { identifier, fireAtMs, nowMs, title, body } = args;
+  return makeRequest({
+    identifier,
+    title,
+    body,
+    trigger: {
+      type: 'timeInterval',
+      seconds: (fireAtMs - nowMs) / 1000,
+      repeats: false,
+    } as unknown as Notifications.NotificationTrigger,
+  });
+}
+
+/**
+ * `DateTriggerInput` 형태(`{ type: 'date', date: Date | number }`)를 보존하는 환경
+ * (테스트 mock, 일부 플랫폼) 시뮬레이션. iOS native와는 다른 경로이지만 본 dump는 둘 다 흡수.
+ */
+function makeDateRequest(args: {
+  identifier: string;
+  date: number | Date;
+  title?: string;
+  body?: string;
+}): Notifications.NotificationRequest {
+  const { identifier, date, title, body } = args;
+  return makeRequest({
+    identifier,
+    title,
+    body,
+    trigger: {
+      type: 'date',
+      date,
+    } as unknown as Notifications.NotificationTrigger,
+  });
+}
+
+function makeRequest(overrides: {
+  identifier: string;
+  trigger: Notifications.NotificationTrigger | null;
+  title?: string;
+  body?: string;
+}): Notifications.NotificationRequest {
+  const { identifier, trigger, title, body } = overrides;
   return {
     identifier,
     content: {
@@ -37,48 +86,72 @@ function makeRequest(overrides: {
       interruptionLevel: undefined,
       threadIdentifier: null,
     } as unknown as Notifications.NotificationContent,
-    trigger:
-      triggerValue == null
-        ? null
-        : ({
-            type: triggerType,
-            value: triggerValue,
-          } as unknown as Notifications.NotificationTrigger),
+    trigger,
   };
 }
 
 describe('dumpScheduledNotifications', () => {
+  const FIXED_NOW = 1_000_000_000_000;
+  let dateNowSpy: jest.SpyInstance<number, []>;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(FIXED_NOW);
   });
 
-  it('returns entries sorted by fireAtMs ascending', async () => {
+  afterEach(() => {
+    dateNowSpy.mockRestore();
+  });
+
+  it('returns entries sorted by fireAtMs ascending (timeInterval trigger — iOS native)', async () => {
+    // boardingLockScheduler.ts:160는 DATE trigger로 등록하지만 iOS native가 timeInterval로 변환.
+    // 본 케이스가 production OS와 가장 일치 — 사용자가 본 dump UI에서 보는 형태.
     mockGetAll.mockResolvedValueOnce([
-      makeRequest({ identifier: 'bl:T:1:imminent:군자', triggerValue: 2000, title: '환승 임박' }),
-      makeRequest({ identifier: 'bl:T:1:early:군자', triggerValue: 1000, title: '환승 알림' }),
+      makeTimeIntervalRequest({
+        identifier: 'bl:T:1:imminent:군자',
+        fireAtMs: FIXED_NOW + 2000,
+        nowMs: FIXED_NOW,
+        title: '환승 임박',
+      }),
+      makeTimeIntervalRequest({
+        identifier: 'bl:T:1:early:군자',
+        fireAtMs: FIXED_NOW + 1000,
+        nowMs: FIXED_NOW,
+        title: '환승 알림',
+      }),
     ]);
 
     const result = await dumpScheduledNotifications();
     expect(result).toEqual([
       {
         identifier: 'bl:T:1:early:군자',
-        fireAtMs: 1000,
+        fireAtMs: FIXED_NOW + 1000,
         title: '환승 알림',
         body: '',
       },
       {
         identifier: 'bl:T:1:imminent:군자',
-        fireAtMs: 2000,
+        fireAtMs: FIXED_NOW + 2000,
         title: '환승 임박',
         body: '',
       },
     ]);
   });
 
-  it('parses Date trigger value as epoch ms', async () => {
+  it('parses DATE trigger with epoch ms number (DateTriggerInput-shape platform)', async () => {
+    const fireAt = new Date('2026-06-02T11:30:00Z').getTime();
+    mockGetAll.mockResolvedValueOnce([
+      makeDateRequest({ identifier: 'bl:T:0:early:장한평', date: fireAt }),
+    ]);
+
+    const result = await dumpScheduledNotifications();
+    expect(result[0].fireAtMs).toBe(fireAt);
+  });
+
+  it('parses DATE trigger with Date object (DateTriggerInput-shape platform)', async () => {
     const dateValue = new Date('2026-06-02T11:30:00Z');
     mockGetAll.mockResolvedValueOnce([
-      makeRequest({ identifier: 'bl:T:0:early:장한평', triggerValue: dateValue }),
+      makeDateRequest({ identifier: 'bl:T:0:early:장한평', date: dateValue }),
     ]);
 
     const result = await dumpScheduledNotifications();
@@ -90,9 +163,17 @@ describe('dumpScheduledNotifications', () => {
     // (a=null, b=non-null) 분기를 hit한다 (`a.fireAtMs == null` early return 분기).
     // 마지막 (a=non-null, b=null) 분기도 후속 비교에서 hit.
     mockGetAll.mockResolvedValueOnce([
-      makeRequest({ identifier: 'with-trigger-1', triggerValue: 3000 }),
-      makeRequest({ identifier: 'no-trigger', triggerValue: null }),
-      makeRequest({ identifier: 'with-trigger-2', triggerValue: 1000 }),
+      makeTimeIntervalRequest({
+        identifier: 'with-trigger-1',
+        fireAtMs: FIXED_NOW + 3000,
+        nowMs: FIXED_NOW,
+      }),
+      makeRequest({ identifier: 'no-trigger', trigger: null }),
+      makeTimeIntervalRequest({
+        identifier: 'with-trigger-2',
+        fireAtMs: FIXED_NOW + 1000,
+        nowMs: FIXED_NOW,
+      }),
     ]);
 
     const result = await dumpScheduledNotifications();
@@ -105,17 +186,24 @@ describe('dumpScheduledNotifications', () => {
 
   it('null fireAtMs only — relative order preserved (sort returns 0 in tie)', async () => {
     mockGetAll.mockResolvedValueOnce([
-      makeRequest({ identifier: 'a', triggerValue: null }),
-      makeRequest({ identifier: 'b', triggerValue: null }),
+      makeRequest({ identifier: 'a', trigger: null }),
+      makeRequest({ identifier: 'b', trigger: null }),
     ]);
 
     const result = await dumpScheduledNotifications();
     expect(result.map((e) => e.identifier)).toEqual(['a', 'b']);
   });
 
-  it('falls back to null for non-date trigger types', async () => {
+  it('falls back to null for unknown trigger types (calendar/daily/etc)', async () => {
     mockGetAll.mockResolvedValueOnce([
-      makeRequest({ identifier: 'interval', triggerValue: 1000, triggerType: 'timeInterval' }),
+      makeRequest({
+        identifier: 'calendar',
+        trigger: {
+          type: 'calendar',
+          repeats: false,
+          dateComponents: {},
+        } as unknown as Notifications.NotificationTrigger,
+      }),
     ]);
 
     const result = await dumpScheduledNotifications();
@@ -123,20 +211,48 @@ describe('dumpScheduledNotifications', () => {
   });
 
   it('falls back to null for null trigger', async () => {
+    mockGetAll.mockResolvedValueOnce([makeRequest({ identifier: 'immediate', trigger: null })]);
+
+    const result = await dumpScheduledNotifications();
+    expect(result[0].fireAtMs).toBeNull();
+  });
+
+  it('falls back to null when DATE trigger date field is missing/invalid', async () => {
     mockGetAll.mockResolvedValueOnce([
-      makeRequest({ identifier: 'immediate', triggerValue: null }),
+      makeRequest({
+        identifier: 'weird-date',
+        trigger: {
+          type: 'date',
+          date: 'string-value',
+        } as unknown as Notifications.NotificationTrigger,
+      }),
     ]);
 
     const result = await dumpScheduledNotifications();
     expect(result[0].fireAtMs).toBeNull();
   });
 
-  it('falls back to null for unrecognized trigger value type', async () => {
+  it('falls back to null when timeInterval trigger seconds field is missing/invalid', async () => {
     mockGetAll.mockResolvedValueOnce([
       makeRequest({
-        identifier: 'weird',
-        triggerValue: 'string-value' as unknown as number,
-        triggerType: 'date',
+        identifier: 'weird-interval',
+        trigger: {
+          type: 'timeInterval',
+          seconds: 'not-a-number',
+          repeats: false,
+        } as unknown as Notifications.NotificationTrigger,
+      }),
+    ]);
+
+    const result = await dumpScheduledNotifications();
+    expect(result[0].fireAtMs).toBeNull();
+  });
+
+  it('falls back to null for trigger object without type field', async () => {
+    mockGetAll.mockResolvedValueOnce([
+      makeRequest({
+        identifier: 'no-type',
+        trigger: { foo: 'bar' } as unknown as Notifications.NotificationTrigger,
       }),
     ]);
 
@@ -153,7 +269,11 @@ describe('dumpScheduledNotifications', () => {
 
   it('returns empty content fields when missing', async () => {
     mockGetAll.mockResolvedValueOnce([
-      makeRequest({ identifier: 'no-content', triggerValue: 1000 }),
+      makeTimeIntervalRequest({
+        identifier: 'no-content',
+        fireAtMs: FIXED_NOW + 1000,
+        nowMs: FIXED_NOW,
+      }),
     ]);
 
     const result = await dumpScheduledNotifications();

--- a/src/features/alarm/utils/scheduledNotificationsDump.ts
+++ b/src/features/alarm/utils/scheduledNotificationsDump.ts
@@ -23,15 +23,37 @@ export interface ScheduledNotificationDumpEntry {
 
 /**
  * iOS notification trigger는 union 타입이라 fire 시각 추출에 narrow가 필요하다.
- * DATE 타입은 `value: number(epoch ms)` 또는 `value: Date`로 보고된다 — 둘 다 흡수.
- * 다른 타입(time-interval/calendar 등)은 본 dump에서 fire 시각을 알 수 없어 null.
+ *
+ * 두 경우 모두 흡수해야 fire 시각 추출 가능 (#1422):
+ *  - `{ type: 'date', date: number(epoch ms) | Date }`
+ *      - JS 입력 `DateTriggerInput` 형태(`{ type: SchedulableTriggerInputTypes.DATE, date }`)
+ *        그대로 보존되는 환경(테스트 mock / 일부 플랫폼).
+ *  - `{ type: 'timeInterval', seconds: number, repeats: boolean }`
+ *      - iOS native 직렬화. `scheduleNotificationAsync({ type: DATE, date })`로 등록해도
+ *        UN side에서 `UNTimeIntervalNotificationTrigger`로 변환되고, dump 시점에
+ *        `EXNotificationSerializer`가 `{ type: 'timeInterval', seconds, repeats }`로
+ *        직렬화한다. `seconds`는 dump 호출 시점부터의 잔여 시간 → `Date.now() + seconds*1000`.
+ *
+ * 다른 타입(calendar/daily/weekly 등)은 본 dump에서 fire 시각을 단정할 수 없어 null.
  */
-function extractFireAtMs(trigger: Notifications.NotificationTrigger | null): number | null {
-  if (!trigger || typeof trigger !== 'object') return null;
-  if (!('type' in trigger) || trigger.type !== 'date') return null;
-  const value = (trigger as { value?: unknown }).value;
-  if (typeof value === 'number' && Number.isFinite(value)) return value;
-  if (value instanceof Date) return value.getTime();
+function extractFireAtMs(
+  trigger: Notifications.NotificationTrigger | null,
+  nowMs: number,
+): number | null {
+  if (!trigger || typeof trigger !== 'object' || !('type' in trigger)) return null;
+  if (trigger.type === 'date') {
+    const { date } = trigger as { date?: unknown };
+    if (typeof date === 'number' && Number.isFinite(date)) return date;
+    if (date instanceof Date) return date.getTime();
+    return null;
+  }
+  if (trigger.type === 'timeInterval') {
+    const { seconds } = trigger as Notifications.TimeIntervalNotificationTrigger;
+    if (typeof seconds === 'number' && Number.isFinite(seconds)) {
+      return nowMs + seconds * 1000;
+    }
+    return null;
+  }
   return null;
 }
 
@@ -47,9 +69,12 @@ export async function dumpScheduledNotifications(): Promise<ScheduledNotificatio
   } catch {
     return [];
   }
+  // timeInterval trigger의 잔여 seconds를 절대 시각으로 환산할 때 모든 entry가 같은
+  // base time을 쓰도록 한 번만 캡처 — entry 간 정렬 안정성 보장.
+  const nowMs = Date.now();
   const entries = requests.map<ScheduledNotificationDumpEntry>((req) => ({
     identifier: req.identifier,
-    fireAtMs: extractFireAtMs(req.trigger),
+    fireAtMs: extractFireAtMs(req.trigger, nowMs),
     title: req.content.title ?? '',
     body: req.content.body ?? '',
   }));


### PR DESCRIPTION
## Summary

- `extractFireAtMs()`가 trigger 객체에서 `.value`를 찾는데 실제 expo-notifications가 반환하는 형태와 불일치 → dump 시각 추출 실패 → `--:--:--` 표시
- 알람은 OS queue에 정확한 시각으로 등록되어 정상 발사됨 (`boardingLockScheduler.ts:160`). **dump(진단) 표시만 깨졌던 것**

## Root cause (이슈 본문 evidence 보강)

- JS 입력 타입(`DateTriggerInput`)은 `{ type: 'date', date: Date | number }`
- 그러나 **iOS native 직렬화는** `getAllScheduledNotificationsAsync` 응답을 `{ type: 'timeInterval', seconds, repeats }` 형태로 전환 — `DateTriggerRecord.toUNNotificationTrigger()`가 내부적으로 `UNTimeIntervalNotificationTrigger`로 변환하고 (`Records.swift:107`) `EXNotificationSerializer.serializedNotificationTrigger`가 그대로 `'timeInterval'`로 직렬화 (`EXNotificationSerializer.m:141`)
- 따라서 `.value`는 어디서도 셋되지 않고, iOS production에서는 `.seconds`로부터 절대 시각을 환산해야 함
- 본 추출기는 두 형태 모두 흡수 — `'date'` 케이스(테스트 mock / DateTriggerInput-shape 환경) + `'timeInterval'` 케이스(iOS native production)

## Lesson 박제

`lesson_test_mock_must_validate_runtime` 위반 동반 — 기존 mock도 `.value` 구조라 회귀가 테스트 통과해서 새어 나감. 이번 fix에서 mock도 실제 iOS native 직렬화(`timeInterval + seconds`) 구조로 정정 + DateTriggerInput-shape도 별도 케이스로 검증.

## 변경 범위

- `src/features/alarm/utils/scheduledNotificationsDump.ts` — `extractFireAtMs` 두 trigger 형태 흡수 + `nowMs` 한 번만 캡처해 entry 간 base time 통일
- `src/features/alarm/utils/__tests__/scheduledNotificationsDump.test.ts` — mock helper를 production OS 직렬화 시뮬레이션으로 재작성 + DATE/timeInterval/null/invalid 케이스 전반 보강 (14 cases)

알람 등록 코드(`boardingLockScheduler.ts` 등)는 무변경 — 이미 정상.

## Test plan

- [ ] BoardingLock 활성 trip의 dump가 `HH:mm:ss` 형식 표시 (실기기)
- [ ] `tba:` / `bl:` / `alarm:` 3종 prefix 모두 시각 표시
- [ ] mock이 실제 native trigger 구조(`timeInterval + seconds`) 시뮬레이션
- [ ] 단위 테스트 커버리지 100% 유지 (lines/functions/branches/statements)

Closes #1422