### PR TITLE
fix(#1525): trip 종료 후 좀비 알림 cancel 완결성 보강

### DIFF
--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -4,7 +4,9 @@ import {
   TRIP_BOUND_CLEANUPS,
   runTripBoundCleanups,
   cancelTripBoundOsQueue,
+  __resetDefensiveCancelForTest,
 } from '../tripBoundCleanups';
+import { TRIP_BOUND_ROUTE_SIG_KEY, BOARDING_LOCK_ROUTE_SIG_KEY } from '../../../../shared/constants/storageKeys';
 import {
   DESTINATION_KEY,
   ROUTE_KEY,
@@ -152,6 +154,150 @@ describe('tripBoundCleanups', () => {
       (c) => c[0] as string,
     );
     expect(cancelled).toContain('bl:T-7172:0:imminent:용마산');
+  });
+
+  describe('#1525 — defensive cancel (zombie alarm backstop)', () => {
+    // sig 가드 테스트에서 getItem/setItem이 일관된 in-memory store처럼 동작해야 한다.
+    const storage = new Map<string, string>();
+
+    beforeEach(async () => {
+      jest.useFakeTimers();
+      __resetDefensiveCancelForTest();
+      storage.clear();
+      // 이전 테스트가 mockRejectedValue로 leak시킨 implementation을 reset — outer beforeEach의
+      // clearAllMocks는 호출 기록만 지우고 implementation은 유지한다.
+      (AsyncStorage.removeItem as jest.Mock).mockReset();
+      (AsyncStorage.removeItem as jest.Mock).mockImplementation((k: string) => {
+        storage.delete(k);
+        return Promise.resolve();
+      });
+      (AsyncStorage.getItem as jest.Mock).mockReset();
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((k: string) =>
+        Promise.resolve(storage.get(k) ?? null),
+      );
+      (AsyncStorage.setItem as jest.Mock).mockReset();
+      (AsyncStorage.setItem as jest.Mock).mockImplementation((k: string, v: string) => {
+        storage.set(k, v);
+        return Promise.resolve();
+      });
+      (Notifications.cancelScheduledNotificationAsync as jest.Mock).mockReset();
+      (Notifications.cancelScheduledNotificationAsync as jest.Mock).mockResolvedValue(undefined);
+      (Notifications.dismissNotificationAsync as jest.Mock).mockReset();
+      (Notifications.dismissNotificationAsync as jest.Mock).mockResolvedValue(undefined);
+      (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockReset();
+      (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue([]);
+    });
+
+    afterEach(async () => {
+      __resetDefensiveCancelForTest();
+      // pending microtask flush — runDefensiveCancel 내부 async chain이 fire 후 다음 tick에
+      // 마무리되는 경우 "Cannot log after tests are done" 경고 방지.
+      await Promise.resolve();
+      await Promise.resolve();
+      jest.useRealTimers();
+    });
+
+    it('cancelTripBoundOsQueue 호출 1분 후 두 채널 cancel을 한 번 더 실행한다 (route sig 없으면)', async () => {
+      // 새 trip이 없을 때(sig=null) defensive retry가 한 번 더 cancel을 시도해 expo 내부
+      // race로 살아남은 사전 예약을 정리한다.
+      await AsyncStorage.removeItem(TRIP_BOUND_ROUTE_SIG_KEY);
+      await AsyncStorage.removeItem(BOARDING_LOCK_ROUTE_SIG_KEY);
+      (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue([
+        { identifier: 'tba:imminent:용마산' },
+      ]);
+      (Notifications.cancelScheduledNotificationAsync as jest.Mock).mockResolvedValue(undefined);
+
+      await cancelTripBoundOsQueue();
+      const firstCallCount = (Notifications.cancelScheduledNotificationAsync as jest.Mock).mock
+        .calls.length;
+
+      // 1분 진행 → defensive timer fire.
+      await jest.advanceTimersByTimeAsync(60_000);
+
+      const secondCallCount = (Notifications.cancelScheduledNotificationAsync as jest.Mock).mock
+        .calls.length;
+      expect(secondCallCount).toBeGreaterThan(firstCallCount);
+    });
+
+    it('defensive timer fire 시점에 새 trip route sig가 기록돼 있으면 cancel을 skip한다', async () => {
+      // 새 trip이 시작돼 sig가 다시 쓰이면 사전 예약은 정상 — defensive가 정상 알람을
+      // 지우면 안 된다.
+      (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue([]);
+      (Notifications.cancelScheduledNotificationAsync as jest.Mock).mockResolvedValue(undefined);
+
+      await cancelTripBoundOsQueue();
+      const baseline = (Notifications.cancelScheduledNotificationAsync as jest.Mock).mock.calls
+        .length;
+
+      // 새 trip 시작 시뮬레이션 — sig 기록.
+      await AsyncStorage.setItem(TRIP_BOUND_ROUTE_SIG_KEY, 'new-trip-sig');
+
+      await jest.advanceTimersByTimeAsync(60_000);
+
+      // sig 가드로 두 번째 cancel은 skip — 새 호출이 없어야 한다.
+      expect((Notifications.cancelScheduledNotificationAsync as jest.Mock).mock.calls.length).toBe(
+        baseline,
+      );
+    });
+
+    it('runTripBoundCleanups도 defensive cancel을 1분 후 실행한다 (FG setDestination(null) 경로 backstop)', async () => {
+      await AsyncStorage.removeItem(TRIP_BOUND_ROUTE_SIG_KEY);
+      await AsyncStorage.removeItem(BOARDING_LOCK_ROUTE_SIG_KEY);
+      (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue([
+        { identifier: 'tba:early:강남' },
+      ]);
+      (Notifications.cancelScheduledNotificationAsync as jest.Mock).mockResolvedValue(undefined);
+      (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+
+      await runTripBoundCleanups();
+      const baseline = (Notifications.cancelScheduledNotificationAsync as jest.Mock).mock.calls
+        .length;
+
+      await jest.advanceTimersByTimeAsync(60_000);
+
+      expect(
+        (Notifications.cancelScheduledNotificationAsync as jest.Mock).mock.calls.length,
+      ).toBeGreaterThan(baseline);
+    });
+
+    it('연속 호출 시 이전 defensive timer를 reset하고 새 timer만 fire한다 (중복 cancel pass 방지)', async () => {
+      await AsyncStorage.removeItem(TRIP_BOUND_ROUTE_SIG_KEY);
+      await AsyncStorage.removeItem(BOARDING_LOCK_ROUTE_SIG_KEY);
+      (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue([]);
+      (Notifications.cancelScheduledNotificationAsync as jest.Mock).mockResolvedValue(undefined);
+
+      await cancelTripBoundOsQueue();
+      await jest.advanceTimersByTimeAsync(30_000);
+      await cancelTripBoundOsQueue();
+      // 30s만 더 진행 — 첫 timer 기준 60s에 도달했지만 reset됐으므로 fire 안 함.
+      const baseline = (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mock.calls
+        .length;
+      await jest.advanceTimersByTimeAsync(30_000);
+      // 첫 60s 시점이라 reset 안 됐다면 fire — 새 호출 발생. reset 됐다면 변화 없음.
+      expect(
+        (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mock.calls.length,
+      ).toBe(baseline);
+
+      // 추가 30s = 두 번째 호출 기준 60s — fire.
+      await jest.advanceTimersByTimeAsync(30_000);
+      expect(
+        (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mock.calls.length,
+      ).toBeGreaterThan(baseline);
+    });
+
+    it('defensive cancel 내부 OS reject는 Promise.allSettled가 흡수한다 (graceful)', async () => {
+      await AsyncStorage.removeItem(TRIP_BOUND_ROUTE_SIG_KEY);
+      await AsyncStorage.removeItem(BOARDING_LOCK_ROUTE_SIG_KEY);
+      (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockRejectedValue(
+        new Error('os err'),
+      );
+      (Notifications.cancelScheduledNotificationAsync as jest.Mock).mockResolvedValue(undefined);
+
+      await cancelTripBoundOsQueue();
+      // getAllScheduledNotificationsAsync reject는 cancelTripBoundAlarms 내부에서 발생하지만
+      // runDefensiveCancel의 Promise.allSettled가 흡수 — unhandled rejection 발생 X.
+      await expect(jest.advanceTimersByTimeAsync(60_000)).resolves.toBeUndefined();
+    });
   });
 
   it('runTripBoundCleanups: 한 항목이 reject해도 나머지 항목이 모두 실행된다', async () => {

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -28,9 +28,30 @@ import { clearTripTrainCode } from '../../route/utils/tripTrainCode';
 import { clearDismissSilence as clearDismissSilenceStorage } from '../utils/dismissSilenceStorage';
 import { clearLaDismissSentinel } from '../utils/laDismissSentinel';
 import { clearPrescheduledLedger } from '../utils/prescheduledMetrics';
-import { purgeBoardingLockSchedulerQueue } from '../utils/boardingLockScheduler';
-import { cancelTripBoundAlarms } from '../utils/tripBoundScheduler';
+import {
+  getRegisteredBlRouteSig,
+  purgeBoardingLockSchedulerQueue,
+} from '../utils/boardingLockScheduler';
+import {
+  cancelTripBoundAlarms,
+  getRegisteredTripRouteSig,
+} from '../utils/tripBoundScheduler';
 import { clearTripCorrId } from '../../observability/utils/tripCorrId';
+import { createLogger } from '../../../shared/utils/logger';
+
+const log = createLogger('tripBoundCleanups');
+
+/**
+ * #1525 — defensive cancel retry interval (ms). trip 종료 직후 한 번 cancel 한 뒤
+ * 이 시간 후 한 번 더 cancel을 시도해 ETA 도달 직전 race window를 좁힌다.
+ *
+ * 1분은 silent push 처리 → setDestination(null) → AsyncStorage settle → OS notification
+ * scheduler 반영의 typical lag(수 초)보다 충분히 길고, 평균 hop time(2~3분) 보다 짧아
+ * 다음 hop이 ETA에 도달하기 전에 두 번째 cancel이 들어간다.
+ */
+const DEFENSIVE_CANCEL_DELAY_MS = 60_000;
+
+let defensiveTimer: ReturnType<typeof setTimeout> | null = null;
 
 // trip-bound storage cleanup 단일 출처.
 // useDestinationStore.setDestination이 isSwitch(목적지 변경 또는 null 클리어) 분기에서 호출한다.
@@ -96,6 +117,10 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
  * 다른 항목 실행이나 호출자에게 전파되지 않도록).
  */
 export function runTripBoundCleanups(): Promise<void> {
+  // #1525 — FG setDestination(null) 경로의 zombie alarm backstop. 1차 cleanup이 in-flight인
+  // 동안 expo-notifications 내부 race로 일부 사전 예약이 살아남는 사례를 1분 후 두번째
+  // cancel pass로 정리. 새 trip이 시작되면 route sig 가드가 skip한다.
+  scheduleDefensiveCancel();
   return Promise.allSettled(TRIP_BOUND_CLEANUPS.map((cleanup) => cleanup())).then(noop);
 }
 
@@ -111,10 +136,63 @@ export function runTripBoundCleanups(): Promise<void> {
  * 두 cancel은 독립적이라 allSettled로 묶어 한쪽 실패가 다른 쪽 실행을 막지 않도록 한다.
  */
 export function cancelTripBoundOsQueue(): Promise<void> {
+  scheduleDefensiveCancel();
   return Promise.allSettled([
     purgeBoardingLockSchedulerQueue(),
     cancelTripBoundAlarms(),
   ]).then(noop);
+}
+
+/**
+ * #1525 — trip 종료 직후 1분 뒤 한 번 더 `tba:`/`bl:` OS 사전 예약을 cancel한다.
+ *
+ * 1차 cancel 시점에 race로 schedule이 in-flight였거나, expo-notifications 내부 큐 반영
+ * 지연으로 일부 identifier가 cancel을 빠져나가는 경우를 보강. 2026-06-19 trip 종료
+ * 11분 후 "안내 종료" 알림이 사용자에게 도달한 사례(zombie alarm)의 backstop.
+ *
+ * 새 trip이 시작되어 routeSig가 다시 기록됐다면 정상 사전 예약을 지우면 안 되므로 skip.
+ * 이미 예약된 defensive timer가 있으면 새 호출이 reset(이전 timer cancel → 새 timer).
+ *
+ * 별도 export 없이 cancelTripBoundOsQueue / runTripBoundCleanups 내부에서만 호출.
+ */
+function scheduleDefensiveCancel(): void {
+  if (defensiveTimer !== null) {
+    clearTimeout(defensiveTimer);
+  }
+  defensiveTimer = setTimeout(() => {
+    defensiveTimer = null;
+    void runDefensiveCancel();
+  }, DEFENSIVE_CANCEL_DELAY_MS);
+}
+
+async function runDefensiveCancel(): Promise<void> {
+  // 새 trip이 시작되어 route sig가 기록됐으면 사전 예약은 정상 — defensive cancel skip.
+  // `tba:` / `bl:` 두 채널 중 하나라도 sig가 살아있으면 새 trip 진행 중으로 판단.
+  // getRegisteredXxxRouteSig는 storage 실패를 내부에서 catch해 null 반환 — 본 함수의
+  // try/catch 없이도 throw가 외부로 새지 않는다 (Promise.allSettled가 cancel 양쪽을 흡수).
+  const [tbaSig, blSig] = await Promise.all([
+    getRegisteredTripRouteSig(),
+    getRegisteredBlRouteSig(),
+  ]);
+  if (tbaSig !== null || blSig !== null) {
+    log.info(`defensive cancel skip: new trip active (tbaSig=${tbaSig !== null} blSig=${blSig !== null})`);
+    return;
+  }
+  log.info('defensive cancel: running second cancel pass (#1525)');
+  await Promise.allSettled([
+    purgeBoardingLockSchedulerQueue(),
+    cancelTripBoundAlarms(),
+  ]);
+}
+
+/**
+ * 테스트용 — pending defensive timer를 즉시 cancel + 모듈 상태 reset. production 호출자 없음.
+ */
+export function __resetDefensiveCancelForTest(): void {
+  if (defensiveTimer !== null) {
+    clearTimeout(defensiveTimer);
+    defensiveTimer = null;
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
@@ -350,6 +350,32 @@ describe('cancelAllHopsForLock', () => {
     await expect(cancelAllHopsForLock(lock)).resolves.toBeUndefined();
     expect(mockedCancel).toHaveBeenCalled();
   });
+
+  it('#1525 — 한 identifier의 cancel reject가 나머지 identifier cancel을 막지 않는다', async () => {
+    // 직렬 await 루프였을 때는 첫 id의 cancel reject에서 throw → 나머지 `bl:` 사전 예약이
+    // OS 큐에 남아 trip 종료 후 좀비 알림으로 발사됐다. allSettled로 묶여 한 id의
+    // cancel reject가 나머지를 막지 않아야 한다.
+    mockedGet.mockResolvedValueOnce([
+      'bl:T-100:0:early:강남',
+      'bl:T-100:0:imminent:강남',
+      'bl:T-100:1:early:역삼',
+    ]);
+    mockedCancel.mockImplementation((id) => {
+      if (id === 'bl:T-100:0:early:강남') return Promise.reject(new Error('already fired'));
+      return Promise.resolve();
+    });
+
+    try {
+      await expect(cancelAllHopsForLock(lock)).resolves.toBeUndefined();
+
+      expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:early:강남');
+      expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:imminent:강남');
+      expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:1:early:역삼');
+    } finally {
+      // 다른 describe로 reject impl leak 방지.
+      mockedCancel.mockReset();
+    }
+  });
 });
 
 // #1356 E1 / #1355 D1 — silent push suppress & cross-channel cancel helper.

--- a/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
@@ -437,6 +437,39 @@ describe('cancelTripBoundAlarms', () => {
     expect(removeSpy).toHaveBeenCalledWith(TRIP_BOUND_ROUTE_SIG_KEY);
     removeSpy.mockRestore();
   });
+
+  it('#1525 — 한 identifier의 cancel이 reject해도 다른 identifier의 cancel은 진행된다 (zombie alarm 방지)', async () => {
+    // 직렬 for await 루프였을 때는 첫 reject에서 throw → 나머지 `tba:` 사전 예약이 OS 큐에
+    // 남아 trip 종료 후 좀비 알림이 발사됐다 (2026-06-19 08:48 사례). allSettled로 묶여
+    // 한 id의 cancel reject가 나머지를 막지 않아야 한다.
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:early:강남' },
+      { identifier: 'tba:imminent:강남' },
+      { identifier: 'tba:early:역삼' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+    mockedCancel.mockImplementation((id) => {
+      if (id === 'tba:early:강남') return Promise.reject(new Error('already fired'));
+      return Promise.resolve();
+    });
+
+    try {
+      await expect(cancelTripBoundAlarms()).resolves.toBeUndefined();
+
+      // 첫 id가 reject해도 모든 id에 cancel 호출이 발생해야 한다.
+      expect(mockedCancel).toHaveBeenCalledWith('tba:early:강남');
+      expect(mockedCancel).toHaveBeenCalledWith('tba:imminent:강남');
+      expect(mockedCancel).toHaveBeenCalledWith('tba:early:역삼');
+      // fulfilled 2건만 cancelled 카운트에 반영.
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        expect.stringContaining('cancelled 2 trip-bound alarms'),
+      );
+    } finally {
+      // 다른 describe로 reject impl이 leak되지 않도록 default 복귀 (beforeEach가
+      // mockReset이 아닌 clearAllMocks만 하므로 implementation은 유지된다).
+      mockedCancel.mockReset();
+    }
+  });
 });
 
 // #1356 E1 / #1355 D1 — silent push suppress & cross-channel cancel helper.

--- a/src/features/alarm/utils/boardingLockScheduler.ts
+++ b/src/features/alarm/utils/boardingLockScheduler.ts
@@ -252,14 +252,20 @@ function shouldSkipFirstTransferForSleep(
 }
 
 async function cancelAndDismiss(ids: string[]): Promise<void> {
-  for (const id of ids) {
-    await Notifications.cancelScheduledNotificationAsync(id);
-    try {
-      await Notifications.dismissNotificationAsync(id);
-    } catch {
-      // 미발사 알람은 dismiss 대상 아님 — 무시.
-    }
-  }
+  // #1525 — Promise.allSettled로 per-id cancel+dismiss를 묶어 한 id의 cancel reject가
+  // 뒤의 id들을 막지 않게 한다. 직렬 await에서 한 번 throw하면 `bl:` 사전 예약 잔여가
+  // OS 큐에 남아 trip 종료 후 좀비 알림이 발사된다 (cancelTripBoundAlarms와 같은 회귀
+  // 표면). dismiss는 기존과 동일하게 throw를 swallow한다.
+  await Promise.allSettled(
+    ids.map(async (id) => {
+      await Notifications.cancelScheduledNotificationAsync(id);
+      try {
+        await Notifications.dismissNotificationAsync(id);
+      } catch {
+        // 미발사 알람은 dismiss 대상 아님 — 무시.
+      }
+    }),
+  );
 }
 
 export interface ScheduleHopsParams {

--- a/src/features/alarm/utils/tripBoundScheduler.ts
+++ b/src/features/alarm/utils/tripBoundScheduler.ts
@@ -753,13 +753,15 @@ export async function rescheduleTripBoundAlarm(
  */
 export async function cancelTripBoundAlarms(): Promise<void> {
   const all = await Notifications.getAllScheduledNotificationsAsync();
-  let cancelled = 0;
-  for (const req of all) {
-    if (req.identifier.startsWith(TRIP_BOUND_ALARM_PREFIX)) {
-      await Notifications.cancelScheduledNotificationAsync(req.identifier);
-      cancelled++;
-    }
-  }
+  const targets = all.filter((req) => req.identifier.startsWith(TRIP_BOUND_ALARM_PREFIX));
+  // #1525 — Promise.allSettled로 per-identifier cancel을 묶어 한 개의 cancel reject가
+  // 나머지 identifier cancel을 막지 않도록 한다. 직렬 await 루프에서 한 번 throw하면
+  // 뒤에 남아 있는 `tba:` 사전 예약이 OS 큐에 그대로 남아 trip 종료 후 좀비 알림으로
+  // 발사된다 (2026-06-19 08:48 "안내 종료" 도달 사례).
+  const results = await Promise.allSettled(
+    targets.map((req) => Notifications.cancelScheduledNotificationAsync(req.identifier)),
+  );
+  const cancelled = results.filter((r) => r.status === 'fulfilled').length;
   if (cancelled > 0) {
     logger.info(`cancelled ${cancelled} trip-bound alarms`);
   }

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -1236,6 +1236,13 @@ function DebugModalInner({
     setScheduledDump(await dumpScheduledNotifications());
   }, []);
 
+  // #1525 — DebugModal 진입 즉시 OS scheduled queue를 1회 dump한다. 사용자가 Refresh를
+  // 누르지 않은 share dump가 항상 "(not loaded)"로 나가 zombie alarm 추적이 불가능했던
+  // 회귀 차단. 이후 갱신은 기존 Refresh 버튼이 담당.
+  useEffect(() => {
+    void refreshScheduledDump();
+  }, [refreshScheduledDump]);
+
   useEffect(() => {
     return subscribeFusionDebug(() => setFusionLogs([...getFusionDebugEntries()]));
   }, []);

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -1991,15 +1991,21 @@ describe('DebugModal — Scheduled queue UI (#756)', () => {
     setupHookDefaults();
   });
 
-  it('초기 마운트 상태에서는 "(tap Refresh to load)" placeholder', () => {
+  it('#1525 — 마운트 즉시 dumpScheduledNotifications가 1회 호출돼 share dump 좀비 추적 가능', async () => {
+    // 직전 동작은 (not loaded) placeholder + 사용자가 Refresh 눌러야 dump. 그 사이에
+    // share dump하면 항상 "(not loaded)"로 박혀 좀비 알림(#1525) 추적 불가. 마운트 시점
+    // 자동 1회 dump로 share에 항상 실제 OS 큐 스냅샷이 들어가야 한다.
+    mockDumpScheduledNotifications.mockResolvedValue([]);
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
-    expect(screen.getByText('(tap Refresh to load)')).toBeTruthy();
-    expect(screen.getByText('Scheduled queue')).toBeTruthy();
+    await waitFor(() => expect(mockDumpScheduledNotifications).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByText('Scheduled queue (0)')).toBeTruthy());
   });
 
   it('Refresh 누르면 dumpScheduledNotifications 호출 + 빈 결과면 "(empty)" 표시', async () => {
     mockDumpScheduledNotifications.mockResolvedValue([]);
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    // #1525 — 마운트 자동 dump 1회.
+    await waitFor(() => expect(mockDumpScheduledNotifications).toHaveBeenCalledTimes(1));
 
     await act(async () => {
       fireEvent.press(screen.getByTestId('debug-scheduled-dump-refresh'));
@@ -2008,7 +2014,8 @@ describe('DebugModal — Scheduled queue UI (#756)', () => {
     await waitFor(() => expect(screen.getByText('Scheduled queue (0)')).toBeTruthy());
     // "(empty)"는 Alarm log 섹션에도 등장 (logs=[])하므로 getByText 다중매칭 회피 — 카운트만 검증.
     expect(screen.getAllByText('(empty)').length).toBeGreaterThanOrEqual(1);
-    expect(mockDumpScheduledNotifications).toHaveBeenCalledTimes(1);
+    // 마운트 자동 1회 + Refresh 1회 = 2회.
+    expect(mockDumpScheduledNotifications).toHaveBeenCalledTimes(2);
     expect(appStateListener).toBeTruthy();
   });
 


### PR DESCRIPTION
Closes #1525

## 배경
2026-06-19 trip 종료 후 11분 뒤(08:48) 사용자에게 "안내 종료" 알림이 도달했다 (마지막 silent push 08:37:23). DebugModal `## Scheduled queue` 섹션이 `(not loaded)`라 진단 0건.

원인: `tba:` / `bl:` 사전예약 cancel의 직렬 await 루프가 한 identifier의 reject(예: 이미 발사된 알람을 cancel 시 expo가 throw)에서 throw되어 뒤따르는 identifier들이 OS 큐에 그대로 남는 회귀.

## 변경
1. **`cancelTripBoundAlarms` (`tripBoundScheduler.ts`)**
   - 직렬 `await` 루프 → `Promise.allSettled(targets.map(cancel))`
   - per-id cancel reject가 다른 id의 cancel을 막지 않음
2. **`cancelAndDismiss` (`boardingLockScheduler.ts`)**
   - 동일 패턴. `bl:` 채널의 모든 cancel 경로(`cancelAllHopsForLock`, `cancelBlByStationPhase`, `purgeBoardingLockSchedulerQueue`, `advanceHopWindow`, `rescheduleHopForLock`)에 효과 전파
3. **Defensive cancel (`tripBoundCleanups.ts`)**
   - `cancelTripBoundOsQueue` / `runTripBoundCleanups` 호출 시 1분 후 한 번 더 cancel pass 예약
   - 새 trip이 시작돼 route sig(`tba:`/`bl:` 둘 중 하나라도)가 기록됐으면 skip — 정상 사전 예약은 보존
   - 연속 호출 시 이전 timer reset → 중복 cancel pass 방지
4. **DebugModal 자동 dump (`DebugModal.tsx`)**
   - 진입 즉시 `dumpScheduledNotifications` 1회 실행
   - 사용자가 Refresh 누르지 않은 share dump가 항상 `(not loaded)`로 박혀 좀비 알림 추적 불가했던 문제 해소

## 테스트 시나리오 (자동)
- `tripBoundScheduler.test.ts #1525` — 첫 `tba:` id가 reject해도 나머지 2건 cancel 호출 + fulfilled 2건 카운트
- `boardingLockScheduler.test.ts #1525` — 첫 `bl:` id reject 시 나머지 2건 cancel 호출
- `tripBoundCleanups.test.ts #1525` 5건 — 1분 후 자동 cancel / route sig 가드 skip / runTripBoundCleanups 경로 / 연속 호출 timer reset / OS reject graceful
- `DebugModal.test.tsx #1525` — 마운트 즉시 dump 1회 호출 + share dump에 실제 큐 반영

## 검증
- `npm test` — 6653 tests pass, coverage 100%
- `npm run type-check` — clean
- `npm run lint` — clean

## 실기기 검증 필요 (사용자)
- trip 종료 후 10~15분 대기 → "안내 종료" 또는 다음 역 알림 fire 0건 확인
- DebugModal 진입 → Scheduled queue 섹션이 즉시 N건 표시되는지 확인
- share dump에 `## Scheduled queue (N)`가 들어가는지 확인

## 충돌 주의
다른 BG agent(#1524 sticky trip-end)도 `tripBoundCleanups.ts`를 수정할 가능성 — 머지 시 sequential 권장.