### PR TITLE
fix(#1637): 환승역 line selection 모달 반복 표시

### DIFF
--- a/src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts
+++ b/src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts
@@ -292,6 +292,95 @@ describe('useTransferAutoDetect', () => {
     expect(onAutoLock).not.toHaveBeenCalled();
   });
 
+  /**
+   * #1637 — 환승역 line selection 모달 반복 표시 회귀 가드.
+   *
+   * Evidence: 2026-06-22 14:01:55 합정 환승역(2호선/6호선) 스크린샷 — 사용자 선택 후에도
+   * 매 GPS cycle 모달 반복. root cause: stationKey = currentStation.id는 line별로 분리되어
+   * fusion이 같은 환승역의 다른 line variant를 primary로 채택하면 stationKey 변경 →
+   * dismissedAtStationRef reset → 모달 재오픈. fix: stationKey를 normalize(name)으로 변경.
+   *
+   * 부수 fix: selectLine arrival race(candidate=null) 시에도 dismiss flag stamp.
+   */
+  describe('#1637 환승역 dismiss 보존', () => {
+    // 합정 — 2호선/6호선 환승역. line별 id 분리 fixture.
+    const HAPJEONG_2: Station = { id: '0238', name: '합정', line: '2', lineColor: '#009D3E', lat: 37.549, lng: 126.913 };
+    const HAPJEONG_6: Station = { id: '0622', name: '합정', line: '6', lineColor: '#CD7C2F', lat: 37.549, lng: 126.913 };
+    const hapjeongNearestLine2: NearestStationsResult = {
+      primary: HAPJEONG_2,
+      variants: [HAPJEONG_2, HAPJEONG_6],
+      distanceKm: 0.03,
+      isTransfer: true,
+    };
+    const hapjeongNearestLine6: NearestStationsResult = {
+      primary: HAPJEONG_6,
+      variants: [HAPJEONG_2, HAPJEONG_6],
+      distanceKm: 0.03,
+      isTransfer: true,
+    };
+    /** 2호선 60s + 6호선 90s 두 줄 임박. */
+    function hapjeongMultiArrival(): StationArrival {
+      return makeArrival([
+        makeArrivalInfo({ destination: '잠실', arrivalSeconds: 60, line: '2', trainCode: 'T-2-A' }),
+        makeArrivalInfo({ destination: '봉화산', arrivalSeconds: 90, line: '6', trainCode: 'T-6-A' }),
+      ]);
+    }
+
+    it('Case A: 환승역 line variant 변경 시 dismiss 보존 (line=2 dismiss → line=6 primary 채택 → 모달 재오픈 X)', () => {
+      const onAutoLock = jest.fn();
+      const arrival = hapjeongMultiArrival();
+      // 2호선 primary로 시작 → 다중 후보 모달 open
+      const { result, rerender } = renderTransferDetect(
+        baseInputs({ nearestStations: hapjeongNearestLine2, arrival, onAutoLock }),
+      );
+      expect(result.current.modalVisible).toBe(true);
+      // 사용자 dismiss
+      act(() => result.current.dismissModal());
+      expect(result.current.modalVisible).toBe(false);
+      // 다음 GPS cycle: fusion이 6호선 variant를 primary로 채택 — id가 '0238' → '0622'로 변경.
+      // station.name은 둘 다 '합정'이라 normalize 기반 stationKey는 보존되어야 한다.
+      rerender(baseInputs({ nearestStations: hapjeongNearestLine6, arrival, onAutoLock }));
+      expect(result.current.modalVisible).toBe(false);
+    });
+
+    it('Case B: selectLine early return (arrival race) 시에도 dismiss flag stamp', () => {
+      const onAutoLock = jest.fn();
+      const arrival = hapjeongMultiArrival();
+      const { result, rerender } = renderTransferDetect(
+        baseInputs({ nearestStations: hapjeongNearestLine2, arrival, onAutoLock }),
+      );
+      expect(result.current.modalVisible).toBe(true);
+      // arrival을 단일-line-only로 갱신 — 사용자가 6호선 선택하지만 6호선 arrival이 사라진 race.
+      // arrival에 line 6 train이 없어 buildAutoLockCandidate(6, ...) → null.
+      const arrivalOnly2 = makeArrival([
+        makeArrivalInfo({ destination: '잠실', arrivalSeconds: 60, line: '2', trainCode: 'T-2-A' }),
+      ]);
+      rerender(baseInputs({ nearestStations: hapjeongNearestLine2, arrival: arrivalOnly2, onAutoLock }));
+      onAutoLock.mockClear();
+      act(() => result.current.selectLine('6'));
+      // candidate=null이라 onAutoLock은 호출 안 됨 (정상)
+      expect(onAutoLock).not.toHaveBeenCalled();
+      // 모달은 닫혀야 하고, 다음 polling에서도 재오픈 안 됨 — 사용자 선택 의도 보존.
+      expect(result.current.modalVisible).toBe(false);
+      rerender(baseInputs({ nearestStations: hapjeongNearestLine2, arrival: hapjeongMultiArrival(), onAutoLock }));
+      expect(result.current.modalVisible).toBe(false);
+    });
+
+    it('Case C: 다른 환승역으로 이동 시는 모달 재오픈 (정상 동작 보존)', () => {
+      const onAutoLock = jest.fn();
+      const arrival = hapjeongMultiArrival();
+      const { result, rerender } = renderTransferDetect(
+        baseInputs({ nearestStations: hapjeongNearestLine2, arrival, onAutoLock }),
+      );
+      expect(result.current.modalVisible).toBe(true);
+      act(() => result.current.dismissModal());
+      expect(result.current.modalVisible).toBe(false);
+      // 합정에서 dismiss 후 동대문역사문화공원(다른 환승역)으로 이동 → 다시 모달 open 가능
+      rerender(baseInputs({ nearestStations: transferNearest, arrival: multiCandidateArrival(), onAutoLock }));
+      expect(result.current.modalVisible).toBe(true);
+    });
+  });
+
   it('currentStation 없는 동안 selectLine 호출 — 안전 no-op', () => {
     const onAutoLock = jest.fn();
     const { result } = renderHook(() =>

--- a/src/features/route/hooks/useTransferAutoDetect.ts
+++ b/src/features/route/hooks/useTransferAutoDetect.ts
@@ -30,7 +30,7 @@ import type { AutoLockCandidate } from '../../nearest-station/api/boardingLockSy
 import type { StationArrival } from '../../../shared/types/arrival';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
 import type { LineNumber, NearestStationsResult, Station } from '../../../shared/types/station';
-import type { Route } from '../../../shared/utils/stationRoute';
+import { normalizeStationName, type Route } from '../../../shared/utils/stationRoute';
 
 export interface UseTransferAutoDetectInputs {
   /** 환승역 신호 + 후보 산출에 필요한 현재 fusion 결과. */
@@ -105,7 +105,11 @@ export function useTransferAutoDetect({
   const dismissedAtStationRef = useRef<string | null>(null);
   const lastAutoLockedKeyRef = useRef<string | null>(null);
 
-  const stationKey = currentStation?.id ?? null;
+  // #1637 — 환승역에서 station.id는 line별로 분리(예: '합정-2' vs '합정-6')되어 있어 dismiss flag
+  // 추적에 부적합. fusion이 같은 환승역의 다른 line variant를 primary로 채택하면 id 변경 →
+  // dismiss reset → 모달 재오픈 무한 cycle (evidence: 2026-06-22 14:01:55 합정역 스크린샷).
+  // station name(normalize)으로 추적해 line 무관하게 dismiss 보존.
+  const stationKey = currentStation ? normalizeStationName(currentStation.name) : null;
 
   // 사용자가 환승역을 벗어나면 dismiss flag 리셋 — 다음 환승에서 다시 모달 열림 허용.
   useEffect(() => {
@@ -153,13 +157,16 @@ export function useTransferAutoDetect({
   const selectLine = useCallback(
     (line: LineNumber) => {
       if (!currentStation) return;
+      // #1637 — arrival race로 candidate=null이어도 사용자 선택 의도는 dismiss로 stamp.
+      // 그렇지 않으면 buildAutoLockCandidate가 null 반환 시(같은 환승역에서 polling 사이
+      // arrival 갱신 race) 모달이 즉시 닫혔다가 다음 cycle에 재오픈된다.
+      setModalVisible(false);
+      dismissedAtStationRef.current = stationKey;
       const candidate = buildAutoLockCandidate(line, arrival, destinationName);
       if (!candidate) return;
       const key = `${currentStation.id}|${candidate.trainCode}|${candidate.line}`;
       lastAutoLockedKeyRef.current = key;
       onAutoLock(candidate);
-      setModalVisible(false);
-      dismissedAtStationRef.current = stationKey;
     },
     [currentStation, arrival, destinationName, onAutoLock, stationKey],
   );


### PR DESCRIPTION
Closes #1637

## Summary

환승역 line selection 모달이 사용자 선택 후에도 매 GPS cycle 반복 표시되는 회귀 fix.

**Evidence**: 2026-06-22 14:01:55 사용자 합정 환승역(2호선/6호선) 스크린샷 — 환승역 사용 자체가 불가능한 사용자 가치 직접 손상.

**Root cause**: `useTransferAutoDetect:108`의 `stationKey = currentStation?.id`가 환승역에서는 line별로 분리됨 (예: `'합정-2'` vs `'합정-6'`). fusion이 같은 환승역의 다른 line variant를 primary로 채택하면 `stationKey` 변경 → `dismissedAtStationRef` reset (line 111-118 effect) → 모달 재오픈.

**Fix 2곳**:
- **A**: `stationKey = normalizeStationName(currentStation.name)` — line 무관하게 dismiss 보존
- **B**: `selectLine`에서 candidate 산출 전에 dismiss flag stamp — arrival race(candidate=null) 시에도 사용자 선택 의도 보존

## Test plan

- [x] 3 case 추가 (`#1637 환승역 dismiss 보존` describe 블록)
  - Case A: line variant 변경 시 dismiss 보존 (line=2 dismiss → line=6 primary → 모달 재오픈 X)
  - Case B: arrival race(candidate=null) 시에도 dismiss flag stamp 검증
  - Case C: 다른 환승역으로 이동 시는 모달 재오픈 (정상 동작 보존)
- [x] `npx jest src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts` — 31/31 pass (기존 28 + 신규 3)
- [x] `npx jest src/features/route/` — 901/901 pass
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` — No orphan exports detected

## Wire-completion 5단 (#1582)

1. **Orphan 없음** — `npm run lint:orphan` pass. `useTransferAutoDetect` 기존 export 그대로, caller(`HomeScreen` 등) 변경 없음.
2. **V/X dashboard** — 사용자가 수동 측정. DebugModal "환승 후보" 섹션 추후 follow-up. 본 PR 회귀는 단위 테스트 3 case로 박제.
3. **의존 PR** — N/A.
4. **측정 plan** — 실기기 합정/충무로/동대문역사문화공원 환승 trip 1주 측정. 사용자 dismiss/select 후 매 cycle 모달 재오픈 0건 evidence. evidence URL: 2026-06-22 14:01:55 합정 스크린샷.
5. **Device verify** — 실기기 필요. 시나리오:
   - 합정 환승역(2/6호선) 도착 → 다중 후보 모달 표시
   - 6호선 선택 또는 dismiss
   - 다음 GPS cycle (~30s) 대기
   - 모달 재오픈 안 되는지 확인
   - fusion primary가 line 변경 시(예: 2→6) 여전히 dismiss 보존되는지 확인

## Follow-up

- 회귀 1 (arrival 1s 지연) — 별도 follow-up issue로 분리 검토 (본 PR scope 아님)

## Note

본 fix는 사용자 가치 코드(V1~V9) 안 건드림. 모달 dismiss 정책만 변경 — 자동 lock / boardingPrompt / autoLock 9-AND gate 등 정확성 게이트 무영향.
