### PR TITLE
feat(#1621): 진단 인프라 강화 — alarm-log-stats + V1 mismatch + baseline-check (3 Phase atomic)

### DIFF
--- a/backend/alarm-worker/src/__tests__/alarmLogStats.test.ts
+++ b/backend/alarm-worker/src/__tests__/alarmLogStats.test.ts
@@ -1,0 +1,302 @@
+/**
+ * alarmLogStats.test.ts — #1621 Phase A computeAlarmLogStats unit tests.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { computeAlarmLogStats } from '../alarmLogStats';
+import {
+  buildAlarmLogNdjsonFixture,
+  makeFakeR2,
+  type FakeR2Archive,
+} from './helpers/r2Fixtures';
+
+const NOW = 1_700_000_000_000;
+
+describe('computeAlarmLogStats', () => {
+  it('returns empty distribution when bucket has no archives', async () => {
+    const r2 = makeFakeR2([]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    expect(stats.totalEvents).toBe(0);
+    expect(stats.fired).toBe(0);
+    expect(stats.suppressed).toBe(0);
+    expect(stats.received).toBe(0);
+    expect(stats.reasons).toEqual({});
+    expect(stats.sources).toEqual({});
+    expect(stats.tripsScanned).toBe(0);
+    expect(stats.windowStart).toBe(NOW - 60 * 60 * 1000);
+    expect(stats.windowEnd).toBe(NOW);
+  });
+
+  it('aggregates outcome/reason/source from a single archive', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/20/aabbccdd-1000.ndjson',
+        tripEndedAt: NOW - 5 * 60 * 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'silent-push-fired', outcome: 'fired' },
+            { source: 'silent-push-skipped', outcome: 'suppressed', reason: 'gate-stale-location' },
+            { source: 'silent-push-received', outcome: 'received' },
+          ],
+          NOW - 5 * 60 * 1000,
+        ),
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    expect(stats.totalEvents).toBe(3);
+    expect(stats.fired).toBe(1);
+    expect(stats.suppressed).toBe(1);
+    expect(stats.received).toBe(1);
+    expect(stats.reasons['gate-stale-location']).toBe(1);
+    expect(stats.sources['silent-push-fired']).toBe(1);
+    expect(stats.sources['silent-push-received']).toBe(1);
+    expect(stats.tripsScanned).toBe(1);
+  });
+
+  it('aggregates across multiple archives', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/20/a-1000.ndjson',
+        tripEndedAt: NOW - 10 * 60 * 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'fg-arvlcd', outcome: 'fired' },
+            { source: 'fg', outcome: 'suppressed', reason: 'cross-trip-mirror-leak' },
+          ],
+          NOW - 10 * 60 * 1000,
+        ),
+      },
+      {
+        key: 'trip-evidence/2026/06/20/b-2000.ndjson',
+        tripEndedAt: NOW - 20 * 60 * 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'fg-arvlcd', outcome: 'fired' },
+            { source: 'fg-arvlcd', outcome: 'suppressed', reason: 'lockless-forward-only-block' },
+          ],
+          NOW - 20 * 60 * 1000,
+        ),
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    expect(stats.totalEvents).toBe(4);
+    expect(stats.fired).toBe(2);
+    expect(stats.suppressed).toBe(2);
+    expect(stats.sources['fg-arvlcd']).toBe(3);
+    expect(stats.reasons['cross-trip-mirror-leak']).toBe(1);
+    expect(stats.reasons['lockless-forward-only-block']).toBe(1);
+    expect(stats.tripsScanned).toBe(2);
+  });
+
+  it('excludes archives outside windowHours window', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/20/old.ndjson',
+        tripEndedAt: NOW - 2 * 60 * 60 * 1000, // 2h ago — outside default 1h
+        body: buildAlarmLogNdjsonFixture(
+          [{ source: 'fg-arvlcd', outcome: 'fired' }],
+          NOW - 2 * 60 * 60 * 1000,
+        ),
+      },
+      {
+        key: 'trip-evidence/2026/06/20/recent.ndjson',
+        tripEndedAt: NOW - 10 * 60 * 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [{ source: 'fg-arvlcd', outcome: 'fired' }],
+          NOW - 10 * 60 * 1000,
+        ),
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    expect(stats.totalEvents).toBe(1);
+    expect(stats.tripsScanned).toBe(1);
+  });
+
+  it.each([
+    {
+      label: 'windowHours=6 includes 3h-ago archive',
+      windowHours: 6,
+      expectTotalEvents: 1,
+      expectWindowStart: NOW - 6 * 60 * 60 * 1000,
+    },
+    {
+      label: 'windowHours=99 clamped to 24h max — still includes',
+      windowHours: 99,
+      expectTotalEvents: 1,
+      expectWindowStart: NOW - 24 * 60 * 60 * 1000,
+    },
+    {
+      label: 'windowHours=0 clamped to 1h min — excludes 3h-ago archive',
+      windowHours: 0,
+      expectTotalEvents: 0,
+      expectWindowStart: NOW - 60 * 60 * 1000,
+    },
+  ])('respects custom windowHours ($label)', async ({ windowHours, expectTotalEvents, expectWindowStart }) => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/20/k.ndjson',
+        tripEndedAt: NOW - 3 * 60 * 60 * 1000, // 3h ago
+        body: buildAlarmLogNdjsonFixture(
+          [{ source: 'fg-arvlcd', outcome: 'fired' }],
+          NOW - 3 * 60 * 60 * 1000,
+        ),
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW, windowHours);
+    expect(stats.totalEvents).toBe(expectTotalEvents);
+    expect(stats.windowStart).toBe(expectWindowStart);
+  });
+
+  it('skips archives without tripEndedAt metadata', async () => {
+    const r2 = {
+      async list() {
+        return {
+          objects: [{ key: 'k1', customMetadata: undefined }],
+          truncated: false,
+          cursor: undefined,
+        };
+      },
+      async get() { throw new Error('should not be called'); },
+    } as unknown as R2Bucket;
+    const stats = await computeAlarmLogStats(r2, NOW);
+    expect(stats.totalEvents).toBe(0);
+    expect(stats.tripsScanned).toBe(0);
+  });
+
+  it('handles malformed ndjson lines and non-alarmLog kinds gracefully', async () => {
+    const malformedBody = [
+      '{not-json',
+      JSON.stringify({ kind: 'header' }),
+      JSON.stringify({ kind: 'alarmLog', entries: [{ source: 'fg', outcome: 'fired' }] }),
+      JSON.stringify({ kind: 'alarmLog', entries: 'not-array' }),
+      JSON.stringify({ kind: 'fusionLog', entries: [{ source: 'should-be-ignored' }] }),
+      '',
+    ].join('\n');
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/20/mixed.ndjson',
+        tripEndedAt: NOW - 1000,
+        body: malformedBody,
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    expect(stats.totalEvents).toBe(1);
+    expect(stats.fired).toBe(1);
+    expect(stats.sources['fg']).toBe(1);
+  });
+
+  it('caps tripsScanned at limit (R2 cost protection)', async () => {
+    const archives: FakeR2Archive[] = [];
+    for (let i = 0; i < 20; i++) {
+      archives.push({
+        key: `trip-evidence/2026/06/20/t-${i}.ndjson`,
+        tripEndedAt: NOW - 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [{ source: 'fg', outcome: 'fired' }],
+          NOW - 1000,
+        ),
+      });
+    }
+    const r2 = makeFakeR2(archives);
+    const stats = await computeAlarmLogStats(r2, NOW, 1, 5);
+    expect(stats.tripsScanned).toBeLessThanOrEqual(5);
+    expect(stats.totalEvents).toBeLessThanOrEqual(5);
+  });
+
+  it('paginates R2 list with cursor across multiple pages', async () => {
+    const archives: FakeR2Archive[] = [];
+    for (let i = 0; i < 6; i++) {
+      archives.push({
+        key: `trip-evidence/2026/06/20/p-${i}.ndjson`,
+        tripEndedAt: NOW - 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [{ source: 'fg', outcome: 'fired' }],
+          NOW - 1000,
+        ),
+      });
+    }
+    // pageSize=2로 강제해 cursor traversal 검증.
+    const r2 = makeFakeR2(archives, 2);
+    const stats = await computeAlarmLogStats(r2, NOW, 1, 6);
+    expect(stats.tripsScanned).toBe(6);
+  });
+
+  it('truncates reasons/sources to top-20 per response size guard', async () => {
+    const entries: Array<{ source: string; outcome: string; reason: string }> = [];
+    for (let i = 0; i < 25; i++) {
+      entries.push({
+        source: `src-${i}`,
+        outcome: 'suppressed',
+        reason: `reason-${i}`,
+      });
+    }
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/20/many.ndjson',
+        tripEndedAt: NOW - 1000,
+        body: buildAlarmLogNdjsonFixture(entries, NOW - 1000),
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    expect(Object.keys(stats.reasons).length).toBe(20);
+    expect(Object.keys(stats.sources).length).toBe(20);
+  });
+
+  it('ignores archives with empty alarmLog entries (no tripsScanned bump)', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/20/empty.ndjson',
+        tripEndedAt: NOW - 1000,
+        body: buildAlarmLogNdjsonFixture([], NOW - 1000),
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    expect(stats.totalEvents).toBe(0);
+    expect(stats.tripsScanned).toBe(0);
+  });
+
+  it('handles R2 get returning null (object deleted mid-scan)', async () => {
+    const r2 = {
+      async list() {
+        return {
+          objects: [
+            {
+              key: 'trip-evidence/2026/06/20/missing.ndjson',
+              customMetadata: { tripEndedAt: String(NOW - 1000) },
+            },
+          ],
+          truncated: false,
+          cursor: undefined,
+        };
+      },
+      async get() { return null; },
+    } as unknown as R2Bucket;
+    const stats = await computeAlarmLogStats(r2, NOW);
+    expect(stats.totalEvents).toBe(0);
+    expect(stats.tripsScanned).toBe(0);
+  });
+
+  it('skips entries with non-string source/outcome/reason fields', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/20/typed.ndjson',
+        tripEndedAt: NOW - 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: '', outcome: 'fired' }, // empty source dropped from sources
+            { source: 'fg', outcome: '' }, // empty outcome dropped from outcomes
+            { source: 'fg', outcome: 'fired', reason: '' }, // empty reason dropped
+          ] as Array<{ source?: string; outcome?: string; reason?: string }>,
+          NOW - 1000,
+        ),
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    // 3 entries total; outcomes recognised: fired=2 (first + third)
+    expect(stats.totalEvents).toBe(3);
+    expect(stats.fired).toBe(2);
+    expect(stats.sources['fg']).toBe(2);
+    expect(stats.sources['']).toBeUndefined();
+    expect(stats.reasons['']).toBeUndefined();
+  });
+});

--- a/backend/alarm-worker/src/__tests__/baselineCheck.test.ts
+++ b/backend/alarm-worker/src/__tests__/baselineCheck.test.ts
@@ -1,0 +1,128 @@
+/**
+ * baselineCheck.test.ts — #1621 Phase C computeBaselineCheck unit tests.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { InMemoryKV } from './inMemoryKv';
+import { computeBaselineCheck } from '../baselineCheck';
+import {
+  buildAlarmLogNdjsonFixture,
+  makeEmptyFakeR2,
+  makeFakeR2,
+} from './helpers/r2Fixtures';
+
+const NOW = 1_700_000_000_000;
+const TOKEN = 'tok-baseline';
+
+function seedActiveTrip(kv: InMemoryKV, token: string): void {
+  kv.store.set(`trip:${token}`, {
+    value: JSON.stringify({
+      token,
+      route: { type: 'direct', line: '2', stops: 3 },
+      destination: 'dst',
+      waypoints: [],
+      expiresAt: NOW + 60 * 60 * 1000,
+      alarmAtEpochMs: NOW + 30 * 60 * 1000,
+    }),
+  });
+}
+
+function seedReceivedPush(kv: InMemoryKV, pushId: string): void {
+  kv.store.set(`received:${pushId}`, {
+    value: JSON.stringify({
+      pushId,
+      receivedAt: NOW - 60 * 1000,
+      stationName: '용마산',
+      phase: 'imminent',
+    }),
+  });
+}
+
+function seedPendingPush(kv: InMemoryKV, pushId: string): void {
+  kv.store.set(`pending:${pushId}`, {
+    value: JSON.stringify({ pushId, sentAt: NOW - 30_000 }),
+  });
+}
+
+describe('computeBaselineCheck', () => {
+  it('pass — silentPushFired > 0 AND v1Mismatch === 0', async () => {
+    const kv = new InMemoryKV();
+    seedActiveTrip(kv, TOKEN);
+    seedReceivedPush(kv, 'p1');
+    seedReceivedPush(kv, 'p2');
+    seedPendingPush(kv, 'p3');
+    const r2 = makeEmptyFakeR2();
+    const result = await computeBaselineCheck(kv as unknown as KVNamespace, r2, TOKEN, NOW);
+    expect(result.baseline).toBe('pass');
+    expect(result.signals.tripActive).toBe(true);
+    expect(result.signals.silentPushReceived).toBe(2);
+    expect(result.signals.silentPushFired).toBe(3); // 2 received + 1 pending
+    expect(result.signals.v1Mismatch).toBe(0);
+  });
+
+  it('fail — silentPushFired === 0 (no push at all)', async () => {
+    const kv = new InMemoryKV();
+    seedActiveTrip(kv, TOKEN);
+    const r2 = makeEmptyFakeR2();
+    const result = await computeBaselineCheck(kv as unknown as KVNamespace, r2, TOKEN, NOW);
+    expect(result.baseline).toBe('fail');
+    expect(result.signals.silentPushFired).toBe(0);
+    expect(result.signals.tripActive).toBe(true);
+  });
+
+  it('fail — v1Mismatch > 0 even with push fired', async () => {
+    const kv = new InMemoryKV();
+    seedActiveTrip(kv, TOKEN);
+    seedReceivedPush(kv, 'p1');
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/20/a.ndjson',
+        tripEndedAt: NOW - 5 * 60 * 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'fg-evaluated', outcome: 'suppressed', reason: 'v1-mismatch' },
+            { source: 'fg-evaluated', outcome: 'suppressed', reason: 'v1-mismatch' },
+          ],
+          NOW - 5 * 60 * 1000,
+        ),
+      },
+    ]);
+    const result = await computeBaselineCheck(kv as unknown as KVNamespace, r2, TOKEN, NOW);
+    expect(result.baseline).toBe('fail');
+    expect(result.signals.silentPushFired).toBe(1);
+    expect(result.signals.v1Mismatch).toBe(2);
+  });
+
+  it('reports tripActive=false when token not in KV', async () => {
+    const kv = new InMemoryKV();
+    // Seed a different token's trip — current token should still be inactive.
+    seedActiveTrip(kv, 'other-token');
+    seedReceivedPush(kv, 'p1');
+    const r2 = makeEmptyFakeR2();
+    const result = await computeBaselineCheck(kv as unknown as KVNamespace, r2, TOKEN, NOW);
+    expect(result.signals.tripActive).toBe(false);
+    // silentPushFired is independent of tripActive — still counts.
+    expect(result.signals.silentPushFired).toBe(1);
+  });
+
+  it('counts only v1-mismatch reason from alarm log (other reasons ignored)', async () => {
+    const kv = new InMemoryKV();
+    seedReceivedPush(kv, 'p1');
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/20/m.ndjson',
+        tripEndedAt: NOW - 5 * 60 * 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'fg', outcome: 'suppressed', reason: 'gate-stale-location' },
+            { source: 'fg', outcome: 'suppressed', reason: 'cross-trip-mirror-leak' },
+            { source: 'fg-evaluated', outcome: 'suppressed', reason: 'v1-mismatch' },
+          ],
+          NOW - 5 * 60 * 1000,
+        ),
+      },
+    ]);
+    const result = await computeBaselineCheck(kv as unknown as KVNamespace, r2, TOKEN, NOW);
+    expect(result.signals.v1Mismatch).toBe(1);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/helpers/r2Fixtures.ts
+++ b/backend/alarm-worker/src/__tests__/helpers/r2Fixtures.ts
@@ -1,0 +1,73 @@
+/**
+ * R2 archive 테스트 fixture — #1621 alarmLogStats.test.ts / baselineCheck.test.ts 공용.
+ *
+ * `alarmLogForward.ts:storeAlarmLogForward`가 archive하는 ndjson 본문과 customMetadata
+ * tripEndedAt을 mimic해, R2Bucket.list + R2Bucket.get을 in-memory로 구현한다.
+ *
+ * Sonar dup 사전 차단 — 두 테스트 파일에서 같은 mock 로직을 직접 작성하면 100+ token 중복이
+ * 검출된다 ([[lesson_sonarcloud_dup_prevention]]).
+ */
+
+export interface FakeR2Archive {
+  /** R2 key, 보통 `trip-evidence/YYYY/MM/DD/{tokenPrefix}-{tripStartedAt}.ndjson` */
+  key: string;
+  /** customMetadata.tripEndedAt 으로 채워질 epoch ms — 윈도우 판정 source */
+  tripEndedAt: number;
+  /** ndjson 본문 — `buildAlarmLogNdjson` helper로 생성 */
+  body: string;
+}
+
+/**
+ * `alarmLog` kind 1줄 + header를 가진 ndjson 본문 빌더.
+ *
+ * 실 운영 ndjson은 6 line(header / alarmLog / fusionLog / gpsDrops / backendSsotSnapshot /
+ * deviceMetadata)이지만 stats 산출엔 alarmLog만 필요하므로 최소 2 line으로 축약.
+ */
+export function buildAlarmLogNdjsonFixture(
+  entries: Array<{ source?: string; outcome?: string; reason?: string }>,
+  tripEndedAt: number,
+): string {
+  return [
+    JSON.stringify({ kind: 'header', tripEndedAt }),
+    JSON.stringify({ kind: 'alarmLog', entries }),
+  ].join('\n');
+}
+
+/**
+ * In-memory R2Bucket double. `list` + `get`만 구현 — alarmLogStats/baselineCheck이 사용하는 표면.
+ *
+ * 페이지네이션은 `pageSize`(default Infinity)로 강제할 수 있어 cursor 회귀 테스트 가능.
+ */
+export function makeFakeR2(
+  archives: FakeR2Archive[],
+  pageSize = Number.POSITIVE_INFINITY,
+): R2Bucket {
+  return {
+    async list({ prefix, cursor, limit }: { prefix?: string; cursor?: string; limit?: number }) {
+      const matching = archives.filter((a) => !prefix || a.key.startsWith(prefix));
+      const startIdx = cursor ? Number.parseInt(cursor, 10) : 0;
+      const cap = Math.min(limit ?? matching.length, pageSize);
+      const page = matching.slice(startIdx, startIdx + cap);
+      const endIdx = startIdx + page.length;
+      const truncated = endIdx < matching.length;
+      return {
+        objects: page.map((a) => ({
+          key: a.key,
+          customMetadata: { tripEndedAt: String(a.tripEndedAt) },
+        })),
+        truncated,
+        cursor: truncated ? String(endIdx) : undefined,
+      };
+    },
+    async get(key: string) {
+      const archive = archives.find((a) => a.key === key);
+      if (!archive) return null;
+      return { async text() { return archive.body; } };
+    },
+  } as unknown as R2Bucket;
+}
+
+/** 빈 archive R2 — endpoint binding/auth 회귀 테스트가 자주 쓴다. */
+export function makeEmptyFakeR2(): R2Bucket {
+  return makeFakeR2([]);
+}

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -15,6 +15,7 @@ import { pendingKey } from '../pendingPushes';
 import { KV_MIN_CACHE_TTL_SEC } from '../kvConsistency';
 import type { AnalyticsEngineWriter, Env } from '../types';
 import { InMemoryKV } from './inMemoryKv';
+import { makeEmptyFakeR2 } from './helpers/r2Fixtures';
 
 function makeEnv(overrides: Partial<Env> = {}): Env {
   return {
@@ -3676,5 +3677,176 @@ describe('GET /admin/push-ack-stats (#1614 Phase D)', () => {
     const env = makeEnv({ TRIPS: undefined as unknown as Env['TRIPS'], ADMIN_TOKEN: 'secret' });
     const res = await getAdminPushAckStats(env, 'Bearer secret');
     expect(res.status).toBe(503);
+  });
+});
+
+// ─── GET /admin/alarm-log-stats (#1621 Phase A) ───────────────────────────────
+
+async function getAdminAlarmLogStats(env: Env, authHeader?: string): Promise<Response> {
+  return app.fetch(
+    new Request('http://example.com/admin/alarm-log-stats', {
+      method: 'GET',
+      headers: authHeader ? { authorization: authHeader } : {},
+    }),
+    env,
+  );
+}
+
+// Sonar dup 차단 — R2 empty/fake mock은 helpers/r2Fixtures.ts에 단일 정의 (#1621).
+const makeEmptyR2 = makeEmptyFakeR2;
+
+describe('GET /admin/alarm-log-stats (#1621 Phase A)', () => {
+  it.each([
+    {
+      label: '503 when ADMIN_TOKEN is not configured',
+      configureEnv: (env: Env) => {
+        env.TELEMETRY_R2 = makeEmptyR2();
+      },
+      authHeader: 'Bearer some-token',
+      expectedStatus: 503,
+    },
+    {
+      label: '401 when no Authorization header',
+      configureEnv: (env: Env) => {
+        env.ADMIN_TOKEN = 'secret';
+        env.TELEMETRY_R2 = makeEmptyR2();
+      },
+      authHeader: undefined,
+      expectedStatus: 401,
+    },
+    {
+      label: '401 when token does not match',
+      configureEnv: (env: Env) => {
+        env.ADMIN_TOKEN = 'secret';
+        env.TELEMETRY_R2 = makeEmptyR2();
+      },
+      authHeader: 'Bearer wrong-token',
+      expectedStatus: 401,
+    },
+    {
+      label: '503 when TELEMETRY_R2 binding unavailable',
+      configureEnv: (env: Env) => {
+        env.ADMIN_TOKEN = 'secret';
+      },
+      authHeader: 'Bearer secret',
+      expectedStatus: 503,
+    },
+  ])('returns $expectedStatus — $label', async ({ configureEnv, authHeader, expectedStatus }) => {
+    const env = makeKvEnv();
+    configureEnv(env);
+    const res = await getAdminAlarmLogStats(env, authHeader);
+    expect(res.status).toBe(expectedStatus);
+  });
+
+  it('returns 200 with stats shape (empty R2)', async () => {
+    const env = makeKvEnv();
+    env.ADMIN_TOKEN = 'secret';
+    env.TELEMETRY_R2 = makeEmptyR2();
+    const res = await getAdminAlarmLogStats(env, 'Bearer secret');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      windowStart: number;
+      windowEnd: number;
+      totalEvents: number;
+      fired: number;
+      suppressed: number;
+      received: number;
+      reasons: Record<string, number>;
+      sources: Record<string, number>;
+      tripsScanned: number;
+    };
+    expect(body.windowStart).toBeLessThan(body.windowEnd);
+    expect(body.totalEvents).toBe(0);
+    expect(body.fired).toBe(0);
+    expect(body.tripsScanned).toBe(0);
+    expect(body.reasons).toEqual({});
+    expect(body.sources).toEqual({});
+  });
+});
+
+// ─── GET /admin/baseline-check (#1621 Phase C) ────────────────────────────────
+
+async function getAdminBaselineCheck(
+  env: Env,
+  query: string,
+  authHeader?: string,
+): Promise<Response> {
+  const url = `http://example.com/admin/baseline-check${query ? '?' + query : ''}`;
+  return app.fetch(
+    new Request(url, {
+      method: 'GET',
+      headers: authHeader ? { authorization: authHeader } : {},
+    }),
+    env,
+  );
+}
+
+describe('GET /admin/baseline-check (#1621 Phase C)', () => {
+  it.each([
+    {
+      label: '503 when ADMIN_TOKEN is not configured',
+      configureEnv: (env: Env) => {
+        env.TELEMETRY_R2 = makeEmptyR2();
+      },
+      query: 'tripToken=tok',
+      authHeader: 'Bearer some-token',
+      expectedStatus: 503,
+    },
+    {
+      label: '401 when no Authorization header',
+      configureEnv: (env: Env) => {
+        env.ADMIN_TOKEN = 'secret';
+        env.TELEMETRY_R2 = makeEmptyR2();
+      },
+      query: 'tripToken=tok',
+      authHeader: undefined,
+      expectedStatus: 401,
+    },
+    {
+      label: '400 when tripToken missing',
+      configureEnv: (env: Env) => {
+        env.ADMIN_TOKEN = 'secret';
+        env.TELEMETRY_R2 = makeEmptyR2();
+      },
+      query: '',
+      authHeader: 'Bearer secret',
+      expectedStatus: 400,
+    },
+    {
+      label: '503 when TELEMETRY_R2 binding unavailable',
+      configureEnv: (env: Env) => {
+        env.ADMIN_TOKEN = 'secret';
+      },
+      query: 'tripToken=tok',
+      authHeader: 'Bearer secret',
+      expectedStatus: 503,
+    },
+  ])('returns $expectedStatus — $label', async ({ configureEnv, query, authHeader, expectedStatus }) => {
+    const env = makeKvEnv();
+    configureEnv(env);
+    const res = await getAdminBaselineCheck(env, query, authHeader);
+    expect(res.status).toBe(expectedStatus);
+  });
+
+  it('returns 200 with baseline=fail shape (empty KV + empty R2)', async () => {
+    const env = makeKvEnv();
+    env.ADMIN_TOKEN = 'secret';
+    env.TELEMETRY_R2 = makeEmptyR2();
+    const res = await getAdminBaselineCheck(env, 'tripToken=tok', 'Bearer secret');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      baseline: string;
+      signals: {
+        tripActive: boolean;
+        silentPushFired: number;
+        silentPushReceived: number;
+        v1Mismatch: number;
+      };
+    };
+    // No fired push, no mismatch — baseline 'fail' (silentPushFired === 0).
+    expect(body.baseline).toBe('fail');
+    expect(body.signals.tripActive).toBe(false);
+    expect(body.signals.silentPushFired).toBe(0);
+    expect(body.signals.v1Mismatch).toBe(0);
   });
 });

