### PR TITLE
feat(#1561): silent push payload SSoT 권위 forward + device mirror (T8 Phase 1, S2 #1535 흡수)

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -380,6 +380,61 @@ describe('sendSilentPush', () => {
     if (expectPresent) expect(body.data.passedStations).toEqual(input);
   });
 
+  // #1561 (T8, ADR-017 / S2 #1535 흡수) — payload.ssot wire 검증.
+  // ssot이 정의되면 currentStationId/motionState/lastAdvanceEvidence/lastAdvanceAt/passedStations가
+  // body.data.ssot으로 그대로 forward. undefined면 omit (구 device 호환).
+  it('forwards ssot to body.data.ssot when defined (#1561)', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const ssotInput = {
+      currentStationId: '강남',
+      motionState: 'moving' as const,
+      lastAdvanceEvidence: 'arvlcd-confirmed-train',
+      lastAdvanceAt: 1_700_000_000_500,
+      passedStations: ['교대', '서초'],
+    };
+    await sendSilentPush({
+      deviceToken: 'tok',
+      payload: {
+        nextWaypoint: '강남',
+        etaSeconds: 0,
+        phase: 'imminent',
+        kind: 'intermediate',
+        sentAt: 1_700_000_000_000,
+        pushId: 'p',
+        ssot: ssotInput,
+      },
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.data.ssot).toEqual(ssotInput);
+    // passedStations은 새 배열로 forward되어 caller mutate가 wire에 영향 주지 않아야.
+    expect(body.data.ssot.passedStations).not.toBe(ssotInput.passedStations);
+  });
+
+  it('omits ssot field when undefined (#1561 구 device 호환)', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await sendSilentPush({
+      deviceToken: 'tok',
+      payload: {
+        nextWaypoint: '강남',
+        etaSeconds: 0,
+        phase: 'imminent',
+        kind: 'intermediate',
+        sentAt: 1_700_000_000_000,
+        pushId: 'p',
+      },
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect('ssot' in body.data).toBe(false);
+  });
+
   it('uses sandbox host when provided', async () => {
     const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) =>
       new Response('', { status: 200 }),

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -29,9 +29,11 @@ import {
   computeCronJitterMs,
   PASSED_STATIONS_MAX_LEN,
   CRON_NOMINAL_INTERVAL_MS,
+  toSilentPushSsot,
   type ScheduledDeps,
   type ScheduledStats,
 } from '../scheduled';
+import { seedSsot, type TripPositionSSoT } from '../tripPositionSsot';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from '../seoul';
 import { putTrip } from '../trips';
 import type { BoardingLockMeta, Env, PositionPoint, Trip, Waypoint } from '../types';
@@ -5135,5 +5137,163 @@ describe('runScheduled cron jitter stat (#1539 S6)', () => {
     expect(stats.cronJitterMs).toBe(expectedJitter);
     expect(logMessages.some((l) => l.msg === 'scheduled: cron jitter' && l.meta?.jitterMs === expectedJitter))
       .toBe(true);
+  });
+});
+
+// #1561 (T8, ADR-017 / S2 #1535 흡수) — silent push payload SSoT 권위 forward.
+//
+// 검증 범위:
+//   1. toSilentPushSsot helper — null/undefined → undefined, 정의된 SSoT → 축소 형태 + passedStations 최근 5개 슬라이스.
+//   2. fireArvlCdStationPush 발사 시 backend SSoT KV에서 읽어 payload.ssot으로 forward.
+//   3. SSoT 부재 trip(seed 전) — payload.ssot 자연 누락 (graceful, 구 device 호환).
+//   4. lockless intermediate fire도 동일하게 SSoT forward.
+describe('silent push SSoT forward (#1561 T8 / S2 흡수)', () => {
+  it('toSilentPushSsot returns undefined for null/undefined input', () => {
+    expect(toSilentPushSsot(null)).toBeUndefined();
+    expect(toSilentPushSsot(undefined)).toBeUndefined();
+  });
+
+  it('toSilentPushSsot reduces TripPositionSSoT to wire payload + slices passedStations to last 5', () => {
+    const ssot: TripPositionSSoT = {
+      tripToken: 'tok-ssot-1',
+      currentStationId: '강남',
+      motionState: 'moving',
+      motionEvidence: [],
+      lastAdvanceAt: 1_700_000_001_000,
+      lastAdvanceEvidence: 'arvlcd-confirmed-train',
+      passedStations: ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
+      userIntentDeclared: false,
+      seedOverrideCount: 0,
+      schemaVersion: 1,
+    };
+    const payload = toSilentPushSsot(ssot);
+    expect(payload).toEqual({
+      currentStationId: '강남',
+      motionState: 'moving',
+      lastAdvanceEvidence: 'arvlcd-confirmed-train',
+      lastAdvanceAt: 1_700_000_001_000,
+      passedStations: ['C', 'D', 'E', 'F', 'G'],
+    });
+  });
+
+  it('arvlcd-fire forwards SSoT from KV to silent push payload', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'ssot-arvlcd-1',
+        waypoints: [
+          { stationName: '중곡', line: '7', kind: 'intermediate' },
+          { stationName: '용마산', line: '7', kind: 'destination' },
+        ],
+        boardingLock: {
+          trainCode: 'T',
+          line: '7',
+          subwayId: '1007',
+          selectedDepartureTime: NOW,
+          segmentStations: ['중곡', '용마산'],
+          expiresAt: NOW + 60 * 60_000,
+        },
+      }),
+    );
+    await seedSsot(kv as unknown as KVNamespace, 'ssot-arvlcd-1', '중곡');
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    await runScheduled(makeEnv(kv), {
+      seoul: makeLockedSeoul(0, 1),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    const calls = apnsFetch.mock.calls as unknown as [string, RequestInit][];
+    const arvlcdCall = calls.find((c) => {
+      const body = JSON.parse(c[1].body as string);
+      return body.data?.origin === 'arvlcd';
+    });
+    expect(arvlcdCall).toBeDefined();
+    const body = JSON.parse(arvlcdCall![1].body as string);
+    expect(body.data.ssot).toBeDefined();
+    expect(body.data.ssot.currentStationId).toBe('중곡');
+    expect(body.data.ssot.motionState).toBe('unknown');
+  });
+
+  it('arvlcd-fire omits ssot field when SSoT KV is absent (graceful)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'ssot-arvlcd-absent',
+        waypoints: [
+          { stationName: '중곡', line: '7', kind: 'intermediate' },
+          { stationName: '용마산', line: '7', kind: 'destination' },
+        ],
+        boardingLock: {
+          trainCode: 'T',
+          line: '7',
+          subwayId: '1007',
+          selectedDepartureTime: NOW,
+          segmentStations: ['중곡', '용마산'],
+          expiresAt: NOW + 60 * 60_000,
+        },
+      }),
+    );
+    // SSoT 미seed → readSsot null 반환.
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    await runScheduled(makeEnv(kv), {
+      seoul: makeLockedSeoul(0, 1),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    const calls = apnsFetch.mock.calls as unknown as [string, RequestInit][];
+    const arvlcdCall = calls.find((c) => {
+      const body = JSON.parse(c[1].body as string);
+      return body.data?.origin === 'arvlcd';
+    });
+    expect(arvlcdCall).toBeDefined();
+    const body = JSON.parse(arvlcdCall![1].body as string);
+    expect('ssot' in body.data).toBe(false);
+  });
+
+  it('lockless-fire forwards SSoT from KV to silent push payload', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({
+      token: 'ssot-lockless-1',
+      route: { type: 'direct', line: '2', stops: 2 },
+      waypoints: [
+        { stationName: '강남', line: '2', kind: 'intermediate' },
+        { stationName: '역삼', line: '2', kind: 'intermediate' },
+      ],
+      locklessStationPassed: true,
+    });
+    await putTrip(kv as unknown as KVNamespace, trip);
+    await seedLocklessMotionSeries(kv, trip.token, 'automotive');
+    await seedSsot(kv as unknown as KVNamespace, trip.token, '강남');
+    const arrived: ArrivalEntry = {
+      destination: '강남행',
+      arrivalSeconds: 30,
+      trainCode: '7246',
+      isUp: true,
+      subwayNm: '지하철2호선',
+      arvlCd: 1,
+    };
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([arrived]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    const calls = apnsFetch.mock.calls as unknown as [string, RequestInit][];
+    const locklessCall = calls.find((c) => {
+      const body = JSON.parse(c[1].body as string);
+      return body.data?.origin === 'lockless';
+    });
+    expect(locklessCall).toBeDefined();
+    const body = JSON.parse(locklessCall![1].body as string);
+    expect(body.data.ssot).toBeDefined();
+    expect(body.data.ssot.currentStationId).toBe('강남');
   });
 });

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -5026,52 +5026,113 @@ describe('computeCronJitterMs (#1539 S6)', () => {
   });
 });
 
