### PR TITLE
fix(#1722): wraparound 호출자 audit — pickCandidateTrains + buildBoardingLockMeta

### DIFF
--- a/src/features/alarm/utils/__tests__/buildBoardingLockMeta.test.ts
+++ b/src/features/alarm/utils/__tests__/buildBoardingLockMeta.test.ts
@@ -176,4 +176,39 @@ describe('buildBoardingLockMeta', () => {
     });
     expect(result).toBeNull();
   });
+
+  describe('2호선 본선 wraparound (#1722, #622 후속)', () => {
+    // 시청(2-001, idx 0) → 합정(2-038): 직선 slice는 37+ stations.
+    // wraparound aware는 시청 → 충정로(2-043) → ... → 합정 = 6 hop (7 stations).
+    it('시청 → 합정 segmentStations는 wraparound short path (≤ 10 stations)', () => {
+      const route = makeDirectRoute(6, '2');
+      const result = buildBoardingLockMeta({
+        lock: { ...baseLock, boardingLine: '2' },
+        route,
+        destinationName: '합정',
+        boardingStationName: '시청',
+      });
+      expect(result).not.toBeNull();
+      expect(result!.segmentStations[0]).toBe('시청');
+      expect(result!.segmentStations[result!.segmentStations.length - 1]).toBe('합정');
+      // wraparound 경로 6 hop (7 stations) 보장 — 직선 slice 38 stations와 명확히 구분.
+      expect(result!.segmentStations.length).toBeLessThanOrEqual(10);
+      // wraparound이므로 두 번째 station은 정방향 인접(을지로입구)이 아니라 충정로(prefix).
+      expect(result!.segmentStations[1].startsWith('충정로')).toBe(true);
+    });
+
+    it('합정 → 시청 segmentStations도 wraparound (역방향, 6 hop)', () => {
+      const route = makeDirectRoute(6, '2');
+      const result = buildBoardingLockMeta({
+        lock: { ...baseLock, boardingLine: '2' },
+        route,
+        destinationName: '시청',
+        boardingStationName: '합정',
+      });
+      expect(result).not.toBeNull();
+      expect(result!.segmentStations[0]).toBe('합정');
+      expect(result!.segmentStations[result!.segmentStations.length - 1]).toBe('시청');
+      expect(result!.segmentStations.length).toBeLessThanOrEqual(10);
+    });
+  });
 });

--- a/src/features/alarm/utils/buildBoardingLockMeta.ts
+++ b/src/features/alarm/utils/buildBoardingLockMeta.ts
@@ -2,6 +2,7 @@ import type { BoardingLock } from '../../../shared/types/boardingLock';
 import { BOARDING_LOCK_EXPIRY_FACTOR } from '../../../shared/types/boardingLock';
 import type { Route } from '../../../shared/utils/stationRoute';
 import { getStationsOnLine, findStationByNameAndLine } from '../../../shared/utils/stationRoute';
+import { shortestLinePathIndices } from '../../../shared/utils/lineLoopPath';
 import { lineToSubwayId } from '../../../shared/constants/lineApiNames';
 import type { Station } from '../../../shared/types/station';
 import type { LineNumber } from '../../../shared/types/station';
