### PR TITLE
fix(#1773): 회귀 차단 unit test 보강 (gps-only-underground 차단 + SSoT mirror × stale GPS)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -446,6 +446,103 @@ describe('useStationAlarm', () => {
     });
   });
 
+  // #1773 (D) — fire path A confidence 화이트리스트 회귀 가드.
+  // gps-only-underground 강등 시 GPS 정확도 게이트(500m > 200m)가 already 차단하므로
+  // station-passed 알람(mockSendStationPassedNotification)과 phase 알람(mockSendAlarmNotification)
+  // 모두 발화 안 됨을 명시 검증. 지상(gps-only/detection-fused)은 정상 진입.
+  describe('#1773 (D) fire path A — confidence 기반 silence 검증', () => {
+    const route = makeDirectRoute(1, '2');
+    // 경로상 2호선 역 — isStationOnRoute 통과 조건.
+    const onRouteStation = makeStation('S2-ON', '역삼');
+
+    it('D1: gps-only-underground + accuracy=500m → station-passed 차단 (지하 GPS 정확도 게이트)', () => {
+      // 지하 GPS 환경: accuracy 500m > MAX_ACCURACY_M(200m) + arrivalConfidence 강등.
+      // !accuracyOk && !arrivalConfirmed → station-passed 효과 early return.
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 500,
+            arrivalConfidence: 'gps-only-underground',
+          }),
+        ),
+      );
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    it('D2: gps-only (지상) + accuracy=100m → evaluateAlarmPhase 호출 + phase fire 경로 진입', async () => {
+      // 지상 GPS — accuracy 게이트 통과, degradedConfidence=false → phase 평가 정상 실행.
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 100,
+            arrivalConfidence: 'gps-only',
+          }),
+        ),
+      );
+      await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
+      // gps-only는 degraded=false → evaluateAlarmPhase에 degradedConfidence=false 전달.
+      expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+        expect.objectContaining({ degradedConfidence: false }),
+        expect.any(Set),
+        undefined,
+        expect.any(Array),
+      );
+    });
+
+    it('D3: detection-fused + accuracy=100m → evaluateAlarmPhase 호출 + degradedConfidence=false', async () => {
+      // detection-fused는 verdict ≥2 합의 + 근접 게이트 결합 — 지하에서도 알람 허용.
+      // degradedConfidence=false이므로 early/transfer도 차단 안 됨.
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 100,
+            arrivalConfidence: 'detection-fused',
+          }),
+        ),
+      );
+      await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
+      expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
+        expect.objectContaining({ degradedConfidence: false }),
+        expect.any(Set),
+        undefined,
+        expect.any(Array),
+      );
+    });
+
+    it('D4: lockless trip + gps-only-underground + accuracy=500m → station-passed 차단 (lock 유무 무관)', () => {
+      // lock 없는 lockless trip도 GPS 정확도 게이트는 동일 적용.
+      // boardingLock=null이어도 !accuracyOk && !arrivalConfirmed → fire path A early return.
+      mockGetBoardingLock.mockResolvedValue(null);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 500,
+            arrivalConfidence: 'gps-only-underground',
+          }),
+        ),
+      );
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+  });
+
   // Epic #1204 N8 — currentLine 소스 boardingLock 우선.
   // 5호선 답십리 lock 진행 중 fusion이 2호선 상왕십리 nearest로 jitter해도
   // currentLine은 lock.boardingLine을 유지해 다른 leg의 hop fire를 차단해야 한다.

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.backendSsotCascade.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.backendSsotCascade.test.ts
@@ -24,6 +24,7 @@ import { useTrainPositions } from '../../../route/hooks/useTrainPositions';
 import { findTopNearestStations } from '../../utils/findNearestStation';
 import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute';
 import { TRAIN_STATUS } from '../../../../shared/constants/trainStatus';
+import { BACKEND_SSOT_MIRROR_MAX_AGE_MS } from '../../../../shared/constants/realtime';
 import {
   arrivalRet,
   positionRet,
@@ -407,5 +408,100 @@ describe('#1705 ssotStation — lockless + currentStationLine line-matched resol
     });
     expect(hook.result.current.result?.station.id).toBe(hapjeong2.id);
     expect(hook.result.current.result?.station.line).toBe('2');
