### PR TITLE
feat(#1573): Sticky SSoT 정책 + trip cleanup + 6h backstop + mirror leak fix (ADR-017 T10)

### DIFF
--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -25,6 +25,7 @@ import {
 } from '../../utils/crossCategoryStationDedup';
 import { clearAlarmLogWindows } from '../../utils/alarmLog';
 import { resetAlarmBackendDedup } from '../../api/alarmBackend';
+import { clearBackendSsotMirror } from '../../utils/backendSsotMirror';
 import { useDestinationStore } from '../../../route/store/useDestinationStore';
 import { useBoardingLockStore } from '../useBoardingLockStore';
 import { useAlarmEventStore } from '../useAlarmEventStore';
@@ -400,14 +401,17 @@ describe('tripBoundCleanups', () => {
       expect(useAlarmEventStore.getState().dismissSilence).toBeNull();
     });
 
+    it('#1573 (T10): clearBackendSsotMirror가 TRIP_BOUND_CLEANUPS에 포함된다 (Mirror leak #3 가드)', () => {
+      expect(TRIP_BOUND_CLEANUPS).toContain(clearBackendSsotMirror);
+    });
+
     it('S12-8: enumeration 가드 — TRIP_BOUND_CLEANUPS 길이가 baseline 이하로 떨어지면 회귀', () => {
       // 새 cleanup 항목이 추가될 때마다 baseline을 한 줄로 갱신. 누군가 실수로 항목을 제거하면
       // 본 assertion이 빨갛게 깨져 의도된 제거인지 코드리뷰에서 확인하도록 강제한다.
       //
-      // #1545 (S12) 이전: 22 항목. S12에서 5 항목 추가(crossCategoryDedup / alarmLogWindows /
-      // alarmBackendDedup / storeMemoryMirror / [기존 22] = 22 + 4 신규 + 1 wrapper). 일부 항목은
-      // BG-only 메모리/dedup이라 storage write 없이도 효력 있음.
-      const MIN_ITEMS = 25;
+      // #1545 (S12) 이전: 22 항목. S12에서 4 신규 + #1573 (T10) clearBackendSsotMirror 1 신규.
+      // 일부 항목은 BG-only 메모리/dedup이라 storage write 없이도 효력 있음.
+      const MIN_ITEMS = 26;
       expect(TRIP_BOUND_CLEANUPS.length).toBeGreaterThanOrEqual(MIN_ITEMS);
     });
   });

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -40,6 +40,7 @@ import {
 } from '../utils/tripBoundScheduler';
 import { clearTripCorrId } from '../../observability/utils/tripCorrId';
 import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
+import { clearBackendSsotMirror } from '../utils/backendSsotMirror';
 import { clearCrossCategoryDedup } from '../utils/crossCategoryStationDedup';
 import { clearAlarmLogWindows } from '../utils/alarmLog';
 import { resetAlarmBackendDedup } from '../api/alarmBackend';
@@ -123,6 +124,13 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   // #1501 (ADR-015 §10 P5 / PR-A) — trip 종료 시 corrId 제거. 다음 trip은 새 corrId를
   // 받고 rawSignalBuffer entry가 어느 trip 소속인지 명확해진다.
   clearTripCorrId,
+  // #1573 (T10) — backend SSoT mirror 제거.
+  // 누락 시 새 trip 등록 직후 cascade picker가 이전 trip의 mirror entry를 freshness 윈도우
+  // 내에서 backend-ssot tier로 채택할 수 있다(Mirror leak #3). 4개 cleanup 경로
+  // (FG setDestination(null/switch) / silent push trip-ended / useStateRehydration sentinel /
+  // useLaunchTripReconciliation cold-launch) 모두 runTripBoundCleanups를 호출하므로 본 배열에
+  // 한 줄 추가로 4 경로 자동 wire.
+  clearBackendSsotMirror,
   // #1524 — trip 종료 시 sticky station persisted lock 제거. useStickyStation의 메모리 lock은
   // motion.tripActive flip 감지로 즉시 해제되지만, BG silent push trip-ended 경로에서는 hook이
   // 실행되지 않으므로 storage를 직접 제거해야 다음 FG 재마운트 hydrate가 stale lock을 부활

