### PR TITLE
feat(#1502): trip 종료 시 사용자 정답지 prompt 자동 노출 (M2)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -15,6 +15,7 @@ import { useDebugStore } from '../src/features/debug/store/useDebugStore';
 import { useDestinationStore } from '../src/features/route/store/useDestinationStore';
 import { useLocaleStore } from '../src/shared/i18n/store/useLocaleStore';
 import { DebugModal } from '../src/features/debug/components/DebugModal';
+import { TripGroundTruthPrompt } from '../src/features/debug/components/TripGroundTruthPrompt';
 import { isDebugModalEnabled } from '../src/shared/constants/debugFlags';
 import '../src/features/nearest-station/tasks/backgroundLocationTask';
 import { registerSilentPushTask } from '../src/features/alarm/tasks/silentPushTask';
@@ -148,6 +149,8 @@ function RootContent() {
       {isDebugModalEnabled() && debugVisible && (
         <DebugModal onClose={() => setDebugVisible(false)} />
       )}
+      {/* #1502 (M2) — trip 종료 정답지 prompt. DebugModal 토글 무관 항상 마운트. */}
+      {isDebugModalEnabled() && <TripGroundTruthPrompt />}
     </>
   );
 }

--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -429,7 +429,9 @@ describe('tripBoundCleanups', () => {
     // resetAlarmBackendDedup / clearTripBoundStoreMemory)은 storage write를 하지 않는
     // module-level/memory 클리어라 removeItem 카운트에 기여하지 않는다. 신규 항목 수만큼
     // 임계값을 낮춰 기존 invariant(storage 기반 항목 모두 실행)는 유지.
-    const NON_STORAGE_CLEANUPS = 4;
+    // #1502 (M2) — triggerTripGroundTruthPrompt는 zustand setState만 수행 (storage는
+    // AsyncStorage.setItem이라 removeItem 카운트와 무관) → NON_STORAGE 5로 증가.
+    const NON_STORAGE_CLEANUPS = 5;
     expect((AsyncStorage.removeItem as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(
       TRIP_BOUND_CLEANUPS.length - NON_STORAGE_CLEANUPS,
     );

--- a/src/features/alarm/store/__tests__/tripBoundCleanupsAudit.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanupsAudit.test.ts
@@ -225,9 +225,24 @@ describe('#1545 (S12) — TRIP_BOUND_CLEANUPS enumeration audit', () => {
     expect(TRIP_BOUND_CLEANUPS).toContain(resetAlarmBackendDedup);
   });
 
-  it('baseline 25 항목(기존 22 + S12 신규 3 wrapper + storeMemory 1)에서 줄어들면 회귀', () => {
+  it('baseline 26 항목(기존 25 + #1502 ground-truth trigger 1)에서 줄어들면 회귀', () => {
     const { TRIP_BOUND_CLEANUPS } = jest.requireActual('../tripBoundCleanups');
     // 현재 baseline. 새 항목 추가 시 한 줄 갱신. 누군가 항목을 의도치 않게 제거하면 회귀로 감지.
-    expect(TRIP_BOUND_CLEANUPS.length).toBeGreaterThanOrEqual(25);
+    expect(TRIP_BOUND_CLEANUPS.length).toBeGreaterThanOrEqual(26);
+  });
+
+  it('#1502 (M2) ground truth prompt trigger가 등록돼 있고 clearTripCorrId보다 앞에 있다', () => {
+    const { TRIP_BOUND_CLEANUPS } = jest.requireActual('../tripBoundCleanups');
+    const { triggerTripGroundTruthPrompt } = jest.requireActual(
+      '../../../debug/utils/triggerTripGroundTruthPrompt',
+    );
+    const { clearTripCorrId } = jest.requireActual('../../../observability/utils/tripCorrId');
+    const triggerIdx = TRIP_BOUND_CLEANUPS.indexOf(triggerTripGroundTruthPrompt);
+    const clearIdx = TRIP_BOUND_CLEANUPS.indexOf(clearTripCorrId);
+    expect(triggerIdx).toBeGreaterThanOrEqual(0);
+    expect(clearIdx).toBeGreaterThanOrEqual(0);
+    // 본 순서가 깨지면 prompt trigger가 corrId=null을 읽고 graceful skip되어 모든 trip 종료가
+    // ground truth 미수집 회귀. 코드 리뷰에서 의도 확인 강제.
+    expect(triggerIdx).toBeLessThan(clearIdx);
   });
 });

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -39,6 +39,7 @@ import {
   getRegisteredTripRouteSig,
 } from '../utils/tripBoundScheduler';
 import { clearTripCorrId } from '../../observability/utils/tripCorrId';
+import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
 import { clearCrossCategoryDedup } from '../utils/crossCategoryStationDedup';
 import { clearAlarmLogWindows } from '../utils/alarmLog';
 import { resetAlarmBackendDedup } from '../api/alarmBackend';
@@ -115,6 +116,10 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   // 새 trip 분모에 섞이는 회귀 차단. LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY는 recall과
   // 같은 이유로 보존 (tripStart값으로 자연 무효화).
   clearPrescheduledLedger,
+  // #1502 (M2) — trip 종료 직후 사용자 정답지 prompt enqueue. clearTripCorrId보다 앞에 두어
+  // trigger가 동기 첫 줄에서 corrId를 캡처할 수 있게 한다 (cleanup map은 parallel-fired지만
+  // 동기 cache read는 순서대로 실행됨). corrId 부재면 graceful skip.
+  triggerTripGroundTruthPrompt,
   // #1501 (ADR-015 §10 P5 / PR-A) — trip 종료 시 corrId 제거. 다음 trip은 새 corrId를
   // 받고 rawSignalBuffer entry가 어느 trip 소속인지 명확해진다.
   clearTripCorrId,

--- a/src/features/debug/components/TripGroundTruthPrompt.tsx
+++ b/src/features/debug/components/TripGroundTruthPrompt.tsx
@@ -1,0 +1,168 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useTheme, spacing, radius, typography } from '../../../shared/theme';
+import {
+  useTripGroundTruthStore,
+  type TripGroundTruthOutcome,
+} from '../store/useTripGroundTruthStore';
+
+const THANKS_AUTO_CLOSE_MS = 1500;
+
+/**
+ * Trip ground truth (사용자 정답지) 자동 prompt — #1502 (M2).
+ *
+ * `useTripGroundTruthStore.pendingPrompt`가 non-null인 동안 modal로 자동 노출.
+ * 사용자가 [좋았어요]/[틀린 알람] 응답 또는 [나중에] dismiss하면 store 갱신.
+ *
+ * trigger source = `TRIP_BOUND_CLEANUPS`의 `triggerTripGroundTruthPrompt` — 모든 trip 종료
+ * 경로(FG setDestination(null/switch) + BG silent push trip-ended) 양쪽 자동 enqueue.
+ * issue 본문 정책: dismiss 후에도 다음 trip 종료 시 다시 노출 (one-time opt-out X).
+ *
+ * 본 컴포넌트는 cross-feature observer로서 DebugModal과 분리 — DebugModal 토글과 무관하게
+ * 항상 마운트되어야 trip 종료 직후 즉시 노출 가능. 호출자는 app root 또는 DebugModal 부근
+ * 어디든 1회 마운트.
+ */
+export function TripGroundTruthPrompt() {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const pendingPrompt = useTripGroundTruthStore((s) => s.pendingPrompt);
+  const respond = useTripGroundTruthStore((s) => s.respond);
+  const hydrated = useTripGroundTruthStore((s) => s.hydrated);
+  const hydrate = useTripGroundTruthStore((s) => s.hydrate);
+
+  // boot 시 1회 hydrate — 앱 cold launch 직후 pendingPrompt 복원.
+  useEffect(() => {
+    if (hydrated) return;
+    void hydrate();
+  }, [hydrated, hydrate]);
+
+  // thanks toast 짧게(THANKS_AUTO_CLOSE_MS) 노출 후 자동 close.
+  const [thanksVisible, setThanksVisible] = useState(false);
+  const thanksTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    return () => {
+      if (thanksTimerRef.current !== null) clearTimeout(thanksTimerRef.current);
+    };
+  }, []);
+
+  const handleRespond = useCallback(
+    async (outcome: TripGroundTruthOutcome) => {
+      await respond(outcome);
+      setThanksVisible(true);
+      if (thanksTimerRef.current !== null) clearTimeout(thanksTimerRef.current);
+      thanksTimerRef.current = setTimeout(() => {
+        setThanksVisible(false);
+        thanksTimerRef.current = null;
+      }, THANKS_AUTO_CLOSE_MS);
+    },
+    [respond],
+  );
+
+  const visible = pendingPrompt !== null || thanksVisible;
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={() => void handleRespond('unanswered')}
+    >
+      <View style={styles.backdrop}>
+        <View
+          testID="trip-ground-truth-card"
+          style={[
+            styles.card,
+            { backgroundColor: colors.bg, borderColor: colors.hair },
+          ]}
+        >
+          {pendingPrompt === null && thanksVisible ? (
+            <Text
+              testID="trip-ground-truth-thanks"
+              style={[typography.body, { color: colors.ink, textAlign: 'center' }]}
+            >
+              {t('debug.tripGroundTruth.thanks')}
+            </Text>
+          ) : (
+            <>
+              <Text style={[typography.label, { color: colors.ink, fontWeight: '700' }]}>
+                {t('debug.tripGroundTruth.title')}
+              </Text>
+              <Text
+                style={[typography.bodySm, { color: colors.muted, marginTop: spacing.xs }]}
+              >
+                {t('debug.tripGroundTruth.body')}
+              </Text>
+              <View style={styles.actions}>
+                <Pressable
+                  testID="trip-ground-truth-accurate"
+                  onPress={() => void handleRespond('accurate')}
+                  style={[styles.button, { backgroundColor: colors.accent }]}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('debug.tripGroundTruth.accurate')}
+                >
+                  <Text style={[typography.body, { color: colors.bg, fontWeight: '700' }]}>
+                    {t('debug.tripGroundTruth.accurate')}
+                  </Text>
+                </Pressable>
+                <Pressable
+                  testID="trip-ground-truth-inaccurate"
+                  onPress={() => void handleRespond('inaccurate')}
+                  style={[
+                    styles.button,
+                    { backgroundColor: 'transparent', borderColor: colors.warn, borderWidth: 1 },
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('debug.tripGroundTruth.inaccurate')}
+                >
+                  <Text style={[typography.body, { color: colors.warn, fontWeight: '700' }]}>
+                    {t('debug.tripGroundTruth.inaccurate')}
+                  </Text>
+                </Pressable>
+                <Pressable
+                  testID="trip-ground-truth-dismiss"
+                  onPress={() => void handleRespond('unanswered')}
+                  style={styles.dismiss}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('debug.tripGroundTruth.dismiss')}
+                >
+                  <Text style={[typography.bodySm, { color: colors.muted }]}>
+                    {t('debug.tripGroundTruth.dismiss')}
+                  </Text>
+                </Pressable>
+              </View>
+            </>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.lg,
+  },
+  card: {
+    borderRadius: radius.md,
+    borderWidth: 1,
+    padding: spacing.lg,
+  },
+  actions: {
+    marginTop: spacing.md,
+    gap: spacing.sm,
+  },
+  button: {
+    borderRadius: radius.sm,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    alignItems: 'center',
+  },
+  dismiss: {
+    alignItems: 'center',
+    paddingVertical: spacing.xs,
+  },
+});

