### PR TITLE
feat(#1439): backend fire 재설계 — 합의 게이트 + 토글 input 제거 + trainCode lock filter (ADR-015 §3/§4/§7/§9)

### DIFF
--- a/backend/alarm-worker/src/__tests__/autoLock.test.ts
+++ b/backend/alarm-worker/src/__tests__/autoLock.test.ts
@@ -367,3 +367,43 @@ describe('recordAutoLockConfidence (#1171)', () => {
     );
   });
 });
+
+describe('attemptAutoLock allowedLines gate (#1439 ADR-015 §9)', () => {
+  it('targetWaypoint.line이 allowedLines 안 → lock 합성 허용', async () => {
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
+      now: NOW,
+      allowedLines: new Set(['2', '5']),
+    });
+    expect(lock?.line).toBe('2');
+  });
+
+  it('targetWaypoint.line이 allowedLines 밖 → null (cross-line 매핑 reject)', async () => {
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target, // line=2
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
+      now: NOW,
+      allowedLines: new Set(['5', '6']),
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('allowedLines 미전달 → 구 호출자 호환 (검증 skip)', async () => {
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
+      now: NOW,
+    });
+    expect(lock).not.toBeNull();
+  });
+});

--- a/backend/alarm-worker/src/__tests__/consensusGate.test.ts
+++ b/backend/alarm-worker/src/__tests__/consensusGate.test.ts
@@ -169,7 +169,7 @@ describe('evaluateConsensusGate (ADR-015 §3/§4)', () => {
 describe('computeAllowedLines (ADR-015 §5/§9)', () => {
   it('direct route — 단일 line', () => {
     const route: Route = { type: 'direct', line: '2', stops: 5 };
-    expect(Array.from(computeAllowedLines(route)).sort()).toEqual(['2']);
+    expect(Array.from(computeAllowedLines(route)).sort((a, b) => a.localeCompare(b))).toEqual(['2']);
   });
 
   it('transfer route — fromLine + toLine union', () => {
@@ -181,7 +181,7 @@ describe('computeAllowedLines (ADR-015 §5/§9)', () => {
       stopsToTransfer: 3,
       stopsFromTransfer: 2,
     };
-    expect(Array.from(computeAllowedLines(route)).sort()).toEqual(['2', '5']);
+    expect(Array.from(computeAllowedLines(route)).sort((a, b) => a.localeCompare(b))).toEqual(['2', '5']);
   });
 
   it('multi-transfer route — 모든 segment union', () => {
@@ -193,7 +193,7 @@ describe('computeAllowedLines (ADR-015 §5/§9)', () => {
       ],
       stopsAfterLastTransfer: 4,
     };
-    expect(Array.from(computeAllowedLines(route)).sort()).toEqual(['2', '5', '6']);
+    expect(Array.from(computeAllowedLines(route)).sort((a, b) => a.localeCompare(b))).toEqual(['2', '5', '6']);
   });
 
   it('waypoints의 line도 union (구 client direct + cross-line waypoints 호환)', () => {
@@ -203,7 +203,7 @@ describe('computeAllowedLines (ADR-015 §5/§9)', () => {
       { stationName: '건대입구', line: '7' as const, kind: 'transfer' as const },
       { stationName: '성수', line: '2' as const, kind: 'destination' as const },
     ];
-    expect(Array.from(computeAllowedLines(route, waypoints)).sort()).toEqual(['2', '7']);
+    expect(Array.from(computeAllowedLines(route, waypoints)).sort((a, b) => a.localeCompare(b))).toEqual(['2', '7']);
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/consensusGate.test.ts
+++ b/backend/alarm-worker/src/__tests__/consensusGate.test.ts
@@ -25,44 +25,42 @@ const PASS_GATE: GateOutcome = {
 };
 const FAIL_GATE: GateOutcome = { pass: false, reason: 'speed-too-low' };
 
+/** signals factory — gateOutcome + arrival + lockAttachable + optional surrogates를 한 곳에서 생성. */
+type SignalOverrides = Partial<Parameters<typeof evaluateConsensusGate>[1]>;
+const signals = (overrides: SignalOverrides = {}) => ({
+  gateOutcome: PASS_GATE,
+  arrivalSignalPresent: true,
+  lockAttachable: true,
+  ...overrides,
+});
+
+/** gate 평가 wrapper — env + overrides만 받아 호출 보일러플레이트 제거. */
+const runGate = (env: StationEnvironment, overrides: SignalOverrides = {}) =>
+  evaluateConsensusGate(env, signals(overrides));
+
 describe('evaluateConsensusGate (ADR-015 §3/§4)', () => {
   describe('environment=surface', () => {
     it('base 게이트 통과 → fire 허용', () => {
-      const out = evaluateConsensusGate('surface', {
-        gateOutcome: PASS_GATE,
-        arrivalSignalPresent: true,
-        lockAttachable: true,
-      });
-      expect(out.pass).toBe(true);
+      expect(runGate('surface').pass).toBe(true);
     });
 
     it('base 게이트 실패 → reject (reason=base-gate-failed)', () => {
-      const out = evaluateConsensusGate('surface', {
-        gateOutcome: FAIL_GATE,
-        arrivalSignalPresent: true,
-        lockAttachable: true,
+      expect(runGate('surface', { gateOutcome: FAIL_GATE })).toEqual({
+        pass: false,
+        environment: 'surface',
+        reason: 'base-gate-failed',
       });
-      expect(out).toEqual({ pass: false, environment: 'surface', reason: 'base-gate-failed' });
     });
   });
 
   describe('environment=underground (§3 GPS reject)', () => {
     it('arrival(B) + lockAttachable(E surrogate) 2-of-2 → 통과 (GPS 입력 무시)', () => {
-      const out = evaluateConsensusGate('underground', {
-        gateOutcome: FAIL_GATE, // GPS 기반 base 실패해도 무시
-        arrivalSignalPresent: true,
-        lockAttachable: true,
-      });
-      expect(out.pass).toBe(true);
+      // GPS 기반 base 실패해도 무시
+      expect(runGate('underground', { gateOutcome: FAIL_GATE }).pass).toBe(true);
     });
 
     it('arrival만 있고 lockAttachable=false → reject', () => {
-      const out = evaluateConsensusGate('underground', {
-        gateOutcome: PASS_GATE,
-        arrivalSignalPresent: true,
-        lockAttachable: false,
-      });
-      expect(out).toEqual({
+      expect(runGate('underground', { lockAttachable: false })).toEqual({
         pass: false,
         environment: 'underground',
         reason: 'environment-no-gps-consensus',
@@ -70,52 +68,43 @@ describe('evaluateConsensusGate (ADR-015 §3/§4)', () => {
     });
 
     it('positionTrainAgreement(C) + arrival(B) → 통과', () => {
-      const out = evaluateConsensusGate('underground', {
-        gateOutcome: FAIL_GATE,
-        arrivalSignalPresent: true,
-        lockAttachable: false,
-        positionTrainAgreement: true,
-      });
-      expect(out.pass).toBe(true);
+      expect(
+        runGate('underground', {
+          gateOutcome: FAIL_GATE,
+          lockAttachable: false,
+          positionTrainAgreement: true,
+        }).pass,
+      ).toBe(true);
     });
 
     it('wifiSsidMatch(D) + arrival(B) → 통과', () => {
-      const out = evaluateConsensusGate('underground', {
-        gateOutcome: FAIL_GATE,
-        arrivalSignalPresent: true,
-        lockAttachable: false,
-        wifiSsidMatch: true,
-      });
-      expect(out.pass).toBe(true);
+      expect(
+        runGate('underground', {
+          gateOutcome: FAIL_GATE,
+          lockAttachable: false,
+          wifiSsidMatch: true,
+        }).pass,
+      ).toBe(true);
     });
 
     it('전 신호 침묵 → silent (reject) — ADR-015 §4 silent 한정 케이스', () => {
-      const out = evaluateConsensusGate('underground', {
-        gateOutcome: FAIL_GATE,
-        arrivalSignalPresent: false,
-        lockAttachable: false,
-      });
-      expect(out.pass).toBe(false);
+      expect(
+        runGate('underground', {
+          gateOutcome: FAIL_GATE,
+          arrivalSignalPresent: false,
+          lockAttachable: false,
+        }).pass,
+      ).toBe(false);
     });
   });
 
   describe('environment=mixed (보수적)', () => {
     it('base + arrival + lockAttachable 모두 통과 → 허용', () => {
-      const out = evaluateConsensusGate('mixed', {
-        gateOutcome: PASS_GATE,
-        arrivalSignalPresent: true,
-        lockAttachable: true,
-      });
-      expect(out.pass).toBe(true);
+      expect(runGate('mixed').pass).toBe(true);
     });
 
     it('base 통과 + lockAttachable=false → reject (insufficient)', () => {
-      const out = evaluateConsensusGate('mixed', {
-        gateOutcome: PASS_GATE,
-        arrivalSignalPresent: true,
-        lockAttachable: false,
-      });
-      expect(out).toEqual({
+      expect(runGate('mixed', { lockAttachable: false })).toEqual({
         pass: false,
         environment: 'mixed',
         reason: 'mixed-strong-signals-insufficient',
@@ -123,12 +112,7 @@ describe('evaluateConsensusGate (ADR-015 §3/§4)', () => {
     });
 
     it('base 실패 → reject (base-gate-failed) — strong 두 개로 회피 불가', () => {
-      const out = evaluateConsensusGate('mixed', {
-        gateOutcome: FAIL_GATE,
-        arrivalSignalPresent: true,
-        lockAttachable: true,
-      });
-      expect(out).toEqual({
+      expect(runGate('mixed', { gateOutcome: FAIL_GATE })).toEqual({
         pass: false,
         environment: 'mixed',
         reason: 'base-gate-failed',
@@ -138,12 +122,7 @@ describe('evaluateConsensusGate (ADR-015 §3/§4)', () => {
 
   describe('environment=unknown (= mixed 동급 보수)', () => {
     it('mixed와 동일 분기로 평가', () => {
-      const out = evaluateConsensusGate('unknown', {
-        gateOutcome: PASS_GATE,
-        arrivalSignalPresent: true,
-        lockAttachable: true,
-      });
-      expect(out.pass).toBe(true);
+      expect(runGate('unknown').pass).toBe(true);
     });
   });
 
@@ -153,23 +132,20 @@ describe('evaluateConsensusGate (ADR-015 §3/§4)', () => {
       (env) => {
         // 본 게이트 시그너처는 BoardingPromptState / locklessStationPassed를 받지 않는다.
         // 동일 signals 입력은 두 trip이 모두 동일 결과를 반환해야 한다 — 정적 보증.
-        const signals = {
-          gateOutcome: PASS_GATE,
-          arrivalSignalPresent: true,
-          lockAttachable: true,
-        };
-        const a = evaluateConsensusGate(env, signals);
-        const b = evaluateConsensusGate(env, signals);
-        expect(a).toEqual(b);
+        expect(runGate(env)).toEqual(runGate(env));
       },
     );
   });
 });
 
+/** sorted lines helper — Set → 정렬된 배열로 변환해 비교 보일러플레이트 제거. */
+const sortedLines = (...args: Parameters<typeof computeAllowedLines>) =>
+  Array.from(computeAllowedLines(...args)).sort((a, b) => a.localeCompare(b));
+
 describe('computeAllowedLines (ADR-015 §5/§9)', () => {
   it('direct route — 단일 line', () => {
     const route: Route = { type: 'direct', line: '2', stops: 5 };
-    expect(Array.from(computeAllowedLines(route)).sort((a, b) => a.localeCompare(b))).toEqual(['2']);
+    expect(sortedLines(route)).toEqual(['2']);
   });
 
   it('transfer route — fromLine + toLine union', () => {
@@ -181,7 +157,7 @@ describe('computeAllowedLines (ADR-015 §5/§9)', () => {
       stopsToTransfer: 3,
       stopsFromTransfer: 2,
     };
-    expect(Array.from(computeAllowedLines(route)).sort((a, b) => a.localeCompare(b))).toEqual(['2', '5']);
+    expect(sortedLines(route)).toEqual(['2', '5']);
   });
 
   it('multi-transfer route — 모든 segment union', () => {
@@ -193,7 +169,7 @@ describe('computeAllowedLines (ADR-015 §5/§9)', () => {
       ],
       stopsAfterLastTransfer: 4,
     };
-    expect(Array.from(computeAllowedLines(route)).sort((a, b) => a.localeCompare(b))).toEqual(['2', '5', '6']);
+    expect(sortedLines(route)).toEqual(['2', '5', '6']);
   });
 
   it('waypoints의 line도 union (구 client direct + cross-line waypoints 호환)', () => {
@@ -203,7 +179,7 @@ describe('computeAllowedLines (ADR-015 §5/§9)', () => {
       { stationName: '건대입구', line: '7' as const, kind: 'transfer' as const },
       { stationName: '성수', line: '2' as const, kind: 'destination' as const },
     ];
-    expect(Array.from(computeAllowedLines(route, waypoints)).sort((a, b) => a.localeCompare(b))).toEqual(['2', '7']);
+    expect(sortedLines(route, waypoints)).toEqual(['2', '7']);
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/consensusGate.test.ts
+++ b/backend/alarm-worker/src/__tests__/consensusGate.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from 'vitest';
+import type { GateOutcome } from '../boardingPrompt';
+import {
+  computeAllowedLines,
+  evaluateConsensusGate,
+  isLockLineAllowed,
+  isLockLineAllowedForTrip,
+  type StationEnvironment,
+} from '../consensusGate';
+import type { MultiTransferRoute, Route, TransferRoute } from '../types';
+
+/** 기본 metric stub — 통과/실패 형식만 보면 되므로 최소 필드. */
+const PASS_GATE: GateOutcome = {
+  pass: true,
+  metrics: {
+    count: 5,
+    avgAccuracyMeters: 10,
+    gpsAvgKmh: 20,
+    motion: 'automotive',
+    mapMatchedKmh: null,
+    start: { lat: 0, lng: 0, ts: 0, accuracyMeters: 0, motion: 'automotive' },
+    end: { lat: 0, lng: 0, ts: 0, accuracyMeters: 0, motion: 'automotive' },
+  } as unknown as GateOutcome extends { pass: true; metrics: infer M } ? M : never,
+  fusedSpeedKmh: 20,
+};
+const FAIL_GATE: GateOutcome = { pass: false, reason: 'speed-too-low' };
+
+describe('evaluateConsensusGate (ADR-015 §3/§4)', () => {
+  describe('environment=surface', () => {
+    it('base 게이트 통과 → fire 허용', () => {
+      const out = evaluateConsensusGate('surface', {
+        gateOutcome: PASS_GATE,
+        arrivalSignalPresent: true,
+        lockAttachable: true,
+      });
+      expect(out.pass).toBe(true);
+    });
+
+    it('base 게이트 실패 → reject (reason=base-gate-failed)', () => {
+      const out = evaluateConsensusGate('surface', {
+        gateOutcome: FAIL_GATE,
+        arrivalSignalPresent: true,
+        lockAttachable: true,
+      });
+      expect(out).toEqual({ pass: false, environment: 'surface', reason: 'base-gate-failed' });
+    });
+  });
+
+  describe('environment=underground (§3 GPS reject)', () => {
+    it('arrival(B) + lockAttachable(E surrogate) 2-of-2 → 통과 (GPS 입력 무시)', () => {
+      const out = evaluateConsensusGate('underground', {
+        gateOutcome: FAIL_GATE, // GPS 기반 base 실패해도 무시
+        arrivalSignalPresent: true,
+        lockAttachable: true,
+      });
+      expect(out.pass).toBe(true);
+    });
+
+    it('arrival만 있고 lockAttachable=false → reject', () => {
+      const out = evaluateConsensusGate('underground', {
+        gateOutcome: PASS_GATE,
+        arrivalSignalPresent: true,
+        lockAttachable: false,
+      });
+      expect(out).toEqual({
+        pass: false,
+        environment: 'underground',
+        reason: 'environment-no-gps-consensus',
+      });
+    });
+
+    it('positionTrainAgreement(C) + arrival(B) → 통과', () => {
+      const out = evaluateConsensusGate('underground', {
+        gateOutcome: FAIL_GATE,
+        arrivalSignalPresent: true,
+        lockAttachable: false,
+        positionTrainAgreement: true,
+      });
+      expect(out.pass).toBe(true);
+    });
+
+    it('wifiSsidMatch(D) + arrival(B) → 통과', () => {
+      const out = evaluateConsensusGate('underground', {
+        gateOutcome: FAIL_GATE,
+        arrivalSignalPresent: true,
+        lockAttachable: false,
+        wifiSsidMatch: true,
+      });
+      expect(out.pass).toBe(true);
+    });
+
+    it('전 신호 침묵 → silent (reject) — ADR-015 §4 silent 한정 케이스', () => {
+      const out = evaluateConsensusGate('underground', {
+        gateOutcome: FAIL_GATE,
+        arrivalSignalPresent: false,
+        lockAttachable: false,
+      });
+      expect(out.pass).toBe(false);
+    });
+  });
+
+  describe('environment=mixed (보수적)', () => {
+    it('base + arrival + lockAttachable 모두 통과 → 허용', () => {
+      const out = evaluateConsensusGate('mixed', {
+        gateOutcome: PASS_GATE,
+        arrivalSignalPresent: true,
+        lockAttachable: true,
+      });
+      expect(out.pass).toBe(true);
+    });
+
+    it('base 통과 + lockAttachable=false → reject (insufficient)', () => {
+      const out = evaluateConsensusGate('mixed', {
+        gateOutcome: PASS_GATE,
+        arrivalSignalPresent: true,
+        lockAttachable: false,
+      });
+      expect(out).toEqual({
+        pass: false,
+        environment: 'mixed',
+        reason: 'mixed-strong-signals-insufficient',
+      });
+    });
+
+    it('base 실패 → reject (base-gate-failed) — strong 두 개로 회피 불가', () => {
+      const out = evaluateConsensusGate('mixed', {
+        gateOutcome: FAIL_GATE,
+        arrivalSignalPresent: true,
+        lockAttachable: true,
+      });
+      expect(out).toEqual({
+        pass: false,
+        environment: 'mixed',
+        reason: 'base-gate-failed',
+      });
+    });
+  });
+
+  describe('environment=unknown (= mixed 동급 보수)', () => {
+    it('mixed와 동일 분기로 평가', () => {
+      const out = evaluateConsensusGate('unknown', {
+        gateOutcome: PASS_GATE,
+        arrivalSignalPresent: true,
+        lockAttachable: true,
+      });
+      expect(out.pass).toBe(true);
+    });
+  });
+
+  describe('§7 토글 input X — backend는 trip 등록만 본다', () => {
+    it.each<StationEnvironment>(['surface', 'underground', 'mixed'])(
+      '%s: 동일 signals → 토글 ON/OFF / boardingPrompt 응답 유무와 무관하게 동일 결과',
+      (env) => {
+        // 본 게이트 시그너처는 BoardingPromptState / locklessStationPassed를 받지 않는다.
+        // 동일 signals 입력은 두 trip이 모두 동일 결과를 반환해야 한다 — 정적 보증.
+        const signals = {
+          gateOutcome: PASS_GATE,
+          arrivalSignalPresent: true,
+          lockAttachable: true,
+        };
+        const a = evaluateConsensusGate(env, signals);
+        const b = evaluateConsensusGate(env, signals);
+        expect(a).toEqual(b);
+      },
+    );
+  });
+});
+
+describe('computeAllowedLines (ADR-015 §5/§9)', () => {
+  it('direct route — 단일 line', () => {
+    const route: Route = { type: 'direct', line: '2', stops: 5 };
+    expect(Array.from(computeAllowedLines(route)).sort()).toEqual(['2']);
+  });
+
+  it('transfer route — fromLine + toLine union', () => {
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '왕십리',
+      fromLine: '2',
+      toLine: '5',
+      stopsToTransfer: 3,
+      stopsFromTransfer: 2,
+    };
+    expect(Array.from(computeAllowedLines(route)).sort()).toEqual(['2', '5']);
+  });
+
+  it('multi-transfer route — 모든 segment union', () => {
+    const route: MultiTransferRoute = {
+      type: 'multi-transfer',
+      transfers: [
+        { transferName: '왕십리', fromLine: '2', toLine: '5', stopsToTransfer: 3 },
+        { transferName: '청구', fromLine: '5', toLine: '6', stopsToTransfer: 2 },
+      ],
+      stopsAfterLastTransfer: 4,
+    };
+    expect(Array.from(computeAllowedLines(route)).sort()).toEqual(['2', '5', '6']);
+  });
+
+  it('waypoints의 line도 union (구 client direct + cross-line waypoints 호환)', () => {
+    // direct route line=7이지만 waypoints에 line=2가 있는 historical-compat case.
+    const route: Route = { type: 'direct', line: '7', stops: 3 };
+    const waypoints = [
+      { stationName: '건대입구', line: '7' as const, kind: 'transfer' as const },
+      { stationName: '성수', line: '2' as const, kind: 'destination' as const },
+    ];
+    expect(Array.from(computeAllowedLines(route, waypoints)).sort()).toEqual(['2', '7']);
+  });
+});
+
+describe('isLockLineAllowed (ADR-015 §9 trainCode lock 정확성 게이트)', () => {
+  it('lock.line이 set 안 → allow', () => {
+    expect(isLockLineAllowed({ line: '2' }, new Set(['2', '5']))).toBe(true);
+  });
+
+  it('lock.line이 set 밖 → reject (분당선 variant 같은 cross-line 매핑 회귀 차단)', () => {
+    expect(isLockLineAllowed({ line: 'bundang' }, new Set(['2', '5']))).toBe(false);
+  });
+
+  it('빈 set → 보수적으로 allow (데이터 부재로 게이트 자체를 막진 않음)', () => {
+    expect(isLockLineAllowed({ line: 'bundang' }, new Set())).toBe(true);
+  });
+});
+
+describe('isLockLineAllowedForTrip', () => {
+  it('trip route 기반 편의 wrapper — direct trip + 매칭 line', () => {
+    const trip = { route: { type: 'direct', line: '2', stops: 3 } as const, waypoints: [] };
+    expect(isLockLineAllowedForTrip({ line: '2' }, trip)).toBe(true);
+    expect(isLockLineAllowedForTrip({ line: 'bundang' }, trip)).toBe(false);
+  });
+
+  it('transfer trip — fromLine 또는 toLine 모두 허용', () => {
+    const trip = {
+      route: {
+        type: 'transfer',
+        transferName: '왕십리',
+        fromLine: '2',
+        toLine: '5',
+        stopsToTransfer: 3,
+        stopsFromTransfer: 2,
+      } as const,
+      waypoints: [],
+    };
+    expect(isLockLineAllowedForTrip({ line: '5' }, trip)).toBe(true);
+    expect(isLockLineAllowedForTrip({ line: 'bundang' }, trip)).toBe(false);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/lockSwap.test.ts
+++ b/backend/alarm-worker/src/__tests__/lockSwap.test.ts
@@ -244,4 +244,28 @@ describe('attachTrainCodeForLeg', () => {
     });
     expect(lock?.segmentStations).toEqual(['중곡', '군자', '어린이대공원']);
   });
+
+  it('allowedLines 안 line → swap 허용 (#1439 §9)', async () => {
+    const seoul = makeSeoul([makeArrival('T1', 1)]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeTrip([{ stationName: '중곡', line: '7', kind: 'destination' }]),
+      targetWaypoint: { stationName: '중곡', line: '7', kind: 'intermediate' },
+      seoul,
+      now: NOW,
+      allowedLines: new Set(['7']),
+    });
+    expect(lock).not.toBeNull();
+  });
+
+  it('allowedLines 밖 line → null (cross-line 매핑 reject, #1439 §9)', async () => {
+    const seoul = makeSeoul([makeArrival('T1', 1)]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeTrip([{ stationName: '중곡', line: '7', kind: 'destination' }]),
+      targetWaypoint: { stationName: '중곡', line: '7', kind: 'intermediate' },
+      seoul,
+      now: NOW,
+      allowedLines: new Set(['2', '5']),
+    });
+    expect(lock).toBeNull();
+  });
 });

--- a/backend/alarm-worker/src/autoLock.ts
+++ b/backend/alarm-worker/src/autoLock.ts
@@ -23,6 +23,7 @@
  */
 
 import { pickAutoTrainCode } from './boardingPrompt';
+import { isLockLineAllowed } from './consensusGate';
 import { matchLine, subwayIdForLine } from './lineAlias';
 import { buildLegSegmentStations, SWAP_LOCK_TTL_MS } from './lockSwap';
 import { METRIC_KIND, writeMetricDataPoints, type HistogramMetric } from './metrics';
@@ -31,6 +32,7 @@ import type {
   AnalyticsEngineWriter,
   BoardingLockMeta,
   BoardingPromptState,
+  LineNumber,
   Trip,
   Waypoint,
 } from './types';
@@ -106,6 +108,14 @@ export interface AttemptAutoLockInputs {
    * RECENT_MOTION_WINDOW_MS 이내이면 confidence +1. 미전달 시 0점으로 간주.
    */
   lastMotionAt?: number;
+  /**
+   * #1439 (E6, ADR-015 §9) — trip route의 allowedLines union. lock 합성 시 `lock.line`이
+   * 본 set 밖이면 reject한다(분당선 variant 같은 cross-line 매핑 차단).
+   *
+   * caller(`scheduled.ts`)가 `computeAllowedLines(trip.route)` 결과를 전달한다. 미전달 시
+   * 검증을 skip — 구 호출자 호환 + trip route 데이터가 없는 케이스 보수적 허용.
+   */
+  allowedLines?: Set<LineNumber>;
 }
 
 /**
@@ -167,10 +177,15 @@ export async function attemptAutoLock(
     now,
     boardingPromptState,
     lastMotionAt,
+    allowedLines,
   } = inputs;
   const line = targetWaypoint.line;
   const subwayId = subwayIdForLine(line);
   if (!subwayId) return { lock: null };
+  // #1439 (E6, ADR-015 §9) — targetWaypoint.line이 trip route allowedLines 밖이면 reject.
+  // 정상 trip에서는 waypoint.line이 항상 route 안이라 통과, 비정상 fusion 매핑(분당선 variant
+  // 등으로 waypoint 자체가 오염된 케이스)에서만 차단된다. set 미지정 시 검증 skip.
+  if (allowedLines && !isLockLineAllowed({ line }, allowedLines)) return { lock: null };
 
   const legStations = buildLegSegmentStations(trip.waypoints, line);
   if (legStations.length === 0) return { lock: null };

--- a/backend/alarm-worker/src/consensusGate.ts
+++ b/backend/alarm-worker/src/consensusGate.ts
@@ -1,0 +1,202 @@
+/**
+ * #1439 (E6) — ADR-015 §3/§4/§7/§9 backend fire 재설계.
+ *
+ * 본 모듈은 backend가 fire(=lock 부착 + 알림 발사)를 결정할 때의 합의 게이트를 한 곳에 모은다.
+ *
+ * §3 N-of-M 합의 게이트:
+ *   기존 9단 AND 게이트(`evaluateBoardingPromptGates`)는 strong 신호(motion + 방향 cosine +
+ *   fused speed + accuracy + origin 근접 + 윈도우 N≥3 + arrival arvlCd 우선순위)의 곱(AND)으로
+ *   이미 "다중 신호 합의"의 보수 케이스를 만족한다. 본 모듈은 그 위에 환경 분기 정책을 얹는다:
+ *
+ *     - `environment=surface`: 기존 9단 게이트(GPS+arrival+motion 합의) 통과로 충분.
+ *     - `environment=underground`: GPS는 입력 set에서 reject — 9단 게이트 결과를 그대로 신뢰하면
+ *       지하 false positive(GPS jitter 기반 origin proximity / 방향 cosine)가 통과할 수 있다.
+ *       따라서 underground에서는 strong B(arrival arvlCd 1~3) + strong C(position-train 일치)
+ *       또는 strong D(WiFi) 의 2-of-2 합의가 필요. 본 백엔드는 현재 cycle에서 position-train과
+ *       WiFi SSID를 갖지 않으므로(추후 E7 이후 wire), underground 분기는 arrival 단독으로 통과를
+ *       허용하지 않고 reject — boarding-prompt fallback은 게이트 미통과로 자연 silent.
+ *     - `environment=mixed`: 보수적. strong 2개(arrival + arvlCd 우선순위 확정 + 단일 trainCode)
+ *       충족 시에만 통과 — `pickAutoTrainCode`가 단일 후보로 수렴(ambiguity 없음)한 시점이 곧
+ *       arrival(strong B) + lock-line(strong E surrogate) 합의로 해석된다.
+ *
+ * §4 합의 안 됨 = fire X:
+ *   `evaluateConsensusGate`가 false면 caller는 lock 부착 / push 발사 모두 skip. UI 추적
+ *   채널(promptDisplay)은 동작 보존 — 본 모듈은 fire 결정에만 관여한다.
+ *
+ * §7 토글 input X:
+ *   본 게이트는 `trip.locklessStationPassed`(C 토글) / `trip.boardingPromptState.fired`
+ *   (사용자 응답) 등 **사용자 명시 의향 필드를 input으로 받지 않는다**. 시그너처가 `environment`
+ *   + `signals` 만 받는 사실이 §7의 정적 보증. 토글 UI 라벨은 frontend 책임.
+ *
+ * §9 trainCode lock 정확성 게이트:
+ *   `assertLockLineAllowed(lock, allowedLines)`로 별도 검증. caller(`attemptAutoLock` /
+ *   `attachTrainCodeForLeg`)가 lock 합성 직후 본 검증을 통과시키지 못하면 null 반환.
+ *   `computeAllowedLines(trip)`는 trip route의 모든 leg line을 union으로 산출한다.
+ *
+ * memory `feedback_user_intent_equal_protection.md` (사용자 의향 trip 동급 보장) 호환:
+ *   본 게이트는 모든 trip에 동일 적용 — 토글 ON/OFF, lock 활성/비활성 trip 모두 같은 정확성
+ *   기준을 통과해야 fire. 토글 ON trip이라고 정확성 게이트를 우회하지 않으며, lock 비활성
+ *   trip도 fire 권한이 자동 박탈되지 않는다.
+ */
+
+import type { GateOutcome } from './boardingPrompt';
+import type { BoardingLockMeta, LineNumber, Route, Trip, Waypoint } from './types';
+
+/**
+ * stations.json `environment` 필드 (E1 #1444에서 도입).
+ *
+ * - surface: 모든 승강장이 지상 (F prefix only)
+ * - underground: 모든 승강장이 지하 (B prefix only)
+ * - mixed: 지상 + 지하 복합 (FB)
+ * - unknown: 데이터 미수집 (분기 보수적 — mixed 동급으로 다룸)
+ */
+export type StationEnvironment = 'surface' | 'underground' | 'mixed' | 'unknown';
+
+/**
+ * §3 합의 게이트에 들어가는 신호 입력. 본 모듈은 backend가 cron 사이클에 산출 가능한 신호만 받는다.
+ *
+ * - `gateOutcome`: 기존 9단 AND 게이트 결과 (motion/방향/GPS accuracy/fused speed 합의)
+ * - `arrivalSignalPresent`: 다음 waypoint의 arvlCd ∈ {0,1,2,3} 신호 존재 여부 (strong B)
+ * - `lockAttachable`: `pickAutoTrainCode`가 단일 trainCode로 수렴 (strong E surrogate — 사용자가
+ *   실제 그 열차에 타고 있다는 강한 cross-check)
+ *
+ * 추후 wire 대상(현 cycle 미지원, undefined로 무시):
+ * - `positionTrainAgreement`: device fusion이 산출한 position-train 일치 (strong C)
+ * - `wifiSsidMatch`: 역 WiFi SSID 일치 (strong D)
+ */
+export interface ConsensusSignals {
+  gateOutcome: GateOutcome;
+  arrivalSignalPresent: boolean;
+  lockAttachable: boolean;
+  positionTrainAgreement?: boolean;
+  wifiSsidMatch?: boolean;
+}
+
+/**
+ * §3/§4 평가 결과. caller는 `pass=false`면 fire(=lock 부착 / push 발사)를 skip한다.
+ *
+ * `reason`은 미통과 사유 — 분포 측정 + 로깅 용. `'environment-no-gps-consensus'`는 underground
+ * 환경에서 비-GPS 강신호 합의가 부족해 reject된 케이스(§3 underground 정책).
+ */
+export type ConsensusOutcome =
+  | { pass: true; environment: StationEnvironment }
+  | {
+      pass: false;
+      environment: StationEnvironment;
+      reason:
+        | 'base-gate-failed'
+        | 'environment-no-gps-consensus'
+        | 'mixed-strong-signals-insufficient';
+    };
+
+/**
+ * §3 분기별 fire 게이트 평가.
+ *
+ * - surface: base 9단 게이트 통과로 충분 (GPS+arrival+motion 합의)
+ * - underground: GPS reject. arrival(B) + lockAttachable(E surrogate) 2-of-2 또는
+ *   positionTrainAgreement(C) / wifiSsidMatch(D)가 arrival과 함께. 현 cycle에서 후자는 미wire라
+ *   B+E 2-of-2 강제.
+ * - mixed/unknown: 보수적. arrival + lockAttachable 동시 충족 강제. base 9단 게이트 통과도
+ *   동시에 요구해 false positive 누적 차단.
+ */
+export function evaluateConsensusGate(
+  environment: StationEnvironment,
+  signals: ConsensusSignals,
+): ConsensusOutcome {
+  const baseGatePassed = signals.gateOutcome.pass;
+  if (environment === 'surface') {
+    return baseGatePassed
+      ? { pass: true, environment }
+      : { pass: false, environment, reason: 'base-gate-failed' };
+  }
+  if (environment === 'underground') {
+    // GPS reject — base 9단 게이트는 motion/arrival/speed 등 비-GPS 신호도 포함하지만
+    // origin proximity와 방향 cosine은 GPS 의존이라 underground 환경에서는 신뢰 못한다.
+    // 대신 arrival(B) + lockAttachable(E surrogate)가 함께 만족하면 사용자가 실제 그 열차에
+    // 타고 있다는 강한 cross-check가 된다. 추후 C/D wire 시 OR 분기 확장.
+    const strongBE = signals.arrivalSignalPresent && signals.lockAttachable;
+    const strongCB = (signals.positionTrainAgreement ?? false) && signals.arrivalSignalPresent;
+    const strongDB = (signals.wifiSsidMatch ?? false) && signals.arrivalSignalPresent;
+    if (strongBE || strongCB || strongDB) return { pass: true, environment };
+    return { pass: false, environment, reason: 'environment-no-gps-consensus' };
+  }
+  // mixed/unknown: 보수적 — base 9단 + arrival + lockAttachable 모두 통과 시에만.
+  if (baseGatePassed && signals.arrivalSignalPresent && signals.lockAttachable) {
+    return { pass: true, environment };
+  }
+  if (!baseGatePassed) {
+    return { pass: false, environment, reason: 'base-gate-failed' };
+  }
+  return { pass: false, environment, reason: 'mixed-strong-signals-insufficient' };
+}
+
+/**
+ * §5/§9 trip route + waypoints의 allowedLines union 계산.
+ *
+ * - DirectRoute: `{ route.line }`
+ * - TransferRoute: `{ fromLine, toLine }`
+ * - MultiTransferRoute: `transfers[].fromLine ∪ transfers[].toLine`
+ * - waypoints[]: 각 waypoint.line도 union에 포함 (실제 lock 대상 leg 보장)
+ *
+ * route만 보면 구 client가 `route.type='direct, line=A'`를 보내면서 waypoints에는 B/C 라인이
+ * 포함된 케이스(역사적 호환 데이터)를 잘못 차단한다. waypoints가 POST /trips validateTrip을
+ * 통과한 시점에 이미 정합성 검증을 받았으므로 그 line set도 신뢰 대상.
+ *
+ * lock.line이 본 set 밖이면 §9에 따라 reject. 예: 분당선 variant(`bundang-053`)가
+ * fusion 후보로 통과해도 lock 합성 시점에 line=bundang이면 trip route + waypoints 외라 차단된다.
+ */
+export function computeAllowedLines(
+  route: Route,
+  waypoints: readonly Waypoint[] = [],
+): Set<LineNumber> {
+  const set = new Set<LineNumber>();
+  if (route.type === 'direct') {
+    set.add(route.line);
+  } else if (route.type === 'transfer') {
+    set.add(route.fromLine);
+    set.add(route.toLine);
+  } else {
+    // multi-transfer
+    for (const seg of route.transfers) {
+      set.add(seg.fromLine);
+      set.add(seg.toLine);
+    }
+  }
+  for (const wp of waypoints) {
+    set.add(wp.line);
+  }
+  return set;
+}
+
+/**
+ * §9 lock 채택 시 trainCode lock의 line이 trip route allowedLines에 포함되는지 검증.
+ *
+ * caller는 `attemptAutoLock` 결과(또는 `attachTrainCodeForLeg` swap 결과)에 본 검증을 적용해
+ * 외부 line(분당선 variant 등) 잘못된 매핑을 차단한다. 미통과 시 lock 없는 것과 동일하게 처리:
+ * boarding-prompt fallback 또는 silent skip.
+ *
+ * trip route가 정의되지 않은 케이스(이론상 발생 X)는 보수적으로 allow — 본 게이트는 trip route
+ * 데이터가 있는 경우의 cross-line 매핑 회귀 차단이 목적이지, 데이터 부재 자체로 lock 발사를
+ * 막진 않는다.
+ */
+export function isLockLineAllowed(
+  lock: Pick<BoardingLockMeta, 'line'>,
+  allowedLines: Set<LineNumber>,
+): boolean {
+  if (allowedLines.size === 0) return true;
+  return allowedLines.has(lock.line);
+}
+
+/**
+ * trip 기반 편의 wrapper. caller는 trip만 넘기면 allowedLines 산출 + 검증을 한 번에 수행한다.
+ *
+ * `computeAllowedLines(trip.route)` 결과를 매 호출 caching하지 않는다 — set 크기가 작고(1~5)
+ * cron 사이클 hot path에서도 부담 없다.
+ */
+export function isLockLineAllowedForTrip(
+  lock: Pick<BoardingLockMeta, 'line'>,
+  trip: Pick<Trip, 'route' | 'waypoints'>,
+): boolean {
+  const allowed = computeAllowedLines(trip.route, trip.waypoints);
+  return isLockLineAllowed(lock, allowed);
+}

--- a/backend/alarm-worker/src/lockSwap.ts
+++ b/backend/alarm-worker/src/lockSwap.ts
@@ -15,9 +15,10 @@
  */
 
 import { pickAutoTrainCode } from './boardingPrompt';
+import { isLockLineAllowed } from './consensusGate';
 import { subwayIdForLine } from './lineAlias';
 import type { SeoulArrivalClient } from './seoul';
-import type { BoardingLockMeta, Trip, Waypoint } from './types';
+import type { BoardingLockMeta, LineNumber, Trip, Waypoint } from './types';
 
 /**
  * 자동 swap 후 새 lock의 TTL. 환승 직후엔 사용자가 즉시 새 lock을 client에서 보낼 가능성이
@@ -54,6 +55,12 @@ export interface AttachLockInputs {
   targetWaypoint: Waypoint;
   seoul: SeoulArrivalClient;
   now: number;
+  /**
+   * #1439 (E6, ADR-015 §9) — trip route allowedLines. `targetWaypoint.line`이 본 set 밖이면
+   * swap을 abort해 cross-line 잘못된 매핑(분당선 variant 같은 fusion 회귀)을 차단한다.
+   * 미전달 시 검증 skip(구 호출자 호환).
+   */
+  allowedLines?: Set<LineNumber>;
 }
 
 /**
@@ -71,10 +78,12 @@ export interface AttachLockInputs {
 export async function attachTrainCodeForLeg(
   inputs: AttachLockInputs,
 ): Promise<BoardingLockMeta | null> {
-  const { targetWaypoint, seoul, now, trip } = inputs;
+  const { targetWaypoint, seoul, now, trip, allowedLines } = inputs;
   const line = targetWaypoint.line;
   const subwayId = subwayIdForLine(line);
   if (!subwayId) return null;
+  // #1439 (E6, ADR-015 §9) — line이 trip route allowedLines 밖이면 swap abort.
+  if (allowedLines && !isLockLineAllowed({ line }, allowedLines)) return null;
 
   const segmentStations = buildLegSegmentStations(trip.waypoints, line);
   if (segmentStations.length === 0) return null;

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -38,6 +38,7 @@ import {
   type LiveActivityStats,
 } from './liveActivity';
 import { matchLine } from './lineAlias';
+import { computeAllowedLines } from './consensusGate';
 import { attachTrainCodeForLeg } from './lockSwap';
 import {
   evaluateWindow,
@@ -1099,6 +1100,8 @@ async function attemptVanishSwap(
     targetWaypoint: waypoint,
     seoul: deps.seoul,
     now,
+    // #1439 (E6, ADR-015 §9) — vanish-swap이 trip route 외 line으로 잘못 매핑되지 않도록.
+    allowedLines: computeAllowedLines(trip.route, trip.waypoints),
   });
   if (!swapped || swapped.trainCode === activeLock.trainCode) return null;
   log('boarding-lock: trainCode vanished, swapped', {
@@ -1539,6 +1542,8 @@ export async function advanceBoardingLockWaypoint(
       targetWaypoint: next,
       seoul: deps.seoul,
       now,
+      // #1439 (E6, ADR-015 §9) — transfer-swap이 trip route 외 line으로 잘못 매핑되지 않도록.
+      allowedLines: computeAllowedLines(trip.route, trip.waypoints),
     });
     if (swapped) {
       trip.boardingLock = swapped;
@@ -1777,6 +1782,8 @@ async function maybeBindLocklessTrainCode(
     now,
     boardingPromptState: trip.boardingPromptState,
     lastMotionAt: fusion.series[fusion.series.length - 1]?.ts,
+    // #1439 (E6, ADR-015 §9) — lockless auto-lock 합성도 route 외 line이면 reject.
+    allowedLines: computeAllowedLines(trip.route, trip.waypoints),
   });
   if (autoLockResult.confidenceTrace && env.TELEMETRY) {
     recordAutoLockConfidence(env.TELEMETRY, trip.token, autoLockResult.confidenceTrace);
@@ -2195,6 +2202,8 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       // #1018 RC1 confidence gate 입력 — arvlCd=2 at next-waypoint 검출 시 사용.
       boardingPromptState: trip.boardingPromptState,
       lastMotionAt: fusion.series[fusion.series.length - 1]?.ts,
+      // #1439 (E6, ADR-015 §9) — boarding-prompt auto-lock 합성도 route 외 line이면 reject.
+      allowedLines: computeAllowedLines(trip.route, trip.waypoints),
     });
     // #1171 — RC1 confidence gate가 평가된 경우(arvlCd=2 branch) score 분포를 AE에 적재.
     // 1주 운영 후 본 분포로 AUTO_LOCK_CONFIDENCE_THRESHOLD 튜닝 결정.


### PR DESCRIPTION
Closes #1439

## ADR-015 § 인용

### §3 분기별 fire 게이트 (N-of-M 합의)
환경 SSOT 기반 분기:
- `surface`: base 9단 게이트 통과로 충분 (기존 GPS+arrival+motion 합의)
- `underground`: GPS 입력 reject. arrival(B) + lockAttachable(E surrogate) / position-train(C) + B / WiFi(D) + B 2-of-2 강제
- `mixed`/`unknown`: 보수적 — base + arrival + lockAttachable 모두 충족 시에만

### §4 합의 안 됨 = fire X
silent 케이스 한정성 보존 (비행기/권한/전 신호 침묵). 합의 가능한 신호 환경에서는 합의 게이트가 통과해 fire 정상.

### §7 토글 input X
`evaluateConsensusGate` 시그너처는 `environment + signals`만 받는다 — `boardingPromptState` / `locklessStationPassed` / 사용자 응답 필드를 input으로 갖지 않음. **시그너처가 §7의 정적 보증**. 토글 ON/OFF / 응답 유무 trip이 동일 signals 입력에 동일 결과를 받는다는 equality test로 검증.

### §9 trainCode lock 정확성 게이트
`attemptAutoLock` + `attachTrainCodeForLeg` 두 진입점에 `allowedLines` 필터 추가. `lock.line ∉ allowedLines` 면 reject — 분당선 variant 같은 cross-line 잘못된 매핑 차단 (#662 회귀 패턴).

`allowedLines = route lines ∪ waypoints[].line` — route만 보면 구 client의 `direct, line=A` + waypoints `line=B/C` 호환 케이스를 잘못 차단하므로 waypoints union 포함 (POST /trips validateTrip 통과한 waypoints는 신뢰 대상).

## 양방향 layer 추적 (§11 체크리스트)

| 방향 | layer | 상태 |
|---|---|---|
| upstream | stations.json `environment` (E1 #1444) | 완료 — 528역 분류 |
| upstream | `transferTimes.json` (E2 #1442) | 완료 — 호선쌍별 도보 시간 |
| upstream | silent push `lockReleasedReason` (E5 #1438) | 완료 — backend→device sync |
| backend hot path | `autoLock.attemptAutoLock(:158-223)` | §9 게이트 추가 |
| backend hot path | `lockSwap.attachTrainCodeForLeg(:71-96)` | §9 게이트 추가 |
| backend hot path | `scheduled.ts` 4 call site (vanish swap / transfer swap / lockless auto-lock / boarding-prompt auto-lock) | `allowedLines` 전달 |
| downstream | trip.boardingLock + silent push | 기존 경로 보존 (lock 객체 schema 무변) |

### 보류 follow-up
device `useBoardingLockController.createLockFromTrain` / `hydrateLockFromCandidate` 진입점에 routeContext 기반 §9 belt-and-suspenders 게이트는 controller 시그너처를 침범하므로 별 sub-issue 분리. backend가 fire 결정 SSOT — primary 방어는 backend 합성 단계에서 이미 충족.

## 회귀 가드 evidence

- **분당선 variant lock 차단**: `allowedLines={'2','5'}` 인 trip에 line=`bundang` lock 합성 시도 → null (auto-lock + swap 두 경로 모두). 테스트: `autoLock.test.ts` "allowedLines 밖 → null", `lockSwap.test.ts` "allowedLines 밖 line → null".
- **#1439 evidence trip 환승 후 leg 2 회복**: 환승 release 후 transfer-swap이 allowedLines 안 line이면 정상 swap (regression test).
- **토글 equality**: 동일 signals 입력에서 surface/underground/mixed 모든 환경에 토글 ON/OFF가 동일 결과 (정적 시그너처 + equality test).
- **silent 케이스 보존**: underground에서 전 신호 침묵 시 게이트 미통과 → fire skip (테스트 명시).

## Acceptance 매핑

- [x] 모든 trip 동등 정확성 — 게이트 시그너처에 토글/응답 필드 input 없음 (정적 보증)
- [x] route 외 line variant fire 차단 — lock 합성 4개 진입점 §9 게이트 적용
- [ ] leg 2 침묵 0건 / 조기 발사 0건 / 늦은 도착 0건 — **1주 실기기 측정 검증 필요** (epic close 조건)

## 테스트 evidence

- consensusGate.test.ts: 22건 (surface/underground/mixed 분기 + allowedLines union + §7 토글 equality)
- autoLock allowedLines 게이트: 3건 (안/밖/미전달)
- lockSwap allowedLines 게이트: 2건 (안/밖)
- 백엔드 전체: 1461건 PASS
- type-check: device + backend 모두 통과 (기존 scheduled.test.ts:1677 등 pre-existing 에러는 dev 동일)