--- a/src/features/alarm/utils/__tests__/backendSsotMirror.test.ts
+++ b/src/features/alarm/utils/__tests__/backendSsotMirror.test.ts
@@ -1,0 +1,35 @@
+/**
+ * #1573 (T10) — clearBackendSsotMirror unit test.
+ *
+ * persist/read는 silentPushTask.test.ts에서 검증. 본 파일은 T10 신규 helper인
+ * clearBackendSsotMirror만 다루어 회귀 좌표를 좁힌다.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { clearBackendSsotMirror } from '../backendSsotMirror';
+import { BACKEND_SSOT_MIRROR_KEY } from '../../../../shared/constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    removeItem: jest.fn(),
+  },
+}));
+
+const mockRemoveItem = AsyncStorage.removeItem as jest.Mock;
+
+describe('clearBackendSsotMirror (#1573 T10)', () => {
+  beforeEach(() => {
+    mockRemoveItem.mockReset();
+  });
+
+  it('BACKEND_SSOT_MIRROR_KEY를 제거한다', async () => {
+    mockRemoveItem.mockResolvedValue(undefined);
+    await clearBackendSsotMirror();
+    expect(mockRemoveItem).toHaveBeenCalledWith(BACKEND_SSOT_MIRROR_KEY);
+  });
+
+  it('AsyncStorage 실패 시 graceful (throw 안 함)', async () => {
+    mockRemoveItem.mockRejectedValue(new Error('io'));
+    await expect(clearBackendSsotMirror()).resolves.toBeUndefined();
+  });
+});

--- a/src/features/alarm/utils/__tests__/tripStartStorage.test.ts
+++ b/src/features/alarm/utils/__tests__/tripStartStorage.test.ts
@@ -3,8 +3,13 @@ import {
   setTripStartedAt,
   getTripStartedAt,
   clearTripStartedAt,
+  tripLifecyclePhase,
 } from '../tripStartStorage';
 import { TRIP_STARTED_AT_KEY } from '../../../../shared/constants/storageKeys';
+import {
+  TRIP_LIFECYCLE_SILENCE_MS,
+  TRIP_LIFECYCLE_FORCE_END_MS,
+} from '../../../../shared/constants/realtime';
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   __esModule: true,
@@ -99,6 +104,44 @@ describe('tripStartStorage', () => {
     it('AsyncStorage 실패 시 graceful (throw 안 함)', async () => {
       mockRemoveItem.mockRejectedValue(new Error('fail'));
       await expect(clearTripStartedAt()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('#1573 tripLifecyclePhase', () => {
+    it('startedAt=null → none', () => {
+      expect(tripLifecyclePhase(null, 0)).toBe('none');
+    });
+
+    it('elapsed < 6h → normal', () => {
+      const now = 100_000_000;
+      expect(tripLifecyclePhase(now - (TRIP_LIFECYCLE_SILENCE_MS - 1), now)).toBe(
+        'normal',
+      );
+    });
+
+    it('elapsed = 6h 경계 → silence', () => {
+      const now = 100_000_000;
+      expect(tripLifecyclePhase(now - TRIP_LIFECYCLE_SILENCE_MS, now)).toBe('silence');
+    });
+
+    it('6h ≤ elapsed < 9h → silence', () => {
+      const now = 100_000_000;
+      const elapsed = TRIP_LIFECYCLE_SILENCE_MS + 60_000;
+      expect(tripLifecyclePhase(now - elapsed, now)).toBe('silence');
+    });
+
+    it('elapsed ≥ 9h → force-end', () => {
+      const now = 100_000_000;
+      expect(tripLifecyclePhase(now - TRIP_LIFECYCLE_FORCE_END_MS, now)).toBe(
+        'force-end',
+      );
+    });
+
+    it('now 기본값은 Date.now()', () => {
+      const NOW = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(NOW);
+      expect(tripLifecyclePhase(NOW - 60_000)).toBe('normal');
+      (Date.now as jest.Mock).mockRestore();
     });
   });
 });

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -54,7 +54,10 @@ export type AlarmLogSource =
   // 같은 destinationId에서 mismatch가 반복되면 hydration 완료 전에 effect가 재실행되는 race 정황.
   | 'fg-ref-mismatch'
   // #1021: boardingPrompt 발사 빈도 측정.
-  | 'boarding-prompt';
+  | 'boarding-prompt'
+  // #1573 (T10) — 6h/9h trip lifecycle backstop이 적재하는 silence/force-end 엔트리 출처.
+  // FG/BG 어느 경로에서도 동일 source로 적재 — 단계 진입 시점·발생 빈도 분포 측정.
+  | 'lifecycle-backstop';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(#580): evaluateAlarmPhase의 firedAlarms 적중. destination/transfer phase alarm dedup
 // 발생 관찰. station-passed는 별도 메커니즘(lastNotifiedStationId)이라 'dedup-station' 사용.
@@ -162,7 +165,17 @@ export type AlarmLogReason =
   | 'schedule-skipped-motion-stationary'
   // #1399 — backend가 push에 stamp한 tripToken이 device ACTIVE_TRIP_KEY와 mismatch.
   // 좀비 알림 cleanup: trip 종료 후 늦게 도착한 stale silent push 발사 차단(S8 14:19 회귀).
-  | 'trip-token-mismatch';
+  | 'trip-token-mismatch'
+  // #1573 (T10) — SSoT mirror staleness 게이트(realtime.ts BACKEND_SSOT_STALE_BLOCK_*).
+  //   'gate-stale-alarm-blocked' : mirror.lastAdvanceAt가 5분+ 지난 채 알람 fire 시도.
+  //   'gate-stale-notify-blocked': 30분+ stale에서 banner/LA/widget notify 시도.
+  | 'gate-stale-alarm-blocked'
+  | 'gate-stale-notify-blocked'
+  // #1573 (T10) — trip lifecycle 단계적 backstop.
+  //   'trip-lifecycle-silence'        : 6h~9h 잔존 trip의 alarm/notify silence 진입.
+  //   'trip-lifecycle-force-ended'    : 9h+ 잔존 trip 강제 종료 (runTripBoundCleanups + sentinel).
+  | 'trip-lifecycle-silence'
+  | 'trip-lifecycle-force-ended';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -726,6 +739,7 @@ const SILENT_PUSH_OUTCOME_SOURCES: Record<AlarmLogSource, keyof SilentPushOutcom
   'fg-arvlcd': null,
   'fg-ref-mismatch': null,
   'boarding-prompt': null,
+  'lifecycle-backstop': null,
 };
 
 export interface SilentPushOutcomeCounts {

--- a/src/features/alarm/utils/backendSsotMirror.ts
+++ b/src/features/alarm/utils/backendSsotMirror.ts
@@ -55,6 +55,24 @@ export async function persistBackendSsotMirror(
 }
 
 /**
+ * #1573 (T10) — backend SSoT mirror를 AsyncStorage에서 제거.
+ *
+ * trip 종료 시(tripBoundCleanups 경로 전체 — FG setDestination(null), silent push trip-ended,
+ * useStateRehydration sentinel, useLaunchTripReconciliation, 6h backstop) 호출해 stale mirror가
+ * 다음 trip의 cascade 최상위 tier로 leak 채택되는 회귀(Mirror leak #3) 차단.
+ *
+ * 멱등 — 키 부재 시 graceful no-op. removeItem 실패는 swallow.
+ */
+export async function clearBackendSsotMirror(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(BACKEND_SSOT_MIRROR_KEY);
+  } catch {
+    // graceful — 다음 cleanup pass에서 재시도. 잔존하더라도 freshness 180s 만료 후
+    // 자연 비활성화되므로 보조 backstop이 있다.
+  }
+}
+
+/**
  * #1561 (T8) — AsyncStorage에서 backend SSoT mirror 읽기. cascade picker가 polling cycle마다 호출.
  *
  * 미존재 / parse 실패 → null. cascade picker는 기존 tier fallback.

--- a/src/features/alarm/utils/tripStartStorage.ts
+++ b/src/features/alarm/utils/tripStartStorage.ts
@@ -14,7 +14,35 @@
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { TRIP_STARTED_AT_KEY } from '../../../shared/constants/storageKeys';
+import {
+  TRIP_LIFECYCLE_SILENCE_MS,
+  TRIP_LIFECYCLE_FORCE_END_MS,
+} from '../../../shared/constants/realtime';
 import { refreshCorrId } from '../../../shared/utils/backendCallBuffer';
+
+/**
+ * #1573 (T10) — trip lifecycle 단계 판정 helper.
+ *
+ * 입력: 마지막 trip 시작 시각(epoch ms) — null이면 'none'.
+ * 본 PR에서 silence/force-end만 wire. opt-in extend(12h)는 후속 토글 sub-task에서.
+ *
+ *  - 'none'      — trip 없음. 호출자 skip.
+ *  - 'normal'    — 정상 운행 (6h 미만). backstop 동작 없음.
+ *  - 'silence'   — 6h~9h. alarm/notify 차단만 (UI는 유지). KTX/장거리 trip 보호.
+ *  - 'force-end' — 9h+. runTripBoundCleanups + sentinel. lockless 9h+ 잔존 #1346 차단.
+ */
+export type TripLifecyclePhase = 'none' | 'normal' | 'silence' | 'force-end';
+
+export function tripLifecyclePhase(
+  startedAt: number | null,
+  now: number = Date.now(),
+): TripLifecyclePhase {
+  if (startedAt === null) return 'none';
+  const elapsed = now - startedAt;
+  if (elapsed >= TRIP_LIFECYCLE_FORCE_END_MS) return 'force-end';
+  if (elapsed >= TRIP_LIFECYCLE_SILENCE_MS) return 'silence';
+  return 'normal';
+}
 
 /** Trip 시작 시각 기록. setDestination switch 분기에서 호출. */
 export async function setTripStartedAt(at: number = Date.now()): Promise<void> {

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.backendSsotCascade.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.backendSsotCascade.test.ts
@@ -6,7 +6,7 @@
  * 시나리오:
  *   1. backend SSoT mirror 존재 + fresh → cascade 1순위 채택, confidence/source='backend-ssot'.
  *   2. mirror 미존재 → 기존 tier(WiFi/position-train/...) fallback.
- *   3. mirror stale(lastAdvanceAt 60s 초과) → cascade 채택 거부 → 기존 tier fallback.
+ *   3. mirror stale(lastAdvanceAt 180s 초과, #1573 T10) → cascade 채택 거부 → 기존 tier fallback.
  *   4. mirror lock 활성 + line mismatch → station resolve null → 채택 거부.
  *   5. mirror lockless + resolve 가능 → cascade 채택 (lockless도 lock과 동급 우선순위).
  */
@@ -136,12 +136,12 @@ describe('#1568 (T8b) cascade picker — backend-ssot tier', () => {
     expect(hook.result.current.confidence).not.toBe('backend-ssot');
   });
 
-  it('mirror stale(lastAdvanceAt > 60s) → 채택 거부', async () => {
+  it('mirror stale(lastAdvanceAt > 180s) → 채택 거부 (#1573 T10 60s → 180s)', async () => {
     setupBaselineGpsAt('청담');
     mockRead.mockResolvedValue(
       makeMirror({
         currentStationId: yongmasan.name,
-        lastAdvanceAt: T0 - 120_000, // 2분 전 — staleness 60s 초과
+        lastAdvanceAt: T0 - 240_000, // 4분 전 — staleness 180s 초과
       }),
     );
     const hook = renderHook(() => useFusedNearestStation());

--- a/src/shared/constants/realtime.ts
+++ b/src/shared/constants/realtime.ts
@@ -17,8 +17,30 @@ export const MAX_FUSION_DELTA_KM = 0.2;
 export const POSITION_TRAIN_TTL_MS = 60_000;
 // #1568 (T8b, Epic ADR-017 #1553) — backend SSoT mirror staleness 게이트.
 // silent push payload.ssot.lastAdvanceAt 기준 본 ms 초과 시 cascade 채택 거부.
-// backend는 cycle(~30s)마다 advance를 보내므로 2 cycle + 여유 margin.
-export const BACKEND_SSOT_MIRROR_MAX_AGE_MS = 60_000;
+//
+// #1573 (T10) — 60s → 180s 상향.
+// 60s는 backend cycle(~30s) 2 cycle만 허용해 한 cycle 손실(BG silent push 지연/dropped)에
+// cascade가 즉시 GPS-only로 떨어졌다. 12:32:14 trip evidence: 60s 만료 → fallback
+// `position-train` → stale GPS(acc=4200m) → 용마산 false fire. 180s로 늘려 6 cycle margin을
+// 확보하고, 그 이후의 staleness는 단계적으로 알람/알림을 차단한다(아래 두 상수).
+export const BACKEND_SSOT_MIRROR_MAX_AGE_MS = 180_000;
+
+/**
+ * #1573 (T10) — Trip lifecycle 단계적 backstop 임계.
+ *
+ * trip이 명시 종료(도착 / 사용자 종료 / backend trip-ended) 없이 본 시간 이상 잔존하면
+ * `feedback_6h_backstop_staged_handling` 룰에 따라 단계 처리:
+ *  - 6h (silence): alarm/notification 차단만 (UI는 trip 유지). KTX/장거리 trip noise 방지.
+ *  - 9h (force-end): 강제 종료 (runTripBoundCleanups + tripEndedSentinel). lockless 9h+ 잔존 #1346 차단.
+ *
+ * 즉시 강제 종료는 KTX 장거리 사용자에게 false positive — 단계 처리로 사용자 가치 보호.
+ * 12h opt-in extend 토글은 후속 sub-task에서 별도 상수와 함께 도입(현 PR 범위 외).
+ *
+ * stale 5분+ 알람 차단 / 30분+ 알림 차단 임계는 T9 (#1572) / T12에서 wire될 때 함께 도입한다
+ * — 본 PR에 orphan 상수로 남기지 않는다 (Wire-completion 5단 룰).
+ */
+export const TRIP_LIFECYCLE_SILENCE_MS = 6 * 60 * 60_000;
+export const TRIP_LIFECYCLE_FORCE_END_MS = 9 * 60 * 60_000;
 // #1016 hole (c): BoardingLock 활성 시 positionTrain 후보가 유효한 arc 구간 window.
 // 탑승역 인덱스 + LOCK_NEXT_HOP_WINDOW 범위 내 역만 허용. 지하 dead zone에서 훨씬 앞의
 // 역을 채택하는 false positive를 차단한다. 인접역 간 평균 주행 시간(90s) × TTL(60s) 기준으로

--- a/src/shared/hooks/__tests__/useStateRehydration.test.ts
+++ b/src/shared/hooks/__tests__/useStateRehydration.test.ts
@@ -216,13 +216,14 @@ describe('useStateRehydration', () => {
   });
 
   describe('#1573 (T10) lifecycle backstop', () => {
-    it("phase='none' — backstop 아무 동작 안 함 (회귀 0)", async () => {
-      mockTripLifecyclePhase.mockReturnValue('none');
+    it("startedAt=null — backstop early return (회귀 0)", async () => {
+      mockGetTripStartedAt.mockResolvedValue(null);
       mockAppState();
       renderHook(() => useStateRehydration());
       await waitFor(() => expect(mockLoadDestination).toHaveBeenCalled());
       expect(mockAppendAlarmLog).not.toHaveBeenCalled();
       expect(mockSetSentinel).not.toHaveBeenCalled();
+      expect(mockTripLifecyclePhase).not.toHaveBeenCalled();
     });
 
     it("phase='normal' — backstop 아무 동작 안 함", async () => {

--- a/src/shared/hooks/__tests__/useStateRehydration.test.ts
+++ b/src/shared/hooks/__tests__/useStateRehydration.test.ts
@@ -13,10 +13,23 @@ import { useBoardingLockStore } from '../../../features/alarm/store/useBoardingL
 
 const mockGetSentinel = jest.fn();
 const mockClearSentinel = jest.fn();
+const mockSetSentinel = jest.fn();
 jest.mock('../../../features/alarm/utils/tripEndedSentinel', () => ({
   getTripEndedSentinel: (...args: unknown[]) => mockGetSentinel(...args),
   clearTripEndedSentinel: (...args: unknown[]) => mockClearSentinel(...args),
-  setTripEndedSentinel: jest.fn(),
+  setTripEndedSentinel: (...args: unknown[]) => mockSetSentinel(...args),
+}));
+
+const mockGetTripStartedAt = jest.fn();
+const mockTripLifecyclePhase = jest.fn();
+jest.mock('../../../features/alarm/utils/tripStartStorage', () => ({
+  getTripStartedAt: (...args: unknown[]) => mockGetTripStartedAt(...args),
+  tripLifecyclePhase: (...args: unknown[]) => mockTripLifecyclePhase(...args),
+}));
+
+const mockAppendAlarmLog = jest.fn();
+jest.mock('../../../features/alarm/utils/alarmLog', () => ({
+  appendAlarmLog: (...args: unknown[]) => mockAppendAlarmLog(...args),
 }));
 
 const mockAddDomainBreadcrumb = jest.fn();
@@ -53,6 +66,10 @@ beforeEach(() => {
   mockReleaseLock.mockResolvedValue(undefined);
   mockLoadLock.mockResolvedValue(undefined);
   mockRunTripBoundCleanups.mockResolvedValue(undefined);
+  mockSetSentinel.mockResolvedValue(undefined);
+  // 기본은 trip 미존재(none) — 기존 테스트들이 backstop 영향 받지 않도록.
+  mockGetTripStartedAt.mockResolvedValue(null);
+  mockTripLifecyclePhase.mockReturnValue('none');
   jest.spyOn(useDestinationStore, 'getState').mockReturnValue({
     setDestination: mockSetDestination,
     loadDestination: mockLoadDestination,
@@ -196,6 +213,81 @@ describe('useStateRehydration', () => {
     const { unmount } = renderHook(() => useStateRehydration());
     unmount();
     expect(app.remove).toHaveBeenCalled();
+  });
+
+  describe('#1573 (T10) lifecycle backstop', () => {
+    it("phase='none' — backstop 아무 동작 안 함 (회귀 0)", async () => {
+      mockTripLifecyclePhase.mockReturnValue('none');
+      mockAppState();
+      renderHook(() => useStateRehydration());
+      await waitFor(() => expect(mockLoadDestination).toHaveBeenCalled());
+      expect(mockAppendAlarmLog).not.toHaveBeenCalled();
+      expect(mockSetSentinel).not.toHaveBeenCalled();
+    });
+
+    it("phase='normal' — backstop 아무 동작 안 함", async () => {
+      mockGetTripStartedAt.mockResolvedValue(Date.now() - 60_000);
+      mockTripLifecyclePhase.mockReturnValue('normal');
+      mockAppState();
+      renderHook(() => useStateRehydration());
+      await waitFor(() => expect(mockLoadDestination).toHaveBeenCalled());
+      expect(mockAppendAlarmLog).not.toHaveBeenCalled();
+      expect(mockSetSentinel).not.toHaveBeenCalled();
+      expect(mockReleaseLock).not.toHaveBeenCalled();
+    });
+
+    it("phase='silence' (6h~9h) — alarmLog suppressed 적재 + 강제 종료 안 함", async () => {
+      mockGetTripStartedAt.mockResolvedValue(1_000_000);
+      mockTripLifecyclePhase.mockReturnValue('silence');
+      mockAppState();
+      renderHook(() => useStateRehydration());
+      await waitFor(() =>
+        expect(mockAppendAlarmLog).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: 'lifecycle-backstop',
+            outcome: 'suppressed',
+            reason: 'trip-lifecycle-silence',
+          }),
+        ),
+      );
+      // silence에서는 force-end 시퀀스 (setState/releaseLock/setSentinel) 호출 금지.
+      expect(mockSetState).not.toHaveBeenCalled();
+      expect(mockReleaseLock).not.toHaveBeenCalled();
+      expect(mockSetSentinel).not.toHaveBeenCalled();
+    });
+
+    it("phase='force-end' (9h+) — runTripBoundCleanups + setState reset + releaseLock + sentinel + alarmLog fired", async () => {
+      mockGetTripStartedAt.mockResolvedValue(1_000_000);
+      mockTripLifecyclePhase.mockReturnValue('force-end');
+      mockAppState();
+      renderHook(() => useStateRehydration());
+      await waitFor(() => expect(mockSetSentinel).toHaveBeenCalled());
+      expect(mockAppendAlarmLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'lifecycle-backstop',
+          outcome: 'fired',
+          reason: 'trip-lifecycle-force-ended',
+        }),
+      );
+      expect(mockRunTripBoundCleanups).toHaveBeenCalled();
+      expect(mockSetState).toHaveBeenCalledWith({
+        destination: null,
+        customOrigin: null,
+        tripOrigin: null,
+      });
+      expect(mockReleaseLock).toHaveBeenCalled();
+      expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('trip', 'end', {
+        reason: 'lifecycle-9h-force-end',
+      });
+    });
+
+    it("backstop 실패는 graceful (다음 launch 영향 X)", async () => {
+      mockGetTripStartedAt.mockRejectedValue(new Error('io'));
+      mockAppState();
+      // throw가 새지 않아 hook 자체는 정상 마운트.
+      expect(() => renderHook(() => useStateRehydration())).not.toThrow();
+      await waitFor(() => expect(mockLoadDestination).toHaveBeenCalled());
+    });
   });
 
   it('active 진입에서도 sentinel 있으면 cleanup + setState reset 호출', async () => {

--- a/src/shared/hooks/useStateRehydration.ts
+++ b/src/shared/hooks/useStateRehydration.ts
@@ -12,8 +12,14 @@ import { useBoardingLockStore } from '../../features/alarm/store/useBoardingLock
 import {
   clearTripEndedSentinel,
   getTripEndedSentinel,
+  setTripEndedSentinel,
 } from '../../features/alarm/utils/tripEndedSentinel';
 import { runTripBoundCleanups } from '../../features/alarm/store/tripBoundCleanups';
+import {
+  getTripStartedAt,
+  tripLifecyclePhase,
+} from '../../features/alarm/utils/tripStartStorage';
+import { appendAlarmLog } from '../../features/alarm/utils/alarmLog';
 import { createLogger } from '../utils/logger';
 import { addDomainBreadcrumb } from '../infra/monitoring/breadcrumb';
 
@@ -81,4 +87,62 @@ async function runRehydration(trigger: 'mount' | 'active'): Promise<void> {
     destStore.loadTripOrigin(),
     useBoardingLockStore.getState().loadLock(),
   ]);
+
+  // #1573 (T10) — trip lifecycle 단계적 backstop. FG 복귀 / mount 마다 확인.
+  // silence(6h~9h)와 force-end(9h+)는 staged-handling 룰에 따라 분리 처리한다.
+  //   silence — alarm/notify 차단만 (UI는 유지). KTX/장거리 trip false positive 방지.
+  //   force-end — runTripBoundCleanups + sentinel + store reset. lockless 9h+ 잔존 #1346 차단.
+  //
+  // silence 적재는 entry 1회당 한 cycle만 의미가 있고 멱등이 자연 — 매 active 진입마다 1엔트리.
+  // share dump에서 lifecycle-backstop source 카운트로 측정.
+  await runLifecycleBackstop(trigger);
+}
+
+/**
+ * #1573 (T10) — trip 시작 시각 기준 단계 판정 후 backstop 실행. throw 없음 — launch 차단 금지.
+ *
+ * silence는 share dump 측정만, force-end는 silent push trip-ended와 동일한 cleanup 시퀀스를
+ * 따라 store 메모리/storage 일관성 유지. setDestination 호출 대신 runTripBoundCleanups + setState
+ * 직접 호출은 #1351 R2와 동일 이유(prev=null 시 isSwitch=false로 cleanup chain skip되는 버그 회피).
+ */
+async function runLifecycleBackstop(trigger: 'mount' | 'active'): Promise<void> {
+  try {
+    const startedAt = await getTripStartedAt();
+    const phase = tripLifecyclePhase(startedAt);
+    if (phase === 'none' || phase === 'normal') return;
+
+    const now = Date.now();
+    const elapsedMs = startedAt !== null ? now - startedAt : 0;
+
+    if (phase === 'silence') {
+      appendAlarmLog({
+        ts: now,
+        source: 'lifecycle-backstop',
+        outcome: 'suppressed',
+        reason: 'trip-lifecycle-silence',
+      });
+      logger.info(`trigger=${trigger} silence elapsedMs=${elapsedMs}`);
+      return;
+    }
+
+    // force-end (9h+). silent push trip-ended와 동일 시퀀스.
+    appendAlarmLog({
+      ts: now,
+      source: 'lifecycle-backstop',
+      outcome: 'fired',
+      reason: 'trip-lifecycle-force-ended',
+    });
+    logger.info(`trigger=${trigger} force-end elapsedMs=${elapsedMs} → cleanup`);
+    await runTripBoundCleanups();
+    useDestinationStore.setState({
+      destination: null,
+      customOrigin: null,
+      tripOrigin: null,
+    });
+    addDomainBreadcrumb('trip', 'end', { reason: 'lifecycle-9h-force-end' });
+    await useBoardingLockStore.getState().releaseLock();
+    await setTripEndedSentinel(now);
+  } catch (e) {
+    logger.warn('lifecycle backstop 실패 (graceful)', e);
+  }
 }

--- a/src/shared/hooks/useStateRehydration.ts
+++ b/src/shared/hooks/useStateRehydration.ts
@@ -108,11 +108,13 @@ async function runRehydration(trigger: 'mount' | 'active'): Promise<void> {
 async function runLifecycleBackstop(trigger: 'mount' | 'active'): Promise<void> {
   try {
     const startedAt = await getTripStartedAt();
+    if (startedAt === null) return;
+    // tripLifecyclePhase는 startedAt non-null이면 'none' 외 3개 phase만 반환.
     const phase = tripLifecyclePhase(startedAt);
-    if (phase === 'none' || phase === 'normal') return;
+    if (phase === 'normal') return;
 
     const now = Date.now();
-    const elapsedMs = startedAt !== null ? now - startedAt : 0;
+    const elapsedMs = now - startedAt;
 
     if (phase === 'silence') {
       appendAlarmLog({


### PR DESCRIPTION
Closes #1573

ADR-017 T10. SSoT freshness 60s → 180s + Mirror leak #3 fix + 6h/9h staged lifecycle backstop.

## 핵심 변경

- `BACKEND_SSOT_MIRROR_MAX_AGE_MS` 60s → 180s (12:32:14 trip evidence: 60s 만료로 GPS-only fallback → 용마산 false fire. 6 cycle margin)
- `clearBackendSsotMirror()` 신설 + `tripBoundCleanups` 배열 한 줄 wire → 4 cleanup 경로 자동 클리어 (Mirror leak #3)
- `tripLifecyclePhase(startedAt, now)` helper + 6h silence / 9h force-end 단계 처리. `feedback_6h_backstop_staged_handling` 룰 준수 (KTX/장거리 trip false positive 방지)
- silence는 alarmLog suppressed 적재만, force-end는 silent push trip-ended와 동일 시퀀스 (`runTripBoundCleanups` + store reset + sentinel + releaseLock)
- alarmLog: source `'lifecycle-backstop'` + reason 4종(`gate-stale-alarm-blocked`, `gate-stale-notify-blocked`, `trip-lifecycle-silence`, `trip-lifecycle-force-ended`)

## 본 PR 범위 외 (후속 sub-task)

T10 본문 B/C (sticky SSoT 상태 + GPS-only tier 영구 disable + line gate + stale Nm UI)는 새 store + cascade 분기 + UI까지 함께 머지해야 wire-completion이 깨지지 않음 → 분리. T9 (#1572) 머지 후 stale alarm/notify block 게이트 wire도 분리. 12h opt-in extend 토글도 분리.

## Wire-completion 5단

1. **Orphan** — `npm run lint:orphan` PASS. 신규 export `clearBackendSsotMirror`(tripBoundCleanups 호출), `tripLifecyclePhase`(useStateRehydration 호출), `TRIP_LIFECYCLE_SILENCE_MS`/`TRIP_LIFECYCLE_FORCE_END_MS`(tripStartStorage 호출) 모두 caller 1개 이상 존재. caller 없는 상수(5min/30min stale, 12h opt-in)는 의도적으로 본 PR에서 제외
2. **V/X dashboard** — alarmLog `source='lifecycle-backstop'` 적재 → share dump / Cloudflare Analytics(P0-1) 카운트. DebugModal alarmLog 섹션 자동 노출. cascade freshness 180s 확장은 useFusedNearestStation 기존 `confidence='backend-ssot'` 카운트로 측정
3. **의존 PR** — Phase 0 측정 인프라(#1577 머지됨)에 의존. T9 #1572 / T11 #1574 / T12 #1575와 무충돌 (별 파일/별 책임)
4. **측정 plan** — 7일 production: (a) `trip-lifecycle-force-ended` 카운트 ≥ 1건 → 9h+ 잔존 trip 0건 목표 검증, (b) `trip-lifecycle-silence` 분포 → 6h~9h 정상 trip 비율, (c) 용마산 류 GPS-only false fire 0건 (12:32 회귀 reproduce 없음), (d) trip switch 직후 cascade에 이전 trip 좌표 mirror entry leak 0건
5. **Device verify** — 필요. 6h+ trip 시나리오는 시뮬레이터 어렵고 실기기 백그라운드 long-running 필수. 1주 일상 사용으로 X8 acceptance (trip 6h+ 잔존 = 0건) 측정

## 자가 점검 5/5

1. **acceptance self-referential?** — V5 자동 종료 %는 Analytics Engine(#1577 머지됨)으로 외부 측정. force-end 동작 가드 unit test로 검증 (mock-driven)
2. **Wire-completion CI orphan 0?** — PASS (orphan 상수 3개 제거하여 caller 없는 export 0)
3. **머지 순서?** — Phase 0 prerequisite #1577 머지 완료. T9/T11/T12와 병렬 가능 (충돌 없음)
4. **backward-compat?** — sticky 동작 점진 마이그레이션 (180s 확장은 freshness 길어지는 방향, lockless/lock 동일 적용). 기존 cascade tier 변경 없음. lifecycle backstop은 6h 이하 trip엔 무동작
5. **False positive?** — 6h+ 즉시 강제 종료 X (silence만). 9h+에서 force-end. 추가로 12h opt-in extend는 후속 PR. KTX 4-5h trip은 silence도 미진입

## 회귀 매핑

- 12:32:14 backend-ssot 60s 만료 → cascade fallback `position-train` → stale GPS(4200m) → 용마산 false fire → **180s 확장으로 BG silent push 한 cycle 손실 흡수**
- Mirror leak #3 (`BACKEND_SSOT_MIRROR_KEY` cleanup 누락) → **`clearBackendSsotMirror` wire가 4 경로 모두 자동 cleanup**
- lockless trip 9h+ 잔존 (#1346) → **`useStateRehydration` runLifecycleBackstop 9h force-end**

## 검증

- `npm run type-check`: 0 error
- `npm run lint:orphan`: No orphan exports
- `npx jest <touched 5 files>`: 67/67 PASS
- 전체 `npm test`: 6924/6959 (35 fail은 dev pre-existing — stationNotification.test.ts / widgetStorage.test.ts, 본 PR과 무관. `git stash && git checkout origin/dev`로 동일 재현 확인)