### PR TITLE
chore(#1762): Dijkstra min-distance type 제거 (사용자 요구 — 2 type만)

### DIFF
--- a/src/shared/utils/__tests__/dijkstraRoute.test.ts
+++ b/src/shared/utils/__tests__/dijkstraRoute.test.ts
@@ -26,7 +26,7 @@ describe('dijkstraRoute (#1499)', () => {
   });
 
   it('finds a direct same-line route without transfers (2-001 → 2-003)', () => {
-    const r = findRouteByType('2-001', '2-003', 'min-distance');
+    const r = findRouteByType('2-001', '2-003', 'min-time');
     expect(r).not.toBeNull();
     expect(r?.transferCount).toBe(0);
     expect(r?.legs).toHaveLength(1);
@@ -49,9 +49,9 @@ describe('dijkstraRoute (#1499)', () => {
     }
   });
 
-  it('min-transfer prefers fewer transfers than min-distance', () => {
+  it('min-transfer prefers fewer transfers than min-time', () => {
     const a = findRouteByType('2-011', '5-032', 'min-transfer');
-    const b = findRouteByType('2-011', '5-032', 'min-distance');
+    const b = findRouteByType('2-011', '5-032', 'min-time');
     expect(a).not.toBeNull();
     expect(b).not.toBeNull();
     if (a && b) {
@@ -59,7 +59,7 @@ describe('dijkstraRoute (#1499)', () => {
     }
   });
 
-  it('findRoutes returns all three types', () => {
+  it('findRoutes returns all two types', () => {
     const result = findRoutes('2-001', '2-003');
     for (const type of ROUTE_OPTIMIZATION_TYPES) {
       expect(result[type]).not.toBeNull();
@@ -86,16 +86,6 @@ describe('dijkstraRoute (#1499)', () => {
     // 9-001(개화) → 2-001 라인 외 연결 없음
     const r = findRouteByType('9-001', '2-001', 'min-time');
     expect(r).toBeNull();
-  });
-
-  it('min-distance excludes walking distance for transfers', () => {
-    const r = findRouteByType('2-011', '5-032', 'min-distance');
-    expect(r).not.toBeNull();
-    if (r) {
-      // totalDistanceMeters should be sum of leg distances only
-      const sumLeg = r.legs.reduce((s, l) => s + l.distanceMeters, 0);
-      expect(r.totalDistanceMeters).toBe(sumLeg);
-    }
   });
 
   it('heap correctness — large random pair stress', () => {

--- a/src/shared/utils/dijkstraRoute.ts
+++ b/src/shared/utils/dijkstraRoute.ts
@@ -1,9 +1,8 @@
 /**
  * #1499 — 자체 Dijkstra 최단경로 알고리즘.
  *
- * 3종 type:
+ * 2종 type:
  *   - `min-transfer`: 환승 횟수 최소화. line edge=1, transfer edge=1000.
- *   - `min-distance`: 운행 거리(m) 최단. transfer edge는 거리 0으로 산정.
  *   - `min-time`: 운행 + 환승 도보 시간(초) 합산 최단.
  *
  * 결과는 `Route` 객체로 leg + transfer 정보를 모두 포함, downstream
@@ -12,11 +11,10 @@
 import { buildRouteGraph, type RouteEdge } from './buildRouteGraph';
 import type { LineNumber } from '../types/station';
 
-export type RouteOptimizationType = 'min-transfer' | 'min-distance' | 'min-time';
+export type RouteOptimizationType = 'min-transfer' | 'min-time';
 
 export const ROUTE_OPTIMIZATION_TYPES: readonly RouteOptimizationType[] = [
   'min-transfer',
-  'min-distance',
   'min-time',
 ];
 
@@ -114,12 +112,10 @@ class MinHeap<T> {
 function edgeWeight(edge: RouteEdge, type: RouteOptimizationType): number {
   if (edge.kind === 'line') {
     if (type === 'min-transfer') return 1;
-    if (type === 'min-distance') return edge.distanceMeters;
     return edge.durationSeconds;
   }
   // transfer
   if (type === 'min-transfer') return 1000;
-  if (type === 'min-distance') return 0;
   return edge.walkingSeconds;
 }
 
@@ -287,7 +283,7 @@ function reconstructRoute(
 }
 
 /**
- * 3종 type 한 번에 산출. UI/DebugModal에서 비교 표시용.
+ * 2종 type 한 번에 산출. UI/DebugModal에서 비교 표시용.
  */
 export function findRoutes(
   fromId: string,
@@ -295,7 +291,6 @@ export function findRoutes(
 ): Record<RouteOptimizationType, Route | null> {
   return {
     'min-transfer': findRouteByType(fromId, toId, 'min-transfer'),
-    'min-distance': findRouteByType(fromId, toId, 'min-distance'),
     'min-time': findRouteByType(fromId, toId, 'min-time'),
   };
 }


### PR DESCRIPTION
Closes #1762

## 변경 요약

사용자 요구: Dijkstra `RouteOptimizationType`을 min-time + min-transfer 2 type으로 단순화.

### 제거된 코드

| 파일 | 제거 내용 |
|------|-----------|
| `src/shared/utils/dijkstraRoute.ts` | `RouteOptimizationType` union에서 `'min-distance'` 제거 |
| `src/shared/utils/dijkstraRoute.ts` | `ROUTE_OPTIMIZATION_TYPES` 상수에서 `'min-distance'` 항목 제거 |
| `src/shared/utils/dijkstraRoute.ts` | `edgeWeight()` 내 `min-distance` 분기 2개 제거 |
| `src/shared/utils/dijkstraRoute.ts` | `findRoutes()` 반환 객체에서 `'min-distance'` 키 제거 |
| `src/shared/utils/__tests__/dijkstraRoute.test.ts` | `min-distance` 전용 시나리오 3건 제거, 나머지 사용처 `min-time`으로 교체 |

**diff**: 2파일, +7 / -22

## 검증

- `grep -rn 'min-distance' src backend` → **0건 확인**
- `npm test` → 7701 tests, 372 suites, coverage 100% ✓
- `npm run type-check` → 오류 없음 ✓
- `npm run lint:orphan` → No orphan exports ✓
- Backend: `npx vitest run` → 2062 tests, 55 files ✓
- Backend: `npx tsc --noEmit` → 오류 없음 ✓

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass. export 삭제이므로 신규 orphan 없음
2. **V/X dashboard** — type 제거이므로 observable 신호 변화 없음. N/A
3. **의존 PR** — N/A (독립 chore)
4. **측정 plan** — type 삭제 회귀 없음. 타입 오류는 CI type-check가 검증
5. **Device verify** — N/A — type+unit only