### PR TITLE
chore(#1453): wrangler tail watchdog 재작성 + logs prune + launchd 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ coverage-temp/
 
 # Project docs & data (별도 이슈로 관리)
 docs/*
+!docs/agents/
 !docs/ci/
 !docs/decisions/
 !docs/ops/
@@ -80,3 +81,15 @@ subway-now_icon.png
 # 데이터 덤프
 # (tasks/는 epic SSOT·작업 계획 문서를 repo로 관리하기로 결정 — 2026-06-11, #1008 SSOT 유실 건)
 scripts/CARD_SUBWAY_MONTH_*.csv
+
+# wrangler tail watchdog 산출물 (#1453)
+tasks/wrangler-tail-watchdog.jsonl
+tasks/wrangler-tail-watchdog.jsonl.*
+tasks/wrangler-tail-watchdog.err
+tasks/wrangler-tail-watchdog.alert
+tasks/wrangler-tail-*.jsonl
+tasks/tail-watchdog-stdout.log
+tasks/launchd-stdout.log
+tasks/launchd-stderr.log
+tasks/launchd-prune-stdout.log
+tasks/launchd-prune-stderr.log

--- a/docs/agents/wrangler-tail-watchdog.md
+++ b/docs/agents/wrangler-tail-watchdog.md
@@ -1,0 +1,98 @@
+# wrangler tail watchdog 운영 (#1453)
+
+backend `alarm-worker`의 `wrangler tail` 스트림을 좀비 없이 유지하기 위한 운영 절차.
+
+배경: `memory/lesson_wrangler_tail_wrapper_reliability.md`. 단순 `while true; do wrangler tail; sleep N; done` 루프는 wrangler 프로세스가 살아있는데 스트림만 죽는 "좀비"를 복구하지 못한다.
+
+## 구성요소
+
+| 파일 | 역할 |
+| --- | --- |
+| `scripts/tail-watchdog.sh` | wrangler tail 무한 spawn + mtime 기반 좀비 감지 + log rotation + max-restarts |
+| `scripts/prune-wrangler-logs.sh` | `~/Library/Preferences/.wrangler/logs/` 7일 이상 자동 prune |
+| `scripts/launchd/com.subway-now.wrangler-log-prune.plist` | 매일 03:00 KST에 prune 실행하는 LaunchAgent |
+
+출력:
+- `tasks/wrangler-tail-watchdog.jsonl` — tail 본 스트림 (10MB 도달 시 `.jsonl.<ts>`로 회전)
+- `tasks/wrangler-tail-watchdog.err` — 재spawn / 좀비 kill / 회전 로그
+- `tasks/wrangler-tail-watchdog.alert` — `MAX_RESTARTS` 초과 시 ALERT 한 줄 + 종료
+
+## 일상 사용
+
+```bash
+# 새 trip 캡처 전에 watchdog 띄우기 (포그라운드)
+scripts/tail-watchdog.sh trip-2026-06-18
+
+# 백그라운드 (세션 종료 후에도 유지하려면 nohup + & 또는 tmux)
+nohup scripts/tail-watchdog.sh trip-2026-06-18 \
+  > tasks/tail-watchdog-stdout.log 2>&1 &
+
+# 상태 점검 — jsonl mtime이 살아있는지
+ls -la tasks/wrangler-tail-watchdog.jsonl
+date; stat -f '%Sm' tasks/wrangler-tail-watchdog.jsonl
+
+# 좀비 발생 흔적 (err 파일에 "stale" 라인이 누적되면 wrangler/네트워크 점검 필요)
+grep stale tasks/wrangler-tail-watchdog.err | tail
+```
+
+## 튜닝
+
+| 환경변수 | 기본 | 의미 |
+| --- | --- | --- |
+| `STALE_SECS` | 90 | jsonl mtime이 N초 stale이면 wrangler kill |
+| `CHECK_INTERVAL` | 30 | watchdog poll 주기 |
+| `MAX_BYTES` | 10485760 (10MB) | jsonl 회전 임계 |
+| `MAX_RESTARTS` | 100 | 누적 spawn 상한 (초과 시 alert + 종료) |
+| `RESPAWN_SLEEP` | 3 | EXIT → 재spawn 대기 |
+| `OUT_DIR` | `tasks/` | 출력 디렉토리 |
+| `TAIL_CMD` | wrangler tail | override (테스트 전용) |
+
+## 로그 prune LaunchAgent 설치
+
+```bash
+# 1) plist 복사 (절대경로가 박혀있으니 워크트리가 아닌 메인 repo의 scripts/ 사용)
+cp scripts/launchd/com.subway-now.wrangler-log-prune.plist \
+   ~/Library/LaunchAgents/
+
+# 2) load
+launchctl bootstrap gui/$(id -u) \
+  ~/Library/LaunchAgents/com.subway-now.wrangler-log-prune.plist
+
+# 3) 즉시 한 번 실행 (검증)
+launchctl kickstart -k gui/$(id -u)/com.subway-now.wrangler-log-prune
+cat tasks/launchd-prune-stdout.log
+```
+
+## 기존 `com.subway-now.scheduled-tail.plist` 제거
+
+이 plist는 존재하지 않는 `scripts/scheduled-deploy-and-tail.sh`를 참조해 매일 08:00 KST에 실패만 로그로 남기던 좀비였다. #1453로 본 watchdog + prune 체계로 대체. 다음 명령으로 제거:
+
+```bash
+launchctl bootout gui/$(id -u)/com.subway-now.scheduled-tail 2>/dev/null || true
+rm -f ~/Library/LaunchAgents/com.subway-now.scheduled-tail.plist
+# 누적된 launchd 로그도 제거
+rm -f tasks/launchd-stdout.log tasks/launchd-stderr.log
+```
+
+## Acceptance 자가 검증
+
+- 6시간 watchdog 띄운 후 `tasks/wrangler-tail-watchdog.err`에 "stale" 라인이 발생해도 jsonl이 다시 자라기 시작했는가? (좀비 복구 성공)
+- `tasks/wrangler-tail-watchdog.jsonl` 크기가 10MB를 넘긴 적이 있는가? (회전 정상)
+- `~/Library/Preferences/.wrangler/logs/`가 LaunchAgent 설치 후 7일 분량으로 안정되는가? (prune 정상)
+
+## 수동 검증 절차
+
+```bash
+# 좀비 시뮬레이션: 무한히 응답 없는 mock 명령으로 watchdog 띄움
+STALE_SECS=5 CHECK_INTERVAL=2 \
+  TAIL_CMD='sleep 600' \
+  OUT_DIR=/tmp/wd-test \
+  scripts/tail-watchdog.sh stale-test &
+WD=$!
+sleep 12
+# err에 "killing wrangler tail" 라인이 찍혀야 함
+grep stale /tmp/wd-test/wrangler-tail-watchdog.err
+kill $WD
+```
+
+수동 검증 결과는 PR 본문에 evidence로 첨부.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -57,3 +57,15 @@ stderr에 출력된다. 0건이 정상이라고 결론짓기 전에 raw tail에 
 
 `scripts/capture-tail.sh`. backend 전반 진단용 raw tail. boarding-prompt 특화 분석은
 위 `measure:blocked-reasons`를 사용.
+
+## tail-watchdog — 좀비 없는 장시간 tail (#1453)
+
+`scripts/tail-watchdog.sh`. `wrangler tail`이 inactivity/stream 죽음으로 빠지는 좀비를
+파일 mtime 기반으로 감지해 강제 재spawn. 10MB 도달 시 자동 회전. 운영/튜닝/LaunchAgent
+설치 절차는 `docs/agents/wrangler-tail-watchdog.md` 참조.
+
+## prune-wrangler-logs — wrangler CLI 로그 정리 (#1453)
+
+`scripts/prune-wrangler-logs.sh`. `~/Library/Preferences/.wrangler/logs/`에서 7일 이상 된
+`wrangler-*.log`를 삭제. `scripts/launchd/com.subway-now.wrangler-log-prune.plist`로
+매일 03:00 KST 자동 실행 가능.

--- a/scripts/__tests__/tail-watchdog.test.js
+++ b/scripts/__tests__/tail-watchdog.test.js
@@ -1,0 +1,114 @@
+/**
+ * tail-watchdog.sh (#1453) — 좀비 감지, log rotation, max-restarts shell 동작 검증.
+ *
+ * 실제 wrangler를 띄우지 않고 TAIL_CMD 환경변수로 mock 명령(`echo + sleep`)을 주입한다.
+ * STALE_SECS / CHECK_INTERVAL / MAX_BYTES / MAX_RESTARTS를 짧게 줄여 빠르게 검증한다.
+ */
+
+'use strict';
+
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const SCRIPT = path.resolve(__dirname, '..', 'tail-watchdog.sh');
+
+function makeTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'tail-watchdog-'));
+}
+
+function runWatchdog(env, timeoutMs) {
+  return new Promise((resolve) => {
+    const child = spawn('bash', [SCRIPT, 'test'], {
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => { stdout += d.toString(); });
+    child.stderr.on('data', (d) => { stderr += d.toString(); });
+    const softKill = setTimeout(() => {
+      child.kill('SIGTERM');
+    }, timeoutMs);
+    // bash trap이 watchdog 서브셸 정리 race를 만들 수 있어 SIGKILL fallback으로 jest
+    // open handle 누수를 막는다.
+    const hardKill = setTimeout(() => {
+      child.kill('SIGKILL');
+    }, timeoutMs + 1500);
+    child.on('exit', (code) => {
+      clearTimeout(softKill);
+      clearTimeout(hardKill);
+      // 자식의 watchdog 서브셸이 상속한 pipe end를 닫아 jest event loop를 풀어준다.
+      child.stdout.destroy();
+      child.stderr.destroy();
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+describe('tail-watchdog.sh', () => {
+  jest.setTimeout(20000);
+
+  test('writes to jsonl when TAIL_CMD emits lines', async () => {
+    const dir = makeTmp();
+    // mock: emit one line every 200ms for 3s, then exit
+    const env = {
+      OUT_DIR: dir,
+      TAIL_CMD: 'for i in 1 2 3 4 5; do echo "{\\"i\\":$i}"; sleep 0.2; done',
+      STALE_SECS: '60',
+      CHECK_INTERVAL: '60',
+      MAX_BYTES: '10485760',
+      MAX_RESTARTS: '100',
+      RESPAWN_SLEEP: '1',
+    };
+    const p = runWatchdog(env, 2500);
+    await p;
+    const jsonl = fs.readFileSync(path.join(dir, 'wrangler-tail-watchdog.jsonl'), 'utf8');
+    expect(jsonl).toMatch(/"i":1/);
+    expect(jsonl).toMatch(/"i":5/);
+  });
+
+  test('rotates jsonl when MAX_BYTES exceeded', async () => {
+    const dir = makeTmp();
+    // pre-seed jsonl above rotation threshold so first rotate fires before spawn
+    fs.writeFileSync(path.join(dir, 'wrangler-tail-watchdog.jsonl'), 'x'.repeat(200));
+    const env = {
+      OUT_DIR: dir,
+      TAIL_CMD: 'echo "fresh"; sleep 0.2',
+      STALE_SECS: '60',
+      CHECK_INTERVAL: '60',
+      MAX_BYTES: '100', // 100 bytes → pre-seeded 200B triggers rotation
+      MAX_RESTARTS: '100',
+      RESPAWN_SLEEP: '1',
+    };
+    await runWatchdog(env, 1500);
+    const files = fs.readdirSync(dir);
+    const rotated = files.filter((f) => /wrangler-tail-watchdog\.jsonl\.\d+/.test(f));
+    expect(rotated.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('stops with ALERT when MAX_RESTARTS exceeded', async () => {
+    const dir = makeTmp();
+    const env = {
+      OUT_DIR: dir,
+      // tail command exits immediately → forces respawn each iteration
+      TAIL_CMD: 'echo "{\\"x\\":1}"; exit 0',
+      STALE_SECS: '600',
+      CHECK_INTERVAL: '600',
+      MAX_BYTES: '10485760',
+      MAX_RESTARTS: '3',
+      RESPAWN_SLEEP: '0.1',
+    };
+    const { code } = await runWatchdog(env, 8000);
+    // Should self-exit (code 0 via cleanup) before SIGTERM at 8s
+    await sleep(50);
+    const alert = fs.readFileSync(path.join(dir, 'wrangler-tail-watchdog.alert'), 'utf8');
+    expect(alert).toMatch(/max-restarts/);
+    expect(code).toBe(0);
+  });
+});

--- a/scripts/__tests__/tail-watchdog.test.js
+++ b/scripts/__tests__/tail-watchdog.test.js
@@ -3,6 +3,9 @@
  *
  * 실제 wrangler를 띄우지 않고 TAIL_CMD 환경변수로 mock 명령(`echo + sleep`)을 주입한다.
  * STALE_SECS / CHECK_INTERVAL / MAX_BYTES / MAX_RESTARTS를 짧게 줄여 빠르게 검증한다.
+ *
+ * 타이밍-독립 패턴: 고정 timeout으로 sleep하지 않고 "조건을 만족할 때까지 poll" 후
+ * SIGTERM으로 종료한다. CI runner의 spawn cost 변동에 영향받지 않는다.
  */
 
 'use strict';
@@ -18,57 +21,82 @@ function makeTmp() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'tail-watchdog-'));
 }
 
-function runWatchdog(env, timeoutMs) {
-  return new Promise((resolve) => {
-    const child = spawn('bash', [SCRIPT, 'test'], {
-      env: { ...process.env, ...env },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    let stdout = '';
-    let stderr = '';
-    child.stdout.on('data', (d) => { stdout += d.toString(); });
-    child.stderr.on('data', (d) => { stderr += d.toString(); });
-    const softKill = setTimeout(() => {
-      child.kill('SIGTERM');
-    }, timeoutMs);
-    // bash trap이 watchdog 서브셸 정리 race를 만들 수 있어 SIGKILL fallback으로 jest
-    // open handle 누수를 막는다.
-    const hardKill = setTimeout(() => {
-      child.kill('SIGKILL');
-    }, timeoutMs + 1500);
-    child.on('exit', (code) => {
-      clearTimeout(softKill);
-      clearTimeout(hardKill);
-      // 자식의 watchdog 서브셸이 상속한 pipe end를 닫아 jest event loop를 풀어준다.
-      child.stdout.destroy();
-      child.stderr.destroy();
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
-
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+/**
+ * Spawn the watchdog and return { child, exited }. Caller decides when to kill.
+ * Caller MUST call `child.kill()` and `await exited` to avoid jest open handles.
+ */
+function spawnWatchdog(env) {
+  const child = spawn('bash', [SCRIPT, 'test'], {
+    env: { ...process.env, ...env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', (d) => { stdout += d.toString(); });
+  child.stderr.on('data', (d) => { stderr += d.toString(); });
+  const exited = new Promise((resolve) => {
+    child.on('exit', (code) => {
+      // 자식의 watchdog 서브셸이 상속한 pipe end를 닫아 jest event loop를 풀어준다.
+      child.stdout.destroy();
+      child.stderr.destroy();
+      resolve({ code, stdout: () => stdout, stderr: () => stderr });
+    });
+  });
+  return { child, exited };
+}
+
+/**
+ * Poll `predicate()` every `intervalMs` until it returns true or `maxMs` elapses.
+ * Returns true if predicate met, false on timeout.
+ */
+async function pollUntil(predicate, maxMs, intervalMs = 50) {
+  const deadline = Date.now() + maxMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await sleep(intervalMs);
+  }
+  return predicate();
+}
+
+async function killAndAwait(child, exited, hardKillMs = 1500) {
+  child.kill('SIGTERM');
+  const hardKill = setTimeout(() => child.kill('SIGKILL'), hardKillMs);
+  try {
+    return await exited;
+  } finally {
+    clearTimeout(hardKill);
+  }
+}
+
 describe('tail-watchdog.sh', () => {
-  jest.setTimeout(20000);
+  jest.setTimeout(30000);
 
   test('writes to jsonl when TAIL_CMD emits lines', async () => {
     const dir = makeTmp();
-    // mock: emit one line every 200ms for 3s, then exit
+    const jsonlPath = path.join(dir, 'wrangler-tail-watchdog.jsonl');
+    // mock: emit one line every 200ms for 1s+, exit. We poll until lines 1 & 5 appear.
     const env = {
       OUT_DIR: dir,
-      TAIL_CMD: 'for i in 1 2 3 4 5; do echo "{\\"i\\":$i}"; sleep 0.2; done',
+      TAIL_CMD: String.raw`for i in 1 2 3 4 5; do echo "{\"i\":$i}"; sleep 0.2; done`,
       STALE_SECS: '60',
       CHECK_INTERVAL: '60',
       MAX_BYTES: '10485760',
       MAX_RESTARTS: '100',
       RESPAWN_SLEEP: '1',
     };
-    const p = runWatchdog(env, 2500);
-    await p;
-    const jsonl = fs.readFileSync(path.join(dir, 'wrangler-tail-watchdog.jsonl'), 'utf8');
+    const { child, exited } = spawnWatchdog(env);
+    const ok = await pollUntil(() => {
+      if (!fs.existsSync(jsonlPath)) return false;
+      const c = fs.readFileSync(jsonlPath, 'utf8');
+      return /"i":1/.test(c) && /"i":5/.test(c);
+    }, 15000);
+    await killAndAwait(child, exited);
+    expect(ok).toBe(true);
+    const jsonl = fs.readFileSync(jsonlPath, 'utf8');
     expect(jsonl).toMatch(/"i":1/);
     expect(jsonl).toMatch(/"i":5/);
   });
@@ -79,14 +107,20 @@ describe('tail-watchdog.sh', () => {
     fs.writeFileSync(path.join(dir, 'wrangler-tail-watchdog.jsonl'), 'x'.repeat(200));
     const env = {
       OUT_DIR: dir,
-      TAIL_CMD: 'echo "fresh"; sleep 0.2',
+      TAIL_CMD: 'echo "fresh"; sleep 5',
       STALE_SECS: '60',
       CHECK_INTERVAL: '60',
       MAX_BYTES: '100', // 100 bytes → pre-seeded 200B triggers rotation
       MAX_RESTARTS: '100',
       RESPAWN_SLEEP: '1',
     };
-    await runWatchdog(env, 1500);
+    const { child, exited } = spawnWatchdog(env);
+    const ok = await pollUntil(() => {
+      const files = fs.readdirSync(dir);
+      return files.some((f) => /wrangler-tail-watchdog\.jsonl\.\d+/.test(f));
+    }, 15000);
+    await killAndAwait(child, exited);
+    expect(ok).toBe(true);
     const files = fs.readdirSync(dir);
     const rotated = files.filter((f) => /wrangler-tail-watchdog\.jsonl\.\d+/.test(f));
     expect(rotated.length).toBeGreaterThanOrEqual(1);
@@ -94,21 +128,24 @@ describe('tail-watchdog.sh', () => {
 
   test('stops with ALERT when MAX_RESTARTS exceeded', async () => {
     const dir = makeTmp();
+    const alertPath = path.join(dir, 'wrangler-tail-watchdog.alert');
     const env = {
       OUT_DIR: dir,
       // tail command exits immediately → forces respawn each iteration
-      TAIL_CMD: 'echo "{\\"x\\":1}"; exit 0',
+      TAIL_CMD: String.raw`echo "{\"x\":1}"; exit 0`,
       STALE_SECS: '600',
       CHECK_INTERVAL: '600',
       MAX_BYTES: '10485760',
       MAX_RESTARTS: '3',
       RESPAWN_SLEEP: '0.1',
     };
-    const { code } = await runWatchdog(env, 8000);
-    // Should self-exit (code 0 via cleanup) before SIGTERM at 8s
-    await sleep(50);
-    const alert = fs.readFileSync(path.join(dir, 'wrangler-tail-watchdog.alert'), 'utf8');
+    const { child, exited } = spawnWatchdog(env);
+    // Watchdog self-exits via cleanup(); wait for that, then assert alert content.
+    const ok = await pollUntil(() => fs.existsSync(alertPath), 20000);
+    // killAndAwait는 child가 이미 종료됐어도 안전(SIGTERM은 no-op, exited는 즉시 resolve)
+    await killAndAwait(child, exited);
+    expect(ok).toBe(true);
+    const alert = fs.readFileSync(alertPath, 'utf8');
     expect(alert).toMatch(/max-restarts/);
-    expect(code).toBe(0);
   });
 });

--- a/scripts/__tests__/tail-watchdog.test.js
+++ b/scripts/__tests__/tail-watchdog.test.js
@@ -25,12 +25,15 @@ function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+// SonarCloud S4036 — bash 절대경로로 PATH 해석 의존성 제거.
+const BASH = '/bin/bash';
+
 /**
  * Spawn the watchdog and return { child, exited }. Caller decides when to kill.
  * Caller MUST call `child.kill()` and `await exited` to avoid jest open handles.
  */
 function spawnWatchdog(env) {
-  const child = spawn('bash', [SCRIPT, 'test'], {
+  const child = spawn(BASH, [SCRIPT, 'test'], {
     env: { ...process.env, ...env },
     stdio: ['ignore', 'pipe', 'pipe'],
   });

--- a/scripts/launchd/com.subway-now.wrangler-log-prune.plist
+++ b/scripts/launchd/com.subway-now.wrangler-log-prune.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  #1453. wrangler 로그 일일 prune.
+  설치: cp scripts/launchd/com.subway-now.wrangler-log-prune.plist ~/Library/LaunchAgents/
+        launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.subway-now.wrangler-log-prune.plist
+
+  매일 03:00 KST에 scripts/prune-wrangler-logs.sh 실행. 7일 이상 wrangler-*.log 삭제.
+
+  참고: 기존 com.subway-now.scheduled-tail.plist는 존재하지 않는
+  scripts/scheduled-deploy-and-tail.sh를 참조해 매일 08:00에 실패 로그만 남기던 좀비였다 (#1453).
+  unload + 삭제 절차는 docs/agents/wrangler-tail-watchdog.md 참조.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.subway-now.wrangler-log-prune</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-lc</string>
+        <string>/Users/kimdohan/IdeaProjects/subway-now/scripts/prune-wrangler-logs.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/Users/kimdohan/IdeaProjects/subway-now/tasks/launchd-prune-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/kimdohan/IdeaProjects/subway-now/tasks/launchd-prune-stderr.log</string>
+    <key>WorkingDirectory</key>
+    <string>/Users/kimdohan/IdeaProjects/subway-now</string>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/scripts/prune-wrangler-logs.sh
+++ b/scripts/prune-wrangler-logs.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# wrangler 로그 prune — #1453.
+#
+# `~/Library/Preferences/.wrangler/logs/`는 wrangler CLI 호출마다 새 파일을 적재한다
+# (2026-06-18 시점 105MB 누적 확인). 7일 이상 된 파일을 자동 삭제한다.
+#
+# 사용:
+#   scripts/prune-wrangler-logs.sh                    # 7일 기준 prune
+#   scripts/prune-wrangler-logs.sh --days 14          # 14일 기준
+#   scripts/prune-wrangler-logs.sh --dry-run          # 삭제 대상 출력만
+#
+# 환경변수:
+#   WRANGLER_LOG_DIR  override (기본: ~/Library/Preferences/.wrangler/logs)
+#
+# launchd 등록:
+#   ~/Library/LaunchAgents/com.subway-now.wrangler-log-prune.plist 참고
+set -euo pipefail
+
+DAYS=7
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --days) DAYS="$2"; shift 2;;
+    --dry-run) DRY_RUN=1; shift;;
+    *) echo "[prune-wrangler-logs] 알 수 없는 옵션: $1" >&2; exit 2;;
+  esac
+done
+
+LOG_DIR="${WRANGLER_LOG_DIR:-$HOME/Library/Preferences/.wrangler/logs}"
+
+if [[ ! -d "$LOG_DIR" ]]; then
+  echo "[prune-wrangler-logs] log dir 없음 — 종료: $LOG_DIR"
+  exit 0
+fi
+
+# find -mtime +N — mtime이 N일보다 오래된 파일.
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  count=$(find "$LOG_DIR" -type f -name 'wrangler-*.log' -mtime "+$DAYS" -print | tee /dev/stderr | wc -l | tr -d ' ')
+  echo "[prune-wrangler-logs] dry-run: $count files >$DAYS days"
+else
+  count=$(find "$LOG_DIR" -type f -name 'wrangler-*.log' -mtime "+$DAYS" -delete -print | wc -l | tr -d ' ')
+  echo "[prune-wrangler-logs] pruned $count files (> $DAYS days) in $LOG_DIR"
+fi

--- a/scripts/tail-watchdog.sh
+++ b/scripts/tail-watchdog.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# wrangler tail watchdog — #1453.
+#
+# `wrangler tail`은 inactivity 또는 stream 죽음으로 silent "좀비"가 된다
+# (lesson_wrangler_tail_wrapper_reliability). 단순 `while true; do wrangler tail; sleep N; done`
+# 루프는 프로세스가 EXIT할 때만 재시작하므로 좀비(alive + 무데이터) 상태에서 복구 못 함.
+#
+# 본 스크립트는 두 개의 협력 루프를 한 프로세스에서 돌린다:
+#   1) tail loop — wrangler tail을 jsonl에 append. EXIT 시 자동 재spawn (max-restarts 이내).
+#   2) watchdog loop — jsonl mtime이 STALE_SECS 이상 정지면 wrangler node를 강제 kill →
+#      tail loop가 EXIT 감지해 재spawn.
+#
+# 부수 기능:
+#   - log rotation: jsonl이 MAX_BYTES 도달 시 timestamp suffix로 회전
+#   - max-restarts: 100회 초과 시 stderr에 ALERT 출력 + 종료
+#
+# 사용:
+#   scripts/tail-watchdog.sh [label]
+#   예: scripts/tail-watchdog.sh origin-verify
+#
+# 종료:
+#   Ctrl+C 또는 SIGTERM. 자식(wrangler + watchdog)도 같이 정리됨.
+#
+# 환경변수 (테스트/튜닝용):
+#   STALE_SECS=90      jsonl mtime 이 N초 stale이면 좀비 판정
+#   CHECK_INTERVAL=30  watchdog poll 주기
+#   MAX_BYTES=10485760 회전 임계 (10MB)
+#   MAX_RESTARTS=100   tail spawn 누적 상한
+#   RESPAWN_SLEEP=3    EXIT 후 재spawn 대기
+#   OUT_DIR=tasks      출력 디렉토리 (절대경로 권장)
+#   TAIL_CMD           override 시 wrangler 대신 임의 명령 (테스트용)
+set -euo pipefail
+
+LABEL="${1:-watchdog}"
+if [[ ! "$LABEL" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "[tail-watchdog] label은 [A-Za-z0-9._-]만 허용: $LABEL" >&2
+  exit 2
+fi
+
+STALE_SECS="${STALE_SECS:-90}"
+CHECK_INTERVAL="${CHECK_INTERVAL:-30}"
+MAX_BYTES="${MAX_BYTES:-10485760}"
+MAX_RESTARTS="${MAX_RESTARTS:-100}"
+RESPAWN_SLEEP="${RESPAWN_SLEEP:-3}"
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT_DIR="${OUT_DIR:-$REPO_ROOT/tasks}"
+mkdir -p "$OUT_DIR"
+
+OUT="$OUT_DIR/wrangler-tail-watchdog.jsonl"
+ERR="$OUT_DIR/wrangler-tail-watchdog.err"
+ALERT="$OUT_DIR/wrangler-tail-watchdog.alert"
+
+# Determine tail command. Default: wrangler tail against backend/alarm-worker.
+if [[ -z "${TAIL_CMD:-}" ]]; then
+  WORKER_NAME=$(awk -F'"' '/^name *=/ {print $2; exit}' "$REPO_ROOT/backend/alarm-worker/wrangler.toml")
+  if [[ -z "$WORKER_NAME" ]]; then
+    echo "[tail-watchdog] backend/alarm-worker/wrangler.toml에서 worker name 추출 실패" >&2
+    exit 1
+  fi
+  TAIL_CMD="cd $REPO_ROOT/backend/alarm-worker && npx wrangler tail $WORKER_NAME --format=json"
+fi
+
+# stat -f (BSD/macOS) vs stat -c (GNU/Linux) shim.
+file_mtime() {
+  local f="$1"
+  if [[ ! -e "$f" ]]; then echo 0; return; fi
+  stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo 0
+}
+
+file_size() {
+  local f="$1"
+  if [[ ! -e "$f" ]]; then echo 0; return; fi
+  stat -f %z "$f" 2>/dev/null || stat -c %s "$f" 2>/dev/null || echo 0
+}
+
+rotate_if_needed() {
+  local size
+  size=$(file_size "$OUT")
+  if [[ "$size" -ge "$MAX_BYTES" ]]; then
+    local ts
+    ts=$(date +%Y%m%d-%H%M%S)
+    mv "$OUT" "$OUT.$ts"
+    : > "$OUT"
+    echo "[tail-watchdog] rotated → $OUT.$ts" >> "$ERR"
+  fi
+}
+
+CHILD_PIDS=()
+cleanup() {
+  for pid in "${CHILD_PIDS[@]}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  # kill any straggling wrangler tail
+  pkill -f "node_modules/.bin/wrangler tail" 2>/dev/null || true
+  exit 0
+}
+trap cleanup INT TERM
+
+# Watchdog loop — pkill wrangler tail when jsonl mtime is stale.
+(
+  while true; do
+    sleep "$CHECK_INTERVAL"
+    mtime=$(file_mtime "$OUT")
+    now=$(date +%s)
+    if [[ "$mtime" -eq 0 ]]; then continue; fi
+    age=$(( now - mtime ))
+    if [[ "$age" -gt "$STALE_SECS" ]]; then
+      echo "[tail-watchdog] jsonl stale ${age}s > ${STALE_SECS}s — killing wrangler tail" >> "$ERR"
+      pkill -f "node_modules/.bin/wrangler tail" 2>/dev/null || true
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+CHILD_PIDS+=("$WATCHDOG_PID")
+
+# Tail loop — respawn on EXIT, rotate before each spawn.
+restarts=0
+while true; do
+  if [[ "$restarts" -ge "$MAX_RESTARTS" ]]; then
+    msg="[tail-watchdog] ALERT max-restarts $MAX_RESTARTS 초과 — 종료. wrangler/network 점검 필요."
+    echo "$msg" >> "$ALERT"
+    echo "$msg" >&2
+    cleanup
+  fi
+  rotate_if_needed
+  echo "[tail-watchdog] spawn #$((restarts + 1)) label=$LABEL out=$OUT" >> "$ERR"
+  # run command — append stdout to OUT, stderr to ERR. Don't fail on non-zero.
+  bash -c "$TAIL_CMD" >> "$OUT" 2>> "$ERR" || true
+  restarts=$((restarts + 1))
+  sleep "$RESPAWN_SLEEP"
+done

--- a/scripts/tail-watchdog.sh
+++ b/scripts/tail-watchdog.sh
@@ -62,16 +62,34 @@ if [[ -z "${TAIL_CMD:-}" ]]; then
 fi
 
 # stat -f (BSD/macOS) vs stat -c (GNU/Linux) shim.
+#
+# 주의: `stat -f %z file` 의 `-f` 는 BSD/macOS에서 `--format`이지만 GNU coreutils
+# stat에서는 `--file-system` 옵션으로 해석되어 filesystem info를 출력하고 exit 0
+# 한다. 즉 `stat -f ... || stat -c ...` chain은 GNU에서도 첫 호출이 exit 0이라
+# fallback이 안 일어나고 잘못된 출력을 size로 받는다. → version 감지 후 분기한다.
+if stat --version >/dev/null 2>&1; then
+  STAT_IS_GNU=1
+else
+  STAT_IS_GNU=0
+fi
+
 file_mtime() {
   local f="$1"
   if [[ ! -e "$f" ]]; then echo 0; return; fi
-  stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo 0
+  if [[ "$STAT_IS_GNU" -eq 1 ]]; then
+    stat -c %Y "$f" 2>/dev/null || echo 0
+  else
+    stat -f %m "$f" 2>/dev/null || echo 0
+  fi
 }
 
+# `wc -c < file` 은 GNU/BSD 동일 출력 (leading whitespace는 trim).
 file_size() {
   local f="$1"
   if [[ ! -e "$f" ]]; then echo 0; return; fi
-  stat -f %z "$f" 2>/dev/null || stat -c %s "$f" 2>/dev/null || echo 0
+  local size
+  size=$(wc -c < "$f" 2>/dev/null | tr -d ' ')
+  echo "${size:-0}"
 }
 
 rotate_if_needed() {


### PR DESCRIPTION
## Summary

`wrangler tail` 좀비 사이클 + wrangler CLI 로그 누적 + 좀비 LaunchAgent 동시 정리.

## 동기

2026-06-18 evidence:
- `tasks/wrangler-tail-watchdog.err`에 `[HH:MM:SS] tail died, restart in 30s` + Cloudflare API 인증 만료 / Connect Timeout 반복 (메모리 `lesson_wrangler_tail_wrapper_reliability.md`)
- `~/Library/Preferences/.wrangler/logs/` 105MB 누적
- `~/Library/LaunchAgents/com.subway-now.scheduled-tail.plist`가 존재하지 않는 `scripts/scheduled-deploy-and-tail.sh`를 매일 08:00 KST 호출 → `tasks/launchd-stderr.log`에 `No such file or directory`만 누적

## 변경 사항

### `scripts/tail-watchdog.sh`
- `wrangler tail` jsonl 적재 + watchdog 두 루프를 한 프로세스에서 협력 운영
- watchdog이 jsonl mtime이 `STALE_SECS`(기본 90s) 초과 정지하면 `pkill -f "node_modules/.bin/wrangler tail"` → tail loop가 EXIT 감지해 재spawn
- jsonl이 `MAX_BYTES`(기본 10MB) 도달 시 timestamp suffix로 회전
- `MAX_RESTARTS`(기본 100) 초과 시 `tasks/wrangler-tail-watchdog.alert`에 한 줄 + 종료
- `TAIL_CMD` env override로 테스트 mock 주입 가능

### `scripts/prune-wrangler-logs.sh`
- `~/Library/Preferences/.wrangler/logs/`에서 7일 이상 된 `wrangler-*.log` 삭제
- `--days N` / `--dry-run` 옵션
- `WRANGLER_LOG_DIR` env override

### `scripts/launchd/com.subway-now.wrangler-log-prune.plist`
- 매일 03:00 KST에 `prune-wrangler-logs.sh` 실행 LaunchAgent
- 설치 + 기존 `scheduled-tail.plist` 제거 절차는 `docs/agents/wrangler-tail-watchdog.md` 참조

### `scripts/__tests__/tail-watchdog.test.js`
- 3 shell 동작 케이스: jsonl 적재 / rotation / max-restarts alert
- mock TAIL_CMD로 실제 wrangler 미관여 — 결정적

### `docs/agents/wrangler-tail-watchdog.md`
- 일상 사용 / 튜닝 표 / Acceptance 자가 검증 / 수동 검증 / 기존 plist 제거 절차

### `.gitignore`
- `!docs/agents/`로 운영 문서 추적 활성 (CLAUDE.md 이미 `docs/agents/issue-tracker.md` 등을 참조 중)
- `tasks/wrangler-tail-watchdog.*`, `tasks/launchd-*.log` 산출물 제외

## Acceptance (이슈 본문 기준)

- [x] mtime watchdog: `STALE_SECS` 초과 시 wrangler kill → 재spawn (테스트 1번 + 수동 검증 절차 박제)
- [x] log rotation: `MAX_BYTES` 초과 시 회전 (테스트 2번 PASS)
- [x] wrangler logs 7일 prune cron: launchd plist + smoke test PASS (old/new mtime 구분)
- [x] launchd plist 정합성: 신규 plist는 존재 스크립트 참조, 기존 `scheduled-tail.plist`는 docs에서 unload 절차 박제

## 검증

- `npm run type-check` PASS
- `npm run lint` PASS
- `npx jest scripts/__tests__/tail-watchdog.test.js` 3/3 PASS (jest open handle 없이 깔끔 종료)
- `prune-wrangler-logs.sh` smoke: `/tmp/prune-test/`에서 7일 이상 파일만 삭제, 최근 파일 보존 확인

## Test plan

- [ ] PR CI `Data Validation` + `Type Check & Test` PASS 확인
- [ ] 머지 후 사용자가 `cp scripts/launchd/com.subway-now.wrangler-log-prune.plist ~/Library/LaunchAgents/ && launchctl bootstrap ...` 설치 + 기존 plist `launchctl bootout ...` 제거
- [ ] 6시간 watchdog 띄운 후 `tasks/wrangler-tail-watchdog.err`에 stale → 재spawn 사이클 확인 (acceptance)

Closes #1453