### PR TITLE
feat(#1539): passedStations 배열 + cron jitter 측정 (S6)

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -352,6 +352,34 @@ describe('sendSilentPush', () => {
     if (expectPresent) expect(body.data.lockReleasedReason).toBe(input);
   });
 
+  // #1539 (S6) — payload.passedStations wire 검증. non-empty 배열만 wire, undefined/빈 배열은 omit.
+  it.each([
+    ['non-empty 배열은 body.data.passedStations로 전달', ['군자', '중곡'], true],
+    ['빈 배열은 omit (구 device 호환)', [], false],
+    ['미지정은 omit (구 backend 호환)', undefined, false],
+  ])('passedStations %s (#1539)', async (_label, input, expectPresent) => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await sendSilentPush({
+      deviceToken: 'tok',
+      payload: {
+        nextWaypoint: '용마산',
+        etaSeconds: 0,
+        phase: 'imminent',
+        kind: 'intermediate',
+        sentAt: 1_700_000_000_000,
+        pushId: 'p',
+        ...(input === undefined ? {} : { passedStations: input }),
+      },
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect('passedStations' in body.data).toBe(expectPresent);
+    if (expectPresent) expect(body.data.passedStations).toEqual(input);
+  });
+
   it('uses sandbox host when provided', async () => {
     const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) =>
       new Response('', { status: 200 }),

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -25,6 +25,10 @@ import {
   pickLatestCurrentStationName,
   resolveEtaMissingThreshold,
   runScheduled,
+  appendPassedStation,
+  computeCronJitterMs,
+  PASSED_STATIONS_MAX_LEN,
+  CRON_NOMINAL_INTERVAL_MS,
   type ScheduledDeps,
   type ScheduledStats,
 } from '../scheduled';
@@ -4941,5 +4945,195 @@ describe('runScheduled — #1402 인프라 안전망 (pendingPushes wire-up + pa
     });
     const body = findApnsCallByPushId(apnsFetch, 'p1402-vf');
     expect((body.data as { origin: string }).origin).toBe('vanish-fallback');
+  });
+});
+
+// #1539 (S6, Epic #1533 / ADR-016) — passedStations 누적 + cron jitter 측정.
+// device가 cron 1분 race로 놓친 station-passed를 사전 예약 큐 diff로 backfill 발사할 수 있게
+// backend가 통과 station 누적 배열 + jitter metric을 제공한다. 본 PR은 데이터 plumbing만,
+// device-side diff/fire wiring은 S5 머지 후 후속 PR.
+describe('appendPassedStation (#1539 S6)', () => {
+  function makeTrip(passed?: string[]): Trip {
+    return {
+      token: 't',
+      route: { type: 'direct', stops: 3, line: '7' },
+      destination: 'D',
+      waypoints: [],
+      expiresAt: NOW + 60_000,
+      createdAt: NOW,
+      alarmAtEpochMs: NOW + 60_000,
+      ...(passed === undefined ? {} : { passedStations: passed }),
+    };
+  }
+
+  it('initializes array on first call (#1539)', () => {
+    const trip = makeTrip();
+    const dirty = appendPassedStation(trip, '군자');
+    expect(dirty).toBe(true);
+    expect(trip.passedStations).toEqual(['군자']);
+  });
+
+  it('appends a different stationName at the end', () => {
+    const trip = makeTrip(['군자']);
+    const dirty = appendPassedStation(trip, '중곡');
+    expect(dirty).toBe(true);
+    expect(trip.passedStations).toEqual(['군자', '중곡']);
+  });
+
+  it('skips duplicate consecutive stationName (defensive dedup)', () => {
+    const trip = makeTrip(['군자']);
+    const dirty = appendPassedStation(trip, '군자');
+    expect(dirty).toBe(false);
+    expect(trip.passedStations).toEqual(['군자']);
+  });
+
+  it('rejects empty stationName', () => {
+    const trip = makeTrip(['군자']);
+    const dirty = appendPassedStation(trip, '');
+    expect(dirty).toBe(false);
+    expect(trip.passedStations).toEqual(['군자']);
+  });
+
+  it(`caps length to PASSED_STATIONS_MAX_LEN (${PASSED_STATIONS_MAX_LEN})`, () => {
+    const initial = Array.from({ length: PASSED_STATIONS_MAX_LEN }, (_, i) => `S${i}`);
+    const trip = makeTrip([...initial]);
+    const dirty = appendPassedStation(trip, 'NEW');
+    expect(dirty).toBe(true);
+    expect(trip.passedStations).toHaveLength(PASSED_STATIONS_MAX_LEN);
+    expect(trip.passedStations?.[0]).toBe('S1');
+    expect(trip.passedStations?.[PASSED_STATIONS_MAX_LEN - 1]).toBe('NEW');
+  });
+});
+
+describe('computeCronJitterMs (#1539 S6)', () => {
+  it('returns 0 when called exactly at a boundary', () => {
+    const boundary = Math.floor(NOW / CRON_NOMINAL_INTERVAL_MS) * CRON_NOMINAL_INTERVAL_MS;
+    expect(computeCronJitterMs(boundary)).toBe(0);
+  });
+
+  it('returns positive ms offset from the prior 60s boundary', () => {
+    const boundary = Math.floor(NOW / CRON_NOMINAL_INTERVAL_MS) * CRON_NOMINAL_INTERVAL_MS;
+    expect(computeCronJitterMs(boundary + 1_234)).toBe(1_234);
+  });
+
+  it('always returns less than CRON_NOMINAL_INTERVAL_MS', () => {
+    const boundary = Math.floor(NOW / CRON_NOMINAL_INTERVAL_MS) * CRON_NOMINAL_INTERVAL_MS;
+    expect(computeCronJitterMs(boundary + CRON_NOMINAL_INTERVAL_MS - 1)).toBe(
+      CRON_NOMINAL_INTERVAL_MS - 1,
+    );
+  });
+});
+
+describe('advanceBoardingLockWaypoint passedStations 누적 (#1539 S6)', () => {
+  // arvlCd=ARRIVED → fireArvlCdStationPush → advance → trip.passedStations에 통과 station이 누적.
+  // 이후 putTrip되어 KV에서 읽으면 wire가 전달된다 (다음 cycle silent push payload).
+  it('accumulates passed stationName into trip.passedStations and forwards to payload', async () => {
+    const kv = new InMemoryKV();
+    // intermediate waypoint(중곡)가 ARRIVED로 advance → trip.passedStations에 push.
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'pass-1',
+        waypoints: [
+          { stationName: '중곡', line: '7', kind: 'intermediate' },
+          { stationName: '용마산', line: '7', kind: 'intermediate' },
+          { stationName: '강남', line: '2', kind: 'destination' },
+        ],
+        boardingLock: {
+          trainCode: 'T',
+          line: '7',
+          subwayId: '1007',
+          selectedDepartureTime: NOW,
+          segmentStations: ['중곡', '용마산'],
+          expiresAt: NOW + 60 * 60_000,
+        },
+      }),
+    );
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    await runScheduled(makeEnv(kv), {
+      seoul: makeLockedSeoul(0, 1),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    const stored = JSON.parse((await kv.get('trip:pass-1')) as string) as Trip;
+    expect(stored.passedStations).toEqual(['중곡']);
+    // arvlCd-fire path silent push payload에 passedStations forward.
+    const calls = apnsFetch.mock.calls as unknown as [string, RequestInit][];
+    const arvlcdCall = calls.find((c) => {
+      const body = JSON.parse(c[1].body as string);
+      return body.data?.origin === 'arvlcd';
+    });
+    expect(arvlcdCall).toBeDefined();
+    const arvlcdBody = JSON.parse(arvlcdCall![1].body as string);
+    // arvlCd-fire는 advance 직전 호출이라 fire 시점엔 아직 passedStations에 push되지 않은 상태.
+    // arvlCd fire path는 stationary trip-state(즉, 발사 시점)를 그대로 forward — empty이면 omit.
+    expect(arvlcdBody.data.passedStations).toBeUndefined();
+  });
+});
+
+describe('runLocklessIntermediate passedStations 누적 (#1539 S6)', () => {
+  it('accumulates passed stationName on lockless advance', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({
+      token: 'lockless-pass',
+      route: { type: 'direct', line: '2', stops: 2 },
+      waypoints: [
+        { stationName: '강남', line: '2', kind: 'intermediate' },
+        { stationName: '역삼', line: '2', kind: 'intermediate' },
+      ],
+      locklessStationPassed: true,
+    });
+    await putTrip(kv as unknown as KVNamespace, trip);
+    await seedLocklessMotionSeries(kv, trip.token, 'automotive');
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const arrived: ArrivalEntry = {
+      destination: '강남행',
+      arrivalSeconds: 30,
+      trainCode: '7246',
+      isUp: true,
+      subwayNm: '지하철2호선',
+      arvlCd: 1,
+    };
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([arrived]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.locklessIntermediateFired).toBe(1);
+    const stored = JSON.parse((await kv.get('trip:lockless-pass')) as string) as Trip;
+    expect(stored.passedStations).toEqual(['강남']);
+  });
+});
+
+describe('runScheduled cron jitter stat (#1539 S6)', () => {
+  it('stamps cronJitterMs on stats + logs it', async () => {
+    const kv = new InMemoryKV();
+    const env = makeEnv(kv);
+    const logMessages: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(env, {
+      seoul: new SeoulArrivalClient({
+        apiKey: 'K',
+        host: 'h',
+        now: () => NOW + 7_321,
+        fetchImpl: (async () =>
+          new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 })) as unknown as typeof fetch,
+      }),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW + 7_321,
+      log: (msg, meta) => {
+        logMessages.push({ msg, meta });
+      },
+    });
+    const expectedJitter = computeCronJitterMs(NOW + 7_321);
+    expect(stats.cronJitterMs).toBe(expectedJitter);
+    expect(logMessages.some((l) => l.msg === 'scheduled: cron jitter' && l.meta?.jitterMs === expectedJitter))
+      .toBe(true);
   });
 });

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -136,6 +136,16 @@ export interface SilentPushPayload {
    * 구 backend 호환 위해 optional — 미전달 시 wire에서 자연 누락.
    */
   lockReleasedReason?: LockReleasedReason;
+  /**
+   * #1539 (S6, Epic #1533 / ADR-016) — backend가 trip 시작 후 통과 확인한 모든 station 누적 배열
+   * (`Trip.passedStations` forward, 최신 N개). device는 사전 예약 큐와 diff하여 cron 1분 race로
+   * 누락된 station-passed 알림을 backfill할 수 있게 된다(S5 머지 후 wiring PR).
+   *
+   * - 빈 배열 또는 undefined → wire 누락 (device backfill 자연 skip)
+   * - 본 PR(S6)은 backend → device 데이터 plumbing만 — actual backfill 발사는 후속 PR.
+   * - readonly: payload 빌더가 trip 상태를 share-by-reference로 전달해도 JSON serialize 시 안전.
+   */
+  passedStations?: readonly string[];
 }
 
 /**
@@ -249,6 +259,11 @@ export async function sendSilentPush(options: SendPushOptions): Promise<SendPush
       ...(options.payload.lockReleasedReason === undefined
         ? {}
         : { lockReleasedReason: options.payload.lockReleasedReason }),
+      // #1539 (S6) — passedStations는 non-empty 배열일 때만 wire. 빈 배열/누락은 JSON에서 자연
+      // 누락 → 구 device(필드 무시) 호환. device는 사전 예약 큐 backfill에 사용한다(후속 PR).
+      ...(options.payload.passedStations && options.payload.passedStations.length > 0
+        ? { passedStations: [...options.payload.passedStations] }
+        : {}),
     },
   });
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -181,6 +181,58 @@ export function resolveEtaMissingThreshold(trip: Pick<Trip, 'subsurface'>): numb
  * 런타임에서 `Invalid cache_ttl` 던짐(#770 hotfix).
  */
 const CRON_PROGRESS_CACHE_TTL_SEC = 30;
