### PR TITLE
fix(#1701): SSoT stale mirror 누수 차단 — deleteSsot cleanup site 추가

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -684,6 +684,56 @@ describe('POST /trips (#578 — preserve advance progress on re-register)', () =
     expect(finalTrip.waypoints[0].stationName).toBe('중곡');
   });
 
+  // #1701 — 새 세션 분기에서 SSoT mirror가 강제 reset되어야 cross-trip stale mirror가 누수되지 않는다.
+  // evidence: device가 옛 trip stationName(7-018 어린이대공원)을 picker 입력으로 받아 잘못된 알림 발사.
+  it('deletes stale SSoT row on new session (different createdAt) (#1701)', async () => {
+    const { seedSsot, readSsot } = await import('../tripPositionSsot');
+    const env = makeKvEnv();
+    await post('/trips', tripBody(), env);
+    // 옛 trip의 SSoT mirror 시뮬레이션 — 다른 line의 station name이 남은 상태.
+    await seedSsot(env.TRIPS, 'tok-578', '어린이대공원(세종대)');
+    expect(await readSsot(env.TRIPS, 'tok-578')).not.toBeNull();
+    // 새 세션(다른 createdAt) 등록.
+    await post('/trips', tripBody({ createdAt: CREATED + 10_000 }), env);
+    // SSoT는 즉시 reset → 후속 lazy-seed가 새 waypoint.stationName으로 정착할 수 있다.
+    expect(await readSsot(env.TRIPS, 'tok-578')).toBeNull();
+  });
+
+  it('preserves SSoT row on same-session re-register (no reset) (#1701)', async () => {
+    // 회귀 가드 — 같은 세션 재등록에서는 SSoT가 유지돼야 한다 (advance 진행분 보존 정신과 정합).
+    const { seedSsot, readSsot } = await import('../tripPositionSsot');
+    const env = makeKvEnv();
+    await post('/trips', tripBody(), env);
+    await seedSsot(env.TRIPS, 'tok-578', '중곡');
+    // 같은 createdAt으로 재POST (same session).
+    await post('/trips', tripBody(), env);
+    const ssot = await readSsot(env.TRIPS, 'tok-578');
+    expect(ssot).not.toBeNull();
+    expect(ssot?.currentStationId).toBe('중곡');
+  });
+
+  it('logs but does not throw when SSoT delete fails on new session (#1701)', async () => {
+    // 회귀 가드 — SSoT delete 실패가 trip 등록을 차단하지 않는다 (graceful).
+    const { seedSsot } = await import('../tripPositionSsot');
+    const env = makeKvEnv();
+    await post('/trips', tripBody(), env);
+    await seedSsot(env.TRIPS, 'tok-578', '어린이대공원(세종대)');
+    // KV.delete가 ssot:* 키에서 throw하도록 patch.
+    const originalDelete = env.TRIPS.delete.bind(env.TRIPS);
+    env.TRIPS.delete = vi.fn(async (key: string) => {
+      if (key.startsWith('ssot:')) throw new Error('ssot kv down');
+      return originalDelete(key);
+    }) as unknown as typeof env.TRIPS.delete;
+    const logSpy = vi.spyOn(console, 'log');
+    const res = await post('/trips', tripBody({ createdAt: CREATED + 10_000 }), env);
+    expect(res.status).toBe(200);
+    const failureLog = logSpy.mock.calls
+      .map((c) => String(c[0]))
+      .find((s) => s.includes('ssot delete on new session failed'));
+    expect(failureLog).toBeDefined();
+    logSpy.mockRestore();
+  });
+
   it('preserves existing apnsEnv when incoming omits it', async () => {
     const env = makeKvEnv();
     await post('/trips', tripBody({ apnsEnv: 'production' }), env);

--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -11,6 +11,7 @@ import {
   type LiveActivityDeps,
   type LiveActivityStats,
 } from '../liveActivity';
+import { readSsot, seedSsot } from '../tripPositionSsot';
 import type { ApnsEnv, Env, Trip, TripEndedReason, Waypoint } from '../types';
 import { InMemoryKV } from './inMemoryKv';
 
@@ -783,6 +784,92 @@ describe('cleanupTripWithLa', () => {
         'expired',
       );
       expect(logs).toContain('trip-status write failed');
+    });
+  });
+
+  // #1701 — SSoT mirror row(`ssot:<token>`) cleanup. 모든 종료 경로(cleanupTripWithLa 호출자)가
+  // SSoT를 함께 정리해 같은 token으로 새 trip 등록 시 lazy-seed가 빈 stationName으로 정착하도록.
+  // evidence: device가 옛 trip stationName(7-018 어린이대공원, 6-038 봉화산)을 stale mirror로 받아
+  // 잘못된 알림 발사. fix는 deleteTrip 직후 deleteSsot도 함께 호출하는 것.
+  describe('SSoT mirror cleanup (#1701)', () => {
+    const reasonMatrix: TripEndedReason[] = [
+      'destination-arrived',
+      'expired',
+      'eta-missing',
+      'seoul-outage',
+      'push-unrecoverable',
+    ];
+
+    for (const reason of reasonMatrix) {
+      it(`removes SSoT row when cleanup called with reason ${reason}`, async () => {
+        const kv = new InMemoryKV();
+        const trip = makeTrip({ activityPushToken: undefined });
+        await kv.put('trip:devtoken', JSON.stringify(trip));
+        // SSoT row 사전 seed — 옛 trip의 stationName이 mirror로 남은 상태.
+        await seedSsot(kv as unknown as KVNamespace, 'devtoken', '봉화산(서울의료원)');
+        expect(await readSsot(kv as unknown as KVNamespace, 'devtoken')).not.toBeNull();
+        const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+        await cleanupTripWithLa(
+          trip,
+          env,
+          makeDeps(vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch),
+          makeStats(),
+          NOW,
+          () => undefined,
+          reason,
+        );
+        // trip + SSoT 모두 KV에서 제거됨.
+        expect(await kv.get('trip:devtoken')).toBeNull();
+        expect(await readSsot(kv as unknown as KVNamespace, 'devtoken')).toBeNull();
+      });
+    }
+
+    it('removes SSoT row even when reason is omitted (HTTP DELETE /trips/:token path)', async () => {
+      // HTTP DELETE 경로는 reason 없이 cleanupTripWithLa를 호출 — SSoT는 동등하게 정리돼야 한다.
+      const kv = new InMemoryKV();
+      const trip = makeTrip({ activityPushToken: undefined });
+      await kv.put('trip:devtoken', JSON.stringify(trip));
+      await seedSsot(kv as unknown as KVNamespace, 'devtoken', '용마산');
+      const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+      await cleanupTripWithLa(
+        trip,
+        env,
+        makeDeps(vi.fn() as unknown as typeof fetch),
+        makeStats(),
+        NOW,
+        () => undefined,
+      );
+      expect(await readSsot(kv as unknown as KVNamespace, 'devtoken')).toBeNull();
+    });
+
+    it('logs but does not throw when SSoT delete fails (cleanup continues)', async () => {
+      // KV.delete가 ssot:* 키에서 throw하는 broken 환경. cleanup 흐름은 끝까지 진행돼야 한다.
+      const kv = new InMemoryKV();
+      const trip = makeTrip({ activityPushToken: undefined });
+      await kv.put('trip:devtoken', JSON.stringify(trip));
+      const brokenKv = {
+        get: kv.get.bind(kv),
+        put: kv.put.bind(kv),
+        delete: vi.fn(async (key: string) => {
+          if (key.startsWith('ssot:')) throw new Error('ssot kv down');
+          return kv.delete(key);
+        }),
+        list: kv.list.bind(kv),
+      };
+      const env = { TRIPS: brokenKv as unknown as KVNamespace } as Env;
+      const logs: string[] = [];
+      await cleanupTripWithLa(
+        trip,
+        env,
+        makeDeps(vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch),
+        makeStats(),
+        NOW,
+        (msg) => logs.push(msg),
+        'expired',
+      );
+      // ssot delete 실패 로그가 남고, trip 정리는 정상 완료.
+      expect(logs).toContain('ssot delete failed');
+      expect(await kv.get('trip:devtoken')).toBeNull();
     });
   });
 });

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -92,7 +92,7 @@ import {
   writeRegressionDataPoints,
 } from './regressionTelemetry';
 import { CRON_READ_CACHE_TTL_SEC, KV_MIN_CACHE_TTL_SEC } from './kvConsistency';
