### PR TITLE
feat(#1543): CTRadioAccessTechnology listener (4분면 환경 1표)

### DIFF
--- a/backend/alarm-worker/src/__tests__/consensusGate.test.ts
+++ b/backend/alarm-worker/src/__tests__/consensusGate.test.ts
@@ -126,6 +126,50 @@ describe('evaluateConsensusGate (ADR-015 §3/§4)', () => {
     });
   });
 
+  describe('S10 #1543 — cellularEnvironmentVote contradict 게이트', () => {
+    it('surface env + cellular=underground → reject (cellular-environment-contradicts)', () => {
+      expect(runGate('surface', { cellularEnvironmentVote: 'underground' })).toEqual({
+        pass: false,
+        environment: 'surface',
+        reason: 'cellular-environment-contradicts',
+      });
+    });
+
+    it('underground env + cellular=surface → reject (contradicts) — base 통과 무시', () => {
+      expect(runGate('underground', { cellularEnvironmentVote: 'surface' })).toEqual({
+        pass: false,
+        environment: 'underground',
+        reason: 'cellular-environment-contradicts',
+      });
+    });
+
+    it('surface env + cellular=surface (일치) → 기존 base 게이트 결과 그대로', () => {
+      expect(runGate('surface', { cellularEnvironmentVote: 'surface' }).pass).toBe(true);
+    });
+
+    it('underground env + cellular=underground (일치) → 기존 B+E 합의 통과', () => {
+      expect(runGate('underground', { cellularEnvironmentVote: 'underground' }).pass).toBe(true);
+    });
+
+    it('cellular=unknown → vote 미투표, 게이트 정책 영향 0', () => {
+      expect(runGate('surface', { cellularEnvironmentVote: 'unknown' }).pass).toBe(true);
+      expect(runGate('underground', { cellularEnvironmentVote: 'unknown' }).pass).toBe(true);
+    });
+
+    it('cellular undefined (필드 미전송) → vote 미투표', () => {
+      expect(runGate('surface').pass).toBe(true);
+    });
+
+    it('mixed env — cellular vote는 contradict 판정 대상이 아님 (보수)', () => {
+      expect(runGate('mixed', { cellularEnvironmentVote: 'surface' }).pass).toBe(true);
+      expect(runGate('mixed', { cellularEnvironmentVote: 'underground' }).pass).toBe(true);
+    });
+
+    it('unknown env — mixed와 동일 (cellular vote는 contradict 판정 X)', () => {
+      expect(runGate('unknown', { cellularEnvironmentVote: 'surface' }).pass).toBe(true);
+    });
+  });
+
   describe('§7 토글 input X — backend는 trip 등록만 본다', () => {
     it.each<StationEnvironment>(['surface', 'underground', 'mixed'])(
       '%s: 동일 signals → 토글 ON/OFF / boardingPrompt 응답 유무와 무관하게 동일 결과',

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1725,6 +1725,57 @@ describe('POST /position (#819)', () => {
       expect(stored[0].currentStationName).toBeUndefined();
     });
   });
+
+  describe('#1543 (S10) — cellularEnvironmentVote 옵션 필드', () => {
+    const BASE_POS = {
+      token: 'tok-cell',
+      lat: 1,
+      lng: 2,
+      accuracy: 5,
+      ts: 1234,
+      motion: 'walking' as const,
+    };
+
+    it.each(['surface', 'underground', 'unknown'] as const)(
+      'enum %s → point.cellularEnvironmentVote에 set',
+      async (vote) => {
+        const env = makeKvEnv();
+        const res = await post(
+          '/position',
+          { ...BASE_POS, cellularEnvironmentVote: vote },
+          env,
+        );
+        expect(res.status).toBe(200);
+        const stored = JSON.parse(
+          (await env.TRIPS.get('pos:tok-cell'))!,
+        ) as Array<Record<string, unknown>>;
+        expect(stored[0].cellularEnvironmentVote).toBe(vote);
+      },
+    );
+
+    it('enum 외 값 → undefined로 graceful skip (payload 거부 X)', async () => {
+      const env = makeKvEnv();
+      const res = await post(
+        '/position',
+        { ...BASE_POS, cellularEnvironmentVote: 'mars' },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const stored = JSON.parse(
+        (await env.TRIPS.get('pos:tok-cell'))!,
+      ) as Array<Record<string, unknown>>;
+      expect(stored[0].cellularEnvironmentVote).toBeUndefined();
+    });
+
+    it('필드 없음 → undefined (회귀 없음)', async () => {
+      const env = makeKvEnv();
+      await post('/position', BASE_POS, env);
+      const stored = JSON.parse(
+        (await env.TRIPS.get('pos:tok-cell'))!,
+      ) as Array<Record<string, unknown>>;
+      expect(stored[0].cellularEnvironmentVote).toBeUndefined();
+    });
+  });
 });
 
 describe('POST /boarding-prompt/dismiss (#819)', () => {

--- a/backend/alarm-worker/src/__tests__/positionSeries.test.ts
+++ b/backend/alarm-worker/src/__tests__/positionSeries.test.ts
@@ -471,6 +471,57 @@ describe('positionSeries — currentStationName field validation (#1363)', () =>
   });
 });
 
