### PR TITLE
fix(#1721): APNs delivery 재시도 + env auto-correct + 410/429 강화

### DIFF
--- a/backend/alarm-worker/src/__tests__/retryPushes.test.ts
+++ b/backend/alarm-worker/src/__tests__/retryPushes.test.ts
@@ -1,0 +1,517 @@
+import { generateKeyPair, exportPKCS8 } from 'jose';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetApnsJwtCache, type ApnsConfig, type SilentPushPayload } from '../apns';
+import {
+  enqueueRetryIfTransient,
+  listRetryPushes,
+  removeRetryPush,
+  retryPushKey,
+  RETRY_PUSH_TTL_SEC,
+  runRetryPushes,
+  type RetryPush,
+} from '../retryPushes';
+import { RETRY_BACKOFF_SCHEDULE_MS } from '../apnsHost';
+import type { Env } from '../types';
+import { InMemoryKV } from './inMemoryKv';
+
+let privateKeyPem = '';
+
+beforeAll(async () => {
+  const { privateKey } = await generateKeyPair('ES256');
+  privateKeyPem = await exportPKCS8(privateKey);
+});
+
+const APNS_HOSTS = {
+  production: 'api.push.apple.com',
+  sandbox: 'api.sandbox.push.apple.com',
+} as const;
+
+function makeApnsConfig(): ApnsConfig {
+  return {
+    keyId: 'KEY123',
+    teamId: 'TEAM456',
+    privateKeyPem,
+    bundleId: 'com.example.app',
+  };
+}
+
+function makePayload(overrides: Partial<SilentPushPayload> = {}): SilentPushPayload {
+  return {
+    nextWaypoint: '중곡',
+    etaSeconds: 60,
+    phase: 'imminent',
+    kind: 'intermediate',
+    sentAt: 1_700_000_000_000,
+    pushId: 'p1',
+    ...overrides,
+  };
+}
+
+function makeEnv(kv: InMemoryKV): Env {
+  return {
+    TRIPS: kv as unknown as KVNamespace,
+    PENDING_PUSHES: kv as unknown as KVNamespace,
+    APNS_HOST: APNS_HOSTS.production,
+    APNS_HOST_SANDBOX: APNS_HOSTS.sandbox,
+    SEOUL_API_HOST: 'swopenapi.seoul.go.kr',
+    SEOUL_API_KEY: 'key',
+    APNS_KEY_ID: 'KEY123',
+    APNS_TEAM_ID: 'TEAM456',
+    APNS_PRIVATE_KEY: privateKeyPem,
+    APNS_BUNDLE_ID: 'com.example.app',
+  };
+}
+
+describe('retryPushes (#1721)', () => {
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+    resetApnsJwtCache();
+  });
+
+  describe('retryPushKey', () => {
+    it('retry-push: 접두어를 붙인다', () => {
+      expect(retryPushKey('abc-123')).toBe('retry-push:abc-123');
+    });
+  });
+
+  describe('RETRY_PUSH_TTL_SEC', () => {
+    it('총 backoff 합 + buffer 60s', () => {
+      // RETRY_BACKOFF_SCHEDULE_MS = [60000,120000,240000] → 420s + 60s = 480s
+      const sumSec = RETRY_BACKOFF_SCHEDULE_MS.reduce((a, b) => a + b, 0) / 1000;
+      expect(RETRY_PUSH_TTL_SEC).toBe(sumSec + 60);
+    });
+  });
+
+  describe('enqueueRetryIfTransient', () => {
+    const NOW = 1_700_000_000_000;
+
+    it('429 status → entry 적재 + nextAttemptAt = now + 60s', async () => {
+      const queued = await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'p1',
+        token: 'tok',
+        payload: makePayload(),
+        apnsEnv: 'sandbox',
+        status: 429,
+        reason: 'TooManyRequests',
+        now: NOW,
+      });
+      expect(queued).toBe(true);
+      const raw = await kv.get('retry-push:p1');
+      expect(raw).not.toBeNull();
+      const entry = JSON.parse(raw as string) as RetryPush;
+      expect(entry.pushId).toBe('p1');
+      expect(entry.attemptCount).toBe(0);
+      expect(entry.nextAttemptAt).toBe(NOW + 60_000);
+      expect(entry.lastErrorStatus).toBe(429);
+      expect(entry.lastErrorReason).toBe('TooManyRequests');
+    });
+
+    it('500/503 status → 적재', async () => {
+      const queued500 = await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'p-500',
+        token: 'tok',
+        payload: makePayload({ pushId: 'p-500' }),
+        apnsEnv: 'sandbox',
+        status: 500,
+        now: NOW,
+      });
+      const queued503 = await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'p-503',
+        token: 'tok',
+        payload: makePayload({ pushId: 'p-503' }),
+        apnsEnv: 'sandbox',
+        status: 503,
+        now: NOW,
+      });
+      expect(queued500).toBe(true);
+      expect(queued503).toBe(true);
+    });
+
+    it('410 (BadDeviceToken Unregistered) → 적재 X', async () => {
+      const queued = await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'p1',
+        token: 'tok',
+        payload: makePayload(),
+        apnsEnv: 'sandbox',
+        status: 410,
+        reason: 'Unregistered',
+        now: NOW,
+      });
+      expect(queued).toBe(false);
+      expect(await kv.get('retry-push:p1')).toBeNull();
+    });
+
+    it('400 BadDeviceToken → 적재 X (envHeal 책임)', async () => {
+      const queued = await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'p1',
+        token: 'tok',
+        payload: makePayload(),
+        apnsEnv: 'sandbox',
+        status: 400,
+        reason: 'BadDeviceToken',
+        now: NOW,
+      });
+      expect(queued).toBe(false);
+    });
+
+    it('attemptCount 명시 → 해당 backoff 적용', async () => {
+      await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'p2',
+        token: 'tok',
+        payload: makePayload({ pushId: 'p2' }),
+        apnsEnv: 'sandbox',
+        status: 500,
+        now: NOW,
+        attemptCount: 1,
+      });
+      const entry = JSON.parse((await kv.get('retry-push:p2')) as string) as RetryPush;
+      expect(entry.attemptCount).toBe(1);
+      expect(entry.nextAttemptAt).toBe(NOW + 120_000);
+    });
+
+    it('attemptCount >= backoff schedule 길이 → 적재 X (영구 폐기 신호)', async () => {
+      const queued = await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'p-exhaust',
+        token: 'tok',
+        payload: makePayload(),
+        apnsEnv: 'sandbox',
+        status: 503,
+        now: NOW,
+        attemptCount: RETRY_BACKOFF_SCHEDULE_MS.length,
+      });
+      expect(queued).toBe(false);
+    });
+
+    it('originalSentAt 미지정 시 now 로 stamp', async () => {
+      await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'p3',
+        token: 'tok',
+        payload: makePayload({ pushId: 'p3' }),
+        apnsEnv: 'sandbox',
+        status: 429,
+        now: NOW,
+      });
+      const entry = JSON.parse((await kv.get('retry-push:p3')) as string) as RetryPush;
+      expect(entry.originalSentAt).toBe(NOW);
+    });
+
+    it('kv === undefined → no-op', async () => {
+      const queued = await enqueueRetryIfTransient(undefined, {
+        pushId: 'p1',
+        token: 'tok',
+        payload: makePayload(),
+        apnsEnv: 'sandbox',
+        status: 429,
+        now: NOW,
+      });
+      expect(queued).toBe(false);
+    });
+
+    it('reason 미지정 → lastErrorReason 필드 omit', async () => {
+      await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'p-no-reason',
+        token: 'tok',
+        payload: makePayload({ pushId: 'p-no-reason' }),
+        apnsEnv: 'sandbox',
+        status: 500,
+        now: NOW,
+      });
+      const entry = JSON.parse((await kv.get('retry-push:p-no-reason')) as string) as RetryPush;
+      expect('lastErrorReason' in entry).toBe(false);
+    });
+  });
+
+  describe('removeRetryPush', () => {
+    it('해당 키 삭제', async () => {
+      await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'p1',
+        token: 'tok',
+        payload: makePayload(),
+        apnsEnv: 'sandbox',
+        status: 429,
+        now: 0,
+      });
+      await removeRetryPush(kv as unknown as KVNamespace, 'p1');
+      expect(await kv.get('retry-push:p1')).toBeNull();
+    });
+
+    it('kv === undefined → no-op', async () => {
+      await expect(removeRetryPush(undefined, 'p1')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('listRetryPushes', () => {
+    it('prefix scan 으로 retry-push:* 만 yield', async () => {
+      await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'a',
+        token: 'tok',
+        payload: makePayload({ pushId: 'a' }),
+        apnsEnv: 'sandbox',
+        status: 429,
+        now: 0,
+      });
+      await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'b',
+        token: 'tok',
+        payload: makePayload({ pushId: 'b' }),
+        apnsEnv: 'sandbox',
+        status: 500,
+        now: 0,
+      });
+      // 무관 entry (다른 prefix) 는 yield 되지 않아야.
+      await kv.put('pending:c', 'unrelated');
+      await kv.put('trip:d', 'unrelated');
+      const collected: string[] = [];
+      for await (const entry of listRetryPushes(kv as unknown as KVNamespace)) {
+        collected.push(entry.pushId);
+      }
+      expect(collected.sort((x, y) => x.localeCompare(y))).toEqual(['a', 'b']);
+    });
+
+    it('kv === undefined → 빈 generator', async () => {
+      const collected: string[] = [];
+      for await (const e of listRetryPushes(undefined)) collected.push(e.pushId);
+      expect(collected).toEqual([]);
+    });
+
+    it('손상된 JSON entry 는 skip', async () => {
+      await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'good',
+        token: 'tok',
+        payload: makePayload({ pushId: 'good' }),
+        apnsEnv: 'sandbox',
+        status: 429,
+        now: 0,
+      });
+      await kv.put('retry-push:bad', 'not-json{');
+      const collected: string[] = [];
+      for await (const e of listRetryPushes(kv as unknown as KVNamespace)) {
+        collected.push(e.pushId);
+      }
+      expect(collected).toEqual(['good']);
+    });
+  });
+
+  describe('runRetryPushes', () => {
+    const NOW = 1_700_000_000_000;
+
+    it('nextAttemptAt 미도달 entry 는 deferred + skip', async () => {
+      await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'p-defer',
+        token: 'tok',
+        payload: makePayload({ pushId: 'p-defer' }),
+        apnsEnv: 'sandbox',
+        status: 429,
+        now: NOW,
+      });
+      const apnsFetch = vi.fn();
+      const stats = await runRetryPushes(makeEnv(kv), {
+        apnsConfig: makeApnsConfig(),
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW + 30_000, // backoff 60s 미달
+      });
+      expect(stats).toEqual({ scanned: 1, deferred: 1, resent: 0, rescheduled: 0, exhausted: 0 });
+      expect(apnsFetch).not.toHaveBeenCalled();
+      // entry 보존
+      expect(await kv.get('retry-push:p-defer')).not.toBeNull();
+    });
+
+    it('backoff 만기 → 재발사 성공 → entry 삭제 + resent', async () => {
+      await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'p-ok',
+        token: 'tok',
+        payload: makePayload({ pushId: 'p-ok', nextWaypoint: '강남' }),
+        apnsEnv: 'sandbox',
+        status: 503,
+        now: NOW,
+      });
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const stats = await runRetryPushes(makeEnv(kv), {
+        apnsConfig: makeApnsConfig(),
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW + 60_000 + 1,
+      });
+      expect(stats.resent).toBe(1);
+      expect(stats.deferred).toBe(0);
+      expect(apnsFetch).toHaveBeenCalledTimes(1);
+      expect(await kv.get('retry-push:p-ok')).toBeNull();
+    });
+
+    it('retryable 실패 다시 떨어지면 attemptCount + 1 로 재 enqueue (rescheduled)', async () => {
+      await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'p-reschedule',
+        token: 'tok',
+        payload: makePayload({ pushId: 'p-reschedule' }),
+        apnsEnv: 'sandbox',
+        status: 503,
+        now: NOW,
+      });
+      const apnsFetch = vi.fn(async () =>
+        new Response(JSON.stringify({ reason: 'InternalServerError' }), { status: 500 }),
+      );
+      const T2 = NOW + 60_000 + 1;
+      const stats = await runRetryPushes(makeEnv(kv), {
+        apnsConfig: makeApnsConfig(),
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => T2,
+      });
+      expect(stats.rescheduled).toBe(1);
+      expect(stats.resent).toBe(0);
+      const stored = JSON.parse((await kv.get('retry-push:p-reschedule')) as string) as RetryPush;
+      expect(stored.attemptCount).toBe(1);
+      // 2번째 backoff = 120s
+      expect(stored.nextAttemptAt).toBe(T2 + 120_000);
+      expect(stored.lastErrorStatus).toBe(500);
+    });
+
+    it('unrecoverable 응답 (410 Unregistered) → 폐기 (exhausted)', async () => {
+      await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'p-410',
+        token: 'tok',
+        payload: makePayload({ pushId: 'p-410' }),
+        apnsEnv: 'sandbox',
+        status: 503,
+        now: NOW,
+      });
+      const apnsFetch = vi.fn(async () =>
+        new Response(JSON.stringify({ reason: 'Unregistered' }), { status: 410 }),
+      );
+      const stats = await runRetryPushes(makeEnv(kv), {
+        apnsConfig: makeApnsConfig(),
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW + 60_000 + 1,
+      });
+      expect(stats.exhausted).toBe(1);
+      expect(stats.rescheduled).toBe(0);
+      expect(await kv.get('retry-push:p-410')).toBeNull();
+    });
+
+    it('attempt 한계 도달 + 실패 → 폐기 (exhausted)', async () => {
+      // 마지막 attempt 까지 도달 — 다음 재시도 시 backoff schedule 끝.
+      await kv.put(
+        'retry-push:p-max',
+        JSON.stringify({
+          pushId: 'p-max',
+          token: 'tok',
+          payload: makePayload({ pushId: 'p-max' }),
+          apnsEnv: 'sandbox',
+          attemptCount: RETRY_BACKOFF_SCHEDULE_MS.length - 1,
+          nextAttemptAt: NOW,
+          originalSentAt: NOW,
+          lastErrorStatus: 503,
+        }),
+      );
+      const apnsFetch = vi.fn(async () => new Response('', { status: 503 }));
+      const stats = await runRetryPushes(makeEnv(kv), {
+        apnsConfig: makeApnsConfig(),
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW + 1,
+      });
+      expect(stats.exhausted).toBe(1);
+      expect(await kv.get('retry-push:p-max')).toBeNull();
+    });
+
+    it('재 enqueue 시 entry.apnsEnv 가 그대로 보존 (env mismatch 미발생 시)', async () => {
+      await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'p-env',
+        token: 'tok',
+        payload: makePayload({ pushId: 'p-env' }),
+        apnsEnv: 'sandbox',
+        status: 503,
+        now: NOW,
+      });
+      const apnsFetch = vi.fn(async () =>
+        new Response(JSON.stringify({ reason: 'InternalServerError' }), { status: 500 }),
+      );
+      await runRetryPushes(makeEnv(kv), {
+        apnsConfig: makeApnsConfig(),
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW + 60_000 + 1,
+      });
+      const stored = JSON.parse((await kv.get('retry-push:p-env')) as string) as RetryPush;
+      // mismatch 미발생 → entry.apnsEnv 보존 (sandbox).
+      expect(stored.apnsEnv).toBe('sandbox');
+    });
+
+    it('kv binding 없으면 graceful — scanned 0', async () => {
+      const envNoKv = {
+        ...makeEnv(kv),
+        PENDING_PUSHES: undefined,
+      } as Env;
+      const stats = await runRetryPushes(envNoKv, {
+        apnsConfig: makeApnsConfig(),
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: vi.fn() as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      expect(stats).toEqual({ scanned: 0, deferred: 0, resent: 0, rescheduled: 0, exhausted: 0 });
+    });
+
+    it('payload.sentAt 은 retry 시점으로 갱신 (관측용)', async () => {
+      await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'p-sentat',
+        token: 'tok',
+        payload: makePayload({ pushId: 'p-sentat' }),
+        apnsEnv: 'sandbox',
+        status: 503,
+        now: NOW,
+      });
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const T2 = NOW + 60_000 + 1;
+      await runRetryPushes(makeEnv(kv), {
+        apnsConfig: makeApnsConfig(),
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => T2,
+      });
+      const call = apnsFetch.mock.calls[0] as unknown as [string, RequestInit];
+      const body = JSON.parse(call[1].body as string);
+      expect(body.data.sentAt).toBe(T2);
+    });
+
+    it('log 미지정 → 동작 정상 (default no-op logger)', async () => {
+      await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'p-nolog',
+        token: 'tok',
+        payload: makePayload({ pushId: 'p-nolog' }),
+        apnsEnv: 'sandbox',
+        status: 503,
+        now: NOW,
+      });
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const stats = await runRetryPushes(makeEnv(kv), {
+        apnsConfig: makeApnsConfig(),
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW + 60_000 + 1,
+      });
+      expect(stats.resent).toBe(1);
+    });
+
+    it('now() 미지정 → Date.now() 기본 사용', async () => {
+      await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+        pushId: 'p-no-now',
+        token: 'tok',
+        payload: makePayload({ pushId: 'p-no-now' }),
+        apnsEnv: 'sandbox',
+        status: 503,
+        now: Date.now() - 60_000 - 1,
+        // nextAttemptAt = (Date.now() - 60_001) + 60_000 = Date.now() - 1 → 만기.
+      });
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const stats = await runRetryPushes(makeEnv(kv), {
+        apnsConfig: makeApnsConfig(),
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+      });
+      expect(stats.resent).toBe(1);
+    });
+  });
+});

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1,6 +1,7 @@
 import { generateKeyPair, exportPKCS8 } from 'jose';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resetApnsJwtCache, type ApnsConfig } from '../apns';
