### PR TITLE
feat(#1582): Wire-completion CI lite — ts-prune orphan + PR template 5단

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!--
+Wire-completion 5단 룰 (#1582)
+"코드만 머지되고 wire가 안 끊긴 신호" 회귀를 차단한다.
+모든 항목을 채워야 머지 가능. N/A는 사유 명시 (예: "리팩터링 only, signal 변경 없음").
+-->
+
+## Summary
+
+<!-- 변경 의도 1~3줄 -->
+
+Closes #<이슈번호>
+
+---
+
+## Wire-completion 5단 체크
+
+- [ ] **1. Orphan 없음** — `npm run lint:orphan` pass (CI 자동 검증). 신규 export에는 caller 존재.
+- [ ] **2. V/X dashboard** — DebugModal/wrangler tail/SSoT 어디서 시각화/관측 가능한지 명시.
+- [ ] **3. 의존 PR** — 이 PR이 작동하려면 머지 필요한 backend/device/infra PR 번호. 없으면 "N/A".
+- [ ] **4. 측정 plan** — 회귀 신호를 1주 안에 어떻게 측정할지(시나리오 / log query / 사용자 trip 캡처).
+- [ ] **5. Device verify** — 실기기 검증 필요 여부. 필요 시 사용자 trip 시나리오 명시. 코드-only면 "N/A — type+unit only".
+
+### V/X dashboard URL
+
+<!-- 예: DebugModal "Backend SSoT" 섹션 / wrangler tail / Cloudflare Dashboard logs / Sentry issue link -->
+
+### 의존 PR
+
+<!-- 예: #1500 (backend), #1571 (device wiring). 없으면 N/A. -->
+
+---
+
+## Test plan
+
+- [ ] `npm test` 100% coverage pass
+- [ ] `npm run type-check` pass
+- [ ] `npm run lint:orphan` pass
+- [ ] <시나리오 1>
+- [ ] <시나리오 2>

--- a/.github/workflows/wire-completion.yml
+++ b/.github/workflows/wire-completion.yml
@@ -1,0 +1,32 @@
+name: Wire-completion CI
+
+# #1582 — Wire-completion 5단 룰 lite 게이트.
+# ts-prune로 orphan export(미연결 신호/모듈)를 탐지해 "코드만 머지되고 호출자 없음" 회귀를 차단한다.
+# 5단 룰 중 1단(orphan 탐지)에 해당. 나머지 4단(V/X dashboard, 의존 PR, 측정 PR template,
+# device verify)은 PR template으로 강제한다.
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+
+jobs:
+  orphan-detection:
+    name: Orphan Export Detection
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Node.js 20 설정
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: 의존성 설치
+        run: npm ci --legacy-peer-deps
+
+      - name: Orphan export 검사 (ts-prune)
+        run: npm run lint:orphan

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,23 @@ GPS 기반으로 현재 탑승 중인 지하철역을 실시간으로 감지하�
 - ADR-010 첫 줄: "두 실패 모드(false positive / miss)는 비대칭이 아니라 **동급**."
 - 출처: `memory/feedback_user_intent_equal_protection.md`, `docs/decisions/ADR-014-decision-process-rules.md`
 
+### Wire-completion 5단 룰 (#1582)
+
+"코드만 머지되고 실제 연결 안 됨" 회귀 차단. 모든 PR에 5단 체크 필수 (`.github/PULL_REQUEST_TEMPLATE.md`).
+
+1. **Orphan 없음** — `npm run lint:orphan` pass. CI `Orphan Export Detection` job이 강제. 신규 export 추가 시 caller 반드시 존재.
+   - 의도적 entry-point(`app/` route, `modules/*/index.ts`, barrel `providers/index.ts` 등)는 `scripts/check-orphan-exports.sh`의 `IGNORE_PATTERN`에 추가.
+   - "(used in module)" 라인은 false-positive로 자동 무시.
+2. **V/X dashboard** — 변경된 신호가 어디서 시각화/관측 가능한지(DebugModal / wrangler tail / Cloudflare Dashboard / Sentry) PR 본문에 명시.
+3. **의존 PR** — 본 PR이 작동하려면 머지돼야 할 다른 PR(backend/device/infra) 번호 명시. 없으면 "N/A".
+4. **측정 plan** — 회귀 신호를 1주 안에 어떻게 측정할지(시나리오 / log query / 사용자 trip 캡처) 명시.
+5. **Device verify** — 실기기 검증 필요 여부 + 시나리오. 코드-only면 "N/A — type+unit only" 명시.
+
+검증 절차:
+- `npm run lint:orphan` 로컬 실행 → 0 orphan 확인 후 PR 생성.
+- CI `Wire-completion CI / Orphan Export Detection` job pass 확인 후 머지.
+- 신규 entry-point export 추가 시 ignore pattern 갱신 PR을 분리하지 말고 같은 PR에 포함.
+
 ---
 
 ## Agent skills

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "jest": "^29.7.0",
         "jest-expo": "^54.0.17",
         "react-test-renderer": "^19.1.0",
+        "ts-prune": "^0.10.3",
         "typescript": "~5.9.2"
       }
     },
