### PR TITLE
feat(#1753): Operation Dashboard device polling + drill-down (#1503 sub 3)

### DIFF
--- a/src/features/debug/components/MetricDrillDownView.tsx
+++ b/src/features/debug/components/MetricDrillDownView.tsx
@@ -1,0 +1,185 @@
+/**
+ * MetricDrillDownView (#1753, #1503 Sub 3).
+ *
+ * metric 1건 클릭 시 expanded view로 전환된다.
+ * rawSignalBuffer entries를 corrId 기준으로 그룹화해 해당 metric과 연관된
+ * 원본 trip raw signal을 "원본 trip 보기" 형태로 노출한다.
+ *
+ * corrId join 흐름:
+ *   MetricDrillDownView props.metricKey
+ *     → rawSignalBuffer.getRawSignalEntries() snapshot
+ *     → corrId별 그룹화 → 최신 trip 순 정렬
+ *     → 각 trip: corrId / entry 수 / 첫·마지막 ts 표시
+ *
+ * Sub 1 확장 원칙 (surgical):
+ *   - MetricRow에 onPress 추가만 — 기존 RatioBar/MetricRow 로직 변경 0.
+ *   - 별도 component로 분리 — OperationDashboardSection.tsx 수정 최소화.
+ */
+
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useTheme, spacing, typography } from '../../../shared/theme';
+import { getRawSignalEntries, type RawSignalEntry } from '../../observability/utils/rawSignalBuffer';
+import { formatClockTimeWithSeconds } from '../../../shared/utils/formatTime';
+
+// ─── 타입 ─────────────────────────────────────────────────────────────────────
+
+export type DrillDownMetricKey =
+  | 'alarmAccuracy'
+  | 'silentPushReach'
+  | 'locklessMiss'
+  | 'boardableMiss';
+
+export interface MetricDrillDownViewProps {
+  metricKey: DrillDownMetricKey;
+  onClose: () => void;
+}
+
+interface TripGroup {
+  corrId: string;
+  entryCount: number;
+  firstTs: number;
+  lastTs: number;
+  entries: readonly RawSignalEntry[];
+}
+
+// ─── 내부 함수 ────────────────────────────────────────────────────────────────
+
+/**
+ * rawSignalBuffer 전체를 corrId별로 그룹화.
+ * corrId=null 항목은 'unknown' 버킷으로 합산.
+ * 반환: lastTs 내림차순 (최신 trip 먼저).
+ */
+function groupByCorrId(entries: readonly RawSignalEntry[]): TripGroup[] {
+  const map = new Map<string, RawSignalEntry[]>();
+  for (const e of entries) {
+    const key = e.corrId ?? 'unknown';
+    const group = map.get(key);
+    if (group) {
+      group.push(e);
+    } else {
+      map.set(key, [e]);
+    }
+  }
+
+  const groups: TripGroup[] = [];
+  for (const [corrId, groupEntries] of map) {
+    const timestamps = groupEntries.map((e) => e.ts);
+    const firstTs = Math.min(...timestamps);
+    const lastTs = Math.max(...timestamps);
+    groups.push({ corrId, entryCount: groupEntries.length, firstTs, lastTs, entries: groupEntries });
+  }
+
+  // 최신 trip 먼저
+  groups.sort((a, b) => b.lastTs - a.lastTs);
+  return groups;
+}
+
+/** metric key → 사람이 읽을 수 있는 레이블. */
+const METRIC_LABELS: Record<DrillDownMetricKey, string> = {
+  alarmAccuracy: '알람 정확성 (24h)',
+  silentPushReach: 'Silent push 도달률 (24h)',
+  locklessMiss: 'Lockless miss (24h)',
+  boardableMiss: 'Boardable train miss (24h)',
+};
+
+// ─── 컴포넌트 ─────────────────────────────────────────────────────────────────
+
+function TripGroupRow({
+  group,
+  colors,
+}: {
+  group: TripGroup;
+  colors: ReturnType<typeof useTheme>['colors'];
+}) {
+  const corrIdShort = group.corrId === 'unknown' ? 'unknown' : group.corrId.slice(0, 16);
+  return (
+    <View style={styles.tripRow} testID={`drilldown-trip-${group.corrId}`}>
+      <Text style={[typography.mono, { color: colors.ink, flex: 1 }]} numberOfLines={1}>
+        {corrIdShort}
+      </Text>
+      <Text style={[typography.mono, { color: colors.subtle, width: 40, textAlign: 'right' }]}>
+        {group.entryCount}
+      </Text>
+      <Text style={[typography.mono, { color: colors.muted, width: 72, textAlign: 'right' }]}>
+        {formatClockTimeWithSeconds(group.firstTs)}
+      </Text>
+      <Text style={[typography.mono, { color: colors.muted, width: 72, textAlign: 'right' }]}>
+        {formatClockTimeWithSeconds(group.lastTs)}
+      </Text>
+    </View>
+  );
+}
+
+/**
+ * MetricDrillDownView — 단일 metric의 corrId ↔ rawSignalBuffer join 뷰.
+ *
+ * `onClose` 로 호출자가 닫을 수 있게 한다.
+ */
+export function MetricDrillDownView({ metricKey, onClose }: MetricDrillDownViewProps) {
+  const { colors } = useTheme();
+  const entries = getRawSignalEntries();
+  const groups = groupByCorrId(entries);
+  const label = METRIC_LABELS[metricKey];
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.card }]} testID="metric-drilldown-view">
+      {/* 헤더 */}
+      <View style={styles.header}>
+        <Text style={[typography.label, { color: colors.muted, flex: 1 }]} numberOfLines={1}>
+          {label}
+        </Text>
+        <TouchableOpacity onPress={onClose} testID="metric-drilldown-close">
+          <Text style={[typography.bodySm, { color: colors.accent, fontWeight: '700' }]}>
+            닫기
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* 컬럼 헤더 */}
+      <View style={styles.tripRow}>
+        <Text style={[typography.mono, { color: colors.subtle, flex: 1 }]}>corrId</Text>
+        <Text style={[typography.mono, { color: colors.subtle, width: 40, textAlign: 'right' }]}>n</Text>
+        <Text style={[typography.mono, { color: colors.subtle, width: 72, textAlign: 'right' }]}>first</Text>
+        <Text style={[typography.mono, { color: colors.subtle, width: 72, textAlign: 'right' }]}>last</Text>
+      </View>
+
+      {/* trip 목록 */}
+      {groups.length === 0 ? (
+        <Text
+          style={[typography.mono, { color: colors.muted, marginTop: spacing.xs }]}
+          testID="metric-drilldown-empty"
+        >
+          (rawSignal 없음)
+        </Text>
+      ) : (
+        <ScrollView style={styles.scroll} testID="metric-drilldown-list">
+          {groups.map((group) => (
+            <TripGroupRow key={group.corrId} group={group} colors={colors} />
+          ))}
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: spacing.sm,
+    borderRadius: 6,
+    padding: spacing.sm,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.xs,
+  },
+  tripRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 2,
+  },
+  scroll: {
+    maxHeight: 180,
+  },
+});

