### PR TITLE
fix(#1438): backend → device lock release sync 채널 (silent push lockReleasedReason)

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -323,6 +323,35 @@ describe('sendSilentPush', () => {
     if (expectPresent) expect(body.data.occupiedLine).toBe('7');
   });
 
+  // #1438 (E5) — payload.lockReleasedReason wire 검증 (backend → device lock release sync).
+  // 지정 시 wire, 미지정은 byte-level 호환 위해 omit.
+  it.each([
+    ['transfer 지정 시 body.data.lockReleasedReason으로 전달', 'transfer' as const, true],
+    ['vanish 지정 시 body.data.lockReleasedReason으로 전달', 'vanish' as const, true],
+    ['미지정이면 body.data에서 omit (구 client/backend 호환)', undefined, false],
+  ])('lockReleasedReason %s (#1438)', async (_label, input, expectPresent) => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await sendSilentPush({
+      deviceToken: 'tok',
+      payload: {
+        nextWaypoint: '군자',
+        etaSeconds: 0,
+        phase: 'imminent',
+        kind: 'transfer',
+        sentAt: 1_700_000_000_000,
+        pushId: 'p',
+        ...(input === undefined ? {} : { lockReleasedReason: input }),
+      },
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect('lockReleasedReason' in body.data).toBe(expectPresent);
+    if (expectPresent) expect(body.data.lockReleasedReason).toBe(input);
+  });
+
   it('uses sandbox host when provided', async () => {
     const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) =>
       new Response('', { status: 200 }),

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1745,6 +1745,47 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
         expect(body.data.origin).toBe('vanish-release');
       });
 
+      // #1438 (E5) — vanish-release 경로는 floor fire 직후 lock을 release하므로 device가 즉시
+      // 로컬 store를 sync할 수 있도록 lockReleasedReason='vanish'를 forward.
+      it('#1438 (E5) vanish-release fire 페이로드에 lockReleasedReason=vanish stamp', async () => {
+        const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+        await runFallbackMotionScenario({
+          motion: 'automotive',
+          hopElapsed: false,
+          pushId: 'p1438-vanish',
+          apnsFetch,
+        });
+        const calls = apnsFetch.mock.calls as unknown as Array<[string, RequestInit]>;
+        const releaseCall = calls.find((c) => {
+          const body = JSON.parse(c[1].body as string);
+          return body.data?.pushId === 'p1438-vanish';
+        });
+        expect(releaseCall).toBeDefined();
+        const body = JSON.parse((releaseCall![1] as RequestInit).body as string);
+        expect(body.data.lockReleasedReason).toBe('vanish');
+      });
+
+      // vanish-fallback 경로(hop 시간 경과)는 caller(advanceBoardingLockWaypoint)가 별도 transfer
+      // release push를 보내므로 fallback 자체에는 lockReleasedReason을 stamp하지 않는다.
+      it('#1438 (E5) vanish-fallback origin은 lockReleasedReason omit', async () => {
+        const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+        await runFallbackMotionScenario({
+          motion: 'automotive',
+          hopElapsed: true,
+          pushId: 'p1438-fallback',
+          apnsFetch,
+        });
+        const calls = apnsFetch.mock.calls as unknown as Array<[string, RequestInit]>;
+        const fallbackCall = calls.find((c) => {
+          const body = JSON.parse(c[1].body as string);
+          return body.data?.pushId === 'p1438-fallback';
+        });
+        expect(fallbackCall).toBeDefined();
+        const body = JSON.parse((fallbackCall![1] as RequestInit).body as string);
+        expect(body.data.origin).toBe('vanish-fallback');
+        expect('lockReleasedReason' in body.data).toBe(false);
+      });
+
       it('hop 시간 미경과 + motion=stationary → release floor fire 보류 + lock release 유지', async () => {
         // #1402 — release 경로도 ADR-010 "false positive / miss 동급" 게이트를 통과해야 fire.
         // motion=stationary이면 floor fire는 보류(motion gate 증가)되지만, lock release는
@@ -1832,6 +1873,45 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
     // P2-1: progress KV도 함께 정리 — token-refresh race에서 옛 trainCode가 progressApplies=true로
     // 진입해 backend에 옛 lock이 부활하는 회귀를 차단.
     expect(await kv.get('progress:lock-tok')).toBeNull();
+  });
+
+  // #1438 (E5) — backend → device lock release sync. transfer waypoint advance 시 device로
+  // silent push에 lockReleasedReason='transfer'를 실어 보내 로컬 useBoardingLockStore가 즉시 sync.
+  it('#1438 (E5) — transfer release 시 silent push payload에 lockReleasedReason=transfer 포함', async () => {
+    const kv = new InMemoryKV();
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({
+        waypoints: [
+          { stationName: '군자', line: '7', kind: 'transfer' },
+          { stationName: '아차산', line: '5', kind: 'destination' },
+        ],
+      }),
+    );
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('군자', 0, 1)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-transfer-1438',
+    });
+    // transfer-release silent push가 발사된 APNs fetch 호출 1건 이상 존재 + payload에 reason 포함.
+    const transferReleaseCall = fetchImpl.mock.calls.find((call) => {
+      const init = call[1] as RequestInit | undefined;
+      if (!init?.body) return false;
+      try {
+        const body = JSON.parse(init.body as string);
+        return body?.data?.lockReleasedReason === 'transfer';
+      } catch {
+        return false;
+      }
+    });
+    expect(transferReleaseCall).toBeDefined();
+    const body = JSON.parse((transferReleaseCall![1] as RequestInit).body as string);
+    expect(body.data.lockReleasedReason).toBe('transfer');
+    expect(body.data.origin).toBe('transfer-release');
   });
 
   it('#864 — intermediate waypoint advance 시 boardingLock은 유지 (같은 train 계속 추적)', async () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1761,7 +1761,7 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
           return body.data?.pushId === 'p1438-vanish';
         });
         expect(releaseCall).toBeDefined();
