### PR TITLE
fix(#1667): ADR-015 consensusGate strongDB wire (wifiSsidStationName device→backend)

### DIFF
--- a/backend/alarm-worker/src/__tests__/autoLock.test.ts
+++ b/backend/alarm-worker/src/__tests__/autoLock.test.ts
@@ -614,3 +614,103 @@ describe('attemptAutoLock #1614 Phase B selfPollPositions wire (S4)', () => {
     expect(lock?.trainCode).toBe('T1');
   });
 });
+
+/**
+ * #1667 (ADR-015 strongDB wire) — wifiSsidStationName → wifiSsidMatch forward.
+ *
+ * targetWaypoint.stationName = '역삼'. wifiSsidStationName이 '역삼'이면 wifiSsidMatch=true → strongDB.
+ * 다른 역명 / undefined → wifiSsidMatch false/undefined → strongDB 비활성.
+ */
+function callAutoLockWithWifi(
+  arrivalEntry: ArrivalEntry,
+  wifiSsidStationName: string | undefined,
+  opts: {
+    environment?: Parameters<typeof attemptAutoLock>[0]['environment'];
+    gateOutcome?: Parameters<typeof attemptAutoLock>[0]['gateOutcome'];
+  } = {},
+) {
+  return attemptAutoLock({
+    trip: makeTrip(),
+    targetWaypoint: target, // stationName='역삼'
+    originStation: '강남',
+    direction: 'up',
+    seoul: makeSeoul([arrivalEntry]),
+    now: NOW,
+    environment: opts.environment,
+    gateOutcome: opts.gateOutcome,
+    wifiSsidStationName,
+  });
+}
+
+describe('attemptAutoLock #1667 wifiSsidStationName → strongDB wire', () => {
+  it.each([
+    {
+      label: 'wifiSsidStationName 일치(역삼) + arvlCd 1 → strongDB pass (underground, base gate fail)',
+      wifi: '역삼',
+      arvlCd: 1,
+      expected: 'lock' as const,
+    },
+    {
+      label: 'wifiSsidStationName 불일치(강남) + arvlCd 1 → strongDB false, strongBE pass (lockAttachable + arrival)',
+      wifi: '강남',
+      arvlCd: 1,
+      expected: 'lock' as const,
+    },
+    {
+      label: 'wifiSsidStationName 불일치(강남) + arvlCd 5(범위 밖) → strongDB false + strongBE false → null',
+      wifi: '강남',
+      arvlCd: 5,
+      expected: 'null' as const,
+    },
+    {
+      label: 'wifiSsidStationName 일치(역삼) + arvlCd 5(범위 밖) → wifiSsidMatch true but arrivalSignalPresent false → null',
+      wifi: '역삼',
+      arvlCd: 5,
+      expected: 'null' as const,
+    },
+    {
+      label: 'wifiSsidStationName undefined + arvlCd 1 → wifiSsidMatch undefined, strongBE pass',
+      wifi: undefined,
+      arvlCd: 1,
+      expected: 'lock' as const,
+    },
+  ])('underground + $label', async ({ wifi, arvlCd, expected }) => {
+    const { lock } = await callAutoLockWithWifi(
+      arrival({ trainCode: 'T1', arvlCd }),
+      wifi,
+      {
+        environment: 'underground',
+        gateOutcome: failingGateOutcome(),
+      },
+    );
+    if (expected === 'lock') {
+      expect(lock?.trainCode).toBe('T1');
+    } else {
+      expect(lock).toBeNull();
+    }
+  });
+
+  it('wifiSsidStationName undefined → 기존 동작 (구 호출자 호환, consensusGate skip)', async () => {
+    const { lock } = await callAutoLockWithWifi(
+      arrival({ trainCode: 'T1', arvlCd: 1 }),
+      undefined,
+      {
+        environment: 'underground',
+        gateOutcome: passingGateOutcome(),
+      },
+    );
+    expect(lock?.trainCode).toBe('T1');
+  });
+
+  it('surface: wifiSsidStationName 무관 — base gate pass면 통과 (wifiSsidMatch 평가 X)', async () => {
+    const { lock } = await callAutoLockWithWifi(
+      arrival({ trainCode: 'T1', arvlCd: 1 }),
+      '강남', // 불일치지만 surface는 base gate만
+      {
+        environment: 'surface',
+        gateOutcome: passingGateOutcome(),
+      },
+    );
+    expect(lock?.trainCode).toBe('T1');
+  });
+});

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1778,6 +1778,54 @@ describe('POST /position (#819)', () => {
     });
   });
 
