### PR TITLE
fix(#1514): lockless trip 출발역 station-passed false fire 차단

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -3668,15 +3668,14 @@ describe('useStationAlarm', () => {
     );
     const routeDirectOrigin = makeDirectRoute(4, '2');
 
-    it('lockless + currentHopIndex=0 + candidate arc[0] → suppressed (gate-origin-hop-lockless)', async () => {
-      mockGetBoardingLock.mockResolvedValue(null);
+    const renderOriginHopCase = (nearestIndex: number, currentHopIndex: number) =>
       renderHook(() =>
         useStationAlarm(
           defaultInputs({
             route: routeDirectOrigin,
             destination,
-            nearestStation: arcOrigin[0],
-            currentHopIndex: 0,
+            nearestStation: arcOrigin[nearestIndex],
+            currentHopIndex,
             arcStations: arcOrigin,
             userLocation: { lat: 37.6, lng: 127.1 },
             speedMps: 10,
@@ -3684,6 +3683,20 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
+
+    const mockNextTargetStops = (stops: number) => {
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '강남',
+        stopsToNextStation: stops,
+        isTransfer: false,
+        stopsToDestination: stops,
+      });
+    };
+
+    it('lockless + currentHopIndex=0 + candidate arc[0] → suppressed (gate-origin-hop-lockless)', async () => {
+      mockGetBoardingLock.mockResolvedValue(null);
+      renderOriginHopCase(0, 0);
       await waitFor(() => {
         expect(mockLogSuppressedOriginHopLockless).toHaveBeenCalledWith({
           source: 'fg',
@@ -3703,27 +3716,8 @@ describe('useStationAlarm', () => {
         boardedAt: Date.now(),
         expectedDurationMs: 600_000,
       });
-      mockGetLastNotifiedStationId.mockResolvedValue(null);
-      mockResolveNextTarget.mockReturnValue({
-        nextStationName: '강남',
-        stopsToNextStation: 4,
-        isTransfer: false,
-        stopsToDestination: 4,
-      });
-      renderHook(() =>
-        useStationAlarm(
-          defaultInputs({
-            route: routeDirectOrigin,
-            destination,
-            nearestStation: arcOrigin[0],
-            currentHopIndex: 0,
-            arcStations: arcOrigin,
-            userLocation: { lat: 37.6, lng: 127.1 },
-            speedMps: 10,
-            accuracyMeters: 50,
-          }),
-        ),
-      );
+      mockNextTargetStops(4);
+      renderOriginHopCase(0, 0);
       await waitFor(() => {
         expect(mockSendStationPassedNotification).toHaveBeenCalled();
       });
@@ -3732,27 +3726,8 @@ describe('useStationAlarm', () => {
 
     it('lockless + currentHopIndex=0 + candidate arc[1] (다음 hop) → 통과 (정상 진행 신호)', async () => {
       mockGetBoardingLock.mockResolvedValue(null);
-      mockGetLastNotifiedStationId.mockResolvedValue(null);
-      mockResolveNextTarget.mockReturnValue({
-        nextStationName: '강남',
-        stopsToNextStation: 3,
-        isTransfer: false,
-        stopsToDestination: 3,
-      });
-      renderHook(() =>
-        useStationAlarm(
-          defaultInputs({
-            route: routeDirectOrigin,
-            destination,
-            nearestStation: arcOrigin[1],
-            currentHopIndex: 0,
-            arcStations: arcOrigin,
-            userLocation: { lat: 37.6, lng: 127.1 },
-            speedMps: 10,
-            accuracyMeters: 50,
-          }),
-        ),
-      );
+      mockNextTargetStops(3);
+      renderOriginHopCase(1, 0);
       await waitFor(() => {
         expect(mockSendStationPassedNotification).toHaveBeenCalled();
       });
@@ -3761,27 +3736,8 @@ describe('useStationAlarm', () => {
 
     it('lockless + currentHopIndex=2 + candidate arc[2] (중간 hop origin 아님) → 통과 (기존 동작 보존)', async () => {
       mockGetBoardingLock.mockResolvedValue(null);
-      mockGetLastNotifiedStationId.mockResolvedValue(null);
-      mockResolveNextTarget.mockReturnValue({
-        nextStationName: '강남',
-        stopsToNextStation: 2,
-        isTransfer: false,
-        stopsToDestination: 2,
-      });
-      renderHook(() =>
-        useStationAlarm(
-          defaultInputs({
-            route: routeDirectOrigin,
-            destination,
-            nearestStation: arcOrigin[2],
-            currentHopIndex: 2,
-            arcStations: arcOrigin,
-            userLocation: { lat: 37.6, lng: 127.1 },
-            speedMps: 10,
-            accuracyMeters: 50,
-          }),
-        ),
-      );
+      mockNextTargetStops(2);
+      renderOriginHopCase(2, 2);
       await waitFor(() => {
         expect(mockSendStationPassedNotification).toHaveBeenCalled();
       });

--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -81,6 +81,7 @@ const mockLogSuppressedDismissSilence = jest.fn();
 const mockLogSuppressedStationPassedWarmup = jest.fn();
 const mockLogSuppressedHopWindow = jest.fn();
 const mockLogSuppressedHopWindowNoSource = jest.fn();
+const mockLogSuppressedOriginHopLockless = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
   logFiredAlarmsHydrate: (...args: unknown[]) => mockLogFiredAlarmsHydrate(...args),
@@ -101,6 +102,8 @@ jest.mock('../../utils/alarmLog', () => ({
   logSuppressedHopWindow: (...args: unknown[]) => mockLogSuppressedHopWindow(...args),
   logSuppressedHopWindowNoSource: (...args: unknown[]) =>
     mockLogSuppressedHopWindowNoSource(...args),
+  logSuppressedOriginHopLockless: (...args: unknown[]) =>
+    mockLogSuppressedOriginHopLockless(...args),
 }));
 
 const mockGetBoardingLock = jest.fn();
@@ -3653,6 +3656,136 @@ describe('useStationAlarm', () => {
         });
       });
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  // #1514 — 2026-06-19 용마산 회귀: lockless trip 출발역(arc[0]) station-passed false fire 차단.
+  // GPS path에서 currentHopIndex=0 + candidateIndex=0이면 estimator default-hop 신호이므로
+  // lock 부재 시 fire 차단. lock 활성은 boardingStationId 기준 origin 알림이 정당이라 우회.
+  describe('#1514 lockless origin hop 차단 (출발역 자기 자신)', () => {
+    const arcOrigin: Station[] = Array.from({ length: 5 }, (_, i) =>
+      makeStation(`OH-A${i}`, `OHname${i}`, 37.6 + i * 0.001, 127.1 + i * 0.001),
+    );
+    const routeDirectOrigin = makeDirectRoute(4, '2');
+
+    it('lockless + currentHopIndex=0 + candidate arc[0] → suppressed (gate-origin-hop-lockless)', async () => {
+      mockGetBoardingLock.mockResolvedValue(null);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: routeDirectOrigin,
+            destination,
+            nearestStation: arcOrigin[0],
+            currentHopIndex: 0,
+            arcStations: arcOrigin,
+            userLocation: { lat: 37.6, lng: 127.1 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+      await waitFor(() => {
+        expect(mockLogSuppressedOriginHopLockless).toHaveBeenCalledWith({
+          source: 'fg',
+          stationName: arcOrigin[0].name,
+        });
+      });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredStationPassed).not.toHaveBeenCalledWith('fg', arcOrigin[0]);
+    });
+
+    it('lock 활성 + currentHopIndex=0 + candidate arc[0] (= boardingStationId) → 통과 (ADR-014 동급 보장)', async () => {
+      mockGetBoardingLock.mockResolvedValue({
+        destinationId: destination.id,
+        trainCode: 'T-LOCK',
+        boardingStationId: arcOrigin[0].id,
+        boardingLine: '2' as const,
+        boardedAt: Date.now(),
+        expectedDurationMs: 600_000,
+      });
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '강남',
+        stopsToNextStation: 4,
+        isTransfer: false,
+        stopsToDestination: 4,
+      });
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: routeDirectOrigin,
+            destination,
+            nearestStation: arcOrigin[0],
+            currentHopIndex: 0,
+            arcStations: arcOrigin,
+            userLocation: { lat: 37.6, lng: 127.1 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      });
+      expect(mockLogSuppressedOriginHopLockless).not.toHaveBeenCalled();
+    });
+
+    it('lockless + currentHopIndex=0 + candidate arc[1] (다음 hop) → 통과 (정상 진행 신호)', async () => {
+      mockGetBoardingLock.mockResolvedValue(null);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '강남',
+        stopsToNextStation: 3,
+        isTransfer: false,
+        stopsToDestination: 3,
+      });
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: routeDirectOrigin,
+            destination,
+            nearestStation: arcOrigin[1],
+            currentHopIndex: 0,
+            arcStations: arcOrigin,
+            userLocation: { lat: 37.6, lng: 127.1 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      });
+      expect(mockLogSuppressedOriginHopLockless).not.toHaveBeenCalled();
+    });
+
+    it('lockless + currentHopIndex=2 + candidate arc[2] (중간 hop origin 아님) → 통과 (기존 동작 보존)', async () => {
+      mockGetBoardingLock.mockResolvedValue(null);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '강남',
+        stopsToNextStation: 2,
+        isTransfer: false,
+        stopsToDestination: 2,
+      });
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: routeDirectOrigin,
+            destination,
+            nearestStation: arcOrigin[2],
+            currentHopIndex: 2,
+            arcStations: arcOrigin,
+            userLocation: { lat: 37.6, lng: 127.1 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      });
+      expect(mockLogSuppressedOriginHopLockless).not.toHaveBeenCalled();
     });
   });
 

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -44,6 +44,7 @@ import {
   logSuppressedDismissSilence,
   logSuppressedHopWindow,
   logSuppressedHopWindowNoSource,
+  logSuppressedOriginHopLockless,
   logSuppressedMovement,
   logSuppressedPhaseGate,
   logSuppressedSleepFirstTransfer,
@@ -859,6 +860,9 @@ export function useStationAlarm({
       //   1. currentHopIndex prop (D1 estimator 또는 lock 활성 시 interp 결과 — 호출자가 결정)
       //   2. firedAlarms set 기반 fallback (graceful, false negative risk)
       //   3. 둘 다 부재 + arcStations 없음 → 게이트 미적용 (gate-hop-window-no-source)
+      // #1514 — 출발역(arc[0]) origin hop fire 차단. lock 활성 trip은 boardingStationId 기준
+      // origin 알림이 정당 신호이므로 IIFE 안에서 추가 검사 (lock fetch 후).
+      let isOriginHopCandidate = false;
       if (arcStations && arcStations.length > 0) {
         const effectiveHopIndex =
           currentHopIndex ?? inferHopIndexFromFiredAlarms(firedAlarmsRef.current, arcStations);
@@ -872,6 +876,10 @@ export function useStationAlarm({
             candidateIndex: arcIndexOf(arcStations, candidateStation),
           });
           return;
+        } else {
+          // hop window 통과 — origin hop 케이스만 추가 표식 (lockless 차단은 IIFE 내부).
+          const candidateIndex = arcIndexOf(arcStations, candidateStation);
+          isOriginHopCandidate = effectiveHopIndex === 0 && candidateIndex === 0;
         }
       }
 
@@ -897,6 +905,15 @@ export function useStationAlarm({
       void (async () => {
         const lock = await getBoardingLock();
         if (cancelled) return;
+        // #1514 — lockless origin hop 차단 (2026-06-19 용마산 evidence).
+        // lock 활성 시는 boardingStationId 기준 origin 알림이 정당이므로 우회 (ADR-014 §4 동급 보장).
+        if (isOriginHopCandidate && !lock) {
+          logSuppressedOriginHopLockless({
+            source: 'fg',
+            stationName: candidateStation.name,
+          });
+          return;
+        }
         await runSilenceGateAndDispatch({
           source: 'fg',
           candidateStation,

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -868,7 +868,11 @@ export function useStationAlarm({
           currentHopIndex ?? inferHopIndexFromFiredAlarms(firedAlarmsRef.current, arcStations);
         if (effectiveHopIndex < 0) {
           logSuppressedHopWindowNoSource({ source: 'fg', stationName: candidateStation.name });
-        } else if (!isStationWithinHopWindow(candidateStation, arcStations, effectiveHopIndex)) {
+        } else if (isStationWithinHopWindow(candidateStation, arcStations, effectiveHopIndex)) {
+          // hop window 통과 — origin hop 케이스만 추가 표식 (lockless 차단은 IIFE 내부).
+          const candidateIndex = arcIndexOf(arcStations, candidateStation);
+          isOriginHopCandidate = effectiveHopIndex === 0 && candidateIndex === 0;
+        } else {
           logSuppressedHopWindow({
             source: 'fg',
             stationName: candidateStation.name,
@@ -876,10 +880,6 @@ export function useStationAlarm({
             candidateIndex: arcIndexOf(arcStations, candidateStation),
           });
           return;
-        } else {
-          // hop window 통과 — origin hop 케이스만 추가 표식 (lockless 차단은 IIFE 내부).
-          const candidateIndex = arcIndexOf(arcStations, candidateStation);
-          isOriginHopCandidate = effectiveHopIndex === 0 && candidateIndex === 0;
         }
       }
 

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -46,6 +46,7 @@ import {
   logSuppressedStationPassedWarmup,
   logSuppressedHopWindow,
   logSuppressedHopWindowNoSource,
+  logSuppressedOriginHopLockless,
   logSuppressedTbaRevalidation,
   summarizeAlarmLogBySource,
   countGateReasons,
@@ -718,6 +719,21 @@ describe('alarmLog', () => {
         source: 'fg',
         outcome: 'suppressed',
         reason: 'gate-hop-window-no-source',
+        stationName: '용마산',
+        kind: 'station-passed',
+      });
+    });
+
+    it('#1514 logSuppressedOriginHopLockless: reason=gate-origin-hop-lockless + kind=station-passed', async () => {
+      logSuppressedOriginHopLockless({ source: 'fg', stationName: '용마산' });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fg',
+        outcome: 'suppressed',
+        reason: 'gate-origin-hop-lockless',
         stationName: '용마산',
         kind: 'station-passed',
       });

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -112,6 +112,11 @@ export type AlarmLogReason =
   // 'gate-hop-window-no-source'는 hop SSOT(estimator/lock/firedAlarms)가 모두 없어 게이트 미적용 graceful skip 적재.
   | 'gate-hop-window'
   | 'gate-hop-window-no-source'
+  // #1514 — lockless trip의 출발역 자기 자신(arc[0])에서 currentHopIndex=0일 때 차단된 발사.
+  // 2026-06-19 용마산 evidence: lockless 또는 lock fetch 부재 상태에서 origin hop window가
+  // candidate=0을 허용해 "출발역 도착" false fire 발생. lock 활성 trip은 본 가드 미적용
+  // (boardingStationId 기준 startStation 진행 알림은 정당 — ADR-014 §4 동급 보장).
+  | 'gate-origin-hop-lockless'
   // #1012 (H5) — useStationAlarm hydration state machine 각 phase 진입 stamp.
   // pre-hydrate → hydrating → storage-synced → ready 4단계. 'ready' 전 phase에서는
   // 모든 phase 알람 발사가 보류된다. transition 한 번에 1엔트리 적재 — 운영에서 phase
@@ -844,6 +849,30 @@ export function logSuppressedHopWindowNoSource(input: {
     source: input.source,
     outcome: 'suppressed',
     reason: 'gate-hop-window-no-source',
+    stationName: input.stationName,
+    kind: 'station-passed',
+  });
+}
+
+/**
+ * #1514 — lockless trip의 origin hop(arc[0] + currentHopIndex=0) station-passed 1건 차단 적재.
+ *
+ * `gate-hop-window`는 currentHopIndex ± windowSize 안의 candidate를 허용하므로 hopIndex=0일 때
+ * arc[0] (출발역 자기 자신)이 통과한다. lockless trip은 사용자가 origin에 도달한 신호가 아니라
+ * estimator default-hop이라 false positive — 본 reason으로 별도 분리해 운영에서 발생률을 추적한다.
+ *
+ * 호출자는 lock=null일 때만 본 함수를 호출 — lock 활성 trip은 boardingStationId 기준 origin
+ * 알림이 정당 신호이므로 본 가드 미적용 (ADR-014 §4 사용자 명시 의향 동급 보장).
+ */
+export function logSuppressedOriginHopLockless(input: {
+  source: AlarmLogSource;
+  stationName: string;
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: input.source,
+    outcome: 'suppressed',
+    reason: 'gate-origin-hop-lockless',
     stationName: input.stationName,
     kind: 'station-passed',
   });


### PR DESCRIPTION
Closes #1514

## Summary
- 2026-06-19 용마산 trip evidence: `08:29:22` / `08:30:21` 출발역 자체에서 station-passed fire 발생 (`fg | fired | station-passed | 용마산`).
- root cause: `useStationAlarm` GPS path에서 estimator default-hop이 `currentHopIndex=0`을 반환하면 `isStationWithinHopWindow`가 `[-1, 1]` window로 arc[0] (출발역 자기 자신) candidate를 통과시킴.
- lockless trip은 사용자가 origin에 도달한 신호가 아니라 estimator 초기값이므로 false positive — `lock=null && effectiveHopIndex=0 && candidateIndex=0`일 때 fire 차단.

## 변경
- `useStationAlarm.ts` GPS station-passed effect:
  - hop window 통과 후 `isOriginHopCandidate` 플래그 캡처
  - IIFE 안 `getBoardingLock()` 결과로 `lock=null + origin hop`이면 `logSuppressedOriginHopLockless` + return
- `alarmLog.ts`:
  - 신규 reason `'gate-origin-hop-lockless'` 추가
  - 신규 `logSuppressedOriginHopLockless` 함수 추가

## ADR-014 §4 동급 보장
- **lock 활성 trip**은 `boardingStationId` 기준 origin 알림이 정당 신호이므로 본 가드 미적용.
- BoardingTrainList 직접 탭 / boardingPrompt 응답으로 생성된 lock은 모두 우회 — 사용자 명시 의향 trip 동급 보장 유지.
- fg-arvlcd fast-path는 이미 `if (!lock) return;` 가드가 있어 lockless 케이스 미존재 → 본 PR에서 변경 없음.

## 테스트
- `useStationAlarm.test.ts` `#1514 lockless origin hop 차단` describe 신규 4건:
  - lockless + currentHopIndex=0 + arc[0] → suppressed
  - lock 활성 + currentHopIndex=0 + arc[0] (= boardingStationId) → 통과
  - lockless + currentHopIndex=0 + arc[1] (다음 hop) → 통과
  - lockless + currentHopIndex=2 + arc[2] (중간 hop) → 통과
- `alarmLog.test.ts` `logSuppressedOriginHopLockless` 1건 추가
- 전체 6606 tests pass, coverage 100%

## Test plan
- [ ] 실기기 lockless 출발역 정지 → origin hop fire 0건 확인 (alarmLog `gate-origin-hop-lockless` 적재)
- [ ] BoardingTrainList 직접 탭 trip → 출발역 origin 알림 정상 동작 (lock 활성 우회 동작)
- [ ] lockless 진행 중 첫 hop 통과(arc[1])에서 station-passed 정상 fire