### PR TITLE
fix(#1536): boardingPrompt 9-AND 환경 분기 + T13 instant trigger 분리

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -771,47 +771,29 @@ describe('sendBoardingPromptPush (#819)', () => {
     expect(result).toEqual({ ok: false, status: 410, reason: 'BadDeviceToken' });
   });
 
-  it('#1536 (S3) — triggerKind="cron" 명시 시 payload.data.triggerKind="cron" forward', async () => {
-    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
-    await sendBoardingPromptPush({
-      deviceToken: 'device-hex',
-      pushId: 'p2',
-      title: 'T',
-      body: 'B',
-      originStation: 'O',
-      line: 'L',
-      tripToken: 't',
-      sentAt: 0,
-      triggerKind: 'cron',
-      config: makeConfig(),
-      host: TEST_HOST,
-      fetchImpl: fetchImpl as unknown as typeof fetch,
-    });
-    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
-    const body = JSON.parse(call[1].body as string);
-    expect(body.data.triggerKind).toBe('cron');
-  });
-
-  it('#1536 (S3) — triggerKind="instant" forward', async () => {
-    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
-    await sendBoardingPromptPush({
-      deviceToken: 'device-hex',
-      pushId: 'p3',
-      title: 'T',
-      body: 'B',
-      originStation: 'O',
-      line: 'L',
-      tripToken: 't',
-      sentAt: 0,
-      triggerKind: 'instant',
-      config: makeConfig(),
-      host: TEST_HOST,
-      fetchImpl: fetchImpl as unknown as typeof fetch,
-    });
-    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
-    const body = JSON.parse(call[1].body as string);
-    expect(body.data.triggerKind).toBe('instant');
-  });
+  it.each([['cron' as const], ['instant' as const]])(
+    '#1536 (S3) — triggerKind=%s payload.data.triggerKind forward',
+    async (triggerKind) => {
+      const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+      await sendBoardingPromptPush({
+        deviceToken: 'device-hex',
+        pushId: 'p-trigger',
+        title: 'T',
+        body: 'B',
+        originStation: 'O',
+        line: 'L',
+        tripToken: 't',
+        sentAt: 0,
+        triggerKind,
+        config: makeConfig(),
+        host: TEST_HOST,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+      const body = JSON.parse(call[1].body as string);
+      expect(body.data.triggerKind).toBe(triggerKind);
+    },
+  );
 });
 
 // #1337 — trip-ended를 silent → alert로 전환. killed 앱에 OS banner로 즉시 표시.

--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -770,6 +770,48 @@ describe('sendBoardingPromptPush (#819)', () => {
     });
     expect(result).toEqual({ ok: false, status: 410, reason: 'BadDeviceToken' });
   });
+
+  it('#1536 (S3) — triggerKind="cron" 명시 시 payload.data.triggerKind="cron" forward', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    await sendBoardingPromptPush({
+      deviceToken: 'device-hex',
+      pushId: 'p2',
+      title: 'T',
+      body: 'B',
+      originStation: 'O',
+      line: 'L',
+      tripToken: 't',
+      sentAt: 0,
+      triggerKind: 'cron',
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.data.triggerKind).toBe('cron');
+  });
+
+  it('#1536 (S3) — triggerKind="instant" forward', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    await sendBoardingPromptPush({
+      deviceToken: 'device-hex',
+      pushId: 'p3',
+      title: 'T',
+      body: 'B',
+      originStation: 'O',
+      line: 'L',
+      tripToken: 't',
+      sentAt: 0,
+      triggerKind: 'instant',
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.data.triggerKind).toBe('instant');
+  });
 });
 
 // #1337 — trip-ended를 silent → alert로 전환. killed 앱에 OS banner로 즉시 표시.

--- a/backend/alarm-worker/src/__tests__/autoLock.test.ts
+++ b/backend/alarm-worker/src/__tests__/autoLock.test.ts
@@ -427,15 +427,32 @@ function failingGateOutcome(): Parameters<typeof attemptAutoLock>[0]['gateOutcom
   return { pass: false as const, reason: 'window-too-small' as const };
 }
 
