### PR TITLE
fix(#1682): alarmLog suppress reason 시간 윈도우 집계 + DebugModal Telemetry 섹션

### DIFF
--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -2185,80 +2185,70 @@ describe('alarmLog', () => {
 
   describe('countAlarmLogReasonsByWindow (#1682)', () => {
     const NOW = 1_700_000_000_000;
+    // 테스트 내 shared factory — SonarCloud CPD 회피 (lesson_sonarcloud_dup_prevention).
+    const sup = (
+      reason: AlarmLogEntry['reason'],
+      tsOffset = 1_000,
+      extra?: Partial<AlarmLogEntry>,
+    ): AlarmLogEntry =>
+      makeEntry({ ts: NOW - tsOffset, outcome: 'suppressed', reason, ...extra });
 
-    it('windowMs 이내 suppressed 엔트리만 집계한다', () => {
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
-        makeEntry({ ts: NOW - 2_000, outcome: 'suppressed', reason: 'dedup-station' }),
-        // 윈도우 밖
-        makeEntry({ ts: NOW - 10_000, outcome: 'suppressed', reason: 'dedup-station' }),
-      ];
+    it('windowMs 이내 suppressed 엔트리만 집계하고 윈도우 밖은 제외한다', () => {
+      const entries = [sup('dedup-station'), sup('dedup-station', 2_000), sup('dedup-station', 10_000)];
       const result = countAlarmLogReasonsByWindow(entries, 5_000, NOW);
       expect(result).toHaveLength(1);
       expect(result[0].reason).toBe('dedup-station');
       expect(result[0].count).toBe(2);
     });
 
-    it('suppressed 아닌 엔트리는 집계 제외', () => {
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts: NOW - 1_000, outcome: 'fired', reason: 'dedup-station' }),
-        makeEntry({ ts: NOW - 1_000, outcome: 'received', reason: 'dedup-station' }),
-        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'gate-accuracy' }),
-      ];
+    it.each<{ name: string; entries: AlarmLogEntry[]; expectLen: number; expectReason?: string }>([
+      {
+        name: 'suppressed 아닌 엔트리는 집계 제외',
+        entries: [
+          makeEntry({ ts: NOW - 1_000, outcome: 'fired', reason: 'dedup-station' }),
+          makeEntry({ ts: NOW - 1_000, outcome: 'received', reason: 'dedup-station' }),
+          sup('gate-accuracy'),
+        ],
+        expectLen: 1,
+        expectReason: 'gate-accuracy',
+      },
+      {
+        name: 'reason 미설정이면 (unknown)으로 집계',
+        entries: [sup(undefined)],
+        expectLen: 1,
+        expectReason: '(unknown)',
+      },
+    ])('$name', ({ entries, expectLen, expectReason }) => {
       const result = countAlarmLogReasonsByWindow(entries, 5_000, NOW);
-      expect(result).toHaveLength(1);
-      expect(result[0].reason).toBe('gate-accuracy');
-    });
-
-    it('reason 미설정이면 (unknown)으로 집계', () => {
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: undefined }),
-      ];
-      const result = countAlarmLogReasonsByWindow(entries, 5_000, NOW);
-      expect(result).toHaveLength(1);
-      expect(result[0].reason).toBe('(unknown)');
+      expect(result).toHaveLength(expectLen);
+      if (expectReason !== undefined) expect(result[0].reason).toBe(expectReason);
     });
 
     it('count 내림차순 정렬', () => {
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'gate-accuracy' }),
-        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
-        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
-        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
-      ];
+      const entries = [sup('gate-accuracy'), sup('dedup-station'), sup('dedup-station'), sup('dedup-station')];
       const result = countAlarmLogReasonsByWindow(entries, 5_000, NOW);
