### PR TITLE
fix(#1440): useNearestStation distanceInterval=0 — FG GPS 회복 (#1416 회귀)

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
@@ -226,9 +226,9 @@ describe('useNearestStation', () => {
     expect(Location.watchPositionAsync).toHaveBeenCalledTimes(2);
   });
 
-  it('watchPositionAsync에 High·distanceInterval:5·timeInterval:2000을 전달한다', async () => {
-    // #1416 — surface는 distanceInterval=5(m)로 GPS jitter callback을 native에서 차단한다.
-    // BG task TRACKING_DISTANCE_INTERVAL_M=20m 패턴 검증 후 보수적 적용.
+  it('watchPositionAsync에 High·distanceInterval:0·timeInterval:2000을 전달한다', async () => {
+    // #1440 — surface는 distanceInterval=0으로 정적 FG에서도 watch 이벤트가 흘러야 GPS acc가
+    // 회복된다. #1416에서 5m 적용 → 정적 30분 acc>30m stuck + 한양대 820m stuck fix 회귀로 되돌림.
     mockGranted();
 
     renderHook(() => useNearestStation());
@@ -238,11 +238,29 @@ describe('useNearestStation', () => {
     expect(Location.watchPositionAsync).toHaveBeenCalledWith(
       {
         accuracy: Location.Accuracy.High,
-        distanceInterval: 5,
+        distanceInterval: 0,
         timeInterval: 2000,
       },
       expect.any(Function),
     );
+  });
+
+  it('#1440 회귀: 정적 FG 시뮬레이션에서 distanceInterval=0이어야 acc 회복 콜백이 흘러간다', async () => {
+    // 회귀: #1416에서 distanceInterval=5로 throttle 후 정적 30분 동안 OS가 callback을 끊어
+    // GPS acc가 stale(>30m)인 채 고착되고 한양대 820m 같은 stuck fix가 fire를 유발했다.
+    // 본 테스트는 같은 좌표라도 acc 회복(>30m → ≤30m)을 위해 watch 옵션이 distanceInterval=0이어야
+    // 한다는 계약을 가드한다.
+    mockGranted();
+    renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    const [options] = (Location.watchPositionAsync as jest.Mock).mock.calls[0];
+    expect(options.distanceInterval).toBe(0);
+
+    // 정적 시뮬레이션: 동일 좌표 + acc 변화(50m → 20m)를 같은 lat/lng로 흘려도 distanceInterval=0이면
+    // OS가 callback을 차단하지 않는다. callback 자체는 expo-location mock이 처리하므로 본 테스트는
+    // 옵션 계약만 검증한다 (native throttle 동작은 단위테스트 범위 외).
+    expect(options.accuracy).toBe(Location.Accuracy.High);
   });
 
   it('언마운트 시 subscription.remove()가 호출된다', async () => {
@@ -1267,7 +1285,7 @@ describe('useNearestStation — #1313 subsurface GPS throttle', () => {
   // 지상 기본값: High@2s. 지하 throttle: Balanced@12s. interval은 상수에서 가져와 매직넘버 회피.
   const SURFACE_OPTIONS = {
     accuracy: Location.Accuracy.High,
-    distanceInterval: 5,
+    distanceInterval: 0,
     timeInterval: FG_WATCH_SURFACE_TIME_INTERVAL_MS,
   };
   const SUBSURFACE_OPTIONS = {

--- a/src/features/nearest-station/hooks/useNearestStation.ts
+++ b/src/features/nearest-station/hooks/useNearestStation.ts
@@ -41,13 +41,17 @@ const MIN_DISTANCE_CHANGE_KM = 0.003; // 3m — UI 갱신을 자주 흘려보낸
 
 // #1313 — subsurface 여부로 갈리는 FG watch 옵션. accuracy 선택 + interval을 한 데이터로 묶어
 // startWatch가 throttle boolean만 보고 분기 없이 선택하게 한다(하드코딩 분기 회피).
-// #1416 — surface는 distanceInterval=5(m)로 GPS jitter callback을 native 단에서 차단한다.
-// 정적 FG 21분에 ~170건 fg fire path cascade(gate-hop-window suppress)가 관측됐고, BG task가
-// TRACKING_DISTANCE_INTERVAL_M=20m 패턴으로 검증된 메커니즘이라 5m는 보수적 적용이다.
-// subsurface(distanceInterval=0)는 지하 indoor positioning에 매 fix가 필요하므로 유지한다.
+// #1440 — surface는 distanceInterval=0으로 되돌린다. #1416에서 5m로 throttle한 결과 정적 FG
+// 30분에 GPS acc 회복 실패(acc>30m stuck) + 한양대 820m 같은 stuck fix 오인 fire가 관측됐다.
+// iOS Core Location은 distanceInterval>0일 때 distanceFilter 활성 → 정적 상태에서 callback 자체가
+// 끊기고, OS가 GPS fix 정밀도를 재조정하지 못해 stale acc가 그대로 굳어 ADR-015 §3 합의 게이트의
+// strong A 신호(acc≤30m + 거리≤100m)가 영구 미달이 된다. fg fire path cascade는 #1416-B의
+// useStationAlarm effect short-circuit으로 별개 layer에서 해소됐으므로 GPS callback throttle을
+// 제거해도 cascade가 재발하지 않는다.
+// subsurface는 동일하게 distanceInterval=0 — 지하 indoor positioning 보강 동안에는 매 fix가 필요.
 const FG_WATCH_OPTIONS_SURFACE: Location.LocationOptions = {
   accuracy: Location.Accuracy.High,
-  distanceInterval: 5,
+  distanceInterval: 0,
   timeInterval: FG_WATCH_SURFACE_TIME_INTERVAL_MS,
 };
 const FG_WATCH_OPTIONS_SUBSURFACE: Location.LocationOptions = {


### PR DESCRIPTION
## 변경 요약

`src/features/nearest-station/hooks/useNearestStation.ts:50`의 `FG_WATCH_OPTIONS_SURFACE.distanceInterval`을 `5` → `0`으로 되돌림.

## 회귀 (#1416 후속)

#1416에서 정적 FG cascade 차단 목적으로 surface distanceInterval=5(m) 적용했으나, 2026-06-18 trip에서 정적 FG 30분 동안 GPS acc 회복 실패 + 한양대 820m 같은 stuck fix 오인 fire가 관측됐다.

원인:
- iOS Core Location은 `distanceInterval>0`일 때 native `distanceFilter` 활성
- 정적 상태에서 watch callback 자체가 끊김 → OS가 GPS fix 정밀도를 재조정하지 못함
- `accuracy` 값이 stale(>30m)로 굳어 ADR-015 §3 합의 게이트의 strong A 신호(acc≤30m + 거리≤100m)가 영구 미달
- 결과: surface 분기 미사용 → 모든 trip이 강제 underground 분기 → C+B 또는 D+B 게이트만 의존 → silent 잦아짐

## 해결

- surface: `distanceInterval: 0` + `Accuracy.High` + `timeInterval: 2000` (기존 #1416 이전 값)
- subsurface: `distanceInterval: 0` 유지 (indoor positioning 매 fix 필요)
- #1416-A의 GPS throttle 의도는 제거되지만, #1416-B `useStationAlarm` 5 effect short-circuit이 별개 layer에서 fg fire path cascade를 차단하므로 cascade는 재발하지 않는다

## 회귀 가드 테스트

- `watchPositionAsync`에 `distanceInterval=0` + `Accuracy.High` 전달 강제 (옵션 계약)
- 정적 FG 시뮬레이션 acceptance 검증
- 기존 `useNearestStation — #1313 subsurface GPS throttle` SURFACE_OPTIONS도 0으로 동기화

## 검증

- `npm run type-check` pass
- `npx jest useNearestStation` 76 tests pass
- 전체 테스트 fail은 dev 브랜치 pre-existing(`widgetStorage` + `stationNotification`) — 본 변경 무관

## ADR

`docs/decisions/ADR-015-multi-signal-consensus-gate.md` §10 마이그레이션 prereq.

Closes #1440
Refs #1416, #1432