### PR TITLE
feat(#1554): TripPositionSSoT 스키마 + KV helpers + ADR-017 doc (Epic #1553)

### DIFF
--- a/backend/alarm-worker/src/__tests__/tripPositionSsot.test.ts
+++ b/backend/alarm-worker/src/__tests__/tripPositionSsot.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  MOTION_EVIDENCE_CAP,
+  SSOT_CRON_READ_CACHE_TTL_SEC,
+  deleteSsot,
+  migrateTripPassedStationsToSsot,
+  pushMotionEvidence,
+  readSsot,
+  seedSsot,
+  ssotKey,
+  writeSsot,
+  type MotionEvidence,
+  type TripPositionSSoT,
+} from '../tripPositionSsot';
+import { CRON_READ_CACHE_TTL_SEC } from '../kvConsistency';
+import { InMemoryKV } from './inMemoryKv';
+
+/**
+ * Sub #1554 / T1 — TripPositionSSoT 스키마 + KV helpers acceptance.
+ *
+ * - Round-trip: writeSsot → readSsot 동등성
+ * - Ring buffer: 51건 push 시 oldest 제거 (cap=50)
+ * - seedSsot: SSOT 정상 생성 (currentStationId, motionState='unknown', passedStations=[])
+ * - cacheTtl: <30 throw (lesson_cron_cachettl_runtime_constraint 준수)
+ * - migrateTripPassedStationsToSsot: 양방향 호환 + dedup
+ */
+
+function makeSsot(overrides?: Partial<TripPositionSSoT>): TripPositionSSoT {
+  return {
+    tripToken: 'tok-abc',
+    currentStationId: '0228',
+    motionState: 'unknown',
+    motionEvidence: [],
+    lastAdvanceAt: 0,
+    lastAdvanceEvidence: 'seed-override',
+    passedStations: [],
+    userIntentDeclared: false,
+    seedOverrideCount: 0,
+    schemaVersion: 1,
+    ...overrides,
+  };
+}
+
+describe('tripPositionSsot — key + CRUD', () => {
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  it('ssotKey: prefix "ssot:<token>" 박제', () => {
+    expect(ssotKey('tok-xyz')).toBe('ssot:tok-xyz');
+  });
+
+  it('round-trip: writeSsot → readSsot은 같은 객체 (동등성)', async () => {
+    const ssot = makeSsot({
+      currentStationId: '0150',
+      motionState: 'moving',
+      passedStations: ['용마산', '중곡'],
+      seedOverrideCount: 2,
+    });
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    const got = await readSsot(kv as unknown as KVNamespace, ssot.tripToken);
+    expect(got).toEqual(ssot);
+  });
+
+  it('readSsot: 없는 token은 null', async () => {
+    const got = await readSsot(kv as unknown as KVNamespace, 'missing');
+    expect(got).toBeNull();
+  });
+
+  it('readSsot: 손상된 JSON은 null (graceful)', async () => {
+    await kv.put(ssotKey('tok-broken'), '{not json');
+    const got = await readSsot(kv as unknown as KVNamespace, 'tok-broken');
+    expect(got).toBeNull();
+  });
+
+  it('deleteSsot: 삭제 후 read는 null', async () => {
+    const ssot = makeSsot();
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await deleteSsot(kv as unknown as KVNamespace, ssot.tripToken);
+    const got = await readSsot(kv as unknown as KVNamespace, ssot.tripToken);
+    expect(got).toBeNull();
+  });
+
+  it('writeSsot: expiresAt 지정 시 expirationTtl 적용 (trip lifecycle 정합)', async () => {
+    const ssot = makeSsot();
+    const expiresAt = Date.now() + 600_000; // +10분
+    await writeSsot(kv as unknown as KVNamespace, ssot, { expiresAt });
+    const entry = kv.store.get(ssotKey(ssot.tripToken));
+    expect(entry?.expiresAt).toBeDefined();
+    // 60s 하한 적용 — 음수/0 입력 시 만료가 즉시 되지 않게 보호
+    expect(entry?.expiresAt! - Date.now()).toBeGreaterThan(60_000);
+  });
+
+  it('writeSsot: expiresAt이 과거여도 최소 60s 하한 적용 (안전 가드)', async () => {
+    const ssot = makeSsot();
+    await writeSsot(kv as unknown as KVNamespace, ssot, {
+      expiresAt: Date.now() - 100_000,
+    });
+    const entry = kv.store.get(ssotKey(ssot.tripToken));
+    // SSOT_MIN_TTL_SEC = 60 적용 — 약 60s 후 만료
+    expect(entry?.expiresAt! - Date.now()).toBeGreaterThanOrEqual(59_000);
+    expect(entry?.expiresAt! - Date.now()).toBeLessThanOrEqual(61_000);
+  });
+});
+
+describe('tripPositionSsot — cacheTtl floor (lesson_cron_cachettl_runtime_constraint)', () => {
+  it('readSsot: cacheTtl < 30 throw RangeError (caller guard)', async () => {
+    const kv = new InMemoryKV();
+    await expect(
+      readSsot(kv as unknown as KVNamespace, 'tok', { cacheTtl: 10 }),
+    ).rejects.toThrow(RangeError);
+  });
+
+  it('readSsot: cacheTtl=30 통과 (cron read floor)', async () => {
+    const kv = new InMemoryKV();
+    const ssot = makeSsot();
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    const got = await readSsot(kv as unknown as KVNamespace, ssot.tripToken, {
+      cacheTtl: 30,
+    });
+    expect(got).toEqual(ssot);
+  });
+
+  it('SSOT_CRON_READ_CACHE_TTL_SEC === CRON_READ_CACHE_TTL_SEC (30s 박제)', () => {
+    expect(SSOT_CRON_READ_CACHE_TTL_SEC).toBe(CRON_READ_CACHE_TTL_SEC);
+    expect(SSOT_CRON_READ_CACHE_TTL_SEC).toBe(30);
+  });
+});
+
+describe('tripPositionSsot — seedSsot (S1 GAP A 수신부)', () => {
+  it('seedSsot: 호출 후 SSOT 정상 생성 + KV write', async () => {
+    const kv = new InMemoryKV();
+    const ssot = await seedSsot(kv as unknown as KVNamespace, 'tok-seed', '0228');
+    expect(ssot.tripToken).toBe('tok-seed');
+    expect(ssot.currentStationId).toBe('0228');
+    expect(ssot.motionState).toBe('unknown');
+    expect(ssot.motionEvidence).toEqual([]);
+    expect(ssot.passedStations).toEqual([]);
+    expect(ssot.userIntentDeclared).toBe(false);
+    expect(ssot.seedOverrideCount).toBe(0);
+    expect(ssot.schemaVersion).toBe(1);
+    expect(ssot.lastAdvanceAt).toBe(0);
+
+    const persisted = await readSsot(kv as unknown as KVNamespace, 'tok-seed');
+    expect(persisted).toEqual(ssot);
+  });
+
+  it('seedSsot: userIntentDeclared 옵션 true로 stamp (C 토글 ON 시나리오)', async () => {
+    const kv = new InMemoryKV();
+    const ssot = await seedSsot(kv as unknown as KVNamespace, 'tok', '0150', {
+      userIntentDeclared: true,
+    });
+    expect(ssot.userIntentDeclared).toBe(true);
+  });
+
+  it('seedSsot: expiresAt 옵션 전달 시 KV TTL 적용', async () => {
+    const kv = new InMemoryKV();
+    const expiresAt = Date.now() + 300_000;
+    await seedSsot(kv as unknown as KVNamespace, 'tok', '0228', { expiresAt });
+    const entry = kv.store.get(ssotKey('tok'));
+    expect(entry?.expiresAt).toBeDefined();
+  });
+});
+
+describe('tripPositionSsot — pushMotionEvidence ring buffer', () => {
+  function makeEvidence(ts: number): MotionEvidence {
+    return { source: 'device-position', ts, signal: { displacementM: 10 } };
+  }
+
+  it('단일 push: ring buffer에 추가', () => {
+    const ssot = makeSsot();
+    pushMotionEvidence(ssot, makeEvidence(1));
+    expect(ssot.motionEvidence).toHaveLength(1);
+    expect(ssot.motionEvidence[0]?.ts).toBe(1);
+  });
+
+  it('50건 push: cap 그대로 유지 (eviction 미발생)', () => {
+    const ssot = makeSsot();
+    for (let i = 0; i < MOTION_EVIDENCE_CAP; i += 1) {
+      pushMotionEvidence(ssot, makeEvidence(i));
+    }
+    expect(ssot.motionEvidence).toHaveLength(MOTION_EVIDENCE_CAP);
+    expect(ssot.motionEvidence[0]?.ts).toBe(0);
+    expect(ssot.motionEvidence[MOTION_EVIDENCE_CAP - 1]?.ts).toBe(
+      MOTION_EVIDENCE_CAP - 1,
+    );
+  });
+
+  it('51건 push: cap 유지 + oldest(ts=0) FIFO eviction', () => {
+    const ssot = makeSsot();
+    for (let i = 0; i <= MOTION_EVIDENCE_CAP; i += 1) {
+      pushMotionEvidence(ssot, makeEvidence(i));
+    }
+    expect(ssot.motionEvidence).toHaveLength(MOTION_EVIDENCE_CAP);
+    expect(ssot.motionEvidence[0]?.ts).toBe(1);
+    expect(ssot.motionEvidence[MOTION_EVIDENCE_CAP - 1]?.ts).toBe(
+      MOTION_EVIDENCE_CAP,
+    );
+  });
+
+  it('MOTION_EVIDENCE_CAP === 50 (KV row 크기 정책 박제)', () => {
+    expect(MOTION_EVIDENCE_CAP).toBe(50);
+  });
+
+  it('이미 cap 초과 상태에서 push: while 루프가 한 step 이상 eviction 수행', () => {
+    const ssot = makeSsot();
+    for (let i = 0; i < MOTION_EVIDENCE_CAP + 5; i += 1) {
+      ssot.motionEvidence.push(makeEvidence(i));
+    }
+    expect(ssot.motionEvidence).toHaveLength(MOTION_EVIDENCE_CAP + 5);
+    pushMotionEvidence(ssot, makeEvidence(999));
+    expect(ssot.motionEvidence).toHaveLength(MOTION_EVIDENCE_CAP);
+    expect(ssot.motionEvidence[MOTION_EVIDENCE_CAP - 1]?.ts).toBe(999);
+    expect(ssot.motionEvidence[0]?.ts).toBe(6);
+  });
+});
+
+describe('tripPositionSsot — migrateTripPassedStationsToSsot', () => {
+  it('Trip.passedStations 비어 있으면 no-op', () => {
+    const ssot = makeSsot();
+    migrateTripPassedStationsToSsot({ passedStations: [] }, ssot);
+    expect(ssot.passedStations).toEqual([]);
+  });
+
+  it('Trip.passedStations === undefined 도 no-op (S6 legacy trip)', () => {
+    const ssot = makeSsot();
+    migrateTripPassedStationsToSsot({ passedStations: undefined }, ssot);
+    expect(ssot.passedStations).toEqual([]);
+  });
+
+  it('Trip.passedStations만 채워졌으면 SSOT로 union 반영', () => {
+    const ssot = makeSsot({ passedStations: [] });
+    migrateTripPassedStationsToSsot(
+      { passedStations: ['용마산', '중곡', '군자'] },
+      ssot,
+    );
+    expect(ssot.passedStations).toEqual(['용마산', '중곡', '군자']);
+  });
+
+  it('양방향 호환: SSOT에 이미 있는 station은 dedup', () => {
+    const ssot = makeSsot({ passedStations: ['용마산', '중곡'] });
+    migrateTripPassedStationsToSsot(
+      { passedStations: ['용마산', '중곡', '군자'] },
+      ssot,
+    );
+    expect(ssot.passedStations).toEqual(['용마산', '중곡', '군자']);
+  });
+
+  it('순서 보존: SSOT 기존 → Trip 신규 station 순으로 append', () => {
+    const ssot = makeSsot({ passedStations: ['A', 'B'] });
+    migrateTripPassedStationsToSsot({ passedStations: ['B', 'C', 'D'] }, ssot);
+    expect(ssot.passedStations).toEqual(['A', 'B', 'C', 'D']);
+  });
+});

