### PR TITLE
feat(#1534): backend infer + lockSuggestion forward + useLockSuggestion hook

### DIFF
--- a/backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts
+++ b/backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts
@@ -542,6 +542,32 @@ describe('advanceTripPosition — lockSuggestion 추론 (S1 T9b, #1534)', () => 
     kv = new InMemoryKV();
   });
 
+  // 게이트 통과만 시키기 위해 wifi-ssid-match strong evidence 1건 주입.
+  // (gps-displacement는 자체로 약하지만 strong evidence가 윈도우 안에 있으면 advance 흐름 평가 가능.)
+  function pushWifiSsotEvidence(ssot: { motionEvidence: MotionEvidence[] }): void {
+    ssot.motionEvidence.push({
+      source: 'device-wifi',
+      ts: NOW - 10_000,
+      signal: { type: 'wifi-ssid-match' },
+    });
+  }
+
+  // 약 evidence (gps-displacement)로 advanceTripPosition 호출 — suggestion 보존/미생성 검증 용.
+  async function advanceWithGpsDisplacement(stationId: string): Promise<void> {
+    await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      stationId,
+      {
+        type: 'gps-displacement',
+        stationId,
+        ts: NOW,
+        environment: 'surface',
+      },
+      { gatePassed: true, lockAttachable: false },
+    );
+  }
+
   it('lockless + arvlcd-confirmed-train + arvlcdTrainCode → high confidence suggestion (waypoint line)', async () => {
     const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
     ssot.motionState = 'moving';
@@ -626,27 +652,11 @@ describe('advanceTripPosition — lockSuggestion 추론 (S1 T9b, #1534)', () => 
   it('lockless + gps-displacement → suggestion 미생성 (약 evidence)', async () => {
     const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
     ssot.motionState = 'moving';
-    // strong evidence 1개 추가 — gps-displacement는 약하지만 게이트 통과만 시켜서 advance 흐름 평가
-    ssot.motionEvidence.push({
-      source: 'device-wifi',
-      ts: NOW - 10_000,
-      signal: { type: 'wifi-ssid-match' },
-    });
+    pushWifiSsotEvidence(ssot);
     await writeSsot(kv as unknown as KVNamespace, ssot);
     await putTrip(kv as unknown as KVNamespace, makeTrip());
 
-    await advanceTripPosition(
-      kv as unknown as KVNamespace,
-      TOKEN,
-      '중곡',
-      {
-        type: 'gps-displacement',
-        stationId: '중곡',
-        ts: NOW,
-        environment: 'surface',
-      },
-      { gatePassed: true, lockAttachable: false },
-    );
+    await advanceWithGpsDisplacement('중곡');
 
     const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
     expect(after?.lockSuggestion).toBeUndefined();
@@ -690,26 +700,11 @@ describe('advanceTripPosition — lockSuggestion 추론 (S1 T9b, #1534)', () => 
     const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
     ssot.motionState = 'moving';
     ssot.lockSuggestion = existing;
-    ssot.motionEvidence.push({
-      source: 'device-wifi',
-      ts: NOW - 10_000,
-      signal: { type: 'wifi-ssid-match' },
-    });
+    pushWifiSsotEvidence(ssot);
     await writeSsot(kv as unknown as KVNamespace, ssot);
     await putTrip(kv as unknown as KVNamespace, makeTrip());
 
-    await advanceTripPosition(
-      kv as unknown as KVNamespace,
-      TOKEN,
-      '중곡',
-      {
-        type: 'gps-displacement',
-        stationId: '중곡',
-        ts: NOW,
-        environment: 'surface',
-      },
-      { gatePassed: true, lockAttachable: false },
-    );
+    await advanceWithGpsDisplacement('중곡');
 
     const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
     expect(after?.lockSuggestion).toEqual(existing);

--- a/backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts
+++ b/backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts
@@ -15,7 +15,13 @@ import {
   type AdvanceStats,
   type WifiSsidEntry,
 } from '../advanceTripPosition';
-import { readSsot, seedSsot, writeSsot, type MotionEvidence } from '../tripPositionSsot';
+import {
+  readSsot,
+  seedSsot,
+  writeSsot,
+  type LockSuggestion,
+  type MotionEvidence,
+} from '../tripPositionSsot';
 import { putTrip } from '../trips';
 import type { BoardingLockMeta, Trip } from '../types';
 import { InMemoryKV } from './inMemoryKv';
@@ -527,6 +533,207 @@ describe('advanceTripPosition — 6단 게이트 양방향 시나리오 (accepta
     );
     const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
     expect(after?.passedStations.filter((s) => s === '용마산').length).toBe(1);
+  });
+});
+
+describe('advanceTripPosition — lockSuggestion 추론 (S1 T9b, #1534)', () => {
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  it('lockless + arvlcd-confirmed-train + arvlcdTrainCode → high confidence suggestion (waypoint line)', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip()); // no boardingLock
+
+    await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      // arvlcd-lockless로는 6단 게이트 통과 못 함 — arvlcd-confirmed-train + 추가 strong이 필요한
+      // 정책은 게이트 #6에서만 적용. 본 시나리오는 lockless + arvlcd-confirmed-train evidence
+      // (lock attach 불필요 — caller가 lockAttachable=false로 호출해도 게이트 #5는 lock 없을 때 skip).
+      makeEvidence({ arvlcdTrainCode: '7246' }),
+      { gatePassed: true, lockAttachable: false },
+    );
+
+    const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    expect(after?.lockSuggestion).toEqual({
+      stationId: '중곡',
+      trainCode: '7246',
+      lineId: '7',
+      confidence: 'high',
+      decidedAt: NOW,
+    });
+  });
+
+  it('lock 활성 trip은 suggestion 미설정 (lock이 SSOT)', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: makeLock() }));
+
+    await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence(),
+      { gatePassed: true, lockAttachable: true },
+    );
+
+    const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    expect(after?.lockSuggestion).toBeUndefined();
+  });
+
+  it('lockless + position-train evidence → medium confidence suggestion', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip());
+
+    await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      {
+        type: 'position-train',
+        stationId: '중곡',
+        ts: NOW,
+        environment: 'surface',
+        positionEntry: {
+          trainCode: '9999',
+          stationName: '중곡',
+          trainSttus: 1,
+          isUp: true,
+          recptnMs: NOW,
+        },
+      },
+      { gatePassed: true, lockAttachable: false },
+    );
+
+    const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    expect(after?.lockSuggestion).toEqual({
+      stationId: '중곡',
+      trainCode: '9999',
+      lineId: '7',
+      confidence: 'medium',
+      decidedAt: NOW,
+    });
+  });
+
+  it('lockless + gps-displacement → suggestion 미생성 (약 evidence)', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    ssot.motionState = 'moving';
+    // strong evidence 1개 추가 — gps-displacement는 약하지만 게이트 통과만 시켜서 advance 흐름 평가
+    ssot.motionEvidence.push({
+      source: 'device-wifi',
+      ts: NOW - 10_000,
+      signal: { type: 'wifi-ssid-match' },
+    });
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip());
+
+    await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      {
+        type: 'gps-displacement',
+        stationId: '중곡',
+        ts: NOW,
+        environment: 'surface',
+      },
+      { gatePassed: true, lockAttachable: false },
+    );
+
+    const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    expect(after?.lockSuggestion).toBeUndefined();
+  });
+
+  it('동일 suggestion 재진입 → 기존 suggestion 보존 (drop 회귀 X)', async () => {
+    const existing: LockSuggestion = {
+      stationId: '중곡',
+      trainCode: '7246',
+      lineId: '7',
+      confidence: 'high',
+      decidedAt: NOW - 5_000,
+    };
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    ssot.motionState = 'moving';
+    ssot.lockSuggestion = existing;
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip());
+
+    await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence({ arvlcdTrainCode: '7246' }),
+      { gatePassed: true, lockAttachable: false },
+    );
+
+    const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    // decidedAt이 기존 값 그대로(같은 stationId+trainCode+lineId면 isSameLockSuggestion=true → 보존)
+    expect(after?.lockSuggestion?.decidedAt).toBe(NOW - 5_000);
+  });
+
+  it('약 evidence advance지만 기존 suggestion 있으면 보존 (drop 회귀 X)', async () => {
+    const existing: LockSuggestion = {
+      stationId: '용마산',
+      trainCode: '7246',
+      lineId: '7',
+      confidence: 'high',
+      decidedAt: NOW - 5_000,
+    };
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    ssot.motionState = 'moving';
+    ssot.lockSuggestion = existing;
+    ssot.motionEvidence.push({
+      source: 'device-wifi',
+      ts: NOW - 10_000,
+      signal: { type: 'wifi-ssid-match' },
+    });
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip());
+
+    await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      {
+        type: 'gps-displacement',
+        stationId: '중곡',
+        ts: NOW,
+        environment: 'surface',
+      },
+      { gatePassed: true, lockAttachable: false },
+    );
+
+    const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    expect(after?.lockSuggestion).toEqual(existing);
+  });
+
+  it('trip waypoints 부재 → suggestion 미생성 (lineId 산출 불가)', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    // 일반 trip 후 in-place로 waypoints 비우기 (validateTrip은 거부하지만 KV 직접 write로 테스트)
+    const trip = makeTrip();
+    trip.waypoints = [];
+    await putTrip(kv as unknown as KVNamespace, trip);
+
+    await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence({ arvlcdTrainCode: '7246' }),
+      { gatePassed: true, lockAttachable: false },
+    );
+
+    const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    expect(after?.lockSuggestion).toBeUndefined();
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1776,6 +1776,76 @@ describe('POST /position (#819)', () => {
       expect(stored[0].cellularEnvironmentVote).toBeUndefined();
     });
   });
+
+  describe('#1534 (S1, T9b, ADR-016) — response embed lockSuggestion + originStationId', () => {
+    const BASE_POS = {
+      token: 'tok-ls',
+      lat: 1,
+      lng: 2,
+      accuracy: 5,
+      ts: 1234,
+      motion: 'walking' as const,
+    };
+
+    it('SSOT 미존재 (trip 미등록) → response { ok: true } only, lockSuggestion/originStationId 누락', async () => {
+      const env = makeKvEnv();
+      const res = await post('/position', BASE_POS, env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.ok).toBe(true);
+      expect(body.lockSuggestion).toBeUndefined();
+      expect(body.originStationId).toBeUndefined();
+    });
+
+    it('SSOT 존재 + currentStationId set → originStationId만 forward', async () => {
+      const env = makeKvEnv();
+      // SSOT 직접 seed
+      const { seedSsot } = await import('../tripPositionSsot');
+      await seedSsot(env.TRIPS, BASE_POS.token, '용마산');
+      const res = await post('/position', BASE_POS, env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.originStationId).toBe('용마산');
+      expect(body.lockSuggestion).toBeUndefined();
+    });
+
+    it('SSOT + lockSuggestion → 둘 다 response embed', async () => {
+      const env = makeKvEnv();
+      const { seedSsot, setLockSuggestion, writeSsot } = await import('../tripPositionSsot');
+      const ssot = await seedSsot(env.TRIPS, BASE_POS.token, '용마산');
+      setLockSuggestion(ssot, {
+        stationId: '용마산',
+        trainCode: '7246',
+        lineId: '7',
+        confidence: 'high',
+        decidedAt: 1_700_000_000_000,
+      });
+      await writeSsot(env.TRIPS, ssot);
+      const res = await post('/position', BASE_POS, env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.originStationId).toBe('용마산');
+      expect(body.lockSuggestion).toEqual({
+        stationId: '용마산',
+        trainCode: '7246',
+        lineId: '7',
+        confidence: 'high',
+        decidedAt: 1_700_000_000_000,
+      });
+    });
+
+    it('SSOT currentStationId 빈 문자열 (GAP A seed 직후) → originStationId 누락 (graceful)', async () => {
+      const env = makeKvEnv();
+      const { seedSsot, writeSsot } = await import('../tripPositionSsot');
+      const ssot = await seedSsot(env.TRIPS, BASE_POS.token, 'X');
+      ssot.currentStationId = '';
+      await writeSsot(env.TRIPS, ssot);
+      const res = await post('/position', BASE_POS, env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.originStationId).toBeUndefined();
+    });
+  });
 });
 
 describe('POST /boarding-prompt/dismiss (#819)', () => {

--- a/backend/alarm-worker/src/__tests__/tripPositionSsot.test.ts
+++ b/backend/alarm-worker/src/__tests__/tripPositionSsot.test.ts
@@ -257,18 +257,18 @@ describe('tripPositionSsot — migrateTripPassedStationsToSsot', () => {
   });
 });
 