--- a/backend/alarm-worker/src/alarmLogStats.ts
+++ b/backend/alarm-worker/src/alarmLogStats.ts
@@ -1,0 +1,187 @@
+/**
+ * Alarm-log stats aggregator (#1621 Phase A).
+ *
+ * 배경
+ * ====
+ * `alarmLogForward.ts:storeAlarmLogForward`가 trip 종료 시 device가 forward한 alarmLog/fusionLog
+ * snapshot을 R2 `trip-evidence/YYYY/MM/DD/{tokenPrefix}-{tripStartedAt}.ndjson` 키로 90일 보관한다.
+ * 본 모듈은 그 archive를 1h 윈도우로 scan해 reason/source 별 분포를 산출 — `/admin/alarm-log-stats`
+ * RCA endpoint가 노출.
+ *
+ * 측정 신호
+ * =========
+ * - `totalEvents`: 1h 윈도우 안에 archive된 alarmLog entry 수
+ * - `fired`/`suppressed`/`received`: outcome 분포
+ * - `reasons`: AlarmLogReason 분포 (e.g. `cross-trip-mirror-leak`, `lockless-forward-only-block`)
+ * - `sources`: AlarmLogSource 분포 (e.g. `silent-push-fired`, `fg-arvlcd`)
+ * - `tripsScanned`: 윈도우 안에 scan된 trip-evidence object 수
+ *
+ * R2 cost
+ * =======
+ * `r2.list({ prefix })` + 각 object get. windowHours 안에 종료된 trip만 scan (cursor pagination).
+ * `limit` param으로 cap (default 50 trips, max 500). 평소 production 1h ~ <10 trips 예상.
+ *
+ * Privacy
+ * =======
+ * archive 자체가 token 8자 prefix만 저장 — 본 endpoint도 동일 보장. 응답에는 stats만 노출,
+ * 개별 trip identifier/원문 미포함.
+ */
+
+const TRIP_EVIDENCE_PREFIX = 'trip-evidence/';
+const MS_PER_HOUR = 60 * 60 * 1000;
+
+/** 단일 alarmLog entry 최소 shape — 사후 분석에 필요한 필드만 narrow.  */
+interface AlarmLogEntryLike {
+  ts?: number;
+  source?: string;
+  outcome?: string;
+  reason?: string;
+}
+
+/**
+ * `/admin/alarm-log-stats` 응답 shape.
+ *
+ * - `windowStart` / `windowEnd`: 측정 윈도우 (epoch ms)
+ * - `totalEvents`: 윈도우 안 alarmLog entry 총 수
+ * - `fired` / `suppressed` / `received`: outcome 분포
+ * - `reasons`: AlarmLogReason 분포 — top-20 정렬
+ * - `sources`: AlarmLogSource 분포 — top-20 정렬
+ * - `tripsScanned`: 윈도우 안 scan된 trip-evidence object 수
+ */
+export interface AlarmLogStatsResponse {
+  windowStart: number;
+  windowEnd: number;
+  totalEvents: number;
+  fired: number;
+  suppressed: number;
+  received: number;
+  reasons: Record<string, number>;
+  sources: Record<string, number>;
+  tripsScanned: number;
+}
+
+/** parse 결과를 outcome/source/reason 카운터에 누적. shape mismatch entry는 silent drop. */
+function accumulateEntry(
+  entry: AlarmLogEntryLike,
+  outcomeCounts: Record<string, number>,
+  reasonCounts: Record<string, number>,
+  sourceCounts: Record<string, number>,
+): void {
+  if (typeof entry.outcome === 'string' && entry.outcome.length > 0) {
+    outcomeCounts[entry.outcome] = (outcomeCounts[entry.outcome] ?? 0) + 1;
+  }
+  if (typeof entry.source === 'string' && entry.source.length > 0) {
+    sourceCounts[entry.source] = (sourceCounts[entry.source] ?? 0) + 1;
+  }
+  if (typeof entry.reason === 'string' && entry.reason.length > 0) {
+    reasonCounts[entry.reason] = (reasonCounts[entry.reason] ?? 0) + 1;
+  }
+}
+
+/** ndjson 본문에서 alarmLog 줄만 추려 entries 추출. malformed 줄/kind는 silent drop. */
+function extractAlarmLogEntries(body: string): AlarmLogEntryLike[] {
+  const out: AlarmLogEntryLike[] = [];
+  for (const line of body.split('\n')) {
+    if (!line) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== 'object') continue;
+    const obj = parsed as { kind?: unknown; entries?: unknown };
+    if (obj.kind !== 'alarmLog') continue;
+    if (!Array.isArray(obj.entries)) continue;
+    for (const e of obj.entries) {
+      if (e && typeof e === 'object') out.push(e as AlarmLogEntryLike);
+    }
+  }
+  return out;
+}
+
+/** `customMetadata.tripEndedAt`이 윈도우 안인지 판정. metadata 미존재 시 false (skip). */
+function isObjectInWindow(
+  meta: Record<string, string> | undefined,
+  windowStart: number,
+  windowEnd: number,
+): boolean {
+  if (!meta) return false;
+  const rawEnd = meta.tripEndedAt;
+  if (typeof rawEnd !== 'string') return false;
+  const ended = Number.parseInt(rawEnd, 10);
+  if (!Number.isFinite(ended)) return false;
+  return ended >= windowStart && ended <= windowEnd;
+}
+
+/** top-N entry만 추출 (response size 보호 — reason/source 다양성 100+ 가능). */
+function topN(dict: Record<string, number>, n: number): Record<string, number> {
+  const sorted = Object.entries(dict)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n);
+  return Object.fromEntries(sorted);
+}
+
+/**
+ * R2 archive scan으로 windowHours 윈도우 안 alarmLog 분포 산출.
+ *
+ * @param r2 TELEMETRY_R2 bucket
+ * @param now 현재 epoch ms (윈도우 계산 기준)
+ * @param windowHours 윈도우 (default 1, 1~24 clamp)
+ * @param limit 최대 enumerate trip-evidence object 수 (default 50, max 500)
+ */
+export async function computeAlarmLogStats(
+  r2: R2Bucket,
+  now: number,
+  windowHours = 1,
+  limit = 50,
+): Promise<AlarmLogStatsResponse> {
+  const safeWindowHours = Math.max(1, Math.min(24, windowHours));
+  const safeLimit = Math.max(1, Math.min(500, limit));
+  const windowStart = now - safeWindowHours * MS_PER_HOUR;
+  const windowEnd = now;
+
+  const outcomeCounts: Record<string, number> = {};
+  const reasonCounts: Record<string, number> = {};
+  const sourceCounts: Record<string, number> = {};
+  let totalEvents = 0;
+  let tripsScanned = 0;
+
+  let cursor: string | undefined;
+  let enumerated = 0;
+  do {
+    const result = await r2.list({
+      prefix: TRIP_EVIDENCE_PREFIX,
+      cursor,
+      limit: Math.min(safeLimit - enumerated, 1000),
+    });
+    for (const obj of result.objects) {
+      if (enumerated >= safeLimit) break;
+      enumerated += 1;
+      if (!isObjectInWindow(obj.customMetadata, windowStart, windowEnd)) continue;
+      const archived = await r2.get(obj.key);
+      if (!archived) continue;
+      const body = await archived.text();
+      const entries = extractAlarmLogEntries(body);
+      if (entries.length === 0) continue;
+      tripsScanned += 1;
+      for (const e of entries) {
+        totalEvents += 1;
+        accumulateEntry(e, outcomeCounts, reasonCounts, sourceCounts);
+      }
+    }
+    cursor = result.truncated && enumerated < safeLimit ? result.cursor : undefined;
+  } while (cursor);
+
+  return {
+    windowStart,
+    windowEnd,
+    totalEvents,
+    fired: outcomeCounts.fired ?? 0,
+    suppressed: outcomeCounts.suppressed ?? 0,
+    received: outcomeCounts.received ?? 0,
+    reasons: topN(reasonCounts, 20),
+    sources: topN(sourceCounts, 20),
+    tripsScanned,
+  };
+}

