### PR TITLE
fix(#1597): M2 trip ground-truth prompt timing — trip 종료 시만 fire

### DIFF
--- a/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
@@ -39,6 +39,17 @@ jest.mock('../../api/signalDumpBackend', () => ({
   flushSignalDumpOutbox: (...args: unknown[]) => mockFlushSignalDumpOutbox(...args),
 }));
 
+// #1597 — trip 종료 ended 경로에서 cleanup 직전에 corrId snapshot 캡처 + cleanup 후 prompt enqueue.
+const mockGetCurrentTripCorrIdSync = jest.fn(() => null);
+jest.mock('../../../observability/utils/tripCorrId', () => ({
+  getCurrentTripCorrIdSync: () => mockGetCurrentTripCorrIdSync(),
+}));
+const mockTriggerTripGroundTruthPrompt = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../debug/utils/triggerTripGroundTruthPrompt', () => ({
+  triggerTripGroundTruthPrompt: (...args: unknown[]) =>
+    mockTriggerTripGroundTruthPrompt(...args),
+}));
+
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),

--- a/src/features/alarm/hooks/useLaunchTripReconciliation.ts
+++ b/src/features/alarm/hooks/useLaunchTripReconciliation.ts
@@ -48,6 +48,8 @@ import { fetchTripStatus } from '../api/tripStatus';
 import { triggerTripEndRecall } from '../utils/triggerTripEndRecall';
 import { runTripBoundCleanups } from '../store/tripBoundCleanups';
 import { flushSignalDumpOutbox } from '../api/signalDumpBackend';
+import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
+import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
 import { createLogger } from '../../../shared/utils/logger';
 
 const logger = createLogger('useLaunchTripReconciliation');
@@ -121,7 +123,11 @@ export async function runLaunchTripReconciliation(): Promise<void> {
     // recall은 cleanup이 storage를 비우기 전에 호출되어야 입력을 읽을 수 있다.
     // 두 호출 모두 멱등 — silent push handler와 중복 호출 안전.
     await triggerTripEndRecall();
+    // #1597 — clearTripCorrId가 cache를 비우기 전에 종료된 trip의 corrId snapshot 캡처.
+    const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
     await runTripBoundCleanups();
+    // #1597 — trip-end 사용자 정답지 prompt enqueue (cleanup 후, corrId snapshot으로).
+    await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
     await setTripEndedSentinel(endedAt);
     await AsyncStorage.removeItem(ACTIVE_TRIP_KEY);
   } catch (e) {

--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -411,7 +411,10 @@ describe('tripBoundCleanups', () => {
       //
       // #1545 (S12) 이전: 22 항목. S12에서 4 신규 + #1573 (T10) clearBackendSsotMirror 1 신규.
       // 일부 항목은 BG-only 메모리/dedup이라 storage write 없이도 효력 있음.
-      const MIN_ITEMS = 26;
+      // #1597 — triggerTripGroundTruthPrompt 제거 (trip-start 경로에서 false fire 회귀 차단).
+      // 종료-only trigger이므로 4 trip-end 호출 경로(setDestination switch/silentPushTask trip-ended/
+      // useLaunchTripReconciliation/useStateRehydration sentinel+force-end)에서 명시 호출.
+      const MIN_ITEMS = 25;
       expect(TRIP_BOUND_CLEANUPS.length).toBeGreaterThanOrEqual(MIN_ITEMS);
     });
   });