-describe('tripPositionSsot — lockSuggestion helpers (S1 T9b, #1534)', () => {
-  function makeSuggestion(overrides?: Partial<LockSuggestion>): LockSuggestion {
-    return {
-      stationId: '0228',
-      trainCode: '7246',
-      lineId: '7',
-      confidence: 'high',
-      decidedAt: 1_700_000_000_000,
-      ...overrides,
-    };
-  }
+function makeSuggestion(overrides?: Partial<LockSuggestion>): LockSuggestion {
+  return {
+    stationId: '0228',
+    trainCode: '7246',
+    lineId: '7',
+    confidence: 'high',
+    decidedAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
 
+describe('tripPositionSsot — lockSuggestion helpers (S1 T9b, #1534)', () => {
   it('setLockSuggestion: in-place mutate ssot.lockSuggestion', () => {
     const ssot = makeSsot();
     expect(ssot.lockSuggestion).toBeUndefined();

--- a/backend/alarm-worker/src/__tests__/tripPositionSsot.test.ts
+++ b/backend/alarm-worker/src/__tests__/tripPositionSsot.test.ts
@@ -3,12 +3,15 @@ import {
   MOTION_EVIDENCE_CAP,
   SSOT_CRON_READ_CACHE_TTL_SEC,
   deleteSsot,
+  isSameLockSuggestion,
   migrateTripPassedStationsToSsot,
   pushMotionEvidence,
   readSsot,
   seedSsot,
+  setLockSuggestion,
   ssotKey,
   writeSsot,
+  type LockSuggestion,
   type MotionEvidence,
   type TripPositionSSoT,
 } from '../tripPositionSsot';
@@ -251,5 +254,74 @@ describe('tripPositionSsot — migrateTripPassedStationsToSsot', () => {
     const ssot = makeSsot({ passedStations: ['A', 'B'] });
     migrateTripPassedStationsToSsot({ passedStations: ['B', 'C', 'D'] }, ssot);
     expect(ssot.passedStations).toEqual(['A', 'B', 'C', 'D']);
+  });
+});
+
+describe('tripPositionSsot — lockSuggestion helpers (S1 T9b, #1534)', () => {
+  function makeSuggestion(overrides?: Partial<LockSuggestion>): LockSuggestion {
+    return {
+      stationId: '0228',
+      trainCode: '7246',
+      lineId: '7',
+      confidence: 'high',
+      decidedAt: 1_700_000_000_000,
+      ...overrides,
+    };
+  }
+
+  it('setLockSuggestion: in-place mutate ssot.lockSuggestion', () => {
+    const ssot = makeSsot();
+    expect(ssot.lockSuggestion).toBeUndefined();
+    const s = makeSuggestion();
+    setLockSuggestion(ssot, s);
+    expect(ssot.lockSuggestion).toEqual(s);
+  });
+
+  it('setLockSuggestion: 기존 suggestion 덮어쓰기 (unconditional write)', () => {
+    const ssot = makeSsot({ lockSuggestion: makeSuggestion({ trainCode: 'OLD' }) });
+    setLockSuggestion(ssot, makeSuggestion({ trainCode: 'NEW' }));
+    expect(ssot.lockSuggestion?.trainCode).toBe('NEW');
+  });
+
+  it('isSameLockSuggestion: 기존 undefined → false', () => {
+    expect(isSameLockSuggestion(undefined, makeSuggestion())).toBe(false);
+  });
+
+  it('isSameLockSuggestion: 동일 stationId+trainCode+lineId → true', () => {
+    const a = makeSuggestion();
+    const b = makeSuggestion();
+    expect(isSameLockSuggestion(a, b)).toBe(true);
+  });
+
+  it('isSameLockSuggestion: confidence/decidedAt 차이는 무시 (정체성 기준은 3개 핵심 필드)', () => {
+    const a = makeSuggestion({ confidence: 'high', decidedAt: 1 });
+    const b = makeSuggestion({ confidence: 'medium', decidedAt: 999 });
+    expect(isSameLockSuggestion(a, b)).toBe(true);
+  });
+
+  it('isSameLockSuggestion: stationId 다르면 false', () => {
+    expect(
+      isSameLockSuggestion(makeSuggestion(), makeSuggestion({ stationId: 'OTHER' })),
+    ).toBe(false);
+  });
+
+  it('isSameLockSuggestion: trainCode 다르면 false', () => {
+    expect(
+      isSameLockSuggestion(makeSuggestion(), makeSuggestion({ trainCode: 'OTHER' })),
+    ).toBe(false);
+  });
+
+  it('isSameLockSuggestion: lineId 다르면 false', () => {
+    expect(
+      isSameLockSuggestion(makeSuggestion(), makeSuggestion({ lineId: '2' })),
+    ).toBe(false);
+  });
+
+  it('lockSuggestion round-trip: writeSsot → readSsot 보존', async () => {
+    const kv = new InMemoryKV();
+    const ssot = makeSsot({ lockSuggestion: makeSuggestion() });
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    const got = await readSsot(kv as unknown as KVNamespace, ssot.tripToken);
+    expect(got?.lockSuggestion).toEqual(makeSuggestion());
   });
 });

--- a/backend/alarm-worker/src/advanceTripPosition.ts
+++ b/backend/alarm-worker/src/advanceTripPosition.ts
@@ -364,30 +364,47 @@ export async function advanceTripPosition(
     lastAdvanceEvidence: evidence.type,
   };
 
-  // #1534 (S1, T9b) — lockless trip + 강 evidence 합의 시 lockSuggestion 추론.
-  //
-  // device가 `useLockSuggestion`으로 본 값을 1순위 채택해 lock 없이도 fire path를 활성화한다
-  // (lockless 첫 station miss 0 acceptance V2). lock 활성 trip에는 set하지 않음 (기존 lock이
-  // SSOT 그대로 forward — 별 reader 정책 불필요).
-  //
-  // 기존 lockSuggestion이 동일 stationId+trainCode+lineId면 보존 (KV write 비용 최소화 +
-  // device cascade picker가 receivedAt drift로 무용한 re-render 방지). 어떤 분기에서도 기존
-  // suggestion이 silently dropped되지 않도록 항상 forward.
-  const suggestion = deriveLockSuggestion({
+  applyLockSuggestion(next, ssot, {
     lockActive: lock !== undefined,
     candidateStationId,
     evidence,
     waypointLine: trip.waypoints[0]?.line,
   });
-  if (suggestion && !isSameLockSuggestion(ssot.lockSuggestion, suggestion)) {
-    setLockSuggestion(next, suggestion);
-  } else if (ssot.lockSuggestion) {
-    // 기존 suggestion 보존 — drop 회귀 차단.
-    next.lockSuggestion = ssot.lockSuggestion;
-  }
 
   await writeSsot(kv, next, { expiresAt: trip.expiresAt });
   return { result: 'advanced', ssot: next };
+}
+
+/**
+ * #1534 (S1, T9b) — lockless trip + 강 evidence 합의 시 lockSuggestion 추론.
+ *
+ * device가 `useLockSuggestion`으로 본 값을 1순위 채택해 lock 없이도 fire path를 활성화한다
+ * (lockless 첫 station miss 0 acceptance V2). lock 활성 trip에는 set하지 않음 (기존 lock이
+ * SSOT 그대로 forward — 별 reader 정책 불필요).
+ *
+ * 기존 lockSuggestion이 동일 stationId+trainCode+lineId면 보존 (KV write 비용 최소화 +
+ * device cascade picker가 receivedAt drift로 무용한 re-render 방지). 어떤 분기에서도 기존
+ * suggestion이 silently dropped되지 않도록 항상 forward.
+ */
+function applyLockSuggestion(
+  next: TripPositionSSoT,
+  prev: TripPositionSSoT,
+  input: {
+    lockActive: boolean;
+    candidateStationId: string;
+    evidence: AdvanceEvidence;
+    waypointLine: string | undefined;
+  },
+): void {
+  const suggestion = deriveLockSuggestion(input);
+  if (suggestion && !isSameLockSuggestion(prev.lockSuggestion, suggestion)) {
+    setLockSuggestion(next, suggestion);
+    return;
+  }
+  if (prev.lockSuggestion) {
+    // 기존 suggestion 보존 — drop 회귀 차단.
+    next.lockSuggestion = prev.lockSuggestion;
+  }
 }
 
 /**

--- a/backend/alarm-worker/src/advanceTripPosition.ts
+++ b/backend/alarm-worker/src/advanceTripPosition.ts
@@ -44,10 +44,13 @@
 import { evaluateConsensusGate, type StationEnvironment } from './consensusGate';
 import type { ArrivalEntry, PositionEntry } from './seoul';
 import {
+  isSameLockSuggestion,
   MOTION_EVIDENCE_CAP,
   readSsot,
+  setLockSuggestion,
   writeSsot,
   type EvidenceType,
+  type LockSuggestion,
   type MotionEvidence,
   type TripPositionSSoT,
 } from './tripPositionSsot';
@@ -360,8 +363,76 @@ export async function advanceTripPosition(
     lastAdvanceAt: evidence.ts,
     lastAdvanceEvidence: evidence.type,
   };
+
+  // #1534 (S1, T9b) — lockless trip + 강 evidence 합의 시 lockSuggestion 추론.
+  //
+  // device가 `useLockSuggestion`으로 본 값을 1순위 채택해 lock 없이도 fire path를 활성화한다
+  // (lockless 첫 station miss 0 acceptance V2). lock 활성 trip에는 set하지 않음 (기존 lock이
+  // SSOT 그대로 forward — 별 reader 정책 불필요).
+  //
+  // 기존 lockSuggestion이 동일 stationId+trainCode+lineId면 보존 (KV write 비용 최소화 +
+  // device cascade picker가 receivedAt drift로 무용한 re-render 방지). 어떤 분기에서도 기존
+  // suggestion이 silently dropped되지 않도록 항상 forward.
+  const suggestion = deriveLockSuggestion({
+    lockActive: lock !== undefined,
+    candidateStationId,
+    evidence,
+    waypointLine: trip.waypoints[0]?.line,
+  });
+  if (suggestion && !isSameLockSuggestion(ssot.lockSuggestion, suggestion)) {
+    setLockSuggestion(next, suggestion);
+  } else if (ssot.lockSuggestion) {
+    // 기존 suggestion 보존 — drop 회귀 차단.
+    next.lockSuggestion = ssot.lockSuggestion;
+  }
+
   await writeSsot(kv, next, { expiresAt: trip.expiresAt });
   return { result: 'advanced', ssot: next };
+}
+
+/**
+ * #1534 (S1, T9b) — advance 통과 evidence로부터 lockSuggestion 추론.
+ *
+ * 정책:
+ *   - lock 활성 trip: suggestion 미설정 (이미 lock이 source of truth)
+ *   - lock 없음 + arvlcd-confirmed-train + arvlcdTrainCode 보유: high confidence suggestion
+ *   - lock 없음 + position-train + positionEntry.trainCode 보유: medium confidence
+ *   - 그 외 (gps / cellular / wifi 단독 등): 약 evidence — suggestion 없음 (caller가 다른 cycle 기다림)
+ *
+ * lineId는 waypointLine(trip route 첫 waypoint의 line)을 사용 — Seoul API는 ArrivalEntry/
+ * PositionEntry에 line 식별자(subwayId)를 제공하지 않으므로 trip route SSOT를 신뢰한다.
+ * 환승 hop 이후 (waypoint shift) 도 첫 waypoint가 현재 leg의 line이라 동일 패턴 적용.
+ */
+function deriveLockSuggestion(input: {
+  lockActive: boolean;
+  candidateStationId: string;
+  evidence: AdvanceEvidence;
+  waypointLine: string | undefined;
+}): LockSuggestion | null {
+  if (input.lockActive) return null;
+  if (!input.waypointLine) return null;
+  const { evidence, candidateStationId, waypointLine } = input;
+  // 강 (high) — arvlcd-confirmed-train evidence는 trainCode 확정. lineId는 waypoint line.
+  if (evidence.type === 'arvlcd-confirmed-train' && evidence.arvlcdTrainCode) {
+    return {
+      stationId: candidateStationId,
+      trainCode: evidence.arvlcdTrainCode,
+      lineId: waypointLine,
+      confidence: 'high',
+      decidedAt: evidence.ts,
+    };
+  }
+  // 중 (medium) — position-train evidence는 Seoul realtimePosition 매칭 trainCode.
+  if (evidence.type === 'position-train' && evidence.positionEntry?.trainCode) {
+    return {
+      stationId: candidateStationId,
+      trainCode: evidence.positionEntry.trainCode,
+      lineId: waypointLine,
+      confidence: 'medium',
+      decidedAt: evidence.ts,
+    };
+  }
+  return null;
 }
 
 /**

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -183,6 +183,31 @@ export interface SilentPushSsotPayload {
   lastAdvanceAt: number;
   /** 통과 확인된 station 누적 (최근 5개만 forward). */
   passedStations: readonly string[];
+  /**
+   * #1534 (S1, T9b, ADR-016) — backend가 추론한 lock 제안.
+   *
+   * lockless trip + 강 evidence 합의 시 set. device `useLockSuggestion` reader가 1순위 채택해
+   * 9-AND gate 통과를 기다리지 않고 즉시 lock UX 활성화. 부재 시 device는 기존 9-AND gate
+   * fallback (graceful, backward-compat). 구 backend 호환 위해 optional.
+   *
+   * device 측 정책: high/medium confidence 모두 채택. low는 향후 확장 slot.
+   */
+  lockSuggestion?: LockSuggestionPayload;
+}
+
+/**
+ * #1534 (S1, T9b) — silent push payload + POST /position response 양쪽이 공유하는
+ * lockSuggestion wire schema. backend `TripPositionSSoT.lockSuggestion`과 1:1.
+ *
+ * 본 type을 apns.ts에 두는 이유: silent push payload schema의 일부이며 device 측 schema
+ * (`SilentPushSsotMirror.lockSuggestion`)와 1:1 mirror라 같은 정의를 backend 진입점에 둔다.
+ */
+export interface LockSuggestionPayload {
+  stationId: string;
+  trainCode: string;
+  lineId: string;
+  confidence: 'high' | 'medium' | 'low';
+  decidedAt: number;
 }
 
 /**

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -1021,7 +1021,7 @@ app.post('/position', async (c) => {
     ok: true,
     // currentStationId가 빈 문자열이 아닐 때만 forward — 빈 stationId는 device 측에서
     // "추론 미정착" 신호로 다뤄야 하므로 명시 누락 (graceful).
-    ...(ssot && ssot.currentStationId
+    ...(ssot?.currentStationId
       ? { originStationId: ssot.currentStationId }
       : {}),
     ...(ssot?.lockSuggestion ? { lockSuggestion: ssot.lockSuggestion } : {}),

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -88,7 +88,8 @@ import {
   validateRegressionUpload,
   writeRegressionDataPoints,
 } from './regressionTelemetry';
-import { KV_MIN_CACHE_TTL_SEC } from './kvConsistency';
+import { CRON_READ_CACHE_TTL_SEC, KV_MIN_CACHE_TTL_SEC } from './kvConsistency';
+import { readSsot } from './tripPositionSsot';
 import { getTrip, putTrip } from './trips';
 import { checkTripRegisterRateLimit } from './tripRegisterRateLimit';
 import {
@@ -1005,7 +1006,26 @@ app.post('/position', async (c) => {
     tripToken: payload.token,
     reason: payload.point.motion,
   });
-  return c.json({ ok: true });
+
+  // #1534 (S1, T9b, ADR-016) — primary transport: POST /position response에 lockSuggestion +
+  // originStationId 회신. silent push가 비활성 OS suspend / kill / 저전력 분기에 도달 못해도
+  // device가 cycle마다 호출하는 /position 응답으로 즉시 lockSuggestion 인계. silent push payload는
+  // secondary transport (`toSilentPushSsot`).
+  //
+  // SSOT 부재 시(trip 미등록) lockSuggestion / originStationId 누락 — graceful, device는
+  // 기존 9-AND gate fallback. SSOT cacheTtl 30s 명시(KV 최소 제약 + cron 사이클 정합).
+  const ssot = await readSsot(c.env.TRIPS, payload.token, {
+    cacheTtl: CRON_READ_CACHE_TTL_SEC,
+  });
+  return c.json({
+    ok: true,
+    // currentStationId가 빈 문자열이 아닐 때만 forward — 빈 stationId는 device 측에서
+    // "추론 미정착" 신호로 다뤄야 하므로 명시 누락 (graceful).
+    ...(ssot && ssot.currentStationId
+      ? { originStationId: ssot.currentStationId }
+      : {}),
+    ...(ssot?.lockSuggestion ? { lockSuggestion: ssot.lockSuggestion } : {}),
+  });
 });
 
 interface PositionUploadPayload {

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -933,6 +933,9 @@ export function toSilentPushSsot(
     lastAdvanceEvidence: ssot.lastAdvanceEvidence,
     lastAdvanceAt: ssot.lastAdvanceAt,
     passedStations: ssot.passedStations.slice(-SSOT_FORWARD_PASSED_STATIONS_MAX),
+    // #1534 (S1, T9b) — backend lockSuggestion forward. 부재 시 wire 자연 누락
+    // (apns.ts JSON serializer는 undefined 필드 omit). device cascade picker는 기존 tier fallback.
+    ...(ssot.lockSuggestion ? { lockSuggestion: ssot.lockSuggestion } : {}),
   };
 }
 

--- a/backend/alarm-worker/src/tripPositionSsot.ts
+++ b/backend/alarm-worker/src/tripPositionSsot.ts
@@ -101,6 +101,34 @@ export interface MotionEvidence {
 }
 
 /**
+ * #1534 (S1, ADR-016 / ADR-017 T9b) — backend가 추론한 lock 제안.
+ *
+ * 배경: lockless trip 등록 직후 backend가 GPS + arvlcd + trainCode 종합으로 origin/train을
+ * 추론하면 device가 9-AND gate 통과를 기다리지 않고도 lock을 즉시 채택할 수 있다 (lockless
+ * 첫 station miss 0 acceptance V2).
+ *
+ * 본 필드가 set되면 device `useLockSuggestion` reader가 본 값을 1순위로 채택. null이면
+ * device는 기존 9-AND gate fallback으로 동작 (graceful, backward-compat).
+ *
+ * confidence:
+ *   - 'high'   : arvlcd-confirmed-train evidence (trainCode/line 명확)
+ *   - 'medium' : position-train / wifi-ssid-match evidence (train 후보 좁힘 + 정합)
+ *   - 'low'    : 향후 cellular/accel single signal 채택 (현재 미사용 — 미래 확장 slot)
+ */
+export interface LockSuggestion {
+  /** 추론된 출발/현재 station identifier. */
+  stationId: string;
+  /** Seoul API btrainNo (예: "7246"). */
+  trainCode: string;
+  /** 노선 (Waypoint.line / BoardingLockMeta.line과 동일 표기). */
+  lineId: string;
+  /** 추론 신뢰도 — device가 채택 정책에 사용 가능 (현 PR은 high/medium 모두 채택). */
+  confidence: 'high' | 'medium' | 'low';
+  /** 추론 결정 시각 (epoch ms). device가 staleness 판단 가능. */
+  decidedAt: number;
+}
+
+/**
  * Trip Position Single Source of Truth (ADR-017).
  *
  * 단일 trip의 위치/모션/사용자 의향 상태를 한 곳에 응집. fire path는 read-only로 본 SSOT
@@ -109,7 +137,13 @@ export interface MotionEvidence {
 export interface TripPositionSSoT {
   /** SSOT가 속한 trip token (APNs device token). */
   tripToken: string;
-  /** 현재 device가 위치한다고 backend가 확신하는 stationId (또는 stationName 호환). */
+  /**
+   * 현재 device가 위치한다고 backend가 확신하는 stationId (또는 stationName 호환).
+   *
+   * #1534 (S1 GAP A) — currentStation 미상으로 trip이 등록되는 경우 빈 문자열("")로 seed될 수
+   * 있다. 후속 advance / lockSuggestion 추론이 정착되면 정상 stationId로 갱신된다.
+   * 본 필드가 빈 문자열인 동안 advance 게이트 #1(no-seed)이 blocked로 차단해 fire를 막는다.
+   */
   currentStationId: string;
   /** 게이트 #2 입력. T3 motion state machine이 갱신. */
   motionState: MotionState;
@@ -125,6 +159,12 @@ export interface TripPositionSSoT {
   userIntentDeclared: boolean;
   /** seed override 발생 횟수 (E5 강 신호 2개 + 30s 연속 일치로 currentStationId 정정 시 +1). */
   seedOverrideCount: number;
+  /**
+   * #1534 (S1, T9b) — backend가 추론한 lock 제안. lockless trip + 강 evidence 합의 시 set.
+   * device `useLockSuggestion`이 reader-only로 채택해 9-AND gate 우회. 부재 시 device는
+   * 기존 9-AND gate fallback (graceful, backward-compat).
+   */
+  lockSuggestion?: LockSuggestion;
   /** schemaVersion. 향후 마이그레이션 분기용. v1 박제. */
   schemaVersion: 1;
 }
@@ -198,6 +238,11 @@ export async function deleteSsot(kv: KVNamespace, token: string): Promise<void> 
  *
  * motionState는 `'unknown'`으로 시작 — T3 motion state machine이 첫 GPS sample 수신 후 갱신.
  * userIntentDeclared / seedOverrideCount는 false / 0.
+ *
+ * #1534 (S1 GAP A) — currentStationId는 빈 문자열("") 허용. device가 currentStation 미상으로
+ * trip을 등록할 때 backend는 빈 stationId로 seed하고, /position upload + 후속 advance 수렴으로
+ * lockSuggestion을 추론한다. advance 게이트 #1(no-seed)가 빈 stationId를 blocked로 차단해
+ * 그 동안 fire는 자연 보류된다.
  */
 export async function seedSsot(
   kv: KVNamespace,
@@ -271,3 +316,33 @@ export function migrateTripPassedStationsToSsot(
  * `CRON_READ_CACHE_TTL_SEC`(30s) 재export — `trips.ts:listTrips` 패턴과 정합.
  */
 export const SSOT_CRON_READ_CACHE_TTL_SEC = CRON_READ_CACHE_TTL_SEC;
+
+/**
+ * #1534 (S1, T9b) — backend lockSuggestion in-place set helper.
+ *
+ * caller(advanceTripPosition / 후속 cron 추론 site)가 LockSuggestion을 결정한 뒤 SSOT mutate.
+ * 본 함수는 in-place — caller가 writeSsot 책임. confidence 같은 비교 정책은 caller가 처리.
+ *
+ * 같은 stationId+trainCode+lineId가 이미 set 됐고 confidence가 같거나 더 높으면 caller가 호출
+ * 자체를 skip해 KV write 비용을 줄여야 한다 (본 함수는 unconditional write).
+ */
+export function setLockSuggestion(
+  ssot: TripPositionSSoT,
+  suggestion: LockSuggestion,
+): void {
+  ssot.lockSuggestion = suggestion;
+}
+
+/**
+ * #1534 (S1, T9b) — 같은 lockSuggestion이 이미 set 됐는지 비교.
+ *
+ * stationId / trainCode / lineId가 모두 같으면 동일 suggestion으로 판정. confidence 변화나
+ * decidedAt 갱신만으로는 본 함수는 false (caller가 더 강한 confidence면 자유롭게 갱신).
+ */
+export function isSameLockSuggestion(
+  a: LockSuggestion | undefined,
+  b: LockSuggestion,
+): boolean {
+  if (a === undefined) return false;
+  return a.stationId === b.stationId && a.trainCode === b.trainCode && a.lineId === b.lineId;
+}

--- a/src/features/alarm/api/__tests__/useLockSuggestion.test.ts
+++ b/src/features/alarm/api/__tests__/useLockSuggestion.test.ts
@@ -1,0 +1,316 @@
+/**
+ * #1534 (S1, T9b, ADR-016) — useLockSuggestion hook acceptance.
+ *
+ * 매핑된 acceptance:
+ *   - V2 lockless 첫 station miss ≤ 2 — useLockSuggestion이 lockSuggestion mirror를 1순위 노출
+ *   - lockSuggestion 부재 → null (caller 9-AND fallback)
+ *   - LOCK_SUGGESTION_MAX_AGE_MS 초과 → null (mirror leak 차단)
+ *   - 동일 mirror entry 재read는 setState skip (re-render 폭주 차단)
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import {
+  LOCK_SUGGESTION_MAX_AGE_MS,
+  LOCK_SUGGESTION_POLL_INTERVAL_MS,
+  useLockSuggestion,
+} from '../useLockSuggestion';
+import * as backendSsotMirror from '../../utils/backendSsotMirror';
+import type {
+  BackendSsotMirrorEntry,
+  LockSuggestionMirror,
+} from '../../utils/backendSsotMirror';
+
+const SUGGESTION: LockSuggestionMirror = {
+  stationId: '용마산',
+  trainCode: '7246',
+  lineId: '7',
+  confidence: 'high',
+  decidedAt: 1_700_000_000_000,
+};
+
+const ENTRY: BackendSsotMirrorEntry = {
+  currentStationId: '용마산',
+  motionState: 'moving',
+  lastAdvanceEvidence: 'arvlcd-confirmed-train',
+  lastAdvanceAt: 1_700_000_000_000,
+  passedStations: ['중곡'],
+  receivedAt: 1_700_000_000_000,
+  lockSuggestion: SUGGESTION,
+};
+
+describe('useLockSuggestion (#1534 S1 T9b)', () => {
+  let readSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    readSpy = jest.spyOn(backendSsotMirror, 'readBackendSsotMirror');
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    readSpy.mockRestore();
+  });
+
+  it('첫 tick 전에는 suggestion=null (마운트 직후 동기 read X)', () => {
+    readSpy.mockResolvedValue(ENTRY);
+    const { result } = renderHook(() =>
+      useLockSuggestion({ now: () => 1_700_000_000_000 }),
+    );
+    expect(result.current.suggestion).toBeNull();
+    expect(result.current.decidedAt).toBeNull();
+    expect(result.current.sourceReceivedAt).toBeNull();
+  });
+
+  it('첫 tick에서 valid suggestion read → state 갱신', async () => {
+    readSpy.mockResolvedValue(ENTRY);
+    const { result } = renderHook(() =>
+      useLockSuggestion({ now: () => 1_700_000_000_000 }),
+    );
+    await act(async () => {
+      jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    });
+    await waitFor(() => {
+      expect(result.current.suggestion).toEqual(SUGGESTION);
+    });
+    expect(result.current.decidedAt).toBe(SUGGESTION.decidedAt);
+    expect(result.current.sourceReceivedAt).toBe(ENTRY.receivedAt);
+  });
+
+  it('mirror 부재 → null state 유지', async () => {
+    readSpy.mockResolvedValue(null);
+    const { result } = renderHook(() =>
+      useLockSuggestion({ now: () => 1_700_000_000_000 }),
+    );
+    await act(async () => {
+      jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    });
+    await waitFor(() => {
+      expect(result.current.suggestion).toBeNull();
+    });
+    expect(result.current.decidedAt).toBeNull();
+    expect(result.current.sourceReceivedAt).toBeNull();
+  });
+
+  it('mirror 있지만 lockSuggestion 없음 → null state', async () => {
+    readSpy.mockResolvedValue({ ...ENTRY, lockSuggestion: undefined });
+    const { result } = renderHook(() =>
+      useLockSuggestion({ now: () => 1_700_000_000_000 }),
+    );
+    await act(async () => {
+      jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    });
+    await waitFor(() => {
+      expect(result.current.suggestion).toBeNull();
+    });
+  });
+
+  it('LOCK_SUGGESTION_MAX_AGE_MS 초과 stale → null (mirror leak 차단)', async () => {
+    readSpy.mockResolvedValue(ENTRY);
+    const { result } = renderHook(() =>
+      useLockSuggestion({
+        now: () => ENTRY.receivedAt + LOCK_SUGGESTION_MAX_AGE_MS + 1,
+      }),
+    );
+    await act(async () => {
+      jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    });
+    await waitFor(() => {
+      expect(result.current.suggestion).toBeNull();
+    });
+  });
+
+  it('LOCK_SUGGESTION_MAX_AGE_MS 정확히 도달 → 통과 (boundary)', async () => {
+    readSpy.mockResolvedValue(ENTRY);
+    const { result } = renderHook(() =>
+      useLockSuggestion({
+        now: () => ENTRY.receivedAt + LOCK_SUGGESTION_MAX_AGE_MS,
+      }),
+    );
+    await act(async () => {
+      jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    });
+    await waitFor(() => {
+      expect(result.current.suggestion).toEqual(SUGGESTION);
+    });
+  });
+
+  it('동일 entry 재read → setState skip (re-render 폭주 차단)', async () => {
+    readSpy.mockResolvedValue(ENTRY);
+    const renders: number[] = [];
+    const { result } = renderHook(() => {
+      const state = useLockSuggestion({ now: () => 1_700_000_000_000 });
+      renders.push(renders.length);
+      return state;
+    });
+    // 3 tick — 동일 entry라 setState는 1회만 발생해야 한다.
+    await act(async () => {
+      jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    });
+    await waitFor(() => {
+      expect(result.current.suggestion).toEqual(SUGGESTION);
+    });
+    // 초기 mount 1회 + 첫 tick state 갱신 1회 = 2회 (정확한 횟수는 React 내부, 적어도 폭주 X)
+    expect(renders.length).toBeLessThan(6);
+  });
+
+  it('lockSuggestion이 다른 trainCode로 변경 → state 갱신', async () => {
+    readSpy.mockResolvedValueOnce(ENTRY);
+    const { result, rerender } = renderHook(() =>
+      useLockSuggestion({ now: () => 1_700_000_000_000 }),
+    );
+    await act(async () => {
+      jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    });
+    await waitFor(() => {
+      expect(result.current.suggestion?.trainCode).toBe('7246');
+    });
+    const newSuggestion: LockSuggestionMirror = {
+      ...SUGGESTION,
+      trainCode: '9999',
+      decidedAt: ENTRY.receivedAt + 1_000,
+    };
+    readSpy.mockResolvedValue({
+      ...ENTRY,
+      receivedAt: ENTRY.receivedAt + 1_000,
+      lockSuggestion: newSuggestion,
+    });
+    rerender({ now: () => 1_700_000_000_000 });
+    await act(async () => {
+      jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    });
+    await waitFor(() => {
+      expect(result.current.suggestion?.trainCode).toBe('9999');
+    });
+  });
+
+  it('null → entry 전이 시 state 갱신', async () => {
+    readSpy.mockResolvedValueOnce(null);
+    const { result } = renderHook(() =>
+      useLockSuggestion({ now: () => 1_700_000_000_000 }),
+    );
+    await act(async () => {
+      jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    });
+    await waitFor(() => {
+      expect(result.current.suggestion).toBeNull();
+    });
+    readSpy.mockResolvedValue(ENTRY);
+    await act(async () => {
+      jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    });
+    await waitFor(() => {
+      expect(result.current.suggestion).toEqual(SUGGESTION);
+    });
+  });
+
+  it('entry → null 전이 시 state reset', async () => {
+    readSpy.mockResolvedValueOnce(ENTRY);
+    const { result } = renderHook(() =>
+      useLockSuggestion({ now: () => 1_700_000_000_000 }),
+    );
+    await act(async () => {
+      jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    });
+    await waitFor(() => {
+      expect(result.current.suggestion).toEqual(SUGGESTION);
+    });
+    readSpy.mockResolvedValue(null);
+    await act(async () => {
+      jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    });
+    await waitFor(() => {
+      expect(result.current.suggestion).toBeNull();
+    });
+  });
+
+  it('unmount 시 interval cleanup (cancelled guard)', async () => {
+    readSpy.mockResolvedValue(ENTRY);
+    const { unmount } = renderHook(() =>
+      useLockSuggestion({ now: () => 1_700_000_000_000 }),
+    );
+    unmount();
+    // unmount 후 추가 tick은 setState 호출 X (cancelled가 true)
+    await act(async () => {
+      jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS * 3);
+    });
+    // 정확한 호출 횟수보다는 throw 없이 종료되는지 확인
+  });
+
+  it('tick 발사 후 unmount 시점에 promise 해소 → cancelled 가드로 setState skip (line 89)', async () => {
+    // Promise를 외부 resolve 함수로 만들어 unmount 후 해결되도록 정확하게 race 시뮬레이션.
+    let resolveRead!: (entry: BackendSsotMirrorEntry | null) => void;
+    readSpy.mockImplementation(
+      () =>
+        new Promise<BackendSsotMirrorEntry | null>((resolve) => {
+          resolveRead = resolve;
+        }),
+    );
+    const { unmount, result } = renderHook(() =>
+      useLockSuggestion({ now: () => 1_700_000_000_000 }),
+    );
+    // tick 발사 (Promise pending 상태)
+    jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    // unmount → cancelled=true
+    unmount();
+    // 이제 해소 — cancelled 가드가 setState를 차단해야 한다
+    await act(async () => {
+      resolveRead(ENTRY);
+      // microtask flush
+      await Promise.resolve();
+    });
+    // state 갱신 안 됨 (unmount 후라 React에서 read하지 못해도 throw 없으면 통과)
+    expect(result.current.suggestion).toBeNull();
+  });
+
+  it('valid suggestion 채택 후 stale 전이 → setState로 null로 전환 (line 107)', async () => {
+    // 첫 tick: 신선한 entry
+    const receivedAt = 1_700_000_000_000;
+    readSpy.mockResolvedValue({ ...ENTRY, receivedAt });
+    let currentNow = receivedAt;
+    const { result } = renderHook(() =>
+      useLockSuggestion({ now: () => currentNow }),
+    );
+    await act(async () => {
+      jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    });
+    await waitFor(() => {
+      expect(result.current.suggestion).toEqual(SUGGESTION);
+    });
+    // now를 stale window 너머로 이동 — 다음 tick에서 stale 분기 진입
+    currentNow = receivedAt + LOCK_SUGGESTION_MAX_AGE_MS + 1;
+    await act(async () => {
+      jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    });
+    await waitFor(() => {
+      expect(result.current.suggestion).toBeNull();
+    });
+    expect(result.current.decidedAt).toBeNull();
+    expect(result.current.sourceReceivedAt).toBeNull();
+  });
+
+  it('options 미전달 → now=Date.now 기본 (회귀 없음)', async () => {
+    const realNow = Date.now();
+    readSpy.mockResolvedValue({ ...ENTRY, receivedAt: realNow });
+    const { result } = renderHook(() => useLockSuggestion());
+    await act(async () => {
+      jest.advanceTimersByTime(LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    });
+    await waitFor(() => {
+      expect(result.current.suggestion).toEqual(SUGGESTION);
+    });
+  });
+
+  it('LOCK_SUGGESTION_POLL_INTERVAL_MS === 5000 (정책 박제)', () => {
+    expect(LOCK_SUGGESTION_POLL_INTERVAL_MS).toBe(5_000);
+  });
+
+  it('LOCK_SUGGESTION_MAX_AGE_MS === 300000 (5분 박제)', () => {
+    expect(LOCK_SUGGESTION_MAX_AGE_MS).toBe(5 * 60_000);
+  });
+});

--- a/src/features/alarm/api/useLockSuggestion.ts
+++ b/src/features/alarm/api/useLockSuggestion.ts
@@ -27,6 +27,7 @@
 import { useEffect, useState } from 'react';
 import {
   readBackendSsotMirror,
+  type BackendSsotMirrorEntry,
   type LockSuggestionMirror,
 } from '../utils/backendSsotMirror';
 
@@ -84,53 +85,13 @@ export function useLockSuggestion(options?: {
 
   useEffect(() => {
     let cancelled = false;
+    const handleEntry = (entry: BackendSsotMirrorEntry | null): void => {
+      if (cancelled) return;
+      const next = computeNextState(entry, now());
+      setState((prev) => mergeSuggestionState(prev, next));
+    };
     const tick = (): void => {
-      void readBackendSsotMirror().then((entry) => {
-        if (cancelled) return;
-        if (entry === null || !entry.lockSuggestion) {
-          // 무의미한 state update 차단 — null→null transitions에서 setState skip.
-          setState((prev) =>
-            prev.suggestion === null &&
-            prev.decidedAt === null &&
-            prev.sourceReceivedAt === null
-              ? prev
-              : { suggestion: null, decidedAt: null, sourceReceivedAt: null },
-          );
-          return;
-        }
-        const suggestion = entry.lockSuggestion;
-        const ageMs = now() - entry.receivedAt;
-        if (ageMs > LOCK_SUGGESTION_MAX_AGE_MS) {
-          // stale — 채택 차단 (caller 9-AND fallback). receivedAt 노출은 보류
-          // (decidedAt도 함께 null로 두어 caller가 채택 가능성 자체를 0로 본다).
-          setState((prev) =>
-            prev.suggestion === null &&
-            prev.decidedAt === null &&
-            prev.sourceReceivedAt === null
-              ? prev
-              : { suggestion: null, decidedAt: null, sourceReceivedAt: null },
-          );
-          return;
-        }
-        setState((prev) => {
-          if (
-            prev.suggestion !== null &&
-            prev.suggestion.stationId === suggestion.stationId &&
-            prev.suggestion.trainCode === suggestion.trainCode &&
-            prev.suggestion.lineId === suggestion.lineId &&
-            prev.suggestion.confidence === suggestion.confidence &&
-            prev.decidedAt === suggestion.decidedAt &&
-            prev.sourceReceivedAt === entry.receivedAt
-          ) {
-            return prev;
-          }
-          return {
-            suggestion,
-            decidedAt: suggestion.decidedAt,
-            sourceReceivedAt: entry.receivedAt,
-          };
-        });
-      });
+      void readBackendSsotMirror().then(handleEntry);
     };
     // 첫 read는 폴링 첫 tick에 맡긴다 — useFusedNearestStation BACKEND_SSOT_MIRROR_KEY 폴링과
     // 동일 패턴. 마운트 직후 동기 read의 microtask resolve가 첫 render commit phase와 겹쳐
@@ -143,4 +104,53 @@ export function useLockSuggestion(options?: {
   }, [now]);
 
   return state;
+}
+
+const NULL_STATE: LockSuggestionResult = {
+  suggestion: null,
+  decidedAt: null,
+  sourceReceivedAt: null,
+};
+
+/**
+ * 폴링 entry를 LockSuggestionResult로 변환. 부재 / stale entry는 null state, valid 정상은 매칭
+ * suggestion entry를 반환. 본 함수는 순수 — `useEffect` 안 nested function 깊이를 4 미만으로 유지.
+ */
+function computeNextState(
+  entry: BackendSsotMirrorEntry | null,
+  nowMs: number,
+): LockSuggestionResult {
+  if (!entry?.lockSuggestion) return NULL_STATE;
+  const ageMs = nowMs - entry.receivedAt;
+  if (ageMs > LOCK_SUGGESTION_MAX_AGE_MS) return NULL_STATE;
+  return {
+    suggestion: entry.lockSuggestion,
+    decidedAt: entry.lockSuggestion.decidedAt,
+    sourceReceivedAt: entry.receivedAt,
+  };
+}
+
+/**
+ * setState reducer — 동일 state 비교로 무용한 update 차단 (re-render 폭주 방지).
+ */
+function mergeSuggestionState(
+  prev: LockSuggestionResult,
+  next: LockSuggestionResult,
+): LockSuggestionResult {
+  if (next.suggestion === null) {
+    if (prev.suggestion === null) return prev;
+    return NULL_STATE;
+  }
+  if (
+    prev.suggestion !== null &&
+    prev.suggestion.stationId === next.suggestion.stationId &&
+    prev.suggestion.trainCode === next.suggestion.trainCode &&
+    prev.suggestion.lineId === next.suggestion.lineId &&
+    prev.suggestion.confidence === next.suggestion.confidence &&
+    prev.decidedAt === next.decidedAt &&
+    prev.sourceReceivedAt === next.sourceReceivedAt
+  ) {
+    return prev;
+  }
+  return next;
 }

--- a/src/features/alarm/api/useLockSuggestion.ts
+++ b/src/features/alarm/api/useLockSuggestion.ts
@@ -1,0 +1,146 @@
+/**
+ * #1534 (S1, T9b, ADR-016) — backend가 추론한 lock 제안 reader hook.
+ *
+ * 배경: lockless trip 등록 직후 backend가 GPS + arvlcd + trainCode 종합으로 origin/train을
+ * 추론한 결과(`TripPositionSSoT.lockSuggestion`)를 silent push payload + POST /position
+ * response 양쪽이 BACKEND_SSOT_MIRROR_KEY에 영속화한다. 본 hook은 그 mirror에서
+ * lockSuggestion을 reader-only로 노출한다.
+ *
+ * 단일 책임:
+ *   - AsyncStorage 폴링(5s 간격) — silent push handler / position upload response가 mirror를
+ *     write하면 다음 tick에서 read.
+ *   - LockSuggestion 형식 검증은 backendSsotMirror.parseLockSuggestion이 책임.
+ *   - 채택 정책(1순위 lockSuggestion / 2순위 9-AND gate fallback)은 consumer
+ *     (`useBoardingLockController`)가 책임 — 본 hook은 raw state만 노출.
+ *
+ * Wire-completion (5단):
+ *   1. Orphan 없음: caller = useBoardingLockController.
+ *   2. V/X dashboard: DebugModal "Backend SSoT mirror" 섹션이 BACKEND_SSOT_MIRROR_KEY 전체를
+ *      이미 노출 (lockSuggestion 필드 포함, 추가 wiring 불필요).
+ *   3. 의존 PR: backend lockSuggestion write site (본 PR 같은 atomic 변경).
+ *   4. 측정 plan: production lockSuggestion 채택율 — alarmLog forward(P0-3)의 ssotMirror
+ *      snapshot에서 1주 측정. V2(lockless 첫 station miss ≤2) 직접 검증.
+ *   5. Device verify: 실기기 trip(currentStation=null start) → lockSuggestion 채택 →
+ *      BoardingLockHopCard 활성화 시나리오.
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  readBackendSsotMirror,
+  type LockSuggestionMirror,
+} from '../utils/backendSsotMirror';
+
+/**
+ * BACKEND_SSOT_MIRROR_KEY 폴링 간격 (ms). useFusedNearestStation의 5s tick과 정합.
+ * backend silent push가 cycle(~30s)마다 발사되므로 5s는 충분히 빈번.
+ */
+export const LOCK_SUGGESTION_POLL_INTERVAL_MS = 5_000;
+
+/**
+ * lockSuggestion이 set된 후 device가 staleness로 판단하기 시작하는 임계 (ms).
+ *
+ * 5분(300s) — backend가 직전 cycle에 set한 lockSuggestion이 그 후 cycle에서 갱신 없이 유지되는
+ * 정상 case (트레인이 멈춰있는 동안 등)를 포용한다. 5분 초과 시 device는 stale로 보고 채택
+ * 차단 — 사용자가 다른 trip으로 전환했는데 mirror가 stale인 회귀(Mirror leak #3)를 방어.
+ *
+ * 본 임계는 cascade picker(BACKEND_SSOT_MIRROR_MAX_AGE_MS=180s)와 별개 — lockSuggestion 채택
+ * 결정은 보수적으로 더 짧은 1차 윈도우를 두지 않는다 (사용자 의향 trip 영구 보호 vs false
+ * positive 차단의 trade-off는 receivedAt drift로 자연 해소).
+ */
+export const LOCK_SUGGESTION_MAX_AGE_MS = 5 * 60_000;
+
+/**
+ * `useLockSuggestion` hook 결과.
+ *
+ * 채택 정책(1순위 / fallback)은 caller가 결정. 본 hook은:
+ *   - suggestion: backend lockSuggestion 또는 null (미존재 / stale / 형식 오류 시 null)
+ *   - decidedAt: backend가 결정한 epoch ms (caller의 UI/디버그 노출용)
+ *   - sourceReceivedAt: device가 mirror를 수신한 epoch ms (staleness 검증 별도 활용 가능)
+ */
+export interface LockSuggestionResult {
+  suggestion: LockSuggestionMirror | null;
+  decidedAt: number | null;
+  sourceReceivedAt: number | null;
+}
+
+/**
+ * BACKEND_SSOT_MIRROR_KEY를 폴링해 lockSuggestion을 노출하는 reader-only hook.
+ *
+ * 빈 상태(null) → backend가 아직 lockSuggestion을 set하지 않은 trip 또는 mirror staleness.
+ * caller는 null일 때 기존 9-AND gate fallback으로 동작해야 한다.
+ *
+ * `now`는 jest 테스트가 `jest.useFakeTimers()` + `Date.now` mock 없이 staleness를 결정적으로
+ * 제어할 수 있게 옵션 주입. production은 `Date.now`가 기본값.
+ */
+export function useLockSuggestion(options?: {
+  now?: () => number;
+}): LockSuggestionResult {
+  const now = options?.now ?? Date.now;
+  const [state, setState] = useState<LockSuggestionResult>({
+    suggestion: null,
+    decidedAt: null,
+    sourceReceivedAt: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = (): void => {
+      void readBackendSsotMirror().then((entry) => {
+        if (cancelled) return;
+        if (entry === null || !entry.lockSuggestion) {
+          // 무의미한 state update 차단 — null→null transitions에서 setState skip.
+          setState((prev) =>
+            prev.suggestion === null &&
+            prev.decidedAt === null &&
+            prev.sourceReceivedAt === null
+              ? prev
+              : { suggestion: null, decidedAt: null, sourceReceivedAt: null },
+          );
+          return;
+        }
+        const suggestion = entry.lockSuggestion;
+        const ageMs = now() - entry.receivedAt;
+        if (ageMs > LOCK_SUGGESTION_MAX_AGE_MS) {
+          // stale — 채택 차단 (caller 9-AND fallback). receivedAt 노출은 보류
+          // (decidedAt도 함께 null로 두어 caller가 채택 가능성 자체를 0로 본다).
+          setState((prev) =>
+            prev.suggestion === null &&
+            prev.decidedAt === null &&
+            prev.sourceReceivedAt === null
+              ? prev
+              : { suggestion: null, decidedAt: null, sourceReceivedAt: null },
+          );
+          return;
+        }
+        setState((prev) => {
+          if (
+            prev.suggestion !== null &&
+            prev.suggestion.stationId === suggestion.stationId &&
+            prev.suggestion.trainCode === suggestion.trainCode &&
+            prev.suggestion.lineId === suggestion.lineId &&
+            prev.suggestion.confidence === suggestion.confidence &&
+            prev.decidedAt === suggestion.decidedAt &&
+            prev.sourceReceivedAt === entry.receivedAt
+          ) {
+            return prev;
+          }
+          return {
+            suggestion,
+            decidedAt: suggestion.decidedAt,
+            sourceReceivedAt: entry.receivedAt,
+          };
+        });
+      });
+    };
+    // 첫 read는 폴링 첫 tick에 맡긴다 — useFusedNearestStation BACKEND_SSOT_MIRROR_KEY 폴링과
+    // 동일 패턴. 마운트 직후 동기 read의 microtask resolve가 첫 render commit phase와 겹쳐
+    // act() warning을 발생시키는 회귀 차단(jest-expo setup).
+    const id = setInterval(tick, LOCK_SUGGESTION_POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [now]);
+
+  return state;
+}

--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -962,4 +962,229 @@ describe('useBoardingLockController', () => {
       expect(remove).toHaveBeenCalled();
     });
   });
+
+  describe('lockSuggestion 1순위 채택 (#1534 S1 T9b, ADR-016)', () => {
+    let readSpy: jest.SpyInstance;
+
+    const SUGGESTION = {
+      stationId: '강남',
+      trainCode: 'AUTO-1',
+      lineId: '2',
+      confidence: 'high' as const,
+      decidedAt: 1_700_000_000_000,
+    };
+
+    const MIRROR = {
+      currentStationId: '강남',
+      motionState: 'moving' as const,
+      lastAdvanceEvidence: 'arvlcd-confirmed-train',
+      lastAdvanceAt: 1_700_000_000_000,
+      passedStations: [],
+      receivedAt: Date.now(),
+      lockSuggestion: SUGGESTION,
+    };
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      // jest.requireActual로 module을 가져오고 readBackendSsotMirror만 spy.
+      const mirror = jest.requireActual('../../utils/backendSsotMirror');
+      readSpy = jest.spyOn(mirror, 'readBackendSsotMirror');
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+      readSpy.mockRestore();
+    });
+
+    it('lockSuggestion → createLock 호출 (1순위 채택, 9-AND gate 우회)', async () => {
+      readSpy.mockResolvedValue(MIRROR);
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({
+        lock: null,
+        createLock: createLockMock,
+      });
+      renderHook(() => useBoardingLockController(defaultInputs));
+      // 첫 polling tick (5s) 후 readBackendSsotMirror → setState → createLock effect 발사
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+      });
+      await waitFor(() => {
+        expect(createLockMock).toHaveBeenCalled();
+      });
+      const arg = createLockMock.mock.calls[0][0];
+      expect(arg.trainCode).toBe('AUTO-1');
+      expect(arg.boardingLine).toBe('2');
+      // motion gate / directionalArrivals 검증 X (suggestion 채택은 우회)
+    });
+
+    it('이미 lock 존재 → suggestion 채택 skip (idempotent)', async () => {
+      readSpy.mockResolvedValue(MIRROR);
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      const existing: BoardingLock = {
+        destinationId: 'dest-1',
+        trainCode: 'USER-TAP',
+        boardingStationId: 'stn-A',
+        boardingLine: '2',
+        boardedAt: Date.now(),
+        expectedDurationMs: 30 * 60_000,
+      };
+      // loadLock effect도 같은 lock을 반환하도록 모킹 — selector가 hydrate한 후에도 lock 유지.
+      mockGetBoardingLock.mockResolvedValue(existing);
+      useBoardingLockStore.setState({ lock: existing, createLock: createLockMock });
+      renderHook(() => useBoardingLockController(defaultInputs));
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+      });
+      // wait briefly — createLock 미호출 확인
+      await act(async () => {
+        jest.advanceTimersByTime(0);
+      });
+      expect(createLockMock).not.toHaveBeenCalled();
+    });
+
+    it('lockSuggestion lineId가 trip route 허용 line이 아니면 reject', async () => {
+      readSpy.mockResolvedValue({
+        ...MIRROR,
+        lockSuggestion: { ...SUGGESTION, lineId: '7' }, // route는 line 2
+      });
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      renderHook(() => useBoardingLockController(defaultInputs));
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+      });
+      await act(async () => {
+        jest.advanceTimersByTime(0);
+      });
+      expect(createLockMock).not.toHaveBeenCalled();
+    });
+
+    it('lockSuggestion lineId가 invalid line code (모르는 노선) → reject', async () => {
+      readSpy.mockResolvedValue({
+        ...MIRROR,
+        lockSuggestion: { ...SUGGESTION, lineId: 'mars' },
+      });
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      renderHook(() => useBoardingLockController(defaultInputs));
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+      });
+      await act(async () => {
+        jest.advanceTimersByTime(0);
+      });
+      expect(createLockMock).not.toHaveBeenCalled();
+    });
+
+    it('createLock 실패는 graceful — throw 안 함 (다음 cycle 재시도)', async () => {
+      readSpy.mockResolvedValue(MIRROR);
+      const createLockMock = jest.fn().mockRejectedValue(new Error('storage'));
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      renderHook(() => useBoardingLockController(defaultInputs));
+      await expect(
+        act(async () => {
+          jest.advanceTimersByTime(5_000);
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('destinationId null → free-trip sentinel으로 createLock', async () => {
+      readSpy.mockResolvedValue(MIRROR);
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, destinationId: null }),
+      );
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+      });
+      await waitFor(() => {
+        expect(createLockMock).toHaveBeenCalled();
+      });
+      const arg = createLockMock.mock.calls[0][0];
+      expect(arg.hydratedFromSentinel).toBeDefined();
+    });
+
+    it('lockSuggestion 부재 → createLock 미호출 (caller 9-AND fallback)', async () => {
+      readSpy.mockResolvedValue(null);
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      renderHook(() => useBoardingLockController(defaultInputs));
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+      });
+      await act(async () => {
+        jest.advanceTimersByTime(0);
+      });
+      expect(createLockMock).not.toHaveBeenCalled();
+    });
+
+    it('result.lockSuggestion 노출 (UI consumer 진입점)', async () => {
+      readSpy.mockResolvedValue(MIRROR);
+      useBoardingLockStore.setState({ lock: null });
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+      });
+      await waitFor(() => {
+        expect(result.current.lockSuggestion).toEqual(SUGGESTION);
+      });
+    });
+
+    it('stationByName lookup 실패 + currentStation null → lockSuggestion.stationId fallback (line 194)', async () => {
+      readSpy.mockResolvedValue(MIRROR);
+      mockFindStationByNameAndLine.mockReturnValue(null);
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, currentStation: null }),
+      );
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+      });
+      await waitFor(() => {
+        expect(createLockMock).toHaveBeenCalled();
+      });
+      expect(createLockMock.mock.calls[0][0].boardingStationId).toBe('강남');
+    });
+
+    it('expectedDurationMinutes null → FALLBACK_BOARDING_DURATION_MINUTES (line 198)', async () => {
+      readSpy.mockResolvedValue(MIRROR);
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, expectedDurationMinutes: null }),
+      );
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+      });
+      await waitFor(() => {
+        expect(createLockMock).toHaveBeenCalled();
+      });
+      // FALLBACK = 30분 (constants/boardingLock.ts) → 30 * 60_000 ms
+      expect(createLockMock.mock.calls[0][0].expectedDurationMs).toBe(30 * 60_000);
+    });
+
+    it('lockSuggestion.stationId가 빈 문자열 + currentStation null → boardingStationId=빈 → guard return (line 195)', async () => {
+      readSpy.mockResolvedValue({
+        ...MIRROR,
+        // 형식 검증을 우회하기 위해 직접 entry override — 실제 readBackendSsotMirror는 빈 stationId reject지만
+        // 미래 schema migration / 손상 KV 에 대비한 guard 분기 cover.
+        lockSuggestion: { ...SUGGESTION, stationId: '' },
+      });
+      mockFindStationByNameAndLine.mockReturnValue(null);
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, currentStation: null }),
+      );
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+      });
+      await act(async () => {
+        jest.advanceTimersByTime(0);
+      });
+      expect(createLockMock).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -984,6 +984,25 @@ describe('useBoardingLockController', () => {
       lockSuggestion: SUGGESTION,
     };
 
+    // 폴링 1 cycle (5s tick) → effect flush (0s tick) — suggestion 채택 흐름 settle 헬퍼.
+    async function tickAndSettleCycle() {
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+      });
+      await act(async () => {
+        jest.advanceTimersByTime(0);
+      });
+    }
+
+    // suggestion reject 시나리오 공용 setup — lock=null + createLock mock + renderHook 후 settle 까지.
+    // assertion(`expect(createLockMock).not.toHaveBeenCalled()`)는 caller가 검증.
+    function setupRejectScenario(inputs: UseBoardingLockControllerInputs = defaultInputs) {
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      renderHook(() => useBoardingLockController(inputs));
+      return createLockMock;
+    }
+
     beforeEach(() => {
       jest.useFakeTimers();
       // jest.requireActual로 module을 가져오고 readBackendSsotMirror만 spy.
@@ -1032,13 +1051,7 @@ describe('useBoardingLockController', () => {
       mockGetBoardingLock.mockResolvedValue(existing);
       useBoardingLockStore.setState({ lock: existing, createLock: createLockMock });
       renderHook(() => useBoardingLockController(defaultInputs));
-      await act(async () => {
-        jest.advanceTimersByTime(5_000);
-      });
-      // wait briefly — createLock 미호출 확인
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
+      await tickAndSettleCycle();
       expect(createLockMock).not.toHaveBeenCalled();
     });
 
@@ -1047,15 +1060,8 @@ describe('useBoardingLockController', () => {
         ...MIRROR,
         lockSuggestion: { ...SUGGESTION, lineId: '7' }, // route는 line 2
       });
-      const createLockMock = jest.fn().mockResolvedValue(undefined);
-      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
-      renderHook(() => useBoardingLockController(defaultInputs));
-      await act(async () => {
-        jest.advanceTimersByTime(5_000);
-      });
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
+      const createLockMock = setupRejectScenario();
+      await tickAndSettleCycle();
       expect(createLockMock).not.toHaveBeenCalled();
     });
 
