### PR TITLE
fix(#1436): fusion route-line filter — findTopNearestStations allowedLines 확장 (분당선 회귀)

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -26,7 +26,7 @@ import {
 } from '../../../../testUtils/positionApiFixtures';
 import type { StationArrival, ArrivalInfo } from '../../../../shared/types/arrival';
 import type { Station } from '../../../../shared/types/station';
-import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
+import { makeDirectRoute, makeTransferRoute, makeMultiTransferRoute } from '../../../../testUtils/routeFixtures';
 
 jest.mock('../useNearestStation');
 jest.mock('../../../arrival/hooks/useArrivalInfo');
@@ -1610,6 +1610,94 @@ describe('useFusedNearestStation', () => {
       expect(result.current.confidence).toBe(expectedConfidence);
       // source는 모든 케이스에서 'gps' — 좌표 신호원 자체는 GPS.
       expect(result.current.source).toBe('gps');
+    });
+  });
+
+  // #1436 — trip route allowedLines filter. fusion 후보 단계에서 trip 외 노선 entry 차단.
+  // 좌표는 같지만 이름이 다른 entry(왕십리(성동구청) vs 왕십리)가 name dedup을 우회해
+  // 분당선 variant가 fusion result로 흘러가던 회귀 차단.
+  describe('routeContext allowedLines filter (#1436)', () => {
+    function originStation(): Station {
+      return MOCK_STATIONS.gangnam;
+    }
+    function destinationStation(): Station {
+      return MOCK_STATIONS.chungmuro;
+    }
+
+    it('routeContext 없으면 allowedLines 미전달 (자유 화면 기존 동작)', () => {
+      mockUseNearest.mockReturnValue(gpsBase());
+      mockFindTop.mockReturnValue([]);
+      renderHook(() => useFusedNearestStation());
+      const call = mockFindTop.mock.calls[0];
+      // 5번째 인자가 allowedLines — undefined여야 함.
+      expect(call[4]).toBeUndefined();
+    });
+
+    it('direct route → allowedLines = {route.line}', () => {
+      mockUseNearest.mockReturnValue(gpsBase());
+      mockFindTop.mockReturnValue([]);
+      const routeContext = {
+        route: makeDirectRoute(5, '2' as const),
+        origin: originStation(),
+        destination: destinationStation(),
+      };
+      renderHook(() => useFusedNearestStation(undefined, undefined, routeContext));
+      const allowed = mockFindTop.mock.calls[0][4] as Set<string>;
+      expect(allowed).toBeInstanceOf(Set);
+      expect([...allowed].sort()).toEqual(['2']);
+    });
+
+    it('transfer route → allowedLines = {fromLine, toLine} (왕십리 분당선 회귀 방어)', () => {
+      mockUseNearest.mockReturnValue(gpsBase());
+      mockFindTop.mockReturnValue([]);
+      const routeContext = {
+        route: makeTransferRoute({
+          transferName: '왕십리(성동구청)',
+          fromLine: '2' as const,
+          toLine: '5' as const,
+          stopsToTransfer: 3,
+          stopsFromTransfer: 4,
+        }),
+        origin: originStation(),
+        destination: destinationStation(),
+      };
+      renderHook(() => useFusedNearestStation(undefined, undefined, routeContext));
+      const allowed = mockFindTop.mock.calls[0][4] as Set<string>;
+      expect([...allowed].sort()).toEqual(['2', '5']);
+      // trip route 외 line(bundang/gyeongui)은 후보 단계에서 reject 대상.
+      expect(allowed.has('bundang' as never)).toBe(false);
+      expect(allowed.has('gyeongui' as never)).toBe(false);
+    });
+
+    it('multi-transfer route → 모든 segment의 fromLine/toLine 합집합', () => {
+      mockUseNearest.mockReturnValue(gpsBase());
+      mockFindTop.mockReturnValue([]);
+      const routeContext = {
+        route: makeMultiTransferRoute({
+          transfers: [
+            { transferName: '교대', fromLine: '2' as const, toLine: '3' as const, stopsToTransfer: 2 },
+            { transferName: '왕십리(성동구청)', fromLine: '3' as const, toLine: '5' as const, stopsToTransfer: 4 },
+          ],
+          stopsAfterLastTransfer: 3,
+        }),
+        origin: originStation(),
+        destination: destinationStation(),
+      };
+      renderHook(() => useFusedNearestStation(undefined, undefined, routeContext));
+      const allowed = mockFindTop.mock.calls[0][4] as Set<string>;
+      expect([...allowed].sort()).toEqual(['2', '3', '5']);
+    });
+
+    it('routeContext.route=null이면 allowedLines 미전달 (route 미설정 상태)', () => {
+      mockUseNearest.mockReturnValue(gpsBase());
+      mockFindTop.mockReturnValue([]);
+      const routeContext = {
+        route: null,
+        origin: originStation(),
+        destination: destinationStation(),
+      };
+      renderHook(() => useFusedNearestStation(undefined, undefined, routeContext));
+      expect(mockFindTop.mock.calls[0][4]).toBeUndefined();
     });
   });
 });

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -95,6 +95,14 @@ function setupPositionTrainTransferStation(trainNo: string): void {
     .mockReturnValueOnce(positionRet(null));
 }
 
