### PR TITLE
chore(#1519): scripts/snapshot-trip-kv.sh — trip KV 주기 캡처 도구

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "validate:data": "node scripts/validate-stations.js",
     "check:infoplist": "bash scripts/check-infoplist-sync.sh",
     "tail:capture": "scripts/capture-tail.sh",
+    "kv:snapshot": "scripts/snapshot-trip-kv.sh",
     "measure:blocked-reasons": "scripts/capture-blocked-reasons.sh",
     "measure:blocked-reasons:aggregate": "node scripts/aggregate-blocked-reasons.js",
     "perf:report": "node scripts/perf-report.js",

--- a/scripts/__tests__/snapshot-trip-kv.test.js
+++ b/scripts/__tests__/snapshot-trip-kv.test.js
@@ -18,12 +18,28 @@ const BASH = '/bin/bash';
 
 function makeMockWrangler(tmpDir, payload) {
   const mockPath = path.join(tmpDir, 'mock-wrangler.sh');
+  const escaped = payload.replaceAll("'", String.raw`'\''`);
   fs.writeFileSync(
     mockPath,
-    `#!/bin/bash\nprintf '%s' '${payload.replace(/'/g, "'\\''")}'\n`,
+    `#!/bin/bash\nprintf '%s' '${escaped}'\n`,
     { mode: 0o755 },
   );
   return mockPath;
+}
+
+function runSnapshot(prefix, payload) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'snap-kv-'));
+  const mock = makeMockWrangler(tmp, payload);
+  const res = spawnSync(
+    BASH,
+    [SCRIPT, prefix, '--interval=1', '--duration=1'],
+    { encoding: 'utf8', env: { ...process.env, WRANGLER_BIN: mock }, timeout: 15000 },
+  );
+  expect(res.status).toBe(0);
+  const out = latestSnapshotFile(prefix);
+  expect(out).toBeTruthy();
+  const lines = readNdjson(out);
+  return { lines, cleanup: () => fs.unlinkSync(out) };
 }
 
 function readNdjson(file) {
@@ -69,55 +85,27 @@ describe('snapshot-trip-kv.sh', () => {
   });
 
   test('captures one sample with valid JSON KV payload', () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'snap-kv-'));
-    const prefix = 'deadbeef';
-    const mock = makeMockWrangler(tmp, '{"currentLine":"2","lock":{"active":true,"stationName":"강남"}}');
-    const res = spawnSync(
-      BASH,
-      [SCRIPT, prefix, '--interval=1', '--duration=1'],
-      { encoding: 'utf8', env: { ...process.env, WRANGLER_BIN: mock }, timeout: 15000 },
+    const { lines, cleanup } = runSnapshot(
+      'deadbeef',
+      '{"currentLine":"2","lock":{"active":true,"stationName":"강남"}}',
     );
-    expect(res.status).toBe(0);
-    const out = latestSnapshotFile(prefix);
-    expect(out).toBeTruthy();
-    const lines = readNdjson(out);
     expect(lines.length).toBeGreaterThanOrEqual(1);
     expect(lines[0]).toMatchObject({ kv: { currentLine: '2' } });
     expect(typeof lines[0].ts).toBe('string');
-    fs.unlinkSync(out);
+    cleanup();
   });
 
   test('records null when KV returns empty', () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'snap-kv-'));
-    const prefix = 'cafebabe';
-    const mock = makeMockWrangler(tmp, '');
-    const res = spawnSync(
-      BASH,
-      [SCRIPT, prefix, '--interval=1', '--duration=1'],
-      { encoding: 'utf8', env: { ...process.env, WRANGLER_BIN: mock }, timeout: 15000 },
-    );
-    expect(res.status).toBe(0);
-    const out = latestSnapshotFile(prefix);
-    const lines = readNdjson(out);
+    const { lines, cleanup } = runSnapshot('cafebabe', '');
     expect(lines[0].kv).toBeNull();
     expect(lines[0].error).toBeUndefined();
-    fs.unlinkSync(out);
+    cleanup();
   });
 
   test('records error when KV returns non-JSON garbage', () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'snap-kv-'));
