### PR TITLE
refactor(#1545): tripBoundCleanups 누락 8 항목 wiring + audit 확장

### DIFF
--- a/src/features/alarm/api/__tests__/alarmBackend.test.ts
+++ b/src/features/alarm/api/__tests__/alarmBackend.test.ts
@@ -7,6 +7,7 @@ import {
   clearLiveActivityToken,
   reportBoardingPromptOutcome,
   __resetAlarmBackendDedup,
+  resetAlarmBackendDedup,
 } from '../alarmBackend';
 import type { RegisterTripPayload } from '../alarmBackend';
 import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
@@ -650,6 +651,28 @@ describe('alarmBackend', () => {
       });
       expect(result.ok).toBe(true);
       AsyncStorage.setItem = originalSetItem;
+    });
+  });
+
+  // #1545 (S12) — TRIP_BOUND_CLEANUPS에 wiring될 production reset.
+  describe('resetAlarmBackendDedup (#1545 S12)', () => {
+    it('완료 hash를 초기화해 같은 페이로드 재등록 시 fetch가 다시 발사된다 (token 불필요)', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://example.com';
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 } as Response);
+
+      // 같은 SAMPLE_PAYLOAD 첫 등록 → fetch 1회.
+      await registerActiveTrip(SAMPLE_PAYLOAD);
+      const afterFirst = (global.fetch as jest.Mock).mock.calls.length;
+      expect(afterFirst).toBe(1);
+
+      // 동일 페이로드 재등록 → hash dedup으로 fetch skip.
+      await registerActiveTrip(SAMPLE_PAYLOAD);
+      expect((global.fetch as jest.Mock).mock.calls.length).toBe(afterFirst);
+
+      // production reset 호출 → 다음 동일 페이로드 등록은 dedup 풀려 fetch 재발사.
+      await expect(resetAlarmBackendDedup()).resolves.toBeUndefined();
+      await registerActiveTrip(SAMPLE_PAYLOAD);
+      expect((global.fetch as jest.Mock).mock.calls.length).toBeGreaterThan(afterFirst);
     });
   });
 });

--- a/src/features/alarm/api/alarmBackend.ts
+++ b/src/features/alarm/api/alarmBackend.ts
@@ -204,6 +204,20 @@ export function __resetAlarmBackendDedup(): void {
   inFlightRegisters.clear();
 }
 
+/**
+ * #1545 (S12) — trip 종료 시 alarm-backend dedup 캐시(완료 hash + in-flight Map) 초기화.
+ *
+ * `clearActiveTrip`이 동일 작업을 수행하지만, BG silent push trip-ended 경로는 token이 없는
+ * 채로 `runTripBoundCleanups`만 호출되어 in-flight Promise/last hash가 다음 trip register에
+ * 의도치 않게 재사용되는 회귀(같은 hash로 stale Promise 공유)가 발생. 본 함수는 token 없이
+ * dedup 상태만 즉시 초기화 — 멱등.
+ */
+export function resetAlarmBackendDedup(): Promise<void> {
+  lastRegisteredHash = null;
+  inFlightRegisters.clear();
+  return Promise.resolve();
+}
+
 function getBackendUrl(): string | null {
   const url = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
   if (!url) return null;

--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -18,6 +18,16 @@ import {
   SCHEDULED_NOTIFICATIONS_KEY,
   STICKY_STATION_KEY,
 } from '../../../../shared/constants/storageKeys';
+import {
+  clearCrossCategoryDedup,
+  markStationFired,
+  isStationRecentlyFired,
+} from '../../utils/crossCategoryStationDedup';
+import { clearAlarmLogWindows } from '../../utils/alarmLog';
+import { resetAlarmBackendDedup } from '../../api/alarmBackend';
+import { useDestinationStore } from '../../../route/store/useDestinationStore';
+import { useBoardingLockStore } from '../useBoardingLockStore';
+import { useAlarmEventStore } from '../useAlarmEventStore';
 
 const mockClearWidgetStation = jest.fn().mockResolvedValue(undefined);
 
@@ -317,6 +327,89 @@ describe('tripBoundCleanups', () => {
     });
   });
 
