### PR TITLE
feat(#1772): silent push latency 측정 (sentAt + receivedAt)

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1301,6 +1301,52 @@ describe('validatePushAck (#566 P2a)', () => {
       expect(ack).not.toHaveProperty('permissionMode');
     });
   });
+
+  describe('#1772 — latencyMs + batteryState', () => {
+    it('양의 latencyMs → payload에 포함', () => {
+      const ack = validatePushAck({ pushId: 'p1', token: 'tok', outcome: 'received', latencyMs: 350 });
+      expect(ack).toMatchObject({ latencyMs: 350 });
+    });
+
+    it('0ms latencyMs → payload에 포함 (0은 유효)', () => {
+      const ack = validatePushAck({ pushId: 'p1', token: 'tok', outcome: 'received', latencyMs: 0 });
+      expect(ack).toMatchObject({ latencyMs: 0 });
+    });
+
+    it('음수 latencyMs → payload에 포함 안 됨 (graceful)', () => {
+      const ack = validatePushAck({ pushId: 'p1', token: 'tok', outcome: 'received', latencyMs: -100 });
+      expect(ack).not.toHaveProperty('latencyMs');
+    });
+
+    it('Infinity latencyMs → payload에 포함 안 됨', () => {
+      const ack = validatePushAck({ pushId: 'p1', token: 'tok', outcome: 'received', latencyMs: Infinity });
+      expect(ack).not.toHaveProperty('latencyMs');
+    });
+
+    it('latencyMs 누락 → payload에 포함 안 됨 (legacy backward compat)', () => {
+      const ack = validatePushAck({ pushId: 'p1', token: 'tok', outcome: 'received' });
+      expect(ack).not.toHaveProperty('latencyMs');
+    });
+
+    it.each([
+      { state: 'normal' as const },
+      { state: 'lowPowerMode' as const },
+      { state: 'unknown' as const },
+    ])('batteryState=$state → payload에 포함', ({ state }) => {
+      const ack = validatePushAck({ pushId: 'p1', token: 'tok', outcome: 'received', batteryState: state });
+      expect(ack).toMatchObject({ batteryState: state });
+    });
+
+    it('batteryState 유효하지 않은 값 → payload에 포함 안 됨', () => {
+      const ack = validatePushAck({ pushId: 'p1', token: 'tok', outcome: 'received', batteryState: 'charging' });
+      expect(ack).not.toHaveProperty('batteryState');
+    });
+
+    it('batteryState 누락 → payload에 포함 안 됨 (legacy)', () => {
+      const ack = validatePushAck({ pushId: 'p1', token: 'tok', outcome: 'received' });
+      expect(ack).not.toHaveProperty('batteryState');
+    });
+  });
 });
 
 describe('POST /push/ack (#566 P2a)', () => {

--- a/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
+++ b/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
@@ -57,6 +57,7 @@ describe('storeObservabilityMetrics + readObservabilityMetrics', () => {
         stationary: { count: 1, ratio: 0.25 },
         unknown: { count: 0, ratio: 0 },
       },
+      silentPushLatency: null,
       window: '24h' as const,
       timestamp: NOW,
     };
@@ -92,6 +93,7 @@ describe('storeObservabilityMetrics + readObservabilityMetrics', () => {
         stationary: { count: 0, ratio: 0 },
         unknown: { count: 0, ratio: 0 },
       },
+      silentPushLatency: null,
       window: '24h' as const,
       timestamp: NOW,
     };
@@ -288,6 +290,44 @@ describe('computeObservabilityMetrics — response shape', () => {
     const r2 = makeEmptyFakeR2();
     const result = await computeObservabilityMetrics(r2, undefined, NOW);
     expect(result.timestamp).toBe(NOW);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// computeObservabilityMetrics — silentPushLatency (#1772)
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('computeObservabilityMetrics — silentPushLatency (#1772)', () => {
+  it('undefined pendingPushesKv → silentPushLatency=null', async () => {
+    const r2 = makeEmptyFakeR2();
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    expect(result.silentPushLatency).toBeNull();
+  });
+
+  it('KV에 latencyMs stamp 있으면 p50/p95 집계 결과 반환', async () => {
+    const kv = new InMemoryKV();
+    // 3개 샘플: 100, 200, 300ms. sorted p50=index1=200, p95=index2=300.
+    for (const [i, ms] of [100, 200, 300].entries()) {
+      kv.store.set(`received:p-lat-${i}`, {
+        value: JSON.stringify({ pushId: `p-lat-${i}`, receivedAt: NOW - 1000, stationName: 'A', phase: 'imminent', latencyMs: ms }),
+      });
+    }
+    const r2 = makeEmptyFakeR2();
+    const result = await computeObservabilityMetrics(r2, kv as unknown as KVNamespace, NOW);
+    expect(result.silentPushLatency).not.toBeNull();
+    expect(result.silentPushLatency!.totalSamples).toBe(3);
+    expect(result.silentPushLatency!.p50).toBe(200);
+    expect(result.silentPushLatency!.p95).toBe(300);
+  });
+
+  it('KV에 latencyMs stamp 없으면 silentPushLatency=null', async () => {
+    const kv = new InMemoryKV();
+    kv.store.set('received:p-no-lat', {
+      value: JSON.stringify({ pushId: 'p-no-lat', receivedAt: NOW - 1000, stationName: 'A', phase: 'imminent' }),
+    });
+    const r2 = makeEmptyFakeR2();
+    const result = await computeObservabilityMetrics(r2, kv as unknown as KVNamespace, NOW);
+    expect(result.silentPushLatency).toBeNull();
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/pendingPushes.test.ts
+++ b/backend/alarm-worker/src/__tests__/pendingPushes.test.ts
@@ -174,7 +174,7 @@ describe('pendingPushes (#566 P2a)', () => {
     it('token 매칭 시 stamp 적재 + pending entry는 보존 + stamped=true', async () => {
       await putPending(
         kv as unknown as KVNamespace,
-        makeEntry({ pushId: 'p1', token: 'devicetoken-hex', stationName: '강남', phase: 'early' }),
+        makeEntry({ pushId: 'p1', token: 'devicetoken-hex', stationName: '강남', phase: 'early', sentAt: 1_700_000_000_000 }),
       );
       const result = await stampReceived(
         kv as unknown as KVNamespace,
@@ -186,11 +186,13 @@ describe('pendingPushes (#566 P2a)', () => {
       expect(kv.store.has('pending:p1')).toBe(true);
       const entry = kv.store.get('received:p1');
       expect(entry).toBeDefined();
-      const parsed = JSON.parse(entry!.value) as { pushId: string; receivedAt: number; stationName: string; phase: string };
+      const parsed = JSON.parse(entry!.value) as { pushId: string; receivedAt: number; stationName: string; phase: string; latencyMs: number };
       expect(parsed.pushId).toBe('p1');
       expect(parsed.receivedAt).toBe(1_700_000_001_000);
       expect(parsed.stationName).toBe('강남');
       expect(parsed.phase).toBe('early');
+      // #1772 — latencyMs fallback: receivedAt(1_700_000_001_000) - sentAt(1_700_000_000_000) = 1000.
+      expect(parsed.latencyMs).toBe(1000);
     });
 
     it('token 불일치면 stamp 미적재 + reason=token-mismatch', async () => {
@@ -228,11 +230,11 @@ describe('pendingPushes (#566 P2a)', () => {
     it('getReceivedStamp: stamp 존재 시 parsed entry 반환', async () => {
       await putPending(
         kv as unknown as KVNamespace,
-        makeEntry({ pushId: 'p1', token: 'tok', stationName: '시청', phase: 'imminent' }),
+        makeEntry({ pushId: 'p1', token: 'tok', stationName: '시청', phase: 'imminent', sentAt: 1_700_000_000_000 }),
       );
       await stampReceived(kv as unknown as KVNamespace, 'p1', 'tok', 1_700_000_500_000);
       const stamp = await getReceivedStamp(kv as unknown as KVNamespace, 'p1');
-      expect(stamp).toEqual({
+      expect(stamp).toMatchObject({
         pushId: 'p1',
         receivedAt: 1_700_000_500_000,
         stationName: '시청',
@@ -288,5 +290,65 @@ describe('pendingPushes (#566 P2a)', () => {
         expect(parsed.permissionMode).toBeUndefined();
       });
     });
+
+    describe('#1772 — stampReceived latencyMs + batteryState', () => {
+      it('device가 latencyMs 전달 시 stamp에 해당 값 사용', async () => {
+        await putPending(
+          kv as unknown as KVNamespace,
+          makeEntry({ pushId: 'p-lat', token: 'tok', sentAt: 1_700_000_000_000 }),
+        );
+        await stampReceived(kv as unknown as KVNamespace, 'p-lat', 'tok', 1_700_000_002_000, undefined, 1500);
+        const raw = kv.store.get('received:p-lat');
+        const parsed = JSON.parse(raw!.value) as Record<string, unknown>;
+        expect(parsed.latencyMs).toBe(1500);
+      });
+
+      it('latencyMs 미전달 → KV sentAt 기반 fallback 계산', async () => {
+        await putPending(
+          kv as unknown as KVNamespace,
+          makeEntry({ pushId: 'p-fallback', token: 'tok', sentAt: 1_700_000_000_000 }),
+        );
+        await stampReceived(kv as unknown as KVNamespace, 'p-fallback', 'tok', 1_700_000_003_000);
+        const raw = kv.store.get('received:p-fallback');
+        const parsed = JSON.parse(raw!.value) as Record<string, unknown>;
+        // fallback: receivedAt(1_700_000_003_000) - sentAt(1_700_000_000_000) = 3000.
+        expect(parsed.latencyMs).toBe(3000);
+      });
+
+      it('batteryState 전달 시 stamp에 포함', async () => {
+        await putPending(
+          kv as unknown as KVNamespace,
+          makeEntry({ pushId: 'p-batt', token: 'tok', sentAt: 1_700_000_000_000 }),
+        );
+        await stampReceived(kv as unknown as KVNamespace, 'p-batt', 'tok', 1_700_000_001_000, undefined, undefined, 'lowPowerMode');
+        const raw = kv.store.get('received:p-batt');
+        const parsed = JSON.parse(raw!.value) as Record<string, unknown>;
+        expect(parsed.batteryState).toBe('lowPowerMode');
+      });
+
+      it('batteryState 미전달(legacy) → stamp에 batteryState 필드 없음', async () => {
+        await putPending(
+          kv as unknown as KVNamespace,
+          makeEntry({ pushId: 'p-nobatt', token: 'tok', sentAt: 1_700_000_000_000 }),
+        );
+        await stampReceived(kv as unknown as KVNamespace, 'p-nobatt', 'tok', 1_700_000_001_000);
+        const raw = kv.store.get('received:p-nobatt');
+        const parsed = JSON.parse(raw!.value) as Record<string, unknown>;
+        expect(parsed.batteryState).toBeUndefined();
+      });
+
+      it('음수 latencyMs 미허용 → KV sentAt fallback 사용', async () => {
+        await putPending(
+          kv as unknown as KVNamespace,
+          makeEntry({ pushId: 'p-neg', token: 'tok', sentAt: 1_700_000_000_000 }),
+        );
+        await stampReceived(kv as unknown as KVNamespace, 'p-neg', 'tok', 1_700_000_001_000, undefined, -100);
+        const raw = kv.store.get('received:p-neg');
+        const parsed = JSON.parse(raw!.value) as Record<string, unknown>;
+        // fallback: 1_700_000_001_000 - 1_700_000_000_000 = 1000.
+        expect(parsed.latencyMs).toBe(1000);
+      });
+    });
   });
 });
+

--- a/backend/alarm-worker/src/__tests__/pushAckStats.test.ts
+++ b/backend/alarm-worker/src/__tests__/pushAckStats.test.ts
@@ -15,9 +15,13 @@ function seedReceivedStamp(
   phase: string,
   stationName: string,
   permissionMode?: 'always' | 'whileInUse' | 'denied',
+  latencyMs?: number,
+  batteryState?: 'normal' | 'lowPowerMode' | 'unknown',
 ): void {
   const entry: Record<string, unknown> = { pushId, receivedAt, stationName, phase };
   if (permissionMode !== undefined) entry.permissionMode = permissionMode;
+  if (latencyMs !== undefined) entry.latencyMs = latencyMs;
+  if (batteryState !== undefined) entry.batteryState = batteryState;
   kv.store.set(`received:${pushId}`, { value: JSON.stringify(entry) });
 }
 
@@ -36,6 +40,8 @@ describe('computePushAckStats', () => {
     expect(stats.receivedByPhase).toEqual({});
     expect(stats.receivedByStation).toEqual({});
     expect(stats.receivedByPermissionMode).toEqual({ always: 0, whileInUse: 0, denied: 0, unknown: 0 });
+    expect(stats.silentPushLatency).toBeNull();
+    expect(stats.receivedByBatteryState).toEqual({ normal: 0, lowPowerMode: 0, unknown: 0 });
   });
 
   it('counts received stamps within 1h window', async () => {
@@ -153,4 +159,53 @@ describe('computePushAckStats', () => {
       expect(stats.receivedByPermissionMode).toEqual(expected);
     });
   });
+
+  describe('#1772 — silentPushLatency 집계', () => {
+    it('latencyMs 있는 샘플만 집계 → p50/p95/totalSamples 반환', async () => {
+      const kv = new InMemoryKV();
+      // 5개 샘플: 100, 200, 300, 400, 500ms
+      for (let i = 0; i < 5; i++) {
+        seedReceivedStamp(kv, `p-lat-${i}`, NOW - 1000, 'imminent', '강남', undefined, (i + 1) * 100);
+      }
+      const stats = await computePushAckStats(kv as unknown as KVNamespace, NOW);
+      expect(stats.silentPushLatency).not.toBeNull();
+      expect(stats.silentPushLatency!.totalSamples).toBe(5);
+      // sorted: [100, 200, 300, 400, 500]. p50 = index floor(5*0.5)=2 → 300, p95 = index min(floor(5*0.95)=4,4) → 500.
+      expect(stats.silentPushLatency!.p50).toBe(300);
+      expect(stats.silentPushLatency!.p95).toBe(500);
+    });
+
+    it('latencyMs 없는 stamps → silentPushLatency null', async () => {
+      const kv = new InMemoryKV();
+      seedReceivedStamp(kv, 'p-no-lat', NOW - 1000, 'imminent', '강남'); // latencyMs 없음
+      const stats = await computePushAckStats(kv as unknown as KVNamespace, NOW);
+      expect(stats.silentPushLatency).toBeNull();
+    });
+
+    it('단일 샘플 → p50=p95=해당값', async () => {
+      const kv = new InMemoryKV();
+      seedReceivedStamp(kv, 'p-single', NOW - 1000, 'imminent', '강남', undefined, 750);
+      const stats = await computePushAckStats(kv as unknown as KVNamespace, NOW);
+      expect(stats.silentPushLatency).toEqual({ p50: 750, p95: 750, totalSamples: 1 });
+    });
+  });
+
+  describe('#1772 — receivedByBatteryState 집계', () => {
+    it('batteryState 있는 stamp → 버킷 증가', async () => {
+      const kv = new InMemoryKV();
+      seedReceivedStamp(kv, 'p1', NOW - 1000, 'imminent', '강남', undefined, undefined, 'normal');
+      seedReceivedStamp(kv, 'p2', NOW - 1000, 'imminent', '강남', undefined, undefined, 'lowPowerMode');
+      seedReceivedStamp(kv, 'p3', NOW - 1000, 'imminent', '강남', undefined, undefined, 'unknown');
+      const stats = await computePushAckStats(kv as unknown as KVNamespace, NOW);
+      expect(stats.receivedByBatteryState).toEqual({ normal: 1, lowPowerMode: 1, unknown: 1 });
+    });
+
+    it('batteryState 없는 legacy stamp → 버킷 증가 없음', async () => {
+      const kv = new InMemoryKV();
+      seedReceivedStamp(kv, 'p-legacy', NOW - 1000, 'imminent', '강남'); // batteryState 없음
+      const stats = await computePushAckStats(kv as unknown as KVNamespace, NOW);
+      expect(stats.receivedByBatteryState).toEqual({ normal: 0, lowPowerMode: 0, unknown: 0 });
+    });
+  });
 });
+

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -1144,6 +1144,9 @@ app.post('/push/ack', async (c) => {
       ack.token,
       Date.now(),
       ack.permissionMode,
+      // #1772 — latencyMs / batteryState forward. legacy device 미전송 시 undefined (graceful).
+      ack.latencyMs,
+      ack.batteryState,
     );
     return c.json({ ok: true, ...stampResult });
   }
@@ -1660,6 +1663,10 @@ interface PushAckPayload {
   reason?: string;
   // #1768 — 권한별 도달률 집계. legacy device 미전송 시 undefined (backward compat).
   permissionMode?: 'always' | 'whileInUse' | 'denied';
+  // #1772 — silent push latency (device 계산: receivedAt - sentAt). legacy 누락 시 undefined.
+  latencyMs?: number;
+  // #1772 — battery state. legacy device 미전송 시 undefined (backward compat).
+  batteryState?: 'normal' | 'lowPowerMode' | 'unknown';
 }
 
 export function validatePushAck(input: unknown): PushAckPayload | null {
@@ -1678,6 +1685,17 @@ export function validatePushAck(input: unknown): PushAckPayload | null {
     obj.permissionMode === 'denied'
   ) {
     out.permissionMode = obj.permissionMode;
+  }
+  // #1772 — latencyMs: 양의 finite number만 허용. 음수/Infinity는 측정 오류.
+  if (typeof obj.latencyMs === 'number' && obj.latencyMs >= 0 && Number.isFinite(obj.latencyMs)) {
+    out.latencyMs = obj.latencyMs;
+  }
+  if (
+    obj.batteryState === 'normal' ||
+    obj.batteryState === 'lowPowerMode' ||
+    obj.batteryState === 'unknown'
+  ) {
+    out.batteryState = obj.batteryState;
   }
   return out;
 }

--- a/backend/alarm-worker/src/observabilityMetrics.ts
+++ b/backend/alarm-worker/src/observabilityMetrics.ts
@@ -56,6 +56,11 @@ export interface ObservabilityMetricsResponse {
   boardableMissRatio: { value: number; total: number; ratio: number };
   /** #1769 — accelerometer pattern 4종 분포 (24h rolling window). */
   accelPatternHitRatio: AccelPatternBucket;
+  /**
+   * #1772 — silent push latency 분포 (1h 윈도우 근사치 — PENDING_PUSHES KV TTL 제약).
+   * latencyMs stamp 있는 샘플만 집계. 샘플 0건이면 null.
+   */
+  silentPushLatency: { p50: number; p95: number; totalSamples: number } | null;
   window: '24h';
   timestamp: number;
 }
@@ -90,12 +95,14 @@ export async function computeObservabilityMetrics(
   const locklessMissCount = alarmStats.reasons['lockless-forward-only-block'] ?? 0;
   const locklessMissRatio = buildMetricBucket(locklessMissCount, alarmTotal);
 
-  // 2. PENDING_PUSHES KV 1h 근사치 — silentPushDeliveryRatio 원천
+  // 2. PENDING_PUSHES KV 1h 근사치 — silentPushDeliveryRatio + silentPushLatency 원천
   let silentPushDeliveryRatio: ObservabilityMetricsResponse['silentPushDeliveryRatio'];
+  let silentPushLatency: ObservabilityMetricsResponse['silentPushLatency'] = null;
   if (pendingPushesKv !== undefined) {
     const pushStats = await computePushAckStats(pendingPushesKv, now, 500);
     const pushTotal = pushStats.received + pushStats.pending;
     silentPushDeliveryRatio = buildMetricBucket(pushStats.received, pushTotal);
+    silentPushLatency = pushStats.silentPushLatency;
   } else {
     // binding 미설정 — graceful placeholder
     silentPushDeliveryRatio = buildMetricBucket(0, 0);
@@ -114,6 +121,7 @@ export async function computeObservabilityMetrics(
     locklessMissRatio,
     boardableMissRatio,
     accelPatternHitRatio,
+    silentPushLatency,
     window: '24h',
     timestamp: now,
   };

--- a/backend/alarm-worker/src/pendingPushes.ts
+++ b/backend/alarm-worker/src/pendingPushes.ts
@@ -172,19 +172,30 @@ export async function stampReceived(
   receivedAt: number,
   // #1768 — 권한별 도달률 집계. legacy device 미전송 시 undefined (graceful).
   permissionMode?: 'always' | 'whileInUse' | 'denied',
+  // #1772 — latency stamp. device가 receivedAt - sentAt을 계산해 전달. legacy 누락 시 KV 기반 계산.
+  latencyMs?: number,
+  // #1772 — battery state. legacy device 미전송 시 undefined (graceful).
+  batteryState?: 'normal' | 'lowPowerMode' | 'unknown',
 ): Promise<ReceivedAckResult> {
   if (!kv) return { stamped: false, reason: 'not-found' };
   const entry = await getPending(kv, pushId);
   if (!entry) return { stamped: false, reason: 'not-found' };
   if (entry.token !== token) return { stamped: false, reason: 'token-mismatch' };
+  // #1772 — latency 계산: device가 명시 전달한 값 우선, 누락 시 KV sentAt 기반 fallback.
+  const resolvedLatencyMs = typeof latencyMs === 'number' && latencyMs >= 0
+    ? latencyMs
+    : receivedAt - entry.sentAt;
   const stampValue: {
     pushId: string;
     receivedAt: number;
     stationName: string;
     phase: string;
+    latencyMs: number;
     permissionMode?: 'always' | 'whileInUse' | 'denied';
-  } = { pushId, receivedAt, stationName: entry.stationName, phase: entry.phase };
+    batteryState?: 'normal' | 'lowPowerMode' | 'unknown';
+  } = { pushId, receivedAt, stationName: entry.stationName, phase: entry.phase, latencyMs: resolvedLatencyMs };
   if (permissionMode !== undefined) stampValue.permissionMode = permissionMode;
+  if (batteryState !== undefined) stampValue.batteryState = batteryState;
   await kv.put(receivedKey(pushId), JSON.stringify(stampValue), {
     expirationTtl: RECEIVED_TTL_SEC,
   });

--- a/backend/alarm-worker/src/pushAckStats.ts
+++ b/backend/alarm-worker/src/pushAckStats.ts
@@ -34,6 +34,10 @@ interface ReceivedEntry {
   phase: string;
   // #1768 — 권한별 도달률 집계. legacy device 누락 시 undefined.
   permissionMode?: 'always' | 'whileInUse' | 'denied';
+  // #1772 — latency stamp (receivedAt - sentAt). legacy device 누락 시 undefined.
+  latencyMs?: number;
+  // #1772 — battery state. legacy device 누락 시 undefined.
+  batteryState?: 'normal' | 'lowPowerMode' | 'unknown';
 }
 
 /**
@@ -44,6 +48,7 @@ interface ReceivedEntry {
  * - `received`: 본 윈도우 내 ack 카운트
  * - `receivedByPhase`: phase 별 ack 분포 (imminent/etc)
  * - `receivedByStation`: station 별 ack 분포 (top 10)
+ * - `silentPushLatency`: #1772 — latency 분포 (p50/p95/totalSamples). 샘플 없으면 null.
  *
  * 비율(도달률) 계산은 client에서 — 본 endpoint는 raw count만 제공.
  */
@@ -56,6 +61,10 @@ export interface PushAckStatsResponse {
   receivedByStation: Record<string, number>;
   // #1768 — 권한별 도달률. legacy device ack에 permissionMode 없으면 'unknown' 버킷으로 집계.
   receivedByPermissionMode: { always: number; whileInUse: number; denied: number; unknown: number };
+  // #1772 — latency 분포. latencyMs stamp 있는 샘플만 집계. 샘플 0건이면 null.
+  silentPushLatency: { p50: number; p95: number; totalSamples: number } | null;
+  // #1772 — battery state 별 ack 분포. stamp 있는 샘플만.
+  receivedByBatteryState: { normal: number; lowPowerMode: number; unknown: number };
 }
 
 /**
@@ -73,10 +82,12 @@ export async function computePushAckStats(
   const windowStart = now - 60 * 60 * 1000; // 1h
   const windowEnd = now;
 
-  // received: prefix enumerate + JSON parse + phase/station/permissionMode bucket.
+  // received: prefix enumerate + JSON parse + phase/station/permissionMode/latency bucket.
   const receivedByPhase: Record<string, number> = {};
   const receivedByStation: Record<string, number> = {};
   const receivedByPermissionMode = { always: 0, whileInUse: 0, denied: 0, unknown: 0 };
+  const receivedByBatteryState = { normal: 0, lowPowerMode: 0, unknown: 0 };
+  const latencySamples: number[] = [];
   let receivedCount = 0;
   let pendingCount = 0;
 
@@ -106,6 +117,15 @@ export async function computePushAckStats(
       receivedByStation[entry.stationName] = (receivedByStation[entry.stationName] ?? 0) + 1;
       const pMode = entry.permissionMode ?? 'unknown';
       receivedByPermissionMode[pMode] += 1;
+      // #1772 — latency + battery state 집계.
+      if (typeof entry.latencyMs === 'number' && entry.latencyMs >= 0) {
+        latencySamples.push(entry.latencyMs);
+      }
+      if (entry.batteryState === 'normal' || entry.batteryState === 'lowPowerMode') {
+        receivedByBatteryState[entry.batteryState] += 1;
+      } else if (entry.batteryState === 'unknown') {
+        receivedByBatteryState.unknown += 1;
+      }
     }
     receivedCursor = result.list_complete || enumerated >= limit ? undefined : result.cursor;
   } while (receivedCursor);
@@ -133,6 +153,8 @@ export async function computePushAckStats(
     receivedByPhase,
     receivedByStation: topN(receivedByStation, 10),
     receivedByPermissionMode,
+    silentPushLatency: computeLatencyPercentiles(latencySamples),
+    receivedByBatteryState,
   };
 }
 
@@ -142,4 +164,19 @@ function topN(dict: Record<string, number>, n: number): Record<string, number> {
     .sort((a, b) => b[1] - a[1])
     .slice(0, n);
   return Object.fromEntries(sorted);
+}
+
+/**
+ * #1772 — latency 샘플 배열에서 P50 / P95 산출.
+ * 샘플 없으면 null. 오름차순 정렬 후 nearest-rank method.
+ */
+function computeLatencyPercentiles(
+  samples: number[],
+): { p50: number; p95: number; totalSamples: number } | null {
+  if (samples.length === 0) return null;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const n = sorted.length;
+  const p50 = sorted[Math.floor(n * 0.5)];
+  const p95 = sorted[Math.min(Math.floor(n * 0.95), n - 1)];
+  return { p50, p95, totalSamples: n };
 }

--- a/src/features/alarm/api/alarmBackend.ts
+++ b/src/features/alarm/api/alarmBackend.ts
@@ -348,6 +348,10 @@ export interface PushAckPayload {
   // #1768 — 권한별 도달률 집계를 위해 foreground+background 권한 조합을 보고.
   // legacy device가 누락 시 backend는 graceful skip (backward compat).
   permissionMode?: 'always' | 'whileInUse' | 'denied';
+  // #1772 — silent push latency (receivedAt - sentAt, ms). legacy 누락 시 backend KV fallback.
+  latencyMs?: number;
+  // #1772 — battery state. legacy device 미전송 시 backend graceful skip.
+  batteryState?: 'normal' | 'lowPowerMode' | 'unknown';
 }
 
 export async function sendPushAck(payload: PushAckPayload): Promise<AlarmBackendResult> {

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -13,6 +13,12 @@ jest.mock('expo-location', () => ({
   getBackgroundPermissionsAsync: () => mockGetBackgroundPermissions(),
 }));
 
+// #1772 — battery state. 기본: lowPowerMode=false → 'normal'.
+const mockGetPowerStateAsync = jest.fn().mockResolvedValue({ lowPowerMode: false });
+jest.mock('expo-battery', () => ({
+  getPowerStateAsync: () => mockGetPowerStateAsync(),
+}));
+
 const mockRegisterTaskAsync = jest.fn();
 const mockScheduleNotificationAsync = jest.fn();
 jest.mock('expo-notifications', () => ({
@@ -231,19 +237,25 @@ const DEFAULT_APNS_TOKEN = 'apns-tok-hex';
 // #1370 L5 — sendPushAck 호출 매칭 헬퍼. ack outcome별로 같은 token/pushId 페이로드를 반복 검증하는
 // 패턴이 다발해 SonarCloud 중복으로 잡힘. 호출 한 줄로 압축해 중복 차단.
 // #1768 — permissionMode 기본값 'always' (기본 mock: foreground+background 모두 granted).
+// #1772 — 'received' outcome은 batteryState 포함. latencyMs는 expect.any(Number)로 유연 검증.
 function ackCall(
   pushId: string,
   outcome: 'received' | 'fired' | 'skipped',
   reason?: string,
   permissionMode: 'always' | 'whileInUse' | 'denied' | undefined = 'always',
-): { pushId: string; token: string; outcome: string; reason?: string; permissionMode?: string } {
-  const base: { pushId: string; token: string; outcome: string; reason?: string; permissionMode?: string } = {
+): Record<string, unknown> {
+  const base: Record<string, unknown> = {
     pushId,
     token: DEFAULT_APNS_TOKEN,
     outcome,
     permissionMode,
   };
   if (reason !== undefined) base.reason = reason;
+  // #1772 — 'received' ack는 batteryState 포함 (기본 mock: lowPowerMode=false → 'normal').
+  // latencyMs는 테스트 실행 타이밍에 따라 달라지므로 expect.objectContaining으로 검증.
+  if (outcome === 'received') {
+    base.batteryState = 'normal';
+  }
   return base;
 }
 
@@ -1955,7 +1967,10 @@ describe('silentPushTask', () => {
         await handleSilentPush(
           payload({ kind: 'destination', phase: 'imminent', pushId: 'p-recv' }),
         );
-        expect(mockSendPushAck).toHaveBeenCalledWith(ackCall('p-recv', 'received'));
+        // #1772 — received ack는 batteryState 포함. latencyMs는 sentAt 없으면 undefined.
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          expect.objectContaining(ackCall('p-recv', 'received')),
+        );
         // 후속 outcome(fired) ack도 그대로 발사 — 별개 호출.
         expect(mockSendPushAck).toHaveBeenCalledWith(ackCall('p-recv', 'fired'));
       });
@@ -1970,7 +1985,9 @@ describe('silentPushTask', () => {
         await handleSilentPush(
           payload({ kind: 'destination', phase: 'imminent', pushId: 'p-recv-skip' }),
         );
-        expect(mockSendPushAck).toHaveBeenCalledWith(ackCall('p-recv-skip', 'received'));
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          expect.objectContaining(ackCall('p-recv-skip', 'received')),
+        );
         expect(mockSendPushAck).toHaveBeenCalledWith(
           ackCall('p-recv-skip', 'skipped', 'gate-out-of-range'),
         );
@@ -2011,12 +2028,16 @@ describe('silentPushTask', () => {
             },
           },
         });
-        expect(mockSendPushAck).toHaveBeenCalledWith({
-          pushId: 'rs-recv',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'received',
-          permissionMode: 'always',
-        });
+        // #1772 — received ack는 batteryState 포함. latencyMs는 sentAt 없을 때 undefined.
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          expect.objectContaining({
+            pushId: 'rs-recv',
+            token: DEFAULT_APNS_TOKEN,
+            outcome: 'received',
+            permissionMode: 'always',
+            batteryState: 'normal',
+          }),
+        );
       });
 
       it('trip-ended payload도 received ack 발사', async () => {
@@ -2031,12 +2052,88 @@ describe('silentPushTask', () => {
             },
           },
         });
-        expect(mockSendPushAck).toHaveBeenCalledWith({
-          pushId: 'te-recv',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'received',
-          permissionMode: 'always',
-        });
+        // #1772 — received ack는 batteryState 포함.
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          expect.objectContaining({
+            pushId: 'te-recv',
+            token: DEFAULT_APNS_TOKEN,
+            outcome: 'received',
+            permissionMode: 'always',
+            batteryState: 'normal',
+          }),
+        );
+      });
+    });
+
+    describe('#1772 — latencyMs + batteryState in received ack', () => {
+      it('sentAt 있는 payload → latencyMs = receivedAt - sentAt (양수)', async () => {
+        const sentAt = Date.now() - 2000; // 2초 전 발사
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-latency', sentAt }),
+        );
+        const receivedCall = mockSendPushAck.mock.calls.find(
+          (c: unknown[]) =>
+            (c[0] as { pushId?: string }).pushId === 'p-latency' &&
+            (c[0] as { outcome?: string }).outcome === 'received',
+        );
+        expect(receivedCall).toBeDefined();
+        const ackPayload = receivedCall![0] as { latencyMs?: number };
+        expect(typeof ackPayload.latencyMs).toBe('number');
+        expect(ackPayload.latencyMs).toBeGreaterThanOrEqual(0);
+      });
+
+      it('sentAt 없으면 latencyMs = undefined (구 backend 호환)', async () => {
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-no-sentat' }),
+        );
+        const receivedCall = mockSendPushAck.mock.calls.find(
+          (c: unknown[]) =>
+            (c[0] as { pushId?: string }).pushId === 'p-no-sentat' &&
+            (c[0] as { outcome?: string }).outcome === 'received',
+        );
+        expect(receivedCall).toBeDefined();
+        expect((receivedCall![0] as { latencyMs?: number }).latencyMs).toBeUndefined();
+      });
+
+      it('lowPowerMode=true → batteryState=lowPowerMode', async () => {
+        mockGetPowerStateAsync.mockResolvedValueOnce({ lowPowerMode: true });
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-lowpwr' }),
+        );
+        const receivedCall = mockSendPushAck.mock.calls.find(
+          (c: unknown[]) =>
+            (c[0] as { pushId?: string }).pushId === 'p-lowpwr' &&
+            (c[0] as { outcome?: string }).outcome === 'received',
+        );
+        expect(receivedCall).toBeDefined();
+        expect((receivedCall![0] as { batteryState?: string }).batteryState).toBe('lowPowerMode');
+      });
+
+      it('getPowerStateAsync throw → batteryState=unknown (graceful)', async () => {
+        mockGetPowerStateAsync.mockRejectedValueOnce(new Error('battery-fail'));
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-batt-fail' }),
+        );
+        const receivedCall = mockSendPushAck.mock.calls.find(
+          (c: unknown[]) =>
+            (c[0] as { pushId?: string }).pushId === 'p-batt-fail' &&
+            (c[0] as { outcome?: string }).outcome === 'received',
+        );
+        expect(receivedCall).toBeDefined();
+        expect((receivedCall![0] as { batteryState?: string }).batteryState).toBe('unknown');
+      });
+
+      it('fired/skipped ack에는 batteryState 포함 안 됨', async () => {
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-fired-nobatt' }),
+        );
+        const firedCall = mockSendPushAck.mock.calls.find(
+          (c: unknown[]) =>
+            (c[0] as { pushId?: string }).pushId === 'p-fired-nobatt' &&
+            (c[0] as { outcome?: string }).outcome === 'fired',
+        );
+        expect(firedCall).toBeDefined();
+        expect((firedCall![0] as { batteryState?: string }).batteryState).toBeUndefined();
       });
     });
 

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -26,6 +26,7 @@
 import * as Notifications from 'expo-notifications';
 import * as TaskManager from 'expo-task-manager';
 import * as Location from 'expo-location';
+import * as Battery from 'expo-battery';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import i18next from 'i18next';
 import {
@@ -695,21 +696,41 @@ async function resolvePermissionMode(): Promise<'always' | 'whileInUse' | 'denie
 }
 
 /**
+ * #1772 — expo-battery로 battery state를 조회한다.
+ * lowPowerMode ON → 'lowPowerMode', OFF → 'normal'. 실패 시 'unknown'.
+ */
+async function resolveBatteryState(): Promise<'normal' | 'lowPowerMode' | 'unknown'> {
+  try {
+    const state = await Battery.getPowerStateAsync();
+    return state.lowPowerMode ? 'lowPowerMode' : 'normal';
+  } catch {
+    return 'unknown';
+  }
+}
+
+/**
  * 백엔드 P2c fallback에서 이 push가 alert로 재발사되지 않도록 처리 결과를 통보한다 (#568 P2b).
  * fire-and-forget — 실패해도 silent push 본 처리 흐름에는 영향 없음.
  * 누락 입력(pushId/token 중 하나라도 null/undefined)은 그대로 skip한다:
  *   - pushId 누락 = 구 백엔드 호환 경로
  *   - token 누락 = APNs 권한 미부여/저장 실패
  * #1768 — permissionMode를 비동기로 resolve해 payload에 포함한다.
+ * #1772 — latencyMs(sentAt 기반 계산) + batteryState를 'received' ack에 포함한다.
  */
 async function ackOutcome(
   pushId: string | undefined,
   token: string | null,
   outcome: 'received' | 'fired' | 'skipped',
   reason?: string,
+  latencyMs?: number,
 ): Promise<void> {
   if (!pushId || !token) return;
   const permissionMode = await resolvePermissionMode();
+  if (outcome === 'received') {
+    const batteryState = await resolveBatteryState();
+    void sendPushAck({ pushId, token, outcome, reason, permissionMode, latencyMs, batteryState });
+    return;
+  }
   void sendPushAck({ pushId, token, outcome, reason, permissionMode });
 }
 
@@ -823,7 +844,11 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     //
     // pushId/token 둘 다 있어야 임의 echo 차단 정책을 지킬 수 있으므로 ackOutcome과 동일하게
     // 누락 시 skip한다 (구 backend 호환 경로).
-    void ackOutcome(payload.pushId, apnsToken, 'received');
+    // #1772 — latencyMs: sentAt이 valid number인 경우만 계산. 구 backend(sentAt 누락) graceful.
+    const latencyMs = typeof payload.sentAt === 'number' && Number.isFinite(payload.sentAt)
+      ? Math.max(0, receivedAt - payload.sentAt)
+      : undefined;
+    void ackOutcome(payload.pushId, apnsToken, 'received', undefined, latencyMs);
 
     // reschedule 분기 (#725). 백엔드는 사전 예약 알람(#584) 시각을 정정하려고 이 push를 보낸다.
     // - 수신 신호는 받았다 알리고(`lastReceivedAt` 갱신)

--- a/src/features/debug/components/OperationDashboardSection.tsx
+++ b/src/features/debug/components/OperationDashboardSection.tsx
@@ -62,7 +62,7 @@ interface MetricData {
 type BackendLoadState =
   | { kind: 'idle' }
   | { kind: 'loading' }
-  | { kind: 'ok'; locklessMiss: ObservabilityMetricsBucket; boardableMiss: ObservabilityMetricsBucket; accelPattern: AccelPatternBucket }
+  | { kind: 'ok'; locklessMiss: ObservabilityMetricsBucket; boardableMiss: ObservabilityMetricsBucket; accelPattern: AccelPatternBucket; pushLatency: { p50: number; p95: number; totalSamples: number } | null }
   | { kind: 'unconfigured' }
   | { kind: 'error'; message: string };
 
@@ -233,6 +233,41 @@ function AccelPatternRow({
   );
 }
 
+// ─── Push Latency Row ─────────────────────────────────────────────────────────
+
+/**
+ * #1772 — silent push latency p50/p95 행.
+ * undefined: backend 미수신 → "(no data)" 표시.
+ * null: backend 수신됐지만 latency 샘플 없음 → "(no samples yet)" 표시.
+ * 데이터 있으면 p50/p95/n 표시.
+ */
+function PushLatencyRow({
+  latency,
+  colors,
+}: {
+  latency: { p50: number; p95: number; totalSamples: number } | null | undefined;
+  colors: ReturnType<typeof useTheme>['colors'];
+}) {
+  return (
+    <View style={rowStyles.container} testID="operation-metric-pushLatency">
+      <Text style={[typography.mono, { color: colors.ink }]}>silentPushLatency</Text>
+      {latency === undefined ? (
+        <Text style={[typography.mono, { color: colors.muted }]} testID="push-latency-na">
+          (no data)
+        </Text>
+      ) : latency === null ? (
+        <Text style={[typography.mono, { color: colors.muted }]} testID="push-latency-empty">
+          (no samples yet)
+        </Text>
+      ) : (
+        <Text style={[typography.mono, { color: colors.subtle }]} testID="push-latency-values">
+          {`p50=${latency.p50}ms  p95=${latency.p95}ms  n=${latency.totalSamples}`}
+        </Text>
+      )}
+    </View>
+  );
+}
+
 // ─── Props ────────────────────────────────────────────────────────────────────
 
 export interface OperationDashboardSectionProps {
@@ -267,6 +302,7 @@ export function OperationDashboardSection({ logs }: OperationDashboardSectionPro
         locklessMiss: result.metrics.locklessMissRatio,
         boardableMiss: result.metrics.boardableMissRatio,
         accelPattern: result.metrics.accelPatternHitRatio,
+        pushLatency: result.metrics.silentPushLatency ?? null,
       });
     } else if (result.kind === 'unconfigured') {
       setBackendState({ kind: 'unconfigured' });
@@ -317,6 +353,12 @@ export function OperationDashboardSection({ logs }: OperationDashboardSectionPro
   const accelPatternData: AccelPatternBucket | null =
     backendState.kind === 'ok' ? backendState.accelPattern : null;
 
+  // Metric 6 — Silent push latency (#1772, backend 수신 시만 유효)
+  // undefined: backend 미수신 (idle/loading/error/unconfigured) — (no data) 표시
+  // null: backend 수신됐지만 샘플 없음 — (no samples yet) 표시
+  const pushLatencyData: { p50: number; p95: number; totalSamples: number } | null | undefined =
+    backendState.kind === 'ok' ? backendState.pushLatency : undefined;
+
   const metrics: MetricData[] = [alarmAccuracy, silentPushReach, locklessMiss, boardableMiss];
 
   const handleMetricPress = useCallback((key: DrillDownMetricKey) => {
@@ -349,6 +391,9 @@ export function OperationDashboardSection({ logs }: OperationDashboardSectionPro
 
       {/* Metric 5 — Accel pattern distribution (#1769) */}
       <AccelPatternRow accelPattern={accelPatternData} colors={colors} />
+
+      {/* Metric 6 — Silent push latency (#1772) */}
+      <PushLatencyRow latency={pushLatencyData} colors={colors} />
 
       {/* Drill-down expanded view */}
       {drillDownKey !== null && (

--- a/src/features/debug/components/__tests__/OperationDashboardSection.test.tsx
+++ b/src/features/debug/components/__tests__/OperationDashboardSection.test.tsx
@@ -86,6 +86,7 @@ function makeSuccessResult(
   boardableValue = 0,
   boardableTotal = 0,
   accelPattern: observabilityClient.AccelPatternBucket = DEFAULT_ACCEL_PATTERN,
+  pushLatency: { p50: number; p95: number; totalSamples: number } | null = null,
 ): observabilityClient.FetchMetricsResult {
   return {
     kind: 'ok',
@@ -95,6 +96,7 @@ function makeSuccessResult(
       locklessMissRatio: { value: locklessValue, total: locklessTotal, ratio: locklessValue / locklessTotal },
       boardableMissRatio: { value: boardableValue, total: boardableTotal, ratio: boardableTotal === 0 ? 0 : boardableValue / boardableTotal },
       accelPatternHitRatio: accelPattern,
+      silentPushLatency: pushLatency,
       window: '24h',
       timestamp: 1_700_000_000_000,
     },
@@ -381,6 +383,45 @@ describe('OperationDashboardSection', () => {
       await act(async () => { jest.runAllTimers(); });
       await waitFor(() => {
         expect(screen.getByTestId('accel-pattern-na')).toBeTruthy();
+      });
+    });
+  });
+
+  // ── #1772 Push Latency section ────────────────────────────────────────────────
+
+  describe('#1772 — pushLatency section', () => {
+    it('backend 미수신 상태에서 pushLatency row가 렌더되며 (no data) 표시', async () => {
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      expect(screen.getByTestId('operation-metric-pushLatency')).toBeTruthy();
+      expect(screen.getByTestId('push-latency-na')).toBeTruthy();
+    });
+
+    it('fetch 성공 but silentPushLatency=null → (no samples yet) 표시', async () => {
+      mockFetchMetrics.mockResolvedValue(makeSuccessResult(2, 10, 0, 0, DEFAULT_ACCEL_PATTERN, null));
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      await waitFor(() => {
+        expect(screen.getByTestId('push-latency-empty')).toBeTruthy();
+      });
+    });
+
+    it('fetch 성공 + silentPushLatency 있음 → p50/p95/n 표시', async () => {
+      mockFetchMetrics.mockResolvedValue(
+        makeSuccessResult(2, 10, 0, 0, DEFAULT_ACCEL_PATTERN, { p50: 350, p95: 800, totalSamples: 42 }),
+      );
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      await waitFor(() => {
+        expect(screen.getByTestId('push-latency-values')).toBeTruthy();
+      });
+    });
+
+    it('unconfigured 상태에서 pushLatency row (no data) 유지', async () => {
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      await waitFor(() => {
+        expect(screen.getByTestId('push-latency-na')).toBeTruthy();
       });
     });
   });

--- a/src/features/observability/api/observabilityMetricsClient.ts
+++ b/src/features/observability/api/observabilityMetricsClient.ts
@@ -31,6 +31,11 @@ export interface ObservabilityMetrics {
   boardableMissRatio: ObservabilityMetricsBucket;
   /** #1769 — accelerometer pattern 4종 분포 (24h rolling window). */
   accelPatternHitRatio: AccelPatternBucket;
+  /**
+   * #1772 — silent push latency 분포 (1h 윈도우 근사치).
+   * latencyMs stamp 있는 샘플만 집계. 샘플 0건이면 null.
+   */
+  silentPushLatency?: { p50: number; p95: number; totalSamples: number } | null;
   window: '24h';
   timestamp: number;
 }


### PR DESCRIPTION
Closes #1772

## Summary

- **backend**: `pendingPushes.stampReceived`에 `latencyMs` 계산 로직 추가 (device 명시값 우선, 누락 시 `receivedAt - sentAt` fallback), `batteryState` 필드 저장
- **backend**: `pushAckStats` P50/P95 latency 집계 + `receivedByBatteryState` 분포 추가
- **backend**: `observabilityMetrics`에 `silentPushLatency` metric 추가 (1h KV 근사치)
- **backend**: `validatePushAck` / `/push/ack` 핸들러에 `latencyMs` · `batteryState` 파싱/forward
- **device**: `silentPushTask` — `receivedAt - sentAt`으로 `latencyMs` 계산, `expo-battery getPowerStateAsync()`로 `batteryState` 결정, `received` ack에 포함 (battery state는 `received` ack에만, `fired`/`skipped`는 미포함)
- **device**: `alarmBackend.PushAckPayload` + `observabilityMetricsClient.ObservabilityMetrics` 타입 확장
- **UI**: `OperationDashboardSection`에 `silentPushLatency` p50/p95/n 행 추가

## Acceptance

| 시나리오 | 결과 |
|---|---|
| device received ack → backend KV `received:` stamp에 `latencyMs` 포함 | ✅ |
| legacy device (sentAt/latencyMs 없음) → KV fallback 계산 또는 graceful | ✅ |
| lowPowerMode ON → `batteryState=lowPowerMode`, OFF → `normal`, 실패 → `unknown` | ✅ |
| `pushAckStats` P50/P95 정렬 계산 정확성 | ✅ |
| `observabilityMetrics silentPushLatency` KV 없으면 null | ✅ |
| DebugModal latency 행: no data / no samples / p50+p95 3-state | ✅ |

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` 0 orphan. 신규 export 없음.
2. **V/X dashboard** — DebugModal `silentPushLatency` 행(p50/p95/n) 즉시 확인 가능. backend tail `received:<pushId>` stamp에 `latencyMs`/`batteryState` 포함.
3. **의존 PR** — N/A. `expo-battery` 이미 `package.json` 의존성에 존재.
4. **측정 plan** — EAS 빌드 후 1주 실기기 trip: DebugModal refresh로 `silentPushLatency` p50/p95 값 확인. backend KV `received:` prefix scan으로 latencyMs 분포 검증.
5. **Device verify** — `expo-battery getPowerStateAsync` 는 native API — device 실행 필요. type+unit CI pass. 실기기 전 device-only 회귀 가능성 있음.

## Battery state 처리

`expo-battery`가 이미 설치돼 있어 `getPowerStateAsync()` 사용. `lowPowerMode` 필드로 'normal' / 'lowPowerMode' / 'unknown'(실패 시) 결정. `received` ack에만 포함 — `fired`/`skipped`는 미포함으로 backward compat.