+  describe('#1667 (ADR-015 strongDB) — wifiSsidStationName 옵션 필드', () => {
+    const BASE_POS = {
+      token: 'tok-wifi',
+      lat: 1,
+      lng: 2,
+      accuracy: 5,
+      ts: 1234,
+      motion: 'walking' as const,
+    };
+
+    it('비어있지 않은 문자열 → point.wifiSsidStationName에 set', async () => {
+      const env = makeKvEnv();
+      const res = await post(
+        '/position',
+        { ...BASE_POS, wifiSsidStationName: '강남' },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const stored = JSON.parse(
+        (await env.TRIPS.get('pos:tok-wifi'))!,
+      ) as Array<Record<string, unknown>>;
+      expect(stored[0].wifiSsidStationName).toBe('강남');
+    });
+
+    it('빈 문자열 → undefined로 graceful skip (payload 거부 X)', async () => {
+      const env = makeKvEnv();
+      const res = await post(
+        '/position',
+        { ...BASE_POS, wifiSsidStationName: '' },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const stored = JSON.parse(
+        (await env.TRIPS.get('pos:tok-wifi'))!,
+      ) as Array<Record<string, unknown>>;
+      expect(stored[0].wifiSsidStationName).toBeUndefined();
+    });
+
+    it('필드 없음 → undefined (회귀 없음)', async () => {
+      const env = makeKvEnv();
+      await post('/position', BASE_POS, env);
+      const stored = JSON.parse(
+        (await env.TRIPS.get('pos:tok-wifi'))!,
+      ) as Array<Record<string, unknown>>;
+      expect(stored[0].wifiSsidStationName).toBeUndefined();
+    });
+  });
+
   describe('#1534 (S1, T9b, ADR-016) — response embed lockSuggestion + originStationId', () => {
     const BASE_POS = {
       token: 'tok-ls',

--- a/backend/alarm-worker/src/autoLock.ts
+++ b/backend/alarm-worker/src/autoLock.ts
@@ -161,6 +161,19 @@ export interface AttemptAutoLockInputs {
    * 미전달(undefined) / 빈 배열 시 consensusGate가 자연 `?? false` fallback (strongBE 동작 유지).
    */
   selfPollPositions?: readonly { trainCode: string; stationName: string }[];
+  /**
+   * #1667 (ADR-015 strongDB wire) — device가 WiFi SSID 매핑으로 결정한 역명.
+   *
+   * `PositionPoint.wifiSsidStationName`에서 가장 최근 point의 값을 forward.
+   * caller(scheduled.ts)가 `fusion.series`의 마지막 point에서 추출해 전달한다.
+   *
+   * attemptAutoLock 내부에서 `targetWaypoint.stationName`과 비교해 `wifiSsidMatch` boolean을
+   * 산출 → `evaluateConsensusGate`의 strongDB 분기를 활성화.
+   *
+   * 미전달(undefined) → wifiSsidMatch=undefined → consensusGate가 `?? false` fallback
+   * (strongBE/strongCB fallback 유지 — iOS WiFi 미연결 시 graceful 동작).
+   */
+  wifiSsidStationName?: string;
 }
 
 /**
@@ -226,6 +239,7 @@ export async function attemptAutoLock(
     environment,
     gateOutcome,
     selfPollPositions,
+    wifiSsidStationName,
   } = inputs;
   const line = targetWaypoint.line;
   const subwayId = subwayIdForLine(line);
@@ -271,6 +285,14 @@ export async function attemptAutoLock(
     const positionTrainAgreement = selfPollPositions
       ? selfPollPositions.some((p) => p.trainCode === trainCode)
       : undefined;
+    // #1667 (ADR-015 strongDB wire) — device WiFi SSID 매핑 역명 cross-match.
+    // wifiSsidStationName이 targetWaypoint.stationName과 일치하면 사용자가 해당 역 WiFi에
+    // 연결 중 → underground에서 strongDB(D) + arrival(B) 2-of-2 통과 path를 연다.
+    // undefined(미전달/iOS WiFi 미연결/Android) → undefined → consensusGate `?? false` fallback.
+    const wifiSsidMatch =
+      typeof wifiSsidStationName === 'string'
+        ? wifiSsidStationName === targetWaypoint.stationName
+        : undefined;
     const consensus = evaluateConsensusGate(environment, {
       gateOutcome,
       arrivalSignalPresent,
@@ -278,6 +300,7 @@ export async function attemptAutoLock(
       // 더 위에서 return 했으므로 본 시점에서는 항상 true.
       lockAttachable: true,
       positionTrainAgreement,
+      wifiSsidMatch,
     });
     if (!consensus.pass) return { lock: null };
   }

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -1171,6 +1171,12 @@ export function validatePositionPayload(input: unknown): PositionUploadPayload |
     obj.cellularEnvironmentVote === 'unknown'
       ? obj.cellularEnvironmentVote
       : undefined;
+  // #1667 (ADR-015 strongDB) — WiFi SSID 매핑 역명. 디바이스가 lookupStationBySsid 결과를 forward.
+  // 빈 문자열은 "매칭 없음"과 동일 → graceful omit (consensusGate wifiSsidMatch=false fallback).
+  const wifiSsidStationName =
+    typeof obj.wifiSsidStationName === 'string' && obj.wifiSsidStationName.length > 0
+      ? obj.wifiSsidStationName
+      : undefined;
   return {
     token: obj.token,
     point: {
@@ -1183,6 +1189,7 @@ export function validatePositionPayload(input: unknown): PositionUploadPayload |
       ...(nearestStationDistanceM !== undefined ? { nearestStationDistanceM } : {}),
       ...(currentStationName !== undefined ? { currentStationName } : {}),
       ...(cellularEnvironmentVote !== undefined ? { cellularEnvironmentVote } : {}),
+      ...(wifiSsidStationName !== undefined ? { wifiSsidStationName } : {}),
     },
     accelSummary,
   };

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -2577,6 +2577,9 @@ async function maybeBindLocklessTrainCode(
     // #1614 Phase B — self-poll 결과를 attemptAutoLock 에 forward. 함수 내부에서 trainCode 결정
     // 직후 cross-match 후 consensusGate 입력으로 positionTrainAgreement 전달.
     selfPollPositions: selfPollPositions?.positions,
+    // #1667 (ADR-015 strongDB) — 마지막 position point의 WiFi SSID 매핑 역명 forward.
+    // undefined(iOS WiFi 미연결/Android/시리즈 없음) 시 consensusGate가 자연 false fallback.
+    wifiSsidStationName: fusion.series[fusion.series.length - 1]?.wifiSsidStationName,
   });
   if (autoLockResult.confidenceTrace && env.TELEMETRY) {
     recordAutoLockConfidence(env.TELEMETRY, trip.token, autoLockResult.confidenceTrace);
@@ -3024,6 +3027,9 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       // #1536 (S3) — environment + gateOutcome forward. 환경 분기 consensusGate 강제.
       environment,
       gateOutcome: outcome,
+      // #1667 (ADR-015 strongDB) — 마지막 position point의 WiFi SSID 매핑 역명 forward.
+      // undefined(iOS WiFi 미연결/Android/시리즈 없음) 시 consensusGate가 자연 false fallback.
+      wifiSsidStationName: fusion.series[fusion.series.length - 1]?.wifiSsidStationName,
     });
     // #1171 — RC1 confidence gate가 평가된 경우(arvlCd=2 branch) score 분포를 AE에 적재.
     // 1주 운영 후 본 분포로 AUTO_LOCK_CONFIDENCE_THRESHOLD 튜닝 결정.

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -426,6 +426,19 @@ export interface PositionPoint {
    * backend는 undefined를 'unknown' 동급으로 graceful 처리.
    */
   cellularEnvironmentVote?: 'surface' | 'underground' | 'unknown';
+  /**
+   * #1667 (ADR-015 strongDB wire) — 디바이스가 WiFi SSID 매핑으로 결정한 역명.
+   *
+   * device가 `lookupStationBySsid(currentWifiSsid)` 결과를 forward한다 — backend는
+   * stations.json을 갖지 않으므로 lookup은 device 책임 (`mapMatchedLine/ArcM`과 동일 패턴).
+   *
+   * - 매칭 성공: `Station.name` 문자열 (예: '강남')
+   * - 미연결 / 매칭 실패 / Android: undefined → consensusGate strongDB는 자연 false fallback
+   *   (undefined → `wifiSsidMatch ?? false` → false, strongBE/strongCB fallback 유지)
+   * - iOS WiFi constraint: 사용자가 연결된 SSID만 얻을 수 있음 (5G/LTE 전용 시 undefined).
+   *   `reference_ios_wifi_api_constraint.md` 참조.
+   */
+  wifiSsidStationName?: string;
 }
 
 /**

--- a/src/features/nearest-station/api/positionUpload.ts
+++ b/src/features/nearest-station/api/positionUpload.ts
@@ -115,6 +115,17 @@ export interface PositionUploadPayload {
    * backend `consensusGate`의 environment contradict 판정에 사용된다.
    */
   cellularEnvironmentVote?: 'surface' | 'underground' | 'unknown';
+  /**
+   * #1667 (ADR-015 strongDB wire) — WiFi SSID 매핑으로 결정한 역명.
+   *
+   * 디바이스가 `lookupStationBySsid(currentWifiSsid)?.name`을 산출해 forward한다.
+   * backend는 stations.json을 갖지 않으므로 lookup은 device 책임 (`mapMatchedLine/ArcM`과 동일 패턴).
+   *
+   * - 매칭 성공: `Station.name` 문자열 (예: '강남')
+   * - iOS WiFi 미연결 / 매칭 실패 / Android: undefined → backend strongDB false fallback
+   * - `reference_ios_wifi_api_constraint.md` — 사용자가 5G/LTE 전용 시 undefined (graceful).
+   */
+  wifiSsidStationName?: string;
 }
 
 export interface PositionUploadResult {

--- a/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
@@ -113,6 +113,16 @@ jest.mock('../../../../shared/utils/logger', () => ({
   }),
 }));
 
+// ── #1667 WiFi SSID 모킹 ──
+const mockGetCurrentWifiSsid = jest.fn<Promise<string | null>, []>();
+jest.mock('../../utils/wifiSsidNative', () => ({
+  getCurrentWifiSsid: () => mockGetCurrentWifiSsid(),
+}));
+const mockLookupStationBySsid = jest.fn<{ name: string } | null, [string | null | undefined]>();
+jest.mock('../../utils/wifiSsidLookup', () => ({
+  lookupStationBySsid: (ssid: string | null | undefined) => mockLookupStationBySsid(ssid),
+}));
+
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { AlarmEvent } from '../../../../shared/types/alarm';
 // 모듈 import — defineTask가 이 시점에 호출되어 global에 콜백이 저장됨
@@ -214,6 +224,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     mockGetBoardingLock.mockResolvedValue(null);
     mockEvaluateBackgroundTransferSwap.mockResolvedValue({ fired: false });
     mockFindNearestStations.mockReturnValue(null);
+    // #1667 기본값: WiFi 미연결(null) → wifiSsidStationName undefined
+    mockGetCurrentWifiSsid.mockResolvedValue(null);
+    mockLookupStationBySsid.mockReturnValue(null);
   });
 
   it('defineTask가 올바른 태스크 이름으로 등록된다', () => {
@@ -1031,6 +1044,67 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
       expect(mockUploadPosition).toHaveBeenCalledWith(expect.objectContaining({ motion: 'stationary' }));
       expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+    });