+  describe('#1545 (S12) — 누락 8 항목 wiring 회귀 가드', () => {
+    // BG silent push trip-ended 경로에서 runTripBoundCleanups만 호출되는 경우, 모든
+    // module-level / in-memory 상태가 일관되게 클리어되는지 검증. 새 cleanup 항목이 누락되면
+    // 본 describe 블록의 assertion 중 하나가 빨갛게 깨진다.
+
+    it('S12-1: clearCrossCategoryDedup이 TRIP_BOUND_CLEANUPS에 포함된다 (lastFire Map 클리어)', async () => {
+      const now = Date.now();
+      markStationFired('dest-1', '강남', 'destination', now);
+      expect(
+        isStationRecentlyFired('dest-1', '강남', 'station-passed', now + 1_000),
+      ).toBe(true);
+      // TRIP_BOUND_CLEANUPS에 포함되어야 함 — 함수 reference 비교.
+      expect(TRIP_BOUND_CLEANUPS).toContain(clearCrossCategoryDedup);
+      // 실제 cleanup 효과: 비운 뒤엔 fire 기록 없음.
+      await clearCrossCategoryDedup();
+      expect(
+        isStationRecentlyFired('dest-1', '강남', 'station-passed', now + 1_000),
+      ).toBe(false);
+    });
+
+    it('S12-2: clearAlarmLogWindows가 TRIP_BOUND_CLEANUPS에 포함된다 (alarmLog 3 Maps 클리어)', async () => {
+      expect(TRIP_BOUND_CLEANUPS).toContain(clearAlarmLogWindows);
+      // 멱등 호출 — 빈 Map 상태에서도 graceful 통과.
+      await expect(clearAlarmLogWindows()).resolves.toBeUndefined();
+    });
+
+    it('S12-3: resetAlarmBackendDedup이 TRIP_BOUND_CLEANUPS에 포함된다 (in-flight + last hash 클리어)', async () => {
+      expect(TRIP_BOUND_CLEANUPS).toContain(resetAlarmBackendDedup);
+      await expect(resetAlarmBackendDedup()).resolves.toBeUndefined();
+    });
+
+    it('S12-4+5+6+7: in-memory zustand store mirror가 일괄 클리어된다 (customOrigin/lock/alarmEvent/dismissSilence)', async () => {
+      // BG silent push trip-ended 직전 상태: 모든 store 메모리에 trip-bound state 존재.
+      useDestinationStore.setState({
+        customOrigin: {
+          id: 'orig-1',
+          name: '용마산',
+          line: '7',
+          lineColor: '#000',
+          lat: 37.5,
+          lng: 127.0,
+        },
+      });
+      useBoardingLockStore.setState({
+        lock: {
+          destinationId: 'stn-1',
+          trainCode: 'T-100',
+          boardingStationId: 'stn-0',
+          boardingLine: '7',
+          boardedAt: Date.now(),
+          expectedDurationMs: 600_000,
+        },
+      });
+      useAlarmEventStore.setState({
+        alarmEvent: {
+          phaseId: 'imminent',
+          type: 'destination',
+          stationName: '강남',
+        },
+        dismissSilence: { sinceTs: Date.now(), sinceLat: null, sinceLng: null },
+      });
+
+      await runTripBoundCleanups();
+
+      // 모든 메모리 state가 null로 비워졌어야 한다 — BG 경로에서도 일관.
+      expect(useDestinationStore.getState().customOrigin).toBeNull();
+      expect(useBoardingLockStore.getState().lock).toBeNull();
+      expect(useAlarmEventStore.getState().alarmEvent).toBeNull();
+      expect(useAlarmEventStore.getState().dismissSilence).toBeNull();
+    });
+
+    it('S12-8: enumeration 가드 — TRIP_BOUND_CLEANUPS 길이가 baseline 이하로 떨어지면 회귀', () => {
+      // 새 cleanup 항목이 추가될 때마다 baseline을 한 줄로 갱신. 누군가 실수로 항목을 제거하면
+      // 본 assertion이 빨갛게 깨져 의도된 제거인지 코드리뷰에서 확인하도록 강제한다.
+      //
+      // #1545 (S12) 이전: 22 항목. S12에서 5 항목 추가(crossCategoryDedup / alarmLogWindows /
+      // alarmBackendDedup / storeMemoryMirror / [기존 22] = 22 + 4 신규 + 1 wrapper). 일부 항목은
+      // BG-only 메모리/dedup이라 storage write 없이도 효력 있음.
+      const MIN_ITEMS = 25;
+      expect(TRIP_BOUND_CLEANUPS.length).toBeGreaterThanOrEqual(MIN_ITEMS);
+    });
+  });
+
   it('runTripBoundCleanups: 한 항목이 reject해도 나머지 항목이 모두 실행된다', async () => {
     // 첫 호출만 reject, 나머지는 정상 — Promise.all 안에서 catch로 흡수되어
     // 다른 cleanup의 실행 자체에는 영향이 없어야 한다.
@@ -330,9 +423,13 @@ describe('tripBoundCleanups', () => {
     await runTripBoundCleanups();
 
     // removeItem이 항목 수만큼(또는 그 이상 helper 경유분 포함) 호출됐는지 확인.
-    // 최소 메타 배열 길이만큼은 호출되어야 한다.
+    // #1545 (S12) — 신규 wiring 4건(clearCrossCategoryDedup / clearAlarmLogWindows /
+    // resetAlarmBackendDedup / clearTripBoundStoreMemory)은 storage write를 하지 않는
+    // module-level/memory 클리어라 removeItem 카운트에 기여하지 않는다. 신규 항목 수만큼
+    // 임계값을 낮춰 기존 invariant(storage 기반 항목 모두 실행)는 유지.
+    const NON_STORAGE_CLEANUPS = 4;
     expect((AsyncStorage.removeItem as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(
-      TRIP_BOUND_CLEANUPS.length,
+      TRIP_BOUND_CLEANUPS.length - NON_STORAGE_CLEANUPS,
     );
   });
 });

--- a/src/features/alarm/store/__tests__/tripBoundCleanupsAudit.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanupsAudit.test.ts
@@ -200,3 +200,34 @@ describe('#1176 tripBoundCleanups audit — lockless ↔ lock 전이 회귀 가�
     expect(useDestinationStore.getState().destination).toEqual(station);
   });
 });
