### PR TITLE
fix(#1668): arvlCd=1 + lock.trainCode 매칭 즉시 SSoT 채택 (V1/V6)

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.arvlCdArrivedSsot.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.arvlCdArrivedSsot.test.ts
@@ -1,0 +1,351 @@
+/* eslint-disable import/no-restricted-paths -- cross-feature orchestration (#890) */
+
+/**
+ * #1668 — arvlCd=1(ARRIVED) + lock.trainCode 매칭 즉시 SSoT 채택 cascade tier 회귀 가드.
+ *
+ * 시나리오:
+ *   1. lock 활성 + ARRIVED + trainCode 매칭 + 신선 → cascade 1순위 (positionTrain 1순위 뒤, backend-ssot 앞).
+ *   2. arvlCd=0 (ENTERING) → 채택 거부 (ARRIVED만 허용).
+ *   3. trainCode mismatch → 채택 거부.
+ *   4. stale (age > 35s) → 채택 거부.
+ *   5. receivedAtMs === 0 (mock/schedule fallback) → 채택 거부.
+ *   6. lockless trip (boardingLock=null) → 채택 거부 → 기존 cascade.
+ *   7. backend-ssot fresh + ARRIVED match → arvlCdArrivedMatch 1순위 (backend-ssot 양보).
+ */
+
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useFusedNearestStation } from '../useFusedNearestStation';
+import { useNearestStation } from '../useNearestStation';
+import { useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
+import { useTrainPositions } from '../../../route/hooks/useTrainPositions';
+import { findTopNearestStations } from '../../utils/findNearestStation';
+import { findStationByNameAndLine } from '../../../../shared/utils/stationLookup';
+import { ARRIVAL_CODE } from '../../../../shared/constants/arrivalCodes';
+import {
+  arrivalRet,
+  positionRet,
+  GPS_BASE_DEFAULTS,
+} from '../../../../testUtils/positionApiFixtures';
+import {
+  BACKEND_SSOT_FIXTURE_T0 as T0,
+  flushBackendSsotMirrorTick,
+  makeBackendSsotMirrorEntry,
+} from '../../../../testUtils/backendSsotMirrorFixtures';
+import { makeArrivalInfo } from '../../../../testUtils/fixtures';
+import { readBackendSsotMirror } from '../../../alarm/utils/backendSsotMirror';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+import type { StationArrival } from '../../../../shared/types/arrival';
+
+jest.mock('../../utils/findNearestStation', () => ({
+  findTopNearestStations: jest.fn(),
+}));
+jest.mock('../useNearestStation');
+jest.mock('../../../arrival/hooks/useArrivalInfo');
+jest.mock('../../../route/hooks/useTrainPositions');
+jest.mock('../../../alarm/utils/tripStartStorage', () => ({
+  getTripStartedAt: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../../../alarm/utils/backendSsotMirror', () => ({
+  readBackendSsotMirror: jest.fn(),
+}));
+
+const mockNearest = useNearestStation as jest.Mock;
+const mockArrival = useArrivalInfo as jest.Mock;
+const mockPos = useTrainPositions as jest.Mock;
+const mockFindTop = findTopNearestStations as jest.Mock;
+const mockRead = readBackendSsotMirror as jest.Mock;
+
+const yongmasan = findStationByNameAndLine('용마산', '7')!;
+const konkuk = findStationByNameAndLine('건대입구', '7')!;
+
+const LOCK_TRAIN_CODE = 'T-1668';
+
+const lockOn7: BoardingLock = {
+  destinationId: 'dest-7',
+  trainCode: LOCK_TRAIN_CODE,
+  boardingLine: '7',
+  boardingStationId: yongmasan.id,
+  boardedAt: T0,
+  expectedDurationMs: 10 * 60_000,
+};
+
+/**
+ * GPS + candidates를 yongmasan(7호선)으로 세팅.
+ * arrival은 makeFreshArrived()로 주입 가능.
+ */
+function setupBaselineAt(
+  stationName: string,
+  line: '7',
+  arrival: StationArrival | null = null,
+) {
+  const stn = findStationByNameAndLine(stationName, line)!;
+  const live = { station: stn, distanceKm: 0 };
+  mockNearest.mockReturnValue({
+    result: live,
+    liveResult: live,
+    stickyDisplayOnly: null,
+    variants: [stn],
+    userLocation: { lat: stn.lat, lng: stn.lng },
+    ...GPS_BASE_DEFAULTS,
+    accuracyMeters: 50,
+    lastFixAtMs: T0,
+    refresh: jest.fn(),
+  });
+  mockFindTop.mockReturnValue([{ station: stn, distanceKm: 0 }]);
+  mockArrival.mockImplementation((sName: string | null, sLine: string | null) => {
+    if (sName === stn.name && sLine === line && arrival !== null) {
+      return arrivalRet(arrival);
+    }
+    return arrivalRet(null);
+  });
+  mockPos.mockReturnValue(positionRet(null));
+}
+
+/** ARRIVED(arvlCd=1) + lock trainCode + fresh receivedAtMs */
+function makeFreshArrivedArrival(trainCode: string, receivedAtMs: number): StationArrival {
+  return {
+    up: [
+      makeArrivalInfo({
+        destination: '장암',
+        arrivalSeconds: 0,
+        arrivalCode: ARRIVAL_CODE.ARRIVED,
+        trainCode,
+        line: '7',
+        receivedAtMs,
+      }),
+    ],
+    down: [],
+  };
+}
+
+describe('#1668 arvlCdArrivedMatch cascade tier', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(T0);
+    mockRead.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('lock + ARRIVED + trainCode 매칭 + 신선 → boarding-lock 1순위', () => {
+    // backend mirror null → arvlCdArrivedMatch가 1순위가 돼야 함
+    const arrival = makeFreshArrivedArrival(LOCK_TRAIN_CODE, T0);
+    setupBaselineAt('용마산', '7', arrival);
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        LOCK_TRAIN_CODE,
+        lockOn7,
+      ),
+    );
+    expect(hook.result.current.source).toBe('boarding-lock');
+    expect(hook.result.current.confidence).toBe('boarding-lock');
+    expect(hook.result.current.result?.station.id).toBe(yongmasan.id);
+  });
+
+  it('ARRIVED + trainCode 매칭 + 신선 → backend-ssot 보다 1순위', async () => {
+    // backend mirror가 다른 역(건대입구)을 가리켜도 arvlCdArrivedMatch가 우선
+    const arrival = makeFreshArrivedArrival(LOCK_TRAIN_CODE, T0);
+    setupBaselineAt('용마산', '7', arrival);
+    mockRead.mockResolvedValue(
+      makeBackendSsotMirrorEntry({ currentStationId: konkuk.name }),
+    );
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        LOCK_TRAIN_CODE,
+        lockOn7,
+      ),
+    );
+    await flushBackendSsotMirrorTick();
+    await waitFor(() => {
+      // backend-ssot가 아닌 boarding-lock이어야 함
+      expect(hook.result.current.confidence).toBe('boarding-lock');
+    });
+    expect(hook.result.current.result?.station.id).toBe(yongmasan.id);
+    expect(hook.result.current.source).not.toBe('backend-ssot');
+  });
+
+  it('arvlCd=0 (ENTERING) → 채택 거부 → 기존 cascade (not boarding-lock)', () => {
+    const enteringArrival: StationArrival = {
+      up: [
+        makeArrivalInfo({
+          destination: '장암',
+          arrivalSeconds: 0,
+          arrivalCode: ARRIVAL_CODE.ENTERING,
+          trainCode: LOCK_TRAIN_CODE,
+          line: '7',
+          receivedAtMs: T0,
+        }),
+      ],
+      down: [],
+    };
+    setupBaselineAt('용마산', '7', enteringArrival);
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        LOCK_TRAIN_CODE,
+        lockOn7,
+      ),
+    );
+    // ENTERING은 거부 → arvlCdArrivedMatch null → 기존 cascade (fused arrival-arriving)
+    // boarding-lock은 arvlCdArrivedMatch 전용 — 미채택 확인
+    expect(hook.result.current.confidence).not.toBe('boarding-lock');
+    expect(hook.result.current.source).not.toBe('boarding-lock');
+  });
+
+  it('trainCode mismatch → 채택 거부 → 기존 cascade (not boarding-lock)', () => {
+    // ARRIVED이지만 trainCode가 다른 열차
+    const mismatchArrival = makeFreshArrivedArrival('T-OTHER', T0);
+    setupBaselineAt('용마산', '7', mismatchArrival);
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        LOCK_TRAIN_CODE,
+        lockOn7,
+      ),
+    );
+    // trainCode 불일치 → arvlCdArrivedMatch 거부 → 기존 cascade
+    expect(hook.result.current.confidence).not.toBe('boarding-lock');
+    expect(hook.result.current.source).not.toBe('boarding-lock');
+  });
+
+  it('stale (age > 35s) → 채택 거부 → 기존 cascade (not boarding-lock)', () => {
+    // T0 기준 시스템 시간이지만, receivedAtMs가 36s 전 — ARVL_CD_ARRIVED_MAX_AGE_MS(35s) 초과
+    const staleReceivedAt = T0 - 36_000;
+    const staleArrival = makeFreshArrivedArrival(LOCK_TRAIN_CODE, staleReceivedAt);
+    setupBaselineAt('용마산', '7', staleArrival);
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        LOCK_TRAIN_CODE,
+        lockOn7,
+      ),
+    );
+    expect(hook.result.current.confidence).not.toBe('boarding-lock');
+    expect(hook.result.current.source).not.toBe('boarding-lock');
+  });
+
+  it('receivedAtMs === 0 (mock/schedule API) → 채택 거부 → 기존 cascade', () => {
+    // receivedAtMs === 0: mock/schedule fallback — 신선도 판정 불가 → 거부
+    const mockArrivalData: StationArrival = {
+      up: [
+        makeArrivalInfo({
+          destination: '장암',
+          arrivalSeconds: 0,
+          arrivalCode: ARRIVAL_CODE.ARRIVED,
+          trainCode: LOCK_TRAIN_CODE,
+          line: '7',
+          receivedAtMs: 0,
+        }),
+      ],
+      down: [],
+    };
+    setupBaselineAt('용마산', '7', mockArrivalData);
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        LOCK_TRAIN_CODE,
+        lockOn7,
+      ),
+    );
+    // receivedAtMs=0 → 신선도 판정 불가 → 거부
+    expect(hook.result.current.confidence).not.toBe('boarding-lock');
+    expect(hook.result.current.source).not.toBe('boarding-lock');
+  });
+
+  it('lockless trip (boardingLock=null) → 채택 거부 → 기존 cascade', () => {
+    const arrival = makeFreshArrivedArrival(LOCK_TRAIN_CODE, T0);
+    setupBaselineAt('용마산', '7', arrival);
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        LOCK_TRAIN_CODE,
+        null, // boardingLock=null
+      ),
+    );
+    // lockless → arvlCdArrivedMatch 미진입 (boardingLock 없음)
+    // fused 경로로 arrival-confirmed가 올 수 있음 — boarding-lock 아님 확인
+    expect(hook.result.current.source).not.toBe('boarding-lock');
+    expect(hook.result.current.confidence).not.toBe('boarding-lock');
+  });
+
+  it('lockedTrainCode null → 채택 거부 → 기존 cascade', () => {
+    const arrival = makeFreshArrivedArrival(LOCK_TRAIN_CODE, T0);
+    setupBaselineAt('용마산', '7', arrival);
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        null, // lockedTrainCode=null
+        lockOn7,
+      ),
+    );
+    // lockedTrainCode null → arvlCdArrivedMatch 미진입
+    expect(hook.result.current.source).not.toBe('boarding-lock');
+    expect(hook.result.current.confidence).not.toBe('boarding-lock');
+  });
+
+  it('arrival 없음 (null) → 채택 거부 → GPS fallback', () => {
+    // arrival=null: arrival API unavailable → no rows to check → GPS fallback
+    setupBaselineAt('용마산', '7', null);
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        LOCK_TRAIN_CODE,
+        lockOn7,
+      ),
+    );
+    expect(hook.result.current.source).toBe('gps');
+  });
+
+  it('down 방향 ARRIVED row에서도 매칭 가능', () => {
+    // down 방향 arrival row에서 ARRIVED + trainCode 매칭
+    const downArrival: StationArrival = {
+      up: [],
+      down: [
+        makeArrivalInfo({
+          destination: '부천종합운동장',
+          arrivalSeconds: 0,
+          arrivalCode: ARRIVAL_CODE.ARRIVED,
+          trainCode: LOCK_TRAIN_CODE,
+          line: '7',
+          receivedAtMs: T0,
+        }),
+      ],
+    };
+    setupBaselineAt('용마산', '7', downArrival);
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        LOCK_TRAIN_CODE,
+        lockOn7,
+      ),
+    );
+    expect(hook.result.current.source).toBe('boarding-lock');
+    expect(hook.result.current.confidence).toBe('boarding-lock');
+    expect(hook.result.current.result?.station.id).toBe(yongmasan.id);
+  });
+});

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -54,7 +54,9 @@ import {
   type BackendSsotMirrorEntry,
 } from '../../alarm/utils/backendSsotMirror';
 import { MAX_STATION_DISTANCE_KM } from '../../../shared/constants/location';
