### PR TITLE
fix(#1541): customOrigin 정정 (F4 trip 중 비활성 + SSOT 시 unlock + trip-end reset)

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useCurrentStationConfirmModal.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useCurrentStationConfirmModal.test.ts
@@ -27,6 +27,7 @@ interface RenderInputs {
   userLocation: typeof YONGMASAN_LOC | null;
   wifiStation: Station | null;
   hasEffectiveOrigin: boolean;
+  tripActive?: boolean;
   onConfirmStation: (s: Station) => void;
   uncertainThresholdMs?: number;
 }
@@ -286,6 +287,50 @@ describe('useCurrentStationConfirmModal', () => {
         jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
       });
       expect(result.current.visible).toBe(false);
+    });
+
+    it('#1541 — tripActive=true면 자동 확정 비활성 (wifi 매칭이어도 onConfirmStation 미호출)', () => {
+      const onConfirmStation = jest.fn();
+      const { result } = setup({
+        locationUncertain: true,
+        wifiStation: YONGMASAN,
+        tripActive: true,
+        onConfirmStation,
+      });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      expect(onConfirmStation).not.toHaveBeenCalled();
+      expect(result.current.autoConfirmedStation).toBeNull();
+    });
+
+    it('#1541 — tripActive=true면 모달도 차단 (uncertain 후보 다중이어도 visible=false)', () => {
+      const { result } = setup({
+        locationUncertain: true,
+        userLocation: FAR_OFFSHORE,
+        tripActive: true,
+      });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      expect(result.current.visible).toBe(false);
+    });
+
+    it('#1541 — tripActive=true → false 전환 시 자동 확정 재개', () => {
+      const onConfirmStation = jest.fn();
+      const { result, rerender, props } = setup({
+        locationUncertain: true,
+        wifiStation: YONGMASAN,
+        tripActive: true,
+        onConfirmStation,
+      });
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_UNCERTAIN_THRESHOLD_MS + 100);
+      });
+      expect(onConfirmStation).not.toHaveBeenCalled();
+      rerender({ ...props, tripActive: false });
+      expect(onConfirmStation).toHaveBeenCalledWith(YONGMASAN);
+      expect(result.current.autoConfirmedStation).toBe(YONGMASAN);
     });
 
     it('dismiss 후 uncertain 해소되었다가 다시 발생 → 모달 재오픈 가능', () => {

--- a/src/features/nearest-station/hooks/useCurrentStationConfirmModal.ts
+++ b/src/features/nearest-station/hooks/useCurrentStationConfirmModal.ts
@@ -31,6 +31,19 @@ export interface UseCurrentStationConfirmModalInputs {
   readonly wifiStation: Station | null;
   /** origin이 이미 결정돼 있으면 모달 차단 — UX 방해 회피. */
   readonly hasEffectiveOrigin: boolean;
+  /**
+   * #1541 — trip(목적지)이 활성 상태이면 F4 자동 확정/모달 모두 비활성.
+   *
+   * trip 중에는 effectiveOrigin이 lock(boardingLock) 또는 customOrigin(사용자 명시 의향)으로
+   * 이미 묶여 있는 게 정상이며, GPS pause(BG 진입/지하 dead zone)로 `result?.station`이
+   * 일시적으로 null이 되어 hasEffectiveOrigin이 false로 떨어지더라도 F4가 다른 station을
+   * customOrigin으로 설정하면 trip-locked origin을 영구 덮어쓰는 stuck 회귀가 발생한다
+   * (2026-06-19 트립 2 "고터 11분 stuck").
+   *
+   * trip 활성 중에는 origin 정정을 사용자 수동 탭(BoardingTrainList / OriginPicker) 또는
+   * 강 SSOT consensus(useDestinationStore.clearCustomOriginForSsotOverride)로만 허용한다.
+   */
+  readonly tripActive?: boolean;
   /** 사용자 1탭 또는 자동 확정 시 호출 (customOrigin 적용). */
   readonly onConfirmStation: (station: Station) => void;
   /** uncertain 지속 임계값(ms). 기본 8000. */
@@ -62,6 +75,7 @@ export function useCurrentStationConfirmModal(
     userLocation,
     wifiStation,
     hasEffectiveOrigin,
+    tripActive = false,
     onConfirmStation,
     uncertainThresholdMs = DEFAULT_UNCERTAIN_THRESHOLD_MS,
   } = inputs;
@@ -89,14 +103,15 @@ export function useCurrentStationConfirmModal(
   }, [locationUncertain, hasEffectiveOrigin, uncertainThresholdMs]);
 
   // 자동 확정: visible 조건 충족 + isAutoConfirmed이면 모달 없이 즉시 적용. 같은 station 재진입은 1회만.
+  // #1541 — trip 활성 중에는 자동 확정 비활성. trip-locked origin을 덮어쓰는 stuck 회귀 차단.
   useEffect(() => {
-    if (!uncertainSustained || dismissed || hasEffectiveOrigin) return;
+    if (!uncertainSustained || dismissed || hasEffectiveOrigin || tripActive) return;
     if (!isAutoConfirmed || topPick === null) return;
     if (autoConfirmedRef.current === topPick.id) return;
     autoConfirmedRef.current = topPick.id;
     setAutoConfirmedStation(topPick);
     onConfirmStation(topPick);
-  }, [uncertainSustained, dismissed, hasEffectiveOrigin, isAutoConfirmed, topPick, onConfirmStation]);
+  }, [uncertainSustained, dismissed, hasEffectiveOrigin, tripActive, isAutoConfirmed, topPick, onConfirmStation]);
 
   // 자동 확정 ref reset — origin이 변경(또는 해제)되면 다음 uncertain 세션에서 다시 자동 확정 가능.
   useEffect(() => {
@@ -120,13 +135,16 @@ export function useCurrentStationConfirmModal(
     setAutoConfirmedStation(null);
   }, []);
 
+  // #1541 — trip 활성 중에는 modal도 차단(자동 확정과 일관). trip 중 origin 정정은
+  // 수동 탭 또는 강 SSOT consensus 경유.
   const visible = useMemo(
     () =>
       uncertainSustained &&
       !dismissed &&
       !hasEffectiveOrigin &&
+      !tripActive &&
       !isAutoConfirmed,
-    [uncertainSustained, dismissed, hasEffectiveOrigin, isAutoConfirmed],
+    [uncertainSustained, dismissed, hasEffectiveOrigin, tripActive, isAutoConfirmed],
   );
 
   return {

--- a/src/features/route/store/__tests__/useDestinationStore.test.ts
+++ b/src/features/route/store/__tests__/useDestinationStore.test.ts
@@ -1020,4 +1020,66 @@ describe('useDestinationStore', () => {
       expect(call).toBeUndefined();
     });
   });
