### PR TITLE
fix(#1663): Seoul outage 시 #1425 cooldown 면제 (23분 black hole 차단)

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -3419,7 +3419,7 @@ describe('POST /trips — #1425 trip-recently-ended reject', () => {
     env: Env,
     token: string,
     endedAt: number,
-    endReason: 'expired' | 'eta-missing' | 'destination' | 'push-unrecoverable' = 'eta-missing',
+    endReason: 'expired' | 'eta-missing' | 'seoul-outage' | 'destination' | 'push-unrecoverable' = 'eta-missing',
   ): void {
     const kv = env.TRIPS as unknown as InMemoryKV;
     kv.store.set(`tripStatus:${token}`, {
@@ -3474,6 +3474,27 @@ describe('POST /trips — #1425 trip-recently-ended reject', () => {
     const res = await post('/trips', { ...base(), token: 'fresh-token' }, env);
     expect(res.status).toBe(200);
     expect(await env.TRIPS.get('trip:fresh-token')).not.toBeNull();
+  });
+
+  // #1663 — Seoul outage cooldown bypass
+  it('bypasses cooldown and accepts re-register when endReason is seoul-outage (within retention)', async () => {
+    const env = makeKvEnv();
+    // trip ended 5s ago due to Seoul outage (still within 1h retention)
+    seedTripEnded(env, 'tok', Date.now() - 5_000, 'seoul-outage');
+
+    const res = await post('/trips', base(), env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, token: 'tok' });
+    expect(await env.TRIPS.get('trip:tok')).not.toBeNull();
+  });
+
+  it('still rejects eta-missing within retention (non-outage cooldown preserved)', async () => {
+    const env = makeKvEnv();
+    seedTripEnded(env, 'tok', Date.now() - 5_000, 'eta-missing');
+
+    const res = await post('/trips', base(), env);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: 'trip-recently-ended' });
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/seoul.test.ts
+++ b/backend/alarm-worker/src/__tests__/seoul.test.ts
@@ -278,4 +278,75 @@ describe('SeoulArrivalClient', () => {
     expect(client.stats.callCount).toBe(2);
     expect(client.stats.cacheSize).toBe(2);
   });
+
+  describe('httpErrorCount (#1663 Seoul outage detection)', () => {
+    it('starts at 0 for successful fetches', async () => {
+      const fetchImpl = vi.fn(async () => makeResponse({ realtimeArrivalList: [] }));
+      const client = new SeoulArrivalClient({
+        apiKey: 'KEY',
+        host: 'example.com',
+        now: () => FIXED_NOW,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      await client.fetchArrivals('서울역');
+      expect(client.stats.httpErrorCount).toBe(0);
+    });
+
+    it('increments on fetchArrivals HTTP error', async () => {
+      const fetchImpl = vi.fn(async () => makeResponse({}, false, 500));
+      const client = new SeoulArrivalClient({
+        apiKey: 'KEY',
+        host: 'example.com',
+        now: () => FIXED_NOW,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      await client.fetchArrivals('서울역');
+      expect(client.stats.httpErrorCount).toBe(1);
+    });
+
+    it('increments on fetchPositions HTTP error', async () => {
+      const fetchImpl = vi.fn(async () => makeResponse({}, false, 503));
+      const client = new SeoulArrivalClient({
+        apiKey: 'KEY',
+        host: 'example.com',
+        now: () => FIXED_NOW,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      await client.fetchPositions('7');
+      expect(client.stats.httpErrorCount).toBe(1);
+    });
+
+    it('accumulates across multiple failed calls', async () => {
+      const fetchImpl = vi.fn(async () => makeResponse({}, false, 500));
+      const client = new SeoulArrivalClient({
+        apiKey: 'KEY',
+        host: 'example.com',
+        now: () => FIXED_NOW,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      await client.fetchArrivals('서울역');
+      // second call hits cache (short error cache), no new HTTP error
+      await client.fetchArrivals('서울역');
+      await client.fetchArrivals('다른역'); // different station — new HTTP call
+      expect(client.stats.httpErrorCount).toBe(2);
+    });
+
+    it('does not count cached error responses as new HTTP errors', async () => {
+      let callCount = 0;
+      const fetchImpl = vi.fn(async () => {
+        callCount += 1;
+        return makeResponse({}, false, 500);
+      });
+      const client = new SeoulArrivalClient({
+        apiKey: 'KEY',
+        host: 'example.com',
+        now: () => FIXED_NOW,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      await client.fetchArrivals('서울역');
+      await client.fetchArrivals('서울역'); // cached — no HTTP call
+      expect(callCount).toBe(1);
+      expect(client.stats.httpErrorCount).toBe(1);
+    });
+  });
 });

--- a/backend/alarm-worker/src/__tests__/tripStatus.test.ts
+++ b/backend/alarm-worker/src/__tests__/tripStatus.test.ts
@@ -25,6 +25,10 @@ describe('toTripStatusEndReason', () => {
     expect(toTripStatusEndReason('eta-missing')).toBe('eta-missing');
     expect(toTripStatusEndReason('push-unrecoverable')).toBe('push-unrecoverable');
   });
+
+  it('passes through seoul-outage unchanged (#1663)', () => {
+    expect(toTripStatusEndReason('seoul-outage')).toBe('seoul-outage');
+  });
 });
 
 describe('writeTripEndedStatus', () => {
@@ -68,6 +72,13 @@ describe('readTripEndedStatus', () => {
     await writeTripEndedStatus(kv as unknown as KVNamespace, 'tok', 'eta-missing', 500);
     const got = await readTripEndedStatus(kv as unknown as KVNamespace, 'tok');
     expect(got).toEqual({ endedAt: 500, endReason: 'eta-missing' });
+  });
+
+  it('returns parsed record for seoul-outage (#1663)', async () => {
+    const kv = new InMemoryKV();
+    await writeTripEndedStatus(kv as unknown as KVNamespace, 'tok', 'seoul-outage', 999);
+    const got = await readTripEndedStatus(kv as unknown as KVNamespace, 'tok');
+    expect(got).toEqual({ endedAt: 999, endReason: 'seoul-outage' });
   });
 
   it('returns null when stored JSON is malformed', async () => {

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -495,19 +495,34 @@ app.post('/trips', async (c) => {
   // `Date.now()` 기준 — device 시계 drift 위험을 피하려면 backend wall clock 사용해야 한다.
   const recentlyEnded = await readTripEndedStatus(c.env.TRIPS, incoming.token);
   if (recentlyEnded && Date.now() - recentlyEnded.endedAt < TRIP_STATUS_RETENTION_MS) {
-    console.log(
-      JSON.stringify({
-        msg: 'trip-recently-ended: reject re-register (#1425)',
-        tokenPrefix: tokenPrefix(incoming.token),
-        endedAt: recentlyEnded.endedAt,
-        endReason: recentlyEnded.endReason,
-        ageMs: Date.now() - recentlyEnded.endedAt,
-      }),
-    );
-    return c.json(
-      { error: 'trip-recently-ended', reason: recentlyEnded.endReason },
-      400,
-    );
+    // #1663 — Seoul outage로 강제 종료된 trip은 cooldown 면제. 사용자가 재등록하면 즉시 허용.
+    // 원래 #1425 cooldown 목적(device race/자동 재시도 차단)과 충돌 없음 — outage false-end는
+    // 사용자 명시 재등록이며, 같은 token의 device race가 아니다.
+    if (recentlyEnded.endReason === 'seoul-outage') {
+      console.log(
+        JSON.stringify({
+          msg: 'trip-recently-ended: bypass cooldown (seoul-outage) (#1663)',
+          tokenPrefix: tokenPrefix(incoming.token),
+          endedAt: recentlyEnded.endedAt,
+          ageMs: Date.now() - recentlyEnded.endedAt,
+        }),
+      );
+      // cooldown skip — 아래 getTrip / isSameSession 경로로 정상 진행
+    } else {
+      console.log(
+        JSON.stringify({
+          msg: 'trip-recently-ended: reject re-register (#1425)',
+          tokenPrefix: tokenPrefix(incoming.token),
+          endedAt: recentlyEnded.endedAt,
+          endReason: recentlyEnded.endReason,
+          ageMs: Date.now() - recentlyEnded.endedAt,
+        }),
+      );
+      return c.json(
+        { error: 'trip-recently-ended', reason: recentlyEnded.endReason },
+        400,
+      );
+    }
   }
 
   const existing = await getTrip(c.env.TRIPS, incoming.token);

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -1909,16 +1909,23 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
   // #903 (Seam G) — subsurface=true trip은 인내 임계(10)로 분기. 지하 dead zone GPS/trainCode 일시 누락 인내.
   const threshold = resolveEtaMissingThreshold(trip);
   if (nextMissCount >= threshold) {
+    // #1663 — Seoul API HTTP error가 이 cron 사이클에 1건이라도 관측됐으면 'seoul-outage'로 구분.
+    // trip auto-end 원인이 Seoul API 장애(일시 HTTP error)였다고 판별해 #1425 cooldown을 면제한다.
+    // httpErrorCount는 SeoulArrivalClient 인스턴스 수명(= cron 1 cycle) 범위라 cron scope 내에서만 유효.
+    const endReason: import('./types').TripEndedReason =
+      deps.seoul.stats.httpErrorCount > 0 ? 'seoul-outage' : 'eta-missing';
     // #706 — 운행 시간대 외 무한 폴링 차단. cleanupTripWithLa가 LA dismissal + deleteTrip을 묶어 정리.
-    // #868 — 클라 state sync용 trip-ended silent push 발사 (reason=eta-missing).
+    // #868 — 클라 state sync용 trip-ended silent push 발사.
     log('boarding-lock: trip auto-ended (consecutiveEtaMissing exceeded)', {
       token: trip.token.slice(0, 8),
       trainCode: activeLock.trainCode,
       station: waypoint.stationName,
       threshold,
       subsurface: trip.subsurface === true,
+      endReason,
+      seoulHttpErrors: deps.seoul.stats.httpErrorCount,
     });
-    await cleanupTripWithLa(trip, env, deps, stats, now, log, 'eta-missing');
+    await cleanupTripWithLa(trip, env, deps, stats, now, log, endReason);
     return;
   }
   trip.consecutiveEtaMissing = nextMissCount;

--- a/backend/alarm-worker/src/seoul.ts
+++ b/backend/alarm-worker/src/seoul.ts
@@ -66,11 +66,18 @@ export class SeoulArrivalClient {
   private readonly cache = new Map<string, CacheEntry>();
   private readonly positionCache = new Map<string, PositionCacheEntry>();
   private callCount = 0;
+  /**
+   * #1663 — HTTP-level error count (non-2xx response) across all fetch calls this instance.
+   * Cron scope = one scheduled() invocation = one SeoulArrivalClient lifetime.
+   * `httpErrorCount > 0` in `handleEtaMissing` signals Seoul API was unreachable this cycle,
+   * not just that the specific trainCode disappeared.
+   */
+  private httpErrorCount = 0;
 
   constructor(private readonly options: FetchSeoulOptions) {}
 
-  get stats(): { callCount: number; cacheSize: number } {
-    return { callCount: this.callCount, cacheSize: this.cache.size };
+  get stats(): { callCount: number; cacheSize: number; httpErrorCount: number } {
+    return { callCount: this.callCount, cacheSize: this.cache.size, httpErrorCount: this.httpErrorCount };
   }
 
   /**
@@ -92,6 +99,7 @@ export class SeoulArrivalClient {
     this.callCount += 1;
     const response = await fetchImpl(url);
     if (!response.ok) {
+      this.httpErrorCount += 1;
       this.positionCache.set(lineName, { expiresAt: now + ERROR_CACHE_TTL_MS, data: [] });
       return [];
     }
@@ -120,6 +128,7 @@ export class SeoulArrivalClient {
     const response = await fetchImpl(url);
     if (!response.ok) {
       // 실패 시 빈 배열을 짧게 캐시해 폭주 방지
+      this.httpErrorCount += 1;
       this.cache.set(stationName, { expiresAt: now + ERROR_CACHE_TTL_MS, data: [] });
       return [];
     }

--- a/backend/alarm-worker/src/tripStatus.ts
+++ b/backend/alarm-worker/src/tripStatus.ts
@@ -18,8 +18,11 @@ import type { TripEndedReason } from './types';
 
 const TRIP_STATUS_PREFIX = 'tripStatus:';
 
-/** 외부 응답에 노출하는 endReason — `destination-arrived` → `destination`로 축약 (contract). */
-export type TripStatusEndReason = 'expired' | 'eta-missing' | 'destination' | 'push-unrecoverable';
+/**
+ * 외부 응답에 노출하는 endReason — `destination-arrived` → `destination`로 축약 (contract).
+ * `seoul-outage` (#1663) — Seoul API HTTP error로 인한 false-end. #1425 cooldown 면제 대상.
+ */
+export type TripStatusEndReason = 'expired' | 'eta-missing' | 'seoul-outage' | 'destination' | 'push-unrecoverable';
 
 export interface TripStatusRecord {
   endedAt: number;
@@ -47,6 +50,7 @@ export function tripStatusKey(token: string): string {
  * TripEndedReason(내부 enum) → TripStatusEndReason(외부 contract) 매핑.
  * 클라이언트 API 응답은 `destination`으로 축약 — `destination-arrived`는 backend 내부 식별자라
  * 외부 노출 표면에는 단축형이 깔끔하다.
+ * `seoul-outage` (#1663) — 1:1 pass-through. POST /trips 핸들러가 cooldown 면제 분기에 사용.
  */
 export function toTripStatusEndReason(reason: TripEndedReason): TripStatusEndReason {
   if (reason === 'destination-arrived') return 'destination';
@@ -88,6 +92,7 @@ export async function readTripEndedStatus(
     if (
       parsed.endReason !== 'expired' &&
       parsed.endReason !== 'eta-missing' &&
+      parsed.endReason !== 'seoul-outage' &&
       parsed.endReason !== 'destination' &&
       parsed.endReason !== 'push-unrecoverable'
     ) {

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -333,6 +333,8 @@ export interface ReschedulePushPayload {
 /**
  * Trip 자동 종료 reason (#868).
  *   - 'eta-missing' — consecutiveEtaMissing 임계 초과 (운행 시간대 외 / trainCode 소실)
+ *   - 'seoul-outage' — consecutiveEtaMissing 임계 초과 + Seoul API HTTP error 관측 (#1663)
+ *                      outage 기인 false-end로 판별 → #1425 cooldown 면제 대상
  *   - 'destination-arrived' — 목적지 도착 또는 마지막 intermediate 통과로 trip 종료
  *   - 'expired' — trip.expiresAt 시각 초과로 자동 만료
  *   - 'push-unrecoverable' — APNs unrecoverable error로 trip 폐기
@@ -342,6 +344,7 @@ export interface ReschedulePushPayload {
  */
 export type TripEndedReason =
   | 'eta-missing'
+  | 'seoul-outage'
   | 'destination-arrived'
   | 'expired'
   | 'push-unrecoverable';

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -980,6 +980,7 @@ describe('silentPushTask', () => {
 
       it.each([
         ['eta-missing'],
+        ['seoul-outage'],
         ['destination-arrived'],
         ['expired'],
         ['push-unrecoverable'],

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -259,9 +259,11 @@ export interface TripEndedSilentPushPayload {
 /**
  * Trip 자동 종료 reason — backend `types.ts`의 TripEndedReason과 정렬.
  * 알 수 없는 reason은 'unknown'으로 정규화해 처리 (구버전 backend 호환 + cleanup은 동일).
+ * 'seoul-outage' (#1663) — Seoul API HTTP error로 인한 false-end. cleanup 동작은 'eta-missing'과 동일.
  */
 export type TripEndedReason =
   | 'eta-missing'
+  | 'seoul-outage'
   | 'destination-arrived'
   | 'expired'
   | 'push-unrecoverable'
@@ -592,6 +594,7 @@ function extractTripEndedPayload(
 
 const KNOWN_TRIP_ENDED_REASONS: ReadonlyArray<TripEndedReason> = [
   'eta-missing',
+  'seoul-outage',
   'destination-arrived',
   'expired',
   'push-unrecoverable',


### PR DESCRIPTION
## Summary

- Seoul API HTTP error로 인해 `consecutiveEtaMissing` 임계 초과 → trip auto-end → #1425 cooldown 23분 적용 → 사용자 black hole 차단
- `SeoulArrivalClient`에 `httpErrorCount` 추적 추가, backend가 outage 기인 false-end를 `'seoul-outage'` reason으로 구분
- POST /trips cooldown 체크에서 `endReason === 'seoul-outage'`면 즉시 면제하여 사용자 재등록 허용

## Wire Matrix (5 시나리오)

| 종료 reason | 설명 | #1425 cooldown |
|---|---|---|
| `seoul-outage` | Seoul API HTTP error → consecutiveEtaMissing 임계 | **면제** (본 PR) |
| `eta-missing` | trainCode 실제 소실 (운행 종료 등) | 유지 |
| `destination-arrived` | 정상 목적지 도착 | 유지 |
| `expired` | trip.expiresAt 초과 | 유지 |
| `push-unrecoverable` | APNs unrecoverable error | 유지 |

## Trip evidence

2026-06-22 14:18:16~14:41:
- Seoul API 100% HTTP error → `consecutiveEtaMissing` = 5(threshold) → `cleanupTripWithLa('eta-missing')` → tripStatus KV stamp
- 14:25 사용자 재등록 시도 → `readTripEndedStatus` hit → `TRIP_STATUS_RETENTION_MS` 23분 미경과 → 400 거부 → **23분 black hole**

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` 0 orphan (신규 export 없음)
2. **V/X dashboard** — `wrangler tail` 로그: `"msg":"trip-recently-ended: bypass cooldown (seoul-outage)"` + `"msg":"boarding-lock: trip auto-ended"` + `endReason:"seoul-outage"` 관측 가능
3. **의존 PR** — N/A (단독 동작)
4. **측정 plan** — `wrangler tail` + Cloudflare Dashboard: Seoul outage 재발 시 `bypass cooldown` 로그 관측. 1주 이내 outage 없으면 `eta-missing` 분포 baseline 유지 확인
5. **Device verify** — UI 변경 없음. backend + device-side enum 추가만. `'seoul-outage'` reason이 device에 도달 시 cleanup 동작은 `'eta-missing'`과 동일 (backward-compat)

## V/X 영향

| Acceptance | 이전 | 본 PR 머지 후 |
|---|---|---|
| **V5** false end 차단 | ⚠️ Seoul outage 시 false end | ✅ reason 구분 (`seoul-outage`) |
| **사용자 black hole** | ❌ 23분 cooldown 적용 | ✅ outage 시 즉시 재등록 허용 |
| **X8** 정상 cooldown | ✅ `eta-missing` 유지 | ✅ 유지 (비-outage는 영향 없음) |

## 트레이드오프

- Seoul outage 오인지 (실제 정상 종료인데 outage로 분류): `httpErrorCount > 0` 조건이 cron 1 사이클 범위라 scope가 좁음. 단일 HTTP error + trainCode 소실이 겹치는 경우는 면제 허용이 더 나음 (false negative보다 false positive 허용)
- spam 재등록: 기존 `checkTripRegisterRateLimit` (10 req/10min, #1575 T12) 가드가 유효

Closes #1663