### PR TITLE
feat(#1756): boardingLockScheduler window 상한 제거 (#1538 sub 1)

### DIFF
--- a/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts
@@ -211,9 +211,9 @@ describe('scheduleHopsForLock', () => {
     expect(ids).toContain('bl:T-100:1:imminent:오금');
   });
 
-  it('multi-transfer: windowSize 기본=10이라 4 waypoint 모두 예약됨 (#1399)', async () => {
+  it('multi-transfer: windowSize 기본=Infinity라 4 waypoint 모두 예약됨 (#1756)', async () => {
     await scheduleHopsForLock({ lock, route: multiRoute, destinationName: '온수' });
-    // targets = 교대, 약수, 한강진, 온수. window=10 (#1399) → 모두 예약 → destination floor 보장.
+    // targets = 교대, 약수, 한강진, 온수. window=Infinity (#1756) → 모두 예약 → destination floor 보장.
     const ids = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
     expect(ids.some((id) => id.includes(':2:'))).toBe(true); // 한강진(idx=2)
     expect(ids.some((id) => id.includes(':3:'))).toBe(true); // 온수(idx=3) destination도 floor
@@ -527,15 +527,15 @@ describe('advanceHopWindow', () => {
     });
     expect(mockedCancel).toHaveBeenCalledWith('bl:T-100:0:early:교대');
     const newIds = mockedSchedule.mock.calls.map((c) => c[0].identifier ?? '');
-    // 1은 이미 있으므로 skip, 2(한강진)와 3(온수)는 채움. (windowSize=3 → 범위 [1..3])
+    // 1은 이미 있으므로 skip, 2(한강진)와 3(온수)는 채움. (windowSize=Infinity → 범위 [1..3])
     expect(newIds.some((id) => id.startsWith('bl:T-100:1:'))).toBe(false);
     expect(newIds.some((id) => id.startsWith('bl:T-100:2:'))).toBe(true);
     expect(newIds.some((id) => id.startsWith('bl:T-100:3:'))).toBe(true);
   });
 
   it('정상 호출(0 → 1): hopIndex 0 cancel + window 끝 hop만 새로 예약', async () => {
-    // multiRoute targets: 교대(0), 약수(1), 한강진(2), 온수(3). window=3 → 0,1,2 예약됨.
-    // 교대 통과 시: hopIndex 0 cancel + 새 hop = passedIndex(0) + window(3) = 3 (온수) 예약.
+    // multiRoute targets: 교대(0), 약수(1), 한강진(2), 온수(3). window=Infinity → 0,1,2,3 예약됨.
+    // 교대 통과 시: hopIndex 0 cancel + 새 hop = 남은 미예약 = 3 (온수) 예약.
     mockedGet.mockResolvedValueOnce([
       'bl:T-100:0:early:교대',
       'bl:T-100:0:imminent:교대',

--- a/src/features/alarm/utils/boardingLockScheduler.ts
+++ b/src/features/alarm/utils/boardingLockScheduler.ts
@@ -48,22 +48,18 @@ const PHASE_INTERRUPTION: Record<AlarmPhaseId, 'active' | 'timeSensitive'> = {
 };
 
 /**
- * Per-Hop Adaptive Scheduling: 한 번에 큐에 두는 waypoint 수 (iOS 64 한도 안전).
+ * Per-Hop Adaptive Scheduling: 한 번에 큐에 두는 waypoint 수.
  *
- * #1399 — 3 → 10. 기존 3은 lock 활성 trip의 "다음 3 hop"만 floor로 깔아 destination/transfer 까지
- * 사전 예약이 도달하지 못했다 (S6/S8 14:10 군자/용마산 vanish + GPS 동결 시 device floor 부족).
- * 10으로 확장하면 평균 환승 trip(편당 hop 5~8)의 destination 까지 사전 예약이 깔린다.
+ * #1756 (#1538 S5 Sub 1) — 10 → Infinity. route의 남은 waypoint 전체를 한 번에 예약해
+ * GPS 동결 / backend silent push 끊김 상황에서도 destination / transfer 알람이
+ * 사전 예약 없이 누락되는 회귀를 원천 차단한다.
  *
- * iOS 한도(64) 분배:
- *  - bl:  10 stop × 2 phase = 20개
- *  - tba: 20 stop × 2 phase = 40개 (TRIPBOUND_WINDOW_SIZE)
- *  - 시스템 silent push delivery(1~2건) ≈ 4개
- *  - 합 ≈ 64 — 안전 마진 좁지만 advance 시 cancel/refill로 rolling 유지.
+ * iOS 64 한도 분배 조정은 Sub 2 (#1757)에서 별도 처리.
+ * 본 sub 단독 머지 시 iOS 64 한도를 초과할 수 있음 — Sub 2 의존.
  *
- * advance 시 `advanceHopWindow`가 다음 windowSize 만큼 채워 floor가 항상 유지된다. backend
- * silent push가 끊겨도 device 측 OS local notification이 시간기반으로 매역/하차 알림을 발사한다.
+ * advance 시 `advanceHopWindow`가 통과 hop cancel + 나머지 전체를 refill해 floor가 항상 유지된다.
  */
-const DEFAULT_WINDOW_SIZE = 10;
+const DEFAULT_WINDOW_SIZE = Infinity;
 
 export interface BoardingLockAlarmIdParts {
   trainCode: string;


### PR DESCRIPTION
## Summary

Closes #1756

`DEFAULT_WINDOW_SIZE`를 10 → `Infinity`로 변경해 `scheduleHopsForLock` / `advanceHopWindow` 모두 route의 남은 waypoint 전체를 한 번에 예약하도록 한다.

**동기**: 기존 window=10은 평균 환승 trip(hop 5~8)에는 충분하지만, GPS 동결 / backend silent push 끊김 상황에서 destination / transfer 알람이 device-side 사전 예약 없이 누락될 수 있는 구조적 위험이 존재했다.

## 변경 파일

| 파일 | 변동 |
|---|---|
| `src/features/alarm/utils/boardingLockScheduler.ts` | `DEFAULT_WINDOW_SIZE = 10` → `Infinity`, JSDoc 갱신 |
| `src/features/alarm/utils/__tests__/boardingLockScheduler.test.ts` | 기본값 관련 주석 갱신 (로직 변경 없음) |

## iOS 64 한도 영향

본 Sub 단독 머지 시 iOS 64 알림 한도를 초과할 가능성이 있다.

- Sub 2 (#1757) — `bl:` + `tba:` 채널 간 quota 분배 조정으로 64 한도 안전 확보 예정.
- **Sub 2 머지 전까지 long trip(10+ hop)에서 iOS 64 한도 초과 위험 존재**.

## Wire-completion 5단 체크

1. **Orphan 없음** — `npm run lint:orphan` pass. 신규 export 없음.
2. **V/X dashboard** — 변경은 순수 상수값 조정. DebugModal `alarmLog` schedule 건수로 관측 가능.
3. **의존 PR** — Sub 2 #1757 (iOS 64 한도 quota 분배). 본 PR 단독 기능 동작은 가능.
4. **측정 plan** — `alarmLog`에서 `scheduled N alarms for lock ... (M hops)` 로그의 M 값이 route 전체 hop 수와 일치하는지 1주 확인.
5. **Device verify** — N/A — type+unit only. iOS 64 초과 영향은 Sub 2 이후 실기기 확인.