+
+    describe('#1667 (ADR-015 strongDB wire) — wifiSsidStationName forward', () => {
+      function stubApnsToken(token: string): void {
+        (AsyncStorage.getItem as jest.Mock)
+          .mockResolvedValueOnce(JSON.stringify(mockDestination))
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(null) // BG_LAST_FIX_KEY
+          .mockResolvedValueOnce(token); // APNS_TOKEN_KEY
+      }
+
+      it('WiFi 매칭 성공 → uploadPosition에 wifiSsidStationName 포함', async () => {
+        stubApnsToken('apns-tok-wifi');
+        mockGetCurrentWifiSsid.mockResolvedValue('T_subway_gangnam_01');
+        mockLookupStationBySsid.mockReturnValue({ name: '강남' });
+
+        const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+        await taskCallback({ data: { locations: [loc] }, error: null });
+
+        expect(mockUploadPosition).toHaveBeenCalledWith(
+          expect.objectContaining({ wifiSsidStationName: '강남' }),
+        );
+      });
+
+      it('WiFi 미연결(null) → uploadPosition에 wifiSsidStationName 없음', async () => {
+        stubApnsToken('apns-tok-wifi');
+        mockGetCurrentWifiSsid.mockResolvedValue(null);
+        mockLookupStationBySsid.mockReturnValue(null);
+
+        const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+        await taskCallback({ data: { locations: [loc] }, error: null });
+
+        const call = mockUploadPosition.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+        expect(call?.wifiSsidStationName).toBeUndefined();
+      });
+
+      it('WiFi SSID 매핑 미일치 → uploadPosition에 wifiSsidStationName 없음', async () => {
+        stubApnsToken('apns-tok-wifi');
+        mockGetCurrentWifiSsid.mockResolvedValue('unknown-ssid');
+        mockLookupStationBySsid.mockReturnValue(null);
+
+        const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+        await taskCallback({ data: { locations: [loc] }, error: null });
+
+        const call = mockUploadPosition.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+        expect(call?.wifiSsidStationName).toBeUndefined();
+      });
+
+      it('getCurrentWifiSsid throw → graceful, wifiSsidStationName 없이 uploadPosition 정상 호출', async () => {
+        stubApnsToken('apns-tok-wifi');
+        mockGetCurrentWifiSsid.mockRejectedValue(new Error('wifi error'));
+
+        const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+        await taskCallback({ data: { locations: [loc] }, error: null });
+
+        expect(mockUploadPosition).toHaveBeenCalled();
+        const call = mockUploadPosition.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+        expect(call?.wifiSsidStationName).toBeUndefined();
+      });
     });
   });
 

