### PR TITLE
fix(#1654): LA content-state transfer waypoint → next leg toLine forward (X9 sub)

### DIFF
--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -104,8 +104,8 @@ describe('buildLiveActivityContentState (#613)', () => {
     expect(cs).not.toHaveProperty('alarmStationName');
   });
 
-  // #1658 — 환승역 waypoint 추적 시 다음 leg의 line을 LA에 즉시 반영 (60s lag 차단).
-  describe('transfer waypoint → new leg line forward (#1658)', () => {
+  // #1654 / #1658 — 환승역 waypoint 추적 시 다음 leg의 line을 LA에 즉시 반영 (60s lag 차단).
+  describe('transfer waypoint → new leg line forward (#1654 / #1658)', () => {
     /** 경의중앙선(K) → 2호선 환승 trip: 홍대입구(transfer, K) → 신촌(intermediate, 2) → 강남(dest, 2). */
     function makeTransferTrip(): Trip {
       return makeTrip({

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -2757,8 +2757,8 @@ describe('runScheduled — Live Activity push integration (#586 D / #612)', () =
     expect(stored.lastLaPushEpoch).toBeUndefined();
   });
 
-  // #1658 — 환승 leg 전환 감지 + LA content-state 즉시 갱신 통합 테스트.
-  describe('transfer waypoint → LA shows new leg line (#1658)', () => {
+  // #1654 / #1658 — 환승 leg 전환 감지 + LA content-state 즉시 갱신 통합 테스트.
+  describe('transfer waypoint → LA shows new leg line (#1654 / #1658)', () => {
     /**
      * 7호선(군자, transfer) → 5호선(아차산, destination) trip.
      * boardingLock은 7호선으로 군자를 추적 중. LA token 활성.
@@ -2821,7 +2821,7 @@ describe('runScheduled — Live Activity push integration (#586 D / #612)', () =
       const laCalls = getLaCalls(fetchImpl);
       expect(laCalls).toHaveLength(1);
       const contentState = parseLaBody(laCalls[0]).aps['content-state'] as Record<string, unknown>;
-      // #1658 — 환승 waypoint는 7호선이지만 다음 leg(아차산, 5호선)의 line을 LA에 즉시 노출
+      // #1654 / #1658 — 환승 waypoint는 7호선이지만 다음 leg(아차산, 5호선)의 line을 LA에 즉시 노출
       expect(contentState.lineName).toBe('5호선');
       expect(contentState.lineColorHex).toBe('#996CAC');
       // stationName은 transfer station(군자) 그대로 유지

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -86,7 +86,7 @@ export interface LiveActivityDeps {
  * stopsFromTransfer)를 함께 emit해 ActivityKit 전체 교체 후도 JS init이 채운 "전체 trip 여정"
  * UI가 유지된다. 누락 시 (legacy 호출) 기존 5 필드만 emit — 회귀 0 / backward compat.
  *
- * **환승 호선 forward (#1658)**: `waypoint.kind === 'transfer'`이고 `trip.waypoints[1]`이 존재하면
+ * **환승 호선 forward (#1654 / #1658)**: `waypoint.kind === 'transfer'`이고 `trip.waypoints[1]`이 존재하면
  * 다음 leg의 line(`trip.waypoints[1].line`)을 `lineName`/`lineColorHex`로 사용한다.
  * 환승역 waypoint는 현재 leg(경의중앙선 등)의 line을 갖지만, 사용자가 환승역에 도착하거나
  * 도착 중인 시점에는 이미 새 호선(2호선 등)으로 탑승 준비 중이므로 새 leg의 호선을 즉시 노출한다.
@@ -98,7 +98,7 @@ export function buildLiveActivityContentState(
   stopsRemaining: number,
   trip?: Trip,
 ): LiveActivityContentState {
-  // #1658 — 환승 waypoint 추적 중에는 다음 leg의 line을 lineName/lineColorHex에 반영한다.
+  // #1654 / #1658 — 환승 waypoint 추적 중에는 다음 leg의 line을 lineName/lineColorHex에 반영한다.
   // waypoint.kind==='transfer' + trip.waypoints[1]이 존재하면 새 leg의 line을 우선 사용.
   // trip이 없거나(legacy 호출) waypoints[1] 부재(직접 환승 도착)이면 waypoint.line으로 fallback.
   const displayLine =


### PR DESCRIPTION
## 개요

Closes #1654

### 배경

이슈 #1654에서 추적된 "환승 leg 호선 표시 60s+ lag" 문제. `buildLiveActivityContentState`가 `waypoint.kind === 'transfer'`일 때 `fromLine`(경의중앙선 등)을 그대로 표시하는 회귀.

### 구현 상태

**핵심 fix는 PR #1664 (#1658)으로 이미 origin/dev에 구현 완료돼 있음.**

| 변경 위치 | 상태 |
|---|---|
| `liveActivity.ts` `buildLiveActivityContentState` `displayLine` 분기 | ✅ 기구현 (#1658) |
| `scheduled.ts` L2627-2631, L2696-2700 — 두 호출 사이트 모두 `trip` 전달 | ✅ 기구현 (#1658) |
| `liveActivity.test.ts` — transfer waypoint head 시나리오 4개 케이스 | ✅ 기구현 (#1658) |
| `scheduled.test.ts` — 통합 테스트 2개 케이스 | ✅ 기구현 (#1658) |

### 본 PR 변경 사항

`#1658` 단독 참조 → `#1654 / #1658` 병기로 issue-reference 갱신:

- `backend/alarm-worker/src/liveActivity.ts` — JSDoc 주석 + 인라인 주석
- `backend/alarm-worker/src/__tests__/liveActivity.test.ts` — describe 주석
- `backend/alarm-worker/src/__tests__/scheduled.test.ts` — describe 주석 + 인라인 주석

### Fix 로직 요약

```typescript
// waypoint.kind === 'transfer' + trip.waypoints[1] 존재 → 새 leg line 우선
const displayLine =
  waypoint.kind === 'transfer' && trip !== undefined && trip.waypoints.length > 1
    ? trip.waypoints[1].line    // toLine (2호선 등)
    : waypoint.line;            // fallback: waypoint.line (fromLine) or legacy 호출
```

- transfer waypoint head 동안 cron heartbeat LA push 시 toLine 즉시 반영 → 60s+ lag 차단
- `trip` 미전달(legacy) / `waypoints.length <= 1` edge case → `waypoint.line` defensive fallback

## Wire-completion 5단

1. **Orphan**: `npm run lint:orphan` → 0 orphan ✅
2. **V/X dashboard**: `wrangler tail` LA push log `content-state.lineName`으로 관측 가능
3. **의존 PR**: N/A
4. **측정 plan**: 사용자 다음 환승 trip에서 LA 표시 line이 toLine으로 즉시 갱신되는지 캡처
5. **Device verify**: N/A — type+unit only. backend 단위 + 통합 테스트로 검증 완료

## 검증 결과

- `cd backend/alarm-worker && npx vitest run` → **2051 passed** ✅
- `npm run type-check` → **pass** ✅
- `npm run lint:orphan` → **0 orphan** ✅