### PR TITLE
fix(#1630): lockless 출발역 가드 effectiveHopIndex AND 조건 제거

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -3768,6 +3768,47 @@ describe('useStationAlarm', () => {
       expect(mockLogFiredStationPassed).not.toHaveBeenCalledWith('fg', arcOrigin[0]);
     });
 
+    // #1630 — lockless mode는 estimator(시간 적분)가 idx를 임의 진행할 수 있으므로 출발역
+    // 머무는 동안에도 effectiveHopIndex >= 1이 정상 산출됨 (2026-06-22 08:34:18 용마산 evidence).
+    // candidate가 arc[0]이면 effectiveHopIndex 값과 무관하게 차단해야 한다 (ADR-014 §4).
+    // effectiveHopIndex가 hop window 범위(±1)를 넘으면 별도 gate-hop-window 가드가 먼저 차단하므로
+    // 본 가드 직접 cover는 effectiveHopIndex=1 케이스 (직전 trip evidence와 정합).
+    it('#1630 lockless + currentHopIndex=1 + candidate arc[0] → suppressed (estimator overshoot, 2026-06-22 용마산 evidence)', async () => {
+      mockGetBoardingLock.mockResolvedValue(null);
+      renderOriginHopCase(0, 1);
+      await waitFor(() => {
+        expect(mockLogSuppressedOriginHopLockless).toHaveBeenCalledWith({
+          source: 'fg',
+          stationName: arcOrigin[0].name,
+        });
+      });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    // #1630 회귀 가드 — lock 활성 + currentHopIndex=1 + candidate arc[0]: isOriginHopCandidate=true이지만
+    // IIFE 내 `!lock` 조건에 걸려 #1514 lockless 가드 미발사 + #1599 lock-origin 가드로 차단해야 함.
+    // (이번 fix로 lock 활성에서 영향 받지 않음을 명시 검증)
+    it('#1630 lock 활성 + currentHopIndex=1 + candidate arc[0] → #1599 lock-origin 가드로 차단 (lockless 가드 미발사)', async () => {
+      mockGetBoardingLock.mockResolvedValue({
+        destinationId: destination.id,
+        trainCode: 'T-LOCK',
+        boardingStationId: arcOrigin[0].id,
+        boardingLine: '2' as const,
+        boardedAt: Date.now(),
+        expectedDurationMs: 600_000,
+      });
+      mockNextTargetStops(4);
+      renderOriginHopCase(0, 1);
+      await waitFor(() => {
+        expect(mockLogSuppressedPassedEventOnLockOrigin).toHaveBeenCalledWith({
+          source: 'fg',
+          stationName: arcOrigin[0].name,
+        });
+      });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockLogSuppressedOriginHopLockless).not.toHaveBeenCalled();
+    });
+
     it('#1599 band-aid — lock 활성 + currentHopIndex=0 + candidate arc[0] (= boardingStationId) → 차단 (passed-event-on-lock-origin)', async () => {
       // ADR-014 §4 "lock origin은 정당 신호" 명제는 2026-06-20 용마산 evidence(lock 1초 후 origin 자체에
       // station-passed fire = X1 wrong-station-alarm)로 반증됨. #1596(autoLock multi-signal consensus)이

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -1002,8 +1002,13 @@ export function useStationAlarm({
           logSuppressedHopWindowNoSource({ source: 'fg', stationName: candidateStation.name });
         } else if (isStationWithinHopWindow(candidateStation, arcStations, effectiveHopIndex)) {
           // hop window 통과 — origin hop 케이스만 추가 표식 (lockless 차단은 IIFE 내부).
+          // #1630 — effectiveHopIndex AND 조건 제거. lockless mode는 estimator(시간 적분)가
+          // idx를 임의 진행 — 출발역에 머물러도 idx>=1 정상 산출(2026-06-22 08:34:18 용마산
+          // evidence: estimator idx=1, 사용자는 출발 직후 = X1 위반). candidate가 arc[0]이면
+          // effectiveHopIndex 값과 무관하게 origin hop으로 판정 (ADR-014 §4: 출발역 자체에
+          // station-passed fire는 X1). lock 활성 trip은 line 1042 `!lock` 가드가 별도 차단.
           const candidateIndex = arcIndexOf(arcStations, candidateStation);
-          isOriginHopCandidate = effectiveHopIndex === 0 && candidateIndex === 0;
+          isOriginHopCandidate = candidateIndex === 0;
         } else {
           logSuppressedHopWindow({
             source: 'fg',


### PR DESCRIPTION
## Summary

- 2026-06-22 trip dump 분석에서 X1 위반 1건 evidence (08:34:18 fg fired 용마산, 사용자 답변: 막 탑승 후 출발 중)
- root cause: `useStationAlarm.ts:1006` 가드 조건이 너무 좁음 (`effectiveHopIndex === 0 && candidateIndex === 0`)
- fix: `effectiveHopIndex === 0` 제거 → `candidateIndex === 0`만으로 판정

Closes #1630

## evidence

trip dump (2026-06-22 08:32~08:48):
- 08:33:59 estimator: `lockless-route-hop 중곡(7) **idx=1**` (lockless mode + 출발 직후인데 estimator가 시간 적분으로 idx=1 임의 산출)
- 08:34:18 fg fired station-passed **용마산** (출발역 자체에 fire = X1 위반)
- Counters: `gate-passed-event-on-lock-origin=28x` (lock 활성 가드만 작동), `gate-origin-hop-lockless` **카운트 0** (lockless 가드 미작동)

ADR-014 §4 명시: "출발역에서 출발하면 첫 station-passed 대상은 다음 역이지 origin 자체가 아님" — candidate가 arc[0]이면 effectiveHopIndex 값과 무관하게 차단해야 함.

## fix

`useStationAlarm.ts:1006`:

```diff
- isOriginHopCandidate = effectiveHopIndex === 0 && candidateIndex === 0;
+ isOriginHopCandidate = candidateIndex === 0;
```

lock 활성 trip은 line 1042 `if (isOriginHopCandidate && !lock)` 가드가 별도로 차단하므로 안전 (lock 활성 시 origin hop 진입은 정당).

## 회귀 분석 (코드 리뷰 결과)

이 fix 이후 실질적으로 변경되는 동작 케이스:

| effectiveHopIndex | candidateIndex | 이전 | 변경 후 |
|---|---|---|---|
| 0 | 0 | 차단 | 차단 (동일) |
| **1** | **0** | **통과 (버그)** | **차단 (fix)** |
| 2+ | 0 | hop window 가드가 먼저 차단 | hop window 가드가 먼저 차단 (동일) |

→ 실질 변경은 **1 케이스**뿐. 회귀 위험 없음.

## 테스트

- `lockless + currentHopIndex=1 + candidate arc[0] → suppressed` (2026-06-22 evidence)
- `lock 활성 + currentHopIndex=1 + candidate arc[0] → #1599 lock-origin 가드로 차단` (lockless 가드 미발사 명시 검증, 코드 리뷰 P1 반영)

기존 4 테스트(currentHopIndex=0 cases) 모두 변경 없이 pass.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass ✅
2. **V/X dashboard** — DebugModal Counters `gate-origin-hop-lockless` + `/admin/alarm-log-stats` `reasons[gate-origin-hop-lockless]`
3. **의존 PR** — N/A (단독)
4. **측정 plan** — 다음 사용자 trip dump 1건 → 출발역 fire 0건 + `gate-origin-hop-lockless` 카운트 1+건 확인
5. **Device verify** — type+unit only. 다음 trip 검증

## follow-up issue

🟢 코드 리뷰 P2: `fg-arvlcd` fast-path (`useStationAlarm.ts:1166~1188`)에는 `isOriginHopCandidate` 로직 자체가 없음. lockless trip + arvlCd가 arc[0] 매칭 시 fast-path로 origin fire 가능. 별도 issue 등록 필요.

## Test plan
- [x] `npm test` — 7339 tests pass, coverage 100%
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass
- [x] code-reviewer agent — 🔴 0건, 🟡 1건 + 🟢 1건 (P1 반영, P2 follow-up 분리)
- [x] CI Data Validation + Type Check & Test pass