### PR TITLE
fix(#1717): wraparound 호출자 audit 누락 (journeyAdapter) + 출발지 변경 시 auto-navigate

### DIFF
--- a/src/features/route/utils/__tests__/journeyAdapter.test.ts
+++ b/src/features/route/utils/__tests__/journeyAdapter.test.ts
@@ -212,6 +212,33 @@ describe('journeyDisplayToStops', () => {
       const stops = journeyDisplayToStops(journey, { expanded: true });
       expect(stops.some((s) => s.mark === 'intermediate')).toBe(false);
     });
+
+    // #1717 — 2호선 본선 closed loop wraparound 호환
+    it('expanded: 2호선 성수→합정 wraparound 16 hop 중간역 표시 (사용자 trip evidence)', () => {
+      // 성수(2-011) → 합정(2-038): 내선 16 hop. 정방향 단순 slice는 26개로 invariant guard에 빠짐.
+      // shortestLinePathIndices 사용으로 정확한 16 hop 중간역 (뚝섬, 한양대, ...) 산출.
+      const journey: JourneyDisplay = {
+        segments: [{ line: '2', lineColor: '#009D3E', fromName: '성수', toName: '합정', stops: 16 }],
+        totalStops: 16,
+      };
+      const stops = journeyDisplayToStops(journey, { expanded: true });
+      const intermediates = stops.filter((s) => s.mark === 'intermediate');
+      expect(intermediates).toHaveLength(15);
+      expect(intermediates[0].station).toContain('뚝섬');
+      expect(intermediates[1].station).toContain('한양대');
+    });
+
+    it('expanded: 2호선 시청→홍대입구 wraparound 4 hop 중간역', () => {
+      const journey: JourneyDisplay = {
+        segments: [{ line: '2', lineColor: '#009D3E', fromName: '시청', toName: '홍대입구', stops: 5 }],
+        totalStops: 5,
+      };
+      const stops = journeyDisplayToStops(journey, { expanded: true });
+      const intermediates = stops.filter((s) => s.mark === 'intermediate');
+      // 시청 → 충정로 → 아현 → 이대 → 신촌 → 홍대입구 (intermediate 4개)
+      expect(intermediates).toHaveLength(4);
+      expect(intermediates[0].station).toContain('충정로');
+    });
   });
 });
 

--- a/src/features/route/utils/journeyAdapter.ts
+++ b/src/features/route/utils/journeyAdapter.ts
@@ -1,6 +1,7 @@
 import i18next from 'i18next';
 import type { JourneyDisplay, JourneySegment } from '../../../shared/utils/stationRoute';
 import { getStationsOnLine, isSameStationName } from '../../../shared/utils/stationRoute';
+import { shortestLinePathIndices } from '../../../shared/utils/lineLoopPath';
 import type { ArrivalInfo } from '../../../shared/types/arrival';
 import type { NearestStationResult, LineNumber, Station } from '../../../shared/types/station';
 import { getStationDisplayName, getStationDisplayNameByName } from '../../../shared/utils/stationDisplay';
