### PR TITLE
feat(#1768): ack payload permissionMode 추가 + backend 권한별 도달률 집계

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1278,6 +1278,29 @@ describe('validatePushAck (#566 P2a)', () => {
       outcome: 'received',
     });
   });
+
+  describe('#1768 — permissionMode', () => {
+    it.each([
+      { mode: 'always' as const },
+      { mode: 'whileInUse' as const },
+      { mode: 'denied' as const },
+    ])('permissionMode=$mode → payload에 포함', ({ mode }) => {
+      const ack = validatePushAck({ pushId: 'p1', token: 'tok', outcome: 'received', permissionMode: mode });
+      expect(ack).toEqual({ pushId: 'p1', token: 'tok', outcome: 'received', permissionMode: mode });
+    });
+
+    it('permissionMode 누락(legacy) → payload에 포함 안 됨', () => {
+      const ack = validatePushAck({ pushId: 'p1', token: 'tok', outcome: 'received' });
+      expect(ack).toEqual({ pushId: 'p1', token: 'tok', outcome: 'received' });
+      expect(ack).not.toHaveProperty('permissionMode');
+    });
+
+    it('permissionMode 유효하지 않은 값 → payload에 포함 안 됨 (graceful 무시)', () => {
+      const ack = validatePushAck({ pushId: 'p1', token: 'tok', outcome: 'received', permissionMode: 'unknown-value' });
+      expect(ack).toEqual({ pushId: 'p1', token: 'tok', outcome: 'received' });
+      expect(ack).not.toHaveProperty('permissionMode');
+    });
+  });
 });
 
 describe('POST /push/ack (#566 P2a)', () => {
@@ -1398,6 +1421,34 @@ describe('POST /push/ack (#566 P2a)', () => {
       );
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ ok: true, stamped: false, reason: 'not-found' });
+    });
+
+    describe('#1768 — received ack에 permissionMode 포함 시 stamp에 저장', () => {
+      it('permissionMode=always → received stamp에 포함', async () => {
+        await kv.put(
+          pendingKey('p-pm'),
+          JSON.stringify({ pushId: 'p-pm', token: 'tok', stationName: '강남', phase: 'early' }),
+        );
+        const env = makeEnv({ PENDING_PUSHES: kv as unknown as KVNamespace });
+        await post('/push/ack', { pushId: 'p-pm', token: 'tok', outcome: 'received', permissionMode: 'always' }, env);
+        const raw = kv.store.get('received:p-pm');
+        expect(raw).toBeDefined();
+        const parsed = JSON.parse(raw!.value) as Record<string, unknown>;
+        expect(parsed.permissionMode).toBe('always');
+      });
+
+      it('permissionMode 누락(legacy) → stamp에 permissionMode 없음', async () => {
+        await kv.put(
+          pendingKey('p-noperm'),
+          JSON.stringify({ pushId: 'p-noperm', token: 'tok', stationName: '강남', phase: 'early' }),
+        );
+        const env = makeEnv({ PENDING_PUSHES: kv as unknown as KVNamespace });
+        await post('/push/ack', { pushId: 'p-noperm', token: 'tok', outcome: 'received' }, env);
+        const raw = kv.store.get('received:p-noperm');
+        expect(raw).toBeDefined();
+        const parsed = JSON.parse(raw!.value) as Record<string, unknown>;
+        expect(parsed.permissionMode).toBeUndefined();
+      });
     });
   });
 });

