### PR TITLE
fix(#1705): SSoT mirror schema에 currentStationLine 추가 — cross-line confusion 차단

### DIFF
--- a/backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts
+++ b/backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts
@@ -1202,3 +1202,126 @@ describe('advanceTripPosition — gate #7 position-train jump/stale (#1665)', ()
     expect(out.result).toBe('advanced');
   });
 });
+
+// #1705 (A1/A3-b) — candidateStationLine stamp.
+describe('advanceTripPosition — candidateStationLine stamp (#1705)', () => {
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  it('options.candidateStationLine 지정 시 advanced 결과의 SSoT.currentStationLine 으로 stamp', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산', { line: '7' });
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: makeLock() }));
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence(),
+      { gatePassed: true, lockAttachable: true, candidateStationLine: '7' },
+    );
+    expect(out.result).toBe('advanced');
+    const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    expect(after?.currentStationLine).toBe('7');
+  });
+
+  it('options.candidateStationLine 미지정 시 currentStationLine 변경 X (기존 값 보존)', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산', { line: '7' });
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: makeLock() }));
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence(),
+      { gatePassed: true, lockAttachable: true },
+    );
+    expect(out.result).toBe('advanced');
+    const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    // 이전 seed line('7')이 보존됨 (caller가 line 미전달이라도 기존 값 유지)
+    expect(after?.currentStationLine).toBe('7');
+  });
+
+  it('legacy v1 SSoT (currentStationLine 부재) + candidateStationLine 지정 → 신규 line stamp', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산'); // line 미지정
+    expect(ssot.currentStationLine).toBeUndefined();
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: makeLock() }));
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence(),
+      { gatePassed: true, lockAttachable: true, candidateStationLine: '7' },
+    );
+    expect(out.result).toBe('advanced');
+    const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    expect(after?.currentStationLine).toBe('7');
+  });
+
+  it('blocked 시 SSoT mutate X (currentStationLine 변경 안 됨)', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산', { line: '7' });
+    ssot.motionState = 'stationary'; // motion 게이트 차단
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: makeLock() }));
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence(),
+      { gatePassed: true, lockAttachable: true, candidateStationLine: '2' },
+    );
+    expect(out.result).toBe('blocked');
+    const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    // 기존 '7' 보존 (candidateStationLine '2' 가 무시됨)
+    expect(after?.currentStationLine).toBe('7');
+  });
+});
+
+// #1705 (A1/A3-b) — toSilentPushSsot currentStationLine forward.
+describe('toSilentPushSsot — currentStationLine forward (#1705)', () => {
+  it('currentStationLine 정의 시 payload 에 forward', async () => {
+    const { toSilentPushSsot } = await import('../scheduled');
+    const ssot: TripPositionSSoT = {
+      tripToken: 't',
+      currentStationId: '용마산',
+      currentStationLine: '7',
+      motionState: 'moving',
+      motionEvidence: [],
+      lastAdvanceAt: 0,
+      lastAdvanceEvidence: 'arvlcd-confirmed-train',
+      passedStations: [],
+      userIntentDeclared: false,
+      seedOverrideCount: 0,
+      schemaVersion: 1,
+    };
+    const payload = toSilentPushSsot(ssot);
+    expect(payload?.currentStationLine).toBe('7');
+  });
+
+  it('currentStationLine 미정의(legacy v1) 시 payload 에 omit', async () => {
+    const { toSilentPushSsot } = await import('../scheduled');
+    const ssot: TripPositionSSoT = {
+      tripToken: 't',
+      currentStationId: '용마산',
+      motionState: 'moving',
+      motionEvidence: [],
+      lastAdvanceAt: 0,
+      lastAdvanceEvidence: 'arvlcd-confirmed-train',
+      passedStations: [],
+      userIntentDeclared: false,
+      seedOverrideCount: 0,
+      schemaVersion: 1,
+    };
+    const payload = toSilentPushSsot(ssot);
+    expect(payload?.currentStationLine).toBeUndefined();
+  });
+});

--- a/backend/alarm-worker/src/__tests__/transferDestinationGate.test.ts
+++ b/backend/alarm-worker/src/__tests__/transferDestinationGate.test.ts
@@ -5,6 +5,7 @@ import {
   evaluateTransferDestinationGate,
   isAtOrApproachingTransferDestination,
   isSsotAdvanceRecent,
+  isSsotLineMatchingWaypoint,
   isTransferOrDestination,
   type TransferDestinationBlockReason,
 } from '../transferDestinationGate';
