### PR TITLE
fix(#1652): 6h trip backstop staged — backend cron lifecycle silence(6h) + force-end(9h)

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -14,6 +14,8 @@ import {
   STALE_LOCK_FIRE_THRESHOLD_MS,
   SUBSURFACE_ETA_MISSING_TOLERANCE,
   VANISH_RE_ATTACH_THRESHOLD,
+  BACKEND_TRIP_LIFECYCLE_SILENCE_MS,
+  BACKEND_TRIP_LIFECYCLE_FORCE_END_MS,
   arvlCdFireKey,
   estimateArrivalFromPosition,
   estimateBoardingLockArrival,
@@ -27,6 +29,7 @@ import {
   pickLatestCurrentStationName,
   resolveEtaMissingThreshold,
   runScheduled,
+  tripLifecyclePhase,
   appendPassedStation,
   computeCronJitterMs,
   PASSED_STATIONS_MAX_LEN,
@@ -3549,6 +3552,159 @@ describe('ScheduledStats 초기값 (#826 E4)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #1652 — staged lifecycle backstop (X8: trip 6h+ 잔존 0건)
+// ---------------------------------------------------------------------------
+
+describe('#1652 — tripLifecyclePhase (staged lifecycle backstop)', () => {
+  it('createdAt 부터 6h 미만 → normal', () => {
+    expect(tripLifecyclePhase({ createdAt: NOW - (6 * 60 * 60_000 - 1) }, NOW)).toBe('normal');
+  });
+
+  it('createdAt 부터 정확히 6h → silence', () => {
+    expect(tripLifecyclePhase({ createdAt: NOW - 6 * 60 * 60_000 }, NOW)).toBe('silence');
+  });
+
+  it('createdAt 부터 6h~9h → silence', () => {
+    expect(tripLifecyclePhase({ createdAt: NOW - 7 * 60 * 60_000 }, NOW)).toBe('silence');
+  });
+
+  it('createdAt 부터 정확히 9h → force-end', () => {
+    expect(tripLifecyclePhase({ createdAt: NOW - 9 * 60 * 60_000 }, NOW)).toBe('force-end');
+  });
+
+  it('createdAt 부터 9h 초과 (10.5h 좀비 evidence) → force-end', () => {
+    expect(tripLifecyclePhase({ createdAt: NOW - 10.5 * 60 * 60_000 }, NOW)).toBe('force-end');
+  });
+
+  it('상수 매핑 — device-side `TRIP_LIFECYCLE_*_MS`와 정합 (6h / 9h)', () => {
+    expect(BACKEND_TRIP_LIFECYCLE_SILENCE_MS).toBe(6 * 60 * 60_000);
+    expect(BACKEND_TRIP_LIFECYCLE_FORCE_END_MS).toBe(9 * 60 * 60_000);
+  });
+});
+
+describe('runScheduled — #1652 staged lifecycle backstop', () => {
+  it('normal phase trip은 게이트 통과 — lifecycleSilenceSkipped / lifecycleForceEnded 둘 다 0', async () => {
+    const kv = new InMemoryKV();
+    // 1h 전 시작 trip + expiresAt 미래 + alarm 윈도우 진입
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'normal-tok',
+        createdAt: NOW - 60 * 60_000,
+        expiresAt: NOW + 60 * 60_000,
+        alarmAtEpochMs: NOW + 60_000,
+      }),
+    );
+
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+
+    expect(stats.lifecycleSilenceSkipped).toBe(0);
+    expect(stats.lifecycleForceEnded).toBe(0);
+  });
+
+  it('silence phase trip (createdAt 7h 전) → cron skip + lifecycleSilenceSkipped++', async () => {
+    const kv = new InMemoryKV();
+    // 7h 전 시작 trip — silence 진입. expiresAt은 미래로 둬서 만료 분기를 통과시킨다.
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'silence-tok',
+        createdAt: NOW - 7 * 60 * 60_000,
+        // expiresAt은 createdAt + 2h가 디바이스 default였지만, 좀비 trip은 client가
+        // re-register하면서 expiresAt이 미래로 갱신됨 (#578/#704 isSameSession 분기).
+        // 즉 expiresAt이 미래여도 6h+ 잔존 가능 — 좀비 evidence.
+        expiresAt: NOW + 60 * 60_000,
+        alarmAtEpochMs: NOW + 60_000,
+        boardingLock: makeBoardingLock(),
+      }),
+    );
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+
+    expect(stats.lifecycleSilenceSkipped).toBe(1);
+    expect(stats.lifecycleForceEnded).toBe(0);
+    // silence는 cron skip — Seoul polling + push 둘 다 발사 안 함.
+    expect(stats.polled).toBe(0);
+    expect(stats.pushed).toBe(0);
+    expect(apnsFetch).not.toHaveBeenCalled();
+  });
+
+  it('force-end phase trip (createdAt 10h 전 좀비) → cleanupTripWithLa + lifecycleForceEnded++', async () => {
+    const kv = new InMemoryKV();
+    // 10.5h 전 시작 좀비 trip — force-end 진입. lockless여도 강제 종료.
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'zombie-tok',
+        createdAt: NOW - 10.5 * 60 * 60_000,
+        expiresAt: NOW + 60 * 60_000,
+        alarmAtEpochMs: NOW + 60_000,
+        locklessStationPassed: true,
+      }),
+    );
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+
+    expect(stats.lifecycleForceEnded).toBe(1);
+    expect(stats.lifecycleSilenceSkipped).toBe(0);
+    // cleanupTripWithLa가 trip-ended alert push를 발사 (reason='expired' 재사용).
+    expect(apnsFetch).toHaveBeenCalled();
+    // trip이 KV에서 제거됐는지 — listTrips로 enumerate 시 비어있어야.
+    const remaining: Trip[] = [];
+    for await (const t of (await import('../trips')).listTrips(kv as unknown as KVNamespace)) {
+      remaining.push(t);
+    }
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('expiresAt 만료 분기는 staged backstop보다 우선 — force-end가 아닌 expired로 종료', async () => {
+    const kv = new InMemoryKV();
+    // createdAt 10h 전 + expiresAt 이미 만료. expiresAt 분기가 먼저 trigger.
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'both-expired-tok',
+        createdAt: NOW - 10 * 60 * 60_000,
+        expiresAt: NOW - 1_000, // 이미 만료
+        alarmAtEpochMs: NOW + 60_000,
+      }),
+    );
+
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+
+    // expiresAt 분기가 먼저 cleanup하므로 lifecycle 카운터는 증가하지 않는다.
+    expect(stats.lifecycleForceEnded).toBe(0);
+    expect(stats.lifecycleSilenceSkipped).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // #826 — drift telemetry
 // ---------------------------------------------------------------------------
 
