### PR TITLE
fix(#1605): Estimator backend SSoT 우선 + lockless-route-hop fallback

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.backendSsotCascade.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.backendSsotCascade.test.ts
@@ -23,6 +23,11 @@ import {
   positionRet,
   GPS_BASE_DEFAULTS,
 } from '../../../../testUtils/positionApiFixtures';
+import {
+  BACKEND_SSOT_FIXTURE_T0 as T0,
+  flushBackendSsotMirrorTick,
+  makeBackendSsotMirrorEntry,
+} from '../../../../testUtils/backendSsotMirrorFixtures';
 import { readBackendSsotMirror } from '../../../alarm/utils/backendSsotMirror';
 import type { BackendSsotMirrorEntry } from '../../../alarm/utils/backendSsotMirror';
 import type { BoardingLock } from '../../../../shared/types/boardingLock';
@@ -50,18 +55,10 @@ const yongmasan = findStationByNameAndLine('용마산', '7')!;
 const chungdam = findStationByNameAndLine('청담', '7')!;
 const gangnam2 = findStationByNameAndLine('강남', '2')!;
 
-const T0 = 1_700_000_000_000;
-
-function makeMirror(overrides: Partial<BackendSsotMirrorEntry> = {}): BackendSsotMirrorEntry {
-  return {
-    currentStationId: yongmasan.name,
-    motionState: 'moving',
-    lastAdvanceEvidence: 'arvlcd-arrived',
-    lastAdvanceAt: T0,
-    passedStations: [],
-    receivedAt: T0,
-    ...overrides,
-  };
+// fixture 기본값(`makeBackendSsotMirrorEntry`)이 이미 '용마산' currentStationId라 단순 위임.
+// override 없는 호출(line ~164, 208)은 본 wrapper의 default arg branch도 같이 커버.
+function makeMirror(overrides?: Partial<BackendSsotMirrorEntry>): BackendSsotMirrorEntry {
+  return makeBackendSsotMirrorEntry(overrides);
 }
 
 function setupBaselineGpsAt(stationName: string) {
@@ -102,14 +99,7 @@ describe('#1568 (T8b) cascade picker — backend-ssot tier', () => {
     jest.useRealTimers();
   });
 
-  async function flushSsotRead() {
-    // 5s interval tick으로 SSoT mirror state hydrate.
-    await act(async () => {
-      jest.advanceTimersByTime(5_000);
-      // microtask flush
-      await Promise.resolve();
-    });
-  }
+  const flushSsotRead = flushBackendSsotMirrorTick;
 
   it('mirror 존재 + fresh → cascade 1순위 (lock 활성, lockless 동등 우선순위)', async () => {
     // 사용자가 다른 역(청담)에 있다고 GPS가 가리켜도 backend mirror가 용마산을 권위 산출 → mirror 우선.

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.estimatorBackendSsotOverride.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.estimatorBackendSsotOverride.test.ts
@@ -1,0 +1,226 @@
+/* eslint-disable import/no-restricted-paths -- cross-feature orchestration (#890) */
+
+/**
+ * #1605 (Estimator lockless-route-hop idx 비정상 — Backend SSoT 우선) 회귀 가드.
+ *
+ * 시나리오 (2026-06-20 trip dump 21:16:05 evidence):
+ *   - 사용자 실제 위치 = 용마산 (origin, arc idx=0, 7호선)
+ *   - destination 성수 (arc idx=arcEnd)
+ *   - lockless-route-hop estimator가 시간 적분으로 destination 성수(idx=arcEnd)를 가리킴 (wrong)
+ *   - backend SSoT mirror가 용마산(권위) 산출
+ *
+ * 본 PR로:
+ *   - displayOnlyEstimate.strategy='backend-ssot-override' + station=용마산 (mirror 우선)
+ *   - mirror stale/null이면 estimator 결과 그대로 fallback (graceful)
+ *   - 라벨 backend-ssot-override가 estimator buffer push 시 strategy로 기록되어 DebugModal 추적 가능
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { useFusedNearestStation } from '../useFusedNearestStation';
+import { useNearestStation } from '../useNearestStation';
+import { useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
+import { useTrainPositions } from '../../../route/hooks/useTrainPositions';
+import { findTopNearestStations } from '../../utils/findNearestStation';
+import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute';
+import {
+  arrivalRet,
+  positionRet,
+  GPS_BASE_DEFAULTS,
+} from '../../../../testUtils/positionApiFixtures';
+import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
+import { readBackendSsotMirror } from '../../../alarm/utils/backendSsotMirror';
+import type { BackendSsotMirrorEntry } from '../../../alarm/utils/backendSsotMirror';
+
+jest.mock('../../utils/findNearestStation', () => ({
+  findTopNearestStations: jest.fn(),
+}));
+jest.mock('../useNearestStation');
+jest.mock('../../../arrival/hooks/useArrivalInfo');
+jest.mock('../../../route/hooks/useTrainPositions');
+jest.mock('../../../alarm/utils/tripStartStorage', () => ({
+  getTripStartedAt: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../../../alarm/utils/backendSsotMirror', () => ({
+  readBackendSsotMirror: jest.fn(),
+}));
+
+const mockNearest = useNearestStation as jest.Mock;
+const mockArrival = useArrivalInfo as jest.Mock;
+const mockPos = useTrainPositions as jest.Mock;
+const mockFindTop = findTopNearestStations as jest.Mock;
+const mockRead = readBackendSsotMirror as jest.Mock;
+
+const yongmasan = findStationByNameAndLine('용마산', '7')!;
+const chungdam = findStationByNameAndLine('청담', '7')!;
+
+const T0 = 1_700_000_000_000;
+
+function makeMirror(overrides: Partial<BackendSsotMirrorEntry> = {}): BackendSsotMirrorEntry {
+  return {
+    currentStationId: yongmasan.name,
+    motionState: 'moving',
+    lastAdvanceEvidence: 'arvlcd-arrived',
+    lastAdvanceAt: T0,
+    passedStations: [],
+    receivedAt: T0,
+    ...overrides,
+  };
+}
+
+function setupLocklessTripAtYongmasan() {
+  // GPS 용마산 정적 보고 (위치는 origin, estimator가 lockless-route-hop으로 destination을 가리킴).
+  const live = { station: yongmasan, distanceKm: 0 };
+  mockNearest.mockReturnValue({
+    result: live,
+    liveResult: live,
+    stickyDisplayOnly: null,
+    variants: [yongmasan],
+    userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
+    ...GPS_BASE_DEFAULTS,
+    accuracyMeters: 14,
+    refresh: jest.fn(),
+  });
+  mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+  mockArrival.mockReturnValue(arrivalRet(null));
+  mockPos.mockReturnValue(positionRet(null));
+
+  // 8개 hop arc (yongmasan → chungdam). tripStartedAt 60분 전 → lockless-route-hop이 arc 끝으로 적분.
+  const route = makeDirectRoute(8, '7');
+  return { route, routeContext: { route, origin: yongmasan, destination: chungdam } };
+}
+
+async function flushSsotRead() {
+  await act(async () => {
+    jest.advanceTimersByTime(5_000);
+    await Promise.resolve();
+  });
+}
+
+describe('#1605 — Estimator backend SSoT 우선 + lockless-route-hop fallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(T0);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('mirror fresh + estimator wrong(lockless-route-hop) → displayOnlyEstimate.strategy=backend-ssot-override + station=mirror', async () => {
+    const { routeContext } = setupLocklessTripAtYongmasan();
+    // mirror lastAdvanceAt이 trip 시간과 함께 fresh로 유지되도록 60min 뒤 시점으로 stamp.
+    // 시간 진행은 trip 시작 60분 → lockless-route-hop이 destination으로 적분.
+    const nowMs = T0 + 60 * 60_000;
+    jest.setSystemTime(nowMs);
+    mockRead.mockResolvedValue(
+      makeMirror({ currentStationId: yongmasan.name, lastAdvanceAt: nowMs, receivedAt: nowMs }),
+    );
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(undefined, undefined, routeContext),
+    );
+    await flushSsotRead();
+
+    await waitFor(() => {
+      expect(hook.result.current.displayOnlyEstimate?.strategy).toBe('backend-ssot-override');
+    });
+    expect(hook.result.current.displayOnlyEstimate?.station.id).toBe(yongmasan.id);
+    // arcStations[0]=yongmasan → idx=0.
+    expect(hook.result.current.displayOnlyEstimate?.index).toBe(0);
+  });
+
+  it('mirror null → estimator 그대로 (lockless-route-hop) — fallback graceful', async () => {
+    const { routeContext } = setupLocklessTripAtYongmasan();
+    const nowMs = T0 + 60 * 60_000;
+    jest.setSystemTime(nowMs);
+    mockRead.mockResolvedValue(null);
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(undefined, undefined, routeContext),
+    );
+    await flushSsotRead();
+
+    // mirror 없으면 estimator 결과 그대로 노출 (lockless-route-hop).
+    expect(hook.result.current.displayOnlyEstimate?.strategy).toBe('lockless-route-hop');
+  });
+
+  it('mirror stale (>180s) → estimator 그대로 fallback', async () => {
+    const { routeContext } = setupLocklessTripAtYongmasan();
+    const nowMs = T0 + 60 * 60_000;
+    jest.setSystemTime(nowMs);
+    // lastAdvanceAt이 nowMs보다 240s 전 — staleness 180s 초과.
+    mockRead.mockResolvedValue(
+      makeMirror({
+        currentStationId: yongmasan.name,
+        lastAdvanceAt: nowMs - 240_000,
+        receivedAt: nowMs - 240_000,
+      }),
+    );
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(undefined, undefined, routeContext),
+    );
+    await flushSsotRead();
+
+    // stale mirror → estimator fallback.
+    expect(hook.result.current.displayOnlyEstimate?.strategy).not.toBe('backend-ssot-override');
+  });
+
+  it('mirror fresh + ssotStation이 arc 밖 → strategy=backend-ssot-override + estimator idx fallback', async () => {
+    // arc는 7호선 8 hop, mirror는 2호선 강남(arc 밖). lockless trip이라 lock line 가드 없음 → resolve 됨.
+    // ssotArcIdx=-1 → estimator의 idx (lockless-route-hop이 적분한 마지막 idx)로 fallback.
+    const { routeContext } = setupLocklessTripAtYongmasan();
+    const gangnam2 = findStationByNameAndLine('강남', '2')!;
+    const nowMs = T0 + 60 * 60_000;
+    jest.setSystemTime(nowMs);
+    mockRead.mockResolvedValue(
+      makeMirror({ currentStationId: gangnam2.name, lastAdvanceAt: nowMs, receivedAt: nowMs }),
+    );
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(undefined, undefined, routeContext),
+    );
+    await flushSsotRead();
+
+    await waitFor(() => {
+      expect(hook.result.current.displayOnlyEstimate?.strategy).toBe('backend-ssot-override');
+    });
+    // station은 mirror가 가리킨 곳.
+    expect(hook.result.current.displayOnlyEstimate?.station.id).toBe(gangnam2.id);
+    // idx는 estimator의 fallback (arc 밖이라 -1 대신 estimator idx).
+    expect(hook.result.current.displayOnlyEstimate?.index).toBeGreaterThanOrEqual(0);
+  });
+
+  it('mirror fresh + estimator null → displayOnlyEstimate.station=mirror, index=0 fallback', async () => {
+    // route 없음 → arcStations=[] → estimator=null. mirror만 있는 경우 idx=0으로 fallback.
+    const live = { station: yongmasan, distanceKm: 0 };
+    mockNearest.mockReturnValue({
+      result: live,
+      liveResult: live,
+      stickyDisplayOnly: null,
+      variants: [yongmasan],
+      userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
+      ...GPS_BASE_DEFAULTS,
+      accuracyMeters: 14,
+      refresh: jest.fn(),
+    });
+    mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+    mockArrival.mockReturnValue(arrivalRet(null));
+    mockPos.mockReturnValue(positionRet(null));
+    const nowMs = T0;
+    mockRead.mockResolvedValue(
+      makeMirror({ currentStationId: yongmasan.name, lastAdvanceAt: nowMs, receivedAt: nowMs }),
+    );
+
+    const hook = renderHook(() => useFusedNearestStation()); // routeContext 없음
+    await flushSsotRead();
+
+    await waitFor(() => {
+      expect(hook.result.current.displayOnlyEstimate?.strategy).toBe('backend-ssot-override');
+    });
+    // arcStations=[] → arcIndexOfStation=-1 → estimator 없으니 0 fallback.
+    expect(hook.result.current.displayOnlyEstimate?.index).toBe(0);
+    expect(hook.result.current.displayOnlyEstimate?.station.id).toBe(yongmasan.id);
+  });
+});

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.estimatorBackendSsotOverride.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.estimatorBackendSsotOverride.test.ts
@@ -15,7 +15,7 @@
  *   - 라벨 backend-ssot-override가 estimator buffer push 시 strategy로 기록되어 DebugModal 추적 가능
  */
 
-import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { renderHook, waitFor } from '@testing-library/react-native';
 import { useFusedNearestStation } from '../useFusedNearestStation';
 import { useNearestStation } from '../useNearestStation';
 import { useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
@@ -28,8 +28,12 @@ import {
   GPS_BASE_DEFAULTS,
 } from '../../../../testUtils/positionApiFixtures';
 import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
+import {
+  BACKEND_SSOT_FIXTURE_T0 as T0,
+  flushBackendSsotMirrorTick,
+  makeBackendSsotMirrorEntry,
+} from '../../../../testUtils/backendSsotMirrorFixtures';
 import { readBackendSsotMirror } from '../../../alarm/utils/backendSsotMirror';
-import type { BackendSsotMirrorEntry } from '../../../alarm/utils/backendSsotMirror';
 
 jest.mock('../../utils/findNearestStation', () => ({
   findTopNearestStations: jest.fn(),
@@ -53,22 +57,11 @@ const mockRead = readBackendSsotMirror as jest.Mock;
 const yongmasan = findStationByNameAndLine('용마산', '7')!;
 const chungdam = findStationByNameAndLine('청담', '7')!;
 
-const T0 = 1_700_000_000_000;
-
-function makeMirror(overrides: Partial<BackendSsotMirrorEntry> = {}): BackendSsotMirrorEntry {
-  return {
-    currentStationId: yongmasan.name,
-    motionState: 'moving',
-    lastAdvanceEvidence: 'arvlcd-arrived',
-    lastAdvanceAt: T0,
-    passedStations: [],
-    receivedAt: T0,
-    ...overrides,
-  };
-}
-
-function setupLocklessTripAtYongmasan() {
-  // GPS 용마산 정적 보고 (위치는 origin, estimator가 lockless-route-hop으로 destination을 가리킴).
+/**
+ * GPS hook mock + arrival/position empty mock 셋업 helper.
+ * setupLocklessTripAtYongmasan과 'mirror fresh + estimator null' 케이스가 동일 패턴이라 추출.
+ */
+function setupQuietGpsAtYongmasan() {
   const live = { station: yongmasan, distanceKm: 0 };
   mockNearest.mockReturnValue({
     result: live,
@@ -83,17 +76,14 @@ function setupLocklessTripAtYongmasan() {
   mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
   mockArrival.mockReturnValue(arrivalRet(null));
   mockPos.mockReturnValue(positionRet(null));
+}
 
+function setupLocklessTripAtYongmasan() {
+  // GPS 용마산 정적 보고 (위치는 origin, estimator가 lockless-route-hop으로 destination을 가리킴).
+  setupQuietGpsAtYongmasan();
   // 8개 hop arc (yongmasan → chungdam). tripStartedAt 60분 전 → lockless-route-hop이 arc 끝으로 적분.
   const route = makeDirectRoute(8, '7');
   return { route, routeContext: { route, origin: yongmasan, destination: chungdam } };
-}
-
-async function flushSsotRead() {
-  await act(async () => {
-    jest.advanceTimersByTime(5_000);
-    await Promise.resolve();
-  });
 }
 
 describe('#1605 — Estimator backend SSoT 우선 + lockless-route-hop fallback', () => {
@@ -114,13 +104,13 @@ describe('#1605 — Estimator backend SSoT 우선 + lockless-route-hop fallback'
     const nowMs = T0 + 60 * 60_000;
     jest.setSystemTime(nowMs);
     mockRead.mockResolvedValue(
-      makeMirror({ currentStationId: yongmasan.name, lastAdvanceAt: nowMs, receivedAt: nowMs }),
+      makeBackendSsotMirrorEntry({ currentStationId: yongmasan.name, lastAdvanceAt: nowMs, receivedAt: nowMs }),
     );
 
     const hook = renderHook(() =>
       useFusedNearestStation(undefined, undefined, routeContext),
     );
-    await flushSsotRead();
+    await flushBackendSsotMirrorTick();
 
     await waitFor(() => {
       expect(hook.result.current.displayOnlyEstimate?.strategy).toBe('backend-ssot-override');
@@ -139,7 +129,7 @@ describe('#1605 — Estimator backend SSoT 우선 + lockless-route-hop fallback'
     const hook = renderHook(() =>
       useFusedNearestStation(undefined, undefined, routeContext),
     );
-    await flushSsotRead();
+    await flushBackendSsotMirrorTick();
 
     // mirror 없으면 estimator 결과 그대로 노출 (lockless-route-hop).
     expect(hook.result.current.displayOnlyEstimate?.strategy).toBe('lockless-route-hop');
@@ -151,7 +141,7 @@ describe('#1605 — Estimator backend SSoT 우선 + lockless-route-hop fallback'
     jest.setSystemTime(nowMs);
     // lastAdvanceAt이 nowMs보다 240s 전 — staleness 180s 초과.
     mockRead.mockResolvedValue(
-      makeMirror({
+      makeBackendSsotMirrorEntry({
         currentStationId: yongmasan.name,
         lastAdvanceAt: nowMs - 240_000,
         receivedAt: nowMs - 240_000,
@@ -161,7 +151,7 @@ describe('#1605 — Estimator backend SSoT 우선 + lockless-route-hop fallback'
     const hook = renderHook(() =>
       useFusedNearestStation(undefined, undefined, routeContext),
     );
-    await flushSsotRead();
+    await flushBackendSsotMirrorTick();
 
     // stale mirror → estimator fallback.
     expect(hook.result.current.displayOnlyEstimate?.strategy).not.toBe('backend-ssot-override');
@@ -175,13 +165,13 @@ describe('#1605 — Estimator backend SSoT 우선 + lockless-route-hop fallback'
     const nowMs = T0 + 60 * 60_000;
     jest.setSystemTime(nowMs);
     mockRead.mockResolvedValue(
-      makeMirror({ currentStationId: gangnam2.name, lastAdvanceAt: nowMs, receivedAt: nowMs }),
+      makeBackendSsotMirrorEntry({ currentStationId: gangnam2.name, lastAdvanceAt: nowMs, receivedAt: nowMs }),
     );
 
     const hook = renderHook(() =>
       useFusedNearestStation(undefined, undefined, routeContext),
     );
-    await flushSsotRead();
+    await flushBackendSsotMirrorTick();
 
     await waitFor(() => {
       expect(hook.result.current.displayOnlyEstimate?.strategy).toBe('backend-ssot-override');
@@ -194,27 +184,14 @@ describe('#1605 — Estimator backend SSoT 우선 + lockless-route-hop fallback'
 
   it('mirror fresh + estimator null → displayOnlyEstimate.station=mirror, index=0 fallback', async () => {
     // route 없음 → arcStations=[] → estimator=null. mirror만 있는 경우 idx=0으로 fallback.
-    const live = { station: yongmasan, distanceKm: 0 };
-    mockNearest.mockReturnValue({
-      result: live,
-      liveResult: live,
-      stickyDisplayOnly: null,
-      variants: [yongmasan],
-      userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
-      ...GPS_BASE_DEFAULTS,
-      accuracyMeters: 14,
-      refresh: jest.fn(),
-    });
-    mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
-    mockArrival.mockReturnValue(arrivalRet(null));
-    mockPos.mockReturnValue(positionRet(null));
+    setupQuietGpsAtYongmasan();
     const nowMs = T0;
     mockRead.mockResolvedValue(
-      makeMirror({ currentStationId: yongmasan.name, lastAdvanceAt: nowMs, receivedAt: nowMs }),
+      makeBackendSsotMirrorEntry({ currentStationId: yongmasan.name, lastAdvanceAt: nowMs, receivedAt: nowMs }),
     );
 
     const hook = renderHook(() => useFusedNearestStation()); // routeContext 없음
-    await flushSsotRead();
+    await flushBackendSsotMirrorTick();
 
     await waitFor(() => {
       expect(hook.result.current.displayOnlyEstimate?.strategy).toBe('backend-ssot-override');

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.estimatorBackendSsotOverride.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.estimatorBackendSsotOverride.test.ts
@@ -35,18 +35,17 @@ import {
 } from '../../../../testUtils/backendSsotMirrorFixtures';
 import { readBackendSsotMirror } from '../../../alarm/utils/backendSsotMirror';
 
-jest.mock('../../utils/findNearestStation', () => ({
-  findTopNearestStations: jest.fn(),
-}));
+// #1605 — useFusedNearestStation 의존 hook/util mock + cascade I/O mock 세트.
+// jest.mock은 호이스팅돼 module scope에서만 가능 — 공통 helper로 추출 불가.
+// 본 fixture 그룹은 backendSsotCascade.test.ts와 의도적으로 같은 구성 (Backend SSoT cascade 검증).
 jest.mock('../useNearestStation');
 jest.mock('../../../arrival/hooks/useArrivalInfo');
 jest.mock('../../../route/hooks/useTrainPositions');
+jest.mock('../../utils/findNearestStation', () => ({ findTopNearestStations: jest.fn() }));
 jest.mock('../../../alarm/utils/tripStartStorage', () => ({
   getTripStartedAt: jest.fn().mockResolvedValue(null),
 }));
-jest.mock('../../../alarm/utils/backendSsotMirror', () => ({
-  readBackendSsotMirror: jest.fn(),
-}));
+jest.mock('../../../alarm/utils/backendSsotMirror', () => ({ readBackendSsotMirror: jest.fn() }));
 
 const mockNearest = useNearestStation as jest.Mock;
 const mockArrival = useArrivalInfo as jest.Mock;
@@ -54,6 +53,7 @@ const mockPos = useTrainPositions as jest.Mock;
 const mockFindTop = findTopNearestStations as jest.Mock;
 const mockRead = readBackendSsotMirror as jest.Mock;
 
+// 시나리오: lockless trip yongmasan→chungdam(7호선). 정적 사용자가 origin에 머무름.
 const yongmasan = findStationByNameAndLine('용마산', '7')!;
 const chungdam = findStationByNameAndLine('청담', '7')!;
 

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -1143,14 +1143,55 @@ export function useFusedNearestStation(
     confidence = 'detection-fused';
   }
 
+  // #1605 — Backend SSoT 권위 override (option C — Estimator backend SSoT 우선 + estimator fallback).
+  //
+  // backend SSoT mirror가 fresh(≤180s, BACKEND_SSOT_MIRROR_MAX_AGE_MS)이고 station이 resolve되면
+  // estimator(lockless-route-hop 등 시간 적분 strategy)의 결과를 override해 displayOnlyEstimate /
+  // estimator buffer push의 SSOT로 채택한다. mirror stale/null/lock line mismatch면 estimator
+  // 결과 그대로 fallback (graceful).
+  //
+  // 사용자 가치(2026-06-20 trip dump 21:16:05 evidence): lockless-route-hop이 destination 성수(idx=6)를
+  // 가리켰으나 사용자 실제 위치는 origin 용마산(idx=0). estimator 시간 적분 SSOT 가정 결함
+  // (lesson_lockless_route_hop_time_integration_ssot_assumption) 때문에 잘못된 station 표시. backend
+  // SSoT는 ADR-017 6단 advance 게이트(seed/repeat/motion-stop/cross-validation 등)를 이미 통과한
+  // 권위 신호이므로 estimator보다 신뢰도가 높다.
+  //
+  // 본 override는 fire path(result/source/confidence/currentHopIndex)와는 분리 — 위 cascade가
+  // backend-ssot tier로 이미 fire path를 점유하므로 본 분기는 *표시 채널*만 갱신한다.
+  // - effectiveEstimate: displayOnlyEstimate에 노출 (DebugModal/UI 추적용).
+  // - estimator buffer: strategy='backend-ssot-override'로 push해 "어떤 estimator strategy를 어떤
+  //   backend SSoT가 override했나" 사후 분석 가능.
+  //
+  // arc index 계산: ssotStation이 arc 위에 있으면 그 idx, 아니면 estimator의 idx 유지 (사용자가
+  // arc 밖 station에 있는 case는 estimator idx fallback이 더 의미 있는 추적값).
+  const effectiveEstimate: {
+    station: Station;
+    strategy: import('../../route/utils/stationProgressEstimator').StationProgressStrategy;
+    index: number;
+  } | null = (() => {
+    if (backendSsotAccepts && ssotStation) {
+      const ssotArcIdx = arcIndexOfStation(arcStations, ssotStation);
+      return {
+        station: ssotStation,
+        strategy: 'backend-ssot-override' as const,
+        index: ssotArcIdx !== -1 ? ssotArcIdx : (estimate?.index ?? 0),
+      };
+    }
+    if (!estimate) return null;
+    return { station: estimate.station, strategy: estimate.strategy, index: estimate.index };
+  })();
+
   // #1025 — Estimator 전략 변화 시 debug buffer에 push.
   // estimate key: strategy|stationId|arcIndex. null estimate는 strategy=null로 기록.
   // estimateRef: effect 내부에서 estimate를 deps 없이 최신값으로 읽기 위한 ref.
   // estimateKey만 deps에 두면 key 변화 시 최신 estimate를 ref로 안전하게 참조 가능.
-  const estimateRef = useRef(estimate);
-  estimateRef.current = estimate;
-  const estimateKey = estimate
-    ? `${estimate.strategy}|${estimate.station.id}|${estimate.index}`
+  //
+  // #1605 — effectiveEstimate(backend SSoT override 결합)를 push해 DebugModal Estimator State 섹션이
+  // SSoT 권위 결과를 그대로 표시. estimator 자체 결과는 ref로 보관해 sanity 비교 가능.
+  const estimateRef = useRef(effectiveEstimate);
+  estimateRef.current = effectiveEstimate;
+  const estimateKey = effectiveEstimate
+    ? `${effectiveEstimate.strategy}|${effectiveEstimate.station.id}|${effectiveEstimate.index}`
     : 'null';
   useEffect(() => {
     const est = estimateRef.current;
@@ -1348,9 +1389,9 @@ export function useFusedNearestStation(
     // fire path 입력에서 박탈. estimator 결과는 displayOnlyEstimate로만 노출.
     currentHopIndex: fireSafeHopIndex,
     // #1437 — UI/DebugModal 추적용 별 채널. fire path는 본 필드를 읽지 않는다.
-    displayOnlyEstimate: estimate
-      ? { station: estimate.station, strategy: estimate.strategy, index: estimate.index }
-      : null,
+    // #1605 — backend SSoT mirror가 fresh면 estimator 결과를 backend-ssot-override로 대체. mirror
+    // null/stale 시 estimator 그대로 fallback. effectiveEstimate가 두 케이스를 모두 캡슐화.
+    displayOnlyEstimate: effectiveEstimate,
     arcStations,
     detectionTier: detectionVerdict.confidence,
     detectionSignalMask: detectionVerdict.signalMask,

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -1174,11 +1174,13 @@ export function useFusedNearestStation(
       return {
         station: ssotStation,
         strategy: 'backend-ssot-override' as const,
-        index: ssotArcIdx !== -1 ? ssotArcIdx : (estimate?.index ?? 0),
+        index: ssotArcIdx === -1 ? (estimate?.index ?? 0) : ssotArcIdx,
       };
     }
-    if (!estimate) return null;
-    return { station: estimate.station, strategy: estimate.strategy, index: estimate.index };
+    if (estimate) {
+      return { station: estimate.station, strategy: estimate.strategy, index: estimate.index };
+    }
+    return null;
   })();
 
   // #1025 — Estimator 전략 변화 시 debug buffer에 push.

--- a/src/features/route/utils/__tests__/stationProgressEstimator.test.ts
+++ b/src/features/route/utils/__tests__/stationProgressEstimator.test.ts
@@ -593,6 +593,25 @@ describe('estimateStationProgress', () => {
       expect(r).toBeNull();
     });
 
+    it('#1605 lock null + locklessTrip + arcStations 단일 역(route hop count=0) → null', () => {
+      // arc가 1개 역만 가지는 edge case(예: destination 미설정 직후 / origin==destination).
+      // 시간 적분이 무의미하므로 estimator skip — strategy=null entry가 buffer에 push되어
+      // trip context 미준비 상태가 명시된다.
+      const singleArc: Station[] = [ARC[0]];
+      const r = estimateStationProgress({
+        lock: null,
+        locklessTrip: { tripStartedAt: T0 },
+        arcStations: singleArc,
+        now: T0 + 60 * 60_000, // 60분 경과해도 idx=0 강제 의미 없음.
+        trainProgress: null,
+        lockedTrainCode: null,
+        lastObserved: null,
+        hopTimeMsForHop: UNIFORM_HOP,
+        ...NO_ARRIVAL_INPUT,
+      });
+      expect(r).toBeNull();
+    });
+
     it('lock null + locklessTrip tripStartedAt 미래(시계 후진) → null', () => {
       const r = estimateStationProgress({
         lock: null,

--- a/src/features/route/utils/stationProgressEstimator.ts
+++ b/src/features/route/utils/stationProgressEstimator.ts
@@ -116,7 +116,17 @@ export type StationProgressStrategy =
   | 'arrival-eta'
   | 'reanchored-hop'
   | 'default-hop'
-  | 'lockless-route-hop';
+  | 'lockless-route-hop'
+  /**
+   * #1605 — backend SSoT 권위 override 결과. estimator 자체가 산출하는 strategy가 아니라
+   * `useFusedNearestStation`이 backend SSoT mirror가 fresh일 때 estimator 결과를 override한 표시.
+   *
+   * cascade의 `backend-ssot` source/confidence와는 분리된 라벨 — estimator/DebugModal Estimator State
+   * 채널에서만 사용한다. `displayOnlyEstimate`와 buffer push의 strategy 출처 표시로 사용해
+   * "estimator가 어떤 strategy로 wrong station을 가리켰는데 backend SSoT가 override했다"의 사후
+   * 분석을 가능하게 한다.
+   */
+  | 'backend-ssot-override';
 
 export interface StationProgressEstimate {
   station: Station;
@@ -289,6 +299,12 @@ function tryLocklessRouteHop(
   // 도달 불가하지만 방어적 유지 — 직접 호출자가 추가될 때 안전.
   /* istanbul ignore next */
   if (arcStations.length === 0) return null;
+  // #1605 — route hop count=0 (arcStations 단일 역 = origin 자체) 가드.
+  // arc가 1개 역만 가지는 경우(예: destination 미설정 직후 / origin==destination edge case)
+  // 시간 적분 자체가 의미 없다 — clamp 결과가 항상 idx=0이라 origin과 동일하지만, "lockless-route-hop"
+  // entry를 강제로 push하면 DebugModal에서 estimator 활성으로 오인되어 보인다. null 반환으로
+  // estimator skip → strategy=null entry가 buffer에 push되어 trip context 미준비 상태가 명시된다.
+  if (arcStations.length === 1) return null;
   const elapsedMs = now - tripStartedAt;
   if (elapsedMs < 0) return null;
   const hops = hopsElapsedFrom(arcStations.length, 0, elapsedMs, hopTimeMsForHop);

--- a/src/testUtils/backendSsotMirrorFixtures.ts
+++ b/src/testUtils/backendSsotMirrorFixtures.ts
@@ -1,0 +1,52 @@
+/* eslint-disable import/no-restricted-paths -- shared test fixtures cross feature slices */
+/**
+ * #1605 — backend SSoT mirror cascade 테스트 공통 fixture.
+ * useFusedNearestStation.backendSsotCascade / estimatorBackendSsotOverride 등 여러 테스트가 같은
+ * mirror entry 빌더를 사용 — 중복 제거 + schema drift 방지.
+ *
+ * jest.mock 자체는 caller가 직접 (compile-time hoist) 호출하고, 본 모듈은 entry 생성/타이밍
+ * 유틸만 제공한다.
+ */
+
+import { act } from '@testing-library/react-native';
+import type { BackendSsotMirrorEntry } from '../features/alarm/utils/backendSsotMirror';
+
+/**
+ * 테스트 기본 시각. 호출자가 jest.setSystemTime + Date.now 기준값으로 사용.
+ * 정수 epoch ms — 시계 후진 검증 시 큰 값에서 -240_000 등 안전.
+ */
+export const BACKEND_SSOT_FIXTURE_T0 = 1_700_000_000_000;
+
+/**
+ * BackendSsotMirrorEntry 기본값 + overrides 빌더.
+ *
+ * 기본값: 용마산(7) currentStationId / 'moving' / arvlcd-arrived evidence / lastAdvanceAt=T0 / passedStations 비어있음.
+ * 호출자는 currentStationId/lastAdvanceAt/receivedAt 등을 override해 fresh/stale/cross-line 시나리오를 만든다.
+ *
+ * stationName 기본값을 '용마산'로 둔 이유: cascade 테스트 두 시나리오가 모두 같은 origin 가정으로
+ * 시작 — fixture는 시나리오 setup의 일부, station id 차이는 override로 명시.
+ */
+export function makeBackendSsotMirrorEntry(
+  overrides: Partial<BackendSsotMirrorEntry> = {},
+): BackendSsotMirrorEntry {
+  return {
+    currentStationId: '용마산',
+    motionState: 'moving',
+    lastAdvanceEvidence: 'arvlcd-arrived',
+    lastAdvanceAt: BACKEND_SSOT_FIXTURE_T0,
+    passedStations: [],
+    receivedAt: BACKEND_SSOT_FIXTURE_T0,
+    ...overrides,
+  };
+}
+
+/**
+ * useFusedNearestStation 내부 5s setInterval 1 tick + microtask flush.
+ * mockRead가 resolveValue로 entry를 반환할 때 cascade reducer가 state를 hydrate하도록 보장.
+ */
+export async function flushBackendSsotMirrorTick(): Promise<void> {
+  await act(async () => {
+    jest.advanceTimersByTime(5_000);
+    await Promise.resolve();
+  });
+}


### PR DESCRIPTION
Closes #1605

## 다운로드 가치

2026-06-20 trip dump 21:16:05 evidence:
- 사용자 실제 위치 = 용마산 (origin, arc idx=0, 7호선)
- destination 성수 (arc idx=6, 2호선) — transfer leg
- lockless-route-hop estimator가 시간 적분으로 destination 성수(idx=6)를 가리킴 (wrong)
- DebugModal Estimator State에 wrong station 노출 → 사용자 진단 신뢰도 손상

`backend-ssot-override` 도입으로 fresh mirror가 있으면 estimator (시간 적분 SSOT 가정 결함) 결과를 backend 권위 SSoT로 override해 추적 채널이 권위 station을 가리킴. 1주 production 측정 시 wrong station 추적 0건 목표.

## 변경 요약

### Device estimator 우선순위 재정렬
- `useFusedNearestStation.ts`: `effectiveEstimate` 합성 — `backendSsotAccepts && ssotStation` 시 strategy=`backend-ssot-override` + station=ssotStation 채택. mirror null/stale 시 estimator 그대로 fallback.
- `displayOnlyEstimate` 반환을 `effectiveEstimate`로 wire.
- estimator buffer push key/entry가 `effectiveEstimate`를 참조 — DebugModal Estimator State 섹션에서 strategy 출처 추적 가능.

### lockless-route-hop 결함 보완 (B 보완)
- `tryLocklessRouteHop`: `arcStations.length === 1` (route hop count=0) 가드 추가. 시간 적분 자체가 무의미한 edge case에서 null 반환 → strategy=null entry로 trip context 미준비 상태 명시.
- 시간 적분 SSOT 가정 결함 자체(lesson_lockless_route_hop_time_integration_ssot_assumption)는 (C) 옵션의 backend SSoT 우선 채택으로 우회.

### Type
- `StationProgressStrategy`: `'backend-ssot-override'` 라벨 추가. estimator 자체 산출 아닌 합성 단계 라벨로 분리.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass.
2. **V/X dashboard** — DebugModal Estimator State 섹션이 strategy=`backend-ssot-override` 표시. displayOnlyEstimate row도 동일 라벨. Share dump에서 SSoT override 활성 시각 추적 가능.
3. **의존 PR** — T8b(#1568 머지) + T10 #1594(머지) 선행. T9 #1572 OPEN — 부분 겹침이지만 본 PR은 estimator 표시 채널만 건드려 fire path 게이트 변경 X → independent.
4. **측정 plan** — P0-1 Analytics `advance` event의 stationId vs DebugModal Estimator State stationId mismatch 카운트 1주 0건. P0-4 trip annotation 시 station 추적 정확도 100%.
5. **Device verify** — 권장. 시나리오: lockless trip 시작 → 시간 진행 → Estimator State 섹션에서 strategy=`backend-ssot-override` + station=현재역 (mirror가 fresh인 동안) 확인.

## 자가 점검 5단

1. **acceptance self-referential?** OK — backend SSoT 자체가 Phase 0 측정 source.
2. **Wire-completion CI?** OK — backend SSoT 채택 site grep + lint:orphan pass.
3. **머지 순서?** T10 #1594 + S1 #1534 머지 후 OK. T9 #1572과 estimator 채널 분리 — fire path 미변경.
4. **backward-compat?** OK — estimator legacy fallback 보존 (mirror null/stale 시).
5. **False positive new?** Yes — backend SSoT가 wrong이면 estimator override가 잘못된 station 표시. 단 *표시 채널만* 영향 (fire path는 cascade backend-ssot tier가 이미 동일 결정 사용). backend SSoT 정확도 자체가 root — Phase 0 측정으로 검증.

## 테스트

- `stationProgressEstimator.test.ts` +1 — arcStations.length=1 → null
- `useFusedNearestStation.estimatorBackendSsotOverride.test.ts` 신규 5건
  - mirror fresh → strategy=backend-ssot-override + station=mirror
  - mirror null → estimator 그대로 (lockless-route-hop)
  - mirror stale (>180s) → estimator fallback
  - mirror fresh + arc 밖 station → backend-ssot-override + estimator idx fallback
  - mirror fresh + estimator null → station=mirror, idx=0 fallback
- 변경 파일 100% coverage. type-check pass. lint:orphan pass.

## 추가 발견

- `useFusedNearestStation` estimator buffer race (같은 timestamp 3 entry 동시 push) — 별 sub-issue 후보. trip context 전환 시 setState chain으로 같은 frame 3 render 발생 가능. 본 PR에서는 strategy 라벨이 명확해져 추적은 가능.