### PR TITLE
fix(#1449): useBoardingLockController trainCode lock 정확성 게이트 — trip route allowedLines filter

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -8,7 +8,10 @@ import { useBoardingLockStore } from '../../store/useBoardingLockStore';
 import type { ArrivalInfo, StationArrival } from '../../../../shared/types/arrival';
 import type { Station } from '../../../../shared/types/station';
 import type { BoardingLock } from '../../../../shared/types/boardingLock';
-import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
+import {
+  makeDirectRoute,
+  makeTransferRoute,
+} from '../../../../testUtils/routeFixtures';
 
 const mockGetBoardingLock = jest.fn();
 const mockSetBoardingLock = jest.fn();
@@ -260,8 +263,18 @@ describe('useBoardingLockController', () => {
     });
 
     it('boardingLine은 train.line을 사용한다 (currentStation.line이 fusion 잘못 잠금 상태여도 lock은 정확) — #663', async () => {
-      // currentStation.line='2'(fusion이 옆 노선으로 잘못 잠긴 상태), train.line='7'(사용자가 탭한 실제 열차)
-      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      // currentStation.line='2'(fusion이 옆 노선으로 잘못 잠긴 상태), train.line='7'(사용자가 탭한 실제 열차).
+      // #1449 filter 회피: trip route를 2↔7 환승으로 두어 line 7이 allowedLines에 포함되게 한다.
+      const transferRoute2to7 = makeTransferRoute({
+        transferName: '강남구청',
+        fromLine: '2',
+        toLine: '7',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 3,
+      });
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, route: transferRoute2to7 }),
+      );
       await act(async () => {
         result.current.createLockFromTrain(makeTrain({ trainCode: 'T-7', line: '7' }));
       });
@@ -280,7 +293,16 @@ describe('useBoardingLockController', () => {
         lat: 37.5,
         lng: 127.0,
       });
-      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      const transferRoute2to7 = makeTransferRoute({
+        transferName: '강남구청',
+        fromLine: '2',
+        toLine: '7',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 3,
+      });
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, route: transferRoute2to7 }),
+      );
       await act(async () => {
         result.current.createLockFromTrain(makeTrain({ trainCode: 'T-7', line: '7' }));
       });
@@ -292,13 +314,84 @@ describe('useBoardingLockController', () => {
 
     it('정정 lookup 실패 시 currentStation.id로 폴백 (#707) — stations.json에 매칭 없는 가상 케이스도 안전', async () => {
       mockFindStationByNameAndLine.mockReturnValue(null);
-      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      const transferRoute2to7 = makeTransferRoute({
+        transferName: '강남구청',
+        fromLine: '2',
+        toLine: '7',
+        stopsToTransfer: 2,
+        stopsFromTransfer: 3,
+      });
+      const { result } = renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, route: transferRoute2to7 }),
+      );
       await act(async () => {
         result.current.createLockFromTrain(makeTrain({ trainCode: 'T-X', line: '7' }));
       });
       expect(mockSetBoardingLock).toHaveBeenCalledWith(
         expect.objectContaining({ boardingStationId: 'stn-A' }),
       );
+    });
+
+    // #1449 (ADR-015 §9 frontend) — trip route allowedLines 외 line traincode reject.
+    describe('#1449 trip route line filter', () => {
+      it('direct route(line 2) 일 때 trip 외 line(7) train 탭 → no-op (lock 채택 차단)', async () => {
+        // defaultInputs.route = makeDirectRoute(_, '2'). train.line='7'은 trip 외.
+        const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+        await act(async () => {
+          result.current.createLockFromTrain(makeTrain({ trainCode: 'T-7', line: '7' }));
+        });
+        expect(mockSetBoardingLock).not.toHaveBeenCalled();
+      });
+
+      it('transfer route(2↔5, 왕십리) 다중 line 환승역에서 양쪽 line 모두 허용', async () => {
+        const transferRoute = makeTransferRoute({
+          transferName: '왕십리',
+          fromLine: '2',
+          toLine: '5',
+          stopsToTransfer: 3,
+          stopsFromTransfer: 4,
+        });
+        const { result } = renderHook(() =>
+          useBoardingLockController({ ...defaultInputs, route: transferRoute }),
+        );
+        // line 5 (toLine) train 탭 → 허용
+        await act(async () => {
+          result.current.createLockFromTrain(makeTrain({ trainCode: 'T-5', line: '5' }));
+        });
+        expect(mockSetBoardingLock).toHaveBeenCalledWith(
+          expect.objectContaining({ trainCode: 'T-5', boardingLine: '5' }),
+        );
+      });
+
+      it('transfer route에서 양쪽 line 외 line(7) train 탭 → no-op', async () => {
+        const transferRoute = makeTransferRoute({
+          transferName: '왕십리',
+          fromLine: '2',
+          toLine: '5',
+          stopsToTransfer: 3,
+          stopsFromTransfer: 4,
+        });
+        const { result } = renderHook(() =>
+          useBoardingLockController({ ...defaultInputs, route: transferRoute }),
+        );
+        await act(async () => {
+          result.current.createLockFromTrain(makeTrain({ trainCode: 'T-7', line: '7' }));
+        });
+        expect(mockSetBoardingLock).not.toHaveBeenCalled();
+      });
+
+      it('trip 비활성(route=null) → filter 미적용 (free-trip 등 기존 UX 유지)', async () => {
+        // route=null이면 allowedLines=undefined → filter skip. 어떤 line이든 lock 생성.
+        const { result } = renderHook(() =>
+          useBoardingLockController({ ...defaultInputs, route: null }),
+        );
+        await act(async () => {
+          result.current.createLockFromTrain(makeTrain({ trainCode: 'T-9', line: '9' }));
+        });
+        expect(mockSetBoardingLock).toHaveBeenCalledWith(
+          expect.objectContaining({ trainCode: 'T-9', boardingLine: '9' }),
+        );
+      });
     });
   });
 
