### PR TITLE
fix(measurement): autoLock + trip dump + fusion tier 통합 (#1687/#1692/#1693)

### DIFF
--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -2004,6 +2004,35 @@ describe('alarmLog', () => {
       const result = countAlarmLogReasonsByWindow(entries, 60 * 60 * 1000, now);
       expect(result).toEqual([{ reason: 'gate-age', count: 2, lastTs: now - 100 }]);
     });
+
+    it('나중 entry의 ts가 더 크면 lastTs를 갱신한다', () => {
+      const now = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: now - 500 }),
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: now - 100 }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, 60 * 60 * 1000, now);
+      expect(result).toEqual([{ reason: 'gate-age', count: 2, lastTs: now - 100 }]);
+    });
+
+    it('reason이 없으면 (unknown)으로 집계한다', () => {
+      const now = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'suppressed', reason: undefined, ts: now - 100 }),
+        makeEntry({ outcome: 'suppressed', reason: undefined, ts: now - 200 }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, 60 * 60 * 1000, now);
+      expect(result).toEqual([{ reason: '(unknown)', count: 2, lastTs: now - 100 }]);
+    });
+
+    it('windowMs/now 기본값으로 호출해도 동작한다', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: Date.now() - 1000 }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.reason).toBe('gate-age');
+    });
   });
 
   describe('logBoardingPromptFired + countBoardingPromptByWindow (#1021)', () => {

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -1941,6 +1941,71 @@ describe('alarmLog', () => {
     });
   });
 
