### PR TITLE
feat(#1556): Motion state machine on POST /position (Epic #1553)

### DIFF
--- a/backend/alarm-worker/src/__tests__/motionState.test.ts
+++ b/backend/alarm-worker/src/__tests__/motionState.test.ts
@@ -1,0 +1,415 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MOTION_MIN_SAMPLES,
+  MOTION_WINDOW_MS,
+  computeMotionState,
+  emitMotionTransitionBreadcrumb,
+  hasArvlcdTrainProgress,
+  maxDisplacementMeters,
+  updateSsotMotion,
+} from '../motionState';
+import {
+  seedSsot,
+  readSsot,
+  writeSsot,
+  type MotionEvidence,
+  type TripPositionSSoT,
+} from '../tripPositionSsot';
+import type { PositionPoint } from '../types';
+import { InMemoryKV } from './inMemoryKv';
+
+/**
+ * Sub #1556 / T3 — Motion state machine acceptance.
+ *
+ * - it.each 6 양방향 시나리오 (issue 본문 보강 섹션 그대로)
+ * - maxDisplacementMeters: pair-wise haversine max
+ * - hasArvlcdTrainProgress: source/stationId 분포 카운트
+ * - updateSsotMotion: SSOT 없으면 no-op, evidence push, breadcrumb emit, write back
+ * - emitMotionTransitionBreadcrumb: from===to no-op + PII-free 출력
+ */
+
+function makeSsot(overrides?: Partial<TripPositionSSoT>): TripPositionSSoT {
+  return {
+    tripToken: 'tok-test',
+    currentStationId: '0228',
+    motionState: 'unknown',
+    motionEvidence: [],
+    lastAdvanceAt: 0,
+    lastAdvanceEvidence: 'seed-override',
+    passedStations: [],
+    userIntentDeclared: false,
+    seedOverrideCount: 0,
+    schemaVersion: 1,
+    ...overrides,
+  };
+}
+
+function makePosition(overrides?: Partial<PositionPoint>): PositionPoint {
+  return {
+    lat: 37.5,
+    lng: 127.0,
+    accuracy: 10,
+    ts: 1_000_000,
+    motion: 'unknown',
+    ...overrides,
+  };
+}
+
+/**
+ * 위도 37.5에서 1m ≈ 9e-6 도 (대략) — 본 단위는 displacement 시나리오 작성용.
+ *
+ * 정확도가 필요한 곳은 직접 haversineKm로 검증. 본 helper는 evidence 합성 편의용.
+ */
+function gpsEvidence(
+  lat: number,
+  lng: number,
+  ts: number,
+  motion: PositionPoint['motion'] = 'unknown',
+): MotionEvidence {
+  return {
+    source: 'device-position',
+    ts,
+    signal: { lat, lng, motion },
+  };
+}
+
+function arvlcdEvidence(stationId: string, ts: number): MotionEvidence {
+  return {
+    source: 'seoul-arvlcd',
+    ts,
+    signal: { stationId },
+  };
+}
+
+describe('maxDisplacementMeters', () => {
+  it('0~1 sample → 0 반환 (변위 측정 불가)', () => {
+    expect(maxDisplacementMeters([])).toBe(0);
+    expect(maxDisplacementMeters([gpsEvidence(37.5, 127.0, 1)])).toBe(0);
+  });
+
+  it('non device-position source는 제외', () => {
+    const evidence = [
+      arvlcdEvidence('0228', 1),
+      arvlcdEvidence('0229', 2),
+    ];
+    expect(maxDisplacementMeters(evidence)).toBe(0);
+  });
+
+  it('signal payload가 lat/lng 결여 시 graceful skip', () => {
+    const bad: MotionEvidence[] = [
+      { source: 'device-position', ts: 1, signal: null },
+      { source: 'device-position', ts: 2, signal: 'string-not-obj' },
+      { source: 'device-position', ts: 3, signal: { lat: 37.5 } },
+      { source: 'device-position', ts: 4, signal: { lat: 'x', lng: 127.0 } },
+      { source: 'device-position', ts: 5, signal: { lat: NaN, lng: 127.0 } },
+    ];
+    expect(maxDisplacementMeters(bad)).toBe(0);
+  });
+
+  it('2건 이상 좌표 → pair-wise max displacement (m)', () => {
+    // 위도 37.5, 경도 0.0001 차이 ≈ 8.8m
+    const evidence = [
+      gpsEvidence(37.5, 127.0, 1),
+      gpsEvidence(37.5, 127.0001, 2),
+      gpsEvidence(37.5, 127.0, 3),
+    ];
+    const d = maxDisplacementMeters(evidence);
+    expect(d).toBeGreaterThan(5);
+    expect(d).toBeLessThan(15);
+  });
+
+  it('윈도우 내 가장 먼 한 쌍을 선택 (pair-wise max)', () => {
+    const evidence = [
+      gpsEvidence(37.5, 127.0, 1),
+      gpsEvidence(37.5, 127.0001, 2), // ~8.8m from base
+      gpsEvidence(37.5, 127.001, 3), // ~88m from base
+    ];
+    const d = maxDisplacementMeters(evidence);
+    expect(d).toBeGreaterThan(80);
+    expect(d).toBeLessThan(100);
+  });
+});
+
+describe('hasArvlcdTrainProgress', () => {
+  it('arvlcd evidence 없으면 false', () => {
+    const ssot = makeSsot();
+    expect(hasArvlcdTrainProgress(ssot, 0)).toBe(false);
+  });
+
+  it('같은 stationId 여러 건은 progress 아님', () => {
+    const ssot = makeSsot({
+      motionEvidence: [
+        arvlcdEvidence('0228', 10),
+        arvlcdEvidence('0228', 20),
+        arvlcdEvidence('0228', 30),
+      ],
+    });
+    expect(hasArvlcdTrainProgress(ssot, 0)).toBe(false);
+  });
+
+  it('다른 stationId 2건 이상 → progress (true)', () => {
+    const ssot = makeSsot({
+      motionEvidence: [
+        arvlcdEvidence('0228', 10),
+        arvlcdEvidence('0229', 20),
+      ],
+    });
+    expect(hasArvlcdTrainProgress(ssot, 0)).toBe(true);
+  });
+
+  it('sinceMs 이전 evidence는 무시', () => {
+    const ssot = makeSsot({
+      motionEvidence: [
+        arvlcdEvidence('0228', 10),
+        arvlcdEvidence('0229', 20),
+      ],
+    });
+    expect(hasArvlcdTrainProgress(ssot, 100)).toBe(false);
+  });
+
+  it('non-arvlcd source는 무시', () => {
+    const ssot = makeSsot({
+      motionEvidence: [
+        gpsEvidence(37.5, 127.0, 10),
+        gpsEvidence(37.6, 128.0, 20),
+      ],
+    });
+    expect(hasArvlcdTrainProgress(ssot, 0)).toBe(false);
+  });
+
+  it('signal payload 결함 sample은 graceful skip', () => {
+    const ssot = makeSsot({
+      motionEvidence: [
+        { source: 'seoul-arvlcd', ts: 10, signal: null },
+        { source: 'seoul-arvlcd', ts: 11, signal: 'str' },
+        { source: 'seoul-arvlcd', ts: 12, signal: {} },
+        { source: 'seoul-arvlcd', ts: 13, signal: { stationId: 123 } },
+        { source: 'seoul-arvlcd', ts: 14, signal: { stationId: '' } },
+        arvlcdEvidence('0228', 15),
+      ],
+    });
+    // 유효 stationId 1개 → false
+    expect(hasArvlcdTrainProgress(ssot, 0)).toBe(false);
+  });
+});
+
+describe('computeMotionState — 보강 섹션 6 양방향 시나리오 (it.each)', () => {
+  const now = 1_000_000;
+  const baseSamples = (count: number, displacementM: number): MotionEvidence[] => {
+    // count 개 sample 생성 — 첫번째와 마지막이 약 displacementM 떨어진 좌표.
+    // 위도 변화로 displacement 부여 — 위도 1° ≈ 111,320m. 1m ≈ 8.98e-6 deg.
+    // 안전 마진 위해 displacement 1.5배 부여 (haversine pair-wise max는 약간 더 큰 값 산출).
+    const degPerM = 1 / 111_320;
+    const result: MotionEvidence[] = [];
+    for (let i = 0; i < count; i++) {
+      const latOffset = (i === count - 1 ? displacementM : 0) * degPerM;
+      result.push(gpsEvidence(37.5 + latOffset, 127.0, now - MOTION_WINDOW_MS + i * 1000));
+    }
+    return result;
+  };
+
+  const scenarios = [
+    {
+      name: 'device walking → moving (즉시)',
+      deviceMotion: 'walking' as const,
+      samples: 0,
+      displacement: 0,
+      arvlcdProgress: false,
+      expected: 'moving' as const,
+    },
+    {
+      name: 'device stationary → stationary (즉시)',
+      deviceMotion: 'stationary' as const,
+      samples: 0,
+      displacement: 0,
+      arvlcdProgress: false,
+      expected: 'stationary' as const,
+    },
+    {
+      name: 'unknown + 10 samples + displ <10m + no progress → stationary',
+      deviceMotion: 'unknown' as const,
+      samples: 10,
+      displacement: 5,
+      arvlcdProgress: false,
+      expected: 'stationary' as const,
+    },
+    {
+      name: 'unknown + 10 samples + displ <10m + arvlcd progress → unknown (보수)',
+      deviceMotion: 'unknown' as const,
+      samples: 10,
+      displacement: 5,
+      arvlcdProgress: true,
+      expected: 'unknown' as const,
+    },
+    {
+      name: 'unknown + displ >50m → moving',
+      deviceMotion: 'unknown' as const,
+      samples: 10,
+      displacement: 60,
+      arvlcdProgress: false,
+      expected: 'moving' as const,
+    },
+    {
+      name: 'unknown + 9 samples (부족) → unknown',
+      deviceMotion: 'unknown' as const,
+      samples: 9,
+      displacement: 5,
+      arvlcdProgress: false,
+      expected: 'unknown' as const,
+    },
+  ];
+
+  it.each(scenarios)('$name', ({ deviceMotion, samples, displacement, arvlcdProgress, expected }) => {
+    const evidence = baseSamples(samples, displacement);
+    if (arvlcdProgress) {
+      evidence.push(arvlcdEvidence('0228', now - MOTION_WINDOW_MS + 1000));
+      evidence.push(arvlcdEvidence('0229', now - MOTION_WINDOW_MS + 2000));
+    }
+    const ssot = makeSsot({ motionEvidence: evidence });
+    const pos = makePosition({ motion: deviceMotion, ts: now });
+    expect(computeMotionState(ssot, pos, now)).toBe(expected);
+  });
+
+  it('unknown + samples >= MIN + displacement 중간(10~50m) → unknown 보수 폴백', () => {
+    const evidence = baseSamples(MOTION_MIN_SAMPLES, 25);
+    const ssot = makeSsot({ motionEvidence: evidence });
+    const pos = makePosition({ motion: 'unknown', ts: now });
+    expect(computeMotionState(ssot, pos, now)).toBe('unknown');
+  });
+
+  it('automotive device motion → moving', () => {
+    const ssot = makeSsot();
+    const pos = makePosition({ motion: 'automotive', ts: now });
+    expect(computeMotionState(ssot, pos, now)).toBe('moving');
+  });
+
+  it('윈도우 밖 sample은 판정 입력에서 제외 (5분 경계)', () => {
+    // 11개 sample 중 1개만 윈도우 밖 — 윈도우 안은 10개 충족
+    const oldSample = gpsEvidence(37.5, 127.0, now - MOTION_WINDOW_MS - 1000);
+    const inWindow: MotionEvidence[] = [];
+    for (let i = 0; i < MOTION_MIN_SAMPLES; i++) {
+      inWindow.push(gpsEvidence(37.5, 127.0, now - MOTION_WINDOW_MS + 1000 + i * 100));
+    }
+    const ssot = makeSsot({ motionEvidence: [oldSample, ...inWindow] });
+    const pos = makePosition({ motion: 'unknown', ts: now });
+    // 윈도우 내 10건 displacement=0 → stationary
+    expect(computeMotionState(ssot, pos, now)).toBe('stationary');
+  });
+});
+
+describe('emitMotionTransitionBreadcrumb', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('from === to → no-op (transition 없음)', () => {
+    emitMotionTransitionBreadcrumb('moving', 'moving');
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('전환 시 라벨만 emit (PII 금지)', () => {
+    emitMotionTransitionBreadcrumb('unknown', 'stationary');
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const [tag, payload] = logSpy.mock.calls[0];
+    expect(tag).toBe('[motion-transition]');
+    expect(payload).toBe(JSON.stringify({ from: 'unknown', to: 'stationary' }));
+    // PII 가드 — 좌표/displacement 키 절대 포함 X
+    expect(payload as string).not.toContain('lat');
+    expect(payload as string).not.toContain('lng');
+    expect(payload as string).not.toContain('displacement');
+  });
+});
+
+describe('updateSsotMotion — POST /position 수신 path', () => {
+  let kv: InMemoryKV;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    kv = new InMemoryKV();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('SSOT 부재 시 null 반환 (no-op — trip 미등록 device)', async () => {
+    const pos = makePosition();
+    const result = await updateSsotMotion(
+      kv as unknown as KVNamespace,
+      'unknown-token',
+      pos,
+      1_000_000,
+    );
+    expect(result).toBeNull();
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('device walking → SSOT.motionState=moving + evidence push + breadcrumb', async () => {
+    await seedSsot(kv as unknown as KVNamespace, 'tok-1', '0228');
+    const pos = makePosition({ motion: 'walking', ts: 1_000_000 });
+    const result = await updateSsotMotion(
+      kv as unknown as KVNamespace,
+      'tok-1',
+      pos,
+      1_000_000,
+    );
+    expect(result?.motionState).toBe('moving');
+    expect(result?.motionEvidence).toHaveLength(1);
+    expect(result?.motionEvidence[0].source).toBe('device-position');
+    expect(logSpy).toHaveBeenCalledWith(
+      '[motion-transition]',
+      JSON.stringify({ from: 'unknown', to: 'moving' }),
+    );
+    // KV에 write 됐는지 확인
+    const persisted = await readSsot(kv as unknown as KVNamespace, 'tok-1');
+    expect(persisted?.motionState).toBe('moving');
+    expect(persisted?.motionEvidence).toHaveLength(1);
+  });
+
+  it('state 유지(전환 없음) → breadcrumb emit 없음', async () => {
+    const ssot = makeSsot({ tripToken: 'tok-2', motionState: 'moving' });
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    const pos = makePosition({ motion: 'walking', ts: 1_000_000 });
+    const result = await updateSsotMotion(
+      kv as unknown as KVNamespace,
+      'tok-2',
+      pos,
+      1_000_000,
+    );
+    expect(result?.motionState).toBe('moving');
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('device unknown + GPS samples 누적 후 stationary 전환', async () => {
+    // 이미 9 sample 누적된 SSOT (윈도우 내). 10번째 sample push 후 평가.
+    const now = 1_000_000;
+    const existing: MotionEvidence[] = [];
+    for (let i = 0; i < 9; i++) {
+      existing.push(gpsEvidence(37.5, 127.0, now - MOTION_WINDOW_MS + i * 1000));
+    }
+    const ssot = makeSsot({
+      tripToken: 'tok-3',
+      motionState: 'moving',
+      motionEvidence: existing,
+    });
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    const pos = makePosition({ lat: 37.5, lng: 127.0, motion: 'unknown', ts: now });
+    const result = await updateSsotMotion(
+      kv as unknown as KVNamespace,
+      'tok-3',
+      pos,
+      now,
+    );
+    expect(result?.motionEvidence).toHaveLength(10);
+    expect(result?.motionState).toBe('stationary');
+    expect(logSpy).toHaveBeenCalledWith(
+      '[motion-transition]',
+      JSON.stringify({ from: 'moving', to: 'stationary' }),
+    );
+  });
+});

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -42,6 +42,7 @@ import {
 import { ackPending, stampReceived } from './pendingPushes';
 import { appendPositionPoint } from './positionSeries';
 import { appendAccelSample, isAccelSummary } from './accelSeries';
+import { updateSsotMotion } from './motionState';
 import { deleteProgress, getProgress, putProgress, type TripProgress } from './progress';
 import { SeoulArrivalClient } from './seoul';
 import { runScheduled } from './scheduled';
@@ -888,6 +889,9 @@ app.post('/position', async (c) => {
   if (payload.accelSummary) {
     await appendAccelSample(c.env.TRIPS, payload.token, payload.accelSummary);
   }
+  // #1556 (T3) — SSOT.motionState 갱신. SSOT 부재(trip 미등록) 시 graceful no-op.
+  // T2 advanceTripPosition 게이트 #2가 본 motionState='stationary'를 차단 입력으로 사용한다.
+  await updateSsotMotion(c.env.TRIPS, payload.token, payload.point, Date.now());
   return c.json({ ok: true });
 });
 

--- a/backend/alarm-worker/src/motionState.ts
+++ b/backend/alarm-worker/src/motionState.ts
@@ -1,0 +1,199 @@
+/**
+ * Motion state machine — ADR-017 Sub #1556 / T3.
+ *
+ * 배경
+ * ====
+ * 2026-06-19 회귀: 사용자가 11분 정지 상태였으나 SSOT.motionState가 갱신되지 않아 T2
+ * advanceTripPosition 게이트 #2(`motionState=='stationary'` 차단)가 작동 못해 wrong advance
+ * fire. T3는 POST /position 수신 시 SSOT.motionState를 정확히 판정/누적해 게이트 #2의 입력을
+ * 제공한다.
+ *
+ * 알고리즘 (issue #1556 보강 섹션)
+ * ================================
+ * 1. device explicit motion(walking/automotive) → 'moving' 즉시
+ * 2. device explicit 'stationary' → 'stationary' 즉시 (보수적 판정 안 함 — 사용자 의도 신뢰)
+ * 3. device 'unknown' → backend가 GPS displacement 5분 윈도우로 판정
+ *    - sample 10건 미만 → 'unknown' (샘플 부족)
+ *    - displacement < 10m AND no arvlcd train-progress → 'stationary'
+ *    - displacement < 10m AND arvlcd train-progress → 'unknown' (이동 가능성, 보수)
+ *    - displacement > 50m → 'moving'
+ *    - 그 사이 (10~50m) → 'unknown' (애매 구간 보수)
+ *
+ * [[lesson_motion_activity_intermittent_signal]] — iOS CMMotionActivity가 5~10분 주기로 뒤집힐 수
+ * 있으나 본 T3는 backend single-update path이므로 매 /position 수신마다 device 신호를 그대로
+ * 반영한다. 합의는 T2 게이트 #2가 motionState 1회 stationary로 판정 시 즉시 차단하지 않고
+ * (T2 책임 — 여러 cron 사이클 연속 stationary 등) 1차 입력만 제공.
+ *
+ * 본 T3는 motion 판정 + SSOT 업데이트만. fire path 변경 X.
+ */
+
+import {
+  pushMotionEvidence,
+  readSsot,
+  writeSsot,
+  type MotionEvidence,
+  type MotionState,
+  type TripPositionSSoT,
+} from './tripPositionSsot';
+import { haversineKm } from './positionSeries';
+import type { PositionPoint } from './types';
+
+/** GPS displacement 평가 윈도우 (ms). 5분. */
+export const MOTION_WINDOW_MS = 5 * 60_000;
+
+/** unknown→stationary 판정에 필요한 최소 GPS sample 수. */
+export const MOTION_MIN_SAMPLES = 10;
+
+/** stationary 판정 GPS displacement 상한 (meters). */
+export const MOTION_STATIONARY_DISPLACEMENT_M = 10;
+
+/** moving 판정 GPS displacement 하한 (meters). */
+export const MOTION_MOVING_DISPLACEMENT_M = 50;
+
+/**
+ * SSOT.motionEvidence 중 'device-position' source의 GPS sample 쌍 최대 displacement (m).
+ *
+ * signal payload는 `{ lat: number; lng: number; ... }` 형태로 stamp되어 들어온다고 가정 —
+ * 형식 불일치 sample은 graceful skip.
+ *
+ * sample 0~1건이면 0 반환 (변위 측정 불가).
+ */
+export function maxDisplacementMeters(samples: readonly MotionEvidence[]): number {
+  const coords: Array<{ lat: number; lng: number }> = [];
+  for (const s of samples) {
+    if (s.source !== 'device-position') continue;
+    const sig = s.signal;
+    if (!sig || typeof sig !== 'object') continue;
+    const o = sig as Record<string, unknown>;
+    if (typeof o.lat !== 'number' || typeof o.lng !== 'number') continue;
+    if (!Number.isFinite(o.lat) || !Number.isFinite(o.lng)) continue;
+    coords.push({ lat: o.lat, lng: o.lng });
+  }
+  if (coords.length < 2) return 0;
+  // 모든 쌍 거리의 max — 윈도우 내 가장 멀리 움직인 거리.
+  let maxKm = 0;
+  for (let i = 0; i < coords.length; i++) {
+    for (let j = i + 1; j < coords.length; j++) {
+      const d = haversineKm(coords[i].lat, coords[i].lng, coords[j].lat, coords[j].lng);
+      if (d > maxKm) maxKm = d;
+    }
+  }
+  return maxKm * 1000;
+}
+
+/**
+ * 같은 line 내 다른 station을 진행 중인 arvlcd evidence가 sinceMs 이후 2건 이상이면 true.
+ *
+ * SSOT.motionEvidence 중 `source === 'seoul-arvlcd'`인 sample의 `signal.stationId`가
+ * 2가지 이상이면 train progress로 판단. 사용자가 정지 GPS 상태에서도 실제로는 탑승해 다른 역을
+ * 지나치는 케이스를 보수적으로 'unknown' 유지하기 위함.
+ */
+export function hasArvlcdTrainProgress(
+  ssot: TripPositionSSoT,
+  sinceMs: number,
+): boolean {
+  const stationIds = new Set<string>();
+  for (const e of ssot.motionEvidence) {
+    if (e.ts < sinceMs) continue;
+    if (e.source !== 'seoul-arvlcd') continue;
+    const sig = e.signal;
+    if (!sig || typeof sig !== 'object') continue;
+    const o = sig as Record<string, unknown>;
+    if (typeof o.stationId !== 'string' || o.stationId.length === 0) continue;
+    stationIds.add(o.stationId);
+    if (stationIds.size >= 2) return true;
+  }
+  return false;
+}
+
+/**
+ * 5단 판정 — 보강 섹션 알고리즘 그대로.
+ *
+ * 호출 시점: POST /position 수신 + SSOT 업데이트 직전.
+ */
+export function computeMotionState(
+  ssot: TripPositionSSoT,
+  devicePosition: PositionPoint,
+  now: number,
+): MotionState {
+  // 1. device explicit moving 신호 (CMMotionActivity walking/automotive)
+  if (devicePosition.motion === 'walking' || devicePosition.motion === 'automotive') {
+    return 'moving';
+  }
+  // 2. device explicit stationary — 즉시 stationary (사용자 의도 신뢰)
+  if (devicePosition.motion === 'stationary') {
+    return 'stationary';
+  }
+  // 3. device 'unknown' → GPS displacement 윈도우 판정
+  const sinceMs = now - MOTION_WINDOW_MS;
+  const recentGps = ssot.motionEvidence.filter(
+    (e) => e.ts >= sinceMs && e.source === 'device-position',
+  );
+  if (recentGps.length < MOTION_MIN_SAMPLES) return 'unknown';
+
+  const displacement = maxDisplacementMeters(recentGps);
+  if (displacement < MOTION_STATIONARY_DISPLACEMENT_M) {
+    if (hasArvlcdTrainProgress(ssot, sinceMs)) return 'unknown';
+    return 'stationary';
+  }
+  if (displacement > MOTION_MOVING_DISPLACEMENT_M) return 'moving';
+  return 'unknown';
+}
+
+/**
+ * Motion transition breadcrumb 출력 — PII 금지 (라벨만).
+ *
+ * Workers 환경에 Sentry SDK 직접 통합은 없으므로 `console.log`로 emit (`wrangler tail`로 수집).
+ * S13 외부 breadcrumb 인프라가 도입되면 본 함수만 교체.
+ *
+ * `from === to`이면 no-op (transition 아님).
+ */
+export function emitMotionTransitionBreadcrumb(
+  from: MotionState,
+  to: MotionState,
+): void {
+  if (from === to) return;
+  // PII 금지: 좌표/displacement 값은 절대 포함하지 않는다.
+  console.log('[motion-transition]', JSON.stringify({ from, to }));
+}
+
+/**
+ * POST /position handler가 호출하는 SSOT motion 업데이트 진입점.
+ *
+ * 1. SSOT read (없으면 no-op — trip 미등록 device의 /position은 series만 누적, T3 입력 없음)
+ * 2. device-position evidence push (ring buffer, T1 helper)
+ * 3. computeMotionState로 새 state 판정
+ * 4. state 전환 시 breadcrumb emit + SSOT.motionState 갱신
+ * 5. SSOT write back (last-write-wins — T2와 동일 race 정책)
+ *
+ * 호출자가 await로 보장해야 BG cron이 새 state를 읽는다. SSOT 부재 시 fast-return.
+ */
+export async function updateSsotMotion(
+  kv: KVNamespace,
+  token: string,
+  position: PositionPoint,
+  now: number,
+): Promise<TripPositionSSoT | null> {
+  const ssot = await readSsot(kv, token);
+  if (!ssot) return null;
+
+  // device GPS sample을 evidence로 누적 (signal은 후속 maxDisplacementMeters가 lat/lng 추출).
+  pushMotionEvidence(ssot, {
+    source: 'device-position',
+    ts: position.ts,
+    signal: {
+      lat: position.lat,
+      lng: position.lng,
+      motion: position.motion,
+    },
+  });
+
+  const next = computeMotionState(ssot, position, now);
+  if (next !== ssot.motionState) {
+    emitMotionTransitionBreadcrumb(ssot.motionState, next);
+    ssot.motionState = next;
+  }
+
+  await writeSsot(kv, ssot);
+  return ssot;
+}


### PR DESCRIPTION
Closes #1556. ADR-017 Epic #1553의 T3 — Motion state machine.

**T1 #1562 의존 (stacked PR).** base = `feat/#1554-trip-position-ssot-foundation`.

## 변경 요약

- `backend/alarm-worker/src/motionState.ts` 신규 — 보강 섹션 알고리즘 그대로:
  - `computeMotionState()` — 5단 판정 (device explicit walking/automotive → moving, stationary → stationary 즉시, unknown → 5분 GPS displacement 윈도우 평가)
  - `maxDisplacementMeters()` — SSOT.motionEvidence의 device-position sample pair-wise haversine max
  - `hasArvlcdTrainProgress()` — 같은 line 다른 stationId arvlcd evidence 2건 이상이면 train progress (정지 GPS에서도 'unknown' 보수 유지)
  - `emitMotionTransitionBreadcrumb()` — PII-free 라벨만(`{from, to}`), 좌표/displacement 절대 미포함. `console.log('[motion-transition]', ...)` (wrangler tail로 수집)
  - `updateSsotMotion()` — POST /position 호출 path. SSOT 부재 시 graceful no-op, evidence push (T1 ring buffer 50 cap) + state 전환 시 breadcrumb emit + write back (last-write-wins, T2 정합)

- `backend/alarm-worker/src/index.ts` POST /position handler 끝부분에 `updateSsotMotion(...)` 호출 wiring (기존 `appendPositionPoint`/`appendAccelSample` 뒤).

## acceptance — 6 양방향 시나리오 통과

vitest `it.each`로 issue 본문 motionScenarios 그대로 통과:

| 시나리오 | 결과 |
| --- | --- |
| device walking → moving | ✓ |
| device stationary → stationary | ✓ |
| unknown 10 samples + displ <10m + no progress → stationary | ✓ |
| unknown 10 samples + displ <10m + arvlcd progress → unknown (보수) | ✓ |
| unknown + displ >50m → moving | ✓ |
| unknown 9 samples (부족) → unknown | ✓ |

추가 가드: 중간 displacement(10~50m) → unknown 폴백 / automotive → moving / 윈도우 밖 sample 제외 / breadcrumb PII 가드.

## 회귀 가드

- SSOT 부재 시 graceful no-op — 기존 trip-미등록 device의 /position이 회귀 없이 유지
- POST /position 기존 1574 backend tests 모두 green (40/40 file). `appendPositionPoint`/`accelSummary` 분기 동작 변경 X
- 본 T3는 motion 판정 + SSoT 업데이트만. fire path / advance 게이트 변경 X (T2가 소비)

## 검증
- [x] `npx vitest run src/__tests__/motionState.test.ts` — 26/26 green
- [x] `npx vitest run` (전체 backend) — 1574/1574 green
- [x] `npx tsc --noEmit` — 신규 코드 오류 0 (scheduled.test.ts의 pre-existing tuple drift는 본 PR 범위 외)

## 의존성

- 선행: T1 #1562 (base branch)
- 후행: T2 advanceTripPosition (게이트 #2가 본 motionState='stationary' 소비), T4~T8