### PR TITLE
fix(#1720): 합성 ArrivalEntry strongBE 통과 차단 (ADR-015 §3)

### DIFF
--- a/backend/alarm-worker/src/__tests__/arrivalsFromPositions.test.ts
+++ b/backend/alarm-worker/src/__tests__/arrivalsFromPositions.test.ts
@@ -186,6 +186,7 @@ describe('synthesizeArrivalsFromPositions', () => {
       isUp: false,
       subwayNm: '6호선', // canonical
       arvlCd: 0, // ENTERING — 가장 보수적, RC1 confidence gate 트리거 X
+      synthesized: true, // #1720 — strongBE signal B 자격 X
     });
   });
 

--- a/backend/alarm-worker/src/__tests__/autoLock.test.ts
+++ b/backend/alarm-worker/src/__tests__/autoLock.test.ts
@@ -983,3 +983,43 @@ describe('attemptAutoLock #1702 positions fallback', () => {
     expect(lock).toBeNull();
   });
 });
+
+/**
+ * #1720 — 합성 ArrivalEntry(arvlCd=0, synthesized=true)가 consensusGate strongBE 통과 자격을 잃는다.
+ *
+ * positions-derived 합성 entry는 ADR-015 §3 signal C(position) 자격만 있고 signal B(arrival) 자격이
+ * 없다. underground 환경 + failing gateOutcome 시 strongBE=arrival+lockAttachable 2-of-2 가 fix 전에는
+ * 합성 entry로 통과되던 false positive를 차단.
+ *
+ * 대조군: real ArrivalEntry(arvlCd=1)는 동일 environment + gateOutcome 에서 strongBE 통과 → lock 채택.
+ */
+describe('attemptAutoLock #1720 합성 entry consensusGate 차단', () => {
+  it('underground + failing gate + arrivals=[] + positions 합성 → strongBE 차단 → null', async () => {
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([]),
+      now: NOW,
+      selfPollPositions: [position({ trainCode: 'SYNTH', stationName: '강남', isUp: true })],
+      environment: 'underground',
+      gateOutcome: failingGateOutcome(),
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('대조군: underground + failing gate + real arrivals(arvlCd=1) → strongBE pass → lock', async () => {
+    const { lock } = await attemptAutoLock({
+      trip: makeTrip(),
+      targetWaypoint: target,
+      originStation: '강남',
+      direction: 'up',
+      seoul: makeSeoul([arrival({ trainCode: 'REAL', arvlCd: 1, isUp: true })]),
+      now: NOW,
+      environment: 'underground',
+      gateOutcome: failingGateOutcome(),
+    });
+    expect(lock?.trainCode).toBe('REAL');
+  });
+});

--- a/backend/alarm-worker/src/arrivalsFromPositions.ts
+++ b/backend/alarm-worker/src/arrivalsFromPositions.ts
@@ -106,6 +106,9 @@ export function synthesizeArrivalsFromPositions(
       // ENTERING(0) — 보수적. priority 우선순위에서 가장 낮아 real arrivals 가 같은 train 을
       // 더 강한 신호로 표기하면 priority 가 우선됨.
       arvlCd: 0,
+      // #1720 — consensusGate strongBE (signal B) 자격 차단. arvlCd=0 + lockAttachable 조합으로
+      // underground 2-of-2 통과되던 false positive 봉쇄. positions-derived 는 signal C 만 자격.
+      synthesized: true,
     });
   }
   return synthesized;

