### PR TITLE
feat(#1501): DebugModal Raw Signal 섹션 자동 표시 (PR-C)

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -60,6 +60,14 @@ import {
   subscribeFusionDebug,
   type FusionDebugEntry,
 } from '../../../features/nearest-station/utils/fusionDebugBuffer';
+// #1501 — PR-C. PR-A(#1512)가 만든 raw signal ring buffer를 DebugModal에 자동 노출 + share dump 통합.
+// 매 fusion cycle/enter/exit 시 push되는 entry를 직전 30건까지 표시 — toggle 없이 모달 열면 즉시.
+import {
+  clearRawSignalEntries,
+  getRawSignalEntries,
+  subscribeRawSignal,
+  type RawSignalEntry,
+} from '../../observability/utils/rawSignalBuffer';
 import {
   dumpScheduledNotifications,
   formatScheduledNotificationLine,
@@ -162,6 +170,12 @@ export interface AutoLockDebugMeta {
 
 const UNKNOWN_LABEL = '—';
 
+/**
+ * #1501 — Raw signal 섹션 UI/share dump에 노출할 최대 엔트리 수. PR-A의 buffer capacity(120)는
+ * 7일 cold-launch 회귀 사후 재구성용이라 더 크고, 모달 진입 시점에는 직전 30건이면 충분.
+ */
+const RAW_SIGNAL_DISPLAY_LIMIT = 30;
+
 function formatOptionalBool(value: boolean | null | undefined): string {
   if (value === true) return 'true';
   if (value === false) return 'false';
@@ -249,6 +263,29 @@ function formatFusionDebugLine(entry: FusionDebugEntry): string {
     .join(' ');
   const candPart = cand.length > 0 ? cand : '-';
   return `${time} | src=${entry.source} conf=${entry.confidence} | ${station} d=${d} acc=${acc} | ${candPart}`;
+}
+
+/**
+ * #1501 — Raw signal ring buffer entry를 한 줄 텍스트로. 필드 순서:
+ *   `HH:MM:SS | kind | stationId | source/confidence | gps(acc/speed) | motion | subsurface | arvlCd | arcProgress`
+ * 누락 필드는 `-`로 출력 — Fusion log와 동일 컨벤션. line/dir/corrId는 share dump 본문에
+ * 추가 정보가 필요할 때 별도 PR로 확장한다(본 PR-C는 필수 9필드만 노출).
+ */
+function formatRawSignalLine(entry: RawSignalEntry): string {
+  const time = formatTime(entry.ts);
+  const stationId = entry.stationId ?? '-';
+  const source = entry.source ?? '-';
+  const confidence = entry.confidence ?? '-';
+  const acc =
+    entry.gps?.accM != null ? `${Math.round(entry.gps.accM)}m` : '-';
+  const speed =
+    entry.gps?.speedMps != null ? `${entry.gps.speedMps.toFixed(1)}m/s` : '-';
+  const motion = entry.motion ?? '-';
+  const subsurface = formatOptionalBool(entry.subsurface ?? undefined);
+  const arvlCd = entry.arvlCd != null ? String(entry.arvlCd) : '-';
+  const progress =
+    entry.arcProgress != null ? entry.arcProgress.toFixed(2) : '-';
+  return `${time} | ${entry.kind} | ${stationId} | ${source}/${confidence} | gps(${acc}/${speed}) | ${motion} | sub=${subsurface} | arvlCd=${arvlCd} | arc=${progress}`;
 }
 
 /**
@@ -471,6 +508,11 @@ interface BuildDumpArgs {
    * 본 PR은 측정만 — 동작 변경 없음.
    */
   envDistribution?: EnvironmentDistributionSnapshot;
+  /**
+   * #1501 — Raw signal ring buffer entries (직전 30건까지). 미전달 시 (empty) 출력 —
+   * 단위 테스트에서 raw signal을 다루지 않는 경우 호환.
+   */
+  rawSignalLog?: readonly RawSignalEntry[];
 }
 
 /** dump 본체에서 사용하는 single builder 시그니처 — 본문 줄 배열을 반환. */
@@ -632,6 +674,22 @@ function buildAlarmLogSection(args: BuildDumpArgs): string[] {
     lines.push(formatLogLine(entry));
   }
   return lines;
+}
+
+/**
+ * #1501 — Raw signal 섹션. 직전 30건(혹은 그 이하)을 최신순으로 직렬화. 빈 buffer는
+ * (empty)로 명시 — "한 번도 push 안 됨"과 "load 안 함"을 구분(Fusion log와 동일 컨벤션).
+ *
+ * 표시 범위는 buffer 전체가 아닌 상위 RAW_SIGNAL_DISPLAY_LIMIT — share dump가 모달
+ * 모든 신호로 폭주하지 않도록. 사후 분석이 더 필요하면 PR-B의 dump 업로드 채널로.
+ */
+function buildRawSignalSection(args: BuildDumpArgs): string[] {
+  const entries = args.rawSignalLog ?? [];
+  if (entries.length === 0) return ['(empty)'];
+  return [...entries]
+    .reverse()
+    .slice(0, RAW_SIGNAL_DISPLAY_LIMIT)
+    .map(formatRawSignalLine);
 }
 
 /**
@@ -977,6 +1035,13 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
   { title: 'Auto-lock Candidate', build: buildAutoLockSection },
   // #1430 — 환경 분포 측정 인프라. SSOT 활성 cascade → state별 누적 시간 + transition 카운트.
   { title: 'Environment Distribution', build: buildEnvironmentDistributionSection },
+  // #1501 — PR-C. Raw signal ring buffer 직전 30건. cold-launch 사후 재구성 데이터 채널.
+  // suffix는 buffer 전체 개수(>= 표시 개수) — 모달은 상위 30건만 노출하더라도 전체 누적량 확인 가능.
+  {
+    title: 'Raw Signal',
+    build: buildRawSignalSection,
+    suffix: (args) => ` (${args.rawSignalLog?.length ?? 0})`,
+  },
 ];
 
 function buildDumpText(args: BuildDumpArgs): string {
@@ -1228,6 +1293,11 @@ function DebugModalInner({
   const [estimatorLogs, setEstimatorLogs] = useState<readonly EstimatorDebugEntry[]>(() =>
     getEstimatorEntries(),
   );
+  // #1501 — PR-C. Raw signal buffer는 module-level singleton(영속 + boot hydrate).
+  // 모달 마운트 시점 스냅샷으로 초기화, 이후 subscribe로 실시간 갱신.
+  const [rawSignalLog, setRawSignalLog] = useState<readonly RawSignalEntry[]>(() =>
+    getRawSignalEntries(),
+  );
   // #756: OS 큐 ground-truth dump. 호출 직후 한 번 비동기로 채워진다.
   // null = 아직 한 번도 dump 안 한 상태 → "Tap Refresh" placeholder 노출.
   const [scheduledDump, setScheduledDump] = useState<ScheduledNotificationDumpEntry[] | null>(null);
@@ -1242,6 +1312,11 @@ function DebugModalInner({
 
   useEffect(() => {
     return subscribeEstimatorDebug(() => setEstimatorLogs([...getEstimatorEntries()]));
+  }, []);
+
+  // #1501 — PR-C. Raw signal buffer 변경 구독. push/clear 어느 쪽이든 같은 listener로 반응.
+  useEffect(() => {
+    return subscribeRawSignal(() => setRawSignalLog([...getRawSignalEntries()]));
   }, []);
 
   const refreshLogs = useCallback(async () => {
@@ -1323,6 +1398,8 @@ function DebugModalInner({
       autoLockMeta,
       // #1430 — 환경 분포 측정 인프라. state별 누적 ms + transition 카운트.
       envDistribution,
+      // #1501 — PR-C. Raw signal buffer entries (직전 N건). share dump가 모달 표시와 동일 SSOT.
+      rawSignalLog,
     });
     void Share.share({ message });
   }, [
@@ -1364,6 +1441,8 @@ function DebugModalInner({
     autoLockMeta,
     // #1430 — env distribution snapshot도 render-time 산출. state flip 시 share 텍스트 갱신.
     envDistribution,
+    // #1501 — PR-C. raw signal entries 변경 시 share 텍스트 자동 갱신.
+    rawSignalLog,
   ]);
 
   return (
@@ -1665,6 +1744,21 @@ function DebugModalInner({
 
           {/* #1024 — ## Counters: reason별 누적 count + 마지막 발생 시각 */}
           <CountersSection logs={logs} colors={colors} />
+
+          {/* #1501 — PR-C. Raw signal 자동 표시 (toggle 없음). 직전 30건만 노출 — share dump에는
+              buffer 전체가 시간 역순으로 흐른다. Clear는 buffer + AsyncStorage 모두 wipe. */}
+          <DebugLogSection
+            title="Raw Signal"
+            logs={[...rawSignalLog].slice(-RAW_SIGNAL_DISPLAY_LIMIT)}
+            formatLine={formatRawSignalLine}
+            onClear={() => {
+              clearRawSignalEntries();
+              setRawSignalLog([]);
+            }}
+            clearTestId="debug-raw-signal-clear"
+            entryTestId="debug-raw-signal-entry"
+            colors={colors}
+          />
 
           {/* #1022: Worker Quota admin view */}
           <Section title="Worker Quota" colors={colors}>
@@ -2030,6 +2124,9 @@ export const __test__ = {
   deriveEnvironmentState,
   formatPercentage,
   formatDurationMs,
+  // #1501 — PR-C. Raw signal 라인 포맷 helper. share dump 단위 테스트에서 직접 호출.
+  formatRawSignalLine,
+  RAW_SIGNAL_DISPLAY_LIMIT,
 };
 
 const styles = StyleSheet.create({

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -3288,3 +3288,224 @@ describe('DebugModal — #1430 환경 분포 share dump 통합', () => {
     shareSpy.mockRestore();
   });
 });
+
+// #1501 — PR-C. Raw signal 라인 포맷 + share dump 섹션 + UI 자동 표시 / Clear 통합.
+describe('DebugModal — #1501 Raw Signal 섹션', () => {
+  const { formatRawSignalLine, buildDumpText, RAW_SIGNAL_DISPLAY_LIMIT } = __test__;
+  type RawEntry = import('../../../observability/utils/rawSignalBuffer').RawSignalEntry;
+
+  // 단일 entry 빌더 — 테스트마다 override 필드만 지정해 표시/dump 케이스를 격리한다.
+  const makeRawEntry = (overrides: Partial<RawEntry> = {}): RawEntry => ({
+    ts: new Date('2026-06-19T08:00:00Z').getTime(),
+    corrId: null,
+    kind: 'cycle',
+    gps: { lat: 37.5, lng: 127, accM: 25, speedMps: 8.3 },
+    motion: 'automotive',
+    subsurface: false,
+    arvlCd: 99,
+    line: '7',
+    dir: 'up',
+    arcIdx: 3,
+    arcProgress: 0.42,
+    stationId: '7-220',
+    source: 'gps',
+    confidence: 'gps-only',
+    ...overrides,
+  });
+
+  describe('formatRawSignalLine', () => {
+    it.each<{ readonly name: string; readonly entry: RawEntry; readonly contains: readonly string[] }>([
+      {
+        name: '전체 필드 채워진 cycle entry → 9개 토큰 직렬화',
+        entry: makeRawEntry(),
+        contains: [
+          'cycle',
+          '7-220',
+          'gps/gps-only',
+          'gps(25m/8.3m/s)',
+          'automotive',
+          'sub=false',
+          'arvlCd=99',
+          'arc=0.42',
+        ],
+      },
+      {
+        name: 'enter kind + stationId/source/confidence null → kind만 표시 + 나머지 -/—',
+        entry: makeRawEntry({
+          kind: 'enter',
+          stationId: null,
+          source: null,
+          confidence: null,
+          arvlCd: null,
+          arcProgress: null,
+        }),
+        contains: ['enter', '-/-', 'arvlCd=-', 'arc=-'],
+      },
+      {
+        name: 'gps null + motion null + subsurface true → gps(-/-)·motion=-·sub=true',
+        entry: makeRawEntry({
+          gps: null,
+          motion: null,
+          subsurface: true,
+        }),
+        contains: ['gps(-/-)', '| - |', 'sub=true'],
+      },
+      {
+        name: 'gps.accM/speedMps null → 개별 토큰만 -',
+        entry: makeRawEntry({
+          gps: { lat: 37.5, lng: 127, accM: null, speedMps: null },
+        }),
+        contains: ['gps(-/-)'],
+      },
+      {
+        name: 'subsurface null → sub=— (unknown sentinel)',
+        entry: makeRawEntry({ subsurface: null }),
+        contains: ['sub=—'],
+      },
+      {
+        name: 'exit kind + arvlCd=0 → arvlCd=0 (truthy 분기 회귀 방지)',
+        entry: makeRawEntry({ kind: 'exit', arvlCd: 0, arcProgress: 0 }),
+        contains: ['exit', 'arvlCd=0', 'arc=0.00'],
+      },
+    ])('$name', ({ entry, contains }) => {
+      const line = formatRawSignalLine(entry);
+      for (const expected of contains) {
+        expect(line).toContain(expected);
+      }
+    });
+  });
+
+  describe('buildDumpText ## Raw Signal', () => {
+    const dumpRawSection = (rawSignalLog?: readonly RawEntry[]): string => {
+      const dump = buildDumpText(
+        makeDumpArgs(rawSignalLog === undefined ? {} : { rawSignalLog }),
+      );
+      return dump.slice(dump.indexOf('## Raw Signal'));
+    };
+
+    it('rawSignalLog 미전달 → 헤더(0) + (empty)', () => {
+      const section = dumpRawSection();
+      expect(section).toContain('## Raw Signal (0)');
+      expect(section).toContain('(empty)');
+    });
+
+    it('빈 배열도 (empty) 출력 (Fusion log 컨벤션)', () => {
+      const section = dumpRawSection([]);
+      expect(section).toContain('## Raw Signal (0)');
+      expect(section).toContain('(empty)');
+    });
+
+    it('3건 → 최신이 위 (역순) + suffix는 buffer 전체 길이', () => {
+      const entries: RawEntry[] = [
+        makeRawEntry({ ts: 1000, stationId: 'A' }),
+        makeRawEntry({ ts: 2000, stationId: 'B' }),
+        makeRawEntry({ ts: 3000, stationId: 'C' }),
+      ];
+      const section = dumpRawSection(entries);
+      expect(section).toContain('## Raw Signal (3)');
+      const stationCIdx = section.indexOf('| C |');
+      const stationBIdx = section.indexOf('| B |');
+      const stationAIdx = section.indexOf('| A |');
+      expect(stationCIdx).toBeGreaterThan(-1);
+      expect(stationCIdx).toBeLessThan(stationBIdx);
+      expect(stationBIdx).toBeLessThan(stationAIdx);
+    });
+
+    it(`상위 ${RAW_SIGNAL_DISPLAY_LIMIT}건만 dump (overflow 분리)`, () => {
+      const entries: RawEntry[] = Array.from({ length: RAW_SIGNAL_DISPLAY_LIMIT + 5 }, (_, i) =>
+        makeRawEntry({ ts: i * 1000, stationId: `S${i}` }),
+      );
+      const dump = buildDumpText(makeDumpArgs({ rawSignalLog: entries }));
+      // suffix는 buffer 전체 (35) — display limit과 분리.
+      expect(dump).toContain(`## Raw Signal (${RAW_SIGNAL_DISPLAY_LIMIT + 5})`);
+      const section = dump.slice(dump.indexOf('## Raw Signal'));
+      // 가장 오래된 entry(S0)는 dump에서 잘림.
+      expect(section).not.toContain('| S0 |');
+      // 가장 최신(S34)은 포함.
+      expect(section).toContain(`| S${RAW_SIGNAL_DISPLAY_LIMIT + 4} |`);
+    });
+
+    it('SHARE_SECTIONS에 Raw Signal 헤더 1회 + Environment Distribution 다음에 위치', () => {
+      const dump = buildDumpText(makeDumpArgs());
+      const envIdx = dump.indexOf('## Environment Distribution');
+      const rawIdx = dump.indexOf('## Raw Signal');
+      expect(envIdx).toBeGreaterThan(-1);
+      expect(rawIdx).toBeGreaterThan(envIdx);
+      expect(dump.split('## Raw Signal').length - 1).toBe(1);
+    });
+  });
+
+  describe('DebugModal UI 자동 표시 + Clear', () => {
+    const {
+      pushRawSignal,
+      clearRawSignalEntries,
+      __resetRawSignalForTests__,
+    } = jest.requireActual('../../../observability/utils/rawSignalBuffer');
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      __resetRawSignalForTests__();
+      setupHookDefaults();
+      jest.spyOn(AppState, 'addEventListener').mockReturnValue({
+        remove: jest.fn(),
+      } as unknown as ReturnType<typeof AppState.addEventListener>);
+    });
+
+    afterEach(() => {
+      __resetRawSignalForTests__();
+    });
+
+    it('모달 진입 시 buffer 스냅샷 표시 (toggle 없음, 직전 entry 자동 노출)', async () => {
+      pushRawSignal(makeRawEntry({ ts: 1000, stationId: 'PRE-MOUNT' }));
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      expect(screen.getByText('Raw Signal (1)')).toBeTruthy();
+      const entries = screen.getAllByTestId('debug-raw-signal-entry');
+      expect(entries[0].props.children).toContain('PRE-MOUNT');
+    });
+
+    it('마운트 이후 push 시 listener가 UI 갱신', async () => {
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      expect(screen.getByText('Raw Signal (0)')).toBeTruthy();
+      act(() => {
+        pushRawSignal(makeRawEntry({ ts: 5000, stationId: 'POST-MOUNT' }));
+      });
+      expect(screen.getByText('Raw Signal (1)')).toBeTruthy();
+      const entries = screen.getAllByTestId('debug-raw-signal-entry');
+      expect(entries[0].props.children).toContain('POST-MOUNT');
+    });
+
+    it('Clear 버튼이 buffer와 UI를 동시에 비운다', async () => {
+      pushRawSignal(makeRawEntry({ stationId: 'TO-CLEAR' }));
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByText('Raw Signal (1)')).toBeTruthy());
+      act(() => {
+        fireEvent.press(screen.getByTestId('debug-raw-signal-clear'));
+      });
+      expect(screen.getByText('Raw Signal (0)')).toBeTruthy();
+      // buffer SSOT까지 비웠는지 확인 — getRawSignalEntries는 listener와 동일 buffer.
+      const { getRawSignalEntries } = jest.requireActual(
+        '../../../observability/utils/rawSignalBuffer',
+      );
+      expect(getRawSignalEntries()).toEqual([]);
+      // 직접 clearRawSignalEntries도 호출 가능(idempotent 확인).
+      clearRawSignalEntries();
+      expect(getRawSignalEntries()).toEqual([]);
+    });
+
+    it('share dump가 SSOT raw signal entries를 포함한다', async () => {
+      pushRawSignal(makeRawEntry({ stationId: 'SHARE-INTEGRATION' }));
+      const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      await waitFor(() => expect(screen.getByText('Raw Signal (1)')).toBeTruthy());
+      fireEvent.press(screen.getByTestId('debug-share-dump'));
+      await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+      const msg = shareSpy.mock.calls[0][0].message;
+      expect(msg).toContain('## Raw Signal (1)');
+      expect(msg).toContain('SHARE-INTEGRATION');
+      shareSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

#1501 (M1 raw signal) sub-PR-C. PR-A(#1512)에서 만든 `rawSignalBuffer` SSOT를 DebugModal에 자동 노출. toggle 없이 모달 진입 즉시 직전 N entry를 표시하고, share dump에도 같은 데이터 채널을 통합한다.

### 변경

- **`DebugModal.tsx`**
  - `subscribeRawSignal()` listener로 마운트 시 buffer 스냅샷 초기화 + 이후 실시간 갱신
  - `formatRawSignalLine` helper: `ts | kind | stationId | source/confidence | gps(acc/speed) | motion | sub | arvlCd | arc` 9필드 직렬화 (Fusion log 컨벤션과 동일)
  - `buildRawSignalSection`을 `SHARE_SECTIONS` 마지막에 등록 (Environment Distribution 다음)
  - UI는 기존 `DebugLogSection` 재사용 — 상위 `RAW_SIGNAL_DISPLAY_LIMIT(30)`건만 노출
  - Clear 버튼이 buffer + AsyncStorage + UI를 동시에 wipe (`clearRawSignalEntries` 호출)
  - share dump suffix는 buffer 전체 길이 → 누적량과 표시량이 분리돼 사용자가 즉시 인지

### 표시 vs Dump 정책

- **모달 UI**: 직전 30건만 (관찰 부담 최소화)
- **Share dump**: buffer 전체를 시간 역순으로 — 헤더 suffix `(N)`로 총량 명시
- **빈 buffer**: `(empty)` 명시 (load 안 함과 push 0건 구분)

### 다른 BG agent와의 충돌 회피

- 다른 BG agent(#1518 backend HTTP 로깅)가 같은 DebugModal에 "Backend Calls" 섹션 추가 예정 → `SHARE_SECTIONS` 배열 끝에 push 패턴으로 등록. UI section도 Counters 다음, Worker Quota 앞에 삽입 — 추후 PR이 같은 위치 또는 그 뒤에 append 가능.

### i18n

- DebugModal은 디버그 도구로 전체 section title이 영문 hardcoded (`Fusion log`, `Environment Distribution`, `Auto-lock Candidate` 등). 본 PR도 같은 컨벤션을 따라 `'Raw Signal'`로 통일 — locales 파일 변경 없음.

### 테스트 (15건)

- `formatRawSignalLine` 6 케이스 — 전체 필드 / null gps / null subsurface / arvlCd=0 truthy 분기 / kind별 분기
- `buildDumpText ## Raw Signal` 5 케이스 — 미전달 / 빈 배열 / 3건 역순 / overflow(buffer 35 → 표시 30) / SHARE_SECTIONS 위치 + 헤더 1회
- UI 통합 4건 — 마운트 시점 스냅샷 / listener 갱신 / Clear 버튼 / share dump 통합

## Test plan

- [x] `npm run type-check` 통과
- [x] `npm run lint` 통과
- [x] `npm test` 통과 (6668 tests, 329 suites, 100% coverage)
- [ ] 사용자: 실기기에서 모달 진입 시 Raw Signal 섹션 자동 표시 확인
- [ ] 사용자: cycle/enter/exit push 시 라인 갱신 확인
- [ ] 사용자: Share dump에 `## Raw Signal (N)` + 30건 시간 역순 라인 확인

Closes #1501 sub-task PR-C.