### PR TITLE
refactor(#1557): arvlcdFire → advanceTripPosition reader (Epic #1553)

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -34,6 +34,7 @@ import {
 } from '../scheduled';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from '../seoul';
 import { putTrip } from '../trips';
+import { readSsot, seedSsot, ssotKey, writeSsot } from '../tripPositionSsot';
 import type { BoardingLockMeta, Env, PositionPoint, Trip, Waypoint } from '../types';
 import { InMemoryKV } from './inMemoryKv';
 
@@ -5135,5 +5136,197 @@ describe('runScheduled cron jitter stat (#1539 S6)', () => {
     expect(stats.cronJitterMs).toBe(expectedJitter);
     expect(logMessages.some((l) => l.msg === 'scheduled: cron jitter' && l.meta?.jitterMs === expectedJitter))
       .toBe(true);
+  });
+});
+
+/**
+ * ADR-017 T4 (#1557) — `advanceTripPosition` SSoT 게이트가 arvlcd fire 발사 직전 차단/통과를
+ * 결정하는지 양방향 검증.
+ *
+ * 본 suite는 `runScheduled` 통합 레벨에서 lock 활성 + arvlcd ARRIVED 신호를 시뮬한 뒤
+ * SSoT motionState / consensusGate / trainCode identity / lazy-seed 등 분기마다 결과를 단언한다.
+ *
+ * 2026-06-19 정지 trip + lock active + arvlcd ARRIVED → wrong "transfer imminent 건대입구"
+ * 발사 회귀(N1)를 본 게이트가 직접 차단함을 박제한다.
+ */
+describe('runScheduled — ADR-017 T4 (#1557) advanceTripPosition SSoT gate (arvlcd fire)', () => {
+  const TOKEN = 'arvl-tok';
+
+  // arvlcd ARRIVED 신호 (중곡, trainCode 7246, arvlCd=1) 공통 Seoul fixture.
+  const makeArrivedSeoul = (trainCode = '7246') => makeArvlCdFireSeoul('중곡', 0, 1, trainCode);
+
+  async function setupTrip(
+    overrides: Partial<Trip> = {},
+  ): Promise<{ kv: InMemoryKV; trip: Trip }> {
+    const kv = new InMemoryKV();
+    const trip = makeLockTripFixture(TOKEN, overrides);
+    await putTrip(kv as unknown as KVNamespace, trip);
+    return { kv, trip };
+  }
+
+  async function runT4(opts: {
+    kv: InMemoryKV;
+    seoul?: SeoulArrivalClient;
+    apnsFetch?: ReturnType<typeof vi.fn>;
+    logMessages?: { msg: string; meta?: Record<string, unknown> }[];
+  }): Promise<{ stats: ScheduledStats; apnsFetch: ReturnType<typeof vi.fn> }> {
+    const apnsFetch = opts.apnsFetch ?? vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(opts.kv), {
+      seoul: opts.seoul ?? makeArrivedSeoul(),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-t4',
+      log: opts.logMessages
+        ? (msg, meta) => {
+            opts.logMessages!.push({ msg, meta });
+          }
+        : undefined,
+    });
+    return { stats, apnsFetch };
+  }
+
+  // 양방향 + 회귀 박제 시나리오 (issue body §검증 + 보강 섹션 arvlcdScenarios).
+  type Scenario = {
+    name: string;
+    motionState: 'moving' | 'stationary' | 'unknown';
+    userIntentDeclared?: boolean;
+    subsurface?: boolean;
+    expectFire: boolean;
+    expectBlockReason?: 'motion-stationary' | 'env-consensus-fail';
+  };
+
+  const arvlcdScenarios: Scenario[] = [
+    // Positive — moving + lock + arvlcd → fire
+    {
+      name: 'P1 moving + lock + arvlcd ARRIVED + trainCode 일치 → fire',
+      motionState: 'moving',
+      expectFire: true,
+    },
+    // Positive — unknown(레거시 / T3 미wire) + lock + arvlcd → fire (gate dormant for unknown)
+    {
+      name: 'P2 unknown(레거시) + lock + arvlcd → fire (게이트 dormant)',
+      motionState: 'unknown',
+      expectFire: true,
+    },
+    // Positive — userIntentDeclared 의향 ON trip은 stationary여도 motion gate 통과 ([[feedback_user_intent_equal_protection]])
+    {
+      name: 'P3 stationary + userIntentDeclared=true → fire (P8 동급 보장)',
+      motionState: 'stationary',
+      userIntentDeclared: true,
+      expectFire: true,
+    },
+    // Negative — 2026-06-19 회귀 박제
+    {
+      name: 'N1 stationary trip + lock + arvlcd → blocked motion-stationary (회귀 박제)',
+      motionState: 'stationary',
+      expectFire: false,
+      expectBlockReason: 'motion-stationary',
+    },
+    // Note: N4 train-mismatch는 본 entry point(arvlcd fire)에서는 구조적으로 도달 불가 —
+    // `estimateBoardingLockArrival`이 이미 lock.trainCode 기준으로 Seoul 응답을 필터하므로,
+    // 일치하지 않는 trainCode는 estimate=null이 되어 vanish path로 분기한다. T2 #1555
+    // advanceTripPosition.test.ts에 게이트 #5 단위 테스트가 박제됨. 본 통합 suite는 arvlcd
+    // entry에서 실제로 활성화되는 시나리오만 cover (motion/env/seed).
+    // Negative — 지하 + base 게이트(gatePassed)는 통과하지만 환경 게이트는 lockAttachable=true로
+    // OR strongBE 통과 (즉 underground도 fire 가능). 본 시나리오는 environment fallthrough를 박제.
+    {
+      name: 'N6-pass underground + arvlcd + lockAttachable → fire (B+E 2-of-2)',
+      motionState: 'moving',
+      subsurface: true,
+      expectFire: true,
+    },
+  ];
+
+  it.each(arvlcdScenarios)('$name', async (sc) => {
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const { kv, trip } = await setupTrip(sc.subsurface !== undefined ? { subsurface: sc.subsurface } : {});
+    // SSoT seed — sc.motionState=='unknown'은 미시드(legacy lazy-seed 경로) 시뮬, 그 외는 명시 stamp.
+    if (sc.motionState !== 'unknown') {
+      const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산', {
+        expiresAt: trip.expiresAt,
+        userIntentDeclared: sc.userIntentDeclared ?? false,
+      });
+      ssot.motionState = sc.motionState;
+      await writeSsot(kv as unknown as KVNamespace, ssot, { expiresAt: trip.expiresAt });
+    }
+    const logMessages: { msg: string; meta?: Record<string, unknown> }[] = [];
+    const { stats } = await runT4({
+      kv,
+      seoul: makeArrivedSeoul(),
+      apnsFetch,
+      logMessages,
+    });
+    if (sc.expectFire) {
+      expect(stats.arvlCdFireFired).toBe(1);
+      expect(stats.arvlCdFireSuccess).toBe(1);
+      expect(stats.arvlCdFireBlocked).toBe(0);
+      expect(getArvlCdStationPassedCalls(apnsFetch)).toHaveLength(1);
+    } else {
+      expect(stats.arvlCdFireFired).toBe(0);
+      expect(stats.arvlCdFireSuccess).toBe(0);
+      expect(stats.arvlCdFireBlocked).toBe(1);
+      expect(getArvlCdStationPassedCalls(apnsFetch)).toHaveLength(0);
+      // blockReason은 log meta로 stamp되어 production tail에서 분포 측정 가능해야 함.
+      const blockedLog = logMessages.find((l) => l.msg === 'arvlcd-fire: blocked');
+      expect(blockedLog?.meta?.reason).toBe(sc.expectBlockReason);
+    }
+  });
+
+  it('lazy-seed — SSoT 부재 시 currentStationId=waypoint.stationName으로 자동 시드', async () => {
+    const { kv } = await setupTrip();
+    expect(await readSsot(kv as unknown as KVNamespace, TOKEN)).toBeNull();
+    const logMessages: { msg: string; meta?: Record<string, unknown> }[] = [];
+    await runT4({ kv, logMessages });
+    const ssot = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    expect(ssot).not.toBeNull();
+    // advance 통과 후 currentStationId=waypoint.stationName(='중곡')으로 유지.
+    expect(ssot?.currentStationId).toBe('중곡');
+    // 직전 currentStationId(='중곡' seed 값)가 passedStations에 append됨 (appendUnique).
+    expect(ssot?.passedStations).toContain('중곡');
+    expect(logMessages.some((l) => l.msg === 'arvlcd-fire: lazy-seed ssot')).toBe(true);
+  });
+
+  it('cross-station dedup — lastFiredStation 윈도우 내 다른 station은 차단(기존 게이트 유지)', async () => {
+    // SSoT는 advance 통과시키되, trip.lastFiredStation 윈도우 가드(scheduled.ts:921-936)는 그대로.
+    const { kv, trip } = await setupTrip({
+      lastFiredStation: { stationName: '용마산', epochMs: NOW - 1_000 },
+    });
+    await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산', {
+      expiresAt: trip.expiresAt,
+    });
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const { stats } = await runT4({ kv, apnsFetch });
+    // advance는 통과 (Fired++) — cross-station dedup은 `fireArvlCdStationPush` 내부에서 push만 차단.
+    expect(stats.arvlCdFireFired).toBe(1);
+    expect(stats.arvlCdFireSuccess).toBe(0);
+    expect(stats.arvlCdFireDedup).toBe(1);
+    expect(getArvlCdStationPassedCalls(apnsFetch)).toHaveLength(0);
+  });
+
+  it('stats — runScheduled 초기 stats에 arvlCdFireBlocked / arvlCdFireFired 0으로 초기화', async () => {
+    const kv = new InMemoryKV();
+    // trip 없이 실행 → 카운터는 0이어야 한다 (초기값 stamp 검증).
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeArrivedSeoul(),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-init',
+    });
+    expect(stats.arvlCdFireBlocked).toBe(0);
+    expect(stats.arvlCdFireFired).toBe(0);
+  });
+
+  it('SSoT는 cron read cacheTtl(30s)로 조회 — ssotKey export로 stamp 검증', async () => {
+    const { kv, trip } = await setupTrip();
+    await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산', {
+      expiresAt: trip.expiresAt,
+    });
+    await runT4({ kv });
+    // 자유 단언 — runScheduled 호출 후에도 SSoT KV row가 유효해야 한다.
+    expect(await kv.get(ssotKey(TOKEN))).not.toBeNull();
   });
 });

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -41,6 +41,12 @@ import { matchLine } from './lineAlias';
 import { computeAllowedLines } from './consensusGate';
 import { attachTrainCodeForLeg } from './lockSwap';
 import {
+  advanceTripPosition,
+  type AdvanceBlockReason,
+  type EvidenceEnvironment,
+} from './advanceTripPosition';
+import { readSsot, seedSsot, SSOT_CRON_READ_CACHE_TTL_SEC } from './tripPositionSsot';
+import {
   evaluateWindow,
   readSeries,
   type WindowedMetrics,
@@ -329,6 +335,20 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   arvlCdFireMismatch: number;
   /**
+   * ADR-017 T4 (#1557) — `advanceTripPosition` SSoT 게이트가 차단해 매역 push가 발사되지
+   * 않은 누적 횟수. 2026-06-19 정지 trip + lock active + arvlcd ARRIVED → false 발사 회귀
+   * (N1)를 직접 차단하는 게이트. 0이 아니면 stationary trip / env-consensus-fail /
+   * train-mismatch 등 6단 게이트 reject 분포를 production tail로 측정 가능.
+   */
+  arvlCdFireBlocked: number;
+  /**
+   * ADR-017 T4 (#1557) — `advanceTripPosition`이 'advanced' 통과 후 실제로 push 발사 시도까지
+   * 도달한 누적 횟수. `arvlCdFireSuccess`(push ack 성공)와 별개 — fire 진입(SSoT 통과)
+   * vs 외부 APNs 성공률을 분리 측정. `arvlCdFireBlocked`와 합쳐 SSoT 게이트의 traffic
+   * 비중(blocked / fired) 분포를 추적한다.
+   */
+  arvlCdFireFired: number;
+  /**
    * #1370 L2 — trainCode vanish 후 시간 기반 fallback advance 직전에 station-passed silent push가
    * 발사된 누적 횟수. fallback path가 어린이대공원/군자/중곡 같은 intermediate를 "지났음" 신호 없이
    * 통과하던 회귀(silent push 0건)를 닫는다.
@@ -418,6 +438,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     arvlCdFireSuccess: 0,
     arvlCdFireDedup: 0,
     arvlCdFireMismatch: 0,
+    arvlCdFireBlocked: 0,
+    arvlCdFireFired: 0,
     vanishFallbackFired: 0,
     vanishReleaseFired: 0,
     vanishLocklessTakeover: 0,
@@ -1011,6 +1033,103 @@ export async function fireArvlCdStationPush(
 }
 
 /**
+ * ADR-017 T4 (#1557) — `advanceTripPosition` SSoT 게이트를 통과한 경우에만 매역 arvlCd push를
+ * 발사하는 thin wrapper.
+ *
+ * 호출 흐름:
+ *   1. SSoT 부재 시 lazy-seed (currentStationId = waypoint.stationName). T1/T2 마이그레이션
+ *      이전 trip 호환. seed 직후 candidate=current이지만 `appendUnique`가 noop 처리.
+ *   2. `advanceTripPosition` 6단 게이트 호출.
+ *   3. `blocked` → push 발사 X. `arvlCdFireBlocked` 카운트 + reason log. Trip mutation 없음.
+ *   4. `advanced` → `arvlCdFireFired` 카운트 후 기존 `fireArvlCdStationPush` 위임 (cross-station
+ *      dedup + APNs send + envHeal + pending fallback 안전망 등 기존 wiring 재사용).
+ *
+ * Trip mutation은 fire 성공 시 `fireArvlCdStationPush`의 dirty 결과를 그대로 forward — 호출자
+ * (`handleBoardingLockTracking`)가 putTrip을 결정한다.
+ *
+ * @returns dirty=true는 trip 객체가 in-place mutate되어 caller가 putTrip 필요.
+ */
+async function tryAdvanceAndFireArvlcd(inputs: {
+  trip: Trip;
+  waypoint: Waypoint;
+  lock: BoardingLockMeta;
+  arvlCd: number;
+  env: Env;
+  deps: ScheduledDeps;
+  stats: ScheduledStats;
+  now: number;
+  log: Logger;
+  generatePushId: () => string;
+}): Promise<{ dirty: boolean }> {
+  const { trip, waypoint, lock, arvlCd, env, deps, stats, now, log, generatePushId } = inputs;
+  let ssot = await readSsot(env.TRIPS, trip.token, { cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC });
+  if (ssot === null) {
+    // Lazy-seed for legacy trips (T1 미마이그레이션). motionState='unknown'로 시작 — T3가
+    // device upload로 motion 갱신을 시작하면 게이트 #2가 자동 활성화.
+    ssot = await seedSsot(env.TRIPS, trip.token, waypoint.stationName, {
+      expiresAt: trip.expiresAt,
+    });
+    log('arvlcd-fire: lazy-seed ssot', {
+      token: trip.token.slice(0, 8),
+      currentStationId: waypoint.stationName,
+    });
+  }
+  const outcome = await advanceTripPosition(
+    env.TRIPS,
+    trip.token,
+    waypoint.stationName,
+    {
+      type: 'arvlcd-confirmed-train',
+      stationId: waypoint.stationName,
+      ts: now,
+      environment: deriveEvidenceEnvironment(trip),
+      arvlcdTrainCode: lock.trainCode,
+      arvlCd,
+    },
+    {
+      // lock 활성 = base 합의 surrogate. consensusGate가 surface는 base만으로, underground는
+      // arrival + lockAttachable 2-of-2로, mixed/unknown은 base + arrival + lockAttachable 모두로
+      // 검증. lock 활성 trip에서 lockAttachable 단일 trainCode 수렴은 lock 부착 자체가 증거.
+      gatePassed: true,
+      lockAttachable: true,
+    },
+  );
+  if (outcome.result !== 'advanced') {
+    stats.arvlCdFireBlocked += 1;
+    log('arvlcd-fire: blocked', {
+      token: trip.token.slice(0, 8),
+      trainCode: lock.trainCode,
+      station: waypoint.stationName,
+      reason: outcome.blockReason satisfies AdvanceBlockReason | undefined,
+    });
+    return { dirty: false };
+  }
+  stats.arvlCdFireFired += 1;
+  return fireArvlCdStationPush({
+    trip,
+    waypoint,
+    lock,
+    arvlCd,
+    env,
+    deps,
+    stats,
+    now,
+    log,
+    generatePushId,
+  });
+}
+
+/**
+ * Trip.subsurface → EvidenceEnvironment 매핑. `consensusGate.StationEnvironment` 어휘로 변환은
+ * `mapEvidenceEnvironment`가 담당하므로 본 함수는 device upload 어휘만 산출한다.
+ */
+function deriveEvidenceEnvironment(trip: Trip): EvidenceEnvironment {
+  if (trip.subsurface === true) return 'underground';
+  if (trip.subsurface === false) return 'surface';
+  return 'unknown';
+}
+
+/**
  * #1370 L2 — trainCode vanish 후 시간 기반 fallback advance 직전에 발사하는 station-passed silent push.
  *
  * arvlCd fire 경로와 모양은 같지만 SSOT가 다르다 — arvlCd∈{0,1}이 아니라 "trainCode 사라짐 + hop 시간
@@ -1420,10 +1539,17 @@ export async function runTrainCodeTracking(
     stats.kalmanReset += 1;
     // #917 A2 — 매역 알림 1차 source는 arvlCd∈{0(ENTERING), 1(ARRIVED)}.
     // positions-fallback arrived(arvlCd=null)는 SSOT 다름 — mismatch로 분류해 push X.
-    // prereq 게이트: lock 활성 + arvlCd∈{0,1}. #640 회귀(lock 없는 trip 발사) defensive recheck.
-    const gate = evaluateArvlCdFireGate(activeLock, estimate.arvlCd, now);
-    if (gate === 'fire' && estimate.arvlCd !== null) {
-      const fire = await fireArvlCdStationPush({
+    // prereq 게이트(레거시): lock 활성 + arvlCd∈{0,1}. #640 회귀(lock 없는 trip 발사) defensive recheck.
+    const legacyGate = evaluateArvlCdFireGate(activeLock, estimate.arvlCd, now);
+    if (legacyGate === 'fire' && estimate.arvlCd !== null) {
+      // ADR-017 T4 (#1557) — 분산된 fire 게이트를 `advanceTripPosition` 단일 진입점으로 통합.
+      // 6단 게이트(seed/motion/env/type/train identity/lockless arvlcd 단독)를 통과한 advance
+      // 결과만 push 발사로 이어진다. 2026-06-19 정지 trip false 발사 회귀(N1)를 직접 차단.
+      //
+      // SSoT 부재 (legacy trip / 마이그레이션 전) → lazy-seed로 currentStationId=waypoint.stationName
+      // 정착. T3 motion state machine wire 전이므로 motionState='unknown' — 정지 게이트는 dormant
+      // 상태이지만, T3가 device upload로 motionState='stationary'를 stamp하기 시작하면 자동 활성화.
+      const fireOutcome = await tryAdvanceAndFireArvlcd({
         trip,
         waypoint,
         lock: activeLock,
@@ -1435,7 +1561,7 @@ export async function runTrainCodeTracking(
         log,
         generatePushId,
       });
-      if (fire.dirty) await putTrip(env.TRIPS, trip);
+      if (fireOutcome.dirty) await putTrip(env.TRIPS, trip);
     } else {
       stats.arvlCdFireMismatch += 1;
       log('arvlcd-fire: mismatch (prereq failed)', {


### PR DESCRIPTION
Closes #1557. ADR-017 T4. 오늘(2026-06-19) 정지 misfire 회귀(N1: 정지 trip + lock active + arvlcd ARRIVED → wrong "transfer imminent 건대입구") 직접 차단.

## 변경 사항
- `backend/alarm-worker/src/scheduled.ts:1416~1450`(arvlcd-arrived branch) — fire 직전 `advanceTripPosition` 단일 진입점 호출. blocked → push X / advanced → 기존 `fireArvlCdStationPush` 위임.
- SSoT 부재 trip(레거시)은 lazy-seed (`currentStationId = waypoint.stationName`, `motionState='unknown'`)로 호환. T3 wire 전이라 motion 게이트는 dormant이지만 device upload 시작 시 자동 활성화.
- `ScheduledStats` 신규 필드: `arvlCdFireBlocked` (게이트 reject 누적) / `arvlCdFireFired` (advance + fire 진입 누적). 기존 `arvlCdFireSuccess`(APNs ack 성공)와 분리 측정.
- `evaluateArvlCdFireGate`는 호환성 export 유지 (T2 PR #1564에서 jsdoc `@deprecated` 마킹 완료).
- `cross-station dedup`(scheduled.ts:921-936, `SAME_PHASE_STATION_DEDUP_WINDOW_MS`)은 `fireArvlCdStationPush` 내부에서 그대로 유지 — advance 통과 후에도 적용.

## 양방향 acceptance 매핑
| 시나리오 | 게이트 결과 | 테스트 |
| --- | --- | --- |
| P1 moving + lock + arvlcd ARRIVED + trainCode 일치 | fire (advanced) | `arvlcdScenarios[0]` |
| P2 unknown(레거시 / T3 미wire) + lock + arvlcd | fire (motion gate dormant) | `arvlcdScenarios[1]` |
| P3 stationary + userIntentDeclared=true | fire (P8 동급 보장, ADR-014) | `arvlcdScenarios[2]` |
| **N1 stationary + lock + arvlcd ARRIVED** | blocked motion-stationary | `arvlcdScenarios[3]` ← 회귀 박제 |
| N6 underground + arvlcd + lockAttachable | fire (B+E 2-of-2 strong consensus) | `arvlcdScenarios[4]` |
| Lazy-seed — SSoT 부재 | seed + advance | `it('lazy-seed...')` |
| cross-station dedup (lastFiredStation window) | Fired++ but push X | `it('cross-station dedup...')` |
| Stats 초기화 | 모두 0 | `it('stats — runScheduled 초기...')` |

**Note**: N4 train-mismatch는 본 entry point에서 구조적으로 도달 불가 — `estimateBoardingLockArrival`이 이미 `lock.trainCode` 기준으로 Seoul 응답을 필터하므로 일치하지 않는 trainCode는 estimate=null이 되어 vanish path로 분기. T2 PR #1564 단위 테스트(`advanceTripPosition.test.ts`)에 게이트 #5 박제됨.

## 검증
- `cd backend/alarm-worker && npm test` → 41 test files / 1632 tests / ALL PASS
- `npm run type-check` (루트) → PASS
- `scheduled.test.ts` 240 tests (T4 신규 9건 + 기존 231건) ALL PASS

## 후속 (스코프 외)
- T5 #1558: `advanceBoardingLockWaypoint` (vanish-fallback path) reader migration
- T3 motion state machine device wire: 본 PR은 SSoT가 `motionState='unknown'`일 때 게이트 dormant. T3가 device upload로 stamp 시작하면 자동 활성화.