--- a/backend/alarm-worker/src/__tests__/pendingPushes.test.ts
+++ b/backend/alarm-worker/src/__tests__/pendingPushes.test.ts
@@ -252,5 +252,41 @@ describe('pendingPushes (#566 P2a)', () => {
     it('getReceivedStamp: kv === undefined면 null', async () => {
       expect(await getReceivedStamp(undefined, 'p1')).toBeNull();
     });
+
+    describe('#1768 — stampReceived permissionMode', () => {
+      it('permissionMode 전달 시 stamp에 포함된다', async () => {
+        await putPending(
+          kv as unknown as KVNamespace,
+          makeEntry({ pushId: 'p-pm', token: 'tok', stationName: '강남', phase: 'imminent' }),
+        );
+        await stampReceived(kv as unknown as KVNamespace, 'p-pm', 'tok', 1_700_000_000_000, 'always');
+        const raw = kv.store.get('received:p-pm');
+        expect(raw).toBeDefined();
+        const parsed = JSON.parse(raw!.value) as Record<string, unknown>;
+        expect(parsed.permissionMode).toBe('always');
+      });
+
+      it('permissionMode=whileInUse 전달 시 stamp에 포함된다', async () => {
+        await putPending(
+          kv as unknown as KVNamespace,
+          makeEntry({ pushId: 'p-wiu', token: 'tok', stationName: '강남', phase: 'imminent' }),
+        );
+        await stampReceived(kv as unknown as KVNamespace, 'p-wiu', 'tok', 1_700_000_000_000, 'whileInUse');
+        const raw = kv.store.get('received:p-wiu');
+        const parsed = JSON.parse(raw!.value) as Record<string, unknown>;
+        expect(parsed.permissionMode).toBe('whileInUse');
+      });
+
+      it('permissionMode 미전달(legacy) → stamp에 permissionMode 필드 없음', async () => {
+        await putPending(
+          kv as unknown as KVNamespace,
+          makeEntry({ pushId: 'p-legacy', token: 'tok', stationName: '강남', phase: 'imminent' }),
+        );
+        await stampReceived(kv as unknown as KVNamespace, 'p-legacy', 'tok', 1_700_000_000_000);
+        const raw = kv.store.get('received:p-legacy');
+        const parsed = JSON.parse(raw!.value) as Record<string, unknown>;
+        expect(parsed.permissionMode).toBeUndefined();
+      });
+    });
   });
 });