--- a/backend/alarm-worker/src/alarmLogStats.ts
+++ b/backend/alarm-worker/src/alarmLogStats.ts
@@ -78,24 +78,29 @@ function accumulateEntry(
   }
 }
 
+/** 단일 ndjson 줄을 parse → alarmLog kind면 entries 추출, 아니면 null. malformed silent drop. */
+function parseAlarmLogLine(line: string): AlarmLogEntryLike[] | null {
+  if (!line) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const obj = parsed as { kind?: unknown; entries?: unknown };
+  if (obj.kind !== 'alarmLog' || !Array.isArray(obj.entries)) return null;
+  return obj.entries.filter(
+    (e): e is AlarmLogEntryLike => !!e && typeof e === 'object',
+  );
+}
+
 /** ndjson 본문에서 alarmLog 줄만 추려 entries 추출. malformed 줄/kind는 silent drop. */
 function extractAlarmLogEntries(body: string): AlarmLogEntryLike[] {
   const out: AlarmLogEntryLike[] = [];
   for (const line of body.split('\n')) {
-    if (!line) continue;
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(line);
-    } catch {
-      continue;
-    }
-    if (!parsed || typeof parsed !== 'object') continue;
-    const obj = parsed as { kind?: unknown; entries?: unknown };
-    if (obj.kind !== 'alarmLog') continue;
-    if (!Array.isArray(obj.entries)) continue;
-    for (const e of obj.entries) {
-      if (e && typeof e === 'object') out.push(e as AlarmLogEntryLike);
-    }
+    const entries = parseAlarmLogLine(line);
+    if (entries) out.push(...entries);
   }
   return out;
 }
