### PR TITLE
chore(#1623): wrangler.toml Free plan 영구 반영 — Analytics Engine 비활성 + R2 활성

### DIFF
--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -65,9 +65,9 @@ preview_id = "d38f190e3f7f4fd3b6e7f6485dd1733d"
 # ⚠️ Workers Paid plan 필수 — Free plan에서는 binding 선언만으로도 deploy 실패(Cloudflare API 10089).
 # Free plan 환경이면 아래 3줄을 주석 처리. 코드는 `if (env.TRIP_METRICS)` 분기로 graceful —
 # binding 없으면 모든 적재 경로가 no-op (개발/테스트 환경 호환, TELEMETRY 동형).
-[[analytics_engine_datasets]]
-binding = "TRIP_METRICS"
-dataset = "trip_metrics"
+# [[analytics_engine_datasets]]
+# binding = "TRIP_METRICS"
+# dataset = "trip_metrics"
 
 # R2: device alarmLog/fusionLog telemetry forward archive (#1579, Phase 0 epic #1576 P0-3)
 # Trip 종료 시 device가 `POST /telemetry/alarm-log`로 4개 buffer snapshot을 forward.
@@ -80,9 +80,9 @@ dataset = "trip_metrics"
 #   2) 아래 binding 활성화 (id 불필요 — bucket_name만 지정).
 #   3) Cloudflare Dashboard → R2 → subway-now-telemetry → Lifecycle 룰에서
 #      "Delete objects after 90 days" 추가 (cost 절감, evidence는 단기 분석 목적).
-# [[r2_buckets]]
-# binding = "TELEMETRY_R2"
-# bucket_name = "subway-now-telemetry"
+[[r2_buckets]]
+binding = "TELEMETRY_R2"
+bucket_name = "subway-now-telemetry"
 
 # 1분마다 활성 트립 폴링
 [triggers]


### PR DESCRIPTION
Closes #1623

## 요약

Cloudflare Workers **Free plan** 운영 결정에 따라 `backend/alarm-worker/wrangler.toml` 정합화. 이미 production deploy 완료 상태 (#1622 baseline 측정 endpoint 활성화 manual step 진행 중 적용).

## 변경

- `[[analytics_engine_datasets]]` TRIP_METRICS **주석 처리**
  - Free plan에서 Analytics Engine binding 선언만으로 deploy 실패 (Cloudflare API 10089)
  - 코드는 `analytics.ts:60` `if (!writer) return;` graceful no-op
- `[[r2_buckets]]` TELEMETRY_R2 **활성화**
  - device alarmLog forward archive (#1579) + baseline 측정 endpoint (#1622) 데이터 출처
  - bucket `subway-now-telemetry` (이미 존재) + 90일 lifecycle 룰 설정 완료

## 검증

- Frontend `npm test` ✅ 7327/7327 (100% coverage)
- Frontend `npm run type-check` ✅
- `npx wrangler deploy` ✅ Version `450cd0c5-2292-417f-ad91-adb1d34228af`
- `/admin/baseline-check` HTTP 401 (endpoint 존재 + 인증 요구) ✅
- TELEMETRY_R2 binding 활성 확인 (wrangler 출력)

## Wire-completion 5단

1. **Orphan 없음** — config-only, code import 없음 → N/A
2. **V/X dashboard** — Cloudflare Dashboard → subway-now-alarm-worker → Bindings에서 TELEMETRY_R2 활성 확인 가능
3. **의존 PR** — PR #1622 (B 진단 인프라, 머지 완료). 본 PR은 후속 운영 반영
4. **측정 plan** — baseline 측정 endpoint 응답 (1 trip 후 `/admin/baseline-check?tripToken=X`)
5. **Device verify** — N/A (config-only, type+unit 영향 없음)

## 코드 리뷰

`code-review` agent 통과 — P0/P1 없음, ✅ 머지 가능. graceful no-op contract 재사용 일관, 복원 절차 주석에 SSoT화.

## 별개 회귀 발견 (#1624)

본 PR 진행 중 `backend/alarm-worker && npm run type-check`에서 upstream type-check 회귀 3건 발견 (`advanceTripPosition.test.ts`). test code only, deploy/runtime 영향 없음. 별도 이슈 #1624로 분리 — CI에 backend type-check job 누락이 root cause.

## 향후 복원

Workers Paid plan 가입 시 3줄 주석 해제 후 deploy. 별도 PR로 처리.