@@ -4952,6 +4953,43 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@ts-morph/common": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.12.3.tgz",
+      "integrity": "sha512-4tUmeLyXJnJWvTFOKtcNJ1yh0a3SsTLi2MUoyj8iUNznFRN1ZquaNe7Oukqrnki2FzZkm0J9adCNLDZxUzvj+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.2.7",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^1.0.4",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -5070,6 +5108,13 @@
       "dependencies": {
         "undici-types": "~7.18.0"
       }
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.17",
@@ -6457,6 +6502,13 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/code-block-writer": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.3.tgz",
+      "integrity": "sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
@@ -6649,6 +6701,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/create-jest": {
@@ -14877,6 +14956,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -17246,6 +17332,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/true-myth": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/true-myth/-/true-myth-4.1.1.tgz",
+      "integrity": "sha512-rqy30BSpxPznbbTcAcci90oZ1YR4DqvKcNXNerG5gQBU2v4jk0cygheiul5J6ExIMrgDVuanv/MkGfqZbKrNNg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -17264,6 +17360,45 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/ts-morph": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-13.0.3.tgz",
+      "integrity": "sha512-pSOfUMx8Ld/WUreoSzvMFQG5i9uEiWIsBYjpU9+TTASOeUa89j5HykomeqVULm1oqWtBdleI3KEFRLrlA3zGIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.12.3",
+        "code-block-writer": "^11.0.0"
+      }
+    },
+    "node_modules/ts-prune": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-prune/-/ts-prune-0.10.3.tgz",
+      "integrity": "sha512-iS47YTbdIcvN8Nh/1BFyziyUqmjXz7GVzWu02RaZXqb+e/3Qe1B7IQ4860krOeCGUeJmterAlaM2FRH0Ue0hjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^6.2.1",
+        "cosmiconfig": "^7.0.1",
+        "json5": "^2.1.3",
+        "lodash": "^4.17.21",
+        "true-myth": "^4.1.0",
+        "ts-morph": "^13.0.1"
+      },
+      "bin": {
+        "ts-prune": "lib/index.js"
+      }
+    },
+    "node_modules/ts-prune/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:watch": "jest --watch",
     "type-check": "tsc --noEmit",
     "lint": "eslint --ext .ts,.tsx src --max-warnings=0",
+    "lint:orphan": "bash scripts/check-orphan-exports.sh",
     "data:merge": "node scripts/merge-station-names-en.js && node scripts/merge-station-names-multilang.js",
     "data:fetch-exit-side": "node scripts/fetch-exit-side.js",
     "data:fetch-quick-exit": "node scripts/fetch-quick-exit.js",
@@ -131,6 +132,7 @@
     "jest": "^29.7.0",
     "jest-expo": "^54.0.17",
     "react-test-renderer": "^19.1.0",
+    "ts-prune": "^0.10.3",
     "typescript": "~5.9.2"
   },
   "private": true