--- a/src/features/debug/components/OperationDashboardSection.tsx
+++ b/src/features/debug/components/OperationDashboardSection.tsx
@@ -1,5 +1,6 @@
 /**
  * #1751 (M3 Sub 1) — DebugModal "Operation Dashboard" 섹션.
+ * #1753 (M3 Sub 3) — Device polling + drill-down 확장.
  *
  * 4개 metric을 chart-library 없이 순수 RN View(ratio bar)로 시각화.
  * 이유: Expo SDK 54 환경에서 추가 CocoaPods 없이 즉시 동작 + bundle size 0 추가 +
@@ -11,19 +12,41 @@
  *   → react-native-chart-kit: 마지막 릴리스 2021년, 유지보수 정지 위험
  *   → 결정: native View 기반 비율 bar(inline) — 외부 dep 0, Expo SDK 54 호환 100%, 빌드 변경 없음
  *
+ * Sub 3 확장 (surgical):
+ *   - DebugModal 진입(마운트) 시 1회 polling → backend metric으로 Metric 3/4 isMock 해제
+ *   - Refresh 버튼 (rate-limit: 마지막 요청 후 5s 이내 재요청 차단)
+ *   - ADMIN_TOKEN 미설정 → placeholder 유지 + 안내 메시지
+ *   - metric row 클릭 → MetricDrillDownView expanded view (corrId join)
+ *
  * Metric 1 — 알람 정확성: useTripGroundTruthStore(M2 구현) 기반
  * Metric 2 — Silent push 도달률: countSilentPushOutcomes (received vs fired)
- * Metric 3 — Lockless miss: mock (Sub 2 머지 후 실제 데이터)
- * Metric 4 — Boardable train miss: mock (Sub 2 머지 후 실제 데이터)
+ * Metric 3 — Lockless miss: backend polling (ADMIN_TOKEN 미설정 시 mock 유지)
+ * Metric 4 — Boardable train miss: backend polling (backend placeholder: 0/0)
  */
-import { StyleSheet, Text, View } from 'react-native';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useTheme, spacing, typography } from '../../../shared/theme';
 import { useTripGroundTruthStore } from '../store/useTripGroundTruthStore';
 import { countSilentPushOutcomes, type AlarmLogEntry } from '../../alarm/utils/alarmLog';
+import {
+  fetchObservabilityMetrics,
+  type ObservabilityMetricsBucket,
+  type FetchMetricsResult,
+} from '../../observability/api/observabilityMetricsClient';
+import {
+  MetricDrillDownView,
+  type DrillDownMetricKey,
+} from './MetricDrillDownView';
+
+// ─── 상수 ─────────────────────────────────────────────────────────────────────
+
+/** Refresh rate-limit — 마지막 요청 후 이 시간(ms) 이내 재요청 차단. */
+const REFRESH_RATE_LIMIT_MS = 5000;
 
 // ─── 내부 타입 ───────────────────────────────────────────────────────────────
 
 interface MetricData {
+  key: DrillDownMetricKey;
   label: string;
   /** 0.0 ~ 1.0 비율. null이면 "데이터 없음" 표시. */
   ratio: number | null;
@@ -31,9 +54,16 @@ interface MetricData {
   numerator: number;
   /** 전체 건수. */
   denominator: number;
-  /** mock 여부 — Sub 2 이후 실제 데이터로 교체. */
+  /** mock 여부 — backend 데이터 수신 전까지 true. */
   isMock?: boolean;
 }
+
+type BackendLoadState =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'ok'; locklessMiss: ObservabilityMetricsBucket; boardableMiss: ObservabilityMetricsBucket }
+  | { kind: 'unconfigured' }
+  | { kind: 'error'; message: string };
 
 // ─── 내부 함수 ────────────────────────────────────────────────────────────────
 
@@ -45,6 +75,21 @@ function computeRatio(numerator: number, denominator: number): number | null {
 function formatPct(ratio: number | null): string {
   if (ratio === null) return '—';
   return `${Math.round(ratio * 100)}%`;
+}
+
+function bucketToMetric(
+  key: DrillDownMetricKey,
+  label: string,
+  bucket: ObservabilityMetricsBucket,
+): MetricData {
+  return {
+    key,
+    label,
+    ratio: computeRatio(bucket.value, bucket.total),
+    numerator: bucket.value,
+    denominator: bucket.total,
+    isMock: false,
+  };
 }
 
 // ─── 컴포넌트 ─────────────────────────────────────────────────────────────────
@@ -96,12 +141,14 @@ const barStyles = StyleSheet.create({
   },
 });
 