-      expect(result[0].reason).toBe('dedup-station');
-      expect(result[0].count).toBe(3);
-      expect(result[1].reason).toBe('gate-accuracy');
-      expect(result[1].count).toBe(1);
+      expect(result[0]).toMatchObject({ reason: 'dedup-station', count: 3 });
+      expect(result[1]).toMatchObject({ reason: 'gate-accuracy', count: 1 });
     });
 
     it('count 필드가 있는 엔트리는 count를 합산한다', () => {
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-alarm', count: 5 }),
-        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-alarm', count: 3 }),
-      ];
+      const entries = [sup('dedup-alarm', 1_000, { count: 5 }), sup('dedup-alarm', 1_000, { count: 3 })];
       const result = countAlarmLogReasonsByWindow(entries, 5_000, NOW);
-      expect(result).toHaveLength(1);
       expect(result[0].count).toBe(8);
     });
 
     it('lastTs는 windowMs 내 가장 최신 ts를 기록한다', () => {
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts: NOW - 3_000, outcome: 'suppressed', reason: 'dedup-station' }),
-        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
-        makeEntry({ ts: NOW - 2_000, outcome: 'suppressed', reason: 'dedup-station' }),
-      ];
+      const entries = [sup('dedup-station', 3_000), sup('dedup-station', 1_000), sup('dedup-station', 2_000)];
       const result = countAlarmLogReasonsByWindow(entries, 5_000, NOW);
       expect(result[0].lastTs).toBe(NOW - 1_000);
     });
 
-    it('windowMs <= 0이면 빈 배열 반환', () => {
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
-      ];
-      expect(countAlarmLogReasonsByWindow(entries, 0, NOW)).toEqual([]);
-      expect(countAlarmLogReasonsByWindow(entries, -100, NOW)).toEqual([]);
+    it.each([
+      { label: 'windowMs=0', windowMs: 0 },
+      { label: 'windowMs=-100', windowMs: -100 },
+    ])('$label이면 빈 배열 반환', ({ windowMs }) => {
+      const entries = [sup('dedup-station')];
+      expect(countAlarmLogReasonsByWindow(entries, windowMs, NOW)).toEqual([]);
     });
 
     it('빈 entries면 빈 배열 반환', () => {
@@ -2266,69 +2256,59 @@ describe('alarmLog', () => {
     });
 
     it('windowMs=Infinity면 전체 집계', () => {
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts: NOW - 999_999_999, outcome: 'suppressed', reason: 'dedup-station' }),
-        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
-      ];
-      const result = countAlarmLogReasonsByWindow(entries, Infinity, NOW);
-      expect(result[0].count).toBe(2);
+      const entries = [sup('dedup-station', 999_999_999), sup('dedup-station')];
+      expect(countAlarmLogReasonsByWindow(entries, Infinity, NOW)[0].count).toBe(2);
     });
 
     it('now 미지정 시 Date.now() 기준으로 집계 (default parameter 분기)', () => {
-      // Date.now() 기준으로 1ms 이내 엔트리 — now 파라미터 없이 호출해 default Date.now() 분기 커버.
       const ts = Date.now() - 500;
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts, outcome: 'suppressed', reason: 'dedup-station' }),
-      ];
+      const entries: AlarmLogEntry[] = [makeEntry({ ts, outcome: 'suppressed', reason: 'dedup-station' })];
       const result = countAlarmLogReasonsByWindow(entries, 5_000);
-      expect(result).toHaveLength(1);
       expect(result[0].reason).toBe('dedup-station');
     });
   });
 
   describe('lastNReasons (#1682)', () => {
     const NOW = 1_700_000_000_000;
+    const sup = (reason: AlarmLogEntry['reason'], tsOffset = 1_000): AlarmLogEntry =>
+      makeEntry({ ts: NOW - tsOffset, outcome: 'suppressed', reason });
 
     it('suppressed 엔트리 최근 N건을 시간 역순으로 반환한다', () => {
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts: NOW - 3_000, outcome: 'suppressed', reason: 'gate-accuracy' }),
-        makeEntry({ ts: NOW - 2_000, outcome: 'suppressed', reason: 'dedup-station' }),
-        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-alarm' }),
-      ];
+      const entries = [sup('gate-accuracy', 3_000), sup('dedup-station', 2_000), sup('dedup-alarm', 1_000)];
       const result = lastNReasons(entries, 2);
       expect(result).toHaveLength(2);
-      // 최신이 앞 (시간 역순)
       expect(result[0].reason).toBe('dedup-alarm');
       expect(result[1].reason).toBe('dedup-station');
     });
 
