### PR TITLE
fix(#1632): eas.json production env에 EXPO_PUBLIC_ALARM_BACKEND_URL 추가

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -20,7 +20,8 @@
     "production": {
       "autoIncrement": true,
       "env": {
-        "EXPO_PUBLIC_APNS_ENV": "production"
+        "EXPO_PUBLIC_APNS_ENV": "production",
+        "EXPO_PUBLIC_ALARM_BACKEND_URL": "https://subway-now-alarm-worker.handokei.workers.dev"
       }
     }
   },


### PR DESCRIPTION
## Summary

- 2026-06-22 trip 2건 진행 후 `/admin/alarm-log-stats?windowHours=24` 응답 `tripsScanned: 0` (R2 forward 끊김)
- root: `eas.json` production env에 `EXPO_PUBLIC_ALARM_BACKEND_URL` 누락 → EAS production build에 URL undefined → `forwardTripTelemetry` graceful skip
- fix: 1줄 추가

Closes #1632

## evidence

```bash
curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$WORKER/admin/alarm-log-stats?windowHours=24" | jq
# { "totalEvents": 0, "tripsScanned": 0, ... }
```

코드 path verify (BG 진단 agent):
- `setDestination(null)` → `triggerTripEndRecall` → `forwardTripTelemetry`
- `getAlarmBackendUrl()` returns null (URL undefined)
- → `skipReason: 'no-url'` graceful skip → R2 0건

opt-in 가설 기각: `forwardTripTelemetry`에 opt-in 게이트 없음.

## fix

`eas.json:23` production env에 URL 추가:

```diff
"production": {
  "autoIncrement": true,
  "env": {
-    "EXPO_PUBLIC_APNS_ENV": "production"
+    "EXPO_PUBLIC_APNS_ENV": "production",
+    "EXPO_PUBLIC_ALARM_BACKEND_URL": "https://subway-now-alarm-worker.handokei.workers.dev"
  }
}
```

backend URL은 public Cloudflare Workers endpoint. ADMIN_TOKEN secret과 별개라 commit 안전.

## Wire-completion 5단

1. **Orphan 없음** — eas.json은 코드 아님, N/A
2. **V/X dashboard** — `/admin/alarm-log-stats` totalEvents > 0 + reasons 적재 확인 가능
3. **의존 PR** — N/A (단독)
4. **측정 plan** — EAS production rebuild + TestFlight 후 trip 1건 → endpoint 응답으로 verify
5. **Device verify** — **사용자 직접 빌드/설치 필요**:
   - `eas build --profile production --platform ios`
   - `eas submit --platform ios --latest`
   - TestFlight 새 빌드 설치
   - trip 1건 진행

## Test plan
- [x] eas.json syntax valid
- [ ] CI Data Validation + Type Check & Test pass
- [ ] PR 머지
- [ ] **사용자: EAS production rebuild + TestFlight 업로드**
- [ ] **사용자: 새 빌드 설치 후 trip 1건 진행**
- [ ] endpoint 응답 `tripsScanned >= 1` 확인