### PR TITLE
fix(#1707): destination 도달 자동 종료 시 device GPS cross-check

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -16,6 +16,10 @@ import {
   VANISH_RE_ATTACH_THRESHOLD,
   BACKEND_TRIP_LIFECYCLE_SILENCE_MS,
   BACKEND_TRIP_LIFECYCLE_FORCE_END_MS,
+  DESTINATION_GPS_CROSS_CHECK_MAX_M,
+  DESTINATION_GPS_STALE_THRESHOLD_MS,
+  evaluateDestinationCrossCheck,
+  recordDestinationCrossCheck,
   arvlCdFireKey,
   estimateArrivalFromPosition,
   estimateBoardingLockArrival,
@@ -6780,6 +6784,14 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
         boardingPrompt: 0,
         reschedule: 0,
       },
+      // #1707 — destination cross-check 결과 분포.
+      destinationCrossCheck: {
+        within: 0,
+        gpsFar: 0,
+        staleGps: 0,
+        noGps: 0,
+        stationUnknown: 0,
+      },
     };
     const { dirty } = await fireArvlCdStationPush({
       trip,
@@ -6850,3 +6862,409 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
     expect(STALE_LOCK_FIRE_THRESHOLD_MS).toBe(3 * 60 * 1000);
   });
 });
