### PR TITLE
feat(#1779): LA push 도달률 metric + analytics forward

### DIFF
--- a/backend/alarm-worker/src/__tests__/laPushCounters.test.ts
+++ b/backend/alarm-worker/src/__tests__/laPushCounters.test.ts
@@ -1,0 +1,137 @@
+/**
+ * laPushCounters.test.ts — #1779 LA push counter accumulation unit tests.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { InMemoryKV } from './inMemoryKv';
+import {
+  accumulateLaPushCounters,
+  laPushCounterKey,
+  LA_PUSH_COUNTER_KEY_PREFIX,
+  sumLaPushCounters,
+} from '../laPushCounters';
+
+const NOW = 1_700_000_000_000;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// laPushCounterKey
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('laPushCounterKey', () => {
+  it('returns same key within the same 1h window', () => {
+    const base = Math.floor(NOW / (60 * 60 * 1000)) * (60 * 60 * 1000);
+    expect(laPushCounterKey(base)).toBe(laPushCounterKey(base + 59 * 60 * 1000));
+  });
+
+  it('returns different key for next hour', () => {
+    const k1 = laPushCounterKey(NOW);
+    const k2 = laPushCounterKey(NOW + 60 * 60 * 1000);
+    expect(k1).not.toBe(k2);
+  });
+
+  it('key starts with LA_PUSH_COUNTER_KEY_PREFIX', () => {
+    expect(laPushCounterKey(NOW)).toMatch(new RegExp(`^${LA_PUSH_COUNTER_KEY_PREFIX}`));
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// accumulateLaPushCounters
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('accumulateLaPushCounters', () => {
+  it('no-op when sent+failed=0', async () => {
+    const kv = new InMemoryKV();
+    await accumulateLaPushCounters(kv as unknown as KVNamespace, 0, 0, NOW);
+    expect(kv.store.size).toBe(0);
+  });
+
+  it('writes first entry for new bucket', async () => {
+    const kv = new InMemoryKV();
+    await accumulateLaPushCounters(kv as unknown as KVNamespace, 5, 1, NOW);
+    const key = laPushCounterKey(NOW);
+    const raw = kv.store.get(key)?.value;
+    expect(raw).toBeDefined();
+    const parsed = JSON.parse(raw as string) as { sent: number; failed: number };
+    expect(parsed.sent).toBe(5);
+    expect(parsed.failed).toBe(1);
+  });
+
+  it('accumulates on existing bucket entry', async () => {
+    const kv = new InMemoryKV();
+    await accumulateLaPushCounters(kv as unknown as KVNamespace, 3, 1, NOW);
+    await accumulateLaPushCounters(kv as unknown as KVNamespace, 2, 0, NOW);
+    const key = laPushCounterKey(NOW);
+    const raw = kv.store.get(key)?.value;
+    const parsed = JSON.parse(raw as string) as { sent: number; failed: number };
+    expect(parsed.sent).toBe(5);
+    expect(parsed.failed).toBe(1);
+  });
+
+  it('treats malformed existing value as zero baseline', async () => {
+    const kv = new InMemoryKV();
+    const key = laPushCounterKey(NOW);
+    kv.store.set(key, { value: '{bad-json' });
+    await accumulateLaPushCounters(kv as unknown as KVNamespace, 4, 2, NOW);
+    const raw = kv.store.get(key)?.value;
+    const parsed = JSON.parse(raw as string) as { sent: number; failed: number };
+    expect(parsed.sent).toBe(4);
+    expect(parsed.failed).toBe(2);
+  });
+
+  it('uses 25h TTL for KV put', async () => {
+    const kv = new InMemoryKV();
+    const before = Date.now();
+    await accumulateLaPushCounters(kv as unknown as KVNamespace, 1, 0, NOW);
+    const after = Date.now();
+    const key = laPushCounterKey(NOW);
+    const entry = kv.store.get(key);
+    expect(entry?.expiresAt).toBeGreaterThan(before + 24 * 60 * 60 * 1000);
+    expect(entry?.expiresAt).toBeLessThanOrEqual(after + 26 * 60 * 60 * 1000);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// sumLaPushCounters
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('sumLaPushCounters', () => {
+  it('returns 0/0 when no entries exist', async () => {
+    const kv = new InMemoryKV();
+    const result = await sumLaPushCounters(kv as unknown as KVNamespace, NOW);
+    expect(result.sent).toBe(0);
+    expect(result.failed).toBe(0);
+  });
+
+  it('sums current hour bucket', async () => {
+    const kv = new InMemoryKV();
+    await accumulateLaPushCounters(kv as unknown as KVNamespace, 10, 2, NOW);
+    const result = await sumLaPushCounters(kv as unknown as KVNamespace, NOW);
+    expect(result.sent).toBe(10);
+    expect(result.failed).toBe(2);
+  });
+
+  it('sums across multiple hour buckets within 24h window', async () => {
+    const kv = new InMemoryKV();
+    // bucket N (current)
+    await accumulateLaPushCounters(kv as unknown as KVNamespace, 5, 1, NOW);
+    // bucket N-1 (1h ago)
+    await accumulateLaPushCounters(kv as unknown as KVNamespace, 3, 0, NOW - 60 * 60 * 1000);
+    // bucket N-23 (23h ago — within window)
+    await accumulateLaPushCounters(kv as unknown as KVNamespace, 2, 1, NOW - 23 * 60 * 60 * 1000);
+    const result = await sumLaPushCounters(kv as unknown as KVNamespace, NOW);
+    expect(result.sent).toBe(10);
+    expect(result.failed).toBe(2);
+  });
+
+  it('ignores malformed bucket entries', async () => {
+    const kv = new InMemoryKV();
+    // Good entry
+    await accumulateLaPushCounters(kv as unknown as KVNamespace, 7, 1, NOW);
+    // Malformed entry for previous bucket
+    const prevKey = `${LA_PUSH_COUNTER_KEY_PREFIX}${Math.floor(NOW / (60 * 60 * 1000)) - 1}`;
+    kv.store.set(prevKey, { value: 'not-json' });
+    const result = await sumLaPushCounters(kv as unknown as KVNamespace, NOW);
+    expect(result.sent).toBe(7);
+    expect(result.failed).toBe(1);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
+++ b/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
@@ -58,6 +58,7 @@ describe('storeObservabilityMetrics + readObservabilityMetrics', () => {
         unknown: { count: 0, ratio: 0 },
       },
       silentPushLatency: null,
+      laPushDeliveryRatio: { sent: 10, failed: 2, ratio: 10 / 12 },
       window: '24h' as const,
       timestamp: NOW,
     };
@@ -94,6 +95,7 @@ describe('storeObservabilityMetrics + readObservabilityMetrics', () => {
         unknown: { count: 0, ratio: 0 },
       },
       silentPushLatency: null,
+      laPushDeliveryRatio: { sent: 0, failed: 0, ratio: 0 },
       window: '24h' as const,
       timestamp: NOW,
     };
@@ -398,5 +400,67 @@ describe('computeObservabilityMetrics — accelPatternHitRatio (#1769)', () => {
       accelPatternHitRatio.stationary.ratio +
       accelPatternHitRatio.unknown.ratio;
     expect(ratioSum).toBeCloseTo(1.0);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// computeObservabilityMetrics — laPushDeliveryRatio (#1779)
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('computeObservabilityMetrics — laPushDeliveryRatio (#1779)', () => {
+  it('no tripsKv → placeholder 0/0/0', async () => {
+    const r2 = makeEmptyFakeR2();
+    const result = await computeObservabilityMetrics(r2, undefined, NOW, undefined);
+    expect(result.laPushDeliveryRatio).toEqual({ sent: 0, failed: 0, ratio: 0 });
+  });
+
+  it('empty tripsKv → 0/0/0', async () => {
+    const r2 = makeEmptyFakeR2();
+    const kv = new InMemoryKV();
+    const result = await computeObservabilityMetrics(r2, undefined, NOW, kv as unknown as KVNamespace);
+    expect(result.laPushDeliveryRatio).toEqual({ sent: 0, failed: 0, ratio: 0 });
+  });
+
+  it('computes sent/(sent+failed) from accumulated KV counters', async () => {
+    const r2 = makeEmptyFakeR2();
+    const kv = new InMemoryKV();
+    // Pre-populate la-push-counters bucket for current hour
+    const bucket = Math.floor(NOW / (60 * 60 * 1000));
+    kv.store.set(`la-push-counters:${bucket}`, {
+      value: JSON.stringify({ sent: 8, failed: 2 }),
+    });
+    const result = await computeObservabilityMetrics(r2, undefined, NOW, kv as unknown as KVNamespace);
+    expect(result.laPushDeliveryRatio.sent).toBe(8);
+    expect(result.laPushDeliveryRatio.failed).toBe(2);
+    expect(result.laPushDeliveryRatio.ratio).toBeCloseTo(0.8);
+  });
+
+  it('all sent (failed=0) → ratio=1', async () => {
+    const r2 = makeEmptyFakeR2();
+    const kv = new InMemoryKV();
+    const bucket = Math.floor(NOW / (60 * 60 * 1000));
+    kv.store.set(`la-push-counters:${bucket}`, {
+      value: JSON.stringify({ sent: 5, failed: 0 }),
+    });
+    const result = await computeObservabilityMetrics(r2, undefined, NOW, kv as unknown as KVNamespace);
+    expect(result.laPushDeliveryRatio.ratio).toBe(1);
+  });
+
+  it('all failed (sent=0) → ratio=0', async () => {
+    const r2 = makeEmptyFakeR2();
+    const kv = new InMemoryKV();
+    const bucket = Math.floor(NOW / (60 * 60 * 1000));
+    kv.store.set(`la-push-counters:${bucket}`, {
+      value: JSON.stringify({ sent: 0, failed: 3 }),
+    });
+    const result = await computeObservabilityMetrics(r2, undefined, NOW, kv as unknown as KVNamespace);
+    expect(result.laPushDeliveryRatio.ratio).toBe(0);
+    expect(result.laPushDeliveryRatio.failed).toBe(3);
+  });
+
+  it('laPushDeliveryRatio included in response shape', async () => {
+    const r2 = makeEmptyFakeR2();
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    expect('laPushDeliveryRatio' in result).toBe(true);
   });
 });

--- a/backend/alarm-worker/src/analytics.ts
+++ b/backend/alarm-worker/src/analytics.ts
@@ -21,6 +21,7 @@ import type { AnalyticsEngineWriter, Env } from './types';
  *  - `motion-transition`: SSoT motionState 전환 (moving ↔ stationary ↔ unknown)
  *  - `position-upload`  : POST `/position` 수신 (V8a 적재 카운터)
  *  - `trip-mutation`    : POST `/trips` 수신 (V8b 적재 카운터)
+ *  - `la-push`          : Live Activity push 발사 결과 (#1779)
  */
 export type TripMetricEventType =
   | 'advance'
@@ -28,7 +29,8 @@ export type TripMetricEventType =
   | 'suppress'
   | 'motion-transition'
   | 'position-upload'
-  | 'trip-mutation';
+  | 'trip-mutation'
+  | 'la-push';
 
 /**
  * 적재 event shape. `tripToken`은 index, dimensions는 blob, metrics는 double로 매핑된다.

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -1109,7 +1109,7 @@ app.get('/v1/observability/metrics', async (c) => {
   if (cached) return c.json(cached);
 
   // 첫 요청 또는 KV TTL 만료(1h) 시 실시간 계산 후 KV 적재.
-  const metrics = await computeObservabilityMetrics(r2, c.env.PENDING_PUSHES, now);
+  const metrics = await computeObservabilityMetrics(r2, c.env.PENDING_PUSHES, now, c.env.TRIPS);
   await storeObservabilityMetrics(c.env.TRIPS, metrics, now);
   return c.json(metrics);
 });
@@ -2123,7 +2123,7 @@ export default {
       const now = Date.now();
       const existing = await readObservabilityMetrics(env.TRIPS, now);
       if (!existing) {
-        const metrics = await computeObservabilityMetrics(env.TELEMETRY_R2, env.PENDING_PUSHES, now);
+        const metrics = await computeObservabilityMetrics(env.TELEMETRY_R2, env.PENDING_PUSHES, now, env.TRIPS);
         await storeObservabilityMetrics(env.TRIPS, metrics, now);
         log('observability metrics aggregated', { window: '24h', timestamp: now });
       }

--- a/backend/alarm-worker/src/laPushCounters.ts
+++ b/backend/alarm-worker/src/laPushCounters.ts
@@ -1,0 +1,78 @@
+/**
+ * LA push delivery counter accumulation (#1779).
+ *
+ * cron cycle 완료 시 laPushSent / laPushFailed를 1h bucket KV에 누적.
+ * computeObservabilityMetrics가 24h bucket 합산으로 laPushDeliveryRatio를 산출한다.
+ *
+ * scheduled.ts, observabilityMetrics.ts 양쪽이 공유하는 독립 모듈.
+ */
+
+/** KV key prefix for per-hour LA push counters. */
+export const LA_PUSH_COUNTER_KEY_PREFIX = 'la-push-counters:';
+
+/** TTL 25h — covers 24h rolling scan. */
+const LA_PUSH_COUNTER_TTL_SEC = 25 * 60 * 60;
+
+/** 1h bucket key for LA push counters. */
+export function laPushCounterKey(now: number): string {
+  const bucket = Math.floor(now / (60 * 60 * 1000));
+  return `${LA_PUSH_COUNTER_KEY_PREFIX}${bucket}`;
+}
+
+/**
+ * cron cycle 완료 후 laPushSent / laPushFailed를 현재 1h bucket KV에 누적.
+ * sent+failed=0이면 no-op (불필요한 KV write 차단).
+ */
+export async function accumulateLaPushCounters(
+  tripsKv: KVNamespace,
+  sent: number,
+  failed: number,
+  now: number,
+): Promise<void> {
+  if (sent + failed === 0) return;
+  const key = laPushCounterKey(now);
+  const raw = await tripsKv.get(key);
+  let prevSent = 0;
+  let prevFailed = 0;
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as { sent: number; failed: number };
+      prevSent = parsed.sent;
+      prevFailed = parsed.failed;
+    } catch {
+      // malformed — start fresh
+    }
+  }
+  await tripsKv.put(
+    key,
+    JSON.stringify({ sent: prevSent + sent, failed: prevFailed + failed }),
+    { expirationTtl: LA_PUSH_COUNTER_TTL_SEC },
+  );
+}
+
+/**
+ * 지난 24h의 bucket 합산으로 총 sent / failed를 산출.
+ * 1h 단위 24 bucket을 KV.get으로 순차 조회 (KV cost: 최대 24 gets).
+ */
+export async function sumLaPushCounters(
+  tripsKv: KVNamespace,
+  now: number,
+): Promise<{ sent: number; failed: number }> {
+  const currentBucket = Math.floor(now / (60 * 60 * 1000));
+  let totalSent = 0;
+  let totalFailed = 0;
+  for (let i = 0; i < 24; i++) {
+    const bucket = currentBucket - i;
+    const key = `${LA_PUSH_COUNTER_KEY_PREFIX}${bucket}`;
+    const raw = await tripsKv.get(key);
+    if (!raw) continue;
+    try {
+      const parsed = JSON.parse(raw) as { sent: number; failed: number };
+      totalSent += parsed.sent;
+      totalFailed += parsed.failed;
+    } catch {
+      // malformed — skip
+    }
+  }
+  return { sent: totalSent, failed: totalFailed };
+}