-    const prefix = 'feedface';
-    const mock = makeMockWrangler(tmp, 'not-json-output');
-    const res = spawnSync(
-      BASH,
-      [SCRIPT, prefix, '--interval=1', '--duration=1'],
-      { encoding: 'utf8', env: { ...process.env, WRANGLER_BIN: mock }, timeout: 15000 },
-    );
-    expect(res.status).toBe(0);
-    const out = latestSnapshotFile(prefix);
-    const lines = readNdjson(out);
+    const { lines, cleanup } = runSnapshot('feedface', 'not-json-output');
     expect(lines[0].kv).toBeNull();
     expect(lines[0].error).toMatch(/not-json-output/);
-    fs.unlinkSync(out);
+    cleanup();
   });
 });

--- a/scripts/__tests__/snapshot-trip-kv.test.js
+++ b/scripts/__tests__/snapshot-trip-kv.test.js
@@ -1,0 +1,123 @@
+/**
+ * snapshot-trip-kv.sh (#1519) — 인자 검증 + mock wrangler로 NDJSON 출력 동작 검증.
+ *
+ * 실제 wrangler/Cloudflare를 호출하지 않고 WRANGLER_BIN 환경변수로 mock 명령을 주입한다.
+ * --interval / --duration을 1초로 줄여 빠르게 1~2 sample만 캡처한다.
+ */
+
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SCRIPT = path.resolve(__dirname, '..', 'snapshot-trip-kv.sh');
+const BASH = '/bin/bash';
+
+function makeMockWrangler(tmpDir, payload) {
+  const mockPath = path.join(tmpDir, 'mock-wrangler.sh');
+  fs.writeFileSync(
+    mockPath,
+    `#!/bin/bash\nprintf '%s' '${payload.replace(/'/g, "'\\''")}'\n`,
+    { mode: 0o755 },
+  );
+  return mockPath;
+}
+
+function readNdjson(file) {
+  return fs
+    .readFileSync(file, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+function latestSnapshotFile(tokenPrefix) {
+  const dir = path.join(REPO_ROOT, 'tasks');
+  const files = fs
+    .readdirSync(dir)
+    .filter((f) => f.startsWith('trip-kv-') && f.endsWith(`-${tokenPrefix}.jsonl`))
+    .map((f) => path.join(dir, f));
+  files.sort();
+  return files.pop();
+}
+
+describe('snapshot-trip-kv.sh', () => {
+  test('rejects invalid tokenPrefix', () => {
+    const res = spawnSync(BASH, [SCRIPT, 'not-hex!'], { encoding: 'utf8' });
+    expect(res.status).toBe(2);
+    expect(res.stderr).toMatch(/tokenPrefix/);
+  });
+
+  test('rejects missing tokenPrefix', () => {
+    const res = spawnSync(BASH, [SCRIPT], { encoding: 'utf8' });
+    expect(res.status).toBe(2);
+    expect(res.stderr).toMatch(/tokenPrefix/);
+  });
+
+  test('rejects non-positive interval', () => {
+    const res = spawnSync(BASH, [SCRIPT, 'abcd', '--interval=0'], { encoding: 'utf8' });
+    expect(res.status).toBe(2);
+    expect(res.stderr).toMatch(/interval/);
+  });
+
+  test('rejects unknown flag', () => {
+    const res = spawnSync(BASH, [SCRIPT, 'abcd', '--nope=1'], { encoding: 'utf8' });
+    expect(res.status).toBe(2);
+  });
+
+  test('captures one sample with valid JSON KV payload', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'snap-kv-'));
+    const prefix = 'deadbeef';
+    const mock = makeMockWrangler(tmp, '{"currentLine":"2","lock":{"active":true,"stationName":"강남"}}');
+    const res = spawnSync(
+      BASH,
+      [SCRIPT, prefix, '--interval=1', '--duration=1'],
+      { encoding: 'utf8', env: { ...process.env, WRANGLER_BIN: mock }, timeout: 15000 },
+    );
+    expect(res.status).toBe(0);
+    const out = latestSnapshotFile(prefix);
+    expect(out).toBeTruthy();
+    const lines = readNdjson(out);
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    expect(lines[0]).toMatchObject({ kv: { currentLine: '2' } });
+    expect(typeof lines[0].ts).toBe('string');
+    fs.unlinkSync(out);
+  });
+
+  test('records null when KV returns empty', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'snap-kv-'));
+    const prefix = 'cafebabe';
+    const mock = makeMockWrangler(tmp, '');
+    const res = spawnSync(
+      BASH,
+      [SCRIPT, prefix, '--interval=1', '--duration=1'],
+      { encoding: 'utf8', env: { ...process.env, WRANGLER_BIN: mock }, timeout: 15000 },
+    );
+    expect(res.status).toBe(0);
+    const out = latestSnapshotFile(prefix);
+    const lines = readNdjson(out);
+    expect(lines[0].kv).toBeNull();
+    expect(lines[0].error).toBeUndefined();
+    fs.unlinkSync(out);
+  });
+
+  test('records error when KV returns non-JSON garbage', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'snap-kv-'));
+    const prefix = 'feedface';
+    const mock = makeMockWrangler(tmp, 'not-json-output');
+    const res = spawnSync(
+      BASH,
+      [SCRIPT, prefix, '--interval=1', '--duration=1'],
+      { encoding: 'utf8', env: { ...process.env, WRANGLER_BIN: mock }, timeout: 15000 },
+    );
+    expect(res.status).toBe(0);
+    const out = latestSnapshotFile(prefix);
+    const lines = readNdjson(out);
+    expect(lines[0].kv).toBeNull();
+    expect(lines[0].error).toMatch(/not-json-output/);
+    fs.unlinkSync(out);
+  });
+});

