### PR TITLE
feat(#1575): NotificationRouter abstraction + surface dedup + /trips rate limit (T12 PR-A)

### DIFF
--- a/backend/alarm-worker/src/__tests__/tripRegisterRateLimit.test.ts
+++ b/backend/alarm-worker/src/__tests__/tripRegisterRateLimit.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import {
+  TRIP_REGISTER_MAX_PER_WINDOW,
+  TRIP_REGISTER_WINDOW_MS,
+  checkTripRegisterRateLimit,
+  makeTokenPrefix,
+  tripRegisterRateLimitKey,
+  tripRegisterWindowStart,
+} from '../tripRegisterRateLimit';
+import { InMemoryKV } from './inMemoryKv';
+
+const TOKEN_A = 'a'.repeat(64);
+const TOKEN_B = 'b'.repeat(64);
+const SHORT_TOKEN = 'abc';
+
+describe('tripRegisterRateLimit (#1575 T12 V8 b)', () => {
+  it('window start aligns nowMs to TRIP_REGISTER_WINDOW_MS', () => {
+    const now = 5 * TRIP_REGISTER_WINDOW_MS + 1234;
+    expect(tripRegisterWindowStart(now)).toBe(5 * TRIP_REGISTER_WINDOW_MS);
+  });
+
+  it('makeTokenPrefix returns first 16 chars', () => {
+    expect(makeTokenPrefix(TOKEN_A)).toBe('aaaaaaaaaaaaaaaa');
+  });
+
+  it('makeTokenPrefix returns short input as-is (graceful)', () => {
+    expect(makeTokenPrefix(SHORT_TOKEN)).toBe('abc');
+  });
+
+  it('key shape includes prefix + windowStart', () => {
+    expect(tripRegisterRateLimitKey('prefix', 1000)).toBe(
+      'trip-rate:prefix:1000',
+    );
+  });
+
+  it('first MAX requests allowed, MAX+1 rejected', async () => {
+    const kv = new InMemoryKV();
+    const now = TRIP_REGISTER_WINDOW_MS;
+    for (let i = 0; i < TRIP_REGISTER_MAX_PER_WINDOW; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const r = await checkTripRegisterRateLimit(
+        kv as unknown as KVNamespace,
+        TOKEN_A,
+        now,
+      );
+      expect(r.allowed).toBe(true);
+      expect(r.count).toBe(i + 1);
+    }
+    const overflow = await checkTripRegisterRateLimit(
+      kv as unknown as KVNamespace,
+      TOKEN_A,
+      now,
+    );
+    expect(overflow.allowed).toBe(false);
+    expect(overflow.count).toBe(TRIP_REGISTER_MAX_PER_WINDOW);
+    expect(overflow.retryAfterSeconds).toBeGreaterThan(0);
+  });
+
+  it('different tokens have independent counters', async () => {
+    const kv = new InMemoryKV();
+    const now = TRIP_REGISTER_WINDOW_MS;
+    for (let i = 0; i < TRIP_REGISTER_MAX_PER_WINDOW; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await checkTripRegisterRateLimit(kv as unknown as KVNamespace, TOKEN_A, now);
+    }
+    // TOKEN_A는 cap에 도달했지만 TOKEN_B는 0/10에서 시작.
+    const r = await checkTripRegisterRateLimit(
+      kv as unknown as KVNamespace,
+      TOKEN_B,
+      now,
+    );
+    expect(r.allowed).toBe(true);
+    expect(r.count).toBe(1);
+  });
+
+  it('new window resets counter', async () => {
+    const kv = new InMemoryKV();
+    const now1 = TRIP_REGISTER_WINDOW_MS;
+    for (let i = 0; i < TRIP_REGISTER_MAX_PER_WINDOW; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await checkTripRegisterRateLimit(kv as unknown as KVNamespace, TOKEN_A, now1);
+    }
+    const blocked = await checkTripRegisterRateLimit(
+      kv as unknown as KVNamespace,
+      TOKEN_A,
+      now1,
+    );
+    expect(blocked.allowed).toBe(false);
+
+    const now2 = now1 + TRIP_REGISTER_WINDOW_MS;
+    const fresh = await checkTripRegisterRateLimit(
+      kv as unknown as KVNamespace,
+      TOKEN_A,
+      now2,
+    );
+    expect(fresh.allowed).toBe(true);
+    expect(fresh.count).toBe(1);
+  });
+
+  it('handles corrupt KV value (parse fail) by treating as 0', async () => {
+    const kv = new InMemoryKV();
+    const now = TRIP_REGISTER_WINDOW_MS;
+    const key = tripRegisterRateLimitKey(
+      makeTokenPrefix(TOKEN_A),
+      tripRegisterWindowStart(now),
+    );
+    await kv.put(key, 'not-a-number');
+    const r = await checkTripRegisterRateLimit(
+      kv as unknown as KVNamespace,
+      TOKEN_A,
+      now,
+    );
+    expect(r.allowed).toBe(true);
+    expect(r.count).toBe(1);
+  });
+
+  it('handles negative KV value (defensive) by treating as 0', async () => {
+    const kv = new InMemoryKV();
+    const now = TRIP_REGISTER_WINDOW_MS;
+    const key = tripRegisterRateLimitKey(
+      makeTokenPrefix(TOKEN_A),
+      tripRegisterWindowStart(now),
+    );
+    await kv.put(key, '-5');
+    const r = await checkTripRegisterRateLimit(
+      kv as unknown as KVNamespace,
+      TOKEN_A,
+      now,
+    );
+    expect(r.allowed).toBe(true);
+    expect(r.count).toBe(1);
+  });
+
+  it('retryAfterSeconds is at least 1 even near window end', async () => {
+    const kv = new InMemoryKV();
+    const windowStart = TRIP_REGISTER_WINDOW_MS;
+    const nearEnd = windowStart + TRIP_REGISTER_WINDOW_MS - 100;
+    const r = await checkTripRegisterRateLimit(
+      kv as unknown as KVNamespace,
+      TOKEN_A,
+      nearEnd,
+    );
+    expect(r.retryAfterSeconds).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -90,6 +90,7 @@ import {
 } from './regressionTelemetry';
 import { KV_MIN_CACHE_TTL_SEC } from './kvConsistency';
 import { getTrip, putTrip } from './trips';
+import { checkTripRegisterRateLimit } from './tripRegisterRateLimit';
 import {
   TRIP_STATUS_RETENTION_MS,
   readTripEndedStatus,
@@ -340,6 +341,32 @@ app.post('/trips', async (c) => {
 
   const incoming = validateTrip(body);
   if (!incoming) return c.json({ error: 'invalid_trip' }, 400);
+
+  // #1575 (T12, ADR-017 V8 (b)) — per-token rate limit 10 req / 10 min.
+  // Device register loop / cold restart 반복 / FG↔BG 빠른 전환 race로 같은 token이 분당
+  // 5~10회 POST되는 사례 차단. Cloudflare Worker quota(100K/day) 보호 + dedup state 안정.
+  // 정상 사용자(<10 req/10min)는 영향 없음. checkTripRegisterRateLimit은 fixed-window KV
+  // counter — best-effort atomic (KV는 strict atomic 없음). cap 근처에서만 race 가능.
+  const rateLimit = await checkTripRegisterRateLimit(
+    c.env.TRIPS,
+    incoming.token,
+    Date.now(),
+  );
+  if (!rateLimit.allowed) {
+    console.log(
+      JSON.stringify({
+        msg: 'trip-register: rate-limited (#1575 T12)',
+        tokenPrefix: tokenPrefix(incoming.token),
+        count: rateLimit.count,
+        retryAfterSeconds: rateLimit.retryAfterSeconds,
+      }),
+    );
+    return c.json(
+      { error: 'rate_limited', retryAfterSeconds: rateLimit.retryAfterSeconds },
+      429,
+      { 'Retry-After': String(rateLimit.retryAfterSeconds) },
+    );
+  }
 
   // #1366 Layer 3 — incoming boardingLock metadata cross-validation.
   // Frontend가 환승 hop 진입 시 store 업데이트 race로 trainCode/line(새 leg) +

--- a/backend/alarm-worker/src/tripRegisterRateLimit.ts
+++ b/backend/alarm-worker/src/tripRegisterRateLimit.ts
@@ -1,0 +1,83 @@
+/**
+ * #1575 (T12, ADR-017 V8 (b)) — `/trips` POST per-token rate limit.
+ *
+ * Acceptance V8 (b): same token으로 10분 윈도우 안에 10회 초과 등록 시도는 reject.
+ *
+ * 회귀 컨텍스트: device 측 register loop / cold restart 반복 / FG↔BG 빠른 전환 race로 같은
+ * trip token이 분당 5~10회 POST되는 사례가 있었다. backend는 isSameSession dedup으로 본체는
+ * 보호하지만 매 요청마다 KV read/write + waypoints validate + boardingLock check가 발생해
+ * Cloudflare Worker 일일 quota(100K)를 소진한다. Token 단위 fixed-window 카운터로 차단.
+ *
+ * Fixed-window 방식 (feedback rate limit과 동일 패턴):
+ *   - window = 10분, 시작 시각으로 정렬(`nowMs - nowMs % WINDOW_MS`).
+ *   - KV key: `trip-rate:<tokenPrefix>:<windowStart>` (PII 회피용 prefix 16자).
+ *   - max 10 → 11번째 요청부터 429 응답 + Retry-After 헤더.
+ *
+ * KV는 atomic increment가 없어 동시 요청 race로 일부 count가 underflow될 수 있으나, 정상
+ * 사용자(< 10 req/10min)는 영향 없고 폭주 시도(분당 100건+)는 cap 근처에서 차단된다.
+ */
+
+export const TRIP_REGISTER_WINDOW_MS = 10 * 60 * 1000;
+export const TRIP_REGISTER_MAX_PER_WINDOW = 10;
+
+export interface TripRegisterRateLimitResult {
+  allowed: boolean;
+  /** 윈도우 종료까지 남은 초. 429 응답 Retry-After 헤더에 사용. */
+  retryAfterSeconds: number;
+  /** 현재 윈도우의 사용량 (allowed = false 시 cap 이상). */
+  count: number;
+}
+
+/**
+ * 윈도우 시작 epoch ms. nowMs - (nowMs % WINDOW_MS).
+ */
+export function tripRegisterWindowStart(nowMs: number): number {
+  return Math.floor(nowMs / TRIP_REGISTER_WINDOW_MS) * TRIP_REGISTER_WINDOW_MS;
+}
+
+/**
+ * KV key — token 전체 대신 prefix 16자만 사용. 같은 device의 token rotation 윈도우 안에서는
+ * 충돌하지만 device 식별엔 충분(APNs token은 첫 16자가 device 고유 신호 강함). 완전한 PII
+ * 회피가 목적이며 false positive는 사용자 본인 device 한정이라 영향 미미.
+ */
+export function tripRegisterRateLimitKey(
+  tokenPrefix: string,
+  windowStart: number,
+): string {
+  return `trip-rate:${tokenPrefix}:${windowStart}`;
+}
+
+/**
+ * token prefix — 첫 16자. KV key에 사용. 빈 문자열 / 짧은 입력은 그대로 사용 (graceful).
+ */
+export function makeTokenPrefix(token: string): string {
+  return token.slice(0, 16);
+}
+
+/**
+ * 본 윈도우의 카운트를 read → +1 write. count > MAX이면 거부.
+ *
+ * KV TTL은 윈도우 길이 + 60초 (만료 race buffer). 다음 윈도우는 자연 reset.
+ */
+export async function checkTripRegisterRateLimit(
+  kv: KVNamespace,
+  token: string,
+  nowMs: number,
+): Promise<TripRegisterRateLimitResult> {
+  const prefix = makeTokenPrefix(token);
+  const windowStart = tripRegisterWindowStart(nowMs);
+  const key = tripRegisterRateLimitKey(prefix, windowStart);
+  const raw = await kv.get(key);
+  const parsed = raw ? Number.parseInt(raw, 10) : 0;
+  const current = Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+  const windowEnd = windowStart + TRIP_REGISTER_WINDOW_MS;
+  const retryAfterSeconds = Math.max(1, Math.ceil((windowEnd - nowMs) / 1000));
+
+  if (current >= TRIP_REGISTER_MAX_PER_WINDOW) {
+    return { allowed: false, retryAfterSeconds, count: current };
+  }
+  await kv.put(key, String(current + 1), {
+    expirationTtl: Math.ceil(TRIP_REGISTER_WINDOW_MS / 1000) + 60,
+  });
+  return { allowed: true, retryAfterSeconds, count: current + 1 };
+}

--- a/src/features/alarm/api/__tests__/notificationRouter.test.ts
+++ b/src/features/alarm/api/__tests__/notificationRouter.test.ts
@@ -1,0 +1,200 @@
+import * as Notifications from 'expo-notifications';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  __resetRouterSingletonForTest,
+  getNotificationRouter,
+} from '../notificationRouter';
+import { __resetDeliveryLogForTest } from '../../../notice/store/notificationDeliveryLog';
+import { BACKEND_SSOT_MIRROR_KEY } from '../../../../shared/constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+jest.mock('expo-notifications', () => ({
+  scheduleNotificationAsync: jest.fn().mockResolvedValue('id-1'),
+}));
+
+const mockSaveStationToWidget = jest.fn();
+const mockClearWidgetStation = jest.fn();
+jest.mock('../../../widget/api/widgetStorage', () => ({
+  saveStationToWidget: (...args: unknown[]) => mockSaveStationToWidget(...args),
+  clearWidgetStation: () => mockClearWidgetStation(),
+}));
+
+const mockSetAlarmEvent = jest.fn();
+jest.mock('../../store/useAlarmEventStore', () => ({
+  useAlarmEventStore: {
+    getState: () => ({ setAlarmEvent: mockSetAlarmEvent }),
+  },
+}));
+
+const scheduleSpy = Notifications.scheduleNotificationAsync as jest.Mock;
+
+describe('notificationRouter wiring (#1575 T12)', () => {
+  beforeEach(async () => {
+    __resetRouterSingletonForTest();
+    __resetDeliveryLogForTest();
+    await AsyncStorage.clear();
+    scheduleSpy.mockClear();
+    mockSaveStationToWidget.mockClear();
+    mockClearWidgetStation.mockClear();
+    mockSetAlarmEvent.mockClear();
+  });
+
+  it('getNotificationRouter returns same singleton on repeat call', () => {
+    const r1 = getNotificationRouter();
+    const r2 = getNotificationRouter();
+    expect(r1).toBe(r2);
+  });
+
+  it('banner surface fans out to Notifications.scheduleNotificationAsync', async () => {
+    const router = getNotificationRouter();
+    const result = await router.deliver({
+      alarmId: 'a-1',
+      eventKey: 'station-passed:중곡',
+      surface: 'banner',
+      content: { title: 'T', body: 'B', data: { foo: 'bar' } },
+      source: 'bg-silent-push',
+    });
+    expect(result.delivered).toBe(true);
+    expect(scheduleSpy).toHaveBeenCalledWith({
+      content: { title: 'T', body: 'B', data: { foo: 'bar' } },
+      trigger: null,
+    });
+  });
+
+  it('banner surface omits data field when content.data is undefined', async () => {
+    const router = getNotificationRouter();
+    await router.deliver({
+      alarmId: 'a-2',
+      eventKey: 'e',
+      surface: 'banner',
+      content: { title: 'T', body: 'B' },
+      source: 'fg',
+    });
+    expect(scheduleSpy).toHaveBeenCalledWith({
+      content: { title: 'T', body: 'B' },
+      trigger: null,
+    });
+  });
+
+  it('widget surface calls saveStationToWidget when station + distanceKm present', async () => {
+    const router = getNotificationRouter();
+    const station = { id: '0228', name: '강남', lat: 0, lng: 0 };
+    await router.deliver({
+      alarmId: 'a-3',
+      eventKey: 'e',
+      surface: 'widget',
+      content: { title: 'T', body: 'B', data: { station, distanceKm: 0.05 } },
+      source: 'fg',
+    });
+    expect(mockSaveStationToWidget).toHaveBeenCalledWith(station, 0.05);
+  });
+
+  it('widget surface no-ops when station or distanceKm missing', async () => {
+    const router = getNotificationRouter();
+    await router.deliver({
+      alarmId: 'a-4',
+      eventKey: 'e',
+      surface: 'widget',
+      content: { title: 'T', body: 'B' },
+      source: 'fg',
+    });
+    expect(mockSaveStationToWidget).not.toHaveBeenCalled();
+  });
+
+  it('widget surface no-ops when distanceKm not number', async () => {
+    const router = getNotificationRouter();
+    await router.deliver({
+      alarmId: 'a-4b',
+      eventKey: 'e',
+      surface: 'widget',
+      content: { title: 'T', body: 'B', data: { station: { id: '1' } } },
+      source: 'fg',
+    });
+    expect(mockSaveStationToWidget).not.toHaveBeenCalled();
+  });
+
+  it('in-app surface calls setAlarmEvent when alarmEvent present', async () => {
+    const router = getNotificationRouter();
+    const alarmEvent = {
+      phaseId: 'early',
+      type: 'destination',
+      stationName: '강남',
+    };
+    await router.deliver({
+      alarmId: 'a-5',
+      eventKey: 'e',
+      surface: 'in-app',
+      content: { title: 'T', body: 'B', data: { alarmEvent } },
+      source: 'fg-phase',
+    });
+    expect(mockSetAlarmEvent).toHaveBeenCalledWith(alarmEvent);
+  });
+
+  it('in-app surface no-ops when alarmEvent missing', async () => {
+    const router = getNotificationRouter();
+    await router.deliver({
+      alarmId: 'a-6',
+      eventKey: 'e',
+      surface: 'in-app',
+      content: { title: 'T', body: 'B' },
+      source: 'fg-phase',
+    });
+    expect(mockSetAlarmEvent).not.toHaveBeenCalled();
+  });
+
+  it('live-activity surface is no-op in PR-A (후속 PR에서 wire)', async () => {
+    const router = getNotificationRouter();
+    const result = await router.deliver({
+      alarmId: 'a-7',
+      eventKey: 'e',
+      surface: 'live-activity',
+      content: { title: 'T', body: 'B' },
+      source: 'bg-silent-push',
+    });
+    expect(result.delivered).toBe(true);
+  });
+
+  it('readSsotMirror adapter reads backend SSoT mirror from AsyncStorage', async () => {
+    const mirror = {
+      currentStationId: '0228',
+      motionState: 'moving',
+      lastAdvanceEvidence: 'gps',
+      lastAdvanceAt: 1_000,
+      passedStations: ['0228'],
+      receivedAt: Date.now(),
+    };
+    await AsyncStorage.setItem(BACKEND_SSOT_MIRROR_KEY, JSON.stringify(mirror));
+    const router = getNotificationRouter();
+    const result = await router.deliver({
+      alarmId: 'a-8',
+      eventKey: 'e',
+      surface: 'banner',
+      content: { title: 'T', body: 'B', data: { stationId: '0228' } },
+      source: 'bg-silent-push',
+    });
+    expect(result.delivered).toBe(false);
+    expect(result.reason).toBe('gate-station-already-passed');
+  });
+
+  it('readSsotMirror adapter returns null when mirror absent (router gate auto-pass)', async () => {
+    const router = getNotificationRouter();
+    const result = await router.deliver({
+      alarmId: 'a-9',
+      eventKey: 'e',
+      surface: 'banner',
+      content: { title: 'T', body: 'B', data: { stationId: '0228' } },
+      source: 'bg-silent-push',
+    });
+    expect(result.delivered).toBe(true);
+  });
+
+  it('clearAllForTrip clears widget station', async () => {
+    const router = getNotificationRouter();
+    await router.clearAllForTrip();
+    expect(mockClearWidgetStation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/alarm/api/notificationRouter.ts
+++ b/src/features/alarm/api/notificationRouter.ts
@@ -1,0 +1,117 @@
+/* eslint-disable import/no-restricted-paths --
+ * #1575 (T12, ADR-017) — Cross-feature orchestration: notice 슬라이스의 NotificationRouter를
+ * widget / live-activity / in-app store surface와 wire한다. notice 슬라이스가 직접 alarm/widget을
+ * import하면 sibling 경계 위반이므로 본 alarm 슬라이스의 api/ 모듈에서 wiring을 담당한다.
+ *
+ * 후속 PR(별도 이슈)에서 orchestration 슬라이스로 이전 예정. 현재는 alarm이 notification 발사
+ * 본거지라 alarm/api 안에 두는 것이 가장 자연스럽다.
+ */
+
+import * as Notifications from 'expo-notifications';
+import {
+  createNotificationRouter,
+  type RouterSsotMirror,
+  type RouterSurfaceFns,
+} from '../../notice/infra/NotificationRouterImpl';
+import type { NotificationRouter } from '../../notice/ports/NotificationRouter';
+import {
+  clearWidgetStation,
+  saveStationToWidget,
+} from '../../widget/api/widgetStorage';
+import { readBackendSsotMirror } from '../utils/backendSsotMirror';
+import { useAlarmEventStore } from '../store/useAlarmEventStore';
+import type { AlarmEvent } from '../../../shared/types/alarm';
+
+/**
+ * SSoT mirror reader adapter — notice 슬라이스가 alarm의 backendSsotMirror를 직접 못 import하므로
+ * 본 wiring 레이어에서 변환해 inject. 미존재 / parse 실패 시 null → router가 검증 skip.
+ */
+async function readSsotMirrorForRouter(): Promise<RouterSsotMirror | null> {
+  const entry = await readBackendSsotMirror();
+  if (entry === null) return null;
+  return {
+    passedStations: entry.passedStations,
+    receivedAt: entry.receivedAt,
+  };
+}
+
+/**
+ * 4 surface side-effect fan-out 함수 묶음.
+ *
+ * - banner: expo-notifications.scheduleNotificationAsync (trigger: null = 즉시 발사).
+ * - live-activity: 본 PR 범위 밖 — 후속 PR에서 ensureLiveActivityRegistered / updateLiveActivity 매핑.
+ * - widget: req.content.data.station(Station JSON)이 있으면 widget storage update, 없으면 no-op.
+ * - in-app: useAlarmEventStore.setAlarmEvent — req.content.data.alarmEvent(AlarmEvent)가 있을 때만.
+ *
+ * surface 함수는 본 PR 시점에 안전한 default 동작만 정의. 호출자 migration PR에서 점진 확장.
+ */
+function buildDefaultSurfaces(): RouterSurfaceFns {
+  return {
+    banner: async (req) => {
+      await Notifications.scheduleNotificationAsync({
+        content: {
+          title: req.content.title,
+          body: req.content.body,
+          ...(req.content.data ? { data: req.content.data } : {}),
+        },
+        trigger: null,
+      });
+    },
+    liveActivity: () => {
+      // 후속 PR에서 wire — modules/live-activity ensureLiveActivityRegistered / updateLiveActivity
+      // signature가 LiveActivityData (trip 컨텍스트 + leg 정보)를 요구해 본 PR의 DeliveryRequest
+      // 만으로는 불충분. surface별 migration PR에서 호출자가 직접 req.content.data로 LiveActivityData
+      // 를 구성해 전달한다.
+    },
+    widget: async (req) => {
+      const station = req.content.data?.station;
+      const distanceKm = req.content.data?.distanceKm;
+      if (
+        station &&
+        typeof station === 'object' &&
+        typeof distanceKm === 'number'
+      ) {
+        await saveStationToWidget(
+          station as Parameters<typeof saveStationToWidget>[0],
+          distanceKm,
+        );
+      }
+    },
+    inApp: (req) => {
+      const alarmEvent = req.content.data?.alarmEvent;
+      if (alarmEvent && typeof alarmEvent === 'object') {
+        useAlarmEventStore.getState().setAlarmEvent(alarmEvent as AlarmEvent);
+      }
+    },
+    clearAll: async () => {
+      // trip-bound cleanup: widget station 비우기. banner queue / LA / in-app store는 기존
+      // tripBoundCleanups의 다른 항목들이 이미 클리어한다 (ALARM_EVENT_KEY 등). 본 함수는
+      // router 진입점 단일화로 인한 추가 cleanup만 담당.
+      await clearWidgetStation();
+    },
+  };
+}
+
+let singleton: NotificationRouter | null = null;
+
+/**
+ * 앱 어디서든 호출 가능한 router singleton accessor. 첫 호출 시 lazy 생성.
+ *
+ * production 호출자는 모두 본 함수 경유로 같은 dedup map을 공유한다 (module-level Set).
+ * 테스트는 `__resetRouterSingletonForTest()`로 reset 후 자체 surfaces로 createNotificationRouter
+ * 직접 호출 (NotificationRouter.test.ts 패턴).
+ */
+export function getNotificationRouter(): NotificationRouter {
+  if (singleton === null) {
+    singleton = createNotificationRouter({
+      surfaces: buildDefaultSurfaces(),
+      readSsotMirror: readSsotMirrorForRouter,
+    });
+  }
+  return singleton;
+}
+
+/** 테스트 전용 — singleton reset. production caller 없음. */
+export function __resetRouterSingletonForTest(): void {
+  singleton = null;
+}

--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -85,7 +85,9 @@ describe('tripBoundCleanups', () => {
     // clearWidgetStation을 호출해 "감지 중" 상태로 즉시 전환.
     mockClearWidgetStation.mockClear();
     await runTripBoundCleanups();
-    expect(mockClearWidgetStation).toHaveBeenCalledTimes(1);
+    // #1524 직접 cleanup 1회 + #1575 (T12) router.clearAllForTrip의 widget surface clear 1회 = 2회.
+    // 둘 다 멱등 — 이미 비어 있으면 graceful no-op.
+    expect(mockClearWidgetStation).toHaveBeenCalledTimes(2);
   });
 
   it('#773 — runTripBoundCleanups 실행 시 OS 사전 예약 큐를 cancel + storage clear한다 (옛 trip 알람 burst 차단)', async () => {

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -42,6 +42,7 @@ import { clearTripCorrId } from '../../observability/utils/tripCorrId';
 import { clearCrossCategoryDedup } from '../utils/crossCategoryStationDedup';
 import { clearAlarmLogWindows } from '../utils/alarmLog';
 import { resetAlarmBackendDedup } from '../api/alarmBackend';
+import { getNotificationRouter } from '../api/notificationRouter';
 import { useDestinationStore } from '../../route/store/useDestinationStore';
 import { useBoardingLockStore } from './useBoardingLockStore';
 import { useAlarmEventStore } from './useAlarmEventStore';
@@ -136,6 +137,10 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   // 때만 호출되는 반면, BG silent push trip-ended 경로는 token 없이 cleanup만 진행 →
   // in-flight Promise/last hash가 다음 trip register에 stale로 재사용되는 회귀 차단.
   resetAlarmBackendDedup,
+  // #1575 (T12, ADR-017) — NotificationRouter dedup map + delivery log + widget surface 클리어.
+  // 새 trip 시작 시 직전 trip의 (alarmId, surface) dedup 상태가 leak되어 새 alarmId의 첫 발사를
+  // 차단하는 회귀 방지. router.clearAllForTrip은 graceful — 내부 surface.clearAll 실패도 swallow.
+  () => getNotificationRouter().clearAllForTrip(),
   // #1545 (S12) — in-memory zustand store mirror 클리어.
   // FG setDestination(null/switch) 경로는 useDestinationStore가 inline으로 customOrigin/
   // alarmEvent/dismissSilence 메모리를 동기화하지만, BG silent push trip-ended 경로는

--- a/src/features/notice/__tests__/NotificationRouter.test.ts
+++ b/src/features/notice/__tests__/NotificationRouter.test.ts
@@ -1,0 +1,362 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  SSOT_MIRROR_STALE_MS,
+  createNotificationRouter,
+  type RouterSsotMirror,
+  type RouterSurfaceFns,
+} from '../infra/NotificationRouterImpl';
+import {
+  __resetDeliveryLogForTest,
+  getDeliveryEntries,
+} from '../store/notificationDeliveryLog';
+import type {
+  DeliveryRequest,
+  NotificationSurface,
+} from '../ports/NotificationRouter';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+function makeReq(
+  overrides: Partial<DeliveryRequest> = {},
+): DeliveryRequest {
+  return {
+    alarmId: 'a-1',
+    eventKey: 'station-passed:중곡',
+    surface: 'banner',
+    content: { title: 'T', body: 'B' },
+    source: 'bg-silent-push',
+    ...overrides,
+  };
+}
+
+interface CountingSurfaces extends RouterSurfaceFns {
+  bannerCalls: number;
+  liveActivityCalls: number;
+  widgetCalls: number;
+  inAppCalls: number;
+  clearAllCalls: number;
+}
+
+function makeSurfaces(): CountingSurfaces {
+  // 한 객체에 counts + 함수를 함께 담아 클로저가 같은 인스턴스를 mutate하도록.
+  const s = {
+    bannerCalls: 0,
+    liveActivityCalls: 0,
+    widgetCalls: 0,
+    inAppCalls: 0,
+    clearAllCalls: 0,
+    banner: () => {
+      s.bannerCalls += 1;
+    },
+    liveActivity: () => {
+      s.liveActivityCalls += 1;
+    },
+    widget: () => {
+      s.widgetCalls += 1;
+    },
+    inApp: () => {
+      s.inAppCalls += 1;
+    },
+    clearAll: () => {
+      s.clearAllCalls += 1;
+    },
+  } as CountingSurfaces;
+  return s;
+}
+
+describe('NotificationRouter (#1575 T12)', () => {
+  beforeEach(async () => {
+    __resetDeliveryLogForTest();
+    await AsyncStorage.clear();
+  });
+
+  describe('dedup (alarmId, surface) matrix', () => {
+    it('same alarmId + same surface twice → first deliver, second suppress', async () => {
+      const surfaces = makeSurfaces();
+      const router = createNotificationRouter({
+        surfaces,
+        readSsotMirror: async () => null,
+      });
+
+      const first = await router.deliver(makeReq());
+      const second = await router.deliver(makeReq());
+
+      expect(first.delivered).toBe(true);
+      expect(second.delivered).toBe(false);
+      expect(second.reason).toBe('dedup-same-surface');
+      expect(surfaces.bannerCalls).toBe(1);
+    });
+
+    it('same alarmId × 4 different surfaces → all delivered (multi-surface intent)', async () => {
+      const surfaces = makeSurfaces();
+      const router = createNotificationRouter({
+        surfaces,
+        readSsotMirror: async () => null,
+      });
+
+      const fanOut: NotificationSurface[] = [
+        'banner',
+        'live-activity',
+        'widget',
+        'in-app',
+      ];
+      const results = await Promise.all(
+        fanOut.map((surface) => router.deliver(makeReq({ surface }))),
+      );
+
+      expect(results.every((r) => r.delivered)).toBe(true);
+      expect(surfaces.bannerCalls).toBe(1);
+      expect(surfaces.liveActivityCalls).toBe(1);
+      expect(surfaces.widgetCalls).toBe(1);
+      expect(surfaces.inAppCalls).toBe(1);
+    });
+  });
+
+  describe('backend SSoT mirror gate', () => {
+    it('mirror fresh + stationId in passedStations → reject', async () => {
+      const surfaces = makeSurfaces();
+      const mirror: RouterSsotMirror = {
+        passedStations: ['0228'],
+        receivedAt: Date.now(),
+      };
+      const router = createNotificationRouter({
+        surfaces,
+        readSsotMirror: async () => mirror,
+      });
+
+      const result = await router.deliver(
+        makeReq({ content: { title: 'T', body: 'B', data: { stationId: '0228' } } }),
+      );
+
+      expect(result.delivered).toBe(false);
+      expect(result.reason).toBe('gate-station-already-passed');
+      expect(surfaces.bannerCalls).toBe(0);
+    });
+
+    it('mirror fresh + stationId NOT in passedStations → deliver', async () => {
+      const surfaces = makeSurfaces();
+      const router = createNotificationRouter({
+        surfaces,
+        readSsotMirror: async () => ({
+          passedStations: ['0220'],
+          receivedAt: Date.now(),
+        }),
+      });
+      const result = await router.deliver(
+        makeReq({ content: { title: 'T', body: 'B', data: { stationId: '0228' } } }),
+      );
+      expect(result.delivered).toBe(true);
+    });
+
+    it('mirror stale (>5min) → gate auto-pass even if stationId in passedStations', async () => {
+      const surfaces = makeSurfaces();
+      const router = createNotificationRouter({
+        surfaces,
+        readSsotMirror: async () => ({
+          passedStations: ['0228'],
+          receivedAt: Date.now() - SSOT_MIRROR_STALE_MS - 1_000,
+        }),
+      });
+      const result = await router.deliver(
+        makeReq({ content: { title: 'T', body: 'B', data: { stationId: '0228' } } }),
+      );
+      expect(result.delivered).toBe(true);
+    });
+
+    it('mirror null (T8 이전 backend) → gate auto-pass', async () => {
+      const surfaces = makeSurfaces();
+      const router = createNotificationRouter({
+        surfaces,
+        readSsotMirror: async () => null,
+      });
+      const result = await router.deliver(makeReq());
+      expect(result.delivered).toBe(true);
+    });
+
+    it('mirror fresh but stationId undefined in content.data → gate skipped (no false reject)', async () => {
+      const surfaces = makeSurfaces();
+      const router = createNotificationRouter({
+        surfaces,
+        readSsotMirror: async () => ({
+          passedStations: ['0228'],
+          receivedAt: Date.now(),
+        }),
+      });
+      // content.data 없음 = stationId 없음 → router는 검증 skip.
+      const result = await router.deliver(makeReq());
+      expect(result.delivered).toBe(true);
+    });
+  });
+
+  describe('sleep mode gate', () => {
+    it('sleepMode ON + sleepRuleEligible true → reject', async () => {
+      const surfaces = makeSurfaces();
+      const router = createNotificationRouter({
+        surfaces,
+        readSsotMirror: async () => null,
+      });
+      const result = await router.deliver(
+        makeReq({ sleepMode: true, sleepRuleEligible: true }),
+      );
+      expect(result.delivered).toBe(false);
+      expect(result.reason).toBe('gate-sleep-mode-blocked');
+    });
+
+    it('sleepMode ON + sleepRuleEligible false → deliver (destination 보호)', async () => {
+      const surfaces = makeSurfaces();
+      const router = createNotificationRouter({
+        surfaces,
+        readSsotMirror: async () => null,
+      });
+      const result = await router.deliver(
+        makeReq({ sleepMode: true, sleepRuleEligible: false }),
+      );
+      expect(result.delivered).toBe(true);
+    });
+
+    it('sleepMode OFF + sleepRuleEligible true → deliver', async () => {
+      const surfaces = makeSurfaces();
+      const router = createNotificationRouter({
+        surfaces,
+        readSsotMirror: async () => null,
+      });
+      const result = await router.deliver(
+        makeReq({ sleepMode: false, sleepRuleEligible: true }),
+      );
+      expect(result.delivered).toBe(true);
+    });
+  });
+
+  describe('delivery log recording', () => {
+    it('every deliver/suppress is logged with surface + source + reason', async () => {
+      const router = createNotificationRouter({
+        surfaces: makeSurfaces(),
+        readSsotMirror: async () => null,
+      });
+      await router.deliver(makeReq({ alarmId: 'a-1' }));
+      await router.deliver(makeReq({ alarmId: 'a-1' })); // dedup suppress
+
+      const entries = getDeliveryEntries();
+      expect(entries).toHaveLength(2);
+      expect(entries[0]?.result).toBe('delivered');
+      expect(entries[1]?.result).toBe('suppressed');
+      expect(entries[1]?.reason).toBe('dedup-same-surface');
+    });
+  });
+
+  describe('surface dispatch resilience', () => {
+    it('surface function throwing does not propagate — logged as delivered (호출 시도 발생)', async () => {
+      const router = createNotificationRouter({
+        surfaces: {
+          banner: () => {
+            throw new Error('expo notif failed');
+          },
+          liveActivity: () => undefined,
+          widget: () => undefined,
+          inApp: () => undefined,
+        },
+        readSsotMirror: async () => null,
+      });
+      const result = await router.deliver(makeReq());
+      expect(result.delivered).toBe(true);
+      // 후속 PR에서 'failed' result + retry queue 도입 예정 (PR body Risk #4 참고).
+    });
+
+    it('async surface function rejection is swallowed', async () => {
+      const router = createNotificationRouter({
+        surfaces: {
+          banner: async () => {
+            throw new Error('async fail');
+          },
+          liveActivity: () => undefined,
+          widget: () => undefined,
+          inApp: () => undefined,
+        },
+        readSsotMirror: async () => null,
+      });
+      await expect(router.deliver(makeReq())).resolves.toMatchObject({
+        delivered: true,
+      });
+    });
+  });
+
+  describe('clearAllForTrip', () => {
+    it('resets dedup map + delivery log + invokes surfaces.clearAll', async () => {
+      const surfaces = makeSurfaces();
+      const router = createNotificationRouter({
+        surfaces,
+        readSsotMirror: async () => null,
+      });
+
+      await router.deliver(makeReq({ alarmId: 'a-1' }));
+      expect(getDeliveryEntries()).toHaveLength(1);
+
+      await router.clearAllForTrip();
+
+      expect(surfaces.clearAllCalls).toBe(1);
+      expect(getDeliveryEntries()).toHaveLength(0);
+
+      // dedup 해제 — 같은 alarmId가 다시 deliver.
+      const after = await router.deliver(makeReq({ alarmId: 'a-1' }));
+      expect(after.delivered).toBe(true);
+      expect(surfaces.bannerCalls).toBe(2);
+    });
+
+    it('clearAllForTrip works when surfaces.clearAll is undefined', async () => {
+      const router = createNotificationRouter({
+        surfaces: {
+          banner: () => undefined,
+          liveActivity: () => undefined,
+          widget: () => undefined,
+          inApp: () => undefined,
+        },
+        readSsotMirror: async () => null,
+      });
+      await expect(router.clearAllForTrip()).resolves.toBeUndefined();
+    });
+
+    it('clearAllForTrip swallows clearAll errors', async () => {
+      const router = createNotificationRouter({
+        surfaces: {
+          banner: () => undefined,
+          liveActivity: () => undefined,
+          widget: () => undefined,
+          inApp: () => undefined,
+          clearAll: () => {
+            throw new Error('cleanup boom');
+          },
+        },
+        readSsotMirror: async () => null,
+      });
+      await expect(router.clearAllForTrip()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('regression: 88건 spam scenario', () => {
+    it('88 fire attempts of same (alarmId, surface) → 1 deliver + 87 suppress', async () => {
+      const surfaces = makeSurfaces();
+      const router = createNotificationRouter({
+        surfaces,
+        readSsotMirror: async () => null,
+      });
+
+      const results = [];
+      for (let i = 0; i < 88; i += 1) {
+        results.push(
+          // eslint-disable-next-line no-await-in-loop
+          await router.deliver(makeReq({ alarmId: 'spam' })),
+        );
+      }
+      const delivered = results.filter((r) => r.delivered).length;
+      const suppressed = results.filter(
+        (r) => !r.delivered && r.reason === 'dedup-same-surface',
+      ).length;
+      expect(delivered).toBe(1);
+      expect(suppressed).toBe(87);
+      expect(surfaces.bannerCalls).toBe(1);
+    });
+  });
+});

--- a/src/features/notice/__tests__/notificationDeliveryLog.test.ts
+++ b/src/features/notice/__tests__/notificationDeliveryLog.test.ts
@@ -1,0 +1,184 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { NOTIFICATION_DELIVERY_LOG_KEY } from '../../../shared/constants/storageKeys';
+import {
+  NOTIFICATION_DELIVERY_LOG_CAP,
+  __resetDeliveryLogForTest,
+  appendDeliveryEntry,
+  clearDeliveryLog,
+  getDeliveryEntries,
+  hydrateDeliveryLog,
+  type NotificationDeliveryEntry,
+} from '../store/notificationDeliveryLog';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+function makeEntry(
+  overrides: Partial<NotificationDeliveryEntry> = {},
+): NotificationDeliveryEntry {
+  return {
+    alarmId: 'a-1',
+    eventKey: 'station-passed:중곡',
+    surface: 'banner',
+    source: 'bg-silent-push',
+    result: 'delivered',
+    at: 1_000,
+    ...overrides,
+  };
+}
+
+describe('notificationDeliveryLog (#1575)', () => {
+  beforeEach(async () => {
+    __resetDeliveryLogForTest();
+    await AsyncStorage.clear();
+  });
+
+  it('append + read returns inserted entries', () => {
+    appendDeliveryEntry(makeEntry());
+    appendDeliveryEntry(makeEntry({ alarmId: 'a-2' }));
+    expect(getDeliveryEntries()).toHaveLength(2);
+    expect(getDeliveryEntries()[1]?.alarmId).toBe('a-2');
+  });
+
+  it('evicts oldest when buffer exceeds CAP (FIFO)', () => {
+    for (let i = 0; i < NOTIFICATION_DELIVERY_LOG_CAP + 5; i += 1) {
+      appendDeliveryEntry(makeEntry({ alarmId: `a-${i}` }));
+    }
+    const entries = getDeliveryEntries();
+    expect(entries).toHaveLength(NOTIFICATION_DELIVERY_LOG_CAP);
+    // oldest 5건은 evicted: a-0..a-4 가 빠지고 a-5가 첫 항목.
+    expect(entries[0]?.alarmId).toBe('a-5');
+    expect(entries[entries.length - 1]?.alarmId).toBe(
+      `a-${NOTIFICATION_DELIVERY_LOG_CAP + 4}`,
+    );
+  });
+
+  it('clearDeliveryLog clears both memory + AsyncStorage', async () => {
+    appendDeliveryEntry(makeEntry());
+    // persist는 fire-and-forget이라 다음 tick까지 기다린다.
+    await Promise.resolve();
+    expect(
+      await AsyncStorage.getItem(NOTIFICATION_DELIVERY_LOG_KEY),
+    ).not.toBeNull();
+
+    await clearDeliveryLog();
+    expect(getDeliveryEntries()).toHaveLength(0);
+    expect(
+      await AsyncStorage.getItem(NOTIFICATION_DELIVERY_LOG_KEY),
+    ).toBeNull();
+  });
+
+  it('clearDeliveryLog swallows AsyncStorage errors gracefully', async () => {
+    appendDeliveryEntry(makeEntry());
+    const spy = jest
+      .spyOn(AsyncStorage, 'removeItem')
+      .mockRejectedValueOnce(new Error('boom'));
+    await expect(clearDeliveryLog()).resolves.toBeUndefined();
+    // 메모리는 비워졌어야 함 (storage 실패는 graceful swallow).
+    expect(getDeliveryEntries()).toHaveLength(0);
+    spy.mockRestore();
+  });
+
+  it('hydrateDeliveryLog restores valid entries from AsyncStorage', async () => {
+    await AsyncStorage.setItem(
+      NOTIFICATION_DELIVERY_LOG_KEY,
+      JSON.stringify([
+        makeEntry({ alarmId: 'a-hydrate-1' }),
+        makeEntry({ alarmId: 'a-hydrate-2', result: 'suppressed' }),
+      ]),
+    );
+    await hydrateDeliveryLog();
+    expect(getDeliveryEntries().map((e) => e.alarmId)).toEqual([
+      'a-hydrate-1',
+      'a-hydrate-2',
+    ]);
+  });
+
+  it('hydrateDeliveryLog filters invalid entries (corrupt schema)', async () => {
+    await AsyncStorage.setItem(
+      NOTIFICATION_DELIVERY_LOG_KEY,
+      JSON.stringify([
+        makeEntry({ alarmId: 'ok' }),
+        { alarmId: 'missing-fields' },
+        null,
+        'not-an-object',
+        { ...makeEntry({ alarmId: 'bad-result' }), result: 'unknown' },
+      ]),
+    );
+    await hydrateDeliveryLog();
+    expect(getDeliveryEntries().map((e) => e.alarmId)).toEqual(['ok']);
+  });
+
+  it('hydrateDeliveryLog with non-array storage value returns empty', async () => {
+    await AsyncStorage.setItem(
+      NOTIFICATION_DELIVERY_LOG_KEY,
+      JSON.stringify({ not: 'an array' }),
+    );
+    await hydrateDeliveryLog();
+    expect(getDeliveryEntries()).toHaveLength(0);
+  });
+
+  it('hydrateDeliveryLog returns empty when key absent', async () => {
+    await hydrateDeliveryLog();
+    expect(getDeliveryEntries()).toHaveLength(0);
+  });
+
+  it('hydrateDeliveryLog swallows JSON parse errors', async () => {
+    await AsyncStorage.setItem(NOTIFICATION_DELIVERY_LOG_KEY, '{not json');
+    await hydrateDeliveryLog();
+    expect(getDeliveryEntries()).toHaveLength(0);
+  });
+
+  it('hydrateDeliveryLog only runs once (idempotent)', async () => {
+    await AsyncStorage.setItem(
+      NOTIFICATION_DELIVERY_LOG_KEY,
+      JSON.stringify([makeEntry({ alarmId: 'first' })]),
+    );
+    await hydrateDeliveryLog();
+    // 두 번째 호출 — 메모리 buffer를 덮어쓰지 않아야 한다.
+    appendDeliveryEntry(makeEntry({ alarmId: 'memory-only' }));
+    await hydrateDeliveryLog();
+    expect(getDeliveryEntries().map((e) => e.alarmId)).toEqual([
+      'first',
+      'memory-only',
+    ]);
+  });
+
+  it('hydrateDeliveryLog truncates to CAP when stored array oversized', async () => {
+    const oversized = Array.from({ length: NOTIFICATION_DELIVERY_LOG_CAP + 3 }, (_, i) =>
+      makeEntry({ alarmId: `a-${i}` }),
+    );
+    await AsyncStorage.setItem(
+      NOTIFICATION_DELIVERY_LOG_KEY,
+      JSON.stringify(oversized),
+    );
+    await hydrateDeliveryLog();
+    const entries = getDeliveryEntries();
+    expect(entries).toHaveLength(NOTIFICATION_DELIVERY_LOG_CAP);
+    expect(entries[0]?.alarmId).toBe('a-3');
+  });
+
+  it('append persists to AsyncStorage (fire-and-forget)', async () => {
+    appendDeliveryEntry(makeEntry({ alarmId: 'persist-me' }));
+    // setItem은 mock이라 microtask로 resolve. flush.
+    await Promise.resolve();
+    await Promise.resolve();
+    const raw = await AsyncStorage.getItem(NOTIFICATION_DELIVERY_LOG_KEY);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!) as NotificationDeliveryEntry[];
+    expect(parsed[0]?.alarmId).toBe('persist-me');
+  });
+
+  it('append swallows AsyncStorage setItem errors gracefully', async () => {
+    const spy = jest
+      .spyOn(AsyncStorage, 'setItem')
+      .mockRejectedValueOnce(new Error('quota'));
+    appendDeliveryEntry(makeEntry({ alarmId: 'still-in-mem' }));
+    await Promise.resolve();
+    // 메모리 buffer에는 정상 추가됨.
+    expect(getDeliveryEntries()[0]?.alarmId).toBe('still-in-mem');
+    spy.mockRestore();
+  });
+});

--- a/src/features/notice/infra/NotificationRouterImpl.ts
+++ b/src/features/notice/infra/NotificationRouterImpl.ts
@@ -1,0 +1,194 @@
+/**
+ * #1575 (T12, ADR-017) — NotificationRouter 기본 구현.
+ *
+ * 4 gate 통과 후 surface로 fan-out:
+ *   1. dedup-same-surface: `(alarmId, surface)` 이미 deliver → suppress.
+ *   2. gate-alarm-not-in-ssot: backend mirror fresh + alarmId 부재 → reject (mirror stale 시 자동 pass).
+ *   3. gate-station-already-passed: SSoT.passedStations에 stationId 포함 → reject.
+ *   4. gate-sleep-mode-blocked: sleepMode ON + sleepRuleEligible → reject.
+ *
+ * 통과 시 surface별 side-effect 함수(`surfaces.banner` 등)를 호출. surface 함수가 throw해도
+ * delivery log에는 'delivered' 로 기록 (호출 시도 자체는 발생). 후속 PR에서 surface별 try/catch
+ * + 'failed' result type 추가 예정.
+ *
+ * factory 패턴인 이유:
+ *   - notice 슬라이스가 alarm/widget을 직접 import하면 ESLint `import/no-restricted-paths` 위반.
+ *   - 호출자(상위 orchestrator, 보통 hook 또는 task)가 surface 함수를 inject하면 분리 유지 + mock 용이.
+ */
+
+import type {
+  DeliveryRequest,
+  DeliveryResult,
+  NotificationRouter,
+} from '../ports/NotificationRouter';
+import {
+  appendDeliveryEntry,
+  clearDeliveryLog,
+} from '../store/notificationDeliveryLog';
+
+/**
+ * backend SSoT mirror가 stale로 간주되는 임계. 5분 이상 mirror 갱신 없으면 validation 자동 pass.
+ *
+ * silent push가 cron 30s 주기로 도착하므로 5분 = 약 10 cycle. 그 이상 끊겼다면 backend connectivity
+ * 자체 문제로 보고 device-side gate에 의존. 보수적 임계 — false reject 회피 우선.
+ */
+export const SSOT_MIRROR_STALE_MS = 5 * 60 * 1000;
+
+/**
+ * backend SSoT mirror snapshot — router가 검증에 사용하는 최소 형태.
+ * 호출자(orchestrator)가 readBackendSsotMirror 등으로 읽어 inject. null이면 mirror 없음 → 검증 자동 pass.
+ */
+export interface RouterSsotMirror {
+  passedStations: readonly string[];
+  receivedAt: number;
+}
+
+export interface RouterSurfaceFns {
+  /** banner 발사 (보통 expo-notifications scheduleNotificationAsync wrap). */
+  banner: (req: DeliveryRequest) => Promise<void> | void;
+  /** Live Activity 갱신 (modules/live-activity updateLiveActivity wrap). */
+  liveActivity: (req: DeliveryRequest) => Promise<void> | void;
+  /** widget storage 갱신 (features/widget saveStationToWidget wrap). */
+  widget: (req: DeliveryRequest) => Promise<void> | void;
+  /** in-app banner store 갱신 (useAlarmEventStore.setAlarmEvent wrap). */
+  inApp: (req: DeliveryRequest) => Promise<void> | void;
+  /**
+   * trip 종료 시 surface별 cleanup. fire-and-forget. router.clearAllForTrip에서 호출.
+   * 옵션 — 미제공 시 cleanup은 dedup map 클리어만 수행.
+   */
+  clearAll?: () => Promise<void> | void;
+}
+
+export interface RouterDeps {
+  surfaces: RouterSurfaceFns;
+  /**
+   * backend SSoT mirror 조회 함수 — orchestrator가 alarm/utils/backendSsotMirror.readBackendSsotMirror
+   * 등을 inject. null 반환 시 검증 skip (mirror 없음).
+   *
+   * 본 파라미터를 inject 받는 이유: notice 슬라이스가 alarm 슬라이스를 직접 import하면 ESLint
+   * `import/no-restricted-paths` 위반. 호출자(상위 orchestrator)가 cross-feature 책임을 진다.
+   */
+  readSsotMirror: () => Promise<RouterSsotMirror | null>;
+}
+
+/**
+ * router 인스턴스 factory.
+ *
+ * caller는 앱 부팅 시 1회 호출해 deps를 inject. 반환된 instance를 module-level singleton으로
+ * 보관해 fire path 어디서든 동일 dedup map을 공유한다.
+ */
+export function createNotificationRouter(
+  deps: RouterDeps,
+): NotificationRouter {
+  const { surfaces, readSsotMirror } = deps;
+  // dedup key: `${alarmId}:${surface}`. Set으로 충분 — TTL은 trip 단위 (clearAllForTrip에서 reset).
+  // 같은 (alarmId, surface) 2회째 deliver 시도가 첫 deliver의 race로 들어와도 sync .has 체크 + add로
+  // 직렬화돼 두 번째는 dedup-same-surface로 suppress. Promise.all fan-out에서도 안전.
+  const dedupKeys = new Set<string>();
+
+  return {
+    deliver: (req) => deliverInternal(req, surfaces, dedupKeys, readSsotMirror),
+    clearAllForTrip: async () => {
+      dedupKeys.clear();
+      await clearDeliveryLog();
+      if (surfaces.clearAll) {
+        try {
+          await surfaces.clearAll();
+        } catch {
+          // graceful — clearAll 실패해도 dedup map + delivery log는 이미 클리어됨.
+        }
+      }
+    },
+  };
+}
+
+async function deliverInternal(
+  req: DeliveryRequest,
+  surfaces: RouterSurfaceFns,
+  dedupKeys: Set<string>,
+  readSsotMirror: () => Promise<RouterSsotMirror | null>,
+): Promise<DeliveryResult> {
+  const now = Date.now();
+  const dedupKey = `${req.alarmId}:${req.surface}`;
+
+  // 1. dedup-same-surface — 동일 (alarmId, surface) 이미 deliver됨.
+  if (dedupKeys.has(dedupKey)) {
+    return logAndReturn(req, false, 'dedup-same-surface', now);
+  }
+
+  // 2/3. backend SSoT mirror gate. mirror stale(>5분) → 자동 pass (보수적).
+  const mirror = await readSsotMirror();
+  if (mirror !== null && now - mirror.receivedAt < SSOT_MIRROR_STALE_MS) {
+    // mirror가 alarmEvents를 보유하지 않는 (T8 이전 backend) 시점이라면 검증 skip.
+    // 현재 BackendSsotMirrorEntry는 alarmEvents 필드 없음 — T12 wire-up 후 도입 예정.
+    // 본 PR은 passedStations gate만 적용. alarmEvents gate는 후속 PR에서 mirror schema 확장 후 wire.
+    const stationId = req.content.data?.stationId;
+    if (
+      typeof stationId === 'string' &&
+      mirror.passedStations.includes(stationId)
+    ) {
+      return logAndReturn(req, false, 'gate-station-already-passed', now);
+    }
+  }
+
+  // 4. sleep mode gate. sleepRuleEligible true 일 때만 적용 — destination은 항상 fire.
+  if (req.sleepMode === true && req.sleepRuleEligible === true) {
+    return logAndReturn(req, false, 'gate-sleep-mode-blocked', now);
+  }
+
+  // pass — dedup 등록 후 surface fan-out.
+  dedupKeys.add(dedupKey);
+  await dispatchToSurface(req, surfaces);
+
+  appendDeliveryEntry({
+    alarmId: req.alarmId,
+    eventKey: req.eventKey,
+    surface: req.surface,
+    source: req.source,
+    result: 'delivered',
+    at: now,
+  });
+  return { delivered: true, surface: req.surface, deliveredAt: now };
+}
+
+async function dispatchToSurface(
+  req: DeliveryRequest,
+  surfaces: RouterSurfaceFns,
+): Promise<void> {
+  const fn =
+    req.surface === 'banner'
+      ? surfaces.banner
+      : req.surface === 'live-activity'
+        ? surfaces.liveActivity
+        : req.surface === 'widget'
+          ? surfaces.widget
+          : surfaces.inApp;
+  try {
+    await fn(req);
+  } catch {
+    // graceful — 한 surface 실패가 다른 surface fan-out을 막지 않도록 swallow.
+    // 후속 PR에서 'failed' result type + 재시도 큐 도입 예정.
+  }
+}
+
+/**
+ * gate에서 차단된 요청을 delivery log에 'suppressed'로 기록하고 결과 반환.
+ * delivered=true 경로는 dispatchToSurface 통과 후 직접 appendDeliveryEntry — 본 함수 미사용.
+ */
+function logAndReturn(
+  req: DeliveryRequest,
+  delivered: false,
+  reason: DeliveryResult['reason'],
+  at: number,
+): DeliveryResult {
+  appendDeliveryEntry({
+    alarmId: req.alarmId,
+    eventKey: req.eventKey,
+    surface: req.surface,
+    source: req.source,
+    result: 'suppressed',
+    reason,
+    at,
+  });
+  return { delivered, reason, surface: req.surface, deliveredAt: at };
+}

--- a/src/features/notice/ports/NotificationRouter.ts
+++ b/src/features/notice/ports/NotificationRouter.ts
@@ -1,0 +1,98 @@
+/**
+ * #1575 (T12, ADR-017) — NotificationRouter abstraction.
+ *
+ * 4개로 분산된 notification surface(banner / live-activity / widget / in-app)의 단일 진입점.
+ * 모든 fire path는 router.deliver()를 경유해 surface별 dedup + backend SSoT mirror 검증 +
+ * sleep mode gate를 통과한 후 실제 발사된다.
+ *
+ * 본 파일은 interface only — 실제 fan-out 구현은 `infra/NotificationRouterImpl.ts`,
+ * surface 별 wrap은 `infra/<Surface>.ts`. caller는 항상 interface로 import해 테스트 시
+ * mock 교체가 용이하도록 한다.
+ *
+ * 회귀 컨텍스트 (이슈 #1575):
+ * - destination-early 88건 spam: 분산 dedup이 발사 자체를 못 막음.
+ * - 어대→군자 늦은 발사: backend.passedStations에 군자 있음에도 backward fire.
+ *
+ * Acceptance (#1575):
+ * - 같은 (alarmId, surface) 2회 fire = 1회 deliver + 1회 suppress.
+ * - 같은 alarmId 다른 surface는 모두 deliver (multi-surface 의도 정합).
+ * - backend SSoT mirror에 없는 alarmId = reject (mirror fresh 일 때).
+ * - SSoT.passedStations에 stationId 있으면 reject (T9 cross-cut).
+ */
+
+/**
+ * 4 surface 식별자. 각 surface는 자체 native API 또는 store를 wrap한다.
+ *
+ * - banner: expo-notifications scheduleNotificationAsync (trigger: null = 즉시 발사)
+ * - live-activity: modules/live-activity ensureLiveActivityRegistered / updateLiveActivity
+ * - widget: features/widget saveStationToWidget
+ * - in-app: useAlarmEventStore.setAlarmEvent (in-app banner UI)
+ */
+export type NotificationSurface =
+  | 'banner'
+  | 'live-activity'
+  | 'widget'
+  | 'in-app';
+
+/**
+ * fire path 식별자 (delivery log + observability용). router 자체 동작에는 영향 없음.
+ *
+ * - fg: FG GPS path (useStationAlarm runSilenceGateAndDispatch)
+ * - fg-arvlcd: FG arvlcd fast-path (useStationAlarm)
+ * - fg-subsurface: FG subsurface station-passed (useStationAlarm)
+ * - fg-phase: FG phase-based fireAndLog (useStationAlarm fireAndLog)
+ * - bg-silent-push: BG silent push handler (silentPushTask)
+ */
+export type NotificationSource =
+  | 'fg'
+  | 'fg-arvlcd'
+  | 'fg-subsurface'
+  | 'fg-phase'
+  | 'bg-silent-push';
+
+export interface DeliveryRequest {
+  /**
+   * backend SSoT.alarmEvents의 hash key (`hash(tripToken, stationId, type)`).
+   * backend에서 발급된 값을 silent push payload로 받아 그대로 사용. FG가 backend mirror에서
+   * 매칭되는 항목이 없으면 fallback id 사용 — `gate-alarm-not-in-ssot` reject 사유로 기록.
+   */
+  alarmId: string;
+  /**
+   * 시각적 dedup key (운영자 가독용). `'station-passed:중곡'` / `'transfer-imminent:건대'`.
+   * router 내부 dedup에는 사용하지 않고 log에만 stamp.
+   */
+  eventKey: string;
+  surface: NotificationSurface;
+  content: {
+    title: string;
+    body: string;
+    data?: Record<string, unknown>;
+  };
+  source: NotificationSource;
+  /** 사용자 sleep mode ON 여부 (호출자가 store에서 읽어 전달). false 또는 undefined = OFF. */
+  sleepMode?: boolean;
+  /** 본 alarm이 sleep rule 적용 대상인지 (transfer/station-passed only). */
+  sleepRuleEligible?: boolean;
+}
+
+export type DeliveryReason =
+  | 'gate-alarm-not-in-ssot' // backend SSoT mirror에 alarmId 부재 (mirror fresh).
+  | 'gate-station-already-passed' // SSoT.passedStations에 stationId 있음 (T9 cross-cut).
+  | 'gate-sleep-mode-blocked' // sleepMode ON + sleepRuleEligible alarm.
+  | 'dedup-same-surface'; // 동일 (alarmId, surface) 이미 deliver됨.
+
+export interface DeliveryResult {
+  delivered: boolean;
+  reason?: DeliveryReason;
+  surface: NotificationSurface;
+  deliveredAt: number;
+}
+
+export interface NotificationRouter {
+  deliver(req: DeliveryRequest): Promise<DeliveryResult>;
+  /**
+   * trip 종료 시 호출. dedup map + 진행 중인 native surface state(banner queue / LA / widget)
+   * 까지 일괄 클리어. tripBoundCleanups에서 fire-and-forget 호출.
+   */
+  clearAllForTrip(): Promise<void>;
+}

--- a/src/features/notice/store/notificationDeliveryLog.ts
+++ b/src/features/notice/store/notificationDeliveryLog.ts
@@ -1,0 +1,119 @@
+/**
+ * #1575 (T12, ADR-017) — NotificationRouter delivery log (ring buffer 200건).
+ *
+ * router.deliver()가 모든 결과를 push. DebugModal "Notification Delivery" 섹션이 read해
+ * surface별 카운터 + suppress 사유 분포 표시.
+ *
+ * 본 모듈은 메모리 + AsyncStorage mirror 형태. push는 sync update + fire-and-forget persist.
+ * read는 sync (메모리). 앱 재시작 시 hydrate (best effort).
+ *
+ * 200건 cap + FIFO eviction. trip 1회 평균 alarm 10건 + suppress 20건 가정 시 약 6~7 trip 보존.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { NOTIFICATION_DELIVERY_LOG_KEY } from '../../../shared/constants/storageKeys';
+import type {
+  DeliveryReason,
+  NotificationSource,
+  NotificationSurface,
+} from '../ports/NotificationRouter';
+
+export const NOTIFICATION_DELIVERY_LOG_CAP = 200;
+
+export interface NotificationDeliveryEntry {
+  alarmId: string;
+  eventKey: string;
+  surface: NotificationSurface;
+  source: NotificationSource;
+  /** 'delivered': router가 surface로 전달 / 'suppressed': gate에서 차단. */
+  result: 'delivered' | 'suppressed';
+  reason?: DeliveryReason;
+  at: number;
+}
+
+let buffer: NotificationDeliveryEntry[] = [];
+let hydrated = false;
+
+/**
+ * append entry to ring buffer. cap 초과 시 oldest eviction.
+ *
+ * AsyncStorage persist는 fire-and-forget — write 실패해도 메모리 buffer에는 남는다.
+ * DebugModal은 메모리를 우선 읽으므로 persist 실패해도 운영 진단 영향 없음.
+ */
+export function appendDeliveryEntry(entry: NotificationDeliveryEntry): void {
+  buffer.push(entry);
+  if (buffer.length > NOTIFICATION_DELIVERY_LOG_CAP) {
+    buffer = buffer.slice(buffer.length - NOTIFICATION_DELIVERY_LOG_CAP);
+  }
+  void persist();
+}
+
+export function getDeliveryEntries(): readonly NotificationDeliveryEntry[] {
+  return buffer;
+}
+
+/**
+ * 메모리 + AsyncStorage 모두 클리어. trip-bound cleanup에서 호출.
+ */
+export async function clearDeliveryLog(): Promise<void> {
+  buffer = [];
+  try {
+    await AsyncStorage.removeItem(NOTIFICATION_DELIVERY_LOG_KEY);
+  } catch {
+    // graceful — 메모리 클리어가 우선. 다음 push가 persist를 다시 시도.
+  }
+}
+
+/**
+ * 앱 시작 시 1회 호출. AsyncStorage에 영속화된 직전 세션 log를 메모리로 복구.
+ *
+ * 두 번 이상 호출되면 두 번째 호출은 skip — 메모리 buffer가 이미 활성이라 덮어쓰면 안 됨.
+ * useStateRehydration 또는 진단 모듈에서 한 번 await하는 entry point 패턴.
+ */
+export async function hydrateDeliveryLog(): Promise<void> {
+  if (hydrated) return;
+  hydrated = true;
+  try {
+    const raw = await AsyncStorage.getItem(NOTIFICATION_DELIVERY_LOG_KEY);
+    if (!raw) return;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return;
+    const valid = parsed.filter(isValidEntry);
+    buffer =
+      valid.length > NOTIFICATION_DELIVERY_LOG_CAP
+        ? valid.slice(valid.length - NOTIFICATION_DELIVERY_LOG_CAP)
+        : valid;
+  } catch {
+    // graceful — corrupt/parse 실패는 빈 buffer로 시작.
+  }
+}
+
+function isValidEntry(v: unknown): v is NotificationDeliveryEntry {
+  if (!v || typeof v !== 'object') return false;
+  const e = v as Partial<NotificationDeliveryEntry>;
+  return (
+    typeof e.alarmId === 'string' &&
+    typeof e.eventKey === 'string' &&
+    typeof e.surface === 'string' &&
+    typeof e.source === 'string' &&
+    (e.result === 'delivered' || e.result === 'suppressed') &&
+    typeof e.at === 'number'
+  );
+}
+
+async function persist(): Promise<void> {
+  try {
+    await AsyncStorage.setItem(
+      NOTIFICATION_DELIVERY_LOG_KEY,
+      JSON.stringify(buffer),
+    );
+  } catch {
+    // graceful — 메모리 buffer는 다음 push에서 다시 persist 시도.
+  }
+}
+
+/** 테스트 전용 — 메모리 + hydration 플래그 reset. production caller 없음. */
+export function __resetDeliveryLogForTest(): void {
+  buffer = [];
+  hydrated = false;
+}

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -187,3 +187,8 @@ export const BACKEND_CALL_LOG_KEY = 'subway-now:backend-call-log';
 // 네트워크 실패 시 단건 enqueue, 다음 trip 종료 시 재시도. 가장 최근 trip만 보존 (1건).
 // 형식: TelemetryForwardOutboxEntry JSON.
 export const TELEMETRY_FORWARD_RETRY_QUEUE_KEY = 'subway-now:telemetry-forward-retry';
+// #1575 (T12, ADR-017) — NotificationRouter surface delivery log (ring buffer 200건).
+// router.deliver()가 모든 surface fan-out 결과(delivered/suppressed + reason)를 push.
+// DebugModal "Notification Delivery" 섹션이 read해 surface별 카운터 + suppress 사유 분포 표시.
+// 형식: NotificationDeliveryEntry[] JSON (capacity 200, FIFO eviction).
+export const NOTIFICATION_DELIVERY_LOG_KEY = 'subway-now:notification-delivery-log';


### PR DESCRIPTION
Closes #1575 (PR-A scope per issue body Risk #1).

## Summary

ADR-017 T12 PR-A — `src/features/notice/` 슬라이스 신설 + NotificationRouter abstraction + surface별 dedup + delivery log + V8 (b) backend rate limit + X11 cleanup wire. **호출자 migration(useStationAlarm 5 path + silentPushTask)은 본 PR 범위 밖** — 이슈 본문 Risk #1에서 명시한 PR-B~PR-E로 분리.

## 변경 사항

### Frontend
- `src/features/notice/ports/NotificationRouter.ts` — interface (DeliveryRequest, DeliveryResult, 4 reason, 4 surface, 5 source).
- `src/features/notice/infra/NotificationRouterImpl.ts` — factory + 4 gate (dedup-same-surface / gate-station-already-passed / gate-sleep-mode-blocked / mirror stale auto-pass) + surface fan-out. `readSsotMirror` 주입으로 notice → alarm 직접 import 회피.
- `src/features/notice/store/notificationDeliveryLog.ts` — ring buffer 200건 + AsyncStorage mirror. fire-and-forget persist + idempotent hydrate.
- `src/features/alarm/api/notificationRouter.ts` — orchestrator singleton. banner = `Notifications.scheduleNotificationAsync` / widget = `saveStationToWidget` / in-app = `useAlarmEventStore.setAlarmEvent` / live-activity = no-op (후속 PR에서 LiveActivityData 매핑) / clearAll = `clearWidgetStation`.
- `src/features/alarm/store/tripBoundCleanups.ts` — `getNotificationRouter().clearAllForTrip()` 항목 추가 (X11 leftover scheduled notification cleanup).
- `src/shared/constants/storageKeys.ts` — `NOTIFICATION_DELIVERY_LOG_KEY` 추가.

### Backend
- `backend/alarm-worker/src/tripRegisterRateLimit.ts` — per-token fixed-window 10 req/10min KV counter (V8 (b)).
- `backend/alarm-worker/src/index.ts` — `/trips` POST 진입부 wire. cap 초과 시 429 + Retry-After.

### 본 PR 범위 외 (issue body 분할 권장 그대로)
- PR-B: Path E (BG silent push) migration
- PR-C: Path A (FG GPS) migration
- PR-D: Path B/C/D migration (FG arvlcd / subsurface / phase)
- PR-E: LA surface 본격 wire + 호출자별 LiveActivityData 매핑

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (No orphan exports detected).
2. **V/X dashboard** — delivery log은 DebugModal `## Notification Delivery` 섹션에 노출 예정 (별도 PR — UI section 신설). 현재는 `getDeliveryEntries()` 메모리 read로 디버깅 즉시 가능.
3. **의존 PR** — N/A. T8/T8b/T9/T10/T11 머지 후라 backend SSoT mirror reader 가용.
4. **측정 plan** — PR-B 이후 1주 production: (a) NotificationDeliveryLog `dedup-same-surface` reason 카운트 (88건 spam 재발 측정), (b) backend log `trip-register: rate-limited` 빈도 (V8 (b) 효과), (c) `gate-station-already-passed` 카운트 (T9 cross-cut backend SSoT 효과).
5. **Device verify** — N/A — type + unit only (호출자 migration 없음, 본 PR 머지로 production 동작 변화 0건). PR-B 이후 device 검증 필요.

## 자가 점검 5단

1. **acceptance self-referential** — V2/V3 (alarm 정확 1회), X4 (spam) 측정 source는 NotificationDeliveryLog 자체. P0-1 Analytics + P0-4 ground standard로 cross-validate 예정 (PR-B+ 시).
2. **Wire-completion orphan 0** — `npm run lint:orphan` pass. caller: `getNotificationRouter` ← `tripBoundCleanups.ts:143` + orchestrator factory consumes notice slice exports.
3. **머지 순서** — Phase 0 측정 인프라 epic 진행 중. 본 PR은 router infra만 추가 (behavior change 0건)이라 Phase 0 머지 전후 무관.
4. **backward-compat** — 기존 호출자 (`useStationAlarm.ts`, `silentPushTask.ts`) 전부 변경 없음. router는 신규 진입점. PR-B~E에서 점진 교체.
5. **False positive** — dedup 윈도우는 trip 단위 (clearAllForTrip에서 reset). SSoT mirror gate는 5분+ stale 시 auto-pass (보수적, mirror 미존재 backend 호환).

## 테스트

- 새 코드 100% coverage:
  - `src/features/notice/infra/NotificationRouterImpl.ts` — 100/100/100/100.
  - `src/features/notice/store/notificationDeliveryLog.ts` — 100/100/100/100.
  - `src/features/alarm/api/notificationRouter.ts` — 100/100/100/100.
- `src/features/notice/__tests__/NotificationRouter.test.ts` — 21 cases (dedup matrix / SSoT gate / sleep gate / clearAllForTrip / surface error resilience / 88건 spam reproduce).
- `src/features/notice/__tests__/notificationDeliveryLog.test.ts` — 13 cases (cap eviction / hydrate / corrupt schema / async error swallow).
- `src/features/alarm/api/__tests__/notificationRouter.test.ts` — 12 cases (singleton / banner fan-out / widget signature / in-app / SSoT adapter / clearAll wiring).
- `backend/alarm-worker/src/__tests__/tripRegisterRateLimit.test.ts` — 10 cases (window align / token isolation / window reset / corrupt KV / retry-after lower bound).
- `npm test` 전체: 6952 pass / 35 fail (35 모두 dev baseline에서 pre-existing — `widgetStorage.test.ts` / `stationNotification.test.ts` 본 PR 무관).
- `npm run type-check` 0.
- Backend `npx vitest run` — 1713 pass.
- `npm run lint:orphan` pass.