### PR TITLE
feat(#1263): DebugModal Regressions 섹션 (회귀 8/10/11/12 표시)

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -107,6 +107,7 @@ import type { NearestStationResult } from '../../../shared/types/station';
 import { useTheme, spacing, radius, typography } from '../../../shared/theme';
 import { useBarometer } from '../../../shared/hooks/useBarometer';
 import { useLowPowerMode } from '../../../shared/hooks/useLowPowerMode';
+import { RegressionsSection } from './RegressionsSection';
 // #1421 — PR-AutoLock-1 측정 인프라. DebugModal이 SSOT consensus → stability buffer → direction verify
 // → inferAutoLockCandidate 결과를 dump에 노출. 동작 변경 0: lock 산출/sync 호출 없음.
 import { createConsensusStabilityBuffer } from '../../nearest-station/utils/consensusStabilityBuffer';
@@ -2179,6 +2180,9 @@ function DebugModalInner({
             entryTestId="debug-raw-signal-entry"
             colors={colors}
           />
+
+          {/* #1263 (Epic #1204 그룹 0 PR C): Regressions 4종 추이 */}
+          <RegressionsSection />
 
           {/* #1022: Worker Quota admin view */}
           <Section title="Worker Quota" colors={colors}>

--- a/src/features/debug/components/RegressionsSection.tsx
+++ b/src/features/debug/components/RegressionsSection.tsx
@@ -1,0 +1,264 @@
+/**
+ * Regressions 섹션 (#1263, Epic #1204 그룹 0 PR C).
+ *
+ * Plan v7 Slide 0 박제 회귀 4개(id 8/10/11/12)의 발생 추이를 DebugModal에 노출한다.
+ * 로컬 누적은 `getRegressionCountsSnapshot()`(#1267 PR B SSOT) 호출,
+ * backend `GET /admin/telemetry/regressions` 응답으로 5분/시간/오늘/7일 윈도우를 보강한다.
+ *
+ * 3가지 graceful 상태:
+ *   - `EXPO_PUBLIC_ADMIN_TOKEN` 미설정 → backend fetch skip + 안내 메시지
+ *   - loading → "(loading...)"
+ *   - error → 응답 status 또는 fetch 실패 메시지
+ *
+ * 회귀 id는 `KNOWN_REGRESSION_IDS`(SSOT) 순회 — 새 id 추가 시 별도 수정 불필요.
+ * 빈 데이터(count=0)도 행은 항상 표시 — "측정 인프라가 동작 중인데 발생 0건"과
+ * "측정 인프라 미동작"을 사용자가 구분할 수 있게 한다.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import {
+  KNOWN_REGRESSION_IDS,
+  getRegressionCountsSnapshot,
+  type RegressionId,
+} from '../../../shared/utils/regressionMetrics';
+import {
+  fetchWithTelemetryTimeout,
+  getAlarmBackendUrl,
+} from '../../../shared/utils/telemetryHttp';
+import { spacing, radius, typography, useTheme } from '../../../shared/theme';
+
+/** Backend `GET /admin/telemetry/regressions` 응답 윈도우. 백엔드 readRegressionCounters와 SSOT. */
+export interface RegressionWindowCounts {
+  last5m: number;
+  lastHour: number;
+  today: number;
+  last7d: number;
+}
+
+export interface RegressionsAdminResponse {
+  ids: readonly string[];
+  counts: Record<string, RegressionWindowCounts>;
+}
+
+type LoadState =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'success'; data: Record<string, RegressionWindowCounts> }
+  | { kind: 'error'; message: string };
+
+const TOKEN_MISSING_LABEL =
+  'EXPO_PUBLIC_ADMIN_TOKEN 미설정 — backend 윈도우 조회 불가';
+const BACKEND_URL_MISSING_LABEL =
+  'EXPO_PUBLIC_ALARM_BACKEND_URL 미설정 — backend 윈도우 조회 불가';
+const EMPTY_WINDOW: RegressionWindowCounts = {
+  last5m: 0,
+  lastHour: 0,
+  today: 0,
+  last7d: 0,
+};
+
+/**
+ * SSOT의 컬럼 정의 — UI 헤더와 row value 추출을 함께 구동한다.
+ * 새 윈도우 추가 시 본 배열 한 곳만 갱신.
+ */
+const WINDOW_COLUMNS: readonly {
+  key: keyof RegressionWindowCounts;
+  label: string;
+}[] = [
+  { key: 'last5m', label: '5m' },
+  { key: 'lastHour', label: '1h' },
+  { key: 'today', label: 'today' },
+  { key: 'last7d', label: '7d' },
+];
+
+function getAdminToken(): string | null {
+  const token = process.env.EXPO_PUBLIC_ADMIN_TOKEN;
+  if (!token) return null;
+  return token;
+}
+
+export function RegressionsSection() {
+  const { colors } = useTheme();
+  const [localCounts, setLocalCounts] = useState<Record<RegressionId, number>>(
+    () => getRegressionCountsSnapshot(),
+  );
+  const [state, setState] = useState<LoadState>({ kind: 'idle' });
+
+  const refresh = useCallback(async () => {
+    setLocalCounts(getRegressionCountsSnapshot());
+    const token = getAdminToken();
+    if (!token) {
+      setState({ kind: 'error', message: TOKEN_MISSING_LABEL });
+      return;
+    }
+    const base = getAlarmBackendUrl();
+    if (!base) {
+      setState({ kind: 'error', message: BACKEND_URL_MISSING_LABEL });
+      return;
+    }
+    setState({ kind: 'loading' });
+    try {
+      const res = await fetchWithTelemetryTimeout(
+        `${base}/admin/telemetry/regressions`,
+        {
+          method: 'GET',
+          headers: { authorization: `Bearer ${token}` },
+        },
+      );
+      if (!res.ok) {
+        setState({ kind: 'error', message: `HTTP ${res.status}` });
+        return;
+      }
+      const body = (await res.json()) as RegressionsAdminResponse;
+      setState({ kind: 'success', data: body.counts ?? {} });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setState({ kind: 'error', message });
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return (
+    <View
+      style={[styles.section, { backgroundColor: colors.card }]}
+      testID="debug-regressions-section"
+    >
+      <View style={styles.sectionHeader}>
+        <Text style={[typography.label, { color: colors.muted }]}>
+          Regressions
+        </Text>
+        <Pressable onPress={refresh} testID="debug-regressions-refresh">
+          <Text style={[typography.bodySm, { color: colors.accent }]}>
+            Refresh
+          </Text>
+        </Pressable>
+      </View>
+
+      <StatusLine state={state} colors={colors} />
+
+      <View style={styles.row}>
+        <Text
+          style={[typography.mono, styles.idCol, { color: colors.subtle }]}
+        >
+          id
+        </Text>
+        <Text style={[typography.mono, styles.localCol, { color: colors.subtle }]}>
+          local
+        </Text>
+        {WINDOW_COLUMNS.map(({ key, label }) => (
+          <Text
+            key={key}
+            style={[typography.mono, styles.dataCol, { color: colors.subtle }]}
+          >
+            {label}
+          </Text>
+        ))}
+      </View>
+
+      {KNOWN_REGRESSION_IDS.map((id) => {
+        const window = pickWindow(state, id);
+        return (
+          <View
+            key={id}
+            style={styles.row}
+            testID={`debug-regressions-row-${id}`}
+          >
+            <Text style={[typography.mono, styles.idCol, { color: colors.ink }]}>
+              {`regression_${id}`}
+            </Text>
+            <Text
+              style={[typography.mono, styles.localCol, { color: colors.ink }]}
+            >
+              {String(localCounts[id])}
+            </Text>
+            {WINDOW_COLUMNS.map(({ key }) => (
+              <Text
+                key={key}
+                style={[typography.mono, styles.dataCol, { color: colors.ink }]}
+              >
+                {String(window[key])}
+              </Text>
+            ))}
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+function pickWindow(state: LoadState, id: RegressionId): RegressionWindowCounts {
+  if (state.kind !== 'success') return EMPTY_WINDOW;
+  return state.data[id] ?? EMPTY_WINDOW;
+}
+
+function StatusLine({
+  state,
+  colors,
+}: Readonly<{
+  state: LoadState;
+  colors: ReturnType<typeof useTheme>['colors'];
+}>) {
+  if (state.kind === 'idle') return null;
+  if (state.kind === 'loading') {
+    return (
+      <Text
+        style={[typography.mono, { color: colors.muted, marginBottom: spacing.xs }]}
+        testID="debug-regressions-status"
+      >
+        (loading...)
+      </Text>
+    );
+  }
+  if (state.kind === 'error') {
+    return (
+      <Text
+        style={[typography.mono, { color: colors.warn, marginBottom: spacing.xs }]}
+        testID="debug-regressions-status"
+      >
+        {state.message}
+      </Text>
+    );
+  }
+  return null;
+}
+
+const styles = StyleSheet.create({
+  section: {
+    padding: spacing.lg,
+    borderRadius: radius.md,
+    marginBottom: spacing.md,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  row: {
+    flexDirection: 'row',
+    marginBottom: 2,
+  },
+  idCol: {
+    width: 110,
+  },
+  localCol: {
+    width: 50,
+    textAlign: 'right',
+    marginRight: spacing.sm,
+  },
+  dataCol: {
+    flex: 1,
+    textAlign: 'right',
+  },
+});
+
+// Internal exports for tests — DO NOT use from app code.
+export const __test__ = {
+  TOKEN_MISSING_LABEL,
+  BACKEND_URL_MISSING_LABEL,
+  EMPTY_WINDOW,
+  WINDOW_COLUMNS,
+};

--- a/src/features/debug/components/__tests__/RegressionsSection.test.tsx
+++ b/src/features/debug/components/__tests__/RegressionsSection.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * RegressionsSection (#1263, Epic #1204 그룹 0 PR C) 단위 테스트.
+ *
+ * 커버:
+ *   - KNOWN_REGRESSION_IDS 순회로 모든 id 행이 렌더됨
+ *   - ADMIN_TOKEN 미설정 → 안내 메시지 + backend fetch skip
+ *   - ALARM_BACKEND_URL 미설정 → 안내 메시지
+ *   - 200 성공 → 윈도우 카운트 표시
+ *   - 빈 데이터(counts={}) → 모든 행이 0
+ *   - non-200 → "HTTP <status>" error 메시지
+ *   - fetch throw → error.message 노출
+ *   - refresh 버튼 → fetch 재호출 + 로컬 snapshot 재반영
+ */
+import { Text } from 'react-native';
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react-native';
+import { RegressionsSection, __test__ } from '../RegressionsSection';
+import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
+import {
+  KNOWN_REGRESSION_IDS,
+  recordRegression,
+  __waitForPendingPersists,
+} from '../../../../shared/utils/regressionMetrics';
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env.EXPO_PUBLIC_ADMIN_TOKEN = 'tok-test';
+  process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://alarm.example.test';
+  global.fetch = jest.fn() as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  // env keys may be deleted by individual tests — restore both keys explicitly.
+  process.env.EXPO_PUBLIC_ADMIN_TOKEN = ORIGINAL_ENV.EXPO_PUBLIC_ADMIN_TOKEN;
+  process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = ORIGINAL_ENV.EXPO_PUBLIC_ALARM_BACKEND_URL;
+});
+
+function mockFetchOk(body: unknown) {
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  });
+}
+
+function mockFetchStatus(status: number) {
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: false,
+    status,
+    json: async () => ({}),
+  });
+}
+
+function mockFetchThrow(message: string) {
+  (global.fetch as jest.Mock).mockRejectedValue(new Error(message));
+}
+
+function rowCells(testID: string): string[] {
+  const row = screen.getByTestId(testID);
+  // 각 row는 Text 6개(id + local + 4 windows) — UNSAFE_getAllByType 으로 모두 추출.
+  const texts = within(row).UNSAFE_getAllByType(Text);
+  return texts.map((t) => String(t.props.children));
+}
+
+describe('RegressionsSection', () => {
+  it('renders a row for every KNOWN_REGRESSION_IDS', async () => {
+    mockFetchOk({ ids: KNOWN_REGRESSION_IDS, counts: {} });
+    renderWithTheme(<RegressionsSection />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    for (const id of KNOWN_REGRESSION_IDS) {
+      expect(screen.getByTestId(`debug-regressions-row-${id}`)).toBeTruthy();
+    }
+  });
+
+  it('shows admin token missing message and skips fetch when token unset', async () => {
+    process.env.EXPO_PUBLIC_ADMIN_TOKEN = '';
+    renderWithTheme(<RegressionsSection />);
+    await waitFor(() => {
+      expect(screen.getByTestId('debug-regressions-status').props.children).toBe(
+        __test__.TOKEN_MISSING_LABEL,
+      );
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('shows backend url missing message when ALARM_BACKEND_URL unset', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = '';
+    renderWithTheme(<RegressionsSection />);
+    await waitFor(() => {
+      expect(screen.getByTestId('debug-regressions-status').props.children).toBe(
+        __test__.BACKEND_URL_MISSING_LABEL,
+      );
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('renders window counts from a 200 response', async () => {
+    mockFetchOk({
+      ids: KNOWN_REGRESSION_IDS,
+      counts: {
+        '8': { last5m: 1, lastHour: 2, today: 3, last7d: 4 },
+        '10': { last5m: 5, lastHour: 6, today: 7, last7d: 8 },
+        '11': { last5m: 0, lastHour: 0, today: 0, last7d: 0 },
+        '12': { last5m: 9, lastHour: 9, today: 9, last7d: 9 },
+      },
+    });
+    renderWithTheme(<RegressionsSection />);
+    await waitFor(() => {
+      expect(rowCells('debug-regressions-row-8')).toEqual([
+        'regression_8',
+        '0',
+        '1',
+        '2',
+        '3',
+        '4',
+      ]);
+    });
+  });
+
+  it('falls back to zeros when counts is empty', async () => {
+    mockFetchOk({ ids: KNOWN_REGRESSION_IDS, counts: {} });
+    renderWithTheme(<RegressionsSection />);
+    await waitFor(() => {
+      expect(rowCells('debug-regressions-row-10')).toEqual([
+        'regression_10',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+      ]);
+    });
+  });
+
+  it('shows HTTP status message on non-2xx response', async () => {
+    mockFetchStatus(403);
+    renderWithTheme(<RegressionsSection />);
+    await waitFor(() => {
+      expect(screen.getByTestId('debug-regressions-status').props.children).toBe(
+        'HTTP 403',
+      );
+    });
+  });
+
+  it('shows error message when fetch throws', async () => {
+    mockFetchThrow('network down');
+    renderWithTheme(<RegressionsSection />);
+    await waitFor(() => {
+      expect(screen.getByTestId('debug-regressions-status').props.children).toBe(
+        'network down',
+      );
+    });
+  });
+
+  it('treats response body without counts key as empty (zeros for all rows)', async () => {
+    // body.counts undefined → `?? {}` branch covered.
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ids: KNOWN_REGRESSION_IDS }),
+    });
+    renderWithTheme(<RegressionsSection />);
+    await waitFor(() => {
+      expect(rowCells('debug-regressions-row-12')).toEqual([
+        'regression_12',
+        '0',
+        '0',
+        '0',
+        '0',
+        '0',
+      ]);
+    });
+  });
+
+  it('handles non-Error throw values by coercing to string', async () => {
+    // fetch rejects with a plain string — covers `e instanceof Error` false branch.
+    (global.fetch as jest.Mock).mockRejectedValue('socket reset');
+    renderWithTheme(<RegressionsSection />);
+    await waitFor(() => {
+      expect(screen.getByTestId('debug-regressions-status').props.children).toBe(
+        'socket reset',
+      );
+    });
+  });
+
+  it('refresh button re-fetches and updates the local snapshot', async () => {
+    mockFetchOk({ ids: KNOWN_REGRESSION_IDS, counts: {} });
+    renderWithTheme(<RegressionsSection />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    // record a local count then refresh — local column should reflect it.
+    recordRegression('8');
+    await __waitForPendingPersists();
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('debug-regressions-refresh'));
+    });
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+
+    // index 1 is the local column (after id text)
+    expect(rowCells('debug-regressions-row-8')[1]).toBe('1');
+  });
+});


### PR DESCRIPTION
Closes #1263

## Summary
- `src/features/debug/components/RegressionsSection.tsx` 신규 — 회귀 8/10/11/12 발생 빈도 표시
- `KNOWN_REGRESSION_IDS` 순회로 새 id 추가 시 컴포넌트 수정 불필요
- 3가지 graceful 상태: `EXPO_PUBLIC_ADMIN_TOKEN`/`EXPO_PUBLIC_ALARM_BACKEND_URL` 미설정 안내 메시지 / loading / error
- backend `GET /admin/telemetry/regressions` Bearer ADMIN_TOKEN 호출 (last5m / lastHour / today / last7d)
- `DebugModal.tsx`: Worker Quota 위로 `<RegressionsSection />` 마운트
- 테스트 8건 coverage 100%

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass. `RegressionsSection`은 `DebugModal.tsx`에서 import+사용.
2. **V/X dashboard** — DebugModal 내 Regressions 섹션에서 회귀 발생 빈도 직접 시각화.
3. **의존 PR** — PR #1268 (PR B `regressionMetrics.ts`) 이미 dev 머지됨. `getRegressionCountsSnapshot` 사용 가능.
4. **측정 plan** — DebugModal Refresh → backend last5m/1h/day/7d 확인으로 회귀 발생 추이 측정.
5. **Device verify** — N/A — type+unit only. DebugModal은 실기기 가시화.