### PR TITLE
fix(#1415, #1353): 정적 misfire root cluster — stale fire 차단 (R1 통합)

### DIFF
--- a/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
@@ -48,11 +48,12 @@ jest.mock('../scheduledNotificationsStorage', () => ({
   getScheduledNotificationIds: jest.fn(),
   clearScheduledNotificationIds: jest.fn(),
 }));
+const mockLoggerWarn = jest.fn();
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),
     info: jest.fn(),
-    warn: jest.fn(),
+    warn: (...args: unknown[]) => mockLoggerWarn(...args),
     error: jest.fn(),
   }),
 }));
@@ -355,13 +356,20 @@ describe('cancelAllHopsForLock', () => {
     // 직렬 await 루프였을 때는 첫 id의 cancel reject에서 throw → 나머지 `bl:` 사전 예약이
     // OS 큐에 남아 trip 종료 후 좀비 알림으로 발사됐다. allSettled로 묶여 한 id의
     // cancel reject가 나머지를 막지 않아야 한다.
+    // #1415/#1353 R1 — Fix 3 retry로 reject된 id는 한 번 더 cancel 호출 발생.
     mockedGet.mockResolvedValueOnce([
       'bl:T-100:0:early:강남',
       'bl:T-100:0:imminent:강남',
       'bl:T-100:1:early:역삼',
     ]);
+    // 강남은 1차 reject, 2차(재시도) success.
+    let gangnamCallCount = 0;
     mockedCancel.mockImplementation((id) => {
-      if (id === 'bl:T-100:0:early:강남') return Promise.reject(new Error('already fired'));
+      if (id === 'bl:T-100:0:early:강남') {
+        gangnamCallCount++;
+        if (gangnamCallCount === 1) return Promise.reject(new Error('temporary OS busy'));
+        return Promise.resolve();
+      }
       return Promise.resolve();
     });
 
@@ -371,8 +379,63 @@ describe('cancelAllHopsForLock', () => {
       expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:early:강남');
       expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:imminent:강남');
       expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:1:early:역삼');
+      // Fix 3 — reject 된 id에 대해 한 번 더 cancel 호출 (총 2회).
+      expect(gangnamCallCount).toBe(2);
     } finally {
       // 다른 describe로 reject impl leak 방지.
+      mockedCancel.mockReset();
+    }
+  });
+
+  // #1415/#1353 R1 — Fix 3: 1차 reject + 재시도도 reject 시 pass-2 warn 로그.
+  it('R1 (#1415/#1353) Fix 3 — 영구 reject identifier는 retry 후에도 실패하면 pass-2 warn 로그', async () => {
+    mockedGet.mockResolvedValueOnce([
+      'bl:T-100:0:early:강남',
+      'bl:T-100:0:imminent:역삼',
+    ]);
+    mockedCancel.mockImplementation((id) => {
+      if (id === 'bl:T-100:0:early:강남') return Promise.reject(new Error('permanent'));
+      return Promise.resolve();
+    });
+
+    try {
+      await expect(cancelAllHopsForLock(lock)).resolves.toBeUndefined();
+
+      // 강남 2회(pass-1+pass-2), 역삼 1회.
+      const gangnamCalls = mockedCancel.mock.calls.filter((c) => c[0] === 'bl:T-100:0:early:강남');
+      expect(gangnamCalls).toHaveLength(2);
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining('cancel reject pass-1: channel=bl count=1'),
+      );
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining('cancel reject pass-2 (final): channel=bl count=1'),
+      );
+    } finally {
+      mockedCancel.mockReset();
+    }
+  });
+
+  // #1415/#1353 R1 — Fix 3: 4건 이상 reject 시 ids 표시는 처음 3건 + '...'.
+  it('R1 (#1415/#1353) Fix 3 — 4건 이상 reject 시 ids 로그는 처음 3건 + "..." 표기', async () => {
+    mockedGet.mockResolvedValueOnce([
+      'bl:T-100:0:early:A',
+      'bl:T-100:0:early:B',
+      'bl:T-100:0:early:C',
+      'bl:T-100:0:early:D',
+    ]);
+    mockedCancel.mockImplementation(() => Promise.reject(new Error('all fail')));
+
+    try {
+      await cancelAllHopsForLock(lock);
+
+      // 처음 3건만 + '...' suffix.
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.stringMatching(/cancel reject pass-1: channel=bl count=4 ids=bl:T-100:0:early:A,bl:T-100:0:early:B,bl:T-100:0:early:C\.\.\./),
+      );
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.stringMatching(/cancel reject pass-2 \(final\): channel=bl count=4/),
+      );
+    } finally {
       mockedCancel.mockReset();
     }
   });