@@ -627,6 +720,99 @@ describe('useBoardingLockController', () => {
             });
           });
           expect(mockSetBoardingLock).not.toHaveBeenCalled();
+        });
+      });
+
+      // #1449 (ADR-015 §9 frontend) — trip route allowedLines 외 candidate.line reject.
+      // backend autoLock(#916) 9-AND gate는 device-side trip context를 모르므로 device가 한 번 더 검증.
+      describe('#1449 trip route line filter', () => {
+        it('direct route(line 2) 일 때 candidate.line=7 → no-op (trip 외 line autoLock 차단)', async () => {
+          // defaultInputs.route = makeDirectRoute(_, '2'). candidate.line='7'은 trip 외.
+          // arrival에 AUTO-7이 있어 Gate 1은 통과해도 line filter에서 차단됨.
+          const arrivalLine7: StationArrival = {
+            up: [makeTrain({ trainCode: 'AUTO-7', line: '7' })],
+            down: [],
+          };
+          const { result } = renderHook(() =>
+            useBoardingLockController({ ...defaultInputs, arrival: arrivalLine7 }),
+          );
+          await act(async () => {
+            result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '7', subwayId: '1007' });
+          });
+          expect(mockSetBoardingLock).not.toHaveBeenCalled();
+        });
+
+        it('transfer route(2↔5, 청량리) 다중 line 환승역 — 양쪽 line 모두 hydrate 허용', async () => {
+          const transferRoute = makeTransferRoute({
+            transferName: '청량리',
+            fromLine: '2',
+            toLine: '5',
+            stopsToTransfer: 3,
+            stopsFromTransfer: 4,
+          });
+          const arrivalLine5: StationArrival = {
+            up: [makeTrain({ trainCode: 'AUTO-5', line: '5' })],
+            down: [],
+          };
+          const { result } = renderHook(() =>
+            useBoardingLockController({
+              ...defaultInputs,
+              route: transferRoute,
+              arrival: arrivalLine5,
+            }),
+          );
+          await act(async () => {
+            result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-5', line: '5', subwayId: '1005' });
+          });
+          await waitFor(() => expect(mockSetBoardingLock).toHaveBeenCalled());
+          expect(mockSetBoardingLock.mock.calls[0][0]).toMatchObject({
+            trainCode: 'AUTO-5',
+            boardingLine: '5',
+          });
+        });
+
+        it('transfer route(2↔5)에서 양쪽 line 외 line(7) candidate → no-op', async () => {
+          const transferRoute = makeTransferRoute({
+            transferName: '왕십리',
+            fromLine: '2',
+            toLine: '5',
+            stopsToTransfer: 3,
+            stopsFromTransfer: 4,
+          });
+          const arrivalLine7: StationArrival = {
+            up: [makeTrain({ trainCode: 'AUTO-7', line: '7' })],
+            down: [],
+          };
+          const { result } = renderHook(() =>
+            useBoardingLockController({
+              ...defaultInputs,
+              route: transferRoute,
+              arrival: arrivalLine7,
+            }),
+          );
+          await act(async () => {
+            result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '7', subwayId: '1007' });
+          });
+          expect(mockSetBoardingLock).not.toHaveBeenCalled();
+        });
+
+        it('trip 비활성(route=null) → line filter 미적용 (기존 free-trip hydrate 경로 유지)', async () => {
+          const arrivalLine9: StationArrival = {
+            up: [makeTrain({ trainCode: 'AUTO-9', line: '9' })],
+            down: [],
+          };
+          const { result } = renderHook(() =>
+            useBoardingLockController({
+              ...defaultInputs,
+              route: null,
+              destinationId: null,
+              arrival: arrivalLine9,
+            }),
+          );
+          await act(async () => {
+            result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-9', line: '9', subwayId: '1009' });
+          });
+          await waitFor(() => expect(mockSetBoardingLock).toHaveBeenCalled());
         });
       });
     });

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -11,6 +11,7 @@ import { AppState, type AppStateStatus } from 'react-native';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import { resolveTripDirection } from '../../route/utils/tripDirection';
 import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
