### PR TITLE
feat(#1739): boardingPrompt push 메시지 방면 + 시간 명시 (paradigm shift Phase 2)

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -33,6 +33,7 @@ import {
   pickBestArrivalSignal,
   pickLatestCurrentStationName,
   resolveEtaMissingThreshold,
+  buildBoardingPromptMessage,
   runScheduled,
   tripLifecyclePhase,
   appendPassedStation,
@@ -7132,6 +7133,55 @@ describe('runScheduled — #1707 destination GPS cross-check integration', () =>
     // trip 보존 — KV에 잔존.
     expect(await kv.get(`trip:${trip.token}`)).not.toBeNull();
     expect(stats.destinationCrossCheck.gpsFar).toBe(1);
+  });
+});
+
+describe('buildBoardingPromptMessage (#1739 — 방면 + 시간 명시)', () => {
+  const BASE_NOW = 1_700_000_000_000; // 2023-11-14T22:13:20.000Z → KST 07:13
+
+  it('nextStation + etaSeconds 둘 다 있음 → "출발역 [호선] → 다음역 방면 HH:MM 진입"', () => {
+    // BASE_NOW + 120s → KST 07:15:20 → HH:MM = 07:15
+    const { title, body } = buildBoardingPromptMessage('시청', '2', '강남', 120, BASE_NOW);
+    expect(title).toBe('Are you on board?');
+    expect(body).toBe('시청 [2] → 강남 방면 07:15 진입');
+  });
+
+  it('nextStation 없음 (null) → 기존 포맷 fallback "${line} · ${originStation}"', () => {
+    const { title, body } = buildBoardingPromptMessage('왕십리', '5', null, 90, BASE_NOW);
+    expect(title).toBe('Are you on board?');
+    expect(body).toBe('5 · 왕십리');
+  });
+
+  it('nextStation 있지만 etaSeconds null → 시간 없이 방면만 표시', () => {
+    const { title, body } = buildBoardingPromptMessage('합정', '6', '마포구청', null, BASE_NOW);
+    expect(title).toBe('Are you on board?');
+    expect(body).toBe('합정 [6] → 마포구청 방면');
+  });
+
+  it('환승 leg — 다른 호선 nextStation + ETA', () => {
+    // BASE_NOW + 180s → KST 07:16:20 → HH:MM = 07:16
+    const { title, body } = buildBoardingPromptMessage('왕십리', '5', '마장', 180, BASE_NOW);
+    expect(title).toBe('Are you on board?');
+    expect(body).toBe('왕십리 [5] → 마장 방면 07:16 진입');
+  });
+
+  it('etaSeconds=0 → now 시각 그대로 표시 (즉시 진입)', () => {
+    const { title, body } = buildBoardingPromptMessage('시청', '2', '을지로입구', 0, BASE_NOW);
+    expect(title).toBe('Are you on board?');
+    expect(body).toBe('시청 [2] → 을지로입구 방면 07:13 진입');
+  });
+
+  it('자정 경계 넘어가는 ETA — HH:MM 포맷 정상', () => {
+    // 23:59 KST = 14:59 UTC → epoch 1_699_973_940_000
+    // +120s → 2023-11-15 00:01 KST
+    const midnight = 1_699_973_940_000; // 2023-11-14 23:59 KST
+    const { body } = buildBoardingPromptMessage('시청', '2', '강남', 120, midnight);
+    expect(body).toBe('시청 [2] → 강남 방면 00:01 진입');
+  });
+
+  it('non-numeric line name (gyeongui) — fallback 포맷 정상', () => {
+    const { body } = buildBoardingPromptMessage('회기', 'gyeongui', null, null, BASE_NOW);
+    expect(body).toBe('gyeongui · 회기');
   });
 });
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -3155,6 +3155,44 @@ function isUnrecoverableApnsError(status: number, _reason: string | undefined): 
   return false;
 }
 