--- a/src/features/debug/components/__tests__/TripGroundTruthPrompt.test.tsx
+++ b/src/features/debug/components/__tests__/TripGroundTruthPrompt.test.tsx
@@ -1,0 +1,184 @@
+import { act, fireEvent, waitFor } from '@testing-library/react-native';
+import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
+import { TripGroundTruthPrompt } from '../TripGroundTruthPrompt';
+import { useTripGroundTruthStore } from '../../store/useTripGroundTruthStore';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn().mockResolvedValue(null),
+  setItem: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('TripGroundTruthPrompt (#1502 M2)', () => {
+  beforeEach(() => {
+    useTripGroundTruthStore.setState({
+      hydrated: true,
+      pendingPrompt: null,
+      responses: [],
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('pendingPrompt 없으면 modal 숨김', () => {
+    const { queryByTestId } = renderWithTheme(<TripGroundTruthPrompt />);
+    expect(queryByTestId('trip-ground-truth-card')).toBeNull();
+  });
+
+  it('pendingPrompt가 set되면 modal 자동 노출 (3 액션 + dismiss)', async () => {
+    const { getByTestId } = renderWithTheme(<TripGroundTruthPrompt />);
+    await act(async () => {
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'c1', endedAt: 100 });
+    });
+    expect(getByTestId('trip-ground-truth-card')).toBeTruthy();
+    expect(getByTestId('trip-ground-truth-accurate')).toBeTruthy();
+    expect(getByTestId('trip-ground-truth-inaccurate')).toBeTruthy();
+    expect(getByTestId('trip-ground-truth-dismiss')).toBeTruthy();
+  });
+
+  it('accurate 탭 → respond("accurate") 호출 + thanks 1.5s 노출 후 자동 close', async () => {
+    jest.useFakeTimers();
+    const { getByTestId, queryByTestId } = renderWithTheme(<TripGroundTruthPrompt />);
+    await act(async () => {
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'c1', endedAt: 100 });
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('trip-ground-truth-accurate'));
+    });
+
+    // pending 해제됨, thanks 노출
+    expect(useTripGroundTruthStore.getState().pendingPrompt).toBeNull();
+    expect(useTripGroundTruthStore.getState().responses[0].outcome).toBe('accurate');
+    expect(getByTestId('trip-ground-truth-thanks')).toBeTruthy();
+
+    // 1500ms 후 thanks 사라짐
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    await waitFor(() => {
+      expect(queryByTestId('trip-ground-truth-thanks')).toBeNull();
+    });
+  });
+
+  it('inaccurate 탭 → respond("inaccurate")', async () => {
+    const { getByTestId } = renderWithTheme(<TripGroundTruthPrompt />);
+    await act(async () => {
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'c2', endedAt: 200 });
+    });
+    await act(async () => {
+      fireEvent.press(getByTestId('trip-ground-truth-inaccurate'));
+    });
+    expect(useTripGroundTruthStore.getState().responses[0].outcome).toBe('inaccurate');
+  });
+
+  it('dismiss 탭 → respond("unanswered")', async () => {
+    const { getByTestId } = renderWithTheme(<TripGroundTruthPrompt />);
+    await act(async () => {
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'c3', endedAt: 300 });
+    });
+    await act(async () => {
+      fireEvent.press(getByTestId('trip-ground-truth-dismiss'));
+    });
+    expect(useTripGroundTruthStore.getState().responses[0].outcome).toBe('unanswered');
+  });
+
+  it('hydrated=false면 hydrate를 자동 호출', async () => {
+    const hydrate = jest.fn().mockResolvedValue(undefined);
+    useTripGroundTruthStore.setState({
+      hydrated: false,
+      pendingPrompt: null,
+      responses: [],
+      hydrate,
+    });
+    renderWithTheme(<TripGroundTruthPrompt />);
+    await waitFor(() => {
+      expect(hydrate).toHaveBeenCalled();
+    });
+  });
+
+  it('hydrated=true면 hydrate 호출 X', async () => {
+    const hydrate = jest.fn().mockResolvedValue(undefined);
+    useTripGroundTruthStore.setState({
+      hydrated: true,
+      pendingPrompt: null,
+      responses: [],
+      hydrate,
+    });
+    renderWithTheme(<TripGroundTruthPrompt />);
+    // microtask flush
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(hydrate).not.toHaveBeenCalled();
+  });
+
+  it('연속 응답 시 이전 thanks timer를 clear하고 새 timer 재시작', async () => {
+    jest.useFakeTimers();
+    const { getByTestId } = renderWithTheme(<TripGroundTruthPrompt />);
+    // 첫 번째 trip 응답
+    await act(async () => {
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'c1', endedAt: 100 });
+    });
+    await act(async () => {
+      fireEvent.press(getByTestId('trip-ground-truth-accurate'));
+    });
+    // thanks가 노출된 사이에 다음 trip 응답 — 이전 timer가 clear되어야 한다.
+    await act(async () => {
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'c2', endedAt: 200 });
+    });
+    await act(async () => {
+      fireEvent.press(getByTestId('trip-ground-truth-accurate'));
+    });
+    // 새 thanks가 노출 중
+    expect(getByTestId('trip-ground-truth-thanks')).toBeTruthy();
+  });
+
+  it('unmount 시 thanks timer cleanup (메모리 누수 방지)', async () => {
+    jest.useFakeTimers();
+    const { getByTestId, unmount } = renderWithTheme(<TripGroundTruthPrompt />);
+    await act(async () => {
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'c1', endedAt: 100 });
+    });
+    await act(async () => {
+      fireEvent.press(getByTestId('trip-ground-truth-accurate'));
+    });
+    // unmount 직후 timer가 더 이상 실행되지 않아야 한다.
+    unmount();
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    // throw 없이 통과하면 OK.
+  });
+
+  it('Modal onRequestClose (안드로이드 back) → unanswered 응답', async () => {
+    const { UNSAFE_getByType } = renderWithTheme(<TripGroundTruthPrompt />);
+    await act(async () => {
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'c4', endedAt: 400 });
+    });
+    // Modal의 onRequestClose prop을 직접 호출.
+    const { Modal } = jest.requireActual('react-native');
+    const modal = UNSAFE_getByType(Modal);
+    await act(async () => {
+      modal.props.onRequestClose();
+    });
+    expect(useTripGroundTruthStore.getState().responses[0].outcome).toBe('unanswered');
+  });
+});