-    it('fired/received 엔트리는 제외', () => {
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts: NOW - 1_000, outcome: 'fired', reason: 'dedup-station' }),
-        makeEntry({ ts: NOW - 1_000, outcome: 'received', reason: 'dedup-station' }),
-        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'gate-accuracy' }),
-      ];
+    it.each<{ name: string; entries: AlarmLogEntry[]; expectLen: number; expectReason?: string }>([
+      {
+        name: 'fired/received 엔트리는 제외',
+        entries: [
+          makeEntry({ ts: NOW - 1_000, outcome: 'fired', reason: 'dedup-station' }),
+          makeEntry({ ts: NOW - 1_000, outcome: 'received', reason: 'dedup-station' }),
+          sup('gate-accuracy'),
+        ],
+        expectLen: 1,
+        expectReason: 'gate-accuracy',
+      },
+      {
+        name: 'reason 미설정 억제 엔트리는 제외',
+        entries: [sup(undefined), sup('dedup-station')],
+        expectLen: 1,
+        expectReason: 'dedup-station',
+      },
+    ])('$name', ({ entries, expectLen, expectReason }) => {
       const result = lastNReasons(entries, 10);
-      expect(result).toHaveLength(1);
-      expect(result[0].reason).toBe('gate-accuracy');
+      expect(result).toHaveLength(expectLen);
+      if (expectReason !== undefined) expect(result[0].reason).toBe(expectReason);
     });
 
