### PR TITLE
fix(#1635): autoLock/lockSwap line cross-check 추가 (LA 호선 오류 root)

### DIFF
--- a/backend/alarm-worker/src/__tests__/autoLock.test.ts
+++ b/backend/alarm-worker/src/__tests__/autoLock.test.ts
@@ -155,6 +155,21 @@ describe('attemptAutoLock (#916 A1)', () => {
     });
     expect(lock?.segmentStations).toEqual(['강남', '역삼']);
   });
+
+  it('chosen arrival subwayNm 이 line 과 불일치 → null (2단 cross-check, #1626 follow-up)', async () => {
+    // 2026-06-22 trip B 회귀 재현 — 2호선 trip 에 trainCode=3222 push 5건 발사.
+    // pickAutoTrainCode 가 matchLine 우회로 chosen 후 subwayNm 이 빈 문자열인 entry 시뮬.
+    // 2단 cross-check 가 lock 합성을 차단해야 한다 (wrong-line trainCode 30분 TTL 지속 봉쇄).
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1, subwayNm: '' })]),
+      now: NOW,
+    });
+    expect(lock).toBeNull();
+  });
 });
 
 describe('attemptAutoLock RC1 confidence gate (#1018)', () => {

--- a/backend/alarm-worker/src/__tests__/lockSwap.test.ts
+++ b/backend/alarm-worker/src/__tests__/lockSwap.test.ts
@@ -268,4 +268,19 @@ describe('attachTrainCodeForLeg', () => {
     });
     expect(lock).toBeNull();
   });
+
+  it('chosen arrival subwayNm 이 line 과 불일치 → null (2단 cross-check, #1626 follow-up)', async () => {
+    // pickAutoTrainCode 가 matchLine 우회로 cross-line train을 선택했다고 가정한 회귀 시뮬레이션:
+    // arrivals 단일 후보로 ambiguity 없이 통과하지만 subwayNm 이 빈 문자열이라 matchLine=false 발동.
+    // chosen subwayNm 의 line cross-check 가 lock 합성을 차단해야 한다 (wrong-line trainCode lock
+    // 30분 TTL 지속 회귀 봉쇄).
+    const seoul = makeSeoul([makeArrival('T1', 1, 60, '')]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeTrip([{ stationName: '중곡', line: '7', kind: 'destination' }]),
+      targetWaypoint: { stationName: '중곡', line: '7', kind: 'intermediate' },
+      seoul,
+      now: NOW,
+    });
+    expect(lock).toBeNull();
+  });
 });

