### PR TITLE
fix(#1599): station-passed lock origin 가드 (band-aid for #1596)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -3906,61 +3906,44 @@ describe('useStationAlarm', () => {
       }
     });
 
-    it('FG arvlCd fast path — lock 활성 + sleep ON + candidate=boardingStation → #1599 lock-origin 가드로 차단 (sleep gate 전)', async () => {
-      // arvlCd fast path는 lock != null 필요 (#640 회귀 가드). lock 활성 + first hop 케이스로 검증.
-      // #1599 band-aid 후: candidate=boardingStation은 sleep gate 진입 전 lock-origin 가드가 먼저 차단.
-      useSettingsStore.setState({ sleepMode: true });
-      mockGetBoardingLock.mockResolvedValue(lockOnSagajeong);
-      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
-      mockGetLastNotifiedStationId.mockResolvedValue(null);
+    // #1599 band-aid: arvlCd fast path에서 lock 활성 + candidate=boardingStation은
+    // sleep 무관 항상 lock-origin 가드가 먼저 차단. 사용자 의향 가장 강한 가드이므로
+    // sleep ON/OFF 모두 적용 (it.each로 매트릭스 검증).
+    it.each([
+      { sleepMode: true, label: 'sleep ON (sleep gate 전 차단)' },
+      { sleepMode: false, label: 'sleep OFF (사용자 의향 강한 가드)' },
+    ])(
+      'FG arvlCd fast path — lock 활성 + first hop + $label → #1599 lock-origin 가드로 차단',
+      async ({ sleepMode }) => {
+        useSettingsStore.setState({ sleepMode });
+        mockGetBoardingLock.mockResolvedValue(lockOnSagajeong);
+        mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+        mockGetLastNotifiedStationId.mockResolvedValue(null);
 
-      renderHook(() =>
-        useStationAlarm(
-          withSleepGateInputs({
-            currentHopIndex: null,
-            currentStationArrival: { up: [], down: [] } as unknown as Parameters<
-              typeof useStationAlarm
-            >[0]['currentStationArrival'],
-          }),
-        ),
-      );
+        renderHook(() =>
+          useStationAlarm(
+            withSleepGateInputs({
+              currentHopIndex: null,
+              currentStationArrival: { up: [], down: [] } as unknown as Parameters<
+                typeof useStationAlarm
+              >[0]['currentStationArrival'],
+            }),
+          ),
+        );
 
-      await waitFor(() => {
-        const calls = mockLogSuppressedPassedEventOnLockOrigin.mock.calls;
-        expect(calls.some((c) => c[0]?.source === 'fg-arvlcd')).toBe(true);
-      });
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
-      // lock-origin guard가 sleep gate보다 위에 있어 sleep stamp는 발생하지 않음.
-      expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
-    });
-
-    it('FG arvlCd fast path — sleep OFF + lock 활성 + first hop → #1599 lock-origin 가드로 차단', async () => {
-      // #1599 band-aid 후: sleep 무관, lock 활성 + candidate=boardingStation이면 항상 차단.
-      // 사용자 의향 가장 강한 가드이므로 sleep OFF에서도 적용.
-      useSettingsStore.setState({ sleepMode: false });
-      mockGetBoardingLock.mockResolvedValue(lockOnSagajeong);
-      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
-      mockGetLastNotifiedStationId.mockResolvedValue(null);
-
-      renderHook(() =>
-        useStationAlarm(
-          withSleepGateInputs({
-            currentHopIndex: null,
-            currentStationArrival: { up: [], down: [] } as unknown as Parameters<
-              typeof useStationAlarm
-            >[0]['currentStationArrival'],
-          }),
-        ),
-      );
-
-      await waitFor(() => {
-        const calls = mockLogSuppressedPassedEventOnLockOrigin.mock.calls;
-        expect(calls.some((c) => c[0]?.source === 'fg-arvlcd')).toBe(true);
-      });
-      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
-      expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
-    });
+        await waitFor(() => {
+          const calls = mockLogSuppressedPassedEventOnLockOrigin.mock.calls;
+          expect(calls.some((c) => c[0]?.source === 'fg-arvlcd')).toBe(true);
+        });
+        const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter(
+          (c) => c[0] === 'fg-arvlcd',
+        );
+        expect(arvlCdFires).toHaveLength(0);
+        expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+        // lock-origin guard가 sleep gate보다 위에 있어 sleep stamp는 발생하지 않음.
+        expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
+      },
+    );
 
     it('GPS station-passed IIFE: getBoardingLock 후 cleanup → 후속 dispatch 미실행 (cancelled guard)', async () => {
       // #1236 — GPS path에 추가된 lock fetch IIFE의 `if (cancelled) return;` 분기 커버.

--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -3828,13 +3828,14 @@ describe('useStationAlarm', () => {
       });
     }
 
+    type ExpectGate = 'sleep' | 'lock-origin' | 'none';
     it.each([
       {
         name: 'FG GPS path — lockless + sleep ON + currentHopIndex=0 → station-passed 차단 (사가정 22:11:56 evidence)',
         sleepMode: true,
         lockValue: null,
         currentHopIndex: 0 as number | null,
-        expectGate: 'sleep' as 'sleep' | 'lock-origin' | 'none',
+        expectGate: 'sleep' as ExpectGate,
       },
       {
         // #1599 band-aid — lock 활성 + candidate=boardingStation은 sleep gate 진입 전에
@@ -3843,28 +3844,28 @@ describe('useStationAlarm', () => {
         sleepMode: true,
         lockValue: lockOnSagajeong,
         currentHopIndex: null,
-        expectGate: 'lock-origin' as 'sleep' | 'lock-origin' | 'none',
+        expectGate: 'lock-origin' as ExpectGate,
       },
       {
         name: 'FG GPS path — sleep OFF + lockless + currentHopIndex=0 → 정상 발사',
         sleepMode: false,
         lockValue: null,
         currentHopIndex: 0 as number | null,
-        expectGate: 'none' as 'sleep' | 'lock-origin' | 'none',
+        expectGate: 'none' as ExpectGate,
       },
       {
         name: 'FG GPS path — sleep ON + lockless + currentHopIndex=3 → 정상 발사 (첫 hop 아님)',
         sleepMode: true,
         lockValue: null,
         currentHopIndex: 3 as number | null,
-        expectGate: 'none' as 'sleep' | 'lock-origin' | 'none',
+        expectGate: 'none' as ExpectGate,
       },
       {
         name: 'FG GPS path — sleep ON + lock 활성 + candidate≠boardingStation → 정상 발사',
         sleepMode: true,
         lockValue: { ...lockOnSagajeong, boardingStationId: 'S-OTHER' },
         currentHopIndex: null,
-        expectGate: 'none' as 'sleep' | 'lock-origin' | 'none',
+        expectGate: 'none' as ExpectGate,
       },
     ])('$name', async ({ sleepMode, lockValue, currentHopIndex, expectGate }) => {
       useSettingsStore.setState({ sleepMode });

--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -82,6 +82,7 @@ const mockLogSuppressedStationPassedWarmup = jest.fn();
 const mockLogSuppressedHopWindow = jest.fn();
 const mockLogSuppressedHopWindowNoSource = jest.fn();
 const mockLogSuppressedOriginHopLockless = jest.fn();
+const mockLogSuppressedPassedEventOnLockOrigin = jest.fn();
 const mockLogSuppressedCrossCategoryDedup = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
@@ -105,6 +106,8 @@ jest.mock('../../utils/alarmLog', () => ({
     mockLogSuppressedHopWindowNoSource(...args),
   logSuppressedOriginHopLockless: (...args: unknown[]) =>
     mockLogSuppressedOriginHopLockless(...args),
+  logSuppressedPassedEventOnLockOrigin: (...args: unknown[]) =>
+    mockLogSuppressedPassedEventOnLockOrigin(...args),
   logSuppressedCrossCategoryDedup: (...args: unknown[]) =>
     mockLogSuppressedCrossCategoryDedup(...args),
 }));
@@ -3749,7 +3752,10 @@ describe('useStationAlarm', () => {
       expect(mockLogFiredStationPassed).not.toHaveBeenCalledWith('fg', arcOrigin[0]);
     });
 
-    it('lock 활성 + currentHopIndex=0 + candidate arc[0] (= boardingStationId) → 통과 (ADR-014 동급 보장)', async () => {
+    it('#1599 band-aid — lock 활성 + currentHopIndex=0 + candidate arc[0] (= boardingStationId) → 차단 (passed-event-on-lock-origin)', async () => {
+      // ADR-014 §4 "lock origin은 정당 신호" 명제는 2026-06-20 용마산 evidence(lock 1초 후 origin 자체에
+      // station-passed fire = X1 wrong-station-alarm)로 반증됨. #1596(autoLock multi-signal consensus)이
+      // 머지될 때까지 origin candidate는 차단 — 출발역에서 출발하면 첫 hop은 "다음 역"이지 origin 자체가 아님.
       mockGetBoardingLock.mockResolvedValue({
         destinationId: destination.id,
         trainCode: 'T-LOCK',
@@ -3761,8 +3767,12 @@ describe('useStationAlarm', () => {
       mockNextTargetStops(4);
       renderOriginHopCase(0, 0);
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+        expect(mockLogSuppressedPassedEventOnLockOrigin).toHaveBeenCalledWith({
+          source: 'fg',
+          stationName: arcOrigin[0].name,
+        });
       });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
       expect(mockLogSuppressedOriginHopLockless).not.toHaveBeenCalled();
     });
 
@@ -3824,37 +3834,39 @@ describe('useStationAlarm', () => {
         sleepMode: true,
         lockValue: null,
         currentHopIndex: 0 as number | null,
-        expectSuppress: true,
+        expectGate: 'sleep' as 'sleep' | 'lock-origin' | 'none',
       },
       {
-        name: 'FG GPS path — lock 활성 + sleep ON + candidate=boardingStation → station-passed 차단',
+        // #1599 band-aid — lock 활성 + candidate=boardingStation은 sleep gate 진입 전에
+        // passed-event-on-lock-origin 가드가 먼저 차단. 다른 가드(#1236 sleep)는 호출되지 않음.
+        name: 'FG GPS path — lock 활성 + sleep ON + candidate=boardingStation → #1599 lock-origin 가드로 차단 (sleep gate 전)',
         sleepMode: true,
         lockValue: lockOnSagajeong,
         currentHopIndex: null,
-        expectSuppress: true,
+        expectGate: 'lock-origin' as 'sleep' | 'lock-origin' | 'none',
       },
       {
         name: 'FG GPS path — sleep OFF + lockless + currentHopIndex=0 → 정상 발사',
         sleepMode: false,
         lockValue: null,
         currentHopIndex: 0 as number | null,
-        expectSuppress: false,
+        expectGate: 'none' as 'sleep' | 'lock-origin' | 'none',
       },
       {
         name: 'FG GPS path — sleep ON + lockless + currentHopIndex=3 → 정상 발사 (첫 hop 아님)',
         sleepMode: true,
         lockValue: null,
         currentHopIndex: 3 as number | null,
-        expectSuppress: false,
+        expectGate: 'none' as 'sleep' | 'lock-origin' | 'none',
       },
       {
         name: 'FG GPS path — sleep ON + lock 활성 + candidate≠boardingStation → 정상 발사',
         sleepMode: true,
         lockValue: { ...lockOnSagajeong, boardingStationId: 'S-OTHER' },
         currentHopIndex: null,
-        expectSuppress: false,
+        expectGate: 'none' as 'sleep' | 'lock-origin' | 'none',
       },
-    ])('$name', async ({ sleepMode, lockValue, currentHopIndex, expectSuppress }) => {
+    ])('$name', async ({ sleepMode, lockValue, currentHopIndex, expectGate }) => {
       useSettingsStore.setState({ sleepMode });
       mockGetBoardingLock.mockResolvedValue(lockValue);
       mockResolveNextTarget.mockReturnValue({
@@ -3866,7 +3878,7 @@ describe('useStationAlarm', () => {
 
       renderHook(() => useStationAlarm(withSleepGateInputs({ currentHopIndex })));
 
-      if (expectSuppress) {
+      if (expectGate === 'sleep') {
         await waitFor(() =>
           expect(mockLogSuppressedSleepStationPassed).toHaveBeenCalledWith({
             source: 'fg',
@@ -3875,14 +3887,27 @@ describe('useStationAlarm', () => {
         );
         expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
         expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
+      } else if (expectGate === 'lock-origin') {
+        await waitFor(() =>
+          expect(mockLogSuppressedPassedEventOnLockOrigin).toHaveBeenCalledWith({
+            source: 'fg',
+            stationName: onRouteStation.name,
+          }),
+        );
+        expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+        expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
+        // lock-origin guard는 sleep gate보다 위에 있어 sleep stamp는 발생하지 않음.
+        expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
       } else {
         await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
         expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
+        expect(mockLogSuppressedPassedEventOnLockOrigin).not.toHaveBeenCalled();
       }
     });
 
-    it('FG arvlCd fast path — lock 활성 + sleep ON + candidate=boardingStation → 차단 + fg-arvlcd suppress 로그', async () => {
+    it('FG arvlCd fast path — lock 활성 + sleep ON + candidate=boardingStation → #1599 lock-origin 가드로 차단 (sleep gate 전)', async () => {
       // arvlCd fast path는 lock != null 필요 (#640 회귀 가드). lock 활성 + first hop 케이스로 검증.
+      // #1599 band-aid 후: candidate=boardingStation은 sleep gate 진입 전 lock-origin 가드가 먼저 차단.
       useSettingsStore.setState({ sleepMode: true });
       mockGetBoardingLock.mockResolvedValue(lockOnSagajeong);
       mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
@@ -3900,14 +3925,18 @@ describe('useStationAlarm', () => {
       );
 
       await waitFor(() => {
-        const calls = mockLogSuppressedSleepStationPassed.mock.calls;
+        const calls = mockLogSuppressedPassedEventOnLockOrigin.mock.calls;
         expect(calls.some((c) => c[0]?.source === 'fg-arvlcd')).toBe(true);
       });
       const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
       expect(arvlCdFires).toHaveLength(0);
+      // lock-origin guard가 sleep gate보다 위에 있어 sleep stamp는 발생하지 않음.
+      expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
     });
 
-    it('FG arvlCd fast path — sleep OFF + lock 활성 + first hop → 정상 발사 (게이트 비활성)', async () => {
+    it('FG arvlCd fast path — sleep OFF + lock 활성 + first hop → #1599 lock-origin 가드로 차단', async () => {
+      // #1599 band-aid 후: sleep 무관, lock 활성 + candidate=boardingStation이면 항상 차단.
+      // 사용자 의향 가장 강한 가드이므로 sleep OFF에서도 적용.
       useSettingsStore.setState({ sleepMode: false });
       mockGetBoardingLock.mockResolvedValue(lockOnSagajeong);
       mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
@@ -3924,7 +3953,11 @@ describe('useStationAlarm', () => {
         ),
       );
 
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      await waitFor(() => {
+        const calls = mockLogSuppressedPassedEventOnLockOrigin.mock.calls;
+        expect(calls.some((c) => c[0]?.source === 'fg-arvlcd')).toBe(true);
+      });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
       expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
     });
 

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -238,7 +238,7 @@ async function runSilenceGateAndDispatch(params: {
   // 2026-06-20 용마산 evidence: lock 활성 1초 후 lock origin 자체에 station-passed fire (X1).
   // #1596(autoLock multi-signal consensus) 머지 전까지 band-aid — origin은 "출발역"이라 station-passed
   // 첫 대상이 될 수 없다 (다음 역이 첫 hop). 모든 다른 게이트보다 위 — 가장 강한 사용자 의향 가드.
-  if (params.lock && params.candidateStation.id === params.lock.boardingStationId) {
+  if (params.candidateStation.id === params.lock?.boardingStationId) {
     logSuppressedPassedEventOnLockOrigin({
       source: params.source,
       stationName: params.candidateStation.name,

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -46,6 +46,7 @@ import {
   logSuppressedHopWindow,
   logSuppressedHopWindowNoSource,
   logSuppressedOriginHopLockless,
+  logSuppressedPassedEventOnLockOrigin,
   logSuppressedMovement,
   logSuppressedPhaseGate,
   logSuppressedSleepFirstTransfer,
@@ -233,6 +234,17 @@ async function runSilenceGateAndDispatch(params: {
   /** lock=null이면 lockless trip — currentHopIndex===0으로 판정. lock 활성이면 boardingStationId 비교. */
   lock: import('../../../shared/types/boardingLock').BoardingLock | null;
 }): Promise<void> {
+  // #1599 — boardingLock active 시 candidate가 lock origin(= boardingStationId)이면 station-passed 차단.
+  // 2026-06-20 용마산 evidence: lock 활성 1초 후 lock origin 자체에 station-passed fire (X1).
+  // #1596(autoLock multi-signal consensus) 머지 전까지 band-aid — origin은 "출발역"이라 station-passed
+  // 첫 대상이 될 수 없다 (다음 역이 첫 hop). 모든 다른 게이트보다 위 — 가장 강한 사용자 의향 가드.
+  if (params.lock && params.candidateStation.id === params.lock.boardingStationId) {
+    logSuppressedPassedEventOnLockOrigin({
+      source: params.source,
+      stationName: params.candidateStation.name,
+    });
+    return;
+  }
   // #1236 — sleep 룰 게이트. dismiss silence 위 — silence 만료/위치 무관하게 sleep 첫 hop은 정책상 차단.
   // sleep 룰은 정확성 게이트(ADR-013 §B3 / ADR-014)라 silence 만료 부수효과(clear)를 막아도 무방.
   if (

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -49,6 +49,7 @@ import {
   logSuppressedHopWindow,
   logSuppressedHopWindowNoSource,
   logSuppressedOriginHopLockless,
+  logSuppressedPassedEventOnLockOrigin,
   logSuppressedTbaRevalidation,
   summarizeAlarmLogBySource,
   countGateReasons,
@@ -764,6 +765,21 @@ describe('alarmLog', () => {
         source: 'fg',
         outcome: 'suppressed',
         reason: 'gate-origin-hop-lockless',
+        stationName: '용마산',
+        kind: 'station-passed',
+      });
+    });
+
+    it('#1599 logSuppressedPassedEventOnLockOrigin: reason=gate-passed-event-on-lock-origin + kind=station-passed', async () => {
+      logSuppressedPassedEventOnLockOrigin({ source: 'fg', stationName: '용마산' });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fg',
+        outcome: 'suppressed',
+        reason: 'gate-passed-event-on-lock-origin',
         stationName: '용마산',
         kind: 'station-passed',
       });

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -126,6 +126,13 @@ export type AlarmLogReason =
   // candidate=0을 허용해 "출발역 도착" false fire 발생. lock 활성 trip은 본 가드 미적용
   // (boardingStationId 기준 startStation 진행 알림은 정당 — ADR-014 §4 동급 보장).
   | 'gate-origin-hop-lockless'
+  // #1599 — boardingLock active 상태에서 candidate stationId가 lock.boardingStationId와 일치할 때
+  // 차단된 station-passed 발사. 2026-06-20 용마산 evidence: lock 활성 1초 후 lock origin
+  // 자체에 station-passed 발사 → 사용자는 출발도 안 했는데 "용마산 통과" 알람 (X1 wrong-station-alarm).
+  // 본 가드는 #1596(autoLock multi-signal consensus)이 머지될 때까지 band-aid — origin = 출발역,
+  // 출발역에서 출발하면 첫 station-passed 대상은 "다음 역"이지 origin 자체가 아님. lock 없는 trip
+  // (lockless)에는 영향 X — 그 케이스는 'gate-origin-hop-lockless'가 담당.
+  | 'gate-passed-event-on-lock-origin'
   // #1012 (H5) — useStationAlarm hydration state machine 각 phase 진입 stamp.
   // pre-hydrate → hydrating → storage-synced → ready 4단계. 'ready' 전 phase에서는
   // 모든 phase 알람 발사가 보류된다. transition 한 번에 1엔트리 적재 — 운영에서 phase
@@ -936,6 +943,31 @@ export function logSuppressedOriginHopLockless(input: {
     source: input.source,
     outcome: 'suppressed',
     reason: 'gate-origin-hop-lockless',
+    stationName: input.stationName,
+    kind: 'station-passed',
+  });
+}
+
+/**
+ * #1599 — boardingLock active 상태에서 candidate stationId === lock.boardingStationId일 때
+ * station-passed 발사 1건 차단 적재. #1596(autoLock multi-signal consensus) 머지 전까지 band-aid.
+ *
+ * 2026-06-20 용마산 evidence: lock 활성 1초 후 lock origin (= boardingStationId) 자체에
+ * station-passed fire → "출발도 안 했는데 통과 알람"(X1). lock origin은 사용자가 직접 탭한
+ * 출발역이므로 station-passed의 의미상 첫 대상이 될 수 없다 (출발역에서 출발 → 다음 역이 첫 hop).
+ *
+ * 호출자는 lock 활성(lock !== null)이며 candidate.id === lock.boardingStationId일 때만 호출.
+ * lockless 케이스는 'gate-origin-hop-lockless'(#1514)가 별도 담당.
+ */
+export function logSuppressedPassedEventOnLockOrigin(input: {
+  source: AlarmLogSource;
+  stationName: string;
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: input.source,
+    outcome: 'suppressed',
+    reason: 'gate-passed-event-on-lock-origin',
     stationName: input.stationName,
     kind: 'station-passed',
   });


### PR DESCRIPTION
## Summary

`runSilenceGateAndDispatch` 진입 시 1줄 가드 추가 — `boardingLock` 활성 + `candidate.id === lock.boardingStationId`이면 station-passed 차단. 모든 다른 gate(sleep / silence / hop window / dedup) 위에 위치.

Closes #1599

## 배경

#1596 (autoLock multi-signal consensus, 1-2주 작업)의 즉시 safety net (band-aid).

### 2026-06-20 evidence (issue #1599 본문)
- boardingLock active **1초 후** lock origin (용마산) 자체에 station-passed fire
- 사용자는 출발도 안 했는데 "용마산 통과" 알람 = **X1 wrong-station-alarm**

### 논리
- lock origin = "출발역"
- 출발역에서 출발 → 첫 station-passed 대상은 **다음 역**
- origin 자체는 station-passed 발사 대상이 될 수 없음

### ADR-014 §4 재해석
기존 `lock 활성 시 boardingStationId 기준 startStation 진행 알림은 정당` 가정은 device evidence(2026-06-20 용마산)로 반증됨. #1596 머지 시까지 본 가드가 false positive 차단. #1596 머지 후 본 가드가 redundant인지 follow-up 검토 (issue 본문에 명시).

---

## Wire-completion 5단 체크

- [x] **1. Orphan 없음** — `npm run lint:orphan` pass. 신규 export `logSuppressedPassedEventOnLockOrigin`는 `useStationAlarm.ts`에서 호출.
- [x] **2. V/X dashboard** — `gate-passed-event-on-lock-origin` reason은 DebugModal Gates/Counters 섹션이 `summarizeAlarmLogByReason` / `summarizeAlarmLogCounters`로 자동 집계 (별도 wire 불필요).
- [x] **3. 의존 PR** — N/A (단일 PR 자체완결).
- [x] **4. 측정 plan** — DebugModal 'Counters' 섹션에서 `gate-passed-event-on-lock-origin` 카운트가 1주 안에 증가하면 false positive 차단 evidence. share dump alarmLog ring buffer에 reason stamp.
- [x] **5. Device verify** — 사용자 실기기 검증 권장. 시나리오: 정적 사용자가 boardingLock 활성 후 1-5초 내 station-passed 알람이 안 와야 함 (용마산 evidence 재현 0건).

### V/X dashboard URL

DebugModal → Counters 섹션 → reason='gate-passed-event-on-lock-origin' 카운트.

### 의존 PR

N/A.

---

## Test plan

- [x] `npm test` 신규/수정 테스트 pass + 영향 영역(`src/features/alarm/`) 100% coverage 유지 (alarmLog.ts: 100/100/100/100, useStationAlarm.ts: 100/100/100/100)
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass
- [x] **신규 unit (1건):** `#1599 logSuppressedPassedEventOnLockOrigin: reason=gate-passed-event-on-lock-origin + kind=station-passed` (alarmLog.test.ts)
- [x] **업데이트 unit (4건, lock active + candidate=boardingStation suppress 검증):**
  - `#1599 band-aid — lock 활성 + currentHopIndex=0 + candidate arc[0] (= boardingStationId) → 차단 (passed-event-on-lock-origin)` (lock active + origin stationId 일치 → suppress)
  - `FG GPS path — lock 활성 + sleep ON + candidate=boardingStation → #1599 lock-origin 가드로 차단 (sleep gate 전)` (lock-origin이 sleep gate보다 위)
  - `FG arvlCd fast path — lock 활성 + sleep ON + candidate=boardingStation → #1599 lock-origin 가드로 차단 (sleep gate 전)`
  - `FG arvlCd fast path — sleep OFF + lock 활성 + first hop → #1599 lock-origin 가드로 차단`
- [x] **기존 회귀 가드 보존 (회귀 0건):**
  - `FG GPS path — sleep ON + lock 활성 + candidate≠boardingStation → 정상 발사` (lock active + 다른 stationId → 정상)
  - `lockless + currentHopIndex=0 + candidate arc[1]` / `lockless + currentHopIndex=2 + candidate arc[2]` (lock 없음 → 정상)

---

## #1596와의 관계

- #1596 = autoLock multi-signal consensus (1-2주 작업) — lock 발사 전 multi-signal consensus로 잘못된 lock 생성 차단
- 본 PR = 잘못 생성된 lock의 origin에서 발사되는 station-passed만 차단 (즉시 safety net)
- #1596 머지 후: 본 가드 redundant 여부 검토 (issue 본문 명시)

## 변경 줄 수

- 핵심 코드 변경: **+12 lines** (`useStationAlarm.ts` 9 lines guard + 3 lines 주석) + **+1 line** import
- alarmLog 신규 reason + 함수: **+32 lines** (`alarmLog.ts`)
- 테스트 추가/갱신: **+93 / -14 lines**

## Dump evidence

- DebugModal alarmLog ring buffer에 `gate-passed-event-on-lock-origin` reason stamp 1건/차단
- Counters 섹션 자동 집계 (reason union 추가만으로 wire 완료)