+import { allowedLinesFromRoute } from '../../../shared/utils/stationRoute';
 import { STATIC_SPEED_THRESHOLD_MPS } from '../../nearest-station/utils/movementGate';
 import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival';
 import type { Route } from '../../../shared/utils/stationRoute';
@@ -153,6 +154,13 @@ export function useBoardingLockController({
     return resolveTripDirection(route, destinationName, currentStation.id);
   }, [route, destinationName, currentStation]);
 
+  // #1449 (ADR-015 §9 frontend) — trip route에 포함된 노선 집합. lock 채택 시 line filter SSOT.
+  // trip 비활성/route null이면 undefined — 두 진입점은 undefined를 "필터 미적용"으로 해석한다
+  // (free-trip / hydrate 경로에서 route가 없는 상태도 기존처럼 허용).
+  // backend(#1439 E6) gate와 같은 규칙을 device 측에도 적용해, trip route 외 line의 traincode가
+  // BoardingLock store로 흘러드는 회귀를 차단한다.
+  const allowedLines = useMemo(() => allowedLinesFromRoute(route), [route]);
+
   const directionalArrivals = useMemo<ArrivalInfo[]>(() => {
     if (!arrival) return [];
     if (direction === 'up') return arrival.up.filter(isReachable);
@@ -176,6 +184,11 @@ export function useBoardingLockController({
   const createLockFromTrain = useCallback(
     (train: ArrivalInfo) => {
       if (!destinationId || !currentStation) return;
+      // #1449 (ADR-015 §9 frontend) — trip route 외 line traincode reject.
+      // 환승역(왕십리/청량리 등)에서 사용자가 옆 노선 열차를 잘못 탭하거나, fusion이 옆 노선의
+      // train arrival을 directionalArrivals에 섞어 노출한 경우 lock 채택을 차단한다.
+      // allowedLines === undefined는 trip 비활성 → 필터 미적용(free-trip 등 기존 UX 유지).
+      if (allowedLines && !allowedLines.has(train.line)) return;
       const durationMin = expectedDurationMinutes ?? FALLBACK_BOARDING_DURATION_MINUTES;
       // #663: boardingLine은 사용자가 실제로 탭한 train의 line을 사용. currentStation.line은 fusion
       // 추정이라 환승역에서 옆 노선으로 잘못 잠긴 상태일 수 있다 (#662). train.line은 어댑터가 subwayId로
@@ -197,7 +210,7 @@ export function useBoardingLockController({
         initialEtaSeconds: train.arrivalSeconds,
       });
     },
-    [destinationId, currentStation, expectedDurationMinutes, createLock],
+    [destinationId, currentStation, expectedDurationMinutes, createLock, allowedLines],
   );
 
   const release = useCallback(() => {
@@ -224,6 +237,11 @@ export function useBoardingLockController({
       const boardingLine = asLineNumber(candidate.line);
       if (!boardingLine) return;
       if (lock) return;
+      // #1449 (ADR-015 §9 frontend) — trip route 외 line autoLockCandidate reject.
+      // backend autoLock(#916) 9-AND gate가 device-side trip context를 완전히 모르므로,
+      // device가 trip route allowedLines 검증을 한 번 더 강제한다.
+      // allowedLines === undefined는 trip 비활성 → 필터 미적용 (free-trip sentinel 경로 유지).
+      if (allowedLines && !allowedLines.has(boardingLine)) return;
 
       // #1014 Gate 1: trainCode가 현재 directionalArrivals에 있는지 확인.
       // directionalArrivals는 arrival + direction 필터로 이미 방향 일치 검증을 포함한다.
@@ -287,7 +305,7 @@ export function useBoardingLockController({
         // store action rejection은 graceful — loadLock race / storage 일시 실패는 다음 sync에서 자연 재시도.
       });
     },
-    [destinationId, currentStation, expectedDurationMinutes, lock, createLock, directionalArrivals, motionStationary, speedMps],
+    [destinationId, currentStation, expectedDurationMinutes, lock, createLock, directionalArrivals, motionStationary, speedMps, allowedLines],
   );
 
   return {

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -50,7 +50,7 @@ import {
 import type { LinePositions } from '../api/positionApi';
 import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
-import type { LineNumber, NearestStationResult, Station } from '../../../shared/types/station';
+import type { NearestStationResult, Station } from '../../../shared/types/station';
 import type { ArrivalProvider } from '../../../shared/types/providers';
 import type { PositionProvider } from '../providers/types';
 import { allowedLinesFromRoute, type Route } from '../../../shared/utils/stationRoute';

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -53,7 +53,7 @@ import type { BoardingLock } from '../../../shared/types/boardingLock';
 import type { LineNumber, NearestStationResult, Station } from '../../../shared/types/station';
 import type { ArrivalProvider } from '../../../shared/types/providers';
 import type { PositionProvider } from '../providers/types';
-import type { Route } from '../../../shared/utils/stationRoute';
+import { allowedLinesFromRoute, type Route } from '../../../shared/utils/stationRoute';
 
 /**
  * fusion 후보 개수. MAX_ACTIVE_LINES와 동기화 — Rules of Hooks로 useArrivalInfo/useTrainPositions를
@@ -290,27 +290,6 @@ export interface FusedRouteContext {
   route: Route;
   origin: Station | null;
   destination: Station | null;
-}
-
-/**
- * #1436 — trip route에 포함된 노선 집합. fusion 후보 단계에서 trip 외 노선 entry를 차단한다.
- * route 형태별로 leg의 line을 모두 모은다. trip 비활성/route null이면 undefined.
- */
-function allowedLinesFromRoute(route: Route | null | undefined): Set<LineNumber> | undefined {
-  if (!route) return undefined;
-  const lines = new Set<LineNumber>();
-  if (route.type === 'direct') {
-    lines.add(route.line);
-  } else if (route.type === 'transfer') {
-    lines.add(route.fromLine);
-    lines.add(route.toLine);
-  } else {
-    for (const t of route.transfers) {
-      lines.add(t.fromLine);
-      lines.add(t.toLine);
-    }
-  }
-  return lines;
 }
 
 export function useFusedNearestStation(

--- a/src/shared/utils/__tests__/stationRoute.test.ts
+++ b/src/shared/utils/__tests__/stationRoute.test.ts
@@ -1,4 +1,4 @@
-import { getStationsOnLine, getRemainingStops, getIntermediateStationNames, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, calculateRemainingLegETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition, isStationOnRoute, isStationWithinHopWindow, arcIndexOf, LOCKLESS_HOP_WINDOW_DEFAULT, getFirstLeg, findRouteCandidatesByCategory, ROUTE_CATEGORIES, normalizeStationName, isSameStationName, routeSignature, getStopDistanceMeters } from '../stationRoute';
+import { getStationsOnLine, getRemainingStops, getIntermediateStationNames, findRoute, findRoutes, pickRouteByPreference, buildJourneyDisplay, calculateETA, calculateStaticETA, calculateRemainingLegETA, getNextStationName, findStationByNameAndLine, updateRouteFromPosition, isStationOnRoute, isStationWithinHopWindow, arcIndexOf, LOCKLESS_HOP_WINDOW_DEFAULT, getFirstLeg, findRouteCandidatesByCategory, ROUTE_CATEGORIES, normalizeStationName, isSameStationName, routeSignature, getStopDistanceMeters, allowedLinesFromRoute } from '../stationRoute';
 import type { Station, LineNumber } from '../../types/station';
 import type { DirectRoute, TransferRoute, MultiTransferRoute, RouteCandidate, RouteCategory } from '../stationRoute';
 import {
@@ -1892,5 +1892,45 @@ describe('getIntermediateStationNames', () => {
   it('returns null for unknown station id', () => {
     expect(getIntermediateStationNames('1-001', 'unknown-id')).toBeNull();
     expect(getIntermediateStationNames('unknown-id', '1-001')).toBeNull();
+  });
+});
+
+describe('allowedLinesFromRoute (#1436 / #1449)', () => {
+  it('route null/undefined → undefined (필터 미적용)', () => {
+    expect(allowedLinesFromRoute(null)).toBeUndefined();
+    expect(allowedLinesFromRoute(undefined)).toBeUndefined();
+  });
+
+  it('DirectRoute → 단일 line set', () => {
+    const route: DirectRoute = makeDirectRoute(3, '2');
+    const lines = allowedLinesFromRoute(route);
+    expect(lines).toBeDefined();
+    expect(Array.from(lines!).sort()).toEqual(['2']);
+  });
+
+  it('TransferRoute → fromLine + toLine 양쪽 포함', () => {
+    const route: TransferRoute = makeTransferRoute({
+      transferName: '왕십리',
+      fromLine: '2',
+      toLine: '5',
+      stopsToTransfer: 3,
+      stopsFromTransfer: 4,
+    });
+    const lines = allowedLinesFromRoute(route);
+    expect(lines).toBeDefined();
+    expect(Array.from(lines!).sort()).toEqual(['2', '5']);
+  });
+
+  it('MultiTransferRoute → 모든 transfer leg의 fromLine/toLine 합집합', () => {
+    const route: MultiTransferRoute = makeMultiTransferRoute({
+      transfers: [
+        { transferName: '잠실(송파구청)', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
+        { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 5 },
+      ],
+      stopsAfterLastTransfer: 4,
+    });
+    const lines = allowedLinesFromRoute(route);
+    expect(lines).toBeDefined();
+    expect(Array.from(lines!).sort()).toEqual(['1', '2', '8']);
   });
 });

--- a/src/shared/utils/__tests__/stationRoute.test.ts
+++ b/src/shared/utils/__tests__/stationRoute.test.ts
@@ -1905,7 +1905,7 @@ describe('allowedLinesFromRoute (#1436 / #1449)', () => {
     const route: DirectRoute = makeDirectRoute(3, '2');
     const lines = allowedLinesFromRoute(route);
     expect(lines).toBeDefined();
-    expect(Array.from(lines!).sort()).toEqual(['2']);
+    expect(Array.from(lines!).sort((a, b) => a.localeCompare(b))).toEqual(['2']);
   });
 
   it('TransferRoute → fromLine + toLine 양쪽 포함', () => {
@@ -1918,7 +1918,7 @@ describe('allowedLinesFromRoute (#1436 / #1449)', () => {
     });
     const lines = allowedLinesFromRoute(route);
     expect(lines).toBeDefined();
-    expect(Array.from(lines!).sort()).toEqual(['2', '5']);
+    expect(Array.from(lines!).sort((a, b) => a.localeCompare(b))).toEqual(['2', '5']);
   });
 
   it('MultiTransferRoute → 모든 transfer leg의 fromLine/toLine 합집합', () => {
@@ -1931,6 +1931,6 @@ describe('allowedLinesFromRoute (#1436 / #1449)', () => {
     });
     const lines = allowedLinesFromRoute(route);
     expect(lines).toBeDefined();
-    expect(Array.from(lines!).sort()).toEqual(['1', '2', '8']);
+    expect(Array.from(lines!).sort((a, b) => a.localeCompare(b))).toEqual(['1', '2', '8']);
   });
 });

--- a/src/shared/utils/stationRoute.ts
+++ b/src/shared/utils/stationRoute.ts
@@ -137,6 +137,32 @@ export interface MultiTransferRoute {
 
 export type Route = DirectRoute | TransferRoute | MultiTransferRoute | null;
 
+/**
+ * #1436 / #1449 — trip route에 포함된 노선 집합.
+ * fusion 후보 단계(#1436)와 BoardingLock 채택 단계(#1449, ADR-015 §9 frontend)에서
+ * trip route 외 노선을 차단하는 SSOT.
+ * route 형태별로 leg의 line을 모두 모은다. trip 비활성/route null이면 undefined —
+ * 호출자는 undefined를 "필터 미적용"으로 해석한다.
+ */
+export function allowedLinesFromRoute(
+  route: Route | null | undefined,
+): Set<LineNumber> | undefined {
+  if (!route) return undefined;
+  const lines = new Set<LineNumber>();
+  if (route.type === 'direct') {
+    lines.add(route.line);
+  } else if (route.type === 'transfer') {
+    lines.add(route.fromLine);
+    lines.add(route.toLine);
+  } else {
+    for (const t of route.transfers) {
+      lines.add(t.fromLine);
+      lines.add(t.toLine);
+    }
+  }
+  return lines;
+}
+
 export type RoutePreference = 'optimal' | 'minTransfer';
 
 export interface RouteCandidate {


### PR DESCRIPTION
Closes #1449

## 요약

ADR-015 §9 trainCode lock 정확성 게이트 — backend(#1439 E6)에서 처리되는 trip route line filter를 frontend `useBoardingLockController` 두 진입점에 동등하게 적용한다.

> ADR-015 §9: lock 채택 시 traincode line이 trip route allowedLines 외이면 reject — backend autoLock 게이트와 device-side BoardingLock store 모두 같은 규칙을 강제해야 한다.

## 변경

- `src/shared/utils/stationRoute.ts`
  - `allowedLinesFromRoute(route)` helper export — 기존 `useFusedNearestStation.ts`의 local helper(#1436)를 shared SSOT로 끌어올림.
  - DirectRoute → `{line}`, TransferRoute → `{fromLine, toLine}`, MultiTransferRoute → 모든 segment leg 합집합. route null → undefined.

- `src/features/alarm/hooks/useBoardingLockController.ts`
  - `createLockFromTrain` 진입점에 `train.line ∈ allowedLines` 게이트 추가.
  - `hydrateLockFromCandidate` 진입점에 `candidate.line ∈ allowedLines` 게이트 추가 (backend autoLock 9-AND gate가 device-side trip context를 모르므로 한 번 더 검증).
  - `allowedLines === undefined`(trip 비활성) → filter 미적용 → free-trip / sentinel hydrate 경로 기존 UX 보존.
  - 두 useCallback의 deps에 `allowedLines` 추가.

- `src/features/nearest-station/hooks/useFusedNearestStation.ts`
  - local `allowedLinesFromRoute` 제거 → shared import로 전환 (중복 제거).

## 양방향 layer 추적

- **Upstream (#1449에서 차단되는 신호 출처)**:
  - 사용자 명시 탭: BoardingTrainList → `createLockFromTrain`. 환승역에서 옆 노선 train을 오탭하거나 `directionalArrivals`에 옆 노선이 섞여 노출된 경우.
  - Backend autoLock: silent push `autoLockCandidate` → `hydrateLockFromCandidate`. backend autoLock(#916)의 9-AND gate가 trip route를 모름 → device 보강.

- **Downstream (게이트 통과 후 흘러가는 곳)**:
  - `useBoardingLockStore.createLock` → AsyncStorage 영속화 + Zustand state.
  - 이후 `/boarding-lock/sync`로 backend 동기화, scheduler/Live Activity 등 모든 lock 기반 경로.

- **인프라**:
  - silent push autoLockCandidate (backend cron #916).
  - `useFusedNearestStation` allowedLines 필터 (#1436) — fusion 단계의 SSOT를 같은 helper로 공유.

## 테스트

- `useBoardingLockController.test.tsx`
  - `createLockFromTrain` describe에 `#1449 trip route line filter` 4 케이스: direct 외 line reject / transfer 양쪽 line 통과 / transfer 외 line(7) reject / route null skip.
  - `hydrateLockFromCandidate` describe에 동등 4 케이스 + 청량리/왕십리 다중 line 환승역 회귀 가드.
  - 기존 #663/#707 케이스(line 2 → 7 변경 lock)는 trip route를 2↔7 transfer로 갱신해 의도 보존(가드는 동일).

- `stationRoute.test.ts`
  - `allowedLinesFromRoute` describe 추가 — direct/transfer/multi-transfer/null 4 분기.

- `npm test`: 본 PR 관련 suite 모두 PASS (useBoardingLockController 59 PASS, stationRoute 신규 케이스 PASS, type-check PASS).
- 단, worktree env drift로 widget/stationNotification suite는 dev base 상태에서도 동일하게 fail (`lesson_worktree_test_env_drift.md`) — 본 PR과 무관, CI 환경에서 PASS.

## Acceptance (issue 본문)

- [x] trip route 외 line traincode로 lock 채택 0건 (game gate 추가)
- [x] 청량리/왕십리 같은 다중 line 환승역 회귀 가드 (테스트 추가)