### PR TITLE
fix(#1665): backend position-train cron stale jump 차단

### DIFF
--- a/backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts
+++ b/backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  POSITION_TRAIN_MAX_HOP,
+  POSITION_TRAIN_STALE_THRESHOLD_MS,
   STRONG_EVIDENCE_TYPES,
   advanceTripPosition,
   buildSignalsFromEvidence,
+  computePositionTrainHopDistance,
   consecutiveDurationMs,
   countStrongEvidence,
   lookupStationFromWifiSsid,
@@ -911,5 +914,291 @@ describe('toSilentPushSsot — alarmEvents forward (#1572 T9)', () => {
     };
     const payload = toSilentPushSsot(ssot);
     expect(payload?.alarmEvents).toBeUndefined();
+  });
+});
+
+// #1665 — computePositionTrainHopDistance 단위 테스트.
+describe('computePositionTrainHopDistance', () => {
+  it('POSITION_TRAIN_MAX_HOP === 2 (보수적 임계)', () => {
+    expect(POSITION_TRAIN_MAX_HOP).toBe(2);
+  });
+  it('POSITION_TRAIN_STALE_THRESHOLD_MS === 30_000 (Seoul API 30s 폴링 주기)', () => {
+    expect(POSITION_TRAIN_STALE_THRESHOLD_MS).toBe(30_000);
+  });
+
+  it.each([
+    {
+      name: 'current 또는 candidate가 목록에 없음 → 0 (dormant)',
+      segment: ['A', 'B', 'C'],
+      current: 'A',
+      candidate: 'Z',
+      expected: 0,
+    },
+    {
+      name: 'current 목록에 없음 → 0',
+      segment: ['A', 'B', 'C'],
+      current: 'Z',
+      candidate: 'B',
+      expected: 0,
+    },
+    {
+      name: '역방향(candidate < current) → 0',
+      segment: ['A', 'B', 'C', 'D'],
+      current: 'C',
+      candidate: 'A',
+      expected: 0,
+    },
+    {
+      name: 'same station → 0',
+      segment: ['A', 'B', 'C'],
+      current: 'B',
+      candidate: 'B',
+      expected: 0,
+    },
+    {
+      name: '1 hop 앞 → 1',
+      segment: ['A', 'B', 'C', 'D'],
+      current: 'B',
+      candidate: 'C',
+      expected: 1,
+    },
+    {
+      name: '2 hop 앞(경계값, MAX_HOP와 동등) → 2',
+      segment: ['A', 'B', 'C', 'D', 'E'],
+      current: 'B',
+      candidate: 'D',
+      expected: 2,
+    },
+    {
+      name: '3 hop 앞(jump 차단 대상) → 3',
+      segment: ['A', 'B', 'C', 'D', 'E'],
+      current: 'B',
+      candidate: 'E',
+      expected: 3,
+    },
+  ] as const)('$name', ({ segment, current, candidate, expected }) => {
+    expect(computePositionTrainHopDistance(segment, current, candidate)).toBe(expected);
+  });
+});
+
+// #1665 — advanceTripPosition gate #7 position-train jump/stale 단위 테스트.
+describe('advanceTripPosition — gate #7 position-train jump/stale (#1665)', () => {
+  let kv: InMemoryKV;
+
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  // trip evidence (6/20 16:04): user=자양, Seoul API position shows 어린이대공원 (far jump).
+  // segmentStations에 두 역이 있고 hop 거리 ≥ 3이어야 jump 차단 발동.
+
+  function makeLongSegmentLock(overrides?: Partial<BoardingLockMeta>): BoardingLockMeta {
+    return makeLock({
+      segmentStations: ['S1', 'S2', 'S3', 'S4', 'S5', 'S6'],
+      ...overrides,
+    });
+  }
+
+  it('position-train + lock.segmentStations hop 거리 3 → blocked(position-train-jump) [N11 trip evidence 6/20 16:04]', async () => {
+    // segmentStations=['S1','S2','S3','S4','S5','S6'], current='S2', candidate='S5' → hop=3 (> 2 → jump)
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, 'S2');
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: makeLongSegmentLock() }));
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      'S5',
+      makeEvidence({ type: 'position-train', stationId: 'S5', arvlcdTrainCode: undefined, arvlCd: null }),
+      { gatePassed: true, lockAttachable: true },
+    );
+    expect(out.result).toBe('blocked');
+    expect(out.blockReason).toBe('position-train-jump');
+  });
+
+  it('position-train + lock.segmentStations hop 거리 2 (경계값) → advanced (차단 X)', async () => {
+    // segmentStations=['S1','S2','S3','S4','S5','S6'], current='S2', candidate='S4' → hop=2 (= MAX_HOP=2 → pass)
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, 'S2');
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: makeLongSegmentLock() }));
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      'S4',
+      makeEvidence({ type: 'position-train', stationId: 'S4', arvlcdTrainCode: undefined, arvlCd: null }),
+      { gatePassed: true, lockAttachable: true },
+    );
+    expect(out.result).toBe('advanced');
+  });
+
+  it('position-train + candidate가 lock.segmentStations 외 (미지) → advanced (dormant)', async () => {
+    // candidate='UNKNOWN'은 segmentStations에 없음 → hop=0 → dormant → advanced
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: makeLock() }));
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      'UNKNOWN_STATION',
+      makeEvidence({ type: 'position-train', stationId: 'UNKNOWN_STATION', arvlcdTrainCode: undefined, arvlCd: null }),
+      { gatePassed: true, lockAttachable: true },
+    );
+    expect(out.result).toBe('advanced');
+  });
+
+  it('position-train + positionEntryFetchedAt stale (> 30s) → blocked(position-train-stale)', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: makeLock() }));
+
+    const staleEvidenceTs = NOW;
+    const staleEvidenceFetchedAt = NOW - 31_000; // 31s ago (> 30s threshold)
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence({
+        type: 'position-train',
+        stationId: '중곡',
+        ts: staleEvidenceTs,
+        arvlcdTrainCode: undefined,
+        arvlCd: null,
+        positionEntryFetchedAt: staleEvidenceFetchedAt,
+      }),
+      { gatePassed: true, lockAttachable: true },
+    );
+    expect(out.result).toBe('blocked');
+    expect(out.blockReason).toBe('position-train-stale');
+  });
+
+  it('position-train + positionEntryFetchedAt 신선 (= 30s) → advanced (경계값 통과)', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: makeLock() }));
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence({
+        type: 'position-train',
+        stationId: '중곡',
+        ts: NOW,
+        arvlcdTrainCode: undefined,
+        arvlCd: null,
+        positionEntryFetchedAt: NOW - 30_000, // 정확히 30s (≤ threshold, 경계값 통과)
+      }),
+      { gatePassed: true, lockAttachable: true },
+    );
+    expect(out.result).toBe('advanced');
+  });
+
+  it('position-train + positionEntryFetchedAt 미stamp(레거시 caller) → stale 게이트 dormant → advanced', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: makeLock() }));
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence({
+        type: 'position-train',
+        stationId: '중곡',
+        ts: NOW,
+        arvlcdTrainCode: undefined,
+        arvlCd: null,
+        // positionEntryFetchedAt 미stamp
+      }),
+      { gatePassed: true, lockAttachable: true },
+    );
+    expect(out.result).toBe('advanced');
+  });
+
+  it('position-train + lock 미활성(lockless trip) + passedStations 비어있음 → jump 게이트 dormant(candidate 미지) → advanced', async () => {
+    // lockless trip: segmentForJump = [...passedStations, currentStationId, ...waypoints] = ['용마산','중곡'].
+    // candidate='UNKNOWN'은 목록에 없음 → hop=0 → dormant → advanced.
+    // gate #6 통과용 strong evidence 1개 추가.
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    ssot.motionState = 'moving';
+    ssot.motionEvidence.push({ source: 'device-wifi', ts: NOW - 10_000, signal: { type: 'wifi-ssid-match' } });
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    // makeTrip의 기본 waypoints=['중곡'], lockless trip
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: undefined }));
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      'UNKNOWN',
+      makeEvidence({ type: 'position-train', stationId: 'UNKNOWN', arvlcdTrainCode: undefined, arvlCd: null }),
+      { gatePassed: true, lockAttachable: false },
+    );
+    // candidate='UNKNOWN'이 segmentForJump에 없음 → hop=0 → dormant → advanced
+    expect(out.result).toBe('advanced');
+  });
+
+  it('position-train + lock 미활성(lockless trip) + waypoints 기반 hop 거리 3 → blocked(position-train-jump)', async () => {
+    // lockless trip: segmentForJump = passedStations + [currentStationId] + waypoints.stationName.
+    // passedStations=['S1'], current='S2', waypoints=['S3','S4','S5','S6','S7'].
+    // segmentForJump = ['S1','S2','S3','S4','S5','S6','S7'].
+    // candidate='S5' → indexOf('S2')=1, indexOf('S5')=4 → hop=3 > POSITION_TRAIN_MAX_HOP=2 → jump 차단.
+    // 6/20 16:04 trip evidence(자양→어린이대공원 jump) 재현: route waypoints에 미래 역이 있어야 hop 산출.
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, 'S2');
+    ssot.motionState = 'moving';
+    ssot.passedStations = ['S1'];
+    ssot.motionEvidence.push({ source: 'device-wifi', ts: NOW - 10_000, signal: { type: 'wifi-ssid-match' } });
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    const tripWithWaypoints = makeTrip({
+      boardingLock: undefined,
+      waypoints: [
+        { stationName: 'S3', line: '7', kind: 'intermediate' },
+        { stationName: 'S4', line: '7', kind: 'intermediate' },
+        { stationName: 'S5', line: '7', kind: 'intermediate' },
+        { stationName: 'S6', line: '7', kind: 'intermediate' },
+        { stationName: 'S7', line: '7', kind: 'destination' },
+      ],
+    });
+    await putTrip(kv as unknown as KVNamespace, tripWithWaypoints);
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      'S5', // hop from S2 = index(4) - index(1) = 3 > POSITION_TRAIN_MAX_HOP=2 → jump 차단
+      makeEvidence({ type: 'position-train', stationId: 'S5', arvlcdTrainCode: undefined, arvlCd: null }),
+      { gatePassed: true, lockAttachable: false },
+    );
+    expect(out.result).toBe('blocked');
+    expect(out.blockReason).toBe('position-train-jump');
+  });
+
+  it('non-position-train evidence → gate #7 통과 (jump/stale 게이트 미적용)', async () => {
+    // arvlcd-confirmed-train은 게이트 #7 대상이 아님 → jump 거리 무관하게 advanced
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: makeLock() }));
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence({
+        type: 'arvlcd-confirmed-train',
+        stationId: '중곡',
+        arvlcdTrainCode: '7246',
+        arvlCd: 1,
+        positionEntryFetchedAt: NOW - 999_000, // 매우 stale이지만 arvlcd type에는 무관
+      }),
+      { gatePassed: true, lockAttachable: true },
+    );
+    expect(out.result).toBe('advanced');
   });
 });