+import { computeNextRetryAt, isRetryableApnsError } from '../apnsHost';
 import { DRIFT_WARNING_THRESHOLD_KMH, R_LOW, readKalmanState, type KalmanState } from '../kalmanFilter';
 import type { WindowedMetrics } from '../positionSeries';
 import {
@@ -447,6 +448,42 @@ describe('pickApnsHost', () => {
   });
   it('falls back to sandbox host when apnsEnv is undefined (#482 safe default)', () => {
     expect(pickApnsHost(undefined, APNS_HOSTS)).toBe(APNS_HOSTS.sandbox);
+  });
+});
+
+describe('isRetryableApnsError (#1721)', () => {
+  it.each([
+    [429, true],
+    [500, true],
+    [502, true],
+    [503, true],
+    [599, true],
+    [200, false],
+    [400, false],
+    [403, false],
+    [404, false],
+    [410, false],
+    [600, false],
+  ])('status=%i → %s', (status, expected) => {
+    expect(isRetryableApnsError(status)).toBe(expected);
+  });
+});
+
+describe('computeNextRetryAt (#1721)', () => {
+  const NOW = 1_700_000_000_000;
+  it.each([
+    [0, NOW + 60_000],
+    [1, NOW + 120_000],
+    [2, NOW + 240_000],
+  ])('attempt=%i → now + correct backoff', (attempt, expectedAt) => {
+    expect(computeNextRetryAt(attempt, NOW)).toBe(expectedAt);
+  });
+  it('attempt >= schedule length → null (영구 폐기 신호)', () => {
+    expect(computeNextRetryAt(3, NOW)).toBeNull();
+    expect(computeNextRetryAt(10, NOW)).toBeNull();
+  });
+  it('attempt < 0 → null (방어적)', () => {
+    expect(computeNextRetryAt(-1, NOW)).toBeNull();
   });
 });
 