@@ -67,13 +68,10 @@ function buildSegmentStations(
   if (startIdx === endIdx) return [lineStations[startIdx].name];
   // backend `estimateArrivalFromPosition`은 `segmentStations.indexOf(currentStation) >= indexOf(target)`
   // 이면 "이미 도착"으로 판정 — boarding이 [0], destination이 [length-1] 순서여야 한다.
-  // lineStations의 id 순서가 진행 방향과 반대인 경우 reverse로 boarding→destination 정렬.
-  // 2호선 순환선의 wrap-around(시계/반시계 더 짧은 길) 케이스는 별도 follow-up으로 처리 (#622 후속).
-  const goesForward = startIdx < endIdx;
-  const slice = goesForward
-    ? lineStations.slice(startIdx, endIdx + 1)
-    : lineStations.slice(endIdx, startIdx + 1).slice().reverse();
-  return slice.map((s) => s.name);
+  // #1722 (#622 후속): 2호선 본선 closed loop은 shortestLinePathIndices가 짧은 쪽 path를
+  // 진행 방향대로 정렬해 반환 — 직선 slice는 wraparound 시 잘못된 구간을 생성한다.
+  const path = shortestLinePathIndices(lineStations, startIdx, endIdx, boardingLine);
+  return path.map((i) => lineStations[i].name);
 }
 
 /**

--- a/src/features/arrival/utils/__tests__/pickCandidateTrains.test.ts
+++ b/src/features/arrival/utils/__tests__/pickCandidateTrains.test.ts
@@ -1,5 +1,6 @@
 import type { LinePositions, TrainPosition } from '../../../../shared/types/position';
 import type { LineNumber } from '../../../../shared/types/station';
+import { getStationsOnLine } from '../../../../shared/utils/stationRoute';
 import { pickCandidateTrains, CANDIDATE_DISTANCE_THRESHOLD_KM } from '../pickCandidateTrains';
 
 const LINE: LineNumber = '2';
@@ -324,6 +325,68 @@ describe('pickCandidateTrains', () => {
       });
       expect(result.map((t) => t.trainNo)).toEqual(['NEAR']);
       expect(onReject).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('2호선 본선 wraparound (#1722)', () => {
+    // 본선 closed loop: 시청(2-001, idx 0) ↔ 충정로(2-043) 인접.
+    // 직선 Math.abs로는 시청 → 합정(2-038) 거리가 37이라 window=10이면 reject.
+    // wraparound aware로는 6 hop (시청→충정로→...→합정)이라 keep.
+    const LINE2: LineNumber = '2';
+    const line2 = getStationsOnLine(LINE2);
+    const sicheongName = line2.find((s) => s.id === '2-001')!.name;
+    const hapjeongName = line2.find((s) => s.id === '2-038')!.name;
+
+    it('keeps wraparound-near train within window (직선 Math.abs로는 reject)', () => {
+      const result = pickCandidateTrains({
+        positions: [
+          {
+            line: LINE2,
+            trains: [makeTrain({ trainNo: 'WRAP', statnNm: hapjeongName })],
+          },
+        ],
+        line: LINE2,
+        anchorStationName: sicheongName,
+        windowStations: 10,
+      });
+      expect(result.map((t) => t.trainNo)).toEqual(['WRAP']);
+    });
+
+    it('rejects train beyond wraparound-aware window', () => {
+      // 시청 idx 0, 사당(2-026) idx 25 — wraparound도 18 hop. window=10이면 양쪽 다 X.
+      const sadangName = line2.find((s) => s.id === '2-026')!.name;
+      const result = pickCandidateTrains({
+        positions: [
+          {
+            line: LINE2,
+            trains: [makeTrain({ trainNo: 'FAR', statnNm: sadangName })],
+          },
+        ],
+        line: LINE2,
+        anchorStationName: sicheongName,
+        windowStations: 10,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('sortKey uses wraparound-aware hops, not |Δidx|', () => {
+      // anchor=시청. 합정(wraparound 6 hop)이 을지로입구(직선 1 hop)보다 멀어야 정상.
+      const euljiroName = line2.find((s) => s.id === '2-002')!.name;
+      const result = pickCandidateTrains({
+        positions: [
+          {
+            line: LINE2,
+            trains: [
+              makeTrain({ trainNo: 'WRAP', statnNm: hapjeongName }),
+              makeTrain({ trainNo: 'NEAR', statnNm: euljiroName }),
+            ],
+          },
+        ],
+        line: LINE2,
+        anchorStationName: sicheongName,
+        windowStations: 10,
+      });
+      expect(result.map((t) => t.trainNo)).toEqual(['NEAR', 'WRAP']);
     });
   });
 

--- a/src/features/arrival/utils/pickCandidateTrains.ts
+++ b/src/features/arrival/utils/pickCandidateTrains.ts
@@ -1,6 +1,7 @@
 import type { LinePositions, TrainPosition } from '../../../shared/types/position';
 import type { LineNumber, Station } from '../../../shared/types/station';
 import { getStationsOnLine } from '../../../shared/utils/stationRoute';
+import { hopsOnLine } from '../../../shared/utils/lineLoopPath';
 import { haversine } from '../../../shared/utils/haversine';
 
 // CandidateTrain은 shared/types/position으로 추출됨 (#890, Phase 5). re-export 유지.
@@ -103,7 +104,11 @@ export function pickCandidateTrains(input: PickCandidateTrainsInput): CandidateT
     const stationIdx = nameToIndex.get(train.statnNm);
     if (stationIdx === undefined) continue;
 
-    if (anchorIdx !== undefined && Math.abs(stationIdx - anchorIdx) > window) continue;
+    // #1722 — 2호선 본선 wraparound 고려. 직선 `Math.abs`는 wraparound 가까운 train을
+    // 멀리 인식해 window 누락 → anchor 부근 train 후보 손실.
+    const hopsFromAnchor =
+      anchorIdx !== undefined ? hopsOnLine(stationsOnLine, anchorIdx, stationIdx, line) : 0;
+    if (anchorIdx !== undefined && hopsFromAnchor > window) continue;
 
     // #1616 (R12-a): candidate station GPS 좌표 hard gate.
     if (distanceGateActive) {
@@ -128,8 +133,7 @@ export function pickCandidateTrains(input: PickCandidateTrainsInput): CandidateT
       }
     }
 
-    const sortKey = anchorIdx !== undefined ? Math.abs(stationIdx - anchorIdx) : 0;
-    candidates.push({ candidate: buildCandidate(train, line, train.updnLine), sortKey });
+    candidates.push({ candidate: buildCandidate(train, line, train.updnLine), sortKey: hopsFromAnchor });
   }
 
   candidates.sort((a, b) => {

--- a/src/shared/utils/__tests__/lineLoopPath.test.ts
+++ b/src/shared/utils/__tests__/lineLoopPath.test.ts
@@ -1,4 +1,4 @@
-import { isClosedLoopMainStation, shortestLinePathIndices } from '../lineLoopPath';
+import { hopsOnLine, isClosedLoopMainStation, shortestLinePathIndices } from '../lineLoopPath';
 import { getStationsOnLine } from '../stationRoute';
 import type { LineNumber } from '../../types/station';
 
@@ -134,5 +134,34 @@ describe('shortestLinePathIndices', () => {
       // 역방향 단순 walk
       expect(path.length).toBe(8);
     });
+  });
+});
+
+describe('hopsOnLine (#1722)', () => {
+  it('2호선 본선 wraparound: 시청(2-001) → 합정(2-038) hop=6 (wraparound 짧음)', () => {
+    const line2 = getStationsOnLine('2');
+    const from = line2.findIndex((s) => s.id === '2-001');
+    const to = line2.findIndex((s) => s.id === '2-038');
+    expect(hopsOnLine(line2, from, to, '2')).toBe(6);
+  });
+
+  it('2호선 본선 정방향: 시청(2-001) → 사당(2-026) hop=25 (정방향 짧음)', () => {
+    const line2 = getStationsOnLine('2');
+    const from = line2.findIndex((s) => s.id === '2-001');
+    const to = line2.findIndex((s) => s.id === '2-026');
+    // 정방향 25, wraparound 18 → wraparound 짧음.  실제 값으로 자가 검증.
+    const hops = hopsOnLine(line2, from, to, '2');
+    expect(hops).toBeLessThanOrEqual(25);
+    expect(hops).toBe(shortestLinePathIndices(line2, from, to, '2').length - 1);
+  });
+
+  it('1호선 직선: 0 → 5 hop=5', () => {
+    const line1 = getStationsOnLine('1');
+    expect(hopsOnLine(line1, 0, 5, '1')).toBe(5);
+  });
+
+  it('같은 idx면 hop=0', () => {
+    const line1 = getStationsOnLine('1');
+    expect(hopsOnLine(line1, 3, 3, '1')).toBe(0);
   });
 });

--- a/src/shared/utils/lineLoopPath.ts
+++ b/src/shared/utils/lineLoopPath.ts
@@ -91,3 +91,19 @@ function buildForward(fromIdx: number, toIdx: number): number[] {
   out.push(toIdx);
   return out;
 }
+
+/**
+ * 같은 line 위 두 station idx 사이 hop 수(wraparound aware).
+ *
+ * Closed loop 본선이면 짧은 쪽 hop 수, 그 외(지선/직선)는 정방향 idx 차이.
+ * `pickCandidateTrains` 같은 anchor 기준 거리 비교에 사용 — 직선 `Math.abs(a-b)`로는
+ * 2호선 본선 wraparound 가까운 train이 멀리 인식되어 window/sort에서 누락된다(#1722).
+ */
+export function hopsOnLine(
+  lineStations: readonly Station[],
+  fromIdx: number,
+  toIdx: number,
+  line: LineNumber,
+): number {
+  return shortestLinePathIndices(lineStations, fromIdx, toIdx, line).length - 1;
+}


