### PR TITLE
fix(#1659): trainCode mismatch 90s 후 lock 자동 무효화 + 재선택 (X1/X3/X9)

### DIFF
--- a/src/features/alarm/store/useBoardingLockStore.ts
+++ b/src/features/alarm/store/useBoardingLockStore.ts
@@ -17,13 +17,15 @@ import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb
  * - 'vanish'          — backend silent push로 trainCode 소실 release 통보.
  * - 'destination-change' — 화면에서 destination이 바뀌어 stale lock 자동 release (controller).
  * - 'expired'         — 자동 만료(`checkExpiry`).
+ * - 'train-code-mismatch' — 같은 노선에서 다른 trainCode가 90s 지속 관찰 (useTrainCodeMismatchDetector, #1659).
  */
 export type LockReleaseReason =
   | 'user'
   | 'transfer'
   | 'vanish'
   | 'destination-change'
-  | 'expired';
+  | 'expired'
+  | 'train-code-mismatch';
 
 /**
  * BoardingLock 전역 store (#584 PR A).

--- a/src/features/route/hooks/__tests__/useTrainCodeMismatchDetector.test.ts
+++ b/src/features/route/hooks/__tests__/useTrainCodeMismatchDetector.test.ts
@@ -1,0 +1,257 @@
+import { renderHook, act, type RenderHookResult } from '@testing-library/react-native';
+import {
+  useTrainCodeMismatchDetector,
+  TRAIN_CODE_MISMATCH_GRACE_MS,
+  TRAIN_CODE_MISMATCH_THRESHOLD,
+} from '../useTrainCodeMismatchDetector';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+import type { LinePositions, TrainPosition } from '../../../../shared/types/position';
+
+const baseLock: BoardingLock = {
+  destinationId: 'd',
+  trainCode: 'T-LOCK',
+  boardingStationId: 's',
+  boardingLine: '2',
+  boardedAt: 1_000_000,
+  expectedDurationMs: 1_800_000,
+};
+
+function train(trainNo: string): TrainPosition {
+  return {
+    statnId: '',
+    statnNm: '',
+    trainNo,
+    trainStatus: 0,
+    updnLine: 0,
+    terminalStationId: '',
+    terminalStationName: '',
+    trainType: 'normal',
+    isLastTrain: false,
+    receivedAtMs: 1_700_000_000_000,
+  };
+}
+
+/** lock.trainCode 있음 — 정상 탑승 */
+const presentPositions: LinePositions = { line: '2', trains: [train('T-LOCK')] };
+/** lock.trainCode 없고 다른 trainCode 존재 — mismatch */
+const mismatchPositions: LinePositions = { line: '2', trains: [train('T-OTHER')] };
+/** trains 빈 배열 — Seoul API stale */
+const emptyPositions: LinePositions = { line: '2', trains: [] };
+
+type Props = Parameters<typeof useTrainCodeMismatchDetector>[0];
+type Result = ReturnType<typeof useTrainCodeMismatchDetector>;
+
+const afterGraceNow = () => baseLock.boardedAt + TRAIN_CODE_MISMATCH_GRACE_MS + 1;
+
+function mount(initial: Partial<Props> = {}): RenderHookResult<Result, Props> {
+  return renderHook((props: Props) => useTrainCodeMismatchDetector(props), {
+    initialProps: {
+      lock: baseLock,
+      positions: mismatchPositions,
+      now: afterGraceNow,
+      ...initial,
+    },
+  });
+}
+
+/** rerender를 N회 — 매번 새 positions 객체로 effect 강제 발화. */
+function rerenderTimes(
+  rerender: (p: Props) => void,
+  props: Props,
+  times: number,
+): void {
+  for (let i = 0; i < times; i++) {
+    act(() => rerender({ ...props, positions: props.positions ? { ...props.positions } : null }));
+  }
+}
+
+describe('useTrainCodeMismatchDetector', () => {
+  // 시나리오 1: mismatch 90s 후 detected=true
+  it('lock.trainCode 없고 다른 train 존재 시 threshold 누적 후 detected=true', () => {
+    const { result, rerender } = mount();
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: mismatchPositions, now: afterGraceNow },
+      TRAIN_CODE_MISMATCH_THRESHOLD - 1,
+    );
+    expect(result.current.detected).toBe(true);
+  });
+
+  // 시나리오 2: Seoul API stale (빈 배열 = no-signal → false invalidate 차단)
+  it('trains 빈 배열(Seoul API stale)은 no-signal로 처리해 카운터 미증가', () => {
+    const { result, rerender } = mount({ positions: emptyPositions });
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: emptyPositions, now: afterGraceNow },
+      TRAIN_CODE_MISMATCH_THRESHOLD + 5,
+    );
+    expect(result.current.detected).toBe(false);
+  });
+
+  // 시나리오 3: lockless trip (lock=null → skip)
+  it('lock=null이면 항상 detected=false', () => {
+    const { result } = mount({ lock: null });
+    expect(result.current.detected).toBe(false);
+  });
+
+  // 시나리오 4: 환승 leg 전환 (새 lock → reset)
+  it('lock.boardedAt 변경(환승 leg 전환) 시 카운터/detected reset', () => {
+    const { result, rerender } = mount();
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: mismatchPositions, now: afterGraceNow },
+      TRAIN_CODE_MISMATCH_THRESHOLD - 1,
+    );
+    expect(result.current.detected).toBe(true);
+
+    const transferLock: BoardingLock = {
+      ...baseLock,
+      trainCode: 'T-TRANSFER',
+      boardingLine: '3',
+      boardedAt: baseLock.boardedAt + 10_000,
+    };
+    const afterTransferGrace = () => transferLock.boardedAt + TRAIN_CODE_MISMATCH_GRACE_MS + 1;
+    act(() =>
+      rerender({
+        lock: transferLock,
+        positions: { line: '3', trains: [train('T-OTHER-3')] },
+        now: afterTransferGrace,
+      }),
+    );
+    expect(result.current.detected).toBe(false);
+  });
+
+  // 시나리오 5: lock 부착 직후 grace 내 mismatch → detected=false
+  it('grace 기간 내 mismatch는 카운터 미증가', () => {
+    const inGraceNow = () => baseLock.boardedAt + 100;
+    const { result, rerender } = mount({ now: inGraceNow });
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: mismatchPositions, now: inGraceNow },
+      TRAIN_CODE_MISMATCH_THRESHOLD + 5,
+    );
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('lock.trainCode가 present로 바뀌면 카운터 reset + detected=false', () => {
+    const { result, rerender } = mount();
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: mismatchPositions, now: afterGraceNow },
+      TRAIN_CODE_MISMATCH_THRESHOLD - 1,
+    );
+    expect(result.current.detected).toBe(true);
+
+    act(() =>
+      rerender({ lock: baseLock, positions: presentPositions, now: afterGraceNow }),
+    );
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('present 후 mismatch 재누적 시 다시 true', () => {
+    const { result, rerender } = mount();
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: mismatchPositions, now: afterGraceNow },
+      TRAIN_CODE_MISMATCH_THRESHOLD - 1,
+    );
+    expect(result.current.detected).toBe(true);
+
+    act(() =>
+      rerender({ lock: baseLock, positions: presentPositions, now: afterGraceNow }),
+    );
+    expect(result.current.detected).toBe(false);
+
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: mismatchPositions, now: afterGraceNow },
+      TRAIN_CODE_MISMATCH_THRESHOLD,
+    );
+    expect(result.current.detected).toBe(true);
+  });
+
+  it('positions=null이면 카운터 미증가', () => {
+    const { result, rerender } = mount({ positions: null });
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: null, now: afterGraceNow },
+      TRAIN_CODE_MISMATCH_THRESHOLD + 5,
+    );
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('positions.isMock=true는 no-signal로 처리해 카운터 미증가', () => {
+    const mockPositions: LinePositions = { ...mismatchPositions, isMock: true };
+    const { result, rerender } = mount({ positions: mockPositions });
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: mockPositions, now: afterGraceNow },
+      TRAIN_CODE_MISMATCH_THRESHOLD + 5,
+    );
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('positions.line이 lock.boardingLine과 다르면 no-signal', () => {
+    const otherLinePositions: LinePositions = { line: '5', trains: [train('T-OTHER')] };
+    const { result, rerender } = mount({ positions: otherLinePositions });
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: otherLinePositions, now: afterGraceNow },
+      TRAIN_CODE_MISMATCH_THRESHOLD + 5,
+    );
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('lock → null이면 detected reset', () => {
+    const { result, rerender } = mount();
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: mismatchPositions, now: afterGraceNow },
+      TRAIN_CODE_MISMATCH_THRESHOLD - 1,
+    );
+    expect(result.current.detected).toBe(true);
+
+    act(() =>
+      rerender({ lock: null, positions: mismatchPositions, now: afterGraceNow }),
+    );
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('동일 trainCode + 다른 boardedAt(새 lock) → grace 재적용', () => {
+    const { result, rerender } = mount();
+    rerenderTimes(
+      rerender,
+      { lock: baseLock, positions: mismatchPositions, now: afterGraceNow },
+      TRAIN_CODE_MISMATCH_THRESHOLD - 1,
+    );
+    expect(result.current.detected).toBe(true);
+
+    const refreshedLock: BoardingLock = { ...baseLock, boardedAt: baseLock.boardedAt + 10_000 };
+    const stillInGrace = () => refreshedLock.boardedAt + 100;
+    act(() =>
+      rerender({ lock: refreshedLock, positions: mismatchPositions, now: stillInGrace }),
+    );
+    expect(result.current.detected).toBe(false);
+
+    rerenderTimes(
+      rerender,
+      { lock: refreshedLock, positions: mismatchPositions, now: stillInGrace },
+      TRAIN_CODE_MISMATCH_THRESHOLD + 2,
+    );
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('now 기본값(Date.now) 사용 — boardedAt 과거면 grace 통과', () => {
+    const longAgoLock: BoardingLock = { ...baseLock, boardedAt: 0 };
+    const { result, rerender } = renderHook(
+      (props: Props) => useTrainCodeMismatchDetector(props),
+      { initialProps: { lock: longAgoLock, positions: mismatchPositions } },
+    );
+    rerenderTimes(
+      rerender,
+      { lock: longAgoLock, positions: mismatchPositions },
+      TRAIN_CODE_MISMATCH_THRESHOLD - 1,
+    );
+    expect(result.current.detected).toBe(true);
+  });
+});