--- a/src/features/debug/store/__tests__/useTripGroundTruthStore.test.ts
+++ b/src/features/debug/store/__tests__/useTripGroundTruthStore.test.ts
@@ -1,0 +1,212 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { TRIP_GROUND_TRUTH_KEY } from '../../../../shared/constants/storageKeys';
+import {
+  RESPONSE_BUFFER_CAPACITY,
+  getRecentResponses,
+  getResponsesForCorrId,
+  useTripGroundTruthStore,
+} from '../useTripGroundTruthStore';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+const mockGetItem = AsyncStorage.getItem as jest.MockedFunction<typeof AsyncStorage.getItem>;
+const mockSetItem = AsyncStorage.setItem as jest.MockedFunction<typeof AsyncStorage.setItem>;
+
+describe('useTripGroundTruthStore (#1502 M2)', () => {
+  beforeEach(() => {
+    useTripGroundTruthStore.setState({
+      hydrated: false,
+      pendingPrompt: null,
+      responses: [],
+    });
+    mockGetItem.mockReset();
+    mockSetItem.mockReset();
+    mockSetItem.mockResolvedValue();
+  });
+
+  describe('enqueuePrompt', () => {
+    it('pending이 없으면 새 prompt를 등록하고 persist한다', async () => {
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'c1', endedAt: 100 });
+      expect(useTripGroundTruthStore.getState().pendingPrompt).toEqual({
+        corrId: 'c1',
+        endedAt: 100,
+      });
+      expect(useTripGroundTruthStore.getState().responses).toEqual([]);
+      expect(mockSetItem).toHaveBeenCalledWith(
+        TRIP_GROUND_TRUTH_KEY,
+        expect.any(String),
+      );
+    });
+
+    it('이전 pending이 미응답이면 unanswered로 합류시키고 새 prompt 등록', async () => {
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'c1', endedAt: 100 });
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'c2', endedAt: 200 });
+      const state = useTripGroundTruthStore.getState();
+      expect(state.pendingPrompt).toEqual({ corrId: 'c2', endedAt: 200 });
+      expect(state.responses).toEqual([
+        { corrId: 'c1', endedAt: 100, respondedAt: 200, outcome: 'unanswered' },
+      ]);
+    });
+
+    it('persist 실패해도 메모리 상태는 갱신된다 (graceful)', async () => {
+      mockSetItem.mockRejectedValueOnce(new Error('storage fail'));
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'c1', endedAt: 100 });
+      expect(useTripGroundTruthStore.getState().pendingPrompt).toEqual({
+        corrId: 'c1',
+        endedAt: 100,
+      });
+    });
+  });
+
+  describe('respond', () => {
+    it('pending이 없으면 graceful no-op', async () => {
+      await useTripGroundTruthStore.getState().respond('accurate');
+      expect(useTripGroundTruthStore.getState().responses).toEqual([]);
+      expect(mockSetItem).not.toHaveBeenCalled();
+    });
+
+    it('accurate 응답을 합류하고 pending=null', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(500);
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'c1', endedAt: 100 });
+      await useTripGroundTruthStore.getState().respond('accurate');
+      const state = useTripGroundTruthStore.getState();
+      expect(state.pendingPrompt).toBeNull();
+      expect(state.responses).toEqual([
+        { corrId: 'c1', endedAt: 100, respondedAt: 500, outcome: 'accurate' },
+      ]);
+    });
+
+    it('inaccurate / unanswered 모두 outcome 그대로 기록', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(600);
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'c1', endedAt: 100 });
+      await useTripGroundTruthStore.getState().respond('inaccurate');
+      expect(useTripGroundTruthStore.getState().responses[0].outcome).toBe('inaccurate');
+
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'c2', endedAt: 200 });
+      await useTripGroundTruthStore.getState().respond('unanswered');
+      expect(useTripGroundTruthStore.getState().responses[1].outcome).toBe('unanswered');
+    });
+
+    it('ring buffer가 capacity를 넘으면 오래된 것부터 drop', async () => {
+      // capacity + 2건을 한 번에 채워 trim 동작 검증.
+      const responses = Array.from({ length: RESPONSE_BUFFER_CAPACITY + 2 }, (_, i) => ({
+        corrId: `c${i}`,
+        endedAt: i,
+        respondedAt: i,
+        outcome: 'accurate' as const,
+      }));
+      useTripGroundTruthStore.setState({ responses });
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'cnew', endedAt: 9999 });
+      // 새 prompt enqueue는 trim을 트리거하지 않지만 이미 capacity 초과 상태 → respond에서 trim.
+      jest.spyOn(Date, 'now').mockReturnValue(10000);
+      await useTripGroundTruthStore.getState().respond('accurate');
+      expect(useTripGroundTruthStore.getState().responses.length).toBe(
+        RESPONSE_BUFFER_CAPACITY,
+      );
+      // 가장 오래된 c0/c1이 drop되었어야 한다.
+      expect(useTripGroundTruthStore.getState().responses[0].corrId).not.toBe('c0');
+    });
+  });
+
+  describe('hydrate', () => {
+    it('storage가 비어있으면 hydrated=true만 set', async () => {
+      mockGetItem.mockResolvedValue(null);
+      await useTripGroundTruthStore.getState().hydrate();
+      expect(useTripGroundTruthStore.getState().hydrated).toBe(true);
+      expect(useTripGroundTruthStore.getState().pendingPrompt).toBeNull();
+    });
+
+    it('persist된 snapshot을 복원한다', async () => {
+      mockGetItem.mockResolvedValue(
+        JSON.stringify({
+          pendingPrompt: { corrId: 'cp', endedAt: 11 },
+          responses: [
+            { corrId: 'cp', endedAt: 11, respondedAt: 12, outcome: 'accurate' },
+          ],
+        }),
+      );
+      await useTripGroundTruthStore.getState().hydrate();
+      const state = useTripGroundTruthStore.getState();
+      expect(state.hydrated).toBe(true);
+      expect(state.pendingPrompt).toEqual({ corrId: 'cp', endedAt: 11 });
+      expect(state.responses).toHaveLength(1);
+    });
+
+    it('JSON 손상 시 graceful — hydrated=true만 set', async () => {
+      mockGetItem.mockResolvedValue('not-json');
+      await useTripGroundTruthStore.getState().hydrate();
+      expect(useTripGroundTruthStore.getState().hydrated).toBe(true);
+    });
+
+    it('responses가 배열이 아니면 빈 배열로 복구', async () => {
+      mockGetItem.mockResolvedValue(
+        JSON.stringify({ pendingPrompt: null, responses: 'broken' }),
+      );
+      await useTripGroundTruthStore.getState().hydrate();
+      expect(useTripGroundTruthStore.getState().responses).toEqual([]);
+    });
+
+    it('storage 예외도 graceful', async () => {
+      mockGetItem.mockRejectedValue(new Error('fail'));
+      await useTripGroundTruthStore.getState().hydrate();
+      expect(useTripGroundTruthStore.getState().hydrated).toBe(true);
+    });
+  });
+
+  describe('read helpers', () => {
+    it('getResponsesForCorrId: 해당 corrId만 필터', () => {
+      useTripGroundTruthStore.setState({
+        responses: [
+          { corrId: 'a', endedAt: 1, respondedAt: 2, outcome: 'accurate' },
+          { corrId: 'b', endedAt: 3, respondedAt: 4, outcome: 'inaccurate' },
+          { corrId: 'a', endedAt: 5, respondedAt: 6, outcome: 'unanswered' },
+        ],
+      });
+      expect(getResponsesForCorrId('a')).toHaveLength(2);
+      expect(getResponsesForCorrId('z')).toEqual([]);
+    });
+
+    it('getRecentResponses: limit 0 또는 음수는 빈 배열', () => {
+      useTripGroundTruthStore.setState({
+        responses: [
+          { corrId: 'a', endedAt: 1, respondedAt: 2, outcome: 'accurate' },
+        ],
+      });
+      expect(getRecentResponses(0)).toEqual([]);
+      expect(getRecentResponses(-5)).toEqual([]);
+    });
+
+    it('getRecentResponses: 직전 N건 반환', () => {
+      const responses = Array.from({ length: 5 }, (_, i) => ({
+        corrId: `c${i}`,
+        endedAt: i,
+        respondedAt: i,
+        outcome: 'accurate' as const,
+      }));
+      useTripGroundTruthStore.setState({ responses });
+      expect(getRecentResponses(2)).toEqual([
+        { corrId: 'c3', endedAt: 3, respondedAt: 3, outcome: 'accurate' },
+        { corrId: 'c4', endedAt: 4, respondedAt: 4, outcome: 'accurate' },
+      ]);
+    });
+  });
+});