@@ -1834,6 +1871,61 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
     expect(stored.waypoints).toHaveLength(1);
     expect(stored.waypoints[0].stationName).toBe('군자');
     expect(stored.lastTrackedArrivalEpoch).toBeUndefined();
+  });
+
+  // #1721 — arvlcd fire 가 transient APNs error(503) 받으면 retry-push: 큐에 적재된다.
+  // sendWithEnvHeal 의 양 env retry 후에도 lost 되던 silent push 가 다음 cron cycle backoff 후
+  // 재발사된다. envHeal 자체는 BadDeviceToken 에만 발동하므로 503 은 1회 호출로 즉시 실패 반환.
+  it('#1721 — arvlcd fire 503 → retry-push: 큐 적재 (transient retry queue)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({ lastTrackedArrivalEpoch: NOW + 5000 }),
+    );
+    const apnsFetch = vi.fn(async () => new Response('', { status: 503 }));
+    // PENDING_PUSHES 는 동일 kv 인스턴스 사용 — retry-push: prefix 도 같은 store 에 적재.
+    const stats = await runScheduled(makeEnv(kv, kv), {
+      seoul: makeSeoulCombo([arrivalForLock('중곡', 0, 1)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-1721',
+    });
+    expect(stats.errors).toBeGreaterThan(0);
+    // retry-push: prefix entry 가 적재되어 다음 cron cycle 에서 재발사 가능.
+    const stored = await kv.get('retry-push:p-1721');
+    expect(stored).not.toBeNull();
+    const entry = JSON.parse(stored as string);
+    expect(entry.pushId).toBe('p-1721');
+    expect(entry.attemptCount).toBe(0);
+    expect(entry.nextAttemptAt).toBe(NOW + 60_000);
+    expect(entry.lastErrorStatus).toBe(503);
+    // payload 도 같이 적재되어 retry 시점에 재구성 불필요.
+    expect(entry.payload.nextWaypoint).toBe('중곡');
+  });
+
+  // #1721 — 410 Unregistered 같은 unrecoverable 은 retry-push: 큐 적재 X.
+  // 기존 cleanup path (cleanupTripWithLa 'push-unrecoverable') 가 책임.
+  it('#1721 — 410 Unregistered 는 retry-push: 큐 적재 X (unrecoverable)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({ lastTrackedArrivalEpoch: NOW + 5000 }),
+    );
+    const apnsFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'Unregistered' }), { status: 410 }),
+    );
+    await runScheduled(makeEnv(kv, kv), {
+      seoul: makeSeoulCombo([arrivalForLock('중곡', 0, 1)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-410',
+    });
+    // 410 은 retry queue 적재 X — trip 자체가 cleanup (deleteTrip) 되므로.
+    expect(await kv.get('retry-push:p-410')).toBeNull();
   });
 
   // #864 — transfer waypoint 통과 시 lock release. 다음 cycle에서 새 leg의 trainCode를