--- a/backend/alarm-worker/src/__tests__/pushAckStats.test.ts
+++ b/backend/alarm-worker/src/__tests__/pushAckStats.test.ts
@@ -14,10 +14,11 @@ function seedReceivedStamp(
   receivedAt: number,
   phase: string,
   stationName: string,
+  permissionMode?: 'always' | 'whileInUse' | 'denied',
 ): void {
-  kv.store.set(`received:${pushId}`, {
-    value: JSON.stringify({ pushId, receivedAt, stationName, phase }),
-  });
+  const entry: Record<string, unknown> = { pushId, receivedAt, stationName, phase };
+  if (permissionMode !== undefined) entry.permissionMode = permissionMode;
+  kv.store.set(`received:${pushId}`, { value: JSON.stringify(entry) });
 }
 
 function seedPending(kv: InMemoryKV, pushId: string): void {
@@ -34,6 +35,7 @@ describe('computePushAckStats', () => {
     expect(stats.pending).toBe(0);
     expect(stats.receivedByPhase).toEqual({});
     expect(stats.receivedByStation).toEqual({});
+    expect(stats.receivedByPermissionMode).toEqual({ always: 0, whileInUse: 0, denied: 0, unknown: 0 });
   });
 
   it('counts received stamps within 1h window', async () => {
@@ -120,5 +122,35 @@ describe('computePushAckStats', () => {
     seedReceivedStamp(kv, 'good', NOW - 1000, 'imminent', '중곡');
     const stats = await computePushAckStats(kv as unknown as KVNamespace, NOW);
     expect(stats.received).toBe(1);
+  });
+
+  describe('#1768 — receivedByPermissionMode 집계', () => {
+    it('permissionMode 있는 stamp → 해당 버킷 증가', async () => {
+      const kv = new InMemoryKV();
+      seedReceivedStamp(kv, 'p1', NOW - 1000, 'imminent', '강남', 'always');
+      seedReceivedStamp(kv, 'p2', NOW - 1000, 'imminent', '강남', 'whileInUse');
+      seedReceivedStamp(kv, 'p3', NOW - 1000, 'imminent', '강남', 'denied');
+      const stats = await computePushAckStats(kv as unknown as KVNamespace, NOW);
+      expect(stats.receivedByPermissionMode).toEqual({ always: 1, whileInUse: 1, denied: 1, unknown: 0 });
+    });
+
+    it('permissionMode 없는 legacy stamp → unknown 버킷', async () => {
+      const kv = new InMemoryKV();
+      seedReceivedStamp(kv, 'p-legacy', NOW - 1000, 'imminent', '강남'); // permissionMode 없음
+      const stats = await computePushAckStats(kv as unknown as KVNamespace, NOW);
+      expect(stats.receivedByPermissionMode).toEqual({ always: 0, whileInUse: 0, denied: 0, unknown: 1 });
+    });
+
+    it.each([
+      { label: 'always 단독', modes: ['always', 'always'] as const, expected: { always: 2, whileInUse: 0, denied: 0, unknown: 0 } },
+      { label: '혼합', modes: ['always', 'whileInUse', 'denied'] as const, expected: { always: 1, whileInUse: 1, denied: 1, unknown: 0 } },
+    ])('$label → 버킷 정확히 집계', async ({ modes, expected }) => {
+      const kv = new InMemoryKV();
+      for (let i = 0; i < modes.length; i++) {
+        seedReceivedStamp(kv, `p-${i}`, NOW - 1000, 'imminent', '강남', modes[i]);
+      }
+      const stats = await computePushAckStats(kv as unknown as KVNamespace, NOW);
+      expect(stats.receivedByPermissionMode).toEqual(expected);
+    });
   });
 });

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -288,7 +288,7 @@ app.get('/admin/feedback/stats', async (c) => {
  * Auth: `Authorization: Bearer <ADMIN_TOKEN>` 필수 — admin 공통 정책.
  * Query: `?limit=N` (default 500, KV cost 보호).
  *
- * Response 200: { windowStart, windowEnd, pending, received, receivedByPhase, receivedByStation }
+ * Response 200: { windowStart, windowEnd, pending, received, receivedByPhase, receivedByStation, receivedByPermissionMode }
  * Response 401/503: 인증/binding 정책은 /admin/feedback과 동일.
  */
 app.get('/admin/push-ack-stats', async (c) => {
@@ -1143,6 +1143,7 @@ app.post('/push/ack', async (c) => {
       ack.pushId,
       ack.token,
       Date.now(),
+      ack.permissionMode,
     );
     return c.json({ ok: true, ...stampResult });
   }
@@ -1657,6 +1658,8 @@ interface PushAckPayload {
   // #1370 L5 — `received`는 도달률 stamp 전용. fired/skipped는 outcome 분리 후 pending entry 삭제.
   outcome: 'received' | 'fired' | 'skipped';
   reason?: string;
+  // #1768 — 권한별 도달률 집계. legacy device 미전송 시 undefined (backward compat).
+  permissionMode?: 'always' | 'whileInUse' | 'denied';
 }
 
 export function validatePushAck(input: unknown): PushAckPayload | null {
@@ -1669,6 +1672,13 @@ export function validatePushAck(input: unknown): PushAckPayload | null {
   }
   const out: PushAckPayload = { pushId: obj.pushId, token: obj.token, outcome: obj.outcome };
   if (typeof obj.reason === 'string') out.reason = obj.reason;
+  if (
+    obj.permissionMode === 'always' ||
+    obj.permissionMode === 'whileInUse' ||
+    obj.permissionMode === 'denied'
+  ) {
+    out.permissionMode = obj.permissionMode;
+  }
   return out;
 }
 

--- a/backend/alarm-worker/src/pendingPushes.ts
+++ b/backend/alarm-worker/src/pendingPushes.ts
@@ -170,16 +170,24 @@ export async function stampReceived(
   pushId: string,
   token: string,
   receivedAt: number,
+  // #1768 — 권한별 도달률 집계. legacy device 미전송 시 undefined (graceful).
+  permissionMode?: 'always' | 'whileInUse' | 'denied',
 ): Promise<ReceivedAckResult> {
   if (!kv) return { stamped: false, reason: 'not-found' };
   const entry = await getPending(kv, pushId);
   if (!entry) return { stamped: false, reason: 'not-found' };
   if (entry.token !== token) return { stamped: false, reason: 'token-mismatch' };
-  await kv.put(
-    receivedKey(pushId),
-    JSON.stringify({ pushId, receivedAt, stationName: entry.stationName, phase: entry.phase }),
-    { expirationTtl: RECEIVED_TTL_SEC },
-  );
+  const stampValue: {
+    pushId: string;
+    receivedAt: number;
+    stationName: string;
+    phase: string;
+    permissionMode?: 'always' | 'whileInUse' | 'denied';
+  } = { pushId, receivedAt, stationName: entry.stationName, phase: entry.phase };
+  if (permissionMode !== undefined) stampValue.permissionMode = permissionMode;
+  await kv.put(receivedKey(pushId), JSON.stringify(stampValue), {
+    expirationTtl: RECEIVED_TTL_SEC,
+  });
   return { stamped: true };
 }
 

--- a/backend/alarm-worker/src/pushAckStats.ts
+++ b/backend/alarm-worker/src/pushAckStats.ts
@@ -32,6 +32,8 @@ interface ReceivedEntry {
   receivedAt: number;
   stationName: string;
   phase: string;
+  // #1768 — 권한별 도달률 집계. legacy device 누락 시 undefined.
+  permissionMode?: 'always' | 'whileInUse' | 'denied';
 }
 
 /**
@@ -52,6 +54,8 @@ export interface PushAckStatsResponse {
   received: number;
   receivedByPhase: Record<string, number>;
   receivedByStation: Record<string, number>;
+  // #1768 — 권한별 도달률. legacy device ack에 permissionMode 없으면 'unknown' 버킷으로 집계.
+  receivedByPermissionMode: { always: number; whileInUse: number; denied: number; unknown: number };
 }
 
 /**
@@ -69,9 +73,10 @@ export async function computePushAckStats(
   const windowStart = now - 60 * 60 * 1000; // 1h
   const windowEnd = now;
 
-  // received: prefix enumerate + JSON parse + phase/station bucket.
+  // received: prefix enumerate + JSON parse + phase/station/permissionMode bucket.
   const receivedByPhase: Record<string, number> = {};
   const receivedByStation: Record<string, number> = {};
+  const receivedByPermissionMode = { always: 0, whileInUse: 0, denied: 0, unknown: 0 };
   let receivedCount = 0;
   let pendingCount = 0;
 
@@ -99,6 +104,8 @@ export async function computePushAckStats(
       receivedCount += 1;
       receivedByPhase[entry.phase] = (receivedByPhase[entry.phase] ?? 0) + 1;
       receivedByStation[entry.stationName] = (receivedByStation[entry.stationName] ?? 0) + 1;
+      const pMode = entry.permissionMode ?? 'unknown';
+      receivedByPermissionMode[pMode] += 1;
     }
     receivedCursor = result.list_complete || enumerated >= limit ? undefined : result.cursor;
   } while (receivedCursor);
@@ -125,6 +132,7 @@ export async function computePushAckStats(
     received: receivedCount,
     receivedByPhase,
     receivedByStation: topN(receivedByStation, 10),
+    receivedByPermissionMode,
   };
 }
 

--- a/src/features/alarm/api/alarmBackend.ts
+++ b/src/features/alarm/api/alarmBackend.ts
@@ -345,6 +345,9 @@ export interface PushAckPayload {
   //   RCA 시 pushed(backend tail) vs received(stamp) 1:1 비교 가능.
   outcome: 'received' | 'fired' | 'skipped';
   reason?: string;
+  // #1768 — 권한별 도달률 집계를 위해 foreground+background 권한 조합을 보고.
+  // legacy device가 누락 시 backend는 graceful skip (backward compat).
+  permissionMode?: 'always' | 'whileInUse' | 'denied';
 }
 
 export async function sendPushAck(payload: PushAckPayload): Promise<AlarmBackendResult> {

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -5,6 +5,14 @@ jest.mock('expo-task-manager', () => ({
   },
 }));
 
+// #1768 — 권한별 ack permissionMode. 기본: foreground=granted, background=granted → 'always'.
+const mockGetForegroundPermissions = jest.fn().mockResolvedValue({ status: 'granted' });
+const mockGetBackgroundPermissions = jest.fn().mockResolvedValue({ status: 'granted' });
+jest.mock('expo-location', () => ({
+  getForegroundPermissionsAsync: () => mockGetForegroundPermissions(),
+  getBackgroundPermissionsAsync: () => mockGetBackgroundPermissions(),
+}));
+
 const mockRegisterTaskAsync = jest.fn();
 const mockScheduleNotificationAsync = jest.fn();
 jest.mock('expo-notifications', () => ({
@@ -222,14 +230,21 @@ const DEFAULT_APNS_TOKEN = 'apns-tok-hex';
 
 // #1370 L5 — sendPushAck 호출 매칭 헬퍼. ack outcome별로 같은 token/pushId 페이로드를 반복 검증하는
 // 패턴이 다발해 SonarCloud 중복으로 잡힘. 호출 한 줄로 압축해 중복 차단.
+// #1768 — permissionMode 기본값 'always' (기본 mock: foreground+background 모두 granted).
 function ackCall(
   pushId: string,
   outcome: 'received' | 'fired' | 'skipped',
   reason?: string,
-): { pushId: string; token: string; outcome: string; reason?: string } {
-  return reason === undefined
-    ? { pushId, token: DEFAULT_APNS_TOKEN, outcome }
-    : { pushId, token: DEFAULT_APNS_TOKEN, outcome, reason };
+  permissionMode: 'always' | 'whileInUse' | 'denied' | undefined = 'always',
+): { pushId: string; token: string; outcome: string; reason?: string; permissionMode?: string } {
+  const base: { pushId: string; token: string; outcome: string; reason?: string; permissionMode?: string } = {
+    pushId,
+    token: DEFAULT_APNS_TOKEN,
+    outcome,
+    permissionMode,
+  };
+  if (reason !== undefined) base.reason = reason;
+  return base;
 }
 
 const destStation = { id: '0228', name: '강남', line: '2', lat: 37.5, lng: 127.0 };
@@ -1298,6 +1313,7 @@ describe('silentPushTask', () => {
           token: DEFAULT_APNS_TOKEN,
           outcome: 'skipped',
           reason: 'lock-line-mismatch',
+          permissionMode: 'always',
         });
       });
 
@@ -1450,6 +1466,7 @@ describe('silentPushTask', () => {
             token: DEFAULT_APNS_TOKEN,
             outcome: 'skipped',
             reason,
+            permissionMode: 'always',
           });
         }
       });
@@ -1584,6 +1601,7 @@ describe('silentPushTask', () => {
           token: DEFAULT_APNS_TOKEN,
           outcome: 'skipped',
           reason: 'lock-line-mismatch',
+          permissionMode: 'always',
         });
       });
 
@@ -1808,6 +1826,7 @@ describe('silentPushTask', () => {
           pushId: 'p-hop-1',
           token: DEFAULT_APNS_TOKEN,
           outcome: 'fired',
+          permissionMode: 'always',
         });
       });
 
@@ -1828,6 +1847,7 @@ describe('silentPushTask', () => {
           token: DEFAULT_APNS_TOKEN,
           outcome: 'skipped',
           reason: 'dedup-already-fired',
+          permissionMode: 'always',
         });
       });
 
@@ -1873,6 +1893,60 @@ describe('silentPushTask', () => {
         );
         expect(mockScheduleNotificationAsync).toHaveBeenCalled();
         expect(mockSendPushAck).not.toHaveBeenCalled();
+      });
+
+      describe('#1768 — permissionMode 권한별 ack', () => {
+        it('foreground+background 모두 granted → permissionMode=always', async () => {
+          mockGetForegroundPermissions.mockResolvedValueOnce({ status: 'granted' });
+          mockGetBackgroundPermissions.mockResolvedValueOnce({ status: 'granted' });
+          await handleSilentPush(
+            payload({ kind: 'destination', phase: 'imminent', pushId: 'p-always' }),
+          );
+          expect(mockSendPushAck).toHaveBeenCalledWith(
+            expect.objectContaining({ pushId: 'p-always', permissionMode: 'always' }),
+          );
+        });
+
+        it('foreground granted + background denied → permissionMode=whileInUse', async () => {
+          mockGetForegroundPermissions.mockResolvedValueOnce({ status: 'granted' });
+          mockGetBackgroundPermissions.mockResolvedValueOnce({ status: 'denied' });
+          await handleSilentPush(
+            payload({ kind: 'destination', phase: 'imminent', pushId: 'p-whileInUse' }),
+          );
+          expect(mockSendPushAck).toHaveBeenCalledWith(
+            expect.objectContaining({ pushId: 'p-whileInUse', permissionMode: 'whileInUse' }),
+          );
+        });
+
+        it('foreground denied → permissionMode=denied (background 무관)', async () => {
+          mockGetForegroundPermissions.mockResolvedValueOnce({ status: 'denied' });
+          mockGetBackgroundPermissions.mockResolvedValueOnce({ status: 'granted' });
+          await handleSilentPush(
+            payload({ kind: 'destination', phase: 'imminent', pushId: 'p-denied' }),
+          );
+          expect(mockSendPushAck).toHaveBeenCalledWith(
+            expect.objectContaining({ pushId: 'p-denied', permissionMode: 'denied' }),
+          );
+        });
+
+        it('resolvePermissionMode throw → permissionMode 누락(undefined), ack는 계속 전송', async () => {
+          // 모든 resolvePermissionMode 호출에서 throw (received + fired 양쪽 ack).
+          mockGetForegroundPermissions.mockRejectedValue(new Error('location-api-fail'));
+          await handleSilentPush(
+            payload({ kind: 'destination', phase: 'imminent', pushId: 'p-throw-perm' }),
+          );
+          // fired ack가 전송됐는지 확인 — permissionMode는 undefined여야 한다.
+          const call = mockSendPushAck.mock.calls.find(
+            (c: unknown[]) =>
+              (c[0] as { pushId?: string }).pushId === 'p-throw-perm' &&
+              (c[0] as { outcome?: string }).outcome === 'fired',
+          );
+          expect(call).toBeDefined();
+          // permissionMode가 undefined이므로 sendPushAck payload에 포함되지 않는다.
+          expect((call![0] as Record<string, unknown>).permissionMode).toBeUndefined();
+          // 기본 mock 복원 (다른 테스트에 영향 없도록).
+          mockGetForegroundPermissions.mockResolvedValue({ status: 'granted' });
+        });
       });
     });
 
@@ -1941,6 +2015,7 @@ describe('silentPushTask', () => {
           pushId: 'rs-recv',
           token: DEFAULT_APNS_TOKEN,
           outcome: 'received',
+          permissionMode: 'always',
         });
       });
 
@@ -1960,6 +2035,7 @@ describe('silentPushTask', () => {
           pushId: 'te-recv',
           token: DEFAULT_APNS_TOKEN,
           outcome: 'received',
+          permissionMode: 'always',
         });
       });
     });
@@ -2033,6 +2109,7 @@ describe('silentPushTask', () => {
           token: DEFAULT_APNS_TOKEN,
           outcome: 'skipped',
           reason: 'movement-static-speed',
+          permissionMode: 'always',
         });
       });
 
@@ -2095,6 +2172,7 @@ describe('silentPushTask', () => {
           token: DEFAULT_APNS_TOKEN,
           outcome: 'skipped',
           reason: 'movement-motion-stationary',
+          permissionMode: 'always',
         });
       });
 
@@ -2248,6 +2326,7 @@ describe('silentPushTask', () => {
           token: DEFAULT_APNS_TOKEN,
           outcome: 'fired',
           reason: 'reschedule-received',
+          permissionMode: 'always',
         });
       });
 
@@ -2671,6 +2750,7 @@ describe('silentPushTask', () => {
           token: DEFAULT_APNS_TOKEN,
           outcome: 'fired',
           reason: 'trip-ended:expired',
+          permissionMode: 'always',
         });
       });
 
@@ -2709,6 +2789,7 @@ describe('silentPushTask', () => {
           token: DEFAULT_APNS_TOKEN,
           outcome: 'fired',
           reason: expect.stringContaining('token-mismatch') as unknown as string,
+          permissionMode: 'always',
         });
       });
 
@@ -2902,6 +2983,7 @@ describe('silentPushTask', () => {
             token: DEFAULT_APNS_TOKEN,
             outcome: 'fired',
             reason: 'trip-ended:expired',
+            permissionMode: 'always',
           });
         });
       });
@@ -2993,6 +3075,7 @@ describe('silentPushTask', () => {
             token: DEFAULT_APNS_TOKEN,
             outcome: 'fired',
             reason: 'trip-ended:destination-arrived',
+            permissionMode: 'always',
           });
         });
 
@@ -3014,6 +3097,7 @@ describe('silentPushTask', () => {
             token: DEFAULT_APNS_TOKEN,
             outcome: 'fired',
             reason: expect.stringContaining('token-mismatch') as unknown as string,
+            permissionMode: 'always',
           });
         });
       });

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -25,6 +25,7 @@
 
 import * as Notifications from 'expo-notifications';
 import * as TaskManager from 'expo-task-manager';
+import * as Location from 'expo-location';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import i18next from 'i18next';
 import {
@@ -676,20 +677,40 @@ function buildIntermediateContent(stationName: string): { title: string; body: s
 }
 
 /**
+ * #1768 — foreground + background 권한 조합에서 permissionMode를 파생한다.
+ * 실패 시 undefined 반환 — graceful, ack 전체를 block하지 않는다.
+ */
+async function resolvePermissionMode(): Promise<'always' | 'whileInUse' | 'denied' | undefined> {
+  try {
+    const [fg, bg] = await Promise.all([
+      Location.getForegroundPermissionsAsync(),
+      Location.getBackgroundPermissionsAsync(),
+    ]);
+    if (fg.status !== 'granted') return 'denied';
+    if (bg.status === 'granted') return 'always';
+    return 'whileInUse';
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * 백엔드 P2c fallback에서 이 push가 alert로 재발사되지 않도록 처리 결과를 통보한다 (#568 P2b).
  * fire-and-forget — 실패해도 silent push 본 처리 흐름에는 영향 없음.
  * 누락 입력(pushId/token 중 하나라도 null/undefined)은 그대로 skip한다:
  *   - pushId 누락 = 구 백엔드 호환 경로
  *   - token 누락 = APNs 권한 미부여/저장 실패
+ * #1768 — permissionMode를 비동기로 resolve해 payload에 포함한다.
  */
-function ackOutcome(
+async function ackOutcome(
   pushId: string | undefined,
   token: string | null,
   outcome: 'received' | 'fired' | 'skipped',
   reason?: string,
-): void {
+): Promise<void> {
   if (!pushId || !token) return;
-  void sendPushAck({ pushId, token, outcome, reason });
+  const permissionMode = await resolvePermissionMode();
+  void sendPushAck({ pushId, token, outcome, reason, permissionMode });
 }
 
 async function loadApnsToken(): Promise<string | null> {
@@ -802,7 +823,7 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     //
     // pushId/token 둘 다 있어야 임의 echo 차단 정책을 지킬 수 있으므로 ackOutcome과 동일하게
     // 누락 시 skip한다 (구 backend 호환 경로).
-    ackOutcome(payload.pushId, apnsToken, 'received');
+    void ackOutcome(payload.pushId, apnsToken, 'received');
 
     // reschedule 분기 (#725). 백엔드는 사전 예약 알람(#584) 시각을 정정하려고 이 push를 보낸다.
     // - 수신 신호는 받았다 알리고(`lastReceivedAt` 갱신)
@@ -825,7 +846,7 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
         receivedAt,
       });
       await applyReschedule(payload, receivedAt);
-      ackOutcome(payload.pushId, apnsToken, 'fired', 'reschedule-received');
+      void ackOutcome(payload.pushId, apnsToken, 'fired', 'reschedule-received');
       return;
     }
 
@@ -851,7 +872,7 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
           logger.warn(
             `trip-ended skip: tripToken mismatch payload=${payload.tripToken.slice(0, 8)} active=${activeTripToken.slice(0, 8)}`,
           );
-          ackOutcome(payload.pushId, apnsToken, 'fired', `trip-ended:${payload.reason}:token-mismatch`);
+          void ackOutcome(payload.pushId, apnsToken, 'fired', `trip-ended:${payload.reason}:token-mismatch`);
           return;
         }
       }
@@ -892,7 +913,7 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
         // 동일 push 재전송(backend retry) 시 pushId 기준 dedup으로 중복 알림 차단.
         await surfaceTripEnded(payload.reason, payload.pushId);
       }
-      ackOutcome(payload.pushId, apnsToken, 'fired', `trip-ended:${payload.reason}`);
+      void ackOutcome(payload.pushId, apnsToken, 'fired', `trip-ended:${payload.reason}`);
       return;
     }
 
@@ -932,7 +953,7 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
         phaseId: payload.phase,
         reason: 'payload-missing-kind',
       });
-      ackOutcome(payload.pushId, apnsToken, 'skipped', 'payload-missing-kind');
+      void ackOutcome(payload.pushId, apnsToken, 'skipped', 'payload-missing-kind');
       logger.info('kind missing — skip fire');
       return;
     }