--- a/backend/alarm-worker/src/autoLock.ts
+++ b/backend/alarm-worker/src/autoLock.ts
@@ -309,8 +309,12 @@ export async function attemptAutoLock(
   // 단일 수렴 = true) 2-of-2 합의가 통과해야 lock 합성 진행. surface 는 base gate(=outcome.pass)
   // 가 통과하면 즉시 통과. 미전달 시 (구 호출자) skip.
   if (environment && gateOutcome) {
+    // #1720 — 합성 entry(arvlCd=0)는 ADR-015 §3 signal B 자격 X. positions-derived 는 signal C 만.
     const arrivalSignalPresent =
-      typeof chosen.arvlCd === 'number' && chosen.arvlCd >= 0 && chosen.arvlCd <= 3;
+      !chosen.synthesized &&
+      typeof chosen.arvlCd === 'number' &&
+      chosen.arvlCd >= 0 &&
+      chosen.arvlCd <= 3;
     // #1614 Phase B / #1676 — backend self-poll realtimePosition cross-match + recptnMs age 가드.
     // pickAutoTrainCode 가 선택한 trainCode가 line의 운행 trains 중에 실제 존재하면 true.
     // recptnMs > 0 이면 Seoul API 수신 시각 기준으로 POSITION_RECPTN_MAX_AGE_MS(30s) 이내만 신선

--- a/backend/alarm-worker/src/seoul.ts
+++ b/backend/alarm-worker/src/seoul.ts
@@ -29,6 +29,11 @@ export interface ArrivalEntry {
    * ETA 예측 대신 실측 신호로 phase 판정하기 위한 핵심 필드.
    */
   arvlCd: number | null;
+  /**
+   * #1720 — positions 합성 entry 표기. true 면 ADR-015 §3 signal B(arrival) 자격이 없어
+   * consensusGate strongBE 통과 X. real Seoul API entry 는 undefined / false.
+   */
+  synthesized?: boolean;
 }
 
 export interface FetchSeoulOptions {


### PR DESCRIPTION
Closes #1720

## 배경
PR #1714 self-review 우려: `backend/alarm-worker/src/arrivalsFromPositions.ts:108`의 합성 ArrivalEntry는 positions-derived인데 `arvlCd=0`(ENTERING)으로 stamp되면 consensusGate가 `arvlCd ∈ [0,3]` 통과 → `arrivalSignalPresent=true` → underground strongBE(arrival + lockAttachable) 2-of-2 통과.

ADR-015 §3: signal B(arrival) + C(position)는 독립 source여야 정합. 같은 positions source에서 양쪽 신호 받으면 정합 약화 → SSoT advance evidence 가짜 통과.

## 변경 사항

### Production (3 파일)
- `backend/alarm-worker/src/seoul.ts` — `ArrivalEntry` interface에 `synthesized?: boolean` optional 필드 추가. real entry는 `undefined`/`false` fallback로 기존 동작 유지.
- `backend/alarm-worker/src/arrivalsFromPositions.ts` — 합성 entry에 `synthesized: true` 표기. priority 자연 강등(arvlCd=0)에 더해 consensusGate signal B 자격 명시 박탈.
- `backend/alarm-worker/src/autoLock.ts` — `arrivalSignalPresent = !chosen.synthesized && (arvlCd validity)` 한정. short-circuit으로 합성 차단이 먼저 평가.

### Tests (2 파일)
- `arrivalsFromPositions.test.ts` — 합성 entry fixture에 `synthesized: true` assert 추가.
- `autoLock.test.ts` — 신규 describe `#1720 합성 entry consensusGate 차단` 2 케이스 (positive: 합성 → null / 대조군: real entry → lock).

## Scope: autoLock 한정
`advanceTripPosition.buildSignalsFromEvidence`도 같은 패턴이지만 **현재 caller(`scheduled.ts`의 `tryAdvanceAndFireArvlcd` / `advanceBoardingLockWaypoint`)가 `evidence.arrivalEntry`를 stamp 하지 않음** → dead guard. 본 PR에서는 변경 X, 별 follow-up 이슈로 분리 (caller wire 보강 필요).

## acceptance (#1720)
- [x] 합성 ArrivalEntry는 underground strongBE 통과 X (autoLock test 1 case)
- [x] 실제 Seoul arrivals API entry는 정상 통과 (대조군 test 1 case)
- [x] backend consensusGate 테스트: 합성 entry + lockAttachable → strongBE false
- [x] ADR-015 §3 정합성 회복 (autoLock site 한정)

## Wire-completion 5단

1. **Orphan**: `npm run lint:orphan` PASS.
2. **V/X dashboard**: X1 (잘못된 candidate train lock) / X2 (autoLock false positive) 영향. backend `alarmLog`의 `lockReason=auto` 분포 추적.
3. **의존 PR**: 없음.
4. **측정 plan**: 머지 후 1주 `alarmLog autoLock candidate` 측정. underground 환경 +arvlCd=0 합성 통과 → lock null 케이스 분포 측정.
5. **Device verify**: 필요. 지하 + Seoul API 단방향 반환(또는 빈 응답) trip 1회. autoLock이 합성 candidate로 lock되지 않고 boarding-prompt fallback 으로 빠지는지 확인.

## 별 follow-up (분리 예정)
- `advanceTripPosition.buildSignalsFromEvidence` site에 동일 가드 wire (`scheduled.ts` caller 두 곳에서 `arrivalEntry` stamp).
- ADR-015 §3과 코드 arvlCd 0~3 range 격차(ADR은 1~3) 정합 결정 — 사용자 결정 필요.

## 검증
- backend `npm test`: 55 suites / 2072 tests PASS
- frontend `npm run type-check`: PASS
- frontend `npm run lint:orphan`: 0 orphan
- 코드 리뷰: P1 2건(scope 축소 + autoLock end-to-end 테스트) 모두 반영됨