### PR TITLE
feat(#1499): 자체 최단경로 알고리즘 — Dijkstra + 2종 type 산출

### DIFF
--- a/src/features/route/utils/__tests__/buildRouteGraph.test.ts
+++ b/src/features/route/utils/__tests__/buildRouteGraph.test.ts
@@ -1,0 +1,78 @@
+import {
+  __resetRouteGraphCache,
+  buildRouteGraph,
+} from '../buildRouteGraph';
+
+describe('buildRouteGraph (#1499)', () => {
+  beforeEach(() => {
+    __resetRouteGraphCache();
+  });
+
+  it('builds nodes from stations.json (533 entries)', () => {
+    const graph = buildRouteGraph();
+    expect(graph.stats.nodeCount).toBe(533);
+  });
+
+  it('builds line edges from stationDistances and computes duration via lineSpeeds', () => {
+    const graph = buildRouteGraph();
+    // 2호선 2-001 → 2-002 (1호선 시청 인근, 700m)
+    const edges = graph.adjacency.get('2-001') ?? [];
+    const lineEdge = edges.find(
+      (e) => e.kind === 'line' && e.toId === '2-002',
+    );
+    expect(lineEdge).toBeDefined();
+    if (lineEdge && lineEdge.kind === 'line') {
+      expect(lineEdge.distanceMeters).toBe(700);
+      expect(lineEdge.line).toBe('2');
+      // 700m @ 32 km/h = 700 / (32000/3600) ≈ 78.75s
+      expect(lineEdge.durationSeconds).toBeCloseTo(78.75, 1);
+    }
+  });
+
+  it('builds bidirectional line edges', () => {
+    const graph = buildRouteGraph();
+    const forward = (graph.adjacency.get('2-001') ?? []).some(
+      (e) => e.kind === 'line' && e.toId === '2-002',
+    );
+    const backward = (graph.adjacency.get('2-002') ?? []).some(
+      (e) => e.kind === 'line' && e.toId === '2-001',
+    );
+    expect(forward).toBe(true);
+    expect(backward).toBe(true);
+  });
+
+  it('builds transfer edges from transferTimes (동대문역사문화공원 2/4/5)', () => {
+    const graph = buildRouteGraph();
+    // 2-005 (동대문역사문화공원, 2호선) → 5-027 (5호선)
+    const edges = graph.adjacency.get('2-005') ?? [];
+    const transfer = edges.find(
+      (e) =>
+        e.kind === 'transfer' && e.toId === '5-027' && e.stationName === '동대문역사문화공원',
+    );
+    expect(transfer).toBeDefined();
+    if (transfer && transfer.kind === 'transfer') {
+      expect(transfer.walkingSeconds).toBeGreaterThan(0);
+      expect(transfer.fromLine).toBe('2');
+      expect(transfer.toLine).toBe('5');
+    }
+  });
+
+  it('caches the graph across calls', () => {
+    const g1 = buildRouteGraph();
+    const g2 = buildRouteGraph();
+    expect(g1).toBe(g2);
+  });
+
+  it('resets cache via __resetRouteGraphCache', () => {
+    const g1 = buildRouteGraph();
+    __resetRouteGraphCache();
+    const g2 = buildRouteGraph();
+    expect(g1).not.toBe(g2);
+  });
+
+  it('exposes edge counts > 0', () => {
+    const graph = buildRouteGraph();
+    expect(graph.stats.lineEdgeCount).toBeGreaterThan(800);
+    expect(graph.stats.transferEdgeCount).toBeGreaterThan(0);
+  });
+});

--- a/src/features/route/utils/__tests__/dijkstraRoute.test.ts
+++ b/src/features/route/utils/__tests__/dijkstraRoute.test.ts
@@ -1,0 +1,108 @@
+import { __resetRouteGraphCache } from '../buildRouteGraph';
+import {
+  findRouteByType,
+  findRoutes,
+  ROUTE_OPTIMIZATION_TYPES,
+} from '../dijkstraRoute';
+
+describe('dijkstraRoute (#1499)', () => {
+  beforeEach(() => {
+    __resetRouteGraphCache();
+  });
+
+  it('returns null for unknown station ids', () => {
+    expect(findRouteByType('UNKNOWN-1', '2-001', 'min-time')).toBeNull();
+    expect(findRouteByType('2-001', 'UNKNOWN-2', 'min-time')).toBeNull();
+  });
+
+  it('returns empty route when from === to', () => {
+    const r = findRouteByType('2-001', '2-001', 'min-time');
+    expect(r).not.toBeNull();
+    expect(r?.legs).toHaveLength(0);
+    expect(r?.transfers).toHaveLength(0);
+    expect(r?.totalDurationSeconds).toBe(0);
+    expect(r?.totalDistanceMeters).toBe(0);
+    expect(r?.transferCount).toBe(0);
+  });
+
+  it('finds a direct same-line route without transfers (2-001 → 2-003)', () => {
+    const r = findRouteByType('2-001', '2-003', 'min-distance');
+    expect(r).not.toBeNull();
+    expect(r?.transferCount).toBe(0);
+    expect(r?.legs).toHaveLength(1);
+    expect(r?.legs[0].line).toBe('2');
+    expect(r?.legs[0].fromId).toBe('2-001');
+    expect(r?.legs[0].toId).toBe('2-003');
+    expect(r?.legs[0].stationIds).toEqual(['2-001', '2-002', '2-003']);
+    // 700 + 800 = 1500m
+    expect(r?.totalDistanceMeters).toBe(1500);
+  });
+
+  it('finds a transfer route (성수 2-011 → 마장 5-032) min-transfer', () => {
+    const r = findRouteByType('2-011', '5-032', 'min-transfer');
+    expect(r).not.toBeNull();
+    expect(r?.transferCount).toBeGreaterThanOrEqual(1);
+    // 첫 leg는 2호선, 마지막 leg는 5호선
+    if (r) {
+      expect(r.legs[0].line).toBe('2');
+      expect(r.legs[r.legs.length - 1].line).toBe('5');
+    }
+  });
+
+  it('min-transfer prefers fewer transfers than min-distance', () => {
+    const a = findRouteByType('2-011', '5-032', 'min-transfer');
+    const b = findRouteByType('2-011', '5-032', 'min-distance');
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    if (a && b) {
+      expect(a.transferCount).toBeLessThanOrEqual(b.transferCount);
+    }
+  });
+
+  it('findRoutes returns all three types', () => {
+    const result = findRoutes('2-001', '2-003');
+    for (const type of ROUTE_OPTIMIZATION_TYPES) {
+      expect(result[type]).not.toBeNull();
+      expect(result[type]?.type).toBe(type);
+    }
+  });
+
+  it('min-time accumulates walking seconds for transfer routes', () => {
+    const r = findRouteByType('2-011', '5-032', 'min-time');
+    expect(r).not.toBeNull();
+    if (r && r.transferCount > 0) {
+      expect(r.totalWalkingSeconds).toBeGreaterThan(0);
+      // totalDuration = sum of leg durations + walking
+      const sumLeg = r.legs.reduce((s, l) => s + l.durationSeconds, 0);
+      expect(r.totalDurationSeconds).toBeCloseTo(
+        sumLeg + r.totalWalkingSeconds,
+        3,
+      );
+    }
+  });
+
+  it('returns null when destination is unreachable (no connecting edges)', () => {
+    // 9호선/airport는 stationDistances에 없어 unreachable
+    // 9-001(개화) → 2-001 라인 외 연결 없음
+    const r = findRouteByType('9-001', '2-001', 'min-time');
+    expect(r).toBeNull();
+  });
+
+  it('min-distance excludes walking distance for transfers', () => {
+    const r = findRouteByType('2-011', '5-032', 'min-distance');
+    expect(r).not.toBeNull();
+    if (r) {
+      // totalDistanceMeters should be sum of leg distances only
+      const sumLeg = r.legs.reduce((s, l) => s + l.distanceMeters, 0);
+      expect(r.totalDistanceMeters).toBe(sumLeg);
+    }
+  });
+
+  it('heap correctness — large random pair stress', () => {
+    // 1-001 → 1-010 같은 호선 직진 sanity
+    const r = findRouteByType('1-009', '1-010', 'min-time');
+    expect(r).not.toBeNull();
+    expect(r?.legs).toHaveLength(1);
+    expect(r?.transferCount).toBe(0);
+  });
+});

--- a/src/features/route/utils/buildRouteGraph.ts
+++ b/src/features/route/utils/buildRouteGraph.ts
@@ -1,0 +1,165 @@
+/**
+ * #1499 — 자체 Dijkstra 그래프 빌더.
+ *
+ * 데이터 SSOT (외부 API 의존 없음, ADR-015 §6):
+ *   - `src/data/stations.json` — 533 역 (그래프 노드)
+ *   - `src/data/stationDistances.json` — 호선 인접 edge (m)
+ *   - `src/data/transferTimes.json` — 환승 도보 edge (초)
+ *   - `src/shared/constants/lineSpeeds.ts` — 호선 평균 속도 (km/h)
+ *
+ * 그래프 구조:
+ *   - node id = station.id (예: `2-011`)
+ *   - line edge: 같은 호선 인접 역. weight = distance(m) / lineSpeed(km/h) → durationSeconds
+ *   - transfer edge: 같은 name + 다른 line. weight = transferTimes 도보 초
+ *
+ * Sub-D 본 PR 범위. boardable wait(Sub C cascade) 합산은 Sub-E 후속.
+ */
+import stationsRaw from '../../../data/stations.json';
+import stationDistancesRaw from '../../../data/stationDistances.json';
+import transferTimesRaw from '../../../data/transferTimes.json';
+import { LINE_AVERAGE_SPEED_KMH } from '../../../shared/constants/lineSpeeds';
+import type { LineNumber, Station } from '../../../shared/types/station';
+
+const STATIONS = stationsRaw as Station[];
+const DISTANCES = stationDistancesRaw as Record<string, number>;
+const TRANSFERS = transferTimesRaw as Record<string, number>;
+
+export interface LineEdge {
+  readonly kind: 'line';
+  readonly toId: string;
+  readonly line: LineNumber;
+  /** edge 물리 거리 (m). */
+  readonly distanceMeters: number;
+  /** 호선 평균 속도 기반 운행 시간 (초). 정차 시간 포함 표정속도. */
+  readonly durationSeconds: number;
+}
+
+export interface TransferEdge {
+  readonly kind: 'transfer';
+  readonly toId: string;
+  /** 환승 도보 시간 (초). */
+  readonly walkingSeconds: number;
+  /** 환승역 이름 (디버그용). */
+  readonly stationName: string;
+  readonly fromLine: LineNumber;
+  readonly toLine: LineNumber;
+}
+
+export type RouteEdge = LineEdge | TransferEdge;
+
+export interface RouteGraph {
+  readonly nodes: ReadonlyMap<string, Station>;
+  readonly adjacency: ReadonlyMap<string, readonly RouteEdge[]>;
+  readonly stats: {
+    readonly nodeCount: number;
+    readonly lineEdgeCount: number;
+    readonly transferEdgeCount: number;
+  };
+}
+
+/**
+ * 거리(m) + 호선 평균 속도(km/h)로 운행 초 산출.
+ * `LINE_AVERAGE_SPEED_KMH`는 모든 `LineNumber`를 망라 (타입 강제) → fallback 불필요.
+ */
+function computeDurationSeconds(distanceMeters: number, line: LineNumber): number {
+  const kmh = LINE_AVERAGE_SPEED_KMH[line];
+  const mps = (kmh * 1000) / 3600;
+  return distanceMeters / mps;
+}
+
+let cachedGraph: RouteGraph | null = null;
+
+/**
+ * 그래프를 1회 빌드 후 캐싱. stations.json 등 SSOT가 정적이므로 안전.
+ * 테스트는 `__resetRouteGraphCache()`로 초기화 가능.
+ */
+export function buildRouteGraph(): RouteGraph {
+  if (cachedGraph) {
+    return cachedGraph;
+  }
+
+  const nodes = new Map<string, Station>();
+  for (const station of STATIONS) {
+    nodes.set(station.id, station);
+  }
+
+  const adjacency = new Map<string, RouteEdge[]>();
+  const pushEdge = (fromId: string, edge: RouteEdge): void => {
+    const list = adjacency.get(fromId);
+    if (list) {
+      list.push(edge);
+    } else {
+      adjacency.set(fromId, [edge]);
+    }
+  };
+
+  let lineEdgeCount = 0;
+  for (const [key, distanceMeters] of Object.entries(DISTANCES)) {
+    const [line, fromId, toId] = key.split('|') as [LineNumber, string, string];
+    // stationDistances의 모든 node id는 stations.json에 존재한다 (CI data validation).
+    const durationSeconds = computeDurationSeconds(distanceMeters, line);
+    pushEdge(fromId, {
+      kind: 'line',
+      toId,
+      line,
+      distanceMeters,
+      durationSeconds,
+    });
+    lineEdgeCount += 1;
+  }
+
+  // 같은 name 그룹별 호선 노드 매핑.
+  const nameGroups = new Map<string, Station[]>();
+  for (const station of STATIONS) {
+    const list = nameGroups.get(station.name);
+    if (list) {
+      list.push(station);
+    } else {
+      nameGroups.set(station.name, [station]);
+    }
+  }
+
+  let transferEdgeCount = 0;
+  for (const [name, group] of nameGroups) {
+    if (group.length < 2) {
+      continue;
+    }
+    for (const a of group) {
+      for (const b of group) {
+        if (a.line === b.line) {
+          continue;
+        }
+        const key = `${a.line}|${b.line}|${name}`;
+        const walkingSeconds = TRANSFERS[key];
+        if (walkingSeconds === undefined) {
+          continue;
+        }
+        pushEdge(a.id, {
+          kind: 'transfer',
+          toId: b.id,
+          walkingSeconds,
+          stationName: name,
+          fromLine: a.line,
+          toLine: b.line,
+        });
+        transferEdgeCount += 1;
+      }
+    }
+  }
+
+  cachedGraph = {
+    nodes,
+    adjacency,
+    stats: {
+      nodeCount: nodes.size,
+      lineEdgeCount,
+      transferEdgeCount,
+    },
+  };
+  return cachedGraph;
+}
+
+/** 테스트 전용 — 캐시 초기화. */
+export function __resetRouteGraphCache(): void {
+  cachedGraph = null;
+}

--- a/src/features/route/utils/dijkstraRoute.ts
+++ b/src/features/route/utils/dijkstraRoute.ts
@@ -1,0 +1,301 @@
+/**
+ * #1499 — 자체 Dijkstra 최단경로 알고리즘.
+ *
+ * 3종 type:
+ *   - `min-transfer`: 환승 횟수 최소화. line edge=1, transfer edge=1000.
+ *   - `min-distance`: 운행 거리(m) 최단. transfer edge는 거리 0으로 산정.
+ *   - `min-time`: 운행 + 환승 도보 시간(초) 합산 최단.
+ *
+ * 결과는 `Route` 객체로 leg + transfer 정보를 모두 포함, downstream
+ * stationRoute.ts / DebugModal에서 cross-check 가능하게 한다.
+ */
+import { buildRouteGraph, type RouteEdge } from './buildRouteGraph';
+import type { LineNumber } from '../../../shared/types/station';
+
+export type RouteOptimizationType = 'min-transfer' | 'min-distance' | 'min-time';
+
+export const ROUTE_OPTIMIZATION_TYPES: readonly RouteOptimizationType[] = [
+  'min-transfer',
+  'min-distance',
+  'min-time',
+];
+
+export interface RouteLeg {
+  /** 같은 호선에서 연속된 line edge의 시작 역 id. */
+  readonly fromId: string;
+  /** 같은 호선에서 마지막 역 id. */
+  readonly toId: string;
+  readonly line: LineNumber;
+  readonly distanceMeters: number;
+  readonly durationSeconds: number;
+  /** 본 leg가 지나는 모든 역 id(시작 포함, 끝 포함). */
+  readonly stationIds: readonly string[];
+}
+
+export interface RouteTransfer {
+  readonly stationName: string;
+  readonly fromLine: LineNumber;
+  readonly toLine: LineNumber;
+  readonly walkingSeconds: number;
+}
+
+export interface Route {
+  readonly fromId: string;
+  readonly toId: string;
+  readonly type: RouteOptimizationType;
+  readonly legs: readonly RouteLeg[];
+  readonly transfers: readonly RouteTransfer[];
+  readonly totalDistanceMeters: number;
+  readonly totalDurationSeconds: number;
+  readonly totalWalkingSeconds: number;
+  readonly transferCount: number;
+}
+
+/**
+ * Min-heap (binary) — node 수 500+ 규모에서 array shift O(n)보다 우수.
+ */
+class MinHeap<T> {
+  private readonly data: Array<{ key: number; value: T }> = [];
+
+  get size(): number {
+    return this.data.length;
+  }
+
+  push(key: number, value: T): void {
+    this.data.push({ key, value });
+    this.bubbleUp(this.data.length - 1);
+  }
+
+  /** 호출자는 항상 `size > 0` 확인 후 호출. */
+  pop(): { key: number; value: T } {
+    const top = this.data[0];
+    const last = this.data.pop() as { key: number; value: T };
+    if (this.data.length > 0) {
+      this.data[0] = last;
+      this.sinkDown(0);
+    }
+    return top;
+  }
+
+  private bubbleUp(index: number): void {
+    let i = index;
+    while (i > 0) {
+      const parent = Math.floor((i - 1) / 2);
+      if (this.data[parent].key <= this.data[i].key) {
+        break;
+      }
+      [this.data[parent], this.data[i]] = [this.data[i], this.data[parent]];
+      i = parent;
+    }
+  }
+
+  private sinkDown(index: number): void {
+    let i = index;
+    const n = this.data.length;
+    for (;;) {
+      const left = 2 * i + 1;
+      const right = 2 * i + 2;
+      let smallest = i;
+      if (left < n && this.data[left].key < this.data[smallest].key) {
+        smallest = left;
+      }
+      if (right < n && this.data[right].key < this.data[smallest].key) {
+        smallest = right;
+      }
+      if (smallest === i) {
+        break;
+      }
+      [this.data[i], this.data[smallest]] = [this.data[smallest], this.data[i]];
+      i = smallest;
+    }
+  }
+}
+
+function edgeWeight(edge: RouteEdge, type: RouteOptimizationType): number {
+  if (edge.kind === 'line') {
+    if (type === 'min-transfer') return 1;
+    if (type === 'min-distance') return edge.distanceMeters;
+    return edge.durationSeconds;
+  }
+  // transfer
+  if (type === 'min-transfer') return 1000;
+  if (type === 'min-distance') return 0;
+  return edge.walkingSeconds;
+}
+
+interface PrevPointer {
+  readonly nodeId: string;
+  readonly edge: RouteEdge;
+}
+
+/**
+ * Dijkstra: from→to 최단경로.
+ * 도달 불가 또는 from/to invalid 시 null.
+ */
+export function findRouteByType(
+  fromId: string,
+  toId: string,
+  type: RouteOptimizationType,
+): Route | null {
+  const graph = buildRouteGraph();
+  if (!graph.nodes.has(fromId) || !graph.nodes.has(toId)) {
+    return null;
+  }
+  if (fromId === toId) {
+    return {
+      fromId,
+      toId,
+      type,
+      legs: [],
+      transfers: [],
+      totalDistanceMeters: 0,
+      totalDurationSeconds: 0,
+      totalWalkingSeconds: 0,
+      transferCount: 0,
+    };
+  }
+
+  const dist = new Map<string, number>();
+  const prev = new Map<string, PrevPointer>();
+  const heap = new MinHeap<string>();
+  dist.set(fromId, 0);
+  heap.push(0, fromId);
+
+  while (heap.size > 0) {
+    const { key: d, value: u } = heap.pop();
+    if (u === toId) {
+      break;
+    }
+    const currentBest = dist.get(u);
+    if (currentBest !== undefined && d > currentBest) {
+      continue;
+    }
+    const neighbors = graph.adjacency.get(u) ?? [];
+    for (const edge of neighbors) {
+      const w = edgeWeight(edge, type);
+      const nd = d + w;
+      const prevBest = dist.get(edge.toId);
+      if (prevBest === undefined || nd < prevBest) {
+        dist.set(edge.toId, nd);
+        prev.set(edge.toId, { nodeId: u, edge });
+        heap.push(nd, edge.toId);
+      }
+    }
+  }
+
+  if (!prev.has(toId)) {
+    return null;
+  }
+  return reconstructRoute(fromId, toId, type, prev);
+}
+
+function reconstructRoute(
+  fromId: string,
+  toId: string,
+  type: RouteOptimizationType,
+  prev: Map<string, PrevPointer>,
+): Route {
+  // walk back collecting edges in reverse
+  const reversedEdges: RouteEdge[] = [];
+  const reversedFromNodes: string[] = [];
+  let cursor = toId;
+  while (cursor !== fromId) {
+    // Caller guarantees prev.has(toId) and Dijkstra invariant means every
+    // node on the back-path has a predecessor — non-null assertion is safe.
+    const p = prev.get(cursor) as PrevPointer;
+    reversedEdges.push(p.edge);
+    reversedFromNodes.push(p.nodeId);
+    cursor = p.nodeId;
+  }
+  reversedEdges.reverse();
+  reversedFromNodes.reverse();
+
+  const legs: RouteLeg[] = [];
+  const transfers: RouteTransfer[] = [];
+  let totalDistanceMeters = 0;
+  let totalDurationSeconds = 0;
+  let totalWalkingSeconds = 0;
+
+  let legStartId: string | null = null;
+  let legLine: LineNumber | null = null;
+  let legStations: string[] = [];
+  let legDistance = 0;
+  let legDuration = 0;
+
+  const flushLeg = (endId: string): void => {
+    /* istanbul ignore next — legStartId/legLine은 동시 set/unset (pair invariant). */
+    if (legLine === null || legStartId === null) {
+      return;
+    }
+    // 마지막 line edge의 toId가 항상 push되어 있으므로 endId와 일치.
+    legs.push({
+      fromId: legStartId,
+      toId: endId,
+      line: legLine,
+      distanceMeters: legDistance,
+      durationSeconds: legDuration,
+      stationIds: [...legStations],
+    });
+    legStartId = null;
+    legLine = null;
+    legStations = [];
+    legDistance = 0;
+    legDuration = 0;
+  };
+
+  for (let i = 0; i < reversedEdges.length; i += 1) {
+    const edge = reversedEdges[i];
+    const from = reversedFromNodes[i];
+    if (edge.kind === 'line') {
+      if (legStartId === null) {
+        legStartId = from;
+        legLine = edge.line;
+        legStations = [from];
+      }
+      legDistance += edge.distanceMeters;
+      legDuration += edge.durationSeconds;
+      totalDistanceMeters += edge.distanceMeters;
+      totalDurationSeconds += edge.durationSeconds;
+      legStations.push(edge.toId);
+    } else {
+      // transfer — close current leg
+      flushLeg(from);
+      transfers.push({
+        stationName: edge.stationName,
+        fromLine: edge.fromLine,
+        toLine: edge.toLine,
+        walkingSeconds: edge.walkingSeconds,
+      });
+      totalWalkingSeconds += edge.walkingSeconds;
+      totalDurationSeconds += edge.walkingSeconds;
+    }
+  }
+  // final flush — leg ends at toId
+  flushLeg(toId);
+
+  return {
+    fromId,
+    toId,
+    type,
+    legs,
+    transfers,
+    totalDistanceMeters,
+    totalDurationSeconds,
+    totalWalkingSeconds,
+    transferCount: transfers.length,
+  };
+}
+
+/**
+ * 3종 type 한 번에 산출. UI/DebugModal에서 비교 표시용.
+ */
+export function findRoutes(
+  fromId: string,
+  toId: string,
+): Record<RouteOptimizationType, Route | null> {
+  return {
+    'min-transfer': findRouteByType(fromId, toId, 'min-transfer'),
+    'min-distance': findRouteByType(fromId, toId, 'min-distance'),
+    'min-time': findRouteByType(fromId, toId, 'min-time'),
+  };
+}


### PR DESCRIPTION
Closes #1499
Epic: #1498

## 요약

외부 OpenAPI 의존 없이 우리 데이터(stations.json + stationDistances.json + transferTimes.json + lineSpeeds.ts)만으로 최단경로를 산출하는 자체 Dijkstra 엔진. Sub A(#1479) 진행 중 서울교통공사 OpenAPI endpoint가 종료된 것이 확인되어 데이터 SSOT 기반으로 전환.

## 구현

### `src/features/route/utils/buildRouteGraph.ts`
- nodes: stations.json 533역
- line edge: stationDistances entry → distance(m) + lineSpeed → durationSeconds
- transfer edge: 같은 name + 다른 line node 간 transferTimes walkingSeconds
- 정적 SSOT 1회 빌드 후 캐싱 (`__resetRouteGraphCache()` 테스트 노출)

### `src/features/route/utils/dijkstraRoute.ts`
- 자체 binary heap min-heap
- 3종 type:
  - `min-transfer`: line=1, transfer=1000 (환승 최소화)
  - `min-distance`: edge.distanceMeters, transfer=0 (거리 산정에서 환승 도보 제외)
  - `min-time`: edge.durationSeconds + transfer.walkingSeconds
- 결과: `Route { legs, transfers, totalDistance/Duration/Walking, transferCount }`
- API: `findRouteByType(from, to, type)` / `findRoutes(from, to)`

## 양방향 layer 추적

### Upstream
- `src/data/stations.json` (ADR-015 §6 SSOT)
- `src/data/stationDistances.json`
- `src/data/transferTimes.json`
- `src/shared/constants/lineSpeeds.ts`

### Downstream (후속 Sub-E에서 연결)
- `useRouteStore` 2종 routes 보존
- `stationRoute.ts` calculateStaticETA cross-check
- DebugModal Route 섹션
- Sub C(#1480) boardable ETA cascade 합산

## 데이터 의존 / fallback

- 1~8호선 + sinbundang + bundang + gyeongui: stationDistances + transferTimes 완전 커버
- 9호선 / airport: stationDistances 미보유 → 해당 호선 시작/도착 trip은 `null` 반환 (unreachable 명시)
  - 후속: 9호선 stationDistances 추가 작업 시 자동 적용

## 테스트 (100% coverage, 17 tests)

- buildRouteGraph: 노드 533 검증, line edge 거리/시간 정확성, 양방향, transfer edge, 캐싱
- dijkstraRoute: 동일역 empty route, 직통 same-line, 사용자 trip (성수 2-011 → 마장 5-032, min-transfer ≥1회 환승), min-transfer ≤ min-distance 환승수, 3종 type 모두 동작, min-time 도보 합산, 9-001→2-001 unreachable null
- 사용자 trip 검증 케이스 명시: 성수→마장 첫 leg 2호선, 마지막 leg 5호선

## CI

- type-check: pass
- 해당 모듈 coverage: 100% (statements/branches/funcs/lines)
- data validation: pass
- (워크트리 환경에서 widget/alarm 기존 테스트 무관 fail 관측 — origin/dev에서도 동일, 본 PR 변경과 무관)

## Out of scope

- Sub C boardable ETA cascade 합산 (Sub-E 후속)
- DebugModal UI 통합 (Sub-E 후속)
- 급행/완행 구분