### PR TITLE
fix(#1624): backend type-check 회귀 + CI gap 차단

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,32 @@ jobs:
 
       - name: 단위 테스트 실행 (커버리지 100% 검증)
         run: npm test -- --ci --forceExit
+
+  backend-validation:
+    # #1624 — backend/alarm-worker type-check + vitest CI gate.
+    # frontend `test` job은 backend를 검증하지 않으므로 별도 job으로 회귀 차단.
+    name: Backend Validation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Node.js 20 설정
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/alarm-worker/package-lock.json
+
+      - name: 의존성 설치
+        working-directory: backend/alarm-worker
+        run: npm ci
+
+      - name: TypeScript 타입 체크
+        working-directory: backend/alarm-worker
+        run: npm run type-check
+
+      - name: vitest 실행
+        working-directory: backend/alarm-worker
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
   backend-validation:
     # #1624 — backend/alarm-worker type-check + vitest CI gate.
     # frontend `test` job은 backend를 검증하지 않으므로 별도 job으로 회귀 차단.
+    #
+    # **frontend deps 선행 설치 필수**: backend/alarm-worker/src/sentry.ts가
+    # `../../../src/shared/infra/monitoring/tripTokenHash`를 import한다. root tsconfig.json이
+    # `expo/tsconfig.base`를 extends하므로, expo 패키지(=frontend node_modules) 부재 시
+    # vite transform이 'Cannot find module expo/tsconfig.base/tsconfig.json' 으로 fail.
     name: Backend Validation
     runs-on: ubuntu-latest
 
@@ -64,9 +69,11 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: backend/alarm-worker/package-lock.json
 
-      - name: 의존성 설치
+      - name: frontend 의존성 설치 (expo tsconfig.base resolver)
+        run: npm ci --legacy-peer-deps
+
+      - name: backend 의존성 설치
         working-directory: backend/alarm-worker
         run: npm ci
 

--- a/backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts
+++ b/backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts
@@ -21,6 +21,7 @@ import {
   writeSsot,
   type LockSuggestion,
   type MotionEvidence,
+  type TripPositionSSoT,
 } from '../tripPositionSsot';
 import { putTrip } from '../trips';
 import type { BoardingLockMeta, Trip } from '../types';
@@ -827,7 +828,7 @@ describe('advanceTripPosition — alarmEvents stamping (#1572 T9)', () => {
   // Shared setup — seedSsot(motion) + putTrip(with lock) + advanceTripPosition 4-line 시퀀스.
   // 3 case가 motion state만 다르고 나머지가 동일 → factory + advance 호출 통합으로 SonarCloud CPD 회피.
   async function setupAndAdvance(motion: 'moving' | 'stationary'): Promise<{
-    result: 'advanced' | 'blocked';
+    result: AdvanceResult;
     after: Awaited<ReturnType<typeof readSsot>>;
   }> {
     const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');


### PR DESCRIPTION
Closes #1624

## 변경 요약

`backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts`의 3 type 에러 + CI gap (backend는 CI에서 검증 안 되고 있었음) 차단.

### Test fix (advanceTripPosition.test.ts)
- L25: `TripPositionSSoT` type import 추가 — line 878/899의 `Cannot find name 'TripPositionSSoT'` 해결
- L831: `setupAndAdvance` 반환 타입 `'advanced' | 'blocked'` → `AdvanceResult` (full union)로 widen — line 845의 `AdvanceResult is not assignable to '"advanced" | "blocked"'` 해결. `.toBe('advanced')` / `.toBe('blocked')` 호출자는 wider 타입에서도 정상 동작.

### CI workflow (.github/workflows/ci.yml)
- 신규 job `backend-validation` 추가:
  - `cd backend/alarm-worker && npm ci`
  - `npm run type-check` (tsc --noEmit)
  - `npm test` (vitest run)
- 기존 frontend `test` job은 backend를 검증하지 않으므로 회귀를 막지 못함 — 이번이 그 갭의 직접 증거.

## Runtime / Deploy 영향

- 없음. 변경된 파일은 (a) `src/__tests__/`로 wrangler deploy ignore + (b) GitHub Actions YAML.
- runtime 코드 0줄 변경.

## 검증 결과

| 검증 | Before | After |
| --- | --- | --- |
| `cd backend/alarm-worker && npm run type-check` | 3 errors (TS2322 + 2x TS2304) | 0 errors |
| `cd backend/alarm-worker && npm test` | (실행 불가 — type fail) | 1892 tests pass |
| `npm run type-check` (frontend) | 0 errors | 0 errors |
| `npm test` (frontend) | 7342 pass / 100% coverage | 7342 pass / 100% coverage |
| `npm run lint:orphan` | 0 orphans | 0 orphans |

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass. 신규 export 없음 (테스트 파일 + CI workflow only).
2. **V/X dashboard** — backend type-check + vitest 결과는 GitHub Actions `CI / Backend Validation` job에서 관측. PR 머지 후 재발 시 동일 job이 fail.
3. **의존 PR** — N/A.
4. **측정 plan** — 1주 PR merge 후 backend 변경 PR에 `Backend Validation` job이 fail 0건 (정상 동작 검증) OR fail → 즉시 fix 사이클. Branch protection의 required status check에 `Backend Validation` 추가 권장 (repo settings 수동 갱신, #1335 패턴).
5. **Device verify** — N/A — type+test+CI only.