### PR TITLE
refactor(#1669): locklessStationPassed → infoModeEnabled rename

### DIFF
--- a/backend/alarm-worker/src/__tests__/consensusGate.test.ts
+++ b/backend/alarm-worker/src/__tests__/consensusGate.test.ts
@@ -174,7 +174,7 @@ describe('evaluateConsensusGate (ADR-015 §3/§4)', () => {
     it.each<StationEnvironment>(['surface', 'underground', 'mixed'])(
       '%s: 동일 signals → 토글 ON/OFF / boardingPrompt 응답 유무와 무관하게 동일 결과',
       (env) => {
-        // 본 게이트 시그너처는 BoardingPromptState / locklessStationPassed를 받지 않는다.
+        // 본 게이트 시그너처는 BoardingPromptState / infoModeEnabled를 받지 않는다.
         // 동일 signals 입력은 두 trip이 모두 동일 결과를 반환해야 한다 — 정적 보증.
         expect(runGate(env)).toEqual(runGate(env));
       },

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -175,17 +175,27 @@ describe('validateTrip', () => {
   });
 
   // #816 C — lockless station-passed opt-in 필드
-  it('preserves boolean locklessStationPassed (#816)', () => {
-    expect(validateTrip({ ...base(), locklessStationPassed: true })?.locklessStationPassed).toBe(true);
-    expect(validateTrip({ ...base(), locklessStationPassed: false })?.locklessStationPassed).toBe(false);
+  it('preserves boolean infoModeEnabled (#816)', () => {
+    expect(validateTrip({ ...base(), infoModeEnabled: true })?.infoModeEnabled).toBe(true);
+    expect(validateTrip({ ...base(), infoModeEnabled: false })?.infoModeEnabled).toBe(false);
   });
 
-  it('drops non-boolean locklessStationPassed and absent field stays undefined', () => {
+  it('drops non-boolean infoModeEnabled and absent field stays undefined', () => {
     expect(
-      validateTrip({ ...base(), locklessStationPassed: 'yes' })?.locklessStationPassed,
+      validateTrip({ ...base(), infoModeEnabled: 'yes' })?.infoModeEnabled,
     ).toBeUndefined();
-    expect(validateTrip({ ...base(), locklessStationPassed: 1 })?.locklessStationPassed).toBeUndefined();
-    expect(validateTrip(base())?.locklessStationPassed).toBeUndefined();
+    expect(validateTrip({ ...base(), infoModeEnabled: 1 })?.infoModeEnabled).toBeUndefined();
+    expect(validateTrip(base())?.infoModeEnabled).toBeUndefined();
+  });
+
+  // #1669 backward-compat: 구 device가 locklessStationPassed 필드명으로 송신해도 infoModeEnabled로 파싱
+  it('backward-compat: locklessStationPassed 필드를 infoModeEnabled로 파싱한다 (#1669)', () => {
+    expect(validateTrip({ ...base(), locklessStationPassed: true })?.infoModeEnabled).toBe(true);
+    expect(validateTrip({ ...base(), locklessStationPassed: false })?.infoModeEnabled).toBe(false);
+    // infoModeEnabled 우선: 둘 다 있으면 infoModeEnabled 채택
+    expect(
+      validateTrip({ ...base(), infoModeEnabled: true, locklessStationPassed: false })?.infoModeEnabled,
+    ).toBe(true);
   });
 
   // #903 (Seam G) — subsurface 필드
@@ -991,7 +1001,7 @@ describe('POST /trips — #1285 lockless progress KV 재등록 시 진행 보존
       ...base(),
       token: LOCKLESS_TOKEN,
       createdAt: SESSION_CREATED,
-      locklessStationPassed: true,
+      infoModeEnabled: true,
       waypoints: LOCKLESS_WAYPOINTS,
       ...overrides,
     };
@@ -1031,12 +1041,12 @@ describe('POST /trips — #1285 lockless progress KV 재등록 시 진행 보존
     expect((finalTrip.waypoints as Array<{ stationName: string }>)[0].stationName).toBe('군자');
   });
 
-  it('lockless progress가 있어도 locklessStationPassed=false면 progress 폐기', async () => {
+  it('lockless progress가 있어도 infoModeEnabled=false면 progress 폐기', async () => {
     const env = makeKvEnv();
     await post('/trips', locklessTripBody(), env);
     await seedLocklessProgress(env, 1);
-    // locklessStationPassed가 false인 재등록 — progress 미적용
-    await post('/trips', locklessTripBody({ locklessStationPassed: false }), env);
+    // infoModeEnabled가 false인 재등록 — progress 미적용
+    await post('/trips', locklessTripBody({ infoModeEnabled: false }), env);
     expect(await env.TRIPS.get(`progress:${LOCKLESS_TOKEN}`)).toBeNull();
   });
 

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -538,7 +538,7 @@ describe('runScheduled', () => {
           { stationName: '강남', line: '2', kind: 'intermediate' },
           { stationName: '역삼', line: '2', kind: 'destination' },
         ],
-        locklessStationPassed: true,
+        infoModeEnabled: true,
         ...overrides,
       });
     }
@@ -618,7 +618,7 @@ describe('runScheduled', () => {
       },
       {
         name: '토글 OFF + intermediate → lockMissing 카운트 (발사 0, arrivals fetch 미호출)',
-        trip: () => intermediateTrip({ locklessStationPassed: false }),
+        trip: () => intermediateTrip({ infoModeEnabled: false }),
         apnsOk: false,
         expect: { pushed: 0, locklessFired: 0, lockMissing: 1 },
         apnsCalled: false,
@@ -630,7 +630,7 @@ describe('runScheduled', () => {
         trip: () =>
           makeTrip({
             waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
-            locklessStationPassed: true,
+            infoModeEnabled: true,
           }),
         apnsOk: false,
         expect: { pushed: 0, locklessFired: 0, lockMissing: 1 },
@@ -680,7 +680,7 @@ describe('runScheduled', () => {
             { stationName: '강남', line: '2', kind: 'intermediate', hopIndex: 3 },
             { stationName: '역삼', line: '2', kind: 'destination', hopIndex: 4 },
           ],
-          locklessStationPassed: true,
+          infoModeEnabled: true,
         }),
         arrivals: [ARVL_ARRIVED],
         apnsOk: true,
@@ -696,7 +696,7 @@ describe('runScheduled', () => {
             { stationName: '강남', line: '2', kind: 'intermediate' },
             { stationName: '역삼', line: '2', kind: 'destination' },
           ],
-          locklessStationPassed: true,
+          infoModeEnabled: true,
         }),
         arrivals: [ARVL_ARRIVED],
         apnsOk: true,
@@ -717,7 +717,7 @@ describe('runScheduled', () => {
             { stationName: '강남', line: '2', kind: 'intermediate', hopIndex: 3 },
             { stationName: '역삼', line: '2', kind: 'destination', hopIndex: 4 },
           ],
-          locklessStationPassed: true,
+          infoModeEnabled: true,
           ...(input === undefined ? {} : { subsurface: input }),
         }),
         arrivals: [ARVL_ARRIVED],
@@ -736,7 +736,7 @@ describe('runScheduled', () => {
             { stationName: '역삼', line: '2', kind: 'intermediate' },
             { stationName: '선릉', line: '2', kind: 'destination' },
           ],
-          locklessStationPassed: true,
+          infoModeEnabled: true,
         }),
         arrivals: [{ ...ARVL_ARRIVED, destination: '선릉행', arrivalSeconds: 0, trainCode: 'X' }],
         apnsOk: true,
@@ -757,7 +757,7 @@ describe('runScheduled', () => {
             { stationName: '중곡', line: '5', kind: 'intermediate' },
             { stationName: '군자', line: '5', kind: 'destination' },
           ],
-          locklessStationPassed: true,
+          infoModeEnabled: true,
         }),
         arrivals: [ARVL_ARRIVED],
         apnsOk: true,
@@ -782,7 +782,7 @@ describe('runScheduled', () => {
           { stationName: '군자', line: '5', kind: 'intermediate' },
           { stationName: '아차산', line: '5', kind: 'destination' },
         ],
-        locklessStationPassed: true,
+        infoModeEnabled: true,
       });
       await putTrip(kv as unknown as KVNamespace, trip);
       // #1315 — bare-arvlCd advance는 motion=walking/automotive에서만 허용 → 이동 series 시드.
@@ -861,7 +861,7 @@ describe('runScheduled', () => {
             { stationName: '어린이대공원', line: '2', kind: 'intermediate' },
             { stationName: '건대입구', line: '2', kind: 'destination' },
           ],
-          locklessStationPassed: true,
+          infoModeEnabled: true,
         });
         await putTrip(kv as unknown as KVNamespace, trip);
         await seedLocklessMotionSeries(kv, trip.token, 'stationary');
@@ -912,7 +912,7 @@ describe('runScheduled', () => {
             { stationName: '역삼', line: '2', kind: 'intermediate' },
             { stationName: '선릉', line: '2', kind: 'destination' },
           ],
-          locklessStationPassed: true,
+          infoModeEnabled: true,
           promptGeoContext: {
             origin: { lat: 0, lng: 0 },
             nextStation: { lat: 0, lng: 0.01 },
@@ -1424,7 +1424,7 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
       expect(stored.boardingLock).toBeUndefined();
       expect(stored.consecutiveEtaMissing).toBe(0);
       // #1370 L3 — lockless 인계가 실제로 작동하도록 강제 enable + stat 기록
-      expect(stored.locklessStationPassed).toBe(true);
+      expect(stored.infoModeEnabled).toBe(true);
     });
 
     it('#1370 L2 — fallback advance 직전 station-passed silent push 발사 (intermediate)', async () => {
@@ -1548,14 +1548,14 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
       expect(stats.errors).toBeGreaterThanOrEqual(1);
     });
 
-    it('#1370 L3 — lock release 시 locklessStationPassed 강제 enable + stat 기록', async () => {
+    it('#1370 L3 — lock release 시 infoModeEnabled 강제 enable + stat 기록', async () => {
       const kv = new InMemoryKV();
       await putTrip(
         kv as unknown as KVNamespace,
         makeLockTrip({
           consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
           lastTrackedArrivalEpoch: LAST_EPOCH_NOT_ELAPSED,
-          locklessStationPassed: false,
+          infoModeEnabled: false,
         }),
       );
       const stats = await runScheduled(makeEnv(kv), {
@@ -1567,7 +1567,7 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
         generatePushId: () => 'p1370-l3',
       });
       const stored = JSON.parse((await kv.get('trip:lock-tok'))!) as Trip;
-      expect(stored.locklessStationPassed).toBe(true);
+      expect(stored.infoModeEnabled).toBe(true);
       expect(stats.vanishLocklessTakeover).toBe(1);
     });
 
@@ -1797,7 +1797,7 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
           motion: 'stationary',
           hopElapsed: false,
           pushId: 'p1386-not-elapsed',
-          tripOverrides: { locklessStationPassed: false },
+          tripOverrides: { infoModeEnabled: false },
         });
         // floor fire 차단 (release 경로 motion gate)
         expect(stats.vanishFallbackMotionGateBlocked).toBe(1);
@@ -1805,7 +1805,7 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
         // lock release + lockless takeover 경로 활성 — gate와 무관하게 진행
         expect(stats.vanishLocklessTakeover).toBe(1);
         expect(stored.boardingLock).toBeUndefined();
-        expect(stored.locklessStationPassed).toBe(true);
+        expect(stored.infoModeEnabled).toBe(true);
       });
     });
   });