--- a/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
+++ b/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
@@ -794,6 +794,39 @@ describe('bl: fire-time 재검증 (#1282)', () => {
       expect(mockSetFiredAlarms).not.toHaveBeenCalled();
       expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('강남');
     });
+
+    // #1415/#1353 R1 — `bl:` 채널도 tripStart 게이트 적용 (revalidateBlAlarm requireTripStart=true).
+    // 6/22 14:19 애오개 / 6/22 14:25 아현 / 6/19 15:51 용마산 stale fire 회귀의 핵심 backstop.
+    it('R1 (#1415/#1353) tripStart 미존재 시 bl: 재검증은 revalidate-no-trip + skip', async () => {
+      mockGetTripStartedAt.mockResolvedValueOnce(null);
+
+      await reconcileScheduledAlarmDelivery(blChannel.id('imminent', '애오개'));
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith({
+        reason: 'revalidate-no-trip',
+        stationName: '애오개',
+        phaseId: 'imminent',
+      });
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+      expect(mockSetLastFiredAlarmStationName).not.toHaveBeenCalled();
+      // suppress 결정 시 OS scheduled queue cancel(#1354)도 함께 트리거되어 영구 misfire 차단.
+      expect(mockCancelScheduled).toHaveBeenCalledWith(blChannel.id('imminent', '애오개'));
+    });
+
+    it('R1 (#1415/#1353) tripStart 미존재 시 sig 검증보다 먼저 차단된다', async () => {
+      // tripStart=null이면 sig 일치 여부와 무관하게 revalidate-no-trip 결정.
+      mockGetTripStartedAt.mockResolvedValueOnce(null);
+      blChannel.registeredSigMock.mockResolvedValueOnce('SIG-A');
+      mockRouteSignature.mockReturnValueOnce('SIG-A');
+
+      await reconcileScheduledAlarmDelivery(blChannel.id('early', '용마산'));
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith({
+        reason: 'revalidate-no-trip',
+        stationName: '용마산',
+        phaseId: 'early',
+      });
+    });
   });
 
   describe('drainDeliveredScheduledAlarms — `bl:` 항목 재검증', () => {
@@ -834,6 +867,28 @@ describe('bl: fire-time 재검증 (#1282)', () => {
 
       expect(mockSetFiredAlarms).not.toHaveBeenCalled();
       expect(mockSetLastFiredAlarmStationName).not.toHaveBeenCalled();
+      handle.remove();
+    });
+
+    // #1415/#1353 R1 — drain 경로에서도 bl 채널의 tripStart 게이트 적용.
+    it('R1 (#1415/#1353) drain — tripStart=null이면 모든 bl 항목 suppress + lastStationName 갱신 안 함', async () => {
+      mockGetTripStartedAt.mockResolvedValue(null);
+      mockGetPresented.mockResolvedValueOnce([
+        { date: 1, request: { identifier: blChannel.id('imminent', '애오개') } },
+        { date: 2, request: { identifier: blChannel.id('imminent', '아현') } },
+      ]);
+
+      const handle = registerScheduledAlarmListener();
+      await awaitInitialScheduledAlarmDrain();
+
+      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
+      expect(mockSetLastFiredAlarmStationName).not.toHaveBeenCalled();
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'revalidate-no-trip', stationName: '애오개' }),
+      );
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'revalidate-no-trip', stationName: '아현' }),
+      );
       handle.remove();
     });
 