+
+// #1707 — destination 도달 자동 종료 시 device GPS cross-check.
+//
+// 검증 범위:
+//   1. evaluateDestinationCrossCheck — 5 결과 enum 분기(within / gps-far / stale-gps / no-gps / station-unknown).
+//   2. recordDestinationCrossCheck — ScheduledStats 카운터 1:1 매핑.
+//   3. runScheduled 통합 — destination kind advance 시점 cross-check 결과별 cleanup vs preserve.
+//   4. 상수값 — 500m / 5min.
+//   5. 사용자 6/23 1차 trip evidence fixture — 외선 27 hop cascade로 홍대입구 자동 종료 회귀 차단.
+//
+// 상수: DESTINATION_GPS_CROSS_CHECK_MAX_M=500m, DESTINATION_GPS_STALE_THRESHOLD_MS=5min.
+describe('evaluateDestinationCrossCheck (#1707)', () => {
+  // 홍대입구 line 2 좌표 (stations.json) — within 케이스 fixture.
+  const HONGIK_DEST: Waypoint = { stationName: '홍대입구', line: '2', kind: 'destination' };
+  // 합정 line 2 좌표 — 홍대입구와 약 1.1km. far 케이스 fixture (gps@합정 vs destination=홍대입구).
+  const HAPJEONG_LAT = 37.549457;
+  const HAPJEONG_LNG = 126.913808;
+  const HONGIK_LAT = 37.55679;
+  const HONGIK_LNG = 126.923708;
+
+  function makePoint(overrides: Partial<PositionPoint> = {}): PositionPoint {
+    return {
+      lat: HONGIK_LAT,
+      lng: HONGIK_LNG,
+      accuracy: 10,
+      ts: NOW,
+      motion: 'automotive',
+      ...overrides,
+    };
+  }
+
+  it('returns "within" when GPS ≤ 500m of destination', () => {
+    const series = [makePoint({ lat: HONGIK_LAT, lng: HONGIK_LNG })];
+    expect(evaluateDestinationCrossCheck(series, HONGIK_DEST, NOW)).toBe('within');
+  });
+
+  it('returns "gps-far" when GPS > 500m and fresh (< 5min stale)', () => {
+    const series = [makePoint({ lat: HAPJEONG_LAT, lng: HAPJEONG_LNG, ts: NOW - 30_000 })];
+    expect(evaluateDestinationCrossCheck(series, HONGIK_DEST, NOW)).toBe('gps-far');
+  });
+
+  it('returns "stale-gps" when last sample > 5min old (even if far)', () => {
+    const series = [
+      makePoint({
+        lat: HAPJEONG_LAT,
+        lng: HAPJEONG_LNG,
+        ts: NOW - DESTINATION_GPS_STALE_THRESHOLD_MS - 1,
+      }),
+    ];
+    expect(evaluateDestinationCrossCheck(series, HONGIK_DEST, NOW)).toBe('stale-gps');
+  });
+
+  it('returns "no-gps" when series is empty', () => {
+    expect(evaluateDestinationCrossCheck([], HONGIK_DEST, NOW)).toBe('no-gps');
+  });
+
+  it('returns "station-unknown" when stations.json lookup fails', () => {
+    const series = [makePoint()];
+    const unknown: Waypoint = { stationName: '없는역', line: '2', kind: 'destination' };
+    expect(evaluateDestinationCrossCheck(series, unknown, NOW)).toBe('station-unknown');
+  });
+
+  it('boundary: exactly 500m → still "within" (≤ 임계)', () => {
+    // 1 degree lat ≈ 111km → 0.0045 deg ≈ 500m. 좌표 살짝 안쪽으로 두어 ≤500m 보장.
+    const series = [makePoint({ lat: HONGIK_LAT + 0.0044, lng: HONGIK_LNG })];
+    const result = evaluateDestinationCrossCheck(series, HONGIK_DEST, NOW);
+    expect(result).toBe('within');
+  });
+
+  it('uses the most recent (last) sample, not first', () => {
+    // 첫 sample은 far, 마지막 sample은 within → within 반환되어야.
+    const series = [
+      makePoint({ lat: HAPJEONG_LAT, lng: HAPJEONG_LNG, ts: NOW - 60_000 }),
+      makePoint({ lat: HONGIK_LAT, lng: HONGIK_LNG, ts: NOW }),
+    ];
+    expect(evaluateDestinationCrossCheck(series, HONGIK_DEST, NOW)).toBe('within');
+  });
+
+  it('DESTINATION_GPS_CROSS_CHECK_MAX_M is 500m', () => {
+    expect(DESTINATION_GPS_CROSS_CHECK_MAX_M).toBe(500);
+  });
+
+  it('DESTINATION_GPS_STALE_THRESHOLD_MS is 5min', () => {
+    expect(DESTINATION_GPS_STALE_THRESHOLD_MS).toBe(5 * 60 * 1000);
+  });
+});
+
+describe('recordDestinationCrossCheck (#1707)', () => {
+  function makeEmptyStats() {
+    return {
+      destinationCrossCheck: {
+        within: 0,
+        gpsFar: 0,
+        staleGps: 0,
+        noGps: 0,
+        stationUnknown: 0,
+      },
+    };
+  }
+
+  it('increments "within" counter for within result', () => {
+    const stats = makeEmptyStats();
+    recordDestinationCrossCheck(stats, 'within');
+    expect(stats.destinationCrossCheck.within).toBe(1);
+    expect(stats.destinationCrossCheck.gpsFar).toBe(0);
+  });
+
+  it('increments "gpsFar" counter for gps-far result', () => {
+    const stats = makeEmptyStats();
+    recordDestinationCrossCheck(stats, 'gps-far');
+    expect(stats.destinationCrossCheck.gpsFar).toBe(1);
+  });
+
+  it('increments "staleGps" counter for stale-gps result', () => {
+    const stats = makeEmptyStats();
+    recordDestinationCrossCheck(stats, 'stale-gps');
+    expect(stats.destinationCrossCheck.staleGps).toBe(1);
+  });
+
+  it('increments "noGps" counter for no-gps result', () => {
+    const stats = makeEmptyStats();
+    recordDestinationCrossCheck(stats, 'no-gps');
+    expect(stats.destinationCrossCheck.noGps).toBe(1);
+  });
+
+  it('increments "stationUnknown" counter for station-unknown result', () => {
+    const stats = makeEmptyStats();
+    recordDestinationCrossCheck(stats, 'station-unknown');
+    expect(stats.destinationCrossCheck.stationUnknown).toBe(1);
+  });
+
+  it('accumulates over multiple calls', () => {
+    const stats = makeEmptyStats();
+    recordDestinationCrossCheck(stats, 'within');
+    recordDestinationCrossCheck(stats, 'within');
+    recordDestinationCrossCheck(stats, 'gps-far');
+    expect(stats.destinationCrossCheck.within).toBe(2);
+    expect(stats.destinationCrossCheck.gpsFar).toBe(1);
+  });
+});
+
+// 통합: destination kind advance 시점 cross-check 결과별 cleanup vs preserve.
+// 사용자 6/23 trip(성수→합정 2호선 외선)을 직접 fixture로 재현해 회귀 차단을 검증한다.
+describe('runScheduled — #1707 destination GPS cross-check integration', () => {
+  /**
+   * 6/23 trip fixture: 합정(line 2) destination, lock active, ARRIVED arvlCd=1로 cleanup 분기 진입.
+   * series는 호출자가 fixture에서 KV에 직접 seed (테스트마다 좌표/ts 다름).
+   */
+  function makeHapjeongDestTrip(token: string): Trip {
+    return makeTrip({
+      token,
+      route: { type: 'direct', line: '2', stops: 1 },
+      destination: '2-038', // 합정 station id (stations.json)
+      waypoints: [{ stationName: '합정', line: '2', kind: 'destination' }],
+      activityPushToken: 'la-token',
+      activityState: 'live',
+      apnsEnv: 'sandbox',
+      boardingLock: {
+        trainCode: 'T',
+        line: '2',
+        subwayId: '1002',
+        selectedDepartureTime: NOW,
+        segmentStations: ['홍대입구', '합정'],
+        expiresAt: NOW + 60 * 60_000,
+      },
+    });
+  }
+
+  function makeHapjeongArrivedSeoul(): SeoulArrivalClient {
+    return new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () =>
+        new Response(
+          JSON.stringify({
+            realtimeArrivalList: [
+              {
+                barvlDt: '0',
+                recptnDt: '',
+                updnLine: '내선',
+                trainLineNm: '합정',
+                btrainNo: 'T',
+                subwayNm: '지하철2호선',
+                arvlCd: 1, // ARRIVED → advanceBoardingLockWaypoint → destination cleanup 분기
+              },
+            ],
+          }),
+          { status: 200 },
+        )) as unknown as typeof fetch,
+    });
+  }
+
+  /**
+   * 6/23 trip evidence fixture — 사용자가 신촌 부근(GPS far)에 있을 때 backend가 합정 도달로 잘못
+   * 판정하면 trip 보존되어야 한다.
+   *   - GPS 좌표: 신촌 부근 (~합정에서 약 1.3km 떨어짐)
+   *   - GPS ts: fresh (NOW - 30s)
+   *   - 결과: 'gps-far' → trip preserved → KV에 trip 잔존 + stats.destinationCrossCheck.gpsFar = 1
+   */
+  it('preserves trip when device GPS is far (>500m) and fresh — 6/23 사용자 trip 회귀 차단', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeHapjeongDestTrip('user-6-23-tok');
+    await putTrip(kv as unknown as KVNamespace, trip);
+    // 신촌 부근 좌표 (37.5552, 126.9368) — 합정(37.549457, 126.913808)에서 약 1.3km. fresh 30s.
+    await kv.put(
+      `pos:${trip.token}`,
+      JSON.stringify([
+        {
+          lat: 37.5552,
+          lng: 126.9368,
+          accuracy: 15,
+          ts: NOW - 30_000,
+          motion: 'automotive',
+        },
+      ]),
+    );
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeHapjeongArrivedSeoul(),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    // trip 보존 — KV에 잔존.
+    expect(await kv.get(`trip:${trip.token}`)).not.toBeNull();
+    // cross-check 카운터 누적.
+    expect(stats.destinationCrossCheck.gpsFar).toBe(1);
+    expect(stats.destinationCrossCheck.within).toBe(0);
+    // cleanup 미발생 — trip-ended push 없음.
+    const calls = fetchImpl.mock.calls as unknown as [string, RequestInit][];
+    const tripEndedCalls = calls.filter((c) => {
+      try {
+        const body = JSON.parse(c[1]?.body as string) as { data?: { reason?: string } };
+        return body?.data?.reason === 'destination-arrived';
+      } catch {
+        return false;
+      }
+    });
+    expect(tripEndedCalls).toHaveLength(0);
+  });
+
+  /**
+   * GPS 500m 이내 + waypoints=0 → 정상 cleanup. 사용자가 실제로 합정에 도착한 happy path.
+   */
+  it('cleans up normally when device GPS is within 500m of destination', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeHapjeongDestTrip('user-happy-tok');
+    await putTrip(kv as unknown as KVNamespace, trip);
+    // 합정 거의 정확한 좌표 (37.549, 126.9138) — 약 50m.
+    await kv.put(
+      `pos:${trip.token}`,
+      JSON.stringify([
+        {
+          lat: 37.549,
+          lng: 126.9138,
+          accuracy: 10,
+          ts: NOW - 10_000,
+          motion: 'automotive',
+        },
+      ]),
+    );
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeHapjeongArrivedSeoul(),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    // trip 삭제됨.
+    expect(await kv.get(`trip:${trip.token}`)).toBeNull();
+    // cross-check 카운터 누적 (within).
+    expect(stats.destinationCrossCheck.within).toBe(1);
+    expect(stats.destinationCrossCheck.gpsFar).toBe(0);
+  });
+
+  /**
+   * Stale GPS (>5min) → conservative cleanup. backend가 device GPS에 종속되면 안 됨.
+   */
+  it('cleans up normally when last GPS upload is stale (>5min) — conservative behavior preserved', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeHapjeongDestTrip('user-stale-tok');
+    await putTrip(kv as unknown as KVNamespace, trip);
+    // 5분 + 1ms 이전 GPS — stale-gps.
+    await kv.put(
+      `pos:${trip.token}`,
+      JSON.stringify([
+        {
+          lat: 37.5552, // 신촌 (far) — stale이라 거리는 무관.
+          lng: 126.9368,
+          accuracy: 15,
+          ts: NOW - DESTINATION_GPS_STALE_THRESHOLD_MS - 1,
+          motion: 'automotive',
+        },
+      ]),
+    );
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeHapjeongArrivedSeoul(),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    // stale → cleanup 진행.
+    expect(await kv.get(`trip:${trip.token}`)).toBeNull();
+    expect(stats.destinationCrossCheck.staleGps).toBe(1);
+    expect(stats.destinationCrossCheck.gpsFar).toBe(0);
+  });
+
+  /**
+   * Position series 없음 (legacy / boardingPrompt-only trip 등) → conservative cleanup.
+   */
+  it('cleans up normally when no position series exists (legacy graceful)', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeHapjeongDestTrip('user-no-gps-tok');
+    await putTrip(kv as unknown as KVNamespace, trip);
+    // pos:${token} 미설정 — series 빈 배열.
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeHapjeongArrivedSeoul(),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(await kv.get(`trip:${trip.token}`)).toBeNull();
+    expect(stats.destinationCrossCheck.noGps).toBe(1);
+  });
+
+  /**
+   * Last-intermediate effective-destination cleanup도 동일 cross-check 적용. trip.waypoints.length === 1
+   * 이고 advance가 발생하면 cleanup 분기 진입 — gps-far면 trip 보존.
+   */
+  it('preserves trip on last-intermediate effective-destination when GPS far', async () => {
+    const kv = new InMemoryKV();
+    // 마지막 intermediate(홍대입구) 도착 → waypoints=[]로 cleanup 분기.
+    const trip = makeTrip({
+      token: 'last-intermediate-tok',
+      route: { type: 'direct', line: '2', stops: 1 },
+      destination: '2-039', // 홍대입구 line 2 id
+      waypoints: [{ stationName: '홍대입구', line: '2', kind: 'intermediate' }],
+      activityPushToken: 'la-token',
+      activityState: 'live',
+      apnsEnv: 'sandbox',
+      boardingLock: {
+        trainCode: 'T',
+        line: '2',
+        subwayId: '1002',
+        selectedDepartureTime: NOW,
+        segmentStations: ['신촌', '홍대입구'],
+        expiresAt: NOW + 60 * 60_000,
+      },
+    });
+    await putTrip(kv as unknown as KVNamespace, trip);
+    // GPS@신촌 부근, destination=홍대입구 → ~1.4km far + fresh.
+    await kv.put(
+      `pos:${trip.token}`,
+      JSON.stringify([
+        {
+          lat: 37.5552,
+          lng: 126.9368,
+          accuracy: 15,
+          ts: NOW - 30_000,
+          motion: 'automotive',
+        },
+      ]),
+    );
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () =>
+        new Response(
+          JSON.stringify({
+            realtimeArrivalList: [
+              {
+                barvlDt: '0',
+                recptnDt: '',
+                updnLine: '내선',
+                trainLineNm: '홍대입구',
+                btrainNo: 'T',
+                subwayNm: '지하철2호선',
+                arvlCd: 1, // ARRIVED
+              },
+            ],
+          }),
+          { status: 200 },
+        )) as unknown as typeof fetch,
+    });
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    // trip 보존 — KV에 잔존.
+    expect(await kv.get(`trip:${trip.token}`)).not.toBeNull();
+    expect(stats.destinationCrossCheck.gpsFar).toBe(1);
+  });
+});
+

