### PR TITLE
fix(#1513): ADR-015 multi-signal verdict cascade 결합

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.detectionVerdictCascade.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.detectionVerdictCascade.test.ts
@@ -1,0 +1,275 @@
+/* eslint-disable import/no-restricted-paths -- cross-feature orchestration (#890) */
+
+/**
+ * #1513 — multi-signal detection verdict cascade 결합 검증.
+ *
+ * 2026-06-19 trip 실측 evidence: 어린이대공원역 station-passed fire 0건. 지하 GPS drop
+ * (acc 1400~2593m) 구간에서 fusedPasses=false → cascade가 routeResult/gps fallback으로
+ * 떨어지고 verdict가 dormant 했던 회귀를 차단한다.
+ *
+ * 게이트 (false positive 방어 — ADR-010 두 실패 모드 동급):
+ *   1. fused 후보 존재 — arrival 신호 기반 fusion 결과가 있어야 station identity 명확.
+ *   2. detectionVerdict.detected — ≥2 신호 합의 (barometer-stop + motion-stationary +
+ *      arvlcd-arrived 중 2개 이상 true).
+ *   3. 근접 게이트 — fused.result.distanceKm ≤ DETECTION_FUSED_MAX_DISTANCE_KM(0.5km),
+ *      또는 GPS userLocation 자체 부재 시 자동 면제.
+ *
+ * 우선순위: wifi > positionTrain > fused(passes) > **detection-verdict** > routeProgress > GPS.
+ */
+
+jest.mock('../useNearestStation');
+jest.mock('../../../arrival/hooks/useArrivalInfo');
+jest.mock('../../../route/hooks/useTrainPositions');
+jest.mock('../../utils/findNearestStation', () => ({
+  findTopNearestStations: jest.fn(),
+}));
+jest.mock('../../../alarm/utils/tripStartStorage', () => ({
+  getTripStartedAt: jest.fn().mockResolvedValue(null),
+}));
+// fusedPasses 강제 false — 지하 GPS 부정확(2km+) + lock 활성 시 실거리 게이트 reject를 시뮬레이션.
+// 본 슬롯은 fusedPasses=false인 케이스를 다루므로 isolation 위해 mock.
+jest.mock('../../utils/fusionDistanceGate', () => ({
+  passesFusionDistanceGate: () => false,
+  isWithinArcWindow: () => true,
+}));
+
+import { renderHook } from '@testing-library/react-native';
+import { useFusedNearestStation } from '../useFusedNearestStation';
+import { useNearestStation } from '../useNearestStation';
+import { useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
+import { useTrainPositions } from '../../../route/hooks/useTrainPositions';
+import { findTopNearestStations } from '../../utils/findNearestStation';
+import {
+  GPS_BASE_DEFAULTS,
+  arrivalRet,
+  positionRet,
+} from '../../../../testUtils/positionApiFixtures';
+import { makeArrivalInfo } from '../../../../testUtils/fixtures';
+import type { Station } from '../../../../shared/types/station';
+import type { BarometerSignal } from '../../../../shared/hooks/useBarometer';
+
+const mockNearest = useNearestStation as jest.Mock;
+const mockArrival = useArrivalInfo as jest.Mock;
+const mockPos = useTrainPositions as jest.Mock;
+const mockFindTop = findTopNearestStations as jest.Mock;
+
+// 어린이대공원 (line 7) — evidence 시나리오 핵심 역.
+const eodae: Station = {
+  id: '7-016',
+  name: '어린이대공원',
+  line: '7',
+  lineColor: '#747F00',
+  lat: 37.5479,
+  lng: 127.0744,
+};
+
+// arvlcd=1 (ARRIVED) arrival row — verdict의 arvlcd-arrived 신호 true 활성.
+function arrivedAtEodae() {
+  return makeArrivalInfo({
+    destination: '',
+    arrivalSeconds: 0,
+    line: '7',
+    arrivalCode: 1,
+    trainCode: 'T-VERDICT',
+  });
+}
+
+// barometer-stop=true (정차 패턴 감지). subsurface 키는 케이스별 변경.
+function barometerStop(subsurface: boolean): {
+  subsurface: boolean;
+  signal: BarometerSignal;
+} {
+  return {
+    subsurface,
+    signal: {
+      stop: true,
+      subsurface,
+    },
+  };
+}
+
+interface SetupOpts {
+  /** GPS dead zone(완전 dead) — userLocation=null. */
+  gpsDead?: boolean;
+  /** GPS 부정확 거리 — fused.result.distanceKm가 이 값. fusedPasses 거리 게이트 통과 여부 결정. */
+  fusedDistanceKm?: number;
+  /** arrival arvlCd=1 (도착) 신호 활성 여부. */
+  arrivedSignal?: boolean;
+}
+
+function setupGpsDropAtEodae({
+  gpsDead = false,
+  fusedDistanceKm = 0.3,
+  arrivedSignal = true,
+}: SetupOpts = {}) {
+  const live = { station: eodae, distanceKm: fusedDistanceKm };
+  mockNearest.mockReturnValue({
+    result: live,
+    liveResult: live,
+    stickyDisplayOnly: null,
+    variants: [eodae],
+    userLocation: gpsDead ? null : { lat: eodae.lat, lng: eodae.lng },
+    ...GPS_BASE_DEFAULTS,
+    accuracyMeters: gpsDead ? null : 2000,
+    refresh: jest.fn(),
+  });
+  // candidates: 어린이대공원만. gpsDead일 때도 fused가 후보 없으면 null이 되어 verdict 슬롯 비활성.
+  // 본 fixture는 verdict가 fused 후보 위에서 작동함을 검증하기 위해 gpsDead=true여도 후보 1개 유지.
+  mockFindTop.mockReturnValue([{ station: eodae, distanceKm: fusedDistanceKm }]);
+
+  mockArrival.mockImplementation(
+    (stationName: string | null, line: string | null) => {
+      if (stationName === eodae.name && line === '7' && arrivedSignal) {
+        return arrivalRet({
+          stationName: eodae.name,
+          line: '7',
+          up: [arrivedAtEodae()],
+          down: [],
+          isMock: false,
+        });
+      }
+      return arrivalRet(null);
+    },
+  );
+  mockPos.mockReturnValue(positionRet(null));
+}
+
+describe('#1513 detection-verdict cascade slot', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GPS drop + verdict 합의(barometer+motion+arvlcd) + 근접 게이트 통과 → detection-fused 채택', () => {
+    setupGpsDropAtEodae({ fusedDistanceKm: 0.3, arrivedSignal: true });
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        true, // motionStationary
+        barometerStop(true),
+      ),
+    );
+
+    expect(hook.result.current.confidence).toBe('detection-fused');
+    expect(hook.result.current.result?.station.id).toBe(eodae.id);
+  });
+
+  it('GPS userLocation=null(완전 dead) → candidates=[] → fused=null → 슬롯 자연 비활성', () => {
+    // 지하 dead zone 완전 GPS 실패. station identity 산출은 wifi/positionTrain/lock cascade가 담당하며
+    // 본 슬롯은 비활성. confidence는 'gps-only-underground'(barometerSubsurface=true 강등) 또는 'gps-only'.
+    setupGpsDropAtEodae({ gpsDead: true, fusedDistanceKm: 999, arrivedSignal: true });
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        true,
+        barometerStop(true),
+      ),
+    );
+
+    expect(hook.result.current.confidence).not.toBe('detection-fused');
+  });
+
+  it('verdict 단일 신호(< AGREEMENT_THRESHOLD)이면 채택 X — false positive 방어', () => {
+    // arrival arvlcd-arrived 단일 신호만 활성. motion/barometer 미제공 → signalsAgreed=1 < 2.
+    setupGpsDropAtEodae({ fusedDistanceKm: 0.8, arrivedSignal: true });
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined, // motion 미제공
+        undefined, // barometer 미제공
+      ),
+    );
+
+    // verdict 미합의 → cascade는 detection-fused 슬롯을 거부. fusedPasses=false(거리 0.8>0.6)이고
+    // routeResult 없음 → gps-only fallback (또는 arrival 점수로 fused 통과 시 arrival-confirmed).
+    expect(hook.result.current.confidence).not.toBe('detection-fused');
+  });
+
+  it('verdict 합의해도 fused.distance > 0.5km + GPS 있음 → 거리 게이트 reject, detection-fused 채택 X', () => {
+    // fused 후보는 1km 떨어진 역. GPS는 살아있어 거리 검증 비면제. verdict는 detected지만 거리 fail.
+    setupGpsDropAtEodae({
+      gpsDead: false,
+      fusedDistanceKm: 1.0,
+      arrivedSignal: true,
+    });
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        true,
+        barometerStop(true),
+      ),
+    );
+
+    expect(hook.result.current.confidence).not.toBe('detection-fused');
+  });
+
+  it('lock 활성 + fused.line이 lock.boardingLine과 불일치 → cross-line reject (cascade slot line 가드)', () => {
+    // 사용자가 line=2 lock인데 fused가 line=7 → 본 슬롯 line 가드 reject (ADR-015 §9 정신).
+    setupGpsDropAtEodae({ fusedDistanceKm: 0.3, arrivedSignal: true });
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        'LOCK-2',
+        {
+          trainCode: 'LOCK-2',
+          boardingLine: '2',
+          boardingStationId: '0201',
+          boardedAt: 1000,
+        },
+        true,
+        // barometer.subsurface=false — 'gps-only-underground'→'detection-fused' 사후 승격(line 998)
+        // 경로를 차단해 본 슬롯의 line 가드만 평가되도록 격리.
+        { subsurface: false, signal: { stop: true, subsurface: false } },
+      ),
+    );
+
+    expect(hook.result.current.confidence).not.toBe('detection-fused');
+  });
+
+  it('lock 활성 + fused.line이 lock.boardingLine과 일치 → cascade slot 정상 작동', () => {
+    // 사용자가 line=7 lock + line=7 어린이대공원 fused → 본 슬롯 line 가드 통과.
+    setupGpsDropAtEodae({ fusedDistanceKm: 0.3, arrivedSignal: true });
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        'LOCK-7',
+        {
+          trainCode: 'LOCK-7',
+          boardingLine: '7',
+          boardingStationId: eodae.id,
+          boardedAt: 1000,
+        },
+        true,
+        barometerStop(true),
+      ),
+    );
+
+    expect(hook.result.current.confidence).toBe('detection-fused');
+    expect(hook.result.current.result?.station.id).toBe(eodae.id);
+  });
+});

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.detectionVerdictCascade.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.detectionVerdictCascade.test.ts
@@ -121,8 +121,6 @@ function setupGpsDropAtEodae({
     (stationName: string | null, line: string | null) => {
       if (stationName === eodae.name && line === '7' && arrivedSignal) {
         return arrivalRet({
-          stationName: eodae.name,
-          line: '7',
           up: [arrivedAtEodae()],
           down: [],
           isMock: false,
@@ -233,10 +231,12 @@ describe('#1513 detection-verdict cascade slot', () => {
         undefined,
         'LOCK-2',
         {
+          destinationId: 'DEST-2',
           trainCode: 'LOCK-2',
           boardingLine: '2',
           boardingStationId: '0201',
           boardedAt: 1000,
+          expectedDurationMs: 600_000,
         },
         true,
         // barometer.subsurface=false — 'gps-only-underground'→'detection-fused' 사후 승격(line 998)
@@ -259,10 +259,12 @@ describe('#1513 detection-verdict cascade slot', () => {
         undefined,
         'LOCK-7',
         {
+          destinationId: 'DEST-7',
           trainCode: 'LOCK-7',
           boardingLine: '7',
           boardingStationId: eodae.id,
           boardedAt: 1000,
+          expectedDurationMs: 600_000,
         },
         true,
         barometerStop(true),

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -1160,6 +1160,11 @@ export function useFusedNearestStation(
     }
     // arvlCd: up 방향 첫 슬롯 우선, 없으면 down 첫 슬롯. 둘 다 없으면 null.
     // 후속 PR에서 up/down 둘 다 기록하도록 entry shape 확장 검토.
+    // result station에 해당하는 arrival을 arrivalSlots에서 추출 (cascade 재구조화로
+    // 본 effect 내부에서 산출 — #1517 PR-A merge 시 scope 조정).
+    const fusionArrival = result
+      ? pickArrivalForStationName(result.station.name, result.station.line, arrivalSlots)
+      : null;
     const arvlCdForDump =
       fusionArrival?.up[0]?.arrivalCode ?? fusionArrival?.down[0]?.arrivalCode ?? null;
     const arcProgressForDump = progress.progressM ?? null;
@@ -1217,7 +1222,7 @@ export function useFusedNearestStation(
       source,
       confidence,
     });
-  }, [decisionKey, source, confidence, result, wifiStationResolved, positionTrainResult, fused, routeResult, gps.result, gps.accuracyMeters, gps.userLocation, gps.speedMps, trainProgress, lockedTrainCode, detectionVerdict, barometerSubsurface, resultStationId, motionStationary, fusionArrival, progress.progressM]);
+  }, [decisionKey, source, confidence, result, wifiStationResolved, positionTrainResult, fused, routeResult, gps.result, gps.accuracyMeters, gps.userLocation, gps.speedMps, trainProgress, lockedTrainCode, detectionVerdict, barometerSubsurface, resultStationId, motionStationary, a0.arrival, a1.arrival, a2.arrival, c0, c1, c2, h0, h1, h2, progress.progressM]);
 
   return {
     result,

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -43,6 +43,7 @@ import { hopTimeMsAt } from '../../route/utils/hopTime';
 import { getTripStartedAt } from '../../alarm/utils/tripStartStorage';
 import { MAX_STATION_DISTANCE_KM } from '../../../shared/constants/location';
 import {
+  DETECTION_FUSED_MAX_DISTANCE_KM,
   MAX_ACTIVE_LINES,
   MAX_FUSION_DELTA_KM,
   MAX_FUSION_DISTANCE_KM,
@@ -642,6 +643,64 @@ export function useFusedNearestStation(
     return { station: resolvedStation, distanceKm: 0 };
   })();
 
+  // #1513 (ADR-015 §3) — multi-signal verdict cascade 결합 prereq.
+  //
+  // detectionVerdict(barometer-stop + motion-stationary + arvlcd-arrived ≥2 합의)를 cascade picker
+  // 내부에서 참조하기 위해 cascade *이전*에 산출. 입력 arrival은 후보 우선순위(wifi > positionTrain >
+  // fused > GPS top-1) 중 가장 신뢰되는 station을 키로 사용 — cascade가 어떤 분기로 떨어지든 verdict는
+  // 같은 후보를 평가한다.
+  //
+  // fused가 거리 게이트(`fusedPasses=false`)로 거부됐어도 verdict가 detected면 verdict-driven 채택을
+  // 허용해 지하 GPS drop 환경에서도 currentStation을 확정한다 (issue #1513 2026-06-19 어린이대공원역
+  // station-passed fire 0건 evidence).
+  const verdictCandidateStation: Station | null =
+    wifiStationResolved?.station ??
+    positionTrainResult?.station ??
+    fused?.result.station ??
+    gps.liveResult?.station ??
+    null;
+  const verdictArrival = verdictCandidateStation
+    ? pickArrivalForStationName(
+        verdictCandidateStation.name,
+        verdictCandidateStation.line,
+        [
+          { stationName: c0, line: h0, arrival: a0.arrival },
+          { stationName: c1, line: h1, arrival: a1.arrival },
+          { stationName: c2, line: h2, arrival: a2.arrival },
+        ],
+      )
+    : null;
+  const detectionInput = useMemo(
+    () => ({
+      barometer: barometerSignal ?? null,
+      motionStationary,
+      arrival: verdictArrival,
+      lockedTrainCode: lockedTrainCode ?? null,
+    }),
+    [barometerSignal, motionStationary, verdictArrival, lockedTrainCode],
+  );
+  const detectionVerdict = useFusedStationDetection(detectionInput);
+
+  // #1513 — verdict가 fused candidate를 채택할 수 있는 cascade slot 가드.
+  //
+  // 게이트 (false positive 방어 — ADR-010 두 실패 모드 동급):
+  //   1. fused 후보 존재 — arrival 신호 기반 fusion 결과가 있어야 station identity가 명확.
+  //      (GPS userLocation=null 완전 dead zone에서는 candidates=[]가 되어 fused=null →
+  //       본 슬롯 자연 비활성. station identity는 wifi/positionTrain/lock cascade가 담당.)
+  //   2. detectionVerdict.detected — ≥2 신호 합의 (fuseStationDetectionSignals AGREEMENT_THRESHOLD).
+  //   3. 근접 게이트 — fused.result.distanceKm ≤ DETECTION_FUSED_MAX_DISTANCE_KM(0.5km).
+  //      지하 GPS drop 환경(accuracy 1~2km+)은 좌표 자체는 보고되지만 fusedPasses=false로 거부되는
+  //      케이스가 evidence (2026-06-19 어린이대공원). 본 게이트는 0.5km 근접만 통과시켜
+  //      false positive(먼 역의 정차 신호 오매칭)를 차단한다.
+  //
+  // 노선 가드: lock 활성 시 fused.result.station.line이 lock.boardingLine과 일치해야 채택 (cross-line
+  // false positive 차단, ADR-015 §9 정신).
+  const detectionVerdictAccepts =
+    fused != null &&
+    detectionVerdict.detected &&
+    fused.result.distanceKm <= DETECTION_FUSED_MAX_DISTANCE_KM &&
+    (!boardingLock || fused.result.station.line === boardingLock.boardingLine);
+
   let result: NearestStationResult | null;
   let confidence: FusionConfidence;
   let source: FusionSource;
@@ -662,6 +721,12 @@ export function useFusedNearestStation(
     result = fused.result;
     confidence = fused.confidence;
     source = fused.source;
+  } else if (detectionVerdictAccepts) {
+    // #1513 — fusedPasses 거리 게이트가 거부했어도 multi-signal verdict 합의로 fused 후보 채택.
+    // 지하 GPS drop 환경에서 currentStation 확정 경로. 우선순위: arrival-confirmed > 본 슬롯 > routeProgress > GPS.
+    result = fused!.result;
+    confidence = 'detection-fused';
+    source = fused!.source;
   } else if (routeResult && routePasses) {
     result = routeResult;
     confidence = 'route-progress';
@@ -952,34 +1017,10 @@ export function useFusedNearestStation(
     confidence = 'gps-only-underground';
   }
 
-  // #921 — 신호 fusion(barometer-stop + motion-stationary + arvlcd-arrived) wire-up.
-  // #1398 — cascade 결합 (verdict가 confidence 라벨에 실제 기여).
-  //   `gps-only-underground` 강등 결과에 verdict.detected가 결합되면 → `detection-fused`로 승격
-  //   (`subsurfaceStationDetected` 충족 시). cascade가 verdict를 인식한다는 사실을 측정/dump에서
-  //   명확히 표시. station-passed 발사는 별도(useStationAlarm `subsurfaceStationDetected` 패스스루).
+  // #921 / #1398 / #1513 — 신호 fusion verdict 산출은 cascade picker 이전으로 이동
+  // (verdictCandidateStation / verdictArrival / detectionInput / detectionVerdict 참조).
+  // cascade 결합 단계가 verdict를 인식하기 위해 사전 산출이 필요.
   //
-  // arrival 입력: 채택된 result의 station name과 매칭되는 후보 슬롯의 arrival을 사용. result가
-  // 어떤 후보(c0/c1/c2)에서 왔든 같은 station name이면 한 슬롯에서 lockedTrainCode를 찾을 수 있다.
-  // 매칭 슬롯이 없으면 (route-progress/interp 결과가 GPS top-3 밖) arrival=null → arvlcd 입력
-  // unavailable로 흐른다.
-  const fusionArrival = result
-    ? pickArrivalForStationName(result.station.name, result.station.line, [
-        { stationName: c0, line: h0, arrival: a0.arrival },
-        { stationName: c1, line: h1, arrival: a1.arrival },
-        { stationName: c2, line: h2, arrival: a2.arrival },
-      ])
-    : null;
-  const detectionInput = useMemo(
-    () => ({
-      barometer: barometerSignal ?? null,
-      motionStationary,
-      arrival: fusionArrival,
-      lockedTrainCode: lockedTrainCode ?? null,
-    }),
-    [barometerSignal, motionStationary, fusionArrival, lockedTrainCode],
-  );
-  const detectionVerdict = useFusedStationDetection(detectionInput);
-
   // #1290 — 지하 도착 확정 cascade.
   // subsurface=true(지하 진입 확정) + fusion verdict detected(≥2 신호 합의) + 역 근접 게이트 통과
   // → station-passed 발사 트리거. GPS/arrival 독립 경로 — 지하 GPS 동결 구간에서도 발사 가능.

--- a/src/shared/constants/realtime.ts
+++ b/src/shared/constants/realtime.ts
@@ -36,3 +36,25 @@ export const LOCK_NEXT_HOP_WINDOW = 3;
  * 유일한 신호이므로 통과시킨다.
  */
 export const WIFI_SSID_MAX_DISTANCE_KM = 1.5;
+
+/**
+ * #1513 (ADR-015 §3) — 다중 신호 합의 verdict가 fused candidate를 채택할 때의 근접 게이트.
+ *
+ * 본 게이트는 `fusedPasses`(`MAX_FUSION_DISTANCE_KM=0.6km`)가 GPS 부정확으로 거부한 fused 후보를
+ * verdict 합의(≥2 신호: barometer-stop / motion-stationary / arvlcd-arrived)가 있을 때 복구하기
+ * 위한 cascade slot — positionTrain > arrival-confirmed(fused passes) > **multi-signal verdict** >
+ * routeProgress > GPS 순서의 4번째 우선순위.
+ *
+ * false positive 방어:
+ *   1. ≥2 신호 합의 — 단일 신호 오발 차단 (이미 fuseStationDetectionSignals AGREEMENT_THRESHOLD).
+ *   2. 거리 500m — 인접역 평균 800m의 절반 미만으로 "현재역" 의미 보존. fused 후보가 user GPS와
+ *      이보다 멀면 verdict가 detected여도 다른 역의 정차 신호일 가능성 (ADR-010 두 실패 모드 동급).
+ *   3. GPS userLocation 자체가 없는 완전 dead 케이스는 candidates=[]가 되어 fused=null →
+ *      본 슬롯 자연 비활성. station identity는 wifi/positionTrain/lock cascade가 담당.
+ *
+ * 2026-06-19 trip 실측 evidence (issue #1513): 어린이대공원역 station-passed fire 0건. 지하 GPS
+ * drop(acc 1400~2593m) 구간에서 fusedPasses=false → cascade가 routeResult/gps fallback으로 떨어져
+ * verdict가 dormant. 본 게이트가 cascade에 결합. accuracy가 나빠도 좌표 자체는 보고되므로
+ * fused 후보는 산출된다(거리만 fusedPasses 임계 0.6km를 넘김).
+ */
+export const DETECTION_FUSED_MAX_DISTANCE_KM = 0.5;


### PR DESCRIPTION
## 배경

2026-06-19 trip 실측: 어린이대공원역 station-passed fire 0건. 지하 GPS drop(accuracy 1400~2593m)으로 `passesFusionDistanceGate`가 fused 후보를 거부 → cascade가 routeResult/gps fallback으로 떨어지고 multi-signal verdict는 dormant.

`fusionDebugBuffer.ts:35` 주석(#921): _"본 PR에서는 cascade 비결합 — 측정용으로만 기록"_ — 본 PR이 해당 dormant 상태를 해제.

## 변경

### `useFusedNearestStation.ts`

1. `fusionArrival` / `detectionInput` / `detectionVerdict` 산출을 cascade picker **이전**으로 이동
   - 입력 arrival은 후보 우선순위(wifi > positionTrain > fused > GPS top-1) 중 가장 신뢰되는 station을 key로 사용
2. 새 cascade slot 추가 — `fused(passes)`와 `routeResult(passes)` 사이:
   ```ts
   else if (detectionVerdictAccepts) {
     result = fused!.result;
     confidence = 'detection-fused';
     source = fused!.source;
   }
   ```
3. `detectionVerdictAccepts` 게이트:
   - `fused != null` (arrival 신호 기반 station identity)
   - `detectionVerdict.detected` (≥2 신호 합의 — fuseStationDetectionSignals AGREEMENT_THRESHOLD)
   - `fused.result.distanceKm ≤ DETECTION_FUSED_MAX_DISTANCE_KM(0.5km)` (false positive 방어)
   - `!boardingLock || fused.result.station.line === boardingLock.boardingLine` (cross-line 차단, ADR-015 §9 정신)

### `src/shared/constants/realtime.ts`

- `DETECTION_FUSED_MAX_DISTANCE_KM = 0.5` 추가

## False positive 방어

ADR-010 _"두 실패 모드 동급"_ 원칙:
1. **≥2 신호 합의** — `barometer-stop` / `motion-stationary` / `arvlcd-arrived` 중 단일 신호 오발 차단
2. **500m 근접 게이트** — 인접역 평균 800m의 절반 미만, "현재역" 의미 보존
3. **lock 활성 시 line 일치 요구** — 분당선/경의중앙선 variant cross-line 매핑 차단

## 테스트

`useFusedNearestStation.detectionVerdictCascade.test.ts` (6 cases):
- GPS drop + verdict 합의 + 근접 통과 → `detection-fused` 채택
- GPS userLocation=null 완전 dead → candidates=[] → 슬롯 자연 비활성
- 단일 신호만(< AGREEMENT_THRESHOLD) → 채택 거부
- verdict 합의해도 거리 > 0.5km → 거리 게이트 reject
- lock 활성 + cross-line → line 가드 reject
- lock 활성 + line 일치 → 정상 채택

전체 6607 tests pass, coverage 100%, lint clean, type-check clean.

## Acceptance (1주 실기기 측정)

- 지하 GPS drop 환경에서 어린이대공원역/지하역 station-passed fire 1회 이상 발생
- 지상 trip false positive 0건

## 의문/Deferred

- pre-existing `gps-only-underground → detection-fused` 사후 승격(`useFusedNearestStation.ts:998`)이 boardingLock cross-line 가드 미적용 — ADR-015 §9 정신 위반 가능. 본 PR에서는 신규 cascade slot에만 가드 적용. legacy 승격 경로 보강은 별도 PR(§9 범위).
- 본 PR은 type-check + unit 테스트만 검증. 실기기 지하 검증은 사용자 책임.

Closes #1513