### PR TITLE
fix(#1703): 6호선 closed loop awareness — lineTopology.json + loopDirection 확장

### DIFF
--- a/src/data/lineTopology.json
+++ b/src/data/lineTopology.json
@@ -11,5 +11,13 @@
     "bundang": { "low": "인천", "high": "청량리" },
     "sinbundang": { "low": "광교", "high": "신사" }
   },
-  "_endpoints_comment": "각 단조 노선의 진행방면 종착역 운영명(#788). SSOT: 본 endpoints. stations.json은 stationId 정렬용으로만 쓰이며 신규 연장(석남/진접/별내/중앙보훈병원 등)을 미반영한 상태. transferExit.json의 fromTerminal은 본 endpoints에 정렬돼야 하며, 미정렬 row는 score=0으로 첫 매칭 fallback(회귀 없음, 정확도 저하). low = stations.json id가 작은 쪽(상행 방면) 운영 종점, high = id가 큰 쪽(하행 방면). 노선 연장 시 본 endpoints 먼저 갱신 → transferExit.json fromTerminal 동기화."
+  "_endpoints_comment": "각 단조 노선의 진행방면 종착역 운영명(#788). SSOT: 본 endpoints. stations.json은 stationId 정렬용으로만 쓰이며 신규 연장(석남/진접/별내/중앙보훈병원 등)을 미반영한 상태. transferExit.json의 fromTerminal은 본 endpoints에 정렬돼야 하며, 미정렬 row는 score=0으로 첫 매칭 fallback(회귀 없음, 정확도 저하). low = stations.json id가 작은 쪽(상행 방면) 운영 종점, high = id가 큰 쪽(하행 방면). 노선 연장 시 본 endpoints 먼저 갱신 → transferExit.json fromTerminal 동기화.",
+  "closedLoops": {
+    "2": { "mainIdRange": { "firstId": "2-001", "lastId": "2-043" } },
+    "6": {
+      "mainIdRange": { "firstId": "6-001", "lastId": "6-039" },
+      "loopTailRange": { "firstId": "6-001", "lastId": "6-007" }
+    }
+  },
+  "_closedLoops_comment": "방향 추론용 노선 토폴로지(#1703). `inferLoopDirection`이 단조 화이트리스트 밖 노선의 방향을 결정하기 위해 참조. `mainIdRange`는 메인 운행 구간(지선 배제용). `loopTailRange`(선택)는 6호선처럼 단방향 응암 루프(P자 노선) 꼬리. loopTailRange가 있으면 hybrid 노선으로 처리한다 — id 단조 비교만으로 방향 결정(루프가 단방향이라 wrap 사용 안 함). loopTailRange가 없으면 진짜 순환선(2호선)으로 처리 — wrap 길이 비교."
 }

--- a/src/features/alarm/utils/__tests__/boardingPromptContext.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingPromptContext.test.ts
@@ -72,15 +72,72 @@ describe('buildBoardingPromptContext', () => {
       expect(ctx?.promptGeoContext.direction).toBe('up');
     });
 