--- a/backend/alarm-worker/src/__tests__/stationsLookup.test.ts
+++ b/backend/alarm-worker/src/__tests__/stationsLookup.test.ts
@@ -1,0 +1,42 @@
+/**
+ * #1707 — Backend stationsLookup adapter 단위 테스트.
+ *
+ * 검증 범위:
+ *   1. 알려진 (name, line) → 좌표 반환 (lat/lng 형태 검증).
+ *   2. 미존재 (name, line) → null.
+ *   3. canonical fallback (alias name) — shared findStationByNameAndLine 동작 위임 검증.
+ */
+import { describe, expect, it } from 'vitest';
+import { findStationCoordsByNameAndLine } from '../stationsLookup';
+
+describe('findStationCoordsByNameAndLine (#1707)', () => {
+  it('returns coords for known (stationName, line) pair', () => {
+    const coords = findStationCoordsByNameAndLine('합정', '2');
+    expect(coords).not.toBeNull();
+    expect(typeof coords?.lat).toBe('number');
+    expect(typeof coords?.lng).toBe('number');
+    // 합정 line 2 (stations.json: 37.549457, 126.913808). 정밀 비교는 stations.json drift에
+    // 약함 — type/finite 검증으로 충분 (canonicalStationName 룰 정합).
+    expect(Number.isFinite(coords?.lat)).toBe(true);
+    expect(Number.isFinite(coords?.lng)).toBe(true);
+  });
+
+  it('returns null for unknown station name', () => {
+    const coords = findStationCoordsByNameAndLine('없는역이름', '2');
+    expect(coords).toBeNull();
+  });
+
+  it('returns null for known name but wrong line (no overlap)', () => {
+    // 합정은 line 2 / 6에 있음. 1호선 합정은 없음.
+    const coords = findStationCoordsByNameAndLine('합정', '1');
+    expect(coords).toBeNull();
+  });
+
+  it('returns only {lat, lng} shape (좁힌 StationCoord 형태)', () => {
+    const coords = findStationCoordsByNameAndLine('홍대입구', '2');
+    expect(coords).not.toBeNull();
+    if (coords !== null) {
+      expect(Object.keys(coords).sort()).toEqual(['lat', 'lng']);
+    }
+  });
+});

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -57,9 +57,11 @@ import {
 } from './tripPositionSsot';
 import {
   evaluateWindow,
+  haversineKm,
   readSeries,
   type WindowedMetrics,
 } from './positionSeries';
