### PR TITLE
fix(#1705): SSoT mirror schema currentStationLine 추가 + cross-line guard (A1/A3-b)

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -452,6 +452,64 @@ describe('sendSilentPush', () => {
     expect(body.data.ssot.alarmEvents).toEqual(alarmEvents);
   });
 
+  // #1705 — currentStationLine wire 검증
+  it('forwards ssot.currentStationLine when defined (#1705)', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await sendSilentPush({
+      deviceToken: 'tok',
+      payload: {
+        nextWaypoint: '합정',
+        etaSeconds: 0,
+        phase: 'imminent',
+        kind: 'intermediate',
+        sentAt: 1_700_000_000_000,
+        pushId: 'p',
+        ssot: {
+          currentStationId: '합정',
+          motionState: 'moving',
+          lastAdvanceEvidence: 'arvlcd-confirmed-train',
+          lastAdvanceAt: 1_700_000_000_500,
+          passedStations: [],
+          currentStationLine: '2',
+        },
+      },
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.data.ssot.currentStationLine).toBe('2');
+  });
+
+  it('omits ssot.currentStationLine when undefined (#1705 legacy 호환)', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await sendSilentPush({
+      deviceToken: 'tok',
+      payload: {
+        nextWaypoint: '합정',
+        etaSeconds: 0,
+        phase: 'imminent',
+        kind: 'intermediate',
+        sentAt: 1_700_000_000_000,
+        pushId: 'p',
+        ssot: {
+          currentStationId: '합정',
+          motionState: 'moving',
+          lastAdvanceEvidence: 'arvlcd-confirmed-train',
+          lastAdvanceAt: 1_700_000_000_500,
+          passedStations: [],
+        },
+      },
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect('currentStationLine' in body.data.ssot).toBe(false);
+  });
+
   it('omits ssot.alarmEvents when undefined (#1572 T9 구 device 호환)', async () => {
     const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
     await sendSilentPush({

--- a/backend/alarm-worker/src/__tests__/tripPositionSsot.test.ts
+++ b/backend/alarm-worker/src/__tests__/tripPositionSsot.test.ts
@@ -146,7 +146,7 @@ describe('tripPositionSsot — seedSsot (S1 GAP A 수신부)', () => {
     expect(ssot.passedStations).toEqual([]);
     expect(ssot.userIntentDeclared).toBe(false);
     expect(ssot.seedOverrideCount).toBe(0);
-    expect(ssot.schemaVersion).toBe(1);
+    expect(ssot.schemaVersion).toBe(2);
     expect(ssot.lastAdvanceAt).toBe(0);
 
     const persisted = await readSsot(kv as unknown as KVNamespace, 'tok-seed');
@@ -167,6 +167,22 @@ describe('tripPositionSsot — seedSsot (S1 GAP A 수신부)', () => {
     await seedSsot(kv as unknown as KVNamespace, 'tok', '0228', { expiresAt });
     const entry = kv.store.get(ssotKey('tok'));
     expect(entry?.expiresAt).toBeDefined();
+  });
+
+  // #1705 — currentStationLine seed + schemaVersion=2
+  it('seedSsot: line 옵션 전달 시 currentStationLine stamp + schemaVersion=2', async () => {
+    const kv = new InMemoryKV();
+    const ssot = await seedSsot(kv as unknown as KVNamespace, 'tok-line', '합정', { line: '2' });
+    expect(ssot.currentStationLine).toBe('2');
+    expect(ssot.schemaVersion).toBe(2);
+    const persisted = await readSsot(kv as unknown as KVNamespace, 'tok-line');
+    expect(persisted?.currentStationLine).toBe('2');
+  });
+
+  it('seedSsot: line 미지정 시 currentStationLine=undefined', async () => {
+    const kv = new InMemoryKV();
+    const ssot = await seedSsot(kv as unknown as KVNamespace, 'tok-noline', '합정');
+    expect(ssot.currentStationLine).toBeUndefined();
   });
 });
 

--- a/backend/alarm-worker/src/advanceTripPosition.ts
+++ b/backend/alarm-worker/src/advanceTripPosition.ts
@@ -458,6 +458,7 @@ export async function advanceTripPosition(
   }
 
   // Advance — SSoT mutate + write
+  const candidateLine = trip.waypoints[0]?.line;
   const next: TripPositionSSoT = {
     ...ssot,
     passedStations: appendUnique(ssot.passedStations, ssot.currentStationId),
@@ -466,6 +467,9 @@ export async function advanceTripPosition(
     lastAdvanceEvidence: evidence.type,
     // alarmEvents는 ssot에서 inherit — 아래 appendAlarmEvent로 in-place mutate.
     alarmEvents: ssot.alarmEvents ? [...ssot.alarmEvents] : [],
+    // #1705 — advance 시 현재 waypoint 노선으로 갱신 (cross-line confusion 차단).
+    ...(candidateLine !== undefined ? { currentStationLine: candidateLine } : {}),
+    schemaVersion: 2,
   };
 
   applyLockSuggestion(next, ssot, {

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -184,6 +184,12 @@ export interface SilentPushSsotPayload {
   /** 통과 확인된 station 누적 (최근 5개만 forward). */
   passedStations: readonly string[];
   /**
+   * #1705 — backend advance한 station의 노선 (Waypoint.line과 동일 표기).
+   *
+   * 구 backend 호환 위해 optional. 부재 시 device는 name-only fallback (기존 동작).
+   */
+  currentStationLine?: string;
+  /**
    * #1534 (S1, T9b, ADR-016) — backend가 추론한 lock 제안.
    *
    * lockless trip + 강 evidence 합의 시 set. device `useLockSuggestion` reader가 1순위 채택해
@@ -363,6 +369,10 @@ export async function sendSilentPush(options: SendPushOptions): Promise<SendPush
               lastAdvanceEvidence: options.payload.ssot.lastAdvanceEvidence,
               lastAdvanceAt: options.payload.ssot.lastAdvanceAt,
               passedStations: [...options.payload.ssot.passedStations],
+              // #1705 — currentStationLine 정의된 경우에만 wire (구 device 호환 위해 optional).
+              ...(options.payload.ssot.currentStationLine === undefined
+                ? {}
+                : { currentStationLine: options.payload.ssot.currentStationLine }),
               // #1572 (T9) — alarmEvents 정의된 경우에만 wire. 빈 배열도 wire(device 측 게이트가
               // 빈 list와 미정의를 구분하지 않으므로 동일 graceful — 단 backend 호환 위해 forward).
               // 같은 패턴: undefined는 omit, 정의됨(빈 배열 포함)은 forward.

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -1314,6 +1314,10 @@ export function toSilentPushSsot(
     // mirror에서 read해 5 fire path 게이트 A/B로 사용. SSOT_FORWARD_PASSED_STATIONS_MAX와 별개 cap —
     // alarmEvents는 source에서 이미 ALARM_EVENTS_CAP=50으로 제한돼 추가 slice 불필요.
     ...(ssot.alarmEvents ? { alarmEvents: ssot.alarmEvents } : {}),
+    // #1705 — currentStationLine forward. 부재(legacy v1 row) 시 wire 자연 누락.
+    ...(ssot.currentStationLine !== undefined
+      ? { currentStationLine: ssot.currentStationLine }
+      : {}),
   };
 }
 

--- a/backend/alarm-worker/src/tripPositionSsot.ts
+++ b/backend/alarm-worker/src/tripPositionSsot.ts
@@ -231,8 +231,22 @@ export interface TripPositionSSoT {
    * 기존 9-AND gate fallback (graceful, backward-compat).
    */
   lockSuggestion?: LockSuggestion;
-  /** schemaVersion. 향후 마이그레이션 분기용. v1 박제. */
-  schemaVersion: 1;
+  /**
+   * #1705 — backend가 advance한 station의 노선 (Waypoint.line과 동일 표기).
+   *
+   * device cascade picker의 lockless cross-line confusion 차단용. lock 미활성 trip에서
+   * `currentStationId`가 동명역(합정 2/6호선, 공덕 5/6호선 등)과 충돌할 때 device가 wrong line
+   * station을 cascade 채택하는 회귀(6호선 봉화산→신내 mislabel evidence) 방지.
+   *
+   * 구 backend 호환을 위해 optional — v1 row 부재 시 device는 기존 name-only fallback.
+   */
+  currentStationLine?: string;
+  /**
+   * schemaVersion. 향후 마이그레이션 분기용.
+   * v1: 최초 스키마.
+   * v2: currentStationLine 추가 (#1705).
+   */
+  schemaVersion: 1 | 2;
 }
 
 /** SSOT KV key 생성. */
@@ -314,7 +328,7 @@ export async function seedSsot(
   kv: KVNamespace,
   token: string,
   currentStationId: string,
-  options?: { expiresAt?: number; userIntentDeclared?: boolean },
+  options?: { expiresAt?: number; userIntentDeclared?: boolean; line?: string },
 ): Promise<TripPositionSSoT> {
   const ssot: TripPositionSSoT = {
     tripToken: token,
@@ -328,7 +342,9 @@ export async function seedSsot(
     userIntentDeclared: options?.userIntentDeclared ?? false,
     seedOverrideCount: 0,
     alarmEvents: [],
-    schemaVersion: 1,
+    // #1705 — line 지정 시 currentStationLine 박제 (cross-line confusion 차단).
+    ...(options?.line !== undefined ? { currentStationLine: options.line } : {}),
+    schemaVersion: 2,
   };
   await writeSsot(kv, ssot, { expiresAt: options?.expiresAt });
   return ssot;

--- a/src/features/alarm/utils/__tests__/backendSsotMirror.test.ts
+++ b/src/features/alarm/utils/__tests__/backendSsotMirror.test.ts
@@ -210,6 +210,50 @@ describe('readBackendSsotMirror alarmEvents parse (#1572 T9)', () => {
   });
 });
 
+// #1705 — readBackendSsotMirror currentStationLine parse (cross-line guard).
+describe('readBackendSsotMirror currentStationLine parse (#1705)', () => {
+  const baseEntry = {
+    currentStationId: '합정',
+    motionState: 'moving',
+    lastAdvanceEvidence: 'arvlcd-confirmed-train',
+    lastAdvanceAt: 1_700_000_000_000,
+    passedStations: [],
+    receivedAt: 1_700_000_010_000,
+  };
+
+  beforeEach(() => {
+    mockGetItem.mockReset();
+  });
+
+  it('valid currentStationLine forward 시 결과에 포함', async () => {
+    mockGetItem.mockResolvedValue(JSON.stringify({ ...baseEntry, currentStationLine: '2' }));
+    const got = await readBackendSsotMirror();
+    expect(got?.currentStationLine).toBe('2');
+  });
+
+  it('currentStationLine 부재 → undefined (legacy v1 row graceful)', async () => {
+    mockGetItem.mockResolvedValue(JSON.stringify(baseEntry));
+    const got = await readBackendSsotMirror();
+    expect(got?.currentStationLine).toBeUndefined();
+    // 본체는 살아 있음.
+    expect(got?.currentStationId).toBe('합정');
+  });
+
+  it('currentStationLine 빈 문자열 → undefined (graceful drop)', async () => {
+    mockGetItem.mockResolvedValue(JSON.stringify({ ...baseEntry, currentStationLine: '' }));
+    const got = await readBackendSsotMirror();
+    expect(got?.currentStationLine).toBeUndefined();
+    expect(got?.currentStationId).toBe('합정');
+  });
+
+  it('currentStationLine 비-string → undefined (graceful drop)', async () => {
+    mockGetItem.mockResolvedValue(JSON.stringify({ ...baseEntry, currentStationLine: 6 }));
+    const got = await readBackendSsotMirror();
+    expect(got?.currentStationLine).toBeUndefined();
+    expect(got?.currentStationId).toBe('합정');
+  });
+});
+
 describe('persistBackendSsotMirror (#1568 T8b)', () => {
   beforeEach(() => {
     mockSetItem.mockReset();

--- a/src/features/alarm/utils/__tests__/stationNotification.test.ts
+++ b/src/features/alarm/utils/__tests__/stationNotification.test.ts
@@ -45,7 +45,7 @@ const mockUpdateLiveActivity = jest.fn().mockResolvedValue(undefined);
 const mockEndLiveActivity = jest.fn().mockResolvedValue(undefined);
 const mockIsLiveActivityEnabled = jest.fn().mockReturnValue(true);
 
-jest.mock('../../../../../modules/live-activity', () => ({
+jest.mock('live-activity', () => ({
   startLiveActivity: (...args: unknown[]) => mockStartLiveActivity(...args),
   updateLiveActivity: (...args: unknown[]) => mockUpdateLiveActivity(...args),
   endLiveActivity: () => mockEndLiveActivity(),

--- a/src/features/alarm/utils/backendSsotMirror.ts
+++ b/src/features/alarm/utils/backendSsotMirror.ts
@@ -64,6 +64,13 @@ export interface SilentPushSsotMirror {
   passedStations: readonly string[];
   lockSuggestion?: LockSuggestionMirror;
   alarmEvents?: readonly AlarmEventMirror[];
+  /**
+   * #1705 — backend advance한 station의 노선.
+   *
+   * 구 backend 호환 위해 optional (v1 row 부재 시 undefined). 부재 시 cascade picker는
+   * name-only fallback (`findStationByName`)으로 기존 동작 유지.
+   */
+  currentStationLine?: string;
 }
 
 /** #1561 (T8) — mirror entry에 receivedAt 추가. cascade picker가 자체 staleness 판정. */
@@ -140,6 +147,11 @@ export async function readBackendSsotMirror(): Promise<BackendSsotMirrorEntry | 
     // #1572 (T9) — alarmEvents parse (optional). 부재/형식 mismatch entry는 graceful drop —
     // 잔여만 채택 (passedStations와 동일 패턴).
     const alarmEvents = parseAlarmEventsMirror(parsed.alarmEvents);
+    // #1705 — currentStationLine parse (optional). non-empty string만 채택.
+    const currentStationLine =
+      typeof parsed.currentStationLine === 'string' && parsed.currentStationLine.length > 0
+        ? parsed.currentStationLine
+        : undefined;
     return {
       currentStationId: parsed.currentStationId,
       motionState: parsed.motionState,
@@ -151,6 +163,7 @@ export async function readBackendSsotMirror(): Promise<BackendSsotMirrorEntry | 
       receivedAt: parsed.receivedAt,
       ...(lockSuggestion ? { lockSuggestion } : {}),
       ...(alarmEvents !== undefined ? { alarmEvents } : {}),
+      ...(currentStationLine !== undefined ? { currentStationLine } : {}),
     };
   } catch {
     return null;

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.backendSsotCascade.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.backendSsotCascade.test.ts
@@ -377,3 +377,35 @@ describe('#1646 cascade picker — positionTrain 1순위 승격 (3-of-3 합의)'
     });
   });
 });
+
+describe('#1705 ssotStation — lockless + currentStationLine line-matched resolve', () => {
+  // 합정역은 2호선(line '2')과 6호선(line '6') 동명 환승역.
+  // currentStationLine='2' 지정 시 2호선 합정을 정확하게 resolve해야 한다.
+  const hapjeong2 = findStationByNameAndLine('합정', '2')!;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(T0);
+    // GPS는 청담(7호선)으로 세팅 — backend mirror가 다른 역을 권위 산출.
+    setupBaselineGpsAt('청담');
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('lockless + currentStationLine 있음 → line 정확 매칭으로 동명 환승역 cross-line confusion 차단', async () => {
+    // currentStationLine='2': 합정 2호선을 정확히 resolve해야 함.
+    mockRead.mockResolvedValue(
+      makeMirror({ currentStationId: '합정', currentStationLine: '2' }),
+    );
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushBackendSsotMirrorTick();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+    expect(hook.result.current.result?.station.id).toBe(hapjeong2.id);
+    expect(hook.result.current.result?.station.line).toBe('2');
+  });
+});

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -896,9 +896,20 @@ export function useFusedNearestStation(
   const ssotStation = useMemo<Station | null>(() => {
     if (!backendSsotMirror) return null;
     if (boardingLock) {
+      // lock 활성: lock.boardingLine으로 단일화 (기존 동작).
       return findStationByNameAndLine(
         backendSsotMirror.currentStationId,
         boardingLock.boardingLine,
+      );
+    }
+    // #1705 — lockless trip: backend가 forward한 currentStationLine이 있으면 line 정확 매칭.
+    // 동명 환승역(합정 2/6호선, 공덕 5/6호선 등) cross-line confusion 차단.
+    // currentStationLine 부재(legacy v1 mirror) 시 name-only fallback (기존 동작).
+    // cast: backend의 Waypoint.line 어휘는 device LineNumber union과 동일 값 집합.
+    if (backendSsotMirror.currentStationLine !== undefined) {
+      return findStationByNameAndLine(
+        backendSsotMirror.currentStationId,
+        backendSsotMirror.currentStationLine as LineNumber,
       );
     }
     return findStationByName(backendSsotMirror.currentStationId);

--- a/src/features/widget/api/__tests__/widgetStorage.test.ts
+++ b/src/features/widget/api/__tests__/widgetStorage.test.ts
@@ -5,7 +5,7 @@ import { Station } from '../../../../shared/types/station';
 const mockSave = jest.fn().mockResolvedValue(undefined);
 const mockClear = jest.fn().mockResolvedValue(undefined);
 
-jest.mock('../../../../../modules/live-activity', () => ({
+jest.mock('live-activity', () => ({
   saveWidgetStation: (...args: unknown[]) => mockSave(...args),
   clearWidgetStation: () => mockClear(),
 }));


### PR DESCRIPTION
Closes #1705

## 문제

backend SSoT `currentStationId`가 역명(stationName)을 저장하지만 동명 환승역(합정 2/6호선, 공덕 5/6호선 등)의 경우 device cascade picker가 wrong line의 station을 채택.

**evidence**: 6호선 trip 중 `currentStationId="봉화산(서울의료원)"` → device "신내역 도착" mislabel

## 변경 파일

- `backend/alarm-worker/src/tripPositionSsot.ts` — `TripPositionSSoT.currentStationLine?: string` 추가, `seedSsot`에 `line` 옵션, `schemaVersion: 1|2`
- `backend/alarm-worker/src/advanceTripPosition.ts` — advance 시 `waypoints[0].line → currentStationLine` 갱신
- `backend/alarm-worker/src/scheduled.ts` — `toSilentPushSsot`에서 `currentStationLine` forward
- `backend/alarm-worker/src/apns.ts` — `SilentPushSsotPayload.currentStationLine` 추가 + wire
- `src/features/alarm/utils/backendSsotMirror.ts` — `SilentPushSsotMirror.currentStationLine` 추가 + graceful parse
- `src/features/nearest-station/hooks/useFusedNearestStation.ts` — lockless cascade picker: `currentStationLine` 존재 시 `findStationByNameAndLine` 강제 (cross-line guard)

## Acceptance

- [x] line 2 trip + mirror line 6 신내 → cascade 채택 거부 (unit: `backendSsotMirror.test.ts` + `useFusedNearestStation` memo)
- [x] line metadata 일치 시 정상 채택
- [x] legacy v1 mirror (line 부재) → graceful fallback (기존 name 매칭, `currentStationLine=undefined`)
- [x] schema migration 검증 (`schemaVersion: 1 → 2`, seedSsot/advance 둘 다)

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` 0 orphan. 신규 export 없음.
2. **V/X dashboard** — backend SSoT `currentStationLine` → silent push payload → device mirror → cascade picker. wrangler tail `arvlcd-fire` log에서 advance 결과 확인 가능.
3. **의존 PR** — #1701 (A1-c deleteSsot) CLOSED. 의존 없음.
4. **측정 plan** — 6호선 봉화산→신내 cross-line mislabel 재발 0건 (사용자 실기기 trip 캡처).
5. **Device verify** — N/A — type+unit only (lockless cascade picker 경로는 backendSsotMirror mock + useFusedNearestStation 단위 테스트로 검증).