+
+/**
+ * #1539 (S6) — `Trip.passedStations` 누적 최대 길이.
+ * silent push payload가 비대해지는 것을 막고(APNs payload limit 4KB), device 사전 예약 큐와
+ * diff에 필요한 직전 N개 station만 유지한다(트립 누적 알림 수는 일반적으로 한 자릿수~십 수개).
+ *
+ * 20은 보수적 상한 — 1분 cron jitter로 device가 놓칠 수 있는 최대 통과 station 수의 2배 이상.
+ */
+export const PASSED_STATIONS_MAX_LEN = 20;
+
+/**
+ * #1539 (S6) — Cloudflare cron trigger의 nominal interval (60s, `wrangler.toml` `[triggers].crons`).
+ * `runScheduled`가 실제 실행된 시각과 직전 60s boundary의 차이로 cron jitter를 측정한다.
+ *
+ * 정상 운영: jitter < 1s. Cloudflare scheduler 부하 시 수 초~수십 초까지 늘어날 수 있고,
+ * device 매역 알림 누락의 1차 원인 중 하나(epic #1533 ADR-016 §3 결정 5). 이 값이 P99로
+ * 추적되면 cron 윈도우 확장(S5) 영향 평가의 정량 근거가 된다.
+ */
+export const CRON_NOMINAL_INTERVAL_MS = 60_000;
+
+/**
+ * #1539 (S6) — `Trip.passedStations`에 stationName을 cap 적용해 누적.
+ * 같은 stationName이 연속 호출되면 push하지 않는다(arrived+entering 양쪽 신호로 advance 헬퍼가
+ * 1 hop에 한 번만 진입하지만 defensive). 길이 초과 시 oldest를 drop.
+ *
+ * pure helper — trip 객체를 mutate하고 변경 여부(dirty)를 반환해 호출자가 putTrip 분기에 사용한다.
+ */
+export function appendPassedStation(trip: Trip, stationName: string): boolean {
+  if (stationName.length === 0) return false;
+  if (trip.passedStations === undefined) {
+    trip.passedStations = [stationName];
+    return true;
+  }
+  const last = trip.passedStations[trip.passedStations.length - 1];
+  if (last === stationName) return false;
+  trip.passedStations.push(stationName);
+  if (trip.passedStations.length > PASSED_STATIONS_MAX_LEN) {
+    trip.passedStations.splice(0, trip.passedStations.length - PASSED_STATIONS_MAX_LEN);
+  }
+  return true;
+}
+
+/**
+ * #1539 (S6) — cron jitter 측정. 실제 실행 시각과 직전 60s boundary의 차이(ms).
+ * 정상 운영에서 < 1s. Cloudflare scheduler 부하 또는 cold start 시 수 초까지 늘어날 수 있다.
+ *
+ * 음수 반환 가능성 없음 — `now`가 boundary 이전인 case는 floor의 의미상 불가능(now ≥ boundary).
+ */
+export function computeCronJitterMs(now: number): number {
+  const boundary = Math.floor(now / CRON_NOMINAL_INTERVAL_MS) * CRON_NOMINAL_INTERVAL_MS;
+  return now - boundary;
+}
 // #1402 — load-time 회귀 가드. 컴파일 시 0/10 같은 값을 silently 넣지 못하도록 module load
 // 시점에 즉시 throw. 신규 callsite 추가 시 type-check + 첫 test run 양쪽에서 잡힌다.
 assertCronCacheTtl(CRON_PROGRESS_CACHE_TTL_SEC);
