### PR TITLE
fix(#1560): transfer/destination-imminent SSoT 도달 시만 fire (Epic #1553)

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -5578,6 +5578,159 @@ describe('runScheduled — ADR-017 T4 (#1557) advanceTripPosition SSoT gate (arv
   });
 });
 
+/**
+ * ADR-017 T7 (#1560) — transfer/destination kind 발사 직전 SSoT 위치 + 신선도 게이트 통합 검증.
+ *
+ * 본 suite는 `tryAdvanceAndFireArvlcd` 진입 시점에 `evaluateTransferDestinationGate`가
+ * pre-advance SSoT 스냅샷으로 위치 일관성을 확인해 N9 회귀(2026-06-19 정지 trip "환승임박
+ * 건대입구" false 발사)를 차단함을 박제한다.
+ *
+ * 시나리오 매트릭스 (issue 본문 §검증 + 보강 §transferScenarios):
+ *   - P1 transfer at-target + 신선 SSoT → fire
+ *   - P2 transfer 직전 1 hop + 신선 SSoT → fire
+ *   - N9 transfer SSoT 다른 station + 신선 → block(ssot-not-at-or-approaching)
+ *   - N9-stale transfer at-target 인데 lastAdvanceAt 60s 초과 → block(ssot-stale)
+ *   - destination 동일 매트릭스 1개로 cover (N10)
+ */
+describe('runScheduled — ADR-017 T7 (#1560) transfer/destination SSoT gate', () => {
+  const TOKEN = 't7-tok';
+  const FRESH_LAST_ADVANCE = NOW - 30_000;
+  const STALE_LAST_ADVANCE = NOW - 90_000;
+
+  type T7Scenario = {
+    name: string;
+    waypointKind: 'transfer' | 'destination';
+    waypointStation: string;
+    ssotCurrentStation: string;
+    ssotLastAdvanceAt: number;
+    passedStations?: string[];
+    expectFire: boolean;
+    expectReason?: 'ssot-not-at-or-approaching' | 'ssot-stale';
+  };
+
+  const t7Scenarios: T7Scenario[] = [
+    {
+      name: 'P1 transfer at-target + 신선 SSoT → fire',
+      waypointKind: 'transfer',
+      waypointStation: '중곡',
+      ssotCurrentStation: '중곡',
+      ssotLastAdvanceAt: FRESH_LAST_ADVANCE,
+      expectFire: true,
+    },
+    {
+      name: 'P2 transfer 직전 1 hop(passedStations[-1]) + 신선 → fire',
+      waypointKind: 'transfer',
+      waypointStation: '중곡',
+      ssotCurrentStation: '용마산',
+      ssotLastAdvanceAt: FRESH_LAST_ADVANCE,
+      passedStations: ['용마산'],
+      expectFire: true,
+    },
+    {
+      name: 'N9 transfer SSoT 다른 station + 신선 → block(ssot-not-at-or-approaching) [회귀 박제]',
+      waypointKind: 'transfer',
+      waypointStation: '중곡',
+      ssotCurrentStation: '강남',
+      ssotLastAdvanceAt: FRESH_LAST_ADVANCE,
+      passedStations: ['역삼'],
+      expectFire: false,
+      expectReason: 'ssot-not-at-or-approaching',
+    },
+    {
+      name: 'N9-stale transfer at-target 인데 60s 초과 → block(ssot-stale)',
+      waypointKind: 'transfer',
+      waypointStation: '중곡',
+      ssotCurrentStation: '중곡',
+      ssotLastAdvanceAt: STALE_LAST_ADVANCE,
+      expectFire: false,
+      expectReason: 'ssot-stale',
+    },
+    {
+      name: 'N10 destination SSoT 다른 station + 신선 → block',
+      waypointKind: 'destination',
+      waypointStation: '군자',
+      ssotCurrentStation: '강남',
+      ssotLastAdvanceAt: FRESH_LAST_ADVANCE,
+      passedStations: ['역삼'],
+      expectFire: false,
+      expectReason: 'ssot-not-at-or-approaching',
+    },
+  ];
+
+  it.each(t7Scenarios)('$name', async (sc) => {
+    const kv = new InMemoryKV();
+    const trip = makeLockTripFixture(TOKEN, {
+      waypoints: [{ stationName: sc.waypointStation, line: '7', kind: sc.waypointKind }],
+      passedStations: sc.passedStations ?? [],
+    });
+    await putTrip(kv as unknown as KVNamespace, trip);
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, sc.ssotCurrentStation, {
+      expiresAt: trip.expiresAt,
+    });
+    ssot.motionState = 'moving';
+    ssot.lastAdvanceAt = sc.ssotLastAdvanceAt;
+    ssot.lastAdvanceEvidence = 'arvlcd-confirmed-train';
+    await writeSsot(kv as unknown as KVNamespace, ssot, { expiresAt: trip.expiresAt });
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const logMessages: { msg: string; meta?: Record<string, unknown> }[] = [];
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeArvlCdFireSeoul(sc.waypointStation, 0, 1, '7246'),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-t7',
+      log: (msg, meta) => {
+        logMessages.push({ msg, meta });
+      },
+    });
+    if (sc.expectFire) {
+      expect(stats.arvlCdFireFired).toBe(1);
+      expect(stats.transferDestinationGateBlocked).toBe(0);
+    } else {
+      expect(stats.arvlCdFireFired).toBe(0);
+      expect(stats.transferDestinationGateBlocked).toBe(1);
+      expect(stats.arvlCdFireBlocked).toBe(1);
+      const blockedLog = logMessages.find(
+        (l) => l.msg === 'arvlcd-fire: transfer/destination gate blocked',
+      );
+      expect(blockedLog?.meta?.reason).toBe(sc.expectReason);
+      expect(blockedLog?.meta?.kind).toBe(sc.waypointKind);
+    }
+  });
+
+  it('intermediate kind 는 본 게이트 우회 (T4 6단 게이트만으로 충분)', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeLockTripFixture(TOKEN, {
+      waypoints: [{ stationName: '중곡', line: '7', kind: 'intermediate' }],
+      passedStations: [],
+    });
+    await putTrip(kv as unknown as KVNamespace, trip);
+    // SSoT를 의도적으로 mismatch state (다른 station + stale) → transfer kind 라면 block 됐을 조건.
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '강남', {
+      expiresAt: trip.expiresAt,
+    });
+    ssot.motionState = 'moving';
+    ssot.lastAdvanceAt = STALE_LAST_ADVANCE;
+    ssot.lastAdvanceEvidence = 'arvlcd-confirmed-train';
+    await writeSsot(kv as unknown as KVNamespace, ssot, { expiresAt: trip.expiresAt });
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeArvlCdFireSeoul('중곡', 0, 1, '7246'),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-t7-int',
+    });
+    // intermediate 는 T7 게이트 미적용 → T4 6단 게이트만 통과해 fire 진입.
+    expect(stats.transferDestinationGateBlocked).toBe(0);
+    expect(stats.arvlCdFireFired).toBe(1);
+  });
+});
+
 describe('runScheduled — ADR-017 T5 (#1558) advanceBoardingLockWaypoint SSoT gate', () => {
   // 양방향 — arvlcd-arrived path (T4 합쳐) + vanish-fallback path 모두 SSoT 단일 진입점 통과 후
   // trip.waypoints / cleanup 진행. 정지 trip 매분 advance 회귀(2026-06-19 8회)를 박제 차단.

--- a/backend/alarm-worker/src/__tests__/transferDestinationGate.test.ts
+++ b/backend/alarm-worker/src/__tests__/transferDestinationGate.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  TRANSFER_DESTINATION_FRESH_WINDOW_MS,
+  evaluateTransferDestinationGate,
+  isAtOrApproachingTransferDestination,
+  isSsotAdvanceRecent,
+  isTransferOrDestination,
+  type TransferDestinationBlockReason,
+} from '../transferDestinationGate';
+import type { TripPositionSSoT } from '../tripPositionSsot';
+import type { Trip, Waypoint } from '../types';
+
+/**
+ * ADR-017 T7 (#1560) — transfer/destination 발사 직전 SSoT 위치 + 신선도 게이트 단위 테스트.
+ *
+ * 본 suite는 evidence 시나리오(transferScenarios)를 it.each로 박제해 N9 회귀(2026-06-19 정지
+ * trip "환승임박 건대입구" false 발사) 차단을 직접 단언한다. integration 레벨 wire-up은
+ * scheduled.test.ts의 T4 suite가 cover.
+ */
+
+const NOW = 1_750_000_000_000;
+const FRESH_LAST_ADVANCE = NOW - 30_000;
+const STALE_LAST_ADVANCE = NOW - 90_000;
+
+function makeSsot(overrides?: Partial<TripPositionSSoT>): TripPositionSSoT {
+  return {
+    tripToken: 'tok-t7',
+    currentStationId: '건대입구',
+    motionState: 'moving',
+    motionEvidence: [],
+    lastAdvanceAt: FRESH_LAST_ADVANCE,
+    lastAdvanceEvidence: 'arvlcd-confirmed-train',
+    passedStations: ['뚝섬', '성수'],
+    userIntentDeclared: false,
+    seedOverrideCount: 0,
+    schemaVersion: 1,
+    ...overrides,
+  };
+}
+
+function makeTrip(overrides?: Partial<Trip>): Trip {
+  return {
+    token: 'tok-t7',
+    route: { type: 'direct', stops: 5, line: '2' },
+    destination: '강남',
+    waypoints: [{ stationName: '건대입구', line: '2', kind: 'transfer' }],
+    expiresAt: NOW + 60 * 60_000,
+    createdAt: NOW,
+    alarmAtEpochMs: NOW + 30 * 60_000,
+    passedStations: ['뚝섬', '성수'],
+    ...overrides,
+  };
+}
+
+function makeWaypoint(overrides?: Partial<Waypoint>): Waypoint {
+  return {
+    stationName: '건대입구',
+    line: '2',
+    kind: 'transfer',
+    ...overrides,
+  };
+}
+
+describe('isTransferOrDestination', () => {
+  it.each([
+    ['transfer', true],
+    ['destination', true],
+    ['intermediate', false],
+  ] as const)('kind=%s → %s', (kind, expected) => {
+    expect(isTransferOrDestination({ kind })).toBe(expected);
+  });
+});
+
+describe('isAtOrApproachingTransferDestination', () => {
+  it('at-target — currentStationId === waypoint.stationName → true', () => {
+    expect(
+      isAtOrApproachingTransferDestination(
+        makeSsot({ currentStationId: '건대입구' }),
+        makeTrip(),
+        makeWaypoint(),
+      ),
+    ).toBe(true);
+  });
+
+  it('approaching — currentStationId === last passedStation → true', () => {
+    expect(
+      isAtOrApproachingTransferDestination(
+        makeSsot({ currentStationId: '성수' }),
+        makeTrip({ passedStations: ['뚝섬', '성수'] }),
+        makeWaypoint(),
+      ),
+    ).toBe(true);
+  });
+
+  it('mismatch — currentStationId is some other station → false (N9 박제)', () => {
+    expect(
+      isAtOrApproachingTransferDestination(
+        makeSsot({ currentStationId: '용마산' }),
+        makeTrip({ passedStations: ['뚝섬', '성수'] }),
+        makeWaypoint(),
+      ),
+    ).toBe(false);
+  });
+
+  it('empty passedStations + currentStationId !== waypoint → false', () => {
+    expect(
+      isAtOrApproachingTransferDestination(
+        makeSsot({ currentStationId: '용마산' }),
+        makeTrip({ passedStations: [] }),
+        makeWaypoint(),
+      ),
+    ).toBe(false);
+  });
+
+  it('passedStations undefined → falls back to empty (no 1-hop candidate)', () => {
+    expect(
+      isAtOrApproachingTransferDestination(
+        makeSsot({ currentStationId: '용마산' }),
+        { passedStations: undefined } as unknown as Trip,
+        makeWaypoint(),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('isSsotAdvanceRecent', () => {
+  it('fresh — lastAdvanceAt within window → true', () => {
+    expect(isSsotAdvanceRecent({ lastAdvanceAt: NOW - 30_000 }, NOW)).toBe(true);
+  });
+
+  it('exactly window boundary → true (≤ inclusive)', () => {
+    expect(
+      isSsotAdvanceRecent(
+        { lastAdvanceAt: NOW - TRANSFER_DESTINATION_FRESH_WINDOW_MS },
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it('stale — beyond window → false', () => {
+    expect(isSsotAdvanceRecent({ lastAdvanceAt: NOW - 90_000 }, NOW)).toBe(false);
+  });
+
+  it('lastAdvanceAt===0 (미advance, lazy-seed 직후) → true (dormant, T4 unknown 통과 정책과 정합)', () => {
+    expect(isSsotAdvanceRecent({ lastAdvanceAt: 0 }, NOW)).toBe(true);
+  });
+});
+
+describe('evaluateTransferDestinationGate', () => {
+  type Scenario = {
+    name: string;
+    currentStationId: string;
+    lastAdvanceAt: number;
+    passedStations?: string[];
+    expectPass: boolean;
+    expectReason?: TransferDestinationBlockReason;
+  };
+
+  const transferScenarios: Scenario[] = [
+    // Positive
+    {
+      name: 'P1 at-transfer + 신선 → pass',
+      currentStationId: '건대입구',
+      lastAdvanceAt: FRESH_LAST_ADVANCE,
+      expectPass: true,
+    },
+    {
+      name: 'P2 직전 1 hop + 신선 → pass',
+      currentStationId: '성수',
+      lastAdvanceAt: FRESH_LAST_ADVANCE,
+      expectPass: true,
+    },
+    // Negative — N9 회귀 박제
+    {
+      name: 'N9 SSoT 정지 다른 station + 신선 → block(ssot-not-at-or-approaching)',
+      currentStationId: '용마산',
+      lastAdvanceAt: FRESH_LAST_ADVANCE,
+      expectPass: false,
+      expectReason: 'ssot-not-at-or-approaching',
+    },
+    {
+      name: 'N9-stale at-transfer 인데 60s 초과 → block(ssot-stale)',
+      currentStationId: '건대입구',
+      lastAdvanceAt: STALE_LAST_ADVANCE,
+      expectPass: false,
+      expectReason: 'ssot-stale',
+    },
+    {
+      name: 'P3 at-transfer 인데 lastAdvanceAt===0 (legacy / lazy-seed 직후) → pass(dormant)',
+      currentStationId: '건대입구',
+      lastAdvanceAt: 0,
+      expectPass: true,
+    },
+  ];
+
+  it.each(transferScenarios)('$name', (sc) => {
+    const ssot = makeSsot({
+      currentStationId: sc.currentStationId,
+      lastAdvanceAt: sc.lastAdvanceAt,
+    });
+    const trip = makeTrip({ passedStations: sc.passedStations ?? ['뚝섬', '성수'] });
+    const waypoint = makeWaypoint();
+    const outcome = evaluateTransferDestinationGate(ssot, trip, waypoint, NOW);
+    expect(outcome.pass).toBe(sc.expectPass);
+    if (!sc.expectPass) {
+      expect(outcome.blockReason).toBe(sc.expectReason);
+    } else {
+      expect(outcome.blockReason).toBeUndefined();
+    }
+  });
+
+  it('destination kind도 동일 게이트 통과 (N10 박제)', () => {
+    const ssot = makeSsot({ currentStationId: '강남', lastAdvanceAt: FRESH_LAST_ADVANCE });
+    const trip = makeTrip();
+    const waypoint = makeWaypoint({ stationName: '강남', kind: 'destination' });
+    expect(evaluateTransferDestinationGate(ssot, trip, waypoint, NOW).pass).toBe(true);
+  });
+
+  it('destination + SSoT 정지 다른 station → block', () => {
+    const ssot = makeSsot({ currentStationId: '용마산', lastAdvanceAt: FRESH_LAST_ADVANCE });
+    const trip = makeTrip({ passedStations: ['뚝섬', '성수'] });
+    const waypoint = makeWaypoint({ stationName: '강남', kind: 'destination' });
+    const outcome = evaluateTransferDestinationGate(ssot, trip, waypoint, NOW);
+    expect(outcome.pass).toBe(false);
+    expect(outcome.blockReason).toBe('ssot-not-at-or-approaching');
+  });
+});

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -65,6 +65,11 @@ import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from './seo
 import { phaseAllowsImminentFiring, runStationPhaseStep } from './stationPhase';
 import { listTrips, putTrip } from './trips';
 import {
+  evaluateTransferDestinationGate,
+  isTransferOrDestination,
+  type TransferDestinationBlockReason,
+} from './transferDestinationGate';
+import {
   readSsot,
   SSOT_CRON_READ_CACHE_TTL_SEC,
   type TripPositionSSoT,
@@ -366,6 +371,13 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   boardingLockWaypointAdvanceBlocked: number;
   /**
+   * ADR-017 T7 (#1560) — transfer/destination kind 의 station-passed/transfer-release fire 시점에
+   * `evaluateTransferDestinationGate`가 차단한 누적 횟수. SSoT.currentStationId 가 waypoint 또는
+   * 직전 1 hop 아님 / lastAdvanceAt 60s stale / 미advance 분포를 production tail 로 확인. 2026-06-19
+   * 정지 trip "환승임박 건대입구" false 발사(N9) 회귀를 직접 차단하는 게이트.
+   */
+  transferDestinationGateBlocked: number;
+  /**
    * #1370 L2 — trainCode vanish 후 시간 기반 fallback advance 직전에 station-passed silent push가
    * 발사된 누적 횟수. fallback path가 어린이대공원/군자/중곡 같은 intermediate를 "지났음" 신호 없이
    * 통과하던 회귀(silent push 0건)를 닫는다.
@@ -472,6 +484,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     arvlCdFireBlocked: 0,
     arvlCdFireFired: 0,
     boardingLockWaypointAdvanceBlocked: 0,
+    transferDestinationGateBlocked: 0,
     vanishFallbackFired: 0,
     vanishReleaseFired: 0,
     vanishLocklessTakeover: 0,
@@ -1155,6 +1168,27 @@ async function tryAdvanceAndFireArvlcd(inputs: {
       currentStationId: waypoint.stationName,
     });
   }
+  // ADR-017 T7 (#1560) — transfer/destination kind 발사 직전 추가 SSoT 일관성 검증.
+  // pre-advance SSoT 스냅샷으로 (1) currentStationId가 transfer/destination waypoint 또는
+  // 직전 1 hop 인지 (2) 마지막 advance 가 60s 이내 신선한지 확인. intermediate kind는 본 게이트
+  // 우회 — T4/T5 6단 게이트만으로 충분. 정지 trip "환승임박 건대입구" false fire(N9) 차단.
+  if (isTransferOrDestination(waypoint)) {
+    const transferGate = evaluateTransferDestinationGate(ssot, trip, waypoint, now);
+    if (!transferGate.pass) {
+      stats.arvlCdFireBlocked += 1;
+      stats.transferDestinationGateBlocked += 1;
+      log('arvlcd-fire: transfer/destination gate blocked', {
+        token: trip.token.slice(0, 8),
+        trainCode: lock.trainCode,
+        station: waypoint.stationName,
+        kind: waypoint.kind,
+        reason: transferGate.blockReason satisfies TransferDestinationBlockReason | undefined,
+        ssotCurrent: ssot.currentStationId,
+        ssotLastAdvanceAt: ssot.lastAdvanceAt,
+      });
+      return { dirty: false };
+    }
+  }
   const outcome = await advanceTripPosition(
     env.TRIPS,
     trip.token,
@@ -1278,6 +1312,29 @@ export async function fireVanishFallbackStationPush(
     });
     return;
   }
+  // #1561 (T8, ADR-017 / S2 흡수) — fire 직전 SSoT 권위 스냅샷 forward (arvlcd-fire와 동일 패턴).
+  const ssot = await readSsot(env.TRIPS, trip.token, {
+    cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
+  });
+  // ADR-017 T7 (#1560) — transfer/destination kind 발사 직전 SSoT 위치 + 신선도 일관성 검증.
+  // SSoT 부재 trip(legacy)은 본 게이트 통과시켜 기존 vanish-fallback 흐름 유지 — graceful.
+  if (ssot !== null && isTransferOrDestination(waypoint)) {
+    const transferGate = evaluateTransferDestinationGate(ssot, trip, waypoint, now);
+    if (!transferGate.pass) {
+      stats.transferDestinationGateBlocked += 1;
+      log(`${logPrefix}: transfer/destination gate blocked`, {
+        token: trip.token.slice(0, 8),
+        trainCode: lock.trainCode,
+        station: waypoint.stationName,
+        kind: waypoint.kind,
+        origin,
+        reason: transferGate.blockReason satisfies TransferDestinationBlockReason | undefined,
+        ssotCurrent: ssot.currentStationId,
+        ssotLastAdvanceAt: ssot.lastAdvanceAt,
+      });
+      return;
+    }
+  }
   const pushId = generatePushId();
   log(`${logPrefix}: station-passed push`, {
     token: trip.token.slice(0, 8),
@@ -1290,10 +1347,6 @@ export async function fireVanishFallbackStationPush(
   // release하므로 device에 `lockReleasedReason='vanish'`를 forward해 store sync. vanish-fallback은
   // 직후 `advanceBoardingLockWaypoint`로 흘러가 그 함수가 transfer 시 별도로 release를 통지한다.
   const lockReleasedReason: 'vanish' | undefined = origin === 'vanish-release' ? 'vanish' : undefined;
-  // #1561 (T8, ADR-017 / S2 흡수) — fire 직전 SSoT 권위 스냅샷 forward (arvlcd-fire와 동일 패턴).
-  const ssot = await readSsot(env.TRIPS, trip.token, {
-    cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
-  });
   const heal = await sendWithEnvHeal(
     (host) =>
       sendSilentPush({

--- a/backend/alarm-worker/src/transferDestinationGate.ts
+++ b/backend/alarm-worker/src/transferDestinationGate.ts
@@ -1,0 +1,134 @@
+/**
+ * transferDestinationGate — ADR-017 T7 (Epic #1553, Sub #1560).
+ *
+ * 배경
+ * ====
+ * 2026-06-19 evidence: 정지 trip + lock active + arvlcd ARRIVED → wrong "transfer imminent
+ * 건대입구" 발사 (device `01:00:01 silent-push-received transfer imminent 건대입구`).
+ *
+ * T4(#1557)/T5(#1558)가 `advanceTripPosition` 단일 mutation 진입점으로 매역 station-passed
+ * 발사를 6단 게이트로 통합했지만, **transfer / destination kind** 특별 변종은 추가 보강이
+ * 필요하다 — 이들은 사용자가 의식적으로 환승/하차해야 하는 critical UX 순간이므로 SSoT가
+ * "정말 그 역(또는 직전 hop)에 있고, 최근(60s 내) advance evidence 가 있다" 둘 다 통과해야만
+ * 발사한다 (시간 적분 false advance 차단 — issue 본문 §검증 N9/N10 회귀 박제).
+ *
+ * 본 모듈은 **순수 게이트 함수**만 정의한다 — caller(scheduled.ts의 fire path들)가
+ * `advanceTripPosition` 호출 직후 또는 직전에 본 게이트로 transfer/destination 발사 여부를
+ * 추가 검증한다.
+ *
+ * 범위 (T7 본 PR)
+ * ===============
+ * - `isAtOrApproachingTransferDestination(ssot, trip, waypoint)` — SSoT.currentStationId가
+ *   transfer/destination waypoint 또는 직전 1 hop(=trip.passedStations 마지막) 인지.
+ * - `isSsotAdvanceRecent(ssot, now)` — `now - ssot.lastAdvanceAt <= 60_000`. 미 advance(0)는
+ *   reject.
+ * - `evaluateTransferDestinationGate(ssot, trip, waypoint, now)` — 두 게이트 합성 + 사유 stamp.
+ *
+ * Out of scope
+ * ============
+ * - intermediate kind는 본 게이트를 통과하지 않는다 (T4/T5 6단 게이트로 충분).
+ * - SSoT mutation X — 본 게이트는 read-only.
+ * - payload.ssot field stamp 는 T8(#1561, 이미 머지)이 담당.
+ */
+
+import type { TripPositionSSoT } from './tripPositionSsot';
+import type { Trip, Waypoint } from './types';
+
+/**
+ * SSoT.lastAdvanceAt 신선도 윈도우 (ms). 60s 초과 시 stale로 판정해 transfer/destination 발사
+ * 차단. 시간 적분 false advance(예: 정지 trip이 cron 60s마다 wake-up하며 stale advance evidence
+ * 없이 도달) 회귀를 차단한다 (issue 본문 §검증 N9 박제).
+ */
+export const TRANSFER_DESTINATION_FRESH_WINDOW_MS = 60_000;
+
+/**
+ * 본 게이트가 차단한 사유. caller가 log meta로 stamp → production tail에서 분포 측정.
+ *
+ * 'ssot-stale'은 lastAdvanceAt 정의됐지만(>0) 윈도우 초과한 경우. lastAdvanceAt===0(미advance,
+ * legacy/lazy-seed 직후)은 본 게이트가 dormant로 통과시킨다 — T4 motion 게이트의 'unknown' 통과
+ * 정책과 동일 ([[advanceTripPosition.ts]] #2 게이트). 본 게이트가 stationary advance와 짝을 이루는
+ * defense-in-depth이지 legacy 경로 차단 게이트가 아니기 때문.
+ */
+export type TransferDestinationBlockReason =
+  | 'ssot-not-at-or-approaching'
+  | 'ssot-stale';
+
+export interface TransferDestinationGateOutcome {
+  pass: boolean;
+  blockReason?: TransferDestinationBlockReason;
+}
+
+/**
+ * 본 게이트가 적용되는 waypoint kind 인지. intermediate 는 T4/T5 6단 게이트만으로 충분.
+ */
+export function isTransferOrDestination(
+  waypoint: Pick<Waypoint, 'kind'>,
+): waypoint is Waypoint & { kind: 'transfer' | 'destination' } {
+  return waypoint.kind === 'transfer' || waypoint.kind === 'destination';
+}
+
+/**
+ * SSoT.currentStationId가 target waypoint 의 stationName 또는 직전 1 hop(=trip.passedStations
+ * 의 마지막 entry) 인지.
+ *
+ * 정상 흐름:
+ *   - lock 활성 trip이 transfer waypoint에 도달하기 직전 → SSoT는 직전 hop에 stamp.
+ *   - arvlcd ARRIVED → `advanceTripPosition` 통과로 SSoT.currentStationId = waypoint.stationName 로
+ *     advance. 이 시점 직후 본 게이트가 다시 호출되더라도 "at" 분기로 통과.
+ *
+ * 차단 흐름:
+ *   - SSoT.currentStationId가 transfer waypoint 도, 직전 hop 도 아닌 station(예: 정지 trip이
+ *     시간 적분으로 cron이 transfer waypoint 발사를 시도하는데 SSoT는 한참 뒤에 있음) → 차단.
+ *
+ * passedStations 미존재 / 빈 배열인 경우 "직전 hop" 후보는 없음 → at-target 분기만 평가.
+ */
+export function isAtOrApproachingTransferDestination(
+  ssot: Pick<TripPositionSSoT, 'currentStationId'>,
+  trip: Pick<Trip, 'passedStations'>,
+  waypoint: Pick<Waypoint, 'stationName'>,
+): boolean {
+  if (ssot.currentStationId === waypoint.stationName) return true;
+  const passed = trip.passedStations ?? [];
+  if (passed.length === 0) return false;
+  const lastPassed = passed[passed.length - 1];
+  return ssot.currentStationId === lastPassed;
+}
+
+/**
+ * SSoT.lastAdvanceAt이 신선(`now - lastAdvanceAt <= TRANSFER_DESTINATION_FRESH_WINDOW_MS`) 한지.
+ *
+ * lastAdvanceAt===0(미 advance, lazy-seed 직후)은 dormant 분기로 true 반환 — T4 motion 게이트가
+ * 'unknown' 통과시키는 것과 같은 legacy 호환. 실 advance가 발생하면(`lastAdvanceAt > 0`) 본
+ * 윈도우 검증이 활성화된다.
+ */
+export function isSsotAdvanceRecent(
+  ssot: Pick<TripPositionSSoT, 'lastAdvanceAt'>,
+  now: number,
+): boolean {
+  if (ssot.lastAdvanceAt === 0) return true;
+  return now - ssot.lastAdvanceAt <= TRANSFER_DESTINATION_FRESH_WINDOW_MS;
+}
+
+/**
+ * 합성 게이트 — transfer/destination 발사 전 caller가 호출.
+ *
+ * @param ssot 현재 trip SSoT (caller가 `readSsot` 으로 fetch). null 이면 호출 X (caller 책임).
+ * @param trip trip 객체 (passedStations 조회).
+ * @param waypoint 발사 후보 waypoint. kind가 transfer/destination 아닌 경우 caller가 본 함수를
+ *                 호출하지 않는다 (intermediate는 통과 정책).
+ * @param now epoch ms.
+ */
+export function evaluateTransferDestinationGate(
+  ssot: Pick<TripPositionSSoT, 'currentStationId' | 'lastAdvanceAt'>,
+  trip: Pick<Trip, 'passedStations'>,
+  waypoint: Pick<Waypoint, 'stationName' | 'kind'>,
+  now: number,
+): TransferDestinationGateOutcome {
+  if (!isAtOrApproachingTransferDestination(ssot, trip, waypoint)) {
+    return { pass: false, blockReason: 'ssot-not-at-or-approaching' };
+  }
+  if (!isSsotAdvanceRecent(ssot, now)) {
+    return { pass: false, blockReason: 'ssot-stale' };
+  }
+  return { pass: true };
+}


### PR DESCRIPTION
Closes #1560. ADR-017 T7 (Epic #1553).

## 배경
2026-06-19 evidence: 정지 trip + lock active + arvlcd ARRIVED → device가 `01:00:01 silent-push-received transfer imminent 건대입구` 수신. 사용자: "환승임박 건대입구 도착한다고 알림이 왔는데 정적인데".

T4(#1557)/T5(#1558)가 `advanceTripPosition` 단일 mutation 진입점으로 매역 station-passed 발사를 6단 게이트로 통합했지만, **transfer / destination kind** 특별 변종은 critical UX 순간이므로 추가 SSoT 위치 + 신선도 보강이 필요했다.

## 변경
- `backend/alarm-worker/src/transferDestinationGate.ts` 신규 (순수 함수 모듈)
  - `isAtOrApproachingTransferDestination` — currentStationId가 waypoint OR 직전 1 hop(=passedStations 마지막)
  - `isSsotAdvanceRecent` — `now - lastAdvanceAt ≤ 60s`. lastAdvanceAt===0(lazy-seed 직후)은 dormant 통과 (T4 motion='unknown' 정책과 정합)
  - `evaluateTransferDestinationGate` — 합성 + blockReason stamp
- `scheduled.ts` 두 fire path 에 게이트 wire-up:
  - `tryAdvanceAndFireArvlcd` — pre-advance SSoT 스냅샷으로 검증, blocked 시 `transferDestinationGateBlocked++` + `arvlCdFireBlocked++`
  - `fireVanishFallbackStationPush` — dedup 후 SSoT 읽고 transfer/destination kind 검증
  - intermediate kind 는 본 게이트 우회 (T4/T5 6단 게이트로 충분)
- `stats.transferDestinationGateBlocked` 카운터 신설 — production tail 분포 측정

## 양방향 시나리오 (transferScenarios)
| # | 시나리오 | 결과 |
|---|---------|------|
| P1 | moving + transfer at-target + 신선 SSoT | fire |
| P2 | moving + transfer 직전 1 hop + 신선 | fire |
| P3 | at-target + lastAdvanceAt===0 (lazy-seed) | pass(dormant) |
| **N9** | **정지 trip transfer 시간 도달 + SSoT 다른 station** | **BLOCK(ssot-not-at-or-approaching)** [회귀 박제] |
| N9-stale | at-target 인데 lastAdvanceAt 60s 초과 | BLOCK(ssot-stale) |
| N10 | destination + SSoT 다른 station | BLOCK |
| intermediate bypass | mismatch SSoT 라도 intermediate 통과 | fire |

## 테스트
- 단위 19개 (`transferDestinationGate.test.ts`) — kind 분기 / at-target / 직전 hop / stale / dormant 매트릭스
- 통합 6개 (`scheduled.test.ts` T7 suite) — `runScheduled` 진입 시점 게이트 활성/통과 + blockReason 로그 stamp + intermediate bypass
- backend 전체 1676 tests 통과 (기존 1670 + T7 6건)

## 의존성
- 선행: T1 #1554 / T2 #1555 / T5 #1558 (전부 머지됨)
- payload SSoT field는 T8 #1567 (머지됨)가 이미 forward — 본 PR은 fire 조건만 추가

## 검증
- [x] backend test 1676 pass
- [x] 단위 + 통합 양방향 시나리오 N9 회귀 박제
- [ ] 실기기 — 정지 trip 등록 후 transfer waypoint 시간 도달 시 발사 0건 확인 (사용자 측)