@@ -122,6 +127,36 @@ function topN(dict: Record<string, number>, n: number): Record<string, number> {
   return Object.fromEntries(sorted);
 }
 
+/** scan loop 누적 카운터 — outcome/reason/source dict + totalEvents/tripsScanned. */
+interface ScanAccumulator {
+  outcomeCounts: Record<string, number>;
+  reasonCounts: Record<string, number>;
+  sourceCounts: Record<string, number>;
+  totalEvents: number;
+  tripsScanned: number;
+}
+
+/** 단일 trip-evidence object를 윈도우 필터링 후 acc에 누적. window 밖/빈 archive는 no-op. */
+async function scanTripEvidenceObject(
+  r2: R2Bucket,
+  obj: R2Object,
+  windowStart: number,
+  windowEnd: number,
+  acc: ScanAccumulator,
+): Promise<void> {
+  if (!isObjectInWindow(obj.customMetadata, windowStart, windowEnd)) return;
+  const archived = await r2.get(obj.key);
+  if (!archived) return;
+  const body = await archived.text();
+  const entries = extractAlarmLogEntries(body);
+  if (entries.length === 0) return;
+  acc.tripsScanned += 1;
+  for (const e of entries) {
+    acc.totalEvents += 1;
+    accumulateEntry(e, acc.outcomeCounts, acc.reasonCounts, acc.sourceCounts);
+  }
+}
+
 /**
  * R2 archive scan으로 windowHours 윈도우 안 alarmLog 분포 산출.
  *
@@ -141,11 +176,13 @@ export async function computeAlarmLogStats(
   const windowStart = now - safeWindowHours * MS_PER_HOUR;
   const windowEnd = now;
 
-  const outcomeCounts: Record<string, number> = {};
-  const reasonCounts: Record<string, number> = {};
-  const sourceCounts: Record<string, number> = {};
-  let totalEvents = 0;
-  let tripsScanned = 0;
+  const acc: ScanAccumulator = {
+    outcomeCounts: {},
+    reasonCounts: {},
+    sourceCounts: {},
+    totalEvents: 0,
+    tripsScanned: 0,
+  };
 
   let cursor: string | undefined;
   let enumerated = 0;
@@ -158,17 +195,7 @@ export async function computeAlarmLogStats(
     for (const obj of result.objects) {
       if (enumerated >= safeLimit) break;
       enumerated += 1;
-      if (!isObjectInWindow(obj.customMetadata, windowStart, windowEnd)) continue;
-      const archived = await r2.get(obj.key);
-      if (!archived) continue;
-      const body = await archived.text();
-      const entries = extractAlarmLogEntries(body);
-      if (entries.length === 0) continue;
-      tripsScanned += 1;
-      for (const e of entries) {
-        totalEvents += 1;
-        accumulateEntry(e, outcomeCounts, reasonCounts, sourceCounts);
-      }
+      await scanTripEvidenceObject(r2, obj, windowStart, windowEnd, acc);
     }
     cursor = result.truncated && enumerated < safeLimit ? result.cursor : undefined;
   } while (cursor);
@@ -176,12 +203,12 @@ export async function computeAlarmLogStats(
   return {
     windowStart,
     windowEnd,
-    totalEvents,
-    fired: outcomeCounts.fired ?? 0,
-    suppressed: outcomeCounts.suppressed ?? 0,
-    received: outcomeCounts.received ?? 0,
-    reasons: topN(reasonCounts, 20),
-    sources: topN(sourceCounts, 20),
-    tripsScanned,
+    totalEvents: acc.totalEvents,
+    fired: acc.outcomeCounts.fired ?? 0,
+    suppressed: acc.outcomeCounts.suppressed ?? 0,
+    received: acc.outcomeCounts.received ?? 0,
+    reasons: topN(acc.reasonCounts, 20),
+    sources: topN(acc.sourceCounts, 20),
+    tripsScanned: acc.tripsScanned,
   };
 }

--- a/backend/alarm-worker/src/baselineCheck.ts
+++ b/backend/alarm-worker/src/baselineCheck.ts
@@ -1,0 +1,75 @@
+/**
+ * Baseline check aggregator (#1621 Phase C).
+ *
+ * 배경
+ * ====
+ * 사용자 framework: "측정을 할 수 있는 기본을 만들어 놓고 측정". V1 회복(Stage 1/2/3 누적)으로
+ * "현재 위치 정확 + backend가 trainCode 알고 silent 알림 도달"이 baseline 정의. 본 모듈은
+ * 사용자 1 trip 시 즉시 pass/fail을 산출 — 자동 baseline 작동 verify.
+ *
+ * 측정 신호
+ * =========
+ *  - `tripActive`: KV `trip:{token}` 존재 여부 (활성 trip 여부)
+ *  - `silentPushFired`: KV `pending:` prefix 카운트 (in-flight push, 60s TTL)
+ *  - `silentPushReceived`: KV `received:` prefix 1h 윈도우 ack 카운트
+ *  - `v1Mismatch`: R2 alarm-log 1h 윈도우 'v1-mismatch' reason 카운트
+ *
+ * pass 조건:
+ *  - `silentPushFired > 0` (baseline 알림 path 작동)
+ *  - `v1Mismatch === 0` (현재역 정확)
+ *
+ * 둘 중 하나라도 미충족 → fail (운영자가 RCA endpoint로 reason 분포 탐색).
+ *
+ * R2 cost: alarmLogStats와 동일 (1h 윈도우, 50 trip cap).
+ */
+
+import { computePushAckStats } from './pushAckStats';
+import { computeAlarmLogStats } from './alarmLogStats';
+import { getTrip } from './trips';
+
+export interface BaselineSignals {
+  tripActive: boolean;
+  silentPushFired: number;
+  silentPushReceived: number;
+  v1Mismatch: number;
+}
+
+export interface BaselineCheckResponse {
+  baseline: 'pass' | 'fail';
+  signals: BaselineSignals;
+}
+
+/**
+ * baseline 작동 신호 집계 + pass/fail 산출.
+ *
+ * @param kv TRIPS KV namespace
+ * @param r2 TELEMETRY_R2 bucket (V1 mismatch source)
+ * @param token 사용자 trip token (활성 trip 신호 source)
+ * @param now epoch ms
+ */
+export async function computeBaselineCheck(
+  kv: KVNamespace,
+  r2: R2Bucket,
+  token: string,
+  now: number,
+): Promise<BaselineCheckResponse> {
+  const [trip, pushStats, alarmStats] = await Promise.all([
+    getTrip(kv, token),
+    computePushAckStats(kv, now),
+    computeAlarmLogStats(r2, now, 1),
+  ]);
+
+  const signals: BaselineSignals = {
+    tripActive: trip !== null,
+    // pending count는 in-flight push 수 — 본 endpoint는 fired 인디케이터로 사용.
+    // received는 ack 도달, fired는 backend 발사 → 운영자가 둘 다 본다.
+    silentPushFired: pushStats.pending + pushStats.received,
+    silentPushReceived: pushStats.received,
+    v1Mismatch: alarmStats.reasons['v1-mismatch'] ?? 0,
+  };
+
+  const baseline: 'pass' | 'fail' =
+    signals.silentPushFired > 0 && signals.v1Mismatch === 0 ? 'pass' : 'fail';
+
+  return { baseline, signals };
+}

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -41,6 +41,8 @@ import {
 } from './liveActivity';
 import { ackPending, stampReceived } from './pendingPushes';
 import { computePushAckStats } from './pushAckStats';