-        const body = JSON.parse((releaseCall![1] as RequestInit).body as string);
+        const body = JSON.parse(releaseCall![1].body as string);
         expect(body.data.lockReleasedReason).toBe('vanish');
       });
 
@@ -1781,7 +1781,7 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
           return body.data?.pushId === 'p1438-fallback';
         });
         expect(fallbackCall).toBeDefined();
-        const body = JSON.parse((fallbackCall![1] as RequestInit).body as string);
+        const body = JSON.parse(fallbackCall![1].body as string);
         expect(body.data.origin).toBe('vanish-fallback');
         expect('lockReleasedReason' in body.data).toBe(false);
       });

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1727,61 +1727,45 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
         expect(stored.boardingLock).toBeUndefined();
       });
 
-      it('#1402 release floor fire 페이로드에 origin=vanish-release stamp', async () => {
+      // vanish-release/vanish-fallback 양 origin의 push payload 검증용 헬퍼.
+      // SonarCloud duplication 차단: 시나리오 실행 + 매칭 call body 추출을 한 곳에 모음.
+      async function capturePushBody(setup: {
+        hopElapsed: boolean;
+        pushId: string;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }): Promise<{ data: any }> {
         const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
         await runFallbackMotionScenario({
           motion: 'automotive',
-          hopElapsed: false,
-          pushId: 'p1402-origin',
+          hopElapsed: setup.hopElapsed,
+          pushId: setup.pushId,
           apnsFetch,
         });
         const calls = apnsFetch.mock.calls as unknown as Array<[string, RequestInit]>;
-        const releaseCall = calls.find((c) => {
+        const matchedCall = calls.find((c) => {
           const body = JSON.parse(c[1].body as string);
-          return body.data?.pushId === 'p1402-origin';
+          return body.data?.pushId === setup.pushId;
         });
-        expect(releaseCall).toBeDefined();
-        const body = JSON.parse((releaseCall![1] as RequestInit).body as string);
+        expect(matchedCall).toBeDefined();
+        return JSON.parse(matchedCall![1].body as string);
+      }
+
+      it('#1402 release floor fire 페이로드에 origin=vanish-release stamp', async () => {
+        const body = await capturePushBody({ hopElapsed: false, pushId: 'p1402-origin' });
         expect(body.data.origin).toBe('vanish-release');
       });
 
       // #1438 (E5) — vanish-release 경로는 floor fire 직후 lock을 release하므로 device가 즉시
       // 로컬 store를 sync할 수 있도록 lockReleasedReason='vanish'를 forward.
       it('#1438 (E5) vanish-release fire 페이로드에 lockReleasedReason=vanish stamp', async () => {
-        const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-        await runFallbackMotionScenario({
-          motion: 'automotive',
-          hopElapsed: false,
-          pushId: 'p1438-vanish',
-          apnsFetch,
-        });
-        const calls = apnsFetch.mock.calls as unknown as Array<[string, RequestInit]>;
-        const releaseCall = calls.find((c) => {
-          const body = JSON.parse(c[1].body as string);
-          return body.data?.pushId === 'p1438-vanish';
-        });
-        expect(releaseCall).toBeDefined();
-        const body = JSON.parse(releaseCall![1].body as string);
+        const body = await capturePushBody({ hopElapsed: false, pushId: 'p1438-vanish' });
         expect(body.data.lockReleasedReason).toBe('vanish');
       });
 
       // vanish-fallback 경로(hop 시간 경과)는 caller(advanceBoardingLockWaypoint)가 별도 transfer
       // release push를 보내므로 fallback 자체에는 lockReleasedReason을 stamp하지 않는다.
       it('#1438 (E5) vanish-fallback origin은 lockReleasedReason omit', async () => {
-        const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-        await runFallbackMotionScenario({
-          motion: 'automotive',
-          hopElapsed: true,
-          pushId: 'p1438-fallback',
-          apnsFetch,
-        });
-        const calls = apnsFetch.mock.calls as unknown as Array<[string, RequestInit]>;
-        const fallbackCall = calls.find((c) => {
-          const body = JSON.parse(c[1].body as string);
-          return body.data?.pushId === 'p1438-fallback';
-        });
-        expect(fallbackCall).toBeDefined();
-        const body = JSON.parse(fallbackCall![1].body as string);
+        const body = await capturePushBody({ hopElapsed: true, pushId: 'p1438-fallback' });
         expect(body.data.origin).toBe('vanish-fallback');
         expect('lockReleasedReason' in body.data).toBe(false);
       });

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -119,7 +119,34 @@ export interface SilentPushPayload {
    * 미전달 시 device는 `'unknown'`으로 기록한다.
    */
   origin?: PushOrigin;
+  /**
+   * #1438 (E5) — backend → device lock release sync 채널.
+   *
+   * backend가 보유한 `trip.boardingLock`을 어떤 이유로 release했는지 device에 통보한다. device는
+   * 이 값을 보고 즉시 로컬 `useBoardingLockStore.releaseLock(reason)`을 호출해 backend와 state를
+   * sync한다. 부재 시 device는 기존 동작 보존(silent push 본 처리만 수행).
+   *
+   * | value      | 발사 위치                                                                |
+   * |------------|--------------------------------------------------------------------------|
+   * | 'transfer' | 환승 waypoint 통과로 lock release (`advanceBoardingLockWaypoint`)        |
+   * | 'vanish'   | trainCode 소실 + lock release floor fire (`vanish-release` 경로)         |
+   *
+   * 다른 release 경로(arrived/expired)는 별도 trip-ended alert push가 이미 클라 state를 sync하므로
+   * 본 silent push 채널은 lock-only release(trip은 살아있음) 시나리오에만 사용한다.
+   * 구 backend 호환 위해 optional — 미전달 시 wire에서 자연 누락.
+   */
+  lockReleasedReason?: LockReleasedReason;
 }
+
+/**
+ * #1438 (E5) — backend → device lock release 사유.
+ *
+ * silent push payload `lockReleasedReason`을 통해 backend가 device에 lock release를 알린다.
+ * device는 이 신호로 즉시 로컬 store를 sync해 환승 직후 leg 2 boardingPrompt 재요청을 트리거한다.
+ *
+ * arrived/expired는 별도 trip-ended alert push 경로가 처리 — 본 enum은 lock-only release 한정.
+ */
+export type LockReleasedReason = 'transfer' | 'vanish';
 
 /**
  * #1402 — silent push 발사 경로(origin) 식별자.
@@ -139,6 +166,7 @@ export type PushOrigin =
   | 'arvlcd'
   | 'vanish-fallback'
   | 'vanish-release'
+  | 'transfer-release'
   | 'lockless'
   | 'reschedule'
   | 'alert-fallback';
@@ -216,6 +244,11 @@ export async function sendSilentPush(options: SendPushOptions): Promise<SendPush
       // #1402 — origin은 정의된 경우에만 wire (좀비 알림 RCA). 구 backend 호환을 위해 optional —
       // 미전달 시 JSON에서 자연 누락, device는 `'unknown'`으로 분류.
       ...(options.payload.origin === undefined ? {} : { origin: options.payload.origin }),
+      // #1438 (E5) — lockReleasedReason은 정의된 경우에만 wire. 미전달 시 JSON에서 자연 누락 →
+      // 구 device(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환.
+      ...(options.payload.lockReleasedReason === undefined
+        ? {}
+        : { lockReleasedReason: options.payload.lockReleasedReason }),
     },
   });
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -757,11 +757,18 @@ interface BuildStationPassedImminentPayloadInputs {
    * vanish lock release 직전 floor = 'vanish-release'.
    */
   origin: PushOrigin;
+  /**
+   * #1438 (E5) — backend → device lock release sync 채널. 이 push 발사와 동시에 backend가
+   * `trip.boardingLock`을 release한 경우 reason을 forward해 device가 즉시 store sync 가능.
+   * floor fire(vanish-release)에서만 'vanish'로 전달 — 다른 경로(arvlcd, vanish-fallback)는
+   * lock을 release하지 않으므로 undefined.
+   */
+  lockReleasedReason?: 'transfer' | 'vanish';
 }
 function buildStationPassedImminentPayload(
   inputs: BuildStationPassedImminentPayloadInputs,
 ): Parameters<typeof sendSilentPush>[0]['payload'] {
-  const { trip, waypoint, lock, pushId, now, origin } = inputs;
+  const { trip, waypoint, lock, pushId, now, origin, lockReleasedReason } = inputs;
   return {
     nextWaypoint: waypoint.stationName,
     // arvlCd∈{0,1}은 "지금 진입/도착" 신호 — eta는 사실상 0. vanish-fallback도 동일 의미.
@@ -790,6 +797,8 @@ function buildStationPassedImminentPayload(
     tripToken: trip.token,
     // #1402 — 발사 경로 stamp. device alarmLog와 backend tail이 같은 값으로 1:1 매핑.
     origin,
+    // #1438 (E5) — lock release sync. 정의된 경우에만 wire (apns.ts JSON serializer가 undefined 누락).
+    lockReleasedReason,
   };
 }
 
@@ -1005,11 +1014,23 @@ export async function fireVanishFallbackStationPush(
     kind: waypoint.kind,
     origin,
   });
+  // #1438 (E5) — vanish-release origin은 직후 caller가 `trip.boardingLock = undefined`로 lock을
+  // release하므로 device에 `lockReleasedReason='vanish'`를 forward해 store sync. vanish-fallback은
+  // 직후 `advanceBoardingLockWaypoint`로 흘러가 그 함수가 transfer 시 별도로 release를 통지한다.
+  const lockReleasedReason: 'vanish' | undefined = origin === 'vanish-release' ? 'vanish' : undefined;
   const heal = await sendWithEnvHeal(
     (host) =>
       sendSilentPush({
         deviceToken: trip.token,
-        payload: buildStationPassedImminentPayload({ trip, waypoint, lock, pushId, now, origin }),
+        payload: buildStationPassedImminentPayload({
+          trip,
+          waypoint,
+          lock,
+          pushId,
+          now,
+          origin,
+          lockReleasedReason,
+        }),
         config: deps.apnsConfig,
         host,
         fetchImpl: deps.fetchImpl,
@@ -1465,10 +1486,46 @@ export async function advanceBoardingLockWaypoint(
   // (`useApnsTripRegistration` `latestInputsRef` 옛 lock 보유) 윈도우에서 client 옛 lock POST 시
   // `progressApplies=true` 분기로 진입해 옛 lock이 backend에 다시 active로 복원되는 회귀가 가능.
   const lockReleasedOnTransfer = waypoint.kind === 'transfer' && trip.boardingLock !== undefined;
+  // #1438 (E5) — release 직전 lock 스냅샷. 직후 fire에서 buildStationPassedImminentPayload가
+  // line/trainCode self-describing 필드(boardingLine/trainCode)를 채우는 데 사용한다.
+  const releasedLockSnapshot = lockReleasedOnTransfer ? trip.boardingLock : undefined;
   if (lockReleasedOnTransfer) {
     trip.boardingLock = undefined;
     trip.consecutiveEtaMissing = 0;
     await deleteProgress(env.TRIPS, trip.token);
+  }
+  // #1438 (E5) — backend → device lock release sync. 환승 waypoint 통과로 backend가 lock을
+  // release한 즉시 device에 silent push로 통보해 로컬 useBoardingLockStore와 sync한다. 종전에는
+  // device가 backend release를 인지하지 못해 leg 1 lock이 21분간 잔존하다 자연 만료에 의존했고,
+  // 그 시간 동안 leg 2 boardingPrompt 발사가 차단됐다 (2026-06-18 evidence). 본 push는 station-passed
+  // 알림 본문(arvlCd/vanish path와 같은 payload 모양)이 아니라 lock-only sync 신호 — etaSeconds=0,
+  // phase='imminent', kind=waypoint.kind. device의 fireWithGate는 station-passed 동등 처리를 하지만,
+  // payload.lockReleasedReason='transfer'가 우선 처리돼 store sync 후 본 처리 흐름을 그대로 진행한다.
+  if (lockReleasedOnTransfer && releasedLockSnapshot !== undefined) {
+    const pushId = crypto.randomUUID();
+    await sendWithEnvHeal(
+      (host) =>
+        sendSilentPush({
+          deviceToken: trip.token,
+          payload: buildStationPassedImminentPayload({
+            trip,
+            waypoint,
+            lock: releasedLockSnapshot,
+            pushId,
+            now,
+            origin: 'transfer-release',
+            lockReleasedReason: 'transfer',
+          }),
+          config: deps.apnsConfig,
+          host,
+          fetchImpl: deps.fetchImpl,
+          now,
+        }),
+      trip.apnsEnv,
+      deps.apnsHosts,
+      log,
+      trip.token.slice(0, 8),
+    );
   }
   // #902 Seam F — 환승 직후 자동 trainCode swap. release한 lock 자리에 새 노선의 후보를
   // 동일 cycle 안에 부착해 다음 cycle의 lockMissing/boarding-prompt 우회 + 즉시 trainCode 추적.

--- a/src/features/alarm/store/__tests__/useBoardingLockStore.test.ts
+++ b/src/features/alarm/store/__tests__/useBoardingLockStore.test.ts
@@ -84,7 +84,7 @@ describe('useBoardingLockStore', () => {
       expect(mockClearBoardingLock).toHaveBeenCalled();
     });
 
-    it('release breadcrumb는 직전 lock이 있을 때만 추가', async () => {
+    it('release breadcrumb는 직전 lock이 있을 때만 추가 (default reason=user)', async () => {
       useBoardingLockStore.setState({ lock: sample });
       await act(async () => {
         await useBoardingLockStore.getState().releaseLock();
@@ -92,6 +92,7 @@ describe('useBoardingLockStore', () => {
       expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('boarding', 'lock-release', {
         trainCode: sample.trainCode,
         line: sample.boardingLine,
+        reason: 'user',
       });
     });
 
@@ -100,6 +101,30 @@ describe('useBoardingLockStore', () => {
         await useBoardingLockStore.getState().releaseLock();
       });
       expect(mockAddDomainBreadcrumb).not.toHaveBeenCalled();
+    });
+
+    it('#1438 (E5) — reason 인자가 breadcrumb 메타에 stamp된다 (transfer)', async () => {
+      useBoardingLockStore.setState({ lock: sample });
+      await act(async () => {
+        await useBoardingLockStore.getState().releaseLock('transfer');
+      });
+      expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('boarding', 'lock-release', {
+        trainCode: sample.trainCode,
+        line: sample.boardingLine,
+        reason: 'transfer',
+      });
+    });
+
+    it('#1438 (E5) — reason=vanish도 breadcrumb에 forward', async () => {
+      useBoardingLockStore.setState({ lock: sample });
+      await act(async () => {
+        await useBoardingLockStore.getState().releaseLock('vanish');
+      });
+      expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('boarding', 'lock-release', {
+        trainCode: sample.trainCode,
+        line: sample.boardingLine,
+        reason: 'vanish',
+      });
     });
   });
 

--- a/src/features/alarm/store/useBoardingLockStore.ts
+++ b/src/features/alarm/store/useBoardingLockStore.ts
@@ -10,6 +10,22 @@ import { clearDismissSilence } from '../utils/dismissSilenceStorage';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
 
 /**
+ * #1438 (E5) — release 사유 식별자.
+ *
+ * - 'user'            — 사용자가 "하차" 직접 탭 (default).
+ * - 'transfer'        — backend silent push로 환승 release 통보.
+ * - 'vanish'          — backend silent push로 trainCode 소실 release 통보.
+ * - 'destination-change' — 화면에서 destination이 바뀌어 stale lock 자동 release (controller).
+ * - 'expired'         — 자동 만료(`checkExpiry`).
+ */
+export type LockReleaseReason =
+  | 'user'
+  | 'transfer'
+  | 'vanish'
+  | 'destination-change'
+  | 'expired';
+
+/**
  * BoardingLock 전역 store (#584 PR A).
  *
  * Single Lock only — trip 1개에 leg 1개. multi-transfer는 createLock으로 교체(PR E).
@@ -20,8 +36,14 @@ export interface BoardingLockState {
   lock: BoardingLock | null;
   /** Trip 진입 또는 환승 전환 시 호출. 기존 Lock은 자동 교체. */
   createLock: (lock: BoardingLock) => Promise<void>;
-  /** 사용자가 "하차" 탭하거나 trip 종료 시 호출. */
-  releaseLock: () => Promise<void>;
+  /**
+   * 사용자가 "하차" 탭하거나 trip 종료 시 호출.
+   *
+   * #1438 (E5) — silent push payload `lockReleasedReason`으로 backend가 lock release를 알릴 때도
+   * 같은 진입점으로 호출. reason은 breadcrumb 메타에만 stamp되며 멱등 — lock=null에서 호출돼도
+   * graceful no-op.
+   */
+  releaseLock: (reason?: LockReleaseReason) => Promise<void>;
   /** 앱 마운트 시 storage에서 복원. */
   loadLock: () => Promise<void>;
   /**
@@ -46,7 +68,7 @@ export const useBoardingLockStore = create<BoardingLockState>((set, get) => ({
     });
   },
 
-  releaseLock: async () => {
+  releaseLock: async (reason: LockReleaseReason = 'user') => {
     const prev = get().lock;
     set({ lock: null });
     await clearBoardingLock();
@@ -54,6 +76,7 @@ export const useBoardingLockStore = create<BoardingLockState>((set, get) => ({
       addDomainBreadcrumb('boarding', 'lock-release', {
         trainCode: prev.trainCode,
         line: prev.boardingLine,
+        reason,
       });
     }
   },

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -124,6 +124,15 @@ jest.mock('../../utils/boardingLockStorage', () => ({
   getBoardingLock: (...args: unknown[]) => mockGetBoardingLock(...args),
 }));
 
+// #1438 (E5) — backend → device lock release sync. handleSilentPush가 payload.lockReleasedReason을
+// 보고 호출하는 store action만 mock으로 가로채 호출 여부/인자 검증.
+const mockStoreReleaseLock = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../store/useBoardingLockStore', () => ({
+  useBoardingLockStore: {
+    getState: () => ({ releaseLock: mockStoreReleaseLock }),
+  },
+}));
+
 // #698 — reschedule silent push 분기에서 호출. mock으로 호출 인자/횟수만 검증.
 const mockRescheduleHopForLock = jest.fn();
 // #1356 E1 — suppress 분기에서 같은 station+phase의 bl: 사전 예약을 cancel.
@@ -577,6 +586,61 @@ describe('silentPushTask', () => {
       });
     });
 
+    // #1438 (E5) — backend → device lock release sync 채널.
+    describe('lockReleasedReason (#1438)', () => {
+      it("'transfer' 그대로 통과", () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              nextWaypoint: 'A',
+              etaSeconds: 0,
+              phase: 'imminent',
+              lockReleasedReason: 'transfer',
+            }),
+          ),
+        ).toMatchObject({ lockReleasedReason: 'transfer' });
+      });
+
+      it("'vanish' 그대로 통과", () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              nextWaypoint: 'A',
+              etaSeconds: 0,
+              phase: 'imminent',
+              lockReleasedReason: 'vanish',
+            }),
+          ),
+        ).toMatchObject({ lockReleasedReason: 'vanish' });
+      });
+
+      it('누락/unknown 문자열/비string이면 undefined (구 backend 호환)', () => {
+        expect(
+          extractPayload(bgTaskData({ nextWaypoint: 'A', etaSeconds: 0, phase: 'imminent' })),
+        ).toMatchObject({ lockReleasedReason: undefined });
+        expect(
+          extractPayload(
+            bgTaskData({
+              nextWaypoint: 'A',
+              etaSeconds: 0,
+              phase: 'imminent',
+              lockReleasedReason: 'arrived',
+            }),
+          ),
+        ).toMatchObject({ lockReleasedReason: undefined });
+        expect(
+          extractPayload(
+            bgTaskData({
+              nextWaypoint: 'A',
+              etaSeconds: 0,
+              phase: 'imminent',
+              lockReleasedReason: 1,
+            }),
+          ),
+        ).toMatchObject({ lockReleasedReason: undefined });
+      });
+    });
+
     // #725 — reschedule schema는 standard와 다르므로 별도 분기 검증.
     describe('reschedule kind (#725)', () => {
       it('정상 reschedule payload → RescheduleSilentPushPayload', () => {
@@ -813,6 +877,51 @@ describe('silentPushTask', () => {
       const arg = mockLogSilentPushReceived.mock.calls[0][0];
       expect(arg.sentAt).toBe(1_700_000_000_000);
       expect(typeof arg.receivedAt).toBe('number');
+    });
+
+    // #1438 (E5) — backend → device lock release sync 채널 통합.
+    describe('lockReleasedReason → store sync (#1438)', () => {
+      it("'transfer' payload면 useBoardingLockStore.releaseLock('transfer') 호출", async () => {
+        await handleSilentPush(
+          payload({
+            kind: 'transfer',
+            phase: 'imminent',
+            lockReleasedReason: 'transfer',
+            sentAt: 1_700_000_000_000,
+          }),
+        );
+        expect(mockStoreReleaseLock).toHaveBeenCalledWith('transfer');
+      });
+
+      it("'vanish' payload면 useBoardingLockStore.releaseLock('vanish') 호출", async () => {
+        await handleSilentPush(
+          payload({
+            kind: 'intermediate',
+            phase: 'imminent',
+            lockReleasedReason: 'vanish',
+            nextWaypoint: '중곡',
+          }),
+        );
+        expect(mockStoreReleaseLock).toHaveBeenCalledWith('vanish');
+      });
+
+      it('lockReleasedReason 누락이면 releaseLock 호출 없음 (구 backend 호환)', async () => {
+        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+        expect(mockStoreReleaseLock).not.toHaveBeenCalled();
+      });
+
+      it('releaseLock throw해도 본 처리 흐름은 계속 진행 (graceful)', async () => {
+        mockStoreReleaseLock.mockRejectedValueOnce(new Error('store-fail'));
+        await handleSilentPush(
+          payload({
+            kind: 'destination',
+            phase: 'imminent',
+            lockReleasedReason: 'transfer',
+          }),
+        );
+        // gate 평가까지 도달 = 본 처리 흐름 차단되지 않음.
+        expect(mockCheckGate).toHaveBeenCalled();
+      });
     });
 
     it('kind 미상(구 백엔드)이면 received 적재 후 skip 적재 + 발사 안 함', async () => {

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -75,6 +75,7 @@ import { refreshLiveActivityFromBackgroundContext } from '../utils/refreshLiveAc
 import { type NotificationSource } from '../utils/notificationSource';
 import { getFiredAlarms, setFiredAlarms } from '../utils/notificationState';
 import { getBoardingLock } from '../utils/boardingLockStorage';
+import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import { getSubsurfaceState } from '../../../shared/utils/subsurfaceState';
 import { findStationByName, findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
@@ -142,6 +143,14 @@ export interface SilentPushPayload {
    * 구 backend 호환 위해 optional — 누락 시 가드 자연 skip(기존 동작 보존).
    */
   tripToken?: string;
+  /**
+   * #1438 (E5) — backend → device lock release sync 채널. backend `apns.ts` `LockReleasedReason`과 1:1.
+   * 'transfer' = 환승 waypoint 통과로 backend가 lock release.
+   * 'vanish'   = trainCode 소실로 backend가 lock release floor fire 후 release.
+   * 디바이스는 본 신호를 받으면 즉시 `useBoardingLockStore.releaseLock()` 호출해 backend와 sync.
+   * 구 backend 호환 위해 optional — 누락 시 sync 자연 skip(기존 동작 보존).
+   */
+  lockReleasedReason?: 'transfer' | 'vanish';
 }
 
 /**
@@ -341,6 +350,7 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
     boardingLine,
     occupiedLine,
     tripToken,
+    lockReleasedReason,
   } = obj as {
     nextWaypoint: string;
   } & Record<string, unknown>;
@@ -360,7 +370,16 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
     boardingLine: validBoardingLine(boardingLine),
     occupiedLine: validBoardingLine(occupiedLine),
     tripToken: validTripToken(tripToken),
+    lockReleasedReason: validLockReleasedReason(lockReleasedReason),
   };
+}
+
+/**
+ * #1438 (E5) — payload.lockReleasedReason 검증. 'transfer'|'vanish' 만 통과.
+ * 그 외(누락/형식 오류/unknown 문자열)는 undefined로 정규화 → store sync 자연 skip (구 backend 호환).
+ */
+function validLockReleasedReason(value: unknown): 'transfer' | 'vanish' | undefined {
+  return value === 'transfer' || value === 'vanish' ? value : undefined;
 }
 
 /**
@@ -741,6 +760,21 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
       sentAt: payload.sentAt,
       receivedAt,
     });
+
+    // #1438 (E5) — backend → device lock release sync. payload.lockReleasedReason이 있으면
+    // backend가 trip.boardingLock을 release했다는 신호 → 로컬 store도 같이 release한다. fire/skip
+    // 분기와 독립적으로 state sync만 수행. 'transfer' 시 다음 leg boardingPrompt 재요청을 유도하고,
+    // 'vanish'는 lockless 인계로 자연 fallback. store releaseLock은 멱등 — lock 없을 때 graceful.
+    if (payload.lockReleasedReason !== undefined) {
+      try {
+        await useBoardingLockStore.getState().releaseLock(payload.lockReleasedReason);
+        logger.info(
+          `lock-release sync: reason=${payload.lockReleasedReason} station=${payload.nextWaypoint}`,
+        );
+      } catch (e) {
+        logger.error('lock-release sync 실패:', e);
+      }
+    }
 
     // kind 미상은 발사 불가 — 알림 본문/dedup 키 결정 불가. 구 백엔드 호환은 received 로그에만.
     if (!payload.kind) {


### PR DESCRIPTION
## Summary (E5 / Epic #1432)

backend가 `trip.boardingLock`을 release한 즉시 device로 silent push payload `lockReleasedReason`을 forward해 로컬 `useBoardingLockStore`를 sync한다. 종전에는 device가 backend의 release를 인지하지 못해 leg 1 lock이 21분간 잔존했고(2026-06-18 evidence), 그 시간 동안 leg 2 boardingPrompt 발사가 차단됐다.

### Backend 변경

- `apns.ts`: `SilentPushPayload.lockReleasedReason?: 'transfer' | 'vanish'` 추가 + JSON serializer wire (구 device 호환: undefined → JSON에서 자연 누락)
- `apns.ts`: `PushOrigin`에 `'transfer-release'` 추가 (RCA stamp용)
- `scheduled.ts`: `buildStationPassedImminentPayload`에 optional `lockReleasedReason` 인자
- `scheduled.ts` `advanceBoardingLockWaypoint`: transfer waypoint 통과로 `lockReleasedOnTransfer=true`인 즉시 dedicated silent push 발사 (origin='transfer-release', reason='transfer'). swap 시도 전 release 스냅샷으로 self-describing payload 구성
- `scheduled.ts` vanish-release fire (`runEtaMissing` 1219 라인 인근): `lockReleasedReason='vanish'` forward. vanish-fallback(hop 시간 경과 → advance로 흐르는 경로)은 후속 advance가 transfer 시 별도 release push를 보내므로 omit

### Device 변경

- `silentPushTask.ts`: `SilentPushPayload`에 `lockReleasedReason` 필드 + extractor + `validLockReleasedReason` 검증 (unknown/누락 → undefined). `handleSilentPush`가 received 적재 후 본 처리 흐름 진입 전에 `useBoardingLockStore.getState().releaseLock(reason)` 호출 (fire/skip 분기와 독립, throw graceful)
- `useBoardingLockStore.ts`: `releaseLock(reason?: LockReleaseReason)` 시그니처 확장 + 멱등 (default 'user'). breadcrumb 메타에 reason stamp

### 테스트

- `useBoardingLockStore.test.ts`: default reason='user' + 'transfer'/'vanish' breadcrumb forward 검증
- `silentPushTask.test.ts`: extractor 분기 3개(transfer/vanish/누락) + `handleSilentPush` 통합 4개(transfer/vanish 호출, 누락 시 skip, throw graceful)
- `apns.test.ts`: it.each로 transfer/vanish/미지정 3 case wire 검증
- `scheduled.test.ts`: transfer-release fire payload + vanish-release reason + vanish-fallback omit 3 cases

변경 파일 coverage 100% (`useBoardingLockStore.ts`, `silentPushTask.ts`).

## Test plan

- [x] device unit: 243 tests pass — `useBoardingLockStore`, `silentPushTask` 100% coverage
- [x] backend unit: 265 tests pass (`apns.test.ts` 45, `scheduled.test.ts` 220)
- [x] device type-check
- [ ] 실기기: 환승 trip 진행 → 환승 waypoint 통과 시점에 leg 1 lock이 즉시 release 되는지 (21분 잔존 회귀 없음) + leg 2 boardingPrompt 즉시 재요청
- [ ] 실기기: trainCode vanish 후 lock release 경로에서도 device store sync (lockless 인계 자연 fallback)
- [ ] APNs payload schema 변경 호환성 — 구 device(payload 미인식) 회귀 0건 (graceful degradation)

Closes #1438