### PR TITLE
feat(#1504): 하차문 방향 platformExitSide fallback — 알림 + Live Activity

### DIFF
--- a/src/features/alarm/utils/__tests__/stationNotification.test.ts
+++ b/src/features/alarm/utils/__tests__/stationNotification.test.ts
@@ -846,39 +846,39 @@ describe('stationNotification', () => {
     });
 
     describe('빠른하차 힌트 (quickExit)', () => {
-      it('해당 역의 빠른하차 데이터가 없으면 본문에 힌트가 붙지 않는다', async () => {
+      // #1504 SonarCloud dedup — quickExit 분기 매트릭스를 it.each로 통합.
+      // 각 row: [phaseId, type, stationName, title, body].
+      // 잠실/왕십리는 platformExitSide fallback fixture가 있어 좌/우 라인이 함께 붙는다.
+      it.each([
+        [
+          '해당 역의 빠른하차 데이터가 없으면 본문에 힌트가 붙지 않는다',
+          'early', 'destination', '시청',
+          '하차 알림', '다음 역 시청에서 하차하세요!',
+        ],
+        [
+          'destination 알람이고 데이터가 있으면 "출구가 빠른 위치" 힌트가 붙는다',
+          'early', 'destination', '잠실',
+          '하차 알림', '다음 역 잠실에서 하차하세요!\n오른쪽 문으로 하차하세요\n출구가 빠른 위치에서 하차하세요',
+        ],
+        [
+          'transfer 알람이고 데이터가 있으면 "환승이 빠른 위치" 힌트가 붙는다',
+          'early', 'transfer', '왕십리(성동구청)',
+          '환승 알림', '다음 역 왕십리(성동구청)에서 환승하세요!\n양쪽 문이 열립니다\n환승이 빠른 위치에서 하차하세요',
+        ],
+        [
+          '알람 대상역이 stations.json에도 없으면 힌트 없이 본문만 표시한다',
+          'early', 'destination', '없는역',
+          '하차 알림', '다음 역 없는역에서 하차하세요!',
+        ],
+        [
+          '정규화 fallback — 괄호 부제가 붙은 이름이어도 매칭된다',
+          'imminent', 'destination', '잠실',
+          '도착 임박', '곧 잠실에 도착합니다. 하차 준비하세요!\n오른쪽 문으로 하차하세요\n출구가 빠른 위치에서 하차하세요',
+        ],
+      ] as const)('%s', async (_label, phaseId, type, stationName, title, body) => {
         jest.replaceProperty(Platform, 'OS', 'ios');
-        await sendAlarmNotification({ phaseId: 'early', type: 'destination', stationName: '시청' });
-        expectAlarmNotification('하차 알림', '다음 역 시청에서 하차하세요!', { interruptionLevel: 'timeSensitive' });
-      });
-
-      it('destination 알람이고 데이터가 있으면 "출구가 빠른 위치" 힌트가 붙는다', async () => {
-        jest.replaceProperty(Platform, 'OS', 'ios');
-        await sendAlarmNotification({ phaseId: 'early', type: 'destination', stationName: '잠실' });
-        // #1504 — 잠실(2-016) platformExitSide fallback이 발화해 좌/우 라인이 함께 붙는다.
-        expectAlarmNotification('하차 알림', '다음 역 잠실에서 하차하세요!\n오른쪽 문으로 하차하세요\n출구가 빠른 위치에서 하차하세요', { interruptionLevel: 'timeSensitive' });
-      });
-
-      it('transfer 알람이고 데이터가 있으면 "환승이 빠른 위치" 힌트가 붙는다', async () => {
-        jest.replaceProperty(Platform, 'OS', 'ios');
-        await sendAlarmNotification({ phaseId: 'early', type: 'transfer', stationName: '왕십리(성동구청)' });
-        // #1504 — 왕십리(2-008) platformExitSide fallback이 발화해 양쪽 문 라인이 함께 붙는다.
-        expectAlarmNotification('환승 알림', '다음 역 왕십리(성동구청)에서 환승하세요!\n양쪽 문이 열립니다\n환승이 빠른 위치에서 하차하세요', { interruptionLevel: 'timeSensitive' });
-      });
-
-      it('알람 대상역이 stations.json에도 없으면 힌트 없이 본문만 표시한다', async () => {
-        jest.replaceProperty(Platform, 'OS', 'ios');
-        await sendAlarmNotification({ phaseId: 'early', type: 'destination', stationName: '없는역' });
-        expectAlarmNotification('하차 알림', '다음 역 없는역에서 하차하세요!', { interruptionLevel: 'timeSensitive' });
-      });
-
-      it('정규화 fallback — 괄호 부제가 붙은 이름이어도 매칭된다', async () => {
-        jest.replaceProperty(Platform, 'OS', 'ios');
-        // 잠실(2-016)이 stations.json에 "잠실(송파구청)" 같은 형태로 등록돼 있지 않더라도
-        // 동일 케이스 보호. 잠실이 단일 이름이라 여기서는 정확 매칭으로 작동.
-        await sendAlarmNotification({ phaseId: 'imminent', type: 'destination', stationName: '잠실' });
-        // #1504 — platformExitSide fallback이 imminent 단계에도 동일하게 적용.
-        expectAlarmNotification('도착 임박', '곧 잠실에 도착합니다. 하차 준비하세요!\n오른쪽 문으로 하차하세요\n출구가 빠른 위치에서 하차하세요', { interruptionLevel: 'timeSensitive' });
+        await sendAlarmNotification({ phaseId, type, stationName });
+        expectAlarmNotification(title, body, { interruptionLevel: 'timeSensitive' });
       });
     });
 

--- a/src/features/alarm/utils/__tests__/stationNotification.test.ts
+++ b/src/features/alarm/utils/__tests__/stationNotification.test.ts
@@ -88,6 +88,15 @@ jest.mock('../../../../data/exitSide.json', () => ({
   시청: { up: 'both' },
 }));
 
+// #1504 — direction-agnostic platform fallback SSOT.
+// 강남(2-022)·시청(1-033/2-001)은 빈 매핑이라 primary(`exitSide.json`) 단독 분기 테스트가 그대로 유지된다.
+// fallback 검증용으로 잠실(2-016)·왕십리(2-008)에만 명시 매핑을 등록한다. 두 역은 exitSide.json에 없어
+// fallback 경로를 단독 측정한다.
+jest.mock('../../../../data/platformExitSide.json', () => ({
+  '2-016': 'right',
+  '2-008': 'both',
+}));
+
 // 빠른하차 힌트 분기 테스트용 — 잠실(2-016)·왕십리(2-008)만 등록.
 // 기존 테스트들이 자주 쓰는 강남(2-022)·시청(1-033)에는 데이터를 두지 않아 기존 본문 비교가 깨지지 않도록 한다.
 jest.mock('../../../../data/quickExit.json', () => ({
@@ -804,6 +813,36 @@ describe('stationNotification', () => {
         await sendAlarmNotification({ ...earlyTransfer, direction: 'down' });
         expectAlarmNotification('환승 알림', '다음 역 시청에서 환승하세요!', { interruptionLevel: 'timeSensitive' });
       });
+
+      // #1504 — direction-agnostic platformExitSide.json fallback.
+      describe('platformExitSide fallback', () => {
+        it('direction이 없어도 platformExitSide에 등록된 역이면 fallback이 적용된다', async () => {
+          jest.replaceProperty(Platform, 'OS', 'ios');
+          await sendAlarmNotification({ phaseId: 'early', type: 'destination', stationName: '잠실' });
+          // 잠실(2-016)='right' fixture. quickExit 힌트도 같이 등록돼 있어 함께 표시된다.
+          expectAlarmNotification('하차 알림', '다음 역 잠실에서 하차하세요!\n오른쪽 문으로 하차하세요\n출구가 빠른 위치에서 하차하세요', { interruptionLevel: 'timeSensitive' });
+        });
+
+        it('primary가 매칭되면 fallback을 무시하고 primary 결과를 사용한다', async () => {
+          jest.replaceProperty(Platform, 'OS', 'ios');
+          // 강남: primary up='left' / platformExitSide fixture 미등록 — primary 단독.
+          await sendAlarmNotification({ ...earlyDest, direction: 'up' });
+          expectAlarmNotification('하차 알림', '다음 역 강남에서 하차하세요!\n왼쪽 문으로 하차하세요', { interruptionLevel: 'timeSensitive' });
+        });
+
+        it('primary가 unmatched여도 platformExitSide에 매핑이 있으면 fallback이 적용된다', async () => {
+          jest.replaceProperty(Platform, 'OS', 'ios');
+          // 왕십리(2-008): primary 미등록 / fallback='both'. direction이 있어도 primary null → fallback.
+          await sendAlarmNotification({ phaseId: 'early', type: 'transfer', stationName: '왕십리(성동구청)', direction: 'up' });
+          expectAlarmNotification('환승 알림', '다음 역 왕십리(성동구청)에서 환승하세요!\n양쪽 문이 열립니다\n환승이 빠른 위치에서 하차하세요', { interruptionLevel: 'timeSensitive' });
+        });
+
+        it('stations.json에 없는 역은 fallback도 발화하지 않는다', async () => {
+          jest.replaceProperty(Platform, 'OS', 'ios');
+          await sendAlarmNotification({ phaseId: 'early', type: 'destination', stationName: '없는역' });
+          expectAlarmNotification('하차 알림', '다음 역 없는역에서 하차하세요!', { interruptionLevel: 'timeSensitive' });
+        });
+      });
     });
 
     describe('빠른하차 힌트 (quickExit)', () => {
@@ -816,13 +855,15 @@ describe('stationNotification', () => {
       it('destination 알람이고 데이터가 있으면 "출구가 빠른 위치" 힌트가 붙는다', async () => {
         jest.replaceProperty(Platform, 'OS', 'ios');
         await sendAlarmNotification({ phaseId: 'early', type: 'destination', stationName: '잠실' });
-        expectAlarmNotification('하차 알림', '다음 역 잠실에서 하차하세요!\n출구가 빠른 위치에서 하차하세요', { interruptionLevel: 'timeSensitive' });
+        // #1504 — 잠실(2-016) platformExitSide fallback이 발화해 좌/우 라인이 함께 붙는다.
+        expectAlarmNotification('하차 알림', '다음 역 잠실에서 하차하세요!\n오른쪽 문으로 하차하세요\n출구가 빠른 위치에서 하차하세요', { interruptionLevel: 'timeSensitive' });
       });
 
       it('transfer 알람이고 데이터가 있으면 "환승이 빠른 위치" 힌트가 붙는다', async () => {
         jest.replaceProperty(Platform, 'OS', 'ios');
         await sendAlarmNotification({ phaseId: 'early', type: 'transfer', stationName: '왕십리(성동구청)' });
-        expectAlarmNotification('환승 알림', '다음 역 왕십리(성동구청)에서 환승하세요!\n환승이 빠른 위치에서 하차하세요', { interruptionLevel: 'timeSensitive' });
+        // #1504 — 왕십리(2-008) platformExitSide fallback이 발화해 양쪽 문 라인이 함께 붙는다.
+        expectAlarmNotification('환승 알림', '다음 역 왕십리(성동구청)에서 환승하세요!\n양쪽 문이 열립니다\n환승이 빠른 위치에서 하차하세요', { interruptionLevel: 'timeSensitive' });
       });
 
       it('알람 대상역이 stations.json에도 없으면 힌트 없이 본문만 표시한다', async () => {
@@ -836,7 +877,8 @@ describe('stationNotification', () => {
         // 잠실(2-016)이 stations.json에 "잠실(송파구청)" 같은 형태로 등록돼 있지 않더라도
         // 동일 케이스 보호. 잠실이 단일 이름이라 여기서는 정확 매칭으로 작동.
         await sendAlarmNotification({ phaseId: 'imminent', type: 'destination', stationName: '잠실' });
-        expectAlarmNotification('도착 임박', '곧 잠실에 도착합니다. 하차 준비하세요!\n출구가 빠른 위치에서 하차하세요', { interruptionLevel: 'timeSensitive' });
+        // #1504 — platformExitSide fallback이 imminent 단계에도 동일하게 적용.
+        expectAlarmNotification('도착 임박', '곧 잠실에 도착합니다. 하차 준비하세요!\n오른쪽 문으로 하차하세요\n출구가 빠른 위치에서 하차하세요', { interruptionLevel: 'timeSensitive' });
       });
     });
 

--- a/src/features/alarm/utils/stationNotification.ts
+++ b/src/features/alarm/utils/stationNotification.ts
@@ -32,6 +32,8 @@ import stationsData from '../../../data/stations.json';
 import type { ExitSide } from '../../../shared/types/exitSide';
 import { lookupExitSide } from '../../route/utils/exitSide';
 import { hasQuickExitData } from '../../route/utils/quickExit';
+import { lookupPlatformExitSide } from '../../../shared/utils/platformExitSideLookup';
+import { findStationByName } from '../../../shared/utils/stationLookup';
 import {
   notificationSourceI18nKey,
   shouldDiscloseNotificationSource,
@@ -185,9 +187,22 @@ function appendExitSide(body: string, side?: ExitSide | null): string {
   return `${body}\n${exitSideText(side)}`;
 }
 
+// 좌/우 하차 방향 해석 (#1504):
+//   1) Primary — `lookupExitSide(name, direction)` (사용자 검수형 direction-aware SSOT).
+//   2) Fallback — primary가 null이면 stations.json id로 `lookupPlatformExitSide(id)` 조회
+//      (승강장 구조 기반 static SSOT, direction 무관). #1482에서 추가된 265역 커버.
+//   3) 둘 다 null이면 기존처럼 좌/우 라인을 생략한다.
+//
+// fallback은 direction 부재(motion gate 미확정 등)나 사용자 검수 데이터 누락 케이스에서
+// 좌/우 안내를 살려준다. direction이 있는 경우에도 primary가 우선이라 정확도 회귀 없음.
 function resolveExitSide(event: AlarmEvent): ExitSide | null {
-  if (!event.direction) return null;
-  return lookupExitSide(event.stationName, event.direction);
+  const direct = event.direction
+    ? lookupExitSide(event.stationName, event.direction)
+    : null;
+  if (direct) return direct;
+  const station = findStationByName(event.stationName);
+  if (!station) return null;
+  return lookupPlatformExitSide(station.id);
 }
 
 // 알람 본문에 추상적 빠른하차 힌트를 붙일지 결정. 해당 역의 빠른하차 데이터가 있을 때만 표시한다.


### PR DESCRIPTION
Closes #1504

## Summary

`#1482`에서 추가된 승강장 구조 기반 하차문 방향 SSOT(`platformExitSide.json` 265역)를 알림 본문 + Live Activity에 fallback layer로 wiring. direction 부재나 사용자 검수 데이터 미등록 케이스에서도 좌/우 안내가 살아남는다.

## 변경

`src/features/alarm/utils/stationNotification.ts` — `resolveExitSide(event)` 단일 함수에 fallback 추가:

\`\`\`ts
// Primary: direction-aware exitSide.json (사용자 검수 SSOT)
const direct = event.direction ? lookupExitSide(event.stationName, event.direction) : null;
if (direct) return direct;
// Fallback: id 기반 platformExitSide.json (승강장 구조 정적 SSOT, 265역)
const station = findStationByName(event.stationName);
if (!station) return null;
return lookupPlatformExitSide(station.id);
\`\`\`

## 양방향 layer 추적

- **Upstream**: `lookupPlatformExitSide(stationId)` (#1482) + `findStationByName(name)` (기존)
- **Downstream (자동 혜택)**:
  - `buildAlarmContent` → `sendAlarmNotification` → Local Notification body
  - `buildLiveActivityData` → `alarmBody`(텍스트) + `alarmExitSide`(필드) → Dynamic Island/Lock Screen Live Activity
- **인프라**: expo-notifications + live-activity native module (변경 없음)

## 비통합 영역 (별도 후보)

- HomeScreen 도착 카드 — 현재 exit-side UI 컴포넌트 없음. 신규 UI는 별도 PR.
- DebugModal Trip 섹션 surfacing — 별도 PR.
- station-passed 매역 알림 — 매역 자백 노이즈 우려, 정책 결정 별도.

## i18n

기존 키 재사용 — 신규 추가 없음 (`alarms.exitSideLeft/Right/Both`, 4 언어 완비).

## 4 언어 메시지 sample (잠실 fallback case)

- ko: `다음 역 잠실에서 하차하세요!\n오른쪽 문으로 하차하세요`
- en: `Get off at the next stop, Jamsil!\nExit on the right`
- ja: `次の駅 잠실で降りてください!\n右側のドアから降りてください`
- zh: `下一站잠실请下车!\n请从右侧车门下车`

(역명 번역은 stations.json의 nameEn/nameJa 기존 path 그대로)

## 사용자 trip 예시 (실제 데이터)

- 성수(2-013): `both` — `양쪽 문이 열립니다`
- 한양대(2-006): `right` — `오른쪽 문으로 하차하세요`
- 마장(5-027): `right` — `오른쪽 문으로 하차하세요`
- 잠실(2-016): `right` — `오른쪽 문으로 하차하세요`
- 왕십리(2-008): `both` — `양쪽 문이 열립니다`

## 통합 통계

- platformExitSide.json 등록 역: **265 / 528** (50.2%)
- direction-aware 우선 정책 유지 — 정확도 회귀 0
- fallback 활성 조건: direction null OR exitSide.json 미등록 AND stations.json에서 name 매칭 성공

## 테스트

`src/features/alarm/utils/__tests__/stationNotification.test.ts` 신규 4 케이스:
- direction-less 발화 (잠실 fallback)
- primary 우선 (강남 direction='up' → exitSide.json 'left')
- primary-null fallback (왕십리 direction='up' / exitSide.json 미등록 / platformExitSide 'both')
- stations.json에 없는 역 graceful (좌/우 라인 생략)

기존 quickExit 본문 기대치(잠실·왕십리) 3건은 platformExitSide 발화 반영해 업데이트.

## Test plan

- [x] `npm run type-check` pass
- [x] 신규 exit-side fallback 4 테스트 pass (지역 검증)
- [ ] CI `Data Validation` + `Type Check & Test` pass 확인 후 머지
- [ ] 실기기 trip 1회로 fallback 메시지 visual 확인 (별도)