### PR TITLE
fix(#1598): app boot 시 active trip 없으면 Backend SSoT mirror clear

### DIFF
--- a/src/shared/hooks/__tests__/useStateRehydration.test.ts
+++ b/src/shared/hooks/__tests__/useStateRehydration.test.ts
@@ -32,6 +32,13 @@ jest.mock('../../../features/alarm/utils/alarmLog', () => ({
   appendAlarmLog: (...args: unknown[]) => mockAppendAlarmLog(...args),
 }));
 
+const mockReadBackendSsotMirror = jest.fn();
+const mockClearBackendSsotMirror = jest.fn();
+jest.mock('../../../features/alarm/utils/backendSsotMirror', () => ({
+  readBackendSsotMirror: (...args: unknown[]) => mockReadBackendSsotMirror(...args),
+  clearBackendSsotMirror: (...args: unknown[]) => mockClearBackendSsotMirror(...args),
+}));
+
 const mockAddDomainBreadcrumb = jest.fn();
 jest.mock('../../infra/monitoring/breadcrumb', () => ({
   addLogBreadcrumb: jest.fn(),
@@ -70,6 +77,9 @@ beforeEach(() => {
   // 기본은 trip 미존재(none) — 기존 테스트들이 backstop 영향 받지 않도록.
   mockGetTripStartedAt.mockResolvedValue(null);
   mockTripLifecyclePhase.mockReturnValue('none');
+  // 기본 mirror 미존재 — 기존 테스트들이 mirror backstop 영향 받지 않도록.
+  mockReadBackendSsotMirror.mockResolvedValue(null);
+  mockClearBackendSsotMirror.mockResolvedValue(undefined);
   jest.spyOn(useDestinationStore, 'getState').mockReturnValue({
     setDestination: mockSetDestination,
     loadDestination: mockLoadDestination,
@@ -286,6 +296,57 @@ describe('useStateRehydration', () => {
       mockGetTripStartedAt.mockRejectedValue(new Error('io'));
       mockAppState();
       // throw가 새지 않아 hook 자체는 정상 마운트.
+      expect(() => renderHook(() => useStateRehydration())).not.toThrow();
+      await waitFor(() => expect(mockLoadDestination).toHaveBeenCalled());
+    });
+  });
+
+  describe('#1598 stale Backend SSoT mirror boot clear', () => {
+    it('active trip 없음 + mirror 잔존 — clearBackendSsotMirror 호출 (2026-06-20 dump 회귀)', async () => {
+      mockGetTripStartedAt.mockResolvedValue(null);
+      mockReadBackendSsotMirror.mockResolvedValue({
+        currentStationId: '건대입구',
+        motionState: 'unknown',
+        lastAdvanceEvidence: 'arrival-prior',
+        lastAdvanceAt: 1_700_000_000_000,
+        passedStations: [],
+        receivedAt: 1_700_000_000_000,
+      });
+      mockAppState();
+      renderHook(() => useStateRehydration());
+      await waitFor(() => expect(mockClearBackendSsotMirror).toHaveBeenCalledTimes(1));
+    });
+
+    it('active trip 있음 — mirror 그대로 (clear 호출 안 함)', async () => {
+      mockGetTripStartedAt.mockResolvedValue(1_000_000);
+      mockTripLifecyclePhase.mockReturnValue('normal');
+      mockReadBackendSsotMirror.mockResolvedValue({
+        currentStationId: '건대입구',
+        motionState: 'moving',
+        lastAdvanceEvidence: 'arrival',
+        lastAdvanceAt: 1_700_000_000_000,
+        passedStations: [],
+        receivedAt: 1_700_000_000_000,
+      });
+      mockAppState();
+      renderHook(() => useStateRehydration());
+      await waitFor(() => expect(mockLoadDestination).toHaveBeenCalled());
+      expect(mockClearBackendSsotMirror).not.toHaveBeenCalled();
+    });
+
+    it('active trip 없음 + mirror 부재 — read만 하고 clear 호출 안 함', async () => {
+      mockGetTripStartedAt.mockResolvedValue(null);
+      mockReadBackendSsotMirror.mockResolvedValue(null);
+      mockAppState();
+      renderHook(() => useStateRehydration());
+      await waitFor(() => expect(mockReadBackendSsotMirror).toHaveBeenCalled());
+      expect(mockClearBackendSsotMirror).not.toHaveBeenCalled();
+    });
+
+    it('mirror read 실패는 graceful (throw 없음)', async () => {
+      mockGetTripStartedAt.mockResolvedValue(null);
+      mockReadBackendSsotMirror.mockRejectedValue(new Error('io'));
+      mockAppState();
       expect(() => renderHook(() => useStateRehydration())).not.toThrow();
       await waitFor(() => expect(mockLoadDestination).toHaveBeenCalled());
     });

--- a/src/shared/hooks/useStateRehydration.ts
+++ b/src/shared/hooks/useStateRehydration.ts
@@ -20,6 +20,10 @@ import {
   tripLifecyclePhase,
 } from '../../features/alarm/utils/tripStartStorage';
 import { appendAlarmLog } from '../../features/alarm/utils/alarmLog';
+import {
+  clearBackendSsotMirror,
+  readBackendSsotMirror,
+} from '../../features/alarm/utils/backendSsotMirror';
 import { createLogger } from '../utils/logger';
 import { addDomainBreadcrumb } from '../infra/monitoring/breadcrumb';
 
@@ -96,6 +100,37 @@ async function runRehydration(trigger: 'mount' | 'active'): Promise<void> {
   // silence 적재는 entry 1회당 한 cycle만 의미가 있고 멱등이 자연 — 매 active 진입마다 1엔트리.
   // share dump에서 lifecycle-backstop source 카운트로 측정.
   await runLifecycleBackstop(trigger);
+
+  // #1598 — app boot / FG 복귀 시 active trip이 없는데 Backend SSoT mirror가 잔존하면 즉시 clear.
+  // 2026-06-20 trip dump evidence: 사용자 위치 용마산 / activeTrip=(none) / mirror=건대입구.
+  // TRIP_BOUND_CLEANUPS는 trip 종료 경로(setDestination(null)/silent push trip-ended/sentinel/
+  // launch reconciliation)에서만 동작 — 정상 종료가 누락된 옛 trip의 mirror 잔재는 본 backstop으로
+  // 회수. mirror read 실패는 graceful — 다음 active 진입에서 재시도.
+  await clearStaleBackendSsotMirrorIfNoTrip(trigger);
+}
+
+/**
+ * #1598 — active trip 없음 + mirror 잔존 시 mirror만 즉시 제거.
+ *
+ * `getTripStartedAt`을 단일 source로 삼아 "active trip 있음" 판정. tripStartedAt 부재 = 정상 종료
+ * 후 잔재이거나 boot 시점 미시작 상태. mirror가 있으면 cascade picker가 다음 polling cycle에서
+ * 이전 trip의 stationId를 backend-ssot tier로 채택하는 회귀(#1598)를 차단.
+ *
+ * mirror 부재 시 read만 하고 종료 — 불필요한 storage write 회피. throw 없음 — launch 차단 금지.
+ */
+async function clearStaleBackendSsotMirrorIfNoTrip(
+  trigger: 'mount' | 'active',
+): Promise<void> {
+  try {
+    const startedAt = await getTripStartedAt();
+    if (startedAt !== null) return;
+    const mirror = await readBackendSsotMirror();
+    if (mirror === null) return;
+    logger.info(`trigger=${trigger} no active trip + mirror stale → clearBackendSsotMirror`);
+    await clearBackendSsotMirror();
+  } catch (e) {
+    logger.warn('stale mirror clear 실패 (graceful)', e);
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #1598

## 배경 (2026-06-20 trip dump evidence)

`/Users/kimdohan/Downloads/텍스트-90D21B97AA1C-1.txt` (Phase 0 활성화 직후 첫 dump):
- 사용자 위치 = 용마산 (`Nearest=용마산 224m`)
- 활성 trip 없음 (`lockless=false`, `tripStartedAt=—`, `activeTrip=(none)`)
- Backend SSoT mirror = **건대입구** (이전 trip 종료 시점 잔재)

T10 #1594 `clearBackendSsotMirror`는 `TRIP_BOUND_CLEANUPS` 배열에만 wire. 정상 종료가 누락된 옛 trip의 mirror 잔재는 cascade picker가 `backend-ssot` 최상위 tier로 채택해 새 trip의 현재역 판정을 오염시킬 수 있다 (Mirror leak #4).

## Fix

`useStateRehydration` (mount + AppState 'active' 진입)에 stale mirror backstop 추가:
- `getTripStartedAt() === null` (no active trip) +
- `readBackendSsotMirror() !== null` (mirror 잔존) →
- `clearBackendSsotMirror()` 즉시 실행

mirror read 실패는 graceful — 다음 active 진입에서 재시도. throw는 launch path를 차단하지 않는다.

## 변경

- `src/shared/hooks/useStateRehydration.ts` (+35 / 신규 helper `clearStaleBackendSsotMirrorIfNoTrip`)
- `src/shared/hooks/__tests__/useStateRehydration.test.ts` (+61 / 4건)

총 변경: 96 lines (+2 files modified, 0 new).

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass. 신규 caller `useStateRehydration` + 기존 `tripBoundCleanups` (T10) 양쪽 모두 import 확인. grep evidence:
   ```
   src/features/alarm/store/tripBoundCleanups.ts:43,133  (T10 #1594)
   src/shared/hooks/useStateRehydration.ts:24,130          (#1598 신규)
   ```
2. **V/X dashboard** — DebugModal "Backend SSoT" section. mirror 잔재 시 currentStationId 노출 → boot 후 즉시 empty 전환 확인.
3. **의존 PR** — T10 #1594 (머지됨).
4. **측정 plan** — Phase 0 (#1576) share dump에서 boot 시점 BACKEND_SSOT_MIRROR_KEY value 캡처. 1주 실기기 trip: trip 종료 후 다음 boot 시점에 mirror=empty 보장 (회귀 0).
5. **Device verify** — 필요. 시나리오:
   - trip 진행 중 silent push로 mirror 채움 → 정상 종료(setDestination(null))로 mirror clear (회귀 0)
   - app force-quit + relaunch 시 mirror 잔존 X (본 PR backstop)
   - active trip 진행 중 FG 복귀 시 mirror 그대로 유지

## 단위 테스트 (4건)

- `active trip 없음 + mirror 잔존 — clearBackendSsotMirror 호출 (2026-06-20 dump 회귀)`
- `active trip 있음 — mirror 그대로 (clear 호출 안 함)`
- `active trip 없음 + mirror 부재 — read만 하고 clear 호출 안 함`
- `mirror read 실패는 graceful (throw 없음)`

전체 `useStateRehydration.test.ts` 20 tests pass.

## Risk

- 1-5줄 추가 helper. 새 hook/store 신설 X. TRIP_BOUND_CLEANUPS 변경 X.
- `getTripStartedAt`을 active trip 단일 source로 사용 (기존 `runLifecycleBackstop`와 동일 판정 기준).