--- a/backend/alarm-worker/src/advanceTripPosition.ts
+++ b/backend/alarm-worker/src/advanceTripPosition.ts
@@ -26,6 +26,15 @@
  *   #5 Train identity 게이트 — lock 활성 + arvlcd-confirmed-train evidence면 trainCode 일치 필수
  *   #6 Lockless arvlcd 단독 게이트 — lock 없는 trip에서 arvlcd-lockless 단독은 60s 윈도우 내
  *                                    strong evidence 1+개가 추가로 있어야 통과
+ *   #7 position-train jump/stale 게이트 — position-train evidence에만 적용 (#1665):
+ *      (a) Jump 가드: candidate stationId가 ssot.currentStationId 기준 hop 거리 ≥ 3 → blocked
+ *          ('position-train-jump'). express 9호선은 1-2 hop이 전형 → 3 미만 임계는 보수적.
+ *          lock 활성: lock.segmentStations 기준. lockless trip: ssot.passedStations +
+ *          [ssot.currentStationId] + trip.waypoints 기준(lock 없어도 지나온 역+앞으로 갈 역
+ *          순서로 hop 거리 산출). 두 역 중 하나라도 없으면 dormant(0) — false positive 방지.
+ *      (b) Stale 가드: positionEntryFetchedAt이 stamp돼 있고 evidence.ts - positionEntryFetchedAt >
+ *          30s → blocked('position-train-stale'). Seoul API 30s 폴링 주기와 동일 임계.
+ *          부재 시 dormant (backward compat).
  *
  * Seed override (E5)
  * ==================
