### PR TITLE
fix(#1647): 자동 trip 종료 trigger — API-independent 3-of-3 (100m + 5min + lock)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useDestinationAutoClear.test.ts
+++ b/src/features/alarm/hooks/__tests__/useDestinationAutoClear.test.ts
@@ -305,20 +305,11 @@ describe('useDestinationAutoClear', () => {
   // #1647 — Seoul API-independent stationary 게이트 (3-of-3: destination 100m + 5min + lock 활성)
   describe('#1647 stationary 게이트 (API-independent fallback)', () => {
     it('arvlCd 없고 lockActive=true + 100m + 5min stationary → 자동 종료', () => {
-      // arrival=null로 arvlCd 게이트 fail. stationary 게이트만으로 fire.
-      setArrival(null);
-      const onAutoClear = jest.fn();
-      const initial: UseDestinationAutoClearInputs = {
-        ...baseInputs(),
-        onAutoClear,
-        motionStationary: true,
-        lockActive: true,
-      };
-      const { rerender } = withDateNow(T0, () =>
-        renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), {
-          initialProps: initial,
-        }),
-      );
+      // arvlCodes: [] → arrival 게이트 fail (pickDestinationArvlCd null). stationary 게이트만으로 fire.
+      const { onAutoClear, initial, rerender } = mountStationaryDetect({
+        arvlCodes: [],
+        inputOverrides: { lockActive: true },
+      });
       withDateNow(T0 + STATIONARY_TRIP_END_THRESHOLD_MS, () => {
         rerender({ ...initial, userLocation: { lat: destination.lat + 0.00001, lng: destination.lng } });
       });
@@ -330,19 +321,10 @@ describe('useDestinationAutoClear', () => {
     });
 
     it('lockActive=false면 stationary 게이트 차단 — lockless trip 보호', () => {
-      setArrival(null);
-      const onAutoClear = jest.fn();
-      const initial: UseDestinationAutoClearInputs = {
-        ...baseInputs(),
-        onAutoClear,
-        motionStationary: true,
-        lockActive: false,
-      };
-      const { rerender } = withDateNow(T0, () =>
-        renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), {
-          initialProps: initial,
-        }),
-      );
+      const { onAutoClear, initial, rerender } = mountStationaryDetect({
+        arvlCodes: [],
+        inputOverrides: { lockActive: false },
+      });
       withDateNow(T0 + STATIONARY_TRIP_END_THRESHOLD_MS, () => {
         rerender({ ...initial, userLocation: { lat: destination.lat + 0.00001, lng: destination.lng } });
       });
@@ -350,21 +332,12 @@ describe('useDestinationAutoClear', () => {
     });
 
     it('userLocation이 100m 밖이면 stationary 게이트도 차단', () => {
-      setArrival(null);
       // 200m offset (1 deg lat ≈ 111km → 0.002 ≈ 222m)
       const far = { lat: destination.lat + 0.002, lng: destination.lng };
-      const onAutoClear = jest.fn();
-      const initial: UseDestinationAutoClearInputs = {
-        ...baseInputs({ userLocation: far }),
-        onAutoClear,
-        motionStationary: true,
-        lockActive: true,
-      };
-      const { rerender } = withDateNow(T0, () =>
-        renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), {
-          initialProps: initial,
-        }),
-      );
+      const { onAutoClear, initial, rerender } = mountStationaryDetect({
+        arvlCodes: [],
+        inputOverrides: { userLocation: far, lockActive: true },
+      });
       withDateNow(T0 + STATIONARY_TRIP_END_THRESHOLD_MS, () => {
         rerender({ ...initial, userLocation: { ...far, lat: far.lat + 0.00001 } });
       });
@@ -372,19 +345,10 @@ describe('useDestinationAutoClear', () => {
     });
 
     it('stationary 5min 미달이면 fire 안 함', () => {
-      setArrival(null);
-      const onAutoClear = jest.fn();
-      const initial: UseDestinationAutoClearInputs = {
-        ...baseInputs(),
-        onAutoClear,
-        motionStationary: true,
-        lockActive: true,
-      };
-      const { rerender } = withDateNow(T0, () =>
-        renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), {
-          initialProps: initial,
-        }),
-      );
+      const { onAutoClear, initial, rerender } = mountStationaryDetect({
+        arvlCodes: [],
+        inputOverrides: { lockActive: true },
+      });
       // 4min만 경과 — 5min 임계 미달
       withDateNow(T0 + STATIONARY_TRIP_END_THRESHOLD_MS - 60_000, () => {
         rerender({ ...initial, userLocation: { lat: destination.lat + 0.00001, lng: destination.lng } });
@@ -395,19 +359,10 @@ describe('useDestinationAutoClear', () => {
     it('두 게이트 동시 만족 시 arrival 게이트 우선 — log gate=arrival', () => {
       // arvlCd ARRIVED + 50m 안 + 60s stationary → arrival 게이트 first 통과.
       // (stationary 게이트도 5min 후 만족하지만 firedRef로 막힘)
-      setArrival(arrivalWithCodes([1])); // ARRIVED
-      const onAutoClear = jest.fn();
-      const initial: UseDestinationAutoClearInputs = {
-        ...baseInputs(),
-        onAutoClear,
-        motionStationary: true,
-        lockActive: true,
-      };
-      const { rerender } = withDateNow(T0, () =>
-        renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), {
-          initialProps: initial,
-        }),
-      );
+      const { onAutoClear, initial, rerender } = mountStationaryDetect({
+        arvlCodes: [1], // ARRIVED
+        inputOverrides: { lockActive: true },
+      });
       // 60s만 경과 — arrival 게이트는 통과, stationary는 미통과
       withDateNow(T0 + STATIONARY_THRESHOLD_MS, () => {
         rerender({ ...initial, userLocation: { lat: destination.lat + 0.00001, lng: destination.lng } });
@@ -419,19 +374,10 @@ describe('useDestinationAutoClear', () => {
     });
 
     it('한 trip에서 stationary 게이트도 1회만 발사 — firedRef로 차단', () => {
-      setArrival(null);
-      const onAutoClear = jest.fn();
-      const initial: UseDestinationAutoClearInputs = {
-        ...baseInputs(),
-        onAutoClear,
-        motionStationary: true,
-        lockActive: true,
-      };
-      const { rerender } = withDateNow(T0, () =>
-        renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), {
-          initialProps: initial,
-        }),
-      );
+      const { onAutoClear, initial, rerender } = mountStationaryDetect({
+        arvlCodes: [],
+        inputOverrides: { lockActive: true },
+      });
       withDateNow(T0 + STATIONARY_TRIP_END_THRESHOLD_MS, () => {
         rerender({ ...initial, userLocation: { lat: destination.lat + 0.00001, lng: destination.lng } });
       });

--- a/src/features/alarm/hooks/__tests__/useDestinationAutoClear.test.ts
+++ b/src/features/alarm/hooks/__tests__/useDestinationAutoClear.test.ts
@@ -7,8 +7,10 @@ import {
 import type { Station } from '../../../../shared/types/station';
 import type { StationArrival, ArrivalInfo } from '../../../../shared/types/arrival';
 import {
+  DESTINATION_NEARBY_RADIUS_M,
   NEAR_STATION_RADIUS_M,
   STATIONARY_THRESHOLD_MS,
+  STATIONARY_TRIP_END_THRESHOLD_MS,
 } from '../../../../shared/constants/arrivalDetect';
 
 const mockUseArrivalInfo = jest.fn();
@@ -79,6 +81,9 @@ function baseInputs(overrides: Partial<UseDestinationAutoClearInputs> = {}): Use
     destination,
     userLocation: { lat: destination.lat, lng: destination.lng },
     motionStationary: false,
+    // #1647 — 기존 arvlCd 게이트 테스트는 lock 무관 → lockActive 기본 false로 후방 호환 보장.
+    // stationary 게이트 테스트만 명시적으로 true로 override.
+    lockActive: false,
     onAutoClear: jest.fn(),
     ...overrides,
   };
@@ -186,7 +191,7 @@ describe('useDestinationAutoClear', () => {
     // #1058: cleared station snapshot이 인자로 전달돼야 함 (undo 복원용).
     expect(onAutoClear).toHaveBeenCalledWith(destination);
     expect(mockLoggerInfo).toHaveBeenCalledWith(
-      'destination=강남 자동 해제 (confidence=high)',
+      'destination=강남 자동 해제 (confidence=high, gate=arrival)',
     );
   });
 
@@ -295,5 +300,152 @@ describe('useDestinationAutoClear', () => {
       rerender({ ...initial, userLocation: { ...near, lat: near.lat + 0.00001 } });
     });
     expect(onAutoClear).toHaveBeenCalledTimes(1);
+  });
+
+  // #1647 — Seoul API-independent stationary 게이트 (3-of-3: destination 100m + 5min + lock 활성)
+  describe('#1647 stationary 게이트 (API-independent fallback)', () => {
+    it('arvlCd 없고 lockActive=true + 100m + 5min stationary → 자동 종료', () => {
+      // arrival=null로 arvlCd 게이트 fail. stationary 게이트만으로 fire.
+      setArrival(null);
+      const onAutoClear = jest.fn();
+      const initial: UseDestinationAutoClearInputs = {
+        ...baseInputs(),
+        onAutoClear,
+        motionStationary: true,
+        lockActive: true,
+      };
+      const { rerender } = withDateNow(T0, () =>
+        renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), {
+          initialProps: initial,
+        }),
+      );
+      withDateNow(T0 + STATIONARY_TRIP_END_THRESHOLD_MS, () => {
+        rerender({ ...initial, userLocation: { lat: destination.lat + 0.00001, lng: destination.lng } });
+      });
+      expect(onAutoClear).toHaveBeenCalledTimes(1);
+      expect(onAutoClear).toHaveBeenCalledWith(destination);
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        'destination=강남 자동 해제 (confidence=high, gate=stationary)',
+      );
+    });
+
+    it('lockActive=false면 stationary 게이트 차단 — lockless trip 보호', () => {
+      setArrival(null);
+      const onAutoClear = jest.fn();
+      const initial: UseDestinationAutoClearInputs = {
+        ...baseInputs(),
+        onAutoClear,
+        motionStationary: true,
+        lockActive: false,
+      };
+      const { rerender } = withDateNow(T0, () =>
+        renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), {
+          initialProps: initial,
+        }),
+      );
+      withDateNow(T0 + STATIONARY_TRIP_END_THRESHOLD_MS, () => {
+        rerender({ ...initial, userLocation: { lat: destination.lat + 0.00001, lng: destination.lng } });
+      });
+      expect(onAutoClear).not.toHaveBeenCalled();
+    });
+
+    it('userLocation이 100m 밖이면 stationary 게이트도 차단', () => {
+      setArrival(null);
+      // 200m offset (1 deg lat ≈ 111km → 0.002 ≈ 222m)
+      const far = { lat: destination.lat + 0.002, lng: destination.lng };
+      const onAutoClear = jest.fn();
+      const initial: UseDestinationAutoClearInputs = {
+        ...baseInputs({ userLocation: far }),
+        onAutoClear,
+        motionStationary: true,
+        lockActive: true,
+      };
+      const { rerender } = withDateNow(T0, () =>
+        renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), {
+          initialProps: initial,
+        }),
+      );
+      withDateNow(T0 + STATIONARY_TRIP_END_THRESHOLD_MS, () => {
+        rerender({ ...initial, userLocation: { ...far, lat: far.lat + 0.00001 } });
+      });
+      expect(onAutoClear).not.toHaveBeenCalled();
+    });
+
+    it('stationary 5min 미달이면 fire 안 함', () => {
+      setArrival(null);
+      const onAutoClear = jest.fn();
+      const initial: UseDestinationAutoClearInputs = {
+        ...baseInputs(),
+        onAutoClear,
+        motionStationary: true,
+        lockActive: true,
+      };
+      const { rerender } = withDateNow(T0, () =>
+        renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), {
+          initialProps: initial,
+        }),
+      );
+      // 4min만 경과 — 5min 임계 미달
+      withDateNow(T0 + STATIONARY_TRIP_END_THRESHOLD_MS - 60_000, () => {
+        rerender({ ...initial, userLocation: { lat: destination.lat + 0.00001, lng: destination.lng } });
+      });
+      expect(onAutoClear).not.toHaveBeenCalled();
+    });
+
+    it('두 게이트 동시 만족 시 arrival 게이트 우선 — log gate=arrival', () => {
+      // arvlCd ARRIVED + 50m 안 + 60s stationary → arrival 게이트 first 통과.
+      // (stationary 게이트도 5min 후 만족하지만 firedRef로 막힘)
+      setArrival(arrivalWithCodes([1])); // ARRIVED
+      const onAutoClear = jest.fn();
+      const initial: UseDestinationAutoClearInputs = {
+        ...baseInputs(),
+        onAutoClear,
+        motionStationary: true,
+        lockActive: true,
+      };
+      const { rerender } = withDateNow(T0, () =>
+        renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), {
+          initialProps: initial,
+        }),
+      );
+      // 60s만 경과 — arrival 게이트는 통과, stationary는 미통과
+      withDateNow(T0 + STATIONARY_THRESHOLD_MS, () => {
+        rerender({ ...initial, userLocation: { lat: destination.lat + 0.00001, lng: destination.lng } });
+      });
+      expect(onAutoClear).toHaveBeenCalledTimes(1);
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        'destination=강남 자동 해제 (confidence=high, gate=arrival)',
+      );
+    });
+
+    it('한 trip에서 stationary 게이트도 1회만 발사 — firedRef로 차단', () => {
+      setArrival(null);
+      const onAutoClear = jest.fn();
+      const initial: UseDestinationAutoClearInputs = {
+        ...baseInputs(),
+        onAutoClear,
+        motionStationary: true,
+        lockActive: true,
+      };
+      const { rerender } = withDateNow(T0, () =>
+        renderHook((p: UseDestinationAutoClearInputs) => useDestinationAutoClear(p), {
+          initialProps: initial,
+        }),
+      );
+      withDateNow(T0 + STATIONARY_TRIP_END_THRESHOLD_MS, () => {
+        rerender({ ...initial, userLocation: { lat: destination.lat + 0.00001, lng: destination.lng } });
+      });
+      expect(onAutoClear).toHaveBeenCalledTimes(1);
+      // 같은 destination + 추가 update → fired ref 차단
+      withDateNow(T0 + STATIONARY_TRIP_END_THRESHOLD_MS + 30_000, () => {
+        rerender({ ...initial, userLocation: { lat: destination.lat + 0.00002, lng: destination.lng } });
+      });
+      expect(onAutoClear).toHaveBeenCalledTimes(1);
+    });
+
+    it('100m 안 + lockActive 안전 확인 — DESTINATION_NEARBY_RADIUS_M(100m) sanity', () => {
+      expect(DESTINATION_NEARBY_RADIUS_M).toBe(100);
+      expect(STATIONARY_TRIP_END_THRESHOLD_MS).toBe(5 * 60 * 1_000);
+    });
   });
 });

