### PR TITLE
chore(#1736): untracked docs 5건 commit

### DIFF
--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — the project's domain glossary.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-*.md
+│   └── 0002-*.md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,13 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.

--- a/docs/decisions/ADR-015-multi-signal-consensus-gate.md
+++ b/docs/decisions/ADR-015-multi-signal-consensus-gate.md
@@ -1,0 +1,220 @@
+# ADR-015 — 다중 신호 합의 게이트 + Deterministic Environment SSOT
+
+## 상태
+
+Draft (2026-06-18) — 검토 대기
+
+## 배경 — 2026-06-17 17 PR 머지 후 trip 회귀 3건 잔존
+
+2026-06-17~18 새벽 17 PR 머지(#1397~#1430)에도 2026-06-18 오후 실기기 trip(token `35b3502c`, 13:23~13:44) 한 번에 회귀 3건 동시 관찰.
+
+### Trip 사실 (디바이스 dump)
+
+route: 성수(2 3F) → 뚝섬(2 3F) → 한양대(2 2F) → 왕십리(2 B2) → [환승] → 왕십리(5 B5) → 마장(5 B3)
+
+- `subsurface=false` 정상 (지상→지하 환승 trip)
+- 13:24:09~13:28:05 leg 1 fire 정상 (성수/뚝섬/한양대 station-passed + 환승 imminent 왕십리)
+- 13:28:05 이후 leg 2 fire **0건 (16분 침묵)**
+- silent push `received=0 fired=0`
+- BoardingLock leg 1(`line=2 trainCode=3212`) 21분 잔존 — 환승 후 release 안 됨
+- fusion이 trip route에 없는 **분당선 `왕십리(bundang-053)` variant 반복 채택**
+- Environment Distribution counter `underground=91.8%` (subsurface=false와 모순)
+
+### 회귀 3건 cross-layer root cause
+
+| 회귀 | layer 분포 |
+|---|---|
+| 조기 발사 + 늦은 도착 알림 | 프론트 `useFusedNearestStation.ts:861-887` interp Tier 5 override (`reanchored-hop`/`default-hop` 통과 + ceiling +1 허용 → forward ratchet) |
+| leg 2 침묵 16분 | 프론트 fusion route-line filter 부재 + 백엔드→device lock release sync 채널 부재 + 환승 도보 윈도우 미배선 (**3 layer 동시 손상**) |
+| 환경 분류 회귀 (`subsurface=false`인데 `underground 91.8%`) | 프론트 `surfaceSSotConsensus.ts:29` `acc≤30m` 임계 미충족 시 default underground 분류 + 환경 SSOT 데이터 부재 |
+
+## 결정
+
+### §1 환경 SSOT = stations.json `environment` 필드 (Deterministic)
+
+stations.json 528역에 `environment: "surface" | "underground" | "mixed"` 필드 도입. 분기 판정은 데이터 기반 deterministic — barometer warm-up 결과 기다리지 않는다. 센서 합의(barometer/WiFi)는 cross-check 용도, 분기 SSOT 아님.
+
+- 서울교통공사 1~8호선(275역): 서울교통공사_역사건축정보 CSV `층수` 컬럼 자동 분류 (B prefix=underground, F prefix=surface, FB 복합=mixed)
+- 외부 노선(253역): 위키 + 나무위키 자동 스크랩 + cross-check + 사용자 검수
+- 같은 좌표 다중 line 환승역은 line별 separate entry 유지 (왕십리 2/5/gyeongui/bundang 등)
+
+### §2 Fire 권한 영구 박탈 — 시간 적분 strategy 3종
+
+다음 source는 알림 fire 권한 영구 박탈. UI 표시(현재 위치 추적)는 유지, 알림 발사 X.
+
+- `boarding-lock-interp` (시간 적분 lock interp)
+- `sticky:locked` (jitter 흡수 표시) — fire path와 표시 채널 분리
+- `lockless-route-hop` (lockless 시간 적분 route hop)
+
+코드 위치: `useFusedNearestStation.ts:861-887` Tier 5 override result/confidence 대입 제거, `useStickyStation.ts:307` 결과는 별 채널 `useStickyDisplayOnly`로 격리.
+
+근거: 추정 신호 3종은 지하 dead-zone fallback 의도로 만들어졌으나 fire 권한까지 가져 dedup 누적 → 실측 신호 도착 시 dedup 차단으로 알림 빠짐. dump L335 13:26:14 `interp 뚝섬 d=827m, gp=성수, rt=성수`이 직접 evidence (사용자 성수 정차 중인데 lock 시점 시간 적분으로 뚝섬 오인 fire). memory `lesson_lockless_route_hop_time_integration_ssot_assumption.md` 동일 처방.
+
+### §3 분기별 fire 게이트 — N-of-M 합의
+
+fire는 다중 신호 합의 게이트 통과 시에만 허용. 점수 기반 1개 채택 X.
+
+**신호 분류**
+
+| 신호 | 등급 |
+|---|---|
+| GPS fix (acc≤30m + 거리≤100m) | strong A |
+| arrival arvlCd 1~3 | strong B |
+| position-train (호선 일치) | strong C |
+| WiFi SSID 매칭 | strong D |
+| boardingLock + pos-train 일치 | strong E |
+| 기압계 stable verdict | medium F |
+| motion activity (walking/automotive) | medium G |
+| SSOT stability buffer N=3 stable | medium L |
+| route arc progress | weak |
+
+**분기별 게이트**
+
+- `environment=surface`: A + B 2-of-2 OR (A 또는 C 또는 D) + B + medium 1개
+- `environment=underground`: C + B 또는 D + B 2-of-2. **GPS는 입력 set에서 reject** (acc 좋아도 무시)
+- `environment=mixed`: 보수적. strong 2개 충족 시에만
+
+### §4 합의 안 됨 = fire X
+
+합의 게이트 미통과 시 fire 권한 박탈. UI는 마지막 합의 위치 + 추적 신호 표시, 알림 발사 X.
+
+silent 케이스 한정성 — 정상 FG/BG + 권한 정상 + 비행기 모드 아님 환경에서는 다중 신호 살아있어 합의 통과 가능. silent는 다음에 한정:
+
+- 비행기 모드 (사용자 의도된 silent)
+- 권한 회수 (사용자 의도된 silent)
+- 전 신호 동시 침묵 (지하 dead-zone + arrival fetch fail + WiFi 미인식 + 기압계 미준비) — 사용자도 인지하는 상태
+
+ADR-010 §"두 실패 모드 동급" 위반 아님 — 합의 가능한 신호 환경에서는 fire 정상 발사.
+
+### §5 Route-line filter (강제)
+
+fusion 후보 산출 시 trip route의 `allowedLines` 외 station/line은 후보 단계에서 reject.
+
+```
+trip 활성 (routeContext 있음):
+  allowedLines = ∪{
+    direct.line ∨
+    transfer.fromLine ∨ transfer.toLine ∨
+    multi-transfer.transfers[].fromLine ∨ multi-transfer.transfers[].toLine
+  }
+trip 비활성 (자유 화면):
+  filter 미적용 (기존 동작 보존)
+```
+
+코드 위치: `findTopNearestStations(..., allowedLines?: Set<LineNumber>)` 시그니처 확장 + `useFusedNearestStation.ts:350-355` 호출에서 `routeContext.route`로부터 `allowedLines` 도출.
+
+근거: `stations.json` L4602 `gyeongui-034 name="왕십리(성동구청)"` vs L5372 `bundang-053 name="왕십리"` — 같은 좌표 다른 이름으로 `findNearestStation.ts:50-71` name dedup 우회. 분당선 variant가 fusion 후보 단계 통과 → `useFusedNearestStation.ts:598-614` cascade에서 result로 채택 → dump L239 `src=position-train | 왕십리(bundang)`. 청량리(서울시립대입구)/(bundang) 등 같은 dedup-bypass 패턴 자동 차단.
+
+### §6 환승 lock 재요청 윈도우 = `transferTimes.json`
+
+환승 도보 시간을 호선쌍별 데이터셋으로 분리. 단순 상수 X.
+
+```json
+{ "from": "2", "to": "5", "station": "왕십리(성동구청)", "seconds": 240 }
+```
+
+출처: 서울 열린데이터 광장 "지하철역 환승소요시간" 또는 코레일 환승역 정보 등 공공데이터 API. 외부 노선은 운영사 안내도 또는 수동 입력.
+
+게이트: `현재 시각 + transferTimes[from→to] ≤ 다음 열차 도착 시각` 인 traincode부터 boardingPrompt 후보로 진입.
+
+기존 `src/shared/constants/boardingLock.ts:17 TRANSFER_WALKING_BUFFER_SECONDS=180` 단순 상수("정밀화는 후속" 주석) 정밀화. 전체 trip 정적 ETA 산출(`stationRoute.ts:934`)에도 호선쌍별 시간 합산.
+
+### §7 토글 input X — backend fire 결정은 trip 등록만 본다
+
+- C 토글 / lockless toggle / boardingPrompt 응답 / BoardingTrainList 직접 탭 등 사용자 명시 의향은 fire 결정 input X
+- backend는 trip 등록 + route + 합의 게이트 신호로만 fire 결정
+- 토글 UI는 정보 라벨(예: "현재 lockless 추적 중")로만 유지
+
+ADR-014 §4 "사용자 명시 의향 trip 동급 보장"과 호환 — backend가 토글 무관 정확하게 동작하면 토글 ON trip도 동등 정확성 자동 보장.
+
+### §8 Lock release sync 채널
+
+backend 환승 release(`scheduled.ts:1467-1472 lockReleasedOnTransfer=true`)를 device로 silent push payload에 실어 전파.
+
+```
+silent push payload 추가:
+{
+  ...,
+  lockReleasedReason?: 'transfer' | 'expired' | 'vanish' | 'arrived'
+}
+```
+
+device 동작:
+- `silentPushTask.ts`가 `lockReleasedReason` 인식 시 `useBoardingLockStore.releaseLock()` 호출
+- `transfer`면 즉시 §6 환승 lock 재요청 게이트로 진입
+
+근거: 현재 backend는 release log만 찍고 device 미통보. dump의 leg 1 lock 21분 잔존이 직접 evidence. memory `project_2026_06_15_lockless_hydration_seam.md` 동일 seam 패턴.
+
+### §9 trainCode lock 정확성 게이트
+
+lock 채택 시 `lock.line`이 trip route `allowedLines` (§5)에 포함되지 않으면 reject.
+
+코드 위치: `useBoardingLockController.ts:176-201 createLockFromTrain` 및 `:221-291 hydrateLockFromCandidate` 진입점, backend `autoLock.ts:158-223` autoLock 9-AND gate 진입점.
+
+근거: #662 환승역 옆 노선 traincode 잘못 매핑 회귀. 분당선 variant 채택과 같은 cross-line 매핑 패턴.
+
+### §10 단계적 마이그레이션 — sub-issue 매핑
+
+- **E0**: 본 ADR 본문 + 메모리 박제
+- **E1** (병렬, 데이터): §1 stations.json `environment` 필드
+- **E2** (병렬, 데이터): §6 `transferTimes.json` 데이터셋
+- **E3** (즉시, ~30줄): §5 Route-line filter — `findTopNearestStations` allowedLines 확장
+- **E4** (1주 내, ~50줄): §2 Fire 권한 박탈 — interp/sticky/route-hop override 제거
+- **E5** (1주 내, ~80줄): §8 Lock release sync — silent push payload `lockReleasedReason`
+- **E6** (E1/E2/E5 완료 후, ~200줄): §3/§4/§7/§9 backend fire 재설계 — 합의 게이트 + 토글 input 제거 + trainCode lock filter
+- **E7** (병렬, ~5줄): `useNearestStation.ts:50 distanceInterval=0` — #1416 회귀, FG GPS 회복 prereq
+
+P5 (가중치 학습) 후속: 1주 raw signal dump → confusion matrix → 가중치 자동 조정. ADR-015 본문 임계값 갱신은 별 PR.
+
+### §11 Process 룰 — 양방향 layer 추적
+
+매 sub-issue(E0~E7) 시작 전 다음 체크리스트 통과 후 코드 수정 시작:
+
+1. 건드리는 함수/handler/cron/payload 식별
+2. upstream — 데이터 source layer 추적
+   - 프론트: hook / component / store / native module (live-activity, motion-activity, audio-route)
+   - 백엔드: worker handler / KV / cron / durable object / lockSwap / boardingPrompt evaluator
+   - 인프라: silent push(APNs production/sandbox) / widget storage / Live Activity push update / expo-location task / barometer
+   - 데이터셋: stations.json / transferTimes.json / locales/* / wifiSsidLookup
+3. downstream — 데이터 effect layer 추적 (위와 동일 카테고리)
+4. sync 깨진 곳이 발견되면 같이 fix
+5. 양방향 회귀 없는지 검증 — layer별 단위 테스트 + E2E 또는 실기기 통합
+
+1줄 patch도 동일 적용. memory `feedback_full_layer_cross_trace.md` 참조.
+
+근거: 2026-06-17 17 PR 회귀가 모두 cross-layer 단일 fix 패턴. backend release vs device 잔존, frontend fusion vs route, scheduled queue dump vs trigger 등.
+
+## Acceptance
+
+본 ADR close 조건 — 1주 실기기 trip 누적 측정 (또는 production 측정):
+
+- **조기 발사 0건** — 실제 위치보다 앞선 station-passed/transfer/destination fire
+- **늦은 도착 알림 0건** — 실제 도착 시점에 dedup 차단된 fire (= 도착 후 알림 X 또는 한참 후 알림)
+- **leg 2 침묵 0건** — 환승 후 다음 leg 16분 이상 침묵
+- **route 외 line variant fire 0건** — 분당선/경의중앙선 등 trip route 외 line으로 잘못 매핑된 fire
+- **모든 trip 동등 정확성** — lockless toggle ON/OFF, boardingPrompt 응답/무응답, lock 활성/비활성 trip 모두 같은 정확성 기준 충족
+
+sub-issue E0~E7 각각 close 조건: 본 ADR § acceptance 부분집합 + §11 cross-layer 체크리스트 통과.
+
+## Followup
+
+본 ADR 검토 시점에 결정 보류된 후보 조항:
+
+- 사용자 정지/하차 시 lock 자동 release 게이트 (boardingLock BG 카탈로그 case #9, "잃어버리는 케이스" 미커버 항목)
+- 모든 신호 침묵 시 backend route + lock + 마지막 fix 시각 기반 ETA prompt fallback (사용자 정정 — "안 되는 것 #15")
+- traincode TTL 동적 갱신 (별 트랙 B2와 통합 검토)
+- WiFi SSID 데이터셋 (별 트랙 B3와 통합 검토)
+- BG WiFi SSID 권한 정책 (Location Always 권한 vs device→backend SSID push)
+
+위 후보는 본 ADR sub-issue 완료 후 1주 측정 결과로 채택 여부 결정.
+
+## 관련 문서
+
+- ADR-010 sensor-fusion-policy (두 실패 모드 동급)
+- ADR-013 lockless-supplementation-policy
+- ADR-014 decision-process-rules (false binary 금지, 옵션 3개 보장, 사용자 의향 trip 동급 보장)
+- memory `feedback_full_layer_cross_trace.md` — §11 양방향 layer 추적 룰 출처
+- memory `lesson_lockless_route_hop_time_integration_ssot_assumption.md` — §2 시간 적분 fire 박탈 근거
+- memory `lesson_motion_activity_intermittent_signal.md` — motion gate 단독 의존 금지
+- memory `lesson_train_progressing_source_strategy_blindness.md` — downstream fix가 아니라 upstream
+- memory `project_2026_06_15_lockless_hydration_seam.md` — §8 lock release sync seam 패턴

--- a/docs/decisions/ADR-016-quadrant-ssot-lockless-first-station.md
+++ b/docs/decisions/ADR-016-quadrant-ssot-lockless-first-station.md
@@ -1,0 +1,202 @@
+# ADR-016 — 4분면 SSOT 통합 + Lockless 첫 station miss 0 + autoLock/boardingPrompt 재설계
+
+## 상태
+
+Active (재활성화 2026-06-20). Epic #1533. T1~S2 머지 (`S2 #1535는 ADR-017 T8 #1561 흡수 close`). **S1 #1534 / S3 #1536 / #1526 / S11 #1544 재활성화** — 2026-06-20 trip evidence (boardingPrompt 7일 0건 + autoLock direction-mismatch) 직접 회귀 cover.
+
+## 배경
+
+### 2026-06-19 PM Phase 1 (S0/M1) 완료
+
+Phase 1 6 PR 머지(#1547~#1552). 4분면 SSOT 통합 + lockless 첫 station miss 0 acceptance 일부 달성.
+
+### 2026-06-20 trip dump evidence — Phase 2 회귀
+
+`/Users/kimdohan/Downloads/텍스트-55EFF2BEC7B2-1.txt` (1.5h lockless trip):
+
+```
+## Auto-lock Candidate
+ssot=surface+underground
+stability=stable count=5 stationId=2-012   ← stability 추출 OK
+direction=mismatch reason=no-route          ← 9-AND gate fail
+candidate=null reason=direction-mismatch
+
+## Boarding Prompt Acceptance
+displayed=0, responded=0, boarded=0 × 7일 누적
+```
+
+= **stability 추출 작동** + **direction-match 게이트가 route 없다고 거부** → autoLock 0 + boardingPrompt 7일 누적 0건.
+
+### 머지된 prompt fix 14건에도 dump 7일 0건
+
+- #1387 (06-16) boardingPrompt displayed wire-up
+- #1420 (06-17) BG drain
+- #1303 (06-14) context 안정화
+- #1456 (06-18) backend fire 재설계 (ADR-015)
+- #1320 (06-15) lockless trainCode 바인딩
+- #1138 (06-11) boardingPrompt 발사 빈도 monitor
+- #1188 (06-11) [탑승] 응답 autoLock fallback
+- #1128 (06-10) attemptAutoLock confidence gate
+- #1427 (06-17) device-side auto-lock 측정 인프라
+- ...총 14건
+
+= 인프라 정의 ↔ consumer 연결의 단절(Wire-completion 미강제) = 한 달 회귀 패턴 root cause.
+
+### 사용자 핵심 인사이트
+
+> "lockless라는게 말이 안되는게 lock을 안해도 우리는 train코드를 보고서 알림 탑승했는지에 대한 탑승 여부 알림푸시를 발사하고 LA도 해놨는데... 처음 시작은 lockless였을 지 몰라도 backend에서 traincode를나 position을 보고 이동중이구나 하고서 알림 푸시를 어떻게든 발사한 이후에 거기서 lock을 걸게 되는거잖아"
+
+→ lockless = transitional state로 강등 + backend advance 결정 = lock 자동 forward.
+
+## 결정
+
+### 원칙 1 — 4분면 SSOT 통합 (Phase 1 머지 완료)
+
+surface / underground / transition / unknown 4분면 환경 SSOT. 각 분면 진입/이탈 조건 결정. ADR-015 §3/§4 통합.
+
+### 원칙 2 — Lockless 재정의 (사용자 룰)
+
+**기존**: lockless = "출발역 모르는 trip의 영구 상태"
+**신규**: lockless = **trip 등록 ~ 첫 advance 1~3 cycle transitional state**
+
+| 상태 | 조건 | 동작 |
+|------|------|------|
+| transitional | `tripStartedAt < 5min` AND `!lockSuggestion` | 정상. cascade GPS-only fallback OK ([[feedback_lockless_redefinition]]) |
+| **persistent lockless = X11 회귀** | `tripStartedAt > 5min` AND `!lockSuggestion` | auto-end 검토 또는 silence 강제 |
+| post-advance | `lockSuggestion` 도달 | lock 자동 전환 (S1 #1534) |
+
+### 원칙 3 — Backend lockSuggestion forward (T9b, S1 #1534 흡수)
+
+backend `advanceTripPosition` 성공 시 SSoT에 `lockSuggestion` 추가:
+
+```ts
+interface TripPositionSSoT {
+  // 기존
+  currentStationId, motionState, passedStations, alarmEvents, ...
+  // T9b 신규
+  lockSuggestion?: {
+    stationId: StationId;
+    trainCode: string;             // arvlcd btrainNo
+    lineId: string;
+    confidence: 'high' | 'medium' | 'low';   // advance evidence type 기반
+    decidedAt: number;
+  };
+}
+```
+
+device boardingLock 결정 권한:
+- **1순위**: backend `lockSuggestion` reader-only 채택 (advance와 동급 confidence)
+- **2순위**: 현재 9-AND gate (lockSuggestion 없을 때만 fallback)
+
+silent push payload SSoT mirror에 `lockSuggestion` 슬롯 추가 (`apns.ts:175-186` `SilentPushSsotPayload`). device validator (`silentPushTask.ts:424-447` `validSsotMirror`) 확장.
+
+### 원칙 4 — boardingPrompt + autoLock trigger 재설계 (T13, S3 #1536 흡수)
+
+**현재**: backend cron 9-AND gate 통과 시 발사
+**사용자 룰**: trip 등록 즉시 LA Interactive + boardingPrompt UI 활성화 (cron 9-AND gate 우회)
+
+trigger 재설계:
+- POST /trips 성공 시 device가 즉시 LA Interactive + boardingPrompt UI mount
+- backend cron 9-AND gate는 fallback (lockSuggestion 못 보내는 케이스)
+- 9-AND gate direction-match → backend SSoT.direction reader-only (route 안 거치고)
+- UI는 'A → B 방면' 형태 (trainCode 노출 X, [[feedback_la_interactive_unified_with_boarding_prompt]])
+
+### 원칙 5 — 5-layer wire 검증 (#1526 acceptance evidence)
+
+| Layer | 위치 | 검증 |
+|-------|------|------|
+| L1 backend cron 호출 | `boardingPrompt.ts:95` | wrangler log evidence (매분 호출 grep) |
+| L2 9-AND gate 통과 | direction-match + GPS-series 5개 | 통합 테스트 + lockSuggestion fallback 채택 |
+| L3 silent push 발사 | backend → APNS | alarmLog `boardingPrompt-push-fired` ≥ 1건 |
+| L4 device UI mount | HomeScreen boardingPrompt component | alarmLog `boardingPrompt-ui-mounted` ≥ 1건 |
+| L5 응답 → POST | `/boarding-lock/sync` | alarmLog `boardingPrompt-response-posted` ≥ 1건 |
+
+5단 evidence 모두 production trip에서 확인되어야 #1526 close.
+
+### 원칙 6 — Wire-completion gate (모든 sub-task close 조건)
+
+신규 코드는 5단 검증 통과해야 close. 인프라 정의는 있는데 consumer 누락 패턴 차단 ([[feedback_wire_completion_gate]]):
+
+1. 신규 상수/타입/필드: grep import + read ≥ 1
+2. 신규 hook/함수: 호출자 ≥ 1 + consumer 도달
+3. 신규 store mutation: subscribe selector ≥ 1
+4. 신규 게이트/패스: 통합 테스트 + production alarmLog evidence
+5. 기존 호출 deprecation: refactor 후 직접 호출 0건 grep
+
+evidence: 머지된 prompt fix 14건에도 dump 7일 0건 = Wire-completion 미강제 정확한 비용.
+
+## Sub-task 매핑
+
+| Sub | 내용 | 상태 |
+|-----|------|------|
+| S1 #1534 | Trip 등록 GAP A + instant autoLock + LA Interactive trigger 분리 + **T9b lockSuggestion forward 흡수** | **OPEN (재활성화)** |
+| S2 #1535 | silent push currentStationId + cascade | ADR-017 T8 #1561 흡수 close |
+| S3 #1536 | 9-AND gate 환경 분기 + **T13 trigger 재설계 흡수** | **OPEN (재활성화)** |
+| S4~S6 | realtimePosition 폴링 / pre-scheduled / passedStations | ADR-017 T1/T3에 통합 |
+| S7~S10 | device-side / docs | independent |
+| S11 #1544 | App Intents + Focus 자동화 + lockless UI 명시 | OPEN |
+| **#1526** | autoLock SSOT 출발역 stability 추출 — **acceptance evidence sub-task** | **OPEN (재활성화)** |
+
+## 머지 순서
+
+1. **S1 #1534** (T9b lockSuggestion forward) — ADR-017 T9 V8(e) prerequisite
+2. **S3 #1536** (T13 trigger 재설계) — S1과 cross-cut, T9 #1572와 병렬 가능
+3. **S11 #1544** (App Intents + Focus) — 독립
+4. **#1526** (5-layer wire 검증) — S1 + S3 머지 후 1주 production 측정
+
+## ADR-017과의 관계
+
+ADR-017이 backend SSoT 구조 + device fire gate를, ADR-016이 lockless 재정의 + autoLock/boardingPrompt 재설계를 담당. 두 ADR이 cross-cut:
+
+| ADR-016 sub | ADR-017 통합 |
+|---|---|
+| S1 #1534 T9b lockSuggestion | ADR-017 T9 #1572의 V8(e) prerequisite |
+| S3 #1536 T13 trigger 재설계 | ADR-017 NotificationRouter (T12 #1575) trigger 통합 |
+| #1526 acceptance evidence | ADR-017 V/X acceptance 5-layer wire 검증 |
+
+ADR-019 신설 X — 본 ADR-016 재활성화로 처리.
+
+## Acceptance — Wire-completion + 다운로드 가치 V/X 매핑
+
+### V/X 매핑 (cross-cutting)
+
+| V/X | 측정 임계 | ADR-016 sub-task | ADR-017 sub-task |
+|-----|----------|------------------|------------------|
+| V2 환승 1역 전 알람 | hop ≥ 2 시만, ±10s | S1 (T9b lock 전환 → hop 산출) | T7 ✅, T9 #1572 |
+| V3 도착 1역 전 알람 | hop ≥ 2 시만, ±10s | 동일 | 동일 |
+| V7 지하 station-passed 정확 | advance ≥ 90% | S3 (9-AND gate 환경 분기) | T11 #1574 |
+| X9 사용자 의도 외 fire | 0건 | S1 + S3 (정확한 lock + trigger) | T9 + T10 + T12 |
+| **X11 persistent lockless** | 5분+ lockless = 0건 | S1 (lockSuggestion forward) | T10 #1573 (6h backstop) |
+| **acceptance evidence (핵심)** | boardingPrompt displayed ≥ 1건/trip | **#1526** | — |
+
+### 측정 acceptance — 1주 production
+
+S1 #1534 + S3 #1536 머지 후:
+- boardingPrompt displayed ≥ 1건/trip (지하 trip 포함)
+- responded rate ≥ 30%
+- boarded rate ≥ 60% (응답 중)
+- 7일 누적 displayed = 0건이면 #1526 close 불가 + revert
+
+### Wire-completion 강제
+
+각 sub-task PR이 close 되려면 5단 검증 통과 (위 원칙 6). #1526가 acceptance evidence sub-task로 5-layer wire 검증 전담.
+
+## 사용자 vision 매핑
+
+| 원칙 | ADR-016 구현 |
+|---|---|
+| "lockless 처음 시작 후 backend가 traincode/position 보고 lock 전환" | S1 #1534 T9b lockSuggestion forward |
+| "lock 안 해도 train code로 알림 발사" | S3 #1536 T13 trigger 분리 (trip 등록 즉시) |
+| "trainCode 노출 X, A → B 방면 UI" | S3 #1536 LA Interactive UI 재설계 |
+| "Wire-completion 원천 차단" | 원칙 6 + #1526 5-layer 검증 |
+| "사용자 가치 → acceptance → 코드" | V/X 매핑 + 측정 acceptance |
+
+## 참고
+
+- Epic #1533
+- ADR-017 (backend SSoT + device fire gate) — cross-cut
+- 2026-06-20 trip evidence: `/Users/kimdohan/Downloads/텍스트-55EFF2BEC7B2-1.txt`
+- 선행 ADR: ADR-010 (sensor fusion), ADR-013 (lockless supplementation), ADR-015 (multi-signal consensus)
+- 후속 강제 doc: `docs/requirements/15-trip-alarm-notification.md` (cross-cutting acceptance + Wire-completion + V8 4 mitigation + lockless 재정의)
+- 관련 mem: [[feedback_lockless_redefinition]], [[feedback_wire_completion_gate]], [[feedback_la_interactive_unified_with_boarding_prompt]], [[lesson_boarding_prompt_9and_gate_gps_only]], [[project_lockless_first_station_miss_zero]]
+- ADR-019 신설 X — 본 ADR-016 재활성화로 처리


### PR DESCRIPTION
## Summary

- `docs/agents/{domain,issue-tracker,triage-labels}.md` — agent skill 가이드 3건 (4월 30일자)
- `docs/decisions/ADR-015-multi-signal-consensus-gate.md` — Draft 2026-06-18
- `docs/decisions/ADR-016-quadrant-ssot-lockless-first-station.md` — Active 2026-06-20 (Epic #1533)

CLAUDE.md L34 (Agent skills) + L102 (ADR-014/016 참조)에서 참조하는 docs 5개가 6일+ untracked. `.gitignore`의 `!docs/decisions/` / `!docs/agents/` unignore 규칙으로 tracked 대상.

## Test plan

- [x] `git status` clean
- [x] 5 파일 모두 staged + commit
- [N/A] type-check / npm test (docs only)
- [N/A] orphan lint (docs only)

## Wire-completion 5단

1. **Orphan** — N/A (docs only)
2. **V/X dashboard** — N/A
3. **의존 PR** — N/A
4. **측정 plan** — N/A — type+unit only
5. **Device verify** — N/A — type+unit only

Closes #1736