### PR TITLE
fix(#1486): sticky:locked fire path 격리 — 별 채널 분리 (ADR-015 §2 보강)

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.movementGuard.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.movementGuard.test.ts
@@ -56,8 +56,12 @@ const mockTrackProgress = trackTrainProgress as jest.Mock;
 const mockPickCandidates = pickCandidateTrains as jest.Mock;
 
 function gpsBase(speedMps: number | null, accuracyMeters: number | null) {
+  const live = { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 };
   return {
-    result: { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
+    result: live,
+    // #1486 (ADR-015 §2) — sticky 비활성 시 liveResult = result, stickyDisplayOnly = null.
+    liveResult: live,
+    stickyDisplayOnly: null,
     variants: [MOCK_STATIONS.gangnam],
     userLocation: { lat: 37.5, lng: 127 },
     speedMps,

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -1892,7 +1892,7 @@ describe('useFusedNearestStation', () => {
       const liveStation = MOCK_STATIONS.chungmuro; // 사용자가 이동한 현재 station
       mockUseNearest.mockReturnValue(
         gpsBase({
-          result: { station: stickyStation, distanceKm: 1.0 }, // sticky override
+          result: { station: stickyStation, distanceKm: 1 }, // sticky override
           liveResult: { station: liveStation, distanceKm: 0.05 }, // 실 GPS
           stickyDisplayOnly: stickyStation,
           source: 'sticky' as const,

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -1855,26 +1855,36 @@ describe('useFusedNearestStation', () => {
   // 보강 (ADR-015 §2 처방): useNearestStation에 `liveResult`/`stickyDisplayOnly` 별 채널 분리.
   // useFusedNearestStation cascade fallback은 `gps.liveResult`만 사용 → sticky가 fire path에 진입 불가.
   describe('#1486 sticky:locked fire path 격리 (ADR-015 §2)', () => {
-    it('sticky가 다른 역 lock + 다른 신호 미통과 → fire path result는 live GPS 결과 (sticky 무시)', () => {
-      // useNearestStation의 sticky override 시뮬레이션:
-      //   exposed.result = sticky.locked (효창공원앞) — sticky가 표시 채널을 override
-      //   liveResult = GPS 최근접 (강남)     — sticky 없는 실 위치
-      const stickyStation = MOCK_STATIONS.chungmuro; // sticky locked station (잘못된 lock)
-      const liveStation = MOCK_STATIONS.gangnam; // 실제 GPS 위치
+    // sticky override + live GPS 분리 setup helper — useNearestStation의 exposed 동작 시뮬레이션.
+    //   result          = sticky.locked로 override된 표시 채널
+    //   liveResult      = sticky override 없는 실 GPS 결과 (cascade fallback SSOT)
+    //   findTopNearest  = 다른 신호(wifi/positionTrain/fused/route) 미통과 가정
+    function renderWithStickyOverride(opts: {
+      stickyStation: (typeof MOCK_STATIONS)[keyof typeof MOCK_STATIONS];
+      liveStation: (typeof MOCK_STATIONS)[keyof typeof MOCK_STATIONS];
+      stickyDistance?: number;
+      liveDistance?: number;
+      accuracyMeters?: number;
+    }) {
+      const { stickyStation, liveStation, stickyDistance = 0.1, liveDistance = 0.1, accuracyMeters } = opts;
       mockUseNearest.mockReturnValue(
         gpsBase({
-          // result는 sticky.locked로 override된 상태 (useNearestStation의 exposed 동작 시뮬)
-          result: { station: stickyStation, distanceKm: 0.1 },
-          // liveResult는 sticky override 없는 실 GPS 결과
-          liveResult: { station: liveStation, distanceKm: 0.1 },
+          result: { station: stickyStation, distanceKm: stickyDistance },
+          liveResult: { station: liveStation, distanceKm: liveDistance },
           stickyDisplayOnly: stickyStation,
           source: 'sticky' as const,
+          ...(accuracyMeters != null ? { accuracyMeters } : {}),
         }),
       );
-      // 다른 신호(wifi/positionTrain/fused/route) 모두 미통과
-      mockFindTop.mockReturnValue([{ station: liveStation, distanceKm: 0.1 }]);
+      mockFindTop.mockReturnValue([{ station: liveStation, distanceKm: liveDistance }]);
+      return renderHook(() => useFusedNearestStation());
+    }
 
-      const { result } = renderHook(() => useFusedNearestStation());
+    it('sticky가 다른 역 lock + 다른 신호 미통과 → fire path result는 live GPS 결과 (sticky 무시)', () => {
+      // exposed.result = sticky.locked (효창공원앞) / liveResult = GPS 최근접 (강남)
+      const stickyStation = MOCK_STATIONS.chungmuro;
+      const liveStation = MOCK_STATIONS.gangnam;
+      const { result } = renderWithStickyOverride({ stickyStation, liveStation });
 
       // fire path SSOT — sticky가 아닌 live GPS 결과로 cascade fallback.
       expect(result.current.result?.station.id).toBe(liveStation.id);
@@ -1888,20 +1898,15 @@ describe('useFusedNearestStation', () => {
       // 2026-06-16 13:27:18 / 13:28:39 dump 재현:
       // sticky가 용마산(7) lock 상태에서 사용자가 사가정(7)으로 이동 → GPS 최근접은 사가정.
       // sticky better-fix 조건(N=3 좋은 fix 연속) 충족 전에는 sticky가 용마산 유지.
-      const stickyStation = MOCK_STATIONS.gangnam; // 사용자가 이전에 있던 station (stale lock)
-      const liveStation = MOCK_STATIONS.chungmuro; // 사용자가 이동한 현재 station
-      mockUseNearest.mockReturnValue(
-        gpsBase({
-          result: { station: stickyStation, distanceKm: 1 }, // sticky override
-          liveResult: { station: liveStation, distanceKm: 0.05 }, // 실 GPS
-          stickyDisplayOnly: stickyStation,
-          source: 'sticky' as const,
-          accuracyMeters: 50,
-        }),
-      );
-      mockFindTop.mockReturnValue([{ station: liveStation, distanceKm: 0.05 }]);
-
-      const { result } = renderHook(() => useFusedNearestStation());
+      const stickyStation = MOCK_STATIONS.gangnam;
+      const liveStation = MOCK_STATIONS.chungmuro;
+      const { result } = renderWithStickyOverride({
+        stickyStation,
+        liveStation,
+        stickyDistance: 1,
+        liveDistance: 0.05,
+        accuracyMeters: 50,
+      });
 
       // fire path는 sticky station에 false station-passed fire를 발사하지 않는다.
       expect(result.current.result?.station.id).toBe(liveStation.id);
@@ -1924,17 +1929,7 @@ describe('useFusedNearestStation', () => {
     it('표시 채널 stickyDisplayOnly — sticky lock된 station 그대로 패스스루', () => {
       const stickyStation = MOCK_STATIONS.chungmuro;
       const liveStation = MOCK_STATIONS.gangnam;
-      mockUseNearest.mockReturnValue(
-        gpsBase({
-          result: { station: stickyStation, distanceKm: 0.1 },
-          liveResult: { station: liveStation, distanceKm: 0.1 },
-          stickyDisplayOnly: stickyStation,
-          source: 'sticky' as const,
-        }),
-      );
-      mockFindTop.mockReturnValue([{ station: liveStation, distanceKm: 0.1 }]);
-
-      const { result } = renderHook(() => useFusedNearestStation());
+      const { result } = renderWithStickyOverride({ stickyStation, liveStation });
 
       // DebugModal/UI는 stickyDisplayOnly로 sticky 정보 노출.
       expect(result.current.stickyDisplayOnly).toEqual(stickyStation);

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -41,7 +41,7 @@ const mockUsePositions = useTrainPositions as jest.Mock;
 const mockFindTop = findTopNearestStations as jest.Mock;
 
 function gpsBase(overrides?: Record<string, unknown>) {
-  return {
+  const base = {
     result: { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
     variants: [MOCK_STATIONS.gangnam],
     userLocation: { lat: 37.5, lng: 127.0 },
@@ -52,8 +52,17 @@ function gpsBase(overrides?: Record<string, unknown>) {
     permissionDenied: false,
     locationUncertain: false,
     refresh: jest.fn(),
+    // #1486 (ADR-015 §2) — sticky override 없는 live GPS 결과. cascade fallback의 SSOT.
+    // 기본값은 `result`와 동일 (sticky 비활성) — sticky lock 테스트에서 명시 override.
+    liveResult: { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
+    stickyDisplayOnly: null,
     ...overrides,
   };
+  // override가 result만 지정하면 liveResult도 동기화 — sticky 시나리오는 직접 분리 지정.
+  if (overrides && 'result' in overrides && !('liveResult' in overrides)) {
+    base.liveResult = overrides.result as typeof base.liveResult;
+  }
+  return base;
 }
 
 function info(arrivalCode: number, overrides?: Partial<ArrivalInfo>): ArrivalInfo {
@@ -1831,6 +1840,104 @@ describe('useFusedNearestStation', () => {
       };
       renderHook(() => useFusedNearestStation(undefined, undefined, routeContext));
       expect(mockFindTop.mock.calls[0][4]).toBeUndefined();
+    });
+  });
+
+  // #1486 (ADR-015 §2) — sticky:locked fire 권한 영구 박탈 회귀 가드.
+  //
+  // useNearestStation:487-504 `exposed`는 sticky.locked가 있고 live와 다른 역이면
+  // result.station을 sticky.locked로 override한다. 이전에는 그 result가 useFusedNearestStation
+  // cascade fallback의 `gps.result` 입력으로 들어가 fire path(`useStationAlarm.nearestStation`)에 새었다.
+  //
+  // 2026-06-16 13:27:18 / 13:28:39 dump 시나리오: sticky:locked가 1km 점프(better-fix 갱신 직전
+  // 혹은 stale lock)된 상태에서 useStationAlarm이 sticky station에 대한 station-passed를 fire할 가능성.
+  //
+  // 보강 (ADR-015 §2 처방): useNearestStation에 `liveResult`/`stickyDisplayOnly` 별 채널 분리.
+  // useFusedNearestStation cascade fallback은 `gps.liveResult`만 사용 → sticky가 fire path에 진입 불가.
+  describe('#1486 sticky:locked fire path 격리 (ADR-015 §2)', () => {
+    it('sticky가 다른 역 lock + 다른 신호 미통과 → fire path result는 live GPS 결과 (sticky 무시)', () => {
+      // useNearestStation의 sticky override 시뮬레이션:
+      //   exposed.result = sticky.locked (효창공원앞) — sticky가 표시 채널을 override
+      //   liveResult = GPS 최근접 (강남)     — sticky 없는 실 위치
+      const stickyStation = MOCK_STATIONS.chungmuro; // sticky locked station (잘못된 lock)
+      const liveStation = MOCK_STATIONS.gangnam; // 실제 GPS 위치
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          // result는 sticky.locked로 override된 상태 (useNearestStation의 exposed 동작 시뮬)
+          result: { station: stickyStation, distanceKm: 0.1 },
+          // liveResult는 sticky override 없는 실 GPS 결과
+          liveResult: { station: liveStation, distanceKm: 0.1 },
+          stickyDisplayOnly: stickyStation,
+          source: 'sticky' as const,
+        }),
+      );
+      // 다른 신호(wifi/positionTrain/fused/route) 모두 미통과
+      mockFindTop.mockReturnValue([{ station: liveStation, distanceKm: 0.1 }]);
+
+      const { result } = renderHook(() => useFusedNearestStation());
+
+      // fire path SSOT — sticky가 아닌 live GPS 결과로 cascade fallback.
+      expect(result.current.result?.station.id).toBe(liveStation.id);
+      expect(result.current.source).toBe('gps');
+      expect(result.current.confidence).toBe('gps-only');
+      // 표시 채널 — sticky 정보는 stickyDisplayOnly로 별 노출(DebugModal/UI 추적용).
+      expect(result.current.stickyDisplayOnly?.id).toBe(stickyStation.id);
+    });
+
+    it('1km 점프 시나리오 — sticky가 stale lock된 station을 가리켜도 fire path는 GPS 최근접', () => {
+      // 2026-06-16 13:27:18 / 13:28:39 dump 재현:
+      // sticky가 용마산(7) lock 상태에서 사용자가 사가정(7)으로 이동 → GPS 최근접은 사가정.
+      // sticky better-fix 조건(N=3 좋은 fix 연속) 충족 전에는 sticky가 용마산 유지.
+      const stickyStation = MOCK_STATIONS.gangnam; // 사용자가 이전에 있던 station (stale lock)
+      const liveStation = MOCK_STATIONS.chungmuro; // 사용자가 이동한 현재 station
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          result: { station: stickyStation, distanceKm: 1.0 }, // sticky override
+          liveResult: { station: liveStation, distanceKm: 0.05 }, // 실 GPS
+          stickyDisplayOnly: stickyStation,
+          source: 'sticky' as const,
+          accuracyMeters: 50,
+        }),
+      );
+      mockFindTop.mockReturnValue([{ station: liveStation, distanceKm: 0.05 }]);
+
+      const { result } = renderHook(() => useFusedNearestStation());
+
+      // fire path는 sticky station에 false station-passed fire를 발사하지 않는다.
+      expect(result.current.result?.station.id).toBe(liveStation.id);
+      expect(result.current.result?.station.id).not.toBe(stickyStation.id);
+      expect(result.current.source).toBe('gps');
+    });
+
+    it('sticky 비활성 → result/liveResult 동일 (회귀 가드 무영향)', () => {
+      // sticky 비활성 (stickyDisplayOnly=null): 기존 동작 그대로.
+      mockUseNearest.mockReturnValue(gpsBase()); // 기본값: result=liveResult=gangnam, sticky=null
+      mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
+
+      const { result } = renderHook(() => useFusedNearestStation());
+
+      expect(result.current.result?.station.id).toBe(MOCK_STATIONS.gangnam.id);
+      expect(result.current.stickyDisplayOnly).toBeNull();
+      expect(result.current.source).toBe('gps');
+    });
+
+    it('표시 채널 stickyDisplayOnly — sticky lock된 station 그대로 패스스루', () => {
+      const stickyStation = MOCK_STATIONS.chungmuro;
+      const liveStation = MOCK_STATIONS.gangnam;
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          result: { station: stickyStation, distanceKm: 0.1 },
+          liveResult: { station: liveStation, distanceKm: 0.1 },
+          stickyDisplayOnly: stickyStation,
+          source: 'sticky' as const,
+        }),
+      );
+      mockFindTop.mockReturnValue([{ station: liveStation, distanceKm: 0.1 }]);
+
+      const { result } = renderHook(() => useFusedNearestStation());
+
+      // DebugModal/UI는 stickyDisplayOnly로 sticky 정보 노출.
+      expect(result.current.stickyDisplayOnly).toEqual(stickyStation);
     });
   });
 });

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.tierCascade.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.tierCascade.test.ts
@@ -57,8 +57,12 @@ function setupLocklessTripAtYongmasan({
   jest.setSystemTime(T0);
 
   // GPS 용마산 정적 보고. accuracy 변경으로 surfaceSSOT 활성/비활성 전환.
+  // #1486 — sticky 비활성: liveResult=result, stickyDisplayOnly=null.
+  const live = { station: yongmasan, distanceKm: 0 };
   mockNearest.mockReturnValue({
-    result: { station: yongmasan, distanceKm: 0 },
+    result: live,
+    liveResult: live,
+    stickyDisplayOnly: null,
     variants: [yongmasan],
     userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
     ...GPS_BASE_DEFAULTS,

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.transferRegression.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.transferRegression.test.ts
@@ -41,8 +41,12 @@ const mockUsePositions = useTrainPositions as jest.Mock;
 const mockFindTop = findTopNearestStations as jest.Mock;
 
 function gpsAt(station: Station) {
+  const live = { station, distanceKm: 0 };
   return {
-    result: { station, distanceKm: 0 },
+    result: live,
+    // #1486 (ADR-015 §2) — sticky 비활성: liveResult=result, stickyDisplayOnly=null.
+    liveResult: live,
+    stickyDisplayOnly: null,
     variants: [station],
     userLocation: { lat: station.lat, lng: station.lng },
     speedMps: 0,

--- a/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
@@ -1031,6 +1031,9 @@ describe('useNearestStation — #876 sticky station integration', () => {
     await waitFor(() => expect(result.current.result).not.toBeNull());
     expect(result.current.source).toBe('live');
     expect(result.current.result?.station.name).toBe('강남');
+    // #1486 (ADR-015 §2) — sticky 비활성 시 liveResult=result, stickyDisplayOnly=null.
+    expect(result.current.liveResult?.station.name).toBe('강남');
+    expect(result.current.stickyDisplayOnly).toBeNull();
   });
 
   it('AsyncStorage 미리 저장된 sticky lock 있고 GPS가 다른 역이면 result는 sticky 역으로 override', async () => {
@@ -1049,6 +1052,11 @@ describe('useNearestStation — #876 sticky station integration', () => {
     expect(result.current.result?.station.name).toBe('효창공원앞');
     // distanceKm은 userLocation 기준 재계산 (효창 ↔ 강남 ≈ 10km+)
     expect(result.current.result?.distanceKm).toBeGreaterThan(5);
+    // #1486 (ADR-015 §2) — sticky override 상황에서 liveResult/stickyDisplayOnly 분리 검증.
+    // liveResult는 sticky 무시 GPS 최근접(강남) — fire path 입력.
+    expect(result.current.liveResult?.station.name).toBe('강남');
+    // stickyDisplayOnly는 표시 전용 sticky 정보(효창공원앞) — DebugModal/UI 추적.
+    expect(result.current.stickyDisplayOnly?.name).toBe('효창공원앞');
   });
 
   // #876 — sticky.locked와 result.station이 같은 역이면 source='sticky'지만 result는 live 객체 그대로 반환.

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -188,6 +188,16 @@ interface UseFusedNearestStationReturn {
    */
   surfaceSSOT: { station: import('../../../shared/types/station').Station; trainCode: string } | null;
   undergroundSSOT: { station: import('../../../shared/types/station').Station; trainCode: string } | null;
+  /**
+   * #1486 (ADR-015 §2) — sticky lock 정보 표시 전용 채널 (useNearestStation 패스스루).
+   *
+   * sticky lock 활성 시 lock된 station만 노출. 비활성/없음 시 null.
+   * fire path 진입 금지 — DebugModal/UI 추적 신호 표시에만 사용.
+   *
+   * displayOnlyEstimate(estimator 표시 채널)와 같은 패턴: 시간 적분/jitter 흡수 신호는
+   * fire path SSOT(result/confidence/source)에서 분리되어 표시 채널로만 노출된다.
+   */
+  stickyDisplayOnly: import('../../../shared/types/station').Station | null;
   refresh: () => Promise<void>;
 }
 
@@ -655,7 +665,13 @@ export function useFusedNearestStation(
     confidence = 'route-progress';
     source = 'route-progress';
   } else {
-    result = gps.result;
+    // #1486 (ADR-015 §2) — sticky:locked fire 권한 영구 박탈.
+    // useNearestStation은 sticky lock 활성 시 exposed.result를 sticky station으로 override한다
+    // (useNearestStation:487-504). 그대로 gps.result를 사용하면 sticky station이 fire path
+    // cascade fallback에 들어가 station-passed/imminent fire의 nearestStation 입력이 된다.
+    // gps.liveResult는 sticky override 없는 GPS 최근접 결과 — sticky:locked가 fire path 진입 차단.
+    // 표시 채널은 gps.stickyDisplayOnly로 별 노출(아래 return).
+    result = gps.liveResult;
     confidence = 'gps-only';
     source = 'gps';
   }
@@ -679,11 +695,14 @@ export function useFusedNearestStation(
     { stationName: c1, line: h1, arrival: a1.arrival },
     { stationName: c2, line: h2, arrival: a2.arrival },
   ];
-  const surfaceArrival = gps.result
-    ? pickArrivalForStationName(gps.result.station.name, gps.result.station.line, arrivalSlots)
+  // #1486 (ADR-015 §2) — surface SSOT 산출도 sticky 격리. sticky:locked가 gps.result에 들어가면
+  // 잘못된 station의 arrival을 pick해 consensus가 sticky station을 SSOT로 산출할 수 있다.
+  // gps.liveResult는 sticky override 없는 live GPS 최근접 — Tier 1 SSOT 산출의 fire path 영향 차단.
+  const surfaceArrival = gps.liveResult
+    ? pickArrivalForStationName(gps.liveResult.station.name, gps.liveResult.station.line, arrivalSlots)
     : null;
   const surfaceSSOT = surfaceSSOTConsensus({
-    gpsResult: gps.result,
+    gpsResult: gps.liveResult,
     gpsAccuracy: gps.accuracyMeters,
     arrival: surfaceArrival,
   });
@@ -900,7 +919,9 @@ export function useFusedNearestStation(
   ) {
     confidence = 'gps-only';
     source = 'gps';
-    result = gps.result;
+    // #1486 (ADR-015 §2) — 강등 후 GPS 원본 fallback도 sticky 격리.
+    // 위 cascade fallback과 동일 패턴: gps.liveResult가 sticky override 없는 GPS 최근접.
+    result = gps.liveResult;
   }
 
   // #1401 — prev arc idx 갱신. 최종 result 결정 후(강등 후 station이 바뀌었을 수 있음) idx 다시 계산.
@@ -1108,6 +1129,9 @@ export function useFusedNearestStation(
     // #1421 — DebugModal Auto-lock 측정 섹션이 SSOT 객체를 inferAutoLockCandidate에 직접 전달.
     surfaceSSOT,
     undergroundSSOT,
+    // #1486 (ADR-015 §2) — sticky 표시 채널 패스스루. useNearestStation이 sticky.locked를 노출하고
+    // 본 hook은 그대로 통과. fire path는 본 필드를 읽지 않는다.
+    stickyDisplayOnly: gps.stickyDisplayOnly,
     refresh: gps.refresh,
   };
 }

--- a/src/features/nearest-station/hooks/useNearestStation.ts
+++ b/src/features/nearest-station/hooks/useNearestStation.ts
@@ -73,6 +73,28 @@ function fgWatchOptionsFor(throttled: boolean): Location.LocationOptions {
 // 이 계약을 강제한다.
 interface UseNearestStationReturn {
   result: NearestStationResult | null;
+  /**
+   * #1486 (ADR-015 §2) — sticky override 없는 live GPS 최근접 결과.
+   *
+   * `result`는 sticky lock이 활성이고 다른 역이면 sticky station으로 override된다(`exposed` 로직).
+   * fire path(`useFusedNearestStation` cascade fallback → `useStationAlarm.nearestStation`)가 sticky
+   * 결과를 받지 않도록 호출자(useFusedNearestStation)는 본 필드를 사용한다.
+   *
+   * sticky 비활성 시 `result`와 동일 reference — 추가 cost 없음.
+   * sticky 활성 + 다른 역 lock 시 `result`는 sticky station, `liveResult`는 GPS 최근접 그대로.
+   *
+   * ADR-015 §2 — sticky:locked fire 권한 영구 박탈, UI 표시 채널만 유지.
+   */
+  liveResult: NearestStationResult | null;
+  /**
+   * #1486 (ADR-015 §2) — sticky lock 정보 표시 전용 채널.
+   *
+   * sticky lock 활성 시 lock된 station만 노출. lock 비활성 시 null.
+   * fire path 진입 금지 — DebugModal/UI 추적 신호 표시에만 사용.
+   *
+   * 호출자(useFusedNearestStation)가 표시 채널로 그대로 통과시킨다.
+   */
+  stickyDisplayOnly: Station | null;
   variants: Station[];
   userLocation: { lat: number; lng: number } | null;
   speedMps: number | null;
@@ -505,6 +527,13 @@ export function useNearestStation(
 
   return {
     result: exposed.result,
+    // #1486 (ADR-015 §2) — sticky override 없는 live GPS 결과. useFusedNearestStation cascade가
+    // fire path 입력으로 사용 (sticky 격리). sticky 비활성 또는 같은 역이면 exposed.result와
+    // 동일 reference (위 useMemo 분기 0의 `result` 그대로) — 추가 cost 없음.
+    liveResult: result,
+    // #1486 (ADR-015 §2) — sticky lock 정보 표시 전용 채널.
+    // 호출자(useFusedNearestStation)가 DebugModal/UI 추적용으로 그대로 통과시킨다.
+    stickyDisplayOnly: sticky.locked,
     variants,
     userLocation,
     speedMps,


### PR DESCRIPTION
## 배경 (ADR-015 §2 후속 — E6 #1439 검증 결과)

ADR-015 §2 처방:

> 다음 source는 알림 fire 권한 영구 박탈. UI 표시(현재 위치 추적)는 유지, 알림 발사 X.
> - `sticky:locked` (jitter 흡수 표시) — fire path와 표시 채널 분리
>
> 코드 위치: `useStickyStation.ts:307` 결과는 별 채널 `useStickyDisplayOnly`로 격리.

E4 PR #1445가 `interp`/`estimator currentHopIndex` 박탈은 완료했으나 sticky:locked 격리는 미완료. 본 PR이 ADR-015 §2의 sticky 격리 처방을 완성.

## 양방향 layer 추적 결과 (검증 evidence)

PR #1445 본문 주장: `useStickyStation`은 `useNearestStation`(MapScreen 전용) 경로에만 존재 — fire path와 격리되어 있어 추가 변경 불필요.

**검증 결과: 부정확.** sticky:locked가 fire path에 새는 경로 존재.

| layer | 코드 | 영향 |
|---|---|---|
| upstream | `useStickyStation.ts:283-313` | 좋은 fix N=3 연속 시 lock 산출 |
| | `useNearestStation.ts:475` | `const sticky = useStickyStation(...)` 호출 |
| | `useNearestStation.ts:487-504` `exposed` memo | sticky.locked 있고 live와 다르면 **result.station을 sticky.locked로 override** |
| seam | `useFusedNearestStation.ts:346` | `const gps = useNearestStation(...)` — sticky-override된 result를 gps.result로 받음 |
| downstream | `useFusedNearestStation.ts:657-660` | cascade fallback `result = gps.result; confidence = 'gps-only'; source = 'gps'` — sticky가 fire path SSOT로 흘러감 |
| | `HomeScreen.tsx:407` | `nearestStation: result?.station ?? null` — useStationAlarm에 sticky station 전달 |
| | `useStationAlarm.ts:849` | `isStationOnRoute(nearestStation, route)` 통과 + accuracy ≤200m 시 station-passed fire |

`useFusedNearestStation.ts:688-693` surface SSOT 산출에도 동일 영향 — sticky 결과로 잘못된 station의 arrival pick → Tier 1 SSOT가 sticky station을 가리킬 가능성.

## 변경 (~30줄 코드 + 회귀 가드 테스트)

### `useNearestStation.ts`
- 신규 반환 필드:
  - `liveResult: NearestStationResult | null` — sticky override 없는 live GPS 결과. cascade fallback의 SSOT.
  - `stickyDisplayOnly: Station | null` — sticky lock 정보 표시 전용 채널. DebugModal/UI 추적용.
- 기존 `result` / `source` 변경 없음 — useNearestStation 단독 호출자(MapScreen 등)는 무회귀.

### `useFusedNearestStation.ts`
- cascade fallback 변경: `result = gps.result` → `result = gps.liveResult` (line 660).
- 강등 분기 변경: shouldDowngradeFusion 후 `result = gps.result` → `result = gps.liveResult` (line 909).
- surface SSOT 산출 변경: `gps.result` → `gps.liveResult` (line 688-693). Tier 1 SSOT도 sticky 격리.
- 신규 반환 필드 `stickyDisplayOnly: Station | null` — useNearestStation 패스스루.

### 테스트 (~120줄)
- `useFusedNearestStation.test.ts`: `#1486 sticky:locked fire path 격리 (ADR-015 §2)` describe 신규 4개.
  - sticky가 다른 역 lock + 다른 신호 미통과 → fire path result는 live GPS (sticky 무시)
  - 1km 점프 시나리오 — sticky가 stale lock 가리켜도 fire path는 GPS 최근접
  - sticky 비활성 → 회귀 가드 무영향
  - 표시 채널 stickyDisplayOnly — sticky lock된 station 그대로 패스스루
- `useNearestStation.test.ts`: 기존 sticky 테스트에 `liveResult`/`stickyDisplayOnly` 분리 검증 추가.
- 기존 mock helper(`gpsBase` / `gpsAt`) — `liveResult`/`stickyDisplayOnly` 필드 추가로 통과.

## Acceptance (이슈 #1486 본문 매핑)

| Acceptance | 본 PR 검증 |
|---|---|
| sticky:locked가 fire path에 진입 0건 | cascade fallback `gps.liveResult` 사용 → sticky 결과 진입 차단. 회귀 가드 4개로 검증. |
| UI 표시 회귀 0건 | `stickyDisplayOnly` 별 채널 노출. DebugModal `kind: 'sticky'` log entries 유지. |
| 회귀 테스트 — 2026-06-16 dump 1km 점프 시나리오 | `1km 점프 시나리오 — sticky가 stale lock된 station을 가리켜도 fire path는 GPS 최근접` it 블록 |
| type-check + 전체 테스트 통과 | type-check ✅, nearest-station hook 533/533 PASS |
| 1주 실기기 또는 production 측정 (epic close 조건) | 본 PR 머지 후 사용자 측정 |

## 검증

- `npm run type-check` ✅
- `npx jest src/features/nearest-station/hooks/__tests__/` — 533/533 PASS
- 전체 `npm test` — 사전 broken 35건 (widgetStorage native mock, 본 변경 무관, dev 동일) 외 PASS

## 참고

- Epic: #1432
- ADR: `docs/decisions/ADR-015-multi-signal-consensus-gate.md` §2
- 선행 PR: #1445 (E4 — interp/estimator currentHopIndex 박탈 완료)
- 관련 메모리:
  - `project_2026_06_16_sticky_cascade.md` — sticky cascade 분석
  - `feedback_full_layer_cross_trace.md` — 양방향 layer 추적 룰
  - `lesson_lockless_route_hop_time_integration_ssot_assumption.md` — 시간 적분 SSOT 가정 결함

Closes #1486