+
+/**
+ * #1545 (S12) — TRIP_BOUND_CLEANUPS enumeration audit (잘못된 누락 제거 회귀 가드).
+ *
+ * 본 describe는 위 audit과 분리해 mock 없이 실제 메타 배열을 직접 inspect한다 — 새 cleanup
+ * 항목 추가 시 갱신해야 할 baseline + 카테고리 카운트를 한 자리에 박제한다. PR에서 항목이
+ * 의도치 않게 제거되면 본 가드가 빨갛게 깨져 코드리뷰에서 의도 여부를 확인하게 강제.
+ */
+describe('#1545 (S12) — TRIP_BOUND_CLEANUPS enumeration audit', () => {
+  // 본 audit 파일 상단은 `../tripBoundCleanups`를 모킹하므로(runTripBoundCleanups 호출 contract용),
+  // 메타 배열 자체를 검증하려면 requireActual로 실제 모듈을 가져온다. crossCategory/alarmLog/
+  // alarmBackend는 모킹 대상이 아니므로 일반 require로 충분.
+  it('S12 신규 wiring(crossCategoryDedup / alarmLogWindows / alarmBackendDedup)이 모두 등록돼 있다', () => {
+    const { TRIP_BOUND_CLEANUPS } = jest.requireActual('../tripBoundCleanups');
+    const { clearCrossCategoryDedup } = jest.requireActual(
+      '../../utils/crossCategoryStationDedup',
+    );
+    const { clearAlarmLogWindows } = jest.requireActual('../../utils/alarmLog');
+    const { resetAlarmBackendDedup } = jest.requireActual('../../api/alarmBackend');
+
+    expect(TRIP_BOUND_CLEANUPS).toContain(clearCrossCategoryDedup);
+    expect(TRIP_BOUND_CLEANUPS).toContain(clearAlarmLogWindows);
+    expect(TRIP_BOUND_CLEANUPS).toContain(resetAlarmBackendDedup);
+  });
+
+  it('baseline 25 항목(기존 22 + S12 신규 3 wrapper + storeMemory 1)에서 줄어들면 회귀', () => {
+    const { TRIP_BOUND_CLEANUPS } = jest.requireActual('../tripBoundCleanups');
+    // 현재 baseline. 새 항목 추가 시 한 줄 갱신. 누군가 항목을 의도치 않게 제거하면 회귀로 감지.
+    expect(TRIP_BOUND_CLEANUPS.length).toBeGreaterThanOrEqual(25);
+  });
+});

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -39,6 +39,12 @@ import {
   getRegisteredTripRouteSig,
 } from '../utils/tripBoundScheduler';
 import { clearTripCorrId } from '../../observability/utils/tripCorrId';
