### PR TITLE
fix(#1776): Widget Swift 4언어 로컬라이제이션

### DIFF
--- a/targets/subway-widget/Localizable.xcstrings
+++ b/targets/subway-widget/Localizable.xcstrings
@@ -1,0 +1,180 @@
+{
+  "sourceLanguage" : "ko",
+  "strings" : {
+    "widget.detecting" : {
+      "comment" : "Placeholder station name while GPS detection is in progress",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detecting"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "감지 중"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "检测中"
+          }
+        }
+      }
+    },
+    "widget.freshness.stale" : {
+      "comment" : "Caption shown when widget data is stale (2–10 min old)",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update delayed"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新遅延"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "갱신 지연"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新延迟"
+          }
+        }
+      }
+    },
+    "widget.freshness.expired" : {
+      "comment" : "Caption shown when widget data is expired (>10 min old)",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Info outdated"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "情報が古い"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "정보 오래됨"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "信息已过期"
+          }
+        }
+      }
+    },
+    "widget.header" : {
+      "comment" : "Header label shown above the station name in the widget",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Subway"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "地下鉄"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "지하철"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "地铁"
+          }
+        }
+      }
+    },
+    "widget.displayName" : {
+      "comment" : "Widget configuration display name shown in the widget picker",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Current Station"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在の駅"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "지하철 현재 역"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前地铁站"
+          }
+        }
+      }
+    },
+    "widget.description" : {
+      "comment" : "Widget description shown in the widget picker",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "See the nearest subway station on your Home Screen."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホーム画面で最寄り駅を確認できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "가장 가까운 지하철역을 홈 화면에서 확인하세요."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在主屏幕上查看最近的地铁站。"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/targets/subway-widget/SubwayWidget.swift
+++ b/targets/subway-widget/SubwayWidget.swift
@@ -80,7 +80,7 @@ struct SubwayProvider: TimelineProvider {
 
         return SubwayEntry(
             date: Date(),
-            stationName: isAvailable ? name : "감지 중",
+            stationName: isAvailable ? name : NSLocalizedString("widget.detecting", comment: "Placeholder station name while GPS detection is in progress"),
             lineColor: color,
             distanceM: distance,
             isAvailable: isAvailable,
@@ -118,8 +118,8 @@ struct SubwayWidgetView: View {
 
     var freshnessCaption: String? {
         switch freshness {
-        case .stale: return "갱신 지연"
-        case .expired: return "정보 오래됨"
+        case .stale: return NSLocalizedString("widget.freshness.stale", comment: "Caption shown when widget data is stale (2–10 min old)")
+        case .expired: return NSLocalizedString("widget.freshness.expired", comment: "Caption shown when widget data is expired (>10 min old)")
         case .fresh, .unknown: return nil
         }
     }
@@ -145,7 +145,7 @@ struct SubwayWidgetView: View {
                 Circle()
                     .fill(lineColor)
                     .frame(width: 10, height: 10)
-                Text("지하철")
+                Text(NSLocalizedString("widget.header", comment: "Header label shown above the station name in the widget"))
                     .font(.caption2)
                     .foregroundColor(.secondary)
             }
@@ -190,8 +190,8 @@ struct SubwayWidget: Widget {
         StaticConfiguration(kind: kind, provider: SubwayProvider()) { entry in
             SubwayWidgetView(entry: entry)
         }
-        .configurationDisplayName("지하철 현재 역")
-        .description("가장 가까운 지하철역을 홈 화면에서 확인하세요.")
+        .configurationDisplayName(NSLocalizedString("widget.displayName", comment: "Widget configuration display name shown in the widget picker"))
+        .description(NSLocalizedString("widget.description", comment: "Widget description shown in the widget picker"))
         .supportedFamilies([.systemSmall, .systemMedium])
     }
 }


### PR DESCRIPTION
## Summary
- `targets/subway-widget/Localizable.xcstrings` 신규 추가 — 6개 키, ko/en/ja/zh-Hans 4언어 완비
- `SubwayWidget.swift` 하드코딩 한국어 5곳 → `NSLocalizedString()` 교체 (L83 detecting / L121 stale / L122 expired / L148 header / L193-194 displayName+description)

Closes #1776

## Wire-completion 5단 체크

1. **Orphan 없음** — `npm run lint:orphan` pass (Swift 파일, JS orphan 검사 대상 아님)
2. **V/X dashboard** — 위젯 텍스트는 iOS 위젯 홈 화면에서 직접 확인. 언어별 iOS 기기 설정 변경 후 위젯 표시 문자열로 검증
3. **의존 PR** — N/A. `expo prebuild` 시 `@bacons/apple-targets`가 `Localizable.xcstrings`를 자동으로 Xcode 프로젝트에 포함
4. **측정 plan** — 기기 언어를 en/ja/zh로 변경 후 위젯 텍스트 정합 확인 (1회성 device verify)
5. **Device verify** — 실기기 빌드 후 위젯 4언어 표시 확인 필요. CI는 type+unit only (Swift 빌드 제외)