@@ -433,9 +436,8 @@ describe('tripBoundCleanups', () => {
     // resetAlarmBackendDedup / clearTripBoundStoreMemory)은 storage write를 하지 않는
     // module-level/memory 클리어라 removeItem 카운트에 기여하지 않는다. 신규 항목 수만큼
     // 임계값을 낮춰 기존 invariant(storage 기반 항목 모두 실행)는 유지.
-    // #1502 (M2) — triggerTripGroundTruthPrompt는 zustand setState만 수행 (storage는
-    // AsyncStorage.setItem이라 removeItem 카운트와 무관) → NON_STORAGE 5로 증가.
-    const NON_STORAGE_CLEANUPS = 5;
+    // #1597 — triggerTripGroundTruthPrompt 제거로 NON_STORAGE 5→4.
+    const NON_STORAGE_CLEANUPS = 4;
     expect((AsyncStorage.removeItem as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(
       TRIP_BOUND_CLEANUPS.length - NON_STORAGE_CLEANUPS,
     );

--- a/src/features/alarm/store/__tests__/tripBoundCleanupsAudit.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanupsAudit.test.ts
@@ -225,24 +225,21 @@ describe('#1545 (S12) — TRIP_BOUND_CLEANUPS enumeration audit', () => {
     expect(TRIP_BOUND_CLEANUPS).toContain(resetAlarmBackendDedup);
   });
 
-  it('baseline 26 항목(기존 25 + #1502 ground-truth trigger 1)에서 줄어들면 회귀', () => {
+  it('baseline 25 항목에서 줄어들면 회귀 (#1597 ground-truth trigger 제거 후)', () => {
     const { TRIP_BOUND_CLEANUPS } = jest.requireActual('../tripBoundCleanups');
-    // 현재 baseline. 새 항목 추가 시 한 줄 갱신. 누군가 항목을 의도치 않게 제거하면 회귀로 감지.
-    expect(TRIP_BOUND_CLEANUPS.length).toBeGreaterThanOrEqual(26);
+    // #1597 — triggerTripGroundTruthPrompt 제거(trip-start 회귀 차단). 종료-only trigger이므로
+    // 4 trip-end 호출 경로(setDestination switch/silentPushTask trip-ended/
+    // useLaunchTripReconciliation/useStateRehydration sentinel+force-end)에서 명시 호출.
+    expect(TRIP_BOUND_CLEANUPS.length).toBeGreaterThanOrEqual(25);
   });
 
-  it('#1502 (M2) ground truth prompt trigger가 등록돼 있고 clearTripCorrId보다 앞에 있다', () => {
+  it('#1597 (regression guard) — ground truth prompt trigger는 TRIP_BOUND_CLEANUPS에 포함되지 않는다 (trip-start 경로 false fire 차단)', () => {
+    // 누군가 실수로 다시 cleanup 배열에 추가하면 trip 시작 직후 prompt가 노출되는 회귀가 재발한다.
+    // trip-end 경로에서만 명시 호출되어야 한다.
     const { TRIP_BOUND_CLEANUPS } = jest.requireActual('../tripBoundCleanups');
     const { triggerTripGroundTruthPrompt } = jest.requireActual(
       '../../../debug/utils/triggerTripGroundTruthPrompt',
     );
-    const { clearTripCorrId } = jest.requireActual('../../../observability/utils/tripCorrId');
-    const triggerIdx = TRIP_BOUND_CLEANUPS.indexOf(triggerTripGroundTruthPrompt);
-    const clearIdx = TRIP_BOUND_CLEANUPS.indexOf(clearTripCorrId);
-    expect(triggerIdx).toBeGreaterThanOrEqual(0);
-    expect(clearIdx).toBeGreaterThanOrEqual(0);
-    // 본 순서가 깨지면 prompt trigger가 corrId=null을 읽고 graceful skip되어 모든 trip 종료가
-    // ground truth 미수집 회귀. 코드 리뷰에서 의도 확인 강제.
-    expect(triggerIdx).toBeLessThan(clearIdx);
+    expect(TRIP_BOUND_CLEANUPS).not.toContain(triggerTripGroundTruthPrompt);
   });
 });

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -39,7 +39,6 @@ import {
   getRegisteredTripRouteSig,
 } from '../utils/tripBoundScheduler';
 import { clearTripCorrId } from '../../observability/utils/tripCorrId';
-import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
 import { clearBackendSsotMirror } from '../utils/backendSsotMirror';
 import { clearCrossCategoryDedup } from '../utils/crossCategoryStationDedup';
 import { clearAlarmLogWindows } from '../utils/alarmLog';
@@ -117,10 +116,6 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   // 새 trip 분모에 섞이는 회귀 차단. LAST_UPLOADED_PRESCHEDULED_TRIP_START_KEY는 recall과
   // 같은 이유로 보존 (tripStart값으로 자연 무효화).
   clearPrescheduledLedger,
-  // #1502 (M2) — trip 종료 직후 사용자 정답지 prompt enqueue. clearTripCorrId보다 앞에 두어
-  // trigger가 동기 첫 줄에서 corrId를 캡처할 수 있게 한다 (cleanup map은 parallel-fired지만
-  // 동기 cache read는 순서대로 실행됨). corrId 부재면 graceful skip.
-  triggerTripGroundTruthPrompt,
   // #1501 (ADR-015 §10 P5 / PR-A) — trip 종료 시 corrId 제거. 다음 trip은 새 corrId를
   // 받고 rawSignalBuffer entry가 어느 trip 소속인지 명확해진다.
   clearTripCorrId,

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -56,6 +56,17 @@ jest.mock('../../utils/triggerTripEndRecall', () => ({
   triggerTripEndRecall: (...args: unknown[]) => mockTriggerTripEndRecall(...args),
 }));
 
+// #1597 — trip-ended 경로에서 cleanup 직전에 corrId snapshot 캡처 + cleanup 후 prompt enqueue.
+const mockGetCurrentTripCorrIdSync = jest.fn(() => null);
+jest.mock('../../../observability/utils/tripCorrId', () => ({
+  getCurrentTripCorrIdSync: () => mockGetCurrentTripCorrIdSync(),
+}));
+const mockTriggerTripGroundTruthPrompt = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../debug/utils/triggerTripGroundTruthPrompt', () => ({
+  triggerTripGroundTruthPrompt: (...args: unknown[]) =>
+    mockTriggerTripGroundTruthPrompt(...args),
+}));
+
 const mockCheckGate = jest.fn();
 jest.mock('../../utils/silentPushLocationGate', () => ({
   checkSilentPushLocationGate: (...args: unknown[]) => mockCheckGate(...args),

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -53,6 +53,8 @@ import {
 import { runTripBoundCleanups, cancelTripBoundOsQueue } from '../store/tripBoundCleanups';
 import { setTripEndedSentinel } from '../utils/tripEndedSentinel';
 import { triggerTripEndRecall } from '../utils/triggerTripEndRecall';
+import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
+import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
 import { evaluateDismissSilence } from '../utils/dismissSilenceGate';
 import { clearDismissSilence, getDismissSilence } from '../utils/dismissSilenceStorage';
 import { evaluateMovement, MOVEMENT_TO_ALARM_LOG_REASON } from '../../nearest-station/utils/movementGate';
@@ -835,7 +837,11 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
       // ROUTE_KEY/DESTINATION_KEY/TRIP_STARTED_AT_KEY를 읽어 routeStops를 구성하기 때문.
       // trigger는 throw하지 않으므로 후속 cleanup/sentinel 흐름 차단 없음.
       await triggerTripEndRecall();
+      // #1597 — clearTripCorrId가 cache를 비우기 전에 종료된 trip의 corrId snapshot 캡처.
+      const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
       await runTripBoundCleanups();
+      // #1597 — trip-end 사용자 정답지 prompt enqueue (cleanup 후, corrId snapshot으로).
+      await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
       // #899 (Seam C) — BG에서는 zustand store에 접근 불가. FG 복귀 시점에
       // useStateRehydration이 이 sentinel을 보고 destination/lock store도 reset.
       await setTripEndedSentinel(receivedAt);

--- a/src/features/debug/components/TripGroundTruthPrompt.tsx
+++ b/src/features/debug/components/TripGroundTruthPrompt.tsx
@@ -15,8 +15,10 @@ const THANKS_AUTO_CLOSE_MS = 1500;
  * `useTripGroundTruthStore.pendingPrompt`가 non-null인 동안 modal로 자동 노출.
  * 사용자가 [좋았어요]/[틀린 알람] 응답 또는 [나중에] dismiss하면 store 갱신.
  *
- * trigger source = `TRIP_BOUND_CLEANUPS`의 `triggerTripGroundTruthPrompt` — 모든 trip 종료
- * 경로(FG setDestination(null/switch) + BG silent push trip-ended) 양쪽 자동 enqueue.
+ * trigger source = `triggerTripGroundTruthPrompt(corrIdSnapshot)` — 4 trip-end 경로에서
+ * 명시 호출(FG setDestination(prev !== null) switch / BG silent push trip-ended /
+ * useLaunchTripReconciliation cold-launch / useStateRehydration sentinel+force-end).
+ * #1597 — TRIP_BOUND_CLEANUPS 배열에서 분리. trip 시작 시 false fire 회귀 차단.
  * issue 본문 정책: dismiss 후에도 다음 trip 종료 시 다시 노출 (one-time opt-out X).
  *
  * 본 컴포넌트는 cross-feature observer로서 DebugModal과 분리 — DebugModal 토글과 무관하게

--- a/src/features/debug/utils/__tests__/triggerTripGroundTruthPrompt.test.ts
+++ b/src/features/debug/utils/__tests__/triggerTripGroundTruthPrompt.test.ts
@@ -1,9 +1,12 @@
 /**
- * Trip ground truth trigger (#1502 M2) — TRIP_BOUND_CLEANUPS 호출 시점에 corrId 캡처 검증.
+ * Trip ground truth trigger (#1502 M2, #1597 fix).
+ *
+ * #1597 — 호출자가 corrId를 명시적으로 캡처해서 전달하도록 signature 변경. trip-start
+ * 경로에서 false fire되는 회귀(setTripCorrId가 sync cache를 덮어쓴 뒤 cleanup chain이 돌아
+ * 새 corrId로 enqueue됨)를 근본 차단.
  */
 import { triggerTripGroundTruthPrompt } from '../triggerTripGroundTruthPrompt';
 import { useTripGroundTruthStore } from '../../store/useTripGroundTruthStore';
-import * as tripCorrId from '../../../observability/utils/tripCorrId';
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn().mockResolvedValue(null),
@@ -11,7 +14,7 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   removeItem: jest.fn().mockResolvedValue(undefined),
 }));
 
-describe('triggerTripGroundTruthPrompt (#1502 M2)', () => {
+describe('triggerTripGroundTruthPrompt (#1502 M2 / #1597)', () => {
   beforeEach(() => {
     useTripGroundTruthStore.setState({
       hydrated: true,
@@ -21,29 +24,27 @@ describe('triggerTripGroundTruthPrompt (#1502 M2)', () => {
   });
 
   it('corrId가 null이면 prompt enqueue X (graceful skip)', async () => {
-    jest.spyOn(tripCorrId, 'getCurrentTripCorrIdSync').mockReturnValue(null);
-    await triggerTripGroundTruthPrompt();
+    await triggerTripGroundTruthPrompt(null);
     expect(useTripGroundTruthStore.getState().pendingPrompt).toBeNull();
   });
 
-  it('corrId가 있으면 동기 캡처 후 enqueue', async () => {
-    jest.spyOn(tripCorrId, 'getCurrentTripCorrIdSync').mockReturnValue('trip-abc');
+  it('corrId가 있으면 enqueue', async () => {
     jest.spyOn(Date, 'now').mockReturnValue(12345);
-    await triggerTripGroundTruthPrompt();
+    await triggerTripGroundTruthPrompt('trip-abc');
     expect(useTripGroundTruthStore.getState().pendingPrompt).toEqual({
       corrId: 'trip-abc',
       endedAt: 12345,
     });
   });
 
-  it('clearTripCorrId가 같은 batch에서 cache를 비워도 트리거가 먼저 호출되면 corrId 캡처 보존', async () => {
-    // 시뮬레이션: triggerTripGroundTruthPrompt 첫 줄이 sync read하므로
-    // 이후 clearTripCorrId가 실행돼도 캡처값은 유지된다.
-    jest.spyOn(tripCorrId, 'getCurrentTripCorrIdSync').mockReturnValue('trip-xyz');
-    const triggerPromise = triggerTripGroundTruthPrompt();
-    // trigger 호출 시점 직후 cache를 비워본다.
-    jest.spyOn(tripCorrId, 'getCurrentTripCorrIdSync').mockReturnValue(null);
-    await triggerPromise;
-    expect(useTripGroundTruthStore.getState().pendingPrompt?.corrId).toBe('trip-xyz');
+  it('#1597 — 호출자가 캡처한 snapshot이 그대로 enqueue된다 (cache mutation과 무관)', async () => {
+    // setDestination switch 경로에서 setTripCorrId(new)가 동기적으로 sync cache를 덮어써도
+    // 호출자가 미리 snapshot을 캡처해서 넘기면 그 값이 보존된다 (read 시점 race 차단).
+    jest.spyOn(Date, 'now').mockReturnValue(99999);
+    const snapshot = 'prev-trip-corr-id';
+    // snapshot 캡처 후 다른 corrId로 cache가 바뀐 상황을 시뮬레이션해도 (본 함수는 sync cache를
+    // 더 이상 읽지 않으므로) snapshot 값이 그대로 사용된다.
+    await triggerTripGroundTruthPrompt(snapshot);
+    expect(useTripGroundTruthStore.getState().pendingPrompt?.corrId).toBe(snapshot);
   });
 });

--- a/src/features/debug/utils/triggerTripGroundTruthPrompt.ts
+++ b/src/features/debug/utils/triggerTripGroundTruthPrompt.ts
@@ -1,24 +1,24 @@
 /* eslint-disable import/no-restricted-paths --
- * Cross-feature orchestration: debug feature가 trip 종료 시점 trigger를 노출하기 위해
- * observability(tripCorrId)에서 sync read한다. trip-bound cleanup orchestrator(alarm/store/
- * tripBoundCleanups.ts)에서 호출되는 entry-point이므로 본질적 cross-feature 의존.
+ * Cross-feature orchestration: debug feature가 trip 종료 경로에서 prompt enqueue trigger를
+ * 노출한다. setDestination(switch) / silentPushTask(trip-ended) / useLaunchTripReconciliation /
+ * useStateRehydration(sentinel/force-end) 4 종료 경로의 호출 entry-point이므로 본질적 cross-feature.
  */
 /**
  * Trip ground truth (#1502 M2) — trip 종료 시 사용자 정답지 prompt enqueue trigger.
  *
- * `TRIP_BOUND_CLEANUPS`에 등록되어 trip 종료 시 자동 호출. 호출 순서가 어디든 — `clearTripCorrId`
- * 전후 무관 — 본 함수는 **호출 즉시 동기**로 `getCurrentTripCorrIdSync()`를 읽어 corrId를
- * 캡처한 뒤 store에 enqueue한다. 이후 `clearTripCorrId`가 cache를 비워도 캡처 값은 그대로.
+ * #1597 fix: 호출자가 corrId를 명시적으로 캡처해서 전달한다. 과거에는 `TRIP_BOUND_CLEANUPS`
+ * 배열에 등록되어 sync cache(`getCurrentTripCorrIdSync`)에서 corrId를 read했지만, 같은 배열이
+ * trip 시작 경로(setDestination(null→station) switch)에서도 호출되며 `setTripCorrId(generateTripCorrId())`가
+ * 이미 새 corrId로 cache를 덮어쓴 뒤 cleanup chain microtask가 돌아 새 trip 시작과 동시에
+ * prompt가 fire되는 회귀가 발생했다 (사용자 보고 2026-06-20).
  *
- * corrId가 null이면(트립 미시작/이미 종료) graceful skip — prompt 미발사. 측정 가치가 없는
- * trip(corrId 없음)에 noise 응답이 섞이는 것 차단.
+ * 본 함수는 trip-end 경로에서만 호출된다. 호출자가 종료 시점의 corrId snapshot을 캡처해서
+ * 넘기면 trigger는 그 snapshot으로 enqueue한다. `corrId === null`이면 graceful skip — prompt
+ * 미발사 (측정 가치 없는 trip에 noise 응답 합류 차단).
  */
-import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
 import { useTripGroundTruthStore } from '../store/useTripGroundTruthStore';
 
-export async function triggerTripGroundTruthPrompt(): Promise<void> {
-  // 동기 read — clearTripCorrId가 같은 cleanup batch에서 cache를 비우기 전 캡처.
-  const corrId = getCurrentTripCorrIdSync();
+export async function triggerTripGroundTruthPrompt(corrId: string | null): Promise<void> {
   if (corrId === null) return;
   await useTripGroundTruthStore.getState().enqueuePrompt({
     corrId,

--- a/src/features/route/store/__tests__/useDestinationStore.test.ts
+++ b/src/features/route/store/__tests__/useDestinationStore.test.ts
@@ -25,10 +25,16 @@ jest.mock('../../../alarm/utils/triggerTripEndRecall', () => ({
   triggerTripEndRecall: jest.fn().mockResolvedValue({ uploaded: false }),
 }));
 // #1501 (PR-A) — trip 시작 시 corrId 생성 wiring 검증용 mock.
+// #1597 — getCurrentTripCorrIdSync는 setDestination이 setTripCorrId 호출 전 snapshot 캡처에 사용.
 jest.mock('../../../observability/utils/tripCorrId', () => ({
   generateTripCorrId: jest.fn(() => 'cid-test-1700000000000-deadbeef'),
   setTripCorrId: jest.fn().mockResolvedValue(undefined),
   clearTripCorrId: jest.fn().mockResolvedValue(undefined),
+  getCurrentTripCorrIdSync: jest.fn(() => null),
+}));
+// #1597 — trigger 호출 자체를 검증하기 위한 spy mock.
+jest.mock('../../../debug/utils/triggerTripGroundTruthPrompt', () => ({
+  triggerTripGroundTruthPrompt: jest.fn().mockResolvedValue(undefined),
 }));
 // expo-notifications mock — cancelTripBoundAlarms가 getAllScheduledNotificationsAsync()를
 // 호출하는데 native module이 undefined를 반환하면 `.map()`에서 process crash. 빈 큐로 graceful.
@@ -1080,6 +1086,77 @@ describe('useDestinationStore', () => {
         .clearCustomOriginForSsotOverride(mockStation2);
       expect(result).toBe(true);
       expect(useDestinationStore.getState().customOrigin).toBeNull();
+    });
+  });
+
+  // ── #1597 — Trip ground truth prompt timing 회귀 가드 ──
+  // 이슈: trip 시작 직후 prompt가 노출되는 회귀 (사용자 보고 2026-06-20).
+  // root cause: triggerTripGroundTruthPrompt가 TRIP_BOUND_CLEANUPS 배열에 있어
+  //   setDestination(null→station) switch 경로에서도 호출되며, setTripCorrId(generateTripCorrId())가
+  //   동기적으로 sync cache를 새 corrId로 덮어쓴 뒤 cleanup chain microtask가 돌아 새 corrId로
+  //   prompt가 enqueue됨.
+  // fix: trigger를 cleanup 배열에서 제거 + 4 trip-end 경로에서 명시 호출 + corrId snapshot을
+  //   호출자가 캡처해서 전달.
+  describe('#1597 ground truth prompt timing 회귀 가드', () => {
+    // 4 acceptance: start no-fire / end fire / 이미 응답한 trip no-fire / app boot no-fire.
+    // 검증은 spy mock된 triggerTripGroundTruthPrompt의 호출 횟수/인자.
+
+    /* eslint-disable @typescript-eslint/no-require-imports */
+    const triggerMock =
+      require('../../../debug/utils/triggerTripGroundTruthPrompt')
+        .triggerTripGroundTruthPrompt as jest.Mock;
+    const corrIdModule = require('../../../observability/utils/tripCorrId');
+    /* eslint-enable @typescript-eslint/no-require-imports */
+
+    beforeEach(() => {
+      triggerMock.mockClear();
+      triggerMock.mockResolvedValue(undefined);
+      // 기본 corrId snapshot — null (trip 미시작). 각 case에서 override.
+      corrIdModule.getCurrentTripCorrIdSync.mockReturnValue(null);
+    });
+
+    it('case 1 (start no-fire): 첫 trip 시작(prev=null → station) 시 trigger 호출 X', async () => {
+      // #1597 root cause 시나리오. prev=null 경로에서 prompt는 절대 fire되어선 안 된다.
+      useDestinationStore.setState({ destination: null });
+      // 새 trip 시작 시뮬레이션 — 새 corrId가 곧 setTripCorrId로 설정될 예정이지만,
+      // setDestination이 setTripCorrId 호출 *전* snapshot을 캡처해야 한다.
+      corrIdModule.getCurrentTripCorrIdSync.mockReturnValue(null);
+      useDestinationStore.getState().setDestination(mockStation);
+      await flushMicrotasks();
+      // prev === null이라 명시 분기로 trigger 호출 자체가 안 일어난다.
+      expect(triggerMock).not.toHaveBeenCalled();
+    });
+
+    it('case 2 (end fire): trip 종료(station → null) 시 trigger 1회 호출 + 종료된 trip의 corrId snapshot 전달', async () => {
+      // prev !== null AND snapshot은 종료될 trip의 corrId.
+      corrIdModule.getCurrentTripCorrIdSync.mockReturnValue('cid-prev-trip');
+      useDestinationStore.setState({ destination: mockStation });
+      useDestinationStore.getState().setDestination(null);
+      await flushMicrotasks();
+      expect(triggerMock).toHaveBeenCalledTimes(1);
+      expect(triggerMock).toHaveBeenCalledWith('cid-prev-trip');
+    });
+
+    it('case 3 (already-responded no-fire): cache가 비어있는 trip 종료(snapshot=null)는 trigger 호출돼도 prompt 미enqueue (graceful skip)', async () => {
+      // 사용자가 이전 prompt에 응답 → cache가 cleanup으로 비워진 상태에서 다음 trip-end 신호가
+      // 도달하더라도 snapshot=null → trigger 내부에서 graceful skip하므로 enqueue 안 됨.
+      // 본 invariant는 trigger 함수 자체의 단위 테스트(triggerTripGroundTruthPrompt.test.ts)에서도
+      // 검증되지만, setDestination 경로에서 snapshot=null이 그대로 전달되는지 한 번 더 확인.
+      corrIdModule.getCurrentTripCorrIdSync.mockReturnValue(null);
+      useDestinationStore.setState({ destination: mockStation });
+      useDestinationStore.getState().setDestination(null);
+      await flushMicrotasks();
+      expect(triggerMock).toHaveBeenCalledTimes(1);
+      expect(triggerMock).toHaveBeenCalledWith(null);
+    });
+
+    it('case 4 (app boot no-fire): app boot 자체로는 trigger 호출 안 됨 — 어떤 setDestination 호출도 없으면 prompt 미발사 (다음 trip 종료까지 보류)', async () => {
+      // store boot 시 storage 복원만 일어남. 어떤 setDestination 호출도 없으면 trigger도 호출 X.
+      // 이전 trip 미응답 pendingPrompt가 storage에 남아 있어도 store hydrate만 일어나며 trigger
+      // 자체는 호출되지 않는다 — 다음 trip 종료까지 보류.
+      useDestinationStore.setState({ destination: null }); // boot init state
+      await flushMicrotasks();
+      expect(triggerMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/route/store/useDestinationStore.ts
+++ b/src/features/route/store/useDestinationStore.ts
@@ -19,8 +19,13 @@ import {
 import { RECENT_ROUTES_LIMIT } from '../../../shared/constants/recentDestinations';
 import { runTripBoundCleanups } from '../../alarm/store/tripBoundCleanups';
 import { setTripStartedAt } from '../../alarm/utils/tripStartStorage';
-import { generateTripCorrId, setTripCorrId } from '../../observability/utils/tripCorrId';
+import {
+  generateTripCorrId,
+  getCurrentTripCorrIdSync,
+  setTripCorrId,
+} from '../../observability/utils/tripCorrId';
 import { triggerTripEndRecall } from '../../alarm/utils/triggerTripEndRecall';
+import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
 import { useAlarmEventStore } from '../../alarm/store/useAlarmEventStore';
 import { ROUTE_CATEGORIES, type RoutePreference } from '../../../shared/utils/stationRoute';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
@@ -175,6 +180,10 @@ export const useDestinationStore = create<DestinationState>((set, get) => ({
       //    LAST_FIRED_ALARM_STATION_NAME_KEY, #746 dismissSilence 등 누락 사례 재발 방지.)
       // 3) 새 trip(station != null)이면 새 tripStart를 기록 — cleanup이 직전에 이전 키를 제거했으니
       //    여기서 set하면 다음 trip 측정 가능. station === null(trip 종료) 경로에서는 set 안 함.
+      // #1597 — prev trip의 corrId snapshot. setTripCorrId가 sync cache를 새 값으로 덮어쓰기 전
+      // 캡처해 trip-end prompt가 올바른 (종료된) trip의 corrId로 enqueue되게 한다. prev === null
+      // (첫 trip 시작) 경로에서는 snapshot도 null → prompt graceful skip.
+      const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
       // #1321 — delete→recreate race 차단: tripTransitionQueue에 chain해 직렬화한다.
       // 직전 transition(예: delete)의 cleanup이 완전히 끝난 뒤에야 이번 transition(예: recreate)의
       // cleanup + setTripStartedAt이 시작된다.
@@ -182,6 +191,13 @@ export const useDestinationStore = create<DestinationState>((set, get) => ({
         .then(() => triggerTripEndRecall())
         .catch(noop)
         .then(() => runTripBoundCleanups())
+        .catch(noop)
+        // #1597 — cleanup 후, 새 trip의 storage write 전에 ground-truth prompt enqueue.
+        // prev trip이 실제로 종료된 경우(prev !== null)에만 fire. 첫 trip 시작(prev === null)
+        // 시 snapshot은 null이라 trigger 내부에서 graceful skip되지만 명시적 분기로 의도를 분명히 함.
+        .then(() =>
+          prev !== null ? triggerTripGroundTruthPrompt(endedCorrIdSnapshot) : undefined,
+        )
         .catch(noop)
         // #1379 — cleanup이 DESTINATION_KEY를 removeItem한 뒤 새 trip의 destination을 write.
         // 분기 순서를 직렬화해 storage 최종 상태가 station(new trip) 또는 null(end)으로 결정적.
@@ -198,6 +214,7 @@ export const useDestinationStore = create<DestinationState>((set, get) => ({
       // chain 밖 fire-and-forget — setTripCorrId가 sync cache를 즉시 갱신해 fusion cycle 다음
       // cycle부터 새 corrId 보장. AsyncStorage write는 백그라운드 (storage 실패는 graceful).
       // station === null(trip 종료) 경로에서는 tripBoundCleanups가 clearTripCorrId를 처리.
+      // #1597 — 위에서 prev corrId snapshot을 미리 캡처했으므로 여기서 새 corrId로 덮어써도 안전.
       if (station) {
         void setTripCorrId(generateTripCorrId());
       }

--- a/src/shared/hooks/__tests__/useStateRehydration.test.ts
+++ b/src/shared/hooks/__tests__/useStateRehydration.test.ts
@@ -50,6 +50,17 @@ jest.mock('../../../features/alarm/store/tripBoundCleanups', () => ({
   runTripBoundCleanups: (...args: unknown[]) => mockRunTripBoundCleanups(...args),
 }));
 
+// #1597 — sentinel + force-end 경로에서 cleanup 직전 corrId snapshot 캡처 + cleanup 후 prompt enqueue.
+const mockGetCurrentTripCorrIdSync = jest.fn(() => null);
+jest.mock('../../../features/observability/utils/tripCorrId', () => ({
+  getCurrentTripCorrIdSync: () => mockGetCurrentTripCorrIdSync(),
+}));
+const mockTriggerTripGroundTruthPrompt = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../features/debug/utils/triggerTripGroundTruthPrompt', () => ({
+  triggerTripGroundTruthPrompt: (...args: unknown[]) =>
+    mockTriggerTripGroundTruthPrompt(...args),
+}));
+
 // destination store cross-feature import는 storage helper 안에서 일어나므로 spy로 충분.
 // useDestinationStore.getState()를 그대로 사용한다 (실제 store)
 

--- a/src/shared/hooks/useStateRehydration.ts
+++ b/src/shared/hooks/useStateRehydration.ts
@@ -24,6 +24,8 @@ import {
   clearBackendSsotMirror,
   readBackendSsotMirror,
 } from '../../features/alarm/utils/backendSsotMirror';
+import { getCurrentTripCorrIdSync } from '../../features/observability/utils/tripCorrId';
+import { triggerTripGroundTruthPrompt } from '../../features/debug/utils/triggerTripGroundTruthPrompt';
 import { createLogger } from '../utils/logger';
 import { addDomainBreadcrumb } from '../infra/monitoring/breadcrumb';
 
@@ -72,7 +74,11 @@ async function runRehydration(trigger: 'mount' | 'active'): Promise<void> {
     // isSwitch=false로 평가되어 cleanup chain이 실행되지 않는 버그가 있었다.
     // isSwitch 의존 없이 storage cleanup을 직접 호출. 멱등이므로 Fix 1 / silent push handler와
     // 중복 호출 안전. 메모리 store도 setState로 즉시 reset해 stale state가 노출되지 않게 한다.
+    // #1597 — clearTripCorrId가 cache를 비우기 전에 종료된 trip의 corrId snapshot 캡처.
+    const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
     await runTripBoundCleanups();
+    // #1597 — trip-end 사용자 정답지 prompt enqueue (cleanup 후, corrId snapshot으로).
+    await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
     useDestinationStore.setState({
       destination: null,
       customOrigin: null,
@@ -170,7 +176,11 @@ async function runLifecycleBackstop(trigger: 'mount' | 'active'): Promise<void> 
       reason: 'trip-lifecycle-force-ended',
     });
     logger.info(`trigger=${trigger} force-end elapsedMs=${elapsedMs} → cleanup`);
+    // #1597 — clearTripCorrId가 cache를 비우기 전에 종료된 trip의 corrId snapshot 캡처.
+    const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
     await runTripBoundCleanups();
+    // #1597 — trip-end 사용자 정답지 prompt enqueue (cleanup 후, corrId snapshot으로).
+    await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
     useDestinationStore.setState({
       destination: null,
       customOrigin: null,


### PR DESCRIPTION
Closes #1597

## 회귀 (사용자 직접 보고 2026-06-20)

trip 시작 직후 ground-truth prompt가 표시됨. 의도: trip 종료 시만 1회 노출.

## Root cause (1줄)

`triggerTripGroundTruthPrompt`가 `TRIP_BOUND_CLEANUPS` 배열에 등록되어 `setDestination(prev=null → station)` switch 경로(=trip 시작)에서도 호출되며, `setTripCorrId(generateTripCorrId())`가 동기적으로 sync cache를 새 corrId로 덮어쓴 뒤 cleanup chain microtask가 돌아 새 trip의 corrId로 prompt가 enqueue됨.

### 코드 위치 (수정 전)

- `src/features/alarm/store/tripBoundCleanups.ts:123` — `triggerTripGroundTruthPrompt`가 `TRIP_BOUND_CLEANUPS` 배열에 포함
- `src/features/route/store/useDestinationStore.ts:202` — `void setTripCorrId(generateTripCorrId())` 동기 호출이 chain microtask 전에 cache를 덮어씀
- `src/features/debug/utils/triggerTripGroundTruthPrompt.ts:21` — `getCurrentTripCorrIdSync()` sync read로 race 의존

## Fix

1. `triggerTripGroundTruthPrompt`를 `TRIP_BOUND_CLEANUPS`에서 제거 (trip 시작 경로 false fire 차단).
2. 4 trip-end 경로에서 명시 호출 + corrId snapshot 캡처:
   - `setDestination` switch: `getCurrentTripCorrIdSync()`를 `setTripCorrId` 호출 *전*에 캡처, chain 안 `prev !== null` 분기에서 trigger 호출.
   - `silentPushTask` trip-ended handler: cleanup 직전 snapshot 캡처 → cleanup 후 trigger 호출.
   - `useLaunchTripReconciliation` ended branch: 동일 패턴.
   - `useStateRehydration` sentinel + force-end: 동일 패턴.
3. `triggerTripGroundTruthPrompt`의 signature를 `(corrId: string | null) => Promise<void>`로 변경 — 호출자가 snapshot을 명시 전달.
4. Audit 테스트(`tripBoundCleanupsAudit.test.ts`)에 회귀 가드 추가 — `TRIP_BOUND_CLEANUPS`에 trigger가 포함되지 않음을 negative invariant로 단언.

## Acceptance 테스트 4건 (모두 PASS)

`src/features/route/store/__tests__/useDestinationStore.test.ts > #1597 ground truth prompt timing 회귀 가드`:

- **case 1 (start no-fire)**: 첫 trip 시작(prev=null → station) 시 trigger 호출 X.
- **case 2 (end fire)**: trip 종료(station → null) 시 trigger 1회 호출 + 종료된 trip의 corrId snapshot 전달.
- **case 3 (already-responded no-fire)**: cache가 비어있는 trip 종료(snapshot=null)는 trigger 호출돼도 prompt 미enqueue (graceful skip).
- **case 4 (app boot no-fire)**: app boot 자체로는 trigger 호출 안 됨 — 어떤 setDestination 호출도 없으면 prompt 미발사 (다음 trip 종료까지 보류).

추가 단위 테스트: `triggerTripGroundTruthPrompt.test.ts` — null snapshot graceful skip / corrId snapshot 그대로 enqueue / cache mutation과 무관.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — DebugModal `TripGroundTruthPrompt`가 trip 종료 시 자동 노출. 응답은 `useTripGroundTruthStore.responses`에 누적 → P0-3 telemetry payload에 합류.
3. **의존 PR** — N/A (단독 fix).
4. **측정 plan** — 사용자 1주 실기기 trip × N건, 시작 시 prompt 미노출 + 종료 시 1회 노출 확인. share dump에서 `tripGroundTruth.responses` count vs 종료 trip count 비교 (1:1 매핑).
5. **Device verify** — 필요. 시나리오: (a) 첫 trip 시작 → prompt 미노출, (b) trip 종료(자동 도착/사용자 clear/destination switch) → prompt 1회, (c) 응답 후 같은 corrId로 재노출 X, (d) cold launch 시 미응답 evidence 있어도 prompt 자동 노출 X.

## 변경 파일

production (6):
- `src/features/debug/utils/triggerTripGroundTruthPrompt.ts` — signature 변경 (corrId 명시 인자).
- `src/features/alarm/store/tripBoundCleanups.ts` — TRIP_BOUND_CLEANUPS에서 제거.
- `src/features/route/store/useDestinationStore.ts` — snapshot 캡처 + chain 안에서 명시 호출.
- `src/features/alarm/tasks/silentPushTask.ts` — trip-ended handler에서 명시 호출.
- `src/features/alarm/hooks/useLaunchTripReconciliation.ts` — ended branch에서 명시 호출.
- `src/shared/hooks/useStateRehydration.ts` — sentinel + force-end에서 명시 호출.
- `src/features/debug/components/TripGroundTruthPrompt.tsx` — 헤더 주석 업데이트.

tests (7):
- `src/features/debug/utils/__tests__/triggerTripGroundTruthPrompt.test.ts` — signature 변경 반영.
- `src/features/alarm/store/__tests__/tripBoundCleanups.test.ts` — MIN_ITEMS 26→25, NON_STORAGE 5→4.
- `src/features/alarm/store/__tests__/tripBoundCleanupsAudit.test.ts` — 회귀 가드(negative invariant) 추가.
- `src/features/route/store/__tests__/useDestinationStore.test.ts` — 4 acceptance 추가 + mock 갱신.
- `src/features/alarm/tasks/__tests__/silentPushTask.test.ts` — 신규 import mock 추가.
- `src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts` — 신규 import mock 추가.
- `src/shared/hooks/__tests__/useStateRehydration.test.ts` — 신규 import mock 추가.

## 검증

- `npm run type-check` PASS.
- 변경된 5 production 파일 모두 100% coverage (Stmts/Branch/Funcs/Lines).
- `npm run lint:orphan` 0 orphan.