### PR TITLE
feat(#1626): DebugModal Notifications fired 섹션 추가 — baseline 측정 fidelity 향상

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -219,6 +219,10 @@ function formatTime(ts: number): string {
   return d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
 }
 
+// #1626 — outcome filter helper. AlarmLogOutcome union 값 변경 시 grep이 흩어지지 않게
+// 한 곳에서 표현. SHARE_SECTIONS suffix / section builder / UI 컴포넌트 3곳 공유.
+const isFired = (e: AlarmLogEntry): boolean => e.outcome === 'fired';
+
 function formatLogLine(entry: AlarmLogEntry): string {
   const parts: string[] = [
     formatTime(entry.ts),
@@ -734,6 +738,14 @@ function buildGatesSection(args: BuildDumpArgs): string[] {
   return reasonLine ? [reasonLine] : [];
 }
 
+// #1626 — AlarmLog 중 outcome='fired'만 시간순 reverse. baseline 측정 fidelity 향상:
+// backend `/admin/alarm-log-stats` 호출 없이 device DebugModal에서 V4 발사 시점 즉시 확인.
+// 30s 미만 trip (R2 forward skip)에도 device-local 보존 — 사용자 자가 진단용.
+function buildNotificationsFiredSection(args: BuildDumpArgs): string[] {
+  const fired = args.logs.filter(isFired);
+  return [...fired].reverse().map(formatLogLine);
+}
+
 function buildAlarmLogSection(args: BuildDumpArgs): string[] {
   const lines: string[] = [];
   // #564 — source별 카운트 헤더(UI와 동일 포매터 공유). 빈 문자열이면 헤더 생략.
@@ -1130,6 +1142,14 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
     title: 'Estimator State',
     build: buildEstimatorSection,
     suffix: (args) => ` (${args.estimatorLog?.length ?? 0})`,
+  },
+  // #1626 — V4 발사 시점만 시간순 reverse. Alarm log 통합 섹션 직전에 노출 →
+  // 사용자가 fired 시점 먼저 보고, 거부/시도는 아래 Alarm log에서 분석.
+  {
+    title: 'Notifications fired',
+    build: buildNotificationsFiredSection,
+    omitIfEmpty: true,
+    suffix: (args) => ` (${args.logs.filter(isFired).length})`,
   },
   {
     title: 'Alarm log',
@@ -1954,6 +1974,8 @@ function DebugModalInner({
             <ScheduledQueueBody dump={scheduledDump} colors={colors} />
           </Section>
 
+          <NotificationsFiredSection logs={logs} colors={colors} />
+
           <Section
             title={`Alarm log (${logs.length})`}
             colors={colors}
@@ -2092,6 +2114,37 @@ function ScheduledQueueBody({
         </MonoEntry>
       ))}
     </>
+  );
+}
+
+// #1626 — V4 발사된 notification만 시간순 reverse. baseline 측정 fidelity 향상.
+// fired 0건이면 섹션 자체를 노출하지 않는다 — 사용자 노이즈 최소화 (fired 없으면 Alarm log
+// Section만 보면 충분).
+function NotificationsFiredSection({
+  logs,
+  colors,
+}: Readonly<{
+  logs: readonly AlarmLogEntry[];
+  colors: ReturnType<typeof useTheme>['colors'];
+}>) {
+  const fired = logs.filter(isFired);
+  if (fired.length === 0) return null;
+  return (
+    <Section
+      title={`Notifications fired (${fired.length})`}
+      colors={colors}
+      testID="notifications-fired-section"
+    >
+      {[...fired].reverse().map((entry, idx) => (
+        <MonoEntry
+          key={`fired-${entry.ts}-${idx}`}
+          testID="debug-notifications-fired-entry"
+          colors={colors}
+        >
+          {formatLogLine(entry)}
+        </MonoEntry>
+      ))}
+    </Section>
   );
 }
 

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -292,6 +292,30 @@ describe('DebugModal', () => {
     expect(screen.queryByTestId('debug-log-source-counts')).toBeNull();
   });
 
+  it('Notifications fired 섹션은 outcome=fired만 시간순 reverse로 표시한다 (#1626)', async () => {
+    mockGetAlarmLog.mockResolvedValue([
+      { ts: 1, source: 'fg', outcome: 'fired', stationName: '강남' },
+      { ts: 2, source: 'boarding-prompt', outcome: 'suppressed', reason: 'cooldown' },
+      { ts: 3, source: 'silent-push-received', outcome: 'received' },
+      { ts: 4, source: 'bg-scheduled', outcome: 'fired', stationName: '면목' },
+    ]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(await screen.findByText('Notifications fired (2)')).toBeTruthy();
+    const entries = screen.getAllByTestId('debug-notifications-fired-entry');
+    expect(entries).toHaveLength(2);
+    expect(entries[0].props.children).toContain('면목');
+    expect(entries[1].props.children).toContain('강남');
+  });
+
+  it('fired 0건이면 Notifications fired 섹션 자체를 렌더링하지 않는다 (#1626)', async () => {
+    mockGetAlarmLog.mockResolvedValue([
+      { ts: 1, source: 'fg', outcome: 'suppressed', reason: 'distance-gate' },
+    ]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await screen.findByText('Alarm log (1)');
+    expect(screen.queryByTestId('notifications-fired-section')).toBeNull();
+  });
+
   it('userLocation이 null이면 "no location"을 표시한다', () => {
     mockUseFusedNearestStation.mockReturnValue(
       fusedReturnFixture({


### PR DESCRIPTION
Closes #1626

## 목적

baseline 측정 fidelity 향상 — backend `/admin/alarm-log-stats` endpoint 호출 없이 device DebugModal에서 V4 발사 시점 즉시 verify. 현재 통합 alarm log 섹션에 fired/suppressed/received가 섞여있어 "진짜 알림 발사" 시점 식별이 번거로움. 특히 30s 미만 trip은 R2 forward skip(`telemetryForward.ts:33 MIN_TRIP_DURATION_MS=30_000`)이라 device-local 보존이 유일한 채널.

## 변경

`src/features/debug/components/DebugModal.tsx` (3곳 + helper):
1. **`isFired` helper** — `AlarmLogOutcome` union 값 변경 시 grep이 흩어지지 않게 한 곳 표현 (formatLogLine 옆)
2. **`buildNotificationsFiredSection`** — Share dump용 builder. `args.logs.filter(isFired)` + 시간순 reverse + formatLogLine
3. **SHARE_SECTIONS spec 등록** — Alarm log 직전 `{ title: 'Notifications fired', omitIfEmpty: true, suffix: count }`
4. **UI `NotificationsFiredSection` 컴포넌트** — Alarm log Section 직전 mount. fired 0건이면 `return null`

`src/features/debug/components/__tests__/DebugModal.test.tsx`:
- "Notifications fired 섹션은 outcome=fired만 시간순 reverse로 표시"
- "fired 0건이면 섹션 자체를 렌더링하지 않는다"

## 표시 예시

```
Notifications fired (2)
HH:MM:SS bg-scheduled fired ... 면목
HH:MM:SS fg fired ... 강남

Alarm log (4)
sources: bg-scheduled=1, boarding-prompt=1, fg=1, silent-push-received=1
... (모든 outcome 통합)
```

## 검증

- frontend `npm run type-check` ✅
- `npm test` (전체) ✅ — 7327/7327 (100% coverage)
- DebugModal.tsx targeted coverage 100% (Stmts/Branch/Funcs/Lines) ✅
- `npm run lint:orphan` ✅ — 0 orphan exports

## 코드 리뷰

`code-review` agent 통과 — P1 0건, ✅ 머지 가능.
- P2-1 `isFired` helper 추출 → 같은 PR 내 후속 커밋으로 적용 완료
- P2-2 SHARE_SECTIONS vs UI 정책 중복 → 별도 작업 후보 (현 PR scope 밖)
- P3 권장사항 모두 적용 또는 별도 후속 처리

## Wire-completion 5단

1. **Orphan 없음** ✅ — `npm run lint:orphan` pass. `buildNotificationsFiredSection` / `NotificationsFiredSection` / `isFired` 모두 module-private
2. **V/X dashboard** ✅ — DebugModal Section + Share dump SHARE_SECTIONS 둘 다 노출. V4 발사 시점 device-visible
3. **의존 PR** — N/A (AlarmLogEntry shape는 기존, alarmLog forward 경로 #1579 이미 머지)
4. **측정 plan** ✅ — trip 1회 후 사용자가 DebugModal `Notifications fired (N)` 카운트 확인 → backend `/admin/alarm-log-stats?windowHours=1` `outcome.fired`와 일치하는지 cross-check. 30s 미만 trip은 device-local 카운트만 노출 (R2 forward skip)
5. **Device verify** — UI 변경이라 필수. 시나리오: trip 진행 + 매역 알림 받음 → DebugModal 열어 fired 섹션에 station + source + ts 보이는지 확인

## 후속 (별건)

- #1624 backend type-check 회귀 fix (CI gap 차단)
- baseline 측정 5/11 신호 gap 메우기 (#6/#7/#9/#10/#11 atomic 5 PR — consensusGate strongCB / candidate-reject / cross-trip-mirror-skip / stale-lock-fire / LA multi-hop alarmLog 적재 helper 추가)