### PR TITLE
fix(#1526): autoLock SSOT 출발역 stability 추출 보강

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -893,7 +893,7 @@ function buildAutoLockSection(args: BuildDumpArgs): string[] {
   const stabilityLine = `stability=${m.stability.stable ? 'stable' : 'pending'} count=${m.stability.count} stationId=${m.stability.stationId ?? UNKNOWN_LABEL}`;
   const directionLine = formatDirectionLine(m.direction);
   const candidateLine = m.candidate
-    ? `candidate=trainCode=${m.candidate.candidate.trainCode} line=${m.candidate.candidate.line} source=${m.candidate.source}`
+    ? `candidate=trainCode=${m.candidate.candidate.trainCode} line=${m.candidate.candidate.line} source=${m.candidate.source} path=${m.candidate.path}`
     : `candidate=null reason=${m.nullReason ?? UNKNOWN_LABEL}`;
   return [ssotLine, stabilityLine, directionLine, candidateLine];
 }
@@ -1012,16 +1012,14 @@ function findArrivalTerminal(
 function computeAutoLockNullReason(
   hasSSOT: boolean,
   stable: boolean,
-  directionMatched: boolean,
   hasCandidate: boolean,
 ): AutoLockDebugMeta['nullReason'] {
   if (hasCandidate) return null;
   if (!hasSSOT) return 'no-ssot';
   if (!stable) return 'stability-pending';
-  if (!directionMatched) return 'direction-mismatch';
-  /* istanbul ignore next -- 3 게이트 모두 통과면 hasCandidate=true가 보장됨 — buildCandidate
-     실패는 lineToSubwayId null 케이스로 valid LineNumber에서 도달 불능. 방어 fallback. */
-  return null;
+  // #1526 — stable+SSOT가 있는데도 candidate=null이면 direction 게이트가 미달 (judge-impossible
+  // + stability count < THRESHOLD 또는 reverse/terminal-out-of-route).
+  return 'direction-mismatch';
 }
 
 /**
@@ -1059,7 +1057,9 @@ function buildAutoLockMeta(input: {
     surfaceSSOT,
     undergroundSSOT,
     stabilityStable: stability.stable,
+    stabilityCount: stability.count,
     directionMatched: direction?.matched ?? false,
+    directionReason: direction?.reason ?? null,
   });
   return {
     surfaceSSOTActive: surfaceSSOT !== null,
@@ -1070,7 +1070,6 @@ function buildAutoLockMeta(input: {
     nullReason: computeAutoLockNullReason(
       surfaceSSOT !== null || undergroundSSOT !== null,
       stability.stable,
-      direction?.matched ?? false,
       candidate !== null,
     ),
   };

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -3000,6 +3000,7 @@ describe('DebugModal share SSOT (#1346)', () => {
       candidate: { trainCode: '2001', line: '2', subwayId: '1002' },
       source: 'device-ssot' as const,
       stationId: '0201',
+      path: 'direction-matched' as const,
     };
 
     type AutoLockMeta = NonNullable<Parameters<typeof __test__.buildDumpText>[0]['autoLockMeta']>;
@@ -3062,7 +3063,7 @@ describe('DebugModal share SSOT (#1346)', () => {
         contains: [
           'ssot=underground',
           'stability=stable count=3',
-          'candidate=trainCode=2001 line=2 source=device-ssot',
+          'candidate=trainCode=2001 line=2 source=device-ssot path=direction-matched',
         ],
       },
       {
@@ -3212,25 +3213,19 @@ describe('DebugModal helpers — #1421 auto-lock', () => {
 
   describe('computeAutoLockNullReason', () => {
     it('candidate 있으면 null 반환', () => {
-      expect(computeAutoLockNullReason(true, true, true, true)).toBeNull();
+      expect(computeAutoLockNullReason(true, true, true)).toBeNull();
     });
 
     it('SSOT 없으면 no-ssot', () => {
-      expect(computeAutoLockNullReason(false, false, false, false)).toBe('no-ssot');
+      expect(computeAutoLockNullReason(false, false, false)).toBe('no-ssot');
     });
 
     it('SSOT 있고 stable 아니면 stability-pending', () => {
-      expect(computeAutoLockNullReason(true, false, false, false)).toBe('stability-pending');
+      expect(computeAutoLockNullReason(true, false, false)).toBe('stability-pending');
     });
 
-    it('SSOT + stable이지만 direction 미일치면 direction-mismatch', () => {
-      expect(computeAutoLockNullReason(true, true, false, false)).toBe('direction-mismatch');
-    });
-
-    it('3 게이트 모두 통과 + hasCandidate=false (inconsistent state) → fallback null', () => {
-      // buildCandidate가 lineToSubwayId null 반환 시 도달 가능 — valid LineNumber에선 미도달.
-      // 방어 fallback 분기 자체를 검증.
-      expect(computeAutoLockNullReason(true, true, true, false)).toBeNull();
+    it('SSOT + stable인데 candidate=null이면 direction-mismatch (judge-wrong 또는 strong-stability 미충족)', () => {
+      expect(computeAutoLockNullReason(true, true, false)).toBe('direction-mismatch');
     });
   });
 });

--- a/src/features/nearest-station/utils/__tests__/inferAutoLockCandidate.test.ts
+++ b/src/features/nearest-station/utils/__tests__/inferAutoLockCandidate.test.ts
@@ -1,15 +1,21 @@
 /**
  * #1421 — PR-AutoLock-1 측정 인프라.
+ * #1526 — 출발역 strong-stability 예외 추가.
  *
  * inferAutoLockCandidate 단위 테스트. SSOT consensus (surface 또는 underground) + stability buffer
- * stable + direction verified 3개 게이트가 모두 충족된 경우에만 AutoLockCandidate를 산출, 그 외 null.
+ * stable + direction verified 3개 게이트가 모두 충족된 경우, 또는 direction judge-impossible
+ * + strong stability(count >= 5) 출발역 예외 케이스에 한해 DeviceAutoLockCandidate 산출.
  *
  * 본 PR은 측정만 — 실제 lock 산출 / sync 호출은 PR-AutoLock-2.
  */
 
-import { inferAutoLockCandidate } from '../inferAutoLockCandidate';
+import {
+  inferAutoLockCandidate,
+  DEPARTURE_STRONG_STABILITY_THRESHOLD,
+} from '../inferAutoLockCandidate';
 import { MOCK_STATIONS } from '../../../../testUtils/fixtures';
 import type { LineNumber, Station } from '../../../../shared/types/station';
+import type { VerifyTrainDirectionReason } from '../verifyTrainDirection';
 
 function station(name: string, line: LineNumber): Station {
   return { id: `${line}-${name}`, name, line, lineColor: '#000', lat: 0, lng: 0 };
@@ -23,15 +29,18 @@ const routeStations: Station[] = [
 
 const surfaceSSOT = { station: MOCK_STATIONS.gangnam, trainCode: '2001' };
 
+const baseInput = {
+  surfaceSSOT,
+  undergroundSSOT: null,
+  stabilityStable: true,
+  stabilityCount: 3,
+  directionMatched: true,
+  directionReason: 'forward' as VerifyTrainDirectionReason,
+};
+
 describe('inferAutoLockCandidate', () => {
   it('모든 게이트 통과 시 DeviceAutoLockCandidate 반환 (surface SSOT 경로)', () => {
-    const result = inferAutoLockCandidate({
-      surfaceSSOT,
-      undergroundSSOT: null,
-      stabilityStable: true,
-      directionMatched: true,
-    });
-    // source는 'device-ssot' 고정 (현 PR 측정 인프라).
+    const result = inferAutoLockCandidate(baseInput);
     expect(result?.candidate).toEqual({
       trainCode: '2001',
       line: '2',
@@ -39,25 +48,24 @@ describe('inferAutoLockCandidate', () => {
     });
     expect(result?.source).toBe('device-ssot');
     expect(result?.stationId).toBe(MOCK_STATIONS.gangnam.id);
+    expect(result?.path).toBe('direction-matched');
   });
 
   it('underground SSOT만 활성 + 모든 게이트 통과', () => {
     const result = inferAutoLockCandidate({
+      ...baseInput,
       surfaceSSOT: null,
       undergroundSSOT: { station: MOCK_STATIONS.chungmuro, trainCode: '3010' },
-      stabilityStable: true,
-      directionMatched: true,
     });
     expect(result?.candidate.trainCode).toBe('3010');
     expect(result?.candidate.line).toBe('3');
+    expect(result?.path).toBe('direction-matched');
   });
 
   it('두 SSOT 모두 활성이면 surface 우선', () => {
     const result = inferAutoLockCandidate({
-      surfaceSSOT,
+      ...baseInput,
       undergroundSSOT: { station: MOCK_STATIONS.chungmuro, trainCode: '3010' },
-      stabilityStable: true,
-      directionMatched: true,
     });
     expect(result?.candidate.trainCode).toBe('2001');
     expect(result?.candidate.line).toBe('2');
@@ -65,52 +73,110 @@ describe('inferAutoLockCandidate', () => {
 
   it('두 SSOT 모두 null이면 null (SSOT 게이트 미충족)', () => {
     const result = inferAutoLockCandidate({
+      ...baseInput,
       surfaceSSOT: null,
       undergroundSSOT: null,
-      stabilityStable: true,
-      directionMatched: true,
     });
     expect(result).toBeNull();
   });
 
   it('stability stable=false면 null', () => {
-    const result = inferAutoLockCandidate({
-      surfaceSSOT,
-      undergroundSSOT: null,
-      stabilityStable: false,
-      directionMatched: true,
-    });
+    const result = inferAutoLockCandidate({ ...baseInput, stabilityStable: false });
     expect(result).toBeNull();
   });
 
-  it('direction matched=false면 null', () => {
+  it('direction matched=false + reason=reverse면 null (실제로 잘못된 방향은 strong-stability에서도 reject)', () => {
     const result = inferAutoLockCandidate({
-      surfaceSSOT,
-      undergroundSSOT: null,
-      stabilityStable: true,
+      ...baseInput,
       directionMatched: false,
+      directionReason: 'reverse',
+      stabilityCount: 99,
     });
     expect(result).toBeNull();
   });
 
-  it('inferAutoLockMeta — 게이트 입력 + reason 노출 (DebugModal 출력용)', () => {
+  it('direction matched=false + reason=terminal-out-of-route면 null (judge-wrong은 reject)', () => {
     const result = inferAutoLockCandidate({
-      surfaceSSOT,
-      undergroundSSOT: null,
-      stabilityStable: false,
-      directionMatched: true,
+      ...baseInput,
+      directionMatched: false,
+      directionReason: 'terminal-out-of-route',
+      stabilityCount: 99,
     });
     expect(result).toBeNull();
-    // null 사유는 호출자가 게이트 상태로 알 수 있음 — meta 함수 없이도 진단 가능.
+  });
+
+  it('#1526 — direction reason=no-route + stability count >= THRESHOLD면 출발역 예외로 통과', () => {
+    const result = inferAutoLockCandidate({
+      ...baseInput,
+      directionMatched: false,
+      directionReason: 'no-route',
+      stabilityCount: DEPARTURE_STRONG_STABILITY_THRESHOLD,
+    });
+    expect(result?.path).toBe('departure-strong-stability');
+    expect(result?.candidate.trainCode).toBe('2001');
+  });
+
+  it('#1526 — direction reason=no-terminal + stability count >= THRESHOLD도 출발역 예외 적용', () => {
+    const result = inferAutoLockCandidate({
+      ...baseInput,
+      directionMatched: false,
+      directionReason: 'no-terminal',
+      stabilityCount: DEPARTURE_STRONG_STABILITY_THRESHOLD + 2,
+    });
+    expect(result?.path).toBe('departure-strong-stability');
+  });
+
+  it('#1526 — direction reason=no-route인데 stability count < THRESHOLD면 null (예외 미발동)', () => {
+    const result = inferAutoLockCandidate({
+      ...baseInput,
+      directionMatched: false,
+      directionReason: 'no-route',
+      stabilityCount: DEPARTURE_STRONG_STABILITY_THRESHOLD - 1,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('#1526 — direction reason=null (verify 결과 부재) + strong stability면 null (judge-impossible 라벨 명시 필요)', () => {
+    // direction verify 자체를 호출 안 한 경우 (예: SSOT 미활성으로 호출자가 verify skip).
+    // judge-impossible 라벨을 명시하지 못한 상태는 strong-stability 예외에서도 reject — false positive 차단.
+    const result = inferAutoLockCandidate({
+      ...baseInput,
+      directionMatched: false,
+      directionReason: null,
+      stabilityCount: 99,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('#1526 — 출발역 예외 발동 시에도 SSOT 미활성이면 null', () => {
+    const result = inferAutoLockCandidate({
+      ...baseInput,
+      surfaceSSOT: null,
+      undergroundSSOT: null,
+      directionMatched: false,
+      directionReason: 'no-route',
+      stabilityCount: DEPARTURE_STRONG_STABILITY_THRESHOLD,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('#1526 — 출발역 예외 + underground SSOT만 활성', () => {
+    const result = inferAutoLockCandidate({
+      ...baseInput,
+      surfaceSSOT: null,
+      undergroundSSOT: { station: MOCK_STATIONS.chungmuro, trainCode: '3010' },
+      directionMatched: false,
+      directionReason: 'no-route',
+      stabilityCount: DEPARTURE_STRONG_STABILITY_THRESHOLD,
+    });
+    expect(result?.path).toBe('departure-strong-stability');
+    expect(result?.candidate.trainCode).toBe('3010');
   });
 
   it('routeStations 컨텍스트 없이도 SSOT+stability+direction만으로 작동 (pure)', () => {
-    // pure 함수: 호출자가 verifyTrainDirection 결과를 그대로 넘긴다.
     const result = inferAutoLockCandidate({
+      ...baseInput,
       surfaceSSOT: { station: routeStations[0], trainCode: 'T-A' },
-      undergroundSSOT: null,
-      stabilityStable: true,
-      directionMatched: true,
     });
     expect(result?.candidate.trainCode).toBe('T-A');
     expect(result?.candidate.line).toBe('2');

--- a/src/features/nearest-station/utils/inferAutoLockCandidate.ts
+++ b/src/features/nearest-station/utils/inferAutoLockCandidate.ts
@@ -1,17 +1,29 @@
 /**
  * #1421 — PR-AutoLock-1 측정 인프라.
+ * #1526 — 출발역 stability 추출 보강 (boardingPrompt 0건 회귀 fix).
  *
  * SSOT consensus + stability buffer + direction verify 3개 게이트 결과를 받아 device-side
- * auto-lock candidate를 산출. 본 PR은 측정만 — useBoardingLockStore.createLock 호출도, backend
+ * auto-lock candidate를 산출. 본 모듈은 측정만 — useBoardingLockStore.createLock 호출도, backend
  * `/boarding-lock/sync` 발사도 없다. PR-AutoLock-2가 결과를 lock 산출에 연결.
  *
- * 입력 결합 정의:
+ * 입력 결합 정의 (#1526 이후):
  *   1) SSOT 게이트: surface 또는 underground 중 적어도 하나의 consensus가 활성 (둘 다 활성이면
  *      surface 우선 — 지상 GPS+Arrival이 가장 신뢰도 높은 신호).
  *   2) Stability 게이트: consensusStabilityBuffer가 N=3 이상 동일 stationId 합의 (stable=true).
- *   3) Direction 게이트: verifyTrainDirection이 route의 destination 쪽 방향과 일치 확인.
+ *   3) Direction 게이트: verifyTrainDirection.matched=true 또는 출발역 예외 적용.
  *
- * 모든 게이트 통과 시 `DeviceAutoLockCandidate` 반환. 셋 중 하나라도 미달이면 null.
+ * 출발역 예외 (#1526):
+ *   - direction reason이 `no-route` / `no-terminal` (= 진행 방향을 판정 불가 — 사용자가 route를
+ *     설정하지 않았거나 arrival terminal이 비어 있는 trip 등록 직후 상태) 이고,
+ *   - stability count가 `DEPARTURE_STRONG_STABILITY_THRESHOLD` (=5) 이상이면 (= 동일 station에
+ *     5폴 이상 합의 = N=3 threshold의 ~1.7x. false consensus가 5회 연속 같은 station을 가리킬
+ *     확률 매우 낮음),
+ *   candidate 산출을 허용한다. 출발역은 정의상 "아직 한 칸도 advance 안 한" 상태로, route 미설정
+ *   trip에서 direction을 판정할 신호 자체가 없다. 이 경계 케이스에서 SSOT+stability만으로
+ *   boardingPrompt evidence를 생성해야 7일 누적 0건 회귀가 해소된다.
+ *
+ *   `reverse` / `terminal-out-of-route` (= 실제로 잘못된 방향)은 출발역 예외에서도 reject —
+ *   judge-impossible과 judge-wrong은 의미가 다르다.
  *
  * `DeviceAutoLockCandidate`는 backend가 발급하는 기존 `AutoLockCandidate` (boardingLockSync.ts)와
  * 의미가 분리된다:
@@ -19,23 +31,41 @@
  *   - 본 type: device가 Tier 1 SSOT 직접 잡고 산출한 측정 후보. PR-AutoLock-2에서 sync payload에
  *     `source: 'device-ssot'`로 노출 예정.
  * 호환을 위해 내부에 기존 `AutoLockCandidate`를 그대로 포함하고(`candidate` 필드), 메타데이터
- * 필드(source/stationId)는 본 type에만 있다.
+ * 필드(source/stationId/path)는 본 type에만 있다.
  */
 
 import { lineToSubwayId } from '../../../shared/constants/lineApiNames';
 import type { AutoLockCandidate } from '../api/boardingLockSync';
 import type { Station } from '../../../shared/types/station';
+import type { VerifyTrainDirectionReason } from './verifyTrainDirection';
 
 /** 측정 인프라가 채택한 candidate의 source 라벨. PR-AutoLock-2 sync payload와 정합. */
 export type DeviceAutoLockSource = 'device-ssot';
 
+/**
+ * #1526 — 출발역 strong-stability 예외에 필요한 최소 count.
+ * threshold=3(stable=true)의 ~1.7x. 5회 연속 동일 station 합의 = N=3 majority vote 통과 + 추가 2폴
+ * 재확인. 5폴 ≈ 150s (30s 폴링 기준) — trip 등록 후 첫 1~3 cycle transitional state를 넘어선 시점.
+ */
+export const DEPARTURE_STRONG_STABILITY_THRESHOLD = 5;
+
+/**
+ * #1526 — candidate 채택 path 라벨. 측정/디버깅 시 어느 경로로 lock 후보가 산출되었는지 추적.
+ *  - `direction-matched`: verifyTrainDirection.matched=true (기존 경로, 정상 progressing).
+ *  - `departure-strong-stability`: direction judge-impossible + stability count ≥ THRESHOLD
+ *    (출발역 예외 — boardingPrompt 0건 회귀 대응).
+ */
+export type DeviceAutoLockPath = 'direction-matched' | 'departure-strong-stability';
+
 export interface DeviceAutoLockCandidate {
   /** Backend `AutoLockCandidate`와 동일 형태 — PR-AutoLock-2에서 sync payload에 그대로 전달. */
   candidate: AutoLockCandidate;
-  /** PR-AutoLock-2 sync payload `source` 필드. 본 PR에서는 측정 라벨로만 사용. */
+  /** PR-AutoLock-2 sync payload `source` 필드. 본 모듈에서는 측정 라벨로만 사용. */
   source: DeviceAutoLockSource;
   /** SSOT가 합의한 stationId — DebugModal/메트릭에서 stable_match 시각화용. */
   stationId: string;
+  /** #1526 — 채택 path. 출발역 예외 발동 여부 추적용. */
+  path: DeviceAutoLockPath;
 }
 
 export interface InferAutoLockCandidateInput {
@@ -45,12 +75,32 @@ export interface InferAutoLockCandidateInput {
   undergroundSSOT: { station: Station; trainCode: string } | null;
   /** consensusStabilityBuffer.push().stable. */
   stabilityStable: boolean;
+  /**
+   * #1526 — consensusStabilityBuffer.push().count. 출발역 strong-stability 예외 판정용.
+   * 기본 stability 게이트(stable=true)와 추가 count 임계를 별도 평가한다.
+   */
+  stabilityCount: number;
   /** verifyTrainDirection.matched. */
   directionMatched: boolean;
+  /**
+   * #1526 — verifyTrainDirection.reason. 출발역 judge-impossible 케이스
+   * (`no-route` / `no-terminal`) 판별용. matched=false여도 reason이 judge-impossible이면
+   * strong-stability 예외 적용 가능.
+   */
+  directionReason: VerifyTrainDirectionReason | null;
+}
+
+/**
+ * #1526 — `no-route` / `no-terminal`은 "방향을 판정할 신호 자체가 없는" 상태.
+ * `reverse` / `terminal-out-of-route`는 "판정 결과가 잘못된 방향"이므로 strong-stability에서도 reject.
+ */
+function isDirectionJudgeImpossible(reason: VerifyTrainDirectionReason | null): boolean {
+  return reason === 'no-route' || reason === 'no-terminal';
 }
 
 function buildCandidate(
   ssot: { station: Station; trainCode: string },
+  path: DeviceAutoLockPath,
 ): DeviceAutoLockCandidate | null {
   const subwayId = lineToSubwayId(ssot.station.line);
   /* istanbul ignore next -- LineNumber 모두 LINE_TO_SUBWAY_ID에 등록. valid 입력 하에서 미도달. */
@@ -59,17 +109,39 @@ function buildCandidate(
     candidate: { trainCode: ssot.trainCode, line: ssot.station.line, subwayId },
     source: 'device-ssot',
     stationId: ssot.station.id,
+    path,
   };
 }
 
 export function inferAutoLockCandidate(
   input: InferAutoLockCandidateInput,
 ): DeviceAutoLockCandidate | null {
-  const { surfaceSSOT, undergroundSSOT, stabilityStable, directionMatched } = input;
+  const {
+    surfaceSSOT,
+    undergroundSSOT,
+    stabilityStable,
+    stabilityCount,
+    directionMatched,
+    directionReason,
+  } = input;
   if (!stabilityStable) return null;
-  if (!directionMatched) return null;
+
+  // 기본 경로: direction matched면 그대로 통과.
+  // 출발역 예외 (#1526): direction judge-impossible + stability count >= THRESHOLD면 통과.
+  let path: DeviceAutoLockPath;
+  if (directionMatched) {
+    path = 'direction-matched';
+  } else if (
+    isDirectionJudgeImpossible(directionReason) &&
+    stabilityCount >= DEPARTURE_STRONG_STABILITY_THRESHOLD
+  ) {
+    path = 'departure-strong-stability';
+  } else {
+    return null;
+  }
+
   // surface 우선 — GPS+Arrival 직접 신호가 가장 신뢰도 높음.
-  if (surfaceSSOT) return buildCandidate(surfaceSSOT);
-  if (undergroundSSOT) return buildCandidate(undergroundSSOT);
+  if (surfaceSSOT) return buildCandidate(surfaceSSOT, path);
+  if (undergroundSSOT) return buildCandidate(undergroundSSOT, path);
   return null;
 }


### PR DESCRIPTION
Closes #1526

## Root cause
trip dump (2026-06-20, 1.5h lockless) 기준 `Auto-lock Candidate` 섹션 `stability=stable count=5` (extraction 자체는 OK)인데, `direction=mismatch reason=no-route` 때문에 `candidate=null reason=direction-mismatch`로 reject. 사용자가 route를 설정하지 않은 trip의 **출발역**에서는 진행 방향을 판정할 신호 자체가 없으므로 (judge-impossible) `verifyTrainDirection`이 `no-route`를 돌려준다. 기존 `inferAutoLockCandidate`는 `judge-impossible`과 `judge-wrong`(reverse)을 구분하지 않고 둘 다 reject → boardingPrompt evidence 7일 0건의 한 layer 원인.

## Fix
`inferAutoLockCandidate`에 출발역 strong-stability 예외 추가:

1. 입력에 `stabilityCount` + `directionReason` 추가.
2. `directionMatched=false`여도 `directionReason ∈ {'no-route', 'no-terminal'}`(judge-impossible)이고 `stabilityCount >= DEPARTURE_STRONG_STABILITY_THRESHOLD`(=5)면 candidate 산출.
3. `reverse` / `terminal-out-of-route`(judge-wrong)는 strong-stability에서도 reject — false positive 차단.
4. `DeviceAutoLockCandidate`에 `path: 'direction-matched' | 'departure-strong-stability'` 필드 추가 — 어느 경로로 lock 후보가 산출되었는지 측정 가능.
5. DebugModal `buildAutoLockMeta` wire: `stability.count` + `direction.reason` 전달, dump candidate line에 `path=` 노출.

## Scope
- 본 PR은 `inferAutoLockCandidate` (device-side 측정 인프라) 한정. lockSuggestion 신규 필드/backend 변경 X.
- S1 #1534 (T9b lockSuggestion forward) 영역과 겹치지 않음 — backend는 그대로, device 출발역 케이스만 보강.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (No orphan exports detected).
2. **V/X dashboard** — DebugModal `## Auto-lock Candidate` 섹션 `candidate=trainCode=... path=departure-strong-stability` 라인으로 출발역 예외 발동 여부 직접 관측.
3. **의존 PR** — N/A. (S1 #1534와 독립. 머지 순서 무관)
4. **측정 plan** — production 1주: trip dump에 `path=departure-strong-stability` 출현 빈도 + `## Boarding Prompt Acceptance` `displayed >= 1건/trip` 회복 측정. 회복 없으면 다른 layer 추가 진단 (L1/L3/L4/L5).
5. **Device verify** — 권장: route 미설정 상태로 trip 등록 후 출발역에서 SSOT consensus 5폴 이상 유지 → DebugModal에 `path=departure-strong-stability` 노출 확인.

## 자가 점검
1. **acceptance self-referential?** — 본 PR은 fix evidence(unit), 최종 boardingPrompt acceptance 측정은 P0-1 Analytics + production trip dump가 담당.
2. **Wire-completion orphan 0** — lint:orphan pass.
3. **머지 순서** — S1 #1534 무관. S1 머지 후라도 본 PR과 충돌 가능성 낮음 (수정 파일 다름).
4. **backward-compat** — 단순 fix. 기존 path=direction-matched는 동일 동작 유지. 신규 path=departure-strong-stability만 추가.
5. **False positive** — judge-wrong은 strong-stability에서도 reject. 5폴 threshold는 majority vote 통과 + 추가 2폴 재확인 = 잘못된 station 5회 연속 합의 확률 낮음.

## 검증
- `npm test src/features/nearest-station/utils/__tests__/inferAutoLockCandidate.test.ts` → 14/14 pass (신규 6 케이스 포함).
- `npm test src/features/debug/components/__tests__/DebugModal.test.tsx` → 275/275 pass.
- `npm run type-check` → pass.
- `npm run lint:orphan` → No orphan exports detected.

## Test plan
- [ ] CI ALL GREEN 확인
- [ ] route 미설정 trip 등록 → 출발역 SSOT consensus 5폴 유지 → DebugModal `path=departure-strong-stability` 노출
- [ ] route 설정 trip 정상 진행 → `path=direction-matched` 유지 (회귀 없음)