+import { findStationCoordsByNameAndLine } from './stationsLookup';
 import { assertCronCacheTtl } from './kvConsistency';
 import { buildAlarmKey, putPending } from './pendingPushes';
 import { deleteProgress, getProgress, putProgress, type TripProgress } from './progress';
@@ -163,6 +165,89 @@ export const SUBSURFACE_ETA_MISSING_TOLERANCE = 10;
  */
 export const BACKEND_TRIP_LIFECYCLE_SILENCE_MS = 6 * 60 * 60 * 1000;
 export const BACKEND_TRIP_LIFECYCLE_FORCE_END_MS = 9 * 60 * 60 * 1000;
+
+/**
+ * #1707 — destination 도달 자동 종료 시 device GPS cross-check 임계.
+ *
+ * 배경: backend vanish-fallback이 1.5분/hop pace로 cascade(`FALLBACK_HOP_SEC=90s`)되면 외선
+ * 우회 27 hop trip이 약 27~40분 만에 destination 도달 신호를 만들어 사용자 trip이 실제 도달
+ * 전에 자동 종료될 수 있다 (2026-06-23 13:35 사용자 1차 trip evidence: 성수→합정 외선 우회를
+ * 14:07 홍대입구에서 강제 종료).
+ *
+ * 정책:
+ *   - DESTINATION_GPS_CROSS_CHECK_MAX_M (500m): GPS 좌표와 destination 좌표 차이 ≤ 이 값이면
+ *     정상 종료. 도시 한 역 반경 + GPS accuracy 여유.
+ *   - DESTINATION_GPS_STALE_THRESHOLD_MS (5min): 마지막 position upload가 이 값보다 오래되면
+ *     "device GPS 자체가 없음"으로 간주해 기존 동작(정상 종료) 유지. backend가 device GPS
+ *     loss에 종속되면 안 됨 — graceful.
+ *
+ * fallback: GPS far(>500m) + fresh(<5min) → trip 보존 + force-end 9h auto-end로 이관.
+ *   force-end는 `tripLifecyclePhase` 9h 백스톱이 처리한다 (`BACKEND_TRIP_LIFECYCLE_FORCE_END_MS`).
+ */
+export const DESTINATION_GPS_CROSS_CHECK_MAX_M = 500;
+export const DESTINATION_GPS_STALE_THRESHOLD_MS = 5 * 60 * 1000;
+
+/** #1707 destination GPS cross-check 결과. log/stats에 1:1로 매핑. */
+export type DestinationCrossCheckResult =
+  | 'within' // GPS 좌표 ≤ 500m → 정상 종료
+  | 'gps-far' // GPS 좌표 > 500m (fresh) → trip 보존 + force-end 위임
+  | 'stale-gps' // 마지막 GPS upload > 5min stale → 정상 종료 (graceful)
+  | 'no-gps' // device GPS upload 자체 없음 → 정상 종료 (legacy graceful)
+  | 'station-unknown'; // stations.json lookup fail → 정상 종료 (conservative)
+
+/**
+ * #1707 — destination 도달 cross-check.
+ *
+ * cleanupTripWithLa('destination-arrived') 호출 직전 device GPS 좌표와 destination station
+ * 좌표 거리를 verify한다. 결과는 호출자에게 enum으로 반환 — 'gps-far'만 trip 보존, 나머지는
+ * 모두 정상 종료.
+ *
+ * 입력 series는 KV에서 호출자가 read해 전달 (테스트 격리 + 호출자 cycle 내 series read 재사용).
+ *
+ * @param series device positionSeries (KV `pos:${token}`)
+ * @param waypoint destination kind waypoint (stationName + line으로 stations.json lookup)
+ * @param now 현재 epoch ms
+ */
+export function evaluateDestinationCrossCheck(
+  series: readonly PositionPoint[],
+  waypoint: Waypoint,
+  now: number,
+): DestinationCrossCheckResult {
+  if (series.length === 0) return 'no-gps';
+  // 마지막 sample 기준 — 시간순 정렬 가정(append-only).
+  const last = series[series.length - 1];
+  const ageMs = now - last.ts;
+  if (ageMs > DESTINATION_GPS_STALE_THRESHOLD_MS) return 'stale-gps';
+  const coords = findStationCoordsByNameAndLine(waypoint.stationName, waypoint.line);
+  if (coords === null) return 'station-unknown';
+  const distanceM = haversineKm(last.lat, last.lng, coords.lat, coords.lng) * 1000;
+  if (distanceM <= DESTINATION_GPS_CROSS_CHECK_MAX_M) return 'within';
+  return 'gps-far';
+}
+
+/** #1707 — cross-check 결과를 ScheduledStats.destinationCrossCheck 카운터에 누적. */
+export function recordDestinationCrossCheck(
+  stats: Pick<ScheduledStats, 'destinationCrossCheck'>,
+  result: DestinationCrossCheckResult,
+): void {
+  switch (result) {
+    case 'within':
+      stats.destinationCrossCheck.within += 1;
+      return;
+    case 'gps-far':
+      stats.destinationCrossCheck.gpsFar += 1;
+      return;
+    case 'stale-gps':
+      stats.destinationCrossCheck.staleGps += 1;
+      return;
+    case 'no-gps':
+      stats.destinationCrossCheck.noGps += 1;
+      return;
+    case 'station-unknown':
+      stats.destinationCrossCheck.stationUnknown += 1;
+      return;
+  }
+}
 
 /**
  * #1680 (V8d) — cron 사이클에서 stationary skip 여부 결정.
@@ -573,6 +658,25 @@ export interface ScheduledStats extends LiveActivityStats {
     boardingPrompt: number;
     reschedule: number;
   };
+  /**
+   * #1707 — destination 도달 자동 종료 시 device GPS cross-check 결과 분포.
+   *
+   * - `within`         : GPS 좌표 ≤ 500m → 정상 종료
+   * - `gpsFar`         : GPS 좌표 > 500m (fresh) → trip 보존 + force-end 9h 위임 (회귀 차단 누적)
+   * - `staleGps`       : 마지막 GPS upload > 5min stale → 정상 종료 (graceful)
+   * - `noGps`          : device GPS upload 자체 없음 → 정상 종료 (legacy graceful)
+   * - `stationUnknown` : stations.json lookup fail → 정상 종료 (conservative)
+   *
+   * 정상 운영에서 `gpsFar` > 0이면 backend가 destination 도달을 잘못 판정한 케이스가 그만큼
+   * 있었다는 신호 = 회귀 차단 발동. cron tail로 1주 측정.
+   */
+  destinationCrossCheck: {
+    within: number;
+    gpsFar: number;
+    staleGps: number;
+    noGps: number;
+    stationUnknown: number;
+  };
 }
 
 /**
@@ -687,6 +791,14 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       destination: 0,
       boardingPrompt: 0,
       reschedule: 0,
+    },
+    // #1707 — destination 도달 cross-check 결과 분포 (회귀 차단 측정).
+    destinationCrossCheck: {
+      within: 0,
+      gpsFar: 0,
+      staleGps: 0,
+      noGps: 0,
+      stationUnknown: 0,
     },
   };
   // #1539 (S6) — cron jitter 즉시 log. 누적 stat이 아니라 매 cycle 1줄 → tail에서 P50/P99 산출.
@@ -2324,6 +2436,37 @@ export async function advanceBoardingLockWaypoint(
     });
   }
 
+  // #1707 — destination 자동 종료 전 device GPS cross-check.
+  // 본 advance가 trip을 cleanup으로 이끄는지 판정 (destination kind 또는 마지막 intermediate).
+  // 둘 다 동일 cross-check 정책: device GPS가 destination 좌표 ≤500m면 정상 종료, >500m이고
+  // GPS fresh면 trip 보존 + 9h force-end 위임. stale/no-gps/station-unknown은 정상 종료.
+  // backend hop-time fallback cascade(1.5분/hop)가 외선 우회 27 hop trip을 약 27~40분 만에
+  // destination 도달로 잘못 판정하던 회귀(2026-06-23 13:35 성수→합정 trip 14:07 홍대입구
+  // 자동 종료 evidence)를 차단한다.
+  const isCleanupAdvance =
+    waypoint.kind === 'destination' || trip.waypoints.length === 1;
+  if (isCleanupAdvance) {
+    const series = await readSeries(env.TRIPS, trip.token);
+    const crossCheck = evaluateDestinationCrossCheck(series, waypoint, now);
+    recordDestinationCrossCheck(stats, crossCheck);
+    log('boarding-lock: destination cross-check', {
+      token: trip.token.slice(0, 8),
+      station: waypoint.stationName,
+      kind: waypoint.kind,
+      result: crossCheck,
+    });
+    if (crossCheck === 'gps-far') {
+      // trip 보존 — advance 자체를 abort. trip.waypoints 미변동 → 다음 cycle 재평가 진입.
+      // 9h 도달 시 `tripLifecyclePhase`의 force-end 가 자연 cleanup (legacy 안전망).
+      log('boarding-lock: cleanup deferred (gps-far)', {
+        token: trip.token.slice(0, 8),
+        station: waypoint.stationName,
+        kind: waypoint.kind,
+      });
+      return;
+    }
+  }
+
   if (waypoint.kind === 'destination') {
     // #868 — destination 도착으로 trip 종료. 클라 state sync용 trip-ended silent push 발사.
     await cleanupTripWithLa(trip, env, deps, stats, now, log, 'destination-arrived');
@@ -2446,6 +2589,9 @@ export async function advanceBoardingLockWaypoint(
   });
   if (trip.waypoints.length === 0) {
     // #868 — waypoints 소진(intermediate 마지막 통과)도 effective destination-arrived.
+    // #1707 — 본 분기 진입 전 상단 isCleanupAdvance 게이트가 cross-check 완료. gps-far 케이스는
+    // 이미 early return으로 차단됐다. 여기 도달 = within / stale-gps / no-gps / station-unknown
+    // 중 하나 = 정상 cleanup 진행.
     await cleanupTripWithLa(trip, env, deps, stats, now, log, 'destination-arrived');
     // ADR-017 T5 (#1558) — trip 종료 시 SSoT cleanup.
     await deleteSsot(env.TRIPS, trip.token);

--- a/backend/alarm-worker/src/stationsLookup.ts
+++ b/backend/alarm-worker/src/stationsLookup.ts
@@ -1,0 +1,42 @@
+/**
+ * #1707 — Backend stations.json 좌표 lookup adapter.
+ *
+ * Backend는 자체 stations.json을 갖지 않는 정책 (types.ts L187/L399 주석 참조)이지만,
+ * destination 도달 자동 종료 시 device GPS cross-check를 위해 destination station 좌표가 필요하다.
+ * 직접 import 대신 shared `findStationByNameAndLine`을 backend adapter로 wrap해 device-shared
+ * stations.json을 단일 SSoT로 활용한다 (#1604 `dijkstraRoute.ts`와 같은 패턴).
+ *
+ * 사용처: `scheduled.ts` `advanceBoardingLockWaypoint` destination 분기 +
+ *         lockless intermediate destination 분기에서 마지막 device position 좌표와
+ *         destination station 좌표 distance 계산.
+ *
+ * Backend가 frontend shared를 import하는 패턴은 [[lesson_backend_imports_frontend_shared]] 참조.
+ * tsconfig include로 shared file 직접 컴파일.
+ */
+import { findStationByNameAndLine } from '../../../src/shared/utils/stationLookup';
+import type { LineNumber } from './types';
+
+/** Station 좌표 (좌표만 필요한 호출자가 전체 Station 객체에 의존하지 않도록 좁힌 shape). */
+export interface StationCoord {
+  lat: number;
+  lng: number;
+}
+
+/**
+ * (stationName, line) → 좌표 lookup. shared `findStationByNameAndLine` 재사용 (canonical
+ * fallback 포함, #1405). 매치 없으면 null — 호출자가 graceful skip.
+ *
+ * backend `LineNumber = string`이지만 shared lookup은 union LineNumber를 받음 — string
+ * 호환성 보장(런타임 비교는 `===`). cast로 타입 시스템 경계만 통과.
+ */
+export function findStationCoordsByNameAndLine(
+  name: string,
+  line: LineNumber,
+): StationCoord | null {
+  const station = findStationByNameAndLine(
+    name,
+    line as Parameters<typeof findStationByNameAndLine>[1],
+  );
+  if (station === null) return null;
+  return { lat: station.lat, lng: station.lng };
+}


