### PR TITLE
feat(#1579): device alarmLog forward + R2 archive (Phase 0 P0-3)

### DIFF
--- a/backend/alarm-worker/src/__tests__/alarmLogForward.test.ts
+++ b/backend/alarm-worker/src/__tests__/alarmLogForward.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ALARM_LOG_FORWARD_KEY_PREFIX,
+  MAX_ENTRIES_PER_BUCKET,
+  buildNdjsonBody,
+  buildR2Key,
+  storeAlarmLogForward,
+  validateAlarmLogForward,
+  type AlarmLogForwardUpload,
+} from '../alarmLogForward';
+
+function validBody(): Record<string, unknown> {
+  return {
+    token: 'aabbccdd11223344',
+    tripStartedAt: Date.UTC(2026, 5, 20, 12, 0, 0),
+    tripEndedAt: Date.UTC(2026, 5, 20, 12, 30, 0),
+    alarmLog: [{ ts: 1, source: 'fg' }],
+    fusionLog: [{ ts: 2, kind: 'cycle' }],
+    gpsDrops: [{ ts: 3, accuracy: 250 }],
+    backendSsotSnapshot: { currentStationId: '강남', motionState: 'moving' },
+    deviceMetadata: { os: 'ios', appVersion: '1.2.3', locale: 'ko' },
+  };
+}
+
+describe('validateAlarmLogForward', () => {
+  it('accepts valid payload', () => {
+    const out = validateAlarmLogForward(validBody());
+    expect(out).not.toBeNull();
+    expect(out?.token).toBe('aabbccdd11223344');
+    expect(out?.alarmLog.length).toBe(1);
+    expect(out?.deviceMetadata.os).toBe('ios');
+    expect(out?.deviceMetadata.appVersion).toBe('1.2.3');
+    expect(out?.deviceMetadata.locale).toBe('ko');
+  });
+
+  it('normalizes null ssot snapshot', () => {
+    const out = validateAlarmLogForward({ ...validBody(), backendSsotSnapshot: null });
+    expect(out?.backendSsotSnapshot).toBeNull();
+  });
+
+  it('strips non-string optional deviceMetadata fields', () => {
+    const out = validateAlarmLogForward({
+      ...validBody(),
+      deviceMetadata: { os: 'ios', appVersion: 123, locale: null },
+    });
+    expect(out?.deviceMetadata.appVersion).toBeUndefined();
+    expect(out?.deviceMetadata.locale).toBeUndefined();
+  });
+
+  it('rejects non-object input', () => {
+    expect(validateAlarmLogForward(null)).toBeNull();
+    expect(validateAlarmLogForward('x')).toBeNull();
+    expect(validateAlarmLogForward(42)).toBeNull();
+  });
+
+  it('rejects empty token', () => {
+    expect(validateAlarmLogForward({ ...validBody(), token: '' })).toBeNull();
+    expect(validateAlarmLogForward({ ...validBody(), token: 42 })).toBeNull();
+  });
+
+  it('rejects invalid tripStartedAt', () => {
+    expect(validateAlarmLogForward({ ...validBody(), tripStartedAt: 0 })).toBeNull();
+    expect(validateAlarmLogForward({ ...validBody(), tripStartedAt: 'x' })).toBeNull();
+  });
+
+  it('rejects tripEndedAt before tripStartedAt', () => {
+    expect(
+      validateAlarmLogForward({ ...validBody(), tripEndedAt: 0 }),
+    ).toBeNull();
+  });
+
+  it('rejects non-array alarmLog/fusionLog/gpsDrops', () => {
+    expect(validateAlarmLogForward({ ...validBody(), alarmLog: 'x' })).toBeNull();
+    expect(validateAlarmLogForward({ ...validBody(), fusionLog: {} })).toBeNull();
+    expect(validateAlarmLogForward({ ...validBody(), gpsDrops: 5 })).toBeNull();
+  });
+
+  it('rejects entries above cap', () => {
+    const tooMany = Array.from({ length: MAX_ENTRIES_PER_BUCKET + 1 }, (_, i) => ({ i }));
+    expect(validateAlarmLogForward({ ...validBody(), alarmLog: tooMany })).toBeNull();
+    expect(validateAlarmLogForward({ ...validBody(), fusionLog: tooMany })).toBeNull();
+    expect(validateAlarmLogForward({ ...validBody(), gpsDrops: tooMany })).toBeNull();
+  });
+
+  it('rejects missing/invalid deviceMetadata', () => {
+    expect(
+      validateAlarmLogForward({ ...validBody(), deviceMetadata: null }),
+    ).toBeNull();
+    expect(
+      validateAlarmLogForward({ ...validBody(), deviceMetadata: { os: 5 } }),
+    ).toBeNull();
+  });
+});
+
+describe('buildR2Key', () => {
+  it('uses YYYY/MM/DD partition + tokenPrefix + tripStartedAt', () => {
+    const u = validateAlarmLogForward(validBody())!;
+    const key = buildR2Key(u);
+    expect(key.startsWith(ALARM_LOG_FORWARD_KEY_PREFIX)).toBe(true);
+    expect(key).toContain('2026/06/20/');
+    expect(key).toContain('aabbccdd-');
+    expect(key.endsWith('.ndjson')).toBe(true);
+  });
+
+  it('pads month/day with leading zero', () => {
+    const u = validateAlarmLogForward({
+      ...validBody(),
+      tripStartedAt: Date.UTC(2026, 0, 5, 0, 0, 0),
+      tripEndedAt: Date.UTC(2026, 0, 5, 0, 1, 0),
+    })!;
+    expect(buildR2Key(u)).toContain('2026/01/05/');
+  });
+});
+
+describe('buildNdjsonBody', () => {
+  it('emits 6 lines: header + 4 buckets + deviceMetadata', () => {
+    const u = validateAlarmLogForward(validBody())!;
+    const body = buildNdjsonBody(u);
+    const lines = body.split('\n');
+    expect(lines).toHaveLength(6);
+    const header = JSON.parse(lines[0]);
+    expect(header.kind).toBe('header');
+    expect(header.tokenPrefix).toBe('aabbccdd');
+    expect(header.durationMs).toBe(u.tripEndedAt - u.tripStartedAt);
+    const kinds = lines.map((l) => JSON.parse(l).kind);
+    expect(kinds).toEqual([
+      'header',
+      'alarmLog',
+      'fusionLog',
+      'gpsDrops',
+      'backendSsotSnapshot',
+      'deviceMetadata',
+    ]);
+  });
+});
+
+describe('storeAlarmLogForward', () => {
+  it('puts ndjson with customMetadata + contentType', async () => {
+    const put = vi.fn().mockResolvedValue(undefined);
+    const r2 = { put } as unknown as R2Bucket;
+    const u = validateAlarmLogForward(validBody())!;
+    const result = await storeAlarmLogForward(r2, u);
+    expect(put).toHaveBeenCalledTimes(1);
+    const [key, body, options] = put.mock.calls[0];
+    expect(typeof key).toBe('string');
+    expect(key).toContain('aabbccdd-');
+    expect(typeof body).toBe('string');
+    expect(options.httpMetadata.contentType).toBe('application/x-ndjson');
+    expect(options.customMetadata.tokenPrefix).toBe('aabbccdd');
+    expect(options.customMetadata.deviceOs).toBe('ios');
+    expect(options.customMetadata.tripStartedAt).toBe(String(u.tripStartedAt));
+    expect(result.key).toBe(key);
+    expect(result.size).toBe(body.length);
+  });
+});
+
+// Type smoke — keep the union exported for downstream consumers.
+const _typeCheck: AlarmLogForwardUpload | null = null;
+void _typeCheck;

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -33,9 +33,9 @@ import {
   type ScheduledDeps,
   type ScheduledStats,
 } from '../scheduled';
