### PR TITLE
fix(#1524): trip 종료 시 sticky station 명시 unlock + 위젯 storage clear

### DIFF
--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -14,12 +14,18 @@ import {
   LAST_UPLOADED_RECALL_TRIP_START_KEY,
   LA_DISMISSED_AT_KEY,
   SCHEDULED_NOTIFICATIONS_KEY,
+  STICKY_STATION_KEY,
 } from '../../../../shared/constants/storageKeys';
+
+const mockClearWidgetStation = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock')
 );
 jest.mock('expo-notifications');
+jest.mock('../../../widget/api/widgetStorage', () => ({
+  clearWidgetStation: () => mockClearWidgetStation(),
+}));
 
 describe('tripBoundCleanups', () => {
   beforeEach(() => {
@@ -57,6 +63,17 @@ describe('tripBoundCleanups', () => {
     // LA 재상승 허용. 누락 회귀가 발생하면 dismiss 후 새 trip 시작해도 LA가 살아나지 않음.
     expect(removedKeys).toContain(LA_DISMISSED_AT_KEY);
     expect(removedKeys).not.toContain(LAST_UPLOADED_RECALL_TRIP_START_KEY);
+    // #1524 — sticky station persisted lock도 trip 종료 시 제거되어야 함.
+    // hook 메모리 unlock만으로는 다음 FG 재마운트 hydrate가 stale lock을 부활시킴.
+    expect(removedKeys).toContain(STICKY_STATION_KEY);
+  });
+
+  it('#1524 — runTripBoundCleanups 실행 시 위젯 storage를 clear한다 (자동 하차 후 stale 차단)', async () => {
+    // trip 종료 시 위젯에는 trip 중 마지막 역이 남아 stale 상태로 노출됨.
+    // clearWidgetStation을 호출해 "감지 중" 상태로 즉시 전환.
+    mockClearWidgetStation.mockClear();
+    await runTripBoundCleanups();
+    expect(mockClearWidgetStation).toHaveBeenCalledTimes(1);
   });
 
   it('#773 — runTripBoundCleanups 실행 시 OS 사전 예약 큐를 cancel + storage clear한다 (옛 trip 알람 burst 차단)', async () => {

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -17,7 +17,9 @@ import {
   ALARM_EVENT_KEY,
   TRIP_STARTED_AT_KEY,
   LAST_UPLOADED_RECALL_TRIP_START_KEY,
+  STICKY_STATION_KEY,
 } from '../../../shared/constants/storageKeys';
+import { clearWidgetStation } from '../../widget/api/widgetStorage';
 import {
   clearFiredAlarms,
   clearLastNotifiedStationId,
@@ -88,6 +90,15 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   // #1501 (ADR-015 §10 P5 / PR-A) — trip 종료 시 corrId 제거. 다음 trip은 새 corrId를
   // 받고 rawSignalBuffer entry가 어느 trip 소속인지 명확해진다.
   clearTripCorrId,
+  // #1524 — trip 종료 시 sticky station persisted lock 제거. useStickyStation의 메모리 lock은
+  // motion.tripActive flip 감지로 즉시 해제되지만, BG silent push trip-ended 경로에서는 hook이
+  // 실행되지 않으므로 storage를 직접 제거해야 다음 FG 재마운트 hydrate가 stale lock을 부활
+  // 시키지 않는다(예: 자동 하차 후 현재역=군자 고착 회귀).
+  () => AsyncStorage.removeItem(STICKY_STATION_KEY),
+  // #1524 — trip 종료 시 위젯 stale 차단. saveStationToWidget은 sticky 또는 live 후보를 기준으로
+  // 저장하므로 trip 끝나도 위젯에는 trip 중 마지막 역이 남는다. clearWidgetStation으로 즉시
+  // "감지 중" 상태로 전환해 다음 fresh fix가 들어올 때까지 정확하지 않은 현재역 노출을 막는다.
+  clearWidgetStation,
 ];
 
 /**

--- a/src/features/nearest-station/hooks/__tests__/useStickyStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useStickyStation.test.ts
@@ -583,4 +583,81 @@ describe('useStickyStation (#876)', () => {
       expect(movedAwayEvents).toHaveLength(0);
     });
   });
+
+  // #1524 — trip-end flip 감지로 sticky lock 즉시 해제.
+  describe('#1524 — trip-ended unlock (자동 하차 후 stale lock 차단)', () => {
+    const lockSeoul = async (initialMotion: StickyMotionInput) => {
+      const hook = renderSticky({ fix: fixAt(seoul), motion: initialMotion });
+      await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+      hook.rerender({ fix: fixAt(seoul), motion: initialMotion });
+      hook.rerender({ fix: fixAt(seoul), motion: initialMotion });
+      await waitFor(() => expect(hook.result.current.locked?.id).toBe(seoul.id));
+      return hook;
+    };
+
+    it('motion.tripActive가 true→false로 flip되면 즉시 unlock + unlocked-trip-ended 이벤트', async () => {
+      const pushSpy = jest.spyOn(fusionDebugBuffer, 'pushFusionDebugEntry');
+      const removeSpy = jest.spyOn(AsyncStorage, 'removeItem');
+      const { result, rerender } = await lockSeoul({ tripActive: true });
+      pushSpy.mockClear();
+      removeSpy.mockClear();
+
+      // trip 종료 시뮬레이션: tripActive true→false flip. fix는 동일.
+      rerender({ fix: fixAt(seoul), motion: { tripActive: false } });
+      await waitFor(() => expect(result.current.locked).toBeNull());
+
+      expect(pushSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'sticky',
+          event: 'unlocked-trip-ended',
+          stationName: '서울역',
+        }),
+      );
+      // persisted lock도 정리.
+      await waitFor(() => expect(removeSpy).toHaveBeenCalledWith(STICKY_STATION_KEY));
+    });
+
+    it('lock 없는 상태에서 tripActive flip → no-op (이벤트 emit 안 함)', async () => {
+      const pushSpy = jest.spyOn(fusionDebugBuffer, 'pushFusionDebugEntry');
+      const { result, rerender } = renderSticky({
+        fix: fixAt(null),
+        motion: { tripActive: true },
+      });
+      await waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalled());
+      pushSpy.mockClear();
+
+      rerender({ fix: fixAt(null), motion: { tripActive: false } });
+      expect(result.current.locked).toBeNull();
+      expect(pushSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'unlocked-trip-ended' }),
+      );
+    });
+
+    it('tripActive가 undefined→false 전이는 unlock 트리거 아님 (true에서 내려간 게 아니므로)', async () => {
+      const pushSpy = jest.spyOn(fusionDebugBuffer, 'pushFusionDebugEntry');
+      // tripActive undefined로 lock.
+      const { result, rerender } = await lockSeoul({});
+      pushSpy.mockClear();
+
+      // undefined → false: 사용자 명시 trip 종료가 아닌 보조 신호 도착. lock 유지해야 함.
+      rerender({ fix: fixAt(seoul), motion: { tripActive: false } });
+      expect(result.current.locked?.id).toBe(seoul.id);
+      expect(pushSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'unlocked-trip-ended' }),
+      );
+    });
+
+    it('tripActive가 true 유지인 동안에는 unlock 안 함', async () => {
+      const pushSpy = jest.spyOn(fusionDebugBuffer, 'pushFusionDebugEntry');
+      const { result, rerender } = await lockSeoul({ tripActive: true });
+      pushSpy.mockClear();
+
+      rerender({ fix: fixAt(seoul), motion: { tripActive: true } });
+      rerender({ fix: fixAt(seoul), motion: { tripActive: true } });
+      expect(result.current.locked?.id).toBe(seoul.id);
+      expect(pushSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'unlocked-trip-ended' }),
+      );
+    });
+  });
 });

--- a/src/features/nearest-station/hooks/useStickyStation.ts
+++ b/src/features/nearest-station/hooks/useStickyStation.ts
@@ -21,6 +21,9 @@
  *   5. moved-away (#1317) — 저품질 fix(≤250m)여도 lock된 역에서 1km+ 떨어진 다른 역이
  *      STICKY_DEGRADED_UNLOCK_COUNT(3)회 연속 관찰되면 unlock. 좋은 fix가 안 잡히는 지하·도심
  *      협곡에서 출발역 lock이 고착되는 회귀 차단. 단발성 부정확 fix는 카운트가 리셋돼 안 풀린다.
+ *   6. trip-ended (#1524) — motion.tripActive가 true→false로 flip되면 즉시 unlock. 자동 하차/
+ *      목적지 클리어 직후 stale lock(예: 현재역=군자 고착)으로 위젯/메인 화면이 잘못된 역을
+ *      계속 보여주는 회귀 차단. tripBoundCleanups의 storage 정리와 일관된 동기 unlock.
  *
  * 명시적 unlock: 사용자가 지도탭 "현재위치"를 탭하면 releaseLock()으로 sticky를 비우고 live 위치를
  * 노출한다(호출자 useNearestStation의 requestCurrentLocation 경로).
@@ -201,6 +204,21 @@ export function useStickyStation(
 
   // releaseLock이 stale closure 없이 최신 lock/fix를 읽도록 ref를 동기화한다.
   lockedRef.current = locked;
+
+  // #1524 — tripActive true→false flip 감지(자동 하차 / 목적지 클리어 / silent push trip-ended).
+  // tripBoundCleanups가 STICKY_STATION_KEY storage를 지우지만, 메모리 lock은 다음 fix까지 남아
+  // 위젯/현재역 표시가 stale로 유지되는 회귀(예: 군자 고착)를 즉시 차단한다.
+  // 이전 tripActive 값을 ref로 추적해 transition만 잡는다(undefined→false 등은 무시).
+  const prevTripActiveRef = useRef<boolean | undefined>(motion.tripActive);
+  useEffect(() => {
+    const prev = prevTripActiveRef.current;
+    const next = motion.tripActive;
+    prevTripActiveRef.current = next;
+    if (prev !== true || next === true) return;
+    if (lockedRef.current == null) return;
+    emitMetric('unlocked-trip-ended', lockedRef.current, lastFixMetaRef.current);
+    clearLockState();
+  }, [motion.tripActive, clearLockState]);
 
   // 매 fix마다 lock/unlock 평가. hydrate 완료 전엔 평가 보류 (race 방지).
   useEffect(() => {

--- a/src/features/nearest-station/utils/fusionDebugBuffer.ts
+++ b/src/features/nearest-station/utils/fusionDebugBuffer.ts
@@ -74,7 +74,10 @@ export type StickyStationEvent =
   // #1317 — 저품질 GPS에서 1km+ 멀어진 다른 역 fix가 N회 연속 관찰돼 unlock.
   | 'unlocked-moved-away'
   // #1317 — 사용자가 지도탭 "현재위치"를 명시적으로 탭해 unlock(live 위치 요청).
-  | 'unlocked-manual';
+  | 'unlocked-manual'
+  // #1524 — trip이 종료(tripActive true→false)되면 sticky lock도 즉시 해제.
+  // 자동 하차 후 stale lock(예: 현재역=군자 고착) 회귀 차단.
+  | 'unlocked-trip-ended';
 
 export interface StickyStationEntry {
   kind: 'sticky';


### PR DESCRIPTION
Closes #1524

## 문제

2026-06-19 실측 회귀 — 자동 하차 후에도 sticky station이 trip 중 마지막 역(예: 군자)에 그대로 lock 되어 메인 현재역/위젯이 stale 상태로 노출.

`useStickyStation`의 기존 unlock trigger 6종(distance/motion/ttl/better-fix/moved-away/manual)에 **trip-end 명시 unlock**이 없어, 좋은 fix가 들어와 better-fix로 자연 갱신될 때까지 stale lock이 유지되는 구조였다.

## 변경

### 1. `useStickyStation` — trip-active flip 감지 effect (`src/features/nearest-station/hooks/useStickyStation.ts`)

`motion.tripActive`가 `true → false`로 flip되면 즉시 sticky lock 해제 + `unlocked-trip-ended` metric emit. 이전 값을 ref로 추적해 transition만 잡는다 — `undefined → false` 같은 보조 신호 도착은 무시(false positive 차단).

### 2. `StickyStationEvent` 확장 (`src/features/nearest-station/utils/fusionDebugBuffer.ts`)

`'unlocked-trip-ended'` 추가 — fusionDebugBuffer에서 trip flip 경로를 distance/motion/ttl/manual과 구분해 사후 분석 가능.

### 3. `TRIP_BOUND_CLEANUPS`에 2개 항목 추가 (`src/features/alarm/store/tripBoundCleanups.ts`)

- `STICKY_STATION_KEY` removeItem — BG silent push trip-ended 경로처럼 hook이 실행되지 않는 상황에서도 persisted lock을 비워, 다음 FG 재마운트 hydrate가 stale lock을 부활시키지 않는다.
- `clearWidgetStation` — 위젯에 남은 trip 중 마지막 역을 즉시 "감지 중" 상태로 전환.

→ FG (`useStickyStation` hook flip) + BG (`silentPushTask` → `runTripBoundCleanups`) 양쪽 경로 모두 커버.

## 양방향 layer 추적

- **sticky (memory)**: `useStickyStation` tripActive flip effect → `clearLockState()` + `emitMetric('unlocked-trip-ended')`
- **sticky (storage)**: `tripBoundCleanups` STICKY_STATION_KEY removeItem (BG 경로 보장)
- **widget (storage)**: `tripBoundCleanups` clearWidgetStation
- **observability**: `fusionDebugBuffer` `StickyStationEntry { event: 'unlocked-trip-ended' }`

## 테스트

- `useStickyStation.test.ts` — #1524 describe block (4 케이스):
  - true → false flip → 즉시 unlock + unlocked-trip-ended emit + STICKY_STATION_KEY removeItem
  - lock 없을 때 flip → no-op (이벤트 emit 없음)
  - undefined → false 전이 → unlock 트리거 아님 (true에서 내려간 게 아니므로)
  - true 유지 → lock 보존
- `tripBoundCleanups.test.ts` — STICKY_STATION_KEY removeItem 검증 + clearWidgetStation 1회 호출 검증
- 기존 D6 (#1212) 지하 + trip 활성 케이스(`automotive + tripActive: false` flip)에서 unlock 사유가 변경되지 않음을 확인 (그 케이스는 prev=`{}` 즉 undefined → false 이므로 새 effect 비-트리거).
- `npm test` 전체 6646건 통과, 100% coverage 유지
- `npm run type-check` / `npm run lint` clean

## Acceptance (실기기 검증 필요)

- 실기기 trip 종료 직후 sticky `unlocked-trip-ended` entry 발생
- 위젯 현재역 stale 0건
- 1주 trip 회귀(자동 하차 후 stale lock) 0건