+// #1561 (T8) — SSoT forward + passedStations 테스트 공용 setup. Sonar 중복 제거.
+const ARVLCD_LOCK_BOILER = {
+  trainCode: 'T',
+  line: '7',
+  subwayId: '1007',
+  selectedDepartureTime: NOW,
+  segmentStations: ['중곡', '용마산'],
+  expiresAt: NOW + 60 * 60_000,
+} as const;
+
+const LOCKLESS_ARRIVED: ArrivalEntry = {
+  destination: '강남행',
+  arrivalSeconds: 30,
+  trainCode: '7246',
+  isUp: true,
+  subwayNm: '지하철2호선',
+  arvlCd: 1,
+};
+
+async function runArvlcdSsotFireScenario(opts: {
+  token: string;
+  waypoints: Waypoint[];
+  seedSsotStation?: string;
+}): Promise<{ arvlcdBody: Record<string, any> | null; stored: Trip }> {
+  const kv = new InMemoryKV();
+  await putTrip(
+    kv as unknown as KVNamespace,
+    makeTrip({
+      token: opts.token,
+      waypoints: opts.waypoints,
+      boardingLock: { ...ARVLCD_LOCK_BOILER },
+    }),
+  );
+  if (opts.seedSsotStation !== undefined) {
+    await seedSsot(kv as unknown as KVNamespace, opts.token, opts.seedSsotStation);
+  }
+  const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+  await runScheduled(makeEnv(kv), {
+    seoul: makeLockedSeoul(0, 1),
+    apnsConfig,
+    apnsHosts: APNS_HOSTS,
+    fetchImpl: apnsFetch as unknown as typeof fetch,
+    now: () => NOW,
+  });
+  const calls = apnsFetch.mock.calls as unknown as [string, RequestInit][];
+  const arvlcdCall = calls.find((c) => {
+    const body = JSON.parse(c[1].body as string);
+    return body.data?.origin === 'arvlcd';
+  });
+  return {
+    arvlcdBody: arvlcdCall ? JSON.parse(arvlcdCall[1].body as string) : null,
+    stored: JSON.parse((await kv.get(`trip:${opts.token}`)) as string) as Trip,
+  };
+}
+
+async function runLocklessSsotFireScenario(opts: {
+  token: string;
+  waypoints: Waypoint[];
+  seedSsotStation?: string;
+}): Promise<{ stored: Trip; locklessBody: Record<string, any> | null }> {
+  const kv = new InMemoryKV();
+  const trip = makeTrip({
+    token: opts.token,
+    route: { type: 'direct', line: '2', stops: 2 },
+    waypoints: opts.waypoints,
+    locklessStationPassed: true,
+  });
+  await putTrip(kv as unknown as KVNamespace, trip);
+  await seedLocklessMotionSeries(kv, trip.token, 'automotive');
+  if (opts.seedSsotStation !== undefined) {
+    await seedSsot(kv as unknown as KVNamespace, opts.token, opts.seedSsotStation);
+  }
+  const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+  await runScheduled(makeEnv(kv), {
+    seoul: makeSeoul([LOCKLESS_ARRIVED]),
+    apnsConfig,
+    apnsHosts: APNS_HOSTS,
+    fetchImpl: apnsFetch as unknown as typeof fetch,
+    now: () => NOW,
+  });
+  const calls = apnsFetch.mock.calls as unknown as [string, RequestInit][];
+  const locklessCall = calls.find((c) => {
+    const body = JSON.parse(c[1].body as string);
+    return body.data?.origin === 'lockless';
+  });
+  return {
+    stored: JSON.parse((await kv.get(`trip:${opts.token}`)) as string) as Trip,
+    locklessBody: locklessCall ? JSON.parse(locklessCall[1].body as string) : null,
+  };
+}
+
 describe('advanceBoardingLockWaypoint passedStations 누적 (#1539 S6)', () => {
   // arvlCd=ARRIVED → fireArvlCdStationPush → advance → trip.passedStations에 통과 station이 누적.
   // 이후 putTrip되어 KV에서 읽으면 wire가 전달된다 (다음 cycle silent push payload).
   it('accumulates passed stationName into trip.passedStations and forwards to payload', async () => {
-    const kv = new InMemoryKV();
-    // intermediate waypoint(중곡)가 ARRIVED로 advance → trip.passedStations에 push.
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeTrip({
-        token: 'pass-1',
-        waypoints: [
-          { stationName: '중곡', line: '7', kind: 'intermediate' },
-          { stationName: '용마산', line: '7', kind: 'intermediate' },
-          { stationName: '강남', line: '2', kind: 'destination' },
-        ],
-        boardingLock: {
-          trainCode: 'T',
-          line: '7',
-          subwayId: '1007',
-          selectedDepartureTime: NOW,
-          segmentStations: ['중곡', '용마산'],
-          expiresAt: NOW + 60 * 60_000,
-        },
-      }),
-    );
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    await runScheduled(makeEnv(kv), {
-      seoul: makeLockedSeoul(0, 1),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
+    const { stored, arvlcdBody } = await runArvlcdSsotFireScenario({
+      token: 'pass-1',
+      waypoints: [
+        { stationName: '중곡', line: '7', kind: 'intermediate' },
+        { stationName: '용마산', line: '7', kind: 'intermediate' },
+        { stationName: '강남', line: '2', kind: 'destination' },
+      ],
     });
-    const stored = JSON.parse((await kv.get('trip:pass-1')) as string) as Trip;
     expect(stored.passedStations).toEqual(['중곡']);
-    // arvlCd-fire path silent push payload에 passedStations forward.
-    const calls = apnsFetch.mock.calls as unknown as [string, RequestInit][];
-    const arvlcdCall = calls.find((c) => {
-      const body = JSON.parse(c[1].body as string);
-      return body.data?.origin === 'arvlcd';
-    });
-    expect(arvlcdCall).toBeDefined();
-    const arvlcdBody = JSON.parse(arvlcdCall![1].body as string);
     // arvlCd-fire는 advance 직전 호출이라 fire 시점엔 아직 passedStations에 push되지 않은 상태.
-    // arvlCd fire path는 stationary trip-state(즉, 발사 시점)를 그대로 forward — empty이면 omit.
-    expect(arvlcdBody.data.passedStations).toBeUndefined();
+    expect(arvlcdBody).toBeDefined();
+    expect(arvlcdBody!.data.passedStations).toBeUndefined();
   });
 });
 
@@ -5177,123 +5238,45 @@ describe('silent push SSoT forward (#1561 T8 / S2 흡수)', () => {
   });
 
   it('arvlcd-fire forwards SSoT from KV to silent push payload', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeTrip({
-        token: 'ssot-arvlcd-1',
-        waypoints: [
-          { stationName: '중곡', line: '7', kind: 'intermediate' },
-          { stationName: '용마산', line: '7', kind: 'destination' },
-        ],
-        boardingLock: {
-          trainCode: 'T',
-          line: '7',
-          subwayId: '1007',
-          selectedDepartureTime: NOW,
-          segmentStations: ['중곡', '용마산'],
-          expiresAt: NOW + 60 * 60_000,
-        },
-      }),
-    );
-    await seedSsot(kv as unknown as KVNamespace, 'ssot-arvlcd-1', '중곡');
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    await runScheduled(makeEnv(kv), {
-      seoul: makeLockedSeoul(0, 1),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
+    const { arvlcdBody } = await runArvlcdSsotFireScenario({
+      token: 'ssot-arvlcd-1',
+      waypoints: [
+        { stationName: '중곡', line: '7', kind: 'intermediate' },
+        { stationName: '용마산', line: '7', kind: 'destination' },
+      ],
+      seedSsotStation: '중곡',
     });
-    const calls = apnsFetch.mock.calls as unknown as [string, RequestInit][];
-    const arvlcdCall = calls.find((c) => {
-      const body = JSON.parse(c[1].body as string);
-      return body.data?.origin === 'arvlcd';
-    });
-    expect(arvlcdCall).toBeDefined();
-    const body = JSON.parse(arvlcdCall![1].body as string);
-    expect(body.data.ssot).toBeDefined();
-    expect(body.data.ssot.currentStationId).toBe('중곡');
-    expect(body.data.ssot.motionState).toBe('unknown');
+    expect(arvlcdBody).toBeDefined();
+    expect(arvlcdBody!.data.ssot).toBeDefined();
+    expect(arvlcdBody!.data.ssot.currentStationId).toBe('중곡');
+    expect(arvlcdBody!.data.ssot.motionState).toBe('unknown');
   });
 
   it('arvlcd-fire omits ssot field when SSoT KV is absent (graceful)', async () => {
-    const kv = new InMemoryKV();
-    await putTrip(
-      kv as unknown as KVNamespace,
-      makeTrip({
-        token: 'ssot-arvlcd-absent',
-        waypoints: [
-          { stationName: '중곡', line: '7', kind: 'intermediate' },
-          { stationName: '용마산', line: '7', kind: 'destination' },
-        ],
-        boardingLock: {
-          trainCode: 'T',
-          line: '7',
-          subwayId: '1007',
-          selectedDepartureTime: NOW,
-          segmentStations: ['중곡', '용마산'],
-          expiresAt: NOW + 60 * 60_000,
-        },
-      }),
-    );
     // SSoT 미seed → readSsot null 반환.
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    await runScheduled(makeEnv(kv), {
-      seoul: makeLockedSeoul(0, 1),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
+    const { arvlcdBody } = await runArvlcdSsotFireScenario({
+      token: 'ssot-arvlcd-absent',
+      waypoints: [
+        { stationName: '중곡', line: '7', kind: 'intermediate' },
+        { stationName: '용마산', line: '7', kind: 'destination' },
+      ],
     });
-    const calls = apnsFetch.mock.calls as unknown as [string, RequestInit][];
-    const arvlcdCall = calls.find((c) => {
-      const body = JSON.parse(c[1].body as string);
-      return body.data?.origin === 'arvlcd';
-    });
-    expect(arvlcdCall).toBeDefined();
-    const body = JSON.parse(arvlcdCall![1].body as string);
-    expect('ssot' in body.data).toBe(false);
+    expect(arvlcdBody).toBeDefined();
+    expect('ssot' in arvlcdBody!.data).toBe(false);
   });
 
   it('lockless-fire forwards SSoT from KV to silent push payload', async () => {
-    const kv = new InMemoryKV();
-    const trip = makeTrip({
+    const { locklessBody } = await runLocklessSsotFireScenario({
       token: 'ssot-lockless-1',
-      route: { type: 'direct', line: '2', stops: 2 },
       waypoints: [
         { stationName: '강남', line: '2', kind: 'intermediate' },
         { stationName: '역삼', line: '2', kind: 'intermediate' },
       ],
-      locklessStationPassed: true,
+      seedSsotStation: '강남',
     });
-    await putTrip(kv as unknown as KVNamespace, trip);
-    await seedLocklessMotionSeries(kv, trip.token, 'automotive');
-    await seedSsot(kv as unknown as KVNamespace, trip.token, '강남');
-    const arrived: ArrivalEntry = {
-      destination: '강남행',
-      arrivalSeconds: 30,
-      trainCode: '7246',
-      isUp: true,
-      subwayNm: '지하철2호선',
-      arvlCd: 1,
-    };
-    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
-    await runScheduled(makeEnv(kv), {
-      seoul: makeSeoul([arrived]),
-      apnsConfig,
-      apnsHosts: APNS_HOSTS,
-      fetchImpl: apnsFetch as unknown as typeof fetch,
-      now: () => NOW,
-    });
-    const calls = apnsFetch.mock.calls as unknown as [string, RequestInit][];
-    const locklessCall = calls.find((c) => {
-      const body = JSON.parse(c[1].body as string);
-      return body.data?.origin === 'lockless';
-    });
-    expect(locklessCall).toBeDefined();
-    const body = JSON.parse(locklessCall![1].body as string);
-    expect(body.data.ssot).toBeDefined();
-    expect(body.data.ssot.currentStationId).toBe('강남');
+    expect(locklessBody).toBeDefined();
+    expect(locklessBody!.data.ssot).toBeDefined();
+    expect(locklessBody!.data.ssot.currentStationId).toBe('강남');
   });
 });
+

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -146,6 +146,43 @@ export interface SilentPushPayload {
    * - readonly: payload 빌더가 trip 상태를 share-by-reference로 전달해도 JSON serialize 시 안전.
    */
   passedStations?: readonly string[];
+  /**
+   * #1561 (T8, ADR-017 / S2 #1535 흡수) — backend가 보유한 TripPositionSSoT를 device에 권위로 forward.
+   *
+   * device의 cascade picker(`useFusedNearestStation`)가 `backend-ssot` tier(최상위)로 채택해 lock 활성
+   * / lockless 양쪽에서 backend SSoT가 모든 다른 tier 위에 위치한다. 위젯 stuck("반포") 해소 + 16:04
+   * 어대 detect 즉시 반영 같은 evidence를 단일 권위 필드로 해결한다.
+   *
+   * - undefined → 구 backend 호환 (wire 자연 누락). 기존 cascade tier로 fallback.
+   * - passedStations.slice(-5): 최근 5개만 (payload 크기 폭주 차단).
+   *
+   * 본 필드와 별개로 기존 top-level `passedStations`는 #1539(S6) device backfill 용도로 유지 — 본 SSoT
+   * 필드의 내부 `passedStations`는 device cascade picker가 자기 일관성 검증에만 사용한다.
+   */
+  ssot?: SilentPushSsotPayload;
+}
+
+/**
+ * #1561 (T8) — silent push payload에 forward되는 TripPositionSSoT 권위 스냅샷.
+ *
+ * device가 backend에서 받은 currentStationId + motionState + lastAdvanceEvidence + passedStations
+ * (최근 5개)를 cascade picker의 `backend-ssot` tier 채택 입력으로 사용한다.
+ *
+ * 정수형 시각(sentAt 기준 relative ms가 아닌 epoch ms 그대로)을 사용해 device가 timestamp 비교 시
+ * 별도 변환이 필요 없다. backend SSoT가 stale한 case는 device가 `lastAdvanceAt` 기반으로 자체
+ * staleness 판단(추후 cascade picker policy).
+ */
+export interface SilentPushSsotPayload {
+  /** 현재 device가 위치한다고 backend가 확신하는 stationId(또는 stationName 호환). */
+  currentStationId: string;
+  /** backend SSoT motion state — `'moving'` | `'stationary'` | `'unknown'`. */
+  motionState: 'moving' | 'stationary' | 'unknown';
+  /** 마지막 advance를 통과시킨 evidence type 표시 — device 진단/cascade tier 보조 판단용. */
+  lastAdvanceEvidence: string;
+  /** 마지막 advance epoch ms. 0이면 미발생(seed 직후). */
+  lastAdvanceAt: number;
+  /** 통과 확인된 station 누적 (최근 5개만 forward). */
+  passedStations: readonly string[];
 }
 
 /**
@@ -264,6 +301,20 @@ export async function sendSilentPush(options: SendPushOptions): Promise<SendPush
       ...(options.payload.passedStations && options.payload.passedStations.length > 0
         ? { passedStations: [...options.payload.passedStations] }
         : {}),
+      // #1561 (T8, ADR-017 / S2 흡수) — ssot은 정의된 경우에만 wire. 미전달 시 JSON에서 자연 누락 →
+      // 구 device(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환. device cascade picker가
+      // `backend-ssot` tier(최상위)로 채택한다.
+      ...(options.payload.ssot === undefined
+        ? {}
+        : {
+            ssot: {
+              currentStationId: options.payload.ssot.currentStationId,
+              motionState: options.payload.ssot.motionState,
+              lastAdvanceEvidence: options.payload.ssot.lastAdvanceEvidence,
+              lastAdvanceAt: options.payload.ssot.lastAdvanceAt,
+              passedStations: [...options.payload.ssot.passedStations],
+            },
+          }),
     },
   });
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -10,6 +10,7 @@ import {
   sendSilentPush,
   type ApnsConfig,
   type PushOrigin,
+  type SilentPushPayload,
 } from './apns';
 import { flipApnsEnv, pickApnsHost, sendWithEnvHeal } from './apnsHost';
 import {
@@ -51,6 +52,11 @@ import { deleteProgress, getProgress, putProgress, type TripProgress } from './p
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from './seoul';
 import { phaseAllowsImminentFiring, runStationPhaseStep } from './stationPhase';
 import { listTrips, putTrip } from './trips';
+import {
+  readSsot,
+  SSOT_CRON_READ_CACHE_TTL_SEC,
+  type TripPositionSSoT,
+} from './tripPositionSsot';
 import type {
   ApnsEnv,
   BoardingLockMeta,
@@ -833,11 +839,46 @@ interface BuildStationPassedImminentPayloadInputs {
    * lock을 release하지 않으므로 undefined.
    */
   lockReleasedReason?: 'transfer' | 'vanish';
+  /**
+   * #1561 (T8, ADR-017 / S2 #1535 흡수) — backend가 보유한 TripPositionSSoT 권위 스냅샷.
+   *
+   * 정의된 경우 silent push payload에 `ssot` 필드로 forward → device cascade picker가 `backend-ssot`
+   * tier(최상위)로 채택. 미전달(undefined) 시 payload에서 자연 누락 → device는 기존 cascade fallback.
+   *
+   * SSoT는 caller가 `readSsot(env.TRIPS, trip.token, { cacheTtl: CRON_READ_CACHE_TTL_SEC })`로
+   * 로드해 전달. read 실패 시 undefined를 그대로 전달해 wire에서 자연 누락하는 정책 — backend SSoT가
+   * 부재한 trip(seed 전 / KV race)도 push 발사 자체는 막지 않는다(graceful).
+   */
+  ssot?: TripPositionSSoT | null;
 }
+/**
+ * #1561 (T8) — silent push payload에 forward되는 SSoT 스냅샷의 passedStations 최근 N개 한도.
+ * 4호선 전 구간(40+ 역) 같은 긴 trip에서도 payload 크기 폭주 차단. device는 자체 누적 + 본 forward로
+ * 짧은 history만 cross-check.
+ */
+const SSOT_FORWARD_PASSED_STATIONS_MAX = 5;
+
+/**
+ * #1561 (T8) — `TripPositionSSoT`를 silent push payload에 forward할 수 있는 `SilentPushSsotPayload`
+ * 형태로 축소. null/undefined는 그대로 통과시켜 caller가 wire 자연 누락 분기를 단순화.
+ */
+export function toSilentPushSsot(
+  ssot: TripPositionSSoT | null | undefined,
+): SilentPushPayload['ssot'] {
+  if (ssot == null) return undefined;
+  return {
+    currentStationId: ssot.currentStationId,
+    motionState: ssot.motionState,
+    lastAdvanceEvidence: ssot.lastAdvanceEvidence,
+    lastAdvanceAt: ssot.lastAdvanceAt,
+    passedStations: ssot.passedStations.slice(-SSOT_FORWARD_PASSED_STATIONS_MAX),
+  };
+}
+
 function buildStationPassedImminentPayload(
   inputs: BuildStationPassedImminentPayloadInputs,
 ): Parameters<typeof sendSilentPush>[0]['payload'] {
-  const { trip, waypoint, lock, pushId, now, origin, lockReleasedReason } = inputs;
+  const { trip, waypoint, lock, pushId, now, origin, lockReleasedReason, ssot } = inputs;
   return {
     nextWaypoint: waypoint.stationName,
     // arvlCd∈{0,1}은 "지금 진입/도착" 신호 — eta는 사실상 0. vanish-fallback도 동일 의미.
@@ -871,6 +912,10 @@ function buildStationPassedImminentPayload(
     // #1539 (S6) — backend 누적 passedStations forward. 빈 배열/undefined는 apns.ts JSON
     // serializer가 자연 누락. device backfill diff(S5 후속 wiring PR)에서 사용.
     passedStations: trip.passedStations,
+    // #1561 (T8, ADR-017 / S2 흡수) — TripPositionSSoT 권위 forward. null/undefined는 apns.ts JSON
+    // serializer가 자연 누락 → device cascade picker는 기존 tier fallback. caller가 SSoT를 읽어
+    // 명시 전달. payload size 폭주 차단 위해 passedStations는 최근 5개로 잘려 forward된다.
+    ssot: toSilentPushSsot(ssot),
   };
 }
 
@@ -948,6 +993,12 @@ export async function fireArvlCdStationPush(
     arvlCd,
     kind: waypoint.kind,
   });
+  // #1561 (T8, ADR-017 / S2 흡수) — fire 직전 SSoT 권위 스냅샷을 읽어 payload로 forward.
+  // read 실패/null은 그대로 forward → wire에서 자연 누락(graceful). cacheTtl=30s는 다른 cron read와
+  // 동일 ([[lesson_cron_cachettl_runtime_constraint]]).
+  const ssot = await readSsot(env.TRIPS, trip.token, {
+    cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
+  });
   const heal = await sendWithEnvHeal(
     (host) =>
       sendSilentPush({
@@ -959,6 +1010,7 @@ export async function fireArvlCdStationPush(
           pushId,
           now,
           origin: 'arvlcd',
+          ssot,
         }),
         config: deps.apnsConfig,
         host,
@@ -1090,6 +1142,10 @@ export async function fireVanishFallbackStationPush(
   // release하므로 device에 `lockReleasedReason='vanish'`를 forward해 store sync. vanish-fallback은
   // 직후 `advanceBoardingLockWaypoint`로 흘러가 그 함수가 transfer 시 별도로 release를 통지한다.
   const lockReleasedReason: 'vanish' | undefined = origin === 'vanish-release' ? 'vanish' : undefined;
+  // #1561 (T8, ADR-017 / S2 흡수) — fire 직전 SSoT 권위 스냅샷 forward (arvlcd-fire와 동일 패턴).
+  const ssot = await readSsot(env.TRIPS, trip.token, {
+    cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
+  });
   const heal = await sendWithEnvHeal(
     (host) =>
       sendSilentPush({
@@ -1102,6 +1158,7 @@ export async function fireVanishFallbackStationPush(
           now,
           origin,
           lockReleasedReason,
+          ssot,
         }),
         config: deps.apnsConfig,
         host,
@@ -1581,6 +1638,10 @@ export async function advanceBoardingLockWaypoint(
   // payload.lockReleasedReason='transfer'가 우선 처리돼 store sync 후 본 처리 흐름을 그대로 진행한다.
   if (lockReleasedOnTransfer && releasedLockSnapshot !== undefined) {
     const pushId = crypto.randomUUID();
+    // #1561 (T8, ADR-017 / S2 흡수) — transfer-release fire 직전 SSoT 권위 스냅샷 forward.
+    const ssotForTransfer = await readSsot(env.TRIPS, trip.token, {
+      cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
+    });
     await sendWithEnvHeal(
       (host) =>
         sendSilentPush({
@@ -1593,6 +1654,7 @@ export async function advanceBoardingLockWaypoint(
             now,
             origin: 'transfer-release',
             lockReleasedReason: 'transfer',
+            ssot: ssotForTransfer,
           }),
           config: deps.apnsConfig,
           host,
@@ -1995,6 +2057,10 @@ export async function runLocklessIntermediate(
     arvlCd: signal.arvlCd,
     etaSeconds: signal.etaSeconds,
   });
+  // #1561 (T8, ADR-017 / S2 흡수) — lockless fire 직전 SSoT 권위 스냅샷 forward.
+  const locklessSsot = await readSsot(env.TRIPS, trip.token, {
+    cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
+  });
   const heal = await sendWithEnvHeal(
     (host) =>
       sendSilentPush({
@@ -2023,6 +2089,10 @@ export async function runLocklessIntermediate(
           // #1539 (S6) — backend 누적 passedStations forward. 빈 배열/undefined는 apns.ts JSON
           // serializer가 자연 누락. device backfill diff(S5 후속 wiring PR)에서 사용.
           passedStations: trip.passedStations,
+          // #1561 (T8, ADR-017 / S2 흡수) — TripPositionSSoT 권위 forward. null/undefined는 apns.ts
+          // JSON serializer가 자연 누락 → device cascade picker는 기존 tier fallback. lockless trip은
+          // backend SSoT가 가장 신뢰 높은 단일 신호 (lock 부재 환경).
+          ssot: toSilentPushSsot(locklessSsot),
         },
         config: deps.apnsConfig,
         host,

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -189,12 +189,16 @@ import {
   extractPayload,
   getSilentPushRegistrationStatus,
   handleSilentPush,
+  persistBackendSsotMirror,
+  readBackendSsotMirror,
   registerSilentPushTask,
   SILENT_PUSH_TASK,
+  validSsotMirror,
 } from '../silentPushTask';
 import {
   APNS_TOKEN_KEY,
   ACTIVE_TRIP_KEY,
+  BACKEND_SSOT_MIRROR_KEY,
   DESTINATION_KEY,
   LOCKLESS_STATION_PASSED_KEY,
   ROUTE_KEY,
@@ -711,6 +715,99 @@ describe('silentPushTask', () => {
             }),
           ),
         ).toMatchObject({ passedStations: undefined });
+      });
+    });
+
+    // #1561 (T8, ADR-017 / S2 흡수) — payload.ssot 검증 + extraction.
+    describe('ssot (#1561 T8 / S2 흡수)', () => {
+      const validSsotInput = {
+        currentStationId: '강남',
+        motionState: 'moving' as const,
+        lastAdvanceEvidence: 'arvlcd-confirmed-train',
+        lastAdvanceAt: 1_700_000_000_500,
+        passedStations: ['교대', '서초'],
+      };
+
+      it('정상 ssot은 payload에 그대로 전달', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              nextWaypoint: '강남',
+              etaSeconds: 0,
+              phase: 'imminent',
+              ssot: validSsotInput,
+            }),
+          ),
+        ).toMatchObject({ ssot: validSsotInput });
+      });
+
+      it('누락은 undefined (구 backend 호환)', () => {
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 0, phase: 'imminent' }),
+          ),
+        ).toMatchObject({ ssot: undefined });
+      });
+
+      it('비-객체 / null은 undefined', () => {
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 0, phase: 'imminent', ssot: null }),
+          ),
+        ).toMatchObject({ ssot: undefined });
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 0, phase: 'imminent', ssot: 'string' }),
+          ),
+        ).toMatchObject({ ssot: undefined });
+      });
+
+      it.each([
+        ['currentStationId 누락', { ...validSsotInput, currentStationId: undefined }],
+        ['currentStationId 빈 문자열', { ...validSsotInput, currentStationId: '' }],
+        ['motionState invalid', { ...validSsotInput, motionState: 'bogus' }],
+        ['lastAdvanceEvidence 누락', { ...validSsotInput, lastAdvanceEvidence: undefined }],
+        ['lastAdvanceEvidence 빈 문자열', { ...validSsotInput, lastAdvanceEvidence: '' }],
+        ['lastAdvanceAt 비-숫자', { ...validSsotInput, lastAdvanceAt: 'now' }],
+        ['lastAdvanceAt NaN', { ...validSsotInput, lastAdvanceAt: Number.NaN }],
+      ])('필수 필드 불완전 → undefined: %s', (_label, brokenSsot) => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              nextWaypoint: 'A',
+              etaSeconds: 0,
+              phase: 'imminent',
+              ssot: brokenSsot,
+            }),
+          ),
+        ).toMatchObject({ ssot: undefined });
+      });
+
+      it('passedStations 비-string 항목은 필터링, 잔여만 채택', () => {
+        const result = extractPayload(
+          bgTaskData({
+            nextWaypoint: 'A',
+            etaSeconds: 0,
+            phase: 'imminent',
+            ssot: {
+              ...validSsotInput,
+              passedStations: ['교대', '', 42, '서초', null],
+            },
+          }),
+        );
+        expect(result).toMatchObject({ ssot: { passedStations: ['교대', '서초'] } });
+      });
+
+      it('passedStations 자체가 누락이면 빈 배열로 정규화', () => {
+        const result = extractPayload(
+          bgTaskData({
+            nextWaypoint: 'A',
+            etaSeconds: 0,
+            phase: 'imminent',
+            ssot: { ...validSsotInput, passedStations: undefined },
+          }),
+        );
+        expect(result).toMatchObject({ ssot: { passedStations: [] } });
       });
     });
 