--- a/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
@@ -442,14 +442,21 @@ describe('cancelTripBoundAlarms', () => {
     // 직렬 for await 루프였을 때는 첫 reject에서 throw → 나머지 `tba:` 사전 예약이 OS 큐에
     // 남아 trip 종료 후 좀비 알림이 발사됐다 (2026-06-19 08:48 사례). allSettled로 묶여
     // 한 id의 cancel reject가 나머지를 막지 않아야 한다.
+    // #1415/#1353 R1 — Fix 3 (retry) 추가로 reject된 id는 한 번 더 cancel 호출 발생.
     mockedGetAll.mockResolvedValue([
       { identifier: 'tba:early:강남' },
       { identifier: 'tba:imminent:강남' },
       { identifier: 'tba:early:역삼' },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ] as any);
+    // 첫 호출은 reject, 재시도(2번째 호출)는 success로 응답 — Fix 3 retry path 검증.
+    let gangNamCallCount = 0;
     mockedCancel.mockImplementation((id) => {
-      if (id === 'tba:early:강남') return Promise.reject(new Error('already fired'));
+      if (id === 'tba:early:강남') {
+        gangNamCallCount++;
+        if (gangNamCallCount === 1) return Promise.reject(new Error('temporary OS busy'));
+        return Promise.resolve();
+      }
       return Promise.resolve();
     });
 
@@ -460,13 +467,79 @@ describe('cancelTripBoundAlarms', () => {
       expect(mockedCancel).toHaveBeenCalledWith('tba:early:강남');
       expect(mockedCancel).toHaveBeenCalledWith('tba:imminent:강남');
       expect(mockedCancel).toHaveBeenCalledWith('tba:early:역삼');
-      // fulfilled 2건만 cancelled 카운트에 반영.
+      // Fix 3 — reject된 id 재시도 후 success → cancelled 카운트 3건 모두 반영.
+      expect(gangNamCallCount).toBe(2);
       expect(mockLoggerInfo).toHaveBeenCalledWith(
-        expect.stringContaining('cancelled 2 trip-bound alarms'),
+        expect.stringContaining('cancelled 3 trip-bound alarms'),
+      );
+      // Fix 3 — pass-1 rejected 명시 로그.
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining('cancel reject pass-1: channel=tba count=1'),
       );
     } finally {
       // 다른 describe로 reject impl이 leak되지 않도록 default 복귀 (beforeEach가
       // mockReset이 아닌 clearAllMocks만 하므로 implementation은 유지된다).
+      mockedCancel.mockReset();
+    }
+  });
+
+  // #1415/#1353 R1 — Fix 3: 1차 reject + 재시도도 reject 시 명시 pass-2 warn 로그.
+  it('R1 (#1415/#1353) Fix 3 — 영구 reject identifier는 retry 후에도 실패하면 명시 pass-2 warn 로그', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:early:강남' },
+      { identifier: 'tba:imminent:역삼' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+    // 강남은 영구 reject (잘못된 identifier 등), 역삼은 정상.
+    mockedCancel.mockImplementation((id) => {
+      if (id === 'tba:early:강남') return Promise.reject(new Error('permanent error'));
+      return Promise.resolve();
+    });
+
+    try {
+      await expect(cancelTripBoundAlarms()).resolves.toBeUndefined();
+
+      // 강남은 2회 호출 (pass-1 + pass-2), 역삼은 1회.
+      const gangnamCalls = mockedCancel.mock.calls.filter((c) => c[0] === 'tba:early:강남');
+      expect(gangnamCalls).toHaveLength(2);
+      // fulfilled 1건만 카운트.
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        expect.stringContaining('cancelled 1 trip-bound alarms'),
+      );
+      // pass-1 + pass-2 warn 로그 둘 다 적재.
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining('cancel reject pass-1: channel=tba count=1'),
+      );
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining('cancel reject pass-2 (final): channel=tba count=1'),
+      );
+    } finally {
+      mockedCancel.mockReset();
+    }
+  });
+
+  // #1415/#1353 R1 — Fix 3: 3건 이상 reject 시 ids 표시는 처음 3건 + '...' 표기.
+  it('R1 (#1415/#1353) Fix 3 — 4건 이상 reject 시 ids 로그는 처음 3건 + "..." 표기', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'tba:early:A' },
+      { identifier: 'tba:early:B' },
+      { identifier: 'tba:early:C' },
+      { identifier: 'tba:early:D' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+    mockedCancel.mockImplementation(() => Promise.reject(new Error('all fail')));
+
+    try {
+      await cancelTripBoundAlarms();
+
+      // pass-1과 pass-2 둘 다 4건 reject. ids는 처음 3건만 + '...' suffix.
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.stringMatching(/cancel reject pass-1: channel=tba count=4 ids=tba:early:A,tba:early:B,tba:early:C\.\.\./),
+      );
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.stringMatching(/cancel reject pass-2 \(final\): channel=tba count=4/),
+      );
+    } finally {
       mockedCancel.mockReset();
     }
   });