+import { clearCrossCategoryDedup } from '../utils/crossCategoryStationDedup';
+import { clearAlarmLogWindows } from '../utils/alarmLog';
+import { resetAlarmBackendDedup } from '../api/alarmBackend';
+import { useDestinationStore } from '../../route/store/useDestinationStore';
+import { useBoardingLockStore } from './useBoardingLockStore';
+import { useAlarmEventStore } from './useAlarmEventStore';
 import { createLogger } from '../../../shared/utils/logger';
 
 const log = createLogger('tripBoundCleanups');
@@ -120,7 +126,58 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   // 저장하므로 trip 끝나도 위젯에는 trip 중 마지막 역이 남는다. clearWidgetStation으로 즉시
   // "감지 중" 상태로 전환해 다음 fresh fix가 들어올 때까지 정확하지 않은 현재역 노출을 막는다.
   clearWidgetStation,
+  // #1545 (S12) — 모듈-level in-memory dedup 윈도우 클리어.
+  // 같은 destination/같은 phase로 새 trip을 즉시 시작할 때 직전 trip의 fire 기록이
+  // 새 trip 첫 fire를 silence하는 회귀 차단. BG silent push trip-ended 경로에서도
+  // 동일하게 비워야 일관.
+  clearCrossCategoryDedup,
+  clearAlarmLogWindows,
+  // #1545 (S12) — alarm-backend register dedup 캐시 클리어. clearActiveTrip이 token이 있을
+  // 때만 호출되는 반면, BG silent push trip-ended 경로는 token 없이 cleanup만 진행 →
+  // in-flight Promise/last hash가 다음 trip register에 stale로 재사용되는 회귀 차단.
+  resetAlarmBackendDedup,
+  // #1545 (S12) — in-memory zustand store mirror 클리어.
+  // FG setDestination(null/switch) 경로는 useDestinationStore가 inline으로 customOrigin/
+  // alarmEvent/dismissSilence 메모리를 동기화하지만, BG silent push trip-ended 경로는
+  // runTripBoundCleanups만 호출되어 storage는 비워도 메모리는 stale로 남는다 (FG 복귀 시
+  // useStateRehydration이 sentinel을 보고 destination/lock만 reset — alarmEvent 등은 누락).
+  // 본 wiring으로 BG 경로에서도 메모리/storage가 동시에 일관 상태가 된다.
+  clearTripBoundStoreMemory,
 ];
