### PR TITLE
chore(#1731): backend POST /trips 400 logger 강화 + Sentry breadcrumb

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import * as sentryModule from '../sentry';
 import {
   app,
   applyBoardingLockTrainCodeSwap,
@@ -451,6 +452,56 @@ describe('POST /trips — boardingLock merge (#585)', () => {
     await post('/trips', lockBody({ trainCode: '2317' }), env);
     const stored = JSON.parse((await env.TRIPS.get('trip:tok-585')) as string);
     expect(stored.lastTrackedArrivalEpoch).toBeUndefined();
+  });
+});
+
+// #1731 — validateTrip reject logger: console.warn + Sentry breadcrumb
+describe('validateTrip — reject logger (#1731)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let breadcrumbSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    breadcrumbSpy = vi.spyOn(sentryModule, 'addValidateRejectBreadcrumb').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ['non-object input → non-object', null, 'non-object'],
+    ['missing token → missing-token', { ...base(), token: undefined }, 'missing-token'],
+    ['missing destination → missing-destination', { ...base(), destination: undefined }, 'missing-destination'],
+    ['missing route → missing-route', { ...base(), route: undefined }, 'missing-route'],
+    ['empty waypoints → empty-waypoints', { ...base(), waypoints: [] }, 'empty-waypoints'],
+    ['expired expiresAt → invalid-expiresAt', { ...base(), expiresAt: Date.now() - 1 }, 'invalid-expiresAt'],
+    ['missing alarmAtEpochMs → missing-alarmAtEpochMs', (() => { const b = base(); delete b.alarmAtEpochMs; return b; })(), 'missing-alarmAtEpochMs'],
+    ['0-stop direct route → zero-stop-direct-route', { ...base(), route: { type: 'direct', line: '2', stops: 0 } }, 'zero-stop-direct-route'],
+    ['waypoint null → invalid-waypoint-non-object', { ...base(), waypoints: [null] }, 'invalid-waypoint-non-object'],
+    ['waypoint stationName number → invalid-waypoint-stationName', { ...base(), waypoints: [{ stationName: 1, line: '2', kind: 'destination' }] }, 'invalid-waypoint-stationName'],
+    ['waypoint line missing → invalid-waypoint-line', { ...base(), waypoints: [{ stationName: '강남', kind: 'destination' }] }, 'invalid-waypoint-line'],
+    ['waypoint kind unknown → invalid-waypoint-kind', { ...base(), waypoints: [{ stationName: '강남', line: '2', kind: 'unknown' }] }, 'invalid-waypoint-kind'],
+  ] as const)('%s', (_label, input, expectedReason) => {
+    validateTrip(input as unknown);
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const warnArg = warnSpy.mock.calls[0][0] as string;
+    expect(warnArg).toContain(expectedReason);
+    expect(breadcrumbSpy).toHaveBeenCalledOnce();
+    expect(breadcrumbSpy).toHaveBeenCalledWith(expectedReason, expect.any(Object));
+  });
+
+  it('valid input → no console.warn, no breadcrumb', () => {
+    validateTrip(base());
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(breadcrumbSpy).not.toHaveBeenCalled();
+  });
+
+  it('token 앞 8자만 tokenPrefix로 mask', () => {
+    validateTrip({ ...base(), destination: undefined });
+    const data = breadcrumbSpy.mock.calls[0][1] as Record<string, unknown>;
+    expect(data.tokenPrefix).toBe('tok');           // 'tok' is 3 chars, slice(0,8) = 'tok'
+    expect(data.tokenPrefix).not.toBe(base().token + 'extra');
   });
 });
 

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -51,7 +51,7 @@ import { writeMetric } from './analytics';
 import { deleteProgress, getProgress, putProgress, type TripProgress } from './progress';
 import { SeoulArrivalClient } from './seoul';
 import { runScheduled } from './scheduled';
