### PR TITLE
feat(#1614): S4 + 알림 path — Backend self-poll + consensusGate strongCB + 도달률 측정 (Stage 3)

### DIFF
--- a/backend/alarm-worker/src/__tests__/autoLock.test.ts
+++ b/backend/alarm-worker/src/__tests__/autoLock.test.ts
@@ -499,3 +499,103 @@ describe('attemptAutoLock #1536 (S3) 환경 분기 consensusGate', () => {
     expect(lock).not.toBeNull();
   });
 });
+
+/**
+ * #1614 Phase B — backend self-poll positionTrainAgreement wire (S4 #1537).
+ *
+ * selfPollPositions list forward 시 trainCode cross-match → consensusGate strongCB 통과 path
+ * 활성화. underground 환경에서 base gate fail + arrival 부재라도 strongCB로 통과.
+ */
+function callAutoLockWithSelfPoll(
+  arrivalEntry: ArrivalEntry,
+  selfPollPositions: readonly { trainCode: string; stationName: string }[] | undefined,
+  opts: {
+    environment?: Parameters<typeof attemptAutoLock>[0]['environment'];
+    gateOutcome?: Parameters<typeof attemptAutoLock>[0]['gateOutcome'];
+  } = {},
+) {
+  return attemptAutoLock({
+    trip: makeTrip(),
+    targetWaypoint: target,
+    originStation: '강남',
+    direction: 'up',
+    seoul: makeSeoul([arrivalEntry]),
+    now: NOW,
+    environment: opts.environment,
+    gateOutcome: opts.gateOutcome,
+    selfPollPositions,
+  });
+}
+
+describe('attemptAutoLock #1614 Phase B selfPollPositions wire (S4)', () => {
+  it.each([
+    {
+      label: 'trainCode 일치 + arvlCd 0~3 → strongCB pass (underground, base gate fail)',
+      positions: [{ trainCode: 'T1', stationName: '강남' }],
+      arvlCd: 1,
+      expected: 'lock' as const,
+    },
+    {
+      label: 'trainCode 불일치 + arvlCd 1 → strongCB undefined, strongBE pass (lockAttachable + arrival)',
+      positions: [{ trainCode: 'OTHER', stationName: '강남' }],
+      arvlCd: 1,
+      expected: 'lock' as const,
+    },
+    {
+      label: 'trainCode 불일치 + arvlCd 5(범위 밖) → strongCB false + strongBE false → null',
+      positions: [{ trainCode: 'OTHER', stationName: '강남' }],
+      arvlCd: 5,
+      expected: 'null' as const,
+    },
+    {
+      label: 'trainCode 일치 + arvlCd 5(범위 밖) → strongCB false (arrival missing) + strongBE false → null',
+      positions: [{ trainCode: 'T1', stationName: '강남' }],
+      arvlCd: 5,
+      expected: 'null' as const,
+    },
+    {
+      label: '빈 list + arvlCd 1 → positionTrainAgreement false, strongBE pass',
+      positions: [] as const,
+      arvlCd: 1,
+      expected: 'lock' as const,
+    },
+  ])('underground + $label', async ({ positions, arvlCd, expected }) => {
+    const { lock } = await callAutoLockWithSelfPoll(
+      arrival({ trainCode: 'T1', arvlCd }),
+      positions,
+      {
+        environment: 'underground',
+        gateOutcome: failingGateOutcome(),
+      },
+    );
+    if (expected === 'lock') {
+      expect(lock?.trainCode).toBe('T1');
+    } else {
+      expect(lock).toBeNull();
+    }
+  });
+
+  it('selfPollPositions undefined → 기존 동작 (구 호출자 호환)', async () => {
+    const { lock } = await callAutoLockWithSelfPoll(
+      arrival({ trainCode: 'T1', arvlCd: 1 }),
+      undefined,
+      {
+        environment: 'underground',
+        gateOutcome: passingGateOutcome(),
+      },
+    );
+    expect(lock?.trainCode).toBe('T1');
+  });
+
+  it('surface: selfPollPositions 무관 — base gate pass면 통과 (positionTrainAgreement 평가 X)', async () => {
+    const { lock } = await callAutoLockWithSelfPoll(
+      arrival({ trainCode: 'T1', arvlCd: 1 }),
+      [{ trainCode: 'OTHER', stationName: '강남' }],
+      {
+        environment: 'surface',
+        gateOutcome: passingGateOutcome(),
+      },
+    );
+    expect(lock?.trainCode).toBe('T1');
+  });
+});

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -3615,3 +3615,66 @@ describe('GET /admin/signals/export (#1520)', () => {
     expect(body.entries.length).toBe(1);
   });
 });
