### PR TITLE
feat(#1777): 핵심 인터랙션 햅틱 피드백 (expo-haptics)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "expo-battery": "~10.0.8",
         "expo-constants": "~18.0.13",
         "expo-dev-client": "~6.0.20",
+        "expo-haptics": "~14.0.1",
         "expo-linking": "~8.0.11",
         "expo-localization": "~17.0.8",
         "expo-location": "~19.0.8",
@@ -8427,6 +8428,15 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-haptics": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-14.0.1.tgz",
+      "integrity": "sha512-V81FZ7xRUfqM6uSI6FA1KnZ+QpEKnISqafob/xEfcx1ymwhm4V3snuLWWFjmAz+XaZQTqlYa8z3QbqEXz7G63w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-json-utils": {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "expo-battery": "~10.0.8",
     "expo-constants": "~18.0.13",
     "expo-dev-client": "~6.0.20",
+    "expo-haptics": "~14.0.1",
     "expo-linking": "~8.0.11",
     "expo-localization": "~17.0.8",
     "expo-location": "~19.0.8",

--- a/src/features/alarm/components/BoardingTrainList.tsx
+++ b/src/features/alarm/components/BoardingTrainList.tsx
@@ -8,6 +8,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
+import * as Haptics from 'expo-haptics';
 import { useTranslation } from 'react-i18next';
 import { useTheme, typography, spacing, radius } from '../../../shared/theme';
 import { LineBadge } from '../../../shared/ui/LineBadge';
@@ -263,6 +264,7 @@ export function BoardingTrainList({
       if (isReleasingRef.current) return;
       // 이미 다른 row가 pending이면 무시(중복 탭 방지). 같은 row 재탭도 무시.
       if (pendingTrainCode != null) return;
+      void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
       setPendingTrainCode(train.trainCode);
       clearRollbackTimer();
       rollbackTimerRef.current = setTimeout(() => {

--- a/src/features/alarm/components/LocklessBadge.tsx
+++ b/src/features/alarm/components/LocklessBadge.tsx
@@ -1,4 +1,5 @@
 import { Pressable, StyleSheet, Text, View } from 'react-native';
+import * as Haptics from 'expo-haptics';
 import { useTranslation } from 'react-i18next';
 import { useTheme, typography, spacing, radius } from '../../../shared/theme';
 
@@ -17,9 +18,14 @@ export function LocklessBadge({ onPress }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
 
+  const handlePress = (): void => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    onPress();
+  };
+
   return (
     <Pressable
-      onPress={onPress}
+      onPress={handlePress}
       style={[styles.badge, { backgroundColor: colors.warn + '22', borderColor: colors.warn }]}
       testID="lockless-badge"
       accessibilityRole="button"

--- a/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent } from '@testing-library/react-native';
+import * as Haptics from 'expo-haptics';
 import { BoardingTrainList } from '../BoardingTrainList';
 import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
 import { LINE_COLORS } from '../../../../shared/constants/lineColors';
@@ -8,6 +9,13 @@ import {
   getLockCorrectionMetrics,
   resetLockCorrectionMetrics,
 } from '../../utils/lockCorrectionMetrics';
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn().mockResolvedValue(undefined),
+  ImpactFeedbackStyle: { Light: 'Light', Medium: 'Medium', Heavy: 'Heavy' },
+  NotificationFeedbackType: { Success: 'Success', Warning: 'Warning', Error: 'Error' },
+  notificationAsync: jest.fn().mockResolvedValue(undefined),
+}));
 
 function makeTrain(overrides: Partial<ArrivalInfo> = {}): ArrivalInfo {
   return {
@@ -26,6 +34,10 @@ function makeTrain(overrides: Partial<ArrivalInfo> = {}): ArrivalInfo {
 }
 
 describe('BoardingTrainList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('arrivals 비어있을 때 placeholder 렌더 (#915 후속: i18n 키 사용)', () => {
     const { getByTestId, getByText } = renderWithTheme(
       <BoardingTrainList arrivals={[]} line="2" onSelect={() => {}} />,
@@ -1161,6 +1173,29 @@ describe('BoardingTrainList', () => {
       } finally {
         jest.useRealTimers();
       }
+    });
+  });
+
+  describe('#1777 햅틱 피드백', () => {
+    it('열차 row 탭 시 Medium 햅틱이 발사된다', () => {
+      const train = makeTrain({ trainCode: 'T-HAPTIC' });
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
+      );
+      fireEvent.press(getByTestId('boarding-train-row-T-HAPTIC'));
+      expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Medium);
+    });
+
+    it('pending 중 탭은 햅틱을 발사하지 않는다 (중복 탭 방지)', () => {
+      const a = makeTrain({ trainCode: 'T-A' });
+      const b = makeTrain({ trainCode: 'T-B' });
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[a, b]} line="2" onSelect={() => {}} />,
+      );
+      fireEvent.press(getByTestId('boarding-train-row-T-A'));
+      jest.clearAllMocks();
+      fireEvent.press(getByTestId('boarding-train-row-T-B'));
+      expect(Haptics.impactAsync).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/alarm/components/__tests__/LocklessBadge.test.tsx
+++ b/src/features/alarm/components/__tests__/LocklessBadge.test.tsx
@@ -1,8 +1,20 @@
 import { fireEvent } from '@testing-library/react-native';
+import * as Haptics from 'expo-haptics';
 import { LocklessBadge } from '../LocklessBadge';
 import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
 
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn().mockResolvedValue(undefined),
+  ImpactFeedbackStyle: { Light: 'Light', Medium: 'Medium', Heavy: 'Heavy' },
+  NotificationFeedbackType: { Success: 'Success', Warning: 'Warning', Error: 'Error' },
+  notificationAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
 describe('LocklessBadge (#1755)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('badge와 "탑승 확인하기" 텍스트를 렌더한다', () => {
     const { getByTestId, getByText } = renderWithTheme(
       <LocklessBadge onPress={() => {}} />,
@@ -19,6 +31,14 @@ describe('LocklessBadge (#1755)', () => {
     );
     fireEvent.press(getByTestId('lockless-badge'));
     expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('탭 시 Light 햅틱이 발사된다 (#1777)', () => {
+    const { getByTestId } = renderWithTheme(
+      <LocklessBadge onPress={() => {}} />,
+    );
+    fireEvent.press(getByTestId('lockless-badge'));
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Light);
   });
 
   it('accessibilityRole이 button이다', () => {

--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { AppState } from 'react-native';
+import * as Haptics from 'expo-haptics';
 import {
   useBoardingLockController,
   type UseBoardingLockControllerInputs,
@@ -12,6 +13,13 @@ import {
   makeDirectRoute,
   makeTransferRoute,
 } from '../../../../testUtils/routeFixtures';
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn().mockResolvedValue(undefined),
+  ImpactFeedbackStyle: { Light: 'Light', Medium: 'Medium', Heavy: 'Heavy' },
+  NotificationFeedbackType: { Success: 'Success', Warning: 'Warning', Error: 'Error' },
+  notificationAsync: jest.fn().mockResolvedValue(undefined),
+}));
 
 const mockGetBoardingLock = jest.fn();
 const mockSetBoardingLock = jest.fn();
@@ -392,6 +400,30 @@ describe('useBoardingLockController', () => {
           expect.objectContaining({ trainCode: 'T-9', boardingLine: '9' }),
         );
       });
+    });
+
+    it('#1777 lock 생성 성공 시 Success 햅틱이 발사된다', async () => {
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      await act(async () => {
+        result.current.createLockFromTrain(makeTrain({ trainCode: 'T-HAPTIC' }));
+      });
+      await waitFor(() => {
+        expect(Haptics.notificationAsync).toHaveBeenCalledWith(
+          Haptics.NotificationFeedbackType.Success,
+        );
+      });
+    });
+
+    it('#1777 lock 생성 실패(store rejection) 시 햅틱 미발사 — graceful no-op', async () => {
+      mockSetBoardingLock.mockRejectedValueOnce(new Error('storage fail'));
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      await act(async () => {
+        result.current.createLockFromTrain(makeTrain({ trainCode: 'T-FAIL' }));
+      });
+      await waitFor(() => {
+        expect(mockSetBoardingLock).toHaveBeenCalled();
+      });
+      expect(Haptics.notificationAsync).not.toHaveBeenCalled();
     });
   });
 

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -8,6 +8,7 @@
  */
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { AppState, type AppStateStatus } from 'react-native';
+import * as Haptics from 'expo-haptics';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import { resolveTripDirection } from '../../route/utils/tripDirection';
 import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
@@ -289,6 +290,10 @@ export function useBoardingLockController({
         // #897 Seam A: 탑승 시점 ETA 스냅샷. 동일 trainCode가 유지되는 동안 새 폴링의 arrivalSeconds가
         // 이 값보다 크게 늘면 그 차이가 지연(분). BoardingTrainList가 "+N분 지연" 칩으로 노출.
         initialEtaSeconds: train.arrivalSeconds,
+      }).then(() => {
+        void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      }).catch(() => {
+        // store action rejection은 graceful — 다음 polling cycle에서 자연 재시도.
       });
     },
     [destinationId, currentStation, expectedDurationMinutes, createLock, allowedLines],


### PR DESCRIPTION
## Summary

- `expo-haptics ~14.0.1` 의존성 추가 (Expo SDK 54 호환)
- `LocklessBadge` 탭 → `ImpactFeedbackStyle.Light`
- `BoardingTrainList` 열차 row 탭 → `ImpactFeedbackStyle.Medium`
- `useBoardingLockController.createLockFromTrain` 성공 → `NotificationFeedbackType.Success`

Closes #1777

## Wire-completion 5단 체크

1. **Orphan 없음** — `npm run lint:orphan` 0 orphan pass. expo-haptics는 신규 export 없음.
2. **V/X dashboard** — 햅틱은 device 감각 채널. DebugModal 시각 관측 대상 없음 (N/A).
3. **의존 PR** — N/A.
4. **측정 plan** — 햅틱 오발화는 unit 테스트로 커버. 실기기 탭 시 진동 여부는 사용자 수동 확인.
5. **Device verify** — 실기기 검증 필요. 시나리오: (a) LocklessBadge 탭 → 약한 진동, (b) BoardingTrainList row 탭 → 중간 진동, (c) lock 부착 성공 → 성공 패턴 진동. Android는 vibrate fallback.

## Test plan

- [x] `npm test` 100% coverage (7783 tests, 377 suites)
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` 0 orphan
- [ ] 실기기: LocklessBadge 탭 → Light 진동 확인
- [ ] 실기기: 열차 row 탭 → Medium 진동 확인
- [ ] 실기기: lock 부착 성공 → Success 진동 패턴 확인
- [ ] Android: 진동 fallback 정상 동작 확인