--- a/scripts/snapshot-trip-kv.sh
+++ b/scripts/snapshot-trip-kv.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# Trip KV snapshot — backend TRIPS KV의 trip:{tokenPrefix} 키를 주기적으로 캡처한다 (#1519).
+#
+# 사용:
+#   scripts/snapshot-trip-kv.sh <tokenPrefix> [--interval=60] [--duration=3600]
+#   예: scripts/snapshot-trip-kv.sh a1b2c3d4 --interval=30 --duration=1800
+#   npm run kv:snapshot -- a1b2c3d4 --interval=30    # ← npm 경유 시 -- 필수
+#
+# 인자:
+#   tokenPrefix    [A-Fa-f0-9]{4,16}. trip:<prefix> 키를 조회.
+#   --interval=N   샘플링 주기(초, 기본 60). 양의 정수.
+#   --duration=N   총 실행 시간(초, 기본 3600). 양의 정수.
+#
+# 요구사항: bash, npx(wrangler), Cloudflare 인증, 분석 시 jq.
+#
+# 동작:
+#   - backend/alarm-worker/wrangler.toml에서 worker name(SSOT)만 추출 (출력에 영향 X)
+#   - interval마다 `npx wrangler kv key get --binding=TRIPS "trip:<prefix>" --remote` 호출
+#   - 결과를 NDJSON으로 tasks/trip-kv-<timestamp>-<prefix>.jsonl 에 저장
+#       각 줄: {"ts":"<ISO>","kv":<parsed JSON or null>,"error":"<msg>"?}
+#   - duration 경과 후 종료. Ctrl+C로 즉시 종료 가능.
+#
+# 분석 팁 (jq 사용):
+#   - currentLine 시계열:
+#       jq -r '[.ts, (.kv.currentLine // "null")] | @tsv' tasks/trip-kv-*.jsonl
+#   - scheduledPushes 개수 변화:
+#       jq -r '[.ts, (.kv.scheduledPushes // [] | length)] | @tsv' tasks/trip-kv-*.jsonl
+#   - lock 활성 구간만:
+#       jq 'select(.kv.lock?.active == true) | {ts, station: .kv.lock.stationName}' tasks/trip-kv-*.jsonl
+#   - 두 스냅샷 사이 diff:
+#       jq -s '.[0].kv as $a | .[-1].kv as $b | {first:$a, last:$b}' tasks/trip-kv-*.jsonl
+#   - error 발생 시점:
+#       jq 'select(.error)' tasks/trip-kv-*.jsonl
+set -euo pipefail
+
+usage() {
+  sed -n '2,28p' "$0" >&2
+  exit "${1:-2}"
+}
+
+TOKEN_PREFIX=""
+INTERVAL=60
+DURATION=3600
+
+for arg in "$@"; do
+  case "$arg" in
+    --interval=*) INTERVAL="${arg#--interval=}" ;;
+    --duration=*) DURATION="${arg#--duration=}" ;;
+    -h|--help) usage 0 ;;
+    --*) echo "[snapshot-trip-kv] 알 수 없는 옵션: $arg" >&2; usage ;;
+    *)
+      if [[ -z "$TOKEN_PREFIX" ]]; then
+        TOKEN_PREFIX="$arg"
+      else
+        echo "[snapshot-trip-kv] tokenPrefix는 한 번만 지정해야 합니다: $arg" >&2
+        usage
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$TOKEN_PREFIX" ]]; then
+  echo "[snapshot-trip-kv] tokenPrefix 인자가 필요합니다." >&2
+  usage
+fi
+
+if [[ ! "$TOKEN_PREFIX" =~ ^[A-Fa-f0-9]{4,16}$ ]]; then
+  echo "[snapshot-trip-kv] tokenPrefix는 [A-Fa-f0-9]{4,16}이어야 합니다: $TOKEN_PREFIX" >&2
+  exit 2
+fi
+
+if [[ ! "$INTERVAL" =~ ^[1-9][0-9]*$ ]]; then
+  echo "[snapshot-trip-kv] --interval은 양의 정수여야 합니다: $INTERVAL" >&2
+  exit 2
+fi
+
+if [[ ! "$DURATION" =~ ^[1-9][0-9]*$ ]]; then
+  echo "[snapshot-trip-kv] --duration은 양의 정수여야 합니다: $DURATION" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WRANGLER_TOML="$REPO_ROOT/backend/alarm-worker/wrangler.toml"
+
+if [[ ! -f "$WRANGLER_TOML" ]]; then
+  echo "[snapshot-trip-kv] wrangler.toml을 찾을 수 없습니다: $WRANGLER_TOML" >&2
+  exit 1
+fi
+
+WORKER_NAME=$(awk -F'"' '/^name *=/ {print $2; exit}' "$WRANGLER_TOML")
+if [[ -z "$WORKER_NAME" ]]; then
+  echo "[snapshot-trip-kv] backend/alarm-worker/wrangler.toml에서 worker name을 추출하지 못했습니다." >&2
+  exit 1
+fi
+
+TS=$(date +%Y%m%d-%H%M%S)
+OUT="$REPO_ROOT/tasks/trip-kv-$TS-$TOKEN_PREFIX.jsonl"
+KEY="trip:$TOKEN_PREFIX"
+
+mkdir -p "$REPO_ROOT/tasks"
+
+# Allow tests/dry-runs to inject a fake wrangler binary.
+WRANGLER_BIN="${WRANGLER_BIN:-npx wrangler}"
+
+echo "[snapshot-trip-kv] worker: $WORKER_NAME"
+echo "[snapshot-trip-kv] key: $KEY"
+echo "[snapshot-trip-kv] interval: ${INTERVAL}s / duration: ${DURATION}s"
+echo "[snapshot-trip-kv] 저장 경로: $OUT"
+echo "[snapshot-trip-kv] Ctrl+C로 즉시 종료"
+echo
+
+cd "$REPO_ROOT/backend/alarm-worker"
+
+# json-string escape (백슬래시/큰따옴표/제어문자 최소 처리).
+json_escape() {
+  python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))' 2>/dev/null \
+    || node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>process.stdout.write(JSON.stringify(d)))'
+}
+
+snapshot_once() {
+  local now stdout rc line
+  now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  set +e
+  stdout=$($WRANGLER_BIN kv key get --binding=TRIPS "$KEY" --remote 2>&1)
+  rc=$?
+  set -e
+  if [[ $rc -ne 0 ]]; then
+    local err_json
+    err_json=$(printf '%s' "$stdout" | json_escape)
+    line=$(printf '{"ts":"%s","kv":null,"error":%s}' "$now" "$err_json")
+  elif [[ -z "$stdout" || "$stdout" == "null" ]]; then
+    line=$(printf '{"ts":"%s","kv":null}' "$now")
+  else
+    # If wrangler stdout is valid JSON, embed as-is; otherwise wrap as string under error.
+    if printf '%s' "$stdout" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{JSON.parse(d);process.exit(0)}catch(e){process.exit(1)}})' >/dev/null 2>&1; then
+      line=$(printf '{"ts":"%s","kv":%s}' "$now" "$stdout")
+    else
+      local raw_json
+      raw_json=$(printf '%s' "$stdout" | json_escape)
+      line=$(printf '{"ts":"%s","kv":null,"error":%s}' "$now" "$raw_json")
+    fi
+  fi
+  printf '%s\n' "$line" >> "$OUT"
+  printf '[snapshot-trip-kv] %s 1 sample appended\n' "$now"
+}
+
+START=$(date +%s)
+END=$(( START + DURATION ))
+
+while :; do
+  snapshot_once
+  NOW=$(date +%s)
+  REMAINING=$(( END - NOW ))
+  if (( REMAINING <= 0 )); then
+    break
+  fi
+  if (( REMAINING < INTERVAL )); then
+    sleep "$REMAINING"
+  else
+    sleep "$INTERVAL"
+  fi
+done
+
+echo "[snapshot-trip-kv] 완료. 총 출력: $OUT"