+
+/**
+ * #1545 (S12) — trip-bound zustand store의 in-memory mirror를 일괄 클리어.
+ *
+ * storage는 다른 항목에서 이미 removeItem 되므로 본 함수는 메모리 setState만 수행.
+ * 멱등 — 이미 null인 state에 setState 호출은 graceful no-op.
+ *
+ * useDestinationStore.customOrigin / useBoardingLockStore.lock / useAlarmEventStore.alarmEvent /
+ * useAlarmEventStore.dismissSilence를 한 번에 동기화한다. setState는 sync — Promise.resolve로
+ * 반환해 TRIP_BOUND_CLEANUPS의 () => Promise<void> shape에 맞춘다.
+ */
+function clearTripBoundStoreMemory(): Promise<void> {
+  const destState = useDestinationStore.getState();
+  // customOrigin: setDestination 경로는 이미 null로 동기화하지만, BG silent push 경로는
+  // 누락. 사용자가 직접 지정한 출발역이 새 trip에 leak되지 않도록 비운다.
+  if (destState.customOrigin !== null) {
+    useDestinationStore.setState({ customOrigin: null });
+  }
+  // boardingLock: storage(BOARDING_LOCK_KEY)는 이미 removeItem 됐지만 zustand snapshot이
+  // 메모리에 lock을 갖고 있으면 FG UI가 stale lock UI를 일시 노출한다.
+  if (useBoardingLockStore.getState().lock !== null) {
+    useBoardingLockStore.setState({ lock: null });
+  }
+  // alarmEvent / dismissSilence: storage(ALARM_EVENT_KEY/dismissSilenceStorage)도 위에서
+  // 이미 cleanup. 메모리만 추가 동기화 — 새 trip UI에 이전 alarm overlay/silence가 leak 차단.
+  const alarmState = useAlarmEventStore.getState();
+  if (alarmState.alarmEvent !== null) {
+    useAlarmEventStore.setState({ alarmEvent: null });
+  }
+  if (alarmState.dismissSilence !== null) {
+    useAlarmEventStore.setState({ dismissSilence: null });
+  }
+  return Promise.resolve();
+}
 
 /**
  * 모든 trip-bound cleanup을 병렬로 실행한다. 항목들 사이에 순서 의존성이 없어

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -24,6 +24,7 @@ import {
   logSuppressedDedupAlarm,
   _resetDedupAlarmWindowForTests,
   _resetBurstSuppressWindowForTests,
+  clearAlarmLogWindows,
   _simulateAppStateForTest,
   DEDUP_LOG_WINDOW_MS,
   FLUSH_DEBOUNCE_MS,
@@ -1798,5 +1799,46 @@ describe('alarmLog', () => {
     });
   });
 
+  // #1545 (S12) — TRIP_BOUND_CLEANUPS에 wiring될 production reset.
+  describe('clearAlarmLogWindows (#1545 S12)', () => {
+    it('3개 윈도우(refMismatch / dedupAlarm / burst)를 모두 비우고 graceful resolve한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+
+      // 윈도우를 채운다 — 같은 key를 5_000ms 내에 두 번 호출하면 두 번째는 silence.
+      logRefMismatch('dest-1', 'ref-1');
+      logSuppressedDedupAlarm('fg-arvlcd', {
+        phaseId: 'imminent',
+        type: 'destination',
+        stationName: '강남',
+      });
+      const baseline = (await getAlarmLog()).length;
+
+      // 같은 키 즉시 재호출 — 윈도우 silence로 추가 entry 0건이어야 함 (sanity check).
+      logRefMismatch('dest-1', 'ref-1');
+      logSuppressedDedupAlarm('fg-arvlcd', {
+        phaseId: 'imminent',
+        type: 'destination',
+        stationName: '강남',
+      });
+      const blocked = (await getAlarmLog()).length;
+      expect(blocked).toBe(baseline);
+
+      // production reset → 다음 동일 키 호출이 silence 풀려 다시 append.
+      await expect(clearAlarmLogWindows()).resolves.toBeUndefined();
+      logRefMismatch('dest-1', 'ref-1');
+      logSuppressedDedupAlarm('fg-arvlcd', {
+        phaseId: 'imminent',
+        type: 'destination',
+        stationName: '강남',
+      });
+      const afterClear = (await getAlarmLog()).length;
+      expect(afterClear).toBeGreaterThan(baseline);
+    });
+
+    it('빈 상태에서도 graceful no-op resolve한다 (멱등)', async () => {
+      await expect(clearAlarmLogWindows()).resolves.toBeUndefined();
+      await expect(clearAlarmLogWindows()).resolves.toBeUndefined();
+    });
+  });
 });
 

--- a/src/features/alarm/utils/__tests__/crossCategoryStationDedup.test.ts
+++ b/src/features/alarm/utils/__tests__/crossCategoryStationDedup.test.ts
@@ -1,6 +1,7 @@
 import {
   CROSS_CATEGORY_DEDUP_WINDOW_MS,
   _resetCrossCategoryDedupForTests,
+  clearCrossCategoryDedup,
   isStationRecentlyFired,
   markStationFired,
 } from '../crossCategoryStationDedup';
@@ -95,5 +96,13 @@ describe('crossCategoryStationDedup (#1515)', () => {
         CROSS_CATEGORY_DEDUP_WINDOW_MS + 2,
       ),
     ).toBe(true);
+  });
+
+  // #1545 (S12) — TRIP_BOUND_CLEANUPS에 wiring될 production reset.
+  it('clearCrossCategoryDedup empties the window and resolves', async () => {
+    markStationFired('dest-1', '강남', 'destination', 1_000);
+    expect(isStationRecentlyFired('dest-1', '강남', 'station-passed', 2_000)).toBe(true);
+    await expect(clearCrossCategoryDedup()).resolves.toBeUndefined();
+    expect(isStationRecentlyFired('dest-1', '강남', 'station-passed', 2_000)).toBe(false);
   });
 });

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -468,6 +468,24 @@ export function _resetBurstSuppressWindowForTests(): void {
 }
 
 /**
+ * #1545 (S12) — trip 종료 시 3개 dedup 윈도우 Map을 모두 클리어.
+ *
+ * 사용자가 직전 trip에서 동일 destination/같은 phaseId를 가진 새 trip을 즉시 시작하면,
+ * 5s 윈도우 안의 lastDedupLogTs / lastBurstSuppressTs / lastRefMismatchTs 엔트리가
+ * 새 trip의 정상 신호를 silence할 수 있다. trip 경계에서 3개 Map을 함께 비워 다음
+ * trip이 깨끗한 상태로 시작하도록 보장. `TRIP_BOUND_CLEANUPS`에 wiring (BG silent push
+ * trip-ended 경로 + FG setDestination(null/switch) 양쪽 커버).
+ *
+ * 멱등 — 빈 Map에서도 graceful no-op.
+ */
+export function clearAlarmLogWindows(): Promise<void> {
+  lastRefMismatchTs.clear();
+  lastDedupLogTs.clear();
+  lastBurstSuppressTs.clear();
+  return Promise.resolve();
+}
+
+/**
  * silent push 수신 1건 적재 (#478 측정 인프라).
  * sentAt(백엔드 payload)와 receivedAt(클라 수신 시점) 차로 도달 지연 측정.
  * sentAt이 없으면(구 백엔드) undefined로 기록 — 추후 백엔드 배포 전후 분리 분석 가능.

--- a/src/features/alarm/utils/crossCategoryStationDedup.ts
+++ b/src/features/alarm/utils/crossCategoryStationDedup.ts
@@ -128,3 +128,16 @@ export function markStationFired(
 export function _resetCrossCategoryDedupForTests(): void {
   lastFire.clear();
 }
+
+/**
+ * #1545 (S12) — trip 종료 시 dedup 윈도우 전체 클리어.
+ *
+ * 사용자가 같은 destination으로 새 trip을 즉시 다시 시작할 때, 직전 trip에서 fire된 station
+ * 키가 30s 윈도우 안에 살아 있으면 새 trip의 같은 station 첫 fire가 silence된다. 본 함수는
+ * `TRIP_BOUND_CLEANUPS`에 wiring되어 BG silent push trip-ended 경로에서도 모든 fire 기록을
+ * 비운다 (멱등 — 빈 Map에서도 graceful no-op).
+ */
+export function clearCrossCategoryDedup(): Promise<void> {
+  lastFire.clear();
+  return Promise.resolve();
+}


