### PR TITLE
fix(#1704): revalidate-position-mismatch 게이트 + cross-trip cleanup 강화

### DIFF
--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -1378,6 +1378,144 @@ describe('useApnsTripRegistration', () => {
       expect(mockRegister).not.toHaveBeenCalled();
     });
   });
+
+  // #1704 (d) — destination.id / boardingLockSig 전환 시 cross-trip cleanup 강화.
+  // 2026-06-23 사용자 trip evidence: 14:18 2차 trip 등록 직후 1차 trip의 공덕/군자 stale fire.
+  // routeSig는 같지만(예: 같은 line · 같은 hop 수의 다른 destination) destination/lock 변경만으로도 cancel 트리거.
+  describe('#1704 (d) destination.id / boardingLockSig 전환 시 cross-trip cancel', () => {
+    type TripProps = {
+      route: Route | null;
+      destination: Station | null;
+      boardingLock?: {
+        destinationId: string;
+        trainCode: string;
+        boardingStationId: string;
+        boardingLine: '2';
+        boardedAt: number;
+        expectedDurationMs: number;
+      } | null;
+    };
+    const renderTrip = (initialProps: TripProps) =>
+      renderHook(
+        ({ route, destination, boardingLock }: TripProps) =>
+          useApnsTripRegistration({
+            route,
+            destination,
+            nextStationEtaSeconds: 120,
+            boardingLock: boardingLock ?? null,
+          }),
+        { initialProps },
+      );
+
+    // it.each + factory로 trip-switch trigger 3종(route/destination/lock) 케이스 공통 패턴 dedup.
+    // 같은 patterns(첫 register → trigger change → cancel + 재register 검증).
+    const lockA = {
+      destinationId: station.id,
+      trainCode: '7246',
+      boardingStationId: station.id,
+      boardingLine: '2' as const,
+      boardedAt: 1_700_000_000_000,
+      expectedDurationMs: 600_000,
+    };
+    const lockB = { ...lockA, trainCode: '7415', boardedAt: 1_700_000_500_000 };
+    const altStation: Station = { ...station, id: '2-023', name: '역삼' };
+
+    it('routeSig 동일 + destination.id 변경 시 cancelTripBoundAlarms 호출', async () => {
+      const { rerender } = renderTrip({
+        route: makeDirectRoute(5, '2'),
+        destination: station,
+      });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockCancelTripBoundAlarms).not.toHaveBeenCalled();
+
+      // routeSig 동일 (같은 line·stops) + destination만 다른 역으로 변경.
+      // 기존 #1264 게이트는 routeSig만 검사라 trigger 안 됐지만 #1704 (d)는 destination 변경도 잡는다.
+      rerender({ route: makeDirectRoute(5, '2'), destination: altStation });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1);
+    });
+
+    it('routeSig 동일 + boardingLockSig 변경 시 cancelTripBoundAlarms 호출', async () => {
+      const { rerender } = renderTrip({
+        route: makeDirectRoute(5, '2'),
+        destination: station,
+        boardingLock: lockA,
+      });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockCancelTripBoundAlarms).not.toHaveBeenCalled();
+
+      // routeSig 동일 + destination 동일 + lock만 다른 trainCode로 변경.
+      rerender({ route: makeDirectRoute(5, '2'), destination: station, boardingLock: lockB });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1);
+    });
+
+    it('routeSig + destination + lock 모두 동일하면 cancel 호출 안 함 (false positive 차단)', async () => {
+      const { rerender } = renderTrip({
+        route: makeDirectRoute(5, '2'),
+        destination: station,
+        boardingLock: lockA,
+      });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+
+      // 모든 trigger 동일 — reference만 신규.
+      rerender({
+        route: makeDirectRoute(5, '2'),
+        destination: { ...station },
+        boardingLock: { ...lockA },
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockCancelTripBoundAlarms).not.toHaveBeenCalled();
+    });
+
+    it('trip 종료(route/destination → null) 후 새 trip 시작 시 첫 register는 cancel 호출 안 함 (모든 ref reset)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+        if (key === APNS_TOKEN_KEY) return 'token-abc';
+        if (key === ACTIVE_TRIP_KEY) return 'token-abc';
+        return null;
+      });
+      const { rerender } = renderTrip({
+        route: makeDirectRoute(5, '2'),
+        destination: station,
+        boardingLock: lockA,
+      });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+
+      // trip 종료 — 모든 ref(routeSig/destinationId/lockSig) reset.
+      rerender({ route: null, destination: null, boardingLock: null });
+      await waitFor(() => expect(mockClear).toHaveBeenCalled());
+
+      // 새 trip 시작 — 모든 ref가 null로 reset되었으므로 cancel skip.
+      rerender({
+        route: makeDirectRoute(7, '2'),
+        destination: altStation,
+        boardingLock: lockB,
+      });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      expect(mockCancelTripBoundAlarms).not.toHaveBeenCalled();
+    });
+
+    it('routeSig + destination + lock이 모두 동시에 바뀌어도 cancel 1회만 호출', async () => {
+      const { rerender } = renderTrip({
+        route: makeDirectRoute(5, '2'),
+        destination: station,
+        boardingLock: lockA,
+      });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+
+      // 모든 trigger 동시 변경 (실제 trip switch 패턴).
+      rerender({
+        route: makeDirectRoute(7, '2'),
+        destination: altStation,
+        boardingLock: lockB,
+      });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      // cancel은 한 effect cycle 안에 1회만.
+      expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 // #1366 Layer 2 — route ↔ lock line 일치 검증 헬퍼.

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -238,6 +238,14 @@ export function useApnsTripRegistration({
   // 첫 setDestination(이전 sig 없음)에는 cancel 호출 X — 불필요한 OS 호출 방지.
   const lastRouteSigRef = useRef<string | null>(null);
 
+  // #1704 (d) — 직전 effect cycle의 destination.id / boardingLockSig. routeSig는 같지만
+  // destination 또는 lock 내용이 바뀌면 (예: 같은 line·hop 수의 다른 destination) routeSig
+  // 단독 게이트가 전환을 감지 못해 stale tba: 사전 예약이 OS queue에 잔존한다. 2026-06-23
+  // 사용자 trip evidence: 14:18 2차 trip 등록 직후 1차 trip의 공덕/군자 stale fire.
+  // 첫 register(이전 값 없음)에는 cancel 호출 X — 신규 trip은 cancel할 대상 없음.
+  const lastDestinationIdRef = useRef<string | null>(null);
+  const lastBoardingLockSigRef = useRef<string | null>(null);
+
   // ── 토큰 발급 + 리스너 등록 (mount-once) ──
   useEffect(() => {
     let cancelled = false;
@@ -325,25 +333,38 @@ export function useApnsTripRegistration({
         // 트립 없음 분기에서도 lock 시그를 reset — 다음 trip이 새로 등록될 때 첫 cycle은
         // 즉시 발사(debounce 미적용) 보장.
         lastSentLockSigRef.current = null;
-        // #1264 (N3): trip 종료 시 routeSig 추적도 reset — 다음 trip 시작 시 첫 routeSig는
-        // 신규로 취급되어 cancel skip(불필요한 OS 호출 방지).
+        // #1264 (N3) + #1704 (d): trip 종료 시 routeSig / destination.id / boardingLockSig 추적
+        // 모두 reset — 다음 trip 시작 시 첫 register는 신규로 취급되어 cancel skip(불필요한 OS 호출 방지).
         lastRouteSigRef.current = null;
+        lastDestinationIdRef.current = null;
+        lastBoardingLockSigRef.current = null;
         // #1284: trip 종료 시 prompt context 캐시 reset — 다음 trip이 이전 trip의
         // 출발역 컨텍스트를 stamp하는 오염 방지.
         lastPromptContextRef.current = null;
         return;
       }
 
-      // #1264 (N3) — routeSig 전환 감지: 이전 routeSig가 있고 다르면 사전 예약된 `tba:` 알람
-      // cancel. backend 정정 silent push가 stale identifier에 매칭 실패하는 회귀 차단.
-      // 첫 setDestination(lastRouteSigRef=null)에는 호출 X — 신규 trip은 cancel할 대상 없음.
+      // #1264 (N3) + #1704 (d) — routeSig / destination.id / boardingLockSig 어느 하나라도
+      // 전환되면 사전 예약된 `tba:` 알람 cancel. backend 정정 silent push가 stale identifier에
+      // 매칭 실패하는 회귀 차단 + 같은 routeSig에서 destination/lock만 바뀐 cross-trip 잔재
+      // (2026-06-23 trip evidence: 14:18 2차 trip 등록 직후 1차 trip 공덕/군자 stale fire) 차단.
+      // 첫 register(이전 값 모두 null)에는 호출 X — 신규 trip은 cancel할 대상 없음.
       // cancel 실패해도 후속 register는 진행 (graceful) — runTripBoundCleanups + useTripBoundAlarmScheduler
       // 가 별경로로 동일 cleanup을 시도하므로 본 호출은 belt-and-suspenders.
-      if (lastRouteSigRef.current !== null && lastRouteSigRef.current !== routeSig) {
+      const hasPrevTrip =
+        lastRouteSigRef.current !== null ||
+        lastDestinationIdRef.current !== null ||
+        lastBoardingLockSigRef.current !== null;
+      const tripSwitched =
+        hasPrevTrip &&
+        (lastRouteSigRef.current !== routeSig ||
+          lastDestinationIdRef.current !== destination.id ||
+          lastBoardingLockSigRef.current !== boardingLockSig);
+      if (tripSwitched) {
         try {
           await cancelTripBoundAlarms();
         } catch (e) {
-          logger.warn('cancelTripBoundAlarms (route switch) 실패:', e);
+          logger.warn('cancelTripBoundAlarms (trip switch) 실패:', e);
         }
         if (cancelled) return;
       }
@@ -382,8 +403,11 @@ export function useApnsTripRegistration({
       // POST 발사 직후(성공/실패 무관) 송신된 lock sig를 기록 — 다음 cycle이 "직전 송신 = lock,
       // 신규 = null" 패턴인지 판정해 race 차단.
       lastSentLockSigRef.current = boardingLockSig;
-      // #1264 (N3) — POST 발사 직후 송신된 routeSig를 기록. 다음 cycle에서 전환 감지에 사용.
+      // #1264 (N3) + #1704 (d) — POST 발사 직후 송신된 routeSig / destination.id / boardingLockSig
+      // 를 기록. 다음 cycle이 trip 전환(어느 하나라도 변경) 시 cancel 트리거.
       lastRouteSigRef.current = routeSig;
+      lastDestinationIdRef.current = destination.id;
+      lastBoardingLockSigRef.current = boardingLockSig;
       // #669: cancelled 가드 밖에서 setItem — backend register 성공이면 UI cleanup 여부와 무관하게
       // ACTIVE_TRIP_KEY를 동기화. 가드 안에 두면 nextStationEtaSeconds·currentStation 변경으로
       // useEffect cleanup이 자주 일어나 setItem이 skip되고 DebugModal activeTrip이 (none)으로 표시됨.

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -733,6 +733,8 @@ describe('alarmLog', () => {
       ['revalidate-no-trip' as const, '강남', 'early' as const],
       ['revalidate-route-sig-mismatch' as const, '시청', 'imminent' as const],
       ['revalidate-waypoint-mismatch' as const, '서울역', 'early' as const],
+      // #1704 — 사용자 위치 대비 fire 대상이 N hop 이상 미래 (2026-06-23 trip evidence backstop).
+      ['revalidate-position-mismatch' as const, '종로3가', 'imminent' as const],
     ])(
       '#918 A3 PR2 logSuppressedTbaRevalidation: %s — source=bg-scheduled 고정 + reason/stationName/phaseId 보존',
       async (reason, stationName, phaseId) => {

--- a/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
+++ b/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
@@ -67,6 +67,13 @@ jest.mock('../alarmLog', () => ({
   logSuppressedTbaRevalidation: (...args: unknown[]) => mockLogSuppressedTbaRevalidation(...args),
 }));
 
+// #1704 — position-mismatch 게이트가 backend SSoT mirror를 read해 사용자 currentStation을 결정.
+// 기본은 null 반환(mirror 부재 → 게이트 skip)으로 기존 테스트 동작 보존.
+const mockReadBackendSsotMirror = jest.fn();
+jest.mock('../backendSsotMirror', () => ({
+  readBackendSsotMirror: (...args: unknown[]) => mockReadBackendSsotMirror(...args),
+}));
+
 const mockErrorSpy = jest.fn();
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
@@ -137,6 +144,9 @@ beforeEach(async () => {
   mockResolveAllTargets.mockReset();
   mockResolveAllTargets.mockReturnValue([{ name: '강남' }, { name: '시청' }, { name: '서울역' }]);
   mockLogSuppressedTbaRevalidation.mockReset();
+  // #1704 — 기본은 mirror null (위치 게이트 skip → 기존 동작 유지). 새 테스트는 mockResolvedValue로 override.
+  mockReadBackendSsotMirror.mockReset();
+  mockReadBackendSsotMirror.mockResolvedValue(null);
   // 기본 AppState 스파이 — 각 테스트는 mockImplementationOnce로 추가 override 가능.
   appStateSpy = jest
     .spyOn(AppState, 'addEventListener')
@@ -906,6 +916,293 @@ describe('bl: fire-time 재검증 (#1282)', () => {
       expect(mockSetFiredAlarms).toHaveBeenCalledWith('dest-1', new Set(['early:강남']));
       expect(blChannel.registeredSigMock).not.toHaveBeenCalled();
       handle.remove();
+    });
+  });
+});
+
+// #1704 — position-mismatch 게이트: 사용자 currentStation 대비 fire 대상이 N hop 이상
+// 미래면 suppress. 2026-06-23 사용자 trip evidence(14:04 신촌 trip 중 종로3가/충정로 BG misfire,
+// 14:18 합정 trip 등록 직후 공덕/군자 미리 fire)의 backstop.
+describe('#1704 position-mismatch 게이트', () => {
+  // 강남(2-022) → 시청(2-001) direct route on line 2 (21 hops via 외선/외부 순환).
+  // 시청·강남·역삼·선릉 등 실 stations.json 데이터로 routeToWaypoints가 intermediate 시퀀스를 생성.
+  const LONG_ROUTE_JSON = JSON.stringify({ type: 'direct', stops: 21, line: '2', travelSeconds: 1260 });
+  const SIHCEONG_DEST_JSON = JSON.stringify({ id: '2-001', name: '시청' });
+
+  // mirror fixture factory. dedup overhead 없이 source별 차이만 입력.
+  // fresh=현재 시각 기준 receivedAt, stale=5+ min 이전 receivedAt.
+  const makeMirror = (currentStationId: string, ageMs = 0) => ({
+    currentStationId,
+    motionState: 'moving' as const,
+    lastAdvanceEvidence: 'test',
+    lastAdvanceAt: Date.now() - ageMs,
+    passedStations: [] as string[],
+    receivedAt: Date.now() - ageMs,
+  });
+
+  beforeEach(() => {
+    setStorageMap({
+      'subway-now:destination': SIHCEONG_DEST_JSON,
+      'subway-now:route': LONG_ROUTE_JSON,
+    });
+    // 본 블록은 routeToWaypoints만 호출하는 위치 게이트를 검증.
+    // resolveAllTargets mock은 waypoint mismatch 게이트가 통과되도록 fire 대상이 포함된 list로 변경.
+    mockResolveAllTargets.mockReturnValue([
+      { name: '시청' },
+      { name: '강남' }, // 강남도 통과시켜 waypoint mismatch 차단 우회 (위치 게이트 검증 목적)
+    ]);
+  });
+
+  // it.each + factory로 같은 패턴(mirror+identifier→expected reason) 반복 코드 dedup (SonarCloud).
+  // pass 케이스는 reason 미발사 검증, suppress 케이스는 reason 검증 + cancel(#1354) 동반 검증.
+  describe('reconcileScheduledAlarmDelivery — `tba:` 단건', () => {
+    it.each([
+      {
+        label: '사용자 강남(2-022) + fire=시청(시청은 21 hop 미래) → suppress',
+        mirrorStationId: '2-022',
+        identifier: 'tba:early:시청',
+        expectedReason: 'revalidate-position-mismatch' as const,
+        expectedStationName: '시청',
+        expectedPhase: 'early',
+      },
+      {
+        label: '사용자 시청(2-001) + fire=시청 → currentName==targetName 즉시 pass',
+        mirrorStationId: '2-001',
+        identifier: 'tba:imminent:시청',
+        expectedReason: null,
+      },
+      {
+        label: '사용자 을지로4가(2-004, 시청 직전 3 hop) + fire=시청 → threshold 미만 pass',
+        // 을지로4가=2-004 → 을지로3가(2-003) → 을지로입구(2-002) → 시청(2-001) = 3 hop.
+        // POSITION_MISMATCH_HOP_THRESHOLD=5 미만이므로 pass.
+        mirrorStationId: '2-004',
+        identifier: 'tba:imminent:시청',
+        expectedReason: null,
+      },
+    ])('$label', async ({ mirrorStationId, identifier, expectedReason, expectedStationName, expectedPhase }) => {
+      mockReadBackendSsotMirror.mockResolvedValueOnce(makeMirror(mirrorStationId));
+
+      await reconcileScheduledAlarmDelivery(identifier);
+
+      if (expectedReason === null) {
+        expect(mockLogSuppressedTbaRevalidation).not.toHaveBeenCalled();
+        expect(mockCancelScheduled).not.toHaveBeenCalled();
+      } else {
+        expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith({
+          reason: expectedReason,
+          stationName: expectedStationName,
+          phaseId: expectedPhase,
+        });
+        expect(mockCancelScheduled).toHaveBeenCalledWith(identifier);
+      }
+    });
+
+    it('mirror가 5분+ stale이고 sticky 부재 → 게이트 skip (보수 fallback)', async () => {
+      // mirror receivedAt이 6분 전 → POSITION_MISMATCH_MIRROR_STALE_MS(5분) 초과로 skip.
+      // sticky storage 키도 부재.
+      mockReadBackendSsotMirror.mockResolvedValueOnce(
+        makeMirror('2-022', 6 * 60 * 1_000),
+      );
+      // 강남 위치 + 시청 fire는 원래라면 suppress 대상. mirror stale로 게이트 skip이라 pass.
+      await reconcileScheduledAlarmDelivery('tba:early:시청');
+
+      expect(mockLogSuppressedTbaRevalidation).not.toHaveBeenCalled();
+      expect(mockCancelScheduled).not.toHaveBeenCalled();
+    });
+
+    it('mirror 부재 + sticky 부재 → 게이트 skip (보수 fallback)', async () => {
+      // mockReadBackendSsotMirror 기본값 = null. sticky storage 키도 setStorageMap에 부재.
+      await reconcileScheduledAlarmDelivery('tba:early:시청');
+
+      expect(mockLogSuppressedTbaRevalidation).not.toHaveBeenCalled();
+      expect(mockCancelScheduled).not.toHaveBeenCalled();
+    });
+
+    it('mirror stale이고 sticky 있으면 sticky로 fallback해 게이트 적용', async () => {
+      // mirror stale + sticky=강남 → 강남 위치 fallback. fire=시청은 21 hop 미래 → suppress.
+      setStorageMap({
+        'subway-now:destination': SIHCEONG_DEST_JSON,
+        'subway-now:route': LONG_ROUTE_JSON,
+        'subway-now:sticky-station': JSON.stringify({
+          station: { id: '2-022', name: '강남', line: '2', lat: 37.5, lng: 127.0 },
+          lockedAt: Date.now() - 1_000,
+        }),
+      });
+      mockReadBackendSsotMirror.mockResolvedValueOnce(
+        makeMirror('2-022', 10 * 60 * 1_000), // 10 min stale
+      );
+
+      await reconcileScheduledAlarmDelivery('tba:early:시청');
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith({
+        reason: 'revalidate-position-mismatch',
+        stationName: '시청',
+        phaseId: 'early',
+      });
+    });
+
+    it('mirror 부재 + sticky JSON 파손 → 게이트 skip (graceful)', async () => {
+      setStorageMap({
+        'subway-now:destination': SIHCEONG_DEST_JSON,
+        'subway-now:route': LONG_ROUTE_JSON,
+        'subway-now:sticky-station': '{not json',
+      });
+      // mirror null + sticky parse fail → currentStation null → 게이트 skip.
+      await reconcileScheduledAlarmDelivery('tba:early:시청');
+
+      expect(mockLogSuppressedTbaRevalidation).not.toHaveBeenCalled();
+    });
+
+    it('sticky에 station.id 필드 누락 → 게이트 skip (graceful)', async () => {
+      setStorageMap({
+        'subway-now:destination': SIHCEONG_DEST_JSON,
+        'subway-now:route': LONG_ROUTE_JSON,
+        'subway-now:sticky-station': JSON.stringify({ station: { name: '강남' }, lockedAt: 0 }),
+      });
+
+      await reconcileScheduledAlarmDelivery('tba:early:시청');
+
+      expect(mockLogSuppressedTbaRevalidation).not.toHaveBeenCalled();
+    });
+
+    it('sticky에 station.id가 있지만 stations.json에 미존재 → 게이트 skip (graceful)', async () => {
+      // readStickyStation의 getStationById(id) ?? null 분기 cover.
+      // 사용자 환경에서 stations.json 갱신으로 옛 sticky id가 무효화된 케이스.
+      setStorageMap({
+        'subway-now:destination': SIHCEONG_DEST_JSON,
+        'subway-now:route': LONG_ROUTE_JSON,
+        'subway-now:sticky-station': JSON.stringify({
+          station: { id: '__deleted_station__', name: '폐역', line: '2', lat: 0, lng: 0 },
+          lockedAt: Date.now() - 1_000,
+        }),
+      });
+
+      await reconcileScheduledAlarmDelivery('tba:early:시청');
+
+      // currentStation null → 게이트 skip → suppress 없음.
+      expect(mockLogSuppressedTbaRevalidation).not.toHaveBeenCalled();
+    });
+
+    it('mirror.currentStationId가 stations.json에 없으면 sticky로 fallback', async () => {
+      setStorageMap({
+        'subway-now:destination': SIHCEONG_DEST_JSON,
+        'subway-now:route': LONG_ROUTE_JSON,
+        'subway-now:sticky-station': JSON.stringify({
+          station: { id: '2-022', name: '강남', line: '2', lat: 37.5, lng: 127.0 },
+          lockedAt: Date.now() - 1_000,
+        }),
+      });
+      // mirror fresh이지만 currentStationId가 stations.json에 없는 ID — getStationById null → fallback.
+      mockReadBackendSsotMirror.mockResolvedValueOnce(makeMirror('__no_such_id__'));
+
+      await reconcileScheduledAlarmDelivery('tba:early:시청');
+
+      // sticky=강남으로 fallback → 21 hop suppress.
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'revalidate-position-mismatch' }),
+      );
+    });
+
+    it('fire 대상이 route waypoint 시퀀스에 없으면 게이트 skip (route 외 역은 별 게이트 담당)', async () => {
+      // 사용자 강남, fire 대상은 route에 없는 '서울대입구' — routeToWaypoints에서 안 나옴 → null → skip.
+      // 단 waypoint mismatch 게이트가 먼저 차단할 수 있으므로 mockResolveAllTargets에 '서울대입구' 포함.
+      mockResolveAllTargets.mockReturnValueOnce([{ name: '서울대입구' }, { name: '시청' }]);
+      mockReadBackendSsotMirror.mockResolvedValueOnce(makeMirror('2-022'));
+
+      await reconcileScheduledAlarmDelivery('tba:early:서울대입구');
+
+      // route는 강남→시청. 서울대입구는 line 2이지만 시청과 정반대 방향 (외선). routeToWaypoints는
+      // currentStation=강남 → 시청 방향만 펼침 → 서울대입구는 시퀀스에 없음 → null → skip.
+      expect(mockLogSuppressedTbaRevalidation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('drainDeliveredScheduledAlarms — `tba:` 항목 위치 게이트', () => {
+    it('suppress된 position-mismatch 항목은 fired set/lastStationName 갱신에서 제외', async () => {
+      // 첫 항목 suppress (강남 위치+시청 fire, 21 hop), 두 번째 항목 pass (을지로4가 위치+시청 fire, 3 hop).
+      mockReadBackendSsotMirror
+        .mockResolvedValueOnce(makeMirror('2-022')) // 강남
+        .mockResolvedValueOnce(makeMirror('2-004')); // 을지로4가
+      mockGetPresented.mockResolvedValueOnce([
+        { date: 1, request: { identifier: 'tba:early:시청' } },
+        { date: 2, request: { identifier: 'tba:imminent:시청' } },
+      ]);
+      mockGetFiredAlarms.mockResolvedValueOnce(new Set());
+
+      const handle = registerScheduledAlarmListener();
+      await awaitInitialScheduledAlarmDrain();
+
+      // 첫 항목(강남 위치) suppress + cancel. 두 번째 항목(을지로4가 위치) pass → fired set에 등록.
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'revalidate-position-mismatch', stationName: '시청' }),
+      );
+      expect(mockCancelScheduled).toHaveBeenCalledWith('tba:early:시청');
+      // 두 번째(pass)만 fired set에 등록. destinationId='2-001' (SIHCEONG_DEST_JSON).
+      expect(mockSetFiredAlarms).toHaveBeenCalledWith('2-001', new Set(['imminent:시청']));
+      expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('시청');
+      handle.remove();
+    });
+  });
+
+  describe('revalidate 순서: position-mismatch는 다른 게이트 통과 후 진입', () => {
+    it('tripStart 미존재면 position 게이트보다 먼저 revalidate-no-trip', async () => {
+      mockGetTripStartedAt.mockResolvedValueOnce(null);
+      // mirror도 fresh이지만 tripStart 없음이 우선 차단.
+      mockReadBackendSsotMirror.mockResolvedValueOnce(makeMirror('2-022'));
+
+      await reconcileScheduledAlarmDelivery('tba:early:시청');
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'revalidate-no-trip' }),
+      );
+      // position-mismatch는 발사 안 함.
+      expect(mockLogSuppressedTbaRevalidation).not.toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'revalidate-position-mismatch' }),
+      );
+    });
+
+    it('route-sig mismatch면 position 게이트보다 먼저 revalidate-route-sig-mismatch', async () => {
+      mockGetRegisteredTripRouteSig.mockResolvedValueOnce('SIG-OLD');
+      mockRouteSignature.mockReturnValueOnce('SIG-NEW');
+      mockReadBackendSsotMirror.mockResolvedValueOnce(makeMirror('2-022'));
+
+      await reconcileScheduledAlarmDelivery('tba:early:시청');
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'revalidate-route-sig-mismatch' }),
+      );
+      expect(mockLogSuppressedTbaRevalidation).not.toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'revalidate-position-mismatch' }),
+      );
+    });
+
+    it('waypoint mismatch면 position 게이트보다 먼저 revalidate-waypoint-mismatch', async () => {
+      // mockResolveAllTargets에 '시청' 누락 → waypoint mismatch 먼저 차단.
+      mockResolveAllTargets.mockReturnValueOnce([{ name: '강남' }, { name: '역삼' }]);
+      mockReadBackendSsotMirror.mockResolvedValueOnce(makeMirror('2-022'));
+
+      await reconcileScheduledAlarmDelivery('tba:early:시청');
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'revalidate-waypoint-mismatch' }),
+      );
+      expect(mockLogSuppressedTbaRevalidation).not.toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'revalidate-position-mismatch' }),
+      );
+    });
+  });
+
+  describe('bl: 채널도 동일 게이트 적용', () => {
+    it('bl: identifier에도 position-mismatch 적용 (revalidateBlAlarm 공유 helper)', async () => {
+      mockReadBackendSsotMirror.mockResolvedValueOnce(makeMirror('2-022'));
+      // bl: identifier 포맷은 `bl:trainCode:hopIdx:phase:stationName`.
+      await reconcileScheduledAlarmDelivery('bl:T-100:0:early:시청');
+
+      expect(mockLogSuppressedTbaRevalidation).toHaveBeenCalledWith({
+        reason: 'revalidate-position-mismatch',
+        stationName: '시청',
+        phaseId: 'early',
+      });
     });
   });
 });

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -157,9 +157,16 @@ export type AlarmLogReason =
   //   'revalidate-no-trip': tripStart 미존재(이미 종료된 trip의 잔여 발화).
   //   'revalidate-route-sig-mismatch': 예약 시점 sig와 현재 sig 불일치(목적지 변경/환승 재산정).
   //   'revalidate-waypoint-mismatch': 파싱된 stationName이 현재 route waypoint에 없음.
