### PR TITLE
feat(#1778): DI compact 뷰 alarmType 긴박감 분기

### DIFF
--- a/targets/subway-widget/SubwayLiveActivityWidget.swift
+++ b/targets/subway-widget/SubwayLiveActivityWidget.swift
@@ -51,15 +51,22 @@ struct SubwayLiveActivityWidget: Widget {
                     .frame(width: 10, height: 10)
                     .padding(.leading, 2)
             } compactTrailing: {
-                Text(context.state.stationName)
+                let alarmType = context.state.alarmType
+                let trailingColor: Color = {
+                    if alarmType == "destination" { return .red }
+                    if alarmType == "transfer" { return .orange }
+                    return .white
+                }()
+                Text(alarmType == "destination" ? "🔴" : alarmType == "transfer" ? "🟠" : context.state.stationName)
                     .font(.caption2)
                     .fontWeight(.semibold)
-                    .foregroundColor(.white)
+                    .foregroundColor(trailingColor)
                     .lineLimit(1)
             } minimal: {
+                let alarmTypeMin = context.state.alarmType
                 Circle()
-                    .fill(context.state.alarmType != nil
-                          ? (context.state.alarmType == "destination" ? Color.red : Color.orange)
+                    .fill(alarmTypeMin == "destination" ? Color.red
+                          : alarmTypeMin == "transfer" ? Color.orange
                           : (Color(hex: context.state.lineColorHex) ?? .gray))
                     .frame(width: 10, height: 10)
             }


### PR DESCRIPTION
## Summary
- `compactTrailing`: `alarmType == 'destination'` → 🔴 빨강 텍스트, `'transfer'` → 🟠 주황 텍스트, 그 외 → 역명 흰색 (기존 유지)
- `minimal`: 동일 패턴 — `destination` → red, `transfer` → orange, 기본 → lineColor
- `LockScreenView` 변경 없음

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (Swift-only 변경, TS export 없음)
2. **V/X dashboard** — 실기기 Dynamic Island compact/minimal 뷰에서 alarmType별 색상·이모지 시각 확인
3. **의존 PR** — N/A
4. **측정 plan** — 실기기 trip에서 destination/transfer 알람 발사 시 DI 색상 변화 캡처
5. **Device verify** — Swift 위젯 변경. expo prebuild + iOS 빌드 필수. 시뮬레이터에서 Live Activity 미지원이므로 실기기 확인 권장

Closes #1778