@@ -224,5 +225,78 @@ describe('evaluateTransferDestinationGate', () => {
     const outcome = evaluateTransferDestinationGate(ssot, trip, waypoint, NOW);
     expect(outcome.pass).toBe(false);
     expect(outcome.blockReason).toBe('ssot-not-at-or-approaching');
+  });
+});
+
+// #1705 (A1/A3-b) — currentStationLine cross-check 단위 + 통합.
+describe('isSsotLineMatchingWaypoint (#1705)', () => {
+  it('currentStationLine 미정의(legacy v1) → 무조건 true (dormant)', () => {
+    expect(
+      isSsotLineMatchingWaypoint(
+        { currentStationLine: undefined },
+        { line: '2' },
+      ),
+    ).toBe(true);
+  });
+
+  it('waypoint.line 비어 있음 → 무조건 true (보수적 dormant)', () => {
+    expect(
+      isSsotLineMatchingWaypoint(
+        { currentStationLine: '2' },
+        { line: '' },
+      ),
+    ).toBe(true);
+  });
+
+  it('line 정합 → true', () => {
+    expect(
+      isSsotLineMatchingWaypoint(
+        { currentStationLine: '2' },
+        { line: '2' },
+      ),
+    ).toBe(true);
+  });
+
+  it('line 불일치 → false (cross-line confusion 차단)', () => {
+    // 사용자 2026-06-23 evidence: 2호선 trip 에 7호선 "어린이대공원(세종대)" mislabel.
+    expect(
+      isSsotLineMatchingWaypoint(
+        { currentStationLine: '7' },
+        { line: '2' },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('evaluateTransferDestinationGate — line cross-check (#1705)', () => {
+  it('SSoT 정합 + line 정합 + 신선 → pass', () => {
+    const ssot = makeSsot({ currentStationLine: '2' });
+    const trip = makeTrip();
+    const waypoint = makeWaypoint({ line: '2' });
+    expect(evaluateTransferDestinationGate(ssot, trip, waypoint, NOW).pass).toBe(true);
+  });
+
+  it('SSoT 정합 + line 불일치 → block(ssot-line-mismatch)', () => {
+    // 사용자 2026-06-23 evidence: 6호선 trip 인데 SSoT currentStationLine=6, waypoint.line=6 정합.
+    // 반대 케이스: backend 가 wrong line stamp → device 가 잘못된 waypoint trigger → 본 게이트가 차단.
+    const ssot = makeSsot({
+      currentStationId: '봉화산(서울의료원)',
+      currentStationLine: '7', // backend 가 잘못된 line stamp (cross-line confusion 시뮬)
+    });
+    const trip = makeTrip();
+    const waypoint = makeWaypoint({
+      stationName: '봉화산(서울의료원)',
+      line: '6', // device 의 trip line
+    });
+    const outcome = evaluateTransferDestinationGate(ssot, trip, waypoint, NOW);
+    expect(outcome.pass).toBe(false);
+    expect(outcome.blockReason).toBe('ssot-line-mismatch');
+  });
+
+  it('legacy v1 SSoT (currentStationLine 부재) → line 검증 dormant, 기존 동작 그대로', () => {
+    const ssot = makeSsot({ currentStationLine: undefined });
+    const trip = makeTrip();
+    const waypoint = makeWaypoint({ line: '2' });
+    expect(evaluateTransferDestinationGate(ssot, trip, waypoint, NOW).pass).toBe(true);
   });
 });

--- a/backend/alarm-worker/src/__tests__/tripPositionSsot.test.ts
+++ b/backend/alarm-worker/src/__tests__/tripPositionSsot.test.ts
@@ -422,3 +422,39 @@ describe('alarmEvents helpers (#1572 T9)', () => {
     ]);
   });
 });
+
+// #1705 (A1/A3-b) — currentStationLine stamp + round-trip + legacy v1 graceful fallback.
+describe('tripPositionSsot — currentStationLine (#1705 A1/A3-b)', () => {
+  it('seedSsot: options.line 지정 시 currentStationLine 으로 stamp', async () => {
+    const kv = new InMemoryKV();
+    const ssot = await seedSsot(kv as unknown as KVNamespace, 'tok', '용마산', {
+      line: '7',
+    });
+    expect(ssot.currentStationLine).toBe('7');
+    const persisted = await readSsot(kv as unknown as KVNamespace, 'tok');
+    expect(persisted?.currentStationLine).toBe('7');
+  });
+
+  it('seedSsot: options.line 미지정 시 currentStationLine 부재 (legacy v1 호환)', async () => {
+    const kv = new InMemoryKV();
+    const ssot = await seedSsot(kv as unknown as KVNamespace, 'tok', '용마산');
+    expect(ssot.currentStationLine).toBeUndefined();
+  });
+
+  it('writeSsot → readSsot round-trip: currentStationLine 보존', async () => {
+    const kv = new InMemoryKV();
+    const ssot = makeSsot({ currentStationLine: '2' });
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    const got = await readSsot(kv as unknown as KVNamespace, ssot.tripToken);
+    expect(got?.currentStationLine).toBe('2');
+  });
+
+  it('legacy v1 row read: currentStationLine 부재 → undefined (graceful)', async () => {
+    const kv = new InMemoryKV();
+    const ssot = makeSsot(); // currentStationLine 미지정
+    expect(ssot.currentStationLine).toBeUndefined();
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    const got = await readSsot(kv as unknown as KVNamespace, ssot.tripToken);
+    expect(got?.currentStationLine).toBeUndefined();
+  });
+});

--- a/backend/alarm-worker/src/advanceTripPosition.ts
+++ b/backend/alarm-worker/src/advanceTripPosition.ts
@@ -66,7 +66,7 @@ import {
   type TripPositionSSoT,
 } from './tripPositionSsot';
 import { getTrip } from './trips';
-import type { BoardingLockMeta, Trip } from './types';
+import type { BoardingLockMeta, LineNumber, Trip } from './types';
 
 /**
  * Evidence environment — device가 upload하는 좁은 set.
@@ -360,6 +360,9 @@ export function lookupStationFromWifiSsid(
  * @param evidence advance 후보 evidence (1건).
  * @param options.gatePassed 외부 9단 AND 게이트 결과 (caller가 stamp). 미stamp 시 false.
  * @param options.lockAttachable `pickAutoTrainCode` 단일 수렴 여부. caller stamp.
+ * @param options.candidateStationLine `waypoint.line` — advance 통과 시 SSoT.currentStationLine 으로 stamp.
+ *   (#1705 A1/A3-b) device cascade picker 가 동명역 cross-line confusion 차단을 위해 사용. 미지정 시
+ *   currentStationLine 누락 (legacy v1 schema 호환, device 는 name-only fallback).
  *
  * blocked 시 SSoT는 mutate 하지 않음. 'noop'은 현재 게이트에서 발생하지 않지만 향후 reader
  * migration이 idempotent advance(이미 같은 stationId)를 'noop'으로 처리할 수 있는 type slot.
@@ -369,7 +372,16 @@ export async function advanceTripPosition(
   token: string,
   candidateStationId: string,
   evidence: AdvanceEvidence,
-  options: { gatePassed: boolean; lockAttachable: boolean },
+  options: {
+    gatePassed: boolean;
+    lockAttachable: boolean;
+    /**
+     * #1705 (A1/A3-b) — advance 통과 시 SSoT.currentStationLine 에 stamp 할 line.
+     * caller(scheduled.ts fire path)는 `waypoint.line` 을 forward. undefined 면 stamp 누락
+     * (legacy v1 schema 호환).
+     */
+    candidateStationLine?: LineNumber;
+  },
 ): Promise<AdvanceOutcome> {
   const ssot = await readSsot(kv, token);
 
@@ -462,6 +474,10 @@ export async function advanceTripPosition(
     ...ssot,
     passedStations: appendUnique(ssot.passedStations, ssot.currentStationId),
     currentStationId: candidateStationId,
+    // #1705 (A1/A3-b) — candidateStationLine 이 주어지면 stamp. 미지정 시 기존 값 보존 (구 caller 호환).
+    ...(options.candidateStationLine !== undefined
+      ? { currentStationLine: options.candidateStationLine }
+      : {}),
     lastAdvanceAt: evidence.ts,
     lastAdvanceEvidence: evidence.type,
     // alarmEvents는 ssot에서 inherit — 아래 appendAlarmEvent로 in-place mutate.

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -10,6 +10,7 @@ import type { AlarmPhase } from './alarm';
 import { TRIP_ENDED_ALERT_BODY, TRIP_ENDED_ALERT_TITLE } from './alertContent';
 import type {
   BoardingPromptPushPayload,
+  LineNumber,
   RescheduleChannel,
   ReschedulePushPayload,
   TripEndedAlertPushPayload,
@@ -175,6 +176,12 @@ export interface SilentPushPayload {
 export interface SilentPushSsotPayload {
   /** 현재 device가 위치한다고 backend가 확신하는 stationId(또는 stationName 호환). */
   currentStationId: string;
+  /**
+   * #1705 (A1/A3-b) — currentStationId 의 노선 metadata. device cascade picker 가 `findStationByNameAndLine`
+   * 으로 동명역/cross-line confusion 차단에 사용. backend v2 schema 부터 stamp; legacy v1 row 호환
+   * 위해 optional — 부재 시 device 는 기존 name-only fallback 으로 동작 (graceful).
+   */
+  currentStationLine?: LineNumber;
   /** backend SSoT motion state — `'moving'` | `'stationary'` | `'unknown'`. */
   motionState: 'moving' | 'stationary' | 'unknown';
   /** 마지막 advance를 통과시킨 evidence type 표시 — device 진단/cascade tier 보조 판단용. */
@@ -359,6 +366,11 @@ export async function sendSilentPush(options: SendPushOptions): Promise<SendPush
         : {
             ssot: {
               currentStationId: options.payload.ssot.currentStationId,
+              // #1705 (A1/A3-b) — currentStationLine 정의된 경우에만 wire (cross-line confusion 차단).
+              // 부재 시 JSON serializer 가 omit → device 는 name-only fallback (legacy v1 호환).
+              ...(options.payload.ssot.currentStationLine === undefined
+                ? {}
+                : { currentStationLine: options.payload.ssot.currentStationLine }),
               motionState: options.payload.ssot.motionState,
               lastAdvanceEvidence: options.payload.ssot.lastAdvanceEvidence,
               lastAdvanceAt: options.payload.ssot.lastAdvanceAt,

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -1194,6 +1194,12 @@ export function toSilentPushSsot(
   if (ssot == null) return undefined;
   return {
     currentStationId: ssot.currentStationId,
+    // #1705 (A1/A3-b) — currentStationLine forward (cross-line confusion 차단). 부재 시 wire 자연
+    // 누락 (apns.ts JSON serializer는 undefined 필드 omit) — device 는 legacy v1 row 처럼 name-only
+    // fallback 으로 동작 (graceful, backward-compat).
+    ...(ssot.currentStationLine !== undefined
+      ? { currentStationLine: ssot.currentStationLine }
+      : {}),
     motionState: ssot.motionState,
     lastAdvanceEvidence: ssot.lastAdvanceEvidence,
     lastAdvanceAt: ssot.lastAdvanceAt,
@@ -1508,10 +1514,13 @@ async function tryAdvanceAndFireArvlcd(inputs: {
     // device upload로 motion 갱신을 시작하면 게이트 #2가 자동 활성화.
     ssot = await seedSsot(env.TRIPS, trip.token, waypoint.stationName, {
       expiresAt: trip.expiresAt,
+      // #1705 (A1/A3-b) — currentStationLine stamp (cross-line confusion 차단).
+      line: waypoint.line,
     });
     log('arvlcd-fire: lazy-seed ssot', {
       token: trip.token.slice(0, 8),
       currentStationId: waypoint.stationName,
+      currentStationLine: waypoint.line,
     });
   }
   // ADR-017 T7 (#1560) — transfer/destination kind 발사 직전 추가 SSoT 일관성 검증.
@@ -1553,6 +1562,8 @@ async function tryAdvanceAndFireArvlcd(inputs: {
       // 검증. lock 활성 trip에서 lockAttachable 단일 trainCode 수렴은 lock 부착 자체가 증거.
       gatePassed: true,
       lockAttachable: true,
+      // #1705 (A1/A3-b) — currentStationLine stamp (cross-line confusion 차단).
+      candidateStationLine: waypoint.line,
     },
   );
   if (outcome.result !== 'advanced') {
@@ -2278,10 +2289,13 @@ export async function advanceBoardingLockWaypoint(
     if (existingSsot === null) {
       await seedSsot(env.TRIPS, trip.token, waypoint.stationName, {
         expiresAt: trip.expiresAt,
+        // #1705 (A1/A3-b) — currentStationLine stamp (cross-line confusion 차단).
+        line: waypoint.line,
       });
       log('boarding-lock: lazy-seed ssot for waypoint advance', {
         token: trip.token.slice(0, 8),
         currentStationId: waypoint.stationName,
+        currentStationLine: waypoint.line,
       });
     }
     const outcome = await advanceTripPosition(
@@ -2293,6 +2307,8 @@ export async function advanceBoardingLockWaypoint(
         // lock 활성 = base 합의 surrogate (T4 `tryAdvanceAndFireArvlcd` 와 같은 정책).
         gatePassed: true,
         lockAttachable: trip.boardingLock !== undefined,
+        // #1705 (A1/A3-b) — currentStationLine stamp (cross-line confusion 차단).
+        candidateStationLine: waypoint.line,
       },
     );
     if (outcome.result !== 'advanced') {

--- a/backend/alarm-worker/src/transferDestinationGate.ts
+++ b/backend/alarm-worker/src/transferDestinationGate.ts
@@ -48,10 +48,15 @@ export const TRANSFER_DESTINATION_FRESH_WINDOW_MS = 60_000;
  * legacy/lazy-seed 직후)은 본 게이트가 dormant로 통과시킨다 — T4 motion 게이트의 'unknown' 통과
  * 정책과 동일 ([[advanceTripPosition.ts]] #2 게이트). 본 게이트가 stationary advance와 짝을 이루는
  * defense-in-depth이지 legacy 경로 차단 게이트가 아니기 때문.
+ *
+ * #1705 (A1/A3-b) — 'ssot-line-mismatch'는 ssot.currentStationLine 이 정의됐고 waypoint.line 과
+ * 일치하지 않는 경우. 동명역(합정 2-038/6-013, 공덕 5-020/6-017) cross-line confusion 차단. legacy
+ * v1 row 는 currentStationLine 미정의 → dormant (graceful, 기존 name-only 비교 그대로).
  */
 export type TransferDestinationBlockReason =
   | 'ssot-not-at-or-approaching'
-  | 'ssot-stale';
+  | 'ssot-stale'
+  | 'ssot-line-mismatch';
 
 export interface TransferDestinationGateOutcome {
   pass: boolean;
@@ -95,6 +100,22 @@ export function isAtOrApproachingTransferDestination(
 }
 
 /**
+ * #1705 (A1/A3-b) — SSoT.currentStationLine 이 waypoint.line 과 정합한지.
+ *
+ * currentStationLine 이 정의된 v2 schema 에 한해 적용. legacy v1 row (currentStationLine 미정의)
+ * 는 dormant 통과 — graceful, 기존 name-only 비교 그대로. waypoint 의 line 이 비어 있으면
+ * 비교 불능 → dormant 통과 (보수적).
+ */
+export function isSsotLineMatchingWaypoint(
+  ssot: Pick<TripPositionSSoT, 'currentStationLine'>,
+  waypoint: Pick<Waypoint, 'line'>,
+): boolean {
+  if (ssot.currentStationLine === undefined) return true;
+  if (!waypoint.line) return true;
+  return ssot.currentStationLine === waypoint.line;
+}
+
+/**
  * SSoT.lastAdvanceAt이 신선(`now - lastAdvanceAt <= TRANSFER_DESTINATION_FRESH_WINDOW_MS`) 한지.
  *
  * lastAdvanceAt===0(미 advance, lazy-seed 직후)은 dormant 분기로 true 반환 — T4 motion 게이트가
@@ -119,13 +140,18 @@ export function isSsotAdvanceRecent(
  * @param now epoch ms.
  */
 export function evaluateTransferDestinationGate(
-  ssot: Pick<TripPositionSSoT, 'currentStationId' | 'lastAdvanceAt'>,
+  ssot: Pick<TripPositionSSoT, 'currentStationId' | 'currentStationLine' | 'lastAdvanceAt'>,
   trip: Pick<Trip, 'passedStations'>,
-  waypoint: Pick<Waypoint, 'stationName' | 'kind'>,
+  waypoint: Pick<Waypoint, 'stationName' | 'line' | 'kind'>,
   now: number,
 ): TransferDestinationGateOutcome {
   if (!isAtOrApproachingTransferDestination(ssot, trip, waypoint)) {
     return { pass: false, blockReason: 'ssot-not-at-or-approaching' };
+  }
+  // #1705 (A1/A3-b) — currentStationLine 정의된 v2 row 에 한해 cross-line confusion 차단.
+  // 동명역(어린이대공원 2/7호선, 합정 2/6, 공덕 5/6) 발사 직전 line 정합 검증.
+  if (!isSsotLineMatchingWaypoint(ssot, waypoint)) {
+    return { pass: false, blockReason: 'ssot-line-mismatch' };
   }
   if (!isSsotAdvanceRecent(ssot, now)) {
     return { pass: false, blockReason: 'ssot-stale' };

--- a/backend/alarm-worker/src/tripPositionSsot.ts
+++ b/backend/alarm-worker/src/tripPositionSsot.ts
@@ -34,7 +34,7 @@
  */
 
 import { assertKvCacheTtl, CRON_READ_CACHE_TTL_SEC } from './kvConsistency';
-import type { Trip } from './types';
+import type { LineNumber, Trip } from './types';
 
 /**
  * Motion evidence ring buffer cap. KV row 크기 폭주 방지 (단일 row ≤25MB CF KV 한도 대비
@@ -201,6 +201,24 @@ export interface TripPositionSSoT {
    * 본 필드가 빈 문자열인 동안 advance 게이트 #1(no-seed)이 blocked로 차단해 fire를 막는다.
    */
   currentStationId: string;
+  /**
+   * #1705 (A1/A3-b) — currentStationId의 노선 metadata. 동명역/cross-line confusion 차단.
+   *
+   * 배경: `currentStationId`는 실제로 한글 stationName(예: "어린이대공원(세종대)")으로 저장된다.
+   * 같은 stationName을 여러 노선이 공유하거나(합정 2-038/6-013, 공덕 5-020/6-017) 다른 노선에 동명
+   * stationName이 존재해 device cascade picker가 wrong line의 station을 채택하는 회귀가 발생했다
+   * (사용자 2026-06-23 trip evidence: 2호선 trip 중 7호선 "어린이대공원(세종대)"; 6호선 trip 중
+   * "봉화산(서울의료원)" → "신내역 도착" mislabel).
+   *
+   * v2 schema (#1705)부터 `seedSsot`/`advanceTripPosition`이 본 필드를 stamp한다 (`waypoint.line` 사용).
+   * 본 필드는 silent push payload `currentStationLine`으로 forward되어 device cascade picker가
+   * `findStationByNameAndLine(currentStationId, currentStationLine)`로 정확 매칭한다.
+   *
+   * 구 backend 호환 (legacy v1 row graceful fallback) — KV에 적재된 구 row는 본 필드가 부재.
+   * 본 필드가 undefined인 경우 device는 기존 name-only fallback(`findStationByName`)으로 동작 (graceful).
+   * 본 필드와 candidate waypoint의 line이 모두 정의됐을 때만 cross-line 가드가 활성화된다.
+   */
+  currentStationLine?: LineNumber;
   /** 게이트 #2 입력. T3 motion state machine이 갱신. */
   motionState: MotionState;
   /** T3가 누적하는 ring buffer (cap 50). 최신 evidence가 마지막 index. */
@@ -309,12 +327,25 @@ export async function deleteSsot(kv: KVNamespace, token: string): Promise<void> 
  * trip을 등록할 때 backend는 빈 stationId로 seed하고, /position upload + 후속 advance 수렴으로
  * lockSuggestion을 추론한다. advance 게이트 #1(no-seed)가 빈 stationId를 blocked로 차단해
  * 그 동안 fire는 자연 보류된다.
+ *
+ * #1705 (A1/A3-b) — `options.line` 으로 currentStationLine 을 stamp 한다. caller(scheduled.ts의 fire
+ * path)는 `waypoint.line` 을 forward 해 동명역 cross-line confusion 을 차단한다. 미지정 시
+ * `currentStationLine` 은 undefined (legacy v1 row graceful fallback) — device cascade picker는 기존
+ * name-only fallback 으로 동작한다.
  */
 export async function seedSsot(
   kv: KVNamespace,
   token: string,
   currentStationId: string,
-  options?: { expiresAt?: number; userIntentDeclared?: boolean },
+  options?: {
+    expiresAt?: number;
+    userIntentDeclared?: boolean;
+    /**
+     * #1705 (A1/A3-b) — currentStationId 의 노선 metadata. caller 는 `waypoint.line` 을 그대로 전달.
+     * undefined 면 legacy v1 schema 와 호환 (graceful, device 는 name-only fallback).
+     */
+    line?: LineNumber;
+  },
 ): Promise<TripPositionSSoT> {
   const ssot: TripPositionSSoT = {
     tripToken: token,
@@ -329,6 +360,7 @@ export async function seedSsot(
     seedOverrideCount: 0,
     alarmEvents: [],
     schemaVersion: 1,
+    ...(options?.line !== undefined ? { currentStationLine: options.line } : {}),
   };
   await writeSsot(kv, ssot, { expiresAt: options?.expiresAt });
   return ssot;

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -822,6 +822,50 @@ describe('silentPushTask', () => {
         );
         expect(result).toMatchObject({ ssot: { passedStations: [] } });
       });
+
+      // #1705 (A1/A3-b) — currentStationLine wire 흡수.
+      it('currentStationLine 정의된 v2 payload → 그대로 forward', () => {
+        const result = extractPayload(
+          bgTaskData({
+            nextWaypoint: 'A',
+            etaSeconds: 0,
+            phase: 'imminent',
+            ssot: { ...validSsotInput, currentStationLine: '7' },
+          }),
+        );
+        expect(result).toMatchObject({ ssot: { currentStationLine: '7' } });
+      });
+
+      it('currentStationLine 부재 → forward omit (legacy v1 graceful)', () => {
+        const result = extractPayload(
+          bgTaskData({
+            nextWaypoint: 'A',
+            etaSeconds: 0,
+            phase: 'imminent',
+            ssot: validSsotInput,
+          }),
+        );
+        // 본체는 wire 됐으나 currentStationLine 은 omit
+        expect((result as { ssot?: { currentStationLine?: unknown } }).ssot?.currentStationLine).toBeUndefined();
+      });
+
+      it.each([
+        ['empty string', ''],
+        ['non-string number', 7],
+        ['non-string null', null],
+      ])('currentStationLine 형식 mismatch %s → omit (graceful, 본체 wire)', (_label, badLine) => {
+        const result = extractPayload(
+          bgTaskData({
+            nextWaypoint: 'A',
+            etaSeconds: 0,
+            phase: 'imminent',
+            ssot: { ...validSsotInput, currentStationLine: badLine },
+          }),
+        );
+        expect((result as { ssot?: { currentStationLine?: unknown } }).ssot?.currentStationLine).toBeUndefined();
+        // 본체 살아있음 확인
+        expect((result as { ssot?: { currentStationId?: string } }).ssot?.currentStationId).toBe('강남');
+      });
     });
 
     // #725 — reschedule schema는 standard와 다르므로 별도 분기 검증.
@@ -3406,6 +3450,31 @@ describe('silentPushTask', () => {
       expect(validSsotMirror(undefined)).toBeUndefined();
       expect(validSsotMirror('string')).toBeUndefined();
       expect(validSsotMirror(123)).toBeUndefined();
+    });
+
+    // #1705 (A1/A3-b) — validSsotMirror currentStationLine narrow.
+    describe('currentStationLine narrow (#1705)', () => {
+      it('valid currentStationLine string → forward', () => {
+        const result = validSsotMirror({ ...validSsot, currentStationLine: '7' });
+        expect(result?.currentStationLine).toBe('7');
+      });
+
+      it('currentStationLine 부재 → undefined (legacy v1 graceful)', () => {
+        const result = validSsotMirror(validSsot);
+        expect(result?.currentStationLine).toBeUndefined();
+        expect(result?.currentStationId).toBe('강남'); // 본체 살아있음
+      });
+
+      it.each([
+        ['empty string', ''],
+        ['non-string number', 7],
+        ['non-string null', null],
+        ['non-string object', { id: '7' }],
+      ])('형식 mismatch %s → currentStationLine omit (graceful, 본체 살아있음)', (_label, badLine) => {
+        const result = validSsotMirror({ ...validSsot, currentStationLine: badLine });
+        expect(result?.currentStationLine).toBeUndefined();
+        expect(result?.currentStationId).toBe('강남');
+      });
     });
 
     // #1572 (T9, ADR-017) — Path E SSoT 게이트 통합 acceptance.

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -435,13 +435,27 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
 export function validSsotMirror(value: unknown): SilentPushSsotMirror | undefined {
   if (value == null || typeof value !== 'object') return undefined;
   const obj = value as Record<string, unknown>;
-  const { currentStationId, motionState, lastAdvanceEvidence, lastAdvanceAt, passedStations, alarmEvents } = obj;
+  const {
+    currentStationId,
+    currentStationLine,
+    motionState,
+    lastAdvanceEvidence,
+    lastAdvanceAt,
+    passedStations,
+    alarmEvents,
+  } = obj;
   if (typeof currentStationId !== 'string' || currentStationId.length === 0) return undefined;
   if (motionState !== 'moving' && motionState !== 'stationary' && motionState !== 'unknown') {
     return undefined;
   }
   if (typeof lastAdvanceEvidence !== 'string' || lastAdvanceEvidence.length === 0) return undefined;
   if (typeof lastAdvanceAt !== 'number' || !Number.isFinite(lastAdvanceAt)) return undefined;
+  // #1705 (A1/A3-b) — currentStationLine optional narrow. 형식 mismatch 시 graceful drop (legacy v1
+  // row 와 동일 처리). 본체 mirror 는 살아 있음. caller(cascade picker) 는 line 부재 시 name-only
+  // fallback 으로 동작.
+  const line = typeof currentStationLine === 'string' && currentStationLine.length > 0
+    ? (currentStationLine as LineNumber)
+    : undefined;
   const passed: string[] = [];
   if (Array.isArray(passedStations)) {
     for (const p of passedStations) {
@@ -454,6 +468,7 @@ export function validSsotMirror(value: unknown): SilentPushSsotMirror | undefine
   const events = parseAlarmEventsMirror(alarmEvents);
   return {
     currentStationId,
+    ...(line !== undefined ? { currentStationLine: line } : {}),
     motionState,
     lastAdvanceEvidence,
     lastAdvanceAt,

--- a/src/features/alarm/utils/__tests__/backendSsotMirror.test.ts
+++ b/src/features/alarm/utils/__tests__/backendSsotMirror.test.ts
@@ -233,3 +233,80 @@ describe('persistBackendSsotMirror (#1568 T8b)', () => {
     );
   });
 });
+
+// #1705 (A1/A3-b) — readBackendSsotMirror currentStationLine parse.
+describe('readBackendSsotMirror currentStationLine parse (#1705)', () => {
+  const baseEntry = {
+    currentStationId: '용마산',
+    motionState: 'moving',
+    lastAdvanceEvidence: 'arvlcd-confirmed-train',
+    lastAdvanceAt: 1_700_000_000_000,
+    passedStations: ['중곡'],
+    receivedAt: 1_700_000_010_000,
+  };
+
+  beforeEach(() => {
+    mockGetItem.mockReset();
+  });
+
+  it('valid currentStationLine forward 시 결과에 포함 (v2 schema)', async () => {
+    mockGetItem.mockResolvedValue(
+      JSON.stringify({ ...baseEntry, currentStationLine: '7' }),
+    );
+    const got = await readBackendSsotMirror();
+    expect(got?.currentStationLine).toBe('7');
+  });
+
+  it('currentStationLine 부재 → undefined (legacy v1 row graceful)', async () => {
+    mockGetItem.mockResolvedValue(JSON.stringify(baseEntry));
+    const got = await readBackendSsotMirror();
+    expect(got?.currentStationLine).toBeUndefined();
+    // 본체 mirror entry 는 살아 있음
+    expect(got?.currentStationId).toBe('용마산');
+  });
+
+  it.each([
+    ['empty string', ''],
+    ['non-string number', 7],
+    ['non-string null', null],
+    ['non-string object', { id: '7' }],
+  ])('형식 mismatch %s → currentStationLine 누락 (graceful, 본체 살아있음)', async (_label, badLine) => {
+    mockGetItem.mockResolvedValue(
+      JSON.stringify({ ...baseEntry, currentStationLine: badLine }),
+    );
+    const got = await readBackendSsotMirror();
+    expect(got?.currentStationLine).toBeUndefined();
+    expect(got?.currentStationId).toBe('용마산');
+  });
+});
+
+// #1705 (A1/A3-b) — persistBackendSsotMirror 에 currentStationLine 까지 round-trip.
+describe('persistBackendSsotMirror currentStationLine round-trip (#1705)', () => {
+  beforeEach(() => {
+    mockSetItem.mockReset();
+    mockGetItem.mockReset();
+  });
+
+  it('v2 mirror persist → read 시 currentStationLine 보존', async () => {
+    mockSetItem.mockResolvedValue(undefined);
+    let stored = '';
+    mockSetItem.mockImplementation(async (_key: string, value: string) => {
+      stored = value;
+    });
+    await persistBackendSsotMirror(
+      {
+        currentStationId: '용마산',
+        currentStationLine: '7',
+        motionState: 'moving',
+        lastAdvanceEvidence: 'arvlcd-confirmed-train',
+        lastAdvanceAt: 1_700_000_000_000,
+        passedStations: ['중곡'],
+      },
+      1_700_000_010_000,
+    );
+    expect(stored).toContain('"currentStationLine":"7"');
+    mockGetItem.mockResolvedValue(stored);
+    const got = await readBackendSsotMirror();
+    expect(got?.currentStationLine).toBe('7');
+  });
+});

--- a/src/features/alarm/utils/backendSsotMirror.ts
+++ b/src/features/alarm/utils/backendSsotMirror.ts
@@ -12,6 +12,7 @@
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { BACKEND_SSOT_MIRROR_KEY } from '../../../shared/constants/storageKeys';
+import type { LineNumber } from '../../../shared/types/station';
 
 /**
  * #1534 (S1, T9b, ADR-016) — backend가 추론한 lock 제안 (device 측 mirror schema).
@@ -58,6 +59,16 @@ export interface AlarmEventMirror {
  */
 export interface SilentPushSsotMirror {
   currentStationId: string;
+  /**
+   * #1705 (A1/A3-b) — currentStationId 의 노선 metadata. device cascade picker 가
+   * `findStationByNameAndLine(currentStationId, currentStationLine)` 으로 동명역/cross-line
+   * confusion 을 차단한다 (사용자 2026-06-23 trip: 2호선 trip 에 7호선 "어린이대공원(세종대)" /
+   * 6호선 trip 에 "신내역 도착" mislabel evidence).
+   *
+   * legacy v1 row (backend v2 schema 적용 전, 또는 부재 시) 호환 위해 optional — 부재 시 device
+   * cascade picker 는 기존 name-only fallback (`findStationByName`) 로 동작 (graceful).
+   */
+  currentStationLine?: LineNumber;
   motionState: 'moving' | 'stationary' | 'unknown';
   lastAdvanceEvidence: string;
   lastAdvanceAt: number;
@@ -140,8 +151,15 @@ export async function readBackendSsotMirror(): Promise<BackendSsotMirrorEntry | 
     // #1572 (T9) — alarmEvents parse (optional). 부재/형식 mismatch entry는 graceful drop —
     // 잔여만 채택 (passedStations와 동일 패턴).
     const alarmEvents = parseAlarmEventsMirror(parsed.alarmEvents);
+    // #1705 (A1/A3-b) — currentStationLine parse (optional). 비-string/빈 문자열은 graceful drop
+    // (legacy v1 row 와 동일 처리). 본체 mirror entry 는 살아 있음.
+    const line =
+      typeof parsed.currentStationLine === 'string' && parsed.currentStationLine.length > 0
+        ? (parsed.currentStationLine as LineNumber)
+        : undefined;
     return {
       currentStationId: parsed.currentStationId,
+      ...(line !== undefined ? { currentStationLine: line } : {}),
       motionState: parsed.motionState,
       lastAdvanceEvidence: parsed.lastAdvanceEvidence,
       lastAdvanceAt: parsed.lastAdvanceAt,

--- a/src/features/nearest-station/api/positionUpload.ts
+++ b/src/features/nearest-station/api/positionUpload.ts
@@ -288,6 +288,11 @@ export async function persistFromPositionResponse(
   if (currentStationId.length === 0) return;
   const mirror: SilentPushSsotMirror = {
     currentStationId,
+    // #1705 (A1/A3-b) — lockSuggestion.lineId 가 있으면 currentStationLine 으로 stamp (cross-line
+    // confusion 차단). lockSuggestion 부재 시 omit (legacy v1 row 와 동일 처리, graceful).
+    ...(body.lockSuggestion?.lineId
+      ? { currentStationLine: body.lockSuggestion.lineId as SilentPushSsotMirror['currentStationLine'] }
+      : {}),
     motionState: 'unknown',
     lastAdvanceEvidence: 'seed-override',
     lastAdvanceAt: body.lockSuggestion?.decidedAt ?? 0,

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.backendSsotCascade.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.backendSsotCascade.test.ts
@@ -240,6 +240,123 @@ describe('#1568 (T8b) cascade picker — backend-ssot tier', () => {
   });
 });
 
+// #1705 (A1/A3-b) — cascade picker currentStationLine cross-check.
+//
+// 사용자 2026-06-23 trip evidence: backend SSoT currentStationId 가 한글 stationName 으로 저장돼
+// 동명역/cross-line confusion 발생 (2호선 trip 에 7호선 "어린이대공원(세종대)" 채택 / 6호선 trip 에
+// "신내역 도착" mislabel). 본 fix 는 backend v2 SSoT 가 currentStationLine 을 forward 하면 device
+// cascade picker 가 line cross-check 으로 wrong line station 채택을 거부하게 한다.
+describe('#1705 cascade picker — currentStationLine cross-line confusion guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(T0);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const flushSsotRead = flushBackendSsotMirrorTick;
+
+  it('lockless trip + mirror line 정의 + 일치 → 정확한 line 으로 채택', async () => {
+    setupBaselineGpsAt('청담');
+    mockRead.mockResolvedValue(
+      makeMirror({
+        currentStationId: yongmasan.name,
+        currentStationLine: '7',
+      }),
+    );
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushSsotRead();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+    expect(hook.result.current.result?.station.id).toBe(yongmasan.id);
+    expect(hook.result.current.result?.station.line).toBe('7');
+  });
+
+  it('lockless trip + mirror line 미정의(legacy v1) → name-only fallback (기존 동작)', async () => {
+    // legacy v1 row: currentStationLine 부재 → 기존 findStationByName fallback 으로 동작.
+    setupBaselineGpsAt('청담');
+    mockRead.mockResolvedValue(
+      makeMirror({
+        currentStationId: yongmasan.name,
+        // currentStationLine 미지정 = legacy v1 row
+      }),
+    );
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushSsotRead();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+    // findStationByName 이 첫 매칭 line 반환 — 용마산은 7호선 단독이라 7로 resolve.
+    expect(hook.result.current.result?.station.id).toBe(yongmasan.id);
+  });
+
+  it('lock 활성 trip(line 2) + mirror line 6 (cross-line confusion) → 채택 거부', async () => {
+    // 사용자 evidence 재현: lock=2호선, backend SSoT 가 wrong line=6 으로 forward.
+    // 동명역 "어린이대공원(세종대)" (2호선 동대문역사문화공원 부근 또는 7호선 어린이대공원) 같은 케이스.
+    // device 는 line cross-check 으로 채택 거부 → wifi/positionTrain/fused 등 device tier fallback.
+    setupBaselineGpsAt('청담');
+    const lockOnLine2: BoardingLock = {
+      destinationId: 'dest-2',
+      trainCode: 'T-2',
+      boardingLine: '2',
+      boardingStationId: gangnam2.id,
+      boardedAt: T0,
+      expectedDurationMs: 10 * 60_000,
+    };
+    mockRead.mockResolvedValue(
+      makeMirror({
+        currentStationId: yongmasan.name, // 용마산은 7호선
+        currentStationLine: '6', // backend 가 wrong line 6 으로 stamp (cross-line confusion 시뮬)
+      }),
+    );
+    const hook = renderHook(() =>
+      useFusedNearestStation(undefined, undefined, undefined, undefined, lockOnLine2),
+    );
+    await flushSsotRead();
+    // line 불일치 → backend-ssot 채택 거부 → 기존 tier(GPS 청담) fallback.
+    expect(hook.result.current.source).not.toBe('backend-ssot');
+  });
+
+  it('lockless trip + mirror line 정의 + cross-line (mirror 가 7로 stamp, 실제 stations.json 에 7호선 station 존재) → 정확한 line 으로 매칭', async () => {
+    // 본 케이스는 lockless trip 인데 backend 가 line metadata 를 정의해 보낸 경우. line 일치 시 정상 채택.
+    setupBaselineGpsAt('청담');
+    mockRead.mockResolvedValue(
+      makeMirror({
+        currentStationId: yongmasan.name,
+        currentStationLine: '7',
+      }),
+    );
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushSsotRead();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+    expect(hook.result.current.result?.station.line).toBe('7');
+  });
+
+  it('lock 활성 trip(line 7) + mirror line 7 일치 → 정상 채택', async () => {
+    setupBaselineGpsAt('청담');
+    mockRead.mockResolvedValue(
+      makeMirror({
+        currentStationId: yongmasan.name,
+        currentStationLine: '7',
+      }),
+    );
+    const hook = renderHook(() =>
+      useFusedNearestStation(undefined, undefined, undefined, undefined, lockOn7),
+    );
+    await flushSsotRead();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+    expect(hook.result.current.result?.station.id).toBe(yongmasan.id);
+  });
+});
+
 describe('#1646 cascade picker — positionTrain 1순위 승격 (3-of-3 합의)', () => {
   const TRAIN_CODE = 'T-1646';
   const lockOn7Match: BoardingLock = {

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -871,15 +871,34 @@ export function useFusedNearestStation(
   //   2. lastAdvanceAt 기준 staleness 60s 이하 — backend cycle(~30s) 2회 + margin.
   //      stale entry는 backend가 trip을 잊었거나 device가 silent push를 한동안 못 받은 상태 →
   //      cascade 채택 시 사용자 실제 위치를 뒤덮을 risk가 있어 자연 fallback.
-  //   3. 노선 가드 — lock 활성 시 resolved station이 lock.boardingLine과 일치해야 채택.
-  //      lockless trip은 노선 가드 없이 backend가 advance한 station을 신뢰(보조 cross-check 없음).
+  //   3. 노선 가드 (3-layer):
+  //      a) lock 활성 + mirror.currentStationLine 정의 + lock.boardingLine 불일치 → 거부.
+  //      b) lock 활성 + mirror.currentStationLine 미정의(legacy v1 row) → boardingLine 기반 매칭 fallback.
+  //      c) lockless + mirror.currentStationLine 정의 → currentStationLine 으로 정확 매칭 (#1705).
+  //      d) lockless + mirror.currentStationLine 미정의(legacy v1 row) → name-only fallback (graceful).
+  //
+  // #1705 (A1/A3-b) — 동명역/cross-line confusion 차단: 사용자 2026-06-23 trip evidence
+  // (2호선 trip 중 "어린이대공원(세종대)" 7호선 mislabel, 6호선 trip 중 "신내역 도착" mislabel)
+  // 직접 fix. backend v2 SSoT 가 currentStationLine 을 stamp 하므로 device 는 line cross-check
+  // 으로 wrong line station 을 cascade 채택 거부한다.
   const ssotStation = useMemo<Station | null>(() => {
     if (!backendSsotMirror) return null;
+    const mirrorLine = backendSsotMirror.currentStationLine;
     if (boardingLock) {
+      // lock 활성: mirror 의 line metadata 가 정의됐고 lock.boardingLine 과 불일치하면 채택 거부
+      // (cross-line confusion 차단). 정의 안 됐으면 boardingLine 기반 매칭으로 graceful fallback.
+      if (mirrorLine !== undefined && mirrorLine !== boardingLock.boardingLine) {
+        return null;
+      }
       return findStationByNameAndLine(
         backendSsotMirror.currentStationId,
         boardingLock.boardingLine,
       );
+    }
+    // lockless: mirror line metadata 가 정의되면 정확 매칭 (cross-line confusion 차단).
+    // 미정의(legacy v1) 면 기존 name-only fallback (graceful).
+    if (mirrorLine !== undefined) {
+      return findStationByNameAndLine(backendSsotMirror.currentStationId, mirrorLine);
     }
     return findStationByName(backendSsotMirror.currentStationId);
   }, [backendSsotMirror, boardingLock]);


### PR DESCRIPTION
## Summary

Backend SSoT `currentStationId`가 한글 stationName(예: "어린이대공원(세종대)")만 저장해 동명역/cross-line confusion 회귀 발생. v2 schema에 `currentStationLine` 추가 + device cascade picker line cross-check으로 차단.

Closes #1705

## 사용자 evidence (2026-06-23 trip)

- 2호선 trip 중 `currentStationId="어린이대공원(세종대)"` (실제는 7호선) → device가 wrong line 채택
- 6호선 trip 중 `currentStationId="봉화산(서울의료원)"` → "신내역 도착" mislabel
- 동명역 패턴: 합정 2-038/6-013, 공덕 5-020/6-017, 어린이대공원 (7호선만 존재하지만 다른 노선의 동명역 케이스)

## 변경 사항

### Backend
1. `backend/alarm-worker/src/tripPositionSsot.ts` — `TripPositionSSoT.currentStationLine?: LineNumber` 필드 추가 (optional, legacy v1 graceful), `seedSsot` options에 `line?` 추가
2. `backend/alarm-worker/src/advanceTripPosition.ts` — `options.candidateStationLine?` 추가, advance 통과 시 `currentStationLine` stamp
3. `backend/alarm-worker/src/scheduled.ts` — 4 호출 site (lazy-seed 2건 + advance 2건)에서 `waypoint.line` forward
4. `backend/alarm-worker/src/apns.ts` — `SilentPushSsotPayload.currentStationLine?` 추가 + JSON wire 처리
5. `backend/alarm-worker/src/scheduled.ts:toSilentPushSsot` — `currentStationLine` forward
6. `backend/alarm-worker/src/transferDestinationGate.ts` — `isSsotLineMatchingWaypoint` 게이트 + `evaluateTransferDestinationGate` line cross-check (`ssot-line-mismatch` reason 추가)

### Frontend
7. `src/features/alarm/utils/backendSsotMirror.ts` — `SilentPushSsotMirror.currentStationLine?: LineNumber` 추가, `readBackendSsotMirror` parse
8. `src/features/alarm/tasks/silentPushTask.ts` — `validSsotMirror`에서 `currentStationLine` narrow
9. `src/features/nearest-station/hooks/useFusedNearestStation.ts:876-895` cascade picker — `currentStationLine` cross-check (lock active: 불일치 시 채택 거부 / lockless: `findStationByNameAndLine` 사용 / legacy v1: name-only fallback)
10. `src/features/nearest-station/api/positionUpload.ts` — `lockSuggestion.lineId`로부터 `currentStationLine` derive

## Schema Migration

`currentStationLine`은 **optional 필드**로 유지 (단순 graceful migration):
- backend v2 row: `currentStationLine` stamp (waypoint.line 사용)
- backend v1 row (KV에 잔존): `currentStationLine` 부재 → device cascade가 name-only fallback (기존 동작)
- schemaVersion은 그대로 1 유지 — optional 필드 추가만으로 forward/backward compat 보장

## 테스트

### Backend (vitest)
- `tripPositionSsot.test.ts` — `seedSsot options.line` stamp + legacy v1 graceful + round-trip (4 신규)
- `advanceTripPosition.test.ts` — `candidateStationLine` stamp / 보존 / blocked 시 미변경 / `toSilentPushSsot` forward (6 신규)
- `transferDestinationGate.test.ts` — `isSsotLineMatchingWaypoint` 단위 + `evaluateTransferDestinationGate` line mismatch block (7 신규)
- **2016 passed (이전 1999 + 17 신규)**

### Frontend (jest)
- `backendSsotMirror.test.ts` — `currentStationLine` parse + round-trip + 형식 mismatch graceful drop (7 신규)
- `silentPushTask.test.ts` — `validSsotMirror` narrow + payload extract wire (8 신규)
- `useFusedNearestStation.backendSsotCascade.test.ts` — cascade picker line cross-check 5 시나리오 (lock 일치/lock 불일치/lockless 정의/lockless 미정의/legacy v1)
- **7584 passed (모든 suite 통과)**

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard** — Backend tail: `transferDestinationGate blocked reason='ssot-line-mismatch'` log. Device cascade picker source/confidence 표시 (`backend-ssot` 거부 → fallback tier 채택)
3. **의존 PR** — 본 PR은 #1709 (fix/#1701-deletessot-cleanup) 위에 stacked. #1709 머지 후 본 PR을 dev 위에 rebase (또는 base 변경)
4. **측정 plan** — 6/23 trip dump 재현 시 2호선 trip 에 7호선 station mislabel 0건. backend tail `transferDestinationGate blocked` reason 분포에서 `ssot-line-mismatch` count 측정 (cross-line confusion 활성화 빈도)
5. **Device verify** — 실기기 검증 필요. 사용자가 동명역 환승 trip (예: 합정 2→6) 시나리오로 1주 재현 0건 확인

## 사용자 6/23 mislabel 회귀 차단 검증 plan

- 시나리오 1: 사용자 2호선 trip 중 어린이대공원(세종대) 부근 경유 → device cascade picker 가 backend mirror line 불일치 시 채택 거부 → wifi/positionTrain/fused tier fallback
- 시나리오 2: 사용자 6호선 trip 중 봉화산(서울의료원) 부근 경유 → 같은 line cross-check 으로 "신내역 도착" mislabel 차단

## Test plan

- [ ] backend type-check (`tsc --noEmit`) pass
- [ ] backend test (2016 pass, +17 신규)
- [ ] frontend type-check pass
- [ ] frontend test (7584 pass, +20 신규)
- [ ] `npm run lint:orphan` pass
- [ ] PR #1709 머지 후 dev rebase + CI pass
- [ ] 실기기: 사용자 동명역 trip 1주 재현 0건