@@ -1110,7 +1131,7 @@ async function fireWithGate(
         phaseId: payload.phase,
         reason: 'trip-token-mismatch',
       });
-      ackOutcome(payload.pushId, apnsToken, 'skipped', 'trip-token-mismatch');
+      void ackOutcome(payload.pushId, apnsToken, 'skipped', 'trip-token-mismatch');
       logger.info(
         `trip-token mismatch skip: payload=${payload.tripToken.slice(0, 8)} active=${activeTripToken?.slice(0, 8) ?? 'null'} station=${payload.nextWaypoint}`,
       );
@@ -1139,7 +1160,7 @@ async function fireWithGate(
         phaseId: payload.phase,
         reason: 'lock-line-mismatch',
       });
-      ackOutcome(payload.pushId, apnsToken, 'skipped', 'lock-line-mismatch');
+      void ackOutcome(payload.pushId, apnsToken, 'skipped', 'lock-line-mismatch');
       logger.info(
         `lock line mismatch skip: nextWaypoint=${payload.nextWaypoint} boardingLine=${guardLine}`,
       );
@@ -1168,7 +1189,7 @@ async function fireWithGate(
         phaseId: payload.phase,
         reason: 'lockless-opt-out',
       });
-      ackOutcome(payload.pushId, apnsToken, 'skipped', 'lockless-opt-out');
+      void ackOutcome(payload.pushId, apnsToken, 'skipped', 'lockless-opt-out');
       logger.info(`lockless skip opt-out: station=${payload.nextWaypoint}`);
       return;
     }