+describe('positionSeries — cellularEnvironmentVote field validation (#1543)', () => {
+  it.each(['surface', 'underground', 'unknown'] as const)(
+    'enum %s → series에 정상 적재',
+    async (vote) => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      const raw = JSON.stringify([
+        {
+          lat: 37.5,
+          lng: 127.0,
+          accuracy: 5,
+          ts: 1000,
+          motion: 'walking',
+          cellularEnvironmentVote: vote,
+        },
+      ]);
+      await kv.put('pos:tok', raw);
+      const series = await readSeries(kv, 'tok');
+      expect(series).toHaveLength(1);
+      expect(series[0].cellularEnvironmentVote).toBe(vote);
+    },
+  );
+
+  it('enum 외 값 → series에서 filter됨 (정합성 보장)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const raw = JSON.stringify([
+      {
+        lat: 37.5,
+        lng: 127.0,
+        accuracy: 5,
+        ts: 1000,
+        motion: 'walking',
+        cellularEnvironmentVote: 'mars',
+      },
+    ]);
+    await kv.put('pos:tok', raw);
+    const series = await readSeries(kv, 'tok');
+    expect(series).toHaveLength(0);
+  });
+
+  it('필드 부재 → 정상 적재 (옵션)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const raw = JSON.stringify([
+      { lat: 37.5, lng: 127.0, accuracy: 5, ts: 1000, motion: 'walking' },
+    ]);
+    await kv.put('pos:tok', raw);
+    const series = await readSeries(kv, 'tok');
+    expect(series).toHaveLength(1);
+    expect(series[0].cellularEnvironmentVote).toBeUndefined();
+  });
+});
+
 describe('cosineDirection', () => {
   it('같은 방향 → 1', () => {
     // 동→서 두 vector 동일 방향

--- a/backend/alarm-worker/src/consensusGate.ts
+++ b/backend/alarm-worker/src/consensusGate.ts
@@ -63,6 +63,10 @@ export type StationEnvironment = 'surface' | 'underground' | 'mixed' | 'unknown'
  * 추후 wire 대상(현 cycle 미지원, undefined로 무시):
  * - `positionTrainAgreement`: device fusion이 산출한 position-train 일치 (strong C)
  * - `wifiSsidMatch`: 역 WiFi SSID 일치 (strong D)
+ * - `cellularEnvironmentVote`: device CTRadioAccessTechnology 기반 환경 vote (S10 #1543)
+ *     - 'surface'      : 4G/5G 잡힘 → 지상 환경 vote (strong F)
+ *     - 'underground'  : 2G/3G fallback → 지하 환경 vote (strong F)
+ *     - 'unknown'/미전송 : vote 미투표 (정책 영향 0)
  */
 export interface ConsensusSignals {
   gateOutcome: GateOutcome;
@@ -70,6 +74,7 @@ export interface ConsensusSignals {
   lockAttachable: boolean;
   positionTrainAgreement?: boolean;
   wifiSsidMatch?: boolean;
+  cellularEnvironmentVote?: 'surface' | 'underground' | 'unknown';
 }
 
 /**
@@ -86,7 +91,8 @@ export type ConsensusOutcome =
       reason:
         | 'base-gate-failed'
         | 'environment-no-gps-consensus'
-        | 'mixed-strong-signals-insufficient';
+        | 'mixed-strong-signals-insufficient'
+        | 'cellular-environment-contradicts';
     };
 
 /**
@@ -99,10 +105,41 @@ export type ConsensusOutcome =
  * - mixed/unknown: 보수적. arrival + lockAttachable 동시 충족 강제. base 9단 게이트 통과도
  *   동시에 요구해 false positive 누적 차단.
  */
+/**
+ * S10 #1543 — cellular vote가 trip 환경과 정면 충돌하는지 판정.
+ *
+ * 충돌 케이스(둘 다 명시적 surface ↔ underground일 때만 contradict):
+ *   - environment=surface + cellularEnvironmentVote=underground
+ *   - environment=underground + cellularEnvironmentVote=surface
+ *
+ * 비충돌 케이스 (모두 false):
+ *   - vote가 'unknown' / undefined (미투표) — 모르는 상태는 차단 안 함
+ *   - environment=mixed/unknown — 환경 자체가 보수적이라 vote로 추가 거절 X
+ *   - vote가 environment와 일치 — 정상
+ *
+ * 정책: 본 함수는 contradict만 식별. 일치 vote가 OR 통과를 추가로 열어주진 않는다
+ * (false positive 차단 우선 — surface GPS jitter가 cellular 4G와 동시에 거짓 합의를 만들면
+ *  지상 false positive로 새는 회귀를 막기 위함).
+ */
+function cellularContradictsEnvironment(
+  environment: StationEnvironment,
+  vote: ConsensusSignals['cellularEnvironmentVote'],
+): boolean {
+  if (vote === undefined || vote === 'unknown') return false;
+  if (environment === 'surface' && vote === 'underground') return true;
+  if (environment === 'underground' && vote === 'surface') return true;
+  return false;
+}
+
 export function evaluateConsensusGate(
   environment: StationEnvironment,
   signals: ConsensusSignals,
 ): ConsensusOutcome {
+  // S10 #1543 — cellular vote가 환경과 정면 충돌하면 즉시 reject.
+  // 본 게이트는 base 통과/미통과와 무관하게 적용 — 환경 자체가 신뢰 불가하다는 강한 신호.
+  if (cellularContradictsEnvironment(environment, signals.cellularEnvironmentVote)) {
+    return { pass: false, environment, reason: 'cellular-environment-contradicts' };
+  }
   const baseGatePassed = signals.gateOutcome.pass;
   if (environment === 'surface') {
     return baseGatePassed

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -944,6 +944,13 @@ export function validatePositionPayload(input: unknown): PositionUploadPayload |
     typeof obj.currentStationName === 'string' && obj.currentStationName.length > 0
       ? obj.currentStationName
       : undefined;
+  // #1543 (S10) — CTRadioAccessTechnology 환경 vote. iOS만 송신. 정의된 enum 외 값은 graceful drop.
+  const cellularEnvironmentVote =
+    obj.cellularEnvironmentVote === 'surface' ||
+    obj.cellularEnvironmentVote === 'underground' ||
+    obj.cellularEnvironmentVote === 'unknown'
+      ? obj.cellularEnvironmentVote
+      : undefined;
   return {
     token: obj.token,
     point: {
@@ -955,6 +962,7 @@ export function validatePositionPayload(input: unknown): PositionUploadPayload |
       ...(hasPair ? { mapMatchedLine, mapMatchedArcM } : {}),
       ...(nearestStationDistanceM !== undefined ? { nearestStationDistanceM } : {}),
       ...(currentStationName !== undefined ? { currentStationName } : {}),
+      ...(cellularEnvironmentVote !== undefined ? { cellularEnvironmentVote } : {}),
     },
     accelSummary,
   };

--- a/backend/alarm-worker/src/positionSeries.ts
+++ b/backend/alarm-worker/src/positionSeries.ts
@@ -127,6 +127,16 @@ function isPositionPoint(value: unknown): value is PositionPoint {
     if (typeof o.currentStationName !== 'string') return false;
     if (o.currentStationName.length === 0) return false;
   }
+  // #1543 (S10) — cellularEnvironmentVote는 옵션. 정의된 enum 외 값은 series 거부 (graceful).
+  if (o.cellularEnvironmentVote !== undefined) {
+    if (
+      o.cellularEnvironmentVote !== 'surface' &&
+      o.cellularEnvironmentVote !== 'underground' &&
+      o.cellularEnvironmentVote !== 'unknown'
+    ) {
+      return false;
+    }
+  }
   return true;
 }
 

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -401,6 +401,18 @@ export interface PositionPoint {
    * 차단한다. 미전달 시 log에서 `currentStation` 키가 omit (graceful, 회귀 없음).
    */
   currentStationName?: string;
+  /**
+   * #1543 (ADR-016 S10) — 디바이스 CTRadioAccessTechnology 환경 vote.
+   *
+   * - 'surface'      : 4G/5G 잡힘 → 지상 환경 vote
+   * - 'underground'  : 2G/3G fallback → 지하 환경 vote
+   * - 'unknown' / 미전송 : vote 미투표 (게이트 영향 0)
+   *
+   * 본 필드는 backend `evaluateConsensusGate`가 `cellularEnvironmentVote`로 입력받아 4분면 SSOT
+   * 합의 게이트의 환경 contradict 판정에 사용한다. iOS only — Android는 본 값을 보내지 않으며
+   * backend는 undefined를 'unknown' 동급으로 graceful 처리.
+   */
+  cellularEnvironmentVote?: 'surface' | 'underground' | 'unknown';
 }
 
 /**

--- a/modules/cellular-tech-listener/CellularTechListener.podspec
+++ b/modules/cellular-tech-listener/CellularTechListener.podspec
@@ -1,0 +1,17 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'CellularTechListener'
+  s.version        = package['version']
+  s.summary        = 'CTRadioAccessTechnology listener for subway-now ADR-016 S10 environment consensus (#1543)'
+  s.homepage       = 'https://github.com/handokei/subway-now'
+  s.license        = 'MIT'
+  s.author         = 'subway-now'
+  s.platform       = :ios, '15.1'
+  s.source         = { path: '.' }
+  s.source_files   = 'ios/**/*.swift'
+  s.frameworks     = 'CoreTelephony'
+  s.dependency 'ExpoModulesCore'
+end

--- a/modules/cellular-tech-listener/expo-module.config.json
+++ b/modules/cellular-tech-listener/expo-module.config.json
@@ -1,0 +1,7 @@
+{
+  "platforms": ["ios"],
+  "ios": {
+    "modules": ["CellularTechListenerModule"],
+    "podspecPath": "CellularTechListener.podspec"
+  }
+}

--- a/modules/cellular-tech-listener/index.ts
+++ b/modules/cellular-tech-listener/index.ts
@@ -1,0 +1,7 @@
+import { requireOptionalNativeModule } from 'expo-modules-core';
+
+const CellularTechListenerModule =
+  // jest/web/Android/미지원 디바이스: null → JS wrapper(src/features/nearest-station/utils/cellularTech.ts)가 graceful fallback.
+  requireOptionalNativeModule('CellularTechListener');
+
+export default CellularTechListenerModule;

--- a/modules/cellular-tech-listener/ios/CellularTechListenerModule.swift
+++ b/modules/cellular-tech-listener/ios/CellularTechListenerModule.swift
@@ -1,0 +1,85 @@
+import ExpoModulesCore
+import CoreTelephony
+
+/**
+ * #1543 (ADR-016 S10) — CTRadioAccessTechnology BG-safe listener.
+ *
+ * 환경(지하/지상) 4분면 SSOT 합의 게이트에 1표 추가.
+ *
+ * 원리:
+ *   - `CTTelephonyNetworkInfo.serviceCurrentRadioAccessTechnology`로 현재 radio access tech 조회
+ *   - `CTServiceRadioAccessTechnologyDidChangeNotification`(iOS 12+) 옵저빙으로 변화 즉시 sync.
+ *     OS-level NotificationCenter post → BG에서도 수신 (Apple docs: "delivered to any observer
+ *     regardless of app state").
+ *
+ * 환경 추론(JS layer 책임):
+ *   - 4G(LTE/LTEAdvanced) / 5G(NR/NRNSA) → 지상 신호 (안정적 macro cell coverage)
+ *   - 2G/3G(GPRS/Edge/UMTS/HSDPA 등) / null → 지하 의심 (지하 캐리어 또는 무신호 상태)
+ *
+ * 미지원 / 권한 / 결과 빈 dict:
+ *   - 사용자 SIM 미장착 / 비활성 → empty dict (`""` 또는 `null` 반환)
+ *   - 본 모듈은 캐리어 정보 / IMSI 미참조 — 별도 권한 prompt 없음 (Apple App Privacy 무영향)
+ *
+ * Graceful 정책: 모든 실패 → null로 회귀. "모르는 상태"는 환경 판정 vote 미투표.
+ */
+public class CellularTechListenerModule: Module {
+    private let networkInfo = CTTelephonyNetworkInfo()
+    private var latestTech: String? = nil
+    private var isObserving: Bool = false
+    private var observer: NSObjectProtocol? = nil
+
+    public func definition() -> ModuleDefinition {
+        Name("CellularTechListener")
+
+        Function("isAvailable") { () -> Bool in
+            // CTTelephonyNetworkInfo는 iOS 표준 — SIM 부재 디바이스에서도 instance 생성은 가능.
+            return true
+        }
+
+        Function("startUpdates") {
+            if self.isObserving { return }
+            // 초기 1회 sync — 옵저빙 시작 시점의 radio tech를 캐시.
+            self.refreshLatest()
+            self.observer = NotificationCenter.default.addObserver(
+                forName: .CTServiceRadioAccessTechnologyDidChange,
+                object: nil,
+                queue: nil
+            ) { [weak self] _ in
+                // 변화 알림 수신 시 networkInfo에서 최신 값을 다시 pull.
+                self?.refreshLatest()
+            }
+            self.isObserving = true
+        }
+
+        Function("stopUpdates") {
+            if let obs = self.observer {
+                NotificationCenter.default.removeObserver(obs)
+                self.observer = nil
+            }
+            self.isObserving = false
+            self.latestTech = nil
+        }
+
+        Function("getCurrentTech") { () -> String? in
+            return self.latestTech
+        }
+    }
+
+    /// `CTTelephonyNetworkInfo`에서 현재 service의 radio access technology 코드를 캐시.
+    ///
+    /// `serviceCurrentRadioAccessTechnology`는 service key → tech 코드 dict.
+    /// 첫 non-empty 값을 채택 (dual-SIM의 경우 활성 service 우선이지만 API 자체가 안정 보장).
+    /// dict가 비어 있거나 모든 value가 nil/빈 문자열이면 latestTech=nil로 둔다 (graceful).
+    private func refreshLatest() {
+        let dict = self.networkInfo.serviceCurrentRadioAccessTechnology
+        if let dict = dict {
+            for (_, tech) in dict {
+                if !tech.isEmpty {
+                    self.latestTech = tech
+                    return
+                }
+            }
+        }
+        self.latestTech = nil
+    }
+}

--- a/modules/cellular-tech-listener/package.json
+++ b/modules/cellular-tech-listener/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "cellular-tech-listener",
+  "version": "1.0.0",
+  "main": "index.ts"
+}

--- a/src/features/nearest-station/api/positionUpload.ts
+++ b/src/features/nearest-station/api/positionUpload.ts
@@ -94,6 +94,17 @@ export interface PositionUploadPayload {
    * undefined/빈 문자열은 backend가 graceful drop (회귀 없음).
    */
   currentStationName?: string;
+  /**
+   * #1543 (ADR-016 S10) — 디바이스 CTRadioAccessTechnology 환경 vote (`useCellularTech`).
+   *
+   * - 'surface'      : 4G/5G 잡힘 → 지상 환경 vote
+   * - 'underground'  : 2G/3G fallback → 지하 환경 vote
+   * - 'unknown' / 미전송 : vote 미투표 (게이트 영향 0)
+   *
+   * iOS only. Android / 미지원 디바이스 / native module 부재 시 omit (graceful).
+   * backend `consensusGate`의 environment contradict 판정에 사용된다.
+   */
+  cellularEnvironmentVote?: 'surface' | 'underground' | 'unknown';
 }
 
 export interface PositionUploadResult {

--- a/src/features/nearest-station/hooks/__tests__/useCellularTech.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useCellularTech.test.ts
@@ -1,0 +1,93 @@
+/**
+ * #1543 (ADR-016 S10) — useCellularTech 훅 테스트.
+ *
+ * 동작:
+ *   1. mount 시 isCellularTechSupported가 true면 startCellularTechUpdates
+ *   2. 5s 폴링으로 getCurrentCellularTech → classifyCellularEnvironment 결과 sync
+ *   3. 미지원 시 vote='unknown'으로 확정 (start/stop 호출 안 함)
+ *   4. unmount 시 stopCellularTechUpdates
+ */
+
+const mockSupported = jest.fn();
+const mockStart = jest.fn();
+const mockStop = jest.fn();
+const mockGet = jest.fn();
+
+jest.mock('../../utils/cellularTech', () => {
+  const actual = jest.requireActual('../../utils/cellularTech');
+  return {
+    ...actual,
+    isCellularTechSupported: () => mockSupported(),
+    startCellularTechUpdates: () => mockStart(),
+    stopCellularTechUpdates: () => mockStop(),
+    getCurrentCellularTech: () => mockGet(),
+  };
+});
+
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { useCellularTech } from '../useCellularTech';
+
+describe('useCellularTech (#1543)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockSupported.mockReset();
+    mockStart.mockReset();
+    mockStop.mockReset();
+    mockGet.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('미지원 디바이스 — vote unknown으로 확정, start/stop 호출 안 함', () => {
+    mockSupported.mockReturnValue(false);
+    const { result, unmount } = renderHook(() => useCellularTech());
+    expect(result.current).toBe('unknown');
+    expect(mockStart).not.toHaveBeenCalled();
+    unmount();
+    expect(mockStop).not.toHaveBeenCalled();
+  });
+
+  it('지원 — LTE 잡힘 시 surface vote', async () => {
+    mockSupported.mockReturnValue(true);
+    mockGet.mockReturnValue('CTRadioAccessTechnologyLTE');
+
+    const { result } = renderHook(() => useCellularTech());
+    await waitFor(() => expect(result.current).toBe('surface'));
+    expect(mockStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('지원 — Edge fallback 시 underground vote (다음 폴링)', async () => {
+    mockSupported.mockReturnValue(true);
+    mockGet.mockReturnValue('CTRadioAccessTechnologyLTE');
+
+    const { result } = renderHook(() => useCellularTech());
+    await waitFor(() => expect(result.current).toBe('surface'));
+
+    // 지하 진입 — native가 Edge로 떨어짐
+    mockGet.mockReturnValue('CTRadioAccessTechnologyEdge');
+    act(() => {
+      jest.advanceTimersByTime(5_000);
+    });
+    await waitFor(() => expect(result.current).toBe('underground'));
+  });
+
+  it('지원 — native null 반환 시 unknown', async () => {
+    mockSupported.mockReturnValue(true);
+    mockGet.mockReturnValue(null);
+
+    const { result } = renderHook(() => useCellularTech());
+    await waitFor(() => expect(result.current).toBe('unknown'));
+  });
+
+  it('unmount 시 stopCellularTechUpdates 호출 (cleanup)', async () => {
+    mockSupported.mockReturnValue(true);
+    mockGet.mockReturnValue('CTRadioAccessTechnologyLTE');
+
+    const { unmount } = renderHook(() => useCellularTech());
+    await waitFor(() => expect(mockStart).toHaveBeenCalled());
+    unmount();
+    expect(mockStop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/nearest-station/hooks/useCellularTech.ts
+++ b/src/features/nearest-station/hooks/useCellularTech.ts
@@ -1,0 +1,57 @@
+/**
+ * #1543 (ADR-016 S10) — CTRadioAccessTechnology 신호 React hook.
+ *
+ * 동작:
+ *   1. mount 시 `isCellularTechSupported` 확인 → true면 `startCellularTechUpdates`
+ *   2. 폴링(5s)으로 native가 캐시한 최신 tech 코드를 sync → 환경 vote로 분류
+ *   3. 미지원/예외 케이스는 `'unknown'`로 확정 — 호출자는 vote 미투표로 인식
+ *   4. unmount 시 `stopCellularTechUpdates`로 cleanup
+ *
+ * 폴링 간격(5s): native는 `CTServiceRadioAccessTechnologyDidChange` 옵저버로 즉시 캐시 갱신
+ *   하지만 JS는 폴링으로 sync. 환경 변화는 사용자 trip 분당 1~2회 수준이라 5s 충분.
+ *   (useMotionActivity와 동일 주기 — 같은 알람 평가 사이클 30s보다 짧으면 stale 우려 적음.)
+ *
+ * 반환:
+ *   - `'unknown'`       : 미지원 / 권한 거절 / native null — vote 미투표
+ *   - `'surface'`       : 4G/5G — 지상 vote
+ *   - `'underground'`   : 2G/3G — 지하 vote
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  classifyCellularEnvironment,
+  getCurrentCellularTech,
+  isCellularTechSupported,
+  startCellularTechUpdates,
+  stopCellularTechUpdates,
+  type CellularEnvironmentVote,
+} from '../utils/cellularTech';
+
+/** 폴링 주기 — `useMotionActivity`와 동일 (5s). 환경 변화는 분당 1~2회라 충분. */
+const POLL_INTERVAL_MS = 5_000;
+
+export function useCellularTech(): CellularEnvironmentVote {
+  const [vote, setVote] = useState<CellularEnvironmentVote>('unknown');
+
+  useEffect(() => {
+    if (!isCellularTechSupported()) {
+      // 미지원(Android/jest/web) — vote 미투표로 확정.
+      setVote('unknown');
+      return;
+    }
+    startCellularTechUpdates();
+
+    // 초기 1회 + 인터벌 폴링. native가 cache한 최신 tech를 sync.
+    setVote(classifyCellularEnvironment(getCurrentCellularTech()));
+    const intervalId = setInterval(() => {
+      setVote(classifyCellularEnvironment(getCurrentCellularTech()));
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      clearInterval(intervalId);
+      stopCellularTechUpdates();
+    };
+  }, []);
+
+  return vote;
+}

--- a/src/features/nearest-station/utils/__tests__/cellularTech.test.ts
+++ b/src/features/nearest-station/utils/__tests__/cellularTech.test.ts
@@ -1,0 +1,176 @@
+/**
+ * #1543 (ADR-016 S10) — CTRadioAccessTechnology JS wrapper + 환경 분류 테스트.
+ *
+ * 핵심 정책:
+ *   - native module 부재 → 모든 API graceful (null / no-op / false)
+ *   - 예외 → null / no-op (graceful)
+ *   - classifyCellularEnvironment: 4G/5G→surface, 2G/3G→underground, 그 외→unknown
+ */
+
+const mockNativeModule = {
+  isAvailable: jest.fn(),
+  startUpdates: jest.fn(),
+  stopUpdates: jest.fn(),
+  getCurrentTech: jest.fn(),
+};
+
+const mockedRequire = jest.fn();
+
+jest.mock('expo-modules-core', () => ({
+  requireOptionalNativeModule: (...args: unknown[]) => mockedRequire(...args),
+}));
+
+import {
+  classifyCellularEnvironment,
+  getCurrentCellularTech,
+  isCellularTechSupported,
+  startCellularTechUpdates,
+  stopCellularTechUpdates,
+} from '../cellularTech';
+
+describe('cellularTech native wrapper (#1543)', () => {
+  beforeEach(() => {
+    mockedRequire.mockReset();
+    mockNativeModule.isAvailable.mockReset();
+    mockNativeModule.startUpdates.mockReset();
+    mockNativeModule.stopUpdates.mockReset();
+    mockNativeModule.getCurrentTech.mockReset();
+  });
+
+  describe('native module 없음 (jest / Android / 미지원)', () => {
+    beforeEach(() => {
+      mockedRequire.mockReturnValue(null);
+    });
+
+    it('isCellularTechSupported() → false', () => {
+      expect(isCellularTechSupported()).toBe(false);
+    });
+
+    it('startCellularTechUpdates() → no-op (throw 없음)', () => {
+      expect(() => startCellularTechUpdates()).not.toThrow();
+    });
+
+    it('stopCellularTechUpdates() → no-op', () => {
+      expect(() => stopCellularTechUpdates()).not.toThrow();
+    });
+
+    it('getCurrentCellularTech() → null', () => {
+      expect(getCurrentCellularTech()).toBeNull();
+    });
+  });
+
+  describe('native module 있음 — 정상', () => {
+    beforeEach(() => {
+      mockedRequire.mockReturnValue(mockNativeModule);
+    });
+
+    it('isCellularTechSupported() → native isAvailable 반영', () => {
+      mockNativeModule.isAvailable.mockReturnValue(true);
+      expect(isCellularTechSupported()).toBe(true);
+      mockNativeModule.isAvailable.mockReturnValue(false);
+      expect(isCellularTechSupported()).toBe(false);
+    });
+
+    it('startCellularTechUpdates() → native startUpdates 호출', () => {
+      startCellularTechUpdates();
+      expect(mockNativeModule.startUpdates).toHaveBeenCalledTimes(1);
+    });
+
+    it('stopCellularTechUpdates() → native stopUpdates 호출', () => {
+      stopCellularTechUpdates();
+      expect(mockNativeModule.stopUpdates).toHaveBeenCalledTimes(1);
+    });
+
+    it('getCurrentCellularTech() → native 값 그대로 반환', () => {
+      mockNativeModule.getCurrentTech.mockReturnValue('CTRadioAccessTechnologyLTE');
+      expect(getCurrentCellularTech()).toBe('CTRadioAccessTechnologyLTE');
+    });
+
+    it('getCurrentCellularTech() — empty string → null로 정규화', () => {
+      mockNativeModule.getCurrentTech.mockReturnValue('');
+      expect(getCurrentCellularTech()).toBeNull();
+    });
+
+    it('getCurrentCellularTech() — null 반환 → null', () => {
+      mockNativeModule.getCurrentTech.mockReturnValue(null);
+      expect(getCurrentCellularTech()).toBeNull();
+    });
+
+    it('getCurrentCellularTech() — non-string → null', () => {
+      mockNativeModule.getCurrentTech.mockReturnValue(undefined);
+      expect(getCurrentCellularTech()).toBeNull();
+    });
+  });
+
+  describe('native module 있음 — 예외 (graceful)', () => {
+    beforeEach(() => {
+      mockedRequire.mockReturnValue(mockNativeModule);
+    });
+
+    it('isAvailable 예외 → false', () => {
+      mockNativeModule.isAvailable.mockImplementation(() => {
+        throw new Error('boom');
+      });
+      expect(isCellularTechSupported()).toBe(false);
+    });
+
+    it('startUpdates 예외 → no-op (throw 없음)', () => {
+      mockNativeModule.startUpdates.mockImplementation(() => {
+        throw new Error('boom');
+      });
+      expect(() => startCellularTechUpdates()).not.toThrow();
+    });
+
+    it('stopUpdates 예외 → no-op', () => {
+      mockNativeModule.stopUpdates.mockImplementation(() => {
+        throw new Error('boom');
+      });
+      expect(() => stopCellularTechUpdates()).not.toThrow();
+    });
+
+    it('getCurrentTech 예외 → null', () => {
+      mockNativeModule.getCurrentTech.mockImplementation(() => {
+        throw new Error('boom');
+      });
+      expect(getCurrentCellularTech()).toBeNull();
+    });
+  });
+});
+
+describe('classifyCellularEnvironment (#1543)', () => {
+  it.each([
+    'CTRadioAccessTechnologyLTE',
+    'CTRadioAccessTechnologyLTEAdvanced',
+    'CTRadioAccessTechnologyNR',
+    'CTRadioAccessTechnologyNRNSA',
+  ])('%s → surface (4G/5G)', (tech) => {
+    expect(classifyCellularEnvironment(tech)).toBe('surface');
+  });
+
+  it.each([
+    'CTRadioAccessTechnologyGPRS',
+    'CTRadioAccessTechnologyEdge',
+    'CTRadioAccessTechnologyWCDMA',
+    'CTRadioAccessTechnologyHSDPA',
+    'CTRadioAccessTechnologyHSUPA',
+    'CTRadioAccessTechnologyCDMA1x',
+    'CTRadioAccessTechnologyeHRPD',
+    'CTRadioAccessTechnologyCDMAEVDORev0',
+    'CTRadioAccessTechnologyCDMAEVDORevA',
+    'CTRadioAccessTechnologyCDMAEVDORevB',
+  ])('%s → underground (2G/3G)', (tech) => {
+    expect(classifyCellularEnvironment(tech)).toBe('underground');
+  });
+
+  it('null → unknown (미투표)', () => {
+    expect(classifyCellularEnvironment(null)).toBe('unknown');
+  });
+
+  it('빈 문자열 → unknown', () => {
+    expect(classifyCellularEnvironment('')).toBe('unknown');
+  });
+
+  it('미지의 미래 상수 → unknown (보수)', () => {
+    expect(classifyCellularEnvironment('CTRadioAccessTechnology6G')).toBe('unknown');
+  });
+});

--- a/src/features/nearest-station/utils/cellularTech.ts
+++ b/src/features/nearest-station/utils/cellularTech.ts
@@ -1,0 +1,120 @@
+/**
+ * #1543 (ADR-016 S10) — CTRadioAccessTechnology(iOS) JS wrapper + 환경 분류 helper.
+ *
+ * 목적: native module에서 받은 radio access tech 코드를 환경(지하/지상) vote로 분류해
+ * 4분면 SSOT 합의 게이트(`consensusGate`)에 1표 추가한다.
+ *
+ * 모든 API는 graceful — native module 부재(jest/web/Android/미지원 디바이스), SIM 비활성,
+ * 예외 모두 `null` / no-op로 처리. "모르는 상태"는 vote 미투표 (환경 판정 영향 0).
+ *
+ * 분류 정책 (Apple `CTRadioAccessTechnology*` 상수 기준):
+ *   - `surface` (지상 vote)  : LTE, LTEAdvanced, NR(5G), NRNSA(5G NSA)
+ *       → macro cell 안정 coverage. 지하 펨토셀로는 통상 NR/LTE 우선 안 잡힘.
+ *   - `underground` (지하 vote): GPRS, Edge, WCDMA, HSDPA, HSUPA, CDMA1x, eHRPD, CDMAEVDORev0/A/B
+ *       → 지하 캐리어 펨토셀 / DAS 안테나가 흔히 fallback하는 2G/3G 신호.
+ *   - `unknown`              : null / 빈 문자열 / 미지의 상수
+ *       → vote 미투표. 무신호도 이론적으로 underground 신호지만 false positive 우려로 보수.
+ *
+ * Android: CTRadioAccessTechnology와 대응되는 무권한 API가 없어 native module 자체 미제공
+ *          → `requireOptionalNativeModule`이 null 반환 → 모든 API graceful.
+ */
+
+import { requireOptionalNativeModule } from 'expo-modules-core';
+
+interface CellularTechNative {
+  isAvailable(): boolean;
+  startUpdates(): void;
+  stopUpdates(): void;
+  /** native가 캐시한 최신 radio access tech 코드. 미확정 시 null. */
+  getCurrentTech(): string | null;
+}
+
+function getNativeModule(): CellularTechNative | null {
+  return requireOptionalNativeModule<CellularTechNative>('CellularTechListener') ?? null;
+}
+
+export function isCellularTechSupported(): boolean {
+  const module = getNativeModule();
+  if (!module) return false;
+  try {
+    return module.isAvailable();
+  } catch {
+    return false;
+  }
+}
+
+export function startCellularTechUpdates(): void {
+  const module = getNativeModule();
+  if (!module) return;
+  try {
+    module.startUpdates();
+  } catch {
+    // graceful — 시작 실패는 getCurrent가 null 반환으로 자연 fallback.
+  }
+}
+
+export function stopCellularTechUpdates(): void {
+  const module = getNativeModule();
+  if (!module) return;
+  try {
+    module.stopUpdates();
+  } catch {
+    // graceful — 중지 실패는 lifecycle 관점에서 무해.
+  }
+}
+
+export function getCurrentCellularTech(): string | null {
+  const module = getNativeModule();
+  if (!module) return null;
+  try {
+    const tech = module.getCurrentTech();
+    return typeof tech === 'string' && tech.length > 0 ? tech : null;
+  } catch {
+    return null;
+  }
+}
+
+/** 환경 vote 결과. consensusGate가 surface/underground 입력으로 사용. */
+export type CellularEnvironmentVote = 'surface' | 'underground' | 'unknown';
+
+/**
+ * Apple `CTRadioAccessTechnology` 상수 → 환경 vote 매핑.
+ *
+ * 하드코딩이 아닌 데이터 주도: 추가 상수가 등장하면 본 표에만 한 줄 추가.
+ * (CLAUDE.md 글로벌 룰 3번 — 확장성/재사용성 우선)
+ *
+ * 상수 prefix `CTRadioAccessTechnology`는 native가 그대로 string으로 반환한다.
+ */
+const SURFACE_TECHS: ReadonlySet<string> = new Set([
+  'CTRadioAccessTechnologyLTE',
+  'CTRadioAccessTechnologyLTEAdvanced',
+  'CTRadioAccessTechnologyNR',
+  'CTRadioAccessTechnologyNRNSA',
+]);
+
+const UNDERGROUND_TECHS: ReadonlySet<string> = new Set([
+  'CTRadioAccessTechnologyGPRS',
+  'CTRadioAccessTechnologyEdge',
+  'CTRadioAccessTechnologyWCDMA',
+  'CTRadioAccessTechnologyHSDPA',
+  'CTRadioAccessTechnologyHSUPA',
+  'CTRadioAccessTechnologyCDMA1x',
+  'CTRadioAccessTechnologyeHRPD',
+  'CTRadioAccessTechnologyCDMAEVDORev0',
+  'CTRadioAccessTechnologyCDMAEVDORevA',
+  'CTRadioAccessTechnologyCDMAEVDORevB',
+]);
+
+/**
+ * radio tech 코드 → 환경 vote 분류.
+ *
+ * - 4G/5G  → `'surface'`  (지상 vote)
+ * - 2G/3G  → `'underground'` (지하 vote)
+ * - null / 미지 코드 → `'unknown'` (vote 미투표)
+ */
+export function classifyCellularEnvironment(tech: string | null): CellularEnvironmentVote {
+  if (!tech) return 'unknown';
+  if (SURFACE_TECHS.has(tech)) return 'surface';
+  if (UNDERGROUND_TECHS.has(tech)) return 'underground';
+  return 'unknown';
+}


### PR DESCRIPTION
Closes #1543 · Epic #1533 (ADR-016) Sub-issue S10

## 요약

iOS `CTRadioAccessTechnology` BG-safe listener를 추가해 4분면 SSOT 환경(지하/지상) 합의 게이트에 **1표**를 더한다.

- 4G(LTE/LTEAdvanced) / 5G(NR/NRNSA) → **surface** vote (지상 신호)
- 2G/3G(GPRS/Edge/WCDMA/HSDPA/HSUPA/CDMA1x/eHRPD/CDMAEVDORev0/A/B) → **underground** vote (지하 펨토셀/DAS fallback)
- null / 미지 상수 → **unknown** (vote 미투표)

## 구현

### 새 native module — `modules/cellular-tech-listener/`
- `CellularTechListener.podspec` (CoreTelephony framework)
- `ios/CellularTechListenerModule.swift`
  - `CTTelephonyNetworkInfo.serviceCurrentRadioAccessTechnology` 초기 sync
  - `CTServiceRadioAccessTechnologyDidChangeNotification` 옵저버 → BG에서도 캐시 즉시 갱신
  - SIM 비활성 / dual-SIM / 미지원 → null (graceful)
- 별도 권한 prompt 없음 — 캐리어 정보 / IMSI 미참조 (Apple App Privacy 무영향)

### JS 통합 — `src/features/nearest-station/`
- `utils/cellularTech.ts` — JS wrapper (`isCellularTechSupported`, `getCurrentCellularTech` 등) + `classifyCellularEnvironment` 분류 helper (데이터 주도 매핑)
- `hooks/useCellularTech.ts` — 5s 폴링 (useMotionActivity와 동일 주기). unmount 시 stopUpdates cleanup

### Backend `consensusGate.ts`
- `ConsensusSignals`에 `cellularEnvironmentVote?: 'surface' | 'underground' | 'unknown'` 옵션 입력 추가
- 새 reject 분기: `cellular-environment-contradicts`
  - environment=surface + vote=underground → reject
  - environment=underground + vote=surface → reject
  - 일치 / unknown / mixed / undefined → 정책 영향 0 (false positive 보수)
- 기존 SSOT 합의 분기(B+E 2-of-2, C+B, D+B)는 변경 없음

### Silent push payload
- `PositionPoint` (`types.ts`) + `POST /position` validator + `positionSeries` 가드에 `cellularEnvironmentVote` 옵션 필드 추가
- enum 외 값은 graceful drop (전체 payload 거부 X)
- `PositionUploadPayload` (`src/features/nearest-station/api/positionUpload.ts`)에도 동일 필드 추가

## 테스트

- `src/features/nearest-station/utils/__tests__/cellularTech.test.ts` — 22 케이스 (native 부재/예외/정상 + 분류 매핑 + 미지 상수)
- `src/features/nearest-station/hooks/__tests__/useCellularTech.test.ts` — 5 케이스 (미지원/지원/Edge fallback/cleanup)
- `backend/alarm-worker/src/__tests__/consensusGate.test.ts` — 8 케이스 추가 (contradict / 일치 / unknown / mixed)
- `backend/alarm-worker/src/__tests__/index.test.ts` — 5 케이스 추가 (enum 허용 / 외 값 drop / 부재)
- `backend/alarm-worker/src/__tests__/positionSeries.test.ts` — 5 케이스 추가 (series 가드)

전체 결과:
- Backend (vitest): 1511/1511 pass
- JS (jest): 신규 37 케이스 pass. 전체 6770 pass + 35 fail (dev baseline 동일, 본 PR 회귀 없음)
- `npm run type-check`: clean

## 사용자 액션 (실기기 검증 전 필수)

1. `npx expo prebuild --clean` — 새 native module pod 등록
2. 로컬 iOS 빌드 (실기기 또는 simulator) — CoreTelephony 링크 확인
3. 트립 도중 cellular tech 변화 → backend `cellularEnvironmentVote` 분포 측정 (epic acceptance 일부)

## 스코프 밖

- **Android**: CTRadioAccessTechnology와 대응되는 무권한 API 부재 → 본 PR은 iOS only. Android counterpart는 별 issue로 분리 추천
- **device-only 회귀**: 본 PR은 type-check + unit만 검증. native compile / BG observer 동작은 사용자 실기기 빌드 책임 (CLAUDE.md PR 머지 규칙)

## 검증 매트릭스 self-check (CLAUDE.md acceptance 규칙)

- lock 활성 / lockless 모두 카테고리 ✓ (consensusGate는 두 trip 동일 적용)
- 사용자 명시 의향 trip 동급 보장 ✓ (게이트 시그너처가 토글/promptState input 받지 않음)
- ADR-010 첫 줄 원칙 ✓ (false positive ↔ miss 비대칭 도입 없음 — contradict만 추가)
- 권한 매트릭스 ✓ (CoreTelephony는 별도 권한 없음, 모든 권한 시나리오 동작)
- 환경 매트릭스 ✓ (surface/underground/mixed/unknown 4분면 모두 명시 분기)