@@ -304,6 +356,13 @@ export interface ScheduledStats extends LiveActivityStats {
    * 발사하던 회귀(2026-06-16 용마산 정지 trip)를 차단한다.
    */
   vanishFallbackMotionGateBlocked: number;
+  /**
+   * #1539 (S6, Epic #1533 / ADR-016) — `runScheduled` 진입 시점의 cron jitter (ms).
+   * 직전 60s boundary와 실제 실행 시각의 차이. 정상 운영 < 1s. 매역 알림 누락 회귀의 1차
+   * 원인 중 하나로 추정되며(2026-06-19 트립 2 evidence), P50/P99 추적이 S5 윈도우 확장 효과
+   * 측정의 정량 근거가 된다. 누적 metric이 아니라 매 cycle의 즉시값을 그대로 log한다.
+   */
+  cronJitterMs: number;
 }
 
 /**
@@ -363,7 +422,11 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     vanishReleaseFired: 0,
     vanishLocklessTakeover: 0,
     vanishFallbackMotionGateBlocked: 0,
+    // #1539 (S6) — cron jitter (실행 시각 - 직전 60s boundary). 매 cycle 즉시값으로 stamp.
+    cronJitterMs: computeCronJitterMs(now),
   };
+  // #1539 (S6) — cron jitter 즉시 log. 누적 stat이 아니라 매 cycle 1줄 → tail에서 P50/P99 산출.
+  log('scheduled: cron jitter', { jitterMs: stats.cronJitterMs });
 
   for await (const trip of listTrips(env.TRIPS)) {
     stats.scanned += 1;
@@ -800,6 +863,9 @@ function buildStationPassedImminentPayload(
     origin,
     // #1438 (E5) — lock release sync. 정의된 경우에만 wire (apns.ts JSON serializer가 undefined 누락).
     lockReleasedReason,
+    // #1539 (S6) — backend 누적 passedStations forward. 빈 배열/undefined는 apns.ts JSON
+    // serializer가 자연 누락. device backfill diff(S5 후속 wiring PR)에서 사용.
+    passedStations: trip.passedStations,
   };
 }
 
@@ -1474,6 +1540,10 @@ export async function advanceBoardingLockWaypoint(
     });
     return;
   }
+  // #1539 (S6) — waypoint advance 시점 직전 station 누적. silent push payload로 forward되어
+  // device가 사전 예약 큐와 diff하여 cron 1분 race로 누락된 station-passed를 backfill 발사한다
+  // (S5 머지 후 후속 wiring PR). 본 PR은 backend → device 데이터 plumbing만.
+  appendPassedStation(trip, waypoint.stationName);
   trip.waypoints.shift();
   trip.lastTrackedArrivalEpoch = undefined;
   trip.lastLaPushEpoch = undefined;
@@ -1945,6 +2015,9 @@ export async function runLocklessIntermediate(
           tripToken: trip.token,
           // #1402 — 발사 경로 stamp. device alarmLog에 pushOrigin=lockless로 기록.
           origin: 'lockless' as const,
+          // #1539 (S6) — backend 누적 passedStations forward. 빈 배열/undefined는 apns.ts JSON
+          // serializer가 자연 누락. device backfill diff(S5 후속 wiring PR)에서 사용.
+          passedStations: trip.passedStations,
         },
         config: deps.apnsConfig,
         host,
@@ -1997,6 +2070,9 @@ export async function runLocklessIntermediate(
     apnsEnv: trip.apnsEnv ?? 'sandbox',
   });
   trip.lastFiredPhase = 'imminent';
+  // #1539 (S6) — lockless intermediate 통과 시점도 동일하게 stationName 누적. lock 경로와 동등
+  // 정확도 보장 의무(ADR-014: 사용자 명시 의향 trip = lock 활성과 동급).
+  appendPassedStation(trip, waypoint.stationName);
   trip.waypoints.shift();
   if (trip.waypoints.length === 0) {
     // 마지막 intermediate까지 통과 — trip 종료. lockless는 destination을 직접 다루지 않는다.

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -208,6 +208,19 @@ export interface Trip {
    * 한 trip 내에서 지상→지하 전이로 false→true 변동 가능. cron 사이클 사이의 stale은 next register로 자연 정정.
    */
   subsurface?: boolean;
