### PR TITLE
feat(#1542): S9 — CMMotionManager accelerometer fingerprint native module (V1 BG 지하 천장 70→90%)

### DIFF
--- a/modules/accelerometer-fingerprint/AccelerometerFingerprint.podspec
+++ b/modules/accelerometer-fingerprint/AccelerometerFingerprint.podspec
@@ -1,0 +1,17 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'AccelerometerFingerprint'
+  s.version        = package['version']
+  s.summary        = 'CMMotionManager raw accelerometer fingerprint for subway-now lockless BG underground (#1542)'
+  s.homepage       = 'https://github.com/handokei/subway-now'
+  s.license        = 'MIT'
+  s.author         = 'subway-now'
+  s.platform       = :ios, '15.1'
+  s.source         = { path: '.' }
+  s.source_files   = 'ios/**/*.swift'
+  s.frameworks     = 'CoreMotion'
+  s.dependency 'ExpoModulesCore'
+end

--- a/modules/accelerometer-fingerprint/expo-module.config.json
+++ b/modules/accelerometer-fingerprint/expo-module.config.json
@@ -1,0 +1,7 @@
+{
+  "platforms": ["ios"],
+  "ios": {
+    "modules": ["AccelerometerFingerprintModule"],
+    "podspecPath": "AccelerometerFingerprint.podspec"
+  }
+}

--- a/modules/accelerometer-fingerprint/index.ts
+++ b/modules/accelerometer-fingerprint/index.ts
@@ -1,0 +1,7 @@
+import { requireOptionalNativeModule } from 'expo-modules-core';
+
+const AccelerometerFingerprintModule =
+  // jest/web/Android/미지원 디바이스: null → JS wrapper(src/features/nearest-station/utils/accelerometerFingerprint.ts)가 graceful fallback.
+  requireOptionalNativeModule('AccelerometerFingerprint');
+
+export default AccelerometerFingerprintModule;

--- a/modules/accelerometer-fingerprint/ios/AccelerometerFingerprintModule.swift
+++ b/modules/accelerometer-fingerprint/ios/AccelerometerFingerprintModule.swift
@@ -1,0 +1,202 @@
+import ExpoModulesCore
+import CoreMotion
+import Foundation
+
+/**
+ * #1542 (ADR-016 S9) — CMMotionManager raw accelerometer fingerprint for lockless BG underground.
+ *
+ * V1 BG 지하 천장 70 → 90% (Transit App 90% / SubwayPS 학술 85% baseline).
+ *
+ * 원리:
+ *   - `CMMotionManager.accelerometerUpdates`는 Background Location piggyback으로 BG에서도 수신 가능
+ *     (Apple Core Motion 공식: location updates 활성 동안 raw 가속도 계속 흐름)
+ *   - 5Hz sampling rate (Transit App pattern, accelerometerUpdateInterval = 0.2s) — 진동 fingerprint
+ *     추출 + 배터리 합리적 (BG에서 100Hz는 V8 배터리 임계 위반)
+ *   - 60s sliding window RMS magnitude로 train automotive / walking / stationary 패턴 분류
+ *   - native가 latest snapshot 캐시 → JS layer가 `getLatestSnapshot()`으로 polling 조회
+ *
+ * BG 호환:
+ *   - `startAccelerometerUpdates(to: OperationQueue)`로 OperationQueue 명시 — `.main` 사용 시
+ *     BG에서 main RunLoop이 suspend되며 callback drop. `OperationQueue()` 신규 queue로 BG 안전.
+ *   - `useAccelerometer` (#823 expo-sensors)와 별 lifecycle — expo-sensors는 BG drop. 본 모듈은
+ *     Background Location 활성 동안만 의미 있는 BG accelerometer 수신을 보장 (호출자가 lifecycle 관리).
+ *
+ * Graceful 정책:
+ *   - 미지원 디바이스 / 권한 거절 / start 실패 → 모두 no-op + getLatestSnapshot null 반환
+ *   - "모르는 상태"는 vote 미투표로 환경 판정 영향 0 (CLAUDE.md feedback_whileinuse_must_work)
+ *
+ * 분류 임계 (generic, 학습 데이터 없으니 보수적):
+ *   - stationary  : RMS < 0.3 m/s² (정지 — 주머니 안 정적 사용자)
+ *   - walking     : 0.3 ≤ RMS < 2.0 m/s² (도보 cadence 0.5~2Hz, peak 2~4 m/s²)
+ *   - automotive  : RMS ≥ 2.0 m/s² (train 가속/감속 / 진동, peak 5~10 m/s²)
+ *   - unknown     : 샘플 부족 (60s window 50개 미만)
+ */
+public class AccelerometerFingerprintModule: Module {
+    private let motionManager = CMMotionManager()
+    /** BG-safe queue. main queue는 BG에서 RunLoop 정지로 callback drop. */
+    private let queue: OperationQueue = {
+        let q = OperationQueue()
+        q.name = "com.subwaynow.accelerometer-fingerprint"
+        q.maxConcurrentOperationCount = 1
+        return q
+    }()
+    /**
+     * 60s sliding window — RMS magnitude 추출용. 1초 5 sample × 60s = 300 capacity (안전 여유).
+     * lock으로 다중 스레드 접근(JS thread vs accelerometer queue) 보호.
+     */
+    private var samples: [SampleRecord] = []
+    private let samplesLock = NSLock()
+    private var isUpdating: Bool = false
+
+    /** 5Hz sampling — Transit App pattern. 0.2s interval. */
+    private static let SAMPLE_INTERVAL_SEC: TimeInterval = 0.2
+    /** 60s window. RMS 추출 + 패턴 분류 sample 모집 기간. */
+    private static let WINDOW_DURATION_SEC: TimeInterval = 60.0
+    /** 분류 신뢰 최소 sample 수 — 60s × 5Hz = 300 기대, 50 미달 시 unknown. */
+    private static let MIN_SAMPLES_FOR_CLASSIFY: Int = 50
+
+    /** stationary 임계 — RMS m/s² 단위. */
+    private static let STATIONARY_RMS_MAX: Double = 0.3
+    /** walking 상한 — RMS m/s². 도보 cadence는 일반적으로 0.3~2 m/s² 범위. */
+    private static let WALKING_RMS_MAX: Double = 2.0
+
+    public func definition() -> ModuleDefinition {
+        Name("AccelerometerFingerprint")
+
+        Function("isAvailable") { () -> Bool in
+            return self.motionManager.isAccelerometerAvailable
+        }
+
+        Function("start") {
+            self.startUpdates()
+        }
+
+        Function("stop") {
+            self.stopUpdates()
+        }
+
+        Function("getLatestSnapshot") { () -> [String: Any]? in
+            return self.computeLatestSnapshot()
+        }
+    }
+
+    private func startUpdates() {
+        if self.isUpdating { return }
+        guard self.motionManager.isAccelerometerAvailable else { return }
+        self.motionManager.accelerometerUpdateInterval = AccelerometerFingerprintModule.SAMPLE_INTERVAL_SEC
+        self.motionManager.startAccelerometerUpdates(to: self.queue) { [weak self] data, _ in
+            guard let self = self, let data = data else { return }
+            self.appendSample(data.acceleration)
+        }
+        self.isUpdating = true
+    }
+
+    private func stopUpdates() {
+        if !self.isUpdating { return }
+        self.motionManager.stopAccelerometerUpdates()
+        self.isUpdating = false
+        self.samplesLock.lock()
+        self.samples.removeAll(keepingCapacity: false)
+        self.samplesLock.unlock()
+    }
+
+    /**
+     * CMAcceleration 단위는 g — SI(m/s²)로 즉시 변환 후 보관.
+     * 중력은 sliding window에서 sample 평균 벡터를 중력 가정해 제거 (`computeLatestSnapshot` 내부).
+     */
+    private func appendSample(_ acc: CMAcceleration) {
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000.0)
+        let record = SampleRecord(
+            tMs: nowMs,
+            x: acc.x * AccelerometerFingerprintModule.GRAVITY_MS2,
+            y: acc.y * AccelerometerFingerprintModule.GRAVITY_MS2,
+            z: acc.z * AccelerometerFingerprintModule.GRAVITY_MS2
+        )
+        self.samplesLock.lock()
+        self.samples.append(record)
+        // 60s window 밖은 trim — 무한 적재 방지.
+        let cutoffMs = nowMs - Int64(AccelerometerFingerprintModule.WINDOW_DURATION_SEC * 1000.0)
+        while let first = self.samples.first, first.tMs < cutoffMs {
+            self.samples.removeFirst()
+        }
+        self.samplesLock.unlock()
+    }
+
+    /**
+     * 60s window의 sample을 snapshot으로 압축. JS layer가 polling으로 조회한다.
+     *
+     * 반환 형태 (JS interface `AccelerometerSnapshot`와 1:1):
+     *   - timestamp: epoch ms (snapshot 생성 시각)
+     *   - rmsMagnitude: 중력 제거 후 linear acceleration RMS (m/s²)
+     *   - patternClass: 'stationary' | 'walking' | 'automotive' | 'unknown'
+     *   - sampleCount: window 내 sample 수
+     */
+    private func computeLatestSnapshot() -> [String: Any]? {
+        self.samplesLock.lock()
+        let snapshot = self.samples
+        self.samplesLock.unlock()
+
+        let count = snapshot.count
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000.0)
+
+        if count < AccelerometerFingerprintModule.MIN_SAMPLES_FOR_CLASSIFY {
+            return [
+                "timestamp": nowMs,
+                "rmsMagnitude": 0.0,
+                "patternClass": "unknown",
+                "sampleCount": count
+            ]
+        }
+
+        // 중력 벡터 = window 평균 (60s 동안 디바이스 자세 거의 일정 가정).
+        var sumX = 0.0
+        var sumY = 0.0
+        var sumZ = 0.0
+        for r in snapshot {
+            sumX += r.x
+            sumY += r.y
+            sumZ += r.z
+        }
+        let nDouble = Double(count)
+        let gravityX = sumX / nDouble
+        let gravityY = sumY / nDouble
+        let gravityZ = sumZ / nDouble
+
+        // Linear acceleration magnitude RMS — 중력 제거 후 진동 강도.
+        var sumSq = 0.0
+        for r in snapshot {
+            let lx = r.x - gravityX
+            let ly = r.y - gravityY
+            let lz = r.z - gravityZ
+            sumSq += lx * lx + ly * ly + lz * lz
+        }
+        let rms = sqrt(sumSq / nDouble)
+
+        let patternClass: String
+        if rms < AccelerometerFingerprintModule.STATIONARY_RMS_MAX {
+            patternClass = "stationary"
+        } else if rms < AccelerometerFingerprintModule.WALKING_RMS_MAX {
+            patternClass = "walking"
+        } else {
+            patternClass = "automotive"
+        }
+
+        return [
+            "timestamp": nowMs,
+            "rmsMagnitude": rms,
+            "patternClass": patternClass,
+            "sampleCount": count
+        ]
+    }
+
+    /** 표준 중력가속도 (m/s²) — 1g → SI. */
+    private static let GRAVITY_MS2: Double = 9.80665
+
+    /** 단일 sample record. SampleBuffer entry. */
+    private struct SampleRecord {
+        let tMs: Int64
+        let x: Double
+        let y: Double
+        let z: Double
+    }
+}