### PR DESCRIPTION
Closes #1707

## 문제 (사용자 6/23 1차 trip evidence)

backend `vanish-fallback` advance가 1.5분/hop pace로 cascade (`FALLBACK_HOP_SEC=90s`)되면 외선 우회 27 hop trip이 약 27~40분 만에 `cleanupTripWithLa('destination-arrived')`까지 도달해 trip이 자동 종료됨.

- 13:35 사용자 1차 trip 등록 (성수→합정 2호선 외선)
- 14:07 backend `boarding-lock: waypoint advanced completed=홍대입구 remaining=0` → `cleanupTripWithLa('destination-arrived')` 종료
- 사용자 실제 위치: 신촌/홍대 부근 ↔ destination=합정 (도달 안 함)
- 사용자 trip이 사용자 가치 손실로 종료

## Fix

`advanceBoardingLockWaypoint`에서 trip을 cleanup으로 이끄는 advance(`waypoint.kind==='destination'` 또는 `trip.waypoints.length===1`) 진입 시 device `positionSeries` 마지막 좌표와 destination station 좌표 거리를 verify.

- 5단 enum 결과 (`evaluateDestinationCrossCheck`):
  - `within` (≤500m): 정상 종료
  - `gps-far` (>500m, fresh): **trip 보존** + 9h `force-end` 위임 (회귀 차단)
  - `stale-gps` (>5min stale): 정상 종료 (graceful, GPS 종속 회피)
  - `no-gps` (series 부재): 정상 종료 (legacy graceful)
  - `station-unknown` (stations.json lookup fail): 정상 종료 (conservative)
