### PR TITLE
fix(#1645): hydrate warmup 30s→10s + Gate A/B staleness 분리 (V4 매역 알림 누락 차단)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -1871,7 +1871,7 @@ describe('useStationAlarm', () => {
     });
   });
 
-  // #670/#672/#1316 — phase 알람 warmup 가드. 하이드레이션 완료 후 HYDRATE_WARMUP_MS(30s) 시간 window
+  // #670/#672/#1316/#1645 — phase 알람 warmup 가드. 하이드레이션 완료 후 HYDRATE_WARMUP_MS(10s) 시간 window
   // 동안 phase 평가를 보류한다. #1316 이전엔 첫 eval 1회만 suppress(isFirstAlarmEvalRef)했으나, 2번째
   // eval이 GPS/ETA 안정화 전 destination/transfer early를 발사 → firedAlarms 슬롯 점유로 실제 도착이
   // dedup되는 회귀(08:24:31 성수)가 있었다. station-passed(#1010)와 동일한 시간 window로 통일한다.
@@ -1914,7 +1914,7 @@ describe('useStationAlarm', () => {
       expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
     });
 
-    it('warmup window 경과 후 좌표 갱신 시 evaluate 호출됨 (hydratedAt + 30s 이후)', async () => {
+    it('warmup window 경과 후 좌표 갱신 시 evaluate 호출됨 (hydratedAt + 10s 이후)', async () => {
       const baseTs = 1_700_000_000_000;
       const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseTs);
       const { rerender } = renderHook(
@@ -1925,7 +1925,7 @@ describe('useStationAlarm', () => {
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
       expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
       // window 경과 후(30s + 1ms) 좌표 갱신 → 안정된 입력으로 평가 진입.
-      nowSpy.mockReturnValue(baseTs + 30_001);
+      nowSpy.mockReturnValue(baseTs + 10_001);
       rerender({ loc: { lat: 37.41, lng: 127.01 } });
       await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
     });
@@ -1988,7 +1988,7 @@ describe('useStationAlarm', () => {
       expect(mockSendAlarmNotification).not.toHaveBeenCalled();
 
       // 실제 도착 시점: window 경과 + 좌표 갱신. firedAlarms가 비어 있으므로 dedup 없이 발사돼야 한다.
-      nowSpy.mockReturnValue(baseTs + 30_001);
+      nowSpy.mockReturnValue(baseTs + 10_001);
       rerender({ loc: { lat: 37.498, lng: 127.028 } });
 
       await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
@@ -2493,7 +2493,7 @@ describe('useStationAlarm', () => {
       await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
     });
 
-    it('warmup window 경과 후 발사 허용 (hydratedAt + 30s 이후)', async () => {
+    it('warmup window 경과 후 발사 허용 (hydratedAt + 10s 이후)', async () => {
       const baseTs = 1_700_000_000_000;
       const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseTs);
       mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 2, isTransfer: false, stopsToDestination: 2 });
@@ -2516,7 +2516,7 @@ describe('useStationAlarm', () => {
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
 
       // warmup window 경과 후 nearestStation 제공 — 이 시점엔 warmup guard를 통과해야 함.
-      nowSpy.mockReturnValue(baseTs + 30_001);
+      nowSpy.mockReturnValue(baseTs + 10_001);
       rerender({ s: station });
 
       await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -77,10 +77,15 @@ import { resolveNotificationSource, type NotificationSource } from '../utils/not
 
 const logger = createLogger('StationAlarm');
 
-// #1010/#1316 — 하이드레이션 warmup. lock hydrate 완료 후 이 기간 동안 알람 발사를 차단한다.
+// #1010/#1316/#1645 — 하이드레이션 warmup. lock hydrate 완료 후 이 기간 동안 알람 발사를 차단한다.
 // 하이드레이션 직후 firedAlarms가 복원되기 전 GPS/ETA 신호와 동기화되는 과도 구간 false alarm 방지.
 // station-passed effect(#1010)와 phase 알람 effect(#1316) 양쪽이 같은 window를 공유한다.
-const HYDRATE_WARMUP_MS = 30_000;
+//
+// #1645 — 30s → 10s 단축. 사용자 trip evidence 6/22 13:38~41 (상왕십리/신당/동대문역사문화공원
+// 첫 3 station 알림 누락) — destination 변경/cold start 직후 30s window가 지하철 station 간격(1~2분)
+// 보다 길어 V4 acceptance(매역 silent 알림) 일관 위반. 단축 + 다른 가드(firedAlarmsRefDestIdRef #699,
+// cross-category dedup #1515, hydrationPhase H5, SSoT Gate A) 이중 보호로 false fire 회귀 방지.
+const HYDRATE_WARMUP_MS = 10_000;
 
 /**
  * #1010/#1316 — 하이드레이션 완료(hydratedAt) 후 HYDRATE_WARMUP_MS 시간 window 안인지 판정.

--- a/src/features/alarm/utils/__tests__/ssotFireGate.test.ts
+++ b/src/features/alarm/utils/__tests__/ssotFireGate.test.ts
@@ -94,31 +94,59 @@ describe('evaluateSsotFireGate — mirror state × type matrix (#1572 T9)', () =
     });
   });
 
-  describe('mirror-stale (no-block, graceful — T10이 별도 staleness 차단 담당)', () => {
-    it('staleness 임계 초과 + station-passed 매칭 → no-block (mirror-stale)', async () => {
+  describe('mirror-stale × Gate A/B 분리 (#1645)', () => {
+    // #1645 — Gate A는 staleness 무관 always-check. alarmId 매칭은 mirror가 stale이어도 차단.
+    // Gate B는 staleness 안에만 적용 → stale 시 stationId 매칭이어도 no-block.
+    it('staleness 초과 + alarmId 매칭(Gate A) → blocked (staleness 무관)', async () => {
       mockGetItem.mockResolvedValue(
         makeMirror({ receivedAt: NOW - SSOT_FIRE_GATE_STALENESS_MS - 1 }),
       );
       const out = await evaluateSsotFireGate({
-        alarmId: 'aaa111',
-        stationId: '용마산',
+        alarmId: 'aaa111', // mirror.alarmEvents[0].alarmId와 매칭
+        stationId: 'X', // 다른 station
+        type: 'station-passed',
+        now: NOW,
+      });
+      expect(out).toEqual({ blocked: true, reason: 'gate-alarm-already-decided' });
+    });
+
+    it('staleness 초과 + Gate B 후보 (stationId 매칭, alarmId 미매칭) → no-block (mirror-stale)', async () => {
+      mockGetItem.mockResolvedValue(
+        makeMirror({ receivedAt: NOW - SSOT_FIRE_GATE_STALENESS_MS - 1 }),
+      );
+      const out = await evaluateSsotFireGate({
+        alarmId: 'different', // alarmId 미매칭 (Gate A pass)
+        stationId: '용마산', // mirror.passedStations 매칭이지만 stale → graceful skip
         type: 'station-passed',
         now: NOW,
       });
       expect(out).toEqual({ blocked: false, reason: 'mirror-stale' });
     });
 
-    it('staleness 경계(=)는 fresh로 판정 — block 가능', async () => {
+    it('staleness 경계(=)는 fresh로 판정 — Gate B block 가능', async () => {
       mockGetItem.mockResolvedValue(
         makeMirror({ receivedAt: NOW - SSOT_FIRE_GATE_STALENESS_MS }),
       );
       const out = await evaluateSsotFireGate({
-        alarmId: 'aaa111',
+        alarmId: 'different',
         stationId: '용마산',
         type: 'station-passed',
         now: NOW,
       });
       expect(out.blocked).toBe(true);
+    });
+
+    it('staleness 초과 + transfer type + alarmId 미매칭 → no-block (mirror-stale)', async () => {
+      mockGetItem.mockResolvedValue(
+        makeMirror({ receivedAt: NOW - SSOT_FIRE_GATE_STALENESS_MS - 1 }),
+      );
+      const out = await evaluateSsotFireGate({
+        alarmId: 'different',
+        stationId: 'X',
+        type: 'transfer',
+        now: NOW,
+      });
+      expect(out).toEqual({ blocked: false, reason: 'mirror-stale' });
     });
   });
 

--- a/src/features/alarm/utils/ssotFireGate.ts
+++ b/src/features/alarm/utils/ssotFireGate.ts
@@ -22,8 +22,10 @@
  * Graceful 정책
  * =============
  *   - mirror 자체 부재(처음 trip / 머지 직후) → `mirror-missing` no-block. 기존 fire path 동작 유지.
- *   - mirror staleness(>180s) → `mirror-stale` no-block. T10 Sticky SSoT가 stale 시 별도 차단 정책
- *     (BACKEND_SSOT_STALE_BLOCK_*)으로 alarm 차단. 본 게이트는 freshness 판정만 graceful skip.
+ *   - mirror staleness(>180s) — #1645 Gate A/B 분리:
+ *     * Gate A는 staleness 무관 always-check (alarmId 중복 차단은 항상 안전).
+ *     * Gate B만 staleness 안에 적용 → stale 시 `mirror-stale` no-block (device 매역 재시도 허용,
+ *       V4 acceptance 유지). T10 Sticky SSoT가 stale 시 별도 차단 정책으로 alarm 차단.
  *   - 게이트가 block 시 caller가 `appendAlarmLog`로 reason stamp + fire path return (silence).
  *
  * 5 fire path wire 위치
@@ -50,7 +52,14 @@ import { readBackendSsotMirror } from './backendSsotMirror';
 
 /**
  * mirror staleness 임계 — backend가 silent push로 mirror를 갱신해야 하는 정상 주기는 ~30s.
- * 180s = 6 polling cycle 누락 = backend 정지/cron failure 정황 → 게이트는 graceful skip.
+ * 180s = 6 polling cycle 누락 = backend 정지/cron failure 정황 → Gate B는 graceful skip.
+ *
+ * #1645 — Gate A/B staleness 분리:
+ *   - Gate A (alarmId 매칭): staleness 무관 always-check. alarmId는 `${type}:${stationName}` 결정론
+ *     이라 같은 trip 안에서만 의미. trip 변경 시 mirror 자체가 reset되므로 stale alarmId 매칭
+ *     false positive risk가 낮다. 같은 alarm 결정 두 번 fire는 항상 차단해야 안전.
+ *   - Gate B (stationId 매칭, station-passed/imminent): staleness 180s 안에만 차단. 이후엔 fire 재시도
+ *     허용 — backend 정지 정황에서 device가 매역 알림을 살리는 기존 graceful 정책 유지.
  *
  * T10 (#1573)이 더 긴 임계(5min/30min)로 별도 alarm/notify 차단을 적용하므로 본 임계는 그 아래.
  */
@@ -90,6 +99,11 @@ export interface SsotFireGateOutcome {
  *
  * mirror read 실패(AsyncStorage error 등)는 readBackendSsotMirror가 null 반환 → mirror-missing
  * graceful no-block. backend가 mirror를 보내기 전까지는 본 게이트가 false-positive 차단을 만들지 않는다.
+ *
+ * #1645 — Gate A/B staleness 분리:
+ *   - Gate A: staleness 무관 always-check. mirror가 stale이어도 alarmId 매칭 시 block (안전 측).
+ *   - Gate B: staleness 180s 안에만 적용. 이후엔 graceful skip — backend 정지 시 device가
+ *     매역 알림을 재시도하도록 허용 (V4 acceptance 유지).
  */
 export async function evaluateSsotFireGate(
   input: SsotFireGateInput,
@@ -99,16 +113,20 @@ export async function evaluateSsotFireGate(
     return { blocked: false, reason: 'mirror-missing' };
   }
   const now = input.now ?? Date.now();
-  if (now - mirror.receivedAt > SSOT_FIRE_GATE_STALENESS_MS) {
-    return { blocked: false, reason: 'mirror-stale' };
-  }
-  // Gate A — alarmId 매칭. backend가 결정한 alarm을 device가 재발사하려는 시도 차단.
+  // Gate A — alarmId 매칭. staleness와 무관하게 항상 평가. backend가 결정한 alarm을 device가
+  // 재발사하려는 시도는 mirror가 stale이어도 차단해야 안전 (같은 alarm 결정 두 번 fire 위험).
   if (mirror.alarmEvents) {
     for (const e of mirror.alarmEvents) {
       if (e.alarmId === input.alarmId) {
         return { blocked: true, reason: 'gate-alarm-already-decided' };
       }
     }
+  }
+  // Gate B는 staleness 안에만 적용. 6 polling cycle(180s) 누락 = backend 정지/cron failure 정황으로
+  // 판단해 graceful skip — device가 매역 알림 재시도 (V4 acceptance 유지). T10 (#1573)이 더 긴 임계로
+  // 별도 차단 정책.
+  if (now - mirror.receivedAt > SSOT_FIRE_GATE_STALENESS_MS) {
+    return { blocked: false, reason: 'mirror-stale' };
   }
   // Gate B — station-passed/imminent 카테고리만 적용. mirror.passedStations + alarmEvents 양쪽에서
   // stationId 매칭 시 차단. transfer/destination은 별도 logic(여러 hop을 cover하므로 단순 station


### PR DESCRIPTION
## Summary

V4 매역 silent 알림 누락 차단. 사용자 trip evidence 6/22 13:38~41 (상왕십리/신당/동대문역사문화공원 첫 3 station 누락) 회귀 fix.

- `HYDRATE_WARMUP_MS` 30_000 → 10_000 (단축)
- `SSOT_FIRE_GATE_STALENESS_MS` Gate A staleness 무관 always-check, Gate B만 적용

Closes #1645

---

## Trip evidence (6/22 13:38~41)

| 시각 | 역 | 알림 |
|---|---|---|
| 13:38 | 상왕십리 도착 | ❌ |
| 13:39 | 신당 도착 | ❌ |
| 13:40 | 동대문역사문화공원 도착 | ❌ |
| 13:41 | FG 진입 | ✅ |

destination 변경 / cold start 직후 30s warmup window가 지하철 station 간격(1~2분)보다 길어 첫 3 station 알림 일관 누락. → V4 acceptance(매역 silent 알림) 일관 위반.

## Fix 설계

### Fix 1 — `HYDRATE_WARMUP_MS` 30_000 → 10_000

`useStationAlarm.ts:83`. station-passed effect(#1010) + phase 알람 effect(#1316) 공유 window 단축.

기존 보조 가드(이중 보호) 유지:
- `firedAlarmsRefDestIdRef` (#699) — destinationId mismatch race 가드
- `hydrationPhase!=='ready'` — H5 state machine
- cross-category station dedup (#1515) — 30s 윈도우
- `evaluateSsotFireGate` Gate A — alarmId 중복 차단

### Fix 2 — Gate A는 staleness 무관 always-check, Gate B만 staleness 적용

`ssotFireGate.ts evaluateSsotFireGate`:

| Gate | 변경 전 | 변경 후 |
|---|---|---|
| Gate A (alarmId 매칭) | staleness 180s 안에만 적용 | **staleness 무관 always-check** |
| Gate B (stationId, station-passed/imminent) | staleness 180s 안에만 적용 | (유지) staleness 180s 안에만 적용 |

Rationale: alarmId는 `${type}:${stationName}` 결정론 — 같은 trip 안에서만 의미. 같은 alarm 결정 두 번 fire는 mirror가 stale이어도 항상 차단해야 안전. stationId 중복 차단은 60s+ 이후 재발사가 정상일 수 있어 graceful skip 유지 (V4 acceptance, backend 정지 시 device 재시도 허용).

## V/X 영향

| Acceptance | 현재 | 본 PR 머지 후 |
|---|---|---|
| V4 매역 silent 알림 | ❌ warmup 첫 3 station 누락 | ✅ 첫 1 station만 잠재 누락 (10s warmup) |
| V6 위치 빠른 반영 | ❌ warmup 30s lag | ✅ warmup 10s lag |
| X9 사용자 의도 외 fire | ✅ warmup 의도(false fire 차단) | ✅ 유지 (10s + Gate A 더 엄격) |

## 트레이드오프 + Mitigation

| Trade-off | Mitigation |
|---|---|
| warmup 10s 단축으로 destination 변경 직후 race로 false fire 가능 | `firedAlarmsRefDestIdRef` (#699) + `hydrationPhase!=='ready'` 가드 이중 보호 + cross-category dedup #1515 |
| Gate A 분리로 stale mirror에서 alarmId 매칭 false positive | alarmId는 `${type}:${stationName}` 결정론. trip 변경 시 mirror 자체 reset → stale alarmId false positive risk 낮음 |
| station-passed gate warmup 약화 (10s 단축) | cross-category dedup hop window + lastNotifiedStationId 단일 출처 dedup이 station 중복 차단 유지 |

## ADR 정합

- **ADR-010 first line**: "두 실패 모드(false positive / miss)는 비대칭이 아니라 동급" — 현재 30s warmup이 miss 측을 일관되게 만들고 있어 위반. 본 fix는 miss 감소 + false positive 보호는 다른 가드로 유지.
- **ADR-014**: 사용자 명시 의향 trip (lock 활성 / lockless opt-in 둘 다) 동급 보장 — 본 fix는 두 mode 모두 동시 적용.
- **시간 적분 fire 권한 X**: Gate B 분리는 advance 추정 X — 단지 staleness 적용 범위 분리만.

## Wire Matrix

| Element | A. FG GPS phase | B. FG arvlCd fast-path | C. BG silent push | D. OS bl: scheduled | E. OS tba: scheduled |
|---|---|---|---|---|---|
| HYDRATE_WARMUP 적용 | `useStationAlarm.ts:749` | (separate effect — warmup 미적용) | N/A (BG handler 내부) | N/A | N/A |
| Gate A 호출 | `useStationAlarm.ts:1059` (helper L312-334) | `useStationAlarm.ts:1194` (helper) | `silentPushTask.ts:1201` | (LA handler) | (LA handler) |
| Gate B 호출 (type=station-passed) | `useStationAlarm.ts:1059` (helper) | `useStationAlarm.ts:1194` (helper) | `silentPushTask.ts:1201` | N/A | N/A |
| dedup 경합 | lastNotifiedStationId + #1515 | lastNotifiedStationId 공유 | lastNotifiedStationId 공유 | firedAlarms | firedAlarms |

## Wire-completion 5단

- [x] **1. Orphan 없음** — `npm run lint:orphan` pass. 상수 + 게이트 내부 logic만, 신규 export 없음.
- [x] **2. V/X dashboard** — alarmLog `gate-phase-warmup` / `gate-station-passed-warmup` / `gate-alarm-already-decided` / `gate-station-already-passed` / `mirror-stale` → DebugModal Counters + Sentry breadcrumb.
- [x] **3. 의존 PR** — N/A — device-only 상수/logic 변경.
- [x] **4. 측정 plan** — 1주 production trip — warmup 차단 카운트(`gate-phase-warmup`, `gate-station-passed-warmup`) 감소 + 매역 알림 첫 station 누락 0건 검증.
- [x] **5. Device verify** — 실기기 trip 필요. 6/22 13:38~41 evidence 시나리오 재현 (cold start / destination 변경 직후 첫 station 알림 발사 확인).

## Test plan

- [x] `npm test` — useStationAlarm 198 pass, ssotFireGate 18 pass (Gate A/B 분리 4 신규 케이스 포함)
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass
- [x] 본 PR 4개 파일 `npx eslint` pass
- [ ] 실기기 trip — 6/22 13:38~41 evidence 재현: cold start / destination 변경 직후 첫 station 알림 발사

## Refs

- ADR-017 #1553 (Backend SSoT Epic, T9 Gate, T10 Sticky SSoT)
- #1010 / #1316 / #670 / #672 (warmup 도입 이력)
- #1572 (Gate A/B 도입)
- #699 (firedAlarmsRefDestIdRef race 가드)
- #1515 (cross-category station dedup)