### PR TITLE
chore(#1546): Sentry DSN 활성 문서 + Instruments 가이드 + breadcrumb 보강

### DIFF
--- a/docs/ops/sentry-setup.md
+++ b/docs/ops/sentry-setup.md
@@ -1,0 +1,82 @@
+# Sentry 설정 운영 가이드 (#1038 / S13 #1546)
+
+본 문서는 Sentry React Native DSN 발급 → 등록 → 활성화 검증 절차의 SSOT.
+
+- **SDK init**: `src/shared/infra/monitoring/sentryInit.ts`
+- **Breadcrumb 유틸**: `src/shared/infra/monitoring/breadcrumb.ts`
+- **활성 상태 SSOT**: `src/shared/infra/monitoring/sentryState.ts` (`isSentryEnabled`)
+- **app.config plugin**: `app.config.js` (`@sentry/react-native/expo`)
+
+## 이중 게이트
+
+DSN이 있어도 사용자가 opt-in 하지 않으면 외부 전송 0. 모든 코드 경로(`enableSentry`, `addLogBreadcrumb`, `addDomainBreadcrumb`, `recordEnvironmentTransition`)가 `isSentryEnabled()` 또는 DSN 가드를 통과해야 한다.
+
+| 조건 | 결과 |
+| --- | --- |
+| `SENTRY_OPT_IN_KEY` AsyncStorage = `'true'` + `EXPO_PUBLIC_SENTRY_DSN` 설정 | Sentry SDK init + breadcrumb 전송 |
+| opt-in O / DSN X | logger.info "DSN 미설정" → no-op |
+| opt-in X | `initSentryIfOptedIn` early return |
+
+기본값: opt-in OFF. 사용자가 설정 화면에서 명시 동의 후만 활성. 개인정보 정책상 GPS/푸시토큰/이메일은 breadcrumb data에 넣지 않는다 (역 이름·노선·trainCode 등 공개 정보만).
+
+## 운영자 액션 절차
+
+DSN 발급은 운영자(`handokei`) 액션. 본 PR은 인프라 + 문서만 제공한다.
+
+### 1. Sentry 프로젝트 생성
+
+1. https://sentry.io → Settings → Projects → Create Project
+2. Platform: **React Native**
+3. Project name: `subway-now` (기존이 있으면 재사용)
+4. 프로젝트 생성 후 Settings → Client Keys (DSN) → 기본 DSN 복사
+
+### 2. 로컬 `.env` 등록
+
+```
+EXPO_PUBLIC_SENTRY_DSN=https://<public_key>@oXXXXXX.ingest.sentry.io/<project_id>
+```
+
+`.env` 자체는 커밋 금지 (`.gitignore`에 이미 포함). `.env.example`에는 키 이름만.
+
+### 3. EAS production 환경 등록
+
+```bash
+eas env:create production --name EXPO_PUBLIC_SENTRY_DSN --value '<DSN>'
+eas env:create preview    --name EXPO_PUBLIC_SENTRY_DSN --value '<DSN>'   # 선택
+```
+
+development profile은 등록하지 않거나 별도 DSN으로 분리(production 노이즈 격리).
+
+### 4. 검증
+
+1. EAS production 빌드 → TestFlight 설치
+2. 앱 설정 → 진단 → Sentry opt-in 토글 ON
+3. 1분 내 boot → Sentry Issues 페이지에서 첫 session event 도착 확인
+4. 의도적 crash 경로(설정 → 디버그 → "테스트 에러 발생" 등이 있다면) 또는 자연 trip 1회로 breadcrumb 5개 이상 누적 확인:
+   - `trip:start`
+   - `boarding:lock-create`
+   - `lifecycle:environment-transition` (지하 진입 시)
+   - `push:silent-push`
+   - `alarm:fire`
+
+## Breadcrumb 카테고리 (현재 wired)
+
+| 카테고리 | 발사 지점 | 파일 |
+| --- | --- | --- |
+| `trip` | destination set/clear, sentinel rehydration | `useDestinationStore.ts`, `useStateRehydration.ts` |
+| `boarding` | createLock / releaseLock | `useBoardingLockStore.ts` |
+| `alarm` | 알람 fire, trip-ended-surface | `stationNotification.ts` |
+| `push` | silent push payload 수신 | `silentPushTask.ts` |
+| `permission` | notification 권한 변경 | `stationNotification.ts` |
+| `lifecycle` | FG/BG transition, environment 전환 | `useStateRehydration.ts`, `useFusedNearestStation.ts` |
+
+## 개인정보·데이터 정책
+
+- DSN 발급된 Sentry 프로젝트는 EU 또는 US region 둘 다 가능. 한국 사용자 대상이면 EU region 권장 (GDPR-aligned).
+- breadcrumb data: 역 이름·노선·trainCode·환경 전환은 OK. GPS 좌표는 호출자가 100m round 후 전달 (`breadcrumb.ts` 주석 참고).
+- 사용자 식별자/푸시토큰 전체 전달 금지.
+- 동의 철회 경로: 설정 → Sentry opt-in 토글 OFF → `Sentry.close()` 즉시 호출 (`setSentryOptIn(false)`).
+
+## Instruments freeze 캡처
+
+JS 로직 외 native hang(15:42 freeze 같은 케이스)은 Sentry로 잡히지 않는다. Xcode Instruments Time Profiler + Hang Tracer 절차는 [xcode-instruments-freeze-capture.md](./xcode-instruments-freeze-capture.md) 참고.

--- a/docs/ops/xcode-instruments-freeze-capture.md
+++ b/docs/ops/xcode-instruments-freeze-capture.md
@@ -1,0 +1,76 @@
+# Xcode Instruments freeze 캡처 가이드 (S13 #1546)
+
+본 문서는 실기기에서 앱이 "수 초간 응답 없음" 또는 main thread block을 일으킬 때 Instruments로 stack trace를 캡처하는 절차의 SSOT.
+
+대상 사례:
+- TestFlight 빌드 15:42 KST UI freeze (evidence 트립)
+- BG → FG 복귀 직후 hang
+- 알람 fire 직후 main thread block
+
+## 준비
+
+- macOS + Xcode (CLI tools만으로는 부족, full Xcode 필요)
+- Apple Developer 계정 (실기기 attach 가능한 provisioning profile)
+- 디바이스 USB 연결 + "이 컴퓨터 신뢰" 완료
+- 캡처 대상은 **EAS production 또는 development 빌드 설치된 실기기**. 시뮬레이터는 main thread 타이밍이 다르므로 freeze 재현이 불가능한 경우가 많다.
+
+## Hang Tracer (가벼움, 1차 선택)
+
+iOS 16+ 기본 제공. 1초 이상 main thread block을 자동 기록.
+
+1. Xcode → Open Developer Tool → Instruments
+2. Template: **Hangs** 선택
+3. 상단 target dropdown → 디바이스 + `SubwayNow` 앱 선택
+4. 빨간 Record 버튼
+5. freeze 재현 시나리오 수행 (예: BG → FG 복귀, 알람 fire 후 탭)
+6. freeze 발생 후 5초 대기 → Stop 버튼
+7. Hangs track에 표시된 막대 클릭 → 우측 Detail pane에서 main thread stack 확인
+
+## Time Profiler (정밀, 2차)
+
+Hang Tracer가 1초 미만 block을 놓치거나 CPU 분포가 필요할 때.
+
+1. Instruments → Template **Time Profiler**
+2. 동일하게 디바이스/앱 선택 → Record
+3. 시나리오 수행 → Stop
+4. Call Tree pane:
+   - Separate by Thread: ON
+   - Invert Call Tree: ON
+   - Hide System Libraries: ON (앱 코드만)
+5. Main Thread row 펼쳐 self time 상위 함수 확인
+
+JS 작업이 main thread를 블록하는 경우 `RCTBridge`, `RCTCxxBridge`, `facebook::react::*` 프레임이 상단에 잡힌다. Native 작업이 원인이면 `subway-now`, `live-activity`, `audio-route` 등 본 프로젝트 native module 프레임이 보인다.
+
+## 캡처 파일 공유
+
+1. Instruments File → Save → `.trace` 파일 (보통 수십 MB)
+2. zip으로 압축 후 GitHub Issue 첨부 또는 사용자가 직접 분석
+3. `.trace` 파일은 PII(앱 내부 상태) 포함 가능 — public repo에 커밋 금지
+
+## 결과 보고 템플릿
+
+GitHub Issue 또는 RCA 문서에 첨부할 때:
+
+```
+## Instruments 캡처 결과
+- 디바이스: iPhone <모델> / iOS <버전>
+- 빌드: <buildNumber> (EAS <profile>)
+- 시나리오: <재현 단계>
+- freeze 시각: <KST HH:MM:SS>
+- 지속 시간: <초>
+- Main thread 상위 프레임 (3~5개):
+  1. <함수> — <self time>
+  2. ...
+- 가설: <JS/Native/IO/lock contention>
+```
+
+## 한계
+
+- 백그라운드 freeze는 OS가 Suspend 상태로 만들기 때문에 Instruments로 캡처 불가능 — 별도 로그(`os_log`) 또는 Sentry breadcrumb로 추적.
+- TestFlight 빌드는 Release 최적화로 일부 frame이 inline되어 stack이 짧을 수 있다. 가능하면 development profile + `-O0` 빌드로 재현.
+
+## Sentry와의 관계
+
+Sentry는 JS error / unhandled promise는 잡지만, native main thread hang은 직접 잡지 못한다(Sentry React Native 7.x 기준 `enableAppHangTracking`은 native 옵션이지만 iOS-only + 별도 설정 필요). 본 문서의 Instruments 절차는 Sentry breadcrumb로 freeze 직전까지의 trail을 좁힌 후 native stack까지 짚어가기 위한 보완 절차.
+
+[sentry-setup.md](./sentry-setup.md)와 함께 사용.

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -34,6 +34,7 @@ import { isWithinArcWindow, passesFusionDistanceGate } from '../utils/fusionDist
 import { surfaceSSOTConsensus } from '../utils/surfaceSSotConsensus';
 import { undergroundSSOTConsensus } from '../utils/undergroundSSotConsensus';
 import { inferEnvironment, type Environment } from '../utils/inferEnvironment';
+import { recordEnvironmentTransition } from '../../../shared/infra/monitoring/breadcrumb';
 import { computeRouteArc } from '../../route/utils/routeProgress';
 import {
   arcIndexOfStation,
@@ -787,6 +788,14 @@ export function useFusedNearestStation(
     surfaceSSOT: surfaceSSOT !== null,
     undergroundSSOT: undergroundSSOT !== null,
   });
+
+  // S13(#1546) — 환경 전환 Sentry breadcrumb. delta-only emit.
+  // dedup은 recordEnvironmentTransition 내부에서 처리(prev === next 시 no-op).
+  const prevEnvironmentRef = useRef<Environment | undefined>(undefined);
+  useEffect(() => {
+    recordEnvironmentTransition(prevEnvironmentRef.current, environment);
+    prevEnvironmentRef.current = environment;
+  }, [environment]);
 
   // ADR-008 stationProgressEstimator — 시간 적분 → 관측 구동 전환 (#739).
   // arc상 추정 위치가 현 채택된 결과보다 앞이거나, 채택 결과가 arc 밖이면 override.

--- a/src/shared/infra/monitoring/__tests__/breadcrumb.test.ts
+++ b/src/shared/infra/monitoring/__tests__/breadcrumb.test.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/react-native';
-import { addDomainBreadcrumb, addLogBreadcrumb } from '../breadcrumb';
+import { addDomainBreadcrumb, addLogBreadcrumb, recordEnvironmentTransition } from '../breadcrumb';
 import { setSentryEnabled } from '../sentryState';
 
 const addBreadcrumbMock = Sentry.addBreadcrumb as jest.Mock;
@@ -112,5 +112,42 @@ describe('addDomainBreadcrumb', () => {
       category: 'lifecycle',
       message: 'foreground',
     });
+  });
+});
+
+describe('recordEnvironmentTransition (S13 #1546)', () => {
+  beforeEach(() => {
+    setSentryEnabled(true);
+  });
+
+  it('prev === undefined (첫 관측)이면 no-op', () => {
+    recordEnvironmentTransition(undefined, 'surface');
+    expect(addBreadcrumbMock).not.toHaveBeenCalled();
+  });
+
+  it('prev === next (전환 없음)이면 no-op', () => {
+    recordEnvironmentTransition('surface', 'surface');
+    expect(addBreadcrumbMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['surface' as const, 'underground' as const],
+    ['underground' as const, 'surface' as const],
+    ['unknown' as const, 'underground' as const],
+    ['surface' as const, 'unknown' as const],
+  ])('%s → %s 전환 시 lifecycle breadcrumb 발사', (from, to) => {
+    recordEnvironmentTransition(from, to);
+    expect(addBreadcrumbMock).toHaveBeenCalledWith({
+      level: 'info',
+      category: 'lifecycle',
+      message: 'environment-transition',
+      data: { from, to },
+    });
+  });
+
+  it('opt-in 비활성이면 no-op', () => {
+    setSentryEnabled(false);
+    recordEnvironmentTransition('surface', 'underground');
+    expect(addBreadcrumbMock).not.toHaveBeenCalled();
   });
 });

--- a/src/shared/infra/monitoring/breadcrumb.ts
+++ b/src/shared/infra/monitoring/breadcrumb.ts
@@ -93,3 +93,22 @@ export function addDomainBreadcrumb(
     ...(data ? { data } : {}),
   });
 }
