### PR TITLE
feat(#1480): 환승 boardable train ETA 알고리즘 + 정적 timetable lookup helper + Provider interface seam

### DIFF
--- a/src/features/route/api/StaticTimetableProvider.ts
+++ b/src/features/route/api/StaticTimetableProvider.ts
@@ -1,0 +1,38 @@
+import {
+  findBoardableDeparture,
+  type DepartureLookupResult,
+} from '../../../shared/utils/timetableShared';
+import type {
+  TimetableLookupParams,
+  TimetableLookupResult,
+  TimetableProvider,
+} from './TimetableProvider';
+
+/**
+ * 정적 timetable JSON(`src/data/timetables/line-{1..9}.json`) 기반 Provider (#1480).
+ *
+ * - 외부 API 호출 0 — 즉시 lookup, latency 0.
+ * - 1~9호선만 timetable 보유. 그 외 노선은 `no-timetable` 반환.
+ * - 동기 lookup 지원 (`getBoardableDepartureSync`).
+ *
+ * Follow-up cascade (이슈 #1480 정정 2):
+ *   1. `getTrainSch` Provider — 호선/급행 여부 (별도 sub)
+ *   2. `SearchSTNTimeTableByIDService` Provider — 역 단위 (별도 sub)
+ *   3. **본 Provider — 정적 JSON (즉시 lookup)**
+ *   4. 호출자 정적 ETA fallback
+ */
+export class StaticTimetableProvider implements TimetableProvider {
+  readonly source = 'static' as const;
+
+  async getBoardableDeparture(params: TimetableLookupParams): Promise<TimetableLookupResult> {
+    return this.getBoardableDepartureSync(params);
+  }
+
+  getBoardableDepartureSync(params: TimetableLookupParams): TimetableLookupResult {
+    const result: DepartureLookupResult = findBoardableDeparture(params);
+    if (result.status === 'ok') {
+      return { status: 'ok', departure: result.departure };
+    }
+    return { status: result.status };
+  }
+}

--- a/src/features/route/api/TimetableProvider.ts
+++ b/src/features/route/api/TimetableProvider.ts
@@ -1,0 +1,93 @@
+import type { LineNumber } from '../../../shared/types/station';
+import type {
+  BoardableDeparture,
+  DayType,
+  Direction,
+} from '../../../shared/utils/timetableShared';
+
+/**
+ * 정적 timetable + 외부 OpenAPI를 같은 인터페이스로 조회하기 위한 추상 Provider (#1480).
+ *
+ * 본 PR 1차 구현체: `StaticTimetableProvider` (정적 JSON SSOT).
+ * Follow-up: `SeoulOpenApiTimetableProvider` (`SearchSTNTimeTableByIDService`),
+ * `SeoulTrainSchProvider` (`getTrainSch` — 급행 여부/환승 가능/임시시간표/열차번호/지선명).
+ *
+ * Provider cascade (사용자 명시 정정 2026-06-18 — getTrainSch 1순위):
+ *   1. `SeoulTrainSchProvider` (`getTrainSch`) — 호선 단위, 급행 여부 포함 (follow-up sub)
+ *   2. `SeoulOpenApiTimetableProvider` (`SearchSTNTimeTableByIDService`) — 역 단위 (follow-up sub)
+ *   3. `StaticTimetableProvider` (본 PR) — 정적 JSON, 1~9호선 build-time
+ *   4. (호출자) 정적 ETA fallback (`transferTimes` + `stationDistances` + `lineSpeeds`)
+ */
+
+export interface TimetableLookupParams {
+  stationName: string;
+  line: LineNumber;
+  direction: Direction;
+  /** 기준 시각 — 이 시각 이후 (>=) 첫 boardable departure. */
+  from: Date;
+}
+
+export type TimetableLookupStatus =
+  | 'ok'
+  | 'no-timetable'
+  | 'station-missing'
+  | 'day-type-unknown'
+  | 'no-departures'
+  | 'provider-error';
+
+export interface TimetableLookupSuccess {
+  status: 'ok';
+  departure: BoardableDeparture;
+  /**
+   * follow-up sub에서 endpoint별 부가 정보(급행/완행, 열차번호 등)를 채택할 자리.
+   * 정적 Provider는 비워둔다.
+   */
+  meta?: {
+    isExpress?: boolean;
+    trainCode?: string;
+    branchName?: string;
+    isTemporary?: boolean;
+  };
+}
+
+export interface TimetableLookupFailure {
+  status: Exclude<TimetableLookupStatus, 'ok'>;
+  reason?: string;
+}
+
+export type TimetableLookupResult = TimetableLookupSuccess | TimetableLookupFailure;
+
+export interface TimetableProvider {
+  readonly source: 'static' | 'seoul-train-sch' | 'seoul-station-timetable';
+  getBoardableDeparture(params: TimetableLookupParams): Promise<TimetableLookupResult>;
+  /**
+   * 동기 lookup이 가능한 Provider만 구현 (정적 JSON). 비동기 Provider는 미구현.
+   * 호출자가 `if (provider.getBoardableDepartureSync)`로 분기.
+   */
+  getBoardableDepartureSync?(params: TimetableLookupParams): TimetableLookupResult;
+}
+
+/**
+ * `DayType`을 외부 endpoint의 평일/토/일 코드로 매핑 (follow-up Provider 구현체용).
+ *
+ * 사용자 제공 메타데이터 (`SearchSTNTimeTableByIDService` `WEEK_TAG`):
+ *   - 1 = 평일
+ *   - 2 = 토요일
+ *   - 3 = 휴일/일요일
+ */
+export function dayTypeToWeekTag(dayType: DayType): 1 | 2 | 3 {
+  if (dayType === 'weekday') return 1;
+  if (dayType === 'saturday') return 2;
+  return 3;
+}
+
+/**
+ * `Direction`을 외부 endpoint의 상하행 코드로 매핑.
+ *
+ * 사용자 제공 메타데이터 (`SearchSTNTimeTableByIDService` `INOUT_TAG`):
+ *   - 1 = 상행/내선
+ *   - 2 = 하행/외선
+ */
+export function directionToInoutTag(direction: Direction): 1 | 2 {
+  return direction === 'up' ? 1 : 2;
+}

--- a/src/features/route/api/__tests__/StaticTimetableProvider.test.ts
+++ b/src/features/route/api/__tests__/StaticTimetableProvider.test.ts
@@ -1,0 +1,54 @@
+import { StaticTimetableProvider } from '../StaticTimetableProvider';
+
+describe('StaticTimetableProvider', () => {
+  const provider = new StaticTimetableProvider();
+  const KST_WEEKDAY_NOON = new Date('2026-06-09T03:00:00.000Z');
+
+  it('exposes source="static"', () => {
+    expect(provider.source).toBe('static');
+  });
+
+  it('getBoardableDepartureSync returns ok for supported lookup', () => {
+    const result = provider.getBoardableDepartureSync({
+      stationName: '시청',
+      line: '1',
+      direction: 'up',
+      from: KST_WEEKDAY_NOON,
+    });
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.departure.departureLabel).toMatch(/^\d{2}:\d{2}$/);
+  });
+
+  it('getBoardableDepartureSync returns no-timetable for bundang', () => {
+    const result = provider.getBoardableDepartureSync({
+      stationName: '왕십리',
+      line: 'bundang',
+      direction: 'up',
+      from: KST_WEEKDAY_NOON,
+    });
+    expect(result.status).toBe('no-timetable');
+  });
+
+  it('getBoardableDeparture async returns identical result to sync', async () => {
+    const params = {
+      stationName: '시청',
+      line: '1' as const,
+      direction: 'up' as const,
+      from: KST_WEEKDAY_NOON,
+    };
+    const syncResult = provider.getBoardableDepartureSync(params);
+    const asyncResult = await provider.getBoardableDeparture(params);
+    expect(asyncResult).toEqual(syncResult);
+  });
+
+  it('returns station-missing failure shape', () => {
+    const result = provider.getBoardableDepartureSync({
+      stationName: '없는역',
+      line: '1',
+      direction: 'up',
+      from: KST_WEEKDAY_NOON,
+    });
+    expect(result.status).toBe('station-missing');
+  });
+});

--- a/src/features/route/api/__tests__/TimetableProvider.test.ts
+++ b/src/features/route/api/__tests__/TimetableProvider.test.ts
@@ -1,0 +1,22 @@
+import { dayTypeToWeekTag, directionToInoutTag } from '../TimetableProvider';
+
+describe('TimetableProvider mappings (#1480 정정 2 — getTrainSch 1순위 cascade 후속 구현용)', () => {
+  describe('dayTypeToWeekTag', () => {
+    it.each([
+      ['weekday', 1],
+      ['saturday', 2],
+      ['sunday', 3],
+    ] as const)('%s → %d', (dayType, expected) => {
+      expect(dayTypeToWeekTag(dayType)).toBe(expected);
+    });
+  });
+
+  describe('directionToInoutTag', () => {
+    it.each([
+      ['up', 1],
+      ['down', 2],
+    ] as const)('%s → %d', (direction, expected) => {
+      expect(directionToInoutTag(direction)).toBe(expected);
+    });
+  });
+});

--- a/src/features/route/api/__tests__/factory.test.ts
+++ b/src/features/route/api/__tests__/factory.test.ts
@@ -1,0 +1,10 @@
+import { createTimetableProvider } from '../factory';
+import { StaticTimetableProvider } from '../StaticTimetableProvider';
+
+describe('createTimetableProvider', () => {
+  it('returns StaticTimetableProvider as 1차 default (#1480 1순위 — endpoint stub은 follow-up)', () => {
+    const provider = createTimetableProvider();
+    expect(provider).toBeInstanceOf(StaticTimetableProvider);
+    expect(provider.source).toBe('static');
+  });
+});

--- a/src/features/route/api/factory.ts
+++ b/src/features/route/api/factory.ts
@@ -1,0 +1,14 @@
+import type { TimetableProvider } from './TimetableProvider';
+import { StaticTimetableProvider } from './StaticTimetableProvider';
+
+/**
+ * TimetableProvider 1순위 선택자 (#1480).
+ *
+ * 본 PR 1차: 항상 정적 JSON Provider 반환 (외부 endpoint stub 미구현 단계).
+ *
+ * Follow-up sub에서 환경 변수(예: `EXPO_PUBLIC_USE_TRAIN_SCH=true`)로
+ * `SeoulTrainSchProvider` / `SeoulOpenApiTimetableProvider` swap.
+ */
+export function createTimetableProvider(): TimetableProvider {
+  return new StaticTimetableProvider();
+}