--- a/backend/alarm-worker/src/observabilityMetrics.ts
+++ b/backend/alarm-worker/src/observabilityMetrics.ts
@@ -33,6 +33,7 @@
 
 import { computeAlarmLogStats } from './alarmLogStats';
 import { computePushAckStats } from './pushAckStats';
+import { sumLaPushCounters } from './laPushCounters';
 
 /** 집계 KV 키 prefix. */
 const METRICS_KEY_PREFIX = 'obs-metrics:24h:';
@@ -61,6 +62,8 @@ export interface ObservabilityMetricsResponse {
    * latencyMs stamp 있는 샘플만 집계. 샘플 0건이면 null.
    */
   silentPushLatency: { p50: number; p95: number; totalSamples: number } | null;
+  /** #1779 — LA push 도달률 (sent / (sent + failed), 24h rolling window). */
+  laPushDeliveryRatio: { sent: number; failed: number; ratio: number };
   window: '24h';
   timestamp: number;
 }
@@ -75,16 +78,18 @@ export function hourBucketKey(now: number): string {
 }
 
 /**
- * R2 alarmLog scan으로 4 metric 계산.
+ * R2 alarmLog scan으로 metric 계산.
  *
  * @param r2 TELEMETRY_R2 bucket
  * @param pendingPushesKv PENDING_PUSHES KV namespace (optional)
  * @param now 현재 epoch ms
+ * @param tripsKv TRIPS KV namespace — laPushDeliveryRatio 산출용 (optional, 미설정 시 placeholder)
  */
 export async function computeObservabilityMetrics(
   r2: R2Bucket,
   pendingPushesKv: KVNamespace | undefined,
   now: number,
+  tripsKv?: KVNamespace,
 ): Promise<ObservabilityMetricsResponse> {
   // 1. R2 alarmLog 24h scan — accuracyRatio + locklessMissRatio 원천
   const alarmStats = await computeAlarmLogStats(r2, now, 24, 500);
@@ -115,6 +120,20 @@ export async function computeObservabilityMetrics(
   // stationName 슬롯에 인코딩된 pattern(automotive/walking/stationary/unknown) 분포 산출.
   const accelPatternHitRatio = buildAccelPatternBucket(alarmStats.accelPatternCounts);
 
+  // 5. #1779 — laPushDeliveryRatio. TRIPS KV la-push-counters:{bucket} 24h 합산.
+  let laPushDeliveryRatio: ObservabilityMetricsResponse['laPushDeliveryRatio'];
+  if (tripsKv !== undefined) {
+    const laCounts = await sumLaPushCounters(tripsKv, now);
+    const laTotal = laCounts.sent + laCounts.failed;
+    laPushDeliveryRatio = {
+      sent: laCounts.sent,
+      failed: laCounts.failed,
+      ratio: laTotal === 0 ? 0 : laCounts.sent / laTotal,
+    };
+  } else {
+    laPushDeliveryRatio = { sent: 0, failed: 0, ratio: 0 };
+  }
+
   return {
     accuracyRatio,
     silentPushDeliveryRatio,
@@ -122,6 +141,7 @@ export async function computeObservabilityMetrics(
     boardableMissRatio,
     accelPatternHitRatio,
     silentPushLatency,
+    laPushDeliveryRatio,
     window: '24h',
     timestamp: now,
   };

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -83,6 +83,7 @@ import type {
 } from './types';
 import { RESCHEDULE_CHANNELS_DEFAULT } from './types';
 import { writeMetric } from './analytics';
+import { accumulateLaPushCounters } from './laPushCounters';
 
 // pickApnsHost / flipApnsEnv는 ./apnsHost로 이동 (liveActivity.ts와 공유 SSOT, #482).
 // 외부(테스트 / index.ts 등)가 scheduled.ts 경유로 import하던 호환성 유지를 위해 re-export.
@@ -952,6 +953,24 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     ...stats,
     seoulCalls: deps.seoul.stats.callCount,
   });
+
+  // #1779 — LA push 도달률 Analytics Engine forward.
+  // cron cycle 합산(laPushSent / laPushFailed)을 단일 la-push 이벤트로 적재.
+  // binding 미설정 시 writeMetric은 no-op — 개발/테스트 환경 호환.
+  if (stats.laPushSent + stats.laPushFailed > 0) {
+    writeMetric(env, {
+      eventType: 'la-push',
+      tripToken: 'cron-aggregate',
+      reason: 'cycle-summary',
+      staleMs: stats.laPushFailed,
+      hopIndex: stats.laPushSent,
+    });
+  }
+
+  // #1779 — LA push 도달률 KV 누적. 1h bucket별 sent/failed를 accumulate해
+  // computeObservabilityMetrics가 laPushDeliveryRatio를 산출할 수 있도록 한다.
+  await accumulateLaPushCounters(env.TRIPS, stats.laPushSent, stats.laPushFailed, now);
+
   return stats;
 }
 