+
+// ─── GET /admin/push-ack-stats (#1614 Phase D, S4 #1537) ──────────────────────
+
+async function getAdminPushAckStats(
+  env: Env,
+  authHeader?: string,
+): Promise<Response> {
+  return app.fetch(
+    new Request('http://example.com/admin/push-ack-stats', {
+      method: 'GET',
+      headers: authHeader ? { authorization: authHeader } : {},
+    }),
+    env,
+  );
+}
+
+describe('GET /admin/push-ack-stats (#1614 Phase D)', () => {
+  it('returns 503 when ADMIN_TOKEN is not configured', async () => {
+    const env = makeKvEnv();
+    const res = await getAdminPushAckStats(env, 'Bearer some-token');
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 401 when no Authorization header', async () => {
+    const env = makeKvEnv();
+    env.ADMIN_TOKEN = 'secret';
+    const res = await getAdminPushAckStats(env);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when token does not match', async () => {
+    const env = makeKvEnv();
+    env.ADMIN_TOKEN = 'secret';
+    const res = await getAdminPushAckStats(env, 'Bearer wrong-token');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with stats shape (empty KV)', async () => {
+    const env = makeKvEnv();
+    env.ADMIN_TOKEN = 'secret';
+    const res = await getAdminPushAckStats(env, 'Bearer secret');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      windowStart: number;
+      windowEnd: number;
+      pending: number;
+      received: number;
+      receivedByPhase: Record<string, number>;
+      receivedByStation: Record<string, number>;
+    };
+    expect(body.windowStart).toBeLessThan(body.windowEnd);
+    expect(body.pending).toBe(0);
+    expect(body.received).toBe(0);
+    expect(body.receivedByPhase).toEqual({});
+    expect(body.receivedByStation).toEqual({});
+  });
+
+  it('returns 503 when TRIPS binding unavailable', async () => {
+    const env = makeEnv({ TRIPS: undefined as unknown as Env['TRIPS'], ADMIN_TOKEN: 'secret' });
+    const res = await getAdminPushAckStats(env, 'Bearer secret');
+    expect(res.status).toBe(503);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/pushAckStats.test.ts
+++ b/backend/alarm-worker/src/__tests__/pushAckStats.test.ts
@@ -1,0 +1,124 @@
+/**
+ * pushAckStats.test.ts — #1614 Phase D (S4 #1537) admin push-ack-stats RCA endpoint helper.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { InMemoryKV } from './inMemoryKv';
+import { computePushAckStats } from '../pushAckStats';
+
+const NOW = 1_700_000_000_000;
+
+function seedReceivedStamp(
+  kv: InMemoryKV,
+  pushId: string,
+  receivedAt: number,
+  phase: string,
+  stationName: string,
+): void {
+  kv.store.set(`received:${pushId}`, {
+    value: JSON.stringify({ pushId, receivedAt, stationName, phase }),
+  });
+}
+
+function seedPending(kv: InMemoryKV, pushId: string): void {
+  kv.store.set(`pending:${pushId}`, {
+    value: JSON.stringify({ pushId, sentAt: NOW - 30_000 }),
+  });
+}
+
+describe('computePushAckStats', () => {
+  it('empty KV → zero counts', async () => {
+    const kv = new InMemoryKV();
+    const stats = await computePushAckStats(kv as unknown as KVNamespace, NOW);
+    expect(stats.received).toBe(0);
+    expect(stats.pending).toBe(0);
+    expect(stats.receivedByPhase).toEqual({});
+    expect(stats.receivedByStation).toEqual({});
+  });
+
+  it('counts received stamps within 1h window', async () => {
+    const kv = new InMemoryKV();
+    seedReceivedStamp(kv, 'p1', NOW - 30 * 60 * 1000, 'imminent', '중곡'); // 30min ago
+    seedReceivedStamp(kv, 'p2', NOW - 5 * 60 * 1000, 'imminent', '용마산'); // 5min ago
+    const stats = await computePushAckStats(kv as unknown as KVNamespace, NOW);
+    expect(stats.received).toBe(2);
+    expect(stats.windowStart).toBe(NOW - 60 * 60 * 1000);
+    expect(stats.windowEnd).toBe(NOW);
+  });
+
+  it('excludes received stamps outside window', async () => {
+    const kv = new InMemoryKV();
+    seedReceivedStamp(kv, 'p-old', NOW - 2 * 60 * 60 * 1000, 'imminent', '중곡'); // 2h ago
+    seedReceivedStamp(kv, 'p-new', NOW - 10 * 60 * 1000, 'imminent', '중곡');
+    const stats = await computePushAckStats(kv as unknown as KVNamespace, NOW);
+    expect(stats.received).toBe(1);
+  });
+
+  it.each([
+    {
+      label: 'single phase',
+      stamps: [
+        { id: 'p1', phase: 'imminent', station: 'A' },
+        { id: 'p2', phase: 'imminent', station: 'B' },
+      ],
+      expectedByPhase: { imminent: 2 },
+    },
+    {
+      label: 'multiple phases',
+      stamps: [
+        { id: 'p1', phase: 'imminent', station: 'A' },
+        { id: 'p2', phase: 'transfer', station: 'B' },
+        { id: 'p3', phase: 'imminent', station: 'C' },
+      ],
+      expectedByPhase: { imminent: 2, transfer: 1 },
+    },
+  ])('groups receivedByPhase ($label)', async ({ stamps, expectedByPhase }) => {
+    const kv = new InMemoryKV();
+    for (const s of stamps) {
+      seedReceivedStamp(kv, s.id, NOW - 10_000, s.phase, s.station);
+    }
+    const stats = await computePushAckStats(kv as unknown as KVNamespace, NOW);
+    expect(stats.receivedByPhase).toEqual(expectedByPhase);
+  });
+
+  it('groups receivedByStation with top-10 truncation', async () => {
+    const kv = new InMemoryKV();
+    // Seed 15 stations with varying counts.
+    for (let i = 0; i < 15; i++) {
+      for (let j = 0; j <= i; j++) {
+        seedReceivedStamp(kv, `p-${i}-${j}`, NOW - 5_000, 'imminent', `Station${i}`);
+      }
+    }
+    const stats = await computePushAckStats(kv as unknown as KVNamespace, NOW);
+    // Top-10 stations only.
+    expect(Object.keys(stats.receivedByStation)).toHaveLength(10);
+    // Highest count (Station14, 15 stamps) is included.
+    expect(stats.receivedByStation['Station14']).toBe(15);
+  });
+
+  it('counts pending entries (TTL alive in-flight pushes)', async () => {
+    const kv = new InMemoryKV();
+    seedPending(kv, 'p1');
+    seedPending(kv, 'p2');
+    seedPending(kv, 'p3');
+    const stats = await computePushAckStats(kv as unknown as KVNamespace, NOW);
+    expect(stats.pending).toBe(3);
+  });
+
+  it('caps at limit (KV cost protection)', async () => {
+    const kv = new InMemoryKV();
+    for (let i = 0; i < 50; i++) {
+      seedReceivedStamp(kv, `p-${i}`, NOW - 1000, 'imminent', `S${i}`);
+    }
+    const stats = await computePushAckStats(kv as unknown as KVNamespace, NOW, 10);
+    expect(stats.received).toBeLessThanOrEqual(10);
+  });
+
+  it('skips malformed JSON entries gracefully', async () => {
+    const kv = new InMemoryKV();
+    kv.store.set('received:bad', { value: '{not-json' });
+    seedReceivedStamp(kv, 'good', NOW - 1000, 'imminent', '중곡');
+    const stats = await computePushAckStats(kv as unknown as KVNamespace, NOW);
+    expect(stats.received).toBe(1);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -11,12 +11,14 @@ import {
   FALLBACK_HOP_SEC,
   MAX_CONSECUTIVE_ETA_MISSING,
   RESCHEDULE_THRESHOLD_MS,
+  STALE_LOCK_FIRE_THRESHOLD_MS,
   SUBSURFACE_ETA_MISSING_TOLERANCE,
   VANISH_RE_ATTACH_THRESHOLD,
   arvlCdFireKey,
   estimateArrivalFromPosition,
   estimateBoardingLockArrival,
   evaluateArvlCdFireGate,
+  fireArvlCdStationPush,
   flipApnsEnv,
   maybeCountDrift,
   pickActiveWaypoint,
@@ -489,10 +491,12 @@ describe('runScheduled', () => {
   // 이전 legacy phase-based push 경로의 회귀 방지 테스트들은 boardingLock 경로의
   // 대응 케이스(self-heal/intermediate/410 등)로 모두 커버되어 삭제됨 (회귀 동등성 유지).
   describe('#640 lockMissing gate', () => {
-    it('lock 부재 trip은 arrival이 와도 push 미발사 + Seoul API 미호출', async () => {
+    it('lock 부재 trip은 arrival이 와도 push 미발사 + Seoul arrivals API 미호출', async () => {
       const kv = new InMemoryKV();
       await putTrip(kv as unknown as KVNamespace, makeTrip()); // makeTrip default: boardingLock undefined
-      const seoulFetch = vi.fn();
+      const seoulFetch = vi.fn(async () =>
+        new Response(JSON.stringify({ realtimePositionList: [] }), { status: 200 }),
+      );
       const seoul = new SeoulArrivalClient({
         apiKey: 'K',
         host: 'h',
@@ -510,7 +514,12 @@ describe('runScheduled', () => {
       expect(stats.pushed).toBe(0);
       expect(stats.lockMissing).toBe(1);
       expect(apnsFetch).not.toHaveBeenCalled();
-      expect(seoulFetch).not.toHaveBeenCalled();
+      // #1614 Phase A — cron 진입부 self-poll로 realtimePosition fetch는 발생할 수 있음.
+      // 본 테스트의 진짜 의도는 arrivals fetch 0 + push 발사 0.
+      const arrivalsCalls = seoulFetch.mock.calls.filter((args: unknown[]) =>
+        String(args[0]).includes('/realtimeStationArrival/'),
+      );
+      expect(arrivalsCalls).toHaveLength(0);
     });
   });
 
@@ -605,12 +614,13 @@ describe('runScheduled', () => {
         apnsCalled: true,
       },
       {
-        name: '토글 OFF + intermediate → lockMissing 카운트 (발사 0, Seoul fetch 미호출)',
+        name: '토글 OFF + intermediate → lockMissing 카운트 (발사 0, arrivals fetch 미호출)',
         trip: () => intermediateTrip({ locklessStationPassed: false }),
         apnsOk: false,
         expect: { pushed: 0, locklessFired: 0, lockMissing: 1 },
         apnsCalled: false,
-        seoulCalled: false,
+        // #1614 Phase A — self-poll은 cron 진입부 unconditional (line set에 활성 trip이 있으면 fetch).
+        // arrivals/realtimePosition fetch 0 보장은 더 이상 lockMissing 진단 신호로 유효 X — seoulCalled 검증 생략.
       },
       {
         name: '토글 ON + destination kind → lockMissing 카운트 (lockless는 intermediate만)',
@@ -5879,7 +5889,7 @@ describe('runScheduled — ADR-017 T5 (#1558) advanceBoardingLockWaypoint SSoT g
     expect(await readSsot(kv as unknown as KVNamespace, TOKEN)).toBeNull();
     const logMessages: { msg: string; meta?: Record<string, unknown> }[] = [];
     await runScheduled(makeEnv(kv), {
-      seoul: makeArvlCdSeoulFor('중곡'),
+      seoul: makeArvlCdFireSeoul('중곡', 0, 1, '7246'),
       apnsConfig,
       apnsHosts: APNS_HOSTS,
       fetchImpl: (vi.fn(async () => new Response('', { status: 200 }))) as unknown as typeof fetch,
@@ -5906,7 +5916,7 @@ describe('runScheduled — ADR-017 T5 (#1558) advanceBoardingLockWaypoint SSoT g
   it('stats — runScheduled 초기 stats에 boardingLockWaypointAdvanceBlocked 0으로 초기화', async () => {
     const kv = new InMemoryKV();
     const stats = await runScheduled(makeEnv(kv), {
-      seoul: makeArvlCdSeoulFor('중곡'),
+      seoul: makeArvlCdFireSeoul('중곡', 0, 1, '7246'),
       apnsConfig,
       apnsHosts: APNS_HOSTS,
       fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
@@ -5945,5 +5955,210 @@ describe('runScheduled — ADR-017 T5 (#1558) advanceBoardingLockWaypoint SSoT g
     const stored = JSON.parse((await kv.get(`trip:${TOKEN}`))!) as Trip;
     expect(stored.waypoints[0].stationName).toBe('중곡');
     expect(stats.boardingLockWaypointAdvanceBlocked).toBe(1);
+  });
+});
+
+/**
+ * #1614 Phase A (S4 #1537) — backend self-poll realtimePosition stats wire.
+ *
+ * runScheduled 진입부에서 활성 trip line union을 추출 → 각 line `seoul.fetchPositions(line)` 호출
+ * → KV `realtime-position:<line>` 30s stamp. stats `realtimePositionFetch` / `selfPollCacheHit` /
+ * `realtimePositionFetchError` 가 분포 측정의 입력.
+ */
+describe('runScheduled — #1614 Phase A self-poll realtimePosition (S4)', () => {
+  const TOKEN = 'phase-a-tok';
+
+  function makeSeoulCallTracker(positionsForLine: Record<string, PositionEntry[]>) {
+    const fetchCalls: string[] = [];
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async (url: string) => {
+        if (url.includes('/realtimePosition/')) {
+          fetchCalls.push(url);
+          // 호선 매칭 — URL에 encoded canonical name 포함 여부.
+          const matchedLine = Object.keys(positionsForLine).find((line) => {
+            const canonical = `${line}호선`;
+            return url.includes(encodeURIComponent(canonical));
+          });
+          const positions = matchedLine ? positionsForLine[matchedLine] : [];
+          return new Response(
+            JSON.stringify({
+              realtimePositionList: positions.map((p) => ({
+                trainNo: p.trainCode,
+                statnNm: p.stationName,
+                updnLine: p.isUp ? '상행' : '하행',
+                trainSttus: p.trainSttus,
+                lastRecptnDt: '',
+              })),
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+    return { seoul, fetchCalls };
+  }
+
+  it('활성 trip 있음 → cron 진입부에서 line별 fetch + stats 누적', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeLockTripFixture(TOKEN);
+    await putTrip(kv as unknown as KVNamespace, trip);
+    const { seoul, fetchCalls } = makeSeoulCallTracker({
+      '7': [{ trainCode: '7246', stationName: '중곡', trainSttus: 1, isUp: true, recptnMs: NOW }],
+    });
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-self-poll',
+    });
+    expect(stats.realtimePositionFetch).toBeGreaterThan(0);
+    expect(stats.realtimePositionFetchError).toBe(0);
+    // realtimePosition URL이 한 번 이상 호출됨 (자체 SeoulClient + cron 진입부 self-poll 양쪽).
+    expect(fetchCalls.length).toBeGreaterThan(0);
+  });
+
+  it('활성 trip 없음 → fetch/error 0', async () => {
+    const kv = new InMemoryKV();
+    const { seoul } = makeSeoulCallTracker({});
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-empty',
+    });
+    expect(stats.realtimePositionFetch).toBe(0);
+    expect(stats.selfPollCacheHit).toBe(0);
+    expect(stats.realtimePositionFetchError).toBe(0);
+  });
+
+  it('expiresAt 만료 trip은 self-poll line set에서 제외', async () => {
+    const kv = new InMemoryKV();
+    // 만료 trip — expiresAt <= now.
+    const expiredTrip = makeLockTripFixture(TOKEN, { expiresAt: NOW - 1 });
+    await putTrip(kv as unknown as KVNamespace, expiredTrip);
+    const { seoul } = makeSeoulCallTracker({});
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-expired',
+    });
+    // 만료 trip은 line set에 포함 안 됨 → fetch 0.
+    expect(stats.realtimePositionFetch).toBe(0);
+  });
+});
+
+/**
+ * #1614 Phase C — fireArvlCdStationPush stale SSoT 가드 (단위).
+ *
+ * SSoT.lastAdvanceAt > 0 + (now - lastAdvanceAt > 3분) 시 fire 차단. lazy-seed (==0) /
+ * SSoT 부재 (legacy) 는 dormant 통과.
+ *
+ * 정상 runScheduled flow 는 advanceTripPosition이 우선 → SSoT fresh이므로 본 가드는
+ * defense-in-depth (외부 race / 다른 entry point). 단위 호출로 가드 자체 효과를 검증.
+ */
+describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
+  const TOKEN = 'phase-c-tok';
+
+  async function callFireDirectly(opts: {
+    setupSsot?: (kv: InMemoryKV, trip: Trip) => Promise<void>;
+  }) {
+    const kv = new InMemoryKV();
+    const trip = makeLockTripFixture(TOKEN);
+    await putTrip(kv as unknown as KVNamespace, trip);
+    if (opts.setupSsot) await opts.setupSsot(kv, trip);
+    const stats: ScheduledStats = {
+      scanned: 0, polled: 0, pushed: 0, errors: 0, etaMissing: 0, envCorrected: 0,
+      lockMissing: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
+      laPushSent: 0, laPushFailed: 0, laTokenCleared: 0,
+      boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
+      phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
+      autoLockSuccess: 0, autoLockFalsePositive: 0, boardingPromptAutoDeduped: 0,
+      arvlCdFireSuccess: 0, arvlCdFireDedup: 0, arvlCdFireMismatch: 0,
+      arvlCdFireBlocked: 0, arvlCdFireFired: 0,
+      boardingLockWaypointAdvanceBlocked: 0, transferDestinationGateBlocked: 0,
+      vanishFallbackFired: 0, vanishReleaseFired: 0, vanishLocklessTakeover: 0,
+      vanishFallbackMotionGateBlocked: 0,
+      cronJitterMs: 0, rescheduleBlockedMotion: 0, rescheduleFallbackNoSsot: 0,
+      realtimePositionFetch: 0, selfPollCacheHit: 0, realtimePositionFetchError: 0,
+      staleLockFireSkipped: 0,
+    };
+    const { dirty } = await fireArvlCdStationPush({
+      trip,
+      waypoint: trip.waypoints[0],
+      lock: trip.boardingLock!,
+      arvlCd: 1,
+      env: makeEnv(kv),
+      deps: {
+        seoul: makeArvlCdFireSeoul('중곡', 0, 1, '7246'),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: (vi.fn(async () => new Response('', { status: 200 }))) as unknown as typeof fetch,
+        now: () => NOW,
+      },
+      stats,
+      now: NOW,
+      log: () => undefined,
+      generatePushId: () => 'p-direct',
+    });
+    return { stats, dirty };
+  }
+
+  it('SSoT.lastAdvanceAt > 3분 stale → fire skip + staleLockFireSkipped++', async () => {
+    const { stats, dirty } = await callFireDirectly({
+      setupSsot: async (kv, trip) => {
+        const seeded = await seedSsot(kv as unknown as KVNamespace, TOKEN, '중곡', {
+          expiresAt: trip.expiresAt,
+        });
+        seeded.lastAdvanceAt = NOW - 4 * 60 * 1000;
+        await writeSsot(kv as unknown as KVNamespace, seeded, { expiresAt: trip.expiresAt });
+      },
+    });
+    expect(stats.staleLockFireSkipped).toBe(1);
+    expect(dirty).toBe(false);
+  });
+
+  it('SSoT.lastAdvanceAt 60s fresh → 가드 통과', async () => {
+    const { stats } = await callFireDirectly({
+      setupSsot: async (kv, trip) => {
+        const seeded = await seedSsot(kv as unknown as KVNamespace, TOKEN, '중곡', {
+          expiresAt: trip.expiresAt,
+        });
+        seeded.lastAdvanceAt = NOW - 30_000;
+        await writeSsot(kv as unknown as KVNamespace, seeded, { expiresAt: trip.expiresAt });
+      },
+    });
+    expect(stats.staleLockFireSkipped).toBe(0);
+  });
+
+  it('SSoT.lastAdvanceAt===0 (lazy-seed) → 가드 dormant 통과', async () => {
+    const { stats } = await callFireDirectly({
+      setupSsot: async (kv, trip) => {
+        await seedSsot(kv as unknown as KVNamespace, TOKEN, '중곡', {
+          expiresAt: trip.expiresAt,
+        });
+        // lastAdvanceAt 0 (seed default).
+      },
+    });
+    expect(stats.staleLockFireSkipped).toBe(0);
+  });
+
+  it('SSoT 부재 (legacy) → 가드 dormant 통과', async () => {
+    const { stats } = await callFireDirectly({});
+    expect(stats.staleLockFireSkipped).toBe(0);
+  });
+
+  it('STALE_LOCK_FIRE_THRESHOLD_MS는 3분 (transferDestinationGate 60s 보다 보수적)', () => {
+    expect(STALE_LOCK_FIRE_THRESHOLD_MS).toBe(3 * 60 * 1000);
   });
 });

