### PR TITLE
refactor(#1558): advanceBoardingLockWaypoint → SSoT 통합 (Epic #1553)

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -5330,3 +5330,221 @@ describe('runScheduled — ADR-017 T4 (#1557) advanceTripPosition SSoT gate (arv
     expect(await kv.get(ssotKey(TOKEN))).not.toBeNull();
   });
 });
+
+describe('runScheduled — ADR-017 T5 (#1558) advanceBoardingLockWaypoint SSoT gate', () => {
+  // 양방향 — arvlcd-arrived path (T4 합쳐) + vanish-fallback path 모두 SSoT 단일 진입점 통과 후
+  // trip.waypoints / cleanup 진행. 정지 trip 매분 advance 회귀(2026-06-19 8회)를 박제 차단.
+  const TOKEN = 'lock-tok';
+  const FALLBACK_TRIGGER = VANISH_RE_ATTACH_THRESHOLD + FALLBACK_ADVANCE_GRACE_CYCLES;
+  const LAST_EPOCH_ELAPSED = NOW - FALLBACK_HOP_SEC * 1000;
+
+  function makeArvlCdSeoulFor(stationName: string, trainCode = '7246'): SeoulArrivalClient {
+    return makeArvlCdFireSeoul(stationName, 0, 1, trainCode);
+  }
+  function makeVanishedSeoul(): SeoulArrivalClient {
+    // arrivals/positions 모두 비어있음 → vanish-fallback path 진입. stats.callCount 가 호출되므로
+    // 실제 SeoulArrivalClient 인스턴스를 사용 (mock client 는 stats 부재로 runScheduled 끝단 throw).
+    return new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async (url: string) => {
+        if (url.includes('/realtimePosition/')) {
+          return new Response(JSON.stringify({ realtimePositionList: [] }), { status: 200 });
+        }
+        return new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+  }
+
+  type Scenario = {
+    name: string;
+    path: 'arvlcd-arrived' | 'vanish-fallback';
+    motionState: 'moving' | 'stationary' | 'unknown';
+    /** trip이 destination 1개만 갖도록 fixture override — destination 통과 + cleanup 검증용. */
+    destinationOnly?: boolean;
+    expectAdvance: boolean;
+    expectBlockReason?: 'motion-stationary';
+    expectCleanup?: boolean;
+  };
+
+  const advanceScenarios: Scenario[] = [
+    // Positive — arvlcd-arrived + moving → advance
+    {
+      name: 'P1 arvlcd-arrived + moving + lock → trip.waypoints shift',
+      path: 'arvlcd-arrived',
+      motionState: 'moving',
+      expectAdvance: true,
+    },
+    // Positive — vanish-fallback + moving → advance
+    {
+      name: 'P2 vanish-fallback + moving → trip.waypoints shift',
+      path: 'vanish-fallback',
+      motionState: 'moving',
+      expectAdvance: true,
+    },
+    // Positive — destination 단독 + advance → cleanupTripWithLa + deleteSsot
+    {
+      name: 'P3 destination 단독 + moving → cleanup + SSoT delete',
+      path: 'arvlcd-arrived',
+      motionState: 'moving',
+      destinationOnly: true,
+      expectAdvance: true,
+      expectCleanup: true,
+    },
+    // Negative — 2026-06-19 회귀 박제
+    {
+      name: 'N1 arvlcd-arrived + stationary trip → trip.waypoints 보존 (회귀 박제)',
+      path: 'arvlcd-arrived',
+      motionState: 'stationary',
+      expectAdvance: false,
+      expectBlockReason: 'motion-stationary',
+    },
+    {
+      name: 'N2 vanish-fallback + stationary trip → trip.waypoints 보존',
+      path: 'vanish-fallback',
+      motionState: 'stationary',
+      expectAdvance: false,
+      expectBlockReason: 'motion-stationary',
+    },
+  ];
+
+  it.each(advanceScenarios)('$name', async (sc) => {
+    const kv = new InMemoryKV();
+    const tripOverrides: Partial<Trip> = sc.destinationOnly
+      ? { waypoints: [{ stationName: '중곡', line: '7', kind: 'destination' }] }
+      : {};
+    // vanish-fallback path 는 hop 시간 경과 + miss 카운터 trigger 도달.
+    if (sc.path === 'vanish-fallback') {
+      tripOverrides.consecutiveEtaMissing = FALLBACK_TRIGGER - 1;
+      tripOverrides.lastTrackedArrivalEpoch = LAST_EPOCH_ELAPSED;
+    }
+    const trip = makeLockTripFixture(TOKEN, tripOverrides);
+    await putTrip(kv as unknown as KVNamespace, trip);
+
+    // motion=stationary 는 SSoT motionState 명시 stamp 필요 (default 'unknown'은 dormant).
+    if (sc.motionState !== 'unknown') {
+      const seeded = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산', {
+        expiresAt: trip.expiresAt,
+      });
+      seeded.motionState = sc.motionState;
+      await writeSsot(kv as unknown as KVNamespace, seeded, { expiresAt: trip.expiresAt });
+    }
+
+    const seoul = sc.path === 'arvlcd-arrived'
+      ? makeArvlCdSeoulFor(trip.waypoints[0].stationName)
+      : makeVanishedSeoul();
+    const logMessages: { msg: string; meta?: Record<string, unknown> }[] = [];
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (vi.fn(async () => new Response('', { status: 200 }))) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-t5',
+      log: (msg, meta) => {
+        logMessages.push({ msg, meta });
+      },
+    });
+
+    const storedRaw = await kv.get(`trip:${TOKEN}`);
+    if (sc.expectCleanup) {
+      expect(storedRaw).toBeNull();
+      // SSoT 도 같이 삭제됐어야 함.
+      expect(await kv.get(ssotKey(TOKEN))).toBeNull();
+      return;
+    }
+    expect(storedRaw).not.toBeNull();
+    const stored = JSON.parse(storedRaw!) as Trip;
+
+    if (sc.expectAdvance) {
+      // 첫 waypoint(중곡)가 shift되어 군자만 남아야 함.
+      expect(stored.waypoints[0].stationName).toBe('군자');
+      expect(stats.boardingLockWaypointAdvanceBlocked).toBe(0);
+    } else {
+      // SSoT 게이트 차단 → trip.waypoints 그대로.
+      expect(stored.waypoints[0].stationName).toBe('중곡');
+      expect(stats.boardingLockWaypointAdvanceBlocked).toBe(1);
+      const blockedLog = logMessages.find(
+        (l) => l.msg === 'boarding-lock: waypoint advance blocked by ssot gate',
+      );
+      expect(blockedLog?.meta?.reason).toBe(sc.expectBlockReason);
+    }
+  });
+
+  it('legacy lazy-seed — SSoT 미정착 trip 도 evidence 호출 시 자동 seed 후 advance', async () => {
+    // SSoT 부재 → 게이트 #1 blocked('no-seed') 회귀 방지. T4 와 동일 정책.
+    const kv = new InMemoryKV();
+    const trip = makeLockTripFixture(TOKEN);
+    await putTrip(kv as unknown as KVNamespace, trip);
+    expect(await readSsot(kv as unknown as KVNamespace, TOKEN)).toBeNull();
+    const logMessages: { msg: string; meta?: Record<string, unknown> }[] = [];
+    await runScheduled(makeEnv(kv), {
+      seoul: makeArvlCdSeoulFor('중곡'),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (vi.fn(async () => new Response('', { status: 200 }))) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-t5-seed',
+      log: (msg, meta) => {
+        logMessages.push({ msg, meta });
+      },
+    });
+    // legacy advance(unknown motionState) 통과 → waypoints shift.
+    const stored = JSON.parse((await kv.get(`trip:${TOKEN}`))!) as Trip;
+    expect(stored.waypoints[0].stationName).toBe('군자');
+    // lazy-seed log stamped — 두 entry: arvlcd-fire 의 lazy-seed (T4) + waypoint advance 의 lazy-seed
+    // (T5). T4 의 lazy-seed 가 먼저 실행돼 SSoT 가 생성되므로 T5 진입 시 existingSsot !== null →
+    // T5 lazy-seed log 는 stamp되지 않을 수 있다. 둘 중 하나만 보장.
+    const anyLazySeed = logMessages.some(
+      (l) =>
+        l.msg === 'arvlcd-fire: lazy-seed ssot' ||
+        l.msg === 'boarding-lock: lazy-seed ssot for waypoint advance',
+    );
+    expect(anyLazySeed).toBe(true);
+  });
+
+  it('stats — runScheduled 초기 stats에 boardingLockWaypointAdvanceBlocked 0으로 초기화', async () => {
+    const kv = new InMemoryKV();
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeArvlCdSeoulFor('중곡'),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-t5-init',
+    });
+    expect(stats.boardingLockWaypointAdvanceBlocked).toBe(0);
+  });
+
+  it('vanish-fallback path 도 stationary trip → trip.waypoints 보존 (SSoT 게이트 광범위 보호)', async () => {
+    // 기존 `isFallbackAdvanceBlockedByMotion`은 GPS series stationary 만 검증.
+    // 본 PR(T5) 이후엔 SSoT motionState='stationary' 가 evidence type 무관(arvlcd 계열 / vanish 계열
+    // 모두)으로 차단 — 동급 보호 보장. 본 테스트는 GPS series 없는 시나리오에서도 SSoT 게이트만으로
+    // advance 차단됨을 박제한다.
+    const kv = new InMemoryKV();
+    const trip = makeLockTripFixture(TOKEN, {
+      consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+      lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
+    });
+    await putTrip(kv as unknown as KVNamespace, trip);
+    const seeded = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산', {
+      expiresAt: trip.expiresAt,
+    });
+    seeded.motionState = 'stationary';
+    await writeSsot(kv as unknown as KVNamespace, seeded, { expiresAt: trip.expiresAt });
+    // GPS series 는 없음(=`isFallbackAdvanceBlockedByMotion` 경유 motion='unknown')으로 두어
+    // SSoT 게이트만 advance 차단을 책임짐을 보장한다.
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeVanishedSeoul(),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (vi.fn(async () => new Response('', { status: 200 }))) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-t5-ssot-vanish',
+    });
+    const stored = JSON.parse((await kv.get(`trip:${TOKEN}`))!) as Trip;
+    expect(stored.waypoints[0].stationName).toBe('중곡');
+    expect(stats.boardingLockWaypointAdvanceBlocked).toBe(1);
+  });
+});

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -43,9 +43,15 @@ import { attachTrainCodeForLeg } from './lockSwap';
 import {
   advanceTripPosition,
   type AdvanceBlockReason,
+  type AdvanceEvidence,
   type EvidenceEnvironment,
 } from './advanceTripPosition';