--- a/backend/alarm-worker/src/tripPositionSsot.ts
+++ b/backend/alarm-worker/src/tripPositionSsot.ts
@@ -1,0 +1,273 @@
+/**
+ * TripPositionSSoT — ADR-017 foundation (Epic #1553, Sub #1554 / T1).
+ *
+ * 배경
+ * ====
+ * 2026-06-19 evidence: 정지 trip + lock active + arvlcd ARRIVED 상태가 `arvlcd-fire`와
+ * `boarding-lock: waypoint advanced`를 분산된 fire path에서 독립 실행 → wrong "transfer
+ * imminent" 발사. 본 모듈은 trip별 단일 state row(SSOT)를 정의해 T2(`advanceTripPosition`)
+ * 단일 mutation 진입점이 6단 게이트로 advance를 결정하게 만드는 foundation이다.
+ *
+ * T1 스코프 (본 PR)
+ * ================
+ * - `TripPositionSSoT` 타입 + 보조 type (EvidenceType / EvidenceSource / MotionEvidence)
+ * - KV CRUD helpers (`readSsot` / `writeSsot` / `deleteSsot`)
+ * - `seedSsot()` — S1 GAP A의 backend 수신부 (trip 시작 시 currentStationId 정착)
+ * - `pushMotionEvidence()` — ring buffer 50건 cap helper
+ * - `migrateTripPassedStationsToSsot()` — S6 #1551의 `Trip.passedStations` → SSOT.passedStations
+ *   read-only fallback (T7 이후 제거 예정)
+ *
+ * T1은 **새 게이트 추가도, 다른 fire path 변경도 하지 않는다**. 후속 T2~T8이 본 SSOT 위에
+ * 게이트/머지/리더-only refactor를 쌓아간다.
+ *
+ * KV 설계
+ * =======
+ * - Key prefix: `ssot:<token>`
+ * - cacheTtl: `CRON_READ_CACHE_TTL_SEC` (30s) — [[lesson_cron_cachettl_runtime_constraint]] 준수.
+ *   Cloudflare KV는 `cacheTtl < 30` read를 throw하므로 helpers는 caller가 cacheTtl을 명시할
+ *   때 `assertKvCacheTtl`로 floor 검증한다 (`trips.ts:getTrip`와 동일 패턴).
+ * - Row 크기 관리: motionEvidence는 ring buffer로 50건 cap. 단일 row 예상 ≤5KB.
+ *
+ * schemaVersion
+ * =============
+ * 초기 값 1. 향후 SSOT 구조 변경 시 readSsot에서 마이그레이션 분기. 본 PR은 v1만 정의.
+ */
+
+import { assertKvCacheTtl, CRON_READ_CACHE_TTL_SEC } from './kvConsistency';
+import type { Trip } from './types';
+
+/**
+ * Motion evidence ring buffer cap. KV row 크기 폭주 방지 (단일 row ≤25MB CF KV 한도 대비
+ * 여유 있게). 50건 초과 push 시 oldest entry FIFO eviction.
+ */
+export const MOTION_EVIDENCE_CAP = 50;
+
+/** SSOT KV key prefix. */
+const SSOT_PREFIX = 'ssot:';
+
+/** SSOT KV row TTL 하한 — trip.expiresAt이 가까워도 최소 60s 보존 (trip TTL과 정합). */
+const SSOT_MIN_TTL_SEC = 60;
+
+/**
+ * Trip별 advance 결정에 사용되는 evidence type.
+ *
+ * ADR-017 T2(`advanceTripPosition`) 6단 게이트가 `'time-only'`을 거부(ADR-015 E4 enforce).
+ * 그 외 type은 합의 게이트(#3)에서 환경별로 가중치 평가.
+ */
+export type EvidenceType =
+  | 'gps-displacement'
+  | 'gps-stationary'
+  | 'arvlcd-confirmed-train'
+  | 'arvlcd-lockless'
+  | 'position-train'
+  | 'wifi-ssid-match'
+  | 'cellular-tech-change'
+  | 'accel-fingerprint'
+  | 'time-only'
+  | 'manual-user-intent'
+  | 'seed-override';
+
+/**
+ * Evidence가 어느 데이터 출처에서 왔는지. T2 합의 게이트가 source 분산을 평가할 때 사용.
+ */
+export type EvidenceSource =
+  | 'device-position'
+  | 'seoul-arvlcd'
+  | 'seoul-realtime-position'
+  | 'device-wifi'
+  | 'device-cellular'
+  | 'device-accel'
+  | 'device-user-intent'
+  | 'cron-time';
+
+/**
+ * Motion state — `advanceTripPosition` 게이트 #2의 입력.
+ *
+ * - `'moving'`     : `/position` 수신부(T3)가 GPS displacement / speed sustained 확인.
+ * - `'stationary'` : 5분 GPS displacement < 10m AND no arvlcd train-progress.
+ * - `'unknown'`    : 보수적 보류. fire 허용하지 않음 (게이트 #2가 'moving'만 통과).
+ */
+export type MotionState = 'moving' | 'stationary' | 'unknown';
+
+/**
+ * 단일 motion evidence sample. T3 motion state machine이 ring buffer로 누적해 게이트 #2가
+ * 합의로 motionState를 결정한다. `signal`은 type별 가변 payload(예: gps displacement m,
+ * accel magnitude std)로 unknown — T2/T3가 type별 파싱.
+ */
+export interface MotionEvidence {
+  source: EvidenceSource;
+  ts: number;
+  signal: unknown;
+}
+
+/**
+ * Trip Position Single Source of Truth (ADR-017).
+ *
+ * 단일 trip의 위치/모션/사용자 의향 상태를 한 곳에 응집. fire path는 read-only로 본 SSOT
+ * 위 advance 결과만 보고 발사 결정.
+ */
+export interface TripPositionSSoT {
+  /** SSOT가 속한 trip token (APNs device token). */
+  tripToken: string;
+  /** 현재 device가 위치한다고 backend가 확신하는 stationId (또는 stationName 호환). */
+  currentStationId: string;
+  /** 게이트 #2 입력. T3 motion state machine이 갱신. */
+  motionState: MotionState;
+  /** T3가 누적하는 ring buffer (cap 50). 최신 evidence가 마지막 index. */
+  motionEvidence: MotionEvidence[];
+  /** 마지막 advance 발생 시각 (epoch ms). 미발생 시 0. */
+  lastAdvanceAt: number;
+  /** 마지막 advance를 통과시킨 evidence type. 미발생 시 `'time-only'` placeholder가 아닌 별도 표기 필요 없음 — `lastAdvanceAt===0`로 구분. */
+  lastAdvanceEvidence: EvidenceType;
+  /** 통과 확인된 station 누적 (S6 #1551 Trip.passedStations migration target). */
+  passedStations: string[];
+  /** C 토글 ON / boardingPrompt 응답 / BoardingTrainList tap. ADR-014 §사용자 명시 의향 trip. */
+  userIntentDeclared: boolean;
+  /** seed override 발생 횟수 (E5 강 신호 2개 + 30s 연속 일치로 currentStationId 정정 시 +1). */
+  seedOverrideCount: number;
+  /** schemaVersion. 향후 마이그레이션 분기용. v1 박제. */
+  schemaVersion: 1;
+}
+
+/** SSOT KV key 생성. */
+export function ssotKey(token: string): string {
+  return `${SSOT_PREFIX}${token}`;
+}
+
+/**
+ * SSOT read.
+ *
+ * `cacheTtl` 미지정 시 KV 기본(60s). caller가 명시할 때 `assertKvCacheTtl`로 floor 검증
+ * ([[lesson_cron_cachettl_runtime_constraint]]). cron 사이클에서 사용 시
+ * `CRON_READ_CACHE_TTL_SEC`(30s)을 명시.
+ *
+ * 손상된 JSON은 null 반환 (TTL로 자연 정리).
+ */
+export async function readSsot(
+  kv: KVNamespace,
+  token: string,
+  options?: { cacheTtl?: number },
+): Promise<TripPositionSSoT | null> {
+  assertKvCacheTtl(options?.cacheTtl);
+  const raw =
+    options?.cacheTtl !== undefined
+      ? await kv.get(ssotKey(token), { cacheTtl: options.cacheTtl })
+      : await kv.get(ssotKey(token));
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as TripPositionSSoT;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * SSOT write.
+ *
+ * `expiresAt` 옵션이 주어지면 그 시각까지(최소 SSOT_MIN_TTL_SEC) 보존. 미지정 시 KV 기본 TTL.
+ * trip lifecycle과 정합 — `putTrip`과 동일 패턴 (`trips.ts:42`).
+ */
+export async function writeSsot(
+  kv: KVNamespace,
+  ssot: TripPositionSSoT,
+  options?: { expiresAt?: number },
+): Promise<void> {
+  if (options?.expiresAt !== undefined) {
+    const ttlSec = Math.max(
+      SSOT_MIN_TTL_SEC,
+      Math.floor((options.expiresAt - Date.now()) / 1000),
+    );
+    await kv.put(ssotKey(ssot.tripToken), JSON.stringify(ssot), {
+      expirationTtl: ttlSec,
+    });
+    return;
+  }
+  await kv.put(ssotKey(ssot.tripToken), JSON.stringify(ssot));
+}
+
+/** SSOT delete (trip 종료 시 호출). */
+export async function deleteSsot(kv: KVNamespace, token: string): Promise<void> {
+  await kv.delete(ssotKey(token));
+}
+
+/**
+ * Seed — trip 등록 직후 SSOT 정착 (S1 GAP A backend 수신부).
+ *
+ * 새 SSOT를 생성해 KV에 write하고 반환. 이미 존재하면 덮어쓴다 (caller가 race 책임 — 본 PR
+ * 스코프 외, T2/T3에서 atomic 보장).
+ *
+ * motionState는 `'unknown'`으로 시작 — T3 motion state machine이 첫 GPS sample 수신 후 갱신.
+ * userIntentDeclared / seedOverrideCount는 false / 0.
+ */
+export async function seedSsot(
+  kv: KVNamespace,
+  token: string,
+  currentStationId: string,
+  options?: { expiresAt?: number; userIntentDeclared?: boolean },
+): Promise<TripPositionSSoT> {
+  const ssot: TripPositionSSoT = {
+    tripToken: token,
+    currentStationId,
+    motionState: 'unknown',
+    motionEvidence: [],
+    lastAdvanceAt: 0,
+    // T1 스코프에서 advance 미발생 상태 placeholder — `lastAdvanceAt===0` 동행으로 caller가 구분.
+    lastAdvanceEvidence: 'seed-override',
+    passedStations: [],
+    userIntentDeclared: options?.userIntentDeclared ?? false,
+    seedOverrideCount: 0,
+    schemaVersion: 1,
+  };
+  await writeSsot(kv, ssot, { expiresAt: options?.expiresAt });
+  return ssot;
+}
+
+/**
+ * Ring buffer push helper. 50건 초과 시 oldest FIFO eviction.
+ *
+ * 본 함수는 SSOT를 in-place mutate. caller가 write back 책임. T3 motion state machine이
+ * 매 `/position` 수신마다 호출하는 hot path.
+ */
+export function pushMotionEvidence(
+  ssot: TripPositionSSoT,
+  evidence: MotionEvidence,
+): void {
+  ssot.motionEvidence.push(evidence);
+  while (ssot.motionEvidence.length > MOTION_EVIDENCE_CAP) {
+    ssot.motionEvidence.shift();
+  }
+}
+
+/**
+ * S6 #1551 `Trip.passedStations` → SSOT.passedStations migration (read-only fallback).
+ *
+ * 본 helper는 SSOT.passedStations와 Trip.passedStations를 union해 SSOT 측에 반영한다.
+ * 본 PR(T1) 시점에는 advance가 여전히 `advanceBoardingLockWaypoint`(scheduled.ts)에서 일어나
+ * Trip.passedStations에만 stamp됨 — 본 helper가 양방향 호환을 보장한다.
+ *
+ * T7(#1560) 이후 advance 진입점이 단일화되어 Trip.passedStations stamp가 제거되면 본 helper도
+ * 함께 제거 예정.
+ *
+ * 본 함수는 SSOT를 in-place mutate. caller가 write back 책임.
+ */
+export function migrateTripPassedStationsToSsot(
+  trip: Pick<Trip, 'passedStations'>,
+  ssot: TripPositionSSoT,
+): void {
+  const tripPassed = trip.passedStations ?? [];
+  if (tripPassed.length === 0) return;
+  const known = new Set(ssot.passedStations);
+  for (const stationName of tripPassed) {
+    if (!known.has(stationName)) {
+      ssot.passedStations.push(stationName);
+      known.add(stationName);
+    }
+  }
+}
+
+/**
+ * Cron read의 SSOT cacheTtl 박제. T4~T8 reader migration에서 사용 예정.
+ *
+ * `CRON_READ_CACHE_TTL_SEC`(30s) 재export — `trips.ts:listTrips` 패턴과 정합.
+ */
+export const SSOT_CRON_READ_CACHE_TTL_SEC = CRON_READ_CACHE_TTL_SEC;

--- a/docs/decisions/ADR-017-trip-position-ssot.md
+++ b/docs/decisions/ADR-017-trip-position-ssot.md
@@ -1,0 +1,188 @@
+# ADR-017 — Backend Trip Position SSoT + 단일 advance 진입점
+
+## 상태
+
+Proposed (2026-06-20). Foundation: T1 (Sub #1554) 머지 후 T2~T8 차례 머지로 acceptance close.
+
+## 배경 — 분산 fire path 회귀
+
+2026-06-19 트립 evidence:
+- backend log `15:53:09 ~ 15:58:10` 매분 `arvlcd-fire: station-passed push` + `boarding-lock: waypoint advanced` 반복 (사용자 11분 정지)
+- 16:00:01 device가 `transfer imminent 건대입구` 잘못 받음
+- 사용자 보고: "정적 misfire 또. 저번에도 계속 수정한다고 했던 건데 왜 계속 이러냐"
+
+memory `project_2026_06_17_p01_epic_lockless_overfire_7day` 동일 회귀 7일 잔존. PR #1382 / #1386 / #1363 / #1408 모두 fail.
+
+### 근본 원인
+
+backend가 **fire 결정을 여러 path에서 독립 수행** → patch가 1개 path만 막고 다음 회귀가 다른 path로 샘:
+
+| Fire path | 현재 게이트 | 누락 |
+|---|---|---|
+| `scheduled.ts:795 evaluateArvlCdFireGate` | lock 활성 + arvlCd ARRIVED/ENTERING | motion, train identity, env |
+| `scheduled.ts:1525 advanceBoardingLockWaypoint` | (cron 호출 직후 무조건) | 합의 게이트 |
+| `scheduled.ts:1705 maybeReschedulePush` | 임계치 변동 | motion |
+| `boardingPrompt.ts:95 evaluateBoardingPromptGates` | 9-AND (GPS series 5개) | env 분기 |
+| `consensusGate.ts:107 evaluateConsensusGate` | env + signals | 호출자가 적용 안 함 |
+
+= **"lock 활성 = fire OK"라는 잘못된 동치**. lock은 fire의 전제일 뿐.
+
+## 결정
+
+### 원칙 1 — Single Source of Truth (`TripPositionSSoT`)
+
+trip별 단일 state row를 KV(`ssot:<token>`)에 보관. trip 위치/모션/사용자 의향을 분산 mutation에서 응집:
+
+```ts
+interface TripPositionSSoT {
+  tripToken: string;
+  currentStationId: string;
+  motionState: 'moving' | 'stationary' | 'unknown';
+  motionEvidence: Array<{ source: EvidenceSource; ts: number; signal: unknown }>;
+  lastAdvanceAt: number;
+  lastAdvanceEvidence: EvidenceType;
+  passedStations: string[];
+  userIntentDeclared: boolean; // C 토글 / boardingPrompt 응답 / BoardingTrainList tap
+  seedOverrideCount: number;
+  schemaVersion: 1;
+}
+```
+
+KV 정책:
+- prefix `ssot:`. row TTL은 trip lifecycle 정합 (`putTrip` 패턴, `trips.ts:42`).
+- `motionEvidence` ring buffer **50건 cap** (`MOTION_EVIDENCE_CAP`). 단일 row ≤5KB.
+- 모든 read는 `assertKvCacheTtl`로 Cloudflare KV runtime floor(30s) 강제 ([[lesson_cron_cachettl_runtime_constraint]]).
+
+### 원칙 2 — 단일 mutation 진입점 (T2 #1555)
+
+`advanceTripPosition(token, candidate, evidence, env): 'advanced' | 'blocked' | 'noop'`
+
+내부 6단 게이트 (위에서 거부되면 아래 안 봄):
+
+1. **Seed 게이트** — SSoT.currentStation 있어야 (S1 GAP A)
+2. **Motion 게이트** — `motionState !== 'stationary'`
+3. **Environment 게이트** — `evaluateConsensusGate(env, signals)` 통과
+4. **Evidence type 게이트** — `time-only` 거부 (ADR-015 E4 enforce)
+5. **Train identity 게이트** — lock 활성 시 arvlcd `btrainNo == lock.trainCode` (Seoul API `seoul.ts:165`)
+6. **Lockless arvlcd 단독 게이트** — lockless면 arvlcd 단독 advance X
+
+추가:
+- **Seed override (E5)** — 강 신호 2개 이상 + 30s 연속 일치 시 currentStationId 정정 (`seedOverrideCount++`)
+- **WiFi SSID evidence (E6)** — `subwayWifiSsidMap.json` 445/445 매핑 활용
+
+### 원칙 3 — fire path는 reader only
+
+기존 fire path 모두 `advanceTripPosition`을 통해서만 advance. advance 발생 시만 fire:
+
+```ts
+// Before (분산):
+const gate = evaluateArvlCdFireGate(lock, arvlCd, now);
+if (gate === 'fire') await fireArvlCdStationPush(...);
+await advanceBoardingLockWaypoint(...);
+
+// After (수렴):
+const result = await advanceTripPosition(token, candidate, { type: 'arvlcd', arvlcdTrainCode, lock }, env);
+if (result === 'advanced') await fireStationPassedPush(token, SSoT.currentStationId);
+```
+
+### 원칙 4 — Motion strict update (T3 #1556)
+
+`/position` POST 수신 시:
+- GPS displacement > 50m within 60s → `moving`
+- speed > 1m/s sustained → `moving`
+- 5분 동안 GPS displacement < 10m AND no arvlcd train-progress → `stationary`
+- 그 외 → `unknown` (보수적 보류)
+
+## Sub-task 매핑 (T1~T8)
+
+| Task | 내용 | 의존성 | 본 ADR 원칙 |
+|---|---|---|---|
+| **T1 #1554** | `TripPositionSSoT` 스키마 + KV helpers + 본 ADR doc | (선행 X) | 원칙 1 |
+| **T2 #1555** | `advanceTripPosition` + 6단 게이트 + seedOverride(E5) + WiFi evidence(E6) + train identity(E8) | T1 | 원칙 2 |
+| **T3 #1556** | Motion state machine (`/position` 수신부) | T1 | 원칙 4 |
+| **T4 #1557** | `arvlcdFire` → `advanceTripPosition` 호출로 refactor | T2, T3 | 원칙 3 |
+| **T5 #1558** | `advanceBoardingLockWaypoint` → 통합 | T2, T3 | 원칙 3 |
+| **T6 #1559** | `maybeReschedulePush` → SSoT ETA 사용 | T2 | 원칙 3 |
+| **T7 #1560** | transferImminent + destinationImminent → SSoT 도달 시만 | T2, T5 | 원칙 3 |
+| **T8 #1561** | silent push payload `currentStationId` 권위 필드 (S2 #1535 통합) + cascade picker contract | T2 | 원칙 1 |
+
+## T1 (본 PR) 스코프
+
+본 ADR foundation. **새 게이트 추가도, 다른 fire path 변경도 하지 않는다**:
+
+- `backend/alarm-worker/src/tripPositionSsot.ts` 신설:
+  - `TripPositionSSoT` + `EvidenceType` + `EvidenceSource` + `MotionEvidence` + `MotionState` 타입
+  - `readSsot` / `writeSsot` / `deleteSsot` KV CRUD
+  - `seedSsot()` — S1 GAP A 수신부
+  - `pushMotionEvidence()` — ring buffer 50건 cap helper
+  - `migrateTripPassedStationsToSsot()` — S6 #1551 read-only fallback (T7 이후 제거)
+  - `MOTION_EVIDENCE_CAP = 50` 상수
+  - `SSOT_CRON_READ_CACHE_TTL_SEC` (cron read 30s 박제)
+- 본 ADR doc
+
+후속 T2~T8이 본 SSOT 위에 게이트/머지/리더-only refactor를 쌓는다.
+
+## ADR-016과의 관계 (보완 / 의존성)
+
+ADR-017이 ADR-016을 대체하지 않음. backend 구조를 잡고 ADR-016 sub들이 그 구조 안에 채워짐:
+
+| ADR-016 sub | ADR-017 통합 |
+|---|---|
+| S1 #1534 GAP A | T1 SSoT.seed 데이터 필수 (`seedSsot`) |
+| S2 #1535 silent push currentStationId + cascade | **T8에 흡수** |
+| S3 #1536 9-AND gate env | T2 게이트 #3에 흡수 |
+| S4 #1537 realtimePosition 폴링 | T3에 evidence 공급 |
+| S5 #1538 pre-scheduled window | 그대로 (device-side) |
+| S6 #1539 → #1551 passedStations + cron jitter (머지됨) | T1 `migrateTripPassedStationsToSsot` → T7 이후 통합 |
+| S7~S13 | device-side / docs, ADR-017과 독립 |
+
+## Acceptance (close 조건 — 1주 실기기 + production 측정)
+
+### 양방향 시나리오 15건
+
+**Positive (fire 되어야 정상)**:
+- P1 lock active + moving + surface + arvlcd + trainCode 일치 → FIRE
+- P2 lock active + moving + underground + 다중 신호 → FIRE
+- P3 lockless + moving + (gps disp + cellular 변화 + arvlcd) → FIRE
+- P4 환승 waypoint 도달 + motion 확정 → transfer-imminent FIRE
+- P5 destination + motion 확정 → destination FIRE
+- P6 LA Interactive (trip 등록 즉시, lockless train 선택 UI)
+- P7 boardingPrompt (lockless + single candidate + moving)
+- P8 C 토글 ON / boardingPrompt 응답 → SSoT 통과 (lock 동급, ADR-014 § 사용자 명시 의향 trip)
+- P9 환승 후 새 line 새 lock → 새 hop fire 재개
+
+**Negative (fire 되면 안 됨)**:
+- N1 **정지 trip + lock active + arvlcd → BLOCK** (2026-06-19 회귀)
+- N2 정지 + lockless + arvlcd → BLOCK
+- N3 정지 + 어떤 evidence이든 → BLOCK
+- N4 moving but arvlcd train != lock.trainCode → BLOCK
+- N5 lockless + arvlcd 단독 → BLOCK
+- N6 underground + only-gps → BLOCK
+
+### Production 측정 (1주)
+
+1. wrong fire 0건 (오늘 같은 정지 transfer-imminent)
+2. lockless trip 첫 station miss ≤ 2
+3. cron 4.6s 이상치 / 동시 3중 race가 fire에 영향 0건
+4. SSoT.advance blocked 사유 분포 (Sentry breadcrumb)
+5. boardingPrompt + autoLock 발사율 (현재 0건 → 정상)
+6. 양방향 시나리오 15건 모두 1주 통과
+
+## 사용자 vision 매핑
+
+| 원칙 | SSoT 구현 |
+|---|---|
+| "정답은 backend가 안다" | SSoT가 backend 단일 SSOT |
+| "device는 받기만 한다" | silent push payload에 SSoT.currentStationId forward (T8) |
+| "GPS는 결정 권한 X" | gps 단독은 evidence 1개. 다른 신호 동의 필요 (게이트 #3) |
+| "시간 적분 fire 권한 박탈" | evidence='time-only' → 게이트 #4 거부 |
+| "사용자 명시 의향 trip = lock 동급" | userIntentDeclared=true → lock 활성과 동치 |
+| "alarm ≠ notification" | SSoT.advance = alarm 결정. notification은 device 측 banner |
+| "한 번 lock 잡으면 X" | 강 신호 2개 + 30s → seedOverride |
+
+## 참고
+
+- Epic #1553
+- 회귀 history: memory `project_2026_06_17_p01_epic_lockless_overfire_7day`
+- 선행 ADR: ADR-013 (lockless supplementation), ADR-014 (decision process), ADR-015 (multi-signal consensus gate)
+- KV runtime 제약: memory `lesson_cron_cachettl_runtime_constraint` + `backend/alarm-worker/src/kvConsistency.ts`


### PR DESCRIPTION
Closes #1554. Part of Epic #1553 (ADR-017).

## Summary
ADR-017 foundation. T2~T8 sub-task 모두 본 PR에 의존. **본 T1 자체는 새 게이트 추가도, 다른 fire path 변경도 하지 않는다** — 스키마 + KV helpers + 문서만.

## 변경 사항
- `backend/alarm-worker/src/tripPositionSsot.ts` 신설
  - `TripPositionSSoT` + 보조 type (`EvidenceType` / `EvidenceSource` / `MotionEvidence` / `MotionState`)
  - `readSsot` / `writeSsot` / `deleteSsot` KV CRUD (key prefix `ssot:<token>`)
  - `seedSsot()` — S1 GAP A 수신부 (motionState='unknown', passedStations=[], schemaVersion=1)
  - `pushMotionEvidence()` — ring buffer `MOTION_EVIDENCE_CAP=50`, FIFO eviction
  - `migrateTripPassedStationsToSsot()` — S6 #1551 read-only fallback (T7 이후 제거 예정)
  - `SSOT_CRON_READ_CACHE_TTL_SEC` (30s 박제, [[lesson_cron_cachettl_runtime_constraint]])
- `docs/decisions/ADR-017-trip-position-ssot.md` 신설
  - 4원칙 (SSOT / 단일 진입점 / reader only / motion strict update)
  - Sub-task T1~T8 매핑 + ADR-016 통합 표
  - 양방향 acceptance 15건 (Positive 9 + Negative 6)
- `tripPositionSsot.test.ts` 23건 (round-trip, ring buffer cap, seed, cacheTtl floor, migrate dedup)

## Acceptance 매핑 (T1)
- writeSsot → readSsot 동등성 (round-trip) — `round-trip: writeSsot → readSsot` test
- 51건 push 시 motionEvidence.length === 50 (FIFO) — `51건 push: cap 유지 + oldest FIFO eviction` test
- deleteSsot 후 read는 null — `deleteSsot: 삭제 후 read는 null` test
- seedSsot 후 currentStationId 정상 + motionState='unknown' + passedStations=[] — `seedSsot: 호출 후 SSOT 정상 생성` test
- cacheTtl<30 throw RangeError — `readSsot: cacheTtl < 30 throw RangeError` test
- migrateTripPassedStationsToSsot 양방향 호환 (dedup + 순서 보존) — 5건 test

## Test plan
- [x] `backend/alarm-worker` 전체 vitest 통과 (1548 tests)
- [x] tripPositionSsot.test.ts 23/23 통과
- [x] type-check (신규 파일 0 errors; pre-existing scheduled.test.ts 5건은 본 PR 무관)
- [ ] 후속 T2 #1555가 본 SSOT 위 `advanceTripPosition` 6단 게이트 구현
- [ ] 후속 T3 #1556이 motion state machine 구현

## 의존성
- 선행: 없음 (ADR-017 foundation)
- 후행: #1555, #1556, #1557, #1558, #1559, #1560, #1561

## 참고
- Epic #1553 (ADR-017)
- memory `lesson_cron_cachettl_runtime_constraint` — Cloudflare KV cacheTtl<30 runtime throw
- memory `project_2026_06_17_p01_epic_lockless_overfire_7day` — 회귀 history