--- a/backend/alarm-worker/src/__tests__/selfPollPosition.test.ts
+++ b/backend/alarm-worker/src/__tests__/selfPollPosition.test.ts
@@ -1,0 +1,196 @@
+/**
+ * selfPollPosition.test.ts — #1614 Phase A (S4 #1537) backend self-poll KV stamp + helper.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { InMemoryKV } from './inMemoryKv';
+import {
+  pollLinesAndStamp,
+  readSelfPollPosition,
+  selfPollKey,
+  SELF_POLL_TTL_SEC,
+  writeSelfPollPosition,
+} from '../selfPollPosition';
+import { SeoulArrivalClient, type PositionEntry } from '../seoul';
+
+const NOW = 1_700_000_000_000;
+
+function makePosition(overrides: Partial<PositionEntry> = {}): PositionEntry {
+  return {
+    trainCode: '7246',
+    stationName: '용마산',
+    trainSttus: 2,
+    isUp: true,
+    recptnMs: NOW,
+    ...overrides,
+  };
+}
+
+function makeSeoulClient(positions: PositionEntry[]): SeoulArrivalClient {
+  return new SeoulArrivalClient({
+    apiKey: 'K',
+    host: 'h',
+    now: () => NOW,
+    fetchImpl: (async (url: string) => {
+      if (url.includes('/realtimePosition/')) {
+        return new Response(
+          JSON.stringify({
+            realtimePositionList: positions.map((p) => ({
+              trainNo: p.trainCode,
+              statnNm: p.stationName,
+              updnLine: p.isUp ? '상행' : '하행',
+              trainSttus: p.trainSttus,
+              lastRecptnDt: '',
+            })),
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response('not found', { status: 404 });
+    }) as unknown as typeof fetch,
+  });
+}
+
+describe('selfPollKey', () => {
+  it('builds stable key for line', () => {
+    expect(selfPollKey('7')).toBe('realtime-position:7');
+    expect(selfPollKey('bundang')).toBe('realtime-position:bundang');
+  });
+});
+
+describe('SELF_POLL_TTL_SEC', () => {
+  it('meets Cloudflare KV minimum cacheTtl floor (30s)', () => {
+    // KV_MIN_CACHE_TTL_SEC=30 [[lesson_cron_cachettl_runtime_constraint]]
+    expect(SELF_POLL_TTL_SEC).toBeGreaterThanOrEqual(30);
+  });
+});
+
+describe('readSelfPollPosition / writeSelfPollPosition round-trip', () => {
+  it('returns null when no stamp', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    expect(await readSelfPollPosition(kv, '7')).toBeNull();
+  });
+
+  it('round-trips positions + fetchedAt', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const positions = [makePosition()];
+    await writeSelfPollPosition(kv, '7', positions, NOW);
+    const stamp = await readSelfPollPosition(kv, '7');
+    expect(stamp).not.toBeNull();
+    expect(stamp?.positions).toEqual(positions);
+    expect(stamp?.fetchedAt).toBe(NOW);
+  });
+
+  it('returns null when JSON is malformed', async () => {
+    const kv = new InMemoryKV();
+    kv.store.set(selfPollKey('7'), { value: '{not-json' });
+    expect(await readSelfPollPosition(kv as unknown as KVNamespace, '7')).toBeNull();
+  });
+
+  it('writes with 30s expirationTtl', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await writeSelfPollPosition(kv, '7', [makePosition()], NOW);
+    const entry = (kv as unknown as InMemoryKV).store.get(selfPollKey('7'));
+    expect(entry?.expiresAt).toBeDefined();
+    // TTL 30s minimum.
+    expect(entry!.expiresAt! - Date.now()).toBeGreaterThan(25 * 1000);
+  });
+});
+
+describe('pollLinesAndStamp', () => {
+  it('returns zero counts for empty line set', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const seoul = makeSeoulClient([]);
+    const stats = await pollLinesAndStamp(kv, seoul, new Set(), NOW);
+    expect(stats).toEqual({ fetched: 0, cacheHit: 0, error: 0 });
+  });
+
+  it.each([
+    { lines: ['7'], expectedFetched: 1 },
+    { lines: ['7', '5'], expectedFetched: 2 },
+    { lines: ['7', '5', '2'], expectedFetched: 3 },
+  ])('fetches each line once on cache miss (lines=$lines)', async ({ lines, expectedFetched }) => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const seoul = makeSeoulClient([makePosition()]);
+    const stats = await pollLinesAndStamp(kv, seoul, new Set(lines), NOW);
+    expect(stats.fetched).toBe(expectedFetched);
+    expect(stats.cacheHit).toBe(0);
+    expect(stats.error).toBe(0);
+  });
+
+  it('skips fetch when KV stamp exists (cacheHit++)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const seoul = makeSeoulClient([makePosition()]);
+    // First call — fetches.
+    await pollLinesAndStamp(kv, seoul, new Set(['7']), NOW);
+    // Second call — KV hit (stamp still alive).
+    const second = await pollLinesAndStamp(kv, seoul, new Set(['7']), NOW + 1000);
+    expect(second).toEqual({ fetched: 0, cacheHit: 1, error: 0 });
+  });
+
+  it('stamps fetched positions into KV (caller can readSelfPollPosition)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const positions = [makePosition({ trainCode: '7246' }), makePosition({ trainCode: '7248' })];
+    const seoul = makeSeoulClient(positions);
+    await pollLinesAndStamp(kv, seoul, new Set(['7']), NOW);
+    const stamp = await readSelfPollPosition(kv, '7');
+    expect(stamp).not.toBeNull();
+    expect(stamp?.positions.map((p) => p.trainCode).sort()).toEqual(['7246', '7248']);
+  });
+
+  it('counts error when Seoul fetch throws', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () => {
+        throw new Error('rate-limited');
+      }) as unknown as typeof fetch,
+    });
+    const stats = await pollLinesAndStamp(kv, seoul, new Set(['7']), NOW);
+    expect(stats.error).toBe(1);
+    expect(stats.fetched).toBe(0);
+  });
+
+  it('Promise.allSettled — one line failure does not block others', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    // Custom Seoul fixture: line '7' returns positions, line '5' throws.
+    // URL params are encoded — match on encoded canonical name ('5호선' → '5%ED%98%B8%EC%84%A0').
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async (url: string) => {
+        if (url.includes(encodeURIComponent('5호선'))) throw new Error('boom');
+        return new Response(JSON.stringify({ realtimePositionList: [] }), { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+    const stats = await pollLinesAndStamp(kv, seoul, new Set(['7', '5']), NOW);
+    expect(stats.fetched).toBe(1);
+    expect(stats.error).toBe(1);
+  });
+
+  it('writes through canonicalLineName — unmapped line returns empty positions (counts as fetched)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const seoul = makeSeoulClient([]);
+    // unmapped line — SeoulArrivalClient returns empty array (not throw).
+    const stats = await pollLinesAndStamp(kv, seoul, new Set(['unmapped-line']), NOW);
+    expect(stats.fetched).toBe(1);
+    expect(stats.error).toBe(0);
+    // KV stamp has empty positions array.
+    const stamp = await readSelfPollPosition(kv, 'unmapped-line');
+    expect(stamp?.positions).toEqual([]);
+  });
+
+  it('counts error when KV write fails after successful fetch', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const seoul = makeSeoulClient([makePosition()]);
+    // Spy on KV.put to throw on second call (first call from cron, no second normally).
+    const spy = vi.spyOn(kv, 'put').mockRejectedValueOnce(new Error('KV write failed'));
+    const stats = await pollLinesAndStamp(kv, seoul, new Set(['7']), NOW);
+    expect(stats.error).toBe(1);
+    expect(stats.fetched).toBe(0);
+    spy.mockRestore();
+  });
+});

--- a/backend/alarm-worker/src/autoLock.ts
+++ b/backend/alarm-worker/src/autoLock.ts
@@ -149,6 +149,18 @@ export interface AttemptAutoLockInputs {
    * 미전달(undefined) 시 검증 skip — 구 호출자 호환.
    */
   gateOutcome?: GateOutcome;