--- a/backend/alarm-worker/src/apnsHost.ts
+++ b/backend/alarm-worker/src/apnsHost.ts
@@ -26,6 +26,47 @@ export function isApnsEnvMismatch(status: number, reason: string | undefined): b
   return status === 400 && reason === 'BadDeviceToken';
 }
 
+/**
+ * #1721 — APNs response status 분류 (transient retry vs permanent fail).
+ *
+ * 6/23 13:44 evidence (backend log): env mismatch self-heal이 1회 retry만 시도하고 second
+ * call도 transient 실패면 silent push 영구 lost. 본 helper는 transient retry가 필요한 상태
+ * 를 분리해 retry queue 적재 결정을 단순화한다.
+ *
+ * | status | 분류           | 처리                                                   |
+ * |--------|---------------|--------------------------------------------------------|
+ * | 410    | unrecoverable | device token 제거 + trip cleanup (기존 흐름 유지)     |
+ * | 429    | retryable     | exponential backoff (60s/120s/240s) → retry           |
+ * | 500-599| retryable     | exponential backoff (60s/120s/240s) → retry           |
+ * | 그 외  | non-retryable | 기존 동작 (envHeal/dedup 등)                          |
+ */
+export function isRetryableApnsError(status: number): boolean {
+  if (status === 429) return true;
+  if (status >= 500 && status < 600) return true;
+  return false;
+}
+
+/**
+ * #1721 — exponential backoff schedule for retryable APNs failures.
+ * - attempt 0 → 1차 시도 (즉시)
+ * - attempt 1 → 60s 후 retry
+ * - attempt 2 → 120s 후 retry
+ * - attempt 3 → 240s 후 retry
+ * - attempt ≥ 4 → 영구 폐기 (RETRY_BACKOFF_SCHEDULE_MS.length 초과)
+ *
+ * 60s가 1차 backoff인 이유: cron이 1분 주기라 그보다 짧은 backoff는 의미 없음. APNs 429는
+ * 대개 burst rate-limit이라 60s면 충분히 해소.
+ */
+export const RETRY_BACKOFF_SCHEDULE_MS = [60_000, 120_000, 240_000] as const;
+
+/**
+ * 다음 retry 시각 계산. attempt가 schedule 범위 밖이면 null (영구 폐기 신호).
+ */
+export function computeNextRetryAt(attempt: number, now: number): number | null {
+  if (attempt < 0 || attempt >= RETRY_BACKOFF_SCHEDULE_MS.length) return null;
+  return now + RETRY_BACKOFF_SCHEDULE_MS[attempt];
+}
+
 export interface EnvHealResult {
   result: SendPushResult;
   /** retry로 정정된 새 env. 정정 발생 시에만 set. */

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -19,6 +19,7 @@ import {
   validateBoardingPromptOutcome,
 } from './boardingPromptOutcome';
 import { runFallbackPushes } from './fallback';
+import { runRetryPushes } from './retryPushes';
 import {
   checkRateLimit,
   generateFeedbackId,
@@ -2058,6 +2059,9 @@ export default {
     await runScheduled(env, { seoul, apnsConfig, apnsHosts, log });
     // #572 P2c — silent push 30s 미ACK entry를 alert로 fallback. 같은 cron 사이클에서 실행.
     await runFallbackPushes(env, { apnsConfig, apnsHosts, log });
+    // #1721 — silent push 발사 실패(429 / 5xx) 영구 lost 차단. retry-push: prefix entry 를 backoff 만기
+    // 시 재발사. KV binding 부재 시 graceful no-op (개발/테스트 환경 호환).
+    await runRetryPushes(env, { apnsConfig, apnsHosts, log });
     // #972 — low-recall trip ratio 임계 위반 시 운영 webhook 발사. dedup KV(1h)로 spam 차단.
     // binding/secret 미설정 환경에서는 graceful no-op이라 회귀 없음.
     await evaluateAndMaybeAlert(env, { fetchImpl: fetch, now: () => Date.now(), log });

--- a/backend/alarm-worker/src/retryPushes.ts
+++ b/backend/alarm-worker/src/retryPushes.ts
@@ -1,0 +1,256 @@
+/**
+ * #1721 — silent push 전송 실패(429 / 5xx) 영구 lost 차단.
+ *
+ * 6/23 13:44 backend log evidence:
+ *   - 13:44:17 `apns env mismatch — retry with opposite host` (sandbox correction)
+ *   - 13:44:17 `apns env corrected to sandbox`
+ *
+ * `sendWithEnvHeal`은 1차(current env) + opposite env 1회 retry 까지만 시도한다. 두 env 모두
+ * transient 실패(429 Too Many Requests / 500-599 server error)면 push가 영구 lost. 한편 401/403
+ * 같은 영구 실패 또는 410 Unregistered는 별 cleanup path가 처리한다.
+ *
+ * 본 모듈은 PENDING_PUSHES KV에 `retry-push:<pushId>` prefix entry를 stamp해 다음 cron cycle 에서
+ * exponential backoff (60s / 120s / 240s) 후 재발사를 시도한다. 별도 KV namespace 생성을 피하고
+ * 기존 binding 을 prefix 로 재사용한다 (운영 manual step 0).
+ *
+ * 책임 분리:
+ *   - `pendingPushes.ts` (`pending:` prefix): silent push 발사 직후 ACK 추적 (30s 미ACK alert fallback).
+ *   - `retryPushes.ts`   (`retry-push:` prefix): silent push 발사 자체 실패 시 transient retry 큐.
+ *
+ * 두 prefix 는 disjoint — 같은 pushId 가 두 큐에 동시 등록되지 않는다 (발사 성공 → pending, 실패 → retry).
+ */
+
+import {
+  isRetryableApnsError,
+  RETRY_BACKOFF_SCHEDULE_MS,
+  computeNextRetryAt,
+  sendWithEnvHeal,
+} from './apnsHost';
+import { sendSilentPush, type ApnsConfig, type SilentPushPayload } from './apns';
+import { assertCronCacheTtl, CRON_READ_CACHE_TTL_SEC as SHARED_CRON_TTL } from './kvConsistency';
+import type { ApnsEnv, Env } from './types';
+
+const RETRY_PREFIX = 'retry-push:';
+
+/**
+ * cron read의 KV cacheTtl. pendingPushes.ts와 동일 정책 — putRetryPush 직후 같은 cron 사이클이
+ * (또는 다음 cycle) entry 를 못 보는 stale read 방지. Cloudflare KV 최소 30s.
+ */
+const CRON_READ_CACHE_TTL_SEC = SHARED_CRON_TTL;
+
+/**
+ * 전체 KV TTL — 모든 backoff 단계를 cover 하고 buffer 60s. attempt 4 도달 시 remove 호출이
+ * idempotent 하므로 TTL 만료 자연 정리도 안전.
+ */
+export const RETRY_PUSH_TTL_SEC = Math.ceil(
+  RETRY_BACKOFF_SCHEDULE_MS.reduce((a, b) => a + b, 0) / 1000,
+) + 60;
+
+/**
+ * Retry queue entry. silent push payload + 발사 컨텍스트(token, apnsEnv) + retry meta.
+ *
+ * payload 전체를 직렬화해 다음 cron 이 원본 push 를 재구성할 수 있게 한다 — caller (`fireArvlCdStationPush`
+ * 등)가 같은 payload 를 다시 빌드할 필요가 없다.
+ */
+export interface RetryPush {
+  pushId: string;
+  /** APNs device token. */
+  token: string;
+  /** silent push payload 전체 (재발사용). */
+  payload: SilentPushPayload;
+  /** apnsEnv snapshot. retry 시점에 trip.apnsEnv 가 corrected 되었을 수 있으나, queue 시점 값으로 1차 시도. */
+  apnsEnv: ApnsEnv;
+  /** 시도 횟수 (0 = 첫 enqueue 직후, 1 = 첫 retry 후, …). RETRY_BACKOFF_SCHEDULE_MS.length 도달 시 폐기. */
+  attemptCount: number;
+  /** 다음 시도 시각 (epoch ms). cron 이 now >= nextAttemptAt 일 때만 처리. */
+  nextAttemptAt: number;
+  /** 원본 발사 시도 시각 (관측용). */
+  originalSentAt: number;
+  /** 마지막 실패 status — RCA 용. */
+  lastErrorStatus: number;
+  /** 마지막 실패 reason (있을 때). */
+  lastErrorReason?: string;
+}
+
+export function retryPushKey(pushId: string): string {
+  return `${RETRY_PREFIX}${pushId}`;
+}
+
+/**
+ * 발사 실패가 retryable 인지 검사 + retry queue 등록. status 가 retryable 이 아니거나 KV 미바인딩이면 no-op.
+ *
+ * `attemptCount` 미지정 시 0 (첫 enqueue). 호출자가 fire path 실패 직후 한 번 호출하면 충분 —
+ * 다음 cron `runRetryPushes` 가 backoff 후 재발사 + 추가 실패 시 attemptCount 증가 + 재 enqueue.
+ */
+export async function enqueueRetryIfTransient(
+  kv: KVNamespace | undefined,
+  input: {
+    pushId: string;
+    token: string;
+    payload: SilentPushPayload;
+    apnsEnv: ApnsEnv;
+    status: number;
+    reason?: string;
+    now: number;
+    attemptCount?: number;
+    originalSentAt?: number;
+  },
+): Promise<boolean> {
+  if (!kv) return false;
+  if (!isRetryableApnsError(input.status)) return false;
+  const attemptCount = input.attemptCount ?? 0;
+  const nextAttemptAt = computeNextRetryAt(attemptCount, input.now);
+  if (nextAttemptAt === null) return false; // 영구 폐기 — caller 가 별도 cleanup
+  const entry: RetryPush = {
+    pushId: input.pushId,
+    token: input.token,
+    payload: input.payload,
+    apnsEnv: input.apnsEnv,
+    attemptCount,
+    nextAttemptAt,
+    originalSentAt: input.originalSentAt ?? input.now,
+    lastErrorStatus: input.status,
+    ...(input.reason !== undefined ? { lastErrorReason: input.reason } : {}),
+  };
+  await kv.put(retryPushKey(input.pushId), JSON.stringify(entry), {
+    expirationTtl: RETRY_PUSH_TTL_SEC,
+  });
+  return true;
+}
+
+export async function removeRetryPush(
+  kv: KVNamespace | undefined,
+  pushId: string,
+): Promise<void> {
+  if (!kv) return;
+  await kv.delete(retryPushKey(pushId));
+}
+
+/**
+ * cron 시점 모든 retry-push entry enumerate. listPending 과 동일 패턴 (prefix scan + cursor).
+ * 손상된 JSON 은 skip (TTL 자연 정리).
+ */
+export async function* listRetryPushes(
+  kv: KVNamespace | undefined,
+): AsyncGenerator<RetryPush> {
+  if (!kv) return;
+  let cursor: string | undefined;
+  do {
+    const result = await kv.list({ prefix: RETRY_PREFIX, cursor });
+    for (const key of result.keys) {
+      assertCronCacheTtl(CRON_READ_CACHE_TTL_SEC);
+      const raw = await kv.get(key.name, { cacheTtl: CRON_READ_CACHE_TTL_SEC });
+      if (!raw) continue;
+      try {
+        yield JSON.parse(raw) as RetryPush;
+      } catch {
+        // 손상된 entry 는 skip — 만료로 자연 정리.
+      }
+    }
+    cursor = result.list_complete ? undefined : result.cursor;
+  } while (cursor);
+}
+
+type Logger = (message: string, meta?: Record<string, unknown>) => void;
+
+export interface RetryPushDeps {
+  apnsConfig: ApnsConfig;
+  apnsHosts: Record<ApnsEnv, string>;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+  log?: Logger;
+}
+
+export interface RetryPushStats {
+  scanned: number;
+  /** nextAttemptAt 미도달로 skip — 다음 cron tick 까지 deferred. */
+  deferred: number;
+  /** 재발사 성공 — entry 삭제. */
+  resent: number;
+  /** transient 실패 → backoff 재 enqueue. */
+  rescheduled: number;
+  /** unrecoverable 또는 attempt 소진 → 영구 폐기 (entry 삭제). */
+  exhausted: number;
+}
+
+/**
+ * `retry-push:` 큐를 스캔하며 backoff 만기 entry 를 재발사한다. cron 1 cycle 당 1회 호출.
+ *
+ * 처리 흐름:
+ *   1. `now < nextAttemptAt` → deferred + skip.
+ *   2. `sendWithEnvHeal` 로 양 env 재시도. envHeal 자체가 mismatch 보정 1회 + opposite 1회.
+ *   3. 성공 → `removeRetryPush` + resent++.
+ *   4. 실패가 retryable + attemptCount < 한계 → 다음 backoff 로 재 enqueue (attemptCount + 1).
+ *   5. 실패가 unrecoverable 또는 attempt 한계 도달 → `removeRetryPush` + exhausted++. caller 의
+ *      별 cleanup (410 → cleanupTripWithLa) 는 본 큐 책임 외 — 원본 발사 사이트가 이미 처리.
+ */
+export async function runRetryPushes(env: Env, deps: RetryPushDeps): Promise<RetryPushStats> {
+  const now = deps.now?.() ?? Date.now();
+  const log = deps.log ?? (() => undefined);
+  const stats: RetryPushStats = { scanned: 0, deferred: 0, resent: 0, rescheduled: 0, exhausted: 0 };
+  for await (const entry of listRetryPushes(env.PENDING_PUSHES)) {
+    stats.scanned += 1;
+    if (now < entry.nextAttemptAt) {
+      stats.deferred += 1;
+      continue;
+    }
+    log('retry-push attempt', {
+      pushId: entry.pushId,
+      attempt: entry.attemptCount + 1,
+      ageMs: now - entry.originalSentAt,
+    });
+    const heal = await sendWithEnvHeal(
+      (host) =>
+        sendSilentPush({
+          deviceToken: entry.token,
+          payload: { ...entry.payload, sentAt: now },
+          config: deps.apnsConfig,
+          host,
+          fetchImpl: deps.fetchImpl,
+          now,
+        }),
+      entry.apnsEnv,
+      deps.apnsHosts,
+      log,
+      entry.token.slice(0, 8),
+    );
+    if (heal.result.ok) {
+      stats.resent += 1;
+      await removeRetryPush(env.PENDING_PUSHES, entry.pushId);
+      continue;
+    }
+    // 실패. retryable 이면 다음 backoff 로 재 enqueue, 아니면 폐기.
+    const nextAttempt = entry.attemptCount + 1;
+    const rescheduled = await enqueueRetryIfTransient(env.PENDING_PUSHES, {
+      pushId: entry.pushId,
+      token: entry.token,
+      payload: entry.payload,
+      apnsEnv: heal.correctedEnv ?? entry.apnsEnv,
+      status: heal.result.status,
+      reason: heal.result.reason,
+      now,
+      attemptCount: nextAttempt,
+      originalSentAt: entry.originalSentAt,
+    });
+    if (rescheduled) {
+      stats.rescheduled += 1;
+      log('retry-push rescheduled', {
+        pushId: entry.pushId,
+        nextAttempt,
+        status: heal.result.status,
+        reason: heal.result.reason,
+      });
+    } else {
+      stats.exhausted += 1;
+      await removeRetryPush(env.PENDING_PUSHES, entry.pushId);
+      log('retry-push exhausted', {
+        pushId: entry.pushId,
+        attempt: nextAttempt,
+        status: heal.result.status,
+        reason: heal.result.reason,
+      });
+    }
+  }
+  log('retry-push run complete', { ...stats });
+  return stats;
+}

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -64,6 +64,7 @@ import {
 import { findStationCoordsByNameAndLine } from './stationsLookup';
 import { assertCronCacheTtl } from './kvConsistency';
 import { buildAlarmKey, putPending } from './pendingPushes';
+import { enqueueRetryIfTransient } from './retryPushes';
 import { deleteProgress, getProgress, putProgress, type TripProgress } from './progress';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from './seoul';
 import { pollLinesAndStamp, readSelfPollPosition } from './selfPollPosition';
@@ -1498,19 +1499,21 @@ export async function fireArvlCdStationPush(
   });
   // #1561 (T8, ADR-017 / S2 흡수) — fire 직전 SSoT 권위 스냅샷 forward.
   // #1614 Phase C — stale guard 단계에서 이미 read한 ssotForStale 재사용 (KV read 1회 절약).
+  // #1721 — payload 를 local 변수로 추출해 transient 실패 시 retry queue 적재에 재사용.
+  const arvlcdPayload = buildStationPassedImminentPayload({
+    trip,
+    waypoint,
+    lock,
+    pushId,
+    now,
+    origin: 'arvlcd',
+    ssot: ssotForStale,
+  });
   const heal = await sendWithEnvHeal(
     (host) =>
       sendSilentPush({
         deviceToken: trip.token,
-        payload: buildStationPassedImminentPayload({
-          trip,
-          waypoint,
-          lock,
-          pushId,
-          now,
-          origin: 'arvlcd',
-          ssot: ssotForStale,
-        }),
+        payload: arvlcdPayload,
         config: deps.apnsConfig,
         host,
         fetchImpl: deps.fetchImpl,
@@ -1539,6 +1542,18 @@ export async function fireArvlCdStationPush(
       status: heal.result.status,
       reason: heal.result.reason,
       token: trip.token.slice(0, 8),
+    });
+    // #1721 — transient 실패(429 / 5xx) 시 retry queue 적재. envHeal 양 env 모두 실패해도 영구 lost
+    // 차단. 410/400 BadDeviceToken 같은 unrecoverable 은 enqueueRetryIfTransient 가 자연 skip
+    // (caller 가 이미 dedup/cleanup 책임).
+    await enqueueRetryIfTransient(env.PENDING_PUSHES, {
+      pushId,
+      token: trip.token,
+      payload: arvlcdPayload,
+      apnsEnv: trip.apnsEnv ?? 'sandbox',
+      status: heal.result.status,
+      reason: heal.result.reason,
+      now,
     });
     // dedup KV는 성공 시에만 stamp — 실패 push는 다음 cycle 재시도 허용.
     return { dirty };
@@ -1843,20 +1858,22 @@ export async function fireVanishFallbackStationPush(
   // release하므로 device에 `lockReleasedReason='vanish'`를 forward해 store sync. vanish-fallback은
   // 직후 `advanceBoardingLockWaypoint`로 흘러가 그 함수가 transfer 시 별도로 release를 통지한다.
   const lockReleasedReason: 'vanish' | undefined = origin === 'vanish-release' ? 'vanish' : undefined;
+  // #1721 — payload 를 local 변수로 추출해 transient 실패 시 retry queue 적재에 재사용.
+  const vanishPayload = buildStationPassedImminentPayload({
+    trip,
+    waypoint,
+    lock,
+    pushId,
+    now,
+    origin,
+    lockReleasedReason,
+    ssot,
+  });
   const heal = await sendWithEnvHeal(
     (host) =>
       sendSilentPush({
         deviceToken: trip.token,
-        payload: buildStationPassedImminentPayload({
-          trip,
-          waypoint,
-          lock,
-          pushId,
-          now,
-          origin,
-          lockReleasedReason,
-          ssot,
-        }),
+        payload: vanishPayload,
         config: deps.apnsConfig,
         host,
         fetchImpl: deps.fetchImpl,
@@ -1881,6 +1898,16 @@ export async function fireVanishFallbackStationPush(
       status: heal.result.status,
       reason: heal.result.reason,
       token: trip.token.slice(0, 8),
+    });
+    // #1721 — vanish 경로는 silent push 가 가장 잘 누락되는 경로라 retry queue 적재 우선순위 1순위.
+    await enqueueRetryIfTransient(env.PENDING_PUSHES, {
+      pushId,
+      token: trip.token,
+      payload: vanishPayload,
+      apnsEnv: trip.apnsEnv ?? 'sandbox',
+      status: heal.result.status,
+      reason: heal.result.reason,
+      now,
     });
     // dedup KV는 성공 시에만 stamp — 실패 push는 다음 cycle 재시도 허용.
     return;
@@ -2525,20 +2552,22 @@ export async function advanceBoardingLockWaypoint(
     const ssotForTransfer = await readSsot(env.TRIPS, trip.token, {
       cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
     });
+    // #1721 — payload 를 local 변수로 추출해 transient 실패 시 retry queue 적재에 재사용.
+    const transferPayload = buildStationPassedImminentPayload({
+      trip,
+      waypoint,
+      lock: releasedLockSnapshot,
+      pushId,
+      now,
+      origin: 'transfer-release',
+      lockReleasedReason: 'transfer',
+      ssot: ssotForTransfer,
+    });
     const transferHeal = await sendWithEnvHeal(
       (host) =>
         sendSilentPush({
           deviceToken: trip.token,
-          payload: buildStationPassedImminentPayload({
-            trip,
-            waypoint,
-            lock: releasedLockSnapshot,
-            pushId,
-            now,
-            origin: 'transfer-release',
-            lockReleasedReason: 'transfer',
-            ssot: ssotForTransfer,
-          }),
+          payload: transferPayload,
           config: deps.apnsConfig,
           host,
           fetchImpl: deps.fetchImpl,
@@ -2561,6 +2590,18 @@ export async function advanceBoardingLockWaypoint(
     // #1683 — transfer-release push 성공 시 kind 카운터 누적.
     if (transferHeal.result.ok) {
       stats.silentPushFiredByKind.transfer += 1;
+    } else {
+      // #1721 — transient 실패(429 / 5xx) 시 retry queue 적재. transfer-release 도 silent push 누락 시
+      // leg 2 boardingPrompt 재요청이 차단되는 회귀(2026-06-18 evidence)가 발생하므로 retry 필요.
+      await enqueueRetryIfTransient(env.PENDING_PUSHES, {
+        pushId,
+        token: trip.token,
+        payload: transferPayload,
+        apnsEnv: trip.apnsEnv ?? 'sandbox',
+        status: transferHeal.result.status,
+        reason: transferHeal.result.reason,
+        now,
+      });
     }
   }
   // #902 Seam F — 환승 직후 자동 trainCode swap. release한 lock 자리에 새 노선의 후보를
@@ -3036,39 +3077,41 @@ export async function runLocklessIntermediate(
   const locklessSsot = await readSsot(env.TRIPS, trip.token, {
     cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
   });
+  // #1721 — payload 를 local 변수로 추출해 transient 실패 시 retry queue 적재에 재사용.
+  const locklessPayload: SilentPushPayload = {
+    nextWaypoint: waypoint.stationName,
+    etaSeconds: signal.etaSeconds,
+    phase: 'imminent',
+    kind: 'intermediate',
+    sentAt: now,
+    pushId,
+    // Epic #1204 그룹 2 D3 (#1273) — lockless intermediate도 waypoint.hopIndex forward.
+    // D1 estimator의 currentHopIndex와 ±tolerance 매칭 시 거리 검증 우회 + GPS 미준비 fallback.
+    hopIndex: waypoint.hopIndex,
+    // #1365 — server-authoritative occupiedLine. 환승역에서 디바이스가 같은 hop index에
+    // 다른 line의 stop과 cross-validation 가능. waypoint.line을 그대로 forward.
+    occupiedLine: waypoint.line,
+    // #1307 — server-authoritative subsurface. lockless intermediate도 지하에선
+    // 디바이스 GPS 게이트(out-of-range 오거부)를 우회하도록 flag를 전달.
+    subsurface: trip.subsurface === true,
+    // #1399 — 좀비 알림 cleanup. lockless intermediate push에도 tripToken stamp.
+    // trip-ended cleanup 후 늦게 도착한 stale push를 ACTIVE_TRIP_KEY mismatch로 drop.
+    tripToken: trip.token,
+    // #1402 — 발사 경로 stamp. device alarmLog에 pushOrigin=lockless로 기록.
+    origin: 'lockless' as const,
+    // #1539 (S6) — backend 누적 passedStations forward. 빈 배열/undefined는 apns.ts JSON
+    // serializer가 자연 누락. device backfill diff(S5 후속 wiring PR)에서 사용.
+    passedStations: trip.passedStations,
+    // #1561 (T8, ADR-017 / S2 흡수) — TripPositionSSoT 권위 forward. null/undefined는 apns.ts
+    // JSON serializer가 자연 누락 → device cascade picker는 기존 tier fallback. lockless trip은
+    // backend SSoT가 가장 신뢰 높은 단일 신호 (lock 부재 환경).
+    ssot: toSilentPushSsot(locklessSsot),
+  };
   const heal = await sendWithEnvHeal(
     (host) =>
       sendSilentPush({
         deviceToken: trip.token,
-        payload: {
-          nextWaypoint: waypoint.stationName,
-          etaSeconds: signal.etaSeconds,
-          phase: 'imminent',
-          kind: 'intermediate',
-          sentAt: now,
-          pushId,
-          // Epic #1204 그룹 2 D3 (#1273) — lockless intermediate도 waypoint.hopIndex forward.
-          // D1 estimator의 currentHopIndex와 ±tolerance 매칭 시 거리 검증 우회 + GPS 미준비 fallback.
-          hopIndex: waypoint.hopIndex,
-          // #1365 — server-authoritative occupiedLine. 환승역에서 디바이스가 같은 hop index에
-          // 다른 line의 stop과 cross-validation 가능. waypoint.line을 그대로 forward.
-          occupiedLine: waypoint.line,
-          // #1307 — server-authoritative subsurface. lockless intermediate도 지하에선
-          // 디바이스 GPS 게이트(out-of-range 오거부)를 우회하도록 flag를 전달.
-          subsurface: trip.subsurface === true,
-          // #1399 — 좀비 알림 cleanup. lockless intermediate push에도 tripToken stamp.
-          // trip-ended cleanup 후 늦게 도착한 stale push를 ACTIVE_TRIP_KEY mismatch로 drop.
-          tripToken: trip.token,
-          // #1402 — 발사 경로 stamp. device alarmLog에 pushOrigin=lockless로 기록.
-          origin: 'lockless' as const,
-          // #1539 (S6) — backend 누적 passedStations forward. 빈 배열/undefined는 apns.ts JSON
-          // serializer가 자연 누락. device backfill diff(S5 후속 wiring PR)에서 사용.
-          passedStations: trip.passedStations,
-          // #1561 (T8, ADR-017 / S2 흡수) — TripPositionSSoT 권위 forward. null/undefined는 apns.ts
-          // JSON serializer가 자연 누락 → device cascade picker는 기존 tier fallback. lockless trip은
-          // backend SSoT가 가장 신뢰 높은 단일 신호 (lock 부재 환경).
-          ssot: toSilentPushSsot(locklessSsot),
-        },
+        payload: locklessPayload,
         config: deps.apnsConfig,
         host,
         fetchImpl: deps.fetchImpl,
@@ -3103,6 +3146,18 @@ export async function runLocklessIntermediate(
       await cleanupTripWithLa(trip, env, deps, stats, now, log, 'push-unrecoverable');
       return;
     }
+    // #1721 — transient 실패(429 / 5xx) 시 retry queue 적재. unrecoverable / envMismatchExhausted
+    // 분기 이후이므로 본 경로는 transient 또는 기타 비치명 실패. enqueueRetryIfTransient 가 retryable
+    // 만 적재한다.
+    await enqueueRetryIfTransient(env.PENDING_PUSHES, {
+      pushId,
+      token: trip.token,
+      payload: locklessPayload,
+      apnsEnv: trip.apnsEnv ?? 'sandbox',
+      status: heal.result.status,
+      reason: heal.result.reason,
+      now,
+    });
     if (dirty) await putTrip(env.TRIPS, trip);
     return;
   }


### PR DESCRIPTION
## Summary

silent push 발사 실패(429 / 5xx) 영구 lost 차단. `sendWithEnvHeal` 양 env retry 후에도 transient 실패하면 PENDING_PUSHES KV에 `retry-push:<pushId>` prefix로 적재 → 다음 cron tick에서 exponential backoff(60s / 120s / 240s) 재발사.

6/23 13:44 backend log evidence:
- 13:44:17 `apns env mismatch — retry with opposite host` (production → sandbox)
- 13:44:17 `apns env corrected to sandbox`

기존 envHeal은 1차(current env) + opposite env 1회 시도까지만 — 둘 다 transient(429 / 5xx)면 영구 lost. 본 PR은 envHeal 위에 retry queue를 얹어 backoff 후 재시도.

Closes #1721

---

## 구현

### 신규 모듈
- **`backend/alarm-worker/src/retryPushes.ts`** — `retry-push:` prefix entry CRUD + `runRetryPushes` cron entry
- **`backend/alarm-worker/src/__tests__/retryPushes.test.ts`** — 26 신규 테스트

### `apnsHost.ts` 추가
- `isRetryableApnsError(status)` — 429 / 500-599 → true
- `RETRY_BACKOFF_SCHEDULE_MS = [60_000, 120_000, 240_000]` — cron 1분 주기 정합
- `computeNextRetryAt(attempt, now)` — schedule 초과 시 null (영구 폐기 신호)

### `scheduled.ts` wire (4개 fire 경로)
- `fireArvlCdStationPush` (arvlcd)
- `fireVanishFallbackStationPush` (vanish-fallback / vanish-release)
- `runLocklessIntermediate` (lockless intermediate)
- `advanceBoardingLockWaypoint` (transfer-release)

각 실패 path에서 payload를 local 변수로 추출 후 `enqueueRetryIfTransient` 호출.

### `index.ts` cron handler
- `runScheduled` → `runFallbackPushes` → **`runRetryPushes`** (new)

### KV namespace
- **별도 namespace 생성 X** — 기존 `PENDING_PUSHES` binding을 3 prefix로 재사용:
  - `pending:` (기존, #566 — silent push ACK 추적)
  - `received:` (기존, #1370 — push 도달 stamp)
  - `retry-push:` (신규, #1721 — silent push 재발사 큐)
- 운영 manual step 0건

---

## Wire-completion 5단 체크

- [x] **1. Orphan 없음** — `npm run lint:orphan` pass. 신규 export(`enqueueRetryIfTransient`, `runRetryPushes`)는 `scheduled.ts`/`index.ts` caller 존재.
- [x] **2. V/X dashboard** — wrangler tail 로그 + Cloudflare Dashboard logs:
  - `retry-push attempt` — backoff 만기 시 시도
  - `retry-push rescheduled` — 재시도 후에도 transient → 다음 backoff 재 enqueue
  - `retry-push exhausted` — attempt 한계 도달 / unrecoverable → 폐기
  - `retry-push run complete` — cron 1 cycle 통계 (scanned / deferred / resent / rescheduled / exhausted)
- [x] **3. 의존 PR** — N/A (backend-only, device wire 무변경)
- [x] **4. 측정 plan** — production 1주 측정:
  - `wrangler tail` 또는 Cloudflare Dashboard에서 `retry-push attempt` 빈도 확인
  - 정상 운영: APNs 429 / 5xx은 드물어 `retry-push rescheduled` 0~몇건/일 예상
  - `retry-push exhausted` > 0이면 backend 측 APNs 인증 / network 회귀 신호
  - `retry-push resent` > 0이면 본 fix 효과 직접 evidence (이전엔 lost되던 push가 retry로 도달)
- [x] **5. Device verify** — N/A — type+unit only. backend 모듈만 변경, device wire 무변경. CI Type Check & Test + Data Validation pass.

---

## Test plan

- [x] `cd backend/alarm-worker && npm test` — 2114 tests pass (+44 신규 vs 2070 baseline)
- [x] `cd backend/alarm-worker && npm run type-check` pass
- [x] `npm run type-check` (frontend) pass
- [x] `npm test` (frontend) — 7643 tests pass
- [x] `npm run lint:orphan` pass

### 신규 테스트 커버리지

**`retryPushes.test.ts` (26 tests):**
- `retryPushKey` / `RETRY_PUSH_TTL_SEC` 상수 검증
- `enqueueRetryIfTransient`: 429 / 500 / 503 / 410 / 400 BadDeviceToken / attemptCount 명시 / 한계 초과 / kv 미바인딩 / reason 미지정
- `removeRetryPush`: 키 삭제 / kv 미바인딩
- `listRetryPushes`: prefix scan / 손상된 JSON skip / kv 미바인딩
- `runRetryPushes`: deferred / 재발사 성공 / 재 enqueue / 410 폐기 / attempt 한계 / apnsEnv 보존 / kv 미바인딩 / sentAt 갱신 / 기본 logger / 기본 now

**`scheduled.test.ts` (+16 tests):**
- `isRetryableApnsError`: 11 status 매트릭스
- `computeNextRetryAt`: 3 attempt + 한계 + 음수
- `#1721 arvlcd fire 503 → retry-push: 큐 적재` integration
- `#1721 410 Unregistered → retry-push: 큐 적재 X` integration

---

## 운영 manual step

**없음.** 기존 `PENDING_PUSHES` KV binding 재사용.

배포 후 첫 cron tick부터 `runRetryPushes`가 자동 실행되며, 큐가 비어있으면 graceful no-op (`scanned: 0`).