+
+  // #1541 — 강 SSOT consensus 시 customOrigin unlock.
+  describe('clearCustomOriginForSsotOverride (#1541)', () => {
+    it('customOrigin이 없으면 no-op (false 반환, storage write 없음)', () => {
+      (AsyncStorage.removeItem as jest.Mock).mockClear();
+      const result = useDestinationStore
+        .getState()
+        .clearCustomOriginForSsotOverride(mockStation);
+      expect(result).toBe(false);
+      expect(useDestinationStore.getState().customOrigin).toBeNull();
+      expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:custom-origin');
+    });
+
+    it('customOrigin과 같은 station이면 no-op (false 반환)', () => {
+      useDestinationStore.getState().setCustomOrigin(mockStation);
+      (AsyncStorage.removeItem as jest.Mock).mockClear();
+      const result = useDestinationStore
+        .getState()
+        .clearCustomOriginForSsotOverride(mockStation);
+      expect(result).toBe(false);
+      expect(useDestinationStore.getState().customOrigin?.id).toBe(mockStation.id);
+      expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('subway-now:custom-origin');
+    });
+
+    it('customOrigin과 다른 station이면 메모리/storage 모두 unlock (true 반환)', () => {
+      useDestinationStore.getState().setCustomOrigin(mockStation);
+      (AsyncStorage.removeItem as jest.Mock).mockClear();
+      const result = useDestinationStore
+        .getState()
+        .clearCustomOriginForSsotOverride(mockStation2);
+      expect(result).toBe(true);
+      expect(useDestinationStore.getState().customOrigin).toBeNull();
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:custom-origin');
+    });
+
+    it('unlock 시 custom-origin-ssot-override breadcrumb 발사', () => {
+      useDestinationStore.getState().setCustomOrigin(mockStation);
+      mockAddDomainBreadcrumb.mockClear();
+      useDestinationStore
+        .getState()
+        .clearCustomOriginForSsotOverride(mockStation2);
+      const call = mockAddDomainBreadcrumb.mock.calls.find(
+        ([_category, message]) => message === 'custom-origin-ssot-override',
+      );
+      expect(call).toBeDefined();
+      const data = call?.[2] as Record<string, unknown> | undefined;
+      expect(data).toMatchObject({
+        prev: mockStation.name,
+        ssot: mockStation2.name,
+      });
+    });
+
+    it('AsyncStorage.removeItem reject돼도 crash 없이 메모리 unlock 유지', () => {
+      useDestinationStore.getState().setCustomOrigin(mockStation);
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      const result = useDestinationStore
+        .getState()
+        .clearCustomOriginForSsotOverride(mockStation2);
+      expect(result).toBe(true);
+      expect(useDestinationStore.getState().customOrigin).toBeNull();
+    });
+  });
 });