@@ -1187,7 +1208,7 @@ async function fireWithGate(
           phaseId: payload.phase,
           reason: 'sleep-first-transfer',
         });
-        ackOutcome(payload.pushId, apnsToken, 'skipped', 'sleep-first-transfer');
+        void ackOutcome(payload.pushId, apnsToken, 'skipped', 'sleep-first-transfer');
         logger.info(`lockless skip sleep-first-transfer: station=${payload.nextWaypoint}`);
         return;
       }
@@ -1217,7 +1238,7 @@ async function fireWithGate(
       phaseId: payload.phase,
       reason,
     });
-    ackOutcome(payload.pushId, apnsToken, 'skipped', reason);
+    void ackOutcome(payload.pushId, apnsToken, 'skipped', reason);
     logger.info(`SSoT fire gate skip reason=${reason} station=${payload.nextWaypoint}`);
     return;
   }
@@ -1238,7 +1259,7 @@ async function fireWithGate(
       phaseId: payload.phase,
       reason: 'dismiss-silence',
     });
-    ackOutcome(payload.pushId, apnsToken, 'skipped', 'dismiss-silence');
+    void ackOutcome(payload.pushId, apnsToken, 'skipped', 'dismiss-silence');
     logger.info(`dismiss-silence skip: station=${payload.nextWaypoint}`);
     return;
   }