+// #1436 routeContext allowedLines filter 테스트용 station helper (S7721 — outer scope).
+function originStation(): Station {
+  return MOCK_STATIONS.gangnam;
+}
+function destinationStation(): Station {
+  return MOCK_STATIONS.chungmuro;
+}
+
 describe('useFusedNearestStation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -1617,13 +1625,6 @@ describe('useFusedNearestStation', () => {
   // 좌표는 같지만 이름이 다른 entry(왕십리(성동구청) vs 왕십리)가 name dedup을 우회해
   // 분당선 variant가 fusion result로 흘러가던 회귀 차단.
   describe('routeContext allowedLines filter (#1436)', () => {
-    function originStation(): Station {
-      return MOCK_STATIONS.gangnam;
-    }
-    function destinationStation(): Station {
-      return MOCK_STATIONS.chungmuro;
-    }
-
     it('routeContext 없으면 allowedLines 미전달 (자유 화면 기존 동작)', () => {
       mockUseNearest.mockReturnValue(gpsBase());
       mockFindTop.mockReturnValue([]);
@@ -1644,7 +1645,7 @@ describe('useFusedNearestStation', () => {
       renderHook(() => useFusedNearestStation(undefined, undefined, routeContext));
       const allowed = mockFindTop.mock.calls[0][4] as Set<string>;
       expect(allowed).toBeInstanceOf(Set);
-      expect([...allowed].sort()).toEqual(['2']);
+      expect([...allowed].sort((a, b) => a.localeCompare(b))).toEqual(['2']);
     });
 
     it('transfer route → allowedLines = {fromLine, toLine} (왕십리 분당선 회귀 방어)', () => {
@@ -1663,10 +1664,10 @@ describe('useFusedNearestStation', () => {
       };
       renderHook(() => useFusedNearestStation(undefined, undefined, routeContext));
       const allowed = mockFindTop.mock.calls[0][4] as Set<string>;
-      expect([...allowed].sort()).toEqual(['2', '5']);
+      expect([...allowed].sort((a, b) => a.localeCompare(b))).toEqual(['2', '5']);
       // trip route 외 line(bundang/gyeongui)은 후보 단계에서 reject 대상.
-      expect(allowed.has('bundang' as never)).toBe(false);
-      expect(allowed.has('gyeongui' as never)).toBe(false);
+      expect(allowed.has('bundang')).toBe(false);
+      expect(allowed.has('gyeongui')).toBe(false);
     });
 
     it('multi-transfer route → 모든 segment의 fromLine/toLine 합집합', () => {
@@ -1685,7 +1686,7 @@ describe('useFusedNearestStation', () => {
       };
       renderHook(() => useFusedNearestStation(undefined, undefined, routeContext));
       const allowed = mockFindTop.mock.calls[0][4] as Set<string>;
-      expect([...allowed].sort()).toEqual(['2', '3', '5']);
+      expect([...allowed].sort((a, b) => a.localeCompare(b))).toEqual(['2', '3', '5']);
     });
 
     it('routeContext.route=null이면 allowedLines 미전달 (route 미설정 상태)', () => {

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -50,7 +50,7 @@ import {
 import type { LinePositions } from '../api/positionApi';
 import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
-import type { NearestStationResult, Station } from '../../../shared/types/station';
+import type { LineNumber, NearestStationResult, Station } from '../../../shared/types/station';
 import type { ArrivalProvider } from '../../../shared/types/providers';
 import type { PositionProvider } from '../providers/types';
 import type { Route } from '../../../shared/utils/stationRoute';
@@ -276,6 +276,27 @@ export interface FusedRouteContext {
   destination: Station | null;
 }
 
+/**
+ * #1436 — trip route에 포함된 노선 집합. fusion 후보 단계에서 trip 외 노선 entry를 차단한다.
+ * route 형태별로 leg의 line을 모두 모은다. trip 비활성/route null이면 undefined.
+ */
+function allowedLinesFromRoute(route: Route | null | undefined): Set<LineNumber> | undefined {
+  if (!route) return undefined;
+  const lines = new Set<LineNumber>();
+  if (route.type === 'direct') {
+    lines.add(route.line);
+  } else if (route.type === 'transfer') {
+    lines.add(route.fromLine);
+    lines.add(route.toLine);
+  } else {
+    for (const t of route.transfers) {
+      lines.add(t.fromLine);
+      lines.add(t.toLine);
+    }
+  }
+  return lines;
+}
+
 export function useFusedNearestStation(
   arrivalProvider?: ArrivalProvider,
   positionProvider?: PositionProvider,
@@ -344,6 +365,13 @@ export function useFusedNearestStation(
     accuracyMeters: gps.accuracyMeters,
   });
 
+  // #1436 — trip route에 포함된 노선 집합. 후보 단계에서 trip 외 노선 entry 차단.
+  // trip 비활성(route 없음)이면 undefined → filter 미적용으로 자유 화면 동작 보존.
+  const allowedLines = useMemo(
+    () => allowedLinesFromRoute(routeContext?.route),
+    [routeContext?.route],
+  );
+
   // GPS 좌표 → 거리순 후보 N개. 좌표 갱신 시에만 재계산.
   const candidates = useMemo<NearestStationResult[]>(() => {
     if (!gps.userLocation) return [];
@@ -352,8 +380,9 @@ export function useFusedNearestStation(
       gps.userLocation.lng,
       FUSION_CANDIDATE_LIMIT,
       MAX_STATION_DISTANCE_KM,
+      allowedLines,
     );
-  }, [gps.userLocation]);
+  }, [gps.userLocation, allowedLines]);
 
   // arrival 폴링: 후보 역명 단위 K=3 고정.
   // 각 후보의 호선을 lineHint로 함께 전달해 schedule fallback이 환승역에서 정확한

--- a/src/features/nearest-station/utils/__tests__/findNearestStation.test.ts
+++ b/src/features/nearest-station/utils/__tests__/findNearestStation.test.ts
@@ -235,7 +235,7 @@ describe('findTopNearestStations', () => {
       37.561,
       127.038,
       50,
-      1.0,
+      1,
       new Set(['2', '5']),
     );
     expect(result.length).toBeGreaterThan(0);
@@ -250,7 +250,7 @@ describe('findTopNearestStations', () => {
 
   it('allowedLines=undefined면 line filter 미적용 (자유 화면 기존 동작 보존)', () => {
     mockHaversine.mockReturnValue(0.1);
-    const result = findTopNearestStations(37.561, 127.038, 200, 1.0);
+    const result = findTopNearestStations(37.561, 127.038, 200, 1);
     const lines = new Set(result.map((r) => r.station.line));
     // line filter 없이는 분당선/경의중앙선 entry도 후보에 포함된다.
     expect(lines.size).toBeGreaterThan(2);
@@ -259,7 +259,7 @@ describe('findTopNearestStations', () => {
   it('allowedLines가 비어있어도 (Set 크기 0) 모든 entry가 reject되지 않고 일반 환승역은 그대로 통과한다', () => {
     // 빈 Set이면 한 entry도 통과하지 않는다 — 호출자가 보장해야 함을 명시적으로 검증.
     mockHaversine.mockReturnValue(0.1);
-    const result = findTopNearestStations(37.561, 127.038, 50, 1.0, new Set());
+    const result = findTopNearestStations(37.561, 127.038, 50, 1, new Set());
     expect(result).toEqual([]);
   });
 });

--- a/src/features/nearest-station/utils/__tests__/findNearestStation.test.ts
+++ b/src/features/nearest-station/utils/__tests__/findNearestStation.test.ts
@@ -225,4 +225,41 @@ describe('findTopNearestStations', () => {
     expect(result.length).toBeGreaterThan(0);
     expect(result.length).toBeLessThan(9999);
   });
+
+  // #1436 — allowedLines가 주어지면 trip route 외 line entry가 후보 단계에서 reject되어야 한다.
+  // 분당선 회귀(왕십리 좌표): trip route = {2, 5} → bundang-053(name="왕십리")이 같은 좌표
+  // 다른 이름이라 dedup을 우회하더라도 line filter로 차단되어야 한다.
+  it('allowedLines가 주어지면 해당 line의 entry만 후보로 통과한다 (분당선 회귀)', () => {
+    mockHaversine.mockReturnValue(0.1);
+    const result = findTopNearestStations(
+      37.561,
+      127.038,
+      50,
+      1.0,
+      new Set(['2', '5']),
+    );
+    expect(result.length).toBeGreaterThan(0);
+    for (const r of result) {
+      expect(['2', '5']).toContain(r.station.line);
+    }
+    // bundang/gyeongui variant는 후보에서 제거되어야 한다.
+    const lines = new Set(result.map((r) => r.station.line));
+    expect(lines.has('bundang')).toBe(false);
+    expect(lines.has('gyeongui')).toBe(false);
+  });
+
+  it('allowedLines=undefined면 line filter 미적용 (자유 화면 기존 동작 보존)', () => {
+    mockHaversine.mockReturnValue(0.1);
+    const result = findTopNearestStations(37.561, 127.038, 200, 1.0);
+    const lines = new Set(result.map((r) => r.station.line));
+    // line filter 없이는 분당선/경의중앙선 entry도 후보에 포함된다.
+    expect(lines.size).toBeGreaterThan(2);
+  });
+
+  it('allowedLines가 비어있어도 (Set 크기 0) 모든 entry가 reject되지 않고 일반 환승역은 그대로 통과한다', () => {
+    // 빈 Set이면 한 entry도 통과하지 않는다 — 호출자가 보장해야 함을 명시적으로 검증.
+    mockHaversine.mockReturnValue(0.1);
+    const result = findTopNearestStations(37.561, 127.038, 50, 1.0, new Set());
+    expect(result).toEqual([]);
+  });
 });

--- a/src/features/nearest-station/utils/findNearestStation.ts
+++ b/src/features/nearest-station/utils/findNearestStation.ts
@@ -1,6 +1,6 @@
 import stationsData from '../../../data/stations.json';
 import { haversine } from '../../../shared/utils/haversine';
-import type { NearestStationResult, NearestStationsResult, Station } from '../../../shared/types/station';
+import type { LineNumber, NearestStationResult, NearestStationsResult, Station } from '../../../shared/types/station';
 
 const stations = stationsData as Station[];
 
@@ -46,17 +46,24 @@ export function findNearestStations(
 /**
  * 사용자 좌표 기준 거리순 상위 N개 역(이름 중복 제거 — 환승역은 한 번만).
  * fusion 후보 추출에 사용. 거리 기준이지 노선 기준이 아니다.
+ *
+ * #1436 — `allowedLines`가 주어지면 trip route에 포함된 노선의 entry만 후보로 통과시킨다.
+ * 좌표는 같지만 이름이 다른 entry(예: `왕십리(성동구청)` vs `왕십리`)가 name dedup을 우회해
+ * trip 외 노선이 fusion result로 흘러가던 회귀를 입구에서 차단한다. ADR-015 §5.
+ * trip 비활성(undefined) 시 기존 동작 보존.
  */
 export function findTopNearestStations(
   lat: number,
   lng: number,
   limit: number,
   maxDistanceKm?: number,
+  allowedLines?: Set<LineNumber>,
 ): NearestStationResult[] {
   if (limit <= 0) return [];
   const ranked = stations
     .map((s) => ({ station: s, distanceKm: haversine(lat, lng, s.lat, s.lng) }))
     .filter((r) => maxDistanceKm == null || r.distanceKm <= maxDistanceKm)
+    .filter((r) => allowedLines == null || allowedLines.has(r.station.line))
     .sort((a, b) => a.distanceKm - b.distanceKm);
 
   const seen = new Set<string>();


### PR DESCRIPTION
Closes #1436

## 배경

2026-06-18 trip dump L239 `src=position-train | 왕십리(bundang)` — trip route는 2→5호선만인데 fusion이 분당선 variant 채택.

- `stations.json` L4602 `gyeongui-034 name="왕십리(성동구청)"` vs L5372 `bundang-053 name="왕십리"` — **같은 좌표 다른 이름**으로 `findTopNearestStations`의 name dedup 우회
- 분당선 variant가 fusion 후보 단계 통과 → cascade에서 result로 채택

청량리(서울시립대입구)/(bundang) 등 같은 dedup-bypass 패턴도 자동 차단.

## 변경

### 입구 필터 — `findTopNearestStations`
- 시그니처 확장: `allowedLines?: Set<LineNumber>`
- 주어지면 ranked 단계에서 `station.line` mismatch entry reject
- 미지정 시 기존 동작 (자유 화면 fusion 보존)

### routeContext → allowedLines 도출 (`useFusedNearestStation`)
모듈 스코프 helper `allowedLinesFromRoute`:
```
allowedLines = ∪{
  direct.line ∨
  transfer.fromLine ∨ transfer.toLine ∨
  multi-transfer.transfers[].fromLine ∨ multi-transfer.transfers[].toLine
}
```
`useMemo`로 candidates 산출에 전달. `routeContext?.route`가 dep.

### 보조 안전망 (pickFusedStation) — 적용 보류
이슈 본문에 "한 줄 더 추가" 언급이 있어 시도했으나 `pickFusedStation` 단계에서 line mismatch reject 시 `null` 반환이 `#1365 lockless-route-hop line guard`의 GPS fallback 케이스(`positionGate.test.ts:477`)를 깨뜨림. 입구 필터(`findTopNearestStations`)만으로 trip 외 line entry가 candidates에 진입하지 못해 동등 효과를 얻으므로 안전망은 보류. 데이터셋/호출자 변경으로 우회 시 추후 별도 PR에서 cascade 흐름과 함께 재검토.

## 분당선 회귀 차단 evidence

`findNearestStation.test.ts`에 추가:
```
allowedLines가 주어지면 해당 line의 entry만 후보로 통과한다 (분당선 회귀)
  → for r in result: r.station.line ∈ {'2', '5'}
  → lines.has('bundang') === false
  → lines.has('gyeongui') === false
```

`useFusedNearestStation.test.ts`에 추가:
- routeContext 없음 → allowedLines undefined (자유 화면 보존)
- direct route → `{route.line}`
- transfer route(왕십리(성동구청), 2→5) → `{'2','5'}` (분당선/경의중앙선 차단)
- multi-transfer(2→3→5) → `{'2','3','5'}`
- route=null → undefined

## 영향 범위

- `findTopNearestStations` optional 추가 — 기존 호출자(useStationCandidates 등) 무영향
- trip 비활성 시 모두 기존 동작 보존
- 테스트 baseline 동일: 35 fail / 6000 pass (widgetStorage + stationNotification은 origin/dev에서도 동일 fail, 본 PR 무관)
- 변경 파일 4개, 165+ / 4-

## Acceptance (1주 검증 대기)

- [ ] trip route 외 line variant fire 0건 (분당선/경의중앙선)
- [ ] trip 비활성 자유 화면에서 기존 fusion 동작 보존
- [ ] 좌표 dedup-bypass entry(왕십리, 청량리, 사당, 서울역 등) 자동 차단

## 참고

- Epic: #1432
- ADR: `docs/decisions/ADR-015-multi-signal-consensus-gate.md` §5
- Memory: `lesson_fusion_route_line_filter_dedup_bypass`