### PR TITLE
chore(#1628): 측정 enable device-side 2 fix alarmLog 적재 helper

### DIFF
--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -32,6 +32,12 @@ jest.mock('../../utils/backendSsotMirror', () => ({
   clearBackendSsotMirror: (...args: unknown[]) => mockClearBackendSsotMirror(...args),
 }));
 
+// #1628 — R11-a 차단 1건 측정 검증. clear 호출과 짝지어 같은 site에서 1회만 발사.
+const mockLogCrossTripMirrorSkip = jest.fn();
+jest.mock('../../utils/alarmLog', () => ({
+  logCrossTripMirrorSkip: (...args: unknown[]) => mockLogCrossTripMirrorSkip(...args),
+}));
+
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),
@@ -147,6 +153,9 @@ describe('useApnsTripRegistration', () => {
       const clearOrder = mockClearBackendSsotMirror.mock.invocationCallOrder[0];
       const registerOrder = mockRegister.mock.invocationCallOrder[0];
       expect(clearOrder).toBeLessThan(registerOrder);
+      // #1628 — R11-a 측정 wire-completion: clear와 짝지어 logCrossTripMirrorSkip('register') 1회.
+      expect(mockLogCrossTripMirrorSkip).toHaveBeenCalledWith('register');
+      expect(mockLogCrossTripMirrorSkip).toHaveBeenCalledTimes(1);
     });
 
     it('route/destination 없으면 clearBackendSsotMirror 호출 안 함 (trip 종료 경로는 별경로)', async () => {
@@ -157,6 +166,8 @@ describe('useApnsTripRegistration', () => {
         await Promise.resolve();
       });
       expect(mockClearBackendSsotMirror).not.toHaveBeenCalled();
+      // #1628 — clear가 안 됐으면 측정도 안 발사.
+      expect(mockLogCrossTripMirrorSkip).not.toHaveBeenCalled();
     });
 
     it('토큰 없으면 register skip되고 clearBackendSsotMirror도 호출 안 함', async () => {
@@ -173,6 +184,7 @@ describe('useApnsTripRegistration', () => {
       });
       expect(mockRegister).not.toHaveBeenCalled();
       expect(mockClearBackendSsotMirror).not.toHaveBeenCalled();
+      expect(mockLogCrossTripMirrorSkip).not.toHaveBeenCalled();
     });
   });
 

--- a/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
@@ -45,6 +45,12 @@ jest.mock('../../utils/backendSsotMirror', () => ({
   clearBackendSsotMirror: (...args: unknown[]) => mockClearBackendSsotMirror(...args),
 }));
 