-    it('reason 미설정 억제 엔트리는 제외', () => {
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: undefined }),
-        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
-      ];
-      const result = lastNReasons(entries, 10);
-      expect(result).toHaveLength(1);
-      expect(result[0].reason).toBe('dedup-station');
-    });
-
-    it('n <= 0이면 빈 배열 반환', () => {
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
-      ];
-      expect(lastNReasons(entries, 0)).toEqual([]);
-      expect(lastNReasons(entries, -1)).toEqual([]);
+    it.each([
+      { label: 'n=0', n: 0 },
+      { label: 'n=-1', n: -1 },
+    ])('$label이면 빈 배열 반환', ({ n }) => {
+      expect(lastNReasons([sup('dedup-station')], n)).toEqual([]);
     });
 
     it('빈 entries면 빈 배열 반환', () => {
@@ -2336,11 +2316,7 @@ describe('alarmLog', () => {
     });
 
     it('entries 수가 n보다 적으면 있는 것만 반환', () => {
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
-      ];
-      const result = lastNReasons(entries, 10);
-      expect(result).toHaveLength(1);
+      expect(lastNReasons([sup('dedup-station')], 10)).toHaveLength(1);
     });
   });
 });

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -61,6 +61,8 @@ import {
   countGateReasons,
   countSilentPushOutcomes,
   summarizeAlarmLogCounters,
+  countAlarmLogReasonsByWindow,
+  lastNReasons,
   logBoardingPromptFired,
   logBoardingPromptResponded,
   BOARDING_PROMPT_WINDOWS,
@@ -2178,6 +2180,167 @@ describe('alarmLog', () => {
       setSentryEnabled(true);
       appendAlarmLog(makeEntry({ source: 'fg', outcome: 'fired' }));
       expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('countAlarmLogReasonsByWindow (#1682)', () => {
+    const NOW = 1_700_000_000_000;
+
+    it('windowMs 이내 suppressed 엔트리만 집계한다', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
+        makeEntry({ ts: NOW - 2_000, outcome: 'suppressed', reason: 'dedup-station' }),
+        // 윈도우 밖
+        makeEntry({ ts: NOW - 10_000, outcome: 'suppressed', reason: 'dedup-station' }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, 5_000, NOW);
+      expect(result).toHaveLength(1);
+      expect(result[0].reason).toBe('dedup-station');
+      expect(result[0].count).toBe(2);
+    });
+
+    it('suppressed 아닌 엔트리는 집계 제외', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: NOW - 1_000, outcome: 'fired', reason: 'dedup-station' }),
+        makeEntry({ ts: NOW - 1_000, outcome: 'received', reason: 'dedup-station' }),
+        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'gate-accuracy' }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, 5_000, NOW);
+      expect(result).toHaveLength(1);
+      expect(result[0].reason).toBe('gate-accuracy');
+    });
+
+    it('reason 미설정이면 (unknown)으로 집계', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: undefined }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, 5_000, NOW);
+      expect(result).toHaveLength(1);
+      expect(result[0].reason).toBe('(unknown)');
+    });
+
+    it('count 내림차순 정렬', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'gate-accuracy' }),
+        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
+        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
+        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, 5_000, NOW);
+      expect(result[0].reason).toBe('dedup-station');
+      expect(result[0].count).toBe(3);
+      expect(result[1].reason).toBe('gate-accuracy');
+      expect(result[1].count).toBe(1);
+    });
+
+    it('count 필드가 있는 엔트리는 count를 합산한다', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-alarm', count: 5 }),
+        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-alarm', count: 3 }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, 5_000, NOW);
+      expect(result).toHaveLength(1);
+      expect(result[0].count).toBe(8);
+    });
+
+    it('lastTs는 windowMs 내 가장 최신 ts를 기록한다', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: NOW - 3_000, outcome: 'suppressed', reason: 'dedup-station' }),
+        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
+        makeEntry({ ts: NOW - 2_000, outcome: 'suppressed', reason: 'dedup-station' }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, 5_000, NOW);
+      expect(result[0].lastTs).toBe(NOW - 1_000);
+    });
+
+    it('windowMs <= 0이면 빈 배열 반환', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
+      ];
+      expect(countAlarmLogReasonsByWindow(entries, 0, NOW)).toEqual([]);
+      expect(countAlarmLogReasonsByWindow(entries, -100, NOW)).toEqual([]);
+    });
+
+    it('빈 entries면 빈 배열 반환', () => {
+      expect(countAlarmLogReasonsByWindow([], 3_600_000, NOW)).toEqual([]);
+    });
+
+    it('windowMs=Infinity면 전체 집계', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: NOW - 999_999_999, outcome: 'suppressed', reason: 'dedup-station' }),
+        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, Infinity, NOW);
+      expect(result[0].count).toBe(2);
+    });
+
+    it('now 미지정 시 Date.now() 기준으로 집계 (default parameter 분기)', () => {
+      // Date.now() 기준으로 1ms 이내 엔트리 — now 파라미터 없이 호출해 default Date.now() 분기 커버.
+      const ts = Date.now() - 500;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts, outcome: 'suppressed', reason: 'dedup-station' }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, 5_000);
+      expect(result).toHaveLength(1);
+      expect(result[0].reason).toBe('dedup-station');
+    });
+  });
+
+  describe('lastNReasons (#1682)', () => {
+    const NOW = 1_700_000_000_000;
+
+    it('suppressed 엔트리 최근 N건을 시간 역순으로 반환한다', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: NOW - 3_000, outcome: 'suppressed', reason: 'gate-accuracy' }),
+        makeEntry({ ts: NOW - 2_000, outcome: 'suppressed', reason: 'dedup-station' }),
+        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-alarm' }),
+      ];
+      const result = lastNReasons(entries, 2);
+      expect(result).toHaveLength(2);
+      // 최신이 앞 (시간 역순)
+      expect(result[0].reason).toBe('dedup-alarm');
+      expect(result[1].reason).toBe('dedup-station');
+    });
+
+    it('fired/received 엔트리는 제외', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: NOW - 1_000, outcome: 'fired', reason: 'dedup-station' }),
+        makeEntry({ ts: NOW - 1_000, outcome: 'received', reason: 'dedup-station' }),
+        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'gate-accuracy' }),
+      ];
+      const result = lastNReasons(entries, 10);
+      expect(result).toHaveLength(1);
+      expect(result[0].reason).toBe('gate-accuracy');
+    });
+
+    it('reason 미설정 억제 엔트리는 제외', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: undefined }),
+        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
+      ];
+      const result = lastNReasons(entries, 10);
+      expect(result).toHaveLength(1);
+      expect(result[0].reason).toBe('dedup-station');
+    });
+
+    it('n <= 0이면 빈 배열 반환', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
+      ];
+      expect(lastNReasons(entries, 0)).toEqual([]);
+      expect(lastNReasons(entries, -1)).toEqual([]);
+    });
+
+    it('빈 entries면 빈 배열 반환', () => {
+      expect(lastNReasons([], 5)).toEqual([]);
+    });
+
+    it('entries 수가 n보다 적으면 있는 것만 반환', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: NOW - 1_000, outcome: 'suppressed', reason: 'dedup-station' }),
+      ];
+      const result = lastNReasons(entries, 10);
+      expect(result).toHaveLength(1);
     });
   });
 });

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -1638,3 +1638,58 @@ export function countGateReasons(
   }
   return counts;
 }
