### PR TITLE
fix(#1702): Seoul OpenAPI arrivals 단방향/0건 시 realtimePosition fallback

### DIFF
--- a/backend/alarm-worker/src/__tests__/arrivalsFromPositions.test.ts
+++ b/backend/alarm-worker/src/__tests__/arrivalsFromPositions.test.ts
@@ -1,0 +1,386 @@
+/**
+ * #1702 (B2-A) — arrivalsFromPositions 단위 테스트.
+ *
+ * Seoul OpenAPI 단방향/0건 시 realtimePosition snapshot 으로 ArrivalEntry 를 합성하는 pure
+ * helper. autoLock + lockSwap 양쪽에서 사용되므로 합성 정책(direction 필터, segmentStations
+ * 위치 검증, ETA 합성, canonical subwayNm) 을 한 곳에서 보장한다.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  pickFallbackTrainCodeFromPositions,
+  resolveTrainCodeWithFallback,
+  synthesizeArrivalsFromPositions,
+} from '../arrivalsFromPositions';
+import type { ArrivalEntry, PositionEntry } from '../seoul';
+
+// HOP_SEC 기본 값 90 — `scheduled.ts:FALLBACK_HOP_SEC` 와 동일.
+const HOP_SEC = 90;
+
+function position(overrides: Partial<PositionEntry> & { trainCode: string }): PositionEntry {
+  return {
+    stationName: '',
+    trainSttus: 0,
+    isUp: false,
+    recptnMs: 0,
+    ...overrides,
+  };
+}
+
+describe('synthesizeArrivalsFromPositions', () => {
+  // 합정 → 광흥창 → 대흥 → 공덕 (6호선 하행 의도) — 사용자 trip evidence 와 같은 segment.
+  const segmentStations = ['합정', '광흥창', '대흥', '공덕'] as const;
+  const targetStation = '광흥창';
+
+  it('positions 비어있음 → 빈 배열', () => {
+    const result = synthesizeArrivalsFromPositions({
+      positions: [],
+      line: '6',
+      direction: 'down',
+      segmentStations,
+      targetStation,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('segmentStations 비어있음 → 빈 배열', () => {
+    const result = synthesizeArrivalsFromPositions({
+      positions: [position({ trainCode: '6187', stationName: '합정', isUp: false })],
+      line: '6',
+      direction: 'down',
+      segmentStations: [],
+      targetStation,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('targetStation이 segmentStations 안 없음 → 빈 배열', () => {
+    const result = synthesizeArrivalsFromPositions({
+      positions: [position({ trainCode: '6187', stationName: '합정', isUp: false })],
+      line: '6',
+      direction: 'down',
+      segmentStations,
+      targetStation: '망원', // segmentStations 밖
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('canonical 매핑 누락 line → 빈 배열 (matchLine 우회 차단)', () => {
+    const result = synthesizeArrivalsFromPositions({
+      positions: [position({ trainCode: 'X', stationName: '합정', isUp: false })],
+      line: 'unmapped',
+      direction: 'down',
+      segmentStations,
+      targetStation,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('direction=down: isUp=true train 필터링 (반대 방향 제외)', () => {
+    const result = synthesizeArrivalsFromPositions({
+      positions: [
+        position({ trainCode: '6184', stationName: '합정', isUp: true }), // up — 제외
+        position({ trainCode: '6187', stationName: '합정', isUp: false }), // down — 채택
+      ],
+      line: '6',
+      direction: 'down',
+      segmentStations,
+      targetStation,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].trainCode).toBe('6187');
+    expect(result[0].isUp).toBe(false);
+  });
+
+  it('direction=up: isUp=false train 필터링', () => {
+    const result = synthesizeArrivalsFromPositions({
+      positions: [
+        position({ trainCode: '6184', stationName: '합정', isUp: true }),
+        position({ trainCode: '6187', stationName: '합정', isUp: false }),
+      ],
+      line: '6',
+      direction: 'up',
+      segmentStations,
+      targetStation,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].trainCode).toBe('6184');
+  });
+
+  it('direction=null: 양방향 허용', () => {
+    const result = synthesizeArrivalsFromPositions({
+      positions: [
+        position({ trainCode: '6184', stationName: '합정', isUp: true }),
+        position({ trainCode: '6187', stationName: '합정', isUp: false }),
+      ],
+      line: '6',
+      direction: null,
+      segmentStations,
+      targetStation,
+    });
+    expect(result).toHaveLength(2);
+  });
+
+  it('segmentStations 밖 train (stationName 매칭 X) 제외', () => {
+    const result = synthesizeArrivalsFromPositions({
+      positions: [
+        position({ trainCode: '6187', stationName: '아예다른역', isUp: false }),
+      ],
+      line: '6',
+      direction: 'down',
+      segmentStations,
+      targetStation,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('이미 target 지난 train (currentIdx > targetIdx) 제외', () => {
+    // target=광흥창(idx=1), train@대흥(idx=2) — 이미 target 지나감 → 제외.
+    const result = synthesizeArrivalsFromPositions({
+      positions: [position({ trainCode: '6187', stationName: '대흥', isUp: false })],
+      line: '6',
+      direction: 'down',
+      segmentStations,
+      targetStation,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('이미 target 역에 있음 (currentIdx === targetIdx) → arrivalSeconds=0', () => {
+    const result = synthesizeArrivalsFromPositions({
+      positions: [position({ trainCode: '6187', stationName: '광흥창', isUp: false })],
+      line: '6',
+      direction: 'down',
+      segmentStations,
+      targetStation,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].arrivalSeconds).toBe(0);
+  });
+
+  it('upstream train ETA = (targetIdx - currentIdx) * HOP_SEC', () => {
+    // target=공덕(idx=3), train@합정(idx=0) → 3 hops × 90s = 270s.
+    const segmentToGongdeok = ['합정', '광흥창', '대흥', '공덕'];
+    const result = synthesizeArrivalsFromPositions({
+      positions: [position({ trainCode: '6187', stationName: '합정', isUp: false })],
+      line: '6',
+      direction: 'down',
+      segmentStations: segmentToGongdeok,
+      targetStation: '공덕',
+    });
+    expect(result[0].arrivalSeconds).toBe(3 * HOP_SEC);
+  });
+
+  it('합성 ArrivalEntry — subwayNm=canonical, arvlCd=0(ENTERING) 보수', () => {
+    const result = synthesizeArrivalsFromPositions({
+      positions: [position({ trainCode: '6187', stationName: '합정', isUp: false })],
+      line: '6',
+      direction: 'down',
+      segmentStations,
+      targetStation,
+    });
+    expect(result[0]).toEqual({
+      destination: '',
+      arrivalSeconds: HOP_SEC, // 합정(0) → 광흥창(1) = 1 hop
+      trainCode: '6187',
+      isUp: false,
+      subwayNm: '6호선', // canonical
+      arvlCd: 0, // ENTERING — 가장 보수적, RC1 confidence gate 트리거 X
+    });
+  });
+
+  it('여러 train 동시 합성 — 각자 ETA 독립 계산', () => {
+    const segmentToGongdeok = ['합정', '광흥창', '대흥', '공덕'];
+    const result = synthesizeArrivalsFromPositions({
+      positions: [
+        position({ trainCode: '6187', stationName: '합정', isUp: false }), // 3 hops
+        position({ trainCode: '6189', stationName: '대흥', isUp: false }), // 1 hop
+      ],
+      line: '6',
+      direction: 'down',
+      segmentStations: segmentToGongdeok,
+      targetStation: '공덕',
+    });
+    expect(result).toHaveLength(2);
+    const map = Object.fromEntries(result.map((r) => [r.trainCode, r.arrivalSeconds]));
+    expect(map['6187']).toBe(3 * HOP_SEC);
+    expect(map['6189']).toBe(1 * HOP_SEC);
+  });
+});
+
+describe('pickFallbackTrainCodeFromPositions', () => {
+  const segmentStations = ['합정', '광흥창', '대흥', '공덕'] as const;
+  const targetStation = '광흥창';
+
+  function realArrival(overrides: Partial<ArrivalEntry> & { trainCode: string }): ArrivalEntry {
+    return {
+      destination: '',
+      arrivalSeconds: 60,
+      isUp: false,
+      subwayNm: '6호선',
+      arvlCd: 1,
+      ...overrides,
+    };
+  }
+
+  it('positions undefined → null', () => {
+    const result = pickFallbackTrainCodeFromPositions({
+      realArrivals: [],
+      positions: undefined,
+      line: '6',
+      direction: 'down',
+      segmentStations,
+      targetStation,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('positions=[] → null', () => {
+    const result = pickFallbackTrainCodeFromPositions({
+      realArrivals: [],
+      positions: [],
+      line: '6',
+      direction: 'down',
+      segmentStations,
+      targetStation,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('synthesized 0건 (segmentStations 밖 train) → null', () => {
+    const result = pickFallbackTrainCodeFromPositions({
+      realArrivals: [],
+      positions: [position({ trainCode: '6187', stationName: '아예다른역', isUp: false })],
+      line: '6',
+      direction: 'down',
+      segmentStations,
+      targetStation,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('합성 단일 candidate → { trainCode, arrivals } 반환', () => {
+    const result = pickFallbackTrainCodeFromPositions({
+      realArrivals: [],
+      positions: [position({ trainCode: '6187', stationName: '합정', isUp: false })],
+      line: '6',
+      direction: 'down',
+      segmentStations,
+      targetStation,
+    });
+    expect(result?.trainCode).toBe('6187');
+    expect(result?.arrivals).toHaveLength(1);
+  });
+
+  it('real arrivals + synthesized merge — 같은 trainCode dedup', () => {
+    // realArrivals: T1 wrong direction (UP). Synthesized: T1 DOWN + T2 DOWN.
+    // dedup 으로 T1 합성 제외 → merged=[T1 real UP, T2 synth DOWN]. direction=down 필터 → T2 만.
+    const result = pickFallbackTrainCodeFromPositions({
+      realArrivals: [realArrival({ trainCode: 'T1', isUp: true })],
+      positions: [
+        position({ trainCode: 'T1', stationName: '합정', isUp: false }),
+        position({ trainCode: 'T2', stationName: '합정', isUp: false }),
+      ],
+      line: '6',
+      direction: 'down',
+      segmentStations,
+      targetStation,
+    });
+    expect(result?.trainCode).toBe('T2');
+    // merged 에는 T1 real + T2 synth = 2개 (T1 synth 는 dedup 으로 제외).
+    expect(result?.arrivals).toHaveLength(2);
+  });
+
+  it('합성 ambiguity (2개 down train) → pickAutoTrainCode null → 반환 null', () => {
+    const result = pickFallbackTrainCodeFromPositions({
+      realArrivals: [],
+      positions: [
+        position({ trainCode: 'T1', stationName: '합정', isUp: false }),
+        position({ trainCode: 'T2', stationName: '합정', isUp: false }),
+      ],
+      line: '6',
+      direction: 'down',
+      segmentStations,
+      targetStation,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe('resolveTrainCodeWithFallback', () => {
+  const segmentStations = ['합정', '광흥창', '대흥', '공덕'] as const;
+  const targetStation = '광흥창';
+
+  function realArrival(overrides: Partial<ArrivalEntry> & { trainCode: string }): ArrivalEntry {
+    return {
+      destination: '',
+      arrivalSeconds: 60,
+      isUp: false,
+      subwayNm: '6호선',
+      arvlCd: 1,
+      ...overrides,
+    };
+  }
+
+  it('realArrivals 통과 → real candidate 사용, fallback 미진입', () => {
+    const result = resolveTrainCodeWithFallback({
+      realArrivals: [realArrival({ trainCode: 'REAL' })],
+      positions: [position({ trainCode: 'SYNTH', stationName: '합정', isUp: false })],
+      line: '6',
+      direction: 'down',
+      segmentStations,
+      targetStation,
+    });
+    expect(result?.trainCode).toBe('REAL');
+    // arrivals 는 realArrivals 그대로 (synth 미포함).
+    expect(result?.arrivals).toHaveLength(1);
+  });
+
+  it('real 0건 + positions 합성 → fallback 사용', () => {
+    const result = resolveTrainCodeWithFallback({
+      realArrivals: [],
+      positions: [position({ trainCode: 'SYNTH', stationName: '합정', isUp: false })],
+      line: '6',
+      direction: 'down',
+      segmentStations,
+      targetStation,
+    });
+    expect(result?.trainCode).toBe('SYNTH');
+  });
+
+  it('real wrong direction + positions 합성 → fallback retry', () => {
+    const result = resolveTrainCodeWithFallback({
+      realArrivals: [realArrival({ trainCode: 'UP_TRAIN', isUp: true })],
+      positions: [position({ trainCode: 'DOWN_TRAIN', stationName: '합정', isUp: false })],
+      line: '6',
+      direction: 'down',
+      segmentStations,
+      targetStation,
+    });
+    expect(result?.trainCode).toBe('DOWN_TRAIN');
+  });
+
+  it('real 0건 + positions 미전달 → null', () => {
+    const result = resolveTrainCodeWithFallback({
+      realArrivals: [],
+      positions: undefined,
+      line: '6',
+      direction: 'down',
+      segmentStations,
+      targetStation,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('real 0건 + positions 빈 list → null', () => {
+    const result = resolveTrainCodeWithFallback({
+      realArrivals: [],
+      positions: [],
+      line: '6',
+      direction: 'down',
+      segmentStations,
+      targetStation,
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/backend/alarm-worker/src/__tests__/autoLock.test.ts
+++ b/backend/alarm-worker/src/__tests__/autoLock.test.ts
@@ -8,7 +8,7 @@ import {
 } from '../autoLock';
 import { METRIC_KIND } from '../metrics';
 import { SWAP_LOCK_TTL_MS } from '../lockSwap';
-import { type ArrivalEntry } from '../seoul';
+import { type ArrivalEntry, type PositionEntry } from '../seoul';
 import type { Waypoint } from '../types';
 import {
   FIXTURE_NOW as NOW,
@@ -29,6 +29,19 @@ function arrival(overrides: Partial<ArrivalEntry>): ArrivalEntry {
     // 기본값 arvlCd=1(도착) — confidence gate(#1018)를 의도치 않게 트리거하지 않도록.
     // arvlCd=2(출발)를 테스트하려면 명시 지정한다.
     arvlCd: 1,
+    ...overrides,
+  };
+}
+
+// PositionEntry 기본값 fixture — recptnMs=0 (age 가드 skip), isUp=true 기본.
+// `selfPollPositions` 입력으로 PositionEntry 전체 타입을 받아 `synthesizeArrivalsFromPositions`
+// 등 새 fallback 분기와 기존 strongCB/recptnMs 가드 모두 일관되게 호출된다.
+function position(overrides: Partial<PositionEntry> & { trainCode: string }): PositionEntry {
+  return {
+    stationName: '',
+    trainSttus: 0,
+    isUp: true,
+    recptnMs: 0,
     ...overrides,
   };
 }
@@ -524,7 +537,7 @@ describe('attemptAutoLock #1536 (S3) 환경 분기 consensusGate', () => {
  */
 function callAutoLockWithSelfPoll(
   arrivalEntry: ArrivalEntry,
-  selfPollPositions: readonly { trainCode: string; stationName: string }[] | undefined,
+  selfPollPositions: readonly PositionEntry[] | undefined,
   opts: {
     environment?: Parameters<typeof attemptAutoLock>[0]['environment'];
     gateOutcome?: Parameters<typeof attemptAutoLock>[0]['gateOutcome'];
@@ -547,31 +560,31 @@ describe('attemptAutoLock #1614 Phase B selfPollPositions wire (S4)', () => {
   it.each([
     {
       label: 'trainCode 일치 + arvlCd 0~3 → strongCB pass (underground, base gate fail)',
-      positions: [{ trainCode: 'T1', stationName: '강남' }],
+      positions: [position({ trainCode: 'T1', stationName: '강남' })],
       arvlCd: 1,
       expected: 'lock' as const,
     },
     {
       label: 'trainCode 불일치 + arvlCd 1 → strongCB undefined, strongBE pass (lockAttachable + arrival)',
-      positions: [{ trainCode: 'OTHER', stationName: '강남' }],
+      positions: [position({ trainCode: 'OTHER', stationName: '강남' })],
       arvlCd: 1,
       expected: 'lock' as const,
     },
     {
       label: 'trainCode 불일치 + arvlCd 5(범위 밖) → strongCB false + strongBE false → null',
-      positions: [{ trainCode: 'OTHER', stationName: '강남' }],
+      positions: [position({ trainCode: 'OTHER', stationName: '강남' })],
       arvlCd: 5,
       expected: 'null' as const,
     },
     {
       label: 'trainCode 일치 + arvlCd 5(범위 밖) → strongCB false (arrival missing) + strongBE false → null',
-      positions: [{ trainCode: 'T1', stationName: '강남' }],
+      positions: [position({ trainCode: 'T1', stationName: '강남' })],
       arvlCd: 5,
       expected: 'null' as const,
     },
     {
       label: '빈 list + arvlCd 1 → positionTrainAgreement false, strongBE pass',
-      positions: [] as const,
+      positions: [] as readonly PositionEntry[],
       arvlCd: 1,
       expected: 'lock' as const,
     },
@@ -606,7 +619,7 @@ describe('attemptAutoLock #1614 Phase B selfPollPositions wire (S4)', () => {
   it('surface: selfPollPositions 무관 — base gate pass면 통과 (positionTrainAgreement 평가 X)', async () => {
     const { lock } = await callAutoLockWithSelfPoll(
       arrival({ trainCode: 'T1', arvlCd: 1 }),
-      [{ trainCode: 'OTHER', stationName: '강남' }],
+      [position({ trainCode: 'OTHER', stationName: '강남' })],
       {
         environment: 'surface',
         gateOutcome: passingGateOutcome(),
@@ -755,7 +768,7 @@ describe('attemptAutoLock #1676 recptnMs age 가드', () => {
       now: NOW,
       environment: 'underground',
       gateOutcome: failingGateOutcome(),
-      selfPollPositions: [{ trainCode: 'T1', stationName: '강남', recptnMs }],
+      selfPollPositions: [position({ trainCode: 'T1', stationName: '강남', recptnMs })],
     });
     if (expected === 'lock') {
       expect(lock?.trainCode).toBe('T1');
@@ -776,7 +789,7 @@ describe('attemptAutoLock #1676 recptnMs age 가드', () => {
       now: NOW,
       environment: 'underground',
       gateOutcome: failingGateOutcome(),
-      selfPollPositions: [{ trainCode: 'T1', stationName: '강남', recptnMs: NOW - 31_000 }],
+      selfPollPositions: [position({ trainCode: 'T1', stationName: '강남', recptnMs: NOW - 31_000 })],
     });
     expect(lock).toBeNull();
   });
@@ -792,7 +805,7 @@ describe('attemptAutoLock #1676 recptnMs age 가드', () => {
       now: NOW,
       environment: 'underground',
       gateOutcome: failingGateOutcome(),
-      selfPollPositions: [{ trainCode: 'T1', stationName: '강남', recptnMs: 0 }],
+      selfPollPositions: [position({ trainCode: 'T1', stationName: '강남', recptnMs: 0 })],
     });
     expect(lock?.trainCode).toBe('T1');
   });
@@ -808,8 +821,165 @@ describe('attemptAutoLock #1676 recptnMs age 가드', () => {
       now: NOW,
       environment: 'underground',
       gateOutcome: failingGateOutcome(),
-      selfPollPositions: [{ trainCode: 'T1', stationName: '강남' }],
+      selfPollPositions: [position({ trainCode: 'T1', stationName: '강남' })],
     });
     expect(lock?.trainCode).toBe('T1');
+  });
+});
+
+/**
+ * #1702 (B2-A) — Seoul OpenAPI 단방향/0건 시 realtimePosition fallback.
+ *
+ * 사용자 6/23 trip evidence: `fetchArrivals(합정 6호선)` 한 방향만 반환 → 사용자 의도 방향
+ * candidate 0건 → wrong-direction lock. 본 describe 는 fallback 분기가 segmentStations 기반
+ * positions 합성으로 올바른 방향 lock 을 만들어내는지 검증.
+ *
+ * 사용 fixture: target=역삼(2호선), origin=강남, waypoints=[역삼, 선릉] → segmentStations=[강남, 역삼, 선릉].
+ */
+describe('attemptAutoLock #1702 positions fallback', () => {
+  it('arrivals=[] + positions=[T1@강남 up] + direction=up → 합성 lock (T1)', async () => {
+    // 가장 단순 시나리오: 실제 arrivals 가 비어 있고 positions 에 사용자 방향 train 이 있는 경우.
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([]), // 빈 arrivals
+      now: NOW,
+      selfPollPositions: [position({ trainCode: 'T1', stationName: '강남', isUp: true })],
+    });
+    expect(lock?.trainCode).toBe('T1');
+    // 합성 entry 의 subwayNm 은 canonical('2호선') 이라 matchLine cross-check 통과.
+    expect(lock?.line).toBe('2');
+  });
+
+  it('arrivals=[] + positions=[T_UP, T_DOWN] + direction=down → DOWN candidate 선택', async () => {
+    // 사용자 6/23 evidence 와 동형: positions 양방향 train 다 있을 때 user direction 만 채택.
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'down',
+      seoul: makeSeoul([]),
+      now: NOW,
+      selfPollPositions: [
+        position({ trainCode: 'TU', stationName: '강남', isUp: true }), // 반대 방향 — 제외
+        position({ trainCode: 'TD', stationName: '강남', isUp: false }), // 사용자 방향 — 채택
+      ],
+    });
+    expect(lock?.trainCode).toBe('TD');
+  });
+
+  it('arrivals=[UP only] + positions=[DOWN train] + direction=down → 합성 DOWN candidate 보강', async () => {
+    // 핵심 evidence 시나리오: 실제 arrivals 가 잘못된 방향만 반환 + user direction 으로 합성 retry.
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'down',
+      seoul: makeSeoul([arrival({ trainCode: 'UP_TRAIN', isUp: true })]), // UP only — direction 불일치
+      now: NOW,
+      selfPollPositions: [
+        position({ trainCode: 'DOWN_TRAIN', stationName: '강남', isUp: false }), // DOWN candidate
+      ],
+    });
+    expect(lock?.trainCode).toBe('DOWN_TRAIN');
+  });
+
+  it('arrivals=[] + positions=[] → 기존 schedule-based fallback (lock null)', async () => {
+    // positions 도 비어있으면 합성 불가 → 기존 null 동작 유지 (caller boarding-prompt fallback).
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([]),
+      now: NOW,
+      selfPollPositions: [],
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('arrivals=[] + positions undefined → lock null (구 호출자 호환)', async () => {
+    // selfPollPositions 미전달 시 fallback 자체가 비활성 → 기존 동작 보존.
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([]),
+      now: NOW,
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('arrivals 통과 candidate 있음 → fallback 진입 X (real arrivals 우선)', async () => {
+    // real arrivals 가 single candidate 를 가지면 positions 는 무시 — 합성보다 신뢰도 높음.
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'REAL', isUp: true })]),
+      now: NOW,
+      selfPollPositions: [
+        position({ trainCode: 'SYNTH', stationName: '강남', isUp: true }),
+      ],
+    });
+    expect(lock?.trainCode).toBe('REAL');
+  });
+
+  it('merge dedup — 같은 trainCode 는 real 만 보존, 합성 동일 trainCode 제거', async () => {
+    // real arrivals: T1 wrong direction (UP) — pickAutoTrainCode(down) null → fallback 진입.
+    // positions: T1 (real 과 같은 code) + T2 (다른 code) → dedup 으로 T1 제외, T2 만 합성.
+    // 결과: merged = [T1 UP (real)] + [T2 DOWN (synth)] → pickAutoTrainCode(down) → T2.
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'down',
+      seoul: makeSeoul([arrival({ trainCode: 'T1', arvlCd: 1, isUp: true })]),
+      now: NOW,
+      selfPollPositions: [
+        position({ trainCode: 'T1', stationName: '강남', isUp: false }), // dedup 제외
+        position({ trainCode: 'T2', stationName: '강남', isUp: false }), // 합성 채택
+      ],
+    });
+    // T2 만 user direction 합성 candidate 로 남아 lock.
+    // (T1 이 dedup 안 되면 T1+T2 → ambiguity → null 이 되어 본 test 가 fail 했을 것)
+    expect(lock?.trainCode).toBe('T2');
+  });
+
+  it('합성 candidate ambiguity (DOWN train 2개) → null (boarding-prompt fallback)', async () => {
+    // 같은 priority tier 에 2개 이상이면 pickAutoTrainCode 가 null 반환 — 합성 분기도 동일.
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'down',
+      seoul: makeSeoul([]),
+      now: NOW,
+      selfPollPositions: [
+        position({ trainCode: 'TD1', stationName: '강남', isUp: false }),
+        position({ trainCode: 'TD2', stationName: '강남', isUp: false }),
+      ],
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('positions train 이미 target 지남 → 합성 제외 → null', async () => {
+    // target=역삼(idx=1), train@선릉(idx=2) — currentIdx>targetIdx → synthesize 에서 제외.
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([]),
+      now: NOW,
+      selfPollPositions: [
+        position({ trainCode: 'PASSED', stationName: '선릉', isUp: true }),
+      ],
+    });
+    expect(lock).toBeNull();
   });
 });

