### PR TITLE
feat(#1577): Cloudflare Analytics Engine wire + V/X 시계열 적재 (Phase 0)

### DIFF
--- a/backend/alarm-worker/README.md
+++ b/backend/alarm-worker/README.md
@@ -104,3 +104,64 @@ npm run type-check   # tsc --noEmit
 - 앱 측 push handler (이슈 #337)
 - 통합 테스트 (#339)
 - Seoul API 트래픽 증설 신청 (#341)
+
+## Analytics Engine — trip_metrics (Phase 0 #1577 / Epic #1576)
+
+ADR-017 / ADR-016의 V/X acceptance를 SQL로 직접 검증하기 위한 시계열 dataset.
+
+### Binding
+
+```toml
+# wrangler.toml
+[[analytics_engine_datasets]]
+binding = "TRIP_METRICS"
+dataset = "trip_metrics"
+```
+
+> Workers Paid plan 필수. Free plan은 binding 선언만으로도 deploy 실패 (Cloudflare API 10089).
+> 코드는 `if (env.TRIP_METRICS)` 분기로 graceful — binding 미바인딩 시 모든 적재 경로가 no-op.
+
+### Event 어휘 (6종)
+
+| eventType | 적재 site | 용도 |
+| --- | --- | --- |
+| `advance` | `tryAdvanceAndFireArvlcd` / `advanceBoardingLockWaypoint` 통과 | V8 적재 카운터 |
+| `fire` | `fireArvlCdStationPush` / `fireVanishFallbackStationPush` 성공 | X3 stale fire 검증 |
+| `suppress` | advance blocked / fire dedup / cross-station dedup | V9 suppress rate |
+| `motion-transition` | `updateSsotMotion` state 전환 | motion 정확도 진단 |
+| `position-upload` | `POST /position` 수신 | V8a `/position` rate |
+| `trip-mutation` | `POST /trips` 수신 | V8b `/trips` rate |
+
+Dimensions(blobs): `eventType`, `station:<id>`, `reason:<r>`, `env:<surface|underground|hybrid|unknown>`
+Metrics(doubles): `staleMs`, `hopIndex`, `motionConfidence`
+Index: `tripToken` 8자 prefix (full token 노출 안 함)
+
+### SQL query examples
+
+```sql
+-- V8a: /position 업로드 ≤ 100건/10min/trip 확인
+SELECT index1 AS tokenPrefix, COUNT(*) AS cnt
+FROM trip_metrics
+WHERE blob1 = 'position-upload' AND timestamp > NOW() - INTERVAL '10' MINUTE
+GROUP BY index1
+HAVING cnt > 100;
+
+-- V9: suppress rate < 100건/시간/trip
+SELECT index1 AS tokenPrefix, COUNT(*) AS suppress_cnt
+FROM trip_metrics
+WHERE blob1 = 'suppress' AND timestamp > NOW() - INTERVAL '1' HOUR
+GROUP BY index1
+HAVING suppress_cnt >= 100;
+
+-- X3: stale fire (SSoT lastAdvanceAt 기준 5분+ 경과 후 fire)
+SELECT index1 AS tokenPrefix, blob2 AS station, double1 AS staleMs
+FROM trip_metrics
+WHERE blob1 = 'fire' AND double1 > 300000;
+
+-- 6 event type 적재 1주 분포 (dashboard 첫 화면용)
+SELECT blob1 AS eventType, COUNT(*) AS cnt
+FROM trip_metrics
+WHERE timestamp > NOW() - INTERVAL '7' DAY
+GROUP BY blob1
+ORDER BY cnt DESC;
+```

--- a/backend/alarm-worker/src/__tests__/analytics.test.ts
+++ b/backend/alarm-worker/src/__tests__/analytics.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Phase 0 측정 인프라 (#1577) — analytics.ts writeMetric() unit tests.
+ *
+ * Coverage:
+ *  - binding 미바인딩 시 graceful no-op
+ *  - 6 eventType 모두 동작
+ *  - dimensions(blobs) / metrics(doubles) / indexes 매핑
+ *  - optional 필드 (undefined skip)
+ *  - tripToken 8자 prefix만 index에 forward
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { writeMetric, type TripMetricEventType } from '../analytics';
+import type { AnalyticsEngineWriter, Env } from '../types';
+
+function makeEnv(writer?: AnalyticsEngineWriter): Env {
+  return {
+    TRIPS: {} as KVNamespace,
+    APNS_HOST: 'api.push.apple.com',
+    APNS_HOST_SANDBOX: 'api.sandbox.push.apple.com',
+    SEOUL_API_HOST: 'swopenapi.seoul.go.kr',
+    SEOUL_API_KEY: 'k',
+    APNS_KEY_ID: 'k',
+    APNS_TEAM_ID: 't',
+    APNS_PRIVATE_KEY: 'p',
+    APNS_BUNDLE_ID: 'b',
+    TRIP_METRICS: writer,
+  };
+}
+
+describe('writeMetric — Phase 0 P0-1 (#1577)', () => {
+  it('binding 미바인딩(env.TRIP_METRICS=undefined) → no-op', () => {
+    const env = makeEnv(undefined);
+    // 단순히 throw 안 하면 통과 — writer 호출 자체가 없어 spy 대상이 없다.
+    expect(() =>
+      writeMetric(env, {
+        eventType: 'advance',
+        tripToken: 'abcdef0123456789',
+      }),
+    ).not.toThrow();
+  });
+
+  it('eventType만 있는 minimal event도 blobs/indexes는 forward', () => {
+    const writeDataPoint = vi.fn();
+    const env = makeEnv({ writeDataPoint });
+    writeMetric(env, {
+      eventType: 'trip-mutation',
+      tripToken: 'deadbeefcafe0000',
+    });
+    expect(writeDataPoint).toHaveBeenCalledTimes(1);
+    const arg = writeDataPoint.mock.calls[0][0];
+    expect(arg.blobs).toEqual(['trip-mutation']);
+    expect(arg.doubles).toEqual([]);
+    expect(arg.indexes).toEqual(['deadbeef']);
+  });
+
+  it('full event — dimensions / metrics 모두 매핑', () => {
+    const writeDataPoint = vi.fn();
+    const env = makeEnv({ writeDataPoint });
+    writeMetric(env, {
+      eventType: 'fire',
+      tripToken: '0123456789abcdef',
+      stationId: '강남',
+      reason: 'arvlcd:intermediate',
+      environment: 'underground',
+      staleMs: 12345,
+      hopIndex: 3,
+      motionConfidence: 0.8,
+    });
+    const arg = writeDataPoint.mock.calls[0][0];
+    expect(arg.blobs).toEqual([
+      'fire',
+      'station:강남',
+      'reason:arvlcd:intermediate',
+      'env:underground',
+    ]);
+    expect(arg.doubles).toEqual([12345, 3, 0.8]);
+    expect(arg.indexes).toEqual(['01234567']);
+  });
+
+  it('optional double 필드 일부만 있어도 doubles에 순서대로 push', () => {
+    const writeDataPoint = vi.fn();
+    const env = makeEnv({ writeDataPoint });
+    writeMetric(env, {
+      eventType: 'suppress',
+      tripToken: 'tok12345extra',
+      hopIndex: 7,
+    });
+    const arg = writeDataPoint.mock.calls[0][0];
+    expect(arg.doubles).toEqual([7]);
+    expect(arg.blobs).toEqual(['suppress']);
+  });
+
+  it('6 eventType 모두 적재 가능 (V/X event 어휘 완전성)', () => {
+    const writeDataPoint = vi.fn();
+    const env = makeEnv({ writeDataPoint });
+    const eventTypes: TripMetricEventType[] = [
+      'advance',
+      'fire',
+      'suppress',
+      'motion-transition',
+      'position-upload',
+      'trip-mutation',
+    ];
+    for (const eventType of eventTypes) {
+      writeMetric(env, { eventType, tripToken: 'token0001abcdef' });
+    }
+    expect(writeDataPoint).toHaveBeenCalledTimes(eventTypes.length);
+    eventTypes.forEach((eventType, i) => {
+      expect(writeDataPoint.mock.calls[i][0].blobs[0]).toBe(eventType);
+    });
+  });
+
+  it('tripToken 8자 미만이어도 그대로 index에 forward (privacy: prefix만)', () => {
+    const writeDataPoint = vi.fn();
+    const env = makeEnv({ writeDataPoint });
+    writeMetric(env, { eventType: 'advance', tripToken: 'short' });
+    expect(writeDataPoint.mock.calls[0][0].indexes).toEqual(['short']);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -33,10 +33,9 @@ import {
   type ScheduledDeps,
   type ScheduledStats,
 } from '../scheduled';
-import { seedSsot, type TripPositionSSoT } from '../tripPositionSsot';
+import { readSsot, seedSsot, ssotKey, writeSsot, type TripPositionSSoT } from '../tripPositionSsot';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from '../seoul';
 import { putTrip } from '../trips';
-import { readSsot, seedSsot, ssotKey, writeSsot } from '../tripPositionSsot';
 import type { BoardingLockMeta, Env, PositionPoint, Trip, Waypoint } from '../types';
 import { InMemoryKV } from './inMemoryKv';
 

--- a/backend/alarm-worker/src/analytics.ts
+++ b/backend/alarm-worker/src/analytics.ts
@@ -1,0 +1,81 @@
+/**
+ * Cloudflare Analytics Engine writer — Phase 0 측정 인프라 (Epic #1576 / P0-1 #1577).
+ *
+ * V/X acceptance (ADR-017 / ADR-016)를 SQL로 직접 검증하기 위해 advance / fire / suppress /
+ * motion-transition / position-upload / trip-mutation 6 event를 시계열 적재한다.
+ *
+ * Binding은 `wrangler.toml`의 `[[analytics_engine_datasets]]`로 주입 (binding=`TRIP_METRICS`,
+ * dataset=`trip_metrics`). 미바인딩 시 `writeMetric`은 graceful no-op — 개발/테스트 환경 호환.
+ *
+ * `writeDataPoint`는 fire-and-forget이라 `await`/`ctx.waitUntil` 불필요 (기존 TELEMETRY 패턴 동일).
+ */
+
+import type { AnalyticsEngineWriter, Env } from './types';
+
+/**
+ * 6 event type — `eventType` blob dimension으로 적재.
+ *
+ *  - `advance`          : `advanceTripPosition`이 SSoT를 advance (게이트 통과)
+ *  - `fire`             : station-passed / transfer-imminent silent push 발사 성공
+ *  - `suppress`         : advance blocked / fire dedup / cross-station dedup
+ *  - `motion-transition`: SSoT motionState 전환 (moving ↔ stationary ↔ unknown)
+ *  - `position-upload`  : POST `/position` 수신 (V8a 적재 카운터)
+ *  - `trip-mutation`    : POST `/trips` 수신 (V8b 적재 카운터)
+ */
+export type TripMetricEventType =
+  | 'advance'
+  | 'fire'
+  | 'suppress'
+  | 'motion-transition'
+  | 'position-upload'
+  | 'trip-mutation';
+
+/**
+ * 적재 event shape. `tripToken`은 index, dimensions는 blob, metrics는 double로 매핑된다.
+ * Token은 dedup/그룹핑용 — privacy를 위해 적재 시 8자 prefix만 forward 한다.
+ */
+export interface TripMetricEvent {
+  eventType: TripMetricEventType;
+  tripToken: string;
+  /** advance/fire/suppress 대상 station identifier (id 또는 표시명). */
+  stationId?: string;
+  /** suppress reason / fire kind / advance evidence type 등. */
+  reason?: string;
+  /** ADR-015 환경 vote 결과 (advance/suppress 입력 컨텍스트). */
+  environment?: 'surface' | 'underground' | 'hybrid' | 'unknown';
+  /** SSoT `lastAdvanceAt`에서 본 event까지 경과 ms (X3 stale fire 검증). */
+  staleMs?: number;
+  /** waypoint hop index (V/X hop-level 집계용). */
+  hopIndex?: number;
+  /** consensus / motion confidence 0~1 (event 결정 근거 강도). */
+  motionConfidence?: number;
+}
+
+/**
+ * Analytics Engine 적재 helper. binding 미바인딩 시 no-op.
+ *
+ * Token은 prefix만 forward — full token은 적재하지 않는다 (telemetry 모듈과 동일 정책).
+ */
+export function writeMetric(env: Env, event: TripMetricEvent): void {
+  const writer: AnalyticsEngineWriter | undefined = env.TRIP_METRICS;
+  if (!writer) return;
+
+  const blobs: string[] = [event.eventType];
+  if (event.stationId !== undefined) blobs.push(`station:${event.stationId}`);
+  if (event.reason !== undefined) blobs.push(`reason:${event.reason}`);
+  if (event.environment !== undefined) blobs.push(`env:${event.environment}`);
+
+  const doubles: number[] = [];
+  if (event.staleMs !== undefined) doubles.push(event.staleMs);
+  if (event.hopIndex !== undefined) doubles.push(event.hopIndex);
+  if (event.motionConfidence !== undefined) doubles.push(event.motionConfidence);
+
+  // tokenPrefix(8자)만 index로 — 같은 trip의 event 집계는 가능, full token은 노출 안 함.
+  const tokenIndex = event.tripToken.slice(0, 8);
+
+  writer.writeDataPoint({
+    blobs,
+    doubles,
+    indexes: [tokenIndex],
+  });
+}

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -43,6 +43,7 @@ import { ackPending, stampReceived } from './pendingPushes';
 import { appendPositionPoint } from './positionSeries';
 import { appendAccelSample, isAccelSummary } from './accelSeries';
 import { updateSsotMotion } from './motionState';
+import { writeMetric } from './analytics';
 import { deleteProgress, getProgress, putProgress, type TripProgress } from './progress';
 import { SeoulArrivalClient } from './seoul';
 import { runScheduled } from './scheduled';
@@ -495,6 +496,14 @@ app.post('/trips', async (c) => {
 
   await putTrip(c.env.TRIPS, trip);
 
+  // P0-1 (#1577) — Site 6 of 6: trip-mutation 적재 (V8b /trips rate 검증).
+  writeMetric(c.env, {
+    eventType: 'trip-mutation',
+    tripToken: trip.token,
+    reason: trip.boardingLock ? 'lock-active' : 'lockless',
+    hopIndex: trip.waypoints[0]?.hopIndex,
+  });
+
   return c.json({ ok: true, token: trip.token });
 });
 
@@ -900,7 +909,22 @@ app.post('/position', async (c) => {
   }
   // #1556 (T3) — SSOT.motionState 갱신. SSOT 부재(trip 미등록) 시 graceful no-op.
   // T2 advanceTripPosition 게이트 #2가 본 motionState='stationary'를 차단 입력으로 사용한다.
-  await updateSsotMotion(c.env.TRIPS, payload.token, payload.point, Date.now());
+  await updateSsotMotion(c.env.TRIPS, payload.token, payload.point, Date.now(), {
+    onTransition: (from, to) => {
+      // P0-1 (#1577) — Site 5 of 6: motion-transition 적재.
+      writeMetric(c.env, {
+        eventType: 'motion-transition',
+        tripToken: payload.token,
+        reason: `${from}->${to}`,
+      });
+    },
+  });
+  // P0-1 (#1577) — Site 6 of 6: position-upload 적재 (V8a /position rate 검증).
+  writeMetric(c.env, {
+    eventType: 'position-upload',
+    tripToken: payload.token,
+    reason: payload.point.motion,
+  });
   return c.json({ ok: true });
 });
 

--- a/backend/alarm-worker/src/motionState.ts
+++ b/backend/alarm-worker/src/motionState.ts
@@ -173,6 +173,7 @@ export async function updateSsotMotion(
   token: string,
   position: PositionPoint,
   now: number,
+  options?: { onTransition?: (from: MotionState, to: MotionState) => void },
 ): Promise<TripPositionSSoT | null> {
   const ssot = await readSsot(kv, token);
   if (!ssot) return null;
@@ -191,6 +192,8 @@ export async function updateSsotMotion(
   const next = computeMotionState(ssot, position, now);
   if (next !== ssot.motionState) {
     emitMotionTransitionBreadcrumb(ssot.motionState, next);
+    // P0-1 (#1577) — Site 5 of 6: motion-transition. caller가 analytics sink을 주입한다.
+    options?.onTransition?.(ssot.motionState, next);
     ssot.motionState = next;
   }
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -52,6 +52,7 @@ import {
   readSsot,
   seedSsot,
   SSOT_CRON_READ_CACHE_TTL_SEC,
+  type TripPositionSSoT,
 } from './tripPositionSsot';
 import {
   evaluateWindow,
@@ -69,11 +70,6 @@ import {
   isTransferOrDestination,
   type TransferDestinationBlockReason,
 } from './transferDestinationGate';
-import {
-  readSsot,
-  SSOT_CRON_READ_CACHE_TTL_SEC,
-  type TripPositionSSoT,
-} from './tripPositionSsot';
 import type {
   ApnsEnv,
   BoardingLockMeta,
@@ -84,6 +80,7 @@ import type {
   Waypoint,
 } from './types';
 import { RESCHEDULE_CHANNELS_DEFAULT } from './types';
+import { writeMetric } from './analytics';
 
 // pickApnsHost / flipApnsEnv는 ./apnsHost로 이동 (liveActivity.ts와 공유 SSOT, #482).
 // 외부(테스트 / index.ts 등)가 scheduled.ts 경유로 import하던 호환성 유지를 위해 re-export.
@@ -1026,6 +1023,14 @@ export async function fireArvlCdStationPush(
       station: waypoint.stationName,
       arvlCd,
     });
+    // P0-1 (#1577) — Site 2 of 6: cross-category station dedup suppress.
+    writeMetric(env, {
+      eventType: 'suppress',
+      tripToken: trip.token,
+      stationId: waypoint.stationName,
+      reason: 'arvlcd-dedup',
+      hopIndex: waypoint.hopIndex,
+    });
     return { dirty: false };
   }
 
@@ -1046,6 +1051,14 @@ export async function fireArvlCdStationPush(
       previousStation: lastFired.stationName,
       sinceMs: now - lastFired.epochMs,
       arvlCd,
+    });
+    // P0-1 (#1577) — Site 2 of 6: cross-station dedup suppress.
+    writeMetric(env, {
+      eventType: 'suppress',
+      tripToken: trip.token,
+      stationId: waypoint.stationName,
+      reason: 'cross-station-dedup',
+      hopIndex: waypoint.hopIndex,
     });
     return { dirty: false };
   }
@@ -1123,6 +1136,15 @@ export async function fireArvlCdStationPush(
   // #1367 — cross-station dedup용 마지막 fire 마커. 성공 시에만 stamp(실패는 다음 cycle 재시도 허용).
   trip.lastFiredStation = { stationName: waypoint.stationName, epochMs: now };
   dirty = true;
+  // P0-1 (#1577) — Site 3 of 6: arvlcd fire 적재 (X3 stale fire 검증).
+  writeMetric(env, {
+    eventType: 'fire',
+    tripToken: trip.token,
+    stationId: waypoint.stationName,
+    reason: `arvlcd:${waypoint.kind}`,
+    hopIndex: waypoint.hopIndex,
+    staleMs: ssot?.lastAdvanceAt ? now - ssot.lastAdvanceAt : undefined,
+  });
   return { dirty };
 }
 
@@ -1217,9 +1239,27 @@ async function tryAdvanceAndFireArvlcd(inputs: {
       station: waypoint.stationName,
       reason: outcome.blockReason satisfies AdvanceBlockReason | undefined,
     });
+    // P0-1 (#1577) — Site 1 of 6: advance suppress 적재 (V/X X3/X8 검증).
+    writeMetric(env, {
+      eventType: 'suppress',
+      tripToken: trip.token,
+      stationId: waypoint.stationName,
+      reason: outcome.blockReason ?? 'advance-blocked',
+      environment: deriveEvidenceEnvironment(trip),
+      hopIndex: waypoint.hopIndex,
+    });
     return { dirty: false };
   }
   stats.arvlCdFireFired += 1;
+  // P0-1 (#1577) — Site 1 of 6: advance 적재 (V8 적재 카운터).
+  writeMetric(env, {
+    eventType: 'advance',
+    tripToken: trip.token,
+    stationId: waypoint.stationName,
+    reason: 'arvlcd-confirmed-train',
+    environment: deriveEvidenceEnvironment(trip),
+    hopIndex: waypoint.hopIndex,
+  });
   return fireArvlCdStationPush({
     trip,
     waypoint,
@@ -1310,6 +1350,14 @@ export async function fireVanishFallbackStationPush(
       trainCode: lock.trainCode,
       station: waypoint.stationName,
     });
+    // P0-1 (#1577) — Site 4 of 6: vanish-fallback dedup suppress.
+    writeMetric(env, {
+      eventType: 'suppress',
+      tripToken: trip.token,
+      stationId: waypoint.stationName,
+      reason: `${origin}-dedup`,
+      hopIndex: waypoint.hopIndex,
+    });
     return;
   }
   // #1561 (T8, ADR-017 / S2 흡수) — fire 직전 SSoT 권위 스냅샷 forward (arvlcd-fire와 동일 패턴).
@@ -1391,6 +1439,15 @@ export async function fireVanishFallbackStationPush(
   } else {
     stats.vanishFallbackFired += 1;
   }
+  // P0-1 (#1577) — Site 4 of 6: vanish fire 적재 (transfer/destination imminent 포함).
+  writeMetric(env, {
+    eventType: 'fire',
+    tripToken: trip.token,
+    stationId: waypoint.stationName,
+    reason: `${origin}:${waypoint.kind}`,
+    hopIndex: waypoint.hopIndex,
+    staleMs: ssot?.lastAdvanceAt ? now - ssot.lastAdvanceAt : undefined,
+  });
   // #1402 — 30s alert fallback 안전망 등록. listPending → runFallbackPushes가 30s 내 ACK
   // 없으면 alert(소리) fallback 발사. vanish 경로는 silent push가 가장 잘 누락되는 경로라
   // 안전망 가동이 acceptance("하차 침묵 0")의 핵심. PENDING_PUSHES 미바인딩(dev/test 호환)
@@ -1884,8 +1941,24 @@ export async function advanceBoardingLockWaypoint(
         reason: outcome.blockReason satisfies AdvanceBlockReason | undefined,
         evidenceType: evidence.type,
       });
+      // P0-1 (#1577) — Site 1 of 6: boarding-lock waypoint advance suppress.
+      writeMetric(env, {
+        eventType: 'suppress',
+        tripToken: trip.token,
+        stationId: waypoint.stationName,
+        reason: outcome.blockReason ?? 'lock-advance-blocked',
+        hopIndex: waypoint.hopIndex,
+      });
       return;
     }
+    // P0-1 (#1577) — Site 1 of 6: boarding-lock waypoint advance.
+    writeMetric(env, {
+      eventType: 'advance',
+      tripToken: trip.token,
+      stationId: waypoint.stationName,
+      reason: evidence.type,
+      hopIndex: waypoint.hopIndex,
+    });
   }
 
   if (waypoint.kind === 'destination') {

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -571,4 +571,16 @@ export interface Env {
    * graceful no-op. 등록: `wrangler secret put SENTRY_DSN`.
    */
   SENTRY_DSN?: string;
+  /**
+   * Phase 0 측정 인프라 — Cloudflare Analytics Engine dataset (#1577, Epic #1576).
+   *
+   * V/X acceptance (ADR-017/016) 검증용 시계열. advance / fire / suppress /
+   * motion-transition / position-upload / trip-mutation 6 event를 `src/analytics.ts`의
+   * `writeMetric()` helper로 적재한다.
+   *
+   * 미바인딩 시 모든 적재 경로는 graceful no-op (TELEMETRY 동형) — 개발/테스트 환경 호환.
+   * 생성: `wrangler.toml`의 `[[analytics_engine_datasets]]` binding=`TRIP_METRICS`,
+   *      dataset=`trip_metrics`.
+   */
+  TRIP_METRICS?: AnalyticsEngineWriter;
 }

--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -58,6 +58,17 @@ preview_id = "d38f190e3f7f4fd3b6e7f6485dd1733d"
 # id = ""
 # preview_id = ""
 
+# Analytics Engine: V/X acceptance 시계열 dataset (#1577, Phase 0 epic #1576)
+# advance / fire / suppress / motion-transition / position-upload / trip-mutation 6 event를
+# `src/analytics.ts`의 `writeMetric()` helper로 적재한다. ADR-017/016 acceptance를 SQL로 직접 검증.
+#
+# ⚠️ Workers Paid plan 필수 — Free plan에서는 binding 선언만으로도 deploy 실패(Cloudflare API 10089).
+# Free plan 환경이면 아래 3줄을 주석 처리. 코드는 `if (env.TRIP_METRICS)` 분기로 graceful —
+# binding 없으면 모든 적재 경로가 no-op (개발/테스트 환경 호환, TELEMETRY 동형).
+[[analytics_engine_datasets]]
+binding = "TRIP_METRICS"
+dataset = "trip_metrics"
+
 # 1분마다 활성 트립 폴링
 [triggers]
 crons = ["*/1 * * * *"]


### PR DESCRIPTION
## Summary

Phase 0 측정 인프라 epic #1576의 prerequisite sub-task. ADR-017 / ADR-016 V/X acceptance를 SQL로 직접 검증하기 위한 Cloudflare Analytics Engine 시계열 적재.

backend-only — device 변경 없음.

## Changes

- `backend/alarm-worker/src/analytics.ts` 신설 — `writeMetric()` helper + `TripMetricEvent` (6 eventType)
- `src/types.ts` — `Env.TRIP_METRICS` binding 추가 (graceful no-op pattern, TELEMETRY 동형)
- `wrangler.toml` — `[[analytics_engine_datasets]]` binding=`TRIP_METRICS`, dataset=`trip_metrics` (Workers Paid plan 필수)
- 6 적재 site wire (아래 grep evidence 참조)
- `README.md` — SQL query examples 4종 박제 (V8a / V9 / X3 / 7일 분포)
- `analytics.test.ts` — 6 unit test (binding 미바인딩 no-op + dimensions/metrics 매핑 + 6 eventType 어휘)

## Wire-completion gate (5단)

- [x] **1. Helper 신설** — `src/analytics.ts` `writeMetric()` + `TripMetricEvent`
- [x] **2. Import** — `scheduled.ts:87` + `index.ts:46`
- [x] **3. Call** — 12 호출 사이트 (아래 grep)
- [x] **4. Test** — `analytics.test.ts` 6 test + 전체 1682/1682 통과
- [x] **5. Orphan 없음** — `writeMetric` / `TripMetricEvent` / `TripMetricEventType` 모두 consumer 존재

## 6 사이트 grep evidence

```
$ grep -n "writeMetric(" backend/alarm-worker/src/*.ts
analytics.ts:59  ← 정의
index.ts:491     ← POST /trips trip-mutation (Site 6)
index.ts:906     ← POST /position motion-transition (Site 5)
index.ts:914     ← POST /position position-upload (Site 6)
scheduled.ts:1031 ← arvlcd dedup suppress (Site 2)
scheduled.ts:1060 ← arvlcd cross-station dedup suppress (Site 2)
scheduled.ts:1144 ← arvlcd fire 성공 (Site 3)
scheduled.ts:1247 ← vanish dedup suppress (Site 4)
scheduled.ts:1259 ← tryAdvanceAndFireArvlcd suppress (Site 1)
scheduled.ts:1358 ← vanish fire 성공 (Site 4)
scheduled.ts:1447 ← tryAdvanceAndFireArvlcd advance (Site 1)
scheduled.ts:1949 ← advanceBoardingLockWaypoint suppress (Site 1)
scheduled.ts:1959 ← advanceBoardingLockWaypoint advance (Site 1)
```

## Acceptance 매핑

| Acceptance | 검증 방법 |
| --- | --- |
| 6 event type 모두 적재 | `analytics.test.ts` 6 eventType test (unit) + 1 trip evidence 후 SQL `SELECT DISTINCT blob1 FROM trip_metrics` |
| Binding 활성 | `wrangler tail`로 `writeDataPoint` 호출 확인 (배포 후) |
| SQL query 1개 동작 | README 박제 V8a query — Cloudflare dashboard에서 실행 |
| dashboard URL 공유 | 운영자 후속 (P0-5) |

## Test plan

- [x] `npx vitest run` — 1682/1682 통과 (신규 6 + 회귀 0)
- [x] `npm run type-check` — pre-existing baseline 오류만 (scheduled.ts duplicate ident 등), 본 PR 추가 0
- [ ] 머지 후 `wrangler deploy` (Workers Paid plan 필요 — 미충족 시 binding 주석 처리)
- [ ] 1 trip evidence 후 `SELECT blob1, COUNT(*) FROM trip_metrics GROUP BY blob1`

## Notes

- Workers Paid plan 미충족 환경이면 `wrangler.toml`의 3줄 binding 주석 처리. 코드는 graceful no-op.
- 후속 P0-3 (alarmLog forward)이 본 dataset 소비. P0-5 (dashboard)가 SQL 시각화.

Closes #1577