### PR DESCRIPTION
Closes #1545

## Summary
Epic #1533 (ADR-016) S12 — 2026-06-19 트립 2에서 발견된 tripBoundCleanups 누락 8 항목을 wiring하고 audit test를 확장한다. BG silent push trip-ended 경로에서도 모든 module-level dedup 윈도우와 in-memory zustand store mirror가 일관되게 클리어되도록 보장.

## Changes

### Production exports 추가
- `crossCategoryStationDedup.ts`: `clearCrossCategoryDedup()` — `lastFire` Map 클리어
- `alarmLog.ts`: `clearAlarmLogWindows()` — `lastRefMismatchTs` / `lastDedupLogTs` / `lastBurstSuppressTs` 3개 Map 일괄 클리어
- `alarmBackend.ts`: `resetAlarmBackendDedup()` — token 없이 호출 가능한 `lastRegisteredHash` + `inFlightRegisters` 초기화 (`clearActiveTrip` 우회 경로용)

### TRIP_BOUND_CLEANUPS wiring (4 항목 추가, 25 → 25 항목 baseline)
- `clearCrossCategoryDedup`
- `clearAlarmLogWindows`
- `resetAlarmBackendDedup`
- `clearTripBoundStoreMemory` (로컬 wrapper) — `useDestinationStore.customOrigin` / `useBoardingLockStore.lock` / `useAlarmEventStore.alarmEvent` / `useAlarmEventStore.dismissSilence` 메모리 일괄 setState({...: null})