@@ -1064,15 +1070,8 @@ describe('useBoardingLockController', () => {
         ...MIRROR,
         lockSuggestion: { ...SUGGESTION, lineId: 'mars' },
       });
-      const createLockMock = jest.fn().mockResolvedValue(undefined);
-      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
-      renderHook(() => useBoardingLockController(defaultInputs));
-      await act(async () => {
-        jest.advanceTimersByTime(5_000);
-      });
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
+      const createLockMock = setupRejectScenario();
+      await tickAndSettleCycle();
       expect(createLockMock).not.toHaveBeenCalled();
     });
 
@@ -1107,15 +1106,8 @@ describe('useBoardingLockController', () => {
 
     it('lockSuggestion 부재 → createLock 미호출 (caller 9-AND fallback)', async () => {
       readSpy.mockResolvedValue(null);
-      const createLockMock = jest.fn().mockResolvedValue(undefined);
-      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
-      renderHook(() => useBoardingLockController(defaultInputs));
-      await act(async () => {
-        jest.advanceTimersByTime(5_000);
-      });
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
+      const createLockMock = setupRejectScenario();
+      await tickAndSettleCycle();
       expect(createLockMock).not.toHaveBeenCalled();
     });
 
@@ -1173,17 +1165,11 @@ describe('useBoardingLockController', () => {
         lockSuggestion: { ...SUGGESTION, stationId: '' },
       });
       mockFindStationByNameAndLine.mockReturnValue(null);
-      const createLockMock = jest.fn().mockResolvedValue(undefined);
-      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
-      renderHook(() =>
-        useBoardingLockController({ ...defaultInputs, currentStation: null }),
-      );
-      await act(async () => {
-        jest.advanceTimersByTime(5_000);
+      const createLockMock = setupRejectScenario({
+        ...defaultInputs,
+        currentStation: null,
       });
-      await act(async () => {
-        jest.advanceTimersByTime(0);
-      });
+      await tickAndSettleCycle();
       expect(createLockMock).not.toHaveBeenCalled();
     });
   });

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -197,7 +197,7 @@ export function useBoardingLockController({
     const effectiveDestinationId = destinationId ?? FREE_TRIP_DESTINATION_SENTINEL;
     const durationMin = expectedDurationMinutes ?? FALLBACK_BOARDING_DURATION_MINUTES;
     const now = Date.now();
-    void createLock({
+    createLock({
       destinationId: effectiveDestinationId,
       trainCode: lockSuggestion.trainCode,
       boardingStationId,

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -22,6 +22,8 @@ import {
   FREE_TRIP_DESTINATION_SENTINEL,
 } from '../../../shared/constants/boardingLock';
 import type { AutoLockCandidate } from '../../nearest-station/api/boardingLockSync';
+import { useLockSuggestion } from '../api/useLockSuggestion';
+import type { LockSuggestionMirror } from '../utils/backendSsotMirror';
 
 export interface UseBoardingLockControllerInputs {
   destinationId: string | null;
@@ -50,6 +52,12 @@ export interface UseBoardingLockControllerInputs {
 
 export interface UseBoardingLockControllerResult {
   lock: BoardingLock | null;
+  /**
+   * #1534 (S1, T9b, ADR-016) — backend가 추론한 lock 제안 (read-only). UI는 본 값으로
+   * "출발역 확인 중..." indicator를 trip 활성 직후 5~30s 동안 노출하거나, 추론 완료 시 lock
+   * badge + station name 노출 분기에 사용. null이면 추론 미정착(또는 9-AND gate fallback 중).
+   */
+  lockSuggestion: LockSuggestionMirror | null;
   /**
    * route 진행 방향으로 필터된 도착 list. 방향 미상이면 up+down 합집합.
    * hydrateLockFromCandidate Gate 1(#1014)의 방향 일치 검증에 쓰이므로 방향 엄격성을 유지한다.
@@ -123,6 +131,10 @@ export function useBoardingLockController({
   const releaseLock = useBoardingLockStore((s) => s.releaseLock);
   const checkExpiry = useBoardingLockStore((s) => s.checkExpiry);
 
+  // #1534 (S1, T9b, ADR-016) — backend lockSuggestion 1순위 reader.
+  // null이면 기존 9-AND gate fallback (`hydrateLockFromCandidate`)이 그대로 동작.
+  const { suggestion: lockSuggestion } = useLockSuggestion();
+
   // 마운트 시 storage hydrate.
   useEffect(() => {
     void loadLock();
@@ -148,6 +160,72 @@ export function useBoardingLockController({
     const sub = AppState.addEventListener('change', handler);
     return () => sub.remove();
   }, [checkExpiry]);
+
+  // #1534 (S1, T9b, ADR-016) — backend lockSuggestion 1순위 채택.
+  //
+  // lock이 이미 존재하면 no-op (`hydrateLockFromCandidate`와 동일 idempotent 정책 — 사용자 명시
+  // 탭 lock 보호 + auto-lock도 한 번 잡히면 변경 X). lockSuggestion이 null이면 9-AND gate
+  // fallback이 `hydrateLockFromCandidate`로 동작 (consumer onAutoLockCandidate 경로).
+  //
+  // 9-AND gate 우회 정책:
+  //   - directionalArrivals 매칭 필수 X — backend가 이미 arvlcd-confirmed-train evidence로 합의
+  //     했으므로 device-side arrival list cross-check를 한 번 더 강제할 필요 없음.
+  //   - motion gate(stationary/speedMps) 우회 — backend가 SSOT 권위 결정. device GPS race로
+  //     일시 이동/정지 신호가 잘못 잡혀도 backend가 evidence 합의로 발사한 suggestion을 신뢰.
+  //
+  // 안전 가드:
+  //   - allowedLines 검증 유지 (trip route 외 line trainCode reject — 환승역 fusion 오류 보호).
+  //   - currentStation 부재 시 boardingStationId fallback이 불가하므로 stationId가 stations.json과
+  //     매칭되지 않으면 graceful skip (다음 cycle 재시도). lockSuggestion.stationId는 backend가
+  //     waypoint 기반으로 산출했으므로 정상 케이스 대부분 매칭.
+  //   - destinationId 없으면 free-trip sentinel으로 hydrate.
+  useEffect(() => {
+    if (!lockSuggestion) return;
+    if (lock) return;
+    const boardingLine = asLineNumber(lockSuggestion.lineId);
+    if (!boardingLine) return;
+    const allowed = allowedLinesFromRoute(route);
+    if (allowed && !allowed.has(boardingLine)) return;
+    // boardingStationId 산출: lockSuggestion.stationId가 stations.json id이면 그대로,
+    // station name이면 (lookup, line) 매칭 — 백엔드는 stationName 그대로 forward 케이스가
+    // 많아 양쪽 모두 지원해야 한다.
+    const stationByName = findStationByNameAndLine(lockSuggestion.stationId, boardingLine);
+    const boardingStationId =
+      stationByName?.id ?? currentStation?.id ?? lockSuggestion.stationId;
+    if (!boardingStationId) return;
+    const isSentinel = !destinationId;
+    const effectiveDestinationId = destinationId ?? FREE_TRIP_DESTINATION_SENTINEL;
+    const durationMin = expectedDurationMinutes ?? FALLBACK_BOARDING_DURATION_MINUTES;
+    const now = Date.now();
+    void createLock({
+      destinationId: effectiveDestinationId,
+      trainCode: lockSuggestion.trainCode,
+      boardingStationId,
+      boardingLine,
+      boardedAt: now,
+      expectedDurationMs: durationMin * 60_000,
+      // initialEtaSeconds는 lockSuggestion에 없음 — 자동 lock 지연 칩은 사용자 명시 탭 lock에만
+      // 노출되는 게 의도 (`hydrateLockFromCandidate`와 동일 정책).
+      ...(isSentinel
+        ? {
+            hydratedFromSentinel: {
+              destinationId: FREE_TRIP_DESTINATION_SENTINEL,
+              sentinelAt: now,
+            },
+          }
+        : {}),
+    }).catch(() => {
+      // store action rejection은 graceful — 다음 polling cycle에서 자연 재시도.
+    });
+  }, [
+    lockSuggestion,
+    lock,
+    route,
+    currentStation,
+    destinationId,
+    expectedDurationMinutes,
+    createLock,
+  ]);
 
   const direction = useMemo(() => {
     if (!route || !destinationName || !currentStation) return null;
@@ -310,6 +388,7 @@ export function useBoardingLockController({
 
   return {
     lock,
+    lockSuggestion,
     directionalArrivals,
     boardingListArrivals,
     createLockFromTrain,

--- a/src/features/alarm/utils/__tests__/backendSsotMirror.test.ts
+++ b/src/features/alarm/utils/__tests__/backendSsotMirror.test.ts
@@ -1,21 +1,24 @@
 /**
  * #1573 (T10) — clearBackendSsotMirror unit test.
+ * #1534 (S1, T9b) — lockSuggestion parse 검증 추가.
  *
- * persist/read는 silentPushTask.test.ts에서 검증. 본 파일은 T10 신규 helper인
- * clearBackendSsotMirror만 다루어 회귀 좌표를 좁힌다.
+ * persist는 silentPushTask.test.ts에서 검증. 본 파일은 T10 신규 helper(clearBackendSsotMirror)
+ * + lockSuggestion 형식 검증(readBackendSsotMirror)을 다룬다.
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { clearBackendSsotMirror } from '../backendSsotMirror';
+import { clearBackendSsotMirror, readBackendSsotMirror } from '../backendSsotMirror';
 import { BACKEND_SSOT_MIRROR_KEY } from '../../../../shared/constants/storageKeys';
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   __esModule: true,
   default: {
     removeItem: jest.fn(),
+    getItem: jest.fn(),
   },
 }));
 
 const mockRemoveItem = AsyncStorage.removeItem as jest.Mock;
+const mockGetItem = AsyncStorage.getItem as jest.Mock;
 
 describe('clearBackendSsotMirror (#1573 T10)', () => {
   beforeEach(() => {
@@ -31,5 +34,75 @@ describe('clearBackendSsotMirror (#1573 T10)', () => {
   it('AsyncStorage 실패 시 graceful (throw 안 함)', async () => {
     mockRemoveItem.mockRejectedValue(new Error('io'));
     await expect(clearBackendSsotMirror()).resolves.toBeUndefined();
+  });
+});
+
+describe('readBackendSsotMirror lockSuggestion parse (#1534 S1 T9b)', () => {
+  const baseEntry = {
+    currentStationId: '용마산',
+    motionState: 'moving',
+    lastAdvanceEvidence: 'arvlcd-confirmed-train',
+    lastAdvanceAt: 1_700_000_000_000,
+    passedStations: ['중곡'],
+    receivedAt: 1_700_000_010_000,
+  };
+
+  beforeEach(() => {
+    mockGetItem.mockReset();
+  });
+
+  it('valid lockSuggestion forward 시 결과에 포함', async () => {
+    const lockSuggestion = {
+      stationId: '용마산',
+      trainCode: '7246',
+      lineId: '7',
+      confidence: 'high' as const,
+      decidedAt: 1_700_000_005_000,
+    };
+    mockGetItem.mockResolvedValue(JSON.stringify({ ...baseEntry, lockSuggestion }));
+    const got = await readBackendSsotMirror();
+    expect(got?.lockSuggestion).toEqual(lockSuggestion);
+  });
+
+  it('lockSuggestion 부재 → 결과 lockSuggestion=undefined (legacy/graceful)', async () => {
+    mockGetItem.mockResolvedValue(JSON.stringify(baseEntry));
+    const got = await readBackendSsotMirror();
+    expect(got?.lockSuggestion).toBeUndefined();
+  });
+
+  it.each([
+    ['stationId missing', { trainCode: 'X', lineId: '2', confidence: 'high', decidedAt: 1 }],
+    [
+      'empty stationId',
+      { stationId: '', trainCode: 'X', lineId: '2', confidence: 'high', decidedAt: 1 },
+    ],
+    [
+      'empty trainCode',
+      { stationId: 'S', trainCode: '', lineId: '2', confidence: 'high', decidedAt: 1 },
+    ],
+    [
+      'empty lineId',
+      { stationId: 'S', trainCode: 'X', lineId: '', confidence: 'high', decidedAt: 1 },
+    ],
+    [
+      'invalid confidence',
+      { stationId: 'S', trainCode: 'X', lineId: '2', confidence: 'very-high', decidedAt: 1 },
+    ],
+    [
+      'decidedAt NaN',
+      { stationId: 'S', trainCode: 'X', lineId: '2', confidence: 'low', decidedAt: NaN },
+    ],
+    [
+      'decidedAt string',
+      { stationId: 'S', trainCode: 'X', lineId: '2', confidence: 'low', decidedAt: '1' },
+    ],
+    ['null payload', null],
+    ['scalar payload', 'oops'],
+  ])('형식 mismatch %s → lockSuggestion 누락 (graceful)', async (_label, ls) => {
+    mockGetItem.mockResolvedValue(JSON.stringify({ ...baseEntry, lockSuggestion: ls }));
+    const got = await readBackendSsotMirror();
+    expect(got?.lockSuggestion).toBeUndefined();
+    // 본체 mirror entry는 살아 있음 (lockSuggestion만 graceful drop)
+    expect(got?.currentStationId).toBe('용마산');
   });
 });

--- a/src/features/alarm/utils/__tests__/backendSsotMirror.test.ts
+++ b/src/features/alarm/utils/__tests__/backendSsotMirror.test.ts
@@ -90,7 +90,7 @@ describe('readBackendSsotMirror lockSuggestion parse (#1534 S1 T9b)', () => {
     ],
     [
       'decidedAt NaN',
-      { stationId: 'S', trainCode: 'X', lineId: '2', confidence: 'low', decidedAt: NaN },
+      { stationId: 'S', trainCode: 'X', lineId: '2', confidence: 'low', decidedAt: Number.NaN },
     ],
     [
       'decidedAt string',

--- a/src/features/alarm/utils/backendSsotMirror.ts
+++ b/src/features/alarm/utils/backendSsotMirror.ts
@@ -14,10 +14,29 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { BACKEND_SSOT_MIRROR_KEY } from '../../../shared/constants/storageKeys';
 
 /**
+ * #1534 (S1, T9b, ADR-016) — backend가 추론한 lock 제안 (device 측 mirror schema).
+ *
+ * backend `apns.ts`의 `LockSuggestionPayload`와 1:1. device `useLockSuggestion` reader가
+ * `useBoardingLockController`에 1순위 candidate로 forward해 9-AND gate 우회.
+ *
+ * confidence 'low'는 향후 단일 cellular/accel 채택 slot. 현재는 high/medium만 backend가 set.
+ */
+export interface LockSuggestionMirror {
+  stationId: string;
+  trainCode: string;
+  lineId: string;
+  confidence: 'high' | 'medium' | 'low';
+  decidedAt: number;
+}
+
+/**
  * #1561 (T8) — silent push payload에 실린 SSoT 권위 스냅샷 형태.
  *
  * backend `apns.ts`의 `SilentPushSsotPayload`와 1:1. device는 본 값을 BACKEND_SSOT_MIRROR_KEY에
  * mirror하며 cascade picker가 다음 polling cycle에서 read해 `backend-ssot` tier로 채택.
+ *
+ * #1534 (S1, T9b) — lockSuggestion optional. 부재 시 device `useLockSuggestion` reader는 null
+ * 반환 (graceful, 기존 9-AND gate fallback).
  */
 export interface SilentPushSsotMirror {
   currentStationId: string;
@@ -25,6 +44,7 @@ export interface SilentPushSsotMirror {
   lastAdvanceEvidence: string;
   lastAdvanceAt: number;
   passedStations: readonly string[];
+  lockSuggestion?: LockSuggestionMirror;
 }
 
 /** #1561 (T8) — mirror entry에 receivedAt 추가. cascade picker가 자체 staleness 판정. */
@@ -105,8 +125,36 @@ export async function readBackendSsotMirror(): Promise<BackendSsotMirrorEntry | 
         (p): p is string => typeof p === 'string' && p.length > 0,
       ),
       receivedAt: parsed.receivedAt,
+      // #1534 (S1, T9b) — lockSuggestion parse (optional). 형식 misjudge 시 omit (graceful).
+      ...(parseLockSuggestion(parsed.lockSuggestion) !== null
+        ? { lockSuggestion: parseLockSuggestion(parsed.lockSuggestion) as LockSuggestionMirror }
+        : {}),
     };
   } catch {
     return null;
   }
+}
+
+/**
+ * #1534 (S1, T9b) — JSON에서 LockSuggestionMirror 형식 검증 후 narrow.
+ *
+ * 필드 누락/타입 mismatch 시 null. graceful — device는 9-AND gate fallback. 본 함수가 backend
+ * forward 호환의 단일 진입점이라 backend가 confidence 어휘를 확장(예: 'very-high')해도 device가
+ * graceful drop으로 동작 (필드 자체 무효 시).
+ */
+function parseLockSuggestion(raw: unknown): LockSuggestionMirror | null {
+  if (raw === null || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.stationId !== 'string' || o.stationId.length === 0) return null;
+  if (typeof o.trainCode !== 'string' || o.trainCode.length === 0) return null;
+  if (typeof o.lineId !== 'string' || o.lineId.length === 0) return null;
+  if (o.confidence !== 'high' && o.confidence !== 'medium' && o.confidence !== 'low') return null;
+  if (typeof o.decidedAt !== 'number' || !Number.isFinite(o.decidedAt)) return null;
+  return {
+    stationId: o.stationId,
+    trainCode: o.trainCode,
+    lineId: o.lineId,
+    confidence: o.confidence,
+    decidedAt: o.decidedAt,
+  };
 }

--- a/src/features/alarm/utils/backendSsotMirror.ts
+++ b/src/features/alarm/utils/backendSsotMirror.ts
@@ -116,6 +116,8 @@ export async function readBackendSsotMirror(): Promise<BackendSsotMirrorEntry | 
     ) {
       return null;
     }
+    // #1534 (S1, T9b) — lockSuggestion parse (optional). 형식 misjudge 시 omit (graceful).
+    const lockSuggestion = parseLockSuggestion(parsed.lockSuggestion);
     return {
       currentStationId: parsed.currentStationId,
       motionState: parsed.motionState,
@@ -125,10 +127,7 @@ export async function readBackendSsotMirror(): Promise<BackendSsotMirrorEntry | 
         (p): p is string => typeof p === 'string' && p.length > 0,
       ),
       receivedAt: parsed.receivedAt,
-      // #1534 (S1, T9b) — lockSuggestion parse (optional). 형식 misjudge 시 omit (graceful).
-      ...(parseLockSuggestion(parsed.lockSuggestion) !== null
-        ? { lockSuggestion: parseLockSuggestion(parsed.lockSuggestion) as LockSuggestionMirror }
-        : {}),
+      ...(lockSuggestion ? { lockSuggestion } : {}),
     };
   } catch {
     return null;

--- a/src/features/nearest-station/api/__tests__/positionUpload.test.ts
+++ b/src/features/nearest-station/api/__tests__/positionUpload.test.ts
@@ -473,30 +473,30 @@ describe('dismissBoardingPrompt (#819)', () => {
   });
 });
 
+const RESPONSE_EMBED_SUGGESTION: LockSuggestionMirror = {
+  stationId: '용마산',
+  trainCode: '7246',
+  lineId: '7',
+  confidence: 'high',
+  decidedAt: 1_700_000_000_000,
+};
+
+function makeFetchResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as unknown as Response;
+}
+
 describe('uploadPosition response embed (#1534 S1 T9b, ADR-016)', () => {
-  const SUGGESTION: LockSuggestionMirror = {
-    stationId: '용마산',
-    trainCode: '7246',
-    lineId: '7',
-    confidence: 'high',
-    decidedAt: 1_700_000_000_000,
-  };
-
-  function makeFetchResponse(body: unknown): Response {
-    return {
-      ok: true,
-      status: 200,
-      json: async () => body,
-    } as unknown as Response;
-  }
-
   it('response body에 lockSuggestion + originStationId → BACKEND_SSOT_MIRROR_KEY mirror write', async () => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
-    (global.fetch as jest.Mock).mockResolvedValue(
+    (globalThis.fetch as jest.Mock).mockResolvedValue(
       makeFetchResponse({
         ok: true,
         originStationId: '용마산',
-        lockSuggestion: SUGGESTION,
+        lockSuggestion: RESPONSE_EMBED_SUGGESTION,
       }),
     );
     await uploadPosition({
@@ -511,13 +511,13 @@ describe('uploadPosition response embed (#1534 S1 T9b, ADR-016)', () => {
     expect(stored).not.toBeNull();
     const parsed = JSON.parse(stored as string);
     expect(parsed.currentStationId).toBe('용마산');
-    expect(parsed.lockSuggestion).toEqual(SUGGESTION);
+    expect(parsed.lockSuggestion).toEqual(RESPONSE_EMBED_SUGGESTION);
     expect(typeof parsed.receivedAt).toBe('number');
   });
 
   it('response body에 originStationId만 (lockSuggestion 없음) → mirror write originStationId만', async () => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
-    (global.fetch as jest.Mock).mockResolvedValue(
+    (globalThis.fetch as jest.Mock).mockResolvedValue(
       makeFetchResponse({ ok: true, originStationId: '중곡' }),
     );
     await uploadPosition({
@@ -537,8 +537,8 @@ describe('uploadPosition response embed (#1534 S1 T9b, ADR-016)', () => {
 
   it('response body에 lockSuggestion만 (originStationId 없음) → lockSuggestion.stationId fallback', async () => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
-    (global.fetch as jest.Mock).mockResolvedValue(
-      makeFetchResponse({ ok: true, lockSuggestion: SUGGESTION }),
+    (globalThis.fetch as jest.Mock).mockResolvedValue(
+      makeFetchResponse({ ok: true, lockSuggestion: RESPONSE_EMBED_SUGGESTION }),
     );
     await uploadPosition({
       token: 'tok-ls-only',
@@ -552,12 +552,12 @@ describe('uploadPosition response embed (#1534 S1 T9b, ADR-016)', () => {
     expect(stored).not.toBeNull();
     const parsed = JSON.parse(stored as string);
     expect(parsed.currentStationId).toBe('용마산');
-    expect(parsed.lockSuggestion).toEqual(SUGGESTION);
+    expect(parsed.lockSuggestion).toEqual(RESPONSE_EMBED_SUGGESTION);
   });
 
   it('response body에 둘 다 없음 → mirror write skip (graceful)', async () => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
-    (global.fetch as jest.Mock).mockResolvedValue(makeFetchResponse({ ok: true }));
+    (globalThis.fetch as jest.Mock).mockResolvedValue(makeFetchResponse({ ok: true }));
     await uploadPosition({
       token: 'tok-empty',
       lat: 37.5,
@@ -572,13 +572,13 @@ describe('uploadPosition response embed (#1534 S1 T9b, ADR-016)', () => {
 
   it('response body json parse 실패 → graceful (caller에는 ok=true 회신)', async () => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
-    (global.fetch as jest.Mock).mockResolvedValue({
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
       ok: true,
       status: 200,
       json: async () => {
         throw new Error('invalid json');
       },
-    } as unknown as Response);
+    });
     const r = await uploadPosition({
       token: 'tok-parse',
       lat: 37.5,
@@ -594,10 +594,10 @@ describe('uploadPosition response embed (#1534 S1 T9b, ADR-016)', () => {
 
   it('non-OK status → mirror write skip + ok=false 회신 (기존 동작 보존)', async () => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
-    (global.fetch as jest.Mock).mockResolvedValue({
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
       ok: false,
       status: 500,
-    } as Response);
+    });
     await uploadPosition({
       token: 'tok-err',
       lat: 0,

--- a/src/features/nearest-station/api/__tests__/positionUpload.test.ts
+++ b/src/features/nearest-station/api/__tests__/positionUpload.test.ts
@@ -2,12 +2,17 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   defaultNearestStationResolver,
   dismissBoardingPrompt,
+  persistFromPositionResponse,
   readActiveBoardingLine,
   uploadPosition,
   withMapMatched,
   withNearestStationDistance,
 } from '../positionUpload';
-import { ACTIVE_BOARDING_LINE_KEY } from '../../../../shared/constants/storageKeys';
+import {
+  ACTIVE_BOARDING_LINE_KEY,
+  BACKEND_SSOT_MIRROR_KEY,
+} from '../../../../shared/constants/storageKeys';
+import type { LockSuggestionMirror } from '../../../alarm/utils/backendSsotMirror';
 
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
@@ -465,5 +470,201 @@ describe('dismissBoardingPrompt (#819)', () => {
     (global.fetch as jest.Mock).mockRejectedValue(new Error('boom'));
     const r = await dismissBoardingPrompt('tok');
     expect(r).toEqual({ ok: false });
+  });
+});
+
+describe('uploadPosition response embed (#1534 S1 T9b, ADR-016)', () => {
+  const SUGGESTION: LockSuggestionMirror = {
+    stationId: '용마산',
+    trainCode: '7246',
+    lineId: '7',
+    confidence: 'high',
+    decidedAt: 1_700_000_000_000,
+  };
+
+  function makeFetchResponse(body: unknown): Response {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => body,
+    } as unknown as Response;
+  }
+
+  it('response body에 lockSuggestion + originStationId → BACKEND_SSOT_MIRROR_KEY mirror write', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    (global.fetch as jest.Mock).mockResolvedValue(
+      makeFetchResponse({
+        ok: true,
+        originStationId: '용마산',
+        lockSuggestion: SUGGESTION,
+      }),
+    );
+    await uploadPosition({
+      token: 'tok-ls',
+      lat: 37.5,
+      lng: 127,
+      accuracy: 10,
+      ts: 0,
+      motion: 'walking',
+    });
+    const stored = await AsyncStorage.getItem(BACKEND_SSOT_MIRROR_KEY);
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored as string);
+    expect(parsed.currentStationId).toBe('용마산');
+    expect(parsed.lockSuggestion).toEqual(SUGGESTION);
+    expect(typeof parsed.receivedAt).toBe('number');
+  });
+
+  it('response body에 originStationId만 (lockSuggestion 없음) → mirror write originStationId만', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    (global.fetch as jest.Mock).mockResolvedValue(
+      makeFetchResponse({ ok: true, originStationId: '중곡' }),
+    );
+    await uploadPosition({
+      token: 'tok-os',
+      lat: 37.5,
+      lng: 127,
+      accuracy: 10,
+      ts: 0,
+      motion: 'walking',
+    });
+    const stored = await AsyncStorage.getItem(BACKEND_SSOT_MIRROR_KEY);
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored as string);
+    expect(parsed.currentStationId).toBe('중곡');
+    expect(parsed.lockSuggestion).toBeUndefined();
+  });
+
+  it('response body에 lockSuggestion만 (originStationId 없음) → lockSuggestion.stationId fallback', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    (global.fetch as jest.Mock).mockResolvedValue(
+      makeFetchResponse({ ok: true, lockSuggestion: SUGGESTION }),
+    );
+    await uploadPosition({
+      token: 'tok-ls-only',
+      lat: 37.5,
+      lng: 127,
+      accuracy: 10,
+      ts: 0,
+      motion: 'walking',
+    });
+    const stored = await AsyncStorage.getItem(BACKEND_SSOT_MIRROR_KEY);
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored as string);
+    expect(parsed.currentStationId).toBe('용마산');
+    expect(parsed.lockSuggestion).toEqual(SUGGESTION);
+  });
+
+  it('response body에 둘 다 없음 → mirror write skip (graceful)', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    (global.fetch as jest.Mock).mockResolvedValue(makeFetchResponse({ ok: true }));
+    await uploadPosition({
+      token: 'tok-empty',
+      lat: 37.5,
+      lng: 127,
+      accuracy: 10,
+      ts: 0,
+      motion: 'walking',
+    });
+    const stored = await AsyncStorage.getItem(BACKEND_SSOT_MIRROR_KEY);
+    expect(stored).toBeNull();
+  });
+
+  it('response body json parse 실패 → graceful (caller에는 ok=true 회신)', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error('invalid json');
+      },
+    } as unknown as Response);
+    const r = await uploadPosition({
+      token: 'tok-parse',
+      lat: 37.5,
+      lng: 127,
+      accuracy: 10,
+      ts: 0,
+      motion: 'walking',
+    });
+    expect(r.ok).toBe(true);
+    const stored = await AsyncStorage.getItem(BACKEND_SSOT_MIRROR_KEY);
+    expect(stored).toBeNull();
+  });
+
+  it('non-OK status → mirror write skip + ok=false 회신 (기존 동작 보존)', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+    } as Response);
+    await uploadPosition({
+      token: 'tok-err',
+      lat: 0,
+      lng: 0,
+      accuracy: 0,
+      ts: 0,
+      motion: 'unknown',
+    });
+    const stored = await AsyncStorage.getItem(BACKEND_SSOT_MIRROR_KEY);
+    expect(stored).toBeNull();
+  });
+});
+
+describe('persistFromPositionResponse (#1534 S1 T9b)', () => {
+  const SUGGESTION: LockSuggestionMirror = {
+    stationId: '용마산',
+    trainCode: '7246',
+    lineId: '7',
+    confidence: 'high',
+    decidedAt: 1_700_000_000_000,
+  };
+
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('originStationId만 있는 partial body → currentStationId set + lockSuggestion undefined', async () => {
+    await persistFromPositionResponse({ originStationId: '중곡' }, 1_700_000_010_000);
+    const stored = await AsyncStorage.getItem(BACKEND_SSOT_MIRROR_KEY);
+    const parsed = JSON.parse(stored as string);
+    expect(parsed.currentStationId).toBe('중곡');
+    expect(parsed.motionState).toBe('unknown');
+    expect(parsed.lastAdvanceEvidence).toBe('seed-override');
+    expect(parsed.lastAdvanceAt).toBe(0);
+    expect(parsed.passedStations).toEqual([]);
+    expect(parsed.receivedAt).toBe(1_700_000_010_000);
+    expect(parsed.lockSuggestion).toBeUndefined();
+  });
+
+  it('lockSuggestion만 있는 partial body → stationId fallback + lastAdvanceAt=decidedAt', async () => {
+    await persistFromPositionResponse(
+      { lockSuggestion: SUGGESTION },
+      1_700_000_010_000,
+    );
+    const stored = await AsyncStorage.getItem(BACKEND_SSOT_MIRROR_KEY);
+    const parsed = JSON.parse(stored as string);
+    expect(parsed.currentStationId).toBe('용마산');
+    expect(parsed.lastAdvanceAt).toBe(SUGGESTION.decidedAt);
+    expect(parsed.lockSuggestion).toEqual(SUGGESTION);
+  });
+
+  it('둘 다 없는 empty body → write skip', async () => {
+    await persistFromPositionResponse({}, 1_700_000_010_000);
+    const stored = await AsyncStorage.getItem(BACKEND_SSOT_MIRROR_KEY);
+    expect(stored).toBeNull();
+  });
+
+  it('둘 다 있는 정상 body → originStationId 우선', async () => {
+    await persistFromPositionResponse(
+      { originStationId: '강변', lockSuggestion: SUGGESTION },
+      1_700_000_010_000,
+    );
+    const parsed = JSON.parse(
+      (await AsyncStorage.getItem(BACKEND_SSOT_MIRROR_KEY)) as string,
+    );
+    // originStationId 우선 (lockSuggestion.stationId '용마산' fallback X)
+    expect(parsed.currentStationId).toBe('강변');
+    expect(parsed.lockSuggestion).toEqual(SUGGESTION);
   });
 });

--- a/src/features/nearest-station/api/positionUpload.ts
+++ b/src/features/nearest-station/api/positionUpload.ts
@@ -17,6 +17,11 @@
  *
  * 백엔드 URL 미설정/네트워크 실패는 throw 없이 graceful `{ ok:false, skipped:true }` — Phase 0
  * baseline(사전 예약만)은 그대로 동작한다.
+ *
+ * #1534 (S1, T9b, ADR-016) — POST /position response body에 backend가 추론한 lockSuggestion +
+ * originStationId가 embed된다. 본 모듈이 response를 parse해 BACKEND_SSOT_MIRROR_KEY에 mirror
+ * write — `useLockSuggestion` reader hook이 다음 polling cycle에서 read해 lockless trip의
+ * lock UX를 즉시 활성화한다 (silent push secondary transport + position primary transport 패턴).
  */
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -28,6 +33,11 @@ import { findNearestStation } from '../utils/findNearestStation';
 import type { LineNumber } from '../../../shared/types/station';
 import { createLogger } from '../../../shared/utils/logger';
 import type { AccelSummary } from '../utils/accelMotion';
+import {
+  persistBackendSsotMirror,
+  type LockSuggestionMirror,
+  type SilentPushSsotMirror,
+} from '../../alarm/utils/backendSsotMirror';
 
 const log = createLogger('positionUpload');
 
@@ -208,11 +218,72 @@ export async function uploadPosition(
       log.warn(`position upload failed status=${res.status}`);
       return { ok: false, status: res.status };
     }
+    // #1534 (S1, T9b, ADR-016) — POST /position response embed: lockSuggestion + originStationId.
+    //
+    // backend가 lockless trip을 추론해 lockSuggestion을 결정하면 응답 body에 embed해 회신한다
+    // (silent push 도달 안 되는 분기 — OS suspend/kill/저전력 — 에서도 device가 cycle마다
+    // 호출하는 /position 응답으로 즉시 인계 가능). device는 BACKEND_SSOT_MIRROR_KEY에 mirror
+    // write — useLockSuggestion이 다음 polling cycle에서 read해 useBoardingLockController가
+    // 1순위 lock 채택.
+    //
+    // parse 실패 / 필드 부재 / 형식 mismatch는 silent — device는 기존 9-AND gate fallback.
+    // res.json() 실패는 try/catch가 catch — 응답 자체는 ok=true로 caller에 회신.
+    try {
+      const body = (await res.json()) as Partial<PositionResponseBody> | null;
+      if (body && (body.lockSuggestion || body.originStationId)) {
+        await persistFromPositionResponse(body, Date.now());
+      }
+    } catch {
+      // graceful — body parse 실패 시 device 측 fallback으로 자연 동작.
+    }
     return { ok: true, status: res.status };
   } catch (e) {
     log.warn('position upload error', e);
     return { ok: false };
   }
+}
+
+/**
+ * #1534 (S1, T9b) — POST /position response body schema. backend `index.ts`의 응답 형태와 1:1.
+ *
+ * 둘 다 optional — backend가 SSOT 부재(trip 미등록) 시 embed 하지 않는다 (graceful).
+ */
+export interface PositionResponseBody {
+  ok: boolean;
+  /** backend가 추론한 출발/현재 station identifier — 빈 stationId 분기는 omit. */
+  originStationId?: string;
+  /** backend가 추론한 lock 제안. lockless trip + 강 evidence 합의 시 set. */
+  lockSuggestion?: LockSuggestionMirror;
+}
+
+/**
+ * #1534 (S1, T9b) — POST /position response body에서 SSOT mirror를 빌드해 영속화.
+ *
+ * silent push가 forward하는 `SilentPushSsotMirror`와 동일 schema로 통합 — device cascade picker
+ * + useLockSuggestion 양쪽이 같은 BACKEND_SSOT_MIRROR_KEY를 single source로 read.
+ *
+ * 본 함수는 response body가 partial 일 때(예: lockSuggestion만 있고 motionState/passedStations
+ * 누락) graceful 기본값으로 채워 mirror write를 시도 — useLockSuggestion이 lockSuggestion만 채택
+ * 하므로 motionState='unknown', passedStations=[]가 채택 결정에 영향 없다.
+ */
+export async function persistFromPositionResponse(
+  body: Partial<PositionResponseBody>,
+  receivedAt: number,
+): Promise<void> {
+  // currentStationId는 originStationId fallback. 둘 다 부재면 빈 문자열로 두는 게 적절하나
+  // SilentPushSsotMirror 형식 검증이 빈 문자열을 reject하므로 lockSuggestion.stationId fallback 시도.
+  const currentStationId =
+    body.originStationId ?? body.lockSuggestion?.stationId ?? '';
+  if (currentStationId.length === 0) return;
+  const mirror: SilentPushSsotMirror = {
+    currentStationId,
+    motionState: 'unknown',
+    lastAdvanceEvidence: 'seed-override',
+    lastAdvanceAt: body.lockSuggestion?.decidedAt ?? 0,
+    passedStations: [],
+    ...(body.lockSuggestion ? { lockSuggestion: body.lockSuggestion } : {}),
+  };
+  await persistBackendSsotMirror(mirror, receivedAt);
 }
 
 /**

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -451,6 +451,7 @@ export default function HomeScreen() {
   // alarm/Fusion과의 wiring은 후속 PR C/D에서 활성화된다.
   const {
     lock: boardingLock,
+    lockSuggestion,
     boardingListArrivals,
     createLockFromTrain,
     hydrateLockFromCandidate,
@@ -1079,6 +1080,22 @@ export default function HomeScreen() {
                               const nearBoardingStation =
                                 isCustomOrigin || distanceToCurrentM < BOARDING_PROXIMITY_THRESHOLD_M;
                               if (!nearBoardingStation) {
+                                // #1534 (S1, T9b, ADR-016) — GAP A 시나리오: backend가 lockSuggestion을
+                                // 추론 중이거나 추론 완료. 사용자에게 "추론 중" feedback 노출해 사용자 대기
+                                // 0초 UX 유지. lockSuggestion이 도착하면 useBoardingLockController가
+                                // 자동으로 lock을 createLock해 다음 cycle에 BoardingLockHopCard로 전이된다.
+                                if (lockSuggestion) {
+                                  return (
+                                    <View
+                                      style={styles.boardingProximityHint}
+                                      testID="origin-resolving-hint"
+                                    >
+                                      <Text style={[typography.bodySm, { color: colors.muted }]}>
+                                        {t('home.originResolving')}
+                                      </Text>
+                                    </View>
+                                  );
+                                }
                                 return (
                                   <View
                                     style={styles.boardingProximityHint}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -54,6 +54,7 @@
     "locationUncertainDescription": "GPS accuracy is low,\nso we can't pinpoint your location.\nWe'll retry automatically.",
     "refresh": "Refresh",
     "boardingProximityHint": "Move closer to the boarding station to pick a train",
+    "originResolving": "Detecting origin station...",
     "boardingTrainListTitle": "Pick your train",
     "boardingTrainListLoading": "Loading arrivals...",
     "boardingTrainListEmpty": "No upcoming trains.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -54,6 +54,7 @@
     "locationUncertainDescription": "GPSの精度が低いため、\n現在地を特定できません。\nしばらくしてから自動で再試行します。",
     "refresh": "更新",
     "boardingProximityHint": "乗車駅の近くで列車を選択できます",
+    "originResolving": "出発駅を確認中...",
     "boardingTrainListTitle": "乗車する列車を選択",
     "boardingTrainListLoading": "到着情報を読み込み中...",
     "boardingTrainListEmpty": "到着予定の列車がありません。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -54,6 +54,7 @@
     "locationUncertainDescription": "현재 GPS 정확도가 낮아\n위치를 단정할 수 없습니다.\n잠시 후 자동으로 다시 확인합니다.",
     "refresh": "새로고침",
     "boardingProximityHint": "탑승역 근처에서 열차를 선택할 수 있어요",
+    "originResolving": "출발역 확인 중...",
     "boardingTrainListTitle": "탑승할 열차 선택",
     "boardingTrainListLoading": "도착 정보를 불러오는 중...",
     "boardingTrainListEmpty": "도착 예정 열차가 없습니다.",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -54,6 +54,7 @@
     "locationUncertainDescription": "GPS精度较低,\n暂时无法确定您的位置。\n稍后将自动重试。",
     "refresh": "刷新",
     "boardingProximityHint": "靠近乘车站后可以选择列车",
+    "originResolving": "正在确认出发站...",
     "boardingTrainListTitle": "选择乘坐列车",
     "boardingTrainListLoading": "正在加载到达信息...",
     "boardingTrainListEmpty": "暂无即将到达的列车。",


### PR DESCRIPTION
Closes #1534

## Summary

Epic ADR-016 #1533 / ADR-017 S1 — backend lockSuggestion 추론 + device reader hook 신설. lockless trip 등록 직후 backend가 GPS + arvlcd + trainCode 종합으로 origin/train을 추론해 `TripPositionSSoT.lockSuggestion`에 set → silent push payload + POST /position response 양쪽으로 forward → device `useLockSuggestion` reader가 BACKEND_SSOT_MIRROR_KEY에서 read → `useBoardingLockController`가 1순위 lock 채택 (9-AND gate 우회). 부재 시 device는 기존 9-AND fallback (graceful, backward-compat).

결정 박제 코멘트: https://github.com/handokei/subway-now/issues/1534#issuecomment-4758231145

## 변경 범위 (decision comment "(g) backend infer만 처리" precedence)

**IN**:
- Backend: `TripPositionSSoT.lockSuggestion` field + `setLockSuggestion` / `isSameLockSuggestion` helpers
- Backend: `advanceTripPosition` lockSuggestion 추론 (lockless + arvlcd-confirmed-train → high, position-train → medium)
- Backend: POST /position response embed `{ ok, originStationId?, lockSuggestion? }` (primary transport)
- Backend: `SilentPushSsotPayload.lockSuggestion` forward via `toSilentPushSsot` (secondary transport)
- Device: `useLockSuggestion` 신규 hook (single-responsibility reader, 5s polling, 5m staleness)
- Device: `useBoardingLockController` 1순위 채택 effect + result.lockSuggestion 노출
- Device: `positionUpload` response parse → `persistFromPositionResponse` → BACKEND_SSOT_MIRROR_KEY mirror
- Device: `backendSsotMirror` `LockSuggestionMirror` type + parse + graceful drop
- UI: i18n `home.originResolving` 4 locales (en/ja/ko/zh) + HomeScreen `origin-resolving-hint` view
- Tests + 100% coverage 유지

**OUT (별 작업, 본 PR scope 밖)**:
- (h) movement consensus → 별 #1596 (정지 false lock evidence acceptance)
- 5 fire path 호출자 migration
- LA Interactive Button (native iOS APNs category 추가) — 별 follow-up
- instant boardingPrompt push from /trips (trigger refactor) — 별 follow-up
- instant autoLock device-side — lockSuggestion 1순위 채택으로 functionally equivalent

## Wire-completion 5단 evidence

1. **Orphan 없음** — `npm run lint:orphan` pass (`No orphan exports detected`).
2. **V/X dashboard** — DebugModal "Backend SSoT mirror" 섹션이 BACKEND_SSOT_MIRROR_KEY 전체 (lockSuggestion 필드 포함) 자동 노출 (변경 없음). Cloudflare Dashboard /position response 200 + body 직접 inspect 가능. 후속 P0-3 (#1579) alarmLog forward의 ssotMirror snapshot에서 lockSuggestion 채택율 측정.
3. **의존 PR** — N/A (atomic backend + device 변경, Phase 0 prerequisite 완료).
4. **측정 plan** — production lockSuggestion 채택율 / V2 (lockless 첫 station miss ≤2) 1주 측정:
   - alarmLog forward ssotMirror snapshot 분석 → lockSuggestion 채택 trip 비율
   - DebugModal에서 trip 시작 → lockSuggestion 도착 latency 직접 관측
   - V8 false lock rate는 P0-4 (#1580) gold standard runner 머지 후 검증
5. **Device verify** — 실기기 실측 1주 + 시나리오:
   - currentStation=null 상태로 trip 시작 → 30s 안에 BoardingLockHopCard 활성화
   - 지하 진입 trip → silent push payload lockSuggestion 도달 확인
   - "출발역 확인 중..." indicator 노출 → lock 채택 시 자동 전환

## Wire-completion 5단 grep evidence

```
# useLockSuggestion consumer (non-test):
src/features/alarm/hooks/useBoardingLockController.ts:25:import { useLockSuggestion } from '../api/useLockSuggestion';
src/features/alarm/hooks/useBoardingLockController.ts:136:  const { suggestion: lockSuggestion } = useLockSuggestion();

# lockSuggestion backend SSoT mirror write site (non-test):
backend/alarm-worker/src/tripPositionSsot.ts:167:  lockSuggestion?: LockSuggestion;
backend/alarm-worker/src/tripPositionSsot.ts:333:  ssot.lockSuggestion = suggestion;
backend/alarm-worker/src/advanceTripPosition.ts:382-386 (advance path write)

# POST /position response embed (non-test):
backend/alarm-worker/src/index.ts:1019-1029 (response builder embed)

# silent push payload forward:
backend/alarm-worker/src/scheduled.ts:936-938 (toSilentPushSsot forward)
```

## 자가 점검 5단 ([[feedback_epic_self_check_5step]])

1. **acceptance self-referential?** — V2 (lockless 첫 station miss ≤2) 직접 측정 가능 (P0-1 Analytics + P0-3 alarmLog forward). V8 false lock rate는 P0-4 gold standard runner 머지 후 검증 — 부분 self-referential, 1주 production 측정으로 검증.
2. **Wire-completion?** ✅ 위 grep evidence + Orphan 0 + persist/read 양방향 테스트.
3. **머지 순서?** ✅ Phase 0 prerequisite (#1577~#1582) 머지 완료. 본 PR은 backend + device atomic 변경.
4. **backward-compat?** ✅ lockSuggestion optional — 부재 시 device는 기존 9-AND gate fallback. 구 backend / 구 client 양방향 호환. 구 mirror entry parse 시 lockSuggestion 누락 graceful drop.
5. **False positive new?** ⚠️ backend infer 잘못된 origin 추론 시 false lock 가능 — 1주 측정으로 정확도 검증. fallback이 9-AND gate라 graceful degradation. low confidence는 본 PR에서 채택하지 않고 future slot으로 유지.

## 5 시나리오 acceptance 시뮬레이션

| 시나리오 | 동작 |
|---|---|
| 1. 정상 lockless start (지상, currentStation 알려짐) | 기존 9-AND gate 그대로 + backend가 advance 시 lockSuggestion 추론 → device 1순위 채택 (개선) |
| 2. GAP A (currentStation=null) start (지하) | 기존: waypoints=[destination] → backend cron lazy seed → 본 PR: backend lockSuggestion forward → device 즉시 lock |
| 3. 환승 leg 진입 | 기존 transfer-swap path 그대로 (`hydrateLockFromCandidate` Gate 2 우회 분기 유지) — lockSuggestion이 환승 시점 trainCode swap도 forward |
| 4. silent push 미도달 (OS suspend) | POST /position response가 primary transport — device가 cycle마다 호출하므로 즉시 인계 |
| 5. **정지 false lock (2026-06-20 evidence)** | **#1596에서 처리** — backend가 정지 중 GPS displacement evidence로 advance를 거부해야 하는 multi-signal consensus 별 작업. 본 PR은 scope 밖. |

## 1주 측정 검증 계획

production alarmLog forward의 ssotMirror snapshot + Analytics Engine `trip_metrics` 데이터셋으로 V2 (lockless 첫 station miss ≤2) / V7 (4분면 SSoT 채택) / lockSuggestion 채택 분포 (high/medium/null) 1주 측정 → ADR-016 / ADR-017 acceptance 검증.

## 검증

- `cd backend/alarm-worker && npm run type-check` → 0 error
- `cd backend/alarm-worker && npx vitest run` → **1762 / 1762 pass**
- `npm run type-check` → 0 error
- `npm test` → **7138 / 7138 pass, coverage 100%**
- `npm run lint:orphan` → orphan 0

## Test plan

- [x] backend type-check pass
- [x] backend unit test pass (1762/1762)
- [x] device type-check pass
- [x] device test pass (7138/7138) + coverage 100%
- [x] Wire-completion lint:orphan pass
- [ ] 실기기 검증 — currentStation=null trip → 30s 내 lockSuggestion 채택
- [ ] 1주 production 측정 — lockSuggestion 채택율 + V2/V7 검증