### PR TITLE
feat(#1520): backend /signals/dump endpoint + RAW_SIGNALS KV + device retry queue

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -3355,18 +3355,18 @@ describe('POST /trips — #1425 trip-recently-ended reject', () => {
   });
 });
 
-describe('POST /signals/dump (#1520)', () => {
-  function rawSignalsEnv(): Env {
-    return makeEnv({ RAW_SIGNALS: new InMemoryKV() as unknown as KVNamespace });
-  }
-  function dumpBody(): Record<string, unknown> {
-    return {
-      corrId: '1700000000000-deadbeef',
-      token: 'aabbccdd11223344',
-      entries: [{ ts: 1, kind: 'cycle' }, { ts: 2, kind: 'enter' }],
-    };
-  }
+function rawSignalsEnv(): Env {
+  return makeEnv({ RAW_SIGNALS: new InMemoryKV() as unknown as KVNamespace });
+}
+function dumpBody(): Record<string, unknown> {
+  return {
+    corrId: '1700000000000-deadbeef',
+    token: 'aabbccdd11223344',
+    entries: [{ ts: 1, kind: 'cycle' }, { ts: 2, kind: 'enter' }],
+  };
+}
 
+describe('POST /signals/dump (#1520)', () => {
   it('returns 503 when RAW_SIGNALS binding is missing (graceful)', async () => {
     const env = makeEnv();
     const res = await post('/signals/dump', dumpBody(), env);
@@ -3403,66 +3403,70 @@ describe('POST /signals/dump (#1520)', () => {
 
     const stored = await env.RAW_SIGNALS!.get('dump:1700000000000-deadbeef');
     expect(stored).not.toBeNull();
-    const parsed = JSON.parse(stored!);
+    const parsed = JSON.parse(stored ?? '');
     expect(parsed.tokenPrefix).toBe('aabbccdd');
     expect(parsed.entries.length).toBe(2);
     expect(typeof parsed.uploadedAt).toBe('number');
   });
 });
 
+function makeAdminRawSignalsEnv(): Env {
+  return makeEnv({
+    RAW_SIGNALS: new InMemoryKV() as unknown as KVNamespace,
+    ADMIN_TOKEN: 'secret',
+  });
+}
+
+async function getAdminSignalsExport(
+  env: Env,
+  query: string,
+  auth?: string,
+): Promise<Response> {
+  return app.fetch(
+    new Request(`http://example.com/admin/signals/export${query}`, {
+      method: 'GET',
+      headers: auth ? { authorization: auth } : {},
+    }),
+    env,
+  );
+}
+
 describe('GET /admin/signals/export (#1520)', () => {
-  function makeAdminRawSignalsEnv(): Env {
-    return makeEnv({
-      RAW_SIGNALS: new InMemoryKV() as unknown as KVNamespace,
-      ADMIN_TOKEN: 'secret',
-    });
-  }
-
-  async function get(env: Env, query: string, auth?: string): Promise<Response> {
-    return app.fetch(
-      new Request(`http://example.com/admin/signals/export${query}`, {
-        method: 'GET',
-        headers: auth ? { authorization: auth } : {},
-      }),
-      env,
-    );
-  }
-
   it('returns 503 when ADMIN_TOKEN not configured', async () => {
     const env = makeEnv({ RAW_SIGNALS: new InMemoryKV() as unknown as KVNamespace });
-    const res = await get(env, '?corrId=1700000000000-deadbeef', 'Bearer x');
+    const res = await getAdminSignalsExport(env, '?corrId=1700000000000-deadbeef', 'Bearer x');
     expect(res.status).toBe(503);
   });
 
   it('returns 401 when auth header missing', async () => {
     const env = makeAdminRawSignalsEnv();
-    const res = await get(env, '?corrId=1700000000000-deadbeef');
+    const res = await getAdminSignalsExport(env, '?corrId=1700000000000-deadbeef');
     expect(res.status).toBe(401);
   });
 
   it('returns 503 when RAW_SIGNALS binding missing', async () => {
     const env = makeEnv({ ADMIN_TOKEN: 'secret' });
-    const res = await get(env, '?corrId=1700000000000-deadbeef', 'Bearer secret');
+    const res = await getAdminSignalsExport(env, '?corrId=1700000000000-deadbeef', 'Bearer secret');
     expect(res.status).toBe(503);
   });
 
   it('returns 400 when corrId param missing', async () => {
     const env = makeAdminRawSignalsEnv();
-    const res = await get(env, '', 'Bearer secret');
+    const res = await getAdminSignalsExport(env, '', 'Bearer secret');
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: 'invalid_corrId' });
   });
 
   it('returns 404 when corrId pattern invalid', async () => {
     const env = makeAdminRawSignalsEnv();
-    const res = await get(env, '?corrId=bad', 'Bearer secret');
+    const res = await getAdminSignalsExport(env, '?corrId=bad', 'Bearer secret');
     expect(res.status).toBe(404);
     expect(await res.json()).toEqual({ error: 'not_found' });
   });
 
   it('returns 404 when no stored dump for corrId', async () => {
     const env = makeAdminRawSignalsEnv();
-    const res = await get(env, '?corrId=1700000000000-deadbeef', 'Bearer secret');
+    const res = await getAdminSignalsExport(env, '?corrId=1700000000000-deadbeef', 'Bearer secret');
     expect(res.status).toBe(404);
   });
 
@@ -3477,7 +3481,7 @@ describe('GET /admin/signals/export (#1520)', () => {
       },
       env,
     );
-    const res = await get(env, '?corrId=1700000000000-deadbeef', 'Bearer secret');
+    const res = await getAdminSignalsExport(env, '?corrId=1700000000000-deadbeef', 'Bearer secret');
     expect(res.status).toBe(200);
     const body = await res.json() as {
       corrId: string;

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -3354,3 +3354,139 @@ describe('POST /trips — #1425 trip-recently-ended reject', () => {
     expect(await env.TRIPS.get('trip:fresh-token')).not.toBeNull();
   });
 });
+
+describe('POST /signals/dump (#1520)', () => {
+  function rawSignalsEnv(): Env {
+    return makeEnv({ RAW_SIGNALS: new InMemoryKV() as unknown as KVNamespace });
+  }
+  function dumpBody(): Record<string, unknown> {
+    return {
+      corrId: '1700000000000-deadbeef',
+      token: 'aabbccdd11223344',
+      entries: [{ ts: 1, kind: 'cycle' }, { ts: 2, kind: 'enter' }],
+    };
+  }
+
+  it('returns 503 when RAW_SIGNALS binding is missing (graceful)', async () => {
+    const env = makeEnv();
+    const res = await post('/signals/dump', dumpBody(), env);
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'raw_signals_unavailable' });
+  });
+
+  it('returns 400 on invalid JSON', async () => {
+    const env = rawSignalsEnv();
+    const res = await post('/signals/dump', 'not-json{', env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_json' });
+  });
+
+  it('returns 400 on invalid payload (bad corrId)', async () => {
+    const env = rawSignalsEnv();
+    const res = await post('/signals/dump', { ...dumpBody(), corrId: 'bad' }, env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_payload' });
+  });
+
+  it('returns 400 when entries exceeds cap', async () => {
+    const env = rawSignalsEnv();
+    const tooMany = Array.from({ length: 501 }, (_, i) => ({ ts: i }));
+    const res = await post('/signals/dump', { ...dumpBody(), entries: tooMany }, env);
+    expect(res.status).toBe(400);
+  });
+
+  it('stores entries under dump:{corrId} with TTL', async () => {
+    const env = rawSignalsEnv();
+    const res = await post('/signals/dump', dumpBody(), env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, accepted: 2 });
+
+    const stored = await env.RAW_SIGNALS!.get('dump:1700000000000-deadbeef');
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored!);
+    expect(parsed.tokenPrefix).toBe('aabbccdd');
+    expect(parsed.entries.length).toBe(2);
+    expect(typeof parsed.uploadedAt).toBe('number');
+  });
+});
+
+describe('GET /admin/signals/export (#1520)', () => {
+  function makeAdminRawSignalsEnv(): Env {
+    return makeEnv({
+      RAW_SIGNALS: new InMemoryKV() as unknown as KVNamespace,
+      ADMIN_TOKEN: 'secret',
+    });
+  }
+
+  async function get(env: Env, query: string, auth?: string): Promise<Response> {
+    return app.fetch(
+      new Request(`http://example.com/admin/signals/export${query}`, {
+        method: 'GET',
+        headers: auth ? { authorization: auth } : {},
+      }),
+      env,
+    );
+  }
+
+  it('returns 503 when ADMIN_TOKEN not configured', async () => {
+    const env = makeEnv({ RAW_SIGNALS: new InMemoryKV() as unknown as KVNamespace });
+    const res = await get(env, '?corrId=1700000000000-deadbeef', 'Bearer x');
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 401 when auth header missing', async () => {
+    const env = makeAdminRawSignalsEnv();
+    const res = await get(env, '?corrId=1700000000000-deadbeef');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 503 when RAW_SIGNALS binding missing', async () => {
+    const env = makeEnv({ ADMIN_TOKEN: 'secret' });
+    const res = await get(env, '?corrId=1700000000000-deadbeef', 'Bearer secret');
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 400 when corrId param missing', async () => {
+    const env = makeAdminRawSignalsEnv();
+    const res = await get(env, '', 'Bearer secret');
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_corrId' });
+  });
+
+  it('returns 404 when corrId pattern invalid', async () => {
+    const env = makeAdminRawSignalsEnv();
+    const res = await get(env, '?corrId=bad', 'Bearer secret');
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'not_found' });
+  });
+
+  it('returns 404 when no stored dump for corrId', async () => {
+    const env = makeAdminRawSignalsEnv();
+    const res = await get(env, '?corrId=1700000000000-deadbeef', 'Bearer secret');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 200 with stored dump after upload', async () => {
+    const env = makeAdminRawSignalsEnv();
+    await post(
+      '/signals/dump',
+      {
+        corrId: '1700000000000-deadbeef',
+        token: 'aabbccdd11223344',
+        entries: [{ ts: 1 }],
+      },
+      env,
+    );
+    const res = await get(env, '?corrId=1700000000000-deadbeef', 'Bearer secret');
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      corrId: string;
+      tokenPrefix: string;
+      entries: unknown[];
+      uploadedAt: number;
+    };
+    expect(body.corrId).toBe('1700000000000-deadbeef');
+    expect(body.tokenPrefix).toBe('aabbccdd');
+    expect(body.entries.length).toBe(1);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/rawSignalDump.test.ts
+++ b/backend/alarm-worker/src/__tests__/rawSignalDump.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CORR_ID_PATTERN,
+  MAX_DUMP_ENTRIES,
+  RAW_SIGNAL_DUMP_KEY_PREFIX,
+  RAW_SIGNAL_DUMP_TTL_SEC,
+  dumpKey,
+  readSignalDump,
+  storeSignalDump,
+  validateSignalDumpUpload,
+} from '../rawSignalDump';
+import { InMemoryKV } from './inMemoryKv';
+
+function validBody(): Record<string, unknown> {
+  return {
+    corrId: '1700000000000-deadbeef',
+    token: 'aabbccdd11223344',
+    entries: [{ ts: 1, kind: 'cycle' }, { ts: 2, kind: 'enter' }],
+  };
+}
+
+describe('CORR_ID_PATTERN', () => {
+  it('accepts valid format', () => {
+    expect(CORR_ID_PATTERN.test('1700000000000-deadbeef')).toBe(true);
+    expect(CORR_ID_PATTERN.test('1-00000000')).toBe(true);
+  });
+
+  it('rejects invalid format', () => {
+    expect(CORR_ID_PATTERN.test('foo')).toBe(false);
+    expect(CORR_ID_PATTERN.test('1700000000000-DEADBEEF')).toBe(false); // uppercase
+    expect(CORR_ID_PATTERN.test('1700000000000-dead')).toBe(false); // <8 hex
+    expect(CORR_ID_PATTERN.test('abc-deadbeef')).toBe(false); // non-digit prefix
+  });
+});
+
+describe('dumpKey', () => {
+  it('prefixes corrId', () => {
+    expect(dumpKey('xyz')).toBe(`${RAW_SIGNAL_DUMP_KEY_PREFIX}xyz`);
+  });
+});
+
+describe('validateSignalDumpUpload', () => {
+  it('accepts valid payload', () => {
+    const out = validateSignalDumpUpload(validBody());
+    expect(out).not.toBeNull();
+    expect(out?.corrId).toBe('1700000000000-deadbeef');
+    expect(out?.entries.length).toBe(2);
+  });
+
+  it('rejects non-object input', () => {
+    expect(validateSignalDumpUpload(null)).toBeNull();
+    expect(validateSignalDumpUpload('x')).toBeNull();
+    expect(validateSignalDumpUpload(42)).toBeNull();
+  });
+
+  it('rejects bad corrId format', () => {
+    expect(validateSignalDumpUpload({ ...validBody(), corrId: 'bad' })).toBeNull();
+    expect(validateSignalDumpUpload({ ...validBody(), corrId: 123 })).toBeNull();
+  });
+
+  it('rejects empty token', () => {
+    expect(validateSignalDumpUpload({ ...validBody(), token: '' })).toBeNull();
+    expect(validateSignalDumpUpload({ ...validBody(), token: 42 })).toBeNull();
+  });
+
+  it('rejects non-array entries', () => {
+    expect(validateSignalDumpUpload({ ...validBody(), entries: 'x' })).toBeNull();
+    expect(validateSignalDumpUpload({ ...validBody(), entries: {} })).toBeNull();
+  });
+
+  it('rejects empty entries', () => {
+    expect(validateSignalDumpUpload({ ...validBody(), entries: [] })).toBeNull();
+  });
+
+  it('rejects entries above cap', () => {
+    const tooMany = Array.from({ length: MAX_DUMP_ENTRIES + 1 }, (_, i) => ({ ts: i }));
+    expect(validateSignalDumpUpload({ ...validBody(), entries: tooMany })).toBeNull();
+  });
+
+  it('accepts entries exactly at cap', () => {
+    const exact = Array.from({ length: MAX_DUMP_ENTRIES }, (_, i) => ({ ts: i }));
+    expect(validateSignalDumpUpload({ ...validBody(), entries: exact })).not.toBeNull();
+  });
+
+  it('rejects primitive entries (non-object)', () => {
+    expect(
+      validateSignalDumpUpload({ ...validBody(), entries: [1, 2] }),
+    ).toBeNull();
+    expect(
+      validateSignalDumpUpload({ ...validBody(), entries: [null] }),
+    ).toBeNull();
+  });
+});
+
+describe('storeSignalDump / readSignalDump', () => {
+  it('writes tokenPrefix(8) + entries + uploadedAt', async () => {
+    const kv = new InMemoryKV();
+    const upload = validateSignalDumpUpload(validBody())!;
+    await storeSignalDump(kv as unknown as KVNamespace, upload, 9999);
+
+    const raw = await kv.get(dumpKey(upload.corrId));
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.tokenPrefix).toBe('aabbccdd'); // 8자 prefix
+    expect(parsed.entries.length).toBe(2);
+    expect(parsed.uploadedAt).toBe(9999);
+  });
+
+  it('sets 60-day TTL', async () => {
+    const kv = new InMemoryKV();
+    const putSpy = vi.fn(kv.put.bind(kv));
+    (kv as unknown as { put: typeof putSpy }).put = putSpy;
+    const upload = validateSignalDumpUpload(validBody())!;
+    await storeSignalDump(kv as unknown as KVNamespace, upload, 0);
+    expect(putSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      { expirationTtl: RAW_SIGNAL_DUMP_TTL_SEC },
+    );
+  });
+
+  it('readSignalDump round-trips', async () => {
+    const kv = new InMemoryKV();
+    const upload = validateSignalDumpUpload(validBody())!;
+    await storeSignalDump(kv as unknown as KVNamespace, upload, 12345);
+    const stored = await readSignalDump(
+      kv as unknown as KVNamespace,
+      upload.corrId,
+    );
+    expect(stored).not.toBeNull();
+    expect(stored?.tokenPrefix).toBe('aabbccdd');
+    expect(stored?.uploadedAt).toBe(12345);
+    expect(stored?.entries.length).toBe(2);
+  });
+
+  it('readSignalDump returns null for invalid corrId pattern', async () => {
+    const kv = new InMemoryKV();
+    const out = await readSignalDump(kv as unknown as KVNamespace, 'bad');
+    expect(out).toBeNull();
+  });
+
+  it('readSignalDump returns null for missing key', async () => {
+    const kv = new InMemoryKV();
+    const out = await readSignalDump(
+      kv as unknown as KVNamespace,
+      '1700000000000-deadbeef',
+    );
+    expect(out).toBeNull();
+  });
+
+  it('readSignalDump returns null for corrupt JSON', async () => {
+    const kv = new InMemoryKV();
+    await kv.put(dumpKey('1700000000000-deadbeef'), 'not-json{');
+    const out = await readSignalDump(
+      kv as unknown as KVNamespace,
+      '1700000000000-deadbeef',
+    );
+    expect(out).toBeNull();
+  });
+
+  it('readSignalDump returns null when stored shape is wrong', async () => {
+    const kv = new InMemoryKV();
+    await kv.put(dumpKey('1700000000000-deadbeef'), JSON.stringify({ entries: 'x' }));
+    const out = await readSignalDump(
+      kv as unknown as KVNamespace,
+      '1700000000000-deadbeef',
+    );
+    expect(out).toBeNull();
+  });
+
+  it('readSignalDump returns null when stored payload is null literal', async () => {
+    const kv = new InMemoryKV();
+    await kv.put(dumpKey('1700000000000-deadbeef'), 'null');
+    const out = await readSignalDump(
+      kv as unknown as KVNamespace,
+      '1700000000000-deadbeef',
+    );
+    expect(out).toBeNull();
+  });
+});

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -49,6 +49,12 @@ import {
   recordRecallUpload,
   validateRecallUpload,
 } from './recallTelemetry';