+  /**
+   * #1539 (S6, Epic #1533 / ADR-016) — backend가 trip 시작 후 통과를 확인한 모든 station
+   * 누적 배열. waypoint advance 시점(`advanceBoardingLockWaypoint` / `runLocklessIntermediate`)에
+   * 직전 waypoint stationName을 push한다. 최대 길이 `PASSED_STATIONS_MAX_LEN`로 cap.
+   *
+   * 용도: silent push payload에 forward되어 device가 사전 예약 큐와 diff하여 cron 1분 race로
+   * 누락된 station-passed 알림을 backfill 발사할 수 있게 한다(S5의 pre-scheduled window 확장과
+   * 결합). 본 PR(S6)은 누적 + payload wire + cron jitter metric만 다루고, device-side diff/fire
+   * wiring은 S5 머지 후 후속 PR.
+   *
+   * 부재(레거시 trip / 신규 trip 첫 cycle 전) → undefined → device는 backfill 자연 skip.
+   */
+  passedStations?: string[];
 }
 
 /**

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -641,6 +641,79 @@ describe('silentPushTask', () => {
       });
     });
 
+    // #1539 (S6, Epic #1533 / ADR-016) — backend가 silent push payload에 통과 station 누적 배열을
+    // forward. device는 사전 예약 큐와 diff하여 cron 1분 race로 놓친 station-passed를 backfill 발사
+    // (실제 backfill wiring은 S5 머지 후 별 PR — 본 PR은 extract만).
+    describe('passedStations (#1539 S6)', () => {
+      it('non-empty 문자열 배열은 그대로 전달', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              nextWaypoint: '용마산',
+              etaSeconds: 0,
+              phase: 'imminent',
+              passedStations: ['군자', '중곡'],
+            }),
+          ),
+        ).toMatchObject({ passedStations: ['군자', '중곡'] });
+      });
+
+      it('빈 배열은 undefined (구 backend 호환)', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              nextWaypoint: 'A',
+              etaSeconds: 0,
+              phase: 'imminent',
+              passedStations: [],
+            }),
+          ),
+        ).toMatchObject({ passedStations: undefined });
+      });
+
+      it('비-배열/누락은 undefined', () => {
+        expect(
+          extractPayload(bgTaskData({ nextWaypoint: 'A', etaSeconds: 0, phase: 'imminent' })),
+        ).toMatchObject({ passedStations: undefined });
+        expect(
+          extractPayload(
+            bgTaskData({
+              nextWaypoint: 'A',
+              etaSeconds: 0,
+              phase: 'imminent',
+              passedStations: 'not-an-array',
+            }),
+          ),
+        ).toMatchObject({ passedStations: undefined });
+      });
+
+      it('비-string/빈 string 항목은 필터링, 잔여만 채택', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              nextWaypoint: 'A',
+              etaSeconds: 0,
+              phase: 'imminent',
+              passedStations: ['군자', '', 42, '중곡', null],
+            }),
+          ),
+        ).toMatchObject({ passedStations: ['군자', '중곡'] });
+      });
+
+      it('필터링 후 잔여 0이면 undefined', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              nextWaypoint: 'A',
+              etaSeconds: 0,
+              phase: 'imminent',
+              passedStations: ['', null, 42],
+            }),
+          ),
+        ).toMatchObject({ passedStations: undefined });
+      });
+    });
+
     // #725 — reschedule schema는 standard와 다르므로 별도 분기 검증.
     describe('reschedule kind (#725)', () => {
       it('정상 reschedule payload → RescheduleSilentPushPayload', () => {

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -151,6 +151,18 @@ export interface SilentPushPayload {
    * 구 backend 호환 위해 optional — 누락 시 sync 자연 skip(기존 동작 보존).
    */
   lockReleasedReason?: 'transfer' | 'vanish';
