### PR TITLE
fix(#1719): lockSwap direction=null wrong-direction 차단

### DIFF
--- a/backend/alarm-worker/src/__tests__/legDirection.test.ts
+++ b/backend/alarm-worker/src/__tests__/legDirection.test.ts
@@ -1,0 +1,90 @@
+/**
+ * #1719 — legDirection.ts 단위 테스트.
+ *
+ * `lockSwap.attachTrainCodeForLeg` 가 `direction=null` 로 호출하면 wrong direction trains 가
+ * candidate pool 에 통과하는 회귀를 차단하기 위해, segmentStations 의 첫 + 마지막 역으로
+ * leg 진행 방향을 추론한다. frontend `loopDirection.ts` + `travelDirection.ts` 와 동일 정책
+ * (`lineTopology.json` 단일 SSoT) 이지만 backend-local 로 작성된 helper 의 정합성 보장.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { inferLegDirection } from '../legDirection';
+
+describe('inferLegDirection — monotonic 노선', () => {
+  it('7호선 중곡 → 어린이대공원 (id 증가) → down', () => {
+    expect(inferLegDirection('7', '중곡', '어린이대공원')).toBe('down');
+  });
+
+  it('7호선 어린이대공원 → 중곡 (id 감소) → up', () => {
+    expect(inferLegDirection('7', '어린이대공원', '중곡')).toBe('up');
+  });
+
+  it('3호선 대화 → 오금 (id 증가) → down', () => {
+    expect(inferLegDirection('3', '대화', '오금')).toBe('down');
+  });
+
+  it('동일 역 → null', () => {
+    expect(inferLegDirection('7', '중곡', '중곡')).toBeNull();
+  });
+
+  it('canonical fallback (부제 포함) → 정상 매칭', () => {
+    // stations.json 은 "군자(능동)" 로 등록 — base name "군자" 도 normalizeStationName 으로 매칭.
+    expect(inferLegDirection('7', '중곡', '군자')).toBe('down');
+  });
+
+  it('존재하지 않는 역 → null', () => {
+    expect(inferLegDirection('7', '없는역', '중곡')).toBeNull();
+    expect(inferLegDirection('7', '중곡', '없는역')).toBeNull();
+  });
+});
+
+describe('inferLegDirection — closedLoop hybrid (6호선 응암 루프)', () => {
+  it('합정 → 광흥창 (id 6-013 → 6-015) → down', () => {
+    // 사용자 6/23 trip evidence — 합정에서 공덕 방면 진행. 잘못된 응암 방향 train(6184)
+    // 차단의 정합성 검증.
+    expect(inferLegDirection('6', '합정', '광흥창')).toBe('down');
+  });
+
+  it('합정 → 공덕 (id 6-013 → 6-017) → down', () => {
+    expect(inferLegDirection('6', '합정', '공덕')).toBe('down');
+  });
+
+  it('공덕 → 합정 (id 감소) → up', () => {
+    expect(inferLegDirection('6', '공덕', '합정')).toBe('up');
+  });
+
+  it('응암 → 연신내 (id 6-001 → 6-005, hybrid 단방향 꼬리) → down', () => {
+    // hybrid 노선이지만 loopTailRange 가 있으면 단순 id 비교 — wrap 무의미.
+    expect(inferLegDirection('6', '응암', '연신내')).toBe('down');
+  });
+});
+
+describe('inferLegDirection — closedLoop pure (2호선 순환선)', () => {
+  it('홍대입구 → 신촌 (인접, id 단조 증가) → down', () => {
+    // forward arc < backward arc → down.
+    expect(inferLegDirection('2', '홍대입구', '신촌')).toBe('down');
+  });
+
+  it('신촌 → 홍대입구 (인접, id 단조 감소) → up', () => {
+    expect(inferLegDirection('2', '신촌', '홍대입구')).toBe('up');
+  });
+
+  it('지선 역(2-105+ 등 mainIdRange 밖) → null', () => {
+    // 2호선 지선 (성수지선, 신정지선) 은 mainIdRange 밖 — null.
+    expect(inferLegDirection('2', '용답', '신답')).toBeNull();
+  });
+});
+
+describe('inferLegDirection — 추론 불가 노선', () => {
+  it('1호선 (다중 종착/지선) → null', () => {
+    expect(inferLegDirection('1', '서울역', '시청')).toBeNull();
+  });
+
+  it('5호선 (마천/상일동 분기) → null', () => {
+    expect(inferLegDirection('5', '광화문', '종로3가')).toBeNull();
+  });
+
+  it('알 수 없는 line code → null', () => {
+    expect(inferLegDirection('99', '서울역', '시청')).toBeNull();
+  });
+});

--- a/backend/alarm-worker/src/__tests__/lockSwap.test.ts
+++ b/backend/alarm-worker/src/__tests__/lockSwap.test.ts
@@ -55,17 +55,21 @@ function makeTrip(waypoints: Waypoint[]): Trip {
   };
 }
 
+// #1719 — leg(중곡→어린이대공원 / 중곡→군자, 7호선) direction=down 인 fixture 가 다수이므로
+// `isUp` 을 5번째 옵션 인자로 노출. 기본값 false 로 down direction 정합(test가 명시 안 하면
+// down). single-waypoint leg(direction=null) test 는 어느 값이든 통과.
 function makeArrival(
   trainCode: string,
   arvlCd: number | null,
   arrivalSeconds = 60,
   subwayNm = '지하철7호선',
+  isUp = false,
 ): ArrivalEntry {
   return {
     destination: '도봉산',
     arrivalSeconds,
     trainCode,
-    isUp: true,
+    isUp,
     subwayNm,
     arvlCd,
   };
@@ -295,11 +299,12 @@ describe('attachTrainCodeForLeg', () => {
  * 사용 fixture: line=7, segmentStations=[중곡, 군자, 어린이대공원], target=중곡.
  */
 
+// #1719 — leg(중곡→어린이대공원, 7호선) direction=down 정합 — default isUp=false.
 function position(overrides: Partial<PositionEntry> & { trainCode: string }): PositionEntry {
   return {
     stationName: '',
     trainSttus: 0,
-    isUp: true,
+    isUp: false,
     recptnMs: 0,
     ...overrides,
   };
@@ -405,5 +410,204 @@ describe('attachTrainCodeForLeg #1702 positions fallback', () => {
       selfPollPositions: [position({ trainCode: 'POSITIONS_TRAIN', stationName: '중곡' })],
     });
     expect(lock?.trainCode).toBe('POSITIONS_TRAIN');
+  });
+});
+
+/**
+ * #1719 — direction=null fallthrough 차단. lockSwap 이 inferLegDirection 으로 leg 진행 방향을
+ * 추론하므로, 양방향 trains 가 같은 station 에 있어도 wrong-direction train 은 candidate pool 에
+ * 들어가지 않는다. 사용자 6/23 trip evidence(6호선 응암 방향 6184) 시나리오 + 2호선 양방향
+ * 시나리오 + 추론 불가 노선의 기존 동작(both directions ambiguity → null) 보존 검증.
+ */
+
+// 6호선 합정 → 광흥창 → 대흥 → 공덕 (사용자 6/23 trip evidence segment).
+function makeLine6Trip(): Trip {
+  return {
+    token: 'tok',
+    route: { type: 'direct', line: '6', stops: 3 },
+    destination: 'dst',
+    waypoints: [
+      { stationName: '합정', line: '6', kind: 'intermediate' },
+      { stationName: '광흥창', line: '6', kind: 'intermediate' },
+      { stationName: '대흥', line: '6', kind: 'intermediate' },
+      { stationName: '공덕', line: '6', kind: 'destination' },
+    ],
+    expiresAt: NOW + 60 * 60_000,
+    createdAt: NOW,
+    alarmAtEpochMs: NOW + 60_000,
+  };
+}
+
+function line6Arrival(
+  trainCode: string,
+  isUp: boolean,
+  arvlCd: number | null = 1,
+  arrivalSeconds = 60,
+): ArrivalEntry {
+  return {
+    destination: isUp ? '응암' : '봉화산',
+    arrivalSeconds,
+    trainCode,
+    isUp,
+    subwayNm: '지하철6호선',
+    arvlCd,
+  };
+}
+
+describe('attachTrainCodeForLeg #1719 wrong-direction 차단', () => {
+  const line6Target: Waypoint = { stationName: '합정', line: '6', kind: 'intermediate' };
+
+  it('real arrivals: 양방향 trains → DOWN train 만 선택 (UP 응암 방향 차단)', async () => {
+    // 사용자 trip evidence — 합정 6호선 양방향 trains 동시 진입. leg 진행 방향(down) 만 채택.
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: makeArrivalsFetch([
+        line6Arrival('6184', true), // 응암 방향 (UP) — leg 와 반대
+        line6Arrival('6187', false), // 공덕 방향 (DOWN) — leg 정합
+      ]),
+    });
+    const lock = await attachTrainCodeForLeg({
+      trip: makeLine6Trip(),
+      targetWaypoint: line6Target,
+      seoul,
+      now: NOW,
+    });
+    expect(lock?.trainCode).toBe('6187');
+  });
+
+  it('real arrivals: UP only (wrong direction) → null (fallback prompt)', async () => {
+    // Seoul OpenAPI 가 한 방향(UP=응암) 만 반환한 회귀 시나리오. leg=down 이므로 매칭 0건 → null.
+    // direction=null 이었으면 6184 가 single candidate 로 lock 합성됐을 케이스를 차단.
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: makeArrivalsFetch([line6Arrival('6184', true)]),
+    });
+    const lock = await attachTrainCodeForLeg({
+      trip: makeLine6Trip(),
+      targetWaypoint: line6Target,
+      seoul,
+      now: NOW,
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('positions fallback: 양방향 trains @ 합정 → DOWN train 만 합성', async () => {
+    // Seoul API 0건 → positions fallback. positions 가 양방향 trains 를 반환해도 leg=down 만 채택.
+    const seoul = makeSeoul([]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeLine6Trip(),
+      targetWaypoint: line6Target,
+      seoul,
+      now: NOW,
+      selfPollPositions: [
+        position({ trainCode: '6184', stationName: '합정', isUp: true }), // UP 응암 방향
+        position({ trainCode: '6187', stationName: '합정', isUp: false }), // DOWN 공덕 방향
+      ],
+    });
+    expect(lock?.trainCode).toBe('6187');
+  });
+
+  it('positions fallback: UP only (wrong direction) → null (잘못된 응암 방향 lock 차단)', async () => {
+    const seoul = makeSeoul([]);
+    const lock = await attachTrainCodeForLeg({
+      trip: makeLine6Trip(),
+      targetWaypoint: line6Target,
+      seoul,
+      now: NOW,
+      selfPollPositions: [position({ trainCode: '6184', stationName: '합정', isUp: true })],
+    });
+    expect(lock).toBeNull();
+  });
+
+  it('2호선 양방향(외선/내선) wrong-direction 차단 — 합정 → 신촌 (DOWN)', async () => {
+    // 2호선 합정 → 신촌 leg 는 외선순환(down). 내선순환(up) train 차단.
+    const trip: Trip = {
+      token: 'tok',
+      route: { type: 'direct', line: '2', stops: 2 },
+      destination: 'dst',
+      waypoints: [
+        { stationName: '합정', line: '2', kind: 'intermediate' },
+        { stationName: '신촌', line: '2', kind: 'destination' },
+      ],
+      expiresAt: NOW + 60 * 60_000,
+      createdAt: NOW,
+      alarmAtEpochMs: NOW + 60_000,
+    };
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: makeArrivalsFetch([
+        {
+          destination: '시청',
+          arrivalSeconds: 60,
+          trainCode: '2_INNER',
+          isUp: true, // 내선순환
+          subwayNm: '지하철2호선',
+          arvlCd: 1,
+        },
+        {
+          destination: '신촌',
+          arrivalSeconds: 60,
+          trainCode: '2_OUTER',
+          isUp: false, // 외선순환
+          subwayNm: '지하철2호선',
+          arvlCd: 1,
+        },
+      ]),
+    });
+    const lock = await attachTrainCodeForLeg({
+      trip,
+      targetWaypoint: { stationName: '합정', line: '2', kind: 'intermediate' },
+      seoul,
+      now: NOW,
+    });
+    // 합정(2-038) → 신촌(2-040) → id 증가 = 외선순환(down). 외선 train 만 통과.
+    // direction=null 이었으면 양방향 priority 1 ambiguity 로 null 이었을 케이스를 차단.
+    expect(lock?.trainCode).toBe('2_OUTER');
+  });
+
+  it('추론 불가 노선(5호선 분기) → direction=null fallback, 기존 동작 유지', async () => {
+    // 5호선은 monotonic + closedLoop 둘 다 X — `inferLegDirection` null. caller 는 direction=null
+    // 로 진행 → 양방향 candidate 같이 통과(ambiguity → null) 또는 단일 후보면 통과 (기존 동작).
+    const trip: Trip = {
+      token: 'tok',
+      route: { type: 'direct', line: '5', stops: 2 },
+      destination: 'dst',
+      waypoints: [
+        { stationName: '광화문', line: '5', kind: 'intermediate' },
+        { stationName: '종로3가', line: '5', kind: 'destination' },
+      ],
+      expiresAt: NOW + 60 * 60_000,
+      createdAt: NOW,
+      alarmAtEpochMs: NOW + 60_000,
+    };
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: makeArrivalsFetch([
+        {
+          destination: '하남검단산',
+          arrivalSeconds: 60,
+          trainCode: '5_DOWN',
+          isUp: false,
+          subwayNm: '지하철5호선',
+          arvlCd: 1,
+        },
+      ]),
+    });
+    const lock = await attachTrainCodeForLeg({
+      trip,
+      targetWaypoint: { stationName: '광화문', line: '5', kind: 'intermediate' },
+      seoul,
+      now: NOW,
+    });
+    // direction=null 이므로 단일 후보 통과 (기존 lockSwap 정책 유지).
+    expect(lock?.trainCode).toBe('5_DOWN');
   });
 });

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1609,8 +1609,9 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
       );
       // arrivals에 다른 trainCode(7999)가 중곡행으로 있음 → attachTrainCodeForLeg가 swap candidate 반환
       // swap 후 재estimate 성공 → consecutiveEtaMissing 리셋, lock 유지