+// #1628 — R11-c 차단 1건 측정 검증. clear 호출과 짝지어 같은 site에서 1회만 발사.
+const mockLogCrossTripMirrorSkip = jest.fn();
+jest.mock('../../utils/alarmLog', () => ({
+  logCrossTripMirrorSkip: (...args: unknown[]) => mockLogCrossTripMirrorSkip(...args),
+}));
+
 // #1597 — trip 종료 ended 경로에서 cleanup 직전에 corrId snapshot 캡처 + cleanup 후 prompt enqueue.
 const mockGetCurrentTripCorrIdSync = jest.fn(() => null);
 jest.mock('../../../observability/utils/tripCorrId', () => ({
@@ -101,6 +107,9 @@ describe('runLaunchTripReconciliation', () => {
       await runLaunchTripReconciliation();
       expect(mockClearBackendSsotMirror).toHaveBeenCalledTimes(1);
       expect(mockFetchTripStatus).not.toHaveBeenCalled();
+      // #1628 — R11-c 측정 wire-completion: clear와 짝지어 logCrossTripMirrorSkip('launch') 1회.
+      expect(mockLogCrossTripMirrorSkip).toHaveBeenCalledWith('launch');
+      expect(mockLogCrossTripMirrorSkip).toHaveBeenCalledTimes(1);
     });
 
     it('ACTIVE_TRIP_KEY 존재 → clearBackendSsotMirror 호출 안 함 (기존 동작 보존)', async () => {
@@ -112,6 +121,8 @@ describe('runLaunchTripReconciliation', () => {
       });
       await runLaunchTripReconciliation();
       expect(mockClearBackendSsotMirror).not.toHaveBeenCalled();
+      // #1628 — clear가 안 됐으면 측정도 안 발사.
+      expect(mockLogCrossTripMirrorSkip).not.toHaveBeenCalled();
     });
   });
 

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -27,6 +27,7 @@ import { routeToWaypoints } from '../../route/utils/routeWaypoints';
 import { buildBoardingLockMeta } from '../utils/buildBoardingLockMeta';
 import { cancelTripBoundAlarms } from '../utils/tripBoundScheduler';
 import { clearBackendSsotMirror } from '../utils/backendSsotMirror';
+import { logCrossTripMirrorSkip } from '../utils/alarmLog';
 import { buildBoardingPromptContext, type BoardingPromptContext } from '../utils/boardingPromptContext';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
 import { BOARDING_LOCK_RELEASE_DEBOUNCE_MS } from '../../../shared/constants/boardingLock';
@@ -364,6 +365,8 @@ export function useApnsTripRegistration({
       // (cleanup 후 OLD trip 지연 push로 mirror 부활) 차단의 1단계로 작동한다.
       // 호출은 멱등 (clearBackendSsotMirror 키 부재 시 graceful no-op).
       await clearBackendSsotMirror();
+      // #1628 — R11-a 차단 1건 측정. burst dedup으로 같은 site 반복은 첫 1건만 적재.
+      logCrossTripMirrorSkip('register');
       const result = await callRegister({
         token,
         route,

--- a/src/features/alarm/hooks/useLaunchTripReconciliation.ts
+++ b/src/features/alarm/hooks/useLaunchTripReconciliation.ts
@@ -51,6 +51,7 @@ import { flushSignalDumpOutbox } from '../api/signalDumpBackend';
 import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
 import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
 import { clearBackendSsotMirror } from '../utils/backendSsotMirror';
+import { logCrossTripMirrorSkip } from '../utils/alarmLog';
 import { createLogger } from '../../../shared/utils/logger';
 
 const logger = createLogger('useLaunchTripReconciliation');
@@ -87,6 +88,8 @@ export async function runLaunchTripReconciliation(): Promise<void> {
       // tier로 stale stationId를 채택해 cross-trip 잔재(2026-06-20 12:30 어대 → 용마산 도착) 회귀.
       // cleanup은 멱등 — 키 부재 시 graceful no-op.
       await clearBackendSsotMirror();
+      // #1628 — R11-c 차단 1건 측정.
+      logCrossTripMirrorSkip('launch');
       return;
     }
 

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -23,6 +23,7 @@ const mockLogSilentPushRescheduleReceived = jest.fn();
 const mockLogSilentPushTripEndedReceived = jest.fn();
 const mockLogSilentPushFired = jest.fn();
 const mockLogSilentPushSkipped = jest.fn();
+const mockLogCrossTripMirrorSkip = jest.fn();
 const mockFlushAlarmLog = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../utils/alarmLog', () => ({
   logSilentPushReceived: (...args: unknown[]) => mockLogSilentPushReceived(...args),
@@ -32,6 +33,7 @@ jest.mock('../../utils/alarmLog', () => ({
     mockLogSilentPushTripEndedReceived(...args),
   logSilentPushFired: (...args: unknown[]) => mockLogSilentPushFired(...args),
   logSilentPushSkipped: (...args: unknown[]) => mockLogSilentPushSkipped(...args),
+  logCrossTripMirrorSkip: (...args: unknown[]) => mockLogCrossTripMirrorSkip(...args),
   flushAlarmLog: () => mockFlushAlarmLog(),
 }));
 
@@ -3314,6 +3316,8 @@ describe('silentPushTask', () => {
         activeTripValue: string | null;
         payloadTripToken: string | undefined;
         expectMirrorDefined: boolean;
+        // #1628 — mismatch 분기에서만 logCrossTripMirrorSkip('mismatch') 1회 호출.
+        expectMirrorSkipLogged: boolean;
       };
 
       async function runR11bCase({
@@ -3355,32 +3359,43 @@ describe('silentPushTask', () => {
           activeTripValue: 'trip-token-A',
           payloadTripToken: 'trip-token-A',
           expectMirrorDefined: true,
+          expectMirrorSkipLogged: false,
         },
         {
           label: 'payload.tripToken !== activeTripToken → mirror write skip (race A 차단)',
           activeTripValue: 'trip-token-NEW',
           payloadTripToken: 'trip-token-OLD',
           expectMirrorDefined: false,
+          expectMirrorSkipLogged: true,
         },
         {
           label: 'activeTripToken null (cold-launch race) → mirror write 허용 (backward-compat)',
           activeTripValue: null,
           payloadTripToken: 'trip-token-X',
           expectMirrorDefined: true,
+          expectMirrorSkipLogged: false,
         },
         {
           label: 'payload.tripToken undefined (구 backend 호환) → mirror write 허용',
           activeTripValue: 'trip-token-Z',
           payloadTripToken: undefined,
           expectMirrorDefined: true,
+          expectMirrorSkipLogged: false,
         },
       ])('$label', async (testCase) => {
+        mockLogCrossTripMirrorSkip.mockClear();
         await runR11bCase(testCase);
         const mirrorCall = findMirrorCall();
         if (testCase.expectMirrorDefined) {
           expect(mirrorCall).toBeDefined();
         } else {
           expect(mirrorCall).toBeUndefined();
+        }
+        // #1628 — mismatch case 1회 호출 / 그 외 0회.
+        if (testCase.expectMirrorSkipLogged) {
+          expect(mockLogCrossTripMirrorSkip).toHaveBeenCalledWith('mismatch');
+        } else {
+          expect(mockLogCrossTripMirrorSkip).not.toHaveBeenCalled();
         }
       });
     });

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -44,6 +44,7 @@ import { sendPushAck } from '../api/alarmBackend';
 import { createLogger } from '../../../shared/utils/logger';
 import {
   flushAlarmLog,
+  logCrossTripMirrorSkip,
   logSilentPushReceived,
   logSilentPushRescheduleReceived,
   logSilentPushTripEndedReceived,
@@ -780,6 +781,8 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
         logger.info(
           `mirror write skip: trip token mismatch payload=${payload.tripToken!.slice(0, 8)} active=${activeTripToken.slice(0, 8)}`,
         );
+        // #1628 — R11-b 차단 1건 측정.
+        logCrossTripMirrorSkip('mismatch');
       } else {
         await persistBackendSsotMirror(payload.ssot, receivedAt);
       }

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -49,6 +49,8 @@ import {
   logSuppressedHopWindow,
   logSuppressedHopWindowNoSource,
   logSuppressedLocklessForwardOnly,
+  logFusionCandidateDistanceReject,
+  logCrossTripMirrorSkip,
   logSuppressedOriginHopLockless,
   logSuppressedPassedEventOnLockOrigin,
   logSuppressedSsotFireGate,
@@ -787,6 +789,94 @@ describe('alarmLog', () => {
       const matching = saved.filter((e) => e.reason === 'lockless-forward-only-block');
       // 첫 entry 한 건 (burst inline count로 누적되거나 단일 entry 유지).
       expect(matching).toHaveLength(1);
+    });
+
+    it('#1628 logFusionCandidateDistanceReject: reason=candidate-distance-reject + source=fusion-candidate-reject + stationName stamped', async () => {
+      _resetBurstSuppressWindowForTests();
+      logFusionCandidateDistanceReject({ stationName: '시청' });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fusion-candidate-reject',
+        outcome: 'suppressed',
+        reason: 'candidate-distance-reject',
+        stationName: '시청',
+      });
+    });
+
+    it('#1628 logFusionCandidateDistanceReject: burst dedup applies — same stationName within window dropped', async () => {
+      _resetBurstSuppressWindowForTests();
+      logFusionCandidateDistanceReject({ stationName: '시청' });
+      logFusionCandidateDistanceReject({ stationName: '시청' });
+      logFusionCandidateDistanceReject({ stationName: '시청' });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      const matching = saved.filter((e) => e.reason === 'candidate-distance-reject');
+      expect(matching).toHaveLength(1);
+    });
+
+    it('#1628 logFusionCandidateDistanceReject: different stationName entries are NOT deduped', async () => {
+      _resetBurstSuppressWindowForTests();
+      logFusionCandidateDistanceReject({ stationName: '시청' });
+      logFusionCandidateDistanceReject({ stationName: '종각' });
+      logFusionCandidateDistanceReject({ stationName: '종로3가' });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      const matching = saved.filter((e) => e.reason === 'candidate-distance-reject');
+      expect(matching).toHaveLength(3);
+    });
+
+    it.each([
+      ['register' as const, 'cross-trip-mirror-register' as const],
+      ['mismatch' as const, 'cross-trip-mirror-mismatch' as const],
+      ['launch' as const, 'cross-trip-mirror-launch' as const],
+    ])(
+      '#1628 logCrossTripMirrorSkip(%s): reason=cross-trip-mirror-skip + source=%s',
+      async (site, expectedSource) => {
+        _resetBurstSuppressWindowForTests();
+        logCrossTripMirrorSkip(site);
+        await flushAlarmLog();
+
+        const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+        const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+        expect(saved[0]).toMatchObject({
+          source: expectedSource,
+          outcome: 'suppressed',
+          reason: 'cross-trip-mirror-skip',
+        });
+      },
+    );
+
+    it('#1628 logCrossTripMirrorSkip: burst dedup applies per site — same site within window dropped', async () => {
+      _resetBurstSuppressWindowForTests();
+      logCrossTripMirrorSkip('register');
+      logCrossTripMirrorSkip('register');
+      logCrossTripMirrorSkip('register');
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      const matching = saved.filter((e) => e.reason === 'cross-trip-mirror-skip');
+      expect(matching).toHaveLength(1);
+    });
+
+    it('#1628 logCrossTripMirrorSkip: different sites are NOT deduped (independent burst keys)', async () => {
+      _resetBurstSuppressWindowForTests();
+      logCrossTripMirrorSkip('register');
+      logCrossTripMirrorSkip('mismatch');
+      logCrossTripMirrorSkip('launch');
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      const matching = saved.filter((e) => e.reason === 'cross-trip-mirror-skip');
+      expect(matching).toHaveLength(3);
     });
 
     it('#1514 logSuppressedOriginHopLockless: reason=gate-origin-hop-lockless + kind=station-passed', async () => {

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -57,7 +57,19 @@ export type AlarmLogSource =
   | 'boarding-prompt'
   // #1573 (T10) — 6h/9h trip lifecycle backstop이 적재하는 silence/force-end 엔트리 출처.
   // FG/BG 어느 경로에서도 동일 source로 적재 — 단계 진입 시점·발생 빈도 분포 측정.
-  | 'lifecycle-backstop';
+  | 'lifecycle-backstop'
+  // #1628 — fusion candidate distance hard gate(R12-a, #1616)가 reject한 1건의 alarmLog mirror.
+  // 기존 pushFusionDebugEntry(fusionLog kind)만 적재되던 reject 신호를 alarmLog kind에도
+  // 적재해 `/admin/alarm-log-stats` (kind='alarmLog' 만 카운트) 응답에서 R12-a 효과 측정 가능.
+  | 'fusion-candidate-reject'
+  // #1628 — R11 cross-trip mirror skip(PR #1613) 차단 3 site 출처. site별로 source 구분해
+  // 분포 측정 — 어느 race(register/mismatch/launch)가 가장 자주 차단하는지 RCA.
+  //   'cross-trip-mirror-register' : R11-a (useApnsTripRegistration.ts:361, POST /trips 직전 clear)
+  //   'cross-trip-mirror-mismatch' : R11-b (silentPushTask.ts:779, token mismatch 시 write skip)
+  //   'cross-trip-mirror-launch'   : R11-c (useLaunchTripReconciliation.ts:89, active trip 없을 때 clear)
+  | 'cross-trip-mirror-register'
+  | 'cross-trip-mirror-mismatch'
+  | 'cross-trip-mirror-launch';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(#580): evaluateAlarmPhase의 firedAlarms 적중. destination/transfer phase alarm dedup
 // 발생 관찰. station-passed는 별도 메커니즘(lastNotifiedStationId)이라 'dedup-station' 사용.
@@ -200,7 +212,13 @@ export type AlarmLogReason =
   // backend SSoT mirror(currentStationId)와 일치하지 않을 때 적재. mismatch는 lockless 회복 path
   // (Stage 1/2/3 누적) 효과를 직접 측정 — 1주 production 카운트 ≪ baseline trip 수면 V1 회복 신호.
   // dedup 1분 윈도우 + (ui, ssot) 쌍 키 — 같은 mismatch가 폴링 cycle마다 반복 적재되는 회귀 차단.
-  | 'v1-mismatch';
+  | 'v1-mismatch'
+  // #1628 — fusion candidate distance hard gate(R12-a) reject 사유. distanceKm/trainNo/stationName/line은
+  // 엔트리 컨텍스트로 별도 적재되지 않으므로 dedup 키는 (trainNo|stationName)으로 station 단위 burst 차단.
+  | 'candidate-distance-reject'
+  // #1628 — R11 cross-trip mirror skip(PR #1613) 차단 1건. 같은 site에서 burst 발사하는 race 케이스를
+  // 차단하기 위해 5s 윈도우 burst dedup 적용.
+  | 'cross-trip-mirror-skip';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -492,9 +510,13 @@ function sweepExpiredBurstEntries(now: number): void {
   }
 }
 
-function isBurstDuplicate(reason: string, stationName: string): boolean {
+// discriminator는 dedup key를 reason과 함께 구성하는 두 번째 차원 — 호출자는 station name이든
+// site label('register'/'mismatch'/'launch')이든 자유롭게 사용한다 (#1628). 키 구성은
+// `${reason}|${discriminator}` 단순 문자열 결합으로, 호출 간 의미 차이는 reason 단위로
+// 격리되므로 같은 reason에서 일관된 차원만 쓰면 충돌하지 않는다.
+function isBurstDuplicate(reason: string, discriminator: string): boolean {
   const now = Date.now();
-  const key = `${reason}|${stationName}`;
+  const key = `${reason}|${discriminator}`;
   const last = lastBurstSuppressTs.get(key);
   if (last !== undefined && now - last < DEDUP_LOG_WINDOW_MS) return true;
   lastBurstSuppressTs.set(key, now);
@@ -505,6 +527,57 @@ function isBurstDuplicate(reason: string, stationName: string): boolean {
 /** 테스트용 — burst dedup 윈도우 캐시 리셋. */
 export function _resetBurstSuppressWindowForTests(): void {
   lastBurstSuppressTs.clear();
+}
+
+/**
+ * #1628 — fusion candidate distance reject 1건 적재 (R12-a 효과 측정).
+ *
+ * 호출 site: `src/features/nearest-station/hooks/useFusedNearestStation.ts:533-543`
+ * `pickCandidateTrains`의 `onCandidateDistanceReject` 콜백. 기존 `pushFusionDebugEntry`
+ * (kind='candidate-reject', reason='candidate-distance')는 fusionLog ring buffer에 적재되어
+ * DebugModal에서만 확인 가능. `/admin/alarm-log-stats` (kind='alarmLog' 만 카운트) 응답에
+ * 노출되도록 alarmLog kind에도 mirror 적재.
+ *
+ * burst dedup: stationName 키 — 같은 station이 5s 윈도우 안에 반복 reject되면 첫 1건만 적재.
+ * trainNo는 동일 station에서 다양해도 측정 목적(reject 분포)에는 영향 없음 — appendAlarmLog의
+ * inline burst counter도 (source, reason, stationName) 동등성으로 합쳐 station 단위 카운트만 유의미.
+ */
+export function logFusionCandidateDistanceReject(input: { stationName: string }): void {
+  if (isBurstDuplicate('candidate-distance-reject', input.stationName)) return;
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'fusion-candidate-reject',
+    outcome: 'suppressed',
+    reason: 'candidate-distance-reject',
+    stationName: input.stationName,
+  });
+}
+
+/**
+ * #1628 — R11 cross-trip mirror skip 1건 적재 (PR #1613 효과 측정).
+ *
+ * R11 차단 site 3곳:
+ *   - 'register' : `useApnsTripRegistration.ts:361` (POST /trips 직전 mirror clear)
+ *   - 'mismatch' : `silentPushTask.ts:779` (token mismatch 시 mirror write skip)
+ *   - 'launch'   : `useLaunchTripReconciliation.ts:89` (active trip 없을 때 mirror clear)
+ *
+ * burst dedup: site 키 — 같은 site에서 5s 윈도우 안에 반복 차단되면 첫 1건만 적재.
+ * 정상 trip 1건 (각 site별 1-3건).
+ */
+export function logCrossTripMirrorSkip(site: 'register' | 'mismatch' | 'launch'): void {
+  if (isBurstDuplicate('cross-trip-mirror-skip', site)) return;
+  const source: AlarmLogSource =
+    site === 'register'
+      ? 'cross-trip-mirror-register'
+      : site === 'mismatch'
+        ? 'cross-trip-mirror-mismatch'
+        : 'cross-trip-mirror-launch';
+  appendAlarmLog({
+    ts: Date.now(),
+    source,
+    outcome: 'suppressed',
+    reason: 'cross-trip-mirror-skip',
+  });
 }
 
 /**
@@ -765,6 +838,10 @@ const SILENT_PUSH_OUTCOME_SOURCES: Record<AlarmLogSource, keyof SilentPushOutcom
   'fg-ref-mismatch': null,
   'boarding-prompt': null,
   'lifecycle-backstop': null,
+  'fusion-candidate-reject': null,
+  'cross-trip-mirror-register': null,
+  'cross-trip-mirror-mismatch': null,
+  'cross-trip-mirror-launch': null,
 };
 
 export interface SilentPushOutcomeCounts {

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -31,7 +31,10 @@ import type { PositionStability } from '../utils/positionStaticDetector';
 import { pickCandidateTrains, type CandidateTrain } from '../../arrival/utils/pickCandidateTrains';
 import { trackTrainProgress } from '../../route/utils/trackTrainProgress';
 import { estimateArcStationsFromRoute } from '../../route/utils/arcEstimation';
-import { logSuppressedLocklessForwardOnly } from '../../alarm/utils/alarmLog';
+import {
+  logFusionCandidateDistanceReject,
+  logSuppressedLocklessForwardOnly,
+} from '../../alarm/utils/alarmLog';
 import { haversine } from '../../../shared/utils/haversine';
 import { findStationByName, findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import { isWithinArcWindow, passesFusionDistanceGate } from '../utils/fusionDistanceGate';
@@ -540,6 +543,9 @@ export function useFusedNearestStation(
               line: info.line,
               distanceKm: info.distanceKm,
             });
+            // #1628 — alarmLog kind에도 mirror 적재. `/admin/alarm-log-stats`는 kind='alarmLog'만
+            // 카운트하므로 R12-a reject 효과를 측정하려면 alarmLog 적재가 필수.
+            logFusionCandidateDistanceReject({ stationName: info.stationName });
           },
         }),
       );


### PR DESCRIPTION
## Summary

- R7 #1596(autoLock multi-signal consensus, +15-20% V1 회복, 3-4주) 진행 전 baseline measurement 인프라 확장
- 사용자 trip 1건 후 `/admin/alarm-log-stats` endpoint에서 R12-a + R11(cross-trip mirror skip) 효과 측정 가능
- 이전: 6/11 측정 가능 → 이후: 8/11
- 사용자 가치 코드(V1~V9) 안 건드림. 진단 path 추가 only

Closes #1628

## 변경 요약

### AlarmLogReason union 확장
- `candidate-distance-reject` (R12-a 효과)
- `cross-trip-mirror-skip` (R11 효과)

### AlarmLogSource union 확장
- `fusion-candidate-reject`
- `cross-trip-mirror-register` / `cross-trip-mirror-mismatch` / `cross-trip-mirror-launch`

### 적재 helper 2개 (alarmLog.ts)
- `logFusionCandidateDistanceReject({ stationName })` — stationName 단위 burst dedup
- `logCrossTripMirrorSkip(site)` — site 단위 burst dedup (`'register' | 'mismatch' | 'launch'`)

### Wire 4곳
| site | 파일 | 기존 메커니즘 |
|---|---|---|
| R12-a | `useFusedNearestStation.ts:533-543` `onCandidateDistanceReject` 콜백 | `pushFusionDebugEntry` (fusionLog kind, alarmLogStats 미카운트) |
| R11-a | `useApnsTripRegistration.ts:367` POST /trips 직전 mirror clear 직후 | (적재 없음) |
| R11-b | `silentPushTask.ts:785` token mismatch 시 mirror write skip 직후 | (적재 없음) |
| R11-c | `useLaunchTripReconciliation.ts:91` active trip 부재 시 mirror clear 직후 | (적재 없음) |

### 코드 리뷰 반영
- 🟡 P1: `isBurstDuplicate` 두 번째 파라미터명 `stationName` → `discriminator` (site discriminator 오용 위험 차단)
- 🟢 P2: hook 2곳(useApnsTripRegistration / useLaunchTripReconciliation) `logCrossTripMirrorSkip` 호출 assertion 추가 (Wire-completion 갭 해소)

## V/X

V1 회복 측정 진단 path 확장. 직접 cover하는 V/X 없음 — measurement enable only.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass ✅
2. **V/X dashboard** — 사용자 1 trip 후 `/admin/alarm-log-stats?windowHours=24` 응답:
   - `reasons[candidate-distance-reject]` — R12-a reject 분포
   - `reasons[cross-trip-mirror-skip]` — R11 차단 총 카운트
   - `sources['cross-trip-mirror-register' | '-mismatch' | '-launch']` — site별 분포
3. **의존 PR** — N/A (단독). PR #1622(measurement infra) 머지 완료 기반
4. **측정 plan** — 사용자 1 trip 후 위 endpoint 즉시 verify. 1주 production = 5 카운트 분포 + baseline pass 통합 신호로 R7 진행/연기 결정
5. **Device verify** — N/A — type+unit only (단순 적재 path 추가)

## follow-up issues (backend-side 3개)

별도 issue로 분리. backend writeMetric → R2 trip-evidence backend-metrics ndjson 적재 인프라 신설 + wrangler deploy 필요:
- #6 consensusGate strongCB pass (S4 효과)
- #10 stale-lock-fire (Phase C 효과)
- #11 LA multi-hop 표시 (R9-b 효과, `buildLiveActivityContentState` 위치가 backend)

## Test plan
- [x] `npm test` — 7337 tests pass, coverage 100%
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass
- [x] code-reviewer agent — 🔴 0건, 🟡 1건 + 🟢 1건 모두 반영
- [x] CI Data Validation + Type Check & Test pass