### PR TITLE
fix: ADR-015 strongCB (positionTrainAgreement) wire 보완 (#1667 follow-up)

### DIFF
--- a/backend/alarm-worker/src/__tests__/autoLock.test.ts
+++ b/backend/alarm-worker/src/__tests__/autoLock.test.ts
@@ -3,6 +3,7 @@ import {
   AUTO_LOCK_CONFIDENCE_THRESHOLD,
   AUTO_LOCK_TTL_MS,
   attemptAutoLock,
+  POSITION_RECPTN_MAX_AGE_MS,
   recordAutoLockConfidence,
 } from '../autoLock';
 import { METRIC_KIND } from '../metrics';
@@ -711,6 +712,104 @@ describe('attemptAutoLock #1667 wifiSsidStationName → strongDB wire', () => {
         gateOutcome: passingGateOutcome(),
       },
     );
+    expect(lock?.trainCode).toBe('T1');
+  });
+});
+
+/**
+ * #1676 — selfPollPositions recptnMs age 가드 테스트.
+ *
+ * positionTrainAgreement 산출 시 recptnMs > 0 이면 POSITION_RECPTN_MAX_AGE_MS(30s) 이내만
+ * 신선 데이터로 인정. stale snapshot으로 strongCB false positive 차단.
+ */
+describe('attemptAutoLock #1676 recptnMs age 가드', () => {
+  it('POSITION_RECPTN_MAX_AGE_MS는 30000ms', () => {
+    expect(POSITION_RECPTN_MAX_AGE_MS).toBe(30_000);
+  });
+
+  it.each([
+    {
+      label: 'recptnMs 신선 (now - recptnMs = 10s) → positionTrainAgreement true, strongCB pass',
+      recptnMs: NOW - 10_000,
+      expected: 'lock' as const,
+    },
+    {
+      label: 'recptnMs 경계 (now - recptnMs = 30s 정확히) → 신선 포함, strongCB pass',
+      recptnMs: NOW - 30_000,
+      expected: 'lock' as const,
+    },
+    {
+      label: 'recptnMs stale (now - recptnMs = 31s) → positionTrainAgreement false, strongBE 의존',
+      recptnMs: NOW - 31_000,
+      // underground + lockAttachable=true + arrival 있으면 strongBE pass (lockAttachable=true는 pickAutoTrainCode 단일 수렴으로 보장)
+      expected: 'lock' as const,
+    },
+  ])('underground + $label', async ({ recptnMs, expected }) => {
+    // trainCode 일치 + recptnMs 조건 → strongCB pass/fail. strongBE는 arrival+lockAttachable 있으면 항상 통과.
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
+      now: NOW,
+      environment: 'underground',
+      gateOutcome: failingGateOutcome(),
+      selfPollPositions: [{ trainCode: 'T1', stationName: '강남', recptnMs }],
+    });
+    if (expected === 'lock') {
+      expect(lock?.trainCode).toBe('T1');
+    } else {
+      expect(lock).toBeNull();
+    }
+  });
+
+  it('underground + trainCode 불일치 + arrival 없음(arvlCd=5) + recptnMs stale → strongCB false + strongBE false → null', async () => {
+    // trainCode 불일치 → positionTrainAgreement false. arvlCd=5(범위 밖) → arrivalSignalPresent false.
+    // strongBE = lockAttachable && arrivalSignalPresent = true && false = false. → null.
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 5 })]),
+      now: NOW,
+      environment: 'underground',
+      gateOutcome: failingGateOutcome(),
+      selfPollPositions: [{ trainCode: 'T1', stationName: '강남', recptnMs: NOW - 31_000 }],
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('recptnMs=0 → age 가드 skip (backward-compat), trainCode 일치 → positionTrainAgreement true', async () => {
+    // recptnMs=0는 미포함 entry의 기본값 — age 가드 skip해 기존 동작 유지.
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
+      now: NOW,
+      environment: 'underground',
+      gateOutcome: failingGateOutcome(),
+      selfPollPositions: [{ trainCode: 'T1', stationName: '강남', recptnMs: 0 }],
+    });
+    expect(lock?.trainCode).toBe('T1');
+  });
+
+  it('recptnMs undefined → age 가드 skip (backward-compat), trainCode 일치 → positionTrainAgreement true', async () => {
+    // recptnMs 필드 없음 — 기존 { trainCode, stationName } 구조 호환.
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1 })]),
+      now: NOW,
+      environment: 'underground',
+      gateOutcome: failingGateOutcome(),
+      selfPollPositions: [{ trainCode: 'T1', stationName: '강남' }],
+    });
     expect(lock?.trainCode).toBe('T1');
   });
 });

