### PR TITLE
fix(#1640): 첫 leg autoLock chain device-side 이전

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -1173,4 +1173,293 @@ describe('useBoardingLockController', () => {
       expect(createLockMock).not.toHaveBeenCalled();
     });
   });
+
+  describe('origin leg device-side auto-lock (#1640)', () => {
+    // ARRIVAL_CODE 미사용 — 테스트는 arvlCd 숫자 리터럴(1=도착, 0=진입)을 직접 사용한다(production 모듈과 같은 SSOT).
+    let alarmLogSpy: jest.SpyInstance;
+    beforeEach(() => {
+      // logBoardingPromptAutoLock은 storage flush를 트리거하므로 spy로 격리.
+      const alarmLog = jest.requireActual('../../utils/alarmLog');
+      alarmLogSpy = jest.spyOn(alarmLog, 'logBoardingPromptAutoLock');
+      // direction 'up' (arrival.up이 directionalArrivals로 흘러가도록).
+      mockResolveTripDirection.mockReturnValue('up');
+    });
+    afterEach(() => {
+      alarmLogSpy.mockRestore();
+    });
+
+    /** trainCode 단일 후보(arvlCd=1 도착) — pickAutoTrainCodeFromArrivals가 항상 같은 train을 선정. */
+    const singleArrived = makeTrain({ trainCode: 'AUTO-X', arrivalCode: 1, line: '2' });
+    const singleArrival: StationArrival = { up: [singleArrived], down: [] };
+
+    it('lock 부재 + directionalArrivals 단일 후보 → device-side createLock 호출 (backend push 의존 없음)', async () => {
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: singleArrival }),
+      );
+      await waitFor(() => {
+        expect(createLockMock).toHaveBeenCalled();
+      });
+      const arg = createLockMock.mock.calls[0][0];
+      expect(arg.trainCode).toBe('AUTO-X');
+      expect(arg.boardingLine).toBe('2');
+      expect(arg.initialEtaSeconds).toBe(180);
+    });
+
+    it('lock 이미 존재 → 자동 lock skip (사용자 명시 탭 / lockSuggestion 보호)', async () => {
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      const existing: BoardingLock = {
+        destinationId: 'dest-1',
+        trainCode: 'USER-TAP',
+        boardingStationId: 'stn-A',
+        boardingLine: '2',
+        boardedAt: Date.now(),
+        expectedDurationMs: 30 * 60_000,
+      };
+      mockGetBoardingLock.mockResolvedValue(existing);
+      useBoardingLockStore.setState({ lock: existing, createLock: createLockMock });
+      renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: singleArrival }),
+      );
+      // 첫 effect cycle이 완전히 settle하도록 microtask flush.
+      await waitFor(() => {
+        // loadLock이 이미 끝났는지 확인. createLock은 미호출이 되어야.
+        expect(mockGetBoardingLock).toHaveBeenCalled();
+      });
+      expect(createLockMock).not.toHaveBeenCalled();
+    });
+
+    it('directionalArrivals empty → skip (다음 polling cycle 재시도)', async () => {
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: { up: [], down: [] } }),
+      );
+      // arrival 비어 있어도 hook 마운트는 동기 — 동기 flush 후 createLock 미호출 확인.
+      await waitFor(() => {
+        expect(mockGetBoardingLock).toHaveBeenCalled();
+      });
+      expect(createLockMock).not.toHaveBeenCalled();
+    });
+
+    it('arvlCd ambiguity (도착=2개) → pickAutoTrainCode null → skip → fallback 흐름 유지', async () => {
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      const ambig: StationArrival = {
+        up: [
+          makeTrain({ trainCode: 'A', arrivalCode: 1, line: '2' }),
+          makeTrain({ trainCode: 'B', arrivalCode: 1, line: '2' }),
+        ],
+        down: [],
+      };
+      renderHook(() => useBoardingLockController({ ...defaultInputs, arrival: ambig }));
+      await waitFor(() => {
+        expect(mockGetBoardingLock).toHaveBeenCalled();
+      });
+      expect(createLockMock).not.toHaveBeenCalled();
+    });
+
+    it('arvlCd가 ENTERING/ARRIVED/DEPARTED 외 (fallback first-candidate) → skip — false positive 차단', async () => {
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      // 모든 train이 RUNNING(99) — pickAutoTrainCodeFromArrivals는 fallback으로 arrivals[0]을 반환하지만
+      // device-side origin auto-lock은 강 evidence(0/1/2)만 신뢰하므로 거부.
+      const weakEvidence: StationArrival = {
+        up: [makeTrain({ trainCode: 'WEAK', arrivalCode: 99, line: '2' })],
+        down: [],
+      };
+      renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: weakEvidence }),
+      );
+      await waitFor(() => {
+        expect(mockGetBoardingLock).toHaveBeenCalled();
+      });
+      expect(createLockMock).not.toHaveBeenCalled();
+    });
+
+    it('arvlCd DEPARTED(2) 단일 후보 → device-side createLock 호출 (출발 evidence)', async () => {
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      const departed: StationArrival = {
+        up: [makeTrain({ trainCode: 'DEP', arrivalCode: 2, line: '2' })],
+        down: [],
+      };
+      renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: departed }),
+      );
+      await waitFor(() => {
+        expect(createLockMock).toHaveBeenCalled();
+      });
+      expect(createLockMock.mock.calls[0][0].trainCode).toBe('DEP');
+    });
+
+    it('arvlCd ENTERING(0) 단일 후보 → device-side createLock 호출 (진입 evidence)', async () => {
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      const entering: StationArrival = {
+        up: [makeTrain({ trainCode: 'ENT', arrivalCode: 0, line: '2' })],
+        down: [],
+      };
+      renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: entering }),
+      );
+      await waitFor(() => {
+        expect(createLockMock).toHaveBeenCalled();
+      });
+      expect(createLockMock.mock.calls[0][0].trainCode).toBe('ENT');
+    });
+
+    it('currentStation null → skip (다음 cycle 재시도)', async () => {
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      renderHook(() =>
+        useBoardingLockController({
+          ...defaultInputs,
+          currentStation: null,
+          arrival: singleArrival,
+        }),
+      );
+      await waitFor(() => {
+        expect(mockGetBoardingLock).toHaveBeenCalled();
+      });
+      expect(createLockMock).not.toHaveBeenCalled();
+    });
+
+    it('route null → skip (lock 컨텍스트 부재 — 사용자 명시 의향 trip 아님)', async () => {
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, route: null, arrival: singleArrival }),
+      );
+      await waitFor(() => {
+        expect(mockGetBoardingLock).toHaveBeenCalled();
+      });
+      expect(createLockMock).not.toHaveBeenCalled();
+    });
+
+    it('allowedLines 검증 — train.line이 trip route allowed 아니면 reject (#1449)', async () => {
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      // route는 line 2, train은 line 7 (옆 노선 fusion 오류 시뮬레이션).
+      const wrongLine: StationArrival = {
+        up: [makeTrain({ trainCode: 'WRONG-LINE', arrivalCode: 1, line: '7' })],
+        down: [],
+      };
+      renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: wrongLine }),
+      );
+      await waitFor(() => {
+        expect(mockGetBoardingLock).toHaveBeenCalled();
+      });
+      expect(createLockMock).not.toHaveBeenCalled();
+    });
+
+    it('idempotency — 같은 origin key (destinationId + currentStation.id) 조합으로 1회만 시도', async () => {
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      const { rerender } = renderHook(
+        (props: { arr: StationArrival }) =>
+          useBoardingLockController({ ...defaultInputs, arrival: props.arr }),
+        { initialProps: { arr: singleArrival } },
+      );
+      await waitFor(() => {
+        expect(createLockMock).toHaveBeenCalledTimes(1);
+      });
+      // arrival이 polling으로 새 객체(같은 train code)로 갱신 — 같은 origin key라 재시도 X.
+      const refreshed: StationArrival = {
+        up: [makeTrain({ trainCode: 'AUTO-X', arrivalCode: 1, line: '2' })],
+        down: [],
+      };
+      rerender({ arr: refreshed });
+      // 충분한 flush 후 여전히 1회.
+      await waitFor(() => {
+        expect(mockGetBoardingLock).toHaveBeenCalled();
+      });
+      expect(createLockMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('expectedDurationMinutes null → FALLBACK_BOARDING_DURATION_MINUTES(30분)', async () => {
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      renderHook(() =>
+        useBoardingLockController({
+          ...defaultInputs,
+          expectedDurationMinutes: null,
+          arrival: singleArrival,
+        }),
+      );
+      await waitFor(() => {
+        expect(createLockMock).toHaveBeenCalled();
+      });
+      expect(createLockMock.mock.calls[0][0].expectedDurationMs).toBe(30 * 60_000);
+    });
+
+    it('destinationId null → free-trip sentinel으로 hydrate (#978 정책 재사용)', async () => {
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      renderHook(() =>
+        useBoardingLockController({
+          ...defaultInputs,
+          destinationId: null,
+          arrival: singleArrival,
+        }),
+      );
+      await waitFor(() => {
+        expect(createLockMock).toHaveBeenCalled();
+      });
+      const arg = createLockMock.mock.calls[0][0];
+      expect(arg.hydratedFromSentinel).toBeDefined();
+    });
+
+    it('boardingStationId — train.line 기준 정정 (#707) — 환승역 옆 노선 stop id 회귀 차단', async () => {
+      mockFindStationByNameAndLine.mockReturnValue({
+        id: 'stn-A-corrected',
+        name: '강남',
+        line: '2',
+        lineColor: '#000',
+        lat: 37.5,
+        lng: 127.0,
+      });
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: singleArrival }),
+      );
+      await waitFor(() => {
+        expect(createLockMock).toHaveBeenCalled();
+      });
+      expect(createLockMock.mock.calls[0][0].boardingStationId).toBe('stn-A-corrected');
+    });
+
+    it('createLock 성공 → logBoardingPromptAutoLock(autolock-success) 적재 (V/X 측정)', async () => {
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: singleArrival }),
+      );
+      await waitFor(() => {
+        expect(alarmLogSpy).toHaveBeenCalledWith({
+          reason: 'autolock-success',
+          originStation: '강남',
+          line: '2',
+        });
+      });
+    });
+
+    it('createLock 실패 → logBoardingPromptAutoLock(autolock-lock-failed) graceful (throw X)', async () => {
+      const createLockMock = jest.fn().mockRejectedValue(new Error('storage'));
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      renderHook(() =>
+        useBoardingLockController({ ...defaultInputs, arrival: singleArrival }),
+      );
+      await waitFor(() => {
+        expect(alarmLogSpy).toHaveBeenCalledWith({
+          reason: 'autolock-lock-failed',
+          originStation: '강남',
+          line: '2',
+        });
+      });
+    });
+  });
 });

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -6,7 +6,7 @@
  *
  * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
  */
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { AppState, type AppStateStatus } from 'react-native';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import { resolveTripDirection } from '../../route/utils/tripDirection';
@@ -24,6 +24,9 @@ import {
 import type { AutoLockCandidate } from '../../nearest-station/api/boardingLockSync';
 import { useLockSuggestion } from '../api/useLockSuggestion';
 import type { LockSuggestionMirror } from '../utils/backendSsotMirror';
+import { pickAutoTrainCodeFromArrivals } from '../utils/boardingPromptAutoLock';
+import { logBoardingPromptAutoLock } from '../utils/alarmLog';
+import { ARRIVAL_CODE } from '../../../shared/constants/arrivalCodes';
 
 export interface UseBoardingLockControllerInputs {
   destinationId: string | null;
@@ -385,6 +388,125 @@ export function useBoardingLockController({
     },
     [destinationId, currentStation, expectedDurationMinutes, lock, createLock, directionalArrivals, motionStationary, speedMps, allowedLines],
   );
+
+  // #1640 — Origin leg device-side auto-lock.
+  //
+  // 환승 leg는 `useTransferTrainList.ts:152-161`에서 이미 device-side로 arvlCd 우선순위 자동 lock을
+  // 시도한다. 하지만 origin leg(첫 lock 부재 상태)는 backend boardingPrompt push → useBoardingPromptResponder
+  // 응답 chain에 100% 종속이라, backend 9-AND gate fail(지하/lockless 환경)이면 device가 자체로 lock 시도조차
+  // 못 했다 — 7일 누적 push 0건 / autoLock 0건 / lockless 알림 0건 회귀의 root cause.
+  //
+  // 본 effect는 origin leg에서 동일 device-side trigger를 복원한다. 정책은 `useTransferTrainList` D5
+  // (#1211)와 같은 패턴:
+  //   - lock 부재 + arrival 가용 + currentStation 확정 시
+  //   - `pickAutoTrainCodeFromArrivals(directionalArrivals)` 단일 후보 산출 가능 시
+  //   - allowedLines 검증 통과 시
+  //   - createLock 즉시 호출 (사용자 액션 0)
+  // ambiguity / empty 시 skip → 자연스럽게 BoardingTrainList (HomeScreen.tsx:1099 분기) fallback UX로 도달.
+  //
+  // backend push 응답 chain(C 경로)은 그대로 유지 — 본 effect가 먼저 성공하면 store lock 활성으로
+  // 뒤늦은 backend push 응답의 createLock도 `if (lock) return` idempotent로 자연 skip.
+  //
+  // 정합성 가드:
+  //   1) `lock != null` → skip (사용자 명시 탭/lockSuggestion/hydrateLockFromCandidate 우선 보호).
+  //   2) `!currentStation || !route` → skip (lock 컨텍스트 부재).
+  //   3) `directionalArrivals.length === 0` → skip (다음 polling cycle 재시도).
+  //   4) `pickAutoTrainCodeFromArrivals` ambiguity/empty → skip + idempotency ref 미설정 (다음 cycle 재시도).
+  //   5) **arvlCd 강 evidence 요구** — 선정된 train의 arvlCd가 ENTERING(0) / ARRIVED(1) / DEPARTED(2) 중
+  //      하나여야 자동 lock 진행. `pickAutoTrainCodeFromArrivals`의 마지막 fallback(arrivals[0] 첫 후보)은
+  //      device-side origin auto-lock에서 거부 — backend push 응답 path는 "사용자가 boarded 응답" 신호로
+  //      그 후보를 신뢰하지만, device-side trigger는 사용자 신호 없이 발사하므로 강 evidence가 필수.
+  //      false positive(엉뚱한 열차 lock) ≤ ambiguity 차단 (CLAUDE.md 룰 + ADR-014 첫 줄).
+  //   6) `allowedLines` 검증 — trip route 외 line train 자동 lock 차단 (환승역 fusion 오류 보호).
+  //   7) Idempotency: 같은 `${destinationId}|${currentStation.id}` 조합에서 최대 1회 lock 시도. 사용자가
+  //      release 후 같은 origin에서 다시 lock 시도하려면 effect의 success 분기에서 ref가 set되므로
+  //      자연 차단. trip 전환(destination 변경)으로 stale lock release되면 새 key → 자동 재시도 허용.
+  //
+  // CLAUDE.md 룰 정렬:
+  //   - lockless 토글 OFF도 자동 lock 진행 (정보용 라벨, ADR-014 "사용자 명시 의향 trip 동급" 룰).
+  //   - GPS 결정 권한 X — 본 effect는 arrival API + arvlCd 우선순위만 사용.
+  //   - 시간 적분 fire 권한 X — fire가 아니라 lock 부착만.
+  const lastOriginAutoLockKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (lock) return;
+    if (!route) return;
+    if (!currentStation) return;
+    if (directionalArrivals.length === 0) return;
+    const originKey = `${destinationId ?? FREE_TRIP_DESTINATION_SENTINEL}|${currentStation.id}`;
+    if (lastOriginAutoLockKeyRef.current === originKey) return;
+    const chosen = pickAutoTrainCodeFromArrivals(directionalArrivals);
+    if (!chosen) return;
+    // 강 evidence 게이트: arvlCd가 ENTERING/ARRIVED/DEPARTED 중 하나일 때만 진행.
+    // `pickAutoTrainCodeFromArrivals`는 receivedAt 정렬 첫 후보로 fallback하지만, 본 effect는
+    // 사용자 신호 없이 device-side 자체 발사이므로 fallback path를 거부한다 (false positive 차단).
+    if (
+      chosen.arrivalCode !== ARRIVAL_CODE.ENTERING &&
+      chosen.arrivalCode !== ARRIVAL_CODE.ARRIVED &&
+      chosen.arrivalCode !== ARRIVAL_CODE.DEPARTED
+    ) {
+      return;
+    }
+    // allowedLines 검증 — useBoardingPromptResponder.tryAutoLock과 createLockFromTrain의 정책을 그대로 반영.
+    if (allowedLines && !allowedLines.has(chosen.line)) return;
+    // idempotency ref는 시도 직전에 set — store action이 race/storage 실패해도 다음 cycle 재시도하지 않도록.
+    // graceful 실패는 ref reset 없이 그대로 두고, 사용자 release 시 자연 재진입(다른 key로) 시점에 재시도된다.
+    lastOriginAutoLockKeyRef.current = originKey;
+    const durationMin = expectedDurationMinutes ?? FALLBACK_BOARDING_DURATION_MINUTES;
+    const correctedStation = findStationByNameAndLine(currentStation.name, chosen.line);
+    const boardingStationId = correctedStation?.id ?? currentStation.id;
+    const isSentinel = !destinationId;
+    const effectiveDestinationId = destinationId ?? FREE_TRIP_DESTINATION_SENTINEL;
+    const now = Date.now();
+    createLock({
+      destinationId: effectiveDestinationId,
+      trainCode: chosen.trainCode,
+      boardingStationId,
+      boardingLine: chosen.line,
+      boardedAt: now,
+      expectedDurationMs: durationMin * 60_000,
+      // #897 Seam A: 자동 lock도 탑승 시점 ETA 스냅샷 보존 — origin leg device-side 채택은 사용자 명시 탭과
+      // 동급으로 신뢰(arvlCd 우선순위 단일 후보 + arrival API 가용)하므로 지연 칩이 backend SSoT hydrate와
+      // 다르게 활성화돼야 자연스럽다.
+      initialEtaSeconds: chosen.arrivalSeconds,
+      ...(isSentinel
+        ? {
+            hydratedFromSentinel: {
+              destinationId: FREE_TRIP_DESTINATION_SENTINEL,
+              sentinelAt: now,
+            },
+          }
+        : {}),
+    })
+      .then(() => {
+        // V/X 측정 — `source='boarding-prompt'` 재사용해 DebugModal/autoLock outcome 분포에서 한 화면에서 가시화.
+        // backend push 응답 path(useBoardingPromptResponder)와 같은 reason 라벨을 쓰되, alarm log entry에는
+        // stationName=`${line}·${originStation}` 포맷으로 stamped — countBoardingPromptAutoLockOutcomes 결과에
+        // 가산되어 1주 production 측정에서 device-side origin 시도 가시화.
+        logBoardingPromptAutoLock({
+          reason: 'autolock-success',
+          originStation: currentStation.name,
+          line: chosen.line,
+        });
+      })
+      .catch(() => {
+        // store action rejection은 graceful — 이미 ref가 set돼 있어 즉시 재시도 폭주는 차단.
+        // 사용자 명시 탭 / backend push 응답 path가 fallback으로 남아 있다.
+        logBoardingPromptAutoLock({
+          reason: 'autolock-lock-failed',
+          originStation: currentStation.name,
+          line: chosen.line,
+        });
+      });
+  }, [
+    lock,
+    route,
+    currentStation,
+    directionalArrivals,
+    destinationId,
+    expectedDurationMinutes,
+    allowedLines,
+    createLock,
+  ]);
 
   return {
     lock,


### PR DESCRIPTION
## 변경 요약

`useBoardingLockController.ts`에 effect 1개 추가 — origin leg autoLock device-side 이전. transfer leg(`useTransferTrainList.ts:152-161`)와 대칭. 신규 UI/store/컴포넌트 X.

**문제:** 7일 누적 boardingPrompt push 0건 + lockless trip 알림 0건 회귀가 한 가지 root cause로 추적된다 — 첫 leg(origin → train) 자동 lock 시도 chain이 backend boardingPrompt push 발사에 100% 종속.

체인:
1. backend `evaluateAndMaybeFireBoardingPrompt` 9-AND gate fail (지하 100% GPS 없음)
2. → device가 받는 `boarding-prompt` push 0건 → `useBoardingPromptResponder.tryAutoLock`(`src/features/alarm/hooks/useBoardingPromptResponder.ts:163`) 0회 호출
3. → device-side에는 첫 leg 자동 lock chain이 **존재하지 않음** → 사용자가 BoardingTrainList를 직접 탭하지 않으면 trip 영구 lockless
4. → lockless 상태에서 backend가 trainCode-bound 알람을 발사 못 함 → 매역 push 0건

**핵심 발견:** 환승 leg(`useTransferTrainList.ts:152-161`)는 이미 device-side 자동 lock 시도를 한다 — backend push 의존 없이 `pickAutoTrainCodeFromArrivals` 직접 호출. **origin leg(첫 lock)** 만 backend에 묶여 있다. 이 대칭만 회복하면 회귀 해결.

Closes #1640

## Wire Matrix

| Element | A. 사용자 직접 train 탭 | B. 자동 lock (신규 device-side) | C. backend push 응답 (기존) | D. MisBoarding 재선택 | E. 환승 leg |
|---|---|---|---|---|---|
| BoardingTrainList 표시 trigger | `src/screens/HomeScreen.tsx:1099` (proximity + `!boardingLock`) | N/A (fallback only — 자동 lock 실패 시 동일 분기) | iOS system notification (UNNotificationCategory.BOARDING_PROMPT) | `src/screens/HomeScreen.tsx:885` (`MisBoardingReselectModal`, misBoarding detect) | `src/screens/HomeScreen.tsx:1171` (transfer hop slot) |
| 자동 lock 시도 trigger | N/A | `src/features/alarm/hooks/useBoardingLockController.ts:430` (신규 effect) | `src/features/alarm/hooks/useBoardingPromptResponder.ts:121` (notification response listener) | N/A | `src/features/route/hooks/useTransferTrainList.ts:152` |
| pickAutoTrainCode 호출 | N/A | `src/features/alarm/hooks/useBoardingLockController.ts:436` | `src/features/alarm/hooks/useBoardingPromptResponder.ts:189` | N/A | `src/features/route/hooks/useTransferTrainList.ts:157` |
| createLock 호출 | `src/features/alarm/hooks/useBoardingLockController.ts:279` (createLockFromTrain) | `src/features/alarm/hooks/useBoardingLockController.ts:457` (신규 effect 내 직접 호출) | `src/features/alarm/hooks/useBoardingPromptResponder.ts:207` (`deps.createLock`) | `src/features/alarm/hooks/useBoardingLockController.ts:279` (재선택 train 입력) | `src/features/route/hooks/useTransferTrainList.ts:137` (createTransferLock) |
| logBoardingPromptAutoLock 호출 | N/A | `src/features/alarm/hooks/useBoardingLockController.ts:482, 492` (success/lock-failed branches) | `src/features/alarm/hooks/useBoardingPromptResponder.ts:171, 179, 194, 202, 217, 222` | N/A | (transfer leg는 별도 측정 trail 미보유 — 본 PR 범위 외) |

## Wire Verification

- `npm run lint:orphan` → **0 orphan** ✅
- 신규 export 수: **0** (effect는 hook 내부 closure)
- 신규 import 추가: `pickAutoTrainCodeFromArrivals`, `logBoardingPromptAutoLock`, `ARRIVAL_CODE`, `useRef` (모두 기존 모듈 재사용)
- 진입점별 chain 도달: A=OK / B=OK (신규) / C=OK / D=OK / E=OK

## V/X 매핑

- **V1 (lockless 0% 보장)** — backend boardingPrompt push 0건 상태에서도 device가 자체로 origin leg autoLock 시도. 회복 조건: arrival API 가용 + arvlCd 단일 후보 산출 가능.
- **V2 (자동 lock 성공률)** — 도착 arrival 가용 + 단일 arvlCd evidence trip에서 자동 lock 성공률 목표 ≥ 80%.
- **V3 (BoardingTrainList fallback 정상)** — ambiguity / weak evidence(arvlCd 99 등) 시 사용자 명시 선택 UX 보존 (기존 `HomeScreen.tsx:1099` 분기).
- **V4 (지하/lockless 동급 보호)** — backend push 0건 시에도 arrival API만 가용하면 device-side trigger 발동.
- **X1 (backend push 응답 backward-compat)** — 기존 `useBoardingPromptResponder.tryAutoLock` chain 미변경.
- **X2 (사용자 명시 탭 우선)** — `if (lock) return` 가드로 사용자 명시 탭/lockSuggestion이 만든 lock 자동 overwrite 차단.
- **X3 (false positive 차단)** — `pickAutoTrainCodeFromArrivals` ambiguity → null → skip. arvlCd가 ENTERING/ARRIVED/DEPARTED 외(RUNNING=99 등) → fallback path 거부.
- **X4 (route 외 line reject)** — `allowedLines` SSoT로 환승역 옆 노선 train 자동 lock 차단.
- **X9 (사용자 의도 외 fire)** — idempotency ref + allowedLines 가드로 false lock 차단. 같은 origin key 1회만 시도.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass. 신규 export 없음 (effect는 hook 내부 closure).
2. **V/X dashboard** — `logBoardingPromptAutoLock` (`source='boarding-prompt'` 재사용) → DebugModal "Boarding Prompt" 카운터 + autoLock outcome 분포에서 가시화. 기존 `countBoardingPromptAutoLockOutcomes`에 가산.
3. **의존 PR** — 없음 (단독 머지 가능, device-only, 기존 backend boarding-prompt push 체계 미변경). `#1421` PR-AutoLock-1 측정 인프라는 본 PR과 별경로지만 함께 close 후보 평가 가능.
4. **측정 plan** — 1주 production trip 동안 `countBoardingPromptAutoLockOutcomes`에서 `autolock-success` count 가시화. baseline: 7일 0건 → 목표: ≥ 1건/active trip. lockless duration ≤ 3 cycle.
5. **Device verify** — 사용자 실기기 trip 1~2건. BoardingTrainList 명시 탭 0번 + 자동 lock 부착 확인. 지하 진입 trip(GPS 0%)에서도 arrival API만 가용하면 동작 확인.

## 회귀 정의 점검

1. **lock 활성 / lockless 둘 다 카테고리** — Yes. lockless trip의 device-side fallback이 본 PR 핵심.
2. **사용자 명시 의향 trip 동급** — Yes. lockless 토글 OFF도 device autoLock 진행 (정보용 라벨, ADR-014 "사용자 명시 의향 trip 동급" 룰).
3. **ADR 첫 줄 원칙** — false positive ≤ ambiguity + arvlCd evidence 차단, miss ≤ device-side trigger 추가로 동급 보호.
4. **권한 매트릭스** — WhileInUse FG에서 즉시 진입. BG/취침은 backend autoLock(`#916`) + lockSuggestion(ADR-016 S1)이 이미 cover. 본 PR은 FG 첫 leg lock 부재 시 즉시 보강.
5. **환경 매트릭스** — 지상/지하/환승 모두 arrival API 가용 시 trigger. 지하 GPS 0% / WiFi 미가용 환경에서도 arrival API(Seoul Open API + BFF)는 가용.

## UX 충돌 mitigation

- **lockless 토글 OFF** — 토글은 정보용. 자동 lock 진행 (조건 통과 시).
- **MisBoardingReselectModal 진행 중** — misBoarding=true → 기존 lock 존재 → `if (lock) return` 가드로 자연 skip.
- **환승 leg** — `useTransferTrainList`가 이미 처리. 본 PR 효과는 origin leg(첫 lock 부재)만.
- **currentStation 미확정** — `if (!currentStation) return` graceful skip + 다음 cycle 재시도.
- **lockSuggestion race** — 두 effect 모두 `if (lock) return`. 먼저 성공한 쪽이 이기는 idempotent 정책.
- **arrival 미도착** — `directionalArrivals.length === 0` graceful skip + 다음 polling cycle 재시도.

## 테스트 결과

- **type-check**: 0 error
- **coverage**: 100% (lines/functions/branches/statements) — `useBoardingLockController.ts` 변경 라인 모두 cover
- **lint**: 0 신규 error, 0 orphan (기존 dev 2 errors는 본 PR과 무관 — `tripBoundCleanups.test.ts` + `positionUpload.test.ts` pre-existing)
- **신규 단위 테스트**: 15개 (describe block: `origin leg device-side auto-lock (#1640)`)
  - 단일 후보 → createLock 호출
  - 이미 lock 존재 → skip
  - directionalArrivals empty → skip
  - arvlCd ambiguity → skip
  - arvlCd weak evidence (RUNNING=99) → skip
  - arvlCd DEPARTED(2) 단일 → 시도
  - arvlCd ENTERING(0) 단일 → 시도
  - currentStation null → skip
  - route null → skip
  - allowedLines reject (#1449)
  - idempotency — 같은 origin key 1회만
  - expectedDurationMinutes null → FALLBACK 30분
  - destinationId null → free-trip sentinel hydrate (#978 재사용)
  - boardingStationId — train.line 기준 정정 (#707)
  - createLock 성공 → logBoardingPromptAutoLock(autolock-success)
  - createLock 실패 → logBoardingPromptAutoLock(autolock-lock-failed) graceful

## 코드 리뷰 결과

`/code-review --effort medium` 실행 — **0 finding** (correctness bug 없음, cleanup 없음). 9 finder angles + 1 sweep 통과.

핵심 검토 사항:
- 비동기 chain `.then().catch()` 안전 — catch가 createLock rejection + then 콜백 throw 둘 다 cover
- `useRef` initialization + 시도 직전 set 위치 — race-safe
- deps array 완전 — `lock`, `route`, `currentStation`, `directionalArrivals`, `destinationId`, `expectedDurationMinutes`, `allowedLines`, `createLock` 모두 포함
- Zustand `createLock` selector — 안정 reference (deps churn 없음)
- 같은 origin 내 release → re-autolock 차단 (UX 정합성)

## 사용자 룰 정합성

- **시간 적분 fire 권한 X**: 본 fix는 arrival arvlCd evidence 기반, 시간 적분 미사용 ✅
- **GPS 결정 권한 X**: GPS 미사용 — arrival API + arvlCd 우선순위만 ✅
- **Co-Authored-By**: 없음 ✅
- **Wire matrix 완성**: A~E 모두 evidence (위 표 참조) ✅
- **신규 UI/store/컴포넌트 0**: 기존 `createLock` store action + `BoardingTrainList` fallback 재사용 ✅

## 변경 파일

- `src/features/alarm/hooks/useBoardingLockController.ts` (+123 lines)
- `src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx` (+289 lines)
