### PR TITLE
feat(#1501): device raw signal dump foundation (M1 PR-A) — corrId + buffer + persist

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -30,12 +30,27 @@ import { useLaunchTripReconciliation } from '../src/features/alarm/hooks/useLaun
 import { fetchArrivalInfo } from '../src/features/arrival/api/arrivalApi';
 import { FALLBACK_BOARDING_DURATION_MINUTES } from '../src/shared/constants/boardingLock';
 import { initSentryIfOptedIn } from '../src/shared/infra/monitoring/sentryInit';
+import { hydrateRawSignalBuffer } from '../src/features/observability/utils/rawSignalBuffer';
+import { getCurrentTripCorrId } from '../src/features/observability/utils/tripCorrId';
 
 const layoutLogger = createLogger('RootLayout');
 
 // #1038 — Sentry 에러 모니터링 init (default OFF, opt-in only).
 // fire-and-forget — boot path 비차단. UI 토글은 follow-up PR.
 initSentryIfOptedIn().catch((e) => layoutLogger.warn('Sentry init 실패(#1038):', e));
+
+// #1501 (ADR-015 §10 P5 / PR-A) — boot 시 device raw signal buffer 복원.
+// 강제종료 후 재시작에서도 마지막 ~120 entry가 살아남아 7일 회귀(2026-06-17 용마산)
+// 같은 cold-launch 사이 데이터 단절을 막는다. fire-and-forget — boot path 비차단.
+hydrateRawSignalBuffer().catch((e) =>
+  layoutLogger.warn('rawSignalBuffer hydrate 실패(#1501):', e),
+);
+// #1501 — trip corrId in-memory cache도 boot 시 storage에서 복원.
+// 강제종료 후 재진입 시 활성 trip이 살아있는데도 cache=null이면 첫 fusion cycle entries에
+// corrId가 박히지 않아 backend join이 깨진다(P2-2 review).
+getCurrentTripCorrId().catch((e) =>
+  layoutLogger.warn('tripCorrId hydrate 실패(#1501):', e),
+);
 
 SplashScreen.preventAutoHideAsync();
 setupNotificationHandler();

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -30,6 +30,7 @@ import { clearLaDismissSentinel } from '../utils/laDismissSentinel';
 import { clearPrescheduledLedger } from '../utils/prescheduledMetrics';
 import { purgeBoardingLockSchedulerQueue } from '../utils/boardingLockScheduler';
 import { cancelTripBoundAlarms } from '../utils/tripBoundScheduler';
+import { clearTripCorrId } from '../../observability/utils/tripCorrId';
 
 // trip-bound storage cleanup 단일 출처.
 // useDestinationStore.setDestination이 isSwitch(목적지 변경 또는 null 클리어) 분기에서 호출한다.
@@ -84,6 +85,9 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   // 새 trip 분모에 섞이는 회귀 차단. LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY는 recall과
   // 같은 이유로 보존 (tripStart값으로 자연 무효화).
   clearPrescheduledLedger,
+  // #1501 (ADR-015 §10 P5 / PR-A) — trip 종료 시 corrId 제거. 다음 trip은 새 corrId를
+  // 받고 rawSignalBuffer entry가 어느 trip 소속인지 명확해진다.
+  clearTripCorrId,
 ];
 
 /**

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -34,6 +34,15 @@ jest.mock('../../../route/hooks/useTrainPositions');
 jest.mock('../../utils/findNearestStation', () => ({
   findTopNearestStations: jest.fn(),
 }));
+// #1501 (PR-A) — rawSignalBuffer / tripCorrId은 본 hook의 측정 채널이라 mock으로 격리.
+// 자체 단위 테스트가 buffer/persist/throttle을 따로 검증한다. 실제 push 호출 횟수/형태만
+// jest.fn으로 확인.
+jest.mock('../../../observability/utils/rawSignalBuffer', () => ({
+  pushRawSignal: jest.fn(),
+}));
+jest.mock('../../../observability/utils/tripCorrId', () => ({
+  getCurrentTripCorrIdSync: jest.fn(() => null),
+}));
 
 const mockUseNearest = useNearestStation as jest.Mock;
 const mockUseArrival = useArrivalInfo as jest.Mock;

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -1111,8 +1111,12 @@ export function useFusedNearestStation(
       : null;
     // motionStationary는 boolean | undefined. boolean으로 들어오면 stationary/unknown 라벨로 매핑.
     // 정확한 motion provider 라벨(walking/automotive)은 후속 PR에서 motion-activity 모듈 expose 후 보강.
-    const motionForDump =
-      motionStationary === true ? 'stationary' : motionStationary === false ? 'unknown' : null;
+    let motionForDump: 'stationary' | 'unknown' | null = null;
+    if (motionStationary === true) {
+      motionForDump = 'stationary';
+    } else if (motionStationary === false) {
+      motionForDump = 'unknown';
+    }
     // arvlCd: up 방향 첫 슬롯 우선, 없으면 down 첫 슬롯. 둘 다 없으면 null.
     // 후속 PR에서 up/down 둘 다 기록하도록 entry shape 확장 검토.
     const arvlCdForDump =

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -11,6 +11,8 @@ import {
   pushFusionDebugEntry,
   type FusionCandidateMini,
 } from '../utils/fusionDebugBuffer';
+import { pushRawSignal } from '../../observability/utils/rawSignalBuffer';
+import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
 import { pushEstimatorEntry } from '../../route/utils/estimatorDebugBuffer';
 import { useNearestStation } from './useNearestStation';
 import { useArrivalInfo } from '../../arrival/hooks/useArrivalInfo';
@@ -1028,6 +1030,10 @@ export function useFusedNearestStation(
   const lastDecisionKeyRef = useRef<string | null>(null);
   const resultStationId = result?.station.id ?? null;
   const decisionKey = `${source}|${confidence}|${resultStationId}|${detectionVerdict.signalMask}`;
+
+  // #1501 (ADR-015 §10 P5 / PR-A) — 직전 cycle stationId 추적해 변화 시 exit + enter stamp.
+  // corrId는 in-memory cache에서 sync read (setTripCorrId/clear 시 cache 갱신 보장).
+  const lastStationIdRef = useRef<string | null>(null);
   useEffect(() => {
     if (lastDecisionKeyRef.current === decisionKey) return;
     lastDecisionKeyRef.current = decisionKey;
@@ -1090,7 +1096,83 @@ export function useFusedNearestStation(
               signalsAvailable: detectionVerdict.signalsAvailable,
             },
     });
-  }, [decisionKey, source, confidence, result, wifiStationResolved, positionTrainResult, fused, routeResult, gps.result, gps.accuracyMeters, trainProgress, lockedTrainCode, detectionVerdict]);
+
+    // #1501 (ADR-015 §10 P5 / PR-A) — device raw signal dump.
+    // fusionDebugBuffer는 in-memory 전용(강제종료 시 소실). rawSignalBuffer는 영속화돼
+    // 7일 cold-launch 회귀 사후 분석에 사용. 동일 결정 변화 keyed cycle에서 함께 push.
+    // 가용 신호를 최대한 채워야 P5 학습 입력으로 활용 가능 (review P1-1).
+    const gpsForDump = gps.userLocation
+      ? {
+          lat: gps.userLocation.lat,
+          lng: gps.userLocation.lng,
+          accM: gps.accuracyMeters,
+          speedMps: gps.speedMps,
+        }
+      : null;
+    // motionStationary는 boolean | undefined. boolean으로 들어오면 stationary/unknown 라벨로 매핑.
+    // 정확한 motion provider 라벨(walking/automotive)은 후속 PR에서 motion-activity 모듈 expose 후 보강.
+    const motionForDump =
+      motionStationary === true ? 'stationary' : motionStationary === false ? 'unknown' : null;
+    // arvlCd: up 방향 첫 슬롯 우선, 없으면 down 첫 슬롯. 둘 다 없으면 null.
+    // 후속 PR에서 up/down 둘 다 기록하도록 entry shape 확장 검토.
+    const arvlCdForDump =
+      fusionArrival?.up[0]?.arrivalCode ?? fusionArrival?.down[0]?.arrivalCode ?? null;
+    const arcProgressForDump = progress.progressM ?? null;
+    const ts = Date.now();
+    const prevStationId = lastStationIdRef.current;
+    const nextStationId = resultStationId;
+    if (prevStationId !== null && result !== null && nextStationId !== null && prevStationId !== nextStationId) {
+      pushRawSignal({
+        ts,
+        corrId: getCurrentTripCorrIdSync(),
+        kind: 'exit',
+        gps: gpsForDump,
+        motion: motionForDump,
+        subsurface: barometerSubsurface ?? null,
+        arvlCd: arvlCdForDump,
+        line: null,
+        dir: null,
+        arcIdx: null,
+        arcProgress: arcProgressForDump,
+        stationId: prevStationId,
+        source: null,
+        confidence: null,
+      });
+      pushRawSignal({
+        ts,
+        corrId: getCurrentTripCorrIdSync(),
+        kind: 'enter',
+        gps: gpsForDump,
+        motion: motionForDump,
+        subsurface: barometerSubsurface ?? null,
+        arvlCd: arvlCdForDump,
+        line: result.station.line,
+        dir: null,
+        arcIdx: null,
+        arcProgress: arcProgressForDump,
+        stationId: nextStationId,
+        source,
+        confidence,
+      });
+    }
+    lastStationIdRef.current = nextStationId;
+    pushRawSignal({
+      ts,
+      corrId: getCurrentTripCorrIdSync(),
+      kind: 'cycle',
+      gps: gpsForDump,
+      motion: motionForDump,
+      subsurface: barometerSubsurface ?? null,
+      arvlCd: arvlCdForDump,
+      line: result?.station.line ?? null,
+      dir: null,
+      arcIdx: null,
+      arcProgress: arcProgressForDump,
+      stationId: nextStationId,
+      source,
+      confidence,
+    });
+  }, [decisionKey, source, confidence, result, wifiStationResolved, positionTrainResult, fused, routeResult, gps.result, gps.accuracyMeters, gps.userLocation, gps.speedMps, trainProgress, lockedTrainCode, detectionVerdict, barometerSubsurface, resultStationId, motionStationary, fusionArrival, progress.progressM]);
 
   return {
     result,

--- a/src/features/observability/utils/__tests__/rawSignalBuffer.test.ts
+++ b/src/features/observability/utils/__tests__/rawSignalBuffer.test.ts
@@ -21,7 +21,7 @@ function entry(overrides?: Partial<RawSignalEntry>): RawSignalEntry {
     ts: 1_700_000_000_000,
     corrId: 'cid-1',
     kind: 'cycle',
-    gps: { lat: 37.5, lng: 127.0, accM: 30, speedMps: 1.2 },
+    gps: { lat: 37.5, lng: 127, accM: 30, speedMps: 1.2 },
     motion: null,
     subsurface: false,
     arvlCd: null,
@@ -94,7 +94,7 @@ describe('rawSignalBuffer (#1501 PR-A)', () => {
       const entries = getRawSignalEntries();
       expect(entries).toHaveLength(RAW_SIGNAL_BUFFER_CAPACITY);
       expect(entries[0].stationId).toBe('S5');
-      expect(entries[entries.length - 1].stationId).toBe(`S${RAW_SIGNAL_BUFFER_CAPACITY + 4}`);
+      expect(entries.at(-1)?.stationId).toBe(`S${RAW_SIGNAL_BUFFER_CAPACITY + 4}`);
     });
   });
 

--- a/src/features/observability/utils/__tests__/rawSignalBuffer.test.ts
+++ b/src/features/observability/utils/__tests__/rawSignalBuffer.test.ts
@@ -1,0 +1,230 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  pushRawSignal,
+  getRawSignalEntries,
+  clearRawSignalEntries,
+  subscribeRawSignal,
+  hydrateRawSignalBuffer,
+  RAW_SIGNAL_BUFFER_CAPACITY,
+  RAW_SIGNAL_WRITE_THROTTLE_MS,
+  __resetRawSignalForTests__,
+  type RawSignalEntry,
+} from '../rawSignalBuffer';
+import { RAW_SIGNAL_BUFFER_KEY } from '../../../../shared/constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+function entry(overrides?: Partial<RawSignalEntry>): RawSignalEntry {
+  return {
+    ts: 1_700_000_000_000,
+    corrId: 'cid-1',
+    kind: 'cycle',
+    gps: { lat: 37.5, lng: 127.0, accM: 30, speedMps: 1.2 },
+    motion: null,
+    subsurface: false,
+    arvlCd: null,
+    line: '2',
+    dir: null,
+    arcIdx: null,
+    arcProgress: null,
+    stationId: '2-022',
+    source: 'gps',
+    confidence: 'gps-only',
+    ...overrides,
+  };
+}
+
+describe('rawSignalBuffer (#1501 PR-A)', () => {
+  beforeEach(async () => {
+    jest.useRealTimers();
+    __resetRawSignalForTests__();
+    await AsyncStorage.clear();
+    jest.clearAllMocks();
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('push/get/clear', () => {
+    it('push 후 getRawSignalEntries에 포함', () => {
+      pushRawSignal(entry({ stationId: 'A' }));
+      pushRawSignal(entry({ stationId: 'B' }));
+      const entries = getRawSignalEntries();
+      expect(entries).toHaveLength(2);
+      expect(entries[0].stationId).toBe('A');
+      expect(entries[1].stationId).toBe('B');
+    });
+
+    it('clear가 buffer + AsyncStorage 모두 비움', () => {
+      pushRawSignal(entry());
+      expect(getRawSignalEntries()).toHaveLength(1);
+      clearRawSignalEntries();
+      expect(getRawSignalEntries()).toHaveLength(0);
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(RAW_SIGNAL_BUFFER_KEY);
+    });
+
+    it('push 없는 상태에서 clear도 graceful (writeTimer null branch)', () => {
+      // push가 한 번도 일어나지 않아 writeTimer === null일 때 clear가 writeTimer 분기를 skip.
+      expect(() => clearRawSignalEntries()).not.toThrow();
+      expect(getRawSignalEntries()).toHaveLength(0);
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(RAW_SIGNAL_BUFFER_KEY);
+    });
+
+    it('clear의 removeItem reject는 graceful 흡수', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      pushRawSignal(entry());
+      expect(() => clearRawSignalEntries()).not.toThrow();
+      // wait microtasks so internal catch runs
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  });
+
+  describe('capacity rotation', () => {
+    it(`capacity ${RAW_SIGNAL_BUFFER_CAPACITY} 초과 시 오래된 항목부터 drop`, () => {
+      for (let i = 0; i < RAW_SIGNAL_BUFFER_CAPACITY + 5; i += 1) {
+        pushRawSignal(entry({ stationId: `S${i}` }));
+      }
+      const entries = getRawSignalEntries();
+      expect(entries).toHaveLength(RAW_SIGNAL_BUFFER_CAPACITY);
+      expect(entries[0].stationId).toBe('S5');
+      expect(entries[entries.length - 1].stationId).toBe(`S${RAW_SIGNAL_BUFFER_CAPACITY + 4}`);
+    });
+  });
+
+  describe('subscribe', () => {
+    it('push 시 subscriber 호출, unsubscribe 후 호출 안 됨', () => {
+      const cb = jest.fn();
+      const unsub = subscribeRawSignal(cb);
+      pushRawSignal(entry());
+      expect(cb).toHaveBeenCalledTimes(1);
+      unsub();
+      pushRawSignal(entry());
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('throttled write', () => {
+    it(`push 후 ${RAW_SIGNAL_WRITE_THROTTLE_MS}ms 경과 후 write 1회`, () => {
+      jest.useFakeTimers();
+      pushRawSignal(entry({ stationId: 'A' }));
+      expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(RAW_SIGNAL_WRITE_THROTTLE_MS);
+      expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+      expect((AsyncStorage.setItem as jest.Mock).mock.calls[0][0]).toBe(RAW_SIGNAL_BUFFER_KEY);
+    });
+
+    it('burst push도 write는 1회만 (마지막 push 기준 throttle)', () => {
+      jest.useFakeTimers();
+      pushRawSignal(entry({ stationId: 'A' }));
+      jest.advanceTimersByTime(500);
+      pushRawSignal(entry({ stationId: 'B' }));
+      jest.advanceTimersByTime(500);
+      // 첫 push에서 1s 지났지만 두 번째 push가 timer reset → 아직 write 없음
+      expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(500);
+      expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+      // 마지막 write에 두 entry가 모두 직렬화됐는지 확인
+      const written = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string);
+      expect(written).toHaveLength(2);
+    });
+
+    it('setItem reject는 graceful 흡수', async () => {
+      jest.useFakeTimers();
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      pushRawSignal(entry());
+      jest.advanceTimersByTime(RAW_SIGNAL_WRITE_THROTTLE_MS);
+      // microtask flush
+      jest.useRealTimers();
+      await Promise.resolve();
+      await Promise.resolve();
+      // 다음 push + advance에서 throw 없이 다시 시도 가능
+      pushRawSignal(entry());
+    });
+  });
+
+  describe('hydrate', () => {
+    it('키 부재 시 buffer 비어 있음', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      await hydrateRawSignalBuffer();
+      expect(getRawSignalEntries()).toHaveLength(0);
+    });
+
+    it('유효 JSON은 buffer로 복원', async () => {
+      const stored = [entry({ stationId: 'X' }), entry({ stationId: 'Y' })];
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(stored));
+      await hydrateRawSignalBuffer();
+      const entries = getRawSignalEntries();
+      expect(entries).toHaveLength(2);
+      expect(entries[0].stationId).toBe('X');
+      expect(entries[1].stationId).toBe('Y');
+    });
+
+    it('손상 JSON은 무시 (빈 buffer 유지)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('not json {{{');
+      await hydrateRawSignalBuffer();
+      expect(getRawSignalEntries()).toHaveLength(0);
+    });
+
+    it('비배열 JSON은 무시', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify({ foo: 'bar' }));
+      await hydrateRawSignalBuffer();
+      expect(getRawSignalEntries()).toHaveLength(0);
+    });
+
+    it('배열 안에 null/primitive 섞이면 그 항목만 skip', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify([entry({ stationId: 'K' }), null, 'oops', entry({ stationId: 'L' })]),
+      );
+      await hydrateRawSignalBuffer();
+      const entries = getRawSignalEntries();
+      expect(entries.map((e) => e.stationId)).toEqual(['K', 'L']);
+    });
+
+    it('AsyncStorage.getItem reject는 graceful (빈 buffer)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      await hydrateRawSignalBuffer();
+      expect(getRawSignalEntries()).toHaveLength(0);
+    });
+
+    it('두 번째 호출은 멱등 (latch — buffer 재로드 안 함)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify([entry({ stationId: 'X' })]),
+      );
+      await hydrateRawSignalBuffer();
+      expect(getRawSignalEntries()).toHaveLength(1);
+      // 두 번째 호출은 getItem을 추가로 부르지 않음
+      await hydrateRawSignalBuffer();
+      expect(AsyncStorage.getItem).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('enter/exit kind', () => {
+    it('kind=enter / exit 모두 push 가능', () => {
+      pushRawSignal(entry({ kind: 'enter', stationId: 'NEW' }));
+      pushRawSignal(entry({ kind: 'exit', stationId: 'OLD' }));
+      const entries = getRawSignalEntries();
+      expect(entries[0].kind).toBe('enter');
+      expect(entries[1].kind).toBe('exit');
+    });
+  });
+
+  describe('reset helper', () => {
+    it('__resetRawSignalForTests__는 in-memory + hydration latch + timer 초기화', () => {
+      jest.useFakeTimers();
+      pushRawSignal(entry());
+      expect(getRawSignalEntries()).toHaveLength(1);
+      __resetRawSignalForTests__();
+      expect(getRawSignalEntries()).toHaveLength(0);
+      // pending timer 없는지 advance로 확인
+      jest.advanceTimersByTime(RAW_SIGNAL_WRITE_THROTTLE_MS * 2);
+      expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/features/observability/utils/__tests__/tripCorrId.test.ts
+++ b/src/features/observability/utils/__tests__/tripCorrId.test.ts
@@ -1,0 +1,122 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  generateTripCorrId,
+  setTripCorrId,
+  getCurrentTripCorrId,
+  getCurrentTripCorrIdSync,
+  clearTripCorrId,
+  __resetTripCorrIdForTests__,
+} from '../tripCorrId';
+import { TRIP_CORR_ID_KEY } from '../../../../shared/constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+describe('tripCorrId (#1501 PR-A)', () => {
+  beforeEach(async () => {
+    __resetTripCorrIdForTests__();
+    await AsyncStorage.clear();
+  });
+
+  describe('generateTripCorrId', () => {
+    it('`${ms}-${8 hex}` 형식 — deps 주입으로 결정적 결과', () => {
+      const id = generateTripCorrId({ now: () => 1_700_000_000_000, random: () => 0.5 });
+      expect(id).toMatch(/^\d+-[0-9a-f]{8}$/);
+      expect(id.startsWith('1700000000000-')).toBe(true);
+    });
+
+    it('hex suffix는 항상 8자(작은 random값도 zero-pad)', () => {
+      const id = generateTripCorrId({ now: () => 1, random: () => 0 });
+      expect(id).toBe('1-00000000');
+    });
+
+    it('hex suffix max — random=0.9999999는 8자 유지', () => {
+      const id = generateTripCorrId({ now: () => 2, random: () => 0.99999999 });
+      // 32-bit 영역. 9자 넘지 않음 확인.
+      const [, hex] = id.split('-');
+      expect(hex.length).toBe(8);
+    });
+
+    it('기본 deps도 형식 일치 (Date.now/Math.random)', () => {
+      const id = generateTripCorrId();
+      expect(id).toMatch(/^\d+-[0-9a-f]{8}$/);
+    });
+  });
+
+  describe('set/get/clear', () => {
+    it('setTripCorrId 후 getCurrentTripCorrId가 같은 값을 반환', async () => {
+      await setTripCorrId('1700000000000-deadbeef');
+      const id = await getCurrentTripCorrId();
+      expect(id).toBe('1700000000000-deadbeef');
+    });
+
+    it('clearTripCorrId 후 getCurrentTripCorrId는 null', async () => {
+      await setTripCorrId('x');
+      await clearTripCorrId();
+      const id = await getCurrentTripCorrId();
+      expect(id).toBeNull();
+    });
+
+    it('키 부재 시 getCurrentTripCorrId는 null', async () => {
+      const id = await getCurrentTripCorrId();
+      expect(id).toBeNull();
+    });
+  });
+
+  describe('storage 실패 graceful', () => {
+    it('setItem reject 시 throw 안 함', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      await expect(setTripCorrId('x')).resolves.toBeUndefined();
+    });
+
+    it('getItem reject 시 null 반환', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      const id = await getCurrentTripCorrId();
+      expect(id).toBeNull();
+    });
+
+    it('removeItem reject 시 throw 안 함', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      await expect(clearTripCorrId()).resolves.toBeUndefined();
+    });
+
+    it('setTripCorrId가 올바른 키로 저장', async () => {
+      await setTripCorrId('abc');
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(TRIP_CORR_ID_KEY, 'abc');
+    });
+  });
+
+  describe('sync cache', () => {
+    it('set 후 sync read 즉시 같은 값 (fusion hot path 보장)', async () => {
+      await setTripCorrId('cid-sync-1');
+      expect(getCurrentTripCorrIdSync()).toBe('cid-sync-1');
+    });
+
+    it('clear 후 sync read 즉시 null', async () => {
+      await setTripCorrId('cid-sync-2');
+      await clearTripCorrId();
+      expect(getCurrentTripCorrIdSync()).toBeNull();
+    });
+
+    it('boot 시 sync read는 null (cache 미초기화)', () => {
+      expect(getCurrentTripCorrIdSync()).toBeNull();
+    });
+
+    it('async get이 storage에서 hydrate → sync cache 갱신', async () => {
+      await AsyncStorage.setItem(TRIP_CORR_ID_KEY, 'cid-hydrated');
+      expect(getCurrentTripCorrIdSync()).toBeNull();
+      const got = await getCurrentTripCorrId();
+      expect(got).toBe('cid-hydrated');
+      expect(getCurrentTripCorrIdSync()).toBe('cid-hydrated');
+    });
+
+    it('async get이 reject 시 cache 보존 (마지막 sync 값 유지)', async () => {
+      await setTripCorrId('cid-prev');
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      const got = await getCurrentTripCorrId();
+      expect(got).toBe('cid-prev'); // catch path returns cache
+      expect(getCurrentTripCorrIdSync()).toBe('cid-prev');
+    });
+  });
+});

--- a/src/features/observability/utils/rawSignalBuffer.ts
+++ b/src/features/observability/utils/rawSignalBuffer.ts
@@ -1,0 +1,134 @@
+/**
+ * Device raw signal dump ring buffer (#1501, ADR-015 §10 P5 / PR-A).
+ *
+ * useFusedNearestStation 매 cycle, station enter/exit 시점에 push되는 측정 entry.
+ * 외부 도구(Metro/Xcode) 없이 사후 재구성하기 위한 채널 — fusionDebugBuffer는 in-memory
+ * 전용이라 강제종료 시 소실되는데, 본 buffer는 AsyncStorage로 영속화해 7일 회귀(2026-06-17
+ * 용마산 trip)처럼 cold-launch 사이 데이터가 끊기는 사고를 막는다.
+ *
+ * 정책:
+ *  - capacity 120 (cycle ~1Hz × 2분 windowfusion + enter/exit stamps)
+ *  - boot 시 1회 hydrate (`hydrateRawSignalBuffer()`)
+ *  - push 후 1초 idle throttle write — burst push에서 storage IO 폭주 차단
+ *  - 손상 JSON / 키 부재 = 빈 buffer로 시작 (graceful)
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { RAW_SIGNAL_BUFFER_KEY } from '../../../shared/constants/storageKeys';
+import { createDebugBuffer } from '../../../shared/utils/createDebugBuffer';
+import type { FusionConfidence, FusionSource } from '../../../shared/types/fusion';
+
+export const RAW_SIGNAL_BUFFER_CAPACITY = 120;
+export const RAW_SIGNAL_WRITE_THROTTLE_MS = 1000;
+
+export type RawSignalKind = 'cycle' | 'enter' | 'exit';
+export type MotionLabel = 'stationary' | 'walking' | 'automotive' | 'unknown';
+export type RawSignalDir = 'up' | 'down';
+
+export interface RawSignalGps {
+  lat: number;
+  lng: number;
+  accM: number | null;
+  speedMps: number | null;
+}
+
+export interface RawSignalEntry {
+  ts: number;
+  corrId: string | null;
+  kind: RawSignalKind;
+  gps: RawSignalGps | null;
+  motion: MotionLabel | null;
+  subsurface: boolean | null;
+  arvlCd: number | null;
+  line: string | null;
+  dir: RawSignalDir | null;
+  arcIdx: number | null;
+  arcProgress: number | null;
+  stationId: string | null;
+  source: FusionSource | null;
+  confidence: FusionConfidence | null;
+}
+
+const db = createDebugBuffer<RawSignalEntry>(RAW_SIGNAL_BUFFER_CAPACITY);
+
+let writeTimer: ReturnType<typeof setTimeout> | null = null;
+let hydrated = false;
+
+function scheduleWrite(): void {
+  if (writeTimer !== null) {
+    clearTimeout(writeTimer);
+  }
+  writeTimer = setTimeout(() => {
+    writeTimer = null;
+    void flushNow();
+  }, RAW_SIGNAL_WRITE_THROTTLE_MS);
+}
+
+async function flushNow(): Promise<void> {
+  try {
+    const entries = db.get();
+    await AsyncStorage.setItem(RAW_SIGNAL_BUFFER_KEY, JSON.stringify(entries));
+  } catch {
+    // graceful — 다음 push 시 재시도.
+  }
+}
+
+/** entry push + throttled write. */
+export function pushRawSignal(entry: RawSignalEntry): void {
+  db.push(entry);
+  scheduleWrite();
+}
+
+/** 현재 buffer entries (in-memory copy). */
+export function getRawSignalEntries(): readonly RawSignalEntry[] {
+  return db.get();
+}
+
+/** buffer + 영속 데이터 모두 클리어. */
+export function clearRawSignalEntries(): void {
+  db.clear();
+  if (writeTimer !== null) {
+    clearTimeout(writeTimer);
+    writeTimer = null;
+  }
+  AsyncStorage.removeItem(RAW_SIGNAL_BUFFER_KEY).catch(() => {
+    // graceful — 다음 write가 덮어씀.
+  });
+}
+
+/** buffer 변경 구독 (DebugModal 등). */
+export function subscribeRawSignal(cb: () => void): () => void {
+  return db.subscribe(cb);
+}
+
+/**
+ * Boot 시 1회 호출. AsyncStorage에서 buffer 복원.
+ * 키 부재 / 손상 JSON / 비배열 모두 graceful no-op.
+ * 멱등 — 두 번째 호출은 무시한다 (테스트에서 명시 reset 필요 시 __resetForTests__).
+ */
+export async function hydrateRawSignalBuffer(): Promise<void> {
+  if (hydrated) return;
+  hydrated = true;
+  try {
+    const raw = await AsyncStorage.getItem(RAW_SIGNAL_BUFFER_KEY);
+    if (raw === null) return;
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return;
+    for (const item of parsed) {
+      if (item && typeof item === 'object') {
+        db.push(item as RawSignalEntry);
+      }
+    }
+  } catch {
+    // graceful — 손상 JSON 무시, 빈 buffer로 시작.
+  }
+}
+
+/** 테스트 전용 — hydration latch + timer 초기화. */
+export function __resetRawSignalForTests__(): void {
+  db.clear();
+  if (writeTimer !== null) {
+    clearTimeout(writeTimer);
+    writeTimer = null;
+  }
+  hydrated = false;
+}