@@ -3406,7 +3406,7 @@ describe('runScheduled — #825 Phase 3 E3: phaseImminentBlocked + stationPhase 
         { stationName: '강남', line: '2', kind: 'intermediate' },
         { stationName: '역삼', line: '2', kind: 'destination' },
       ],
-      locklessStationPassed: true,
+      infoModeEnabled: true,
       ...overrides,
     });
   }
@@ -3763,7 +3763,7 @@ describe('runScheduled — #1652 staged lifecycle backstop', () => {
         createdAt: NOW - 10.5 * 60 * 60_000,
         expiresAt: NOW + 60 * 60_000,
         alarmAtEpochMs: NOW + 60_000,
-        locklessStationPassed: true,
+        infoModeEnabled: true,
       }),
     );
 
@@ -4010,7 +4010,7 @@ function makeLocklessKalmanTrip(token: string, overrides: Partial<Trip> = {}): T
       { stationName: '강남', line: '2', kind: 'intermediate' },
       { stationName: '역삼', line: '2', kind: 'destination' },
     ],
-    locklessStationPassed: true,
+    infoModeEnabled: true,
     ...overrides,
   });
 }
@@ -5512,7 +5512,7 @@ async function runLocklessSsotFireScenario(opts: {
     token: opts.token,
     route: { type: 'direct', line: '2', stops: 2 },
     waypoints: opts.waypoints,
-    locklessStationPassed: true,
+    infoModeEnabled: true,
   });
   await putTrip(kv as unknown as KVNamespace, trip);
   await seedLocklessMotionSeries(kv, trip.token, 'automotive');
@@ -5567,7 +5567,7 @@ describe('runLocklessIntermediate passedStations 누적 (#1539 S6)', () => {
         { stationName: '강남', line: '2', kind: 'intermediate' },
         { stationName: '역삼', line: '2', kind: 'intermediate' },
       ],
-      locklessStationPassed: true,
+      infoModeEnabled: true,
     });
     await putTrip(kv as unknown as KVNamespace, trip);
     await seedLocklessMotionSeries(kv, trip.token, 'automotive');

--- a/backend/alarm-worker/src/consensusGate.ts
+++ b/backend/alarm-worker/src/consensusGate.ts
@@ -24,7 +24,7 @@
  *   채널(promptDisplay)은 동작 보존 — 본 모듈은 fire 결정에만 관여한다.
  *
  * §7 토글 input X:
