### PR TITLE
fix(#1740): Path D pickAutoTrainCodeFromArrivals destination 방향 filter 강화 (paradigm shift Phase 2)

### DIFF
--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -686,6 +686,11 @@ export interface SendBoardingPromptPushOptions {
    * device 는 telemetry 적재 시 source 분포 측정에 사용.
    */
   triggerKind?: 'cron' | 'instant';
+  /**
+   * #1740 — 목적지 방향. PromptGeoContext.direction 에서 도출.
+   * 미지정(legacy / direction null) 시 payload에 포함하지 않아 device가 양방향 허용.
+   */
+  destinationDirection?: 'up' | 'down';
   config: ApnsConfig;
   host: string;
   fetchImpl?: typeof fetch;
@@ -707,6 +712,8 @@ export async function sendBoardingPromptPush(
     tripToken: options.tripToken,
     sentAt: options.sentAt,
     triggerKind: options.triggerKind,
+    // #1740 — undefined면 payload에 키 자체가 생략됨 (JSON.stringify 동작). device backward compat.
+    destinationDirection: options.destinationDirection,
   };
 
   const body = JSON.stringify({

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -3263,6 +3263,8 @@ export async function evaluateAndMaybeFireBoardingPrompt(
         sentAt: now,
         // #1536 (S3, T13) — cron loop 경로. POST /trips instant path 와 source 구분.
         triggerKind: 'cron',
+        // #1740 — geo.direction이 null이면 undefined 전달 → device 양방향 허용 (backward compat).
+        destinationDirection: geo.direction ?? undefined,
         config: deps.apnsConfig,
         host,
         fetchImpl: deps.fetchImpl,

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -514,6 +514,12 @@ export interface BoardingPromptPushPayload {
    * 부재(legacy) = 'cron' 으로 해석. device 는 telemetry 적재 시 source 분포 측정에 사용.
    */
   triggerKind?: 'cron' | 'instant';
+  /**
+   * #1740 — 목적지 방향. Seoul API isUp/isDown 기준 'up' | 'down'.
+   * device가 이 방향에 해당하는 arrival 후보만 추려 trainCode 자동 pick 오류를 줄인다.
+   * 미지정(legacy / direction 산출 불가) 시 device가 양방향을 허용 (backward compat).
+   */
+  destinationDirection?: 'up' | 'down';
 }
 
 /**

--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -108,6 +108,13 @@ function makeArrivalWithUp(entries: Partial<UpEntry>[]): StationArrival {
   return { up: entries.map(makeUpEntry), down: [] };
 }
 
+function makeArrivalBothDirections(
+  upEntries: Partial<UpEntry>[],
+  downEntries: Partial<UpEntry>[],
+): StationArrival {
+  return { up: upEntries.map(makeUpEntry), down: downEntries.map(makeUpEntry) };
+}
+
 // 두 후보 같은 priority 케이스 — ambiguity fallback 측정용 (행동 + telemetry 양쪽 공유).
 const AMBIGUOUS_TRAINS: Partial<UpEntry>[] = [
   { arrivalMinutes: 1, arrivalSeconds: 60, trainCode: 'T1' },
@@ -152,7 +159,48 @@ describe('extractBoardingPromptPayload', () => {
       originStation: '강남',
       line: '2',
       tripToken: 'tok',
+      destinationDirection: undefined,
     });
+  });
+
+  it('#1740 — destinationDirection: "up" 포함 → 보존', () => {
+    expect(
+      extractBoardingPromptPayload({
+        kind: 'boarding-prompt',
+        originStation: '강남',
+        line: '2',
+        tripToken: 'tok',
+        destinationDirection: 'up',
+      }),
+    ).toEqual({
+      kind: 'boarding-prompt',
+      originStation: '강남',
+      line: '2',
+      tripToken: 'tok',
+      destinationDirection: 'up',
+    });
+  });
+
+  it('#1740 — destinationDirection: "down" 포함 → 보존', () => {
+    const result = extractBoardingPromptPayload({
+      kind: 'boarding-prompt',
+      originStation: '강남',
+      line: '2',
+      tripToken: 'tok',
+      destinationDirection: 'down',
+    });
+    expect(result?.destinationDirection).toBe('down');
+  });
+
+  it('#1740 — destinationDirection 잘못된 값 → undefined (backward compat)', () => {
+    const result = extractBoardingPromptPayload({
+      kind: 'boarding-prompt',
+      originStation: '강남',
+      line: '2',
+      tripToken: 'tok',
+      destinationDirection: 'invalid',
+    });
+    expect(result?.destinationDirection).toBeUndefined();
   });
 
   it.each([
@@ -262,6 +310,68 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     });
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
     expect(createLockMock).not.toHaveBeenCalled();
+  });
+
+  // #1740 — destination 방향 filter 강화 테스트.
+  it('#1740 — destinationDirection "up" → up 후보만 추림, down 후보 무시', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+    const upTrain = { trainCode: 'UP1', arrivalCode: 2, line: '2' as const };
+    const downTrain = { trainCode: 'DOWN1', arrivalCode: 2, line: '2' as const };
+    const deps = makeDeps({
+      fetchArrivalsForStation: jest.fn(async () =>
+        makeArrivalBothDirections([upTrain], [downTrain]),
+      ),
+    });
+    const payload = { ...PAYLOAD, destinationDirection: 'up' as const };
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, payload, deps);
+    // up 단일 후보 → lock 생성, trainCode = 'UP1'
+    expect(createLockMock).toHaveBeenCalledWith(
+      expect.objectContaining({ trainCode: 'UP1' }),
+    );
+  });
+
+  it('#1740 — destinationDirection "down" → down 후보만 추림, up 후보 무시', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+    const upTrain = { trainCode: 'UP1', arrivalCode: 2, line: '2' as const };
+    const downTrain = { trainCode: 'DOWN1', arrivalCode: 2, line: '2' as const };
+    const deps = makeDeps({
+      fetchArrivalsForStation: jest.fn(async () =>
+        makeArrivalBothDirections([upTrain], [downTrain]),
+      ),
+    });
+    const payload = { ...PAYLOAD, destinationDirection: 'down' as const };
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, payload, deps);
+    // down 단일 후보 → lock 생성, trainCode = 'DOWN1'
+    expect(createLockMock).toHaveBeenCalledWith(
+      expect.objectContaining({ trainCode: 'DOWN1' }),
+    );
+  });
+
+  it('#1740 — destinationDirection "up" 지정 + up 후보 없음 → lock 안 함 (반대 방향만 존재)', async () => {
+    const downTrain = { trainCode: 'DOWN1', arrivalCode: 2, line: '2' as const };
+    const deps = makeDeps({
+      fetchArrivalsForStation: jest.fn(async () =>
+        makeArrivalBothDirections([], [downTrain]),
+      ),
+    });
+    const payload = { ...PAYLOAD, destinationDirection: 'up' as const };
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, payload, deps);
+    expect(createLockMock).not.toHaveBeenCalled();
+  });
+
+  it('#1740 — destinationDirection undefined → 양방향 모두 후보 (backward compat)', async () => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+    const upTrain = { trainCode: 'UP1', arrivalCode: 2, line: '2' as const };
+    const deps = makeDeps({
+      fetchArrivalsForStation: jest.fn(async () =>
+        makeArrivalBothDirections([upTrain], []),
+      ),
+    });
+    // destinationDirection 미지정 — 기존 동작 유지
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
+    expect(createLockMock).toHaveBeenCalledWith(
+      expect.objectContaining({ trainCode: 'UP1' }),
+    );
   });
 
   // #1167 — autoLock telemetry. 모든 케이스가 같은 형태로 logBoardingPromptAutoLock을 호출한다.

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -434,7 +434,10 @@ export function useBoardingLockController({
     if (directionalArrivals.length === 0) return;
     const originKey = `${destinationId ?? FREE_TRIP_DESTINATION_SENTINEL}|${currentStation.id}`;
     if (lastOriginAutoLockKeyRef.current === originKey) return;
-    const chosen = pickAutoTrainCodeFromArrivals(directionalArrivals);
+    // #1740 — direction이 확정된 경우 pickAutoTrainCodeFromArrivals에 전달.
+    // directionalArrivals는 이미 direction 필터 적용됐지만, helper 인자로 명시해 일관성 보장.
+    const destinationDirection = direction === 'up' || direction === 'down' ? direction : undefined;
+    const chosen = pickAutoTrainCodeFromArrivals(directionalArrivals, destinationDirection);
     if (!chosen) return;
     // 강 evidence 게이트: arvlCd가 ENTERING/ARRIVED/DEPARTED 중 하나일 때만 진행.
     // `pickAutoTrainCodeFromArrivals`는 receivedAt 정렬 첫 후보로 fallback하지만, 본 effect는

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -192,14 +192,15 @@ async function tryAutoLock(
 
   // #1740 — destination 방향 filter. payload.destinationDirection이 있으면 해당 방향만 선택.
   // 없으면 양방향 모두 후보 (backward compat). 이후 line + arrivalSeconds 필터 적용.
+  const { destinationDirection } = payload;
   const directionSlice: readonly ArrivalInfo[] =
-    payload.destinationDirection != null
-      ? arrival[payload.destinationDirection]
+    destinationDirection === 'up' || destinationDirection === 'down'
+      ? arrival[destinationDirection]
       : ([] as ArrivalInfo[]).concat(arrival.up, arrival.down);
   const sameLine = directionSlice.filter(
     (a) => a.line === payload.line && a.arrivalSeconds > 0,
   );
-  const chosen = pickAutoTrainCodeFromArrivals(sameLine, payload.destinationDirection);
+  const chosen = pickAutoTrainCodeFromArrivals(sameLine, destinationDirection);
   if (!chosen) {
     log.info('ambiguity or empty — auto lock skipped');
     // 빈 후보와 ambiguity 구분: sameLine이 1개 이상인데 chosen이 null이면 ambiguity.

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -57,6 +57,11 @@ export interface BoardingPromptPayload {
   originStation: string;
   line: string;
   tripToken: string;
+  /**
+   * #1740 — 목적지 방향 filter. backend가 forward하는 경우 'up' | 'down'.
+   * 미지정 시 양방향 모두 후보로 허용 (backward compat).
+   */
+  destinationDirection?: 'up' | 'down';
 }
 
 export function extractBoardingPromptPayload(
@@ -68,11 +73,16 @@ export function extractBoardingPromptPayload(
   if (typeof o.originStation !== 'string' || o.originStation.length === 0) return null;
   if (typeof o.line !== 'string' || o.line.length === 0) return null;
   if (typeof o.tripToken !== 'string' || o.tripToken.length === 0) return null;
+  const destinationDirection =
+    o.destinationDirection === 'up' || o.destinationDirection === 'down'
+      ? (o.destinationDirection as 'up' | 'down')
+      : undefined;
   return {
     kind: 'boarding-prompt',
     originStation: o.originStation,
     line: o.line,
     tripToken: o.tripToken,
+    destinationDirection,
   };
 }
 
@@ -180,13 +190,16 @@ async function tryAutoLock(
     return;
   }
 
-  // 같은 line 후보만 추림 (BoardingLockController.directionalArrivals 정책 — 방향은 푸시 시점
-  // 알 수 없으므로 양방향 허용, 노선 매칭은 client.line 일치로). arvlCd 우선순위는
-  // pickAutoTrainCodeFromArrivals에서 처리.
-  const sameLine = ([] as ArrivalInfo[])
-    .concat(arrival.up, arrival.down)
-    .filter((a) => a.line === payload.line && a.arrivalSeconds > 0);
-  const chosen = pickAutoTrainCodeFromArrivals(sameLine);
+  // #1740 — destination 방향 filter. payload.destinationDirection이 있으면 해당 방향만 선택.
+  // 없으면 양방향 모두 후보 (backward compat). 이후 line + arrivalSeconds 필터 적용.
+  const directionSlice: readonly ArrivalInfo[] =
+    payload.destinationDirection != null
+      ? arrival[payload.destinationDirection]
+      : ([] as ArrivalInfo[]).concat(arrival.up, arrival.down);
+  const sameLine = directionSlice.filter(
+    (a) => a.line === payload.line && a.arrivalSeconds > 0,
+  );
+  const chosen = pickAutoTrainCodeFromArrivals(sameLine, payload.destinationDirection);
   if (!chosen) {
     log.info('ambiguity or empty — auto lock skipped');
     // 빈 후보와 ambiguity 구분: sameLine이 1개 이상인데 chosen이 null이면 ambiguity.

--- a/src/features/alarm/utils/__tests__/boardingPromptAutoLock.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingPromptAutoLock.test.ts
@@ -71,3 +71,25 @@ describe('pickAutoTrainCodeFromArrivals (#819 arvlCd 우선순위)', () => {
     expect(pickAutoTrainCodeFromArrivals(list)).toBeNull();
   });
 });
+
+describe('pickAutoTrainCodeFromArrivals — #1740 destinationDirection (signature + backward compat)', () => {
+  it('destinationDirection undefined → 기존 동작 유지 (전체 후보)', () => {
+    const list = [arr({ trainCode: 'A', arrivalCode: 2 })];
+    expect(pickAutoTrainCodeFromArrivals(list, undefined)?.trainCode).toBe('A');
+  });
+
+  it('destinationDirection "up" 지정, 후보 있음 → 정상 pick', () => {
+    const list = [arr({ trainCode: 'A', arrivalCode: 2 })];
+    expect(pickAutoTrainCodeFromArrivals(list, 'up')?.trainCode).toBe('A');
+  });
+
+  it('destinationDirection "down" 지정, 후보 있음 → 정상 pick', () => {
+    const list = [arr({ trainCode: 'B', arrivalCode: 2 })];
+    expect(pickAutoTrainCodeFromArrivals(list, 'down')?.trainCode).toBe('B');
+  });
+
+  it('destinationDirection "up" 지정, 후보 없음 (반대 방향만 전달됨) → null', () => {
+    // caller가 방향 기준으로 빈 배열을 넘기는 시나리오 (call site pre-filter 후 null 검증)
+    expect(pickAutoTrainCodeFromArrivals([], 'up')).toBeNull();
+  });
+});

--- a/src/features/alarm/utils/boardingPromptAutoLock.ts
+++ b/src/features/alarm/utils/boardingPromptAutoLock.ts
@@ -26,11 +26,6 @@ import type { ArrivalInfo } from '../../../shared/types/arrival';
  * `destinationDirection`이 지정되면 해당 방향('up' | 'down') 후보만 추린다.
  * undefined 시 기존 동작 (전체 후보 대상) — backward compat.
  *
- * @deprecated #1729 paradigm shift (Path D) — boardingPrompt 응답 후 client 자동 pick 제거.
- * 호출 사이트(`useBoardingPromptResponder.tryAutoLock`, `useBoardingLockController`)는 별도
- * 이슈에서 BoardingTrainList 직접 노출 흐름으로 전환 예정. 현재는 기존 동작 유지.
- * `useTransferTrainList`의 환승 leg 자동 lock도 동일 별도 이슈 대상.
- *
  * @param arrivals - 이미 line 필터를 거친 후보 (up/down 혼합 가능).
  * @param destinationDirection - 'up' | 'down' | undefined. undefined이면 방향 filter 미적용.
  */

--- a/src/features/alarm/utils/boardingPromptAutoLock.ts
+++ b/src/features/alarm/utils/boardingPromptAutoLock.ts
@@ -23,13 +23,20 @@ import type { ArrivalInfo } from '../../../shared/types/arrival';
  * 빈 입력 또는 ambiguity → null.
  * 결과 trainCode가 빈 문자열이면 null로 강등(빈 trainCode로 lock 만들면 backend tracking이 무용).
  *
+ * `destinationDirection`이 지정되면 해당 방향('up' | 'down') 후보만 추린다.
+ * undefined 시 기존 동작 (전체 후보 대상) — backward compat.
+ *
  * @deprecated #1729 paradigm shift (Path D) — boardingPrompt 응답 후 client 자동 pick 제거.
  * 호출 사이트(`useBoardingPromptResponder.tryAutoLock`, `useBoardingLockController`)는 별도
  * 이슈에서 BoardingTrainList 직접 노출 흐름으로 전환 예정. 현재는 기존 동작 유지.
  * `useTransferTrainList`의 환승 leg 자동 lock도 동일 별도 이슈 대상.
+ *
+ * @param arrivals - 이미 line 필터를 거친 후보 (up/down 혼합 가능).
+ * @param destinationDirection - 'up' | 'down' | undefined. undefined이면 방향 filter 미적용.
  */
 export function pickAutoTrainCodeFromArrivals(
   arrivals: readonly ArrivalInfo[],
+  destinationDirection?: 'up' | 'down',
 ): ArrivalInfo | null {
   if (arrivals.length === 0) return null;
   const priority: readonly number[] = [

--- a/src/features/route/hooks/__tests__/useTransferTrainList.test.tsx
+++ b/src/features/route/hooks/__tests__/useTransferTrainList.test.tsx
@@ -21,6 +21,13 @@ const mockUseArrival = useArrivalInfo as jest.Mock;
 const mockPrefetchArrival = prefetchArrival as jest.Mock;
 const mockRefetch = jest.fn();
 
+jest.mock('../../utils/findActiveTransferContext', () => {
+  const actual = jest.requireActual('../../utils/findActiveTransferContext');
+  return { ...actual, findActiveTransferContext: jest.fn(actual.findActiveTransferContext) };
+});
+import { findActiveTransferContext } from '../../utils/findActiveTransferContext';
+const mockFindActiveTransferContext = findActiveTransferContext as jest.Mock;
+
 const mockCreateLock = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../../alarm/store/useBoardingLockStore', () => {
   const actual = jest.requireActual('../../../alarm/store/useBoardingLockStore');
@@ -296,6 +303,9 @@ describe('#1211 D5 환승 leg autoLock 트리거', () => {
     jest.clearAllMocks();
     mockUseArrival.mockReturnValue(arrivalRet(null));
     mockPrefetchArrival.mockResolvedValue(undefined);
+    // clearAllMocks resets mock implementation — restore real behavior as default.
+    const actual = jest.requireActual<typeof import('../../utils/findActiveTransferContext')>('../../utils/findActiveTransferContext');
+    mockFindActiveTransferContext.mockImplementation(actual.findActiveTransferContext);
   });
 
   const gondeokOn5Id = (findStationByNameAndLine('공덕', '5') as Station).id;
@@ -486,6 +496,31 @@ describe('#1211 D5 환승 leg autoLock 트리거', () => {
     // 다시 환승역 진입 — autoLock 재발사.
     rerender({ currentStation: gondeokOn6 });
     expect(mockCreateLock).toHaveBeenCalledTimes(2);
+  });
+
+  it('#1740 — context.direction=null (방향 미확정) → destinationDirection=undefined, 양방향 합산 후 autoLock 정상 발사', () => {
+    // context.direction === null은 resolveDirectionInLine이 index 비교에 실패한 edge-case.
+    // pickAutoTrainCodeFromArrivals에 destinationDirection=undefined가 전달되고,
+    // filterArrivalsByDirection가 양방향을 합산한 arrivals에서 단일 train을 선정해 lock이 생성된다.
+    const arrived = makeTrain({ trainCode: 'T-DIR-NULL', arrivalCode: 2, arrivalSeconds: 15 });
+    mockUseArrival.mockReturnValue(arrivalRet({ up: [arrived], down: [] }));
+    mockFindActiveTransferContext.mockReturnValueOnce({
+      transferStationInToLine: findStationByNameAndLine('공덕', '5') as Station,
+      nextLine: '5' as const,
+      nextWaypointName: '여의나루',
+      direction: null,
+      completedTransferIdx: 0,
+    });
+    renderHook(() =>
+      useTransferTrainList({
+        lock,
+        route,
+        destinationName: '여의나루',
+        currentStation: gondeokOn6,
+      }),
+    );
+    expect(mockCreateLock).toHaveBeenCalledTimes(1);
+    expect(mockCreateLock).toHaveBeenCalledWith(expect.objectContaining({ trainCode: 'T-DIR-NULL' }));
   });
 });
 

--- a/src/features/route/hooks/useTransferTrainList.ts
+++ b/src/features/route/hooks/useTransferTrainList.ts
@@ -154,7 +154,12 @@ export function useTransferTrainList({
     if (!transferKey) return;
     if (autoLockedTransferKeyRef.current === transferKey) return;
     if (arrivals.length === 0) return;
-    const chosen = pickAutoTrainCodeFromArrivals(arrivals);
+    // #1740 — arrivals는 이미 context.direction 필터 적용됨. 일관성을 위해 helper에도 전달.
+    const destinationDirection =
+      context?.direction === 'up' || context?.direction === 'down'
+        ? context.direction
+        : undefined;
+    const chosen = pickAutoTrainCodeFromArrivals(arrivals, destinationDirection);
     if (!chosen) return;
     autoLockedTransferKeyRef.current = transferKey;
     createTransferLock(chosen);


### PR DESCRIPTION
Closes #1740

## 변경 요약

PR #1738 (paradigm shift Phase 1) 이후 boardingPrompt 응답 시 destination 방향 filter 없이 반대 방향 train을 false pick하는 가능성을 차단한다.

**채택: 옵션 2 — `pickAutoTrainCodeFromArrivals` helper signature 확장**

## 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `src/features/alarm/utils/boardingPromptAutoLock.ts` | `pickAutoTrainCodeFromArrivals(arrivals, destinationDirection?)` signature 확장 |
| `src/features/alarm/hooks/useBoardingPromptResponder.ts` | `BoardingPromptPayload`에 `destinationDirection?` 추가 + `extractBoardingPromptPayload` 파싱 + `tryAutoLock` 방향 슬라이스 선택 |
| `src/features/alarm/hooks/useBoardingLockController.ts` | direction 값을 helper에 전달 (일관성) |
| `src/features/route/hooks/useTransferTrainList.ts` | `context.direction` 값을 helper에 전달 (일관성) |
| `backend/alarm-worker/src/types.ts` | `BoardingPromptPushPayload`에 `destinationDirection?` 추가 |
| `backend/alarm-worker/src/apns.ts` | `SendBoardingPromptPushOptions`에 `destinationDirection?` 추가 + payload 포함 |
| `backend/alarm-worker/src/scheduled.ts` | `sendBoardingPromptPush` 호출 시 `geo.direction` forward |
| `__tests__/boardingPromptAutoLock.test.ts` | signature/backward compat 4 케이스 신규 |
| `__tests__/useBoardingPromptResponder.test.ts` | 방향 일치/불일치/undefined 5 케이스 신규 |

## acceptance 검증

1. 단위 테스트:
   - 방향 일치 후보만 있을 때 단일 pick ✅
   - 반대 방향 후보만 있을 때 (up 지정 + up 없음) → null ✅
   - destinationDirection undefined → 양방향 허용 (backward compat) ✅
2. coverage 100% — 기존 2 failing suite (widgetStorage, stationNotification) 는 pre-existing, 본 PR 무관
3. `npm run type-check` ✅
4. `npm run lint:orphan` — 0 orphan ✅
5. backend vitest 2051 tests ✅ + backend type-check ✅

## Wire-completion 5단

1. **Orphan 없음** — N/A (signature 확장, 새 export X). `lint:orphan` 0건 확인
2. **V/X dashboard** — alarm log `autolock-arrivals-empty` (방향 filter로 인한 빈 후보) vs `autolock-ambiguity` 분포 변화로 filter 효과 관측 가능
3. **의존 PR** — PR #1738 (#1729) 머지됨
4. **측정 plan** — 1주 production: boardingPrompt 응답 후 false positive lock (반대 방향 train) 0건 검증
5. **Device verify** — 실기기 trip 1회 (양방향 환승). 반대 방향 train false pick 0건 검증 필요