@@ -3071,6 +3168,138 @@ describe('silentPushTask', () => {
     it('error input 시 breadcrumb 없음', async () => {
       await handleSilentPush({ data: undefined, error: { message: 'boom' } });
       expect(mockAddDomainBreadcrumb).not.toHaveBeenCalled();
+    });
+  });
+
+  // #1561 (T8, ADR-017 / S2 #1535 흡수) — backend SSoT mirror persistence + read.
+  describe('backend SSoT mirror (#1561 T8 / S2 흡수)', () => {
+    const validSsot = {
+      currentStationId: '강남',
+      motionState: 'moving' as const,
+      lastAdvanceEvidence: 'arvlcd-confirmed-train',
+      lastAdvanceAt: 1_700_000_000_500,
+      passedStations: ['교대', '서초'],
+    };
+
+    beforeEach(() => {
+      (AsyncStorage.getItem as jest.Mock).mockReset();
+      (AsyncStorage.setItem as jest.Mock).mockReset();
+    });
+
+    it('persistBackendSsotMirror writes JSON with receivedAt stamp', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+      await persistBackendSsotMirror(validSsot, 1_700_000_001_000);
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        BACKEND_SSOT_MIRROR_KEY,
+        JSON.stringify({ ...validSsot, receivedAt: 1_700_000_001_000 }),
+      );
+    });
+
+    it('persistBackendSsotMirror swallows AsyncStorage errors (graceful)', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValue(new Error('boom'));
+      await expect(persistBackendSsotMirror(validSsot, 0)).resolves.toBeUndefined();
+    });
+
+    it('readBackendSsotMirror parses valid entry', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+        JSON.stringify({ ...validSsot, receivedAt: 1_700_000_001_000 }),
+      );
+      await expect(readBackendSsotMirror()).resolves.toEqual({
+        ...validSsot,
+        receivedAt: 1_700_000_001_000,
+      });
+    });
+
+    it('readBackendSsotMirror returns null when storage empty', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      await expect(readBackendSsotMirror()).resolves.toBeNull();
+    });
+
+    it('readBackendSsotMirror returns null when JSON parse fails', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue('not-json{');
+      await expect(readBackendSsotMirror()).resolves.toBeNull();
+    });
+
+    it('readBackendSsotMirror swallows AsyncStorage errors', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValue(new Error('io'));
+      await expect(readBackendSsotMirror()).resolves.toBeNull();
+    });
+
+    it.each([
+      ['currentStationId missing', { ...validSsot, currentStationId: undefined }],
+      ['motionState invalid', { ...validSsot, motionState: 'bogus' }],
+      ['lastAdvanceEvidence missing', { ...validSsot, lastAdvanceEvidence: undefined }],
+      ['lastAdvanceAt non-number', { ...validSsot, lastAdvanceAt: 'now' }],
+      ['passedStations non-array', { ...validSsot, passedStations: 'x' }],
+    ])('readBackendSsotMirror returns null when %s', async (_label, broken) => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+        JSON.stringify({ ...broken, receivedAt: 1 }),
+      );
+      await expect(readBackendSsotMirror()).resolves.toBeNull();
+    });
+
+    it('readBackendSsotMirror returns null when receivedAt missing', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(validSsot));
+      await expect(readBackendSsotMirror()).resolves.toBeNull();
+    });
+
+    it('readBackendSsotMirror filters non-string passedStations entries', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+        JSON.stringify({
+          ...validSsot,
+          passedStations: ['교대', '', 42, '서초', null],
+          receivedAt: 1,
+        }),
+      );
+      const result = await readBackendSsotMirror();
+      expect(result?.passedStations).toEqual(['교대', '서초']);
+    });
+
+    it('handleSilentPush persists SSoT mirror when payload.ssot is present', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+      mockCheckGate.mockReturnValue({ allow: false, skip: 'gate-no-location' });
+      await handleSilentPush(
+        bgTaskData({
+          nextWaypoint: '강남',
+          etaSeconds: 0,
+          phase: 'imminent',
+          kind: 'intermediate',
+          ssot: validSsot,
+        }),
+      );
+      const mirrorCall = (AsyncStorage.setItem as jest.Mock).mock.calls.find(
+        ([key]) => key === BACKEND_SSOT_MIRROR_KEY,
+      );
+      expect(mirrorCall).toBeDefined();
+      const stored = JSON.parse(mirrorCall![1] as string);
+      expect(stored).toMatchObject(validSsot);
+      expect(typeof stored.receivedAt).toBe('number');
+    });
+
+    it('handleSilentPush does not persist mirror when payload.ssot is absent', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+      mockCheckGate.mockReturnValue({ allow: false, skip: 'gate-no-location' });
+      await handleSilentPush(
+        bgTaskData({
+          nextWaypoint: '강남',
+          etaSeconds: 0,
+          phase: 'imminent',
+          kind: 'intermediate',
+        }),
+      );
+      const mirrorCall = (AsyncStorage.setItem as jest.Mock).mock.calls.find(
+        ([key]) => key === BACKEND_SSOT_MIRROR_KEY,
+      );
+      expect(mirrorCall).toBeUndefined();
+    });
+
+    it('validSsotMirror returns undefined for null/non-object', () => {
+      expect(validSsotMirror(null)).toBeUndefined();
+      expect(validSsotMirror(undefined)).toBeUndefined();
+      expect(validSsotMirror('string')).toBeUndefined();
+      expect(validSsotMirror(123)).toBeUndefined();
     });
   });
 });

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -31,6 +31,7 @@ import type { LineNumber, Station } from '../../../shared/types/station';
 import {
   APNS_TOKEN_KEY,
   ACTIVE_TRIP_KEY,
+  BACKEND_SSOT_MIRROR_KEY,
   DESTINATION_KEY,
   LOCKLESS_STATION_PASSED_KEY,
   SLEEP_MODE_KEY,
@@ -163,6 +164,29 @@ export interface SilentPushPayload {
    * 구 backend 호환 / 빈 배열 / wire 누락 → undefined → 기존 동작 그대로(backfill 자연 skip).
    */
   passedStations?: readonly string[];
+  /**
+   * #1561 (T8, ADR-017 / S2 #1535 흡수) — backend가 forward한 TripPositionSSoT 권위 스냅샷.
+   *
+   * device의 cascade picker(`useFusedNearestStation`)가 `backend-ssot` tier(최상위)로 채택한다.
+   * silent push handler가 본 값을 BACKEND_SSOT_MIRROR_KEY에 mirror하고 cascade picker가 다음 cycle에 read.
+   *
+   * 구 backend 호환 / 누락 → undefined → cascade는 기존 tier fallback (graceful).
+   */
+  ssot?: SilentPushSsotMirror;
+}
+
+/**
+ * #1561 (T8) — silent push payload에 실린 SSoT 권위 스냅샷 형태.
+ *
+ * backend `apns.ts`의 `SilentPushSsotPayload`와 1:1. device는 본 값을 BACKEND_SSOT_MIRROR_KEY에
+ * mirror하며 cascade picker가 다음 polling cycle에서 read해 `backend-ssot` tier로 채택.
+ */
+export interface SilentPushSsotMirror {
+  currentStationId: string;
+  motionState: 'moving' | 'stationary' | 'unknown';
+  lastAdvanceEvidence: string;
+  lastAdvanceAt: number;
+  passedStations: readonly string[];
 }
 
 /**
@@ -364,6 +388,7 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
     tripToken,
     lockReleasedReason,
     passedStations,
+    ssot,
   } = obj as {
     nextWaypoint: string;
   } & Record<string, unknown>;
@@ -385,6 +410,38 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
     tripToken: validTripToken(tripToken),
     lockReleasedReason: validLockReleasedReason(lockReleasedReason),
     passedStations: validPassedStations(passedStations),
+    ssot: validSsotMirror(ssot),
+  };
+}
+
+/**
+ * #1561 (T8, ADR-017 / S2 흡수) — payload.ssot 검증. 모든 필수 필드가 유효해야 통과.
+ *
+ * 누락/형식 오류/필수 필드 부재 → undefined → cascade picker가 기존 tier fallback(graceful).
+ * passedStations는 string 배열로 정규화 (비-string 항목 필터). 빈 배열은 허용 (backend가 보낼 수 있음).
+ */
+export function validSsotMirror(value: unknown): SilentPushSsotMirror | undefined {
+  if (value == null || typeof value !== 'object') return undefined;
+  const obj = value as Record<string, unknown>;
+  const { currentStationId, motionState, lastAdvanceEvidence, lastAdvanceAt, passedStations } = obj;
+  if (typeof currentStationId !== 'string' || currentStationId.length === 0) return undefined;
+  if (motionState !== 'moving' && motionState !== 'stationary' && motionState !== 'unknown') {
+    return undefined;
+  }
+  if (typeof lastAdvanceEvidence !== 'string' || lastAdvanceEvidence.length === 0) return undefined;
+  if (typeof lastAdvanceAt !== 'number' || !Number.isFinite(lastAdvanceAt)) return undefined;
+  const passed: string[] = [];
+  if (Array.isArray(passedStations)) {
+    for (const p of passedStations) {
+      if (typeof p === 'string' && p.length > 0) passed.push(p);
+    }
+  }
+  return {
+    currentStationId,
+    motionState,
+    lastAdvanceEvidence,
+    lastAdvanceAt,
+    passedStations: passed,
   };
 }
 
@@ -626,6 +683,72 @@ async function loadApnsToken(): Promise<string | null> {
 }
 
 /**
+ * #1561 (T8, ADR-017 / S2 #1535 흡수) — backend SSoT 권위 mirror를 AsyncStorage에 영속화.
+ *
+ * useFusedNearestStation cascade picker가 다음 polling cycle에서 본 값을 read해 `backend-ssot`
+ * tier(최상위)로 채택한다. receivedAt epoch ms를 함께 stamp해 cascade picker가 자체 staleness
+ * 판단(cascade tier policy 후속 PR).
+ *
+ * write 실패는 silent — backend SSoT mirror는 보조 신호로 미존재 시 cascade는 기존 tier fallback.
+ */
+export async function persistBackendSsotMirror(
+  ssot: SilentPushSsotMirror,
+  receivedAt: number,
+): Promise<void> {
+  try {
+    await AsyncStorage.setItem(
+      BACKEND_SSOT_MIRROR_KEY,
+      JSON.stringify({ ...ssot, receivedAt }),
+    );
+  } catch {
+    // graceful — cascade picker는 mirror 부재 시 기존 tier fallback.
+  }
+}
+
+/**
+ * #1561 (T8) — AsyncStorage에서 backend SSoT mirror 읽기. cascade picker가 polling cycle마다 호출.
+ *
+ * 미존재 / parse 실패 → null. cascade picker는 기존 tier fallback.
+ */
+export interface BackendSsotMirrorEntry extends SilentPushSsotMirror {
+  receivedAt: number;
+}
+
+export async function readBackendSsotMirror(): Promise<BackendSsotMirrorEntry | null> {
+  try {
+    const raw = await AsyncStorage.getItem(BACKEND_SSOT_MIRROR_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<BackendSsotMirrorEntry> | null;
+    if (
+      !parsed ||
+      typeof parsed.currentStationId !== 'string' ||
+      parsed.currentStationId.length === 0 ||
+      (parsed.motionState !== 'moving' &&
+        parsed.motionState !== 'stationary' &&
+        parsed.motionState !== 'unknown') ||
+      typeof parsed.lastAdvanceEvidence !== 'string' ||
+      typeof parsed.lastAdvanceAt !== 'number' ||
+      !Array.isArray(parsed.passedStations) ||
+      typeof parsed.receivedAt !== 'number'
+    ) {
+      return null;
+    }
+    return {
+      currentStationId: parsed.currentStationId,
+      motionState: parsed.motionState,
+      lastAdvanceEvidence: parsed.lastAdvanceEvidence,
+      lastAdvanceAt: parsed.lastAdvanceAt,
+      passedStations: parsed.passedStations.filter(
+        (p): p is string => typeof p === 'string' && p.length > 0,
+      ),
+      receivedAt: parsed.receivedAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * #816 C — 사용자 토글 (lockless station-passed opt-in) 현재값을 AsyncStorage에서 읽는다.
  * BG task에서는 zustand store에 접근 불가하므로 useSettingsStore.setLocklessStationPassed가
  * 기록한 키를 직접 read. 값이 없거나 파싱 실패면 OFF(false) — default 보수적.
@@ -678,6 +801,19 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     const receivedAt = Date.now();
     addDomainBreadcrumb('push', 'silent-push', { kind: payload.kind ?? 'fire' });
     const apnsToken = await loadApnsToken();
+
+    // #1561 (T8, ADR-017 / S2 #1535 흡수) — backend SSoT 권위 mirror 저장.
+    //
+    // standard silent push payload에 ssot가 실려 있으면 BACKEND_SSOT_MIRROR_KEY에 그대로 영속화.
+    // useFusedNearestStation cascade picker가 다음 polling cycle에서 본 값을 read해 `backend-ssot`
+    // tier(최상위)로 채택한다. receivedAt도 함께 stamp해 cascade picker가 자체 staleness 판단.
+    //
+    // reschedule/trip-ended payload는 SSoT를 forward하지 않으므로 본 분기에서는 호출되지 않는다.
+    //
+    // 실패는 silent — backend SSoT mirror는 보조 신호로 cascade는 기존 tier fallback이 가능.
+    if ('ssot' in payload && payload.ssot !== undefined) {
+      await persistBackendSsotMirror(payload.ssot, receivedAt);
+    }
 
     // #1370 L5 — silent push 도달률 observability stamp.
     //

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -168,6 +168,15 @@ export const LAST_UPLOADED_SIGNAL_DUMP_CORR_ID_KEY = 'subway-now:last-uploaded-s
 // 위치 게이트가 동일한 값을 read할 수 있도록 한다. updatedAt(epoch ms)은 TTL 만료 판별용.
 // 형식: {"subsurface": boolean, "updatedAt": number} JSON.
 export const SUBSURFACE_STATE_KEY = 'subway-now:subsurface';
+// #1561 (T8, ADR-017 / ADR-016 S2 흡수) — backend가 silent push로 forward한 TripPositionSSoT
+// 권위 스냅샷을 device가 mirror하는 AsyncStorage key.
+//
+// silent push handler가 payload.ssot를 추출하면 JSON으로 그대로 영속화. `useFusedNearestStation`
+// cascade picker가 다음 cycle에서 본 값을 읽어 `backend-ssot` tier(최상위)로 채택한다.
+// 형식: { currentStationId, motionState, lastAdvanceEvidence, lastAdvanceAt, passedStations, receivedAt } JSON.
+//   - receivedAt: device가 silent push를 수신한 epoch ms. cascade picker가 자체 staleness 판정에 사용.
+// 미존재 / parse 실패는 cascade가 자연 skip (구 backend 호환, graceful).
+export const BACKEND_SSOT_MIRROR_KEY = 'subway-now:backend-ssot-mirror';
 // #1518 — device → backend HTTP 호출 로그 ring buffer 영속화.
 // `instrumentBackendFetch` wrapper가 모든 backend fetch 시점에 call/response/error entry를
 // push하고 ring buffer를 통째로 AsyncStorage에 mirror한다. 앱 재시작 후 진단해도 직전 trip의


### PR DESCRIPTION
ADR-017 Epic #1553 / T8 (#1561). ADR-016 S2 #1535 흡수.

## 범위 (Phase 1 — plumbing only)

본 PR은 backend → device 데이터 plumbing을 완결한다.

**Phase 2(별도 PR, T8b)로 분리한 항목:**
- `useFusedNearestStation` cascade picker `backend-ssot` tier 결합 (lock 활성/lockless 양쪽 최상위)
- `HomeScreen` sticky 격리 (`useWidgetMirror(gps.liveResult)`)
- `DebugModal` `## Backend SSoT` section

이유: cascade tier 의미 변경은 광범위한 회귀 테스트를 동반한다. plumbing이
production에서 1주 stale forward 신호 없음이 확인된 후 cascade 채택을 가는 것이
ADR-016 §1 "두 실패 모드 동급" 원칙에 부합. 본 PR이 wire/persist 단계까지 안정시킨다.

## Backend 변경
- `SilentPushPayload.ssot?: SilentPushSsotPayload` 신설 (`apns.ts`).
- `sendSilentPush` JSON body에 `ssot` 정의 시에만 wire (구 device 호환).
- `toSilentPushSsot(ssot)` helper — `TripPositionSSoT`를 wire 형태로 축소 + `passedStations.slice(-5)`로 size cap.
- `buildStationPassedImminentPayload` `ssot?: TripPositionSSoT | null` 옵션 추가.
- fire 직전 4 callsite (arvlcd / vanish-fallback / vanish-release / transfer-release / lockless) 모두 `readSsot(env.TRIPS, trip.token, { cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC })`로 SSoT 권위 스냅샷 forward.
- read 실패/null은 graceful (wire 자연 누락).

## Device 변경
- `SilentPushPayload.ssot?: SilentPushSsotMirror` 신설 (`silentPushTask.ts`).
- `extractStandardPayload`에서 `ssot` 추출 + `validSsotMirror` 검증.
- `handleSilentPush`가 `payload.ssot` 정의 시 `persistBackendSsotMirror`로 `BACKEND_SSOT_MIRROR_KEY`에 `{ ssot, receivedAt }` JSON으로 영속화.
- `readBackendSsotMirror` helper — cascade picker(Phase 2)가 다음 cycle에 read 예정.
- 영속화 실패는 silent (graceful).

## Storage keys
- `BACKEND_SSOT_MIRROR_KEY = 'subway-now:backend-ssot-mirror'` 신설.

## 테스트 (100% 파일 커버리지)
- Backend `apns.test`: ssot wire on / omit 2건.
- Backend `scheduled.test`: `toSilentPushSsot` 2건 + arvlcd/lockless SSoT KV→payload forward 3건 (5건).
- Device `silentPushTask.test`: extract validation 9건 + mirror persist/read 13건 + handleSilentPush 통합 2건 + helper edge 1건 (25건).

**결과:**
- Backend: 1623 → 1630 tests pass.
- Device silentPushTask: 232 → 260 tests pass.
- 양쪽 모두 변경 파일 100% line/branch/function coverage.
- `npm run type-check` pass.
- 사전-존재 widgetStorage/stationNotification 실패는 dev 동일 (본 PR과 무관).

## S2 #1535 흡수
ADR-016 S2 #1535(closed)의 silent push currentStationId 권위 forward는 본 PR이 다룬다.
cascade picker 채택 + sticky 격리는 Phase 2 후속 PR로.

## 의존성
- T1 (#1554) `tripPositionSsot.ts` SSoT KV + `seedSsot` — 머지됨, 본 PR이 사용.
- T2 (#1555) `advanceTripPosition` SSoT mutation — 머지됨, SSoT가 advance마다 갱신되어 본 PR이 forward할 값이 살아 있음.

## ADR-014 acceptance 매트릭스
| 항목 | 적용 |
| --- | --- |
| lock 활성 | ✅ arvlcd/vanish-fallback/vanish-release/transfer-release fire 시 SSoT forward |
| lockless | ✅ lockless intermediate fire 시 SSoT forward |
| 사용자 명시 의향 trip | ✅ 동급 — SSoT.userIntentDeclared가 motion gate와 결합되어 forward 자체는 lock과 무관 |
| 권한 매트릭스 | ✅ silent push 경로(WhileInUse/Always × FG/BG/취침) 모두 동일 |
| 환경 매트릭스 | ✅ 지상/지하/환승 — SSoT는 환경 인지 후 advance 결과만 표현 |

Closes #1561. Closes #1535.