--- a/src/features/debug/store/useTripGroundTruthStore.ts
+++ b/src/features/debug/store/useTripGroundTruthStore.ts
@@ -1,0 +1,165 @@
+/**
+ * Trip ground truth (사용자 정답지) store — #1502 (M2, ADR-015 §10 P5).
+ *
+ * trip 종료 직후 사용자에게 자동으로 "이번 trip 알람 정확했어요? Yes/No" prompt를 노출하고
+ * 응답을 누적한다. 응답은 backend로 forward되어 P0-3 telemetry payload(`user-feedback` 필드)에
+ * 합류, M1 raw signal과 corrId 단위로 join되어 학습 라벨이 된다.
+ *
+ * 정책:
+ *  - 매 trip 종료마다 자동 prompt (one-time opt-out X, manual toggle X — issue 본문)
+ *  - 사용자 dismiss/skip은 'unanswered' 상태로 기록, 다음 trip 종료 시 또 노출
+ *  - 응답 ring buffer 최대 RESPONSE_BUFFER_CAPACITY건 (오래된 응답부터 drop)
+ *  - AsyncStorage 영속화 — 앱 강제종료/cold launch에도 pendingPrompt 살아남는다
+ *
+ * 본 store는 zustand 메모리 + AsyncStorage 양방향. hydrate는 app boot 시 1회.
+ * 모든 storage 작업 graceful — 실패는 측정에만 영향, trip 흐름 무관.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { create } from 'zustand';
+import { TRIP_GROUND_TRUTH_KEY } from '../../../shared/constants/storageKeys';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('tripGroundTruth');
+
+/**
+ * 응답 outcome.
+ * - 'accurate' : 사용자 "이번 trip 알람 정확했어요" 응답 (option A "좋았어요")
+ * - 'inaccurate' : 사용자 "틀린 알람이 있었어요" 응답 (false positive 또는 miss)
+ * - 'unanswered' : prompt dismiss 또는 다음 trip 시작으로 자동 만료
+ */
+export type TripGroundTruthOutcome = 'accurate' | 'inaccurate' | 'unanswered';
+
+export interface TripGroundTruthResponse {
+  corrId: string;
+  endedAt: number;
+  respondedAt: number;
+  outcome: TripGroundTruthOutcome;
+}
+
+export interface TripGroundTruthPendingPrompt {
+  corrId: string;
+  endedAt: number;
+}
+
+export interface TripGroundTruthState {
+  hydrated: boolean;
+  pendingPrompt: TripGroundTruthPendingPrompt | null;
+  responses: TripGroundTruthResponse[];
+  /**
+   * trip 종료 시 호출 — pending prompt 등록. 이미 pending이 있으면 (이전 trip 미응답)
+   * 'unanswered'로 응답에 합류하고 새 prompt로 교체.
+   */
+  enqueuePrompt: (prompt: TripGroundTruthPendingPrompt) => Promise<void>;
+  /**
+   * 사용자 응답 — pending prompt를 responses에 합류하고 pending=null.
+   * pendingPrompt 부재 시 graceful no-op (race 안전).
+   */
+  respond: (outcome: TripGroundTruthOutcome) => Promise<void>;
+  /** AsyncStorage → memory hydrate. boot 1회. */
+  hydrate: () => Promise<void>;
+}
+
+/**
+ * 응답 ring buffer 최대 크기. P0-3 forward 1회 분량 + 잔여 backlog 보존을 고려해 50건.
+ * forward 성공 후에도 직전 응답들은 DebugModal에서 다시 볼 수 있어야 사용자가 자기 응답
+ * 이력을 확인 가능.
+ */
+export const RESPONSE_BUFFER_CAPACITY = 50;
+
+interface PersistedShape {
+  pendingPrompt: TripGroundTruthPendingPrompt | null;
+  responses: TripGroundTruthResponse[];
+}
+
+async function persist(snapshot: PersistedShape): Promise<void> {
+  try {
+    await AsyncStorage.setItem(TRIP_GROUND_TRUTH_KEY, JSON.stringify(snapshot));
+  } catch (e) {
+    logger.warn('persist 실패 (graceful):', e);
+  }
+}
+
+function trimResponses(responses: TripGroundTruthResponse[]): TripGroundTruthResponse[] {
+  if (responses.length <= RESPONSE_BUFFER_CAPACITY) return responses;
+  // 오래된 응답부터 drop.
+  return responses.slice(responses.length - RESPONSE_BUFFER_CAPACITY);
+}
+
+export const useTripGroundTruthStore = create<TripGroundTruthState>((set, get) => ({
+  hydrated: false,
+  pendingPrompt: null,
+  responses: [],
+
+  enqueuePrompt: async (prompt) => {
+    const { pendingPrompt, responses } = get();
+    // 이전 prompt가 미응답이면 'unanswered'로 합류시키고 새 prompt 교체.
+    let nextResponses = responses;
+    if (pendingPrompt !== null) {
+      nextResponses = trimResponses([
+        ...responses,
+        {
+          corrId: pendingPrompt.corrId,
+          endedAt: pendingPrompt.endedAt,
+          respondedAt: prompt.endedAt,
+          outcome: 'unanswered',
+        },
+      ]);
+    }
+    set({ pendingPrompt: prompt, responses: nextResponses });
+    await persist({ pendingPrompt: prompt, responses: nextResponses });
+  },
+
+  respond: async (outcome) => {
+    const { pendingPrompt, responses } = get();
+    if (pendingPrompt === null) return;
+    const nextResponses = trimResponses([
+      ...responses,
+      {
+        corrId: pendingPrompt.corrId,
+        endedAt: pendingPrompt.endedAt,
+        respondedAt: Date.now(),
+        outcome,
+      },
+    ]);
+    set({ pendingPrompt: null, responses: nextResponses });
+    await persist({ pendingPrompt: null, responses: nextResponses });
+  },
+
+  hydrate: async () => {
+    try {
+      const raw = await AsyncStorage.getItem(TRIP_GROUND_TRUTH_KEY);
+      if (raw === null) {
+        set({ hydrated: true });
+        return;
+      }
+      const parsed = JSON.parse(raw) as PersistedShape;
+      set({
+        hydrated: true,
+        pendingPrompt: parsed.pendingPrompt ?? null,
+        responses: Array.isArray(parsed.responses) ? parsed.responses : [],
+      });
+    } catch (e) {
+      logger.warn('hydrate 실패 (graceful):', e);
+      set({ hydrated: true });
+    }
+  },
+}));
+
+/**
+ * P0-3 telemetry forward payload에 합류시키기 위한 read helper.
+ * 직전 N건의 응답 또는 corrId 매칭 응답 1건을 반환 — caller가 결정.
+ *
+ * 본 helper는 store가 hydrate되지 않은 상태에서도 동기적으로 메모리 snapshot을 읽는다 —
+ * boot 직후 호출되면 빈 배열 (graceful).
+ */
+export function getResponsesForCorrId(corrId: string): TripGroundTruthResponse[] {
+  const { responses } = useTripGroundTruthStore.getState();
+  return responses.filter((r) => r.corrId === corrId);
+}
+
+/** 직전 N건 응답 (telemetry payload 보강용). */
+export function getRecentResponses(limit: number): TripGroundTruthResponse[] {
+  const { responses } = useTripGroundTruthStore.getState();
+  if (limit <= 0) return [];
+  return responses.slice(-limit);
+}

