### PR TITLE
fix(#1656): phase↔phase cross-station dedup — leg 전환 race 차단

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -85,6 +85,7 @@ const mockLogSuppressedOriginHopLockless = jest.fn();
 const mockLogSuppressedPassedEventOnLockOrigin = jest.fn();
 const mockLogSuppressedCrossCategoryDedup = jest.fn();
 const mockLogSuppressedCrossCategoryRecent = jest.fn();
+const mockLogSuppressedPhaseToPhaseDedup = jest.fn();
 const mockLogSuppressedSsotFireGate = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
@@ -114,6 +115,8 @@ jest.mock('../../utils/alarmLog', () => ({
     mockLogSuppressedCrossCategoryDedup(...args),
   logSuppressedCrossCategoryRecent: (...args: unknown[]) =>
     mockLogSuppressedCrossCategoryRecent(...args),
+  logSuppressedPhaseToPhaseDedup: (...args: unknown[]) =>
+    mockLogSuppressedPhaseToPhaseDedup(...args),
   logSuppressedSsotFireGate: (...args: unknown[]) =>
     mockLogSuppressedSsotFireGate(...args),
 }));
@@ -705,6 +708,31 @@ describe('useStationAlarm', () => {
       }),
     );
     expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+  });
+
+  it('#1656 phase↔phase dedup — 직전 3s 안 다른 station에서 phase fire됐다면 phase 알람 차단', async () => {
+    // 어대 12:32 시나리오: "곧 건대"(transfer imminent) 직후 "성수 도착"(destination) 차단.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const dedup = require('../../utils/crossCategoryStationDedup');
+    const route = makeDirectRoute(1, '2');
+    // 직전 다른 station(건대)에서 transfer phase fire를 시뮬레이션.
+    dedup.markStationFired(destination.id, '건대', 'transfer', Date.now());
+    // destination phase 알람(성수=earlyDest.stationName, 다른 station) 발사 시도.
+    mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+    renderHook(() =>
+      useStationAlarm(
+        defaultInputs({ route, destination, userLocation: { lat: 37.4, lng: 127 }, speedMps: 5 }),
+      ),
+    );
+    await waitFor(() =>
+      expect(mockLogSuppressedPhaseToPhaseDedup).toHaveBeenCalledWith({
+        source: 'fg',
+        stationName: earlyDest.stationName,
+        kind: 'destination',
+        phaseId: 'early',
+      }),
+    );
+    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
   });
 
   it('destination 변경 시 새 destinationId로 re-hydrate 한다 (#462 destination scoped)', async () => {

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -41,6 +41,7 @@ import {
   logRefMismatch,
   logSuppressedCrossCategoryDedup,
   logSuppressedCrossCategoryRecent,
+  logSuppressedPhaseToPhaseDedup,
   logSuppressedDedupAlarm,
   logSuppressedDedupStation,
   logSuppressedDismissSilence,
@@ -59,6 +60,7 @@ import {
 import { evaluateSsotFireGate } from '../utils/ssotFireGate';
 import {
   isStationRecentlyFired,
+  isPhaseToPhaseCrossStationRecentlyFired,
   isTripScopedCrossCategoryRecentlyFired,
   markStationFired,
 } from '../utils/crossCategoryStationDedup';
@@ -686,8 +688,7 @@ export function useStationAlarm({
     // #1643 — trip-scoped cross-category + cross-station 즉시 cascade(5s 윈도우). 같은 trip에 직전
     // 5s 안에 **다른 station에서 station-passed** fire가 있었다면 phase 알람 차단. 2026-06-20 12:31
     // 어대 "군자 도착"(SP) → "곧 성수 도착"(D imminent) 회귀 차단. 같은 station 진행(early→imminent)은
-    // 통과 — firedAlarms set이 그 dedup을 담당. same-category(phase→phase) cross-station도 통과 —
-    // 별도 leg 진행 보존(case 2 어대 "곧 건대"+"성수 도착"은 currentLine 게이트가 잡아야 함).
+    // 통과 — firedAlarms set이 그 dedup을 담당.
     // firedAlarmsRef는 sleep/CC dedup와 동일 패턴 (storage 영속화 skip — net-zero).
     if (
       isTripScopedCrossCategoryRecentlyFired(
@@ -699,6 +700,29 @@ export function useStationAlarm({
     ) {
       firedAlarmsRef.current.delete(key);
       logSuppressedCrossCategoryRecent({
+        source: 'fg',
+        stationName: rawEvent.stationName,
+        kind: rawEvent.type,
+        phaseId: rawEvent.phaseId,
+      });
+      return;
+    }
+    // #1656 — phase↔phase cross-station 즉시 cascade(3s 윈도우). 같은 trip에 직전 3s 안에 **다른
+    // station에서 phase(transfer/destination) fire**가 있었다면 차단. leg 전환 race에서 옛 leg +
+    // 새 leg phase가 동시 fire되는 회귀 차단:
+    //   - 2026-06-20 12:32 어대: "곧 건대"(transfer imminent) + "성수 도착"(destination)
+    //   - 2026-06-19 15:37 BG: "곧 이수"(destination imminent) + "다음 역 사당"(transfer)
+    // firedAlarmsRef.current.delete(key) — 나중 발사가 차단되므로 진입부 add를 복구.
+    if (
+      isPhaseToPhaseCrossStationRecentlyFired(
+        activeDestination.id,
+        rawEvent.stationName,
+        rawEvent.type,
+        Date.now(),
+      )
+    ) {
+      firedAlarmsRef.current.delete(key);
+      logSuppressedPhaseToPhaseDedup({
         source: 'fg',
         stationName: rawEvent.stationName,
         kind: rawEvent.type,

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -31,6 +31,7 @@ import {
   FLUSH_MAX_DELAY_MS,
   logSuppressedCrossCategoryDedup,
   logSuppressedCrossCategoryRecent,
+  logSuppressedPhaseToPhaseDedup,
   logSuppressedDedupStation,
   logSuppressedDismissSilence,
   logSuppressedSleepFirstTransfer,
@@ -588,6 +589,36 @@ describe('alarmLog', () => {
       const saved: AlarmLogEntry[] = JSON.parse(lastJson);
       const recent = saved.filter((e) => e.reason === 'dedup-cross-category-recent');
       expect(recent).toHaveLength(1);
+    });
+
+    it('#1656 logSuppressedPhaseToPhaseDedup: reason=dedup-phase-to-phase + kind/phase 보존', async () => {
+      _resetBurstSuppressWindowForTests();
+      logSuppressedPhaseToPhaseDedup({
+        source: 'fg',
+        stationName: '성수',
+        kind: 'destination',
+        phaseId: 'imminent',
+      });
+      await expectLastSavedEntryMatches({
+        source: 'fg',
+        outcome: 'suppressed',
+        reason: 'dedup-phase-to-phase',
+        stationName: '성수',
+        kind: 'destination',
+        phaseId: 'imminent',
+      });
+    });
+
+    it('#1656 logSuppressedPhaseToPhaseDedup: 윈도우 내 같은 stationName 재호출은 drop', async () => {
+      _resetBurstSuppressWindowForTests();
+      logSuppressedPhaseToPhaseDedup({ source: 'fg', stationName: '성수', kind: 'destination' });
+      logSuppressedPhaseToPhaseDedup({ source: 'bg', stationName: '성수', kind: 'transfer' });
+      await flushAlarmLog();
+      const calls = (AsyncStorage.setItem as jest.Mock).mock.calls;
+      const lastJson = calls[calls.length - 1][1];
+      const saved: AlarmLogEntry[] = JSON.parse(lastJson);
+      const p2p = saved.filter((e) => e.reason === 'dedup-phase-to-phase');
+      expect(p2p).toHaveLength(1);
     });
 
     it('logSuppressedDedupAlarm: reason=dedup-alarm, phase+type+stationName 적재 (#580)', async () => {

--- a/src/features/alarm/utils/__tests__/crossCategoryStationDedup.test.ts
+++ b/src/features/alarm/utils/__tests__/crossCategoryStationDedup.test.ts
@@ -1,9 +1,11 @@
 import {
   CROSS_CATEGORY_DEDUP_WINDOW_MS,
+  PHASE_TO_PHASE_CROSS_STATION_WINDOW_MS,
   TRIP_SCOPED_CROSS_CATEGORY_WINDOW_MS,
   _resetCrossCategoryDedupForTests,
   clearCrossCategoryDedup,
   isStationRecentlyFired,
+  isPhaseToPhaseCrossStationRecentlyFired,
   isTripScopedCrossCategoryRecentlyFired,
   markStationFired,
 } from '../crossCategoryStationDedup';
@@ -131,8 +133,10 @@ describe('crossCategoryStationDedup (#1515)', () => {
 
       // ── 통과 (cross-station + same-category, 정상 trip 진행 보존) ──
       ['역삼', 'station-passed', '선릉', 'station-passed', false, 'cross-station + SP→SP NOT blocked (정상 trip 폴링 station 변경)'],
-      ['건대', 'transfer', '성수', 'destination', false, 'cross-station + phase→phase NOT blocked (별도 leg 진행, currentLine 게이트가 담당)'],
-      ['이수', 'destination', '사당', 'transfer', false, 'cross-station + phase→phase NOT blocked (별도 leg)'],
+      // phase→phase cross-station은 isPhaseToPhaseCrossStationRecentlyFired(3s 윈도우)가 별도 담당.
+      // isTripScopedCrossCategoryRecentlyFired는 SP↔phase 그룹만 차단 — phase→phase는 통과.
+      ['건대', 'transfer', '성수', 'destination', false, 'cross-station + phase→phase NOT blocked (isPhaseToPhaseCrossStationRecentlyFired 담당)'],
+      ['이수', 'destination', '사당', 'transfer', false, 'cross-station + phase→phase NOT blocked (isPhaseToPhaseCrossStationRecentlyFired 담당)'],
     ])(
       '(%s, %s) → (%s, %s) within trip window: blocked=%s (%s)',
       (firstSt, firstCat, secondSt, secondCat, blocked) => {
@@ -204,6 +208,88 @@ describe('crossCategoryStationDedup (#1515)', () => {
       expect(isTripScopedCrossCategoryRecentlyFired('dest-1', '성수', 'destination', 1_500)).toBe(true);
       _resetCrossCategoryDedupForTests();
       expect(isTripScopedCrossCategoryRecentlyFired('dest-1', '성수', 'destination', 1_500)).toBe(false);
+    });
+  });
+
+  // #1656 — phase↔phase cross-station cascade window (3s).
+  // 차단 조건: (1) 다른 stationName + (2) 양쪽 모두 phase(destination/transfer). 둘 다 만족해야 차단.
+  // station-passed 포함 케이스는 isTripScopedCrossCategoryRecentlyFired / isStationRecentlyFired 담당.
+  describe('isPhaseToPhaseCrossStationRecentlyFired (#1656)', () => {
+    it('returns false when no fire has been recorded', () => {
+      expect(isPhaseToPhaseCrossStationRecentlyFired('dest-1', '건대', 'destination', 1_000)).toBe(false);
+    });
+
+    // (firstStation, firstCategory, secondStation, secondCategory, expectedBlocked, label)
+    it.each<[string, Category, string, Category, boolean, string]>([
+      // ── 차단 (cross-station + 양쪽 phase) ──
+      // 2026-06-20 12:32 어대: "곧 건대 도착"(transfer) + "성수 도착"(destination)
+      ['건대', 'transfer', '성수', 'destination', true, 'transfer→destination cross-station blocked (어대 12:32 evidence)'],
+      // 2026-06-19 15:37 BG: "곧 이수"(destination imminent) + "다음 역 사당"(transfer)
+      ['이수', 'destination', '사당', 'transfer', true, 'destination→transfer cross-station blocked (15:37 evidence)'],
+      // 역방향도 차단
+      ['성수', 'destination', '건대', 'transfer', true, 'destination→transfer cross-station blocked'],
+      ['사당', 'transfer', '이수', 'destination', true, 'transfer→destination cross-station blocked'],
+
+      // ── 통과 (same station 진행, firedAlarms set이 dedup) ──
+      ['건대', 'transfer', '건대', 'destination', false, 'same station: NOT blocked (early→imminent on same station)'],
+      ['성수', 'destination', '성수', 'destination', false, 'same station same-cat: NOT blocked'],
+      ['이수(부속)', 'destination', '이수', 'transfer', false, 'same station normalized: NOT blocked'],
+
+      // ── 통과 (station-passed 포함, 다른 함수가 담당) ──
+      ['군자', 'station-passed', '성수', 'destination', false, 'station-passed as prev: NOT blocked (isTripScoped 담당)'],
+      ['성수', 'destination', '왕십리', 'station-passed', false, 'station-passed as current: NOT blocked (isTripScoped 담당)'],
+      ['역삼', 'station-passed', '선릉', 'station-passed', false, 'SP→SP: NOT blocked'],
+    ])(
+      '(%s, %s) → (%s, %s) within 3s window: blocked=%s (%s)',
+      (firstSt, firstCat, secondSt, secondCat, blocked) => {
+        markStationFired('dest-1', firstSt, firstCat, 10_000);
+        expect(isPhaseToPhaseCrossStationRecentlyFired('dest-1', secondSt, secondCat, 10_500)).toBe(blocked);
+      },
+    );
+
+    it('returns false once the 3s window has elapsed', () => {
+      markStationFired('dest-1', '건대', 'transfer', 1_000);
+      expect(
+        isPhaseToPhaseCrossStationRecentlyFired(
+          'dest-1',
+          '성수',
+          'destination',
+          1_000 + PHASE_TO_PHASE_CROSS_STATION_WINDOW_MS,
+        ),
+      ).toBe(false);
+    });
+
+    it('blocks within 3s window then allows after window (normal leg progression)', () => {
+      // leg 전환 즉시 cascade는 차단.
+      markStationFired('dest-1', '건대', 'transfer', 1_000);
+      expect(isPhaseToPhaseCrossStationRecentlyFired('dest-1', '성수', 'destination', 1_500)).toBe(true);
+      // 3s 이후엔 통과 (정상 다음 hop fire 보존).
+      expect(isPhaseToPhaseCrossStationRecentlyFired('dest-1', '성수', 'destination', 4_500)).toBe(false);
+    });
+
+    it('isolates entries by destinationId', () => {
+      markStationFired('dest-1', '건대', 'transfer', 1_000);
+      expect(isPhaseToPhaseCrossStationRecentlyFired('dest-2', '성수', 'destination', 1_500)).toBe(false);
+    });
+
+    it('accepts custom window override', () => {
+      markStationFired('dest-1', '건대', 'transfer', 1_000);
+      expect(isPhaseToPhaseCrossStationRecentlyFired('dest-1', '성수', 'destination', 1_500, 100)).toBe(false);
+      expect(isPhaseToPhaseCrossStationRecentlyFired('dest-1', '성수', 'destination', 1_050, 100)).toBe(true);
+    });
+
+    it('clearCrossCategoryDedup also clears phase-to-phase fire records', async () => {
+      markStationFired('dest-1', '건대', 'transfer', 1_000);
+      expect(isPhaseToPhaseCrossStationRecentlyFired('dest-1', '성수', 'destination', 1_500)).toBe(true);
+      await clearCrossCategoryDedup();
+      expect(isPhaseToPhaseCrossStationRecentlyFired('dest-1', '성수', 'destination', 1_500)).toBe(false);
+    });
+
+    it('_resetCrossCategoryDedupForTests also clears phase-to-phase fire records', () => {
+      markStationFired('dest-1', '건대', 'transfer', 1_000);
+      expect(isPhaseToPhaseCrossStationRecentlyFired('dest-1', '성수', 'destination', 1_500)).toBe(true);
+      _resetCrossCategoryDedupForTests();
+      expect(isPhaseToPhaseCrossStationRecentlyFired('dest-1', '성수', 'destination', 1_500)).toBe(false);
     });
   });
 });

--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -78,6 +78,7 @@ const mockLogSuppressedSleepStationPassed = jest.fn();
 const mockLogSuppressedDismissSilence = jest.fn();
 const mockLogSuppressedCrossCategoryDedup = jest.fn();
 const mockLogSuppressedCrossCategoryRecent = jest.fn();
+const mockLogSuppressedPhaseToPhaseDedup = jest.fn();
 jest.mock('../alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
   logFiredStationPassed: (...args: unknown[]) => mockLogFiredStationPassed(...args),
@@ -92,6 +93,8 @@ jest.mock('../alarmLog', () => ({
     mockLogSuppressedCrossCategoryDedup(...args),
   logSuppressedCrossCategoryRecent: (...args: unknown[]) =>
     mockLogSuppressedCrossCategoryRecent(...args),
+  logSuppressedPhaseToPhaseDedup: (...args: unknown[]) =>
+    mockLogSuppressedPhaseToPhaseDedup(...args),
 }));
 
 import { processLocationUpdate, resolveNextTarget } from '../stationPipeline';
@@ -958,6 +961,68 @@ describe('processLocationUpdate', () => {
         kind: 'station-passed',
       });
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  // #1656 — phase↔phase cross-station 즉시 cascade dedup (BG path).
+  // 2026-06-20 12:32 어대 "곧 건대"(transfer) + "성수 도착"(destination) 회귀 차단.
+  describe('#1656 phase↔phase cross-station cascade dedup (BG path)', () => {
+    const transferStation: Station = { ...mockStation, name: '건대', id: 'station-transfer' };
+    const destStation: Station = { ...mockStation, name: '성수', id: 'station-dest' };
+
+    beforeEach(() => {
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockIsStationOnRoute.mockReturnValue(false);
+    });
+
+    it('transfer phase 발사(건대) 후 3s 안 destination phase(성수=다른 station)는 phase↔phase dedup으로 차단', async () => {
+      // 1st: 건대 transfer phase 발사.
+      mockFindNearestStation.mockReturnValue({ station: transferStation, distanceKm: 0.05 });
+      mockEvaluateAlarmPhase.mockReturnValueOnce({
+        phaseId: 'imminent',
+        type: 'transfer',
+        stationName: transferStation.name,
+      });
+      await call({ source: 'bg' });
+      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+
+      // 2nd: 성수(다른 station) destination phase — 3s 안 phase→phase cross-station → 차단.
+      mockFindNearestStation.mockReturnValue({ station: destStation, distanceKm: 0.05 });
+      mockEvaluateAlarmPhase.mockReturnValueOnce({
+        phaseId: 'early',
+        type: 'destination',
+        stationName: destStation.name,
+      });
+      await call({ source: 'bg' });
+      expect(mockLogSuppressedPhaseToPhaseDedup).toHaveBeenCalledWith({
+        source: 'bg',
+        stationName: destStation.name,
+        kind: 'destination',
+        phaseId: 'early',
+      });
+      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1); // 추가 발사 없음
+    });
+
+    it('같은 station 진행(건대 transfer → 건대 destination early→imminent)은 차단하지 않음', async () => {
+      // 1st: 건대 transfer imminent 발사.
+      mockFindNearestStation.mockReturnValue({ station: transferStation, distanceKm: 0.05 });
+      mockEvaluateAlarmPhase.mockReturnValueOnce({
+        phaseId: 'imminent',
+        type: 'transfer',
+        stationName: transferStation.name,
+      });
+      await call({ source: 'bg' });
+      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+
+      // 2nd: 같은 station(건대) destination — same station이라 통과.
+      mockEvaluateAlarmPhase.mockReturnValueOnce({
+        phaseId: 'early',
+        type: 'destination',
+        stationName: transferStation.name, // 건대 = 같은 station
+      });
+      await call({ source: 'bg' });
+      // phase↔phase dedup은 발동 안 됨 — same station은 firedAlarms가 담당.
+      expect(mockLogSuppressedPhaseToPhaseDedup).not.toHaveBeenCalled();
     });
   });
 

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -223,7 +223,11 @@ export type AlarmLogReason =
   // 안에서 phase ↔ station-passed가 다른 station에 즉시 cascade로 발사되는 회귀 차단(2026-06-19
   // 15:37 이수-사당, 2026-06-20 12:31 어대-군자-성수). 기존 'dedup-station-unified'(같은 station 30s
   // 윈도우)와 분리해 trip-scoped cross-station cascade를 독립 카운트.
-  | 'dedup-cross-category-recent';
+  | 'dedup-cross-category-recent'
+  // #1656 — phase↔phase cross-station 즉시 cascade 윈도우(PHASE_TO_PHASE_CROSS_STATION_WINDOW_MS=3s)
+  // 안에서 다른 station에 두 phase 알람(transfer + destination 또는 역방향)이 leg 전환 race로
+  // 연이어 발사되는 회귀 차단(2026-06-20 12:32 건대+성수, 2026-06-19 15:37 이수+사당).
+  | 'dedup-phase-to-phase';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -401,6 +405,31 @@ export function logSuppressedCrossCategoryRecent(input: {
     source: input.source,
     outcome: 'suppressed',
     reason: 'dedup-cross-category-recent',
+    stationName: input.stationName,
+    kind: input.kind,
+    phaseId: input.phaseId,
+  });
+}
+
+/**
+ * #1656 — phase↔phase cross-station cascade 차단 suppression 로그.
+ * 같은 trip 안에서 다른 station에 transfer/destination phase가 3s 안에 연이어 fire될 때 차단.
+ * 2026-06-20 12:32 어대 "곧 건대"+성수 도착 / 2026-06-19 15:37 이수+사당 회귀.
+ *
+ * burst dedup 윈도우로 같은 (source, stationName) 반복 로그는 1건만 적재.
+ */
+export function logSuppressedPhaseToPhaseDedup(input: {
+  source: AlarmLogSource;
+  stationName: string;
+  kind: AlarmLogKind;
+  phaseId?: AlarmPhaseId;
+}): void {
+  if (isBurstDuplicate('dedup-phase-to-phase', input.stationName)) return;
+  appendAlarmLog({
+    ts: Date.now(),
+    source: input.source,
+    outcome: 'suppressed',
+    reason: 'dedup-phase-to-phase',
     stationName: input.stationName,
     kind: input.kind,
     phaseId: input.phaseId,

--- a/src/features/alarm/utils/crossCategoryStationDedup.ts
+++ b/src/features/alarm/utils/crossCategoryStationDedup.ts
@@ -56,6 +56,22 @@ export const CROSS_CATEGORY_DEDUP_WINDOW_MS = 30_000;
  */
 export const TRIP_SCOPED_CROSS_CATEGORY_WINDOW_MS = 5_000;
 
+/**
+ * #1656 — phase↔phase cross-station 즉시 cascade 윈도우.
+ *
+ * 같은 trip(destinationId) 안에서 **다른 station + 양쪽 phase 카테고리(transfer/destination)**가 같은
+ * cycle/leg 전환 race로 연이어 발사되는 회귀를 차단한다:
+ *   - 2026-06-20 12:32 어대 "곧 건대 도착"(transfer imminent, line 7) + "성수 도착"(destination, line 2)
+ *   - 2026-06-19 15:37 BG "곧 이수 도착"(destination imminent, line 4) + "다음 역 사당 하차"(transfer, line 4→2)
+ *
+ * `TRIP_SCOPED_CROSS_CATEGORY_WINDOW_MS`(5s, SP↔phase) 보다 좁은 3s 윈도우 — phase→phase 정상 leg 진행
+ * (환승 직후 새 leg의 early phase 즉시 fire 등)을 보존하기 위해 더 좁게 잡는다. 같은 cycle 즉시 cascade
+ * (< 1s)만 차단하면 충분.
+ *
+ * ADR-010 첫 줄(false positive ↔ miss 동급) 정합 — window를 좁게 두어 miss 위험 최소화.
+ */
+export const PHASE_TO_PHASE_CROSS_STATION_WINDOW_MS = 3_000;
+
 /** Map 무한 성장 cap. 정상 trip(역 수 ~수십) × destination ~수 = ≤ 수백. cap 도달 시 만료 일괄 정리. */
 const DEDUP_MAP_CAP = 256;
 
@@ -191,7 +207,7 @@ export function markStationFired(
  * 차단하지 않는 케이스 (정상 동작 보존):
  *   - **같은 station 진행** (early→imminent): per-station dedup(`isStationRecentlyFired`)이 담당.
  *   - **same-category cross-station**: station-passed→station-passed (정상 trip 폴링 station 변경),
- *     phase→phase (별도 leg/waypoint 진행). 본 PR 범위 외 — followup 이슈로 분리.
+ *     phase→phase (`isPhaseToPhaseCrossStationRecentlyFired`가 3s 윈도우로 별도 차단).
  *
  * 윈도우(5s, TRIP_SCOPED_CROSS_CATEGORY_WINDOW_MS)는 사용자 체감 cascade(< 1s)만 차단하고
  * 정상 진행(30s cycle 다음 hop fire)은 통과시키도록 좁게 설정.
@@ -212,6 +228,50 @@ export function isTripScopedCrossCategoryRecentlyFired(
   if (rec.stationName === normalizeStationName(stationName)) return false;
   // 같은 그룹(phase↔phase or SP→SP) cross-station은 통과 — 정상 trip 진행 보존.
   return isCategoryGroupChange(rec.category, category);
+}
+
+/**
+ * #1656 — phase↔phase cross-station 즉시 cascade가 짧은 윈도우 내에 발생했는지 확인.
+ *
+ * 같은 trip(destinationId)에 직전 fire가 본 query와:
+ *   1) **다른 station** (stationName 비교, normalize 후)
+ *   2) **양쪽 모두 phase** (destination 또는 transfer; station-passed 제외)
+ * 두 조건을 모두 만족하면 차단.
+ *
+ * trip evidence 회귀:
+ *   - 2026-06-20 12:32 어대: "곧 건대 도착"(transfer imminent) + "성수 도착"(destination)
+ *     ← leg 전환 race에서 옛 leg(2호선→건대입구 imminent) + 새 leg(7호선→성수 도착) 동시 fire
+ *   - 2026-06-19 15:37 BG: "곧 이수 도착"(destination imminent) + "다음 역 사당 하차"(transfer)
+ *     ← 동일 race 패턴, BG path
+ *
+ * 차단하지 않는 케이스 (정상 동작 보존):
+ *   - **같은 station 진행** (early→imminent on same station): per-station firedAlarms가 dedup.
+ *   - **station-passed 포함**: `isTripScopedCrossCategoryRecentlyFired`(5s) 또는
+ *     `isStationRecentlyFired`(30s)가 커버.
+ *
+ * 윈도우(3s, PHASE_TO_PHASE_CROSS_STATION_WINDOW_MS)는 SP↔phase 5s보다 좁음 — leg 전환 직후
+ * 새 leg의 early phase가 즉시 fire돼야 정상인 케이스를 보존하기 위해 더 좁게 잡는다.
+ *
+ * fire 직전 호출 — true면 호출자는 발사 skip + 'dedup-phase-to-phase' 로그.
+ */
+export function isPhaseToPhaseCrossStationRecentlyFired(
+  destinationId: string,
+  stationName: string,
+  category: FireCategory,
+  now: number,
+  windowMs: number = PHASE_TO_PHASE_CROSS_STATION_WINDOW_MS,
+): boolean {
+  // station-passed는 본 함수가 담당하는 phase↔phase 차단 대상이 아님.
+  if (category === 'station-passed') return false;
+  const rec = lastTripFire.get(destinationId);
+  if (rec === undefined) return false;
+  if (now - rec.ts >= windowMs) return false;
+  // 직전 fire가 station-passed면 본 함수 대상 아님(isTripScopedCrossCategoryRecentlyFired 담당).
+  if (rec.category === 'station-passed') return false;
+  // 같은 station 진행(early→imminent on same station)은 통과 — firedAlarms set이 dedup.
+  if (rec.stationName === normalizeStationName(stationName)) return false;
+  // 여기까지 오면: 직전=phase, 현재=phase, 다른 station, 윈도우 안 → 차단.
+  return true;
 }
 
 /** 테스트 전용 — 모듈 상태 리셋. production 호출 금지. */

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -19,6 +19,7 @@ import {
   logFiredStationPassed,
   logSuppressedCrossCategoryDedup,
   logSuppressedCrossCategoryRecent,
+  logSuppressedPhaseToPhaseDedup,
   logSuppressedDedupAlarm,
   logSuppressedDedupStation,
   logSuppressedDismissSilence,
@@ -28,6 +29,7 @@ import {
 } from './alarmLog';
 import {
   isStationRecentlyFired,
+  isPhaseToPhaseCrossStationRecentlyFired,
   isTripScopedCrossCategoryRecentlyFired,
   markStationFired,
 } from './crossCategoryStationDedup';
@@ -332,9 +334,26 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
       // #1643 — trip-scoped cross-category + cross-station 즉시 cascade. 같은 trip에 직전 5s 안에
       // **다른 station에서 cross-category(SP↔phase)** fire가 있었다면 phase 알람 차단. 2026-06-20
       // 12:31 어대 "군자 도착"(SP) + "곧 성수 도착"(D imminent) 회귀 차단. 같은 station 진행
-      // (early→imminent)은 통과 — per-station dedup이 담당. same-category cross-station은 통과 —
-      // 정상 trip 진행 보존.
+      // (early→imminent)은 통과 — per-station dedup이 담당.
       logSuppressedCrossCategoryRecent({
+        source,
+        stationName: alarmEvent.stationName,
+        kind: alarmEvent.type,
+        phaseId: alarmEvent.phaseId,
+      });
+    } else if (
+      isPhaseToPhaseCrossStationRecentlyFired(
+        destination.id,
+        alarmEvent.stationName,
+        alarmEvent.type,
+        Date.now(),
+      )
+    ) {
+      // #1656 — phase↔phase cross-station 즉시 cascade(3s 윈도우). 같은 trip에 직전 3s 안에 다른
+      // station에서 phase(transfer/destination) fire가 있었다면 차단. leg 전환 race 회귀:
+      //   - 2026-06-20 12:32 어대: "곧 건대"(transfer) + "성수 도착"(destination)
+      //   - 2026-06-19 15:37 BG: "곧 이수"(destination) + "다음 역 사당"(transfer)
+      logSuppressedPhaseToPhaseDedup({
         source,
         stationName: alarmEvent.stationName,
         kind: alarmEvent.type,


### PR DESCRIPTION
Closes #1656

## 요약

leg 전환 race에서 옛 leg의 phase 알람 + 새 leg의 phase 알람이 3s 안에 동시 발사되는 회귀(X2 잔여) 차단.

**Trip evidence:**
- 2026-06-20 12:32 어대: "곧 건대 도착"(transfer imminent) + "성수 도착"(destination) — 2호선→7호선 leg 전환 race
- 2026-06-19 15:37 BG: "곧 이수 도착"(destination imminent) + "다음 역 사당 하차"(transfer) — BG path 동일 패턴

**관련 이슈:** #1643 follow-up (PR #1653 머지). SP↔phase는 #1643이 5s 윈도우로 차단. 본 PR은 phase↔phase 3s 윈도우 추가.

## 변경 내용

| 파일 | 변경 |
|------|------|
| `crossCategoryStationDedup.ts` | `isPhaseToPhaseCrossStationRecentlyFired` 신규 함수 (3s 윈도우, `lastTripFire` 재사용) |
| `alarmLog.ts` | `dedup-phase-to-phase` reason + `logSuppressedPhaseToPhaseDedup` 헬퍼 |
| `useStationAlarm.ts` | `fireAndLog` — `isTripScopedCrossCategoryRecentlyFired` 체크 직후 추가 |
| `stationPipeline.ts` | BG phase 발사 분기 — `else if isPhaseToPhaseCrossStationRecentlyFired` 추가 |

## Wire Matrix

| 신호 | 변경 | 관측 |
|------|------|------|
| `dedup-phase-to-phase` alarmLog reason | FG `fireAndLog` + BG `processLocationUpdate` | DebugModal → Gates 섹션 |

## V/X 매핑

- **X2 phase↔phase cross-station** (legacy D4 follow-up): 3s 윈도우로 leg 전환 즉시 cascade 차단
- **정상 보존**: 같은 station early→imminent, SP 포함 케이스, 30s 이후 다음 hop — 모두 통과

## 트레이드오프

- **3s 윈도우 너무 좁으면** — 같은 cycle 즉시 cascade(< 1s)만 차단하면 충분. 정상 trip 30s cycle은 확실히 통과. 측정 후 조정 가능
- **3s 윈도우 너무 넓으면** — leg 전환 직후 새 leg의 valid early phase가 차단될 수 있음. 실기기 검증 필요

## 의존 PR

N/A — device-only frontend 변경.

## 측정 plan

1주 후 alarmLog `dedup-phase-to-phase` 건수 확인 (DebugModal Gates 섹션 또는 Sentry breadcrumb)
재발 조건: "곧 X 도착"(transfer) + "Y 도착"(destination) 동시 fire가 30s 안에 쌍으로 관측될 때

## Device verify

실기기 검증 필요 — 환승이 포함된 trip에서 환승역 접근 시 알람 1건만 발사되는지 확인.
시나리오: 2호선 → 7호선 환승 trip, 건대입구 접근 시 transfer 알람 1건만, 3s 내 성수 도착 알람 미발사.