+import { computeAlarmLogStats } from './alarmLogStats';
+import { computeBaselineCheck } from './baselineCheck';
 import { appendPositionPoint } from './positionSeries';
 import { appendAccelSample, isAccelSummary } from './accelSeries';
 import { updateSsotMotion } from './motionState';
@@ -322,6 +324,64 @@ app.get('/admin/push-ack-stats', async (c) => {
   const limit = parseQueryNumber(c.req.query('limit'));
   const stats = await computePushAckStats(kv, Date.now(), limit);
   return c.json(stats);
+});
+
+/**
+ * #1621 Phase A — Device R2 archive alarmLog 분포 RCA endpoint.
+ *
+ * `alarmLogForward.ts:storeAlarmLogForward`가 trip 종료 시 archive한 `trip-evidence/`
+ * R2 object를 windowHours(default 1, max 24) 윈도우로 scan해 reason/source 분포 산출.
+ * 사용자 trip 1건이 종료되면 다음 호출에서 즉시 분포 노출 — baseline 측정 자동화.
+ *
+ * Auth: `Authorization: Bearer <ADMIN_TOKEN>` — admin 공통 정책.
+ * Query:
+ *   - `?windowHours=N` (default 1, clamp 1~24)
+ *   - `?limit=N` (default 50, max 500 — R2 cost 보호)
+ *
+ * Response 200: { windowStart, windowEnd, totalEvents, fired, suppressed, received,
+ *                 reasons, sources, tripsScanned }
+ * Response 401/503: 인증/binding 정책 동일 (TELEMETRY_R2 미바인딩 시 503 graceful).
+ */
+app.get('/admin/alarm-log-stats', async (c) => {
+  const authError = checkAdminAuth(c.req.header('authorization'), c.env.ADMIN_TOKEN);
+  if (authError) return c.json({ error: authError.code }, authError.status);
+  const r2 = c.env.TELEMETRY_R2;
+  if (!r2) return c.json({ error: 'telemetry_r2_unavailable' }, 503);
+  const windowHours = parseQueryNumber(c.req.query('windowHours')) ?? 1;
+  const limit = parseQueryNumber(c.req.query('limit')) ?? 50;
+  const stats = await computeAlarmLogStats(r2, Date.now(), windowHours, limit);
+  return c.json(stats);
+});
+
+/**
+ * #1621 Phase C — Baseline 작동 verify endpoint.
+ *
+ * 사용자 framework: 측정 기본 만들어 놓고 측정. 사용자 1 trip 시 즉시 baseline 작동
+ * (silent push 발사 + V1 mismatch 0) pass/fail 산출. V1 회복(Stage 1/2/3) 효과를
+ * 사용자 trip 1건이면 바로 검증 가능.
+ *
+ * Auth: `Authorization: Bearer <ADMIN_TOKEN>` — admin 공통 정책.
+ * Query: `?tripToken=<X>` — 필수 (활성 trip 신호 source).
+ *
+ * Response 200: { baseline: 'pass' | 'fail', signals: {
+ *   tripActive, silentPushFired, silentPushReceived, v1Mismatch
+ * }}
+ * Response 400: { error: 'invalid_trip_token' } — tripToken 누락
+ * Response 401/503: 인증/binding 정책 동일 (TRIPS 또는 TELEMETRY_R2 미바인딩 시 503).
+ */
+app.get('/admin/baseline-check', async (c) => {
+  const authError = checkAdminAuth(c.req.header('authorization'), c.env.ADMIN_TOKEN);
+  if (authError) return c.json({ error: authError.code }, authError.status);
+  const tripToken = c.req.query('tripToken');
+  if (!tripToken || tripToken.length === 0) {
+    return c.json({ error: 'invalid_trip_token' }, 400);
+  }
+  const kv = c.env.TRIPS;
+  if (!kv) return c.json({ error: 'trips_unavailable' }, 503);
+  const r2 = c.env.TELEMETRY_R2;
+  if (!r2) return c.json({ error: 'telemetry_r2_unavailable' }, 503);
+  const result = await computeBaselineCheck(kv, r2, tripToken, Date.now());
+  return c.json(result);
 });
 
 interface AdminAuthError {

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -195,7 +195,12 @@ export type AlarmLogReason =
   // 추정된 arcStations에 의해 backward jump candidate를 reject한 경우. boardingLock 없으면 forward-only
   // 가드가 OFF였던 기존 동작과 다르게 보수적 안전망 — R2 lockless time-integration cascade(backward
   // jump 허용) 차단. 1주 production 측정: false reject 빈도 + 사용자 trip V1 회복 evidence.
-  | 'lockless-forward-only-block';
+  | 'lockless-forward-only-block'
+  // #1621 (Phase B) — V1 자동 측정 신호: UI currentStation(useFusedNearestStation.result.station.id)이
+  // backend SSoT mirror(currentStationId)와 일치하지 않을 때 적재. mismatch는 lockless 회복 path
+  // (Stage 1/2/3 누적) 효과를 직접 측정 — 1주 production 카운트 ≪ baseline trip 수면 V1 회복 신호.
+  // dedup 1분 윈도우 + (ui, ssot) 쌍 키 — 같은 mismatch가 폴링 cycle마다 반복 적재되는 회귀 차단.
+  | 'v1-mismatch';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.

--- a/src/features/nearest-station/hooks/__tests__/useV1MismatchDetector.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useV1MismatchDetector.test.ts
@@ -1,0 +1,124 @@
+/**
+ * #1621 Phase B — useV1MismatchDetector 단위 테스트.
+ *
+ * 동작:
+ *   1. UI/SSoT 일치 → appendAlarmLog 호출 X
+ *   2. UI/SSoT 다름 → appendAlarmLog 1건 호출 (reason='v1-mismatch')
+ *   3. null input (둘 중 하나라도 null) → no-op
+ *   4. 같은 (ui, ssot) mismatch 반복 → 1분 dedup
+ *   5. 다른 mismatch 쌍 → 각각 적재
+ */
+
+const mockAppend = jest.fn();
+jest.mock('../../../alarm/utils/alarmLog', () => ({
+  appendAlarmLog: (entry: unknown) => mockAppend(entry),
+}));
+
+import { renderHook } from '@testing-library/react-native';
+import {
+  useV1MismatchDetector,
+  V1_MISMATCH_DEDUP_WINDOW_MS,
+} from '../useV1MismatchDetector';
+
+describe('useV1MismatchDetector (#1621 Phase B)', () => {
+  beforeEach(() => {
+    mockAppend.mockReset();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-06-21T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it.each([
+    {
+      label: 'UI/SSoT 일치',
+      ui: 'STN_A',
+      ssot: 'STN_A',
+    },
+    {
+      label: 'UI null',
+      ui: null,
+      ssot: 'STN_A',
+    },
+    {
+      label: 'SSoT null',
+      ui: 'STN_A',
+      ssot: null,
+    },
+    {
+      label: '둘 다 null',
+      ui: null,
+      ssot: null,
+    },
+  ])('적재 X — $label', ({ ui, ssot }) => {
+    renderHook(() => useV1MismatchDetector(ui, ssot));
+    expect(mockAppend).not.toHaveBeenCalled();
+  });
+
+  it('UI/SSoT 다름 → alarmLog v1-mismatch 1건 적재', () => {
+    renderHook(() => useV1MismatchDetector('STN_UI', 'STN_SSOT'));
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+    const entry = mockAppend.mock.calls[0][0];
+    expect(entry.source).toBe('fg-evaluated');
+    expect(entry.outcome).toBe('suppressed');
+    expect(entry.reason).toBe('v1-mismatch');
+    expect(entry.stationName).toBe('STN_UI');
+    expect(entry.expectedStationAtFire).toBe('STN_SSOT');
+  });
+
+  it('같은 (ui, ssot) mismatch 반복 — re-render에도 effect 미재실행 (deps 안 변함)', () => {
+    const { rerender } = renderHook(
+      ({ ui, ssot }: { ui: string; ssot: string }) => useV1MismatchDetector(ui, ssot),
+      { initialProps: { ui: 'STN_UI', ssot: 'STN_SSOT' } },
+    );
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+    // 같은 props 재호출 — useEffect deps([ui, ssot]) 안 바뀌어 재실행 X.
+    rerender({ ui: 'STN_UI', ssot: 'STN_SSOT' });
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+    rerender({ ui: 'STN_UI', ssot: 'STN_SSOT' });
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+  });
+
+  it('같은 쌍이 dedup window 안에 재진입 시 차단 (effect deps 변경 케이스)', () => {
+    const { rerender } = renderHook(
+      ({ ui, ssot }: { ui: string; ssot: string }) => useV1MismatchDetector(ui, ssot),
+      { initialProps: { ui: 'STN_UI', ssot: 'STN_SSOT' } },
+    );
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+    // 일시적으로 SSoT가 UI와 일치 → mismatch 아님 (적재 X).
+    rerender({ ui: 'STN_UI', ssot: 'STN_UI' });
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+    // 같은 쌍 재진입 — dedup window 안이라 차단.
+    rerender({ ui: 'STN_UI', ssot: 'STN_SSOT' });
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedup 윈도우 만료 후 같은 쌍 재적재', () => {
+    const { rerender } = renderHook(
+      ({ ui, ssot }: { ui: string; ssot: string }) => useV1MismatchDetector(ui, ssot),
+      { initialProps: { ui: 'STN_UI', ssot: 'STN_SSOT' } },
+    );
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+    // 다른 쌍으로 잠시 전환
+    rerender({ ui: 'STN_OTHER', ssot: 'STN_SSOT' });
+    expect(mockAppend).toHaveBeenCalledTimes(2);
+    // 시간 점프 후 동일 (UI, SSoT) 쌍 복귀
+    jest.setSystemTime(new Date(Date.now() + V1_MISMATCH_DEDUP_WINDOW_MS + 1));
+    rerender({ ui: 'STN_UI', ssot: 'STN_SSOT' });
+    expect(mockAppend).toHaveBeenCalledTimes(3);
+  });
+
+  it('다른 (ui, ssot) 쌍은 각각 적재', () => {
+    const { rerender } = renderHook(
+      ({ ui, ssot }: { ui: string; ssot: string }) => useV1MismatchDetector(ui, ssot),
+      { initialProps: { ui: 'STN_A', ssot: 'STN_X' } },
+    );
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+    rerender({ ui: 'STN_B', ssot: 'STN_Y' });
+    expect(mockAppend).toHaveBeenCalledTimes(2);
+    rerender({ ui: 'STN_C', ssot: 'STN_Z' });
+    expect(mockAppend).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/features/nearest-station/hooks/__tests__/useV1MismatchDetector.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useV1MismatchDetector.test.ts
@@ -20,6 +20,15 @@ import {
   V1_MISMATCH_DEDUP_WINDOW_MS,
 } from '../useV1MismatchDetector';
 
+/** rerender 가능한 hook factory — 4건 테스트의 동일 setup 중복 제거. */
+function renderDetector(initialProps: { ui: string | null; ssot: string | null }) {
+  return renderHook(
+    ({ ui, ssot }: { ui: string | null; ssot: string | null }) =>
+      useV1MismatchDetector(ui, ssot),
+    { initialProps },
+  );
+}
+
 describe('useV1MismatchDetector (#1621 Phase B)', () => {
   beforeEach(() => {
     mockAppend.mockReset();
@@ -69,10 +78,7 @@ describe('useV1MismatchDetector (#1621 Phase B)', () => {
   });
 
   it('같은 (ui, ssot) mismatch 반복 — re-render에도 effect 미재실행 (deps 안 변함)', () => {
-    const { rerender } = renderHook(
-      ({ ui, ssot }: { ui: string; ssot: string }) => useV1MismatchDetector(ui, ssot),
-      { initialProps: { ui: 'STN_UI', ssot: 'STN_SSOT' } },
-    );
+    const { rerender } = renderDetector({ ui: 'STN_UI', ssot: 'STN_SSOT' });
     expect(mockAppend).toHaveBeenCalledTimes(1);
     // 같은 props 재호출 — useEffect deps([ui, ssot]) 안 바뀌어 재실행 X.
     rerender({ ui: 'STN_UI', ssot: 'STN_SSOT' });
@@ -82,10 +88,7 @@ describe('useV1MismatchDetector (#1621 Phase B)', () => {
   });
 
   it('같은 쌍이 dedup window 안에 재진입 시 차단 (effect deps 변경 케이스)', () => {
-    const { rerender } = renderHook(
-      ({ ui, ssot }: { ui: string; ssot: string }) => useV1MismatchDetector(ui, ssot),
-      { initialProps: { ui: 'STN_UI', ssot: 'STN_SSOT' } },
-    );
+    const { rerender } = renderDetector({ ui: 'STN_UI', ssot: 'STN_SSOT' });
     expect(mockAppend).toHaveBeenCalledTimes(1);
     // 일시적으로 SSoT가 UI와 일치 → mismatch 아님 (적재 X).
     rerender({ ui: 'STN_UI', ssot: 'STN_UI' });
@@ -96,10 +99,7 @@ describe('useV1MismatchDetector (#1621 Phase B)', () => {
   });
 
   it('dedup 윈도우 만료 후 같은 쌍 재적재', () => {
-    const { rerender } = renderHook(
-      ({ ui, ssot }: { ui: string; ssot: string }) => useV1MismatchDetector(ui, ssot),
-      { initialProps: { ui: 'STN_UI', ssot: 'STN_SSOT' } },
-    );
+    const { rerender } = renderDetector({ ui: 'STN_UI', ssot: 'STN_SSOT' });
     expect(mockAppend).toHaveBeenCalledTimes(1);
     // 다른 쌍으로 잠시 전환
     rerender({ ui: 'STN_OTHER', ssot: 'STN_SSOT' });
@@ -111,10 +111,7 @@ describe('useV1MismatchDetector (#1621 Phase B)', () => {
   });
 
   it('다른 (ui, ssot) 쌍은 각각 적재', () => {
-    const { rerender } = renderHook(
-      ({ ui, ssot }: { ui: string; ssot: string }) => useV1MismatchDetector(ui, ssot),
-      { initialProps: { ui: 'STN_A', ssot: 'STN_X' } },
-    );
+    const { rerender } = renderDetector({ ui: 'STN_A', ssot: 'STN_X' });
     expect(mockAppend).toHaveBeenCalledTimes(1);
     rerender({ ui: 'STN_B', ssot: 'STN_Y' });
     expect(mockAppend).toHaveBeenCalledTimes(2);

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -223,6 +223,14 @@ interface UseFusedNearestStationReturn {
    * fire path SSOT(result/confidence/source)에서 분리되어 표시 채널로만 노출된다.
    */
   stickyDisplayOnly: import('../../../shared/types/station').Station | null;
+  /**
+   * #1621 (Phase B) — backend SSoT mirror가 fresh일 때 currentStationId, 미존재/stale일 때 null.
+   *
+   * `useV1MismatchDetector(uiCurrentStationId, ssotCurrentStationId)`의 두 번째 입력.
+   * cascade picker 내부 polling(5s)을 재사용해 별도 폴링 중복 방지 — consumer는 이 값만 받으면
+   * V1 mismatch 자동 측정에 충분.
+   */
+  backendSsotCurrentStationId: string | null;
   refresh: () => Promise<void>;
 }
 
@@ -1474,8 +1482,12 @@ export function useFusedNearestStation(
     surfaceSSOT,
     undergroundSSOT,
     // #1486 (ADR-015 §2) — sticky 표시 채널 패스스루. useNearestStation이 sticky.locked를 노출하고
-    // 본 hook은 그대로 통과. fire path는 본 필드를 읽지 않는다.
+    // 본 hook은 그대로 통과. fire path는 본 필드는 읽지 않는다.
     stickyDisplayOnly: gps.stickyDisplayOnly,
+    // #1621 (Phase B) — V1 mismatch 자동 측정용. silent push handler가 영속화한 backend SSoT
+    // currentStationId를 그대로 노출. mirror null/stale 시 null. consumer는
+    // `useV1MismatchDetector(uiCurrentStationId, ssotCurrentStationId)` 한 줄로 wire.
+    backendSsotCurrentStationId: backendSsotMirror?.currentStationId ?? null,
     refresh: gps.refresh,
   };
 }

--- a/src/features/nearest-station/hooks/useV1MismatchDetector.ts
+++ b/src/features/nearest-station/hooks/useV1MismatchDetector.ts
@@ -48,7 +48,7 @@ export function useV1MismatchDetector(
     const now = Date.now();
     const key = `${uiCurrentStationId}|${ssotCurrentStationId}`;
     const last = lastMismatchRef.current;
-    if (last && last.key === key && now - last.ts < V1_MISMATCH_DEDUP_WINDOW_MS) return;
+    if (last?.key === key && now - last.ts < V1_MISMATCH_DEDUP_WINDOW_MS) return;
     lastMismatchRef.current = { key, ts: now };
     appendAlarmLog({
       ts: now,

--- a/src/features/nearest-station/hooks/useV1MismatchDetector.ts
+++ b/src/features/nearest-station/hooks/useV1MismatchDetector.ts
@@ -1,0 +1,67 @@
+/* eslint-disable import/no-restricted-paths --
+ * #1621 (Phase B) — cross-feature 측정 인프라. nearest-station 결과(UI currentStationId)와
+ * alarm 슬라이스의 alarmLog를 cross로 연결해 V1 mismatch를 단일 출처(alarmLog reason)로 적재.
+ * useStationAlarm/useFusedNearestStation 등 다른 cross-feature orchestrator와 동일 패턴 — CLAUDE.md
+ * `디렉토리 경계 룰` 섹션에 따라 헤더 opt-in.
+ */
+import { useEffect, useRef } from 'react';
+import { appendAlarmLog } from '../../alarm/utils/alarmLog';
+
+/**
+ * #1621 Phase B — V1 mismatch 자동 측정 hook.
+ *
+ * 배경
+ * ====
+ * Stage 1/2/3-1 (#1613/#1615/#1617) 누적 fix 후 V1(정확한 현재역)이 60-70% 회복 추정.
+ * 그동안 V1 측정은 사용자 trip 직후 수동 annotation에만 의존 — 자동 측정 path 부재 (메모리
+ * `feedback_wire_completion_gate`: "인프라 정의는 있는데 consumer 누락" 패턴 직접 evidence).
+ *
+ * 본 hook은 다음 두 signal을 비교해 mismatch를 alarmLog에 적재:
+ *  - UI currentStation: `useFusedNearestStation`의 result.station.id (cascade picker 결과)
+ *  - backend SSoT mirror: silent push handler가 영속화한 권위 currentStationId
+ *
+ * 두 값이 다르면 V1 회귀 신호 → 1분 dedup 윈도우로 entry 1건 적재.
+ *
+ * Wire-completion
+ * ================
+ * HomeScreen.tsx에서 호출 (consumer site 1개 — useFusedNearestStation 결과 + backendSsotMirror).
+ * R2 archive 후 `/admin/alarm-log-stats` 응답의 `reasons['v1-mismatch']`로 1주 production 측정.
+ *
+ * Race condition guards
+ * =====================
+ *  - 둘 중 하나라도 null이면 비교 skip (graceful no-op).
+ *  - 1분 dedup 윈도우 — 같은 (ui, ssot) 쌍 반복 mismatch는 1회만 적재.
+ *  - SSoT mirror freshness는 caller (useFusedNearestStation)가 이미 60s 윈도우로 판정 후
+ *    null로 두므로 본 hook은 단순 ID 비교만.
+ *
+ * @param uiCurrentStationId useFusedNearestStation.result.station.id (UI 표시 station)
+ * @param ssotCurrentStationId backendSsotMirror.currentStationId (fresh일 때만)
+ */
+export function useV1MismatchDetector(
+  uiCurrentStationId: string | null,
+  ssotCurrentStationId: string | null,
+): void {
+  const lastMismatchRef = useRef<{ key: string; ts: number } | null>(null);
+  useEffect(() => {
+    if (uiCurrentStationId === null || ssotCurrentStationId === null) return;
+    if (uiCurrentStationId === ssotCurrentStationId) return;
+    const now = Date.now();
+    const key = `${uiCurrentStationId}|${ssotCurrentStationId}`;
+    const last = lastMismatchRef.current;
+    if (last && last.key === key && now - last.ts < V1_MISMATCH_DEDUP_WINDOW_MS) return;
+    lastMismatchRef.current = { key, ts: now };
+    appendAlarmLog({
+      ts: now,
+      source: 'fg-evaluated',
+      outcome: 'suppressed',
+      reason: 'v1-mismatch',
+      stationName: uiCurrentStationId,
+      // ssot stationId는 expectedStationAtFire 슬롯 재사용 (새 schema 추가 회피).
+      // DebugModal/baseline-check 응답에서 "expected vs actual" 한 줄로 가시.
+      expectedStationAtFire: ssotCurrentStationId,
+    });
+  }, [uiCurrentStationId, ssotCurrentStationId]);
+}
+
+/** 같은 (ui, ssot) mismatch 쌍 dedup 윈도우. polling cycle 5s를 충분히 흡수. */
+export const V1_MISMATCH_DEDUP_WINDOW_MS = 60 * 1000;

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import * as SplashScreen from 'expo-splash-screen';
 import { useTranslation } from 'react-i18next';
 import { useFusedNearestStation } from '../features/nearest-station/hooks/useFusedNearestStation';
+import { useV1MismatchDetector } from '../features/nearest-station/hooks/useV1MismatchDetector';
 import { useArrivalInfo } from '../features/arrival/hooks/useArrivalInfo';
 import type { ArrivalInfo } from '../features/arrival/api/arrivalApi';
 import { useArrivalCountdown } from '../features/arrival/hooks/useArrivalCountdown';
@@ -191,7 +192,12 @@ export default function HomeScreen() {
   //   2) useCurrentStationConfirmModal: 매칭되면 useStationCandidates가 단일 후보로 자동 확정(#914 F4).
   // useFusedNearestStation 호출(아래) 전에 선언해 8번째 인자로 전달한다.
   const wifiStation = useWifiStation();
-  const { result, liveResult, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source, currentHopIndex, arcStations, trainProgressing } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal }, wifiStation);
+  const { result, liveResult, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source, currentHopIndex, arcStations, trainProgressing, backendSsotCurrentStationId } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal }, wifiStation);
+
+  // #1621 Phase B — V1 mismatch 자동 측정. UI currentStation(cascade picker)이 backend SSoT
+  // 권위 mirror와 일치하지 않으면 alarmLog 'v1-mismatch' reason으로 1분 dedup 적재.
+  // R2 archive 후 `/admin/alarm-log-stats` 응답으로 1주 production 측정.
+  useV1MismatchDetector(result?.station.id ?? null, backendSsotCurrentStationId);
 
   // #914 (F4) — 1탭 현재역 확정 모달. 자동 추정이 locationUncertain으로 길어지면 후보 1~3개를
   // 카드로 노출, 1탭 = customOrigin 적용.


### PR DESCRIPTION
Closes #1621

## 다운로드 가치
사용자 framework "측정을 할 수 있는 기본 만들어 놓고 측정". 사용자 1 trip 시 즉시 baseline 작동 + V/X 측정 자동화.

V/X 매핑:
- V1 (정확한 현재역) — `useV1MismatchDetector` UI vs SSoT 비교 자동 측정
- V4 (매역 silent 알림) — `/admin/alarm-log-stats` 응답으로 silent-push-fired 자동 집계
- baseline pass/fail = silentPushFired > 0 AND v1Mismatch === 0 (사용자 1 trip 즉시)

## 변경 3 Phase (atomic)

### Phase A — backend `/admin/alarm-log-stats` endpoint
- `backend/alarm-worker/src/alarmLogStats.ts` (신규, 187 line)
  - R2 archived `trip-evidence/YYYY/MM/DD/{prefix}-{started}.ndjson` scan
  - windowHours 1~24 clamp + limit 50~500 (R2 cost 보호)
  - reasons/sources top-20 정렬 + tripsScanned 카운트
- `backend/alarm-worker/src/index.ts` admin endpoint wire
  - Bearer auth + TELEMETRY_R2 graceful 503 + parseQueryNumber 패턴

### Phase B — device V1 mismatch 자동 측정
- `src/features/nearest-station/hooks/useV1MismatchDetector.ts` (신규)
  - UI currentStation(`result.station.id`) vs backend SSoT mirror 비교
  - mismatch 시 `alarmLog` `v1-mismatch` reason 적재 (`source='fg-evaluated'`, dedup 1분)
- `src/features/alarm/utils/alarmLog.ts`
  - `AlarmLogReason`에 `'v1-mismatch'` union 추가
- `src/features/nearest-station/hooks/useFusedNearestStation.ts`
  - `backendSsotCurrentStationId` return 신규 export (cascade picker 5s 폴링 재사용)
- `src/screens/HomeScreen.tsx`
  - `useV1MismatchDetector(result?.station.id ?? null, backendSsotCurrentStationId)` wire

### Phase C — backend `/admin/baseline-check` endpoint
- `backend/alarm-worker/src/baselineCheck.ts` (신규, 75 line)
  - tripActive + silentPushFired + silentPushReceived + v1Mismatch 집계
  - pass 조건: silentPushFired > 0 AND v1Mismatch === 0
- index.ts admin endpoint wire (400 tripToken missing / 503 TELEMETRY_R2)

## Wire-completion 5단
1. **Orphan**: pass (`npm run lint:orphan` 0 orphan)
2. **V/X dashboard**: `/admin/alarm-log-stats` 응답이 V/X dashboard SQL source. `/admin/baseline-check` 응답이 사용자 trip 1건 즉시 pass/fail
3. **의존 PR**: PR #1615 `/admin/push-ack-stats` 머지 완료 (computePushAckStats 재사용). 독립 PR
4. **측정 plan**: 사용자 다음 trip 종료 → R2 archive forward → 1주 production. `/admin/alarm-log-stats?windowHours=24` 응답의 `reasons['v1-mismatch']` 카운트로 V1 회복 효과 직접 evidence
5. **Device verify**: device hook wire(useV1MismatchDetector) — 사용자 trip 시 검증

## 운영자 사전 조건
- `wrangler secret put ADMIN_TOKEN` (admin Bearer 인증)
- `wrangler r2 bucket create subway-now-telemetry` + wrangler.toml [[r2_buckets]] binding 활성화 (Phase A/C 응답)
- R2 lifecycle 90일 룰은 Cloudflare Dashboard에서 수동 설정 (기존 #1579와 동일)

## 테스트
- type-check: 0 error (device + backend 양쪽)
- backend: 52 파일 1889 PASS (alarmLogStats 13 + baselineCheck 5 + index admin 6 추가)
- device: 362 파일 7327 PASS / coverage 100%
- Sonar dup 사전 차단: `helpers/r2Fixtures.ts`로 R2 mock 단일 정의 (alarmLogStats/baselineCheck/index 3 파일 공유), it.each + helper 패턴

## 자가 점검 (이슈 #1621 acceptance 5단)
1. acceptance self-referential? PASS — baseline 작동 자체가 사용자 가치 기준
2. Wire-completion CI? PASS — orphan 0, consumer 명시
3. 머지 순서? 독립
4. backward-compat? PASS — 신규 endpoint/hook만, 기존 동작 변경 X
5. False positive? V1 mismatch 측정 timing — 1분 dedup + (ui, ssot) 쌍 key로 폴링 cycle burst 흡수