### PR TITLE
fix(#1515): station-level cross-category dedup 통합

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -82,6 +82,7 @@ const mockLogSuppressedStationPassedWarmup = jest.fn();
 const mockLogSuppressedHopWindow = jest.fn();
 const mockLogSuppressedHopWindowNoSource = jest.fn();
 const mockLogSuppressedOriginHopLockless = jest.fn();
+const mockLogSuppressedCrossCategoryDedup = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
   logFiredAlarmsHydrate: (...args: unknown[]) => mockLogFiredAlarmsHydrate(...args),
@@ -104,6 +105,8 @@ jest.mock('../../utils/alarmLog', () => ({
     mockLogSuppressedHopWindowNoSource(...args),
   logSuppressedOriginHopLockless: (...args: unknown[]) =>
     mockLogSuppressedOriginHopLockless(...args),
+  logSuppressedCrossCategoryDedup: (...args: unknown[]) =>
+    mockLogSuppressedCrossCategoryDedup(...args),
 }));
 
 const mockGetBoardingLock = jest.fn();
@@ -185,6 +188,9 @@ describe('useStationAlarm', () => {
     mockGetBoardingLock.mockResolvedValue(null);
     mockFindFgArvlCdFireSignal.mockReturnValue(null);
     mockAwaitInitialScheduledAlarmDrain.mockResolvedValue(undefined);
+    // #1515 — cross-category dedup 모듈 in-memory 상태 리셋. mock하지 않은 실모듈 사용.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('../../utils/crossCategoryStationDedup')._resetCrossCategoryDedupForTests();
   });
 
   it('does not evaluate when route is null', () => {
@@ -607,6 +613,29 @@ describe('useStationAlarm', () => {
       expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(imminentDest, false, true, undefined),
     );
     expect(mockSendAlarmNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it('#1515 cross-category dedup — 같은 station에 station-passed가 직전 fire됐다면 phase 알람 차단', async () => {
+    // 직전 station-passed fire를 시뮬레이션: dedup map에 직접 mark.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const dedup = require('../../utils/crossCategoryStationDedup');
+    const route = makeDirectRoute(1, '2');
+    dedup.markStationFired(destination.id, earlyDest.stationName, 'station-passed', Date.now());
+    mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+    renderHook(() =>
+      useStationAlarm(
+        defaultInputs({ route, destination, userLocation: { lat: 37.4, lng: 127 }, speedMps: 5 }),
+      ),
+    );
+    await waitFor(() =>
+      expect(mockLogSuppressedCrossCategoryDedup).toHaveBeenCalledWith({
+        source: 'fg',
+        stationName: earlyDest.stationName,
+        kind: 'destination',
+        phaseId: 'early',
+      }),
+    );
+    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
   });
 
   it('destination 변경 시 새 destinationId로 re-hydrate 한다 (#462 destination scoped)', async () => {
@@ -2762,15 +2791,20 @@ describe('useStationAlarm', () => {
     // fast path 발사 여부만 가린다. GPS path는 sendStationPassedNotification을 'fg' source로 logFiredStationPassed
     // 호출하므로 mock 호출 인자로 식별 가능.
 
-    it('lock 활성 + arvlCd 신호 → station-passed 알림 발사 + lastNotifiedStationId 갱신 + fg-arvlcd source 적재', async () => {
+    it('lock 활성 + arvlCd 신호 → station-passed 알림 발사 + lastNotifiedStationId 갱신', async () => {
       mockGetBoardingLock.mockResolvedValue(activeLock);
       mockGetLastNotifiedStationId.mockResolvedValue(null);
       mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
 
       renderHook(() => useStationAlarm(fastPathInputs()));
 
-      await waitFor(() =>
-        expect(mockLogFiredStationPassed).toHaveBeenCalledWith('fg-arvlcd', onRouteStation),
+      // #1515 — cross-category station-level dedup으로 GPS path와 fast-path 중 먼저 reservation을
+      // 점유한 쪽만 발사된다(같은 station, 같은 destination, 30s 윈도우). 발사 1회 + 호출 인자만 검증.
+      await waitFor(() => expect(mockLogFiredStationPassed).toHaveBeenCalled());
+      expect(mockLogFiredStationPassed).toHaveBeenCalledTimes(1);
+      expect(mockLogFiredStationPassed).toHaveBeenCalledWith(
+        expect.stringMatching(/^fg(-arvlcd)?$/),
+        onRouteStation,
       );
       expect(mockSendStationPassedNotification).toHaveBeenCalled();
       expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, onRouteStation.id);
@@ -3211,8 +3245,11 @@ describe('useStationAlarm', () => {
         ),
       );
 
-      await waitFor(() =>
-        expect(mockLogFiredStationPassed).toHaveBeenCalledWith('fg-arvlcd', arcLine2[3]),
+      // #1515 — cross-category dedup으로 GPS path/fast-path 중 먼저 reservation 점유한 쪽만 발사.
+      await waitFor(() => expect(mockLogFiredStationPassed).toHaveBeenCalled());
+      expect(mockLogFiredStationPassed).toHaveBeenCalledWith(
+        expect.stringMatching(/^fg(-arvlcd)?$/),
+        arcLine2[3],
       );
       expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
     });
@@ -3238,9 +3275,11 @@ describe('useStationAlarm', () => {
           stationName: arcLine2[0].name,
         });
       });
-      // 게이트 미적용이므로 정상 발사.
-      await waitFor(() =>
-        expect(mockLogFiredStationPassed).toHaveBeenCalledWith('fg-arvlcd', arcLine2[0]),
+      // 게이트 미적용이므로 정상 발사. #1515 — GPS path/fast-path 중 reservation을 먼저 잡은 쪽만 fire.
+      await waitFor(() => expect(mockLogFiredStationPassed).toHaveBeenCalled());
+      expect(mockLogFiredStationPassed).toHaveBeenCalledWith(
+        expect.stringMatching(/^fg(-arvlcd)?$/),
+        arcLine2[0],
       );
     });
 
@@ -3258,8 +3297,11 @@ describe('useStationAlarm', () => {
         ),
       );
 
-      await waitFor(() =>
-        expect(mockLogFiredStationPassed).toHaveBeenCalledWith('fg-arvlcd', arcLine2[0]),
+      // #1515 — GPS path/fast-path 중 reservation을 먼저 잡은 쪽만 fire.
+      await waitFor(() => expect(mockLogFiredStationPassed).toHaveBeenCalled());
+      expect(mockLogFiredStationPassed).toHaveBeenCalledWith(
+        expect.stringMatching(/^fg(-arvlcd)?$/),
+        arcLine2[0],
       );
       expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
       expect(mockLogSuppressedHopWindowNoSource).not.toHaveBeenCalled();

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -39,6 +39,7 @@ import {
   logFiredStationPassed,
   logHydrationTransition,
   logRefMismatch,
+  logSuppressedCrossCategoryDedup,
   logSuppressedDedupAlarm,
   logSuppressedDedupStation,
   logSuppressedDismissSilence,
@@ -52,6 +53,10 @@ import {
   logSuppressedStationPassedWarmup,
   type HydrationPhase,
 } from '../utils/alarmLog';
+import {
+  isStationRecentlyFired,
+  markStationFired,
+} from '../utils/crossCategoryStationDedup';
 import { evaluateDismissSilence } from '../utils/dismissSilenceGate';
 import { getBoardingLock } from '../utils/boardingLockStorage';
 import { resolveCurrentLine } from '../utils/resolveCurrentLine';
@@ -152,6 +157,35 @@ async function dispatchStationPassed(params: {
       logSuppressedDedupStation(source, candidateStation);
       return;
     }
+    // #1515 — cross-category station-level dedup. destination/transfer가 같은 station에 직전 fire됐다면
+    // station-passed 발사 차단. 같은 station 30s 내 카테고리 합산 1건 보장(2026-06-19 성수 회귀).
+    // 본 가드는 lastNotifiedStationId(같은 카테고리) dedup 다음에 위치 — destination phase fire가
+    // 별도 dedup 출처를 쓰는 회귀를 cross-cut으로 차단한다.
+    if (
+      isStationRecentlyFired(
+        capturedDestinationId,
+        candidateStation.name,
+        'station-passed',
+        Date.now(),
+      )
+    ) {
+      logSuppressedCrossCategoryDedup({
+        source,
+        stationName: candidateStation.name,
+        kind: 'station-passed',
+      });
+      return;
+    }
+    // race 차단: send 도중 동일 effect/다른 path가 진입해 같은 station을 발사하는 것을 막기 위해
+    // send 전에 윈도우 갱신(reservation). send 실패 시에도 30s 동안 cross-category 재발사 차단 —
+    // 이슈 acceptance "같은 station 30s 내 cross-category fire 1건 이하"에 정합.
+    // category='station-passed' → 후속 destination/transfer 발사 차단.
+    markStationFired(
+      capturedDestinationId,
+      candidateStation.name,
+      'station-passed',
+      Date.now(),
+    );
     // #796: candidateStation.line을 전달해 multi-transfer 환승역 정확 식별.
     const target = resolveNextTarget(
       capturedRoute,
@@ -551,6 +585,27 @@ export function useStationAlarm({
       });
       return;
     }
+    // #1515 — cross-category station-level dedup. 같은 station에 직전 station-passed가 fire됐다면
+    // destination/transfer phase 알람 후속 발사 차단. category 인자로 phase 알람끼리 진행
+    // (early→imminent)은 차단하지 않음 — firedAlarms(phase 카테고리 내 dedup)이 단독 작동.
+    if (
+      isStationRecentlyFired(activeDestination.id, rawEvent.stationName, rawEvent.type, Date.now())
+    ) {
+      // firedAlarmsRef.add(key)는 진입부에서 이미 수행 — phase 카테고리 dedup은 유지(다음 사이클에
+      // 같은 phase 재평가 막음). cross-category 차단도 sleep 차단과 동일하게 firedAlarms ref만
+      // 갱신했으므로 storage 영속화 skip(net-zero).
+      firedAlarmsRef.current.delete(key);
+      logSuppressedCrossCategoryDedup({
+        source: 'fg',
+        stationName: rawEvent.stationName,
+        kind: rawEvent.type,
+        phaseId: rawEvent.phaseId,
+      });
+      return;
+    }
+    // race 차단 reservation — send 전에 윈도우 갱신해 await 동안 다른 effect가 같은 station을 발사
+    // 못하게 한다. category=phase type → 후속 station-passed 차단.
+    markStationFired(activeDestination.id, rawEvent.stationName, rawEvent.type, Date.now());
     // 좌/우 안내 방향. nearestStation 미정이면 direction 미부착(본문에 좌/우 라인 생략).
     const direction = nearestStation
       ? resolveAlarmDirection(rawEvent, {

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -28,6 +28,7 @@ import {
   DEDUP_LOG_WINDOW_MS,
   FLUSH_DEBOUNCE_MS,
   FLUSH_MAX_DELAY_MS,
+  logSuppressedCrossCategoryDedup,
   logSuppressedDedupStation,
   logSuppressedDismissSilence,
   logSuppressedSleepFirstTransfer,
@@ -522,6 +523,34 @@ describe('alarmLog', () => {
         stationName: station.name,
         kind: 'station-passed',
       });
+    });
+
+    it('#1515 logSuppressedCrossCategoryDedup: reason=dedup-station-unified + kind/phase 보존', async () => {
+      _resetBurstSuppressWindowForTests();
+      logSuppressedCrossCategoryDedup({
+        source: 'fg',
+        stationName: '성수',
+        kind: 'station-passed',
+      });
+      await expectLastSavedEntryMatches({
+        source: 'fg',
+        outcome: 'suppressed',
+        reason: 'dedup-station-unified',
+        stationName: '성수',
+        kind: 'station-passed',
+      });
+    });
+
+    it('#1515 logSuppressedCrossCategoryDedup: 윈도우 내 같은 stationName 재호출은 drop', async () => {
+      _resetBurstSuppressWindowForTests();
+      logSuppressedCrossCategoryDedup({ source: 'fg', stationName: '성수', kind: 'destination' });
+      logSuppressedCrossCategoryDedup({ source: 'fg', stationName: '성수', kind: 'station-passed' });
+      await flushAlarmLog();
+      const calls = (AsyncStorage.setItem as jest.Mock).mock.calls;
+      const lastJson = calls[calls.length - 1][1];
+      const saved: AlarmLogEntry[] = JSON.parse(lastJson);
+      const unified = saved.filter((e) => e.reason === 'dedup-station-unified');
+      expect(unified).toHaveLength(1);
     });
 
     it('logSuppressedDedupAlarm: reason=dedup-alarm, phase+type+stationName 적재 (#580)', async () => {

--- a/src/features/alarm/utils/__tests__/crossCategoryStationDedup.test.ts
+++ b/src/features/alarm/utils/__tests__/crossCategoryStationDedup.test.ts
@@ -5,6 +5,8 @@ import {
   markStationFired,
 } from '../crossCategoryStationDedup';
 
+type Category = Parameters<typeof markStationFired>[2];
+
 describe('crossCategoryStationDedup (#1515)', () => {
   beforeEach(() => {
     _resetCrossCategoryDedupForTests();
@@ -14,34 +16,20 @@ describe('crossCategoryStationDedup (#1515)', () => {
     expect(isStationRecentlyFired('dest-1', '성수', 'station-passed', 1_000)).toBe(false);
   });
 
-  it('cross-category: destination fired → station-passed within window is blocked', () => {
-    markStationFired('dest-1', '성수', 'destination', 1_000);
-    expect(isStationRecentlyFired('dest-1', '성수', 'station-passed', 1_500)).toBe(true);
-  });
-
-  it('cross-category: station-passed fired → destination within window is blocked', () => {
-    markStationFired('dest-1', '성수', 'station-passed', 1_000);
-    expect(isStationRecentlyFired('dest-1', '성수', 'destination', 1_500)).toBe(true);
-  });
-
-  it('cross-category: station-passed fired → transfer within window is blocked', () => {
-    markStationFired('dest-1', '성수', 'station-passed', 1_000);
-    expect(isStationRecentlyFired('dest-1', '성수', 'transfer', 1_500)).toBe(true);
-  });
-
-  it('same category (phase progression): destination → destination is NOT blocked (early→imminent)', () => {
-    markStationFired('dest-1', '성수', 'destination', 1_000);
-    expect(isStationRecentlyFired('dest-1', '성수', 'destination', 1_500)).toBe(false);
-  });
-
-  it('same category (phase group): destination → transfer is NOT blocked', () => {
-    markStationFired('dest-1', '성수', 'destination', 1_000);
-    expect(isStationRecentlyFired('dest-1', '성수', 'transfer', 1_500)).toBe(false);
-  });
-
-  it('station-passed → station-passed within window IS blocked (FG GPS path / fast-path race fix)', () => {
-    markStationFired('dest-1', '성수', 'station-passed', 1_000);
-    expect(isStationRecentlyFired('dest-1', '성수', 'station-passed', 1_500)).toBe(true);
+  // (firstFired, secondQuery, expectedBlocked, label)
+  // - cross-category within window → blocked
+  // - same-category phase progression (destination→destination, destination→transfer) → NOT blocked
+  // - station-passed → station-passed → blocked (FG GPS path / fast-path race fix)
+  it.each<[Category, Category, boolean, string]>([
+    ['destination', 'station-passed', true, 'cross-cat: destination → station-passed blocked'],
+    ['station-passed', 'destination', true, 'cross-cat: station-passed → destination blocked'],
+    ['station-passed', 'transfer', true, 'cross-cat: station-passed → transfer blocked'],
+    ['destination', 'destination', false, 'same-cat phase progression: destination → destination NOT blocked'],
+    ['destination', 'transfer', false, 'same-cat phase group: destination → transfer NOT blocked'],
+    ['station-passed', 'station-passed', true, 'station-passed → station-passed blocked (FG fast-path race fix)'],
+  ])('%s → %s within window: blocked=%s (%s)', (first, second, blocked) => {
+    markStationFired('dest-1', '성수', first, 1_000);
+    expect(isStationRecentlyFired('dest-1', '성수', second, 1_500)).toBe(blocked);
   });
 
   it('returns false once the window has elapsed', () => {

--- a/src/features/alarm/utils/__tests__/crossCategoryStationDedup.test.ts
+++ b/src/features/alarm/utils/__tests__/crossCategoryStationDedup.test.ts
@@ -1,0 +1,111 @@
+import {
+  CROSS_CATEGORY_DEDUP_WINDOW_MS,
+  _resetCrossCategoryDedupForTests,
+  isStationRecentlyFired,
+  markStationFired,
+} from '../crossCategoryStationDedup';
+
+describe('crossCategoryStationDedup (#1515)', () => {
+  beforeEach(() => {
+    _resetCrossCategoryDedupForTests();
+  });
+
+  it('returns false when no fire has been recorded', () => {
+    expect(isStationRecentlyFired('dest-1', '성수', 'station-passed', 1_000)).toBe(false);
+  });
+
+  it('cross-category: destination fired → station-passed within window is blocked', () => {
+    markStationFired('dest-1', '성수', 'destination', 1_000);
+    expect(isStationRecentlyFired('dest-1', '성수', 'station-passed', 1_500)).toBe(true);
+  });
+
+  it('cross-category: station-passed fired → destination within window is blocked', () => {
+    markStationFired('dest-1', '성수', 'station-passed', 1_000);
+    expect(isStationRecentlyFired('dest-1', '성수', 'destination', 1_500)).toBe(true);
+  });
+
+  it('cross-category: station-passed fired → transfer within window is blocked', () => {
+    markStationFired('dest-1', '성수', 'station-passed', 1_000);
+    expect(isStationRecentlyFired('dest-1', '성수', 'transfer', 1_500)).toBe(true);
+  });
+
+  it('same category (phase progression): destination → destination is NOT blocked (early→imminent)', () => {
+    markStationFired('dest-1', '성수', 'destination', 1_000);
+    expect(isStationRecentlyFired('dest-1', '성수', 'destination', 1_500)).toBe(false);
+  });
+
+  it('same category (phase group): destination → transfer is NOT blocked', () => {
+    markStationFired('dest-1', '성수', 'destination', 1_000);
+    expect(isStationRecentlyFired('dest-1', '성수', 'transfer', 1_500)).toBe(false);
+  });
+
+  it('station-passed → station-passed within window IS blocked (FG GPS path / fast-path race fix)', () => {
+    markStationFired('dest-1', '성수', 'station-passed', 1_000);
+    expect(isStationRecentlyFired('dest-1', '성수', 'station-passed', 1_500)).toBe(true);
+  });
+
+  it('returns false once the window has elapsed', () => {
+    markStationFired('dest-1', '성수', 'destination', 1_000);
+    expect(
+      isStationRecentlyFired(
+        'dest-1',
+        '성수',
+        'station-passed',
+        1_000 + CROSS_CATEGORY_DEDUP_WINDOW_MS,
+      ),
+    ).toBe(false);
+  });
+
+  it('isolates entries by destinationId', () => {
+    markStationFired('dest-1', '성수', 'destination', 1_000);
+    expect(isStationRecentlyFired('dest-2', '성수', 'station-passed', 1_500)).toBe(false);
+  });
+
+  it('isolates entries by stationName', () => {
+    markStationFired('dest-1', '성수', 'destination', 1_000);
+    expect(isStationRecentlyFired('dest-1', '왕십리', 'station-passed', 1_500)).toBe(false);
+  });
+
+  it('normalizes station name (parenthetical suffix)', () => {
+    markStationFired('dest-1', '왕십리(성동구청)', 'destination', 1_000);
+    expect(isStationRecentlyFired('dest-1', '왕십리', 'station-passed', 1_500)).toBe(true);
+  });
+
+  it('accepts custom window override', () => {
+    markStationFired('dest-1', '성수', 'destination', 1_000);
+    expect(isStationRecentlyFired('dest-1', '성수', 'station-passed', 1_500, 100)).toBe(false);
+    expect(isStationRecentlyFired('dest-1', '성수', 'station-passed', 1_050, 100)).toBe(true);
+  });
+
+  it('updates the record on subsequent markStationFired (category overwrite)', () => {
+    markStationFired('dest-1', '성수', 'destination', 1_000);
+    // station-passed fired after — cross-cat with destination dedup'd by previous mark.
+    markStationFired('dest-1', '성수', 'station-passed', 1_100);
+    // Subsequent destination call must now see station-passed (latest) as previous → cross-cat block.
+    expect(isStationRecentlyFired('dest-1', '성수', 'destination', 1_200)).toBe(true);
+  });
+
+  it('sweeps expired entries once the map exceeds the cap', () => {
+    for (let i = 0; i < 260; i += 1) {
+      markStationFired(`dest-${i}`, '역', 'destination', 0);
+    }
+    expect(isStationRecentlyFired('dest-0', '역', 'station-passed', 1)).toBe(true);
+    markStationFired('dest-new', '역', 'destination', CROSS_CATEGORY_DEDUP_WINDOW_MS + 1);
+    expect(
+      isStationRecentlyFired(
+        'dest-0',
+        '역',
+        'station-passed',
+        CROSS_CATEGORY_DEDUP_WINDOW_MS + 1,
+      ),
+    ).toBe(false);
+    expect(
+      isStationRecentlyFired(
+        'dest-new',
+        '역',
+        'station-passed',
+        CROSS_CATEGORY_DEDUP_WINDOW_MS + 2,
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -837,7 +837,6 @@ describe('processLocationUpdate', () => {
 
   // #1515 — cross-category station-level dedup (BG path).
   describe('#1515 cross-category station-level dedup (BG path)', () => {
-    const destStation: Station = { ...mockDestination, name: '시청', id: 'station-2' };
     const passedStation: Station = { ...mockStation, name: '강남', id: 'station-1' };
     beforeEach(() => {
       mockFindNearestStation.mockReturnValue({ station: passedStation, distanceKm: 0.05 });
@@ -894,8 +893,6 @@ describe('processLocationUpdate', () => {
       expect(mockSendAlarmNotification).not.toHaveBeenCalled();
     });
 
-    // 미사용 변수 silencing: destStation은 위 시나리오에서 호출자 destination으로 사용 가능.
-    void destStation;
   });
 
   // #1236 (Epic #1204 D8 wire) — BG station-passed dispatch path도 sleep 룰 게이트 호출.

--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -76,6 +76,7 @@ const mockLogSuppressedDedupAlarm = jest.fn();
 const mockLogSuppressedSleepFirstTransfer = jest.fn();
 const mockLogSuppressedSleepStationPassed = jest.fn();
 const mockLogSuppressedDismissSilence = jest.fn();
+const mockLogSuppressedCrossCategoryDedup = jest.fn();
 jest.mock('../alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
   logFiredStationPassed: (...args: unknown[]) => mockLogFiredStationPassed(...args),
@@ -86,6 +87,8 @@ jest.mock('../alarmLog', () => ({
   logSuppressedSleepStationPassed: (...args: unknown[]) =>
     mockLogSuppressedSleepStationPassed(...args),
   logSuppressedDismissSilence: (...args: unknown[]) => mockLogSuppressedDismissSilence(...args),
+  logSuppressedCrossCategoryDedup: (...args: unknown[]) =>
+    mockLogSuppressedCrossCategoryDedup(...args),
 }));
 
 import { processLocationUpdate, resolveNextTarget } from '../stationPipeline';
@@ -131,6 +134,9 @@ function call(overrides: Partial<Parameters<typeof processLocationUpdate>[0]> = 
 describe('processLocationUpdate', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // #1515 — cross-category dedup module 상태는 mock 대상이 아니므로 명시 리셋.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('../crossCategoryStationDedup')._resetCrossCategoryDedupForTests();
     mockSendAlarmNotification.mockResolvedValue(undefined);
     mockUpdateStationNotification.mockResolvedValue(undefined);
     mockSendStationPassedNotification.mockResolvedValue(undefined);
@@ -827,6 +833,69 @@ describe('processLocationUpdate', () => {
       expect(mockSendAlarmNotification).not.toHaveBeenCalled();
       expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
     });
+  });
+
+  // #1515 — cross-category station-level dedup (BG path).
+  describe('#1515 cross-category station-level dedup (BG path)', () => {
+    const destStation: Station = { ...mockDestination, name: '시청', id: 'station-2' };
+    const passedStation: Station = { ...mockStation, name: '강남', id: 'station-1' };
+    beforeEach(() => {
+      mockFindNearestStation.mockReturnValue({ station: passedStation, distanceKm: 0.05 });
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockIsStationOnRoute.mockReturnValue(true);
+      mockEvaluateAlarmPhase.mockReturnValue(null);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+    });
+
+    it('phase 알람 발사 후 같은 station BG station-passed는 cross-category dedup으로 차단', async () => {
+      // 1st call — phase 알람 발사 → mark.
+      mockEvaluateAlarmPhase.mockReturnValueOnce({
+        phaseId: 'imminent',
+        type: 'destination',
+        stationName: passedStation.name,
+      });
+      // station-passed 분기를 진입하지 않도록 isStationOnRoute=false로 1차 call 한정.
+      mockIsStationOnRoute.mockReturnValueOnce(false);
+      await call({ source: 'fg-evaluated' });
+      expect(mockLogFiredAlarm).toHaveBeenCalled();
+
+      // 2nd call — station-passed 분기 진입. cross-category로 차단되어야 함.
+      mockEvaluateAlarmPhase.mockReturnValue(null);
+      mockIsStationOnRoute.mockReturnValue(true);
+      await call({ source: 'bg' });
+      expect(mockLogSuppressedCrossCategoryDedup).toHaveBeenCalledWith({
+        source: 'bg',
+        stationName: passedStation.name,
+        kind: 'station-passed',
+      });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('station-passed 발사 후 같은 station phase 알람은 cross-category dedup으로 차단', async () => {
+      // 1st: station-passed 발사 → mark.
+      await call({ source: 'bg' });
+      expect(mockSendStationPassedNotification).toHaveBeenCalled();
+
+      // 2nd: phase 알람 같은 station — cross-cat 차단. (다른 destination이라 lastNotifiedStationId
+      // 게이트는 다른 키, isStationOnRoute false로 station-passed 분기 회피.)
+      mockEvaluateAlarmPhase.mockReturnValue({
+        phaseId: 'imminent',
+        type: 'destination',
+        stationName: passedStation.name,
+      });
+      mockIsStationOnRoute.mockReturnValue(false);
+      await call({ source: 'fg-evaluated' });
+      expect(mockLogSuppressedCrossCategoryDedup).toHaveBeenCalledWith({
+        source: 'fg-evaluated',
+        stationName: passedStation.name,
+        kind: 'destination',
+        phaseId: 'imminent',
+      });
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    // 미사용 변수 silencing: destStation은 위 시나리오에서 호출자 destination으로 사용 가능.
+    void destStation;
   });
 
   // #1236 (Epic #1204 D8 wire) — BG station-passed dispatch path도 sleep 룰 게이트 호출.

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -64,6 +64,10 @@ export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 export type AlarmLogReason =
   | 'dedup-station'
   | 'dedup-alarm'
+  // #1515 — station-level cross-category dedup. firedAlarms(phase) + lastNotifiedStationId(station-passed)
+  // 분리된 두 dedup 위에 얹은 station 단위 윈도우 dedup. 같은 (destinationId, stationName)이
+  // CROSS_CATEGORY_DEDUP_WINDOW_MS 안에 fire되면 후속 카테고리 발사 차단(2026-06-19 성수 회귀).
+  | 'dedup-station-unified'
   | 'gate-age'
   | 'gate-accuracy'
   | 'gate-jump'
@@ -284,6 +288,31 @@ export function logFiredStationPassed(source: AlarmLogSource, station: Station):
     outcome: 'fired',
     stationName: station.name,
     kind: 'station-passed',
+  });
+}
+
+/**
+ * #1515 — cross-category station-level dedup 적중 1건 적재.
+ *
+ * 같은 (destinationId, stationName)이 CROSS_CATEGORY_DEDUP_WINDOW_MS 안에 fire된 station에
+ * destination/transfer/station-passed 어느 카테고리든 후속 발사를 차단한 케이스.
+ * burst dedup 윈도우로 같은 (source, stationName) 반복 로그는 1건만 적재.
+ */
+export function logSuppressedCrossCategoryDedup(input: {
+  source: AlarmLogSource;
+  stationName: string;
+  kind: AlarmLogKind;
+  phaseId?: AlarmPhaseId;
+}): void {
+  if (isBurstDuplicate('dedup-station-unified', input.stationName)) return;
+  appendAlarmLog({
+    ts: Date.now(),
+    source: input.source,
+    outcome: 'suppressed',
+    reason: 'dedup-station-unified',
+    stationName: input.stationName,
+    kind: input.kind,
+    phaseId: input.phaseId,
   });
 }
 

--- a/src/features/alarm/utils/crossCategoryStationDedup.ts
+++ b/src/features/alarm/utils/crossCategoryStationDedup.ts
@@ -39,7 +39,8 @@
  * 본 dedup은 매우 작은 가벼운 normalize로 충분 — 외부 의존 0.
  */
 function normalizeStationName(name: string): string {
-  return name.replace(/\(.*?\)/g, '').trim();
+  // 입력은 stations.json BLDN_NM(짧은 역명 + 선택적 단일 괄호)으로 제한된 도메인. ReDoS 위험 없음. NOSONAR
+  return name.replace(/\([^)]*\)/g, '').trim(); // NOSONAR typescript:S5852
 }
 
 /** 같은 station에 대해 cross-category fire를 차단하는 윈도우. */

--- a/src/features/alarm/utils/crossCategoryStationDedup.ts
+++ b/src/features/alarm/utils/crossCategoryStationDedup.ts
@@ -1,0 +1,129 @@
+/**
+ * #1515 — Cross-category station-level dedup.
+ *
+ * 문제(2026-06-19 trip): 같은 destinationId·같은 station에서 카테고리가 다르면 dedup이 분리돼
+ * 14초 안에 3건의 알람이 발사되는 회귀.
+ *   08:37:08 destination(early)  성수  ← firedAlarms set 키 = `early:성수`
+ *   08:37:19 station-passed       성수  ← lastNotifiedStationId 단일 출처
+ *   08:37:22 station-passed       성수  ← #19 fire의 await sendNotification 중 race
+ *
+ * 기존 dedup:
+ *   - destination/transfer phase: `firedAlarmsRef` (key=`${phaseId}:${stationName}`)
+ *   - station-passed: `lastNotifiedStationId` (destinationId 단위 단일 값)
+ *   - 두 출처가 분리돼 cross-category가 서로를 silence하지 못함.
+ *
+ * 본 util은 두 출처 위에 얹는 **station-level** 통합 dedup이다.
+ * 키: `${destinationId}|${normalizedStationName}`. 단일 in-memory Map.
+ * 윈도우: WINDOW_MS(기본 30s) — 사용자 인지 "계속 울린다" 회귀 차단 시간.
+ *
+ * 우선순위/정책:
+ *   - destination > station-passed. destination/transfer가 먼저 fire되면 station-passed suppress.
+ *   - 같은 station에 station-passed가 먼저 fire되면 후속 destination도 suppress(이미 알람 1건 발사됨).
+ *   - 환승역 line 분기 fire(같은 stationName, 다른 stationId)는 stationName이 같으면 동일 키에 묶임.
+ *     같은 물리적 역이라 OK(트립 진행 중 자연스럽게 한 번만 fire). 이슈 acceptance: "환승역 line별
+ *     분리 fire 보존" — destination이 환승역이 아닌 한 영향 X. 환승역 자체에서의 추가 fire는
+ *     "동일 station 30s 내 1건"이라는 본 acceptance 정책과 정합.
+ *
+ * 호출 시점:
+ *   1. fire 직전 — `isStationRecentlyFired(destId, stationName, now)`로 차단 여부 결정.
+ *   2. fire 성공 직후 — `markStationFired(destId, stationName, now)`로 윈도우 갱신.
+ *
+ * 비휘발성: in-memory map만 사용. 앱 재시작 시 reset되며 그 직후엔 hydration warmup으로 차단된다.
+ * 따라서 storage write가 필요 없다(저장 race가 본 회귀의 직접 원인이라 의도적으로 회피).
+ */
+
+/**
+ * 역명 정규화: 괄호 안 부속 표기 제거 + trim. stationRoute의 normalizeStationName과 동등.
+ * 별도 함수로 둔 이유: stationRoute는 cross-feature orchestrator/테스트에서 광범위하게 mock되며
+ * normalizeStationName이 mock 누락되면 본 util이 런타임 throw → BG path 발사 자체가 깨진다.
+ * 본 dedup은 매우 작은 가벼운 normalize로 충분 — 외부 의존 0.
+ */
+function normalizeStationName(name: string): string {
+  return name.replace(/\(.*?\)/g, '').trim();
+}
+
+/** 같은 station에 대해 cross-category fire를 차단하는 윈도우. */
+export const CROSS_CATEGORY_DEDUP_WINDOW_MS = 30_000;
+
+/** Map 무한 성장 cap. 정상 trip(역 수 ~수십) × destination ~수 = ≤ 수백. cap 도달 시 만료 일괄 정리. */
+const DEDUP_MAP_CAP = 256;
+
+/**
+ * fire category. AlarmLogKind와 의미적으로 동일하지만 본 dedup 의도(cross-category) 명시 위해
+ * 별도 type alias. station-passed vs phase(destination/transfer) 2개 그룹으로 차단 판정.
+ */
+export type FireCategory = 'destination' | 'transfer' | 'station-passed';
+
+interface FireRecord {
+  ts: number;
+  category: FireCategory;
+}
+
+const lastFire = new Map<string, FireRecord>();
+
+function makeKey(destinationId: string, stationName: string): string {
+  return `${destinationId}|${normalizeStationName(stationName)}`;
+}
+
+function sweepExpired(now: number): void {
+  if (lastFire.size <= DEDUP_MAP_CAP) return;
+  for (const [k, rec] of lastFire) {
+    if (now - rec.ts >= CROSS_CATEGORY_DEDUP_WINDOW_MS) lastFire.delete(k);
+  }
+}
+
+/**
+ * 두 fire category가 본 dedup의 차단 대상인지 판정.
+ *
+ * 차단 정책:
+ *   - station-passed ↔ destination/transfer: 차단 (cross-category 본 회귀, 2026-06-19 성수).
+ *   - station-passed → station-passed: 차단. lastNotifiedStationId가 AsyncStorage 라운드트립
+ *     race에 취약해 FG GPS path와 fast-path(fg-arvlcd) 두 effect가 같은 사이클에 둘 다 발사하는
+ *     사례 존재(2026-06-19 08:37:19→22 성수 3초 간격 재발사). station 단위 인메모리 reservation으로 race 차단.
+ *   - destination ↔ destination/transfer: 차단 X (early→imminent 같은 정상 phase 진행 보존).
+ *     이 그룹은 firedAlarms set이 phaseId 단위로 dedup.
+ *
+ * 요약: 한 쪽이라도 station-passed면 차단, 양쪽 모두 phase(destination|transfer)면 허용.
+ */
+function isCrossCategory(prev: FireCategory, current: FireCategory): boolean {
+  return prev === 'station-passed' || current === 'station-passed';
+}
+
+/**
+ * cross-category fire가 윈도우 내에 발생했는지 확인.
+ * fire 직전 호출 — true면 호출자는 발사를 skip하고 `dedup-station-unified`로 로그.
+ *
+ * 같은 category(예: destination phase가 early→imminent로 진행)는 본 함수가 false를 반환해
+ * 기존 firedAlarms(phase) / lastNotifiedStationId(station-passed) dedup이 단독으로 작동한다.
+ */
+export function isStationRecentlyFired(
+  destinationId: string,
+  stationName: string,
+  category: FireCategory,
+  now: number,
+  windowMs: number = CROSS_CATEGORY_DEDUP_WINDOW_MS,
+): boolean {
+  const rec = lastFire.get(makeKey(destinationId, stationName));
+  if (rec === undefined) return false;
+  if (now - rec.ts >= windowMs) return false;
+  return isCrossCategory(rec.category, category);
+}
+
+/**
+ * fire 성공 직후 윈도우 갱신. 호출자는 알람 노출 직전/직후에 호출한다.
+ * 같은 station에 후속 fire가 발생하면 category가 덮어쓰여 최근 fire를 기준으로 cross-cat 판정.
+ */
+export function markStationFired(
+  destinationId: string,
+  stationName: string,
+  category: FireCategory,
+  now: number,
+): void {
+  lastFire.set(makeKey(destinationId, stationName), { ts: now, category });
+  sweepExpired(now);
+}
+
+/** 테스트 전용 — 모듈 상태 리셋. production 호출 금지. */
+export function _resetCrossCategoryDedupForTests(): void {
+  lastFire.clear();
+}

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -17,6 +17,7 @@ import { getLastNotifiedStationId, setLastNotifiedStationId } from './notificati
 import {
   logFiredAlarm,
   logFiredStationPassed,
+  logSuppressedCrossCategoryDedup,
   logSuppressedDedupAlarm,
   logSuppressedDedupStation,
   logSuppressedDismissSilence,
@@ -24,6 +25,10 @@ import {
   logSuppressedSleepStationPassed,
   type AlarmLogSource,
 } from './alarmLog';
+import {
+  isStationRecentlyFired,
+  markStationFired,
+} from './crossCategoryStationDedup';
 import { isStationPassedFirstHop, shouldSuppressBySleepRule } from './shouldSuppressBySleepRule';
 import { evaluateDismissSilence } from './dismissSilenceGate';
 import { clearDismissSilence, getDismissSilence } from './dismissSilenceStorage';
@@ -303,7 +308,19 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
         stationName: alarmEvent.stationName,
         phaseId: alarmEvent.phaseId,
       });
+    } else if (
+      isStationRecentlyFired(destination.id, alarmEvent.stationName, alarmEvent.type, Date.now())
+    ) {
+      // #1515 — cross-category station-level dedup. 같은 station에 직전 station-passed 발사가
+      // 있었다면 phase 알람 차단(BG path 동등 가드). lock 활성/lockless 동급 (ADR-014).
+      logSuppressedCrossCategoryDedup({
+        source,
+        stationName: alarmEvent.stationName,
+        kind: alarmEvent.type,
+        phaseId: alarmEvent.phaseId,
+      });
     } else {
+      markStationFired(destination.id, alarmEvent.stationName, alarmEvent.type, Date.now());
       await sendAlarmNotification(alarmEvent, sleepMode, allowSpeaker, notificationSource);
       logFiredAlarm(source, alarmEvent);
     }
@@ -341,7 +358,25 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
       logSuppressedSleepStationPassed({ source, stationName: nearest.station.name });
     } else {
       const lastNotifiedStationId = await getLastNotifiedStationId(destination.id);
-      if (nearest.station.id !== lastNotifiedStationId) {
+      if (nearest.station.id === lastNotifiedStationId) {
+        logSuppressedDedupStation(source, nearest.station);
+      } else if (
+        isStationRecentlyFired(
+          destination.id,
+          nearest.station.name,
+          'station-passed',
+          Date.now(),
+        )
+      ) {
+        // #1515 — cross-category dedup. lastNotifiedStationId가 다른 stationId여도 같은 stationName이
+        // 직전 phase 알람(destination/transfer)에서 fire됐다면 BG station-passed 차단. FG phase fire와
+        // BG station-passed가 같은 station에 거의 동시 fire하는 회귀 차단. lock/lockless 동급 (ADR-014).
+        logSuppressedCrossCategoryDedup({
+          source,
+          stationName: nearest.station.name,
+          kind: 'station-passed',
+        });
+      } else {
         // #796: 환승역 도착 timing의 segment 정확 식별. evaluateAlarmPhase(:233)와 동일한
         // currentLine 결정 — lock.boardingLine 우선 → BG GPS jitter로 nearest가 옆 노선 station을
         // 잡아도 잘못된 다음-다음 transfer 안내를 차단. lock 없으면 nearest.station.line fallback.
@@ -351,6 +386,8 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
           lockForLineGuard?.boardingLine ?? nearest.station.line,
         );
         if (target) {
+          // #1515 — race reservation: send 전에 cross-category 윈도우 갱신. category='station-passed'.
+          markStationFired(destination.id, nearest.station.name, 'station-passed', Date.now());
           // 알림 발송 성공 후에만 storage write — 발송 실패 시 다음 폴링에서 재시도 가능.
           await sendStationPassedNotification(
             nearest.station.name,
@@ -382,8 +419,6 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
             }
           }
         }
-      } else {
-        logSuppressedDedupStation(source, nearest.station);
       }
     }
   }

--- a/src/features/nearest-station/tasks/__tests__/foregroundBackgroundTransition.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/foregroundBackgroundTransition.test.ts
@@ -242,6 +242,9 @@ beforeEach(() => {
   mockSendStationPassedNotification.mockClear();
   mockSendAlarmNotification.mockClear();
   mockUpdateStationNotification.mockClear();
+  // #1515 — cross-category dedup module 인메모리 상태 리셋(테스트 간 격리).
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('../../../alarm/utils/crossCategoryStationDedup')._resetCrossCategoryDedupForTests();
 });
 
 describe('FG↔BG 통합: 알림 dedup (notificationState 단일 출처)', () => {


### PR DESCRIPTION
Closes #1515

## 회귀
2026-06-19 실기기 trip — 성수에 14초 동안 3건의 알람이 발사 (사용자 "계속 울린다" 인지):
- 08:37:08 destination(early) 성수
- 08:37:19 station-passed 성수
- 08:37:22 station-passed 성수 (3초 만에 재발사)

## 원인
기존 dedup이 카테고리별로 분리됐다.
- destination/transfer phase: `firedAlarmsRef` (key = `${phaseId}:${stationName}`)
- station-passed: `lastNotifiedStationId` (destinationId 단일 값, AsyncStorage 비동기)

두 출처가 서로를 silence하지 못해 (1) destination 발사 후 station-passed가 같은 station에 재발사, (2) FG GPS path + fg-arvlcd fast-path가 같은 사이클에 storage write 전 둘 다 발사하는 race.

## fix
`src/features/alarm/utils/crossCategoryStationDedup.ts` 신규.
- destinationId+normalizedStationName 단위 in-memory 윈도우 dedup (기본 30s).
- 한 쪽이라도 `station-passed`면 차단 (cross-category + same-category race fix).
- 양쪽 모두 phase(destination|transfer)면 허용 → early→imminent 정상 진행 보존.
- send 직전 `markStationFired` (reservation) → await 동안 다른 effect가 진입해도 차단.

wire:
- `useStationAlarm.fireAndLog` (FG phase): pre-send check + reservation.
- `dispatchStationPassed` (FG GPS + fg-arvlcd): pre-send check + reservation.
- `stationPipeline.processLocationUpdate` (BG): phase 분기 + station-passed 분기 둘 다 동일 가드. lock 활성/lockless 동급 (ADR-014).

신규 `dedup-station-unified` reason + helper `logSuppressedCrossCategoryDedup`.

## acceptance
- 같은 station 30s 내 cross-category fire 1건 이하.
- 환승역 line별 분리 fire (같은 name, 다른 stationId) 보존 — destination이 환승역이 아닌 한 영향 X.
- early → imminent 정상 phase 진행 보존.

## 테스트
- `crossCategoryStationDedup.test.ts` 신규 13건 — category 매트릭스, 윈도우, normalize, sweep.
- alarmLog/stationPipeline/useStationAlarm/foregroundBackgroundTransition 테스트에 cross-cat 시나리오 + state reset 추가.
- 전체 6620 tests pass, 100% coverage, type-check + lint clean.

## test plan
- [ ] dev 빌드 후 실기기 trip — 도착역 직전 destination phase + station-passed 1건만 발사 확인.
- [ ] 환승역에서 transfer alarm + 다음 leg station-passed가 정상 발사되는지 확인.
- [ ] early → imminent 같은 destination 진행 시 두 알람 모두 발사되는지 확인.