-    it('비단조 line(2호선 순환) — direction null', () => {
+    it('순환선(2호선) — resolveTravelDirection null이지만 inferLoopDirection fallback으로 down 채움 (#1703)', () => {
+      // 시청(2-001) → 을지로3가(2-003): forward=2, backward=41 → forward 짧음 → down(외선순환).
+      // 이전엔 null이었지만 #1703 wiring으로 순환선도 backend가 양방향 후보 ambiguity 회피.
       const ctx = buildBoardingPromptContext({
         route: makeDirectRoute(2, '2'),
         currentStation: st('2-001'),
         destination: st('2-003'),
       });
       expect(ctx).not.toBeNull();
-      expect(ctx?.promptGeoContext.direction).toBeNull();
+      expect(ctx?.promptGeoContext.direction).toBe('down');
       expect(ctx?.promptDisplay.line).toBe('2');
+    });
+
+    it('하이브리드 노선(6호선) — 합정→공덕 down (#1703, 사용자 6/23 trip 회귀 차단)', () => {
+      // 합정(6-013) → 공덕(6-017): id 증가 → down. backend pickAutoTrainCode가 응암 방면
+      // 6184 trainCode를 잘못 잡지 않게 한다.
+      const ctx = buildBoardingPromptContext({
+        route: makeDirectRoute(4, '6'),
+        currentStation: st('6-013'),
+        destination: st('6-017'),
+      });
+      expect(ctx).not.toBeNull();
+      expect(ctx?.promptGeoContext.direction).toBe('down');
+      expect(ctx?.promptDisplay.line).toBe('6');
+      expect(ctx?.promptDisplay.originStation).toBe('합정');
+    });
+
+    it('하이브리드 노선(6호선) — 합정→망원 up (#1703)', () => {
+      const ctx = buildBoardingPromptContext({
+        route: makeDirectRoute(1, '6'),
+        currentStation: st('6-013'),
+        destination: st('6-012'),
+      });
+      expect(ctx?.promptGeoContext.direction).toBe('up');
+    });
+
+    it('하이브리드 노선(6호선) — 응암→연신내 down (loop 안, #1703)', () => {
+      const ctx = buildBoardingPromptContext({
+        route: makeDirectRoute(4, '6'),
+        currentStation: st('6-001'),
+        destination: st('6-005'),
+      });
+      expect(ctx?.promptGeoContext.direction).toBe('down');
+    });
+
+    it('하이브리드 노선(6호선) — 새절→증산 down (loop→본선 연결점, #1703)', () => {
+      const ctx = buildBoardingPromptContext({
+        route: makeDirectRoute(1, '6'),
+        currentStation: st('6-007'),
+        destination: st('6-008'),
+      });
+      expect(ctx?.promptGeoContext.direction).toBe('down');
+    });
+
+    it('비단조/closedLoops 미포함 line(1호선) — direction null fallback', () => {
+      // 1호선은 단조 화이트리스트 + closedLoops 둘 다 없음 → 양쪽 모두 null → 양방향 허용.
+      const current = st('1-001');
+      const dest = st('1-003');
+      const ctx = buildBoardingPromptContext({
+        route: makeDirectRoute(2, '1'),
+        currentStation: current,
+        destination: dest,
+      });
+      expect(ctx).not.toBeNull();
+      expect(ctx?.promptGeoContext.direction).toBeNull();
+      expect(ctx?.promptDisplay.line).toBe('1');
     });
 
     it('next station lookup 실패(current===destination) → null', () => {

--- a/src/features/alarm/utils/boardingPromptContext.ts
+++ b/src/features/alarm/utils/boardingPromptContext.ts
@@ -36,6 +36,7 @@ import {
   getNextStationName,
 } from '../../../shared/utils/stationRoute';
 import { resolveTravelDirection } from '../../route/utils/travelDirection';
+import { inferLoopDirection } from '../../route/utils/loopDirection';
 
 export interface BoardingPromptContext {
   promptGeoContext: {
@@ -70,8 +71,12 @@ export function buildBoardingPromptContext({
   /* istanbul ignore next -- getNextStationName이 같은 line에서 lookup한 name이므로 재조회 실패 불가 */
   if (!nextStation) return null;
 
-  const resolved = resolveTravelDirection(leg.line, currentStation.name, leg.endName);
-  const direction = resolved ? resolved.direction : null;
+  // 단조 노선은 resolveTravelDirection이, 순환/하이브리드 노선(2호선/6호선)은 inferLoopDirection
+  // 이 fallback으로 방향을 채운다(#1703). 둘 다 null이면 양방향 후보 허용 — backend
+  // `pickAutoTrainCode`는 stationName 필터로 implicit 방향 해소(허용 가능한 false negative).
+  const direction =
+    resolveTravelDirection(leg.line, currentStation.name, leg.endName)?.direction ??
+    inferLoopDirection(leg.line, currentStation.name, leg.endName);
 
   return {
     promptGeoContext: {

--- a/src/features/route/utils/__tests__/loopDirection.test.ts
+++ b/src/features/route/utils/__tests__/loopDirection.test.ts
@@ -17,7 +17,31 @@ jest.mock('../../../../shared/utils/stationRoute', () => ({
       ];
     }
     if (line === '3') return [{ id: '3-0', name: '대화', line: '3' }];
-    if (line === '6') return []; // 빈 노선
+    if (line === '6') {
+      // 6호선 hybrid 노선: 응암 단방향 루프(6-001~6-007) + 본선(6-008~6-039).
+      // 본 fixture는 운영 구간(6-001~6-017)만 발췌 — main range 안에서 id 단조 비교만으로
+      // 방향 결정. 6-007 새절은 루프와 본선의 연결점.
+      return [
+        { id: '6-001', name: '응암', line: '6' },
+        { id: '6-002', name: '역촌', line: '6' },
+        { id: '6-003', name: '불광', line: '6' },
+        { id: '6-004', name: '독바위', line: '6' },
+        { id: '6-005', name: '연신내', line: '6' },
+        { id: '6-006', name: '구산', line: '6' },
+        { id: '6-007', name: '새절', line: '6' }, // normalize 매칭(원본 '새절(신사)')
+        { id: '6-008', name: '증산', line: '6' },
+        { id: '6-009', name: '디지털미디어시티', line: '6' },
+        { id: '6-010', name: '월드컵경기장', line: '6' },
+        { id: '6-011', name: '마포구청', line: '6' },
+        { id: '6-012', name: '망원', line: '6' },
+        { id: '6-013', name: '합정', line: '6' },
+        { id: '6-014', name: '상수', line: '6' },
+        { id: '6-015', name: '광흥창', line: '6' },
+        { id: '6-016', name: '대흥', line: '6' },
+        { id: '6-017', name: '공덕', line: '6' },
+      ];
+    }
+    if (line === '9') return []; // 빈 노선 (closedLoops에 없음)
     return [];
   },
   normalizeStationName: (name: string) => {
@@ -29,14 +53,14 @@ jest.mock('../../../../shared/utils/stationRoute', () => ({
   },
 }));
 
-describe('inferLoopDirection', () => {
+describe('inferLoopDirection — 순환선 (2호선)', () => {
   // 케이스: [설명, line, from, to, 기대값]
-  // - LOOP_LINES(2호선) 외 / 동일 역 / 정반대 위치 / 지선 매칭 실패 → null
+  // - CLOSED_LOOPS 미포함 노선 / 동일 역 / 정반대 위치 / 지선 매칭 실패 → null
   // - id 증가 방향이 짧으면 'down' (외선순환), wrap 방향이 짧으면 'up' (내선순환)
   // - normalize는 정확 매칭 다음 fallback
   const cases: Array<[string, '2' | '3', string, string, 'up' | 'down' | null]> = [
-    ['순환선 외(monotonic) 노선은 null', '3', '대화', '주엽', null],
-    ['LOOP_LINES 미포함 노선은 동일 역도 null', '3', '대화', '대화', null],
+    ['CLOSED_LOOPS 외(monotonic) 노선은 null', '3', '대화', '주엽', null],
+    ['CLOSED_LOOPS 미포함 노선은 동일 역도 null', '3', '대화', '대화', null],
     ['시청(0) → 을지로4가(3): forward=3, backward=5 → down', '2', '시청', '을지로4가', 'down'],
     ['시청(0) → 왕십리(7): forward=7, backward=1 → up', '2', '시청', '왕십리', 'up'],
     ['시청(0) ↔ 동대문역사문화공원(4): 정반대 → null', '2', '시청', '동대문역사문화공원', null],
@@ -52,10 +76,34 @@ describe('inferLoopDirection', () => {
   });
 });
 
+describe('inferLoopDirection — 하이브리드 노선 (6호선 응암 루프, #1703)', () => {
+  // 6호선은 P자 노선(응암 단방향 꼬리 + 본선). closedLoops.6.loopTailRange 존재 → wrap 비교
+  // 비활성화. 단순 id 단조 비교로 동작:
+  //   - id 증가 = 'down' (신내 방면)
+  //   - id 감소 = 'up' (응암 방면)
+  // 사용자 6/23 트립 evidence: 합정(6-013) → 공덕(6-017) 'down'이어야 backend가 응암 방면
+  // 6184 train code를 잘못 잡지 않는다.
+  const cases: Array<[string, string, string, 'up' | 'down' | null]> = [
+    ['합정(12) → 공덕(16) 본선 forward → down', '합정', '공덕', 'down'],
+    ['합정(12) → 망원(11) 본선 backward → up', '합정', '망원', 'up'],
+    ['응암(0) → 연신내(4) 루프 안 forward → down', '응암', '연신내', 'down'],
+    ['새절(6) → 증산(7) 루프 끝→본선 forward → down', '새절', '증산', 'down'],
+    ['공덕(16) → 응암(0) 본선→루프 backward → up', '공덕', '응암', 'up'],
+    ['연신내(4) → 응암(0) 루프 backward → up', '연신내', '응암', 'up'],
+    ['동일 역이면 null', '합정', '합정', null],
+    ['미존재 from → null', '없는역', '공덕', null],
+    ['미존재 to → null', '합정', '없는역', null],
+    ['새절(신사) 원본명 → normalize 매칭으로 새절 → down 유지', '새절(신사)', '증산', 'down'],
+  ];
+
+  it.each(cases)('%s', (_desc, from, to, expected) => {
+    expect(inferLoopDirection('6', from, to)).toBe(expected);
+  });
+});
+
 describe('inferLoopDirection — empty/small loop guards', () => {
-  // line '6'은 빈 배열을 반환하지만 LOOP_LINES에 포함돼있지 않아 stations.length === 0 분기에
-  // 도달하지 않는다. 해당 가드 + 'loop.length < 2' 가드를 명시적으로 커버하기 위해
-  // 임시로 mock을 재설정해 line '2'를 빈 배열 / 단일 항목으로 만든다.
+  // line '9'는 closedLoops에 없어 stations.length === 0 분기 자체에 도달하지 않는다.
+  // stations 빈 배열 + small loop 가드를 명시적으로 커버하기 위해 mock을 재설정.
   const stationRoute = jest.requireMock('../../../../shared/utils/stationRoute') as {
     getStationsOnLine: (line: string) => Array<{ id: string; name: string; line: string }>;
   };
@@ -74,6 +122,12 @@ describe('inferLoopDirection — empty/small loop guards', () => {
     stationRoute.getStationsOnLine = (line: string) =>
       line === '2' ? [{ id: '2-001', name: '시청', line: '2' }] : [];
     expect(inferLoopDirection('2', '시청', '왕십리')).toBeNull();
+  });
+
+  it('하이브리드 노선(6)도 메인 구간 1개 이하면 null', () => {
+    stationRoute.getStationsOnLine = (line: string) =>
+      line === '6' ? [{ id: '6-001', name: '응암', line: '6' }] : [];
+    expect(inferLoopDirection('6', '응암', '공덕')).toBeNull();
   });
 });
 

--- a/src/features/route/utils/loopDirection.ts
+++ b/src/features/route/utils/loopDirection.ts
@@ -1,51 +1,65 @@
 import type { LineNumber } from '../../../shared/types/station';
 import type { TravelDirection } from '../../../shared/types/exitSide';
 import { getStationsOnLine, normalizeStationName } from '../../../shared/utils/stationRoute';
+import lineTopology from '../../../data/lineTopology.json';
 
-// 비단조 노선(현재 2호선 순환선만) 방향 추론.
-// monotonic 화이트리스트(`travelDirection.ts`)에 들어가지 못하는 노선을 보완한다.
+// 비단조 노선 방향 추론. `MONOTONIC_LINES` 화이트리스트(`travelDirection.ts`)에 들어가지 못하는
+// 노선을 보완한다. 토폴로지 SSOT는 `lineTopology.json`의 `closedLoops`.
 //
-// 2호선 순환선:
-//   - 메인 루프(시청 ~ 충정로, stations.json id 2-001 ~ 2-043, 43개)는 순환선.
-//   - 까치산(2-105) / 신설동(2-205)은 지선으로 본 추론 대상 외 → null.
-//   - 진행 방향 결정: from → to까지 id 증가 방향으로 가는 호(arc)와
-//     반대 방향(루프 wrap) 호 중 짧은 쪽을 선택.
-//   - 증가 방향이 더 짧으면 외선순환 = 'down' (low→high 컨벤션 정렬)
-//   - 감소 방향(wrap)이 더 짧으면 내선순환 = 'up'
-//   - 두 호가 정확히 같은 길이(정반대 위치)면 ambiguous → null.
+// 모델:
+//   - **순환선 (2호선)**: `mainIdRange`만 있는 진짜 closed loop. forward/backward 호 중 짧은
+//     쪽을 채택. 지선(2-105/2-205)은 main range 밖이라 자동 배제.
+//   - **Hybrid 노선 (6호선 응암 루프)**: `loopTailRange`가 있는 P자 노선. 루프 꼬리는 단방향
+//     운행(응암→역촌→...→새절)이라 wrap이 의미 없음 — 모든 from/to 쌍을 단순 id 단조 비교로
+//     처리한다(id 증가=down, 감소=up). 합정(6-013)→공덕(6-017)=down / 합정→망원(6-012)=up /
+//     응암(6-001)→연신내(6-005)=down / 새절(6-007)→증산(6-008)=down 등 acceptance 케이스
+//     (#1703)를 모두 자연스럽게 만족한다.
 //
-// 이 util은 호출부에 직접 wiring 되지 않는다(후속 PR). monotonic util과 분리 유지.
+// 본 util은 `boardingPromptContext.ts`와 `alarmDirection.ts`에서 `resolveTravelDirection` null
+// 시 fallback으로 호출된다.
 
-const LOOP_LINES = new Set<LineNumber>(['2']);
+interface ClosedLoopMeta {
+  mainIdRange: { firstId: string; lastId: string };
+  /** 있으면 hybrid 노선(P자 + 단방향 꼬리). 없으면 진짜 순환선. */
+  loopTailRange?: { firstId: string; lastId: string };
+}
 
-// 2호선 메인 루프 station id prefix. 지선(2-105, 2-205)을 배제.
-const LINE2_LOOP_PREFIX = '2-0';
+const CLOSED_LOOPS = lineTopology.closedLoops as Partial<Record<LineNumber, ClosedLoopMeta>>;
 
 /**
- * 2호선 순환선의 from → to 방향을 추론한다.
- * - 'up'   = 내선순환 (id 감소 방향이 더 짧음)
- * - 'down' = 외선순환 (id 증가 방향이 더 짧음)
- * - null   = 추론 불가 (지선 포함, 동일 역, 정반대 위치 등)
+ * 순환/하이브리드 노선의 from → to 방향을 추론한다.
+ * - 'up'   = id 감소 방향 (순환선의 경우 내선순환 = wrap 짧음)
+ * - 'down' = id 증가 방향 (순환선의 경우 외선순환 = forward 짧음)
+ * - null   = 추론 불가 (대상 노선 아님, 동일 역, 지선, 정반대 위치 등)
  */
 export function inferLoopDirection(
   line: LineNumber,
   fromName: string,
   toName: string,
 ): TravelDirection | null {
-  if (!LOOP_LINES.has(line)) return null;
+  const meta = CLOSED_LOOPS[line];
+  if (!meta) return null;
+
   const stations = getStationsOnLine(line);
   if (stations.length === 0) return null;
 
-  // 메인 루프만 추출(지선 제외). id 오름차순 정렬은 stations.json 기준 유지.
-  const loop = stations.filter((s) => s.id.startsWith(LINE2_LOOP_PREFIX));
-  if (loop.length < 2) return null;
+  // 메인 운행 구간만 추출(지선 배제). id 오름차순은 stations.json 기준.
+  const { firstId, lastId } = meta.mainIdRange;
+  const main = stations.filter((s) => s.id >= firstId && s.id <= lastId);
+  if (main.length < 2) return null;
 
-  const fromIdx = indexOf(loop, fromName);
-  const toIdx = indexOf(loop, toName);
+  const fromIdx = indexOf(main, fromName);
+  const toIdx = indexOf(main, toName);
   if (fromIdx === -1 || toIdx === -1) return null;
   if (fromIdx === toIdx) return null;
 
-  const n = loop.length;
+  // Hybrid 노선(6호선)은 단방향 꼬리 때문에 wrap 비교가 무의미 — 단순 id 단조 비교.
+  if (meta.loopTailRange) {
+    return toIdx > fromIdx ? 'down' : 'up';
+  }
+
+  // 진짜 순환선(2호선): forward/backward 호 길이 비교.
+  const n = main.length;
   const forward = (toIdx - fromIdx + n) % n; // id 증가 방향 호 길이
   const backward = n - forward; // wrap 방향 호 길이
 


### PR DESCRIPTION
Closes #1703

## 문제

6호선이 `monotonicLines` 화이트리스트(`src/data/lineTopology.json`)에 없고 `LOOP_LINES`(`src/features/route/utils/loopDirection.ts`)에도 없음 → 6호선 trip에서 `resolveTravelDirection`이 항상 null → `boardingPromptContext.direction = null` → backend `pickAutoTrainCode`가 양방향 train을 모두 candidate로 잡아 ambiguity 발생.

### evidence

사용자 6/23 trip (합정 → 공덕 → 군자 → 용마산) — backend가 응암 방면 train code 6184를 잘못 잡음. `direction=null`이 root cause.

## Fix

### 1. `src/data/lineTopology.json` — `closedLoops` 토폴로지 추가

```jsonc
"closedLoops": {
  "2": { "mainIdRange": { "firstId": "2-001", "lastId": "2-043" } },
  "6": {
    "mainIdRange": { "firstId": "6-001", "lastId": "6-039" },
    "loopTailRange": { "firstId": "6-001", "lastId": "6-007" }
  }
}
```

- `mainIdRange`: 메인 운행 구간(지선 배제용).
- `loopTailRange`(선택): 6호선처럼 단방향 응암 루프(P자 노선) 꼬리. 있으면 hybrid 노선.

### 2. `src/features/route/utils/loopDirection.ts` — 데이터 주도 + hybrid 노선 모델링

기존 하드코딩 `LOOP_LINES`/`LINE2_LOOP_PREFIX` 제거, `CLOSED_LOOPS` 데이터에서 구동.

- **순환선 (2호선)**: `loopTailRange` 없음 → forward/backward 호 길이 비교 (기존 로직 유지).
- **Hybrid 노선 (6호선)**: `loopTailRange` 있음 → 루프 꼬리가 단방향이라 wrap 무의미. id 단조 비교(증가=down, 감소=up).

### 3. `src/features/alarm/utils/boardingPromptContext.ts` — fallback wiring

`resolveTravelDirection` null이면 `inferLoopDirection` 호출로 2호선/6호선 direction 채움. 둘 다 null이면 양방향 후보 허용(backend `pickAutoTrainCode`의 stationName 필터가 implicit 방향 해소).

## Acceptance

- [x] 6호선 합정(6-013) → 공덕(6-017) `direction='down'`
- [x] 6호선 합정(6-013) → 망원(6-012) `direction='up'`
- [x] 6호선 응암(6-001) → 연신내(6-005) `direction='down'`
- [x] 6호선 새절(6-007) → 증산(6-008) `direction='down'`
- [x] `loopDirection.test.ts` 6호선 hybrid 케이스 추가 (10개 it.each + guard 1개)
- [x] `boardingPromptContext.test.ts` 6호선 4개 + 2호선 fallback + 1호선 null fallback 추가
- [ ] **사용자 6/23 trip 재현 시 train code 6184(응암) 잡힘 안 함** (device verify)

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — `pickAutoTrainCode` candidate filtering 결정은 backend log (Cloudflare Dashboard `boardingPrompt` evaluator).
3. **의존 PR** — N/A (자체 완결, backend 변경 없음).
4. **측정 plan** — 1주 안 6호선 trip의 `pickAutoTrainCode` 단일 수렴률 측정. backend log query `line:6 promptGeoContext.direction != null` 비율 증가 확인.
5. **Device verify** — 필요. 사용자 6/23 합정→공덕→군자→용마산 trip 회귀 재현으로 train code 6184(응암 방면) 잡힘 차단 확인.

## 테스트 결과

- `loopDirection.test.ts`: 28 tests pass (line 2 + line 6 hybrid + guards + parseTrainLineDirection)
- `boardingPromptContext.test.ts`: 14 tests pass
- `alarmDirection.test.ts`: 19 tests pass (회귀 없음)
- `travelDirection.test.ts`: 15 tests pass
- 두 touched 파일 모두 100% coverage
- `npm run type-check` pass
- `npm run lint:orphan` pass (No orphan exports detected)