### PR TITLE
chore(#1732): DebugModal 일괄 Clear All

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -1628,7 +1628,14 @@ function DebugModalInner({
   }, [refreshLogs]);
 
   const handleClear = useCallback(async () => {
-    await clearAlarmLog();
+    await Promise.all([
+      clearAlarmLog(),
+      clearEstimatorEntries(),
+      clearFusionDebugEntries(),
+      clearGpsDropEntries(),
+      clearBackendCallEntries(),
+      clearRawSignalEntries(),
+    ]);
     await refreshLogs();
   }, [refreshLogs]);
 
@@ -2194,7 +2201,7 @@ function DebugModalInner({
               onPress={handleClear}
               testID="debug-clear-log"
             >
-              <Text style={[styles.actionText, { color: colors.accent }]}>Clear log</Text>
+              <Text style={[styles.actionText, { color: colors.accent }]}>Clear all logs</Text>
             </TouchableOpacity>
             <TouchableOpacity
               style={[styles.actionButton, { backgroundColor: colors.accent }]}

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -517,14 +517,38 @@ describe('DebugModal', () => {
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalledTimes(2));
   });
 
-  it('Clear log 버튼이 로그를 비우고 재조회한다', async () => {
+  it('Clear all logs 버튼이 6개 buffer를 모두 비우고 재조회한다', async () => {
+    const estimatorMod = jest.requireActual('../../../route/utils/estimatorDebugBuffer') as typeof import('../../../route/utils/estimatorDebugBuffer');
+    const fusionMod = jest.requireActual('../../../nearest-station/utils/fusionDebugBuffer') as typeof import('../../../nearest-station/utils/fusionDebugBuffer');
+    const gpsDropMod = jest.requireActual('../../../nearest-station/utils/gpsDropBuffer') as typeof import('../../../nearest-station/utils/gpsDropBuffer');
+    const backendMod = jest.requireActual('../../../../shared/utils/backendCallBuffer') as typeof import('../../../../shared/utils/backendCallBuffer');
+    const rawMod = jest.requireActual('../../../observability/utils/rawSignalBuffer') as typeof import('../../../observability/utils/rawSignalBuffer');
+
+    const spyEstimator = jest.spyOn(estimatorMod, 'clearEstimatorEntries');
+    const spyFusion = jest.spyOn(fusionMod, 'clearFusionDebugEntries');
+    const spyGpsDrop = jest.spyOn(gpsDropMod, 'clearGpsDropEntries');
+    const spyBackend = jest.spyOn(backendMod, 'clearBackendCallEntries');
+    const spyRaw = jest.spyOn(rawMod, 'clearRawSignalEntries');
+
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalledTimes(1));
     await act(async () => {
       fireEvent.press(screen.getByTestId('debug-clear-log'));
     });
-    expect(mockClearAlarmLog).toHaveBeenCalled();
+
+    expect(mockClearAlarmLog).toHaveBeenCalledTimes(1);
+    expect(spyEstimator).toHaveBeenCalledTimes(1);
+    expect(spyFusion).toHaveBeenCalledTimes(1);
+    expect(spyGpsDrop).toHaveBeenCalledTimes(1);
+    expect(spyBackend).toHaveBeenCalledTimes(1);
+    expect(spyRaw).toHaveBeenCalledTimes(1);
     expect(mockGetAlarmLog).toHaveBeenCalledTimes(2);
+
+    spyEstimator.mockRestore();
+    spyFusion.mockRestore();
+    spyGpsDrop.mockRestore();
+    spyBackend.mockRestore();
+    spyRaw.mockRestore();
   });
 
   it('Close 버튼이 onClose를 호출한다', () => {


### PR DESCRIPTION
## 변경 요약

- `handleClear`가 `clearAlarmLog`만 호출하던 것을 6개 buffer 동시 clear로 확장
- Promise.all로 병렬 실행: `clearAlarmLog`, `clearEstimatorEntries`, `clearFusionDebugEntries`, `clearGpsDropEntries`, `clearBackendCallEntries`, `clearRawSignalEntries`
- Clear 버튼 라벨: "Clear log" → "Clear all logs"

Closes #1732

---

## Wire-completion 5단 체크

1. **Orphan 없음** — `npm run lint:orphan` pass. 신규 export 없음, 기존 import만 사용.
2. **V/X dashboard** — DebugModal 내 모든 ring buffer (Estimator / Fusion / GPS drop / Backend calls / Raw signal / Alarm log) 가 Clear all logs 1번으로 일괄 초기화됨. DebugModal 자체가 관측 지점.
3. **의존 PR** — N/A
4. **측정 plan** — N/A — UX 개선(버튼 동작 통일). 회귀 신호 없음.
5. **Device verify** — N/A — type+unit only. 버튼 라벨 변경 + handleClear 로직 확장으로 런타임 device-only 회귀 없음.