--- a/src/features/debug/utils/__tests__/triggerTripGroundTruthPrompt.test.ts
+++ b/src/features/debug/utils/__tests__/triggerTripGroundTruthPrompt.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Trip ground truth trigger (#1502 M2) — TRIP_BOUND_CLEANUPS 호출 시점에 corrId 캡처 검증.
+ */
+import { triggerTripGroundTruthPrompt } from '../triggerTripGroundTruthPrompt';
+import { useTripGroundTruthStore } from '../../store/useTripGroundTruthStore';
+import * as tripCorrId from '../../../observability/utils/tripCorrId';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn().mockResolvedValue(null),
+  setItem: jest.fn().mockResolvedValue(undefined),
+  removeItem: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('triggerTripGroundTruthPrompt (#1502 M2)', () => {
+  beforeEach(() => {
+    useTripGroundTruthStore.setState({
+      hydrated: true,
+      pendingPrompt: null,
+      responses: [],
+    });
+  });
+
+  it('corrId가 null이면 prompt enqueue X (graceful skip)', async () => {
+    jest.spyOn(tripCorrId, 'getCurrentTripCorrIdSync').mockReturnValue(null);
+    await triggerTripGroundTruthPrompt();
+    expect(useTripGroundTruthStore.getState().pendingPrompt).toBeNull();
+  });
+
+  it('corrId가 있으면 동기 캡처 후 enqueue', async () => {
+    jest.spyOn(tripCorrId, 'getCurrentTripCorrIdSync').mockReturnValue('trip-abc');
+    jest.spyOn(Date, 'now').mockReturnValue(12345);
+    await triggerTripGroundTruthPrompt();
+    expect(useTripGroundTruthStore.getState().pendingPrompt).toEqual({
+      corrId: 'trip-abc',
+      endedAt: 12345,
+    });
+  });
+
+  it('clearTripCorrId가 같은 batch에서 cache를 비워도 트리거가 먼저 호출되면 corrId 캡처 보존', async () => {
+    // 시뮬레이션: triggerTripGroundTruthPrompt 첫 줄이 sync read하므로
+    // 이후 clearTripCorrId가 실행돼도 캡처값은 유지된다.
+    jest.spyOn(tripCorrId, 'getCurrentTripCorrIdSync').mockReturnValue('trip-xyz');
+    const triggerPromise = triggerTripGroundTruthPrompt();
+    // trigger 호출 시점 직후 cache를 비워본다.
+    jest.spyOn(tripCorrId, 'getCurrentTripCorrIdSync').mockReturnValue(null);
+    await triggerPromise;
+    expect(useTripGroundTruthStore.getState().pendingPrompt?.corrId).toBe('trip-xyz');
+  });
+});

--- a/src/features/debug/utils/triggerTripGroundTruthPrompt.ts
+++ b/src/features/debug/utils/triggerTripGroundTruthPrompt.ts
@@ -1,0 +1,27 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: debug feature가 trip 종료 시점 trigger를 노출하기 위해
+ * observability(tripCorrId)에서 sync read한다. trip-bound cleanup orchestrator(alarm/store/
+ * tripBoundCleanups.ts)에서 호출되는 entry-point이므로 본질적 cross-feature 의존.
+ */
+/**
+ * Trip ground truth (#1502 M2) — trip 종료 시 사용자 정답지 prompt enqueue trigger.
+ *
+ * `TRIP_BOUND_CLEANUPS`에 등록되어 trip 종료 시 자동 호출. 호출 순서가 어디든 — `clearTripCorrId`
+ * 전후 무관 — 본 함수는 **호출 즉시 동기**로 `getCurrentTripCorrIdSync()`를 읽어 corrId를
+ * 캡처한 뒤 store에 enqueue한다. 이후 `clearTripCorrId`가 cache를 비워도 캡처 값은 그대로.
+ *
+ * corrId가 null이면(트립 미시작/이미 종료) graceful skip — prompt 미발사. 측정 가치가 없는
+ * trip(corrId 없음)에 noise 응답이 섞이는 것 차단.
+ */
+import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
+import { useTripGroundTruthStore } from '../store/useTripGroundTruthStore';
+
+export async function triggerTripGroundTruthPrompt(): Promise<void> {
+  // 동기 read — clearTripCorrId가 같은 cleanup batch에서 cache를 비우기 전 캡처.
+  const corrId = getCurrentTripCorrIdSync();
+  if (corrId === null) return;
+  await useTripGroundTruthStore.getState().enqueuePrompt({
+    corrId,
+    endedAt: Date.now(),
+  });
+}

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -192,3 +192,8 @@ export const TELEMETRY_FORWARD_RETRY_QUEUE_KEY = 'subway-now:telemetry-forward-r
 // DebugModal "Notification Delivery" 섹션이 read해 surface별 카운터 + suppress 사유 분포 표시.
 // 형식: NotificationDeliveryEntry[] JSON (capacity 200, FIFO eviction).
 export const NOTIFICATION_DELIVERY_LOG_KEY = 'subway-now:notification-delivery-log';
+// #1502 (M2) — Trip ground truth (사용자 정답지) state.
+// trip 종료 직후 사용자에게 "이번 trip 알람 정확했어요? Yes/No" 자동 prompt를 띄우고
+// 응답을 누적. ADR-015 §10 P5 가중치 자동 학습의 label(=ground truth)이다.
+// 형식: { pendingPrompt: { corrId, endedAt } | null, responses: TripGroundTruthResponse[] } JSON.
+export const TRIP_GROUND_TRUTH_KEY = 'subway-now:trip-ground-truth';

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -345,5 +345,15 @@
       "buttonLabel": "Share route",
       "bodyTemplate": "🚇 Subway Route\nFrom: {{fromName}} ({{fromLine}})\nTo: {{toName}} ({{toLine}})\nAbout {{minutes}} min ({{stops}} stops)"
     }