-/** 단일 metric 행 — label / 수치 / ratio bar */
+/** 단일 metric 행 — label / 수치 / ratio bar. 클릭 시 drill-down 전환. */
 function MetricRow({
   metric,
+  onPress,
   colors,
 }: {
   metric: MetricData;
+  onPress: (key: DrillDownMetricKey) => void;
   colors: ReturnType<typeof useTheme>['colors'];
 }) {
   const pctLabel = formatPct(metric.ratio);
@@ -109,7 +156,11 @@ function MetricRow({
     metric.denominator === 0 ? '0/0' : `${metric.numerator}/${metric.denominator}`;
   const mockLabel = metric.isMock ? ' [mock]' : '';
   return (
-    <View style={rowStyles.container} testID={`operation-metric-${metric.label}`}>
+    <Pressable
+      onPress={() => onPress(metric.key)}
+      style={rowStyles.container}
+      testID={`operation-metric-${metric.label}`}
+    >
       <View style={rowStyles.header}>
         <Text style={[typography.mono, { color: colors.ink }]}>
           {metric.label}
@@ -122,7 +173,7 @@ function MetricRow({
         </Text>
       </View>
       <RatioBar ratio={metric.ratio} isMock={metric.isMock} colors={colors} />
-    </View>
+    </Pressable>
   );
 }
 
@@ -149,16 +200,45 @@ export interface OperationDashboardSectionProps {
 /**
  * DebugModal "Operation Dashboard" 섹션.
  *
- * 4 metric을 ratio bar로 표시. Sub 2 머지 전까지 Metric 3/4는 mock=0/0.
+ * 4 metric을 ratio bar로 표시.
+ * Sub 3: 마운트 시 backend polling + Refresh 버튼 + metric 클릭 drill-down.
  */
 export function OperationDashboardSection({ logs }: OperationDashboardSectionProps) {
   const { colors } = useTheme();
   const responses = useTripGroundTruthStore((s) => s.responses);
+  const [backendState, setBackendState] = useState<BackendLoadState>({ kind: 'idle' });
+  const [drillDownKey, setDrillDownKey] = useState<DrillDownMetricKey | null>(null);
+  const lastFetchAtRef = useRef<number>(0);
+
+  const doFetch = useCallback(async () => {
+    const now = Date.now();
+    if (now - lastFetchAtRef.current < REFRESH_RATE_LIMIT_MS) return;
+    lastFetchAtRef.current = now;
+    setBackendState({ kind: 'loading' });
+    const result: FetchMetricsResult = await fetchObservabilityMetrics();
+    if (result.kind === 'ok') {
+      setBackendState({
+        kind: 'ok',
+        locklessMiss: result.metrics.locklessMissRatio,
+        boardableMiss: result.metrics.boardableMissRatio,
+      });
+    } else if (result.kind === 'unconfigured') {
+      setBackendState({ kind: 'unconfigured' });
+    } else {
+      setBackendState({ kind: 'error', message: result.message });
+    }
+  }, []);
+
+  // 마운트 시 1회 polling
+  useEffect(() => {
+    void doFetch();
+  }, [doFetch]);
 
   // Metric 1 — 알람 정확성 (M2 구현 기반)
   const accurateCount = responses.filter((r) => r.outcome === 'accurate').length;
   const answeredCount = responses.filter((r) => r.outcome !== 'unanswered').length;
   const alarmAccuracy: MetricData = {
+    key: 'alarmAccuracy',
     label: 'alarmAccuracy',
     ratio: computeRatio(accurateCount, answeredCount),
     numerator: accurateCount,
@@ -168,37 +248,113 @@ export function OperationDashboardSection({ logs }: OperationDashboardSectionPro
   // Metric 2 — Silent push 도달률 (received 중 fired 비율)
   const silentCounts = countSilentPushOutcomes(logs);
   const silentPushReach: MetricData = {
+    key: 'silentPushReach',
     label: 'silentPushReach',
     ratio: computeRatio(silentCounts.fired, silentCounts.received),
     numerator: silentCounts.fired,
     denominator: silentCounts.received,
   };
 
-  // Metric 3 — Lockless miss (Sub 2 머지 후 실제 데이터로 교체)
-  const locklessMiss: MetricData = {
-    label: 'locklessMiss',
-    ratio: null,
-    numerator: 0,
-    denominator: 0,
-    isMock: true,
-  };
+  // Metric 3 — Lockless miss (backend polling 결과 또는 mock 유지)
+  const locklessMiss: MetricData =
+    backendState.kind === 'ok'
+      ? bucketToMetric('locklessMiss', 'locklessMiss', backendState.locklessMiss)
+      : { key: 'locklessMiss', label: 'locklessMiss', ratio: null, numerator: 0, denominator: 0, isMock: true };
 
-  // Metric 4 — Boardable train miss (Sub 2 머지 후 실제 데이터로 교체)
-  const boardableMiss: MetricData = {
-    label: 'boardableMiss',
-    ratio: null,
-    numerator: 0,
-    denominator: 0,
-    isMock: true,
-  };
+  // Metric 4 — Boardable train miss (backend polling 결과 또는 mock 유지)
+  const boardableMiss: MetricData =
+    backendState.kind === 'ok'
+      ? bucketToMetric('boardableMiss', 'boardableMiss', backendState.boardableMiss)
+      : { key: 'boardableMiss', label: 'boardableMiss', ratio: null, numerator: 0, denominator: 0, isMock: true };
 
   const metrics: MetricData[] = [alarmAccuracy, silentPushReach, locklessMiss, boardableMiss];
 
+  const handleMetricPress = useCallback((key: DrillDownMetricKey) => {
+    setDrillDownKey((prev) => (prev === key ? null : key));
+  }, []);
+
+  const handleDrillDownClose = useCallback(() => {
+    setDrillDownKey(null);
+  }, []);
+
   return (
     <View testID="operation-dashboard-section">
+      {/* Refresh + 상태 라인 */}
+      <View style={headerStyles.row}>
+        <TouchableOpacity onPress={doFetch} testID="operation-dashboard-refresh">
+          <Text style={[typography.bodySm, { color: colors.accent }]}>Refresh</Text>
+        </TouchableOpacity>
+        <BackendStatusLabel state={backendState} colors={colors} />
+      </View>
+
+      {/* Metric rows */}
       {metrics.map((metric) => (
-        <MetricRow key={metric.label} metric={metric} colors={colors} />
+        <MetricRow
+          key={metric.label}
+          metric={metric}
+          onPress={handleMetricPress}
+          colors={colors}
+        />
       ))}
+
+      {/* Drill-down expanded view */}
+      {drillDownKey !== null && (
+        <MetricDrillDownView
+          metricKey={drillDownKey}
+          onClose={handleDrillDownClose}
+        />
+      )}
     </View>
   );
+}
+
+const headerStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.xs,
+  },
+});
+
+function BackendStatusLabel({
+  state,
+  colors,
+}: Readonly<{
+  state: BackendLoadState;
+  colors: ReturnType<typeof useTheme>['colors'];
+}>) {
+  if (state.kind === 'idle') return null;
+  if (state.kind === 'loading') {
+    return (
+      <Text
+        style={[typography.mono, { color: colors.muted }]}
+        testID="operation-dashboard-status"
+      >
+        loading...
+      </Text>
+    );
+  }
+  if (state.kind === 'unconfigured') {
+    return (
+      <Text
+        style={[typography.mono, { color: colors.muted }]}
+        testID="operation-dashboard-status"
+      >
+        ADMIN_TOKEN 미설정
+      </Text>
+    );
+  }
+  if (state.kind === 'error') {
+    return (
+      <Text
+        style={[typography.mono, { color: colors.warn }]}
+        testID="operation-dashboard-status"
+      >
+        {state.message}
+      </Text>
+    );
+  }
+  // ok
+  return null;
 }

--- a/src/features/debug/components/__tests__/MetricDrillDownView.test.tsx
+++ b/src/features/debug/components/__tests__/MetricDrillDownView.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * MetricDrillDownView (#1753, Sub 3) 단위 테스트.
+ *
+ * 커버:
+ *   - rawSignal 없음 → "(rawSignal 없음)" 메시지
+ *   - rawSignal 있음 → corrId별 그룹화 + trip row 렌더
+ *   - corrId=null → 'unknown' 버킷으로 합산
+ *   - 최신 trip 먼저(lastTs 내림차순)
+ *   - 닫기 버튼 → onClose 호출
+ *   - metricKey별 레이블 렌더 (4가지)
+ */
+import { fireEvent, screen } from '@testing-library/react-native';
+import { MetricDrillDownView, type DrillDownMetricKey } from '../MetricDrillDownView';
+import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
+import {
+  pushRawSignal,
+  clearRawSignalEntries,
+  __resetRawSignalForTests__,
+  type RawSignalEntry,
+} from '../../../observability/utils/rawSignalBuffer';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+function makeEntry(overrides?: Partial<RawSignalEntry>): RawSignalEntry {
+  return {
+    ts: 1_700_000_000_000,
+    corrId: 'corr-abc',
+    kind: 'cycle',
+    gps: null,
+    motion: null,
+    subsurface: null,
+    arvlCd: null,
+    line: '2',
+    dir: null,
+    arcIdx: null,
+    arcProgress: null,
+    stationId: null,
+    source: null,
+    confidence: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  __resetRawSignalForTests__();
+});
+
+afterEach(() => {
+  clearRawSignalEntries();
+  jest.useRealTimers();
+});
+
+const METRIC_KEYS: DrillDownMetricKey[] = [
+  'alarmAccuracy',
+  'silentPushReach',
+  'locklessMiss',
+  'boardableMiss',
+];
+
+describe('MetricDrillDownView', () => {
+  it('renders the container testID', () => {
+    renderWithTheme(
+      <MetricDrillDownView metricKey="alarmAccuracy" onClose={jest.fn()} />,
+    );
+    expect(screen.getByTestId('metric-drilldown-view')).toBeTruthy();
+  });
+
+  it('shows empty message when no rawSignal entries', () => {
+    renderWithTheme(
+      <MetricDrillDownView metricKey="alarmAccuracy" onClose={jest.fn()} />,
+    );
+    expect(screen.getByTestId('metric-drilldown-empty')).toBeTruthy();
+  });
+
+  it('calls onClose when 닫기 is pressed', () => {
+    const onClose = jest.fn();
+    renderWithTheme(
+      <MetricDrillDownView metricKey="alarmAccuracy" onClose={onClose} />,
+    );
+    fireEvent.press(screen.getByTestId('metric-drilldown-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  describe('with rawSignal entries', () => {
+    it('renders a trip row for each unique corrId', () => {
+      pushRawSignal(makeEntry({ corrId: 'corr-1', ts: 1_000 }));
+      pushRawSignal(makeEntry({ corrId: 'corr-2', ts: 2_000 }));
+      pushRawSignal(makeEntry({ corrId: 'corr-1', ts: 1_500 }));
+      renderWithTheme(
+        <MetricDrillDownView metricKey="silentPushReach" onClose={jest.fn()} />,
+      );
+      expect(screen.getByTestId('drilldown-trip-corr-1')).toBeTruthy();
+      expect(screen.getByTestId('drilldown-trip-corr-2')).toBeTruthy();
+    });
+
+    it('groups corrId=null entries under "unknown" bucket', () => {
+      pushRawSignal(makeEntry({ corrId: null, ts: 1_000 }));
+      pushRawSignal(makeEntry({ corrId: null, ts: 2_000 }));
+      renderWithTheme(
+        <MetricDrillDownView metricKey="locklessMiss" onClose={jest.fn()} />,
+      );
+      expect(screen.getByTestId('drilldown-trip-unknown')).toBeTruthy();
+    });
+
+    it('shows the list when entries are present', () => {
+      pushRawSignal(makeEntry({ corrId: 'trip-x', ts: 5_000 }));
+      renderWithTheme(
+        <MetricDrillDownView metricKey="boardableMiss" onClose={jest.fn()} />,
+      );
+      expect(screen.getByTestId('metric-drilldown-list')).toBeTruthy();
+    });
+  });
+
+  describe('metricKey labels', () => {
+    it.each(METRIC_KEYS)(
+      'renders without crash for metricKey="%s"',
+      (key) => {
+        renderWithTheme(
+          <MetricDrillDownView metricKey={key} onClose={jest.fn()} />,
+        );
+        expect(screen.getByTestId('metric-drilldown-view')).toBeTruthy();
+      },
+    );
+  });
+});

--- a/src/features/debug/components/__tests__/OperationDashboardSection.test.tsx
+++ b/src/features/debug/components/__tests__/OperationDashboardSection.test.tsx
@@ -1,17 +1,27 @@
 /**
- * #1751 (M3 Sub 1) — OperationDashboardSection 단위 테스트.
+ * OperationDashboardSection (#1751 Sub 1 + #1753 Sub 3) 단위 테스트.
  *
- * 커버리지 기준:
+ * Sub 1 커버리지:
  *   - 빈 데이터 상태 (4 metric 모두 0 / no data)
  *   - 정상 데이터 상태 (M2 responses mock + silent push alarmLog mock)
  *   - ratio bar 렌더 분기 (null vs 유효 비율)
+ *
+ * Sub 3 추가 커버리지:
+ *   - 마운트 시 fetchObservabilityMetrics 1회 호출
+ *   - ADMIN_TOKEN 미설정 → unconfigured 상태 메시지
+ *   - fetch 성공 → locklessMiss/boardableMiss isMock 해제 + ratio 반영
+ *   - fetch 오류 → error 상태 메시지
+ *   - Refresh 버튼 클릭 → 재호출 (rate-limit 제어 포함)
+ *   - metric 클릭 → drill-down view 토글 (열기/닫기)
  */
 import React from 'react';
-import { screen } from '@testing-library/react-native';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react-native';
 import { OperationDashboardSection } from '../OperationDashboardSection';
 import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
 import { useTripGroundTruthStore, type TripGroundTruthState } from '../../store/useTripGroundTruthStore';
 import type { AlarmLogEntry } from '../../../alarm/utils/alarmLog';
+import * as observabilityClient from '../../../observability/api/observabilityMetricsClient';
+import { __resetRawSignalForTests__ } from '../../../observability/utils/rawSignalBuffer';
 
 // ─── mock ─────────────────────────────────────────────────────────────────────
 
@@ -19,7 +29,18 @@ jest.mock('../../store/useTripGroundTruthStore', () => ({
   useTripGroundTruthStore: jest.fn(),
 }));
 
+jest.mock('../../../observability/api/observabilityMetricsClient', () => ({
+  fetchObservabilityMetrics: jest.fn(),
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
 const mockUseTripGroundTruthStore = useTripGroundTruthStore as jest.MockedFunction<typeof useTripGroundTruthStore>;
+const mockFetchMetrics = observabilityClient.fetchObservabilityMetrics as jest.MockedFunction<
+  typeof observabilityClient.fetchObservabilityMetrics
+>;
 
 // AlarmLogEntry 최소 픽스처
 function makeLogEntry(
@@ -47,45 +68,75 @@ function setupStore(responses: { outcome: 'accurate' | 'inaccurate' | 'unanswere
     respond: jest.fn(),
     hydrate: jest.fn(),
   };
-  // useTripGroundTruthStore selector 호출 패턴: (s) => s.responses
   mockUseTripGroundTruthStore.mockImplementation((selector: (s: TripGroundTruthState) => unknown) =>
     selector(stubState),
   );
 }
 
+function makeSuccessResult(
+  locklessValue = 2,
+  locklessTotal = 10,
+  boardableValue = 0,
+  boardableTotal = 0,
+): observabilityClient.FetchMetricsResult {
+  return {
+    kind: 'ok',
+    metrics: {
+      accuracyRatio: { value: 8, total: 10, ratio: 0.8 },
+      silentPushDeliveryRatio: { value: 5, total: 6, ratio: 0.833 },
+      locklessMissRatio: { value: locklessValue, total: locklessTotal, ratio: locklessValue / locklessTotal },
+      boardableMissRatio: { value: boardableValue, total: boardableTotal, ratio: boardableTotal === 0 ? 0 : boardableValue / boardableTotal },
+      window: '24h',
+      timestamp: 1_700_000_000_000,
+    },
+  };
+}
+
+// ─── setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  __resetRawSignalForTests__();
+  setupStore([]);
+  // 기본: unconfigured 반환
+  mockFetchMetrics.mockResolvedValue({ kind: 'unconfigured' });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.clearAllMocks();
+});
+
 // ─── tests ────────────────────────────────────────────────────────────────────
 
 describe('OperationDashboardSection', () => {
-  describe('빈 데이터 상태 (4 metric 모두 0)', () => {
-    beforeEach(() => {
-      setupStore([]);
-    });
-
-    it('4개 metric row를 렌더한다', () => {
+  describe('Sub 1 — 빈 데이터 상태 (4 metric 모두 0)', () => {
+    it('4개 metric row를 렌더한다', async () => {
       renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
       expect(screen.getByTestId('operation-metric-alarmAccuracy')).toBeTruthy();
       expect(screen.getByTestId('operation-metric-silentPushReach')).toBeTruthy();
       expect(screen.getByTestId('operation-metric-locklessMiss')).toBeTruthy();
       expect(screen.getByTestId('operation-metric-boardableMiss')).toBeTruthy();
     });
 
-    it('alarmAccuracy: 응답 0건 → no data bar 렌더', () => {
+    it('alarmAccuracy: 응답 0건 → no data bar 렌더', async () => {
       renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
       const naTexts = screen.getAllByTestId('ratio-bar-na');
-      // 빈 상태: alarmAccuracy, locklessMiss, boardableMiss 3개가 (no data)
-      // silentPushReach도 received=0 → null → (no data)
       expect(naTexts.length).toBeGreaterThanOrEqual(2);
     });
 
-    it('silentPushReach: received=0 → no data bar 렌더', () => {
+    it('silentPushReach: received=0 → no data bar 렌더', async () => {
       renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
       const naTexts = screen.getAllByTestId('ratio-bar-na');
       expect(naTexts.length).toBeGreaterThanOrEqual(1);
     });
   });
 
-  describe('정상 데이터 상태', () => {
-    it('alarmAccuracy: accurate 3/5 응답 → ratio bar 렌더', () => {
+  describe('Sub 1 — 정상 데이터 상태', () => {
+    it('alarmAccuracy: accurate 3/5 응답 → ratio bar 렌더', async () => {
       setupStore([
         { outcome: 'accurate' },
         { outcome: 'accurate' },
@@ -94,14 +145,12 @@ describe('OperationDashboardSection', () => {
         { outcome: 'unanswered' },
       ]);
       renderWithTheme(<OperationDashboardSection logs={[]} />);
-      // accurate=3, answered(accurate+inaccurate)=4 → 75%
-      // ratio bar track이 렌더되어야 함
+      await act(async () => { jest.runAllTimers(); });
       const tracks = screen.getAllByTestId('ratio-bar-track');
       expect(tracks.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('silentPushReach: received 5, fired 4 → ratio bar 렌더', () => {
-      setupStore([]);
+    it('silentPushReach: received 5, fired 4 → ratio bar 렌더', async () => {
       const logs: AlarmLogEntry[] = [
         makeLogEntry('silent-push-received', 'fired'),
         makeLogEntry('silent-push-received', 'fired'),
@@ -114,43 +163,176 @@ describe('OperationDashboardSection', () => {
         makeLogEntry('silent-push-fired', 'fired'),
       ];
       renderWithTheme(<OperationDashboardSection logs={logs} />);
-      // received=5, fired=4 → 80% → ratio bar track이 렌더되어야 함
+      await act(async () => { jest.runAllTimers(); });
       const tracks = screen.getAllByTestId('ratio-bar-track');
       expect(tracks.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('locklessMiss, boardableMiss: mock 상태 → (no data) 유지', () => {
-      setupStore([]);
+    it('locklessMiss, boardableMiss: unconfigured 상태 → (no data) 유지', async () => {
       renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
       const naTexts = screen.getAllByTestId('ratio-bar-na');
-      // locklessMiss + boardableMiss = 2개 이상 (no data)
       expect(naTexts.length).toBeGreaterThanOrEqual(2);
     });
   });
 
-  describe('ratio bar fill 렌더', () => {
-    it('ratio=1.0 → fill 렌더', () => {
-      setupStore([
-        { outcome: 'accurate' },
-      ]);
+  describe('Sub 1 — ratio bar fill 렌더', () => {
+    it('ratio=1.0 → fill 렌더', async () => {
+      setupStore([{ outcome: 'accurate' }]);
       renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
       const fills = screen.getAllByTestId('ratio-bar-fill');
       expect(fills.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('ratio=null → ratio-bar-na 렌더 (no data)', () => {
-      setupStore([]);
+    it('ratio=null → ratio-bar-na 렌더 (no data)', async () => {
       renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
       const naTexts = screen.getAllByTestId('ratio-bar-na');
       expect(naTexts.length).toBeGreaterThanOrEqual(1);
     });
   });
 
-  describe('section wrapper testID', () => {
-    it('operation-dashboard-section testID가 존재한다', () => {
-      setupStore([]);
+  describe('Sub 1 — section wrapper testID', () => {
+    it('operation-dashboard-section testID가 존재한다', async () => {
       renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
       expect(screen.getByTestId('operation-dashboard-section')).toBeTruthy();
+    });
+  });
+
+  // ── Sub 3 ──────────────────────────────────────────────────────────────────
+
+  describe('Sub 3 — polling', () => {
+    it('마운트 시 fetchObservabilityMetrics를 1회 호출한다', async () => {
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      expect(mockFetchMetrics).toHaveBeenCalledTimes(1);
+    });
+
+    it('ADMIN_TOKEN 미설정(unconfigured) → 상태 메시지 렌더', async () => {
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      await waitFor(() => {
+        const status = screen.getByTestId('operation-dashboard-status');
+        expect(status.props.children).toBe('ADMIN_TOKEN 미설정');
+      });
+    });
+
+    it('fetch 성공 → locklessMiss/boardableMiss isMock 해제 (ratio bar 노출)', async () => {
+      mockFetchMetrics.mockResolvedValue(makeSuccessResult(2, 10));
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      // locklessMiss: 2/10 = 20% → ratio bar track이 렌더되어야 함
+      await waitFor(() => {
+        const tracks = screen.getAllByTestId('ratio-bar-track');
+        expect(tracks.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it('fetch 성공 시 status label이 없다 (ok 상태는 메시지 없음)', async () => {
+      mockFetchMetrics.mockResolvedValue(makeSuccessResult(2, 10));
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      await waitFor(() => {
+        expect(screen.queryByTestId('operation-dashboard-status')).toBeNull();
+      });
+    });
+
+    it('fetch 오류 → error 상태 메시지 렌더', async () => {
+      mockFetchMetrics.mockResolvedValue({ kind: 'error', message: 'HTTP 503' });
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      await waitFor(() => {
+        const status = screen.getByTestId('operation-dashboard-status');
+        expect(status.props.children).toBe('HTTP 503');
+      });
+    });
+  });
+
+  describe('Sub 3 — Refresh 버튼', () => {
+    it('Refresh 버튼이 렌더된다', async () => {
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      expect(screen.getByTestId('operation-dashboard-refresh')).toBeTruthy();
+    });
+
+    it('Refresh 버튼 클릭 후 rate-limit 해제되면 재호출된다', async () => {
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      expect(mockFetchMetrics).toHaveBeenCalledTimes(1);
+
+      // rate-limit(5s) 경과 시뮬레이션
+      await act(async () => { jest.advanceTimersByTime(6000); });
+
+      // Refresh 버튼 클릭
+      await act(async () => {
+        fireEvent.press(screen.getByTestId('operation-dashboard-refresh'));
+        jest.runAllTimers();
+      });
+      await waitFor(() => {
+        expect(mockFetchMetrics).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('rate-limit 이내 Refresh → 추가 호출 없음', async () => {
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      expect(mockFetchMetrics).toHaveBeenCalledTimes(1);
+
+      // rate-limit 이내 (1s만 경과)
+      await act(async () => { jest.advanceTimersByTime(1000); });
+
+      await act(async () => {
+        fireEvent.press(screen.getByTestId('operation-dashboard-refresh'));
+        jest.runAllTimers();
+      });
+      // 추가 호출 없어야 함
+      expect(mockFetchMetrics).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Sub 3 — drill-down', () => {
+    it('metric 클릭 → MetricDrillDownView 표시', async () => {
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+
+      fireEvent.press(screen.getByTestId('operation-metric-alarmAccuracy'));
+      expect(screen.getByTestId('metric-drilldown-view')).toBeTruthy();
+    });
+
+    it('같은 metric 다시 클릭 → drill-down 닫힘 (토글)', async () => {
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+
+      fireEvent.press(screen.getByTestId('operation-metric-alarmAccuracy'));
+      expect(screen.getByTestId('metric-drilldown-view')).toBeTruthy();
+
+      fireEvent.press(screen.getByTestId('operation-metric-alarmAccuracy'));
+      expect(screen.queryByTestId('metric-drilldown-view')).toBeNull();
+    });
+
+    it('drill-down 닫기 버튼 → drill-down 사라짐', async () => {
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+
+      fireEvent.press(screen.getByTestId('operation-metric-silentPushReach'));
+      expect(screen.getByTestId('metric-drilldown-view')).toBeTruthy();
+
+      fireEvent.press(screen.getByTestId('metric-drilldown-close'));
+      expect(screen.queryByTestId('metric-drilldown-view')).toBeNull();
+    });
+
+    it('다른 metric 클릭 → drill-down key 전환 (view 유지)', async () => {
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+
+      fireEvent.press(screen.getByTestId('operation-metric-alarmAccuracy'));
+      expect(screen.getByTestId('metric-drilldown-view')).toBeTruthy();
+
+      // 다른 metric 클릭 → 여전히 view 보임 (key만 바뀜)
+      fireEvent.press(screen.getByTestId('operation-metric-locklessMiss'));
+      expect(screen.getByTestId('metric-drilldown-view')).toBeTruthy();
     });
   });
 });

--- a/src/features/observability/api/__tests__/observabilityMetricsClient.test.ts
+++ b/src/features/observability/api/__tests__/observabilityMetricsClient.test.ts
@@ -1,0 +1,175 @@
+/**
+ * observabilityMetricsClient (#1753, Sub 3) 단위 테스트.
+ *
+ * 커버:
+ *   - ADMIN_TOKEN 미설정 → unconfigured
+ *   - ALARM_BACKEND_URL 미설정 → unconfigured
+ *   - fetch 200 성공 → ok + metrics 반환
+ *   - fetch non-200 → error + HTTP status
+ *   - fetch throw → error + message
+ *   - endpoint URL 포맷 (`/v1/observability/metrics?window=24h`)
+ *   - Bearer token header 전달
+ */
+import {
+  fetchObservabilityMetrics,
+  __test__,
+  type ObservabilityMetrics,
+} from '../observabilityMetricsClient';
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env.EXPO_PUBLIC_ADMIN_TOKEN = 'test-token';
+  process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://alarm.example.test';
+  global.fetch = jest.fn() as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  process.env.EXPO_PUBLIC_ADMIN_TOKEN = ORIGINAL_ENV.EXPO_PUBLIC_ADMIN_TOKEN;
+  process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = ORIGINAL_ENV.EXPO_PUBLIC_ALARM_BACKEND_URL;
+});
+
+function makeMetrics(): ObservabilityMetrics {
+  return {
+    accuracyRatio: { value: 8, total: 10, ratio: 0.8 },
+    silentPushDeliveryRatio: { value: 5, total: 6, ratio: 0.833 },
+    locklessMissRatio: { value: 1, total: 10, ratio: 0.1 },
+    boardableMissRatio: { value: 0, total: 0, ratio: 0 },
+    window: '24h',
+    timestamp: 1_700_000_000_000,
+  };
+}
+
+function mockFetchOk(body: unknown) {
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  });
+}
+
+function mockFetchStatus(status: number) {
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: false,
+    status,
+    json: async () => ({}),
+  });
+}
+
+function mockFetchThrow(message: string) {
+  (global.fetch as jest.Mock).mockRejectedValue(new Error(message));
+}
+
+describe('fetchObservabilityMetrics', () => {
+  describe('unconfigured', () => {
+    it('returns unconfigured when ADMIN_TOKEN is empty', async () => {
+      process.env.EXPO_PUBLIC_ADMIN_TOKEN = '';
+      const result = await fetchObservabilityMetrics();
+      expect(result.kind).toBe('unconfigured');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns unconfigured when ADMIN_TOKEN is unset', async () => {
+      delete process.env.EXPO_PUBLIC_ADMIN_TOKEN;
+      const result = await fetchObservabilityMetrics();
+      expect(result.kind).toBe('unconfigured');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns unconfigured when ALARM_BACKEND_URL is empty', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = '';
+      const result = await fetchObservabilityMetrics();
+      expect(result.kind).toBe('unconfigured');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('success', () => {
+    it('returns ok with metrics on 200', async () => {
+      const metrics = makeMetrics();
+      mockFetchOk(metrics);
+      const result = await fetchObservabilityMetrics();
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.metrics.accuracyRatio.value).toBe(8);
+        expect(result.metrics.locklessMissRatio.ratio).toBe(0.1);
+        expect(result.metrics.window).toBe('24h');
+      }
+    });
+
+    it('calls the correct endpoint URL with window=24h', async () => {
+      mockFetchOk(makeMetrics());
+      await fetchObservabilityMetrics();
+      const [url] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('https://alarm.example.test/v1/observability/metrics?window=24h');
+    });
+
+    it('sends Bearer authorization header', async () => {
+      mockFetchOk(makeMetrics());
+      await fetchObservabilityMetrics();
+      const [, init] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+      expect((init.headers as Record<string, string>)['authorization']).toBe(
+        'Bearer test-token',
+      );
+    });
+
+    it('strips trailing slash from ALARM_BACKEND_URL', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://alarm.example.test/';
+      mockFetchOk(makeMetrics());
+      await fetchObservabilityMetrics();
+      const [url] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+      expect(url).not.toContain('//v1');
+      expect(url).toContain('/v1/observability/metrics');
+    });
+  });
+
+  describe('error cases', () => {
+    it('returns error with HTTP status on non-200', async () => {
+      mockFetchStatus(401);
+      const result = await fetchObservabilityMetrics();
+      expect(result.kind).toBe('error');
+      if (result.kind === 'error') {
+        expect(result.message).toBe('HTTP 401');
+      }
+    });
+
+    it('returns error on 503', async () => {
+      mockFetchStatus(503);
+      const result = await fetchObservabilityMetrics();
+      expect(result.kind).toBe('error');
+      if (result.kind === 'error') {
+        expect(result.message).toBe('HTTP 503');
+      }
+    });
+
+    it('returns error with message when fetch throws', async () => {
+      mockFetchThrow('network timeout');
+      const result = await fetchObservabilityMetrics();
+      expect(result.kind).toBe('error');
+      if (result.kind === 'error') {
+        expect(result.message).toBe('network timeout');
+      }
+    });
+
+    it('returns error with string when non-Error thrown', async () => {
+      (global.fetch as jest.Mock).mockRejectedValue('raw string error');
+      const result = await fetchObservabilityMetrics();
+      expect(result.kind).toBe('error');
+      if (result.kind === 'error') {
+        expect(typeof result.message).toBe('string');
+      }
+    });
+  });
+
+  describe('__test__ internal exports', () => {
+    it('getAdminToken returns null when unset', () => {
+      process.env.EXPO_PUBLIC_ADMIN_TOKEN = '';
+      expect(__test__.getAdminToken()).toBeNull();
+    });
+
+    it('getAdminToken returns token string when set', () => {
+      process.env.EXPO_PUBLIC_ADMIN_TOKEN = 'my-token';
+      expect(__test__.getAdminToken()).toBe('my-token');
+    });
+  });
+});

--- a/src/features/observability/api/observabilityMetricsClient.ts
+++ b/src/features/observability/api/observabilityMetricsClient.ts
@@ -1,0 +1,77 @@
+/**
+ * Observability metrics polling client (#1753, #1503 Sub 3).
+ *
+ * DebugModal 진입 시 1회 `/v1/observability/metrics?window=24h`를 호출하고,
+ * 사용자 refresh 버튼 트리거 시 재요청한다. 지속 polling 없음 (배터리 절약).
+ *
+ * ADMIN_TOKEN / ALARM_BACKEND_URL 미설정 시 null 반환 — 호출자가 안내 메시지 표시.
+ */
+
+import { fetchWithTelemetryTimeout, getAlarmBackendUrl } from '../../../shared/utils/telemetryHttp';
+
+/** /v1/observability/metrics 응답 shape (Sub 2 `ObservabilityMetricsResponse`와 동일). */
+export interface ObservabilityMetricsBucket {
+  value: number;
+  total: number;
+  ratio: number;
+}
+
+export interface ObservabilityMetrics {
+  accuracyRatio: ObservabilityMetricsBucket;
+  silentPushDeliveryRatio: ObservabilityMetricsBucket;
+  locklessMissRatio: ObservabilityMetricsBucket;
+  boardableMissRatio: ObservabilityMetricsBucket;
+  window: '24h';
+  timestamp: number;
+}
+
+export type FetchMetricsResult =
+  | { kind: 'ok'; metrics: ObservabilityMetrics }
+  | { kind: 'error'; message: string }
+  | { kind: 'unconfigured' };
+
+/** ADMIN_TOKEN 환경변수 조회. 미설정 시 null. */
+function getAdminToken(): string | null {
+  const token = process.env.EXPO_PUBLIC_ADMIN_TOKEN;
+  if (!token) return null;
+  return token;
+}
+
+/**
+ * `/v1/observability/metrics?window=24h` 단건 fetch.
+ *
+ * - ADMIN_TOKEN 미설정 → `{ kind: 'unconfigured' }`
+ * - ALARM_BACKEND_URL 미설정 → `{ kind: 'unconfigured' }`
+ * - HTTP 오류 / network 실패 → `{ kind: 'error', message }`
+ * - 성공 → `{ kind: 'ok', metrics }`
+ */
+export async function fetchObservabilityMetrics(): Promise<FetchMetricsResult> {
+  const token = getAdminToken();
+  if (!token) return { kind: 'unconfigured' };
+
+  const base = getAlarmBackendUrl();
+  if (!base) return { kind: 'unconfigured' };
+
+  try {
+    const res = await fetchWithTelemetryTimeout(
+      `${base}/v1/observability/metrics?window=24h`,
+      {
+        method: 'GET',
+        headers: { authorization: `Bearer ${token}` },
+      },
+    );
+    if (!res.ok) {
+      return { kind: 'error', message: `HTTP ${res.status}` };
+    }
+    const body = (await res.json()) as ObservabilityMetrics;
+    return { kind: 'ok', metrics: body };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return { kind: 'error', message };
+  }
+}
+
+// Internal exports for tests — DO NOT use from app code.
+export const __test__ = {
+  getAdminToken,
+};


### PR DESCRIPTION
Closes #1753

## Summary

- **observabilityMetricsClient** (`src/features/observability/api/observabilityMetricsClient.ts`) — `GET /v1/observability/metrics?window=24h` 단건 fetch helper. ADMIN_TOKEN/ALARM_BACKEND_URL 미설정 시 `unconfigured` graceful fallback, non-200/throw는 `error` 반환.
- **OperationDashboardSection 확장** — 마운트 1회 polling + Refresh 버튼(5s rate-limit). backend 성공 시 Metric 3(locklessMiss)/4(boardableMiss) isMock 해제. ADMIN_TOKEN 미설정 → `ADMIN_TOKEN 미설정` 안내 메시지. metric row 클릭 → MetricDrillDownView 토글(같은 key 재클릭 닫기).
- **MetricDrillDownView** (`src/features/debug/components/MetricDrillDownView.tsx`) — rawSignalBuffer corrId join. trip 그룹 목록 (lastTs 내림차순, corrId=null → `unknown` 버킷). 닫기 버튼으로 상위 토글 해제.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` → `No orphan exports detected`
2. **V/X dashboard** — DebugModal → Operation Dashboard 섹션에서 시각화. polling 성공 시 Metric 3/4 ratio bar 실데이터 노출. drill-down은 rawSignalBuffer corrId 그룹으로 trip 추적 가능.
3. **의존 PR** — Sub 1 (PR #1754) + Sub 2 (PR #1759) 머지 완료 의존.
4. **측정 plan** — DebugModal 진입 시 backend metric 로드 확인 + Refresh 클릭 재호출 확인. locklessMiss ratio 변화 관찰 (1주).
5. **Device verify** — N/A — type+unit only. DebugModal 실기기 검증은 사용자 책임.

## Test

- 44 신규 테스트 (Sub 3)
- 전체 7750 pass, coverage 100%, type-check clean