### PR DESCRIPTION
Closes #1519

## 변경 사항
- `scripts/snapshot-trip-kv.sh`: tokenPrefix 받아 backend TRIPS KV의 `trip:<prefix>` 키를 interval(기본 60s)마다 `npx wrangler kv key get --binding=TRIPS --remote`로 조회 → NDJSON으로 `tasks/trip-kv-<timestamp>-<prefix>.jsonl` 저장.
- worker name은 `backend/alarm-worker/wrangler.toml`에서 SSOT 추출 (`capture-tail.sh`와 동일 패턴).
- `tokenPrefix [A-Fa-f0-9]{4,16}` 정규식, `--interval/--duration` 양의 정수 검증, `set -euo pipefail`.
- `WRANGLER_BIN` 환경변수로 mock 주입 가능 → 테스트에서 실제 Cloudflare 호출 없이 검증.
- `scripts/__tests__/snapshot-trip-kv.test.js`: 인자 검증 4건 + valid JSON / empty / non-JSON garbage 3가지 응답 케이스 NDJSON 출력 검증 (총 7건, 모두 pass).
- `package.json`: `"kv:snapshot"` 스크립트 등록.

## 사용 예시
```bash
scripts/snapshot-trip-kv.sh a1b2c3d4 --interval=30 --duration=1800
npm run kv:snapshot -- a1b2c3d4 --interval=30 --duration=1800
```

## jq 분석 예시 (헤더에도 박제)
```bash
# currentLine 시계열
jq -r '[.ts, (.kv.currentLine // "null")] | @tsv' tasks/trip-kv-*.jsonl

# scheduledPushes 개수 변화
jq -r '[.ts, (.kv.scheduledPushes // [] | length)] | @tsv' tasks/trip-kv-*.jsonl

# 첫/마지막 스냅샷 diff
jq -s '.[0].kv as $a | .[-1].kv as $b | {first:$a, last:$b}' tasks/trip-kv-*.jsonl
```

## Acceptance
- [x] `bash -n scripts/snapshot-trip-kv.sh` 통과
- [x] mock wrangler로 1회 호출 시뮬레이션 (7건 jest 테스트 pass)
- [x] jq 분석 예시 헤더 + PR 본문에 박제

## 노트
- `scripts/`는 `collectCoverageFrom`(`src/**`)에 포함되지 않아 coverage 영향 없음.