-import { readSsot, seedSsot, ssotKey, writeSsot, type TripPositionSSoT } from '../tripPositionSsot';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from '../seoul';
 import { putTrip } from '../trips';
+import { readSsot, seedSsot, ssotKey, writeSsot, type TripPositionSSoT } from '../tripPositionSsot';
 import type { BoardingLockMeta, Env, PositionPoint, Trip, Waypoint } from '../types';
 import { InMemoryKV } from './inMemoryKv';
 

--- a/backend/alarm-worker/src/alarmLogForward.ts
+++ b/backend/alarm-worker/src/alarmLogForward.ts
@@ -1,0 +1,136 @@
+/**
+ * Device alarmLog forward → R2 archive (#1579, Phase 0 epic #1576 — P0-3).
+ *
+ * Device가 trip 종료 시 `POST /telemetry/alarm-log`로 alarmLog 200 + fusionLog 200 + gpsDrops
+ * + backendSsotSnapshot + deviceMetadata를 한 번 보낸다. 본 모듈이 payload 검증 + R2 put을
+ * 담당. handler는 index.ts에 inline 등록 (기존 라우트 패턴과 동형).
+ *
+ * R2 key: `trip-evidence/YYYY/MM/DD/{tokenPrefix}-{tripStartedAt}.ndjson`
+ *   - tokenPrefix는 8자 prefix (`tokenPrefix(token)`와 동일 PII 정책).
+ *   - tripStartedAt epoch ms로 같은 device의 동시 trip 충돌 차단.
+ *   - YYYY/MM/DD는 tripStartedAt UTC 기준 — operator가 prefix list로 일자별 조회 가능.
+ *
+ * Body: ndjson (1줄 = JSON 객체). 7줄: header + alarmLog 1줄 + fusionLog 1줄 + gpsDrops 1줄
+ *   + ssotSnapshot 1줄 + deviceMetadata 1줄. 사후 분석 도구가 줄 단위 stream parse 가능.
+ *
+ * R2 lifecycle 90일 삭제는 Cloudflare Dashboard에서 운영자가 수동 설정 (PR 본문 참고).
+ *
+ * Privacy:
+ *   - token은 8자 prefix만 R2 key/customMetadata에 적재 (원문 미저장).
+ *   - alarmLog/fusionLog/gpsDrops/ssot는 device fusion 측정값 — 원문 사용자 식별자 없음.
+ */
+import { tokenPrefix } from './telemetry';
+
+/** entries cap — alarmLog 200 + fusionLog 200 + gpsDrops 100 = 500 + overhead. 1500 cap. */
+export const MAX_ENTRIES_PER_BUCKET = 1500;
+
+/** R2 key prefix. */
+export const ALARM_LOG_FORWARD_KEY_PREFIX = 'trip-evidence/';
+
+export interface AlarmLogForwardUpload {
+  token: string;
+  tripStartedAt: number;
+  tripEndedAt: number;
+  alarmLog: unknown[];
+  fusionLog: unknown[];
+  gpsDrops: unknown[];
+  backendSsotSnapshot: unknown;
+  deviceMetadata: {
+    os: string;
+    appVersion?: string;
+    locale?: string;
+  };
+}
+
+function isStringRecord(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object';
+}
+
+export function validateAlarmLogForward(input: unknown): AlarmLogForwardUpload | null {
+  if (!isStringRecord(input)) return null;
+  const {
+    token,
+    tripStartedAt,
+    tripEndedAt,
+    alarmLog,
+    fusionLog,
+    gpsDrops,
+    backendSsotSnapshot,
+    deviceMetadata,
+  } = input;
+  if (typeof token !== 'string' || token.length === 0) return null;
+  if (typeof tripStartedAt !== 'number' || tripStartedAt <= 0) return null;
+  if (typeof tripEndedAt !== 'number' || tripEndedAt < tripStartedAt) return null;
+  if (!Array.isArray(alarmLog) || alarmLog.length > MAX_ENTRIES_PER_BUCKET) return null;
+  if (!Array.isArray(fusionLog) || fusionLog.length > MAX_ENTRIES_PER_BUCKET) return null;
+  if (!Array.isArray(gpsDrops) || gpsDrops.length > MAX_ENTRIES_PER_BUCKET) return null;
+  if (!isStringRecord(deviceMetadata)) return null;
+  if (typeof deviceMetadata.os !== 'string') return null;
+  return {
+    token,
+    tripStartedAt,
+    tripEndedAt,
+    alarmLog,
+    fusionLog,
+    gpsDrops,
+    backendSsotSnapshot: backendSsotSnapshot ?? null,
+    deviceMetadata: {
+      os: deviceMetadata.os,
+      appVersion:
+        typeof deviceMetadata.appVersion === 'string'
+          ? deviceMetadata.appVersion
+          : undefined,
+      locale:
+        typeof deviceMetadata.locale === 'string' ? deviceMetadata.locale : undefined,
+    },
+  };
+}
+
+/** `trip-evidence/YYYY/MM/DD/{tokenPrefix}-{tripStartedAt}.ndjson` */
+export function buildR2Key(upload: AlarmLogForwardUpload): string {
+  const d = new Date(upload.tripStartedAt);
+  const yyyy = d.getUTCFullYear().toString().padStart(4, '0');
+  const mm = (d.getUTCMonth() + 1).toString().padStart(2, '0');
+  const dd = d.getUTCDate().toString().padStart(2, '0');
+  const prefix = tokenPrefix(upload.token);
+  return `${ALARM_LOG_FORWARD_KEY_PREFIX}${yyyy}/${mm}/${dd}/${prefix}-${upload.tripStartedAt}.ndjson`;
+}
+
+/** ndjson — 줄 단위 stream parse 가능한 형태로 직렬화. */
+export function buildNdjsonBody(upload: AlarmLogForwardUpload): string {
+  const lines = [
+    {
+      kind: 'header',
+      tokenPrefix: tokenPrefix(upload.token),
+      tripStartedAt: upload.tripStartedAt,
+      tripEndedAt: upload.tripEndedAt,
+      durationMs: upload.tripEndedAt - upload.tripStartedAt,
+      uploadedAt: Date.now(),
+    },
+    { kind: 'alarmLog', entries: upload.alarmLog },
+    { kind: 'fusionLog', entries: upload.fusionLog },
+    { kind: 'gpsDrops', entries: upload.gpsDrops },
+    { kind: 'backendSsotSnapshot', value: upload.backendSsotSnapshot },
+    { kind: 'deviceMetadata', value: upload.deviceMetadata },
+  ];
+  return lines.map((l) => JSON.stringify(l)).join('\n');
+}
+
+/** R2 put with customMetadata. R2Bucket subset만 사용 — test mock 표면 최소화. */
+export async function storeAlarmLogForward(
+  r2: R2Bucket,
+  upload: AlarmLogForwardUpload,
+): Promise<{ key: string; size: number }> {
+  const key = buildR2Key(upload);
+  const body = buildNdjsonBody(upload);
+  await r2.put(key, body, {
+    httpMetadata: { contentType: 'application/x-ndjson' },
+    customMetadata: {
+      tokenPrefix: tokenPrefix(upload.token),
+      tripStartedAt: String(upload.tripStartedAt),
+      tripEndedAt: String(upload.tripEndedAt),
+      deviceOs: upload.deviceMetadata.os,
+    },
+  });
+  return { key, size: body.length };
+}

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -58,6 +58,10 @@ import {
   storeSignalDump,
   validateSignalDumpUpload,
 } from './rawSignalDump';
