### PR TITLE
feat(#1555): advanceTripPosition + 6단 게이트 + seedOverride + WiFi/train identity (Epic #1553)

### DIFF
--- a/backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts
+++ b/backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts
@@ -1,0 +1,616 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  STRONG_EVIDENCE_TYPES,
+  advanceTripPosition,
+  buildSignalsFromEvidence,
+  consecutiveDurationMs,
+  countStrongEvidence,
+  lookupStationFromWifiSsid,
+  mapEvidenceEnvironment,
+  trySeedOverride,
+  type AdvanceBlockReason,
+  type AdvanceEvidence,
+  type AdvanceResult,
+  type AdvanceStats,
+  type WifiSsidEntry,
+} from '../advanceTripPosition';
+import { readSsot, seedSsot, writeSsot, type MotionEvidence } from '../tripPositionSsot';
+import { putTrip } from '../trips';
+import type { BoardingLockMeta, Trip } from '../types';
+import { InMemoryKV } from './inMemoryKv';
+
+/**
+ * Sub #1555 / T2 — advanceTripPosition 6단 게이트 + seedOverride + WiFi/train identity acceptance.
+ *
+ * 양방향 시나리오(Positive 3 + Negative 6)를 it.each 패턴으로 박제 ([[lesson_sonarcloud_dup_prevention]]).
+ * 각 시나리오는 본문 acceptance 매핑과 1:1.
+ */
+
+const TOKEN = 'tok-advance-test';
+const NOW = 1_750_000_000_000;
+
+function makeTrip(overrides?: Partial<Trip>): Trip {
+  return {
+    token: TOKEN,
+    route: { type: 'direct', stops: 3, line: '7' },
+    destination: '신도림',
+    waypoints: [{ stationName: '중곡', line: '7', kind: 'intermediate' }],
+    expiresAt: NOW + 60 * 60_000,
+    createdAt: NOW,
+    alarmAtEpochMs: NOW + 30 * 60_000,
+    ...overrides,
+  };
+}
+
+function makeLock(overrides?: Partial<BoardingLockMeta>): BoardingLockMeta {
+  return {
+    trainCode: '7246',
+    line: '7',
+    subwayId: '1007',
+    selectedDepartureTime: NOW,
+    segmentStations: ['용마산', '중곡', '군자(능동)'],
+    expiresAt: NOW + 30 * 60_000,
+    ...overrides,
+  };
+}
+
+function makeEvidence(overrides?: Partial<AdvanceEvidence>): AdvanceEvidence {
+  return {
+    type: 'arvlcd-confirmed-train',
+    stationId: '중곡',
+    ts: NOW,
+    environment: 'surface',
+    arvlCd: 1,
+    arvlcdTrainCode: '7246',
+    ...overrides,
+  };
+}
+
+describe('mapEvidenceEnvironment', () => {
+  it.each([
+    ['surface', 'surface'],
+    ['underground', 'underground'],
+    ['hybrid', 'mixed'],
+    ['unknown', 'unknown'],
+  ] as const)('%s → %s (consensusGate 어휘 매핑)', (input, expected) => {
+    expect(mapEvidenceEnvironment(input)).toBe(expected);
+  });
+});
+
+describe('STRONG_EVIDENCE_TYPES', () => {
+  it('5종 strong evidence (arvlcd-confirmed-train / wifi / cellular / position / accel)', () => {
+    expect(STRONG_EVIDENCE_TYPES.size).toBe(5);
+    for (const t of [
+      'arvlcd-confirmed-train',
+      'wifi-ssid-match',
+      'cellular-tech-change',
+      'position-train',
+      'accel-fingerprint',
+    ] as const) {
+      expect(STRONG_EVIDENCE_TYPES.has(t)).toBe(true);
+    }
+  });
+  it('GPS / time-only / arvlcd-lockless 는 strong 아님 (false positive 차단 정책)', () => {
+    expect(STRONG_EVIDENCE_TYPES.has('gps-displacement')).toBe(false);
+    expect(STRONG_EVIDENCE_TYPES.has('time-only')).toBe(false);
+    expect(STRONG_EVIDENCE_TYPES.has('arvlcd-lockless')).toBe(false);
+  });
+});
+
+describe('countStrongEvidence', () => {
+  const makeMe = (signal: unknown, ts: number): MotionEvidence => ({
+    source: 'device-position',
+    ts,
+    signal,
+  });
+
+  it('윈도우 밖 evidence 미카운트', () => {
+    const list = [makeMe({ type: 'wifi-ssid-match' }, NOW - 90_000)];
+    expect(countStrongEvidence(list, NOW - 60_000)).toBe(0);
+  });
+
+  it('signal.type / signal.evidenceType 둘 다 인식', () => {
+    const list = [
+      makeMe({ type: 'wifi-ssid-match' }, NOW),
+      makeMe({ evidenceType: 'cellular-tech-change' }, NOW + 1),
+    ];
+    expect(countStrongEvidence(list, NOW - 60_000)).toBe(2);
+  });
+
+  it('weak/unknown signal은 0 (보수)', () => {
+    const list = [
+      makeMe({ type: 'gps-displacement' }, NOW),
+      makeMe(null, NOW),
+      makeMe('raw-string', NOW),
+      makeMe({ type: 123 }, NOW),
+      makeMe({}, NOW),
+    ];
+    expect(countStrongEvidence(list, NOW - 60_000)).toBe(0);
+  });
+});
+
+describe('consecutiveDurationMs', () => {
+  const ev = (stationId: string, ts: number): AdvanceEvidence =>
+    makeEvidence({ stationId, ts });
+
+  it('빈 list / 단일 entry → 0', () => {
+    expect(consecutiveDurationMs([])).toBe(0);
+    expect(consecutiveDurationMs([ev('A', NOW)])).toBe(0);
+  });
+
+  it('같은 station 30s 연속 → 30_000', () => {
+    expect(consecutiveDurationMs([ev('A', NOW), ev('A', NOW + 30_000)])).toBe(30_000);
+  });
+
+  it('다른 stationId 섞임 → 첫 station만 카운트', () => {
+    // 첫 entry stationId='A' 기준으로 filter — 'B'는 무시. A 단일 남아 0.
+    expect(consecutiveDurationMs([ev('A', NOW), ev('B', NOW + 10_000)])).toBe(0);
+  });
+
+  it('60s gap 초과 → 연속 끊김 → 0', () => {
+    expect(consecutiveDurationMs([ev('A', NOW), ev('A', NOW + 61_000)])).toBe(0);
+  });
+
+  it('정렬 비순서 입력도 정상 처리', () => {
+    expect(consecutiveDurationMs([ev('A', NOW + 30_000), ev('A', NOW)])).toBe(30_000);
+  });
+});
+
+describe('buildSignalsFromEvidence', () => {
+  it('gatePassed=true → GateOutcome.pass=true', () => {
+    const signals = buildSignalsFromEvidence(makeEvidence(), {
+      gatePassed: true,
+      lockAttachable: false,
+    });
+    expect(signals.gateOutcome.pass).toBe(true);
+  });
+
+  it('gatePassed=false → window-too-small reason', () => {
+    const signals = buildSignalsFromEvidence(makeEvidence(), {
+      gatePassed: false,
+      lockAttachable: false,
+    });
+    expect(signals.gateOutcome.pass).toBe(false);
+  });
+
+  it('arvlcd 계열 evidence → arrivalSignalPresent=true', () => {
+    const signals = buildSignalsFromEvidence(makeEvidence({ type: 'arvlcd-lockless' }), {
+      gatePassed: true,
+      lockAttachable: true,
+    });
+    expect(signals.arrivalSignalPresent).toBe(true);
+  });
+
+  it('arvlCd 0~3 stamp만으로도 arrivalSignalPresent=true', () => {
+    const signals = buildSignalsFromEvidence(
+      makeEvidence({ type: 'gps-displacement', arvlCd: 2 }),
+      { gatePassed: true, lockAttachable: true },
+    );
+    expect(signals.arrivalSignalPresent).toBe(true);
+  });
+
+  it('arvlCd null / 범위 밖 → arrivalSignalPresent=false (evidence type도 비arvlcd)', () => {
+    const a = buildSignalsFromEvidence(
+      makeEvidence({ type: 'gps-displacement', arvlCd: null }),
+      { gatePassed: true, lockAttachable: true },
+    );
+    const b = buildSignalsFromEvidence(
+      makeEvidence({ type: 'gps-displacement', arvlCd: 99 }),
+      { gatePassed: true, lockAttachable: true },
+    );
+    expect(a.arrivalSignalPresent).toBe(false);
+    expect(b.arrivalSignalPresent).toBe(false);
+  });
+
+  it('position-train / wifi-ssid-match evidence → 해당 강신호 stamp', () => {
+    const pt = buildSignalsFromEvidence(makeEvidence({ type: 'position-train' }), {
+      gatePassed: true,
+      lockAttachable: true,
+    });
+    expect(pt.positionTrainAgreement).toBe(true);
+    const wf = buildSignalsFromEvidence(makeEvidence({ type: 'wifi-ssid-match' }), {
+      gatePassed: true,
+      lockAttachable: true,
+    });
+    expect(wf.wifiSsidMatch).toBe(true);
+  });
+
+  it('cellularTechVote forward', () => {
+    const signals = buildSignalsFromEvidence(
+      makeEvidence({ cellularTechVote: 'surface' }),
+      { gatePassed: true, lockAttachable: true },
+    );
+    expect(signals.cellularEnvironmentVote).toBe('surface');
+  });
+});
+
+describe('lookupStationFromWifiSsid', () => {
+  const entries: WifiSsidEntry[] = [
+    { stationId: '용마산', patterns: ['^T_subway_용마산', '^Olleh_Subway_용마산'] },
+    { stationId: '중곡', patterns: ['^T_subway_중곡'] },
+  ];
+
+  it.each([
+    [null, null],
+    [undefined, null],
+    ['', null],
+    ['   ', null],
+    ['T_subway_용마산_5G', '용마산'],
+    ['t_subway_중곡', '중곡'], // case-insensitive
+    ['Free_Wifi_별빛마을', null],
+  ] as const)('"%s" → %s', (ssid, expected) => {
+    expect(lookupStationFromWifiSsid(ssid, entries)).toBe(expected);
+  });
+
+  it('invalid regex pattern은 silent skip — 다음 pattern으로 진행', () => {
+    const buggy: WifiSsidEntry[] = [
+      { stationId: '잘못', patterns: ['['] }, // 잘못된 regex
+      { stationId: '중곡', patterns: ['^T_subway_중곡'] },
+    ];
+    expect(lookupStationFromWifiSsid('T_subway_중곡', buggy)).toBe('중곡');
+  });
+});
+
+describe('advanceTripPosition — 6단 게이트 양방향 시나리오 (acceptance 매핑)', () => {
+  let kv: InMemoryKV;
+
+  beforeEach(async () => {
+    kv = new InMemoryKV();
+  });
+
+  /**
+   * 시나리오 fixture — Positive 3 + Negative 6.
+   * acceptance 매핑: P1/P3/P8/N1/N4/N5/N6/N7 + extra N(no-seed)
+   */
+  const scenarios: Array<{
+    name: string;
+    motion: 'moving' | 'stationary' | 'unknown';
+    userIntent: boolean;
+    hasLock: boolean;
+    env: 'surface' | 'underground' | 'hybrid' | 'unknown';
+    evidenceType: AdvanceEvidence['type'];
+    trainMatch: boolean;
+    gatePassed: boolean;
+    lockAttachable: boolean;
+    extraStrongInRing: number;
+    expected: AdvanceResult;
+    expectedReason?: AdvanceBlockReason;
+  }> = [
+    // Positive
+    {
+      name: 'P1 lock + moving + arvlcd-confirmed-train + trainCode 일치 → advanced',
+      motion: 'moving',
+      userIntent: false,
+      hasLock: true,
+      env: 'surface',
+      evidenceType: 'arvlcd-confirmed-train',
+      trainMatch: true,
+      gatePassed: true,
+      lockAttachable: true,
+      extraStrongInRing: 0,
+      expected: 'advanced',
+    },
+    {
+      name: 'P3 lockless + walking + arvlcd-lockless + 추가 strong evidence → advanced',
+      motion: 'moving',
+      userIntent: false,
+      hasLock: false,
+      env: 'surface',
+      evidenceType: 'arvlcd-lockless',
+      trainMatch: false,
+      gatePassed: true,
+      lockAttachable: false,
+      extraStrongInRing: 1, // 60s 윈도우 내 wifi-ssid-match 1개
+      expected: 'advanced',
+    },
+    {
+      name: 'P8 userIntentDeclared=true + 정지 + arvlcd 일치 → advanced (사용자 의향)',
+      motion: 'stationary',
+      userIntent: true,
+      hasLock: true,
+      env: 'surface',
+      evidenceType: 'arvlcd-confirmed-train',
+      trainMatch: true,
+      gatePassed: true,
+      lockAttachable: true,
+      extraStrongInRing: 0,
+      expected: 'advanced',
+    },
+    // Negative
+    {
+      name: 'N1 정지 + arvlcd + userIntent OFF → blocked(motion-stationary)',
+      motion: 'stationary',
+      userIntent: false,
+      hasLock: true,
+      env: 'surface',
+      evidenceType: 'arvlcd-confirmed-train',
+      trainMatch: true,
+      gatePassed: true,
+      lockAttachable: true,
+      extraStrongInRing: 0,
+      expected: 'blocked',
+      expectedReason: 'motion-stationary',
+    },
+    {
+      name: 'N4 lock + moving + arvlcd + trainCode 불일치 → blocked(train-mismatch)',
+      motion: 'moving',
+      userIntent: false,
+      hasLock: true,
+      env: 'surface',
+      evidenceType: 'arvlcd-confirmed-train',
+      trainMatch: false,
+      gatePassed: true,
+      lockAttachable: true,
+      extraStrongInRing: 0,
+      expected: 'blocked',
+      expectedReason: 'train-mismatch',
+    },
+    {
+      name: 'N5 lockless + arvlcd-lockless 단독(추가 strong 0) → blocked(lockless-arvlcd-alone)',
+      motion: 'moving',
+      userIntent: false,
+      hasLock: false,
+      env: 'surface',
+      evidenceType: 'arvlcd-lockless',
+      trainMatch: false,
+      gatePassed: true,
+      lockAttachable: false,
+      extraStrongInRing: 0,
+      expected: 'blocked',
+      expectedReason: 'lockless-arvlcd-alone',
+    },
+    {
+      name: 'N6 underground + gps-displacement만 → blocked(env-consensus-fail)',
+      motion: 'moving',
+      userIntent: false,
+      hasLock: false,
+      env: 'underground',
+      evidenceType: 'gps-displacement',
+      trainMatch: false,
+      gatePassed: true,
+      lockAttachable: false,
+      extraStrongInRing: 0,
+      expected: 'blocked',
+      expectedReason: 'env-consensus-fail',
+    },
+    {
+      name: 'N7 time-only evidence → blocked(time-only-forbidden) (ADR-015 §E4)',
+      motion: 'moving',
+      userIntent: false,
+      hasLock: true,
+      env: 'surface',
+      evidenceType: 'time-only',
+      trainMatch: true,
+      gatePassed: true,
+      lockAttachable: true,
+      extraStrongInRing: 0,
+      expected: 'blocked',
+      expectedReason: 'time-only-forbidden',
+    },
+  ];
+
+  it.each(scenarios)('$name', async (sc) => {
+    // Seed SSoT
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산', {
+      userIntentDeclared: sc.userIntent,
+    });
+    ssot.motionState = sc.motion;
+    if (sc.extraStrongInRing > 0) {
+      for (let i = 0; i < sc.extraStrongInRing; i += 1) {
+        ssot.motionEvidence.push({
+          source: 'device-wifi',
+          ts: NOW - 30_000 + i,
+          signal: { type: 'wifi-ssid-match' },
+        });
+      }
+    }
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+
+    // Seed Trip
+    const trip = makeTrip({
+      boardingLock: sc.hasLock ? makeLock() : undefined,
+    });
+    await putTrip(kv as unknown as KVNamespace, trip);
+
+    const evidence = makeEvidence({
+      type: sc.evidenceType,
+      environment: sc.env,
+      arvlcdTrainCode: sc.trainMatch ? '7246' : '9999',
+      // arvlcd-lockless는 lock-아닌 trip evidence — arvlCd는 set
+      arvlCd:
+        sc.evidenceType === 'arvlcd-confirmed-train' || sc.evidenceType === 'arvlcd-lockless'
+          ? 1
+          : null,
+    });
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      evidence,
+      { gatePassed: sc.gatePassed, lockAttachable: sc.lockAttachable },
+    );
+
+    expect(out.result).toBe(sc.expected);
+    if (sc.expectedReason !== undefined) {
+      expect(out.blockReason).toBe(sc.expectedReason);
+    } else {
+      expect(out.blockReason).toBeUndefined();
+    }
+    if (sc.expected === 'advanced') {
+      // SSoT mutate 검증: currentStationId 갱신 + passedStations에 이전 station stamp
+      const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+      expect(after?.currentStationId).toBe('중곡');
+      expect(after?.passedStations).toContain('용마산');
+      expect(after?.lastAdvanceAt).toBe(NOW);
+      expect(after?.lastAdvanceEvidence).toBe(evidence.type);
+    } else {
+      // blocked: SSoT 변경 X
+      const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+      expect(after?.currentStationId).toBe('용마산');
+    }
+  });
+
+  it('SSoT 미존재 → blocked(no-seed)', async () => {
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence(),
+      { gatePassed: true, lockAttachable: true },
+    );
+    expect(out.result).toBe('blocked');
+    expect(out.blockReason).toBe('no-seed');
+  });
+
+  it('SSoT 존재 + Trip 미존재 → blocked(no-trip)', async () => {
+    await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence(),
+      { gatePassed: true, lockAttachable: true },
+    );
+    expect(out.result).toBe('blocked');
+    expect(out.blockReason).toBe('no-trip');
+  });
+
+  it('lock 만료(expiresAt <= ts) → train identity 게이트 통과 (lock 없는 trip 동급 처리)', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    const expiredLock = makeLock({ expiresAt: NOW - 1_000 });
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: expiredLock }));
+
+    // lock 만료 + lockless 단독 arvlcd-lockless → 게이트 #6 blocked (lock 없음 동급)
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence({ type: 'arvlcd-lockless', arvlcdTrainCode: undefined }),
+      { gatePassed: true, lockAttachable: false },
+    );
+    expect(out.result).toBe('blocked');
+    expect(out.blockReason).toBe('lockless-arvlcd-alone');
+  });
+
+  it('currentStationId 빈 문자열도 no-seed 처리', async () => {
+    // 비정상 SSoT 수동 write
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, 'X');
+    ssot.currentStationId = '';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence(),
+      { gatePassed: true, lockAttachable: true },
+    );
+    expect(out.result).toBe('blocked');
+    expect(out.blockReason).toBe('no-seed');
+  });
+
+  it('이미 passedStations에 있는 stationId는 중복 stamp 안 함 (idempotent)', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    ssot.motionState = 'moving';
+    ssot.passedStations = ['용마산'];
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: makeLock() }));
+    await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence(),
+      { gatePassed: true, lockAttachable: true },
+    );
+    const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    expect(after?.passedStations.filter((s) => s === '용마산').length).toBe(1);
+  });
+});
+
+describe('trySeedOverride (E5)', () => {
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  const ev = (stationId: string, ts: number, type: AdvanceEvidence['type']): AdvanceEvidence => ({
+    type,
+    stationId,
+    ts,
+    environment: 'surface',
+  });
+
+  it('SSoT 없음 → reject', async () => {
+    const r = await trySeedOverride(kv as unknown as KVNamespace, TOKEN, '중곡', []);
+    expect(r).toBe('reject');
+  });
+
+  it('strong evidence 2+ + 30s 연속 일치 → override (currentStationId 정정 + passedStations 초기화 + count+1)', async () => {
+    await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    const list = [
+      ev('중곡', NOW, 'wifi-ssid-match'),
+      ev('중곡', NOW + 30_000, 'cellular-tech-change'),
+    ];
+    const r = await trySeedOverride(kv as unknown as KVNamespace, TOKEN, '중곡', list);
+    expect(r).toBe('override');
+    const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    expect(after?.currentStationId).toBe('중곡');
+    expect(after?.passedStations).toEqual([]);
+    expect(after?.seedOverrideCount).toBe(1);
+    expect(after?.lastAdvanceEvidence).toBe('seed-override');
+  });
+
+  it('strong evidence 1개만 → reject (2+ 미달)', async () => {
+    await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    const r = await trySeedOverride(kv as unknown as KVNamespace, TOKEN, '중곡', [
+      ev('중곡', NOW, 'wifi-ssid-match'),
+    ]);
+    expect(r).toBe('reject');
+  });
+
+  it('strong evidence 2개지만 연속 30s 미달 → reject', async () => {
+    await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    const r = await trySeedOverride(kv as unknown as KVNamespace, TOKEN, '중곡', [
+      ev('중곡', NOW, 'wifi-ssid-match'),
+      ev('중곡', NOW + 10_000, 'position-train'),
+    ]);
+    expect(r).toBe('reject');
+  });
+
+  it('trip 미존재 → override 적용되지만 expiresAt 미지정 (writeSsot 기본 TTL)', async () => {
+    await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    const r = await trySeedOverride(kv as unknown as KVNamespace, TOKEN, '중곡', [
+      ev('중곡', NOW, 'wifi-ssid-match'),
+      ev('중곡', NOW + 30_000, 'cellular-tech-change'),
+    ]);
+    expect(r).toBe('override');
+  });
+});
+
+describe('AdvanceStats / AdvanceResult / AdvanceBlockReason — type 보장', () => {
+  it('AdvanceStats 모든 필드 추적 가능 (compile-time check)', () => {
+    const stats: AdvanceStats = {
+      advanceTotal: 0,
+      blockedNoSeed: 0,
+      blockedNoTrip: 0,
+      blockedMotionStationary: 0,
+      blockedEnvConsensus: 0,
+      blockedTimeOnly: 0,
+      blockedTrainMismatch: 0,
+      blockedLocklessArvlcdAlone: 0,
+      seedOverrideAttempted: 0,
+      seedOverrideAccepted: 0,
+    };
+    expect(Object.keys(stats)).toHaveLength(10);
+  });
+});
+
+describe('evaluateArvlCdFireGate — @deprecated jsdoc 보존 (T2가 export keep)', () => {
+  it('signature 그대로 사용 가능 (jsdoc deprecated만 마킹)', async () => {
+    const mod = await import('../scheduled');
+    expect(typeof mod.evaluateArvlCdFireGate).toBe('function');
+  });
+});