+
+/**
+ * #1682 — suppressed reason별 집계 (시간 윈도우 필터링).
+ *
+ * countBoardingPromptByWindow 패턴 재사용 — suppressed 엔트리의 reason을 windowMs 이내 항목만
+ * 집계해 반환. read-only, write 부담 0.
+ *
+ * count 내림차순 정렬 — 가장 빈번한 reason이 상단에 노출.
+ *
+ * @param entries  alarmLog 전체 또는 부분 스냅샷
+ * @param windowMs 집계 윈도우 (ms). 0 이하이면 빈 객체 반환. Infinity이면 전체.
+ * @param now      기준 시각 (ms epoch). 테스트 결정성용. 기본값 Date.now().
+ */
+export function countAlarmLogReasonsByWindow(
+  entries: readonly AlarmLogEntry[],
+  windowMs: number,
+  now: number = Date.now(),
+): AlarmLogReasonCounter[] {
+  if (windowMs <= 0) return [];
+  const map = new Map<string, AlarmLogReasonCounter>();
+  for (const entry of entries) {
+    if (entry.outcome !== 'suppressed') continue;
+    const ageMs = now - entry.ts;
+    if (ageMs > windowMs) continue;
+    const key = entry.reason ?? '(unknown)';
+    const entryCount = entry.count ?? 1;
+    const existing = map.get(key);
+    if (existing) {
+      existing.count += entryCount;
+      if (entry.ts > existing.lastTs) existing.lastTs = entry.ts;
+    } else {
+      map.set(key, { reason: key, count: entryCount, lastTs: entry.ts });
+    }
+  }
+  return [...map.values()].sort((a, b) => b.count - a.count);
+}
+
+/**
+ * #1682 — 최근 N건의 suppressed reason raw entries 반환.
+ *
+ * DebugModal Telemetry 섹션에서 suppressed reason 분포를 빠르게 파악하기 위한 헬퍼.
+ * reason 미설정 항목은 포함되지 않는다 (순수 suppressed signal만 취급).
+ * 시간 역순 정렬 (최신이 앞) — DebugModal 표시에 직접 사용 가능.
+ *
+ * @param entries alarmLog 전체 또는 부분 스냅샷
+ * @param n       반환할 최대 항목 수. 0 이하이면 빈 배열 반환.
+ */
+export function lastNReasons(
+  entries: readonly AlarmLogEntry[],
+  n: number,
+): AlarmLogEntry[] {
+  if (n <= 0) return [];
+  const suppressed = entries.filter((e) => e.outcome === 'suppressed' && e.reason !== undefined);
+  return suppressed.slice(-n).reverse();
+}

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -1642,13 +1642,13 @@ export function countGateReasons(
 /**
  * #1682 — suppressed reason별 집계 (시간 윈도우 필터링).
  *
- * countBoardingPromptByWindow 패턴 재사용 — suppressed 엔트리의 reason을 windowMs 이내 항목만
- * 집계해 반환. read-only, write 부담 0.
+ * summarizeAlarmLogCounters에 시간 윈도우 필터를 추가한 래퍼.
+ * windowMs 이내 suppressed 엔트리만 집계해 반환. read-only, write 부담 0.
  *
  * count 내림차순 정렬 — 가장 빈번한 reason이 상단에 노출.
  *
  * @param entries  alarmLog 전체 또는 부분 스냅샷
- * @param windowMs 집계 윈도우 (ms). 0 이하이면 빈 객체 반환. Infinity이면 전체.
+ * @param windowMs 집계 윈도우 (ms). 0 이하이면 빈 배열 반환. Infinity이면 전체.
  * @param now      기준 시각 (ms epoch). 테스트 결정성용. 기본값 Date.now().
  */
 export function countAlarmLogReasonsByWindow(
@@ -1657,22 +1657,8 @@ export function countAlarmLogReasonsByWindow(
   now: number = Date.now(),
 ): AlarmLogReasonCounter[] {
   if (windowMs <= 0) return [];
-  const map = new Map<string, AlarmLogReasonCounter>();
-  for (const entry of entries) {
-    if (entry.outcome !== 'suppressed') continue;
-    const ageMs = now - entry.ts;
-    if (ageMs > windowMs) continue;
-    const key = entry.reason ?? '(unknown)';
-    const entryCount = entry.count ?? 1;
-    const existing = map.get(key);
-    if (existing) {
-      existing.count += entryCount;
-      if (entry.ts > existing.lastTs) existing.lastTs = entry.ts;
-    } else {
-      map.set(key, { reason: key, count: entryCount, lastTs: entry.ts });
-    }
-  }
-  return [...map.values()].sort((a, b) => b.count - a.count);
+  const windowed = entries.filter((e) => now - e.ts <= windowMs);
+  return summarizeAlarmLogCounters(windowed);
 }
 
 /**

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -34,6 +34,7 @@ import {
 import {
   BOARDING_PROMPT_WINDOWS,
   clearAlarmLog,
+  countAlarmLogReasonsByWindow,
   countBoardingPromptByWindow,
   countGateReasons,
   countSilentPushOutcomes,
@@ -929,6 +930,24 @@ function buildCountersSection(args: BuildDumpArgs): string[] {
 }
 
 /**
+ * #1682 — Suppress Reasons 섹션. 1h 윈도우 suppress reason 분포 top 5.
+ * V9(suppress event rate < 100/h/trip) 측정 인프라.
+ */
+const SUPPRESS_REASONS_WINDOW_MS = 60 * 60 * 1000; // 1h
+const SUPPRESS_REASONS_TOP_N = 5;
+
+function buildSuppressReasonsSection(args: BuildDumpArgs): string[] {
+  const counters = countAlarmLogReasonsByWindow(
+    args.logs,
+    SUPPRESS_REASONS_WINDOW_MS,
+    args.nowMs ?? Date.now(),
+  );
+  if (counters.length === 0) return ['(empty — no suppressed events in 1h)'];
+  const top = counters.slice(0, SUPPRESS_REASONS_TOP_N);
+  return top.map(({ reason, count, lastTs }) => `${reason}=${count}x (${formatTime(lastTs)})`);
+}
+
+/**
  * #1421 — Auto-lock Candidate 섹션. SSOT/stability/direction/candidate 4개 라인으로
  * device-side auto-lock 측정 상태를 dump.
  *
@@ -1207,6 +1226,8 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
   { title: 'Boarding Prompt Acceptance', build: buildBoardingPromptAcceptanceSection },
   // #1413 — reason별 누적 + 마지막 발생 시각.
   { title: 'Counters', build: buildCountersSection },
+  // #1682 — suppress reason 1h 윈도우 top 5. V9(suppress event rate < 100/h/trip) 측정 인프라.
+  { title: 'Suppress Reasons (1h)', build: buildSuppressReasonsSection },
   // #1421 — PR-AutoLock-1 측정 인프라. SSOT consensus → stability → direction → candidate 4줄.
   { title: 'Auto-lock Candidate', build: buildAutoLockSection },
   // #1430 — 환경 분포 측정 인프라. SSOT 활성 cascade → state별 누적 시간 + transition 카운트.
@@ -2072,6 +2093,9 @@ function DebugModalInner({
           {/* #1024 — ## Counters: reason별 누적 count + 마지막 발생 시각 */}
           <CountersSection logs={logs} colors={colors} />
 
+          {/* #1682 — Suppress Reasons: 1h 윈도우 top 5 suppress reason 분포 */}
+          <SuppressReasonsSection logs={logs} colors={colors} />
+
           {/* #1501 — PR-C. Raw signal 자동 표시 (toggle 없음). 직전 30건만 노출 — share dump에는
               buffer 전체가 시간 역순으로 흐른다. Clear는 buffer + AsyncStorage 모두 wipe. */}
           <DebugLogSection
@@ -2389,6 +2413,42 @@ function CountersSection({
         <Text style={[typography.mono, { color: colors.muted }]}>(empty)</Text>
       ) : (
         counters.map(({ reason, count, lastTs }) => (
+          <KeyValue
+            key={reason}
+            label={reason}
+            value={`${count}x (${formatTime(lastTs)})`}
+            colors={colors}
+          />
+        ))
+      )}
+    </Section>
+  );
+}
+
+/**
+ * #1682 — Suppress Reasons 섹션 본문. 1h 윈도우 top 5 suppress reason 분포.
+ * V9(suppress event rate < 100/h/trip) 측정 인프라. 디버그 only.
+ */
+function SuppressReasonsSection({
+  logs,
+  colors,
+}: Readonly<{
+  logs: readonly AlarmLogEntry[];
+  colors: ReturnType<typeof useTheme>['colors'];
+}>) {
+  const counters = countAlarmLogReasonsByWindow(logs, SUPPRESS_REASONS_WINDOW_MS);
+  const top = counters.slice(0, SUPPRESS_REASONS_TOP_N);
+  return (
+    <Section title="Suppress Reasons (1h)" colors={colors}>
+      {top.length === 0 ? (
+        <Text
+          style={[typography.mono, { color: colors.muted }]}
+          testID="debug-suppress-reasons-empty"
+        >
+          (empty — no suppressed events in 1h)
+        </Text>
+      ) : (
+        top.map(({ reason, count, lastTs }) => (
           <KeyValue
             key={reason}
             label={reason}

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -2758,6 +2758,35 @@ describe('DebugModal — Gates 섹션 (#1025)', () => {
   });
 });
 
+// #1682 — Suppress Reasons (1h) 섹션 UI 검증.
+describe('DebugModal — Suppress Reasons 섹션 (#1682)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupHookDefaults();
+  });
+
+  it('1h 이내 suppressed 엔트리가 없으면 empty 메시지를 표시한다', async () => {
+    // ts=1 은 Date.now()보다 훨씬 과거(ms epoch) → 1h 윈도우 밖 → empty
+    mockGetAlarmLog.mockResolvedValue([
+      { ts: 1, source: 'bg', outcome: 'suppressed', reason: 'gate-out-of-range' },
+    ]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('debug-suppress-reasons-empty')).toBeTruthy());
+  });
+
+  it('1h 이내 suppressed 엔트리가 있으면 reason 카운트를 표시한다', async () => {
+    const ts = Date.now() - 1_000; // 1초 전 — 1h 윈도우 이내
+    mockGetAlarmLog.mockResolvedValue([
+      { ts, source: 'bg', outcome: 'suppressed', reason: 'gate-out-of-range' },
+      { ts, source: 'bg', outcome: 'suppressed', reason: 'gate-out-of-range' },
+    ]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(screen.getByText('Suppress Reasons (1h)')).toBeTruthy());
+    // reason label 노출. getAllByText — CountersSection도 같은 reason을 표시할 수 있음.
+    expect(screen.getAllByText('gate-out-of-range').length).toBeGreaterThan(0);
+  });
+});
+
 // #1346 — Share build SSOT. 모든 섹션이 한 배열에서 enumerate되므로 누락 없이 출력된다.
 describe('DebugModal share SSOT (#1346)', () => {
   // outer scope factory — SonarCloud nested function 회피.
@@ -2820,6 +2849,8 @@ describe('DebugModal share SSOT (#1346)', () => {
     expect(dump).toContain('## Counters');
     // #1421 — PR-AutoLock-1 측정 인프라.
     expect(dump).toContain('## Auto-lock Candidate');
+    // #1682 — suppress reason 1h 윈도우 섹션.
+    expect(dump).toContain('## Suppress Reasons (1h)');
     // suppressed reason 없으면 Gates 헤더 자체 생략(omitIfEmpty=true).
     expect(dump).not.toContain('## Gates');
   });
@@ -3105,6 +3136,33 @@ describe('DebugModal share SSOT (#1346)', () => {
       const section = dump.slice(dump.indexOf('## Counters'));
       expect(section).toContain('gate-out-of-range=2x');
       expect(section).toContain('movement-static-speed=1x');
+    });
+
+    it('Suppress Reasons (1h): 비어있으면 empty 메시지 출력', () => {
+      const dump = __test__.buildDumpText(makeSsotArgs());
+      const section = dump.slice(dump.indexOf('## Suppress Reasons (1h)'));
+      expect(section).toContain('(empty — no suppressed events in 1h)');
+    });
+
+    it('Suppress Reasons (1h): 1h 이내 suppressed reason count 출력', () => {
+      // nowMs를 고정해 윈도우 계산을 결정적으로 만든다.
+      const NOW = new Date('2026-06-17T13:00:10Z').getTime();
+      const ts1 = NOW - 1_000; // 1h 이내
+      const ts2 = NOW - 2_000; // 1h 이내
+      const tsOld = NOW - 2 * 60 * 60 * 1000; // 2h 전 → 윈도우 밖
+      const dump = __test__.buildDumpText(
+        makeSsotArgs({
+          nowMs: NOW,
+          logs: [
+            { ts: ts1, source: 'bg', outcome: 'suppressed', reason: 'gate-out-of-range' },
+            { ts: ts2, source: 'bg', outcome: 'suppressed', reason: 'gate-out-of-range' },
+            { ts: tsOld, source: 'bg', outcome: 'suppressed', reason: 'dedup-station' }, // 윈도우 밖
+          ],
+        }),
+      );
+      const section = dump.slice(dump.indexOf('## Suppress Reasons (1h)'));
+      expect(section).toContain('gate-out-of-range=2x');
+      expect(section).not.toContain('dedup-station');
     });
   });
 