@@ -6133,6 +6289,8 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
       cronJitterMs: 0, rescheduleBlockedMotion: 0, rescheduleFallbackNoSsot: 0,
       realtimePositionFetch: 0, selfPollCacheHit: 0, realtimePositionFetchError: 0,
       staleLockFireSkipped: 0,
+      // #1652 — staged lifecycle backstop.
+      lifecycleSilenceSkipped: 0, lifecycleForceEnded: 0,
     };
     const { dirty } = await fireArvlCdStationPush({
       trip,

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -134,6 +134,48 @@ export const MAX_CONSECUTIVE_ETA_MISSING = 5;
 export const SUBSURFACE_ETA_MISSING_TOLERANCE = 10;
 
 /**
+ * #1652 — backend cron staged trip lifecycle backstop (X8 차단).
+ *
+ * 배경: `consecutiveEtaMissing` 임계 종료(5/10 cycle)는 Seoul API가 trainCode를 잃을 때만 발동.
+ * Seoul outage / lockless 정적 / 권한 손상 등으로 cleanup 분기에 닿지 않으면 trip이 무한 잔존
+ * (10.5h 좀비 evidence, 2026-06-20 dump).
+ *
+ * Device-side는 T10 #1573 / PR #1594에서 `tripStartStorage.tripLifecyclePhase` +
+ * `useStateRehydration.runLifecycleBackstop`이 같은 임계로 silence/force-end를 처리한다.
+ * 본 backend backstop은 device가 죽거나 BG 미진입 상태에서도 trip이 KV에 무한 잔존하지
+ * 않도록 하는 **마지막 line of defense** — device-side와 dual safety net.
+ *
+ * 정합성: 임계는 device-side `TRIP_LIFECYCLE_SILENCE_MS` / `TRIP_LIFECYCLE_FORCE_END_MS`와 1:1
+ * (`src/shared/constants/realtime.ts`). 두 값이 어긋나면 한쪽이 먼저 발동해 cleanup race가 발생하므로
+ * 변경 시 양쪽 동시 업데이트 필수.
+ */
+export const BACKEND_TRIP_LIFECYCLE_SILENCE_MS = 6 * 60 * 60 * 1000;
+export const BACKEND_TRIP_LIFECYCLE_FORCE_END_MS = 9 * 60 * 60 * 1000;
+
+/**
+ * #1652 — trip lifecycle phase 판정.
+ *
+ * `createdAt` 기준 elapsed로 단계 분리. cron이 매 cycle iterate하면서 phase에 따라 처리 분기:
+ *  - 'normal'    : 정상 운행 (createdAt < 6h). 기존 로직 그대로
+ *  - 'silence'   : 6h~9h. cron skip (Seoul polling + push 모두 미발사) — KTX/장거리 trip 보호
+ *  - 'force-end' : 9h+. cleanupTripWithLa('expired')로 강제 종료
+ *
+ * 좀비 회수가 cleanup이므로 reason='expired' 재사용 — TripEndedReason enum 변경 없이 client는
+ * 이미 graceful handle. log/stats에 별도 label로 telemetry 구분.
+ */
+export type TripLifecyclePhase = 'normal' | 'silence' | 'force-end';
+
+export function tripLifecyclePhase(
+  trip: Pick<Trip, 'createdAt'>,
+  now: number,
+): TripLifecyclePhase {
+  const elapsed = now - trip.createdAt;
+  if (elapsed >= BACKEND_TRIP_LIFECYCLE_FORCE_END_MS) return 'force-end';
+  if (elapsed >= BACKEND_TRIP_LIFECYCLE_SILENCE_MS) return 'silence';
+  return 'normal';
+}
+
+/**
  * #1315 — lockless trip에서 trainCode를 확보하지 못한 cycle의 bare-arvlCd advance 보수 게이트.
  *
  * 배경(2026-06-15 trip): 사용자가 정적(용마산 근처)인데 backend가 waypoint 역의 "아무 열차"
@@ -448,6 +490,20 @@ export interface ScheduledStats extends LiveActivityStats {
    * misfire 회귀 신호. (transferDestinationGateBlocked와 별도 계측 — 본 가드는 intermediate 포함.)
    */
   staleLockFireSkipped: number;
+  /**
+   * #1652 — staged lifecycle backstop. trip이 createdAt > 6h이라 silence cycle로 skip된 누적 횟수.
+   * Seoul polling + push 발사 모두 skip된 cycle 수 = 6h+ 잔존 trip × 분당 1 cycle. 정상 운영에선
+   * 일반적으로 0에 수렴 (대부분 trip이 6h 이내 종료). 0이 아니면 KTX/장거리 trip 또는 좀비 trip이
+   * 잔존 중이라는 신호 — 9h 도달 시 force-end로 자연 회수.
+   */
+  lifecycleSilenceSkipped: number;
+  /**
+   * #1652 — staged lifecycle backstop. trip이 createdAt > 9h이라 force-end로 cleanup된 누적 횟수.
+   * 정상 운영에선 0이어야 (정상 trip + device staged backstop이 9h 이내 종료). 0이 아니면 device가
+   * 죽었거나 BG 미진입 상태에서 backend가 마지막 line of defense로 cleanup한 케이스 = 회귀 신호.
+   * cron tail에서 1주 0건이면 본 backstop이 dual safety net으로 동작 중임을 확인.
+   */
+  lifecycleForceEnded: number;
 }
 
 /**
@@ -484,11 +540,17 @@ export interface ScheduledDeps {
  * `expiresAt` 만료 trip은 skip — 메인 루프의 cleanup 분기가 어차피 처리하므로 self-poll 대상 X.
  * `alarmAtEpochMs - now > POLLING_WINDOW_MS`(아직 알람 윈도우 진입 전) trip은 포함 — 미리 line의
  * realtimePosition stamp를 적재해두면 윈도우 진입 시 첫 cycle부터 cross-match 가능.
+ *
+ * #1652 — staged lifecycle backstop 도달 trip은 self-poll 대상 X. 같은 cycle에 메인 루프가
+ *   - silence(6h~9h): cron skip → polling 무의미
+ *   - force-end(9h+): cleanupTripWithLa로 cleanup → 다음 cycle에 line union에서 자연 빠짐
+ *   둘 다 Seoul 호출을 미리 줄여 quota 절감 + cron throughput 보호.
  */
 async function collectActiveLines(env: Env, now: number): Promise<Set<LineNumber>> {
   const lines = new Set<LineNumber>();
   for await (const trip of listTrips(env.TRIPS)) {
     if (trip.expiresAt <= now) continue;
+    if (tripLifecyclePhase(trip, now) !== 'normal') continue;
     for (const line of computeAllowedLines(trip.route, trip.waypoints)) {
       lines.add(line);
     }
@@ -544,6 +606,9 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     realtimePositionFetchError: 0,
     // #1614 Phase C — stale SSoT 가드 fire 차단.
     staleLockFireSkipped: 0,
+    // #1652 — staged lifecycle backstop (X8). 6h~9h skip / 9h+ force-end.
+    lifecycleSilenceSkipped: 0,
+    lifecycleForceEnded: 0,
   };
   // #1539 (S6) — cron jitter 즉시 log. 누적 stat이 아니라 매 cycle 1줄 → tail에서 P50/P99 산출.
   log('scheduled: cron jitter', { jitterMs: stats.cronJitterMs });
@@ -573,6 +638,31 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       // #586 D — trip 만료 시 활성 LA가 남아 있으면 dismissal push로 정리하고 KV에서 제거.
       // #868 — 클라 state sync용 trip-ended silent push도 함께 발사 (reason=expired).
       await cleanupTripWithLa(trip, env, deps, stats, now, log, 'expired');
+      continue;
+    }
+
+    // #1652 — staged lifecycle backstop (X8 차단). expiresAt 만료 분기 직후 게이트.
+    // device-side (T10 #1573 / PR #1594)가 staged backstop을 처리하지만 device가 죽거나 BG 미진입
+    // 시 trip이 backend KV에 무한 잔존(10.5h 좀비 evidence). backend 마지막 line of defense.
+    //   - silence (6h~9h): cron skip — KTX/장거리 trip 보호. Seoul polling + push 모두 미발사.
+    //   - force-end (9h+) : cleanupTripWithLa로 강제 종료. reason='expired' 재사용 (client는 이미
+    //     graceful handle, 신규 enum 추가 없이 backward-compat). log/stats로 telemetry 구분.
+    const lifecyclePhase = tripLifecyclePhase(trip, now);
+    if (lifecyclePhase === 'force-end') {
+      stats.lifecycleForceEnded += 1;
+      log('lifecycle: force-end (>9h)', {
+        token: trip.token.slice(0, 8),
+        elapsedMs: now - trip.createdAt,
+      });
+      await cleanupTripWithLa(trip, env, deps, stats, now, log, 'expired');
+      continue;
+    }
+    if (lifecyclePhase === 'silence') {
+      stats.lifecycleSilenceSkipped += 1;
+      log('lifecycle: silence cycle skipped (>6h)', {
+        token: trip.token.slice(0, 8),
+        elapsedMs: now - trip.createdAt,
+      });
       continue;
     }
 


### PR DESCRIPTION
## Summary

X8 (`trip 6h+ 잔존 0건`) backend-side staged backstop. T10 #1573 / PR #1594 device-side와 임계값(6h/9h) 1:1 정합, dual safety net 완성.

Closes #1652.

## Wire Matrix

| Element | A. backend cron 정상 종료 | **B. 6h silence (신규)** | **C. 9h 강제 종료 (신규)** | D. Seoul outage 좀비 | E. device-side 자동 종료 (#1647) |
|---|---|---|---|---|---|
| 종료 trigger | `consecutiveEtaMissing` 임계 | `createdAt > 6h` | `createdAt > 9h` | (현재) 없음 → 좀비 | destination 100m + stationary 5min |
| Seoul polling | 진행 | **skip** | **skip** | 진행 (etaMissing 누적) | 진행 |
| silent push | reschedule/station-passed | **skip** | trip-ended (`expired`) | (없음) | trip-ended |
| trip KV | 유지 | 유지 | **deleteTrip** | 유지 → 좀비 | deleteTrip |
| LA dismissal | 없음 | 없음 | **fire** | 없음 | fire |
| 측정 | (기존) | `lifecycleSilenceSkipped` | `lifecycleForceEnded` | (없음) | client alarmLog |

## V/X 영향

| Acceptance | 현재 | 본 PR 머지 후 |
|---|---|---|
| **X8** trip 6h+ 잔존 0건 | ❌ 10.5h 좀비 evidence (2026-06-20 dump) | ✅ backend 9h 강제 종료 backstop |
| **V5** 자동 종료 | ⚠️ device-only | ✅ device + backend dual safety net |

## 변경 파일 (2)

- `backend/alarm-worker/src/scheduled.ts` (+90 lines)
  - `BACKEND_TRIP_LIFECYCLE_SILENCE_MS` / `FORCE_END_MS` 상수
  - `tripLifecyclePhase(trip, now)` helper (export)
  - `ScheduledStats` 인터페이스 + 초기화에 `lifecycleSilenceSkipped` / `lifecycleForceEnded` 추가
  - 메인 cron 루프 진입부 (`expiresAt` 분기 직후) staged backstop gate
  - `collectActiveLines`에 lifecycle phase 게이트 적용 (non-normal phase trip은 self-poll 대상 X)
- `backend/alarm-worker/src/__tests__/scheduled.test.ts` (+158 lines)
  - `tripLifecyclePhase` 6단 phase 매핑 테스트
  - `runScheduled` staged backstop 4 시나리오 (normal / silence / force-end / expiresAt 우선)

## 트레이드오프

| Trade-off | Mitigation |
|---|---|
| KTX/장거리 trip 6h 초과 시 silence 진입 (알람 못 받음) | Stage 3 사용자 토글(12h 연장) follow-up. 본 PR은 device-side와 동일 정책. KTX 등은 일반적으로 6h 미만이고, 6h 초과 trip은 좀비 likelihood가 더 큼 |
| device-side 자동 종료 trigger (#1647)와 중복 | 별 trigger. device = destination 100m + stationary; backend = lifecycle 6h/9h. 보완 관계 — device 죽었을 때 backend가 마지막 line of defense |
| `reason='expired'` 재사용으로 telemetry 구분 불가 | log key `lifecycle: force-end (>9h)` + `stats.lifecycleForceEnded` 별도 카운터 |
| Stage 3 사용자 토글이 본 PR에 없음 | follow-up issue로 분리. UI 변경 필요해서 본 PR scope X |

## Wire-completion 5단

1. **Orphan 없음** — 신규 export `tripLifecyclePhase` / `BACKEND_TRIP_LIFECYCLE_*_MS`는 모두 backend cron 루프 + 테스트에서 직접 사용. orphan check pass.
2. **V/X dashboard** — `stats.lifecycle*` 카운터 + `scheduled run complete` cron tail log에 자동 노출. Cloudflare Dashboard에서 추적 가능.
3. **의존 PR** — N/A (backend 단독)
4. **측정 plan**:
   - cron tail (wrangler tail / Cloudflare Dashboard) 1주 모니터: `stats.lifecycleForceEnded` 누적 0이면 좀비 trip 회수가 dev side에서 충분 (정상). 0이 아니면 backend safety net이 실제로 동작 중인 케이스 발견 → 추가 진단
   - `wrangler kv key list --binding TRIPS --prefix=trip:` 1주 후 모든 entry의 createdAt이 < 9h ago 확인
5. **Device verify** — N/A (backend-only, type+unit only). 별 follow-up에서 KTX 시나리오 실측

## Test plan

- [x] `npm run type-check` (backend + frontend) pass
- [x] `npm test` (backend) 1902/1902 pass — 새 테스트 11건 포함
- [x] `npm test` (frontend) 7358/7358 pass, coverage 100%
- [x] `npm run lint:orphan` pass (0 orphan)
- [ ] cron tail 1주 측정 — `lifecycleSilenceSkipped` / `lifecycleForceEnded` 추적

## 참조

- ADR-010 (false positive / miss 동급) — staged backstop은 둘 다 보호
- `feedback_6h_backstop_staged_handling` (memory) — 임계값 단계적 처리 룰
- `feedback_v_x_acceptance_full_table` — X8 acceptance
- T10 #1573 / PR #1594 — device-side 6h/9h staged backstop (같은 임계 1:1)
