### PR TITLE
fix(#1633): apns env corrected 후 trip record 즉시 KV persist

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -2066,6 +2066,47 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
     expect(await kv.get('trip:lock-tok')).toBeNull();
   });
 
+  // #1633 — corrected env 즉시 KV persist 검증.
+  //
+  // 2026-06-22 trip 회귀: 같은 token에 대해 매 cron cycle(13:42/43/44/46) mismatch retry가 반복돼
+  // 매번 ~1초 지연 → device fg가 먼저 station 발사 → backend silent push가 `gate-station-already-passed`로
+  // drop → 매역 알림 backend 발사 0건. 종전엔 corrected env가 in-memory mutate 후 caller의 후속
+  // putTrip에 의존했으나, 그 사이 race / cleanup 분기 / KV eventual consistency로 영구 저장이 누락 가능.
+  //
+  // 본 테스트는 corrected env 발생 직후 KV trip record에 'production'이 stamp되는 immediate persist를
+  // 검증한다 — apns fetch 성공 직후 곧바로 kv put이 실행됨을 fetch ↔ put 호출 순서로 확인.
+  it('#1633 — corrected env 즉시 KV persist (fetch 성공 → 다음 KV put이 trip.apnsEnv=production stamp)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip({ apnsEnv: 'sandbox' }));
+    // KV put을 spy. corrected env 직후의 putTrip 호출에서 apnsEnv='production'이 stamp되는지 검증.
+    const putSpy = vi.spyOn(kv, 'put');
+    const apnsFetch = vi.fn();
+    apnsFetch
+      .mockImplementationOnce(async () =>
+        new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
+      )
+      .mockImplementationOnce(async () => new Response('', { status: 200 }));
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('중곡', 120)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-persist',
+    });
+    // 첫 번째 trip:lock-tok 대상 put에 apnsEnv='production'이 포함돼야 한다.
+    // (caller 후속 putTrip이 다시 같은 값을 쓰는 idempotent dedup도 허용 — 여기서는 처음 stamp만 검증.)
+    const tripPutsAfterMismatch = putSpy.mock.calls
+      .filter(([key]) => key === 'trip:lock-tok')
+      .map(([, value]) => JSON.parse(value as string));
+    expect(tripPutsAfterMismatch.length).toBeGreaterThan(0);
+    // 모든 trip put이 corrected env(production)를 가져야 한다 — corrected 이후 어느 putTrip도
+    // 절대 sandbox로 되돌아가지 않음을 보장.
+    for (const stored of tripPutsAfterMismatch) {
+      expect(stored.apnsEnv).toBe('production');
+    }
+  });
+
   it('deletes trip on Unregistered (410)', async () => {
     const kv = new InMemoryKV();
     await putTrip(kv as unknown as KVNamespace, makeLockTrip());

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -1220,6 +1220,12 @@ export async function fireArvlCdStationPush(
     trip.apnsEnv = heal.correctedEnv;
     dirty = true;
     stats.envCorrected += 1;
+    // #1633 — corrected env 즉시 KV persist. 후속 caller putTrip이 early-return / race /
+    // exception으로 누락되거나 KV eventual consistency로 다음 cron이 stale read해도, 본
+    // 즉시 write가 origin 갱신을 보장해 같은 trip의 후속 push가 mismatch retry로 1초 지연
+    // → device gate-station-already-passed로 drop되는 회귀(2026-06-22 evidence)를 차단.
+    // putTrip은 idempotent하며 caller의 후속 putTrip은 자연 dedup(같은 in-memory snapshot).
+    await putTrip(env.TRIPS, trip);
   }
   if (!heal.result.ok) {
     stats.errors += 1;
@@ -1550,6 +1556,10 @@ export async function fireVanishFallbackStationPush(
   if (heal.correctedEnv) {
     trip.apnsEnv = heal.correctedEnv;
     stats.envCorrected += 1;
+    // #1633 — corrected env 즉시 KV persist. vanish-fallback / vanish-release 경로는 본 함수가
+    // void 반환이라 호출자가 dirty 신호 없이 putTrip 결정. 후속 putTrip은 advanceBoardingLockWaypoint
+    // 또는 명시 putTrip이 있지만 race/early-return 시 누락 가능 — 본 즉시 write로 영구 보존.
+    await putTrip(env.TRIPS, trip);
   }
   if (!heal.result.ok) {
     stats.errors += 1;
@@ -2142,7 +2152,7 @@ export async function advanceBoardingLockWaypoint(
     const ssotForTransfer = await readSsot(env.TRIPS, trip.token, {
       cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
     });
-    await sendWithEnvHeal(
+    const transferHeal = await sendWithEnvHeal(
       (host) =>
         sendSilentPush({
           deviceToken: trip.token,
@@ -2166,6 +2176,15 @@ export async function advanceBoardingLockWaypoint(
       log,
       trip.token.slice(0, 8),
     );
+    // #1633 — transfer-release fire의 corrected env capture. 종전엔 결과 discard로
+    // trip.apnsEnv 가 in-memory mutate 되지 않아 line 2217 putTrip 이 OLD value 를 쓰고,
+    // 환승 후 leg 2 의 후속 push 들이 매번 mismatch retry 로 1초 지연된다. 즉시 write 로
+    // corrected env 영구 보존.
+    if (transferHeal.correctedEnv) {
+      trip.apnsEnv = transferHeal.correctedEnv;
+      stats.envCorrected += 1;
+      await putTrip(env.TRIPS, trip);
+    }
   }
   // #902 Seam F — 환승 직후 자동 trainCode swap. release한 lock 자리에 새 노선의 후보를
   // 동일 cycle 안에 부착해 다음 cycle의 lockMissing/boarding-prompt 우회 + 즉시 trainCode 추적.
@@ -2358,6 +2377,10 @@ export async function maybeReschedulePush(
     trip.apnsEnv = heal.correctedEnv;
     dirty = true;
     stats.envCorrected += 1;
+    // #1633 — reschedule push corrected env 즉시 KV persist. 후속 maybeReschedulePush 호출이
+    // 다음 cron까지 1분 간격이라 그 사이 device re-POST나 cron stale read로 mismatch가 반복될
+    // 수 있다. 즉시 write로 race window 차단.
+    await putTrip(env.TRIPS, trip);
   }
   const envMismatchExhausted = heal.envMismatchExhausted;
   const result = heal.result;
@@ -2651,6 +2674,10 @@ export async function runLocklessIntermediate(
     trip.apnsEnv = heal.correctedEnv;
     dirty = true;
     stats.envCorrected += 1;
+    // #1633 — lockless intermediate corrected env 즉시 KV persist. lockless는 매역 fire 경로라
+    // 다음 push까지 짧은 간격(~60s)이지만, 본 cycle 내 후속 코드가 cleanupTripWithLa로 early
+    // return하면 putTrip이 호출되지 않는다. 즉시 write로 corrected env 영구 보존.
+    await putTrip(env.TRIPS, trip);
   }
   if (!heal.result.ok) {
     stats.errors += 1;
@@ -2965,6 +2992,10 @@ export async function evaluateAndMaybeFireBoardingPrompt(
     trip.apnsEnv = heal.correctedEnv;
     dirty = true;
     stats.envCorrected += 1;
+    // #1633 — boarding-prompt corrected env 즉시 KV persist. dirty 후속 putTrip(line 2990)이
+    // 정상 경로지만, 본 함수가 trip 종료 / cleanup 경로로 분기하면 누락 가능. 즉시 write로
+    // corrected env가 영구 보존돼 후속 cron / push가 mismatch retry 없이 정상 호스트로 직행.
+    await putTrip(env.TRIPS, trip);
   }
   if (heal.result.ok) {
     stats.boardingPromptFired += 1;


### PR DESCRIPTION
Closes #1633

## Summary
2026-06-22 trip backend log (13:36~13:47) — 같은 token에 `apns env mismatch — retry with opposite host` 로그 4건 반복 (13:42:10, 13:43:09, 13:44:10, 13:46:10). 매번 corrected로 정정됐지만 매 push마다 ~1초 retry 지연 → 그 사이 device fg가 같은 station을 먼저 발사 → silent push 도달 시점 device gate가 `gate-station-already-passed` skip → V4 매역 알림 backend 발사 0건.

## Root Cause

`sendWithEnvHeal`이 corrected env를 in-memory `trip.apnsEnv`에 stamp하지만 KV persist는 caller의 후속 `putTrip` 호출에 의존한다. 다음 갭이 존재:

### 1. `transfer-release` path (scheduled.ts:2145) — `sendWithEnvHeal` 결과 완전 discard
`await sendWithEnvHeal(...)`이 결과 변수를 받지 않음 → `heal.correctedEnv`가 있어도 `trip.apnsEnv` mutation X → 후속 putTrip(line 2217)이 OLD value를 stamp. 환승 후 leg 2의 모든 push가 같은 mismatch retry 반복.

### 2. 5개 정상 path의 race window
arvlcd-fire / vanish-fallback / reschedule / lockless / boarding-prompt 모두 dirty 또는 후속 putTrip 패턴이지만, 그 사이:
- exception / early-return / cleanup 분기로 putTrip이 skip되거나
- KV eventual consistency로 다음 cron이 stale read 가능 (cacheTtl=30s × cron 60s 윈도우)

## Fix

**옵션 A 채택 — corrected env를 KV TRIPS의 trip record에 즉시 persist** (가장 안전, 1줄 추가/site).

- 5개 site (arvlcd-fire / vanish / reschedule / lockless / boarding-prompt) corrected env 직후 `await putTrip(env.TRIPS, trip)` 추가.
- transfer-release site 결과 capture + 동일 immediate persist.

원본 dirty 추적은 그대로 유지(idempotent) — caller의 후속 putTrip은 같은 in-memory snapshot으로 dedup. push 발사 시점에 envCorrected가 발생하면 1회 추가 KV write 비용으로 안전 trade-off.

## Wire-completion 5단

1. **Orphan**: 신규 export 없음. `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard**: backend wrangler tail에서 `apns env mismatch` 같은 token 1회만 등장 (다음 cron부터 정상). `envCorrected` stat은 trip당 1회로 정착.
3. **의존 PR**: N/A.
4. **측정 plan**: 사용자 다음 trip에서 13:36~13:47 같은 시나리오 재현 — `apns env mismatch` 로그가 trip 첫 push에만 등장하고 후속 cron cycle에서 사라져야 한다.
5. **Device verify**: N/A — backend-only, type+unit only.

## Test plan
- [x] `backend/alarm-worker/src/__tests__/scheduled.test.ts` — 신규 #1633 테스트: corrected env 직후 KV put에 `apnsEnv='production'` stamp 검증.
- [x] 기존 1889 backend test 전부 pass (1892 total, +1 #1633 + 2 from rebase).
- [x] `npm run lint:orphan` pass (0 orphan).
- [ ] 실측 — 사용자 다음 trip에서 매 cron cycle mismatch 반복이 사라지는지 wrangler tail 확인.