### PR TITLE
fix(#1706): fusion-picker-tier 별 ring buffer 분리 (alarmLog 점령 회귀 차단)

### DIFF
--- a/backend/alarm-worker/src/__tests__/alarmLogForward.test.ts
+++ b/backend/alarm-worker/src/__tests__/alarmLogForward.test.ts
@@ -16,6 +16,8 @@ function validBody(): Record<string, unknown> {
     tripEndedAt: Date.UTC(2026, 5, 20, 12, 30, 0),
     alarmLog: [{ ts: 1, source: 'fg' }],
     fusionLog: [{ ts: 2, kind: 'cycle' }],
+    // #1706 — fusion picker tier 별 ring buffer. alarmLog ring과 분리.
+    fusionTierLog: [{ ts: 5, tier: 'gpsFallback' }],
     gpsDrops: [{ ts: 3, accuracy: 250 }],
     backendSsotSnapshot: { currentStationId: '강남', motionState: 'moving' },
     deviceMetadata: { os: 'ios', appVersion: '1.2.3', locale: 'ko' },
@@ -28,9 +30,35 @@ describe('validateAlarmLogForward', () => {
     expect(out).not.toBeNull();
     expect(out?.token).toBe('aabbccdd11223344');
     expect(out?.alarmLog.length).toBe(1);
+    // #1706 — 별 ring buffer entries 보존.
+    expect(out?.fusionTierLog.length).toBe(1);
     expect(out?.deviceMetadata.os).toBe('ios');
     expect(out?.deviceMetadata.appVersion).toBe('1.2.3');
     expect(out?.deviceMetadata.locale).toBe('ko');
+  });
+
+  it('#1706 — fusionTierLog 미설정(구 device 호환) 시 기본 [] 채워 accept', () => {
+    const body = validBody();
+    delete (body as Record<string, unknown>).fusionTierLog;
+    const out = validateAlarmLogForward(body);
+    expect(out).not.toBeNull();
+    expect(out?.fusionTierLog).toEqual([]);
+  });
+
+  it('#1706 — fusionTierLog 비배열이면 reject', () => {
+    expect(
+      validateAlarmLogForward({ ...validBody(), fusionTierLog: 'x' }),
+    ).toBeNull();
+    expect(
+      validateAlarmLogForward({ ...validBody(), fusionTierLog: {} }),
+    ).toBeNull();
+  });
+
+  it('#1706 — fusionTierLog cap 초과 시 reject', () => {
+    const tooMany = Array.from({ length: MAX_ENTRIES_PER_BUCKET + 1 }, (_, i) => ({ i }));
+    expect(
+      validateAlarmLogForward({ ...validBody(), fusionTierLog: tooMany }),
+    ).toBeNull();
   });
 
   it('normalizes null ssot snapshot', () => {
@@ -113,11 +141,11 @@ describe('buildR2Key', () => {
 });
 
 describe('buildNdjsonBody', () => {
-  it('emits 6 lines: header + 4 buckets + deviceMetadata', () => {
+  it('#1706 — emits 7 lines: header + alarmLog + fusionLog + fusionTierLog + gpsDrops + ssot + deviceMetadata', () => {
     const u = validateAlarmLogForward(validBody())!;
     const body = buildNdjsonBody(u);
     const lines = body.split('\n');
-    expect(lines).toHaveLength(6);
+    expect(lines).toHaveLength(7);
     const header = JSON.parse(lines[0]);
     expect(header.kind).toBe('header');
     expect(header.tokenPrefix).toBe('aabbccdd');
@@ -127,10 +155,20 @@ describe('buildNdjsonBody', () => {
       'header',
       'alarmLog',
       'fusionLog',
+      'fusionTierLog',
       'gpsDrops',
       'backendSsotSnapshot',
       'deviceMetadata',
     ]);
+  });
+
+  it('#1706 — fusionTierLog 라인이 entries로 device snapshot 보존', () => {
+    const u = validateAlarmLogForward(validBody())!;
+    const body = buildNdjsonBody(u);
+    const lines = body.split('\n').map((l) => JSON.parse(l));
+    const tierLine = lines.find((l) => l.kind === 'fusionTierLog');
+    expect(tierLine).toBeDefined();
+    expect(tierLine.entries).toEqual([{ ts: 5, tier: 'gpsFallback' }]);
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/alarmLogStats.test.ts
+++ b/backend/alarm-worker/src/__tests__/alarmLogStats.test.ts
@@ -88,6 +88,43 @@ describe('computeAlarmLogStats', () => {
     expect(stats.tripsScanned).toBe(2);
   });
 
+  it('#1706 — fusionTierLog kind는 sources/reasons 카운터에서 자동 제외', async () => {
+    // ndjson에 alarmLog 1 entry + fusionTierLog 5 entry. stats는 alarmLog kind만 카운트해야 함.
+    const tripEndedAt = NOW - 5 * 60 * 1000;
+    const body = [
+      JSON.stringify({ kind: 'header', tripEndedAt }),
+      JSON.stringify({
+        kind: 'alarmLog',
+        entries: [{ source: 'silent-push-received', outcome: 'received' }],
+      }),
+      JSON.stringify({
+        kind: 'fusionTierLog',
+        entries: [
+          { ts: 1, tier: 'gpsFallback' },
+          { ts: 2, tier: 'gpsFallback' },
+          { ts: 3, tier: 'gpsFallback' },
+          { ts: 4, tier: 'backendSsotAccepts' },
+          { ts: 5, tier: 'backendSsotAccepts' },
+        ],
+      }),
+    ].join('\n');
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/20/aabbccdd-1000.ndjson',
+        tripEndedAt,
+        body,
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    // alarmLog 1건만 반영. fusionTierLog 5건은 카운터에 추가되지 않는다.
+    expect(stats.totalEvents).toBe(1);
+    expect(stats.received).toBe(1);
+    expect(stats.sources['silent-push-received']).toBe(1);
+    expect(stats.sources['fusion-picker-tier']).toBeUndefined();
+    expect(stats.reasons['tier-gpsFallback']).toBeUndefined();
+    expect(stats.reasons['tier-backendSsotAccepts']).toBeUndefined();
+  });
+
   it('excludes archives outside windowHours window', async () => {
     const r2 = makeFakeR2([
       {

--- a/backend/alarm-worker/src/alarmLogForward.ts
+++ b/backend/alarm-worker/src/alarmLogForward.ts
@@ -10,8 +10,9 @@
  *   - tripStartedAt epoch ms로 같은 device의 동시 trip 충돌 차단.
  *   - YYYY/MM/DD는 tripStartedAt UTC 기준 — operator가 prefix list로 일자별 조회 가능.
  *
- * Body: ndjson (1줄 = JSON 객체). 7줄: header + alarmLog 1줄 + fusionLog 1줄 + gpsDrops 1줄
- *   + ssotSnapshot 1줄 + deviceMetadata 1줄. 사후 분석 도구가 줄 단위 stream parse 가능.
+ * Body: ndjson (1줄 = JSON 객체). 7줄: header + alarmLog 1줄 + fusionLog 1줄
+ *   + fusionTierLog 1줄(#1706) + gpsDrops 1줄 + ssotSnapshot 1줄 + deviceMetadata 1줄.
+ *   사후 분석 도구가 줄 단위 stream parse 가능.
  *
  * R2 lifecycle 90일 삭제는 Cloudflare Dashboard에서 운영자가 수동 설정 (PR 본문 참고).
  *
@@ -21,7 +22,10 @@
  */
 import { tokenPrefix } from './telemetry';
 
-/** entries cap — alarmLog 200 + fusionLog 200 + gpsDrops 100 = 500 + overhead. 1500 cap. */
+/**
+ * entries cap — alarmLog 200 + fusionLog 200 + fusionTierLog 200 + gpsDrops 100 = 700 + overhead.
+ * 1500 cap.
+ */
 export const MAX_ENTRIES_PER_BUCKET = 1500;
 
 /** R2 key prefix. */
@@ -33,6 +37,13 @@ export interface AlarmLogForwardUpload {
   tripEndedAt: number;
   alarmLog: unknown[];
   fusionLog: unknown[];
+  /**
+   * #1706 — fusion picker tier 별 ring buffer entries.
+   * alarmLog ring 점령 회귀 차단을 위해 device-side에서 분리된 채널.
+   * alarmLogStats.ts의 `obj.kind !== 'alarmLog'` 필터로 자동 stats에서 제외 — fusion-picker-tier
+   * 가 sources/reasons 분포를 점령하지 않는다.
+   */
+  fusionTierLog: unknown[];
   gpsDrops: unknown[];
   backendSsotSnapshot: unknown;
   deviceMetadata: {
@@ -54,6 +65,7 @@ export function validateAlarmLogForward(input: unknown): AlarmLogForwardUpload |
     tripEndedAt,
     alarmLog,
     fusionLog,
+    fusionTierLog,
     gpsDrops,
     backendSsotSnapshot,
     deviceMetadata,
@@ -63,6 +75,15 @@ export function validateAlarmLogForward(input: unknown): AlarmLogForwardUpload |
   if (typeof tripEndedAt !== 'number' || tripEndedAt < tripStartedAt) return null;
   if (!Array.isArray(alarmLog) || alarmLog.length > MAX_ENTRIES_PER_BUCKET) return null;
   if (!Array.isArray(fusionLog) || fusionLog.length > MAX_ENTRIES_PER_BUCKET) return null;
+  // #1706 — fusionTierLog는 신규 채널. 누락 시 기본값 [] 허용(구 device 호환). 배열이면 cap 검증.
+  let safeFusionTierLog: unknown[];
+  if (fusionTierLog === undefined) {
+    safeFusionTierLog = [];
+  } else if (Array.isArray(fusionTierLog) && fusionTierLog.length <= MAX_ENTRIES_PER_BUCKET) {
+    safeFusionTierLog = fusionTierLog;
+  } else {
+    return null;
+  }
   if (!Array.isArray(gpsDrops) || gpsDrops.length > MAX_ENTRIES_PER_BUCKET) return null;
   if (!isStringRecord(deviceMetadata)) return null;
   if (typeof deviceMetadata.os !== 'string') return null;
@@ -72,6 +93,7 @@ export function validateAlarmLogForward(input: unknown): AlarmLogForwardUpload |
     tripEndedAt,
     alarmLog,
     fusionLog,
+    fusionTierLog: safeFusionTierLog,
     gpsDrops,
     backendSsotSnapshot: backendSsotSnapshot ?? null,
     deviceMetadata: {
@@ -109,6 +131,8 @@ export function buildNdjsonBody(upload: AlarmLogForwardUpload): string {
     },
     { kind: 'alarmLog', entries: upload.alarmLog },
     { kind: 'fusionLog', entries: upload.fusionLog },
+    // #1706 — fusion picker tier 별 채널. alarmLogStats가 `obj.kind !== 'alarmLog'` 필터로 제외.
+    { kind: 'fusionTierLog', entries: upload.fusionTierLog },
     { kind: 'gpsDrops', entries: upload.gpsDrops },
     { kind: 'backendSsotSnapshot', value: upload.backendSsotSnapshot },
     { kind: 'deviceMetadata', value: upload.deviceMetadata },

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -1047,6 +1047,8 @@ app.post('/telemetry/alarm-log', async (c) => {
       durationMs: payload.tripEndedAt - payload.tripStartedAt,
       alarmLog: payload.alarmLog.length,
       fusionLog: payload.fusionLog.length,
+      // #1706 — 별 ring 채널. 점령 회귀 측정 baseline.
+      fusionTierLog: payload.fusionTierLog.length,
       gpsDrops: payload.gpsDrops.length,
     }),
   );

--- a/src/features/alarm/api/__tests__/telemetryForward.test.ts
+++ b/src/features/alarm/api/__tests__/telemetryForward.test.ts
@@ -27,6 +27,8 @@ function basePayload(over: Partial<TelemetryForwardPayload> = {}): TelemetryForw
     tripEndedAt: tripStartedAt + MIN_TRIP_DURATION_MS + 1,
     alarmLog: [{ ts: 1 }],
     fusionLog: [{ ts: 2 }],
+    // #1706 — fusion picker tier 별 ring buffer. alarmLog ring 점령 회귀 차단 채널.
+    fusionTierLog: [{ ts: 4, tier: 'gpsFallback' }],
     gpsDrops: [{ ts: 3 }],
     backendSsotSnapshot: { currentStationId: '강남' },
     deviceMetadata: { os: 'ios', appVersion: '1.2.3', locale: 'ko' },
@@ -89,12 +91,48 @@ describe('forwardTripTelemetry', () => {
       basePayload({
         alarmLog: [],
         fusionLog: [],
+        fusionTierLog: [],
         gpsDrops: [],
         backendSsotSnapshot: null,
       }),
     );
     expect(result.skipReason).toBe('empty-payload');
     expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('#1706 — fusionTierLog만 단독 적재돼도 forward (empty-payload 아님)', async () => {
+    setBackend({ ok: true, status: 200 });
+    const result = await forwardTripTelemetry(
+      basePayload({
+        alarmLog: [],
+        fusionLog: [],
+        fusionTierLog: [{ ts: 1, tier: 'gpsFallback' }],
+        gpsDrops: [],
+        backendSsotSnapshot: null,
+      }),
+    );
+    expect(result.ok).toBe(true);
+    const [, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(init.body);
+    // 별 채널로 분리됐는지 검증 — alarmLog ring과 같은 line에 섞이지 않는다.
+    expect(body.fusionTierLog).toEqual([{ ts: 1, tier: 'gpsFallback' }]);
+    expect(body.alarmLog).toEqual([]);
+  });
+
+  it('#1706 — alarmLog/fusionLog/fusionTierLog 동시 forward 시 별 line으로 분리', async () => {
+    setBackend({ ok: true, status: 200 });
+    await forwardTripTelemetry(
+      basePayload({
+        alarmLog: [{ ts: 10, source: 'silent-push-received' }],
+        fusionLog: [{ ts: 20 }],
+        fusionTierLog: [{ ts: 30, tier: 'backendSsotAccepts' }],
+      }),
+    );
+    const [, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.alarmLog).toEqual([{ ts: 10, source: 'silent-push-received' }]);
+    expect(body.fusionLog).toEqual([{ ts: 20 }]);
+    expect(body.fusionTierLog).toEqual([{ ts: 30, tier: 'backendSsotAccepts' }]);
   });
 
   it('성공 시 ok=true + outbox 비움', async () => {

--- a/src/features/alarm/api/telemetryForward.ts
+++ b/src/features/alarm/api/telemetryForward.ts
@@ -49,6 +49,11 @@ export interface TelemetryForwardPayload {
   alarmLog: readonly unknown[];
   /** fusionLog 200 ring buffer snapshot. */
   fusionLog: readonly unknown[];
+  /**
+   * fusion picker tier 200 ring buffer snapshot (#1706).
+   * alarmLog ring과 분리된 별 채널 — 점령 회귀 차단.
+   */
+  fusionTierLog: readonly unknown[];
   /** GPS drop 100 ring buffer snapshot. */
   gpsDrops: readonly unknown[];
   /** backend SSoT mirror snapshot (또는 null — mirror 미존재 trip). */
@@ -130,6 +135,7 @@ function payloadIsEmpty(p: TelemetryForwardPayload): boolean {
   return (
     p.alarmLog.length === 0 &&
     p.fusionLog.length === 0 &&
+    p.fusionTierLog.length === 0 &&
     p.gpsDrops.length === 0 &&
     p.backendSsotSnapshot === null
   );

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -55,6 +55,9 @@ import {
   logFusionPickerTier,
   _resetFusionPickerTierWindowForTests,
   formatFusionPickerTierDistribution,
+  getFusionTierLog,
+  FUSION_TIER_LOG_BUFFER_SIZE,
+  type FusionTierLogEntry,
   logCrossTripMirrorSkip,
   logSuppressedOriginHopLockless,
   logSuppressedPassedEventOnLockOrigin,
@@ -2543,94 +2546,106 @@ describe('alarmLog', () => {
     });
   });
 
-  describe('logFusionPickerTier + formatFusionPickerTierDistribution (#1693)', () => {
-    it('logFusionPickerTier: tier 채택 시 source=fusion-picker-tier, outcome=fired 적재', async () => {
+  describe('logFusionPickerTier + getFusionTierLog (#1693/#1706 별 ring buffer)', () => {
+    it('logFusionPickerTier: 별 ring buffer에만 적재 — alarmLog ring에 안 들어감', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
       logFusionPickerTier('gpsFallback');
+      // alarmLog는 flush 시도해도 빈 채로 유지 — 별 채널 분리 검증.
       await flushAlarmLog();
+      expect(AsyncStorage.setItem).not.toHaveBeenCalled();
 
-      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
-      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
-      expect(saved[0]).toMatchObject({
-        source: 'fusion-picker-tier',
-        outcome: 'fired',
-        reason: 'tier-gpsFallback',
-      });
+      const ring = getFusionTierLog();
+      expect(ring).toHaveLength(1);
+      expect(ring[0]?.tier).toBe('gpsFallback');
+      expect(typeof ring[0]?.ts).toBe('number');
     });
 
-    it('logFusionPickerTier: 1s 윈도우 내 같은 tier 재호출은 drop (dedup)', async () => {
+    it('logFusionPickerTier: 1s 윈도우 내 같은 tier 재호출은 drop (dedup)', () => {
       const baseTs = 1_700_000_000_000;
       const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseTs);
       try {
         logFusionPickerTier('backendSsotAccepts');
         logFusionPickerTier('backendSsotAccepts'); // 동일 tier, 1s 이내 → drop
-        await flushAlarmLog();
 
-        const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
-        const saved: AlarmLogEntry[] = JSON.parse(savedJson);
-        expect(saved).toHaveLength(1);
-        expect(saved[0]).toMatchObject({
-          source: 'fusion-picker-tier',
-          reason: 'tier-backendSsotAccepts',
-        });
+        const ring = getFusionTierLog();
+        expect(ring).toHaveLength(1);
+        expect(ring[0]?.tier).toBe('backendSsotAccepts');
       } finally {
         nowSpy.mockRestore();
       }
     });
 
-    it('logFusionPickerTier: 1s 경과 후 같은 tier 재호출은 적재 (appendAlarmLog burst counter로 합산)', async () => {
-      // 첫 호출 → 적재
+    it('logFusionPickerTier: dedup 윈도우 reset 후 같은 tier 재호출은 새 entry 추가', () => {
       logFusionPickerTier('fused');
       // dedup window 리셋 (1s+ 경과 시뮬레이션)
       _resetFusionPickerTierWindowForTests();
-      // 두 번째 호출 → burst counter 증가 (appendAlarmLog가 같은 source/reason 연속이면 count++)
       logFusionPickerTier('fused');
-      await flushAlarmLog();
 
-      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
-      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
-      // appendAlarmLog burst inline counter: 같은 (source, reason, stationName) 연속이면 count++ (1 entry)
-      expect(saved).toHaveLength(1);
-      expect(saved[0]).toMatchObject({ source: 'fusion-picker-tier', reason: 'tier-fused' });
-      expect(saved[0].count).toBe(2);
+      const ring = getFusionTierLog();
+      expect(ring).toHaveLength(1); // reset이 ring도 비웠으므로 1건만 (사양: reset = full reset)
+      expect(ring[0]?.tier).toBe('fused');
     });
 
-    it('logFusionPickerTier: 다른 tier는 각각 독립 dedup', async () => {
+    it('logFusionPickerTier: 다른 tier는 각각 독립 dedup → 모두 ring에 적재', () => {
       logFusionPickerTier('positionTrainBoardingLockMatch');
-      logFusionPickerTier('gpsDerivedFastPath'); // 다른 tier → 별도 적재
-      await flushAlarmLog();
+      logFusionPickerTier('gpsDerivedFastPath');
 
-      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
-      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
-      expect(saved).toHaveLength(2);
-      expect(saved[0]).toMatchObject({ reason: 'tier-positionTrainBoardingLockMatch' });
-      expect(saved[1]).toMatchObject({ reason: 'tier-gpsDerivedFastPath' });
+      const ring = getFusionTierLog();
+      expect(ring).toHaveLength(2);
+      expect(ring[0]?.tier).toBe('positionTrainBoardingLockMatch');
+      expect(ring[1]?.tier).toBe('gpsDerivedFastPath');
+    });
+
+    it(`logFusionPickerTier: ring buffer cap=${FUSION_TIER_LOG_BUFFER_SIZE} FIFO drop`, () => {
+      // cap+5건을 unique tier 조합 + ts 진행으로 push.
+      // dedup window를 매 호출마다 reset해 모두 적재.
+      const baseTs = 2_000_000_000_000;
+      const nowSpy = jest.spyOn(Date, 'now');
+      try {
+        for (let i = 0; i < FUSION_TIER_LOG_BUFFER_SIZE + 5; i++) {
+          nowSpy.mockReturnValue(baseTs + i * 2_000);
+          // dedup map reset 없이도 ts gap > 1s 이므로 dedup 통과
+          // 단 첫 reset은 ring 비우니까 호출 X
+          logFusionPickerTier('gpsFallback');
+        }
+        const ring = getFusionTierLog();
+        expect(ring).toHaveLength(FUSION_TIER_LOG_BUFFER_SIZE);
+        // 가장 오래된 entry(i=0~4)가 drop됐는지: 첫 entry ts는 baseTs+5*2000 이상.
+        expect(ring[0]?.ts).toBeGreaterThanOrEqual(baseTs + 5 * 2_000);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('getFusionTierLog: 호출 시 snapshot copy 반환 (외부 변경 영향 없음)', () => {
+      logFusionPickerTier('routeResult');
+      const ring = getFusionTierLog() as FusionTierLogEntry[];
+      ring.push({ ts: 0, tier: 'gpsFallback' });
+      // 내부 ring은 외부 push에 영향 없음.
+      expect(getFusionTierLog()).toHaveLength(1);
+    });
+
+    it('_resetFusionPickerTierWindowForTests: dedup window + ring 모두 reset', () => {
+      logFusionPickerTier('positionTrain');
+      expect(getFusionTierLog()).toHaveLength(1);
+      _resetFusionPickerTierWindowForTests();
+      expect(getFusionTierLog()).toHaveLength(0);
     });
 
     it('formatFusionPickerTierDistribution: 1h 내 entries만 집계', () => {
       const nowMs = 1_700_000_000_000;
       const ONE_HOUR_MS = 60 * 60 * 1_000;
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts: nowMs - 100, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' }),
-        makeEntry({ ts: nowMs - 200, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' }),
-        makeEntry({ ts: nowMs - ONE_HOUR_MS - 1, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' }), // 1h 초과 → 제외
-        makeEntry({ ts: nowMs - 100, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-backendSsotAccepts' }),
+      const entries: FusionTierLogEntry[] = [
+        { ts: nowMs - 100, tier: 'gpsFallback' },
+        { ts: nowMs - 200, tier: 'gpsFallback' },
+        { ts: nowMs - ONE_HOUR_MS - 1, tier: 'gpsFallback' }, // 1h 초과 → 제외
+        { ts: nowMs - 100, tier: 'backendSsotAccepts' },
       ];
 
       const result = formatFusionPickerTierDistribution(entries, nowMs);
       expect(result).toContain('tier-gpsFallback=2');
       expect(result).toContain('tier-backendSsotAccepts=1');
       expect(result).not.toContain('tier-gpsFallback=3'); // stale entry 포함 X
-    });
-
-    it('formatFusionPickerTierDistribution: fusion-picker-tier 아닌 entries 무시', () => {
-      const nowMs = 1_700_000_000_000;
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts: nowMs - 100, source: 'fg', outcome: 'fired', reason: 'tier-gpsFallback' }),
-        makeEntry({ ts: nowMs - 100, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-positionTrain' }),
-      ];
-
-      const result = formatFusionPickerTierDistribution(entries, nowMs);
-      expect(result).toBe('tier-positionTrain=1');
     });
 
     it('formatFusionPickerTierDistribution: entries 없으면 (none) 반환', () => {
@@ -2640,10 +2655,10 @@ describe('alarmLog', () => {
 
     it('formatFusionPickerTierDistribution: count 내림차순 정렬', () => {
       const nowMs = 1_700_000_000_000;
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts: nowMs - 100, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-fused' }),
-        makeEntry({ ts: nowMs - 200, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' }),
-        makeEntry({ ts: nowMs - 300, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' }),
+      const entries: FusionTierLogEntry[] = [
+        { ts: nowMs - 100, tier: 'fused' },
+        { ts: nowMs - 200, tier: 'gpsFallback' },
+        { ts: nowMs - 300, tier: 'gpsFallback' },
       ];
 
       const result = formatFusionPickerTierDistribution(entries, nowMs);
@@ -2652,24 +2667,13 @@ describe('alarmLog', () => {
       expect(parts[1]).toBe('tier-fused=1');
     });
 
-    it('formatFusionPickerTierDistribution: outcome이 fired가 아닌 fusion-picker-tier entries는 무시', () => {
+    it('formatFusionPickerTierDistribution: 1h 윈도우 밖 entries만 있으면 (none)', () => {
       const nowMs = 1_700_000_000_000;
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts: nowMs - 100, source: 'fusion-picker-tier', outcome: 'suppressed', reason: 'tier-gpsFallback' }),
+      const ONE_HOUR_MS = 60 * 60 * 1_000;
+      const entries: FusionTierLogEntry[] = [
+        { ts: nowMs - ONE_HOUR_MS - 1, tier: 'gpsFallback' },
       ];
-
-      const result = formatFusionPickerTierDistribution(entries, nowMs);
-      expect(result).toBe('(none)');
-    });
-
-    it('formatFusionPickerTierDistribution: reason이 없는 fusion-picker-tier entries는 (unknown) 키로 집계', () => {
-      const nowMs = 1_700_000_000_000;
-      const entries: AlarmLogEntry[] = [
-        makeEntry({ ts: nowMs - 100, source: 'fusion-picker-tier', outcome: 'fired' }),
-      ];
-
-      const result = formatFusionPickerTierDistribution(entries, nowMs);
-      expect(result).toBe('(unknown)=1');
+      expect(formatFusionPickerTierDistribution(entries, nowMs)).toBe('(none)');
     });
   });
 });

--- a/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
+++ b/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
@@ -19,6 +19,8 @@ const mockGetRawSignalEntries = jest.fn();
 const mockForwardTripTelemetry = jest.fn();
 const mockBuildDeviceMetadata = jest.fn();
 const mockGetAlarmLog = jest.fn();
+// #1706 — fusion picker tier 별 ring buffer reader mock.
+const mockGetFusionTierLog = jest.fn();
 const mockGetFusionDebugEntries = jest.fn();
 const mockGetGpsDropEntries = jest.fn();
 const mockReadBackendSsotMirror = jest.fn();
@@ -78,6 +80,8 @@ jest.mock('../../api/telemetryForward', () => ({
 
 jest.mock('../alarmLog', () => ({
   getAlarmLog: (...args: unknown[]) => mockGetAlarmLog(...args),
+  // #1706 — 별 ring reader. test가 명시적으로 entries 주입.
+  getFusionTierLog: (...args: unknown[]) => mockGetFusionTierLog(...args),
 }));
 
 jest.mock('../../../nearest-station/utils/fusionDebugBuffer', () => ({
@@ -161,6 +165,8 @@ describe('triggerTripEndRecall', () => {
     mockBuildDeviceMetadata.mockReturnValue({ os: 'ios' });
     mockGetAlarmLog.mockReset();
     mockGetAlarmLog.mockResolvedValue([]);
+    mockGetFusionTierLog.mockReset();
+    mockGetFusionTierLog.mockReturnValue([]);
     mockGetFusionDebugEntries.mockReset();
     mockGetFusionDebugEntries.mockReturnValue([]);
     mockGetGpsDropEntries.mockReset();
@@ -538,6 +544,8 @@ describe('triggerTripEndRecall', () => {
       setupHappyPath();
       mockGetAlarmLog.mockResolvedValue([{ ts: 1, source: 'fg' }]);
       mockGetFusionDebugEntries.mockReturnValue([{ ts: 2, kind: 'cycle' }]);
+      // #1706 — 별 ring buffer entries 주입. 별 line으로 forward.
+      mockGetFusionTierLog.mockReturnValue([{ ts: 4, tier: 'gpsFallback' }]);
       mockGetGpsDropEntries.mockReturnValue([{ ts: 3 }]);
       mockReadBackendSsotMirror.mockResolvedValue({ currentStationId: '강남' });
       mockBuildDeviceMetadata.mockReturnValue({ os: 'ios', appVersion: '1.2.3' });
@@ -551,6 +559,8 @@ describe('triggerTripEndRecall', () => {
       expect(payload.tripEndedAt).toBeGreaterThanOrEqual(100);
       expect(payload.alarmLog).toEqual([{ ts: 1, source: 'fg' }]);
       expect(payload.fusionLog).toEqual([{ ts: 2, kind: 'cycle' }]);
+      // #1706 — 별 ring 채널 분리.
+      expect(payload.fusionTierLog).toEqual([{ ts: 4, tier: 'gpsFallback' }]);
       expect(payload.gpsDrops).toEqual([{ ts: 3 }]);
       expect(payload.backendSsotSnapshot).toEqual({ currentStationId: '강남' });
       expect(payload.deviceMetadata).toEqual({ os: 'ios', appVersion: '1.2.3' });

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -69,10 +69,7 @@ export type AlarmLogSource =
   //   'cross-trip-mirror-launch'   : R11-c (useLaunchTripReconciliation.ts:89, active trip 없을 때 clear)
   | 'cross-trip-mirror-register'
   | 'cross-trip-mirror-mismatch'
-  | 'cross-trip-mirror-launch'
-  // #1693 — fusion cascade picker가 어느 tier를 채택했는지 측정. tier 변화 시 1건 적재.
-  // PR #1650/#1662/#1674 효과(지하 positionTrain/GPS-derived/arvlCd tier 채택률) 검증.
-  | 'fusion-picker-tier';
+  | 'cross-trip-mirror-launch';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(#580): evaluateAlarmPhase의 firedAlarms 적중. destination/transfer phase alarm dedup
 // 발생 관찰. station-passed는 별도 메커니즘(lastNotifiedStationId)이라 'dedup-station' 사용.
@@ -230,19 +227,7 @@ export type AlarmLogReason =
   // #1656 — phase↔phase cross-station 즉시 cascade 윈도우(PHASE_TO_PHASE_CROSS_STATION_WINDOW_MS=3s)
   // 안에서 다른 station에 두 phase 알람(transfer + destination 또는 역방향)이 leg 전환 race로
   // 연이어 발사되는 회귀 차단(2026-06-20 12:32 건대+성수, 2026-06-19 15:37 이수+사당).
-  | 'dedup-phase-to-phase'
-  // #1693 — fusion cascade picker tier 채택 이름. 'fusion-picker-tier' source로 적재.
-  // PR #1650/#1662/#1674 효과(지하 positionTrain/GPS-derived/arvlCd 채택률) 검증.
-  | 'tier-positionTrainBoardingLockMatch'
-  | 'tier-gpsDerivedFastPath'
-  | 'tier-arvlCdArrivedMatch'
-  | 'tier-backendSsotAccepts'
-  | 'tier-wifiStationResolved'
-  | 'tier-positionTrain'
-  | 'tier-fused'
-  | 'tier-detectionVerdictAccepts'
-  | 'tier-routeResult'
-  | 'tier-gpsFallback';
+  | 'dedup-phase-to-phase';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -658,7 +643,11 @@ export function logCrossTripMirrorSkip(site: 'register' | 'mismatch' | 'launch')
 }
 
 /**
- * #1693 — fusion cascade picker tier 채택 1건 적재.
+ * #1693/#1706 — fusion cascade picker tier 채택 1건 적재.
+ *
+ * **별 ring buffer (#1706).** PR #1697까지는 `appendAlarmLog`로 alarmLog 200 cap에 적재했으나
+ * 1 trip에 110/137 (≈99%) 점령으로 silent-push-received/fired 같은 진짜 측정 신호가 ring
+ * 밖으로 밀려나 R2 forward에 도달 못 함. 별 200 cap ring으로 분리해 채널 오염 차단.
  *
  * tier가 변경됐을 때만 적재(dedup window 1s) — 같은 tier가 연속 폴링으로 반복 채택돼도
  * log spam 없이 tier 변화 분포만 측정한다.
@@ -688,26 +677,46 @@ export type FusionPickerTier =
   | 'routeResult'
   | 'gpsFallback';
 
+/** 별 ring buffer 엔트리 (alarmLog와 분리, #1706). */
+export interface FusionTierLogEntry {
+  ts: number;
+  tier: FusionPickerTier;
+}
+
+/** 별 ring cap. alarmLog 200과 동일 정책 — DebugModal 표시 + R2 forward 용량 한정. */
+export const FUSION_TIER_LOG_BUFFER_SIZE = 200;
+
 const FUSION_PICKER_TIER_DEDUP_MS = 1_000;
 const lastFusionPickerTierTs = new Map<string, number>();
+
+// 별 ring buffer — module-private. AsyncStorage 적재 X (in-memory only, alarmLog와 다른 정책).
+// trip 종료 시 `getFusionTierLog()` snapshot이 backend로 forward되어 R2에 archive.
+const fusionTierLog: FusionTierLogEntry[] = [];
 
 export function logFusionPickerTier(tier: FusionPickerTier): void {
   const now = Date.now();
   const last = lastFusionPickerTierTs.get(tier);
   if (last !== undefined && now - last < FUSION_PICKER_TIER_DEDUP_MS) return;
   lastFusionPickerTierTs.set(tier, now);
-  const reason: AlarmLogReason = `tier-${tier}` as AlarmLogReason;
-  appendAlarmLog({
-    ts: now,
-    source: 'fusion-picker-tier',
-    outcome: 'fired',
-    reason,
-  });
+  fusionTierLog.push({ ts: now, tier });
+  // FIFO — 가장 오래된 entry부터 drop.
+  if (fusionTierLog.length > FUSION_TIER_LOG_BUFFER_SIZE) {
+    fusionTierLog.splice(0, fusionTierLog.length - FUSION_TIER_LOG_BUFFER_SIZE);
+  }
 }
 
-/** 테스트용 — fusion picker tier dedup 윈도우 캐시 리셋. */
+/**
+ * 별 ring buffer 스냅샷 — 호출 시점 누적 entry copy.
+ * DebugModal / triggerTripEndRecall에서 사용.
+ */
+export function getFusionTierLog(): readonly FusionTierLogEntry[] {
+  return [...fusionTierLog];
+}
+
+/** 테스트용 — fusion picker tier dedup 윈도우 + ring buffer 모두 리셋. */
 export function _resetFusionPickerTierWindowForTests(): void {
   lastFusionPickerTierTs.clear();
+  fusionTierLog.length = 0;
 }
 
 /**
@@ -944,25 +953,26 @@ export function summarizeAlarmLogCounters(
 
 
 /**
- * #1693 — fusion picker tier 채택 분포 집계 (최근 1h, DebugModal Telemetry row).
+ * #1693/#1706 — fusion picker tier 채택 분포 집계 (최근 1h, DebugModal Telemetry row).
  *
- * 직전 1h의 'fusion-picker-tier' source 엔트리에서 reason(tier name) 별 count를 집계.
- * DebugModal이 "Fusion Tier (1h)" row에 표시할 문자열로 포맷해 반환한다.
+ * 직전 1h의 fusionTierLog 엔트리에서 tier 별 count를 집계. DebugModal이 "Fusion Tier (1h)"
+ * row에 표시할 문자열로 포맷해 반환한다.
  *
  * 예: "tier-positionTrainBoardingLockMatch=3, tier-gpsFallback=12"
  * 엔트리 없음 시 "(none)" 반환.
+ *
+ * **별 ring 분리 (#1706).** 입력은 `FusionTierLogEntry[]` — alarmLog ring과 채널 분리로
+ * 점령 회귀 차단.
  */
 export function formatFusionPickerTierDistribution(
-  entries: readonly AlarmLogEntry[],
+  entries: readonly FusionTierLogEntry[],
   nowMs: number = Date.now(),
 ): string {
   const ONE_HOUR_MS = 60 * 60 * 1_000;
   const counts: Record<string, number> = {};
   for (const e of entries) {
-    if (e.source !== 'fusion-picker-tier') continue;
-    if (e.outcome !== 'fired') continue;
     if (nowMs - e.ts > ONE_HOUR_MS) continue;
-    const key = e.reason ?? '(unknown)';
+    const key = `tier-${e.tier}`;
     counts[key] = (counts[key] ?? 0) + 1;
   }
   const keys = Object.keys(counts);
@@ -1004,7 +1014,6 @@ const SILENT_PUSH_OUTCOME_SOURCES: Record<AlarmLogSource, keyof SilentPushOutcom
   'cross-trip-mirror-register': null,
   'cross-trip-mirror-mismatch': null,
   'cross-trip-mirror-launch': null,
-  'fusion-picker-tier': null,
 };
 
 export interface SilentPushOutcomeCounts {

--- a/src/features/alarm/utils/triggerTripEndRecall.ts
+++ b/src/features/alarm/utils/triggerTripEndRecall.ts
@@ -53,7 +53,7 @@ import {
   buildDeviceMetadata,
   forwardTripTelemetry,
 } from '../api/telemetryForward';
-import { getAlarmLog } from './alarmLog';
+import { getAlarmLog, getFusionTierLog } from './alarmLog';
 import { getFusionDebugEntries } from '../../nearest-station/utils/fusionDebugBuffer';
 import { getGpsDropEntries } from '../../nearest-station/utils/gpsDropBuffer';
 import { readBackendSsotMirror } from './backendSsotMirror';
@@ -216,6 +216,8 @@ async function triggerAlarmLogForward(tripStart: number): Promise<void> {
       tripEndedAt: Date.now(),
       alarmLog,
       fusionLog: getFusionDebugEntries(),
+      // #1706 — fusion picker tier 별 ring buffer. alarmLog ring 점령 회귀 차단용 채널 분리.
+      fusionTierLog: getFusionTierLog(),
       gpsDrops: getGpsDropEntries(),
       backendSsotSnapshot: ssotMirror,
       deviceMetadata: buildDeviceMetadata(),

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -42,12 +42,14 @@ import {
   countSilentPushOutcomes,
   formatFusionPickerTierDistribution,
   getAlarmLog,
+  getFusionTierLog,
   summarizeAlarmLogByReason,
   summarizeAlarmLogBySource,
   summarizeAlarmLogCounters,
   type AlarmLogEntry,
   type AlarmLogReason,
   type AlarmLogReasonCounter,
+  type FusionTierLogEntry,
 } from '../../../features/alarm/utils/alarmLog';
 import {
   computeBoardingPromptMonitor,
@@ -1547,6 +1549,11 @@ function DebugModalInner({
   });
 
   const [logs, setLogs] = useState<AlarmLogEntry[]>([]);
+  // #1706 — fusion picker tier 별 ring buffer snapshot. alarmLog ring 점령 회귀 차단으로
+  // 분리된 채널 (alarmLog와 다른 200 cap). refresh 사이클에 함께 snapshot.
+  const [fusionTierLogs, setFusionTierLogs] = useState<readonly FusionTierLogEntry[]>(() =>
+    getFusionTierLog(),
+  );
   const [fusionLogs, setFusionLogs] = useState<readonly FusionDebugEntry[]>(() =>
     getFusionDebugEntries(),
   );
@@ -1607,6 +1614,9 @@ function DebugModalInner({
 
   const refreshLogs = useCallback(async () => {
     setLogs(await getAlarmLog());
+    // #1706 — fusion picker tier 별 ring buffer 동시 snapshot. AsyncStorage 없는 in-memory ring
+    // 이라 동기 read. logs와 함께 refresh되어 UI/share dump 정합성 유지.
+    setFusionTierLogs(getFusionTierLog());
   }, []);
 
   useEffect(() => {
@@ -2113,14 +2123,15 @@ function DebugModalInner({
             </Section>
           ) : null}
 
-          {/* #1693 — fusion picker tier 채택 분포 (최근 1h). PR #1650/#1662/#1674 효과 검증. */}
+          {/* #1693/#1706 — fusion picker tier 채택 분포 (최근 1h). 별 ring buffer(#1706)에서
+              직접 집계 — alarmLog ring 점령 회귀 차단. PR #1650/#1662/#1674 효과 검증. */}
           <Section title="Fusion Tier (1h)" colors={colors}>
             <Text
               style={[typography.mono, { color: colors.ink }]}
               selectable
               testID="debug-fusion-picker-tier"
             >
-              {formatFusionPickerTierDistribution(logs)}
+              {formatFusionPickerTierDistribution(fusionTierLogs)}
             </Text>
           </Section>
 

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -14,6 +14,8 @@ const mockUseArrivalInfo = jest.fn();
 const mockUseSilentPushDiagnostics = jest.fn();
 const mockGetAlarmLog = jest.fn();
 const mockClearAlarmLog = jest.fn();
+// #1706 — fusion picker tier 별 ring buffer mock. alarmLog ring과 분리된 채널.
+const mockGetFusionTierLog = jest.fn();
 const mockUseBarometer = jest.fn();
 const mockUseLowPowerMode = jest.fn();
 // #1235 (D9 wire) — DebugModal이 destinationStore + tripStartStorage SSOT로 trip props 도출.
@@ -57,6 +59,8 @@ jest.mock('../../../alarm/utils/alarmLog', () => {
     ...actual,
     getAlarmLog: () => mockGetAlarmLog(),
     clearAlarmLog: () => mockClearAlarmLog(),
+    // #1706 — 별 ring buffer reader mock. test가 명시적으로 entries 주입.
+    getFusionTierLog: () => mockGetFusionTierLog(),
   };
 });
 
@@ -183,6 +187,8 @@ const setupHookDefaults = () => {
   });
   mockGetAlarmLog.mockResolvedValue([]);
   mockClearAlarmLog.mockResolvedValue(undefined);
+  // #1706 — 별 ring 기본 빈 배열. fusion-picker-tier 테스트는 명시 주입.
+  mockGetFusionTierLog.mockReturnValue([]);
   mockDumpScheduledNotifications.mockResolvedValue([]);
   // #1215 (D9) — 기본은 subsurface=false (지상).
   mockUseBarometer.mockReturnValue({ subsurface: false, stop: undefined });
@@ -707,12 +713,13 @@ describe('DebugModal', () => {
     expect(el.props.children).toContain('fail=1');
   });
 
-  it('#1693: Fusion Tier (1h) 섹션이 tier 분포를 표시한다', async () => {
+  it('#1693/#1706: Fusion Tier (1h) 섹션이 별 ring tier 분포를 표시한다', async () => {
     const now = Date.now();
-    mockGetAlarmLog.mockResolvedValue([
-      { ts: now - 100, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' },
-      { ts: now - 200, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' },
-      { ts: now - 300, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-backendSsotAccepts' },
+    // #1706 — alarmLog ring이 아닌 fusionTierLog 별 ring에서 집계.
+    mockGetFusionTierLog.mockReturnValue([
+      { ts: now - 100, tier: 'gpsFallback' },
+      { ts: now - 200, tier: 'gpsFallback' },
+      { ts: now - 300, tier: 'backendSsotAccepts' },
     ]);
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
@@ -722,11 +729,25 @@ describe('DebugModal', () => {
     expect(tierEl.props.children).toContain('tier-backendSsotAccepts=1');
   });
 
-  it('#1693: Fusion Tier (1h) 섹션 — fusion-picker-tier 없으면 (none) 표시', async () => {
-    mockGetAlarmLog.mockResolvedValue([]);
+  it('#1693/#1706: Fusion Tier (1h) 섹션 — 별 ring 빈 경우 (none) 표시', async () => {
+    mockGetFusionTierLog.mockReturnValue([]);
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
     expect(screen.getByText('Fusion Tier (1h)')).toBeTruthy();
+    const tierEl = screen.getByTestId('debug-fusion-picker-tier');
+    expect(tierEl.props.children).toBe('(none)');
+  });
+
+  it('#1706: alarmLog에 fusion-picker-tier 들어 있어도 Fusion Tier 섹션은 별 ring만 본다', async () => {
+    const now = Date.now();
+    // 회귀 evidence: 만에 하나 stale entry가 alarmLog ring에 남아 있어도 ((과거 PR #1697 시절))
+    // 새 섹션은 별 ring만 본다. 별 ring 비어 있으면 (none).
+    mockGetAlarmLog.mockResolvedValue([
+      { ts: now - 100, source: 'fusion-picker-tier', outcome: 'fired', reason: 'tier-gpsFallback' },
+    ]);
+    mockGetFusionTierLog.mockReturnValue([]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
     const tierEl = screen.getByTestId('debug-fusion-picker-tier');
     expect(tierEl.props.children).toBe('(none)');
   });


### PR DESCRIPTION
## Summary

- PR #1697로 추가된 `logFusionPickerTier`가 `appendAlarmLog`로 alarmLog 200 cap ring 점령(6/23 trip evidence: **110/137 ≈ 99%**). 결과로 silent-push-received/fired 같은 진짜 측정 신호가 ring 밖으로 밀려나 `/admin/alarm-log-stats` R2 forward에 도달 못 함.
- **별 in-memory ring buffer `fusionTierLog` (200 cap) 도입**. `logFusionPickerTier`는 `appendAlarmLog`를 통하지 않는다 — alarmLog 채널 정합성 회복.
- backend `obj.kind !== 'alarmLog'` 필터로 fusionTierLog kind는 stats에서 자동 제외 — `alarmLogStats.ts` 변경 X.

Closes #1706

## 변경 파일

### Frontend
- `src/features/alarm/utils/alarmLog.ts`
  - `AlarmLogSource`에서 `'fusion-picker-tier'`, `AlarmLogReason`에서 `tier-*` 10개 제거 (type-level guard).
  - 별 type `FusionTierLogEntry` + module-private `fusionTierLog: FusionTierLogEntry[]`.
  - 새 export: `getFusionTierLog()` (snapshot copy), `FUSION_TIER_LOG_BUFFER_SIZE`.
  - `logFusionPickerTier`가 별 ring에 push, 1s dedup + 200 cap FIFO drop.
  - `formatFusionPickerTierDistribution` 시그니처: `FusionTierLogEntry[]`.
- `src/features/alarm/api/telemetryForward.ts`: `TelemetryForwardPayload.fusionTierLog` 별 line, `payloadIsEmpty` 포함.
- `src/features/alarm/utils/triggerTripEndRecall.ts`: `getFusionTierLog()` snapshot 전달.
- `src/features/debug/components/DebugModal.tsx`: `fusionTierLogs` state 추가 (refresh 사이클에 snapshot), Fusion Tier (1h) row가 별 ring 사용.

### Backend
- `backend/alarm-worker/src/alarmLogForward.ts`:
  - `AlarmLogForwardUpload.fusionTierLog` 필드 추가.
  - `validateAlarmLogForward`: 누락 시 기본값 `[]` 허용 (구 device 호환). 비배열/cap 초과는 reject.
  - `buildNdjsonBody`: 7 lines (`header / alarmLog / fusionLog / fusionTierLog / gpsDrops / backendSsotSnapshot / deviceMetadata`).
- `backend/alarm-worker/src/index.ts`: success log line에 `fusionTierLog: payload.fusionTierLog.length` 추가.
- `backend/alarm-worker/src/alarmLogStats.ts`: **변경 없음** — 기존 `obj.kind !== 'alarmLog'` 필터로 fusionTierLog kind 자동 제외 (별도 검증 테스트 추가).

## 테스트 fixture 개수 (추가)

| File | New tests |
| --- | --- |
| `src/features/alarm/utils/__tests__/alarmLog.test.ts` | 10 (fusion-picker-tier 섹션 전면 재작성 — 별 ring, 1s dedup, 200 cap FIFO, reader copy, reset, 1h 윈도우 등) |
| `src/features/alarm/api/__tests__/telemetryForward.test.ts` | 2 (fusionTierLog 단독 forward, 3 채널 분리) |
| `src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts` | happy path 검증에 fusionTierLog assertion 추가 |
| `src/features/debug/components/__tests__/DebugModal.test.tsx` | 3 (별 ring 분포 표시, (none), alarmLog stale entry 있어도 Fusion Tier는 별 ring만 본다) |
| `backend/alarm-worker/src/__tests__/alarmLogForward.test.ts` | 5 (valid payload fusionTierLog 보존, 미설정 default [], 비배열/cap 초과 reject, ndjson 7 lines + tierLine entries 검증) |
| `backend/alarm-worker/src/__tests__/alarmLogStats.test.ts` | 1 (fusionTierLog kind는 sources/reasons 카운터 자동 제외) |

## 5단 Wire-completion 체크

1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan). 새 export(`getFusionTierLog`, `FusionTierLogEntry`, `FUSION_TIER_LOG_BUFFER_SIZE`) caller 존재: `triggerTripEndRecall.ts`, `DebugModal.tsx`, 테스트.
2. **V/X dashboard** —
   - **DebugModal "Fusion Tier (1h)"** row: 별 ring 분포 표시 (`debug-fusion-picker-tier`).
   - **`/admin/alarm-log-stats`** sources: `silent-push-received/fired/skipped` 등 진짜 신호가 alarmLog ring에 살아남음 → ring forward R2 archive에서 `fusion-picker-tier` 0건 확인.
   - **Cloudflare Dashboard logs**: `telemetry-forward-success` log line에 새 `fusionTierLog` 카운트.
3. **의존 PR** — N/A. backend 호환성은 `validateAlarmLogForward` default `[]`로 구 device 보호.
4. **측정 plan** —
   - 1주 production: `/admin/alarm-log-stats?windowHours=24`의 `sources` 응답에서 `fusion-picker-tier` 0건 / `silent-push-received` 등 진짜 신호 카운트 회복 검증.
   - R2 archive: `trip-evidence/YYYY/MM/DD/{tokenPrefix}-{tripStartedAt}.ndjson` 7 line 중 `kind:'fusionTierLog'` line이 동일 trip ndjson 안에 분리 적재 확인 (CLI inspect).
   - DebugModal Telemetry → Fusion Tier (1h) row가 별 ring에서 분포 표시 확인.
5. **Device verify** — N/A — type+unit only. native module 영향 없음. 1주 trip dump로 baseline 측정.

## CI 체크

- `npm run type-check`: pass
- `npm run lint:orphan`: pass
- 본 PR 영역 frontend 테스트: 542/542 pass (`alarmLog.test.ts` 201, `telemetryForward.test.ts` + `DebugModal.test.tsx` 315, `triggerTripEndRecall.test.ts` 26)
- backend test: CI에서 검증 (worktree에 backend `node_modules` 없음, 권한 차단으로 로컬 install skip)