### PR TITLE
fix(#1683): silent push fired/miss counter aggregation (측정 보강 1차)

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -3823,6 +3823,26 @@ describe('ScheduledStats 초기값 (#826 E4)', () => {
   });
 });
 
+describe('ScheduledStats 초기값 (#1683 silentPushFiredByKind)', () => {
+  it('silentPushFiredByKind 모든 kind 초기값 0 — trip 없는 빈 실행', async () => {
+    const kv = new InMemoryKV();
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.silentPushFiredByKind).toEqual({
+      intermediate: 0,
+      transfer: 0,
+      destination: 0,
+      boardingPrompt: 0,
+      reschedule: 0,
+    });
+  });
+});
+
 // ---------------------------------------------------------------------------
 // #1652 — staged lifecycle backstop (X8: trip 6h+ 잔존 0건)
 // ---------------------------------------------------------------------------
@@ -6752,6 +6772,14 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
       lifecycleSilenceSkipped: 0, lifecycleForceEnded: 0,
       // #1680 — stationary cron skip.
       lifecycleStationarySkipped: 0,
+      // #1683 — silent push fired by kind.
+      silentPushFiredByKind: {
+        intermediate: 0,
+        transfer: 0,
+        destination: 0,
+        boardingPrompt: 0,
+        reschedule: 0,
+      },
     };
     const { dirty } = await fireArvlCdStationPush({
       trip,

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -554,6 +554,25 @@ export interface ScheduledStats extends LiveActivityStats {
    * 정상 운영: 정지 대기 사용자 수(trip × cycle) 만큼 누적. Seoul API call 절감 + false fire 방어 효과.
    */
   lifecycleStationarySkipped: number;
+  /**
+   * #1683 — silent push 발사 건수 kind별 분리 (backend 단계 측정).
+   * `sendSilentPush` 성공 호출 수 = APNs로 넘어간 push 수. device received와 diff → APNs 손실 분리.
+   *
+   * - `intermediate`: station-passed(매역 통과) 알림 발사
+   * - `transfer`     : 환승 임박 / transfer-release lock sync 발사
+   * - `destination`  : 도착 임박 발사
+   * - `boardingPrompt`: boarding-prompt alert push 발사
+   * - `reschedule`   : reschedule push 발사 (스케줄 정정)
+   *
+   * cron tail `kind` 필드로 fired vs received 단계 손실을 손쉽게 집계 가능.
+   */
+  silentPushFiredByKind: {
+    intermediate: number;
+    transfer: number;
+    destination: number;
+    boardingPrompt: number;
+    reschedule: number;
+  };
 }
 
 /**
@@ -661,6 +680,14 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     lifecycleForceEnded: 0,
     // #1680 (V8d) — stationary cron skip.
     lifecycleStationarySkipped: 0,
+    // #1683 — silent push kind별 발사 카운터 (backend cron stage 측정).
+    silentPushFiredByKind: {
+      intermediate: 0,
+      transfer: 0,
+      destination: 0,
+      boardingPrompt: 0,
+      reschedule: 0,
+    },
   };
   // #1539 (S6) — cron jitter 즉시 log. 누적 stat이 아니라 매 cycle 1줄 → tail에서 P50/P99 산출.
   log('scheduled: cron jitter', { jitterMs: stats.cronJitterMs });
@@ -1406,6 +1433,14 @@ export async function fireArvlCdStationPush(
   }
   stats.arvlCdFireSuccess += 1;
   stats.pushed += 1;
+  // #1683 — kind별 발사 카운터. 'intermediate'는 station-passed 경로, 그 외 그대로.
+  if (waypoint.kind === 'intermediate') {
+    stats.silentPushFiredByKind.intermediate += 1;
+  } else if (waypoint.kind === 'transfer') {
+    stats.silentPushFiredByKind.transfer += 1;
+  } else if (waypoint.kind === 'destination') {
+    stats.silentPushFiredByKind.destination += 1;
+  }
   // #1402 — 30s alert fallback 안전망 등록. silent push가 30s 내 ACK되지 않으면
   // runFallbackPushes가 alert(소리) push를 발사. arvlCd 경로는 가장 흔한 발사 경로이므로
   // 여기서도 안전망을 가동해 "하차 침묵 0" acceptance를 보강한다.
@@ -1743,6 +1778,14 @@ export async function fireVanishFallbackStationPush(
     stats.vanishReleaseFired += 1;
   } else {
     stats.vanishFallbackFired += 1;
+  }
+  // #1683 — kind별 발사 카운터. vanish 경로는 waypoint.kind로 분류.
+  if (waypoint.kind === 'intermediate') {
+    stats.silentPushFiredByKind.intermediate += 1;
+  } else if (waypoint.kind === 'transfer') {
+    stats.silentPushFiredByKind.transfer += 1;
+  } else if (waypoint.kind === 'destination') {
+    stats.silentPushFiredByKind.destination += 1;
   }
   // P0-1 (#1577) — Site 4 of 6: vanish fire 적재 (transfer/destination imminent 포함).
   writeMetric(env, {
@@ -2367,6 +2410,10 @@ export async function advanceBoardingLockWaypoint(
       stats.envCorrected += 1;
       await putTrip(env.TRIPS, trip);
     }
+    // #1683 — transfer-release push 성공 시 kind 카운터 누적.
+    if (transferHeal.result.ok) {
+      stats.silentPushFiredByKind.transfer += 1;
+    }
   }
   // #902 Seam F — 환승 직후 자동 trainCode swap. release한 lock 자리에 새 노선의 후보를
   // 동일 cycle 안에 부착해 다음 cycle의 lockMissing/boarding-prompt 우회 + 즉시 trainCode 추적.
@@ -2589,6 +2636,8 @@ export async function maybeReschedulePush(
 
   if (result.ok) {
     stats.pushed += 1;
+    // #1683 — reschedule kind 카운터.
+    stats.silentPushFiredByKind.reschedule += 1;
     trip.lastTrackedArrivalEpoch = newArrivalEpoch;
     dirty = true;
   } else {
@@ -2905,6 +2954,8 @@ export async function runLocklessIntermediate(
   // 발사 성공 — waypoint 진행 + dedup stamp + 측정 카운터.
   stats.pushed += 1;
   stats.locklessIntermediateFired += 1;
+  // #1683 — lockless intermediate kind 카운터.
+  stats.silentPushFiredByKind.intermediate += 1;
   // #1402 — 30s alert fallback 안전망 등록. shift 전 stationName으로 등록해 alert 본문이
   // 사용자가 실제로 통과한 station을 가리키게 한다. lockless intermediate는 lock 경로보다
   // device-side validation이 느슨해 silent push 누락 시 안전망 가동이 더 절실한 경로.
@@ -3214,6 +3265,8 @@ export async function evaluateAndMaybeFireBoardingPrompt(
   }
   if (heal.result.ok) {
     stats.boardingPromptFired += 1;
+    // #1683 — boardingPrompt kind 카운터.
+    stats.silentPushFiredByKind.boardingPrompt += 1;
     trip.boardingPromptState = markPromptFired(now);
     // #916 follow-up B — prompt push도 같은 dedup 마커를 stamp한다. dismiss + 클리어 후
     // isSameSession=false 분기로 boardingPromptState가 사라져도 window 안에서 재발사 차단.

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -59,6 +59,7 @@ import {
   logSuppressedTbaRevalidation,
   summarizeAlarmLogBySource,
   countGateReasons,
+  countSilentPushKindBreakdown,
   countSilentPushOutcomes,
   summarizeAlarmLogCounters,
   countAlarmLogReasonsByWindow,
@@ -1662,6 +1663,61 @@ describe('alarmLog', () => {
         makeEntry({ source: 'silent-push-received' }),
       ];
       expect(countSilentPushOutcomes(entries)).toEqual({ received: 1, fired: 0, skipped: 0 });
+    });
+  });
+
+  describe('countSilentPushKindBreakdown (#1683)', () => {
+    it('빈 배열이면 모두 0', () => {
+      expect(countSilentPushKindBreakdown([])).toEqual({
+        'station-passed': 0,
+        transfer: 0,
+        destination: 0,
+        unknown: 0,
+      });
+    });
+
+    it('silent-push-received 엔트리만 kind별 집계한다', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ source: 'silent-push-received', kind: 'station-passed' }),
+        makeEntry({ source: 'silent-push-received', kind: 'station-passed' }),
+        makeEntry({ source: 'silent-push-received', kind: 'transfer' }),
+        makeEntry({ source: 'silent-push-received', kind: 'destination' }),
+        makeEntry({ source: 'silent-push-fired', kind: 'station-passed' }), // fired는 집계 X
+      ];
+      expect(countSilentPushKindBreakdown(entries)).toEqual({
+        'station-passed': 2,
+        transfer: 1,
+        destination: 1,
+        unknown: 0,
+      });
+    });
+
+    it('kind 미지정(구버전 backend)은 unknown 버킷', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ source: 'silent-push-received', kind: undefined }), // kind 명시 없음
+        makeEntry({ source: 'silent-push-received', kind: 'transfer' }),
+      ];
+      expect(countSilentPushKindBreakdown(entries)).toEqual({
+        'station-passed': 0,
+        transfer: 1,
+        destination: 0,
+        unknown: 1,
+      });
+    });
+
+    it('silent-push-received 이외 source(fired/skipped/fg 등)는 무시', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ source: 'silent-push-fired', kind: 'station-passed' }),
+        makeEntry({ source: 'silent-push-skipped', kind: 'transfer' }),
+        makeEntry({ source: 'fg', kind: 'destination' }),
+        makeEntry({ source: 'silent-push-received', kind: 'destination' }),
+      ];
+      expect(countSilentPushKindBreakdown(entries)).toEqual({
+        'station-passed': 0,
+        transfer: 0,
+        destination: 1,
+        unknown: 0,
+      });
     });
   });
 

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -923,6 +923,41 @@ export function countSilentPushOutcomes(
   return counts;
 }
 
+/**
+ * #1683 — silent push received 엔트리를 kind별로 집계.
+ *
+ * `silent-push-received` 소스의 엔트리만 추출해 kind 분포를 반환.
+ * kind가 없는(구버전 backend / 미지정) 엔트리는 `unknown` 버킷에 포함.
+ * DebugModal Silent Push 섹션에서 "received by kind" 분포로 시각화한다.
+ */
+export interface SilentPushKindBreakdown {
+  'station-passed': number;
+  transfer: number;
+  destination: number;
+  unknown: number;
+}
+
+export function countSilentPushKindBreakdown(
+  entries: readonly AlarmLogEntry[],
+): SilentPushKindBreakdown {
+  const counts: SilentPushKindBreakdown = {
+    'station-passed': 0,
+    transfer: 0,
+    destination: 0,
+    unknown: 0,
+  };
+  for (const entry of entries) {
+    if (entry.source !== 'silent-push-received') continue;
+    const { kind } = entry;
+    if (kind === 'station-passed' || kind === 'transfer' || kind === 'destination') {
+      counts[kind] += 1;
+    } else {
+      counts.unknown += 1;
+    }
+  }
+  return counts;
+}
+
 export function logSuppressedGate(
   reason: 'gate-age' | 'gate-accuracy' | 'gate-jump' | 'gate-motion-stationary',
   location: AlarmLogLocation,

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -37,6 +37,7 @@ import {
   countAlarmLogReasonsByWindow,
   countBoardingPromptByWindow,
   countGateReasons,
+  countSilentPushKindBreakdown,
   countSilentPushOutcomes,
   getAlarmLog,
   summarizeAlarmLogByReason,
@@ -374,6 +375,9 @@ function silentPushDiagRows(
   // #1308 — LPM은 silent push를 throttle/drop 한다. received 카운트 옆에 두어 "LPM ON인데
   // received가 안 늘어남"을 한눈에 보고 측정할 수 있게 한다.
   const lowPowerValue = lowPowerMode ? 'ON' : 'off';
+  // #1683 — received kind 분포. backend fired vs device received 갭 분석용.
+  const kindBreakdown = countSilentPushKindBreakdown(logs);
+  const receivedKindValue = `stn=${kindBreakdown['station-passed']} xfer=${kindBreakdown.transfer} dst=${kindBreakdown.destination} unk=${kindBreakdown.unknown}`;
   return [
     { uiLabel: 'permission', dumpKey: 'permission', value: d.permissionStatus ?? '(unknown)' },
     { uiLabel: 'apnsToken', dumpKey: 'apnsToken', value: formatTokenTail(d.apnsToken) },
@@ -388,6 +392,8 @@ function silentPushDiagRows(
       dumpKey: SILENT_PUSH_LABELS.receivedKey,
       value: receivedValue,
     },
+    // #1683 — received kind 분포 (station-passed / transfer / destination / unknown)
+    { uiLabel: 'recvKind', dumpKey: 'receivedByKind', value: receivedKindValue },
     {
       uiLabel: SILENT_PUSH_LABELS.firedKey,
       dumpKey: SILENT_PUSH_LABELS.firedKey,


### PR DESCRIPTION
Closes #1683

## Summary

- **backend**: `ScheduledStats`에 `silentPushFiredByKind` 필드 추가 → `sendSilentPush` 5개 fire site에서 kind별 누적 → `scheduled run complete` log에 자동 포함
- **device**: `alarmLog.ts`에 `countSilentPushKindBreakdown` 추가 → `silent-push-received` 엔트리를 `station-passed / transfer / destination / unknown` 4버킷으로 집계
- **DebugModal**: Silent Push 섹션에 `recvKind` row 추가 (`stn=N xfer=N dst=N unk=N` 형식)

## Wire Matrix

| 단계 | 측정 채널 | 내용 |
|---|---|---|
| backend cron 발사 | wrangler tail `scheduled run complete` | `silentPushFiredByKind.{intermediate,transfer,destination,boardingPrompt,reschedule}` |
| APNs delivery | (기존 pushAckStats / pendingPushes) | 변경 없음 |
| device received | DebugModal Silent Push `recvKind` row | `countSilentPushKindBreakdown` kind 분포 |
| device fired | DebugModal Silent Push `fired` row | 기존 `countSilentPushOutcomes` 그대로 |

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` 0 orphan ✅
2. **V/X dashboard** — DebugModal Silent Push 섹션 `recvKind` row (device) + wrangler tail `silentPushFiredByKind` (backend)
3. **의존 PR** — N/A
4. **측정 plan** — 1주 production trip 이후 DebugModal dump의 `receivedByKind` vs wrangler tail `silentPushFiredByKind` diff → APNs 손실 단계 특정
5. **Device verify** — DebugModal Silent Push 섹션에서 silent push 수신 후 `recvKind` 값 변화 확인 필요

## V/X 영향

| acceptance | 이전 | 이후 |
|---|---|---|
| V4 매역 silent baseline | 분포 X | ✅ kind별 fired/received 분포 |
| silent push 손실 root | 불명확 | ✅ backend/APNs/device 3단계 비교 가능 |
| trip evidence 분석 | 수동 dump | ✅ DebugModal `recvKind` 자동 |

## 정책 정합 (배터리/발열/효율)

- 신규 polling 없음 — 기존 handler 진입에 연산 1회 추가
- log spam 없음 — kind별 counter 단순 덧셈, alarmLog 1h cap 기존 적용
- DebugModal only — production user 영향 0