### PR TITLE
chore(#1435): transferTimes.json 호선쌍별 환승 도보 시간 데이터셋 도입

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -65,7 +65,11 @@ import { useMisBoardingDetector } from '../features/route/hooks/useMisBoardingDe
 import { useTrainPositions } from '../features/route/hooks/useTrainPositions';
 import { useTransferTrainList } from '../features/route/hooks/useTransferTrainList';
 import { useTransferAutoDetect } from '../features/route/hooks/useTransferAutoDetect';
-import { TRANSFER_WALKING_BUFFER_SECONDS, BOARDING_PROXIMITY_THRESHOLD_M } from '../shared/constants/boardingLock';
+import {
+  BOARDING_PROXIMITY_THRESHOLD_M,
+  TRANSFER_WALKING_BUFFER_SECONDS,
+} from '../shared/constants/boardingLock';
+import { getTransferSeconds } from '../shared/utils/transferTimes';
 import { BoardingTrainList } from '../features/alarm/components/BoardingTrainList';
 import { BoardingLockHopCard } from '../features/alarm/components/BoardingLockHopCard';
 import { resolveNextAdjacentStationName } from '../features/route/utils/nextAdjacentStation';
@@ -1101,7 +1105,20 @@ export default function HomeScreen() {
                                   arrivals={transferArrivals}
                                   line={transferContext.nextLine}
                                   onSelect={createTransferLock}
-                                  walkingBufferSeconds={TRANSFER_WALKING_BUFFER_SECONDS}
+                                  walkingBufferSeconds={
+                                    // ADR-015 §6 — 호선쌍별 환승 도보 시간(#1435).
+                                    // lock.boardingLine = 환승 직전 leg의 노선 (fromLine).
+                                    // useTransferTrainList가 lock 활성 시에만 context를 노출하므로
+                                    // 정상 흐름에서는 lock이 항상 존재한다. ts narrowing이 불가능하므로
+                                    // optional chaining + `getTransferSeconds`의 fallback(=180s)에 위임한다.
+                                    boardingLock
+                                      ? getTransferSeconds(
+                                          boardingLock.boardingLine,
+                                          transferContext.nextLine,
+                                          transferContext.transferStationInToLine.name,
+                                        )
+                                      : TRANSFER_WALKING_BUFFER_SECONDS
+                                  }
                                   compact
                                   nextStationLabel={label}
                                   // #1166: 환승 leg lock도 같은 SSOT(fusionBoardingLock). 환승 row에서도

--- a/src/shared/utils/__tests__/transferTimes.test.ts
+++ b/src/shared/utils/__tests__/transferTimes.test.ts
@@ -1,0 +1,62 @@
+import {
+  getTransferSeconds,
+  getTransferSecondsOrNull,
+} from '../transferTimes';
+import { TRANSFER_WALKING_BUFFER_SECONDS } from '../../constants/boardingLock';
+
+describe('transferTimes', () => {
+  describe('getTransferSeconds', () => {
+    // 주요 환승역 표본(공공데이터포털 15044419 기준) — ADR-015 §6 acceptance.
+    // 데이터셋 자체가 회귀로 변경되지 않도록 양수 + 합리적 범위(0 < s ≤ 1800)로만 단언.
+    it.each([
+      // 1~8호선 핵심 환승역 양방향
+      ['2', '5', '왕십리'],
+      ['5', '2', '왕십리'],
+      ['1', '2', '시청'],
+      ['1', '2', '신도림'],
+      ['1', '3', '종로3가'],
+      ['1', '4', '동대문'],
+      ['2', '4', '사당'],
+      ['2', '8', '잠실'],
+      ['3', '4', '충무로'],
+      ['2', '3', '교대'],
+    ] as const)('returns positive seconds for %s↔%s @ %s', (fromLine, toLine, station) => {
+      const seconds = getTransferSeconds(fromLine, toLine, station);
+      expect(seconds).toBeGreaterThan(0);
+      expect(seconds).toBeLessThanOrEqual(1800);
+    });
+
+    it('falls back to TRANSFER_WALKING_BUFFER_SECONDS for unknown line pair', () => {
+      expect(getTransferSeconds('1', '2', '존재하지않는역')).toBe(
+        TRANSFER_WALKING_BUFFER_SECONDS,
+      );
+    });
+
+    it('normalizes station name with parentheses subtitle', () => {
+      // "왕십리(성동구청)" → "왕십리" 로 정규화되어 동일 값 반환.
+      const plain = getTransferSeconds('2', '5', '왕십리');
+      const withSubtitle = getTransferSeconds('2', '5', '왕십리(성동구청)');
+      expect(withSubtitle).toBe(plain);
+    });
+
+    it('applies station alias (e.g. 총신대입구 → 이수)', () => {
+      // 4호선/7호선 환승역 — 공식 표기 차이 alias 적용.
+      const v1 = getTransferSeconds('4', '7', '이수');
+      const v2 = getTransferSeconds('4', '7', '총신대입구');
+      expect(v1).toBe(v2);
+      expect(v1).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getTransferSecondsOrNull', () => {
+    it('returns undefined for unknown pair', () => {
+      expect(getTransferSecondsOrNull('1', '2', '존재하지않는역')).toBeUndefined();
+    });
+
+    it('returns the same value as getTransferSeconds when known', () => {
+      expect(getTransferSecondsOrNull('2', '5', '왕십리')).toBe(
+        getTransferSeconds('2', '5', '왕십리'),
+      );
+    });
+  });
+});

--- a/src/shared/utils/stationRoute.ts
+++ b/src/shared/utils/stationRoute.ts
@@ -1,7 +1,6 @@
 import stations from '../../data/stations.json';
 import stationTravelTimesJson from '../../data/stationTravelTimes.json';
 import stationDistancesJson from '../../data/stationDistances.json';
-import transferTimes from '../../data/transferTimes.json';
 import type { Station } from '../types/station';
 import { LINE_COLORS } from '../constants/lineColors';
 import { WALKING_SPEED_M_PER_S, ARRIVAL_FRESHNESS_MS } from '../constants/eta';
@@ -10,6 +9,7 @@ import { applyStationAlias } from '../../data/stationAliases';
 import { createLogger } from './logger';
 import { normalizeStationName as baseNormalizeStationName } from './normalizeStationName';
 import { distanceMetersBetween, estimateEtaSeconds } from './stationEta';
+import { getTransferSeconds } from './transferTimes';
 
 const logger = createLogger('StationRoute');
 
@@ -706,22 +706,9 @@ function findMultiTransferRoute(
   return best;
 }
 
-// 환승역별 실제 소요시간 데이터(공공데이터포털 15044419, 보행속도 1.2 m/s 기준)에
-// 미등록된 환승역에 적용하는 fallback. 기존 균일 가정값 3분(=180초)을 유지.
-const FALLBACK_TRANSFER_SECONDS = 180;
-
-const transferTimeTable = transferTimes as Record<string, number>;
-
-// (fromLine, toLine, 환승역명) 조합에 대응하는 실제 환승 소요시간(초).
-// 미등록 시 FALLBACK_TRANSFER_SECONDS.
-function getTransferSeconds(
-  fromLine: LineNumber,
-  toLine: LineNumber,
-  stationName: string,
-): number {
-  const key = `${fromLine}|${toLine}|${normalizeStationName(stationName)}`;
-  return transferTimeTable[key] ?? FALLBACK_TRANSFER_SECONDS;
-}
+// 환승 도보 시간 lookup은 `./transferTimes.ts` (ADR-015 §6 SSOT)로 추출 — 동일 데이터셋을
+// `BoardingTrainList walkingBufferSeconds` 등 다른 호출자와 공유. fallback은 동일 모듈 안에서
+// `TRANSFER_WALKING_BUFFER_SECONDS`(180s)로 처리. import 위치는 파일 상단.
 
 export function buildJourneyDisplay(
   route: Route,

--- a/src/shared/utils/transferTimes.ts
+++ b/src/shared/utils/transferTimes.ts
@@ -1,0 +1,52 @@
+/**
+ * 환승 도보 시간 lookup helper — ADR-015 §6 SSOT (#1435).
+ *
+ * 데이터 출처: 공공데이터포털 15044419 "서울교통공사 환승역거리 소요시간 정보_20250331"
+ * 보행속도 1.2 m/s 기준 측정값. 양방향 등록(`fromLine|toLine|station`).
+ *
+ * 본 모듈은 두 호출자가 공유한다:
+ *   1) `stationRoute.calculateStaticETA` — 경로 정적 ETA 산출 시 호선쌍별 시간 합산
+ *   2) `HomeScreen` BoardingTrainList walkingBufferSeconds — 환승 도보 시간 부족한 traincode 비활성화
+ *
+ * 미등록 호선쌍(주로 외부 노선 환승)은 `TRANSFER_WALKING_BUFFER_SECONDS` fallback 적용 →
+ * ADR-014 §"두 실패 모드 동급" 원칙과 호환(데이터 미보장 케이스도 fire 가능).
+ */
+import transferTimes from '../../data/transferTimes.json';
+import type { LineNumber } from '../types/station';
+import { TRANSFER_WALKING_BUFFER_SECONDS } from '../constants/boardingLock';
+import { normalizeStationName } from './normalizeStationName';
+import { applyStationAlias } from '../../data/stationAliases';
+
+const transferTimeTable = transferTimes as Record<string, number>;
+
+function buildKey(fromLine: LineNumber, toLine: LineNumber, stationName: string): string {
+  // stationRoute의 normalizeStationName(괄호 부제 제거 + alias 적용)과 동일 정규화 — build-transfer-times.js와 SSOT 일치.
+  const normalized = applyStationAlias(normalizeStationName(stationName));
+  return `${fromLine}|${toLine}|${normalized}`;
+}
+
+/**
+ * 호선쌍별 환승 도보 시간(초). 미등록이면 `undefined` 반환.
+ *
+ * 호출자가 fallback 정책을 직접 결정해야 하는 경우 사용 (예: UI에 "데이터 없음" 표시).
+ */
+export function getTransferSecondsOrNull(
+  fromLine: LineNumber,
+  toLine: LineNumber,
+  stationName: string,
+): number | undefined {
+  return transferTimeTable[buildKey(fromLine, toLine, stationName)];
+}
+
+/**
+ * 호선쌍별 환승 도보 시간(초). 미등록이면 `TRANSFER_WALKING_BUFFER_SECONDS`(180s) fallback.
+ *
+ * 호출자가 fallback을 신경 쓸 필요가 없는 일반 케이스에서 사용.
+ */
+export function getTransferSeconds(
+  fromLine: LineNumber,
+  toLine: LineNumber,
+  stationName: string,
+): number {
+  return getTransferSecondsOrNull(fromLine, toLine, stationName) ?? TRANSFER_WALKING_BUFFER_SECONDS;
+}


### PR DESCRIPTION
## Summary

ADR-015 §6 — 환승 도보 시간을 단순 상수(`TRANSFER_WALKING_BUFFER_SECONDS=180s`)에서 호선쌍별 데이터셋(`src/data/transferTimes.json`)으로 wire-up.

- `src/shared/utils/transferTimes.ts` 신설 — `getTransferSeconds(fromLine, toLine, stationName)` / `getTransferSecondsOrNull(...)` helper (shared/utils로 SSOT 추출)
- `stationRoute.ts` 내부에 있던 private `getTransferSeconds` 제거 + 새 helper로 위임 — `calculateStaticETA`의 호선쌍별 시간 합산 동작 동일
- `HomeScreen` 환승 hop slot `BoardingTrainList walkingBufferSeconds` 를 호선쌍별 lookup으로 변경 — `boardingLock.boardingLine` (fromLine) + `transferContext.nextLine` (toLine) + `transferStationInToLine.name` 으로 조회
- 데이터셋 자체(175 entry)는 기존 그대로 활용 — 공공데이터포털 15044419 "서울교통공사 환승역거리 소요시간 정보_20250331" (보행속도 1.2 m/s)
- 미등록 호선쌍은 기존 `TRANSFER_WALKING_BUFFER_SECONDS=180s` fallback 유지

## 양방향 layer 추적 (§11)

- **upstream**: 공공데이터포털 15044419 CSV → `scripts/build-transfer-times.js` → `src/data/transferTimes.json` (기존 파이프라인 그대로)
- **downstream (fix 대상)**:
  - 프론트 utils: `stationRoute.calculateStaticETA` (이미 사용 중) → 동일 helper로 위임
  - 프론트 UI: `HomeScreen` → `BoardingTrainList walkingBufferSeconds` (본 PR에서 wire-up)
- **인프라**: 없음 (정적 데이터)

## 누락 환승역 데이터 (사용자 검수 필요)

전체 78개 정규화 환승역 중 42개 호선쌍(주로 외부 노선)이 데이터셋에 미등록 — fallback 180s 사용 중. 후속 데이터 보강 PR 대상:

- 1↔gyeongui (외대앞/회기/용산/청량리(서울시립대입구))
- 2↔gyeongui (왕십리/신촌)
- 1↔6 석계, 1↔9 노량진, 1↔bundang 인천, 1↔7 온수
- airport↔gyeongui (서울역/홍대입구/공덕/디지털미디어시티)
- 3↔bundang 수서, 5↔gyeongui 양평
- 9↔airport (김포공항/마곡나루), 9↔sinbundang 신논현, 9↔bundang 선정릉
- bundang↔sinbundang (미금/정자), gyeongui↔bundang (왕십리/청량리)

## Test plan

- [x] `npx jest transferTimes` — 15/15 pass, transferTimes.ts coverage 100%
- [x] `npx jest stationRoute` — 193/193 pass (기존 `calculateStaticETA` 회귀 없음)
- [x] `npm run type-check` — pass
- [x] `npx eslint` (변경 파일) — clean
- [ ] 실기기 환승 trip — 왕십리 2↔5 등에서 BoardingTrainList의 "도보 buffer 부족" 비활성화 row가 기존 180s 대신 호선쌍 실측치(왕십리 240s)로 동작하는지 확인

## ADR / 관련 작업

- ADR: `docs/decisions/ADR-015-multi-signal-consensus-gate.md` §6
- Epic: #1432
- 기존 상수: `src/shared/constants/boardingLock.ts:17 TRANSFER_WALKING_BUFFER_SECONDS=180` (미등록 호선쌍 fallback으로 유지)

Closes #1435