### PR TITLE
fix(#1658): LA content-state 환승 시 새 leg.line 즉시 반영

### DIFF
--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -102,6 +102,58 @@ describe('buildLiveActivityContentState (#613)', () => {
     expect(cs).not.toHaveProperty('alarmType');
     expect(cs).not.toHaveProperty('alarmStationName');
   });
+
+  // #1658 — 환승역 waypoint 추적 시 다음 leg의 line을 LA에 즉시 반영 (60s lag 차단).
+  describe('transfer waypoint → new leg line forward (#1658)', () => {
+    /** 경의중앙선(K) → 2호선 환승 trip: 홍대입구(transfer, K) → 신촌(intermediate, 2) → 강남(dest, 2). */
+    function makeTransferTrip(): Trip {
+      return makeTrip({
+        waypoints: [
+          { stationName: '홍대입구', line: 'K', kind: 'transfer' },
+          { stationName: '신촌', line: '2', kind: 'intermediate' },
+          { stationName: '강남', line: '2', kind: 'destination' },
+        ],
+        route: { type: 'transfer', fromLine: 'K', toLine: '2', transferName: '홍대입구', stopsToTransfer: 1, stopsFromTransfer: 2 },
+      });
+    }
+
+    it('환승 waypoint + trip 전달 시 다음 leg line(2호선)을 lineName/lineColorHex에 사용', () => {
+      const transferWp: Waypoint = { stationName: '홍대입구', line: 'K', kind: 'transfer' };
+      const trip = makeTransferTrip();
+      const cs = buildLiveActivityContentState(transferWp, 30, 3, trip);
+      // 2호선 meta 사용 — waypoint.line='K' 아니라 trip.waypoints[1].line='2'를 기준으로 해야 함
+      expect(cs.lineName).toBe('2호선');
+      expect(cs.lineColorHex).toBe('#009D3E');
+      // stationName은 transfer station 이름 그대로 유지
+      expect(cs.stationName).toBe('홍대입구');
+    });
+
+    it('환승 waypoint이더라도 trip 미전달이면 waypoint.line으로 fallback (legacy 호환)', () => {
+      const transferWp: Waypoint = { stationName: '홍대입구', line: 'K', kind: 'transfer' };
+      const cs = buildLiveActivityContentState(transferWp, 30, 3);
+      // trip 없음 → waypoint.line='K' 사용, LINE_META['K'] 없으면 raw 코드 fallback
+      expect(cs.lineName).toBe('K');
+      expect(cs.lineColorHex).toBe('#888888');
+    });
+
+    it('환승 waypoint + trip.waypoints[1] 없음(마지막 waypoint)이면 waypoint.line fallback', () => {
+      const transferWp: Waypoint = { stationName: '홍대입구', line: 'K', kind: 'transfer' };
+      // waypoints에 transfer만 있고 그 다음이 없는 edge case
+      const trip = makeTrip({ waypoints: [transferWp] });
+      const cs = buildLiveActivityContentState(transferWp, 30, 1, trip);
+      // trip.waypoints.length === 1 (> 1 조건 불충족) → fallback to waypoint.line='K'
+      expect(cs.lineName).toBe('K');
+    });
+
+    it('non-transfer waypoint(intermediate/destination)는 영향 없음 (회귀 가드)', () => {
+      // intermediate: waypoint.line='2' 그대로 사용
+      const intermediateWp: Waypoint = { stationName: '신촌', line: '2', kind: 'intermediate' };
+      const trip = makeTransferTrip();
+      const cs = buildLiveActivityContentState(intermediateWp, 60, 2, trip);
+      expect(cs.lineName).toBe('2호선');
+      expect(cs.lineColorHex).toBe('#009D3E');
+    });
+  });
 });
 
 // #1618 R9-b — backend buildLiveActivityContentState multi-hop 필드 wipe 차단.

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -2630,6 +2630,117 @@ describe('runScheduled — Live Activity push integration (#586 D / #612)', () =
     const stored = JSON.parse((await kv.get('trip:la-tok')) as string) as Trip;
     expect(stored.lastLaPushEpoch).toBeUndefined();
   });