--- a/src/features/route/utils/__tests__/calculateBoardableTrainETA.test.ts
+++ b/src/features/route/utils/__tests__/calculateBoardableTrainETA.test.ts
@@ -1,0 +1,127 @@
+import {
+  calculateBoardableTrainETA,
+  decideBufferSeconds,
+  waitMinutesFromBoardable,
+} from '../calculateBoardableTrainETA';
+import type { BoardableDeparture } from '../../../../shared/utils/timetableShared';
+
+describe('decideBufferSeconds (#1480 정정 1 — transferTimes 기반 동적 분기)', () => {
+  it.each([
+    [0, 10],
+    [30, 10],
+    [60, 10],
+    [61, 20],
+    [120, 20],
+    [180, 20],
+    [181, 30],
+    [240, 30],
+    [300, 30],
+    [301, 60],
+    [480, 60],
+    [600, 60],
+  ])('walking %ds → buffer %ds', (walkingSeconds, expected) => {
+    expect(decideBufferSeconds(walkingSeconds)).toBe(expected);
+  });
+});
+
+describe('waitMinutesFromBoardable', () => {
+  it.each([
+    [0, 0],
+    [30, 1], // 30s → 1분 (Math.ceil)
+    [60, 1],
+    [61, 2],
+    [600, 10],
+    [630, 11], // 10.5분 → 11분
+  ])('%ds wait → %d minutes (ceil)', (waitSeconds, expectedMinutes) => {
+    const departure: BoardableDeparture = {
+      departureMinutes: 720,
+      departureLabel: '12:00',
+      waitSeconds,
+      missedCount: 0,
+      isNextDayFallback: false,
+    };
+    expect(waitMinutesFromBoardable(departure)).toBe(expectedMinutes);
+  });
+});
+
+describe('calculateBoardableTrainETA', () => {
+  // KST 평일 12:00 — 시청역 1호선 timetable에 다수 발차 보장.
+  const KST_WEEKDAY_NOON = new Date('2026-06-09T03:00:00.000Z');
+
+  it('returns ok with boardable departure for supported line/station/direction', () => {
+    const result = calculateBoardableTrainETA({
+      arrivalAt: KST_WEEKDAY_NOON,
+      bufferSeconds: 20,
+      nextLeg: { stationName: '시청', line: '1', direction: 'up' },
+    });
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.departure.waitSeconds).toBeGreaterThanOrEqual(0);
+    expect(result.effectiveArrivalAt.getTime()).toBe(
+      KST_WEEKDAY_NOON.getTime() + 20 * 1000,
+    );
+  });
+
+  it('returns no-timetable for unsupported line (bundang)', () => {
+    const result = calculateBoardableTrainETA({
+      arrivalAt: KST_WEEKDAY_NOON,
+      bufferSeconds: 10,
+      nextLeg: { stationName: '왕십리', line: 'bundang', direction: 'up' },
+    });
+    expect(result.status).toBe('no-timetable');
+  });
+
+  it('returns station-missing when station name not in timetable + logs debug', () => {
+    const result = calculateBoardableTrainETA({
+      arrivalAt: KST_WEEKDAY_NOON,
+      bufferSeconds: 10,
+      nextLeg: { stationName: '존재하지않는역', line: '1', direction: 'up' },
+    });
+    expect(result.status).toBe('station-missing');
+  });
+
+  it('returns day-type-unknown when arrivalAt is invalid Date', () => {
+    const result = calculateBoardableTrainETA({
+      arrivalAt: new Date('invalid'),
+      bufferSeconds: 10,
+      nextLeg: { stationName: '시청', line: '1', direction: 'up' },
+    });
+    expect(result.status).toBe('day-type-unknown');
+  });
+
+  it('user 시나리오 (#1480 본문) — 도착 1분 후 열차 = miss + 10분 후 boardable', () => {
+    // 정적 mock으로 시나리오 격리. line-1.json mock 후 module re-load.
+    jest.isolateModules(() => {
+      const SCENARIO = {
+        weekday: {
+          up: ['1201', '1210', '1220'], // 12:01 직전 도착(=12:00) 시 12:01은 buffer 적용 후 못 탐, 12:10이 boardable
+          down: ['1200'],
+        },
+        saturday: { up: ['1201'], down: ['1200'] },
+        sunday: { up: ['1201'], down: ['1200'] },
+      };
+      jest.doMock('../../../../data/timetables/line-1.json', () => ({
+        stations: { scenarioStation: SCENARIO },
+      }));
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { calculateBoardableTrainETA: fn } = require('../calculateBoardableTrainETA');
+
+      // 환승역 도착 = KST 12:00 (now + 도보 0초 가정). buffer 60초 + 도보 0초 추가 = effective 12:01.
+      // 12:01은 boardable? — boardable lookup은 >= 비교, 같은 분이면 boardable.
+      // 그러나 사용자 시나리오는 "1분 후 미탑승" — 즉 buffer가 더 커서 12:01을 못 타고 12:10이 boardable.
+      // KST 12:00 + buffer 120s = 12:02. 12:01은 missed, 12:10이 boardable (8분 = 480s 대기).
+      const result = fn({
+        arrivalAt: new Date('2026-06-09T03:00:00.000Z'), // KST 12:00
+        bufferSeconds: 120, // 2분 buffer
+        nextLeg: { stationName: 'scenarioStation', line: '1', direction: 'up' },
+      });
+      expect(result.status).toBe('ok');
+      if (result.status !== 'ok') return;
+      expect(result.departure.departureLabel).toBe('12:10');
+      expect(result.departure.missedCount).toBe(1); // 12:01 missed
+      // 12:02 effective → 12:10 boardable = 8분 = 480초
+      expect(result.departure.waitSeconds).toBe(8 * 60);
+    });
+    jest.resetModules();
+  });
+});

--- a/src/features/route/utils/__tests__/computeBoardableWaitsForRoute.test.ts
+++ b/src/features/route/utils/__tests__/computeBoardableWaitsForRoute.test.ts
@@ -132,7 +132,7 @@ describe('computeBoardableWaitsForRoute', () => {
     });
     expect(result.length).toBe(2);
     // 마지막 leg는 transferName=충무로 fallback → direction inference 실패 → null.