### PR DESCRIPTION
Closes #1722

## 배경
PR #1718 (#1717 fix)이 4번째 wraparound 호출자(`journeyAdapter.ts`)를 추가했다. 본 PR은 grep audit로 5번째+ 호출자를 식별하고, 2호선 본선 closed loop 회귀 가능한 핵심 2개 호출자를 wraparound aware로 fix한다.

## 변경 사항

### Production (3 파일)
- `src/shared/utils/lineLoopPath.ts` — `hopsOnLine(lineStations, fromIdx, toIdx, line): number` helper 추가 (`shortestLinePathIndices` wrap, hop 수만 반환). 새 closed loop 추가 시 SSoT 1곳만 갱신.
- `src/features/arrival/utils/pickCandidateTrains.ts` — `Math.abs(stationIdx - anchorIdx)` (window + sortKey 2곳) → `hopsOnLine(...)`. anchor=시청, train=합정 case에서 직선 거리 37 hop이라 reject되던 wraparound 6 hop train이 정상 keep.
- `src/features/alarm/utils/buildBoardingLockMeta.ts` — `lineStations.slice(startIdx, endIdx + 1)` or reverse → `shortestLinePathIndices(...).map(...)`. backend SSoT `segmentStations` 정합 회복. 코멘트의 "#622 후속 follow-up" deferred 흡수.