+  describe('countAlarmLogReasonsByWindow (#1692)', () => {
+    it('1h 윈도우 내 suppressed reason을 count 내림차순으로 반환한다', () => {
+      const now = 1_700_000_000_000;
+      const oneHourMs = 60 * 60 * 1000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'suppressed', reason: 'movement-static-speed', ts: now - 1000 }),
+        makeEntry({ outcome: 'suppressed', reason: 'movement-static-speed', ts: now - 2000 }),
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: now - 3000 }),
+        makeEntry({ outcome: 'fired', ts: now - 100 }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, oneHourMs, now);
+      expect(result[0]).toEqual({ reason: 'movement-static-speed', count: 2, lastTs: now - 1000 });
+      expect(result[1]).toEqual({ reason: 'gate-age', count: 1, lastTs: now - 3000 });
+    });
+
+    it('1h 윈도우 밖 항목은 제외한다', () => {
+      const now = 1_700_000_000_000;
+      const oneHourMs = 60 * 60 * 1000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: now - oneHourMs - 1 }),
+        makeEntry({ outcome: 'suppressed', reason: 'dedup-station', ts: now - 1000 }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, oneHourMs, now);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.reason).toBe('dedup-station');
+    });
+
+    it('suppressed가 없으면 빈 배열을 반환한다', () => {
+      const now = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'fired', ts: now - 1000 }),
+      ];
+      expect(countAlarmLogReasonsByWindow(entries, 60 * 60 * 1000, now)).toEqual([]);
+    });
+
+    it('topN 제한이 적용된다', () => {
+      const now = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = Array.from({ length: 15 }, (_, i) =>
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: now - (i + 1) * 1000, count: 15 - i }),
+      );
+      const result = countAlarmLogReasonsByWindow(entries, 60 * 60 * 1000, now, 3);
+      expect(result.length).toBeLessThanOrEqual(3);
+    });
+
+    it('count 필드가 없으면 1로 해석한다', () => {
+      const now = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: now - 100 }),
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: now - 200 }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, 60 * 60 * 1000, now);
+      expect(result).toEqual([{ reason: 'gate-age', count: 2, lastTs: now - 100 }]);
+    });
+
+    it('나중 entry의 ts가 더 작으면 lastTs를 갱신하지 않는다', () => {
+      const now = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: now - 100 }),
+        makeEntry({ outcome: 'suppressed', reason: 'gate-age', ts: now - 500 }),
+      ];
+      const result = countAlarmLogReasonsByWindow(entries, 60 * 60 * 1000, now);
+      expect(result).toEqual([{ reason: 'gate-age', count: 2, lastTs: now - 100 }]);
+    });
+  });
+
   describe('logBoardingPromptFired + countBoardingPromptByWindow (#1021)', () => {
     it('logBoardingPromptFired가 boarding-prompt entry를 적재한다', async () => {
       (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -52,6 +52,9 @@ import {
   logSuppressedHopWindowNoSource,
   logSuppressedLocklessForwardOnly,
   logFusionCandidateDistanceReject,
+  logFusionPickerTier,
+  _resetFusionPickerTierWindowForTests,
+  formatFusionPickerTierDistribution,
   logCrossTripMirrorSkip,
   logSuppressedOriginHopLockless,
   logSuppressedPassedEventOnLockOrigin,
@@ -123,6 +126,7 @@ describe('alarmLog', () => {
     _resetDedupAlarmWindowForTests();
     _resetRefMismatchWindowForTests();
     _resetBurstSuppressWindowForTests();
+    _resetFusionPickerTierWindowForTests();
     // #735 — 모듈 스코프 pending/timer 격리.
     resetAlarmLogForTest();
   });
@@ -2536,6 +2540,136 @@ describe('alarmLog', () => {
 
     it('entries 수가 n보다 적으면 있는 것만 반환', () => {
       expect(lastNReasons([sup('dedup-station')], 10)).toHaveLength(1);
+    });
+  });
+
+  describe('logFusionPickerTier + formatFusionPickerTierDistribution (#1693)', () => {
+    it('logFusionPickerTier: tier 채택 시 source=fusion-picker-tier, outcome=fired 적재', async () => {
+      logFusionPickerTier('gpsFallback');
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fusion-picker-tier',
+        outcome: 'fired',
+        reason: 'tier-gpsFallback',
+      });
+    });
+
+    it('logFusionPickerTier: 1s 윈도우 내 같은 tier 재호출은 drop (dedup)', async () => {
+      const baseTs = 1_700_000_000_000;
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseTs);
+      try {
+        logFusionPickerTier('backendSsotAccepts');
+        logFusionPickerTier('backendSsotAccepts'); // 동일 tier, 1s 이내 → drop
+        await flushAlarmLog();
+
+        const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+        const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+        expect(saved).toHaveLength(1);
+        expect(saved[0]).toMatchObject({
+          source: 'fusion-picker-tier',
+          reason: 'tier-backendSsotAccepts',
+        });
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('logFusionPickerTier: 1s 경과 후 같은 tier 재호출은 적재 (appendAlarmLog burst counter로 합산)', async () => {
+      // 첫 호출 → 적재
+      logFusionPickerTier('fused');
+      // dedup window 리셋 (1s+ 경과 시뮬레이션)
+      _resetFusionPickerTierWindowForTests();
+      // 두 번째 호출 → burst counter 증가 (appendAlarmLog가 같은 source/reason 연속이면 count++)
+      logFusionPickerTier('fused');
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      // appendAlarmLog burst inline counter: 같은 (source, reason, stationName) 연속이면 count++ (1 entry)
+      expect(saved).toHaveLength(1);
+      expect(saved[0]).toMatchObject({ source: 'fusion-picker-tier', reason: 'tier-fused' });
+      expect(saved[0].count).toBe(2);
+    });
+
+    it('logFusionPickerTier: 다른 tier는 각각 독립 dedup', async () => {
+      logFusionPickerTier('positionTrainBoardingLockMatch');
+      logFusionPickerTier('gpsDerivedFastPath'); // 다른 tier → 별도 적재
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved).toHaveLength(2);
+      expect(saved[0]).toMatchObject({ reason: 'tier-positionTrainBoardingLockMatch' });
+      expect(saved[1]).toMatchObject({ reason: 'tier-gpsDerivedFastPath' });
+    });
+
+    it('formatFusionPickerTierDistribution: 1h 내 entries만 집계', () => {
+      const nowMs = 1_700_000_000_000;
+      const ONE_HOUR_MS = 60 * 60 * 1_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: nowMs - 100, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' }),
+        makeEntry({ ts: nowMs - 200, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' }),
+        makeEntry({ ts: nowMs - ONE_HOUR_MS - 1, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' }), // 1h 초과 → 제외
+        makeEntry({ ts: nowMs - 100, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-backendSsotAccepts' }),
+      ];
+
+      const result = formatFusionPickerTierDistribution(entries, nowMs);
+      expect(result).toContain('tier-gpsFallback=2');
+      expect(result).toContain('tier-backendSsotAccepts=1');
+      expect(result).not.toContain('tier-gpsFallback=3'); // stale entry 포함 X
+    });
+
+    it('formatFusionPickerTierDistribution: fusion-picker-tier 아닌 entries 무시', () => {
+      const nowMs = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: nowMs - 100, source: 'fg', outcome: 'fired', reason: 'tier-gpsFallback' }),
+        makeEntry({ ts: nowMs - 100, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-positionTrain' }),
+      ];
+
+      const result = formatFusionPickerTierDistribution(entries, nowMs);
+      expect(result).toBe('tier-positionTrain=1');
+    });
+
+    it('formatFusionPickerTierDistribution: entries 없으면 (none) 반환', () => {
+      const result = formatFusionPickerTierDistribution([], Date.now());
+      expect(result).toBe('(none)');
+    });
+
+    it('formatFusionPickerTierDistribution: count 내림차순 정렬', () => {
+      const nowMs = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: nowMs - 100, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-fused' }),
+        makeEntry({ ts: nowMs - 200, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' }),
+        makeEntry({ ts: nowMs - 300, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' }),
+      ];
+
+      const result = formatFusionPickerTierDistribution(entries, nowMs);
+      const parts = result.split(', ');
+      expect(parts[0]).toBe('tier-gpsFallback=2');
+      expect(parts[1]).toBe('tier-fused=1');
+    });
+
+    it('formatFusionPickerTierDistribution: outcome이 fired가 아닌 fusion-picker-tier entries는 무시', () => {
+      const nowMs = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: nowMs - 100, source: 'fusion-picker-tier', outcome: 'suppressed', reason: 'tier-gpsFallback' }),
+      ];
+
+      const result = formatFusionPickerTierDistribution(entries, nowMs);
+      expect(result).toBe('(none)');
+    });
+
+    it('formatFusionPickerTierDistribution: reason이 없는 fusion-picker-tier entries는 (unknown) 키로 집계', () => {
+      const nowMs = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ ts: nowMs - 100, source: 'fusion-picker-tier', outcome: 'fired' }),
+      ];
+
+      const result = formatFusionPickerTierDistribution(entries, nowMs);
+      expect(result).toBe('(unknown)=1');
     });
   });
 });

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -70,6 +70,7 @@ import {
   countBoardingPromptByWindow,
   logBoardingPromptAutoLock,
   countBoardingPromptAutoLockOutcomes,
+  countAutoLockReasonsByWindow,
   logScheduleSkipped,
   ALARM_LOG_BUFFER_SIZE,
   type AlarmLogEntry,
@@ -2068,6 +2069,74 @@ describe('alarmLog', () => {
       const counts = countBoardingPromptAutoLockOutcomes(entries);
       expect(counts['autolock-success']).toBe(0);
       expect(counts['autolock-no-trip']).toBe(0);
+    });
+  });
+
+  describe('countAutoLockReasonsByWindow (#1687)', () => {
+    it('windowMs 이후 엔트리만 집계한다', () => {
+      const now = 10_000;
+      const entries: AlarmLogEntry[] = [
+        // 윈도우 안 (now - 5000 = 5000, ts=6000 > 5000)
+        { ts: 6_000, source: 'boarding-prompt', outcome: 'fired', reason: 'autolock-success' },
+        // 윈도우 경계 밖 (ts=5000 <= 5000)
+        { ts: 5_000, source: 'boarding-prompt', outcome: 'fired', reason: 'autolock-success' },
+        // 윈도우 밖 (ts=4000 < 5000)
+        { ts: 4_000, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-ambiguity' },
+      ];
+      const counts = countAutoLockReasonsByWindow(entries, 5_000, now);
+      expect(counts['autolock-success']).toBe(1);
+      expect(counts['autolock-ambiguity']).toBe(0);
+    });
+
+    it('reason별 분포를 올바르게 집계한다', () => {
+      const now = 100_000;
+      const entries: AlarmLogEntry[] = [
+        { ts: 99_000, source: 'boarding-prompt', outcome: 'fired', reason: 'autolock-success' },
+        { ts: 99_001, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-ambiguity' },
+        { ts: 99_002, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-arrivals-empty' },
+        { ts: 99_003, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-no-trip' },
+        { ts: 99_004, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-station-lookup' },
+        { ts: 99_005, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-lock-failed' },
+      ];
+      const counts = countAutoLockReasonsByWindow(entries, 10_000, now);
+      expect(counts).toEqual({
+        'autolock-success': 1,
+        'autolock-ambiguity': 1,
+        'autolock-arrivals-empty': 1,
+        'autolock-no-trip': 1,
+        'autolock-station-lookup': 1,
+        'autolock-lock-failed': 1,
+      });
+    });
+
+    it('boarding-prompt 외 source는 무시한다', () => {
+      const now = 10_000;
+      const entries: AlarmLogEntry[] = [
+        { ts: 9_000, source: 'fg', outcome: 'fired', reason: 'autolock-success' },
+        { ts: 9_001, source: 'boarding-prompt', outcome: 'fired', reason: 'autolock-success' },
+      ];
+      const counts = countAutoLockReasonsByWindow(entries, 5_000, now);
+      expect(counts['autolock-success']).toBe(1);
+    });
+
+    it('엔트리 없을 때 모든 카운터가 0', () => {
+      const counts = countAutoLockReasonsByWindow([], 3_600_000);
+      expect(counts['autolock-success']).toBe(0);
+      expect(counts['autolock-ambiguity']).toBe(0);
+      expect(counts['autolock-arrivals-empty']).toBe(0);
+      expect(counts['autolock-no-trip']).toBe(0);
+      expect(counts['autolock-station-lookup']).toBe(0);
+      expect(counts['autolock-lock-failed']).toBe(0);
+    });
+
+    it('reason 없는 entry(발사 빈도 #1021)는 집계에서 제외한다', () => {
+      const now = 10_000;
+      const entries: AlarmLogEntry[] = [
+        // reason 없는 발사 빈도 entry — autolock 집계 제외
+        { ts: 9_000, source: 'boarding-prompt', outcome: 'fired' },
+      ];
+      const counts = countAutoLockReasonsByWindow(entries, 5_000, now);
+      expect(counts['autolock-success']).toBe(0);
     });
   });
 

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -69,7 +69,10 @@ export type AlarmLogSource =
   //   'cross-trip-mirror-launch'   : R11-c (useLaunchTripReconciliation.ts:89, active trip 없을 때 clear)
   | 'cross-trip-mirror-register'
   | 'cross-trip-mirror-mismatch'
-  | 'cross-trip-mirror-launch';
+  | 'cross-trip-mirror-launch'
+  // #1693 — fusion cascade picker가 어느 tier를 채택했는지 측정. tier 변화 시 1건 적재.
+  // PR #1650/#1662/#1674 효과(지하 positionTrain/GPS-derived/arvlCd tier 채택률) 검증.
+  | 'fusion-picker-tier';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(#580): evaluateAlarmPhase의 firedAlarms 적중. destination/transfer phase alarm dedup
 // 발생 관찰. station-passed는 별도 메커니즘(lastNotifiedStationId)이라 'dedup-station' 사용.
@@ -227,7 +230,19 @@ export type AlarmLogReason =
   // #1656 — phase↔phase cross-station 즉시 cascade 윈도우(PHASE_TO_PHASE_CROSS_STATION_WINDOW_MS=3s)
   // 안에서 다른 station에 두 phase 알람(transfer + destination 또는 역방향)이 leg 전환 race로
   // 연이어 발사되는 회귀 차단(2026-06-20 12:32 건대+성수, 2026-06-19 15:37 이수+사당).
-  | 'dedup-phase-to-phase';
+  | 'dedup-phase-to-phase'
+  // #1693 — fusion cascade picker tier 채택 이름. 'fusion-picker-tier' source로 적재.
+  // PR #1650/#1662/#1674 효과(지하 positionTrain/GPS-derived/arvlCd 채택률) 검증.
+  | 'tier-positionTrainBoardingLockMatch'
+  | 'tier-gpsDerivedFastPath'
+  | 'tier-arvlCdArrivedMatch'
+  | 'tier-backendSsotAccepts'
+  | 'tier-wifiStationResolved'
+  | 'tier-positionTrain'
+  | 'tier-fused'
+  | 'tier-detectionVerdictAccepts'
+  | 'tier-routeResult'
+  | 'tier-gpsFallback';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -643,6 +658,59 @@ export function logCrossTripMirrorSkip(site: 'register' | 'mismatch' | 'launch')
 }
 
 /**
+ * #1693 — fusion cascade picker tier 채택 1건 적재.
+ *
+ * tier가 변경됐을 때만 적재(dedup window 1s) — 같은 tier가 연속 폴링으로 반복 채택돼도
+ * log spam 없이 tier 변화 분포만 측정한다.
+ * 호출 site: `useFusedNearestStation.ts` cascade picker if/else if 블록 이후.
+ *
+ * 각 tier 이름 → reason 매핑:
+ *   positionTrainBoardingLockMatch (#1646) → tier-positionTrainBoardingLockMatch
+ *   gpsDerivedFastPath (#1657)             → tier-gpsDerivedFastPath
+ *   arvlCdArrivedMatch (#1668)             → tier-arvlCdArrivedMatch
+ *   backendSsotAccepts (#1568 T8b)         → tier-backendSsotAccepts
+ *   wifiStationResolved (#1286)            → tier-wifiStationResolved
+ *   positionTrain (Phase 1C)               → tier-positionTrain
+ *   fused (pickFusedStation)               → tier-fused
+ *   detectionVerdictAccepts (#1513)        → tier-detectionVerdictAccepts
+ *   routeResult (Phase A)                  → tier-routeResult
+ *   gpsFallback (gps.liveResult)           → tier-gpsFallback
+ */
+export type FusionPickerTier =
+  | 'positionTrainBoardingLockMatch'
+  | 'gpsDerivedFastPath'
+  | 'arvlCdArrivedMatch'
+  | 'backendSsotAccepts'
+  | 'wifiStationResolved'
+  | 'positionTrain'
+  | 'fused'
+  | 'detectionVerdictAccepts'
+  | 'routeResult'
+  | 'gpsFallback';
+
+const FUSION_PICKER_TIER_DEDUP_MS = 1_000;
+const lastFusionPickerTierTs = new Map<string, number>();
+
+export function logFusionPickerTier(tier: FusionPickerTier): void {
+  const now = Date.now();
+  const last = lastFusionPickerTierTs.get(tier);
+  if (last !== undefined && now - last < FUSION_PICKER_TIER_DEDUP_MS) return;
+  lastFusionPickerTierTs.set(tier, now);
+  const reason: AlarmLogReason = `tier-${tier}` as AlarmLogReason;
+  appendAlarmLog({
+    ts: now,
+    source: 'fusion-picker-tier',
+    outcome: 'fired',
+    reason,
+  });
+}
+
+/** 테스트용 — fusion picker tier dedup 윈도우 캐시 리셋. */
+export function _resetFusionPickerTierWindowForTests(): void {
+  lastFusionPickerTierTs.clear();
+}
+
+/**
  * #1545 (S12) — trip 종료 시 3개 dedup 윈도우 Map을 모두 클리어.
  *
  * 사용자가 직전 trip에서 동일 destination/같은 phaseId를 가진 새 trip을 즉시 시작하면,
@@ -876,6 +944,36 @@ export function summarizeAlarmLogCounters(
 
 
 /**
+ * #1693 — fusion picker tier 채택 분포 집계 (최근 1h, DebugModal Telemetry row).
+ *
+ * 직전 1h의 'fusion-picker-tier' source 엔트리에서 reason(tier name) 별 count를 집계.
+ * DebugModal이 "Fusion Tier (1h)" row에 표시할 문자열로 포맷해 반환한다.
+ *
+ * 예: "tier-positionTrainBoardingLockMatch=3, tier-gpsFallback=12"
+ * 엔트리 없음 시 "(none)" 반환.
+ */
+export function formatFusionPickerTierDistribution(
+  entries: readonly AlarmLogEntry[],
+  nowMs: number = Date.now(),
+): string {
+  const ONE_HOUR_MS = 60 * 60 * 1_000;
+  const counts: Record<string, number> = {};
+  for (const e of entries) {
+    if (e.source !== 'fusion-picker-tier') continue;
+    if (e.outcome !== 'fired') continue;
+    if (nowMs - e.ts > ONE_HOUR_MS) continue;
+    const key = e.reason ?? '(unknown)';
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  const keys = Object.keys(counts);
+  if (keys.length === 0) return '(none)';
+  return keys
+    .sort((a, b) => (counts[b] as number) - (counts[a] as number))
+    .map((k) => `${k}=${counts[k]}`)
+    .join(', ');
+}
+
+/**
  * Silent push outcome별 집계 (#856).
  *
  * DebugModal Silent Push 섹션에서 "lastRecv 시간만 보고 왜 안 울리지?" 의문을 해소하기 위한
@@ -906,6 +1004,7 @@ const SILENT_PUSH_OUTCOME_SOURCES: Record<AlarmLogSource, keyof SilentPushOutcom
   'cross-trip-mirror-register': null,
   'cross-trip-mirror-mismatch': null,
   'cross-trip-mirror-launch': null,
+  'fusion-picker-tier': null,
 };
 
 export interface SilentPushOutcomeCounts {

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -873,6 +873,8 @@ export function summarizeAlarmLogCounters(
   return [...map.values()].sort((a, b) => b.count - a.count);
 }
 
+
+
 /**
  * Silent push outcome별 집계 (#856).
  *
@@ -1709,7 +1711,7 @@ export function countGateReasons(
 }
 
 /**
- * #1682 — suppressed reason별 집계 (시간 윈도우 필터링).
+ * #1682/#1692 — suppressed reason별 집계 (시간 윈도우 필터링, top-N 옵션).
  *
  * summarizeAlarmLogCounters에 시간 윈도우 필터를 추가한 래퍼.
  * windowMs 이내 suppressed 엔트리만 집계해 반환. read-only, write 부담 0.
@@ -1719,15 +1721,18 @@ export function countGateReasons(
  * @param entries  alarmLog 전체 또는 부분 스냅샷
  * @param windowMs 집계 윈도우 (ms). 0 이하이면 빈 배열 반환. Infinity이면 전체.
  * @param now      기준 시각 (ms epoch). 테스트 결정성용. 기본값 Date.now().
+ * @param topN     반환할 최대 reason 수. 미지정 시 전체 반환.
  */
 export function countAlarmLogReasonsByWindow(
   entries: readonly AlarmLogEntry[],
   windowMs: number,
   now: number = Date.now(),
+  topN?: number,
 ): AlarmLogReasonCounter[] {
   if (windowMs <= 0) return [];
   const windowed = entries.filter((e) => now - e.ts <= windowMs);
-  return summarizeAlarmLogCounters(windowed);
+  const result = summarizeAlarmLogCounters(windowed);
+  return topN !== undefined ? result.slice(0, topN) : result;
 }
 
 /**

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -1818,13 +1818,13 @@ export function countGateReasons(
  * count 내림차순 정렬 — 가장 빈번한 reason이 상단에 노출.
  *
  * @param entries  alarmLog 전체 또는 부분 스냅샷
- * @param windowMs 집계 윈도우 (ms). 0 이하이면 빈 배열 반환. Infinity이면 전체.
+ * @param windowMs 집계 윈도우 (ms). 기본값 1h. 0 이하이면 빈 배열 반환. Infinity이면 전체.
  * @param now      기준 시각 (ms epoch). 테스트 결정성용. 기본값 Date.now().
  * @param topN     반환할 최대 reason 수. 미지정 시 전체 반환.
  */
 export function countAlarmLogReasonsByWindow(
   entries: readonly AlarmLogEntry[],
-  windowMs: number,
+  windowMs: number = 60 * 60 * 1000,
   now: number = Date.now(),
   topN?: number,
 ): AlarmLogReasonCounter[] {

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -1400,6 +1400,40 @@ export function countBoardingPromptAutoLockOutcomes(
   return counts;
 }
 
+/**
+ * #1687 — 시간 윈도우 기반 autolock outcome 분포 집계.
+ *
+ * `countBoardingPromptAutoLockOutcomes`와 동일 로직에 windowMs 시간 필터를 추가.
+ * DebugModal Telemetry 섹션에서 "autoLock (1h)" 같은 최근 N분/시간 집계에 사용.
+ *
+ * @param entries  alarmLog 전체 엔트리 배열
+ * @param windowMs 집계 윈도우(ms). `now - windowMs` 이후 엔트리만 포함.
+ * @param now      현재 시각(epoch ms). 기본값 Date.now() — 테스트에서 고정값 주입 가능.
+ */
+export function countAutoLockReasonsByWindow(
+  entries: readonly AlarmLogEntry[],
+  windowMs: number,
+  now: number = Date.now(),
+): Record<BoardingPromptAutoLockReason, number> {
+  const cutoff = now - windowMs;
+  const counts: Record<BoardingPromptAutoLockReason, number> = {
+    'autolock-success': 0,
+    'autolock-no-trip': 0,
+    'autolock-arrivals-empty': 0,
+    'autolock-ambiguity': 0,
+    'autolock-station-lookup': 0,
+    'autolock-lock-failed': 0,
+  };
+  for (const entry of entries) {
+    if (entry.ts <= cutoff) continue;
+    if (entry.source !== 'boarding-prompt') continue;
+    const { reason } = entry;
+    if (reason === undefined) continue;
+    if (reason in counts) counts[reason as BoardingPromptAutoLockReason] += 1;
+  }
+  return counts;
+}
+
 /** #1170: boardingPrompt 사용자 응답 1건 적재. */
 export function logBoardingPromptResponded(input: {
   outcome: 'boarded' | 'dismissed';

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -792,6 +792,22 @@ function buildAlarmLogSection(args: BuildDumpArgs): string[] {
 }
 
 /**
+ * #1692 — Alarm Log Reasons (1h) 섹션.
+ *
+ * dump 시점 기준 최근 1시간 내 suppressed reason 집계 (count 내림차순 top-10).
+ * 사용자가 "어떤 게이트가 가장 자주 발동했는지"를 share dump 수신 즉시 파악 가능.
+ *
+ * nowMs 미전달 시 Date.now() 사용 — 테스트 결정적 출력 확보.
+ * 1h 윈도우 내 suppressed 항목이 없으면 (empty) 반환.
+ */
+function buildAlarmLogReasonsSummarySection(args: BuildDumpArgs): string[] {
+  const now = args.nowMs ?? Date.now();
+  const counters = countAlarmLogReasonsByWindow(args.logs, 60 * 60 * 1000, now);
+  if (counters.length === 0) return ['(empty)'];
+  return counters.map(({ reason, count }) => `${reason}: ${count}`);
+}
+
+/**
  * #1501 — Raw signal 섹션. 직전 30건(혹은 그 이하)을 최신순으로 직렬화. 빈 buffer는
  * (empty)로 명시 — "한 번도 push 안 됨"과 "load 안 함"을 구분(Fusion log와 동일 컨벤션).
  *
@@ -1208,6 +1224,9 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
     build: buildAlarmLogSection,
     suffix: (args) => ` (${args.logs.length})`,
   },
+  // #1692 — Alarm Log Reasons (1h): suppress reason 집계 요약. Alarm log 직후 배치해
+  // 사용자가 발사 실패 분포를 share dump에서 즉시 파악 가능.
+  { title: 'Alarm Log Reasons (1h)', build: buildAlarmLogReasonsSummarySection },
   // #1346 — fusion log를 share에 포함. 누락 시 sticky cascade 같은 회귀를 사후 재구성 불가.
   {
     title: 'Fusion log',

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -40,6 +40,7 @@ import {
   countGateReasons,
   countSilentPushKindBreakdown,
   countSilentPushOutcomes,
+  formatFusionPickerTierDistribution,
   getAlarmLog,
   summarizeAlarmLogByReason,
   summarizeAlarmLogBySource,
@@ -2111,6 +2112,17 @@ function DebugModalInner({
               </Text>
             </Section>
           ) : null}
+
+          {/* #1693 — fusion picker tier 채택 분포 (최근 1h). PR #1650/#1662/#1674 효과 검증. */}
+          <Section title="Fusion Tier (1h)" colors={colors}>
+            <Text
+              style={[typography.mono, { color: colors.ink }]}
+              selectable
+              testID="debug-fusion-picker-tier"
+            >
+              {formatFusionPickerTierDistribution(logs)}
+            </Text>
+          </Section>
 
           {/* #1021: boardingPrompt 발사 빈도 카운터 */}
           <Section title="Boarding Prompt" colors={colors}>

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -35,6 +35,7 @@ import {
   BOARDING_PROMPT_WINDOWS,
   clearAlarmLog,
   countAlarmLogReasonsByWindow,
+  countAutoLockReasonsByWindow,
   countBoardingPromptByWindow,
   countGateReasons,
   countSilentPushKindBreakdown,
@@ -2102,6 +2103,8 @@ function DebugModalInner({
                 colors={colors}
               />
             ))}
+            {/* #1687 — autoLock outcome 분포 (1h 윈도우). success rate baseline 측정. */}
+            <AutoLockTelemetryRow logs={logs} colors={colors} />
           </Section>
 
           {/* #1170: boarding-prompt acceptance dashboard (gate 통과율/응답률) */}
@@ -2439,6 +2442,44 @@ function CountersSection({
         ))
       )}
     </Section>
+  );
+}
+
+const AUTOLOCK_1H_MS = 60 * 60 * 1000;
+
+/**
+ * #1687 — autoLock outcome 분포 row (1h 윈도우).
+ *
+ * boardingPrompt 응답 → autoLock chain 성공률 baseline 측정 인프라.
+ * 표시: success / ambiguous(=ambiguity) / empty(=arrivals-empty) / failed(=lock-failed) 4개 카운트.
+ * 1시간 윈도우 고정 — 단기 측정에 적합. 0건이면 "—"로 표기.
+ */
+function AutoLockTelemetryRow({
+  logs,
+  colors,
+}: Readonly<{
+  logs: readonly AlarmLogEntry[];
+  colors: ReturnType<typeof useTheme>['colors'];
+}>) {
+  const counts = useMemo(() => countAutoLockReasonsByWindow(logs, AUTOLOCK_1H_MS), [logs]);
+  const total =
+    counts['autolock-success'] +
+    counts['autolock-ambiguity'] +
+    counts['autolock-arrivals-empty'] +
+    counts['autolock-no-trip'] +
+    counts['autolock-station-lookup'] +
+    counts['autolock-lock-failed'];
+  const value =
+    total === 0
+      ? '—'
+      : `ok=${counts['autolock-success']} amb=${counts['autolock-ambiguity']} empty=${counts['autolock-arrivals-empty']} fail=${counts['autolock-lock-failed']}`;
+  return (
+    <KeyValue
+      label="autoLock(1h)"
+      value={value}
+      colors={colors}
+      testID="debug-autolock-telemetry-1h"
+    />
   );
 }
 

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -681,7 +681,33 @@ describe('DebugModal', () => {
     expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
   });
 
-    it('unmount 시 AppState listener를 정리한다', async () => {
+  it('#1687: autoLock(1h) row — 엔트리 없을 때 "—" 표기', async () => {
+    mockGetAlarmLog.mockResolvedValue([]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByTestId('debug-autolock-telemetry-1h')).toBeTruthy();
+    expect(screen.getByTestId('debug-autolock-telemetry-1h').props.children).toBe('—');
+  });
+
+  it('#1687: autoLock(1h) row — success/ambiguous/empty/failed 분포 표기', async () => {
+    const now = Date.now();
+    mockGetAlarmLog.mockResolvedValue([
+      { ts: now - 1_000, source: 'boarding-prompt', outcome: 'fired', reason: 'autolock-success' },
+      { ts: now - 2_000, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-ambiguity' },
+      { ts: now - 3_000, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-arrivals-empty' },
+      { ts: now - 4_000, source: 'boarding-prompt', outcome: 'suppressed', reason: 'autolock-lock-failed' },
+    ]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    const el = screen.getByTestId('debug-autolock-telemetry-1h');
+    expect(el).toBeTruthy();
+    expect(el.props.children).toContain('ok=1');
+    expect(el.props.children).toContain('amb=1');
+    expect(el.props.children).toContain('empty=1');
+    expect(el.props.children).toContain('fail=1');
+  });
+
+  it('unmount 시 AppState listener를 정리한다', async () => {
     const { unmount } = renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
     unmount();

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -707,6 +707,30 @@ describe('DebugModal', () => {
     expect(el.props.children).toContain('fail=1');
   });
 
+  it('#1693: Fusion Tier (1h) 섹션이 tier 분포를 표시한다', async () => {
+    const now = Date.now();
+    mockGetAlarmLog.mockResolvedValue([
+      { ts: now - 100, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' },
+      { ts: now - 200, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' },
+      { ts: now - 300, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-backendSsotAccepts' },
+    ]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('Fusion Tier (1h)')).toBeTruthy();
+    const tierEl = screen.getByTestId('debug-fusion-picker-tier');
+    expect(tierEl.props.children).toContain('tier-gpsFallback=2');
+    expect(tierEl.props.children).toContain('tier-backendSsotAccepts=1');
+  });
+
+  it('#1693: Fusion Tier (1h) 섹션 — fusion-picker-tier 없으면 (none) 표시', async () => {
+    mockGetAlarmLog.mockResolvedValue([]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('Fusion Tier (1h)')).toBeTruthy();
+    const tierEl = screen.getByTestId('debug-fusion-picker-tier');
+    expect(tierEl.props.children).toBe('(none)');
+  });
+
   it('unmount 시 AppState listener를 정리한다', async () => {
     const { unmount } = renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -1016,6 +1016,31 @@ describe('DebugModal helpers', () => {
     expect(dump).not.toContain('sources:');
   });
 
+  it('buildDumpText: Alarm Log Reasons (1h) 섹션이 suppressed reason 집계를 포함한다 (#1692)', () => {
+    const now = 1_700_000_000_000;
+    const logs: AlarmLogEntry[] = [
+      { ts: now - 1000, source: 'fg', outcome: 'suppressed', reason: 'movement-static-speed' },
+      { ts: now - 2000, source: 'fg', outcome: 'suppressed', reason: 'movement-static-speed' },
+      { ts: now - 3000, source: 'bg', outcome: 'suppressed', reason: 'gate-age' },
+    ];
+    const dump = __test__.buildDumpText(makeDumpArgs({ logs, nowMs: now }));
+    expect(dump).toContain('## Alarm Log Reasons (1h)');
+    expect(dump).toContain('movement-static-speed: 2');
+    expect(dump).toContain('gate-age: 1');
+  });
+
+  it('buildDumpText: Alarm Log Reasons (1h) suppressed가 없으면 (empty)를 표기한다 (#1692)', () => {
+    const now = 1_700_000_000_000;
+    const logs: AlarmLogEntry[] = [
+      { ts: now - 1000, source: 'fg', outcome: 'fired', stationName: '강남' },
+    ];
+    const dump = __test__.buildDumpText(makeDumpArgs({ logs, nowMs: now }));
+    expect(dump).toContain('## Alarm Log Reasons (1h)');
+    // fired 항목만 있으면 (empty) 출력
+    const section = dump.slice(dump.indexOf('## Alarm Log Reasons (1h)'));
+    expect(section).toContain('(empty)');
+  });
+
   it('formatLogLine: location 없는 fired 엔트리는 acc/age를 포함하지 않는다', () => {
     const line = __test__.formatLogLine({
       ts: Date.now(),

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -33,6 +33,7 @@ import { trackTrainProgress } from '../../route/utils/trackTrainProgress';
 import { estimateArcStationsFromRoute } from '../../route/utils/arcEstimation';
 import {
   logFusionCandidateDistanceReject,
+  logFusionPickerTier,
   logSuppressedLocklessForwardOnly,
 } from '../../alarm/utils/alarmLog';
 import { haversine } from '../../../shared/utils/haversine';
@@ -1078,6 +1079,31 @@ export function useFusedNearestStation(
     result = gps.liveResult;
     confidence = 'gps-only';
     source = 'gps';
+  }
+
+  // #1693 — cascade picker가 채택한 tier를 alarmLog에 적재 (측정 보강 3차).
+  // dedup 1s — 같은 tier 연속 폴링 cycle에서 1건만 적재.
+  // PR #1650/#1662/#1674 효과(지하 positionTrain/GPS-derived/arvlCd tier 채택률) 검증.
+  if (positionTrainBoardingLockMatch) {
+    logFusionPickerTier('positionTrainBoardingLockMatch');
+  } else if (gpsDerivedFastPath) {
+    logFusionPickerTier('gpsDerivedFastPath');
+  } else if (arvlCdArrivedMatch) {
+    logFusionPickerTier('arvlCdArrivedMatch');
+  } else if (backendSsotAccepts) {
+    logFusionPickerTier('backendSsotAccepts');
+  } else if (wifiStationResolved) {
+    logFusionPickerTier('wifiStationResolved');
+  } else if (positionTrainResult) {
+    logFusionPickerTier('positionTrain');
+  } else if (fused && fusedPasses) {
+    logFusionPickerTier('fused');
+  } else if (detectionVerdictAccepts) {
+    logFusionPickerTier('detectionVerdictAccepts');
+  } else if (routeResult && routePasses) {
+    logFusionPickerTier('routeResult');
+  } else {
+    logFusionPickerTier('gpsFallback');
   }
 
   // #1418 — Tier 1 SSOT 합의 판정 + 환경 추정.


### PR DESCRIPTION
## 개요

측정 baseline 3 PR 통합 — cascade 충돌 회피.

- PR #1691 (`fix/#1687-autolock-counter-aggregation`): autoLock counter aggregation — success rate baseline 측정 보강
- PR #1694 (`fix/#1692-trip-dump-alarm-log-reasons`): trip dump 자동 alarmLog reason aggregate (1h) 포함
- PR #1695 (`fix/#1693-fusion-picker-tier-distribution`): fusion picker tier 채택 분포 측정

Closes #1687, Closes #1692, Closes #1693

기존 PR #1691/#1694/#1695는 이 PR 머지 후 close 예정.

---

## Wire-completion 5단 체크

1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard** — 신규 3개 row가 DebugModal Telemetry 섹션에 표시됨:
   - `autoLock (1h)`: `debug-autolock-telemetry-1h` testId
   - `Alarm Log Reasons (1h)`: trip dump share 텍스트에 포함
   - `Fusion Tier (1h)`: `debug-fusion-picker-tier` testId
3. **의존 PR** — N/A (device-only 변경, backend 의존 없음)
4. **측정 plan** — DebugModal share dump 텍스트 + DebugModal testId 시각 확인. 1주 trip 후 각 섹션 비어있지 않은지 확인.
5. **Device verify** — N/A — type+unit only

## 충돌 해결 내역

`countAlarmLogReasonsByWindow` 함수 중복:
- dev (#1682): 3-param `(entries, windowMs, now)`, `windowMs ≤ 0` 가드, `Infinity` 지원
- PR #1694 (#1692): 4-param `(entries, windowMs=1h, now, topN=10)`, 내부 Map 직접 구현

→ 두 시그니처를 단일 함수로 통합:
```typescript
export function countAlarmLogReasonsByWindow(
  entries, windowMs = 60*60*1000, now = Date.now(), topN?: number
): AlarmLogReasonCounter[]
```
- `windowMs ≤ 0` 가드 유지 (dev #1682 dev tests 호환)
- `topN` optional (PR #1694 4th-arg 호환)
- `summarizeAlarmLogCounters` delegation 유지 (clean wrapper 패턴)