### PR TITLE
fix(#1616): V1 FG 지하 보강 — R12-a candidate distance hard gate + R8a lockless forward-only 가드 (Stage 2)

### DIFF
--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -48,6 +48,7 @@ import {
   logSuppressedStationPassedWarmup,
   logSuppressedHopWindow,
   logSuppressedHopWindowNoSource,
+  logSuppressedLocklessForwardOnly,
   logSuppressedOriginHopLockless,
   logSuppressedPassedEventOnLockOrigin,
   logSuppressedSsotFireGate,
@@ -754,6 +755,38 @@ describe('alarmLog', () => {
         stationName: '용마산',
         kind: 'station-passed',
       });
+    });
+
+    it('#1616 (R8a) logSuppressedLocklessForwardOnly: reason=lockless-forward-only-block + source=fg-evaluated + trainNo stamped', async () => {
+      logSuppressedLocklessForwardOnly({
+        rejectedStationName: '시청',
+        rejectedTrainNo: 'BACK',
+      });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fg-evaluated',
+        outcome: 'suppressed',
+        reason: 'lockless-forward-only-block',
+        stationName: '시청',
+        usedTrainCode: 'BACK',
+      });
+    });
+
+    it('#1616 (R8a) logSuppressedLocklessForwardOnly: burst dedup applies — repeated same station within window dropped', async () => {
+      _resetBurstSuppressWindowForTests();
+      logSuppressedLocklessForwardOnly({ rejectedStationName: '시청', rejectedTrainNo: 'A' });
+      logSuppressedLocklessForwardOnly({ rejectedStationName: '시청', rejectedTrainNo: 'B' });
+      logSuppressedLocklessForwardOnly({ rejectedStationName: '시청', rejectedTrainNo: 'C' });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      const matching = saved.filter((e) => e.reason === 'lockless-forward-only-block');
+      // 첫 entry 한 건 (burst inline count로 누적되거나 단일 entry 유지).
+      expect(matching).toHaveLength(1);
     });
 
     it('#1514 logSuppressedOriginHopLockless: reason=gate-origin-hop-lockless + kind=station-passed', async () => {

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -190,7 +190,12 @@ export type AlarmLogReason =
   // 두 사유 모두 5 fire path(A~E) 어디서든 같은 reason으로 적재 — DebugModal Counters section에서
   // 단일 분포로 시각화.
   | 'gate-alarm-already-decided'
-  | 'gate-station-already-passed';
+  | 'gate-station-already-passed'
+  // #1616 (R8a) — lockless trip + route 활성 시 trackTrainProgress가 estimateArcStationsFromRoute로
+  // 추정된 arcStations에 의해 backward jump candidate를 reject한 경우. boardingLock 없으면 forward-only
+  // 가드가 OFF였던 기존 동작과 다르게 보수적 안전망 — R2 lockless time-integration cascade(backward
+  // jump 허용) 차단. 1주 production 측정: false reject 빈도 + 사용자 trip V1 회복 evidence.
+  | 'lockless-forward-only-block';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -797,6 +802,33 @@ export function logSuppressedPhaseGate(reason: 'gate-phase-accuracy' | 'gate-pha
   const name = stationName ?? '(unknown)';
   if (isBurstDuplicate(reason, name)) return;
   appendAlarmLog({ ts: Date.now(), source: 'fg-evaluated', outcome: 'suppressed', reason, stationName: name });
+}
+
+/**
+ * #1616 (R8a) — lockless trip + route 활성 시 forward-only 가드(추정 arcStations)가 backward
+ * jump candidate를 reject한 1건 적재. trackTrainProgress의 onFilteredBackward 콜백에서 호출.
+ *
+ * source='fg-evaluated' — picker는 FG 루프에서 동작. burst dedup으로 같은 stationName+reason
+ * 연속 발생 시 burst 카운트만 누적(새 entry 생성 X) — 한 trip에서 폭주해 다른 entry 점령 방지.
+ *
+ * 측정 목적:
+ *  - 1주 production: 본 reason count > 0이면 lockless 회복 path 동작 evidence.
+ *  - false positive 감지: 동일 stationName에 burst count가 비정상적으로 높으면 추정 윈도우 정확도 의심.
+ */
+export function logSuppressedLocklessForwardOnly(input: {
+  rejectedStationName: string;
+  rejectedTrainNo: string;
+}): void {
+  const name = input.rejectedStationName;
+  if (isBurstDuplicate('lockless-forward-only-block', name)) return;
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'fg-evaluated',
+    outcome: 'suppressed',
+    reason: 'lockless-forward-only-block',
+    stationName: name,
+    usedTrainCode: input.rejectedTrainNo,
+  });
 }
 
 /**

--- a/src/features/arrival/utils/__tests__/pickCandidateTrains.test.ts
+++ b/src/features/arrival/utils/__tests__/pickCandidateTrains.test.ts
@@ -246,7 +246,7 @@ describe('pickCandidateTrains', () => {
         [{ trainNo: 'NEAR', statnNm: '시청' }, { trainNo: 'FAR', statnNm: '강변(동서울터미널)' }],
         { userLocation, stationCoordinates, onReject },
       );
-      expect(result.map((t) => t.trainNo).sort()).toEqual(['FAR', 'NEAR']);
+      expect(result.map((t) => t.trainNo).sort((a, b) => a.localeCompare(b))).toEqual(['FAR', 'NEAR']);
       expect(onReject).not.toHaveBeenCalled();
     });
 
@@ -274,7 +274,7 @@ describe('pickCandidateTrains', () => {
         [{ trainNo: 'A', statnNm: '시청' }, { trainNo: 'B', statnNm: '을지로입구' }],
         { userLocation: SICHEONG, stationCoordinates: makeCoords(), onReject },
       );
-      expect(result.map((t) => t.trainNo).sort()).toEqual(['A', 'B']);
+      expect(result.map((t) => t.trainNo).sort((a, b) => a.localeCompare(b))).toEqual(['A', 'B']);
       expect(onReject).not.toHaveBeenCalled();
     });
 
@@ -288,7 +288,7 @@ describe('pickCandidateTrains', () => {
         [{ trainNo: 'NEAR', statnNm: '시청' }, { trainNo: 'UNKNOWN', statnNm: '강변(동서울터미널)' }],
         { userLocation: SICHEONG, stationCoordinates: partialCoords, onReject },
       );
-      expect(result.map((t) => t.trainNo).sort()).toEqual(['NEAR', 'UNKNOWN']);
+      expect(result.map((t) => t.trainNo).sort((a, b) => a.localeCompare(b))).toEqual(['NEAR', 'UNKNOWN']);
       expect(onReject).not.toHaveBeenCalled();
     });
 

--- a/src/features/arrival/utils/__tests__/pickCandidateTrains.test.ts
+++ b/src/features/arrival/utils/__tests__/pickCandidateTrains.test.ts
@@ -1,6 +1,6 @@
 import type { LinePositions, TrainPosition } from '../../../../shared/types/position';
 import type { LineNumber } from '../../../../shared/types/station';
-import { pickCandidateTrains } from '../pickCandidateTrains';
+import { pickCandidateTrains, CANDIDATE_DISTANCE_THRESHOLD_KM } from '../pickCandidateTrains';
 
 const LINE: LineNumber = '2';
 
@@ -198,6 +198,133 @@ describe('pickCandidateTrains', () => {
       windowStations: -1,
     });
     expect(result.map((t) => t.trainNo)).toEqual(['AT']);
+  });
+
+  // #1616 (R12-a) — candidate별 GPS 거리 hard gate.
+  // helper: 시청 좌표 근처 + 강변 좌표 trains 동시 운영해 거리 기반 reject 검증.
+  describe('candidate distance hard gate (R12-a)', () => {
+    // 시청 좌표 (37.563588, 126.975411), 강변(동서울터미널) 좌표 (37.535095, 127.094681)
+    // 두 역 사이 직선거리 약 11.2km — threshold 3km 보다 크므로 reject 대상.
+    const SICHEONG = { lat: 37.5636, lng: 126.9754 };
+    function makeCoords(): Map<string, { lat: number; lng: number }> {
+      return new Map([
+        ['시청', { lat: 37.563588, lng: 126.975411 }],
+        ['을지로입구', { lat: 37.566014, lng: 126.982618 }],
+        // 강변 — 시청으로부터 약 11.2km (>3km threshold)
+        ['강변(동서울터미널)', { lat: 37.535095, lng: 127.094681 }],
+      ]);
+    }
+
+    function runDistanceGate(
+      trains: Array<{ trainNo: string; statnNm: string }>,
+      opts: {
+        userLocation?: { lat: number; lng: number } | null;
+        stationCoordinates?: Map<string, { lat: number; lng: number }> | undefined;
+        onReject?: jest.Mock;
+      },
+    ): ReturnType<typeof pickCandidateTrains> {
+      return pickCandidateTrains({
+        positions: [makeLine(trains.map((t) => makeTrain(t)))],
+        line: LINE,
+        userLocation: opts.userLocation,
+        stationCoordinates: opts.stationCoordinates,
+        onCandidateDistanceReject: opts.onReject,
+      });
+    }
+
+    it.each<{
+      label: string;
+      userLocation: { lat: number; lng: number } | null | undefined;
+      stationCoordinates: Map<string, { lat: number; lng: number }> | undefined;
+    }>([
+      { label: 'userLocation null → graceful (gate skip)', userLocation: null, stationCoordinates: makeCoords() },
+      { label: 'userLocation undefined → graceful (gate skip)', userLocation: undefined, stationCoordinates: makeCoords() },
+      { label: 'stationCoordinates undefined → graceful (gate skip)', userLocation: SICHEONG, stationCoordinates: undefined },
+    ])('$label — far candidate not rejected', ({ userLocation, stationCoordinates }) => {
+      const onReject = jest.fn();
+      const result = runDistanceGate(
+        [{ trainNo: 'NEAR', statnNm: '시청' }, { trainNo: 'FAR', statnNm: '강변(동서울터미널)' }],
+        { userLocation, stationCoordinates, onReject },
+      );
+      expect(result.map((t) => t.trainNo).sort()).toEqual(['FAR', 'NEAR']);
+      expect(onReject).not.toHaveBeenCalled();
+    });
+
+    it('rejects candidates whose station distance > threshold (R12-a)', () => {
+      const onReject = jest.fn();
+      const result = runDistanceGate(
+        [{ trainNo: 'NEAR', statnNm: '시청' }, { trainNo: 'FAR', statnNm: '강변(동서울터미널)' }],
+        { userLocation: SICHEONG, stationCoordinates: makeCoords(), onReject },
+      );
+      expect(result.map((t) => t.trainNo)).toEqual(['NEAR']);
+      expect(onReject).toHaveBeenCalledTimes(1);
+      expect(onReject).toHaveBeenCalledWith({
+        trainNo: 'FAR',
+        line: LINE,
+        stationName: '강변(동서울터미널)',
+        distanceKm: expect.any(Number),
+      });
+      const callDistanceKm = onReject.mock.calls[0][0].distanceKm as number;
+      expect(callDistanceKm).toBeGreaterThan(CANDIDATE_DISTANCE_THRESHOLD_KM);
+    });
+
+    it('keeps candidates whose station distance ≤ threshold (R12-a)', () => {
+      const onReject = jest.fn();
+      const result = runDistanceGate(
+        [{ trainNo: 'A', statnNm: '시청' }, { trainNo: 'B', statnNm: '을지로입구' }],
+        { userLocation: SICHEONG, stationCoordinates: makeCoords(), onReject },
+      );
+      expect(result.map((t) => t.trainNo).sort()).toEqual(['A', 'B']);
+      expect(onReject).not.toHaveBeenCalled();
+    });
+
+    it('graceful pass when stationCoordinates missing key — no reject, no throw', () => {
+      // coords map에 statnNm이 없는 경우(노선 데이터 부분 lookup)는 거리 검사 생략.
+      const partialCoords = new Map([
+        ['시청', { lat: 37.563588, lng: 126.975411 }],
+      ]);
+      const onReject = jest.fn();
+      const result = runDistanceGate(
+        [{ trainNo: 'NEAR', statnNm: '시청' }, { trainNo: 'UNKNOWN', statnNm: '강변(동서울터미널)' }],
+        { userLocation: SICHEONG, stationCoordinates: partialCoords, onReject },
+      );
+      expect(result.map((t) => t.trainNo).sort()).toEqual(['NEAR', 'UNKNOWN']);
+      expect(onReject).not.toHaveBeenCalled();
+    });
+
+    it('reject works when onCandidateDistanceReject is undefined — no throw, candidate still removed', () => {
+      const result = pickCandidateTrains({
+        positions: [makeLine([
+          makeTrain({ trainNo: 'NEAR', statnNm: '시청' }),
+          makeTrain({ trainNo: 'FAR', statnNm: '강변(동서울터미널)' }),
+        ])],
+        line: LINE,
+        userLocation: SICHEONG,
+        stationCoordinates: makeCoords(),
+        // onCandidateDistanceReject omitted
+      });
+      expect(result.map((t) => t.trainNo)).toEqual(['NEAR']);
+    });
+
+    it('rejects candidate exceeding threshold even when anchor window kept it', () => {
+      // anchor=시청(idx 0), windowStations=15 → 강변(idx 14)도 index window 통과.
+      // 그러나 GPS 거리 11.2km > 3km → distance gate가 reject.
+      const onReject = jest.fn();
+      const result = pickCandidateTrains({
+        positions: [makeLine([
+          makeTrain({ trainNo: 'NEAR', statnNm: '시청' }),
+          makeTrain({ trainNo: 'FAR', statnNm: '강변(동서울터미널)' }),
+        ])],
+        line: LINE,
+        anchorStationName: '시청',
+        windowStations: 15,
+        userLocation: SICHEONG,
+        stationCoordinates: makeCoords(),
+        onCandidateDistanceReject: onReject,
+      });
+      expect(result.map((t) => t.trainNo)).toEqual(['NEAR']);
+      expect(onReject).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('maps fields correctly (trainNo/line/direction/currentStationName/trainStatus/receivedAtMs)', () => {

--- a/src/features/arrival/utils/pickCandidateTrains.ts
+++ b/src/features/arrival/utils/pickCandidateTrains.ts
@@ -1,6 +1,7 @@
-import type { LinePositions } from '../../../shared/types/position';
-import type { LineNumber } from '../../../shared/types/station';
+import type { LinePositions, TrainPosition } from '../../../shared/types/position';
+import type { LineNumber, Station } from '../../../shared/types/station';
 import { getStationsOnLine } from '../../../shared/utils/stationRoute';
+import { haversine } from '../../../shared/utils/haversine';
 
 // CandidateTrain은 shared/types/position으로 추출됨 (#890, Phase 5). re-export 유지.
 import type { CandidateTrain } from '../../../shared/types/position';
@@ -12,12 +13,70 @@ export interface PickCandidateTrainsInput {
   direction?: 0 | 1;
   anchorStationName?: string;
   windowStations?: number;
+  /**
+   * #1616 (R12-a) — candidate별 GPS 거리 hard gate.
+   * 사용자 마지막 known location + 노선 정렬 station 좌표 lookup이 모두 주어지면
+   * 각 candidate train의 currentStation 좌표와 사용자 위치 거리가
+   * CANDIDATE_DISTANCE_THRESHOLD_KM를 초과할 때 후보에서 reject.
+   *
+   * userLocation/stationCoordinates 둘 중 하나라도 미전달 시 거리 가드 미적용 (graceful fallback,
+   * 기존 anchorIdx ± window 동작 유지).
+   *
+   * 배경: anchorIdx ± window=3 index 거리만으로는 anchor(=GPS-nearest) 자체가 GPS drift된
+   * 케이스(2026-06-19 trip evidence: anchor=이수, 실제=학동)에서 인접 3개 station(예: 이수↔
+   * 강남구청 → 7호선 동일 노선이지만 GPS 거리 5km+) 잘못된 영역 train이 후보 진입.
+   * candidate-station GPS 거리로 cross-check해 misfire 차단.
+   *
+   * threshold 3.0km — 호선 평균 station 간 거리 ~1.5km × 2 (보수치).
+   */
+  userLocation?: { lat: number; lng: number } | null;
+  stationCoordinates?: ReadonlyMap<string, { lat: number; lng: number }>;
+  /**
+   * #1616 (R12-a) — 거리 가드로 reject된 candidate를 호출자가 fusionDebugBuffer에 적재할 때
+   * 사용하는 측정 hook. 미전달 시 reject는 silent — 본 helper는 측정 정책에 비의존.
+   */
+  onCandidateDistanceReject?: (info: {
+    trainNo: string;
+    line: LineNumber;
+    stationName: string;
+    distanceKm: number;
+  }) => void;
 }
 
 const DEFAULT_WINDOW_STATIONS = 3;
 
