### PR TITLE
feat(#1757): iOS 64 한도 분배 재계산 (#1538 sub 2)

### DIFF
--- a/src/features/alarm/utils/boardingLockScheduler.ts
+++ b/src/features/alarm/utils/boardingLockScheduler.ts
@@ -14,6 +14,7 @@ import {
 } from './scheduledNotificationsStorage';
 import { createLogger } from '../../../shared/utils/logger';
 import { HOP_TIME_MS } from '../../../shared/constants/boardingLock';
+import { BL_MAX_WAYPOINTS } from '../../../shared/constants/iosScheduledLimit';
 import { shouldSuppressBySleepRule } from './shouldSuppressBySleepRule';
 import { logScheduleSkipped, logSuppressedSleepFirstTransfer } from './alarmLog';
 import { BOARDING_LOCK_ROUTE_SIG_KEY } from '../../../shared/constants/storageKeys';
@@ -341,7 +342,10 @@ export async function scheduleHopsForLock(params: ScheduleHopsParams): Promise<s
 
   const allTargets = resolveAllTargets(route, destinationName);
   const timings = computeHopTimings(lock, route, allTargets);
-  const lastIdx = Math.min(windowSize, allTargets.length);
+  // #1757 (Sub 2) — iOS 64 한도 분배. BL_MAX_WAYPOINTS(15)로 OS 예약 수를 cap.
+  // DEFAULT_WINDOW_SIZE=Infinity(Sub 1)는 "route 끝까지 advance" 의미를 유지하되,
+  // 실제 OS 예약 건수는 BL_QUOTA(30건) = BL_MAX_WAYPOINTS × 2 phase 이내로 제한.
+  const lastIdx = Math.min(windowSize, allTargets.length, BL_MAX_WAYPOINTS);
 
   const scheduledIds: string[] = [];
   for (let hopIndex = 0; hopIndex < lastIdx; hopIndex++) {
@@ -512,7 +516,13 @@ export async function advanceHopWindow(params: AdvanceHopWindowParams): Promise<
   const observedMs = now ?? lock.boardedAt;
   const timings = computeHopTimings(lock, route, allTargets);
   const scheduledIds: string[] = [];
-  const windowEnd = Math.min(passedIndex + windowSize, allTargets.length - 1);
+  // #1757 (Sub 2) — BL_MAX_WAYPOINTS cap. advanceHopWindow도 동일 정책 적용.
+  // passedIndex 기준 앞으로 최대 BL_MAX_WAYPOINTS개 waypoint까지만 OS 예약.
+  const windowEnd = Math.min(
+    passedIndex + windowSize,
+    passedIndex + BL_MAX_WAYPOINTS,
+    allTargets.length - 1,
+  );
   for (let hopIndex = passedIndex + 1; hopIndex <= windowEnd; hopIndex++) {
     if (existingHopIndexes.has(hopIndex)) continue;
     if (

--- a/src/features/alarm/utils/tripBoundScheduler.ts
+++ b/src/features/alarm/utils/tripBoundScheduler.ts
@@ -8,6 +8,7 @@ import type { AlarmType } from '../../../shared/types/alarm';
 import { isSameStationName, type Route } from '../../../shared/utils/stationRoute';
 import { HOP_TIME_MS } from '../../../shared/constants/boardingLock';
 import { TRIP_BOUND_ROUTE_SIG_KEY } from '../../../shared/constants/storageKeys';
+import { TBA_WINDOW_SIZE } from '../../../shared/constants/iosScheduledLimit';
 import { createLogger } from '../../../shared/utils/logger';
 import { recordScheduledAlarm } from './prescheduledMetrics';
 // #1357 (S1) — preschedule 진입 시 motion gate. silentPushTask와 같은 evaluateMovement 재사용.
@@ -43,14 +44,16 @@ const ALARM_CHANNEL_ID = 'station-alarm';
  * #918 A3 PR3 — rolling window 64 cap 회피용 윈도우 크기 (stop 단위).
  *
  * iOS는 앱당 pending local notification 64개 한도. 한 stop당 (early, imminent) 2개씩 예약되므로
- * `TRIPBOUND_WINDOW_SIZE * 2`가 tba: 채널이 OS 큐에서 점유하는 상한이다. 20 stop으로 둔 이유:
- *  - tba: 40개 + bl: 채널 6~8개(현재 windowSize 3 × 2 phase, 다음 leg 진입 시 일시적 중복 포함)
- *    + 시스템(silent push delivery 1~2건) ≈ 50개 — 64 cap 안쪽 안전 마진.
- *  - 평균 trip 길이(서울 1~9호선 30~40 stop) 대비 절반 이상 커버해, 사용자 통과 1회당 top-up 1회로
- *    rolling이 매끄럽게 진행된다 — 너무 작으면(예: 5) top-up이 매역 발생해 storage I/O 부담.
- *  - 64 cap에 너무 가까우면(예: 30) bl: 채널이 lock 전환기에 일시적으로 부풀 때 cap 초과 위험.
+ * `TRIPBOUND_WINDOW_SIZE * 2`가 tba: 채널이 OS 큐에서 점유하는 상한이다.
+ *
+ * #1757 (#1538 Sub 2) — TBA_WINDOW_SIZE(12 stop = TBA_QUOTA 24건 / 2 phase)로 변경.
+ * Sub 1 (#1756)에서 BL 채널이 Infinity window로 route 전체를 예약하게 되어 기존 20 stop 가정이
+ * 무효화됐다. iosScheduledLimit.ts의 quota 분배(BL 30 + TBA 24 + 버퍼 6 = 60)에 맞춰 조정.
+ * 이전 20 stop × 2 phase = 40건 → 12 stop × 2 phase = 24건.
+ *
+ * @see TBA_WINDOW_SIZE in iosScheduledLimit.ts
  */
-export const TRIPBOUND_WINDOW_SIZE = 20;
+export const TRIPBOUND_WINDOW_SIZE = TBA_WINDOW_SIZE;
 
 /**
  * 사전 예약 대상 단일 stop. lock-free — boarding lock 메타에 의존하지 않고,

--- a/src/shared/constants/__tests__/iosScheduledLimit.test.ts
+++ b/src/shared/constants/__tests__/iosScheduledLimit.test.ts
@@ -1,0 +1,67 @@
+import {
+  IOS_NOTIFICATION_HARD_LIMIT,
+  IOS_NOTIFICATION_SAFETY_BUFFER,
+  IOS_NOTIFICATION_USABLE_QUOTA,
+  BL_QUOTA,
+  TBA_QUOTA,
+  TBA_WINDOW_SIZE,
+  TRANSFER_QUOTA,
+  BL_MAX_WAYPOINTS,
+} from '../iosScheduledLimit';
+
+describe('iosScheduledLimit (#1757, #1538 Sub 2)', () => {
+  it('iOS 한도 상수는 Apple 문서 기준 64', () => {
+    expect(IOS_NOTIFICATION_HARD_LIMIT).toBe(64);
+  });
+
+  it('safety buffer는 4', () => {
+    expect(IOS_NOTIFICATION_SAFETY_BUFFER).toBe(4);
+  });
+
+  it('분배 가능 quota = 한도 - 버퍼', () => {
+    expect(IOS_NOTIFICATION_USABLE_QUOTA).toBe(
+      IOS_NOTIFICATION_HARD_LIMIT - IOS_NOTIFICATION_SAFETY_BUFFER,
+    );
+    expect(IOS_NOTIFICATION_USABLE_QUOTA).toBe(60);
+  });
+
+  it('BL_QUOTA + TBA_QUOTA + TRANSFER_QUOTA = 분배 가능 quota', () => {
+    expect(BL_QUOTA + TBA_QUOTA + TRANSFER_QUOTA).toBe(IOS_NOTIFICATION_USABLE_QUOTA);
+  });
+
+  it('BL_QUOTA는 30', () => {
+    expect(BL_QUOTA).toBe(30);
+  });
+
+  it('TBA_QUOTA는 24', () => {
+    expect(TBA_QUOTA).toBe(24);
+  });
+
+  it('TRANSFER_QUOTA는 나머지 6', () => {
+    expect(TRANSFER_QUOTA).toBe(6);
+  });
+
+  it('TBA_WINDOW_SIZE = TBA_QUOTA / 2 (stop 단위 환산)', () => {
+    expect(TBA_WINDOW_SIZE).toBe(TBA_QUOTA / 2);
+    expect(TBA_WINDOW_SIZE).toBe(12);
+  });
+
+  it('BL_MAX_WAYPOINTS = BL_QUOTA / 2 (waypoint 단위 환산)', () => {
+    expect(BL_MAX_WAYPOINTS).toBe(BL_QUOTA / 2);
+    expect(BL_MAX_WAYPOINTS).toBe(15);
+  });
+
+  it('BL_MAX_WAYPOINTS × 2 phase ≤ BL_QUOTA (OS 예약 건수 초과 불가)', () => {
+    expect(BL_MAX_WAYPOINTS * 2).toBeLessThanOrEqual(BL_QUOTA);
+  });
+
+  it('TBA_WINDOW_SIZE × 2 phase ≤ TBA_QUOTA (OS 예약 건수 초과 불가)', () => {
+    expect(TBA_WINDOW_SIZE * 2).toBeLessThanOrEqual(TBA_QUOTA);
+  });
+
+  it('모든 채널 합산 × 2 phase ≤ IOS_NOTIFICATION_HARD_LIMIT', () => {
+    const maxNotifications =
+      BL_MAX_WAYPOINTS * 2 + TBA_WINDOW_SIZE * 2 + TRANSFER_QUOTA;
+    expect(maxNotifications).toBeLessThanOrEqual(IOS_NOTIFICATION_HARD_LIMIT);
+  });
+});

--- a/src/shared/constants/iosScheduledLimit.ts
+++ b/src/shared/constants/iosScheduledLimit.ts
@@ -1,0 +1,80 @@
+/**
+ * iOS pending local notification 64개 한도 분배 상수 (#1757, #1538 Sub 2).
+ *
+ * Sub 1 (#1756)에서 boardingLockScheduler.DEFAULT_WINDOW_SIZE를 Infinity로 변경해
+ * BL 채널이 route 전체를 사전 예약 — 64 한도 초과 위험. 본 상수로 채널별 quota를 고정한다.
+ *
+ * 분배 근거:
+ *   iOS 한도:           64
+ *   safety buffer:       4  (silent push delivery 1~2건 + 시스템 여유)
+ *   분배 가능:          60
+ *
+ *   BL (boardingLock):  30  — lock 활성 시 destination + 환승 all waypoint × 2 phase.
+ *                            서울 최장 노선(9호선 급행 38 stop) 기준 waypoint 수는 소수.
+ *                            직접 destination: 1 waypoint × 2 = 2건.
+ *                            1환승: 2 waypoints × 2 = 4건.
+ *                            다환승(3~4): 4~5 waypoints × 2 = 8~10건.
+ *                            30으로 다환승 ~ 종점까지 여유 보유.
+ *   TBA (trip-bound):   24  — lockless / lock 미확정 시 역 시퀀스 × 2 phase rolling window.
+ *                            기존 TRIPBOUND_WINDOW_SIZE=20 → 12 stop × 2 = 24건.
+ *                            BL 활성 후 tba: cancel이 발생하지만 양 채널 동시 존재 과도기 허용.
+ *   TRANSFER (예비):     6  — 환승 직후 leg 전환 과도기 중복 허용 버퍼.
+ *                            BL + TBA 각각 다음 window로 채우는 순간 일시적 중복 최대 6건.
+ *
+ *   합계: 30 + 24 + 6 = 60 ≤ 60 (buffer 포함 총 64).
+ *
+ * 채널별 적용:
+ *   - BL_QUOTA: scheduleHopsForLock / advanceHopWindow의 window 상한.
+ *               DEFAULT_WINDOW_SIZE=Infinity 는 유지 — advance 로직의 "route 끝까지" 의미.
+ *               실제 OS 예약 수는 본 quota로 cap.
+ *   - TBA_QUOTA: prescheduleStationAlerts의 windowSize 기본값으로 대체.
+ *                기존 TRIPBOUND_WINDOW_SIZE=20 stop × 2 phase = 40건이었으나
+ *                quota 12 stop × 2 phase = 24건으로 조정.
+ *   - TRANSFER_QUOTA: 과도기 버퍼. 현재 코드에서 채널로 예약되지 않고 BL/TBA margin 내에 흡수됨.
+ *                     향후 환승 전용 채널 도입 시 사용 예정 (현재는 문서화/측정용).
+ */
+
+/** iOS pending notification 절대 한도. */
+export const IOS_NOTIFICATION_HARD_LIMIT = 64;
+
+/** 시스템 여유 + silent push delivery용 buffer. */
+export const IOS_NOTIFICATION_SAFETY_BUFFER = 4;
+
+/** 앱이 사용 가능한 분배 가능 quota 합계. */
+export const IOS_NOTIFICATION_USABLE_QUOTA = IOS_NOTIFICATION_HARD_LIMIT - IOS_NOTIFICATION_SAFETY_BUFFER;
+
+/**
+ * boardingLock 채널 (bl:) OS 예약 최대 건수.
+ * scheduleHopsForLock / advanceHopWindow 내 실제 예약 건수 상한.
+ * 2 phase(early+imminent) × waypoint 수이므로 waypoint 기준 15 stop에 해당.
+ */
+export const BL_QUOTA = 30;
+
+/**
+ * trip-bound 채널 (tba:) OS 예약 최대 건수.
+ * prescheduleStationAlerts의 windowSize 기본값으로 사용.
+ * 2 phase(early+imminent) × 12 stop = 24건.
+ *
+ * @see TBA_WINDOW_SIZE — stop 단위 환산값 (TBA_QUOTA / 2).
+ */
+export const TBA_QUOTA = 24;
+
+/**
+ * TBA_QUOTA를 stop 개수로 환산 (각 stop에 2 phase 예약).
+ * prescheduleStationAlerts의 windowSize 파라미터는 stop 단위이므로 이 값을 넘긴다.
+ */
+export const TBA_WINDOW_SIZE = TBA_QUOTA / 2; // 12
+
+/**
+ * 환승 leg 전환 과도기 중복 버퍼.
+ * 현재는 BL + TBA margin 내에서 흡수되며 별도 채널로 예약되지 않는다.
+ * 향후 환승 전용 채널 도입 시 명시 적용 예정.
+ */
+export const TRANSFER_QUOTA = IOS_NOTIFICATION_USABLE_QUOTA - BL_QUOTA - TBA_QUOTA; // 6
+
+/**
+ * BL_QUOTA를 waypoint 개수로 환산 (각 waypoint에 2 phase 예약).
+ * scheduleHopsForLock / advanceHopWindow 의 lastIdx cap에 사용.
+ * 각 hop이 최대 2건(early + imminent)을 OS 큐에 push하므로 BL_QUOTA / 2 = 15.
+ */
+export const BL_MAX_WAYPOINTS = BL_QUOTA / 2; // 15


### PR DESCRIPTION
## Summary

Closes #1757

Sub 1 (#1756)에서 `boardingLockScheduler.DEFAULT_WINDOW_SIZE = Infinity`로 변경해 BL 채널이 route 전체를 OS 예약 → iOS 64 한도 초과 가능. 본 PR에서 채널별 quota를 상수화하고 cap을 적용한다.

- `src/shared/constants/iosScheduledLimit.ts` 신설: `BL_QUOTA=30 / TBA_QUOTA=24 / TRANSFER_QUOTA=6 / 합계 60` (safety buffer 4 포함 총 64)
- `TRIPBOUND_WINDOW_SIZE`: 20 stop → `TBA_WINDOW_SIZE=12` stop (TBA_QUOTA 24건 기반)
- `scheduleHopsForLock` / `advanceHopWindow`: `BL_MAX_WAYPOINTS=15` cap 추가 (`DEFAULT_WINDOW_SIZE=Infinity` 유지 + OS 예약 상한 제어 분리)
- `iosScheduledLimit.test.ts` 신설: quota 합산 / stop 환산 / 2 phase 초과 불가 12개 assertion

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` 0 orphan. 신규 export(`iosScheduledLimit.ts`)는 `tripBoundScheduler.ts`, `boardingLockScheduler.ts`가 import.
2. **V/X dashboard** — 알람 예약 건수는 DebugModal의 scheduled notifications dump에서 관측 가능. 64 초과 시 OS silent drop이 없어짐.
3. **의존 PR** — Sub 1 #1756 (feat/#1756-boarding-lock-window-unlimited) 머지 선행 필요 → 이미 머지됨.
4. **측정 plan** — 실기기 trip 1회: DebugModal scheduled count ≤ 60 확인 + iOS 64 초과 OS drop 없음.
5. **Device verify** — N/A — type + unit only (quota 상수 + cap 로직, runtime native 불필요).