+
+  // #1658 — 환승 leg 전환 감지 + LA content-state 즉시 갱신 통합 테스트.
+  describe('transfer waypoint → LA shows new leg line (#1658)', () => {
+    /**
+     * 7호선(군자, transfer) → 5호선(아차산, destination) trip.
+     * boardingLock은 7호선으로 군자를 추적 중. LA token 활성.
+     * maybeFireLiveActivityUpdate 경로(reschedule + LA 동시 발사): estimate NOT arrived 상태에서
+     * 환승역 추적 중 LA push 시 content-state의 lineName이 새 leg(5호선)로 반영되는지 검증.
+     */
+    function makeTransferLaTrip(overrides: Partial<Trip> = {}): Trip {
+      return makeLockedLaTrip({
+        token: 'la-xfer-tok',
+        route: { type: 'transfer', fromLine: '7', toLine: '5', transferName: '군자', stopsToTransfer: 1, stopsFromTransfer: 1 },
+        waypoints: [
+          { stationName: '군자', line: '7', kind: 'transfer' },
+          { stationName: '아차산', line: '5', kind: 'destination' },
+        ],
+        boardingLock: {
+          trainCode: 'T',
+          line: '7',
+          subwayId: '1007',
+          selectedDepartureTime: NOW,
+          segmentStations: ['중곡', '군자'],
+          expiresAt: NOW + 60 * 60_000,
+        },
+        ...overrides,
+      });
+    }
+
+    /** 군자역 ETA 120s (NOT arrived) 응답 — maybeFireLiveActivityUpdate 경로(reschedule + LA). */
+    function makeTransferSeoul120(): SeoulArrivalClient {
+      return new SeoulArrivalClient({
+        apiKey: 'K',
+        host: 'h',
+        now: () => NOW,
+        fetchImpl: (async () =>
+          new Response(
+            JSON.stringify({
+              realtimeArrivalList: [
+                {
+                  barvlDt: '120',
+                  recptnDt: '',
+                  updnLine: '상행',
+                  trainLineNm: '군자',
+                  btrainNo: 'T',
+                  subwayNm: '지하철7호선',
+                  arvlCd: 5, // 미결 (not ENTERING/ARRIVED)
+                },
+              ],
+            }),
+            { status: 200 },
+          )) as unknown as typeof fetch,
+      });
+    }
+
+    it('환승 waypoint 추적 중 LA push content-state lineName이 새 leg(5호선)으로 갱신됨', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, makeTransferLaTrip());
+      const fetchImpl = makeOkFetch();
+      const stats = await runLaScheduled(kv, { seoul: makeTransferSeoul120(), fetchImpl });
+      // reschedule push(background) 1건 + LA update 1건 발사 기대
+      expect(stats.laPushSent).toBe(1);
+      const laCalls = getLaCalls(fetchImpl);
+      expect(laCalls).toHaveLength(1);
+      const contentState = parseLaBody(laCalls[0]).aps['content-state'] as Record<string, unknown>;
+      // #1658 — 환승 waypoint는 7호선이지만 다음 leg(아차산, 5호선)의 line을 LA에 즉시 노출
+      expect(contentState.lineName).toBe('5호선');
+      expect(contentState.lineColorHex).toBe('#996CAC');
+      // stationName은 transfer station(군자) 그대로 유지
+      expect(contentState.stationName).toBe('군자');
+    });
+
+    it('환승 waypoint 도착(ARRIVED) → advanceBoardingLockWaypoint LA update도 새 leg(5호선) 반영', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, makeTransferLaTrip());
+      const fetchImpl = makeOkFetch();
+      // 군자역 ARRIVED(arvlCd=1) → advanceBoardingLockWaypoint → 다음 waypoint=아차산(5호선)
+      await runLaScheduled(kv, {
+        seoul: new SeoulArrivalClient({
+          apiKey: 'K',
+          host: 'h',
+          now: () => NOW,
+          fetchImpl: (async () =>
+            new Response(
+              JSON.stringify({
+                realtimeArrivalList: [
+                  {
+                    barvlDt: '0',
+                    recptnDt: '',
+                    updnLine: '상행',
+                    trainLineNm: '군자',
+                    btrainNo: 'T',
+                    subwayNm: '지하철7호선',
+                    arvlCd: 1, // ARRIVED
+                  },
+                ],
+              }),
+              { status: 200 },
+            )) as unknown as typeof fetch,
+        }),
+        fetchImpl,
+      });
+      const laCalls = getLaCalls(fetchImpl);
+      // advanceBoardingLockWaypoint 직후 즉시 LA update 발사 (ETA 임계 무시)
+      expect(laCalls).toHaveLength(1);
+      const contentState = parseLaBody(laCalls[0]).aps['content-state'] as Record<string, unknown>;
+      // nextWaypoint = 아차산(5호선) → LA는 5호선 표시
+      expect(contentState.lineName).toBe('5호선');
+      expect(contentState.stationName).toBe('아차산');
+    });
+  });
 });
 
 // #1337 — server-side trip auto-end 경로에서 클라 state sync용 trip-ended alert push가 발사되는지.

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -84,6 +84,12 @@ export interface LiveActivityDeps {
  * stopsToTransfer / secondTransferStationName / stopsAfterLastTransfer / stopsToSecondTransfer /
  * stopsFromTransfer)를 함께 emit해 ActivityKit 전체 교체 후도 JS init이 채운 "전체 trip 여정"
  * UI가 유지된다. 누락 시 (legacy 호출) 기존 5 필드만 emit — 회귀 0 / backward compat.