+  });
+});
+
+describe('#1773 (E) SSoT mirror staleness × stale GPS 겹침 회귀 가드', () => {
+  // GPS lastFixAtMs=T0-200_000: 200s old. GPS_FALLBACK_STALE_MAX_AGE_MS(300s) 이내라 GPS 게이트 통과.
+  // BACKEND_SSOT_MIRROR_MAX_AGE_MS = 180s. lastAdvanceAt으로 SSoT mirror 신선도 판정.
+  //
+  // 시나리오:
+  //   E1. mirror 60s old (fresh) + GPS 200s old → backend-ssot 채택 OK.
+  //   E2. mirror 170s old (한계 직전, 여전히 fresh) + GPS 200s old → backend-ssot 채택 OK.
+  //   E3. mirror 200s old (stale, >180s) + GPS 200s old → backend-ssot 채택 거부 → GPS fallback.
+
+  function setupBaselineGpsWithLastFix(stationName: string, lastFixAtMs: number) {
+    const stn = findStationByNameAndLine(stationName, '7')!;
+    const live = { station: stn, distanceKm: 0 };
+    (useNearestStation as jest.Mock).mockReturnValue({
+      result: live,
+      liveResult: live,
+      stickyDisplayOnly: null,
+      variants: [stn],
+      userLocation: { lat: stn.lat, lng: stn.lng },
+      ...GPS_BASE_DEFAULTS,
+      accuracyMeters: 14,
+      lastFixAtMs,
+      refresh: jest.fn(),
+    });
+    (findTopNearestStations as jest.Mock).mockReturnValue([{ station: stn, distanceKm: 0 }]);
+    (useArrivalInfo as jest.Mock).mockReturnValue(arrivalRet(null));
+    (useTrainPositions as jest.Mock).mockReturnValue(positionRet(null));
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(T0);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('E1: mirror 60s old(fresh) + GPS 200s old → backend-ssot 채택 OK', async () => {
+    // lastAdvanceAt = T0 - 60_000 (60s old). 60s < BACKEND_SSOT_MIRROR_MAX_AGE_MS(180s) → fresh.
+    // GPS 200s old는 GPS_FALLBACK_STALE_MAX_AGE_MS(300s) 이내 → GPS 게이트 통과.
+    // 결과: backend-ssot가 cascade 1순위로 채택됨.
+    setupBaselineGpsWithLastFix('청담', T0 - 200_000);
+    (readBackendSsotMirror as jest.Mock).mockResolvedValue(
+      makeBackendSsotMirrorEntry({
+        currentStationId: yongmasan.name,
+        lastAdvanceAt: T0 - 60_000,
+      }),
+    );
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushBackendSsotMirrorTick();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+    expect(hook.result.current.confidence).toBe('backend-ssot');
+    expect(hook.result.current.result?.station.id).toBe(yongmasan.id);
+  });
+
+  it('E2: mirror 170s old(한계 직전, still fresh) + GPS 200s old → backend-ssot 채택 OK', async () => {
+    // lastAdvanceAt = T0 - 170_000 (170s old). 170s < 180s → 아직 fresh(경계 직전).
+    // 이 edge case는 stale 직전 구간 — 채택 허용 확인.
+    setupBaselineGpsWithLastFix('청담', T0 - 200_000);
+    (readBackendSsotMirror as jest.Mock).mockResolvedValue(
+      makeBackendSsotMirrorEntry({
+        currentStationId: yongmasan.name,
+        lastAdvanceAt: T0 - 170_000,
+      }),
+    );
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushBackendSsotMirrorTick();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+    expect(hook.result.current.result?.station.id).toBe(yongmasan.id);
+  });
+
+  it('E3: mirror 200s old(stale, >180s) + GPS 200s old → backend-ssot 채택 거부 → GPS fallback', async () => {
+    // lastAdvanceAt = T0 - 200_000 (200s old). 200s > 180s → stale → ssotFresh=false → 채택 거부.
+    // GPS 200s old는 GPS gate 통과 → GPS fallback으로 cascade 진행 (source='gps').
+    // mirror stale + GPS not stale → fusion이 GPS tier로 fallback (source != 'backend-ssot').
+    setupBaselineGpsWithLastFix('청담', T0 - 200_000);
+    (readBackendSsotMirror as jest.Mock).mockResolvedValue(
+      makeBackendSsotMirrorEntry({
+        currentStationId: yongmasan.name,
+        lastAdvanceAt: T0 - 200_000,
+      }),
+    );
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushBackendSsotMirrorTick();
+    expect(hook.result.current.source).not.toBe('backend-ssot');
+    // GPS fallback으로 청담 채택 (GPS는 stale 아님 — 200s < 300s).
+    expect(hook.result.current.result?.station.name).toBe('청담');
   });
 });


### PR DESCRIPTION
Closes #1773

## Summary

- **D — useStationAlarm fire path A confidence whitelist (4건)**
  - D1: `gps-only-underground` + accuracy=500m → `mockSendStationPassedNotification` / `mockSendAlarmNotification` 모두 미호출 (GPS 정확도 게이트 차단)
  - D2: `gps-only` (지상) + accuracy=100m → `evaluateAlarmPhase` 정상 호출 + `degradedConfidence=false`
  - D3: `detection-fused` + accuracy=100m → `degradedConfidence=false` (지하 verdict 결합 경로 허용)
  - D4: lockless trip + `gps-only-underground` + accuracy=500m → 동일 차단 (lock 유무 무관)
- **E — SSoT mirror staleness × stale GPS 겹침 (3건)**
  - E1: mirror 60s old(fresh) + GPS 200s old → `backend-ssot` 채택 OK
  - E2: mirror 170s old(경계 직전, still fresh) + GPS 200s old → `backend-ssot` 채택 OK
  - E3: mirror 200s old(stale, >180s) + GPS 200s old → `backend-ssot` 거부 → GPS fallback

## Acceptance

- D 4건 + E 3건 총 7건 unit test pass
- 기존 7785개 tests all pass, coverage 100% 유지
- production 코드 변경 없음 (test only)

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan). test 파일이므로 신규 export 없음.
2. **V/X dashboard** — test only. DebugModal/Sentry 관측 대상 없음 (regression test).
3. **의존 PR** — N/A (test only, production 코드 의존 없음)
4. **측정 plan** — CI `Type Check & Test` job에서 7건 추가 커버. 회귀 차단은 CI 자동화.
5. **Device verify** — N/A — type+unit only