### PR TITLE
fix(#1437): interp/sticky/route-hop fire 권한 영구 박탈 — 추정 신호 표시 채널 격리

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
@@ -417,23 +417,18 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
       tripStartStorage.getTripStartedAt.mockResolvedValue(null);
     });
 
-    it('lock 없음 + routeCtx + 시간 경과 → lockless-route-hop이 arc hop time lookup closure 호출', () => {
-      // lock 없음 + routeCtx 있음 → 첫 render에 locklessTripStartRef 캡처(=T0).
-      // 5분 경과 → hopsElapsedFrom이 0번 hop의 시작 노선('7') lookup → hopTimeMsForHop 호출.
-      // Closure 내부 (segmentLine = arc[fromIdx].line) 경로 커버.
-      // (mockPos는 beforeEach에서 null → trainProgress null → positionTrainResult null.)
+    it('#1437 lock 없음 + routeCtx + 시간 경과 → lockless-route-hop이 displayOnly 채널에 노출', () => {
+      // estimator closure 호출 경로 커버는 유지 — 다만 fire path는 GPS, estimator는 displayOnly.
       const result = runEstimatorScenario({ elapsedMs: 5 * 60_000 });
-
-      // lock 없음 + estimator 채택 → boarding-lock-interp.
-      expect(result.current.source).toBe('boarding-lock-interp');
+      expect(result.current.source).not.toBe('boarding-lock-interp');
+      expect(result.current.displayOnlyEstimate?.strategy).toBe('lockless-route-hop');
     });
   });
 
