### PR TITLE
feat(#1454): 권한 회수 / Always→WhileInUse 변경 UX

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -40,6 +40,8 @@ import { useTheme, typography, spacing, radius } from '../shared/theme';
 import { LineBadge } from '../shared/ui/LineBadge';
 import { LocationStateView } from '../shared/ui/LocationStateView';
 import { ServiceWindowBanner } from '../shared/ui/ServiceWindowBanner';
+import { PermissionChangeBanner } from '../shared/ui/PermissionChangeBanner';
+import { useLocationPermissionWatcher } from '../shared/hooks/useLocationPermissionWatcher';
 import { SourceBadge } from '../features/arrival/components/SourceBadge';
 import { resolveNotificationSource } from '../features/alarm/utils/notificationSource';
 import { ArrivalSourceNotice } from '../features/arrival/components/ArrivalSourceNotice';
@@ -611,6 +613,7 @@ export default function HomeScreen() {
     [selectTransferDetectLine],
   );
   useBackgroundLocation(destination);
+  const permissionWatcher = useLocationPermissionWatcher();
   useLiveActivityDismissBridge();
   useApnsTripRegistration({
     route,
@@ -862,6 +865,10 @@ export default function HomeScreen() {
                  wrapper로 padding을 두면 운행 중에도 phantom 여백이 남아 하단 레이아웃을
                  밀어내고 E2E scrollUntilVisible 회귀를 일으킨다(#1083). */}
             <ServiceWindowBanner stationName={effectiveOrigin.name} line={effectiveOrigin.line} />
+            <PermissionChangeBanner
+              change={permissionWatcher.change}
+              onAcknowledge={permissionWatcher.acknowledge}
+            />
             {/* Hero: origin station */}
             <View style={{ paddingHorizontal: spacing.xxl, paddingTop: spacing.xxxl - 4 }}>
               <Text

--- a/src/shared/hooks/__tests__/useLocationPermissionWatcher.test.ts
+++ b/src/shared/hooks/__tests__/useLocationPermissionWatcher.test.ts
@@ -1,0 +1,182 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+const mockGetForeground = jest.fn();
+const mockGetBackground = jest.fn();
+
+jest.mock('expo-location', () => ({
+  getForegroundPermissionsAsync: (...args: unknown[]) => mockGetForeground(...args),
+  getBackgroundPermissionsAsync: (...args: unknown[]) => mockGetBackground(...args),
+}));
+
+const mockAddEventListener = jest.fn();
+const mockRemove = jest.fn();
+
+jest.mock('react-native', () => ({
+  AppState: {
+    addEventListener: (...args: unknown[]) => mockAddEventListener(...args),
+  },
+}));
+
+import {
+  classifyPermissionChange,
+  useLocationPermissionWatcher,
+} from '../useLocationPermissionWatcher';
+
+type AppStateListener = (s: 'active' | 'background' | 'inactive') => void;
+
+function captureAppStateListener(): AppStateListener {
+  const last = mockAddEventListener.mock.calls.at(-1);
+  if (!last) throw new Error('AppState.addEventListener not called');
+  return last[1] as AppStateListener;
+}
+
+beforeEach(() => {
+  mockGetForeground.mockReset();
+  mockGetBackground.mockReset();
+  mockAddEventListener.mockReset();
+  mockRemove.mockReset();
+  mockAddEventListener.mockReturnValue({ remove: mockRemove });
+  mockGetForeground.mockResolvedValue({ status: 'granted' });
+  mockGetBackground.mockResolvedValue({ status: 'granted' });
+});
+
+describe('classifyPermissionChange', () => {
+  it('unknown 관여 시 항상 none', () => {
+    expect(classifyPermissionChange('unknown', 'granted-always')).toBe('none');
+    expect(classifyPermissionChange('granted-always', 'unknown')).toBe('none');
+  });
+
+  it('같은 상태는 none', () => {
+    expect(classifyPermissionChange('granted-always', 'granted-always')).toBe('none');
+    expect(classifyPermissionChange('denied', 'denied')).toBe('none');
+  });
+
+  it('granted → denied는 revoked', () => {
+    expect(classifyPermissionChange('granted-always', 'denied')).toBe('revoked');
+    expect(classifyPermissionChange('granted-whileinuse', 'denied')).toBe('revoked');
+  });
+
+  it('granted-always → granted-whileinuse는 downgraded', () => {
+    expect(classifyPermissionChange('granted-always', 'granted-whileinuse')).toBe('downgraded');
+  });
+
+  it('상향(whileinuse → always)이나 denied → granted는 none', () => {
+    expect(classifyPermissionChange('granted-whileinuse', 'granted-always')).toBe('none');
+    expect(classifyPermissionChange('denied', 'granted-always')).toBe('none');
+    expect(classifyPermissionChange('denied', 'granted-whileinuse')).toBe('none');
+  });
+});
+
+describe('useLocationPermissionWatcher', () => {
+  it('마운트 시 권한을 조회하고 status를 반영한다 (granted-always)', async () => {
+    const { result } = renderHook(() => useLocationPermissionWatcher());
+    expect(result.current.status).toBe('unknown');
+    await waitFor(() => expect(result.current.status).toBe('granted-always'));
+    expect(result.current.change).toBe('none');
+  });
+
+  it('FG denied면 status=denied', async () => {
+    mockGetForeground.mockResolvedValue({ status: 'denied' });
+    const { result } = renderHook(() => useLocationPermissionWatcher());
+    await waitFor(() => expect(result.current.status).toBe('denied'));
+    // BG는 조회하지 않는다 (FG denied 시점에 short-circuit).
+    expect(mockGetBackground).not.toHaveBeenCalled();
+  });
+
+  it('FG granted + BG denied면 status=granted-whileinuse', async () => {
+    mockGetBackground.mockResolvedValue({ status: 'denied' });
+    const { result } = renderHook(() => useLocationPermissionWatcher());
+    await waitFor(() => expect(result.current.status).toBe('granted-whileinuse'));
+  });
+
+  it('FG 조회 예외 시 status=unknown 유지', async () => {
+    mockGetForeground.mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useLocationPermissionWatcher());
+    // 비동기 처리 완료를 기다리기 위해 한 cycle 흘려보낸다.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.status).toBe('unknown');
+    expect(result.current.change).toBe('none');
+  });
+
+  it('AppState active 진입 시 재조회 + 변화 감지 (revoked)', async () => {
+    const { result } = renderHook(() => useLocationPermissionWatcher());
+    await waitFor(() => expect(result.current.status).toBe('granted-always'));
+
+    mockGetForeground.mockResolvedValue({ status: 'denied' });
+    const listener = captureAppStateListener();
+    await act(async () => {
+      listener('active');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.status).toBe('denied');
+    expect(result.current.change).toBe('revoked');
+  });
+
+  it('AppState active 진입 시 downgrade 감지', async () => {
+    const { result } = renderHook(() => useLocationPermissionWatcher());
+    await waitFor(() => expect(result.current.status).toBe('granted-always'));
+
+    mockGetBackground.mockResolvedValue({ status: 'denied' });
+    const listener = captureAppStateListener();
+    await act(async () => {
+      listener('active');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.status).toBe('granted-whileinuse');
+    expect(result.current.change).toBe('downgraded');
+  });
+
+  it('AppState background/inactive 진입은 재조회하지 않는다', async () => {
+    renderHook(() => useLocationPermissionWatcher());
+    await waitFor(() => expect(mockGetForeground).toHaveBeenCalledTimes(1));
+
+    const listener = captureAppStateListener();
+    await act(async () => {
+      listener('background');
+      listener('inactive');
+      await Promise.resolve();
+    });
+    expect(mockGetForeground).toHaveBeenCalledTimes(1);
+  });
+
+  it('acknowledge 호출 시 change가 none으로 리셋된다', async () => {
+    const { result } = renderHook(() => useLocationPermissionWatcher());
+    await waitFor(() => expect(result.current.status).toBe('granted-always'));
+
+    mockGetForeground.mockResolvedValue({ status: 'denied' });
+    const listener = captureAppStateListener();
+    await act(async () => {
+      listener('active');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.change).toBe('revoked');
+
+    act(() => result.current.acknowledge());
+    expect(result.current.change).toBe('none');
+  });
+
+  it('unmount 시 구독을 해제하고 늦은 비동기 결과가 setState를 호출하지 않는다', async () => {
+    let resolveFg: ((value: { status: string }) => void) | null = null;
+    mockGetForeground.mockReturnValue(
+      new Promise<{ status: string }>((resolve) => {
+        resolveFg = resolve;
+      }),
+    );
+    const { unmount } = renderHook(() => useLocationPermissionWatcher());
+    unmount();
+    expect(mockRemove).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolveFg?.({ status: 'granted' });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    // setState 호출이 일어났다면 unmount 후 React 경고가 뜨지만, cancelled 가드로 차단.
+    // 직접 검증은 어렵지만 unmount 후 throw가 없음을 확인.
+  });
+});

--- a/src/shared/hooks/__tests__/useLocationPermissionWatcher.test.ts
+++ b/src/shared/hooks/__tests__/useLocationPermissionWatcher.test.ts
@@ -20,6 +20,7 @@ jest.mock('react-native', () => ({
 import {
   classifyPermissionChange,
   useLocationPermissionWatcher,
+  type LocationPermissionChange,
 } from '../useLocationPermissionWatcher';
 
 type AppStateListener = (s: 'active' | 'background' | 'inactive') => void;
@@ -28,6 +29,28 @@ function captureAppStateListener(): AppStateListener {
   const last = mockAddEventListener.mock.calls.at(-1);
   if (!last) throw new Error('AppState.addEventListener not called');
   return last[1] as AppStateListener;
+}
+
+/**
+ * SonarCloud duplication 회피용 helper.
+ * setState 큐를 안정화하기 위해 두 cycle을 흘려보낸다.
+ * 여러 테스트에서 동일하게 반복되던 act+Promise 블록을 한 곳으로 모은다.
+ */
+async function flushTwoCycles() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+/** AppState 'active' 진입을 트리거하고 setState 큐를 비운다. */
+async function triggerAppStateActive() {
+  const listener = captureAppStateListener();
+  await act(async () => {
+    listener('active');
+    await Promise.resolve();
+    await Promise.resolve();
+  });
 }
 
 beforeEach(() => {
@@ -41,29 +64,19 @@ beforeEach(() => {
 });
 
 describe('classifyPermissionChange', () => {
-  it('unknown 관여 시 항상 none', () => {
-    expect(classifyPermissionChange('unknown', 'granted-always')).toBe('none');
-    expect(classifyPermissionChange('granted-always', 'unknown')).toBe('none');
-  });
-
-  it('같은 상태는 none', () => {
-    expect(classifyPermissionChange('granted-always', 'granted-always')).toBe('none');
-    expect(classifyPermissionChange('denied', 'denied')).toBe('none');
-  });
-
-  it('granted → denied는 revoked', () => {
-    expect(classifyPermissionChange('granted-always', 'denied')).toBe('revoked');
-    expect(classifyPermissionChange('granted-whileinuse', 'denied')).toBe('revoked');
-  });
-
-  it('granted-always → granted-whileinuse는 downgraded', () => {
-    expect(classifyPermissionChange('granted-always', 'granted-whileinuse')).toBe('downgraded');
-  });
-
-  it('상향(whileinuse → always)이나 denied → granted는 none', () => {
-    expect(classifyPermissionChange('granted-whileinuse', 'granted-always')).toBe('none');
-    expect(classifyPermissionChange('denied', 'granted-always')).toBe('none');
-    expect(classifyPermissionChange('denied', 'granted-whileinuse')).toBe('none');
+  it.each<[string, Parameters<typeof classifyPermissionChange>[0], Parameters<typeof classifyPermissionChange>[1], LocationPermissionChange]>([
+    ['unknown(prev) 관여', 'unknown', 'granted-always', 'none'],
+    ['unknown(next) 관여', 'granted-always', 'unknown', 'none'],
+    ['같은 always', 'granted-always', 'granted-always', 'none'],
+    ['같은 denied', 'denied', 'denied', 'none'],
+    ['always → denied', 'granted-always', 'denied', 'revoked'],
+    ['whileinuse → denied', 'granted-whileinuse', 'denied', 'revoked'],
+    ['always → whileinuse (downgrade)', 'granted-always', 'granted-whileinuse', 'downgraded'],
+    ['상향 whileinuse → always', 'granted-whileinuse', 'granted-always', 'none'],
+    ['denied → always 상향', 'denied', 'granted-always', 'none'],
+    ['denied → whileinuse 상향', 'denied', 'granted-whileinuse', 'none'],
+  ])('%s', (_, prev, next, expected) => {
+    expect(classifyPermissionChange(prev, next)).toBe(expected);
   });
 });
 
@@ -92,43 +105,27 @@ describe('useLocationPermissionWatcher', () => {
   it('FG 조회 예외 시 status=unknown 유지', async () => {
     mockGetForeground.mockRejectedValue(new Error('boom'));
     const { result } = renderHook(() => useLocationPermissionWatcher());
-    // 비동기 처리 완료를 기다리기 위해 한 cycle 흘려보낸다.
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await flushTwoCycles();
     expect(result.current.status).toBe('unknown');
     expect(result.current.change).toBe('none');
   });
 
-  it('AppState active 진입 시 재조회 + 변화 감지 (revoked)', async () => {
+  it.each<[LocationPermissionChange, 'denied' | 'granted', LocationPermissionChange]>([
+    ['revoked', 'denied', 'revoked'],
+    ['downgraded', 'granted', 'downgraded'],
+  ])('AppState active 진입 시 %s 감지', async (label, nextFgOrBg, expected) => {
     const { result } = renderHook(() => useLocationPermissionWatcher());
     await waitFor(() => expect(result.current.status).toBe('granted-always'));
 
-    mockGetForeground.mockResolvedValue({ status: 'denied' });
-    const listener = captureAppStateListener();
-    await act(async () => {
-      listener('active');
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-    expect(result.current.status).toBe('denied');
-    expect(result.current.change).toBe('revoked');
-  });
-
-  it('AppState active 진입 시 downgrade 감지', async () => {
-    const { result } = renderHook(() => useLocationPermissionWatcher());
-    await waitFor(() => expect(result.current.status).toBe('granted-always'));
-
-    mockGetBackground.mockResolvedValue({ status: 'denied' });
-    const listener = captureAppStateListener();
-    await act(async () => {
-      listener('active');
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-    expect(result.current.status).toBe('granted-whileinuse');
-    expect(result.current.change).toBe('downgraded');
+    // revoked: FG를 denied로 / downgraded: BG를 denied로 (FG는 granted 유지)
+    if (label === 'revoked') {
+      mockGetForeground.mockResolvedValue({ status: nextFgOrBg });
+    } else {
+      mockGetBackground.mockResolvedValue({ status: 'denied' });
+    }
+    await triggerAppStateActive();
+    expect(result.current.change).toBe(expected);
+    expect(result.current.status).toBe(label === 'revoked' ? 'denied' : 'granted-whileinuse');
   });
 
   it('AppState background/inactive 진입은 재조회하지 않는다', async () => {
@@ -149,12 +146,7 @@ describe('useLocationPermissionWatcher', () => {
     await waitFor(() => expect(result.current.status).toBe('granted-always'));
 
     mockGetForeground.mockResolvedValue({ status: 'denied' });
-    const listener = captureAppStateListener();
-    await act(async () => {
-      listener('active');
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await triggerAppStateActive();
     expect(result.current.change).toBe('revoked');
 
     act(() => result.current.acknowledge());

--- a/src/shared/hooks/useLocationPermissionWatcher.ts
+++ b/src/shared/hooks/useLocationPermissionWatcher.ts
@@ -99,9 +99,17 @@ export function useLocationPermissionWatcher(): LocationPermissionWatcherResult 
 
   useEffect(() => {
     const cancelledRef = { current: false };
-    void refresh(cancelledRef);
+    // refresh 내부에서 probePermissionStatus가 모든 에러를 흡수하므로 reject 가능성은 없지만,
+    // 방어적으로 .catch로 floating promise를 명시적으로 종결한다(SonarCloud S3735 회피).
+    const runRefresh = () => {
+      refresh(cancelledRef).catch(
+        /* istanbul ignore next — probePermissionStatus가 모든 에러를 흡수해 도달 불가 */
+        (e: unknown) => logger.warn('refresh 실패 — 무시', e),
+      );
+    };
+    runRefresh();
     const sub = AppState.addEventListener('change', (s: AppStateStatus) => {
-      if (s === 'active') void refresh(cancelledRef);
+      if (s === 'active') runRefresh();
     });
     return () => {
       cancelledRef.current = true;

--- a/src/shared/hooks/useLocationPermissionWatcher.ts
+++ b/src/shared/hooks/useLocationPermissionWatcher.ts
@@ -1,0 +1,117 @@
+/**
+ * #1454 — 위치 권한 회수 / Always→WhileInUse 강등 감지 훅.
+ *
+ * 사용자가 시스템 설정에서 위치 권한을 회수하거나(Always/WhileInUse → 거부)
+ * Always 권한을 WhileInUse로 낮추면 silent trip(알림 누락)이 발생한다. 게이트 외
+ * 영역이므로 사용자 명시 알림(UI 배너)로 원인을 인지하게 한다.
+ *
+ * 동작:
+ *   - 마운트 시 FG + BG 권한을 동시에 조회한다.
+ *   - 이후 AppState 'active' 진입 시마다 다시 조회한다 — 사용자가 설정 앱에 다녀온 직후
+ *     변화를 감지하는 가장 신뢰 가능한 시점.
+ *   - 직전 status 대비 (revoked | downgraded | none) change 종류를 산출한다.
+ *
+ * 본 훅은 표시 결정을 하지 않는다 — 호출자가 change에 따라 UI(예: PermissionChangeBanner)
+ * 노출/dismiss를 결정한다. 책임 분리로 테스트 용이성 + 표시 정책 다양화(banner / push 등)를
+ * 모두 지원한다.
+ *
+ * 의도적으로 LocationPort를 거치지 않는다 — Port가 노출하는 권한 API는 request 한 종(Phase 3
+ * 단계). FG/BG 권한 조회는 watcher 한정 책임이라 expo-location 직접 호출이 더 명확하다.
+ *
+ * 관련: B4 (WhileInUse 권한 정책), feedback_whileinuse_must_work
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+import * as Location from 'expo-location';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('LocationPermissionWatcher');
+
+/** 권한 상태 분류. iOS Always = granted+background, WhileInUse = granted+!background. */
+export type LocationPermissionStatus =
+  | 'unknown'
+  | 'denied'
+  | 'granted-whileinuse'
+  | 'granted-always';
+
+/** 직전 상태 대비 변화 종류. */
+export type LocationPermissionChange = 'none' | 'revoked' | 'downgraded';
+
+export interface LocationPermissionWatcherResult {
+  /** 현재 권한 상태. 초기값 'unknown' — 첫 조회 완료 후 갱신된다. */
+  status: LocationPermissionStatus;
+  /** 직전 status 대비 의미 있는 변화 종류. 표시 정책의 입력 신호. */
+  change: LocationPermissionChange;
+  /** change를 'none'으로 리셋(사용자가 배너를 dismiss한 시점 등). */
+  acknowledge: () => void;
+}
+
+async function probePermissionStatus(): Promise<LocationPermissionStatus> {
+  try {
+    const fg = await Location.getForegroundPermissionsAsync();
+    if (fg.status !== 'granted') return 'denied';
+    const bg = await Location.getBackgroundPermissionsAsync();
+    return bg.status === 'granted' ? 'granted-always' : 'granted-whileinuse';
+  } catch (e) {
+    logger.warn('권한 조회 실패 — unknown 유지', e);
+    return 'unknown';
+  }
+}
+
+/**
+ * 두 status 사이 변화 종류를 분류한다.
+ * - granted(any) → denied: revoked
+ * - granted-always → granted-whileinuse: downgraded
+ * - 그 외(unknown 관여 / 같음 / granted-whileinuse → granted-always 등 상향): none
+ */
+export function classifyPermissionChange(
+  prev: LocationPermissionStatus,
+  next: LocationPermissionStatus,
+): LocationPermissionChange {
+  if (prev === 'unknown' || next === 'unknown') return 'none';
+  if (prev === next) return 'none';
+  if (next === 'denied' && (prev === 'granted-always' || prev === 'granted-whileinuse')) {
+    return 'revoked';
+  }
+  if (prev === 'granted-always' && next === 'granted-whileinuse') return 'downgraded';
+  return 'none';
+}
+
+export function useLocationPermissionWatcher(): LocationPermissionWatcherResult {
+  const [status, setStatus] = useState<LocationPermissionStatus>('unknown');
+  const [change, setChange] = useState<LocationPermissionChange>('none');
+  // prev status는 비교 전용 — re-render를 유발하지 않도록 ref로 보관.
+  const prevStatusRef = useRef<LocationPermissionStatus>('unknown');
+
+  const refresh = useCallback(async (cancelledRef: { current: boolean }) => {
+    const next = await probePermissionStatus();
+    if (cancelledRef.current) return;
+    const prev = prevStatusRef.current;
+    const detected = classifyPermissionChange(prev, next);
+    if (detected !== 'none') {
+      logger.info('권한 변화 감지', { prev, next, change: detected });
+      setChange(detected);
+    }
+    prevStatusRef.current = next;
+    setStatus(next);
+  }, []);
+
+  useEffect(() => {
+    const cancelledRef = { current: false };
+    void refresh(cancelledRef);
+    const sub = AppState.addEventListener('change', (s: AppStateStatus) => {
+      if (s === 'active') void refresh(cancelledRef);
+    });
+    return () => {
+      cancelledRef.current = true;
+      sub.remove();
+    };
+  }, [refresh]);
+
+  const acknowledge = useCallback(() => {
+    setChange('none');
+  }, []);
+
+  return { status, change, acknowledge };
+}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -19,7 +19,11 @@
     "locating": "Locating...",
     "backgroundDeniedTitle": "Background location required",
     "backgroundDeniedBody": "To receive background alarms, set location access to \"Always\" in Settings.",
-    "openSettings": "Open Settings"
+    "openSettings": "Open Settings",
+    "changeRevokedTitle": "Location permission was revoked",
+    "changeRevokedBody": "Location access is off, so alarms may not fire. Please re-enable location access in Settings.",
+    "changeDowngradedTitle": "Background location was disabled",
+    "changeDowngradedBody": "\"Always\" was changed to \"While Using the App\", so background alarms may be missed. Please set access back to \"Always\" in Settings."
   },
   "home": {
     "arrived": "Arrived!",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -19,7 +19,11 @@
     "locating": "位置情報を取得中...",
     "backgroundDeniedTitle": "バックグラウンド位置情報の許可が必要です",
     "backgroundDeniedBody": "バックグラウンドでアラームを受け取るには、設定で位置情報を「常に許可」にしてください。",
-    "openSettings": "設定を開く"
+    "openSettings": "設定を開く",
+    "changeRevokedTitle": "位置情報の許可が取り消されました",
+    "changeRevokedBody": "位置情報がオフになり、アラームが鳴らない可能性があります。設定で位置情報の利用を再度許可してください。",
+    "changeDowngradedTitle": "バックグラウンドの位置情報が無効になりました",
+    "changeDowngradedBody": "「常に許可」が「Appの使用中のみ許可」に変更され、バックグラウンドアラームを受け取れない可能性があります。設定で「常に許可」に戻してください。"
   },
   "home": {
     "arrived": "到着!",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -19,7 +19,11 @@
     "locating": "위치 확인 중...",
     "backgroundDeniedTitle": "백그라운드 위치 권한 필요",
     "backgroundDeniedBody": "백그라운드에서 알람을 받으려면 설정에서 위치 권한을 '항상 허용'으로 설정해 주세요.",
-    "openSettings": "설정 열기"
+    "openSettings": "설정 열기",
+    "changeRevokedTitle": "위치 권한이 회수되었어요",
+    "changeRevokedBody": "위치 권한이 꺼져 알람이 울리지 않을 수 있어요. 설정에서 권한을 다시 허용해 주세요.",
+    "changeDowngradedTitle": "백그라운드 위치 권한이 해제되었어요",
+    "changeDowngradedBody": "'항상 허용'이 '앱 사용 중'으로 바뀌어 백그라운드 알람이 누락될 수 있어요. 설정에서 '항상 허용'으로 다시 설정해 주세요."
   },
   "home": {
     "arrived": "도착!",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -19,7 +19,11 @@
     "locating": "正在定位...",
     "backgroundDeniedTitle": "需要后台位置权限",
     "backgroundDeniedBody": "要在后台接收闹钟，请在设置中将位置访问设为\"始终允许\"。",
-    "openSettings": "打开设置"
+    "openSettings": "打开设置",
+    "changeRevokedTitle": "位置权限已被撤销",
+    "changeRevokedBody": "位置访问已关闭，闹钟可能不会响起。请在设置中重新允许位置访问。",
+    "changeDowngradedTitle": "后台位置权限已关闭",
+    "changeDowngradedBody": "\"始终允许\"已改为\"使用App时\"，后台闹钟可能会丢失。请在设置中重新设为\"始终允许\"。"
   },
   "home": {
     "arrived": "已到达!",

--- a/src/shared/ui/PermissionChangeBanner.tsx
+++ b/src/shared/ui/PermissionChangeBanner.tsx
@@ -1,0 +1,60 @@
+import { Linking, Text } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useTheme, typography, spacing } from '../theme';
+import { ActionBanner } from './ActionBanner';
+import type { LocationPermissionChange } from '../hooks/useLocationPermissionWatcher';
+
+interface Props {
+  /**
+   * 직전 권한 상태 대비 변화 종류. 'none'이면 banner를 렌더링하지 않는다.
+   * 호출자는 useLocationPermissionWatcher().change를 그대로 전달한다.
+   */
+  change: LocationPermissionChange;
+  /** 사용자가 dismiss/액션 시 watcher의 acknowledge를 호출하기 위한 콜백. */
+  onAcknowledge: () => void;
+}
+
+/**
+ * #1454 — 위치 권한이 회수되거나 Always→WhileInUse로 강등된 직후 노출되는 사용자 알림 배너.
+ *
+ * 사용자가 시스템 설정에서 변경한 직후 앱 foreground 진입 시점에 표시되며, 액션 버튼은
+ * iOS 설정 앱 deep link로 연결된다. dismiss/액션 모두 onAcknowledge를 호출해 같은
+ * change 상태로 재노출되지 않도록 한다(노출은 변화 이벤트 단위, dismiss 후 다음 변화까지 침묵).
+ *
+ * 표시 정책은 호출자가 결정한다 — 본 컴포넌트는 change 값에 따라 메시지만 분기한다.
+ */
+export function PermissionChangeBanner({ change, onAcknowledge }: Props) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+
+  if (change === 'none') return null;
+
+  const titleKey =
+    change === 'revoked'
+      ? 'permissions.changeRevokedTitle'
+      : 'permissions.changeDowngradedTitle';
+  const bodyKey =
+    change === 'revoked'
+      ? 'permissions.changeRevokedBody'
+      : 'permissions.changeDowngradedBody';
+
+  const handlePress = () => {
+    onAcknowledge();
+    void Linking.openSettings();
+  };
+
+  return (
+    <ActionBanner
+      accent={colors.warn}
+      testID="permission-change-banner"
+      actionLabel={t('permissions.openSettings')}
+      onActionPress={handlePress}
+      actionTestID="permission-change-open-settings"
+      marginBottom={spacing.md}
+      accessibilityLabel={t(titleKey)}
+    >
+      <Text style={[typography.label, { color: colors.warn }]}>{t(titleKey)}</Text>
+      <Text style={[typography.body, { color: colors.muted }]}>{t(bodyKey)}</Text>
+    </ActionBanner>
+  );
+}

--- a/src/shared/ui/PermissionChangeBanner.tsx
+++ b/src/shared/ui/PermissionChangeBanner.tsx
@@ -2,16 +2,19 @@ import { Linking, Text } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useTheme, typography, spacing } from '../theme';
 import { ActionBanner } from './ActionBanner';
+import { createLogger } from '../utils/logger';
 import type { LocationPermissionChange } from '../hooks/useLocationPermissionWatcher';
+
+const logger = createLogger('PermissionChangeBanner');
 
 interface Props {
   /**
    * 직전 권한 상태 대비 변화 종류. 'none'이면 banner를 렌더링하지 않는다.
    * 호출자는 useLocationPermissionWatcher().change를 그대로 전달한다.
    */
-  change: LocationPermissionChange;
+  readonly change: LocationPermissionChange;
   /** 사용자가 dismiss/액션 시 watcher의 acknowledge를 호출하기 위한 콜백. */
-  onAcknowledge: () => void;
+  readonly onAcknowledge: () => void;
 }
 
 /**
@@ -40,7 +43,9 @@ export function PermissionChangeBanner({ change, onAcknowledge }: Props) {
 
   const handlePress = () => {
     onAcknowledge();
-    void Linking.openSettings();
+    // Linking.openSettings()는 Promise를 반환한다.
+    // 실패해도 사용자에게 추가로 안내할 수단이 없으므로 logger.warn만 남기고 종결한다(SonarCloud S3735).
+    Linking.openSettings().catch((e: unknown) => logger.warn('설정 앱 열기 실패', e));
   };
 
   return (

--- a/src/shared/ui/__tests__/PermissionChangeBanner.test.tsx
+++ b/src/shared/ui/__tests__/PermissionChangeBanner.test.tsx
@@ -1,0 +1,48 @@
+import { Linking } from 'react-native';
+import { fireEvent } from '@testing-library/react-native';
+import { PermissionChangeBanner } from '../PermissionChangeBanner';
+import { renderWithTheme } from '../../../testUtils/renderWithTheme';
+
+let openSettingsSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  openSettingsSpy = jest.spyOn(Linking, 'openSettings').mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  openSettingsSpy.mockRestore();
+});
+
+describe('PermissionChangeBanner', () => {
+  it('change=none 일 때 null 렌더 (banner 미노출)', () => {
+    const { queryByTestId } = renderWithTheme(
+      <PermissionChangeBanner change="none" onAcknowledge={() => {}} />,
+    );
+    expect(queryByTestId('permission-change-banner')).toBeNull();
+  });
+
+  it('change=revoked 일 때 revoked 메시지가 노출된다', () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <PermissionChangeBanner change="revoked" onAcknowledge={() => {}} />,
+    );
+    expect(getByTestId('permission-change-banner')).toBeTruthy();
+    expect(getByText('위치 권한이 회수되었어요')).toBeTruthy();
+  });
+
+  it('change=downgraded 일 때 downgraded 메시지가 노출된다', () => {
+    const { getByText } = renderWithTheme(
+      <PermissionChangeBanner change="downgraded" onAcknowledge={() => {}} />,
+    );
+    expect(getByText('백그라운드 위치 권한이 해제되었어요')).toBeTruthy();
+  });
+
+  it('액션 탭 시 onAcknowledge 호출 + Linking.openSettings 호출', () => {
+    const onAcknowledge = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <PermissionChangeBanner change="revoked" onAcknowledge={onAcknowledge} />,
+    );
+    fireEvent.press(getByTestId('permission-change-open-settings'));
+    expect(onAcknowledge).toHaveBeenCalledTimes(1);
+    expect(openSettingsSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/shared/ui/__tests__/PermissionChangeBanner.test.tsx
+++ b/src/shared/ui/__tests__/PermissionChangeBanner.test.tsx
@@ -45,4 +45,17 @@ describe('PermissionChangeBanner', () => {
     expect(onAcknowledge).toHaveBeenCalledTimes(1);
     expect(openSettingsSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('Linking.openSettings rejection은 흡수되어 throw하지 않는다', async () => {
+    openSettingsSpy.mockRejectedValueOnce(new Error('settings unavailable'));
+    const onAcknowledge = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <PermissionChangeBanner change="revoked" onAcknowledge={onAcknowledge} />,
+    );
+    fireEvent.press(getByTestId('permission-change-open-settings'));
+    // 비동기 catch가 흐르도록 한 cycle 흘려보낸다 — throw가 없으면 통과.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onAcknowledge).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## 배경

GPS 위치 권한 회수 / Always→WhileInUse 강등은 정확성 게이트 외 영역이라 코드만으로 막을 수 없다. 변경 직후 사용자에게 명시 알림으로 silent trip(알림 누락) 원인을 인지시키고 설정 deep link로 복구 동선을 제공한다.

Closes #1454

관련: Epic #1432 · B4 #1452 (권한 정책 결정 의존)

## 변경 사항

- `src/shared/hooks/useLocationPermissionWatcher.ts` (+ 100% coverage 테스트)
  - 마운트 시 FG/BG 권한 동시 조회
  - `AppState 'active'` 진입 시 재조회 (사용자가 설정 앱에 다녀온 직후 변화 감지의 가장 신뢰 가능한 시점)
  - 직전 status 대비 `revoked` | `downgraded` | `none` 산출
  - `acknowledge()`로 change 리셋 (배너 dismiss 시 동일 change 재노출 차단)
  - 늦은 비동기 결과가 unmount 후 setState 호출하지 않도록 `cancelledRef` 가드
- `src/shared/ui/PermissionChangeBanner.tsx` (+ 100% coverage 테스트)
  - `change=none` 시 null 렌더 (배너 미노출)
  - revoked / downgraded 분기 메시지 + `Linking.openSettings()` 액션
  - 액션 탭 시 `onAcknowledge` 선행 호출 후 설정 앱 진입
- `src/screens/HomeScreen.tsx` — `ServiceWindowBanner` 직후 배너 wire-up (운영 모드 view 상단)
- `src/shared/i18n/locales/{ko,en,ja,zh}.json` — `permissions.changeRevokedTitle/Body`, `permissions.changeDowngradedTitle/Body` 4 locale 추가 (기존 `permissions` namespace 확장)

## 양방향 layer 추적

| 방향 | 의존 | 본 PR 처리 |
| --- | --- | --- |
| upstream | `expo-location` 권한 상태 (FG/BG `getXxxPermissionsAsync`) | 직접 호출. LocationPort 미경유 (Port는 `request*` 한정) |
| downstream | HomeScreen UI 배너 | `permissionWatcher.change` → `<PermissionChangeBanner>` 분기 |
| 데이터 의존 | i18n locales (ko/en/ja/zh) | 4 파일 동시 추가 |
| 인프라 | AppState 이벤트 | `AppState.addEventListener('change', ...)` + unmount 시 `sub.remove()` |
| 권한 매트릭스 | WhileInUse↔Always × FG↔BG | revoked (granted→denied), downgraded (always→whileinuse) 두 케이스 모두 감지 |

## 본 PR 범위 밖 (의도)

- Live Activity / push 알림 채널: HomeScreen 배너로 우선 대응. 사용자 BG 알림은 후속 결정 의존 (B4 #1452 권한 정책 확정 후)
- 권한 정책 자체: 본 PR은 사용자 명시 알림 UX만 제공. WhileInUse vs Always 강제 여부는 #1452 결정 후 별도 PR

## Acceptance

- 권한 변경/회수 시 HomeScreen 배너 노출 (revoked/downgraded 두 케이스)
- 배너 액션 → 설정 앱 deep link
- 배너 dismiss 후 같은 change 상태로 재노출 안 됨 (다음 변화 이벤트까지 침묵)
- silent trip 회귀 시 사용자가 원인 인지 가능

## 검증

- 새 파일 단위 테스트 18개 + 100% coverage (lines/branches/functions/statements)
- 전체 6327 테스트 PASS · 100% coverage 유지
- `npm run type-check` PASS
- `npm run lint` PASS (boundary 룰 포함)
- device-only 검증 갭: 실기기에서 권한 토글 후 앱 foreground 진입 시 배너 노출 + 설정 deep link 동작은 사용자 검증 필요 (Epic close 조건)

## Test plan

- [ ] iOS 실기기: Always 권한 → 설정에서 WhileInUse로 강등 → 앱 foreground 진입 시 downgraded 배너 노출
- [ ] iOS 실기기: WhileInUse 권한 → 설정에서 '안 함'으로 회수 → 앱 foreground 진입 시 revoked 배너 노출
- [ ] iOS 실기기: 배너 액션 탭 → 설정 앱 deep link 진입 + 배너 dismiss
- [ ] iOS 실기기: dismiss 후 같은 권한 상태 유지하면 재진입 시 배너 미노출
- [ ] 4 locale(ko/en/ja/zh) 메시지 시각 검수