### PR TITLE
feat(#1430): 환경 분포 측정 인프라 (PR #1427 stacked)

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -83,6 +83,13 @@ import type {
   ConsensusStabilitySnapshot,
 } from '../../nearest-station/utils/consensusStabilityBuffer';
 import type { VerifyTrainDirectionResult } from '../../nearest-station/utils/verifyTrainDirection';
+// #1430 — 환경 분포 측정 인프라. SSOT 활성 cascade → state 결정 → time-based counter tick.
+// 동작 변경 0: 측정만. PR #1427(autoLockMeta)와 동일 helper 패턴(buildEnvironmentDistributionMeta).
+import {
+  createEnvironmentDistributionCounter,
+  type EnvironmentDistributionSnapshot,
+  type EnvironmentDistributionState,
+} from '../../nearest-station/utils/environmentDistributionCounter';
 
 /**
  * #1215 (D9) — DebugModal 상태 가시화 신규 prop 묶음.
@@ -444,6 +451,12 @@ interface BuildDumpArgs {
    * 계산해 주입한다. 본 PR은 측정만 — 동작 변경 없음.
    */
   autoLockMeta?: AutoLockDebugMeta;
+  /**
+   * #1430 — Environment Distribution 측정 스냅샷. 미전달 시 섹션은 (n/a) 표기.
+   * DebugModalInner가 매 render에서 SSOT 활성 cascade → state 결정 → counter tick → snapshot.
+   * 본 PR은 측정만 — 동작 변경 없음.
+   */
+  envDistribution?: EnvironmentDistributionSnapshot;
 }
 
 /** dump 본체에서 사용하는 single builder 시그니처 — 본문 줄 배열을 반환. */
@@ -700,6 +713,85 @@ function formatSSOTLabel(surface: boolean, underground: boolean): string {
 }
 
 /**
+ * #1430 — Environment Distribution 섹션. SSOT 활성 cascade로 결정한 state별 누적 시간을
+ * percentages + totals(분/초) + transitions + observed 4줄로 dump.
+ *
+ * meta 미전달 시 (n/a) — DebugModal에서 counter 미주입 (off-state).
+ *
+ * 본문 형식:
+ *   surface=42.3% underground=18.1% hybrid=3.2% unknown=36.4%
+ *   totals: surface=12m30s underground=5m24s hybrid=58s unknown=10m54s
+ *   transitions=5
+ *   observed=30m0s
+ */
+function buildEnvironmentDistributionSection(args: BuildDumpArgs): string[] {
+  const snap = args.envDistribution;
+  if (!snap) return ['(n/a)'];
+  const pct = snap.percentages;
+  const t = snap.totals;
+  return [
+    `surface=${formatPercentage(pct.surface)} underground=${formatPercentage(pct.underground)} hybrid=${formatPercentage(pct.hybrid)} unknown=${formatPercentage(pct.unknown)}`,
+    `totals: surface=${formatDurationMs(t.surface)} underground=${formatDurationMs(t.underground)} hybrid=${formatDurationMs(t.hybrid)} unknown=${formatDurationMs(t.unknown)}`,
+    `transitions=${snap.transitions}`,
+    `observed=${formatDurationMs(snap.observedMs)}`,
+  ];
+}
+
+/** Percentage 표기 — 소수 1자리 고정. */
+function formatPercentage(value: number): string {
+  return `${value.toFixed(1)}%`;
+}
+
+/**
+ * ms 누적값을 dump-friendly 형태로 포맷.
+ *   - <60s    → `Xs` (소수 0자리)
+ *   - <60m    → `XmYs`
+ *   - 그 이상 → `XmYs` (분 단위 누적)
+ *
+ * Acceptance: 0ms는 `0s` — `(empty)`/`—`와 구분되도록 명시 숫자 노출.
+ */
+function formatDurationMs(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds - minutes * 60;
+  return `${minutes}m${seconds}s`;
+}
+
+/**
+ * #1430 — SSOT 활성 cascade로 환경 state 결정. PR #1427의 `surfaceSSOTActive`/`undergroundSSOTActive`를
+ * 그대로 입력으로 받아 1줄로 분류.
+ */
+function deriveEnvironmentState(input: {
+  readonly surfaceSSOTActive: boolean;
+  readonly undergroundSSOTActive: boolean;
+}): EnvironmentDistributionState {
+  const { surfaceSSOTActive, undergroundSSOTActive } = input;
+  if (surfaceSSOTActive && undergroundSSOTActive) return 'hybrid';
+  if (surfaceSSOTActive) return 'surface';
+  if (undergroundSSOTActive) return 'underground';
+  return 'unknown';
+}
+
+/**
+ * #1430 — Environment distribution counter tick + snapshot 묶음. DebugModalInner는
+ * 호출 1줄로 cognitive complexity 유지(PR #1427 `buildAutoLockMeta`와 동일 패턴).
+ */
+function buildEnvironmentDistributionMeta(input: {
+  readonly surfaceSSOTActive: boolean;
+  readonly undergroundSSOTActive: boolean;
+  readonly counter: ReturnType<typeof createEnvironmentDistributionCounter>;
+  readonly nowMs: number;
+}): EnvironmentDistributionSnapshot {
+  const state = deriveEnvironmentState({
+    surfaceSSOTActive: input.surfaceSSOTActive,
+    undergroundSSOTActive: input.undergroundSSOTActive,
+  });
+  input.counter.tick(state, input.nowMs);
+  return input.counter.snapshot(input.nowMs);
+}
+
+/**
  * #1421 — arrival에서 trainCode에 매칭되는 row의 destination(종착명) 반환.
  * 매칭 없으면 null. verifyTrainDirection 입력 trainTerminalStationName 산출용.
  */