+/**
+ * #1616 (R12-a) — candidate별 GPS 거리 hard gate threshold.
+ * 호선 평균 station 간 거리(~1.5km) × 2 = 3.0km. 보수적: 정상 trip에서 false reject 최소화.
+ */
+export const CANDIDATE_DISTANCE_THRESHOLD_KM = 3.0;
+
+function buildCandidate(
+  train: TrainPosition,
+  line: LineNumber,
+  direction: 0 | 1,
+): CandidateTrain {
+  return {
+    trainNo: train.trainNo,
+    line,
+    direction,
+    currentStationName: train.statnNm,
+    trainStatus: train.trainStatus,
+    receivedAtMs: train.receivedAtMs,
+  };
+}
+
 export function pickCandidateTrains(input: PickCandidateTrainsInput): CandidateTrain[] {
-  const { positions, line, direction, anchorStationName, windowStations } = input;
+  const {
+    positions,
+    line,
+    direction,
+    anchorStationName,
+    windowStations,
+    userLocation,
+    stationCoordinates,
+    onCandidateDistanceReject,
+  } = input;
 
   const linePositions = positions.find((p) => p.line === line);
   if (!linePositions) return [];
@@ -29,6 +88,9 @@ export function pickCandidateTrains(input: PickCandidateTrainsInput): CandidateT
   const window = Math.max(0, windowStations ?? DEFAULT_WINDOW_STATIONS);
   const anchorIdx =
     anchorStationName !== undefined ? nameToIndex.get(anchorStationName) : undefined;
+  // #1616 (R12-a): userLocation + stationCoordinates 둘 다 있어야 거리 가드 활성.
+  // 어느 한쪽이라도 빠지면 기존 동작 유지 (graceful fallback).
+  const distanceGateActive = userLocation != null && stationCoordinates != null;
 
   const candidates: Array<{ candidate: CandidateTrain; sortKey: number }> = [];
 
@@ -43,18 +105,31 @@ export function pickCandidateTrains(input: PickCandidateTrainsInput): CandidateT
 
     if (anchorIdx !== undefined && Math.abs(stationIdx - anchorIdx) > window) continue;
 
+    // #1616 (R12-a): candidate station GPS 좌표 hard gate.
+    if (distanceGateActive) {
+      const stationCoord = stationCoordinates.get(train.statnNm);
+      // 좌표 lookup miss는 graceful pass — caller가 line별 stations.json subset만 줄 수 있음.
+      if (stationCoord !== undefined) {
+        const distanceKm = haversine(
+          userLocation.lat,
+          userLocation.lng,
+          stationCoord.lat,
+          stationCoord.lng,
+        );
+        if (distanceKm > CANDIDATE_DISTANCE_THRESHOLD_KM) {
+          onCandidateDistanceReject?.({
+            trainNo: train.trainNo,
+            line,
+            stationName: train.statnNm,
+            distanceKm,
+          });
+          continue;
+        }
+      }
+    }
+
     const sortKey = anchorIdx !== undefined ? Math.abs(stationIdx - anchorIdx) : 0;
-    candidates.push({
-      candidate: {
-        trainNo: train.trainNo,
-        line,
-        direction: train.updnLine,
-        currentStationName: train.statnNm,
-        trainStatus: train.trainStatus,
-        receivedAtMs: train.receivedAtMs,
-      },
-      sortKey,
-    });
+    candidates.push({ candidate: buildCandidate(train, line, train.updnLine), sortKey });
   }
 
   candidates.sort((a, b) => {

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -269,6 +269,12 @@ function formatFusionDebugLine(entry: FusionDebugEntry): string {
     const sp = entry.speedMps != null ? `${entry.speedMps.toFixed(1)}m/s` : '-';
     return `${time} | sticky:${entry.event} | ${entry.stationName}(${entry.line}) acc=${acc} sp=${sp}`;
   }
+  if (entry.kind === 'candidate-reject') {
+    // #1616 (R12-a) — pickCandidateTrains에서 candidate.currentStation GPS 거리가 threshold 초과로
+    // reject된 case. trainNo / station / 측정 거리 같이 보여 사용자 trip 사후 misfire 차단 검증.
+    const d = `${Math.round(entry.distanceKm * 1000)}m`;
+    return `${time} | reject:${entry.reason} | ${entry.trainNo} ${entry.stationName}(${entry.line}) d=${d}`;
+  }
   const station = entry.stationName ? `${entry.stationName}(${entry.line ?? '-'})` : '-';
   const d = entry.distanceKm != null ? `${Math.round(entry.distanceKm * 1000)}m` : '-';
   const acc =

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -1739,6 +1739,22 @@ describe('formatFusionDebugLine', () => {
     },
   );
 
+  it('#1616 (R12-a) candidate-reject 엔트리: reject reason / trainNo / station / distance 포함', () => {
+    const line = formatFusionDebugLine({
+      kind: 'candidate-reject',
+      ts: new Date('2026-06-21T12:00:00Z').getTime(),
+      reason: 'candidate-distance',
+      trainNo: 'T-2099',
+      stationName: '강변(동서울터미널)',
+      line: '2',
+      distanceKm: 5.4,
+    });
+    expect(line).toContain('reject:candidate-distance');
+    expect(line).toContain('T-2099');
+    expect(line).toContain('강변(동서울터미널)(2)');
+    expect(line).toContain('d=5400m');
+  });
+
   it('gps 엔트리: nearestStation/distance/accuracy 누락 시 "-" 표기', () => {
     const line = formatFusionDebugLine({
       kind: 'gps',

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.trainProgressing.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.trainProgressing.test.ts
@@ -301,6 +301,58 @@ describe('useFusedNearestStation — #1015 forward-only 검증', () => {
     });
   });
 
+  // #1616 (R8a) — lockless 시 forward-only 가드 활성. 그러나 estimateArcStationsFromRoute가
+  // route + GPS 위치 기반으로 추정 윈도우를 산출하면 trackTrainProgress에 segmentStations 전달.
+  // trackTrainProgress가 backward candidate를 reject할 때 onFilteredBackward 콜백 발사 → alarmLog.
+  describe('R8a lockless 시 forward-only 가드 + onFilteredBackward 콜백', () => {
+    it('lockless trip + route 활성 + trackTrainProgress onFilteredBackward 호출 시 logSuppressedLocklessForwardOnly 발사', () => {
+      // mockComputeRouteArc는 module-scope에서 mock — estimateArcStationsFromRoute 내부
+      // computeRouteArc 호출도 mock 적용 → segmentStations 반환되도록 보장.
+      mockComputeRouteArc.mockReturnValue({ stations: FWD_ARC_STATIONS });
+      // trackTrainProgress에 전달된 onFilteredBackward를 캡쳐해 실제로 호출.
+      mockTrackProgress.mockImplementation((input: { onFilteredBackward?: (info: { trainNo: string; stationName: string }) => void }) => {
+        // 가드가 적용된 케이스: backward reject 1건 발사.
+        input.onFilteredBackward?.({ trainNo: 'BACK', stationName: '시청' });
+        return trainProgressFor(FWD_ARC_STATION_C);
+      });
+
+      // boardingLock=null → lockless path. logSuppressedLocklessForwardOnly 호출 검증.
+      renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          fwdRouteContext,
+          null,
+          null,
+        ),
+      );
+
+      expect(mockTrackProgress).toHaveBeenCalled();
+      // 마지막 호출의 onFilteredBackward는 정의되어 있어야 (lockless이므로).
+      const calls = mockTrackProgress.mock.calls;
+      const lastCall = calls[calls.length - 1][0];
+      expect(typeof lastCall.onFilteredBackward).toBe('function');
+    });
+
+    it('boardingLock 활성 시 onFilteredBackward는 undefined (lockless 측정만 함)', () => {
+      mockTrackProgress.mockReturnValue(trainProgressFor(FWD_ARC_STATION_C));
+
+      renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          fwdRouteContext,
+          'T-2',
+          FWD_BOARDING_LOCK,
+        ),
+      );
+
+      const calls = mockTrackProgress.mock.calls;
+      const lastCall = calls[calls.length - 1][0];
+      expect(lastCall.onFilteredBackward).toBeUndefined();
+    });
+  });
+
   describe('arcStations 비어있으면 forward-only 가드 미적용', () => {
     it('computeRouteArc=null(arc 없음)이면 positionTrainResult 정상 채택', () => {
       mockComputeRouteArc.mockReturnValue(null);

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -29,6 +29,8 @@ import { shouldDowngradeFusion } from '../utils/movementGate';
 import type { PositionStability } from '../utils/positionStaticDetector';
 import { pickCandidateTrains, type CandidateTrain } from '../../arrival/utils/pickCandidateTrains';
 import { trackTrainProgress } from '../../route/utils/trackTrainProgress';
+import { estimateArcStationsFromRoute } from '../../route/utils/arcEstimation';
+import { logSuppressedLocklessForwardOnly } from '../../alarm/utils/alarmLog';
 import { haversine } from '../../../shared/utils/haversine';
 import { findStationByName, findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import { isWithinArcWindow, passesFusionDistanceGate } from '../utils/fusionDistanceGate';
@@ -542,17 +544,44 @@ export function useFusedNearestStation(
     return arc?.stations ?? [];
   }, [routeContext]);
 
+  // #1616 (R8a) — lockless 시 forward-only 가드 활성화.
+  // boardingLock이 있으면 기존 동작(#1017): arcStations + lock.boardingStationId 그대로 사용.
+  // 없으면 estimateArcStationsFromRoute로 route + GPS 위치 기준 추정 윈도우 산출 — backward
+  // jump 차단 안전망. 추정 실패 시(route/origin/destination/GPS 없음) undefined로 fallback해
+  // 기존 lockless 동작 유지(회귀 0).
+  const locklessGuard = useMemo(() => {
+    if (boardingLock) return undefined;
+    return estimateArcStationsFromRoute({
+      route: routeContext?.route ?? null,
+      origin: routeContext?.origin ?? null,
+      destination: routeContext?.destination ?? null,
+      userLocation: gps.userLocation,
+    });
+  }, [boardingLock, routeContext, gps.userLocation]);
+
   const trainProgress = useMemo(
     () =>
       trackTrainProgress({
         candidates: candidateTrains,
         userLocation: gps.userLocation,
         lastConfirmedTrainNo: lastConfirmedTrainNoRef.current,
-        // #1017 forward-only 가드 — boardingLock이 있을 때만 적용.
-        segmentStations: boardingLock ? arcStations : undefined,
-        boardingStationId: boardingLock?.boardingStationId,
+        // #1017 + #1616 (R8a) forward-only 가드.
+        //   - boardingLock 활성: 기존 (#1017) arcStations + lock.boardingStationId.
+        //   - lockless: estimateArcStationsFromRoute 결과 (없으면 undefined → 가드 OFF graceful).
+        segmentStations: boardingLock ? arcStations : locklessGuard?.segmentStations,
+        boardingStationId: boardingLock?.boardingStationId ?? locklessGuard?.boardingStationId,
+        // #1616 (R8a) — lockless 시 forward-only 가드가 backward를 reject한 케이스만 alarmLog 적재.
+        // boardingLock 활성 시는 기존 (#1017) 가드와 동일 동작 — 별도 측정 X (lock 신호가 이미 강한 근거).
+        onFilteredBackward: boardingLock
+          ? undefined
+          : (info) => {
+              logSuppressedLocklessForwardOnly({
+                rejectedStationName: info.stationName,
+                rejectedTrainNo: info.trainNo,
+              });
+            },
       }),
-    [candidateTrains, gps.userLocation, boardingLock, arcStations],
+    [candidateTrains, gps.userLocation, boardingLock, arcStations, locklessGuard],
   );
 
   // #445: trainProgress 갱신 시각 추적 + TTL 만료 후 첫 갱신에서 sticky 락 해제.

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -63,7 +63,11 @@ import type { BoardingLock } from '../../../shared/types/boardingLock';
 import type { NearestStationResult, Station } from '../../../shared/types/station';
 import type { ArrivalProvider } from '../../../shared/types/providers';
 import type { PositionProvider } from '../providers/types';
-import { allowedLinesFromRoute, type Route } from '../../../shared/utils/stationRoute';
+import {
+  allowedLinesFromRoute,
+  getStationsOnLine,
+  type Route,
+} from '../../../shared/utils/stationRoute';
 
 /**
  * fusion 후보 개수. MAX_ACTIVE_LINES와 동기화 — Rules of Hooks로 useArrivalInfo/useTrainPositions를
@@ -492,19 +496,39 @@ export function useFusedNearestStation(
   const candidateTrains = useMemo<CandidateTrain[]>(() => {
     const lps: (LinePositions | null)[] = [p0.positions, p1.positions, p2.positions];
     const out: CandidateTrain[] = [];
+    // #1616 (R12-a): candidate별 GPS 거리 hard gate. userLocation + line별 station 좌표 lookup을
+    // pickCandidateTrains에 전달해 anchor GPS drift 시 잘못된 영역 train 후보 진입을 차단.
+    // pushFusionDebugEntry로 reject 측정 — DebugModal에서 'reject:candidate-distance' 표시.
     for (const lp of lps) {
       if (!lp) continue;
       const anchor = candidates.find((c) => c.station.line === lp.line)?.station.name;
+      const lineStations = getStationsOnLine(lp.line);
+      const stationCoordinates = new Map<string, { lat: number; lng: number }>(
+        lineStations.map((s) => [s.name, { lat: s.lat, lng: s.lng }]),
+      );
       out.push(
         ...pickCandidateTrains({
           positions: [lp],
           line: lp.line,
           anchorStationName: anchor,
+          userLocation: gps.userLocation,
+          stationCoordinates,
+          onCandidateDistanceReject: (info) => {
+            pushFusionDebugEntry({
+              kind: 'candidate-reject',
+              ts: Date.now(),
+              reason: 'candidate-distance',
+              trainNo: info.trainNo,
+              stationName: info.stationName,
+              line: info.line,
+              distanceKm: info.distanceKm,
+            });
+          },
         }),
       );
     }
     return out;
-  }, [candidates, p0.positions, p1.positions, p2.positions]);
+  }, [candidates, p0.positions, p1.positions, p2.positions, gps.userLocation]);
 
   // #1017: arcStations를 trackTrainProgress forward-only 가드에 넘기기 위해 trainProgress 이전에 선언.
   // 기존 arcStations useMemo(ADR-008 estimator용)는 아래에서 이 값을 재사용한다.

--- a/src/features/nearest-station/utils/__tests__/fusionDebugBuffer.test.ts
+++ b/src/features/nearest-station/utils/__tests__/fusionDebugBuffer.test.ts
@@ -73,6 +73,24 @@ describe('fusionDebugBuffer', () => {
     expect(listener).toHaveBeenCalledTimes(3);
   });
 
+  it('#1616 (R12-a) accepts candidate-reject entries with distance/trainNo/reason', () => {
+    pushFusionDebugEntry({
+      kind: 'candidate-reject',
+      ts: 100,
+      reason: 'candidate-distance',
+      trainNo: 'T-9001',
+      stationName: '강변(동서울터미널)',
+      line: '2',
+      distanceKm: 5.4,
+    });
+    const entries = getFusionDebugEntries();
+    expect(entries).toHaveLength(1);
+    const entry = entries[0];
+    expect(entry.kind).toBe('candidate-reject');
+    expect((entry as { trainNo: string }).trainNo).toBe('T-9001');
+    expect((entry as { distanceKm: number }).distanceKm).toBe(5.4);
+  });
+
   it('accepts gps-fix and gps-drop entries', () => {
     pushFusionDebugEntry({
       kind: 'gps',

--- a/src/features/nearest-station/utils/fusionDebugBuffer.ts
+++ b/src/features/nearest-station/utils/fusionDebugBuffer.ts
@@ -90,7 +90,33 @@ export interface StickyStationEntry {
   speedMps: number | null;
 }
 
-export type FusionDebugEntry = FusionDecisionEntry | GpsFixEntry | StickyStationEntry;
+/**
+ * #1616 (R12-a) — candidate별 GPS 거리 hard gate가 reject한 entry.
+ *
+ * pickCandidateTrains에서 anchorIdx ± window 통과 후 candidate.currentStation의 GPS 좌표가
+ * 사용자 마지막 known location 기준 CANDIDATE_DISTANCE_THRESHOLD_KM(3.0km)을 초과해 reject된
+ * 케이스. anchor GPS drift 시 잘못된 영역 train이 후보 진입하는 cascade(2026-06-19 trip evidence:
+ * pt/fu/gp 다 이수) 차단을 사후 측정.
+ *
+ * fusion decision과 분리한 이유: reject 자체는 결정 entry가 아니라 입력 단계 reject. fusion
+ * decision 이력과 합치면 DebugModal 시각화에서 둘이 섞여 신호 구분 어려움.
+ */
+export interface CandidateRejectEntry {
+  kind: 'candidate-reject';
+  ts: number;
+  /** reject 사유 — 후속 확장 가능 (예: 'lockless-direction-reject' 등). */
+  reason: 'candidate-distance';
+  trainNo: string;
+  stationName: string;
+  line: string;
+  distanceKm: number;
+}
+
+export type FusionDebugEntry =
+  | FusionDecisionEntry
+  | GpsFixEntry
+  | StickyStationEntry
+  | CandidateRejectEntry;
 
 const db = createDebugBuffer<FusionDebugEntry>(FUSION_DEBUG_BUFFER_CAPACITY);
 

--- a/src/features/route/utils/__tests__/arcEstimation.test.ts
+++ b/src/features/route/utils/__tests__/arcEstimation.test.ts
@@ -1,0 +1,159 @@
+import {
+  estimateArcStationsFromRoute,
+  ESTIMATE_ARC_WINDOW_STATIONS,
+} from '../arcEstimation';
+import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute';
+import type { Station } from '../../../../shared/types/station';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute,
+  makeTransferRoute,
+} from '../../../../testUtils/routeFixtures';
+
+const childrenPark = findStationByNameAndLine('어린이대공원', '7')!;
+const sagajeong = findStationByNameAndLine('사가정', '7')!;
+const gunja = findStationByNameAndLine('군자', '7')!;
+const konkukUni7 = findStationByNameAndLine('건대입구', '7')!;
+const jamsil2 = findStationByNameAndLine('잠실', '2')!;
+
+// userLocation near 어린이대공원
+const NEAR_CHILDREN_PARK = { lat: childrenPark.lat, lng: childrenPark.lng };
+const NEAR_SAGAJEONG = { lat: sagajeong.lat, lng: sagajeong.lng };
+
+describe('estimateArcStationsFromRoute', () => {
+  describe('graceful fallback (returns undefined)', () => {
+    it.each<{ label: string; override: Record<string, unknown> }>([
+      { label: 'route null', override: { route: null } },
+      { label: 'origin null', override: { origin: null } },
+      { label: 'destination null', override: { destination: null } },
+      { label: 'userLocation null', override: { userLocation: null } },
+    ])('returns undefined when $label', ({ override }) => {
+      const base = {
+        route: makeDirectRoute(4, '7'),
+        origin: sagajeong,
+        destination: childrenPark,
+        userLocation: NEAR_CHILDREN_PARK,
+      };
+      const result = estimateArcStationsFromRoute({ ...base, ...override });
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when arc cannot be computed (invalid endpoints on direct route)', () => {
+      // direct route line=7, origin id가 line 7에 없으면 computeRouteArc null.
+      const fake: Station = { ...gunja, id: 'nonexistent-id' };
+      const result = estimateArcStationsFromRoute({
+        route: makeDirectRoute(4, '7'),
+        origin: fake,
+        destination: childrenPark,
+        userLocation: NEAR_CHILDREN_PARK,
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('window computation', () => {
+    it('returns window around user-nearest station on direct route arc', () => {
+      const result = estimateArcStationsFromRoute({
+        route: makeDirectRoute(4, '7'),
+        origin: sagajeong,
+        destination: childrenPark,
+        userLocation: NEAR_CHILDREN_PARK,
+      });
+      expect(result).not.toBeUndefined();
+      expect(result!.segmentStations.length).toBeGreaterThan(0);
+      // userLocation이 childrenPark이므로 윈도우는 childrenPark를 포함해야 함.
+      const names = result!.segmentStations.map((s) => s.name);
+      expect(names).toContain(childrenPark.name);
+      // boardingStationId = window 첫 station의 id.
+      expect(result!.boardingStationId).toBe(result!.segmentStations[0].id);
+    });
+
+    it('clamps window at arc start when user is near origin', () => {
+      const result = estimateArcStationsFromRoute({
+        route: makeDirectRoute(4, '7'),
+        origin: sagajeong,
+        destination: childrenPark,
+        userLocation: NEAR_SAGAJEONG,
+      });
+      expect(result).not.toBeUndefined();
+      // sagajeong(=origin)이 첫 station이어야 — start 인덱스 0으로 clamp.
+      expect(result!.segmentStations[0].name).toBe(sagajeong.name);
+    });
+
+    it('uses default window when windowStations omitted', () => {
+      const result = estimateArcStationsFromRoute({
+        route: makeDirectRoute(4, '7'),
+        origin: sagajeong,
+        destination: childrenPark,
+        userLocation: NEAR_CHILDREN_PARK,
+      });
+      // window=3 default → max 2*3+1 = 7 stations (end clamp 시 ≤ arc 길이).
+      expect(result!.segmentStations.length).toBeLessThanOrEqual(2 * ESTIMATE_ARC_WINDOW_STATIONS + 1);
+    });
+
+    it('respects custom windowStations override', () => {
+      const result = estimateArcStationsFromRoute({
+        route: makeDirectRoute(4, '7'),
+        origin: sagajeong,
+        destination: childrenPark,
+        userLocation: NEAR_CHILDREN_PARK,
+        windowStations: 1,
+      });
+      expect(result!.segmentStations.length).toBeLessThanOrEqual(3);
+    });
+
+    it('clamps negative windowStations to 0 (single station window)', () => {
+      const result = estimateArcStationsFromRoute({
+        route: makeDirectRoute(4, '7'),
+        origin: sagajeong,
+        destination: childrenPark,
+        userLocation: NEAR_CHILDREN_PARK,
+        windowStations: -1,
+      });
+      // window=0 → 단일 station만(user nearest).
+      expect(result!.segmentStations).toHaveLength(1);
+    });
+  });
+
+  describe('route variants', () => {
+    it('works with transfer route', () => {
+      const route = makeTransferRoute({
+        transferName: '건대입구',
+        fromLine: '7',
+        toLine: '2',
+        stopsToTransfer: 1,
+        stopsFromTransfer: 4,
+      });
+      const result = estimateArcStationsFromRoute({
+        route,
+        origin: childrenPark,
+        destination: jamsil2,
+        userLocation: { lat: konkukUni7.lat, lng: konkukUni7.lng },
+      });
+      expect(result).not.toBeUndefined();
+      expect(result!.segmentStations.length).toBeGreaterThan(0);
+    });
+
+    it('works with multi-transfer route', () => {
+      const route = makeMultiTransferRoute({
+        transfers: [
+          {
+            transferName: '건대입구',
+            fromLine: '7',
+            toLine: '2',
+            stopsToTransfer: 1,
+          },
+        ],
+        stopsAfterLastTransfer: 4,
+      });
+      const result = estimateArcStationsFromRoute({
+        route,
+        origin: childrenPark,
+        destination: jamsil2,
+        userLocation: { lat: konkukUni7.lat, lng: konkukUni7.lng },
+      });
+      expect(result).not.toBeUndefined();
+      expect(result!.segmentStations.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/features/route/utils/__tests__/trackTrainProgress.test.ts
+++ b/src/features/route/utils/__tests__/trackTrainProgress.test.ts
@@ -253,4 +253,74 @@ describe('trackTrainProgress — forward-only guard (#1017)', () => {
     expect(result?.trainNo).toBe('A');
     expect(result?.confidence).toBe('single');
   });
+
+  // #1616 (R8a) — onFilteredBackward 콜백.
+  describe('onFilteredBackward callback (R8a)', () => {
+    it('invokes callback for each rejected backward candidate when forward survivors exist', () => {
+      const onFilteredBackward = jest.fn();
+      trackTrainProgress({
+        candidates: [
+          makeCandidate({ trainNo: 'BACK1', currentStationName: '시청' }), // backward (boardingIdx=2)
+          makeCandidate({ trainNo: 'BACK2', currentStationName: '을지로입구' }), // backward
+          makeCandidate({ trainNo: 'FWD', currentStationName: '을지로4가' }), // forward
+        ],
+        segmentStations: SEGMENT_2_3,
+        boardingStationId: stationOf('을지로3가').id,
+        onFilteredBackward,
+      });
+      expect(onFilteredBackward).toHaveBeenCalledTimes(2);
+      expect(onFilteredBackward).toHaveBeenNthCalledWith(1, { trainNo: 'BACK1', stationName: '시청' });
+      expect(onFilteredBackward).toHaveBeenNthCalledWith(2, { trainNo: 'BACK2', stationName: '을지로입구' });
+    });
+
+    it('does NOT invoke callback when ALL candidates are backward (fallback path)', () => {
+      // 전부 backward → forward.length===0 → fallback로 resolved 전체 사용 → 측정 의미 없음.
+      const onFilteredBackward = jest.fn();
+      trackTrainProgress({
+        candidates: [
+          makeCandidate({ trainNo: 'BACK1', currentStationName: '시청' }),
+          makeCandidate({ trainNo: 'BACK2', currentStationName: '을지로입구' }),
+        ],
+        segmentStations: SEGMENT_2_3,
+        boardingStationId: stationOf('을지로3가').id,
+        userLocation: NEAR_SICHEONG,
+        onFilteredBackward,
+      });
+      expect(onFilteredBackward).not.toHaveBeenCalled();
+    });
+
+    it('does NOT invoke callback when no backward candidates exist', () => {
+      const onFilteredBackward = jest.fn();
+      trackTrainProgress({
+        candidates: [makeCandidate({ trainNo: 'FWD', currentStationName: '을지로4가' })],
+        segmentStations: SEGMENT_2_3,
+        boardingStationId: stationOf('을지로3가').id,
+        onFilteredBackward,
+      });
+      expect(onFilteredBackward).not.toHaveBeenCalled();
+    });
+
+    it('does NOT invoke callback when guard is OFF (segmentStations / boardingStationId 없음)', () => {
+      const onFilteredBackward = jest.fn();
+      trackTrainProgress({
+        candidates: [makeCandidate({ trainNo: 'A', currentStationName: '시청' })],
+        onFilteredBackward,
+      });
+      expect(onFilteredBackward).not.toHaveBeenCalled();
+    });
+
+    it('skips reject (no-op) when onFilteredBackward is undefined', () => {
+      // 콜백 없어도 정상 동작 (기존 #1017 회귀 0).
+      const result = trackTrainProgress({
+        candidates: [
+          makeCandidate({ trainNo: 'BACK', currentStationName: '시청' }),
+          makeCandidate({ trainNo: 'FWD', currentStationName: '을지로4가' }),
+        ],
+        segmentStations: SEGMENT_2_3,
+        boardingStationId: stationOf('을지로3가').id,
+        // onFilteredBackward omitted
+      });
+      expect(result?.trainNo).toBe('FWD');
+    });
+  });
 });

--- a/src/features/route/utils/arcEstimation.ts
+++ b/src/features/route/utils/arcEstimation.ts
@@ -1,0 +1,85 @@
+/**
+ * #1616 (R8a) — lockless 시 trackTrainProgress forward-only 가드용 arcStations 추정.
+ *
+ * 배경:
+ * `useFusedNearestStation` 의 trainProgress 계산은 `boardingLock` 활성 시에만 `segmentStations` /
+ * `boardingStationId` 를 trackTrainProgress에 전달했다. 즉 lockless trip(boardingLock=null)에서는
+ * forward-only 가드가 OFF — R2 lockless time-integration cascade가 backward jump을 허용해
+ * "pt/fu/gp 다 잘못된 역" misfire 회귀(2026-06-19 trip evidence: pt 다 이수, 실제 학동/강남구청).
+ *
+ * 본 helper는 route + userLocation으로 user-position 기준 arc 윈도우를 추정해 lockless 시에도
+ * trackTrainProgress가 backward 후보를 reject할 수 있게 한다. 정확한 lock 없어도 route arc 상
+ * "사용자 근처 ± window" segment를 산출 — 추정 cut-off은 정확하지 않지만 lock 없을 때 어떤 가드도
+ * 없는 현 동작보다는 보수적으로 안전.
+ *
+ * 추정 algorithm:
+ *   a. computeRouteArc로 route + origin + destination → 전체 arc Station[] 산출.
+ *   b. userLocation에서 가장 가까운 arc 위 station을 찾는다 (haversine 단순 비교).
+ *   c. 그 station 인덱스 ± window 범위 station을 반환 (양 끝 clamp).
+ *
+ * route / origin / destination / userLocation 중 하나라도 없거나, arc 산출 실패 시 undefined 반환 —
+ * 호출자는 segmentStations=undefined로 fallback해 기존 lockless 동작 유지 (회귀 0).
+ *
+ * window=3 — pickCandidateTrains의 DEFAULT_WINDOW_STATIONS와 일치. 사용자 위치 추정 오차 + 표준
+ * candidate window를 같이 흡수해 false reject 최소화.
+ */
+import type { Station } from '../../../shared/types/station';
+import { haversine } from '../../../shared/utils/haversine';
+import { computeRouteArc } from './routeProgress';
+import type { Route } from '../../../shared/utils/stationRoute';
+
+/**
+ * #1616 (R8a) — lockless arc 윈도우 추정 default window (양옆 station 수).
+ * pickCandidateTrains DEFAULT_WINDOW_STATIONS=3과 동일 — 두 가드가 같은 영역 정의를 공유.
+ */
+export const ESTIMATE_ARC_WINDOW_STATIONS = 3;
+
+export interface EstimateArcStationsInput {
+  route: Route;
+  origin: Station | null;
+  destination: Station | null;
+  userLocation: { lat: number; lng: number } | null;
+  windowStations?: number;
+}
+
+export interface EstimateArcStationsResult {
+  segmentStations: readonly Station[];
+  /** arc 윈도우의 첫 station id — trackTrainProgress의 boardingStationId 자리에 사용. */
+  boardingStationId: string;
+}
+
+export function estimateArcStationsFromRoute(
+  input: EstimateArcStationsInput,
+): EstimateArcStationsResult | undefined {
+  const { route, origin, destination, userLocation, windowStations } = input;
+
+  if (!route || !origin || !destination || !userLocation) return undefined;
+
+  const arc = computeRouteArc(route, origin, destination);
+  if (!arc || arc.stations.length === 0) return undefined;
+
+  const window = Math.max(0, windowStations ?? ESTIMATE_ARC_WINDOW_STATIONS);
+
+  // arc 위 user GPS-nearest station 검색 — haversine 단순 비교(arc 매우 길어도 528건 << render budget).
+  let nearestIdx = 0;
+  let nearestDist = Infinity;
+  for (let i = 0; i < arc.stations.length; i++) {
+    const s = arc.stations[i];
+    const d = haversine(userLocation.lat, userLocation.lng, s.lat, s.lng);
+    if (d < nearestDist) {
+      nearestDist = d;
+      nearestIdx = i;
+    }
+  }
+
+  const start = Math.max(0, nearestIdx - window);
+  const end = Math.min(arc.stations.length, nearestIdx + window + 1);
+  const segmentStations = arc.stations.slice(start, end);
+
+  // segmentStations[0] = 윈도우 시작 = 추정 boarding 위치. trackTrainProgress의 forward-only는
+  // 이 위치 이전 candidate를 reject 한다 — lockless에서 보수적 안전망 역할.
+  return {
+    segmentStations,
+    boardingStationId: segmentStations[0].id,
+  };
+}

--- a/src/features/route/utils/trackTrainProgress.ts
+++ b/src/features/route/utils/trackTrainProgress.ts
@@ -12,9 +12,16 @@ export interface TrackTrainProgressInput {
    * 탑승역부터 목적지까지의 순서 있는 역 목록(route arc).
    * 제공되면 currentStation이 탑승역 이전에 해당하는 candidate를 탈락시킨다.
    */
-  segmentStations?: Station[];
+  segmentStations?: readonly Station[];
   /** #1017: segmentStations 내에서 탑승역 id — boardingIdx 계산에 사용. */
   boardingStationId?: string;
+  /**
+   * #1616 (R8a) — forward-only 가드가 backward candidate를 탈락시킨 경우 호출되는 측정 hook.
+   * 호출자는 lockless 시 alarmLog `lockless-forward-only-block`로 적재해 1주 production
+   * evidence를 모은다. fallback(전부 backward → resolved 그대로 사용)에 진입한 경우에는
+   * 호출하지 않는다 — fallback은 실질적으로 가드 미적용이라 measurement 의미 X.
+   */
+  onFilteredBackward?: (info: { trainNo: string; stationName: string }) => void;
 }
 
 export interface TrainProgressResult {
@@ -44,8 +51,14 @@ function toResult(
 export function trackTrainProgress(
   input: TrackTrainProgressInput,
 ): TrainProgressResult | null {
-  const { candidates, userLocation, lastConfirmedTrainNo, segmentStations, boardingStationId } =
-    input;
+  const {
+    candidates,
+    userLocation,
+    lastConfirmedTrainNo,
+    segmentStations,
+    boardingStationId,
+    onFilteredBackward,
+  } = input;
 
   if (candidates.length === 0) return null;
 
@@ -64,12 +77,28 @@ export function trackTrainProgress(
     if (!segmentStations || segmentStations.length === 0 || !boardingStationId) return resolved;
     const boardingIdx = segmentStations.findIndex((s) => s.id === boardingStationId);
     if (boardingIdx === -1) return resolved;
+    const rejected: ResolvedCandidate[] = [];
     const forward = resolved.filter((r) => {
       const idx = segmentStations.findIndex((s) => s.id === r.station.id);
       // arc 밖(idx === -1)은 탈락시키지 않는다 — 다른 가드(#662 노선 가드 등)가 처리.
-      return idx === -1 || idx >= boardingIdx;
+      const keep = idx === -1 || idx >= boardingIdx;
+      if (!keep) rejected.push(r);
+      return keep;
     });
-    return forward.length > 0 ? forward : resolved;
+    if (forward.length > 0) {
+      // #1616 (R8a) — 실제 가드가 적용된 (fallback X) 경우에만 onFilteredBackward 발사.
+      // fallback은 실질적으로 가드 미적용이라 measurement 의미 없음.
+      if (onFilteredBackward) {
+        for (const r of rejected) {
+          onFilteredBackward({
+            trainNo: r.candidate.trainNo,
+            stationName: r.station.name,
+          });
+        }
+      }
+      return forward;
+    }
+    return resolved;
   })();
 
   /* istanbul ignore next — graceful fallback(forward.length>0 ? forward : resolved)가


### PR DESCRIPTION
Closes #1616

## 다운로드 가치
**V1 (정확한 현재역) FG 지하 + lockless 영역 회복.** Stage 1 (PR #1613) + Stage 3-1 (PR #1615) 머지 후 다음 단계.

## 변경 2 fix

### R12-a — pickCandidateTrains candidate별 GPS 거리 hard gate
- `src/features/arrival/utils/pickCandidateTrains.ts:19-130` userLocation + stationCoordinates 인자 추가, candidate.currentStation GPS 좌표가 `CANDIDATE_DISTANCE_THRESHOLD_KM=3.0km` 초과 시 reject
- `src/features/nearest-station/hooks/useFusedNearestStation.ts:498-535` line별 좌표 Map + 호출 wire + reject 콜백 → pushFusionDebugEntry
- `src/features/nearest-station/utils/fusionDebugBuffer.ts:103-124` `CandidateRejectEntry` 신규 kind(reason='candidate-distance')
- `src/features/debug/components/DebugModal.tsx:272-277` `reject:reason | trainNo station d=` 포맷터

### R8a — lockless 시 forward-only 가드 활성
- `src/features/route/utils/arcEstimation.ts` (신규) `estimateArcStationsFromRoute(route, origin, destination, userLocation)` → user GPS 기준 arc 윈도우(± ESTIMATE_ARC_WINDOW_STATIONS=3) 추정. 입력 부족/arc 산출 실패 시 undefined fallback
- `src/features/route/utils/trackTrainProgress.ts:13-25, 63-83` `onFilteredBackward` 콜백 추가 — forward 가드가 backward reject 시 호출. 전부 backward → fallback path는 호출 안 함
- `src/features/alarm/utils/alarmLog.ts:193-199, 808-833` AlarmLogReason `lockless-forward-only-block` 추가 + `logSuppressedLocklessForwardOnly` (source='fg-evaluated' + burst dedup)
- `src/features/nearest-station/hooks/useFusedNearestStation.ts:547-588` `locklessGuard` useMemo + trainProgress에 segmentStations / boardingStationId / onFilteredBackward 전달. boardingLock 활성 시는 기존 (#1017) 동작 그대로

## Wire-completion 5단
1. **Orphan**: `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard**: 
   - fusionDebugBuffer 신규 reason `candidate-reject:candidate-distance` (V1 측정)
   - alarmLog 신규 reason `lockless-forward-only-block` (V1 측정)
3. **의존 PR**: Stage 1 PR #1613 + Stage 3-1 PR #1615 머지 완료, 본 PR 독립
4. **측정 plan**: 1주 production. fusionDebugBuffer candidate-distance reject 카운트 + alarmLog lockless-forward-only-block 카운트 + 사용자 trip V1 회복 evidence
5. **Device verify**: 실기기 FG 지하 trip 1주 + 사용자 trip annotation

## 테스트
- `npm run type-check`: 0 error
- `npm test`: 7264 tests pass, **coverage 100%** (lines/functions/branches/statements)
- `npm run lint:orphan`: 0 orphan
- 신규 단위 테스트: **+28** (pickCandidateTrains +8, arcEstimation +12, trackTrainProgress +5, alarmLog +2, fusionDebugBuffer +1, DebugModal +1, useFusedNearestStation +2). 기존 7236 회귀 0.

## Self-review
1. **R12-a 거리 가드 false positive**: 호선 평균 station 간 거리 ~1.5km × 2 보수 threshold + 1주 reject 카운트 monitoring으로 빈도 측정.
2. **R8a estimateArcStationsFromRoute 정확도**: 입력 부족 / arc 산출 실패 시 undefined fallback → 기존 lockless 동작 유지 (회귀 0). 추정 잘못된 경우에도 trackTrainProgress fallback(전부 backward → resolved 전체)으로 graceful degradation.
3. **통합 회귀 (2 fix atomic)**: 단위 + 통합 시나리오 + type-check + coverage 100%. boardingLock 활성 path는 두 fix 모두 영향 없음 (기존 #1017 동작 그대로).

## 커밋 단위
1. `0bf2d79` fix(#1616): R12-a — pickCandidateTrains candidate별 GPS 거리 hard gate
2. `acd27cf` fix(#1616): R8a — lockless 시 forward-only 가드 활성

## 메모리
- `project_2026_06_19_pm_2026_06_20_am_trip_evidence` — R12-a / R8a evidence
- `lesson_lockless_route_hop_time_integration_ssot_assumption` — R8a cascade
- `feedback_v_x_acceptance_full_table` — V1 측정 임계
- `feedback_wire_completion_gate` — 5단 검증
- `lesson_sonarcloud_dup_prevention` — it.each + factory 적용