--- a/src/features/nearest-station/tasks/backgroundLocationTask.ts
+++ b/src/features/nearest-station/tasks/backgroundLocationTask.ts
@@ -43,6 +43,10 @@ import { getBoardingLock } from '../../alarm/utils/boardingLockStorage';
 import type { Route } from '../../../shared/utils/stationRoute';
 import { isValidGpsSpeedMps, MAX_STATION_DISTANCE_KM } from '../../../shared/constants/location';
 import type { Station } from '../../../shared/types/station';
+// #1667 (ADR-015 strongDB wire) — WiFi SSID 매핑 역명 backend forward.
+// device가 lookup 후 역명만 송신 — backend는 stations.json 없으므로 lookup은 device 책임.
+import { getCurrentWifiSsid } from '../utils/wifiSsidNative';
+import { lookupStationBySsid } from '../utils/wifiSsidLookup';
 
 const logger = createLogger('BackgroundLocation');
 
@@ -197,6 +201,12 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
       // 뒤집힘 mitigation, lesson_motion_activity_intermittent_signal).
       const accelPattern = classifyAccelerometerPattern(getLatestAccelerometerSnapshot());
       const motion: PositionMotion = pickMotionLabel(accelPattern, getCurrentMotionStationary());
+      // #1667 (ADR-015 strongDB wire) — WiFi SSID 매핑 역명 산출. await로 동기화해 uploadPosition
+      // 에 함께 전달 — WiFi lookup 실패 시 graceful undefined (strongDB false fallback,
+      // strongBE/strongCB는 계속 활성). iOS WiFi 미연결 시 null → undefined.
+      // `reference_ios_wifi_api_constraint.md`: 사용자가 5G/LTE만 쓰면 항상 undefined.
+      const wifiSsid = await getCurrentWifiSsid().catch(() => null);
+      const wifiStation = lookupStationBySsid(wifiSsid);
       void uploadPosition({
         token: apnsToken,
         lat,
@@ -205,6 +215,7 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
         ts: latest.timestamp,
         motion,
         accelSummary,
+        ...(wifiStation ? { wifiSsidStationName: wifiStation.name } : {}),
       });
     }
 