@@ -848,6 +940,8 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
   { title: 'Counters', build: buildCountersSection },
   // #1421 — PR-AutoLock-1 측정 인프라. SSOT consensus → stability → direction → candidate 4줄.
   { title: 'Auto-lock Candidate', build: buildAutoLockSection },
+  // #1430 — 환경 분포 측정 인프라. SSOT 활성 cascade → state별 누적 시간 + transition 카운트.
+  { title: 'Environment Distribution', build: buildEnvironmentDistributionSection },
 ];
 
 function buildDumpText(args: BuildDumpArgs): string {
@@ -1069,6 +1163,16 @@ function DebugModalInner({
     stabilityBuffer: stabilityBufferRef.current,
   });
 
+  // #1430 — 환경 분포 측정 인프라. counter도 모달이 열린 동안만 누적(관찰자 효과 최소화).
+  // 산출 로직은 `buildEnvironmentDistributionMeta`에 위임 — DebugModalInner는 호출 1줄.
+  const envDistributionCounterRef = useRef(createEnvironmentDistributionCounter());
+  const envDistribution = buildEnvironmentDistributionMeta({
+    surfaceSSOTActive,
+    undergroundSSOTActive,
+    counter: envDistributionCounterRef.current,
+    nowMs: Date.now(),
+  });
+
   const [logs, setLogs] = useState<AlarmLogEntry[]>([]);
   const [fusionLogs, setFusionLogs] = useState<readonly FusionDebugEntry[]>(() =>
     getFusionDebugEntries(),
@@ -1169,6 +1273,8 @@ function DebugModalInner({
       estimatorLog: estimatorLogs,
       // #1421 — PR-AutoLock-1 측정 인프라. SSOT/stability/direction/candidate 4줄.
       autoLockMeta,
+      // #1430 — 환경 분포 측정 인프라. state별 누적 ms + transition 카운트.
+      envDistribution,
     });
     void Share.share({ message });
   }, [
@@ -1208,6 +1314,8 @@ function DebugModalInner({
     estimatorLogs,
     // #1421 — auto-lock meta는 render-time 산출. 의존성으로 추가해 stability flip 시 share 갱신.
     autoLockMeta,
+    // #1430 — env distribution snapshot도 render-time 산출. state flip 시 share 텍스트 갱신.
+    envDistribution,
   ]);
 
   return (
@@ -1856,6 +1964,10 @@ export const __test__ = {
   // #1421 — Auto-lock 측정 인프라 내부 헬퍼. 호출자는 DebugModal 자체에서 render-time 산출.
   findArrivalTerminal,
   computeAutoLockNullReason,
+  // #1430 — 환경 분포 측정 인프라 내부 헬퍼. render-time SSOT cascade → state 결정.
+  deriveEnvironmentState,
+  formatPercentage,
+  formatDurationMs,
 };
 
 const styles = StyleSheet.create({

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -2958,3 +2958,200 @@ describe('DebugModal helpers — formatEstimatorLine (#1025)', () => {
     for (const token of expected) expect(line).toContain(token);
   });
 });
+
+// #1430 — Environment Distribution 측정 인프라. PR #1427 (Auto-lock) 패턴과 동일하게
+// CPD 회피 (lesson_sonarcloud_dup_prevention): outer scope factory + it.each + wrapper.
+describe('DebugModal helpers — #1430 environment distribution', () => {
+  const { deriveEnvironmentState, formatPercentage, formatDurationMs } = __test__;
+
+  describe('deriveEnvironmentState', () => {
+    it.each([
+      [{ surfaceSSOTActive: true, undergroundSSOTActive: true }, 'hybrid'],
+      [{ surfaceSSOTActive: true, undergroundSSOTActive: false }, 'surface'],
+      [{ surfaceSSOTActive: false, undergroundSSOTActive: true }, 'underground'],
+      [{ surfaceSSOTActive: false, undergroundSSOTActive: false }, 'unknown'],
+    ] as const)('%j → %p', (input, expected) => {
+      expect(deriveEnvironmentState(input)).toBe(expected);
+    });
+  });
+
+  describe('formatPercentage', () => {
+    it.each([
+      [0, '0.0%'],
+      [42.3, '42.3%'],
+      [100, '100.0%'],
+      [99.999, '100.0%'],
+    ])('%p → %p', (input, expected) => {
+      expect(formatPercentage(input)).toBe(expected);
+    });
+  });
+
+  describe('formatDurationMs', () => {
+    it.each([
+      [0, '0s'],
+      [999, '0s'], // sub-second → 0s
+      [58_000, '58s'],
+      [60_000, '1m0s'],
+      [90_500, '1m30s'],
+      [3_600_000, '60m0s'],
+      [1_800_000, '30m0s'],
+    ])('%p ms → %p', (input, expected) => {
+      expect(formatDurationMs(input)).toBe(expected);
+    });
+  });
+});
+
+// #1430 — buildDumpText Environment Distribution 섹션. PR #1427 Auto-lock 섹션과 동일하게
+// it.each + wrapper로 CPD 회피.
+describe('DebugModal buildDumpText — #1430 Environment Distribution 섹션', () => {
+  type DumpArgs = Parameters<typeof __test__.buildDumpText>[0];
+  type EnvSnapshot = NonNullable<DumpArgs['envDistribution']>;
+
+  const baseDumpArgs: DumpArgs = {
+    userLocation: null,
+    speedMps: null,
+    accuracyMeters: null,
+    nearestName: null,
+    nearestDistanceM: null,
+    variants: [],
+    fusion: baseFusion,
+    arrivalSummary: '-',
+    isMock: false,
+    silentPush: baseSilentPush,
+    logs: [],
+  };
+
+  const dumpEnvSection = (envDistribution?: EnvSnapshot): string => {
+    const dump = __test__.buildDumpText({
+      ...baseDumpArgs,
+      ...(envDistribution ? { envDistribution } : {}),
+    });
+    return dump.slice(dump.indexOf('## Environment Distribution'));
+  };
+
+  it.each<{
+    readonly name: string;
+    readonly envDistribution: EnvSnapshot | undefined;
+    readonly contains: readonly string[];
+  }>([
+    {
+      name: 'envDistribution 미전달 시 (n/a) 출력',
+      envDistribution: undefined,
+      contains: ['(n/a)'],
+    },
+    {
+      name: 'observedMs=0 + 빈 totals → 모든 state 0.0% + observed=0s',
+      envDistribution: {
+        totals: { surface: 0, underground: 0, hybrid: 0, unknown: 0 },
+        percentages: { surface: 0, underground: 0, hybrid: 0, unknown: 0 },
+        transitions: 0,
+        observedMs: 0,
+      },
+      contains: [
+        'surface=0.0% underground=0.0% hybrid=0.0% unknown=0.0%',
+        'totals: surface=0s underground=0s hybrid=0s unknown=0s',
+        'transitions=0',
+        'observed=0s',
+      ],
+    },
+    {
+      name: '4 state 분포 (예시 시나리오) → percentages + totals + transitions + observed',
+      envDistribution: {
+        totals: {
+          surface: 12 * 60_000 + 30_000, // 12m30s
+          underground: 5 * 60_000 + 24_000, // 5m24s
+          hybrid: 58_000, // 58s
+          unknown: 10 * 60_000 + 54_000, // 10m54s
+        },
+        percentages: { surface: 42.3, underground: 18.1, hybrid: 3.2, unknown: 36.4 },
+        transitions: 5,
+        observedMs: 30 * 60_000 + 46_000, // 30m46s
+      },
+      contains: [
+        'surface=42.3% underground=18.1% hybrid=3.2% unknown=36.4%',
+        'totals: surface=12m30s underground=5m24s hybrid=58s unknown=10m54s',
+        'transitions=5',
+        'observed=30m46s',
+      ],
+    },
+    {
+      name: 'surface 100% 단일 state → 다른 state 0.0%',
+      envDistribution: {
+        totals: { surface: 60_000, underground: 0, hybrid: 0, unknown: 0 },
+        percentages: { surface: 100, underground: 0, hybrid: 0, unknown: 0 },
+        transitions: 0,
+        observedMs: 60_000,
+      },
+      contains: ['surface=100.0% underground=0.0% hybrid=0.0% unknown=0.0%', 'transitions=0'],
+    },
+  ])('$name', ({ envDistribution, contains }) => {
+    const section = dumpEnvSection(envDistribution);
+    for (const expected of contains) {
+      expect(section).toContain(expected);
+    }
+  });
+
+  it('SHARE_SECTIONS에 Environment Distribution 헤더가 한 번만 등장 + Auto-lock Candidate 다음에 위치', () => {
+    const dump = __test__.buildDumpText(baseDumpArgs);
+    const autoLockIdx = dump.indexOf('## Auto-lock Candidate');
+    const envIdx = dump.indexOf('## Environment Distribution');
+    expect(autoLockIdx).toBeGreaterThan(-1);
+    expect(envIdx).toBeGreaterThan(autoLockIdx);
+    // 헤더가 한 번만 노출되는지(중복 등록 회귀 방지).
+    expect(dump.split('## Environment Distribution').length - 1).toBe(1);
+  });
+});
+
+// #1430 — DebugModalInner render time SSOT cascade로 env counter tick → snapshot이 share dump에
+// 흘러가는 통합 케이스. PR #1421 Auto-lock과 동일한 mock 패턴.
+describe('DebugModal — #1430 환경 분포 share dump 통합', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupHookDefaults();
+    jest.spyOn(AppState, 'addEventListener').mockReturnValue({
+      remove: jest.fn(),
+    } as unknown as ReturnType<typeof AppState.addEventListener>);
+  });
+
+  // SSOT 활성 → state 분류 → share text에 토큰 노출. it.each + 헬퍼로 CPD 회피.
+  it.each([
+    {
+      name: 'surface SSOT 활성',
+      surfaceSSOTActive: true,
+      undergroundSSOTActive: false,
+      // 첫 tick은 진입 기록만 → 누적은 0이지만 헤더와 4줄은 항상 dump.
+    },
+    {
+      name: 'underground SSOT 활성',
+      surfaceSSOTActive: false,
+      undergroundSSOTActive: true,
+    },
+    {
+      name: 'hybrid (둘 다 활성)',
+      surfaceSSOTActive: true,
+      undergroundSSOTActive: true,
+    },
+    {
+      name: 'unknown (둘 다 비활성)',
+      surfaceSSOTActive: false,
+      undergroundSSOTActive: false,
+    },
+  ])('Environment Distribution 섹션이 share dump에 노출 ($name)', async ({
+    surfaceSSOTActive,
+    undergroundSSOTActive,
+  }) => {
+    mockUseFusedNearestStation.mockReturnValue(
+      fusedReturnFixture({ surfaceSSOTActive, undergroundSSOTActive }),
+    );
+    const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    fireEvent.press(screen.getByTestId('debug-share-dump'));
+    await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+    const msg = shareSpy.mock.calls[0][0].message;
+    expect(msg).toContain('## Environment Distribution');
+    expect(msg).toContain('transitions=');
+    expect(msg).toContain('observed=');
+    shareSpy.mockRestore();
+  });
+});