+
+/**
+ * S13(#1546) — 환경 전환 breadcrumb. delta-only 발사.
+ *
+ * `prev === next`(전환 없음) 또는 `prev === undefined`(첫 관측, 비교 기준 없음)이면 no-op.
+ * 호출자는 이전 환경을 ref/state로 보존하고 매 폴링마다 호출하면 된다 — 본 함수가 dedup 책임.
+ *
+ * 예: `surface → underground` 전환은 silent push polling 주기 변화 / boardingPrompt 게이트
+ * 활성화 / GPS gating downgrade 등 여러 downstream 효과를 가져온다. Sentry trail에서
+ * "정확히 언제 지하 진입을 감지했는가"를 보기 위함.
+ */
+export function recordEnvironmentTransition(
+  prev: 'surface' | 'underground' | 'unknown' | undefined,
+  next: 'surface' | 'underground' | 'unknown',
+): void {
+  if (prev === undefined) return;
+  if (prev === next) return;
+  addDomainBreadcrumb('lifecycle', 'environment-transition', { from: prev, to: next });
+}


### PR DESCRIPTION
Closes #1546. Epic ADR-016(#1533) S13.

## 변경 사항
- `docs/ops/sentry-setup.md` 신설 — DSN 발급 → 로컬 `.env` → EAS production 등록 → 활성 검증 절차. 이중 게이트(opt-in + DSN) + breadcrumb 카테고리 wire-up 표.
- `docs/ops/xcode-instruments-freeze-capture.md` 신설 — 15:42 freeze 같은 native main thread hang 캡처 절차 (Hang Tracer + Time Profiler + 결과 보고 템플릿).
- `src/shared/infra/monitoring/breadcrumb.ts`에 `recordEnvironmentTransition(prev, next)` 추가 — `prev === undefined`(첫 관측) / `prev === next`(전환 없음) 시 no-op. surface/underground/unknown 4가지 전환 모두 `lifecycle` 카테고리로 emit.
- `useFusedNearestStation.ts`에 `prevEnvironmentRef` + 1줄 effect로 wire-up. 폴링 hot-path 영향 없음 (dedup 책임은 helper 안).
- `breadcrumb.test.ts`에 전환 4종/no-op 2종/opt-in 가드 1종 추가.