+      // #1719 — leg(중곡→군자, 7호선) direction=down 이므로 isUp=false 로 fixture 정정.
       const arrivals: ArrivalEntry[] = [
-        { destination: '중곡', arrivalSeconds: 60, trainCode: '7999', isUp: true, subwayNm: '지하철7호선', arvlCd: null },
+        { destination: '중곡', arrivalSeconds: 60, trainCode: '7999', isUp: false, subwayNm: '지하철7호선', arvlCd: null },
       ];
       await runScheduled(makeEnv(kv), {
         seoul: makeSeoulCombo(arrivals, []),

--- a/backend/alarm-worker/src/legDirection.ts
+++ b/backend/alarm-worker/src/legDirection.ts
@@ -1,0 +1,107 @@
+/**
+ * #1719 — Backend leg-direction 추론.
+ *
+ * 배경
+ * ====
+ * `lockSwap.attachTrainCodeForLeg` 는 `direction=null` 로 `resolveTrainCodeWithFallback` 을
+ * 호출하므로, 양방향 trains 가 같은 station 에 있으면 wrong direction train 도 candidate 로
+ * 통과한다. 2호선 외선/내선, 6호선 응암 방향 train 같은 사례에서 silent push 정확도 회귀.
+ *
+ * 본 모듈은 leg 의 첫 station + 마지막 station 의 stations.json id 를 비교해 진행 방향을
+ * 추론한다. frontend `loopDirection.ts` + `travelDirection.ts` 와 동일 정책(`lineTopology.json`
+ * 단일 SSoT) 이지만, backend 가 frontend `getStationsOnLine` 의존 그래프(stationRoute → logger,
+ * lineColors) 를 끌어오지 않도록 backend-local 로 작성한다.
+ *
+ * 정책
+ * ====
+ *  - **monotonic 노선** (3/4/7/8/9/airport/bundang/sinbundang): stations.json id 단순 비교.
+ *    `from.id > to.id` → 'up' (id 감소 = 상행), 아니면 'down'.
+ *  - **closedLoop hybrid 노선** (6호선): mainIdRange 안에서 id 단조 비교. loopTailRange 가
+ *    있으면 단방향 꼬리라 wrap 무의미 — 단순 id 비교만으로 frontend `inferLoopDirection` 의
+ *    hybrid 분기와 정렬.
+ *  - **closedLoop pure 노선** (2호선): mainIdRange 안 stations 의 forward/backward arc 길이
+ *    비교. 짧은 호 채택 (forward < backward → down).
+ *  - **그 외** (1/5/gyeongui 등 비단조/지선): null 반환. caller 는 기존 direction=null 동작
+ *    유지 (현재 회귀 봉쇄 효과 0, 기존 implicit segmentStations 필터에 의존).
+ *
+ * 사용처
+ * ======
+ * `lockSwap.attachTrainCodeForLeg` 가 segmentStations[0] + segmentStations[last] 로 호출.
+ * segmentStations.length < 2 (target == leg 마지막) 일 때는 caller 가 segmentStations[0] +
+ * targetStation 으로 호출해도 결과 null (동일 역) → 안전.
+ */
+
+import lineTopology from '../../../src/data/lineTopology.json';
+import { findStationByNameAndLine } from '../../../src/shared/utils/stationLookup';
+import stationsRaw from '../../../src/data/stations.json';
+import type { Station } from '../../../src/shared/types/station';
+import type { LineNumber } from './types';
+
+/** stations.json 전체 — 2호선 pure loop 의 mainIdRange 안 stations 만 추출용. */
+const stations = stationsRaw as Station[];
+
+interface ClosedLoopMeta {
+  mainIdRange: { firstId: string; lastId: string };
+  /** 있으면 hybrid 노선(P자 + 단방향 꼬리). 없으면 진짜 순환선. */
+  loopTailRange?: { firstId: string; lastId: string };
+}
+
+const MONOTONIC_LINES: ReadonlySet<string> = new Set(lineTopology.monotonicLines);
+const CLOSED_LOOPS = lineTopology.closedLoops as Partial<Record<string, ClosedLoopMeta>>;
+
+/**
+ * leg 의 진행 방향 추론. 추론 불가 시 null.
+ *
+ * 입력
+ *   - line: leg 의 호선 (backend `LineNumber = string`).
+ *   - fromStationName: leg 시작 (segmentStations[0] 추천).
+ *   - toStationName: leg 끝 (segmentStations[last] 추천).
+ *
+ * 반환
+ *   - 'up' | 'down' | null
+ *
+ * 동일 역(from === to canonical) 또는 매핑 실패 시 null.
+ */
+export function inferLegDirection(
+  line: LineNumber,
+  fromStationName: string,
+  toStationName: string,
+): 'up' | 'down' | null {
+  const fromStation = findStationByNameAndLine(
+    fromStationName,
+    line as Parameters<typeof findStationByNameAndLine>[1],
+  );
+  const toStation = findStationByNameAndLine(
+    toStationName,
+    line as Parameters<typeof findStationByNameAndLine>[1],
+  );
+  if (!fromStation || !toStation) return null;
+  if (fromStation.id === toStation.id) return null;
+
+  // Monotonic 노선 + Hybrid closedLoop(6호선) — 단순 id 비교.
+  // Hybrid 는 단방향 꼬리라 wrap 의미 X — frontend `inferLoopDirection` hybrid 분기와 정합.
+  const hybrid = CLOSED_LOOPS[line];
+  if (MONOTONIC_LINES.has(line) || (hybrid && hybrid.loopTailRange)) {
+    return fromStation.id > toStation.id ? 'up' : 'down';
+  }
+
+  // Pure closedLoop(2호선) — mainIdRange 안 forward/backward arc 길이 비교.
+  if (hybrid && !hybrid.loopTailRange) {
+    const { firstId, lastId } = hybrid.mainIdRange;
+    const main = stations.filter(
+      (s) => s.line === line && s.id >= firstId && s.id <= lastId,
+    );
+    if (main.length < 2) return null;
+    const fromIdx = main.findIndex((s) => s.id === fromStation.id);
+    const toIdx = main.findIndex((s) => s.id === toStation.id);
+    if (fromIdx === -1 || toIdx === -1) return null; // 지선 (mainIdRange 밖)
+    const n = main.length;
+    const forward = (toIdx - fromIdx + n) % n;
+    const backward = n - forward;
+    if (forward === backward) return null; // 정반대 위치 — ambiguous
+    return forward < backward ? 'down' : 'up';
+  }
+
+  // 비단조 + closedLoop 등록 X (1/5/gyeongui) — 추론 불가.
+  return null;
+}

--- a/backend/alarm-worker/src/lockSwap.ts
+++ b/backend/alarm-worker/src/lockSwap.ts
@@ -9,13 +9,18 @@
  *
  * 본 모듈은 순수 pipeline (KV I/O 없음). 호출자가 결과 BoardingLockMeta를 trip에 stamp + putTrip.
  *
- * 방향 매칭은 stationName 필터로 implicit 해소:
- *  - 다음 waypoint stationName + 같은 line의 arrivals만 평가 → 잘못된 방향은 station 응답 자체가 없음.
- *  - 추가로 `pickAutoTrainCode`(boardingPrompt.ts)의 arvlCd 우선순위(2>1>0)로 ambiguity 회피.
+ * 방향 매칭 (#1719):
+ *  - `inferLegDirection(line, segmentStations[0], segmentStations[last])` 로 leg 진행 방향 추론.
+ *    추론 가능 노선(monotonic + closedLoop hybrid/pure)에서는 wrong-direction trains 가 candidate
+ *    pool 에 들어가지 않는다 (2호선 외선/내선 / 6호선 응암 방향 회귀 봉쇄).
+ *  - 추론 불가 노선(1/5/gyeongui)에서는 direction=null fallback → stationName + segmentStations
+ *    인덱스 필터로 진행 방향 implicit 해소 (기존 동작 유지).
+ *  - `pickAutoTrainCode` 의 arvlCd 우선순위(2>1>0) + ambiguity null 반환으로 후보 확정.
  */
 
 import { resolveTrainCodeWithFallback } from './arrivalsFromPositions';
 import { isLockLineAllowed } from './consensusGate';
+import { inferLegDirection } from './legDirection';
 import { matchLine, subwayIdForLine } from './lineAlias';
 import type { PositionEntry, SeoulArrivalClient } from './seoul';
 import type { BoardingLockMeta, LineNumber, Trip, Waypoint } from './types';
@@ -79,8 +84,10 @@ export interface AttachLockInputs {
  * 후보 선택 정책:
  *  - 노선 매칭(matchLine) + arvlCd 우선순위(2 출발 > 1 도착 > 0 진입 > 그 외)
  *  - 같은 우선순위 후보 다수 = ambiguity → null (silent skip, caller가 boarding-prompt fallback)
- *  - direction=null: stationName 필터가 이미 진행 방향을 implicit으로 결정 (그 역에 보이지 않는
- *    방향 train은 응답 자체가 없음).
+ *  - direction: #1719 — `inferLegDirection(line, segmentStations[0], segmentStations[last])` 로
+ *    leg 의 진행 방향을 추론해 `resolveTrainCodeWithFallback` 에 forward. 실패(비단조 노선 /
+ *    단일-station leg / 매핑 실패) 시 null → 기존 양방향 허용 동작 유지. 양방향 train 이 같은
+ *    station 에 있는 케이스(2호선 외선/내선, 6호선 응암 방향) 의 wrong-direction lock 회귀 차단.
  *
  * subwayId 매핑 누락 line이면 null — backend는 stations.json 없이 line code만 신뢰.
  */
@@ -97,15 +104,23 @@ export async function attachTrainCodeForLeg(
   const segmentStations = buildLegSegmentStations(trip.waypoints, line);
   if (segmentStations.length === 0) return null;
 
+  // #1719 — leg 진행 방향 추론. segmentStations 가 단일 역이거나 비단조 노선이면 null →
+  // 기존 양방향 허용 동작 유지 (현재 코드와 동일 회귀 위험 잔존, 단 회귀 가능 line 은 추론
+  // 가능 노선 밖). 추론 성공 시 양방향 train 동일 station 의 wrong-direction lock 봉쇄.
+  const direction =
+    segmentStations.length >= 2
+      ? inferLegDirection(line, segmentStations[0], segmentStations[segmentStations.length - 1])
+      : null;
+
   const realArrivals = await seoul.fetchArrivals(targetWaypoint.stationName);
   // #1702 (B2-A) — Seoul OpenAPI 단방향/0건 시 realtimePosition fallback. autoLock 과 동일 패턴.
-  // direction=null 인 swap 흐름에서도 segmentStations 기반 필터로 같은 line 의 진행 방향 trains
-  // 만 추출되므로 wrong-direction lock 회귀를 차단한다 (transfer 후 leg + vanish 후 재부착 모두).
+  // direction (#1719) 으로 양방향 합성/real arrivals 양쪽에서 wrong-direction trains 차단 —
+  // transfer 후 leg + vanish 후 재부착 모두 같은 게이트.
   const resolved = resolveTrainCodeWithFallback({
     realArrivals,
     positions: selfPollPositions,
     line,
-    direction: null,
+    direction,
     segmentStations,
     targetStation: targetWaypoint.stationName,
   });

--- a/backend/alarm-worker/tsconfig.json
+++ b/backend/alarm-worker/tsconfig.json
@@ -25,6 +25,7 @@
     "../../src/data/stationDistances.json",
     "../../src/data/transferTimes.json",
     "../../src/data/stationAliases.js",
+    "../../src/data/lineTopology.json",
     "../../src/shared/types/station.ts",
     "../../src/shared/utils/stationLookup.ts",
     "../../src/shared/utils/normalizeStationName.js",


### PR DESCRIPTION
## Summary

`lockSwap.attachTrainCodeForLeg`가 `direction=null`로 `resolveTrainCodeWithFallback`을 호출하던 fallthrough를 차단. `inferLegDirection(line, segmentStations[0], segmentStations[last])`로 leg 진행 방향을 추론해 forward하므로, 양방향 trains가 같은 station에 있는 케이스(2호선 외선/내선, 6호선 응암 방향) 의 wrong-direction lock 회귀를 봉쇄한다.

Closes #1719

---

## 변경 사항

### lockSwap.ts (#1719)
- `attachTrainCodeForLeg`에 `inferLegDirection` 호출 추가 — `segmentStations.length >= 2` 인 경우 leg 첫 + 마지막 역으로 방향 추론.
- 추론 가능 노선(monotonic / closedLoop hybrid·pure)에서는 wrong-direction trains가 candidate pool에 들어가지 않음.
- 추론 불가 노선(1/5/gyeongui)에서는 `direction=null` fallback → 기존 동작(stationName + segmentStations 인덱스 필터) 유지.

### legDirection.ts (신규)
- backend-local helper. frontend `loopDirection.ts` + `travelDirection.ts`와 동일 정책(`lineTopology.json` 단일 SSoT)이지만, heavy 의존 그래프(`stationRoute` → `logger`, `lineColors`) 미포함.
- `findStationByNameAndLine`(이미 backend import)으로 station id 조회 + `lineTopology.json` 의 `monotonicLines` / `closedLoops.{mainIdRange, loopTailRange}` 기반 분기.
- monotonic + hybrid(6호선): 단순 id 비교 (hybrid는 단방향 꼬리라 wrap 무의미).
- pure closedLoop(2호선): mainIdRange 안 forward/backward arc 길이 비교.

### tsconfig.json
- `../../src/data/lineTopology.json` 추가.

### Test fixture 정정
- `lockSwap.test.ts`의 `makeArrival` / `position` 헬퍼 기본값을 `isUp=false`로 변경 — 기존 fixture가 line 7 leg(중곡→어린이대공원, direction=down)에서 `isUp=true`(UP)였던 회귀 evidence 정정.
- `scheduled.test.ts`의 1건 vanish-swap fixture(중곡→군자, line 7) 의 arrival `isUp: true → false` 정정.

---

## Acceptance (이슈 본문)

- [x] lockSwap direction=null 호출 시 segmentStations indexing으로 direction 산출 — `attachTrainCodeForLeg`이 `inferLegDirection(line, segmentStations[0], segmentStations[last])` 호출.
- [x] wrong direction train 합성 candidate 통과 X — `synthesizeArrivalsFromPositions:88-91`의 `direction !== null` 필터가 직접 적용됨.
- [x] backend test fixture: 양방향 trains + segmentStations → 사용자 진행 방향만 candidate — `attachTrainCodeForLeg #1719 wrong-direction 차단` describe 블록의 4건.
- [x] 6호선 응암 방향 train 차단 검증 — `real arrivals: UP only (wrong direction) → null` + `positions fallback: UP only (wrong direction) → null` 2건.

---

## Wire-completion 5단 체크

- [x] **1. Orphan 없음** — `npm run lint:orphan` pass. `legDirection.ts`의 `inferLegDirection` export는 `lockSwap.ts:23`이 import.
- [x] **2. V/X dashboard** — backend `wrangler tail` 의 `boarding-lock: trainCode vanished, swapped` / `boarding-lock: waypoint advanced` log + Cloudflare Dashboard scheduled invocations. 새 direction filter는 swap candidate pool 에서 wrong-direction trainCode가 제외되는 효과로 관측됨 (swap 시 swapped.trainCode 가 사용자 진행 방향과 일치).
- [x] **3. 의존 PR** — N/A. 본 PR은 backend self-contained.
- [x] **4. 측정 plan** — 1주 production 측정으로 silent push reschedule push 의 `trainCode lock` 이 사용자 진행 방향과 일치하는지 trip evidence 캡처. wrong-direction lock 재발 0건 확인. backend Sentry `boarding-lock: trainCode vanished, swapped` event 의 swapped trainCode 가 leg direction 정합.
- [x] **5. Device verify** — N/A — backend type+unit only. 사용자 6/23 trip evidence segment(6호선 합정→공덕) 시나리오는 production 측정으로 확인.

### V/X dashboard URL

- Cloudflare Dashboard: alarm-worker `boarding-lock: trainCode vanished, swapped` / `boarding-lock: waypoint advanced` log query.
- backend Sentry `swap` event 의 `swapped.trainCode` cross-check.

### 의존 PR

N/A.

---

## Test plan

- [x] `cd backend/alarm-worker && npm test` PASS (2092 tests).
- [x] `cd backend/alarm-worker && npm run type-check` PASS.
- [x] `npm run type-check` (frontend) PASS.
- [x] `npm run lint:orphan` PASS.
- [x] `legDirection.test.ts` 16건 — monotonic / closedLoop hybrid / closedLoop pure / 추론 불가 노선 + canonical fallback + 동일 역.
- [x] `lockSwap.test.ts` 30건 — 기존 24건 + `#1719 wrong-direction 차단` 6건 (real arrivals 양방향 / UP only / positions fallback 양방향 / positions UP only / 2호선 외선·내선 / 5호선 fallback).

---

## 코드 리뷰 결과

자체 리뷰 결과 (Karpathy guideline 점검):

- **Think Before Coding**: 옵션 A(caller 산출) + 옵션 B(synthesize 내부 추론) 비교 후 옵션 A 채택. 양쪽 fix path(real arrivals + positions fallback)를 한 곳에서 cover, 함수 시그니처 변경 없음.
- **Simplicity First**: backend-local helper로 frontend 의존 그래프 회피. `inferLegDirection` 자체는 3 분기 + 5 if 가드 (~70 lines).
- **Surgical Changes**: `lockSwap.ts`는 import 1줄 + direction 산출 4줄 + parameter swap 1줄 + 주석. 기존 fixture 정정은 helper 기본값 변경 1+1줄 + scheduled.test.ts 1줄.
- **Goal-Driven Execution**: acceptance 4항 모두 테스트로 verify.