### PR TITLE
fix(#1693): fusion picker tier 채택 분포 측정 (측정 보강 3차)

### DIFF
--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -52,6 +52,9 @@ import {
   logSuppressedHopWindowNoSource,
   logSuppressedLocklessForwardOnly,
   logFusionCandidateDistanceReject,
+  logFusionPickerTier,
+  _resetFusionPickerTierWindowForTests,
+  formatFusionPickerTierDistribution,
   logCrossTripMirrorSkip,
   logSuppressedOriginHopLockless,
   logSuppressedPassedEventOnLockOrigin,
@@ -119,6 +122,7 @@ describe('alarmLog', () => {
     _resetDedupAlarmWindowForTests();
     _resetRefMismatchWindowForTests();
     _resetBurstSuppressWindowForTests();
+    _resetFusionPickerTierWindowForTests();
     // #735 — 모듈 스코프 pending/timer 격리.
     resetAlarmLogForTest();
   });
@@ -2178,6 +2182,136 @@ describe('alarmLog', () => {
       setSentryEnabled(true);
       appendAlarmLog(makeEntry({ source: 'fg', outcome: 'fired' }));
       expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('logFusionPickerTier + formatFusionPickerTierDistribution (#1693)', () => {
+    it('logFusionPickerTier: tier 채택 시 source=fusion-picker-tier, outcome=fired 적재', async () => {
+      logFusionPickerTier('gpsFallback');
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fusion-picker-tier',
+        outcome: 'fired',
+        reason: 'tier-gpsFallback',
+      });
+    });
+
+    it('logFusionPickerTier: 1s 윈도우 내 같은 tier 재호출은 drop (dedup)', async () => {
+      const baseTs = 1_700_000_000_000;
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseTs);
+      try {
+        logFusionPickerTier('backendSsotAccepts');
+        logFusionPickerTier('backendSsotAccepts'); // 동일 tier, 1s 이내 → drop
+        await flushAlarmLog();
+
+        const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+        const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+        expect(saved).toHaveLength(1);
+        expect(saved[0]).toMatchObject({
+          source: 'fusion-picker-tier',
+          reason: 'tier-backendSsotAccepts',
+        });
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('logFusionPickerTier: 1s 경과 후 같은 tier 재호출은 적재 (appendAlarmLog burst counter로 합산)', async () => {
+      // 첫 호출 → 적재
+      logFusionPickerTier('fused');
+      // dedup window 리셋 (1s+ 경과 시뮬레이션)
+      _resetFusionPickerTierWindowForTests();
+      // 두 번째 호출 → burst counter 증가 (appendAlarmLog가 같은 source/reason 연속이면 count++)
+      logFusionPickerTier('fused');
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      // appendAlarmLog burst inline counter: 같은 (source, reason, stationName) 연속이면 count++ (1 entry)
+      expect(saved).toHaveLength(1);
+      expect(saved[0]).toMatchObject({ source: 'fusion-picker-tier', reason: 'tier-fused' });
+      expect(saved[0].count).toBe(2);
+    });
+
+    it('logFusionPickerTier: 다른 tier는 각각 독립 dedup', async () => {
+      logFusionPickerTier('positionTrainBoardingLockMatch');
+      logFusionPickerTier('gpsDerivedFastPath'); // 다른 tier → 별도 적재
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved).toHaveLength(2);
+      expect(saved[0]).toMatchObject({ reason: 'tier-positionTrainBoardingLockMatch' });
+      expect(saved[1]).toMatchObject({ reason: 'tier-gpsDerivedFastPath' });
+    });
+
+    it('formatFusionPickerTierDistribution: 1h 내 entries만 집계', () => {
+      const nowMs = 1_700_000_000_000;
+      const ONE_HOUR_MS = 60 * 60 * 1_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: nowMs - 100, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' }),
+        makeEntry({ ts: nowMs - 200, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' }),
+        makeEntry({ ts: nowMs - ONE_HOUR_MS - 1, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' }), // 1h 초과 → 제외
+        makeEntry({ ts: nowMs - 100, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-backendSsotAccepts' }),
+      ];
+
+      const result = formatFusionPickerTierDistribution(entries, nowMs);
+      expect(result).toContain('tier-gpsFallback=2');
+      expect(result).toContain('tier-backendSsotAccepts=1');
+      expect(result).not.toContain('tier-gpsFallback=3'); // stale entry 포함 X
+    });
+
+    it('formatFusionPickerTierDistribution: fusion-picker-tier 아닌 entries 무시', () => {
+      const nowMs = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: nowMs - 100, source: 'fg', outcome: 'fired', reason: 'tier-gpsFallback' }),
+        makeEntry({ ts: nowMs - 100, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-positionTrain' }),
+      ];
+
+      const result = formatFusionPickerTierDistribution(entries, nowMs);
+      expect(result).toBe('tier-positionTrain=1');
+    });
+
+    it('formatFusionPickerTierDistribution: entries 없으면 (none) 반환', () => {
+      const result = formatFusionPickerTierDistribution([], Date.now());
+      expect(result).toBe('(none)');
+    });
+
+    it('formatFusionPickerTierDistribution: count 내림차순 정렬', () => {
+      const nowMs = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: nowMs - 100, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-fused' }),
+        makeEntry({ ts: nowMs - 200, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' }),
+        makeEntry({ ts: nowMs - 300, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' }),
+      ];
+
+      const result = formatFusionPickerTierDistribution(entries, nowMs);
+      const parts = result.split(', ');
+      expect(parts[0]).toBe('tier-gpsFallback=2');
+      expect(parts[1]).toBe('tier-fused=1');
+    });
+
+    it('formatFusionPickerTierDistribution: outcome이 fired가 아닌 fusion-picker-tier entries는 무시', () => {
+      const nowMs = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: nowMs - 100, source: 'fusion-picker-tier', outcome: 'suppressed', reason: 'tier-gpsFallback' }),
+      ];
+
+      const result = formatFusionPickerTierDistribution(entries, nowMs);
+      expect(result).toBe('(none)');
+    });
+
+    it('formatFusionPickerTierDistribution: reason이 없는 fusion-picker-tier entries는 (unknown) 키로 집계', () => {
+      const nowMs = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: nowMs - 100, source: 'fusion-picker-tier', outcome: 'fired' }),
+      ];
+
+      const result = formatFusionPickerTierDistribution(entries, nowMs);
+      expect(result).toBe('(unknown)=1');
     });
   });
 });

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -69,7 +69,10 @@ export type AlarmLogSource =
   //   'cross-trip-mirror-launch'   : R11-c (useLaunchTripReconciliation.ts:89, active trip 없을 때 clear)
   | 'cross-trip-mirror-register'
   | 'cross-trip-mirror-mismatch'
-  | 'cross-trip-mirror-launch';
+  | 'cross-trip-mirror-launch'
+  // #1693 — fusion cascade picker가 어느 tier를 채택했는지 측정. tier 변화 시 1건 적재.
+  // PR #1650/#1662/#1674 효과(지하 positionTrain/GPS-derived/arvlCd tier 채택률) 검증.
+  | 'fusion-picker-tier';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(#580): evaluateAlarmPhase의 firedAlarms 적중. destination/transfer phase alarm dedup
 // 발생 관찰. station-passed는 별도 메커니즘(lastNotifiedStationId)이라 'dedup-station' 사용.
@@ -227,7 +230,19 @@ export type AlarmLogReason =
   // #1656 — phase↔phase cross-station 즉시 cascade 윈도우(PHASE_TO_PHASE_CROSS_STATION_WINDOW_MS=3s)
   // 안에서 다른 station에 두 phase 알람(transfer + destination 또는 역방향)이 leg 전환 race로
   // 연이어 발사되는 회귀 차단(2026-06-20 12:32 건대+성수, 2026-06-19 15:37 이수+사당).
-  | 'dedup-phase-to-phase';
+  | 'dedup-phase-to-phase'
+  // #1693 — fusion cascade picker tier 채택 이름. 'fusion-picker-tier' source로 적재.
+  // PR #1650/#1662/#1674 효과(지하 positionTrain/GPS-derived/arvlCd 채택률) 검증.
+  | 'tier-positionTrainBoardingLockMatch'
+  | 'tier-gpsDerivedFastPath'
+  | 'tier-arvlCdArrivedMatch'
+  | 'tier-backendSsotAccepts'
+  | 'tier-wifiStationResolved'
+  | 'tier-positionTrain'
+  | 'tier-fused'
+  | 'tier-detectionVerdictAccepts'
+  | 'tier-routeResult'
+  | 'tier-gpsFallback';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -643,6 +658,59 @@ export function logCrossTripMirrorSkip(site: 'register' | 'mismatch' | 'launch')
 }
 
 /**
+ * #1693 — fusion cascade picker tier 채택 1건 적재.
+ *
+ * tier가 변경됐을 때만 적재(dedup window 1s) — 같은 tier가 연속 폴링으로 반복 채택돼도
+ * log spam 없이 tier 변화 분포만 측정한다.
+ * 호출 site: `useFusedNearestStation.ts` cascade picker if/else if 블록 이후.
+ *
+ * 각 tier 이름 → reason 매핑:
+ *   positionTrainBoardingLockMatch (#1646) → tier-positionTrainBoardingLockMatch
+ *   gpsDerivedFastPath (#1657)             → tier-gpsDerivedFastPath
+ *   arvlCdArrivedMatch (#1668)             → tier-arvlCdArrivedMatch
+ *   backendSsotAccepts (#1568 T8b)         → tier-backendSsotAccepts
+ *   wifiStationResolved (#1286)            → tier-wifiStationResolved
+ *   positionTrain (Phase 1C)               → tier-positionTrain
+ *   fused (pickFusedStation)               → tier-fused
+ *   detectionVerdictAccepts (#1513)        → tier-detectionVerdictAccepts
+ *   routeResult (Phase A)                  → tier-routeResult
+ *   gpsFallback (gps.liveResult)           → tier-gpsFallback
+ */
+export type FusionPickerTier =
+  | 'positionTrainBoardingLockMatch'
+  | 'gpsDerivedFastPath'
+  | 'arvlCdArrivedMatch'
+  | 'backendSsotAccepts'
+  | 'wifiStationResolved'
+  | 'positionTrain'
+  | 'fused'
+  | 'detectionVerdictAccepts'
+  | 'routeResult'
+  | 'gpsFallback';
+
+const FUSION_PICKER_TIER_DEDUP_MS = 1_000;
+const lastFusionPickerTierTs = new Map<string, number>();
+
+export function logFusionPickerTier(tier: FusionPickerTier): void {
+  const now = Date.now();
+  const last = lastFusionPickerTierTs.get(tier);
+  if (last !== undefined && now - last < FUSION_PICKER_TIER_DEDUP_MS) return;
+  lastFusionPickerTierTs.set(tier, now);
+  const reason: AlarmLogReason = `tier-${tier}` as AlarmLogReason;
+  appendAlarmLog({
+    ts: now,
+    source: 'fusion-picker-tier',
+    outcome: 'fired',
+    reason,
+  });
+}
+
+/** 테스트용 — fusion picker tier dedup 윈도우 캐시 리셋. */
+export function _resetFusionPickerTierWindowForTests(): void {
+  lastFusionPickerTierTs.clear();
+}
+
+/**
  * #1545 (S12) — trip 종료 시 3개 dedup 윈도우 Map을 모두 클리어.
  *
  * 사용자가 직전 trip에서 동일 destination/같은 phaseId를 가진 새 trip을 즉시 시작하면,
@@ -874,6 +942,36 @@ export function summarizeAlarmLogCounters(
 }
 
 /**
+ * #1693 — fusion picker tier 채택 분포 집계 (최근 1h, DebugModal Telemetry row).
+ *
+ * 직전 1h의 'fusion-picker-tier' source 엔트리에서 reason(tier name) 별 count를 집계.
+ * DebugModal이 "Fusion Tier (1h)" row에 표시할 문자열로 포맷해 반환한다.
+ *
+ * 예: "tier-positionTrainBoardingLockMatch=3, tier-gpsFallback=12"
+ * 엔트리 없음 시 "(none)" 반환.
+ */
+export function formatFusionPickerTierDistribution(
+  entries: readonly AlarmLogEntry[],
+  nowMs: number = Date.now(),
+): string {
+  const ONE_HOUR_MS = 60 * 60 * 1_000;
+  const counts: Record<string, number> = {};
+  for (const e of entries) {
+    if (e.source !== 'fusion-picker-tier') continue;
+    if (e.outcome !== 'fired') continue;
+    if (nowMs - e.ts > ONE_HOUR_MS) continue;
+    const key = e.reason ?? '(unknown)';
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  const keys = Object.keys(counts);
+  if (keys.length === 0) return '(none)';
+  return keys
+    .sort((a, b) => (counts[b] as number) - (counts[a] as number))
+    .map((k) => `${k}=${counts[k]}`)
+    .join(', ');
+}
+
+/**
  * Silent push outcome별 집계 (#856).
  *
  * DebugModal Silent Push 섹션에서 "lastRecv 시간만 보고 왜 안 울리지?" 의문을 해소하기 위한
@@ -904,6 +1002,7 @@ const SILENT_PUSH_OUTCOME_SOURCES: Record<AlarmLogSource, keyof SilentPushOutcom
   'cross-trip-mirror-register': null,
   'cross-trip-mirror-mismatch': null,
   'cross-trip-mirror-launch': null,
+  'fusion-picker-tier': null,
 };
 
 export interface SilentPushOutcomeCounts {

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -37,6 +37,7 @@ import {
   countBoardingPromptByWindow,
   countGateReasons,
   countSilentPushOutcomes,
+  formatFusionPickerTierDistribution,
   getAlarmLog,
   summarizeAlarmLogByReason,
   summarizeAlarmLogBySource,
@@ -2053,6 +2054,17 @@ function DebugModalInner({
               </Text>
             </Section>
           ) : null}
+
+          {/* #1693 — fusion picker tier 채택 분포 (최근 1h). PR #1650/#1662/#1674 효과 검증. */}
+          <Section title="Fusion Tier (1h)" colors={colors}>
+            <Text
+              style={[typography.mono, { color: colors.ink }]}
+              selectable
+              testID="debug-fusion-picker-tier"
+            >
+              {formatFusionPickerTierDistribution(logs)}
+            </Text>
+          </Section>
 
           {/* #1021: boardingPrompt 발사 빈도 카운터 */}
           <Section title="Boarding Prompt" colors={colors}>

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -677,7 +677,31 @@ describe('DebugModal', () => {
     expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
   });
 
-    it('unmount 시 AppState listener를 정리한다', async () => {
+  it('#1693: Fusion Tier (1h) 섹션이 tier 분포를 표시한다', async () => {
+    const now = Date.now();
+    mockGetAlarmLog.mockResolvedValue([
+      { ts: now - 100, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' },
+      { ts: now - 200, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' },
+      { ts: now - 300, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-backendSsotAccepts' },
+    ]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('Fusion Tier (1h)')).toBeTruthy();
+    const tierEl = screen.getByTestId('debug-fusion-picker-tier');
+    expect(tierEl.props.children).toContain('tier-gpsFallback=2');
+    expect(tierEl.props.children).toContain('tier-backendSsotAccepts=1');
+  });
+
+  it('#1693: Fusion Tier (1h) 섹션 — fusion-picker-tier 없으면 (none) 표시', async () => {
+    mockGetAlarmLog.mockResolvedValue([]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('Fusion Tier (1h)')).toBeTruthy();
+    const tierEl = screen.getByTestId('debug-fusion-picker-tier');
+    expect(tierEl.props.children).toBe('(none)');
+  });
+
+  it('unmount 시 AppState listener를 정리한다', async () => {
     const { unmount } = renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
     unmount();

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -33,6 +33,7 @@ import { trackTrainProgress } from '../../route/utils/trackTrainProgress';
 import { estimateArcStationsFromRoute } from '../../route/utils/arcEstimation';
 import {
   logFusionCandidateDistanceReject,
+  logFusionPickerTier,
   logSuppressedLocklessForwardOnly,
 } from '../../alarm/utils/alarmLog';
 import { haversine } from '../../../shared/utils/haversine';
@@ -1051,6 +1052,31 @@ export function useFusedNearestStation(
     result = gps.liveResult;
     confidence = 'gps-only';
     source = 'gps';
+  }
+
+  // #1693 — cascade picker가 채택한 tier를 alarmLog에 적재 (측정 보강 3차).
+  // dedup 1s — 같은 tier 연속 폴링 cycle에서 1건만 적재.
+  // PR #1650/#1662/#1674 효과(지하 positionTrain/GPS-derived/arvlCd tier 채택률) 검증.
+  if (positionTrainBoardingLockMatch) {
+    logFusionPickerTier('positionTrainBoardingLockMatch');
+  } else if (gpsDerivedFastPath) {
+    logFusionPickerTier('gpsDerivedFastPath');
+  } else if (arvlCdArrivedMatch) {
+    logFusionPickerTier('arvlCdArrivedMatch');
+  } else if (backendSsotAccepts) {
+    logFusionPickerTier('backendSsotAccepts');
+  } else if (wifiStationResolved) {
+    logFusionPickerTier('wifiStationResolved');
+  } else if (positionTrainResult) {
+    logFusionPickerTier('positionTrain');
+  } else if (fused && fusedPasses) {
+    logFusionPickerTier('fused');
+  } else if (detectionVerdictAccepts) {
+    logFusionPickerTier('detectionVerdictAccepts');
+  } else if (routeResult && routePasses) {
+    logFusionPickerTier('routeResult');
+  } else {
+    logFusionPickerTier('gpsFallback');
   }
 
   // #1418 — Tier 1 SSOT 합의 판정 + 환경 추정.


### PR DESCRIPTION
Closes #1693

## 변경 요약

`useFusedNearestStation` cascade picker가 어느 tier를 채택했는지 측정 인프라가 없었음. PR #1650/#1662/#1674 효과(지하 positionTrain/GPS-derived/arvlCd 채택률) 검증을 위한 측정 보강.

## Wire Matrix

| 항목 | 상태 |
|------|------|
| 1. Orphan 없음 | `npm run lint:orphan` 0 orphan ✅ |
| 2. V/X dashboard | DebugModal `Fusion Tier (1h)` 섹션 (`testID=debug-fusion-picker-tier`) — 모달 열면 즉시 확인 가능 ✅ |
| 3. 의존 PR | N/A — device-only 변경 ✅ |
| 4. 측정 plan | DebugModal에서 1h 창 tier 분포 직접 관찰. `/admin/alarm-log-stats` source=fusion-picker-tier 집계로 PR #1650/#1662/#1674 효과 검증 (positionTrainBoardingLockMatch/gpsDerivedFastPath/arvlCdArrivedMatch 채택 횟수 증가 여부) ✅ |
| 5. Device verify | N/A — type+unit only. DebugModal 렌더링은 실기기 확인 권장 |

## 변경 상세

### Fix 1. `alarmLog.ts`
- `AlarmLogSource` 에 `'fusion-picker-tier'` 추가
- `AlarmLogReason` 에 tier 이름 9개(`tier-positionTrainBoardingLockMatch` ~ `tier-gpsFallback`) 추가
- `FusionPickerTier` 타입 export
- `logFusionPickerTier(tier)` helper — dedup 1s (같은 tier 연속 폴링 시 1회만)
- `formatFusionPickerTierDistribution(entries, nowMs)` — 1h 창 tier 분포 문자열
- `SILENT_PUSH_OUTCOME_SOURCES` 에 `fusion-picker-tier: null` 추가 (타입 완전성)

### Fix 2. `useFusedNearestStation.ts`
- cascade picker `if/else if` 블록 이후 `logFusionPickerTier(tier)` 호출 (전 9개 tier 커버)

### Fix 3. `DebugModal.tsx`
- `Fusion Tier (1h)` 섹션 추가 — Boarding Prompt 섹션 바로 위
- `testID="debug-fusion-picker-tier"` 로 테스트/실기기 확인 가능

## 정책 정합

- ✅ dedup window 1s — log spam X
- ✅ 신규 polling X (cascade picker cycle 안에서만 호출)
- ✅ memory bounded (alarmLog 1h cap 기존)
- ✅ UI 변경 X (DebugModal debug-only)

## 테스트

- `alarmLog.test.ts` +10 케이스 (logFusionPickerTier dedup/적재 + formatFusionPickerTierDistribution 분포)
- `DebugModal.test.tsx` +2 케이스 (tier 있음/없음 섹션 렌더)
- type-check 0 error, coverage 100%, lint:orphan 0