--- a/backend/alarm-worker/src/__tests__/lockSwap.test.ts
+++ b/backend/alarm-worker/src/__tests__/lockSwap.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { SeoulArrivalClient, type ArrivalEntry } from '../seoul';
+import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from '../seoul';
 import {
   SWAP_LOCK_TTL_MS,
   attachTrainCodeForLeg,
@@ -282,5 +282,128 @@ describe('attachTrainCodeForLeg', () => {
       now: NOW,
     });
     expect(lock).toBeNull();
+  });
+});
+
+/**
+ * #1702 (B2-A) — Seoul OpenAPI 단방향/0건 시 realtimePosition fallback.
+ *
+ * `attachTrainCodeForLeg` 는 direction=null 로 호출 (swap 흐름은 양방향 허용) 이지만
+ * segmentStations 기반 필터로 진행 방향 외 train (이미 target 지남) 은 자연 제외된다.
+ * 합성 path 가 transfer-swap + vanish-swap 모두에서 작동하는지 검증.
+ *
+ * 사용 fixture: line=7, segmentStations=[중곡, 군자, 어린이대공원], target=중곡.
+ */
+
+function position(overrides: Partial<PositionEntry> & { trainCode: string }): PositionEntry {
+  return {
+    stationName: '',
+    trainSttus: 0,
+    isUp: true,
+    recptnMs: 0,
+    ...overrides,
+  };
+}
+
+describe('attachTrainCodeForLeg #1702 positions fallback', () => {
+  const swapTarget: Waypoint = { stationName: '중곡', line: '7', kind: 'intermediate' };
+  const swapWaypoints: Waypoint[] = [
+    swapTarget,
+    { stationName: '군자', line: '7', kind: 'intermediate' },
+    { stationName: '어린이대공원', line: '7', kind: 'destination' },
+  ];
+
+  it('arrivals=[] + positions=[T1@중곡] → 합성 swap candidate', async () => {
+    const seoul = makeSeoul([]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeTrip(swapWaypoints),
+      targetWaypoint: swapTarget,
+      seoul,
+      now: NOW,
+      selfPollPositions: [position({ trainCode: 'T1', stationName: '중곡' })],
+    });
+    expect(lock?.trainCode).toBe('T1');
+    expect(lock?.line).toBe('7');
+  });
+
+  it('arrivals=[] + positions=[] → null (구 schedule fallback 유지)', async () => {
+    const seoul = makeSeoul([]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeTrip(swapWaypoints),
+      targetWaypoint: swapTarget,
+      seoul,
+      now: NOW,
+      selfPollPositions: [],
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('arrivals=[] + positions undefined → null (구 호출자 호환)', async () => {
+    const seoul = makeSeoul([]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeTrip(swapWaypoints),
+      targetWaypoint: swapTarget,
+      seoul,
+      now: NOW,
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('real arrivals 통과 → fallback 진입 X', async () => {
+    // real arrivals 가 candidate 를 가지면 positions 무시 — real 우선.
+    const seoul = makeSeoul([makeArrival('REAL', 1, 60)]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeTrip(swapWaypoints),
+      targetWaypoint: swapTarget,
+      seoul,
+      now: NOW,
+      selfPollPositions: [position({ trainCode: 'SYNTH', stationName: '중곡' })],
+    });
+    expect(lock?.trainCode).toBe('REAL');
+  });
+
+  it('positions train 이미 target 지남 → 합성 제외 → null', async () => {
+    // target=중곡(idx=0), train@군자(idx=1) — currentIdx>targetIdx → 제외.
+    const seoul = makeSeoul([]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeTrip(swapWaypoints),
+      targetWaypoint: swapTarget,
+      seoul,
+      now: NOW,
+      selfPollPositions: [position({ trainCode: 'PASSED', stationName: '군자' })],
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('합성 candidate ambiguity → null (boarding-prompt fallback)', async () => {
+    const seoul = makeSeoul([]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeTrip(swapWaypoints),
+      targetWaypoint: swapTarget,
+      seoul,
+      now: NOW,
+      selfPollPositions: [
+        position({ trainCode: 'T1', stationName: '중곡' }),
+        position({ trainCode: 'T2', stationName: '중곡' }),
+      ],
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('arrivals=[UP only] + positions=[DOWN train] → DOWN train 합성 보강', async () => {
+    // direction=null swap 분기지만, positions 의 다른 stationName/방향 train 이 segmentStations
+    // 인덱스로 자연 필터링. arrivals 가 wrong-line (matchLine 우회로 null) 인 경우 fallback.
+    const seoul = makeSeoul([
+      // 빈 subwayNm — matchLine 통과 X. pickAutoTrainCode null 반환.
+      makeArrival('UP_TRAIN', 1, 60, ''),
+    ]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeTrip(swapWaypoints),
+      targetWaypoint: swapTarget,
+      seoul,
+      now: NOW,
+      selfPollPositions: [position({ trainCode: 'POSITIONS_TRAIN', stationName: '중곡' })],
+    });
+    expect(lock?.trainCode).toBe('POSITIONS_TRAIN');
   });
 });

--- a/backend/alarm-worker/src/arrivalsFromPositions.ts
+++ b/backend/alarm-worker/src/arrivalsFromPositions.ts
@@ -1,0 +1,194 @@
+/**
+ * #1702 (B2-A) — Seoul OpenAPI arrivals 단방향/0건 시 realtimePosition fallback.
+ *
+ * 배경
+ * ====
+ * 2026-06-23 사용자 trip evidence: `fetchArrivals(합정 6호선)`이 한 방향(망원방면=상행)만 반환 →
+ * 사용자 의도 방향(공덕방면=하행) train candidate 0건 → `pickAutoTrainCode`가 응암 방향
+ * train(6184)만 lock → 잘못된 방향 lock → vanish fallback 도착 알림 mislabel.
+ *
+ * 본 모듈은 같은 line의 `realtimePosition` snapshot(이미 `selfPollPosition`이 cron 진입부에서
+ * 호선당 1회 stamp)을 활용해 ArrivalEntry 를 합성한다. arrivals API 가 한 방향만 반환해도
+ * positions API 는 호선의 양방향 전체 trains 를 반환하므로 missing direction 보강이 가능하다.
+ *
+ * 합성 정책
+ * ========
+ * 입력 positions 의 각 train 마다:
+ *   1. direction 필터 — `direction='up'` → `isUp=true`, `'down'` → `isUp=false`, `null` → 양방향.
+ *   2. segmentStations 위치 검증 — train.stationName 이 segmentStations 안에 있고, 그 인덱스가
+ *      targetIndex 보다 작거나 같은 경우만 (아직 target 통과 X). 이미 target 지난 train(currentIdx
+ *      > targetIdx) 은 제외.
+ *   3. ETA 합성 — `(targetIdx - currentIdx) * HOP_SEC * 1000` ms (scheduled.ts:FALLBACK_HOP_SEC 와 동일).
+ *   4. ArrivalEntry 합성 — `arvlCd=0` (ENTERING). 이는 `pickAutoTrainCode` 의 priority 우선순위에서
+ *      2(출발) / 1(도착) 보다 낮아 real arrivals 가 같은 train 을 더 강한 신호로 표기하면 우선되도록.
+ *      `subwayNm` 은 canonical line name 으로 합성 — `matchLine` cross-check 통과 보장.
+ *
+ * `arvlCd` 를 ENTERING(0) 으로 두는 이유
+ * ====================================
+ * positions API 의 trainSttus(0=진입/1=도착/2=출발) 는 train 위치 기준 신호로, 합성 ArrivalEntry
+ * 의 도착 예측은 fallback 추정값이므로 가장 보수적인 ENTERING(0) 으로 통일한다. autoLock 의 RC1
+ * confidence gate(arvlCd=2 branch)는 합성 entry 로는 트리거되지 않아 false positive 차단.
+ *
+ * 제한
+ * ====
+ * - positions 가 비어 있으면 빈 배열 반환 (caller 는 기존 schedule-based fallback 진행).
+ * - segmentStations 가 비어 있으면 빈 배열 반환 (인덱스 산출 불가).
+ * - `realtimePosition` API 가 호선 전체 trains 를 반환하므로 line 필터는 caller 의 책임 (caller 는
+ *   target.line 의 positions 를 전달).
+ */
+
+import { pickAutoTrainCode } from './boardingPrompt';
+import { canonicalLineName } from './lineAlias';
+import type { ArrivalEntry, PositionEntry } from './seoul';
+
+/**
+ * hop 당 기본 소요(초). `scheduled.ts:FALLBACK_HOP_SEC` 와 동일 값을 사용해야 하지만,
+ * `scheduled.ts → lockSwap.ts → arrivalsFromPositions.ts → scheduled.ts` 순환 import 를
+ * 피하기 위해 본 모듈에서 별도 선언한다. 두 값은 항상 동일해야 한다 — `scheduled.ts` 의
+ * `FALLBACK_HOP_SEC` 변경 시 본 상수도 동시에 갱신.
+ */
+const HOP_SEC = 90;
+
+export interface SynthesizeArrivalsInputs {
+  /** `selfPollPositions` 또는 `seoul.fetchPositions(line)` 결과 — line 의 모든 trains. */
+  positions: readonly PositionEntry[];
+  /** target waypoint 의 line — `subwayNm` 합성 + matchLine cross-check 용. */
+  line: string;
+  /** 사용자 진행 방향. null 이면 양방향 허용. */
+  direction: 'up' | 'down' | null;
+  /** trip leg 의 segmentStations (origin 포함) — train 위치 인덱스 산출 기반. */
+  segmentStations: readonly string[];
+  /** 합성 ETA 계산 기준 target station name. */
+  targetStation: string;
+}
+
+/**
+ * positions list 에서 ArrivalEntry 들을 합성. 합성 가능한 train 이 없으면 빈 배열 반환.
+ *
+ * 본 함수는 pure — KV/네트워크 의존 없음. caller 가 결과를 real arrivals 와 merge 해서
+ * `pickAutoTrainCode` 에 전달한다.
+ */
+export function synthesizeArrivalsFromPositions(
+  inputs: SynthesizeArrivalsInputs,
+): ArrivalEntry[] {
+  const { positions, line, direction, segmentStations, targetStation } = inputs;
+  if (positions.length === 0 || segmentStations.length === 0) return [];
+
+  const targetIdx = segmentStations.indexOf(targetStation);
+  if (targetIdx < 0) return [];
+
+  const subwayNm = canonicalLineName(line) ?? '';
+  // canonical 매핑 누락 line (이론상 발생 X — caller 가 이미 subwayId 검증) 은 matchLine
+  // 우회 위험이 있어 빈 배열 반환으로 자연 차단.
+  if (!subwayNm) return [];
+
+  const synthesized: ArrivalEntry[] = [];
+  for (const train of positions) {
+    // direction 필터.
+    if (direction !== null) {
+      const wantUp = direction === 'up';
+      if (train.isUp !== wantUp) continue;
+    }
+    // segmentStations 위치 검증.
+    const currentIdx = segmentStations.indexOf(train.stationName);
+    if (currentIdx < 0) continue;
+    // 이미 target 을 지난 train 은 제외.
+    if (currentIdx > targetIdx) continue;
+    // ETA 합성 — currentIdx === targetIdx 인 경우 (이미 target 역에 있음) arrivalSeconds=0.
+    const hops = targetIdx - currentIdx;
+    const arrivalSeconds = hops * HOP_SEC;
+    synthesized.push({
+      destination: '',
+      arrivalSeconds,
+      trainCode: train.trainCode,
+      isUp: train.isUp,
+      subwayNm,
+      // ENTERING(0) — 보수적. priority 우선순위에서 가장 낮아 real arrivals 가 같은 train 을
+      // 더 강한 신호로 표기하면 priority 가 우선됨.
+      arvlCd: 0,
+    });
+  }
+  return synthesized;
+}
+
+/**
+ * `pickAutoTrainCode(realArrivals, ...)` 가 candidate 를 찾지 못한 경우 positions snapshot 으로
+ * 합성 entry 를 만들어 retry 하는 helper.
+ *
+ * autoLock + lockSwap 두 caller 모두 동형 패턴 (real candidate 시도 → 실패 시 합성 retry) 을
+ * 쓰므로 한 곳에 모아 SonarCloud duplication < 3% 유지.
+ *
+ * 반환:
+ *   - `{ trainCode, arrivals }` — fallback 으로 채택한 trainCode + merged arrivals (caller 의
+ *     subsequent `arrivals.find` 가 fallback 분기 entry 를 찾을 수 있도록 merged 를 노출).
+ *   - `null` — positions 미전달 / 합성 0건 / 합성 후에도 ambiguity 등 → caller 는 기존 null 동작.
+ */
+export interface FallbackPickInputs {
+  realArrivals: readonly ArrivalEntry[];
+  positions: readonly PositionEntry[] | undefined;
+  line: string;
+  direction: 'up' | 'down' | null;
+  segmentStations: readonly string[];
+  targetStation: string;
+}
+
+export function pickFallbackTrainCodeFromPositions(
+  inputs: FallbackPickInputs,
+): { trainCode: string; arrivals: readonly ArrivalEntry[] } | null {
+  const { realArrivals, positions, line, direction, segmentStations, targetStation } = inputs;
+  if (!positions || positions.length === 0) return null;
+
+  const synthesized = synthesizeArrivalsFromPositions({
+    positions,
+    line,
+    direction,
+    segmentStations,
+    targetStation,
+  });
+  if (synthesized.length === 0) return null;
+
+  // real arrivals 가 있는 경우 merge — real 의 arvlCd 우선순위(2/1/0) 가 자연 우선됨.
+  // 같은 trainCode 가 양쪽에 있으면 real 우선 (synthesized 는 arvlCd=0 으로 보수적).
+  const realCodes = new Set(realArrivals.map((a) => a.trainCode));
+  const merged: readonly ArrivalEntry[] = [
+    ...realArrivals,
+    ...synthesized.filter((s) => !realCodes.has(s.trainCode)),
+  ];
+  const trainCode = pickAutoTrainCode(merged, line, direction);
+  if (!trainCode) return null;
+  return { trainCode, arrivals: merged };
+}
+
+/**
+ * `pickAutoTrainCode` 시도 → 실패 시 `pickFallbackTrainCodeFromPositions` retry 의 결합 helper.
+ *
+ * autoLock + lockSwap 두 caller 가 동형으로 사용 (direction 만 다름) — duplication < 3% 유지를
+ * 위해 한 곳에 모음. 반환된 `arrivals` 는 caller 가 chosen entry 의 subwayNm cross-check 등
+ * subsequent verification 에 사용한다.
+ *
+ * 입력
+ *   - realArrivals: `seoul.fetchArrivals(target.stationName)` 결과 (호출자 책임)
+ *   - 그 외: pickFallbackTrainCodeFromPositions 와 동일.
+ *
+ * 반환
+ *   - `{ trainCode, arrivals }` — real 또는 fallback 으로 결정된 candidate + 검증용 arrivals.
+ *   - `null` — 양쪽 모두 실패. caller 는 기존 null 동작 진행.
+ */
+export interface ResolveTrainCodeInputs {
+  realArrivals: readonly ArrivalEntry[];
+  positions: readonly PositionEntry[] | undefined;
+  line: string;
+  direction: 'up' | 'down' | null;
+  segmentStations: readonly string[];
+  targetStation: string;
+}
+
+export function resolveTrainCodeWithFallback(
+  inputs: ResolveTrainCodeInputs,
+): { trainCode: string; arrivals: readonly ArrivalEntry[] } | null {
+  const { realArrivals, line, direction } = inputs;
+  const realCandidate =
+    realArrivals.length > 0 ? pickAutoTrainCode(realArrivals, line, direction) : null;
+  if (realCandidate) return { trainCode: realCandidate, arrivals: realArrivals };
+  return pickFallbackTrainCodeFromPositions(inputs);
+}

--- a/backend/alarm-worker/src/autoLock.ts
+++ b/backend/alarm-worker/src/autoLock.ts
@@ -28,7 +28,8 @@
  * (지하 7일 누적 0건) 직접 해소.
  */
 
-import { pickAutoTrainCode, type GateOutcome } from './boardingPrompt';
+import { resolveTrainCodeWithFallback } from './arrivalsFromPositions';
+import { type GateOutcome } from './boardingPrompt';
 import {
   evaluateConsensusGate,
   isLockLineAllowed,
@@ -37,7 +38,7 @@ import {
 import { matchLine, subwayIdForLine } from './lineAlias';
 import { buildLegSegmentStations, SWAP_LOCK_TTL_MS } from './lockSwap';
 import { METRIC_KIND, writeMetricDataPoints, type HistogramMetric } from './metrics';
-import type { SeoulArrivalClient } from './seoul';
+import type { PositionEntry, SeoulArrivalClient } from './seoul';
 import type {
   AnalyticsEngineWriter,
   BoardingLockMeta,
@@ -173,8 +174,13 @@ export interface AttemptAutoLockInputs {
    * `recptnMs` 미포함(=0 또는 undefined) entry는 age 가드를 skip (backward-compat).
    *
    * 미전달(undefined) / 빈 배열 시 consensusGate가 자연 `?? false` fallback (strongBE 동작 유지).
+   *
+   * #1702 (B2-A) — Seoul OpenAPI 단방향/0건 arrivals fallback 에도 본 list 가 사용된다. positions
+   * 의 `isUp` + `stationName` 을 기반으로 segmentStations 진행 방향 trains 만 추출 → ArrivalEntry
+   * 합성 → `pickAutoTrainCode` retry. 따라서 entry 의 `isUp` / `trainSttus` 필드 (PositionEntry)
+   * 가 필요해졌으므로 narrow 구조 대신 PositionEntry 전체 타입을 받는다.
    */
-  selfPollPositions?: readonly { trainCode: string; stationName: string; recptnMs?: number }[];
+  selfPollPositions?: readonly PositionEntry[];
   /**
    * #1667 (ADR-015 strongDB wire) — device가 WiFi SSID 매핑으로 결정한 역명.
    *
@@ -271,11 +277,23 @@ export async function attemptAutoLock(
   const segmentStations =
     legStations[0] === originStation ? legStations : [originStation, ...legStations];
 
-  const arrivals = await seoul.fetchArrivals(targetWaypoint.stationName);
-  if (arrivals.length === 0) return { lock: null };
-
-  const trainCode = pickAutoTrainCode(arrivals, line, direction);
-  if (!trainCode) return { lock: null };
+  const realArrivals = await seoul.fetchArrivals(targetWaypoint.stationName);
+  // #1702 (B2-A) — Seoul OpenAPI 단방향/0건 시 realtimePosition fallback.
+  //
+  // realArrivals 가 비어 있거나, `pickAutoTrainCode` 가 user direction 으로 candidate 를 찾지
+  // 못한 경우 (단방향만 반환된 케이스) selfPollPositions 에서 ArrivalEntry 를 합성한다.
+  // 합성된 entry 는 segmentStations 인덱스 기반 ETA + canonical subwayNm 으로 matchLine
+  // cross-check 까지 통과한다. positions 미전달 / 빈 list 시 기존 동작 (null 반환) 유지.
+  const resolved = resolveTrainCodeWithFallback({
+    realArrivals,
+    positions: selfPollPositions,
+    line,
+    direction,
+    segmentStations,
+    targetStation: targetWaypoint.stationName,
+  });
+  if (!resolved) return { lock: null };
+  const { trainCode, arrivals } = resolved;
 
   // line cross-check (2단 방어, #1626 follow-up) — `pickAutoTrainCode`가 이미 `matchLine`을
   // 적용하지만, chosen trainCode 의 실제 entry 의 subwayNm 이 line 과 매칭되는지 한 번 더

--- a/backend/alarm-worker/src/lockSwap.ts
+++ b/backend/alarm-worker/src/lockSwap.ts
@@ -14,10 +14,10 @@
  *  - 추가로 `pickAutoTrainCode`(boardingPrompt.ts)의 arvlCd 우선순위(2>1>0)로 ambiguity 회피.
  */
 
-import { pickAutoTrainCode } from './boardingPrompt';
+import { resolveTrainCodeWithFallback } from './arrivalsFromPositions';
 import { isLockLineAllowed } from './consensusGate';
 import { matchLine, subwayIdForLine } from './lineAlias';
-import type { SeoulArrivalClient } from './seoul';
+import type { PositionEntry, SeoulArrivalClient } from './seoul';
 import type { BoardingLockMeta, LineNumber, Trip, Waypoint } from './types';
 
 /**
@@ -61,6 +61,15 @@ export interface AttachLockInputs {
    * 미전달 시 검증 skip(구 호출자 호환).
    */
   allowedLines?: Set<LineNumber>;
+  /**
+   * #1702 (B2-A) — Seoul OpenAPI 단방향/0건 fallback 용 realtimePosition snapshot.
+   *
+   * caller (scheduled.ts `attemptVanishSwap` / transfer-swap site) 가
+   * `readSelfPollPosition(env.TRIPS, line)` 결과를 전달한다. arrivals 가 비거나
+   * `pickAutoTrainCode` 가 candidate 를 찾지 못한 경우 positions 에서 segmentStations 기반
+   * ArrivalEntry 를 합성해 retry. 미전달 / 빈 list 시 기존 동작 (null 반환) 유지.
+   */
+  selfPollPositions?: readonly PositionEntry[];
 }
 
 /**
@@ -78,7 +87,7 @@ export interface AttachLockInputs {
 export async function attachTrainCodeForLeg(
   inputs: AttachLockInputs,
 ): Promise<BoardingLockMeta | null> {
-  const { targetWaypoint, seoul, now, trip, allowedLines } = inputs;
+  const { targetWaypoint, seoul, now, trip, allowedLines, selfPollPositions } = inputs;
   const line = targetWaypoint.line;
   const subwayId = subwayIdForLine(line);
   if (!subwayId) return null;
@@ -88,11 +97,20 @@ export async function attachTrainCodeForLeg(
   const segmentStations = buildLegSegmentStations(trip.waypoints, line);
   if (segmentStations.length === 0) return null;
 
-  const arrivals = await seoul.fetchArrivals(targetWaypoint.stationName);
-  if (arrivals.length === 0) return null;
-
-  const trainCode = pickAutoTrainCode(arrivals, line, null);
-  if (!trainCode) return null;
+  const realArrivals = await seoul.fetchArrivals(targetWaypoint.stationName);
+  // #1702 (B2-A) — Seoul OpenAPI 단방향/0건 시 realtimePosition fallback. autoLock 과 동일 패턴.
+  // direction=null 인 swap 흐름에서도 segmentStations 기반 필터로 같은 line 의 진행 방향 trains
+  // 만 추출되므로 wrong-direction lock 회귀를 차단한다 (transfer 후 leg + vanish 후 재부착 모두).
+  const resolved = resolveTrainCodeWithFallback({
+    realArrivals,
+    positions: selfPollPositions,
+    line,
+    direction: null,
+    segmentStations,
+    targetStation: targetWaypoint.stationName,
+  });
+  if (!resolved) return null;
+  const { trainCode, arrivals } = resolved;
 
   // line cross-check (2단 방어, #1626 follow-up) — `pickAutoTrainCode`가 이미 `matchLine`을
   // 적용하지만, chosen trainCode entry 의 subwayNm 이 line 과 매칭되는지 한 번 더 verify.

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -1823,12 +1823,16 @@ async function attemptVanishSwap(
   trip: Trip,
   waypoint: Waypoint,
   activeLock: BoardingLockMeta,
+  env: Env,
   deps: ScheduledDeps,
   now: number,
   log: Logger,
 ): Promise<BoardingLockMeta | null> {
   const previousMissCount = trip.consecutiveEtaMissing ?? 0;
   if (previousMissCount + 1 < VANISH_RE_ATTACH_THRESHOLD) return null;
+  // #1702 (B2-A) — Seoul 단방향/0건 arrivals fallback. attachTrainCodeForLeg 가 candidate 를
+  // 찾지 못하면 line 의 realtimePosition snapshot 에서 segmentStations 기반 합성을 시도.
+  const selfPollPositions = await readSelfPollPosition(env.TRIPS, waypoint.line);
   const swapped = await attachTrainCodeForLeg({
     trip,
     targetWaypoint: waypoint,
@@ -1836,6 +1840,7 @@ async function attemptVanishSwap(
     now,
     // #1439 (E6, ADR-015 §9) — vanish-swap이 trip route 외 line으로 잘못 매핑되지 않도록.
     allowedLines: computeAllowedLines(trip.route, trip.waypoints),
+    selfPollPositions: selfPollPositions?.positions,
   });
   if (!swapped || swapped.trainCode === activeLock.trainCode) return null;
   log('boarding-lock: trainCode vanished, swapped', {
@@ -2067,7 +2072,7 @@ export async function runTrainCodeTracking(
   let activeLock = lock;
   let estimate = await estimateBoardingLockArrival(deps, activeLock, waypoint, now);
   if (estimate === null) {
-    const swappedLock = await attemptVanishSwap(trip, waypoint, activeLock, deps, now, log);
+    const swappedLock = await attemptVanishSwap(trip, waypoint, activeLock, env, deps, now, log);
     if (swappedLock) {
       activeLock = swappedLock;
       estimate = await estimateBoardingLockArrival(deps, activeLock, waypoint, now);
@@ -2422,6 +2427,9 @@ export async function advanceBoardingLockWaypoint(
   let transferSwapAttached = false;
   if (lockReleasedOnTransfer && trip.waypoints.length > 0) {
     const next = trip.waypoints[0];
+    // #1702 (B2-A) — transfer-swap arrivals 단방향/0건 fallback. 새 leg 의 line positions 를 함께
+    // 전달해 `attachTrainCodeForLeg` 내부에서 합성 ArrivalEntry retry path 활성화.
+    const transferSelfPoll = await readSelfPollPosition(env.TRIPS, next.line);
     const swapped = await attachTrainCodeForLeg({
       trip,
       targetWaypoint: next,
@@ -2429,6 +2437,7 @@ export async function advanceBoardingLockWaypoint(
       now,
       // #1439 (E6, ADR-015 §9) — transfer-swap이 trip route 외 line으로 잘못 매핑되지 않도록.
       allowedLines: computeAllowedLines(trip.route, trip.waypoints),
+      selfPollPositions: transferSelfPoll?.positions,
     });
     if (swapped) {
       trip.boardingLock = swapped;


### PR DESCRIPTION
## Summary

- 신규 `arrivalsFromPositions.ts`: positions snapshot으로 `ArrivalEntry` 합성
  - direction filter + segmentStations 위치 검증 + ETA hop 산출
  - 합성 `arvlCd=0` (보수, real arrivals 우선)
- `autoLock` + `lockSwap`에서 `resolveTrainCodeWithFallback` 사용
- 2029 backend tests pass (+386 신규)

## Self-review 발견 follow-up 우려 (별도 sub-issue 권장)

1. **`lockSwap`에서 direction=null 호출 시 양방향 candidate 통과** — wrong direction lock 우려. 후속: `lockSwap` caller가 #1703 (6호선 loop direction)을 활용해 direction 산출하도록 변경.
2. **합성 `arvlCd=0`이 `consensusGate` strongBE 통과** — `arvlCd ∈ [0,3]`이 `arrivalSignalPresent=true`라 signal B(arrival)/C(position) 분리 정합성 일부 약화. 후속: underground 분기에서 합성 entry 차별화 (별 flag).
3. **`HOP_SEC=90` 중복** — `scheduled.ts:FALLBACK_HOP_SEC`와 sync 코멘트만. 후속: 별 상수 SSOT.

## Test plan

- [x] backend `npm test`: 2029 pass
- [x] `npm run type-check`: pass
- [ ] 사용자 6/23 합정→용마산 trip 재현 시 train code 6184(응암) 잡힘 0건

## Wire-completion

1. Orphan: 신규 export caller 존재 (autoLock + lockSwap)
2. V/X dashboard: wrangler tail `synthesizeArrivalsFromPositions` count
3. 의존 PR: N/A (단, #1703 6호선 loop이 효과 cascade)
4. 측정 plan: backend log `pickAutoTrainCode` candidate count + selected trainCode direction 분포
5. Device verify: type+unit only

Closes #1702