### PR TITLE
fix(#1678): S9 accelerometer fingerprint 네이티브 모듈 등록 + DebugModal raw signal wire

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
         "@sentry/react-native": "~7.13.0",
+        "accelerometer-fingerprint": "file:./modules/accelerometer-fingerprint",
         "audio-route": "file:./modules/audio-route",
         "expo": "~54.0.33",
         "expo-av": "~16.0.8",
@@ -59,6 +60,9 @@
         "ts-prune": "^0.10.3",
         "typescript": "~5.9.2"
       }
+    },
+    "modules/accelerometer-fingerprint": {
+      "version": "1.0.0"
     },
     "modules/audio-route": {
       "version": "1.0.0"
@@ -5404,6 +5408,10 @@
       "engines": {
         "node": ">=6.5"
       }
+    },
+    "node_modules/accelerometer-fingerprint": {
+      "resolved": "modules/accelerometer-fingerprint",
+      "link": true
     },
     "node_modules/accepts": {
       "version": "1.3.8",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
   "dependencies": {
     "@react-native-async-storage/async-storage": "2.2.0",
     "@sentry/react-native": "~7.13.0",
+    "accelerometer-fingerprint": "file:./modules/accelerometer-fingerprint",
     "audio-route": "file:./modules/audio-route",
     "expo": "~54.0.33",
     "expo-av": "~16.0.8",

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -1356,6 +1356,9 @@ function DebugModalInner({
     // #1447 — E4(#1437) 격리 후 노출된 별 채널. strategy 라벨을 Trip 섹션 + Share dump에 wire-up.
     // null이면 fallback 라벨로 항상 표시(estimator 미산출 상태 명시).
     displayOnlyEstimate,
+    // #1678 — S9 accelerometer fingerprint vote 상태. 'automotive' = train 진동 env 1표.
+    // 'unknown' = 60s window 미수렴 또는 네이티브 모듈 미지원(EAS rebuild 전).
+    accelerometerPattern,
   } = useFusedNearestStation();
   // arc 길이 = trip의 hop 총 수. trip 미설정이면 0.
   const routeHopCount = arcStations.length;
@@ -1764,6 +1767,14 @@ function DebugModalInner({
             <KeyValue
               label="undergroundSSOT"
               value={undergroundSSOTActive ? 'active' : 'null'}
+              colors={colors}
+            />
+            {/* #1678 — S9 accelerometer fingerprint env vote. 'automotive' = train 진동 1표.
+                'unknown' = 60s window 미수렴 또는 네이티브 모듈 미포함(EAS rebuild 필요).
+                EAS rebuild 후에도 'unknown'이면 native 모듈 autolinking 실패 의심. */}
+            <KeyValue
+              label="accelPattern"
+              value={accelerometerPattern}
               colors={colors}
             />
             {differs && (

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -117,6 +117,8 @@ const fusedReturnFixture = (overrides: Record<string, unknown> = {}) => ({
   undergroundSSOT: null,
   // #1447 — E4(#1437) 격리 후 별 채널. 기본값은 null(estimator 미산출).
   displayOnlyEstimate: null,
+  // #1678 — S9 accelerometer fingerprint. 기본값은 unknown(미지원/미수렴).
+  accelerometerPattern: 'unknown' as const,
   ...overrides,
 });
 const arrivalDefaults = {
@@ -161,6 +163,8 @@ const setupHookDefaults = () => {
     undergroundSSOT: null,
     // #1447 — E4(#1437) 격리 후 별 채널. 기본 setupHook은 estimator 미산출(null).
     displayOnlyEstimate: null,
+    // #1678 — S9 accelerometer fingerprint. 기본값은 unknown(미지원/미수렴).
+    accelerometerPattern: 'unknown',
   });
   mockUseArrivalInfo.mockReturnValue({ arrival: baseArrival, loading: false, isMock: false });
   mockUseSilentPushDiagnostics.mockReturnValue({

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.accelPattern.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.accelPattern.test.ts
@@ -1,0 +1,153 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: 이 파일은 의도적으로 여러 features의 hook/util을 조합하는
+ * orchestrator 역할이라 직접 import가 본질적이다. Phase 5 enforce 모드에서 file-level disable로
+ * 옵트인 처리.
+ */
+/**
+ * #1678 — accelerometerPattern raw signal dump 브랜치 커버리지.
+ *
+ * useFusedNearestStation 내부 motionForDump 계산:
+ *   - accelerometerPattern !== 'unknown' → 그대로 채택 (신규 브랜치)
+ *   - accelerometerPattern === 'unknown' + motionStationary=true → 'stationary' fallback (기존)
+ *
+ * useAccelerometerFingerprint를 'automotive' / 'walking' / 'stationary'로 mock해
+ * 신규 브랜치를 실행한다.
+ */
+jest.mock('../useNearestStation');
+jest.mock('../../../arrival/hooks/useArrivalInfo');
+jest.mock('../../../route/hooks/useTrainPositions');
+jest.mock('../../utils/findNearestStation', () => ({
+  findTopNearestStations: jest.fn(() => []),
+}));
+jest.mock('../../../route/utils/findActiveLines', () => ({
+  findActiveLines: jest.fn(() => []),
+}));
+jest.mock('../../../observability/utils/rawSignalBuffer', () => ({
+  pushRawSignal: jest.fn(),
+}));
+jest.mock('../../../observability/utils/tripCorrId', () => ({
+  getCurrentTripCorrIdSync: jest.fn(() => null),
+}));
+jest.mock('../useAccelerometerFingerprint');
+
+import { renderHook, act } from '@testing-library/react-native';
+import { useFusedNearestStation } from '../useFusedNearestStation';
+import { useNearestStation } from '../useNearestStation';
+import { useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
+import { useTrainPositions } from '../../../route/hooks/useTrainPositions';
+import { pushRawSignal } from '../../../observability/utils/rawSignalBuffer';
+import { useAccelerometerFingerprint } from '../useAccelerometerFingerprint';
+import { MOCK_STATIONS } from '../../../../testUtils/fixtures';
+import type { AccelerometerPattern } from '../../utils/accelerometerFingerprint';
+
+const mockUseNearest = useNearestStation as jest.Mock;
+const mockUseArrival = useArrivalInfo as jest.Mock;
+const mockUsePositions = useTrainPositions as jest.Mock;
+const mockUseAccelPattern = useAccelerometerFingerprint as jest.Mock;
+const mockPushRawSignal = pushRawSignal as jest.Mock;
+
+function gangnamGps() {
+  const station = { station: MOCK_STATIONS.gangnam, distanceKm: 0.1 };
+  return {
+    result: station,
+    liveResult: station,
+    stickyDisplayOnly: null,
+    variants: [MOCK_STATIONS.gangnam],
+    userLocation: { lat: 37.5, lng: 127.0 },
+    speedMps: 3,
+    accuracyMeters: 50,
+    loading: false,
+    error: null,
+    permissionDenied: false,
+    locationUncertain: false,
+    gpsActive: 'fg' as const,
+    lastFixAtMs: Date.now(),
+    refresh: jest.fn(),
+  };
+}
+
+function chungmuroGps() {
+  const station = { station: MOCK_STATIONS.chungmuro, distanceKm: 0.05 };
+  return {
+    ...gangnamGps(),
+    result: station,
+    liveResult: station,
+    variants: [MOCK_STATIONS.chungmuro],
+  };
+}
+
+describe('useFusedNearestStation — #1678 accelPattern 반환값 및 motionForDump', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseNearest.mockReturnValue(gangnamGps());
+    mockUseArrival.mockReturnValue({ arrival: null, loading: false, isMock: false });
+    mockUsePositions.mockReturnValue({ positions: null, loading: false, isMock: false });
+  });
+
+  it.each<AccelerometerPattern>(['automotive', 'walking', 'stationary'])(
+    'accelerometerPattern=%s가 hook 반환값에 포함된다',
+    (pattern) => {
+      mockUseAccelPattern.mockReturnValue(pattern);
+
+      const { result } = renderHook(() => useFusedNearestStation());
+
+      expect(result.current.accelerometerPattern).toBe(pattern);
+    },
+  );
+
+  it('accelerometerPattern=unknown이면 hook 반환값도 unknown', () => {
+    mockUseAccelPattern.mockReturnValue('unknown');
+
+    const { result } = renderHook(() => useFusedNearestStation());
+
+    expect(result.current.accelerometerPattern).toBe('unknown');
+  });
+
+  it.each<[AccelerometerPattern, string]>([
+    ['automotive', 'automotive'],
+    ['walking', 'walking'],
+    ['stationary', 'stationary'],
+  ])(
+    'accelerometerPattern=%s → pushRawSignal motion=%s (unknown 아닐 때 우선 채택)',
+    (pattern, expectedMotion) => {
+      mockUseAccelPattern.mockReturnValue(pattern);
+      jest.useFakeTimers();
+
+      const { rerender } = renderHook(() => useFusedNearestStation());
+      act(() => { jest.advanceTimersByTime(0); });
+
+      // station 변경으로 decisionKey 전환 → useEffect 재실행 → pushRawSignal 호출
+      mockUseNearest.mockReturnValue(chungmuroGps());
+      rerender({});
+      act(() => { jest.advanceTimersByTime(0); });
+
+      jest.useRealTimers();
+
+      const allMotions = mockPushRawSignal.mock.calls.map(
+        ([entry]: [{ motion: string | null }]) => entry.motion,
+      );
+      expect(allMotions.some((m) => m === expectedMotion)).toBe(true);
+    },
+  );
+
+  it('accelerometerPattern=unknown + motionStationary=true → pushRawSignal motion=stationary fallback', () => {
+    mockUseAccelPattern.mockReturnValue('unknown');
+    jest.useFakeTimers();
+
+    const { rerender } = renderHook(() =>
+      useFusedNearestStation(undefined, undefined, undefined, null, null, true),
+    );
+    act(() => { jest.advanceTimersByTime(0); });
+
+    mockUseNearest.mockReturnValue(chungmuroGps());
+    rerender({});
+    act(() => { jest.advanceTimersByTime(0); });
+
+    jest.useRealTimers();
+
+    const allMotions = mockPushRawSignal.mock.calls.map(
+      ([entry]: [{ motion: string | null }]) => entry.motion,
+    );
+    expect(allMotions.some((m) => m === 'stationary')).toBe(true);
+  });
+});

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -11,7 +11,7 @@ import {
   pushFusionDebugEntry,
   type FusionCandidateMini,
 } from '../utils/fusionDebugBuffer';
-import { pushRawSignal } from '../../observability/utils/rawSignalBuffer';
+import { pushRawSignal, type MotionLabel } from '../../observability/utils/rawSignalBuffer';
 import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
 import { pushEstimatorEntry } from '../../route/utils/estimatorDebugBuffer';
 import { useNearestStation } from './useNearestStation';
@@ -237,6 +237,13 @@ interface UseFusedNearestStationReturn {
    * V1 mismatch 자동 측정에 충분.
    */
   backendSsotCurrentStationId: string | null;
+  /**
+   * #1678 — CMMotionManager 60s window RMS magnitude 분류 결과.
+   * DebugModal Fusion 섹션 + raw signal dump motion 필드의 SSOT.
+   * 'automotive' = train 진동 env vote 1표, 'unknown' = 미수렴/미지원.
+   * EAS rebuild 전에는 native module이 없어 항상 'unknown'.
+   */
+  accelerometerPattern: import('../utils/accelerometerFingerprint').AccelerometerPattern;
   refresh: () => Promise<void>;
 }
 
@@ -1458,10 +1465,13 @@ export function useFusedNearestStation(
           speedMps: gps.speedMps,
         }
       : null;
-    // motionStationary는 boolean | undefined. boolean으로 들어오면 stationary/unknown 라벨로 매핑.
-    // 정확한 motion provider 라벨(walking/automotive)은 후속 PR에서 motion-activity 모듈 expose 후 보강.
-    let motionForDump: 'stationary' | 'unknown' | null = null;
-    if (motionStationary === true) {
+    // #1678 — accelerometerPattern이 concrete(unknown 아님)이면 우선 채택.
+    // 'automotive' / 'walking' / 'stationary'는 raw signal dump에 직접 반영.
+    // 'unknown' (60s window 미수렴 / 미지원)이면 boolean motionStationary fallback.
+    let motionForDump: MotionLabel | null = null;
+    if (accelerometerPattern !== 'unknown') {
+      motionForDump = accelerometerPattern;
+    } else if (motionStationary === true) {
       motionForDump = 'stationary';
     } else if (motionStationary === false) {
       motionForDump = 'unknown';
@@ -1530,7 +1540,7 @@ export function useFusedNearestStation(
       source,
       confidence,
     });
-  }, [decisionKey, source, confidence, result, wifiStationResolved, positionTrainResult, fused, routeResult, gps.result, gps.accuracyMeters, gps.userLocation, gps.speedMps, trainProgress, lockedTrainCode, detectionVerdict, barometerSubsurface, resultStationId, motionStationary, a0.arrival, a1.arrival, a2.arrival, c0, c1, c2, h0, h1, h2, progress.progressM]);
+  }, [decisionKey, source, confidence, result, wifiStationResolved, positionTrainResult, fused, routeResult, gps.result, gps.accuracyMeters, gps.userLocation, gps.speedMps, trainProgress, lockedTrainCode, detectionVerdict, barometerSubsurface, resultStationId, motionStationary, accelerometerPattern, a0.arrival, a1.arrival, a2.arrival, c0, c1, c2, h0, h1, h2, progress.progressM]);
 
   return {
     result,
@@ -1570,6 +1580,8 @@ export function useFusedNearestStation(
     // #1421 — DebugModal Auto-lock 측정 섹션이 SSOT 객체를 inferAutoLockCandidate에 직접 전달.
     surfaceSSOT,
     undergroundSSOT,
+    // #1678 — DebugModal Fusion 섹션 + raw signal dump에서 accelerometer vote 상태 확인.
+    accelerometerPattern,
     // #1486 (ADR-015 §2) — sticky 표시 채널 패스스루. useNearestStation이 sticky.locked를 노출하고
     // 본 hook은 그대로 통과. fire path는 본 필드는 읽지 않는다.
     stickyDisplayOnly: gps.stickyDisplayOnly,


### PR DESCRIPTION
Closes #1678

## Wire Matrix (S9 chain 현황)

| Layer | 이전 상태 | 이후 상태 |
|---|---|---|
| **A. native module autolinking** | ❌ package.json 미등록 → Pods 없음 | ✅ 등록 완료 → EAS rebuild 후 AccelerometerFingerprintModule 포함 |
| **B. BG location piggyback** | ✅ backgroundLocationTask.ts에 `startAccelerometerFingerprint()` 호출 있음 | ✅ 변경 없음 (이미 wired) |
| **C. undergroundSSotConsensus vote** | ✅ accelerometerPattern='automotive' → env vote 1표 이미 wired | ✅ 변경 없음 |
| **D. DebugModal raw signal** | ❌ motion 필드: 'stationary'/'unknown' 만 기록 (accel pattern 미반영) | ✅ automotive/walking/stationary/unknown 전체 반영 |
| **E. DebugModal accelPattern row** | ❌ 표시 없음 | ✅ Fusion 섹션에 accelPattern row 추가 |

## 발견된 갭 및 Fix

### Gap A (Critical) — package.json 미등록
`ios/Podfile.lock`에 `AccelerometerFingerprint` 항목 없음 확인. `cellular-tech-listener`, `motion-activity`, `wifi-ssid`는 모두 등록되어 있으나 `accelerometer-fingerprint`만 누락.

**Fix**: `package.json` dependencies에 `"accelerometer-fingerprint": "file:./modules/accelerometer-fingerprint"` 추가.

### Gap C — raw signal dump motion 필드 미반영
`useFusedNearestStation`의 `pushRawSignal` 호출 시 `motionForDump`가 `boolean motionStationary`만 참조 → 'stationary'/'unknown' 두 값만 기록. accelerometerPattern의 'automotive'/'walking'이 trip dump에 나타나지 않았음.

**Fix**: `accelerometerPattern !== 'unknown'`이면 accelerometerPattern을 motionForDump로 우선 채택. 'unknown'일 때만 boolean motionStationary fallback.

### Gap D — DebugModal accelPattern row 없음
DebugModal Fusion 섹션에 accelerometer vote 상태 표시 없음 → trip dump 공유 시 accelerometer가 vote에 기여했는지 알 수 없음.

**Fix**: Fusion 섹션에 `accelPattern` row 추가. 'unknown'이면 native module 미포함(EAS rebuild 필요) 명시.

## V/X 영향

| Acceptance | 이전 | 이후 |
|---|---|---|
| **V7 지하 station-passed** | ⚠️ S9 native module 없어 env vote 항상 0 | ✅ EAS rebuild 후 S9 vote 활성 (V1 BG 지하 천장 70→90% 목표) |
| **device self-contained 3 신호** | ❌ S9 wire 미완성 | ✅ native 등록 + wire 검증 완료 |

## 정책 정합 (배터리/발열/효율)

- ✅ 신규 polling 없음 — 기존 5s hook + BG location piggyback 재사용
- ✅ log spam 없음 — DebugModal 표시는 trip dump 시만
- ✅ memory bounded — 60s window 50개 samples (native 측)

## 사용자 액션 필수

**EAS production rebuild 필요.** Gap A fix(`package.json` 등록)는 `expo prebuild + pod install`이 포함된 EAS production 빌드에서만 적용됨. 현재 설치된 앱은 `AccelerometerFingerprintModule` Pod 없이 빌드되어 `requireOptionalNativeModule`이 항상 null 반환.

1. PR 머지 후 EAS production 빌드 트리거
2. DebugModal → Fusion 섹션 → `accelPattern` 행 확인
3. 지하 trip에서 `accelPattern=automotive` 전환 여부 1주 baseline 측정

## Wire-completion 5단 체크

1. **Orphan 없음** — `npm run lint:orphan` 0 orphan 확인
2. **V/X dashboard** — DebugModal `accelPattern` row로 즉시 확인 가능
3. **의존 PR** — N/A (독립 fix)
4. **측정 plan** — EAS rebuild 후 1주 raw signal dump에서 `motion=automotive` 건 확인
5. **Device verify** — EAS rebuild 필수 (native Pod 포함 여부 확인)

## 테스트

- `useFusedNearestStation.accelPattern.test.ts` 신규 8 케이스 (automotive/walking/stationary 우선 채택 + unknown fallback + return값 노출)
- `DebugModal.test.tsx` mock fixture에 `accelerometerPattern: 'unknown'` 기본값 추가
- 커버리지 100% / type-check 0 / orphan 0