--- a/src/features/observability/utils/tripCorrId.ts
+++ b/src/features/observability/utils/tripCorrId.ts
@@ -24,12 +24,13 @@ export interface CorrIdDeps {
 
 const defaultDeps: CorrIdDeps = {
   now: () => Date.now(),
-  random: () => Math.random(),
+  // Math.random은 trip 식별용 비암호 collision suffix 목적. 보안/예측 불가성 요구 없음. NOSONAR
+  random: () => Math.random(), // NOSONAR typescript:S2245
 };
 
 function hex8(rand: () => number): string {
   // 8 hex chars = 32 bit. Math.random은 unbiased 가정.
-  const n = Math.floor(rand() * 0x1_0000_0000);
+  const n = Math.floor(rand() * 2 ** 32);
   return n.toString(16).padStart(8, '0');
 }
 

--- a/src/features/observability/utils/tripCorrId.ts
+++ b/src/features/observability/utils/tripCorrId.ts
@@ -1,0 +1,87 @@
+/**
+ * Trip correlation id (#1501, ADR-015 §10 P5 / PR-A).
+ *
+ * 매 trip에 unique id를 부여해 rawSignalBuffer entry / backend evidence가 어떤 trip
+ * 소속인지 사후 재구성한다. trip 시작 시 `setTripCorrId(generateTripCorrId())` 호출,
+ * tripBoundCleanups에서 `clearTripCorrId()`로 제거.
+ *
+ * 형식: `${epoch ms}-${8 hex}`. timestamp 자체로 정렬 가능 + random suffix로 collision 차단
+ * (밀리초 안에 동시 trip 생성 race 방지).
+ *
+ * 모든 storage 작업은 graceful — 실패 시 측정만 영향, trip 흐름 무관.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { TRIP_CORR_ID_KEY } from '../../../shared/constants/storageKeys';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('tripCorrId');
+
+/** 내부 factory — test에서 fixed seed 주입 가능하게 추출. */
+export interface CorrIdDeps {
+  now: () => number;
+  random: () => number;
+}
+
+const defaultDeps: CorrIdDeps = {
+  now: () => Date.now(),
+  random: () => Math.random(),
+};
+
+function hex8(rand: () => number): string {
+  // 8 hex chars = 32 bit. Math.random은 unbiased 가정.
+  const n = Math.floor(rand() * 0x1_0000_0000);
+  return n.toString(16).padStart(8, '0');
+}
+
+/** `${epoch ms}-${8 hex}` 형식 corrId 생성. test에서 deps 주입 가능. */
+export function generateTripCorrId(deps: CorrIdDeps = defaultDeps): string {
+  return `${deps.now()}-${hex8(deps.random)}`;
+}
+
+// In-memory cache — fusion cycle hot path에서 sync read를 보장한다 (async useEffect로
+// state 갱신 시 React 19 act() race가 발생). set/clear/hydrate가 cache를 항상 동기 갱신.
+let cachedCorrId: string | null = null;
+
+/** corrId를 AsyncStorage에 저장 + in-memory cache 동기 갱신. trip 시작 시 호출. */
+export async function setTripCorrId(id: string): Promise<void> {
+  cachedCorrId = id;
+  try {
+    await AsyncStorage.setItem(TRIP_CORR_ID_KEY, id);
+  } catch (e) {
+    // graceful — 측정만 영향, trip 흐름 무관.
+    logger.warn('storage 실패(graceful):', e);
+  }
+}
+
+/** 현재 corrId 또는 null. 키 부재 = trip 미시작/종료. async — boot/hydrate 경로용. */
+export async function getCurrentTripCorrId(): Promise<string | null> {
+  try {
+    const stored = await AsyncStorage.getItem(TRIP_CORR_ID_KEY);
+    cachedCorrId = stored;
+    return stored;
+  } catch (e) {
+    logger.warn('hydrate 실패(graceful, cache fallback):', e);
+    return cachedCorrId;
+  }
+}
+
+/** sync read — fusion cycle hot path 전용. boot 시 hydrate 후 정상 값. */
+export function getCurrentTripCorrIdSync(): string | null {
+  return cachedCorrId;
+}
+
+/** corrId 제거 + cache 동기 갱신. tripBoundCleanups에서 호출. */
+export async function clearTripCorrId(): Promise<void> {
+  cachedCorrId = null;
+  try {
+    await AsyncStorage.removeItem(TRIP_CORR_ID_KEY);
+  } catch (e) {
+    // graceful — 다음 cleanup에서 재시도.
+    logger.warn('clear 실패(graceful):', e);
+  }
+}
+
+/** 테스트 전용 — cache 초기화. */
+export function __resetTripCorrIdForTests__(): void {
+  cachedCorrId = null;
+}

--- a/src/features/route/store/__tests__/useDestinationStore.test.ts
+++ b/src/features/route/store/__tests__/useDestinationStore.test.ts
@@ -10,6 +10,7 @@ import { useAlarmEventStore } from '../../../alarm/store/useAlarmEventStore';
 import { Station } from '../../../../shared/types/station';
 import { setTripStartedAt } from '../../../alarm/utils/tripStartStorage';
 import { triggerTripEndRecall } from '../../../alarm/utils/triggerTripEndRecall';
+import { setTripCorrId, generateTripCorrId } from '../../../observability/utils/tripCorrId';
 
 jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
@@ -22,6 +23,22 @@ jest.mock('../../../alarm/utils/tripStartStorage', () => ({
 }));
 jest.mock('../../../alarm/utils/triggerTripEndRecall', () => ({
   triggerTripEndRecall: jest.fn().mockResolvedValue({ uploaded: false }),
+}));
+// #1501 (PR-A) — trip 시작 시 corrId 생성 wiring 검증용 mock.
+jest.mock('../../../observability/utils/tripCorrId', () => ({
+  generateTripCorrId: jest.fn(() => 'cid-test-1700000000000-deadbeef'),
+  setTripCorrId: jest.fn().mockResolvedValue(undefined),
+  clearTripCorrId: jest.fn().mockResolvedValue(undefined),
+}));
+// expo-notifications mock — cancelTripBoundAlarms가 getAllScheduledNotificationsAsync()를
+// 호출하는데 native module이 undefined를 반환하면 `.map()`에서 process crash. 빈 큐로 graceful.
+jest.mock('expo-notifications', () => ({
+  getAllScheduledNotificationsAsync: jest.fn().mockResolvedValue([]),
+  cancelScheduledNotificationAsync: jest.fn().mockResolvedValue(undefined),
+  dismissNotificationAsync: jest.fn().mockResolvedValue(undefined),
+  scheduleNotificationAsync: jest.fn().mockResolvedValue('id'),
+  addPushTokenListener: jest.fn(() => ({ remove: jest.fn() })),
+  setNotificationHandler: jest.fn(),
 }));
 
 const mockAddDomainBreadcrumb = jest.fn();
@@ -66,6 +83,8 @@ describe('useDestinationStore', () => {
     // Promise를 반환하지 않으면 setDestination의 .then chain이 깨진다. 기본 impl 복구.
     (triggerTripEndRecall as jest.Mock).mockResolvedValue({ uploaded: false });
     (setTripStartedAt as jest.Mock).mockResolvedValue(undefined);
+    (setTripCorrId as jest.Mock).mockResolvedValue(undefined);
+    (generateTripCorrId as jest.Mock).mockReturnValue('cid-test-1700000000000-deadbeef');
   });
 
   // ── destination ──
@@ -333,8 +352,9 @@ describe('useDestinationStore', () => {
     const setItemImpl = (AsyncStorage.setItem as jest.Mock).getMockImplementation();
     const removeItemImpl = (AsyncStorage.removeItem as jest.Mock).getMockImplementation();
     (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('저장 실패'));
-    // setDestination(null) switch: DESTINATION + fired + route + customOrigin + lock + scheduled + active-trip + TRIP_ORIGIN = 8 removeItem
-    for (let i = 0; i < 8; i++) {
+    // setDestination(null) switch: trip-bound cleanup의 모든 removeItem이 실패해도 graceful해야.
+    // tripBoundCleanups에 키 추가 시 카운트 fragility를 피하기 위해 충분히 큰 N(20)으로 queue.
+    for (let i = 0; i < 20; i++) {
       (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('삭제 실패'));
     }
 
@@ -767,6 +787,33 @@ describe('useDestinationStore', () => {
 
     expect(triggerMock).not.toHaveBeenCalled();
     expect(setTripStartedAtMock).not.toHaveBeenCalled();
+  });
+
+  // ── #1501 (PR-A) — trip start 시 corrId 생성 wire-up ──
+
+  it('setDestination(#1501): switch(prev=null→station) 시 setTripCorrId가 호출된다 (chain 밖 fire-and-forget)', () => {
+    (setTripCorrId as jest.Mock).mockClear();
+    (generateTripCorrId as jest.Mock).mockClear();
+    useDestinationStore.getState().setDestination(mockStation);
+    // sync 분기 — chain 밖이므로 microtask flush 없이도 fire.
+    expect(generateTripCorrId).toHaveBeenCalledTimes(1);
+    expect(setTripCorrId).toHaveBeenCalledWith('cid-test-1700000000000-deadbeef');
+  });
+
+  it('setDestination(#1501): null로 종료 시 setTripCorrId 호출 안 됨 (cleanup이 clear 담당)', async () => {
+    useDestinationStore.setState({ destination: mockStation });
+    (setTripCorrId as jest.Mock).mockClear();
+    useDestinationStore.getState().setDestination(null);
+    await flushMicrotasks();
+    expect(setTripCorrId).not.toHaveBeenCalled();
+  });
+
+  it('setDestination(#1501): 같은 destination 재설정 시 setTripCorrId 호출 안 됨', async () => {
+    useDestinationStore.setState({ destination: mockStation });
+    (setTripCorrId as jest.Mock).mockClear();
+    useDestinationStore.getState().setDestination(mockStation);
+    await flushMicrotasks();
+    expect(setTripCorrId).not.toHaveBeenCalled();
   });
 
   it('setDestination(#919): trigger가 reject해도 setDestination 흐름은 영향 없음 (graceful)', async () => {

--- a/src/features/route/store/useDestinationStore.ts
+++ b/src/features/route/store/useDestinationStore.ts
@@ -19,6 +19,7 @@ import {
 import { RECENT_ROUTES_LIMIT } from '../../../shared/constants/recentDestinations';
 import { runTripBoundCleanups } from '../../alarm/store/tripBoundCleanups';
 import { setTripStartedAt } from '../../alarm/utils/tripStartStorage';
+import { generateTripCorrId, setTripCorrId } from '../../observability/utils/tripCorrId';
 import { triggerTripEndRecall } from '../../alarm/utils/triggerTripEndRecall';
 import { useAlarmEventStore } from '../../alarm/store/useAlarmEventStore';
 import { ROUTE_CATEGORIES, type RoutePreference } from '../../../shared/utils/stationRoute';
@@ -181,6 +182,14 @@ export const useDestinationStore = create<DestinationState>((set, get) => ({
         .catch(noop)
         .then(() => (station ? setTripStartedAt() : undefined))
         .catch(noop);
+      // #1501 (ADR-015 §10 P5 / PR-A) — 새 trip 시작 시 corrId 생성.
+      // rawSignalBuffer entry / backend evidence가 어떤 trip 소속인지 사후 재구성용.
+      // chain 밖 fire-and-forget — setTripCorrId가 sync cache를 즉시 갱신해 fusion cycle 다음
+      // cycle부터 새 corrId 보장. AsyncStorage write는 백그라운드 (storage 실패는 graceful).
+      // station === null(trip 종료) 경로에서는 tripBoundCleanups가 clearTripCorrId를 처리.
+      if (station) {
+        void setTripCorrId(generateTripCorrId());
+      }
       // customOrigin 메모리 상태도 동기화. (loadCustomOrigin은 hydration용이므로 영향 없음)
       if (get().customOrigin !== null) {
         set({ customOrigin: null });

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -141,6 +141,19 @@ export const LOCKLESS_FUNNEL_SEEN_OFF_KEY = 'subway-now:lockless-funnel-seen-off
 // UI 토글은 follow-up PR — 현재는 init 인프라만.
 // 형식: 'true' 또는 키 부재.
 export const SENTRY_OPT_IN_KEY = 'subway-now:sentry-opt-in';
+// #1501 (ADR-015 §10 P5 / PR-A) — Trip correlation id.
+// trip 시작 시 `${epoch ms}-${8 hex}` 형식으로 생성하고 trip 종료(tripBoundCleanups)
+// 시점에 제거한다. rawSignalBuffer entry와 backend evidence(P5 PR-B)의 같은 trip을
+// 묶기 위한 unique id — 사용자가 trip을 여러 개 빠르게 만들어도 cycle/enter/exit
+// entry가 어느 trip 소속인지 사후 재구성한다.
+// 형식: 문자열 (`${epoch ms}-${8 hex}`). 키 부재 = trip 미시작 또는 종료된 상태.
+export const TRIP_CORR_ID_KEY = 'subway-now:trip-corr-id';
+// #1501 (ADR-015 §10 P5 / PR-A) — Device raw signal dump ring buffer (capacity 120).
+// useFusedNearestStation 매 cycle에 push되는 (gps, motion, subsurface, source, confidence)
+// 측정 entry. boot 시 1회 hydrate, push 후 1초 idle throttle write — 강제종료 후에도
+// 마지막 ~120 entry가 복원돼 7일 회귀 사후 분석에 사용.
+// 형식: RawSignalEntry[] JSON.
+export const RAW_SIGNAL_BUFFER_KEY = 'subway-now:raw-signal-buffer';
 // #1279 — 기압계 지하 감지 상태(subsurface boolean) AsyncStorage stamp.
 // useBarometer(FG-only React state)가 subsurface flip 시 write → BG silent-push task와
 // 위치 게이트가 동일한 값을 read할 수 있도록 한다. updatedAt(epoch ms)은 TTL 만료 판별용.


### PR DESCRIPTION
Closes #1501 (PR-A only — backend upload는 PR-B, DebugModal "Raw Signal" 섹션은 PR-C 별도)

ADR-015 §10 P5 가중치 학습 prereq. 7일 cold-launch 회귀(2026-06-17 용마산)처럼 강제종료 후 data 단절을 막는 device-side foundation.

## Summary

- **`observability/utils/tripCorrId.ts`** 신규 — `${epoch ms}-${8 hex}` corrId. in-memory cache + AsyncStorage. fusion hot path는 sync read 보장.
- **`observability/utils/rawSignalBuffer.ts`** 신규 — ring buffer (capacity 120) + throttled write (1s idle) + AsyncStorage 영속화 + boot hydrate.
- **Wire-up**: `useDestinationStore.setDestination` switch 시 corrId 생성 (chain 밖 fire-and-forget), `tripBoundCleanups`에 `clearTripCorrId` 추가, `useFusedNearestStation` decisionKey effect에서 cycle + enter/exit stamp push.
- **Boot**: `app/_layout.tsx`에 `hydrateRawSignalBuffer()` + `getCurrentTripCorrId()` 호출.

## RawSignalEntry 필드 (P1-1 리뷰 반영 — null 박제 X)

| 필드 | 출처 | 비고 |
|---|---|---|
| `ts` | `Date.now()` | |
| `corrId` | `getCurrentTripCorrIdSync()` | sync cache, race 0 |
| `kind` | `'cycle' \| 'enter' \| 'exit'` | station change 시 exit+enter pair |
| `gps` | `gps.userLocation/accuracyMeters/speedMps` | userLocation 없으면 null |
| `motion` | `motionStationary === true ? 'stationary' : false ? 'unknown' : null` | motion-activity provider 확장은 후속 |
| `subsurface` | `barometerSubsurface ?? null` | 지하 감지 |
| `arvlCd` | `fusionArrival.up[0].arrivalCode ?? down[0].arrivalCode ?? null` | up/down 분리는 후속 |
| `line` | `result.station.line` | enter/cycle에서 사용 |
| `stationId/source/confidence` | fusion 결정 | 사후 재구성 SSOT |
| `arcProgress` | `progress.progressM` | 경로 진행도(m) |
| `dir/arcIdx` | null | route arc index 추출은 후속 PR |

## 양방향 layer 추적

- **Upstream (trip 시작)**: `useDestinationStore.setDestination` switch → `generateTripCorrId()` → `setTripCorrId(id)` → cache 동기 갱신 + AsyncStorage write.
- **Downstream (fusion)**: `useFusedNearestStation` decisionKey effect → `getCurrentTripCorrIdSync()` → cache read → `pushRawSignal({corrId, ...})` → ring buffer + throttled storage write.
- **Cleanup**: `runTripBoundCleanups` (Promise.allSettled) → `clearTripCorrId` → cache null + AsyncStorage removeItem.
- **Cold restart**: `app/_layout.tsx` boot → `hydrateRawSignalBuffer()` + `getCurrentTripCorrId()` → buffer 복원 + cache hydrate → 첫 fusion cycle부터 corrId 정상 stamp.

## 테스트 (커버리지 100%)

- `tripCorrId.test.ts` (16건): generate format / set-get-clear / sync cache 일관성 / hydrate fallback / storage 실패 graceful + logger 검증
- `rawSignalBuffer.test.ts` (17건): push/get/clear/subscribe + capacity rotation + throttled write burst + hydrate 4 케이스 + enter/exit + reset helper
- `useDestinationStore.test.ts` 보강: switch(prev=null→station) 시 corrId 생성 wiring + null/same destination 시 미호출
- `useFusedNearestStation.test.ts`: rawSignalBuffer/tripCorrId mock으로 격리, 기존 85건 무회귀
- 전체 6638/6638 pass

## 리뷰 반영 (code-review agent)

| 등급 | 항목 | 반영 |
|---|---|---|
| P1-1 | motion/arvlCd/arcProgress 가용 신호 wire | ✓ |
| P1-2 | `result!` non-null assertion 제거 | ✓ result 분기 조건 포함 |
| P2-2 | boot tripCorrId hydrate 추가 | ✓ `app/_layout.tsx` |
| P3-1 | storage 실패 logger.warn | ✓ |

## Test plan

- [x] `npm test` — 6638/6638 pass, coverage 100%
- [x] `npm run type-check` — pass
- [x] `npm run lint` — clean
- [x] code-review agent 리뷰 → P1/P2/P3 반영
- [x] CI `Data Validation` + `Type Check & Test` pass 확인 후 머지
- [ ] 실기기 trip 1회로 buffer 영속화 (강제종료 → 재시작 → 직전 entry 보존) 확인 (PR-B/PR-C 머지 후 DebugModal에서 검증 가능)

## 후속

- **PR-B**: backend `/signals/dump` endpoint + KV `RAW_SIGNALS` (60일 TTL) + AsyncStorage retry queue. trip 종료 시 `triggerTripEndRecall` 흐름에 piggyback.
- **PR-C**: DebugModal "Raw Signal" 섹션 자동 표시 (toggle 없이) — 직전 30 cycle + 최근 dump 업로드 상태.