+ *
+ * **환승 호선 forward (#1658)**: `waypoint.kind === 'transfer'`이고 `trip.waypoints[1]`이 존재하면
+ * 다음 leg의 line(`trip.waypoints[1].line`)을 `lineName`/`lineColorHex`로 사용한다.
+ * 환승역 waypoint는 현재 leg(경의중앙선 등)의 line을 갖지만, 사용자가 환승역에 도착하거나
+ * 도착 중인 시점에는 이미 새 호선(2호선 등)으로 탑승 준비 중이므로 새 leg의 호선을 즉시 노출한다.
+ * trip.waypoints는 매 advance마다 shifted SSOT라 race 없이 현재 시점을 정확히 반영한다.
  */
 export function buildLiveActivityContentState(
   waypoint: Waypoint,
@@ -91,12 +97,19 @@ export function buildLiveActivityContentState(
   stopsRemaining: number,
   trip?: Trip,
 ): LiveActivityContentState {
-  const meta = LINE_META[waypoint.line];
+  // #1658 — 환승 waypoint 추적 중에는 다음 leg의 line을 lineName/lineColorHex에 반영한다.
+  // waypoint.kind==='transfer' + trip.waypoints[1]이 존재하면 새 leg의 line을 우선 사용.
+  // trip이 없거나(legacy 호출) waypoints[1] 부재(직접 환승 도착)이면 waypoint.line으로 fallback.
+  const displayLine =
+    waypoint.kind === 'transfer' && trip !== undefined && trip.waypoints.length > 1
+      ? trip.waypoints[1].line
+      : waypoint.line;
+  const meta = LINE_META[displayLine];
   const base: LiveActivityContentState = {
     stationName: waypoint.stationName,
     // LINE_META는 13개 노선을 모두 커버하지만, stations.json에 없는 신규 line code가 들어와도
     // widget의 non-optional 필드가 비지 않도록 raw line code를 fallback으로 사용한다.
-    lineName: meta?.canonical ?? waypoint.line,
+    lineName: meta?.canonical ?? displayLine,
     lineColorHex: meta?.color ?? '#888888',
     stopsRemaining,
     etaMinutes: Math.max(0, Math.round(etaSeconds / 60)),


### PR DESCRIPTION
Closes #1658

## 현상

6/22 13:37 환승 후 LA(Dynamic Island/Lock Screen Live Activity)가 경의중앙선을 표시. 실제 사용자는 2호선 탑승 중. backend liveActivity cron 60s cycle race로 환승 waypoint 추적 중 구 leg의 line(경의중앙선)이 LA에 노출됨.

## Root Cause

`buildLiveActivityContentState`가 `waypoint.line`을 lineName/lineColorHex 소스로 사용. 환승 waypoint(`kind==='transfer'`)는 현재 leg(FROM line)의 line을 갖고 있어, `maybeFireLiveActivityUpdate` 경로에서 서울 API가 ARRIVED를 보고하기 전 60s 동안 구 호선이 LA에 노출됨.

## Fix

`buildLiveActivityContentState`에서 `waypoint.kind === 'transfer'` AND `trip.waypoints[1]` 존재 시 다음 leg의 line(`trip.waypoints[1].line`)을 lineName/lineColorHex에 우선 사용.

- `trip.waypoints`는 advance마다 shifted SSOT → race 없음
- trip 미전달(legacy 호출) 또는 waypoints[1] 부재면 waypoint.line fallback — backward compat
- `advanceBoardingLockWaypoint` 경로(nextWaypoint가 이미 새 leg 첫 waypoint)는 영향 없음

## Wire Matrix (5단)

1. **Orphan**: `npm run lint:orphan` → 0 orphan ✓
2. **V/X dashboard**: wrangler tail에서 LA push body `content-state.lineName` 값 확인. 환승 후 구 호선 → 새 호선으로 즉시 전환 여부 관측.
3. **의존 PR**: N/A — backend only, device LA reader는 content-state 그대로 수신
4. **측정 plan**: 환승 포함 실기기 trip 후 R2 telemetry에서 alarmLog의 LA push timestamps + lineName 분포 확인 (1주)
5. **Device verify**: LA는 device-only 검증 필요. 시나리오: 환승 경로(예: 7호선→5호선) trip 등록 → 군자 도착 전 LA 호선 확인 → 군자 도착 후 5호선 표시 확인. backend type+unit만으로는 native LA widget render 미검증.