-  describe('observation ceiling — line 564 커버', () => {
-    it('interpolated estimate + positionTrainResult null → livePositionIdx=-1 분기 통과', () => {
+  describe('observation ceiling — estimator displayOnly 노출', () => {
+    it('#1437 interpolated estimate + positionTrainResult null → fire path는 GPS, estimator는 displayOnly', () => {
       // boardingLock 활성 + 90s 경과 → estimator default-hop 채택 (isInterpolated=true).
-      // 열차 위치 없음 → positionTrainResult null → line 564 ternary false branch(: -1) 실행.
-      // (mockPos는 beforeEach에서 null로 설정됨 → trainProgress null → positionTrainResult null.)
+      // ADR-015 §2 박탈로 fire path는 GPS('gps') 유지. displayOnly만 estimator strategy 노출.
       const result = runEstimatorScenario({
         lock: makeLock({
           trainCode: 'T-INTERP',
@@ -445,7 +440,8 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
         trainCode: 'T-INTERP',
       });
 
-      expect(result.current.source).toBe('boarding-lock-interp');
+      expect(result.current.source).not.toBe('boarding-lock-interp');
+      expect(result.current.displayOnlyEstimate?.strategy).toBe('default-hop');
     });
   });
 
@@ -489,36 +485,34 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
       expect(result.current.result?.station.id).toBe(chungmuro3.id);
     });
 
-    it('estimatedLine = gpsNearestLine → line guard 통과 (estimator 채택)', () => {
-      // 회귀 차단: 같은 line이면 기존 동작 (lockless-route-hop 채택)이 유지되어야 한다.
+    it('#1437 estimatedLine = gpsNearestLine → estimator는 displayOnly에만 노출 (fire path 박탈)', () => {
+      // 같은 line('7')이어도 ADR-015 §2 박탈 — line guard 통과해도 fire path는 GPS.
       const result = runLine7LocklessRouteScenario(gpsBase());
 
-      // 같은 line('7') → line guard 통과 → estimator override 채택.
-      expect(result.current.source).toBe('boarding-lock-interp');
+      expect(result.current.source).not.toBe('boarding-lock-interp');
+      expect(result.current.displayOnlyEstimate?.strategy).toBe('lockless-route-hop');
     });
   });
 
   // #1382 — lock-interp adoption 게이트에 motion=stationary 가드 추가.
   // 정지 trip에서 시간 적분 forward ratchet 보류. consensus 게이트(#1363)와 분리 책임.
-  describe('#1382 lock-interp forward ratchet — motion=stationary 보류', () => {
-    it('motionStationary=true → forward ratchet 보류 (lock-interp 미채택)', () => {
-      // estimator는 다음 hop을 가리키지만, 사용자가 명시적 정지 상태.
-      // 게이트 차단 → result/source가 boarding-lock-interp로 승격되지 않음.
+  // #1437 (ADR-015 §2) — 시간 적분 strategy의 fire 권한 영구 박탈로 #1382 motion 가드는
+  // 본 cascade 단에서 무의미해졌다(어차피 ratchet 자체가 사라짐). motion 가드는 호출자(useStationAlarm)의
+  // station-passed evaluateMovement에서 별도 책임. 본 describe는 회귀 가드로만 유지.
+  describe('#1382 lock-interp forward ratchet — motion=stationary 보류 (#1437 박탈로 모두 미채택)', () => {
+    it('motionStationary=true → fire path 미승격', () => {
       const result = runLockedMotionScenario(true);
       expect(result.current.source).not.toBe('boarding-lock-interp');
     });
 
-    it('motionStationary=undefined(warmup) → 기존 ratchet 동작 유지', () => {
-      // motion warmup 상태(fg-hydrate 직후 ~30s)는 기존 동작 유지 — 정지 신호 미확정.
+    it('motionStationary=undefined(warmup) → fire path 미승격 (#1437 박탈)', () => {
       const result = runLockedMotionScenario(undefined);
-      expect(result.current.source).toBe('boarding-lock-interp');
+      expect(result.current.source).not.toBe('boarding-lock-interp');
     });
 
-    it('motionStationary=false → 기존 ratchet 동작 유지 (이동 또는 미지원)', () => {
-      // motion 신호가 이동 중이라고 보고하거나 디바이스 미지원으로 false fallback.
-      // forward ratchet 정상.
+    it('motionStationary=false → fire path 미승격 (#1437 박탈)', () => {
       const result = runLockedMotionScenario(false);
-      expect(result.current.source).toBe('boarding-lock-interp');
+      expect(result.current.source).not.toBe('boarding-lock-interp');
     });
   });
 });

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -852,9 +852,10 @@ describe('useFusedNearestStation', () => {
       mockUsePositions.mockReturnValue(positionRet(null));
     }
 
-    it('GPS stale(용마산) + 1 hop 경과 → interp(중곡)이 ratchet forward로 승격', () => {
-      // Seam B (#898): 라이브 관측 없는 dead-zone에선 boardingIdx+1까지만 허용.
-      // 본 시나리오는 lastObservedRef=null + boardingIdx=용마산(0) → cap=중곡(1).
+    it('#1437 (ADR-015 §2) GPS stale(용마산) + 1 hop 경과 → fire path는 GPS(용마산) 유지, estimator(중곡)는 displayOnly 채널에만', () => {
+      // 시간 적분 strategy(default-hop / lockless-route-hop / reanchored-hop)의 fire 권한 박탈.
+      // estimator override가 result/source를 덮어쓰지 않는다 — GPS가 fire path SSOT.
+      // UI 추적용 displayOnlyEstimate는 estimator 결과를 그대로 노출 (DebugModal에서 strategy 라벨 추적).
       jest.useFakeTimers();
       try {
         jest.setSystemTime(T0 + 90_000);
@@ -862,17 +863,20 @@ describe('useFusedNearestStation', () => {
         const { result } = renderHook(() =>
           useFusedNearestStation(undefined, undefined, routeContext, '7093', lock),
         );
-        expect(result.current.source).toBe('boarding-lock-interp');
-        expect(result.current.confidence).toBe('boarding-lock-interp');
-        expect(result.current.result?.station.id).toBe(junggok.id);
+        expect(result.current.source).not.toBe('boarding-lock-interp');
+        expect(result.current.result?.station.id).toBe(yongmasan.id);
+        // displayOnly 채널은 estimator 결과 노출
+        expect(result.current.displayOnlyEstimate?.station.id).toBe(junggok.id);
+        expect(result.current.displayOnlyEstimate?.strategy).toBe('default-hop');
+        // fire path SSOT인 currentHopIndex는 시간 적분 strategy에서 박탈 (null)
+        expect(result.current.currentHopIndex).toBeNull();
       } finally {
         jest.useRealTimers();
       }
     });
 
-    it('Seam B (#898) — dead-zone 3 hop 경과해도 interp이 boardingIdx+1 초과 안 함', () => {
-      // 13:19:12 회귀 fixture 인자: LivePosition/ArrivalEta 모두 결손인 상황에서 적분이
-      // 물리 위치보다 여러 hop 앞서 가는 것을 차단. estimator 내부 cap + 외부 cap 이중 가드.
+    it('#1437 dead-zone 3 hop 경과해도 fire path는 GPS(용마산) 유지', () => {
+      // 정책 박탈 후: estimator가 어디까지 적분하더라도 fire path는 GPS SSOT.
       jest.useFakeTimers();
       try {
         jest.setSystemTime(T0 + 3 * 90_000);
@@ -880,7 +884,7 @@ describe('useFusedNearestStation', () => {
         const { result } = renderHook(() =>
           useFusedNearestStation(undefined, undefined, routeContext, '7093', lock),
         );
-        expect(result.current.result?.station.id).toBe(junggok.id);
+        expect(result.current.result?.station.id).toBe(yongmasan.id);
         expect(result.current.result?.station.id).not.toBe(oolinidae.id);
         expect(result.current.result?.station.id).not.toBe(konkuk.id);
       } finally {
@@ -948,8 +952,9 @@ describe('useFusedNearestStation', () => {
       }
     });
 
-    it('GPS가 arc 밖(서울역 공항철도) + lock 활성 → interp가 boardingIdx+1까지 채택', () => {
-      // Seam B (#898): GPS가 arc 밖이라도 라이브 관측은 여전히 없음 → cap=중곡(1).
+    it('#1437 GPS가 arc 밖(서울역 공항철도) + lock 활성 → estimator override 안 함, GPS 유지', () => {
+      // 정책 박탈 후: estimator가 hop을 산출해도 fire path는 GPS SSOT.
+      // arc 밖 GPS는 그대로 노출 — 호출자(useStationAlarm)가 hop window 게이트로 차단.
       jest.useFakeTimers();
       try {
         jest.setSystemTime(T0 + 2 * 90_000);
@@ -958,8 +963,11 @@ describe('useFusedNearestStation', () => {
         const { result } = renderHook(() =>
           useFusedNearestStation(undefined, undefined, routeContext, '7093', lock),
         );
-        expect(result.current.source).toBe('boarding-lock-interp');
-        expect(result.current.result?.station.id).toBe(junggok.id);
+        expect(result.current.source).not.toBe('boarding-lock-interp');
+        // estimator override 박탈 — result.station이 estimator의 junggok이 아님.
+        expect(result.current.result?.station.id).not.toBe(junggok.id);
+        // estimator는 displayOnly에만
+        expect(result.current.displayOnlyEstimate?.station.id).toBe(junggok.id);
       } finally {
         jest.useRealTimers();
       }
@@ -1064,7 +1072,9 @@ describe('useFusedNearestStation', () => {
       }
     });
 
-    it('시간만 흐르면(부모 리렌더 없이) interp가 다음 hop으로 전진 — useMemo 캐시 회귀 가드', () => {
+    it('#1437 시간만 흐르면(부모 리렌더 없이) displayOnlyEstimate가 다음 hop 반영 — useMemo 캐시 회귀 가드', () => {
+      // 정책 박탈 후: estimator는 시간 경과로 추정 hop을 진전시키지만 fire path는 GPS 유지.
+      // displayOnlyEstimate가 새 hop을 반영하는지 (useMemo 캐시 회귀)만 검증.
       jest.useFakeTimers();
       try {
         jest.setSystemTime(T0);
@@ -1072,22 +1082,50 @@ describe('useFusedNearestStation', () => {
         const { result, rerender } = renderHook(() =>
           useFusedNearestStation(undefined, undefined, routeContext, '7093', lock),
         );
-        // 탑승 직후: interp=용마산(idx 0), GPS=용마산 → tied. GPS 유지.
         expect(result.current.result?.station.id).toBe(yongmasan.id);
+        expect(result.current.displayOnlyEstimate?.station.id).toBe(yongmasan.id);
 
-        // 시계만 진행. boardingLock/arcStations/GPS는 그대로 — 의존성이 안 바뀌어도
-        // interp이 새 now를 반영해야 한다. 부모 리렌더(rerender)는 한 번 발생시켜
-        // hook이 다시 호출되는 정상 사이클을 시뮬레이션. Seam B cap에 따라 +1 hop까지.
         jest.setSystemTime(T0 + 90_000);
         rerender(undefined);
-        expect(result.current.source).toBe('boarding-lock-interp');
-        expect(result.current.result?.station.id).toBe(junggok.id);
+        // fire path: GPS(용마산) 유지
+        expect(result.current.source).not.toBe('boarding-lock-interp');
+        expect(result.current.result?.station.id).toBe(yongmasan.id);
+        // displayOnly: estimator 진전(중곡)
+        expect(result.current.displayOnlyEstimate?.station.id).toBe(junggok.id);
       } finally {
         jest.useRealTimers();
       }
     });
 
-    it('userLocation null + GPS result null → interp 단독 채택 (distanceKm=0)', () => {
+    it('#1437 회귀 가드 — 2026-06-18 13:25:26 시나리오 (gps=성수 + lock=뚝섬 시점 시간 적분) → fire path X', () => {
+      // trip dump L335 13:26:14 `interp 뚝섬 d=827m, gp=성수, rt=성수` 케이스 재현.
+      // lock 시점 시간 적분이 lockless-route-hop/default-hop으로 뚝섬을 가리켜도,
+      // fire path는 GPS(성수) 유지여야 한다. 사용자 실제 위치 추월 차단.
+      jest.useFakeTimers();
+      try {
+        jest.setSystemTime(T0 + 90_000);
+        // 사용자는 성수 정차 중 — GPS가 성수 보고. lock anchor는 출발 시 용마산이지만
+        // 시간이 흘러 estimator는 다음 hop을 추정한다.
+        // 본 케이스의 핵심: estimator 결과가 GPS와 다른 station을 가리키더라도 fire path 불승격.
+        setupGpsAt(gunja); // 군자 시뮬레이션 (lock 뚝섬, gps gunja 류 mismatch)
+        const { result } = renderHook(() =>
+          useFusedNearestStation(undefined, undefined, routeContext, '7093', lock),
+        );
+        // fire path source: GPS 또는 fused 실측 — 절대 boarding-lock-interp 아님.
+        expect(result.current.source).not.toBe('boarding-lock-interp');
+        expect(result.current.confidence).not.toBe('boarding-lock-interp');
+        // dedup 누적 차단: currentHopIndex(시간 적분 SSOT)도 null로 박탈.
+        expect(result.current.currentHopIndex).toBeNull();
+        // UI 추적은 유지 — displayOnlyEstimate에 estimator 결과 그대로.
+        expect(result.current.displayOnlyEstimate).not.toBeNull();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('#1437 userLocation null + GPS result null → fire path result도 null (estimator override 박탈)', () => {
+      // 정책 박탈 후: GPS가 없으면 fire path도 그대로 비어 있다. estimator가 채워주지 않는다.
+      // displayOnlyEstimate만 estimator 결과를 노출.
       jest.useFakeTimers();
       try {
         jest.setSystemTime(T0 + 90_000);
@@ -1100,9 +1138,9 @@ describe('useFusedNearestStation', () => {
         const { result } = renderHook(() =>
           useFusedNearestStation(undefined, undefined, routeContext, '7093', lock),
         );
-        expect(result.current.source).toBe('boarding-lock-interp');
-        expect(result.current.result?.station.id).toBe(junggok.id);
-        expect(result.current.result?.distanceKm).toBe(0);
+        expect(result.current.source).not.toBe('boarding-lock-interp');
+        expect(result.current.result).toBeNull();
+        expect(result.current.displayOnlyEstimate?.station.id).toBe(junggok.id);
       } finally {
         jest.useRealTimers();
       }
@@ -1238,7 +1276,10 @@ describe('useFusedNearestStation', () => {
         }));
         jest.setSystemTime(opts.disconnectAtMs);
         rerender(undefined);
-        expect(result.current.source).toBe('boarding-lock-interp');
+        // #1437 — ReanchoredHop도 시간 적분이라 fire path 박탈. estimator는 displayOnly에만.
+        // fire path source는 GPS('gps')로 fallback. displayOnly에 reanchored-hop strategy 노출.
+        expect(result.current.source).not.toBe('boarding-lock-interp');
+        expect(result.current.displayOnlyEstimate?.strategy).toBe('reanchored-hop');
       } finally {
         jest.useRealTimers();
         mockUseArrival.mockReset();

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.tierCascade.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.tierCascade.test.ts
@@ -120,21 +120,24 @@ describe('#1418 Tier 5 reject — lockless-route-hop forward ratchet 차단', ()
     expect(result.result.current.surfaceSSOTActive).toBe(true);
   });
 
-  it('실측 신호 없음(arrival 없음) → Tier 5 fallback 허용 (dead zone)', () => {
-    // 진짜 dead zone: GPS만 있고 arrival 신호 없음 → surfaceSSOT 미합의.
-    // lockless-route-hop이 적분 결과로 forward ratchet 가능.
+  it('#1437 실측 신호 없음(arrival 없음) → estimator는 displayOnly만, fire path는 GPS', () => {
+    // 진짜 dead zone: GPS만 있고 arrival 신호 없음. 이전 정책에서는 lockless-route-hop이
+    // forward ratchet 했지만, ADR-015 §2 박탈로 fire path는 GPS('gps') 유지.
+    // estimator는 displayOnlyEstimate 채널로만 노출.
     const result = setupLocklessTripAtYongmasan({
       gpsAccuracy: 14,
       arrivalAtYongmasan: null,
     });
 
-    // 실측 신호 부재 → Tier 5 허용 → estimator override → boarding-lock-interp.
-    expect(result.result.current.source).toBe('boarding-lock-interp');
+    expect(result.result.current.source).not.toBe('boarding-lock-interp');
     expect(result.result.current.surfaceSSOTActive).toBe(false);
+    // 시간 적분 strategy는 currentHopIndex에서도 박탈
+    expect(result.result.current.currentHopIndex).toBeNull();
   });
 
-  it('GPS accuracy 너무 큼(>30m) → surfaceSSOT 미합의 → 실측 신호 부재 → Tier 5 허용', () => {
+  it('#1437 GPS accuracy 너무 큼(>30m) → surfaceSSOT 미합의여도 estimator override 박탈', () => {
     // 지하 fallback 등으로 accuracy 50m → Tier 1 surface 미충족.
+    // 이전엔 Tier 5 허용으로 override됐지만 ADR-015 §2 박탈.
     const result = setupLocklessTripAtYongmasan({
       gpsAccuracy: 50,
       arrivalAtYongmasan: makeArrivalInfo({
@@ -146,7 +149,7 @@ describe('#1418 Tier 5 reject — lockless-route-hop forward ratchet 차단', ()
     });
 
     expect(result.result.current.surfaceSSOTActive).toBe(false);
-    // Tier 5 허용 → estimator override.
-    expect(result.result.current.source).toBe('boarding-lock-interp');
+    expect(result.result.current.source).not.toBe('boarding-lock-interp');
+    expect(result.result.current.currentHopIndex).toBeNull();
   });
 });

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -103,8 +103,24 @@ interface UseFusedNearestStationReturn {
    * useStationAlarm이 station-passed 게이트(`isStationWithinHopWindow`)의 SSOT로 사용.
    * #1235 (D9 wire) — DebugModal Trip 섹션 currentHopIndex row의 SSOT도 동일.
    * estimator 미채택 시 null — 호출자가 firedAlarms 등의 fallback으로 추정.
+   *
+   * #1437 (E4 / ADR-015 §2) — 시간 적분 strategy(default-hop / lockless-route-hop / reanchored-hop)는
+   * 본 필드에서 박탈된다(null로 노출). 시간 적분이 fire path 게이트의 SSOT가 되면
+   * 사용자 실제 위치를 추월해 false station-passed fire/dedup 누적 회귀를 일으킨다.
+   * UI 추적용으로는 displayOnlyEstimate를 사용.
    */
   currentHopIndex: number | null;
+  /**
+   * #1437 (E4 / ADR-015 §2) — estimator 결과의 표시 전용 채널.
+   * DebugModal/UI 위치 추적용. fire path는 본 필드를 읽지 않는다 (시간 적분 결과의 fire 권한 박탈).
+   * 모든 strategy(live-position / arrival-eta / reanchored-hop / default-hop / lockless-route-hop)가
+   * 그대로 노출돼 디버그 인프라에서 strategy 라벨 추적이 가능하다.
+   */
+  displayOnlyEstimate: {
+    station: Station;
+    strategy: import('../../route/utils/stationProgressEstimator').StationProgressStrategy;
+    index: number;
+  } | null;
   /**
    * #1208 — 현재 trip의 arc(탑승역~다음 waypoint) station 배열.
    * useStationAlarm의 hop window 게이트 입력 및 firedAlarms 기반 fallback hop 계산용.
@@ -787,105 +803,30 @@ export function useFusedNearestStation(
     currentIdxHint,
   });
 
-  // #662 invariant: estimate가 boardingLock이 active일 때만 만들어지고 arcStations(route segment)
-  // 위로만 전진하므로 lock.boardingLine 외 노선이 들어올 수 없음 — #662 가드 별도 적용 불필요.
+  // #1437 (E4 / ADR-015 §2) — interp/sticky/route-hop fire 권한 영구 박탈.
   //
-  // ADR-008 #739 — monotone forward 가드 유지.
-  // 'station-passed' 알람은 lastNotifiedStationId로 dedup하나, 통과한 역 id가 바뀌면 새 알람을 발사한다.
-  // backward 정정 허용 시 이미 통과한 역의 알람이 재발사되어 사용자 혼란. ReanchoredHop이 적분을 1 hop으로
-  // 제한해 잘못된 forward를 구조적으로 막으므로 forward 가드만으로도 ADR §원인 ③의 누적 drift는 해소된다.
-  // LivePosition으로 fusion 자체가 이미 정정되는 경우(positionTrainResult branch)에는 estimator override
-  // 자체가 일어나지 않으므로 backward 정정 손실 없음.
-  if (estimate && arcStations.length > 0) {
-    const chosenIdx = arcIndexOfStation(arcStations, result?.station ?? null);
-    // Seam B (#898): hop-time 적분 전략(③④)에 forward observation ceiling 적용 —
-    // LivePosition/ArrivalEta dead-zone에서 적분이 물리 위치보다 앞서 발산하면 알람·LA·위젯이
-    // 모두 잘못된 "다음 역"을 소비(2026-06-05 13:19 transfer/early/건대입구 fired @ 성수).
-    // 실시간 신호(①LivePosition·②ArrivalEta) 외 모든 strategy는 cap 대상 — 부정형 분기로
-    // 신규 strategy(Seam G 등)가 추가될 때 기본 cap 적용 되도록 안전 방향 디폴트.
-    //
-    // #1207 (Epic #1204 D1) — lockless-route-hop은 boardingLock 없음 → boardingIdx=-1, lastObserved
-    // 미갱신 → lastRealObservedIdx=-1로 ceiling이 idx 0에 박혀 lockless trip이 영구 0번 hop에 정지.
-    // lockless 전략 자체가 시간 적분 SSOT(D2 hop window 게이트의 source of truth) — observation
-    // ceiling을 면제한다. 잘못된 forward 발산 방지는 lockless 분기 내 arc clamp + over-terminal cap이 담당.
-    const isInterpolated =
-      estimate.strategy !== 'live-position' &&
-      estimate.strategy !== 'arrival-eta' &&
-      estimate.strategy !== 'lockless-route-hop';
-    let withinObservationCeiling = true;
-    if (isInterpolated) {
-      // positionTrainResult non-null → freshTrainProgress non-null → tryLivePosition='live-position' →
-      // isInterpolated=false → 이 블록 도달 불가. positionTrainResult는 항상 null.
-      // 향후 새 전략(non-live/non-arrival)이 추가될 때를 대비한 future-proofing.
-      const livePositionIdx = /* istanbul ignore next */ positionTrainResult
-        ? /* istanbul ignore next */ arcIndexOfStation(arcStations, positionTrainResult.station)
-        : -1;
-      const reanchoredObservedIdx = lastObservedRef.current?.arcIndex ?? -1;
-      // estimate가 non-null이면 boardingLock도 non-null(estimator 245 가드) — false branch 도달 불가.
-      const boardingIdx = boardingLock
-        ? arcStations.findIndex((s) => s.id === boardingLock.boardingStationId)
-        : /* istanbul ignore next */ -1;
-      const lastRealObservedIdx = Math.max(
-        livePositionIdx,
-        reanchoredObservedIdx,
-        boardingIdx,
-      );
-      withinObservationCeiling = estimate.index <= lastRealObservedIdx + 1;
-    }
-    // #1365 — lockless-route-hop은 ceiling 면제(시간 적분 SSOT)지만 환승역에서 같은
-    // hop index에 다른 line의 stop이 존재할 수 있다. 채택 전 line 검증: GPS 최근접
-    // (candidates[0]) line과 일치하지 않으면 fallback(GPS) — 잘못된 line의 station-passed/
-    // destination 알람 차단. 다른 strategy(live-position / arrival-eta)는 fusion 자체가 실시간
-    // 신호로 line이 강제되므로 면제. lockless trip은 lock 부재로 lastObservedRef도 anchor되지
-    // 않아 currentIdxHint를 SSOT로 신뢰할 수 없으므로 GPS 최근접만 cross-check 기준.
-    let withinLineGuard = true;
-    if (estimate.strategy === 'lockless-route-hop') {
-      const gpsNearestLine = candidates[0]?.station.line ?? null;
-      withinLineGuard = estimate.station.line === gpsNearestLine;
-    }
-    // #1382 — motion 명시 정지(true) 시 시간 적분 forward ratchet 보류. undefined(warmup) /
-    // false(이동·미지원)는 기존 동작. consensus 게이트(#1363, movementGate.ts)는 confidence
-    // 라벨 안정성을 별도 책임 — 라벨/forward 이동을 분리. 정지 trip에서 origin chip / 위젯
-    // mirror가 잘못된 다음 역으로 forward 표시되는 회귀(2026-06-16 18:11~18:12) 차단.
-    //
-    // #1418 — Tier 5 reject 게이트. 시간 적분 strategy(lockless-route-hop / default-hop)는
-    // 실측 신호(SSOT / lastObservedRef / positionTrainResult)가 하나라도 활성이면 forward ratchet 차단.
-    //
-    // boardingLock 자체는 본 게이트에서 제외:
-    //   - default-hop은 boardingLock.boardedAt이 anchor라 lock 활성이 strategy의 *입력*이다.
-    //     lock 활성을 reject 신호로 쓰면 default-hop이 영구 차단되어 dead zone fallback이 무력화.
-    //   - lockless-route-hop은 lock 부재 상황이라 boardingLock 검사 자체가 무의미.
-    //
-    // 실시간 strategy(live-position / arrival-eta / reanchored-hop)는 strategy 자체가 실측 기반이라
-    // 면제 — 본 게이트는 isTimeIntegration=true 케이스에만 적용.
-    const isTimeIntegration =
-      estimate.strategy === 'lockless-route-hop' || estimate.strategy === 'default-hop';
-    const realtimeSignalActive =
-      surfaceSSOT !== null ||
-      undergroundSSOT !== null ||
-      lastObservedRef.current !== null ||
-      positionTrainResult !== null;
-    const passesTier5Gate = !isTimeIntegration || !realtimeSignalActive;
-    if (
-      (chosenIdx === -1 || estimate.index > chosenIdx) &&
-      withinObservationCeiling &&
-      withinLineGuard &&
-      motionStationary !== true &&
-      passesTier5Gate
-    ) {
-      const distanceKm = gps.userLocation
-        ? haversine(
-            gps.userLocation.lat,
-            gps.userLocation.lng,
-            estimate.station.lat,
-            estimate.station.lng,
-          )
-        : 0;
-      result = { station: estimate.station, distanceKm };
-      confidence = 'boarding-lock-interp';
-      source = 'boarding-lock-interp';
-    }
-  }
+  // estimator(default-hop / lockless-route-hop / reanchored-hop)는 모두 시간 적분 기반 추정 신호다.
+  // 2026-06-18 trip dump L335 13:26:14 `interp 뚝섬 d=827m, gp=성수, rt=성수` 케이스가 보여주듯,
+  // 시간 적분이 사용자 실제 위치를 추월해 false station-passed fire를 일으키고, dedup 누적으로
+  // 실측 신호 도착 시 알람이 빠지는 회귀를 만든다.
+  //
+  // ADR-015 §2: estimator 결과는 fire path 입력(result/confidence/source/currentHopIndex)에서 분리.
+  //   - fire path 입력: 실측 신호(SSOT / lastObservedRef / positionTrainResult / lock + arrival)만 채택.
+  //   - 표시 채널: estimator 결과는 `displayOnlyEstimate`로만 노출 — DebugModal/UI 추적에 유지.
+  //
+  // 이전 정책(#1418 Tier 5 reject 게이트, lockless/default만 reject + reanchored override 허용,
+  // #1207 D2 hop window 게이트가 estimate.index를 currentHopIndex로 사용) 모두 본 PR로 박탈.
+  // estimator 호출과 디버그 buffer push(아래)는 유지 — UI/측정 인프라용.
+  //
+  // 관련:
+  //   - lesson_lockless_route_hop_time_integration_ssot_assumption.md (시간 적분 SSOT 가정 결함)
+  //   - lesson_train_progressing_source_strategy_blindness.md (upstream fusion arbitration에서 차단)
+  const estimatorIsTimeIntegration =
+    estimate?.strategy === 'lockless-route-hop'
+    || estimate?.strategy === 'default-hop'
+    || estimate?.strategy === 'reanchored-hop';
+  const fireSafeHopIndex =
+    estimate != null && !estimatorIsTimeIntegration ? estimate.index : null;
 
   // #1401 — 열차 진행(trainProgressing) 신호. 직전 tick 대비 fusion result.station이 arc 위에서
   // advance(idx 증가)했는지. forward-only: 동일/감소는 false. arcKey 변경(새 trip arc) 시 리셋 —
@@ -1117,7 +1058,13 @@ export function useFusedNearestStation(
     positionStability,
     estimatorStrategy: estimate?.strategy ?? null,
     // D2(#1208) + #1235 (D9 wire) — useStationAlarm hop window 게이트 + DebugModal Trip/Fusion/GPS 섹션 SSOT.
-    currentHopIndex: estimate?.index ?? null,
+    // #1437 (E4 / ADR-015 §2) — 시간 적분 strategy(default-hop / lockless-route-hop / reanchored-hop)는
+    // fire path 입력에서 박탈. estimator 결과는 displayOnlyEstimate로만 노출.
+    currentHopIndex: fireSafeHopIndex,
+    // #1437 — UI/DebugModal 추적용 별 채널. fire path는 본 필드를 읽지 않는다.
+    displayOnlyEstimate: estimate
+      ? { station: estimate.station, strategy: estimate.strategy, index: estimate.index }
+      : null,
     arcStations,
     detectionTier: detectionVerdict.confidence,
     detectionSignalMask: detectionVerdict.signalMask,


### PR DESCRIPTION
## 배경 (ADR-015 §2, Epic #1432)

`useFusedNearestStation`의 시간 적분 estimator 결과(default-hop / lockless-route-hop / reanchored-hop)는 사용자 실제 위치를 추월해 false `station-passed` fire를 일으키고, dedup 누적으로 실측 신호 도착 시 알람이 빠지는 회귀를 만든다. 2026-06-18 trip dump L335 13:26:14 `interp 뚝섬 d=827m, gp=성수, rt=성수`가 evidence.

본 PR은 ADR-015 §2에 따라 estimator 결과의 fire 권한을 영구 박탈하고, 표시(DebugModal/UI) 전용 채널로 격리한다.

## 변경 (~50줄 + 테스트 일괄 전환)

### `useFusedNearestStation.ts`
- 기존 Tier 5 override block 제거 — `result` / `confidence` / `source` 덮어쓰기 영구 차단.
- `currentHopIndex` 노출 시 시간 적분 strategy(default-hop / lockless-route-hop / reanchored-hop)는 `null`로 박탈 (fire path SSOT에서 분리).
- 신규 반환 필드 `displayOnlyEstimate: { station, strategy, index } | null` — UI/DebugModal 추적용 별 채널.
- 이전 정책 박탈: #1418 Tier 5 reject gate, #1207 D2 hop window가 estimate.index를 currentHopIndex로 사용하던 흐름, #1365 lockless line guard, #1382 motion gate(시간 적분이 사라져 무의미해짐) 모두 제거 또는 회귀 가드용으로만 유지.

### `useStickyStation`
- 이미 `useNearestStation`(MapScreen 전용) 경로에만 존재. fire path(`HomeScreen` → `useFusedNearestStation` → `useStationAlarm`)와 격리되어 있어 본 PR에서 추가 변경 불필요. 회귀 가드 테스트만 유지.

### 테스트
- `useFusedNearestStation.test.ts`: #621 BoardingLock interpolation 시나리오 일괄 전환(GPS 유지 + `displayOnlyEstimate` 노출 검증), #745 ArrivalEta `runArrivalEtaSkipScenario`도 동일 전환.
- `useFusedNearestStation.tierCascade.test.ts`: #1418 Tier 5 fallback 케이스 전환.
- `useFusedNearestStation.positionGate.test.ts`: lockless-route-hop / observation ceiling / #1365 line guard / #1382 motion gate 시나리오 전환.
- **회귀 가드**: 2026-06-18 13:25:26 시나리오(`#1437 회귀 가드 — gps=성수 + lock=뚝섬 시점 시간 적분`) — fire path `source` / `confidence` / `currentHopIndex` 모두 박탈 검증, `displayOnlyEstimate`만 estimator 결과 노출 검증.

## Acceptance (이슈 본문 매핑)

| Acceptance | 본 PR 검증 |
| --- | --- |
| 조기 발사 0건 (interp/route-hop 시간 적분 source fire 없음) | `expect(source).not.toBe('boarding-lock-interp')` + `currentHopIndex === null` |
| 늦은 도착 알림 0건 (dedup 누적 차단으로 실측 신호 통과) | 시간 적분이 result에 안 들어가 dedup 비축적 — useStationAlarm 입력은 실측 신호만 |
| UI 표시(현재 위치 추적)는 정상 | `displayOnlyEstimate` 별 채널에 estimator 결과 그대로 노출, DebugModal 추적 유지 |
| 1주 실기기 또는 production 측정 검증 | epic close 조건 (본 PR 머지 후 사용자 측정) |

## 검증

- `npm run type-check` ✅
- `npx jest src/features/nearest-station/hooks/__tests__/useFusedNearestStation` — 285/285 PASS, useFusedNearestStation.ts 100% coverage
- 전체 `npm test`는 사전 broken 35건(widgetStorage/stationNotification native mock — 본 변경 무관, dev 동일) 외 PASS

## 참고

- Epic: #1432
- ADR: `docs/decisions/ADR-015-multi-signal-consensus-gate.md` §2 (별도 PR로 작성 예정)
- 메모리: `lesson_lockless_route_hop_time_integration_ssot_assumption.md`, `lesson_train_progressing_source_strategy_blindness.md`

Closes #1437