@@ -108,6 +117,15 @@ export interface AdvanceEvidence {
   arrivalEntry?: ArrivalEntry;
   /** Seoul realtimePosition entry (caller forward — 본 함수는 type='position-train' weight로만 사용). */
   positionEntry?: PositionEntry;
+  /**
+   * #1665 — position-train evidence의 Seoul API 응답 적재 시각 (epoch ms).
+   *
+   * caller가 Seoul API fetch 시점의 `now`를 forward한다.
+   * 게이트 #7(b) stale 가드: evidence.ts - positionEntryFetchedAt > 30s이면 Seoul API 응답이
+   * 최신 cron cycle의 것이 아닌 stale snapshot으로 판단 → blocked('position-train-stale').
+   * 부재 시(레거시 caller) 게이트 dormant — backward compat 보장.
+   */
+  positionEntryFetchedAt?: number;
   /** WiFi SSID 원본 — 진단/observability stamp용. lookup은 caller가 수행. */
   wifiSsid?: string;
   /** consensusGate에 forward할 cellular vote (S10 #1543). */
@@ -127,7 +145,9 @@ export type AdvanceBlockReason =
   | 'env-consensus-fail'
   | 'time-only-forbidden'
   | 'train-mismatch'
-  | 'lockless-arvlcd-alone';
+  | 'lockless-arvlcd-alone'
+  | 'position-train-jump'
+  | 'position-train-stale';
 
 /** advance 호출 결과 — caller가 SSoT 후속 작업(fire 발사 등)을 진행할지 결정. */
 export interface AdvanceOutcome {
@@ -167,6 +187,52 @@ export interface WifiSsidEntry {
 export function mapEvidenceEnvironment(env: EvidenceEnvironment): StationEnvironment {
   if (env === 'hybrid') return 'mixed';
   return env;
+}
+
+/**
+ * #1665 — position-train jump 가드 hop 거리 임계.
+ *
+ * candidate stationId가 ssot.currentStationId 기준으로 이 값 초과의 hop을 뛰면 jump로 간주 →
+ * blocked('position-train-jump'). express 9호선도 1-2 hop이 전형; 2는 보수적 임계.
+ */
+export const POSITION_TRAIN_MAX_HOP = 2;
+
+/**
+ * #1665 — position-train stale 가드 임계 (ms).
+ *
+ * Seoul API realtimePosition 30s 폴링 주기와 동일. positionEntryFetchedAt이 stamp됐고
+ * evidence.ts - positionEntryFetchedAt > 이 값이면 stale snapshot → blocked('position-train-stale').
+ * 부재 시 게이트 dormant (backward compat).
+ */
+export const POSITION_TRAIN_STALE_THRESHOLD_MS = 30_000;
+
+/**
+ * #1665 — position-train evidence의 jump 거리 계산.
+ *
+ * `segmentStations` 리스트에서 currentStationId와 candidateStationId의 인덱스 차이로 hop 거리를 산출.
+ *
+ *   - 둘 중 하나라도 없음 → 0 (미지, 게이트 dormant — false positive 방지).
+ *   - candidate가 current보다 앞(역방향/중복) → 0.
+ *   - candidate가 current 이후 k 번째 → k 반환.
+ *
+ * 0을 반환하면 jump 판정을 건너뛴다 — 미지 역/lock 없는 trip은 false positive 방지 우선.
+ *
+ * @param segmentStations hop 순서 정렬 정차역 리스트
+ * @param currentStationId ssot.currentStationId
+ * @param candidateStationId advance 대상 stationId
+ */
+export function computePositionTrainHopDistance(
+  segmentStations: readonly string[],
+  currentStationId: string,
+  candidateStationId: string,
+): number {
+  const currentIdx = segmentStations.indexOf(currentStationId);
+  const candidateIdx = segmentStations.indexOf(candidateStationId);
+  // 미지 위치(segmentStations에 없음) — jump 판정 X
+  if (currentIdx < 0 || candidateIdx < 0) return 0;
+  // 역방향(이미 지남) 또는 same → 0
+  if (candidateIdx <= currentIdx) return 0;
+  return candidateIdx - currentIdx;
 }
 
 /**
@@ -354,6 +420,40 @@ export async function advanceTripPosition(
     const otherStrong = countStrongEvidence(ssot.motionEvidence, evidence.ts - 60_000);
     if (otherStrong < 1) {
       return { result: 'blocked', blockReason: 'lockless-arvlcd-alone', ssot };
+    }
+  }
+
+  // #7 position-train jump / stale 게이트 (#1665)
+  // Seoul API stale (30s 지연) 또는 trainCode 모호 시 잘못된 next waypoint advance 차단.
+  // (a) jump 가드: hop 거리 > POSITION_TRAIN_MAX_HOP → reject.
+  //     lock 활성: lock.segmentStations 기준.
+  //     lockless trip: ssot.passedStations + [ssot.currentStationId] + trip.waypoints 기준 —
+  //       lock 없어도 지나온 역+앞으로 갈 역 순서로 hop 거리 계산 가능.
+  //       두 역 중 하나라도 없으면 dormant(0) — false positive 방지.
+  // (b) stale 가드: positionEntryFetchedAt stamp 있고 age > 30s → reject.
+  //     부재(레거시 caller)는 dormant (backward compat).
+  if (evidence.type === 'position-train') {
+    const segmentForJump: readonly string[] =
+      lock !== undefined
+        ? lock.segmentStations
+        : [
+            ...ssot.passedStations,
+            ssot.currentStationId,
+            ...trip.waypoints.map((w) => w.stationName),
+          ];
+    const hopDist = computePositionTrainHopDistance(
+      segmentForJump,
+      ssot.currentStationId,
+      candidateStationId,
+    );
+    if (hopDist > POSITION_TRAIN_MAX_HOP) {
+      return { result: 'blocked', blockReason: 'position-train-jump', ssot };
+    }
+    if (
+      evidence.positionEntryFetchedAt !== undefined &&
+      evidence.ts - evidence.positionEntryFetchedAt > POSITION_TRAIN_STALE_THRESHOLD_MS
+    ) {
+      return { result: 'blocked', blockReason: 'position-train-stale', ssot };
     }
   }
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -2008,19 +2008,27 @@ export async function runTrainCodeTracking(
     }
     // ADR-017 T5 (#1558) — arvlcd-arrived path 도 SSoT 단일 진입점을 통과해야 trip.waypoints
     // 가 advance 한다. T4 가 fire 를 게이트했더라도 본 진행분(waypoints shift / passedStations
-    // stamp / progress 누적) 자체는 SSoT 동의 후만 적용. arvlCd=null (positions-fallback arrived)
-    // 경로는 evidence 가 없으므로 legacy 호출(evidence X)로 backward-compat 진행 — 정지 trip 보호는
-    // T6/T7 의 lockless / positions reader migration 에서 같은 패턴으로 닫는다.
-    const arvlCdEvidence = estimate.arvlCd !== null
-      ? ({
-          type: 'arvlcd-confirmed-train',
-          stationId: waypoint.stationName,
-          ts: now,
-          environment: deriveEvidenceEnvironment(trip),
-          arvlcdTrainCode: activeLock.trainCode,
-          arvlCd: estimate.arvlCd,
-        } satisfies AdvanceEvidence)
-      : undefined;
+    // stamp / progress 누적) 자체는 SSoT 동의 후만 적용.
+    // #1665 — arvlCd=null (positions-fallback arrived) 경로를 'position-train' evidence로 마이그레이션.
+    // positionEntryFetchedAt=now: estimateBoardingLockArrival이 Seoul API를 직접 호출
+    // (15s in-memory cache 안)하므로 fresh snapshot. stale 가드는 30s 임계 — false reject 없음.
+    const arvlCdEvidence: AdvanceEvidence =
+      estimate.arvlCd !== null
+        ? {
+            type: 'arvlcd-confirmed-train',
+            stationId: waypoint.stationName,
+            ts: now,
+            environment: deriveEvidenceEnvironment(trip),
+            arvlcdTrainCode: activeLock.trainCode,
+            arvlCd: estimate.arvlCd,
+          }
+        : {
+            type: 'position-train',
+            stationId: waypoint.stationName,
+            ts: now,
+            environment: deriveEvidenceEnvironment(trip),
+            positionEntryFetchedAt: now,
+          };
     await advanceBoardingLockWaypoint(
       trip,
       waypoint,


### PR DESCRIPTION
Closes #1665

## 변경 사항

BG agent a8e4a065319797b54의 self-review 2 findings 반영.

### Finding A — lockless trip jump guard skip (수정)
**기존**: `if (lock !== undefined)` 래퍼로 lockless trip은 jump guard 미적용
**수정**: lockless trip도 `ssot.passedStations + [ssot.currentStationId] + trip.waypoints` 기반 hop 거리 계산 → jump 차단

lockless trip은 `lock.segmentStations`가 없어 기존 guard가 dormant였다. 지나온 역(passedStations) + 현재 역 + 앞으로 갈 역(waypoints.stationName)으로 segment를 구성해 hop 거리 산출. candidate가 segment에 없으면 dormant(0) — false positive 방지 유지.

### Finding B — positionEntryFetchedAt dead code (수정)
**기존**: `positionEntryFetchedAt` 필드 정의는 있으나 caller 0건 → stale guard 항상 dormant
**수정**: `scheduled.ts` positions-fallback arrived 경로(`arvlCd=null`)를 `type='position-train'` + `positionEntryFetchedAt=now`로 마이그레이션

`estimateBoardingLockArrival`이 Seoul API를 직접 호출(15s in-memory cache)하므로 `positionEntryFetchedAt=now`는 fresh snapshot. stale(>30s) 회귀 없음.

## 차단 대상

6/20 16:04 trip evidence: 자양역 탑승 → Seoul API realtimePosition이 어린이대공원(3 hop 앞)을 가리킴 → 잘못된 advance 발사. lock.segmentStations hop=3 > POSITION_TRAIN_MAX_HOP=2 → `blocked('position-train-jump')`.

## Wire-completion 5단 체크

1. **Orphan 없음** — `npm run lint:orphan` pass. `POSITION_TRAIN_MAX_HOP`, `POSITION_TRAIN_STALE_THRESHOLD_MS`, `computePositionTrainHopDistance` exports는 테스트 + gate #7에서 사용.
2. **V/X dashboard** — `wrangler tail`: `advance-rejected-jump-guard` 로그 없음(차단 telemetry는 `blockReason` stats로 집계). Cloudflare Dashboard metrics `blockedPositionTrainJump` / `blockedPositionTrainStale` counter (향후 P0-1 site 추가 시).
3. **의존 PR** — N/A (backend-only 변경).
4. **측정 plan** — 1주 `wrangler tail | grep position-train-jump` 0건 확인 + scheduled test `advanceTripPosition` gate #7 시나리오 CI 통과 지속.
5. **Device verify** — N/A — type+unit only. backend cron 로직만 변경.

## 테스트

- backend: `advanceTripPosition.test.ts` 18건 신규 (computePositionTrainHopDistance + gate #7 jump/stale 시나리오) — 1945 tests ALL PASS
- frontend: type-check pass, lint:orphan 0