--- a/src/features/route/hooks/useTrainCodeMismatchDetector.ts
+++ b/src/features/route/hooks/useTrainCodeMismatchDetector.ts
@@ -1,0 +1,118 @@
+import { type MutableRefObject, useEffect, useRef, useState } from 'react';
+import type { BoardingLock } from '../../../shared/types/boardingLock';
+import type { LinePositions } from '../../../shared/types/position';
+
+/**
+ * ref + state 이중관리 helper — stale closure 없이 ref는 effect 분기에, state는 외부 노출에 쓴다.
+ */
+function setDetectedSynced(
+  detectedRef: MutableRefObject<boolean>,
+  setDetectedState: (v: boolean) => void,
+  next: boolean,
+): void {
+  if (detectedRef.current === next) return;
+  detectedRef.current = next;
+  setDetectedState(next);
+}
+
+/**
+ * lock 생성 직후 race를 막는 그레이스 기간(ms).
+ * useMisBoardingDetector.MIS_BOARDING_GRACE_MS와 동일 값으로 통일.
+ */
+export const TRAIN_CODE_MISMATCH_GRACE_MS = 60_000;
+
+/**
+ * mismatch 관측이 N회 연속이면 trainCode 오선택으로 확정.
+ * positionApi 폴링 30s × 3 = 90s — useMisBoardingDetector threshold와 동일.
+ */
+export const TRAIN_CODE_MISMATCH_THRESHOLD = 3;
+
+export interface UseTrainCodeMismatchDetectorInputs {
+  lock: BoardingLock | null;
+  /**
+   * lock.boardingLine의 위치 데이터.
+   * lock이 없거나 호출자가 polling 안 하면 null.
+   */
+  positions: LinePositions | null;
+  /** 테스트용 시각 주입. 미전달 시 Date.now(). */
+  now?: () => number;
+}
+
+export interface UseTrainCodeMismatchDetectorResult {
+  /**
+   * mismatch threshold 도달 시 true.
+   * lock 해제/교체 시 false로 reset.
+   */
+  detected: boolean;
+}
+
+/**
+ * lock.trainCode와 **다른** trainCode가 같은 노선에서 90s 지속 관찰되면 감지 (#1659).
+ *
+ * Fail 1 (trainCode 오선택) + Fail 3 (하차 후 lock 잔존) 대응:
+ *   - 사용자가 BoardingTrainList에서 잘못된 열차를 탭한 경우
+ *   - 환승역에서 내렸으나 lock.trainCode가 계속 살아 있는 경우
+ *
+ * useMisBoardingDetector(absent 감지)와의 차이:
+ *   - absent: lock.trainCode가 positions에서 아예 사라진 경우 (Seoul API stale, 지하 dead zone 포함)
+ *   - mismatch: lock.trainCode는 없고 **다른 trainCode가 존재** → 사용자가 실제로 다른 열차에 있음
+ *
+ * 동작:
+ *   - lock 없음 / positions 없음 / isMock / 다른 노선 → 'no-signal', 카운터 미증가.
+ *   - lock.trainCode 존재 → 'present', 카운터 reset + detected=false.
+ *   - lock.trainCode 없고 다른 train 존재 → 'mismatch', grace 후 카운터 증가.
+ *   - lock.trainCode 없고 positions.trains 빈 배열 → 'no-signal' (API 응답 없음, stale로 간주).
+ *   - lock.trainCode 또는 boardedAt 변화(새 lock) → 카운터 + detected reset.
+ *
+ * detected 상태는 ref + state 이중관리 — stale closure를 피하면서 외부에 state를 노출한다.
+ */
+export function useTrainCodeMismatchDetector({
+  lock,
+  positions,
+  now = Date.now,
+}: UseTrainCodeMismatchDetectorInputs): UseTrainCodeMismatchDetectorResult {
+  const [detected, setDetectedState] = useState(false);
+  const detectedRef = useRef(false);
+  const consecutiveMismatchRef = useRef(0);
+  const trackedLockKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const updateDetected = (next: boolean): void =>
+      setDetectedSynced(detectedRef, setDetectedState, next);
+
+    // 새 lock(= trainCode + boardedAt 조합 변화) → 카운터/감지 reset.
+    const lockKey = lock ? `${lock.trainCode}:${lock.boardedAt}` : null;
+    if (trackedLockKeyRef.current !== lockKey) {
+      trackedLockKeyRef.current = lockKey;
+      consecutiveMismatchRef.current = 0;
+      updateDetected(false);
+    }
+
+    if (!lock || !positions) return;
+    if (positions.isMock) return;
+    if (positions.line !== lock.boardingLine) return;
+
+    // lock.trainCode가 현재 positions에 present → 정상 탑승, 카운터 reset.
+    const isPresent = positions.trains.some((t) => t.trainNo === lock.trainCode);
+    if (isPresent) {
+      consecutiveMismatchRef.current = 0;
+      updateDetected(false);
+      return;
+    }
+
+    // trains 배열이 비어 있으면 API 응답 자체가 없거나 stale — Seoul API dead zone 오진 방지.
+    // no-signal로 처리해 카운터 미증가.
+    if (positions.trains.length === 0) return;
+
+    // lock.trainCode는 없고, 다른 trainCode가 존재 → mismatch 후보.
+    // grace 기간 내에는 cache 지연 false-positive 방지를 위해 카운터 미증가.
+    if (now() - lock.boardedAt < TRAIN_CODE_MISMATCH_GRACE_MS) return;
+
+    consecutiveMismatchRef.current += 1;
+    if (consecutiveMismatchRef.current >= TRAIN_CODE_MISMATCH_THRESHOLD) {
+      updateDetected(true);
+    }
+  }, [lock, positions, now]);
+
+  return { detected };
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -67,6 +67,7 @@ import { ShareTripButton } from '../features/route/components/ShareTripButton';
 import { isDegenerateDestination } from '../features/route/utils/isDegenerateDestination';
 import { Toast } from '../shared/ui/Toast';
 import { useMisBoardingDetector } from '../features/route/hooks/useMisBoardingDetector';