--- a/src/features/alarm/hooks/useDestinationAutoClear.ts
+++ b/src/features/alarm/hooks/useDestinationAutoClear.ts
@@ -41,7 +41,9 @@ import { useArrivalInfo } from '../../arrival/hooks/useArrivalInfo';
 import type { Station } from '../../../shared/types/station';
 import {
   detectDestinationArrival,
+  detectStationaryTripEnd,
   type DestinationArrivalDetectInput,
+  type StationaryTripEndDetectInput,
 } from '../utils/destinationArrivalDetect';
 import { getArrivalPriority } from '../../../shared/constants/arrivalCodes';
 import { createLogger } from '../../../shared/utils/logger';
@@ -56,6 +58,12 @@ export interface UseDestinationAutoClearInputs {
   userLocation: { lat: number; lng: number } | null;
   /** CMMotionActivity stationary 신호. 미지원/거절 케이스는 false, warmup은 undefined로 전달. */
   motionStationary: boolean | undefined;
+  /**
+   * #1647 — boardingLock 활성 여부. API-independent 5min stationary 게이트가 lockless trip을
+   * 자동 종료하지 않도록 차단한다 (사용자 명시 의향 trip만 동급 보호 — ADR-014).
+   * 기존 arvlCd 게이트는 lock 비활성에서도 동작 — 후방 호환 보장.
+   */
+  lockActive: boolean;
   /**
    * 자동 해제 시 호출. `setDestination(null)` 등 cleanup은 caller 책임이다.
    * #1058: cleared station을 인자로 받아 caller가 undo toast에 노출하거나 복원할 수 있다.
@@ -90,6 +98,7 @@ export function useDestinationAutoClear({
   destination,
   userLocation,
   motionStationary,
+  lockActive,
   onAutoClear,
 }: UseDestinationAutoClearInputs): void {
   // destination 폴링 — useStationAlarm의 동일 호출과 TtlCache dedup.
@@ -143,7 +152,24 @@ export function useDestinationAutoClear({
     if (result.shouldAutoClear) {
       firedForDestIdRef.current = destId;
       logger.info(
-        `destination=${destination.name} 자동 해제 (confidence=${result.confidence})`,
+        `destination=${destination.name} 자동 해제 (confidence=${result.confidence}, gate=arrival)`,
+      );
+      onAutoClear(destination);
+      return;
+    }
+    // #1647 — Seoul API-independent fallback gate. arvlCd 게이트가 outage/dead zone로 fire 0건일 때
+    // 100m + 5min stationary + lock 활성 3-of-3로 자동 종료. lockless trip은 차단(정보용 trip 보호).
+    const stationaryInput: StationaryTripEndDetectInput = {
+      destinationStation: destination,
+      userLocation,
+      stationaryDurationMs,
+      lockActive,
+    };
+    const stationaryResult = detectStationaryTripEnd(stationaryInput);
+    if (stationaryResult.shouldAutoClear) {
+      firedForDestIdRef.current = destId;
+      logger.info(
+        `destination=${destination.name} 자동 해제 (confidence=${stationaryResult.confidence}, gate=stationary)`,
       );
       onAutoClear(destination);
     }
@@ -152,6 +178,7 @@ export function useDestinationAutoClear({
     destinationArrival,
     userLocation,
     motionStationary,
+    lockActive,
     onAutoClear,
   ]);
 }

--- a/src/features/alarm/utils/__tests__/destinationArrivalDetect.test.ts
+++ b/src/features/alarm/utils/__tests__/destinationArrivalDetect.test.ts
@@ -165,132 +165,59 @@ describe('detectDestinationArrival', () => {
 });
 
 describe('detectStationaryTripEnd', () => {
+  /**
+   * 3-of-3 합의 기본 입력. happy path를 시작점으로 각 케이스가 한 필드만 override하면
+   * SonarCloud가 잡는 boilerplate 중복(매 it() 마다 동일 4-key object) 제거.
+   */
+  type Input = Parameters<typeof detectStationaryTripEnd>[0];
+  const happyInput: Input = {
+    destinationStation: DESTINATION,
+    userLocation: AT_DESTINATION,
+    stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
+    lockActive: true,
+  };
+
   it('3-of-3 합의 만족(destination 100m + 5min stationary + lock 활성) → high', () => {
-    const result = detectStationaryTripEnd({
-      destinationStation: DESTINATION,
-      userLocation: AT_DESTINATION,
-      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
-      lockActive: true,
+    expect(detectStationaryTripEnd(happyInput)).toEqual({
+      shouldAutoClear: true,
+      confidence: 'high',
     });
-    expect(result).toEqual({ shouldAutoClear: true, confidence: 'high' });
   });
 
-  it('lockActive=false → 자동 종료 차단 (lockless trip 보호)', () => {
-    const result = detectStationaryTripEnd({
-      destinationStation: DESTINATION,
-      userLocation: AT_DESTINATION,
-      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
-      lockActive: false,
-    });
-    expect(result).toEqual({ shouldAutoClear: false, confidence: 'low' });
-  });
-
-  it('destinationStation 없으면 low', () => {
-    const result = detectStationaryTripEnd({
-      destinationStation: null,
-      userLocation: AT_DESTINATION,
-      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
-      lockActive: true,
-    });
-    expect(result).toEqual({ shouldAutoClear: false, confidence: 'low' });
-  });
-
-  it('destinationStation undefined도 low', () => {
-    const result = detectStationaryTripEnd({
-      destinationStation: undefined,
-      userLocation: AT_DESTINATION,
-      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
-      lockActive: true,
-    });
+  // 거리/lock/destination/userLocation 미충족 = low.
+  it.each<[string, Partial<Input>]>([
+    ['lockActive=false (lockless trip 보호)', { lockActive: false }],
+    ['destinationStation=null', { destinationStation: null }],
+    ['destinationStation=undefined', { destinationStation: undefined }],
+    ['userLocation=null', { userLocation: null }],
+    ['userLocation=undefined', { userLocation: undefined }],
+    ['destination 100m 밖 (환승역/인접역 false fire 차단)', { userLocation: FAR_FROM_DESTINATION }],
+  ])('low 반환 — %s', (_label, override) => {
+    const result = detectStationaryTripEnd({ ...happyInput, ...override });
     expect(result.shouldAutoClear).toBe(false);
     expect(result.confidence).toBe('low');
   });
 
-  it('userLocation 없으면 low', () => {
-    const result = detectStationaryTripEnd({
-      destinationStation: DESTINATION,
-      userLocation: null,
-      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
-      lockActive: true,
-    });
-    expect(result).toEqual({ shouldAutoClear: false, confidence: 'low' });
-  });
-
-  it('userLocation undefined도 low', () => {
-    const result = detectStationaryTripEnd({
-      destinationStation: DESTINATION,
-      userLocation: undefined,
-      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
-      lockActive: true,
-    });
+  // destination/lock/거리는 통과하고 stationary 시간만 부족 = medium.
+  it.each<[string, Partial<Input>]>([
+    ['1ms 부족', { stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS - 1 }],
+    ['stationaryDurationMs=null', { stationaryDurationMs: null }],
+    ['stationaryDurationMs=undefined', { stationaryDurationMs: undefined }],
+  ])('medium 반환 — 정지 시간 %s', (_label, override) => {
+    const result = detectStationaryTripEnd({ ...happyInput, ...override });
     expect(result.shouldAutoClear).toBe(false);
-    expect(result.confidence).toBe('low');
-  });
-
-  it('destination 100m 밖 → low (환승역/인접역 false fire 차단)', () => {
-    const result = detectStationaryTripEnd({
-      destinationStation: DESTINATION,
-      userLocation: FAR_FROM_DESTINATION,
-      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
-      lockActive: true,
-    });
-    expect(result).toEqual({ shouldAutoClear: false, confidence: 'low' });
-  });
-
-  it('destination 100m 안 + lock + 정지 시간 부족 → medium', () => {
-    const result = detectStationaryTripEnd({
-      destinationStation: DESTINATION,
-      userLocation: AT_DESTINATION,
-      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS - 1,
-      lockActive: true,
-    });
-    expect(result).toEqual({ shouldAutoClear: false, confidence: 'medium' });
-  });
-
-  it('stationaryDurationMs null이면 medium', () => {
-    const result = detectStationaryTripEnd({
-      destinationStation: DESTINATION,
-      userLocation: AT_DESTINATION,
-      stationaryDurationMs: null,
-      lockActive: true,
-    });
-    expect(result).toEqual({ shouldAutoClear: false, confidence: 'medium' });
-  });
-
-  it('stationaryDurationMs undefined도 medium', () => {
-    const result = detectStationaryTripEnd({
-      destinationStation: DESTINATION,
-      userLocation: AT_DESTINATION,
-      stationaryDurationMs: undefined,
-      lockActive: true,
-    });
-    expect(result).toEqual({ shouldAutoClear: false, confidence: 'medium' });
+    expect(result.confidence).toBe('medium');
   });
 
   it('정확히 DESTINATION_NEARBY_RADIUS_M 경계 직전(99m)은 통과', () => {
     // 위도 1m ≈ 0.0000090 도. 99m ≈ 0.000891 도 (위도축).
     const nearEdge = { lat: DESTINATION.lat + 0.00089, lng: DESTINATION.lng };
-    const result = detectStationaryTripEnd({
-      destinationStation: DESTINATION,
-      userLocation: nearEdge,
-      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
-      lockActive: true,
-    });
+    const result = detectStationaryTripEnd({ ...happyInput, userLocation: nearEdge });
     expect(result.shouldAutoClear).toBe(true);
   });
 
   it('상수 export 확인 — 회귀 게이트', () => {
     expect(DESTINATION_NEARBY_RADIUS_M).toBe(100);
     expect(STATIONARY_TRIP_END_THRESHOLD_MS).toBe(5 * 60 * 1_000);
-  });
-
-  it('lockActive와 destination 동시 조건 — destination null이면 lock 무관하게 low', () => {
-    const result = detectStationaryTripEnd({
-      destinationStation: null,
-      userLocation: AT_DESTINATION,
-      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
-      lockActive: false,
-    });
-    expect(result.shouldAutoClear).toBe(false);
   });
 });

--- a/src/features/alarm/utils/__tests__/destinationArrivalDetect.test.ts
+++ b/src/features/alarm/utils/__tests__/destinationArrivalDetect.test.ts
@@ -1,10 +1,12 @@
 import { ARRIVAL_CODE } from '../../../../shared/constants/arrivalCodes';
 import {
+  DESTINATION_NEARBY_RADIUS_M,
   NEAR_STATION_RADIUS_M,
   STATIONARY_THRESHOLD_MS,
+  STATIONARY_TRIP_END_THRESHOLD_MS,
 } from '../../../../shared/constants/arrivalDetect';
 import type { Station } from '../../../../shared/types/station';
-import { detectDestinationArrival } from '../destinationArrivalDetect';
+import { detectDestinationArrival, detectStationaryTripEnd } from '../destinationArrivalDetect';
 
 const DESTINATION: Station = {
   id: '0150',
@@ -159,5 +161,136 @@ describe('detectDestinationArrival', () => {
   it('상수 export 확인 — 회귀 게이트', () => {
     expect(NEAR_STATION_RADIUS_M).toBe(50);
     expect(STATIONARY_THRESHOLD_MS).toBe(60_000);
+  });
+});
+
+describe('detectStationaryTripEnd', () => {
+  it('3-of-3 합의 만족(destination 100m + 5min stationary + lock 활성) → high', () => {
+    const result = detectStationaryTripEnd({
+      destinationStation: DESTINATION,
+      userLocation: AT_DESTINATION,
+      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
+      lockActive: true,
+    });
+    expect(result).toEqual({ shouldAutoClear: true, confidence: 'high' });
+  });
+
+  it('lockActive=false → 자동 종료 차단 (lockless trip 보호)', () => {
+    const result = detectStationaryTripEnd({
+      destinationStation: DESTINATION,
+      userLocation: AT_DESTINATION,
+      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
+      lockActive: false,
+    });
+    expect(result).toEqual({ shouldAutoClear: false, confidence: 'low' });
+  });
+
+  it('destinationStation 없으면 low', () => {
+    const result = detectStationaryTripEnd({
+      destinationStation: null,
+      userLocation: AT_DESTINATION,
+      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
+      lockActive: true,
+    });
+    expect(result).toEqual({ shouldAutoClear: false, confidence: 'low' });
+  });
+
+  it('destinationStation undefined도 low', () => {
+    const result = detectStationaryTripEnd({
+      destinationStation: undefined,
+      userLocation: AT_DESTINATION,
+      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
+      lockActive: true,
+    });
+    expect(result.shouldAutoClear).toBe(false);
+    expect(result.confidence).toBe('low');
+  });
+
+  it('userLocation 없으면 low', () => {
+    const result = detectStationaryTripEnd({
+      destinationStation: DESTINATION,
+      userLocation: null,
+      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
+      lockActive: true,
+    });
+    expect(result).toEqual({ shouldAutoClear: false, confidence: 'low' });
+  });
+
+  it('userLocation undefined도 low', () => {
+    const result = detectStationaryTripEnd({
+      destinationStation: DESTINATION,
+      userLocation: undefined,
+      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
+      lockActive: true,
+    });
+    expect(result.shouldAutoClear).toBe(false);
+    expect(result.confidence).toBe('low');
+  });
+
+  it('destination 100m 밖 → low (환승역/인접역 false fire 차단)', () => {
+    const result = detectStationaryTripEnd({
+      destinationStation: DESTINATION,
+      userLocation: FAR_FROM_DESTINATION,
+      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
+      lockActive: true,
+    });
+    expect(result).toEqual({ shouldAutoClear: false, confidence: 'low' });
+  });
+
+  it('destination 100m 안 + lock + 정지 시간 부족 → medium', () => {
+    const result = detectStationaryTripEnd({
+      destinationStation: DESTINATION,
+      userLocation: AT_DESTINATION,
+      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS - 1,
+      lockActive: true,
+    });
+    expect(result).toEqual({ shouldAutoClear: false, confidence: 'medium' });
+  });
+
+  it('stationaryDurationMs null이면 medium', () => {
+    const result = detectStationaryTripEnd({
+      destinationStation: DESTINATION,
+      userLocation: AT_DESTINATION,
+      stationaryDurationMs: null,
+      lockActive: true,
+    });
+    expect(result).toEqual({ shouldAutoClear: false, confidence: 'medium' });
+  });
+
+  it('stationaryDurationMs undefined도 medium', () => {
+    const result = detectStationaryTripEnd({
+      destinationStation: DESTINATION,
+      userLocation: AT_DESTINATION,
+      stationaryDurationMs: undefined,
+      lockActive: true,
+    });
+    expect(result).toEqual({ shouldAutoClear: false, confidence: 'medium' });
+  });
+
+  it('정확히 DESTINATION_NEARBY_RADIUS_M 경계 직전(99m)은 통과', () => {
+    // 위도 1m ≈ 0.0000090 도. 99m ≈ 0.000891 도 (위도축).
+    const nearEdge = { lat: DESTINATION.lat + 0.00089, lng: DESTINATION.lng };
+    const result = detectStationaryTripEnd({
+      destinationStation: DESTINATION,
+      userLocation: nearEdge,
+      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
+      lockActive: true,
+    });
+    expect(result.shouldAutoClear).toBe(true);
+  });
+
+  it('상수 export 확인 — 회귀 게이트', () => {
+    expect(DESTINATION_NEARBY_RADIUS_M).toBe(100);
+    expect(STATIONARY_TRIP_END_THRESHOLD_MS).toBe(5 * 60 * 1_000);
+  });
+
+  it('lockActive와 destination 동시 조건 — destination null이면 lock 무관하게 low', () => {
+    const result = detectStationaryTripEnd({
+      destinationStation: null,
+      userLocation: AT_DESTINATION,
+      stationaryDurationMs: STATIONARY_TRIP_END_THRESHOLD_MS,
+      lockActive: false,
+    });
+    expect(result.shouldAutoClear).toBe(false);
   });
 });

--- a/src/features/alarm/utils/destinationArrivalDetect.ts
+++ b/src/features/alarm/utils/destinationArrivalDetect.ts
@@ -20,8 +20,10 @@
 
 import { ARRIVAL_CODE } from '../../../shared/constants/arrivalCodes';
 import {
+  DESTINATION_NEARBY_RADIUS_M,
   NEAR_STATION_RADIUS_M,
   STATIONARY_THRESHOLD_MS,
+  STATIONARY_TRIP_END_THRESHOLD_MS,
 } from '../../../shared/constants/arrivalDetect';
 import type { Station } from '../../../shared/types/station';
 import { haversine } from '../../../shared/utils/haversine';
@@ -78,6 +80,73 @@ export function detectDestinationArrival(
 
   const stationaryEnough =
     stationaryDurationMs != null && stationaryDurationMs >= STATIONARY_THRESHOLD_MS;
+  if (!stationaryEnough) {
+    return { shouldAutoClear: false, confidence: 'medium' };
+  }
+
+  return { shouldAutoClear: true, confidence: 'high' };
+}
+
+/**
+ * #1647 — Seoul Arrival API-independent auto-end gate.
+ *
+ * 기존 `detectDestinationArrival`은 arvlCd(ARRIVED/ENTERING)를 1단 게이트로 요구해 Seoul API
+ * outage / 지하 dead zone에서 fire 0건(6/22 13:36 trip + 10.5h 좀비 evidence). 본 detector는
+ * arvlCd 의존 없이 device-self-contained로 동일 책임(도착 자동 종료)을 수행한다.
+ *
+ * 3-of-3 합의:
+ *   1) destinationStation ≠ null
+ *   2) userLocation → destinationStation 거리 ≤ DESTINATION_NEARBY_RADIUS_M (100m)
+ *   3) stationaryDurationMs ≥ STATIONARY_TRIP_END_THRESHOLD_MS (5min)
+ *   4) lockActive === true (사용자 명시 의향 trip만)
+ *
+ * 4번 lockActive 추가 이유:
+ *   - lockless trip은 정보용 — 사용자가 명시 의향을 표명하지 않은 trip을 자동 종료 X.
+ *   - ADR-014 "사용자 명시 의향 = lock 동급 보호" 원칙. lock 있으면 동급 정확도 의무.
+ *
+ * 본 detector는 기존 detector와 OR 결합돼 둘 중 하나라도 true면 자동 종료된다(useDestinationAutoClear).
+ *
+ * confidence:
+ *   - 'high'   → 4개 모두 만족 (shouldAutoClear=true)
+ *   - 'medium' → destination/lock/distance 통과, 정지 시간만 부족
+ *   - 'low'    → 그 외
+ */
+export interface StationaryTripEndDetectInput {
+  destinationStation: Station | null | undefined;
+  userLocation: { lat: number; lng: number } | null | undefined;
+  stationaryDurationMs: number | null | undefined;
+  /**
+   * 사용자 명시 의향 trip인지 — boardingLock 활성 여부. lockless trip 자동 종료 차단.
+   * 호출자가 `Boolean(boardingLock)`을 그대로 전달.
+   */
+  lockActive: boolean;
+}
+
+export function detectStationaryTripEnd(
+  input: StationaryTripEndDetectInput,
+): DestinationArrivalDetectResult {
+  const { destinationStation, userLocation, stationaryDurationMs, lockActive } = input;
+
+  if (destinationStation == null || userLocation == null) {
+    return { shouldAutoClear: false, confidence: 'low' };
+  }
+  if (!lockActive) {
+    return { shouldAutoClear: false, confidence: 'low' };
+  }
+
+  const distanceM =
+    haversine(
+      userLocation.lat,
+      userLocation.lng,
+      destinationStation.lat,
+      destinationStation.lng,
+    ) * KM_TO_M;
+  if (distanceM > DESTINATION_NEARBY_RADIUS_M) {
+    return { shouldAutoClear: false, confidence: 'low' };
+  }
+
+  const stationaryEnough =
+    stationaryDurationMs != null && stationaryDurationMs >= STATIONARY_TRIP_END_THRESHOLD_MS;
   if (!stationaryEnough) {
     return { shouldAutoClear: false, confidence: 'medium' };
   }

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -562,10 +562,15 @@ export default function HomeScreen() {
     setAutoDisembarkToast(null);
   }, [autoDisembarkToast, setDestination]);
   const handleAutoDisembarkDismiss = useCallback(() => setAutoDisembarkToast(null), []);
+  // #1647 — boardingLock 활성 시 API-independent fallback 게이트 활성화.
+  // Seoul Arrival API outage / 지하 dead zone에서 기존 arvlCd 게이트가 fire 0건이라
+  // 좀비 trip(10.5h evidence) + V5/X8/X9 회귀 발생. 5min stationary + 100m + lock 활성
+  // 3-of-3 합의로 device self-contained 자동 종료.
   useDestinationAutoClear({
     destination,
     userLocation,
     motionStationary,
+    lockActive: Boolean(boardingLock),
     onAutoClear: handleAutoDisembark,
   });
   // #584 PR D3: lock.boardingLine 위치 데이터를 별도 구독 — fusion 캐시와 dedup되어 추가 비용 없음.

--- a/src/shared/constants/arrivalDetect.ts
+++ b/src/shared/constants/arrivalDetect.ts
@@ -15,3 +15,21 @@
  */
 export const NEAR_STATION_RADIUS_M = 50;
 export const STATIONARY_THRESHOLD_MS = 60_000;
+
+/**
+ * #1647 — API-independent auto-end gate 임계값.
+ *
+ * 기존 detectDestinationArrival(arvlCd ARRIVED/ENTERING + 50m + 60s)은 Seoul Arrival API
+ * 단일 의존이라 outage(6/22 13:36 / 10.5h 좀비 trip evidence) 시 fire 0건.
+ * device self-contained 보장을 위해 API-independent 3-of-3 게이트 추가 (#1647).
+ *
+ * - DESTINATION_NEARBY_RADIUS_M (100m):
+ *   destination 도착 게이트 — GPS noise tolerance를 50m → 100m로 완화.
+ *   환승역/인접역 false fire 방지는 destination 1:1 매칭으로 보장 (destination ≠ 환승역).
+ *
+ * - STATIONARY_TRIP_END_THRESHOLD_MS (5min):
+ *   60s → 5min로 강화. 정차(20~30s) + 개찰구(1~2min) + 출구 진입(1~2min) 합산이 안전 마진 안.
+ *   3-of-3 합의(lock + destination 100m + 5min stationary)라 false positive 비대칭 작음.
+ */
+export const DESTINATION_NEARBY_RADIUS_M = 100;
+export const STATIONARY_TRIP_END_THRESHOLD_MS = 5 * 60 * 1_000;


### PR DESCRIPTION
Closes #1647

## Trip evidence (V5 / X8 / X9 회귀)

- **6/22 13:36** destination 도착 후 trip 종료 안 됨 — 앱 진입 시 강제 종료 알람 fire
- **10.5h 좀비 trip** (이전 trip evidence) — Seoul API outage 시 기존 device-side auto-clear 게이트 무력화
- **6/22 14:18** backend cron `consecutiveEtaMissing` 임계 → 가짜 종료 (Seoul outage 시 backend도 false-trigger)

## Root cause

### 기존 device-side 자동 종료 (useDestinationAutoClear / detectDestinationArrival)

```
destination set
  AND arvlCdAtDestination ∈ {ARRIVED, ENTERING}  ← Seoul API hard dependency
  AND distance ≤ 50m
  AND stationary ≥ 60s
```

→ `arvlCdAtDestination`은 **Seoul Arrival API 단일 의존**. outage/지하 dead zone에서 fire 0건 → 좀비 trip.

## Fix: API-independent backstop gate 병렬 추가 (3-of-3)

기존 게이트 **유지**, stationary 게이트 추가 — 둘 중 하나라도 fire 시 자동 종료.

```
detectStationaryTripEnd if (
  destination_distance_m ≤ 100               # GPS noise tolerance (50m→100m)
  AND motion === 'stationary' for ≥ 5 min    # 진짜 하차 + 개찰구 (60s→5min)
  AND boardingLock active                    # 사용자 명시 의향 trip만
)
```

## Wire Matrix (시나리오 × 게이트)

| 시나리오 | A. FG 도착 + 정지 | B. BG 도착 + 정지 | C. 환승역 5min 정차 | D. KTX 장거리 | E. Lockless trip |
|---|---|---|---|---|---|
| destination 100m | ✅ | ⚠️ BG location 활성 시 | ❌ destination ≠ 환승역 | ❌ destination 미도달 | varies |
| stationary 5min | ✅ CMMotionActivity | △ S9 piggyback (#1620) | ✅ 만족하지만 무관 | ✅ KTX 정차 만족하지만 무관 | varies |
| lock 활성 | ✅ | ✅ | ✅ | ✅ | ❌ |
| **stationary 게이트 fire** | **✅** | **△** (BG motion 부재 시 X) | **❌** | **❌** | **❌** |
| **arrival 게이트 fire** | ✅ Seoul API up 시 | ❌ BG 보통 X | ❌ | ❌ | ✅ Seoul API up 시 |

→ **A 정상 fire** (arrival OR stationary), **C/D false fire 차단**, **E lockless 정보용 trip 보호**.

## V/X 영향

| Acceptance | 현재 | 본 PR 머지 후 |
|---|---|---|
| V5 도착 자동 종료 | ❌ Seoul API 단일 의존 | ✅ API-independent path 추가 |
| X8 trip 6h+ 잔존 | ❌ 좀비 10.5h | ✅ 5min stationary trigger |
| X9 사용자 의도 외 fire | ❌ stale trip이 stale alarm fire | ✅ stale trip 자동 종료 |

## Trade-off + Mitigation

| Trade-off | Mitigation |
|---|---|
| 지하 GPS 0% 환경 trigger X (userLocation 없음) | 본 PR scope 밖. 후속 backend cron / WiFi SSID 기반 fix 별도 |
| BG에서 CMMotionActivity 안 됨 | 본 PR FG 우선. BG는 후속 accelerometer S9 piggyback (#1620) |
| 사용자가 5분 환승 정차 후 false 종료 | destination 100m gate가 차단 — 환승역 ≠ destination |
| backend Seoul outage 시 backend false auto-end (현재 14:18 사고) | 본 PR scope 밖 — device-side path 추가가 우선. backend 별도 |

## Wire-completion 5단

1. **Orphan**: `npm run lint:orphan` PASS (0 orphan exports)
2. **V/X dashboard**: 로그 `destination=X 자동 해제 (confidence=high, gate=arrival|stationary)` — DebugModal logger viewer / Sentry breadcrumb로 trip 종료 사유 측정 가능. gate suffix로 두 path fire 비율 추적
3. **의존 PR**: N/A — device-only path 추가, backend 의존 없음
4. **측정 plan**:
   - logger.info 'gate=stationary' fire 횟수 1주 측정 (Seoul outage 대응 효과)
   - 'gate=arrival' fire는 후방 호환 — 기존 회귀 확인
   - X8 좀비 trip(6h+) 발생 횟수 baseline 대비 감소 확인
   - false fire(환승역 등) 0건 확인
5. **Device verify**: 실기기 검증 필요
   - **시나리오 1**: destination 도착 후 5min 정차 → 자동 종료 알람 + toast 노출 (lock 활성 trip)
   - **시나리오 2**: Lockless trip + destination 100m 도달 + 5min 정차 → 자동 종료 X (정보용 trip 보호)
   - **시나리오 3**: 환승역에서 5min 정차 → 자동 종료 X (destination ≠ 환승역)

## 변경 파일

- `src/features/alarm/utils/destinationArrivalDetect.ts` — `detectStationaryTripEnd` 신규 pure 함수
- `src/features/alarm/utils/__tests__/destinationArrivalDetect.test.ts` — 12 신규 케이스 (3-of-3 + lock + edge)
- `src/features/alarm/hooks/useDestinationAutoClear.ts` — `lockActive` 입력 + 두 detector OR
- `src/features/alarm/hooks/__tests__/useDestinationAutoClear.test.ts` — 6 신규 케이스 + log suffix 업데이트
- `src/screens/HomeScreen.tsx` — `lockActive: Boolean(boardingLock)` wire (5줄, UI 변경 X)
- `src/shared/constants/arrivalDetect.ts` — `DESTINATION_NEARBY_RADIUS_M`(100m), `STATIONARY_TRIP_END_THRESHOLD_MS`(5min)

## 사용자 룰 정합성

- ✅ **Device self-contained** — backend/Seoul API 죽어도 device 자체로 종료 (paradigm shift 정합)
- ✅ **GPS 결정 권한 X** — destination 100m gate는 거리 비교만, station 추정 아님
- ✅ **시간 적분 fire 권한 X** — stationary 5min은 motion 신호 누적, trip advance 아님
- ✅ **ADR-010 동급 보호** — lock 활성 trip만 — 사용자 명시 의향 동급 정확도
- ✅ **UI 변경 X** — hook + trigger logic만, 기존 toast/undo path 재사용

## 테스트 결과

- type-check: PASS
- lint:orphan: PASS (0 orphan)
- 영향 파일 coverage: **100%** (lines/branches/funcs/statements)
- 신규 테스트 18건 추가 (utils 12 + hook 6)