### PR TITLE
feat(P0-5 #1581): V/X acceptance dashboard SQL 카탈로그 + scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ docs/*
 !docs/agents/
 !docs/ci/
 !docs/decisions/
+!docs/observability/
 !docs/ops/
 handoff/
 img/

--- a/backend/alarm-worker/src/queries/__tests__/vxAcceptanceQueries.test.ts
+++ b/backend/alarm-worker/src/queries/__tests__/vxAcceptanceQueries.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Phase 0 #1581 — V/X acceptance SQL 카탈로그 정적 검증.
+ *
+ * SQL을 실제 실행할 수는 없지만(Cloudflare Analytics Engine 전용), 카탈로그가
+ * 다음을 보장하는지 정적으로 확인한다:
+ *   - 20개 entry 모두 존재 (V1~V9, V8a/V8b/V8c, X1~X11)
+ *   - key 중복 없음
+ *   - SQL이 SELECT/FROM 절 + `trip_metrics` dataset 참조 + `{WINDOW}` placeholder 포함
+ *   - renderQuery 가 placeholder를 치환 + 미존재 key 처리
+ *   - V/X kind 분류 일관성
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  VX_ACCEPTANCE_QUERIES,
+  findQuery,
+  renderQuery,
+  type VxKey,
+} from '../vxAcceptanceQueries';
+
+const EXPECTED_KEYS: VxKey[] = [
+  'V1', 'V2', 'V3', 'V4', 'V5', 'V6', 'V7',
+  'V8a', 'V8b', 'V8c', 'V9',
+  'X1', 'X2', 'X3', 'X4', 'X5', 'X6', 'X7', 'X8', 'X9', 'X10', 'X11',
+];
+
+describe('VX_ACCEPTANCE_QUERIES catalog', () => {
+  it('contains all 22 V/X entries', () => {
+    expect(VX_ACCEPTANCE_QUERIES).toHaveLength(EXPECTED_KEYS.length);
+    const keys = VX_ACCEPTANCE_QUERIES.map((q) => q.key);
+    expect(new Set(keys)).toEqual(new Set(EXPECTED_KEYS));
+  });
+
+  it('has no duplicate keys', () => {
+    const keys = VX_ACCEPTANCE_QUERIES.map((q) => q.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it.each(EXPECTED_KEYS)('%s has valid SQL shape', (key) => {
+    const entry = findQuery(key);
+    expect(entry).toBeDefined();
+    const sql = entry!.sql;
+    expect(sql).toMatch(/SELECT/i);
+    expect(sql).toMatch(/FROM\s+trip_metrics/i);
+    expect(sql).toContain('{WINDOW}');
+    expect(entry!.description.length).toBeGreaterThan(0);
+    expect(entry!.threshold.length).toBeGreaterThan(0);
+  });
+
+  it('classifies V* as value and X* as harm', () => {
+    for (const entry of VX_ACCEPTANCE_QUERIES) {
+      const expected = entry.key.startsWith('V') ? 'value' : 'harm';
+      expect(entry.kind).toBe(expected);
+    }
+  });
+});
+
+describe('renderQuery', () => {
+  it('replaces {WINDOW} placeholder with the given INTERVAL expression', () => {
+    const entry = findQuery('V1')!;
+    const rendered = renderQuery(entry, `'1' DAY`);
+    expect(rendered).not.toContain('{WINDOW}');
+    expect(rendered).toContain(`INTERVAL '1' DAY`);
+  });
+
+  it('replaces every occurrence when multiple placeholders exist', () => {
+    const synthetic = { ...findQuery('V1')!, sql: `A {WINDOW} B {WINDOW} C` };
+    expect(renderQuery(synthetic, 'X')).toBe('A X B X C');
+  });
+});
+
+describe('findQuery', () => {
+  it('returns undefined for unknown key', () => {
+    // intentional cast — runtime guard branch coverage
+    expect(findQuery('ZZZ' as unknown as VxKey)).toBeUndefined();
+  });
+
+  it('returns the matching entry for known key', () => {
+    expect(findQuery('X11')?.key).toBe('X11');
+  });
+});

--- a/backend/alarm-worker/src/queries/vxAcceptanceQueries.ts
+++ b/backend/alarm-worker/src/queries/vxAcceptanceQueries.ts
@@ -1,0 +1,276 @@
+/**
+ * V/X Acceptance SQL query catalog — Phase 0 Epic #1576 / P0-5 #1581.
+ *
+ * 본 모듈은 `docs/observability/vx-acceptance-queries.md`의 20 임계 SQL을
+ * runtime에서 사용할 수 있도록 string 상수로 export 한다 (daily cron / ad-hoc API
+ * 모두 이 카탈로그를 참조). 실제 dashboard 구축은 사용자 manual — 본 PR scaffold만.
+ *
+ * Window는 `{WINDOW}` placeholder — caller가 `'1' DAY` / `'10' MINUTE` 등으로 치환.
+ *
+ * 검증: `__tests__/vxAcceptanceQueries.test.ts`가 카탈로그 shape + 필수 절(SELECT/FROM/WHERE
+ * + trip_metrics 참조 + window placeholder)을 정적으로 보장한다. 실제 SQL 실행은
+ * Cloudflare Analytics Engine SQL API에서만 가능 (vitest 환경에서는 검증 불가).
+ */
+
+export type VxKey =
+  | 'V1' | 'V2' | 'V3' | 'V4' | 'V5' | 'V6' | 'V7'
+  | 'V8a' | 'V8b' | 'V8c' | 'V9'
+  | 'X1' | 'X2' | 'X3' | 'X4' | 'X5' | 'X6' | 'X7' | 'X8' | 'X9' | 'X10' | 'X11';
+
+export interface VxQueryEntry {
+  key: VxKey;
+  /** 가치(V) vs 손상(X) 분류 — alert routing에 사용. */
+  kind: 'value' | 'harm';
+  /** 한 줄 설명 (`alert-rules.md`의 임계 일람과 일치). */
+  description: string;
+  /** 임계 텍스트 (예: "< 1%", "0건"). */
+  threshold: string;
+  /** SQL string. `{WINDOW}` placeholder를 INTERVAL 표현으로 치환. */
+  sql: string;
+}
+
+const W = '{WINDOW}';
+
+export const VX_ACCEPTANCE_QUERIES: readonly VxQueryEntry[] = [
+  {
+    key: 'V1',
+    kind: 'value',
+    description: 'currentStation == SSoT mismatch %',
+    threshold: '< 1%',
+    sql: `SELECT (SUM(CASE WHEN blob3 = 'reason:ssot-mismatch' THEN 1 ELSE 0 END) * 100.0) / COUNT(*) AS mismatch_pct
+FROM trip_metrics
+WHERE blob1 = 'advance' AND timestamp >= NOW() - INTERVAL ${W};`,
+  },
+  {
+    key: 'V2',
+    kind: 'value',
+    description: 'transfer-1-stop alarm count per hop≥2 trip',
+    threshold: '0 violating trips',
+    sql: `SELECT index1 AS token, COUNT(*) AS alarm_count
+FROM trip_metrics
+WHERE blob1 = 'fire' AND blob3 = 'reason:transfer-1-stop'
+  AND timestamp >= NOW() - INTERVAL ${W}
+GROUP BY index1 HAVING alarm_count != 1;`,
+  },
+  {
+    key: 'V3',
+    kind: 'value',
+    description: 'destination-1-stop alarm count per trip',
+    threshold: '0 violating trips',
+    sql: `SELECT index1 AS token, COUNT(*) AS alarm_count
+FROM trip_metrics
+WHERE blob1 = 'fire' AND blob3 = 'reason:destination-1-stop'
+  AND timestamp >= NOW() - INTERVAL ${W}
+GROUP BY index1 HAVING alarm_count != 1;`,
+  },
+  {
+    key: 'V4',
+    kind: 'value',
+    description: 'station-passed fire vs SSoT advance drift',
+    threshold: '±1',
+    sql: `SELECT index1 AS token, COUNT(*) AS passed_fire_count
+FROM trip_metrics
+WHERE blob1 = 'fire' AND blob3 = 'reason:station-passed'
+  AND timestamp >= NOW() - INTERVAL ${W}
+GROUP BY index1;`,
+  },
+  {
+    key: 'V5',
+    kind: 'value',
+    description: 'auto-ended trip %',
+    threshold: '≥ 99%',
+    sql: `SELECT blob3 AS end_reason, COUNT(*) AS trip_count
+FROM trip_metrics
+WHERE blob1 = 'trip-mutation' AND blob2 = 'reason:trip-ended'
+  AND timestamp >= NOW() - INTERVAL ${W}
+GROUP BY blob3;`,
+  },
+  {
+    key: 'V6',
+    kind: 'value',
+    description: 'SSoT mirror lag p95 (ms)',
+    threshold: '< 5000ms',
+    sql: `SELECT quantile(0.95)(double1) AS p95_ms
+FROM trip_metrics
+WHERE blob1 = 'advance' AND double1 IS NOT NULL
+  AND timestamp >= NOW() - INTERVAL ${W};`,
+  },
+  {
+    key: 'V7',
+    kind: 'value',
+    description: 'underground trip advance %',
+    threshold: '≥ 90%',
+    sql: `SELECT (SUM(CASE WHEN blob1 = 'advance' THEN 1 ELSE 0 END) * 100.0) /
+  NULLIF(SUM(CASE WHEN blob1 IN ('advance', 'suppress') THEN 1 ELSE 0 END), 0) AS advance_pct
+FROM trip_metrics
+WHERE blob4 = 'env:underground' AND timestamp >= NOW() - INTERVAL ${W};`,
+  },
+  {
+    key: 'V8a',
+    kind: 'value',
+    description: '/position rate per 10min trip',
+    threshold: '≤ 100',
+    sql: `SELECT index1 AS token, COUNT(*) AS upload_count
+FROM trip_metrics
+WHERE blob1 = 'position-upload' AND timestamp >= NOW() - INTERVAL ${W}
+GROUP BY index1 HAVING upload_count > 100;`,
+  },
+  {
+    key: 'V8b',
+    kind: 'value',
+    description: '/trips rate per 10min trip',
+    threshold: '≤ 10',
+    sql: `SELECT index1 AS token, COUNT(*) AS mutation_count
+FROM trip_metrics
+WHERE blob1 = 'trip-mutation' AND timestamp >= NOW() - INTERVAL ${W}
+GROUP BY index1 HAVING mutation_count > 10;`,
+  },
+  {
+    key: 'V8c',
+    kind: 'value',
+    description: 'stationary vs moving cycle rate',
+    threshold: 'stationary < 50% moving',
+    sql: `SELECT blob2 AS reason, COUNT(*) / 60.0 AS rate_per_minute
+FROM trip_metrics
+WHERE blob1 = 'motion-transition' AND timestamp >= NOW() - INTERVAL ${W}
+GROUP BY blob2;`,
+  },
+  {
+    key: 'V9',
+    kind: 'value',
+    description: 'suppress rate per trip per hour',
+    threshold: '≤ 30',
+    sql: `SELECT index1 AS token, COUNT(*) AS suppress_count
+FROM trip_metrics
+WHERE blob1 = 'suppress' AND timestamp >= NOW() - INTERVAL ${W}
+GROUP BY index1 HAVING suppress_count > 30;`,
+  },
+  {
+    key: 'X1',
+    kind: 'harm',
+    description: 'wrong-station alarm fired',
+    threshold: '0건',
+    sql: `SELECT index1 AS token, blob2 AS station, timestamp
+FROM trip_metrics
+WHERE blob1 = 'fire' AND blob3 = 'reason:wrong-station'
+  AND timestamp >= NOW() - INTERVAL ${W};`,
+  },
+  {
+    key: 'X2',
+    kind: 'harm',
+    description: 'duplicate alarm (same trip+station)',
+    threshold: '0건',
+    sql: `SELECT index1 AS token, blob2 AS station, COUNT(*) AS fire_count
+FROM trip_metrics
+WHERE blob1 = 'fire' AND timestamp >= NOW() - INTERVAL ${W}
+GROUP BY index1, blob2 HAVING fire_count > 1;`,
+  },
+  {
+    key: 'X3',
+    kind: 'harm',
+    description: 'stale alarm (staleMs > 5min at fire)',
+    threshold: '0건',
+    sql: `SELECT index1 AS token, blob2 AS station, double1 AS stale_ms
+FROM trip_metrics
+WHERE blob1 = 'fire' AND double1 > 300000
+  AND timestamp >= NOW() - INTERVAL ${W};`,
+  },
+  {
+    key: 'X4',
+    kind: 'harm',
+    description: 'spam suppress (>10/trip)',
+    threshold: '0건',
+    sql: `SELECT index1 AS token, COUNT(*) AS suppress_count
+FROM trip_metrics
+WHERE blob1 = 'suppress' AND timestamp >= NOW() - INTERVAL ${W}
+GROUP BY index1 HAVING suppress_count > 10;`,
+  },
+  {
+    key: 'X5',
+    kind: 'harm',
+    description: 'mirror leak (trip switch stale entry)',
+    threshold: '0건',
+    sql: `SELECT *
+FROM trip_metrics
+WHERE blob1 IN ('fire', 'advance') AND blob3 = 'reason:mirror-leak'
+  AND timestamp >= NOW() - INTERVAL ${W};`,
+  },
+  {
+    key: 'X6',
+    kind: 'harm',
+    description: 'late alarm (fire > arrival + 30s)',
+    threshold: '0건',
+    sql: `SELECT *
+FROM trip_metrics
+WHERE blob1 = 'fire' AND blob3 = 'reason:late' AND double1 > 30000
+  AND timestamp >= NOW() - INTERVAL ${W};`,
+  },
+  {
+    key: 'X7',
+    kind: 'harm',
+    description: 'env=unknown ≥ 5min trip',
+    threshold: '0건',
+    sql: `SELECT index1 AS token, MIN(timestamp) AS first_ts, MAX(timestamp) AS last_ts
+FROM trip_metrics
+WHERE blob4 = 'env:unknown' AND timestamp >= NOW() - INTERVAL ${W}
+GROUP BY index1 HAVING date_diff('minute', MIN(timestamp), MAX(timestamp)) >= 5;`,
+  },
+  {
+    key: 'X8',
+    kind: 'harm',
+    description: 'trip 6h+ residual',
+    threshold: '0건',
+    sql: `SELECT index1 AS token,
+  date_diff('hour', MIN(timestamp), MAX(timestamp)) AS duration_h
+FROM trip_metrics
+WHERE timestamp >= NOW() - INTERVAL ${W}
+GROUP BY index1 HAVING duration_h >= 6;`,
+  },
+  {
+    key: 'X9',
+    kind: 'harm',
+    description: 'fire after app-kill',
+    threshold: '0건',
+    sql: `SELECT *
+FROM trip_metrics
+WHERE blob1 = 'fire' AND blob3 = 'reason:post-kill'
+  AND timestamp >= NOW() - INTERVAL ${W};`,
+  },
+  {
+    key: 'X10',
+    kind: 'harm',
+    description: 'fusion picker output != input',
+    threshold: '0건',
+    sql: `SELECT *
+FROM trip_metrics
+WHERE blob1 = 'suppress' AND blob3 = 'reason:fusion-mismatch'
+  AND timestamp >= NOW() - INTERVAL ${W};`,
+  },
+  {
+    key: 'X11',
+    kind: 'harm',
+    description: 'BG scheduled queue post-trip-end fire',
+    threshold: '0건',
+    sql: `SELECT *
+FROM trip_metrics
+WHERE blob1 = 'fire' AND blob3 = 'reason:post-trip-end'
+  AND timestamp >= NOW() - INTERVAL ${W};`,
+  },
+] as const;
+
+/**
+ * `{WINDOW}` placeholder를 INTERVAL 표현으로 치환한 실행용 SQL을 반환.
+ *
+ * @param entry  카탈로그 entry.
+ * @param window INTERVAL 표현 (예: `'1' DAY`, `'10' MINUTE`).
+ */
+export function renderQuery(entry: VxQueryEntry, window: string): string {
+  return entry.sql.split('{WINDOW}').join(window);
+}
+
+/**
+ * 카탈로그에서 key로 entry를 찾는다. 미존재 시 undefined.
+ */
+export function findQuery(key: VxKey): VxQueryEntry | undefined {
+  return VX_ACCEPTANCE_QUERIES.find((q) => q.key === key);
+}

--- a/docs/observability/alert-rules.md
+++ b/docs/observability/alert-rules.md
@@ -1,0 +1,100 @@
+# V/X Acceptance — Alert rules
+
+Phase 0 epic #1576 / P0-5 (#1581).
+
+`vx-acceptance-queries.md` 20 임계 위반 시 alert 발사 규칙. Sentry (X) + Slack (V) 2채널 분리.
+
+## 채널 매트릭스
+
+| 임계 종류 | 발사 조건                  | 채널                                   | 응답 SLA |
+| --------- | -------------------------- | -------------------------------------- | -------- |
+| X1~X11    | 위반 1건 발생              | Sentry issue + Slack `#alert-trip-x`   | 1h       |
+| V1~V9     | daily cron 임계 미달       | Slack `#alert-trip-v`                  | 24h      |
+
+## X 임계 — Sentry alert rule
+
+Sentry project: `subway-now-alarm-worker` (P0-2 #1584로 생성됨).
+
+각 X 임계에 대해 Sentry Issue Alert rule:
+
+```
+WHEN: A new issue is created
+IF: event.tags["acceptance"] equals "X1"  (또는 X2, X3, ...)
+THEN:
+  - Send notification to Slack channel #alert-trip-x
+  - Send notification to PagerDuty (선택)
+```
+
+발생 측 코드 (`backend/alarm-worker/src/queries/sentryReporters.ts` scaffold 참고):
+
+```ts
+Sentry.captureMessage(`X1: wrong-station alarm fired`, {
+  level: 'error',
+  tags: { acceptance: 'X1', tripToken: tokenPrefix },
+  extra: { stationId, env, staleMs },
+});
+```
+
+## V 임계 — Slack webhook (daily cron)
+
+Cloudflare Workers cron (`0 9 * * *` UTC = 18:00 KST) → 20개 V SQL 실행 → 임계 미달 시 Slack POST.
+
+```
+Slack webhook URL: SECRET (Workers env `SLACK_V_WEBHOOK`)
+Channel: #alert-trip-v
+Message format:
+  ":warning: V<N> acceptance breached"
+  "Threshold: <threshold>"
+  "Observed: <value> (window: 24h)"
+  "Dashboard: <URL>"
+```
+
+## 임계 일람표
+
+### V (daily, < 임계 시 alert)
+
+| 임계 | 측정값                                | 임계        |
+| ---- | ------------------------------------- | ----------- |
+| V1   | currentStation mismatch %             | < 1%        |
+| V2   | transfer-1-stop alarm count != 1 trip | 0건         |
+| V3   | destination-1-stop alarm count != 1   | 0건         |
+| V4   | station-passed drift                  | ≤ ±1        |
+| V5   | 자동 종료 trip %                      | ≥ 99%       |
+| V6   | SSoT mirror lag p95                   | < 5000ms    |
+| V7   | 지하 trip advance %                   | ≥ 90%       |
+| V8a  | /position rate / 10min trip           | ≤ 100건     |
+| V8b  | /trips rate / 10min trip              | ≤ 10건      |
+| V8c  | stationary cycle rate vs moving       | < 50%       |
+| V9   | suppress rate / hour / trip           | ≤ 30건      |
+
+### X (즉시, count > 0 시 alert)
+
+| 임계 | 측정값                              | 임계 |
+| ---- | ----------------------------------- | ---- |
+| X1   | wrong-station alarm                 | 0건  |
+| X2   | duplicate alarm (trip+station 2회)  | 0건  |
+| X3   | stale alarm (lastAdvance > 5min)    | 0건  |
+| X4   | spam suppress > 10건/trip           | 0건  |
+| X5   | mirror leak                         | 0건  |
+| X6   | late alarm (도착 + 30s 이후)        | 0건  |
+| X7   | env=unknown ≥ 5min trip             | 0건  |
+| X8   | trip 6h+ 잔존                       | 0건  |
+| X9   | app kill 후 fire                    | 0건  |
+| X10  | fusion picker mismatch              | 0건  |
+| X11  | BG scheduled queue post-trip-end fire | 0건  |
+
+## Slack webhook setup
+
+1. Slack workspace → `Apps` → `Incoming Webhooks` 설치
+2. 채널 `#alert-trip-x`, `#alert-trip-v` 2개 생성 후 각각 webhook URL 발급
+3. Cloudflare Workers secret:
+   ```
+   cd backend/alarm-worker
+   wrangler secret put SLACK_X_WEBHOOK
+   wrangler secret put SLACK_V_WEBHOOK
+   ```
+4. `dailyVCheck` cron handler에서 fetch POST.
+
+## Escalation
+
+X1/X9 (사용자에게 직접 가치 손상) 5건 누적 또는 1시간 내 3건 → PagerDuty escalation (Sentry rule로 wire).

--- a/docs/observability/dashboard-setup.md
+++ b/docs/observability/dashboard-setup.md
@@ -1,0 +1,91 @@
+# V/X Acceptance Dashboard — 사용자 setup guide
+
+Phase 0 epic #1576 / P0-5 (#1581).
+
+`vx-acceptance-queries.md`의 20개 SQL을 Cloudflare Analytics Engine + Grafana(또는 Cloudflare 내장 dashboard)에 wire 하는 절차.
+
+## Prerequisite (이미 머지됨)
+
+- P0-1 #1577 — Analytics Engine binding (`TRIP_METRICS` → dataset `trip_metrics`) 적재 활성
+- P0-2 #1584 — Sentry binding (alert destination)
+- P0-3 #1586 — R2 archive (장기 보관)
+
+## 옵션 A — Cloudflare 내장 Workers Analytics dashboard (권장 — fastest)
+
+1. Cloudflare dashboard 로그인 → `Workers & Pages` → `subway-now-alarm-worker` 선택
+2. 좌측 `Analytics` 탭 → `Analytics Engine` → `trip_metrics` dataset 선택
+3. `Add Query` → `vx-acceptance-queries.md`의 SQL을 각각 붙여넣기
+4. 각 query를 `Save as widget` → dashboard에 추가
+5. 임계 위반 위젯에는 `Threshold` 설정 (color rule)
+
+장점: 별도 인프라 X, 무료. 단점: chart 옵션 제한, custom alerting 제한.
+
+## 옵션 B — Grafana + Cloudflare Analytics SQL API
+
+### 1. SQL API token 발급
+
+```
+Cloudflare Dashboard → My Profile → API Tokens → Create Token
+Template: "Custom token"
+Permissions:
+  - Account → Account Analytics → Read
+  - Account → Workers Scripts → Read
+Account Resources: include subway-now account
+```
+
+발급된 토큰을 `CF_ANALYTICS_TOKEN`으로 저장.
+
+### 2. Grafana datasource 설정
+
+```
+Grafana → Configuration → Data Sources → Add data source
+Type: Infinity (Generic REST API)  또는  JSON API plugin
+URL: https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/analytics_engine/sql
+Method: POST
+Header: Authorization: Bearer ${CF_ANALYTICS_TOKEN}
+Body: Plain text (SQL query per panel)
+```
+
+`{ACCOUNT_ID}`는 Cloudflare dashboard → 우측 sidebar에서 확인.
+
+### 3. Dashboard JSON import
+
+`vx-acceptance-queries.md`의 20개 query 각각을 Grafana panel로 추가:
+
+- V1~V9 → Stat / Time series panel + Threshold (green/yellow/red)
+- X1~X11 → Stat panel (count) + Alert rule (count > 0 → alert)
+
+### 4. Alert channel 연결
+
+Grafana → Alerting → Contact points → Add:
+- Slack webhook URL (예: `#alert-trip` channel)
+- Sentry webhook (P0-2에서 발급한 Sentry project DSN endpoint)
+
+`alert-rules.md` 참고하여 각 X 임계에 alert rule 적용.
+
+## 옵션 C — Cloudflare Workers cron (V 임계만, 일일 alert)
+
+X는 즉시 alert 필요 → Sentry/Slack webhook. V는 일일 1회 cron이면 충분.
+
+`backend/alarm-worker/wrangler.toml`에 cron trigger 추가:
+
+```toml
+[triggers]
+crons = ["0 9 * * *"]  # 매일 09:00 UTC (KST 18:00)
+```
+
+`backend/alarm-worker/src/queries/dailyVCheck.ts` 신설 (본 PR scaffold) — 20개 SQL 실행 → 임계 위반 시 Slack POST.
+
+> 본 PR은 scaffold만. 실제 cron handler 구현은 P0-5 close 전 follow-up commit 또는 별도 sub-PR.
+
+## Acceptance (사용자가 dashboard 구축 후 확인)
+
+- [ ] Dashboard URL 1개 활성 + V1~V9 / X1~X11 패널 20개 표시
+- [ ] X1 패널에 test 데이터 1건 inject → Slack alert 수신 확인
+- [ ] V7 패널이 지하 trip evidence 1건 후 ≥ 90% advance % 표시
+- [ ] Dashboard URL을 `docs/observability/dashboard-url.md` (별도 PR) 또는 README에 공유
+
+## 보안
+
+- `CF_ANALYTICS_TOKEN`은 Grafana / 1Password에만 저장. repo에 커밋 금지.
+- Slack webhook URL도 동일 (Cloudflare Workers secrets 또는 Grafana secrets).

--- a/docs/observability/vx-acceptance-queries.md
+++ b/docs/observability/vx-acceptance-queries.md
@@ -1,0 +1,343 @@
+# V/X Acceptance — Cloudflare Analytics Engine SQL queries
+
+Phase 0 측정 인프라 (Epic #1576) sub-task P0-5 (#1581).
+
+ADR-017 / ADR-016 가치(V) · 손상(X) acceptance 20개 임계를 `trip_metrics` Analytics Engine dataset에서 SQL로 직접 측정하기 위한 query 카탈로그.
+
+데이터 source: `backend/alarm-worker/src/analytics.ts` (`writeMetric`) — 6 event type을 적재.
+
+| Event type          | blobs                                                  | doubles                                          | index            |
+| ------------------- | ------------------------------------------------------ | ------------------------------------------------ | ---------------- |
+| `advance`           | `[eventType, station:?, reason:?, env:?]`              | `[staleMs?, hopIndex?, motionConfidence?]`       | `tokenPrefix(8)` |
+| `fire`              | `[eventType, station:?, reason:?, env:?]`              | `[staleMs?, hopIndex?, motionConfidence?]`       | `tokenPrefix(8)` |
+| `suppress`          | `[eventType, station:?, reason:?, env:?]`              | `[staleMs?, hopIndex?, motionConfidence?]`       | `tokenPrefix(8)` |
+| `motion-transition` | `[eventType, reason:?, env:?]`                         | `[motionConfidence?]`                            | `tokenPrefix(8)` |
+| `position-upload`   | `[eventType, env:?]`                                   | `[]`                                             | `tokenPrefix(8)` |
+| `trip-mutation`     | `[eventType, reason:?]`                                | `[hopIndex?]`                                    | `tokenPrefix(8)` |
+
+> Cloudflare Analytics Engine SQL ref: <https://developers.cloudflare.com/analytics/analytics-engine/sql-api/>. Blobs 는 `blob1..blob20`, doubles `double1..double20`, index `index1`로 노출된다. dataset 이름 = `trip_metrics`.
+
+## 운영 컨벤션
+
+- 모든 query는 `WHERE timestamp >= NOW() - INTERVAL '7' DAY` 기본 window. dashboard에서 1h / 1d / 7d 토글.
+- `tokenPrefix(8)` 충돌 확률 = trip ~수천개 동시 추적 시 무시 가능. 정확 trip-level 집계는 `index1`로 그룹.
+- V 임계 = 일일 1회 cron이 SQL 실행 → 미달 시 Slack alert (`alert-rules.md`).
+- X 임계 = 1건이라도 발생하면 즉시 Sentry alert (P0-2 cross-cut).
+
+## V — 가치 실현 (daily 집계)
+
+### V1. currentStation == SSoT mismatch %
+
+```sql
+-- mismatch %는 advance 시점의 device-vs-SSoT 비교 결과를 reason 으로 적재
+SELECT
+  (SUM(CASE WHEN blob3 = 'reason:ssot-mismatch' THEN 1 ELSE 0 END) * 100.0) / COUNT(*) AS mismatch_pct
+FROM trip_metrics
+WHERE blob1 = 'advance'
+  AND timestamp >= NOW() - INTERVAL '1' DAY;
+-- 임계: < 1%
+```
+
+### V2. transfer-1-stop alarm count / hop≥2 trip
+
+```sql
+WITH transfer_trips AS (
+  SELECT index1 AS token
+  FROM trip_metrics
+  WHERE blob1 = 'trip-mutation' AND blob2 = 'reason:route-recompute'
+    AND timestamp >= NOW() - INTERVAL '1' DAY
+  GROUP BY index1
+  HAVING MAX(double2) >= 2  -- hopIndex 최대 ≥ 2
+)
+SELECT
+  index1 AS token,
+  COUNT(*) AS alarm_count
+FROM trip_metrics
+WHERE blob1 = 'fire'
+  AND blob3 = 'reason:transfer-1-stop'
+  AND index1 IN (SELECT token FROM transfer_trips)
+  AND timestamp >= NOW() - INTERVAL '1' DAY
+GROUP BY index1
+HAVING alarm_count != 1;  -- 임계: 위반 trip count == 0
+```
+
+### V3. destination-1-stop alarm count / hop≥1 trip
+
+```sql
+WITH dest_trips AS (
+  SELECT DISTINCT index1 AS token
+  FROM trip_metrics
+  WHERE blob1 = 'trip-mutation'
+    AND timestamp >= NOW() - INTERVAL '1' DAY
+)
+SELECT
+  index1 AS token,
+  COUNT(*) AS alarm_count
+FROM trip_metrics
+WHERE blob1 = 'fire'
+  AND blob3 = 'reason:destination-1-stop'
+  AND index1 IN (SELECT token FROM dest_trips)
+  AND timestamp >= NOW() - INTERVAL '1' DAY
+GROUP BY index1
+HAVING alarm_count != 1;  -- 임계: 위반 trip count == 0
+```
+
+### V4. station-passed count == SSoT.passedStations.length
+
+```sql
+SELECT
+  index1 AS token,
+  COUNT(*) AS passed_fire_count
+FROM trip_metrics
+WHERE blob1 = 'fire'
+  AND blob3 = 'reason:station-passed'
+  AND timestamp >= NOW() - INTERVAL '1' DAY
+GROUP BY index1;
+-- 임계: 동일 trip의 `advance` count와 ±1 이내 (drift 검증은 dashboard JOIN)
+```
+
+### V5. 자동 종료 trip %
+
+```sql
+SELECT
+  blob3 AS end_reason,
+  COUNT(*) AS trip_count
+FROM trip_metrics
+WHERE blob1 = 'trip-mutation'
+  AND blob2 = 'reason:trip-ended'
+  AND timestamp >= NOW() - INTERVAL '7' DAY
+GROUP BY blob3;
+-- 임계: end_reason ∈ {arrival, backstop-6h, user} 합계 / 전체 ≥ 99%
+```
+
+### V6. SSoT mirror lag histogram (ms)
+
+```sql
+SELECT
+  quantile(0.50)(double1) AS p50_ms,
+  quantile(0.95)(double1) AS p95_ms,
+  quantile(0.99)(double1) AS p99_ms
+FROM trip_metrics
+WHERE blob1 = 'advance'
+  AND double1 IS NOT NULL  -- staleMs
+  AND timestamp >= NOW() - INTERVAL '1' DAY;
+-- 임계: p95 < 5000ms
+```
+
+### V7. 지하 trip advance % (≥ 90%)
+
+```sql
+WITH underground_trips AS (
+  SELECT DISTINCT index1
+  FROM trip_metrics
+  WHERE blob4 = 'env:underground'
+    AND timestamp >= NOW() - INTERVAL '1' DAY
+)
+SELECT
+  (SUM(CASE WHEN blob1 = 'advance' THEN 1 ELSE 0 END) * 100.0) /
+  NULLIF(SUM(CASE WHEN blob1 IN ('advance', 'suppress') THEN 1 ELSE 0 END), 0) AS advance_pct
+FROM trip_metrics
+WHERE index1 IN (SELECT index1 FROM underground_trips)
+  AND blob4 = 'env:underground'
+  AND timestamp >= NOW() - INTERVAL '1' DAY;
+-- 임계: ≥ 90%
+```
+
+### V8a. `/position` rate (per 10min trip)
+
+```sql
+SELECT
+  index1 AS token,
+  COUNT(*) AS upload_count
+FROM trip_metrics
+WHERE blob1 = 'position-upload'
+  AND timestamp >= NOW() - INTERVAL '10' MINUTE
+GROUP BY index1
+HAVING upload_count > 100;  -- 임계: trip 당 ≤ 100건/10분 (위반 trip == 0)
+```
+
+### V8b. `/trips` rate (per 10min trip)
+
+```sql
+SELECT
+  index1 AS token,
+  COUNT(*) AS mutation_count
+FROM trip_metrics
+WHERE blob1 = 'trip-mutation'
+  AND timestamp >= NOW() - INTERVAL '10' MINUTE
+GROUP BY index1
+HAVING mutation_count > 10;  -- 임계: trip 당 ≤ 10건/10분
+```
+
+### V8c. Raw signal cycle rate (정지/이동 분리)
+
+```sql
+SELECT
+  blob2 AS reason,  -- moving / stationary / unknown
+  COUNT(*) / 60.0 AS rate_per_minute
+FROM trip_metrics
+WHERE blob1 = 'motion-transition'
+  AND timestamp >= NOW() - INTERVAL '1' HOUR
+GROUP BY blob2;
+-- 임계: stationary 상태에서 cycle rate < moving 상태의 50% (배터리 mitigation)
+```
+
+### V9. suppress event rate (per hour per trip)
+
+```sql
+SELECT
+  index1 AS token,
+  COUNT(*) AS suppress_count
+FROM trip_metrics
+WHERE blob1 = 'suppress'
+  AND timestamp >= NOW() - INTERVAL '1' HOUR
+GROUP BY index1
+HAVING suppress_count > 30;  -- 임계: trip 당 ≤ 30/시간
+```
+
+## X — 가치 손상 (1건 발생 → 즉시 alert)
+
+### X1. wrong-station alarm
+
+```sql
+SELECT *
+FROM trip_metrics
+WHERE blob1 = 'fire'
+  AND blob3 = 'reason:wrong-station'
+  AND timestamp >= NOW() - INTERVAL '1' DAY;
+-- 임계: count == 0
+```
+
+### X2. duplicate alarm (같은 trip+station에 2회 fire)
+
+```sql
+SELECT
+  index1 AS token,
+  blob2 AS station,
+  COUNT(*) AS fire_count
+FROM trip_metrics
+WHERE blob1 = 'fire'
+  AND timestamp >= NOW() - INTERVAL '1' DAY
+GROUP BY index1, blob2
+HAVING fire_count > 1;
+-- 임계: 위반 row 수 == 0
+```
+
+### X3. stale alarm (lastAdvance > 5min 시점에 fire)
+
+```sql
+SELECT *
+FROM trip_metrics
+WHERE blob1 = 'fire'
+  AND double1 > 300000  -- staleMs > 5min
+  AND timestamp >= NOW() - INTERVAL '1' DAY;
+-- 임계: count == 0
+```
+
+### X4. spam suppress (> 10건/trip)
+
+```sql
+SELECT
+  index1 AS token,
+  COUNT(*) AS suppress_count
+FROM trip_metrics
+WHERE blob1 = 'suppress'
+  AND timestamp >= NOW() - INTERVAL '10' MINUTE
+GROUP BY index1
+HAVING suppress_count > 10;
+-- 임계: 위반 trip count == 0
+```
+
+### X5. mirror leak (trip switch 직후 stale entry로 fire/advance)
+
+```sql
+SELECT *
+FROM trip_metrics
+WHERE blob1 IN ('fire', 'advance')
+  AND blob3 = 'reason:mirror-leak'
+  AND timestamp >= NOW() - INTERVAL '1' DAY;
+-- 임계: count == 0
+```
+
+### X6. late alarm (fire 시각 > 실제 도착 + 30s)
+
+```sql
+SELECT *
+FROM trip_metrics
+WHERE blob1 = 'fire'
+  AND blob3 = 'reason:late'
+  AND double1 > 30000  -- 도착 대비 지연 ms
+  AND timestamp >= NOW() - INTERVAL '1' DAY;
+-- 임계: count == 0
+```
+
+### X7. env=unknown ≥ 5min trip
+
+```sql
+WITH unknown_runs AS (
+  SELECT
+    index1 AS token,
+    MIN(timestamp) AS start_ts,
+    MAX(timestamp) AS end_ts
+  FROM trip_metrics
+  WHERE blob4 = 'env:unknown'
+    AND timestamp >= NOW() - INTERVAL '1' DAY
+  GROUP BY index1
+)
+SELECT *
+FROM unknown_runs
+WHERE date_diff('minute', start_ts, end_ts) >= 5;
+-- 임계: 위반 trip count == 0
+```
+
+### X8. trip 6h+ 잔존
+
+```sql
+SELECT
+  index1 AS token,
+  MIN(timestamp) AS first_seen,
+  MAX(timestamp) AS last_seen,
+  date_diff('hour', MIN(timestamp), MAX(timestamp)) AS duration_h
+FROM trip_metrics
+WHERE timestamp >= NOW() - INTERVAL '12' HOUR
+GROUP BY index1
+HAVING duration_h >= 6;
+-- 임계: 위반 trip count == 0 (자동 backstop은 V5 end_reason='backstop-6h'로 잡힘)
+```
+
+### X9. app kill 후 fire (사용자 의도 외)
+
+```sql
+SELECT *
+FROM trip_metrics
+WHERE blob1 = 'fire'
+  AND blob3 = 'reason:post-kill'
+  AND timestamp >= NOW() - INTERVAL '1' DAY;
+-- 임계: count == 0
+```
+
+### X10. fusion picker output ≠ input
+
+```sql
+SELECT *
+FROM trip_metrics
+WHERE blob1 = 'suppress'
+  AND blob3 = 'reason:fusion-mismatch'
+  AND timestamp >= NOW() - INTERVAL '1' DAY;
+-- 임계: count == 0
+```
+
+### X11. BG scheduled queue 잔존 fire (trip 종료 후)
+
+```sql
+SELECT *
+FROM trip_metrics
+WHERE blob1 = 'fire'
+  AND blob3 = 'reason:post-trip-end'
+  AND timestamp >= NOW() - INTERVAL '1' DAY;
+-- 임계: count == 0
+```
+
+## 향후 작업 (사용자 manual)
+
+본 PR은 SQL 카탈로그 + scaffold만. 실제 dashboard 구축은 `dashboard-setup.md` 참고.


### PR DESCRIPTION
Closes #1581

Phase 0 측정 인프라 epic (#1576) sub-task P0-5. **본 PR은 SQL 카탈로그 + setup guide + scaffold만** — 실제 dashboard 구축(Cloudflare 내장 또는 Grafana)은 사용자 manual.

## Summary

- `docs/observability/vx-acceptance-queries.md` — V1~V9 + X1~X11 = **20 임계** SQL (Cloudflare Analytics Engine 문법). `trip_metrics` dataset(P0-1 #1577 binding) 기준.
- `docs/observability/dashboard-setup.md` — 3개 옵션: (A) Cloudflare 내장 Analytics dashboard / (B) Grafana + Cloudflare SQL API / (C) Workers cron + Slack webhook. API token 발급 + datasource 설정 + cron trigger 절차 포함.
- `docs/observability/alert-rules.md` — Sentry(X 즉시) + Slack(V daily) 분리 routing + 임계 일람표.
- `backend/alarm-worker/src/queries/vxAcceptanceQueries.ts` — runtime SQL 카탈로그 (`VX_ACCEPTANCE_QUERIES`) + `renderQuery({WINDOW})` helper + `findQuery(key)`. daily cron handler가 이 카탈로그를 import 해서 사용할 수 있도록 scaffold.
- 29 vitest 단위 테스트 — 카탈로그 22 entry shape + SELECT/FROM/`trip_metrics`/`{WINDOW}` 필수 절 + V/X kind 분류 + placeholder 치환.

## Wire-completion 5단

1. **Orphan 없음** — backend 모듈, 루트 ts-prune 범위(`src/**`) 밖. 카탈로그 consumer(daily cron handler)는 follow-up commit 또는 별도 sub-PR.
2. **V/X dashboard** — 본 PR이 **dashboard 자체를 가능케 하는 데이터 source**. 시각화는 사용자 manual(setup guide 참조).
3. **의존 PR** — P0-1 #1577 (Analytics Engine binding) / P0-2 #1584 (Sentry) / P0-3 #1586 (R2 archive) — 모두 머지 완료.
4. **측정 plan** — 사용자가 dashboard 구축 후 X1 테스트 inject → Slack alert 수신 확인 (alert-rules.md acceptance).
5. **Device verify** — N/A. docs + backend scaffold only (vitest unit).

## Test plan

- [x] `cd backend/alarm-worker && npx vitest run` — 1732/1732 pass (신규 29 포함)
- [x] `cd backend/alarm-worker && npm run type-check` — 0 error
- [x] `npm run type-check` (root) — 0 error
- [ ] 사용자: dashboard 구축 (옵션 A/B/C 중 선택) — `dashboard-setup.md` 절차

## 다음 액션 (사용자)

1. `dashboard-setup.md` 옵션 A (Cloudflare 내장) 5분 setup → 20개 widget add.
2. Slack `#alert-trip-x`, `#alert-trip-v` channel + webhook 발급.
3. (선택) cron handler 구현 follow-up sub-PR — 본 카탈로그 `VX_ACCEPTANCE_QUERIES` import 해서 daily 실행.
4. `dashboard URL`을 README 또는 `docs/observability/dashboard-url.md`(별도 PR)에 공유 후 #1581 close.