+  },
+  "debug": {
+    "tripGroundTruth": {
+      "title": "Were the alarms accurate this trip?",
+      "body": "Your answer trains the alarm accuracy model.",
+      "accurate": "All good",
+      "inaccurate": "Some were wrong",
+      "dismiss": "Later",
+      "thanks": "Thanks for your feedback."
+    }
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -345,5 +345,15 @@
       "buttonLabel": "ルートを共有",
       "bodyTemplate": "🚇 地下鉄ルート\n出発: {{fromName}} ({{fromLine}})\n到着: {{toName}} ({{toLine}})\n約 {{minutes}} 分 ({{stops}} 駅)"
     }
+  },
+  "debug": {
+    "tripGroundTruth": {
+      "title": "今回のtripのアラームは正確でしたか?",
+      "body": "回答はアラーム精度の学習に使われます。",
+      "accurate": "良かった",
+      "inaccurate": "間違いがあった",
+      "dismiss": "あとで",
+      "thanks": "ご回答ありがとうございます。"
+    }
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -345,5 +345,15 @@
       "buttonLabel": "경로 공유",
       "bodyTemplate": "🚇 지하철 경로\n출발: {{fromName}} ({{fromLine}})\n도착: {{toName}} ({{toLine}})\n약 {{minutes}}분 소요 ({{stops}}정거장)"
     }