+import {
+  storeAlarmLogForward,
+  validateAlarmLogForward,
+} from './alarmLogForward';
 import { MIN_RECALL_RATIO_THRESHOLD, RECALL_THRESHOLD_CRITICAL } from './metrics';
 import { RECALL_DATASET, RECALL_OPS_PAGE_URL, RECALL_QUERIES } from './recallQueries';
 import {
@@ -790,6 +794,55 @@ app.post('/signals/dump', async (c) => {
     }),
   );
   return c.json({ ok: true, accepted: payload.entries.length });
+});
+
+/**
+ * Device alarmLog telemetry forward (#1579, Phase 0 epic #1576 P0-3).
+ *
+ * Trip 종료 시 device가 alarmLog 200 + fusionLog 200 + gpsDrops 100 + backendSsotSnapshot +
+ * deviceMetadata를 한 번 forward. R2 `trip-evidence/YYYY/MM/DD/{tokenPrefix}-{tripStartedAt}.ndjson`
+ * 키로 90일 보관 (lifecycle 룰은 Cloudflare Dashboard에서 운영자가 수동 설정).
+ *
+ * Body: { token, tripStartedAt, tripEndedAt, alarmLog[], fusionLog[], gpsDrops[],
+ *         backendSsotSnapshot, deviceMetadata: { os, appVersion?, locale? } }
+ *
+ * Response:
+ *   200 { ok: true, key, size }
+ *   400 { error: 'invalid_json' | 'invalid_payload' }
+ *   503 { error: 'telemetry_r2_unavailable' } — TELEMETRY_R2 미바인딩 (개발 환경 호환)
+ *
+ * Privacy: token은 8자 prefix만 R2 key/customMetadata에 저장 (원문 미저장).
+ */
+app.post('/telemetry/alarm-log', async (c) => {
+  const r2 = c.env.TELEMETRY_R2;
+  if (!r2) return c.json({ error: 'telemetry_r2_unavailable' }, 503);
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_json' }, 400);
+  }
+
+  const payload = validateAlarmLogForward(body);
+  if (!payload) return c.json({ error: 'invalid_payload' }, 400);
+
+  const { key, size } = await storeAlarmLogForward(r2, payload);
+
+  console.log(
+    JSON.stringify({
+      msg: 'telemetry-forward-success',
+      tokenPrefix: tokenPrefix(payload.token),
+      key,
+      size,
+      tripStartedAt: payload.tripStartedAt,
+      durationMs: payload.tripEndedAt - payload.tripStartedAt,
+      alarmLog: payload.alarmLog.length,
+      fusionLog: payload.fusionLog.length,
+      gpsDrops: payload.gpsDrops.length,
+    }),
+  );
+  return c.json({ ok: true, key, size });
 });
 
 /**

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -583,4 +583,13 @@ export interface Env {
    *      dataset=`trip_metrics`.
    */
   TRIP_METRICS?: AnalyticsEngineWriter;
+  /**
+   * Device alarmLog telemetry forward → R2 archive (#1579, Phase 0 epic #1576 P0-3).
+   * Trip 종료 시 device가 alarmLog/fusionLog/gpsDrops/ssotMirror snapshot을 forward해
+   * `trip-evidence/YYYY/MM/DD/{tokenPrefix}-{tripStartedAt}.ndjson` 키로 90일 보관.
+   * 미바인딩 시 `/telemetry/alarm-log`는 503 graceful.
+   * 생성: `wrangler r2 bucket create subway-now-telemetry`
+   *   + 90일 lifecycle 룰은 Cloudflare Dashboard에서 운영자가 수동 설정.
+   */
+  TELEMETRY_R2?: R2Bucket;
 }

--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -69,6 +69,21 @@ preview_id = "d38f190e3f7f4fd3b6e7f6485dd1733d"
 binding = "TRIP_METRICS"
 dataset = "trip_metrics"
 
+# R2: device alarmLog/fusionLog telemetry forward archive (#1579, Phase 0 epic #1576 P0-3)
+# Trip 종료 시 device가 `POST /telemetry/alarm-log`로 4개 buffer snapshot을 forward.
+# `trip-evidence/YYYY/MM/DD/{tokenPrefix}-{tripStartedAt}.ndjson` 키로 90일 보관해
+# 운영자가 사용자 trip evidence를 사용자 부담 없이 자동 수집.
+# 미바인딩 시 endpoint는 503 graceful (개발 환경 호환).
+#
+# 운영자 1회성 등록 절차:
+#   1) `wrangler r2 bucket create subway-now-telemetry`
+#   2) 아래 binding 활성화 (id 불필요 — bucket_name만 지정).
+#   3) Cloudflare Dashboard → R2 → subway-now-telemetry → Lifecycle 룰에서
+#      "Delete objects after 90 days" 추가 (cost 절감, evidence는 단기 분석 목적).
+# [[r2_buckets]]
+# binding = "TELEMETRY_R2"
+# bucket_name = "subway-now-telemetry"
+
 # 1분마다 활성 트립 폴링
 [triggers]
 crons = ["*/1 * * * *"]

