### PR TITLE
chore(#1508): iOS Access WiFi Information entitlement 추가 — app.config.js

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -35,6 +35,10 @@ module.exports = {
       appleTeamId: '4755N5H4T4',
       entitlements: {
         'aps-environment': apsEnvironment,
+        // #1508 — Apple Developer Portal "Access WiFi Information" Capability 활성(2026-06-19) 후속.
+        // NEHotspotNetwork.fetchCurrent()가 SSID/BSSID를 노출하려면 본 entitlement 필요.
+        // B3-native(#1476) bridge가 이 값을 읽어 F2 SSID lookup(`lookupStationBySsid`)에 공급.
+        'com.apple.developer.networking.wifi-info': true,
       },
       infoPlist: {
         NSAppTransportSecurity: {


### PR DESCRIPTION
Closes #1508

## Summary

- `app.config.js` 의 `ios.entitlements` 에 `com.apple.developer.networking.wifi-info: true` 1줄 추가
- Apple Developer Portal 의 Capability 활성(사용자 2026-06-19 확인) 이후 client 측 entitlement plist 반영
- B3-native(#1476) `NEHotspotNetwork.fetchCurrent()` bridge 의 prereq

## 양방향 layer 추적

| Layer | 항목 | 상태 |
|---|---|---|
| upstream | Apple Developer Portal "Access WiFi Information" Capability | 완료 |
| **본 PR** | `app.config.js` entitlements key 추가 | 머지 대기 |
| downstream | EAS Build / `expo prebuild` → `ios/<App>.entitlements` 자동 반영 | 다음 빌드 |
| downstream | Provisioning Profile 재생성 | 사용자 액션 |
| downstream | B3-native bridge (#1476) — native module 신규 | 별도 PR |
| consumer | F2 SSID lookup (`lookupStationBySsid`) → 지하 100% 역 확정 | 기존 (#913) |

## 변경 내용

`app.config.js` `ios.entitlements`:
```js
entitlements: {
  'aps-environment': apsEnvironment,
  // #1508 — Apple Developer Portal "Access WiFi Information" Capability 활성(2026-06-19) 후속.
  'com.apple.developer.networking.wifi-info': true,
},
```

## CI

- `npm run type-check` 통과 (로컬)
- unit/coverage는 변경 영향 없음 (config-only)
- ios/ 폴더 직접 수정 없음 — prebuild 시 자동 동기화

## 본 PR 머지 후 사용자 액션

```bash
# 1) Provisioning Profile 재생성 (Capability 추가 후 필요)
eas credentials

# 2) 개발 빌드로 entitlement 반영 검증
eas build --profile development --platform ios --device
# 또는 로컬:
npm run ios

# 3) device에서 NEHotspotNetwork.fetchCurrent() 호출 시 SSID/BSSID 노출 확인
#    (B3-native #1476 머지 후 측정 가능)
```

## 검증 절차 (옵션)

머지 전 미리 plist 반영 확인:
```bash
npx expo prebuild --clean
grep -A1 wifi-info ios/subwaynow.entitlements
```

## 후속

- 본 PR 머지 → B3-native #1476 (NEHotspotNetwork bridge) 작업 시작
- 참고: B4 #1452, Epic #1432