--- a/backend/alarm-worker/src/autoLock.ts
+++ b/backend/alarm-worker/src/autoLock.ts
@@ -89,6 +89,16 @@ const ARVL_CD_DEPARTED = 2;
 /** lastMotionAt이 이 시간(ms) 이내이면 "최근 이동" 신호로 간주. */
 const RECENT_MOTION_WINDOW_MS = 3 * 60 * 1000;
 
+/**
+ * #1676 — Seoul API realtimePosition recptnDt 신선도 임계 (30s).
+ *
+ * `selfPollPositions` entry의 `recptnMs`(Seoul API 수신 시각)이 이 임계를 초과하면
+ * stale snapshot으로 간주해 positionTrainAgreement 산출 시 제외. cron 주기(60s)의 절반 —
+ * 직전 cron cycle의 snapshot이 다음 cycle 시작 직전까지 ≤60s이므로 30s는 "이번 cycle
+ * 내 신선 데이터"를 의미. 0 또는 미포함 entry는 age 가드 skip (backward-compat).
+ */
+export const POSITION_RECPTN_MAX_AGE_MS = 30_000;
+
 export interface AttemptAutoLockInputs {
   trip: Trip;
   /** 다음 추적 대상 waypoint — arrivals 폴링 대상 (현재 leg 첫 waypoint). */
@@ -152,15 +162,19 @@ export interface AttemptAutoLockInputs {
   /**
    * #1614 Phase B (S4 #1537) — backend self-poll realtimePosition 결과 (호선 단위 운행 trainCode 위치).
    *
-   * caller(scheduled.ts `maybeBindLocklessTrainCode`)가 `readSelfPollPosition(env.TRIPS, line)`
-   * 으로 KV stamp 읽어 그대로 전달. attemptAutoLock 가 `pickAutoTrainCode` 결과로 trainCode를
-   * 결정한 직후, 본 list 에 해당 trainCode가 존재하면 `consensusGate.ts:155` strongCB
-   * (positionTrainAgreement + arrival) 통과 path를 연다 — underground 환경에서 strongBE 외 추가
-   * 합의 분기를 활성화.
+   * caller(scheduled.ts `maybeBindLocklessTrainCode` / `evaluateAndMaybeFireBoardingPrompt`)가
+   * `readSelfPollPosition(env.TRIPS, line)`으로 KV stamp 읽어 그대로 전달. attemptAutoLock 가
+   * `pickAutoTrainCode` 결과로 trainCode를 결정한 직후, 본 list 에 해당 trainCode가 존재하면
+   * `consensusGate.ts:155` strongCB (positionTrainAgreement + arrival) 통과 path를 연다 —
+   * underground 환경에서 strongBE 외 추가 합의 분기를 활성화.
+   *
+   * `recptnMs` (Seoul API 수신 시각 epoch ms) 포함 시 age ≤ `POSITION_RECPTN_MAX_AGE_MS`(30s)
+   * 가드 적용 — stale snapshot으로 positionTrainAgreement=true 되는 false positive 차단.
+   * `recptnMs` 미포함(=0 또는 undefined) entry는 age 가드를 skip (backward-compat).
    *
    * 미전달(undefined) / 빈 배열 시 consensusGate가 자연 `?? false` fallback (strongBE 동작 유지).
    */
-  selfPollPositions?: readonly { trainCode: string; stationName: string }[];
+  selfPollPositions?: readonly { trainCode: string; stationName: string; recptnMs?: number }[];
   /**
    * #1667 (ADR-015 strongDB wire) — device가 WiFi SSID 매핑으로 결정한 역명.
    *
@@ -279,11 +293,20 @@ export async function attemptAutoLock(
   if (environment && gateOutcome) {
     const arrivalSignalPresent =
       typeof chosen.arvlCd === 'number' && chosen.arvlCd >= 0 && chosen.arvlCd <= 3;
-    // #1614 Phase B — backend self-poll realtimePosition cross-match.
+    // #1614 Phase B / #1676 — backend self-poll realtimePosition cross-match + recptnMs age 가드.
     // pickAutoTrainCode 가 선택한 trainCode가 line의 운행 trains 중에 실제 존재하면 true.
+    // recptnMs > 0 이면 Seoul API 수신 시각 기준으로 POSITION_RECPTN_MAX_AGE_MS(30s) 이내만 신선
+    // 데이터로 인정 — stale snapshot으로 positionTrainAgreement=true 되는 false positive 차단.
+    // recptnMs=0 / 미포함 entry는 age 가드 skip (backward-compat, 기존 entry 구조 유지).
     // undefined / 빈 list 시 자연 undefined → consensusGate가 `?? false` fallback (strongBE 동작 유지).
     const positionTrainAgreement = selfPollPositions
-      ? selfPollPositions.some((p) => p.trainCode === trainCode)
+      ? selfPollPositions.some(
+          (p) =>
+            p.trainCode === trainCode &&
+            (p.recptnMs === undefined ||
+              p.recptnMs === 0 ||
+              now - p.recptnMs <= POSITION_RECPTN_MAX_AGE_MS),
+        )
       : undefined;
     // #1667 (ADR-015 strongDB wire) — device WiFi SSID 매핑 역명 cross-match.
     // wifiSsidStationName이 targetWaypoint.stationName과 일치하면 사용자가 해당 역 WiFi에

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -3051,6 +3051,11 @@ export async function evaluateAndMaybeFireBoardingPrompt(
   // 자연 교체. boardingPromptState도 함께 fired stamp해 같은 cycle에서 prompt 발사를 차단.
   const targetWaypoint = pickActiveWaypoint(trip);
   if (targetWaypoint) {
+    // #1676 — strongCB (positionTrainAgreement) wire. cron 진입부에서 stamp된
+    // `realtime-position:<line>` KV를 read해 pickAutoTrainCode 후보 cross-match 입력으로 전달.
+    // maybeBindLocklessTrainCode 와 동일 패턴 — boarding-prompt auto-lock 경로에서도
+    // underground 환경의 strongCB 통과 path를 활성화해 5G/LTE 사용자(WiFi 미연결) V4 cover.
+    const selfPollPositions = await readSelfPollPosition(env.TRIPS, targetWaypoint.line);
     const autoLockResult = await attemptAutoLock({
       trip,
       targetWaypoint,
@@ -3066,6 +3071,8 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       // #1536 (S3) — environment + gateOutcome forward. 환경 분기 consensusGate 강제.
       environment,
       gateOutcome: outcome,
+      // #1676 — strongCB wire. self-poll stamp → attemptAutoLock 내 positionTrainAgreement 산출.
+      selfPollPositions: selfPollPositions?.positions,
       // #1667 (ADR-015 strongDB) — 마지막 position point의 WiFi SSID 매핑 역명 forward.
       // undefined(iOS WiFi 미연결/Android/시리즈 없음) 시 consensusGate가 자연 false fallback.
       wifiSsidStationName: fusion.series[fusion.series.length - 1]?.wifiSsidStationName,


### PR DESCRIPTION
## 배경

PR #1673 (이슈 #1667) strongDB (wifiSsidMatch)만 처리. strongCB (positionTrainAgreement) 미처리.

```typescript
// consensusGate.ts underground 분기
const strongBE = arrivalSignalPresent && lockAttachable
const strongCB = (positionTrainAgreement ?? false) && arrivalSignalPresent  // ?? false fallback
const strongDB = (wifiSsidMatch ?? false) && arrivalSignalPresent           // PR #1673로 wire됨
```

`maybeBindLocklessTrainCode` 경로는 #1614 Phase B에서 `selfPollPositions`를 전달했으나,
`evaluateAndMaybeFireBoardingPrompt` 경로는 `selfPollPositions` 미전달 → strongCB 영구 false.

## 변경사항

### Fix 1. `autoLock.ts` — recptnMs age ≤ 30s 가드 추가
- `selfPollPositions` entry type에 `recptnMs?: number` 추가
- `POSITION_RECPTN_MAX_AGE_MS = 30_000` export (cron 주기 60s의 절반)
- `positionTrainAgreement` 산출: `recptnMs > 0`이면 30s 이내만 신선 데이터로 인정
- `recptnMs=0` / `undefined` → age 가드 skip (backward-compat, 기존 `{trainCode, stationName}` 구조 유지)

### Fix 2. `scheduled.ts` — boardingPrompt 경로 selfPollPositions forward
- `evaluateAndMaybeFireBoardingPrompt` 내 `pickActiveWaypoint` 후 `readSelfPollPosition(env.TRIPS, targetWaypoint.line)` 추가
- `attemptAutoLock` 호출에 `selfPollPositions: selfPollPositions?.positions` 전달
- `maybeBindLocklessTrainCode` 와 완전히 동일한 패턴 (line 2568-2586 참조)

## V/X 영향

| Acceptance | 이전 (미wire) | 본 PR 머지 후 |
|---|---|---|
| **V4 매역 silent** (지하, WiFi 미연결, 5G/LTE 사용자) | ❌ strongCB 영구 false → strongBE 의존 | ✅ strongCB 활성 (realtimePosition cross-match) |
| **boardingPrompt auto-lock** (지하 환경) | ⚠️ lockAttachable 의존만 | ✅ 3 source (strongBE / strongCB / strongDB) 완전 cover |

## Wire Matrix

| 시나리오 | positionTrainAgreement | 결과 |
|---|---|---|
| realtimePosition에 trainCode 존재 + recptnMs ≤ 30s | `true` | strongCB pass (underground) |
| realtimePosition에 trainCode 존재 + recptnMs > 30s | `false` (stale 가드) | strongBE fallback |
| realtimePosition에 trainCode 불일치 | `false` | strongBE fallback |
| selfPollPositions 빈 배열 / KV miss | `false` | strongBE fallback (기존 동작) |
| selfPollPositions undefined (구 호출자) | `undefined` → `?? false` | strongBE 동작 유지 |

## Wire-completion 5단

1. **Orphan 없음** — `POSITION_RECPTN_MAX_AGE_MS` export, `autoLock.test.ts`에서 import 사용. `npm run lint:orphan` pass.
2. **V/X dashboard** — wrangler tail의 `boarding-prompt: auto-lock attached` log + `consensusGate` reason 분포. `realtimePositionFetch` stat으로 self-poll 정상 작동 확인.
3. **의존 PR** — N/A (단독 backend fix, frontend 변경 없음)
4. **측정 plan** — 1주 운영 후 `boarding-prompt: auto-lock attached` with underground environment 건수 + `boardingPromptFired` / `boardingPromptBlocked` 비율 변화로 효과 측정.
5. **Device verify** — N/A — backend-only type+unit. 실기기: 지하 역 boarding-prompt auto-lock 개선은 다음 cron cycle부터 자동 반영.

## 정책 정합 (배터리/발열/효율)

- ✅ 신규 polling X — 기존 `readSelfPollPosition` KV read (이미 cron loop에 있음) 재사용
- ✅ log spam X — autoLock attempt 부속 1 log entry만 (기존 `boarding-prompt: auto-lock attached`)
- ✅ async race 최소화 — KV read는 `readSelfPollPosition` 단일 call, sync evaluation
- ✅ 효율 — O(1) trainCode string === + O(1) recptnMs 비교

## 테스트

- `POSITION_RECPTN_MAX_AGE_MS` constant 값 검증
- recptnMs 신선 (10s) → strongCB pass
- recptnMs 경계 (30s 정확히) → strongCB pass
- recptnMs stale (31s) → positionTrainAgreement false (strongBE fallback으로 통과)
- recptnMs + arvlCd 범위 밖 → strongCB false + strongBE false → null
- recptnMs=0 → age 가드 skip (backward-compat)
- recptnMs undefined → age 가드 skip (backward-compat)

## Closes

Closes #1676
References #1667