--- a/src/features/alarm/api/__tests__/telemetryForward.test.ts
+++ b/src/features/alarm/api/__tests__/telemetryForward.test.ts
@@ -1,0 +1,314 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  buildDeviceMetadata,
+  forwardTripTelemetry,
+  MIN_TRIP_DURATION_MS,
+  type TelemetryForwardPayload,
+} from '../telemetryForward';
+import { TELEMETRY_FORWARD_RETRY_QUEUE_KEY } from '../../../../shared/constants/storageKeys';
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const TEST_URL = 'https://api.test/';
+
+function basePayload(over: Partial<TelemetryForwardPayload> = {}): TelemetryForwardPayload {
+  const tripStartedAt = 1_000_000;
+  return {
+    token: 'aabbccdd11223344',
+    tripStartedAt,
+    tripEndedAt: tripStartedAt + MIN_TRIP_DURATION_MS + 1,
+    alarmLog: [{ ts: 1 }],
+    fusionLog: [{ ts: 2 }],
+    gpsDrops: [{ ts: 3 }],
+    backendSsotSnapshot: { currentStationId: '강남' },
+    deviceMetadata: { os: 'ios', appVersion: '1.2.3', locale: 'ko' },
+    ...over,
+  };
+}
+
+function setBackend(fetchResult?: { ok: boolean; status?: number } | Error): void {
+  process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = TEST_URL;
+  if (fetchResult instanceof Error) {
+    (globalThis.fetch as jest.Mock).mockRejectedValue(fetchResult);
+  } else if (fetchResult) {
+    (globalThis.fetch as jest.Mock).mockResolvedValue(fetchResult);
+  }
+}
+
+describe('forwardTripTelemetry', () => {
+  beforeEach(async () => {
+    delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+    globalThis.fetch = jest.fn();
+    await AsyncStorage.clear();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+
+  it('URL 미설정이면 skipped=true (no-url) + fetch 호출 안 함', async () => {
+    const result = await forwardTripTelemetry(basePayload());
+    expect(result).toEqual({ ok: false, skipped: true, skipReason: 'no-url' });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('빈 token이면 skipped=true (no-token)', async () => {
+    setBackend();
+    const result = await forwardTripTelemetry(basePayload({ token: '' }));
+    expect(result.skipReason).toBe('no-token');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('30s 미만 trip은 skipped=true (trip-too-short)', async () => {
+    setBackend();
+    const ts = 1_000_000;
+    const result = await forwardTripTelemetry(
+      basePayload({ tripStartedAt: ts, tripEndedAt: ts + MIN_TRIP_DURATION_MS - 1 }),
+    );
+    expect(result.skipReason).toBe('trip-too-short');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('tripStartedAt <=0 이면 skipped=true (no-tripStart)', async () => {
+    setBackend();
+    const result = await forwardTripTelemetry(basePayload({ tripStartedAt: 0 }));
+    expect(result.skipReason).toBe('no-tripStart');
+  });
+
+  it('payload 빈 (모든 buffer 비고 ssot null) 시 skipped=true (empty-payload)', async () => {
+    setBackend();
+    const result = await forwardTripTelemetry(
+      basePayload({
+        alarmLog: [],
+        fusionLog: [],
+        gpsDrops: [],
+        backendSsotSnapshot: null,
+      }),
+    );
+    expect(result.skipReason).toBe('empty-payload');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('성공 시 ok=true + outbox 비움', async () => {
+    setBackend({ ok: true, status: 200 });
+    const result = await forwardTripTelemetry(basePayload());
+    expect(result).toEqual({ ok: true, status: 200 });
+    expect(await AsyncStorage.getItem(TELEMETRY_FORWARD_RETRY_QUEUE_KEY)).toBeNull();
+
+    const [url, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe(`${TEST_URL}telemetry/alarm-log`);
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body);
+    expect(body.token).toBe('aabbccdd11223344');
+    expect(body.alarmLog.length).toBe(1);
+    expect(body.deviceMetadata.os).toBe('ios');
+  });
+
+  it('실패 시 outbox에 enqueue', async () => {
+    setBackend({ ok: false, status: 500 });
+    const payload = basePayload();
+    const result = await forwardTripTelemetry(payload);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(500);
+    const outboxRaw = await AsyncStorage.getItem(TELEMETRY_FORWARD_RETRY_QUEUE_KEY);
+    expect(outboxRaw).not.toBeNull();
+    const stored = JSON.parse(outboxRaw ?? '');
+    expect(stored.payload.token).toBe(payload.token);
+    expect(stored.payload.alarmLog.length).toBe(1);
+  });
+
+  it('fetch throw 시 ok=false + outbox 보존', async () => {
+    setBackend(new Error('network'));
+    const result = await forwardTripTelemetry(basePayload());
+    expect(result).toEqual({ ok: false });
+    expect(await AsyncStorage.getItem(TELEMETRY_FORWARD_RETRY_QUEUE_KEY)).not.toBeNull();
+  });
+
+  it('outbox에 직전 retry 항목이 있으면 신규 forward 전에 flush 시도', async () => {
+    // 두 번째 호출(신규) 성공 + 첫 번째 호출(retry) 성공
+    setBackend({ ok: true, status: 200 });
+    const prev = basePayload({ tripStartedAt: 500_000, tripEndedAt: 600_000 });
+    await AsyncStorage.setItem(
+      TELEMETRY_FORWARD_RETRY_QUEUE_KEY,
+      JSON.stringify({ payload: prev }),
+    );
+
+    const result = await forwardTripTelemetry(basePayload());
+    expect(result.ok).toBe(true);
+    // 1) outbox flush 2) 신규 forward
+    expect((globalThis.fetch as jest.Mock).mock.calls).toHaveLength(2);
+    // 두 호출 모두 outbox clear 했어야 함 (마지막 성공이 최종 상태).
+    expect(await AsyncStorage.getItem(TELEMETRY_FORWARD_RETRY_QUEUE_KEY)).toBeNull();
+  });
+
+  it('outbox flush 실패해도 신규 forward는 진행', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = TEST_URL;
+    // 두 번 호출: 1번째(flush) 실패, 2번째(신규) 성공.
+    (globalThis.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+
+    const prev = basePayload({ tripStartedAt: 500_000, tripEndedAt: 600_000 });
+    await AsyncStorage.setItem(
+      TELEMETRY_FORWARD_RETRY_QUEUE_KEY,
+      JSON.stringify({ payload: prev }),
+    );
+
+    const result = await forwardTripTelemetry(basePayload());
+    expect(result.ok).toBe(true);
+    expect((globalThis.fetch as jest.Mock).mock.calls).toHaveLength(2);
+    // 신규 forward 성공 시 outbox clear.
+    expect(await AsyncStorage.getItem(TELEMETRY_FORWARD_RETRY_QUEUE_KEY)).toBeNull();
+  });
+
+  it('손상된 outbox JSON은 graceful skip (flush 시도 안 함)', async () => {
+    setBackend({ ok: true, status: 200 });
+    await AsyncStorage.setItem(TELEMETRY_FORWARD_RETRY_QUEUE_KEY, 'not-json{');
+    const result = await forwardTripTelemetry(basePayload());
+    expect(result.ok).toBe(true);
+    expect((globalThis.fetch as jest.Mock).mock.calls).toHaveLength(1);
+  });
+
+  it('shape mismatch outbox는 무시', async () => {
+    setBackend({ ok: true, status: 200 });
+    await AsyncStorage.setItem(
+      TELEMETRY_FORWARD_RETRY_QUEUE_KEY,
+      JSON.stringify({ payload: { token: 5 } }),
+    );
+    const result = await forwardTripTelemetry(basePayload());
+    expect(result.ok).toBe(true);
+    expect((globalThis.fetch as jest.Mock).mock.calls).toHaveLength(1);
+  });
+});
+
+describe('outbox storage error 흡수', () => {
+  beforeEach(async () => {
+    delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+    globalThis.fetch = jest.fn();
+    await AsyncStorage.clear();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    jest.restoreAllMocks();
+  });
+
+  it('writeOutbox 실패해도 caller 흐름은 계속 (graceful)', async () => {
+    setBackend({ ok: false, status: 500 });
+    const spy = jest
+      .spyOn(AsyncStorage, 'setItem')
+      .mockRejectedValue(new Error('storage full'));
+    try {
+      const result = await forwardTripTelemetry(basePayload());
+      expect(result.ok).toBe(false);
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('clearOutbox 실패해도 caller 흐름은 계속 (graceful)', async () => {
+    setBackend({ ok: true, status: 200 });
+    const spy = jest
+      .spyOn(AsyncStorage, 'removeItem')
+      .mockRejectedValue(new Error('storage'));
+    try {
+      const result = await forwardTripTelemetry(basePayload());
+      expect(result.ok).toBe(true);
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('readOutbox JSON parse 실패는 graceful skip', async () => {
+    setBackend({ ok: true, status: 200 });
+    const spy = jest
+      .spyOn(AsyncStorage, 'getItem')
+      .mockRejectedValueOnce(new Error('read fail'));
+    try {
+      const result = await forwardTripTelemetry(basePayload());
+      expect(result.ok).toBe(true);
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('buildDeviceMetadata', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('수집 기본값 — os 항상 set, optional은 환경값 있으면 포함', () => {
+    const meta = buildDeviceMetadata();
+    expect(['ios', 'android', 'unknown']).toContain(meta.os);
+  });
+
+  it('expoConfig.version + i18n.language 둘 다 있으면 포함', () => {
+    jest.isolateModules(() => {
+      jest.doMock('expo-constants', () => ({
+        __esModule: true,
+        default: { expoConfig: { version: '9.9.9' } },
+      }));
+      jest.doMock('i18next', () => ({ __esModule: true, default: { language: 'ko' } }));
+      const { buildDeviceMetadata: build } = require('../telemetryForward');
+      const meta = build();
+      expect(meta.appVersion).toBe('9.9.9');
+      expect(meta.locale).toBe('ko');
+    });
+  });
+
+  it('알 수 없는 OS는 unknown으로 fallback', () => {
+    const { Platform } = require('react-native');
+    const originalOS = Platform.OS;
+    Platform.OS = 'web';
+    try {
+      const meta = buildDeviceMetadata();
+      expect(meta.os).toBe('unknown');
+    } finally {
+      Platform.OS = originalOS;
+    }
+  });
+
+  it('expoConfig 자체가 null이면 appVersion + locale 미포함', () => {
+    jest.isolateModules(() => {
+      jest.doMock('expo-constants', () => ({
+        __esModule: true,
+        default: { expoConfig: null },
+      }));
+      jest.doMock('i18next', () => ({ __esModule: true, default: { language: '' } }));
+      const { buildDeviceMetadata: build } = require('../telemetryForward');
+      const meta = build();
+      expect(meta.appVersion).toBeUndefined();
+      expect(meta.locale).toBeUndefined();
+    });
+  });
+
+  it('expoConfig.version 부재 시 appVersion 미포함', () => {
+    jest.isolateModules(() => {
+      jest.doMock('expo-constants', () => ({
+        __esModule: true,
+        default: { expoConfig: {} },
+      }));
+      // i18n.language도 동시에 빈 값으로 → locale도 미포함 (한 번에 두 분기 커버).
+      jest.doMock('i18next', () => ({
+        __esModule: true,
+        default: { language: '' },
+      }));
+      const { buildDeviceMetadata: build } = require('../telemetryForward');
+      const meta = build();
+      expect(meta.appVersion).toBeUndefined();
+      expect(meta.locale).toBeUndefined();
+    });
+  });
+});

--- a/src/features/alarm/api/telemetryForward.ts
+++ b/src/features/alarm/api/telemetryForward.ts
@@ -1,0 +1,207 @@
+/**
+ * Trip telemetry forward (#1579, Phase 0 epic #1576 — P0-3).
+ *
+ * Trip 종료 시 device가 alarmLog 200 ring + fusionLog 200 + gpsDrops + backendSsotMirror
+ * snapshot + deviceMetadata를 backend `POST /telemetry/alarm-log`로 forward한다. 백엔드는
+ * 페이로드를 R2 `trip-evidence/YYYY/MM/DD/{tripTokenHash}.ndjson`로 적재해 운영자가
+ * 4 trip evidence를 사용자 부담 없이 수집한다.
+ *
+ * 정책 (signalDumpBackend.ts 패턴 답습):
+ *  - graceful — URL 미설정 / token 부재 / 짧은 trip(<30s) / payload 비었음 시 throw 안 함.
+ *    critical path(trip-end recall + cleanup) 보호.
+ *  - retry — 실패 시 단건 outbox에 enqueue. 다음 trip 종료 시 같은 함수가 outbox flush 시도.
+ *    outbox는 가장 최근 1건만 보존(R2 archive는 evidence 수집이 목적, 누적 보관 불필요).
+ *  - 짧은 trip skip — 30s 미만 trip은 R2 archive 가치보다 noise 비용이 커서 forward 안 함.
+ *
+ * 호출자: `triggerTripEndRecall` (fire-and-forget). cleanup 전에 호출되어야 alarmLog/fusionLog
+ *   ring buffer가 유효 (cleanup이 `clearAlarmLogWindows`로 일부 모듈 in-memory 윈도우 reset).
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Platform } from 'react-native';
+import Constants from 'expo-constants';
+import i18n from 'i18next';
+import { TELEMETRY_FORWARD_RETRY_QUEUE_KEY } from '../../../shared/constants/storageKeys';
+import { createLogger } from '../../../shared/utils/logger';
+import {
+  fetchWithTelemetryTimeout,
+  getAlarmBackendUrl,
+} from '../../../shared/utils/telemetryHttp';
+
+const log = createLogger('telemetryForward');
+
+/** 30s 미만 trip은 forward skip — R2 archive 가치보다 noise 비용이 크다. */
+export const MIN_TRIP_DURATION_MS = 30_000;
+
+export interface DeviceMetadata {
+  os: 'ios' | 'android' | 'unknown';
+  appVersion?: string;
+  locale?: string;
+}
+
+export interface TelemetryForwardPayload {
+  /** APNs device token. backend가 8자 prefix로 익명화해 R2 key/customMetadata에 적재. */
+  token: string;
+  /** trip 시작 epoch ms. R2 key의 YYYY/MM/DD partition 산출 기준. */
+  tripStartedAt: number;
+  /** trip 종료 epoch ms. customMetadata + 길이 게이트(>=30s) 산출. */
+  tripEndedAt: number;
+  /** alarmLog 200 ring buffer snapshot. */
+  alarmLog: readonly unknown[];
+  /** fusionLog 200 ring buffer snapshot. */
+  fusionLog: readonly unknown[];
+  /** GPS drop 100 ring buffer snapshot. */
+  gpsDrops: readonly unknown[];
+  /** backend SSoT mirror snapshot (또는 null — mirror 미존재 trip). */
+  backendSsotSnapshot: unknown;
+  /** OS / appVersion / locale 메타. */
+  deviceMetadata: DeviceMetadata;
+}
+
+export interface TelemetryForwardResult {
+  ok: boolean;
+  /** URL 미설정 / token 부재 / 짧은 trip / 빈 payload로 호출이 건너뛰어진 경우 true. */
+  skipped?: boolean;
+  skipReason?:
+    | 'no-url'
+    | 'no-token'
+    | 'trip-too-short'
+    | 'empty-payload'
+    | 'no-tripStart';
+  status?: number;
+}
+
+interface OutboxEntry {
+  payload: TelemetryForwardPayload;
+}
+
+/** 디바이스 메타 수집 — Platform / expo-constants / i18next. 모두 fallback 안전. */
+export function buildDeviceMetadata(): DeviceMetadata {
+  const os: DeviceMetadata['os'] =
+    Platform.OS === 'ios' || Platform.OS === 'android' ? Platform.OS : 'unknown';
+  const meta: DeviceMetadata = { os };
+  const version = Constants.expoConfig?.version;
+  if (typeof version === 'string' && version.length > 0) meta.appVersion = version;
+  const locale = i18n.language;
+  if (typeof locale === 'string' && locale.length > 0) meta.locale = locale;
+  return meta;
+}
+
+async function readOutbox(): Promise<OutboxEntry | null> {
+  try {
+    const raw = await AsyncStorage.getItem(TELEMETRY_FORWARD_RETRY_QUEUE_KEY);
+    if (raw === null) return null;
+    const parsed = JSON.parse(raw) as OutboxEntry;
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      !parsed.payload ||
+      typeof parsed.payload !== 'object' ||
+      typeof parsed.payload.token !== 'string'
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch (e) {
+    log.warn('outbox read error', e);
+    return null;
+  }
+}
+
+async function writeOutbox(entry: OutboxEntry): Promise<void> {
+  try {
+    await AsyncStorage.setItem(
+      TELEMETRY_FORWARD_RETRY_QUEUE_KEY,
+      JSON.stringify(entry),
+    );
+  } catch (e) {
+    log.warn('outbox write error', e);
+  }
+}
+
+async function clearOutbox(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(TELEMETRY_FORWARD_RETRY_QUEUE_KEY);
+  } catch (e) {
+    log.warn('outbox clear error', e);
+  }
+}
+
+function payloadIsEmpty(p: TelemetryForwardPayload): boolean {
+  return (
+    p.alarmLog.length === 0 &&
+    p.fusionLog.length === 0 &&
+    p.gpsDrops.length === 0 &&
+    p.backendSsotSnapshot === null
+  );
+}
+
+async function performForward(
+  base: string,
+  payload: TelemetryForwardPayload,
+): Promise<TelemetryForwardResult> {
+  try {
+    const res = await fetchWithTelemetryTimeout(`${base}/telemetry/alarm-log`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      log.warn(`telemetry forward failed status=${res.status}`);
+      return { ok: false, status: res.status };
+    }
+    return { ok: true, status: res.status };
+  } catch (e) {
+    log.warn('telemetry forward error', e);
+    return { ok: false };
+  }
+}
+
+/**
+ * Trip telemetry 1건 forward + outbox retain on failure.
+ *
+ * 1) Outbox에 직전 trip의 retry 항목이 있으면 먼저 flush 시도(성공/실패 무관, 결과는 무시).
+ * 2) 신규 payload 검증 (URL/token/duration/empty) → 검증 실패 시 graceful skip.
+ * 3) POST `/telemetry/alarm-log` → 성공 시 outbox clear, 실패 시 outbox에 enqueue.
+ *
+ * 절대 throw 안 한다 — trip-end critical path 보호.
+ */
+export async function forwardTripTelemetry(
+  payload: TelemetryForwardPayload,
+): Promise<TelemetryForwardResult> {
+  const base = getAlarmBackendUrl();
+  if (!base) {
+    return { ok: false, skipped: true, skipReason: 'no-url' };
+  }
+  // 직전 trip retry — base가 있는 경우만 시도. 결과는 신규 forward와 독립.
+  await flushPendingOutbox(base);
+
+  if (!payload.token) {
+    return { ok: false, skipped: true, skipReason: 'no-token' };
+  }
+  if (payload.tripStartedAt <= 0) {
+    return { ok: false, skipped: true, skipReason: 'no-tripStart' };
+  }
+  if (payload.tripEndedAt - payload.tripStartedAt < MIN_TRIP_DURATION_MS) {
+    return { ok: false, skipped: true, skipReason: 'trip-too-short' };
+  }
+  if (payloadIsEmpty(payload)) {
+    return { ok: false, skipped: true, skipReason: 'empty-payload' };
+  }
+
+  const result = await performForward(base, payload);
+  if (result.ok) {
+    await clearOutbox();
+  } else {
+    await writeOutbox({ payload });
+  }
+  return result;
+}
+
+async function flushPendingOutbox(base: string): Promise<void> {
+  const entry = await readOutbox();
+  if (entry === null) return;
+  const result = await performForward(base, entry.payload);
+  if (result.ok) {
+    await clearOutbox();
+  }
+}

--- a/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
+++ b/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
@@ -16,6 +16,12 @@ const mockUploadSignalDump = jest.fn();
 const mockGetCurrentTripCorrIdSync = jest.fn();
 const mockGetCurrentTripCorrId = jest.fn();
 const mockGetRawSignalEntries = jest.fn();
+const mockForwardTripTelemetry = jest.fn();
+const mockBuildDeviceMetadata = jest.fn();
+const mockGetAlarmLog = jest.fn();
+const mockGetFusionDebugEntries = jest.fn();
+const mockGetGpsDropEntries = jest.fn();
+const mockReadBackendSsotMirror = jest.fn();
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   __esModule: true,
@@ -63,6 +69,27 @@ jest.mock('../../../observability/utils/tripCorrId', () => ({
 
 jest.mock('../../../observability/utils/rawSignalBuffer', () => ({
   getRawSignalEntries: (...args: unknown[]) => mockGetRawSignalEntries(...args),
+}));
+
+jest.mock('../../api/telemetryForward', () => ({
+  forwardTripTelemetry: (...args: unknown[]) => mockForwardTripTelemetry(...args),
+  buildDeviceMetadata: (...args: unknown[]) => mockBuildDeviceMetadata(...args),
+}));
+
+jest.mock('../alarmLog', () => ({
+  getAlarmLog: (...args: unknown[]) => mockGetAlarmLog(...args),
+}));
+
+jest.mock('../../../nearest-station/utils/fusionDebugBuffer', () => ({
+  getFusionDebugEntries: (...args: unknown[]) => mockGetFusionDebugEntries(...args),
+}));
+
+jest.mock('../../../nearest-station/utils/gpsDropBuffer', () => ({
+  getGpsDropEntries: (...args: unknown[]) => mockGetGpsDropEntries(...args),
+}));
+
+jest.mock('../backendSsotMirror', () => ({
+  readBackendSsotMirror: (...args: unknown[]) => mockReadBackendSsotMirror(...args),
 }));
 
 import { triggerTripEndRecall } from '../triggerTripEndRecall';
@@ -128,6 +155,18 @@ describe('triggerTripEndRecall', () => {
     mockGetCurrentTripCorrId.mockResolvedValue(null);
     mockGetRawSignalEntries.mockReset();
     mockGetRawSignalEntries.mockReturnValue([]);
+    mockForwardTripTelemetry.mockReset();
+    mockForwardTripTelemetry.mockResolvedValue({ ok: true });
+    mockBuildDeviceMetadata.mockReset();
+    mockBuildDeviceMetadata.mockReturnValue({ os: 'ios' });
+    mockGetAlarmLog.mockReset();
+    mockGetAlarmLog.mockResolvedValue([]);
+    mockGetFusionDebugEntries.mockReset();
+    mockGetFusionDebugEntries.mockReturnValue([]);
+    mockGetGpsDropEntries.mockReset();
+    mockGetGpsDropEntries.mockReturnValue([]);
+    mockReadBackendSsotMirror.mockReset();
+    mockReadBackendSsotMirror.mockResolvedValue(null);
   });
 
   it('tripStart 부재 시 즉시 skip (no-trip-start)', async () => {
@@ -491,6 +530,61 @@ describe('triggerTripEndRecall', () => {
 
       const result = await triggerTripEndRecall();
       expect(result.uploaded).toBe(true);
+    });
+  });
+
+  describe('#1579 (P0-3) — alarm log telemetry forward', () => {
+    it('정상 흐름 — token + buffer snapshot + deviceMetadata로 forwardTripTelemetry 호출', async () => {
+      setupHappyPath();
+      mockGetAlarmLog.mockResolvedValue([{ ts: 1, source: 'fg' }]);
+      mockGetFusionDebugEntries.mockReturnValue([{ ts: 2, kind: 'cycle' }]);
+      mockGetGpsDropEntries.mockReturnValue([{ ts: 3 }]);
+      mockReadBackendSsotMirror.mockResolvedValue({ currentStationId: '강남' });
+      mockBuildDeviceMetadata.mockReturnValue({ os: 'ios', appVersion: '1.2.3' });
+
+      await triggerTripEndRecall();
+
+      expect(mockForwardTripTelemetry).toHaveBeenCalledTimes(1);
+      const payload = mockForwardTripTelemetry.mock.calls[0][0];
+      expect(payload.token).toBe('apns-token-xyz');
+      expect(payload.tripStartedAt).toBe(100);
+      expect(payload.tripEndedAt).toBeGreaterThanOrEqual(100);
+      expect(payload.alarmLog).toEqual([{ ts: 1, source: 'fg' }]);
+      expect(payload.fusionLog).toEqual([{ ts: 2, kind: 'cycle' }]);
+      expect(payload.gpsDrops).toEqual([{ ts: 3 }]);
+      expect(payload.backendSsotSnapshot).toEqual({ currentStationId: '강남' });
+      expect(payload.deviceMetadata).toEqual({ os: 'ios', appVersion: '1.2.3' });
+    });
+
+    it('APNS token 부재 시 forward skip', async () => {
+      setupHappyPath();
+      setStorage({
+        [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
+        [ROUTE_KEY]: ROUTE_JSON,
+        [TRIP_ORIGIN_KEY]: ORIGIN_JSON,
+        [DESTINATION_KEY]: DEST_JSON,
+        [APNS_TOKEN_KEY]: null,
+      });
+
+      await triggerTripEndRecall();
+      expect(mockForwardTripTelemetry).not.toHaveBeenCalled();
+    });
+
+    it('forwardTripTelemetry 예외 흡수 (recall 결과는 영향 없음)', async () => {
+      setupHappyPath();
+      mockForwardTripTelemetry.mockRejectedValue(new Error('boom'));
+
+      const result = await triggerTripEndRecall();
+      expect(result.uploaded).toBe(true);
+    });
+
+    it('getAlarmLog 예외 흡수', async () => {
+      setupHappyPath();
+      mockGetAlarmLog.mockRejectedValue(new Error('storage'));
+
+      const result = await triggerTripEndRecall();
+      expect(result.uploaded).toBe(true);
+      expect(mockForwardTripTelemetry).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/alarm/utils/triggerTripEndRecall.ts
+++ b/src/features/alarm/utils/triggerTripEndRecall.ts
@@ -49,6 +49,14 @@ import {
 } from '../../observability/utils/tripCorrId';
 import { getRawSignalEntries } from '../../observability/utils/rawSignalBuffer';
 import { uploadSignalDump } from '../api/signalDumpBackend';
+import {
+  buildDeviceMetadata,
+  forwardTripTelemetry,
+} from '../api/telemetryForward';
+import { getAlarmLog } from './alarmLog';
+import { getFusionDebugEntries } from '../../nearest-station/utils/fusionDebugBuffer';
+import { getGpsDropEntries } from '../../nearest-station/utils/gpsDropBuffer';
+import { readBackendSsotMirror } from './backendSsotMirror';
 
 const log = createLogger('triggerTripEndRecall');
 
@@ -118,6 +126,11 @@ export async function triggerTripEndRecall(): Promise<TriggerTripEndRecallResult
     // 같은 critical path와 분리해 실패해도 trip-end 흐름은 정상 동작.
     await triggerSignalDumpUpload();
 
+    // #1579 (Phase 0 epic #1576 P0-3) — alarmLog/fusionLog/gpsDrops/ssotMirror snapshot을
+    // backend R2로 forward. cleanup 전에 호출되어야 ring buffer가 유효. fire-and-forget —
+    // 짧은 trip(<30s)/payload 비었음은 함수가 자체 skip.
+    await triggerAlarmLogForward(tripStart);
+
     return { uploaded: result.uploaded };
   } catch (e) {
     log.warn('trigger error', e);
@@ -177,6 +190,38 @@ async function triggerSignalDumpUpload(): Promise<void> {
     await uploadSignalDump(corrId, token, entries);
   } catch (e) {
     log.warn('signal dump trigger error', e);
+  }
+}
+
+/**
+ * #1579 (P0-3) — alarmLog/fusionLog/gpsDrops/ssotMirror snapshot을 backend로 forward.
+ *
+ * tripBoundCleanups 전에 호출되어야 한다 — cleanup 시점에 alarmLog 모듈 in-memory 윈도우
+ * (`clearAlarmLogWindows`)가 초기화되고 ssotMirror가 storage에서 사라진다.
+ *
+ * graceful: token 부재 / 30s 미만 trip / payload 빈 케이스는 forward 함수 내부에서 skip.
+ * 모든 오류는 흡수 — trip-end critical path 보호.
+ */
+async function triggerAlarmLogForward(tripStart: number): Promise<void> {
+  try {
+    const token = await AsyncStorage.getItem(APNS_TOKEN_KEY);
+    if (!token) return;
+    const [alarmLog, ssotMirror] = await Promise.all([
+      getAlarmLog(),
+      readBackendSsotMirror(),
+    ]);
+    await forwardTripTelemetry({
+      token,
+      tripStartedAt: tripStart,
+      tripEndedAt: Date.now(),
+      alarmLog,
+      fusionLog: getFusionDebugEntries(),
+      gpsDrops: getGpsDropEntries(),
+      backendSsotSnapshot: ssotMirror,
+      deviceMetadata: buildDeviceMetadata(),
+    });
+  } catch (e) {
+    log.warn('alarm log forward trigger error', e);
   }
 }
 

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -182,3 +182,8 @@ export const BACKEND_SSOT_MIRROR_KEY = 'subway-now:backend-ssot-mirror';
 // push하고 ring buffer를 통째로 AsyncStorage에 mirror한다. 앱 재시작 후 진단해도 직전 trip의
 // 호출 흔적을 잃지 않게 하는 게 목적. 형식: BackendCallLogEntry[] JSON (capacity 100).
 export const BACKEND_CALL_LOG_KEY = 'subway-now:backend-call-log';
+// #1579 (P0-3) — alarmLog telemetry forward retry queue.
+// trip 종료 시 device가 alarmLog/fusionLog/gpsDrops/ssotMirror snapshot을 backend로 forward.
+// 네트워크 실패 시 단건 enqueue, 다음 trip 종료 시 재시도. 가장 최근 trip만 보존 (1건).
+// 형식: TelemetryForwardOutboxEntry JSON.
+export const TELEMETRY_FORWARD_RETRY_QUEUE_KEY = 'subway-now:telemetry-forward-retry';


### PR DESCRIPTION
Closes #1579

Phase 0 epic #1576 sub-task P0-3 — 사용자 trip evidence를 R2로 자동 수집.

## 변경 요약

### Device
- `src/features/alarm/api/telemetryForward.ts` 신설 — `forwardTripTelemetry(payload)` async.
  - POST `BACKEND_BASE/telemetry/alarm-log`
  - 실패 시 device storage outbox (`TELEMETRY_FORWARD_RETRY_QUEUE_KEY`) 보존
  - 다음 trip 시 outbox flush 후 신규 forward (single-entry retain — 가장 최근 trip만 보호)
  - 30s 미만 trip / payload 빈 / token 부재 / URL 부재는 graceful skip
- `buildDeviceMetadata` — Platform.OS + expo-constants version + i18n.language
- `triggerTripEndRecall`에 `triggerAlarmLogForward(tripStart)` wire — cleanup 직전에 호출되어
  alarmLog 200 ring + fusionLog 200 + gpsDrops 100 + backendSsotMirror snapshot이 모두 유효한
  상태로 forward (cleanup이 `clearAlarmLogWindows`로 in-memory 윈도우 reset).

### Backend
- `src/alarmLogForward.ts` 신설 — payload 검증 + R2 put (ndjson 6줄).
- `index.ts`에 `POST /telemetry/alarm-log` 핸들러 등록 (rawSignalDump 패턴 답습).
- `wrangler.toml`에 commented `[[r2_buckets]] TELEMETRY_R2` 블록 추가 + 운영자 1회성 등록 절차.
- `types.ts` Env에 `TELEMETRY_R2?: R2Bucket` 추가 (미바인딩 시 endpoint는 503 graceful).
- R2 key: `trip-evidence/YYYY/MM/DD/{tokenPrefix}-{tripStartedAt}.ndjson`
  - PII: token은 8자 prefix만 R2 key/customMetadata에 적재 (원문 미저장)

## Wire-completion 5단 grep

| 항목 | 위치 |
| --- | --- |
| 1. Definition | `src/features/alarm/api/telemetryForward.ts:168` `forwardTripTelemetry` export |
| 2. Import | `src/features/alarm/utils/triggerTripEndRecall.ts:54` |
| 3. Call | `src/features/alarm/utils/triggerTripEndRecall.ts:213` (cleanup 전) |
| 4. Backend route | `backend/alarm-worker/src/index.ts:798` POST `/telemetry/alarm-log` |
| 5. Storage put | `backend/alarm-worker/src/alarmLogForward.ts:storeAlarmLogForward` |

## Acceptance 매핑

- 사용자 trip 1건 종료 시 R2 archive에 ndjson 1개 생성 → `storeAlarmLogForward` 단위 테스트로 검증
- backend log `telemetry-forward-success` 이벤트 1건 → handler 내 `console.log(JSON.stringify(...))`
- forward 실패 시 device retain → 단위 테스트 (`실패 시 outbox에 enqueue` / `fetch throw 시 outbox 보존`)
- 다음 trip 시 outbox flush → 단위 테스트 (`outbox에 직전 retry 항목이 있으면 신규 forward 전에 flush 시도`)

## R2 bucket 운영자 manual step (PR 머지 후 1회)

```bash
# 1) R2 bucket 생성
wrangler r2 bucket create subway-now-telemetry

# 2) wrangler.toml의 [[r2_buckets]] 블록 주석 해제 (binding=TELEMETRY_R2, bucket_name=subway-now-telemetry)

# 3) wrangler deploy

# 4) Cloudflare Dashboard → R2 → subway-now-telemetry → Settings → Lifecycle 룰 추가:
#    "Delete objects after 90 days" (cost 절감, evidence는 단기 분석 목적)
```

## 테스트 / 검증

- **Device unit**: `telemetryForward.test.ts` 20 PASS, `triggerTripEndRecall.test.ts` 26 PASS (+4 신규)
- **Device coverage**: `telemetryForward.ts` / `triggerTripEndRecall.ts` 둘 다 100%
- **Backend unit**: `alarmLogForward.test.ts` 14 PASS. 백엔드 전체 1690 PASS
- **Type-check**: device PASS. backend는 기존 `scheduled.ts` duplicate ident baseline만 (본 PR 무관)
- **Full device suite**: 35 fail / 6898 pass — dev baseline과 100% 일치 (widgetStorage + stationNotification 모듈, 본 PR 무관)
- **Coverage diff**: dev baseline 99.33/99.32/99.89/99.23 = 본 PR baseline 99.33/99.32/99.89/99.23 (gap = baseline 그대로)

## Test plan

- [x] CI 통과 확인 (Type Check & Test + Data Validation)
- [ ] 사용자가 manual step 4단계 실행 (R2 bucket + lifecycle 룰)
- [ ] EAS dev build로 실기기 trip 1건 종료 → R2에 ndjson 파일 1개 확인
- [ ] 백엔드 logs에 `telemetry-forward-success` 1건 확인
- [ ] device 비행기 모드 → trip 종료 → outbox 적재 확인 → 다음 trip에서 flush 확인