+  /**
+   * #1539 (S6, Epic #1533 / ADR-016) — backend가 trip 시작 후 통과를 확인한 모든 station 누적 배열
+   * (직전 N개, 최신순 뒤). cron 1분 race로 device가 station을 "지나친 것" 인지 못 한 케이스를
+   * 사후 backfill하기 위한 SSOT.
+   *
+   * 사용: device는 사전 예약 큐(`bl:`/`tba:`)와 diff하여 payload에 있지만 아직 발사되지 않은
+   * station-passed를 backfill 발사한다. **본 PR(S6) 단계는 schema/extract만 — actual diff/fire
+   * wiring은 S5 머지 후 후속 PR**(S5 pre-scheduled window 확장과 결합).
+   *
+   * 구 backend 호환 / 빈 배열 / wire 누락 → undefined → 기존 동작 그대로(backfill 자연 skip).
+   */
+  passedStations?: readonly string[];
 }
 
 /**
@@ -351,6 +363,7 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
     occupiedLine,
     tripToken,
     lockReleasedReason,
+    passedStations,
   } = obj as {
     nextWaypoint: string;
   } & Record<string, unknown>;
@@ -371,7 +384,26 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
     occupiedLine: validBoardingLine(occupiedLine),
     tripToken: validTripToken(tripToken),
     lockReleasedReason: validLockReleasedReason(lockReleasedReason),
+    passedStations: validPassedStations(passedStations),
   };
+}
+
+/**
+ * #1539 (S6) — payload.passedStations 검증. non-empty string 배열만 통과.
+ * - 누락/형식 오류/빈 배열 → undefined → device backfill 자연 skip(기존 동작 보존).
+ * - 항목별 비-string 또는 빈 string은 필터 후 잔여가 있으면 그것만 채택. 잔여 0이면 undefined.
+ * - 길이 cap은 backend 책임(`PASSED_STATIONS_MAX_LEN`). device 추가 cap은 적용하지 않는다 —
+ *   payload 크기 제약은 APNs serializer에서 이미 강제.
+ *
+ * S5 머지 후 wiring PR에서 사전 예약 큐 diff에 사용된다.
+ */
+function validPassedStations(value: unknown): readonly string[] | undefined {
+  if (!Array.isArray(value) || value.length === 0) return undefined;
+  const filtered: string[] = [];
+  for (const v of value) {
+    if (typeof v === 'string' && v.length > 0) filtered.push(v);
+  }
+  return filtered.length > 0 ? filtered : undefined;
 }
 
 /**


### PR DESCRIPTION
Closes #1539
Epic: #1533 (ADR-016) · Sub: S6 (depends on S5 #1538 for wiring follow-up)

## 배경
2026-06-19 트립 2 매역 알림 누락 6역. cron 1분 race로 device가 중간역 통과 인지 못 함. backend cron jitter 측정 인프라도 없어 회귀 정량 추적 불가.

## 변경 사항 (backend + device 양쪽 데이터 plumbing만)

### Backend (`backend/alarm-worker/src/`)
- **`types.ts`** — `Trip.passedStations?: string[]` 신설 (capped, 최대 20).
- **`scheduled.ts`**
  - `appendPassedStation(trip, stationName)` pure helper — capped FIFO 누적 + consecutive duplicate dedup.
  - `advanceBoardingLockWaypoint` + `runLocklessIntermediate`에서 waypoint shift 직전 누적.
  - `buildStationPassedImminentPayload` + lockless 인라인 payload가 `trip.passedStations` forward.
  - `computeCronJitterMs(now)` — `now`와 직전 60s boundary 차이 산출.
  - `runScheduled` 진입 시 `stats.cronJitterMs` stamp + `scheduled: cron jitter` log 발사 (tail에서 P50/P99 산출).
- **`apns.ts`** — `SilentPushPayload.passedStations?: readonly string[]` + JSON serializer가 non-empty 배열일 때만 wire.

### Device (`src/features/alarm/tasks/silentPushTask.ts`)
- `SilentPushPayload.passedStations?: readonly string[]` 신설.
- `validPassedStations(value)` — non-empty string 배열 필터, 잔여 0이면 undefined로 정규화.
- `extractStandardPayload`가 payload에 forward.
- **wiring(사전 예약 큐 diff/backfill 발사)는 S5 머지 후 별 PR로 분리** — 본 PR은 데이터 plumbing만.

## 테스트 (모두 추가, 100% 커버리지 유지)
- `apns.test.ts` — `passedStations` wire 3-case it.each (non-empty/빈 배열/undefined).
- `scheduled.test.ts` — `appendPassedStation` 5 case (초기/append/dedup/empty/cap), `computeCronJitterMs` 3 case (boundary/offset/edge), `runScheduled` jitter stamp+log 1, advance 누적 통합 1, lockless 누적 통합 1.
- `silentPushTask.test.ts` — `passedStations` 추출 5 case (non-empty/빈 배열/누락·비-array/항목 필터/잔여 0 → undefined).

## Acceptance 매핑
- ✅ "passedStations 배열 신설 + backend 누적 + payload forward" → `appendPassedStation` + `buildStationPassedImminentPayload`/lockless 두 payload 모두 wire.
- ✅ "Backend cron jitter 측정 metric" → `runScheduled` 진입 stamp + `scheduled: cron jitter` log + `stats.cronJitterMs` 표면화.
- ✅ "S5 머지 후 wiring 별 PR" — 본 PR 본문에 명시.

## 검증 — 후속 PR / 실측 책임
- 매역 알림 통과율 95%+ 측정 → S5 wiring PR 머지 후 1주 production.
- cron jitter P50/P99 → 본 PR 머지 직후 wrangler tail에서 24h 수집.

## Test plan
- [x] `npm run type-check` (device) pass
- [x] `cd backend/alarm-worker && npx vitest run` — 1507 tests pass (38 files)
- [x] `npx jest src/features/alarm/tasks/__tests__/silentPushTask.test.ts` — 232 pass + silentPushTask.ts 100% coverage
- [ ] CI: `Data Validation` + `Type Check & Test` green