### PR DESCRIPTION
## Summary

- `countAlarmLogReasonsByWindow(entries, windowMs, now)` 신규 함수 — suppressed 엔트리를 windowMs 이내만 필터링해 reason별 카운트 집계 (count 내림차순 정렬). `countBoardingPromptByWindow` 패턴 재사용.
- `lastNReasons(entries, n)` 신규 함수 — 최근 N건 suppressed reason raw entries 시간 역순 반환.
- DebugModal에 **"Suppress Reasons (1h)"** 섹션 추가 — 1h 윈도우 top 5 reason 분포 표시 (디버그 only, production user 영향 0).
- share dump `SHARE_SECTIONS` 동일 섹션 포함 → trip 사후 분석 시 dump 한 장으로 1h suppress 분포 확인 가능.
- 신규 테스트 16건, `alarmLog.ts` coverage 100% 유지.

Closes #1682

---

## Wire-completion 5단 체크

1. **Orphan 없음** — `npm run lint:orphan` 0 orphan 확인. `countAlarmLogReasonsByWindow` / `lastNReasons` 모두 DebugModal에서 호출됨.
2. **V/X dashboard** — DebugModal "Suppress Reasons (1h)" 섹션 + share dump 동일 섹션에서 시각화. V9(suppress event rate < 100/h/trip) 측정 가능.
3. **의존 PR** — N/A (device-side read-only 집계, backend 연동 없음).
4. **측정 plan** — 1주 trip 후 share dump에서 `## Suppress Reasons (1h)` 섹션 확인. top reason이 `dedup-cross-category-recent`·`gate-station-already-passed` 등 정상 game gate면 V9 충족. 비정상적으로 높은 reason이 있으면 별도 issue.
5. **Device verify** — N/A — type+unit only. UI는 DebugModal(디버그 only), 사용자 동선 변경 없음.

---

## V/X 영향

| 측정 acceptance | 본 PR 머지 후 |
|---|---|
| **V9 suppress event rate < 100/h/trip** | ✅ 측정 가능 (1h 윈도우 aggregate) |
| **X1~X11 reason 추적** | ✅ top 5 분포 DebugModal + dump에서 확인 |
| **사용자 trip evidence 분석** | ✅ share dump "Suppress Reasons (1h)" 섹션 |

## 정책 정합 (배터리/발열/효율)

- ✅ 신규 polling X — 기존 alarmLog read-only 집계만
- ✅ log spam X — read-only, write 부담 0
- ✅ memory bounded — alarmLog 기존 ALARM_LOG_BUFFER_SIZE(200) 그대로
- ✅ DebugModal cost — 디버그 only, production user 영향 0