### PR TITLE
fix(#1450): traincode TTL 동적 갱신 — lock 활성 시 arrival 폴링마다 refresh

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -700,6 +700,119 @@ describe('useFusedNearestStation', () => {
         mockUsePositions.mockReset();
       }
     });
+
+    it('#1450 (B2): lock 활성 + arrival 폴링 동일 trainCode 지속 → TTL 만료해도 traincode 강등 없음', () => {
+      // lock 활성 trip에서 polling 5회 사이 60s 경과해도 candidateTrains에 동일 trainCode가
+      // 계속 관찰되면 strong C가 살아있다고 보고 TTL 게이트 면제.
+      jest.useFakeTimers();
+      try {
+        const lock: import('../../../../shared/types/boardingLock').BoardingLock = {
+          destinationId: 'dest-1',
+          trainCode: 'T-LOCK-ALIVE',
+          boardingStationId: sagajeong.id,
+          boardingLine: '7',
+          boardedAt: Date.now(),
+          expectedDurationMs: 600_000,
+        };
+        // GPS = 사가정 실좌표 — lock 활성 + accuracy=50으로 거리 게이트 통과.
+        mockUseNearest.mockReturnValue(
+          gpsBase({
+            userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+            accuracyMeters: 50,
+            result: { station: sagajeong, distanceKm: 0 },
+          }),
+        );
+        mockFindTop.mockReturnValue([{ station: sagajeong, distanceKm: 0 }]);
+        mockUseArrival.mockReturnValue(arrivalRet(null));
+        mockUsePositions.mockImplementation((line: string | null) => {
+          if (line === '7') {
+            return positionRet({
+              line: '7',
+              trains: [
+                train(sagajeong.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-LOCK-ALIVE' }),
+              ],
+            });
+          }
+          return positionRet(null);
+        });
+
+        const { result, rerender } = renderHook(
+          ({ tick }: { tick: number }) =>
+            useFusedNearestStation(undefined, undefined, undefined, lock.trainCode, {
+              ...lock,
+              // boardedAt은 deps 변경용 — 실제 의미는 무관.
+              boardedAt: lock.boardedAt + tick,
+            }),
+          { initialProps: { tick: 0 } },
+        );
+        expect(result.current.source).toBe('boarding-lock');
+
+        // 5회 폴링 시뮬레이션 — 매 폴링마다 lock.trainCode가 candidateTrains에 살아있음.
+        for (let i = 0; i < 5; i += 1) {
+          jest.advanceTimersByTime(30_000);
+          mockUseNearest.mockReturnValue(
+            gpsBase({
+              userLocation: { lat: sagajeong.lat + 0.00001 * (i + 1), lng: sagajeong.lng },
+              accuracyMeters: 50,
+              result: { station: sagajeong, distanceKm: 0 },
+            }),
+          );
+          rerender({ tick: i + 1 });
+        }
+
+        // 150s 경과(TTL 60s의 2.5배) → 기존 동작이면 강등이지만, lock 동일 trainCode 지속이라 유지.
+        expect(result.current.source).toBe('boarding-lock');
+      } finally {
+        jest.useRealTimers();
+        mockUsePositions.mockReset();
+      }
+    });
+
+    it('#1450 (B2): lock 부재 시 동일 trainCode 지속이어도 기존 TTL 강등 동작 유지', () => {
+      // lockless trip에서는 본 fix가 발화하지 않아야 함 (lockless route hop 정확도 가정 결함 #1432).
+      jest.useFakeTimers();
+      try {
+        mockUseNearest.mockReturnValue(
+          gpsBase({
+            userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
+            accuracyMeters: 1500,
+            result: { station: yongmasan, distanceKm: 0 },
+          }),
+        );
+        mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+        mockUseArrival.mockReturnValue(arrivalRet(null));
+        mockUsePositions.mockImplementation((line: string | null) => {
+          if (line === '7') {
+            return positionRet({
+              line: '7',
+              trains: [
+                train(sagajeong.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-NOLOCK' }),
+              ],
+            });
+          }
+          return positionRet(null);
+        });
+
+        const { result, rerender } = renderHook(() => useFusedNearestStation());
+        expect(result.current.source).toBe('position-train');
+
+        jest.advanceTimersByTime(61_000);
+        mockUseNearest.mockReturnValue(
+          gpsBase({
+            userLocation: { lat: yongmasan.lat + 0.00001, lng: yongmasan.lng },
+            accuracyMeters: 1500,
+            result: { station: yongmasan, distanceKm: 0 },
+          }),
+        );
+        rerender(undefined);
+
+        // lock 없으니 TTL 게이트 그대로 발동 → 강등.
+        expect(result.current.source).not.toBe('position-train');
+      } finally {
+        jest.useRealTimers();
+        mockUsePositions.mockReset();
+      }
+    });
   });
 
   describe('#444 fused/route 거리 sanity gate', () => {

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -701,117 +701,95 @@ describe('useFusedNearestStation', () => {
       }
     });
 
-    it('#1450 (B2): lock 활성 + arrival 폴링 동일 trainCode 지속 → TTL 만료해도 traincode 강등 없음', () => {
-      // lock 활성 trip에서 polling 5회 사이 60s 경과해도 candidateTrains에 동일 trainCode가
-      // 계속 관찰되면 strong C가 살아있다고 보고 TTL 게이트 면제.
-      jest.useFakeTimers();
-      try {
-        const lock: import('../../../../shared/types/boardingLock').BoardingLock = {
-          destinationId: 'dest-1',
-          trainCode: 'T-LOCK-ALIVE',
-          boardingStationId: sagajeong.id,
-          boardingLine: '7',
-          boardedAt: Date.now(),
-          expectedDurationMs: 600_000,
-        };
-        // GPS = 사가정 실좌표 — lock 활성 + accuracy=50으로 거리 게이트 통과.
+    describe('#1450 (B2): traincode TTL 동적 갱신 (lock 활성 시 arrival 폴링 동일 trainCode 지속)', () => {
+      // 두 케이스(lock 활성 / lockless) 공통 setup. mockReset은 finally에 둠.
+      const setupTrainCodePolling = (params: {
+        station: typeof sagajeong;
+        accuracyMeters: number;
+        trainNo: string;
+      }) => {
         mockUseNearest.mockReturnValue(
           gpsBase({
-            userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
-            accuracyMeters: 50,
-            result: { station: sagajeong, distanceKm: 0 },
+            userLocation: { lat: params.station.lat, lng: params.station.lng },
+            accuracyMeters: params.accuracyMeters,
+            result: { station: params.station, distanceKm: 0 },
           }),
         );
-        mockFindTop.mockReturnValue([{ station: sagajeong, distanceKm: 0 }]);
+        mockFindTop.mockReturnValue([{ station: params.station, distanceKm: 0 }]);
         mockUseArrival.mockReturnValue(arrivalRet(null));
-        mockUsePositions.mockImplementation((line: string | null) => {
-          if (line === '7') {
-            return positionRet({
-              line: '7',
-              trains: [
-                train(sagajeong.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-LOCK-ALIVE' }),
-              ],
-            });
-          }
-          return positionRet(null);
-        });
-
-        const { result, rerender } = renderHook(
-          ({ tick }: { tick: number }) =>
-            useFusedNearestStation(undefined, undefined, undefined, lock.trainCode, {
-              ...lock,
-              // boardedAt은 deps 변경용 — 실제 의미는 무관.
-              boardedAt: lock.boardedAt + tick,
-            }),
-          { initialProps: { tick: 0 } },
+        mockUsePositions.mockImplementation((line: string | null) =>
+          line === '7'
+            ? positionRet({
+                line: '7',
+                trains: [train(params.station.name, TRAIN_STATUS.ARRIVED, { trainNo: params.trainNo })],
+              })
+            : positionRet(null),
         );
-        expect(result.current.source).toBe('boarding-lock');
+      };
+      const advanceWithJitter = (
+        station: typeof sagajeong,
+        accuracyMeters: number,
+        jitterIndex: number,
+      ) => {
+        jest.advanceTimersByTime(30_000);
+        mockUseNearest.mockReturnValue(
+          gpsBase({
+            userLocation: { lat: station.lat + 0.00001 * jitterIndex, lng: station.lng },
+            accuracyMeters,
+            result: { station, distanceKm: 0 },
+          }),
+        );
+      };
 
-        // 5회 폴링 시뮬레이션 — 매 폴링마다 lock.trainCode가 candidateTrains에 살아있음.
-        for (let i = 0; i < 5; i += 1) {
-          jest.advanceTimersByTime(30_000);
-          mockUseNearest.mockReturnValue(
-            gpsBase({
-              userLocation: { lat: sagajeong.lat + 0.00001 * (i + 1), lng: sagajeong.lng },
-              accuracyMeters: 50,
-              result: { station: sagajeong, distanceKm: 0 },
-            }),
+      it('lock 활성 + 동일 trainCode 5회 폴링 지속 → TTL 만료(150s)해도 traincode 강등 없음', () => {
+        jest.useFakeTimers();
+        try {
+          const lock: import('../../../../shared/types/boardingLock').BoardingLock = {
+            destinationId: 'dest-1',
+            trainCode: 'T-LOCK-ALIVE',
+            boardingStationId: sagajeong.id,
+            boardingLine: '7',
+            boardedAt: Date.now(),
+            expectedDurationMs: 600_000,
+          };
+          setupTrainCodePolling({ station: sagajeong, accuracyMeters: 50, trainNo: 'T-LOCK-ALIVE' });
+          const { result, rerender } = renderHook(
+            ({ tick }: { tick: number }) =>
+              useFusedNearestStation(undefined, undefined, undefined, lock.trainCode, {
+                ...lock,
+                boardedAt: lock.boardedAt + tick,
+              }),
+            { initialProps: { tick: 0 } },
           );
-          rerender({ tick: i + 1 });
-        }
+          expect(result.current.source).toBe('boarding-lock');
 
-        // 150s 경과(TTL 60s의 2.5배) → 기존 동작이면 강등이지만, lock 동일 trainCode 지속이라 유지.
-        expect(result.current.source).toBe('boarding-lock');
-      } finally {
-        jest.useRealTimers();
-        mockUsePositions.mockReset();
-      }
-    });
-
-    it('#1450 (B2): lock 부재 시 동일 trainCode 지속이어도 기존 TTL 강등 동작 유지', () => {
-      // lockless trip에서는 본 fix가 발화하지 않아야 함 (lockless route hop 정확도 가정 결함 #1432).
-      jest.useFakeTimers();
-      try {
-        mockUseNearest.mockReturnValue(
-          gpsBase({
-            userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
-            accuracyMeters: 1500,
-            result: { station: yongmasan, distanceKm: 0 },
-          }),
-        );
-        mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
-        mockUseArrival.mockReturnValue(arrivalRet(null));
-        mockUsePositions.mockImplementation((line: string | null) => {
-          if (line === '7') {
-            return positionRet({
-              line: '7',
-              trains: [
-                train(sagajeong.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-NOLOCK' }),
-              ],
-            });
+          for (let i = 0; i < 5; i += 1) {
+            advanceWithJitter(sagajeong, 50, i + 1);
+            rerender({ tick: i + 1 });
           }
-          return positionRet(null);
-        });
+          expect(result.current.source).toBe('boarding-lock');
+        } finally {
+          jest.useRealTimers();
+          mockUsePositions.mockReset();
+        }
+      });
 
-        const { result, rerender } = renderHook(() => useFusedNearestStation());
-        expect(result.current.source).toBe('position-train');
+      it('lock 부재 시 동일 trainCode 지속이어도 기존 TTL 강등 동작 유지 (#1432)', () => {
+        jest.useFakeTimers();
+        try {
+          setupTrainCodePolling({ station: yongmasan, accuracyMeters: 1500, trainNo: 'T-NOLOCK' });
+          const { result, rerender } = renderHook(() => useFusedNearestStation());
+          expect(result.current.source).toBe('position-train');
 
-        jest.advanceTimersByTime(61_000);
-        mockUseNearest.mockReturnValue(
-          gpsBase({
-            userLocation: { lat: yongmasan.lat + 0.00001, lng: yongmasan.lng },
-            accuracyMeters: 1500,
-            result: { station: yongmasan, distanceKm: 0 },
-          }),
-        );
-        rerender(undefined);
-
-        // lock 없으니 TTL 게이트 그대로 발동 → 강등.
-        expect(result.current.source).not.toBe('position-train');
-      } finally {
-        jest.useRealTimers();
-        mockUsePositions.mockReset();
-      }
+          advanceWithJitter(yongmasan, 1500, 1);
+          jest.advanceTimersByTime(31_000); // 합산 61s — TTL 60s 초과
+          rerender(undefined);
+          expect(result.current.source).not.toBe('position-train');
+        } finally {
+          jest.useRealTimers();
+          mockUsePositions.mockReset();
+        }
+      });
     });
   });
 

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -505,19 +505,19 @@ export function useFusedNearestStation(
   // 동일 ref면 발화하지 않아 TTL이 자연 만료된다. lockless trip에서는 기존 #445 sticky-락
   // 해제 동작이 유지되어야 하므로 본 refresh는 lock 활성 + lockedTrainCode 일치 시만 발화.
   // ADR-015 §3 지하 분기 strong C 합의 게이트.
-  const lockedTrainCodeAlive = useMemo(() => {
-    if (!boardingLock) return false;
-    const code = boardingLock.trainCode;
-    if (!code) return false;
-    return candidateTrains.some((c) => c.trainNo === code);
+  // boardingLock.trainCode가 이번 폴링 candidateTrains에서 관찰되면 strong C 살아있음.
+  // 두 값 중 하나라도 빠지면 null → effect는 비활성 + positionTrainResult TTL 게이트 정상 적용.
+  const aliveLockedTrainCode = useMemo<string | null>(() => {
+    const code = boardingLock?.trainCode;
+    if (code == null) return null;
+    return candidateTrains.some((c) => c.trainNo === code) ? code : null;
   }, [candidateTrains, boardingLock]);
+  const lockedTrainCodeAlive = aliveLockedTrainCode != null;
   useEffect(() => {
-    if (!lockedTrainCodeAlive) return;
+    if (aliveLockedTrainCode == null) return;
     lastProgressTsRef.current = Date.now();
-    if (boardingLock?.trainCode) {
-      lastConfirmedTrainNoRef.current = boardingLock.trainCode;
-    }
-  }, [lockedTrainCodeAlive, boardingLock]);
+    lastConfirmedTrainNoRef.current = aliveLockedTrainCode;
+  }, [aliveLockedTrainCode]);
 
   const positionTrainResult: NearestStationResult | null = useMemo(() => {
     if (!trainProgress) return null;

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -499,6 +499,26 @@ export function useFusedNearestStation(
     lastProgressTsRef.current = now;
   }, [trainProgress]);
 
+  // #1450 (B2): lock 활성 trip에서 매 arrival 폴링마다 lock.trainCode와 동일한 후보가
+  // 계속 관찰되면 traincode strong C가 TTL 만료로 강등되는 사이클을 끊는다.
+  // 위 effect는 trainProgress 의존이라 trainProgress가 일시적으로 null(GPS 끊김 등)이거나
+  // 동일 ref면 발화하지 않아 TTL이 자연 만료된다. lockless trip에서는 기존 #445 sticky-락
+  // 해제 동작이 유지되어야 하므로 본 refresh는 lock 활성 + lockedTrainCode 일치 시만 발화.
+  // ADR-015 §3 지하 분기 strong C 합의 게이트.
+  const lockedTrainCodeAlive = useMemo(() => {
+    if (!boardingLock) return false;
+    const code = boardingLock.trainCode;
+    if (!code) return false;
+    return candidateTrains.some((c) => c.trainNo === code);
+  }, [candidateTrains, boardingLock]);
+  useEffect(() => {
+    if (!lockedTrainCodeAlive) return;
+    lastProgressTsRef.current = Date.now();
+    if (boardingLock?.trainCode) {
+      lastConfirmedTrainNoRef.current = boardingLock.trainCode;
+    }
+  }, [lockedTrainCodeAlive, boardingLock]);
+
   const positionTrainResult: NearestStationResult | null = useMemo(() => {
     if (!trainProgress) return null;
     // #1016 hole (a): userLocation 없으면 distanceKm=0 placeholder 대신 null 반환.
@@ -510,9 +530,12 @@ export function useFusedNearestStation(
 
     // #445 TTL: trainProgress가 신선해야 함. stale하면 강등.
     // ref가 0이면 effect가 첫 ts를 commit하기 전 — useMemo는 pure하게 두기 위해 면제.
+    // #1450 (B2): lock 활성 + lockedTrainCode가 이번 폴링 candidateTrains에서 관찰되면
+    // TTL 게이트 면제 — strong C 신호가 살아있다고 보고 강등하지 않는다. lockless trip은 기존대로.
     if (
       lastProgressTsRef.current !== 0 &&
-      Date.now() - lastProgressTsRef.current > POSITION_TRAIN_TTL_MS
+      Date.now() - lastProgressTsRef.current > POSITION_TRAIN_TTL_MS &&
+      !lockedTrainCodeAlive
     ) {
       return null;
     }
@@ -557,7 +580,7 @@ export function useFusedNearestStation(
       }
     }
     return candidate;
-  }, [trainProgress, gps.userLocation, gps.accuracyMeters, candidates, boardingLock, arcStations]);
+  }, [trainProgress, gps.userLocation, gps.accuracyMeters, candidates, boardingLock, arcStations, lockedTrainCodeAlive]);
 
   const routeResult: NearestStationResult | null = progress.position
     ? {


### PR DESCRIPTION
## Summary

- `useFusedNearestStation`에서 lock 활성 + `lockedTrainCode`가 매 arrival 폴링 candidateTrains에 살아있으면 `POSITION_TRAIN_TTL_MS` 게이트를 면제해 traincode strong C 강등을 차단한다.
- `lastProgressTsRef`/`lastConfirmedTrainNoRef`를 폴링마다 refresh.
- lockless trip은 기존 #445 sticky-락 해제 동작 그대로 유지 (회귀 방지).

## 양방향 layer 추적

- **upstream**: arrival 폴링(`useTrainPositions` → `pickCandidateTrains`)이 lock의 trainCode 후보를 지속 관찰.
- **downstream**: fusion 합의 게이트 (ADR-015 §3 지하 분기 strong C). traincode가 살아있는 동안 합의가 깨지지 않는다.

## Test plan

- [x] `npm test` (격리: useFusedNearestStation.test.ts 81/81 pass) — widget/alarm 사전 실패는 dev 베이스라인 동일
- [x] `npm run type-check`
- [x] Lint clean
- [ ] 실기기 1주 측정: lock 활성 trip 중 traincode 강등 0건 (acceptance)

Closes #1450