+  //   'revalidate-position-mismatch' (#1704): fire 대상 stationName이 사용자 currentStation보다
+  //     N hop(POSITION_MISMATCH_HOP_THRESHOLD=5) 이상 미래라 fire 시점이 도래하지 않은 잔여 발화.
+  //     2026-06-23 사용자 trip evidence: 14:04 신촌(2-018) trip 중 종로3가/합정/충정로 3건 BG misfire,
+  //     14:18 합정 trip 등록 직후 공덕/군자 2건 BG misfire — 모두 routeSig/waypoint pass인데 사용자
+  //     위치가 fire 대상보다 한참 뒤. 기존 게이트가 사용자 위치를 검사하지 않아 OS DATE trigger
+  //     도달 시 그냥 fire. backend SSoT mirror + sticky station fallback으로 위치 결정.
   | 'revalidate-no-trip'
   | 'revalidate-route-sig-mismatch'
   | 'revalidate-waypoint-mismatch'
+  | 'revalidate-position-mismatch'
   // #1167 — boardingPrompt [탑승] 응답 → arvlCd 우선순위 autoLock 결과.
   //   'autolock-success': arvlCd 우선순위로 1대 확정 → createLock 성공.
   //   'autolock-no-trip': destinationId null (사용자 trip 종료 후 늦은 탭).
