### PR TITLE
feat(#1447): DebugModal displayOnlyEstimate strategy 라벨 wire-up + null fallback (E4 후속)

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -112,6 +112,20 @@ export interface TripDebugState {
   currentHopIndex: number | null | undefined;
   /** 경로 arcStations 총 개수. */
   routeHopCount: number | null;
+  /**
+   * #1447 — `displayOnlyEstimate`의 채택 strategy 라벨. UI/Share dump 추적 SSOT.
+   *
+   * PR #1445(E4 / #1437)에서 estimator 시간 적분 결과의 fire 권한을 박탈하고 결과를
+   * `useFusedNearestStation.displayOnlyEstimate` 별 채널로 격리했다. 본 필드는 그 strategy를
+   * DebugModal Trip 섹션과 Share dump에 노출하기 위한 wire-up — strategy 산출 시 strategy 이름,
+   * displayOnlyEstimate=null이면 fallback 라벨로 항상 표시한다.
+   *
+   * "신호 없음(estimator null)"과 "표시 wire-up 자체 누락"이 dump만 보고 구분 가능해야
+   * 사용자 trip 사후 재구성이 가능하다 — strategy가 비어 있어도 항상 row를 노출하는 이유.
+   */
+  displayOnlyEstimateStrategy:
+    | import('../../route/utils/stationProgressEstimator').StationProgressStrategy
+    | null;
 }
 
 export interface SleepDebugState {
@@ -542,12 +556,33 @@ function buildFusionSection(args: BuildDumpArgs): string[] {
   return lines;
 }
 
+/**
+ * #1447 — `displayOnlyEstimate`가 null일 때 노출하는 fallback 라벨.
+ * "estimator 결과 자체 없음" 상태를 명시한다(표시 wire-up 누락과 구분).
+ */
+const DISPLAY_ONLY_ESTIMATE_NONE_LABEL = '(none)';
+
+/**
+ * #1447 — Trip 섹션 displayOnlyEstimate row 값 산출.
+ * trip 미전달/strategy=null → fallback. 모든 strategy(5종)는 그대로 노출.
+ */
+function formatDisplayOnlyEstimateStrategy(
+  strategy:
+    | import('../../route/utils/stationProgressEstimator').StationProgressStrategy
+    | null
+    | undefined,
+): string {
+  return strategy == null ? DISPLAY_ONLY_ESTIMATE_NONE_LABEL : strategy;
+}
+
 function buildTripSection(args: BuildDumpArgs): string[] {
   return [
     `lockless=${formatOptionalBool(args.trip?.lockless)}`,
     `tripStartedAt=${formatOptionalTs(args.trip?.tripStartedAt ?? null)}`,
     `currentHopIndex=${formatOptionalNumber(args.trip?.currentHopIndex)}`,
     `route hop count=${formatOptionalNumber(args.trip?.routeHopCount ?? null)}`,
+    // #1447 — displayOnlyEstimate.strategy 라벨. null 케이스도 fallback으로 항상 노출.
+    `displayOnlyEstimate=${formatDisplayOnlyEstimateStrategy(args.trip?.displayOnlyEstimateStrategy)}`,
   ];
 }
 
@@ -1077,6 +1112,9 @@ function DebugModalInner({
     // #1421 — PR-AutoLock-1 측정 인프라. SSOT 객체 직접 받아 inferAutoLockCandidate에 전달.
     surfaceSSOT,
     undergroundSSOT,
+    // #1447 — E4(#1437) 격리 후 노출된 별 채널. strategy 라벨을 Trip 섹션 + Share dump에 wire-up.
+    // null이면 fallback 라벨로 항상 표시(estimator 미산출 상태 명시).
+    displayOnlyEstimate,
   } = useFusedNearestStation();
   // arc 길이 = trip의 hop 총 수. trip 미설정이면 0.
   const routeHopCount = arcStations.length;
@@ -1137,8 +1175,18 @@ function DebugModalInner({
         currentHopIndex,
         // destination 있어야 routeHopCount 표기 의미. 없으면 null → '—' 표기.
         routeHopCount: destination ? routeHopCount : null,
+        // #1447 — displayOnlyEstimate가 없으면 null 전달 → UI/dump가 fallback 라벨 표시.
+        displayOnlyEstimateStrategy: displayOnlyEstimate?.strategy ?? null,
       },
-    [tripProp, locklessTrip, tripStartedAt, currentHopIndex, routeHopCount, destination],
+    [
+      tripProp,
+      locklessTrip,
+      tripStartedAt,
+      currentHopIndex,
+      routeHopCount,
+      destination,
+      displayOnlyEstimate,
+    ],
   );
   const sleep: SleepDebugState = useMemo(
     () =>
@@ -1444,6 +1492,13 @@ function DebugModalInner({
               label="route hop count"
               value={formatOptionalNumber(trip?.routeHopCount ?? null)}
               colors={colors}
+            />
+            {/* #1447 — displayOnlyEstimate.strategy 라벨. null이면 fallback "(none)"으로 항상 표시. */}
+            <KeyValue
+              label="displayOnlyEstimate"
+              value={formatDisplayOnlyEstimateStrategy(trip?.displayOnlyEstimateStrategy)}
+              colors={colors}
+              testID="debug-modal-display-only-estimate"
             />
           </Section>
 
@@ -1842,15 +1897,22 @@ function KeyValue({
   label,
   value,
   colors,
+  testID,
 }: {
   label: string;
   value: string;
   colors: ReturnType<typeof useTheme>['colors'];
+  /** #1447 — 특정 row를 테스트에서 식별할 때 optional testID. 미전달 시 무영향. */
+  testID?: string;
 }) {
   return (
     <View style={styles.kvRow}>
       <Text style={[typography.mono, { color: colors.subtle, width: 80 }]}>{label}</Text>
-      <Text style={[typography.mono, { color: colors.ink, flex: 1 }]} selectable>
+      <Text
+        style={[typography.mono, { color: colors.ink, flex: 1 }]}
+        selectable
+        testID={testID}
+      >
         {value}
       </Text>
     </View>

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -104,6 +104,8 @@ const fusedReturnFixture = (overrides: Record<string, unknown> = {}) => ({
   // #1421 — PR-AutoLock-1 측정 인프라 신규 노출 필드 기본값.
   surfaceSSOT: null,
   undergroundSSOT: null,
+  // #1447 — E4(#1437) 격리 후 별 채널. 기본값은 null(estimator 미산출).
+  displayOnlyEstimate: null,
   ...overrides,
 });
 const arrivalDefaults = {
@@ -146,6 +148,8 @@ const setupHookDefaults = () => {
     // #1421 — PR-AutoLock-1 측정 인프라.
     surfaceSSOT: null,
     undergroundSSOT: null,
+    // #1447 — E4(#1437) 격리 후 별 채널. 기본 setupHook은 estimator 미산출(null).
+    displayOnlyEstimate: null,
   });
   mockUseArrivalInfo.mockReturnValue({ arrival: baseArrival, loading: false, isMock: false });
   mockUseSilentPushDiagnostics.mockReturnValue({
@@ -1023,6 +1027,7 @@ describe('DebugModal buildDumpText — D9 sections (#1215)', () => {
           tripStartedAt,
           currentHopIndex: 2,
           routeHopCount: 7,
+          displayOnlyEstimateStrategy: null,
         },
         sleep: { sleepMode: true, firstHopApproaching: false },
       }),
@@ -1046,6 +1051,7 @@ describe('DebugModal buildDumpText — D9 sections (#1215)', () => {
           tripStartedAt: null,
           currentHopIndex: null,
           routeHopCount: 5,
+          displayOnlyEstimateStrategy: null,
         },
         sleep: { sleepMode: false, firstHopApproaching: false },
       }),
@@ -1054,6 +1060,53 @@ describe('DebugModal buildDumpText — D9 sections (#1215)', () => {
     expect(dump).toContain('currentHopIndex=—');
     expect(dump).toContain('route hop count=5');
     expect(dump).toContain('sleepMode=off');
+  });
+
+  // #1447 — displayOnlyEstimate strategy 라벨 wire-up + fallback.
+  // 5종 strategy + null + trip 미전달 케이스가 모두 항상 노출되는지(라벨 누락 0건).
+  describe('#1447 — displayOnlyEstimate strategy 라벨 wire-up + fallback', () => {
+    const strategies = [
+      'live-position',
+      'arrival-eta',
+      'reanchored-hop',
+      'default-hop',
+      'lockless-route-hop',
+    ] as const;
+
+    it.each(strategies)('strategy=%s → dump에 그대로 노출', (strategy) => {
+      const dump = __test__.buildDumpText(
+        makeDumpArgs({
+          trip: {
+            lockless: true,
+            tripStartedAt: null,
+            currentHopIndex: 1,
+            routeHopCount: 5,
+            displayOnlyEstimateStrategy: strategy,
+          },
+        }),
+      );
+      expect(dump).toContain(`displayOnlyEstimate=${strategy}`);
+    });
+
+    it('displayOnlyEstimateStrategy=null → "(none)" fallback 노출', () => {
+      const dump = __test__.buildDumpText(
+        makeDumpArgs({
+          trip: {
+            lockless: false,
+            tripStartedAt: null,
+            currentHopIndex: null,
+            routeHopCount: null,
+            displayOnlyEstimateStrategy: null,
+          },
+        }),
+      );
+      expect(dump).toContain('displayOnlyEstimate=(none)');
+    });
+
+    it('trip 자체 미전달 → "(none)" fallback 노출 (라벨 항상 표시)', () => {
+      const dump = __test__.buildDumpText(makeDumpArgs());
+      expect(dump).toContain('displayOnlyEstimate=(none)');
+    });
   });
 
   describe('#1398 — 기압계 unavailable 원인 분해 dump', () => {
@@ -1198,6 +1251,7 @@ describe('DebugModal — D9 UI sections (#1215)', () => {
           tripStartedAt,
           currentHopIndex: 3,
           routeHopCount: 8,
+          displayOnlyEstimateStrategy: null,
         }}
       />,
     );
@@ -1211,6 +1265,76 @@ describe('DebugModal — D9 UI sections (#1215)', () => {
     expect(screen.getByText('8')).toBeTruthy();
   });
 
+  // #1447 — Trip 섹션에 displayOnlyEstimate row가 항상 노출돼야 한다(라벨/값 wire-up).
+  // 5종 strategy + null fallback 둘 다 UI에 나오는지 확인.
+  it.each([
+    ['live-position'],
+    ['arrival-eta'],
+    ['reanchored-hop'],
+    ['default-hop'],
+    ['lockless-route-hop'],
+  ] as const)(
+    'Trip 섹션 displayOnlyEstimate row: strategy=%s → 값 노출',
+    async (strategy) => {
+      renderWithTheme(
+        <DebugModal
+          onClose={jest.fn()}
+          trip={{
+            lockless: true,
+            tripStartedAt: null,
+            currentHopIndex: 0,
+            routeHopCount: 5,
+            displayOnlyEstimateStrategy: strategy,
+          }}
+        />,
+      );
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      expect(screen.getByText('displayOnlyEstimate')).toBeTruthy();
+      expect(screen.getByTestId('debug-modal-display-only-estimate').props.children).toBe(strategy);
+    },
+  );
+
+  it('Trip 섹션 displayOnlyEstimate row: null → "(none)" fallback 노출', async () => {
+    renderWithTheme(
+      <DebugModal
+        onClose={jest.fn()}
+        trip={{
+          lockless: false,
+          tripStartedAt: null,
+          currentHopIndex: null,
+          routeHopCount: null,
+          displayOnlyEstimateStrategy: null,
+        }}
+      />,
+    );
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByTestId('debug-modal-display-only-estimate').props.children).toBe('(none)');
+  });
+
+  it('Trip 섹션 displayOnlyEstimate row: trip prop 미전달 → hook displayOnlyEstimate=null SSOT 도출 → "(none)"', async () => {
+    // setupHookDefaults가 displayOnlyEstimate=null 주입 → fallback이 노출돼야 한다.
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByTestId('debug-modal-display-only-estimate').props.children).toBe('(none)');
+  });
+
+  it('Trip 섹션 displayOnlyEstimate row: hook displayOnlyEstimate.strategy SSOT 도출 → 라벨 노출', async () => {
+    mockUseFusedNearestStation.mockReturnValue(
+      fusedReturnFixture({
+        displayOnlyEstimate: {
+          station: { id: '2-001', name: '강남', line: '2', lineColor: '#009D3E', lat: 37.5, lng: 127 },
+          strategy: 'lockless-route-hop',
+          index: 2,
+        },
+      }),
+    );
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByTestId('debug-modal-display-only-estimate').props.children).toBe(
+      'lockless-route-hop',
+    );
+  });
+
   it('Trip 섹션: currentHopIndex undefined(D1 미머지) → —', async () => {
     renderWithTheme(
       <DebugModal
@@ -1220,6 +1344,7 @@ describe('DebugModal — D9 UI sections (#1215)', () => {
           tripStartedAt: null,
           currentHopIndex: undefined,
           routeHopCount: null,
+          displayOnlyEstimateStrategy: null,
         }}
       />,
     );
@@ -1254,7 +1379,13 @@ describe('DebugModal — D9 UI sections (#1215)', () => {
       <DebugModal
         onClose={jest.fn()}
         fusionDetection={{ tier: 'high', signalMask: 'TTT' }}
-        trip={{ lockless: true, tripStartedAt: null, currentHopIndex: 1, routeHopCount: 4 }}
+        trip={{
+          lockless: true,
+          tripStartedAt: null,
+          currentHopIndex: 1,
+          routeHopCount: 4,
+          displayOnlyEstimateStrategy: 'lockless-route-hop',
+        }}
         sleep={{ sleepMode: true, firstHopApproaching: true }}
       />,
     );
@@ -1270,6 +1401,8 @@ describe('DebugModal — D9 UI sections (#1215)', () => {
     expect(message).toContain('route hop count=4');
     expect(message).toContain('sleepMode=on');
     expect(message).toContain('firstHopApproaching=true');
+    // #1447 — displayOnlyEstimate strategy 라벨이 Share dump에 포함돼야 한다.
+    expect(message).toContain('displayOnlyEstimate=lockless-route-hop');
     shareSpy.mockRestore();
   });
 


### PR DESCRIPTION
Closes #1447

## 배경

PR #1445 (E4 / #1437) 에서 estimator 시간 적분 strategy(`default-hop` / `lockless-route-hop` / `reanchored-hop`)의 fire 권한을 박탈하고 결과를 별 채널 `displayOnlyEstimate`로 격리했다 (ADR-015 §2). 그러나 격리만 됐을 뿐 **production consumer 0건** — DebugModal Trip 섹션에 strategy 라벨이 노출되지 않아 사용자 trip 분석 시 추적 불가.

사용자 강조:
> "작어하고 안나오는 경우도 있으니까 연결해서 나오게 만들어야해"

→ strategy 산출 시 strategy 이름, displayOnlyEstimate=null 시 명시적 fallback 라벨(`(none)`)을 **항상** 노출.

## ADR-015 §2 인용

> 코드 위치: `useFusedNearestStation.ts:861-887` Tier 5 override result/confidence 대입 제거, `useStickyStation.ts:307` 결과는 별 채널 `useStickyDisplayOnly`로 격리.
>
> 근거: 추정 신호 3종은 지하 dead-zone fallback 의도로 만들어졌으나 fire 권한까지 가져 dedup 누적 → 실측 신호 도착 시 dedup 차단으로 알림 빠짐.

본 PR은 §2 격리 결과를 디버그 인프라에 wire-up해 사후 분석 가능하게 만든다.

## 변경 사항

### `src/features/debug/components/DebugModal.tsx`

- `TripDebugState`에 `displayOnlyEstimateStrategy: StationProgressStrategy | null` 신규 필드
- `DebugModalInner`: `useFusedNearestStation()`에서 `displayOnlyEstimate` 구조분해 + trip useMemo에 `displayOnlyEstimate?.strategy ?? null` 주입 (SSOT 도출)
- Trip 섹션 UI: KeyValue row 추가 (testID=`debug-modal-display-only-estimate`)
- `buildTripSection` dump: `displayOnlyEstimate=<strategy|(none)>` 라인 추가
- `formatDisplayOnlyEstimateStrategy` 헬퍼 — null 케이스 fallback 단일 책임
- `KeyValue` 컴포넌트에 optional `testID` 인자 추가 (다른 row에도 점진 채택 가능)

### `src/features/debug/components/__tests__/DebugModal.test.tsx`

- fixture: `fusedReturnFixture` / `setupHookDefaults`에 `displayOnlyEstimate: null` 기본값 추가
- 기존 trip 리터럴 4곳에 `displayOnlyEstimateStrategy` 필드 추가
- **신규 dump 테스트**: 5종 strategy 각각 + null + trip 미전달 — 총 7 케이스 (it.each + null + 미전달)
- **신규 UI 테스트**: 5종 strategy 각각 + null fallback + trip 미전달 (hook null SSOT) + hook 비-null SSOT → 총 8 케이스
- 기존 Share dump 테스트에 `displayOnlyEstimate=lockless-route-hop` assertion 추가

## 양방향 layer 추적 (ADR-015 §11)

| layer | upstream | downstream |
|---|---|---|
| frontend hook | `useFusedNearestStation.ts:119` displayOnlyEstimate 산출 (PR #1445이 추가) | `useFusedNearestStation.ts:1065` 매 render 노출 |
| frontend component | `DebugModal.tsx:1080` 구조분해 | `DebugModal.tsx` Trip 섹션 KeyValue + buildTripSection dump |
| 데이터셋 | — | — |
| 인프라/백엔드 | — | — |

sync 깨진 곳: PR #1445가 `displayOnlyEstimate`를 노출까지만 했고 DebugModal 소비자 미배선이었다 → 본 PR이 closure.

## Before / After dump 예시

### Before

```
## Trip
lockless=true
tripStartedAt=2026-06-17T13:23:00.000Z
currentHopIndex=—            ← E4 후 시간 적분 strategy는 hop index에서 박탈 → null
route hop count=5
                              ← strategy가 무엇이었는지 알 수 없음
```

### After

```
## Trip
lockless=true
tripStartedAt=2026-06-17T13:23:00.000Z
currentHopIndex=—
route hop count=5
displayOnlyEstimate=lockless-route-hop   ← strategy 라벨 노출 (또는 (none))
```

## Acceptance

- [x] 5종 strategy + null fallback + trip 미전달 모든 상황에서 라벨 노출 (테스트 12 케이스)
- [x] Share dump에 동일 라벨 포함 (사후 재구성)
- [x] type-check 통과
- [x] 신규 테스트 모두 통과 (DebugModal suite 238/238)

## 참고

- Epic: #1432 (ADR-015 환경 SSOT + 합의 게이트)
- 후속: PR #1445 (E4 #1437 fire 권한 박탈 + 격리)
- ADR: `docs/decisions/ADR-015-multi-signal-consensus-gate.md` §2 (Fire 권한 영구 박탈 — 시간 적분 strategy 3종)