### PR TITLE
feat(#1568): cascade picker backend-ssot tier + HomeScreen sticky 격리 + DebugModal SSoT section

### DIFF
--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -27,11 +27,14 @@ import * as Notifications from 'expo-notifications';
 import * as TaskManager from 'expo-task-manager';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import i18next from 'i18next';
+import {
+  persistBackendSsotMirror,
+  type SilentPushSsotMirror,
+} from '../utils/backendSsotMirror';
 import type { LineNumber, Station } from '../../../shared/types/station';
 import {
   APNS_TOKEN_KEY,
   ACTIVE_TRIP_KEY,
-  BACKEND_SSOT_MIRROR_KEY,
   DESTINATION_KEY,
   LOCKLESS_STATION_PASSED_KEY,
   SLEEP_MODE_KEY,
@@ -176,18 +179,16 @@ export interface SilentPushPayload {
 }
 
 /**
- * #1561 (T8) — silent push payload에 실린 SSoT 권위 스냅샷 형태.
- *
- * backend `apns.ts`의 `SilentPushSsotPayload`와 1:1. device는 본 값을 BACKEND_SSOT_MIRROR_KEY에
- * mirror하며 cascade picker가 다음 polling cycle에서 read해 `backend-ssot` tier로 채택.
+ * #1568 (T8b) — `SilentPushSsotMirror` / `BackendSsotMirrorEntry` / `persistBackendSsotMirror` /
+ * `readBackendSsotMirror`는 expo-notifications 의존성 없이 cascade picker / DebugModal에서 import
+ * 가능하도록 `utils/backendSsotMirror.ts`로 이전했다. 기존 호출자 호환을 위해 본 파일에서 re-export.
  */
-export interface SilentPushSsotMirror {
-  currentStationId: string;
-  motionState: 'moving' | 'stationary' | 'unknown';
-  lastAdvanceEvidence: string;
-  lastAdvanceAt: number;
-  passedStations: readonly string[];
-}
+export {
+  persistBackendSsotMirror,
+  readBackendSsotMirror,
+  type SilentPushSsotMirror,
+  type BackendSsotMirrorEntry,
+} from '../utils/backendSsotMirror';
 
 /**
  * Reschedule push channel discriminator (#918 A3 PR4). Backend `types.ts`의 `RescheduleChannel`과 정렬.
@@ -682,71 +683,8 @@ async function loadApnsToken(): Promise<string | null> {
   }
 }
 
-/**
- * #1561 (T8, ADR-017 / S2 #1535 흡수) — backend SSoT 권위 mirror를 AsyncStorage에 영속화.
- *
- * useFusedNearestStation cascade picker가 다음 polling cycle에서 본 값을 read해 `backend-ssot`
- * tier(최상위)로 채택한다. receivedAt epoch ms를 함께 stamp해 cascade picker가 자체 staleness
- * 판단(cascade tier policy 후속 PR).
- *
- * write 실패는 silent — backend SSoT mirror는 보조 신호로 미존재 시 cascade는 기존 tier fallback.
- */
-export async function persistBackendSsotMirror(
-  ssot: SilentPushSsotMirror,
-  receivedAt: number,
-): Promise<void> {
-  try {
-    await AsyncStorage.setItem(
-      BACKEND_SSOT_MIRROR_KEY,
-      JSON.stringify({ ...ssot, receivedAt }),
-    );
-  } catch {
-    // graceful — cascade picker는 mirror 부재 시 기존 tier fallback.
-  }
-}
-
-/**
- * #1561 (T8) — AsyncStorage에서 backend SSoT mirror 읽기. cascade picker가 polling cycle마다 호출.
- *
- * 미존재 / parse 실패 → null. cascade picker는 기존 tier fallback.
- */
-export interface BackendSsotMirrorEntry extends SilentPushSsotMirror {
-  receivedAt: number;
-}
-
-export async function readBackendSsotMirror(): Promise<BackendSsotMirrorEntry | null> {
-  try {
-    const raw = await AsyncStorage.getItem(BACKEND_SSOT_MIRROR_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as Partial<BackendSsotMirrorEntry> | null;
-    if (
-      !parsed ||
-      typeof parsed.currentStationId !== 'string' ||
-      parsed.currentStationId.length === 0 ||
-      (parsed.motionState !== 'moving' &&
-        parsed.motionState !== 'stationary' &&
-        parsed.motionState !== 'unknown') ||
-      typeof parsed.lastAdvanceEvidence !== 'string' ||
-      typeof parsed.lastAdvanceAt !== 'number' ||
-      !Array.isArray(parsed.passedStations) ||
-      typeof parsed.receivedAt !== 'number'
-    ) {
-      return null;
-    }
-    return {
-      currentStationId: parsed.currentStationId,
-      motionState: parsed.motionState,
-      lastAdvanceEvidence: parsed.lastAdvanceEvidence,
-      lastAdvanceAt: parsed.lastAdvanceAt,
-      passedStations: parsed.passedStations.filter(
-        (p): p is string => typeof p === 'string' && p.length > 0,
-      ),
-      receivedAt: parsed.receivedAt,
-    };
-  } catch {
-    return null;
-  }
-}
+// #1568 (T8b) — persistBackendSsotMirror / readBackendSsotMirror는 utils/backendSsotMirror로 이전.
+// 본 파일 상단에서 type/함수 re-export 유지.
 
 /**
  * #816 C — 사용자 토글 (lockless station-passed opt-in) 현재값을 AsyncStorage에서 읽는다.

--- a/src/features/alarm/utils/__tests__/notificationSource.test.ts
+++ b/src/features/alarm/utils/__tests__/notificationSource.test.ts
@@ -13,6 +13,7 @@ jest.mock('../../../../shared/constants/debugFlags', () => ({
 
 describe('resolveNotificationSource', () => {
   it.each<[FusionSource, NotificationSource]>([
+    ['backend-ssot', 'positionTrain'],
     ['boarding-lock', 'positionTrain'],
     ['boarding-lock-interp', 'positionTrain'],
     ['position-train', 'positionTrain'],

--- a/src/features/alarm/utils/backendSsotMirror.ts
+++ b/src/features/alarm/utils/backendSsotMirror.ts
@@ -1,0 +1,94 @@
+/**
+ * #1568 (T8b, Epic ADR-017 #1553) — backend SSoT 권위 mirror storage SSoT 모듈.
+ *
+ * silent push handler가 payload.ssot를 영속화하고 device 화면/cascade picker가 read한다.
+ * 본 모듈은 AsyncStorage I/O만 다루며 expo-notifications / expo-task-manager 의존성이 없어
+ * 어떤 feature에서든 가볍게 import 가능하다 (#1568 cascade picker / DebugModal 양쪽이 사용).
+ *
+ * 구 호환: 원래 `silentPushTask.ts`에 함께 있던 helper(`persistBackendSsotMirror`/`readBackendSsotMirror`/
+ * `SilentPushSsotMirror`/`BackendSsotMirrorEntry`)를 본 모듈로 이전. silentPushTask.ts는 re-export로
+ * 기존 import path를 유지한다.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { BACKEND_SSOT_MIRROR_KEY } from '../../../shared/constants/storageKeys';
+
+/**
+ * #1561 (T8) — silent push payload에 실린 SSoT 권위 스냅샷 형태.
+ *
+ * backend `apns.ts`의 `SilentPushSsotPayload`와 1:1. device는 본 값을 BACKEND_SSOT_MIRROR_KEY에
+ * mirror하며 cascade picker가 다음 polling cycle에서 read해 `backend-ssot` tier로 채택.
+ */
+export interface SilentPushSsotMirror {
+  currentStationId: string;
+  motionState: 'moving' | 'stationary' | 'unknown';
+  lastAdvanceEvidence: string;
+  lastAdvanceAt: number;
+  passedStations: readonly string[];
+}
+
+/** #1561 (T8) — mirror entry에 receivedAt 추가. cascade picker가 자체 staleness 판정. */
+export interface BackendSsotMirrorEntry extends SilentPushSsotMirror {
+  receivedAt: number;
+}
+
+/**
+ * #1561 (T8, ADR-017 / S2 #1535 흡수) — backend SSoT 권위 mirror를 AsyncStorage에 영속화.
+ *
+ * useFusedNearestStation cascade picker가 다음 polling cycle에서 본 값을 read해 `backend-ssot`
+ * tier(최상위)로 채택한다. receivedAt epoch ms를 함께 stamp.
+ *
+ * write 실패는 silent — backend SSoT mirror는 보조 신호로 미존재 시 cascade는 기존 tier fallback.
+ */
+export async function persistBackendSsotMirror(
+  ssot: SilentPushSsotMirror,
+  receivedAt: number,
+): Promise<void> {
+  try {
+    await AsyncStorage.setItem(
+      BACKEND_SSOT_MIRROR_KEY,
+      JSON.stringify({ ...ssot, receivedAt }),
+    );
+  } catch {
+    // graceful — cascade picker는 mirror 부재 시 기존 tier fallback.
+  }
+}
+
+/**
+ * #1561 (T8) — AsyncStorage에서 backend SSoT mirror 읽기. cascade picker가 polling cycle마다 호출.
+ *
+ * 미존재 / parse 실패 → null. cascade picker는 기존 tier fallback.
+ */
+export async function readBackendSsotMirror(): Promise<BackendSsotMirrorEntry | null> {
+  try {
+    const raw = await AsyncStorage.getItem(BACKEND_SSOT_MIRROR_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<BackendSsotMirrorEntry> | null;
+    if (
+      !parsed ||
+      typeof parsed.currentStationId !== 'string' ||
+      parsed.currentStationId.length === 0 ||
+      (parsed.motionState !== 'moving' &&
+        parsed.motionState !== 'stationary' &&
+        parsed.motionState !== 'unknown') ||
+      typeof parsed.lastAdvanceEvidence !== 'string' ||
+      typeof parsed.lastAdvanceAt !== 'number' ||
+      !Array.isArray(parsed.passedStations) ||
+      typeof parsed.receivedAt !== 'number'
+    ) {
+      return null;
+    }
+    return {
+      currentStationId: parsed.currentStationId,
+      motionState: parsed.motionState,
+      lastAdvanceEvidence: parsed.lastAdvanceEvidence,
+      lastAdvanceAt: parsed.lastAdvanceAt,
+      passedStations: parsed.passedStations.filter(
+        (p): p is string => typeof p === 'string' && p.length > 0,
+      ),
+      receivedAt: parsed.receivedAt,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/features/alarm/utils/notificationSource.ts
+++ b/src/features/alarm/utils/notificationSource.ts
@@ -26,6 +26,7 @@ export function resolveNotificationSource(
 ): NotificationSource {
   if (locationUncertain) return 'uncertain';
   switch (source) {
+    case 'backend-ssot':
     case 'boarding-lock':
     case 'boarding-lock-interp':
     case 'position-train':

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -14,6 +14,10 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useSettingsStore } from '../../settings/store/useSettingsStore';
 import { useDestinationStore } from '../../route/store/useDestinationStore';
 import { getTripStartedAt } from '../../alarm/utils/tripStartStorage';
+import {
+  readBackendSsotMirror,
+  type BackendSsotMirrorEntry,
+} from '../../alarm/utils/backendSsotMirror';
 import { isDebugModalEnabled } from '../../../shared/constants/debugFlags';
 import type { GpsActiveState } from '../../../shared/constants/gpsStatus';
 import { formatClockTimeWithSeconds } from '../../../shared/utils/formatTime';
@@ -468,6 +472,11 @@ interface BuildDumpArgs {
   arrivalSummary: string;
   isMock: boolean;
   silentPush: SilentPushDiagnostics;
+  /**
+   * #1568 (T8b, Epic ADR-017 #1553) — backend가 silent push로 forward한 TripPositionSSoT mirror.
+   * null/미전달 시 dump는 `(no recent SSoT push)` 한 줄만 출력 — backend 호환성 추적용.
+   */
+  backendSsotMirror?: BackendSsotMirrorEntry | null;
   logs: AlarmLogEntry[];
   // #856: lockless station-passed toggle ON/OFF — Silent Push 섹션 row의 SSOT.
   // optional — DebugModal 본체는 항상 전달, 단순 dump 단위 테스트는 생략 가능(기본 false).
@@ -674,6 +683,31 @@ function buildSilentPushSection(args: BuildDumpArgs): string[] {
     args.locklessOn ?? false,
     args.lowPowerMode ?? false,
   ).map(({ dumpKey, value }) => `${dumpKey}=${value}`);
+}
+
+/**
+ * #1568 (T8b, Epic ADR-017 #1553) — backend SSoT mirror dump rows.
+ *
+ * silent push payload.ssot가 BACKEND_SSOT_MIRROR_KEY에 영속화한 상태. backend cycle이 한 번도
+ * SSoT 권위를 forward 안 했으면 `(no recent SSoT push)` 1줄만 노출 — share dump에서 backend
+ * 호환성/cycle 활성 여부가 즉시 식별 가능하도록.
+ */
+const BACKEND_SSOT_DUMP_LABELS = {
+  currentStationId: 'currentStationId',
+  motionState: 'motionState',
+  lastAdvanceEvidence: 'lastAdvanceEvidence',
+  lastAdvanceAt: 'lastAdvanceAt',
+} as const;
+
+function buildBackendSsotSection(args: BuildDumpArgs): string[] {
+  const entry = args.backendSsotMirror ?? null;
+  if (!entry) return ['(no recent SSoT push)'];
+  return [
+    `${BACKEND_SSOT_DUMP_LABELS.currentStationId}=${entry.currentStationId}`,
+    `${BACKEND_SSOT_DUMP_LABELS.motionState}=${entry.motionState}`,
+    `${BACKEND_SSOT_DUMP_LABELS.lastAdvanceEvidence}=${entry.lastAdvanceEvidence}`,
+    `${BACKEND_SSOT_DUMP_LABELS.lastAdvanceAt}=${entry.lastAdvanceAt}`,
+  ];
 }
 
 function buildScheduledQueueSection(args: BuildDumpArgs): string[] {
@@ -1071,6 +1105,8 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
   { title: 'Sleep', build: buildSleepSection },
   { title: 'Arrival', build: buildArrivalSection },
   { title: 'Silent Push', build: buildSilentPushSection },
+  // #1568 (T8b, Epic ADR-017 #1553) — backend SSoT 권위 mirror.
+  { title: 'Backend SSoT', build: buildBackendSsotSection },
   {
     title: 'Scheduled queue',
     build: buildScheduledQueueSection,
@@ -1271,6 +1307,37 @@ function DebugModalInner({
   const stationName = result?.station.name ?? null;
   const { arrival, isMock } = useArrivalInfo(stationName);
   const silentPush = useSilentPushDiagnostics();
+  // #1568 (T8b, Epic ADR-017 #1553) — backend SSoT 권위 mirror 폴링. 5s 간격.
+  // 미존재(backend가 한 번도 forward 안 함) / parse 실패 시 null → '(no recent SSoT push)' 표시.
+  const [backendSsotMirror, setBackendSsotMirror] =
+    useState<BackendSsotMirrorEntry | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    const tick = () => {
+      void readBackendSsotMirror().then((entry) => {
+        if (cancelled) return;
+        setBackendSsotMirror((prev) => {
+          if (prev === null && entry === null) return prev;
+          if (
+            prev !== null &&
+            entry !== null &&
+            prev.receivedAt === entry.receivedAt &&
+            prev.currentStationId === entry.currentStationId
+          ) {
+            return prev;
+          }
+          return entry;
+        });
+      });
+    };
+    // 첫 read 즉시 실행 — DebugModal은 사용자가 명시적으로 연 화면이라 첫 entry를 빠르게 표시.
+    tick();
+    const id = setInterval(tick, 5_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
   // #856: lockless station-passed toggle. OFF면 backend가 받은 silent push도 client가
   // intermediate 알림을 차단 → "received는 늘어도 fired는 안 늘어남"이 정상 동작.
   // DebugModal에 한 줄로 노출해 사용자가 설정 위치를 즉시 알 수 있게 한다.
@@ -1489,6 +1556,8 @@ function DebugModalInner({
       arrivalSummary,
       isMock,
       silentPush,
+      // #1568 (T8b, Epic ADR-017 #1553) — backend SSoT 권위 mirror.
+      backendSsotMirror,
       logs,
       locklessOn,
       lowPowerMode,
@@ -1536,6 +1605,7 @@ function DebugModalInner({
     arrivalSummary,
     isMock,
     silentPush,
+    backendSsotMirror,
     logs,
     locklessOn,
     lowPowerMode,
@@ -1754,6 +1824,45 @@ function DebugModalInner({
               ({ uiLabel, value }) => (
                 <KeyValue key={uiLabel} label={uiLabel} value={value} colors={colors} />
               ),
+            )}
+          </Section>
+
+          {/*
+           * #1568 (T8b, Epic ADR-017 #1553) — backend SSoT 권위 mirror 표시.
+           * silent push payload.ssot가 BACKEND_SSOT_MIRROR_KEY에 영속화한 권위 스냅샷.
+           * backend가 한 번도 SSoT 권위를 forward 안 한 cycle은 `(no recent SSoT push)` 1줄.
+           */}
+          <Section title="Backend SSoT" colors={colors}>
+            {backendSsotMirror ? (
+              <>
+                <KeyValue
+                  label={BACKEND_SSOT_DUMP_LABELS.currentStationId}
+                  value={backendSsotMirror.currentStationId}
+                  colors={colors}
+                />
+                <KeyValue
+                  label={BACKEND_SSOT_DUMP_LABELS.motionState}
+                  value={backendSsotMirror.motionState}
+                  colors={colors}
+                />
+                <KeyValue
+                  label={BACKEND_SSOT_DUMP_LABELS.lastAdvanceEvidence}
+                  value={backendSsotMirror.lastAdvanceEvidence}
+                  colors={colors}
+                />
+                <KeyValue
+                  label={BACKEND_SSOT_DUMP_LABELS.lastAdvanceAt}
+                  value={String(backendSsotMirror.lastAdvanceAt)}
+                  colors={colors}
+                />
+              </>
+            ) : (
+              <Text
+                style={[typography.mono, { color: colors.muted }]}
+                testID="debug-backend-ssot-empty"
+              >
+                (no recent SSoT push)
+              </Text>
             )}
           </Section>
 

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -40,6 +40,11 @@ jest.mock('../../../../shared/hooks/useLowPowerMode', () => ({
 jest.mock('../../../alarm/hooks/useSilentPushDiagnostics', () => ({
   useSilentPushDiagnostics: () => mockUseSilentPushDiagnostics(),
 }));
+// #1568 (T8b) — backend SSoT mirror 폴링. test에서는 default null로 mock.
+const mockReadBackendSsotMirror = jest.fn();
+jest.mock('../../../alarm/utils/backendSsotMirror', () => ({
+  readBackendSsotMirror: () => mockReadBackendSsotMirror(),
+}));
 jest.mock('../../../alarm/utils/alarmLog', () => {
   const actual = jest.requireActual('../../../alarm/utils/alarmLog');
   return {
@@ -175,6 +180,8 @@ const setupHookDefaults = () => {
   mockUseLowPowerMode.mockReturnValue(false);
   // #1235 (D9 wire) — tripStartedAt 기본 null (trip 미시작).
   mockGetTripStartedAt.mockResolvedValue(null);
+  // #1568 (T8b) — backend SSoT mirror 기본 null (backend가 forward 안 함).
+  mockReadBackendSsotMirror.mockResolvedValue(null);
   // #1235 (D9 wire) — destinationStore/settingsStore SSOT 초기화. 매 테스트 독립.
   useDestinationStore.setState({ destination: null });
   useSettingsStore.setState({ sleepMode: false });
@@ -2024,6 +2031,98 @@ describe('DebugModal — Silent Push 진단 섹션 (#506)', () => {
     expect(dump).toContain('bl:T:1:early:군자');
     expect(dump).toContain('bl:T:1:imminent:군자');
     expect(dump).not.toContain('(not loaded)');
+  });
+});
+
+describe('DebugModal — Backend SSoT 섹션 (#1568, T8b)', () => {
+  const mirrorEntry = {
+    currentStationId: '용마산',
+    motionState: 'moving' as const,
+    lastAdvanceEvidence: 'arvlcd-arrived',
+    lastAdvanceAt: 1_700_000_000_000,
+    passedStations: ['중곡', '군자'] as readonly string[],
+    receivedAt: 1_700_000_001_000,
+  };
+
+  let appStateListener: ((state: string) => void) | null = null;
+  const appStateRemove = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appStateListener = null;
+    jest.spyOn(AppState, 'addEventListener').mockImplementation((_t, l) => {
+      appStateListener = l as (state: string) => void;
+      return { remove: appStateRemove } as unknown as ReturnType<typeof AppState.addEventListener>;
+    });
+    setupHookDefaults();
+  });
+
+  it('UI: mirror 미존재 시 "(no recent SSoT push)" 노출', async () => {
+    mockReadBackendSsotMirror.mockResolvedValue(null);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('debug-backend-ssot-empty')).toBeTruthy();
+    });
+    expect(screen.getByText('(no recent SSoT push)')).toBeTruthy();
+  });
+
+  it('UI: mirror 존재 시 4 row 노출', async () => {
+    mockReadBackendSsotMirror.mockResolvedValue(mirrorEntry);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    // currentStationId row value 등장 — 폴링 첫 tick 후
+    await waitFor(() => {
+      expect(screen.getByText('용마산')).toBeTruthy();
+    });
+    expect(screen.getByText('moving')).toBeTruthy();
+    expect(screen.getByText('arvlcd-arrived')).toBeTruthy();
+    expect(screen.getByText(String(mirrorEntry.lastAdvanceAt))).toBeTruthy();
+  });
+
+  it('UI: 동일 entry로 두 cycle → reducer no-op (extra render 없음)', async () => {
+    jest.useFakeTimers();
+    try {
+      mockReadBackendSsotMirror.mockResolvedValue(mirrorEntry);
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      // 첫 tick는 즉시 실행. microtask flush로 setState 적용.
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(screen.getByText('용마산')).toBeTruthy();
+      // 5s 후 interval tick — 동일 entry → reducer가 prev 그대로 반환.
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+        await Promise.resolve();
+      });
+      expect(screen.getByText('용마산')).toBeTruthy();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('mirror 미전달 → dump에 (no recent SSoT push) 1줄', () => {
+    const dump = __test__.buildDumpText(makeDumpArgs({}));
+    expect(dump).toContain('## Backend SSoT');
+    expect(dump).toContain('(no recent SSoT push)');
+  });
+
+  it('mirror 존재 → currentStationId/motionState/lastAdvanceEvidence/lastAdvanceAt 4줄', () => {
+    const dump = __test__.buildDumpText(
+      makeDumpArgs({ backendSsotMirror: mirrorEntry }),
+    );
+    expect(dump).toContain('## Backend SSoT');
+    expect(dump).toContain('currentStationId=용마산');
+    expect(dump).toContain('motionState=moving');
+    expect(dump).toContain('lastAdvanceEvidence=arvlcd-arrived');
+    expect(dump).toContain(`lastAdvanceAt=${mirrorEntry.lastAdvanceAt}`);
+    expect(dump).not.toContain('(no recent SSoT push)');
+  });
+
+  it('mirror null도 (no recent SSoT push)로 처리 (graceful)', () => {
+    const dump = __test__.buildDumpText(
+      makeDumpArgs({ backendSsotMirror: null }),
+    );
+    expect(dump).toContain('## Backend SSoT');
+    expect(dump).toContain('(no recent SSoT push)');
   });
 });
 

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.backendSsotCascade.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.backendSsotCascade.test.ts
@@ -1,0 +1,244 @@
+/* eslint-disable import/no-restricted-paths -- cross-feature orchestration (#890) */
+
+/**
+ * #1568 (T8b, Epic ADR-017 #1553) — cascade picker `backend-ssot` tier 회귀 가드.
+ *
+ * 시나리오:
+ *   1. backend SSoT mirror 존재 + fresh → cascade 1순위 채택, confidence/source='backend-ssot'.
+ *   2. mirror 미존재 → 기존 tier(WiFi/position-train/...) fallback.
+ *   3. mirror stale(lastAdvanceAt 60s 초과) → cascade 채택 거부 → 기존 tier fallback.
+ *   4. mirror lock 활성 + line mismatch → station resolve null → 채택 거부.
+ *   5. mirror lockless + resolve 가능 → cascade 채택 (lockless도 lock과 동급 우선순위).
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { useFusedNearestStation } from '../useFusedNearestStation';
+import { useNearestStation } from '../useNearestStation';
+import { useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
+import { useTrainPositions } from '../../../route/hooks/useTrainPositions';
+import { findTopNearestStations } from '../../utils/findNearestStation';
+import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute';
+import {
+  arrivalRet,
+  positionRet,
+  GPS_BASE_DEFAULTS,
+} from '../../../../testUtils/positionApiFixtures';
+import { readBackendSsotMirror } from '../../../alarm/utils/backendSsotMirror';
+import type { BackendSsotMirrorEntry } from '../../../alarm/utils/backendSsotMirror';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+
+jest.mock('../../utils/findNearestStation', () => ({
+  findTopNearestStations: jest.fn(),
+}));
+jest.mock('../useNearestStation');
+jest.mock('../../../arrival/hooks/useArrivalInfo');
+jest.mock('../../../route/hooks/useTrainPositions');
+jest.mock('../../../alarm/utils/tripStartStorage', () => ({
+  getTripStartedAt: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../../../alarm/utils/backendSsotMirror', () => ({
+  readBackendSsotMirror: jest.fn(),
+}));
+
+const mockNearest = useNearestStation as jest.Mock;
+const mockArrival = useArrivalInfo as jest.Mock;
+const mockPos = useTrainPositions as jest.Mock;
+const mockFindTop = findTopNearestStations as jest.Mock;
+const mockRead = readBackendSsotMirror as jest.Mock;
+
+const yongmasan = findStationByNameAndLine('용마산', '7')!;
+const chungdam = findStationByNameAndLine('청담', '7')!;
+const gangnam2 = findStationByNameAndLine('강남', '2')!;
+
+const T0 = 1_700_000_000_000;
+
+function makeMirror(overrides: Partial<BackendSsotMirrorEntry> = {}): BackendSsotMirrorEntry {
+  return {
+    currentStationId: yongmasan.name,
+    motionState: 'moving',
+    lastAdvanceEvidence: 'arvlcd-arrived',
+    lastAdvanceAt: T0,
+    passedStations: [],
+    receivedAt: T0,
+    ...overrides,
+  };
+}
+
+function setupBaselineGpsAt(stationName: string) {
+  const stn = findStationByNameAndLine(stationName, '7')!;
+  const live = { station: stn, distanceKm: 0 };
+  mockNearest.mockReturnValue({
+    result: live,
+    liveResult: live,
+    stickyDisplayOnly: null,
+    variants: [stn],
+    userLocation: { lat: stn.lat, lng: stn.lng },
+    ...GPS_BASE_DEFAULTS,
+    accuracyMeters: 14,
+    refresh: jest.fn(),
+  });
+  mockFindTop.mockReturnValue([{ station: stn, distanceKm: 0 }]);
+  mockArrival.mockReturnValue(arrivalRet(null));
+  mockPos.mockReturnValue(positionRet(null));
+}
+
+const lockOn7: BoardingLock = {
+  destinationId: 'dest-7',
+  trainCode: 'T-LOCK',
+  boardingLine: '7',
+  boardingStationId: yongmasan.id,
+  boardedAt: T0,
+  expectedDurationMs: 10 * 60_000,
+};
+
+describe('#1568 (T8b) cascade picker — backend-ssot tier', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(T0);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  async function flushSsotRead() {
+    // 5s interval tick으로 SSoT mirror state hydrate.
+    await act(async () => {
+      jest.advanceTimersByTime(5_000);
+      // microtask flush
+      await Promise.resolve();
+    });
+  }
+
+  it('mirror 존재 + fresh → cascade 1순위 (lock 활성, lockless 동등 우선순위)', async () => {
+    // 사용자가 다른 역(청담)에 있다고 GPS가 가리켜도 backend mirror가 용마산을 권위 산출 → mirror 우선.
+    setupBaselineGpsAt('청담');
+    mockRead.mockResolvedValue(makeMirror({ currentStationId: yongmasan.name }));
+    const hook = renderHook(() =>
+      useFusedNearestStation(undefined, undefined, undefined, undefined, lockOn7),
+    );
+    await flushSsotRead();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+    expect(hook.result.current.confidence).toBe('backend-ssot');
+    expect(hook.result.current.result?.station.id).toBe(yongmasan.id);
+  });
+
+  it('mirror 없음 → 기존 tier(GPS fallback)로 자연 fallback', async () => {
+    setupBaselineGpsAt('청담');
+    mockRead.mockResolvedValue(null);
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushSsotRead();
+    // mirror 없음 + GPS 청담 → cascade 기본 GPS fallback ('gps')
+    expect(hook.result.current.source).not.toBe('backend-ssot');
+    expect(hook.result.current.confidence).not.toBe('backend-ssot');
+  });
+
+  it('mirror stale(lastAdvanceAt > 60s) → 채택 거부', async () => {
+    setupBaselineGpsAt('청담');
+    mockRead.mockResolvedValue(
+      makeMirror({
+        currentStationId: yongmasan.name,
+        lastAdvanceAt: T0 - 120_000, // 2분 전 — staleness 60s 초과
+      }),
+    );
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushSsotRead();
+    expect(hook.result.current.source).not.toBe('backend-ssot');
+  });
+
+  it('mirror lock 활성 + line mismatch → station resolve 실패 → 채택 거부', async () => {
+    // mirror가 2호선 강남을 가리키지만 lock은 7호선 → findStationByNameAndLine('강남', '7') = null.
+    setupBaselineGpsAt('청담');
+    mockRead.mockResolvedValue(makeMirror({ currentStationId: gangnam2.name }));
+    const hook = renderHook(() =>
+      useFusedNearestStation(undefined, undefined, undefined, undefined, lockOn7),
+    );
+    await flushSsotRead();
+    expect(hook.result.current.source).not.toBe('backend-ssot');
+  });
+
+  it('mirror lockless → 채택 (lockless trip 동등 우선순위)', async () => {
+    setupBaselineGpsAt('청담');
+    mockRead.mockResolvedValue(makeMirror({ currentStationId: yongmasan.name }));
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushSsotRead();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+    expect(hook.result.current.result?.station.id).toBe(yongmasan.id);
+  });
+
+  it('두 cycle 동일 entry → 추가 render skip (setState reducer no-op)', async () => {
+    setupBaselineGpsAt('청담');
+    mockRead.mockResolvedValue(makeMirror());
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushSsotRead();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+    // 두 번째 tick에서 동일 entry → setState reducer가 prev 그대로 반환 → 추가 render 없음.
+    await flushSsotRead();
+    expect(hook.result.current.source).toBe('backend-ssot');
+  });
+
+  it('null → null 전이도 추가 render 없음 (no-op reducer)', async () => {
+    setupBaselineGpsAt('청담');
+    mockRead.mockResolvedValue(null);
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushSsotRead();
+    await flushSsotRead();
+    expect(hook.result.current.source).not.toBe('backend-ssot');
+  });
+
+  it('liveResult exposes raw GPS — sticky 격리 채널', async () => {
+    setupBaselineGpsAt('청담');
+    mockRead.mockResolvedValue(null);
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushSsotRead();
+    expect(hook.result.current.liveResult?.station.name).toBe('청담');
+  });
+
+  it('unmount 후 resolve된 read는 setState 무시 (cancelled 가드)', async () => {
+    setupBaselineGpsAt('청담');
+    let resolveRead!: (entry: BackendSsotMirrorEntry | null) => void;
+    mockRead.mockReturnValueOnce(
+      new Promise<BackendSsotMirrorEntry | null>((res) => {
+        resolveRead = res;
+      }),
+    );
+    const hook = renderHook(() => useFusedNearestStation());
+    // 5s tick으로 read 시작 (resolve는 보류)
+    act(() => {
+      jest.advanceTimersByTime(5_000);
+    });
+    hook.unmount();
+    // unmount 이후에 read resolve — cancelled 가드로 setState skip되어 warning/error 없음.
+    await act(async () => {
+      resolveRead(makeMirror());
+      await Promise.resolve();
+    });
+    // 별도 assertion 없음 — error 없이 통과하면 cancelled 분기 커버.
+    expect(true).toBe(true);
+  });
+
+  it('mirror cycle에서 backend가 station을 바꾸면 entry diff로 setState 발화', async () => {
+    setupBaselineGpsAt('청담');
+    mockRead.mockResolvedValueOnce(makeMirror({ currentStationId: yongmasan.name }));
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushSsotRead();
+    await waitFor(() => {
+      expect(hook.result.current.result?.station.id).toBe(yongmasan.id);
+    });
+    // 다음 cycle은 다른 receivedAt + 다른 currentStationId
+    mockRead.mockResolvedValue(
+      makeMirror({ currentStationId: chungdam.name, receivedAt: T0 + 5_000 }),
+    );
+    await flushSsotRead();
+    await waitFor(() => {
+      expect(hook.result.current.result?.station.id).toBe(chungdam.id);
+    });
+  });
+});

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -6,7 +6,7 @@
  *
  * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
  */
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   pushFusionDebugEntry,
   type FusionCandidateMini,
@@ -29,7 +29,7 @@ import type { PositionStability } from '../utils/positionStaticDetector';
 import { pickCandidateTrains, type CandidateTrain } from '../../arrival/utils/pickCandidateTrains';
 import { trackTrainProgress } from '../../route/utils/trackTrainProgress';
 import { haversine } from '../../../shared/utils/haversine';
-import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
+import { findStationByName, findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import { isWithinArcWindow, passesFusionDistanceGate } from '../utils/fusionDistanceGate';
 import { surfaceSSOTConsensus } from '../utils/surfaceSSotConsensus';
 import { undergroundSSOTConsensus } from '../utils/undergroundSSotConsensus';
@@ -42,8 +42,13 @@ import {
 } from '../../route/utils/stationProgressEstimator';
 import { hopTimeMsAt } from '../../route/utils/hopTime';
 import { getTripStartedAt } from '../../alarm/utils/tripStartStorage';
+import {
+  readBackendSsotMirror,
+  type BackendSsotMirrorEntry,
+} from '../../alarm/utils/backendSsotMirror';
 import { MAX_STATION_DISTANCE_KM } from '../../../shared/constants/location';
 import {
+  BACKEND_SSOT_MIRROR_MAX_AGE_MS,
   DETECTION_FUSED_MAX_DISTANCE_KM,
   MAX_ACTIVE_LINES,
   MAX_FUSION_DELTA_KM,
@@ -72,6 +77,14 @@ interface UseFusedNearestStationReturn {
   result: NearestStationResult | null;
   /** GPS 원본 result — 비교/디버깅용. */
   gpsResult: NearestStationResult | null;
+  /**
+   * #1568 (T8b, Epic ADR-017 #1553) — sticky override 없는 raw GPS 최근접.
+   *
+   * 위젯 mirror(useWidgetMirror)는 본 값을 사용해 sticky:locked가 위젯에 stuck되는 회귀를 차단한다.
+   * fire path 채택 SSOT는 본 hook의 `result`(cascade 산출). 본 필드는 표시·sticky 격리 전용.
+   * 미정의 시 null (GPS dead zone 또는 권한 미부여).
+   */
+  liveResult: NearestStationResult | null;
   /** fusion 신뢰도. */
   confidence: FusionConfidence;
   /** fusion 신호 출처. position(가장 정확) > arrival(추정) > gps(거리). */
@@ -361,6 +374,43 @@ export function useFusedNearestStation(
   // #733 — 위치 이력 기반 정적 판정. shouldDowngradeFusion이 speed=null일 때 fallback으로 사용.
   // useNearestStation의 userLocation 변경마다 자동 누적/판정.
   const positionStability = usePositionStability(gps.userLocation);
+
+  // #1568 (T8b, Epic ADR-017 #1553) — backend SSoT mirror 폴링.
+  //
+  // silent push handler가 BACKEND_SSOT_MIRROR_KEY에 영속화한 권위 스냅샷을 읽어 cascade picker가
+  // `backend-ssot` tier(최상위)로 채택할 수 있게 한다. 5s 간격 폴링 — backend는 cycle(~30s)마다
+  // 발사하므로 충분히 빈번하며 매 render read를 피해 AsyncStorage I/O 폭주를 방지.
+  // 미존재 / parse 실패 / staleness(60s 초과) 시 null로 두어 cascade는 기존 tier fallback (graceful).
+  const [backendSsotMirror, setBackendSsotMirror] = useState<BackendSsotMirrorEntry | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    const tick = () => {
+      void readBackendSsotMirror().then((entry) => {
+        if (cancelled) return;
+        // 무의미한 state update로 인한 추가 render 방지 — receivedAt이 같으면 동일 entry.
+        // 미존재(null) → 미존재(null) 전이도 setState skip.
+        setBackendSsotMirror((prev) => {
+          if (prev === null && entry === null) return prev;
+          if (
+            prev !== null &&
+            entry !== null &&
+            prev.receivedAt === entry.receivedAt &&
+            prev.currentStationId === entry.currentStationId
+          ) {
+            return prev;
+          }
+          return entry;
+        });
+      });
+    };
+    // 첫 read는 5s interval 첫 tick에 맡긴다 — 마운트 직후 동기 read의 microtask resolve가
+    // 첫 render commit phase와 겹쳐 act() warning을 발생시키는 회귀 차단(jest-expo setup).
+    const id = setInterval(tick, 5_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
 
   // Phase A: 경로가 설정되면 진행도 기반 현재역으로 GPS 결과를 덮어쓴다.
   // origin/destination이 빠지면 useRouteProgress가 arc를 만들지 못하고 null을 반환,
@@ -702,10 +752,42 @@ export function useFusedNearestStation(
     fused.result.distanceKm <= DETECTION_FUSED_MAX_DISTANCE_KM &&
     (!boardingLock || fused.result.station.line === boardingLock.boardingLine);
 
+  // #1568 (T8b, Epic ADR-017 #1553) — backend SSoT mirror cascade 채택 자격.
+  //
+  // 게이트 (false positive 방어):
+  //   1. mirror entry 존재 + station name이 stations.json로 resolve 가능.
+  //   2. lastAdvanceAt 기준 staleness 60s 이하 — backend cycle(~30s) 2회 + margin.
+  //      stale entry는 backend가 trip을 잊었거나 device가 silent push를 한동안 못 받은 상태 →
+  //      cascade 채택 시 사용자 실제 위치를 뒤덮을 risk가 있어 자연 fallback.
+  //   3. 노선 가드 — lock 활성 시 resolved station이 lock.boardingLine과 일치해야 채택.
+  //      lockless trip은 노선 가드 없이 backend가 advance한 station을 신뢰(보조 cross-check 없음).
+  const ssotStation = useMemo<Station | null>(() => {
+    if (!backendSsotMirror) return null;
+    if (boardingLock) {
+      return findStationByNameAndLine(
+        backendSsotMirror.currentStationId,
+        boardingLock.boardingLine,
+      );
+    }
+    return findStationByName(backendSsotMirror.currentStationId);
+  }, [backendSsotMirror, boardingLock]);
+  const nowMsForSsot = Date.now();
+  const ssotFresh =
+    backendSsotMirror !== null &&
+    nowMsForSsot - backendSsotMirror.lastAdvanceAt <= BACKEND_SSOT_MIRROR_MAX_AGE_MS;
+  const backendSsotAccepts = ssotStation !== null && ssotFresh;
+
   let result: NearestStationResult | null;
   let confidence: FusionConfidence;
   let source: FusionSource;
-  if (wifiStationResolved) {
+  if (backendSsotAccepts) {
+    // #1568 (T8b) — backend SSoT 권위 mirror. cascade 최상위. backend advance 게이트가
+    // ADR-017 6단(seed/repeat/motion-stop/cross-validation 등)을 이미 통과한 결과이므로
+    // device-side cascade tier보다 신뢰도가 높다. lock 활성/lockless 모두 동일 우선순위.
+    result = { station: ssotStation!, distanceKm: 0 };
+    confidence = 'backend-ssot';
+    source = 'backend-ssot';
+  } else if (wifiStationResolved) {
     result = wifiStationResolved;
     confidence = 'wifi-ssid';
     source = 'wifi-ssid';
@@ -1236,6 +1318,7 @@ export function useFusedNearestStation(
   return {
     result,
     gpsResult: gps.result,
+    liveResult: gps.liveResult,
     confidence,
     source,
     variants: gps.variants,

--- a/src/features/nearest-station/utils/__tests__/fusionTierPriority.test.ts
+++ b/src/features/nearest-station/utils/__tests__/fusionTierPriority.test.ts
@@ -8,9 +8,15 @@ import type { FusionConfidence, FusionSource } from '../../../../shared/types/fu
 
 describe('fusionTierPriority (R-10, #1168)', () => {
   describe('FUSION_TIER_PRIORITY table', () => {
-    it('spec §4.2 순서 — wifi-ssid가 최상위, gps-only가 최하위', () => {
-      expect(FUSION_TIER_PRIORITY[0]).toBe<FusionTier>('wifi-ssid');
+    it('spec §4.2 순서 — backend-ssot가 최상위, gps-only가 최하위 (#1568 T8b)', () => {
+      expect(FUSION_TIER_PRIORITY[0]).toBe<FusionTier>('backend-ssot');
       expect(FUSION_TIER_PRIORITY[FUSION_TIER_PRIORITY.length - 1]).toBe<FusionTier>('gps-only');
+    });
+
+    it('#1568 (T8b) — backend-ssot이 wifi-ssid보다 상위', () => {
+      expect(FUSION_TIER_PRIORITY.indexOf('backend-ssot')).toBeLessThan(
+        FUSION_TIER_PRIORITY.indexOf('wifi-ssid'),
+      );
     });
 
     it('boarding-lock-train-match가 position-train보다 상위', () => {
@@ -46,7 +52,8 @@ describe('fusionTierPriority (R-10, #1168)', () => {
 
   describe('getTierRank', () => {
     it('표에 있는 tier는 indexOf 결과 반환', () => {
-      expect(getTierRank('wifi-ssid')).toBe(0);
+      expect(getTierRank('backend-ssot')).toBe(0);
+      expect(getTierRank('wifi-ssid')).toBe(1);
       expect(getTierRank('gps-only')).toBe(FUSION_TIER_PRIORITY.length - 1);
     });
 
@@ -57,6 +64,7 @@ describe('fusionTierPriority (R-10, #1168)', () => {
 
   describe('tierFor — (source, confidence) → FusionTier 매핑', () => {
     const cases: ReadonlyArray<[FusionSource, FusionConfidence, FusionTier]> = [
+      ['backend-ssot', 'backend-ssot', 'backend-ssot'],
       ['wifi-ssid', 'wifi-ssid', 'wifi-ssid'],
       ['boarding-lock', 'boarding-lock', 'boarding-lock-train-match'],
       ['boarding-lock-interp', 'boarding-lock-interp', 'estimator-live-position'],

--- a/src/features/nearest-station/utils/fusionTierPriority.ts
+++ b/src/features/nearest-station/utils/fusionTierPriority.ts
@@ -25,6 +25,7 @@ import type { FusionConfidence, FusionSource } from '../../../shared/types/fusio
  * 자리만 미리 박아둔다(미통합이라 결정 트리에 영향 없음).
  */
 export type FusionTier =
+  | 'backend-ssot'
   | 'wifi-ssid'
   | 'boarding-lock-train-match'
   | 'position-train-locked'
@@ -50,6 +51,10 @@ export type FusionTier =
  *   여전히 'gps'다.
  */
 export const FUSION_TIER_PRIORITY: readonly FusionTier[] = [
+  // #1568 (T8b, Epic ADR-017 #1553) — backend SSoT 권위 mirror가 cascade 최상위.
+  // backend advance 게이트(seed/repeat/motion-stop/cross-validation 6단)를 통과한 결과라
+  // device-side cascade tier보다 신뢰도 우선.
+  'backend-ssot',
   'wifi-ssid',
   'boarding-lock-train-match',
   'position-train-locked',
@@ -99,6 +104,8 @@ export function getTierRank(tier: FusionTier): number {
  */
 export function tierFor(source: FusionSource, confidence: FusionConfidence): FusionTier {
   switch (source) {
+    case 'backend-ssot':
+      return 'backend-ssot';
     case 'wifi-ssid':
       return 'wifi-ssid';
     case 'boarding-lock':

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -190,7 +190,7 @@ export default function HomeScreen() {
   //   2) useCurrentStationConfirmModal: 매칭되면 useStationCandidates가 단일 후보로 자동 확정(#914 F4).
   // useFusedNearestStation 호출(아래) 전에 선언해 8번째 인자로 전달한다.
   const wifiStation = useWifiStation();
-  const { result, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source, currentHopIndex, arcStations, trainProgressing } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal }, wifiStation);
+  const { result, liveResult, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source, currentHopIndex, arcStations, trainProgressing } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal }, wifiStation);
 
   // #914 (F4) — 1탭 현재역 확정 모달. 자동 추정이 locationUncertain으로 길어지면 후보 1~3개를
   // 카드로 노출, 1탭 = customOrigin 적용.
@@ -693,7 +693,11 @@ export default function HomeScreen() {
 
   // #1094: 위젯은 destination/route 진행 여부와 무관하게 항상 nearest station을 미러링한다.
   // 50m bucket 단위로 dedupe되어 GPS tick 폭주를 흡수. LA/푸시 알림 lifecycle과 의도적으로 분리.
-  useWidgetMirror(result?.station ?? null, result?.distanceKm ?? null);
+  //
+  // #1568 (T8b, Epic ADR-017 #1553) — sticky 격리: fused result는 sticky:locked override가 들어가
+  // 위젯에 stuck되는 회귀("반포 stuck") 회피하려고 raw GPS 최근접(liveResult)을 전달한다.
+  // 위젯은 boardingLock·trip context와 무관한 ambient display 채널이라 sticky override 의무 없음.
+  useWidgetMirror(liveResult?.station ?? null, liveResult?.distanceKm ?? null);
 
   useEffect(() => {
     const prevDestId = prevDestIdRef.current;

--- a/src/shared/constants/realtime.ts
+++ b/src/shared/constants/realtime.ts
@@ -15,6 +15,10 @@ export const MAX_FUSION_DELTA_KM = 0.2;
 // #445 positionTrain trainProgress 신선도. 7호선 역간 평균 100~120s의 절반.
 // 이 시간 이상 갱신 없으면 sticky 락(lastConfirmedTrainNo) 자체를 해제한다.
 export const POSITION_TRAIN_TTL_MS = 60_000;
+// #1568 (T8b, Epic ADR-017 #1553) — backend SSoT mirror staleness 게이트.
+// silent push payload.ssot.lastAdvanceAt 기준 본 ms 초과 시 cascade 채택 거부.
+// backend는 cycle(~30s)마다 advance를 보내므로 2 cycle + 여유 margin.
+export const BACKEND_SSOT_MIRROR_MAX_AGE_MS = 60_000;
 // #1016 hole (c): BoardingLock 활성 시 positionTrain 후보가 유효한 arc 구간 window.
 // 탑승역 인덱스 + LOCK_NEXT_HOP_WINDOW 범위 내 역만 허용. 지하 dead zone에서 훨씬 앞의
 // 역을 채택하는 false positive를 차단한다. 인접역 간 평균 주행 시간(90s) × TTL(60s) 기준으로

--- a/src/shared/types/fusion.ts
+++ b/src/shared/types/fusion.ts
@@ -26,6 +26,7 @@
  * 별도 트리거. 본 라벨은 cascade의 confidence 표시 단에서 verdict 기여를 명확히 표기한다.
  */
 export type FusionConfidence =
+  | 'backend-ssot'
   | 'boarding-lock'
   | 'boarding-lock-interp'
   | 'position-train'
@@ -47,6 +48,7 @@ export type FusionConfidence =
  * 사용되며 GPS/arrival 호출 없이 역을 확정한다.
  */
 export type FusionSource =
+  | 'backend-ssot'
   | 'boarding-lock'
   | 'boarding-lock-interp'
   | 'position-train'


### PR DESCRIPTION
## Summary

ADR-017 Epic #1553 T8b — T8 #1561 (PR #1567)가 backend payload SSoT forward + device mirror 저장(Phase 1)만 다뤘다. 본 PR은 **fusion picker가 실제로 backend SSoT를 cascade 1순위로 사용**하는 Phase 2 wiring을 마무리한다.

### Changes
- **cascade picker `backend-ssot` tier 신설** (`useFusedNearestStation`)
  - 우선순위: `backend-ssot > wifi-ssid > boarding-lock-train-match > position-train-locked > … > gps-only` (lock 활성/lockless 동등)
  - 5s 폴링으로 `BACKEND_SSOT_MIRROR_KEY` read, reducer-based dedup으로 추가 render 차단
  - 게이트: (a) station resolve 가능 (lock 활성 시 line-aware), (b) `lastAdvanceAt` 기준 60s 이내 fresh
- **HomeScreen sticky 격리**: `useWidgetMirror(liveResult, …)`로 전환 — sticky:locked override가 위젯에 stuck되는 "반포 stuck" 회귀 차단
- **DebugModal `## Backend SSoT` section** (Silent Push 다음): `currentStationId / motionState / lastAdvanceEvidence / lastAdvanceAt` 4행, 미존재 시 `(no recent SSoT push)`
- `backendSsotMirror.ts` 유틸 모듈 분리: silentPushTask에서 expo-notifications 비의존 모듈로 추출해 cascade picker / DebugModal이 import (silentPushTask는 기존 호출자 호환 re-export)
- `notificationSource`: `'backend-ssot'` source를 `positionTrain` 채널로 라우팅 (boarding-lock 류와 동등 정확도)

### Acceptance (issue #1568)
- cascade picker `backend-ssot` 1순위 채택 (lock 활성 + lockless): O
- mirror stale → 채택 거부: O
- lock 활성 + line mismatch → resolve 실패 → 거부: O
- 위젯에 raw `liveResult` 전달: O
- DebugModal `## Backend SSoT` section: O
- 100% coverage (new/touched files 모두 100%): O

## Test plan
- [x] `npm run type-check` 통과
- [x] `npm test` — 신규/수정 파일 전부 100% coverage. `backendSsotCascade.test.ts` 10건 + fusionTierPriority 회귀 3건 + DebugModal SSoT section 5건 + notificationSource 1건 = 19 신규 assertion
- [ ] 실기기 — 트립 시작 후 silent push로 SSoT mirror 도착 → DebugModal `## Backend SSoT` section에 currentStationId 표시 확인
- [ ] 실기기 — 위젯이 sticky:locked 동안에도 raw GPS 최근접 역으로 갱신되는지 확인 ("반포 stuck" 회귀 0건)

Closes #1568