-import { readSsot } from './tripPositionSsot';
+import { deleteSsot, readSsot } from './tripPositionSsot';
 import { getTrip, putTrip } from './trips';
 import { inferWaypointsFromOriginAndDestination } from './dijkstraRoute';
 import { checkTripRegisterRateLimit } from './tripRegisterRateLimit';
@@ -684,6 +684,27 @@ app.post('/trips', async (c) => {
     : baseTrip;
 
   await putTrip(c.env.TRIPS, trip);
+
+  // #1701 — 새 세션 분기에서는 SSoT mirror도 강제 cleanup. cleanupTripWithLa가 이미 4 종료
+  // 경로에서 deleteSsot를 호출하지만, 종료 후 KV TTL 자연 만료를 기다리는 동안 같은 token으로
+  // 새 trip이 등록되거나, cleanup 호출 자체가 race로 누락된 경우(예: trip TTL 만료 → cron이
+  // 그냥 skip → trip + SSoT 둘 다 KV에 남음 → 새 POST /trips가 SSoT 살아있는 상태에서 등록)에
+  // 옛 stationName이 device로 forward되는 회귀가 발생한다. 새 세션 판정 시 SSoT 즉시 reset해
+  // 후속 lazy-seed가 새 waypoint.stationName으로 정착되도록 강제한다.
+  // KV delete 실패 graceful — putTrip 성공이 우선이며 trip 등록을 차단하지 않는다.
+  if (!isSameSession) {
+    try {
+      await deleteSsot(c.env.TRIPS, incoming.token);
+    } catch (e) {
+      console.log(
+        JSON.stringify({
+          msg: 'ssot delete on new session failed (#1701)',
+          tokenPrefix: tokenPrefix(incoming.token),
+          error: String(e),
+        }),
+      );
+    }
+  }
 
   // P0-1 (#1577) — Site 6 of 6: trip-mutation 적재 (V8b /trips rate 검증).
   writeMetric(c.env, {

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -22,6 +22,7 @@ import { pickApnsHost, sendWithEnvHeal } from './apnsHost';
 import { LINE_META } from './lineAlias';
 import { deleteProgress } from './progress';
 import { computeMultiHopContext } from './tripMultiHop';
+import { deleteSsot } from './tripPositionSsot';
 import { deleteTrip } from './trips';
 import type { ApnsEnv, Env, Trip, TripEndedReason, Waypoint } from './types';
 import { writeTripEndedStatus } from './tripStatus';
@@ -282,6 +283,20 @@ export async function cleanupTripWithLa(
   // #705 — trip을 폐기할 때 progress entry도 함께 제거. TTL이 자연 만료를 보장하지만
   // 즉시 cleanup해야 새 동일 token trip 등록 시 stale shiftedCount가 끼지 않는다.
   await deleteProgress(env.TRIPS, trip.token);
+  // #1701 — SSoT mirror row(`ssot:<token>`)도 함께 제거. trip TTL(최대 9h+)이 자연 만료를
+  // 보장하지만, 같은 token 새 trip 등록 시 lazy-seed가 `ssot === null` 조건이라 옛 SSoT가
+  // 살아있으면 새 trip의 stationName이 아닌 옛 trip stationName이 그대로 device로 forward되어
+  // cross-trip stale mirror 누수 (evidence: 7-018 어린이대공원, 6-038 봉화산). 즉시 cleanup해
+  // 새 trip seed가 비어있는 stationName으로 정착되도록 강제한다.
+  // KV write 실패 graceful — alert push와 마찬가지로 best-effort. cleanup 흐름 차단 X.
+  try {
+    await deleteSsot(env.TRIPS, trip.token);
+  } catch (e) {
+    log('ssot delete failed', {
+      token: trip.token.slice(0, 8),
+      error: String(e),
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #1701

## 문제

`cleanupTripWithLa` (liveActivity.ts:281)가 `deleteTrip` 직후 **`deleteSsot` 미호출**. SSoT KV row(`ssot:<token>`)가 trip TTL 만료까지(최대 9h+) 잔존 → 새 trip 등록 시 stale mirror가 device로 forward.

`POST /trips` (index.ts:587-696)도 새 trip 등록 시 `deleteSsot` 호출 없음. lazy-seed가 `ssot === null` 조건이라 기존 SSoT 살아있으면 새 trip의 stationName이 아닌 옛 trip stationName 그대로 보존.

### evidence (이슈 #1701)

- `Backend SSoT.currentStationId="어린이대공원(세종대)"` (7-018) — 2호선 trip인데 7호선 station name이 SSoT에 잡힘 = cross-trip stale mirror
- `currentStationId="봉화산(서울의료원)"` (6-038) — 외선 우회 cascade 후 device cascade picker가 다음 hop 신내(6-039) 추정 → "신내역 도착" 잘못된 알림

## Fix

| 변경 site | 동작 |
| --- | --- |
| `liveActivity.ts:281 cleanupTripWithLa` | `deleteTrip` + `deleteProgress` 직후 `deleteSsot` 추가. 5 cleanup reason(destination-arrived / expired / eta-missing / seoul-outage / push-unrecoverable) + reason omit(HTTP DELETE) 모두 자동 해소 |
| `index.ts:686 POST /trips` | `!isSameSession` 분기에서 `await deleteSsot(c.env.TRIPS, incoming.token)` 호출. cleanup race로 SSoT가 남아있는 경우(trip TTL 만료 + cron skip)에도 새 세션 판정 시 즉시 reset |

두 site 모두 KV delete throw graceful — log만 남기고 cleanup/trip 등록 흐름 차단 X.

## 테스트

### `liveActivity.test.ts` (5 + 1 + 1 = 7건)
- 5 cleanup reason matrix에서 SSoT row 삭제 검증
- reason omit(HTTP DELETE) 경로에서도 동등 삭제 검증
- KV delete throw graceful — `ssot delete failed` log + trip 정리 정상 완료

### `index.test.ts` (3건)
- 새 세션(다른 createdAt) 등록 시 SSoT 즉시 reset
- 같은 세션 재등록 시 SSoT 보존 (회귀 가드, advance 진행분 보존 정신과 정합)
- KV delete throw graceful — `ssot delete on new session failed` log + 200 응답

### 결과
- Backend test: **1999 passed / 53 files** (기존 1996 → 추가 3건 + 6 reason matrix)
- Backend type-check: pass

## Wire-completion 5단

1. **Orphan 없음** — N/A (frontend 변경 없음, backend는 orphan lint 대상 외)
2. **V/X dashboard** — Cloudflare Dashboard `ssot delete failed` / `ssot delete on new session failed (#1701)` log query로 graceful fail rate 관측. SSoT 누수 회귀는 device DebugModal `Backend SSoT.currentStationId`와 현재 trip waypoint stationName 일치 확인
3. **의존 PR** — N/A
4. **측정 plan** — 1주 production tail에서 `Backend SSoT.currentStationId`가 옛 trip stationName으로 잡히는 사례 0건 검증. 사용자 trip dump 캡처 시 동일 token 새 trip이 SSoT mirror에 옛 stationName을 갖지 않음
5. **Device verify** — N/A — backend-only fix. type-check + unit test로 정확성 보장

## Acceptance

- [x] cleanupTripWithLa 5 cleanup site(destination/expired/eta-missing/seoul-outage/push-unrecoverable) 모두 SSoT 삭제 검증
- [x] HTTP DELETE 경로(reason omit)에서도 SSoT 삭제 검증
- [x] POST /trips 새 세션 분기에서 stale SSoT 즉시 reset 검증
- [x] same-session 재등록은 SSoT 보존 (회귀 가드)
- [x] KV delete throw가 cleanup/등록 흐름을 차단하지 않음 (graceful)
- [ ] 사용자 6/23 trip dump 재현 시 어린이대공원/봉화산 stale SSoT 발생 안 함 (1주 production 측정)