+import { useTrainCodeMismatchDetector } from '../features/route/hooks/useTrainCodeMismatchDetector';
 import { useTrainPositions } from '../features/route/hooks/useTrainPositions';
 import { useTransferTrainList } from '../features/route/hooks/useTransferTrainList';
 import { useTransferAutoDetect } from '../features/route/hooks/useTransferAutoDetect';
@@ -174,6 +175,9 @@ export default function HomeScreen() {
   // #621: lock 전체도 전달 — 지하 GPS stale 시 시간 interpolation으로 ratchet forward.
   // 동일 store의 lock을 useBoardingLockController가 아래서 다시 소비하지만 selector라 churn 없음.
   const fusionBoardingLock = useBoardingLockStore((s) => s.lock);
+  // #1659 — train-code-mismatch release 시 reason stamp용. controller releaseLock은 () => void라
+  // breadcrumb reason을 전달할 수 없어 store를 직접 참조한다.
+  const releaseLockWithReason = useBoardingLockStore((s) => s.releaseLock);
   const lockedTrainCode = fusionBoardingLock?.trainCode ?? null;
   // #728 — CMMotionActivity 신호. 권한 요청/폴링은 hook 내부에서 lifecycle 관리.
   // 미지원/거절 시 false로 고정되어 기존 가드만 동작 (graceful fallback).
@@ -604,6 +608,24 @@ export default function HomeScreen() {
   // Toast의 5초 타이머 effect가 재설정된다(역 폴링 30s, 도착 갱신 등으로 리렌더 잦음).
   const handleMisBoardingToastDismiss = useCallback(() => setMisBoardingToastVisible(false), []);
   const handleMisBoardingModalClose = useCallback(() => setMisBoardingModalVisible(false), []);
+  // #1659: 같은 노선 다른 trainCode가 90s 지속 → lock 무효화 + 재선택 모달.
+  // useMisBoardingDetector(absent)와 달리 trains 배열에 다른 trainCode가 있을 때만 감지 —
+  // Seoul API stale(빈 배열) 오판 차단. lockLinePositions를 공유해 추가 폴링 비용 없음.
+  const { detected: trainCodeMismatchDetected } = useTrainCodeMismatchDetector({
+    lock: boardingLock,
+    positions: lockLinePositions,
+  });
+  const prevTrainCodeMismatchRef = useRef(false);
+  useEffect(() => {
+    if (trainCodeMismatchDetected && !prevTrainCodeMismatchRef.current) {
+      // lock 무효화 — breadcrumb에 reason='train-code-mismatch' stamp.
+      void releaseLockWithReason('train-code-mismatch');
+      // 사용자에게 재선택 UI 제시. 기존 MisBoardingReselectModal 재사용.
+      setMisBoardingToastVisible(true);
+      setMisBoardingModalVisible(true);
+    }
+    prevTrainCodeMismatchRef.current = trainCodeMismatchDetected;
+  }, [trainCodeMismatchDetected, releaseLockWithReason]);
   // #584 PR E: 활성 lock이 현재 leg의 transfer waypoint에 도달하면 다음 노선 도착 list 노출.
   const {
     context: transferContext,


### PR DESCRIPTION
Closes #1659

## 변경 개요

Strategy ① 6 fail mode 중 **Fail 1** (trainCode 오선택) + **Fail 3** (하차 후 lock 잔존) mitigation.

기존 가드 갭:
- `useMisBoardingDetector`: lock.trainCode가 positions에서 **아예 사라질 때** (Seoul API stale/지하 dead zone 포함) → Fail 1/3 미감지
- `lock.boardingLine` 가드: 다른 노선만 차단, **같은 노선 다른 trainCode는 통과**

→ 같은 노선에서 다른 trainCode가 90s 지속 관찰되는 mismatch 케이스 미처리.

## 구현

### `useTrainCodeMismatchDetector` (신규)

| 관찰 결과 | 처리 |
|---|---|
| lock.trainCode present | 카운터 reset, detected=false |
| trains 빈 배열 (Seoul API stale) | **no-signal** — 카운터 미증가 |
| lock.trainCode 없고 다른 trainCode 존재 | grace(60s) 후 카운터 증가 |
| 3 cycle(90s) 누적 | detected=true |
| lock 교체(boardedAt 변화) | 카운터 + detected reset, grace 재적용 |

`useMisBoardingDetector`와 비교:
- absent: lock.trainCode가 positions에서 사라짐 (API dead zone 포함)
- **mismatch: lock.trainCode 없고 다른 trainCode 실제로 존재** → 사용자가 다른 열차에 탑승

### `LockReleaseReason` 확장

`'train-code-mismatch'` 추가 — breadcrumb에 reason stamp.

### `HomeScreen` wire

```
lockLinePositions (공유, 추가 폴링 비용 없음)
  → useTrainCodeMismatchDetector
    → detected false→true:
        releaseLockWithReason('train-code-mismatch')
        MisBoardingReselectModal 표시 (재선택 UI 재사용)
```

## V/X 영향

| Acceptance | 이전 | 본 PR 머지 후 |
|---|---|---|
| **X1** 잘못된 station 알람 (trainCode 오선택) | ⚠️ 부분 | ✅ 90s 후 자동 정정 |
| **X3** stale lock (하차 후 lock 잔존) | ⚠️ 부분 | ✅ 90s mismatch 후 무효화 |
| **X9** 사용자 의도 외 fire | ⚠️ 부분 | ✅ 잘못된 lock 자동 release |

## Wire-completion 5단 체크

1. **Orphan 없음** — `npm run lint:orphan` pass. `useTrainCodeMismatchDetector`는 HomeScreen에서 import.
2. **V/X dashboard** — lock release reason='train-code-mismatch'가 breadcrumb에 stamp → Sentry/DebugModal에서 관측 가능.
3. **의존 PR** — N/A. 단독 device-side 변경.
4. **측정 plan** — Sentry breadcrumb `boarding/lock-release reason=train-code-mismatch` 발생 횟수를 1주 모니터링. 정상 lock이 무효화되는 경우(false positive) alarm log 급증으로 확인.
5. **Device verify** — 실기기 시나리오: BoardingTrainList에서 잘못된 열차 탭 후 90s 대기 → MisBoardingReselectModal 자동 표시 + lock 무효화 확인. 에이전트 검증 범위: type-check + unit 100%.

## 트레이드오프 처리

| Trade-off | Mitigation |
|---|---|
| Seoul API stale → false invalidate | trains 빈 배열 = no-signal (카운터 미증가) |
| lock 생성 직후 race | grace 60s 가드 |
| 환승 leg 전환 후 race | boardedAt 변화 → 카운터 + grace reset |
| lockless trip 영향 없음 | lock=null 시 hook skip |