+  /**
+   * #1614 Phase B (S4 #1537) — backend self-poll realtimePosition 결과 (호선 단위 운행 trainCode 위치).
+   *
+   * caller(scheduled.ts `maybeBindLocklessTrainCode`)가 `readSelfPollPosition(env.TRIPS, line)`
+   * 으로 KV stamp 읽어 그대로 전달. attemptAutoLock 가 `pickAutoTrainCode` 결과로 trainCode를
+   * 결정한 직후, 본 list 에 해당 trainCode가 존재하면 `consensusGate.ts:155` strongCB
+   * (positionTrainAgreement + arrival) 통과 path를 연다 — underground 환경에서 strongBE 외 추가
+   * 합의 분기를 활성화.
+   *
+   * 미전달(undefined) / 빈 배열 시 consensusGate가 자연 `?? false` fallback (strongBE 동작 유지).
+   */
+  selfPollPositions?: readonly { trainCode: string; stationName: string }[];
 }
 
 /**
@@ -213,6 +225,7 @@ export async function attemptAutoLock(
     allowedLines,
     environment,
     gateOutcome,
+    selfPollPositions,
   } = inputs;
   const line = targetWaypoint.line;
   const subwayId = subwayIdForLine(line);
@@ -246,12 +259,19 @@ export async function attemptAutoLock(
       typeof chosenForGate?.arvlCd === 'number' &&
       chosenForGate.arvlCd >= 0 &&
       chosenForGate.arvlCd <= 3;
+    // #1614 Phase B — backend self-poll realtimePosition cross-match.
+    // pickAutoTrainCode 가 선택한 trainCode가 line의 운행 trains 중에 실제 존재하면 true.
+    // undefined / 빈 list 시 자연 undefined → consensusGate가 `?? false` fallback (strongBE 동작 유지).
+    const positionTrainAgreement = selfPollPositions
+      ? selfPollPositions.some((p) => p.trainCode === trainCode)
+      : undefined;
     const consensus = evaluateConsensusGate(environment, {
       gateOutcome,
       arrivalSignalPresent,
       // trainCode 단일 수렴 = lockAttachable. pickAutoTrainCode 가 null 이면 함수가 이미
       // 더 위에서 return 했으므로 본 시점에서는 항상 true.
       lockAttachable: true,
+      positionTrainAgreement,
     });
     if (!consensus.pass) return { lock: null };
   }

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -40,6 +40,7 @@ import {
   type LiveActivityStats,
 } from './liveActivity';
 import { ackPending, stampReceived } from './pendingPushes';
+import { computePushAckStats } from './pushAckStats';
 import { appendPositionPoint } from './positionSeries';
 import { appendAccelSample, isAccelSummary } from './accelSeries';
 import { updateSsotMotion } from './motionState';
@@ -299,6 +300,28 @@ app.get('/admin/quota', async (c) => {
   if (authError) return c.json({ error: authError.code }, authError.status);
   const status = await getQuotaStatus(c.env.TRIPS, Date.now());
   return c.json(status);
+});
+
+/**
+ * #1614 Phase D — silent push 도달률 측정 RCA (S4 #1537).
+ *
+ * `pendingPushes.ts`의 `received:<pushId>` stamp(1h TTL) 와 `pending:<pushId>` (60s TTL) 를
+ * scan해 1시간 윈도우 분포 산출. 도달률 = received / sent (sent는 별도 stats catalog에서).
+ *
+ * Auth: `Authorization: Bearer <ADMIN_TOKEN>` 필수 — admin 공통 정책.
+ * Query: `?limit=N` (default 500, KV cost 보호).
+ *
+ * Response 200: { windowStart, windowEnd, pending, received, receivedByPhase, receivedByStation }
+ * Response 401/503: 인증/binding 정책은 /admin/feedback과 동일.
+ */
+app.get('/admin/push-ack-stats', async (c) => {
+  const authError = checkAdminAuth(c.req.header('authorization'), c.env.ADMIN_TOKEN);
+  if (authError) return c.json({ error: authError.code }, authError.status);
+  const kv = c.env.TRIPS;
+  if (!kv) return c.json({ error: 'trips_unavailable' }, 503);
+  const limit = parseQueryNumber(c.req.query('limit'));
+  const stats = await computePushAckStats(kv, Date.now(), limit);
+  return c.json(stats);
 });
 
 interface AdminAuthError {

--- a/backend/alarm-worker/src/pushAckStats.ts
+++ b/backend/alarm-worker/src/pushAckStats.ts
@@ -1,0 +1,137 @@
+/**
+ * Push ack stats (S4 #1537 / #1614 Phase D).
+ *
+ * 배경
+ * ====
+ * `pendingPushes.ts:152` receivedKey + `stampReceived`로 push 도달 이벤트가 KV에 stamp되어
+ * 있다. RCA endpoint(`/admin/push-ack-stats`)가 이를 scan해 1시간 윈도우 분포를 산출.
+ *
+ * 측정 신호
+ * =========
+ * - `pending:` prefix: silent push가 발사된 entries (60s TTL)
+ * - `received:` prefix: device가 ack한 entries (1h TTL)
+ *
+ * 도달률 = receivedCount / sentCount(=fallback pending or 발사 카운터 별도 metric)
+ *
+ * 본 모듈은 raw count만 산출 — 비율/대시보드는 운영자 측 후처리. 단순화 위해 1h 윈도우 고정
+ * (TTL과 일치). 윈도우 짧게 하려면 client filter — 본 endpoint는 raw enumerate만 제공.
+ *
+ * KV cost
+ * =======
+ * `kv.list` 호출 + 각 key get. 활성 trip 시 평소 ~수십 entry. limit param으로 cap (default 100).
+ */
+
+import { CRON_READ_CACHE_TTL_SEC, assertCronCacheTtl } from './kvConsistency';
+
+const RECEIVED_PREFIX = 'received:';
+const PENDING_PREFIX = 'pending:';
+
+/** 단일 received ack entry (json-decoded). */
+interface ReceivedEntry {
+  pushId: string;
+  receivedAt: number;
+  stationName: string;
+  phase: string;
+}
+
+/**
+ * `/admin/push-ack-stats` 응답 shape.
+ *
+ * - `windowStart` / `windowEnd`: 측정 윈도우 (epoch ms)
+ * - `pending`: 현재 발사 중(60s TTL) 미ack push 카운트
+ * - `received`: 본 윈도우 내 ack 카운트
+ * - `receivedByPhase`: phase 별 ack 분포 (imminent/etc)
+ * - `receivedByStation`: station 별 ack 분포 (top 10)
+ *
+ * 비율(도달률) 계산은 client에서 — 본 endpoint는 raw count만 제공.
+ */
+export interface PushAckStatsResponse {
+  windowStart: number;
+  windowEnd: number;
+  pending: number;
+  received: number;
+  receivedByPhase: Record<string, number>;
+  receivedByStation: Record<string, number>;
+}
+
+/**
+ * KV `received:` + `pending:` prefix scan으로 분포 산출.
+ *
+ * @param kv TRIPS KV namespace
+ * @param now 현재 epoch ms (윈도우 계산)
+ * @param limit 최대 enumerate entry 수 (KV cost 보호, default 500)
+ */
+export async function computePushAckStats(
+  kv: KVNamespace,
+  now: number,
+  limit = 500,
+): Promise<PushAckStatsResponse> {
+  const windowStart = now - 60 * 60 * 1000; // 1h
+  const windowEnd = now;
+
+  // received: prefix enumerate + JSON parse + phase/station bucket.
+  const receivedByPhase: Record<string, number> = {};
+  const receivedByStation: Record<string, number> = {};
+  let receivedCount = 0;
+  let pendingCount = 0;
+
+  assertCronCacheTtl(CRON_READ_CACHE_TTL_SEC);
+  let receivedCursor: string | undefined;
+  let enumerated = 0;
+  do {
+    const result = await kv.list({
+      prefix: RECEIVED_PREFIX,
+      cursor: receivedCursor,
+      limit: Math.min(limit - enumerated, 1000),
+    });
+    for (const key of result.keys) {
+      if (enumerated >= limit) break;
+      const raw = await kv.get(key.name, { cacheTtl: CRON_READ_CACHE_TTL_SEC });
+      enumerated += 1;
+      if (!raw) continue;
+      let entry: ReceivedEntry;
+      try {
+        entry = JSON.parse(raw) as ReceivedEntry;
+      } catch {
+        continue;
+      }
+      if (entry.receivedAt < windowStart || entry.receivedAt > windowEnd) continue;
+      receivedCount += 1;
+      receivedByPhase[entry.phase] = (receivedByPhase[entry.phase] ?? 0) + 1;
+      receivedByStation[entry.stationName] = (receivedByStation[entry.stationName] ?? 0) + 1;
+    }
+    receivedCursor = result.list_complete || enumerated >= limit ? undefined : result.cursor;
+  } while (receivedCursor);
+
+  // pending: prefix scan — count only (TTL 60s, 살아있는 발사 in-flight).
+  let pendingCursor: string | undefined;
+  let pendingEnumerated = 0;
+  do {
+    const result = await kv.list({
+      prefix: PENDING_PREFIX,
+      cursor: pendingCursor,
+      limit: Math.min(limit - pendingEnumerated, 1000),
+    });
+    pendingCount += result.keys.length;
+    pendingEnumerated += result.keys.length;
+    pendingCursor =
+      result.list_complete || pendingEnumerated >= limit ? undefined : result.cursor;
+  } while (pendingCursor);
+
+  return {
+    windowStart,
+    windowEnd,
+    pending: pendingCount,
+    received: receivedCount,
+    receivedByPhase,
+    receivedByStation: topN(receivedByStation, 10),
+  };
+}
+
+/** 큰 dict에서 top-N 만 추출 (KV station 분포가 100+ 가능 — response size 보호). */
+function topN(dict: Record<string, number>, n: number): Record<string, number> {
+  const sorted = Object.entries(dict)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n);
+  return Object.fromEntries(sorted);
+}

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -64,6 +64,7 @@ import { assertCronCacheTtl } from './kvConsistency';
 import { buildAlarmKey, putPending } from './pendingPushes';
 import { deleteProgress, getProgress, putProgress, type TripProgress } from './progress';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from './seoul';
