### PR TITLE
fix(#1618): R9-b — backend buildLiveActivityContentState multi-hop 필드 wipe 차단 (LA "전체 여정" 회복)

### DIFF
--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -104,6 +104,146 @@ describe('buildLiveActivityContentState (#613)', () => {
   });
 });
 
+// #1618 R9-b — backend buildLiveActivityContentState multi-hop 필드 wipe 차단.
+// ActivityKit content-state는 update 시 전체 교체 → backend가 multi-hop 필드를 누락하면
+// JS init이 stamp한 transfer/destination chain이 첫 backend push에 wipe된다.
+// `trip` 인자가 전달되면 multi-hop context를 함께 emit해 LA 화면 "전체 여정" 유지.
+describe('buildLiveActivityContentState multi-hop (#1618 R9-b)', () => {
+  /** Trip factory — multi-hop test 케이스 dedup. waypoints만 override해 케이스 표현. */
+  const makeTripForMultiHop = (waypoints: Waypoint[]): Trip =>
+    makeTrip({ waypoints, route: { type: 'direct', line: '2', stops: waypoints.length } });
+
+  /**
+   * direct trip: destination 한 개만. transferStationName / stopsToTransfer /
+   * secondTransferStationName / stopsAfterLastTransfer / stopsToSecondTransfer /
+   * stopsFromTransfer 모두 undefined.
+   */
+  it('direct trip — destinationName 채움, transfer 필드 모두 undefined', () => {
+    const trip = makeTripForMultiHop([
+      { stationName: '중곡', line: '2', kind: 'intermediate' },
+      { stationName: '강남', line: '2', kind: 'destination' },
+    ]);
+    const cs = buildLiveActivityContentState(WAYPOINT, 60, 2, trip);
+    expect(cs.destinationName).toBe('강남');
+    expect(cs.transferStationName).toBeUndefined();
+    expect(cs.stopsToTransfer).toBeUndefined();
+    expect(cs.secondTransferStationName).toBeUndefined();
+    expect(cs.stopsAfterLastTransfer).toBeUndefined();
+    expect(cs.stopsToSecondTransfer).toBeUndefined();
+    expect(cs.stopsFromTransfer).toBeUndefined();
+  });
+
+  /**
+   * single-transfer trip: transfer 1개. stopsToTransfer = first transfer index + 1,
+   * stopsFromTransfer = remaining after transfer. secondTransfer 필드는 undefined.
+   */
+  it('transfer 1회 — transferStationName + stopsToTransfer + stopsFromTransfer 채움', () => {
+    // 진행: [A(int), 시청(t1), C(int), 강남(dest)]
+    //   - transfer 위치 idx=1 → stopsToTransfer = 2 (A 지나서 시청 도착)
+    //   - 환승 이후 남은 stop = 2 (C 지나 강남)
+    const trip = makeTripForMultiHop([
+      { stationName: 'A', line: '2', kind: 'intermediate' },
+      { stationName: '시청', line: '2', kind: 'transfer' },
+      { stationName: 'C', line: '1', kind: 'intermediate' },
+      { stationName: '강남', line: '1', kind: 'destination' },
+    ]);
+    const cs = buildLiveActivityContentState(WAYPOINT, 60, 4, trip);
+    expect(cs.destinationName).toBe('강남');
+    expect(cs.transferStationName).toBe('시청');
+    expect(cs.stopsToTransfer).toBe(2);
+    expect(cs.stopsFromTransfer).toBe(2);
+    expect(cs.secondTransferStationName).toBeUndefined();
+    expect(cs.stopsToSecondTransfer).toBeUndefined();
+    expect(cs.stopsAfterLastTransfer).toBeUndefined();
+  });
+
+  /**
+   * multi-transfer trip: transfer 2개 이상. secondTransfer 필드 + stopsAfterLastTransfer 채움,
+   * stopsFromTransfer는 undefined (multi-transfer schema는 stopsAfterLastTransfer로만 표현).
+   */
+  it('transfer 2회 — second transfer 필드 + stopsAfterLastTransfer 채움', () => {
+    // 진행: [A(int), 시청(t1), C(int), 동대문(t2), E(int), F(int), 강남(dest)]
+    //   - first transfer idx=1 → stopsToTransfer = 2
+    //   - second transfer idx=3 → stopsToSecondTransfer = 2 (3 - 1)
+    //   - 마지막 transfer 이후 남은 stop = 3 (E, F 지나 강남) = (7 - 1 - 3)
+    const trip = makeTripForMultiHop([
+      { stationName: 'A', line: '2', kind: 'intermediate' },
+      { stationName: '시청', line: '2', kind: 'transfer' },
+      { stationName: 'C', line: '1', kind: 'intermediate' },
+      { stationName: '동대문', line: '1', kind: 'transfer' },
+      { stationName: 'E', line: '4', kind: 'intermediate' },
+      { stationName: 'F', line: '4', kind: 'intermediate' },
+      { stationName: '강남', line: '4', kind: 'destination' },
+    ]);
+    const cs = buildLiveActivityContentState(WAYPOINT, 60, 7, trip);
+    expect(cs.destinationName).toBe('강남');
+    expect(cs.transferStationName).toBe('시청');
+    expect(cs.stopsToTransfer).toBe(2);
+    expect(cs.secondTransferStationName).toBe('동대문');
+    expect(cs.stopsToSecondTransfer).toBe(2);
+    expect(cs.stopsAfterLastTransfer).toBe(3);
+    expect(cs.stopsFromTransfer).toBeUndefined();
+  });
+
+  /**
+   * transfer가 next waypoint 인 경우 — stopsToTransfer는 최소 1 (next stop이 transfer)
+   * 이어야 한다. 0이 아닌 1.
+   */
+  it('next waypoint가 transfer일 때 stopsToTransfer = 1 (off-by-one 회귀 가드)', () => {
+    const trip = makeTripForMultiHop([
+      { stationName: '시청', line: '2', kind: 'transfer' },
+      { stationName: '강남', line: '1', kind: 'destination' },
+    ]);
+    const cs = buildLiveActivityContentState(WAYPOINT, 60, 2, trip);
+    expect(cs.stopsToTransfer).toBe(1);
+    expect(cs.stopsFromTransfer).toBe(1);
+  });
+
+  /**
+   * 빈 waypoints — 사용자 도착 직후 (advance 후 호출). multi-hop 필드 모두 undefined.
+   * base 5 필드는 그대로 유지.
+   */
+  it('빈 waypoints — multi-hop 필드 전부 omit, base 5 필드만 emit', () => {
+    const trip = makeTrip({ waypoints: [] });
+    const cs = buildLiveActivityContentState(WAYPOINT, 0, 0, trip);
+    expect(cs).toEqual({
+      stationName: '강남',
+      lineName: '2호선',
+      lineColorHex: '#009D3E',
+      stopsRemaining: 0,
+      etaMinutes: 0,
+    });
+  });
+
+  /**
+   * destination만 있고 transfer가 한 개도 없으면, 마지막에 destination이 와도 정상 추출.
+   * (단, 마지막이 destination이 아닌 비정상 경우도 가장 마지막 destination을 추출 — defensive.)
+   */
+  it('마지막이 intermediate 인 비정상 waypoints에서도 destination 정상 추출', () => {
+    const trip = makeTripForMultiHop([
+      { stationName: '강남', line: '2', kind: 'destination' },
+      // 비정상: destination 뒤 추가 intermediate (예: 미래 변경 또는 schema drift).
+      { stationName: '잘못된역', line: '2', kind: 'intermediate' },
+    ]);
+    const cs = buildLiveActivityContentState(WAYPOINT, 60, 2, trip);
+    expect(cs.destinationName).toBe('강남');
+  });
+
+  /**
+   * trip 미전달 시 (legacy 호출자) — base 5 필드만 emit, multi-hop 필드 0개. backward-compat.
+   * 기존 테스트(line 65-74)와 동일 결과지만 명시 회귀 가드.
+   */
+  it('trip 미전달 — base 5 필드만 emit (backward-compat)', () => {
+    const cs = buildLiveActivityContentState(WAYPOINT, 60, 3);
+    expect(cs).not.toHaveProperty('destinationName');
+    expect(cs).not.toHaveProperty('transferStationName');
+    expect(cs).not.toHaveProperty('stopsToTransfer');
+    expect(cs).not.toHaveProperty('secondTransferStationName');
+    expect(cs).not.toHaveProperty('stopsAfterLastTransfer');
+    expect(cs).not.toHaveProperty('stopsFromTransfer');
+  });
+});
+
 describe('fireLiveActivityUpdate', () => {
   it('no-ops when activityPushToken is missing', async () => {
     const fetchImpl = vi.fn();

--- a/backend/alarm-worker/src/__tests__/tripMultiHop.test.ts
+++ b/backend/alarm-worker/src/__tests__/tripMultiHop.test.ts
@@ -24,6 +24,17 @@ function makeTrip(waypoints: Waypoint[]): Trip {
   };
 }
 
+// Waypoint factory helpers — kill the repeated `{ stationName, line, kind }` literal noise across
+// it.each cases. `line` defaults to '2' (most cases) and overrides only when crossing lines.
+const wp = (
+  stationName: string,
+  kind: Waypoint['kind'],
+  line: string = '2',
+): Waypoint => ({ stationName, line, kind });
+const int = (stationName: string, line: string = '2'): Waypoint => wp(stationName, 'intermediate', line);
+const tx = (stationName: string, line: string = '2'): Waypoint => wp(stationName, 'transfer', line);
+const dst = (stationName: string, line: string = '2'): Waypoint => wp(stationName, 'destination', line);
+
 describe('computeMultiHopContext (#1618)', () => {
   it('returns empty object for trips with no remaining waypoints', () => {
     expect(computeMultiHopContext(makeTrip([]))).toEqual({});
@@ -31,14 +42,8 @@ describe('computeMultiHopContext (#1618)', () => {
 
   // Direct trip (no transfer waypoints) — only destinationName is populated.
   it.each<[string, Waypoint[]]>([
-    ['destination only', [{ stationName: '강남', line: '2', kind: 'destination' }]],
-    [
-      'intermediate + destination',
-      [
-        { stationName: '중곡', line: '2', kind: 'intermediate' },
-        { stationName: '강남', line: '2', kind: 'destination' },
-      ],
-    ],
+    ['destination only', [dst('강남')]],
+    ['intermediate + destination', [int('중곡'), dst('강남')]],
   ])('direct trip (%s) populates destinationName only', (_label, waypoints) => {
     const ctx = computeMultiHopContext(makeTrip(waypoints));
     expect(ctx.destinationName).toBe('강남');
@@ -56,35 +61,16 @@ describe('computeMultiHopContext (#1618)', () => {
    * transfer waypoint (= waypoints.length - 1 - transferIdx).
    */
   it.each<[string, Waypoint[], number, number]>([
-    [
-      'transfer as next waypoint',
-      [
-        { stationName: '시청', line: '2', kind: 'transfer' },
-        { stationName: '강남', line: '1', kind: 'destination' },
-      ],
-      1,
-      1,
-    ],
+    ['transfer as next waypoint', [tx('시청'), dst('강남', '1')], 1, 1],
     [
       'transfer after 1 intermediate',
-      [
-        { stationName: 'A', line: '2', kind: 'intermediate' },
-        { stationName: '시청', line: '2', kind: 'transfer' },
-        { stationName: 'C', line: '1', kind: 'intermediate' },
-        { stationName: '강남', line: '1', kind: 'destination' },
-      ],
+      [int('A'), tx('시청'), int('C', '1'), dst('강남', '1')],
       2,
       2,
     ],
     [
       'transfer after 3 intermediates',
-      [
-        { stationName: 'A', line: '2', kind: 'intermediate' },
-        { stationName: 'B', line: '2', kind: 'intermediate' },
-        { stationName: 'C', line: '2', kind: 'intermediate' },
-        { stationName: '시청', line: '2', kind: 'transfer' },
-        { stationName: '강남', line: '1', kind: 'destination' },
-      ],
+      [int('A'), int('B'), int('C'), tx('시청'), dst('강남', '1')],
       4,
       1,
     ],
@@ -110,11 +96,7 @@ describe('computeMultiHopContext (#1618)', () => {
   it.each<[string, Waypoint[], number, number, number]>([
     [
       'two adjacent transfers',
-      [
-        { stationName: '시청', line: '2', kind: 'transfer' },
-        { stationName: '동대문', line: '1', kind: 'transfer' },
-        { stationName: '강남', line: '4', kind: 'destination' },
-      ],
+      [tx('시청'), tx('동대문', '1'), dst('강남', '4')],
       1, // stopsToTransfer
       1, // stopsToSecondTransfer
       1, // stopsAfterLastTransfer
@@ -122,13 +104,13 @@ describe('computeMultiHopContext (#1618)', () => {
     [
       'two transfers with intermediates between',
       [
-        { stationName: 'A', line: '2', kind: 'intermediate' },
-        { stationName: '시청', line: '2', kind: 'transfer' },
-        { stationName: 'C', line: '1', kind: 'intermediate' },
-        { stationName: '동대문', line: '1', kind: 'transfer' },
-        { stationName: 'E', line: '4', kind: 'intermediate' },
-        { stationName: 'F', line: '4', kind: 'intermediate' },
-        { stationName: '강남', line: '4', kind: 'destination' },
+        int('A'),
+        tx('시청'),
+        int('C', '1'),
+        tx('동대문', '1'),
+        int('E', '4'),
+        int('F', '4'),
+        dst('강남', '4'),
       ],
       2,
       2,
@@ -136,12 +118,7 @@ describe('computeMultiHopContext (#1618)', () => {
     ],
     [
       'three transfers — only first two surface',
-      [
-        { stationName: '시청', line: '2', kind: 'transfer' },
-        { stationName: '동대문', line: '1', kind: 'transfer' },
-        { stationName: '왕십리', line: '4', kind: 'transfer' },
-        { stationName: '강남', line: '5', kind: 'destination' },
-      ],
+      [tx('시청'), tx('동대문', '1'), tx('왕십리', '4'), dst('강남', '5')],
       1,
       1,
       2,
@@ -166,12 +143,7 @@ describe('computeMultiHopContext (#1618)', () => {
    * scan tolerates schema drift (e.g. backfilled intermediates after the destination).
    */
   it('defensive destination scan — picks last destination even if not at tail', () => {
-    const ctx = computeMultiHopContext(
-      makeTrip([
-        { stationName: '강남', line: '2', kind: 'destination' },
-        { stationName: '잘못된역', line: '2', kind: 'intermediate' },
-      ]),
-    );
+    const ctx = computeMultiHopContext(makeTrip([dst('강남'), int('잘못된역')]));
     expect(ctx.destinationName).toBe('강남');
   });
 
@@ -180,9 +152,7 @@ describe('computeMultiHopContext (#1618)', () => {
    * Returns undefined `destinationName` rather than crashing.
    */
   it('returns undefined destinationName when no destination waypoint present', () => {
-    const ctx = computeMultiHopContext(
-      makeTrip([{ stationName: 'A', line: '2', kind: 'intermediate' }]),
-    );
+    const ctx = computeMultiHopContext(makeTrip([int('A')]));
     expect(ctx.destinationName).toBeUndefined();
   });
 });

--- a/backend/alarm-worker/src/__tests__/tripMultiHop.test.ts
+++ b/backend/alarm-worker/src/__tests__/tripMultiHop.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Unit tests for `computeMultiHopContext` (#1618 R9-b).
+ *
+ * `buildLiveActivityContentState` integrations are exercised in `liveActivity.test.ts`;
+ * this file pins the lower-level helper semantics — index/off-by-one math, defensive
+ * scanning, and empty-input handling.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { computeMultiHopContext } from '../tripMultiHop';
+import type { Trip, Waypoint } from '../types';
+
+const NOW = 1_700_000_000_000;
+
+function makeTrip(waypoints: Waypoint[]): Trip {
+  return {
+    token: 'tok',
+    route: { type: 'direct', line: '2', stops: waypoints.length },
+    destination: 'dst',
+    waypoints,
+    expiresAt: NOW + 3_600_000,
+    createdAt: NOW,
+    alarmAtEpochMs: NOW + 60_000,
+  };
+}
+
+describe('computeMultiHopContext (#1618)', () => {
+  it('returns empty object for trips with no remaining waypoints', () => {
+    expect(computeMultiHopContext(makeTrip([]))).toEqual({});
+  });
+
+  // Direct trip (no transfer waypoints) — only destinationName is populated.
+  it.each<[string, Waypoint[]]>([
+    ['destination only', [{ stationName: '강남', line: '2', kind: 'destination' }]],
+    [
+      'intermediate + destination',
+      [
+        { stationName: '중곡', line: '2', kind: 'intermediate' },
+        { stationName: '강남', line: '2', kind: 'destination' },
+      ],
+    ],
+  ])('direct trip (%s) populates destinationName only', (_label, waypoints) => {
+    const ctx = computeMultiHopContext(makeTrip(waypoints));
+    expect(ctx.destinationName).toBe('강남');
+    expect(ctx.transferStationName).toBeUndefined();
+    expect(ctx.stopsToTransfer).toBeUndefined();
+    expect(ctx.stopsFromTransfer).toBeUndefined();
+    expect(ctx.secondTransferStationName).toBeUndefined();
+    expect(ctx.stopsToSecondTransfer).toBeUndefined();
+    expect(ctx.stopsAfterLastTransfer).toBeUndefined();
+  });
+
+  /**
+   * Single-transfer cases. `stopsToTransfer` = (index of transfer) + 1 — 1-based count of
+   * stations to pass, where 1 = next stop. `stopsFromTransfer` = remaining count after the
+   * transfer waypoint (= waypoints.length - 1 - transferIdx).
+   */
+  it.each<[string, Waypoint[], number, number]>([
+    [
+      'transfer as next waypoint',
+      [
+        { stationName: '시청', line: '2', kind: 'transfer' },
+        { stationName: '강남', line: '1', kind: 'destination' },
+      ],
+      1,
+      1,
+    ],
+    [
+      'transfer after 1 intermediate',
+      [
+        { stationName: 'A', line: '2', kind: 'intermediate' },
+        { stationName: '시청', line: '2', kind: 'transfer' },
+        { stationName: 'C', line: '1', kind: 'intermediate' },
+        { stationName: '강남', line: '1', kind: 'destination' },
+      ],
+      2,
+      2,
+    ],
+    [
+      'transfer after 3 intermediates',
+      [
+        { stationName: 'A', line: '2', kind: 'intermediate' },
+        { stationName: 'B', line: '2', kind: 'intermediate' },
+        { stationName: 'C', line: '2', kind: 'intermediate' },
+        { stationName: '시청', line: '2', kind: 'transfer' },
+        { stationName: '강남', line: '1', kind: 'destination' },
+      ],
+      4,
+      1,
+    ],
+  ])(
+    'single-transfer (%s) → stopsToTransfer=%i, stopsFromTransfer=%i',
+    (_label, waypoints, expectedTo, expectedFrom) => {
+      const ctx = computeMultiHopContext(makeTrip(waypoints));
+      expect(ctx.transferStationName).toBe('시청');
+      expect(ctx.stopsToTransfer).toBe(expectedTo);
+      expect(ctx.stopsFromTransfer).toBe(expectedFrom);
+      expect(ctx.secondTransferStationName).toBeUndefined();
+      expect(ctx.stopsToSecondTransfer).toBeUndefined();
+      expect(ctx.stopsAfterLastTransfer).toBeUndefined();
+      expect(ctx.destinationName).toBe('강남');
+    },
+  );
+
+  /**
+   * Multi-transfer cases (≥2 transfers). `stopsAfterLastTransfer` replaces `stopsFromTransfer`
+   * (matches JS-side `MultiTransferRoute` schema). Only the first two transfers are surfaced —
+   * extra transfer waypoints are ignored (JS LA UI also caps at 2).
+   */
+  it.each<[string, Waypoint[], number, number, number]>([
+    [
+      'two adjacent transfers',
+      [
+        { stationName: '시청', line: '2', kind: 'transfer' },
+        { stationName: '동대문', line: '1', kind: 'transfer' },
+        { stationName: '강남', line: '4', kind: 'destination' },
+      ],
+      1, // stopsToTransfer
+      1, // stopsToSecondTransfer
+      1, // stopsAfterLastTransfer
+    ],
+    [
+      'two transfers with intermediates between',
+      [
+        { stationName: 'A', line: '2', kind: 'intermediate' },
+        { stationName: '시청', line: '2', kind: 'transfer' },
+        { stationName: 'C', line: '1', kind: 'intermediate' },
+        { stationName: '동대문', line: '1', kind: 'transfer' },
+        { stationName: 'E', line: '4', kind: 'intermediate' },
+        { stationName: 'F', line: '4', kind: 'intermediate' },
+        { stationName: '강남', line: '4', kind: 'destination' },
+      ],
+      2,
+      2,
+      3,
+    ],
+    [
+      'three transfers — only first two surface',
+      [
+        { stationName: '시청', line: '2', kind: 'transfer' },
+        { stationName: '동대문', line: '1', kind: 'transfer' },
+        { stationName: '왕십리', line: '4', kind: 'transfer' },
+        { stationName: '강남', line: '5', kind: 'destination' },
+      ],
+      1,
+      1,
+      2,
+    ],
+  ])(
+    'multi-transfer (%s) → stopsToTransfer=%i, stopsToSecondTransfer=%i, stopsAfterLastTransfer=%i',
+    (_label, waypoints, expectedTo, expectedToSecond, expectedAfterLast) => {
+      const ctx = computeMultiHopContext(makeTrip(waypoints));
+      expect(ctx.transferStationName).toBe('시청');
+      expect(ctx.secondTransferStationName).toBe('동대문');
+      expect(ctx.stopsToTransfer).toBe(expectedTo);
+      expect(ctx.stopsToSecondTransfer).toBe(expectedToSecond);
+      expect(ctx.stopsAfterLastTransfer).toBe(expectedAfterLast);
+      expect(ctx.stopsFromTransfer).toBeUndefined();
+      expect(ctx.destinationName).toBe('강남');
+    },
+  );
+
+  /**
+   * Defensive scanning — `destinationName` extraction walks waypoints from the tail and picks
+   * the last waypoint with `kind='destination'`. Normally exactly one and at the tail, but the
+   * scan tolerates schema drift (e.g. backfilled intermediates after the destination).
+   */
+  it('defensive destination scan — picks last destination even if not at tail', () => {
+    const ctx = computeMultiHopContext(
+      makeTrip([
+        { stationName: '강남', line: '2', kind: 'destination' },
+        { stationName: '잘못된역', line: '2', kind: 'intermediate' },
+      ]),
+    );
+    expect(ctx.destinationName).toBe('강남');
+  });
+
+  /**
+   * Waypoints with no `destination` kind at all (edge case — should not happen but graceful).
+   * Returns undefined `destinationName` rather than crashing.
+   */
+  it('returns undefined destinationName when no destination waypoint present', () => {
+    const ctx = computeMultiHopContext(
+      makeTrip([{ stationName: 'A', line: '2', kind: 'intermediate' }]),
+    );
+    expect(ctx.destinationName).toBeUndefined();
+  });
+});

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -21,6 +21,10 @@ import {
 import { pickApnsHost, sendWithEnvHeal } from './apnsHost';
 import { LINE_META } from './lineAlias';
 import { deleteProgress } from './progress';
+import {
+  computeMultiHopContext,
+  type MultiHopContext,
+} from './tripMultiHop';
 import { deleteTrip } from './trips';
 import type { ApnsEnv, Env, Trip, TripEndedReason, Waypoint } from './types';
 import { writeTripEndedStatus } from './tripStatus';
@@ -75,14 +79,20 @@ export interface LiveActivityDeps {
  * alarmType은 채우지 않는다 — backend는 알람을 트리거하지 않고(디바이스 사전 예약, #584) 정보 갱신만 함.
  * widget의 긴급 모드(LockScreenView.isUrgent)는 alarmType 존재로 판정하므로, polling 정정마다
  * 긴급 UI가 강제되지 않도록 omit. 알람 트리거 시점의 별도 텍스트 push에서 채우는 것이 정상 경로.
+ *
+ * `trip` 인자 (#1618 R9-b) — 채워주면 multi-hop 필드(destinationName / transferStationName /
+ * stopsToTransfer / secondTransferStationName / stopsAfterLastTransfer / stopsToSecondTransfer /
+ * stopsFromTransfer)를 함께 emit해 ActivityKit 전체 교체 후도 JS init이 채운 "전체 trip 여정"
+ * UI가 유지된다. 누락 시 (legacy 호출) 기존 5 필드만 emit — 회귀 0 / backward compat.
  */
 export function buildLiveActivityContentState(
   waypoint: Waypoint,
   etaSeconds: number,
   stopsRemaining: number,
+  trip?: Trip,
 ): LiveActivityContentState {
   const meta = LINE_META[waypoint.line];
-  return {
+  const base: LiveActivityContentState = {
     stationName: waypoint.stationName,
     // LINE_META는 13개 노선을 모두 커버하지만, stations.json에 없는 신규 line code가 들어와도
     // widget의 non-optional 필드가 비지 않도록 raw line code를 fallback으로 사용한다.
@@ -91,7 +101,15 @@ export function buildLiveActivityContentState(
     stopsRemaining,
     etaMinutes: Math.max(0, Math.round(etaSeconds / 60)),
   };
+  if (!trip) return base;
+  // multi-hop optional 필드는 존재하는 것만 spread — undefined assignment를 피해 기존 5 필드
+  // toEqual 단언과 ActivityKit content-state diff 모두 깔끔.
+  const multiHop = computeMultiHopContext(trip);
+  return { ...base, ...multiHop };
 }
+
+/** Re-export for callers/tests that want the helper signature explicitly. */
+export type { MultiHopContext };
 
 export interface LiveActivityFireResult {
   /** trip의 activityPushToken/activityState가 변경되어 putTrip이 필요한지. */

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -21,13 +21,13 @@ import {
 import { pickApnsHost, sendWithEnvHeal } from './apnsHost';
 import { LINE_META } from './lineAlias';
 import { deleteProgress } from './progress';
-import {
-  computeMultiHopContext,
-  type MultiHopContext,
-} from './tripMultiHop';
+import { computeMultiHopContext } from './tripMultiHop';
 import { deleteTrip } from './trips';
 import type { ApnsEnv, Env, Trip, TripEndedReason, Waypoint } from './types';
 import { writeTripEndedStatus } from './tripStatus';
+
+// S7763 — direct re-export avoids local rebinding when only forwarding the type.
+export type { MultiHopContext } from './tripMultiHop';
 
 /**
  * stale-date까지 클라이언트가 last content-state를 신뢰할 수 있는 시간(초).
@@ -107,9 +107,6 @@ export function buildLiveActivityContentState(
   const multiHop = computeMultiHopContext(trip);
   return { ...base, ...multiHop };
 }
-
-/** Re-export for callers/tests that want the helper signature explicitly. */
-export type { MultiHopContext };
 
 export interface LiveActivityFireResult {
   /** trip의 activityPushToken/activityState가 변경되어 putTrip이 필요한지. */

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -2210,6 +2210,7 @@ export async function advanceBoardingLockWaypoint(
       nextWaypoint,
       0,
       trip.waypoints.length,
+      trip,
     );
     await fireLiveActivityUpdate(trip, contentState, deps, stats, now, log, nextWaypoint.kind);
   }
@@ -2258,6 +2259,7 @@ export async function maybeFireLiveActivityUpdate(
     waypoint,
     etaSeconds,
     trip.waypoints.length,
+    trip,
   );
   const result = await fireLiveActivityUpdate(trip, contentState, deps, stats, now, log, waypoint.kind);
   if (result.dirty) {

--- a/backend/alarm-worker/src/tripMultiHop.ts
+++ b/backend/alarm-worker/src/tripMultiHop.ts
@@ -1,0 +1,99 @@
+/**
+ * Multi-hop context derivation for Live Activity content-state (#1618 R9-b).
+ *
+ * Mirrors JS-side `buildLiveActivityData` (src/features/alarm/utils/stationNotification.ts:278)
+ * which populates `destinationName / transferStationName / stopsToTransfer / stopsFromTransfer /
+ * secondTransferStationName / stopsToSecondTransfer / stopsAfterLastTransfer` from a
+ * `DirectRoute | TransferRoute | MultiTransferRoute`. The backend cron path historically only
+ * wrote `stationName / lineName / lineColorHex / stopsRemaining / etaMinutes`, so the very first
+ * APNs Live Activity update push wiped the multi-hop chain that JS init had stamped — leaving
+ * the user with only the destination visible on the lock screen (#1618 evidence).
+ *
+ * Data source choice: `trip.waypoints` (not `trip.route`).
+ *
+ * `trip.waypoints` is the **shifted SSOT** — backend `advanceBoardingLockWaypoint` /
+ * `runLocklessIntermediate` pop the head as the user passes stations, so it always reflects the
+ * remaining station-pass events ahead. Each waypoint is one station-pass (intermediate / transfer
+ * / destination). Index N in the remaining array means "N+1 stations from now" — the very next
+ * station is index 0 and counts as 1 stop. This matches the JS semantics where
+ * `route.stopsToTransfer` shrinks as the nearest station advances.
+ *
+ * `trip.route` would also work but holds the **original** route (never shifts) — using it would
+ * require deriving "remaining" from cross-referencing waypoints anyway, which is what we already do.
+ */
+
+import type { Trip } from './types';
+
+/** Multi-hop snapshot derived from a trip's remaining waypoints. */
+export interface MultiHopContext {
+  /** Final destination station name (last waypoint with kind='destination'). */
+  destinationName?: string;
+  /** First transfer station name ahead, if any. */
+  transferStationName?: string;
+  /** Stations to pass before reaching the first transfer (1-based; 1 = transfer is the very next stop). */
+  stopsToTransfer?: number;
+  /** Second transfer station name ahead (multi-transfer trips). */
+  secondTransferStationName?: string;
+  /** Stations to pass between first and second transfer (1-based). */
+  stopsToSecondTransfer?: number;
+  /** Stations to pass between the last transfer and the destination. */
+  stopsAfterLastTransfer?: number;
+  /** Stations to pass from the first transfer to the destination (single-transfer trips). */
+  stopsFromTransfer?: number;
+}
+
+/**
+ * Derive multi-hop context from a trip's remaining waypoints array.
+ *
+ * Returns an empty object for trips with no waypoints (effectively arrived). All fields are
+ * optional — direct trips populate only `destinationName`, single-transfer trips add
+ * `transferStationName` + `stopsToTransfer` + `stopsFromTransfer`, multi-transfer trips
+ * additionally populate `secondTransferStationName` + `stopsToSecondTransfer` +
+ * `stopsAfterLastTransfer`.
+ */
+export function computeMultiHopContext(trip: Trip): MultiHopContext {
+  const waypoints = trip.waypoints;
+  if (waypoints.length === 0) return {};
+
+  const ctx: MultiHopContext = {};
+
+  // Destination: the last waypoint with kind='destination'. There is normally exactly one and it
+  // sits at the tail, but we scan defensively (handles future schema where intermediate could
+  // wrap a destination — graceful for an edge case rather than tightly coupling to position).
+  for (let i = waypoints.length - 1; i >= 0; i--) {
+    if (waypoints[i].kind === 'destination') {
+      ctx.destinationName = waypoints[i].stationName;
+      break;
+    }
+  }
+
+  // Transfers: first two transfer waypoints in order. JS-side `buildLiveActivityData` only
+  // surfaces up to two transfers (MultiTransferRoute), so we cap accordingly.
+  const transferIndices: number[] = [];
+  for (let i = 0; i < waypoints.length; i++) {
+    if (waypoints[i].kind === 'transfer') {
+      transferIndices.push(i);
+      if (transferIndices.length === 2) break;
+    }
+  }
+
+  if (transferIndices.length >= 1) {
+    const firstIdx = transferIndices[0];
+    ctx.transferStationName = waypoints[firstIdx].stationName;
+    // 1-based: index 0 = next stop = 1 station to pass.
+    ctx.stopsToTransfer = firstIdx + 1;
+
+    if (transferIndices.length === 2) {
+      const secondIdx = transferIndices[1];
+      ctx.secondTransferStationName = waypoints[secondIdx].stationName;
+      ctx.stopsToSecondTransfer = secondIdx - firstIdx;
+      // Multi-transfer: stops from second (last) transfer to the end (destination inclusive).
+      ctx.stopsAfterLastTransfer = waypoints.length - 1 - secondIdx;
+    } else {
+      // Single-transfer: stops from the transfer to the end (destination inclusive).
+      ctx.stopsFromTransfer = waypoints.length - 1 - firstIdx;
+    }
+  }
+
+  return ctx;
+}


### PR DESCRIPTION
Closes #1618

## 다운로드 가치
V1 시각 채널 (LA "전체 trip 여정") 회복. 사용자 evidence (2026-06-19 15:51) "LA가 전체 trip 여정 X, 도착지만 ui로 표시" 직접 fix.

ActivityKit content-state는 update 시 **전체 교체** → backend가 multi-hop 필드를 누락하면 JS init이 stamp한 transfer/destination chain이 첫 backend push에 wipe.

## 변경 3 Phase (atomic, 1 commit)

### Phase A — backend `buildLiveActivityContentState` multi-hop 5 필드 추가
- 신규 4번째 `trip?: Trip` 인자. 전달 시 multi-hop spread, 미전달 시 base 5 필드만 emit (backward-compat)
- 호출자 wiring: `scheduled.ts` advanceBoardingLockWaypoint + maybeFireLiveActivityUpdate 양쪽에 `trip` 전달

### Phase B — Type 정합성
- **별도 코드 변경 없음** (이미 정합 상태):
  - TS `LiveActivityContentState` = `[key: string]: unknown` (apns.ts:607) — 신규 필드 자유 spread
  - Swift `SubwayActivityAttributes.ContentState` (targets/subway-widget/_shared + modules/live-activity/ios mirror) — 7개 multi-hop 필드 모두 optional declare 완료
  - device `LiveActivityData` interface (modules/live-activity/index.ts) — 동형

### Phase C — `computeMultiHopContext(trip)` helper 신규 (tripMultiHop.ts)
- `trip.waypoints` (shifted SSOT) 에서 destination / 첫 transfer / 두 번째 transfer 추출
- stops 산출: `stopsToTransfer = firstTransferIdx + 1` (1-based, next stop = 1) / `stopsFromTransfer = waypoints.length - 1 - firstIdx` (single-transfer) / `stopsAfterLastTransfer = waypoints.length - 1 - secondIdx` (multi-transfer)
- JS-side `buildLiveActivityData`의 MultiTransferRoute schema 와 1:1 정합 (transfer 최대 2개 surface)

## Wire-completion 5단
1. **Orphan**: pass (`npm run lint:orphan` 0 orphan)
2. **V/X dashboard**: V1 시각 (LA 전체 여정) + V6 (위치 변화 빠른 반영)
3. **의존 PR**: Stage 1/2/3-1 머지 완료, 독립 PR
4. **측정 plan**: 1주 production. 사용자 LA 캡처 evidence (transfer chain 표시 유지 확인)
5. **Device verify**: 사용자 실기기 LA 활성 trip 1주

## 테스트
- backend type-check: 0 error (PR diff 기준; pre-existing TS2304 KVNamespace는 advanceTripPosition.test.ts에 #1573 머지 이전부터 존재 — 본 PR 무관)
- backend full suite: **1859 tests pass** (50 test files)
- device full suite: **7264 tests pass** (359 test files), coverage **100%**
- 신규 단위 테스트: **18개**
  - tripMultiHop.test.ts: 11 tests (it.each + makeTrip helper)
  - liveActivity.test.ts multi-hop describe: 7 tests
- SonarCloud dup 사전 차단: it.each + factory helper 적용

## 자가 점검 5단 (시니어 review 시뮬레이션)
1. **acceptance self-referential?** 사용자 LA 캡처 = 사용자 annotation → 측정 가능
2. **Wire-completion CI?** pass — orphan 0 (helper는 liveActivity.ts에서 import)
3. **머지 순서?** 독립 — Stage 1/2/3-1 의존 머지 완료
4. **backward-compat?** trip 인자 optional. 미전달 = 기존 5 필드만. 기존 toEqual 단언 36 tests 그대로 pass
5. **False positive new?** multi-hop 계산 정확도 — direct / single / multi / off-by-one / 빈 waypoints / defensive scan 모두 단위 테스트로 가드

## Self-review
- Swift attributes 정합성 — TS `LiveActivityContentState` open type + Swift Codable optional decoding으로 양방향 안전. 신규 필드 7개 모두 Swift에 이미 declare (코드 변경 0)
- multi-hop 계산 정확도 (transfer 2회+) — 단위 테스트 (multi-transfer 3 케이스) + JS-side 1:1 정합 검토
- LA payload 4KB 한도 — 신규 필드 모두 optional + 짧은 한국어 문자열 (역명 2-4자 × 2개 + Int × 3개). 기존 페이로드 대비 ~50바이트 증가 추정, 4KB 여유 충분