+import { ARRIVAL_CODE } from '../../../shared/constants/arrivalCodes';
 import {
+  ARVL_CD_ARRIVED_MAX_AGE_MS,
   BACKEND_SSOT_MIRROR_MAX_AGE_MS,
   DETECTION_FUSED_MAX_DISTANCE_KM,
   GPS_DERIVED_ACCURACY_MAX_M,
@@ -928,6 +930,55 @@ export function useFusedNearestStation(
     gpsTopCandidate.station.line === boardingLock.boardingLine &&
     gpsTopCandidate.distanceKm <= GPS_DERIVED_ROUTE_MATCH_MAX_KM;
 
+  // #1668 — arvlCd=1(ARRIVED) + lock.trainCode 매칭 즉시 SSoT 채택.
+  //
+  // Seoul realtimeStationArrival API가 직접 확정한 "열차 도착" 신호 + 사용자가 탑승한 trainCode와 매칭.
+  // backend SSoT mirror lag(10-30s) 없이 arrival API 30s cycle에서 즉시 advance 가능.
+  //
+  // 3-of-3 합의 (ADR-010 두 실패 모드 동급 — false positive/miss 동급 방어):
+  //   1. boardingLock 활성 + lockedTrainCode 존재 — 사용자 명시 의향 trip 한정 (lockless 미적용).
+  //   2. arrival row: arrivalCode === ARRIVED(1) AND trainCode === lock.trainCode.
+  //   3. arrival row: receivedAtMs age ≤ ARVL_CD_ARRIVED_MAX_AGE_MS(35s) — stale 신호 채택 차단.
+  //      (receivedAtMs === 0 = mock/미상 → 신선도 판정 불가 → 거부)
+  //
+  // 채택 station: boardingLock.boardingLine에 일치하는 candidates 슬롯의 station.
+  //   - candidates는 GPS 좌표 기준 거리순 정렬 — 가장 가까운 매칭 역을 우선 채택.
+  //   - lockless trip(boardingLock=null)은 본 분기 미진입 → 기존 cascade.
+  //
+  // 트레이드오프 완화:
+  //   - trainCode 중복 운행(같은 코드 다른 회차): age ≤ 35s 가드로 최근 cycle 신호만 채택.
+  //   - ARRIVED 신호 짧음(~30s): 본 tier 이후 positionTrain/backend-ssot 등 cascade가 유지.
+  //   - 사용자 하차 후 lock 잔존: useTrainCodeMismatchDetector(#1659) 90s 가드 별도 방어.
+  //   - receivedAtMs === 0(mock/schedule API 응답): 거부해 테스트/schedule fallback 오채택 차단.
+  //
+  // PR #1646/#1662 보완 관계:
+  //   - #1646: lock + 지하 + positionTrain lockMatch → positionTrain 1순위
+  //   - #1662: lock + 지상 + GPS 신선 → GPS-derived 1순위 (gpsDerivedFastPath, 위)
+  //   - 본 PR: lock + ARRIVED + trainCode 매칭 + 신선 → arrival-ssot 1순위 (지상/지하 무관)
+  //   셋 합쳐 lock 활성 환경 3 path 커버.
+  const arvlCdArrivedMatch = (() => {
+    if (!boardingLock || !lockedTrainCode) return null;
+    const now = Date.now();
+    const candidateSlots = [
+      { candidate: candidates[0] ?? null, arrival: a0.arrival },
+      { candidate: candidates[1] ?? null, arrival: a1.arrival },
+      { candidate: candidates[2] ?? null, arrival: a2.arrival },
+    ];
+    for (const { candidate, arrival } of candidateSlots) {
+      if (!candidate || !arrival) continue;
+      if (candidate.station.line !== boardingLock.boardingLine) continue;
+      const allRows = [...arrival.up, ...arrival.down];
+      for (const row of allRows) {
+        if (row.arrivalCode !== ARRIVAL_CODE.ARRIVED) continue;
+        if (row.trainCode !== lockedTrainCode) continue;
+        if (row.receivedAtMs === 0) continue;
+        if (now - row.receivedAtMs > ARVL_CD_ARRIVED_MAX_AGE_MS) continue;
+        return candidate;
+      }
+    }
+    return null;
+  })();
+
   let result: NearestStationResult | null;
   let confidence: FusionConfidence;
   let source: FusionSource;
@@ -945,12 +996,21 @@ export function useFusedNearestStation(
     result = gpsTopCandidate!;
     confidence = 'gps-only';
     source = 'gps';
+  } else if (arvlCdArrivedMatch) {
+    // #1668 — ARRIVED + trainCode 매칭 + 신선 3-of-3 합의 시 arrival-ssot 1순위.
+    // Seoul API 직접 도착 확정 신호 — backend SSoT mirror 10-30s lag 우회.
+    // boardingLock.boardingLine 일치 + 거리 기준 가장 가까운 candidates 슬롯 station 채택.
+    // confidence='boarding-lock' (사용자 탭한 열차가 도착 확정된 가장 강한 신호).
+    result = arvlCdArrivedMatch;
+    confidence = 'boarding-lock';
+    source = 'boarding-lock';
   } else if (backendSsotAccepts) {
     // #1568 (T8b) — backend SSoT 권위 mirror. backend advance 게이트가
     // ADR-017 6단(seed/repeat/motion-stop/cross-validation 등)을 이미 통과한 결과이므로
     // device-side cascade tier보다 신뢰도가 높다. lock 활성/lockless 모두 동일 우선순위.
     // #1646 — 3-of-3 합의(lock+지하+lockMatch) 시 positionTrain에 양보 (위 분기).
     // #1657 — 지상 GPS 신선 합의 시 gpsDerivedFastPath에 양보 (위 분기).
+    // #1668 — ARRIVED+trainCode 합의 시 arvlCdArrivedMatch에 양보 (위 분기).
     result = { station: ssotStation!, distanceKm: 0 };
     confidence = 'backend-ssot';
     source = 'backend-ssot';

--- a/src/shared/constants/realtime.ts
+++ b/src/shared/constants/realtime.ts
@@ -101,3 +101,13 @@ export const DETECTION_FUSED_MAX_DISTANCE_KM = 0.5;
 export const GPS_DERIVED_ACCURACY_MAX_M = 50;
 export const GPS_DERIVED_FIX_MAX_AGE_MS = 30_000;
 export const GPS_DERIVED_ROUTE_MATCH_MAX_KM = 0.1;
+
+/**
+ * #1668 — arvlCd=1(ARRIVED) + lock.trainCode 매칭 즉시 SSoT 채택 신선도 게이트.
+ *
+ * Seoul realtimeStationArrival API의 ARRIVED 신호는 열차 정차 구간(~30s)에서만 발생.
+ * receivedAtMs 기준 본 ms 초과 시 stale로 간주해 cascade 채택 거부.
+ * Seoul API 폴링 주기(30s) + 처리 latency (~5s) 여유 → 35s.
+ * stale 신호를 채택하면 이전 정차 역을 현재역으로 오인하는 false positive 위험.
+ */
+export const ARVL_CD_ARRIVED_MAX_AGE_MS = 35_000;


### PR DESCRIPTION
Closes #1668

## PR #1650/#1662 보완 관계

| PR | 케이스 | 1순위 tier |
|---|---|---|
| #1650 (머지됨) | lock + 지하 + positionTrain lockMatch | positionTrain |
| #1662 (별도 브랜치) | lock + 지상 + GPS 신선 + 노선 정합 | GPS-derived |
| **본 PR** | lock + ARRIVED(arvlCd=1) + trainCode 매칭 + 신선 | arrival-ssot (지상/지하 무관) |

3개 PR 합쳐 lock 활성 전 환경 커버.

## Fix 설계

`useFusedNearestStation.ts` cascade에 `arvlCdArrivedMatch` tier 추가.

**위치**: `positionTrainBoardingLockMatch` 다음, `backendSsotAccepts` 앞 (2순위).

**3-of-3 합의 (ADR-010 두 실패 모드 동급)**:
1. `boardingLock != null` + `lockedTrainCode != null` — 사용자 명시 의향 trip 한정
2. arrival row: `arrivalCode === ARRIVAL_CODE.ARRIVED(1)` AND `trainCode === lockedTrainCode`
3. arrival row: `receivedAtMs` age ≤ `ARVL_CD_ARRIVED_MAX_AGE_MS(35s)` — stale 신호 차단 (`receivedAtMs === 0` = mock/schedule → 거부)

**채택 station**: `boardingLock.boardingLine`에 일치하는 `candidates` 슬롯의 station (GPS 거리순 최근접).

## V/X 영향

| Acceptance | 현재 | 본 PR 머지 후 |
|---|---|---|
| **V1** 정확한 현재역 (arvlCd=1 매칭) | positionTrain/GPS에만 의존 | Seoul API 직접 확정 신호 추가 |
| **V6** 위치 빠른 반영 | backend-ssot 10-30s lag | arrival API 30s cycle 직접 |

## 트레이드오프 + Mitigation

| Trade-off | Mitigation |
|---|---|
| arvlCd stale (Seoul API 30s 지연) | age ≤ 35s 가드 |
| trainCode 중복 운행 (같은 코드 다른 회차) | age ≤ 35s 가드로 최근 cycle 신호만 채택 |
| ARRIVED 신호 짧음 (~30s) | 미채택 시 #1650 positionTrain / backend-ssot cascade 유지 |
| 사용자 하차 후 lock 잔존 | useTrainCodeMismatchDetector(#1659) 90s 가드 별도 방어 |
| receivedAtMs=0 (mock/schedule) → stale 오채택 | `receivedAtMs === 0` 명시 거부 |

## 신규 상수

`src/shared/constants/realtime.ts`:
- `ARVL_CD_ARRIVED_MAX_AGE_MS = 35_000` — arrival ARRIVED 신선도 게이트 (Seoul API 30s 폴링 + 5s margin)

## Wire-completion 5단

1. **Orphan 없음**: 신규 export 없음 (cascade if문 + 상수 추가). `npm run lint:orphan` pass — 0 orphans.
2. **V/X dashboard**: DebugModal `source='boarding-lock'` + `confidence='boarding-lock'`로 arvlCdArrivedMatch 채택 확인. `pushFusionDebugEntry` cascade decision buffer에 기록됨.
3. **의존 PR**: N/A — #1650이 이미 머지됨. useFusedNearestStation 내부 변경만.
4. **측정 plan**: 1주 사용자 trip DebugModal 캡처에서 lock 활성 구간 ARRIVED 신호 발화 시 `source='boarding-lock'` advance 확인. backend-ssot 대비 advance 시점 lag 개선.
5. **Device verify**: **필요** — lock 활성 trip 시나리오에서 역 도착 시 현재역 즉시 advance 확인 (ARRIVED arrival row 수신 확인). 코드 경로 자체는 type+unit 검증 완료.

## 변경 파일

- `src/features/nearest-station/hooks/useFusedNearestStation.ts` — cascade에 `arvlCdArrivedMatch` tier 추가 + `ARRIVAL_CODE`/`ARVL_CD_ARRIVED_MAX_AGE_MS` import
- `src/shared/constants/realtime.ts` — `ARVL_CD_ARRIVED_MAX_AGE_MS` 상수 추가
- `src/features/nearest-station/hooks/__tests__/useFusedNearestStation.arvlCdArrivedSsot.test.ts` — 10 케이스 (채택 2 + 거부 8)

## 테스트 결과

- `npm test`: 7404 tests pass, 2 pre-existing failures (widgetStorage/stationNotification — dev 브랜치 동일)
- `npm run type-check`: 0 errors
- `npm run lint:orphan`: 0 orphans
- `useFusedNearestStation.ts` coverage: 100%
- `realtime.ts` coverage: 100%