### PR TITLE
fix(#1692): trip dump 자동 alarmLog reason aggregate (측정 보강 2차 — a78b 재spawn)

### DIFF
--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -1946,6 +1946,35 @@ describe('alarmLog', () => {
       const result = countAlarmLogReasonsByWindow(entries, 60 * 60 * 1000, now);
       expect(result).toEqual([{ reason: 'gate-age', count: 2, lastTs: now - 100 }]);
     });
+
+    it('나중 entry의 ts가 더 크면 lastTs를 갱신한다', () => {
+      const now = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: now - 500 }),
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: now - 100 }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, 60 * 60 * 1000, now);
+      expect(result).toEqual([{ reason: 'gate-age', count: 2, lastTs: now - 100 }]);
+    });
+
+    it('reason이 없으면 (unknown)으로 집계한다', () => {
+      const now = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'suppressed', reason: undefined, ts: now - 100 }),
+        makeEntry({ outcome: 'suppressed', reason: undefined, ts: now - 200 }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, 60 * 60 * 1000, now);
+      expect(result).toEqual([{ reason: '(unknown)', count: 2, lastTs: now - 100 }]);
+    });
+
+    it('windowMs/now 기본값으로 호출해도 동작한다', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: Date.now() - 1000 }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.reason).toBe('gate-age');
+    });
   });
 
   describe('logBoardingPromptFired + countBoardingPromptByWindow (#1021)', () => {

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -61,6 +61,7 @@ import {
   countGateReasons,
   countSilentPushOutcomes,
   summarizeAlarmLogCounters,
+  countAlarmLogReasonsByWindow,
   logBoardingPromptFired,
   logBoardingPromptResponded,
   BOARDING_PROMPT_WINDOWS,
@@ -1879,6 +1880,71 @@ describe('alarmLog', () => {
       ];
       const result = summarizeAlarmLogCounters(entries);
       expect(result).toEqual([{ reason: 'gate-age', count: 2, lastTs: 200 }]);
+    });
+  });
+
+  describe('countAlarmLogReasonsByWindow (#1692)', () => {
+    it('1h 윈도우 내 suppressed reason을 count 내림차순으로 반환한다', () => {
+      const now = 1_700_000_000_000;
+      const oneHourMs = 60 * 60 * 1000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'suppressed', reason: 'movement-static-speed', ts: now - 1000 }),
+        makeEntry({ outcome: 'suppressed', reason: 'movement-static-speed', ts: now - 2000 }),
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: now - 3000 }),
+        makeEntry({ outcome: 'fired', ts: now - 100 }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, oneHourMs, now);
+      expect(result[0]).toEqual({ reason: 'movement-static-speed', count: 2, lastTs: now - 1000 });
+      expect(result[1]).toEqual({ reason: 'gate-age', count: 1, lastTs: now - 3000 });
+    });
+
+    it('1h 윈도우 밖 항목은 제외한다', () => {
+      const now = 1_700_000_000_000;
+      const oneHourMs = 60 * 60 * 1000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: now - oneHourMs - 1 }),
+        makeEntry({ outcome: 'suppressed', reason: 'dedup-station', ts: now - 1000 }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, oneHourMs, now);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.reason).toBe('dedup-station');
+    });
+
+    it('suppressed가 없으면 빈 배열을 반환한다', () => {
+      const now = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'fired', ts: now - 1000 }),
+      ];
+      expect(countAlarmLogReasonsByWindow(entries, 60 * 60 * 1000, now)).toEqual([]);
+    });
+
+    it('topN 제한이 적용된다', () => {
+      const now = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = Array.from({ length: 15 }, (_, i) =>
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: now - (i + 1) * 1000, count: 15 - i }),
+      );
+      const result = countAlarmLogReasonsByWindow(entries, 60 * 60 * 1000, now, 3);
+      expect(result.length).toBeLessThanOrEqual(3);
+    });
+
+    it('count 필드가 없으면 1로 해석한다', () => {
+      const now = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: now - 100 }),
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: now - 200 }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, 60 * 60 * 1000, now);
+      expect(result).toEqual([{ reason: 'gate-age', count: 2, lastTs: now - 100 }]);
+    });
+
+    it('나중 entry의 ts가 더 작으면 lastTs를 갱신하지 않는다', () => {
+      const now = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: now - 100 }),
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: now - 500 }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, 60 * 60 * 1000, now);
+      expect(result).toEqual([{ reason: 'gate-age', count: 2, lastTs: now - 100 }]);
     });
   });
 

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -874,6 +874,41 @@ export function summarizeAlarmLogCounters(
 }
 
 /**
+ * #1692 — 지정 시간 윈도우 내 suppressed reason 집계 (count 내림차순, top-N).
+ *
+ * dump 시점 1회 read — polling / log spam 없음. dump 자체가 사용자 action이므로
+ * 배터리/발열에 영향 없음. 시간 윈도우 밖 항목은 카운트에 포함되지 않는다.
+ *
+ * @param entries  alarmLog 전체 항목 (getAlarmLog 결과)
+ * @param windowMs 집계 윈도우 (ms). 기본값 1h.
+ * @param now      기준 시각 (ms). 미전달 시 Date.now() 사용 — 테스트 결정적 출력용.
+ * @param topN     반환할 최대 reason 수. 기본값 10.
+ */
+export function countAlarmLogReasonsByWindow(
+  entries: readonly AlarmLogEntry[],
+  windowMs: number = 60 * 60 * 1000,
+  now: number = Date.now(),
+  topN: number = 10,
+): AlarmLogReasonCounter[] {
+  const cutoff = now - windowMs;
+  const map = new Map<string, AlarmLogReasonCounter>();
+  for (const entry of entries) {
+    if (entry.outcome !== 'suppressed') continue;
+    if (entry.ts < cutoff) continue;
+    const key = entry.reason ?? '(unknown)';
+    const entryCount = entry.count ?? 1;
+    const existing = map.get(key);
+    if (existing) {
+      existing.count += entryCount;
+      if (entry.ts > existing.lastTs) existing.lastTs = entry.ts;
+    } else {
+      map.set(key, { reason: key, count: entryCount, lastTs: entry.ts });
+    }
+  }
+  return [...map.values()].sort((a, b) => b.count - a.count).slice(0, topN);
+}
+
+/**
  * Silent push outcome별 집계 (#856).
  *
  * DebugModal Silent Push 섹션에서 "lastRecv 시간만 보고 왜 안 울리지?" 의문을 해소하기 위한

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -34,6 +34,7 @@ import {
 import {
   BOARDING_PROMPT_WINDOWS,
   clearAlarmLog,
+  countAlarmLogReasonsByWindow,
   countBoardingPromptByWindow,
   countGateReasons,
   countSilentPushOutcomes,
@@ -784,6 +785,22 @@ function buildAlarmLogSection(args: BuildDumpArgs): string[] {
 }
 
 /**
+ * #1692 — Alarm Log Reasons (1h) 섹션.
+ *
+ * dump 시점 기준 최근 1시간 내 suppressed reason 집계 (count 내림차순 top-10).
+ * 사용자가 "어떤 게이트가 가장 자주 발동했는지"를 share dump 수신 즉시 파악 가능.
+ *
+ * nowMs 미전달 시 Date.now() 사용 — 테스트 결정적 출력 확보.
+ * 1h 윈도우 내 suppressed 항목이 없으면 (empty) 반환.
+ */
+function buildAlarmLogReasonsSummarySection(args: BuildDumpArgs): string[] {
+  const now = args.nowMs ?? Date.now();
+  const counters = countAlarmLogReasonsByWindow(args.logs, 60 * 60 * 1000, now);
+  if (counters.length === 0) return ['(empty)'];
+  return counters.map(({ reason, count }) => `${reason}: ${count}`);
+}
+
+/**
  * #1501 — Raw signal 섹션. 직전 30건(혹은 그 이하)을 최신순으로 직렬화. 빈 buffer는
  * (empty)로 명시 — "한 번도 push 안 됨"과 "load 안 함"을 구분(Fusion log와 동일 컨벤션).
  *
@@ -1182,6 +1199,9 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
     build: buildAlarmLogSection,
     suffix: (args) => ` (${args.logs.length})`,
   },
+  // #1692 — Alarm Log Reasons (1h): suppress reason 집계 요약. Alarm log 직후 배치해
+  // 사용자가 발사 실패 분포를 share dump에서 즉시 파악 가능.
+  { title: 'Alarm Log Reasons (1h)', build: buildAlarmLogReasonsSummarySection },
   // #1346 — fusion log를 share에 포함. 누락 시 sticky cascade 같은 회귀를 사후 재구성 불가.
   {
     title: 'Fusion log',

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -986,6 +986,31 @@ describe('DebugModal helpers', () => {
     expect(dump).not.toContain('sources:');
   });
 
+  it('buildDumpText: Alarm Log Reasons (1h) 섹션이 suppressed reason 집계를 포함한다 (#1692)', () => {
+    const now = 1_700_000_000_000;
+    const logs: AlarmLogEntry[] = [
+      { ts: now - 1000, source: 'fg', outcome: 'suppressed', reason: 'movement-static-speed' },
+      { ts: now - 2000, source: 'fg', outcome: 'suppressed', reason: 'movement-static-speed' },
+      { ts: now - 3000, source: 'bg', outcome: 'suppressed', reason: 'gate-age' },
+    ];
+    const dump = __test__.buildDumpText(makeDumpArgs({ logs, nowMs: now }));
+    expect(dump).toContain('## Alarm Log Reasons (1h)');
+    expect(dump).toContain('movement-static-speed: 2');
+    expect(dump).toContain('gate-age: 1');
+  });
+
+  it('buildDumpText: Alarm Log Reasons (1h) suppressed가 없으면 (empty)를 표기한다 (#1692)', () => {
+    const now = 1_700_000_000_000;
+    const logs: AlarmLogEntry[] = [
+      { ts: now - 1000, source: 'fg', outcome: 'fired', stationName: '강남' },
+    ];
+    const dump = __test__.buildDumpText(makeDumpArgs({ logs, nowMs: now }));
+    expect(dump).toContain('## Alarm Log Reasons (1h)');
+    // fired 항목만 있으면 (empty) 출력
+    const section = dump.slice(dump.indexOf('## Alarm Log Reasons (1h)'));
+    expect(section).toContain('(empty)');
+  });
+
   it('formatLogLine: location 없는 fired 엔트리는 acc/age를 포함하지 않는다', () => {
     const line = __test__.formatLogLine({
       ts: Date.now(),


### PR DESCRIPTION
## 변경 요약

사용자 trip dump (`getBatteryDiagnosticsDump` 등) 출력에 alarmLog suppress reason 1h aggregate 자동 포함. 사용자 수동 보고 부담 ↓ + 다음 회차 trip evidence 정밀 분석.

Closes #1692

## 정책 정합 (배터리/발열/효율)

- ✅ 신규 polling X — dump 시점 1회 read
- ✅ log spam X — dump 자체가 사용자 action 시만
- ✅ memory bounded — alarmLog 1h cap
- ✅ async race X — sync read

## V/X 영향

- **측정 baseline** — 사용자 trip evidence 자동 reason 수집
- **다음 trip evidence 정밀 분석** — 수동 dump 보고 부담 ↓

## Wire-completion 5단

1. Orphan: 0
2. V/X dashboard: trip dump 출력에 reason aggregate section
3. 의존 PR: #1684 (alarmLog measurement infra) — countAlarmLogReasonsByWindow 활용 가능 (또는 inline)
4. 측정 plan: 1주 production trip 종료 시 dump → reason 분포 확인
5. Device verify: 사용자 실기기 trip 1건 — dump 출력 형식 확인