### PR TITLE
fix(#1643): cross-category dedup window 확대 — 환승+도착 연이어 발사 차단

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -84,6 +84,7 @@ const mockLogSuppressedHopWindowNoSource = jest.fn();
 const mockLogSuppressedOriginHopLockless = jest.fn();
 const mockLogSuppressedPassedEventOnLockOrigin = jest.fn();
 const mockLogSuppressedCrossCategoryDedup = jest.fn();
+const mockLogSuppressedCrossCategoryRecent = jest.fn();
 const mockLogSuppressedSsotFireGate = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
@@ -111,6 +112,8 @@ jest.mock('../../utils/alarmLog', () => ({
     mockLogSuppressedPassedEventOnLockOrigin(...args),
   logSuppressedCrossCategoryDedup: (...args: unknown[]) =>
     mockLogSuppressedCrossCategoryDedup(...args),
+  logSuppressedCrossCategoryRecent: (...args: unknown[]) =>
+    mockLogSuppressedCrossCategoryRecent(...args),
   logSuppressedSsotFireGate: (...args: unknown[]) =>
     mockLogSuppressedSsotFireGate(...args),
 }));
@@ -655,6 +658,53 @@ describe('useStationAlarm', () => {
       }),
     );
     expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+  });
+
+  it('#1643 trip-scoped dedup — 직전 5s 안 다른 station에서 station-passed fire됐다면 phase 알람 차단', async () => {
+    // 어대 evidence 시나리오: "군자 도착"(SP) 직후 "곧 성수 도착"(D imminent) 차단.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const dedup = require('../../utils/crossCategoryStationDedup');
+    const route = makeDirectRoute(1, '2');
+    // 직전 다른 station(군자)에서 SP fire를 시뮬레이션.
+    dedup.markStationFired(destination.id, '군자', 'station-passed', Date.now());
+    // phase 알람은 다른 station(성수=earlyDest.stationName)에 발사 시도.
+    mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+    renderHook(() =>
+      useStationAlarm(
+        defaultInputs({ route, destination, userLocation: { lat: 37.4, lng: 127 }, speedMps: 5 }),
+      ),
+    );
+    await waitFor(() =>
+      expect(mockLogSuppressedCrossCategoryRecent).toHaveBeenCalledWith({
+        source: 'fg',
+        stationName: earlyDest.stationName,
+        kind: 'destination',
+        phaseId: 'early',
+      }),
+    );
+    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+  });
+
+  it('#1643 trip-scoped dedup — 직전 5s 안 다른 station에서 phase fire됐다면 station-passed 차단', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const dedup = require('../../utils/crossCategoryStationDedup');
+    const route = makeDirectRoute(1, '2');
+    // 직전 다른 station(성수=earlyDest.stationName)에서 phase D fire를 시뮬레이션.
+    dedup.markStationFired(destination.id, earlyDest.stationName, 'destination', Date.now());
+    // station-passed는 다른 station(군자) 통과 시도 — cross-station + cross-cat이라 차단.
+    const passedStation = makeStation('S-gunja', '군자');
+    mockEvaluateAlarmPhase.mockReturnValue(null);
+    renderHook(() =>
+      useStationAlarm(defaultInputs({ route, destination, nearestStation: passedStation })),
+    );
+    await waitFor(() =>
+      expect(mockLogSuppressedCrossCategoryRecent).toHaveBeenCalledWith({
+        source: 'fg',
+        stationName: '군자',
+        kind: 'station-passed',
+      }),
+    );
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
   });
 
   it('destination 변경 시 새 destinationId로 re-hydrate 한다 (#462 destination scoped)', async () => {

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -40,6 +40,7 @@ import {
   logHydrationTransition,
   logRefMismatch,
   logSuppressedCrossCategoryDedup,
+  logSuppressedCrossCategoryRecent,
   logSuppressedDedupAlarm,
   logSuppressedDedupStation,
   logSuppressedDismissSilence,
@@ -58,6 +59,7 @@ import {
 import { evaluateSsotFireGate } from '../utils/ssotFireGate';
 import {
   isStationRecentlyFired,
+  isTripScopedCrossCategoryRecentlyFired,
   markStationFired,
 } from '../utils/crossCategoryStationDedup';
 import { evaluateDismissSilence } from '../utils/dismissSilenceGate';
@@ -173,6 +175,25 @@ async function dispatchStationPassed(params: {
       )
     ) {
       logSuppressedCrossCategoryDedup({
+        source,
+        stationName: candidateStation.name,
+        kind: 'station-passed',
+      });
+      return;
+    }
+    // #1643 — trip-scoped cross-category + cross-station 즉시 cascade(5s 윈도우). 같은 trip에 직전
+    // 5s 안에 **다른 station에서 phase 알람** fire가 있었다면 station-passed 차단. 어대 "곧 성수 도착"
+    // 직후 어대 station-passed 발사 같은 회귀 차단. same-category(SP→SP) cross-station은 통과 —
+    // 정상 trip 폴링 진행 보존.
+    if (
+      isTripScopedCrossCategoryRecentlyFired(
+        capturedDestinationId,
+        candidateStation.name,
+        'station-passed',
+        Date.now(),
+      )
+    ) {
+      logSuppressedCrossCategoryRecent({
         source,
         stationName: candidateStation.name,
         kind: 'station-passed',
@@ -650,6 +671,29 @@ export function useStationAlarm({
       // 갱신했으므로 storage 영속화 skip(net-zero).
       firedAlarmsRef.current.delete(key);
       logSuppressedCrossCategoryDedup({
+        source: 'fg',
+        stationName: rawEvent.stationName,
+        kind: rawEvent.type,
+        phaseId: rawEvent.phaseId,
+      });
+      return;
+    }
+    // #1643 — trip-scoped cross-category + cross-station 즉시 cascade(5s 윈도우). 같은 trip에 직전
+    // 5s 안에 **다른 station에서 station-passed** fire가 있었다면 phase 알람 차단. 2026-06-20 12:31
+    // 어대 "군자 도착"(SP) → "곧 성수 도착"(D imminent) 회귀 차단. 같은 station 진행(early→imminent)은
+    // 통과 — firedAlarms set이 그 dedup을 담당. same-category(phase→phase) cross-station도 통과 —
+    // 별도 leg 진행 보존(case 2 어대 "곧 건대"+"성수 도착"은 currentLine 게이트가 잡아야 함).
+    // firedAlarmsRef는 sleep/CC dedup와 동일 패턴 (storage 영속화 skip — net-zero).
+    if (
+      isTripScopedCrossCategoryRecentlyFired(
+        activeDestination.id,
+        rawEvent.stationName,
+        rawEvent.type,
+        Date.now(),
+      )
+    ) {
+      firedAlarmsRef.current.delete(key);
+      logSuppressedCrossCategoryRecent({
         source: 'fg',
         stationName: rawEvent.stationName,
         kind: rawEvent.type,

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -30,6 +30,7 @@ import {
   FLUSH_DEBOUNCE_MS,
   FLUSH_MAX_DELAY_MS,
   logSuppressedCrossCategoryDedup,
+  logSuppressedCrossCategoryRecent,
   logSuppressedDedupStation,
   logSuppressedDismissSilence,
   logSuppressedSleepFirstTransfer,
@@ -557,6 +558,36 @@ describe('alarmLog', () => {
       const saved: AlarmLogEntry[] = JSON.parse(lastJson);
       const unified = saved.filter((e) => e.reason === 'dedup-station-unified');
       expect(unified).toHaveLength(1);
+    });
+
+    it('#1643 logSuppressedCrossCategoryRecent: reason=dedup-cross-category-recent + kind/phase 보존', async () => {
+      _resetBurstSuppressWindowForTests();
+      logSuppressedCrossCategoryRecent({
+        source: 'fg',
+        stationName: '성수',
+        kind: 'destination',
+        phaseId: 'imminent',
+      });
+      await expectLastSavedEntryMatches({
+        source: 'fg',
+        outcome: 'suppressed',
+        reason: 'dedup-cross-category-recent',
+        stationName: '성수',
+        kind: 'destination',
+        phaseId: 'imminent',
+      });
+    });
+
+    it('#1643 logSuppressedCrossCategoryRecent: 윈도우 내 같은 stationName 재호출은 drop', async () => {
+      _resetBurstSuppressWindowForTests();
+      logSuppressedCrossCategoryRecent({ source: 'fg', stationName: '성수', kind: 'destination' });
+      logSuppressedCrossCategoryRecent({ source: 'bg', stationName: '성수', kind: 'station-passed' });
+      await flushAlarmLog();
+      const calls = (AsyncStorage.setItem as jest.Mock).mock.calls;
+      const lastJson = calls[calls.length - 1][1];
+      const saved: AlarmLogEntry[] = JSON.parse(lastJson);
+      const recent = saved.filter((e) => e.reason === 'dedup-cross-category-recent');
+      expect(recent).toHaveLength(1);
     });
 
     it('logSuppressedDedupAlarm: reason=dedup-alarm, phase+type+stationName 적재 (#580)', async () => {

--- a/src/features/alarm/utils/__tests__/crossCategoryStationDedup.test.ts
+++ b/src/features/alarm/utils/__tests__/crossCategoryStationDedup.test.ts
@@ -1,8 +1,10 @@
 import {
   CROSS_CATEGORY_DEDUP_WINDOW_MS,
+  TRIP_SCOPED_CROSS_CATEGORY_WINDOW_MS,
   _resetCrossCategoryDedupForTests,
   clearCrossCategoryDedup,
   isStationRecentlyFired,
+  isTripScopedCrossCategoryRecentlyFired,
   markStationFired,
 } from '../crossCategoryStationDedup';
 
@@ -104,5 +106,104 @@ describe('crossCategoryStationDedup (#1515)', () => {
     expect(isStationRecentlyFired('dest-1', '강남', 'station-passed', 2_000)).toBe(true);
     await expect(clearCrossCategoryDedup()).resolves.toBeUndefined();
     expect(isStationRecentlyFired('dest-1', '강남', 'station-passed', 2_000)).toBe(false);
+  });
+
+  // #1643 — trip-scoped cross-category + cross-station 즉시 cascade window (5s).
+  // 차단 조건: (1) 다른 stationName + (2) cross-category(phase ↔ station-passed). 둘 다 만족해야 차단.
+  describe('isTripScopedCrossCategoryRecentlyFired (#1643)', () => {
+    it('returns false when no fire has been recorded', () => {
+      expect(isTripScopedCrossCategoryRecentlyFired('dest-1', '성수', 'destination', 1_000)).toBe(false);
+    });
+
+    // (firstStation, firstCategory, secondStation, secondCategory, expectedBlocked, label)
+    it.each<[string, Category, string, Category, boolean, string]>([
+      // ── 차단 (cross-station + cross-category) ──
+      // 2026-06-20 12:31 어대 evidence: "군자 도착"(SP) + "곧 성수 도착"(D imminent)
+      ['군자', 'station-passed', '성수', 'destination', true, 'cross-station + SP→D blocked (어대 evidence)'],
+      ['군자', 'station-passed', '건대', 'transfer', true, 'cross-station + SP→T blocked'],
+      ['성수', 'destination', '왕십리', 'station-passed', true, 'cross-station + D→SP blocked'],
+      ['건대', 'transfer', '왕십리', 'station-passed', true, 'cross-station + T→SP blocked'],
+
+      // ── 통과 (same station 진행, per-station dedup이 담당) ──
+      ['성수', 'destination', '성수', 'destination', false, 'same station + same-cat: D→D NOT blocked (early→imminent 진행)'],
+      ['성수', 'station-passed', '성수', 'destination', false, 'same station + cross-cat: per-station이 담당'],
+      ['성수', 'destination', '성수(부속)', 'station-passed', false, 'same station normalized: NOT blocked'],
+
+      // ── 통과 (cross-station + same-category, 정상 trip 진행 보존) ──
+      ['역삼', 'station-passed', '선릉', 'station-passed', false, 'cross-station + SP→SP NOT blocked (정상 trip 폴링 station 변경)'],
+      ['건대', 'transfer', '성수', 'destination', false, 'cross-station + phase→phase NOT blocked (별도 leg 진행, currentLine 게이트가 담당)'],
+      ['이수', 'destination', '사당', 'transfer', false, 'cross-station + phase→phase NOT blocked (별도 leg)'],
+    ])(
+      '(%s, %s) → (%s, %s) within trip window: blocked=%s (%s)',
+      (firstSt, firstCat, secondSt, secondCat, blocked) => {
+        markStationFired('dest-1', firstSt, firstCat, 10_000);
+        expect(isTripScopedCrossCategoryRecentlyFired('dest-1', secondSt, secondCat, 10_500)).toBe(blocked);
+      },
+    );
+
+    it('returns false once the trip-scoped window has elapsed (default 5s)', () => {
+      markStationFired('dest-1', '군자', 'station-passed', 1_000);
+      expect(
+        isTripScopedCrossCategoryRecentlyFired(
+          'dest-1',
+          '성수',
+          'destination',
+          1_000 + TRIP_SCOPED_CROSS_CATEGORY_WINDOW_MS,
+        ),
+      ).toBe(false);
+    });
+
+    it('blocks within window then allows after window for normal 30s cycle progression', () => {
+      // 같은 cycle 즉시 cascade는 차단.
+      markStationFired('dest-1', '군자', 'station-passed', 1_000);
+      expect(isTripScopedCrossCategoryRecentlyFired('dest-1', '성수', 'destination', 1_500)).toBe(true);
+      // 정상 30s cycle 이후엔 통과 (사용자 trip 정상 진행 보존).
+      expect(isTripScopedCrossCategoryRecentlyFired('dest-1', '성수', 'destination', 31_500)).toBe(false);
+    });
+
+    it('isolates entries by destinationId', () => {
+      markStationFired('dest-1', '군자', 'station-passed', 1_000);
+      expect(isTripScopedCrossCategoryRecentlyFired('dest-2', '성수', 'destination', 1_500)).toBe(false);
+    });
+
+    it('accepts custom window override', () => {
+      markStationFired('dest-1', '군자', 'station-passed', 1_000);
+      expect(
+        isTripScopedCrossCategoryRecentlyFired('dest-1', '성수', 'destination', 1_500, 100),
+      ).toBe(false);
+      expect(
+        isTripScopedCrossCategoryRecentlyFired('dest-1', '성수', 'destination', 1_050, 100),
+      ).toBe(true);
+    });
+
+    it('updates record on subsequent markStationFired (latest stationName is reference)', () => {
+      markStationFired('dest-1', '군자', 'station-passed', 1_000);
+      // 같은 trip의 다른 station에 destination fire — 마지막 fire가 성수+destination으로 덮어쓰임.
+      markStationFired('dest-1', '성수', 'destination', 1_100);
+      // 후속 query 강남+SP는 성수(다른 station)+cross-cat(D↔SP)이라 차단.
+      expect(isTripScopedCrossCategoryRecentlyFired('dest-1', '강남', 'station-passed', 1_200)).toBe(true);
+      // 같은 성수 query는 통과 (per-station이 담당).
+      expect(isTripScopedCrossCategoryRecentlyFired('dest-1', '성수', 'station-passed', 1_200)).toBe(false);
+    });
+
+    it('normalizes station name (parenthetical suffix matches same-station)', () => {
+      markStationFired('dest-1', '왕십리(성동구청)', 'station-passed', 1_000);
+      // normalize 후 같은 station '왕십리' → 통과 (per-station이 담당).
+      expect(isTripScopedCrossCategoryRecentlyFired('dest-1', '왕십리', 'destination', 1_500)).toBe(false);
+    });
+
+    it('clearCrossCategoryDedup also clears trip-scoped fire records', async () => {
+      markStationFired('dest-1', '군자', 'station-passed', 1_000);
+      expect(isTripScopedCrossCategoryRecentlyFired('dest-1', '성수', 'destination', 1_500)).toBe(true);
+      await clearCrossCategoryDedup();
+      expect(isTripScopedCrossCategoryRecentlyFired('dest-1', '성수', 'destination', 1_500)).toBe(false);
+    });
+
+    it('_resetCrossCategoryDedupForTests also clears trip-scoped fire records', () => {
+      markStationFired('dest-1', '군자', 'station-passed', 1_000);
+      expect(isTripScopedCrossCategoryRecentlyFired('dest-1', '성수', 'destination', 1_500)).toBe(true);
+      _resetCrossCategoryDedupForTests();
+      expect(isTripScopedCrossCategoryRecentlyFired('dest-1', '성수', 'destination', 1_500)).toBe(false);
+    });
   });
 });

--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -77,6 +77,7 @@ const mockLogSuppressedSleepFirstTransfer = jest.fn();
 const mockLogSuppressedSleepStationPassed = jest.fn();
 const mockLogSuppressedDismissSilence = jest.fn();
 const mockLogSuppressedCrossCategoryDedup = jest.fn();
+const mockLogSuppressedCrossCategoryRecent = jest.fn();
 jest.mock('../alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
   logFiredStationPassed: (...args: unknown[]) => mockLogFiredStationPassed(...args),
@@ -89,6 +90,8 @@ jest.mock('../alarmLog', () => ({
   logSuppressedDismissSilence: (...args: unknown[]) => mockLogSuppressedDismissSilence(...args),
   logSuppressedCrossCategoryDedup: (...args: unknown[]) =>
     mockLogSuppressedCrossCategoryDedup(...args),
+  logSuppressedCrossCategoryRecent: (...args: unknown[]) =>
+    mockLogSuppressedCrossCategoryRecent(...args),
 }));
 
 import { processLocationUpdate, resolveNextTarget } from '../stationPipeline';
@@ -893,6 +896,69 @@ describe('processLocationUpdate', () => {
       expect(mockSendAlarmNotification).not.toHaveBeenCalled();
     });
 
+  });
+
+  // #1643 — trip-scoped cross-category + cross-station 즉시 cascade dedup (BG path).
+  // 2026-06-20 12:31 어대 "군자 도착"(SP) + "곧 성수 도착"(D imminent) 회귀 차단.
+  describe('#1643 trip-scoped cross-category + cross-station cascade dedup (BG path)', () => {
+    const passedStation: Station = { ...mockStation, name: '군자', id: 'station-1' };
+    const otherStation: Station = { ...mockStation, name: '성수', id: 'station-3' };
+
+    beforeEach(() => {
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockIsStationOnRoute.mockReturnValue(true);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+    });
+
+    it('station-passed 발사(군자) 후 5s 안 phase 알람(성수=다른 station, cross-cat)은 trip-scoped dedup으로 차단', async () => {
+      // 1st: 군자 station-passed 발사 → trip-scoped mark.
+      mockFindNearestStation.mockReturnValue({ station: passedStation, distanceKm: 0.05 });
+      mockEvaluateAlarmPhase.mockReturnValue(null);
+      await call({ source: 'bg' });
+      expect(mockSendStationPassedNotification).toHaveBeenCalled();
+
+      // 2nd: 다른 station(성수) phase 알람 — cross-station + cross-cat이라 trip-scoped 차단.
+      mockFindNearestStation.mockReturnValue({ station: otherStation, distanceKm: 0.05 });
+      mockEvaluateAlarmPhase.mockReturnValue({
+        phaseId: 'imminent',
+        type: 'destination',
+        stationName: otherStation.name,
+      });
+      mockIsStationOnRoute.mockReturnValue(false); // station-passed 분기 회피
+      await call({ source: 'bg' });
+      expect(mockLogSuppressedCrossCategoryRecent).toHaveBeenCalledWith({
+        source: 'bg',
+        stationName: otherStation.name,
+        kind: 'destination',
+        phaseId: 'imminent',
+      });
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    it('phase 알람 발사(성수) 후 5s 안 다른 station(군자) station-passed는 trip-scoped dedup으로 차단', async () => {
+      // 1st: 성수 phase 발사 → trip-scoped mark.
+      mockFindNearestStation.mockReturnValue({ station: otherStation, distanceKm: 0.05 });
+      mockEvaluateAlarmPhase.mockReturnValueOnce({
+        phaseId: 'imminent',
+        type: 'destination',
+        stationName: otherStation.name,
+      });
+      mockIsStationOnRoute.mockReturnValueOnce(false);
+      await call({ source: 'fg-evaluated' });
+      expect(mockSendAlarmNotification).toHaveBeenCalled();
+
+      // 2nd: 군자(다른 station) station-passed 시도 — trip-scoped cross-cat 차단.
+      mockFindNearestStation.mockReturnValue({ station: passedStation, distanceKm: 0.05 });
+      mockEvaluateAlarmPhase.mockReturnValue(null);
+      mockIsStationOnRoute.mockReturnValue(true);
+      await call({ source: 'bg' });
+      expect(mockLogSuppressedCrossCategoryRecent).toHaveBeenCalledWith({
+        source: 'bg',
+        stationName: passedStation.name,
+        kind: 'station-passed',
+      });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
   });
 
   // #1236 (Epic #1204 D8 wire) — BG station-passed dispatch path도 sleep 룰 게이트 호출.

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -218,7 +218,12 @@ export type AlarmLogReason =
   | 'candidate-distance-reject'
   // #1628 — R11 cross-trip mirror skip(PR #1613) 차단 1건. 같은 site에서 burst 발사하는 race 케이스를
   // 차단하기 위해 5s 윈도우 burst dedup 적용.
-  | 'cross-trip-mirror-skip';
+  | 'cross-trip-mirror-skip'
+  // #1643 — trip-scoped cross-category recent fire 윈도우(TRIP_SCOPED_CROSS_CATEGORY_WINDOW_MS=5s)
+  // 안에서 phase ↔ station-passed가 다른 station에 즉시 cascade로 발사되는 회귀 차단(2026-06-19
+  // 15:37 이수-사당, 2026-06-20 12:31 어대-군자-성수). 기존 'dedup-station-unified'(같은 station 30s
+  // 윈도우)와 분리해 trip-scoped cross-station cascade를 독립 카운트.
+  | 'dedup-cross-category-recent';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -368,6 +373,34 @@ export function logSuppressedCrossCategoryDedup(input: {
     source: input.source,
     outcome: 'suppressed',
     reason: 'dedup-station-unified',
+    stationName: input.stationName,
+    kind: input.kind,
+    phaseId: input.phaseId,
+  });
+}
+
+/**
+ * #1643 — trip-scoped cross-category cascade 차단 1건 적재.
+ *
+ * 같은 trip(destinationId)에 직전 cross-category fire(phase ↔ station-passed)가 5s 윈도우 안에
+ * 있을 때 다른 station 후속 발사를 차단한 케이스. 'dedup-station-unified'(같은 station 30s)와
+ * 다른 신호 — station 무관 trip-wide 즉시 cascade(2026-06-19 15:37 이수-사당, 2026-06-20 12:31
+ * 어대-군자-성수)를 잡는다.
+ *
+ * burst dedup 윈도우로 같은 (source, stationName) 반복 로그는 1건만 적재.
+ */
+export function logSuppressedCrossCategoryRecent(input: {
+  source: AlarmLogSource;
+  stationName: string;
+  kind: AlarmLogKind;
+  phaseId?: AlarmPhaseId;
+}): void {
+  if (isBurstDuplicate('dedup-cross-category-recent', input.stationName)) return;
+  appendAlarmLog({
+    ts: Date.now(),
+    source: input.source,
+    outcome: 'suppressed',
+    reason: 'dedup-cross-category-recent',
     stationName: input.stationName,
     kind: input.kind,
     phaseId: input.phaseId,

--- a/src/features/alarm/utils/crossCategoryStationDedup.ts
+++ b/src/features/alarm/utils/crossCategoryStationDedup.ts
@@ -46,6 +46,16 @@ function normalizeStationName(name: string): string {
 /** 같은 station에 대해 cross-category fire를 차단하는 윈도우. */
 export const CROSS_CATEGORY_DEDUP_WINDOW_MS = 30_000;
 
+/**
+ * #1643 — trip-scoped 즉시 cascade 윈도우.
+ * 같은 trip(destinationId) 안에서 **다른 station + cross-category(phase↔SP)** 알람이 같은 cycle/
+ * 즉시 cascade로 발사되는 회귀(2026-06-20 12:31 어대 "군자 도착"(SP)+"곧 성수 도착"(D imminent))를 차단한다.
+ * 짧은 윈도우(5s)로 잡아 정상 진행(30s cycle)에 영향이 없도록 한다.
+ * ADR-010 첫 줄 (false positive ↔ miss 동급) 정합 — window를 좁게 두어 miss 위험 최소화.
+ * 같은 그룹(phase↔phase, SP→SP) cross-station은 통과시킴 — 정상 trip 진행 보존.
+ */
+export const TRIP_SCOPED_CROSS_CATEGORY_WINDOW_MS = 5_000;
+
 /** Map 무한 성장 cap. 정상 trip(역 수 ~수십) × destination ~수 = ≤ 수백. cap 도달 시 만료 일괄 정리. */
 const DEDUP_MAP_CAP = 256;
 
@@ -61,6 +71,29 @@ interface FireRecord {
 }
 
 const lastFire = new Map<string, FireRecord>();
+
+/**
+ * #1643 — trip-scoped last-fire 추적. 키는 destinationId만.
+ *
+ * 사용자 trip evidence (2026-06-20 12:31 어대) 회귀는 같은 trip 안에 **다른 stationName + cross-category
+ * (SP↔phase)** 알람이 5s 안에 연이어 발사되는 형태:
+ *   - "군자 도착"(station-passed) → "곧 성수 도착"(destination imminent)
+ *
+ * 같은 그룹 cross-station (예: phase→phase, SP→SP) 또는 같은 station 진행(early→imminent)은
+ * 정상 동작이므로 통과시킴 — 본 record는 두 비교를 위해 stationName과 category를 모두 보존한다.
+ *
+ * phase→phase cross-station 회귀(2026-06-20 12:32 어대 "곧 건대"+"성수 도착", 2026-06-19 15:37 BG
+ * "곧 이수"+"다음 역 사당")는 본 PR 범위 외 — `evaluateAlarmPhase`의 currentLine 게이트가 담당하며,
+ * 별도 followup 이슈로 분리해 추적.
+ *
+ * 정상 30s cycle 진행(다음 hop fire)은 5s 윈도우 통과 → 정상 발사 보장.
+ */
+interface TripFireRecord {
+  ts: number;
+  category: FireCategory;
+  stationName: string;
+}
+const lastTripFire = new Map<string, TripFireRecord>();
 
 function makeKey(destinationId: string, stationName: string): string {
   return `${destinationId}|${normalizeStationName(stationName)}`;
@@ -91,6 +124,20 @@ function isCrossCategory(prev: FireCategory, current: FireCategory): boolean {
 }
 
 /**
+ * #1643 — 카테고리 그룹 차이 판정. `isCrossCategory`와 다름:
+ *   - `isCrossCategory`: SP→SP도 true (per-station race 차단 의도, #1515).
+ *   - `isCategoryGroupChange`: SP↔phase 그룹 변화일 때만 true (SP→SP / phase→phase = false).
+ *
+ * trip-scoped cascade 회귀(2026-06-20 어대 evidence)는 phase↔SP 그룹 cascade — 같은 그룹 안
+ * cross-station은 정상 trip 진행이라 통과시켜야 한다.
+ */
+function isCategoryGroupChange(prev: FireCategory, current: FireCategory): boolean {
+  const prevIsSP = prev === 'station-passed';
+  const currentIsSP = current === 'station-passed';
+  return prevIsSP !== currentIsSP;
+}
+
+/**
  * cross-category fire가 윈도우 내에 발생했는지 확인.
  * fire 직전 호출 — true면 호출자는 발사를 skip하고 `dedup-station-unified`로 로그.
  *
@@ -113,6 +160,8 @@ export function isStationRecentlyFired(
 /**
  * fire 성공 직후 윈도우 갱신. 호출자는 알람 노출 직전/직후에 호출한다.
  * 같은 station에 후속 fire가 발생하면 category가 덮어쓰여 최근 fire를 기준으로 cross-cat 판정.
+ *
+ * #1643 — 같은 trip의 last fire도 함께 갱신(station 무관). trip-scoped cross-category cascade 차단용.
  */
 export function markStationFired(
   destinationId: string,
@@ -121,12 +170,54 @@ export function markStationFired(
   now: number,
 ): void {
   lastFire.set(makeKey(destinationId, stationName), { ts: now, category });
+  lastTripFire.set(destinationId, {
+    ts: now,
+    category,
+    stationName: normalizeStationName(stationName),
+  });
   sweepExpired(now);
+}
+
+/**
+ * #1643 — trip-scoped cross-category + cross-station 즉시 cascade가 짧은 윈도우 내에 발생했는지 확인.
+ *
+ * 같은 trip(destinationId)에 직전 fire가 본 query와:
+ *   1) **다른 station** (stationName 비교, normalize 후)
+ *   2) **cross-category** (한 쪽은 phase, 다른 쪽은 station-passed)
+ * 두 조건을 모두 만족하면 차단.
+ *
+ * trip evidence 회귀(2026-06-20 12:31 어대 "군자 도착"(SP) + "곧 성수 도착"(D imminent))를 잡는다.
+ *
+ * 차단하지 않는 케이스 (정상 동작 보존):
+ *   - **같은 station 진행** (early→imminent): per-station dedup(`isStationRecentlyFired`)이 담당.
+ *   - **same-category cross-station**: station-passed→station-passed (정상 trip 폴링 station 변경),
+ *     phase→phase (별도 leg/waypoint 진행). 본 PR 범위 외 — followup 이슈로 분리.
+ *
+ * 윈도우(5s, TRIP_SCOPED_CROSS_CATEGORY_WINDOW_MS)는 사용자 체감 cascade(< 1s)만 차단하고
+ * 정상 진행(30s cycle 다음 hop fire)은 통과시키도록 좁게 설정.
+ *
+ * fire 직전 호출 — true면 호출자는 발사 skip + 'dedup-cross-category-recent' 로그.
+ */
+export function isTripScopedCrossCategoryRecentlyFired(
+  destinationId: string,
+  stationName: string,
+  category: FireCategory,
+  now: number,
+  windowMs: number = TRIP_SCOPED_CROSS_CATEGORY_WINDOW_MS,
+): boolean {
+  const rec = lastTripFire.get(destinationId);
+  if (rec === undefined) return false;
+  if (now - rec.ts >= windowMs) return false;
+  // 같은 station 진행(예: early→imminent)은 통과 — per-station dedup이 담당.
+  if (rec.stationName === normalizeStationName(stationName)) return false;
+  // 같은 그룹(phase↔phase or SP→SP) cross-station은 통과 — 정상 trip 진행 보존.
+  return isCategoryGroupChange(rec.category, category);
 }
 
 /** 테스트 전용 — 모듈 상태 리셋. production 호출 금지. */
 export function _resetCrossCategoryDedupForTests(): void {
   lastFire.clear();
+  lastTripFire.clear();
 }
 
 /**
@@ -139,5 +230,6 @@ export function _resetCrossCategoryDedupForTests(): void {
  */
 export function clearCrossCategoryDedup(): Promise<void> {
   lastFire.clear();
+  lastTripFire.clear();
   return Promise.resolve();
 }

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -18,6 +18,7 @@ import {
   logFiredAlarm,
   logFiredStationPassed,
   logSuppressedCrossCategoryDedup,
+  logSuppressedCrossCategoryRecent,
   logSuppressedDedupAlarm,
   logSuppressedDedupStation,
   logSuppressedDismissSilence,
@@ -27,6 +28,7 @@ import {
 } from './alarmLog';
 import {
   isStationRecentlyFired,
+  isTripScopedCrossCategoryRecentlyFired,
   markStationFired,
 } from './crossCategoryStationDedup';
 import { isStationPassedFirstHop, shouldSuppressBySleepRule } from './shouldSuppressBySleepRule';
@@ -319,6 +321,25 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
         kind: alarmEvent.type,
         phaseId: alarmEvent.phaseId,
       });
+    } else if (
+      isTripScopedCrossCategoryRecentlyFired(
+        destination.id,
+        alarmEvent.stationName,
+        alarmEvent.type,
+        Date.now(),
+      )
+    ) {
+      // #1643 — trip-scoped cross-category + cross-station 즉시 cascade. 같은 trip에 직전 5s 안에
+      // **다른 station에서 cross-category(SP↔phase)** fire가 있었다면 phase 알람 차단. 2026-06-20
+      // 12:31 어대 "군자 도착"(SP) + "곧 성수 도착"(D imminent) 회귀 차단. 같은 station 진행
+      // (early→imminent)은 통과 — per-station dedup이 담당. same-category cross-station은 통과 —
+      // 정상 trip 진행 보존.
+      logSuppressedCrossCategoryRecent({
+        source,
+        stationName: alarmEvent.stationName,
+        kind: alarmEvent.type,
+        phaseId: alarmEvent.phaseId,
+      });
     } else {
       markStationFired(destination.id, alarmEvent.stationName, alarmEvent.type, Date.now());
       await sendAlarmNotification(alarmEvent, sleepMode, allowSpeaker, notificationSource);
@@ -372,6 +393,23 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
         // 직전 phase 알람(destination/transfer)에서 fire됐다면 BG station-passed 차단. FG phase fire와
         // BG station-passed가 같은 station에 거의 동시 fire하는 회귀 차단. lock/lockless 동급 (ADR-014).
         logSuppressedCrossCategoryDedup({
+          source,
+          stationName: nearest.station.name,
+          kind: 'station-passed',
+        });
+      } else if (
+        isTripScopedCrossCategoryRecentlyFired(
+          destination.id,
+          nearest.station.name,
+          'station-passed',
+          Date.now(),
+        )
+      ) {
+        // #1643 — trip-scoped cross-category + cross-station 즉시 cascade. 같은 trip에 직전 5s 안에
+        // **다른 station에서 phase 알람** fire가 있었다면 station-passed 차단. 어대 "곧 성수 도착"
+        // 직후 어대 station-passed 발사 같은 회귀 차단. same-category(SP→SP) cross-station은 통과 —
+        // 정상 trip 폴링 진행 보존.
+        logSuppressedCrossCategoryRecent({
           source,
           stationName: nearest.station.name,
           kind: 'station-passed',


### PR DESCRIPTION
Closes #1643

## 회귀 (사용자 trip evidence)

### Case 1 — cross-category cross-station cascade (본 PR이 차단)
- **2026-06-20 12:31 어대역**: "군자 도착"(station-passed) 직후 "곧 성수 도착"(destination imminent)
- 같은 trip(목적지=성수), 다른 station(군자→성수), 다른 category(SP↔D)

### Case 2, 3 — phase↔phase cross-station cascade (별도 followup)
- **2026-06-20 12:32 어대역**: "곧 건대"(transfer imminent) 직후 "성수 도착"(destination)
- **2026-06-19 15:37 BG**: "곧 이수 도착"(destination imminent) 직후 "다음 역 사당 하차"(transfer)
- 둘 다 phase 카테고리 안. `evaluateAlarmPhase`의 currentLine 게이트가 담당해야 함. 본 PR 범위 외 — followup 이슈 분리.

## Root cause

`src/features/alarm/utils/crossCategoryStationDedup.ts:100` `isStationRecentlyFired`:

> "같은 `${destId}|${normalizedStation}` 키 30s 안의 cross-category(station-passed↔phase)만 차단"

→ **cross-station + cross-category는 통과**. 같은 cycle 즉시 cascade 가능.

## Fix

신규 API `isTripScopedCrossCategoryRecentlyFired(destinationId, stationName, category, now, windowMs?)` 추가:

차단 조건 (둘 다 만족):
1. **다른 stationName** (normalize 후 비교) — 같은 station 진행은 통과
2. **cross-category** (`SP ↔ phase`) — same-category cross-station(phase→phase, SP→SP)은 통과

윈도우: `TRIP_SCOPED_CROSS_CATEGORY_WINDOW_MS = 5_000` (5s).

기존 `isCrossCategory`는 SP→SP도 cross-category로 분류하지만(per-station race 차단 목적, #1515), trip-scoped는 SP→SP cross-station은 정상 trip 폴링 station 변경이라 통과시켜야 함 → 별도 `isCategoryGroupChange` 함수 (그룹 변화만 true).

## 옵션 비교 (PR 본문 결정 기록)

| Option | 차단 조건 | 장점 | 단점 |
|---|---|---|---|
| A — Trip-scoped (station 무관) | 같은 trip 5s 안 cross-cat | 단순 | 정상 진행(다른 station SP) 차단 위험 |
| B — Hop-window dedup | current ± hopWindow + cross-cat | 정상 진행 안전 | hopIndex 계산 복잡 |
| **C — Cross-station + cross-category** (채택) | 다른 station + 그룹 변화(SP↔phase) | 정상 진행 보존 + 회귀 차단 | phase↔phase cross-station은 followup 필요 |

ADR-010 (false positive ↔ miss 동급) 정합: window 좁게(5s) + 조건 보수적(둘 다 만족) → miss 위험 최소화.

## Wire Matrix

| Element | A. silent push (BG) | B. OS bl: scheduled | C. OS tba: scheduled | D. FG arvlCd | E. FG GPS phase |
|---|---|---|---|---|---|
| crossCategoryDedup 호출 | stationPipeline.ts:329, :395 (BG processLocationUpdate) | N/A (OS pre-schedule, dedup util 미사용) | N/A | useStationAlarm.ts:178 (dispatchStationPassed) | useStationAlarm.ts:678 (fireAndLog) |
| trip-scoped 가드 wire | stationPipeline.ts:329 (phase) + :405 (station-passed) | N/A | N/A | useStationAlarm.ts:191 (station-passed) | useStationAlarm.ts:692 (phase) |
| dedup 결과 활용 | logSuppressedCrossCategoryRecent → alarmLog | N/A | N/A | 같음 | 같음 |

OS 사전 예약(`boardingLockScheduler.ts` / `alarmScheduler.ts`)은 dedup util을 호출하지 않는 별도 채널 → 본 PR 범위 외.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (확인됨, "No orphan exports detected.")
2. **V/X dashboard** — alarmLog `dedup-cross-category-recent` 적재 → DebugModal Counters section에서 시각화. burst dedup 윈도우로 (source, stationName) 1건/cycle 로그.
3. **의존 PR** — N/A (독립 PR)
4. **측정 plan** — 1주 동안 alarmLog query: `reason='dedup-cross-category-recent'` 발생률 (source별). 사용자 trip evidence 3건 시나리오 재현 시 case 1은 0건 기대.
5. **Device verify** — 코드 + unit only. 실기기 1주 trip evidence로 acceptance 검증 (사용자).

## Acceptance

- [ ] 사용자 trip evidence Case 1 시나리오에서 SP→D cascade 0건 (1주 production)
- [ ] 정상 trip 진행 30s cycle 다음 hop fire는 차단되지 않음 (회귀 0건)
- [ ] alarmLog `dedup-cross-category-recent` 카운트 발생 시 (source, stationName) burst dedup 작동

## 트레이드오프

- **너무 강한 차단 위험**: 5s window는 보수적이지만 정상 cross-cat 흐름(같은 trip 안 짧은 간격 SP+phase)이 있다면 차단됨. 사용자 trip 패턴상 정상 cycle은 30s 주기라 5s window가 충분히 좁음.
- **phase↔phase cross-station 회귀 (case 2, 3) 미해결**: 본 PR은 cross-category 범위만. 별도 fix는 `evaluateAlarmPhase`의 currentLine 게이트 + 환승 전 destination 차단 보강이 필요. followup 이슈 분리 예정.
- **측정 후 window 조정 가능**: TRIP_SCOPED_CROSS_CATEGORY_WINDOW_MS는 상수로 export — 1주 측정 후 조정 가능.

## Sub PR 변경 요약

- `src/features/alarm/utils/crossCategoryStationDedup.ts` — 신규 API `isTripScopedCrossCategoryRecentlyFired` + `lastTripFire` Map + `isCategoryGroupChange` helper + clearCrossCategoryDedup/`_resetCrossCategoryDedupForTests` 보강
- `src/features/alarm/utils/alarmLog.ts` — 신규 reason `dedup-cross-category-recent` + `logSuppressedCrossCategoryRecent` 함수
- `src/features/alarm/utils/stationPipeline.ts` — BG phase + BG station-passed 분기에 가드 wire
- `src/features/alarm/hooks/useStationAlarm.ts` — FG fireAndLog (phase) + FG dispatchStationPassed 분기에 가드 wire
- 테스트: 4 파일 (dedup util / alarmLog / stationPipeline / useStationAlarm) — 새 케이스 + mock update