+import {
+  MAX_DUMP_ENTRIES,
+  readSignalDump,
+  storeSignalDump,
+  validateSignalDumpUpload,
+} from './rawSignalDump';
 import { MIN_RECALL_RATIO_THRESHOLD, RECALL_THRESHOLD_CRITICAL } from './metrics';
 import { RECALL_DATASET, RECALL_OPS_PAGE_URL, RECALL_QUERIES } from './recallQueries';
 import {
@@ -718,6 +724,83 @@ app.get('/admin/telemetry/regressions', async (c) => {
   if (authError) return c.json({ error: authError.code }, authError.status);
   const counts = await readRegressionCounters(c.env.TRIPS, Date.now());
   return c.json({ ids: KNOWN_REGRESSION_IDS, counts });
+});
+
+/**
+ * Device raw signal dump upload (#1520, ADR-015 §10 P5 / PR-B).
+ *
+ * Trip 종료 시 device가 `useFusedNearestStation` ring buffer(capacity 120)을 한 번 보낸다.
+ * KV에 `dump:{corrId}` 키로 60일 TTL 적재 — 운영자가 `/admin/signals/export?corrId=`로 조회.
+ *
+ * Body: { corrId, token, entries[] }
+ *   - corrId: `${epoch ms}-${8 hex}` 형식 (device tripCorrId.ts와 정합)
+ *   - token: APNs device token (8자 prefix만 KV에 저장 — PII 보호)
+ *   - entries: RawSignalEntry[] (1~500개, schema 검증은 device 책임 — forward compat)
+ *
+ * Response:
+ *   200 { ok: true, accepted: N }      — 정상 적재
+ *   400 { error: 'invalid_json' | 'invalid_payload' }
+ *   503 { error: 'raw_signals_unavailable' } — RAW_SIGNALS binding 미설정 (개발 환경 호환)
+ *
+ * Idempotency: 같은 corrId 재호출은 덮어쓰기 — device가 outbox flush로 retry해도
+ *   server side에서 별도 dedup 불필요 (entries는 동일 trip의 동일 buffer 스냅샷).
+ */
+app.post('/signals/dump', async (c) => {
+  const kv = c.env.RAW_SIGNALS;
+  if (!kv) return c.json({ error: 'raw_signals_unavailable' }, 503);
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_json' }, 400);
+  }
+
+  const payload = validateSignalDumpUpload(body);
+  if (!payload) return c.json({ error: 'invalid_payload' }, 400);
+
+  await storeSignalDump(kv, payload, Date.now());
+
+  console.log(
+    JSON.stringify({
+      msg: 'signal dump stored',
+      tokenPrefix: tokenPrefix(payload.token),
+      corrId: payload.corrId,
+      entries: payload.entries.length,
+      maxEntries: MAX_DUMP_ENTRIES,
+    }),
+  );
+  return c.json({ ok: true, accepted: payload.entries.length });
+});
+
+/**
+ * Raw signal dump export (#1520). 운영자가 corrId로 적재된 dump를 조회한다.
+ *
+ * Auth: `Authorization: Bearer <ADMIN_TOKEN>` — admin endpoint 공통 정책.
+ * Query: `?corrId={cid}` — 필수.
+ *
+ * Response:
+ *   200 { corrId, tokenPrefix, entries[], uploadedAt }
+ *   400 { error: 'invalid_corrId' }
+ *   404 { error: 'not_found' }
+ *   401/503: 인증/binding 정책 동일 (`/admin/feedback` 패턴).
+ */
+app.get('/admin/signals/export', async (c) => {
+  const authError = checkAdminAuth(c.req.header('authorization'), c.env.ADMIN_TOKEN);
+  if (authError) return c.json({ error: authError.code }, authError.status);
+  const kv = c.env.RAW_SIGNALS;
+  if (!kv) return c.json({ error: 'raw_signals_unavailable' }, 503);
+
+  const corrId = c.req.query('corrId');
+  if (!corrId) return c.json({ error: 'invalid_corrId' }, 400);
+
+  const stored = await readSignalDump(kv, corrId);
+  if (!stored) {
+    // invalid pattern과 not-found를 같은 응답으로 구분 — readSignalDump가 pattern 위반 시 null 반환.
+    // 호출자(운영자) 입장에서 둘 다 "조회 불가" 동일 의미이므로 404로 정렬.
+    return c.json({ error: 'not_found' }, 404);
+  }
+  return c.json({ corrId, ...stored });
 });
 
 /**

--- a/backend/alarm-worker/src/rawSignalDump.ts
+++ b/backend/alarm-worker/src/rawSignalDump.ts
@@ -1,0 +1,99 @@
+/**
+ * Raw signal dump endpoint helpers (#1520, ADR-015 §10 P5 / PR-B).
+ *
+ * Device가 trip 종료 시 `useFusedNearestStation`의 raw signal ring buffer를 backend KV에
+ * 60일 누적해 사후 회귀 분석에 사용한다. PR-A(device buffer/corrId)와 짝.
+ *
+ * Privacy:
+ *  - token은 8자 prefix로 익명화 (`tokenPrefix`와 동일 정책).
+ *  - entries는 fusion 측정값(GPS/motion/source/confidence/arvlCd 등) — 원문 사용자 식별자 없음.
+ *  - corrId는 `${epoch ms}-${8 hex}` — device-local 생성, 사용자 식별 불가.
+ */
+import { tokenPrefix } from './telemetry';
+
+/** corrId 형식 — `${epoch ms}-${8 hex}` (device tripCorrId.ts와 정합). */
+export const CORR_ID_PATTERN = /^\d+-[0-9a-f]{8}$/;
+
+/** entries 수 cap — device buffer capacity(120) × 안전 여유. 초과 시 400. */
+export const MAX_DUMP_ENTRIES = 500;
+
+/** KV TTL — 60일. */
+export const RAW_SIGNAL_DUMP_TTL_SEC = 60 * 24 * 3600;
+
+/** KV key prefix — `dump:{corrId}`. export endpoint도 동일 prefix. */
+export const RAW_SIGNAL_DUMP_KEY_PREFIX = 'dump:';
+
+export function dumpKey(corrId: string): string {
+  return `${RAW_SIGNAL_DUMP_KEY_PREFIX}${corrId}`;
+}
+
+export interface SignalDumpUpload {
+  corrId: string;
+  token: string;
+  /**
+   * Raw signal entries — device 측 `RawSignalEntry[]`와 정합.
+   * backend는 schema 검증 안 한다 (forward compat — device가 새 필드 추가해도 KV에 그대로 적재).
+   * 단 배열 + 객체임은 검사한다.
+   */
+  entries: unknown[];
+}
+
+export interface SignalDumpStored {
+  tokenPrefix: string;
+  entries: unknown[];
+  uploadedAt: number;
+}
+
+export function validateSignalDumpUpload(input: unknown): SignalDumpUpload | null {
+  if (!input || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  if (typeof obj.corrId !== 'string' || !CORR_ID_PATTERN.test(obj.corrId)) return null;
+  if (typeof obj.token !== 'string' || obj.token.length === 0) return null;
+  if (!Array.isArray(obj.entries)) return null;
+  if (obj.entries.length === 0) return null;
+  if (obj.entries.length > MAX_DUMP_ENTRIES) return null;
+  // 모든 entry가 object여야 함 (primitive/null reject — schema 안정성).
+  for (const e of obj.entries) {
+    if (!e || typeof e !== 'object') return null;
+  }
+  return {
+    corrId: obj.corrId,
+    token: obj.token,
+    entries: obj.entries,
+  };
+}
+
+/** KV에 dump 1건 적재. tokenPrefix만 보관 (PII 보호). */
+export async function storeSignalDump(
+  kv: KVNamespace,
+  upload: SignalDumpUpload,
+  now: number,
+): Promise<void> {
+  const stored: SignalDumpStored = {
+    tokenPrefix: tokenPrefix(upload.token),
+    entries: upload.entries,
+    uploadedAt: now,
+  };
+  await kv.put(dumpKey(upload.corrId), JSON.stringify(stored), {
+    expirationTtl: RAW_SIGNAL_DUMP_TTL_SEC,
+  });
+}
+
+/** corrId로 stored dump 조회. 부재/parse 실패 시 null. */
+export async function readSignalDump(
+  kv: KVNamespace,
+  corrId: string,
+): Promise<SignalDumpStored | null> {
+  if (!CORR_ID_PATTERN.test(corrId)) return null;
+  const raw = await kv.get(dumpKey(corrId));
+  if (raw === null) return null;
+  try {
+    const parsed = JSON.parse(raw) as SignalDumpStored;
+    if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.entries)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -533,4 +533,12 @@ export interface Env {
    * 등록: `wrangler secret put QUOTA_ALERT_WEBHOOK_URL`
    */
   QUOTA_ALERT_WEBHOOK_URL?: string;
+  /**
+   * Device raw signal dump KV (#1520, ADR-015 §10 P5 / PR-B).
+   * Trip 종료 시 device가 fusion raw signal ring buffer를 60일 TTL로 적재 →
+   * 운영자가 `/admin/signals/export?corrId=`로 조회해 7일 회귀 사후 분석.
+   * 미바인딩 시 `/signals/dump`는 503 graceful (개발 환경 호환).
+   * 생성: `wrangler kv namespace create RAW_SIGNALS`
+   */
+  RAW_SIGNALS?: KVNamespace;
 }

--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -44,6 +44,20 @@ preview_id = "d38f190e3f7f4fd3b6e7f6485dd1733d"
 # binding = "TELEMETRY"
 # dataset = "silent_push_telemetry"
 
+# KV: device raw signal dump (#1520, ADR-015 §10 P5 / PR-B)
+# `POST /signals/dump`이 trip 종료 시 device fusion ring buffer를 60일 TTL로 적재한다.
+# `GET /admin/signals/export?corrId=`로 운영자가 7일 회귀 사후 분석.
+# 코드는 `if (env.RAW_SIGNALS)` 분기로 graceful — binding 없으면 endpoint가 503 반환.
+#
+# 운영자 1회성 등록 절차:
+#   1) `wrangler kv namespace create RAW_SIGNALS`
+#   2) `wrangler kv namespace create RAW_SIGNALS --preview`
+#   3) 출력된 id / preview_id를 아래 두 줄에 채워 binding 활성화.
+# [[kv_namespaces]]
+# binding = "RAW_SIGNALS"
+# id = ""
+# preview_id = ""
+
 # 1분마다 활성 트립 폴링
 [triggers]
 crons = ["*/1 * * * *"]

--- a/src/features/alarm/api/__tests__/signalDumpBackend.test.ts
+++ b/src/features/alarm/api/__tests__/signalDumpBackend.test.ts
@@ -19,11 +19,13 @@ jest.mock('../../../../shared/utils/logger', () => ({
 }));
 
 const ORIGINAL_FETCH = globalThis.fetch;
+const TEST_URL = 'https://api.test/';
+const CORR_ID = '1700000000000-deadbeef';
 
 function entry(ts: number, kind: RawSignalEntry['kind'] = 'cycle'): RawSignalEntry {
   return {
     ts,
-    corrId: '1700000000000-deadbeef',
+    corrId: CORR_ID,
     kind,
     gps: null,
     motion: null,
@@ -37,6 +39,29 @@ function entry(ts: number, kind: RawSignalEntry['kind'] = 'cycle'): RawSignalEnt
     source: null,
     confidence: null,
   };
+}
+
+function configureBackend(fetchResult?: { ok: boolean; status?: number } | Error): void {
+  process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = TEST_URL;
+  if (fetchResult instanceof Error) {
+    (globalThis.fetch as jest.Mock).mockRejectedValue(fetchResult);
+  } else if (fetchResult) {
+    (globalThis.fetch as jest.Mock).mockResolvedValue(fetchResult);
+  }
+}
+
+async function seedOutbox(
+  overrides: Partial<{ corrId: string; token: string; entries: RawSignalEntry[] }> = {},
+): Promise<void> {
+  await AsyncStorage.setItem(
+    RAW_SIGNAL_OUTBOX_KEY,
+    JSON.stringify({
+      corrId: CORR_ID,
+      token: 'tok',
+      entries: [entry(1)],
+      ...overrides,
+    }),
+  );
 }
 
 describe('uploadSignalDump', () => {
@@ -57,52 +82,50 @@ describe('uploadSignalDump', () => {
   });
 
   it('빈 token이면 skipped=true (no-token)', async () => {
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    configureBackend();
     const result = await uploadSignalDump('1-00000000', '', [entry(1)]);
     expect(result.skipReason).toBe('no-token');
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
   it('빈 entries이면 skipped=true (no-entries)', async () => {
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    configureBackend();
     const result = await uploadSignalDump('1-00000000', 'tok', []);
     expect(result.skipReason).toBe('no-entries');
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
   it('성공 시 outbox 비우고 마지막 corrId 기록', async () => {
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
-    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+    configureBackend({ ok: true, status: 200 });
 
-    const result = await uploadSignalDump('1700000000000-deadbeef', 'tok', [entry(1)]);
+    const result = await uploadSignalDump(CORR_ID, 'tok', [entry(1)]);
     expect(result).toEqual({ ok: true, status: 200 });
 
     expect(await AsyncStorage.getItem(RAW_SIGNAL_OUTBOX_KEY)).toBeNull();
     expect(
       await AsyncStorage.getItem(LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY),
-    ).toBe('1700000000000-deadbeef');
+    ).toBe(CORR_ID);
 
     const [url, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
-    expect(url).toBe('https://api.test/signals/dump');
+    expect(url).toBe(`${TEST_URL}signals/dump`);
     expect(init.method).toBe('POST');
     const body = JSON.parse(init.body);
-    expect(body.corrId).toBe('1700000000000-deadbeef');
+    expect(body.corrId).toBe(CORR_ID);
     expect(body.token).toBe('tok');
     expect(body.entries.length).toBe(1);
   });
 
   it('실패 시 outbox에 남고 last corrId 미기록', async () => {
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
-    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 });
+    configureBackend({ ok: false, status: 500 });
 
-    const result = await uploadSignalDump('1700000000000-deadbeef', 'tok', [entry(1)]);
+    const result = await uploadSignalDump(CORR_ID, 'tok', [entry(1)]);
     expect(result.ok).toBe(false);
     expect(result.status).toBe(500);
 
     const outbox = await AsyncStorage.getItem(RAW_SIGNAL_OUTBOX_KEY);
     expect(outbox).not.toBeNull();
-    const parsed = JSON.parse(outbox!);
-    expect(parsed.corrId).toBe('1700000000000-deadbeef');
+    const parsed = JSON.parse(outbox ?? '');
+    expect(parsed.corrId).toBe(CORR_ID);
     expect(parsed.entries.length).toBe(1);
     expect(
       await AsyncStorage.getItem(LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY),
@@ -110,26 +133,18 @@ describe('uploadSignalDump', () => {
   });
 
   it('fetch throw 시 ok=false, outbox 보존', async () => {
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
-    (globalThis.fetch as jest.Mock).mockRejectedValue(new Error('network'));
+    configureBackend(new Error('network'));
 
-    const result = await uploadSignalDump('1700000000000-deadbeef', 'tok', [entry(1)]);
+    const result = await uploadSignalDump(CORR_ID, 'tok', [entry(1)]);
     expect(result).toEqual({ ok: false });
     expect(await AsyncStorage.getItem(RAW_SIGNAL_OUTBOX_KEY)).not.toBeNull();
   });
 
   it('같은 corrId 재시도 skip (duplicate)', async () => {
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
-    await AsyncStorage.setItem(
-      LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY,
-      '1700000000000-deadbeef',
-    );
+    configureBackend();
+    await AsyncStorage.setItem(LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY, CORR_ID);
 
-    const result = await uploadSignalDump(
-      '1700000000000-deadbeef',
-      'tok',
-      [entry(1)],
-    );
+    const result = await uploadSignalDump(CORR_ID, 'tok', [entry(1)]);
     expect(result.skipReason).toBe('duplicate');
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
@@ -152,32 +167,25 @@ describe('flushSignalDumpOutbox', () => {
   });
 
   it('outbox 비어있으면 skip (no-entries)', async () => {
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    configureBackend();
     const result = await flushSignalDumpOutbox();
     expect(result.skipReason).toBe('no-entries');
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
-  it('outbox JSON 손상이면 skip (no-entries)', async () => {
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
-    await AsyncStorage.setItem(RAW_SIGNAL_OUTBOX_KEY, 'not-json{');
-    const result = await flushSignalDumpOutbox();
-    expect(result.skipReason).toBe('no-entries');
-  });
-
-  it('outbox shape 부적합도 skip', async () => {
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
-    await AsyncStorage.setItem(RAW_SIGNAL_OUTBOX_KEY, JSON.stringify({ corrId: 1 }));
+  it.each([
+    ['JSON 손상', 'not-json{'],
+    ['shape 부적합', JSON.stringify({ corrId: 1 })],
+  ])('outbox %s이면 skip (no-entries)', async (_label, payload) => {
+    configureBackend();
+    await AsyncStorage.setItem(RAW_SIGNAL_OUTBOX_KEY, payload);
     const result = await flushSignalDumpOutbox();
     expect(result.skipReason).toBe('no-entries');
   });
 
   it('outbox.corrId가 이미 업로드된 corrId면 outbox만 정리 (duplicate)', async () => {
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
-    await AsyncStorage.setItem(
-      RAW_SIGNAL_OUTBOX_KEY,
-      JSON.stringify({ corrId: 'c1', token: 'tok', entries: [entry(1)] }),
-    );
+    configureBackend();
+    await seedOutbox({ corrId: 'c1' });
     await AsyncStorage.setItem(LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY, 'c1');
 
     const result = await flushSignalDumpOutbox();
@@ -187,53 +195,23 @@ describe('flushSignalDumpOutbox', () => {
   });
 
   it('outbox flush 성공 시 outbox 정리 + last corrId 기록', async () => {
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
-    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
-    await AsyncStorage.setItem(
-      RAW_SIGNAL_OUTBOX_KEY,
-      JSON.stringify({
-        corrId: '1700000000000-deadbeef',
-        token: 'tok',
-        entries: [entry(1)],
-      }),
-    );
+    configureBackend({ ok: true, status: 200 });
+    await seedOutbox();
 
     const result = await flushSignalDumpOutbox();
     expect(result.ok).toBe(true);
     expect(await AsyncStorage.getItem(RAW_SIGNAL_OUTBOX_KEY)).toBeNull();
     expect(
       await AsyncStorage.getItem(LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY),
-    ).toBe('1700000000000-deadbeef');
+    ).toBe(CORR_ID);
   });
 
-  it('outbox flush 실패 시 outbox 보존', async () => {
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
-    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 });
-    await AsyncStorage.setItem(
-      RAW_SIGNAL_OUTBOX_KEY,
-      JSON.stringify({
-        corrId: '1700000000000-deadbeef',
-        token: 'tok',
-        entries: [entry(1)],
-      }),
-    );
-
-    const result = await flushSignalDumpOutbox();
-    expect(result.ok).toBe(false);
-    expect(await AsyncStorage.getItem(RAW_SIGNAL_OUTBOX_KEY)).not.toBeNull();
-  });
-
-  it('outbox flush fetch throw 시에도 outbox 보존', async () => {
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
-    (globalThis.fetch as jest.Mock).mockRejectedValue(new Error('network'));
-    await AsyncStorage.setItem(
-      RAW_SIGNAL_OUTBOX_KEY,
-      JSON.stringify({
-        corrId: '1700000000000-deadbeef',
-        token: 'tok',
-        entries: [entry(1)],
-      }),
-    );
+  it.each([
+    ['실패 응답', { ok: false, status: 500 } as { ok: boolean; status?: number }],
+    ['fetch throw', new Error('network')],
+  ])('outbox flush %s 시 outbox 보존', async (_label, fetchResult) => {
+    configureBackend(fetchResult);
+    await seedOutbox();
 
     const result = await flushSignalDumpOutbox();
     expect(result.ok).toBe(false);
@@ -253,87 +231,53 @@ describe('storage failure handling (graceful)', () => {
     jest.restoreAllMocks();
   });
 
-  it('AsyncStorage.getItem(LAST_UPLOADED) throw → null fallback, upload 정상 진행', async () => {
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
-    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+  type StorageMethod = 'getItem' | 'setItem' | 'removeItem';
 
-    const original = AsyncStorage.getItem;
+  async function expectUploadOkWithFailingStorage(
+    method: StorageMethod,
+    keyMatcher: (key: string) => boolean,
+  ): Promise<void> {
+    configureBackend({ ok: true, status: 200 });
+    const originalGetItem = AsyncStorage.getItem.bind(AsyncStorage);
     const spy = jest
-      .spyOn(AsyncStorage, 'getItem')
-      .mockImplementation(async (key: string) => {
-        if (key === LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY) {
+      .spyOn(AsyncStorage, method)
+      .mockImplementation((async (key: string) => {
+        if (keyMatcher(key)) {
           throw new Error('storage fail');
         }
-        return original(key);
-      });
-
-    const result = await uploadSignalDump(
-      '1700000000000-deadbeef',
-      'tok',
-      [entry(1)],
-    );
-    expect(result.ok).toBe(true);
-    spy.mockRestore();
-  });
-
-  it('AsyncStorage.setItem(LAST_UPLOADED) throw 시 ok=true 유지', async () => {
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
-    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
-
-    const spy = jest
-      .spyOn(AsyncStorage, 'setItem')
-      .mockImplementation(async (key: string) => {
-        if (key === LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY) {
-          throw new Error('storage fail');
+        if (method === 'getItem') {
+          return originalGetItem(key);
         }
-      });
+        return undefined;
+      }) as never);
 
-    const result = await uploadSignalDump(
-      '1700000000000-deadbeef',
-      'tok',
-      [entry(1)],
-    );
+    const result = await uploadSignalDump(CORR_ID, 'tok', [entry(1)]);
     expect(result.ok).toBe(true);
     spy.mockRestore();
-  });
+  }
 
-  it('AsyncStorage.setItem(outbox) throw 시 upload는 계속 진행', async () => {
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
-    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
-
-    const spy = jest
-      .spyOn(AsyncStorage, 'setItem')
-      .mockImplementation(async (key: string) => {
-        if (key === RAW_SIGNAL_OUTBOX_KEY) {
-          throw new Error('storage fail');
-        }
-      });
-
-    const result = await uploadSignalDump(
-      '1700000000000-deadbeef',
-      'tok',
-      [entry(1)],
-    );
-    expect(result.ok).toBe(true);
-    spy.mockRestore();
-  });
-
-  it('AsyncStorage.removeItem(outbox) throw 시 ok=true 유지', async () => {
-    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
-    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
-
-    const spy = jest
-      .spyOn(AsyncStorage, 'removeItem')
-      .mockImplementation(async () => {
-        throw new Error('storage fail');
-      });
-
-    const result = await uploadSignalDump(
-      '1700000000000-deadbeef',
-      'tok',
-      [entry(1)],
-    );
-    expect(result.ok).toBe(true);
-    spy.mockRestore();
+  it.each<[string, StorageMethod, (key: string) => boolean]>([
+    [
+      'getItem(LAST_UPLOADED) throw → null fallback, upload 정상 진행',
+      'getItem',
+      (key) => key === LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY,
+    ],
+    [
+      'setItem(LAST_UPLOADED) throw 시 ok=true 유지',
+      'setItem',
+      (key) => key === LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY,
+    ],
+    [
+      'setItem(outbox) throw 시 upload는 계속 진행',
+      'setItem',
+      (key) => key === RAW_SIGNAL_OUTBOX_KEY,
+    ],
+    [
+      'removeItem(outbox) throw 시 ok=true 유지',
+      'removeItem',
+      () => true,
+    ],
+  ])('AsyncStorage.%s', async (_label, method, matcher) => {
+    await expectUploadOkWithFailingStorage(method, matcher);
   });
 });

--- a/src/features/alarm/api/__tests__/signalDumpBackend.test.ts
+++ b/src/features/alarm/api/__tests__/signalDumpBackend.test.ts
@@ -1,0 +1,339 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  uploadSignalDump,
+  flushSignalDumpOutbox,
+} from '../signalDumpBackend';
+import {
+  RAW_SIGNAL_OUTBOX_KEY,
+  LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY,
+} from '../../../../shared/constants/storageKeys';
+import type { RawSignalEntry } from '../../../observability/utils/rawSignalBuffer';
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function entry(ts: number, kind: RawSignalEntry['kind'] = 'cycle'): RawSignalEntry {
+  return {
+    ts,
+    corrId: '1700000000000-deadbeef',
+    kind,
+    gps: null,
+    motion: null,
+    subsurface: null,
+    arvlCd: null,
+    line: null,
+    dir: null,
+    arcIdx: null,
+    arcProgress: null,
+    stationId: null,
+    source: null,
+    confidence: null,
+  };
+}
+
+describe('uploadSignalDump', () => {
+  beforeEach(async () => {
+    delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+    globalThis.fetch = jest.fn();
+    await AsyncStorage.clear();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+
+  it('URL 미설정이면 skipped=true (no-url)', async () => {
+    const result = await uploadSignalDump('1-00000000', 'tok', [entry(1)]);
+    expect(result).toEqual({ ok: false, skipped: true, skipReason: 'no-url' });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('빈 token이면 skipped=true (no-token)', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    const result = await uploadSignalDump('1-00000000', '', [entry(1)]);
+    expect(result.skipReason).toBe('no-token');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('빈 entries이면 skipped=true (no-entries)', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    const result = await uploadSignalDump('1-00000000', 'tok', []);
+    expect(result.skipReason).toBe('no-entries');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('성공 시 outbox 비우고 마지막 corrId 기록', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+
+    const result = await uploadSignalDump('1700000000000-deadbeef', 'tok', [entry(1)]);
+    expect(result).toEqual({ ok: true, status: 200 });
+
+    expect(await AsyncStorage.getItem(RAW_SIGNAL_OUTBOX_KEY)).toBeNull();
+    expect(
+      await AsyncStorage.getItem(LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY),
+    ).toBe('1700000000000-deadbeef');
+
+    const [url, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('https://api.test/signals/dump');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body);
+    expect(body.corrId).toBe('1700000000000-deadbeef');
+    expect(body.token).toBe('tok');
+    expect(body.entries.length).toBe(1);
+  });
+
+  it('실패 시 outbox에 남고 last corrId 미기록', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 });
+
+    const result = await uploadSignalDump('1700000000000-deadbeef', 'tok', [entry(1)]);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(500);
+
+    const outbox = await AsyncStorage.getItem(RAW_SIGNAL_OUTBOX_KEY);
+    expect(outbox).not.toBeNull();
+    const parsed = JSON.parse(outbox!);
+    expect(parsed.corrId).toBe('1700000000000-deadbeef');
+    expect(parsed.entries.length).toBe(1);
+    expect(
+      await AsyncStorage.getItem(LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY),
+    ).toBeNull();
+  });
+
+  it('fetch throw 시 ok=false, outbox 보존', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    (globalThis.fetch as jest.Mock).mockRejectedValue(new Error('network'));
+
+    const result = await uploadSignalDump('1700000000000-deadbeef', 'tok', [entry(1)]);
+    expect(result).toEqual({ ok: false });
+    expect(await AsyncStorage.getItem(RAW_SIGNAL_OUTBOX_KEY)).not.toBeNull();
+  });
+
+  it('같은 corrId 재시도 skip (duplicate)', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    await AsyncStorage.setItem(
+      LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY,
+      '1700000000000-deadbeef',
+    );
+
+    const result = await uploadSignalDump(
+      '1700000000000-deadbeef',
+      'tok',
+      [entry(1)],
+    );
+    expect(result.skipReason).toBe('duplicate');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('flushSignalDumpOutbox', () => {
+  beforeEach(async () => {
+    delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+    globalThis.fetch = jest.fn();
+    await AsyncStorage.clear();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+
+  it('URL 미설정이면 skip', async () => {
+    const result = await flushSignalDumpOutbox();
+    expect(result.skipReason).toBe('no-url');
+  });
+
+  it('outbox 비어있으면 skip (no-entries)', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    const result = await flushSignalDumpOutbox();
+    expect(result.skipReason).toBe('no-entries');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('outbox JSON 손상이면 skip (no-entries)', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    await AsyncStorage.setItem(RAW_SIGNAL_OUTBOX_KEY, 'not-json{');
+    const result = await flushSignalDumpOutbox();
+    expect(result.skipReason).toBe('no-entries');
+  });
+
+  it('outbox shape 부적합도 skip', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    await AsyncStorage.setItem(RAW_SIGNAL_OUTBOX_KEY, JSON.stringify({ corrId: 1 }));
+    const result = await flushSignalDumpOutbox();
+    expect(result.skipReason).toBe('no-entries');
+  });
+
+  it('outbox.corrId가 이미 업로드된 corrId면 outbox만 정리 (duplicate)', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    await AsyncStorage.setItem(
+      RAW_SIGNAL_OUTBOX_KEY,
+      JSON.stringify({ corrId: 'c1', token: 'tok', entries: [entry(1)] }),
+    );
+    await AsyncStorage.setItem(LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY, 'c1');
+
+    const result = await flushSignalDumpOutbox();
+    expect(result.skipReason).toBe('duplicate');
+    expect(await AsyncStorage.getItem(RAW_SIGNAL_OUTBOX_KEY)).toBeNull();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('outbox flush 성공 시 outbox 정리 + last corrId 기록', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+    await AsyncStorage.setItem(
+      RAW_SIGNAL_OUTBOX_KEY,
+      JSON.stringify({
+        corrId: '1700000000000-deadbeef',
+        token: 'tok',
+        entries: [entry(1)],
+      }),
+    );
+
+    const result = await flushSignalDumpOutbox();
+    expect(result.ok).toBe(true);
+    expect(await AsyncStorage.getItem(RAW_SIGNAL_OUTBOX_KEY)).toBeNull();
+    expect(
+      await AsyncStorage.getItem(LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY),
+    ).toBe('1700000000000-deadbeef');
+  });
+
+  it('outbox flush 실패 시 outbox 보존', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 });
+    await AsyncStorage.setItem(
+      RAW_SIGNAL_OUTBOX_KEY,
+      JSON.stringify({
+        corrId: '1700000000000-deadbeef',
+        token: 'tok',
+        entries: [entry(1)],
+      }),
+    );
+
+    const result = await flushSignalDumpOutbox();
+    expect(result.ok).toBe(false);
+    expect(await AsyncStorage.getItem(RAW_SIGNAL_OUTBOX_KEY)).not.toBeNull();
+  });
+
+  it('outbox flush fetch throw 시에도 outbox 보존', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    (globalThis.fetch as jest.Mock).mockRejectedValue(new Error('network'));
+    await AsyncStorage.setItem(
+      RAW_SIGNAL_OUTBOX_KEY,
+      JSON.stringify({
+        corrId: '1700000000000-deadbeef',
+        token: 'tok',
+        entries: [entry(1)],
+      }),
+    );
+
+    const result = await flushSignalDumpOutbox();
+    expect(result.ok).toBe(false);
+    expect(await AsyncStorage.getItem(RAW_SIGNAL_OUTBOX_KEY)).not.toBeNull();
+  });
+});
+
+describe('storage failure handling (graceful)', () => {
+  beforeEach(async () => {
+    delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+    globalThis.fetch = jest.fn();
+    await AsyncStorage.clear();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    jest.restoreAllMocks();
+  });
+
+  it('AsyncStorage.getItem(LAST_UPLOADED) throw → null fallback, upload 정상 진행', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+
+    const original = AsyncStorage.getItem;
+    const spy = jest
+      .spyOn(AsyncStorage, 'getItem')
+      .mockImplementation(async (key: string) => {
+        if (key === LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY) {
+          throw new Error('storage fail');
+        }
+        return original(key);
+      });
+
+    const result = await uploadSignalDump(
+      '1700000000000-deadbeef',
+      'tok',
+      [entry(1)],
+    );
+    expect(result.ok).toBe(true);
+    spy.mockRestore();
+  });
+
+  it('AsyncStorage.setItem(LAST_UPLOADED) throw 시 ok=true 유지', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+
+    const spy = jest
+      .spyOn(AsyncStorage, 'setItem')
+      .mockImplementation(async (key: string) => {
+        if (key === LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY) {
+          throw new Error('storage fail');
+        }
+      });
+
+    const result = await uploadSignalDump(
+      '1700000000000-deadbeef',
+      'tok',
+      [entry(1)],
+    );
+    expect(result.ok).toBe(true);
+    spy.mockRestore();
+  });
+
+  it('AsyncStorage.setItem(outbox) throw 시 upload는 계속 진행', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+
+    const spy = jest
+      .spyOn(AsyncStorage, 'setItem')
+      .mockImplementation(async (key: string) => {
+        if (key === RAW_SIGNAL_OUTBOX_KEY) {
+          throw new Error('storage fail');
+        }
+      });
+
+    const result = await uploadSignalDump(
+      '1700000000000-deadbeef',
+      'tok',
+      [entry(1)],
+    );
+    expect(result.ok).toBe(true);
+    spy.mockRestore();
+  });
+
+  it('AsyncStorage.removeItem(outbox) throw 시 ok=true 유지', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test/';
+    (globalThis.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+
+    const spy = jest
+      .spyOn(AsyncStorage, 'removeItem')
+      .mockImplementation(async () => {
+        throw new Error('storage fail');
+      });
+
+    const result = await uploadSignalDump(
+      '1700000000000-deadbeef',
+      'tok',
+      [entry(1)],
+    );
+    expect(result.ok).toBe(true);
+    spy.mockRestore();
+  });
+});

--- a/src/features/alarm/api/signalDumpBackend.ts
+++ b/src/features/alarm/api/signalDumpBackend.ts
@@ -1,0 +1,201 @@
+/**
+ * Raw signal dump backend client (#1520, ADR-015 §10 P5 / PR-B).
+ *
+ * Trip 종료 시 `useFusedNearestStation` ring buffer를 backend KV에 60일 누적해 사후
+ * 회귀 분석에 사용한다. PR-A(device buffer/corrId)와 짝.
+ *
+ * 정책:
+ *  - graceful — URL 미설정/token 부재/실패 시 throw 안 함. critical path(trip-end recall + cleanup)
+ *    보호.
+ *  - idempotency — `LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY`로 같은 corrId 재시도 skip. trip마다
+ *    새 corrId가 생성되므로 정상 trip-end는 1회 upload 보장.
+ *  - retry — 실패 시 outbox(`RAW_SIGNAL_OUTBOX_KEY`)에 단건 enqueue. 다음 cold-launch
+ *    (`useLaunchTripReconciliation`)에서 flush. outbox는 가장 최근 1건만 보존 — 7일 회귀 사후
+ *    분석에 가장 중요한 trip(최근)만 보호.
+ *  - backend 호환 — 같은 corrId 재전송은 KV가 덮어쓰기로 처리(server-side dedup 불필요).
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  RAW_SIGNAL_OUTBOX_KEY,
+  LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY,
+} from '../../../shared/constants/storageKeys';
+import { createLogger } from '../../../shared/utils/logger';
+import {
+  fetchWithTelemetryTimeout,
+  getAlarmBackendUrl,
+} from '../../../shared/utils/telemetryHttp';
+import type { RawSignalEntry } from '../../observability/utils/rawSignalBuffer';
+
+const log = createLogger('signalDumpBackend');
+
+export interface SignalDumpUploadResult {
+  ok: boolean;
+  /** URL 미설정 / token 빈 / 같은 corrId 재시도 등으로 호출이 건너뛰어진 경우 true. */
+  skipped?: boolean;
+  /** skip 사유 — 진단/테스트용. */
+  skipReason?: 'no-url' | 'no-token' | 'no-entries' | 'duplicate';
+  status?: number;
+}
+
+interface OutboxEntry {
+  corrId: string;
+  token: string;
+  entries: RawSignalEntry[];
+}
+
+async function readOutbox(): Promise<OutboxEntry | null> {
+  try {
+    const raw = await AsyncStorage.getItem(RAW_SIGNAL_OUTBOX_KEY);
+    if (raw === null) return null;
+    const parsed = JSON.parse(raw) as OutboxEntry;
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      typeof parsed.corrId !== 'string' ||
+      typeof parsed.token !== 'string' ||
+      !Array.isArray(parsed.entries)
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch (e) {
+    log.warn('outbox read error', e);
+    return null;
+  }
+}
+
+async function writeOutbox(entry: OutboxEntry): Promise<void> {
+  try {
+    await AsyncStorage.setItem(RAW_SIGNAL_OUTBOX_KEY, JSON.stringify(entry));
+  } catch (e) {
+    log.warn('outbox write error', e);
+  }
+}
+
+async function clearOutbox(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(RAW_SIGNAL_OUTBOX_KEY);
+  } catch (e) {
+    log.warn('outbox clear error', e);
+  }
+}
+
+async function getLastUploadedCorrId(): Promise<string | null> {
+  try {
+    return await AsyncStorage.getItem(LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY);
+  } catch {
+    return null;
+  }
+}
+
+async function setLastUploadedCorrId(corrId: string): Promise<void> {
+  try {
+    await AsyncStorage.setItem(LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY, corrId);
+  } catch (e) {
+    log.warn('idempotency key write error (graceful)', e);
+  }
+}
+
+async function performUpload(
+  base: string,
+  body: OutboxEntry,
+): Promise<SignalDumpUploadResult> {
+  try {
+    const res = await fetchWithTelemetryTimeout(`${base}/signals/dump`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      log.warn(`signal dump upload failed status=${res.status}`);
+      return { ok: false, status: res.status };
+    }
+    return { ok: true, status: res.status };
+  } catch (e) {
+    log.warn('signal dump upload error', e);
+    return { ok: false };
+  }
+}
+
+/**
+ * Raw signal dump 1건을 backend `/signals/dump`로 upload.
+ *
+ * 호출자: `triggerTripEndRecall` (fire-and-forget). trip-end recall + cleanup의 critical path를
+ *   차단하지 않게 throw 안 한다. cleanup 전에 호출되어야 corrId/entries가 유효.
+ *
+ * 실패 시 outbox에 enqueue — 다음 cold-launch에서 `flushSignalDumpOutbox`가 retry.
+ * 같은 corrId 재호출은 즉시 skip (idempotency).
+ */
+export async function uploadSignalDump(
+  corrId: string,
+  token: string,
+  entries: readonly RawSignalEntry[],
+): Promise<SignalDumpUploadResult> {
+  const base = getAlarmBackendUrl();
+  if (!base) {
+    log.info('ALARM_BACKEND_URL not set — skip signal dump');
+    return { ok: false, skipped: true, skipReason: 'no-url' };
+  }
+  if (!token) {
+    return { ok: false, skipped: true, skipReason: 'no-token' };
+  }
+  if (entries.length === 0) {
+    return { ok: false, skipped: true, skipReason: 'no-entries' };
+  }
+
+  const lastCorrId = await getLastUploadedCorrId();
+  if (lastCorrId === corrId) {
+    log.info(`duplicate signal dump skip: corrId=${corrId}`);
+    return { ok: false, skipped: true, skipReason: 'duplicate' };
+  }
+
+  // Outbox에 미리 적재 — 업로드 시도 도중 앱이 죽어도 다음 cold-launch에서 retry 가능.
+  // 성공 시 clear, 실패 시 그대로 유지.
+  const payload: OutboxEntry = {
+    corrId,
+    token,
+    // readonly → mutable copy (JSON.stringify에는 영향 없지만 schema 일치).
+    entries: [...entries],
+  };
+  await writeOutbox(payload);
+
+  const result = await performUpload(base, payload);
+  if (result.ok) {
+    await setLastUploadedCorrId(corrId);
+    await clearOutbox();
+  }
+  return result;
+}
+
+/**
+ * Cold-launch 시 outbox flush. `useLaunchTripReconciliation` 마운트 직후 호출.
+ *
+ * 마지막 trip-end에서 upload 실패한 dump를 다시 시도. 성공 시 outbox + idempotency 키 갱신.
+ * URL 미설정 / outbox 비어있음 / 마지막 corrId == outbox.corrId(이미 성공한 trip)는 graceful skip.
+ *
+ * 절대 throw 안 한다 — launch path critical.
+ */
+export async function flushSignalDumpOutbox(): Promise<SignalDumpUploadResult> {
+  const base = getAlarmBackendUrl();
+  if (!base) {
+    return { ok: false, skipped: true, skipReason: 'no-url' };
+  }
+  const entry = await readOutbox();
+  if (entry === null) {
+    return { ok: false, skipped: true, skipReason: 'no-entries' };
+  }
+
+  const lastCorrId = await getLastUploadedCorrId();
+  if (lastCorrId === entry.corrId) {
+    // 이미 성공한 trip — outbox만 정리.
+    await clearOutbox();
+    return { ok: false, skipped: true, skipReason: 'duplicate' };
+  }
+
+  const result = await performUpload(base, entry);
+  if (result.ok) {
+    await setLastUploadedCorrId(entry.corrId);
+    await clearOutbox();
+  }
+  return result;
+}

--- a/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
@@ -34,6 +34,11 @@ jest.mock('../../store/tripBoundCleanups', () => ({
   runTripBoundCleanups: (...args: unknown[]) => mockRunTripBoundCleanups(...args),
 }));
 
+const mockFlushSignalDumpOutbox = jest.fn();
+jest.mock('../../api/signalDumpBackend', () => ({
+  flushSignalDumpOutbox: (...args: unknown[]) => mockFlushSignalDumpOutbox(...args),
+}));
+
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),
@@ -51,6 +56,7 @@ beforeEach(async () => {
   mockSendTripEnded.mockResolvedValue(undefined);
   mockTriggerTripEndRecall.mockResolvedValue({ uploaded: false });
   mockRunTripBoundCleanups.mockResolvedValue(undefined);
+  mockFlushSignalDumpOutbox.mockResolvedValue({ ok: false, skipped: true });
   process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
 });
 
@@ -186,6 +192,18 @@ describe('runLaunchTripReconciliation', () => {
       endedAt: 1,
       endReason: 'expired',
     });
+    await expect(runLaunchTripReconciliation()).resolves.toBeUndefined();
+  });
+
+  it('#1520 — flushSignalDumpOutbox 항상 호출 (cold-launch retry)', async () => {
+    // ACTIVE_TRIP_KEY 없어도 flush는 호출되어야 한다 — outbox에는 직전 trip의 dump가 남아있을 수 있음.
+    await runLaunchTripReconciliation();
+    expect(mockFlushSignalDumpOutbox).toHaveBeenCalledTimes(1);
+  });
+
+  it('#1520 — flushSignalDumpOutbox 예외 시에도 trip status reconciliation은 계속 진행', async () => {
+    // runLaunchTripReconciliation은 outer try-catch로 보호되므로 예외는 silent fail로 흡수.
+    mockFlushSignalDumpOutbox.mockRejectedValueOnce(new Error('boom'));
     await expect(runLaunchTripReconciliation()).resolves.toBeUndefined();
   });
 });

--- a/src/features/alarm/hooks/useLaunchTripReconciliation.ts
+++ b/src/features/alarm/hooks/useLaunchTripReconciliation.ts
@@ -47,6 +47,7 @@ import { sendTripEndedNotification } from '../utils/stationNotification';
 import { fetchTripStatus } from '../api/tripStatus';
 import { triggerTripEndRecall } from '../utils/triggerTripEndRecall';
 import { runTripBoundCleanups } from '../store/tripBoundCleanups';
+import { flushSignalDumpOutbox } from '../api/signalDumpBackend';
 import { createLogger } from '../../../shared/utils/logger';
 
 const logger = createLogger('useLaunchTripReconciliation');
@@ -65,6 +66,11 @@ function getBackendUrl(): string | null {
  */
 export async function runLaunchTripReconciliation(): Promise<void> {
   try {
+    // #1520 (ADR-015 §10 P5 / PR-B) — outbox flush retry. trip-end 시 upload 실패해 outbox에
+    // enqueue된 raw signal dump를 cold-launch 시점에 다시 시도. trip status reconciliation과
+    // 독립 — backend URL이 없거나 outbox 비어있으면 즉시 graceful skip.
+    await flushSignalDumpOutbox();
+
     const baseUrl = getBackendUrl();
     if (!baseUrl) {
       logger.info('skip — ALARM_BACKEND_URL not set');

--- a/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
+++ b/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
@@ -12,6 +12,10 @@ const mockComputeAndUploadTripPrescheduled = jest.fn();
 const mockComputeRouteArc = jest.fn();
 const mockGetTripStartedAt = jest.fn();
 const mockFlushRegressionCounters = jest.fn();
+const mockUploadSignalDump = jest.fn();
+const mockGetCurrentTripCorrIdSync = jest.fn();
+const mockGetCurrentTripCorrId = jest.fn();
+const mockGetRawSignalEntries = jest.fn();
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   __esModule: true,
@@ -46,6 +50,19 @@ jest.mock('../../../../shared/utils/logger', () => ({
 
 jest.mock('../../../../shared/utils/regressionMetrics', () => ({
   flushRegressionCounters: (...args: unknown[]) => mockFlushRegressionCounters(...args),
+}));
+
+jest.mock('../../api/signalDumpBackend', () => ({
+  uploadSignalDump: (...args: unknown[]) => mockUploadSignalDump(...args),
+}));
+
+jest.mock('../../../observability/utils/tripCorrId', () => ({
+  getCurrentTripCorrIdSync: (...args: unknown[]) => mockGetCurrentTripCorrIdSync(...args),
+  getCurrentTripCorrId: (...args: unknown[]) => mockGetCurrentTripCorrId(...args),
+}));
+
+jest.mock('../../../observability/utils/rawSignalBuffer', () => ({
+  getRawSignalEntries: (...args: unknown[]) => mockGetRawSignalEntries(...args),
 }));
 
 import { triggerTripEndRecall } from '../triggerTripEndRecall';
@@ -85,6 +102,14 @@ describe('triggerTripEndRecall', () => {
     mockGetTripStartedAt.mockReset();
     mockFlushRegressionCounters.mockReset();
     mockFlushRegressionCounters.mockResolvedValue(undefined);
+    mockUploadSignalDump.mockReset();
+    mockUploadSignalDump.mockResolvedValue({ ok: true });
+    mockGetCurrentTripCorrIdSync.mockReset();
+    mockGetCurrentTripCorrIdSync.mockReturnValue(null);
+    mockGetCurrentTripCorrId.mockReset();
+    mockGetCurrentTripCorrId.mockResolvedValue(null);
+    mockGetRawSignalEntries.mockReset();
+    mockGetRawSignalEntries.mockReturnValue([]);
   });
 
   it('tripStart 부재 시 즉시 skip (no-trip-start)', async () => {
@@ -373,5 +398,99 @@ describe('triggerTripEndRecall', () => {
 
     const result = await triggerTripEndRecall();
     expect(result.uploaded).toBe(true); // recall 성공 영향 없음
+  });
+
+  describe('#1520 — signal dump upload', () => {
+    function setupHappyPath(): void {
+      mockGetTripStartedAt.mockResolvedValue(100);
+      setStorage({
+        [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
+        [ROUTE_KEY]: ROUTE_JSON,
+        [TRIP_ORIGIN_KEY]: ORIGIN_JSON,
+        [DESTINATION_KEY]: DEST_JSON,
+        [APNS_TOKEN_KEY]: 'apns-token-xyz',
+      });
+      mockComputeRouteArc.mockReturnValue({
+        stations: ROUTE_ARC_STATIONS,
+        arcM: [0, 1, 2],
+        totalLengthM: 2,
+      });
+      mockComputeAndUploadTripRecall.mockResolvedValue({ uploaded: true });
+      mockSetItem.mockResolvedValue(undefined);
+    }
+
+    it('corrId(sync) + token + entries 정상 시 uploadSignalDump 호출', async () => {
+      setupHappyPath();
+      mockGetCurrentTripCorrIdSync.mockReturnValue('1700000000000-deadbeef');
+      const entries = [{ ts: 1, kind: 'cycle' }];
+      mockGetRawSignalEntries.mockReturnValue(entries);
+
+      await triggerTripEndRecall();
+
+      expect(mockUploadSignalDump).toHaveBeenCalledWith(
+        '1700000000000-deadbeef',
+        'apns-token-xyz',
+        entries,
+      );
+      // sync hit으로 async getCurrentTripCorrId는 호출 안 됨.
+      expect(mockGetCurrentTripCorrId).not.toHaveBeenCalled();
+    });
+
+    it('sync 부재 시 storage hydrate fallback 사용', async () => {
+      setupHappyPath();
+      mockGetCurrentTripCorrIdSync.mockReturnValue(null);
+      mockGetCurrentTripCorrId.mockResolvedValue('1700000000000-deadbeef');
+      mockGetRawSignalEntries.mockReturnValue([{ ts: 1, kind: 'cycle' }]);
+
+      await triggerTripEndRecall();
+
+      expect(mockGetCurrentTripCorrId).toHaveBeenCalled();
+      expect(mockUploadSignalDump).toHaveBeenCalled();
+    });
+
+    it('corrId 부재 시 upload skip', async () => {
+      setupHappyPath();
+      mockGetCurrentTripCorrIdSync.mockReturnValue(null);
+      mockGetCurrentTripCorrId.mockResolvedValue(null);
+      mockGetRawSignalEntries.mockReturnValue([{ ts: 1 }]);
+
+      await triggerTripEndRecall();
+      expect(mockUploadSignalDump).not.toHaveBeenCalled();
+    });
+
+    it('APNS token 부재 시 upload skip', async () => {
+      setupHappyPath();
+      setStorage({
+        [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
+        [ROUTE_KEY]: ROUTE_JSON,
+        [TRIP_ORIGIN_KEY]: ORIGIN_JSON,
+        [DESTINATION_KEY]: DEST_JSON,
+        [APNS_TOKEN_KEY]: null,
+      });
+      mockGetCurrentTripCorrIdSync.mockReturnValue('1700000000000-deadbeef');
+      mockGetRawSignalEntries.mockReturnValue([{ ts: 1 }]);
+
+      await triggerTripEndRecall();
+      expect(mockUploadSignalDump).not.toHaveBeenCalled();
+    });
+
+    it('entries 빈 배열이면 upload skip', async () => {
+      setupHappyPath();
+      mockGetCurrentTripCorrIdSync.mockReturnValue('1700000000000-deadbeef');
+      mockGetRawSignalEntries.mockReturnValue([]);
+
+      await triggerTripEndRecall();
+      expect(mockUploadSignalDump).not.toHaveBeenCalled();
+    });
+
+    it('uploadSignalDump 예외 흡수 (recall 결과는 영향 없음)', async () => {
+      setupHappyPath();
+      mockGetCurrentTripCorrIdSync.mockReturnValue('1700000000000-deadbeef');
+      mockGetRawSignalEntries.mockReturnValue([{ ts: 1 }]);
+      mockUploadSignalDump.mockRejectedValue(new Error('boom'));
+
+      const result = await triggerTripEndRecall();
+      expect(result.uploaded).toBe(true);
+    });
   });
 });

--- a/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
+++ b/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
@@ -91,6 +91,24 @@ const ROUTE_ARC_STATIONS = [
   { id: 'd', name: 'Dest', line: '2', lat: 0, lng: 0 },
 ];
 
+function setupHappyPath(): void {
+  mockGetTripStartedAt.mockResolvedValue(100);
+  setStorage({
+    [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
+    [ROUTE_KEY]: ROUTE_JSON,
+    [TRIP_ORIGIN_KEY]: ORIGIN_JSON,
+    [DESTINATION_KEY]: DEST_JSON,
+    [APNS_TOKEN_KEY]: 'apns-token-xyz',
+  });
+  mockComputeRouteArc.mockReturnValue({
+    stations: ROUTE_ARC_STATIONS,
+    arcM: [0, 1, 2],
+    totalLengthM: 2,
+  });
+  mockComputeAndUploadTripRecall.mockResolvedValue({ uploaded: true });
+  mockSetItem.mockResolvedValue(undefined);
+}
+
 describe('triggerTripEndRecall', () => {
   beforeEach(() => {
     mockGetItem.mockReset();
@@ -401,24 +419,6 @@ describe('triggerTripEndRecall', () => {
   });
 
   describe('#1520 — signal dump upload', () => {
-    function setupHappyPath(): void {
-      mockGetTripStartedAt.mockResolvedValue(100);
-      setStorage({
-        [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
-        [ROUTE_KEY]: ROUTE_JSON,
-        [TRIP_ORIGIN_KEY]: ORIGIN_JSON,
-        [DESTINATION_KEY]: DEST_JSON,
-        [APNS_TOKEN_KEY]: 'apns-token-xyz',
-      });
-      mockComputeRouteArc.mockReturnValue({
-        stations: ROUTE_ARC_STATIONS,
-        arcM: [0, 1, 2],
-        totalLengthM: 2,
-      });
-      mockComputeAndUploadTripRecall.mockResolvedValue({ uploaded: true });
-      mockSetItem.mockResolvedValue(undefined);
-    }
-
     it('corrId(sync) + token + entries 정상 시 uploadSignalDump 호출', async () => {
       setupHappyPath();
       mockGetCurrentTripCorrIdSync.mockReturnValue('1700000000000-deadbeef');

--- a/src/features/alarm/utils/triggerTripEndRecall.ts
+++ b/src/features/alarm/utils/triggerTripEndRecall.ts
@@ -43,6 +43,12 @@ import {
 import { getTripStartedAt } from './tripStartStorage';
 import { createLogger } from '../../../shared/utils/logger';
 import { flushRegressionCounters } from '../../../shared/utils/regressionMetrics';
+import {
+  getCurrentTripCorrIdSync,
+  getCurrentTripCorrId,
+} from '../../observability/utils/tripCorrId';
+import { getRawSignalEntries } from '../../observability/utils/rawSignalBuffer';
+import { uploadSignalDump } from '../api/signalDumpBackend';
 
 const log = createLogger('triggerTripEndRecall');
 
@@ -107,6 +113,11 @@ export async function triggerTripEndRecall(): Promise<TriggerTripEndRecallResult
     // 즉시 reset하므로 같은 trip이 두 번 trigger되어도 두 번째는 자연스럽게 no-op이 된다.
     await triggerRegressionFlush();
 
+    // #1520 (ADR-015 §10 P5 / PR-B) — fusion raw signal dump upload. tripBoundCleanups가
+    // 도착하기 *전*에 호출되어야 corrId/entries가 유효. fire-and-forget — silent push ack
+    // 같은 critical path와 분리해 실패해도 trip-end 흐름은 정상 동작.
+    await triggerSignalDumpUpload();
+
     return { uploaded: result.uploaded };
   } catch (e) {
     log.warn('trigger error', e);
@@ -137,6 +148,35 @@ async function triggerPrescheduledUpload(tripStart: number): Promise<void> {
     }
   } catch (e) {
     log.warn('prescheduled trigger error', e);
+  }
+}
+
+/**
+ * #1520 — fusion raw signal dump upload. corrId(sync 우선, 부재 시 storage hydrate) +
+ * token + 현재 ring buffer entries를 upload한다.
+ *
+ * cleanup 전에 호출되어야 한다 — tripBoundCleanups가 corrId/buffer를 모두 비우기 때문.
+ * graceful: corrId 부재 / token 부재 / entries 빈 어떤 경우도 trip-end critical path 차단 안 함.
+ */
+async function triggerSignalDumpUpload(): Promise<void> {
+  try {
+    // sync 우선 (fusion hot path 정합). 부재 시 storage hydrate fallback.
+    const corrId =
+      getCurrentTripCorrIdSync() ?? (await getCurrentTripCorrId());
+    if (corrId === null) {
+      return;
+    }
+    const token = await AsyncStorage.getItem(APNS_TOKEN_KEY);
+    if (!token) {
+      return;
+    }
+    const entries = getRawSignalEntries();
+    if (entries.length === 0) {
+      return;
+    }
+    await uploadSignalDump(corrId, token, entries);
+  } catch (e) {
+    log.warn('signal dump trigger error', e);
   }
 }
 

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -154,6 +154,15 @@ export const TRIP_CORR_ID_KEY = 'subway-now:trip-corr-id';
 // 마지막 ~120 entry가 복원돼 7일 회귀 사후 분석에 사용.
 // 형식: RawSignalEntry[] JSON.
 export const RAW_SIGNAL_BUFFER_KEY = 'subway-now:raw-signal-buffer';
+// #1520 (ADR-015 §10 P5 / PR-B) — Raw signal dump outbox queue.
+// triggerTripEndRecall이 fire-and-forget으로 upload 시도 → 네트워크 실패 시 outbox에 enqueue,
+// 다음 cold-launch에서 useLaunchTripReconciliation 시점에 flush. 같은 corrId 재전송은 backend가 덮어쓰기로 처리.
+// 형식: {corrId, token, entries}[] JSON. 단일 항목만 보존(가장 최근 trip-end).
+export const RAW_SIGNAL_OUTBOX_KEY = 'subway-now:raw-signal-outbox';
+// #1520 — 마지막으로 backend에 upload 성공한 corrId. 같은 corrId 재시도는 즉시 skip.
+// triggerTripEndRecall이 1차 호출 + outbox flush 양쪽에서 이 키로 멱등성 보장.
+// 형식: 문자열 (corrId). 부재 = 아직 upload 성공 trip 없음.
+export const LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY = 'subway-now:last-uploaded-signal-dump-corr-id';
 // #1279 — 기압계 지하 감지 상태(subsurface boolean) AsyncStorage stamp.
 // useBarometer(FG-only React state)가 subsurface flip 시 write → BG silent-push task와
 // 위치 게이트가 동일한 값을 read할 수 있도록 한다. updatedAt(epoch ms)은 TTL 만료 판별용.


### PR DESCRIPTION
## Summary

ADR-015 §10 P5 / M1 PR-B. PR-A(#1512, dev 머지됨) device buffer/corrId 산출물에 backend KV 적재 + device retry 인프라를 더해 trip 종료 시 fusion raw signal dump를 60일 누적.

Closes #1520

### Backend (`backend/alarm-worker/`)

- **`src/rawSignalDump.ts`** — corrId 형식(`^\d+-[0-9a-f]{8}$`) validator + entries cap 500. KV key `dump:{corrId}` + TTL 60일. tokenPrefix(8자) 적재로 PII 익명화.
- **`POST /signals/dump`** — RAW_SIGNALS 미바인딩 시 503 graceful. invalid JSON / payload는 400. 성공 시 `{ ok: true, accepted: N }`.
- **`GET /admin/signals/export?corrId=`** — `Authorization: Bearer <ADMIN_TOKEN>` 인증. corrId 부재 400, 잘못된 corrId/미존재 404.
- **`Env.RAW_SIGNALS?: KVNamespace`** optional binding 추가.
- **wrangler.toml** — placeholder binding (사용자 실행 후 id/preview_id 채움).

### Device (`src/`)

- **`signalDumpBackend.ts`** — `uploadSignalDump(corrId, token, entries)` + `flushSignalDumpOutbox()`. graceful: URL/token 부재 / 같은 corrId 재시도 즉시 skip. 실패 시 outbox(`RAW_SIGNAL_OUTBOX_KEY`)에 단건 enqueue. 성공 시 outbox 정리 + `LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY` 기록.
- **`triggerTripEndRecall`** — cleanup *전*에 corrId(sync 우선, async fallback) + token + buffer fire-and-forget upload. silent push ack critical path와 분리.
- **`useLaunchTripReconciliation`** — cold-launch 시 outbox flush. backend URL 미설정 / outbox 비어있음 graceful skip.

### 양방향 layer 추적

```
device tripStart → corrId 생성 → cache + storage (PR-A)
                                      │
                                      ▼
device tripEnd → triggerTripEndRecall → uploadSignalDump(corrId, token, entries)
                                                 │
                                                 ▼
                  실패 → outbox → 다음 cold-launch flushSignalDumpOutbox
                                                 │
                                                 ▼
backend POST /signals/dump → KV `dump:{corrId}` (60일 TTL, tokenPrefix만)
                                                 │
                                                 ▼
운영자 GET /admin/signals/export?corrId=… → 7일 회귀 사후 분석
```

corrId 일치로 device log ↔ backend KV 양방향 매칭 가능. 실패 시 outbox → cold-launch retry로 회복.

### 운영자 실행 절차 (1회성)

```bash
cd backend/alarm-worker
wrangler kv namespace create RAW_SIGNALS
wrangler kv namespace create RAW_SIGNALS --preview
# 출력된 id / preview_id를 wrangler.toml의 `[[kv_namespaces]] binding="RAW_SIGNALS"` 블록 주석 해제 + 채움
wrangler deploy
```

binding 미설정 동안은 `POST /signals/dump`가 503 반환 — device는 `{ok:false}` graceful 처리, trip-end 흐름 영향 없음.

## Test plan

Backend
- [x] vitest unit — `rawSignalDump.test.ts` 20 cases (validator + KV round-trip + corrupt JSON + missing key)
- [x] vitest endpoint — index.test.ts `POST /signals/dump` 5 cases + `GET /admin/signals/export` 7 cases (auth/binding/corrId/dump)
- [x] backend type-check (scheduled.test.ts 사전존재 에러는 무관)
- [x] backend test suite 전체 1493/1493 pass

Device
- [x] jest unit — `signalDumpBackend.test.ts` 19 cases (upload 성공/실패/skip/duplicate + outbox flush + storage graceful)
- [x] jest unit — `triggerTripEndRecall.test.ts` +6 cases (sync/async corrId / skip / 예외 흡수)
- [x] jest unit — `useLaunchTripReconciliation.test.ts` +2 cases (flush 호출 + 예외 흡수)
- [x] `npm run type-check`
- [x] `npm run lint` (max-warnings=0)
- [x] `npm test` 전체 6668/6668 pass, 커버리지 100%

수동 (사용자 — PR-A device wire-up + binding 설정 후)
- [ ] trip 1건 시작 → 도착 trip-end → backend `wrangler kv key get --binding RAW_SIGNALS dump:{corrId}` 확인
- [ ] backend offline 상태에서 trip-end → outbox 적재 확인 → backend 복구 + 앱 cold-launch → flush + KV 적재 확인
- [ ] `GET /admin/signals/export?corrId={cid}` Bearer ADMIN_TOKEN 호출로 entries 회수