## 운영자 액션 체크리스트 (사용자 전담)
- [ ] Sentry React Native project 생성 (sentry.io, EU region 권장)
- [ ] 로컬 `.env`에 `EXPO_PUBLIC_SENTRY_DSN` 추가 (`.env.example`는 이미 키만 비워둠)
- [ ] `eas env:create production --name EXPO_PUBLIC_SENTRY_DSN --value '<DSN>'`
- [ ] 다음 production 빌드 → TestFlight 설치 → 설정에서 Sentry opt-in ON
- [ ] Sentry Issues 페이지에서 첫 session event + 5종 breadcrumb 누적 확인 (`trip:start` / `boarding:lock-create` / `lifecycle:environment-transition` / `push:silent-push` / `alarm:fire`)

## 검증
- `npm run type-check` ✅
- `npx jest src/shared/infra/monitoring/__tests__/breadcrumb.test.ts` 19/19 ✅
- `npx jest src/features/nearest-station/hooks/__tests__/useFusedNearestStation` 302/302 ✅
- ⚠️ 별개 pre-existing 실패 (`widgetStorage.test.ts`, `stationNotification.test.ts`) — origin/dev 베이스라인에서도 동일하게 실패. 본 PR과 무관.

## Privacy
기본값 opt-in OFF 유지. breadcrumb data는 역 이름/노선/trainCode/환경값만 (GPS 좌표는 호출자가 100m round 후 전달, 사용자 식별자/푸시토큰 전달 금지). `docs/ops/sentry-setup.md` "개인정보·데이터 정책" 섹션 참고.