--- a/backend/alarm-worker/src/autoLock.ts
+++ b/backend/alarm-worker/src/autoLock.ts
@@ -249,16 +249,22 @@ export async function attemptAutoLock(
   const trainCode = pickAutoTrainCode(arrivals, line, direction);
   if (!trainCode) return { lock: null };
 
+  // line cross-check (2단 방어, #1626 follow-up) — `pickAutoTrainCode`가 이미 `matchLine`을
+  // 적용하지만, chosen trainCode 의 실제 entry 의 subwayNm 이 line 과 매칭되는지 한 번 더
+  // verify 한다. trainCode 가 line 과 다른 경우(예: 2호선 trip 에 trainCode=3222 가 발사된
+  // 2026-06-22 trip B 회귀) 명시적으로 차단. chosen entry 가 없거나 subwayNm 이 line 과
+  // 매칭되지 않으면 null 반환 → prompt fallback. lock TTL 30분 동안 wrong-line trainCode 가
+  // reschedule push 마다 노출되는 회귀를 봉쇄.
+  const chosen = arrivals.find((a) => a.trainCode === trainCode);
+  if (!chosen || !matchLine(chosen.subwayNm, line)) return { lock: null };
+
   // #1536 (S3, Epic #1533) — environment + gateOutcome 모두 전달 시 consensusGate 분기 강제.
   // underground/mixed/unknown 환경에서 arrival(=chosen arvlCd 0~3) + lockAttachable(=trainCode
   // 단일 수렴 = true) 2-of-2 합의가 통과해야 lock 합성 진행. surface 는 base gate(=outcome.pass)
   // 가 통과하면 즉시 통과. 미전달 시 (구 호출자) skip.
   if (environment && gateOutcome) {
-    const chosenForGate = arrivals.find((a) => a.trainCode === trainCode);
     const arrivalSignalPresent =
-      typeof chosenForGate?.arvlCd === 'number' &&
-      chosenForGate.arvlCd >= 0 &&
-      chosenForGate.arvlCd <= 3;
+      typeof chosen.arvlCd === 'number' && chosen.arvlCd >= 0 && chosen.arvlCd <= 3;
     // #1614 Phase B — backend self-poll realtimePosition cross-match.
     // pickAutoTrainCode 가 선택한 trainCode가 line의 운행 trains 중에 실제 존재하면 true.
     // undefined / 빈 list 시 자연 undefined → consensusGate가 `?? false` fallback (strongBE 동작 유지).
@@ -279,9 +285,8 @@ export async function attemptAutoLock(
   // #1018 RC1 confidence gate — arvlCd=2(출발) at next-waypoint는 사용자가 이미 그 열차를
   // 타고 origin을 떠났거나, 반대로 그 열차가 사용자보다 먼저 출발했을 수 있다 (origin-pass 후보).
   // 추가 신호로 confidence를 합산해 임계 미달 시 null 반환 → prompt push fallback.
-  const chosenEntry = arrivals.find((a) => a.trainCode === trainCode);
   let confidenceTrace: AutoLockConfidenceTrace | undefined;
-  if (chosenEntry?.arvlCd === ARVL_CD_DEPARTED) {
+  if (chosen.arvlCd === ARVL_CD_DEPARTED) {
     const score = await computeConfidence({
       trainCode,
       line,

--- a/backend/alarm-worker/src/lockSwap.ts
+++ b/backend/alarm-worker/src/lockSwap.ts
@@ -16,7 +16,7 @@
 
 import { pickAutoTrainCode } from './boardingPrompt';
 import { isLockLineAllowed } from './consensusGate';
-import { subwayIdForLine } from './lineAlias';
+import { matchLine, subwayIdForLine } from './lineAlias';
 import type { SeoulArrivalClient } from './seoul';
 import type { BoardingLockMeta, LineNumber, Trip, Waypoint } from './types';
 
@@ -93,6 +93,13 @@ export async function attachTrainCodeForLeg(
 
   const trainCode = pickAutoTrainCode(arrivals, line, null);
   if (!trainCode) return null;
+
+  // line cross-check (2단 방어, #1626 follow-up) — `pickAutoTrainCode`가 이미 `matchLine`을
+  // 적용하지만, chosen trainCode entry 의 subwayNm 이 line 과 매칭되는지 한 번 더 verify.
+  // swap 흐름은 transfer 직후 + vanish 후 재부착 모두 같은 보호가 필요하다 — autoLock 과
+  // 동일 정책으로 wrong-line trainCode lock 합성을 봉쇄. autoLock.ts:258-259 참조.
+  const chosen = arrivals.find((a) => a.trainCode === trainCode);
+  if (!chosen || !matchLine(chosen.subwayNm, line)) return null;
 
   return {
     trainCode,


### PR DESCRIPTION
Closes #1635

## 배경

2026-06-22 13:36~13:47 trip B (왕십리→을지로입구, 2호선) 진행 중:
- 사용자 피드백: \"LA 경의 중앙선 호선 표시\"
- backend log: 모든 reschedule push \`trainCode=3222\` (5건) — 2호선 trip 에 noise 호선의 trainCode
- lock TTL 30분 동안 reschedule push 마다 wrong-line trainCode 가 LA/alert 에 노출

## Root cause

`backend/alarm-worker/src/autoLock.ts` + `lockSwap.ts` 에서 `pickAutoTrainCode` 가 반환한 trainCode 의 line cross-check 가 **1단**만 존재.

- `pickAutoTrainCode` 내부에서 `matchLine(arrival.subwayNm, line)` 으로 필터.
- 그러나 chosen trainCode 의 line 정합성을 lock 합성 직전에 **2단 방어**로 한 번 더 검증하지는 않음.
- arrival subwayNm 이 빈 문자열, alias 회귀, matchLine 우회 등 edge case 에 fail-open.

## Fix

autoLock.ts + lockSwap.ts 모두 `pickAutoTrainCode` 직후 chosen arrival entry 를 lookup → `matchLine(chosen.subwayNm, line)` 으로 한 번 더 verify. 미통과 시 `null` 반환 → prompt fallback.

- `autoLock.ts`: 2줄 추가 (`const chosen` + `if (!chosen || !matchLine(...))` guard) + 기존 `chosenEntry` 변수 재사용으로 변경
- `lockSwap.ts`: 동일 패턴 2줄 추가 + `matchLine` import 한 줄

총 4 파일 변경 (코드 2 + 테스트 2), +49/-7 line.

## 영향

- 정상 trip 동작 그대로 유지 (chosen.subwayNm 이 line 과 매칭되면 통과).
- wrong-line trainCode lock 합성 봉쇄. 미통과 시 boarding-prompt fallback → 사용자가 직접 탑승 응답.
- 2호선 trip 에 trainCode=3222 같은 회귀 30분 TTL 지속 차단.

## 테스트

- `autoLock.test.ts`: subwayNm='' (빈 문자열) chosen entry 시 lock=null 검증.
- `lockSwap.test.ts`: 동일 시나리오 검증.
- 기존 attemptAutoLock 45 tests + lockSwap 17 tests 전부 pass.
- backend alarm-worker 전체: 1891 tests pass (52 files).
- frontend 전체: 7339 tests pass, 100% coverage.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (No orphan exports detected).
2. **V/X dashboard** — backend log `boarding-prompt: auto-lock attached` 의 line vs trainCode, alarm log forward(#1579) 통해 lock.line vs trainCode 매핑 가시성.
3. **의존 PR** — N/A (independent).
4. **측정 plan** — 1주 backend log 모니터링 + 사용자 피드백 (LA 호선 오류 0건 / lock 합성 시 line vs trainCode mismatch 0건).
5. **Device verify** — N/A — backend-only (cron-driven). type+unit only.