### PR TITLE
chore(#1497): fetch-timetables FR_CODE 범위 확장 — stationCodes.json 기반 (누락 16역 자동 수집)

### DIFF
--- a/scripts/__tests__/fetch-timetables.test.js
+++ b/scripts/__tests__/fetch-timetables.test.js
@@ -1,0 +1,647 @@
+/**
+ * #1497: fetch-timetables — stationCodes.json 기반 FR_CODE 확장.
+ * 누락 16역(5호선 마천 지선/6호선 응암 순환/2호선 지선/4호선 당고개/1호선 가산디지털단지) 케이스 + 레거시 모드 회귀.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  compactTime,
+  fetchOne,
+  fetchStation,
+  collectFrCodesByLine,
+  collectMissingFrCodes,
+  legacyRangeFrCodes,
+  parseArgs,
+  selectTargetLines,
+  resolveFrCodeSets,
+  readExistingLine,
+  writeLine,
+  processLine,
+  main,
+} = require('../fetch-timetables');
+
+// fetch 응답 mock helper
+function mockOk(json) {
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(json) });
+}
+function mockNotOk(status) {
+  return Promise.resolve({ ok: false, status, json: () => Promise.resolve({}) });
+}
+function noopSleep() {
+  return Promise.resolve();
+}
+
+describe('compactTime', () => {
+  it('"HH:MM:SS" → "HHMM"', () => {
+    expect(compactTime('05:18:00')).toBe('0518');
+    expect(compactTime('23:59:30')).toBe('2359');
+  });
+
+  it('24시간 초과 표기 보존', () => {
+    expect(compactTime('24:09:30')).toBe('2409');
+  });
+
+  it('형식 불일치는 null', () => {
+    expect(compactTime('abc')).toBeNull();
+    expect(compactTime('5:18:00')).toBeNull();
+    expect(compactTime('')).toBeNull();
+  });
+
+  it('비문자열은 null', () => {
+    expect(compactTime(null)).toBeNull();
+    expect(compactTime(undefined)).toBeNull();
+    expect(compactTime(530)).toBeNull();
+  });
+});
+
+describe('fetchOne', () => {
+  it('정상 응답 row 배열 반환', async () => {
+    const fetchImpl = jest.fn(() =>
+      mockOk({
+        SearchSTNTimeTableByFRCodeService: {
+          row: [{ STATION_NM: '서울역', ARRIVETIME: '05:18:00' }],
+        },
+      }),
+    );
+    const rows = await fetchOne('KEY', '100', '1', '1', { fetchImpl });
+    expect(rows).toEqual([{ STATION_NM: '서울역', ARRIVETIME: '05:18:00' }]);
+    expect(fetchImpl).toHaveBeenCalledWith(expect.stringContaining('SearchSTNTimeTableByFRCodeService/1/1000/100/1/1'));
+  });
+
+  it('row 누락 시 빈 배열', async () => {
+    const fetchImpl = jest.fn(() => mockOk({ SearchSTNTimeTableByFRCodeService: {} }));
+    const rows = await fetchOne('KEY', '100', '1', '1', { fetchImpl });
+    expect(rows).toEqual([]);
+  });
+
+  it('INFO-200 (데이터 없음)은 null', async () => {
+    const fetchImpl = jest.fn(() => mockOk({ RESULT: { CODE: 'INFO-200', MESSAGE: 'no data' } }));
+    const rows = await fetchOne('KEY', '999', '1', '1', { fetchImpl });
+    expect(rows).toBeNull();
+  });
+
+  it('HTTP non-OK는 throw', async () => {
+    const fetchImpl = jest.fn(() => mockNotOk(500));
+    await expect(fetchOne('KEY', '100', '1', '1', { fetchImpl })).rejects.toThrow(/HTTP 500/);
+  });
+
+  it('wrapper 누락 + RESULT 코드 없음 → throw', async () => {
+    const fetchImpl = jest.fn(() => mockOk({ unexpected: true }));
+    await expect(fetchOne('KEY', '100', '1', '1', { fetchImpl })).rejects.toThrow(/unexpected response/);
+  });
+});
+
+describe('fetchStation', () => {
+  it('probe 실패 시 stationName=null + 빈 timetable, 나머지 호출 skip', async () => {
+    const fetchImpl = jest.fn(() => mockOk({ RESULT: { CODE: 'INFO-200' } }));
+    const { stationName, timetable } = await fetchStation('KEY', '999', { fetchImpl, sleepImpl: noopSleep });
+    expect(stationName).toBeNull();
+    expect(timetable).toEqual({});
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('6개 weekTag×inoutTag 조합 모두 호출 + 결과 머지', async () => {
+    const fetchImpl = jest.fn((url) => {
+      // path 끝 "/{frCode}/{w}/{i}" 추출
+      const parts = url.split('/');
+      const inout = parts.at(-1);
+      const week = parts.at(-2);
+      return mockOk({
+        SearchSTNTimeTableByFRCodeService: {
+          row: [
+            { STATION_NM: '마천', ARRIVETIME: `0${week}:0${inout}:00` },
+          ],
+        },
+      });
+    });
+    const { stationName, timetable } = await fetchStation('KEY', '548', { fetchImpl, sleepImpl: noopSleep });
+    expect(stationName).toBe('마천');
+    expect(fetchImpl).toHaveBeenCalledTimes(6);
+    expect(timetable.weekday.up).toEqual(['0101']);
+    expect(timetable.weekday.down).toEqual(['0102']);
+    expect(timetable.saturday.up).toEqual(['0201']);
+    expect(timetable.saturday.down).toEqual(['0202']);
+    expect(timetable.sunday.up).toEqual(['0301']);
+    expect(timetable.sunday.down).toEqual(['0302']);
+  });
+
+  it('일부 weekTag×inoutTag만 데이터 있어도 정상 머지 (빈 row skip)', async () => {
+    let call = 0;
+    const fetchImpl = jest.fn(() => {
+      call++;
+      // probe(1)만 데이터, 나머지 5는 INFO-200
+      if (call === 1) {
+        return mockOk({
+          SearchSTNTimeTableByFRCodeService: {
+            row: [{ STATION_NM: '신설동', ARRIVETIME: '05:30:00' }],
+          },
+        });
+      }
+      return mockOk({ RESULT: { CODE: 'INFO-200' } });
+    });
+    const { stationName, timetable } = await fetchStation('KEY', '211', { fetchImpl, sleepImpl: noopSleep });
+    expect(stationName).toBe('신설동');
+    expect(timetable.weekday.up).toEqual(['0530']);
+    expect(timetable.weekday.down).toBeUndefined();
+    expect(timetable.saturday).toBeUndefined();
+  });
+
+  it('rest step에서 빈 배열도 skip 처리', async () => {
+    let call = 0;
+    const fetchImpl = jest.fn(() => {
+      call++;
+      if (call === 1) {
+        return mockOk({
+          SearchSTNTimeTableByFRCodeService: {
+            row: [{ STATION_NM: '둔촌동', ARRIVETIME: '05:35:00' }],
+          },
+        });
+      }
+      if (call === 2) {
+        return mockOk({ SearchSTNTimeTableByFRCodeService: { row: [] } });
+      }
+      return mockOk({
+        SearchSTNTimeTableByFRCodeService: {
+          row: [{ STATION_NM: '둔촌동', ARRIVETIME: '06:00:00' }],
+        },
+      });
+    });
+    const { timetable } = await fetchStation('KEY', '548', { fetchImpl, sleepImpl: noopSleep });
+    expect(timetable.weekday.up).toEqual(['0535']);
+    expect(timetable.weekday.down).toBeUndefined();
+    expect(timetable.saturday.up).toEqual(['0600']);
+  });
+});
+
+describe('collectFrCodesByLine', () => {
+  const stations = [
+    { id: '1-001', name: '소요산', line: '1' },
+    { id: '1-100', name: '가산디지털단지', line: '1' },
+    { id: '5-001', name: '방화', line: '5' },
+    { id: '5-046', name: '마천', line: '5' },
+    { id: '6-002', name: '역촌', line: '6' },
+    { id: 'airport-001', name: '서울역', line: 'airport' }, // skip
+  ];
+  const codes = {
+    '1-001': { stationCd: '0150', frCode: '150' },
+    '1-100': { stationCd: '1800', frCode: '801' }, // 1호선 가산디지털단지: range 밖
+    '5-001': { stationCd: '2511', frCode: '510' },
+    '5-046': { stationCd: '2548', frCode: '744' }, // 마천: 5호선 range 밖
+    '6-002': { stationCd: '2611', frCode: '610' },
+    'airport-001': { stationCd: '4101', frCode: '410' },
+  };
+
+  it('1~9호선 entry만 line별로 모음', () => {
+    const byLine = collectFrCodesByLine(codes, stations);
+    expect(byLine.get('1')).toEqual(new Set(['150', '801']));
+    expect(byLine.get('5')).toEqual(new Set(['510', '744']));
+    expect(byLine.get('6')).toEqual(new Set(['610']));
+    expect(byLine.get('airport')).toBeUndefined();
+  });
+
+  it('stations 미포함 id는 무시', () => {
+    const byLine = collectFrCodesByLine({ 'unknown-9': { frCode: '999' } }, stations);
+    expect([...byLine.values()].every((s) => !s.has('999'))).toBe(true);
+  });
+
+  it('frCode 없는 entry는 skip', () => {
+    const byLine = collectFrCodesByLine({ '1-001': { stationCd: '0150' } }, stations);
+    expect(byLine.get('1').size).toBe(0);
+  });
+
+  it('frCode가 string 아니면 skip', () => {
+    const byLine = collectFrCodesByLine({ '1-001': { stationCd: '0150', frCode: 150 } }, stations);
+    expect(byLine.get('1').size).toBe(0);
+  });
+
+  it('lines 인자로 대상 노선 제한', () => {
+    const byLine = collectFrCodesByLine(codes, stations, ['5']);
+    expect([...byLine.keys()]).toEqual(['5']);
+    expect(byLine.get('5')).toEqual(new Set(['510', '744']));
+  });
+
+  it('frCode가 3자리 미만이면 0-pad', () => {
+    const byLine = collectFrCodesByLine({ '1-001': { frCode: '99' } }, [{ id: '1-001', line: '1', name: 'X' }]);
+    expect(byLine.get('1')).toEqual(new Set(['099']));
+  });
+});
+
+describe('collectMissingFrCodes', () => {
+  const stations = [
+    { id: '1-001', name: '소요산', line: '1' },
+    { id: '1-100', name: '가산디지털단지', line: '1' },
+    { id: '5-046', name: '마천', line: '5' },
+    { id: '6-002', name: '역촌', line: '6' },
+  ];
+  const codes = {
+    '1-001': { frCode: '150' },
+    '1-100': { frCode: '801' },
+    '5-046': { frCode: '744' },
+    '6-002': { frCode: '610' },
+  };
+
+  it('firstLastTrainTimes에 없는 id만 수집', () => {
+    const flt = { '1-001': { weekday: { up: { first: '05:18', last: '23:48' } } } };
+    const byLine = collectMissingFrCodes(codes, stations, flt);
+    expect(byLine.get('1')).toEqual(new Set(['801']));
+    expect(byLine.get('5')).toEqual(new Set(['744']));
+    expect(byLine.get('6')).toEqual(new Set(['610']));
+  });
+
+  it('1~9호선 외 station은 무시', () => {
+    const external = [{ id: 'airport-001', name: '인천공항', line: 'airport' }];
+    const byLine = collectMissingFrCodes({ 'airport-001': { frCode: '410' } }, external, {});
+    for (const s of byLine.values()) expect(s.size).toBe(0);
+  });
+
+  it('frCode 누락 entry는 skip', () => {
+    const byLine = collectMissingFrCodes({ '1-001': {} }, [{ id: '1-001', line: '1' }], {});
+    expect(byLine.get('1').size).toBe(0);
+  });
+
+  it('stationCodes에 아예 없는 station은 skip', () => {
+    const byLine = collectMissingFrCodes({}, stations, {});
+    for (const s of byLine.values()) expect(s.size).toBe(0);
+  });
+});
+
+describe('legacyRangeFrCodes', () => {
+  it('line N → N*100 ~ N*100+99', () => {
+    const set = legacyRangeFrCodes('1');
+    expect(set.size).toBe(100);
+    expect(set.has('100')).toBe(true);
+    expect(set.has('199')).toBe(true);
+    expect(set.has('200')).toBe(false);
+  });
+
+  it('한자리 padding 적용', () => {
+    const set = legacyRangeFrCodes('1');
+    expect(set.has('100')).toBe(true);
+    // 1호선 100~199 — 모두 3자리
+    for (const c of set) expect(c).toMatch(/^\d{3}$/);
+  });
+});
+
+describe('parseArgs', () => {
+  let originalEnv;
+  beforeEach(() => {
+    originalEnv = process.env.LINE;
+  });
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.LINE;
+    else process.env.LINE = originalEnv;
+  });
+
+  it('기본값', () => {
+    delete process.env.LINE;
+    expect(parseArgs([])).toEqual({ legacyRange: false, missingOnly: false, lineEnv: null });
+  });
+
+  it('--legacy-range / --missing-only flag', () => {
+    delete process.env.LINE;
+    expect(parseArgs(['--legacy-range'])).toMatchObject({ legacyRange: true });
+    expect(parseArgs(['--missing-only'])).toMatchObject({ missingOnly: true });
+  });
+
+  it('LINE env 흡수 + trim', () => {
+    process.env.LINE = '  5  ';
+    expect(parseArgs([])).toMatchObject({ lineEnv: '5' });
+  });
+});
+
+describe('selectTargetLines', () => {
+  it('lineEnv 없으면 1~9 전체', () => {
+    expect(selectTargetLines({ lineEnv: null })).toEqual(['1', '2', '3', '4', '5', '6', '7', '8', '9']);
+  });
+
+  it('lineEnv 지정 시 단일', () => {
+    expect(selectTargetLines({ lineEnv: '5' })).toEqual(['5']);
+  });
+
+  it('1~9 밖이면 throw', () => {
+    expect(() => selectTargetLines({ lineEnv: '0' })).toThrow(/지원 대상이 아닙니다/);
+    expect(() => selectTargetLines({ lineEnv: 'airport' })).toThrow(/지원 대상이 아닙니다/);
+  });
+});
+
+describe('resolveFrCodeSets', () => {
+  const stations = [
+    { id: '1-001', name: '소요산', line: '1' },
+    { id: '5-046', name: '마천', line: '5' },
+  ];
+  const codes = {
+    '1-001': { frCode: '150' },
+    '5-046': { frCode: '744' },
+  };
+
+  it('legacyRange 모드 → range probe set', () => {
+    const sets = resolveFrCodeSets(['1'], {
+      legacyRange: true,
+      missingOnly: false,
+      stationCodes: codes,
+      stations,
+      firstLastTimes: {},
+    });
+    expect(sets.get('1').size).toBe(100);
+  });
+
+  it('missingOnly 모드 → 누락 id만', () => {
+    const sets = resolveFrCodeSets(['1', '5'], {
+      legacyRange: false,
+      missingOnly: true,
+      stationCodes: codes,
+      stations,
+      firstLastTimes: { '1-001': {} },
+    });
+    expect(sets.get('1').size).toBe(0);
+    expect(sets.get('5')).toEqual(new Set(['744']));
+  });
+
+  it('기본 모드 → stationCodes 전체', () => {
+    const sets = resolveFrCodeSets(['1', '5'], {
+      legacyRange: false,
+      missingOnly: false,
+      stationCodes: codes,
+      stations,
+      firstLastTimes: {},
+    });
+    expect(sets.get('1')).toEqual(new Set(['150']));
+    expect(sets.get('5')).toEqual(new Set(['744']));
+  });
+});
+
+describe('readExistingLine / writeLine', () => {
+  let tmpDir, originalOutDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ftt-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('파일 없으면 빈 stations', () => {
+    // 실제 파일 시스템 의존 — 존재하지 않는 line으로 호출
+    const data = readExistingLine('zzz-nonexistent');
+    expect(data).toEqual({ stations: {} });
+  });
+
+  it('JSON 파싱 실패 시 빈 stations로 fallback', () => {
+    // 임시로 깨진 JSON 파일을 timetables/ 위치에 만들고 모듈 다시 호출
+    // module이 path를 ROOT 기준 고정하므로 우회: 작성/검증 통합 테스트는 writeLine 흐름으로 대체
+    // 여기선 fallback 분기를 별도로 강제하기 어려우니, mock fs 사용
+    const realRead = fs.readFileSync;
+    const realExists = fs.existsSync;
+    jest.spyOn(fs, 'existsSync').mockImplementation((p) => {
+      if (String(p).endsWith('line-9.json')) return true;
+      return realExists(p);
+    });
+    jest.spyOn(fs, 'readFileSync').mockImplementation((p, enc) => {
+      if (String(p).endsWith('line-9.json')) return '{not json';
+      return realRead(p, enc);
+    });
+    try {
+      expect(readExistingLine('9')).toEqual({ stations: {} });
+    } finally {
+      fs.existsSync.mockRestore();
+      fs.readFileSync.mockRestore();
+    }
+  });
+
+  it('writeLine — sorted key + line-N.json 위치', () => {
+    // OUT_DIR을 임시로 mock — writeFileSync를 capture
+    const writes = [];
+    const realWrite = fs.writeFileSync;
+    jest.spyOn(fs, 'writeFileSync').mockImplementation((p, content) => {
+      writes.push({ p, content });
+    });
+    const realMkdir = fs.mkdirSync;
+    jest.spyOn(fs, 'mkdirSync').mockImplementation(() => {});
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    try {
+      const stations = { 영등포: { weekday: { up: ['0500'] } }, 가산디지털단지: { weekday: { up: ['0510'] } } };
+      const outPath = writeLine('1', stations);
+      expect(outPath).toMatch(/line-1\.json$/);
+      const parsed = JSON.parse(writes[0].content);
+      // sort by localeCompare en — '가' < '영' (가 has lower code point)
+      const keys = Object.keys(parsed.stations);
+      expect(keys).toEqual(['가산디지털단지', '영등포']);
+    } finally {
+      fs.writeFileSync.mockRestore();
+      fs.mkdirSync.mockRestore();
+      fs.existsSync.mockRestore();
+    }
+  });
+
+  it('writeLine — OUT_DIR 없으면 생성', () => {
+    let createdDir = null;
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    jest.spyOn(fs, 'mkdirSync').mockImplementation((p) => {
+      createdDir = p;
+    });
+    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+    try {
+      writeLine('2', {});
+      expect(String(createdDir)).toMatch(/timetables$/);
+    } finally {
+      fs.existsSync.mockRestore();
+      fs.mkdirSync.mockRestore();
+      fs.writeFileSync.mockRestore();
+    }
+  });
+});
+
+describe('processLine', () => {
+  const noLog = () => {};
+
+  it('frCode 후보 없으면 skip', async () => {
+    const fetchImpl = jest.fn();
+    const result = await processLine('KEY', '1', new Set(), { fetchImpl, sleepImpl: noopSleep, log: noLog });
+    expect(result).toEqual({ line: '1', stationCount: 0, outPath: null });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('정상 fetch → writeLine 호출, 기존 데이터 merge', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest
+      .spyOn(fs, 'readFileSync')
+      .mockReturnValue(JSON.stringify({ stations: { 기존역: { weekday: { up: ['0400'] } } } }));
+    const writes = [];
+    jest.spyOn(fs, 'writeFileSync').mockImplementation((p, c) => writes.push({ p, c }));
+    jest.spyOn(fs, 'mkdirSync').mockImplementation(() => {});
+
+    const fetchImpl = jest.fn(() =>
+      mockOk({
+        SearchSTNTimeTableByFRCodeService: { row: [{ STATION_NM: '마천', ARRIVETIME: '05:18:00' }] },
+      }),
+    );
+    try {
+      const r = await processLine('KEY', '5', new Set(['744']), { fetchImpl, sleepImpl: noopSleep, log: noLog });
+      expect(r.added).toBe(1);
+      expect(r.stationCount).toBe(2); // 기존역 + 마천
+      const parsed = JSON.parse(writes[0].c);
+      expect(Object.keys(parsed.stations).sort()).toEqual(['기존역', '마천']);
+    } finally {
+      fs.existsSync.mockRestore();
+      fs.readFileSync.mockRestore();
+      fs.writeFileSync.mockRestore();
+      fs.mkdirSync.mockRestore();
+    }
+  });
+
+  it('fetch error → 해당 frCode skip, 다음 진행', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+    jest.spyOn(fs, 'mkdirSync').mockImplementation(() => {});
+    let call = 0;
+    const fetchImpl = jest.fn(() => {
+      call++;
+      if (call === 1) return mockNotOk(500);
+      return mockOk({
+        SearchSTNTimeTableByFRCodeService: { row: [{ STATION_NM: '둔촌동', ARRIVETIME: '05:20:00' }] },
+      });
+    });
+    try {
+      const r = await processLine('KEY', '5', new Set(['999', '548']), {
+        fetchImpl,
+        sleepImpl: noopSleep,
+        log: noLog,
+      });
+      expect(r.added).toBe(1);
+    } finally {
+      fs.existsSync.mockRestore();
+      fs.writeFileSync.mockRestore();
+      fs.mkdirSync.mockRestore();
+    }
+  });
+
+  it('빈 timetable(probe 실패) → skip', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+    jest.spyOn(fs, 'mkdirSync').mockImplementation(() => {});
+    const fetchImpl = jest.fn(() => mockOk({ RESULT: { CODE: 'INFO-200' } }));
+    try {
+      const r = await processLine('KEY', '5', new Set(['999']), { fetchImpl, sleepImpl: noopSleep, log: noLog });
+      expect(r.added).toBe(0);
+    } finally {
+      fs.existsSync.mockRestore();
+      fs.writeFileSync.mockRestore();
+      fs.mkdirSync.mockRestore();
+    }
+  });
+});
+
+describe('main', () => {
+  let exitSpy, stderrSpy, stdoutSpy;
+  beforeEach(() => {
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`__EXIT_${code}__`);
+    });
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  });
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    jest.restoreAllMocks();
+  });
+
+  it('API 키 없으면 exit 1', async () => {
+    await expect(main([], {})).rejects.toThrow('__EXIT_1__');
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('EXPO_PUBLIC_SEOUL_DATA_API_KEY'));
+  });
+
+  it('stationCodes.json 비어있고 legacy-range 아니면 exit 1', async () => {
+    jest.spyOn(fs, 'existsSync').mockImplementation((p) => {
+      if (String(p).endsWith('stationCodes.json')) return true;
+      if (String(p).endsWith('stations.json')) return true;
+      if (String(p).endsWith('firstLastTrainTimes.json')) return true;
+      return false;
+    });
+    jest.spyOn(fs, 'readFileSync').mockImplementation((p) => {
+      if (String(p).endsWith('stationCodes.json')) return '{}';
+      if (String(p).endsWith('stations.json')) return '[]';
+      if (String(p).endsWith('firstLastTrainTimes.json')) return '{}';
+      return '';
+    });
+    await expect(main([], { EXPO_PUBLIC_SEOUL_DATA_API_KEY: 'X', LINE: '1' })).rejects.toThrow('__EXIT_1__');
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('stationCodes.json이 비어있습니다'));
+  });
+
+  it('legacy-range 모드는 stationCodes 빈 상태도 통과', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'readFileSync').mockImplementation((p) => {
+      if (String(p).endsWith('stationCodes.json')) return '{}';
+      if (String(p).endsWith('stations.json')) return '[]';
+      if (String(p).endsWith('firstLastTrainTimes.json')) return '{}';
+      return '';
+    });
+    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+    jest.spyOn(fs, 'mkdirSync').mockImplementation(() => {});
+    const fetchImpl = jest.fn(() => mockOk({ RESULT: { CODE: 'INFO-200' } }));
+    await main(['--legacy-range'], { EXPO_PUBLIC_SEOUL_DATA_API_KEY: 'X', LINE: '1' }, {
+      fetchImpl,
+      sleepImpl: noopSleep,
+    });
+    // legacy 모드 + 1호선 → 100회 fetch (probe만 호출, INFO-200으로 stop)
+    expect(fetchImpl).toHaveBeenCalledTimes(100);
+  });
+
+  it('stationCodes 기반 + LINE=5 → 5호선만 처리', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'readFileSync').mockImplementation((p) => {
+      if (String(p).endsWith('stationCodes.json'))
+        return JSON.stringify({ '5-046': { frCode: '744' } });
+      if (String(p).endsWith('stations.json')) return JSON.stringify([{ id: '5-046', line: '5', name: '마천' }]);
+      if (String(p).endsWith('firstLastTrainTimes.json')) return '{}';
+      if (String(p).endsWith('line-5.json')) return JSON.stringify({ stations: {} });
+      return '';
+    });
+    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+    jest.spyOn(fs, 'mkdirSync').mockImplementation(() => {});
+    const fetchImpl = jest.fn(() =>
+      mockOk({ SearchSTNTimeTableByFRCodeService: { row: [{ STATION_NM: '마천', ARRIVETIME: '05:18:00' }] } }),
+    );
+    await main([], { EXPO_PUBLIC_SEOUL_DATA_API_KEY: 'X', LINE: '5' }, { fetchImpl, sleepImpl: noopSleep });
+    // 5호선 마천 1역 × 6 호출
+    expect(fetchImpl).toHaveBeenCalledTimes(6);
+  });
+
+  it('--missing-only → firstLastTimes 누락 id만', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'readFileSync').mockImplementation((p) => {
+      if (String(p).endsWith('stationCodes.json'))
+        return JSON.stringify({
+          '1-001': { frCode: '150' },
+          '1-100': { frCode: '801' },
+        });
+      if (String(p).endsWith('stations.json'))
+        return JSON.stringify([
+          { id: '1-001', line: '1', name: '소요산' },
+          { id: '1-100', line: '1', name: '가산디지털단지' },
+        ]);
+      if (String(p).endsWith('firstLastTrainTimes.json'))
+        return JSON.stringify({ '1-001': { weekday: { up: { first: '05:18', last: '23:48' } } } });
+      if (String(p).endsWith('line-1.json')) return JSON.stringify({ stations: {} });
+      return '';
+    });
+    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+    jest.spyOn(fs, 'mkdirSync').mockImplementation(() => {});
+    const fetchImpl = jest.fn(() =>
+      mockOk({
+        SearchSTNTimeTableByFRCodeService: { row: [{ STATION_NM: '가산디지털단지', ARRIVETIME: '05:30:00' }] },
+      }),
+    );
+    await main(['--missing-only'], { EXPO_PUBLIC_SEOUL_DATA_API_KEY: 'X', LINE: '1' }, {
+      fetchImpl,
+      sleepImpl: noopSleep,
+    });
+    // 누락 1역(1-100) × 6 호출
+    expect(fetchImpl).toHaveBeenCalledTimes(6);
+  });
+});

--- a/scripts/__tests__/fetch-timetables.test.js
+++ b/scripts/__tests__/fetch-timetables.test.js
@@ -376,7 +376,7 @@ describe('resolveFrCodeSets', () => {
 });
 
 describe('readExistingLine / writeLine', () => {
-  let tmpDir, originalOutDir;
+  let tmpDir;
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ftt-'));
   });
@@ -415,11 +415,9 @@ describe('readExistingLine / writeLine', () => {
   it('writeLine — sorted key + line-N.json 위치', () => {
     // OUT_DIR을 임시로 mock — writeFileSync를 capture
     const writes = [];
-    const realWrite = fs.writeFileSync;
     jest.spyOn(fs, 'writeFileSync').mockImplementation((p, content) => {
       writes.push({ p, content });
     });
-    const realMkdir = fs.mkdirSync;
     jest.spyOn(fs, 'mkdirSync').mockImplementation(() => {});
     jest.spyOn(fs, 'existsSync').mockReturnValue(true);
     try {
@@ -484,7 +482,7 @@ describe('processLine', () => {
       expect(r.added).toBe(1);
       expect(r.stationCount).toBe(2); // 기존역 + 마천
       const parsed = JSON.parse(writes[0].c);
-      expect(Object.keys(parsed.stations).sort()).toEqual(['기존역', '마천']);
+      expect(Object.keys(parsed.stations).sort((a, b) => a.localeCompare(b))).toEqual(['기존역', '마천']);
     } finally {
       fs.existsSync.mockRestore();
       fs.readFileSync.mockRestore();

--- a/scripts/fetch-timetables.js
+++ b/scripts/fetch-timetables.js
@@ -244,7 +244,7 @@ async function processLine(apiKey, line, frCodes, { fetchImpl, sleepImpl, log } 
   }
   // 기존 데이터 merge — missing-only 모드 등 부분 갱신 케이스 보존
   const existing = readExistingLine(line);
-  const stations = { ...(existing.stations ?? {}) };
+  const stations = { ...existing.stations };
   let added = 0;
   const sortedCodes = [...frCodes].sort((a, b) => a.localeCompare(b, 'en'));
   for (const frCode of sortedCodes) {

--- a/scripts/fetch-timetables.js
+++ b/scripts/fetch-timetables.js
@@ -3,19 +3,33 @@
  * 서울 열린데이터광장 SearchSTNTimeTableByFRCodeService에서 노선별 시간표를 수집해
  * src/data/timetables/line-{N}.json으로 저장한다.
  *
- * Phase 1 스코프: 1호선만 시범 ETL. 크기 실측 및 동적 import 호환성 검증용.
+ * #1497 — FR_CODE 범위 확장. stationCodes.json (#1484 산출물)을 SSOT로 사용해
+ * 지선/순환선 종착역(예: 5호선 마천 지선, 6호선 응암 순환, 4호선 당고개, 2호선 까치산/신설동,
+ * 1호선 가산디지털단지)의 FR_CODE를 자동 발견한다.
  *
- * 사용법:
+ * ## 사용법
+ *
+ *   # 기본: 1~9호선 전체, stationCodes.json 기반
  *   EXPO_PUBLIC_SEOUL_DATA_API_KEY=xxxx node scripts/fetch-timetables.js
- *   EXPO_PUBLIC_SEOUL_DATA_API_KEY=xxxx LINE=1 node scripts/fetch-timetables.js
  *
- * API 사양:
+ *   # 단일 노선
+ *   EXPO_PUBLIC_SEOUL_DATA_API_KEY=xxxx LINE=5 node scripts/fetch-timetables.js
+ *
+ *   # 누락 16역(firstLastTrainTimes.json 기준)만 — 빠른 보강용
+ *   EXPO_PUBLIC_SEOUL_DATA_API_KEY=xxxx node scripts/fetch-timetables.js --missing-only
+ *
+ *   # 레거시 range probe 모드 (회귀 방지용)
+ *   EXPO_PUBLIC_SEOUL_DATA_API_KEY=xxxx LINE=1 node scripts/fetch-timetables.js --legacy-range
+ *
+ * ## API 사양
+ *
  *   엔드포인트: /SearchSTNTimeTableByFRCodeService/{start}/{end}/{FR_CODE}/{WEEK_TAG}/{INOUT_TAG}
- *   FR_CODE: 3자리 정수 (노선별 100단위, 예: 1호선=100~199, 3호선=300~399)
+ *   FR_CODE: 3자리 정수 (노선별 100단위가 base, 지선/순환선은 별도 대역 — stationCodes.json 참조)
  *   WEEK_TAG: 1=평일, 2=토요일, 3=일요일/공휴일
  *   INOUT_TAG: 1=상행/내선, 2=하행/외선
  *
- * 출력 형식 (line-N.json):
+ * ## 출력 형식 (line-N.json)
+ *
  *   {
  *     "stations": {
  *       "서울역": {
@@ -27,38 +41,46 @@
  *   }
  */
 
+'use strict';
+
 const fs = require('node:fs');
 const path = require('node:path');
 
-const API_KEY = process.env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
-if (!API_KEY) {
-  console.error('EXPO_PUBLIC_SEOUL_DATA_API_KEY 환경변수가 없습니다.');
-  process.exit(1);
+const ROOT = path.join(__dirname, '..');
+const STATION_CODES_PATH = path.join(ROOT, 'src', 'data', 'stationCodes.json');
+const STATIONS_PATH = path.join(ROOT, 'src', 'data', 'stations.json');
+const FIRST_LAST_PATH = path.join(ROOT, 'src', 'data', 'firstLastTrainTimes.json');
+const OUT_DIR = path.join(ROOT, 'src', 'data', 'timetables');
+
+const SLEEP_MS = 800;
+const TARGET_LINES = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
+
+const WEEK_INOUT_PLAN = [
+  { weekTag: '1', inoutTag: '1', weekKey: 'weekday', inoutKey: 'up' },
+  { weekTag: '1', inoutTag: '2', weekKey: 'weekday', inoutKey: 'down' },
+  { weekTag: '2', inoutTag: '1', weekKey: 'saturday', inoutKey: 'up' },
+  { weekTag: '2', inoutTag: '2', weekKey: 'saturday', inoutKey: 'down' },
+  { weekTag: '3', inoutTag: '1', weekKey: 'sunday', inoutKey: 'up' },
+  { weekTag: '3', inoutTag: '2', weekKey: 'sunday', inoutKey: 'down' },
+];
+
+const ARRIVE_TIME_RE = /^(\d{2}):(\d{2}):/;
+
+// "HH:MM:SS" → "HHMM". 24h+ 표기("24:09:30")는 익일 시각으로 보존 (정렬은 문자열 비교).
+function compactTime(arriveTime) {
+  if (typeof arriveTime !== 'string') return null;
+  const m = ARRIVE_TIME_RE.exec(arriveTime);
+  if (!m) return null;
+  return `${m[1]}${m[2]}`;
 }
 
-const TARGET_LINE = process.env.LINE ? Number.parseInt(process.env.LINE, 10) : 1;
-const SLEEP_MS = 800;
-const FR_CODE_START = TARGET_LINE * 100;
-const FR_CODE_END = FR_CODE_START + 99;
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
 
-const WEEK_TAGS = [
-  { tag: '1', key: 'weekday' },
-  { tag: '2', key: 'saturday' },
-  { tag: '3', key: 'sunday' },
-];
-const INOUT_TAGS = [
-  { tag: '1', key: 'up' },
-  { tag: '2', key: 'down' },
-];
-
-const OUT_DIR = path.join(__dirname, '..', 'src', 'data', 'timetables');
-if (!fs.existsSync(OUT_DIR)) fs.mkdirSync(OUT_DIR, { recursive: true });
-
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-
-async function fetchOne(frCode, weekTag, inoutTag) {
-  const url = `http://openapi.seoul.go.kr:8088/${API_KEY}/json/SearchSTNTimeTableByFRCodeService/1/1000/${frCode}/${weekTag}/${inoutTag}`;
-  const res = await fetch(url);
+async function fetchOne(apiKey, frCode, weekTag, inoutTag, { fetchImpl = fetch } = {}) {
+  const url = `http://openapi.seoul.go.kr:8088/${apiKey}/json/SearchSTNTimeTableByFRCodeService/1/1000/${frCode}/${weekTag}/${inoutTag}`;
+  const res = await fetchImpl(url);
   if (!res.ok) throw new Error(`HTTP ${res.status} for FR_CODE=${frCode} W=${weekTag} I=${inoutTag}`);
   const json = await res.json();
   const wrapper = json.SearchSTNTimeTableByFRCodeService;
@@ -69,76 +91,238 @@ async function fetchOne(frCode, weekTag, inoutTag) {
   return wrapper.row ?? [];
 }
 
-// "HH:MM:SS" → "HHMM"(2자리×2). 24시간 초과 표기("24:09:30")는 익일 시각으로 보존
-// (정렬은 문자열 비교로 가능, 24+ 시각이 23대보다 큰 값).
-const ARRIVE_TIME_RE = /^(\d{2}):(\d{2}):/;
-function compactTime(arriveTime) {
-  if (typeof arriveTime !== 'string') return null;
-  const m = ARRIVE_TIME_RE.exec(arriveTime);
-  if (!m) return null;
-  return `${m[1]}${m[2]}`;
-}
-
-async function fetchStation(frCode) {
-  // 평일 상행으로 probe — 데이터 없으면 나머지 5호출 생략.
-  const probe = await fetchOne(frCode, '1', '1');
-  await sleep(SLEEP_MS);
-  if (!probe || probe.length === 0) return { stationName: null, timetable: {} };
-  const stationName = probe[0].STATION_NM;
+async function fetchStation(apiKey, frCode, { fetchImpl = fetch, sleepImpl = sleep } = {}) {
+  // 평일 상행 probe — 데이터 없으면 나머지 5호출 생략
+  const [probe, ...rest] = WEEK_INOUT_PLAN;
+  const probeRows = await fetchOne(apiKey, frCode, probe.weekTag, probe.inoutTag, { fetchImpl });
+  await sleepImpl(SLEEP_MS);
+  if (!probeRows || probeRows.length === 0) return { stationName: null, timetable: {} };
+  const stationName = probeRows[0].STATION_NM;
   const result = {
-    weekday: {
-      up: probe.map((r) => compactTime(r.ARRIVETIME)).filter(Boolean).sort(),
+    [probe.weekKey]: {
+      [probe.inoutKey]: probeRows.map((r) => compactTime(r.ARRIVETIME)).filter(Boolean).sort(),
     },
   };
-  // 나머지 5개 호출 (평일 하행, 토 상/하, 일 상/하)
-  const remaining = [
-    { weekTag: '1', inoutTag: '2', weekKey: 'weekday', inoutKey: 'down' },
-    { weekTag: '2', inoutTag: '1', weekKey: 'saturday', inoutKey: 'up' },
-    { weekTag: '2', inoutTag: '2', weekKey: 'saturday', inoutKey: 'down' },
-    { weekTag: '3', inoutTag: '1', weekKey: 'sunday', inoutKey: 'up' },
-    { weekTag: '3', inoutTag: '2', weekKey: 'sunday', inoutKey: 'down' },
-  ];
-  for (const { weekTag, inoutTag, weekKey, inoutKey } of remaining) {
-    const rows = await fetchOne(frCode, weekTag, inoutTag);
-    await sleep(SLEEP_MS);
+  for (const step of rest) {
+    const rows = await fetchOne(apiKey, frCode, step.weekTag, step.inoutTag, { fetchImpl });
+    await sleepImpl(SLEEP_MS);
     if (!rows || rows.length === 0) continue;
     const times = rows.map((r) => compactTime(r.ARRIVETIME)).filter(Boolean).sort();
-    if (!result[weekKey]) result[weekKey] = {};
-    result[weekKey][inoutKey] = times;
+    if (!result[step.weekKey]) result[step.weekKey] = {};
+    result[step.weekKey][step.inoutKey] = times;
   }
   return { stationName, timetable: result };
 }
 
-async function main() {
-  console.log(`# 시간표 ETL 시작 — 노선 ${TARGET_LINE} (FR_CODE ${FR_CODE_START}~${FR_CODE_END})`);
-  const stations = {};
-  let stationCount = 0;
-  for (let frCode = FR_CODE_START; frCode <= FR_CODE_END; frCode++) {
-    const code3 = String(frCode).padStart(3, '0');
+// ---- frCode source resolution ----
+
+function loadStationCodes() {
+  if (!fs.existsSync(STATION_CODES_PATH)) return {};
+  return JSON.parse(fs.readFileSync(STATION_CODES_PATH, 'utf8'));
+}
+
+function loadStations() {
+  return JSON.parse(fs.readFileSync(STATIONS_PATH, 'utf8'));
+}
+
+function loadFirstLastTimes() {
+  if (!fs.existsSync(FIRST_LAST_PATH)) return {};
+  return JSON.parse(fs.readFileSync(FIRST_LAST_PATH, 'utf8'));
+}
+
+/**
+ * stationCodes.json + stations.json을 join해 노선별 FR_CODE 집합을 반환.
+ * 반환: Map<line, Set<frCode3digit>>
+ */
+function collectFrCodesByLine(stationCodes, stations, lines = TARGET_LINES) {
+  const byLine = new Map();
+  for (const line of lines) byLine.set(line, new Set());
+  const stationsById = new Map(stations.map((s) => [s.id, s]));
+  for (const [id, entry] of Object.entries(stationCodes)) {
+    const st = stationsById.get(id);
+    if (!st) continue;
+    if (!byLine.has(st.line)) continue;
+    if (!entry || typeof entry.frCode !== 'string') continue;
+    byLine.get(st.line).add(entry.frCode.padStart(3, '0'));
+  }
+  return byLine;
+}
+
+/**
+ * 누락 station id 집합(line별)을 반환 — firstLastTrainTimes.json에 빠진 1~9호선 entry.
+ * Map<line, Set<frCode3digit>> 형태로 frCode만 추림.
+ */
+function collectMissingFrCodes(stationCodes, stations, firstLastTimes, lines = TARGET_LINES) {
+  const byLine = new Map();
+  for (const line of lines) byLine.set(line, new Set());
+  const lineSet = new Set(lines);
+  for (const s of stations) {
+    if (!lineSet.has(s.line)) continue;
+    if (firstLastTimes[s.id]) continue;
+    const entry = stationCodes[s.id];
+    if (!entry || typeof entry.frCode !== 'string') continue;
+    byLine.get(s.line).add(entry.frCode.padStart(3, '0'));
+  }
+  return byLine;
+}
+
+/**
+ * 레거시 range probe — line * 100 ~ line * 100 + 99.
+ */
+function legacyRangeFrCodes(line) {
+  const start = Number.parseInt(line, 10) * 100;
+  const codes = new Set();
+  for (let i = 0; i < 100; i++) codes.add(String(start + i).padStart(3, '0'));
+  return codes;
+}
+
+// ---- arg parsing ----
+
+function parseArgs(argv, env = process.env) {
+  const args = new Set(argv);
+  return {
+    legacyRange: args.has('--legacy-range'),
+    missingOnly: args.has('--missing-only'),
+    lineEnv: env.LINE ? env.LINE.trim() : null,
+  };
+}
+
+function selectTargetLines({ lineEnv }) {
+  if (!lineEnv) return [...TARGET_LINES];
+  if (!TARGET_LINES.includes(lineEnv)) {
+    throw new Error(`LINE=${lineEnv} 은 지원 대상이 아닙니다 (1~9만 가능)`);
+  }
+  return [lineEnv];
+}
+
+/**
+ * 노선별 FR_CODE 후보 집합 결정 — 모드/누락 옵션 반영.
+ */
+function resolveFrCodeSets(targetLines, { legacyRange, missingOnly, stationCodes, stations, firstLastTimes }) {
+  if (legacyRange) {
+    const byLine = new Map();
+    for (const line of targetLines) byLine.set(line, legacyRangeFrCodes(line));
+    return byLine;
+  }
+  if (missingOnly) {
+    return collectMissingFrCodes(stationCodes, stations, firstLastTimes, targetLines);
+  }
+  return collectFrCodesByLine(stationCodes, stations, targetLines);
+}
+
+// ---- IO ----
+
+function readExistingLine(line) {
+  const filePath = path.join(OUT_DIR, `line-${line}.json`);
+  if (!fs.existsSync(filePath)) return { stations: {} };
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return { stations: {} };
+  }
+}
+
+function writeLine(line, stations) {
+  if (!fs.existsSync(OUT_DIR)) fs.mkdirSync(OUT_DIR, { recursive: true });
+  const sortedKeys = Object.keys(stations).sort((a, b) => a.localeCompare(b, 'en'));
+  const sorted = sortedKeys.reduce((acc, k) => {
+    acc[k] = stations[k];
+    return acc;
+  }, {});
+  const outPath = path.join(OUT_DIR, `line-${line}.json`);
+  fs.writeFileSync(outPath, JSON.stringify({ stations: sorted }, null, 0));
+  return outPath;
+}
+
+// ---- main ----
+
+async function processLine(apiKey, line, frCodes, { fetchImpl, sleepImpl, log } = {}) {
+  log(`# 시간표 ETL — 노선 ${line} (FR_CODE 후보 ${frCodes.size}개)`);
+  if (frCodes.size === 0) {
+    log(`# 노선 ${line} 후보 없음 — skip`);
+    return { line, stationCount: 0, outPath: null };
+  }
+  // 기존 데이터 merge — missing-only 모드 등 부분 갱신 케이스 보존
+  const existing = readExistingLine(line);
+  const stations = { ...(existing.stations ?? {}) };
+  let added = 0;
+  const sortedCodes = [...frCodes].sort((a, b) => a.localeCompare(b, 'en'));
+  for (const frCode of sortedCodes) {
     let stationName, timetable;
     try {
-      ({ stationName, timetable } = await fetchStation(code3));
-    } catch {
-      process.stdout.write('E');
+      ({ stationName, timetable } = await fetchStation(apiKey, frCode, { fetchImpl, sleepImpl }));
+    } catch (e) {
+      log(`E(${frCode}:${e.message})`);
       continue;
     }
     if (!stationName || Object.keys(timetable).length === 0) {
-      process.stdout.write('.');
+      log(`.${frCode}`);
       continue;
     }
     stations[stationName] = timetable;
-    stationCount++;
-    process.stdout.write('o');
+    added++;
+    log(`o${frCode}:${stationName}`);
   }
-  console.log(`\n# 총 ${stationCount}개 역 수집`);
-  const outPath = path.join(OUT_DIR, `line-${TARGET_LINE}.json`);
-  fs.writeFileSync(outPath, JSON.stringify({ stations }, null, 0));
-  const stat = fs.statSync(outPath);
-  console.log(`# 저장: ${outPath}`);
-  console.log(`# 크기 (minified): ${stat.size} bytes (${(stat.size / 1024).toFixed(1)} KB)`);
+  const outPath = writeLine(line, stations);
+  log(`# 노선 ${line} 완료 — 신규/갱신 ${added}, 총 ${Object.keys(stations).length}역, ${outPath}`);
+  return { line, stationCount: Object.keys(stations).length, added, outPath };
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+async function main(argv = process.argv.slice(2), env = process.env, deps = {}) {
+  const { fetchImpl, sleepImpl } = deps;
+  const apiKey = env.EXPO_PUBLIC_SEOUL_DATA_API_KEY;
+  if (!apiKey) {
+    process.stderr.write('EXPO_PUBLIC_SEOUL_DATA_API_KEY 환경변수가 없습니다.\n');
+    process.exit(1);
+  }
+  const opts = parseArgs(argv, env);
+  const targetLines = selectTargetLines(opts);
+  const stationCodes = loadStationCodes();
+  const stations = loadStations();
+  const firstLastTimes = loadFirstLastTimes();
+  if (!opts.legacyRange && Object.keys(stationCodes).length === 0) {
+    process.stderr.write(
+      'stationCodes.json이 비어있습니다 — 먼저 `node scripts/fetch-station-codes-and-times.js`를 실행하거나 `--legacy-range`를 사용하세요.\n',
+    );
+    process.exit(1);
+  }
+  const sets = resolveFrCodeSets(targetLines, {
+    legacyRange: opts.legacyRange,
+    missingOnly: opts.missingOnly,
+    stationCodes,
+    stations,
+    firstLastTimes,
+  });
+  const log = (msg) => process.stdout.write(`${msg}\n`);
+  const results = [];
+  for (const line of targetLines) {
+    const frCodes = sets.get(line) ?? new Set();
+    const r = await processLine(apiKey, line, frCodes, { log, fetchImpl, sleepImpl });
+    results.push(r);
+  }
+  log(`# 전체 완료 — ${results.length}개 노선 처리`);
+}
+
+module.exports = {
+  compactTime,
+  fetchOne,
+  fetchStation,
+  collectFrCodesByLine,
+  collectMissingFrCodes,
+  legacyRangeFrCodes,
+  parseArgs,
+  selectTargetLines,
+  resolveFrCodeSets,
+  readExistingLine,
+  writeLine,
+  processLine,
+  main,
+  TARGET_LINES,
+};
+
+if (require.main === module) {
+  main().catch((e) => {
+    process.stderr.write(`${e.stack || e.message}\n`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

`scripts/fetch-timetables.js`가 FR_CODE를 `{line*100}~{line*100+99}` range로 probe하던 가정 때문에 지선/순환선 종착역 16역이 1~9호선임에도 누락돼 있었다. PR #1490 머지로 `src/data/stationCodes.json`(530 entries) 인프라가 들어왔으므로, 이를 SSOT로 사용해 누락 16역을 자동 수집한다.

## Changes

- **기본 모드 (신규)**: `stationCodes.json`을 read해 1~9호선 392역 각각의 FR_CODE 직접 호출
- `--missing-only`: `firstLastTrainTimes.json`에 빠진 id만 보강 — 빠른 보강용
- `--legacy-range`: 기존 range probe 모드 유지 (회귀 방지)
- `LINE` env 미지정 시 1~9호선 전체 순회
- 기존 `line-N.json` 데이터와 merge (부분 갱신 케이스 보존)
- 결정론적 sort + JSON write
- 단위 테스트 47개 추가 (`scripts/__tests__/fetch-timetables.test.js`)

## 누락 16역 (1~9호선)

| line | id | name | 패턴 |
|---|---|---|---|
| 1 | 1-100 | 가산디지털단지 | FR_CODE 100-199 밖 |
| 2 | 2-105 | 까치산 | 신정지선 |
| 2 | 2-205 | 신설동 | 성수지선 |
| 4 | 4-001 | 당고개 | 4호선 종점 |
| 5 | 5-040~5-046 | 둔촌동/올림픽공원/방이/오금/개롱/거여/마천 | 마천 지선 (7역) |
| 6 | 6-002~6-006 | 역촌/불광/독바위/연신내/구산 | 응암 순환선 (5역) |

`firstLastTrainTimes.json`: 376/392 → 392/392 (사용자 액션 후)

## 양방향 추적

**Upstream**:
- `src/data/stationCodes.json` (PR #1490 산출물, 530 entries)
- 서울 OpenAPI `SearchSTNTimeTableByFRCodeService`

**Downstream**:
- `src/data/timetables/line-{1..9}.json` — timetable raw
- `src/data/firstLastTrainTimes.json` — derived 첫차/막차

**의존**: `src/data/stations.json` id 매핑

## 사용자 액션 (본 PR 머지 후)

```bash
set -a; source .env; set +a

# 1) stationCodes.json 채우기 (PR #1484 이후 한 번만, 이미 채워졌다면 skip)
node scripts/fetch-station-codes-and-times.js

# 2) 1~9호선 timetable 재수집 — stationCodes 모드 (기본)
node scripts/fetch-timetables.js

# 또는 빠른 보강 (누락 16역만):
node scripts/fetch-timetables.js --missing-only

# 3) firstLastTrainTimes.json 재생성
node scripts/fetch-station-codes-and-times.js --derive-only

# 4) 검증 — 392 entries 확인
node -e "const f=require('./src/data/firstLastTrainTimes.json'); console.log('entries:', Object.keys(f).length, '(expected 392)')"
```

## Test plan

- [x] `npx jest scripts/__tests__/fetch-timetables.test.js` — 47/47 pass
- [x] `npm run type-check` — pass
- [x] `npm run validate:data` — 533 stations OK
- [x] dev baseline에 이미 존재하는 widgetStorage/stationNotification 35 fail은 본 PR 범위 외 (scripts/는 coverage 대상 아님)
- [ ] 사용자: 본 PR 머지 후 위 4-step 절차로 실 API 호출 검증

## 참고

- PR #1490 (chore/#1484-station-code-mapping-v2) — stationCodes.json 인프라
- 본 PR은 stationCodes.json이 사용자에 의해 채워진 후 실효성 발휘

Closes #1497