--- a/src/features/alarm/utils/boardingLockScheduler.ts
+++ b/src/features/alarm/utils/boardingLockScheduler.ts
@@ -256,7 +256,11 @@ async function cancelAndDismiss(ids: string[]): Promise<void> {
   // 뒤의 id들을 막지 않게 한다. 직렬 await에서 한 번 throw하면 `bl:` 사전 예약 잔여가
   // OS 큐에 남아 trip 종료 후 좀비 알림이 발사된다 (cancelTripBoundAlarms와 같은 회귀
   // 표면). dismiss는 기존과 동일하게 throw를 swallow한다.
-  await Promise.allSettled(
+  //
+  // #1415/#1353 R1 — Fix 3 보강: rejected 결과를 명시 로그 + 1회 재시도.
+  // cancelTripBoundAlarms와 동형. dismiss 실패는 무시(기존 정책 보존) — cancel만 측정.
+  // 호출자는 모두 `length > 0` 가드 후 진입하므로 본 함수 내부엔 empty 가드 불필요.
+  const firstPass = await Promise.allSettled(
     ids.map(async (id) => {
       await Notifications.cancelScheduledNotificationAsync(id);
       try {
@@ -266,6 +270,30 @@ async function cancelAndDismiss(ids: string[]): Promise<void> {
       }
     }),
   );
+  const rejected: string[] = [];
+  for (let i = 0; i < firstPass.length; i++) {
+    if (firstPass[i].status === 'rejected') {
+      rejected.push(ids[i]);
+    }
+  }
+  if (rejected.length === 0) return;
+  logger.warn(
+    `cancel reject pass-1: channel=bl count=${rejected.length} ids=${rejected.slice(0, 3).join(',')}${rejected.length > 3 ? '...' : ''}`,
+  );
+  const secondPass = await Promise.allSettled(
+    rejected.map((id) => Notifications.cancelScheduledNotificationAsync(id)),
+  );
+  const stillRejected: string[] = [];
+  for (let i = 0; i < secondPass.length; i++) {
+    if (secondPass[i].status === 'rejected') {
+      stillRejected.push(rejected[i]);
+    }
+  }
+  if (stillRejected.length > 0) {
+    logger.warn(
+      `cancel reject pass-2 (final): channel=bl count=${stillRejected.length} ids=${stillRejected.slice(0, 3).join(',')}${stillRejected.length > 3 ? '...' : ''}`,
+    );
+  }
 }
 
 export interface ScheduleHopsParams {

--- a/src/features/alarm/utils/scheduledAlarmReceiver.ts
+++ b/src/features/alarm/utils/scheduledAlarmReceiver.ts
@@ -176,13 +176,39 @@ function revalidateTbaAlarm(parsed: {
   });
 }
 
-/** `bl:` 알람 재검증 — lock SSOT이라 tripStart 게이트 없음 + boarding-lock sig (#1282). */
+/**
+ * `bl:` 알람 재검증 (#1282 → #1415/#1353 R1).
+ *
+ * #1415/#1353 R1 (stale-fire cluster) — `requireTripStart=true`로 강화.
+ *
+ * 회귀 evidence (2026-06-22 / 2026-06-19 사용자 trip):
+ *   - 6/22 14:19 사용자 을지로3가 위치인데 `bl:5호선:1:imminent:애오개` stale fire
+ *   - 6/22 14:25 사용자 상왕십리 위치인데 `bl:2호선:1:imminent:아현` stale fire
+ *   - 6/19 15:51 사용자 고속터미널 위치인데 `bl:7호선:N:imminent:용마산` stale fire (이전 trip의 destination)
+ *
+ * Root cause chain: backend cron auto-end → silent push trip-ended 도착 → device cleanup
+ * (`purgeBoardingLockSchedulerQueue` + `runTripBoundCleanups`)이 OS queue cancel을 시도하지만,
+ * race / 직렬 cancel reject / expo-notifications 내부 큐 반영 지연으로 일부 `bl:` 사전 예약이 OS
+ * 큐에 잔존. 이후 ETA 도달 시 OS가 잔존 알람을 직접 발사 → 사용자 체감 "정적인데 다음역 stale fire".
+ *
+ * 기존 정책(`requireTripStart=false`)은 "lock SSOT이라 tripStart 게이트가 불필요"라는 가정에
+ * 의존했으나, lock release / trip cleanup 후의 race window를 가드하지 못했다. tripStart 게이트는
+ * 가장 강력한 trip-종료 신호이므로 `bl:` 채널에도 동일하게 적용한다 — `bl:` 사전 예약은 항상 trip
+ * 컨텍스트 내에서 의미 있는 알람이고, trip이 끝났다면 lock 유무와 무관하게 stale.
+ *
+ * 트레이드오프 (의도적):
+ *   - Trip 종료 직후 OS가 발사한 직전 `bl:` 알람이 race로 `tripStartedAt=null` 상태에서 도달하면
+ *     `revalidate-no-trip`으로 suppress될 수 있다. 그러나 trip 종료 = lock 무효 = stale 알람이라
+ *     이 silence는 의도적 — false positive (잘못 발사) 방지가 사용자 가치 직결 (ADR-010 동급).
+ *   - 새 trip 시작 직후 backend가 새 `bl:` sig를 등록하기 전 race window에서 도달한 알람은 본
+ *     게이트가 아닌 `revalidate-route-sig-mismatch`로 분류 — 새 trip의 sig가 다르기 때문.
+ */
 function revalidateBlAlarm(parsed: {
   phaseId: string;
   stationName: string;
 }): Promise<'pass' | 'suppress'> {
   return revalidatePrescheduledAlarm(parsed, {
-    requireTripStart: false,
+    requireTripStart: true,
     getRegisteredSig: getRegisteredBlRouteSig,
   });
 }

--- a/src/features/alarm/utils/tripBoundScheduler.ts
+++ b/src/features/alarm/utils/tripBoundScheduler.ts
@@ -758,13 +758,79 @@ export async function cancelTripBoundAlarms(): Promise<void> {
   // 나머지 identifier cancel을 막지 않도록 한다. 직렬 await 루프에서 한 번 throw하면
   // 뒤에 남아 있는 `tba:` 사전 예약이 OS 큐에 그대로 남아 trip 종료 후 좀비 알림으로
   // 발사된다 (2026-06-19 08:48 "안내 종료" 도달 사례).
-  const results = await Promise.allSettled(
-    targets.map((req) => Notifications.cancelScheduledNotificationAsync(req.identifier)),
+  //
+  // #1415/#1353 R1 — Fix 3 보강: rejected 결과를 명시 로그 + 1회 재시도.
+  // 기존엔 rejected를 allSettled가 silent swallow → cancel 실패가 측정 인프라에 노출 안 됐고,
+  // 일시적 OS 내부 race로 인한 reject도 재시도 없이 그대로 좀비 알림 유발. 1회 재시도는 throw
+  // 가능하므로 동일 allSettled 패턴으로 묶어 retry-of-retry는 silent log (회수 무한 루프 방지).
+  const cancelled = await cancelIdentifiersWithRetry(
+    targets.map((req) => req.identifier),
+    'tba',
   );
-  const cancelled = results.filter((r) => r.status === 'fulfilled').length;
   if (cancelled > 0) {
     logger.info(`cancelled ${cancelled} trip-bound alarms`);
   }
   // #918 A3 PR2: sig storage도 함께 cleanup — 다음 reconcile 시 stale sig가 남지 않게.
   await clearRegisteredTripRouteSig();
+}
+
+/**
+ * #1415/#1353 R1 — Fix 3 (cancel 직렬화 + 재시도).
+ *
+ * `Notifications.cancelScheduledNotificationAsync`를 identifier 배열에 대해 호출하며,
+ * 1차 reject 발생 시 1회 재시도한다. `Promise.allSettled` 패턴을 유지해 한 항목 실패가 나머지 진행을
+ * 막지 않는다 (#1525 정책 보존). 재시도 후에도 실패하면 명시 로그만 남기고 다음 항목 진행 — production
+ * 회귀가 측정 인프라(`logger.warn`)에 노출되도록 한다.
+ *
+ * 반환: 최종 성공한 cancel 수. 호출자가 log info에 사용.
+ *
+ * 트레이드오프:
+ *   - 1회 재시도는 expo-notifications 내부 큐 race 또는 일시적 OS busy state 회복용. 영구 오류
+ *     (잘못된 identifier 등)는 retry해도 같은 reject — log warn으로 측정 노출 후 다음 진행.
+ *   - 직렬 await 루프로 바꾸지 않은 이유: trip 종료 직후 수십~64개 identifier에 대해 직렬 await하면
+ *     앱 종료까지 수 초 stall 가능 (OS API latency 100~300ms × N). allSettled 병렬 유지가 성능 우선.
+ */
+async function cancelIdentifiersWithRetry(
+  identifiers: string[],
+  channelLabel: 'tba',
+): Promise<number> {
+  if (identifiers.length === 0) return 0;
+  const firstPass = await Promise.allSettled(
+    identifiers.map((id) => Notifications.cancelScheduledNotificationAsync(id)),
+  );
+  const rejected: string[] = [];
+  for (let i = 0; i < firstPass.length; i++) {
+    if (firstPass[i].status === 'rejected') {
+      rejected.push(identifiers[i]);
+    }
+  }
+  if (rejected.length === 0) {
+    return firstPass.length;
+  }
+  // 1차 reject 발견 — 명시 로그 + 1회 재시도.
+  logger.warn(
+    `cancel reject pass-1: channel=${channelLabel} count=${rejected.length} ids=${rejected.slice(0, 3).join(',')}${rejected.length > 3 ? '...' : ''}`,
+  );
+  const secondPass = await Promise.allSettled(
+    rejected.map((id) => Notifications.cancelScheduledNotificationAsync(id)),
+  );
+  let firstPassSuccess = 0;
+  for (const r of firstPass) {
+    if (r.status === 'fulfilled') firstPassSuccess++;
+  }
+  let retryRescued = 0;
+  const stillRejected: string[] = [];
+  for (let i = 0; i < secondPass.length; i++) {
+    if (secondPass[i].status === 'fulfilled') {
+      retryRescued++;
+    } else {
+      stillRejected.push(rejected[i]);
+    }
+  }
+  if (stillRejected.length > 0) {
+    logger.warn(
+      `cancel reject pass-2 (final): channel=${channelLabel} count=${stillRejected.length} ids=${stillRejected.slice(0, 3).join(',')}${stillRejected.length > 3 ? '...' : ''}`,
+    );
+  }
+  return firstPassSuccess + retryRescued;
 }


### PR DESCRIPTION
## 변경 요약

R1 통합 PR. 6/22 14:19 애오개 / 6/22 14:25 아현 / 6/19 15:51 용마산 하차 stale fire 회귀의 root cause cluster — `bl:` 사전 예약이 trip 종료 후 race로 OS 큐에 잔존하다 ETA 도달 시 자체 발사 — 를 차단한다. 함께 cancel 직렬화 시 silent fail 측정 + 1회 재시도 보강.

Closes #1415, Closes #1353

## Trip evidence 매핑

| Trip | 위치 | 발사된 stale 알람 | Root cause |
|---|---|---|---|
| 6/22 14:19 | 을지로3가 (5호선) | `bl:5호선:1:imminent:애오개` | `bl:` revalidate가 trip 종료 후 사전 예약을 통과시킴 |
| 6/22 14:25 | 상왕십리 (2호선) | `bl:2호선:1:imminent:아현` | 동일 |
| 6/19 15:51 | 고속터미널 (9호선) | `bl:7호선:N:imminent:용마산` | 이전 trip의 destination — backend cron auto-end 후 cleanup race로 잔존 |

3건 모두 같은 chain: backend cron auto-end → silent push trip-ended 도착 → device cleanup (`purgeBoardingLockSchedulerQueue` + `runTripBoundCleanups`)이 OS queue cancel을 시도하지만, race / cancel reject / expo-notifications 내부 큐 반영 지연으로 일부 `bl:` 사전 예약이 OS 큐에 잔존. 이후 ETA 도달 시 OS가 잔존 알람을 자체 발사.

## 6 fix 통합 — 상태

> 본 PR 진입 시 코드를 read-only 분석한 결과, Fix 2/4/5/6은 이미 prior PR로 머지되어 있어 본 PR은 Fix 1, 3만 적용한다 (surgical change).

| Fix | 상태 | 위치 |
|---|---|---|
| **Fix 1** — `bl:` revalidate `requireTripStart=true` (R1 핵심) | **본 PR** | `scheduledAlarmReceiver.ts:206-214` |
| **Fix 2** — alert path `cancelTripBoundOsQueue` 호출 | 기존 (#1370 L4) | `silentPushTask.ts:868` (alert/silent 둘 다 진입 전 호출) |
| **Fix 3** — Cancel 직렬화/재시도 | **본 PR** | `tripBoundScheduler.ts:cancelIdentifiersWithRetry`, `boardingLockScheduler.ts:cancelAndDismiss` |
| **Fix 4** — `boarding-lock-interp` lockless 차단 | 기존 (#1437 E4) | `useFusedNearestStation.ts:1123-1128` (`estimatorIsTimeIntegration` reject) |
| **Fix 5** — Motion gate lockless 적용 | 기존 (#1357 S1 / #728 BG) | `useStationAlarm.ts:runMovementGate`, `silentPushTask.ts:1295-1304`, `tripBoundScheduler.ts:190-203`, `boardingLockScheduler.ts:304-316` |
| **Fix 6** — Cross-channel cancel (`bl:` ↔ `tba:`) | 기존 (#1355 D1 / #1356 E1) | `silentPushTask.ts:1027-1032, 1053-1056, 1284-1285, 1322-1323` |

## Wire Matrix

| Element | A. silent push fire | B. OS `bl:` scheduled fire | C. OS `tba:` scheduled fire | D. FG arvlCd | E. backend reschedule |
|---|---|---|---|---|---|
| revalidate gate | N/A (silent push는 backend SSOT) | `scheduledAlarmReceiver.ts:206-214` (Fix 1 — `requireTripStart: true`) | `scheduledAlarmReceiver.ts:169-177` (이미 `requireTripStart: true`) | N/A | N/A |
| cancel on trip-end | `silentPushTask.ts:868` → `cancelTripBoundOsQueue` (alert+silent 둘 다) | `tripBoundCleanups.ts:93` `purgeBoardingLockSchedulerQueue` + Fix 3 재시도 | `tripBoundCleanups.ts:97` `cancelTripBoundAlarms` + Fix 3 재시도 | N/A | `silentPushTask.ts:1031,1055` cross-channel cancel |
| motion gate 적용 | `silentPushTask.ts:1295-1304` (lock/lockless 둘 다) | `boardingLockScheduler.ts:304-316` preschedule motion gate | `tripBoundScheduler.ts:190-203` preschedule motion gate | `useStationAlarm.ts:runMovementGate` | N/A (정정만, fire 없음) |
| dedup 적용 | `silentPushTask.ts:1342-1354` `alarmKey` | `scheduledAlarmReceiver.ts:227-247` fired set | `scheduledAlarmReceiver.ts:227-247` fired set | `useStationAlarm.ts:firedAlarmsRef` | N/A |

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass.
2. **V/X dashboard** — `alarmLog`의 `revalidate-no-trip` reason count (DebugModal Suppress 섹션). cancel 재시도는 `wrangler tail` log (`cancel reject pass-1/pass-2`) — Cloudflare Dashboard에서 일주일 query.
3. **의존 PR** — N/A. 단독 머지 가능.
4. **측정 plan** — 1주 production: `alarmLog`에서 `revalidate-no-trip` reason count >= 1건이면 회귀 잡힘 evidence (이전 X1 회귀 trip에서 본 패턴이 잡혔어야 함). cancel 재시도 `cancel reject pass-1` warn 로그 발생 빈도로 OS 큐 race 빈도 측정.
5. **Device verify** — 사용자 실기기 trip 필요. 시나리오:
   - (a) 정적 trip 등록 → backend auto-end → 1시간 대기 → 새 위치로 이동 → 이전 destination stale fire 0건 확인.
   - (b) 6/22 14:19 / 14:25 패턴: 환승 후 다른 노선 trip 시작 → 이전 leg `bl:` stale fire 0건 확인.

## 트레이드오프 (의도적)

- **Fix 1**: Trip 종료 직후 OS가 race로 발사한 직전 `bl:` 알람이 `tripStartedAt=null` 상태에서 도달하면 `revalidate-no-trip`으로 suppress될 수 있다. **이는 의도적 silence** — trip 종료 = lock 무효 = stale 알람이라 false positive (잘못 발사) 방지가 사용자 가치 직결 (ADR-010 동급 원칙).
- **Fix 3**: 1회 재시도는 expo-notifications 내부 큐 race 회복용. 영구 오류(잘못된 identifier)는 retry해도 같은 reject — log warn으로 측정 노출 후 다음 진행. `Promise.allSettled` 병렬은 #1525 정책 유지 (직렬 await으로 바꾸면 64 identifier × 100~300ms OS latency = 수 초 stall 위험).

## 자가 점검

- [x] ADR-010 첫 줄 원칙 — false positive == miss 동급. Fix 1은 false positive 차단 (사용자 가치 직결)
- [x] 시간 적분 fire 권한 X 룰 정합 — Fix 4 (이미 적용된 #1437 E4)
- [x] GPS 결정 권한 X 룰 정합 — 본 PR은 GPS 신호를 결정에 사용하지 않음
- [x] Wire matrix 모든 셀 채워짐
- [x] 6 fix 모두 확인 — 4건은 prior PR, 2건은 본 PR
- [x] Coverage 100% (modified files 215 tests)