### PR DESCRIPTION
Closes #1667

## Summary

ADR-015 consensusGate `strongDB` 분기(`wifiSsidMatch`)가 항상 `?? false`로 차단됐던 dead-wire를 연결한다. `positionTrainAgreement`(strongCB)는 #1614에서 이미 연결됐으며 본 PR은 `wifiSsidMatch`(strongDB) wire를 완성한다.

## Wire Matrix

| 시나리오 | strongBE | strongCB | strongDB | 결과 |
|---|---|---|---|---|
| arrival + lockAttachable (기존) | ✅ | — | — | pass |
| positionTrain + arrival (#1614) | — | ✅ | — | pass |
| **wifiSsidMatch + arrival (본 PR)** | — | — | **✅** | **pass** |
| arrival 없음 (Seoul API outage) | ❌ | ❌ | ❌ | blocked (정책대로) |
| iOS WiFi 미연결 (5G/LTE) | ✅/❌ | ✅/❌ | ❌(undefined→false) | strongBE/CB fallback |

## 변경 파일

**Backend:**
- `types.ts`: `PositionPoint.wifiSsidStationName?: string` 추가
- `index.ts`: `validatePositionPayload`가 `wifiSsidStationName` 수신 (빈 문자열 graceful drop)
- `autoLock.ts`: `AttemptAutoLockInputs.wifiSsidStationName` 추가 → `targetWaypoint.stationName` 비교로 `wifiSsidMatch` 산출 → `evaluateConsensusGate` strongDB 활성화
- `scheduled.ts`: `evaluateAndMaybeFireBoardingPrompt` + `maybeBindLocklessTrainCode` 두 경로에서 `fusion.series` 마지막 point의 `wifiSsidStationName` → `attemptAutoLock` forward

**Device:**
- `positionUpload.ts`: `PositionUploadPayload.wifiSsidStationName?: string` 추가
- `backgroundLocationTask.ts`: BG tick마다 `getCurrentWifiSsid()` + `lookupStationBySsid()` → `wifiSsidStationName` position upload 포함 (graceful: 미연결/매칭 실패 → undefined → backend strongDB false fallback)

## V/X 영향

| Acceptance | 현재 | 본 PR 후 |
|---|---|---|
| **boardingPrompt 지하 발사** | ❌ 7일 0건 | ✅ underground에서 OR 3개 모두 활성 |
| **V4 매역 silent (지하)** | ⚠️ 부분 | ✅ strongDB 추가 합의 경로 |

## 트레이드오프

- `wifiSsidMatch false positive`: 사용자가 실제 역 WiFi가 아닌 다른 AP에 연결 시 역명 불일치 → `wifiSsidMatch=false` → strongBE/CB fallback (기존 동작 유지). false positive 경로 없음.
- `iOS WiFi 제약` (`reference_ios_wifi_api_constraint.md`): 5G/LTE 전용 시 항상 undefined → strongDB 미활성 → 기존 strongBE/strongCB만 동작 (graceful degradation).

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` 0 orphan. 신규 export 없음
2. **V/X dashboard** — wrangler tail: `boarding-prompt: auto-lock attached` 로그 증가 / wrangler tail `env-consensus-fail` reason 분포 감소
3. **의존 PR** — N/A (standalone, #1614 Phase B already merged)
4. **측정 plan** — boardingPrompt fired 카운터 1주 0→>0 변화. wrangler tail `strongDB` 경로로 통과한 첫 trip evidence 캡처
5. **Device verify** — iOS WiFi 연결 후 지하 BG task에서 wifiSsidStationName이 position payload에 포함되는지 wrangler tail 확인 필요