### PR TITLE
fix(#1559): maybeReschedulePush motion 게이트 (Epic #1553)

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -34,6 +34,7 @@ import {
 } from '../scheduled';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from '../seoul';
 import { putTrip } from '../trips';
+import { writeSsot } from '../tripPositionSsot';
 import type { BoardingLockMeta, Env, PositionPoint, Trip, Waypoint } from '../types';
 import { InMemoryKV } from './inMemoryKv';
 
@@ -2090,6 +2091,109 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
       now: () => NOW,
     });
     expect(stats.pushed).toBe(0);
+  });
+
+  // #1559 (T6, Epic #1553 / ADR-017) — maybeReschedulePush SSoT motion 게이트.
+  // 정지 trip에서 ETA 임계치 변동만으로 reschedule silent push가 발사되던 회귀
+  // (2026-06-19 15:53/15:56 evidence) 차단. SSoT 부재(legacy trip) → fallback.
+  describe('#1559 SSoT motion gate', () => {
+    type Scenario = {
+      name: string;
+      ssotMotion: 'moving' | 'stationary' | null; // null = SSoT 없음 (legacy fallback)
+      arrivalSec: number;
+      lastTrackedDeltaMs: number | undefined; // baseline epoch offset (undefined → no baseline)
+      expectedFire: boolean;
+      expectedBlockedMotion: number;
+      expectedFallbackNoSsot: number;
+    };
+    const rescheduleScenarios: Scenario[] = [
+      // Positive — SSoT moving + delta > 15s → fire
+      {
+        name: 'SSoT moving + ETA delta > 15s → reschedule fires',
+        ssotMotion: 'moving',
+        arrivalSec: 140,
+        lastTrackedDeltaMs: 120_000,
+        expectedFire: true,
+        expectedBlockedMotion: 0,
+        expectedFallbackNoSsot: 0,
+      },
+      // Negative — SSoT stationary + delta > 15s → blocked
+      {
+        name: 'SSoT stationary + ETA delta > 15s → blocked (motion-stationary)',
+        ssotMotion: 'stationary',
+        arrivalSec: 140,
+        lastTrackedDeltaMs: 120_000,
+        expectedFire: false,
+        expectedBlockedMotion: 1,
+        expectedFallbackNoSsot: 0,
+      },
+      // Fallback — SSoT 없음 (legacy) + delta > 15s → fire (기존 동작 유지)
+      {
+        name: 'SSoT missing (legacy) + ETA delta > 15s → fallback fires',
+        ssotMotion: null,
+        arrivalSec: 140,
+        lastTrackedDeltaMs: 120_000,
+        expectedFire: true,
+        expectedBlockedMotion: 0,
+        expectedFallbackNoSsot: 1,
+      },
+      // Noop — SSoT moving + delta < 15s → 기존 임계치 게이트로 미발사 (motion 게이트 통과 후)
+      {
+        name: 'SSoT moving + ETA delta < 15s → noop (existing threshold gate)',
+        ssotMotion: 'moving',
+        arrivalSec: 125,
+        lastTrackedDeltaMs: 120_000,
+        expectedFire: false,
+        expectedBlockedMotion: 0,
+        expectedFallbackNoSsot: 0,
+      },
+    ];
+
+    it.each(rescheduleScenarios)(
+      '$name',
+      async ({
+        ssotMotion,
+        arrivalSec,
+        lastTrackedDeltaMs,
+        expectedFire,
+        expectedBlockedMotion,
+        expectedFallbackNoSsot,
+      }) => {
+        const kv = new InMemoryKV();
+        const trip = makeLockTrip(
+          lastTrackedDeltaMs !== undefined
+            ? { lastTrackedArrivalEpoch: NOW + lastTrackedDeltaMs }
+            : {},
+        );
+        await putTrip(kv as unknown as KVNamespace, trip);
+        if (ssotMotion !== null) {
+          await writeSsot(kv as unknown as KVNamespace, {
+            tripToken: trip.token,
+            currentStationId: '용마산',
+            motionState: ssotMotion,
+            motionEvidence: [],
+            lastAdvanceAt: 0,
+            lastAdvanceEvidence: 'seed-override',
+            passedStations: [],
+            userIntentDeclared: false,
+            seedOverrideCount: 0,
+            schemaVersion: 1,
+          });
+        }
+        const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+        const stats = await runScheduled(makeEnv(kv), {
+          seoul: makeSeoulCombo([arrivalForLock('중곡', arrivalSec)], []),
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW,
+          generatePushId: () => 'p-t6',
+        });
+        expect(stats.pushed).toBe(expectedFire ? 1 : 0);
+        expect(stats.rescheduleBlockedMotion).toBe(expectedBlockedMotion);
+        expect(stats.rescheduleFallbackNoSsot).toBe(expectedFallbackNoSsot);
+      },
+    );
   });
 });
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -51,6 +51,7 @@ import { deleteProgress, getProgress, putProgress, type TripProgress } from './p
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from './seoul';
 import { phaseAllowsImminentFiring, runStationPhaseStep } from './stationPhase';
 import { listTrips, putTrip } from './trips';