+  },
+  "debug": {
+    "tripGroundTruth": {
+      "title": "이번 trip 알람 정확했어요?",
+      "body": "사용자 응답은 알람 정확도 학습에 사용돼요.",
+      "accurate": "좋았어요",
+      "inaccurate": "틀린 알람 있었어요",
+      "dismiss": "나중에",
+      "thanks": "응답 감사합니다."
+    }
   }
 }

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -345,5 +345,15 @@
       "buttonLabel": "分享路线",
       "bodyTemplate": "🚇 地铁路线\n起点: {{fromName}} ({{fromLine}})\n终点: {{toName}} ({{toLine}})\n约 {{minutes}} 分钟 ({{stops}} 站)"
     }
+  },
+  "debug": {
+    "tripGroundTruth": {
+      "title": "本次行程的提醒准确吗?",
+      "body": "您的反馈将用于提升提醒准确度。",
+      "accurate": "都不错",
+      "inaccurate": "有错误的提醒",
+      "dismiss": "稍后",
+      "thanks": "感谢您的反馈。"
+    }
   }
 }


### PR DESCRIPTION
Closes #1502

## Summary
- Trip 종료 시점에 `TRIP_BOUND_CLEANUPS` hook(`triggerTripGroundTruthPrompt`)이 `getCurrentTripCorrIdSync()`로 corrId를 캡처해 store에 enqueue → `TripGroundTruthPrompt` 컴포넌트가 자동으로 Yes/No/나중에 modal 노출
- `useTripGroundTruthStore` zustand store가 응답을 ring buffer(50건)로 누적 + AsyncStorage 영속화. 미응답 prompt는 다음 trip 시작 시 `'unanswered'`로 합류
- 4 lang i18n(ko/en/ja/zh) 추가. DebugModal 토글과 독립적으로 항상 마운트 (issue 본문 정책 — 매 trip 자동 노출)
- `getResponsesForCorrId` / `getRecentResponses` helper로 P0-3 telemetry forward payload(`user-feedback` 필드)에 합류 준비

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass. 신규 export 모두 consumer 존재 (`triggerTripGroundTruthPrompt`→`TRIP_BOUND_CLEANUPS`, `TripGroundTruthPrompt`→`app/_layout.tsx`, store/helper→component+tests).
2. **V/X dashboard** — 응답 데이터는 `useTripGroundTruthStore.responses`(메모리 + AsyncStorage `subway-now:trip-ground-truth`). 본 PR 단독으로는 사용자가 modal에서 응답 → 다음 prompt 노출까지 자기 응답 이력만 확인 가능. P0-3 forward 머지 시 backend 노출.
3. **의존 PR** — 단독 머지 가능. wire 활성 의존:
   - **P0-3 (#1586) `alarmLog forward + R2`** 머지 후 → telemetry payload `user-feedback` 필드에 `getResponsesForCorrId(corrId)` 합류 (별도 follow-up PR)
   - **P0-4 (#1580) `fixture schema`** 머지 후 → `TripGroundTruthResponse` shape를 fixture schema와 align (현재 자체 schema, 호환 변환 follow-up)
4. **측정 plan** — 머지 후 1주: 응답률 30% 이상(issue acceptance), 응답 1건 → AsyncStorage `subway-now:trip-ground-truth` snapshot에서 corrId 매칭 확인. P0-3 forward 머지 후 backend KV에서 M1 raw signal과 corrId join 시연.
5. **Device verify** — 권장. 시나리오: trip 시작 → 도착(또는 setDestination(null)) → modal 즉시 노출 → 응답 → 다음 trip 종료 시 또 노출(one-time opt-out X 검증). 4 lang 각각 1회. cold launch 후 pending prompt 복원 검증.

## Acceptance 자가 점검

1. self-referential? — **No**. 사용자 응답이 ground truth label, 코드가 자기 자신 평가하는 게 아님
2. Wire-completion orphan 0 — pass (`lint:orphan`)
3. 머지 순서 — 단독 머지 가능. P0-3/P0-4 후속 머지 시 forward/schema align follow-up PR 필요
4. backward-compat — 신규 store/key, 기존 storage/wire 영향 0. AsyncStorage `subway-now:trip-ground-truth` 부재 시 빈 상태 graceful
5. False positive — UI prompt + store, 알람 발사 경로 무관

## Test plan
- [x] `useTripGroundTruthStore` 15 tests (enqueue/respond/hydrate/ring-buffer trim/read helpers/graceful storage 실패) — 100% coverage
- [x] `triggerTripGroundTruthPrompt` 3 tests (corrId null skip / 정상 enqueue / 동기 캡처 race) — 100% coverage
- [x] `TripGroundTruthPrompt` 10 tests (visibility / 3 outcome 액션 / dismiss / hydrate / Modal back / 연속 응답 timer cleanup / unmount cleanup) — 100% coverage
- [x] `tripBoundCleanupsAudit` 2 new tests (trigger 등록 + clearTripCorrId 앞 순서 invariant) + baseline 25→26
- [x] `tripBoundCleanups` NON_STORAGE_CLEANUPS 4→5 (신규 항목 storage write 무영향 invariant)
- [x] `npm run type-check` pass, `npm run lint:orphan` pass
- [x] 전체 `npm test`: 6939 pass / 35 fail (2 suite — `widgetStorage`/`stationNotification` 모두 origin/dev에서 이미 동일하게 fail, 본 PR 무관)
- [ ] 실기기 — modal 자동 노출 + 4 lang 표시 + cold launch hydrate