@@ -1381,7 +1388,11 @@ export function logHydrationTransition(
  * source='bg-scheduled' 재사용 — preschedule path 출처 통일(stamp/fired log와 동일 source).
  */
 export function logSuppressedTbaRevalidation(input: {
-  reason: 'revalidate-no-trip' | 'revalidate-route-sig-mismatch' | 'revalidate-waypoint-mismatch';
+  reason:
+    | 'revalidate-no-trip'
+    | 'revalidate-route-sig-mismatch'
+    | 'revalidate-waypoint-mismatch'
+    | 'revalidate-position-mismatch';
   stationName: string;
   phaseId?: AlarmPhaseId;
 }): void {

--- a/src/features/alarm/utils/scheduledAlarmReceiver.ts
+++ b/src/features/alarm/utils/scheduledAlarmReceiver.ts
@@ -1,3 +1,10 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: 사전 예약 알람 fire-time 재검증 게이트(#1704)가 features/route의
+ * routeToWaypoints를 호출해 사용자 currentStation 기반 hop distance를 계산한다. 알람 발사 정확도가
+ * route의 segment 순회 로직(intermediate name 추출 포함)에 본질적으로 의존하므로 직접 import가
+ * 자연스러움. 후속 PR에서 routeToWaypoints를 src/shared/utils/로 추출하거나 orchestration 슬라이스로
+ * 이전 예정. ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
 import * as Notifications from 'expo-notifications';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AppState, type AppStateStatus } from 'react-native';
@@ -7,7 +14,11 @@ import {
   setFiredAlarms,
   setLastFiredAlarmStationName,
 } from './notificationState';
-import { DESTINATION_KEY, ROUTE_KEY } from '../../../shared/constants/storageKeys';
+import {
+  DESTINATION_KEY,
+  ROUTE_KEY,
+  STICKY_STATION_KEY,
+} from '../../../shared/constants/storageKeys';
 import { createLogger } from '../../../shared/utils/logger';
 import { recordFiredAlarm } from './prescheduledMetrics';
 import {
@@ -24,7 +35,14 @@ import {
   BOARDING_LOCK_ALARM_PREFIX,
 } from './boardingLockScheduler';
 import { logSuppressedTbaRevalidation } from './alarmLog';
+import { readBackendSsotMirror } from './backendSsotMirror';
+import {
+  getStationById,
+  isSameStationName,
+} from '../../../shared/utils/stationRoute';
+import { routeToWaypoints } from '../../route/utils/routeWaypoints';
 import type { Route } from '../../../shared/utils/stationRoute';
+import type { Station } from '../../../shared/types/station';
 import type { AlarmPhaseId } from './alarmPhases';
 
 const logger = createLogger('ScheduledAlarmReceiver');
@@ -104,6 +122,19 @@ function parseDestinationName(raw: string | null): string | null {
 }
 
 /**
+ * #1704 — position-mismatch 게이트 임계값. 사용자 currentStation에서 fire 대상 stationName까지
+ * 이 hop 수 이상 떨어져 있으면 suppress.
+ *
+ * 5 hop 선택 근거: 2호선/1호선 환승 평균 2-3 hop 사이, BG fire 정상 임계(early phase=3 stops,
+ * imminent=1 stop)보다 충분히 여유. evidence: 14:04 신촌(2-018) → 종로3가(1-027) trip에서
+ * 사용자 신촌 위치인데 종로3가 미리 fire(약 6+ hop 미래) — 5 hop 임계로 차단.
+ *
+ * mirror가 5 min 이상 stale이면 게이트 자체를 skip(보수 fallback) — false negative 차단.
+ */
+const POSITION_MISMATCH_HOP_THRESHOLD = 5;
+const POSITION_MISMATCH_MIRROR_STALE_MS = 5 * 60 * 1_000;
+
+/**
  * 사전 예약 알람(`tba:` / `bl:`)의 fire-time 재검증 공통 구현 (#918 A3 PR2, #729 흡수, #1282).
  *
  * OS가 예약된 시각에 발사한 알람이 *현재* 시점에도 유효한지 확인한다. 두 채널이 동일한
@@ -116,11 +147,117 @@ function parseDestinationName(raw: string | null): string | null {
  *   1) (requireTripStart 시) tripStart 존재 — trip이 종료되지 않았다.
  *   2) ROUTE_KEY/DESTINATION_KEY 기반 현재 sig가 등록 시점 sig와 동일 — 목적지/환승 변경 없음.
  *   3) 파싱된 stationName이 현재 route waypoint 시퀀스 안에 있음 — 방어 검증.
+ *   4) (#1704) 사용자 currentStation 대비 fire 대상이 N hop 미래가 아님 — backend SSoT mirror +
+ *      sticky station fallback으로 위치 결정. 둘 다 부재/stale이면 보수적으로 게이트 skip.
  *
  * 한 가지라도 실패하면 reason과 함께 alarmLog에 적재하고 'suppress'를 반환한다.
  * 호출자는 fired set / lastStationName 갱신을 skip해 stale 알람이 후속 상태를 오염시키지 않게 한다.
  */
 type RevalidationSuppressReason = Parameters<typeof logSuppressedTbaRevalidation>[0]['reason'];
+
+/**
+ * #1704 — sticky station 영속화 데이터에서 Station을 안전하게 추출.
+ * 형식: `{station: Station, lockedAt: number}` JSON (useStickyStation.writePersistedLock과 일치).
+ * 파싱 실패 / 필수 필드 결손 시 null 반환 — fallback path가 graceful skip.
+ *
+ * stations.json id로 단일 조회해 stale data와 정합성 확보 — sticky write 시점 이후 stations.json
+ * 갱신이 있어도 게이트 결정이 최신 데이터 기준으로 일관.
+ */
+function readStickyStation(raw: string | null): Station | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as { station?: { id?: unknown } } | null;
+    const id = parsed?.station?.id;
+    if (typeof id !== 'string' || id.length === 0) return null;
+    return getStationById(id) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * #1704 — route 위 두 stationName의 hop distance(진행 방향 +).
+ *
+ * `currentStation`을 origin으로 두고 `routeToWaypoints`로 intermediate + transfer + destination
+ * 시퀀스(진행 방향 순서 보존)를 구성한다. 시퀀스 내 `targetName` 첫 매칭 index가 곧 hop distance
+ * (1-based: 1 = 바로 다음 역). `target`이 시퀀스에 없으면 null (게이트 skip). 같은 역(currentName
+ * 자체)이면 0 반환은 본 함수가 아닌 caller에서 currentName==targetName 체크로 처리한다 — 본 함수의
+ * 시퀀스는 currentStation 이후만 포함하므로 targetName==currentName이면 시퀀스에 없어 null이 된다.
+ *
+ * routeToWaypoints는 currentStation이 route 위 어느 leg에 속하든 그 leg부터 destination까지의
+ * intermediate를 펼친다. 환승 route에선 환승역 이후 leg도 자동으로 펼쳐진다.
+ *
+ * 같은 stationName이 여러 번 등장하는 순환 route(2호선 등)는 첫 매칭이 가장 이른 hop이므로
+ * 보수적으로 작은 hop distance를 반환 — false positive(suppress) 방지.
+ */
+function computeHopDistance(
+  route: NonNullable<Route>,
+  destinationName: string,
+  currentStation: Station,
+  targetName: string,
+): number | null {
+  const waypoints = routeToWaypoints(route, destinationName, currentStation);
+  /* istanbul ignore next -- routeToWaypoints는 destination waypoint를 항상 push하므로
+   * 실제 도달 불가능. defensive guard. */
+  if (waypoints.length === 0) return null;
+  // currentName(==currentStation.name)은 시퀀스에 포함되지 않음 — routeToWaypoints가
+  // intermediates(fromId 제외 ~ toId 제외)를 펼치기 때문. 따라서 sequence[0]은 currentStation의
+  // "다음 역"이고, index N은 N+1번째 hop이므로 1-based hop distance = idx + 1.
+  const targetIdx = waypoints.findIndex((w) => isSameStationName(w.stationName, targetName));
+  if (targetIdx === -1) return null;
+  return targetIdx + 1;
+}
+
+/**
+ * #1704 — fire 대상이 사용자 currentStation보다 N hop 이상 미래인지 판정.
+ *
+ * source 우선순위:
+ *   1) backend SSoT mirror (`BACKEND_SSOT_MIRROR_KEY`) — currentStationId가 가장 신뢰.
+ *      receivedAt이 5 min 이상 stale이면 사용 안 함(보수 fallback).
+ *   2) sticky station (`STICKY_STATION_KEY`) — name만 보유. mirror 부재 시 fallback.
+ *
+ * 둘 다 부재/stale이면 'pass' (기존 게이트만 적용). 위치 정보 부재로 false suppress 발생 위험이
+ * 크기 때문에 보수적으로 skip.
+ *
+ * 위치 source 결정 후 `computeHopDistance` 결과가 threshold 이상이면 'suppress'. 음수/0/null은
+ * pass (이미 통과한 역이거나 route 외 역은 별 게이트가 담당).
+ */
+async function evaluatePositionMismatch(input: {
+  route: NonNullable<Route>;
+  destinationName: string;
+  targetStationName: string;
+}): Promise<'pass' | 'suppress'> {
+  const [mirror, stickyRaw] = await Promise.all([
+    readBackendSsotMirror(),
+    AsyncStorage.getItem(STICKY_STATION_KEY),
+  ]);
+
+  // mirror 신뢰성: receivedAt 5 min 이내일 때만 사용.
+  let currentStation: Station | null = null;
+  if (mirror && Date.now() - mirror.receivedAt <= POSITION_MISMATCH_MIRROR_STALE_MS) {
+    currentStation = getStationById(mirror.currentStationId) ?? null;
+  }
+  // mirror가 stale이거나 매핑 실패면 sticky로 fallback.
+  if (currentStation === null) {
+    currentStation = readStickyStation(stickyRaw);
+  }
+  // 둘 다 부재 — 보수적으로 게이트 skip (기존 동작 유지).
+  if (currentStation === null) return 'pass';
+
+  // 사용자가 이미 target에 도달 — 본 게이트는 skip (기존 게이트가 fire 적절성 판정).
+  if (isSameStationName(currentStation.name, input.targetStationName)) return 'pass';
+
+  const hopDistance = computeHopDistance(
+    input.route,
+    input.destinationName,
+    currentStation,
+    input.targetStationName,
+  );
+  // route 외 / 매칭 실패는 별 게이트가 담당 — 본 게이트는 skip.
+  if (hopDistance === null) return 'pass';
+  // hop이 threshold 이상 미래면 suppress. threshold 미만(이미 통과 or 가까움)은 pass.
+  return hopDistance >= POSITION_MISMATCH_HOP_THRESHOLD ? 'suppress' : 'pass';
+}
 
 async function revalidatePrescheduledAlarm(
   parsed: { phaseId: string; stationName: string },
@@ -160,6 +297,18 @@ async function revalidatePrescheduledAlarm(
   const targets = resolveAllTargets(route as NonNullable<Route>, destinationName as string);
   if (!targets.some((t) => t.name === parsed.stationName)) {
     return suppress('revalidate-waypoint-mismatch');
+  }
+
+  // #1704 — 위치 게이트: 사용자 currentStation 대비 fire 대상이 N hop 이상 미래면 suppress.
+  // 기존 게이트 통과 후 진입 — backend SSoT mirror + sticky station 둘 다 부재/stale이면 skip(보수).
+  // 2026-06-23 사용자 trip evidence (14:04 신촌→종로3가 미리 fire, 14:18 합정→공덕/군자 미리 fire) 차단.
+  const positionGate = await evaluatePositionMismatch({
+    route: route as NonNullable<Route>,
+    destinationName: destinationName as string,
+    targetStationName: parsed.stationName,
+  });
+  if (positionGate === 'suppress') {
+    return suppress('revalidate-position-mismatch');
   }
 
   return 'pass';


### PR DESCRIPTION
## 문제

`src/features/alarm/utils/scheduledAlarmReceiver.ts:125-166 revalidatePrescheduledAlarm`의 기존 gate (`requireTripStart` + `registeredSig === currentSig` + `targets.some(t => t.name === parsed.stationName)`) 가 **사용자 실제 위치를 검사하지 않아** OS DATE trigger 시각 도달 시 route waypoint에 stationName이 있으면 그냥 fire.

### Evidence (2026-06-23 trip)

- 14:04 1차 trip BG: 종로3가 환승 / 합정 하차 / 충정로 환승임박 3건 발사 (사용자 실제 신촌).
- 14:18 2차 trip 등록 직후 BG: 공덕 환승 / 군자 환승 발사 (사용자 실제 합정 막 시작).
- 두 사례 모두 stationName이 route waypoint에 있어 gate 통과.

## Fix

### 1. `scheduledAlarmReceiver.ts` 새 gate

`revalidatePrescheduledAlarm`에 위치 게이트 추가:
- 사용자 currentStation 결정: `readBackendSsotMirror` (5분 이내 fresh) → `STICKY_STATION_KEY` (sticky station) → 둘 다 부재/stale이면 게이트 skip(보수 fallback).
- `routeToWaypoints(route, destination, currentStation)`로 사용자 다음 hop부터 destination까지 시퀀스 구성 → fire target name의 1-based hop distance 계산.
- hop ≥ `POSITION_MISMATCH_HOP_THRESHOLD`(5)면 suppress.
- 새 reason: `'revalidate-position-mismatch'` (`alarmLog.ts` union 확장).

### 2. `useApnsTripRegistration.ts` cross-trip cleanup 강화

기존 `lastRouteSigRef`만 추적하던 cancel 분기에 `lastDestinationIdRef` + `lastBoardingLockSigRef` 추가:
- routeSig 동일하더라도 destination.id 또는 boardingLockSig 변경 시 `cancelTripBoundAlarms()` 호출.
- trip 종료(route/destination → null) 시 3개 ref 모두 reset → 새 trip 첫 register는 cancel skip(불필요한 OS 호출 방지).

## Acceptance

- [x] 사용자 강남(2-022) + fire=시청(21 hop 미래) → suppress
- [x] 사용자 시청(2-001) + fire=시청 → currentName==targetName 즉시 pass
- [x] 사용자 을지로4가(시청 3 hop 직전) + fire=시청 → threshold 미만 pass
- [x] mirror 5분+ stale + sticky 부재 → 게이트 skip (보수)
- [x] mirror 부재 + sticky JSON 파손 → 게이트 skip (graceful)
- [x] sticky station.id 누락 / stations.json에 미존재 → 게이트 skip (graceful)
- [x] mirror.currentStationId가 stations.json에 없으면 sticky로 fallback
- [x] fire 대상이 route waypoint 시퀀스에 없으면 게이트 skip
- [x] `bl:` 채널에도 동일 게이트 적용 (`revalidateBlAlarm` 공유 helper)
- [x] revalidate 순서: tripStart / route-sig / waypoint mismatch가 position보다 먼저
- [x] cross-trip cleanup: routeSig 동일 + destination/lock 변경 시 cancel 호출
- [x] cross-trip cleanup: 모든 ref 동일하면 cancel 호출 안 함 (false positive 차단)
- [x] cross-trip cleanup: trip 종료 후 새 trip 첫 register는 cancel skip

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (No orphan exports detected).
2. **V/X dashboard** — DebugModal alarmLog 섹션이 `revalidate-position-mismatch` reason을 표시(suppressed entry). wrangler tail에는 backend가 forward할 때만(`alarmLogForward` worker) 노출.
3. **의존 PR** — N/A (device-only fix). backend SSoT mirror는 이미 운영 중(#1561 T8).
4. **측정 plan** — 1주 production trip에서 `revalidate-position-mismatch` reason count 추적. 14:04/14:18 trip 재현 시 fire 0건 확인. DebugModal alarmLog dump aggregate.
5. **Device verify** — 실기기 BG 시나리오: route 위 6+ hop 떨어진 stationName이 사전 예약된 상태에서 사용자가 trip 시작 직후 그 알람이 fire되는지 확인. 코드-only 변경이지만 OS scheduled trigger interaction이라 device verify 권장.

## 테스트

- `scheduledAlarmReceiver.test.ts`: 신규 16개 (position-mismatch 게이트 단건 + drain + 순서 + bl 채널). 총 72 pass.
- `useApnsTripRegistration.test.ts`: 신규 5개 (destination.id / lockSig 전환 + false positive + trip 종료 후 reset). 총 79 pass.
- `alarmLog.test.ts`: parametric reason 케이스에 `revalidate-position-mismatch` 추가. 총 201 pass.
- 변경 3 파일 모두 100% line/function/statement 커버리지.
- `npm run type-check` pass.
- `npm run lint:orphan` pass.

Closes #1704