--- a/src/features/nearest-station/utils/__tests__/environmentDistributionCounter.test.ts
+++ b/src/features/nearest-station/utils/__tests__/environmentDistributionCounter.test.ts
@@ -170,10 +170,10 @@ describe('createEnvironmentDistributionCounter', () => {
     counter.tick('surface', T0);
     const snap: EnvironmentDistributionSnapshot = counter.snapshot(T0 + 1000);
     // 컴파일 타임 타입 보장 + 런타임 키 존재 확인.
-    expect(Object.keys(snap.totals).sort()).toEqual(
+    expect(Object.keys(snap.totals).sort((a, b) => a.localeCompare(b))).toEqual(
       ['hybrid', 'surface', 'underground', 'unknown'],
     );
-    expect(Object.keys(snap.percentages).sort()).toEqual(
+    expect(Object.keys(snap.percentages).sort((a, b) => a.localeCompare(b))).toEqual(
       ['hybrid', 'surface', 'underground', 'unknown'],
     );
     expect(typeof snap.transitions).toBe('number');

--- a/src/features/nearest-station/utils/__tests__/environmentDistributionCounter.test.ts
+++ b/src/features/nearest-station/utils/__tests__/environmentDistributionCounter.test.ts
@@ -1,0 +1,182 @@
+/**
+ * #1430 — 환경 분포 측정 인프라 단위 테스트.
+ *
+ * State 4종 누적 정확성 + 전환 카운트 + 진행분 포함 snapshot + observedMs=0 시 percentage 0%.
+ */
+
+import {
+  createEnvironmentDistributionCounter,
+  type EnvironmentDistributionSnapshot,
+} from '../environmentDistributionCounter';
+
+const T0 = 1_700_000_000_000;
+
+describe('createEnvironmentDistributionCounter', () => {
+  it('첫 snapshot은 totals/transitions/observedMs 모두 0', () => {
+    const counter = createEnvironmentDistributionCounter();
+    const snap = counter.snapshot(T0);
+    expect(snap.totals).toEqual({ surface: 0, underground: 0, hybrid: 0, unknown: 0 });
+    expect(snap.percentages).toEqual({ surface: 0, underground: 0, hybrid: 0, unknown: 0 });
+    expect(snap.transitions).toBe(0);
+    expect(snap.observedMs).toBe(0);
+  });
+
+  it('첫 tick은 진입 기록만 — 누적 없음, transitions=0', () => {
+    const counter = createEnvironmentDistributionCounter();
+    counter.tick('surface', T0);
+    const snap = counter.snapshot(T0);
+    expect(snap.totals.surface).toBe(0);
+    expect(snap.transitions).toBe(0);
+  });
+
+  it('동일 state 연속 tick → 누적만, transitions=0', () => {
+    const counter = createEnvironmentDistributionCounter();
+    counter.tick('surface', T0);
+    counter.tick('surface', T0 + 1000);
+    counter.tick('surface', T0 + 3000);
+    const snap = counter.snapshot(T0 + 3000);
+    expect(snap.totals.surface).toBe(3000);
+    expect(snap.totals.underground).toBe(0);
+    expect(snap.transitions).toBe(0);
+    expect(snap.observedMs).toBe(3000);
+  });
+
+  it('state 전환 시 transitions++ 및 누적 정확성', () => {
+    const counter = createEnvironmentDistributionCounter();
+    counter.tick('surface', T0);
+    counter.tick('underground', T0 + 2000); // surface 누적 2000
+    counter.tick('underground', T0 + 5000); // underground 누적 3000
+    counter.tick('surface', T0 + 9000); // underground 추가 4000
+    const snap = counter.snapshot(T0 + 10_000); // surface 추가 1000
+    expect(snap.totals.surface).toBe(3000);
+    expect(snap.totals.underground).toBe(7000);
+    expect(snap.transitions).toBe(2);
+    expect(snap.observedMs).toBe(10_000);
+  });
+
+  it('unknown 경유 transition도 카운트에 포함 (단순 정책)', () => {
+    const counter = createEnvironmentDistributionCounter();
+    counter.tick('surface', T0);
+    counter.tick('unknown', T0 + 1000); // +1
+    counter.tick('underground', T0 + 2000); // +1
+    const snap = counter.snapshot(T0 + 3000);
+    expect(snap.transitions).toBe(2);
+    expect(snap.totals.surface).toBe(1000);
+    expect(snap.totals.unknown).toBe(1000);
+    expect(snap.totals.underground).toBe(1000);
+  });
+
+  it('hybrid state도 동등하게 누적', () => {
+    const counter = createEnvironmentDistributionCounter();
+    counter.tick('hybrid', T0);
+    counter.tick('hybrid', T0 + 5000);
+    const snap = counter.snapshot(T0 + 5000);
+    expect(snap.totals.hybrid).toBe(5000);
+    expect(snap.observedMs).toBe(5000);
+  });
+
+  it('snapshot 시 현재 state 진행분 포함', () => {
+    const counter = createEnvironmentDistributionCounter();
+    counter.tick('surface', T0);
+    // tick 호출 없이 snapshot 시각이 6000 후
+    const snap = counter.snapshot(T0 + 6000);
+    expect(snap.totals.surface).toBe(6000);
+    expect(snap.observedMs).toBe(6000);
+  });
+
+  it('snapshot 호출이 내부 totals를 변경하지 않는다 (재호출 동일)', () => {
+    const counter = createEnvironmentDistributionCounter();
+    counter.tick('surface', T0);
+    const a = counter.snapshot(T0 + 1000);
+    const b = counter.snapshot(T0 + 1000);
+    expect(a.totals.surface).toBe(1000);
+    expect(b.totals.surface).toBe(1000);
+  });
+
+  it('percentages: 단일 state 100%', () => {
+    const counter = createEnvironmentDistributionCounter();
+    counter.tick('surface', T0);
+    counter.tick('surface', T0 + 1000);
+    const snap = counter.snapshot(T0 + 1000);
+    expect(snap.percentages.surface).toBe(100);
+    expect(snap.percentages.underground).toBe(0);
+    expect(snap.percentages.hybrid).toBe(0);
+    expect(snap.percentages.unknown).toBe(0);
+  });
+
+  it('percentages: 분포 합=100%', () => {
+    const counter = createEnvironmentDistributionCounter();
+    counter.tick('surface', T0);
+    counter.tick('underground', T0 + 2500); // surface 2500
+    counter.tick('hybrid', T0 + 5000); // underground 2500
+    counter.tick('unknown', T0 + 7500); // hybrid 2500
+    const snap = counter.snapshot(T0 + 10_000); // unknown 2500
+    const pctSum =
+      snap.percentages.surface +
+      snap.percentages.underground +
+      snap.percentages.hybrid +
+      snap.percentages.unknown;
+    expect(pctSum).toBeCloseTo(100, 5);
+    expect(snap.percentages.surface).toBeCloseTo(25, 5);
+  });
+
+  it('percentages: observedMs=0이면 모두 0%', () => {
+    const counter = createEnvironmentDistributionCounter();
+    const snap = counter.snapshot(T0);
+    expect(snap.percentages.surface).toBe(0);
+    expect(snap.percentages.underground).toBe(0);
+    expect(snap.percentages.hybrid).toBe(0);
+    expect(snap.percentages.unknown).toBe(0);
+    expect(snap.observedMs).toBe(0);
+  });
+
+  it('snapshot 시각이 lastTickMs와 같으면 진행분 0 (방어)', () => {
+    const counter = createEnvironmentDistributionCounter();
+    counter.tick('surface', T0);
+    const snap = counter.snapshot(T0);
+    expect(snap.totals.surface).toBe(0);
+    expect(snap.observedMs).toBe(0);
+  });
+
+  it('snapshot 시각이 lastTickMs보다 작아도 진행분 0 (방어 — 비정상 입력)', () => {
+    const counter = createEnvironmentDistributionCounter();
+    counter.tick('surface', T0 + 5000);
+    const snap = counter.snapshot(T0);
+    expect(snap.totals.surface).toBe(0);
+  });
+
+  it('tick 시각이 lastTickMs보다 작아도 누적 0 (방어 — 시계 역행)', () => {
+    const counter = createEnvironmentDistributionCounter();
+    counter.tick('surface', T0 + 5000);
+    counter.tick('underground', T0); // backwards
+    const snap = counter.snapshot(T0 + 10_000);
+    // surface 누적은 0 (시계 역행 보호) — underground 신호 진입 후 10s 진행분만 카운트.
+    expect(snap.totals.surface).toBe(0);
+    expect(snap.totals.underground).toBe(10_000);
+    expect(snap.transitions).toBe(1);
+  });
+
+  it('동일 시각 연속 tick (시계 정지) → 누적 0, transitions=0', () => {
+    const counter = createEnvironmentDistributionCounter();
+    counter.tick('surface', T0);
+    counter.tick('surface', T0);
+    const snap = counter.snapshot(T0);
+    expect(snap.totals.surface).toBe(0);
+    expect(snap.transitions).toBe(0);
+  });
+
+  it('snapshot return은 EnvironmentDistributionSnapshot 형태', () => {
+    const counter = createEnvironmentDistributionCounter();
+    counter.tick('surface', T0);
+    const snap: EnvironmentDistributionSnapshot = counter.snapshot(T0 + 1000);
+    // 컴파일 타임 타입 보장 + 런타임 키 존재 확인.
+    expect(Object.keys(snap.totals).sort()).toEqual(
+      ['hybrid', 'surface', 'underground', 'unknown'],
+    );
+    expect(Object.keys(snap.percentages).sort()).toEqual(
+      ['hybrid', 'surface', 'underground', 'unknown'],
+    );
+    expect(typeof snap.transitions).toBe('number');
+    expect(typeof snap.observedMs).toBe('number');
+  });
+});

--- a/src/features/nearest-station/utils/environmentDistributionCounter.ts
+++ b/src/features/nearest-station/utils/environmentDistributionCounter.ts
@@ -1,0 +1,120 @@
+/**
+ * #1430 — 환경 분포 측정 인프라. 동작 변경 0: 측정만.
+ *
+ * Time-based counter — state(`surface` | `underground` | `hybrid` | `unknown`)별 누적 ms를
+ * 적분한다. Tier 1 surface/underground SSOT 합의 활성 여부를 기반으로 호출자가 매 render time
+ * tick을 push, snapshot은 dump 시 한 번씩 조회.
+ *
+ * 환경 결정 정책 (호출자가 결정 후 tick 인자로 전달):
+ *   - surfaceSSOTActive && undergroundSSOTActive → 'hybrid'
+ *   - surfaceSSOTActive only                     → 'surface'
+ *   - undergroundSSOTActive only                 → 'underground'
+ *   - 둘 다 미합의                                 → 'unknown'
+ *
+ * Transition 정책:
+ *   - 동일 state 연속 tick: 누적만, transitions 증가 X.
+ *   - 다른 state로 전환: transitions++ (`unknown` 경유 포함). 단순 정책 — barometer warmup
+ *     일시 unknown으로 inflate 가능성이 있으나 별도 카운트 분리는 후속 작업.
+ *
+ * 메모리: 모달 인스턴스마다 1개. 관찰자 효과 최소화를 위해 모달이 열려있는 동안만 동작.
+ *
+ * 의도적으로 React/AsyncStorage 의존 없음 — 순수 클로저 factory.
+ */
+
+export type EnvironmentDistributionState =
+  | 'surface'
+  | 'underground'
+  | 'hybrid'
+  | 'unknown';
+
+export interface EnvironmentDistributionSnapshot {
+  /** state별 누적 ms (snapshot 시점 진행분 포함). */
+  readonly totals: Record<EnvironmentDistributionState, number>;
+  /** state별 백분율 (0~100, observedMs=0이면 모두 0). */
+  readonly percentages: Record<EnvironmentDistributionState, number>;
+  /** 지상↔지하 등 환경 전환 누적 횟수. */
+  readonly transitions: number;
+  /** 누적 관찰 시간 (totals 합). */
+  readonly observedMs: number;
+}
+
+export interface EnvironmentDistributionCounter {
+  /** state 신호를 시간 적분에 반영. 첫 호출은 시각 진입 기록만 (누적 없음). */
+  tick(state: EnvironmentDistributionState, nowMs: number): void;
+  /** 현재 진행분을 합산해 snapshot 산출 (counter 내부 상태는 변경 안 함). */
+  snapshot(nowMs: number): EnvironmentDistributionSnapshot;
+}
+
+const ALL_STATES: readonly EnvironmentDistributionState[] = [
+  'surface',
+  'underground',
+  'hybrid',
+  'unknown',
+];
+
+function emptyTotals(): Record<EnvironmentDistributionState, number> {
+  return { surface: 0, underground: 0, hybrid: 0, unknown: 0 };
+}
+
+function computePercentages(
+  totals: Record<EnvironmentDistributionState, number>,
+  observedMs: number,
+): Record<EnvironmentDistributionState, number> {
+  if (observedMs <= 0) {
+    return { surface: 0, underground: 0, hybrid: 0, unknown: 0 };
+  }
+  const pct = emptyTotals();
+  for (const state of ALL_STATES) {
+    pct[state] = (totals[state] / observedMs) * 100;
+  }
+  return pct;
+}
+
+export function createEnvironmentDistributionCounter(): EnvironmentDistributionCounter {
+  const totals = emptyTotals();
+  let currentState: EnvironmentDistributionState | null = null;
+  let lastTickMs: number | null = null;
+  let transitions = 0;
+
+  function flushAccumulated(nowMs: number): void {
+    if (currentState !== null && lastTickMs !== null && nowMs > lastTickMs) {
+      totals[currentState] += nowMs - lastTickMs;
+    }
+  }
+
+  return {
+    tick(state, nowMs) {
+      // 첫 tick: 시각 진입 기록만 — 누적할 직전 dwell 없음.
+      if (currentState === null) {
+        currentState = state;
+        lastTickMs = nowMs;
+        return;
+      }
+      // 동일 state 연속 tick — 누적만 갱신, transition 증가 X.
+      flushAccumulated(nowMs);
+      if (state !== currentState) transitions += 1;
+      currentState = state;
+      lastTickMs = nowMs;
+    },
+    snapshot(nowMs) {
+      // 진행분 포함: 현재 state 누적에 (nowMs - lastTickMs) 추가 후 합산.
+      // 내부 totals 자체는 변경하지 않아 같은 시각에 재호출해도 결과 동일.
+      const snapshotTotals = emptyTotals();
+      for (const state of ALL_STATES) snapshotTotals[state] = totals[state];
+      if (currentState !== null && lastTickMs !== null && nowMs > lastTickMs) {
+        snapshotTotals[currentState] += nowMs - lastTickMs;
+      }
+      const observedMs =
+        snapshotTotals.surface +
+        snapshotTotals.underground +
+        snapshotTotals.hybrid +
+        snapshotTotals.unknown;
+      return {
+        totals: snapshotTotals,
+        percentages: computePercentages(snapshotTotals, observedMs),
+        transitions,
+        observedMs,
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- epic #1415 acceptance "환경 매트릭스(지하/지상/환승) 모두 커버" 검증 보조 측정 인프라
- 신규 `environmentDistributionCounter` — surface/underground/hybrid/unknown 시간 분포 적분 + transition 카운트
- DebugModal `## Environment Distribution` 섹션 (Share dump + UI)
- 동작 변경 0. PR #1427 stacked.

## 의존
- **Stacked on PR #1427** (PR-AutoLock-1 측정 인프라). 머지 순서: #1427 → 본 PR.
- PR #1427 머지 후 base 자동 dev 변경됨.

## 5건 "측정 필요" 항목 정밀 판정 데이터 확보
1. lastObservedRef TTL 내 stale
2. 환경 전환 1~5초 latency (transitions count + 분포 비교)
3. 지하 GPS 강등 임계값(acc<50m) 적정성
4. CMAltimeter unavailable 빈도 (unknown % 측정)
5. WiFi+Arrival underground SSOT 합의 빈도 (underground %)

## Test plan
- [ ] 단위 테스트 — 4 state + transition + percentage 합=100%
- [ ] DebugModal Share dump 섹션 노출
- [ ] 100% 커버리지 유지
- [ ] 1주 측정 — 분포 dump 확보

Closes #1430