### PR TITLE
fix(#1723): stale GPS sticky reset + 환승역 trip line 우선 cascade

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.staleGpsAndTransferLine.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.staleGpsAndTransferLine.test.ts
@@ -1,0 +1,370 @@
+/* eslint-disable import/no-restricted-paths -- cross-feature orchestration (#890) */
+
+/**
+ * #1723 — GPS fallback 정제: stale 거부 + 환승역 line 보정.
+ *
+ * 사용자 6/23 evidence:
+ *   - 13:56 trip 종료 후 새로고침 → 을지로3가 stuck (실제 위치 다름, stale GPS lastFix 6분 전)
+ *   - 14:20 광흥창 도착 시 현재역 신내/합정 toggle (환승역 cascade picker switching)
+ *
+ * fix 영역:
+ *   1. GPS lastFixAtMs 5분+ stale → cascade 최종 fallback에서 result=null (gps.liveResult 거부).
+ *   2. 환승역(동명 station 여러 line)에서 boardingLock.boardingLine 일치 line 우선.
+ *
+ * 시나리오:
+ *   A. stale GPS:
+ *      A1. lastFixAtMs 5분 초과 → cascade fallback result=null
+ *      A2. lastFixAtMs 5분 이내 → 정상 fallback (liveResult 채택)
+ *      A3. lastFixAtMs null (cold start) → liveResult가 null이라 fallback도 null (기존 동작)
+ *      A4. lastFixAtMs undefined (미주입 fixture) → liveResult 그대로 채택 (graceful)
+ *      A5. stale + 다른 tier(positionTrain) active → tier 채택 (본 게이트 비진입)
+ *      A6. shouldDowngradeFusion 강등 후에도 stale GPS면 result=null
+ *
+ *   B. 환승역 line 보정:
+ *      B1. lock 활성 + liveResult line != boardingLine → boardingLine line으로 재해석
+ *      B2. lock 활성 + liveResult line == boardingLine → 그대로 (no-op)
+ *      B3. lockless trip + allowedLines size=1 → 그 line으로 재해석
+ *      B4. lockless trip + allowedLines size > 1 → 보정 없음 (그대로)
+ *      B5. lock 활성 + line mismatch + findStationByNameAndLine 매칭 실패 → 원본 그대로 (graceful)
+ */
+
+import { renderHook } from '@testing-library/react-native';
+import { useFusedNearestStation } from '../useFusedNearestStation';
+import { useNearestStation } from '../useNearestStation';
+import { useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
+import { useTrainPositions } from '../../../route/hooks/useTrainPositions';
+import { findTopNearestStations } from '../../utils/findNearestStation';
+import { findStationByNameAndLine } from '../../../../shared/utils/stationLookup';
+import {
+  arrivalRet,
+  positionRet,
+  GPS_BASE_DEFAULTS,
+  makeTrain,
+} from '../../../../testUtils/positionApiFixtures';
+import { TRAIN_STATUS } from '../../../../shared/constants/trainStatus';
+import { GPS_FALLBACK_STALE_MAX_AGE_MS } from '../../../../shared/constants/realtime';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+import type { Station } from '../../../../shared/types/station';
+import type { LinePositions } from '../../api/positionApi';
+
+jest.mock('../../utils/findNearestStation', () => ({
+  findTopNearestStations: jest.fn(),
+}));
+jest.mock('../useNearestStation');
+jest.mock('../../../arrival/hooks/useArrivalInfo');
+jest.mock('../../../route/hooks/useTrainPositions');
+jest.mock('../../../alarm/utils/tripStartStorage', () => ({
+  getTripStartedAt: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../../../alarm/utils/backendSsotMirror', () => ({
+  readBackendSsotMirror: jest.fn().mockResolvedValue(null),
+}));
+
+const mockNearest = useNearestStation as jest.Mock;
+const mockArrival = useArrivalInfo as jest.Mock;
+const mockPos = useTrainPositions as jest.Mock;
+const mockFindTop = findTopNearestStations as jest.Mock;
+
+// 합정: 2호선/6호선 환승역 — 동명 station 다른 line 케이스의 fixture.
+const hapjeong2 = findStationByNameAndLine('합정', '2')!;
+const hapjeong6 = findStationByNameAndLine('합정', '6')!;
+const yongmasan7 = findStationByNameAndLine('용마산', '7')!;
+
+const T0 = 1_700_000_000_000;
+
+function makeLock(station: Station): BoardingLock {
+  return {
+    destinationId: 'dest',
+    trainCode: 'T-LOCK',
+    boardingLine: station.line,
+    boardingStationId: station.id,
+    boardedAt: T0,
+    expectedDurationMs: 10 * 60_000,
+  };
+}
+
+/** GPS mock: liveResult + lastFixAtMs를 명시 제어 (스테일 시나리오) */
+function setupGps(
+  liveStation: Station,
+  options: {
+    lastFixAtMs?: number | null;
+    distanceKm?: number;
+  } = {},
+) {
+  const distanceKm = options.distanceKm ?? 0.05;
+  const live = { station: liveStation, distanceKm };
+  mockNearest.mockReturnValue({
+    result: live,
+    liveResult: live,
+    stickyDisplayOnly: null,
+    variants: [liveStation],
+    userLocation: { lat: liveStation.lat, lng: liveStation.lng },
+    ...GPS_BASE_DEFAULTS,
+    lastFixAtMs: options.lastFixAtMs,
+    refresh: jest.fn(),
+  });
+  mockFindTop.mockReturnValue([{ station: liveStation, distanceKm }]);
+  mockArrival.mockReturnValue(arrivalRet(null));
+  mockPos.mockReturnValue(positionRet(null));
+}
+
+describe('#1723 GPS fallback stale + 환승역 line 보정', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(T0);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('A. stale GPS 처리', () => {
+    it('A1: lastFixAtMs 5분 초과 → cascade fallback result=null', () => {
+      setupGps(hapjeong2, { lastFixAtMs: T0 - (GPS_FALLBACK_STALE_MAX_AGE_MS + 1) });
+      const hook = renderHook(() => useFusedNearestStation());
+      expect(hook.result.current.result).toBeNull();
+      expect(hook.result.current.source).toBe('gps');
+      expect(hook.result.current.confidence).toBe('gps-only');
+    });
+
+    it('A2: lastFixAtMs 5분 이내 → 정상 fallback (liveResult 채택)', () => {
+      setupGps(hapjeong2, { lastFixAtMs: T0 - (GPS_FALLBACK_STALE_MAX_AGE_MS - 1) });
+      const hook = renderHook(() => useFusedNearestStation());
+      expect(hook.result.current.result?.station.id).toBe(hapjeong2.id);
+    });
+
+    it('A3: lastFixAtMs=null + liveResult=null → fallback도 null (cold start)', () => {
+      mockNearest.mockReturnValue({
+        result: null,
+        liveResult: null,
+        stickyDisplayOnly: null,
+        variants: [],
+        userLocation: null,
+        ...GPS_BASE_DEFAULTS,
+        lastFixAtMs: null,
+        refresh: jest.fn(),
+      });
+      mockFindTop.mockReturnValue([]);
+      mockArrival.mockReturnValue(arrivalRet(null));
+      mockPos.mockReturnValue(positionRet(null));
+      const hook = renderHook(() => useFusedNearestStation());
+      expect(hook.result.current.result).toBeNull();
+    });
+
+    it('A4: lastFixAtMs=undefined (테스트 fixture 미주입) → liveResult 그대로 (graceful)', () => {
+      // 기존 테스트 호환: GPS_BASE_DEFAULTS는 lastFixAtMs를 포함 안 함 → undefined.
+      // 이 경우 stale 게이트 비진입 → liveResult 그대로 채택.
+      const live = { station: hapjeong2, distanceKm: 0.05 };
+      mockNearest.mockReturnValue({
+        result: live,
+        liveResult: live,
+        stickyDisplayOnly: null,
+        variants: [hapjeong2],
+        userLocation: { lat: hapjeong2.lat, lng: hapjeong2.lng },
+        ...GPS_BASE_DEFAULTS,
+        // lastFixAtMs 미주입 → undefined
+        refresh: jest.fn(),
+      });
+      mockFindTop.mockReturnValue([{ station: hapjeong2, distanceKm: 0.05 }]);
+      mockArrival.mockReturnValue(arrivalRet(null));
+      mockPos.mockReturnValue(positionRet(null));
+      const hook = renderHook(() => useFusedNearestStation());
+      expect(hook.result.current.result?.station.id).toBe(hapjeong2.id);
+    });
+
+    it('A5: stale GPS + positionTrain active → positionTrain 채택 (게이트 비진입)', () => {
+      // stale GPS임에도 positionTrain tier가 살아있으면 cascade가 positionTrain 채택 — 본 게이트는 미진입.
+      const lock = makeLock(yongmasan7);
+      const liveAtChungdam = findStationByNameAndLine('청담', '7')!;
+      mockNearest.mockReturnValue({
+        result: { station: liveAtChungdam, distanceKm: 0 },
+        liveResult: { station: liveAtChungdam, distanceKm: 0 },
+        stickyDisplayOnly: null,
+        variants: [liveAtChungdam],
+        userLocation: { lat: liveAtChungdam.lat, lng: liveAtChungdam.lng },
+        ...GPS_BASE_DEFAULTS,
+        lastFixAtMs: T0 - (GPS_FALLBACK_STALE_MAX_AGE_MS + 60_000), // 6분 전 stale
+        refresh: jest.fn(),
+      });
+      mockFindTop.mockReturnValue([{ station: yongmasan7, distanceKm: 0 }]);
+      // positionTrain: 7호선 용마산에 lock.trainCode 매칭 열차 정차 → positionTrain tier 진입.
+      const train = makeTrain('용마산', TRAIN_STATUS.ARRIVED, { trainNo: lock.trainCode });
+      const linePositions: LinePositions = {
+        line: '7',
+        trains: [train],
+      };
+      mockPos.mockImplementation((line: string | null) => {
+        if (line === '7') return positionRet(linePositions);
+        return positionRet(null);
+      });
+      mockArrival.mockReturnValue(arrivalRet(null));
+      const hook = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, lock.trainCode, lock),
+      );
+      // positionTrain tier가 1순위 → 용마산 채택 (stale GPS의 청담 무시).
+      expect(hook.result.current.source).not.toBe('gps');
+      expect(hook.result.current.result?.station.id).toBe(yongmasan7.id);
+    });
+
+    it('A6: shouldDowngradeFusion 강등 후 stale GPS면 result=null (motionStationary + speedMps=0 합의)', () => {
+      // 정적 합의 2 signal(speed=0 + motionStationary=true) + position-train 채택 → shouldDowngradeFusion 강등.
+      // 강등 후 GPS fallback이 stale → applyTransferLineCorrection(null) = null.
+      const lock = makeLock(yongmasan7);
+      const train = makeTrain('용마산', TRAIN_STATUS.ARRIVED, { trainNo: 'OTHER-TRAIN' });
+      const linePositions: LinePositions = { line: '7', trains: [train] };
+      mockNearest.mockReturnValue({
+        result: { station: yongmasan7, distanceKm: 0 },
+        liveResult: { station: yongmasan7, distanceKm: 0 },
+        stickyDisplayOnly: null,
+        variants: [yongmasan7],
+        userLocation: { lat: yongmasan7.lat, lng: yongmasan7.lng },
+        ...GPS_BASE_DEFAULTS,
+        speedMps: 0, // 정적 신호 1
+        accuracyMeters: 14,
+        lastFixAtMs: T0 - (GPS_FALLBACK_STALE_MAX_AGE_MS + 60_000), // 6분 전 stale
+        refresh: jest.fn(),
+      });
+      mockFindTop.mockReturnValue([{ station: yongmasan7, distanceKm: 0 }]);
+      mockPos.mockImplementation((line: string | null) => {
+        if (line === '7') return positionRet(linePositions);
+        return positionRet(null);
+      });
+      mockArrival.mockReturnValue(arrivalRet(null));
+      // motionStationary=true (정적 신호 2) → consensus 2 충족 → shouldDowngradeFusion 강등.
+      // 강등 후 fallback이 stale GPS이므로 result=null.
+      const hook = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          lock.trainCode,
+          lock,
+          true, // motionStationary
+        ),
+      );
+      expect(hook.result.current.source).toBe('gps');
+      expect(hook.result.current.result).toBeNull();
+    });
+
+    it('A7: shouldDowngradeFusion 강등 후 fresh GPS + 환승역 line drift → 환승역 line 보정 적용', () => {
+      // lock 활성 (line 6) + position-train tier 채택 → 정적 신호 2건 합의 → 강등 → gps-only.
+      // 강등 후 fallback이 fresh이지만 hapjeong2(line 2) → 환승역 line 보정으로 hapjeong6(line 6) 노출.
+      const lock = makeLock(hapjeong6);
+      const train = makeTrain('합정', TRAIN_STATUS.ARRIVED, { trainNo: 'OTHER-TRAIN' });
+      const linePositions: LinePositions = { line: '6', trains: [train] };
+      mockNearest.mockReturnValue({
+        result: { station: hapjeong2, distanceKm: 0.05 }, // GPS는 hapjeong2 (line 2)로 산출
+        liveResult: { station: hapjeong2, distanceKm: 0.05 },
+        stickyDisplayOnly: null,
+        variants: [hapjeong2, hapjeong6],
+        userLocation: { lat: hapjeong2.lat, lng: hapjeong2.lng },
+        ...GPS_BASE_DEFAULTS,
+        speedMps: 0,
+        accuracyMeters: 14,
+        lastFixAtMs: T0, // fresh
+        refresh: jest.fn(),
+      });
+      mockFindTop.mockReturnValue([{ station: hapjeong6, distanceKm: 0.05 }]);
+      mockPos.mockImplementation((line: string | null) => {
+        if (line === '6') return positionRet(linePositions);
+        return positionRet(null);
+      });
+      mockArrival.mockReturnValue(arrivalRet(null));
+      const hook = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          lock.trainCode,
+          lock,
+          true,
+        ),
+      );
+      // 강등 결과: source='gps', result=hapjeong6 (lock.boardingLine=6으로 재해석).
+      expect(hook.result.current.source).toBe('gps');
+      expect(hook.result.current.result?.station.id).toBe(hapjeong6.id);
+      expect(hook.result.current.result?.station.line).toBe('6');
+    });
+  });
+
+  describe('B. 환승역 line 보정', () => {
+    it('B1: lock 활성 + liveResult line != boardingLine → boardingLine line으로 재해석', () => {
+      // liveResult가 합정@2호선(stations.json entry order로 GPS top-1 채택)이지만 lock은 6호선.
+      // gpsFallbackResult helper가 boardingLine=6으로 재해석.
+      const lock = makeLock(hapjeong6);
+      setupGps(hapjeong2, { lastFixAtMs: T0 });
+      const hook = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, undefined, lock),
+      );
+      // fallback 결과는 같은 name '합정'이지만 line='6' (lock.boardingLine).
+      expect(hook.result.current.result?.station.name).toBe('합정');
+      expect(hook.result.current.result?.station.line).toBe('6');
+      expect(hook.result.current.result?.station.id).toBe(hapjeong6.id);
+    });
+
+    it('B2: lock 활성 + liveResult line == boardingLine → 그대로 (no-op)', () => {
+      const lock = makeLock(hapjeong2);
+      setupGps(hapjeong2, { lastFixAtMs: T0 });
+      const hook = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, undefined, lock),
+      );
+      expect(hook.result.current.result?.station.id).toBe(hapjeong2.id);
+    });
+
+    it('B3: lockless trip + allowedLines size=1 → 그 line으로 재해석', () => {
+      // direct route on 6호선 → allowedLines = {'6'}. liveResult는 합정@2 → 재해석 합정@6.
+      setupGps(hapjeong2, { lastFixAtMs: T0 });
+      const origin = findStationByNameAndLine('상수', '6')!;
+      const destination = findStationByNameAndLine('망원', '6')!;
+      const routeContext = {
+        route: { type: 'direct' as const, line: '6' as const, stops: 2, travelSeconds: 120 },
+        origin,
+        destination,
+      };
+      const hook = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, routeContext),
+      );
+      expect(hook.result.current.result?.station.line).toBe('6');
+      expect(hook.result.current.result?.station.id).toBe(hapjeong6.id);
+    });
+
+    it('B4: liveResult가 환승역이 아닌 단일 line station → 보정 없음 (그대로)', () => {
+      // 용마산은 7호선 단일 — boardingLine 일치 여부와 무관하게 그대로.
+      setupGps(yongmasan7, { lastFixAtMs: T0 });
+      const lock = makeLock(yongmasan7);
+      const hook = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, undefined, lock),
+      );
+      expect(hook.result.current.result?.station.id).toBe(yongmasan7.id);
+    });
+
+    it('B5: lock 활성 + line mismatch + findStationByNameAndLine 매칭 실패 → 원본 그대로 (graceful)', () => {
+      // 용마산은 7호선만 — boardingLine='2'로 재해석 시도 시 매칭 실패 → 원본(용마산@7) 그대로.
+      // lockOn2: 2호선 lock인데 GPS는 7호선 단일 station을 가리킴 (실제 production에선 allowedLines가
+      // 이미 차단하지만 본 helper graceful 분기 커버).
+      setupGps(yongmasan7, { lastFixAtMs: T0 });
+      const lockOn2: BoardingLock = {
+        destinationId: 'dest',
+        trainCode: 'T-LOCK',
+        boardingLine: '2',
+        boardingStationId: 'dummy-2',
+        boardedAt: T0,
+        expectedDurationMs: 10 * 60_000,
+      };
+      const hook = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, undefined, lockOn2),
+      );
+      // 매칭 실패 → 원본 용마산@7 그대로.
+      expect(hook.result.current.result?.station.id).toBe(yongmasan7.id);
+      expect(hook.result.current.result?.station.line).toBe('7');
+    });
+
+    it('B6: lockless + allowedLines undefined → 보정 없음 (그대로)', () => {
+      // routeContext 없음 → allowedLines undefined → 보정 helper에서 preferredLine null → 원본 그대로.
+      setupGps(hapjeong2, { lastFixAtMs: T0 });
+      const hook = renderHook(() => useFusedNearestStation());
+      expect(hook.result.current.result?.station.id).toBe(hapjeong2.id);
+    });
+  });
+});

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -63,6 +63,7 @@ import {
   GPS_DERIVED_ACCURACY_MAX_M,
   GPS_DERIVED_FIX_MAX_AGE_MS,
   GPS_DERIVED_ROUTE_MATCH_MAX_KM,
+  GPS_FALLBACK_STALE_MAX_AGE_MS,
   MAX_ACTIVE_LINES,
   MAX_FUSION_DELTA_KM,
   MAX_FUSION_DISTANCE_KM,
@@ -72,7 +73,7 @@ import {
 import type { LinePositions } from '../api/positionApi';
 import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
-import type { NearestStationResult, Station } from '../../../shared/types/station';
+import type { LineNumber, NearestStationResult, Station } from '../../../shared/types/station';
 import type { ArrivalProvider } from '../../../shared/types/providers';
 import type { PositionProvider } from '../providers/types';
 import {
@@ -754,17 +755,36 @@ export function useFusedNearestStation(
     maxDeltaKm: MAX_FUSION_DELTA_KM,
     lockActive: boardingLock != null,
   };
+  // #1723 — GPS fix staleness 게이트 (5분+ stale 거부).
+  //
+  // gps-only confidence(arrival/position 신호 부재 시 pickFusedStation이 GPS top-1로 fallback)는
+  // 사실상 GPS 좌표만으로 station을 산출하므로 GPS가 stale이면 stale station을 cascade로 흘려보낸다
+  // (사용자 6/23 13:56 evidence: trip 종료 후 을지로3가 stuck, GPS lastFix 6분 전 → fused tier가
+  // gps-only로 stale 좌표 채택). arrival/position 신호가 있는 fused는 GPS 좌표와 무관하게 신뢰
+  // 가능하므로 본 게이트 비적용.
+  const nowForGpsFallback = Date.now();
+  const gpsFallbackStale =
+    typeof gps.lastFixAtMs === 'number' &&
+    nowForGpsFallback - gps.lastFixAtMs > GPS_FALLBACK_STALE_MAX_AGE_MS;
+
   // #662: BoardingLock 활성 시 fused도 lock.boardingLine과 다른 노선이면 강등 — positionTrain과
   // 동일 정신. 환승역에서 GPS 후보가 두 노선 모두 잡아 fused가 옆 노선으로 fusion되는 케이스 방어.
   // race: createTransferLock으로 lock이 새 leg로 교체되는 순간 1 render cycle 동안 옛 lock 기준
   // 강등이 일어나 source가 한 번 gps로 flash 가능 — UX 임팩트 미미해 현재는 수용.
+  // #1723: fused.confidence='gps-only' + GPS stale → 게이트 실패 → cascade 다음 우선순위(routeResult /
+  //   verdict / GPS fallback) 시도. arrival/position 신호 있는 fused는 본 게이트 비적용 (gps-only만).
   const fusedPasses =
     fused != null &&
     passesFusionDistanceGate({ ...gateOpts, candidate: fused.result }) &&
-    (!boardingLock || fused.result.station.line === boardingLock.boardingLine);
+    (!boardingLock || fused.result.station.line === boardingLock.boardingLine) &&
+    !(fused.confidence === 'gps-only' && gpsFallbackStale);
   // routeResult는 route arc(단일 노선 segment) 위 진행도라 옆 노선 station이 들어올 수 없음 → 가드 불필요.
+  // #1723: route-progress는 progress 알고리즘이 user GPS와 arc를 fusion한 결과 — GPS stale이면
+  //   arc 위 progress 추정도 stale이므로 거부 (gps-only fused와 동일 정신).
   const routePasses =
-    routeResult != null && passesFusionDistanceGate({ ...gateOpts, candidate: routeResult });
+    routeResult != null &&
+    passesFusionDistanceGate({ ...gateOpts, candidate: routeResult }) &&
+    !gpsFallbackStale;
 
   // #1286 — WiFi SSID 역 매칭 → fusion cascade.
   // wifiSsidLookup은 역명 → 첫 번째 호선 Station을 반환하므로, 환승역 호선 보정:
@@ -1007,6 +1027,22 @@ export function useFusedNearestStation(
     return null;
   })();
 
+  // #1723 — GPS fallback 정제: stale 거부 (환승역 line 보정은 post-cascade에서 처리).
+  //
+  // useNearestStation.liveResult는 sticky override 없는 GPS 최근접 결과. cascade 최종 fallback
+  // (모든 device tier 실패) 또는 shouldDowngradeFusion 강등 후 GPS 원본 fallback에서 사용. stale GPS
+  // 6분 전 fix가 BG/지하 dead zone 후에도 남아 사용자 실제 위치와 무관한 stale station을 표시하는
+  // 회귀를 차단 (사용자 6/23 13:56 evidence: trip 종료 후 을지로3가 stuck).
+  //
+  // gpsFallbackStale는 위(fusedPasses/routePasses)에서 이미 계산. 본 helper도 같은 신선도 게이트
+  // 공유 — gps-only 모든 cascade tier(fused gps-only / routeProgress / 최종 fallback)에서 일관 적용.
+  //
+  // 환승역 line drift 보정은 cascade picker 직후 post-cascade 단계에서 source 화이트리스트
+  // (`source === 'gps' || source === 'route-progress'`) 기반으로 처리 — 본 helper는 stale gate만 담당.
+  const gpsFallbackResult: NearestStationResult | null = gpsFallbackStale
+    ? null
+    : gps.liveResult;
+
   let result: NearestStationResult | null;
   let confidence: FusionConfidence;
   let source: FusionSource;
@@ -1076,7 +1112,9 @@ export function useFusedNearestStation(
     // cascade fallback에 들어가 station-passed/imminent fire의 nearestStation 입력이 된다.
     // gps.liveResult는 sticky override 없는 GPS 최근접 결과 — sticky:locked가 fire path 진입 차단.
     // 표시 채널은 gps.stickyDisplayOnly로 별 노출(아래 return).
-    result = gps.liveResult;
+    // #1723 — stale GPS 거부 + 환승역 line 보정 (gpsFallbackResult helper).
+    //   gps.liveResult를 직접 쓰지 않고 정제된 helper를 사용해 stale fix stuck + cross-line drift 회귀 차단.
+    result = gpsFallbackResult;
     confidence = 'gps-only';
     source = 'gps';
   }
@@ -1105,6 +1143,43 @@ export function useFusedNearestStation(
   } else {
     logFusionPickerTier('gpsFallback');
   }
+
+  // #1723 — 환승역 line drift 보정 (post-cascade + 강등 후 fallback 공통).
+  //
+  // gps 또는 route-progress source로 산출된 result는 stations.json entry order 의존이라 환승역에서
+  // 잘못된 line이 채택될 수 있다 (사용자 6/23 14:20 evidence: 광흥창 부근에서 신내/합정 toggle).
+  // 이미 line-validated된 tier(boarding-lock / backend-ssot / wifi-ssid / position-train)는 본 보정
+  // 미적용 — source 화이트리스트로 강등.
+  //
+  // 보정 정책:
+  //   1. lock 활성 → boardingLock.boardingLine 선호
+  //   2. lockless + allowedLines size=1 (direct route 또는 단일 leg) → 그 line 선호
+  //   3. lockless + allowedLines size≥2 (환승 route) → 보정 없음 (어느 line 선호인지 불명확)
+  //   4. lockless + allowedLines undefined (trip 비활성) → 보정 없음 (자유 화면)
+  //
+  // 매칭 실패(target line에 해당 name 없음) 시 원본 그대로 (graceful, 회귀 0).
+  //
+  // distanceKm: 환승역 line별 좌표 미세 차이(예: 합정 line2 vs line6 ~25m)는 보존된 distanceKm로
+  // 흡수. fusion 거리 게이트 임계(0.5~0.6km)에 비해 미세해 false positive/negative 임팩트 무시 가능.
+  // 정확한 distanceKm 갱신은 후속 cycle GPS userLocation 변화 시 자연 재산출.
+  const applyTransferLineCorrection = (
+    candidate: NearestStationResult | null,
+    sourceForCheck: FusionSource,
+  ): NearestStationResult | null => {
+    if (candidate == null) return null;
+    if (sourceForCheck !== 'gps' && sourceForCheck !== 'route-progress') return candidate;
+    const preferredLine: LineNumber | null =
+      boardingLock?.boardingLine ??
+      (allowedLines && allowedLines.size === 1
+        ? Array.from(allowedLines)[0]
+        : null);
+    if (preferredLine === null) return candidate;
+    if (candidate.station.line === preferredLine) return candidate;
+    const reresolved = findStationByNameAndLine(candidate.station.name, preferredLine);
+    if (!reresolved) return candidate;
+    return { station: reresolved, distanceKm: candidate.distanceKm };
+  };
+  result = applyTransferLineCorrection(result, source);
 
   // #1418 — Tier 1 SSOT 합의 판정 + 환경 추정.
   //
@@ -1366,7 +1441,10 @@ export function useFusedNearestStation(
     source = 'gps';
     // #1486 (ADR-015 §2) — 강등 후 GPS 원본 fallback도 sticky 격리.
     // 위 cascade fallback과 동일 패턴: gps.liveResult가 sticky override 없는 GPS 최근접.
-    result = gps.liveResult;
+    // #1723 — 정제된 gpsFallbackResult helper (stale 거부) + 환승역 line 보정 동시 적용.
+    //   강등 후 source가 'gps'로 flip되므로 post-cascade 단계에서 놓친 transfer correction을
+    //   본 분기에서 다시 적용해 환승역 line drift 회귀 차단 (lock 활성 trip 보호).
+    result = applyTransferLineCorrection(gpsFallbackResult, 'gps');
   }
 
   // #1401 — prev arc idx 갱신. 최종 result 결정 후(강등 후 station이 바뀌었을 수 있음) idx 다시 계산.
@@ -1661,7 +1739,9 @@ export function useFusedNearestStation(
     loading: gps.loading,
     error: gps.error,
     permissionDenied: gps.permissionDenied,
-    locationUncertain: gps.locationUncertain,
+    // #1723 — GPS lastFix 5분+ stale 시 locationUncertain hoist. HomeScreen lastFusedStationRef +
+    //   effectiveOrigin cascade가 stale station을 사용자에게 stuck으로 노출하지 않도록 신호 전파.
+    locationUncertain: gps.locationUncertain || gpsFallbackStale,
     gpsActive: gps.gpsActive,
     lastFixAtMs: gps.lastFixAtMs,
     positionStability,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -307,10 +307,14 @@ export default function HomeScreen() {
   const boardingLockStation = fusionBoardingLock
     ? getStationById(fusionBoardingLock.boardingStationId) ?? null
     : null;
+  // #1723 — locationUncertain(GPS stale 5분+ 포함) 동안 lastFusedStationRef 우회.
+  //   사용자 6/23 13:56 evidence: trip 종료 후 GPS lastFix 6분 전 → result=null 이지만
+  //   lastFusedStationRef가 이전 trip 마지막 fused station(을지로3가) 보존 → stale stuck.
+  //   stale 시 ref skip → boardingLockStation / tripOrigin fallback → 모두 null 시 "위치 확인 중" UX.
   const effectiveOrigin =
     customOrigin ??
     result?.station ??
-    lastFusedStationRef.current ??
+    (locationUncertain ? null : lastFusedStationRef.current) ??
     boardingLockStation ??
     tripOrigin ??
     null;

--- a/src/shared/constants/realtime.ts
+++ b/src/shared/constants/realtime.ts
@@ -111,3 +111,25 @@ export const GPS_DERIVED_ROUTE_MATCH_MAX_KM = 0.1;
  * stale 신호를 채택하면 이전 정차 역을 현재역으로 오인하는 false positive 위험.
  */
 export const ARVL_CD_ARRIVED_MAX_AGE_MS = 35_000;
+
+/**
+ * #1723 — GPS fallback stale 게이트.
+ *
+ * 사용자 6/23 evidence: 13:56 trip 종료 후 새로고침 시 을지로3가 stuck (실제 위치 다름, stale GPS
+ * lastFix 6분 전). useFusedNearestStation cascade의 최종 fallback인 `gps.liveResult`가 GPS lastFix
+ * 6분 전 좌표를 들고 있어 현재역으로 표시. 5분+ stale은 사용자가 BG 동안 이동했거나 지하 dead zone
+ * 진입한 가능성이 높아 사용자 실제 위치와 무관.
+ *
+ * 5분 임계의 근거:
+ *   - 일반 도시 trip 평균 한 정차 ~1-2분 → 5분이면 3+ stop 통과 가능 (정확도 게이트로 부적합).
+ *   - iOS BG 위치 보고가 정상이면 lastFixAtMs는 3-5분 안에 갱신 (silent push wake / FG 복귀).
+ *   - 60s/30s 임계는 cascade의 다른 tier(positionTrain / GPS-derived / ARRIVED)가 이미 처리 —
+ *     본 게이트는 모든 device tier 실패 후 최종 fallback에만 적용해 false null 위험 최소화.
+ *
+ * 채택 시 동작: 5분+ stale GPS는 cascade 최종 fallback에서 채택 거부 → result=null 노출. 호출자는
+ * "위치 확인 중" UX(useNearestStation.locationUncertain와 동일 의미)로 표시.
+ *
+ * lockless / lock 활성 모두 동일 게이트 — backend SSoT / wifi / positionTrain 등 다른 tier가
+ * 살아있으면 자연 채택되므로 본 게이트 미진입.
+ */
+export const GPS_FALLBACK_STALE_MAX_AGE_MS = 5 * 60_000;


### PR DESCRIPTION
Closes #1723

## 배경
사용자 6/23 evidence:
- 13:56 trip 종료 후 새로고침 → 을지로3가 stuck (실제 위치 다름, GPS lastFix 6분 전)
- 14:20 광흥창 부근 신내/합정 toggle (환승역 cascade picker switching)

chain 1단 (multi-signal 현재역 detect) + 3단 (SSoT mirror forward) 본질적 한계.

## 변경 사항

### Production (3 파일)
- `src/shared/constants/realtime.ts` — `GPS_FALLBACK_STALE_MAX_AGE_MS = 5*60_000` 상수.
- `src/features/nearest-station/hooks/useFusedNearestStation.ts`:
  - GPS lastFix 5분+ stale 시 cascade fallback 거부 (gps-only fused / route-progress / GPS 원본 fallback)
  - `applyTransferLineCorrection` helper: source=gps/route-progress + (boardingLock.boardingLine 또는 allowedLines.size=1) 시 trip line 우선 재해석. line-validated tier(boarding-lock/backend-ssot/wifi-ssid/position-train)는 미적용.
  - `locationUncertain` hoist: `gps.locationUncertain || gpsFallbackStale` — stale 신호 consumer 채널로 전파.
- `src/screens/HomeScreen.tsx`:
  - `effectiveOrigin` cascade에서 `locationUncertain` 동안 `lastFusedStationRef.current` 우회 → stale 시 ref skip → boardingLockStation/tripOrigin fallback → 모두 null이면 "위치 확인 중" UX.

### Tests
- `useFusedNearestStation.staleGpsAndTransferLine.test.ts` (신규)

## evidence cover (acceptance)

| Evidence | cover |
|---|---|
| 6/23 13:56 을지로3가 stuck | ✅ fused stale 거부 + lastFusedStationRef 우회 chain |
| 6/23 14:20 광흥창 신내/합정 toggle | ⚠️ 부분 cover — `applyTransferLineCorrection`은 line drift(같은 station 다른 line)만 cover. **station hopping(같은 line 다른 station)은 별 follow-up 이슈** |

## 별 follow-up (분리 예정)
- 광흥창 14:20 신내/합정 toggle은 cascade picker가 tier 사이에서 다른 station 채택하는 문제. fusion log(`logFusionPickerTier`) trace로 어느 tier가 어느 station 산출하는지 박제 후 별 fix.

## acceptance (#1723)
- [x] GPS lastFix 5분+ stale 시 sticky station 강제 reset 또는 confidence demote (locationUncertain hoist + lastFusedStationRef 우회)
- [x] 환승역에서 trip line 우선 채택 (`applyTransferLineCorrection`)
- [⚠️] 사용자 6/23 13:56 evidence: stuck 0건 차단 — 코드 검증 완료, **실기기 검증 필요**
- [⚠️] 6/23 14:20 toggle은 별 이슈로 분리 (station hopping은 본 PR 범위 X)
- [x] frontend tests: stale GPS sticky reset + 환승역 line 보정 fixture

## Wire-completion 5단

1. **Orphan**: `npm run lint:orphan` PASS.
2. **V/X dashboard**: X1 (잘못된 현재역 표시) / V1 (정확한 현재역 표시) 영향. `logFusionPickerTier` 분포 추적.
3. **의존 PR**: 없음 (독립).
4. **측정 plan**: 머지 후 1주 fusion-picker-tier 분포 + GPS lastFix age 분포. stale 게이트 진입 빈도 측정.
5. **Device verify**: **필수**. 사용자 6/23 13:56 evidence 시나리오 — trip 종료 후 GPS dead zone에서 새로고침 시 stuck 0건 확인.

## 코드 리뷰 결과 반영
- P1-1 (사용자 evidence stuck 미해소): HomeScreen `lastFusedStationRef` 우회 + locationUncertain hoist로 해소.
- P1-2 (광흥창 toggle fix 범위 오인): 별 follow-up 이슈로 분리 (PR 본문 명시).
- P1-3 (test untracked): `git add` 완료.

## 검증
- `npm test`: 370 suites / 7656 tests PASS / 100% coverage
- `npm run type-check`: PASS
- `npm run lint:orphan`: 0 orphan