--- a/scripts/check-orphan-exports.sh
+++ b/scripts/check-orphan-exports.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Wire-completion CI: detects orphan exports (#1582)
+#
+# 정책: "(used in module)" 라인은 ts-prune false-positive (모듈 내부 자기 참조)이므로 무시한다.
+# entry-point/배럴 re-export 경로(app/, modules/, providers/index.ts, theme/index.ts,
+# shared/types/ 등)는 --ignore regex로 제외한다.
+#
+# 새로운 orphan(미연결 export)이 발견되면 exit 1 → CI fail.
+# 의도적 entry-point 추가 시 IGNORE_PATTERN 갱신.
+
+set -euo pipefail
+
+IGNORE_PATTERN='app/|modules/|providers/index\.ts|providers/types\.ts|providers/progress/index\.ts|theme/index\.ts|src/shared/types/|src/shared/constants/(e2e|storageKeys)\.ts|silentPushTask\.ts|movementGate\.ts'
+
+OUTPUT=$(npx --no-install ts-prune --ignore "$IGNORE_PATTERN" 2>&1 | grep -v "(used in module)" || true)
+
+if [ -n "$OUTPUT" ]; then
+  echo "Orphan exports detected (Wire-completion 5단 룰 위반):"
+  echo "$OUTPUT"
+  echo ""
+  echo "→ caller 추가 또는 export 제거. 의도적 entry-point면 scripts/check-orphan-exports.sh IGNORE_PATTERN 갱신."
+  exit 1
+fi
+
+echo "No orphan exports detected."
+exit 0


### PR DESCRIPTION
Closes #1582

## Summary

"코드만 머지되고 호출자/UI/관측 surface가 끊긴 신호" 회귀를 차단하는 Wire-completion 게이트 lite 도입. orphan export 자동 탐지 + PR template 5단 체크리스트 + CLAUDE.md 영구 박제.

## Wire-completion 5단 체크

- [x] **1. Orphan 없음** — 본 PR이 도입하는 게이트 자체. `npm run lint:orphan` 0건 (entry-point ignore pattern baseline).
- [x] **2. V/X dashboard** — GitHub Actions `Wire-completion CI / Orphan Export Detection` job + PR template 본문이 dashboard.
- [x] **3. 의존 PR** — N/A. 독립 PR.
- [x] **4. 측정 plan** — 임의 PR에 미사용 export 추가 후 CI fail 확인 (수동). 1주 운영 후 false-positive 빈도 측정.
- [x] **5. Device verify** — N/A. CI/config/docs only, runtime 영향 없음.

## 변경 요약

- `package.json` — `ts-prune` devDep + `lint:orphan` script
- `scripts/check-orphan-exports.sh` — wrapper. ts-prune 출력에서 "(used in module)" false-positive 자동 필터. entry-point 경로(app/, modules/, providers barrel, theme/index, shared/types 등)는 IGNORE_PATTERN으로 baseline. 실 orphan 발견 시 exit 1.
- `.github/workflows/wire-completion.yml` — PR/push 게이트. Node 20 + npm ci + npm run lint:orphan.
- `.github/PULL_REQUEST_TEMPLATE.md` — 5단 체크리스트 + V/X dashboard URL + 의존 PR + Test plan.
- `CLAUDE.md` — "Wire-completion 5단 룰 (#1582)" 섹션 영구 박제. 검증 절차 명시.

## Test plan

- [x] 로컬 `npm run type-check` pass
- [x] 로컬 `npm run lint:orphan` pass (0 orphan)
- [x] CI `Wire-completion CI / Orphan Export Detection` pass
- [ ] (후속) 미사용 export 1개 추가한 PoC PR로 fail 검증
- [ ] (후속) 1주 운영 후 false-positive 빈도 확인 → 필요 시 IGNORE_PATTERN 갱신

## Risk

- ts-prune false-positive (dynamic import / 동적 호출). 현재 entry-point 경로 ignore + "(used in module)" 필터로 0건 상태. 신규 false-positive 발생 시 `scripts/check-orphan-exports.sh` IGNORE_PATTERN 갱신.
- branch protection의 required check에 추가 여부는 1주 운영 신뢰도 확인 후 사용자 판단.