### PR TITLE
fix(#1687): autoLock counter aggregation — success rate baseline 측정 보강

### DIFF
--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -67,6 +67,7 @@ import {
   countBoardingPromptByWindow,
   logBoardingPromptAutoLock,
   countBoardingPromptAutoLockOutcomes,
+  countAutoLockReasonsByWindow,
   logScheduleSkipped,
   ALARM_LOG_BUFFER_SIZE,
   type AlarmLogEntry,
@@ -2010,6 +2011,74 @@ describe('alarmLog', () => {
       const counts = countBoardingPromptAutoLockOutcomes(entries);
       expect(counts['autolock-success']).toBe(0);
       expect(counts['autolock-no-trip']).toBe(0);
+    });
+  });
+
+  describe('countAutoLockReasonsByWindow (#1687)', () => {
+    it('windowMs 이후 엔트리만 집계한다', () => {
+      const now = 10_000;
+      const entries: AlarmLogEntry[] = [
+        // 윈도우 안 (now - 5000 = 5000, ts=6000 > 5000)
+        { ts: 6_000, source: 'boarding-prompt', outcome: 'fired', reason: 'autolock-success' },
+        // 윈도우 경계 밖 (ts=5000 <= 5000)
+        { ts: 5_000, source: 'boarding-prompt', outcome: 'fired', reason: 'autolock-success' },
+        // 윈도우 밖 (ts=4000 < 5000)
+        { ts: 4_000, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-ambiguity' },
+      ];
+      const counts = countAutoLockReasonsByWindow(entries, 5_000, now);
+      expect(counts['autolock-success']).toBe(1);
+      expect(counts['autolock-ambiguity']).toBe(0);
+    });
+
+    it('reason별 분포를 올바르게 집계한다', () => {
+      const now = 100_000;
+      const entries: AlarmLogEntry[] = [
+        { ts: 99_000, source: 'boarding-prompt', outcome: 'fired', reason: 'autolock-success' },
+        { ts: 99_001, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-ambiguity' },
+        { ts: 99_002, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-arrivals-empty' },
+        { ts: 99_003, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-no-trip' },
+        { ts: 99_004, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-station-lookup' },
+        { ts: 99_005, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-lock-failed' },
+      ];
+      const counts = countAutoLockReasonsByWindow(entries, 10_000, now);
+      expect(counts).toEqual({
+        'autolock-success': 1,
+        'autolock-ambiguity': 1,
+        'autolock-arrivals-empty': 1,
+        'autolock-no-trip': 1,
+        'autolock-station-lookup': 1,
+        'autolock-lock-failed': 1,
+      });
+    });
+
+    it('boarding-prompt 외 source는 무시한다', () => {
+      const now = 10_000;
+      const entries: AlarmLogEntry[] = [
+        { ts: 9_000, source: 'fg', outcome: 'fired', reason: 'autolock-success' },
+        { ts: 9_001, source: 'boarding-prompt', outcome: 'fired', reason: 'autolock-success' },
+      ];
+      const counts = countAutoLockReasonsByWindow(entries, 5_000, now);
+      expect(counts['autolock-success']).toBe(1);
+    });
+
+    it('엔트리 없을 때 모든 카운터가 0', () => {
+      const counts = countAutoLockReasonsByWindow([], 3_600_000);
+      expect(counts['autolock-success']).toBe(0);
+      expect(counts['autolock-ambiguity']).toBe(0);
+      expect(counts['autolock-arrivals-empty']).toBe(0);
+      expect(counts['autolock-no-trip']).toBe(0);
+      expect(counts['autolock-station-lookup']).toBe(0);
+      expect(counts['autolock-lock-failed']).toBe(0);
+    });
+
+    it('reason 없는 entry(발사 빈도 #1021)는 집계에서 제외한다', () => {
+      const now = 10_000;
+      const entries: AlarmLogEntry[] = [
+        // reason 없는 발사 빈도 entry — autolock 집계 제외
+        { ts: 9_000, source: 'boarding-prompt', outcome: 'fired' },
+      ];
+      const counts = countAutoLockReasonsByWindow(entries, 5_000, now);
+      expect(counts['autolock-success']).toBe(0);
     });
   });
 

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -1365,6 +1365,40 @@ export function countBoardingPromptAutoLockOutcomes(
   return counts;
 }
 
+/**
+ * #1687 — 시간 윈도우 기반 autolock outcome 분포 집계.
+ *
+ * `countBoardingPromptAutoLockOutcomes`와 동일 로직에 windowMs 시간 필터를 추가.
+ * DebugModal Telemetry 섹션에서 "autoLock (1h)" 같은 최근 N분/시간 집계에 사용.
+ *
+ * @param entries  alarmLog 전체 엔트리 배열
+ * @param windowMs 집계 윈도우(ms). `now - windowMs` 이후 엔트리만 포함.
+ * @param now      현재 시각(epoch ms). 기본값 Date.now() — 테스트에서 고정값 주입 가능.
+ */
+export function countAutoLockReasonsByWindow(
+  entries: readonly AlarmLogEntry[],
+  windowMs: number,
+  now: number = Date.now(),
+): Record<BoardingPromptAutoLockReason, number> {
+  const cutoff = now - windowMs;
+  const counts: Record<BoardingPromptAutoLockReason, number> = {
+    'autolock-success': 0,
+    'autolock-no-trip': 0,
+    'autolock-arrivals-empty': 0,
+    'autolock-ambiguity': 0,
+    'autolock-station-lookup': 0,
+    'autolock-lock-failed': 0,
+  };
+  for (const entry of entries) {
+    if (entry.ts <= cutoff) continue;
+    if (entry.source !== 'boarding-prompt') continue;
+    const { reason } = entry;
+    if (reason === undefined) continue;
+    if (reason in counts) counts[reason as BoardingPromptAutoLockReason] += 1;
+  }
+  return counts;
+}
+
 /** #1170: boardingPrompt 사용자 응답 1건 적재. */
 export function logBoardingPromptResponded(input: {
   outcome: 'boarded' | 'dismissed';

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -34,6 +34,7 @@ import {
 import {
   BOARDING_PROMPT_WINDOWS,
   clearAlarmLog,
+  countAutoLockReasonsByWindow,
   countBoardingPromptByWindow,
   countGateReasons,
   countSilentPushOutcomes,
@@ -2064,6 +2065,8 @@ function DebugModalInner({
                 colors={colors}
               />
             ))}
+            {/* #1687 — autoLock outcome 분포 (1h 윈도우). success rate baseline 측정. */}
+            <AutoLockTelemetryRow logs={logs} colors={colors} />
           </Section>
 
           {/* #1170: boarding-prompt acceptance dashboard (gate 통과율/응답률) */}
@@ -2398,6 +2401,44 @@ function CountersSection({
         ))
       )}
     </Section>
+  );
+}
+
+const AUTOLOCK_1H_MS = 60 * 60 * 1000;
+
+/**
+ * #1687 — autoLock outcome 분포 row (1h 윈도우).
+ *
+ * boardingPrompt 응답 → autoLock chain 성공률 baseline 측정 인프라.
+ * 표시: success / ambiguous(=ambiguity) / empty(=arrivals-empty) / failed(=lock-failed) 4개 카운트.
+ * 1시간 윈도우 고정 — 단기 측정에 적합. 0건이면 "—"로 표기.
+ */
+function AutoLockTelemetryRow({
+  logs,
+  colors,
+}: Readonly<{
+  logs: readonly AlarmLogEntry[];
+  colors: ReturnType<typeof useTheme>['colors'];
+}>) {
+  const counts = useMemo(() => countAutoLockReasonsByWindow(logs, AUTOLOCK_1H_MS), [logs]);
+  const total =
+    counts['autolock-success'] +
+    counts['autolock-ambiguity'] +
+    counts['autolock-arrivals-empty'] +
+    counts['autolock-no-trip'] +
+    counts['autolock-station-lookup'] +
+    counts['autolock-lock-failed'];
+  const value =
+    total === 0
+      ? '—'
+      : `ok=${counts['autolock-success']} amb=${counts['autolock-ambiguity']} empty=${counts['autolock-arrivals-empty']} fail=${counts['autolock-lock-failed']}`;
+  return (
+    <KeyValue
+      label="autoLock(1h)"
+      value={value}
+      colors={colors}
+      testID="debug-autolock-telemetry-1h"
+    />
   );
 }
 

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -677,7 +677,33 @@ describe('DebugModal', () => {
     expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
   });
 
-    it('unmount 시 AppState listener를 정리한다', async () => {
+  it('#1687: autoLock(1h) row — 엔트리 없을 때 "—" 표기', async () => {
+    mockGetAlarmLog.mockResolvedValue([]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByTestId('debug-autolock-telemetry-1h')).toBeTruthy();
+    expect(screen.getByTestId('debug-autolock-telemetry-1h').props.children).toBe('—');
+  });
+
+  it('#1687: autoLock(1h) row — success/ambiguous/empty/failed 분포 표기', async () => {
+    const now = Date.now();
+    mockGetAlarmLog.mockResolvedValue([
+      { ts: now - 1_000, source: 'boarding-prompt', outcome: 'fired', reason: 'autolock-success' },
+      { ts: now - 2_000, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-ambiguity' },
+      { ts: now - 3_000, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-arrivals-empty' },
+      { ts: now - 4_000, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-lock-failed' },
+    ]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    const el = screen.getByTestId('debug-autolock-telemetry-1h');
+    expect(el).toBeTruthy();
+    expect(el.props.children).toContain('ok=1');
+    expect(el.props.children).toContain('amb=1');
+    expect(el.props.children).toContain('empty=1');
+    expect(el.props.children).toContain('fail=1');
+  });
+
+  it('unmount 시 AppState listener를 정리한다', async () => {
     const { unmount } = renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
     unmount();


### PR DESCRIPTION
## Summary

Closes #1687

autoLock 시도(boardingPromptAutoLock) 결과 분포 측정 부재 → success rate baseline 확보.

- `alarmLog.ts`: `countAutoLockReasonsByWindow(entries, windowMs, now?)` 추가 — 시간 윈도우 기반 autolock reason 집계 (기존 `countBoardingPromptAutoLockOutcomes` + 시간 필터)
- `DebugModal.tsx`: Boarding Prompt 섹션에 `AutoLockTelemetryRow` 추가 — `autoLock(1h)` row: `ok=N amb=N empty=N fail=N` 포맷, 0건 시 `—`

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass. `countAutoLockReasonsByWindow`의 caller = DebugModal `AutoLockTelemetryRow`
2. **V/X dashboard** — DebugModal Boarding Prompt 섹션 `autoLock(1h)` row에서 직접 관찰. testID=`debug-autolock-telemetry-1h`
3. **의존 PR** — N/A (alarmLog 내 inline 구현, 기존 `logBoardingPromptAutoLock` 적재 데이터 활용)
4. **측정 plan** — 1주 production trip 후 DebugModal에서 `ok` vs `amb/empty/fail` 비율 확인. autolock-success 비율이 baseline 미달 시 boardingPromptAutoLock 로직 개선
5. **Device verify** — N/A — type+unit only. DebugModal은 디버그 전용, 사용자 UI 변경 없음

## 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `src/features/alarm/utils/alarmLog.ts` | `countAutoLockReasonsByWindow` 추가 (+36줄) |
| `src/features/debug/components/DebugModal.tsx` | `AutoLockTelemetryRow` 컴포넌트 + import (+37줄) |
| `src/features/alarm/utils/__tests__/alarmLog.test.ts` | 5개 케이스 추가 |
| `src/features/debug/components/__tests__/DebugModal.test.tsx` | 2개 케이스 추가 |

## 정책 정합

- ✅ 신규 polling X (read-only 집계 함수)
- ✅ log spam X (기존 alarmLog 엔트리 재활용, 새 write 없음)
- ✅ memory bounded (기존 alarmLog ring buffer 내 집계)
- ✅ `useMemo` 캐시로 DebugModal re-render 비용 최소화