--- a/src/features/route/store/useDestinationStore.ts
+++ b/src/features/route/store/useDestinationStore.ts
@@ -82,6 +82,17 @@ export interface DestinationState {
   removeRecentDestination: (stationId: string) => void;
   loadRecentDestinations: () => Promise<void>;
   setCustomOrigin: (station: Station | null) => void;
+  /**
+   * #1541 — backend SSOT consensus가 강 신호로 customOrigin과 다른 station을 가리킬 때
+   * customOrigin을 unlock한다. customOrigin이 없거나 같은 station이면 no-op.
+   *
+   * 호출자(HomeScreen/fusion orchestration)는 `confidence === 'high'` 같은 강 신호 게이트를
+   * 통과한 후에만 호출해야 한다. ADR-014 §4 "사용자 명시 의향 = lock 동급 보호" 원칙상
+   * 약한 신호로 사용자 의향을 덮어쓰면 안 된다.
+   *
+   * @returns customOrigin이 실제로 해제됐으면 true, no-op이면 false.
+   */
+  clearCustomOriginForSsotOverride: (ssotStation: Station) => boolean;
   loadCustomOrigin: () => Promise<void>;
   setTripOrigin: (station: Station | null) => void;
   loadTripOrigin: () => Promise<void>;
@@ -261,6 +272,21 @@ export const useDestinationStore = create<DestinationState>((set, get) => ({
     } else {
       AsyncStorage.removeItem(CUSTOM_ORIGIN_KEY).catch(noop);
     }
+  },
+
+  // #1541 — 강 SSOT consensus가 customOrigin과 다른 station을 가리키면 unlock.
+  // 같은 station 또는 customOrigin 없음이면 no-op (불필요한 storage write/breadcrumb 회피).
+  clearCustomOriginForSsotOverride: (ssotStation: Station) => {
+    const current = get().customOrigin;
+    if (current === null) return false;
+    if (current.id === ssotStation.id) return false;
+    addDomainBreadcrumb('trip', 'custom-origin-ssot-override', {
+      prev: current.name,
+      ssot: ssotStation.name,
+    });
+    set({ customOrigin: null });
+    AsyncStorage.removeItem(CUSTOM_ORIGIN_KEY).catch(noop);
+    return true;
   },
 
   loadCustomOrigin: async () => {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -56,6 +56,7 @@ import { useDestinationAutoClear } from '../features/alarm/hooks/useDestinationA
 import { useBoardingLockSync } from '../features/alarm/hooks/useBoardingLockSync';
 import { useFgPositionUpload } from '../features/alarm/hooks/useFgPositionUpload';
 import { useCurrentStationConfirmModal } from '../features/nearest-station/hooks/useCurrentStationConfirmModal';
+import { isStrongFusionConfidence } from '../shared/constants/fusionConfidenceStrength';
 import { useWifiStation } from '../features/nearest-station/hooks/useWifiStation';
 import { CurrentStationConfirmModal } from '../features/nearest-station/components/CurrentStationConfirmModal';
 import { MisBoardingBanner } from '../features/route/components/MisBoardingBanner';
@@ -95,6 +96,10 @@ export default function HomeScreen() {
   const customOrigin = useDestinationStore((s) => s.customOrigin);
   const setCustomOrigin = useDestinationStore((s) => s.setCustomOrigin);
   const loadCustomOrigin = useDestinationStore((s) => s.loadCustomOrigin);
+  // #1541 — 강 SSOT consensus가 customOrigin과 다른 station을 가리킬 때 unlock하는 액션.
+  const clearCustomOriginForSsotOverride = useDestinationStore(
+    (s) => s.clearCustomOriginForSsotOverride,
+  );
   const addFavorite = useFavoritesStore((s) => s.addFavorite);
   const removeFavorite = useFavoritesStore((s) => s.removeFavorite);
   const setSlotFavorite = useFavoritesStore((s) => s.setSlotFavorite);
@@ -207,8 +212,22 @@ export default function HomeScreen() {
     userLocation,
     wifiStation,
     hasEffectiveOrigin: customOrigin !== null || result?.station != null,
+    // #1541 — trip 활성 중에는 F4 자동 확정/모달 모두 비활성. trip-locked origin을
+    // 덮어쓰는 stuck 회귀 차단(2026-06-19 트립 2 "고터 11분 stuck").
+    tripActive: destination !== null,
     onConfirmStation: handleConfirmStation,
   });
+  // #1541 — fusion이 강 confidence로 customOrigin과 다른 station을 SSOT로 가리킬 때
+  // customOrigin을 unlock해 사용자가 trip 내내 stuck되는 회귀를 차단한다. confidence='high'는
+  // ADR-015 §5 consensus gate 통과 신호이며, ADR-014 §4 "사용자 명시 의향 동급 보호" 원칙상
+  // 약한 신호로 덮어쓰지 않는다.
+  useEffect(() => {
+    if (!customOrigin) return;
+    if (!result?.station) return;
+    if (!isStrongFusionConfidence(confidence)) return;
+    if (result.station.id === customOrigin.id) return;
+    clearCustomOriginForSsotOverride(result.station);
+  }, [customOrigin, result?.station, confidence, clearCustomOriginForSsotOverride]);
   useEffect(() => {
     if (confirmModal.autoConfirmedStation) {
       setConfirmAutoToast(

--- a/src/shared/constants/__tests__/fusionConfidenceStrength.test.ts
+++ b/src/shared/constants/__tests__/fusionConfidenceStrength.test.ts
@@ -1,0 +1,38 @@
+import {
+  STRONG_FUSION_CONFIDENCE,
+  isStrongFusionConfidence,
+} from '../fusionConfidenceStrength';
+import type { FusionConfidence } from '../../types/fusion';
+
+describe('STRONG_FUSION_CONFIDENCE (#1541)', () => {
+  // ADR-014 §4 사용자 명시 의향 동급 보호 원칙: 실측 신호만 강 신호로 분류.
+  // 시간 적분/거리 기반 추정(*-interp, gps-only*, route-progress)은 약 신호.
+  const STRONG_CASES: readonly FusionConfidence[] = [
+    'boarding-lock',
+    'position-train',
+    'arrival-confirmed',
+    'wifi-ssid',
+  ];
+  const WEAK_CASES: readonly FusionConfidence[] = [
+    'boarding-lock-interp',
+    'arrival-arriving',
+    'route-progress',
+    'gps-only',
+    'gps-only-underground',
+    'detection-fused',
+  ];
+
+  it.each(STRONG_CASES)('%s는 강 신호로 분류된다', (c) => {
+    expect(STRONG_FUSION_CONFIDENCE.has(c)).toBe(true);
+    expect(isStrongFusionConfidence(c)).toBe(true);
+  });
+
+  it.each(WEAK_CASES)('%s는 약 신호로 분류된다 (override 게이트 통과 X)', (c) => {
+    expect(STRONG_FUSION_CONFIDENCE.has(c)).toBe(false);
+    expect(isStrongFusionConfidence(c)).toBe(false);
+  });
+
+  it.each([null, undefined])('%p은 약 신호로 처리된다', (c) => {
+    expect(isStrongFusionConfidence(c)).toBe(false);
+  });
+});

--- a/src/shared/constants/fusionConfidenceStrength.ts
+++ b/src/shared/constants/fusionConfidenceStrength.ts
@@ -1,0 +1,25 @@
+/**
+ * #1541 — fusion confidence "강 신호" 게이트 (S8, Epic #1533 / ADR-016).
+ *
+ * 강 신호: 실측 신호 기반(boarding-lock = 사용자 명시 의향, position-train = 트랙 1D
+ * 진행도, arrival-confirmed = 도착 확정, wifi-ssid = SSID 매칭). 약 신호: 시간 적분
+ * 또는 거리 기반 추정(gps-only, route-progress, *-interp 등).
+ *
+ * 용례:
+ *  - customOrigin SSOT override (S8): 강 신호로 다른 station을 가리킬 때만 사용자
+ *    명시 의향(customOrigin) unlock. ADR-014 §4 "사용자 명시 의향 동급 보호" 원칙상
+ *    약한 신호로 덮어쓰지 않는다.
+ *  - 후속 게이트에서 동일 set를 재사용해 cross-feature 일관성을 보장.
+ */
+import type { FusionConfidence } from '../types/fusion';
+
+export const STRONG_FUSION_CONFIDENCE: ReadonlySet<FusionConfidence> = new Set<FusionConfidence>([
+  'boarding-lock',
+  'position-train',
+  'arrival-confirmed',
+  'wifi-ssid',
+]);
+
+export function isStrongFusionConfidence(confidence: FusionConfidence | undefined | null): boolean {
+  return confidence != null && STRONG_FUSION_CONFIDENCE.has(confidence);
+}


### PR DESCRIPTION
Closes #1541
Epic #1533 (ADR-016) — S8

## 배경
2026-06-19 트립 2:
- 현재역 탭 "고터" 11분 stuck (실제: 학동/강남구청/청담)
- trip end 안 됨 ("14분 도착" 무한 stuck)

F4 autoConfirm이 trip 진행 중 GPS pause 윈도우(`result?.station=null`)에서 잘못된 station을 `setCustomOrigin`하여 trip-locked origin을 영구 덮어씀.

## 변경
1. **F4 autoConfirm trip 중 비활성** — `useCurrentStationConfirmModal`에 `tripActive` prop 추가. trip 활성 중에는 자동 확정/모달 모두 비활성. 수동 탭(BoardingTrainList / OriginPicker) 또는 강 SSOT consensus만 origin 정정 허용.
2. **강 SSOT consensus 시 customOrigin unlock** — `useDestinationStore.clearCustomOriginForSsotOverride(ssotStation)` 추가. customOrigin이 있고 ssot과 다른 station이면 메모리/storage 모두 unlock + `custom-origin-ssot-override` breadcrumb.
3. **강 신호 set 단일 출처** — `shared/constants/fusionConfidenceStrength.ts`. 강 신호 = `boarding-lock`, `position-train`, `arrival-confirmed`, `wifi-ssid` (실측 기반). 약 신호 = `*-interp`, `gps-only*`, `route-progress` 등(추정 기반).
4. **HomeScreen wiring** — `tripActive={destination !== null}` 전달 + `isStrongFusionConfidence(confidence)` 게이트로 SSOT override effect.
5. **trip end customOrigin reset** — 기존 `setDestination(null)` 경로 line 194-196에서 메모리 reset, `TRIP_BOUND_CLEANUPS`가 `CUSTOM_ORIGIN_KEY` storage 정리(이미 보유). BG silent push trip-ended도 동일 경로.

## ADR-014 §4 준수
"사용자 명시 의향 동급 보호" — 약 신호(`gps-only*`, `route-progress`, `*-interp`)로 customOrigin을 덮어쓰지 않는다. 강 신호 set 통과 후에만 unlock.

## 테스트 (모두 통과)
- `useCurrentStationConfirmModal.test.ts` — tripActive 시나리오 3건 추가 (자동 확정 비활성 / 모달 차단 / true→false 전환 재개)
- `useDestinationStore.test.ts` — `clearCustomOriginForSsotOverride` 5건 (no-op 2 / unlock 1 / breadcrumb 1 / storage reject graceful 1)
- `fusionConfidenceStrength.test.ts` — 강/약/null/undefined 신호 분류 (it.each 14 케이스)

## 검증 계획 (실기기 1주 — close 조건)
- [ ] 다음 trip dump: 현재역 탭 stuck 0건
- [ ] trip end 정상 (도착 후 무한 stuck 0건)
- [ ] customOrigin lifecycle log: trip 중 자동 설정 없음 + 강 SSOT 발생 시 `custom-origin-ssot-override` breadcrumb 관측