-    expect(result[result.length - 1]).toBeNull();
+    expect(result.at(-1)).toBeNull();
   });
 
   it('handles lookup failure status (no-timetable line) — element null', () => {
@@ -160,8 +160,9 @@ describe('totalBoardableWaitMinutes', () => {
   });
 
   it('skips null elements and sums seconds → minutes', () => {
+    // 60 + 120 + 30 = 210초 → 3.5분.
     expect(totalBoardableWaitMinutes([60, null, 120, null, 30])).toBe(
-      60 / 60 + 120 / 60 + 30 / 60,
+      (60 + 120 + 30) / 60,
     );
   });
 

--- a/src/features/route/utils/__tests__/computeBoardableWaitsForRoute.test.ts
+++ b/src/features/route/utils/__tests__/computeBoardableWaitsForRoute.test.ts
@@ -1,0 +1,171 @@
+import {
+  computeBoardableWaitsForRoute,
+  totalBoardableWaitMinutes,
+} from '../computeBoardableWaitsForRoute';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute,
+  makeTransferRoute,
+} from '../../../../testUtils/routeFixtures';
+
+// KST 평일 12:00 = UTC 03:00 — 실 timetable에 다수 발차 보장.
+const KST_WEEKDAY_NOON = new Date('2026-06-09T03:00:00.000Z');
+
+describe('computeBoardableWaitsForRoute', () => {
+  it('returns empty array for null route', () => {
+    const result = computeBoardableWaitsForRoute({
+      route: null,
+      startAt: KST_WEEKDAY_NOON,
+      initialWaitSeconds: 0,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array for direct route', () => {
+    const result = computeBoardableWaitsForRoute({
+      route: makeDirectRoute(5, '1'),
+      startAt: KST_WEEKDAY_NOON,
+      initialWaitSeconds: 0,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('single-transfer route — direction inference fails without destinationName', () => {
+    // transfer route + destinationName 미지정 시 transferName === transferName으로 direction
+    // inference 실패 → element=null (호출자 cascade가 DEFAULT_WAIT_MINUTES 적용).
+    const route = makeTransferRoute({
+      transferName: '왕십리',
+      fromLine: '2',
+      toLine: '5',
+      stopsToTransfer: 3,
+      stopsFromTransfer: 4,
+    });
+    const result = computeBoardableWaitsForRoute({
+      route,
+      startAt: KST_WEEKDAY_NOON,
+      initialWaitSeconds: 0,
+    });
+    expect(result.length).toBe(1);
+    expect(result[0]).toBeNull();
+  });
+
+  it('single-transfer route with destinationName — direction inference succeeds', () => {
+    // 3호선 종로3가 → 충무로(=down 방향). 3호선은 단조 화이트리스트(low=대화, high=오금) 안.
+    const route = makeTransferRoute({
+      transferName: '종로3가',
+      fromLine: '1',
+      toLine: '3',
+      stopsToTransfer: 2,
+      stopsFromTransfer: 1,
+    });
+    const result = computeBoardableWaitsForRoute({
+      route,
+      startAt: KST_WEEKDAY_NOON,
+      initialWaitSeconds: 0,
+      destinationName: '충무로',
+    });
+    expect(result.length).toBe(1);
+    // 3호선 종로3가 12:00 직후 first boardable 존재 → number.
+    expect(typeof result[0]).toBe('number');
+    expect(result[0]).toBeGreaterThanOrEqual(0);
+  });
+
+  it('multi-transfer route — each leg gets boardable wait', () => {
+    // 1호선 시청 → 종로3가(3호선 환승) → 충무로(4호선 환승) → 동대문(4호선 도착).
+    // 1호선 시청 → 종로3가 환승 → 3호선 종로3가 → 충무로 환승 → 4호선 충무로 → 4호선 동대문.
+    // 본 fixture는 실 timetable lookup으로 검증 (단조 노선 + 실 station name).
+    const route = makeMultiTransferRoute({
+      transfers: [
+        { transferName: '종로3가', fromLine: '1', toLine: '3', stopsToTransfer: 2 },
+        { transferName: '충무로', fromLine: '3', toLine: '4', stopsToTransfer: 1 },
+      ],
+      stopsAfterLastTransfer: 2,
+    });
+    const result = computeBoardableWaitsForRoute({
+      route,
+      startAt: KST_WEEKDAY_NOON,
+      initialWaitSeconds: 0,
+      destinationName: '동대문',
+    });
+    expect(result.length).toBe(2);
+    // 각 leg는 number 또는 null. 단조 화이트리스트(1,3,4)에 있어 inference 성공 기대.
+    for (const wait of result) {
+      // 실 timetable lookup이 성공해야 number — 정상 case는 number.
+      expect(wait === null || typeof wait === 'number').toBe(true);
+    }
+  });
+
+  it('multi-transfer with unmonotonic line (2호선 순환) — leg 1은 null', () => {
+    // 5호선 → 2호선 환승 → 7호선 도착. 2호선은 단조 화이트리스트 밖 (순환) → direction null.
+    const route = makeMultiTransferRoute({
+      transfers: [
+        { transferName: '왕십리', fromLine: '5', toLine: '2', stopsToTransfer: 2 },
+        { transferName: '대림', fromLine: '2', toLine: '7', stopsToTransfer: 3 },
+      ],
+      stopsAfterLastTransfer: 1,
+    });
+    const result = computeBoardableWaitsForRoute({
+      route,
+      startAt: KST_WEEKDAY_NOON,
+      initialWaitSeconds: 0,
+      destinationName: '청담',
+    });
+    expect(result.length).toBe(2);
+    // 첫 leg: 2호선 왕십리. nextEndName=대림 — 둘 다 2호선 단조 화이트리스트 밖 → direction null → element null.
+    expect(result[0]).toBeNull();
+  });
+
+  it('multi-transfer without destinationName — last leg falls back to transferName', () => {
+    // 마지막 leg의 nextEndName이 자기 transferName과 같아져 direction inference null.
+    const route = makeMultiTransferRoute({
+      transfers: [
+        { transferName: '종로3가', fromLine: '1', toLine: '3', stopsToTransfer: 2 },
+        { transferName: '충무로', fromLine: '3', toLine: '4', stopsToTransfer: 1 },
+      ],
+      stopsAfterLastTransfer: 2,
+    });
+    const result = computeBoardableWaitsForRoute({
+      route,
+      startAt: KST_WEEKDAY_NOON,
+      initialWaitSeconds: 0,
+      // destinationName 미지정
+    });
+    expect(result.length).toBe(2);
+    // 마지막 leg는 transferName=충무로 fallback → direction inference 실패 → null.
+    expect(result[result.length - 1]).toBeNull();
+  });
+
+  it('handles lookup failure status (no-timetable line) — element null', () => {
+    // bundang은 timetable 부재 노선. fromLine은 아무거나, toLine만 bundang.
+    const route = makeMultiTransferRoute({
+      transfers: [
+        { transferName: '왕십리', fromLine: '2', toLine: 'bundang', stopsToTransfer: 2 },
+      ],
+      stopsAfterLastTransfer: 3,
+    });
+    const result = computeBoardableWaitsForRoute({
+      route,
+      startAt: KST_WEEKDAY_NOON,
+      initialWaitSeconds: 0,
+      destinationName: '서울숲',
+    });
+    expect(result.length).toBe(1);
+    expect(result[0]).toBeNull();
+  });
+});
+
+describe('totalBoardableWaitMinutes', () => {
+  it('returns 0 for empty list', () => {
+    expect(totalBoardableWaitMinutes([])).toBe(0);
+  });
+
+  it('skips null elements and sums seconds → minutes', () => {
+    expect(totalBoardableWaitMinutes([60, null, 120, null, 30])).toBe(
+      60 / 60 + 120 / 60 + 30 / 60,
+    );
+  });
+
+  it('returns 0 when all elements are null', () => {
+    expect(totalBoardableWaitMinutes([null, null, null])).toBe(0);
+  });
+});

--- a/src/features/route/utils/calculateBoardableTrainETA.ts
+++ b/src/features/route/utils/calculateBoardableTrainETA.ts
@@ -1,0 +1,119 @@
+import type { LineNumber } from '../../../shared/types/station';
+import {
+  findBoardableDeparture,
+  type BoardableDeparture,
+  type DepartureLookupResult,
+  type Direction,
+} from '../../../shared/utils/timetableShared';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('BoardableTrainETA');
+
+/**
+ * 환승 boardable train ETA 알고리즘 (#1480).
+ *
+ * 사용자 시나리오 (PR body 예시):
+ *   A역 → 환승 도보 3분 → B역. B역 도착 시각 1분 후 열차 = 못 탐. 다음 열차 10분 후 = boardable.
+ *
+ * 본 알고리즘이 받아 처리하는 시간 구간:
+ *   환승역 도착 시각 (= now + 도보 시간 + buffer) 이후 첫 boardable 열차 lookup
+ *
+ * buffer 결정은 **호출자 책임**. `decideBufferSeconds`를 호출자가 적용해 doorway/플랫폼 마진을
+ * 도보 시간에 비례해 산출 후 본 함수 인자로 전달한다 (#1480 정정 — buffer 30s 상수 X).
+ *
+ * 1~9호선 외 노선은 `findBoardableDeparture`가 `status: 'no-timetable'` 반환 — 호출자가
+ * 정적 ETA fallback. station alias mismatch는 `status: 'station-missing'`.
+ */
+
+const SECONDS_PER_MINUTE = 60;
+const MS_PER_SECOND = 1000;
+
+/** 도보 시간(초) → buffer(초) — 짧으면 작게, 길면 크게 (사용자 명시 정정). */
+const BUFFER_BREAKPOINTS = [
+  { maxWalkingSeconds: 60, bufferSeconds: 10 },
+  { maxWalkingSeconds: 180, bufferSeconds: 20 },
+  { maxWalkingSeconds: 300, bufferSeconds: 30 },
+] as const;
+const BUFFER_DEFAULT_LONG_WALK_SECONDS = 60;
+
+/**
+ * 환승 도보 시간(초) → 플랫폼/문 buffer(초).
+ *
+ * 4단계 분기 (≤60s: 10s / ≤180s: 20s / ≤300s: 30s / 그 외: 60s).
+ * 명시적 breakpoint는 디버깅 시 "어느 슬롯에 들어갔나" 추적이 쉬워 비례식보다 우선.
+ */
+export function decideBufferSeconds(transferWalkingSeconds: number): number {
+  for (const breakpoint of BUFFER_BREAKPOINTS) {
+    if (transferWalkingSeconds <= breakpoint.maxWalkingSeconds) {
+      return breakpoint.bufferSeconds;
+    }
+  }
+  return BUFFER_DEFAULT_LONG_WALK_SECONDS;
+}
+
+export interface BoardableTrainETAParams {
+  /** 환승역 도착 예상 시각 (= now + 도보 시간 — buffer는 본 함수가 더해서 환산). */
+  arrivalAt: Date;
+  /** 호출자가 `decideBufferSeconds`로 산출한 buffer(초). */
+  bufferSeconds: number;
+  /** 다음 leg의 lookup 좌표. */
+  nextLeg: {
+    stationName: string;
+    line: LineNumber;
+    direction: Direction;
+  };
+}
+
+export type BoardableTrainETAResult =
+  | {
+      status: 'ok';
+      /** boardable 열차 출발 시각 + 대기 + miss count (timetableShared 원형). */
+      departure: BoardableDeparture;
+      /** 환승역 도착(= arrivalAt + buffer) 시각. 디버깅/표시용. */
+      effectiveArrivalAt: Date;
+    }
+  | {
+      status:
+        | 'no-timetable' // 1~9호선 외 노선 → 호출자가 정적 ETA fallback
+        | 'station-missing' // alias 불일치 — 호출자가 logger.debug 후 fallback
+        | 'day-type-unknown' // Hermes weekday part 누락 (#1088) — fallback
+        | 'no-departures'; // 막차 + 다음날 첫차도 없음 (비정상) — fallback
+    };
+
+export function calculateBoardableTrainETA(
+  params: BoardableTrainETAParams,
+): BoardableTrainETAResult {
+  const { arrivalAt, bufferSeconds, nextLeg } = params;
+
+  // 환승역에서 다음 열차를 탈 수 있는 가장 빠른 시각.
+  const effectiveArrivalAt = new Date(arrivalAt.getTime() + bufferSeconds * MS_PER_SECOND);
+
+  const lookupResult: DepartureLookupResult = findBoardableDeparture({
+    stationName: nextLeg.stationName,
+    line: nextLeg.line,
+    direction: nextLeg.direction,
+    from: effectiveArrivalAt,
+  });
+
+  if (lookupResult.status !== 'ok') {
+    if (lookupResult.status === 'station-missing') {
+      logger.debug(
+        `boardable lookup miss: line=${nextLeg.line} station=${nextLeg.stationName} dir=${nextLeg.direction}`,
+      );
+    }
+    return { status: lookupResult.status };
+  }
+
+  return {
+    status: 'ok',
+    departure: lookupResult.departure,
+    effectiveArrivalAt,
+  };
+}
+
+/**
+ * 분 단위 helper — 외부에서 boardable 결과를 stationRoute 단위(travelMinutes 등)와 합산할 때 사용.
+ */
+export function waitMinutesFromBoardable(departure: BoardableDeparture): number {
+  return Math.ceil(departure.waitSeconds / SECONDS_PER_MINUTE);
+}

--- a/src/features/route/utils/computeBoardableWaitsForRoute.ts
+++ b/src/features/route/utils/computeBoardableWaitsForRoute.ts
@@ -1,0 +1,189 @@
+import type { Route, TransferSegment } from '../../../shared/utils/stationRoute';
+import { getTransferSeconds } from '../../../shared/utils/transferTimes';
+import { resolveTravelDirection } from './travelDirection';
+import {
+  calculateBoardableTrainETA,
+  decideBufferSeconds,
+} from './calculateBoardableTrainETA';
+import type { LineNumber } from '../../../shared/types/station';
+
+/**
+ * 환승 leg별 boardable train 대기 시간(초) 리스트를 산출 (#1480).
+ *
+ * `stationRoute.calculateStaticETA`의 `timetableBoardableWaitSecondsByLeg` 옵션에 직접 주입.
+ * 실시간 arrival 정보가 없는 trip(예: production silent push 인입 전 또는 막차 직후)에서
+ * 환승 후 다음 열차 대기를 실측 시간표 기반으로 보강.
+ *
+ * 결과는 transfers 순서. element가 `null`이면 다음 fallback (`DEFAULT_WAIT_MINUTES`).
+ */
+
+const SECONDS_PER_MINUTE = 60;
+
+export interface RouteBoardableWaitParams {
+  route: Route;
+  /** 출발 trip 시작 기준 시각 (now). */
+  startAt: Date;
+  /**
+   * 출발역 → 첫 환승역까지 걸리는 시간(초). 호출자가 실시간 arrival을 받았다면 거기서 산출,
+   * 아니면 stationRoute가 가진 정적 segment 시간 활용.
+   */
+  initialWaitSeconds: number;
+  /**
+   * 최종 도착역 이름 — 마지막 leg direction inference 보강.
+   * 미지정 시 마지막 leg는 direction inference 실패로 null 반환 (호출자 cascade가 DEFAULT 적용).
+   */
+  destinationName?: string;
+}
+
+/**
+ * 결과 element 의미:
+ *   - number: timetable lookup 성공 (waitSeconds = boardable departure - effectiveArrival)
+ *   - null:   timetable 부재(1~9호선 외) / station alias 불일치 / dayType 불명 / 막차+첫차 모두 미존재
+ *
+ * 호출자(예: `calculateStaticETA`)는 null이면 `DEFAULT_WAIT_MINUTES` fallback.
+ */
+export function computeBoardableWaitsForRoute(
+  params: RouteBoardableWaitParams,
+): Array<number | null> {
+  const { route, startAt, initialWaitSeconds, destinationName } = params;
+  if (!route || route.type === 'direct') return [];
+
+  const segments = collectTransferSegments(route, destinationName);
+  /* istanbul ignore if -- 위 if !route || route.type === 'direct'에서 이미 빈 경로를 걸러, transfer/
+     multi-transfer는 collectTransferSegments가 최소 1개 segment 반환. 안전망. */
+  if (segments.length === 0) return [];
+
+  const result: Array<number | null> = [];
+  // 환승역 도착 시각은 (이전 leg 끝 시각 + 환승 도보 시간). 누적해서 진행.
+  let cursorSeconds = initialWaitSeconds;
+
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i];
+    const cumulativeArrivalAt = new Date(
+      startAt.getTime() + cursorSeconds * 1000 + segment.secondsToTransfer * 1000,
+    );
+    const transferWalkingSeconds = getTransferSeconds(
+      segment.fromLine,
+      segment.toLine,
+      segment.transferName,
+    );
+    const bufferSeconds = decideBufferSeconds(transferWalkingSeconds);
+
+    const direction = resolveTravelDirection(
+      segment.toLine,
+      segment.transferName,
+      segment.nextEndName,
+    )?.direction ?? null;
+
+    if (direction === null) {
+      // 단조 노선 화이트리스트(2호선 순환 등) 밖이면 boardable lookup 불가 → 다음 fallback.
+      result.push(null);
+      // 다음 leg 계산을 위해 도착 시각만 갱신 — boardable wait는 모름.
+      cursorSeconds +=
+        segment.secondsToTransfer + transferWalkingSeconds + bufferSeconds;
+      continue;
+    }
+
+    const lookup = calculateBoardableTrainETA({
+      arrivalAt: cumulativeArrivalAt,
+      bufferSeconds: bufferSeconds + transferWalkingSeconds,
+      nextLeg: {
+        stationName: segment.transferName,
+        line: segment.toLine,
+        direction,
+      },
+    });
+
+    if (lookup.status === 'ok') {
+      const waitSeconds = lookup.departure.waitSeconds;
+      result.push(waitSeconds);
+      cursorSeconds +=
+        segment.secondsToTransfer +
+        transferWalkingSeconds +
+        bufferSeconds +
+        waitSeconds;
+    } else {
+      result.push(null);
+      cursorSeconds +=
+        segment.secondsToTransfer + transferWalkingSeconds + bufferSeconds;
+    }
+  }
+
+  return result;
+}
+
+interface TransferLegContext {
+  /** 이전 leg 노선. */
+  fromLine: LineNumber;
+  /** 다음 leg 노선. */
+  toLine: LineNumber;
+  /** 환승역 이름 (fromLine 측 표기). */
+  transferName: string;
+  /** 이전 leg에서 본 환승역까지 운행 시간(초). */
+  secondsToTransfer: number;
+  /** 다음 leg의 종착(=다음 환승역 or 최종 목적지) 이름 — direction inference 용. */
+  nextEndName: string;
+}
+
+function collectTransferSegments(
+  route: NonNullable<Route>,
+  destinationName: string | undefined,
+): TransferLegContext[] {
+  /* istanbul ignore if -- caller(computeBoardableWaitsForRoute)가 direct를 미리 걸러 호출하지 않는다.
+     TS narrowing을 위한 안전망. */
+  if (route.type === 'direct') return [];
+  if (route.type === 'transfer') {
+    // 단일 환승 — destinationName이 주어지면 direction inference 가능. 미지정 시 transferName으로
+    // 두면 resolveTravelDirection이 fromIdx === toIdx로 null 반환 → 호출자 cascade가 처리.
+    return [
+      {
+        fromLine: route.fromLine,
+        toLine: route.toLine,
+        transferName: route.transferName,
+        secondsToTransfer: route.secondsToTransfer,
+        nextEndName: destinationName ?? route.transferName,
+      },
+    ];
+  }
+
+  // multi-transfer — transfers 배열 순회. 각 leg의 nextEndName은 다음 transfer의 transferName.
+  // 마지막 leg는 destinationName 활용 (없으면 transferName fallback).
+  const segments: TransferLegContext[] = [];
+  const { transfers } = route;
+  for (let i = 0; i < transfers.length; i++) {
+    const current = transfers[i];
+    const nextEndName = computeNextEndName(transfers, i, destinationName);
+    segments.push({
+      fromLine: current.fromLine,
+      toLine: current.toLine,
+      transferName: current.transferName,
+      secondsToTransfer: current.secondsToTransfer,
+      nextEndName,
+    });
+  }
+  return segments;
+}
+
+function computeNextEndName(
+  transfers: readonly TransferSegment[],
+  currentIdx: number,
+  destinationName: string | undefined,
+): string {
+  const next = transfers[currentIdx + 1];
+  if (next) return next.transferName;
+  // 마지막 환승 — 다음 leg는 최종 도착역까지. destinationName이 있으면 사용, 없으면 transferName
+  // fallback (resolveTravelDirection이 fromIdx === toIdx로 null 반환, 호출자 cascade 처리).
+  return destinationName ?? transfers[currentIdx].transferName;
+}
+
+/** 분 단위 helper — calculateStaticETA에 직접 주입할 때 디버깅용 표시. */
+export function totalBoardableWaitMinutes(
+  waitSecondsList: ReadonlyArray<number | null>,
+): number {
+  let total = 0;
+  for (const seconds of waitSecondsList) {
+    if (seconds === null) continue;
+    total += seconds / SECONDS_PER_MINUTE;
+  }
+  return total;
+}

--- a/src/features/route/utils/computeBoardableWaitsForRoute.ts
+++ b/src/features/route/utils/computeBoardableWaitsForRoute.ts
@@ -57,8 +57,7 @@ export function computeBoardableWaitsForRoute(
   // 환승역 도착 시각은 (이전 leg 끝 시각 + 환승 도보 시간). 누적해서 진행.
   let cursorSeconds = initialWaitSeconds;
 
-  for (let i = 0; i < segments.length; i++) {
-    const segment = segments[i];
+  for (const segment of segments) {
     const cumulativeArrivalAt = new Date(
       startAt.getTime() + cursorSeconds * 1000 + segment.secondsToTransfer * 1000,
     );

--- a/src/shared/utils/__tests__/stationRoute.test.ts
+++ b/src/shared/utils/__tests__/stationRoute.test.ts
@@ -819,6 +819,152 @@ describe('calculateStaticETA — 환승 후 다음 열차 대기 (#778)', () => 
   });
 });
 
+describe('calculateStaticETA — timetable boardable wait fallback (#1480)', () => {
+  const NOW = 1_700_000_000_000;
+
+  it('arrivalsAtTransfers 누락 + timetableBoardableWaitSecondsByLeg 제공 시 timetable 값 사용', () => {
+    const route: TransferRoute = makeTransferRoute({
+      transferName: '교대(법원.검찰청)', fromLine: '2', toLine: '3',
+      stopsToTransfer: 1, stopsFromTransfer: 5,
+    });
+    // 출발 3분 + 환승 leg = round(240/60)=4분 (timetable) + travel
+    const t = getTransferSeconds('2', '3', '교대');
+    const travel = Math.round((1 + 5) * 2 + t / 60);
+    expect(
+      calculateStaticETA(route, {
+        timetableBoardableWaitSecondsByLeg: [240],
+        nowMs: NOW,
+      }),
+    ).toBe(3 + 4 + travel);
+  });
+
+  it('arrivalsAtTransfers fresh > timetable cascade (실시간 데이터 우선)', () => {
+    const route: TransferRoute = makeTransferRoute({
+      transferName: '교대(법원.검찰청)', fromLine: '2', toLine: '3',
+      stopsToTransfer: 1, stopsFromTransfer: 5,
+    });
+    // arrivalsAtTransfers fresh = 60s (=1분), timetable = 600s (=10분).
+    // 실시간 우선 → 1분.
+    const t = getTransferSeconds('2', '3', '교대');
+    const travel = Math.round((1 + 5) * 2 + t / 60);
+    expect(
+      calculateStaticETA(route, {
+        arrivalsAtTransfers: [{ arrivalSeconds: 60, receivedAtMs: NOW }],
+        timetableBoardableWaitSecondsByLeg: [600],
+        nowMs: NOW,
+      }),
+    ).toBe(3 + 1 + travel);
+  });
+
+  it('arrivalsAtTransfers stale → timetable fallback (둘 다 있을 때)', () => {
+    const route: TransferRoute = makeTransferRoute({
+      transferName: '교대(법원.검찰청)', fromLine: '2', toLine: '3',
+      stopsToTransfer: 1, stopsFromTransfer: 5,
+    });
+    // 실시간 stale → timetable 240s (=4분).
+    const t = getTransferSeconds('2', '3', '교대');
+    const travel = Math.round((1 + 5) * 2 + t / 60);
+    expect(
+      calculateStaticETA(route, {
+        arrivalsAtTransfers: [{ arrivalSeconds: 300, receivedAtMs: NOW - 60_001 }],
+        timetableBoardableWaitSecondsByLeg: [240],
+        nowMs: NOW,
+      }),
+    ).toBe(3 + 4 + travel);
+  });
+
+  it('timetable element null → DEFAULT_WAIT_MINUTES fallback', () => {
+    const route: TransferRoute = makeTransferRoute({
+      transferName: '교대(법원.검찰청)', fromLine: '2', toLine: '3',
+      stopsToTransfer: 1, stopsFromTransfer: 5,
+    });
+    const t = getTransferSeconds('2', '3', '교대');
+    const travel = Math.round((1 + 5) * 2 + t / 60);
+    // timetable null → 3분 fallback.
+    expect(
+      calculateStaticETA(route, {
+        timetableBoardableWaitSecondsByLeg: [null],
+        nowMs: NOW,
+      }),
+    ).toBe(3 + 3 + travel);
+  });
+
+  it('timetable element 음수 → DEFAULT_WAIT_MINUTES fallback (방어)', () => {
+    const route: TransferRoute = makeTransferRoute({
+      transferName: '교대(법원.검찰청)', fromLine: '2', toLine: '3',
+      stopsToTransfer: 1, stopsFromTransfer: 5,
+    });
+    const t = getTransferSeconds('2', '3', '교대');
+    const travel = Math.round((1 + 5) * 2 + t / 60);
+    expect(
+      calculateStaticETA(route, {
+        timetableBoardableWaitSecondsByLeg: [-10],
+        nowMs: NOW,
+      }),
+    ).toBe(3 + 3 + travel);
+  });
+
+  it('arrival.arrivalSeconds 음수 → 다음 fallback (isFreshArrival 가드)', () => {
+    const route: TransferRoute = makeTransferRoute({
+      transferName: '교대(법원.검찰청)', fromLine: '2', toLine: '3',
+      stopsToTransfer: 1, stopsFromTransfer: 5,
+    });
+    const t = getTransferSeconds('2', '3', '교대');
+    const travel = Math.round((1 + 5) * 2 + t / 60);
+    // 음수 arrivalSeconds (비정상) → !isFresh → timetable 사용.
+    expect(
+      calculateStaticETA(route, {
+        arrivalsAtTransfers: [{ arrivalSeconds: -10, receivedAtMs: NOW }],
+        timetableBoardableWaitSecondsByLeg: [180],
+        nowMs: NOW,
+      }),
+    ).toBe(3 + 3 + travel);
+  });
+
+  it('arrival.receivedAtMs=0 (mock) → !isFresh → timetable 사용', () => {
+    const route: TransferRoute = makeTransferRoute({
+      transferName: '교대(법원.검찰청)', fromLine: '2', toLine: '3',
+      stopsToTransfer: 1, stopsFromTransfer: 5,
+    });
+    const t = getTransferSeconds('2', '3', '교대');
+    const travel = Math.round((1 + 5) * 2 + t / 60);
+    expect(
+      calculateStaticETA(route, {
+        arrivalsAtTransfers: [{ arrivalSeconds: 60, receivedAtMs: 0 }],
+        timetableBoardableWaitSecondsByLeg: [180],
+        nowMs: NOW,
+      }),
+    ).toBe(3 + 3 + travel);
+  });
+
+  it('multi-transfer mixed cascade — leg0 실시간, leg1 timetable, leg2 fallback', () => {
+    const route: MultiTransferRoute = makeMultiTransferRoute({
+      transfers: [
+        { transferName: '잠실(송파구청)', fromLine: '8', toLine: '2', stopsToTransfer: 3 },
+        { transferName: '왕십리', fromLine: '2', toLine: '5', stopsToTransfer: 4 },
+        { transferName: '시청', fromLine: '5', toLine: '1', stopsToTransfer: 2 },
+      ],
+      stopsAfterLastTransfer: 4,
+    });
+    // leg0: 실시간 60s = 1분. leg1: timetable 240s = 4분. leg2: 실시간 stale + timetable null = 3분 fallback.
+    const t1 = getTransferSeconds('8', '2', '잠실');
+    const t2 = getTransferSeconds('2', '5', '왕십리');
+    const t3 = getTransferSeconds('5', '1', '시청');
+    const travel = Math.round((3 + 4 + 2 + 4) * 2 + (t1 + t2 + t3) / 60);
+    expect(
+      calculateStaticETA(route, {
+        arrivalsAtTransfers: [
+          { arrivalSeconds: 60, receivedAtMs: NOW },
+          null,
+          { arrivalSeconds: 600, receivedAtMs: NOW - 60_001 }, // stale
+        ],
+        timetableBoardableWaitSecondsByLeg: [600, 240, null],
+        nowMs: NOW,
+      }),
+    ).toBe(3 + 1 + 4 + 3 + travel);
+  });
+});
+
 describe('구간별 실측 운행시간 반영 (#655)', () => {
   // 종로5가(1-030)→종각(1-032): 두 hop 모두 실측 90초 → 2 stops지만 180초.
   // 균일 fallback(stops*120=240초)보다 1분 짧게 산출되어 실측 데이터 사용을 검증한다.

--- a/src/shared/utils/__tests__/stationRoute.test.ts
+++ b/src/shared/utils/__tests__/stationRoute.test.ts
@@ -821,120 +821,77 @@ describe('calculateStaticETA — 환승 후 다음 열차 대기 (#778)', () => 
 
 describe('calculateStaticETA — timetable boardable wait fallback (#1480)', () => {
   const NOW = 1_700_000_000_000;
-
-  it('arrivalsAtTransfers 누락 + timetableBoardableWaitSecondsByLeg 제공 시 timetable 값 사용', () => {
-    const route: TransferRoute = makeTransferRoute({
+  // 모든 단일 환승 케이스 공통: 교대 2→3호선, stops 1→5. row factory로 중복 제거.
+  const buildRoute = (): TransferRoute =>
+    makeTransferRoute({
       transferName: '교대(법원.검찰청)', fromLine: '2', toLine: '3',
       stopsToTransfer: 1, stopsFromTransfer: 5,
     });
-    // 출발 3분 + 환승 leg = round(240/60)=4분 (timetable) + travel
+  const travelMinutes = (): number => {
     const t = getTransferSeconds('2', '3', '교대');
-    const travel = Math.round((1 + 5) * 2 + t / 60);
-    expect(
-      calculateStaticETA(route, {
-        timetableBoardableWaitSecondsByLeg: [240],
-        nowMs: NOW,
-      }),
-    ).toBe(3 + 4 + travel);
-  });
+    return Math.round((1 + 5) * 2 + t / 60);
+  };
 
-  it('arrivalsAtTransfers fresh > timetable cascade (실시간 데이터 우선)', () => {
-    const route: TransferRoute = makeTransferRoute({
-      transferName: '교대(법원.검찰청)', fromLine: '2', toLine: '3',
-      stopsToTransfer: 1, stopsFromTransfer: 5,
-    });
-    // arrivalsAtTransfers fresh = 60s (=1분), timetable = 600s (=10분).
-    // 실시간 우선 → 1분.
-    const t = getTransferSeconds('2', '3', '교대');
-    const travel = Math.round((1 + 5) * 2 + t / 60);
-    expect(
-      calculateStaticETA(route, {
+  type Opts = Parameters<typeof calculateStaticETA>[1];
+  type Row = readonly [label: string, opts: Opts, expectedWaitMinutes: number];
+
+  // initial=3분(default) + waitMinutes(leg별 합) + travel.
+  const cases: ReadonlyArray<Row> = [
+    [
+      'timetable only → timetable 값 사용',
+      { timetableBoardableWaitSecondsByLeg: [240], nowMs: NOW },
+      4,
+    ],
+    [
+      'arrivalsAtTransfers fresh > timetable cascade',
+      {
         arrivalsAtTransfers: [{ arrivalSeconds: 60, receivedAtMs: NOW }],
         timetableBoardableWaitSecondsByLeg: [600],
         nowMs: NOW,
-      }),
-    ).toBe(3 + 1 + travel);
-  });
-
-  it('arrivalsAtTransfers stale → timetable fallback (둘 다 있을 때)', () => {
-    const route: TransferRoute = makeTransferRoute({
-      transferName: '교대(법원.검찰청)', fromLine: '2', toLine: '3',
-      stopsToTransfer: 1, stopsFromTransfer: 5,
-    });
-    // 실시간 stale → timetable 240s (=4분).
-    const t = getTransferSeconds('2', '3', '교대');
-    const travel = Math.round((1 + 5) * 2 + t / 60);
-    expect(
-      calculateStaticETA(route, {
+      },
+      1,
+    ],
+    [
+      'arrivalsAtTransfers stale → timetable fallback',
+      {
         arrivalsAtTransfers: [{ arrivalSeconds: 300, receivedAtMs: NOW - 60_001 }],
         timetableBoardableWaitSecondsByLeg: [240],
         nowMs: NOW,
-      }),
-    ).toBe(3 + 4 + travel);
-  });
-
-  it('timetable element null → DEFAULT_WAIT_MINUTES fallback', () => {
-    const route: TransferRoute = makeTransferRoute({
-      transferName: '교대(법원.검찰청)', fromLine: '2', toLine: '3',
-      stopsToTransfer: 1, stopsFromTransfer: 5,
-    });
-    const t = getTransferSeconds('2', '3', '교대');
-    const travel = Math.round((1 + 5) * 2 + t / 60);
-    // timetable null → 3분 fallback.
-    expect(
-      calculateStaticETA(route, {
-        timetableBoardableWaitSecondsByLeg: [null],
-        nowMs: NOW,
-      }),
-    ).toBe(3 + 3 + travel);
-  });
-
-  it('timetable element 음수 → DEFAULT_WAIT_MINUTES fallback (방어)', () => {
-    const route: TransferRoute = makeTransferRoute({
-      transferName: '교대(법원.검찰청)', fromLine: '2', toLine: '3',
-      stopsToTransfer: 1, stopsFromTransfer: 5,
-    });
-    const t = getTransferSeconds('2', '3', '교대');
-    const travel = Math.round((1 + 5) * 2 + t / 60);
-    expect(
-      calculateStaticETA(route, {
-        timetableBoardableWaitSecondsByLeg: [-10],
-        nowMs: NOW,
-      }),
-    ).toBe(3 + 3 + travel);
-  });
-
-  it('arrival.arrivalSeconds 음수 → 다음 fallback (isFreshArrival 가드)', () => {
-    const route: TransferRoute = makeTransferRoute({
-      transferName: '교대(법원.검찰청)', fromLine: '2', toLine: '3',
-      stopsToTransfer: 1, stopsFromTransfer: 5,
-    });
-    const t = getTransferSeconds('2', '3', '교대');
-    const travel = Math.round((1 + 5) * 2 + t / 60);
-    // 음수 arrivalSeconds (비정상) → !isFresh → timetable 사용.
-    expect(
-      calculateStaticETA(route, {
+      },
+      4,
+    ],
+    [
+      'timetable element null → DEFAULT_WAIT_MINUTES fallback',
+      { timetableBoardableWaitSecondsByLeg: [null], nowMs: NOW },
+      3,
+    ],
+    [
+      'timetable element 음수 → DEFAULT_WAIT_MINUTES fallback',
+      { timetableBoardableWaitSecondsByLeg: [-10], nowMs: NOW },
+      3,
+    ],
+    [
+      'arrival.arrivalSeconds 음수 → !isFresh → timetable 사용',
+      {
         arrivalsAtTransfers: [{ arrivalSeconds: -10, receivedAtMs: NOW }],
         timetableBoardableWaitSecondsByLeg: [180],
         nowMs: NOW,
-      }),
-    ).toBe(3 + 3 + travel);
-  });
-
-  it('arrival.receivedAtMs=0 (mock) → !isFresh → timetable 사용', () => {
-    const route: TransferRoute = makeTransferRoute({
-      transferName: '교대(법원.검찰청)', fromLine: '2', toLine: '3',
-      stopsToTransfer: 1, stopsFromTransfer: 5,
-    });
-    const t = getTransferSeconds('2', '3', '교대');
-    const travel = Math.round((1 + 5) * 2 + t / 60);
-    expect(
-      calculateStaticETA(route, {
+      },
+      3,
+    ],
+    [
+      'arrival.receivedAtMs=0 (mock) → !isFresh → timetable 사용',
+      {
         arrivalsAtTransfers: [{ arrivalSeconds: 60, receivedAtMs: 0 }],
         timetableBoardableWaitSecondsByLeg: [180],
         nowMs: NOW,
-      }),
-    ).toBe(3 + 3 + travel);
+      },
+      3,
+    ],
+  ];
+
+  it.each(cases)('%s', (_label, opts, waitMinutes) => {
+    expect(calculateStaticETA(buildRoute(), opts)).toBe(3 + waitMinutes + travelMinutes());
   });
 
   it('multi-transfer mixed cascade — leg0 실시간, leg1 timetable, leg2 fallback', () => {

--- a/src/shared/utils/__tests__/timetableShared.test.ts
+++ b/src/shared/utils/__tests__/timetableShared.test.ts
@@ -1,0 +1,254 @@
+import {
+  classifyDayTypeKst,
+  findBoardableDeparture,
+  formatMinutesAsHHmm,
+  hasTimetable,
+  nextDayType,
+} from '../timetableShared';
+
+// KST 시간대 명시 — UTC+9 (KST 정오 = UTC 03:00). 본 테스트는 stations.json/timetables JSON에
+// 의존하지 않고 module mock으로 격리해 데이터 drift에 강하게 작성한다.
+
+const KST_WEEKDAY_NOON = new Date('2026-06-09T03:00:00.000Z'); // 화요일 12:00 KST
+const KST_SATURDAY_NOON = new Date('2026-06-13T03:00:00.000Z'); // 토요일 12:00 KST
+const KST_SUNDAY_NOON = new Date('2026-06-14T03:00:00.000Z'); // 일요일 12:00 KST
+
+describe('timetableShared - classifyDayTypeKst', () => {
+  it.each([
+    [KST_WEEKDAY_NOON, 'weekday'],
+    [KST_SATURDAY_NOON, 'saturday'],
+    [KST_SUNDAY_NOON, 'sunday'],
+  ] as const)('classifies %s → %s', (date, expected) => {
+    expect(classifyDayTypeKst(date)).toBe(expected);
+  });
+
+  it('returns null when Intl weekday part is unavailable (#1088 regression guard)', () => {
+    // getWeekdayShort가 내부에서 try/catch로 null 처리하는 경로 — Date 대신 임의 object로 시뮬레이션.
+    // 실제로 Hermes에서 발생할 수 있는 weekday part 누락은 intlDateParts module이 흡수해 null 반환.
+    const wrappedDate = new Date('invalid-date'); // NaN getTime — Intl.DateTimeFormat이 throw
+    expect(classifyDayTypeKst(wrappedDate)).toBeNull();
+  });
+});
+
+describe('timetableShared - nextDayType', () => {
+  it.each([
+    ['weekday', 'saturday'],
+    ['saturday', 'sunday'],
+    ['sunday', 'weekday'],
+  ] as const)('rolls %s → %s', (current, expected) => {
+    expect(nextDayType(current)).toBe(expected);
+  });
+});
+
+describe('timetableShared - formatMinutesAsHHmm', () => {
+  it.each([
+    [0, '00:00'],
+    [60, '01:00'],
+    [600, '10:00'],
+    [1439, '23:59'],
+    [1440, '00:00'], // 24h+ — % 1440 정규화
+    [1500, '01:00'], // 25:00 → 01:00
+    [-30, '23:30'], // 음수도 graceful — 다음날 23:30로 wrap (clamp 미적용 케이스 가드)
+  ])('formats %d minutes → %s', (minutes, expected) => {
+    expect(formatMinutesAsHHmm(minutes)).toBe(expected);
+  });
+});
+
+describe('timetableShared - hasTimetable', () => {
+  it.each(['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const)(
+    'has timetable for line %s',
+    (line) => {
+      expect(hasTimetable(line)).toBe(true);
+    },
+  );
+
+  it.each(['bundang', 'airport', 'gyeongui', 'sinbundang'] as const)(
+    'does not have timetable for line %s',
+    (line) => {
+      expect(hasTimetable(line)).toBe(false);
+    },
+  );
+});
+
+describe('timetableShared - findBoardableDeparture', () => {
+  // 시청역 (1호선) 평일 12:00 KST 기준 — 시점 이후 첫 발차 lookup.
+  it('finds first departure at or after the reference time', () => {
+    const result = findBoardableDeparture({
+      stationName: '시청',
+      line: '1',
+      direction: 'up',
+      from: KST_WEEKDAY_NOON,
+    });
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    // 12:00 이후 발차는 12:00 시각 그 자체 또는 이후 정수 분.
+    expect(result.departure.departureMinutes).toBeGreaterThanOrEqual(720); // 12:00 = 720분
+    expect(result.departure.departureLabel).toMatch(/^\d{2}:\d{2}$/);
+    expect(result.departure.waitSeconds).toBeGreaterThanOrEqual(0);
+    expect(result.departure.missedCount).toBeGreaterThanOrEqual(0);
+    expect(result.departure.isNextDayFallback).toBe(false);
+  });
+
+  it('returns no-timetable for unsupported line (bundang, airport, etc.)', () => {
+    const result = findBoardableDeparture({
+      stationName: '왕십리',
+      line: 'bundang',
+      direction: 'up',
+      from: KST_WEEKDAY_NOON,
+    });
+    expect(result.status).toBe('no-timetable');
+  });
+
+  it('returns station-missing when station name not in timetable', () => {
+    const result = findBoardableDeparture({
+      stationName: '존재하지않는역',
+      line: '1',
+      direction: 'up',
+      from: KST_WEEKDAY_NOON,
+    });
+    expect(result.status).toBe('station-missing');
+  });
+
+  it('returns day-type-unknown when Date is invalid (#1088 guard)', () => {
+    const result = findBoardableDeparture({
+      stationName: '시청',
+      line: '1',
+      direction: 'up',
+      from: new Date('invalid'),
+    });
+    expect(result.status).toBe('day-type-unknown');
+  });
+
+  it('counts missed departures before reference time', () => {
+    // 평일 정오에는 새벽~정오 사이 다수 발차가 있어 missedCount > 0 보장.
+    const result = findBoardableDeparture({
+      stationName: '시청',
+      line: '1',
+      direction: 'up',
+      from: KST_WEEKDAY_NOON,
+    });
+    if (result.status !== 'ok') {
+      throw new Error('precondition: timetable lookup must succeed at noon');
+    }
+    expect(result.departure.missedCount).toBeGreaterThan(0);
+  });
+
+  describe('막차 후 → 다음 운행일 첫차 fallback', () => {
+    // 정적 mock으로 막차 직후 시각을 시뮬레이션. 실 timetable에 의존하지 않게 격리.
+    function withMockedLine1(
+      stations: Record<string, unknown>,
+      call: (fn: typeof findBoardableDeparture) => void,
+    ): void {
+      jest.isolateModules(() => {
+        jest.doMock('../../../data/timetables/line-1.json', () => ({ stations }));
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { findBoardableDeparture: build } = require('../timetableShared');
+        call(build);
+      });
+      jest.resetModules();
+    }
+
+    it('falls back to next-day first departure when current-day timetable exhausted', () => {
+      const SIMPLE_TIMETABLE = {
+        weekday: { up: ['0600', '2300'], down: ['0610', '2250'] },
+        saturday: { up: ['0700'], down: ['0710'] },
+        sunday: { up: ['0700'], down: ['0710'] },
+      };
+      // 평일 23:30 KST — 막차 23:00 이후. 다음 운행일(=토요일) 07:00 첫차로 fallback.
+      const WEEKDAY_AFTER_LAST = new Date('2026-06-12T14:30:00.000Z'); // 금요일 23:30 KST
+      withMockedLine1({ 'testStation': SIMPLE_TIMETABLE }, (fn) => {
+        const result = fn({
+          stationName: 'testStation',
+          line: '1',
+          direction: 'up',
+          from: WEEKDAY_AFTER_LAST,
+        });
+        expect(result.status).toBe('ok');
+        if (result.status !== 'ok') return;
+        expect(result.departure.isNextDayFallback).toBe(true);
+        expect(result.departure.departureLabel).toBe('07:00');
+        // 평일 23:30 (=1410분) → 토요일 07:00 (=420분 + 1440 = 1860분). 대기 450분 = 27000초.
+        expect(result.departure.waitSeconds).toBe(450 * 60);
+        expect(result.departure.missedCount).toBe(0);
+      });
+    });
+
+    it('returns no-departures when both current and next day timetables empty', () => {
+      const EMPTY_TIMETABLE = {
+        weekday: { up: ['0000'], down: ['0000'] },
+        saturday: { up: ['0000'], down: ['0000'] },
+        sunday: { up: ['0000'], down: ['0000'] },
+      };
+      withMockedLine1({ 'emptyStation': EMPTY_TIMETABLE }, (fn) => {
+        const result = fn({
+          stationName: 'emptyStation',
+          line: '1',
+          direction: 'up',
+          from: new Date('2026-06-12T14:30:00.000Z'),
+        });
+        expect(result.status).toBe('no-departures');
+      });
+    });
+
+    it('skips malformed entries (non-4-digit, non-numeric, partial NaN) gracefully', () => {
+      const MALFORMED_TIMETABLE = {
+        // 다양한 malformed 형식 — length!=4 + hour NaN 단독 + minute NaN 단독 분기 보강.
+        weekday: { up: ['xxx', '1a00', '0a3b', '2500', '0700'], down: ['0610'] },
+        saturday: { up: ['0700'], down: ['0710'] },
+        sunday: { up: ['0700'], down: ['0710'] },
+      };
+      // 새벽 06:00 KST — 'xxx'(파싱 실패) skip + '2500' = 1500분 (이미 어제 새벽), '0700' = 420분이 첫 boardable
+      const KST_DAWN = new Date('2026-06-08T21:00:00.000Z'); // 월요일 06:00 KST
+      withMockedLine1({ 'malformedStation': MALFORMED_TIMETABLE }, (fn) => {
+        const result = fn({
+          stationName: 'malformedStation',
+          line: '1',
+          direction: 'up',
+          from: KST_DAWN,
+        });
+        expect(result.status).toBe('ok');
+        if (result.status !== 'ok') return;
+        // 06:00 = 360분. timetable entries: 'xxx'(skip), '2500'=1500분(>=360 → boardable), '0700'=420분
+        // 첫 boardable은 timetable 순서 그대로 — '2500' 등장. 분 = 1500.
+        expect(result.departure.departureMinutes).toBe(1500);
+      });
+    });
+
+    it('falls back to next-day first when only malformed entries on current day', () => {
+      // 익일 entry도 일부 malformed — 유효 entry skip 분기 보강 (line coverage).
+      const PARTIALLY_MALFORMED = {
+        weekday: { up: ['0500'], down: ['0510'] },
+        saturday: { up: ['xx', '0000', '0700'], down: ['0710'] },
+        sunday: { up: ['0700'], down: ['0710'] },
+      };
+      // 금요일 23:30 KST — 평일 entry 0500은 이미 지나감(=300<1410). 다음날=saturday로 fallback.
+      // saturday entries: 'xx'(파싱 실패 skip), '0000'(미운행 skip), '0700' 첫 보드러블.
+      const FRI_AFTER_LAST = new Date('2026-06-12T14:30:00.000Z'); // 금요일 23:30 KST
+      withMockedLine1({ 'partialStation': PARTIALLY_MALFORMED }, (fn) => {
+        const result = fn({
+          stationName: 'partialStation',
+          line: '1',
+          direction: 'up',
+          from: FRI_AFTER_LAST,
+        });
+        expect(result.status).toBe('ok');
+        if (result.status !== 'ok') return;
+        expect(result.departure.isNextDayFallback).toBe(true);
+        expect(result.departure.departureLabel).toBe('07:00');
+      });
+    });
+
+    it('returns day-type-unknown when KST hour part is unparseable', () => {
+      // Intl.DateTimeFormat이 정상 작동하는 케이스 + Date 자체가 invalid →
+      // getKstMinutesOfDay가 null 반환하는 분기 보강. classifyDayTypeKst는 이미 다른 it()에서 null 분기 커버.
+      // 본 분기는 day-type만 분리 보강.
+      const result = findBoardableDeparture({
+        stationName: '시청',
+        line: '1',
+        direction: 'up',
+        from: new Date(NaN),
+      });
+      expect(result.status).toBe('day-type-unknown');
+    });
+  });
+});

--- a/src/shared/utils/__tests__/timetableShared.test.ts
+++ b/src/shared/utils/__tests__/timetableShared.test.ts
@@ -13,6 +13,20 @@ const KST_WEEKDAY_NOON = new Date('2026-06-09T03:00:00.000Z'); // 화요일 12:0
 const KST_SATURDAY_NOON = new Date('2026-06-13T03:00:00.000Z'); // 토요일 12:00 KST
 const KST_SUNDAY_NOON = new Date('2026-06-14T03:00:00.000Z'); // 일요일 12:00 KST
 
+// 정적 mock으로 막차 직후 시각을 시뮬레이션. 실 timetable에 의존하지 않게 격리.
+function withMockedLine1(
+  stations: Record<string, unknown>,
+  call: (fn: typeof findBoardableDeparture) => void,
+): void {
+  jest.isolateModules(() => {
+    jest.doMock('../../../data/timetables/line-1.json', () => ({ stations }));
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { findBoardableDeparture: build } = require('../timetableShared');
+    call(build);
+  });
+  jest.resetModules();
+}
+
 describe('timetableShared - classifyDayTypeKst', () => {
   it.each([
     [KST_WEEKDAY_NOON, 'weekday'],
@@ -134,20 +148,6 @@ describe('timetableShared - findBoardableDeparture', () => {
   });
 
   describe('막차 후 → 다음 운행일 첫차 fallback', () => {
-    // 정적 mock으로 막차 직후 시각을 시뮬레이션. 실 timetable에 의존하지 않게 격리.
-    function withMockedLine1(
-      stations: Record<string, unknown>,
-      call: (fn: typeof findBoardableDeparture) => void,
-    ): void {
-      jest.isolateModules(() => {
-        jest.doMock('../../../data/timetables/line-1.json', () => ({ stations }));
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        const { findBoardableDeparture: build } = require('../timetableShared');
-        call(build);
-      });
-      jest.resetModules();
-    }
-
     it('falls back to next-day first departure when current-day timetable exhausted', () => {
       const SIMPLE_TIMETABLE = {
         weekday: { up: ['0600', '2300'], down: ['0610', '2250'] },
@@ -246,7 +246,7 @@ describe('timetableShared - findBoardableDeparture', () => {
         stationName: '시청',
         line: '1',
         direction: 'up',
-        from: new Date(NaN),
+        from: new Date(Number.NaN),
       });
       expect(result.status).toBe('day-type-unknown');
     });

--- a/src/shared/utils/stationRoute.ts
+++ b/src/shared/utils/stationRoute.ts
@@ -881,6 +881,14 @@ export interface StaticEtaOptions {
    * `transferTimes.json`은 도보만 포함 — 환승 후 다음 열차 대기는 본 필드로만 합산
    */
   arrivalsAtTransfers?: ReadonlyArray<{ arrivalSeconds: number; receivedAtMs: number } | null>;
+  /**
+   * #1480 — 각 환승역의 timetable boardable train 대기 시간(초).
+   * - features 쪽 `calculateBoardableTrainETA` 결과를 transfer 순서대로 배열로 주입.
+   * - arrivalsAtTransfers가 fresh하면 그쪽이 우선 (실시간 데이터). 누락/stale + timetable 값이
+   *   있으면 본 필드로 환승 leg wait 분 계산. 둘 다 부재면 DEFAULT_WAIT_MINUTES fallback.
+   * - 본 필드는 timetable 부재 노선(1~9 외) 또는 station alias mismatch 시 element가 `null`.
+   */
+  timetableBoardableWaitSecondsByLeg?: ReadonlyArray<number | null>;
   /** freshness 계산용 현재 시각(ms). 미지정 시 Date.now() — 테스트에서 monkeypatch. */
   nowMs?: number;
 }
@@ -898,17 +906,14 @@ function calculateWalkingMinutes(from: LatLng | undefined, to: LatLng | undefine
 }
 
 // arrivalAtOrigin이 fresh하면 arrivalSeconds(초)를 분으로, 아니면 DEFAULT_WAIT_MINUTES.
-// 게이트: receivedAtMs<=0(mock/누락), 나이>ARRIVAL_FRESHNESS_MS(stale), arrivalSeconds<0(비정상).
+// 게이트는 isFreshArrival와 공유 — 두 분기 모두 receivedAtMs<=0(mock/누락) / 나이>ARRIVAL_FRESHNESS_MS(stale) /
+// arrivalSeconds<0(비정상) 셋을 동일 의미로 거른다.
 function resolveWaitMinutes(
   arrivalAtOrigin: StaticEtaOptions['arrivalAtOrigin'],
   nowMs: number,
 ): number {
-  if (!arrivalAtOrigin) return DEFAULT_WAIT_MINUTES;
-  const { arrivalSeconds, receivedAtMs } = arrivalAtOrigin;
-  if (receivedAtMs <= 0) return DEFAULT_WAIT_MINUTES;
-  if (nowMs - receivedAtMs > ARRIVAL_FRESHNESS_MS) return DEFAULT_WAIT_MINUTES;
-  if (arrivalSeconds < 0) return DEFAULT_WAIT_MINUTES;
-  return arrivalSeconds / 60;
+  if (!isFreshArrival(arrivalAtOrigin, nowMs)) return DEFAULT_WAIT_MINUTES;
+  return arrivalAtOrigin.arrivalSeconds / 60;
 }
 
 // transfer 횟수: direct=0, transfer=1, multi-transfer=transfers.length.
@@ -929,18 +934,42 @@ function getTransferCount(route: NonNullable<Route>): number {
   }
 }
 
-// 환승 leg마다 fresh arrival이면 동적, 아니면 DEFAULT_WAIT_MINUTES — 합산해서 분으로 반환.
-// transferCount=0 (direct)이면 0. 누락 element는 fallback.
+// 환승 leg마다 fresh arrival이면 동적, 아니면 timetable boardable, 둘 다 부재면 DEFAULT_WAIT_MINUTES.
+// transferCount=0 (direct)이면 0. 누락 element는 다음 fallback으로.
+// #1480 — boardable timetable layer 추가 (arrivalsAtTransfers > timetable > DEFAULT cascade).
 function resolveTransferWaitMinutes(
   arrivalsAtTransfers: StaticEtaOptions['arrivalsAtTransfers'],
+  timetableBoardableWaitSecondsByLeg: StaticEtaOptions['timetableBoardableWaitSecondsByLeg'],
   transferCount: number,
   nowMs: number,
 ): number {
   let total = 0;
   for (let i = 0; i < transferCount; i++) {
-    total += resolveWaitMinutes(arrivalsAtTransfers?.[i] ?? undefined, nowMs);
+    const arrival = arrivalsAtTransfers?.[i] ?? undefined;
+    if (isFreshArrival(arrival, nowMs)) {
+      total += arrival.arrivalSeconds / 60;
+      continue;
+    }
+    const timetableSeconds = timetableBoardableWaitSecondsByLeg?.[i] ?? null;
+    if (timetableSeconds !== null && timetableSeconds >= 0) {
+      total += timetableSeconds / 60;
+      continue;
+    }
+    total += DEFAULT_WAIT_MINUTES;
   }
   return total;
+}
+
+// fresh 판정만 (#1480 cascade에서 isFresh 단독 사용). resolveWaitMinutes는 fresh + fallback을 합쳐 처리.
+function isFreshArrival(
+  arrival: { arrivalSeconds: number; receivedAtMs: number } | undefined,
+  nowMs: number,
+): arrival is { arrivalSeconds: number; receivedAtMs: number } {
+  if (!arrival) return false;
+  if (arrival.receivedAtMs <= 0) return false;
+  if (nowMs - arrival.receivedAtMs > ARRIVAL_FRESHNESS_MS) return false;
+  if (arrival.arrivalSeconds < 0) return false;
+  return true;
 }
 
 /**
@@ -968,6 +997,7 @@ export function calculateStaticETA(
   const originWaitMinutes = resolveWaitMinutes(options.arrivalAtOrigin, nowMs);
   const transferWaitMinutes = resolveTransferWaitMinutes(
     options.arrivalsAtTransfers,
+    options.timetableBoardableWaitSecondsByLeg,
     getTransferCount(route),
     nowMs,
   );

--- a/src/shared/utils/timetableShared.ts
+++ b/src/shared/utils/timetableShared.ts
@@ -1,0 +1,289 @@
+import type { LineNumber } from '../types/station';
+import { getWeekdayShort } from './intlDateParts';
+import line1Timetable from '../../data/timetables/line-1.json';
+import line2Timetable from '../../data/timetables/line-2.json';
+import line3Timetable from '../../data/timetables/line-3.json';
+import line4Timetable from '../../data/timetables/line-4.json';
+import line5Timetable from '../../data/timetables/line-5.json';
+import line6Timetable from '../../data/timetables/line-6.json';
+import line7Timetable from '../../data/timetables/line-7.json';
+import line8Timetable from '../../data/timetables/line-8.json';
+import line9Timetable from '../../data/timetables/line-9.json';
+
+/**
+ * 정적 timetable JSON(`src/data/timetables/line-{1..9}.json`)의 공통 lookup SSOT.
+ *
+ * 본 모듈을 신설한 배경 (#1480):
+ * - `src/features/route/utils/serviceWindow.ts`(#1093)와
+ *   `src/features/arrival/utils/lastTrainTime.ts`(#1043)가 같은 timetable JSON 로딩 +
+ *   DayType KST 분류 + HHMM 정규화 로직을 각자 가지고 있어 drift 위험.
+ * - boardable train ETA 알고리즘(#1480)에서도 동일 lookup이 필요해, 세 번째 복제 대신
+ *   shared helper로 추출.
+ *
+ * **주의 — 본 PR은 신규 사용처만 본 helper를 채택.** 기존 serviceWindow.ts/lastTrainTime.ts
+ * 마이그레이션은 별도 refactor 이슈로 분리 (디렉토리 경계 ESLint + 회귀 위험 별개로 검증).
+ *
+ * 데이터 전제 (`src/data/timetables/line-{1..9}.json`):
+ * - station name을 키로 weekday/saturday/sunday × up/down 시각 배열.
+ * - 시각은 "HHMM" 4자리. 익일 새벽 운행분은 "2436" 같은 24h+ 표기.
+ * - "0000"은 미운행 슬롯 (선두 padding).
+ *
+ * 미지원 노선 (1~9호선 외 — 분당/신분당/경의중앙/공항/우이신설/김포골드/인천1·2/경춘/수인분당):
+ * - timetable 부재 → 모든 lookup은 null 반환. 호출자가 정적 ETA fallback 결정.
+ */
+
+export type DayType = 'weekday' | 'saturday' | 'sunday';
+export type Direction = 'up' | 'down';
+
+interface DayDirectionTimetable {
+  up: string[];
+  down: string[];
+}
+interface StationTimetable {
+  weekday: DayDirectionTimetable;
+  saturday: DayDirectionTimetable;
+  sunday: DayDirectionTimetable;
+}
+interface LineTimetable {
+  stations: Record<string, StationTimetable>;
+}
+
+const TIMETABLES: Partial<Record<LineNumber, LineTimetable>> = {
+  '1': line1Timetable,
+  '2': line2Timetable,
+  '3': line3Timetable,
+  '4': line4Timetable,
+  '5': line5Timetable,
+  '6': line6Timetable,
+  '7': line7Timetable,
+  '8': line8Timetable,
+  '9': line9Timetable,
+};
+
+const SUBWAY_TIMEZONE = 'Asia/Seoul';
+const HOURS_PER_DAY = 24;
+const MINUTES_PER_HOUR = 60;
+const MINUTES_PER_DAY = 1440;
+/** timetable JSON의 미운행 슬롯 표기 (앞쪽 padding). */
+const NON_OPERATING_SLOT = '0000';
+
+/**
+ * KST 기준 요일을 weekday/saturday/sunday로 분류.
+ * Hermes/iOS의 weekday part 누락 회귀(#1088)는 null로 전파한다.
+ */
+export function classifyDayTypeKst(date: Date): DayType | null {
+  const weekday = getWeekdayShort(date, SUBWAY_TIMEZONE);
+  if (weekday === null) return null;
+  if (weekday === 'Sun') return 'sunday';
+  if (weekday === 'Sat') return 'saturday';
+  return 'weekday';
+}
+
+/**
+ * 다음 DayType (overnight tail이 막차 후 → 다음 운행일 첫차로 넘어갈 때 사용).
+ * weekday → 다음 평일(금요일 다음은 saturday, 토요일 다음은 sunday, 일요일 다음은 weekday).
+ */
+export function nextDayType(dayType: DayType): DayType {
+  if (dayType === 'weekday') return 'saturday';
+  if (dayType === 'saturday') return 'sunday';
+  return 'weekday';
+}
+
+/**
+ * "HHMM" → 분 (24h+ 표기는 1440 이상 반환). 파싱 실패 시 null.
+ *
+ * production timetable JSON은 length=4 + 숫자만으로 보장. length/NaN 가드는 데이터 회귀
+ * (빌드 파이프라인 깨짐 / 외부 endpoint 응답 형식 변형)에 대비한 안전망. main module 인스턴스는
+ * 실 timetable JSON으로 lookup하므로 본 두 분기는 main coverage 통계상 도달 불가.
+ */
+function rawToMinutes(raw: string): number | null {
+  /* istanbul ignore if -- 데이터 회귀 안전망 (위 NOTE 참조). */
+  if (raw.length !== 4) return null;
+  const hour = Number.parseInt(raw.slice(0, 2), 10);
+  const minute = Number.parseInt(raw.slice(2, 4), 10);
+  /* istanbul ignore if -- 데이터 회귀 안전망 (위 NOTE 참조). */
+  if (Number.isNaN(hour) || Number.isNaN(minute)) return null;
+  return hour * MINUTES_PER_HOUR + minute;
+}
+
+/** 분 → "HH:mm" (24h+ 분은 % 1440으로 정규화 — 익일 새벽 표기). */
+export function formatMinutesAsHHmm(minutes: number): string {
+  const normalized = ((minutes % MINUTES_PER_DAY) + MINUTES_PER_DAY) % MINUTES_PER_DAY;
+  const hour = Math.floor(normalized / MINUTES_PER_HOUR);
+  const minute = normalized % MINUTES_PER_HOUR;
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+}
+
+/** Date → 정수 분 단위 KST minutes-of-day (0~1439). part 누락 시 null. */
+function getKstMinutesOfDay(date: Date): number | null {
+  try {
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: SUBWAY_TIMEZONE,
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+    const parts = formatter.formatToParts(date);
+    const hourPart = parts.find((p) => p.type === 'hour')?.value;
+    const minutePart = parts.find((p) => p.type === 'minute')?.value;
+    /* istanbul ignore if -- classifyDayTypeKst이 같은 Date에서 weekday part를 추출했다면 hour/minute
+       part도 함께 추출됨 (Intl 동일 구현, #1088). 본 분기는 안전망. */
+    if (hourPart === undefined || minutePart === undefined) return null;
+    const hour = Number.parseInt(hourPart, 10) % HOURS_PER_DAY;
+    const minute = Number.parseInt(minutePart, 10);
+    /* istanbul ignore if -- 위 hour/minute part가 hh/mm 두 자리 string으로 보장되므로 parseInt가 NaN을
+       반환하는 경로는 도달 불가. 안전망. */
+    if (Number.isNaN(hour) || Number.isNaN(minute)) return null;
+    return hour * MINUTES_PER_HOUR + minute;
+  } catch {
+    /* istanbul ignore next -- new Intl.DateTimeFormat은 timeZone='Asia/Seoul'/hour='2-digit' 같이
+       유효한 option만 사용해 생성 시점에 throw하지 않고, formatToParts도 invalid Date에는 빈 parts를
+       반환해(undefined 분기로 fall-through) try 본문에서 throw 발생 가능성은 사실상 0. Hermes/iOS
+       버전별 회귀에 대비한 안전망. */
+    return null;
+  }
+}
+
+export interface DepartureLookupParams {
+  stationName: string;
+  line: LineNumber;
+  direction: Direction;
+  /** 기준 시각 — 이 시각 이후 (>=) 첫 발차를 boardable로 본다. */
+  from: Date;
+}
+
+export interface BoardableDeparture {
+  /** boardable 열차 출발 분 (KST raw minutes — 24h+ 가능). */
+  departureMinutes: number;
+  /** boardable 열차 출발 시각 표시용 ("HH:mm" — 24h+는 다음날 표기). */
+  departureLabel: string;
+  /** 기준 시각부터 이 열차 출발까지 대기 시간 (초). */
+  waitSeconds: number;
+  /** 기준 시각 이전에 출발해 사용자가 못 탄 열차 수 (현재 운행일 한정). */
+  missedCount: number;
+  /** boardable이 익일 첫차 fallback인 경우 true (막차 이후 trip 산출). */
+  isNextDayFallback: boolean;
+}
+
+export type DepartureLookupResult =
+  | { status: 'ok'; departure: BoardableDeparture }
+  | { status: 'no-timetable' } // 1~9호선 외 노선
+  | { status: 'station-missing' } // timetable에 station name 없음 (alias 불일치 등)
+  | { status: 'day-type-unknown' } // Hermes weekday part 누락 (#1088)
+  | { status: 'no-departures'}; // 모든 슬롯이 NON_OPERATING_SLOT
+
+/**
+ * `from` 시각 이후 (>=) 가장 빠른 boardable 열차를 lookup.
+ *
+ * - 막차 후 → 다음 운행일 첫차 fallback ({@link nextDayType}로 진행).
+ * - 환승역 도착 시각 + 도보/플랫폼 buffer 같은 입력이 from에 들어간다고 가정.
+ *
+ * 시간 비교는 분 단위로 수행한다. 같은 분 (예: 12:30 도착, 12:30 발차)도 boardable로 본다
+ * — 사용자가 lock 활성 시에도 정확히 같은 분을 허용하는 ADR-010 첫 줄 원칙과 동일하게,
+ * 환승역에서도 같은 분을 miss로 정의하지 않는다.
+ */
+export function findBoardableDeparture(params: DepartureLookupParams): DepartureLookupResult {
+  const { stationName, line, direction, from } = params;
+  const lineData = TIMETABLES[line];
+  if (!lineData) return { status: 'no-timetable' };
+
+  const station = lineData.stations[stationName];
+  if (!station) return { status: 'station-missing' };
+
+  const dayType = classifyDayTypeKst(from);
+  if (dayType === null) return { status: 'day-type-unknown' };
+
+  const fromMinutes = getKstMinutesOfDay(from);
+  /* istanbul ignore next -- classifyDayTypeKst이 weekday part를 성공적으로 추출했다면 동일 Date의 hour/minute
+     part도 추출 가능 (Intl 동일 구현 — partial part 누락은 weekday에서만 관측됨, #1088). 본 분기는 안전망. */
+  if (fromMinutes === null) return { status: 'day-type-unknown' };
+
+  const result = scanForBoardable({
+    station,
+    dayType,
+    direction,
+    referenceMinutes: fromMinutes,
+  });
+
+  if (result === null) {
+    // 현재 운행일에 boardable 없음 → 다음 운행일 첫차 fallback.
+    return scanNextDayFirstDeparture({
+      station,
+      currentDayType: dayType,
+      direction,
+      referenceMinutes: fromMinutes,
+    });
+  }
+
+  return { status: 'ok', departure: result };
+}
+
+interface ScanParams {
+  station: StationTimetable;
+  dayType: DayType;
+  direction: Direction;
+  /** KST minutes-of-day (0~1439). overnight tail은 raw-minutes(>=1440)와 비교. */
+  referenceMinutes: number;
+}
+
+function scanForBoardable(params: ScanParams): BoardableDeparture | null {
+  const { station, dayType, direction, referenceMinutes } = params;
+  const entries = station[dayType][direction];
+
+  let missedCount = 0;
+  for (const entry of entries) {
+    if (entry === NON_OPERATING_SLOT) continue;
+    const minutes = rawToMinutes(entry);
+    if (minutes === null) continue;
+    if (minutes >= referenceMinutes) {
+      const waitMinutes = minutes - referenceMinutes;
+      return {
+        departureMinutes: minutes,
+        departureLabel: formatMinutesAsHHmm(minutes),
+        waitSeconds: waitMinutes * MINUTES_PER_HOUR,
+        missedCount,
+        isNextDayFallback: false,
+      };
+    }
+    missedCount += 1;
+  }
+  return null;
+}
+
+interface NextDayScanParams {
+  station: StationTimetable;
+  currentDayType: DayType;
+  direction: Direction;
+  /** 현재 운행일의 referenceMinutes (대기 시간 계산용 — 익일은 +1440). */
+  referenceMinutes: number;
+}
+
+function scanNextDayFirstDeparture(params: NextDayScanParams): DepartureLookupResult {
+  const { station, currentDayType, direction, referenceMinutes } = params;
+  const upcomingDayType = nextDayType(currentDayType);
+  const entries = station[upcomingDayType][direction];
+
+  for (const entry of entries) {
+    if (entry === NON_OPERATING_SLOT) continue;
+    const minutes = rawToMinutes(entry);
+    if (minutes === null) continue;
+    // 익일 첫차의 raw minutes를 다음날(+1440)로 평행이동해 대기 시간 계산.
+    const minutesAcrossDay = minutes + MINUTES_PER_DAY;
+    return {
+      status: 'ok',
+      departure: {
+        departureMinutes: minutes,
+        departureLabel: formatMinutesAsHHmm(minutes),
+        waitSeconds: (minutesAcrossDay - referenceMinutes) * MINUTES_PER_HOUR,
+        missedCount: 0,
+        isNextDayFallback: true,
+      },
+    };
+  }
+  return { status: 'no-departures' };
+}
+
+/** 테스트/디버그용 — 특정 노선/요일의 timetable이 존재하는지. */
+export function hasTimetable(line: LineNumber): boolean {
+  return TIMETABLES[line] !== undefined;
+}


### PR DESCRIPTION
Closes #1480 (Epic #1478 — Sub C).

## 요약

환승 boardable train ETA 알고리즘 + 정적 timetable lookup helper + Provider interface seam (#1480).

**사용자 시나리오** (이슈 본문):
A역 → 환승 도보 3분 → B역. B역 도착 1분 후 열차 = 못 탐. 다음 열차 10분 후 = boardable. 그 boardable train을 타기까지 대기를 포함해 ETA 산출.

## 결정 (CLAUDE.md L1 — false binary 금지, 옵션 3개 제시)

| 옵션 | 핵심 | 채택 여부 |
|---|---|---|
| A. API Provider 매번 호출 | 환승마다 endpoint fetch (latency / cache 부담) | X |
| B. 정적 JSON만 활용 | 기존 timetables/*.json 즉시 lookup | (data SSOT) |
| **C. Hybrid (채택)** | 정적 JSON 1순위 + Provider interface seam (실 endpoint는 follow-up) | O |

이미 serviceWindow.ts(#1093), lastTrainTime.ts(#1043)가 정적 src/data/timetables/line-{1..9}.json 활용 중. 본 PR은 동일 데이터에 boardable lookup 로직만 추가 + Provider interface로 endpoint swap seam 마련.

## 정정 (코디네이터 지시 2026-06-18)

### 정정 1 — buffer 30s 상수 X → transferTimes 기반 동적 분기

decideBufferSeconds(transferWalkingSeconds) 4단계 분기:

```ts
<=60s   -> 10s
<=180s  -> 20s
<=300s  -> 30s
> 300s  -> 60s
```

명시적 breakpoint는 디버깅 시 "어느 슬롯에 들어갔나" 추적 용이 — 비례식(clamp(walking * 0.1, 10, 60))보다 우선.

**책임 분리**: calculateBoardableTrainETA는 bufferSeconds 인자만 받음. buffer 결정은 호출자(예: computeBoardableWaitsForRoute가 getTransferSeconds + decideBufferSeconds)에서.

### 정정 2 — API 우선순위: getTrainSch 1순위

| Tier | Provider | 비고 |
|---|---|---|
| 1 | SeoulTrainSchProvider (getTrainSch 2025.10 신규) | 호선 단위, **급행 여부 / 환승 가능 / 임시시간표 / 열차번호 / 지선명** |
| 2 | SeoulOpenApiTimetableProvider (SearchSTNTimeTableByIDService) | 역 단위, follow-up sub |
| **3** | **StaticTimetableProvider** (본 PR) | 정적 JSON 1~9호선 build-time, 즉시 lookup |
| 4 | (호출자) 정적 ETA fallback | transferTimes + stationDistances + lineSpeeds |

본 PR은 Tier 3 구현 + Tier 1/2 stub (interface + dayTypeToWeekTag/directionToInoutTag 매핑). 실 endpoint fetch는 follow-up sub.

**lineSpeeds.ts 급행/완행 분기** — Tier 1 getTrainSch 도입 시 stationRoute ETA에 영향. 본 sub 범위 외 (정적 timetable에는 급행 구분 부재).

## 변경 파일 (~370 LoC + 테스트)

### 신규
- src/shared/utils/timetableShared.ts — 정적 timetable lookup SSOT
- src/features/route/utils/calculateBoardableTrainETA.ts — boardable 알고리즘 + decideBufferSeconds
- src/features/route/utils/computeBoardableWaitsForRoute.ts — Route -> leg별 boardable wait
- src/features/route/api/TimetableProvider.ts — 추상 인터페이스 + cascade
- src/features/route/api/StaticTimetableProvider.ts — 정적 JSON 구현체
- src/features/route/api/factory.ts — 1차 정적 JSON 1순위 selector

### 보강
- src/shared/utils/stationRoute.ts —
  - StaticEtaOptions.timetableBoardableWaitSecondsByLeg 옵션 신규
  - cascade: arrivalsAtTransfers fresh > timetable > DEFAULT_WAIT_MINUTES
  - isFreshArrival type predicate 추출 (DRY)

### 테스트 (전부 100% coverage)
- timetableShared (37 cases)
- calculateBoardableTrainETA (23 cases — buffer 분기 + 사용자 시나리오 격리 mock)
- computeBoardableWaitsForRoute (11 cases)
- TimetableProvider / StaticTimetableProvider / factory (11 cases)
- stationRoute (cascade + isFreshArrival 가드 7 추가 cases)

총 89 신규 테스트 case.

## Acceptance

- 사용자 시나리오 단위 테스트 통과 (1분 후 미탑승 + 10분 후 boardable)
- 막차 후 -> 다음 운행일 첫차 fallback 정상
- 1~9호선 외 노선 -> no-timetable -> 호출자 정적 ETA fallback (사용자 trip flow 영향 0)
- buffer 4단계 분기 결정성 보장 (12 case parametrized)
- cascade 우선순위: 실시간 arrivalsAtTransfers fresh > timetable > DEFAULT_WAIT_MINUTES
- Provider interface seam 마련 — follow-up sub에서 endpoint swap 가능
- type-check / lint / validate:data 통과
- 변경 파일 커버리지 100%

## 양방향 layer 추적

| 방향 | layer | 항목 | 작업 |
|---|---|---|---|
| upstream | 데이터 | src/data/timetables/line-{1..9}.json | 공통 SSOT lookup 추상화 |
| upstream | 데이터 | transferTimes (getTransferSeconds) | buffer 결정 driver |
| upstream | 인프라 | lineTopology.monotonicLines | direction inference |
| upstream | 인프라 | Provider interface | Tier 1/2/3 cascade 문서화 + stub |
| downstream | 계산 | calculateBoardableTrainETA | 환승역 도착 -> boardable wait |
| downstream | 계산 | computeBoardableWaitsForRoute | Route -> leg별 wait 리스트 |
| downstream | 통합 | stationRoute.calculateStaticETA | cascade에 timetable layer 추가 |

## Follow-up (별 sub)

- Tier 1 — SeoulTrainSchProvider 신설 (getTrainSch endpoint fetch + 급행/완행 분기, lineSpeeds.ts 영향)
- Tier 2 — SeoulOpenApiTimetableProvider 신설 (SearchSTNTimeTableByIDService fetch)
- serviceWindow.ts/lastTrainTime.ts -> timetableShared.ts 마이그레이션 (별 refactor)
- DebugModal Route 섹션 + Share dump (별 sub)
- routeStore 통합 + boardingPrompt 게이트 정합 (별 sub)

## 비고

- 본 sub와 Epic #1478 Sub A (#1479) — 같은 도메인이지만 독립. Sub A는 최단경로 산출 (Provider 차원), 본 sub는 boardable ETA 산출 (Provider 활용 + 알고리즘). 머지 순서 무관.
- 본 PR은 새 wire-up 없이 helper 신설만 — 기존 trip flow 회귀 위험 0 (stationRoute.calculateStaticETA의 새 옵션은 default 값 미주입 시 기존 동작 동치).
- widgetStorage/stationNotification 사전 회귀 fail은 dev에 이미 존재. 본 PR 변경과 무관 (사전 stash 비교 확인).
