### PR TITLE
fix(#1657): GPS-derived advance fast-path 지상 lock 활성 (PR #1646 보완)

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.gpsDerivedFastPath.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.gpsDerivedFastPath.test.ts
@@ -1,0 +1,328 @@
+/* eslint-disable import/no-restricted-paths -- cross-feature orchestration (#890) */
+
+/**
+ * #1657 — GPS-derived advance fast-path (지상 lock 활성 보완).
+ *
+ * PR #1646 보완 테스트 — 지상(subsurface===false) lock 활성 + GPS 신선 + 노선 정합 4-gate 합의.
+ *
+ * 시나리오:
+ *   1. 4-gate 모두 충족 → GPS-derived station 1순위 (backend mirror 무시).
+ *   2. GPS stale(accuracy > 50m) → 게이트 실패 → 기존 cascade(backend-ssot) 채택.
+ *   3. GPS fix age 초과(> 30s) → 게이트 실패 → 기존 cascade.
+ *   4. 지하(subsurface === true) → 게이트 실패 → PR #1646 경로(positionTrain 분기) 또는 기존 cascade.
+ *   5. lockless trip(boardingLock=null) → 게이트 실패 → 기존 cascade.
+ *   6. 노선 불일치(candidates[0].line !== boardingLine) → 게이트 실패 → 기존 cascade.
+ *   7. 노선 정합이지만 100m 초과 → 게이트 실패 → 기존 cascade.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useFusedNearestStation } from '../useFusedNearestStation';
+import { useNearestStation } from '../useNearestStation';
+import { useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
+import { useTrainPositions } from '../../../route/hooks/useTrainPositions';
+import { findTopNearestStations } from '../../utils/findNearestStation';
+import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute';
+import {
+  arrivalRet,
+  positionRet,
+  GPS_BASE_DEFAULTS,
+} from '../../../../testUtils/positionApiFixtures';
+import {
+  BACKEND_SSOT_FIXTURE_T0 as T0,
+  flushBackendSsotMirrorTick,
+  makeBackendSsotMirrorEntry,
+} from '../../../../testUtils/backendSsotMirrorFixtures';
+import { readBackendSsotMirror } from '../../../alarm/utils/backendSsotMirror';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+import {
+  GPS_DERIVED_ACCURACY_MAX_M,
+  GPS_DERIVED_FIX_MAX_AGE_MS,
+  GPS_DERIVED_ROUTE_MATCH_MAX_KM,
+} from '../../../../shared/constants/realtime';
+
+jest.mock('../../utils/findNearestStation', () => ({
+  findTopNearestStations: jest.fn(),
+}));
+jest.mock('../useNearestStation');
+jest.mock('../../../arrival/hooks/useArrivalInfo');
+jest.mock('../../../route/hooks/useTrainPositions');
+jest.mock('../../../alarm/utils/tripStartStorage', () => ({
+  getTripStartedAt: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../../../alarm/utils/backendSsotMirror', () => ({
+  readBackendSsotMirror: jest.fn(),
+}));
+
+const mockNearest = useNearestStation as jest.Mock;
+const mockArrival = useArrivalInfo as jest.Mock;
+const mockPos = useTrainPositions as jest.Mock;
+const mockFindTop = findTopNearestStations as jest.Mock;
+const mockRead = readBackendSsotMirror as jest.Mock;
+
+const hanyangdae = findStationByNameAndLine('한양대', '2')!;
+const ttukssom = findStationByNameAndLine('뚝섬', '2')!;
+// 2호선과 노선이 다른 역 — line mismatch 시나리오용 (7호선 역)
+const junggok7 = findStationByNameAndLine('중곡', '7')!;
+
+const lockOn2: BoardingLock = {
+  destinationId: 'dest-2',
+  trainCode: 'T-LOCK',
+  boardingLine: '2',
+  boardingStationId: hanyangdae.id,
+  boardedAt: T0,
+  expectedDurationMs: 10 * 60_000,
+};
+
+/**
+ * GPS를 stationName(2호선) + freshAge(ms) + accuracy(m) + distance(km)로 설정.
+ * lastFixAtMs = T0 - freshAge.
+ */
+function setupSurfaceGps({
+  station = hanyangdae,
+  accuracy = GPS_DERIVED_ACCURACY_MAX_M,
+  freshAgeMs = 0,
+  distanceKm = GPS_DERIVED_ROUTE_MATCH_MAX_KM - 0.001,
+}: {
+  station?: typeof hanyangdae;
+  accuracy?: number | null;
+  freshAgeMs?: number;
+  distanceKm?: number;
+} = {}) {
+  const live = { station, distanceKm };
+  mockNearest.mockReturnValue({
+    result: live,
+    liveResult: live,
+    stickyDisplayOnly: null,
+    variants: [station],
+    userLocation: { lat: station.lat, lng: station.lng },
+    ...GPS_BASE_DEFAULTS,
+    accuracyMeters: accuracy,
+    lastFixAtMs: T0 - freshAgeMs,
+    refresh: jest.fn(),
+  });
+  mockFindTop.mockReturnValue([{ station, distanceKm }]);
+  mockArrival.mockReturnValue(arrivalRet(null));
+  mockPos.mockReturnValue(positionRet(null));
+}
+
+describe('#1657 GPS-derived advance fast-path (지상 lock 활성)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(T0);
+    // 기본: backend mirror는 ttukssom(다른 역)으로 fresh하게 세팅 → gate 미충족 시 backend-ssot 채택 확인
+    mockRead.mockResolvedValue(
+      makeBackendSsotMirrorEntry({
+        currentStationId: ttukssom.name,
+        lastAdvanceAt: T0,
+        receivedAt: T0,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('4-gate 모두 충족 → GPS-derived station 1순위 (backend mirror 무시)', async () => {
+    // 한양대 GPS 신선(accuracy 50m, age 0s, distance 0.09km, 2호선 정합)
+    setupSurfaceGps({ station: hanyangdae, accuracy: GPS_DERIVED_ACCURACY_MAX_M, freshAgeMs: 0 });
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        lockOn2,
+        undefined,
+        { subsurface: false },
+      ),
+    );
+    await flushBackendSsotMirrorTick();
+    // backend mirror는 ttukssom이지만 GPS-derived fast-path가 1순위 → hanyangdae 채택
+    await waitFor(() => {
+      expect(hook.result.current.result?.station.id).toBe(hanyangdae.id);
+    });
+    // confidence는 gps-only (GPS 신호원), source는 gps
+    expect(hook.result.current.confidence).toBe('gps-only');
+    expect(hook.result.current.source).toBe('gps');
+  });
+
+  it('GPS accuracy > MAX → 게이트 실패 → backend-ssot 채택', async () => {
+    setupSurfaceGps({ accuracy: GPS_DERIVED_ACCURACY_MAX_M + 1 });
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        lockOn2,
+        undefined,
+        { subsurface: false },
+      ),
+    );
+    await flushBackendSsotMirrorTick();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+    expect(hook.result.current.result?.station.id).toBe(ttukssom.id);
+  });
+
+  it('GPS fix age > MAX(30s) → 게이트 실패 → backend-ssot 채택', async () => {
+    setupSurfaceGps({ freshAgeMs: GPS_DERIVED_FIX_MAX_AGE_MS + 1 });
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        lockOn2,
+        undefined,
+        { subsurface: false },
+      ),
+    );
+    await flushBackendSsotMirrorTick();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+    expect(hook.result.current.result?.station.id).toBe(ttukssom.id);
+  });
+
+  it('lastFixAtMs=null(GPS 미fix) → 게이트 실패 → backend-ssot 채택', async () => {
+    const live = { station: hanyangdae, distanceKm: 0.05 };
+    mockNearest.mockReturnValue({
+      result: live,
+      liveResult: live,
+      stickyDisplayOnly: null,
+      variants: [hanyangdae],
+      userLocation: { lat: hanyangdae.lat, lng: hanyangdae.lng },
+      ...GPS_BASE_DEFAULTS,
+      accuracyMeters: GPS_DERIVED_ACCURACY_MAX_M,
+      lastFixAtMs: null, // GPS fix 없음
+      refresh: jest.fn(),
+    });
+    mockFindTop.mockReturnValue([{ station: hanyangdae, distanceKm: 0.05 }]);
+    mockArrival.mockReturnValue(arrivalRet(null));
+    mockPos.mockReturnValue(positionRet(null));
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        lockOn2,
+        undefined,
+        { subsurface: false },
+      ),
+    );
+    await flushBackendSsotMirrorTick();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+  });
+
+  it('지하(subsurface=true) → 게이트 실패 → backend-ssot 채택', async () => {
+    setupSurfaceGps();
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        lockOn2,
+        undefined,
+        { subsurface: true }, // 지하
+      ),
+    );
+    await flushBackendSsotMirrorTick();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+  });
+
+  it('lockless trip(boardingLock=null) → 게이트 실패 → backend-ssot 채택', async () => {
+    setupSurfaceGps();
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        null, // boardingLock 없음
+        undefined,
+        { subsurface: false },
+      ),
+    );
+    await flushBackendSsotMirrorTick();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+  });
+
+  it('candidates[0] 노선 불일치(7호선) → 게이트 실패 → backend-ssot 채택', async () => {
+    // 7호선 중곡역이 candidates[0]가 되도록 설정 (lock은 2호선) → boardingLine mismatch
+    setupSurfaceGps({ station: junggok7, distanceKm: 0.05 });
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        lockOn2, // boardingLine: '2'
+        undefined,
+        { subsurface: false },
+      ),
+    );
+    await flushBackendSsotMirrorTick();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+  });
+
+  it('노선 정합이지만 distance > 100m → 게이트 실패 → backend-ssot 채택', async () => {
+    setupSurfaceGps({ distanceKm: GPS_DERIVED_ROUTE_MATCH_MAX_KM + 0.001 });
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        lockOn2,
+        undefined,
+        { subsurface: false },
+      ),
+    );
+    await flushBackendSsotMirrorTick();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+  });
+
+  it('subsurface=undefined(barometer 미전달) → 게이트 실패 → backend-ssot 채택', async () => {
+    setupSurfaceGps();
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        lockOn2,
+        undefined,
+        undefined, // barometer 미전달
+      ),
+    );
+    await flushBackendSsotMirrorTick();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+  });
+});

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -57,6 +57,9 @@ import { MAX_STATION_DISTANCE_KM } from '../../../shared/constants/location';
 import {
   BACKEND_SSOT_MIRROR_MAX_AGE_MS,
   DETECTION_FUSED_MAX_DISTANCE_KM,
+  GPS_DERIVED_ACCURACY_MAX_M,
+  GPS_DERIVED_FIX_MAX_AGE_MS,
+  GPS_DERIVED_ROUTE_MATCH_MAX_KM,
   MAX_ACTIVE_LINES,
   MAX_FUSION_DELTA_KM,
   MAX_FUSION_DISTANCE_KM,
@@ -885,6 +888,46 @@ export function useFusedNearestStation(
     barometerSubsurface === true &&
     boardingLock != null;
 
+  // #1657 — GPS-derived advance fast-path (지상 lock 활성 보완).
+  //
+  // PR #1646 보완 — 지상 lock 활성 + GPS 신선 케이스.
+  // 지상(subsurface===false)에서 GPS가 신선(accuracy ≤ 50m, age ≤ 30s)하면
+  // GPS-nearest station을 backend SSoT mirror보다 1순위로 채택.
+  // backend mirror 10-30s lag를 GPS 실시간 신호로 우회한다.
+  //
+  // 4-gate 3-of-3 합의 (false positive 방어 — ADR-010 두 실패 모드 동급):
+  //   1. boardingLock != null — 사용자 명시 의향 trip 한정 (lockless trip 미적용).
+  //   2. barometerSubsurface === false — 지상 환경 명시. 지하에서는 PR #1646이 담당.
+  //   3. GPS 신선 — accuracy ≤ GPS_DERIVED_ACCURACY_MAX_M(50m) AND fix age ≤ 30s.
+  //      stale GPS(lastFixAtMs === null)는 게이트 실패 → 기존 cascade.
+  //   4. 노선 정합 — candidates[0].station.line === boardingLock.boardingLine AND
+  //      candidates[0].distanceKm ≤ GPS_DERIVED_ROUTE_MATCH_MAX_KM(100m).
+  //      옆 노선 역 drift(GPS 정확도 한계로 인접 노선 역이 candidates[0]가 되는 케이스) 차단.
+  //
+  // candidates[0]는 GPS userLocation 기준 최근접 역(haversine 정렬, allowedLines 필터 적용).
+  // boardingLine 일치 + 100m 이내이면 GPS 좌표가 해당 역에 있다고 판단 가능.
+  //
+  // GPS 결정 권한 X 룰 정합 (memory/feedback_no_gps_for_decision.md):
+  //   - 지상(subsurface===false 명시)에서만 적용 — 지하 GPS는 WiFi/cell 삼각측량 fallback일
+  //     가능성이 높아 결정 권한 금지 룰 적용.
+  //   - 이 tier는 지상 open-sky GPS fix에서만 활성되므로 룰 위반 아님.
+  //
+  // 트레이드오프 완화:
+  //   - GPS drift false advance → accuracy 50m + boardingLine 정합 100m 이중 gate.
+  //   - 지상↔지하 환경 전환 race → subsurface false → cascade 진입 X (자연 fallback).
+  //   - 사용자 하차 후 lock 잔존 → useMisBoardingDetector 90s absent 가드 (별도 seam).
+  const gpsTopCandidate = candidates[0] ?? null;
+  const gpsDerivedFastPath =
+    boardingLock != null &&
+    barometerSubsurface === false &&
+    gps.accuracyMeters !== null &&
+    gps.accuracyMeters <= GPS_DERIVED_ACCURACY_MAX_M &&
+    gps.lastFixAtMs !== null &&
+    Date.now() - gps.lastFixAtMs <= GPS_DERIVED_FIX_MAX_AGE_MS &&
+    gpsTopCandidate !== null &&
+    gpsTopCandidate.station.line === boardingLock.boardingLine &&
+    gpsTopCandidate.distanceKm <= GPS_DERIVED_ROUTE_MATCH_MAX_KM;
+
   let result: NearestStationResult | null;
   let confidence: FusionConfidence;
   let source: FusionSource;
@@ -895,11 +938,19 @@ export function useFusedNearestStation(
     result = positionTrainResult!;
     confidence = 'boarding-lock';
     source = 'boarding-lock';
+  } else if (gpsDerivedFastPath) {
+    // #1657 — 지상 + GPS 신선 + 노선 정합 4-gate 합의 시 GPS-derived station 1순위.
+    // backend SSoT mirror lag(10-30s)를 지상 open-sky GPS 실시간 신호로 우회한다.
+    // candidates[0]는 이미 boardingLine + 100m 게이트를 통과 — gps-only와 달리 노선 정합 강화.
+    result = gpsTopCandidate!;
+    confidence = 'gps-only';
+    source = 'gps';
   } else if (backendSsotAccepts) {
     // #1568 (T8b) — backend SSoT 권위 mirror. backend advance 게이트가
     // ADR-017 6단(seed/repeat/motion-stop/cross-validation 등)을 이미 통과한 결과이므로
     // device-side cascade tier보다 신뢰도가 높다. lock 활성/lockless 모두 동일 우선순위.
     // #1646 — 3-of-3 합의(lock+지하+lockMatch) 시 positionTrain에 양보 (위 분기).
+    // #1657 — 지상 GPS 신선 합의 시 gpsDerivedFastPath에 양보 (위 분기).
     result = { station: ssotStation!, distanceKm: 0 };
     confidence = 'backend-ssot';
     source = 'backend-ssot';

--- a/src/shared/constants/realtime.ts
+++ b/src/shared/constants/realtime.ts
@@ -84,3 +84,20 @@ export const WIFI_SSID_MAX_DISTANCE_KM = 1.5;
  * fused 후보는 산출된다(거리만 fusedPasses 임계 0.6km를 넘김).
  */
 export const DETECTION_FUSED_MAX_DISTANCE_KM = 0.5;
+
+/**
+ * #1657 — GPS-derived advance fast-path (지상 lock 활성).
+ *
+ * GPS 신선도 게이트:
+ *   - accuracy ≤ GPS_DERIVED_ACCURACY_MAX_M: 지상 open-sky GPS fix. 50m는 기존
+ *     passesFusionDistanceGate strict 기준(50m)과 동일 — 불일관 차단.
+ *   - fix age ≤ GPS_DERIVED_FIX_MAX_AGE_MS: 30s 초과는 GPS가 stale해 cascade advance의
+ *     SSOT로 쓸 수 없다.
+ *
+ * 노선 정합 게이트:
+ *   - candidates[0].distanceKm ≤ GPS_DERIVED_ROUTE_MATCH_MAX_KM(100m): GPS 좌표가
+ *     boardingLine 위 역 100m 이내 — 옆 노선 station drift 차단.
+ */
+export const GPS_DERIVED_ACCURACY_MAX_M = 50;
+export const GPS_DERIVED_FIX_MAX_AGE_MS = 30_000;
+export const GPS_DERIVED_ROUTE_MATCH_MAX_KM = 0.1;


### PR DESCRIPTION
Closes #1657

## PR #1646 보완 관계

| PR | 케이스 | 1순위 tier |
|---|---|---|
| #1646 (머지됨) | lock + **지하**(subsurface=true) + lockMatch | positionTrain |
| **본 PR** | lock + **지상**(subsurface=false) + GPS 신선 + 노선 정합 | GPS-derived station |

두 PR 합쳐 V1 지하/지상 전 환경 커버.

## 사용자 trip evidence (2026-06-22)

- 14:30 한양대 도착 (지상) — 현재역 표시 lag. GPS 신선(accuracy ~14m)한데도 backend mirror advance 대기.
- 원인: backend SSoT mirror 1순위라 cron 5s + silent push 5-10s + APNs 처리 = 10-30s lag

## Root cause

`useFusedNearestStation.ts` cascade:
- PR #1646 이후: `positionTrainBoardingLockMatch` (lock+지하+lockMatch) → 1순위
- 잔여: lock + **지상** + GPS 신선 케이스 → 여전히 backend mirror 1순위

## Fix 설계

4-gate 합의 (`gpsDerivedFastPath`):
1. `boardingLock != null` — 사용자 명시 의향 trip 한정
2. `barometerSubsurface === false` — 지상 환경 명시
3. `gps.accuracyMeters ≤ 50m && gps.lastFixAtMs` age ≤ 30s — GPS 신선도
4. `candidates[0].station.line === boardingLock.boardingLine && candidates[0].distanceKm ≤ 100m` — 노선 정합

4-gate 모두 true → GPS-derived station 1순위. 미충족 → 기존 cascade 그대로.

## V/X 영향

| Acceptance | 현재 (지상) | 본 PR 머지 후 | Evidence |
|---|---|---|---|
| V1 정확한 현재역 표시 (지상) | ❌ 10-30s lag | ✅ GPS 즉시 advance | 6/22 14:30 한양대 |
| V6 위치 빠른 반영 ≤3s (지상) | ❌ 10-30s | ✅ ≤ 5s | 6/22 지상 구간 |
| X3 stale 알람 (지상) | ❌ fusion stuck | ✅ stale 차단 | 6/22 지상 알람 X |

## 트레이드오프 + Mitigation

| Trade-off | Mitigation |
|---|---|
| GPS drift false advance | accuracy 50m + boardingLine 정합 100m 이중 gate |
| 지상↔지하 환경 전환 race | subsurface===false 가드 — 전환 즉시 자연 fallback |
| 사용자 하차 후 lock 잔존 + GPS 신선 | useMisBoardingDetector 90s absent 가드 (별도 seam) |
| barometer 미지원 기기 | subsurface===false가 아닌 undefined → 게이트 실패 → 기존 cascade (graceful) |

## GPS 결정 권한 X 룰 정합 (memory/feedback_no_gps_for_decision.md)

- `barometerSubsurface === false` 명시 가드 필수
- 지하 GPS는 WiFi/cell 삼각측량 fallback 가능성 → 결정 권한 금지 룰 적용
- 본 tier는 지상 open-sky GPS fix에서만 활성 → 룰 위반 없음

## ADR 룰 정합

- ADR-010 false positive/miss 동급 — 4-gate 합의로 false fire 차단
- 사용자 명시 의향 trip = lock 활성 동급 정확도 (CLAUDE.md)
- 시간 적분 fire 권한 X — GPS는 실시간 신호

## Wire Matrix

| 케이스 | 결과 |
|---|---|
| A. lock + 지상 + GPS 신선 + 노선 정합 | gpsDerivedFastPath → GPS-derived 1순위 (신규) |
| B. lock + 지하 + lockMatch | PR #1646 positionTrainBoardingLockMatch → positionTrain 1순위 |
| C. lock + 지상 + GPS stale/부정확 | 기존 cascade (backend-ssot → wifi → positionTrain...) |
| D. lockless trip | gpsDerivedFastPath 미적용 → 기존 cascade |
| E. barometer 미전달 | subsurface=undefined → 게이트 실패 → 기존 cascade |

## Wire-completion 5단

1. **Orphan 없음**: 신규 export 없음 (cascade if문 추가). `npm run lint:orphan` pass — 0 orphans.
2. **V/X dashboard**: DebugModal `source='gps'` + `confidence='gps-only'` + `subsurface=false` 조합으로 gpsDerivedFastPath 채택 확인. `pushFusionDebugEntry` cascade decision buffer에 기록.
3. **의존 PR**: N/A — PR #1646이 이미 머지됨. useFusedNearestStation 내부 변경만.
4. **측정 plan**: 1주 사용자 trip의 DebugModal 캡처에서 지상 lock 활성 구간의 `source='gps'` + `confidence='gps-only'` 발화 비율 측정. 기존 `backend-ssot` 대비 advance 시점 lag 개선 확인.
5. **Device verify**: **필요** — 지상 lock 활성 trip 시나리오 1회 (역 도착 시 현재역 즉시 advance 확인). barometer subsurface=false는 native 신호.

## 변경 파일

- `src/features/nearest-station/hooks/useFusedNearestStation.ts` — cascade에 `gpsDerivedFastPath` 분기 추가 (1순위) + 상수 import
- `src/shared/constants/realtime.ts` — GPS_DERIVED_ACCURACY_MAX_M / GPS_DERIVED_FIX_MAX_AGE_MS / GPS_DERIVED_ROUTE_MATCH_MAX_KM 추가
- `src/features/nearest-station/hooks/__tests__/useFusedNearestStation.gpsDerivedFastPath.test.ts` — 9 케이스

## 테스트 결과

- `npm test`: 7428 tests pass, coverage 100%
- `npm run type-check`: 0 errors
- `npm run lint:orphan`: 0 orphans