+/**
+ * #1536 환경 분기 테스트 공통 fixture — `arrivalEntry` 와 옵션만 받아 attemptAutoLock 호출.
+ * 중복 호출 패턴 제거(SonarCloud duplication < 3% 충족).
+ */
+function callEnvAutoLock(
+  arrivalEntry: ArrivalEntry,
+  opts: {
+    environment?: Parameters<typeof attemptAutoLock>[0]['environment'];
+    gateOutcome?: Parameters<typeof attemptAutoLock>[0]['gateOutcome'];
+  } = {},
+) {
+  return attemptAutoLock({
+    trip: makeTrip(),
+    targetWaypoint: target,
+    originStation: '강남',
+    direction: 'up',
+    seoul: makeSeoul([arrivalEntry]),
+    now: NOW,
+    environment: opts.environment,
+    gateOutcome: opts.gateOutcome,
+  });
+}
+
 describe('attemptAutoLock #1536 (S3) 환경 분기 consensusGate', () => {
   it('surface + base gate pass + arrival 신호 있음 → lock 합성', async () => {
-    const { lock } = await attemptAutoLock({
-      trip: makeTrip(),
-      targetWaypoint: target,
-      originStation: '강남',
-      direction: 'up',
-      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
-      now: NOW,
+    const { lock } = await callEnvAutoLock(arrival({ trainCode: 'T1', arvlCd: 1 }), {
       environment: 'surface',
       gateOutcome: passingGateOutcome(),
     });
@@ -443,13 +460,7 @@ describe('attemptAutoLock #1536 (S3) 환경 분기 consensusGate', () => {
   });
 
   it('surface + base gate fail → consensusGate "base-gate-failed" → null', async () => {
-    const { lock } = await attemptAutoLock({
-      trip: makeTrip(),
-      targetWaypoint: target,
-      originStation: '강남',
-      direction: 'up',
-      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
-      now: NOW,
+    const { lock } = await callEnvAutoLock(arrival({ trainCode: 'T1', arvlCd: 1 }), {
       environment: 'surface',
       gateOutcome: failingGateOutcome(),
     });
@@ -459,13 +470,7 @@ describe('attemptAutoLock #1536 (S3) 환경 분기 consensusGate', () => {
   it('underground + arrival(arvlCd=1) + lockAttachable → 합의 통과 → lock 합성', async () => {
     // underground 분기는 base gate 결과 무관하게 arrival + lockAttachable 2-of-2
     // (consensusGate.ts:149-158). 따라서 base gate fail 도 통과.
-    const { lock } = await attemptAutoLock({
-      trip: makeTrip(),
-      targetWaypoint: target,
-      originStation: '강남',
-      direction: 'up',
-      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
-      now: NOW,
+    const { lock } = await callEnvAutoLock(arrival({ trainCode: 'T1', arvlCd: 1 }), {
       environment: 'underground',
       gateOutcome: failingGateOutcome(),
     });
@@ -474,13 +479,7 @@ describe('attemptAutoLock #1536 (S3) 환경 분기 consensusGate', () => {
 
   it('underground + arrival arvlCd 범위 밖 (=5) → arrival signal 미존재 → null', async () => {
     // arvlCd=5 (PREV_ARRIVED) 는 0~3 범위 밖 → arrivalSignalPresent=false → 합의 미달.
-    const { lock } = await attemptAutoLock({
-      trip: makeTrip(),
-      targetWaypoint: target,
-      originStation: '강남',
-      direction: 'up',
-      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 5 })]),
-      now: NOW,
+    const { lock } = await callEnvAutoLock(arrival({ trainCode: 'T1', arvlCd: 5 }), {
       environment: 'underground',
       gateOutcome: passingGateOutcome(),
     });
@@ -488,13 +487,7 @@ describe('attemptAutoLock #1536 (S3) 환경 분기 consensusGate', () => {
   });
 
   it('mixed + base gate pass + arrival + lockAttachable → 통과', async () => {
-    const { lock } = await attemptAutoLock({
-      trip: makeTrip(),
-      targetWaypoint: target,
-      originStation: '강남',
-      direction: 'up',
-      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
-      now: NOW,
+    const { lock } = await callEnvAutoLock(arrival({ trainCode: 'T1', arvlCd: 1 }), {
       environment: 'mixed',
       gateOutcome: passingGateOutcome(),
     });
@@ -502,13 +495,7 @@ describe('attemptAutoLock #1536 (S3) 환경 분기 consensusGate', () => {
   });
 
   it('mixed + base gate fail → null (mixed 는 base gate 통과 강제)', async () => {
-    const { lock } = await attemptAutoLock({
-      trip: makeTrip(),
-      targetWaypoint: target,
-      originStation: '강남',
-      direction: 'up',
-      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
-      now: NOW,
+    const { lock } = await callEnvAutoLock(arrival({ trainCode: 'T1', arvlCd: 1 }), {
       environment: 'mixed',
       gateOutcome: failingGateOutcome(),
     });
@@ -516,28 +503,13 @@ describe('attemptAutoLock #1536 (S3) 환경 분기 consensusGate', () => {
   });
 
   it('environment 미전달 → consensusGate skip (구 호출자 호환)', async () => {
-    const { lock } = await attemptAutoLock({
-      trip: makeTrip(),
-      targetWaypoint: target,
-      originStation: '강남',
-      direction: 'up',
-      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
-      now: NOW,
-      // environment 미전달 → consensusGate 미적용
-    });
+    const { lock } = await callEnvAutoLock(arrival({ trainCode: 'T1', arvlCd: 1 }));
     expect(lock).not.toBeNull();
   });
 
   it('gateOutcome 미전달 → consensusGate skip (구 호출자 호환)', async () => {
-    const { lock } = await attemptAutoLock({
-      trip: makeTrip(),
-      targetWaypoint: target,
-      originStation: '강남',
-      direction: 'up',
-      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
-      now: NOW,
+    const { lock } = await callEnvAutoLock(arrival({ trainCode: 'T1', arvlCd: 1 }), {
       environment: 'underground',
-      // gateOutcome 미전달 → consensusGate 미적용
     });
     expect(lock).not.toBeNull();
   });

--- a/backend/alarm-worker/src/__tests__/autoLock.test.ts
+++ b/backend/alarm-worker/src/__tests__/autoLock.test.ts
@@ -408,26 +408,26 @@ describe('attemptAutoLock allowedLines gate (#1439 ADR-015 §9)', () => {
   });
 });
 
-describe('attemptAutoLock #1536 (S3) 환경 분기 consensusGate', () => {
-  function passingGateOutcome(): Parameters<typeof attemptAutoLock>[0]['gateOutcome'] {
-    return {
-      pass: true as const,
-      metrics: {
-        count: 3,
-        gpsAvgKmh: 20,
-        avgAccuracyMeters: 10,
-        motion: 'automotive',
-        start: { lat: 0, lng: 0 },
-        end: { lat: 0, lng: 0.001 },
-        mapMatchedKmh: null,
-      },
-      fusedSpeedKmh: 20,
-    };
-  }
-  function failingGateOutcome(): Parameters<typeof attemptAutoLock>[0]['gateOutcome'] {
-    return { pass: false as const, reason: 'window-too-small' as const };
-  }
+function passingGateOutcome(): Parameters<typeof attemptAutoLock>[0]['gateOutcome'] {
+  return {
+    pass: true as const,
+    metrics: {
+      count: 3,
+      gpsAvgKmh: 20,
+      avgAccuracyMeters: 10,
+      motion: 'automotive',
+      start: { lat: 0, lng: 0 },
+      end: { lat: 0, lng: 0.001 },
+      mapMatchedKmh: null,
+    },
+    fusedSpeedKmh: 20,
+  };
+}
+function failingGateOutcome(): Parameters<typeof attemptAutoLock>[0]['gateOutcome'] {
+  return { pass: false as const, reason: 'window-too-small' as const };
+}
 
+describe('attemptAutoLock #1536 (S3) 환경 분기 consensusGate', () => {
   it('surface + base gate pass + arrival 신호 있음 → lock 합성', async () => {
     const { lock } = await attemptAutoLock({
       trip: makeTrip(),

--- a/backend/alarm-worker/src/__tests__/autoLock.test.ts
+++ b/backend/alarm-worker/src/__tests__/autoLock.test.ts
@@ -451,25 +451,29 @@ function callEnvAutoLock(
 }
 
 describe('attemptAutoLock #1536 (S3) 환경 분기 consensusGate', () => {
-  it('surface + base gate pass + arrival 신호 있음 → lock 합성', async () => {
+  // it.each: (env, gate pass/fail, expected) 매트릭스로 surface + mixed 의 base-gate 의존성 일괄 검증.
+  // surface = base gate pass-through, mixed = base gate + 합의 동시 강제 (둘 다 base fail 시 null).
+  // underground 는 base gate 무관 — 별도 it 로 분리.
+  it.each([
+    ['surface', 'pass', 'lock'] as const,
+    ['surface', 'fail', 'null'] as const,
+    ['mixed', 'pass', 'lock'] as const,
+    ['mixed', 'fail', 'null'] as const,
+  ])('%s + base gate %s → %s', async (env, gate, expected) => {
     const { lock } = await callEnvAutoLock(arrival({ trainCode: 'T1', arvlCd: 1 }), {
-      environment: 'surface',
-      gateOutcome: passingGateOutcome(),
+      environment: env,
+      gateOutcome: gate === 'pass' ? passingGateOutcome() : failingGateOutcome(),
     });
-    expect(lock?.trainCode).toBe('T1');
+    if (expected === 'lock') {
+      expect(lock?.trainCode).toBe('T1');
+    } else {
+      expect(lock).toBeNull();
+    }
   });
 
-  it('surface + base gate fail → consensusGate "base-gate-failed" → null', async () => {
-    const { lock } = await callEnvAutoLock(arrival({ trainCode: 'T1', arvlCd: 1 }), {
-      environment: 'surface',
-      gateOutcome: failingGateOutcome(),
-    });
-    expect(lock).toBeNull();
-  });
-
-  it('underground + arrival(arvlCd=1) + lockAttachable → 합의 통과 → lock 합성', async () => {
+  it('underground: base gate fail 도 arrival+lockAttachable 만 있으면 통과 (GPS 무관)', async () => {
     // underground 분기는 base gate 결과 무관하게 arrival + lockAttachable 2-of-2
-    // (consensusGate.ts:149-158). 따라서 base gate fail 도 통과.
+    // (consensusGate.ts:149-158).
     const { lock } = await callEnvAutoLock(arrival({ trainCode: 'T1', arvlCd: 1 }), {
       environment: 'underground',
       gateOutcome: failingGateOutcome(),
@@ -486,31 +490,12 @@ describe('attemptAutoLock #1536 (S3) 환경 분기 consensusGate', () => {
     expect(lock).toBeNull();
   });
 
-  it('mixed + base gate pass + arrival + lockAttachable → 통과', async () => {
-    const { lock } = await callEnvAutoLock(arrival({ trainCode: 'T1', arvlCd: 1 }), {
-      environment: 'mixed',
-      gateOutcome: passingGateOutcome(),
-    });
-    expect(lock?.trainCode).toBe('T1');
-  });
-
-  it('mixed + base gate fail → null (mixed 는 base gate 통과 강제)', async () => {
-    const { lock } = await callEnvAutoLock(arrival({ trainCode: 'T1', arvlCd: 1 }), {
-      environment: 'mixed',
-      gateOutcome: failingGateOutcome(),
-    });
-    expect(lock).toBeNull();
-  });
-
-  it('environment 미전달 → consensusGate skip (구 호출자 호환)', async () => {
-    const { lock } = await callEnvAutoLock(arrival({ trainCode: 'T1', arvlCd: 1 }));
-    expect(lock).not.toBeNull();
-  });
-
-  it('gateOutcome 미전달 → consensusGate skip (구 호출자 호환)', async () => {
-    const { lock } = await callEnvAutoLock(arrival({ trainCode: 'T1', arvlCd: 1 }), {
-      environment: 'underground',
-    });
+  // env / gateOutcome 미전달 시 모두 consensusGate skip (구 호출자 호환). 매트릭스로 한번에.
+  it.each([
+    ['env 미전달', {} as const],
+    ['gateOutcome 미전달', { environment: 'underground' as const }],
+  ])('%s → consensusGate skip', async (_label, opts) => {
+    const { lock } = await callEnvAutoLock(arrival({ trainCode: 'T1', arvlCd: 1 }), opts);
     expect(lock).not.toBeNull();
   });
 });

--- a/backend/alarm-worker/src/__tests__/autoLock.test.ts
+++ b/backend/alarm-worker/src/__tests__/autoLock.test.ts
@@ -407,3 +407,138 @@ describe('attemptAutoLock allowedLines gate (#1439 ADR-015 §9)', () => {
     expect(lock).not.toBeNull();
   });
 });
+
+describe('attemptAutoLock #1536 (S3) 환경 분기 consensusGate', () => {
+  function passingGateOutcome(): Parameters<typeof attemptAutoLock>[0]['gateOutcome'] {
+    return {
+      pass: true as const,
+      metrics: {
+        count: 3,
+        gpsAvgKmh: 20,
+        avgAccuracyMeters: 10,
+        motion: 'automotive',
+        start: { lat: 0, lng: 0 },
+        end: { lat: 0, lng: 0.001 },
+        mapMatchedKmh: null,
+      },
+      fusedSpeedKmh: 20,
+    };
+  }
+  function failingGateOutcome(): Parameters<typeof attemptAutoLock>[0]['gateOutcome'] {
+    return { pass: false as const, reason: 'window-too-small' as const };
+  }
+
+  it('surface + base gate pass + arrival 신호 있음 → lock 합성', async () => {
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
+      now: NOW,
+      environment: 'surface',
+      gateOutcome: passingGateOutcome(),
+    });
+    expect(lock?.trainCode).toBe('T1');
+  });
+
+  it('surface + base gate fail → consensusGate "base-gate-failed" → null', async () => {
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
+      now: NOW,
+      environment: 'surface',
+      gateOutcome: failingGateOutcome(),
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('underground + arrival(arvlCd=1) + lockAttachable → 합의 통과 → lock 합성', async () => {
+    // underground 분기는 base gate 결과 무관하게 arrival + lockAttachable 2-of-2
+    // (consensusGate.ts:149-158). 따라서 base gate fail 도 통과.
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
+      now: NOW,
+      environment: 'underground',
+      gateOutcome: failingGateOutcome(),
+    });
+    expect(lock?.trainCode).toBe('T1');
+  });
+
+  it('underground + arrival arvlCd 범위 밖 (=5) → arrival signal 미존재 → null', async () => {
+    // arvlCd=5 (PREV_ARRIVED) 는 0~3 범위 밖 → arrivalSignalPresent=false → 합의 미달.
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 5 })]),
+      now: NOW,
+      environment: 'underground',
+      gateOutcome: passingGateOutcome(),
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('mixed + base gate pass + arrival + lockAttachable → 통과', async () => {
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
+      now: NOW,
+      environment: 'mixed',
+      gateOutcome: passingGateOutcome(),
+    });
+    expect(lock?.trainCode).toBe('T1');
+  });
+
+  it('mixed + base gate fail → null (mixed 는 base gate 통과 강제)', async () => {
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
+      now: NOW,
+      environment: 'mixed',
+      gateOutcome: failingGateOutcome(),
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('environment 미전달 → consensusGate skip (구 호출자 호환)', async () => {
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
+      now: NOW,
+      // environment 미전달 → consensusGate 미적용
+    });
+    expect(lock).not.toBeNull();
+  });
+
+  it('gateOutcome 미전달 → consensusGate skip (구 호출자 호환)', async () => {
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
+      now: NOW,
+      environment: 'underground',
+      // gateOutcome 미전달 → consensusGate 미적용
+    });
+    expect(lock).not.toBeNull();
+  });
+});

--- a/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
+++ b/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
@@ -389,6 +389,123 @@ describe('evaluateBoardingPromptGates — #833 pre-computed metrics 재사용', 
   });
 });
 
+describe('evaluateBoardingPromptGates — #1536 (S3) 환경 분기', () => {
+  const now = 1_000_000;
+
+  /**
+   * 지하 환경에서 GPS series 가 stale(=잘못된 좌표) 인 경우. 기존 9단 AND 게이트는
+   * #4 origin-too-far / #5 direction-mismatch 등으로 100% fail → 7일 누적 0건 회귀.
+   * environment='underground' 분기는 GPS 의존 게이트(#3~#7) byPass 후 #8 motion 만 평가.
+   * accuracy 는 surface 분기의 #4 origin-too-far reason 분리를 위해 cutoff(50m) 미만 사용.
+   */
+  function staleGpsSeries(n: number): PositionPoint[] {
+    // 출발역(0,0) 에서 1km 떨어진 wrong 좌표 + 잘못된 방향 진행 (서쪽). accuracy 10m.
+    return [
+      { lat: 0.01, lng: 0.01, accuracy: 10, ts: n - 60_000, motion: 'automotive' },
+      { lat: 0.01, lng: 0.009, accuracy: 10, ts: n - 30_000, motion: 'automotive' },
+      { lat: 0.01, lng: 0.008, accuracy: 10, ts: n, motion: 'automotive' },
+    ];
+  }
+
+  it('underground: stale GPS series 도 motion=automotive 면 통과 (fusedSpeedKmh=0)', () => {
+    const r = evaluateBoardingPromptGates({
+      series: staleGpsSeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      environment: 'underground',
+    });
+    expect(r.pass).toBe(true);
+    if (r.pass) expect(r.fusedSpeedKmh).toBe(0);
+  });
+
+  it('underground: motion=stationary 면 #8 게이트로 차단 (motion-not-moving)', () => {
+    const stationary = staleGpsSeries(now).map((p) => ({
+      ...p,
+      motion: 'stationary' as const,
+    }));
+    const r = evaluateBoardingPromptGates({
+      series: stationary,
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      environment: 'underground',
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('motion-not-moving');
+  });
+
+  it('underground: 이미 fired = already-fired (게이트 #9 우선 평가)', () => {
+    const r = evaluateBoardingPromptGates({
+      series: staleGpsSeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      environment: 'underground',
+      promptState: { fired: true, lastFiredAt: now - 1000 },
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('already-fired');
+  });
+
+  it('mixed: GPS 의존 게이트 byPass (underground 와 동일 분기)', () => {
+    const r = evaluateBoardingPromptGates({
+      series: staleGpsSeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      environment: 'mixed',
+    });
+    expect(r.pass).toBe(true);
+  });
+
+  it('unknown: GPS 의존 게이트 byPass (보수적 분기)', () => {
+    const r = evaluateBoardingPromptGates({
+      series: staleGpsSeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      environment: 'unknown',
+    });
+    expect(r.pass).toBe(true);
+  });
+
+  it('surface: stale GPS series 는 기존 9단 AND 그대로 — origin-too-far 차단', () => {
+    const r = evaluateBoardingPromptGates({
+      series: staleGpsSeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      environment: 'surface',
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('origin-too-far');
+  });
+
+  it('environment undefined (legacy 호출자) 는 기존 9단 AND 그대로', () => {
+    const r = evaluateBoardingPromptGates({
+      series: staleGpsSeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('origin-too-far');
+  });
+
+  it('surface env + happy series → 기존처럼 fusedSpeedKmh>0', () => {
+    const r = evaluateBoardingPromptGates({
+      series: happySeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      environment: 'surface',
+    });
+    expect(r.pass).toBe(true);
+    if (r.pass) expect(r.fusedSpeedKmh).toBeGreaterThan(5);
+  });
+});
+
 describe('markPromptFired / markPromptSilenced', () => {
   it('markPromptFired는 fired=true + lastFiredAt 설정', () => {
     expect(markPromptFired(1234)).toEqual({ fired: true, lastFiredAt: 1234 });

--- a/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
+++ b/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
@@ -389,23 +389,23 @@ describe('evaluateBoardingPromptGates — #833 pre-computed metrics 재사용', 
   });
 });
 
+/**
+ * 지하 환경에서 GPS series 가 stale(=잘못된 좌표) 인 경우. 기존 9단 AND 게이트는
+ * #4 origin-too-far / #5 direction-mismatch 등으로 100% fail → 7일 누적 0건 회귀.
+ * environment='underground' 분기는 GPS 의존 게이트(#3~#7) byPass 후 #8 motion 만 평가.
+ * accuracy 는 surface 분기의 #4 origin-too-far reason 분리를 위해 cutoff(50m) 미만 사용.
+ */
+function staleGpsSeries(n: number): PositionPoint[] {
+  // 출발역(0,0) 에서 1km 떨어진 wrong 좌표 + 잘못된 방향 진행 (서쪽). accuracy 10m.
+  return [
+    { lat: 0.01, lng: 0.01, accuracy: 10, ts: n - 60_000, motion: 'automotive' },
+    { lat: 0.01, lng: 0.009, accuracy: 10, ts: n - 30_000, motion: 'automotive' },
+    { lat: 0.01, lng: 0.008, accuracy: 10, ts: n, motion: 'automotive' },
+  ];
+}
+
 describe('evaluateBoardingPromptGates — #1536 (S3) 환경 분기', () => {
   const now = 1_000_000;
-
-  /**
-   * 지하 환경에서 GPS series 가 stale(=잘못된 좌표) 인 경우. 기존 9단 AND 게이트는
-   * #4 origin-too-far / #5 direction-mismatch 등으로 100% fail → 7일 누적 0건 회귀.
-   * environment='underground' 분기는 GPS 의존 게이트(#3~#7) byPass 후 #8 motion 만 평가.
-   * accuracy 는 surface 분기의 #4 origin-too-far reason 분리를 위해 cutoff(50m) 미만 사용.
-   */
-  function staleGpsSeries(n: number): PositionPoint[] {
-    // 출발역(0,0) 에서 1km 떨어진 wrong 좌표 + 잘못된 방향 진행 (서쪽). accuracy 10m.
-    return [
-      { lat: 0.01, lng: 0.01, accuracy: 10, ts: n - 60_000, motion: 'automotive' },
-      { lat: 0.01, lng: 0.009, accuracy: 10, ts: n - 30_000, motion: 'automotive' },
-      { lat: 0.01, lng: 0.008, accuracy: 10, ts: n, motion: 'automotive' },
-    ];
-  }
 
   it('underground: stale GPS series 도 motion=automotive 면 통과 (fusedSpeedKmh=0)', () => {
     const r = evaluateBoardingPromptGates({

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -643,6 +643,11 @@ export interface SendBoardingPromptPushOptions {
   line: string;
   tripToken: string;
   sentAt: number;
+  /**
+   * #1536 (S3, T13) — trigger source. 미지정 시 'cron' (기존 동작).
+   * device 는 telemetry 적재 시 source 분포 측정에 사용.
+   */
+  triggerKind?: 'cron' | 'instant';
   config: ApnsConfig;
   host: string;
   fetchImpl?: typeof fetch;
@@ -663,6 +668,7 @@ export async function sendBoardingPromptPush(
     line: options.line,
     tripToken: options.tripToken,
     sentAt: options.sentAt,
+    triggerKind: options.triggerKind,
   };
 
   const body = JSON.stringify({

--- a/backend/alarm-worker/src/autoLock.ts
+++ b/backend/alarm-worker/src/autoLock.ts
@@ -20,10 +20,20 @@
  *
  * 거짓 양성 차단: 사용자가 자동 lock 직후 다른 trainCode를 탭하면 client가 새 lock POST →
  * 기존 #864/#704 same-session 분기가 새 lock으로 자연 교체 (Seam F swap과 동일 경로).
+ *
+ * #1536 (S3, Epic #1533) — 환경 분기. caller 가 `environment` + `gateOutcome` 동반 전달 시
+ * `evaluateConsensusGate(environment, signals)` 가 추가 합의 검증. underground 환경에서
+ * arrival(arvlCd 0~3) + lockAttachable(trainCode 단일 수렴) 2-of-2 합의 미충족 시 null
+ * 반환 → boarding-prompt push fallback. lesson `boarding_prompt_9and_gate_gps_only` 회귀
+ * (지하 7일 누적 0건) 직접 해소.
  */
 
-import { pickAutoTrainCode } from './boardingPrompt';
-import { isLockLineAllowed } from './consensusGate';
+import { pickAutoTrainCode, type GateOutcome } from './boardingPrompt';
+import {
+  evaluateConsensusGate,
+  isLockLineAllowed,
+  type StationEnvironment,
+} from './consensusGate';
 import { matchLine, subwayIdForLine } from './lineAlias';
 import { buildLegSegmentStations, SWAP_LOCK_TTL_MS } from './lockSwap';
 import { METRIC_KIND, writeMetricDataPoints, type HistogramMetric } from './metrics';
@@ -116,6 +126,29 @@ export interface AttemptAutoLockInputs {
    * 검증을 skip — 구 호출자 호환 + trip route 데이터가 없는 케이스 보수적 허용.
    */
   allowedLines?: Set<LineNumber>;
+  /**
+   * #1536 (S3, Epic #1533) — trip 환경. consensusGate 분기 입력.
+   *
+   * - 'surface': 9단 게이트 통과면 lockAttachable=true 면 즉시 통과 — 기존 동작.
+   * - 'underground' | 'mixed' | 'unknown': arrival + lockAttachable 2-of-2 합의 강제.
+   *   `evaluateConsensusGate` 가 미통과면 lock 합성 skip — `pickAutoTrainCode` 단일 수렴이
+   *   lockAttachable signal 로 forward 되어 합의를 만든다(arrival signal 은 chosen
+   *   ArrivalEntry.arvlCd 가 0~3 범위면 present 로 판정).
+   *
+   * 미전달(undefined) 시 검증 skip — 구 호출자 호환. 신규 호출자(scheduled.ts)는 항상 전달.
+   */
+  environment?: StationEnvironment;
+  /**
+   * #1536 (S3) — 9단 게이트 결과. `evaluateConsensusGate` 의 `gateOutcome` 입력으로 forward.
+   *
+   * caller(scheduled.ts) 가 `evaluateBoardingPromptGates` 결과를 그대로 전달한다.
+   * GPS bypass 분기에서는 `outcome.pass=true` 이고 `fusedSpeedKmh=0` 이지만 consensusGate
+   * 의 underground 분기는 baseGatePassed 와 무관하게 arrival+lockAttachable 만 평가하므로
+   * 안전(consensusGate.ts:149-158 참조).
+   *
+   * 미전달(undefined) 시 검증 skip — 구 호출자 호환.
+   */
+  gateOutcome?: GateOutcome;
 }
 
 /**
@@ -178,6 +211,8 @@ export async function attemptAutoLock(
     boardingPromptState,
     lastMotionAt,
     allowedLines,
+    environment,
+    gateOutcome,
   } = inputs;
   const line = targetWaypoint.line;
   const subwayId = subwayIdForLine(line);
@@ -200,6 +235,26 @@ export async function attemptAutoLock(
 
   const trainCode = pickAutoTrainCode(arrivals, line, direction);
   if (!trainCode) return { lock: null };
+
+  // #1536 (S3, Epic #1533) — environment + gateOutcome 모두 전달 시 consensusGate 분기 강제.
+  // underground/mixed/unknown 환경에서 arrival(=chosen arvlCd 0~3) + lockAttachable(=trainCode
+  // 단일 수렴 = true) 2-of-2 합의가 통과해야 lock 합성 진행. surface 는 base gate(=outcome.pass)
+  // 가 통과하면 즉시 통과. 미전달 시 (구 호출자) skip.
+  if (environment && gateOutcome) {
+    const chosenForGate = arrivals.find((a) => a.trainCode === trainCode);
+    const arrivalSignalPresent =
+      typeof chosenForGate?.arvlCd === 'number' &&
+      chosenForGate.arvlCd >= 0 &&
+      chosenForGate.arvlCd <= 3;
+    const consensus = evaluateConsensusGate(environment, {
+      gateOutcome,
+      arrivalSignalPresent,
+      // trainCode 단일 수렴 = lockAttachable. pickAutoTrainCode 가 null 이면 함수가 이미
+      // 더 위에서 return 했으므로 본 시점에서는 항상 true.
+      lockAttachable: true,
+    });
+    if (!consensus.pass) return { lock: null };
+  }
 
   // #1018 RC1 confidence gate — arvlCd=2(출발) at next-waypoint는 사용자가 이미 그 열차를
   // 타고 origin을 떠났거나, 반대로 그 열차가 사용자보다 먼저 출발했을 수 있다 (origin-pass 후보).

--- a/backend/alarm-worker/src/boardingPrompt.ts
+++ b/backend/alarm-worker/src/boardingPrompt.ts
@@ -15,9 +15,20 @@
  * arvlCd 우선순위 (ADR Section 1.2):
  *   2 (출발) > 1 (도착) > 0 (진입) > 그 외 receivedAt 가까운 + 방향 매칭
  *   ambiguity → 자동 안 함 → 클라가 manual fallback.
+ *
+ * #1536 (S3, Epic #1533) — 환경 분기 추가.
+ *   inputs.environment 가 underground / mixed / unknown 인 경우 GPS 의존 게이트
+ *   (#3 accuracy / #4 origin / #5 direction / #6 window / #7 speed) 를 byPass 한다.
+ *   이 게이트들은 모두 GPS series 신호에서 유도되므로 지하 GPS stale 환경에서는
+ *   100% fail → 7일 누적 boardingPrompt 0건 회귀 (mem `lesson_boarding_prompt_9and_gate_gps_only`).
+ *   대신 caller(scheduled.ts)가 evaluateConsensusGate(environment, signals)로 합의 게이트를
+ *   적용하여 arrival + lockAttachable 2-of-2 신호로 통과 판정한다. 본 함수는 environment
+ *   인자가 underground/mixed/unknown 이면 #8(motion) + #9(silence/fired) 만 평가 — caller가
+ *   consensusGate 통과 책임을 진다. surface(또는 환경 미상 = undefined)는 기존 9단 AND 동작 유지.
  */
 
 import { ARRIVAL_CODE } from './alarm';
+import type { StationEnvironment } from './consensusGate';
 import { fusedSpeed } from './fusedSpeed';
 import { matchLine } from './lineAlias';
 import {
@@ -86,11 +97,28 @@ export interface EvaluateBoardingPromptInputs {
    * hot path redundancy를 제거한다. 미지정 시 내부에서 1회 계산 — 회귀 없음.
    */
   metrics?: WindowedMetrics;
+  /**
+   * #1536 (S3) — trip 환경. 'underground' | 'mixed' | 'unknown' 이면 GPS 의존 게이트
+   * (#3 accuracy / #4 origin / #5 direction / #6 window / #7 speed) 를 byPass 한다.
+   * 'surface' 또는 undefined(legacy 호출자) 는 기존 9단 AND 게이트를 그대로 평가한다.
+   *
+   * caller(scheduled.ts)가 trip.subsurface → deriveEvidenceEnvironment → mapEvidenceEnvironment
+   * 로 변환된 값을 그대로 forward한다. underground 분기에서도 #8 motion + #9 silence/fired는
+   * 반드시 평가 — caller는 별도로 evaluateConsensusGate(environment, signals)로 arrival+
+   * lockAttachable 2-of-2 합의를 검증해야 한다(false positive 차단).
+   */
+  environment?: StationEnvironment;
 }
 
 /**
  * 9단 AND 게이트 평가. 한 게이트라도 실패하면 즉시 reason과 함께 fail.
  * 게이트 #1/#2는 caller가 미리 보장 (listTrips × lockMissing 분기) — 본 함수는 #3~#9만 평가.
+ *
+ * #1536 (S3) — `inputs.environment` 가 'underground' | 'mixed' | 'unknown' 이면 GPS 의존
+ * 게이트(#3~#7) 를 byPass 한다. 지하 GPS stale 환경에서 series 신호가 항상 wrong → 100%
+ * fail 회귀 차단. 이 분기에서는 #8 motion + #9 silence/fired 만 평가하며, caller(scheduled.ts)
+ * 가 evaluateConsensusGate(environment, signals) 로 arrival + lockAttachable 합의를 별도 검증해
+ * false positive 를 차단해야 한다. `environment` 미지정 또는 'surface' 면 기존 9단 AND 평가.
  */
 export function evaluateBoardingPromptGates(
   inputs: EvaluateBoardingPromptInputs,
@@ -108,70 +136,88 @@ export function evaluateBoardingPromptGates(
     }
   }
 
+  const env = inputs.environment;
+  const gpsDependentBypass =
+    env === 'underground' || env === 'mixed' || env === 'unknown';
+
   // #6 — 60s 윈도우 N≥3 (cold start 보호). 0/1 sample은 metrics.start/end null로 자연 차단.
   // #833 — 호출자가 동일 series/now로 이미 evaluateWindow를 돌렸다면(예: scheduled.ts의
   // Kalman observation) 결과를 재사용해 hot path 중복 계산을 제거한다.
+  // #1536 — series 가 비어 있을 수 있는 지하 환경에서도 metrics 자체는 산출 가능
+  // (count=0). GPS bypass 분기는 motion 평가에 metrics.motion 가 'unknown'(window-too-small의
+  // 자연 결과)이라도 #8 motion 게이트가 자연 차단. 분기 이전에 metrics 계산은 공통 비용.
   const metrics = inputs.metrics ?? evaluateWindow(inputs.series, inputs.now);
-  if (metrics.count < MIN_WINDOW_SAMPLES) {
-    return { pass: false, reason: 'window-too-small', metrics };
-  }
-  // window-too-small이 통과한 이후엔 start/end가 null이 될 수 없음(count ≥ 3).
-  // TypeScript narrowing을 위해 명시 assert로 진행.
-  if (!metrics.start || !metrics.end) {
-    return { pass: false, reason: 'window-too-small', metrics };
+
+  if (!gpsDependentBypass) {
+    if (metrics.count < MIN_WINDOW_SAMPLES) {
+      return { pass: false, reason: 'window-too-small', metrics };
+    }
+    // window-too-small이 통과한 이후엔 start/end가 null이 될 수 없음(count ≥ 3).
+    // TypeScript narrowing을 위해 명시 assert로 진행.
+    if (!metrics.start || !metrics.end) {
+      return { pass: false, reason: 'window-too-small', metrics };
+    }
+
+    // #3 — accuracy. 평균 accuracy가 50m 이상이면 신뢰 불가.
+    if (metrics.avgAccuracyMeters >= ACCURACY_CUTOFF_M) {
+      return { pass: false, reason: 'accuracy-too-poor', metrics };
+    }
+
+    // #4 — 출발역 100m 이내. 마지막 sample 기준 (가장 최신 위치).
+    const originDistanceKm = haversineKm(
+      metrics.end.lat,
+      metrics.end.lng,
+      inputs.origin.lat,
+      inputs.origin.lng,
+    );
+    if (originDistanceKm > ORIGIN_RADIUS_KM) {
+      return { pass: false, reason: 'origin-too-far', metrics };
+    }
+
+    // #5 — 방향 cosine ≥ 0.7. expected vector는 출발역 → 다음역.
+    const cos = cosineDirection(
+      metrics.start.lat,
+      metrics.start.lng,
+      metrics.end.lat,
+      metrics.end.lng,
+      inputs.origin.lat,
+      inputs.origin.lng,
+      inputs.nextStation.lat,
+      inputs.nextStation.lng,
+    );
+    if (cos < DIRECTION_COSINE_THRESHOLD) {
+      return { pass: false, reason: 'direction-mismatch', metrics };
+    }
   }
 
-  // #3 — accuracy. 평균 accuracy가 50m 이상이면 신뢰 불가.
-  if (metrics.avgAccuracyMeters >= ACCURACY_CUTOFF_M) {
-    return { pass: false, reason: 'accuracy-too-poor', metrics };
-  }
-
-  // #4 — 출발역 100m 이내. 마지막 sample 기준 (가장 최신 위치).
-  const originDistanceKm = haversineKm(
-    metrics.end.lat,
-    metrics.end.lng,
-    inputs.origin.lat,
-    inputs.origin.lng,
-  );
-  if (originDistanceKm > ORIGIN_RADIUS_KM) {
-    return { pass: false, reason: 'origin-too-far', metrics };
-  }
-
-  // #5 — 방향 cosine ≥ 0.7. expected vector는 출발역 → 다음역.
-  const cos = cosineDirection(
-    metrics.start.lat,
-    metrics.start.lng,
-    metrics.end.lat,
-    metrics.end.lng,
-    inputs.origin.lat,
-    inputs.origin.lng,
-    inputs.nextStation.lat,
-    inputs.nextStation.lng,
-  );
-  if (cos < DIRECTION_COSINE_THRESHOLD) {
-    return { pass: false, reason: 'direction-mismatch', metrics };
-  }
-
-  // #8 — motion ∈ {walking, automotive}. stationary/unknown은 차단.
+  // #8 — motion ∈ {walking, automotive}. stationary/unknown은 차단. GPS bypass 분기에서도
+  // 평가 — CMMotionActivity 기반 신호는 지하에서도 작동(mem `lesson_motion_activity_intermittent_signal`
+  // 의 5~10분 주기 뒤집힘 한계는 있으나 #819 게이트 #8 단독으로 false positive 차단 의무는 없음 —
+  // caller 의 consensusGate 가 arrival+lockAttachable 합의로 보완).
   if (metrics.motion !== 'walking' && metrics.motion !== 'automotive') {
     return { pass: false, reason: 'motion-not-moving', metrics };
   }
 
-  // #7 — fused speed. mapMatchedKmh는 #828, kalmanKmh는 #824에서 wire — 양 끝 sample이 같은
-  // line + arcM을 가질 때만 evaluateWindow가 mapMatchedKmh 산출, 그 외에는 null로 강등
-  // (GPS-only fallback). kalmanKmh는 호출자(scheduled.ts)가 runKalmanStep으로 산출 후 주입.
-  const fused = fusedSpeed({
-    gpsAvgKmh: metrics.gpsAvgKmh,
-    gpsAccuracyMeters: metrics.avgAccuracyMeters,
-    motion: metrics.motion,
-    mapMatchedKmh: metrics.mapMatchedKmh,
-    kalmanKmh: inputs.kalmanKmh ?? null,
-  });
-  if (fused.speed < MIN_FUSED_SPEED_KMH || fused.confidence === 'low') {
-    return { pass: false, reason: 'speed-too-low', metrics };
+  if (!gpsDependentBypass) {
+    // #7 — fused speed. mapMatchedKmh는 #828, kalmanKmh는 #824에서 wire — 양 끝 sample이 같은
+    // line + arcM을 가질 때만 evaluateWindow가 mapMatchedKmh 산출, 그 외에는 null로 강등
+    // (GPS-only fallback). kalmanKmh는 호출자(scheduled.ts)가 runKalmanStep으로 산출 후 주입.
+    const fused = fusedSpeed({
+      gpsAvgKmh: metrics.gpsAvgKmh,
+      gpsAccuracyMeters: metrics.avgAccuracyMeters,
+      motion: metrics.motion,
+      mapMatchedKmh: metrics.mapMatchedKmh,
+      kalmanKmh: inputs.kalmanKmh ?? null,
+    });
+    if (fused.speed < MIN_FUSED_SPEED_KMH || fused.confidence === 'low') {
+      return { pass: false, reason: 'speed-too-low', metrics };
+    }
+    return { pass: true, metrics, fusedSpeedKmh: fused.speed };
   }
 
-  return { pass: true, metrics, fusedSpeedKmh: fused.speed };
+  // #1536 — GPS bypass 분기는 fusedSpeed 산출 자체가 의미 없으므로 0 으로 표기.
+  // caller 가 본 값을 로깅 외 용도로 쓰면 회귀 → caller(scheduled.ts) 가 분기 인지하고 사용.
+  return { pass: true, metrics, fusedSpeedKmh: 0 };
 }
 
 /**

--- a/backend/alarm-worker/src/boardingPrompt.ts
+++ b/backend/alarm-worker/src/boardingPrompt.ts
@@ -111,6 +111,101 @@ export interface EvaluateBoardingPromptInputs {
 }
 
 /**
+ * 게이트 #9 — silence / 1회 발사 dedup. promptState 부재 = 첫 시도, 통과 (null 반환).
+ */
+function evaluateSilenceGate(
+  promptState: BoardingPromptState | undefined,
+  now: number,
+): GateOutcome | null {
+  if (!promptState) return null;
+  if (promptState.fired) {
+    return { pass: false, reason: 'already-fired' };
+  }
+  if (
+    promptState.silencedUntil !== undefined &&
+    promptState.silencedUntil > now
+  ) {
+    return { pass: false, reason: 'silenced' };
+  }
+  return null;
+}
+
+/**
+ * GPS 의존 게이트 #3~#5 + #6 평가 (window + accuracy + origin + direction).
+ * 통과 시 null 반환, fail 시 GateOutcome.
+ */
+function evaluateGpsGeometryGates(
+  inputs: EvaluateBoardingPromptInputs,
+  metrics: WindowedMetrics,
+): GateOutcome | null {
+  if (metrics.count < MIN_WINDOW_SAMPLES) {
+    return { pass: false, reason: 'window-too-small', metrics };
+  }
+  // window-too-small이 통과한 이후엔 start/end가 null이 될 수 없음(count ≥ 3).
+  // TypeScript narrowing을 위해 명시 assert로 진행.
+  if (!metrics.start || !metrics.end) {
+    return { pass: false, reason: 'window-too-small', metrics };
+  }
+  // #3 — accuracy. 평균 accuracy가 50m 이상이면 신뢰 불가.
+  if (metrics.avgAccuracyMeters >= ACCURACY_CUTOFF_M) {
+    return { pass: false, reason: 'accuracy-too-poor', metrics };
+  }
+  // #4 — 출발역 100m 이내. 마지막 sample 기준 (가장 최신 위치).
+  const originDistanceKm = haversineKm(
+    metrics.end.lat,
+    metrics.end.lng,
+    inputs.origin.lat,
+    inputs.origin.lng,
+  );
+  if (originDistanceKm > ORIGIN_RADIUS_KM) {
+    return { pass: false, reason: 'origin-too-far', metrics };
+  }
+  // #5 — 방향 cosine ≥ 0.7. expected vector는 출발역 → 다음역.
+  const cos = cosineDirection(
+    metrics.start.lat,
+    metrics.start.lng,
+    metrics.end.lat,
+    metrics.end.lng,
+    inputs.origin.lat,
+    inputs.origin.lng,
+    inputs.nextStation.lat,
+    inputs.nextStation.lng,
+  );
+  if (cos < DIRECTION_COSINE_THRESHOLD) {
+    return { pass: false, reason: 'direction-mismatch', metrics };
+  }
+  return null;
+}
+
+/**
+ * 게이트 #7 — fused speed 평가. mapMatchedKmh + kalmanKmh 가중 합산.
+ * 통과 시 fusedSpeedKmh, fail 시 reason.
+ */
+function evaluateFusedSpeedGate(
+  inputs: EvaluateBoardingPromptInputs,
+  metrics: WindowedMetrics,
+): { pass: true; fusedSpeedKmh: number } | { pass: false; reason: GateSkipReason } {
+  const fused = fusedSpeed({
+    gpsAvgKmh: metrics.gpsAvgKmh,
+    gpsAccuracyMeters: metrics.avgAccuracyMeters,
+    motion: metrics.motion,
+    mapMatchedKmh: metrics.mapMatchedKmh,
+    kalmanKmh: inputs.kalmanKmh ?? null,
+  });
+  if (fused.speed < MIN_FUSED_SPEED_KMH || fused.confidence === 'low') {
+    return { pass: false, reason: 'speed-too-low' };
+  }
+  return { pass: true, fusedSpeedKmh: fused.speed };
+}
+
+/**
+ * #1536 — 환경 분기 판정. underground / mixed / unknown 은 GPS 의존 게이트 byPass.
+ */
+function isGpsDependentBypassEnv(env: StationEnvironment | undefined): boolean {
+  return env === 'underground' || env === 'mixed' || env === 'unknown';
+}
+
+/**
  * 9단 AND 게이트 평가. 한 게이트라도 실패하면 즉시 reason과 함께 fail.
  * 게이트 #1/#2는 caller가 미리 보장 (listTrips × lockMissing 분기) — 본 함수는 #3~#9만 평가.
  *
@@ -123,101 +218,40 @@ export interface EvaluateBoardingPromptInputs {
 export function evaluateBoardingPromptGates(
   inputs: EvaluateBoardingPromptInputs,
 ): GateOutcome {
-  // #9 — silence / 1회 발사 dedup. promptState 부재 = 첫 시도, 통과.
-  if (inputs.promptState) {
-    if (inputs.promptState.fired) {
-      return { pass: false, reason: 'already-fired' };
-    }
-    if (
-      inputs.promptState.silencedUntil !== undefined &&
-      inputs.promptState.silencedUntil > inputs.now
-    ) {
-      return { pass: false, reason: 'silenced' };
-    }
-  }
+  // #9 — silence / 1회 발사 dedup (가장 cheap한 가드 우선).
+  const silenceOutcome = evaluateSilenceGate(inputs.promptState, inputs.now);
+  if (silenceOutcome) return silenceOutcome;
 
-  const env = inputs.environment;
-  const gpsDependentBypass =
-    env === 'underground' || env === 'mixed' || env === 'unknown';
+  const gpsDependentBypass = isGpsDependentBypassEnv(inputs.environment);
 
-  // #6 — 60s 윈도우 N≥3 (cold start 보호). 0/1 sample은 metrics.start/end null로 자연 차단.
-  // #833 — 호출자가 동일 series/now로 이미 evaluateWindow를 돌렸다면(예: scheduled.ts의
-  // Kalman observation) 결과를 재사용해 hot path 중복 계산을 제거한다.
+  // #833 — 호출자가 동일 series/now로 이미 evaluateWindow를 돌렸다면 결과 재사용.
   // #1536 — series 가 비어 있을 수 있는 지하 환경에서도 metrics 자체는 산출 가능
   // (count=0). GPS bypass 분기는 motion 평가에 metrics.motion 가 'unknown'(window-too-small의
-  // 자연 결과)이라도 #8 motion 게이트가 자연 차단. 분기 이전에 metrics 계산은 공통 비용.
+  // 자연 결과)이라도 #8 motion 게이트가 자연 차단.
   const metrics = inputs.metrics ?? evaluateWindow(inputs.series, inputs.now);
 
+  // surface / undefined 만 GPS 의존 게이트 평가 — underground/mixed/unknown 은 byPass.
   if (!gpsDependentBypass) {
-    if (metrics.count < MIN_WINDOW_SAMPLES) {
-      return { pass: false, reason: 'window-too-small', metrics };
-    }
-    // window-too-small이 통과한 이후엔 start/end가 null이 될 수 없음(count ≥ 3).
-    // TypeScript narrowing을 위해 명시 assert로 진행.
-    if (!metrics.start || !metrics.end) {
-      return { pass: false, reason: 'window-too-small', metrics };
-    }
-
-    // #3 — accuracy. 평균 accuracy가 50m 이상이면 신뢰 불가.
-    if (metrics.avgAccuracyMeters >= ACCURACY_CUTOFF_M) {
-      return { pass: false, reason: 'accuracy-too-poor', metrics };
-    }
-
-    // #4 — 출발역 100m 이내. 마지막 sample 기준 (가장 최신 위치).
-    const originDistanceKm = haversineKm(
-      metrics.end.lat,
-      metrics.end.lng,
-      inputs.origin.lat,
-      inputs.origin.lng,
-    );
-    if (originDistanceKm > ORIGIN_RADIUS_KM) {
-      return { pass: false, reason: 'origin-too-far', metrics };
-    }
-
-    // #5 — 방향 cosine ≥ 0.7. expected vector는 출발역 → 다음역.
-    const cos = cosineDirection(
-      metrics.start.lat,
-      metrics.start.lng,
-      metrics.end.lat,
-      metrics.end.lng,
-      inputs.origin.lat,
-      inputs.origin.lng,
-      inputs.nextStation.lat,
-      inputs.nextStation.lng,
-    );
-    if (cos < DIRECTION_COSINE_THRESHOLD) {
-      return { pass: false, reason: 'direction-mismatch', metrics };
-    }
+    const geomOutcome = evaluateGpsGeometryGates(inputs, metrics);
+    if (geomOutcome) return geomOutcome;
   }
 
-  // #8 — motion ∈ {walking, automotive}. stationary/unknown은 차단. GPS bypass 분기에서도
-  // 평가 — CMMotionActivity 기반 신호는 지하에서도 작동(mem `lesson_motion_activity_intermittent_signal`
-  // 의 5~10분 주기 뒤집힘 한계는 있으나 #819 게이트 #8 단독으로 false positive 차단 의무는 없음 —
-  // caller 의 consensusGate 가 arrival+lockAttachable 합의로 보완).
+  // #8 — motion ∈ {walking, automotive}. GPS bypass 분기에서도 평가 — CMMotionActivity
+  // 기반 신호는 지하에서도 작동 (mem `lesson_motion_activity_intermittent_signal` 의 5~10분
+  // 주기 뒤집힘 한계는 caller 의 consensusGate 가 arrival+lockAttachable 합의로 보완).
   if (metrics.motion !== 'walking' && metrics.motion !== 'automotive') {
     return { pass: false, reason: 'motion-not-moving', metrics };
   }
 
-  if (!gpsDependentBypass) {
-    // #7 — fused speed. mapMatchedKmh는 #828, kalmanKmh는 #824에서 wire — 양 끝 sample이 같은
-    // line + arcM을 가질 때만 evaluateWindow가 mapMatchedKmh 산출, 그 외에는 null로 강등
-    // (GPS-only fallback). kalmanKmh는 호출자(scheduled.ts)가 runKalmanStep으로 산출 후 주입.
-    const fused = fusedSpeed({
-      gpsAvgKmh: metrics.gpsAvgKmh,
-      gpsAccuracyMeters: metrics.avgAccuracyMeters,
-      motion: metrics.motion,
-      mapMatchedKmh: metrics.mapMatchedKmh,
-      kalmanKmh: inputs.kalmanKmh ?? null,
-    });
-    if (fused.speed < MIN_FUSED_SPEED_KMH || fused.confidence === 'low') {
-      return { pass: false, reason: 'speed-too-low', metrics };
-    }
-    return { pass: true, metrics, fusedSpeedKmh: fused.speed };
+  // #7 — fused speed. GPS bypass 분기는 fusedSpeed 산출 자체가 의미 없어 0 으로 표기.
+  if (gpsDependentBypass) {
+    return { pass: true, metrics, fusedSpeedKmh: 0 };
   }
-
-  // #1536 — GPS bypass 분기는 fusedSpeed 산출 자체가 의미 없으므로 0 으로 표기.
-  // caller 가 본 값을 로깅 외 용도로 쓰면 회귀 → caller(scheduled.ts) 가 분기 인지하고 사용.
-  return { pass: true, metrics, fusedSpeedKmh: 0 };
+  const speedOutcome = evaluateFusedSpeedGate(inputs, metrics);
+  if (!speedOutcome.pass) {
+    return { pass: false, reason: speedOutcome.reason, metrics };
+  }
+  return { pass: true, metrics, fusedSpeedKmh: speedOutcome.fusedSpeedKmh };
 }
 
 /**

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -43,6 +43,7 @@ import { computeAllowedLines, type StationEnvironment } from './consensusGate';
 import { attachTrainCodeForLeg } from './lockSwap';
 import {
   advanceTripPosition,
+  mapEvidenceEnvironment,
   type AdvanceBlockReason,
   type AdvanceEvidence,
   type EvidenceEnvironment,
@@ -1288,18 +1289,15 @@ function deriveEvidenceEnvironment(trip: Trip): EvidenceEnvironment {
 }
 
 /**
- * #1536 (S3) — Trip.subsurface → consensusGate.StationEnvironment 직접 매핑.
+ * #1536 (S3) — Trip.subsurface → consensusGate.StationEnvironment 매핑.
  *
- * `deriveEvidenceEnvironment` 와 어휘 set 이 동일하지만(subsurface true→underground,
- * false→surface, undefined→unknown), boardingPrompt + autoLock + consensusGate 경로는
- * EvidenceEnvironment 의 'hybrid' 변환을 거치지 않으므로 별도 헬퍼로 분리. trip 데이터
- * 자체가 device 어휘인 `subsurface` boolean 만 갖고 'mixed' 표현이 없어, mixed 분기는
- * 현재 호출자에서 발생하지 않는다(추후 trip.environment 필드 도입 시 확장).
+ * `deriveEvidenceEnvironment` (EvidenceEnvironment 어휘) 결과를 `mapEvidenceEnvironment`
+ * 로 한 단계 변환해 single source 유지 (S4144 회피). trip 데이터 자체가 device 어휘인
+ * `subsurface` boolean 만 갖고 'mixed' 표현이 없으므로 mapping 결과는 underground / surface
+ * / unknown 셋 중 하나(추후 trip.environment 필드 도입 시 'mixed' 분기 자연 확장).
  */
 function deriveTripEnvironment(trip: Trip): StationEnvironment {
-  if (trip.subsurface === true) return 'underground';
-  if (trip.subsurface === false) return 'surface';
-  return 'unknown';
+  return mapEvidenceEnvironment(deriveEvidenceEnvironment(trip));
 }
 
 /**

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -39,7 +39,7 @@ import {
   type LiveActivityStats,
 } from './liveActivity';
 import { matchLine } from './lineAlias';
-import { computeAllowedLines } from './consensusGate';
+import { computeAllowedLines, type StationEnvironment } from './consensusGate';
 import { attachTrainCodeForLeg } from './lockSwap';
 import {
   advanceTripPosition,
@@ -1288,6 +1288,21 @@ function deriveEvidenceEnvironment(trip: Trip): EvidenceEnvironment {
 }
 
 /**
+ * #1536 (S3) — Trip.subsurface → consensusGate.StationEnvironment 직접 매핑.
+ *
+ * `deriveEvidenceEnvironment` 와 어휘 set 이 동일하지만(subsurface true→underground,
+ * false→surface, undefined→unknown), boardingPrompt + autoLock + consensusGate 경로는
+ * EvidenceEnvironment 의 'hybrid' 변환을 거치지 않으므로 별도 헬퍼로 분리. trip 데이터
+ * 자체가 device 어휘인 `subsurface` boolean 만 갖고 'mixed' 표현이 없어, mixed 분기는
+ * 현재 호출자에서 발생하지 않는다(추후 trip.environment 필드 도입 시 확장).
+ */
+function deriveTripEnvironment(trip: Trip): StationEnvironment {
+  if (trip.subsurface === true) return 'underground';
+  if (trip.subsurface === false) return 'surface';
+  return 'unknown';
+}
+
+/**
  * #1370 L2 — trainCode vanish 후 시간 기반 fallback advance 직전에 발사하는 station-passed silent push.
  *
  * arvlCd fire 경로와 모양은 같지만 SSOT가 다르다 — arvlCd∈{0,1}이 아니라 "trainCode 사라짐 + hop 시간
@@ -2295,6 +2310,8 @@ async function maybeBindLocklessTrainCode(
 
   // 9단 AND 게이트 — 사용자가 실제 이동 중일 때만 통과 (정적/저신뢰는 false positive 차단).
   // boarding-prompt 경로와 동일하게 fusion 결과(series/kalman/metrics)를 그대로 입력으로 전달.
+  // #1536 (S3) — 환경 분기. underground/unknown 은 GPS 의존 게이트(#3~#7) 를 byPass.
+  const environment = deriveTripEnvironment(trip);
   const outcome = evaluateBoardingPromptGates({
     series: fusion.series,
     origin: geo.origin,
@@ -2303,9 +2320,14 @@ async function maybeBindLocklessTrainCode(
     promptState: trip.boardingPromptState,
     kalmanKmh: fusion.kalmanKmh,
     metrics: fusion.posMetrics,
+    environment,
   });
   if (!outcome.pass) return false;
-
+  // #1536 (S3) — environment-aware consensusGate. underground 분기는 arrival +
+  // lockAttachable 2-of-2 합의로 false positive 차단. arrivals 는 attemptAutoLock 이
+  // fetch 하므로 본 함수에서는 lockAttachable 신호만 forward 하고 consensusGate 의 분기
+  // 자체는 attemptAutoLock 내부에서 평가한다. caller 는 outcome.pass(motion+silence) 만
+  // 사용해 auto-lock 시도 진입을 허용.
   const autoLockResult = await attemptAutoLock({
     trip,
     targetWaypoint: waypoint,
@@ -2317,6 +2339,10 @@ async function maybeBindLocklessTrainCode(
     lastMotionAt: fusion.series[fusion.series.length - 1]?.ts,
     // #1439 (E6, ADR-015 §9) — lockless auto-lock 합성도 route 외 line이면 reject.
     allowedLines: computeAllowedLines(trip.route, trip.waypoints),
+    // #1536 (S3) — environment + gateOutcome forward. attemptAutoLock 이 환경 분기
+    // consensusGate 평가로 surface 통과 / underground arrival+lockAttachable 합의 강제.
+    environment,
+    gateOutcome: outcome,
   });
   if (autoLockResult.confidenceTrace && env.TELEMETRY) {
     recordAutoLockConfidence(env.TELEMETRY, trip.token, autoLockResult.confidenceTrace);
@@ -2710,6 +2736,10 @@ export async function evaluateAndMaybeFireBoardingPrompt(
     dirty = true;
   }
 
+  // #1536 (S3) — 환경 분기. underground/unknown 은 GPS 의존 게이트(#3~#7) 를 byPass.
+  // 결과(outcome.pass) 는 motion+silence/fired 만 보장하므로 caller 는 별도 consensusGate
+  // 로 arrival+lockAttachable 합의를 검증해야 false positive 차단.
+  const environment = deriveTripEnvironment(trip);
   const outcome = evaluateBoardingPromptGates({
     series: fusion.series,
     origin: geo.origin,
@@ -2720,6 +2750,7 @@ export async function evaluateAndMaybeFireBoardingPrompt(
     // #833 — runFusionStep이 Kalman observation을 위해 이미 evaluateWindow를 1회 돌렸다.
     // 그 결과를 그대로 재사용해 trip당 redundant window 평가를 제거 (동작 동치).
     metrics: fusion.posMetrics,
+    environment,
   });
 
   if (!outcome.pass) {
@@ -2727,6 +2758,7 @@ export async function evaluateAndMaybeFireBoardingPrompt(
     log('boarding-prompt: gate blocked', {
       token: trip.token.slice(0, 8),
       reason: outcome.reason satisfies GateSkipReason,
+      environment,
     });
     if (dirty) await putTrip(env.TRIPS, trip);
     return;
@@ -2751,6 +2783,9 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       lastMotionAt: fusion.series[fusion.series.length - 1]?.ts,
       // #1439 (E6, ADR-015 §9) — boarding-prompt auto-lock 합성도 route 외 line이면 reject.
       allowedLines: computeAllowedLines(trip.route, trip.waypoints),
+      // #1536 (S3) — environment + gateOutcome forward. 환경 분기 consensusGate 강제.
+      environment,
+      gateOutcome: outcome,
     });
     // #1171 — RC1 confidence gate가 평가된 경우(arvlCd=2 branch) score 분포를 AE에 적재.
     // 1주 운영 후 본 분포로 AUTO_LOCK_CONFIDENCE_THRESHOLD 튜닝 결정.
@@ -2792,6 +2827,8 @@ export async function evaluateAndMaybeFireBoardingPrompt(
         line: display.line,
         tripToken: trip.token,
         sentAt: now,
+        // #1536 (S3, T13) — cron loop 경로. POST /trips instant path 와 source 구분.
+        triggerKind: 'cron',
         config: deps.apnsConfig,
         host,
         fetchImpl: deps.fetchImpl,

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -486,6 +486,17 @@ export interface BoardingPromptPushPayload {
   /** trip 토큰 — 푸시 응답 시점에 trip 컨텍스트 복원용. */
   tripToken: string;
   sentAt: number;
+  /**
+   * #1536 (S3, T13) — trigger source 구분.
+   *
+   * - 'cron': scheduled.ts cron 사이클에서 9단 게이트 통과로 발사 (기존 동작).
+   * - 'instant': POST /trips 등록 즉시 발사 path (T13 trigger 재설계). 9단 cron loop
+   *   우회. lockSuggestion 부재 + 30s advance 없음 confidence 가 부족할 때 fallback 으로
+   *   cron 게이트 발사.
+   *
+   * 부재(legacy) = 'cron' 으로 해석. device 는 telemetry 적재 시 source 분포 측정에 사용.
+   */
+  triggerKind?: 'cron' | 'instant';
 }
 
 /**


### PR DESCRIPTION
Closes #1536

## 배경 (이슈 #1536)

7일 누적 `BoardingPrompt(all)=0` (displayed=0, responded=0, boarded=0). 직전 지하 trip dump `direction=mismatch reason=no-route`. `boardingPrompt` + `autoLock` 9-AND gate가 GPS series 의존이라 지하 GPS stale 환경에서 100% fail → 발사 0건 회귀.

mem `lesson_boarding_prompt_9and_gate_gps_only` 직접 해소.

## 변경

### Part A — 9-AND gate 환경 분기 (`backend/alarm-worker/`)

**`boardingPrompt.ts:120` `evaluateBoardingPromptGates`**
- `inputs.environment?: StationEnvironment` 인자 추가
- `'underground' | 'mixed' | 'unknown'`: GPS 의존 게이트(#3 accuracy / #4 origin / #5 direction / #6 window / #7 speed) byPass. #8 motion + #9 silence/fired 만 평가
- `'surface' | undefined`: 기존 9단 AND 게이트 그대로 (legacy 호출자 회귀 0)
- GPS bypass 분기는 `fusedSpeedKmh=0` 으로 표기

**`autoLock.ts:168` `attemptAutoLock`**
- `environment?: StationEnvironment` + `gateOutcome?: GateOutcome` 인자 추가
- 내부에서 `evaluateConsensusGate(environment, signals)` 호출
  - `arrivalSignalPresent`: chosen `arvlCd ∈ [0,3]`
  - `lockAttachable`: `pickAutoTrainCode` 단일 수렴 (도달 시 항상 true)
- underground: arrival + lockAttachable 2-of-2 합의 강제 (false positive 차단)
- surface: base gate 통과 시 통과
- 두 인자 미전달 (legacy 호출자) 시 consensusGate skip

**`scheduled.ts` 2 call site 갱신**
- `maybeBindLocklessTrainCode` (line 2298, lockless trainCode 확보)
- `evaluateAndMaybeFireBoardingPrompt` (line 2727, lockMissing boarding-prompt)
- 신규 헬퍼 `deriveTripEnvironment(trip)` (Trip.subsurface → StationEnvironment)
- log entry에 `environment` 동봉 (운영 분포 측정)
- 기존 발사 path: `triggerKind='cron'` 명시 forward

**`direction-match → SSoT.direction reader-only`**: GPS 게이트 #5 (velocity cosine) 자체가 underground 에서 byPass. 실제 `direction` 채택은 이미 `promptGeoContext.direction` (trip register payload, non-route non-GPS) — `pickAutoTrainCode(arrivals, line, direction)` 에서 isUp/isDown 필터링. SSoT direction reader-only 패턴 만족.

### Part B — T13 trigger 분리 (minimal scope)

**`types.ts` + `apns.ts`**
- `BoardingPromptPushPayload.triggerKind?: 'cron' | 'instant'` (optional, telemetry)
- `sendBoardingPromptPush({ triggerKind })` forward
- 기존 cron 발사 경로: `triggerKind='cron'` 명시

**out of scope (follow-up PR)** — device-side 변경 의존:
- LA Interactive UI 통일 ('A → B 방면' 라벨, trainCode 노출 X)
- POST /trips 등록 즉시 instant fire path (cron 우회)
- 30s advance 없을 때 9-AND fallback timing

## Wire-completion 체크리스트

- [x] `environment` 인자 grep — `evaluateBoardingPromptGates` 호출자 2/2 갱신
- [x] `consensusGate` 호출 grep — `attemptAutoLock` 내부 환경 분기 평가
- [x] LA Interactive UI 'A → B 방면' 라벨 — device 변경 의존, out of scope (follow-up)
- [x] direct call to `evaluateBoardingPromptGates` (lockSuggestion 없을 때) — 기존 cron path 보존 (fallback)
- [x] `triggerKind` payload field — `cron` 명시 (instant path는 follow-up)
- [x] `lint:orphan` PASS

## 5-layer wire 검증

| L | 단계 | 검증 |
|---|---|---|
| L1 | backend cron evaluate | `environment` grep — `scheduled.ts:2323/2344/2761/2787` |
| L2 | consensusGate 호출 | `attemptAutoLock` 내부 — `autoLock.ts:222-238` |
| L3 | silent push 발사 (`scheduled.ts`) | `triggerKind='cron'` — `scheduled.ts:2831` |
| L4 | device UI mount | (변경 없음, 기존 path 보존) |
| L5 | 응답 POST 라운드트립 | (변경 없음, 기존 path 보존) |

## 자가 점검 5단

1. **acceptance self-referential**: `boardingPromptFired` / `boardingPromptBlocked` stat 운영 측정 (Phase 0 alarmLog forward → R2 직결)
2. **Wire-completion**: 5-layer L1~L3 환경 분기 wire grep evidence — 추가 path 0 orphan
3. **머지 순서**: S1 #1534 (`lockSuggestion`) 머지 완료 후 진행. T9 #1572 미머지지만 본 PR 의존 X (boardingPrompt + autoLock 독립 path)
4. **backward-compat**: `environment` + `gateOutcome` undefined 시 consensusGate skip. surface env / legacy 호출자 회귀 0. 1780 tests pass
5. **False positive new**: underground 환경 분기는 arrival(arvlCd∈[0,3]) + lockAttachable 2-of-2 합의 강제. arrival absent 또는 trainCode ambiguity 시 자연 차단. 1주 측정 검증

## V/X dashboard

- 측정 신호: `boardingPromptFired` / `boardingPromptBlocked` / `autoLockSuccess` stat (cron loop). log entry `environment` 분포
- 위치: Cloudflare Logpush (`scheduled.ts` cron stats), Analytics Engine `BOARDING_FALSE_POSITIVE` rate
- DebugModal: 기존 boardingPrompt acceptance dashboard 활용 (변경 없음)

## 의존 PR

- 선행: S1 #1534 (lockSuggestion backend infer) — MERGED ([`82674e3`](../commit/82674e3))
- 병렬: T9 #1572 (device fire path SSoT 게이트) — 본 PR 의존 X
- Out-of-scope follow-up: LA Interactive UI 통일 (device-side PR 필요)

## 측정 plan (1주)

- (a) 다음 지하 trip dump: `boardingPromptFired > 0` 또는 `autoLockSuccess > 0` 확인
- (b) `boardingPromptBlocked` reason 분포 — `environment=underground` 통과 / `consensus reason=environment-no-gps-consensus` 분포
- (c) production alarmLog forward: 7일 누적 `boarding-prompt` source displayed/responded/boarded > 0
- (d) Live Activity 같은 trip 두 surface 출현 확인 (UI 통합은 follow-up이라 본 PR에서는 trigger 발사 자체만 검증)

## Device verify

필요 — 실기기 지하 trip 1회 (강남 → 역삼 2호선, 또는 사용자 평소 경로). cron 발사 시 backend log `environment=underground` 통과 + boarding-prompt push 수신 확인.

## 자가 점검 (5/5)

| 단 | 결과 |
|---|---|
| 1 acceptance | Phase 0 alarmLog forward → R2 직결. fired/blocked stat |
| 2 Wire-completion | L1~L3 grep PASS, `lint:orphan` PASS |
| 3 머지 순서 | S1 #1534 머지 후 진행, T9 #1572 의존 X |
| 4 backward-compat | undefined 인자 시 기존 path. 1780 tests pass |
| 5 false positive new | underground arrival+lockAttachable 2-of-2 강제. arvlCd!=[0,3] 시 차단 |

CI ALL GREEN 후 사용자 머지 결정. 머지 X.