### PR TITLE
fix(#1698): 2호선 본선 closed loop wraparound 처리

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     ],
     "modulePathIgnorePatterns": [
       "<rootDir>/backend/",
-      "<rootDir>/.claude/worktrees/"
+      "<rootDir>/.claude/worktrees/",
+      "<rootDir>/.worktrees/"
     ]
   },
   "dependencies": {

--- a/src/features/route/utils/routeProgress.ts
+++ b/src/features/route/utils/routeProgress.ts
@@ -4,6 +4,7 @@ import {
   getStationsOnLine,
   type Route,
 } from '../../../shared/utils/stationRoute';
+import { shortestLinePathIndices } from '../../../shared/utils/lineLoopPath';
 import type { Station } from '../../../shared/types/station';
 import { MAX_INTER_STATION_M } from '../../../shared/constants/routeProgress';
 
@@ -56,9 +57,9 @@ function stationsBetween(
   const fromIdx = lineStations.findIndex((s) => s.id === fromId);
   const toIdx = lineStations.findIndex((s) => s.id === toId);
   if (fromIdx === -1 || toIdx === -1) return null;
-  if (fromIdx === toIdx) return [lineStations[fromIdx]];
-  if (fromIdx < toIdx) return lineStations.slice(fromIdx, toIdx + 1);
-  return lineStations.slice(toIdx, fromIdx + 1).reverse();
+  // #1698 — 2호선 본선 closed loop은 shortestLinePathIndices가 짧은 쪽 path 반환.
+  const path = shortestLinePathIndices(lineStations, fromIdx, toIdx, line);
+  return path.map((i) => lineStations[i]);
 }
 
 function appendSegment(stations: Station[], segment: Station[]): void {

--- a/src/shared/utils/__tests__/lineLoopPath.test.ts
+++ b/src/shared/utils/__tests__/lineLoopPath.test.ts
@@ -1,0 +1,138 @@
+import { isClosedLoopMainStation, shortestLinePathIndices } from '../lineLoopPath';
+import { getStationsOnLine } from '../stationRoute';
+import type { LineNumber } from '../../types/station';
+
+describe('isClosedLoopMainStation', () => {
+  it.each<[LineNumber, string, boolean]>([
+    ['2', '2-001', true], // 시청 (본선 시작)
+    ['2', '2-009', true], // 한양대
+    ['2', '2-043', true], // 충정로 (본선 끝)
+    ['2', '2-105', false], // 까치산 (지선)
+    ['2', '2-205', false], // 신설동 (지선)
+    ['1', '1-001', false], // 1호선 직선
+    ['6', '6-013', false], // 6호선 (closed loop 아님)
+    ['7', '7-015', false], // 7호선 (closed loop 아님)
+  ])('line=%s id=%s → %s', (line, id, expected) => {
+    expect(isClosedLoopMainStation(line, id)).toBe(expected);
+  });
+});
+
+describe('shortestLinePathIndices', () => {
+  describe('2호선 본선 closed loop (이슈 #1698)', () => {
+    const line2 = getStationsOnLine('2');
+    const idxOf = (id: string) => line2.findIndex((s) => s.id === id);
+
+    it('성수(2-011) → 합정(2-038): 내선 16 hop wraparound 선택 (사용자 trip evidence)', () => {
+      const from = idxOf('2-011');
+      const to = idxOf('2-038');
+      const path = shortestLinePathIndices(line2, from, to, '2');
+      // 내선 짧은 쪽: 성수 → 뚝섬(2-010) → 한양대(2-009) → ... → 합정
+      // hop 수 = 16 (path 길이 = 17)
+      expect(path.length).toBe(17);
+      expect(line2[path[0]].id).toBe('2-011'); // 성수
+      expect(line2[path[1]].id).toBe('2-010'); // 뚝섬
+      expect(line2[path[2]].id).toBe('2-009'); // 한양대
+      expect(line2[path[path.length - 1]].id).toBe('2-038'); // 합정
+    });
+
+    it('시청(2-001) → 홍대입구(2-039): wraparound 4 hop', () => {
+      const from = idxOf('2-001');
+      const to = idxOf('2-039');
+      const path = shortestLinePathIndices(line2, from, to, '2');
+      // 시청 → 충정로(2-043) → 아현(2-042) → 이대(2-041) → ... → 홍대입구(2-039)
+      // hop 수 = 5 (시청→충정로→아현→이대→신촌→홍대입구)
+      expect(path.length).toBe(6);
+      expect(line2[path[0]].id).toBe('2-001');
+      expect(line2[path[1]].id).toBe('2-043'); // 충정로 (wraparound)
+      expect(line2[path[path.length - 1]].id).toBe('2-039');
+    });
+
+    it('한양대(2-009) → 사당(2-026): 17 hop 정방향 (wraparound 짧지 않음)', () => {
+      const from = idxOf('2-009');
+      const to = idxOf('2-026');
+      const path = shortestLinePathIndices(line2, from, to, '2');
+      // 정방향 17 hop, wraparound 26 hop → 정방향 선택
+      expect(path.length).toBe(18);
+      expect(line2[path[1]].id).toBe('2-010');
+    });
+
+    it('합정(2-038) → 성수(2-011): 16 hop wraparound 역방향', () => {
+      const from = idxOf('2-038');
+      const to = idxOf('2-011');
+      const path = shortestLinePathIndices(line2, from, to, '2');
+      expect(path.length).toBe(17);
+      expect(line2[path[0]].id).toBe('2-038');
+      expect(line2[path[path.length - 1]].id).toBe('2-011');
+    });
+
+    it('정방향 hop == wraparound hop이면 정방향 선택 (안정성)', () => {
+      // 본선 43 stations이라 21~22 hop이 경계. 시청(idx 0) → idx 21(서초) 비교
+      const from = 0;
+      const toForwardSubHops = 21;
+      const toIdx = idxOf(line2.filter((s, i) => isClosedLoopMainStation('2', s.id))[toForwardSubHops].id);
+      const path = shortestLinePathIndices(line2, from, toIdx, '2');
+      // 21 vs 22 → 21 정방향 선택
+      expect(path.length).toBe(22);
+      expect(path[0]).toBe(from);
+      expect(path[1]).toBeGreaterThan(path[0]); // 정방향 idx 증가
+    });
+
+    it('같은 idx면 [idx]', () => {
+      expect(shortestLinePathIndices(line2, 5, 5, '2')).toEqual([5]);
+    });
+  });
+
+  describe('2호선 지선 (wraparound 적용 X)', () => {
+    const line2 = getStationsOnLine('2');
+
+    it('까치산(2-105) → 시청(2-001): 정방향 slice (지선은 본선 closed loop 영향 X)', () => {
+      const from = line2.findIndex((s) => s.id === '2-105');
+      const to = line2.findIndex((s) => s.id === '2-001');
+      const path = shortestLinePathIndices(line2, from, to, '2');
+      // wraparound 적용 X (까치산은 본선 range 밖) → 정방향 walk
+      expect(line2[path[0]].id).toBe('2-105');
+      expect(line2[path[path.length - 1]].id).toBe('2-001');
+      // step -1 walk이므로 fromIdx > toIdx
+      expect(path[0]).toBeGreaterThan(path[path.length - 1]);
+    });
+
+    it('신설동(2-205) → 성수(2-011): 정방향 (지선)', () => {
+      const from = line2.findIndex((s) => s.id === '2-205');
+      const to = line2.findIndex((s) => s.id === '2-011');
+      const path = shortestLinePathIndices(line2, from, to, '2');
+      expect(line2[path[0]].id).toBe('2-205');
+      expect(line2[path[path.length - 1]].id).toBe('2-011');
+    });
+  });
+
+  describe('다른 line (closed loop 아님)', () => {
+    it('1호선: 정방향 slice 그대로', () => {
+      const line1 = getStationsOnLine('1');
+      const from = 0;
+      const to = 5;
+      const path = shortestLinePathIndices(line1, from, to, '1');
+      expect(path).toEqual([0, 1, 2, 3, 4, 5]);
+    });
+
+    it('6호선 합정(6-013) → 공덕(6-017): 정방향 4 hop', () => {
+      const line6 = getStationsOnLine('6');
+      const from = line6.findIndex((s) => s.id === '6-013');
+      const to = line6.findIndex((s) => s.id === '6-017');
+      const path = shortestLinePathIndices(line6, from, to, '6');
+      expect(path.length).toBe(5);
+      expect(line6[path[0]].id).toBe('6-013');
+      expect(line6[path[path.length - 1]].id).toBe('6-017');
+    });
+
+    it('7호선 역방향: step -1 정방향', () => {
+      const line7 = getStationsOnLine('7');
+      const from = 10;
+      const to = 3;
+      const path = shortestLinePathIndices(line7, from, to, '7');
+      expect(path[0]).toBe(10);
+      expect(path[path.length - 1]).toBe(3);
+      // 역방향 단순 walk
+      expect(path.length).toBe(8);
+    });
+  });
+});

--- a/src/shared/utils/__tests__/stationRoute.test.ts
+++ b/src/shared/utils/__tests__/stationRoute.test.ts
@@ -60,6 +60,16 @@ describe('getRemainingStops', () => {
     expect(getRemainingStops('1-001', 'unknown-id')).toBeNull();
     expect(getRemainingStops('unknown-id', '1-001')).toBeNull();
   });
+
+  // #1698 — 2호선 본선 closed loop wraparound 정합 (사용자 trip evidence)
+  it.each<[string, string, number, string]>([
+    ['2-011', '2-038', 16, '성수→합정 내선 16 hop (사용자 6/23 trip)'],
+    ['2-038', '2-011', 16, '합정→성수 내선 16 hop 역방향'],
+    ['2-001', '2-039', 5, '시청→홍대입구 wraparound 5 hop'],
+    ['2-009', '2-026', 17, '한양대→사당 정방향 17 hop (wraparound 짧지 않음)'],
+  ])('getRemainingStops(%s, %s) === %i — %s', (from, to, expected) => {
+    expect(getRemainingStops(from, to)).toBe(expected);
+  });
 });
 
 describe('findRoute', () => {
@@ -84,6 +94,34 @@ describe('findRoute', () => {
     if (route?.type === 'direct') {
       expect(route.stops).toBe(0);
     }
+  });
+
+  // #1698 — 2호선 본선 closed loop wraparound
+  it('2호선 성수→합정 DirectRoute는 wraparound 16 stops를 반환한다 (사용자 trip)', () => {
+    const route = findRoute('2-011', '2-038');
+    expect(route?.type).toBe('direct');
+    if (route?.type === 'direct') {
+      expect(route.stops).toBe(16);
+    }
+  });
+
+  it('2호선 시청→홍대입구 DirectRoute는 wraparound 5 stops', () => {
+    const route = findRoute('2-001', '2-039');
+    expect(route?.type).toBe('direct');
+    if (route?.type === 'direct') {
+      expect(route.stops).toBe(5);
+    }
+  });
+
+  // #1698 — 2호선 본선 closed loop awareness: getNextStationName이 외선/내선 짧은 쪽 다음 역
+  it.each<[string, string, string, string]>([
+    ['2-011', '2-038', '뚝섬', '성수→합정: 내선 다음 역 = 뚝섬 (사용자 trip)'],
+    ['2-038', '2-011', '홍대입구', '합정→성수: 내선 다음 역 = 홍대입구'],
+    ['2-001', '2-039', '충정로(경기대입구)', '시청→홍대입구: wraparound 다음 역 = 충정로'],
+    ['2-009', '2-026', '뚝섬', '한양대→사당: 정방향 다음 역 = 뚝섬 (wraparound 아님)'],
+  ])('getNextStationName(%s, %s) === %s — %s', (from, to, expected) => {
+    const route = findRoute(from, to);
+    expect(getNextStationName(from, to, route)).toBe(expected);
   });
 
   it('환승 가능한 다른 노선이면 TransferRoute를 반환한다', () => {

--- a/src/shared/utils/lineLoopPath.ts
+++ b/src/shared/utils/lineLoopPath.ts
@@ -1,0 +1,93 @@
+import type { LineNumber, Station } from '../types/station';
+
+/**
+ * Closed loop 본선의 id 범위 SSOT.
+ *
+ * 2호선 본선은 시청(2-001) ↔ 충정로(2-043)가 인접한 closed loop이지만
+ * `getLineStationsCached('2')`는 id 사전순으로 정렬되어 인접관계를 잃는다.
+ * 단순 `step ±1` walk만 사용하면 외선(잠실 우회) 27 hop을 강제 선택해
+ * 사용자 의도(내선 16 hop)와 정반대 방향이 산출된다 (이슈 #1698).
+ *
+ * 까치산 지선(2-105) / 신설동 지선(2-205)은 본선과 별도 경로이므로
+ * wraparound를 적용하지 않는다 (lastId 안에 포함되지 않으면 자동 제외).
+ *
+ * 새 closed loop 추가는 이 상수만 갱신한다.
+ */
+const CLOSED_LOOP_MAIN_ID_RANGES: Partial<Record<LineNumber, { firstId: string; lastId: string }>> = {
+  '2': { firstId: '2-001', lastId: '2-043' },
+};
+
+/**
+ * 주어진 line/id가 closed loop 본선 range에 속하는지.
+ * 지선/직선 line은 false.
+ */
+export function isClosedLoopMainStation(line: LineNumber, id: string): boolean {
+  const range = CLOSED_LOOP_MAIN_ID_RANGES[line];
+  if (!range) return false;
+  return id >= range.firstId && id <= range.lastId;
+}
+
+/**
+ * 같은 line 위 두 station idx 사이의 짧은 path indices.
+ *
+ * - Closed loop 본선(양 끝 모두 본선 range 안)이면 정방향 vs wraparound 짧은 쪽 선택.
+ * - 그 외(지선 포함 또는 직선 line)는 기존 단순 정방향 slice.
+ * - 두 방향 hop 수가 같으면 정방향 (안정성).
+ *
+ * @returns 진행 방향으로 정렬된 idx 배열 (양 끝 포함). `fromIdx === toIdx`면 `[fromIdx]`.
+ */
+export function shortestLinePathIndices(
+  lineStations: readonly Station[],
+  fromIdx: number,
+  toIdx: number,
+  line: LineNumber,
+): number[] {
+  if (fromIdx === toIdx) return [fromIdx];
+
+  const forwardIndices = buildForward(fromIdx, toIdx);
+
+  const fromId = lineStations[fromIdx]?.id;
+  const toId = lineStations[toIdx]?.id;
+  /* istanbul ignore next -- caller가 valid idx를 넘긴다는 invariant */
+  if (!fromId || !toId) return forwardIndices;
+  if (!isClosedLoopMainStation(line, fromId) || !isClosedLoopMainStation(line, toId)) {
+    return forwardIndices;
+  }
+
+  const mainLineIndices: number[] = [];
+  for (let i = 0; i < lineStations.length; i++) {
+    if (isClosedLoopMainStation(line, lineStations[i].id)) {
+      mainLineIndices.push(i);
+    }
+  }
+  const subFromPos = mainLineIndices.indexOf(fromIdx);
+  const subToPos = mainLineIndices.indexOf(toIdx);
+  /* istanbul ignore next -- 위 isClosedLoopMainStation 통과 시 본선 list에 포함 invariant */
+  if (subFromPos === -1 || subToPos === -1) return forwardIndices;
+
+  const subLen = mainLineIndices.length;
+  // 본선 subset 안에서 +1 (idx 증가) / -1 (idx 감소) 두 방향 hop 수 비교.
+  // 같으면 +1 방향 선택 (안정성).
+  const plusHops = (subToPos - subFromPos + subLen) % subLen;
+  const minusHops = subLen - plusHops;
+  const usePlusDirection = plusHops <= minusHops;
+  const totalHops = usePlusDirection ? plusHops : minusHops;
+  const directionSign = usePlusDirection ? 1 : -1;
+
+  const indices: number[] = [];
+  for (let step = 0; step <= totalHops; step++) {
+    const subPos = (subFromPos + directionSign * step + subLen) % subLen;
+    indices.push(mainLineIndices[subPos]);
+  }
+  return indices;
+}
+
+function buildForward(fromIdx: number, toIdx: number): number[] {
+  const step = fromIdx < toIdx ? 1 : -1;
+  const out: number[] = [];
+  for (let i = fromIdx; i !== toIdx; i += step) {
+    out.push(i);
+  }
+  out.push(toIdx);
+  return out;
+}

--- a/src/shared/utils/stationRoute.ts
+++ b/src/shared/utils/stationRoute.ts
@@ -11,6 +11,7 @@ import { normalizeStationName as baseNormalizeStationName } from './normalizeSta
 import { distanceMetersBetween, estimateEtaSeconds } from './stationEta';
 import { getTransferSeconds } from './transferTimes';
 import { getStopSecondsFromDistance } from './lineSpeeds';
+import { shortestLinePathIndices } from './lineLoopPath';
 
 const logger = createLogger('StationRoute');
 
@@ -58,19 +59,29 @@ export function getStopDistanceMeters(line: LineNumber, fromId: string, toId: st
 }
 
 // line 위 fromIdx → toIdx 구간을 한 hop씩 누적한 운행 시간(초). 환승 대기 미포함.
+// #1698 — 2호선 본선 closed loop은 shortestLinePathIndices가 짧은 쪽 path를 반환한다.
 function computeSegmentSeconds(
   line: LineNumber,
   fromIdx: number,
   toIdx: number,
   lineStations: Station[],
 ): number {
-  if (fromIdx === toIdx) return 0;
-  const step = fromIdx < toIdx ? 1 : -1;
+  const path = shortestLinePathIndices(lineStations, fromIdx, toIdx, line);
   let total = 0;
-  for (let i = fromIdx; i !== toIdx; i += step) {
-    total += getStopSeconds(line, lineStations[i].id, lineStations[i + step].id);
+  for (let i = 0; i < path.length - 1; i++) {
+    total += getStopSeconds(line, lineStations[path[i]].id, lineStations[path[i + 1]].id);
   }
   return total;
+}
+
+// #1698 — line 위 fromIdx → toIdx hop 수 (closed loop 짧은 쪽 awareness).
+function computeSegmentHops(
+  line: LineNumber,
+  fromIdx: number,
+  toIdx: number,
+  lineStations: Station[],
+): number {
+  return shortestLinePathIndices(lineStations, fromIdx, toIdx, line).length - 1;
 }
 
 // O(1) 룩업 테이블 (성능 최적화)
@@ -492,7 +503,10 @@ export function getRemainingStops(
   const currentIdx = lineStations.findIndex((s) => s.id === currentId);
   const destIdx = lineStations.findIndex((s) => s.id === destinationId);
 
-  return Math.abs(destIdx - currentIdx);
+  // #1698 — 2호선 본선 closed loop은 shortestLinePathIndices가 짧은 쪽 path 반환.
+  // trip 진행 중 매 update마다 호출되는 hot path이므로 wraparound도 정합 필수.
+  const path = shortestLinePathIndices(lineStations, currentIdx, destIdx, current.line);
+  return path.length - 1;
 }
 
 // 같은 노선 위 두 역 사이의 중간역 이름 배열을 진행 방향대로 반환.
@@ -513,12 +527,9 @@ export function getIntermediateStationNames(
   if (fromIdx === -1 || toIdx === -1) return null;
   if (fromIdx === toIdx) return [];
 
-  const step = fromIdx < toIdx ? 1 : -1;
-  const names: string[] = [];
-  for (let i = fromIdx + step; i !== toIdx; i += step) {
-    names.push(lineStations[i].name);
-  }
-  return names;
+  // #1698 — 2호선 본선 closed loop은 shortestLinePathIndices가 짧은 쪽 path 반환.
+  const path = shortestLinePathIndices(lineStations, fromIdx, toIdx, from.line);
+  return path.slice(1, -1).map((i) => lineStations[i].name);
 }
 
 function buildNameIndex(stations: Station[]): Map<string, number> {
@@ -560,9 +571,11 @@ export function findRoutes(currentId: string, destinationId: string): RouteCandi
     const lineStations = getLineStationsCached(current.line);
     const cIdx = lineStations.findIndex((s) => s.id === currentId);
     const dIdx = lineStations.findIndex((s) => s.id === destinationId);
+    // #1698 — 2호선 본선 closed loop은 wraparound 짧은 쪽 stops 산출.
+    const path = shortestLinePathIndices(lineStations, cIdx, dIdx, current.line);
     const direct: DirectRoute = {
       type: 'direct',
-      stops: Math.abs(dIdx - cIdx),
+      stops: path.length - 1,
       line: current.line,
       travelSeconds: computeSegmentSeconds(current.line, cIdx, dIdx, lineStations),
     };
@@ -587,8 +600,9 @@ export function findRoutes(currentId: string, destinationId: string): RouteCandi
     const transferDestIdx = lookupNameIdx(destNameIndex, candidate.name);
     if (transferDestIdx === undefined) continue;
 
-    const stopsToTransfer = Math.abs(i - currentIdx);
-    const stopsFromTransfer = Math.abs(transferDestIdx - destIdx);
+    // #1698 — 환승 leg도 closed loop 짧은 쪽 hop 수 사용 (stops/seconds 정합).
+    const stopsToTransfer = computeSegmentHops(current.line, currentIdx, i, currentLineStations);
+    const stopsFromTransfer = computeSegmentHops(destination.line, transferDestIdx, destIdx, destLineStations);
     const total = stopsToTransfer + stopsFromTransfer;
 
     if (total < bestSingleTotal) {
@@ -697,7 +711,8 @@ function findMultiTransferRoute(
       /* istanbul ignore next -- 환승 그래프가 같은 데이터에서 빌드되므로 undefined 불가 */
       if (t1CurrentIdx === undefined || t1MidIdx === undefined) continue;
 
-      const stopsToFirst = Math.abs(t1CurrentIdx - currentIdx);
+      // #1698 — 환승 leg hop 수도 closed loop awareness.
+      const stopsToFirst = computeSegmentHops(fromLine, currentIdx, t1CurrentIdx, currentLineStations);
 
       // 두 번째 환승: 중간노선 → 목적지노선
       for (const t2Name of transfer2Names) {
@@ -706,8 +721,8 @@ function findMultiTransferRoute(
         /* istanbul ignore next */
         if (t2MidIdx === undefined || t2DestIdx === undefined) continue;
 
-        const stopsToSecond = Math.abs(t2MidIdx - t1MidIdx);
-        const stopsAfter = Math.abs(destIdx - t2DestIdx);
+        const stopsToSecond = computeSegmentHops(midLine, t1MidIdx, t2MidIdx, midLineStations);
+        const stopsAfter = computeSegmentHops(toLine, t2DestIdx, destIdx, destLineStations);
         const total = stopsToFirst + stopsToSecond + stopsAfter;
 
         if (total < bestTotal) {
@@ -1136,12 +1151,13 @@ function getNextStationOnLine(
   if (currentIdx === undefined || targetIdx === undefined) return null;
   if (currentIdx === targetIdx) return null;
 
+  // #1698 — 2호선 본선 closed loop은 shortestLinePathIndices의 path[1]이 다음 역.
+  // 외선/내선 짧은 쪽 방향과 일치.
   const lineStations = getLineStationsCached(line);
-  const step = targetIdx > currentIdx ? 1 : -1;
-  const nextIdx = currentIdx + step;
-  /* istanbul ignore next -- 노선 데이터에서 boundary를 벗어나는 케이스는 발생 불가 */
-  if (nextIdx < 0 || nextIdx >= lineStations.length) return null;
-  return lineStations[nextIdx].name;
+  const path = shortestLinePathIndices(lineStations, currentIdx, targetIdx, line);
+  /* istanbul ignore next -- currentIdx !== targetIdx invariant → path.length >= 2 */
+  if (path.length < 2) return null;
+  return lineStations[path[1]].name;
 }
 
 export function getNextStationName(


### PR DESCRIPTION
## Summary

- 2호선 본선(시청 2-001 ↔ 충정로 2-043)이 closed loop인 것을 코드가 모르고 id sort + step ±1 단순 walk만 함 → 외선 우회 강제 (예: 성수→합정 27 hop, 실제 내선 16 hop).
- 공통 helper `shortestLinePathIndices` + `computeSegmentHops` 추가하여 본선 range에서만 정방향/wraparound 짧은 쪽 선택.
- 모든 hop/stops/path 산출 경로 적용 (direct/transfer/multi-transfer + getRemainingStops + getNextStationOnLine + stationsBetween + computeSegmentSeconds + getIntermediateStationNames).
- 까치산(2-105) / 신설동(2-205) 지선은 wraparound 적용 X. 다른 노선 영향 X.

## 변경 파일

| 파일 | 변경 |
|---|---|
| `src/shared/utils/lineLoopPath.ts` | 신규 — `isClosedLoopMainStation` + `shortestLinePathIndices` |
| `src/shared/utils/stationRoute.ts` | `computeSegmentSeconds`, `computeSegmentHops`(신규), `getIntermediateStationNames`, `findRoutes` direct/transfer/multi-transfer, `getRemainingStops`, `getNextStationOnLine` |
| `src/features/route/utils/routeProgress.ts` | `stationsBetween` |
| `src/shared/utils/__tests__/lineLoopPath.test.ts` | 신규 — 19 케이스 it.each (성수→합정 16 hop, 시청→홍대 4 hop, 한양대→사당 17 hop 정방향, 까치산/신설동 지선 wraparound X, 1/6/7호선 등 closed loop 아닌 line 영향 X) |
| `src/shared/utils/__tests__/stationRoute.test.ts` | `getRemainingStops` / `findRoute` / `getNextStationName` 2호선 wraparound 케이스 추가 |
| `package.json` | `modulePathIgnorePatterns`에 `<rootDir>/.worktrees/` 추가 (haste duplication 차단) |

## 사용자 evidence (2026-06-23 trip)

- 입력: 성수(2-011) → 합정(2-038), train 2267 (line 2)
- 사용자 실제 train: 성수 → 뚝섬 → 한양대 → 왕십리 → ... → 합정 = **내선 16 hop**
- 본 fix 적용 후: stops=16, getNextStationName=뚝섬, 외선 27 hop 산출 없음 (테스트 검증)

## Test plan

- [x] `npm test` — 7590 tests 통과, coverage 100% (lines/functions/branches/statements)
- [x] `npm run type-check` — pass
- [x] `npm run lint:orphan` — pass
- [x] 성수(2-011)→합정(2-038) 내선 16 hop 검증 (`getRemainingStops`/`findRoute`/`getNextStationName`)
- [x] 시청(2-001)→홍대입구(2-039) wraparound 5 hop
- [x] 한양대(2-009)→사당(2-026) 정방향 17 hop (wraparound 짧지 않음)
- [x] 까치산/신설동 지선 영향 없음
- [x] 다른 노선(1/3/4/5/6/7/8/9 등) regression 없음

### code-review

- reviewer agent 2회 호출 (loop):
  - 1차: P1-1 (`getRemainingStops`) + P1-2 (`findRoutes` 환승 stops) 지적 → fix
  - 2차: P1-3 (`getNextStationOnLine`) 지적 → fix
- P2/P3 권고는 follow-up issue로 분리 예정:
  - `pickCandidateTrains` candidate window wraparound (별도)
  - `CLOSED_LOOP_MAIN_ID_RANGES`를 `src/shared/constants/lineTopology.ts`로 이전
  - 6호선 응암루프 추가 검토

## Wire-completion 5단

1. **Orphan**: `lineLoopPath` 모든 export caller 존재. `npm run lint:orphan` pass.
2. **V/X dashboard**: 사용자 trip dump의 `Estimator State` row + Fusion log `fu=` station 이름. 사용자 trip 재현 시 한양대 → 왕십리 cascade 관측.
3. **의존 PR**: 없음.
4. **측정 plan**: 다음 2호선 본선 trip(성수↔합정 등) 실기기 dump에서 lockless-route-hop이 내선 방향 cascade + stops=16 확인.
5. **Device verify**: 실기기 검증 필수 — 사용자가 내선 trip 등록 후 알림 / 다음 역 표시 정상 확인.

## 비-포함 (별도 sub-issue)

- backend `inferWaypointsFromOriginAndDestination` Dijkstra graph fix
- SSoT `currentStationId` 한글 stationName 정정 (cross-line confusion)
- 측정 baseline `/admin/alarm-log-stats` forward gap (PR #1684/#1690 wire-up)
- 2차 trip 회귀 4건 (backend train code / BG queue / 6호선 하행 정보 / mislabel)
- 6호선 응암루프 closed loop awareness

Closes #1698