-import { sentryInit } from './sentry';
+import { addValidateRejectBreadcrumb, sentryInit } from './sentry';
 import {
   recordRecallUpload,
   validateRecallUpload,
@@ -1878,30 +1878,40 @@ export function applyProgress(
 }
 
 export function validateTrip(input: unknown): Trip | null {
-  if (!input || typeof input !== 'object') return null;
+  // #1731 — reject helper: console.warn + Sentry breadcrumb (DSN 미설정 시 no-op).
+  // sanitizedPayload: token은 앞 8자만 노출 (PII mask).
+  function reject(reason: string, tokenRaw?: string): null {
+    const tokenPrefix = typeof tokenRaw === 'string' ? tokenRaw.slice(0, 8) : undefined;
+    console.warn(`validateTrip reject: ${reason}`, JSON.stringify({ reason, tokenPrefix }));
+    addValidateRejectBreadcrumb(reason, { tokenPrefix });
+    return null;
+  }
+
+  if (!input || typeof input !== 'object') return reject('non-object');
   const obj = input as Record<string, unknown>;
 
-  if (typeof obj.token !== 'string' || obj.token.length === 0) return null;
-  if (typeof obj.destination !== 'string') return null;
-  if (!obj.route || typeof obj.route !== 'object') return null;
-  if (!Array.isArray(obj.waypoints) || obj.waypoints.length === 0) return null;
-  if (typeof obj.expiresAt !== 'number' || obj.expiresAt <= Date.now()) return null;
-  if (typeof obj.alarmAtEpochMs !== 'number') return null;
+  const tokenRaw = typeof obj.token === 'string' ? obj.token : undefined;
+  if (!tokenRaw || tokenRaw.length === 0) return reject('missing-token');
+  if (typeof obj.destination !== 'string') return reject('missing-destination', tokenRaw);
+  if (!obj.route || typeof obj.route !== 'object') return reject('missing-route', tokenRaw);
+  if (!Array.isArray(obj.waypoints) || obj.waypoints.length === 0) return reject('empty-waypoints', tokenRaw);
+  if (typeof obj.expiresAt !== 'number' || obj.expiresAt <= Date.now()) return reject('invalid-expiresAt', tokenRaw);
+  if (typeof obj.alarmAtEpochMs !== 'number') return reject('missing-alarmAtEpochMs', tokenRaw);
 
   // #1324 — degenerate trip 방어: 출발역 == 목적지면 client(stationRoute.findRoutes)가
   // `{ type: 'direct', stops: 0 }` 경로를 만든다 — 진행할 hop이 없어 방향 null/빈 탑승목록/
   // skip-cycle로 이어진다(사가정 trip 사고). frontend 경계가 1차 차단하지만, 0-stop direct
   // 경로는 backend도 거부해 어떤 client에서도 이런 trip이 등록되지 않게 한다.
   const route = obj.route as Record<string, unknown>;
-  if (route.type === 'direct' && route.stops === 0) return null;
+  if (route.type === 'direct' && route.stops === 0) return reject('zero-stop-direct-route', tokenRaw);
 
   // waypoints 검증
   for (const w of obj.waypoints) {
-    if (!w || typeof w !== 'object') return null;
+    if (!w || typeof w !== 'object') return reject('invalid-waypoint-non-object', tokenRaw);
     const wp = w as Record<string, unknown>;
-    if (typeof wp.stationName !== 'string') return null;
-    if (typeof wp.line !== 'string') return null;
-    if (wp.kind !== 'transfer' && wp.kind !== 'destination' && wp.kind !== 'intermediate') return null;
+    if (typeof wp.stationName !== 'string') return reject('invalid-waypoint-stationName', tokenRaw);
+    if (typeof wp.line !== 'string') return reject('invalid-waypoint-line', tokenRaw);
+    if (wp.kind !== 'transfer' && wp.kind !== 'destination' && wp.kind !== 'intermediate') return reject('invalid-waypoint-kind', tokenRaw);
   }
 
   // #1193 — incoming waypoints 전체에 대해 occurrenceIdx를 1-pass로 stamp.
@@ -1929,13 +1939,13 @@ export function validateTrip(input: unknown): Trip | null {
   });
 
   return {
-    token: obj.token,
+    token: tokenRaw,
     route: obj.route as Trip['route'],
-    destination: obj.destination,
+    destination: obj.destination as string,
     waypoints: stampedWaypoints,
-    expiresAt: obj.expiresAt,
+    expiresAt: obj.expiresAt as number,
     createdAt: typeof obj.createdAt === 'number' ? obj.createdAt : Date.now(),
-    alarmAtEpochMs: obj.alarmAtEpochMs,
+    alarmAtEpochMs: obj.alarmAtEpochMs as number,
     lastFiredPhase: obj.lastFiredPhase === 'early' || obj.lastFiredPhase === 'imminent'
       ? obj.lastFiredPhase
       : undefined,

--- a/backend/alarm-worker/src/sentry.ts
+++ b/backend/alarm-worker/src/sentry.ts
@@ -18,7 +18,7 @@
  *   현재 모듈은 DSN 부재 시 100% no-op이라 production runtime 영향 없음.
  */
 
-import { captureMessage } from '@sentry/cloudflare';
+import { addBreadcrumb, captureMessage } from '@sentry/cloudflare';
 import {
   hashTripToken,
   sanitizeContext,
@@ -85,6 +85,24 @@ export function isSentryInitialized(): boolean {
 /** 진단/테스트용 — 현재 DSN(노출 가능 시). */
 export function getConfiguredDsn(): string | null {
   return configuredDsn;
+}
+
+/**
+ * #1731 — validateTrip reject breadcrumb.
+ *
+ * DSN 미설정 시 no-op (graceful). Sentry SDK 실패 시 swallow.
+ * reason: reject 사유 식별자, data: sanitized payload 조각.
+ */
+export function addValidateRejectBreadcrumb(
+  reason: string,
+  data: Record<string, string | number | boolean | null | undefined>,
+): void {
+  if (!initialized) return;
+  try {
+    addBreadcrumb({ category: 'trips-validate', level: 'warning', data: { reason, ...data } });
+  } catch (e) {
+    console.warn(JSON.stringify({ msg: 'sentry addBreadcrumb failed', err: String(e) }));
+  }
 }
 
 /** 테스트 격리용 — 모듈 스코프 init 상태 reset. */


### PR DESCRIPTION
Closes #1731

## 변경 요약

`validateTrip` (backend `index.ts`) 의 모든 reject path에 **console.warn + Sentry breadcrumb** 적재를 추가해, 다음 trip 1건 후 400 reject의 정확한 사유를 즉시 추적 가능하게 합니다.

### 변경 파일

| 파일 | 변경 |
|---|---|
| `backend/alarm-worker/src/index.ts` | `validateTrip` 내부 `reject()` 헬퍼 추가 — 9개 reject case 전부 reason 명시 + `console.warn` + `addValidateRejectBreadcrumb` 호출 |
| `backend/alarm-worker/src/sentry.ts` | `addValidateRejectBreadcrumb` export 추가 (`@sentry/cloudflare` `addBreadcrumb` 래퍼, DSN 미설정 시 no-op) |
| `backend/alarm-worker/src/__tests__/index.test.ts` | reject path 12종 × console.warn + breadcrumb 호출 검증 + valid input은 no-call 검증 |

### Reject reason 식별자

```
non-object | missing-token | missing-destination | missing-route
empty-waypoints | invalid-expiresAt | missing-alarmAtEpochMs
zero-stop-direct-route | invalid-waypoint-non-object
invalid-waypoint-stationName | invalid-waypoint-line | invalid-waypoint-kind
```

### PII mask

token 은 `token.slice(0, 8)` 로 mask 후 `tokenPrefix` 키로 적재 (원본 token 비노출).

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (`addValidateRejectBreadcrumb` 는 `index.ts` 에서 호출)
2. **V/X dashboard** — Cloudflare worker tail 단기 + Sentry breadcrumbs 탭 1주 누적 분포
3. **의존 PR** — N/A
4. **측정 plan** — 다음 trip POST 후 `wrangler tail` 에서 `validateTrip reject: <reason>` 로그 확인 → 정확한 root cause 식별 → 후속 fix 방향 결정
5. **Device verify** — N/A — backend only (type + unit only)