+import { readSsot, SSOT_CRON_READ_CACHE_TTL_SEC } from './tripPositionSsot';
 import type {
   ApnsEnv,
   BoardingLockMeta,
@@ -363,6 +364,20 @@ export interface ScheduledStats extends LiveActivityStats {
    * 측정의 정량 근거가 된다. 누적 metric이 아니라 매 cycle의 즉시값을 그대로 log한다.
    */
   cronJitterMs: number;
+  /**
+   * #1559 (T6, Epic #1553 / ADR-017) — `maybeReschedulePush` 진입 시 SSoT.motionState === 'stationary'로
+   * reschedule silent push가 차단된 누적 횟수. 정지 trip에서 ETA 임계치 변동만으로 LA/scheduled queue를
+   * 재발사하던 회귀(2026-06-19 15:53/15:56 evidence)를 닫는다. lock-active fallback
+   * (`vanishFallbackMotionGateBlocked`) / lockless advance(`locklessMotionGateBlocked`)와 동일 정책의
+   * reschedule-push 버전 — `tripPositionSsot.motionState` SSoT 단일 소스.
+   */
+  rescheduleBlockedMotion: number;
+  /**
+   * #1559 (T6) — `maybeReschedulePush` 진입 시 SSoT가 존재하지 않아(legacy trip — T1 SSoT seeding 이전에
+   * 생성된 trip 또는 KV TTL 만료) motion 게이트를 적용하지 않고 기존 로직으로 fallback한 누적 횟수.
+   * SSoT 마이그레이션 진행도 측정 — 모든 trip이 T1 seeding을 거치게 되면 0으로 수렴한다.
+   */
+  rescheduleFallbackNoSsot: number;
 }
 
 /**
@@ -424,6 +439,9 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     vanishFallbackMotionGateBlocked: 0,
     // #1539 (S6) — cron jitter (실행 시각 - 직전 60s boundary). 매 cycle 즉시값으로 stamp.
     cronJitterMs: computeCronJitterMs(now),
+    // #1559 (T6) — reschedule push motion 게이트 차단/fallback 누적.
+    rescheduleBlockedMotion: 0,
+    rescheduleFallbackNoSsot: 0,
   };
   // #1539 (S6) — cron jitter 즉시 log. 누적 stat이 아니라 매 cycle 1줄 → tail에서 P50/P99 산출.
   log('scheduled: cron jitter', { jitterMs: stats.cronJitterMs });
@@ -1725,6 +1743,25 @@ export async function maybeReschedulePush(
   log: Logger,
   generatePushId: () => string,
 ): Promise<{ cleanedUp: boolean }> {
+  // #1559 (T6, Epic #1553 / ADR-017) — SSoT.motionState 게이트.
+  // 정지 trip에서도 ETA 임계치 변동만으로 reschedule silent push가 발사되던 회귀
+  // (2026-06-19 15:53/15:56 evidence) 차단. SSoT 부재 시(legacy trip — T1 seeding 이전 또는
+  // KV TTL 만료)는 backward compat을 위해 fallback. cron read는 SSOT_CRON_READ_CACHE_TTL_SEC
+  // (30s)로 같은 사이클 내 stale read 방지.
+  const ssot = await readSsot(env.TRIPS, trip.token, {
+    cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
+  });
+  if (ssot === null) {
+    log('reschedule push: no-ssot fallback', { token: trip.token.slice(0, 8) });
+    stats.rescheduleFallbackNoSsot += 1;
+  } else if (ssot.motionState === 'stationary') {
+    log('reschedule push: blocked (motion-stationary)', {
+      token: trip.token.slice(0, 8),
+    });
+    stats.rescheduleBlockedMotion += 1;
+    return { cleanedUp: false };
+  }
+
   const lastEpoch = trip.lastTrackedArrivalEpoch;
   if (
     lastEpoch !== undefined &&


### PR DESCRIPTION
Closes #1559. ADR-017 T6.

## 변경 — `backend/alarm-worker/src/scheduled.ts:1716` `maybeReschedulePush`
정지 trip 진입 시 `readSsot()` 게이트 추가. `SSoT.motionState === 'stationary'`면 reschedule silent push 차단, SSoT 부재(legacy trip — T1 seeding 이전 또는 KV TTL 만료) 시 backward compat로 기존 로직 fallback + log stamp.

ETA 산출 변경은 본 PR 스코프 외 — motion 게이트만.

## RCA evidence
2026-06-19 backend log:
- `15:53:08 reschedule push` (정지 trip)
- `15:56:08 reschedule push` (정지 trip)

기존 게이트는 `RESCHEDULE_THRESHOLD_S` 임계치 변동 검사만 — motion 무관. ETA가 임계 초과로 흔들리면 정지 중에도 LA/scheduled queue를 재발사.

## stats (운영 가시성)
- `rescheduleBlockedMotion` — 정지로 인한 차단 누적
- `rescheduleFallbackNoSsot` — SSoT 부재 fallback 누적 (마이그레이션 진행도)

## 테스트 (`scheduled.test.ts` 신규 `#1559 SSoT motion gate` describe)
`it.each(rescheduleScenarios)` 4 시나리오:
- `SSoT moving + ETA delta > 15s` → fire ✅
- `SSoT stationary + ETA delta > 15s` → blocked (motion-stationary) ✅
- `SSoT missing (legacy) + ETA delta > 15s` → fallback fires ✅ (backward compat)
- `SSoT moving + ETA delta < 15s` → noop (기존 threshold 게이트) ✅

backend test 1627건 ALL PASS.

## 의존
- 선행: T1 (SSoT helper)
- Epic: #1553 (ADR-017)