-import { readSsot, seedSsot, SSOT_CRON_READ_CACHE_TTL_SEC } from './tripPositionSsot';
+import {
+  deleteSsot,
+  readSsot,
+  seedSsot,
+  SSOT_CRON_READ_CACHE_TTL_SEC,
+} from './tripPositionSsot';
 import {
   evaluateWindow,
   readSeries,
@@ -151,19 +157,17 @@ export function isAdvanceAllowedByMotion(motion: PositionPoint['motion']): boole
 /**
  * #1386 — lock-active vanish fallback advance(`handleEtaMissing` time-based) 전용 motion 게이트.
  *
- * lockless 경로(`isAdvanceAllowedByMotion`)는 엄격(walking/automotive만 허용)이지만, 이 분기는
- * trip이 한 번이라도 정상 추적된 적이 있고(`lastTrackedArrivalEpoch !== undefined`) hop 시간을
- * 채웠다는 약한 ground truth가 이미 있다. 그래서 보수의 결을 다르게 잡는다:
+ * @deprecated ADR-017 T5 (#1558) — `advanceBoardingLockWaypoint`가 `advanceTripPosition` 단일
+ *   진입점을 통해 SSoT motion 게이트(#2)로 정지 trip을 차단한다. 본 함수는 backward-compat 용으로
+ *   export를 유지하지만 신규 호출 X. vanish-fallback path는 evidence를 stamp하면 SSoT가 자동으로
+ *   stationary를 차단한다 (`tripPositionSsot.motionState` + `advanceTripPosition` #2 게이트).
  *
- * - `stationary` (사용자가 명확히 정지 중) → 보류 (false positive 1차 방어).
- * - `walking` / `automotive` (실제 이동) → 진행 (기존 동작).
- * - `unknown` (센서 미지원/권한 거절/샘플 없음) → 진행 (기존 동작 유지, 사용자 가시성 트레이드오프).
- *   `unknown`까지 보류하면 motion 신호 없는 다수 사용자의 trip이 무한 freeze에 가까워지므로
- *   기존 hop-elapsed advance를 유지한다. positive stationary 신호가 있는 경우만 게이트 진입.
+ * 기존 동작 (참조):
+ * - `stationary` → 보류, `walking`/`automotive`/`unknown` → 진행.
+ * - SSoT 도입 후엔 motionState='stationary' + userIntentDeclared=false 시 자동 차단.
  *
- * 트레이드오프(이슈 #1386): `unknown` 중 실제 정지인 케이스는 못 잡는다 — 대신 false negative
- * (정상 이동 trip을 잘못 동결)를 피한다. 사용자가 진짜 정지일 땐 device가 stationary로 송신하므로
- * (`backgroundLocationTask.ts:150` / `useFgPositionUpload.ts`) 실측 신호 도달 시 게이트 발동.
+ * 트레이드오프(이슈 #1386): `unknown` 중 실제 정지인 케이스는 못 잡는다 — SSoT motionState
+ * 'unknown'도 #2 게이트를 통과하므로 동등한 트레이드오프가 유지된다.
  */
 export function isFallbackAdvanceBlockedByMotion(motion: PositionPoint['motion']): boolean {
   return motion === 'stationary';
@@ -349,6 +353,13 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   arvlCdFireFired: number;
   /**
+   * ADR-017 T5 (#1558) — `advanceBoardingLockWaypoint` 진입했지만 `advanceTripPosition` SSoT
+   * 게이트가 차단해 trip.waypoints advance 가 일어나지 않은 횟수. 2026-06-19 정지 trip 매분
+   * waypoint advance 회귀(8회)를 직접 차단하는 게이트. arvlcd-arrived path (T4 와 짝) +
+   * vanish-fallback path 모두 본 카운터에 집계. blockReason 분포는 log 로 확인.
+   */
+  boardingLockWaypointAdvanceBlocked: number;
+  /**
    * #1370 L2 — trainCode vanish 후 시간 기반 fallback advance 직전에 station-passed silent push가
    * 발사된 누적 횟수. fallback path가 어린이대공원/군자/중곡 같은 intermediate를 "지났음" 신호 없이
    * 통과하던 회귀(silent push 0건)를 닫는다.
@@ -440,6 +451,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     arvlCdFireMismatch: 0,
     arvlCdFireBlocked: 0,
     arvlCdFireFired: 0,
+    boardingLockWaypointAdvanceBlocked: 0,
     vanishFallbackFired: 0,
     vanishReleaseFired: 0,
     vanishLocklessTakeover: 0,
@@ -1413,7 +1425,18 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
         generatePushId,
         origin: 'vanish-fallback',
       });
-      await advanceBoardingLockWaypoint(trip, waypoint, env, deps, stats, now, log);
+      // ADR-017 T5 (#1558) — vanish-fallback path 도 SSoT 단일 진입점을 통과해야 trip.waypoints
+      // 가 advance 한다. evidence type 은 `arvlcd-confirmed-train` — lock 활성 시점에서 vanish 직전
+      // 마지막으로 확정된 trainCode 가 ground truth 이고, 본 fallback 은 hop 시간 + 직전 lock 으로
+      // optimistic advance 를 취급하기 때문. SSoT motionState='stationary' 이면 #2 게이트가 차단해
+      // 기존 `isFallbackAdvanceBlockedByMotion` 보다 광범위(정지 trip 어떤 경로도)로 보호한다.
+      await advanceBoardingLockWaypoint(trip, waypoint, env, deps, stats, now, log, {
+        type: 'arvlcd-confirmed-train',
+        stationId: waypoint.stationName,
+        ts: now,
+        environment: deriveEvidenceEnvironment(trip),
+        arvlcdTrainCode: activeLock.trainCode,
+      });
       return;
     }
     // hop 시간 미경과 → lock release해 lockless/boardingPrompt가 인계받도록.
@@ -1571,7 +1594,31 @@ export async function runTrainCodeTracking(
         arvlCd: estimate.arvlCd,
       });
     }
-    await advanceBoardingLockWaypoint(trip, waypoint, env, deps, stats, now, log);
+    // ADR-017 T5 (#1558) — arvlcd-arrived path 도 SSoT 단일 진입점을 통과해야 trip.waypoints
+    // 가 advance 한다. T4 가 fire 를 게이트했더라도 본 진행분(waypoints shift / passedStations
+    // stamp / progress 누적) 자체는 SSoT 동의 후만 적용. arvlCd=null (positions-fallback arrived)
+    // 경로는 evidence 가 없으므로 legacy 호출(evidence X)로 backward-compat 진행 — 정지 trip 보호는
+    // T6/T7 의 lockless / positions reader migration 에서 같은 패턴으로 닫는다.
+    const arvlCdEvidence = estimate.arvlCd !== null
+      ? ({
+          type: 'arvlcd-confirmed-train',
+          stationId: waypoint.stationName,
+          ts: now,
+          environment: deriveEvidenceEnvironment(trip),
+          arvlcdTrainCode: activeLock.trainCode,
+          arvlCd: estimate.arvlCd,
+        } satisfies AdvanceEvidence)
+      : undefined;
+    await advanceBoardingLockWaypoint(
+      trip,
+      waypoint,
+      env,
+      deps,
+      stats,
+      now,
+      log,
+      arvlCdEvidence,
+    );
     return;
   }
 
@@ -1661,10 +1708,65 @@ export async function advanceBoardingLockWaypoint(
   stats: ScheduledStats,
   now: number,
   log: Logger,
+  // ADR-017 T5 (#1558) — SSoT advance evidence. 호출자가 stamp 한 evidence로
+  // `advanceTripPosition` 6단 게이트 통과 시에만 trip.waypoints 를 advance 한다.
+  // optional 인 이유: legacy 호출자(테스트 fixture, T6 reader migration 미적용 path)는
+  // evidence 없이 호출 가능 — 그 경우 SSoT 게이트를 skip 하고 기존 동작 그대로 진행한다.
+  // 새 호출자는 반드시 evidence 를 전달해야 한다.
+  evidence?: AdvanceEvidence,
 ): Promise<void> {
+  // ADR-017 T5 (#1558) — SSoT 통합 게이트.
+  // evidence 가 제공되면 `advanceTripPosition`이 동의해야만 trip.waypoints / cleanup 이 진행된다.
+  // 정지 trip + arvlcd ARRIVED → SSoT motion 게이트(#2)가 blocked('motion-stationary') 반환 →
+  // trip mutation X (2026-06-19 정지 trip 8회 waypoint advance 회귀 직접 차단).
+  if (evidence !== undefined) {
+    // T4 `tryAdvanceAndFireArvlcd` 와 같은 lazy-seed 정책 — legacy trip (SSoT 미정착) 은
+    // currentStationId=waypoint.stationName 로 seed 후 정상 advance. motionState='unknown' 으로
+    // 시작하므로 정지 게이트는 dormant 이지만 T3 motion state machine 갱신 후 자동 활성화.
+    // seed 없이 바로 advanceTripPosition 을 호출하면 #1 Seed 게이트가 blocked('no-seed') 반환 →
+    // legacy 호출자가 모두 frozen 되는 회귀 발생.
+    const existingSsot = await readSsot(env.TRIPS, trip.token, {
+      cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
+    });
+    if (existingSsot === null) {
+      await seedSsot(env.TRIPS, trip.token, waypoint.stationName, {
+        expiresAt: trip.expiresAt,
+      });
+      log('boarding-lock: lazy-seed ssot for waypoint advance', {
+        token: trip.token.slice(0, 8),
+        currentStationId: waypoint.stationName,
+      });
+    }
+    const outcome = await advanceTripPosition(
+      env.TRIPS,
+      trip.token,
+      waypoint.stationName,
+      evidence,
+      {
+        // lock 활성 = base 합의 surrogate (T4 `tryAdvanceAndFireArvlcd` 와 같은 정책).
+        gatePassed: true,
+        lockAttachable: trip.boardingLock !== undefined,
+      },
+    );
+    if (outcome.result !== 'advanced') {
+      stats.boardingLockWaypointAdvanceBlocked += 1;
+      log('boarding-lock: waypoint advance blocked by ssot gate', {
+        token: trip.token.slice(0, 8),
+        station: waypoint.stationName,
+        kind: waypoint.kind,
+        reason: outcome.blockReason satisfies AdvanceBlockReason | undefined,
+        evidenceType: evidence.type,
+      });
+      return;
+    }
+  }
+
   if (waypoint.kind === 'destination') {
     // #868 — destination 도착으로 trip 종료. 클라 state sync용 trip-ended silent push 발사.
     await cleanupTripWithLa(trip, env, deps, stats, now, log, 'destination-arrived');
+    // ADR-017 T5 (#1558) — trip 종료 시 SSoT 도 cleanup. cleanupTripWithLa 가 throw 하면
+    // SSoT 가 남아있을 수 있으나 본 PR 스코프 외 (다음 cron 의 stale 정리 path 는 후속 PR).
+    await deleteSsot(env.TRIPS, trip.token);
     log('boarding-lock: destination arrived, trip cleared', {
       token: trip.token.slice(0, 8),
       station: waypoint.stationName,
@@ -1675,7 +1777,8 @@ export async function advanceBoardingLockWaypoint(
   // device가 사전 예약 큐와 diff하여 cron 1분 race로 누락된 station-passed를 backfill 발사한다
   // (S5 머지 후 후속 wiring PR). 본 PR은 backend → device 데이터 plumbing만.
   appendPassedStation(trip, waypoint.stationName);
-  trip.waypoints.shift();
+  // ADR-017 T5 (#1558) — immutable slice 로 mutation race 방지 (.shift 는 in-place).
+  trip.waypoints = trip.waypoints.slice(1);
   trip.lastTrackedArrivalEpoch = undefined;
   trip.lastLaPushEpoch = undefined;
   // #900 Seam D — heartbeat 기준점도 reset. 다음 hop은 첫 LA push 후 wall-clock stamp.
@@ -1763,6 +1866,8 @@ export async function advanceBoardingLockWaypoint(
   if (trip.waypoints.length === 0) {
     // #868 — waypoints 소진(intermediate 마지막 통과)도 effective destination-arrived.
     await cleanupTripWithLa(trip, env, deps, stats, now, log, 'destination-arrived');
+    // ADR-017 T5 (#1558) — trip 종료 시 SSoT cleanup.
+    await deleteSsot(env.TRIPS, trip.token);
     return;
   }
   // stopsRemaining 변동 즉시 LA 발사 — 사용자에게 새 hop 정보를 즉시 노출.


### PR DESCRIPTION
Closes #1558. ADR-017 T5 — Epic #1553. T4 #1566 stacked.

## 변경 요약

`advanceBoardingLockWaypoint`을 `advanceTripPosition` 단일 진입점으로 통합. evidence를 전달받으면 6단 SSoT 게이트 통과 시에만 `trip.waypoints` mutation + `cleanupTripWithLa` 진행. 정지 trip 매분 waypoint advance 회귀 (2026-06-19 8회, 본 이슈 evidence) 직접 차단.

## 호출자 마이그레이션 체크리스트
- [x] `scheduled.ts:1428` (vanish-fallback path) — evidence type `arvlcd-confirmed-train`, `arvlcdTrainCode=activeLock.trainCode`로 stamp. SSoT motionState='stationary'면 #2 게이트 차단.
- [x] `scheduled.ts:1597` (arvlcd-arrived path) — `estimate.arvlCd !== null`일 때만 evidence stamp. positions-fallback arrived(arvlCd=null)는 backward-compat (T6/T7에서 lockless/positions reader migration로 마무리).
- [x] 모든 evidence에 `environment` (deriveEvidenceEnvironment), `ts=now`, `stationId=waypoint.stationName`, `arvlcdTrainCode=activeLock.trainCode` 정확히 전달.
- [x] 기존 `advanceBoardingLockWaypoint` 함수 keep, evidence 미전달 호출자는 SSoT 게이트 skip (legacy 호환).

## 양방향 시나리오 (테스트 통과)

Positive:
- P1 arvlcd-arrived + moving + lock → `waypoints.shift` → `군자` 잔존
- P2 vanish-fallback + moving → `waypoints.shift`
- P3 destination 단독 + advance → `cleanupTripWithLa` + `deleteSsot`

Negative (회귀 박제):
- N1 arvlcd-arrived + **stationary trip** → `boardingLockWaypointAdvanceBlocked=1`, `waypoints` 그대로 (2026-06-19 8회 회귀 직접 차단)
- N2 vanish-fallback + **stationary trip** → 동일 차단 (기존 `isFallbackAdvanceBlockedByMotion` GPS-only보다 광범위 보호)

추가 박제:
- legacy lazy-seed — SSoT 부재 시 자동 seed 후 advance (`no-seed` blocked 회귀 차단)
- `boardingLockWaypointAdvanceBlocked` stats 0으로 초기화
- GPS series 없는 시나리오에서도 SSoT motionState='stationary'만으로 차단됨 박제

## 기타 변경
- `trip.waypoints.shift()` → `trip.waypoints = trip.waypoints.slice(1)` (immutable, race safety).
- `cleanupTripWithLa` 직후 `deleteSsot(env.TRIPS, trip.token)` 추가 (destination-arrived / waypoints 소진 둘 다).
- `isFallbackAdvanceBlockedByMotion` jsdoc `@deprecated` — SSoT motionState 게이트가 동등 보호. backward-compat 용도로 export keep.
- `ScheduledStats.boardingLockWaypointAdvanceBlocked` 신규 카운터 (production tail 분포 측정).

## Out of scope (후속 PR)
- `cleanupTripWithLa`가 throw 하면 SSoT가 남아있을 수 있음 — 다음 cron의 stale 정리 path 필요 (T5 본 스코프 외).
- T6/T7: lockless + positions-fallback reader migration (arvlCd=null path도 SSoT 게이트 통과).

## 의존
- T1, T2, T3, T4 (#1566) 완료. T4 와 stacked — base 머지 후 dev 로 rebase 필요.

## 검증
- `npx vitest run` — 1640/1640 passed.
- `npx tsc --noEmit` — 본 PR 신규 type error 0 (pre-existing 5건만 잔존, 본 PR 무관).