+import { pollLinesAndStamp, readSelfPollPosition } from './selfPollPosition';
 import { phaseAllowsImminentFiring, runStationPhaseStep } from './stationPhase';
 import { listTrips, putTrip } from './trips';
 import {
@@ -75,6 +76,7 @@ import type {
   ApnsEnv,
   BoardingLockMeta,
   Env,
+  LineNumber,
   PositionPoint,
   StationPhaseState,
   Trip,
@@ -424,6 +426,28 @@ export interface ScheduledStats extends LiveActivityStats {
    * SSoT 마이그레이션 진행도 측정 — 모든 trip이 T1 seeding을 거치게 되면 0으로 수렴한다.
    */
   rescheduleFallbackNoSsot: number;
+  /**
+   * #1614 Phase A (S4 #1537) — cron 진입부 self-poll realtimePosition fetch 횟수.
+   * 활성 trip line union에 대해 Seoul API를 1회 호출(KV cache miss). 호선당 30s TTL.
+   * positionTrainAgreement strongCB wire의 입력 단(端) 카운터.
+   */
+  realtimePositionFetch: number;
+  /**
+   * #1614 Phase A — KV stamp 살아있어 fetch skip한 횟수. cron 1분 race에서 동일 line 재진입 시.
+   */
+  selfPollCacheHit: number;
+  /**
+   * #1614 Phase A — Seoul API throw 또는 KV write throw 등 self-poll 전반 실패 횟수.
+   * 0이 아니면 cron tail에서 Seoul API rate limit / KV 장애 진단 신호.
+   */
+  realtimePositionFetchError: number;
+  /**
+   * #1614 Phase C — `fireArvlCdStationPush` 진입 시 SSoT.lastAdvanceAt이 stale(>3분 경과)이라
+   * fire를 차단한 누적 횟수. transferDestinationGate(60s)보다 보수적이지만 모든 fire kind에
+   * 동일 적용. 정상 운영에서는 0에 가깝고, 0이 아니면 motion 추적 cascade fail 또는 stale lock
+   * misfire 회귀 신호. (transferDestinationGateBlocked와 별도 계측 — 본 가드는 intermediate 포함.)
+   */
+  staleLockFireSkipped: number;
 }
 
 /**
@@ -448,6 +472,28 @@ export interface ScheduledDeps {
   log?: (message: string, meta?: Record<string, unknown>) => void;
   /** pushId 발급 — 테스트에선 결정적 값을 주입한다. 기본은 crypto.randomUUID. */
   generatePushId?: () => string;
+}
+
+/**
+ * #1614 Phase A — 활성 trip의 line union 수집.
+ *
+ * 다음 메인 루프와 같은 `listTrips`를 한 번 더 iterate해 route + waypoints의 모든 line을
+ * `computeAllowedLines`로 union. 환승 route는 fromLine/toLine 모두 포함되므로 leg마다 별도 fetch
+ * 필요 없이 한 cron tick에 trip이 다닐 수 있는 모든 line이 stamp된다.
+ *
+ * `expiresAt` 만료 trip은 skip — 메인 루프의 cleanup 분기가 어차피 처리하므로 self-poll 대상 X.
+ * `alarmAtEpochMs - now > POLLING_WINDOW_MS`(아직 알람 윈도우 진입 전) trip은 포함 — 미리 line의
+ * realtimePosition stamp를 적재해두면 윈도우 진입 시 첫 cycle부터 cross-match 가능.
+ */
+async function collectActiveLines(env: Env, now: number): Promise<Set<LineNumber>> {
+  const lines = new Set<LineNumber>();
+  for await (const trip of listTrips(env.TRIPS)) {
+    if (trip.expiresAt <= now) continue;
+    for (const line of computeAllowedLines(trip.route, trip.waypoints)) {
+      lines.add(line);
+    }
+  }
+  return lines;
 }
 
 export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<ScheduledStats> {
@@ -492,9 +538,33 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     // #1559 (T6) — reschedule push motion 게이트 차단/fallback 누적.
     rescheduleBlockedMotion: 0,
     rescheduleFallbackNoSsot: 0,
+    // #1614 Phase A (S4) — backend self-poll realtimePosition stats.
+    realtimePositionFetch: 0,
+    selfPollCacheHit: 0,
+    realtimePositionFetchError: 0,
+    // #1614 Phase C — stale SSoT 가드 fire 차단.
+    staleLockFireSkipped: 0,
   };
   // #1539 (S6) — cron jitter 즉시 log. 누적 stat이 아니라 매 cycle 1줄 → tail에서 P50/P99 산출.
   log('scheduled: cron jitter', { jitterMs: stats.cronJitterMs });
+
+  // #1614 Phase A (S4 #1537) — 활성 trip line union 추출 + Seoul realtimePosition 전수 self-poll.
+  // 1차 iterate: 활성 trip의 route + waypoints에서 line set 수집 (computeAllowedLines 활용 — 환승
+  // route는 transfers의 fromLine/toLine 모두 포함). 2차 iterate(아래 메인 루프)는 그대로 폴링 ·
+  // push 발사 흐름 유지. KV stamp는 advanceTripPosition site들이 lock.trainCode cross-match에 사용.
+  const activeLines = await collectActiveLines(env, now);
+  const selfPollStats = await pollLinesAndStamp(env.TRIPS, deps.seoul, activeLines, now);
+  stats.realtimePositionFetch += selfPollStats.fetched;
+  stats.selfPollCacheHit += selfPollStats.cacheHit;
+  stats.realtimePositionFetchError += selfPollStats.error;
+  if (activeLines.size > 0) {
+    log('self-poll: realtimePosition', {
+      lines: activeLines.size,
+      fetched: selfPollStats.fetched,
+      cacheHit: selfPollStats.cacheHit,
+      error: selfPollStats.error,
+    });
+  }
 
   for await (const trip of listTrips(env.TRIPS)) {
     stats.scanned += 1;
@@ -1017,10 +1087,52 @@ export interface FireArvlCdStationPushInputs {
   generatePushId: () => string;
 }
 
+/**
+ * #1614 Phase C — stale SSoT lock false-fire 차단 임계.
+ *
+ * `transferDestinationGate.TRANSFER_DESTINATION_FRESH_WINDOW_MS` (60s) 는 transfer/destination
+ * kind 만 보호. 본 임계는 intermediate 포함 모든 arvlCd fire 에 적용 — transfer 게이트보다 보수적
+ * (3분) 으로 두어 정상 운영(역 간 hop 평균 1~2분 + cron jitter) 을 차단하지 않으면서, 멈춘 trip
+ * 의 stale lock 에서 cron 누적 misfire(2026-06-19 evidence) 를 차단한다.
+ *
+ * `lastAdvanceAt===0` (lazy-seed 직후, 미advance) 은 본 가드 dormant — T4 motion 게이트의
+ * 'unknown' 통과 정책과 동일 ([[transferDestinationGate.isSsotAdvanceRecent]] 와 같은 의미론).
+ */
+export const STALE_LOCK_FIRE_THRESHOLD_MS = 3 * 60 * 1000;
+
 export async function fireArvlCdStationPush(
   inputs: FireArvlCdStationPushInputs,
 ): Promise<{ dirty: boolean }> {
   const { trip, waypoint, lock, arvlCd, env, deps, stats, now, log, generatePushId } = inputs;
+  // #1614 Phase C — stale SSoT 가드. SSoT.lastAdvanceAt > 0 이고 3분 초과면 fire skip.
+  // transferDestinationGate (60s) 보다 보수적이지만 intermediate 까지 보호. lazy-seed (==0) 통과.
+  // SSoT 부재 trip (legacy) 도 통과 — 본 가드는 SSoT 활성화 후 stale 진단 만.
+  const ssotForStale = await readSsot(env.TRIPS, trip.token, {
+    cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
+  });
+  if (
+    ssotForStale !== null &&
+    ssotForStale.lastAdvanceAt > 0 &&
+    now - ssotForStale.lastAdvanceAt > STALE_LOCK_FIRE_THRESHOLD_MS
+  ) {
+    stats.staleLockFireSkipped += 1;
+    log('arvlcd-fire: stale SSoT skip', {
+      token: trip.token.slice(0, 8),
+      trainCode: lock.trainCode,
+      station: waypoint.stationName,
+      lastAdvanceAt: ssotForStale.lastAdvanceAt,
+      staleMs: now - ssotForStale.lastAdvanceAt,
+    });
+    writeMetric(env, {
+      eventType: 'suppress',
+      tripToken: trip.token,
+      stationId: waypoint.stationName,
+      reason: 'stale-lock-fire',
+      hopIndex: waypoint.hopIndex,
+      staleMs: now - ssotForStale.lastAdvanceAt,
+    });
+    return { dirty: false };
+  }
   const key = arvlCdFireKey(trip.token, lock.trainCode, waypoint.stationName, arvlCd);
   const existing = await env.TRIPS.get(key);
   if (existing !== null) {
@@ -1078,12 +1190,8 @@ export async function fireArvlCdStationPush(
     arvlCd,
     kind: waypoint.kind,
   });
-  // #1561 (T8, ADR-017 / S2 흡수) — fire 직전 SSoT 권위 스냅샷을 읽어 payload로 forward.
-  // read 실패/null은 그대로 forward → wire에서 자연 누락(graceful). cacheTtl=30s는 다른 cron read와
-  // 동일 ([[lesson_cron_cachettl_runtime_constraint]]).
-  const ssot = await readSsot(env.TRIPS, trip.token, {
-    cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
-  });
+  // #1561 (T8, ADR-017 / S2 흡수) — fire 직전 SSoT 권위 스냅샷 forward.
+  // #1614 Phase C — stale guard 단계에서 이미 read한 ssotForStale 재사용 (KV read 1회 절약).
   const heal = await sendWithEnvHeal(
     (host) =>
       sendSilentPush({
@@ -1095,7 +1203,7 @@ export async function fireArvlCdStationPush(
           pushId,
           now,
           origin: 'arvlcd',
-          ssot,
+          ssot: ssotForStale,
         }),
         config: deps.apnsConfig,
         host,
@@ -1151,7 +1259,7 @@ export async function fireArvlCdStationPush(
     stationId: waypoint.stationName,
     reason: `arvlcd:${waypoint.kind}`,
     hopIndex: waypoint.hopIndex,
-    staleMs: ssot?.lastAdvanceAt ? now - ssot.lastAdvanceAt : undefined,
+    staleMs: ssotForStale?.lastAdvanceAt ? now - ssotForStale.lastAdvanceAt : undefined,
   });
   return { dirty };
 }
@@ -2330,6 +2438,12 @@ async function maybeBindLocklessTrainCode(
   // fetch 하므로 본 함수에서는 lockAttachable 신호만 forward 하고 consensusGate 의 분기
   // 자체는 attemptAutoLock 내부에서 평가한다. caller 는 outcome.pass(motion+silence) 만
   // 사용해 auto-lock 시도 진입을 허용.
+  // #1614 Phase B (S4 #1537) — backend self-poll positionTrainAgreement forward. cron 진입부에서
+  // stamp된 `realtime-position:<line>` KV를 read해, pickAutoTrainCode 가 선택할 candidate
+  // trainCode가 line에서 실제 운행 중인지 검사. caller 시점에는 trainCode 가 아직 결정 안 됐으므로
+  // line의 positions list 자체를 forward — attemptAutoLock 가 pickAutoTrainCode 결과를 그 list 와
+  // cross-match (Phase B-2 함수에서 처리). 본 caller 는 raw list 전달만 담당.
+  const selfPollPositions = await readSelfPollPosition(env.TRIPS, waypoint.line);
   const autoLockResult = await attemptAutoLock({
     trip,
     targetWaypoint: waypoint,
@@ -2345,6 +2459,9 @@ async function maybeBindLocklessTrainCode(
     // consensusGate 평가로 surface 통과 / underground arrival+lockAttachable 합의 강제.
     environment,
     gateOutcome: outcome,
+    // #1614 Phase B — self-poll 결과를 attemptAutoLock 에 forward. 함수 내부에서 trainCode 결정
+    // 직후 cross-match 후 consensusGate 입력으로 positionTrainAgreement 전달.
+    selfPollPositions: selfPollPositions?.positions,
   });
   if (autoLockResult.confidenceTrace && env.TELEMETRY) {
     recordAutoLockConfidence(env.TELEMETRY, trip.token, autoLockResult.confidenceTrace);

--- a/backend/alarm-worker/src/selfPollPosition.ts
+++ b/backend/alarm-worker/src/selfPollPosition.ts
@@ -1,0 +1,160 @@
+/**
+ * Backend self-poll realtimePosition (S4 #1537 / #1614 Phase A).
+ *
+ * 배경
+ * ====
+ * 기존 backend는 lock 활성 trip의 trainCode 추적 시점(`scheduled.ts:1888`)에만
+ * `seoul.fetchPositions(lock.line)`을 호출한다. lock 부재(lockless) trip에는 realtimePosition을
+ * 활용하지 않아 `consensusGate.ts:155` strongCB (positionTrainAgreement + arrival) 분기가
+ * 영구 닫혀 있었다. 6/19 + 6/20 trip evidence — BG 지하 boardingPrompt 0건 + lock 부착 fail.
+ *
+ * 본 모듈은 cron 진입부에서 활성 trip의 line set을 추출 → 각 line마다
+ * `seoul.fetchPositions(line)`을 병렬 호출 → 결과를 KV `realtime-position:<line>` 30s TTL로
+ * stamp한다. caller(`advanceTripPosition` site들)는 본 stamp를 lock.trainCode와 cross-match해
+ * `evidence.type='position-train'`을 합성 → strongCB 통과 가능.
+ *
+ * KV cacheTtl 정책
+ * ================
+ * `expirationTtl: 30s` — Cloudflare KV 런타임 floor(`KV_MIN_CACHE_TTL_SEC=30`). cron 1분 race
+ * 보호: 같은 cycle 내 중복 호출 차단 + 다음 cycle 시작 직전까지 stale snapshot 활용 가능.
+ * cacheTtl<30 회귀(#1364, [[lesson_cron_cachettl_runtime_constraint]])를 직접 차단.
+ *
+ * Rate limit / cost
+ * =================
+ * 호선당 1 entry — 활성 trip line union (대개 1~3 line)이므로 cron tick당 추가 KV write 1~3건,
+ * Seoul API call도 1~3건. 같은 line trip이 여러 개여도 호출은 1회로 dedup.
+ *
+ * 본 모듈은 SeoulArrivalClient의 in-memory cache(15s)와는 별개 — Worker isolate가 바뀌면
+ * in-memory cache가 사라지지만 KV stamp는 30s 살아남는다. 두 layer로 안정성 확보.
+ */
+
+import { assertCronCacheTtl, CRON_READ_CACHE_TTL_SEC } from './kvConsistency';
+import type { PositionEntry, SeoulArrivalClient } from './seoul';
+import type { LineNumber } from './types';
+
+/** KV key prefix — 노선 단위 1 entry. */
+const SELF_POLL_PREFIX = 'realtime-position:';
+
+/**
+ * KV expirationTtl — Cloudflare 런타임 floor(`CRON_READ_CACHE_TTL_SEC=30`).
+ *
+ * 같은 cron cycle 내 dedup + 다음 cycle 시작 직전까지 stale snapshot 활용. Seoul API rate
+ * limit 보호도 겸한다 — 호선당 30s에 1회 fetch 보장.
+ */
+export const SELF_POLL_TTL_SEC = CRON_READ_CACHE_TTL_SEC;
+
+/** KV에 stamp된 self-poll entry (live PositionEntry[] + 적재 시점 stamp). */
+interface SelfPollEntry {
+  /** Seoul realtimePosition 결과 (호선 단위 모든 운행 trainCode 위치). */
+  positions: PositionEntry[];
+  /** stamp 시점 epoch ms — caller가 staleness 판정에 사용 (TTL 안쪽이라도 30s 직전이면 보수적 선택 가능). */
+  fetchedAt: number;
+}
+
+export function selfPollKey(line: LineNumber): string {
+  return `${SELF_POLL_PREFIX}${line}`;
+}
+
+/**
+ * KV에서 line의 마지막 self-poll position 결과를 조회.
+ *
+ * `expirationTtl=30s` 안쪽이면 stamp가 살아 있고, 초과 시 KV가 자동 삭제 → null 반환.
+ * caller(advanceTripPosition site들)가 trainCode cross-match 시도용.
+ *
+ * @param kv TRIPS KV namespace
+ * @param line `LineNumber` (canonicalLineName로 정규화된 값)
+ * @returns 마지막 stamp 또는 null
+ */
+export async function readSelfPollPosition(
+  kv: KVNamespace,
+  line: LineNumber,
+): Promise<SelfPollEntry | null> {
+  assertCronCacheTtl(CRON_READ_CACHE_TTL_SEC);
+  const raw = await kv.get(selfPollKey(line), { cacheTtl: CRON_READ_CACHE_TTL_SEC });
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as SelfPollEntry;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `SeoulArrivalClient.fetchPositions(line)` 결과를 KV에 30s TTL로 stamp.
+ *
+ * Seoul API 호출 실패 시 빈 배열을 받을 수 있음(SeoulArrivalClient 내부에서 error→[] 매핑) —
+ * 본 함수는 그대로 stamp한다. caller가 빈 배열을 "positionTrainAgreement undefined"로 자연
+ * fallback (strongBE 분기 유지).
+ *
+ * @param kv TRIPS KV namespace
+ * @param line `LineNumber`
+ * @param positions `seoul.fetchPositions(line)` 결과
+ * @param now stamp 시점 epoch ms
+ */
+export async function writeSelfPollPosition(
+  kv: KVNamespace,
+  line: LineNumber,
+  positions: PositionEntry[],
+  now: number,
+): Promise<void> {
+  const entry: SelfPollEntry = { positions, fetchedAt: now };
+  await kv.put(selfPollKey(line), JSON.stringify(entry), {
+    expirationTtl: SELF_POLL_TTL_SEC,
+  });
+}
+
+/**
+ * Self-poll 호출 stats — `runScheduled`의 stats 객체에 누적된다.
+ *
+ * - `fetched`: 실제 Seoul API 호출 횟수 (KV cache miss).
+ * - `cacheHit`: KV stamp가 살아 있어 fetch skip한 횟수.
+ * - `error`: SeoulArrivalClient throw + KV write throw 등 전반 실패.
+ */
+export interface SelfPollStats {
+  fetched: number;
+  cacheHit: number;
+  error: number;
+}
+
+/**
+ * 활성 trip line union에 대해 self-poll을 1회 수행하고 결과를 KV에 stamp.
+ *
+ * `runScheduled` 진입부에서 `listTrips`로 활성 trip을 enumerate한 caller가 `Set<LineNumber>`를
+ * 모아 본 함수에 전달. 각 line에 대해 (1) KV stamp가 살아있으면 skip (cacheHit++) (2) 없으면
+ * `seoul.fetchPositions(line)` 후 `writeSelfPollPosition` (fetched++).
+ *
+ * 병렬 `Promise.allSettled` — 한 line 실패가 다른 line 영향 X. 실패는 error++ 누적 후 graceful
+ * (caller는 stamp 부재로 자연 fallback).
+ *
+ * @param kv TRIPS KV namespace
+ * @param seoul SeoulArrivalClient
+ * @param lines 활성 trip line union
+ * @param now 현재 epoch ms (KV stamp 시점)
+ * @returns SelfPollStats
+ */
+export async function pollLinesAndStamp(
+  kv: KVNamespace,
+  seoul: SeoulArrivalClient,
+  lines: ReadonlySet<LineNumber>,
+  now: number,
+): Promise<SelfPollStats> {
+  const stats: SelfPollStats = { fetched: 0, cacheHit: 0, error: 0 };
+  if (lines.size === 0) return stats;
+  await Promise.allSettled(
+    Array.from(lines).map(async (line) => {
+      try {
+        const existing = await readSelfPollPosition(kv, line);
+        if (existing) {
+          stats.cacheHit += 1;
+          return;
+        }
+        const positions = await seoul.fetchPositions(line);
+        await writeSelfPollPosition(kv, line, positions, now);
+        stats.fetched += 1;
+      } catch {
+        stats.error += 1;
+      }
+    }),
+  );
+  return stats;
+}


### PR DESCRIPTION
Closes #1614

## 다운로드 가치
**V1 BG 지하 fire path 열림** — 현재 BG 지하 알림 0건의 root 해소. Stage 1 (PR #1613) 머지 후 다음 단계. V/X 매핑: V1 / V2 / V3 / V4 / X1 / X3

## 변경 4 Phase (atomic)
### Phase A — Backend self-poll realtimePosition (`backend/alarm-worker/src/selfPollPosition.ts`, +130 lines)
- `pollLinesAndStamp` — cron 진입부에서 활성 trip line 추출(`collectActiveLines`) → line 병렬 `seoul.fetchPositions` → KV 30s stamp
- `selfPollKey` / `readSelfPollPosition` / `writeSelfPollPosition` round-trip
- KV cacheTtl=30s ([[lesson_cron_cachettl_runtime_constraint]])
- stats: `realtimePositionFetch` / `selfPollCacheHit` / `realtimePositionFetchError`

### Phase B — consensusGate strongCB wire (`autoLock.ts` + `scheduled.ts`)
- `AttemptAutoLockInputs.selfPollPositions` 추가
- `attemptAutoLock` 내부에서 `pickAutoTrainCode` 결과를 self-poll positions와 cross-match → `positionTrainAgreement` boolean을 consensusGate 입력으로 forward
- `maybeBindLocklessTrainCode`가 KV stamp read 후 `attemptAutoLock`에 전달
- 결과: underground 환경에서 base gate fail이라도 strongCB(positionTrainAgreement + arrival)로 통과 가능

### Phase C — fireArvlCdStationPush stale SSoT 가드 (`scheduled.ts`)
- `STALE_LOCK_FIRE_THRESHOLD_MS = 3 * 60 * 1000` export
- SSoT.lastAdvanceAt > 0 + (now - lastAdvanceAt > 3분) → fire skip + `staleLockFireSkipped++` + `writeMetric(suppress)`
- lazy-seed (==0) / SSoT 부재 (legacy) dormant 통과
- 기존 SSoT read (line 1196)을 stale guard read와 통합 — KV cost 0
- `transferDestinationGate` 호출 site (1313, 1497) 재검증 — 모든 transfer/destination fire site에 적용 완료, intermediate kind는 advanceTripPosition 6단 게이트 + Phase C stale guard로 보호

### Phase D — `/admin/push-ack-stats` RCA endpoint (`pushAckStats.ts` + `index.ts`)
- 1h 윈도우 received/pending KV scan + receivedByPhase + receivedByStation (top-10)
- admin Bearer auth + TRIPS binding 가드 (503 / 401)
- KV cost 보호: `limit` param (default 500)

## Wire-completion 5단
1. **Orphan**: `npm run lint:orphan` pass — 신규 export 모두 caller 있음 (`pollLinesAndStamp` / `readSelfPollPosition` → scheduled.ts; `computePushAckStats` → index.ts admin endpoint; `STALE_LOCK_FIRE_THRESHOLD_MS` / `fireArvlCdStationPush` → scheduled.ts + test)
2. **V/X dashboard**: V1 (currentStation BG 지하) / V2 / V3 / V4 (silent push 도달률) — Phase D `/admin/push-ack-stats` 신규 시각화. backend tail에서 `self-poll: realtimePosition lines=N fetched=N` + `arvlcd-fire: stale SSoT skip` log query
3. **의존 PR**: 독립 (Phase 0/1/Stage 1 PR #1613 머지 완료)
4. **측정 plan**: 1주 production 후
   - `stats.realtimePositionFetch > 0` (호선당 30s cache)
   - `stats.staleLockFireSkipped` 분포 (정상 0에 가까움, 비정상 evidence)
   - `/admin/push-ack-stats` 도달률 ≥ 95% 기준
   - 사용자 trip dump V1 회복 evidence
5. **Device verify**: 실기기 평일 출퇴근 trip 1주 (FG/BG/주머니 시나리오)

## 자가 점검 5단
1. **acceptance self-referential?** V1 회복 = 사용자 trip annotation. P0-4 gold standard 누적 강화
2. **Wire-completion CI?** 신규 함수 모두 caller + 단위 테스트 박제
3. **머지 순서?** 독립 — Stage 1 (#1613) / Phase 0/1 머지 완료
4. **backward-compat?** Phase A/B 신규 path 추가, 기존 strongBE 동작 유지. Phase C는 stale 가드 strict화 (1주 monitoring). Phase D는 신규 endpoint
5. **False positive new?** Phase C strict 가드는 lastAdvanceAt > 0인 경우만 — lazy-seed/legacy는 통과. Phase B는 cross-match true 시만 strongCB 추가 path 열림 (false negative 줄임, false positive 증가 X)

## 테스트
- type-check: 본 PR 변경 0 error (pre-existing 3개는 `advanceTripPosition.test.ts` — 본 PR 무관)
- vitest run: **1434 tests passed**
- 신규 단위 테스트: **50건** (selfPollPosition 16 + pushAckStats 9 + autoLock Phase B 7 + scheduled Phase A/C 13 + index Phase D 5)
- lint:orphan: 0 신규 orphan

## Risk + mitigation
| risk | mitigation |
|---|---|
| Phase A Seoul API rate limit 초과 | 호선당 30s KV cache + 활성 trip 1~3 lines 평균 |
| Phase B position match false positive (다른 trainCode 매칭) | trainCode는 1:1 unique, `pickAutoTrainCode` 단일 수렴 후 cross-match만 |
| Phase C strict 가드 정상 알림 차단 | 3분 threshold = transferDestinationGate(60s) 보다 보수적. 정상 hop은 1~2분 |
| Phase D admin endpoint 보안 | 기존 admin Bearer auth middleware 재사용 (`checkAdminAuth`) |
| KV cost 증가 | self-poll 호선당 30s 1 entry. push-ack-stats는 admin 호출시에만 |

## Self-review
- transferDestinationGate 호출 site 2개 모두 적용 확인 (1313, 1497)
- transfer-release sync push (line 2147)는 정상 advance 후 sync — 추가 guard 불필요
- silentPushLocationGate (device) 검증: 지하 intermediate bypass + lockless hop-window 매치 path 모두 wire 완료 (변경 X)