- backend `stationsLookup` 어댑터 추가 — device shared `findStationByNameAndLine` 재사용 (`dijkstraRoute.ts`와 같은 패턴, `tsconfig` include 활용).
- `ScheduledStats.destinationCrossCheck` 분포 카운터 추가 — 5 결과 1:1 매핑, `scheduled run complete` 로그에 `...stats` spread로 forward.
- 임계: `DESTINATION_GPS_CROSS_CHECK_MAX_M=500m` / `DESTINATION_GPS_STALE_THRESHOLD_MS=5min`.

## Acceptance

- [x] GPS 500m 이내 + waypoints=0 → 정상 종료 (within 카운터)
- [x] GPS far (5km+) → trip 보존 + force-end deferred (gpsFar 카운터)
- [x] Stale GPS (>5min) → conservative 종료 허용 (staleGps 카운터)
- [x] backend `scheduled.test.ts`에 GPS cross-check fixture 추가 (20개 신규 케이스, 사용자 6/23 trip evidence 재현 포함)
- [ ] 사용자 6/23 1차 trip 재현 시 홍대입구 자동 종료 회귀 0건 (device evidence 기반 측정)

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass. `stationsLookup.findStationCoordsByNameAndLine` / `evaluateDestinationCrossCheck` / `recordDestinationCrossCheck` 모두 caller 존재.
2. **V/X dashboard** — `ScheduledStats.destinationCrossCheck` 카운터가 `scheduled run complete` 로그에 spread → wrangler tail / Cloudflare Dashboard에서 5 결과 분포 직접 관측. `gpsFar > 0`이면 회귀 차단 발동 = 측정 가능 신호.
3. **의존 PR** — N/A
4. **측정 plan** — 1주간 `destinationCrossCheck.gpsFar` 카운터 추적. 사용자 6/23 trip 같은 외선 cascade trip이 재발하면 본 카운터에 누적되며 device evidence(`tripEnded` reason 미수신)로 cross-check.
5. **Device verify** — N/A (backend type+unit only). 다만 device 측에선 trip이 보존되면 trip-ended push 없이 사용자가 직접 종료 또는 9h force-end로 자연 회수되며, 별도 device-side 변경은 불필요.

## 테스트

- `backend/alarm-worker/src/__tests__/scheduled.test.ts` — `evaluateDestinationCrossCheck` 8건, `recordDestinationCrossCheck` 6건, `runScheduled` 통합 6건 (사용자 6/23 trip 재현 포함). 2025/2025 pass.
- `backend/alarm-worker/src/__tests__/stationsLookup.test.ts` — 4건 (known coord / unknown name / wrong line / shape).
- backend type-check + 전체 테스트(54 files / 2025 tests) ALL GREEN.

## 회귀 차단 동작 흐름

1. 27 hop fallback cascade 진행 중 — vanish-fallback이 매 cycle station-passed push 발사 + SSoT advance.
2. 마지막 hop 도달 → `advanceBoardingLockWaypoint`가 cleanup 분기 진입.
3. 본 PR cross-check: GPS@신촌(약 1km) vs destination=합정 → `gps-far` → cleanup deferred + `gpsFar` 카운터 누적 + log `cleanup deferred (gps-far)`.
4. trip은 KV에 잔존 → 사용자가 실제 합정 도달 시 GPS within → 다음 cycle에 within으로 정상 종료. 또는 9h force-end로 자연 회수.