- *   본 게이트는 `trip.locklessStationPassed`(C 토글) / `trip.boardingPromptState.fired`
+ *   본 게이트는 `trip.infoModeEnabled`(C 토글) / `trip.boardingPromptState.fired`
  *   (사용자 응답) 등 **사용자 명시 의향 필드를 input으로 받지 않는다**. 시그너처가 `environment`
  *   + `signals` 만 받는 사실이 §7의 정적 보증. 토글 UI 라벨은 frontend 책임.
  *

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -523,14 +523,14 @@ app.post('/trips', async (c) => {
       : undefined;
   // #705: progress KV 우선 참조. 같은 trainCode면 shift된 waypoints를 incoming에 적용.
   // 다른 trainCode/none이면 progress 폐기.
-  // #1285: lockless opt-in trip(boardingLock 없음 + locklessStationPassed===true)은
+  // #1285: lockless opt-in trip(boardingLock 없음 + infoModeEnabled===true)은
   // token 기준 lockless progress로 보존 — trainCode 없이 lockless===true 마커로 매칭.
   const progress = existing !== null ? await getProgress(c.env.TRIPS, incoming.token) : null;
   const progressApplies =
     progress !== null &&
     ((incoming.boardingLock !== undefined &&
       progress.trainCode === incoming.boardingLock.trainCode) ||
-      (progress.lockless === true && incoming.locklessStationPassed === true));
+      (progress.lockless === true && incoming.infoModeEnabled === true));
   if (progress !== null && !progressApplies) {
     await deleteProgress(c.env.TRIPS, incoming.token);
   }
@@ -1844,8 +1844,14 @@ export function validateTrip(input: unknown): Trip | null {
     consecutiveEtaMissing:
       typeof obj.consecutiveEtaMissing === 'number' ? obj.consecutiveEtaMissing : undefined,
     // #816 C: 사용자 명시 opt-in 토글값. 미송신 또는 boolean 아니면 undefined (default OFF).
-    locklessStationPassed:
-      typeof obj.locklessStationPassed === 'boolean' ? obj.locklessStationPassed : undefined,
+    // #1669 backward-compat: 구 device는 locklessStationPassed, 신 device는 infoModeEnabled 송신.
+    // 둘 다 accept하고 infoModeEnabled 우선.
+    infoModeEnabled:
+      typeof obj.infoModeEnabled === 'boolean'
+        ? obj.infoModeEnabled
+        : typeof obj.locklessStationPassed === 'boolean'
+          ? obj.locklessStationPassed
+          : undefined,
     // #819: boarding-prompt 평가용 컨텍스트. 좌표/표시 명시 부재 시 백엔드는 lockMissing 분기에서
     // 자연 skip — 좌표 없는 평가는 게이트 #4/#5 정확도 0이라 의미 없음.
     promptGeoContext: parsePromptGeoContext(obj.promptGeoContext),

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -434,7 +434,7 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   vanishReleaseFired: number;
   /**
-   * #1370 L3 — vanish 후 hop 시간 미경과로 lock release할 때 trip.locklessStationPassed가
+   * #1370 L3 — vanish 후 hop 시간 미경과로 lock release할 때 trip.infoModeEnabled가
    * false였던 trip을 강제 enable해 lockless 인계 경로를 살린 횟수. 0이 아니면 사용자가 opt-in
    * 토글 OFF였지만 vanish recovery로 매역 push가 복구된 trip 수.
    */
@@ -682,7 +682,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       // 시 station-passed push 발사. 사용자가 명시 동의(client 토글)한 trip에 한정한다.
       // intermediate kind가 아니면(transfer/destination) 여전히 skip — trainCode 없이 발사하면
       // 잘못된 leg/방향으로 갈 위험.
-      if (trip.locklessStationPassed && waypoint.kind === 'intermediate') {
+      if (trip.infoModeEnabled && waypoint.kind === 'intermediate') {
         try {
           await runLocklessIntermediate(trip, waypoint, env, deps, stats, now, log, generatePushId);
         } catch (e) {
@@ -695,7 +695,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       log('boarding-lock: skip cycle (lock missing or expired)', {
         token: trip.token.slice(0, 8),
         station: waypoint.stationName,
-        locklessOptIn: trip.locklessStationPassed === true,
+        locklessOptIn: trip.infoModeEnabled === true,
         waypointKind: waypoint.kind,
       });
       // #819 — lock 미발생 trip에 boarding-prompt 9단 게이트 평가 분기. 게이트 통과 시 alert
@@ -1853,8 +1853,8 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
     }
     // hop 시간 미경과 → lock release해 lockless/boardingPrompt가 인계받도록.
     // isBoardingLockActive=false가 되는 즉시 다음 cycle의 evaluateAndMaybeFireBoardingPrompt 경로 복구.
-    // #1370 L3 — lock release 후 lockless 인계가 실제로 작동하려면 trip.locklessStationPassed가
-    // true여야 한다(`if (!isBoardingLockActive) → if (trip.locklessStationPassed && intermediate)`).
+    // #1370 L3 — lock release 후 lockless 인계가 실제로 작동하려면 trip.infoModeEnabled가
+    // true여야 한다(`if (!isBoardingLockActive) → if (trip.infoModeEnabled && intermediate)`).
     // OFF인 trip은 다음 cycle에서 lockMissing으로 spin하며 군자/중곡까지 push 0건. vanish fallback은
     // 시스템이 trainCode를 잃은 상황이므로 lockless 인계를 강제 enable해 매역 push 경로를 복구한다.
     //
@@ -1895,11 +1895,11 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
       station: waypoint.stationName,
       consecutiveEtaMissing: nextMissCount,
       lastTrackedArrivalEpoch: lastEpoch,
-      locklessTakeoverEnabled: trip.locklessStationPassed !== true,
+      locklessTakeoverEnabled: trip.infoModeEnabled !== true,
     });
     trip.boardingLock = undefined;
     trip.consecutiveEtaMissing = 0;
-    trip.locklessStationPassed = true;
+    trip.infoModeEnabled = true;
     stats.vanishLocklessTakeover += 1;
     await deleteProgress(env.TRIPS, trip.token);
     await putTrip(env.TRIPS, trip);

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -148,7 +148,7 @@ export interface Trip {
    */
   consecutiveEtaMissing?: number;
   /**
-   * #816 C — 사용자 opt-in lockless station-passed.
+   * #816 C — 사용자 opt-in lockless station-passed (UI: "전체역 보기").
    * BoardingLock 없는 trip에서도 station-passed(intermediate) 알림을 발사할지 여부.
    *
    * 기본 (필드 부재 또는 false): #640 게이트 그대로 — lock 없으면 cycle skip.
@@ -157,8 +157,9 @@ export interface Trip {
    *   - 사용자가 명시 설정 토글로 ON했을 때만 trip 등록 시 송신
    *
    * 노이즈 차단 책임: 사용자에게 옵트인 권한 위임. #640 회귀는 OFF가 default로 보호.
+   * (#1669 device rename: locklessStationPassed → infoModeEnabled, 필드명 동기화)
    */
-  locklessStationPassed?: boolean;
+  infoModeEnabled?: boolean;
   /**
    * boarding-prompt(#819) 발사 추적 — trip당 1회 + dismiss 5분 silence 게이트(#9).
    * 부재 = 미발사 상태. 사용자 응답으로 lock이 생기면 자연스럽게 게이트 #2가 차단한다.

--- a/src/features/alarm/api/__tests__/alarmBackend.test.ts
+++ b/src/features/alarm/api/__tests__/alarmBackend.test.ts
@@ -208,30 +208,30 @@ describe('alarmBackend', () => {
       });
 
       // #816 C — lockless station-passed 토글
-      it('locklessStationPassed=true 송신 + 토글 변경 시 재등록', async () => {
+      it('infoModeEnabled=true 송신 + 토글 변경 시 재등록', async () => {
         const first = await registerActiveTrip({
           ...SAMPLE_PAYLOAD,
-          locklessStationPassed: true,
+          infoModeEnabled: true,
         });
         expect(first.ok).toBe(true);
         const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
-        expect(body.locklessStationPassed).toBe(true);
+        expect(body.infoModeEnabled).toBe(true);
 
         // 토글 OFF로 재호출 → hash 달라져서 재등록 (dedup 미적용)
         const off = await registerActiveTrip({
           ...SAMPLE_PAYLOAD,
-          locklessStationPassed: false,
+          infoModeEnabled: false,
         });
         expect(off).toEqual({ ok: true, status: 200 });
         expect(global.fetch).toHaveBeenCalledTimes(2);
         const offBody = JSON.parse((global.fetch as jest.Mock).mock.calls[1][1].body);
-        expect(offBody.locklessStationPassed).toBeUndefined();
+        expect(offBody.infoModeEnabled).toBeUndefined();
       });
 
-      it('locklessStationPassed=false/미설정이면 body에 미포함', async () => {
-        await registerActiveTrip({ ...SAMPLE_PAYLOAD, locklessStationPassed: false });
+      it('infoModeEnabled=false/미설정이면 body에 미포함', async () => {
+        await registerActiveTrip({ ...SAMPLE_PAYLOAD, infoModeEnabled: false });
         const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
-        expect(body.locklessStationPassed).toBeUndefined();
+        expect(body.infoModeEnabled).toBeUndefined();
       });
 
       // #903 (Seam G) — subsurface 동봉

--- a/src/features/alarm/api/alarmBackend.ts
+++ b/src/features/alarm/api/alarmBackend.ts
@@ -89,7 +89,7 @@ export interface RegisterTripPayload {
    * 토글 OFF 상태에선 false를 명시 송신할 필요 없음 — alarmBackend는 미송신 시 backend에서
    * default OFF로 해석. dedup hash에는 반드시 포함해 토글 변경이 즉시 재등록되도록 한다.
    */
-  locklessStationPassed?: boolean;
+  infoModeEnabled?: boolean;
   /**
    * #819 — boarding-prompt 9단 게이트 평가에 필요한 출발역/다음역 좌표.
    * lockMissing trip에 대해 backend가 평가 — 좌표 부재 시 backend는 자동 skip.
@@ -167,7 +167,7 @@ function buildRegisterHash(body: {
   alarmAtEpochMs: number;
   apnsEnv: ApnsEnv;
   boardingLock?: AlarmBoardingLock;
-  locklessStationPassed?: boolean;
+  infoModeEnabled?: boolean;
   promptDisplay?: { originStation: string; line: string };
   subsurface?: boolean;
 }): string {
@@ -185,7 +185,7 @@ function buildRegisterHash(body: {
       : null,
     // #816 C — 토글 변경 즉시 backend로 전달되도록 dedup key에 포함.
     // undefined와 false를 다르게 다루지 않는다 — 둘 다 OFF 동일 효과.
-    locklessStationPassed: body.locklessStationPassed === true,
+    infoModeEnabled: body.infoModeEnabled === true,
     // #819 — promptDisplay(출발역/라인)가 바뀌면 backend가 보내는 push 본문이 달라지므로 dedup 키 일부.
     // 좌표(promptGeoContext)는 GPS jitter로 매번 약간씩 흔들리므로 hash에 안 넣어 폭주 방지 — backend가
     // 게이트 평가 시점에 KV series로 자체 계산하니 영향 없음.
@@ -254,7 +254,7 @@ async function performRegisterFetch(
     // boardingLock은 있을 때만 송신 (없으면 backend는 기존 anchor 폴링).
     ...(payload.boardingLock ? { boardingLock: payload.boardingLock } : {}),
     // #816 C — 토글 ON일 때만 송신. OFF/미설정은 필드 자체를 누락해 기존 trip schema 호환.
-    ...(payload.locklessStationPassed === true ? { locklessStationPassed: true } : {}),
+    ...(payload.infoModeEnabled === true ? { infoModeEnabled: true } : {}),
     // #819 — boarding-prompt 평가 컨텍스트. 좌표/표시 둘 중 하나라도 없으면 backend는 자동 skip.
     ...(payload.promptGeoContext ? { promptGeoContext: payload.promptGeoContext } : {}),
     ...(payload.promptDisplay ? { promptDisplay: payload.promptDisplay } : {}),
@@ -305,7 +305,7 @@ export function registerActiveTrip(
     alarmAtEpochMs: payload.alarmAtEpochMs,
     apnsEnv: payload.apnsEnv,
     boardingLock: payload.boardingLock,
-    locklessStationPassed: payload.locklessStationPassed,
+    infoModeEnabled: payload.infoModeEnabled,
     promptDisplay: payload.promptDisplay,
     subsurface: payload.subsurface,
   });

--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -973,20 +973,20 @@ describe('useApnsTripRegistration', () => {
 
   // #816 C — lockless station-passed opt-in
   describe('lockless station-passed (#816)', () => {
-    it('locklessStationPassed=true 입력 시 register payload에 포함', async () => {
+    it('infoModeEnabled=true 입력 시 register payload에 포함', async () => {
       renderHook(() =>
         useApnsTripRegistration({
           route: directRoute,
           destination: station,
           nextStationEtaSeconds: 120,
-          locklessStationPassed: true,
+          infoModeEnabled: true,
         }),
       );
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
-      expect(mockRegister.mock.calls[0][0].locklessStationPassed).toBe(true);
+      expect(mockRegister.mock.calls[0][0].infoModeEnabled).toBe(true);
     });
 
-    it('locklessStationPassed 미지정/false면 register payload에 미포함', async () => {
+    it('infoModeEnabled 미지정/false면 register payload에 미포함', async () => {
       renderHook(() =>
         useApnsTripRegistration({
           route: directRoute,
@@ -995,7 +995,7 @@ describe('useApnsTripRegistration', () => {
         }),
       );
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
-      expect(mockRegister.mock.calls[0][0].locklessStationPassed).toBeUndefined();
+      expect(mockRegister.mock.calls[0][0].infoModeEnabled).toBeUndefined();
     });
 
     it('토글 OFF→ON 전환 시 즉시 재등록 (deps 반영)', async () => {
@@ -1005,16 +1005,16 @@ describe('useApnsTripRegistration', () => {
             route: directRoute,
             destination: station,
             nextStationEtaSeconds: 120,
-            locklessStationPassed: lsp,
+            infoModeEnabled: lsp,
           }),
         { initialProps: { lsp: false } },
       );
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
-      expect(mockRegister.mock.calls[0][0].locklessStationPassed).toBeUndefined();
+      expect(mockRegister.mock.calls[0][0].infoModeEnabled).toBeUndefined();
 
       rerender({ lsp: true });
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
-      expect(mockRegister.mock.calls[1][0].locklessStationPassed).toBe(true);
+      expect(mockRegister.mock.calls[1][0].infoModeEnabled).toBe(true);
     });
 
     it('token refresh 경로도 최신 토글값을 송신 (latestInputsRef)', async () => {
@@ -1024,7 +1024,7 @@ describe('useApnsTripRegistration', () => {
             route: directRoute,
             destination: station,
             nextStationEtaSeconds: 120,
-            locklessStationPassed: lsp,
+            infoModeEnabled: lsp,
           }),
         { initialProps: { lsp: false } },
       );
@@ -1043,7 +1043,7 @@ describe('useApnsTripRegistration', () => {
       const refreshed = mockRegister.mock.calls.find(
         (c) => (c[0] as { token: string }).token === 'token-NEW',
       );
-      expect(refreshed?.[0].locklessStationPassed).toBe(true);
+      expect(refreshed?.[0].infoModeEnabled).toBe(true);
     });
   });
 
@@ -1190,7 +1190,7 @@ describe('useApnsTripRegistration', () => {
         expect(mockRegister.mock.calls[0][0].promptDisplay).toBeDefined();
 
         // currentStation → null (BG GPS 누락 시뮬레이션). deps에 포함 안 됐으므로
-        // register 재호출 안 됨 (#703). token-refresh나 다음 locklessStationPassed toggle 등으로
+        // register 재호출 안 됨 (#703). token-refresh나 다음 infoModeEnabled toggle 등으로
         // re-register 시 캐시 활용 여부를 아래 token-refresh 경로로 검증.
         rerender({ cs: null });
         // 재등록 미발생 (currentStation은 deps 아님) — 캐시 검증은 token-refresh로 진행

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -55,7 +55,7 @@ export interface UseApnsTripRegistrationInputs {
    * true면 backend가 lock 부재 trip에서도 intermediate waypoint 통과 시 silent push 발사한다.
    * 미설정/false면 기존 #640 게이트 그대로 (lock 없으면 push 0건).
    */
-  locklessStationPassed?: boolean;
+  infoModeEnabled?: boolean;
   /**
    * #903 (Seam G) — 기압계 dP/dt가 지하 진입을 시사하는가. true면 backend로 함께 전달되어
    * consecutiveEtaMissing threshold를 5→10으로 늘려 일시 GPS/arrival 누락에 더 인내한다.
@@ -83,7 +83,7 @@ interface RegisterCallInputs {
   nextStationEtaSeconds: number | null;
   currentStation: Station | null;
   boardingLock: BoardingLock | null;
-  locklessStationPassed: boolean;
+  infoModeEnabled: boolean;
   /** #903 (Seam G) — 기압계 subsurface 신호. true면 backend threshold 5→10. */
   subsurface: boolean;
   /** 같은 trip 세션 동안 고정되는 epoch ms. backend `isSameSession` 판정 키(#589). */
@@ -175,7 +175,7 @@ async function callRegister(input: RegisterCallInputs) {
     createdAt: input.createdAt,
     ...(boardingLockMeta ? { boardingLock: boardingLockMeta } : {}),
     // #816 C — 토글 ON이면 backend에 lockless station-passed opt-in 명시. OFF면 필드 누락.
-    ...(input.locklessStationPassed ? { locklessStationPassed: true } : {}),
+    ...(input.infoModeEnabled ? { infoModeEnabled: true } : {}),
     // #819 / #1028 — boarding-prompt 평가/표시 컨텍스트. 짝으로만 송신.
     ...(promptContext
       ? {
@@ -194,7 +194,7 @@ export function useApnsTripRegistration({
   nextStationEtaSeconds,
   currentStation = null,
   boardingLock = null,
-  locklessStationPassed = false,
+  infoModeEnabled = false,
   subsurface = false,
 }: UseApnsTripRegistrationInputs): void {
   // route 객체 reference가 categorized recompute로 자주 바뀌므로 내용 기반 signature로
@@ -204,9 +204,9 @@ export function useApnsTripRegistration({
   // alarmBackend dedup hash와 동일 필드 사용 (trainCode + line + boardedAt).
   const boardingLockSig = lockSig(boardingLock);
   // 최신 트립 입력을 ref에 보관 — pushTokenListener가 갱신 시 재등록에 사용한다.
-  const latestInputsRef = useRef({ route, destination, nextStationEtaSeconds, currentStation, boardingLock, locklessStationPassed, subsurface });
+  const latestInputsRef = useRef({ route, destination, nextStationEtaSeconds, currentStation, boardingLock, infoModeEnabled, subsurface });
   useEffect(() => {
-    latestInputsRef.current = { route, destination, nextStationEtaSeconds, currentStation, boardingLock, locklessStationPassed, subsurface };
+    latestInputsRef.current = { route, destination, nextStationEtaSeconds, currentStation, boardingLock, infoModeEnabled, subsurface };
   });
 
   // #589 — backend `isSameSession`(token+createdAt) 판정용. 같은 trip(같은
@@ -275,7 +275,7 @@ export function useApnsTripRegistration({
           nextStationEtaSeconds: eta,
           currentStation: cs,
           boardingLock: bl,
-          locklessStationPassed: lsp,
+          infoModeEnabled: lsp,
           subsurface: sub,
         } = latestInputsRef.current;
         if (!r || !d) return;
@@ -287,7 +287,7 @@ export function useApnsTripRegistration({
           nextStationEtaSeconds: eta,
           currentStation: cs,
           boardingLock: bl,
-          locklessStationPassed: lsp,
+          infoModeEnabled: lsp,
           subsurface: sub,
           createdAt: resolveTripCreatedAt(sessionKey),
           cachedPromptContext: lastPromptContextRef.current,
@@ -374,7 +374,7 @@ export function useApnsTripRegistration({
         nextStationEtaSeconds,
         currentStation,
         boardingLock,
-        locklessStationPassed,
+        infoModeEnabled,
         subsurface,
         createdAt: resolveTripCreatedAt(sessionKey),
         cachedPromptContext: lastPromptContextRef.current,
@@ -428,5 +428,5 @@ export function useApnsTripRegistration({
     // 일시 GPS/arrival 누락에 인내. useBarometer의 60s 윈도우 평가가 토글 폭주를 자체 흡수하므로
     // deps churn 위험 낮음. alarmBackend의 dedup hash가 subsurface 미변화 사이클은 POST를 skip.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routeSig, destination?.id, boardingLockSig, locklessStationPassed, subsurface]);
+  }, [routeSig, destination?.id, boardingLockSig, infoModeEnabled, subsurface]);
 }

--- a/src/features/alarm/store/__tests__/tripBoundCleanupsAudit.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanupsAudit.test.ts
@@ -17,7 +17,7 @@
  *       `runTripBoundCleanups` 호출 금지(destination/route 살아남아야 함).
  *
  *  2. lock active → toggle OFF (B1 / PR-β):
- *     - `setLocklessStationPassed(false)` → `releaseLock()`만. trip 유지.
+ *     - `setInfoModeEnabled(false)` → `releaseLock()`만. trip 유지.
  *       `runTripBoundCleanups`는 호출 금지(destination 사용자 의도 보존).
  *
  *  3. lock active → toggle ON (사용자가 다시 ON):
@@ -116,7 +116,7 @@ describe('#1176 tripBoundCleanups audit — lockless ↔ lock 전이 회귀 가�
     jest.clearAllMocks();
     (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
     (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
-    useSettingsStore.setState({ locklessStationPassed: true });
+    useSettingsStore.setState({ infoModeEnabled: true });
     useDestinationStore.setState({
       destination: null,
       customOrigin: null,
@@ -126,21 +126,21 @@ describe('#1176 tripBoundCleanups audit — lockless ↔ lock 전이 회귀 가�
 
   // ── case 2: lock active → toggle OFF (B1 / PR-β) ─────────────────────────────
 
-  it('case 2: setLocklessStationPassed(false)은 releaseLock만 호출하고 runTripBoundCleanups를 호출하지 않는다', async () => {
+  it('case 2: setInfoModeEnabled(false)은 releaseLock만 호출하고 runTripBoundCleanups를 호출하지 않는다', async () => {
     // PR-β의 B1 결정: 토글 OFF는 lock만 정리하고 destination/route는 유지한다.
-    // 누군가 실수로 setLocklessStationPassed(false) → runTripBoundCleanups()를 추가하면
+    // 누군가 실수로 setInfoModeEnabled(false) → runTripBoundCleanups()를 추가하면
     // 사용자의 destination이 사라지는 회귀가 즉시 빨갛게 잡힌다.
-    await useSettingsStore.getState().setLocklessStationPassed(false);
+    await useSettingsStore.getState().setInfoModeEnabled(false);
     expect(mockReleaseLock).toHaveBeenCalledTimes(1);
     expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
     expect(mockTriggerTripEndRecall).not.toHaveBeenCalled();
   });
 
-  it('case 3: setLocklessStationPassed(true)은 releaseLock도 runTripBoundCleanups도 호출하지 않는다', async () => {
+  it('case 3: setInfoModeEnabled(true)은 releaseLock도 runTripBoundCleanups도 호출하지 않는다', async () => {
     // 토글 ON 전환은 backend register payload flag만 갱신하는 의미. lock 자동 재생성은
     // 사용자 명시 탑승 의사를 요구하므로 여기서 어떤 cleanup도 일어나면 안 된다.
-    useSettingsStore.setState({ locklessStationPassed: false });
-    await useSettingsStore.getState().setLocklessStationPassed(true);
+    useSettingsStore.setState({ infoModeEnabled: false });
+    await useSettingsStore.getState().setInfoModeEnabled(true);
     expect(mockReleaseLock).not.toHaveBeenCalled();
     expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
   });
@@ -190,7 +190,7 @@ describe('#1176 tripBoundCleanups audit — lockless ↔ lock 전이 회귀 가�
     // settings → alarm cross-feature는 의도된 orchestration이지만, 그 효과가
     // destination layer까지 확산되면 안 된다. settings → route 호출은 금지.
     useDestinationStore.setState({ destination: station });
-    await useSettingsStore.getState().setLocklessStationPassed(false);
+    await useSettingsStore.getState().setInfoModeEnabled(false);
     await Promise.resolve();
 
     expect(mockTriggerTripEndRecall).not.toHaveBeenCalled();

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -213,7 +213,7 @@ import {
   ACTIVE_TRIP_KEY,
   BACKEND_SSOT_MIRROR_KEY,
   DESTINATION_KEY,
-  LOCKLESS_STATION_PASSED_KEY,
+  INFO_MODE_ENABLED_KEY,
   ROUTE_KEY,
   SLEEP_MODE_KEY,
 } from '../../../../shared/constants/storageKeys';
@@ -1341,7 +1341,7 @@ describe('silentPushTask', () => {
         (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
           if (key === DESTINATION_KEY) return JSON.stringify(destStation);
           if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
-          if (key === LOCKLESS_STATION_PASSED_KEY) return JSON.stringify(true);
+          if (key === INFO_MODE_ENABLED_KEY) return JSON.stringify(true);
           return null;
         });
         await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent' }));
@@ -1373,7 +1373,7 @@ describe('silentPushTask', () => {
         (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
           if (key === DESTINATION_KEY) return JSON.stringify(destStation);
           if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
-          if (key === LOCKLESS_STATION_PASSED_KEY) {
+          if (key === INFO_MODE_ENABLED_KEY) {
             if (state === 'on') return JSON.stringify(true);
             if (state === 'off') return JSON.stringify(false);
             if (state === 'throw') throw new Error('boom');
@@ -1541,7 +1541,7 @@ describe('silentPushTask', () => {
         (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
           if (key === DESTINATION_KEY) return JSON.stringify(destStation);
           if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
-          if (key === LOCKLESS_STATION_PASSED_KEY) return JSON.stringify(value);
+          if (key === INFO_MODE_ENABLED_KEY) return JSON.stringify(value);
           return null;
         });
       }
@@ -1688,7 +1688,7 @@ describe('silentPushTask', () => {
 
       it('sleep ON + transfer + hopIndex=0 (first hop) → sleep-first-transfer skip', async () => {
         setAsyncStorageMap({
-          [LOCKLESS_STATION_PASSED_KEY]: JSON.stringify(true),
+          [INFO_MODE_ENABLED_KEY]: JSON.stringify(true),
           [SLEEP_MODE_KEY]: JSON.stringify(true),
         });
         await handleSilentPush(
@@ -1705,7 +1705,7 @@ describe('silentPushTask', () => {
 
       it('sleep ON + destination + hopIndex=0 → 통과 (destination은 절대 suppress 안 함)', async () => {
         setAsyncStorageMap({
-          [LOCKLESS_STATION_PASSED_KEY]: JSON.stringify(true),
+          [INFO_MODE_ENABLED_KEY]: JSON.stringify(true),
           [SLEEP_MODE_KEY]: JSON.stringify(true),
         });
         await handleSilentPush(
@@ -1717,7 +1717,7 @@ describe('silentPushTask', () => {
 
       it('sleep ON + transfer + hopIndex>0 → 통과 (first hop 아님)', async () => {
         setAsyncStorageMap({
-          [LOCKLESS_STATION_PASSED_KEY]: JSON.stringify(true),
+          [INFO_MODE_ENABLED_KEY]: JSON.stringify(true),
           [SLEEP_MODE_KEY]: JSON.stringify(true),
         });
         await handleSilentPush(
@@ -1728,7 +1728,7 @@ describe('silentPushTask', () => {
 
       it('sleep OFF + transfer + hopIndex=0 → 통과', async () => {
         setAsyncStorageMap({
-          [LOCKLESS_STATION_PASSED_KEY]: JSON.stringify(true),
+          [INFO_MODE_ENABLED_KEY]: JSON.stringify(true),
           [SLEEP_MODE_KEY]: JSON.stringify(false),
         });
         await handleSilentPush(
@@ -1739,7 +1739,7 @@ describe('silentPushTask', () => {
 
       it('SLEEP_MODE_KEY AsyncStorage read 오류 → 가드 자연 skip (안전 fallback)', async () => {
         setAsyncStorageMap({
-          [LOCKLESS_STATION_PASSED_KEY]: JSON.stringify(true),
+          [INFO_MODE_ENABLED_KEY]: JSON.stringify(true),
           [SLEEP_MODE_KEY]: THROW,
         });
         await handleSilentPush(
@@ -1751,7 +1751,7 @@ describe('silentPushTask', () => {
 
       it('SLEEP_MODE_KEY 부재 (key 자체 없음) → 가드 자연 skip (기본 OFF)', async () => {
         // SLEEP_MODE_KEY override 없음 → 기본 null 반환 → loadSleepModeFlag가 false return.
-        setAsyncStorageMap({ [LOCKLESS_STATION_PASSED_KEY]: JSON.stringify(true) });
+        setAsyncStorageMap({ [INFO_MODE_ENABLED_KEY]: JSON.stringify(true) });
         await handleSilentPush(
           payload({ kind: 'transfer', phase: 'imminent', hopIndex: 0 }),
         );

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -37,7 +37,7 @@ import {
   APNS_TOKEN_KEY,
   ACTIVE_TRIP_KEY,
   DESTINATION_KEY,
-  LOCKLESS_STATION_PASSED_KEY,
+  INFO_MODE_ENABLED_KEY,
   SLEEP_MODE_KEY,
 } from '../../../shared/constants/storageKeys';
 import { sendPushAck } from '../api/alarmBackend';
@@ -707,7 +707,7 @@ async function loadApnsToken(): Promise<string | null> {
  */
 async function loadLocklessOptIn(): Promise<boolean> {
   try {
-    const raw = await AsyncStorage.getItem(LOCKLESS_STATION_PASSED_KEY);
+    const raw = await AsyncStorage.getItem(INFO_MODE_ENABLED_KEY);
     if (!raw) return false;
     return JSON.parse(raw) === true;
   } catch {

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -1370,7 +1370,7 @@ function DebugModalInner({
   // #856: lockless station-passed toggle. OFF면 backend가 받은 silent push도 client가
   // intermediate 알림을 차단 → "received는 늘어도 fired는 안 늘어남"이 정상 동작.
   // DebugModal에 한 줄로 노출해 사용자가 설정 위치를 즉시 알 수 있게 한다.
-  const locklessOn = useSettingsStore((s) => s.locklessStationPassed);
+  const locklessOn = useSettingsStore((s) => s.infoModeEnabled);
   // #1215 (D9) — 기압계 subsurface. useBarometer는 shared/hooks이라 의존 위배 없음.
   // useFusedNearestStation 내부 useBarometer와 별개 listener — DebugModal 관찰자 효과 허용 범위.
   // #1398 — `stop=undefined` 원인(unavailableReason)과 readingCount도 dump에 노출.

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -2262,13 +2262,13 @@ describe('DebugModal — Silent Push UX 카운트/토글 (#856)', () => {
     jest.clearAllMocks();
     setupHookDefaults();
     act(() => {
-      useSettingsStore.setState({ locklessStationPassed: false });
+      useSettingsStore.setState({ infoModeEnabled: false });
     });
   });
 
   afterEach(() => {
     act(() => {
-      useSettingsStore.setState({ locklessStationPassed: false });
+      useSettingsStore.setState({ infoModeEnabled: false });
     });
   });
 
@@ -2299,15 +2299,15 @@ describe('DebugModal — Silent Push UX 카운트/토글 (#856)', () => {
     expect(screen.getByText(/^1 \(last \d{2}:\d{2}:\d{2}\)$/)).toBeTruthy();
   });
 
-  it('locklessStationPassed=false면 toggle row가 OFF 안내 문구로 노출된다', async () => {
+  it('infoModeEnabled=false면 toggle row가 OFF 안내 문구로 노출된다', async () => {
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
     expect(screen.getByText(/lockless station-passed 비활성/)).toBeTruthy();
   });
 
-  it('locklessStationPassed=true면 toggle row가 "on"으로 노출된다', async () => {
+  it('infoModeEnabled=true면 toggle row가 "on"으로 노출된다', async () => {
     act(() => {
-      useSettingsStore.setState({ locklessStationPassed: true });
+      useSettingsStore.setState({ infoModeEnabled: true });
     });
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
@@ -2320,7 +2320,7 @@ describe('DebugModal — Silent Push UX 카운트/토글 (#856)', () => {
       { ts: 2, source: 'silent-push-fired', outcome: 'fired' },
     ]);
     act(() => {
-      useSettingsStore.setState({ locklessStationPassed: true });
+      useSettingsStore.setState({ infoModeEnabled: true });
     });
     const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
     renderWithTheme(<DebugModal onClose={jest.fn()} />);

--- a/src/features/settings/store/__tests__/useSettingsStore.test.ts
+++ b/src/features/settings/store/__tests__/useSettingsStore.test.ts
@@ -45,7 +45,7 @@ describe('useSettingsStore', () => {
       allowSpeaker: true,
       accessibilityMode: false,
       // #915 — default ON. 각 테스트가 명시적으로 false로 덮어쓸 수 있다.
-      locklessStationPassed: true,
+      infoModeEnabled: true,
       sentryOptIn: false,
     });
     jest.clearAllMocks();
@@ -169,25 +169,25 @@ describe('useSettingsStore', () => {
     expect(useSettingsStore.getState().accessibilityMode).toBe(false);
   });
 
-  // ── #816 C / #915 — locklessStationPassed (기본 ON, destination-only baseline) ──
+  // ── #816 C / #915 — infoModeEnabled (기본 ON, destination-only baseline) ──
 
-  it('초기 locklessStationPassed는 true이다 (#915 default ON)', () => {
-    expect(useSettingsStore.getState().locklessStationPassed).toBe(true);
+  it('초기 infoModeEnabled는 true이다 (#915 default ON)', () => {
+    expect(useSettingsStore.getState().infoModeEnabled).toBe(true);
   });
 
-  it('setLocklessStationPassed: false를 설정하면 상태와 AsyncStorage가 갱신된다', async () => {
-    await useSettingsStore.getState().setLocklessStationPassed(false);
-    expect(useSettingsStore.getState().locklessStationPassed).toBe(false);
+  it('setInfoModeEnabled: false를 설정하면 상태와 AsyncStorage가 갱신된다', async () => {
+    await useSettingsStore.getState().setInfoModeEnabled(false);
+    expect(useSettingsStore.getState().infoModeEnabled).toBe(false);
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
       'subway-now:lockless-station-passed',
       JSON.stringify(false),
     );
   });
 
-  it('setLocklessStationPassed: true를 설정하면 상태와 AsyncStorage가 갱신된다', async () => {
-    useSettingsStore.setState({ locklessStationPassed: false });
-    await useSettingsStore.getState().setLocklessStationPassed(true);
-    expect(useSettingsStore.getState().locklessStationPassed).toBe(true);
+  it('setInfoModeEnabled: true를 설정하면 상태와 AsyncStorage가 갱신된다', async () => {
+    useSettingsStore.setState({ infoModeEnabled: false });
+    await useSettingsStore.getState().setInfoModeEnabled(true);
+    expect(useSettingsStore.getState().infoModeEnabled).toBe(true);
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
       'subway-now:lockless-station-passed',
       JSON.stringify(true),
@@ -195,48 +195,48 @@ describe('useSettingsStore', () => {
   });
 
   // B1 (Epic #1008, ADR-013) — 토글 OFF 시 활성 BoardingLock cleanup
-  it('setLocklessStationPassed(false): useBoardingLockStore.releaseLock을 호출한다', async () => {
+  it('setInfoModeEnabled(false): useBoardingLockStore.releaseLock을 호출한다', async () => {
     const releaseLock = jest.fn().mockResolvedValue(undefined);
     useBoardingLockStoreMock.getState.mockReturnValue({ releaseLock });
-    await useSettingsStore.getState().setLocklessStationPassed(false);
+    await useSettingsStore.getState().setInfoModeEnabled(false);
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 
-  it('setLocklessStationPassed(true): releaseLock을 호출하지 않는다', async () => {
+  it('setInfoModeEnabled(true): releaseLock을 호출하지 않는다', async () => {
     const releaseLock = jest.fn().mockResolvedValue(undefined);
     useBoardingLockStoreMock.getState.mockReturnValue({ releaseLock });
-    await useSettingsStore.getState().setLocklessStationPassed(true);
+    await useSettingsStore.getState().setInfoModeEnabled(true);
     expect(releaseLock).not.toHaveBeenCalled();
   });
 
-  it('loadLocklessStationPassed: 저장된 false를 복원한다 (기존 사용자 명시 OFF 보존)', async () => {
+  it('loadInfoModeEnabled: 저장된 false를 복원한다 (기존 사용자 명시 OFF 보존)', async () => {
     (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(false));
-    await useSettingsStore.getState().loadLocklessStationPassed();
-    expect(useSettingsStore.getState().locklessStationPassed).toBe(false);
+    await useSettingsStore.getState().loadInfoModeEnabled();
+    expect(useSettingsStore.getState().infoModeEnabled).toBe(false);
   });
 
-  it('loadLocklessStationPassed: 저장된 값이 없으면 기본 true 유지 (#915)', async () => {
+  it('loadInfoModeEnabled: 저장된 값이 없으면 기본 true 유지 (#915)', async () => {
     (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
-    await useSettingsStore.getState().loadLocklessStationPassed();
-    expect(useSettingsStore.getState().locklessStationPassed).toBe(true);
+    await useSettingsStore.getState().loadInfoModeEnabled();
+    expect(useSettingsStore.getState().infoModeEnabled).toBe(true);
   });
 
-  it('loadLocklessStationPassed: AsyncStorage 오류 시 true 유지', async () => {
+  it('loadInfoModeEnabled: AsyncStorage 오류 시 true 유지', async () => {
     (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage error'));
-    await useSettingsStore.getState().loadLocklessStationPassed();
-    expect(useSettingsStore.getState().locklessStationPassed).toBe(true);
+    await useSettingsStore.getState().loadInfoModeEnabled();
+    expect(useSettingsStore.getState().infoModeEnabled).toBe(true);
   });
 
   // #1175 — lockless funnel transition emit
-  it('setLocklessStationPassed: prev=true → next=false 시 emit(true, false) 호출', async () => {
-    useSettingsStore.setState({ locklessStationPassed: true });
-    await useSettingsStore.getState().setLocklessStationPassed(false);
+  it('setInfoModeEnabled: prev=true → next=false 시 emit(true, false) 호출', async () => {
+    useSettingsStore.setState({ infoModeEnabled: true });
+    await useSettingsStore.getState().setInfoModeEnabled(false);
     expect(emitLocklessToggleTransition).toHaveBeenCalledWith(true, false);
   });
 
-  it('setLocklessStationPassed: prev=false → next=true 시 emit(false, true) 호출', async () => {
-    useSettingsStore.setState({ locklessStationPassed: false });
-    await useSettingsStore.getState().setLocklessStationPassed(true);
+  it('setInfoModeEnabled: prev=false → next=true 시 emit(false, true) 호출', async () => {
+    useSettingsStore.setState({ infoModeEnabled: false });
+    await useSettingsStore.getState().setInfoModeEnabled(true);
     expect(emitLocklessToggleTransition).toHaveBeenCalledWith(false, true);
   });
 

--- a/src/features/settings/store/useSettingsStore.ts
+++ b/src/features/settings/store/useSettingsStore.ts
@@ -10,7 +10,7 @@ import {
   SLEEP_MODE_KEY,
   ALLOW_SPEAKER_KEY,
   ACCESSIBILITY_MODE_KEY,
-  LOCKLESS_STATION_PASSED_KEY,
+  INFO_MODE_ENABLED_KEY,
 } from '../../../shared/constants/storageKeys';
 import { getSentryOptIn, setSentryOptIn } from '../../../shared/infra/monitoring/sentryInit';
 import { useBoardingLockStore } from '../../alarm/store/useBoardingLockStore';
@@ -19,7 +19,7 @@ import { emitLocklessToggleTransition } from '../utils/locklessFunnel';
 /**
  * Settings store — ADR 후속 Step 6 (#892).
  *
- * 사용자 토글 묶음: sleepMode / allowSpeaker / accessibilityMode / locklessStationPassed.
+ * 사용자 토글 묶음: sleepMode / allowSpeaker / accessibilityMode / infoModeEnabled.
  * 각 토글은 AsyncStorage에 개별 키로 영속화되고 boolean 단일 값만 갖는다.
  *
  * 원본: `src/store/useAppStore.ts` settings slice (god object 분해).
@@ -42,10 +42,11 @@ export interface SettingsState {
    * 기본 ON (#915 — destination-only baseline). ON 시 useApnsTripRegistration이 backend trip register
    * payload에 포함시키고, backend가 lockless intermediate 발사를 허용한다. 사용자가 명시적으로 OFF
    * 하지 않는 한 zero-config baseline UX를 위해 매역 알림이 자동 동작한다.
+   * UI 라벨: "전체역 보기". (#1669 rename: locklessStationPassed → infoModeEnabled)
    */
-  locklessStationPassed: boolean;
-  setLocklessStationPassed: (enabled: boolean) => Promise<void>;
-  loadLocklessStationPassed: () => Promise<void>;
+  infoModeEnabled: boolean;
+  setInfoModeEnabled: (enabled: boolean) => Promise<void>;
+  loadInfoModeEnabled: () => Promise<void>;
 
   /**
    * #1038 follow-up — Sentry 오류 진단 정보 전송 opt-in. 기본 OFF.
@@ -62,7 +63,7 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   allowSpeaker: true,
   accessibilityMode: false,
   // #915 — destination-only baseline UX. 매역 알림이 zero-config로 동작하도록 default ON.
-  locklessStationPassed: true,
+  infoModeEnabled: true,
   // #1038 — privacy stance. 사용자가 명시 동의해야 활성화.
   sentryOptIn: false,
 
@@ -114,11 +115,11 @@ export const useSettingsStore = create<SettingsState>((set) => ({
     }
   },
 
-  setLocklessStationPassed: async (enabled: boolean) => {
+  setInfoModeEnabled: async (enabled: boolean) => {
     // #1175 — funnel transition emit. set() 전에 prev를 캡처해야 정확한 분기를 얻는다.
-    const prev = useSettingsStore.getState().locklessStationPassed;
-    set({ locklessStationPassed: enabled });
-    await AsyncStorage.setItem(LOCKLESS_STATION_PASSED_KEY, JSON.stringify(enabled));
+    const prev = useSettingsStore.getState().infoModeEnabled;
+    set({ infoModeEnabled: enabled });
+    await AsyncStorage.setItem(INFO_MODE_ENABLED_KEY, JSON.stringify(enabled));
     // B1 (ADR-013): 토글 OFF 전환 시 활성 BoardingLock을 즉시 해제하여
     // "전체역 보기 OFF면 lockless 알림 없음" 의미를 즉시 반영한다.
     if (!enabled) {
@@ -127,11 +128,11 @@ export const useSettingsStore = create<SettingsState>((set) => ({
     await emitLocklessToggleTransition(prev, enabled);
   },
 
-  loadLocklessStationPassed: async () => {
+  loadInfoModeEnabled: async () => {
     try {
-      const raw = await AsyncStorage.getItem(LOCKLESS_STATION_PASSED_KEY);
+      const raw = await AsyncStorage.getItem(INFO_MODE_ENABLED_KEY);
       if (raw) {
-        set({ locklessStationPassed: JSON.parse(raw) === true });
+        set({ infoModeEnabled: JSON.parse(raw) === true });
       }
     } catch {
       // 저장된 데이터 없음 — false 유지

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -120,8 +120,8 @@ export default function HomeScreen() {
   const loadSleepMode = useSettingsStore((s) => s.loadSleepMode);
   const loadAllowSpeaker = useSettingsStore((s) => s.loadAllowSpeaker);
   // #816 C — lockless station-passed 토글. useApnsTripRegistration이 backend register payload에 포함시킨다.
-  const locklessStationPassed = useSettingsStore((s) => s.locklessStationPassed);
-  const loadLocklessStationPassed = useSettingsStore((s) => s.loadLocklessStationPassed);
+  const infoModeEnabled = useSettingsStore((s) => s.infoModeEnabled);
+  const loadInfoModeEnabled = useSettingsStore((s) => s.loadInfoModeEnabled);
   const showSleepModeGuide = useSleepModeGuide();
   const alarmEvent = useAlarmEventStore((s) => s.alarmEvent);
   const clearAlarmEvent = useAlarmEventStore((s) => s.clearAlarmEvent);
@@ -680,7 +680,7 @@ export default function HomeScreen() {
       nextTrainMinutes != null && nextTrainMinutes !== Infinity ? nextTrainMinutes * 60 : null,
     currentStation: result?.station ?? null,
     boardingLock,
-    locklessStationPassed,
+    infoModeEnabled,
     subsurface: barometerSubsurface,
   });
 
@@ -698,7 +698,7 @@ export default function HomeScreen() {
     loadRoutePreference();
     loadRecentDestinations();
     loadAlarmEvent();
-    loadLocklessStationPassed();
+    loadInfoModeEnabled();
     loadDismissSilence();
     // iOS가 BG에서 앱을 메모리 압박으로 종료하면 Zustand 상태는 휘발되지만
     // DESTINATION_KEY는 디스크에 남는다. 콜드/웜 부팅 시 복원해 trip을 이어간다 (#541).

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -38,9 +38,9 @@ export default function SettingsScreen() {
   const setAccessibilityMode = useSettingsStore((s) => s.setAccessibilityMode);
   const loadAccessibilityMode = useSettingsStore((s) => s.loadAccessibilityMode);
   // #816 C — lockless station-passed opt-in 토글.
-  const locklessStationPassed = useSettingsStore((s) => s.locklessStationPassed);
-  const setLocklessStationPassed = useSettingsStore((s) => s.setLocklessStationPassed);
-  const loadLocklessStationPassed = useSettingsStore((s) => s.loadLocklessStationPassed);
+  const infoModeEnabled = useSettingsStore((s) => s.infoModeEnabled);
+  const setInfoModeEnabled = useSettingsStore((s) => s.setInfoModeEnabled);
+  const loadInfoModeEnabled = useSettingsStore((s) => s.loadInfoModeEnabled);
   // #1038 follow-up — Sentry 오류 진단 정보 opt-in.
   const sentryOptIn = useSettingsStore((s) => s.sentryOptIn);
   const setSentryOptIn = useSettingsStore((s) => s.setSentryOptIn);
@@ -63,7 +63,7 @@ export default function SettingsScreen() {
     loadAllowSpeaker();
     loadAccessibilityMode();
     loadRoutePreference();
-    loadLocklessStationPassed();
+    loadInfoModeEnabled();
     loadSentryOptIn();
     // #1175 — lockless 토글 학습 funnel viewed step. SettingsScreen 진입 = 토글 노출.
     emitLocklessToggleViewed();
@@ -175,15 +175,15 @@ export default function SettingsScreen() {
               </Text>
             </View>
             <Switch
-              value={locklessStationPassed}
-              onValueChange={setLocklessStationPassed}
+              value={infoModeEnabled}
+              onValueChange={setInfoModeEnabled}
               trackColor={{ false: colors.hair, true: colors.accent }}
-              thumbColor={locklessStationPassed ? colors.onAccent : colors.subtle}
+              thumbColor={infoModeEnabled ? colors.onAccent : colors.subtle}
               testID="lockless-station-passed-switch"
               accessibilityRole="switch"
               accessibilityLabel={t('settings.locklessStationPassedLabel')}
               accessibilityHint={t('a11y.settings.locklessStationPassedHint')}
-              accessibilityState={{ checked: locklessStationPassed }}
+              accessibilityState={{ checked: infoModeEnabled }}
             />
           </View>
         </View>

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -55,7 +55,8 @@ export const BG_LAST_STATION_KEY = 'subway-now:bg-last-station';
 // #816 C — 사용자 opt-in 토글: lock 없는 trip route에서도 station-passed 알림 허용 여부.
 // 기본 OFF. #640 회귀(lock 없는 noise alarm) 차단을 위해 명시적 opt-in 필요.
 // 형식: 'true' 또는 키 부재. (sleep 모드 같은 패턴 — 단순 boolean)
-export const LOCKLESS_STATION_PASSED_KEY = 'subway-now:lockless-station-passed';
+// AsyncStorage key string은 backward-compat 유지 — #1669 rename.
+export const INFO_MODE_ENABLED_KEY = 'subway-now:lockless-station-passed';
 // #816 B — boardingPrompt 발사 추적 (trip당 1회 발사 + dismiss 시 5분 silence).
 // 형식: {"tripKey": string, "promptedAt": number, "dismissedAt"?: number} JSON.
 // tripKey는 `${destinationId}|${createdAtBucketMs}` — destination 변경 시 자동 reset.


### PR DESCRIPTION
## Summary

- `locklessStationPassed` → `infoModeEnabled` 전수 rename (변수명 단순화 — UI 라벨은 이미 "전체역 보기"로 단순화됨)
- UI 변경 없음 — i18n key(`settings.locklessStationPassedLabel` 등) 그대로 유지
- V/X 영향 없음 — cleanup only

Closes #1669

---

## Wire Matrix (rename 영향)

| Layer | 변경 파일 |
|---|---|
| Settings store | `src/features/settings/store/useSettingsStore.ts` |
| Storage const 이름 | `src/shared/constants/storageKeys.ts` — `INFO_MODE_ENABLED_KEY` (string 값 유지) |
| Alarm hook | `src/features/alarm/hooks/useApnsTripRegistration.ts` |
| Alarm API | `src/features/alarm/api/alarmBackend.ts` |
| Silent push task | `src/features/alarm/tasks/silentPushTask.ts` |
| Screens | `src/screens/SettingsScreen.tsx`, `src/screens/HomeScreen.tsx` |
| Debug modal | `src/features/debug/components/DebugModal.tsx` |
| Backend types | `backend/alarm-worker/src/types.ts` |
| Backend logic | `backend/alarm-worker/src/index.ts`, `backend/alarm-worker/src/scheduled.ts` |
| Backend comment | `backend/alarm-worker/src/consensusGate.ts` |
| Tests | 전수 (21개 파일) |

---

## Backward-Compat 보장

| 항목 | 방법 |
|---|---|
| AsyncStorage persist key | `'subway-now:lockless-station-passed'` string 그대로 유지 — 기존 사용자 토글 상태 보존 |
| Backend POST /trips 구 device | `validateTrip`에서 `infoModeEnabled ?? locklessStationPassed` fallback. 구 device(old APK/IPA)가 `locklessStationPassed` 필드를 보내도 `infoModeEnabled`로 정상 파싱 |
| Telemetry step ID | `lockless_toggle.*` step 이름 유지 — 외부 노출 string 미변경 |

---

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` 0 orphan ✅
2. **V/X dashboard** — rename only, 신규 신호 없음. DebugModal `locklessOn` 로컬 변수는 store selector(`s.infoModeEnabled`)만 변경
3. **의존 PR** — N/A (단독 cleanup)
4. **측정 plan** — V/X 영향 없음. 기존 telemetry step ID 유지로 측정 연속성 보장
5. **Device verify** — N/A — type+unit only. UI 변경 없음, AsyncStorage key 유지, backward-compat 검증됨

---

## Test 결과

- `npm run type-check` — 0 errors ✅
- 영향 파일 732 tests — 전부 pass ✅
- `npm run lint:orphan` — 0 orphan ✅
- 사전 존재 실패(`widgetStorage`) 변동 없음 (본 PR 무관)