--- a/backend/alarm-worker/src/advanceTripPosition.ts
+++ b/backend/alarm-worker/src/advanceTripPosition.ts
@@ -1,0 +1,417 @@
+/**
+ * advanceTripPosition — ADR-017 T2 단일 mutation 진입점 (Epic #1553, Sub #1555).
+ *
+ * 배경
+ * ====
+ * 2026-06-19 evidence: 정지 trip + lock active + arvlcd ARRIVED → wrong "transfer imminent
+ * 건대입구" 발사. 분산된 fire path별 게이트가 다 달랐다:
+ *   - `scheduled.ts:795 evaluateArvlCdFireGate` — lock+arvlCd만
+ *   - lockless `LOCKLESS_ADVANCE_MOTION_MODES` — lockless만 motion 검증
+ *   - vanish path `isFallbackAdvanceBlockedByMotion` — vanish만 stationary 차단
+ *   - `evaluateConsensusGate` — 호출자 미적용
+ *
+ * 본 T2는 단일 진입점 `advanceTripPosition`을 도입해 6단 게이트를 강제한다.
+ * 본 PR은 함수 + 테스트만 추가하고 기존 fire path를 변경하지 않는다 (T4~T7가 reader migration).
+ *
+ * 6단 게이트 (순서 강제, ADR-017)
+ * ===============================
+ *   #1 Seed 게이트         — SSoT 미존재 / currentStationId 없으면 blocked('no-seed')
+ *   #2 Motion 게이트       — motionState==='stationary' 이고 userIntentDeclared=false면 blocked('motion-stationary')
+ *                            ([[feedback_user_intent_equal_protection]] — userIntent ON trip은
+ *                             lock 활성과 동급 정확도 → motion stationary 게이트도 우회 X 아닌 동급 처리.
+ *                             그러나 P8 acceptance "userIntentDeclared=true + 정지 → advanced"가
+ *                             명시되어 있어 #2에서만 명시 의향 trip을 통과시킨다. 다른 게이트는 동급.)
+ *   #3 Environment 게이트  — evaluateConsensusGate 통과 필수 (지하 GPS-only false positive 차단)
+ *   #4 Evidence type 게이트 — ADR-015 §E4: 'time-only' evidence 절대 거부
+ *   #5 Train identity 게이트 — lock 활성 + arvlcd-confirmed-train evidence면 trainCode 일치 필수
+ *   #6 Lockless arvlcd 단독 게이트 — lock 없는 trip에서 arvlcd-lockless 단독은 60s 윈도우 내
+ *                                    strong evidence 1+개가 추가로 있어야 통과
+ *
+ * Seed override (E5)
+ * ==================
+ * `trySeedOverride`가 strong evidence 2+개 + 30s 연속 일치 시 currentStationId 정정.
+ * passedStations은 초기화 (잘못 stamp된 station 폐기). seedOverrideCount += 1.
+ *
+ * Out of scope (본 PR)
+ * ====================
+ * - 기존 fire path 변경 (T4~T7가 reader migration)
+ * - KV CAS retry (issue 본문 §Race safety — "last write wins" 허용. motionEvidence ring buffer로 손실 X)
+ * - WiFi SSID map 데이터 자체 (`subwayWifiSsidMap.json`) backend 임포트 — `lookupStationFromWifiSsid`는
+ *   injectable entries 인자를 받는 순수 함수로 두고, 실제 매핑 데이터 wire는 T3 (device/position upload
+ *   payload에 `wifiSsid` 추가 + backend wire) 또는 별도 데이터 module로 분리한다.
+ */
+
+import { evaluateConsensusGate, type StationEnvironment } from './consensusGate';
+import type { ArrivalEntry, PositionEntry } from './seoul';
+import {
+  MOTION_EVIDENCE_CAP,
+  readSsot,
+  writeSsot,
+  type EvidenceType,
+  type MotionEvidence,
+  type TripPositionSSoT,
+} from './tripPositionSsot';
+import { getTrip } from './trips';
+import type { BoardingLockMeta, Trip } from './types';
+
+/**
+ * Evidence environment — device가 upload하는 좁은 set.
+ *
+ * 'hybrid'는 `consensusGate.StationEnvironment` 의 'mixed'에 매핑된다 (E1 #1444 stations.json
+ * 필드와 device payload 어휘가 달라서). `mapEvidenceEnvironment`가 변환.
+ */
+export type EvidenceEnvironment = 'surface' | 'underground' | 'hybrid' | 'unknown';
+
+/**
+ * Strong evidence type — 게이트 #6 + seedOverride 공통.
+ *
+ * 단일 신호만으로 advance를 견인할 수 있는 weight. GPS는 의도적으로 제외 (지하 false positive 차단).
+ */
+export const STRONG_EVIDENCE_TYPES: ReadonlySet<EvidenceType> = new Set<EvidenceType>([
+  'arvlcd-confirmed-train',
+  'wifi-ssid-match',
+  'cellular-tech-change',
+  'position-train',
+  'accel-fingerprint',
+]);
+
+/**
+ * Cellular tech vote — `evaluateConsensusGate.cellularEnvironmentVote` 입력 호환.
+ */
+export type CellularTechVote = 'surface' | 'underground' | 'unknown';
+
+/**
+ * 단일 advance 후보 evidence. caller(T3/T4+ fire path)가 본 객체로 advance 시도.
+ *
+ * - `arvlcdTrainCode` — evidence type 이 arvlcd 계열일 때 lock.trainCode와 cross-check (E8)
+ * - `wifiSsid` — 'wifi-ssid-match'일 때 caller가 lookup 결과를 stamp (E6)
+ * - `cellularTechVote` — `consensusGate.cellularEnvironmentVote`로 forward (S10)
+ */
+export interface AdvanceEvidence {
+  type: EvidenceType;
+  /** evidence 발생 stationId. seedOverride consecutive 윈도우 일치 비교 + passedStations stamp용. */
+  stationId: string;
+  /** evidence 발생 시각 (epoch ms). 게이트 #5 lock.expiresAt 비교 + window 산출. */
+  ts: number;
+  /** device가 upload한 environment vote ([[reference_wifi_ssid_100pct_mapped]] 게이트 #3). */
+  environment: EvidenceEnvironment;
+  /** arvlcd 계열 evidence의 train identity (E8). lock 활성 시 lock.trainCode와 일치 강제. */
+  arvlcdTrainCode?: string;
+  /** Seoul API arvlCd 원본 (게이트 #3 arrivalSignalPresent 신호로 매핑). */
+  arvlCd?: number | null;
+  /** 매핑된 arrival 원본 (caller가 보유 시 forward — 본 함수는 caller가 채워준 가공 신호만 사용). */
+  arrivalEntry?: ArrivalEntry;
+  /** Seoul realtimePosition entry (caller forward — 본 함수는 type='position-train' weight로만 사용). */
+  positionEntry?: PositionEntry;
+  /** WiFi SSID 원본 — 진단/observability stamp용. lookup은 caller가 수행. */
+  wifiSsid?: string;
+  /** consensusGate에 forward할 cellular vote (S10 #1543). */
+  cellularTechVote?: CellularTechVote;
+  /** accel fingerprint 식별자 (S9, type='accel-fingerprint' 시). */
+  accelFingerprint?: string;
+}
+
+/** advance 시도 결과. */
+export type AdvanceResult = 'advanced' | 'blocked' | 'noop';
+
+/** advance 차단 사유 — production stats 분포 측정용. */
+export type AdvanceBlockReason =
+  | 'no-seed'
+  | 'no-trip'
+  | 'motion-stationary'
+  | 'env-consensus-fail'
+  | 'time-only-forbidden'
+  | 'train-mismatch'
+  | 'lockless-arvlcd-alone';
+
+/** advance 호출 결과 — caller가 SSoT 후속 작업(fire 발사 등)을 진행할지 결정. */
+export interface AdvanceOutcome {
+  result: AdvanceResult;
+  blockReason?: AdvanceBlockReason;
+  ssot: TripPositionSSoT | null;
+}
+
+/**
+ * 게이트 분포 측정용 stats. production에서 분포 수집 → acceptance 검증.
+ */
+export interface AdvanceStats {
+  advanceTotal: number;
+  blockedNoSeed: number;
+  blockedNoTrip: number;
+  blockedMotionStationary: number;
+  blockedEnvConsensus: number;
+  blockedTimeOnly: number;
+  blockedTrainMismatch: number;
+  blockedLocklessArvlcdAlone: number;
+  seedOverrideAttempted: number;
+  seedOverrideAccepted: number;
+}
+
+/** 단일 WiFi SSID → stationId(=stationName canonical) lookup entry. */
+export interface WifiSsidEntry {
+  stationId: string;
+  patterns: readonly string[];
+}
+
+/**
+ * Evidence environment ('hybrid') → consensusGate environment ('mixed') 변환.
+ *
+ * device payload 어휘와 backend `StationEnvironment`(E1 #1444 stations.json 필드)가 다르기에
+ * 단일 지점에서 매핑. 'unknown'은 보수적으로 'unknown'으로 forward (consensusGate가 mixed 동급으로 다룸).
+ */
+export function mapEvidenceEnvironment(env: EvidenceEnvironment): StationEnvironment {
+  if (env === 'hybrid') return 'mixed';
+  return env;
+}
+
+/**
+ * MotionEvidence ring buffer 내에서 윈도우 [sinceMs, +∞) strong evidence 카운트.
+ *
+ * `MotionEvidence.signal`은 unknown payload — caller(T3)가 evidence type을 어떤 key로 stamp하는지에
+ * 의존. 본 함수는 보수적으로 signal이 객체이면 `.type` 또는 `.evidenceType` 키를 찾아 type 추출.
+ * 그 외(원시값 / type 키 부재)는 미카운트 — strong 신호로 보장 못 함.
+ */
+export function countStrongEvidence(motionEvidence: readonly MotionEvidence[], sinceMs: number): number {
+  let count = 0;
+  for (const e of motionEvidence) {
+    if (e.ts < sinceMs) continue;
+    const type = extractEvidenceType(e.signal);
+    if (type !== null && STRONG_EVIDENCE_TYPES.has(type)) count += 1;
+  }
+  return count;
+}
+
+function extractEvidenceType(signal: unknown): EvidenceType | null {
+  if (signal === null || typeof signal !== 'object') return null;
+  const obj = signal as { type?: unknown; evidenceType?: unknown };
+  const raw = obj.type ?? obj.evidenceType;
+  if (typeof raw !== 'string') return null;
+  return raw as EvidenceType;
+}
+
+/**
+ * 같은 stationId를 가리키는 strong evidence가 끊김 없이 도착한 윈도우의 ts 범위 (max - min).
+ *
+ * 인접 evidence 사이 gap ≤ 60s를 "연속"으로 본다. 첫 evidence stationId 기준으로 필터한 뒤
+ * sort + gap 검증 후 끝-시작 차이를 반환. 연속 끊기면 0.
+ *
+ * 입력 list가 비어 있거나 단일 entry면 0 (단일은 "연속 윈도우"가 아니므로).
+ */
+export function consecutiveDurationMs(strongEvidence: readonly AdvanceEvidence[]): number {
+  if (strongEvidence.length === 0) return 0;
+  const first = strongEvidence[0];
+  const sorted = strongEvidence
+    .filter((e) => e.stationId === first.stationId)
+    .slice()
+    .sort((a, b) => a.ts - b.ts);
+  if (sorted.length < 2) return 0;
+  for (let i = 1; i < sorted.length; i += 1) {
+    if (sorted[i].ts - sorted[i - 1].ts > 60_000) return 0;
+  }
+  return sorted[sorted.length - 1].ts - sorted[0].ts;
+}
+
+/**
+ * AdvanceEvidence → evaluateConsensusGate 신호 변환.
+ *
+ * `gateOutcome`는 외부에서 산출되어야 하는 9단 AND 게이트 결과 — 본 함수는 caller가 stamp한 값을
+ * 그대로 forward한다. arrivalSignalPresent / lockAttachable / positionTrainAgreement /
+ * wifiSsidMatch는 evidence type 기반으로 유도.
+ */
+export function buildSignalsFromEvidence(
+  evidence: AdvanceEvidence,
+  options: { gatePassed: boolean; lockAttachable: boolean },
+): Parameters<typeof evaluateConsensusGate>[1] {
+  const arvlCdValid =
+    typeof evidence.arvlCd === 'number' && evidence.arvlCd >= 0 && evidence.arvlCd <= 3;
+  const arrivalSignalPresent =
+    evidence.type === 'arvlcd-confirmed-train' ||
+    evidence.type === 'arvlcd-lockless' ||
+    arvlCdValid;
+  return {
+    gateOutcome: options.gatePassed
+      ? {
+          pass: true,
+          metrics: {
+            count: 0,
+            gpsAvgKmh: 0,
+            avgAccuracyMeters: 0,
+            motion: 'unknown',
+            start: null,
+            end: null,
+            mapMatchedKmh: null,
+          },
+          fusedSpeedKmh: 0,
+        }
+      : { pass: false, reason: 'window-too-small' },
+    arrivalSignalPresent,
+    lockAttachable: options.lockAttachable,
+    positionTrainAgreement: evidence.type === 'position-train' ? true : undefined,
+    wifiSsidMatch: evidence.type === 'wifi-ssid-match' ? true : undefined,
+    cellularEnvironmentVote: evidence.cellularTechVote,
+  };
+}
+
+/**
+ * WiFi SSID → stationId 조회. 미매칭 시 null.
+ *
+ * 본 함수는 injectable `entries` 리스트를 받는다 — 실제 매핑 데이터(`subwayWifiSsidMap.json`)는
+ * T3 wire-up에서 주입 (본 PR은 함수 logic + 테스트만). pattern은 case-insensitive regex.
+ */
+export function lookupStationFromWifiSsid(
+  ssid: string | null | undefined,
+  entries: readonly WifiSsidEntry[],
+): string | null {
+  if (typeof ssid !== 'string') return null;
+  const trimmed = ssid.trim();
+  if (trimmed.length === 0) return null;
+  for (const entry of entries) {
+    for (const pattern of entry.patterns) {
+      let re: RegExp;
+      try {
+        re = new RegExp(pattern, 'i');
+      } catch {
+        continue;
+      }
+      if (re.test(trimmed)) return entry.stationId;
+    }
+  }
+  return null;
+}
+
+/**
+ * advance 시도 — 6단 게이트 통과 시 SSoT mutation + write.
+ *
+ * @param kv SSOT / Trip KV namespace (둘 다 동일 namespace 가정, T1 + trips.ts 패턴).
+ * @param tripKv Trip KV (lock 조회용).
+ * @param token APNs device token (SSoT key).
+ * @param candidateStationId advance하려는 station identifier.
+ * @param evidence advance 후보 evidence (1건).
+ * @param options.gatePassed 외부 9단 AND 게이트 결과 (caller가 stamp). 미stamp 시 false.
+ * @param options.lockAttachable `pickAutoTrainCode` 단일 수렴 여부. caller stamp.
+ *
+ * blocked 시 SSoT는 mutate 하지 않음. 'noop'은 현재 게이트에서 발생하지 않지만 향후 reader
+ * migration이 idempotent advance(이미 같은 stationId)를 'noop'으로 처리할 수 있는 type slot.
+ */
+export async function advanceTripPosition(
+  kv: KVNamespace,
+  token: string,
+  candidateStationId: string,
+  evidence: AdvanceEvidence,
+  options: { gatePassed: boolean; lockAttachable: boolean },
+): Promise<AdvanceOutcome> {
+  const ssot = await readSsot(kv, token);
+
+  // #1 Seed 게이트
+  if (ssot === null || !ssot.currentStationId) {
+    return { result: 'blocked', blockReason: 'no-seed', ssot };
+  }
+
+  // #5 (lock 조회를 위해 trip을 미리 fetch — #2/#3/#4 검증 비용보다 1건 KV read가 가볍고,
+  //      이후 게이트 분기에 활용)
+  const trip = await getTrip(kv, token);
+  if (trip === null) {
+    return { result: 'blocked', blockReason: 'no-trip', ssot };
+  }
+  const lock = pickActiveLock(trip, evidence.ts);
+
+  // #2 Motion 게이트 — userIntentDeclared trip은 명시 의향이므로 통과 (P8 acceptance).
+  if (ssot.motionState === 'stationary' && !ssot.userIntentDeclared) {
+    return { result: 'blocked', blockReason: 'motion-stationary', ssot };
+  }
+
+  // #3 Environment 게이트
+  const consensusOutcome = evaluateConsensusGate(
+    mapEvidenceEnvironment(evidence.environment),
+    buildSignalsFromEvidence(evidence, {
+      gatePassed: options.gatePassed,
+      lockAttachable: options.lockAttachable,
+    }),
+  );
+  if (!consensusOutcome.pass) {
+    return { result: 'blocked', blockReason: 'env-consensus-fail', ssot };
+  }
+
+  // #4 Evidence type 게이트 (ADR-015 §E4 — time-only 절대 거부)
+  if (evidence.type === 'time-only') {
+    return { result: 'blocked', blockReason: 'time-only-forbidden', ssot };
+  }
+
+  // #5 Train identity 게이트
+  if (lock !== undefined && evidence.type === 'arvlcd-confirmed-train') {
+    if (evidence.arvlcdTrainCode !== lock.trainCode) {
+      return { result: 'blocked', blockReason: 'train-mismatch', ssot };
+    }
+  }
+
+  // #6 Lockless arvlcd 단독 게이트 — 60s 윈도우 내 추가 strong evidence 1+ 필요
+  if (lock === undefined && evidence.type === 'arvlcd-lockless') {
+    const otherStrong = countStrongEvidence(ssot.motionEvidence, evidence.ts - 60_000);
+    if (otherStrong < 1) {
+      return { result: 'blocked', blockReason: 'lockless-arvlcd-alone', ssot };
+    }
+  }
+
+  // Advance — SSoT mutate + write
+  const next: TripPositionSSoT = {
+    ...ssot,
+    passedStations: appendUnique(ssot.passedStations, ssot.currentStationId),
+    currentStationId: candidateStationId,
+    lastAdvanceAt: evidence.ts,
+    lastAdvanceEvidence: evidence.type,
+  };
+  await writeSsot(kv, next, { expiresAt: trip.expiresAt });
+  return { result: 'advanced', ssot: next };
+}
+
+/**
+ * Seed override (E5).
+ *
+ * Strong evidence 2+개가 같은 stationId를 30s 이상 연속 가리키면 currentStationId를 정정.
+ * passedStations는 초기화 (잘못 stamp된 station 폐기). seedOverrideCount += 1.
+ *
+ * @returns 'override' (적용됨) | 'reject' (조건 미달 / SSoT 없음)
+ */
+export async function trySeedOverride(
+  kv: KVNamespace,
+  token: string,
+  newStationId: string,
+  evidenceList: readonly AdvanceEvidence[],
+): Promise<'override' | 'reject'> {
+  const ssot = await readSsot(kv, token);
+  if (ssot === null) return 'reject';
+  const strong = evidenceList.filter((e) => STRONG_EVIDENCE_TYPES.has(e.type));
+  if (strong.length < 2) return 'reject';
+  const duration = consecutiveDurationMs(strong);
+  if (duration < 30_000) return 'reject';
+  const trip = await getTrip(kv, token);
+  const expiresAt = trip?.expiresAt;
+  const next: TripPositionSSoT = {
+    ...ssot,
+    currentStationId: newStationId,
+    passedStations: [],
+    seedOverrideCount: ssot.seedOverrideCount + 1,
+    lastAdvanceEvidence: 'seed-override',
+  };
+  await writeSsot(kv, next, expiresAt !== undefined ? { expiresAt } : undefined);
+  return 'override';
+}
+
+/**
+ * trip.boardingLock이 evidence 시점에 활성인지 확인 후 반환. 만료/부재 시 undefined.
+ */
+function pickActiveLock(trip: Trip, ts: number): BoardingLockMeta | undefined {
+  const lock = trip.boardingLock;
+  if (!lock) return undefined;
+  if (lock.expiresAt <= ts) return undefined;
+  return lock;
+}
+
+function appendUnique(arr: readonly string[], next: string): string[] {
+  if (arr.includes(next)) return arr.slice();
+  const copy = arr.slice();
+  copy.push(next);
+  // motionEvidence와 동일한 ring buffer cap을 적용해 KV row 폭주 방지.
+  while (copy.length > MOTION_EVIDENCE_CAP) copy.shift();
+  return copy;
+}

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -791,6 +791,11 @@ export function arvlCdFireKey(
  * #640 회귀 차단: lock 없는 trip은 애초에 runTrainCodeTracking에 도달하지 못한다.
  * positions-fallback arrived(arvlCd=null)는 매역 알림 SSOT(arvlCd)와 다른 신호 →
  * mismatch로 분류해 push 미발사 + 운영 가시성 카운트.
+ *
+ * @deprecated ADR-017 T2 (#1555) — 본 게이트는 분산된 fire path 잔존 호출자 보존용. 신규 호출자는
+ *   `advanceTripPosition` (단일 mutation 진입점)을 사용해 6단 게이트(seed/motion/env/type/train
+ *   identity/lockless arvlcd 단독)를 전부 거치게 해야 한다. T4~T7 reader migration에서 호출자
+ *   교체가 완료되면 본 함수는 제거 예정.
  */
 export function evaluateArvlCdFireGate(
   lock: BoardingLockMeta | undefined,


### PR DESCRIPTION
Closes #1555. ADR-017 T2 단일 mutation 진입점. T1 #1562 의존 (stacked PR). **T1 머지 후 base를 dev로 rebase 예정.**

## 변경 요약

- `backend/alarm-worker/src/advanceTripPosition.ts` 신설 — 단일 mutation 진입점
- 6단 게이트 순서 강제:
  1. **Seed** — SSoT/currentStationId 부재 → `blocked('no-seed')`
  2. **Motion** — `motionState='stationary'` + `userIntentDeclared=false` → `blocked('motion-stationary')` (P8 acceptance: userIntent ON이면 통과)
  3. **Environment** — `evaluateConsensusGate` 통과 필수 (지하 GPS-only false positive 차단)
  4. **Evidence type** — `'time-only'` 절대 거부 (ADR-015 §E4)
  5. **Train identity** — lock 활성 + `arvlcd-confirmed-train` evidence면 `trainCode` 일치 필수
  6. **Lockless arvlcd 단독** — lock 없는 trip의 `arvlcd-lockless`는 60s 윈도우 내 추가 strong evidence 1+ 필요
- **seedOverride (E5)** — strong evidence 2+ + 30s 연속 일치 시 currentStationId 정정 + passedStations 초기화 + `seedOverrideCount += 1`
- **WiFi (E6)** — `lookupStationFromWifiSsid(ssid, entries)` injectable. 실제 `subwayWifiSsidMap.json` 데이터 wire는 T3로 분리 (본 PR은 logic + tests만)
- **Train identity (E8)** — `lock.trainCode` cross-check
- **AdvanceStats** interface — production 분포 측정 SSOT
- `scheduled.ts:evaluateArvlCdFireGate` 에 `@deprecated` jsdoc 마킹 (export keep — T4~T7 reader migration까지 보존)

기존 fire path는 변경하지 않습니다. T4~T7가 reader migration을 통해 본 진입점으로 호출자 전환을 수행합니다.

## 양방향 시나리오 acceptance 매핑 (49 vitest case)

**Positive**:
- P1 lock + moving + arvlcd + trainCode 일치 → `advanced`
- P3 lockless + walking + arvlcd-lockless + 추가 strong evidence → `advanced`
- P8 `userIntentDeclared=true` + 정지 → `advanced` (사용자 의향 동급 보장, ADR-014)

**Negative**:
- N1 정지 + arvlcd → `blocked('motion-stationary')`
- N4 lock + moving + arvlcd + trainCode 불일치 → `blocked('train-mismatch')`
- N5 lockless + arvlcd-lockless 단독 → `blocked('lockless-arvlcd-alone')`
- N6 underground + only-gps → `blocked('env-consensus-fail')`
- N7 time-only → `blocked('time-only-forbidden')`

추가 보강: no-seed / no-trip / lock 만료 → lockless 동급 / `currentStationId=''` no-seed / passedStations idempotent.

## 테스트

- `npm run type-check` (backend + root) 통과
- `cd backend/alarm-worker && npm test` — **1597 passed (49 신규)**

## 후속

- T3 `/position` payload `wifiSsid` 필드 추가 + WifiSsidEntry 데이터 wire
- T4~T7 reader migration — `evaluateArvlCdFireGate` 호출자 교체