### 누락 8 항목 매핑
1. `crossCategoryStationDedup.lastFire` → `clearCrossCategoryDedup`
2. `alarmLog` 3 Maps → `clearAlarmLogWindows`
3. `alarmBackend.inFlightRegisters` → `resetAlarmBackendDedup`
4. `useApnsTripRegistration.lastRouteSigRef` → 기존 hook effect가 destination=null 시 reset(line 328). 별도 wiring 불필요 — useStateRehydration sentinel 경로가 zustand destination을 null로 reset → effect 재실행 → ref clear.
5. `useDestinationStore.customOrigin` (BG path) → `clearTripBoundStoreMemory`
6. `useBoardingLockStore` memory → `clearTripBoundStoreMemory`
7. `useAlarmEventStore` memory (alarmEvent + dismissSilence) → `clearTripBoundStoreMemory`
8. `useStickyStation` memory → 기존 hook 메커니즘이 처리. `motion.tripActive` flip 감지(line 215~221) + persisted `STICKY_STATION_KEY` 제거(기존 wiring) 양쪽이 커버.

### Test 확장
- `tripBoundCleanups.test.ts`: 4 신규 wiring 회귀 가드 + storeMemory 메모리 클리어 검증 + enumeration 가드 (MIN_ITEMS=25)
- `tripBoundCleanupsAudit.test.ts`: `jest.requireActual`로 메타 배열 enumeration audit 추가
- `crossCategoryStationDedup.test.ts` / `alarmLog.test.ts` / `alarmBackend.test.ts`: 각 production reset의 단위 검증 추가

## 머지 순서 주의
S8 #1541(`useDestinationStore.customOrigin` BG path)과 영역 겹침 가능. 후속 머지 측이 rebase 필요할 수 있음.

## Test plan
- [x] `npm test` — 본 PR 신규/수정 테스트 모두 pass (259 passed in alarm/route/shared 영역)
- [x] `npm run type-check` — clean
- [x] `tripBoundCleanups.test.ts` 21 tests pass
- [x] `tripBoundCleanupsAudit.test.ts` 8 tests pass (기존 6 + S12 신규 2)
- [ ] 실기기 BG silent push trip-ended 회귀 검증 — trip 종료 후 같은 destination 재시작 시 첫 fire silence 없음
- [ ] 강제종료 시나리오 — trip 잔존 없이 모든 store/dedup 메모리 클리어 확인 (다음 trip end dump)