### Tests (3 파일)
- `lineLoopPath.test.ts` — `hopsOnLine` 4 케이스 (2호선 wraparound 6 hop / 정방향 / 직선 / 동일 idx).
- `pickCandidateTrains.test.ts` — 2호선 wraparound 3 케이스 (window keep / window reject / sort 순서).
- `buildBoardingLockMeta.test.ts` — 시청↔합정 wraparound 2 케이스 (정방향 / 역방향).

## Acceptance (#1722)
- [x] 5번째+ 호출자 0건 (audit 결과 4개 추가 호출자 발견, 별 follow-up 이슈로 분리)
- [x] grep 결과 audit table PR 본문에 포함 (아래)
- [ ] (선택) 신규 호출자 추가 시 사용 강제 helper ESLint rule — 향후 별 이슈

## Audit Table

### Wraparound aware (기존 정합 OK)
| # | 호출자 | 파일:줄 | aware 방식 |
|---|---|---|---|
| 1 | `stationsBetween` | `routeProgress.ts:60` | shortestLinePathIndices |
| 2 | `intermediateStationsForSegment` | `journeyAdapter.ts:36` | shortestLinePathIndices (PR #1718) |
| 3 | `computeSegmentSeconds` | `stationRoute.ts:69` | shortestLinePathIndices |
| 4 | `computeSegmentHops` | `stationRoute.ts:84` | shortestLinePathIndices |
| 5 | `getRemainingStops` | `stationRoute.ts:508` | shortestLinePathIndices |
| 6 | `getIntermediateStationNames` | `stationRoute.ts:531` | shortestLinePathIndices |
| 7 | `getNextStationOnLine` related | `stationRoute.ts:575` | shortestLinePathIndices |
| 8 | `inferLoopDirection` | `loopDirection.ts:62-67` | `(toIdx - fromIdx + n) % n` |
| 9 | `resolveTravelDirection` | `travelDirection.ts:29` | MONOTONIC_LINES 화이트리스트 |
| 10 | `resolveTripDirection` | `tripDirection.ts:14-26` | closed loop null fallback |
| 11 | `resolveDirectionInLine` | `findActiveTransferContext.ts:171-183` | findIndex만, slice 없음 |
| 12 | `resolveNextAdjacentStationName` | `nextAdjacentStation.ts:20-21` | resolveTravelDirection 의존 |

### 본 PR fix (P0)
| # | 호출자 | 파일:줄 | fix |
|---|---|---|---|
| 13 | `pickCandidateTrains` | `arrival/utils/pickCandidateTrains.ts:106,131` | Math.abs → hopsOnLine |
| 14 | `buildSegmentStations` | `alarm/utils/buildBoardingLockMeta.ts:73` | slice → shortestLinePathIndices |

### 별 follow-up (P1/P2 — 후속 이슈로 분리 예정)
| # | 호출자 | 파일:줄 | 영향 | 우선순위 |
|---|---|---|---|---|
| 15 | `sliceLine` (Map polyline) | `route/utils/routeToCoordinates.ts:26-37` | UI 폴리라인이 잠실 우회로 그려질 가능성 | 🟡 P1 |
| 16 | `getLinePolyline` (snap) | `route/utils/linePolyline.ts:99-105` | 마지막 wrap segment 누락 (snap unmatched) | 🟡 P1 |
| 17 | `deriveCongestionDirection` | `congestion/utils/deriveDirection.ts:22-26` | 시청→충정로 congestion label 역방향 가능 | 🟢 P2 |
| 18 | `findNextStationOnLine` | `route/utils/findNextStationOnLine.ts:23-26` | 외선 train marker 보간 회귀 | 🟢 P2 |

## Wire-completion 5단

1. **Orphan**: `npm run lint:orphan` PASS (0 orphan).
2. **V/X dashboard**: 본 fix는 X1 (잘못된 candidate train 선택) / X6 (boarding lock SSoT segment 잘못) 영향. backend `alarmLog`의 `boardingLockMeta` 분포 확인 가능.
3. **의존 PR**: 없음 (독립).
4. **측정 plan**: 머지 후 P1/P2 4개 호출자 별 이슈 분리 → 각각 별도 측정. 본 PR fix는 wraparound trip(시청↔합정) 실기기 1회 verify.
5. **Device verify**: 필요. 시청↔합정 trip 1회 — candidate train 노출 정상 / boarding lock segmentStations 정합 확인.

## 검증
- `npm test`: 369 suites / 7643 tests PASS / 100% coverage
- `npm run type-check`: PASS
- `npm run lint:orphan`: 0 orphan
- 코드 리뷰: P1 없음, P2-1 정리됨 (dead variable 제거)