--- a/modules/accelerometer-fingerprint/package.json
+++ b/modules/accelerometer-fingerprint/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "accelerometer-fingerprint",
+  "version": "1.0.0",
+  "main": "index.ts"
+}

--- a/src/features/nearest-station/hooks/__tests__/useAccelerometerFingerprint.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useAccelerometerFingerprint.test.ts
@@ -1,0 +1,106 @@
+/**
+ * #1542 (ADR-016 S9) — useAccelerometerFingerprint 훅 테스트.
+ *
+ * 동작:
+ *   1. mount 시 isAccelerometerFingerprintSupported가 true면 startAccelerometerFingerprint
+ *   2. 5s 폴링으로 getLatestAccelerometerSnapshot → classifyAccelerometerPattern 결과 sync
+ *   3. 미지원 시 pattern='unknown'으로 확정 (start/stop 호출 안 함)
+ *   4. unmount 시 stopAccelerometerFingerprint
+ */
+
+const mockSupported = jest.fn();
+const mockStart = jest.fn();
+const mockStop = jest.fn();
+const mockGetSnapshot = jest.fn();
+
+jest.mock('../../utils/accelerometerFingerprint', () => {
+  const actual = jest.requireActual('../../utils/accelerometerFingerprint');
+  return {
+    ...actual,
+    isAccelerometerFingerprintSupported: () => mockSupported(),
+    startAccelerometerFingerprint: () => mockStart(),
+    stopAccelerometerFingerprint: () => mockStop(),
+    getLatestAccelerometerSnapshot: () => mockGetSnapshot(),
+  };
+});
+
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { useAccelerometerFingerprint } from '../useAccelerometerFingerprint';
+import type { AccelerometerSnapshot } from '../../utils/accelerometerFingerprint';
+
+function makeSnapshot(
+  patternClass: AccelerometerSnapshot['patternClass'],
+  rmsMagnitude: number = 0.5,
+): AccelerometerSnapshot {
+  return {
+    timestamp: 1_700_000_000_000,
+    rmsMagnitude,
+    patternClass,
+    sampleCount: 200,
+  };
+}
+
+describe('useAccelerometerFingerprint (#1542)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockSupported.mockReset();
+    mockStart.mockReset();
+    mockStop.mockReset();
+    mockGetSnapshot.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('미지원 디바이스 — pattern unknown으로 확정, start/stop 호출 안 함', () => {
+    mockSupported.mockReturnValue(false);
+    const { result, unmount } = renderHook(() => useAccelerometerFingerprint());
+    expect(result.current).toBe('unknown');
+    expect(mockStart).not.toHaveBeenCalled();
+    unmount();
+    expect(mockStop).not.toHaveBeenCalled();
+  });
+
+  it('지원 — automotive snapshot 시 automotive pattern', async () => {
+    mockSupported.mockReturnValue(true);
+    mockGetSnapshot.mockReturnValue(makeSnapshot('automotive', 3.5));
+
+    const { result } = renderHook(() => useAccelerometerFingerprint());
+    await waitFor(() => expect(result.current).toBe('automotive'));
+    expect(mockStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('지원 — stationary → automotive 전환 시 다음 폴링에서 채택', async () => {
+    mockSupported.mockReturnValue(true);
+    mockGetSnapshot.mockReturnValue(makeSnapshot('stationary', 0.1));
+
+    const { result } = renderHook(() => useAccelerometerFingerprint());
+    await waitFor(() => expect(result.current).toBe('stationary'));
+
+    // train 출발 — 진동 RMS 상승
+    mockGetSnapshot.mockReturnValue(makeSnapshot('automotive', 3.0));
+    act(() => {
+      jest.advanceTimersByTime(5_000);
+    });
+    await waitFor(() => expect(result.current).toBe('automotive'));
+  });
+
+  it('지원 — native null 반환 시 unknown', async () => {
+    mockSupported.mockReturnValue(true);
+    mockGetSnapshot.mockReturnValue(null);
+
+    const { result } = renderHook(() => useAccelerometerFingerprint());
+    await waitFor(() => expect(result.current).toBe('unknown'));
+  });
+
+  it('unmount 시 stopAccelerometerFingerprint 호출 (cleanup)', async () => {
+    mockSupported.mockReturnValue(true);
+    mockGetSnapshot.mockReturnValue(makeSnapshot('walking', 1.2));
+
+    const { unmount } = renderHook(() => useAccelerometerFingerprint());
+    await waitFor(() => expect(mockStart).toHaveBeenCalled());
+    unmount();
+    expect(mockStop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/nearest-station/hooks/useAccelerometerFingerprint.ts
+++ b/src/features/nearest-station/hooks/useAccelerometerFingerprint.ts
@@ -1,0 +1,63 @@
+/**
+ * #1542 (ADR-016 S9) — CMMotionManager accelerometer fingerprint React hook.
+ *
+ * 동작:
+ *   1. mount 시 `isAccelerometerFingerprintSupported` 확인 → true면 `startAccelerometerFingerprint`
+ *   2. 폴링(5s)으로 native가 캐시한 최신 60s window snapshot을 sync → pattern 분류
+ *   3. 미지원/예외 케이스는 'unknown'으로 확정 — 호출자는 vote 미투표로 인식
+ *   4. unmount 시 `stopAccelerometerFingerprint`로 cleanup
+ *
+ * 폴링 간격(5s): native는 5Hz raw sample을 60s window에 누적 → 60s window가 첫 수렴까지 ~60초
+ *   걸린다. 5s 폴링이면 첫 자동 분류 시점 이후 매 cycle마다 freshness 충분 (useMotionActivity /
+ *   useCellularTech와 같은 주기 — 알람 평가 30s보다 짧다).
+ *
+ * BG 호환:
+ *   - 본 FG hook은 mount/unmount lifecycle 동안만 active. expo-sensors `useAccelerometer`(#823)와
+ *     별 lifecycle — 본 hook은 native CMMotionManager 기반이라 Background Location piggyback과
+ *     호환된다 (BG task가 `startAccelerometerFingerprint`를 별 호출해 BG 동안 유지).
+ *
+ * 반환:
+ *   - 'unknown' (default / 미지원 / 60s window 미수렴)
+ *   - 'stationary' (정적 사용자, RMS < 0.3 m/s²)
+ *   - 'walking' (도보, 0.3 ≤ RMS < 2.0 m/s²)
+ *   - 'automotive' (train 진동, RMS ≥ 2.0 m/s²) — undergroundSSotConsensus env vote 1표
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  classifyAccelerometerPattern,
+  getLatestAccelerometerSnapshot,
+  isAccelerometerFingerprintSupported,
+  startAccelerometerFingerprint,
+  stopAccelerometerFingerprint,
+  type AccelerometerPattern,
+} from '../utils/accelerometerFingerprint';
+
+/** 폴링 주기 — `useCellularTech` / `useMotionActivity`와 동일 (5s). 알람 평가 30s보다 짧다. */
+const POLL_INTERVAL_MS = 5_000;
+
+export function useAccelerometerFingerprint(): AccelerometerPattern {
+  const [pattern, setPattern] = useState<AccelerometerPattern>('unknown');
+
+  useEffect(() => {
+    if (!isAccelerometerFingerprintSupported()) {
+      // 미지원(Android/jest/web/iOS 시뮬레이터 일부) — vote 미투표 확정.
+      setPattern('unknown');
+      return;
+    }
+    startAccelerometerFingerprint();
+
+    // 초기 1회 + 인터벌 폴링. native가 cache한 최신 snapshot을 sync.
+    setPattern(classifyAccelerometerPattern(getLatestAccelerometerSnapshot()));
+    const intervalId = setInterval(() => {
+      setPattern(classifyAccelerometerPattern(getLatestAccelerometerSnapshot()));
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      clearInterval(intervalId);
+      stopAccelerometerFingerprint();
+    };
+  }, []);
+
+  return pattern;
+}

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -16,6 +16,7 @@ import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
 import { pushEstimatorEntry } from '../../route/utils/estimatorDebugBuffer';
 import { useNearestStation } from './useNearestStation';
 import { useCellularTech } from './useCellularTech';
+import { useAccelerometerFingerprint } from './useAccelerometerFingerprint';
 import { useArrivalInfo } from '../../arrival/hooks/useArrivalInfo';
 import { useTrainPositions } from '../../route/hooks/useTrainPositions';
 import { useRouteProgress } from '../../route/hooks/useRouteProgress';
@@ -386,6 +387,12 @@ export function useFusedNearestStation(
   // (CTServiceRadioAccessTechnologyDidChangeNotification observer). underground SSOT 4-signal
   // 합의의 환경-확정 vote로 사용. 미지원(Android/jest/web) 시 'unknown' 고정 → vote 미투표.
   const cellularEnvironmentVote = useCellularTech();
+
+  // #1542 (ADR-016 S9) — CMMotionManager raw accelerometer 60s window RMS magnitude 분류.
+  // 'automotive' (RMS ≥ 2.0 m/s²)이면 train 진동 환경 vote 1표 — undergroundSSotConsensus 5번째 signal.
+  // BG location piggyback (backgroundLocationTask가 별 start 호출)로 BG에서도 동작.
+  // V1 BG 지하 천장 70 → 90% (Transit App 90% / SubwayPS 학술 85% baseline).
+  const accelerometerPattern = useAccelerometerFingerprint();
 
   // #1568 (T8b, Epic ADR-017 #1553) — backend SSoT mirror 폴링.
   //
@@ -931,6 +938,9 @@ export function useFusedNearestStation(
     // barometerSignal.stop=undefined(warmup) / cellular 'unknown'은 vote 미투표.
     barometerStop: barometerSignal?.stop,
     cellularEnvironmentVote,
+    // #1542 (ADR-016 S9) — accelerometer fingerprint env vote. 'automotive' = train 진동 1표,
+    // 'stationary'/'walking'/'unknown'은 vote 미투표. 미지원/warmup 60s 동안 'unknown' fallback.
+    accelerometerPattern,
   });
   const environment: Environment = inferEnvironment({
     subsurface: barometerSubsurface,

--- a/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
@@ -64,6 +64,17 @@ jest.mock('../../utils/accelMotionState', () => ({
   getLatestAccelSummary: () => mockGetLatestAccelSummary(),
 }));
 
+// ── accelerometerFingerprint 모킹 (#1542 BG location piggyback) ──
+// classifyAccelerometerPattern은 helper; default 'unknown' 반환으로 기존 motion stationary fallback 동작.
+const mockStartAccelerometerFingerprint = jest.fn();
+const mockGetLatestAccelerometerSnapshot = jest.fn();
+const mockClassifyAccelerometerPattern = jest.fn();
+jest.mock('../../utils/accelerometerFingerprint', () => ({
+  startAccelerometerFingerprint: () => mockStartAccelerometerFingerprint(),
+  getLatestAccelerometerSnapshot: () => mockGetLatestAccelerometerSnapshot(),
+  classifyAccelerometerPattern: (snapshot: unknown) => mockClassifyAccelerometerPattern(snapshot),
+}));
+
 // ── widgetStorage 모킹 (#1237 Phase 2) ──
 const mockSaveStationToWidget = jest.fn();
 jest.mock('../../../widget/api/widgetStorage', () => ({
@@ -196,6 +207,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     mockUploadPosition.mockResolvedValue({ ok: true, status: 200 });
     mockGetCurrentMotionStationary.mockReturnValue(false);
     mockGetLatestAccelSummary.mockReturnValue(null);
+    mockGetLatestAccelerometerSnapshot.mockReturnValue(null);
+    // 기본: 60s window 미수렴 → 'unknown' (CMMotionActivity fallback 경로 trigger).
+    mockClassifyAccelerometerPattern.mockReturnValue('unknown');
     mockSaveStationToWidget.mockResolvedValue(undefined);
     mockGetBoardingLock.mockResolvedValue(null);
     mockEvaluateBackgroundTransferSwap.mockResolvedValue({ fired: false });
@@ -1105,5 +1119,111 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
       expect(mockEvaluateBackgroundTransferSwap).not.toHaveBeenCalled();
     });
+  });
+
+  describe('#1542 (ADR-016 S9) — accelerometer fingerprint BG piggyback', () => {
+    /** Phase B 전용 token chain — APNS token after storage 4 + BG_LAST_FIX null. */
+    function stubApnsTokenAfterStorage(token: string | null): void {
+      (AsyncStorage.getItem as jest.Mock)
+        .mockResolvedValueOnce(null) // BG_LAST_FIX_KEY — prevFix 없음
+        .mockResolvedValueOnce(token); // APNS_TOKEN_KEY
+    }
+
+    it('apnsToken 있으면 BG fingerprint start 호출 (Background Location piggyback)', async () => {
+      mockStorageValues(JSON.stringify(mockDestination));
+      stubApnsTokenAfterStorage('apns-tok-1');
+
+      const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+      await taskCallback({ data: { locations: [loc] }, error: null });
+
+      expect(mockStartAccelerometerFingerprint).toHaveBeenCalledTimes(1);
+    });
+
+    it('apnsToken 부재면 BG fingerprint start 미호출 (graceful)', async () => {
+      mockStorageValues(JSON.stringify(mockDestination));
+      stubApnsTokenAfterStorage(null);
+
+      const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+      await taskCallback({ data: { locations: [loc] }, error: null });
+
+      expect(mockStartAccelerometerFingerprint).not.toHaveBeenCalled();
+    });
+
+    it.each<'stationary' | 'walking' | 'automotive'>(['stationary', 'walking', 'automotive'])(
+      'accelerometer pattern=%s → motion 필드 그대로 채택 (motionActivity 무시)',
+      async (pattern) => {
+        mockStorageValues(JSON.stringify(mockDestination));
+        stubApnsTokenAfterStorage('apns-tok-1');
+        // motionActivity는 false(이동 중)지만 accelerometer 분류가 우선.
+        mockGetCurrentMotionStationary.mockReturnValue(false);
+        mockClassifyAccelerometerPattern.mockReturnValue(pattern);
+
+        const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+        await taskCallback({ data: { locations: [loc] }, error: null });
+
+        expect(mockUploadPosition).toHaveBeenCalledWith(
+          expect.objectContaining({ motion: pattern }),
+        );
+      },
+    );
+
+    it('accelerometer unknown + motionActivity stationary → motion=stationary (fallback)', async () => {
+      mockStorageValues(JSON.stringify(mockDestination));
+      stubApnsTokenAfterStorage('apns-tok-1');
+      mockGetCurrentMotionStationary.mockReturnValue(true);
+      mockClassifyAccelerometerPattern.mockReturnValue('unknown');
+
+      const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+      await taskCallback({ data: { locations: [loc] }, error: null });
+
+      expect(mockUploadPosition).toHaveBeenCalledWith(
+        expect.objectContaining({ motion: 'stationary' }),
+      );
+    });
+
+    it('accelerometer unknown + motionActivity false → motion=unknown (기존 #819 정책)', async () => {
+      mockStorageValues(JSON.stringify(mockDestination));
+      stubApnsTokenAfterStorage('apns-tok-1');
+      mockGetCurrentMotionStationary.mockReturnValue(false);
+      mockClassifyAccelerometerPattern.mockReturnValue('unknown');
+
+      const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+      await taskCallback({ data: { locations: [loc] }, error: null });
+
+      expect(mockUploadPosition).toHaveBeenCalledWith(
+        expect.objectContaining({ motion: 'unknown' }),
+      );
+    });
+  });
+});
+
+describe('pickMotionLabel (#1542 ADR-016 S9)', () => {
+  // 별 describe — pure helper. backgroundLocationTask scope 외부에서 직접 unit test.
+  // accelerometer pattern이 'unknown'이 아니면 motionActivity stationary 무시 — RMS 60s 진동이
+  // CMMotionActivity의 5~10분 intermittent flip(lesson_motion_activity_intermittent_signal)보다 강.
+  const { pickMotionLabel } = jest.requireActual('../backgroundLocationTask');
+
+  it.each<['stationary' | 'walking' | 'automotive']>([
+    ['stationary'],
+    ['walking'],
+    ['automotive'],
+  ])('accelerometer pattern=%s + motionActivity false → 그대로 그 pattern', (pattern) => {
+    expect(pickMotionLabel(pattern, false)).toBe(pattern);
+  });
+
+  it.each<['stationary' | 'walking' | 'automotive']>([
+    ['stationary'],
+    ['walking'],
+    ['automotive'],
+  ])('accelerometer pattern=%s + motionActivity true → 그대로 그 pattern (accelerometer 우선)', (pattern) => {
+    expect(pickMotionLabel(pattern, true)).toBe(pattern);
+  });
+
+  it('accelerometer unknown + motionActivity true → stationary (fallback)', () => {
+    expect(pickMotionLabel('unknown', true)).toBe('stationary');
+  });
+
+  it('accelerometer unknown + motionActivity false → unknown (기존 #819 정책)', () => {
+    expect(pickMotionLabel('unknown', false)).toBe('unknown');
   });
 });

--- a/src/features/nearest-station/tasks/backgroundLocationTask.ts
+++ b/src/features/nearest-station/tasks/backgroundLocationTask.ts
@@ -20,6 +20,15 @@ import { BG_LAST_FIX_KEY, BG_LAST_STATION_KEY } from '../../../shared/constants/
 import { uploadPosition, type PositionMotion } from '../api/positionUpload';
 import { getCurrentMotionStationary } from '../utils/motionActivity';
 import { getLatestAccelSummary } from '../utils/accelMotionState';
+// #1542 (ADR-016 S9) — CMMotionManager accelerometer fingerprint (Background Location piggyback).
+// BG location updates 활성 동안 raw 가속도 5Hz sampling 시작 — 정적 native module (no-op if already
+// started). position upload 시점에 latest 60s window snapshot을 첨부해 backend가 진동 fingerprint
+// 환경 vote로 사용 + undergroundSSotConsensus가 'automotive' pattern을 1표로 채택.
+import {
+  startAccelerometerFingerprint,
+  getLatestAccelerometerSnapshot,
+  classifyAccelerometerPattern,
+} from '../utils/accelerometerFingerprint';
 import { evaluateMovement } from '../utils/movementGate';
 // #1237 — BG tick에서도 위젯 SSOT(App Groups UserDefaults)를 갱신해 FG 진입 전까지 stale로 남지 않게 한다.
 // cross-feature import는 파일 헤더의 file-level eslint-disable로 옵트인 (orchestrator 본질).
@@ -44,6 +53,29 @@ export const BACKGROUND_LOCATION_TASK = 'background-location-task';
  * FG가 짧게 꺼졌다 다시 켜지는 경우는 허용하면서, 분 단위로 오래된 stale은 차단한다.
  */
 export const ACCEL_SUMMARY_MAX_AGE_MS = 5_000;
+
+/**
+ * #1542 (ADR-016 S9) — accelerometer fingerprint pattern + CMMotionActivity stationary 신호 결합.
+ *
+ * 정책:
+ *   - accelerometer 'stationary' / 'walking' / 'automotive' → 그대로 PositionMotion 라벨 채택
+ *   - accelerometer 'unknown' (60s window 미수렴 / 미지원) → CMMotionActivity fallback
+ *       - motionActivity.stationary=true → 'stationary'
+ *       - 그 외 → 'unknown' (기존 #819 정책)
+ *
+ * 우선순위 이유: 60s window RMS magnitude는 CMMotionActivity의 5~10분 intermittent flip 문제
+ * (lesson_motion_activity_intermittent_signal)를 piggyback BG 실측으로 mitigation한다. 단,
+ * 60s window 미수렴 시(0-60s 첫 cycle) fallback이 안전.
+ *
+ * pure function — 별 파일 분리 없이 backgroundLocationTask scope 내부 helper.
+ */
+export function pickMotionLabel(
+  accelPattern: 'stationary' | 'walking' | 'automotive' | 'unknown',
+  motionStationary: boolean,
+): PositionMotion {
+  if (accelPattern !== 'unknown') return accelPattern;
+  return motionStationary ? 'stationary' : 'unknown';
+}
 
 async function readBgLastFix(): Promise<FixSample | null> {
   try {
@@ -147,7 +179,11 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     // 통과 못 하게 만들 뿐).
     const apnsToken = await AsyncStorage.getItem(APNS_TOKEN_KEY).catch(() => null);
     if (apnsToken) {
-      const motion: PositionMotion = getCurrentMotionStationary() ? 'stationary' : 'unknown';
+      // #1542 (ADR-016 S9) — Background Location piggyback: BG task가 호출될 때마다
+      // accelerometer fingerprint start를 no-op 보장으로 호출. native 모듈이 isUpdating 가드를
+      // 갖고 있어 한 번만 시작되며, 이후 BG location updates 활성 동안 raw 가속도 5Hz가 계속 흐른다.
+      // 미지원/실패는 graceful (snapshot 조회가 null로 fallback).
+      startAccelerometerFingerprint();
       // #823 — 가속도 latest summary 첨부 (옵션). useAccelerometer가 FG에서 갱신.
       //   BG-only 또는 FG → BG 전환 후 시간이 지난 케이스에 stale snapshot이 남아있을 수 있어
       //   ACCEL_SUMMARY_MAX_AGE_MS 이상 오래된 건 제외 (E1 정책: 결정적 freshness 우선).
@@ -156,6 +192,11 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
         latestAccel && Date.now() - latestAccel.endTs <= ACCEL_SUMMARY_MAX_AGE_MS
           ? latestAccel
           : undefined;
+      // #1542 — 60s window snapshot pattern 분류. motion 필드와 결합 — accelerometer 'automotive'/
+      // 'walking'은 stationary 우선보다 강 신호 (raw 가속도 진동은 CMMotionActivity stationary 5~10분
+      // 뒤집힘 mitigation, lesson_motion_activity_intermittent_signal).
+      const accelPattern = classifyAccelerometerPattern(getLatestAccelerometerSnapshot());
+      const motion: PositionMotion = pickMotionLabel(accelPattern, getCurrentMotionStationary());
       void uploadPosition({
         token: apnsToken,
         lat,

--- a/src/features/nearest-station/utils/__tests__/accelerometerFingerprint.test.ts
+++ b/src/features/nearest-station/utils/__tests__/accelerometerFingerprint.test.ts
@@ -1,0 +1,168 @@
+/**
+ * #1542 (ADR-016 S9) — CMMotionManager accelerometer fingerprint JS wrapper 테스트.
+ *
+ * 핵심 정책:
+ *   - native module 부재 → 모든 API graceful (null / no-op / false)
+ *   - 예외 → null / no-op (graceful)
+ *   - classifyAccelerometerPattern: 분류 결과 그대로, null → 'unknown'
+ *   - isValidSnapshot: invalid shape → null fallback (binary 호환성 안전망)
+ */
+
+const mockNativeModule = {
+  isAvailable: jest.fn(),
+  start: jest.fn(),
+  stop: jest.fn(),
+  getLatestSnapshot: jest.fn(),
+};
+
+const mockedRequire = jest.fn();
+
+jest.mock('expo-modules-core', () => ({
+  requireOptionalNativeModule: (...args: unknown[]) => mockedRequire(...args),
+}));
+
+import {
+  classifyAccelerometerPattern,
+  getLatestAccelerometerSnapshot,
+  isAccelerometerFingerprintSupported,
+  startAccelerometerFingerprint,
+  stopAccelerometerFingerprint,
+  type AccelerometerPattern,
+  type AccelerometerSnapshot,
+} from '../accelerometerFingerprint';
+
+function makeSnapshot(overrides: Partial<AccelerometerSnapshot> = {}): AccelerometerSnapshot {
+  return {
+    timestamp: 1_700_000_000_000,
+    rmsMagnitude: 0.5,
+    patternClass: 'walking',
+    sampleCount: 200,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockedRequire.mockReset();
+  mockNativeModule.isAvailable.mockReset();
+  mockNativeModule.start.mockReset();
+  mockNativeModule.stop.mockReset();
+  mockNativeModule.getLatestSnapshot.mockReset();
+});
+
+describe('accelerometerFingerprint native wrapper (#1542)', () => {
+  describe('native module 없음 (jest / Android / 미지원)', () => {
+    beforeEach(() => {
+      mockedRequire.mockReturnValue(null);
+    });
+
+    it('isAccelerometerFingerprintSupported() → false', () => {
+      expect(isAccelerometerFingerprintSupported()).toBe(false);
+    });
+
+    it('startAccelerometerFingerprint() → no-op', () => {
+      expect(() => startAccelerometerFingerprint()).not.toThrow();
+    });
+
+    it('stopAccelerometerFingerprint() → no-op', () => {
+      expect(() => stopAccelerometerFingerprint()).not.toThrow();
+    });
+
+    it('getLatestAccelerometerSnapshot() → null', () => {
+      expect(getLatestAccelerometerSnapshot()).toBeNull();
+    });
+  });
+
+  describe('native module 있음 — 정상', () => {
+    beforeEach(() => {
+      mockedRequire.mockReturnValue(mockNativeModule);
+    });
+
+    it('isAccelerometerFingerprintSupported() — native isAvailable 반영', () => {
+      mockNativeModule.isAvailable.mockReturnValue(true);
+      expect(isAccelerometerFingerprintSupported()).toBe(true);
+      mockNativeModule.isAvailable.mockReturnValue(false);
+      expect(isAccelerometerFingerprintSupported()).toBe(false);
+    });
+
+    it('startAccelerometerFingerprint() — native start 호출', () => {
+      startAccelerometerFingerprint();
+      expect(mockNativeModule.start).toHaveBeenCalledTimes(1);
+    });
+
+    it('stopAccelerometerFingerprint() — native stop 호출', () => {
+      stopAccelerometerFingerprint();
+      expect(mockNativeModule.stop).toHaveBeenCalledTimes(1);
+    });
+
+    it('getLatestAccelerometerSnapshot() — valid snapshot 그대로 반환', () => {
+      const snap = makeSnapshot();
+      mockNativeModule.getLatestSnapshot.mockReturnValue(snap);
+      expect(getLatestAccelerometerSnapshot()).toEqual(snap);
+    });
+
+    it('getLatestAccelerometerSnapshot() — native null → null', () => {
+      mockNativeModule.getLatestSnapshot.mockReturnValue(null);
+      expect(getLatestAccelerometerSnapshot()).toBeNull();
+    });
+
+    it.each([
+      { case: 'undefined', value: undefined },
+      { case: 'string', value: 'oops' },
+      { case: 'missing timestamp', value: { ...makeSnapshot(), timestamp: undefined } },
+      { case: 'missing rmsMagnitude', value: { ...makeSnapshot(), rmsMagnitude: undefined } },
+      { case: 'missing sampleCount', value: { ...makeSnapshot(), sampleCount: undefined } },
+      { case: 'invalid patternClass', value: { ...makeSnapshot(), patternClass: 'driving' } },
+      { case: 'patternClass non-string', value: { ...makeSnapshot(), patternClass: 1 } },
+    ])('getLatestAccelerometerSnapshot() — invalid ($case) → null', ({ value }) => {
+      mockNativeModule.getLatestSnapshot.mockReturnValue(value);
+      expect(getLatestAccelerometerSnapshot()).toBeNull();
+    });
+  });
+
+  describe('native module 있음 — 예외 (graceful)', () => {
+    beforeEach(() => {
+      mockedRequire.mockReturnValue(mockNativeModule);
+    });
+
+    it('isAvailable 예외 → false', () => {
+      mockNativeModule.isAvailable.mockImplementation(() => {
+        throw new Error('boom');
+      });
+      expect(isAccelerometerFingerprintSupported()).toBe(false);
+    });
+
+    it('start 예외 → no-op (throw 없음)', () => {
+      mockNativeModule.start.mockImplementation(() => {
+        throw new Error('boom');
+      });
+      expect(() => startAccelerometerFingerprint()).not.toThrow();
+    });
+
+    it('stop 예외 → no-op', () => {
+      mockNativeModule.stop.mockImplementation(() => {
+        throw new Error('boom');
+      });
+      expect(() => stopAccelerometerFingerprint()).not.toThrow();
+    });
+
+    it('getLatestSnapshot 예외 → null', () => {
+      mockNativeModule.getLatestSnapshot.mockImplementation(() => {
+        throw new Error('boom');
+      });
+      expect(getLatestAccelerometerSnapshot()).toBeNull();
+    });
+  });
+});
+
+describe('classifyAccelerometerPattern (#1542)', () => {
+  it.each<AccelerometerPattern>(['stationary', 'walking', 'automotive', 'unknown'])(
+    'snapshot patternClass=%s → 그대로 반환',
+    (pattern) => {
+      expect(classifyAccelerometerPattern(makeSnapshot({ patternClass: pattern }))).toBe(pattern);
+    },
+  );
+
+  it('null snapshot → unknown (미투표)', () => {
+    expect(classifyAccelerometerPattern(null)).toBe('unknown');
+  });
+});

--- a/src/features/nearest-station/utils/__tests__/undergroundSSotConsensus.test.ts
+++ b/src/features/nearest-station/utils/__tests__/undergroundSSotConsensus.test.ts
@@ -226,3 +226,95 @@ describe('undergroundSSOTConsensus — 4-signal 2-of-N (#1574 ADR-017 T11)', () 
     expect(result?.station.id).toBe(positionTrain.station.id);
   });
 });
+
+describe('undergroundSSOTConsensus — accelerometer fingerprint (#1542 ADR-016 S9)', () => {
+  it('Position + accelerometer automotive (BG WiFi nil, baro/cellular 미수렴) → 2-of-N pass', () => {
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    const result = undergroundSSOTConsensus({
+      wifiStation: null,
+      positionTrainResult: positionTrain,
+      arrival: arrivalLine2,
+      accelerometerPattern: 'automotive',
+    });
+    expect(result?.station.id).toBe(positionTrain.station.id);
+    expect(result?.trainCode).toBe('T1');
+  });
+
+  it('WiFi + accelerometer automotive → 2-of-N pass', () => {
+    const wifi = MOCK_STATIONS.gangnam;
+    const result = undergroundSSOTConsensus({
+      wifiStation: wifi,
+      positionTrainResult: null,
+      arrival: arrivalLine2,
+      accelerometerPattern: 'automotive',
+    });
+    expect(result?.station.id).toBe(wifi.id);
+    expect(result?.trainCode).toBe('T1');
+  });
+
+  it('Position + barometer + accelerometer → 3 env votes 누적, station 채택 (position 우선)', () => {
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    const result = undergroundSSOTConsensus({
+      wifiStation: null,
+      positionTrainResult: positionTrain,
+      arrival: arrivalLine2,
+      barometerStop: true,
+      cellularEnvironmentVote: 'underground',
+      accelerometerPattern: 'automotive',
+    });
+    expect(result?.station.id).toBe(positionTrain.station.id);
+  });
+
+  it.each<'stationary' | 'walking' | 'unknown'>(['stationary', 'walking', 'unknown'])(
+    'accelerometer pattern=%s → vote 미투표 (1-of-N)',
+    (pattern) => {
+      const positionTrain = makeNearestResult('gangnam', 0.05);
+      expect(
+        undergroundSSOTConsensus({
+          wifiStation: null,
+          positionTrainResult: positionTrain,
+          arrival: arrivalLine2,
+          accelerometerPattern: pattern,
+        }),
+      ).toBeNull();
+    },
+  );
+
+  it('accelerometer automotive + cellular surface → reject (환경 확정 모순 우선)', () => {
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    expect(
+      undergroundSSOTConsensus({
+        wifiStation: null,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine2,
+        accelerometerPattern: 'automotive',
+        cellularEnvironmentVote: 'surface',
+      }),
+    ).toBeNull();
+  });
+
+  it('env vote만 (baro + cellular + accelerometer) station pair 0 → null', () => {
+    expect(
+      undergroundSSOTConsensus({
+        wifiStation: null,
+        positionTrainResult: null,
+        arrival: arrivalLine2,
+        barometerStop: true,
+        cellularEnvironmentVote: 'underground',
+        accelerometerPattern: 'automotive',
+      }),
+    ).toBeNull();
+  });
+
+  it('accelerometer undefined (호출자 미전달) → backward-compat 기존 동작 보존', () => {
+    // wifi + position 둘 다 매칭 → 2-of-N station pair 모드 그대로.
+    const wifi = MOCK_STATIONS.gangnam;
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    const result = undergroundSSOTConsensus({
+      wifiStation: wifi,
+      positionTrainResult: positionTrain,
+      arrival: arrivalLine2,
+    });
+    expect(result?.station.id).toBe(positionTrain.station.id);
+  });
+});

--- a/src/features/nearest-station/utils/accelerometerFingerprint.ts
+++ b/src/features/nearest-station/utils/accelerometerFingerprint.ts
@@ -1,0 +1,148 @@
+/**
+ * #1542 (ADR-016 S9) — CMMotionManager accelerometer fingerprint JS wrapper.
+ *
+ * 목적: native module(`modules/accelerometer-fingerprint/`)이 캐시한 60s window snapshot을 JS layer에
+ * 노출. underground SSOT 합의 게이트(`undergroundSSotConsensus`)에 진동 fingerprint vote 1표 추가
+ * + lockless 5단 fallback 4단계 (project_lockless_first_station_miss_zero).
+ *
+ * V1 BG 지하 천장 70 → 90% (Transit App 90% / SubwayPS 학술 85% baseline).
+ *
+ * 모든 API는 graceful — native module 부재(jest/web/Android/미지원 디바이스), 예외 모두
+ * `null` / no-op로 처리한다. "모르는 상태"는 vote 미투표 (환경 판정 영향 0).
+ *
+ * 분류 정책 (Apple CMMotionManager raw accelerometer 기준):
+ *   - `stationary` : RMS < 0.3 m/s² (정적 사용자)
+ *   - `walking`    : 0.3 ≤ RMS < 2.0 m/s² (도보 cadence)
+ *   - `automotive` : RMS ≥ 2.0 m/s² (train 가속/감속, env vote 1표 추가)
+ *   - `unknown`    : window 미수렴 (60s × 5Hz=300 기대, 50개 미달) — vote 미투표
+ *
+ * 호환:
+ *   - 기존 `useAccelerometer` (#823, expo-sensors 기반)와 별 lifecycle. expo-sensors는 FG-only.
+ *   - 본 모듈은 BG location piggyback으로 BG에서도 raw 가속도 수신 보장.
+ */
+
+import { requireOptionalNativeModule } from 'expo-modules-core';
+
+/**
+ * native가 반환하는 snapshot 구조 — Swift `computeLatestSnapshot()` dictionary와 1:1.
+ *
+ * `patternClass` 분류 임계는 native Swift 측 상수와 동일 — 둘 중 한 곳만 바꾸면 분류 일관성 깨짐.
+ * JS는 raw rmsMagnitude까지 노출해 후속 PR에서 학습 데이터 기반 재분류 가능.
+ */
+export interface AccelerometerSnapshot {
+  /** snapshot 생성 epoch ms. */
+  timestamp: number;
+  /** 중력 제거 후 linear acceleration RMS magnitude (m/s²). */
+  rmsMagnitude: number;
+  /** 분류 결과. 'unknown'은 vote 미투표. */
+  patternClass: AccelerometerPattern;
+  /** window 내 sample 수. MIN(=50) 미달 시 unknown 강제. */
+  sampleCount: number;
+}
+
+/** 패턴 분류 결과. underground SSOT env vote는 'automotive'만 투표. */
+export type AccelerometerPattern = 'stationary' | 'walking' | 'automotive' | 'unknown';
+
+interface AccelerometerFingerprintNative {
+  isAvailable(): boolean;
+  start(): void;
+  stop(): void;
+  /** native가 캐시한 최신 60s window snapshot. 미수렴 시 sampleCount<50 + patternClass='unknown'. */
+  getLatestSnapshot(): AccelerometerSnapshot | null;
+}
+
+function getNativeModule(): AccelerometerFingerprintNative | null {
+  return requireOptionalNativeModule<AccelerometerFingerprintNative>(
+    'AccelerometerFingerprint',
+  ) ?? null;
+}
+
+export function isAccelerometerFingerprintSupported(): boolean {
+  const module = getNativeModule();
+  if (!module) return false;
+  try {
+    return module.isAvailable();
+  } catch {
+    return false;
+  }
+}
+
+export function startAccelerometerFingerprint(): void {
+  const module = getNativeModule();
+  if (!module) return;
+  try {
+    module.start();
+  } catch {
+    // graceful — 시작 실패는 후속 getLatestSnapshot null로 자연 fallback.
+  }
+}
+
+export function stopAccelerometerFingerprint(): void {
+  const module = getNativeModule();
+  if (!module) return;
+  try {
+    module.stop();
+  } catch {
+    // graceful — 중지 실패는 lifecycle 관점에서 무해.
+  }
+}
+
+/**
+ * native가 캐시한 최신 snapshot 조회. 미지원/예외/미수렴 시 null.
+ *
+ * 호출자는 snapshot.patternClass로 분류 결과를 사용하며, raw rmsMagnitude는 후속 학습 데이터 수집
+ * (별 PR)에서 station-specific vibrationSignature 매칭에 사용한다.
+ */
+export function getLatestAccelerometerSnapshot(): AccelerometerSnapshot | null {
+  const module = getNativeModule();
+  if (!module) return null;
+  try {
+    const snapshot = module.getLatestSnapshot();
+    return isValidSnapshot(snapshot) ? snapshot : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * snapshot.patternClass 분류 결과만 추출 — undergroundSSotConsensus 입력 변환.
+ *
+ * - null (미지원/예외/미수렴) → 'unknown' (vote 미투표)
+ * - 정상 snapshot → patternClass 그대로 반환
+ *
+ * 데이터 주도 (CLAUDE.md 글로벌 룰 3번): 호출자는 항상 `'unknown' | 'stationary' | 'walking' | 'automotive'`
+ * 4 case를 처리하며 분기 추가 없이 분류 변경 가능.
+ */
+export function classifyAccelerometerPattern(
+  snapshot: AccelerometerSnapshot | null,
+): AccelerometerPattern {
+  if (!snapshot) return 'unknown';
+  return snapshot.patternClass;
+}
+
+/**
+ * native가 반환한 dictionary가 expected shape인지 런타임 검증.
+ *
+ * native가 정상 동작하면 항상 valid shape이지만, 미래 native 버전 mismatch (binary 호환성 깨짐) 시
+ * undefined 필드로 인한 silent failure 방지 — invalid이면 null로 fallback.
+ */
+function isValidSnapshot(value: unknown): value is AccelerometerSnapshot {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<AccelerometerSnapshot>;
+  if (typeof candidate.timestamp !== 'number') return false;
+  if (typeof candidate.rmsMagnitude !== 'number') return false;
+  if (typeof candidate.sampleCount !== 'number') return false;
+  return isValidPatternClass(candidate.patternClass);
+}
+
+/** 분류 결과 string이 expected union case인지 확인. data-driven set 비교. */
+const VALID_PATTERN_CLASSES: ReadonlySet<string> = new Set<string>([
+  'stationary',
+  'walking',
+  'automotive',
+  'unknown',
+]);
+
+function isValidPatternClass(value: unknown): value is AccelerometerPattern {
+  return typeof value === 'string' && VALID_PATTERN_CLASSES.has(value);
+}

--- a/src/features/nearest-station/utils/undergroundSSotConsensus.ts
+++ b/src/features/nearest-station/utils/undergroundSSotConsensus.ts
@@ -8,6 +8,10 @@
  *   - Position-Train+Arrival 1-input에 의존 → 1 input 실패 시 합의 붕괴
  *   - Barometer `stop`(dP/dt 정착) + Cellular `underground` vote를 환경-확정 vote로 추가
  *
+ * #1542 (ADR-016 S9) — CMMotionManager accelerometer fingerprint 환경 vote 추가.
+ *   - V1 BG 지하 천장 70 → 90% (Transit App 90% / SubwayPS 학술 85% baseline)
+ *   - patternClass='automotive' (RMS ≥ 2.0 m/s² 진동) = train 진행 신호 환경 vote 1표
+ *
  * 합의 구조 — station-providing pair + environment-confirming vote:
  *   - Station pair (station 채택 가능, arrival 호선 매칭 필수):
  *       (a) WiFi SSID    + Arrival  (FG only — BG에선 SSID nil)
@@ -15,6 +19,7 @@
  *   - Environment vote (station 미제공, 환경 확정만):
  *       (c) Barometer `stop=true` (FG/BG) — #1574
  *       (d) Cellular `underground` vote (FG/BG) — #1574
+ *       (e) Accelerometer `automotive` pattern (FG/BG, BG location piggyback) — #1542
  *
  * 합의 임계:
  *   - 2-of-N 통과 시 SSOT 채택 (station pair + env vote 어떤 조합이든 OK)
@@ -25,14 +30,15 @@
  * station 채택 우선순위: Position-Train > WiFi (강 → 약 신호).
  *
  * Backward-compat:
- *   - barometerStop/cellularEnvironmentVote 미전달 → 기존 호출자 동작 유지
+ *   - barometerStop/cellularEnvironmentVote/accelerometerPattern 미전달 → 기존 호출자 동작 유지
  *   - 단, 2-of-N quorum이 강화되어 단일 station pair만으로는 통과 불가 (의도된 tightening).
- *     기존 wifi-only / position-only 통과 케이스는 barometer/cellular 보강으로 회복.
+ *     기존 wifi-only / position-only 통과 케이스는 barometer/cellular/accelerometer 보강으로 회복.
  */
 
 import type { NearestStationResult, Station } from '../../../shared/types/station';
 import type { StationArrival } from '../../../shared/types/arrival';
 import type { CellularEnvironmentVote } from './cellularTech';
+import type { AccelerometerPattern } from './accelerometerFingerprint';
 
 /** arvlCd "정착한 위치 보고" 코드 집합. surfaceSSotConsensus와 동일 — 향후 공용 추출 여지. */
 const ARVL_CD_STATIONARY = new Set<number>([1, 2, 3, 5]);
@@ -61,6 +67,14 @@ export interface UndergroundSSOTInput {
    * iOS BG에서도 동작 (CTServiceRadioAccessTechnologyDidChangeNotification observer).
    */
   cellularEnvironmentVote?: CellularEnvironmentVote | undefined;
+  /**
+   * #1542 (ADR-016 S9) — CMMotionManager 60s window RMS magnitude 분류 결과.
+   * 'automotive' (RMS ≥ 2.0 m/s² 진동 — train 진행)이면 환경-확정 1표 추가.
+   * 'stationary' / 'walking' (정지/도보) → vote 미투표 (station 채택 신호 X, 환경 모순 X).
+   * 'unknown'/undefined (60s window 미수렴, 미지원) → vote 미투표.
+   * iOS BG에서도 동작 (Background Location piggyback으로 raw 가속도 수신).
+   */
+  accelerometerPattern?: AccelerometerPattern | undefined;
 }
 
 export interface UndergroundSSOT {
@@ -84,7 +98,14 @@ function findStationaryTrain(
 }
 
 export function undergroundSSOTConsensus(input: UndergroundSSOTInput): UndergroundSSOT | null {
-  const { wifiStation, positionTrainResult, arrival, barometerStop, cellularEnvironmentVote } = input;
+  const {
+    wifiStation,
+    positionTrainResult,
+    arrival,
+    barometerStop,
+    cellularEnvironmentVote,
+    accelerometerPattern,
+  } = input;
 
   // 환경 확정 모순 — cellular가 surface면 underground SSOT 자체 candidate X.
   if (cellularEnvironmentVote === 'surface') return null;
@@ -104,10 +125,11 @@ export function undergroundSSOTConsensus(input: UndergroundSSOTInput): Undergrou
     }
   }
 
-  // Environment-confirming votes (station 미제공). 신규 #1574 — BG WiFi 갭 해소.
+  // Environment-confirming votes (station 미제공). 신규 #1574 — BG WiFi 갭 해소 + #1542 accelerometer.
   let envVotes = 0;
   if (barometerStop === true) envVotes += 1;
   if (cellularEnvironmentVote === 'underground') envVotes += 1;
+  if (accelerometerPattern === 'automotive') envVotes += 1;
 
   // 2-of-N quorum. station pair ≥ 1 필수 (env vote만으로는 station 채택 불가).
   if (stationPairs.length === 0) return null;


### PR DESCRIPTION
Closes #1542

## 다운로드 가치
V1 BG 지하 천장 70 → 90% (Transit App 90% / SubwayPS 학술 85% baseline).

본 프로젝트가 시도하는 lockless BG 영역 best-in-market 도달 (시장 어느 앱도 lockless BG 매역 알림 X).

## 변경 5 Phase (atomic)

| Phase | 변경 |
|-------|------|
| **A** | `modules/accelerometer-fingerprint/` 신규 Expo Module (iOS only) — CMMotionManager raw accelerometer 5Hz + 60s window RMS magnitude 분류 + BG-safe OperationQueue. JS wrapper(`utils/accelerometerFingerprint.ts`) + graceful schema 검증. |
| **B** | `backgroundLocationTask` piggyback — apnsToken 있을 때 startAccelerometerFingerprint() 호출. position upload payload.motion 라벨에 accelerometer pattern 우선 (CMMotionActivity 5~10분 flip mitigation). |
| **C** | pattern 분류 helper (Phase A 내 generic threshold). station-specific vibrationSignature는 후속 PR (학습 데이터 수집 후). |
| **D** | `undergroundSSotConsensus` 5번째 signal slot — `accelerometerPattern='automotive'` = env vote 1표. backward-compat (undefined → 기존 동작). |
| **E** | `useAccelerometerFingerprint` hook (useCellularTech 패턴, 5s 폴링) → `useFusedNearestStation`에서 호출하여 undergroundSSOTConsensus 입력으로 wire. lockless 5단 fallback의 4단계. |

## Wire-completion 5단
1. **Orphan**: pass (`npm run lint:orphan` 0)
2. **V/X**: V1 BG 지하 (70→90% 천장), V8 (배터리 — 5Hz BG sampling, motion-warmup mitigation)
3. **의존 PR**: T11 #1574 머지 완료 + S10 #1543 머지 완료 (각각 cellular/barometer env vote 패턴). 독립 PR.
4. **측정 plan**: 1주 production. 지하 BG trip dump에서 accelerometer snapshot patternClass 분포 + station match accuracy vs baseline. SubwayPS 85% 대비 측정.
5. **Device verify**: 실기기 BG 지하 trip 1주 (사용자 책임). FG iOS 시뮬레이터는 accelerometer 미지원 — Android는 graceful unknown.

## 시그널 정책 (lesson_motion_activity_intermittent_signal mitigation)

- **stationary**: RMS < 0.3 m/s² (정적 사용자, 주머니 안)
- **walking**: 0.3 ≤ RMS < 2.0 m/s² (도보 cadence)
- **automotive**: RMS ≥ 2.0 m/s² (train 진동) — env vote 1표
- **unknown**: 60s window 미수렴 (sample < 50) — vote 미투표

CMMotionActivity가 5~10분 주기로 false↔true 뒤집히는 회귀에 대한 raw 가속도 실측 mitigation. accelerometer pattern이 non-unknown이면 CMMotionActivity stationary 무시 (uploadPosition motion 필드 우선).

## 테스트
- **type-check**: 0 error
- **coverage**: 100% (lines/functions/branches/statements)
- **tests**: 7318 pass / 7318 (361 suites)
- **신규 단위 테스트**: 47개
  - utils/accelerometerFingerprint: 25 (graceful fallback / schema 검증 / 분류)
  - hooks/useAccelerometerFingerprint: 5 (lifecycle / pattern 전환)
  - undergroundSSotConsensus: 9 신규 (accelerometer 단독 / 결합 / backward-compat)
  - backgroundLocationTask: 8 신규 (pickMotionLabel / BG piggyback)

## 코드 분포

| 파일 | 라인 |
|------|-----|
| modules/accelerometer-fingerprint/ios/*.swift | 202 |
| utils/accelerometerFingerprint.ts | 148 |
| hooks/useAccelerometerFingerprint.ts | 63 |
| backgroundLocationTask.ts (pickMotionLabel + piggyback) | +43 |
| undergroundSSotConsensus.ts (Phase D) | +30 |
| useFusedNearestStation.ts (Phase E wire) | +10 |

## 사용자 머지 전 확인 (device-only)
- Expo prebuild → iOS native build (Pods autolinking이 `modules/accelerometer-fingerprint/`를 새로 picks up — `cellular-tech-listener` 머지 시점과 동일 패턴)
- 실기기 BG 지하 trip 1주 측정 — patternClass=automotive 발사율 + station match accuracy
- V8 배터리 — 5Hz BG sampling의 추가 부하 측정 (BG location 활성 동안만이라 incremental cost 낮음)
- 학습 데이터 수집 후 후속 PR에서 station-specific vibrationSignature 매칭으로 정확도 추가 향상 가능