--- a/src/features/debug/components/OperationDashboardSection.tsx
+++ b/src/features/debug/components/OperationDashboardSection.tsx
@@ -32,6 +32,7 @@ import {
   fetchObservabilityMetrics,
   type ObservabilityMetricsBucket,
   type AccelPatternBucket,
+  type LaPushDeliveryBucket,
   type FetchMetricsResult,
 } from '../../observability/api/observabilityMetricsClient';
 import {
@@ -62,7 +63,7 @@ interface MetricData {
 type BackendLoadState =
   | { kind: 'idle' }
   | { kind: 'loading' }
-  | { kind: 'ok'; locklessMiss: ObservabilityMetricsBucket; boardableMiss: ObservabilityMetricsBucket; accelPattern: AccelPatternBucket; pushLatency: { p50: number; p95: number; totalSamples: number } | null }
+  | { kind: 'ok'; locklessMiss: ObservabilityMetricsBucket; boardableMiss: ObservabilityMetricsBucket; accelPattern: AccelPatternBucket; pushLatency: { p50: number; p95: number; totalSamples: number } | null; laPushDelivery: LaPushDeliveryBucket }
   | { kind: 'unconfigured' }
   | { kind: 'error'; message: string };
 
@@ -303,6 +304,7 @@ export function OperationDashboardSection({ logs }: OperationDashboardSectionPro
         boardableMiss: result.metrics.boardableMissRatio,
         accelPattern: result.metrics.accelPatternHitRatio,
         pushLatency: result.metrics.silentPushLatency ?? null,
+        laPushDelivery: result.metrics.laPushDeliveryRatio,
       });
     } else if (result.kind === 'unconfigured') {
       setBackendState({ kind: 'unconfigured' });
@@ -359,7 +361,20 @@ export function OperationDashboardSection({ logs }: OperationDashboardSectionPro
   const pushLatencyData: { p50: number; p95: number; totalSamples: number } | null | undefined =
     backendState.kind === 'ok' ? backendState.pushLatency : undefined;
 
-  const metrics: MetricData[] = [alarmAccuracy, silentPushReach, locklessMiss, boardableMiss];
+  // Metric 7 — LA push delivery ratio (#1779, backend 수신 시만 유효)
+  const laPushDelivery: MetricData =
+    backendState.kind === 'ok'
+      ? {
+          key: 'locklessMiss', // drill-down reuse — LA push has no dedicated drill-down yet
+          label: 'laPushDelivery',
+          ratio: computeRatio(backendState.laPushDelivery.sent, backendState.laPushDelivery.sent + backendState.laPushDelivery.failed),
+          numerator: backendState.laPushDelivery.sent,
+          denominator: backendState.laPushDelivery.sent + backendState.laPushDelivery.failed,
+          isMock: false,
+        }
+      : { key: 'locklessMiss', label: 'laPushDelivery', ratio: null, numerator: 0, denominator: 0, isMock: true };
+
+  const metrics: MetricData[] = [alarmAccuracy, silentPushReach, locklessMiss, boardableMiss, laPushDelivery];
 
   const handleMetricPress = useCallback((key: DrillDownMetricKey) => {
     setDrillDownKey((prev) => (prev === key ? null : key));

--- a/src/features/debug/components/__tests__/OperationDashboardSection.test.tsx
+++ b/src/features/debug/components/__tests__/OperationDashboardSection.test.tsx
@@ -87,6 +87,8 @@ function makeSuccessResult(
   boardableTotal = 0,
   accelPattern: observabilityClient.AccelPatternBucket = DEFAULT_ACCEL_PATTERN,
   pushLatency: { p50: number; p95: number; totalSamples: number } | null = null,
+  laSent = 10,
+  laFailed = 2,
 ): observabilityClient.FetchMetricsResult {
   return {
     kind: 'ok',
@@ -97,6 +99,7 @@ function makeSuccessResult(
       boardableMissRatio: { value: boardableValue, total: boardableTotal, ratio: boardableTotal === 0 ? 0 : boardableValue / boardableTotal },
       accelPatternHitRatio: accelPattern,
       silentPushLatency: pushLatency,
+      laPushDeliveryRatio: { sent: laSent, failed: laFailed, ratio: laSent / (laSent + laFailed) },
       window: '24h',
       timestamp: 1_700_000_000_000,
     },
@@ -122,13 +125,14 @@ afterEach(() => {
 
 describe('OperationDashboardSection', () => {
   describe('Sub 1 — 빈 데이터 상태 (4 metric 모두 0)', () => {
-    it('4개 metric row를 렌더한다', async () => {
+    it('5개 metric row를 렌더한다 (laPushDelivery 포함)', async () => {
       renderWithTheme(<OperationDashboardSection logs={[]} />);
       await act(async () => { jest.runAllTimers(); });
       expect(screen.getByTestId('operation-metric-alarmAccuracy')).toBeTruthy();
       expect(screen.getByTestId('operation-metric-silentPushReach')).toBeTruthy();
       expect(screen.getByTestId('operation-metric-locklessMiss')).toBeTruthy();
       expect(screen.getByTestId('operation-metric-boardableMiss')).toBeTruthy();
+      expect(screen.getByTestId('operation-metric-laPushDelivery')).toBeTruthy();
     });
 
     it('alarmAccuracy: 응답 0건 → no data bar 렌더', async () => {
@@ -422,6 +426,25 @@ describe('OperationDashboardSection', () => {
       await act(async () => { jest.runAllTimers(); });
       await waitFor(() => {
         expect(screen.getByTestId('push-latency-na')).toBeTruthy();
+      });
+    });
+  });
+
+  // ── #1779 LA push delivery section ──────────────────────────────────────────
+
+  describe('#1779 — laPushDelivery metric', () => {
+    it('backend 미수신 상태에서 laPushDelivery row가 (no data) 표시', async () => {
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      expect(screen.getByTestId('operation-metric-laPushDelivery')).toBeTruthy();
+    });
+
+    it('fetch 성공 → laPushDelivery ratio bar 렌더', async () => {
+      mockFetchMetrics.mockResolvedValue(makeSuccessResult(2, 10, 0, 0, DEFAULT_ACCEL_PATTERN, null, 10, 2));
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      await waitFor(() => {
+        expect(screen.getByTestId('operation-metric-laPushDelivery')).toBeTruthy();
       });
     });
   });

--- a/src/features/observability/api/__tests__/observabilityMetricsClient.test.ts
+++ b/src/features/observability/api/__tests__/observabilityMetricsClient.test.ts
@@ -41,6 +41,7 @@ function makeMetrics(): ObservabilityMetrics {
       stationary: { count: 2, ratio: 0.2 },
       unknown: { count: 1, ratio: 0.1 },
     },
+    laPushDeliveryRatio: { sent: 10, failed: 2, ratio: 10 / 12 },
     window: '24h',
     timestamp: 1_700_000_000_000,
   };
@@ -100,6 +101,17 @@ describe('fetchObservabilityMetrics', () => {
         expect(result.metrics.accuracyRatio.value).toBe(8);
         expect(result.metrics.locklessMissRatio.ratio).toBe(0.1);
         expect(result.metrics.window).toBe('24h');
+      }
+    });
+
+    it('forwards laPushDeliveryRatio from response (#1779)', async () => {
+      mockFetchOk(makeMetrics());
+      const result = await fetchObservabilityMetrics();
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.metrics.laPushDeliveryRatio.sent).toBe(10);
+        expect(result.metrics.laPushDeliveryRatio.failed).toBe(2);
+        expect(result.metrics.laPushDeliveryRatio.ratio).toBeCloseTo(10 / 12);
       }
     });
 

--- a/src/features/observability/api/observabilityMetricsClient.ts
+++ b/src/features/observability/api/observabilityMetricsClient.ts
@@ -24,6 +24,13 @@ export interface AccelPatternBucket {
   unknown: { count: number; ratio: number };
 }
 
+/** #1779 — LA push 도달률 응답 bucket. */
+export interface LaPushDeliveryBucket {
+  sent: number;
+  failed: number;
+  ratio: number;
+}
+
 export interface ObservabilityMetrics {
   accuracyRatio: ObservabilityMetricsBucket;
   silentPushDeliveryRatio: ObservabilityMetricsBucket;
@@ -36,6 +43,8 @@ export interface ObservabilityMetrics {
    * latencyMs stamp 있는 샘플만 집계. 샘플 0건이면 null.
    */
   silentPushLatency?: { p50: number; p95: number; totalSamples: number } | null;
+  /** #1779 — LA push 도달률 (sent / (sent + failed), 24h rolling window). */
+  laPushDeliveryRatio: LaPushDeliveryBucket;
   window: '24h';
   timestamp: number;
 }


### PR DESCRIPTION
Closes #1779

## 변경 요약

- **`laPushCounters.ts`** (신규): 1h bucket KV 누적 모듈. `accumulateLaPushCounters` / `sumLaPushCounters` / `laPushCounterKey` 제공.
- **`scheduled.ts`**: cron cycle 완료 시 `laPushSent`/`laPushFailed` → KV 누적 + Analytics Engine `la-push` event forward.
- **`observabilityMetrics.ts`**: `laPushDeliveryRatio: { sent, failed, ratio }` 필드 추가. `computeObservabilityMetrics`가 TRIPS KV 24h 합산.
- **`index.ts`**: `/v1/observability/metrics` endpoint + 1h cron handler에 `tripsKv` 파라미터 전달.
- **`observabilityMetricsClient.ts`**: `LaPushDeliveryBucket` 타입 + `ObservabilityMetrics.laPushDeliveryRatio` 필드 추가.
- **`OperationDashboardSection.tsx`**: Metric 6 `laPushDelivery` ratio bar 표시.

## Metric 계산 흐름

```
cron 60s 실행
  → fireLiveActivityUpdate → stats.laPushSent / stats.laPushFailed 누적
  → runScheduled 완료 후 accumulateLaPushCounters(TRIPS KV, sent, failed, now)
    → la-push-counters:{hourBucket} KV에 read-add-write (25h TTL)
  → writeMetric(env, { eventType: 'la-push', ... }) Analytics Engine forward

/v1/observability/metrics 요청
  → sumLaPushCounters(TRIPS KV, now): 24h bucket 합산
  → laPushDeliveryRatio = { sent, failed, ratio: sent/(sent+failed) }
  → DebugModal OperationDashboardSection에 표시
```

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` 0 orphan 확인.
2. **V/X dashboard** — DebugModal `laPushDelivery` metric row + Cloudflare Analytics Engine `la-push` event (`wrangler tail`).
3. **의존 PR** — N/A (독립).
4. **측정 plan** — 1주: `la-push-counters:*` KV 존재 확인 + `/v1/observability/metrics` 응답의 `laPushDeliveryRatio.ratio` ≥ 0.9 목표.
5. **Device verify** — N/A — type+unit only.

## 검증 결과

- backend type-check: pass
- backend tests: 2119 passed (57 files, 신규 `laPushCounters.test.ts` 포함)
- frontend type-check: pass
- frontend tests: 7781 passed, coverage 100%
- lint:orphan: 0 orphan