@@ -1278,7 +1299,7 @@ async function fireWithGate(
       locationSource: gate.locationSource,
       locationAgeMs: gate.locationAgeMs,
     });
-    ackOutcome(payload.pushId, apnsToken, 'skipped', reason);
+    void ackOutcome(payload.pushId, apnsToken, 'skipped', reason);
     logger.info(`gate skip reason=${gate.reason} distance=${gate.distanceM ?? '-'}`);
     // #1356 E1 — silent fire가 suppress되는 동안 같은 station의 사전 예약(`tba:`/`bl:`)도 OS queue
     // 에서 cancel. backend는 정적/out-of-range를 인식해 다음 silent push를 발사하지 않지만, OS queue에
@@ -1317,7 +1338,7 @@ async function fireWithGate(
       locationSource: gate.locationSource,
       locationAgeMs: gate.locationAgeMs,
     });
-    ackOutcome(payload.pushId, apnsToken, 'skipped', movementReason);
+    void ackOutcome(payload.pushId, apnsToken, 'skipped', movementReason);
     logger.info(
       `movement skip: reason=${movementReason} speed=${gate.speedMps ?? '-'} accuracy=${gate.accuracyM ?? '-'}`,
     );
@@ -1346,7 +1367,7 @@ async function fireWithGate(
     const fired = await getFiredAlarms(destinationId);
     if (fired.has(dedupKey)) {
       // 다른 채널(FG GPS 등)이 이미 발사 — backend 입장에선 fallback 불필요. ACK로 정리.
-      ackOutcome(payload.pushId, apnsToken, 'skipped', 'dedup-already-fired');
+      void ackOutcome(payload.pushId, apnsToken, 'skipped', 'dedup-already-fired');
       // P2e — 동일 pushId의 alert가 race로 도달하면 FG에서 중복 표시 차단되도록 기록.
       if (payload.pushId) void addFiredPushId(payload.pushId);
       logger.info(`dedup: ${dedupKey} already fired — skip`);
@@ -1382,7 +1403,7 @@ async function fireWithGate(
     locationSource: gate.locationSource!,
     locationAgeMs: gate.locationAgeMs!,
   });
-  ackOutcome(payload.pushId, apnsToken, 'fired');
+  void ackOutcome(payload.pushId, apnsToken, 'fired');
   // P2e — alert fallback이 race로 도달해도 FG에서 중복 표시 차단되도록 기록.
   if (payload.pushId) void addFiredPushId(payload.pushId);
   logger.info(


### PR DESCRIPTION
Closes #1768

## Summary

- `PushAckPayload`에 `permissionMode?: 'always' | 'whileInUse' | 'denied'` 추가 (backward compat — legacy device 누락 시 graceful)
- `silentPushTask`: `resolvePermissionMode()` — foreground+background 권한 조합으로 파생, throw 시 undefined
- `ackOutcome` async 전환 + 모든 callsite void 접두어
- Backend: `stampReceived` + `computePushAckStats` + `validatePushAck` + `/push/ack` handler 전반 확장
- `/admin/push-ack-stats` response에 `receivedByPermissionMode: { always, whileInUse, denied, unknown }` 추가

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (No orphan exports detected)
2. **V/X dashboard** — `/admin/push-ack-stats` 응답에 `receivedByPermissionMode` 필드 추가. wrangler tail / Cloudflare Dashboard에서 즉시 관측 가능
3. **의존 PR** — N/A (독립 PR)
4. **측정 plan** — `/admin/push-ack-stats` 1주 polling으로 always/whileInUse/denied 버킷 분포 확인. 기대: always 90%+ (실기기 대부분 Always 허용)
5. **Device verify** — N/A — type+unit only (권한 API는 expo-location mock으로 격리됨)

## Test results

- Frontend: 7766 passed (coverage 100%)
- Backend: 2095 passed
- Orphan: 0
- Type-check: pass (frontend + backend)