### PR TITLE
feat(#1574): 4-signal underground 합의 (Barometer + Cellular, BG WiFi 갭 해소)

### DIFF
--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -15,6 +15,7 @@ import { pushRawSignal } from '../../observability/utils/rawSignalBuffer';
 import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
 import { pushEstimatorEntry } from '../../route/utils/estimatorDebugBuffer';
 import { useNearestStation } from './useNearestStation';
+import { useCellularTech } from './useCellularTech';
 import { useArrivalInfo } from '../../arrival/hooks/useArrivalInfo';
 import { useTrainPositions } from '../../route/hooks/useTrainPositions';
 import { useRouteProgress } from '../../route/hooks/useRouteProgress';
@@ -374,6 +375,11 @@ export function useFusedNearestStation(
   // #733 — 위치 이력 기반 정적 판정. shouldDowngradeFusion이 speed=null일 때 fallback으로 사용.
   // useNearestStation의 userLocation 변경마다 자동 누적/판정.
   const positionStability = usePositionStability(gps.userLocation);
+
+  // #1574 (ADR-017 T11) — CTRadioAccessTechnology 환경 vote. iOS BG에서도 동작
+  // (CTServiceRadioAccessTechnologyDidChangeNotification observer). underground SSOT 4-signal
+  // 합의의 환경-확정 vote로 사용. 미지원(Android/jest/web) 시 'unknown' 고정 → vote 미투표.
+  const cellularEnvironmentVote = useCellularTech();
 
   // #1568 (T8b, Epic ADR-017 #1553) — backend SSoT mirror 폴링.
   //
@@ -864,6 +870,10 @@ export function useFusedNearestStation(
     wifiStation: wifiStationResolved?.station ?? null,
     positionTrainResult,
     arrival: undergroundArrival,
+    // #1574 (ADR-017 T11) — BG WiFi 갭 해소: barometer-stop + cellular env vote 보강.
+    // barometerSignal.stop=undefined(warmup) / cellular 'unknown'은 vote 미투표.
+    barometerStop: barometerSignal?.stop,
+    cellularEnvironmentVote,
   });
   const environment: Environment = inferEnvironment({
     subsurface: barometerSubsurface,

--- a/src/features/nearest-station/utils/__tests__/undergroundSSotConsensus.test.ts
+++ b/src/features/nearest-station/utils/__tests__/undergroundSSotConsensus.test.ts
@@ -1,3 +1,13 @@
+/**
+ * #1418 — 원형 (WiFi+Arrival / Position-Train+Arrival) 단일 pair 합의.
+ * #1574 (ADR-017 T11) — 4-signal 2-of-N 합의로 확장:
+ *   station pair: wifi+arrival, position+arrival
+ *   env vote: barometer-stop, cellular-underground
+ *   - station pair ≥ 1 + (station pair + env vote) ≥ 2 통과 시 채택
+ *   - cellular surface vote → reject (환경 확정 모순)
+ *   - station 우선순위: position > wifi
+ */
+
 import { undergroundSSOTConsensus } from '../undergroundSSotConsensus';
 import { MOCK_STATIONS, makeArrivalInfo, makeNearestResult } from '../../../../testUtils/fixtures';
 import type { StationArrival } from '../../../../shared/types/arrival';
@@ -6,40 +16,53 @@ function makeArrival(rows: ReturnType<typeof makeArrivalInfo>[]): StationArrival
   return { up: rows, down: [], source: 'realtime' };
 }
 
-describe('undergroundSSOTConsensus', () => {
-  it('WiFi + Arrival arvlCd 정착 합의 시 WiFi 우선 채택', () => {
-    const wifi = MOCK_STATIONS.gangnam;
-    const positionTrain = makeNearestResult('chungmuro', 0.05);
-    const arrival = makeArrival([
-      makeArrivalInfo({ destination: '', arrivalSeconds: 0, line: '2', arrivalCode: 1, trainCode: 'W1' }),
-    ]);
-    const result = undergroundSSOTConsensus({ wifiStation: wifi, positionTrainResult: positionTrain, arrival });
-    expect(result).toEqual({ station: wifi, trainCode: 'W1' });
+const arrivalLine2 = makeArrival([
+  makeArrivalInfo({ destination: '', arrivalSeconds: 0, line: '2', arrivalCode: 1, trainCode: 'T1' }),
+]);
+const arrivalLine3 = makeArrival([
+  makeArrivalInfo({ destination: '', arrivalSeconds: 0, line: '3', arrivalCode: 2, trainCode: 'P1' }),
+]);
+
+describe('undergroundSSOTConsensus — base behavior (#1418)', () => {
+  it('WiFi + Position 둘 다 매칭 시 2-of-N pass, position-train station 우선', () => {
+    const wifi = MOCK_STATIONS.gangnam; // line=2
+    const positionTrain = makeNearestResult('gangnam', 0.05); // line=2 (same line for both to match arrival)
+    const result = undergroundSSOTConsensus({
+      wifiStation: wifi,
+      positionTrainResult: positionTrain,
+      arrival: arrivalLine2,
+    });
+    expect(result?.station.id).toBe(positionTrain.station.id);
+    expect(result?.trainCode).toBe('T1');
   });
 
-  it('WiFi 없고 Position-Train + Arrival 합의', () => {
-    const positionTrain = makeNearestResult('chungmuro', 0.05);
-    const arrival = makeArrival([
-      makeArrivalInfo({ destination: '', arrivalSeconds: 0, line: '3', arrivalCode: 2, trainCode: 'P1' }),
-    ]);
-    const result = undergroundSSOTConsensus({ wifiStation: null, positionTrainResult: positionTrain, arrival });
-    expect(result).toEqual({ station: positionTrain.station, trainCode: 'P1' });
+  it('WiFi만 매칭, position 호선 불일치 → 1-of-N → null (보강 필요)', () => {
+    const wifi = MOCK_STATIONS.gangnam; // line=2
+    const positionTrain = makeNearestResult('chungmuro', 0.05); // line=3, arrival은 line=2
+    expect(
+      undergroundSSOTConsensus({
+        wifiStation: wifi,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine2,
+      }),
+    ).toBeNull();
   });
 
-  it('WiFi 있지만 line 매칭 arrival 없음 → Position-Train으로 fallback', () => {
-    const wifi = MOCK_STATIONS.gangnam;
+  it('Position-Train만 (WiFi nil — BG 시나리오) → 1-of-N → null (env vote 보강 필요)', () => {
     const positionTrain = makeNearestResult('chungmuro', 0.05);
-    const arrival = makeArrival([
-      makeArrivalInfo({ destination: '', arrivalSeconds: 0, line: '3', arrivalCode: 1, trainCode: 'P2' }),
-    ]);
-    const result = undergroundSSOTConsensus({ wifiStation: wifi, positionTrainResult: positionTrain, arrival });
-    expect(result?.trainCode).toBe('P2');
-    expect(result?.station).toEqual(positionTrain.station);
+    expect(
+      undergroundSSOTConsensus({
+        wifiStation: null,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine3,
+      }),
+    ).toBeNull();
   });
 
   it('둘 다 null이면 합의 미성립', () => {
-    const arrival = makeArrival([makeArrivalInfo({ destination: '', arrivalSeconds: 0, line: '2', arrivalCode: 1 })]);
-    expect(undergroundSSOTConsensus({ wifiStation: null, positionTrainResult: null, arrival })).toBeNull();
+    expect(
+      undergroundSSOTConsensus({ wifiStation: null, positionTrainResult: null, arrival: arrivalLine2 }),
+    ).toBeNull();
   });
 
   it('arrival null이면 합의 미성립', () => {
@@ -52,30 +75,154 @@ describe('undergroundSSOTConsensus', () => {
     ).toBeNull();
   });
 
-  it.each([0, 4, 99, -1])('비정착 arvlCd=%i는 합의 미성립', (arvlCd) => {
-    const arrival = makeArrival([
+  it.each([0, 4, 99, -1])('비정착 arvlCd=%i는 합의 미성립 (station pair 0)', (arvlCd) => {
+    const arrivalMoving = makeArrival([
       makeArrivalInfo({ destination: '', arrivalSeconds: 0, line: '2', arrivalCode: arvlCd }),
     ]);
     expect(
       undergroundSSOTConsensus({
         wifiStation: MOCK_STATIONS.gangnam,
-        positionTrainResult: null,
-        arrival,
+        positionTrainResult: makeNearestResult('gangnam', 0.05),
+        arrival: arrivalMoving,
+        barometerStop: true,
+        cellularEnvironmentVote: 'underground',
       }),
     ).toBeNull();
   });
 
   it('down 슬롯 arrival도 합의 인식', () => {
-    const arrival: StationArrival = {
+    const arrivalDown: StationArrival = {
       up: [],
       down: [makeArrivalInfo({ destination: '', arrivalSeconds: 0, line: '2', arrivalCode: 5, trainCode: 'D1' })],
       source: 'realtime',
     };
     const result = undergroundSSOTConsensus({
       wifiStation: MOCK_STATIONS.gangnam,
-      positionTrainResult: null,
-      arrival,
+      positionTrainResult: makeNearestResult('gangnam', 0.05),
+      arrival: arrivalDown,
     });
     expect(result?.trainCode).toBe('D1');
+  });
+});
+
+describe('undergroundSSOTConsensus — 4-signal 2-of-N (#1574 ADR-017 T11)', () => {
+  it('Position + barometer-stop (BG WiFi nil) → 2-of-N pass', () => {
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    const result = undergroundSSOTConsensus({
+      wifiStation: null, // BG에서 NEHotspotNetwork.fetchCurrent nil
+      positionTrainResult: positionTrain,
+      arrival: arrivalLine2,
+      barometerStop: true,
+    });
+    expect(result?.station.id).toBe(positionTrain.station.id);
+    expect(result?.trainCode).toBe('T1');
+  });
+
+  it('Position + cellular-underground (BG) → 2-of-N pass', () => {
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    const result = undergroundSSOTConsensus({
+      wifiStation: null,
+      positionTrainResult: positionTrain,
+      arrival: arrivalLine2,
+      cellularEnvironmentVote: 'underground',
+    });
+    expect(result?.station.id).toBe(positionTrain.station.id);
+  });
+
+  it('WiFi + barometer-stop → 2-of-N pass', () => {
+    const wifi = MOCK_STATIONS.gangnam;
+    const result = undergroundSSOTConsensus({
+      wifiStation: wifi,
+      positionTrainResult: null,
+      arrival: arrivalLine2,
+      barometerStop: true,
+    });
+    expect(result?.station.id).toBe(wifi.id);
+    expect(result?.trainCode).toBe('T1');
+  });
+
+  it('Cellular surface → underground SSOT reject (환경 확정 모순)', () => {
+    expect(
+      undergroundSSOTConsensus({
+        wifiStation: MOCK_STATIONS.gangnam,
+        positionTrainResult: makeNearestResult('gangnam', 0.05),
+        arrival: arrivalLine2,
+        barometerStop: true,
+        cellularEnvironmentVote: 'surface',
+      }),
+    ).toBeNull();
+  });
+
+  it('FG 4-of-4 (wifi + position + barometer + cellular-underground) → pass, position 우선', () => {
+    const wifi = MOCK_STATIONS.gangnam;
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    const result = undergroundSSOTConsensus({
+      wifiStation: wifi,
+      positionTrainResult: positionTrain,
+      arrival: arrivalLine2,
+      barometerStop: true,
+      cellularEnvironmentVote: 'underground',
+    });
+    expect(result?.station.id).toBe(positionTrain.station.id);
+  });
+
+  it('barometer + cellular only (station pair 0) → null (env vote만으로는 station 채택 불가)', () => {
+    expect(
+      undergroundSSOTConsensus({
+        wifiStation: null,
+        positionTrainResult: null,
+        arrival: arrivalLine2,
+        barometerStop: true,
+        cellularEnvironmentVote: 'underground',
+      }),
+    ).toBeNull();
+  });
+
+  it('barometer-stop=false → vote 미투표 (1-of-N)', () => {
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    expect(
+      undergroundSSOTConsensus({
+        wifiStation: null,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine2,
+        barometerStop: false,
+      }),
+    ).toBeNull();
+  });
+
+  it('cellular unknown → vote 미투표 (1-of-N)', () => {
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    expect(
+      undergroundSSOTConsensus({
+        wifiStation: null,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine2,
+        cellularEnvironmentVote: 'unknown',
+      }),
+    ).toBeNull();
+  });
+
+  it('barometer/cellular undefined (warmup/미지원) → fallback to 2-station-pair mode', () => {
+    // wifi + position 둘 다 매칭 → 2-of-N pass (env vote 없이도)
+    const wifi = MOCK_STATIONS.gangnam;
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    const result = undergroundSSOTConsensus({
+      wifiStation: wifi,
+      positionTrainResult: positionTrain,
+      arrival: arrivalLine2,
+    });
+    expect(result?.trainCode).toBe('T1');
+  });
+
+  it('Position 호선 매칭, barometer-stop=true → 2-of-N pass (cellular unknown 무관)', () => {
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    const result = undergroundSSOTConsensus({
+      wifiStation: null,
+      positionTrainResult: positionTrain,
+      arrival: arrivalLine2,
+      barometerStop: true,
+      cellularEnvironmentVote: 'unknown',
+    });
+    expect(result?.station.id).toBe(positionTrain.station.id);
   });
 });

--- a/src/features/nearest-station/utils/undergroundSSotConsensus.ts
+++ b/src/features/nearest-station/utils/undergroundSSotConsensus.ts
@@ -3,26 +3,64 @@
  *
  * #1418 — 지하 GPS dead zone에서 WiFi SSID 또는 realtimePosition train 신호 + Arrival arvlCd 합의.
  *
- * 합의 경로 (둘 중 하나라도 만족):
- *   - WiFi+Arrival: `wifiStation` 비-null + 매칭 arrival row `arvlCd ∈ {1,2,3,5}`
- *   - Position-Train+Arrival: `positionTrainResult` 비-null + 매칭 arrival row 동일 조건
+ * #1574 (ADR-017 T11) — BG WiFi 갭 해소를 위한 4-signal 합의로 확장.
+ *   - iOS BG에서 `NEHotspotNetwork.fetchCurrent`는 nil → WiFi pair 사실상 불가
+ *   - Position-Train+Arrival 1-input에 의존 → 1 input 실패 시 합의 붕괴
+ *   - Barometer `stop`(dP/dt 정착) + Cellular `underground` vote를 환경-확정 vote로 추가
  *
- * 두 신호 모두 활성이면 WiFi 우선 (SSID 매칭은 지하 직접 신호, position-train은 API 추정).
+ * 합의 구조 — station-providing pair + environment-confirming vote:
+ *   - Station pair (station 채택 가능, arrival 호선 매칭 필수):
+ *       (a) WiFi SSID    + Arrival  (FG only — BG에선 SSID nil)
+ *       (b) Position-Train + Arrival (FG/BG)
+ *   - Environment vote (station 미제공, 환경 확정만):
+ *       (c) Barometer `stop=true` (FG/BG) — #1574
+ *       (d) Cellular `underground` vote (FG/BG) — #1574
+ *
+ * 합의 임계:
+ *   - 2-of-N 통과 시 SSOT 채택 (station pair + env vote 어떤 조합이든 OK)
+ *   - 단, 채택 station이 필요하므로 station pair ≥ 1 필수 (env vote만 2개로는 불가)
+ *   - Cellular `surface` vote 시 underground SSOT 자체 reject (환경 확정 모순)
+ *   - GPS는 input set에서 reject (ADR-015 §5, backend `consensusGate.ts` 동일 정책)
+ *
+ * station 채택 우선순위: Position-Train > WiFi (강 → 약 신호).
+ *
+ * Backward-compat:
+ *   - barometerStop/cellularEnvironmentVote 미전달 → 기존 호출자 동작 유지
+ *   - 단, 2-of-N quorum이 강화되어 단일 station pair만으로는 통과 불가 (의도된 tightening).
+ *     기존 wifi-only / position-only 통과 케이스는 barometer/cellular 보강으로 회복.
  */
 
 import type { NearestStationResult, Station } from '../../../shared/types/station';
 import type { StationArrival } from '../../../shared/types/arrival';
+import type { CellularEnvironmentVote } from './cellularTech';
 
 /** arvlCd "정착한 위치 보고" 코드 집합. surfaceSSotConsensus와 동일 — 향후 공용 추출 여지. */
 const ARVL_CD_STATIONARY = new Set<number>([1, 2, 3, 5]);
 
+/** 2-of-N quorum 임계 — 4 input 중 2개 이상 통과 시 합의 채택. */
+const CONSENSUS_QUORUM = 2;
+
 export interface UndergroundSSOTInput {
-  /** useWifiStation 매칭 결과. null이면 SSID 미매칭. */
+  /** useWifiStation 매칭 결과. null이면 SSID 미매칭(또는 BG nil). */
   wifiStation: Station | null;
   /** trackTrainProgress 결과 (fusion 게이트 통과 후). null이면 position-train 신호 부재. */
   positionTrainResult: NearestStationResult | null;
   /** 채택 후보 station 매칭 슬롯의 arrival. null이면 arrival 신호 부재. */
   arrival: StationArrival | null;
+  /**
+   * #1574 — 기압계 `useBarometer().signal.stop`. 30s 윈도우 |dP|가 정착 임계 이하 = true.
+   * undefined(평가 불가, warmup) → vote 미투표.
+   * iOS BG에서도 동작 (NSMotionUsageDescription 1회로 충분).
+   */
+  barometerStop?: boolean | undefined;
+  /**
+   * #1574 — `useCellularTech()` 환경 vote (CTRadioAccessTechnology 분류).
+   * 'surface'면 underground SSOT 자체 reject (환경 확정 모순).
+   * 'underground'면 환경-확정 1표.
+   * 'unknown'/undefined → vote 미투표.
+   * iOS BG에서도 동작 (CTServiceRadioAccessTechnologyDidChangeNotification observer).
+   */
+  cellularEnvironmentVote?: CellularEnvironmentVote | undefined;
 }
 
 export interface UndergroundSSOT {
@@ -46,19 +84,35 @@ function findStationaryTrain(
 }
 
 export function undergroundSSOTConsensus(input: UndergroundSSOTInput): UndergroundSSOT | null {
-  const { wifiStation, positionTrainResult, arrival } = input;
-  // WiFi 우선 — SSID 직접 매칭.
-  if (wifiStation) {
-    const trainCode = findStationaryTrain(arrival, wifiStation.line);
-    if (trainCode !== null) {
-      return { station: wifiStation, trainCode };
-    }
-  }
+  const { wifiStation, positionTrainResult, arrival, barometerStop, cellularEnvironmentVote } = input;
+
+  // 환경 확정 모순 — cellular가 surface면 underground SSOT 자체 candidate X.
+  if (cellularEnvironmentVote === 'surface') return null;
+
+  // Station pair 후보 — 채택 우선순위 순서. position-train > wifi.
+  const stationPairs: Array<{ station: Station; trainCode: string }> = [];
   if (positionTrainResult) {
     const trainCode = findStationaryTrain(arrival, positionTrainResult.station.line);
     if (trainCode !== null) {
-      return { station: positionTrainResult.station, trainCode };
+      stationPairs.push({ station: positionTrainResult.station, trainCode });
     }
   }
-  return null;
+  if (wifiStation) {
+    const trainCode = findStationaryTrain(arrival, wifiStation.line);
+    if (trainCode !== null) {
+      stationPairs.push({ station: wifiStation, trainCode });
+    }
+  }
+
+  // Environment-confirming votes (station 미제공). 신규 #1574 — BG WiFi 갭 해소.
+  let envVotes = 0;
+  if (barometerStop === true) envVotes += 1;
+  if (cellularEnvironmentVote === 'underground') envVotes += 1;
+
+  // 2-of-N quorum. station pair ≥ 1 필수 (env vote만으로는 station 채택 불가).
+  if (stationPairs.length === 0) return null;
+  if (stationPairs.length + envVotes < CONSENSUS_QUORUM) return null;
+
+  // station 채택: position-train > wifi (stationPairs는 우선순위 순서로 push됨).
+  return stationPairs[0];
 }


### PR DESCRIPTION
Closes #1574 (ADR-017 T11)

## 요약
BG에서 `NEHotspotNetwork.fetchCurrent`가 nil이라 underground SSOT가 1-input(Position-Train+Arrival)로 떨어져 회귀 trigger가 되던 갭을, 이미 구현되어 있던 Barometer `stop`(dP/dt 정착) + Cellular `CTRadioAccessTechnology` 환경 vote를 합의 input으로 추가해 2-of-N quorum으로 회복.

## 변경
- `undergroundSSOTConsensus` 인터페이스에 `barometerStop?`, `cellularEnvironmentVote?` 추가
- 합의 구조: station pair (wifi/position + arrival) + env vote (barometer-stop, cellular-underground)
  - 2-of-N quorum, station pair ≥ 1 필수, cellular surface 시 reject
- `useFusedNearestStation`에서 `useCellularTech()` 신규 wire — **현재 device 어디서도 미호출이던 orphan 해소**
- `barometerSignal?.stop` 전달
- 단위 테스트 20건 (base 7 + 4-signal 10 + backward-compat 3)

## Wire-completion 5단 (#1582)

1. **Orphan 없음** — `npx ts-prune` 0 orphan 확인. `useCellularTech` 이전엔 test에서만 import되던 orphan이었으나 `useFusedNearestStation`에서 신규 호출.
   ```
   grep:
   - useCellularTech caller: src/features/nearest-station/hooks/useFusedNearestStation.ts:18 (import) + body call
   - undergroundSSOTConsensus new inputs: undergroundSSotConsensus.ts:48 (interface) + 같은 파일 body
   - test: undergroundSSotConsensus.test.ts 20 cases
   ```
2. **V/X dashboard** — DebugModal Underground Consensus section은 후속 sub-task F에서 추가. 본 PR은 backend `consensusGate` 4-signal 진화(이미 device가 cellularEnvironmentVote upload하면 backend도 자동) 측면에서 wrangler tail로 observable.
3. **의존 PR** — N/A (Phase 0 prerequisite P0-1/P0-2/P0-3 머지 완료)
4. **측정 plan** — 지하 trip 4건(출퇴근 2 + 환승 2)에서 alarmLog `gate-env-consensus-2of4-pass` 빈도 + V7 (지하 station-passed 정확률 ≥ 90%) 측정 후 close
5. **Device verify** — 필요. 지하 BG trip에서 SSOT 갱신율 + spam 미발생 확인. 코드+테스트는 CI로 검증, runtime은 사용자 실기기 검증

## 자가 점검 (5/5)

1. acceptance self-referential? — V7 측정은 P0-1 Analytics 인프라로. 본 PR 코드 자체 측정 X
2. Wire-completion CI? — `ts-prune` 0 orphan ✅
3. 머지 순서? — Phase 0 prerequisite 완료 ✅
4. backward-compat? — barometer/cellular 미전달 시 기존 wifi+position 2-pair 합의 동작 유지. 단 단일 pair 통과는 의도적으로 tightening (1-of-N → 2-of-N) — issue 본문 명시
5. False positive? — 2-of-N 엄격, GPS reject, cellular surface 시 reject ✅

## CI 검증

- `npm run type-check` — 0 error
- `npx jest src/features/nearest-station/` — 1172 tests pass
- `ts-prune` — 0 orphan
- 본 worktree 외 pre-existing 35 fail(widgetStorage / stationNotification)은 dev 동일 상태 (본 변경 무관)

## 추천

머지 후 P0-1 Analytics dashboard에서 underground 합의 통과 비율을 1주 관찰 후 V7 90%+ 확인되면 close.