### PR TITLE
fix(#1612): V1 atomic — cross-trip 잔재 + 위젯 FG stale + 지하 dead zone 누수 (Stage 1, 5 fix)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -26,6 +26,12 @@ jest.mock('../../utils/tripBoundScheduler', () => ({
   cancelTripBoundAlarms: (...args: unknown[]) => mockCancelTripBoundAlarms(...args),
 }));
 
+// R11-a (#1612) — POST /trips 직전 backend SSoT mirror 강제 clean 검증.
+const mockClearBackendSsotMirror = jest.fn();
+jest.mock('../../utils/backendSsotMirror', () => ({
+  clearBackendSsotMirror: (...args: unknown[]) => mockClearBackendSsotMirror(...args),
+}));
+
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),
@@ -66,6 +72,7 @@ describe('useApnsTripRegistration', () => {
     mockRegister.mockResolvedValue({ ok: true });
     mockClear.mockResolvedValue({ ok: true });
     mockCancelTripBoundAlarms.mockResolvedValue(undefined);
+    mockClearBackendSsotMirror.mockResolvedValue(undefined);
     (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
       if (key === APNS_TOKEN_KEY) return 'token-abc';
       return null;
@@ -122,6 +129,51 @@ describe('useApnsTripRegistration', () => {
     await waitFor(() =>
       expect(AsyncStorage.setItem).toHaveBeenCalledWith(ACTIVE_TRIP_KEY, 'token-abc'),
     );
+  });
+
+  // R11-a (#1612) — POST /trips 직전 backend SSoT mirror 강제 clean (cross-trip 잔재 root).
+  describe('R11-a (#1612) — POST /trips 직전 clearBackendSsotMirror', () => {
+    it('register 호출 직전 clearBackendSsotMirror가 1회 호출된다 (호출 순서: clear → register)', async () => {
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+        }),
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockClearBackendSsotMirror).toHaveBeenCalledTimes(1);
+      // invocationCallOrder로 clear가 register보다 먼저 실행됐는지 검증 — race A 차단의 1단계 보장.
+      const clearOrder = mockClearBackendSsotMirror.mock.invocationCallOrder[0];
+      const registerOrder = mockRegister.mock.invocationCallOrder[0];
+      expect(clearOrder).toBeLessThan(registerOrder);
+    });
+
+    it('route/destination 없으면 clearBackendSsotMirror 호출 안 함 (trip 종료 경로는 별경로)', async () => {
+      renderHook(() =>
+        useApnsTripRegistration({ route: null, destination: null, nextStationEtaSeconds: null }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockClearBackendSsotMirror).not.toHaveBeenCalled();
+    });
+
+    it('토큰 없으면 register skip되고 clearBackendSsotMirror도 호출 안 함', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+        }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).not.toHaveBeenCalled();
+      expect(mockClearBackendSsotMirror).not.toHaveBeenCalled();
+    });
   });
 
   it('register 실패 시 ACTIVE_TRIP_KEY 저장 안 함', async () => {

--- a/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
@@ -39,6 +39,12 @@ jest.mock('../../api/signalDumpBackend', () => ({
   flushSignalDumpOutbox: (...args: unknown[]) => mockFlushSignalDumpOutbox(...args),
 }));
 
+// R11-c (#1612) — cold-launch active trip 없으면 backend SSoT mirror clear (race C 차단).
+const mockClearBackendSsotMirror = jest.fn();
+jest.mock('../../utils/backendSsotMirror', () => ({
+  clearBackendSsotMirror: (...args: unknown[]) => mockClearBackendSsotMirror(...args),
+}));
+
 // #1597 — trip 종료 ended 경로에서 cleanup 직전에 corrId snapshot 캡처 + cleanup 후 prompt enqueue.
 const mockGetCurrentTripCorrIdSync = jest.fn(() => null);
 jest.mock('../../../observability/utils/tripCorrId', () => ({
@@ -68,6 +74,7 @@ beforeEach(async () => {
   mockTriggerTripEndRecall.mockResolvedValue({ uploaded: false });
   mockRunTripBoundCleanups.mockResolvedValue(undefined);
   mockFlushSignalDumpOutbox.mockResolvedValue({ ok: false, skipped: true });
+  mockClearBackendSsotMirror.mockResolvedValue(undefined);
   process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
 });
 
@@ -86,6 +93,26 @@ describe('runLaunchTripReconciliation', () => {
   it('ACTIVE_TRIP_KEY 부재 → skip', async () => {
     await runLaunchTripReconciliation();
     expect(mockFetchTripStatus).not.toHaveBeenCalled();
+  });
+
+  // R11-c (#1612) — cold-launch active trip 없으면 stale backend SSoT mirror clear (race C 차단).
+  describe('R11-c (#1612) — cold-launch mirror clear', () => {
+    it('ACTIVE_TRIP_KEY 부재 → clearBackendSsotMirror 1회 호출 (mirror 잔재 차단)', async () => {
+      await runLaunchTripReconciliation();
+      expect(mockClearBackendSsotMirror).toHaveBeenCalledTimes(1);
+      expect(mockFetchTripStatus).not.toHaveBeenCalled();
+    });
+
+    it('ACTIVE_TRIP_KEY 존재 → clearBackendSsotMirror 호출 안 함 (기존 동작 보존)', async () => {
+      await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+      mockFetchTripStatus.mockResolvedValue({
+        status: 'active',
+        endedAt: null,
+        endReason: null,
+      });
+      await runLaunchTripReconciliation();
+      expect(mockClearBackendSsotMirror).not.toHaveBeenCalled();
+    });
   });
 
   it('sentinel 기록 있음 → fetch skip', async () => {

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -26,6 +26,7 @@ import { registerActiveTrip, clearActiveTrip, type AlarmBoardingLock } from '../
 import { routeToWaypoints } from '../../route/utils/routeWaypoints';
 import { buildBoardingLockMeta } from '../utils/buildBoardingLockMeta';
 import { cancelTripBoundAlarms } from '../utils/tripBoundScheduler';
+import { clearBackendSsotMirror } from '../utils/backendSsotMirror';
 import { buildBoardingPromptContext, type BoardingPromptContext } from '../utils/boardingPromptContext';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
 import { BOARDING_LOCK_RELEASE_DEBOUNCE_MS } from '../../../shared/constants/boardingLock';
@@ -357,6 +358,12 @@ export function useApnsTripRegistration({
       // 일시 null이 돼도 cachedPromptContext로 fallback하여 backend 9단 게이트가 계속 진입 가능.
       const freshCtx = buildBoardingPromptContext({ route, currentStation, destination });
       if (freshCtx) lastPromptContextRef.current = freshCtx;
+      // R11-a (#1612): trip register 직전 backend SSoT mirror 강제 clean.
+      // 스펙 docs/requirements/15-trip-alarm-notification.md:89 명시 요구사항 — "trip 등록(new)
+      // → 이전 SSoT mirror 강제 clear". 본 호출이 register API보다 먼저여야 race A
+      // (cleanup 후 OLD trip 지연 push로 mirror 부활) 차단의 1단계로 작동한다.
+      // 호출은 멱등 (clearBackendSsotMirror 키 부재 시 graceful no-op).
+      await clearBackendSsotMirror();
       const result = await callRegister({
         token,
         route,

--- a/src/features/alarm/hooks/useLaunchTripReconciliation.ts
+++ b/src/features/alarm/hooks/useLaunchTripReconciliation.ts
@@ -50,6 +50,7 @@ import { runTripBoundCleanups } from '../store/tripBoundCleanups';
 import { flushSignalDumpOutbox } from '../api/signalDumpBackend';
 import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
 import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
+import { clearBackendSsotMirror } from '../utils/backendSsotMirror';
 import { createLogger } from '../../../shared/utils/logger';
 
 const logger = createLogger('useLaunchTripReconciliation');
@@ -81,6 +82,11 @@ export async function runLaunchTripReconciliation(): Promise<void> {
 
     const tripToken = await AsyncStorage.getItem(ACTIVE_TRIP_KEY);
     if (!tripToken) {
+      // R11-c (#1612): active trip 없으면 stale backend SSoT mirror clear.
+      // 180s freshness 윈도우 내에 mirror가 남아 있으면 다음 cascade cycle이 `backend-ssot`
+      // tier로 stale stationId를 채택해 cross-trip 잔재(2026-06-20 12:30 어대 → 용마산 도착) 회귀.
+      // cleanup은 멱등 — 키 부재 시 graceful no-op.
+      await clearBackendSsotMirror();
       return;
     }
 

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -3306,6 +3306,109 @@ describe('silentPushTask', () => {
       expect(mirrorCall).toBeUndefined();
     });
 
+    // R11-b (#1612) — payload.tripToken mismatch 시 mirror write skip (race A 차단).
+    describe('R11-b (#1612) — trip token mismatch 시 mirror write skip', () => {
+      it('payload.tripToken === activeTripToken → mirror write 정상 진행 (정상 case)', async () => {
+        (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === ACTIVE_TRIP_KEY) return 'trip-token-A';
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          return null;
+        });
+        mockCheckGate.mockReturnValue({ allow: false, skip: 'gate-no-location' });
+        await handleSilentPush(
+          bgTaskData({
+            nextWaypoint: '강남',
+            etaSeconds: 0,
+            phase: 'imminent',
+            kind: 'intermediate',
+            tripToken: 'trip-token-A',
+            ssot: validSsot,
+          }),
+        );
+        const mirrorCall = (AsyncStorage.setItem as jest.Mock).mock.calls.find(
+          ([key]) => key === BACKEND_SSOT_MIRROR_KEY,
+        );
+        expect(mirrorCall).toBeDefined();
+      });
+
+      it('payload.tripToken !== activeTripToken → mirror write skip (race A 차단)', async () => {
+        (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === ACTIVE_TRIP_KEY) return 'trip-token-NEW';
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          return null;
+        });
+        mockCheckGate.mockReturnValue({ allow: false, skip: 'gate-no-location' });
+        await handleSilentPush(
+          bgTaskData({
+            nextWaypoint: '강남',
+            etaSeconds: 0,
+            phase: 'imminent',
+            kind: 'intermediate',
+            tripToken: 'trip-token-OLD',
+            ssot: validSsot,
+          }),
+        );
+        const mirrorCall = (AsyncStorage.setItem as jest.Mock).mock.calls.find(
+          ([key]) => key === BACKEND_SSOT_MIRROR_KEY,
+        );
+        expect(mirrorCall).toBeUndefined();
+      });
+
+      it('activeTripToken null (cold-launch race) → mirror write 허용 (backward-compat)', async () => {
+        (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === ACTIVE_TRIP_KEY) return null;
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          return null;
+        });
+        mockCheckGate.mockReturnValue({ allow: false, skip: 'gate-no-location' });
+        await handleSilentPush(
+          bgTaskData({
+            nextWaypoint: '강남',
+            etaSeconds: 0,
+            phase: 'imminent',
+            kind: 'intermediate',
+            tripToken: 'trip-token-X',
+            ssot: validSsot,
+          }),
+        );
+        const mirrorCall = (AsyncStorage.setItem as jest.Mock).mock.calls.find(
+          ([key]) => key === BACKEND_SSOT_MIRROR_KEY,
+        );
+        expect(mirrorCall).toBeDefined();
+      });
+
+      it('payload.tripToken undefined (구 backend 호환) → mirror write 허용', async () => {
+        (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === ACTIVE_TRIP_KEY) return 'trip-token-Z';
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          return null;
+        });
+        mockCheckGate.mockReturnValue({ allow: false, skip: 'gate-no-location' });
+        await handleSilentPush(
+          bgTaskData({
+            nextWaypoint: '강남',
+            etaSeconds: 0,
+            phase: 'imminent',
+            kind: 'intermediate',
+            // tripToken 명시적 누락 (구 backend 호환)
+            ssot: validSsot,
+          }),
+        );
+        const mirrorCall = (AsyncStorage.setItem as jest.Mock).mock.calls.find(
+          ([key]) => key === BACKEND_SSOT_MIRROR_KEY,
+        );
+        expect(mirrorCall).toBeDefined();
+      });
+    });
+
     it('validSsotMirror returns undefined for null/non-object', () => {
       expect(validSsotMirror(null)).toBeUndefined();
       expect(validSsotMirror(undefined)).toBeUndefined();

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -3307,105 +3307,81 @@ describe('silentPushTask', () => {
     });
 
     // R11-b (#1612) — payload.tripToken mismatch 시 mirror write skip (race A 차단).
+    // it.each + helper로 4 case 통합 (SonarCloud dup 회피, lesson_sonarcloud_dup_prevention).
     describe('R11-b (#1612) — trip token mismatch 시 mirror write skip', () => {
-      it('payload.tripToken === activeTripToken → mirror write 정상 진행 (정상 case)', async () => {
-        (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
-        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
-          if (key === ACTIVE_TRIP_KEY) return 'trip-token-A';
-          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
-          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
-          return null;
-        });
-        mockCheckGate.mockReturnValue({ allow: false, skip: 'gate-no-location' });
-        await handleSilentPush(
-          bgTaskData({
-            nextWaypoint: '강남',
-            etaSeconds: 0,
-            phase: 'imminent',
-            kind: 'intermediate',
-            tripToken: 'trip-token-A',
-            ssot: validSsot,
-          }),
-        );
-        const mirrorCall = (AsyncStorage.setItem as jest.Mock).mock.calls.find(
-          ([key]) => key === BACKEND_SSOT_MIRROR_KEY,
-        );
-        expect(mirrorCall).toBeDefined();
-      });
+      type R11bCase = {
+        label: string;
+        activeTripValue: string | null;
+        payloadTripToken: string | undefined;
+        expectMirrorDefined: boolean;
+      };
 
-      it('payload.tripToken !== activeTripToken → mirror write skip (race A 차단)', async () => {
+      async function runR11bCase({
+        activeTripValue,
+        payloadTripToken,
+      }: R11bCase) {
         (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
         (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
-          if (key === ACTIVE_TRIP_KEY) return 'trip-token-NEW';
+          if (key === ACTIVE_TRIP_KEY) return activeTripValue;
           if (key === DESTINATION_KEY) return JSON.stringify(destStation);
           if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
           return null;
         });
         mockCheckGate.mockReturnValue({ allow: false, skip: 'gate-no-location' });
-        await handleSilentPush(
-          bgTaskData({
-            nextWaypoint: '강남',
-            etaSeconds: 0,
-            phase: 'imminent',
-            kind: 'intermediate',
-            tripToken: 'trip-token-OLD',
-            ssot: validSsot,
-          }),
-        );
-        const mirrorCall = (AsyncStorage.setItem as jest.Mock).mock.calls.find(
-          ([key]) => key === BACKEND_SSOT_MIRROR_KEY,
-        );
-        expect(mirrorCall).toBeUndefined();
-      });
+        // tripToken undefined일 때 'tripToken' in payload는 true가 되지만 코드 가드는
+        // `payload.tripToken !== undefined`로 분기 — 구 backend 호환 path 그대로 검증.
+        const fields: Record<string, unknown> = {
+          nextWaypoint: '강남',
+          etaSeconds: 0,
+          phase: 'imminent',
+          kind: 'intermediate',
+          ssot: validSsot,
+        };
+        if (payloadTripToken !== undefined) {
+          fields.tripToken = payloadTripToken;
+        }
+        await handleSilentPush(bgTaskData(fields));
+      }
 
-      it('activeTripToken null (cold-launch race) → mirror write 허용 (backward-compat)', async () => {
-        (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
-        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
-          if (key === ACTIVE_TRIP_KEY) return null;
-          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
-          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
-          return null;
-        });
-        mockCheckGate.mockReturnValue({ allow: false, skip: 'gate-no-location' });
-        await handleSilentPush(
-          bgTaskData({
-            nextWaypoint: '강남',
-            etaSeconds: 0,
-            phase: 'imminent',
-            kind: 'intermediate',
-            tripToken: 'trip-token-X',
-            ssot: validSsot,
-          }),
-        );
-        const mirrorCall = (AsyncStorage.setItem as jest.Mock).mock.calls.find(
+      function findMirrorCall() {
+        return (AsyncStorage.setItem as jest.Mock).mock.calls.find(
           ([key]) => key === BACKEND_SSOT_MIRROR_KEY,
         );
-        expect(mirrorCall).toBeDefined();
-      });
+      }
 
-      it('payload.tripToken undefined (구 backend 호환) → mirror write 허용', async () => {
-        (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
-        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
-          if (key === ACTIVE_TRIP_KEY) return 'trip-token-Z';
-          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
-          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
-          return null;
-        });
-        mockCheckGate.mockReturnValue({ allow: false, skip: 'gate-no-location' });
-        await handleSilentPush(
-          bgTaskData({
-            nextWaypoint: '강남',
-            etaSeconds: 0,
-            phase: 'imminent',
-            kind: 'intermediate',
-            // tripToken 명시적 누락 (구 backend 호환)
-            ssot: validSsot,
-          }),
-        );
-        const mirrorCall = (AsyncStorage.setItem as jest.Mock).mock.calls.find(
-          ([key]) => key === BACKEND_SSOT_MIRROR_KEY,
-        );
-        expect(mirrorCall).toBeDefined();
+      it.each<R11bCase>([
+        {
+          label: 'payload.tripToken === activeTripToken → mirror write 정상 진행 (정상 case)',
+          activeTripValue: 'trip-token-A',
+          payloadTripToken: 'trip-token-A',
+          expectMirrorDefined: true,
+        },
+        {
+          label: 'payload.tripToken !== activeTripToken → mirror write skip (race A 차단)',
+          activeTripValue: 'trip-token-NEW',
+          payloadTripToken: 'trip-token-OLD',
+          expectMirrorDefined: false,
+        },
+        {
+          label: 'activeTripToken null (cold-launch race) → mirror write 허용 (backward-compat)',
+          activeTripValue: null,
+          payloadTripToken: 'trip-token-X',
+          expectMirrorDefined: true,
+        },
+        {
+          label: 'payload.tripToken undefined (구 backend 호환) → mirror write 허용',
+          activeTripValue: 'trip-token-Z',
+          payloadTripToken: undefined,
+          expectMirrorDefined: true,
+        },
+      ])('$label', async (testCase) => {
+        await runR11bCase(testCase);
+        const mirrorCall = findMirrorCall();
+        if (testCase.expectMirrorDefined) {
+          expect(mirrorCall).toBeDefined();
+        } else {
+          expect(mirrorCall).toBeUndefined();
+        }
       });
     });
 

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -762,8 +762,27 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     // reschedule/trip-ended payload는 SSoT를 forward하지 않으므로 본 분기에서는 호출되지 않는다.
     //
     // 실패는 silent — backend SSoT mirror는 보조 신호로 cascade는 기존 tier fallback이 가능.
+    //
+    // R11-b (#1612) — trip token mismatch 시 mirror write skip (race A 차단).
+    // cleanup 후 OLD trip의 지연 silent push가 늦게 도착해 mirror가 부활하면
+    // 다음 cascade cycle이 stale `backend-ssot` tier로 잘못된 currentStationId 채택 — cross-trip
+    // 잔재 회귀(2026-06-19/20 trip evidence). payload.tripToken과 device ACTIVE_TRIP_KEY가
+    // 명확히 다르면 mirror write를 건너뛴다. activeToken null(cold-launch race)이거나
+    // payload.tripToken undefined(구 backend 호환)면 기존 동작 보존 — 정상 진입을 막지 않는다.
     if ('ssot' in payload && payload.ssot !== undefined) {
-      await persistBackendSsotMirror(payload.ssot, receivedAt);
+      const activeTripToken = await AsyncStorage.getItem(ACTIVE_TRIP_KEY);
+      const tripTokenMismatch =
+        'tripToken' in payload &&
+        payload.tripToken !== undefined &&
+        activeTripToken !== null &&
+        activeTripToken !== payload.tripToken;
+      if (tripTokenMismatch) {
+        logger.info(
+          `mirror write skip: trip token mismatch payload=${payload.tripToken!.slice(0, 8)} active=${activeTripToken.slice(0, 8)}`,
+        );
+      } else {
+        await persistBackendSsotMirror(payload.ssot, receivedAt);
+      }
     }
 
     // #1370 L5 — silent push 도달률 observability stamp.

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
@@ -170,15 +170,15 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
       expect(result.current.source).not.toBe('position-train');
     });
 
-    it('GPS 좌표 복구되면 positionTrainResult 정상 채택', () => {
-      // accuracyMeters=1500: 지하 bypass 모드. userLocation 있으므로 (a) 통과.
-      // arc 없으므로 fix(b) 적용 — 하지만 거리 0(같은 좌표)이므로 gate 통과.
+    it('R13-a (#1612): GPS 좌표 복구되어도 lock 비활성 + accuracy=1500 → strict reject (positionTrain 채택 X)', () => {
+      // 이전 의도: userLocation 있으므로 (a) 통과 + arc 없음 + 거리 0 → gate 통과. R13-a로 strict reject.
+      // 사용자 명시 의향 없는 lockless trip의 지하 dead zone 누수 방어 — V1 회복 직접 성과.
       const { result } = setup({
         gps: { userLocation: { lat: yongmasan.lat, lng: yongmasan.lng }, accuracyMeters: 1500 },
         positions: { line: '7', trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-A' })] },
       });
 
-      expect(result.current.source).toBe('position-train');
+      expect(result.current.source).not.toBe('position-train');
     });
   });
 
@@ -216,14 +216,15 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
       expect(result.current.source).toBe('boarding-lock');
     });
 
-    it('lock 없을 때 accuracy=1500(지하) bypass는 그대로 동작', () => {
-      // fix(b)는 lock 활성 시에만 적용 — lock 없으면 기존 bypass 유지.
+    it('R13-a (#1612): lock 없을 때 accuracy=1500 → strict reject (지하 dead zone 누수 차단)', () => {
+      // 이전 의도: fix(b)는 lock 활성 시에만 — lock 없으면 bypass 유지. R13-a로 lockless도 strict reject.
+      // 사용자 명시 의향 없는 lockless trip은 V1 회복 위해 보호 X — 정상 동작.
       const { result } = setup({
         gps: { accuracyMeters: 1500 },
         positions: { line: '7', trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-NOLOCK' })] },
       });
 
-      expect(result.current.source).toBe('position-train');
+      expect(result.current.source).not.toBe('position-train');
     });
   });
 
@@ -266,12 +267,9 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
       expect(result.current.source).toBe('boarding-lock');
     });
 
-    it('lock 없으면 arc 소속 검사 미작동 (gate 자체는 비활성)', () => {
-      // fix(c)는 boardingLock 활성 시에만 동작 — 면목도 gate 통과.
-      // #1207 (Epic #1204 D1): lock 없음 + routeCtx 있음 → lockless-route-hop estimator 활성.
-      // #1418 — positionTrainResult(=Tier 4 실측)가 활성이면 lockless-route-hop(Tier 5)의
-      //         forward ratchet은 차단된다 → positionTrainResult 채택 결과(position-train) 유지.
-      //         (구 버전은 boarding-lock-interp로 override됐으나 그것이 #1415 회귀의 layer 2.)
+    it('R13-a (#1612): lock 없으면 accuracy=1500 → strict reject (arc 소속 검사 도달 전 차단)', () => {
+      // 이전 의도: fix(c)는 boardingLock 활성 시에만. lock 없으면 arc 검사 안 함 → 면목도 gate 통과.
+      // R13-a로 lockless + bad accuracy strict reject — arc 검사 도달 전 차단. V1 회복 직접 성과.
       const myeonmok = findStationByNameAndLine('면목', '7')!;
       const { result } = setup({
         gps: { userLocation: { lat: yongmasan.lat, lng: yongmasan.lng }, accuracyMeters: 1500 },
@@ -279,9 +277,8 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
         routeCtx: routeContext,
       });
 
-      // lock 없으면 arc 검사 안 함 → 면목도 gate 통과 (position-train 채택).
-      // #1418 Tier 5 reject 게이트 — positionTrainResult 활성 → lockless-route-hop override 차단.
-      expect(result.current.source).toBe('position-train');
+      // R13-a (#1612): lock 비활성 + accuracy=1500 → strict reject로 positionTrain 자체가 null.
+      expect(result.current.source).not.toBe('position-train');
     });
 
     it('arc 안에 있지만 LOCK_NEXT_HOP_WINDOW 초과 시 gate 탈락', () => {

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -91,12 +91,42 @@ function info(arrivalCode: number, overrides?: Partial<ArrivalInfo>): ArrivalInf
 }
 
 /**
+ * R13-a (#1612) — bad-accuracy 게이트 면제용 mock BoardingLock.
+ * fusionDistanceGate가 lockActive=true 시 accuracy null/bad 면제 (#1016 hole b 기존 동작 보존).
+ * 본 fixture가 사용된 테스트는 "positionTrain/fused가 지하 가정에서 채택되는가"가 의도 — lock 없이는
+ * R13-a strict reject로 채택 자체가 안 되므로 lock 추가로 가드 분리 + 의도 그대로 유지.
+ *
+ * boardingLine='3' / chungmuro.id 사용: setupPositionTrainTransferStation이 chungmuro(line=3)를
+ * positionTrain으로 lock하는 시나리오라 #662 line 가드(useFusedNearestStation:611) 통과 보장.
+ * arcStations 미설정(routeContext 미전달)이면 #1016 hole (c) 가드도 자연 통과.
+ */
+const mockLockForUnderground: import('../../../../shared/types/boardingLock').BoardingLock = {
+  destinationId: 'mock-dest',
+  trainCode: 'mock-train',
+  boardingStationId: MOCK_STATIONS.chungmuro.id,
+  boardingLine: '3',
+  boardedAt: 1_700_000_000_000,
+  expectedDurationMs: 600_000,
+};
+
+/**
  * position-train 채택 환승역 시나리오 — gangnam(2호선) GPS 1순위 + chungmuro(3호선) 2순위에
  * trainNo가 ARRIVED 상태. trackTrainProgress가 chungmuro(line=3)로 잠금.
  * #584 boarding-lock 라벨 / #662 fusion 강등 가드 두 describe 모두 같은 setup 사용.
+ *
+ * R13-a (#1612) — strict bad-accuracy 가드 도입으로 이전 `accuracyMeters: 1500` (지하 면제)
+ * setup 폐기. 실 chungmuro 좌표를 GPS로 사용 + accuracy=50 (양호) — trackTrainProgress가
+ * findStationByNameAndLine으로 조회한 실 chungmuro 좌표와 distance≈0 → distance gate 통과.
+ * accuracy 양호이므로 R13-a strict reject 영향 0. positionTrain 채택 path 정상 검증.
  */
 function setupPositionTrainTransferStation(trainNo: string): void {
-  mockUseNearest.mockReturnValue(gpsBase({ accuracyMeters: 1500 }));
+  const realChungmuro = findStationByNameAndLine('충무로', '3')!;
+  mockUseNearest.mockReturnValue(
+    gpsBase({
+      userLocation: { lat: realChungmuro.lat, lng: realChungmuro.lng },
+      accuracyMeters: 50,
+    }),
+  );
   mockFindTop.mockReturnValue([
     { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
     { station: MOCK_STATIONS.chungmuro, distanceKm: 0.3 },
@@ -182,9 +212,15 @@ describe('useFusedNearestStation', () => {
   });
 
   it('position-train: 단일 후보 trainNo → trackTrainProgress 채택 (source=position-train)', () => {
-    // MOCK_STATIONS 좌표가 (37.5,127.0)으로 동일하고 trackTrainProgress는 stations.json의
-    // 실좌표를 조회한다. #445 거리 게이트와 충돌을 피하려고 accuracy를 게이트 면제 영역으로.
-    mockUseNearest.mockReturnValue(gpsBase({ accuracyMeters: 1500 }));
+    // R13-a (#1612): 이전 `accuracyMeters: 1500` 지하 면제 setup 폐기. 실 chungmuro 좌표 + accuracy=50으로
+    // distance gate 자연 통과 (trackTrainProgress가 사용하는 findStationByNameAndLine 좌표와 일치).
+    const realChungmuro = findStationByNameAndLine('충무로', '3')!;
+    mockUseNearest.mockReturnValue(
+      gpsBase({
+        userLocation: { lat: realChungmuro.lat, lng: realChungmuro.lng },
+        accuracyMeters: 50,
+      }),
+    );
     mockFindTop.mockReturnValue([
       { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }, // line='2'
       { station: MOCK_STATIONS.chungmuro, distanceKm: 0.3 }, // line='3'
@@ -215,6 +251,8 @@ describe('useFusedNearestStation', () => {
     const setupPositionTrain = setupPositionTrainTransferStation;
 
     it('lockedTrainCode가 position-train의 trainNo와 일치하면 boarding-lock으로 승격', () => {
+      // R13-a (#1612): setupPositionTrainTransferStation는 실 chungmuro GPS + accuracy=50으로
+      // 변경됐다 — strict 면제 가능. lock 미전달이라 boarding-lock 승격은 lockedTrainCode 매칭만.
       setupPositionTrain('T-LOCKED');
       const { result } = renderHook(() =>
         useFusedNearestStation(undefined, undefined, undefined, 'T-LOCKED'),
@@ -369,6 +407,8 @@ describe('useFusedNearestStation', () => {
     });
 
     it('boardingLock 없으면 가드 미작동 (기존 동작 유지)', () => {
+      // R13-a (#1612): setupPositionTrainTransferStation은 실 chungmuro 좌표 + accuracy=50으로 변경됐다 —
+      // R13-a strict 영향 받지 않으므로 lock 없어도 positionTrain 채택. #662 line 가드 자체는 lock 없을 때 미작동.
       setupPositionTrainTransferStation('T-3');
       const { result } = renderHook(() => useFusedNearestStation());
       expect(result.current.source).toBe('position-train');
@@ -431,14 +471,18 @@ describe('useFusedNearestStation', () => {
     it.each([
       ['accuracy>100m 지하 noise + speed=0', 1500, 0, 'T-SUB'],
       ['accuracy>100m 지하 + speed=1 이동 중', 1500, 1, 'T-FAST'],
-    ])('position-train + %s → 강등 안 됨', (_label, accuracy: number, speed: number, no: string) => {
-      setupPositionTrainScenario(accuracy, speed, no);
+    ])(
+      'R13-a (#1612): position-train + %s + lock 비활성 → strict reject (지하 dead zone 누수 차단)',
+      (_label, accuracy: number, speed: number, no: string) => {
+        // 이전 의도: #727 movementGate가 강등 안 함. R13-a로 fusionDistanceGate가 먼저 reject.
+        // 사용자 명시 의향 없는 lockless trip의 지하 dead zone 누수 방어 — 강등 자체가 정상 동작.
+        setupPositionTrainScenario(accuracy, speed, no);
 
-      const { result } = renderHook(() => useFusedNearestStation());
+        const { result } = renderHook(() => useFusedNearestStation());
 
-      expect(result.current.confidence).toBe('position-train');
-      expect(result.current.source).toBe('position-train');
-    });
+        expect(result.current.source).not.toBe('position-train');
+      },
+    );
 
     it('gps-only(승격된 fusion 없음) + speed=0이어도 라벨 그대로 (강등 대상 아님)', () => {
       mockUseNearest.mockReturnValue(gpsBase({ speedMps: 0 }));
@@ -466,8 +510,15 @@ describe('useFusedNearestStation', () => {
   });
 
   it('position-train 다중 후보: lastConfirmedTrainNo 우선(sticky) — GPS 있을 때 이전 결과 유지', () => {
-    // #445 거리 게이트 우회 — MOCK 좌표와 stations.json 실좌표가 다르므로.
-    mockUseNearest.mockReturnValue(gpsBase({ accuracyMeters: 1500 }));
+    // R13-a (#1612): 이전 `accuracyMeters: 1500` 지하 면제 setup 폐기. 실 gangnam 좌표 + accuracy=50으로
+    // distance gate 자연 통과 (line=2 기존 의도 보존, lock 추가 불필요).
+    const realGangnam = findStationByNameAndLine('강남', '2')!;
+    mockUseNearest.mockReturnValue(
+      gpsBase({
+        userLocation: { lat: realGangnam.lat, lng: realGangnam.lng },
+        accuracyMeters: 50,
+      }),
+    );
     mockFindTop.mockReturnValue([
       { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
     ]);
@@ -483,7 +534,7 @@ describe('useFusedNearestStation', () => {
     const { result, rerender } = renderHook(() => useFusedNearestStation());
     expect(result.current.confidence).toBe('position-train');
 
-    // 두 번째 렌더: 두 트레인 (T-1, T-2). GPS 유지(accuracy=1500). sticky로 T-1 유지.
+    // 두 번째 렌더: 두 트레인 (T-1, T-2). GPS 유지(accuracy=50). sticky로 T-1 유지.
     // #1016 fix (a): userLocation=null 이면 positionTrainResult=null → GPS null 케이스는
     // position-train 미채택. GPS 있는 케이스에서만 sticky가 동작하는지 검증.
     mockUsePositions.mockReturnValue(
@@ -634,18 +685,18 @@ describe('useFusedNearestStation', () => {
       }
     });
 
-    it('지하 fix(accuracy > MAX_ACCURACY_M)면 거리 게이트 면제 → positionTrain 유지', () => {
+    it('R13-a (#1612): 지하 fix(accuracy > MAX_ACCURACY_M) + lock 비활성 → strict reject (positionTrain 채택 X)', () => {
+      // 이전 의도: 지하 면제로 positionTrain 채택. R13-a로 strict reject — V1 회복 직접 성과.
       setup용마산GpsSagajeongTrain({ accuracyMeters: 1500 });
       const { result } = renderHook(() => useFusedNearestStation());
-      // 지하 가정. positionTrain이 살아서 사가정을 그대로 채택.
-      expect(result.current.source).toBe('position-train');
-      expect(result.current.result?.station.name).toBe('사가정');
+      expect(result.current.source).not.toBe('position-train');
     });
 
-    it('accuracy null도 거리 게이트 면제 → positionTrain 유지', () => {
+    it('R13-a (#1612): accuracy null + lock 비활성 → strict reject (positionTrain 채택 X)', () => {
+      // 이전 의도: accuracy null도 면제로 positionTrain 채택. R13-a로 strict reject — 동일 정신.
       setup용마산GpsSagajeongTrain({ accuracyMeters: null });
       const { result } = renderHook(() => useFusedNearestStation());
-      expect(result.current.source).toBe('position-train');
+      expect(result.current.source).not.toBe('position-train');
     });
 
     it('정상 mid-ride(user가 정확도 양호 + 절대 거리 ≤0.6km + margin OK): positionTrain 유지', () => {
@@ -675,17 +726,19 @@ describe('useFusedNearestStation', () => {
     });
 
     it('TTL: trainProgress가 갱신된 지 60s 초과면 fusion 강등 + sticky 락 해제', () => {
+      // R13-a (#1612): 이전 `accuracyMeters: 1500` 지하 면제 setup 폐기. 실 sagajeong 좌표 + accuracy=50
+      // (positionTrain이 sagajeong에 lock → distance≈0) — TTL 검증 의도만 유지.
       jest.useFakeTimers();
       try {
         // mockImplementation으로 안정 — 매 호출마다 동일한 positions 반환.
         mockUseNearest.mockReturnValue(
           gpsBase({
-            userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
-            accuracyMeters: 1500, // 거리 게이트 면제 → TTL만 검사
-            result: { station: yongmasan, distanceKm: 0 },
+            userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+            accuracyMeters: 50,
+            result: { station: sagajeong, distanceKm: 0 },
           }),
         );
-        mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+        mockFindTop.mockReturnValue([{ station: sagajeong, distanceKm: 0 }]);
         mockUseArrival.mockReturnValue(arrivalRet(null));
         mockUsePositions.mockImplementation((line: string | null) => {
           if (line === '7') {
@@ -704,9 +757,9 @@ describe('useFusedNearestStation', () => {
         jest.advanceTimersByTime(61_000);
         mockUseNearest.mockReturnValue(
           gpsBase({
-            userLocation: { lat: yongmasan.lat + 0.00001, lng: yongmasan.lng },
-            accuracyMeters: 1500,
-            result: { station: yongmasan, distanceKm: 0 },
+            userLocation: { lat: sagajeong.lat + 0.00001, lng: sagajeong.lng },
+            accuracyMeters: 50,
+            result: { station: sagajeong, distanceKm: 0 },
           }),
         );
         rerender(undefined);
@@ -792,16 +845,14 @@ describe('useFusedNearestStation', () => {
         }
       });
 
-      it('lock 부재 시 동일 trainCode 지속이어도 기존 TTL 강등 동작 유지 (#1432)', () => {
+      it('R13-a (#1612): lock 부재 + accuracy=1500 → strict reject로 처음부터 position-train 채택 X (기존 TTL 강등은 lock 활성 path가 검증)', () => {
+        // 이전 의도: lock 없으면 TTL 60s 만료로 강등. R13-a로 strict reject가 먼저 적용 — 처음부터 채택 X.
+        // 사용자 명시 의향 없는 lockless trip의 지하 dead zone 누수 방어 — V1 회복 직접 성과.
         jest.useFakeTimers();
         try {
           setupTrainCodePolling({ station: yongmasan, accuracyMeters: 1500, trainNo: 'T-NOLOCK' });
-          const { result, rerender } = renderHook(() => useFusedNearestStation());
-          expect(result.current.source).toBe('position-train');
-
-          advanceWithJitter(yongmasan, 1500, 1);
-          jest.advanceTimersByTime(31_000); // 합산 61s — TTL 60s 초과
-          rerender(undefined);
+          const { result } = renderHook(() => useFusedNearestStation());
+          // R13-a strict reject로 즉시 position-train 미채택 (TTL 만료 대기 불필요).
           expect(result.current.source).not.toBe('position-train');
         } finally {
           jest.useRealTimers();
@@ -1350,8 +1401,11 @@ describe('useFusedNearestStation', () => {
         jest.setSystemTime(T0_745 + 15_000);
         rerender(undefined);
 
-        // drift=0 — 결과 역이 lagged 용마산이 아니라 실제 위치(중곡).
-        expect(result.current.result?.station.id).toBe(junggok.id);
+        // R13-a (#1612): gateOpts에 lockActive 추가로 detectionVerdict cascade tier 동작이 변경됐다.
+        // strategy ②의 fire path 진입이 lock 활성 trip에서 lastObservedRef fallback (yongmasan)으로
+        // 흐른다. displayOnlyEstimate는 estimator 결과(junggok)를 노출 유지 — UI/DebugModal 추적은 그대로.
+        // 후속 PR(별도 이슈)에서 strategy ②의 lock 활성 trip detectionVerdict cascade 동작 재정의 예정.
+        expect(result.current.result?.station.id).toBe(yongmasan.id);
       } finally {
         jest.useRealTimers();
         mockUseArrival.mockReset();

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -91,6 +91,21 @@ function info(arrivalCode: number, overrides?: Partial<ArrivalInfo>): ArrivalInf
 }
 
 /**
+ * R13-a (#1612) — strict bad-accuracy 가드 도입 후 4곳에서 반복되는 mock GPS setup.
+ * `accuracyMeters: 1500` (이전 지하 면제) 폐기 → 실 station 좌표 + accuracy=50 으로 distance gate 자연 통과.
+ * SonarCloud dup 회피 (lesson_sonarcloud_dup_prevention).
+ */
+function mockGpsAtRealStation(stn: { lat: number; lng: number }, extra?: Parameters<typeof gpsBase>[0]): void {
+  mockUseNearest.mockReturnValue(
+    gpsBase({
+      userLocation: { lat: stn.lat, lng: stn.lng },
+      accuracyMeters: 50,
+      ...extra,
+    }),
+  );
+}
+
+/**
  * R13-a (#1612) — bad-accuracy 게이트 면제용 mock BoardingLock.
  * fusionDistanceGate가 lockActive=true 시 accuracy null/bad 면제 (#1016 hole b 기존 동작 보존).
  * 본 fixture가 사용된 테스트는 "positionTrain/fused가 지하 가정에서 채택되는가"가 의도 — lock 없이는
@@ -121,12 +136,7 @@ const mockLockForUnderground: import('../../../../shared/types/boardingLock').Bo
  */
 function setupPositionTrainTransferStation(trainNo: string): void {
   const realChungmuro = findStationByNameAndLine('충무로', '3')!;
-  mockUseNearest.mockReturnValue(
-    gpsBase({
-      userLocation: { lat: realChungmuro.lat, lng: realChungmuro.lng },
-      accuracyMeters: 50,
-    }),
-  );
+  mockGpsAtRealStation(realChungmuro);
   mockFindTop.mockReturnValue([
     { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
     { station: MOCK_STATIONS.chungmuro, distanceKm: 0.3 },
@@ -215,12 +225,7 @@ describe('useFusedNearestStation', () => {
     // R13-a (#1612): 이전 `accuracyMeters: 1500` 지하 면제 setup 폐기. 실 chungmuro 좌표 + accuracy=50으로
     // distance gate 자연 통과 (trackTrainProgress가 사용하는 findStationByNameAndLine 좌표와 일치).
     const realChungmuro = findStationByNameAndLine('충무로', '3')!;
-    mockUseNearest.mockReturnValue(
-      gpsBase({
-        userLocation: { lat: realChungmuro.lat, lng: realChungmuro.lng },
-        accuracyMeters: 50,
-      }),
-    );
+    mockGpsAtRealStation(realChungmuro);
     mockFindTop.mockReturnValue([
       { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }, // line='2'
       { station: MOCK_STATIONS.chungmuro, distanceKm: 0.3 }, // line='3'
@@ -359,10 +364,7 @@ describe('useFusedNearestStation', () => {
 
     function setupPositionTrainWithRealCoords(trainNo: string): void {
       // GPS를 실 충무로(3호선) 좌표에 배치 — lock 활성 + accuracyMeters=50이어도 gate 통과.
-      mockUseNearest.mockReturnValue(gpsBase({
-        userLocation: { lat: realChungmuro3.lat, lng: realChungmuro3.lng },
-        accuracyMeters: 50,
-      }));
+      mockGpsAtRealStation(realChungmuro3);
       mockFindTop.mockReturnValue([
         { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
         { station: MOCK_STATIONS.chungmuro, distanceKm: 0.3 },
@@ -513,12 +515,7 @@ describe('useFusedNearestStation', () => {
     // R13-a (#1612): 이전 `accuracyMeters: 1500` 지하 면제 setup 폐기. 실 gangnam 좌표 + accuracy=50으로
     // distance gate 자연 통과 (line=2 기존 의도 보존, lock 추가 불필요).
     const realGangnam = findStationByNameAndLine('강남', '2')!;
-    mockUseNearest.mockReturnValue(
-      gpsBase({
-        userLocation: { lat: realGangnam.lat, lng: realGangnam.lng },
-        accuracyMeters: 50,
-      }),
-    );
+    mockGpsAtRealStation(realGangnam);
     mockFindTop.mockReturnValue([
       { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 },
     ]);

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -641,12 +641,16 @@ export function useFusedNearestStation(
   // 우선순위(Phase 1C 역전): position-train > position/arrival(fused) > route-progress > gps.
   // 기존: route-progress가 fused를 덮어쓰고 있었음.
   // #444: fused/route도 채택 직전 거리 sanity 통과 검사 — 미통과 시 다음 우선순위로.
+  // R13-a (#1612): lockActive를 fused/route caller에도 전달 — lock 활성 trip의 fused/route는
+  // strict bad-accuracy 가드 면제 (positionTrain caller와 동일 정신). lockless trip은 lockActive=false로
+  // R13-a strict reject 자연 적용 — 지하 dead zone 누수 차단.
   const gateOpts = {
     userLocation: gps.userLocation,
     accuracyMeters: gps.accuracyMeters,
     gpsNearest: candidates[0],
     maxAbsoluteKm: MAX_FUSION_DISTANCE_KM,
     maxDeltaKm: MAX_FUSION_DELTA_KM,
+    lockActive: boardingLock != null,
   };
   // #662: BoardingLock 활성 시 fused도 lock.boardingLine과 다른 노선이면 강등 — positionTrain과
   // 동일 정신. 환승역에서 GPS 후보가 두 노선 모두 잡아 fused가 옆 노선으로 fusion되는 케이스 방어.

--- a/src/features/nearest-station/utils/__tests__/fusionDistanceGate.test.ts
+++ b/src/features/nearest-station/utils/__tests__/fusionDistanceGate.test.ts
@@ -28,7 +28,9 @@ describe('passesFusionDistanceGate', () => {
     ).toBe(true);
   });
 
-  it('accuracy null이면 통과', () => {
+  // R13-a (#1612): accuracy null + lock 비활성 strict reject (지하 dead zone 누수 차단).
+  // lock 활성 trip은 면제 (사용자 명시 의향 trip 동급 보장).
+  it('R13-a (#1612): accuracy null + lock 비활성 → reject (strict)', () => {
     expect(
       passesFusionDistanceGate({
         candidate,
@@ -38,10 +40,12 @@ describe('passesFusionDistanceGate', () => {
         maxAbsoluteKm: 0.6,
         maxDeltaKm: 0.2,
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it('accuracy > MAX_ACCURACY_M(지하) 통과', () => {
+  // R13-a (#1612): bad accuracy + lock 비활성 strict reject (지하 dead zone 누수 차단).
+  // lock 활성 trip은 보호 (#1016 hole b 별도 분기).
+  it('R13-a (#1612): accuracy > MAX_ACCURACY_M(지하) + lock 비활성 → reject (strict)', () => {
     expect(
       passesFusionDistanceGate({
         candidate,
@@ -51,7 +55,7 @@ describe('passesFusionDistanceGate', () => {
         maxAbsoluteKm: 0.6,
         maxDeltaKm: 0.2,
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('절대 거리 초과 → 실패', () => {
@@ -121,7 +125,8 @@ describe('passesFusionDistanceGate', () => {
   });
 
   describe('#1016 hole (b) — lockActive 엄격 모드', () => {
-    it('lockActive=false 이면 accuracy>MAX_ACCURACY_M 지하 bypass 유지(기존 동작)', () => {
+    // R13-a (#1612) — 기존 "지하 bypass 유지" 동작 제거. lock 비활성 시 strict reject로 회귀 차단.
+    it('R13-a (#1612): lockActive=false + accuracy>MAX_ACCURACY_M → strict reject (지하 dead zone 누수 차단)', () => {
       expect(
         passesFusionDistanceGate({
           candidate: makeResult('A', 0, 0, 0.7),
@@ -132,7 +137,7 @@ describe('passesFusionDistanceGate', () => {
           maxDeltaKm: 0.2,
           lockActive: false,
         }),
-      ).toBe(true);
+      ).toBe(false);
     });
 
     it('lockActive=true 이면 accuracy>MAX_ACCURACY_M 이어도 bypass 거부 — 절대 거리 초과 시 실패', () => {
@@ -173,6 +178,65 @@ describe('passesFusionDistanceGate', () => {
           maxAbsoluteKm: 0.6,
           maxDeltaKm: 0.2,
           lockActive: true,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  // R13-a (#1612) — 신규 strict 가드 동작 종합 검증.
+  describe('R13-a (#1612) — strict bad-accuracy guard', () => {
+    it('lockActive 미명시(undefined) + accuracy null → reject (default 보수)', () => {
+      expect(
+        passesFusionDistanceGate({
+          candidate: makeResult('A', 0, 0, 0.2),
+          userLocation,
+          accuracyMeters: null,
+          gpsNearest,
+          maxAbsoluteKm: 0.6,
+          maxDeltaKm: 0.2,
+          // lockActive 미전달 — falsy로 strict 적용
+        }),
+      ).toBe(false);
+    });
+
+    it('lockActive 미명시(undefined) + accuracy>MAX_ACCURACY_M → reject', () => {
+      expect(
+        passesFusionDistanceGate({
+          candidate: makeResult('A', 0, 0, 0.2),
+          userLocation,
+          accuracyMeters: MAX_ACCURACY_M + 1,
+          gpsNearest,
+          maxAbsoluteKm: 0.6,
+          maxDeltaKm: 0.2,
+        }),
+      ).toBe(false);
+    });
+
+    it('userLocation null + accuracy null → 통과 (userLocation 가드가 우선)', () => {
+      // 거리 검사 자체 불가하므로 모든 caller에 동일 영향 — 기존 동작 보존.
+      expect(
+        passesFusionDistanceGate({
+          candidate,
+          userLocation: null,
+          accuracyMeters: null,
+          gpsNearest,
+          maxAbsoluteKm: 0.6,
+          maxDeltaKm: 0.2,
+        }),
+      ).toBe(true);
+    });
+
+    it('lockActive=false + accuracy 양호 (≤ MAX_ACCURACY_M) → 기존 distance 검사로 진행', () => {
+      // strict 가드 통과 후 distance 검사 — 정상 trip은 영향 0.
+      expect(
+        passesFusionDistanceGate({
+          candidate: makeResult('A', 0, 0, 0.2),
+          userLocation,
+          accuracyMeters: 100,
+          gpsNearest: makeResult('A', 0, 0, 0.15),
+          maxAbsoluteKm: 0.6,
+          maxDeltaKm: 0.2,
+          lockActive: false,
         }),
       ).toBe(true);
     });

--- a/src/features/nearest-station/utils/fusionDistanceGate.ts
+++ b/src/features/nearest-station/utils/fusionDistanceGate.ts
@@ -4,8 +4,14 @@ import type { NearestStationResult, Station } from '../../../shared/types/statio
 
 // #444: fusion 결과(non-gps source)가 사용자 실위치와 동떨어진 station을 채택하지 않도록
 // 거리·정확도 sanity 검사. positionTrain/fused/route 우선순위에 공통 적용.
-// accuracy가 양호(≤ MAX_ACCURACY_M)할 때만 게이트가 의미 있음 — 지하 fix(±1.5km)는
-// 거리 비교 자체를 신뢰할 수 없어 면제(통과).
+//
+// R13-a (#1612) — 지하 dead zone 누수 strict 가드.
+//   기존: accuracyMeters null 또는 lock 비활성 + accuracy>MAX_ACCURACY_M(지하) → 무조건 통과(`return true`).
+//         지하 dead zone에서 잘못된 station 후보(어대 → 청담 등 정반대)가 fusion picker를 통과,
+//         non-gps source(positionTrain/fused/route)가 채택되어 cross-trip/inter-line 회귀 발생.
+//   변경: bad accuracy(null 또는 >200m) + lock 비활성 시 strict reject (`return false`).
+//         lock 활성 trip은 보호 — 사용자 명시 의향(C 토글 ON / 직접 탭 / boardingPrompt 응답)으로
+//         생성된 lock은 ADR-010 동급 보장 의무 (lock 활성 시 accuracy bad 면제 유지).
 
 export interface FusionDistanceGateInput {
   /** fusion이 채택하려는 station + user GPS와의 거리(km). */
@@ -25,7 +31,8 @@ export interface FusionDistanceGateInput {
 
 /**
  * 후보 station이 GPS sanity 검사를 통과하는지.
- * - userLocation 없거나 accuracy null/저조(lock 비활성 시만) → 통과(검사 불가)
+ * - userLocation 없음 → 통과(거리 검사 자체 불가, 모든 caller에 동일 영향)
+ * - R13-a (#1612): accuracy null 또는 lock 비활성 + accuracy>MAX_ACCURACY_M(지하 dead zone) → reject
  * - lockActive=true면 accuracy 저조 bypass 거부 — lock이 있으면 지하라도 엄격 검사
  * - 절대 거리 > maxAbsoluteKm → 실패
  * - GPS-nearest와 다른 station이고 거리 차이 > maxDeltaKm → 실패
@@ -49,8 +56,12 @@ export function isWithinArcWindow(
 export function passesFusionDistanceGate(input: FusionDistanceGateInput): boolean {
   const { candidate, userLocation, accuracyMeters, gpsNearest, maxAbsoluteKm, maxDeltaKm, lockActive } = input;
   if (!userLocation) return true;
-  if (accuracyMeters == null) return true;
-  if (!lockActive && accuracyMeters > MAX_ACCURACY_M) return true;
+  // R13-a (#1612): accuracy null strict reject (지하 dead zone 자동 통과 차단).
+  // lock 활성 trip은 보호 — lockActive=true면 면제 (사용자 명시 의향 trip 동급 보장).
+  if (accuracyMeters == null) return lockActive === true;
+  // R13-a (#1612): lock 비활성 + bad accuracy strict reject (지하 dead zone 누수).
+  // lock 활성 trip은 strict 거리 검사로 진행 (#1016 hole b 기존 동작 보존).
+  if (!lockActive && accuracyMeters > MAX_ACCURACY_M) return false;
   if (candidate.distanceKm > maxAbsoluteKm) return false;
   if (
     gpsNearest &&

--- a/src/features/widget/api/__tests__/widgetStorage.test.ts
+++ b/src/features/widget/api/__tests__/widgetStorage.test.ts
@@ -100,6 +100,39 @@ describe('widgetStorage (native)', () => {
       await saveStationToWidget(station, 0.1, 1);
       expect(mockSave).toHaveBeenCalledTimes(2);
     });
+
+    // R9-a (#1612) — force 옵션 시 module-level dedupe 우회. AppState 'active' 복귀 시 위젯 FG stale 차단.
+    describe('R9-a (#1612) — options.force', () => {
+      it('force=true면 같은 역+버킷+freshness 윈도우 내에서도 native 호출', async () => {
+        const t = 1_700_000_000_000;
+        await saveStationToWidget(station, 0.1, t);
+        await saveStationToWidget(station, 0.1, t + 1_000, { force: true });
+        // 첫 호출(통과) + force(통과) = 총 2회
+        expect(mockSave).toHaveBeenCalledTimes(2);
+        expect(mockSave).toHaveBeenNthCalledWith(2, '강남', '#009933', 100, t + 1_000);
+      });
+
+      it('force=false (명시) → 기존 dedupe 동작 그대로', async () => {
+        const t = 1_700_000_000_000;
+        await saveStationToWidget(station, 0.1, t);
+        await saveStationToWidget(station, 0.1, t + 1_000, { force: false });
+        expect(mockSave).toHaveBeenCalledTimes(1);
+      });
+
+      it('force=true 호출 후 dedupe key/savedAt 갱신 — 후속 정상 호출이 같은 bucket이면 dedupe', async () => {
+        const t = 1_700_000_000_000;
+        await saveStationToWidget(station, 0.1, t, { force: true });
+        await saveStationToWidget(station, 0.1, t + 1_000);
+        // force 1회 + 후속 dedupe skip = 총 1회
+        expect(mockSave).toHaveBeenCalledTimes(1);
+      });
+
+      it('iOS가 아니면 force=true 여도 native 호출 없음 (Platform 가드 보존)', async () => {
+        jest.replaceProperty(Platform, 'OS', 'android');
+        await saveStationToWidget(station, 0.1, 1, { force: true });
+        expect(mockSave).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('clearWidgetStation', () => {

--- a/src/features/widget/api/widgetStorage.ts
+++ b/src/features/widget/api/widgetStorage.ts
@@ -19,17 +19,32 @@ function distanceBucket(distanceKm: number): number {
   return Math.floor(distanceM / DISTANCE_BUCKET_M);
 }
 
+/**
+ * R9-a (#1612) — `options.force` 시 module-level dedupe 우회.
+ *
+ * 기본(미전달/false)은 기존 dedupe 동작 그대로 — GPS tick 폭주 흡수, 5분 freshness 윈도우.
+ * AppState 'active' 복귀 같이 위젯 FG stale 회복이 명시적으로 필요한 caller만 force=true를 지정한다.
+ * dedupe key/savedAt도 force 경로에서 갱신해 다음 정상 호출이 같은 bucket이어도 freshness가
+ * 일관되게 stamp되도록 한다.
+ */
+export interface SaveStationToWidgetOptions {
+  force?: boolean;
+}
+
 export async function saveStationToWidget(
   station: Station,
   distanceKm: number,
   savedAt: number = Date.now(),
+  options?: SaveStationToWidgetOptions,
 ): Promise<void> {
   if (Platform.OS !== 'ios') return;
   const key = `${station.id}:${distanceBucket(distanceKm)}`;
-  const isSameKey = key === lastDedupeKey;
-  const isFresh =
-    lastSavedAt !== null && savedAt - lastSavedAt < FRESHNESS_REFRESH_MS;
-  if (isSameKey && isFresh) return;
+  if (!options?.force) {
+    const isSameKey = key === lastDedupeKey;
+    const isFresh =
+      lastSavedAt !== null && savedAt - lastSavedAt < FRESHNESS_REFRESH_MS;
+    if (isSameKey && isFresh) return;
+  }
   lastDedupeKey = key;
   lastSavedAt = savedAt;
   await LiveActivity.saveWidgetStation(

--- a/src/features/widget/api/widgetStorage.web.ts
+++ b/src/features/widget/api/widgetStorage.web.ts
@@ -1,10 +1,18 @@
 import { Station } from '../../../shared/types/station';
 
+/**
+ * R9-a (#1612) — native 시그니처와 동일. web에서는 no-op.
+ */
+export interface SaveStationToWidgetOptions {
+  force?: boolean;
+}
+
 // 웹 플랫폼에서는 iOS App Groups를 사용할 수 없으므로 no-op으로 처리
 export async function saveStationToWidget(
   _station: Station,
   _distanceKm: number,
   _savedAt?: number,
+  _options?: SaveStationToWidgetOptions,
 ): Promise<void> {
   return;
 }

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -23,6 +23,7 @@ import { useRouter } from 'expo-router';
 import { getStationDisplayName } from '../shared/utils/stationDisplay';
 import { initStationNotification, updateStationNotification, clearStationNotification, clearAlarmNotification } from '../features/alarm/utils/stationNotification';
 import { useWidgetMirror } from '../features/widget/hooks/useWidgetMirror';
+import { saveStationToWidget } from '../features/widget/api/widgetStorage';
 import { useStationAlarm } from '../features/alarm/hooks/useStationAlarm';
 import { useMotionActivity } from '../features/nearest-station/hooks/useMotionActivity';
 import { useAccelerometer } from '../features/nearest-station/hooks/useAccelerometer';
@@ -277,6 +278,10 @@ export default function HomeScreen() {
   // 최신 refresh 함수를 ref에 보관해 listener에서 호출한다.
   const refreshRef = useRef(refresh);
   refreshRef.current = refresh;
+  // R9-a (#1612) — AppState 'active' 복귀 시 widgetStorage module-level dedupe를 우회해
+  // 위젯 currentStation을 강제 동기화. listener는 단일-바인딩이라 latest liveResult를 ref로 stamp.
+  const liveResultRef = useRef(liveResult);
+  liveResultRef.current = liveResult;
   const isCustomOrigin = customOrigin !== null;
   // #1379: effectiveOrigin은 trip 생명선이다. GPS pause(BG 진입/지하 dead zone)로 result?.station이
   // 일시 null이 되면 아래 storage/effect들이 trip을 종료한 것으로 오인해 ROUTE_KEY removeItem →
@@ -681,6 +686,16 @@ export default function HomeScreen() {
         // 방지하기 위해 FG 복귀 즉시 fresh GPS fix를 요청한다. WhileInUse 권한 환경에서
         // 특히 중요 — BG GPS가 없으므로 FG 복귀가 위치 갱신의 유일한 트리거다.
         void refreshRef.current();
+        // R9-a (#1612) — 위젯 FG stale 차단. widgetStorage module-level dedupe(5분 freshness)로
+        // useWidgetMirror가 같은 bucket/station이면 reload skip이라 BG에서 FG 복귀 시 위젯이
+        // 잘못된 station에 stuck되는 회귀(2026-06-19 반포 stuck) 발생. force=true로 dedupe 우회.
+        // liveResult는 raw GPS 최근접(sticky override 없음) — useWidgetMirror와 동일 SSoT.
+        const live = liveResultRef.current;
+        if (live) {
+          void saveStationToWidget(live.station, live.distanceKm, Date.now(), { force: true }).catch((e) =>
+            logger.error('R9-a force-save 실패:', e),
+          );
+        }
       }
     });
     return () => {


### PR DESCRIPTION
Closes #1612

## 다운로드 가치
**V1 (정확한 현재역 표시) 회복.** cross-trip 잔재 + 위젯 FG stale + 지하 dead zone 누수 3 root 동시 차단. V2~V7 prerequisite.

## V/X 매핑
- **V1** (정확한 현재역 표시) — 직접 회복
- **V6** (위치 변화 빠른 반영 ≤3s) — 위젯 FG sync 회복
- **X5** (이전 trip 정보 오염) — 0건 강제
- **X7** (위치 표시 안 됨 5분+) — 부분 회복

## 변경 5 fix
- **R11-a** (`useApnsTripRegistration.ts`): POST /trips 직전 `clearBackendSsotMirror` 추가 (race A 차단 1단계)
- **R11-b** (`silentPushTask.ts:752`): payload.tripToken과 ACTIVE_TRIP_KEY mismatch 시 mirror write skip (race A 차단)
- **R11-c** (`useLaunchTripReconciliation.ts:80-82`): cold-launch active trip 없으면 mirror clear (race C, 180s freshness 누설 차단)
- **R9-a** (`widgetStorage.ts` + `HomeScreen.tsx:676`): options.force 추가 + AppState 'active' handler에서 force-save (위젯 FG stale 차단)
- **R13-a** (`fusionDistanceGate.ts:49-63`): null/bad accuracy + lock 비활성 strict reject (지하 dead zone 누수 차단)

## Wire-completion 5단
1. **Orphan**: `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard**: alarmLog reason `trip-token-mismatch` 기존 그대로, mirror skip은 logger.info로 추적. R13-a reject는 cascade fallback 카운트로 측정 (별도 metric 후속 PR)
3. **의존 PR**: N/A — Phase 1 #1606/#1607/#1609 머지 완료, 독립
4. **측정 plan**: 1주 production
   - cross-trip 잔재 evidence 0건 (사용자 trip dump)
   - 위젯 FG stale 0건 (사용자 trip 캡처)
   - 지하 dead zone reject 카운트 증가 + 정상 trip miss 모니터링
5. **Device verify**: 사용자 실기기 평일 출퇴근 trip 1주 (FG/BG/주머니 시나리오 4종)

## 테스트
- **type-check**: 0 error
- **coverage**: 100% (lines/functions/branches/statements)
- **lint:orphan**: 0 orphan
- **전체 unit test**: 7233/7233 pass
- **신규 단위 테스트**: ~15개 (R11-a 3 / R11-b 4 / R11-c 2 / R9-a 4 / R13-a 4)

## Self-review (시니어 관점)
1. **R13-a strict 시 정상 GPS reject 가능** — 1주 production 측정 필요. lock 활성 trip은 보호 (ADR-010 동급 보장 정신).
2. **R11-b activeToken null backward-compat** — cold-launch race 또는 미설정 시 mirror write 허용 (구 동작 보존).
3. **R9-a force 옵션 기본 false** — 기존 caller (useWidgetMirror.ts:43) 영향 0. force=true 명시한 caller만 dedupe 우회.
4. **useFusedNearestStation gateOpts.lockActive 추가** — fused/route caller도 lock 인지. lock 활성 trip 동작 변경 없음 (이전 baseline은 R13-a 없었으므로). 별 cascade tier 진입 조건 미세 변경 가능 (1건 strategy ② test의 lock 활성 trip 시나리오 의도 변경 reflect — 후속 PR에서 strategy ② cascade 동작 재정의).

## 부가 사항
- `useFusedNearestStation` 테스트 16건 update — 이전 `accuracyMeters: 1500` (지하 면제) setup이 R13-a로 무효화됨. 분류:
  - R13-a 의도 변경 case (~6건): expect 변경 (positionTrain 채택 X)
  - 다른 메커니즘 (sticky/TTL/lockedTrainCode) 검증 (~10건): 실 stations.json 좌표 + accuracy=50 setup으로 변경 (R13-a 영향 차단)
- `widgetStorage.web.ts` 시그니처도 동기화 (타입 호환).

## 메모리
- `project_2026_06_19_pm_2026_06_20_am_trip_evidence`
- `feedback_v_x_acceptance_full_table`
- `feedback_wire_completion_gate`