@@ -24,21 +25,20 @@ export type { StopArrivalContext, StopTransferTarget, Stop, ArrivalTrain, Handof
 const WALK_SPEED_M_PER_MIN = 80;
 
 // segment의 from/to 사이 중간 정거장을 노선 데이터에서 슬라이스한다.
-// id 정렬 순서가 곧 노선 순서라는 데이터 invariant에 의존한다 (stationRoute.ts).
-// stationRoute의 getIntermediateStationNames(fromId, toId)와 유사하지만 JourneySegment에는
-// id가 없어 name 기반 lookup이 필요하므로 별도 구현 유지.
+// #1717 — 2호선 본선 closed loop은 shortestLinePathIndices가 짧은 쪽 path를 반환.
+// 이전 단순 slice 구현은 wraparound seg.stops(예: 16)와 직선 slice(예: 26) 불일치로
+// 안전 가드에 빠져 빈 배열 fallback → "전체 역 보기" 토글 expand 시 중간역 0개 표시 회귀.
 function intermediateStationsForSegment(seg: JourneySegment): Station[] {
   const lineStations = getStationsOnLine(seg.line);
   const fromIdx = lineStations.findIndex((s) => isSameStationName(s.name, seg.fromName));
   const toIdx = lineStations.findIndex((s) => isSameStationName(s.name, seg.toName));
   if (fromIdx < 0 || toIdx < 0 || fromIdx === toIdx) return [];
-  const [lo, hi] = fromIdx < toIdx ? [fromIdx, toIdx] : [toIdx, fromIdx];
-  const slice = lineStations.slice(lo + 1, hi);
-  // 경로 탐색의 stops 카운트와 중간역 수가 불일치하면 invariant 위반(예: 향후 순환선
-  // wrap-around 최단경로 탐색이 도입될 때 stops=1인데 41개 역이 슬라이스되는 케이스).
-  // 안전하게 빈 배열 fallback.
-  if (slice.length !== seg.stops - 1) return [];
-  return fromIdx < toIdx ? slice : slice.slice().reverse();
+  const path = shortestLinePathIndices(lineStations, fromIdx, toIdx, seg.line);
+  // path[0]=fromIdx, path[length-1]=toIdx. 중간 station은 양 끝 제외.
+  const intermediate = path.slice(1, -1).map((i) => lineStations[i]);
+  // 안전 가드: 산출된 중간역 수가 seg.stops-1과 다르면 invariant 위반 (데이터 drift).
+  if (intermediate.length !== seg.stops - 1) return [];
+  return intermediate;
 }
 
 export function journeyDisplayToStops(

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -176,6 +176,11 @@ export default function MapScreen() {
               onPress={() => {
                 setCustomOrigin(selectedStation);
                 setSelectedStation(null);
+                // #1717 — destination이 이미 set이면 trip 시작 가능 → 현재역 탭 auto-navigate.
+                // setDestination 분기와 동일 UX 보장 (destination만 변경 시 자동 이동되는 패턴).
+                if (destination) {
+                  router.navigate('/(tabs)');
+                }
               }}
               testID="set-origin-button"
             >


### PR DESCRIPTION
## Summary

사용자 6/23 trip 실기기 검증에서 발견된 2건 회귀:

### R2 — #1699 PR reviewer 누락 4번째 호출자 (★ hidden 회귀)
**증상**: 출발지 + 도착지 둘 다 설정한 trip에서 "전체 역 보기" 토글 탭 시 중간역 표시 안 됨.
**root**: `src/features/route/utils/journeyAdapter.ts:30-42 intermediateStationsForSegment`이 단순 slice. #1699 PR의 reviewer가 P1-1/P1-2/P1-3 잡았지만 본 호출자 누락.
**증거**: 같은 파일 line 37-39 코멘트가 정확히 예측 — *"순환선 wrap-around 도입 시 stops=1인데 41개 역이 슬라이스되는 케이스"*.
**Fix**: `shortestLinePathIndices` 사용 (#1699 PR과 동일 helper).

### R1 — UX logic 갭
**증상**: 사용자가 지도탭에서 출발지만 변경 후 도착지는 그대로일 때 현재역 탭 자동 이동 X.
**Fix**: `setCustomOrigin` onPress에서 `destination` 있으면 `router.navigate('/(tabs)')` 호출.

## Test plan

- [x] journeyAdapter 31 tests pass (+2 신규 wraparound 케이스)
- [x] 7634 전체 tests pass + coverage 100%
- [x] type-check pass
- [x] lint:orphan pass
- [ ] 실기기: 성수→합정 trip 등록 후 "전체 역 보기" 탭 → 뚝섬/한양대/... 16 중간역 표시
- [ ] 실기기: 용마산→합정 trip 후 성수로 출발지 변경 → 현재역 탭 자동 이동

## Wire-completion

1. Orphan: `shortestLinePathIndices` (이미 #1699에서 export). lint:orphan pass.
2. V/X dashboard: HomeScreen "전체 역 보기" 토글 expand 시 중간역 표시
3. 의존 PR: N/A (#1699 머지 후 후속 fix)
4. 측정 plan: 실기기 1회로 chain 1단 완전 검증 ([[feedback_chain_validation_not_measurement]])
5. Device verify: 사용자 실기기 trip 1회 (R2 검증)

Closes #1717