+/** KST(UTC+9) HH:MM 문자열로 변환 (#1739). */
+function toKstHhmm(epochMs: number): string {
+  const kstMs = epochMs + 9 * 60 * 60 * 1000;
+  const d = new Date(kstMs);
+  const hh = String(d.getUTCHours()).padStart(2, '0');
+  const mm = String(d.getUTCMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+/**
+ * boardingPrompt push 메시지 빌드 (#1739 — 방면 + 시간 명시).
+ *
+ * title: 항상 영문 raw (backend raw 원칙 — i18n는 client 담당).
+ * body:  nextStation이 있으면 "출발역 [호선] → 다음역 방면 HH:MM 진입",
+ *        없으면 기존 포맷 "${line} · ${originStation}" fallback.
+ *
+ * @param originStation  display.originStation (출발역 표시명)
+ * @param line           display.line ("2", "gyeongui" 등)
+ * @param nextStation    trip.waypoints[0].stationName (다음 정거장 — 방면 표시)
+ * @param etaSeconds     arrivals에서 추출한 도착 잔여 초 (null = 정보 없음)
+ * @param now            현재 epoch ms (ETA 절대 시각 계산용)
+ */
+export function buildBoardingPromptMessage(
+  originStation: string,
+  line: string,
+  nextStation: string | null,
+  etaSeconds: number | null,
+  now: number,
+): { title: string; body: string } {
+  const title = 'Are you on board?';
+  if (!nextStation) {
+    return { title, body: `${line} · ${originStation}` };
+  }
+  const timeStr =
+    etaSeconds !== null ? ` ${toKstHhmm(now + etaSeconds * 1000)} 진입` : '';
+  return { title, body: `${originStation} [${line}] → ${nextStation} 방면${timeStr}` };
+}
+
 /**
  * APNs 토큰 환경(sandbox/production)과 host가 어긋났을 때 Apple이 내는 시그널.
  * 이 조건에 한해서만 self-heal retry를 시도한다.
@@ -3248,6 +3286,33 @@ export async function evaluateAndMaybeFireBoardingPrompt(
   // #1729 paradigm shift — attemptAutoLock(Path B) 제거.
   // 9단 게이트 통과 시 backend가 자동 trainCode 결정 X. boardingPrompt push 발사 → 사용자 인지 요구.
 
+  // #1739 — 방면 + 시간 명시. 출발역 arrivals를 fetch해 방향 일치 최소 ETA 추출.
+  // 실패 시 graceful fallback (메시지 없이 push는 항상 발사).
+  const nextStation = trip.waypoints[0]?.stationName ?? null;
+  let etaSeconds: number | null = null;
+  try {
+    const arrivals = await deps.seoul.fetchArrivals(display.originStation);
+    const directional = arrivals.filter(
+      (a) =>
+        matchLine(a.subwayNm, display.line) &&
+        (geo.direction === null || (geo.direction === 'up' ? a.isUp : !a.isUp)),
+    );
+    const pool = directional.length > 0 ? directional : arrivals.filter((a) => matchLine(a.subwayNm, display.line));
+    if (pool.length > 0) {
+      const best = pool.reduce((min, cur) => (cur.arrivalSeconds < min.arrivalSeconds ? cur : min));
+      etaSeconds = best.arrivalSeconds;
+    }
+  } catch {
+    // Seoul API 장애 시 ETA 없이 push 발사 — 메시지 degradation만 발생, push 자체는 보존.
+  }
+  const { title, body } = buildBoardingPromptMessage(
+    display.originStation,
+    display.line,
+    nextStation,
+    etaSeconds,
+    now,
+  );
+
   // 9단 통과 — alert push 발사.
   const pushId = generatePushId();
   const heal = await sendWithEnvHeal(
@@ -3255,8 +3320,8 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       sendBoardingPromptPush({
         deviceToken: trip.token,
         pushId,
-        title: 'Are you on board?',
-        body: `${display.line} · ${display.originStation}`,
+        title,
+        body,
         originStation: display.originStation,
         line: display.line,
         tripToken: trip.token,

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -3189,7 +3189,7 @@ export function buildBoardingPromptMessage(
     return { title, body: `${line} · ${originStation}` };
   }
   const timeStr =
-    etaSeconds !== null ? ` ${toKstHhmm(now + etaSeconds * 1000)} 진입` : '';
+    etaSeconds === null ? '' : ` ${toKstHhmm(now + etaSeconds * 1000)} 진입`;
   return { title, body: `${originStation} [${line}] → ${nextStation} 방면${timeStr}` };
 }
 
@@ -3299,7 +3299,7 @@ export async function evaluateAndMaybeFireBoardingPrompt(
     );
     const pool = directional.length > 0 ? directional : arrivals.filter((a) => matchLine(a.subwayNm, display.line));
     if (pool.length > 0) {
-      const best = pool.reduce((min, cur) => (cur.arrivalSeconds < min.arrivalSeconds ? cur : min));
+      const best = pool.reduce((min, cur) => (cur.arrivalSeconds < min.arrivalSeconds ? cur : min), pool[0]);
       etaSeconds = best.arrivalSeconds;
     }
   } catch {


### PR DESCRIPTION
## Summary

Closes #1739

boardingPrompt push 메시지에 **방면 + 도착 시간** 을 명시해 사용자가 yes/no 응답 시 정확한 열차를 확인할 수 있도록 한다.

### 변경 전
```
title: "Are you on board?"
body:  "2 · 시청"
```

### 변경 후 (nextStation + ETA 있는 경우)
```
title: "Are you on board?"
body:  "시청 [2] → 강남 방면 07:15 진입"
```

## 변경 파일 (2개)

| 파일 | 변경 내용 |
|------|-----------|
| `backend/alarm-worker/src/scheduled.ts` | `buildBoardingPromptMessage` helper 신설 + `evaluateAndMaybeFireBoardingPrompt` 수정 (+67줄) |
| `backend/alarm-worker/src/__tests__/scheduled.test.ts` | `buildBoardingPromptMessage` 7 시나리오 테스트 (+50줄) |

## 구현 상세

1. **`buildBoardingPromptMessage`** (exported pure function):
   - `nextStation` + `etaSeconds` 둘 다 있으면: `"${originStation} [${line}] → ${nextStation} 방면 HH:MM 진입"`
   - `nextStation` 없으면: 기존 포맷 `"${line} · ${originStation}"` fallback
   - `etaSeconds` null이면: 방면만 표시 (시간 생략)
   - KST(UTC+9) HH:MM 변환 (`toKstHhmm` 내부 helper)

2. **`evaluateAndMaybeFireBoardingPrompt`** 수정:
   - 9단 게이트 통과 직후 `deps.seoul.fetchArrivals(display.originStation)` 호출
   - `geo.direction` + 호선으로 arrivals 필터링 → 최소 ETA 추출
   - Seoul API 장애/빈 arrivals 시 `try/catch` graceful fallback (push 항상 발사됨, 메시지만 degradation)

## Wire-completion 5단

1. **Orphan** — `buildBoardingPromptMessage`는 `evaluateAndMaybeFireBoardingPrompt`에서 호출 (caller 1곳). `npm run lint:orphan` pass
2. **V/X dashboard** — boardingPrompt push body 변경 → DebugModal alarm log + wrangler tail `boarding-prompt: fired` log에서 `line`/`originStation` 확인 가능
3. **의존 PR** — #1738 (#1729 paradigm shift Phase 1) — 이미 머지됨
4. **측정 plan** — 1주 후: boardingPrompt 응답률(boarded/dismissed) before/after 비교. 방면+시간 명시 후 응답률 증가 검증
5. **Device verify** — 실기기 trip 1회 (환승 1+): boardingPrompt push body에 방면+시간 표시 확인 필요 (backend-only 변경이라 EAS rebuild 불필요)

## 테스트 결과

- `backend/alarm-worker`: **2058 tests all passed** (+ 7 new `buildBoardingPromptMessage` 시나리오)
- `backend npm run type-check`: pass
- `npm run type-check`: pass
- `npm run lint:orphan`: 0 orphan