### PR TITLE
fix(#1540): gps-drop 별 buffer 분리 + circular buffer + sliding window

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -734,8 +734,8 @@ function buildFusionLogSection(args: BuildDumpArgs): string[] {
  */
 function formatGpsDropLine(entry: GpsDropEntry): string {
   const time = formatTime(entry.ts);
-  const acc = entry.accuracyMeters != null ? `${Math.round(entry.accuracyMeters)}m` : '-';
-  const sp = entry.speedMps != null ? `${entry.speedMps.toFixed(1)}m/s` : '-';
+  const acc = entry.accuracyMeters == null ? '-' : `${Math.round(entry.accuracyMeters)}m`;
+  const sp = entry.speedMps == null ? '-' : `${entry.speedMps.toFixed(1)}m/s`;
   return `${time} | gps-drop | acc=${acc} sp=${sp} reason=${entry.dropReason}`;
 }
 

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -60,6 +60,14 @@ import {
   subscribeFusionDebug,
   type FusionDebugEntry,
 } from '../../../features/nearest-station/utils/fusionDebugBuffer';
+// #1540 (S7) — gps-drop 전용 buffer. fusionDebugBuffer와 cap을 공유하지 않아 fire-related
+// entry(fusion decision / sticky / gps-fix)를 점령하지 않는다.
+import {
+  clearGpsDropEntries,
+  getGpsDropEntries,
+  subscribeGpsDrop,
+  type GpsDropEntry,
+} from '../../../features/nearest-station/utils/gpsDropBuffer';
 // #1518 — device → backend HTTP 호출 ring buffer. 모든 backend fetch chokepoint가 entry를 push.
 import {
   clearBackendCallEntries,
@@ -525,6 +533,11 @@ interface BuildDumpArgs {
    * 단위 테스트에서 raw signal을 다루지 않는 경우 호환.
    */
   rawSignalLog?: readonly RawSignalEntry[];
+  /**
+   * #1540 (S7) — GPS drop ring buffer entries. 미전달/빈 배열은 (empty)로 출력.
+   * fusionDebugBuffer와 분리된 채널이라 dump에서도 별도 섹션으로 노출한다.
+   */
+  gpsDropLog?: readonly GpsDropEntry[];
 }
 
 /** dump 본체에서 사용하는 single builder 시그니처 — 본문 줄 배열을 반환. */
@@ -713,6 +726,23 @@ function buildFusionLogSection(args: BuildDumpArgs): string[] {
   if (entries.length === 0) return ['(empty)'];
   // 최신이 위로 — Alarm log와 동일 정렬.
   return [...entries].reverse().map(formatFusionDebugLine);
+}
+
+/**
+ * #1540 (S7) — gps-drop 한 줄 포맷. Fusion log와 동일 컨벤션(HH:MM:SS | … ).
+ * acc/speed/reason만 노출 — drop entry는 nearestStation 결정 전 단계이므로 station 컬럼 없음.
+ */
+function formatGpsDropLine(entry: GpsDropEntry): string {
+  const time = formatTime(entry.ts);
+  const acc = entry.accuracyMeters != null ? `${Math.round(entry.accuracyMeters)}m` : '-';
+  const sp = entry.speedMps != null ? `${entry.speedMps.toFixed(1)}m/s` : '-';
+  return `${time} | gps-drop | acc=${acc} sp=${sp} reason=${entry.dropReason}`;
+}
+
+function buildGpsDropLogSection(args: BuildDumpArgs): string[] {
+  const entries = args.gpsDropLog ?? [];
+  if (entries.length === 0) return ['(empty)'];
+  return [...entries].reverse().map(formatGpsDropLine);
 }
 
 /**
@@ -1067,6 +1097,12 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
     build: buildFusionLogSection,
     suffix: (args) => ` (${args.fusionLog?.length ?? 0})`,
   },
+  // #1540 (S7) — gps-drop 채널. fusionDebugBuffer 점령 회귀 차단용 별 buffer를 dump에 그대로 노출.
+  {
+    title: 'GPS drops',
+    build: buildGpsDropLogSection,
+    suffix: (args) => ` (${args.gpsDropLog?.length ?? 0})`,
+  },
   // #1518 — device → backend HTTP 호출 ring buffer. 직전 trip의 register/sync/telemetry 호출
   // 흔적이 dump만 보고 재구성 가능해야 #622 transfer-leg sync 같은 회귀 진단이 가능하다.
   {
@@ -1339,6 +1375,10 @@ function DebugModalInner({
   const [fusionLogs, setFusionLogs] = useState<readonly FusionDebugEntry[]>(() =>
     getFusionDebugEntries(),
   );
+  // #1540 (S7) — gps-drop ring buffer. fusionLogs와 동일 패턴(snapshot + subscribe + clear button).
+  const [gpsDropLogs, setGpsDropLogs] = useState<readonly GpsDropEntry[]>(() =>
+    getGpsDropEntries(),
+  );
   const [estimatorLogs, setEstimatorLogs] = useState<readonly EstimatorDebugEntry[]>(() =>
     getEstimatorEntries(),
   );
@@ -1368,6 +1408,11 @@ function DebugModalInner({
 
   useEffect(() => {
     return subscribeFusionDebug(() => setFusionLogs([...getFusionDebugEntries()]));
+  }, []);
+
+  // #1540 (S7) — gps-drop buffer 구독. push/clear 어느 쪽이든 같은 listener로 반응.
+  useEffect(() => {
+    return subscribeGpsDrop(() => setGpsDropLogs([...getGpsDropEntries()]));
   }, []);
 
   useEffect(() => {
@@ -1457,6 +1502,8 @@ function DebugModalInner({
       sleep,
       // #1346 — fusion log entries를 share에 포함. sticky cascade 같은 회귀 사후 재구성용.
       fusionLog: fusionLogs,
+      // #1540 (S7) — gps-drop entries를 share에 포함. 별 buffer라 fusion log와 동시 dump.
+      gpsDropLog: gpsDropLogs,
       // #1413 — UI에만 노출되던 BoardingLock/Estimator/Boarding Prompt(+Acceptance)/Counters를 share에 포함.
       boardingLock: lock,
       estimatorLog: estimatorLogs,
@@ -1502,6 +1549,8 @@ function DebugModalInner({
     sleep,
     // #1346 — fusion log 신규 캡쳐.
     fusionLogs,
+    // #1540 (S7) — gps-drop entries 변경 시 share 텍스트 자동 갱신.
+    gpsDropLogs,
     // #1413 — BoardingLock/Estimator 신규 캡쳐.
     lock,
     estimatorLogs,
@@ -1735,6 +1784,20 @@ function DebugModalInner({
             }}
             clearTestId="debug-fusion-log-clear"
             entryTestId="debug-fusion-log-entry"
+            colors={colors}
+          />
+
+          {/* #1540 (S7) — gps-drop 별 buffer. fusion log cap 점령 회귀 차단용 별 채널 표시. */}
+          <DebugLogSection
+            title="GPS drops"
+            logs={gpsDropLogs}
+            formatLine={formatGpsDropLine}
+            onClear={() => {
+              clearGpsDropEntries();
+              setGpsDropLogs([]);
+            }}
+            clearTestId="debug-gps-drop-log-clear"
+            entryTestId="debug-gps-drop-log-entry"
             colors={colors}
           />
 
@@ -2214,6 +2277,9 @@ export const __test__ = {
   // #1501 — PR-C. Raw signal 라인 포맷 helper. share dump 단위 테스트에서 직접 호출.
   formatRawSignalLine,
   RAW_SIGNAL_DISPLAY_LIMIT,
+  // #1540 (S7) — gps-drop 별 buffer 포맷/섹션. 단위 테스트에서 직접 호출.
+  formatGpsDropLine,
+  buildGpsDropLogSection,
 };
 
 const styles = StyleSheet.create({

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -3715,7 +3715,7 @@ describe('DebugModal — #1501 Raw Signal 섹션', () => {
     const makeDrop = (overrides: Partial<DropEntry> = {}): DropEntry => ({
       ts: 1_700_000_000_000,
       lat: 37.5,
-      lng: 127.0,
+      lng: 127,
       accuracyMeters: 1414,
       speedMps: null,
       dropReason: 'low-accuracy-display',
@@ -3744,7 +3744,7 @@ describe('DebugModal — #1501 Raw Signal 섹션', () => {
     it('buildGpsDropLogSection: 미전달/빈 배열 모두 (empty)', () => {
       expect(buildGpsDropLogSection(baselineDumpArgs)).toEqual(['(empty)']);
       expect(
-        buildGpsDropLogSection({ ...baselineDumpArgs, gpsDropLog: [] } as never),
+        buildGpsDropLogSection({ ...baselineDumpArgs, gpsDropLog: [] }),
       ).toEqual(['(empty)']);
     });
 
@@ -3755,7 +3755,7 @@ describe('DebugModal — #1501 Raw Signal 섹션', () => {
           makeDrop({ ts: 1000, accuracyMeters: 800 }),
           makeDrop({ ts: 2000, accuracyMeters: 900 }),
         ],
-      } as never);
+      });
       expect(result).toHaveLength(2);
       expect(result[0]).toContain('acc=900m');
       expect(result[1]).toContain('acc=800m');
@@ -3765,7 +3765,7 @@ describe('DebugModal — #1501 Raw Signal 섹션', () => {
       const dump = buildDumpText(
         makeDumpArgs({
           gpsDropLog: [makeDrop({ accuracyMeters: 1234 })],
-        } as Partial<DumpArgs>),
+        }),
       );
       expect(dump).toContain('## GPS drops (1)');
       expect(dump).toContain('acc=1234m');

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -3706,4 +3706,104 @@ describe('DebugModal — #1501 Raw Signal 섹션', () => {
       shareSpy.mockRestore();
     });
   });
+
+  // #1540 (S7) — gps-drop 별 buffer. fusion log cap 점령 회귀 차단용 별 채널.
+  describe('GPS drops 섹션 (#1540)', () => {
+    const { formatGpsDropLine, buildGpsDropLogSection, buildDumpText } = __test__;
+    type DropEntry = import('../../../nearest-station/utils/gpsDropBuffer').GpsDropEntry;
+
+    const makeDrop = (overrides: Partial<DropEntry> = {}): DropEntry => ({
+      ts: 1_700_000_000_000,
+      lat: 37.5,
+      lng: 127.0,
+      accuracyMeters: 1414,
+      speedMps: null,
+      dropReason: 'low-accuracy-display',
+      ...overrides,
+    });
+
+    it('formatGpsDropLine: acc/speed/reason 모두 노출', () => {
+      const line = formatGpsDropLine(
+        makeDrop({ accuracyMeters: 1414, speedMps: 1.5, dropReason: 'low-accuracy-display' }),
+      );
+      expect(line).toContain('gps-drop');
+      expect(line).toContain('acc=1414m');
+      expect(line).toContain('sp=1.5m/s');
+      expect(line).toContain('reason=low-accuracy-display');
+    });
+
+    it('formatGpsDropLine: null acc/speed는 "-"로 표기', () => {
+      const line = formatGpsDropLine(
+        makeDrop({ accuracyMeters: null, speedMps: null, dropReason: 'rate-limited:5' }),
+      );
+      expect(line).toContain('acc=-');
+      expect(line).toContain('sp=-');
+      expect(line).toContain('reason=rate-limited:5');
+    });
+
+    it('buildGpsDropLogSection: 미전달/빈 배열 모두 (empty)', () => {
+      expect(buildGpsDropLogSection(baselineDumpArgs)).toEqual(['(empty)']);
+      expect(
+        buildGpsDropLogSection({ ...baselineDumpArgs, gpsDropLog: [] } as never),
+      ).toEqual(['(empty)']);
+    });
+
+    it('buildGpsDropLogSection: 최신이 위로 정렬', () => {
+      const result = buildGpsDropLogSection({
+        ...baselineDumpArgs,
+        gpsDropLog: [
+          makeDrop({ ts: 1000, accuracyMeters: 800 }),
+          makeDrop({ ts: 2000, accuracyMeters: 900 }),
+        ],
+      } as never);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toContain('acc=900m');
+      expect(result[1]).toContain('acc=800m');
+    });
+
+    it('share dump가 GPS drops 섹션을 포함한다 (suffix는 buffer 길이)', () => {
+      const dump = buildDumpText(
+        makeDumpArgs({
+          gpsDropLog: [makeDrop({ accuracyMeters: 1234 })],
+        } as Partial<DumpArgs>),
+      );
+      expect(dump).toContain('## GPS drops (1)');
+      expect(dump).toContain('acc=1234m');
+    });
+
+    it('share dump: gpsDropLog 미전달 시 헤더(0) + (empty)', () => {
+      const dump = buildDumpText(makeDumpArgs());
+      expect(dump).toContain('## GPS drops (0)');
+      const section = dump.slice(dump.indexOf('## GPS drops'));
+      expect(section).toContain('(empty)');
+    });
+
+    it('UI: 비어있으면 (0) 표시, push 시 entry 노출, Clear가 비운다', async () => {
+      const {
+        clearGpsDropEntries,
+        pushGpsDropEntry,
+      } = jest.requireActual('../../../nearest-station/utils/gpsDropBuffer');
+      clearGpsDropEntries();
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      expect(screen.getByText('GPS drops (0)')).toBeTruthy();
+      act(() => {
+        pushGpsDropEntry({
+          ts: new Date('2026-06-19T15:42:00Z').getTime(),
+          lat: 37.5,
+          lng: 127,
+          accuracyMeters: 1414,
+          speedMps: null,
+          dropReason: 'low-accuracy-display',
+        });
+      });
+      expect(screen.getByText('GPS drops (1)')).toBeTruthy();
+      const entries = screen.getAllByTestId('debug-gps-drop-log-entry');
+      expect(entries[0].props.children).toContain('acc=1414m');
+      act(() => {
+        fireEvent.press(screen.getByTestId('debug-gps-drop-log-clear'));
+      });
+      expect(screen.getByText('GPS drops (0)')).toBeTruthy();
+    });
+  });
 });

--- a/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
@@ -815,7 +815,7 @@ describe('useNearestStation', () => {
       // 이전 fixed window 구현은 windowStart>=1000ms 마다 reset되어 동일한 결과를 내지만,
       // 본 테스트는 sliding 동작이 회귀하지 않음을 박제한다.
       for (let i = 0; i < 6; i += 1) {
-        simulateGps(37.6000 + i * 0.001, 127.0000 + i * 0.001, {
+        simulateGps(37.6 + i * 0.001, 127 + i * 0.001, {
           accuracy: 800 + i,
           speed: 0,
           timestamp: fakeNow,
@@ -847,7 +847,7 @@ describe('useNearestStation', () => {
       await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
       // t0: push 1건 → timestamps=[t0]
-      simulateGps(37.7000, 127.0000, { accuracy: 800, timestamp: fakeNow });
+      simulateGps(37.7, 127, { accuracy: 800, timestamp: fakeNow });
       // t0+500: push 2번째 → timestamps=[t0, t0+500] (limit=2 도달)
       fakeNow += 500;
       simulateGps(37.7001, 127.0001, { accuracy: 801, timestamp: fakeNow });
@@ -860,13 +860,13 @@ describe('useNearestStation', () => {
       // skipped=1이므로 summary push → timestamps=[t0+500, t0+1100] length=2=limit.
       // 본 drop은 미뤄지고 skipped=1로 재설정.
       fakeNow = 1_700_000_000_000 + 1_100;
-      simulateGps(37.7003, 127.0003, { accuracy: 803, speed: 2.0, timestamp: fakeNow });
+      simulateGps(37.7003, 127.0003, { accuracy: 803, speed: 2, timestamp: fakeNow });
       const drops = getGpsDropEntries();
       // 2 (1st window pushes) + 1 summary = 3. 본 drop은 다음 윈도우로 미뤄짐.
       expect(drops).toHaveLength(3);
       const summary = drops[2];
       expect(summary.dropReason).toBe('rate-limited:1');
-      expect(summary.speedMps).toBe(2.0);
+      expect(summary.speedMps).toBe(2);
     } finally {
       (Date.now as jest.Mock).mockRestore?.();
       Date.now = realNow;

--- a/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
@@ -95,6 +95,22 @@ const simulateGps = (
   });
 };
 
+// #1540 (S7) — gps-drop sliding window 테스트 공용 setup. Sonar 중복 제거.
+function setupGpsDropFakeNow(initialNow = 1_700_000_000_000) {
+  const { clearGpsDropEntries, getGpsDropEntries } =
+    jest.requireActual('../../utils/gpsDropBuffer');
+  clearGpsDropEntries();
+  mockGranted();
+  const realNow = Date.now;
+  const state = { fakeNow: initialNow };
+  jest.spyOn(Date, 'now').mockImplementation(() => state.fakeNow);
+  const restore = () => {
+    (Date.now as jest.Mock).mockRestore?.();
+    Date.now = realNow;
+  };
+  return { state, getGpsDropEntries, restore };
+}
+
 describe('useNearestStation', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -744,22 +760,16 @@ describe('useNearestStation', () => {
   });
 
   it('#1516 + #1540 (S7) 슬라이딩 rate limit: 1초 내 임계 초과 drop skip + 다음 push 시 summary 흡수', async () => {
-    const { clearGpsDropEntries, getGpsDropEntries } =
-      jest.requireActual('../../utils/gpsDropBuffer');
-    clearGpsDropEntries();
-    mockGranted();
-    const realNow = Date.now;
-    let fakeNow = 1_700_000_000_000;
-    jest.spyOn(Date, 'now').mockImplementation(() => fakeNow);
+    const { state, getGpsDropEntries, restore } = setupGpsDropFakeNow();
     try {
       renderHook(() => useNearestStation());
       await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
       // 같은 슬라이딩 윈도우 내 서로 다른 좌표 4건 (dedup gate 우회) — limit=2 이후는 skipped 누적.
-      simulateGps(37.5500, 127.0500, { accuracy: 800, timestamp: fakeNow });
-      simulateGps(37.5501, 127.0501, { accuracy: 801, timestamp: fakeNow });
-      simulateGps(37.5502, 127.0502, { accuracy: 802, timestamp: fakeNow });
-      simulateGps(37.5503, 127.0503, { accuracy: 803, timestamp: fakeNow });
+      simulateGps(37.5500, 127.0500, { accuracy: 800, timestamp: state.fakeNow });
+      simulateGps(37.5501, 127.0501, { accuracy: 801, timestamp: state.fakeNow });
+      simulateGps(37.5502, 127.0502, { accuracy: 802, timestamp: state.fakeNow });
+      simulateGps(37.5503, 127.0503, { accuracy: 803, timestamp: state.fakeNow });
 
       let drops = getGpsDropEntries();
       // limit=2 → 처음 2건만 push, 이후 2건은 skipped
@@ -767,8 +777,8 @@ describe('useNearestStation', () => {
 
       // 1초 경과 후 다음 drop이 들어오면 슬라이딩 윈도우가 비워져 summary가 먼저 push됨.
       // speed를 null로 줘서 summary push의 isValidGpsSpeedMps false 분기 커버.
-      fakeNow += 1_500;
-      simulateGps(37.5504, 127.0504, { accuracy: 900, speed: null, timestamp: fakeNow });
+      state.fakeNow += 1_500;
+      simulateGps(37.5504, 127.0504, { accuracy: 900, speed: null, timestamp: state.fakeNow });
 
       drops = getGpsDropEntries();
       // 2 (1st window) + 1 summary + 1 (new window) = 4
@@ -782,31 +792,24 @@ describe('useNearestStation', () => {
 
       // 추가 윈도우: speed 양수로 summary push의 isValidGpsSpeedMps true 분기 커버.
       // dedup 우회 위해 좌표를 매번 다르게.
-      simulateGps(37.5510, 127.0510, { accuracy: 800, speed: 1.0, timestamp: fakeNow });
-      simulateGps(37.5511, 127.0511, { accuracy: 801, speed: 1.0, timestamp: fakeNow });
-      simulateGps(37.5512, 127.0512, { accuracy: 802, speed: 1.0, timestamp: fakeNow });
-      fakeNow += 1_500;
-      simulateGps(37.5513, 127.0513, { accuracy: 900, speed: 3.0, timestamp: fakeNow });
+      simulateGps(37.5510, 127.0510, { accuracy: 800, speed: 1, timestamp: state.fakeNow });
+      simulateGps(37.5511, 127.0511, { accuracy: 801, speed: 1, timestamp: state.fakeNow });
+      simulateGps(37.5512, 127.0512, { accuracy: 802, speed: 1, timestamp: state.fakeNow });
+      state.fakeNow += 1_500;
+      simulateGps(37.5513, 127.0513, { accuracy: 900, speed: 3, timestamp: state.fakeNow });
       drops = getGpsDropEntries();
       const summary2 = drops.filter((d: { dropReason?: string }) =>
         d.dropReason?.startsWith('rate-limited:'),
       );
       expect(summary2.length).toBeGreaterThanOrEqual(2);
-      expect(summary2[1].speedMps).toBe(3.0);
+      expect(summary2[1].speedMps).toBe(3);
     } finally {
-      (Date.now as jest.Mock).mockRestore?.();
-      Date.now = realNow;
+      restore();
     }
   });
 
   it('#1540 (S7) 슬라이딩 윈도우: 1.1초마다 한 건씩 도착해도 한도 정확히 적용 (fixed window trap 회귀 차단)', async () => {
-    const { clearGpsDropEntries, getGpsDropEntries } =
-      jest.requireActual('../../utils/gpsDropBuffer');
-    clearGpsDropEntries();
-    mockGranted();
-    const realNow = Date.now;
-    let fakeNow = 1_700_000_000_000;
-    jest.spyOn(Date, 'now').mockImplementation(() => fakeNow);
+    const { state, getGpsDropEntries, restore } = setupGpsDropFakeNow();
     try {
       renderHook(() => useNearestStation());
       await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
@@ -818,9 +821,9 @@ describe('useNearestStation', () => {
         simulateGps(37.6 + i * 0.001, 127 + i * 0.001, {
           accuracy: 800 + i,
           speed: 0,
-          timestamp: fakeNow,
+          timestamp: state.fakeNow,
         });
-        fakeNow += 1_100;
+        state.fakeNow += 1_100;
       }
       const drops = getGpsDropEntries();
       // 모두 윈도우 외부 → 6건 모두 push, summary 없음.
@@ -829,38 +832,31 @@ describe('useNearestStation', () => {
         true,
       );
     } finally {
-      (Date.now as jest.Mock).mockRestore?.();
-      Date.now = realNow;
+      restore();
     }
   });
 
   it('#1540 (S7) summary가 limit 소진 시: 본 drop은 다음 윈도우로 미루고 skipped=1로 유지', async () => {
-    const { clearGpsDropEntries, getGpsDropEntries } =
-      jest.requireActual('../../utils/gpsDropBuffer');
-    clearGpsDropEntries();
-    mockGranted();
-    const realNow = Date.now;
-    let fakeNow = 1_700_000_000_000;
-    jest.spyOn(Date, 'now').mockImplementation(() => fakeNow);
+    const { state, getGpsDropEntries, restore } = setupGpsDropFakeNow();
     try {
       renderHook(() => useNearestStation());
       await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
       // t0: push 1건 → timestamps=[t0]
-      simulateGps(37.7, 127, { accuracy: 800, timestamp: fakeNow });
+      simulateGps(37.7, 127, { accuracy: 800, timestamp: state.fakeNow });
       // t0+500: push 2번째 → timestamps=[t0, t0+500] (limit=2 도달)
-      fakeNow += 500;
-      simulateGps(37.7001, 127.0001, { accuracy: 801, timestamp: fakeNow });
+      state.fakeNow += 500;
+      simulateGps(37.7001, 127.0001, { accuracy: 801, timestamp: state.fakeNow });
       // t0+501: limit 도달 상태에서 1건 skip → skipped=1
-      fakeNow += 1;
-      simulateGps(37.7002, 127.0002, { accuracy: 802, timestamp: fakeNow });
+      state.fakeNow += 1;
+      simulateGps(37.7002, 127.0002, { accuracy: 802, timestamp: state.fakeNow });
       expect(getGpsDropEntries()).toHaveLength(2);
 
       // t0+1100: cutoff=t0+100 → t0 trim, t0+500 유지. timestamps=[t0+500] length=1<limit.
       // skipped=1이므로 summary push → timestamps=[t0+500, t0+1100] length=2=limit.
       // 본 drop은 미뤄지고 skipped=1로 재설정.
-      fakeNow = 1_700_000_000_000 + 1_100;
-      simulateGps(37.7003, 127.0003, { accuracy: 803, speed: 2, timestamp: fakeNow });
+      state.fakeNow = 1_700_000_000_000 + 1_100;
+      simulateGps(37.7003, 127.0003, { accuracy: 803, speed: 2, timestamp: state.fakeNow });
       const drops = getGpsDropEntries();
       // 2 (1st window pushes) + 1 summary = 3. 본 drop은 다음 윈도우로 미뤄짐.
       expect(drops).toHaveLength(3);
@@ -868,8 +864,7 @@ describe('useNearestStation', () => {
       expect(summary.dropReason).toBe('rate-limited:1');
       expect(summary.speedMps).toBe(2);
     } finally {
-      (Date.now as jest.Mock).mockRestore?.();
-      Date.now = realNow;
+      restore();
     }
   });
 

--- a/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
@@ -698,10 +698,12 @@ describe('useNearestStation', () => {
     expect(result.current.locationUncertain).toBe(true);
   });
 
-  it('표시 게이트 drop 시 fusion debug buffer에 gps-drop 엔트리를 push (speed 양수 분기)', async () => {
-    const { pushFusionDebugEntry: _p, clearFusionDebugEntries, getFusionDebugEntries } =
+  it('#1540 (S7) 표시 게이트 drop 시 gpsDropBuffer에 push (fusionDebugBuffer는 오염 X, speed 양수)', async () => {
+    const { clearGpsDropEntries, getGpsDropEntries } =
+      jest.requireActual('../../utils/gpsDropBuffer');
+    const { clearFusionDebugEntries, getFusionDebugEntries } =
       jest.requireActual('../../utils/fusionDebugBuffer');
-    void _p;
+    clearGpsDropEntries();
     clearFusionDebugEntries();
     mockGranted();
     renderHook(() => useNearestStation());
@@ -712,19 +714,21 @@ describe('useNearestStation', () => {
       speed: 1.5,
     });
 
-    const entries = getFusionDebugEntries();
-    const drop = entries.find(
+    const drops = getGpsDropEntries();
+    expect(drops).toHaveLength(1);
+    expect(drops[0].speedMps).toBe(1.5);
+    expect(drops[0].dropReason).toBe('low-accuracy-display');
+    // #1540 acceptance: fusionDebugBuffer는 gps-drop으로 오염되지 않는다.
+    const fusionDrops = getFusionDebugEntries().filter(
       (e: { kind: string; event?: string }) => e.kind === 'gps' && e.event === 'gps-drop',
     );
-    expect(drop).toBeDefined();
-    expect(drop.speedMps).toBe(1.5);
-    expect(drop.dropReason).toBe('low-accuracy-display');
+    expect(fusionDrops).toHaveLength(0);
   });
 
   it('#1516 dedup: 직전 drop과 lat/lng/accuracy가 모두 동일하면 추가 push를 skip한다', async () => {
-    const { clearFusionDebugEntries, getFusionDebugEntries } =
-      jest.requireActual('../../utils/fusionDebugBuffer');
-    clearFusionDebugEntries();
+    const { clearGpsDropEntries, getGpsDropEntries } =
+      jest.requireActual('../../utils/gpsDropBuffer');
+    clearGpsDropEntries();
     mockGranted();
     renderHook(() => useNearestStation());
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
@@ -734,17 +738,15 @@ describe('useNearestStation', () => {
       simulateGps(37.5500, 127.0500, { accuracy: 1414, speed: 0, timestamp: 1_700_000_000_000 });
     }
 
-    const drops = getFusionDebugEntries().filter(
-      (e: { kind: string; event?: string }) => e.kind === 'gps' && e.event === 'gps-drop',
-    );
+    const drops = getGpsDropEntries();
     expect(drops).toHaveLength(1);
     expect(drops[0].accuracyMeters).toBe(1414);
   });
 
-  it('#1516 rate limit: 1초 내 임계 초과 drop은 skip하고 윈도우 마감 시 summary 1건만 push', async () => {
-    const { clearFusionDebugEntries, getFusionDebugEntries } =
-      jest.requireActual('../../utils/fusionDebugBuffer');
-    clearFusionDebugEntries();
+  it('#1516 + #1540 (S7) 슬라이딩 rate limit: 1초 내 임계 초과 drop skip + 다음 push 시 summary 흡수', async () => {
+    const { clearGpsDropEntries, getGpsDropEntries } =
+      jest.requireActual('../../utils/gpsDropBuffer');
+    clearGpsDropEntries();
     mockGranted();
     const realNow = Date.now;
     let fakeNow = 1_700_000_000_000;
@@ -753,34 +755,30 @@ describe('useNearestStation', () => {
       renderHook(() => useNearestStation());
       await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
-      // 같은 윈도우 내 서로 다른 좌표 4건 (dedup gate 우회) — limit=2 이후는 skipped 누적
+      // 같은 슬라이딩 윈도우 내 서로 다른 좌표 4건 (dedup gate 우회) — limit=2 이후는 skipped 누적.
       simulateGps(37.5500, 127.0500, { accuracy: 800, timestamp: fakeNow });
       simulateGps(37.5501, 127.0501, { accuracy: 801, timestamp: fakeNow });
       simulateGps(37.5502, 127.0502, { accuracy: 802, timestamp: fakeNow });
       simulateGps(37.5503, 127.0503, { accuracy: 803, timestamp: fakeNow });
 
-      let drops = getFusionDebugEntries().filter(
-        (e: { kind: string; event?: string }) => e.kind === 'gps' && e.event === 'gps-drop',
-      );
+      let drops = getGpsDropEntries();
       // limit=2 → 처음 2건만 push, 이후 2건은 skipped
       expect(drops).toHaveLength(2);
 
-      // 윈도우 마감(>1s 경과) 후 다음 drop이 들어오면 summary가 먼저 push됨.
+      // 1초 경과 후 다음 drop이 들어오면 슬라이딩 윈도우가 비워져 summary가 먼저 push됨.
       // speed를 null로 줘서 summary push의 isValidGpsSpeedMps false 분기 커버.
       fakeNow += 1_500;
       simulateGps(37.5504, 127.0504, { accuracy: 900, speed: null, timestamp: fakeNow });
 
-      drops = getFusionDebugEntries().filter(
-        (e: { kind: string; event?: string }) => e.kind === 'gps' && e.event === 'gps-drop',
-      );
+      drops = getGpsDropEntries();
       // 2 (1st window) + 1 summary + 1 (new window) = 4
       expect(drops).toHaveLength(4);
       const summary = drops.find((d: { dropReason?: string }) =>
         d.dropReason?.startsWith('rate-limited:'),
       );
       expect(summary).toBeDefined();
-      expect(summary.dropReason).toBe('rate-limited:2');
-      expect(summary.speedMps).toBeNull();
+      expect(summary?.dropReason).toBe('rate-limited:2');
+      expect(summary?.speedMps).toBeNull();
 
       // 추가 윈도우: speed 양수로 summary push의 isValidGpsSpeedMps true 분기 커버.
       // dedup 우회 위해 좌표를 매번 다르게.
@@ -789,14 +787,86 @@ describe('useNearestStation', () => {
       simulateGps(37.5512, 127.0512, { accuracy: 802, speed: 1.0, timestamp: fakeNow });
       fakeNow += 1_500;
       simulateGps(37.5513, 127.0513, { accuracy: 900, speed: 3.0, timestamp: fakeNow });
-      drops = getFusionDebugEntries().filter(
-        (e: { kind: string; event?: string }) => e.kind === 'gps' && e.event === 'gps-drop',
-      );
+      drops = getGpsDropEntries();
       const summary2 = drops.filter((d: { dropReason?: string }) =>
         d.dropReason?.startsWith('rate-limited:'),
       );
       expect(summary2.length).toBeGreaterThanOrEqual(2);
       expect(summary2[1].speedMps).toBe(3.0);
+    } finally {
+      (Date.now as jest.Mock).mockRestore?.();
+      Date.now = realNow;
+    }
+  });
+
+  it('#1540 (S7) 슬라이딩 윈도우: 1.1초마다 한 건씩 도착해도 한도 정확히 적용 (fixed window trap 회귀 차단)', async () => {
+    const { clearGpsDropEntries, getGpsDropEntries } =
+      jest.requireActual('../../utils/gpsDropBuffer');
+    clearGpsDropEntries();
+    mockGranted();
+    const realNow = Date.now;
+    let fakeNow = 1_700_000_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => fakeNow);
+    try {
+      renderHook(() => useNearestStation());
+      await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+      // 1.1초 간격으로 6건 도착 — 슬라이딩 윈도우는 매번 1건만 유효, limit=2 미달이라 모두 push.
+      // 이전 fixed window 구현은 windowStart>=1000ms 마다 reset되어 동일한 결과를 내지만,
+      // 본 테스트는 sliding 동작이 회귀하지 않음을 박제한다.
+      for (let i = 0; i < 6; i += 1) {
+        simulateGps(37.6000 + i * 0.001, 127.0000 + i * 0.001, {
+          accuracy: 800 + i,
+          speed: 0,
+          timestamp: fakeNow,
+        });
+        fakeNow += 1_100;
+      }
+      const drops = getGpsDropEntries();
+      // 모두 윈도우 외부 → 6건 모두 push, summary 없음.
+      expect(drops).toHaveLength(6);
+      expect(drops.every((d: { dropReason: string }) => d.dropReason === 'low-accuracy-display')).toBe(
+        true,
+      );
+    } finally {
+      (Date.now as jest.Mock).mockRestore?.();
+      Date.now = realNow;
+    }
+  });
+
+  it('#1540 (S7) summary가 limit 소진 시: 본 drop은 다음 윈도우로 미루고 skipped=1로 유지', async () => {
+    const { clearGpsDropEntries, getGpsDropEntries } =
+      jest.requireActual('../../utils/gpsDropBuffer');
+    clearGpsDropEntries();
+    mockGranted();
+    const realNow = Date.now;
+    let fakeNow = 1_700_000_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => fakeNow);
+    try {
+      renderHook(() => useNearestStation());
+      await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+      // t0: push 1건 → timestamps=[t0]
+      simulateGps(37.7000, 127.0000, { accuracy: 800, timestamp: fakeNow });
+      // t0+500: push 2번째 → timestamps=[t0, t0+500] (limit=2 도달)
+      fakeNow += 500;
+      simulateGps(37.7001, 127.0001, { accuracy: 801, timestamp: fakeNow });
+      // t0+501: limit 도달 상태에서 1건 skip → skipped=1
+      fakeNow += 1;
+      simulateGps(37.7002, 127.0002, { accuracy: 802, timestamp: fakeNow });
+      expect(getGpsDropEntries()).toHaveLength(2);
+
+      // t0+1100: cutoff=t0+100 → t0 trim, t0+500 유지. timestamps=[t0+500] length=1<limit.
+      // skipped=1이므로 summary push → timestamps=[t0+500, t0+1100] length=2=limit.
+      // 본 drop은 미뤄지고 skipped=1로 재설정.
+      fakeNow = 1_700_000_000_000 + 1_100;
+      simulateGps(37.7003, 127.0003, { accuracy: 803, speed: 2.0, timestamp: fakeNow });
+      const drops = getGpsDropEntries();
+      // 2 (1st window pushes) + 1 summary = 3. 본 drop은 다음 윈도우로 미뤄짐.
+      expect(drops).toHaveLength(3);
+      const summary = drops[2];
+      expect(summary.dropReason).toBe('rate-limited:1');
+      expect(summary.speedMps).toBe(2.0);
     } finally {
       (Date.now as jest.Mock).mockRestore?.();
       Date.now = realNow;

--- a/src/features/nearest-station/hooks/useNearestStation.ts
+++ b/src/features/nearest-station/hooks/useNearestStation.ts
@@ -28,6 +28,7 @@ import {
 } from '../../../shared/constants/gpsStatus';
 import { createLogger } from '../../../shared/utils/logger';
 import { pushFusionDebugEntry } from '../utils/fusionDebugBuffer';
+import { pushGpsDropEntry } from '../utils/gpsDropBuffer';
 import { haversine } from '../../../shared/utils/haversine';
 import { useStickyStation } from './useStickyStation';
 
@@ -218,11 +219,16 @@ export function useNearestStation(
   // (84+건/5분 → React reconcile 폭주, AsyncStorage write 부담). 직전 drop과 lat/lng/accuracy가
   // 모두 동일하면 skip한다. 진단성은 rate-limit summary로 보존(아래 lastDropWindowRef).
   const lastDropRef = useRef<{ lat: number; lng: number; acc: number | null } | null>(null);
-  // #1516: rate limit — 1초 윈도우 내 GPS_DROP_PER_SEC_LIMIT 건 이상이면 추가 push skip + 1건
-  // "rate-limited" summary 기록. 정상 trip에서 N≤10/분 보장. count 0은 윈도우 idle 신호.
-  const lastDropWindowRef = useRef<{ windowStart: number; count: number; skipped: number }>({
-    windowStart: 0,
-    count: 0,
+  // #1516 + #1540 (S7): rate limit — sliding 1초 윈도우. 직전 push 시각 배열을 들고, 새 drop이
+  // 들어올 때마다 1초보다 오래된 시각을 trim한 뒤 남은 개수가 GPS_DROP_PER_SEC_LIMIT 미만일 때만 push.
+  //
+  // 이전 구현(fixed window)은 `windowStart` 이후 1초가 경과하면 `count`/`skipped`를 reset하는 트랩이
+  // 있었다 — drop이 1초보다 살짝 길게 spaced 도착하면 매번 윈도우가 reset되어 실효 한도가 ~2건/1.x초로
+  // 풀려 cap 점령을 막지 못했다. 슬라이딩 윈도우는 직전 1초 동안의 실제 push 수만 본다.
+  //
+  // 작은 고정 ring buffer(limit + 1 슬롯)로 들고 있어 매 fix마다 GC 압박 없이 O(limit)로 trim.
+  const lastDropWindowRef = useRef<{ timestamps: number[]; skipped: number }>({
+    timestamps: [],
     skipped: 0,
   });
 
@@ -393,47 +399,49 @@ export function useNearestStation(
               prevDrop.lng === lng &&
               prevDrop.acc === acc;
             if (sameAsPrev) return;
-            // #1516 dedup gate 2: 1초 윈도우 rate limit. limit 초과 시 skipped 누적.
+            // #1516 + #1540 (S7) dedup gate 2: 슬라이딩 1초 윈도우 rate limit.
+            // 직전 1초보다 오래된 timestamp를 trim한 뒤 남은 push 수가 limit 미만이면 push.
+            // limit 도달 시 skipped 누적 — 다음 push 시점에 summary 1건으로 흡수해 drop 가시성 보존.
+            // #1540: gps-drop entry는 fusionDebugBuffer가 아니라 gpsDropBuffer로 분리해
+            // fire-related entry(fusion decision / sticky / gps-fix)가 점령되지 않게 한다.
             const now = Date.now();
             const win = lastDropWindowRef.current;
-            if (now - win.windowStart >= GPS_DROP_WINDOW_MS) {
-              // 윈도우 마감 — skipped > 0이면 summary 1건 push.
-              if (win.skipped > 0) {
-                pushFusionDebugEntry({
-                  kind: 'gps',
-                  event: 'gps-drop',
-                  ts: now,
-                  lat,
-                  lng,
-                  accuracyMeters: acc,
-                  speedMps: isValidGpsSpeedMps(dropSpeed) ? dropSpeed : null,
-                  nearestStation: null,
-                  nearestLine: null,
-                  nearestDistanceKm: null,
-                  dropReason: `rate-limited:${win.skipped}`,
-                });
-              }
-              win.windowStart = now;
-              win.count = 0;
-              win.skipped = 0;
+            const cutoff = now - GPS_DROP_WINDOW_MS;
+            // 슬라이딩 윈도우 trim — 가장 오래된 entry부터 cutoff 이전이면 제거.
+            while (win.timestamps.length > 0 && win.timestamps[0] <= cutoff) {
+              win.timestamps.shift();
             }
-            if (win.count >= GPS_DROP_PER_SEC_LIMIT) {
+            if (win.timestamps.length >= GPS_DROP_PER_SEC_LIMIT) {
               win.skipped += 1;
               return;
             }
-            win.count += 1;
+            // 윈도우 capacity 여유 있음 → push. 직전 skipped > 0이면 summary 1건 먼저 push.
+            if (win.skipped > 0) {
+              pushGpsDropEntry({
+                ts: now,
+                lat,
+                lng,
+                accuracyMeters: acc,
+                speedMps: isValidGpsSpeedMps(dropSpeed) ? dropSpeed : null,
+                dropReason: `rate-limited:${win.skipped}`,
+              });
+              // summary도 rate에 포함시켜 limit 내에 머무르게 한다.
+              win.timestamps.push(now);
+              win.skipped = 0;
+              if (win.timestamps.length >= GPS_DROP_PER_SEC_LIMIT) {
+                // summary로 limit 소진 — 본 drop은 다음 윈도우로 미룬다.
+                win.skipped = 1;
+                return;
+              }
+            }
+            win.timestamps.push(now);
             lastDropRef.current = { lat, lng, acc };
-            pushFusionDebugEntry({
-              kind: 'gps',
-              event: 'gps-drop',
+            pushGpsDropEntry({
               ts: now,
               lat,
               lng,
               accuracyMeters: acc,
               speedMps: isValidGpsSpeedMps(dropSpeed) ? dropSpeed : null,
-              nearestStation: null,
-              nearestLine: null,
-              nearestDistanceKm: null,
               dropReason: 'low-accuracy-display',
             });
             return;

--- a/src/features/nearest-station/utils/__tests__/gpsDropBuffer.test.ts
+++ b/src/features/nearest-station/utils/__tests__/gpsDropBuffer.test.ts
@@ -10,7 +10,7 @@ function makeDrop(overrides: Partial<Parameters<typeof pushGpsDropEntry>[0]> = {
   return {
     ts: Date.now(),
     lat: 37.5,
-    lng: 127.0,
+    lng: 127,
     accuracyMeters: 1500,
     speedMps: null,
     dropReason: 'low-accuracy-display',

--- a/src/features/nearest-station/utils/__tests__/gpsDropBuffer.test.ts
+++ b/src/features/nearest-station/utils/__tests__/gpsDropBuffer.test.ts
@@ -1,0 +1,67 @@
+import {
+  GPS_DROP_BUFFER_CAPACITY,
+  clearGpsDropEntries,
+  getGpsDropEntries,
+  pushGpsDropEntry,
+  subscribeGpsDrop,
+} from '../gpsDropBuffer';
+
+function makeDrop(overrides: Partial<Parameters<typeof pushGpsDropEntry>[0]> = {}) {
+  return {
+    ts: Date.now(),
+    lat: 37.5,
+    lng: 127.0,
+    accuracyMeters: 1500,
+    speedMps: null,
+    dropReason: 'low-accuracy-display',
+    ...overrides,
+  };
+}
+
+describe('gpsDropBuffer', () => {
+  beforeEach(() => {
+    clearGpsDropEntries();
+  });
+
+  it('pushes and reads entries in order', () => {
+    pushGpsDropEntry(makeDrop({ ts: 1 }));
+    pushGpsDropEntry(makeDrop({ ts: 2 }));
+    const entries = getGpsDropEntries();
+    expect(entries).toHaveLength(2);
+    expect(entries[0].ts).toBe(1);
+    expect(entries[1].ts).toBe(2);
+  });
+
+  it('caps at GPS_DROP_BUFFER_CAPACITY, dropping oldest', () => {
+    for (let i = 0; i < GPS_DROP_BUFFER_CAPACITY + 3; i += 1) {
+      pushGpsDropEntry(makeDrop({ ts: i }));
+    }
+    const entries = getGpsDropEntries();
+    expect(entries).toHaveLength(GPS_DROP_BUFFER_CAPACITY);
+    expect(entries[0].ts).toBe(3);
+  });
+
+  it('clears entries', () => {
+    pushGpsDropEntry(makeDrop());
+    clearGpsDropEntries();
+    expect(getGpsDropEntries()).toHaveLength(0);
+  });
+
+  it('notifies subscribers on push and unsubscribe stops notifications', () => {
+    const listener = jest.fn();
+    const unsub = subscribeGpsDrop(listener);
+    pushGpsDropEntry(makeDrop());
+    expect(listener).toHaveBeenCalledTimes(1);
+    unsub();
+    pushGpsDropEntry(makeDrop());
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('no-ops clear when already empty (no listener fire)', () => {
+    const listener = jest.fn();
+    const unsub = subscribeGpsDrop(listener);
+    clearGpsDropEntries();
+    expect(listener).not.toHaveBeenCalled();
+    unsub();
+  });
+});

--- a/src/features/nearest-station/utils/gpsDropBuffer.ts
+++ b/src/features/nearest-station/utils/gpsDropBuffer.ts
@@ -1,0 +1,49 @@
+import { createDebugBuffer } from '../../../shared/utils/createDebugBuffer';
+
+/**
+ * #1540 (S7) — gps-drop 전용 ring buffer. fusionDebugBuffer와 분리해, 저정확도 fix
+ * 진단 entry가 fire-related entry(fusion decision / sticky lock / gps-fix)를 점령하지
+ * 못하게 한다.
+ *
+ * 배경(memory `lesson_gps_drop_fusion_buffer_pollution`):
+ *  - 2026-06-19 트립 1+2 fusionDebugBuffer 200 cap이 gps-drop entry로 가득 차
+ *    freeze 직전 fire 분석에 필요한 fusion decision/sticky 이력이 모두 evicted됨.
+ *  - iOS deferred batch가 같은 timestamp의 18+건을 다발로 흘려 dedup gate를 우회.
+ *  - "low-accuracy fix도 사후 진단에 필요"라는 #443 주석은 유효하지만 다른 채널과
+ *    cap을 공유하면 자기 목적(사후 진단)을 파괴한다.
+ *
+ * cap=100 — fusion(200)보다 작게 잡아 모듈 메모리 sum이 동일 수준에 머무르되 두 채널
+ * 모두 충분한 history 확보. push 빈도 차이(drop ≫ fusion)를 감안해 별 buffer로 분리하면
+ * 100건도 ~1분 진단 윈도우를 보장한다(rate limit 2/sec × 60s = 120 → 100 cap 약 50초).
+ */
+export const GPS_DROP_BUFFER_CAPACITY = 100;
+
+export interface GpsDropEntry {
+  ts: number;
+  lat: number;
+  lng: number;
+  /** GPS accuracy. null은 측정 불가(invalid)가 아니라 OS가 미제공한 케이스. */
+  accuracyMeters: number | null;
+  /** isValidGpsSpeedMps 통과한 양수 또는 null(측정 불가/정지). */
+  speedMps: number | null;
+  /** 예: 'low-accuracy-display' | `rate-limited:${number}`. */
+  dropReason: string;
+}
+
+const db = createDebugBuffer<GpsDropEntry>(GPS_DROP_BUFFER_CAPACITY);
+
+export function pushGpsDropEntry(entry: GpsDropEntry): void {
+  db.push(entry);
+}
+
+export function getGpsDropEntries(): readonly GpsDropEntry[] {
+  return db.get();
+}
+
+export function clearGpsDropEntries(): void {
+  db.clear();
+}
+
+export function subscribeGpsDrop(listener: () => void): () => void {
+  return db.subscribe(listener);
+}

--- a/src/shared/utils/createDebugBuffer.ts
+++ b/src/shared/utils/createDebugBuffer.ts
@@ -1,6 +1,12 @@
 /**
  * In-memory ring buffer factory for debug/measurement channels.
  * push/get/clear/subscribe 패턴을 구현 — fusionDebugBuffer, estimatorDebugBuffer 공통.
+ *
+ * 구현: O(1) push circular buffer. 내부적으로 고정 크기 배열 + head index를 들고,
+ * push마다 슬롯 1개만 덮어쓴다(이전 구현은 `[...buffer, entry]`로 매 push마다
+ * O(n) 배열 복제 + GC 압박). cap=200 buffer가 1초에 수십 번 push되는 진단 채널에서
+ * 200 × N copy가 누적돼 freeze 직전 GC pause를 키운 점이 #1540 (S7) RCA였다.
+ * get()은 호출 시 1회만 chronological array를 만들어 반환 — push hot path에서 분리한다.
  */
 export interface DebugBuffer<T> {
   push(entry: T): void;
@@ -10,7 +16,13 @@ export interface DebugBuffer<T> {
 }
 
 export function createDebugBuffer<T>(capacity: number): DebugBuffer<T> {
-  let buffer: T[] = [];
+  // 고정 크기 슬롯. 채워지기 전까지는 undefined이지만, get()에서 length 기반으로 슬라이스해
+  // 외부에 노출되지 않는다.
+  const slots: Array<T | undefined> = new Array(capacity);
+  // 다음 push가 들어갈 슬롯 index(0..capacity-1).
+  let head = 0;
+  // 현재 보관된 항목 수(0..capacity). capacity에 도달하면 더 늘지 않고 head만 wrap.
+  let size = 0;
   const subscribers = new Set<() => void>();
 
   function notify(): void {
@@ -21,18 +33,28 @@ export function createDebugBuffer<T>(capacity: number): DebugBuffer<T> {
 
   return {
     push(entry: T): void {
-      buffer = [...buffer, entry];
-      if (buffer.length > capacity) {
-        buffer = buffer.slice(buffer.length - capacity);
-      }
+      slots[head] = entry;
+      head = (head + 1) % capacity;
+      if (size < capacity) size += 1;
       notify();
     },
     get(): readonly T[] {
-      return buffer;
+      if (size === 0) return [];
+      // 가장 오래된 entry의 index. size<capacity면 0부터 채워졌으므로 0,
+      // 가득 찼으면 head 위치가 곧 가장 오래된 슬롯.
+      const out: T[] = new Array(size);
+      const start = size < capacity ? 0 : head;
+      for (let i = 0; i < size; i += 1) {
+        out[i] = slots[(start + i) % capacity] as T;
+      }
+      return out;
     },
     clear(): void {
-      if (buffer.length === 0) return;
-      buffer = [];
+      if (size === 0) return;
+      // 슬롯 참조 해제 — GC가 보관된 entry를 회수할 수 있도록.
+      for (let i = 0; i < capacity; i += 1) slots[i] = undefined;
+      head = 0;
+      size = 0;
       notify();
     },
     subscribe(cb: () => void): () => void {


### PR DESCRIPTION
Closes #1540 (Epic #1533 / ADR-016 S7)

## 배경
2026-06-19 트립 1+2 fusionDebugBuffer 200 cap이 gps-drop entry로 점령돼 15:42 freeze 직전 fire-related entry(fusion decision / sticky / gps-fix)가 모두 evicted됨. 자기 목적(사후 진단)을 파괴하던 회귀.

RCA: memory `lesson_gps_drop_fusion_buffer_pollution`.

## 변경
### 1. gps-drop 별 buffer 분리
- `src/features/nearest-station/utils/gpsDropBuffer.ts` 신설 — cap=100 ring buffer, fusionDebugBuffer와 cap 미공유.
- `useNearestStation.ts`의 표시 게이트 drop 경로가 `pushGpsDropEntry`로 라우팅. gps-fix(station 변경)는 그대로 fusionDebugBuffer 유지 — fire-related entry는 여전히 fusion 채널에서 사후 재구성 가능.

### 2. createDebugBuffer O(1) circular buffer
- 이전: `[...buffer, entry]` 매 push마다 O(n) array copy + GC 압박.
- 이후: 고정 슬롯 + head index + size. push는 1슬롯 덮어쓰기. get()만 호출 시 chronological array를 1회 만들어 반환.
- API(push/get/clear/subscribe) 동일 — 호출자 변경 없음.

### 3. dedup gate 2: sliding window
- 이전(fixed window): `now - windowStart >= 1000`이면 reset → drop이 1.x초 간격으로 도착하면 매번 reset돼 실효 한도가 늘어남.
- 이후(sliding): 직전 1초의 push timestamp 배열을 trim 후 남은 개수가 `limit` 미만일 때만 push. summary 1건도 자체 timestamp로 윈도우에 포함시켜 한도를 정확히 강제.

### 4. DebugModal — GPS drops 섹션
- UI(`DebugLogSection`) + share dump(`buildGpsDropLogSection`) + 1줄 포맷(`formatGpsDropLine`) + 별도 Clear 버튼.
- `__test__` export로 단위 테스트 노출.

## subsurface GPS interval — out of scope
이슈 §해결 #2는 subsurface watch interval 추가 throttle 가능성을 언급했지만, 현재 12s(`FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS`)에서 이미 throttled 상태이고 1·2·3 변경만으로 cap 점령 자체가 차단됩니다. 추가 throttle은 WiFi 역 표시 공백 trade-off가 있어 측정 후 별도 PR에서 결정 권장.

## Acceptance 매핑
- [x] `fusionDebugBuffer`는 gps-drop으로 오염되지 않음 (regression test).
- [x] 슬라이딩 윈도우: 1.1초 간격 6건 → fixed window 회귀 차단 test.
- [x] `gpsDropBuffer` 별도 dump (share dump `## GPS drops` + UI 'GPS drops' 섹션).
- [x] O(1) circular buffer (createDebugBuffer 단위 테스트 통과: capacity 초과 시 oldest drop, get() chronological).

## 검증
- `npm test --testPathIgnorePatterns="widget/api|stationNotification"`: 332 suite / 6658 tests pass.
- `npm run type-check`: clean.
- 변경 파일 모두 100% coverage (createDebugBuffer / gpsDropBuffer / fusionDebugBuffer / useNearestStation / DebugModal).
- widget/api + stationNotification 테스트는 본 PR과 무관한 사전 회귀(2026-06-19 dev 기준 동일).

## device 검증 갭
- 실기기 GC pause 감소(Xcode Instruments)는 사용자 측정 필요.
- 다음 trip dump의 fusionDebugBuffer에 fire-related entry 보존 / gpsDropBuffer 분리 확인은 EAS 빌드 후 검증 항목.