### PR TITLE
feat(#1780): 첫 실행 onboarding 화면 (권한 사전 맥락 + 직렬 요청)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,12 @@
 import { useEffect } from 'react';
 import { DevSettings } from 'react-native';
 import * as Notifications from 'expo-notifications';
-import { Stack } from 'expo-router';
+import { Stack, useRouter, useSegments } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import * as SplashScreen from 'expo-splash-screen';
 import { I18nextProvider, useTranslation } from 'react-i18next';
 import { ThemeProvider, useTheme } from '../src/shared/theme';
+import { useOnboardingStore } from '../src/features/onboarding/store/useOnboardingStore';
 import { setupNotificationHandler, refreshNotificationChannels } from '../src/features/alarm/utils/stationNotification';
 import { setMinLevel, createLogger } from '../src/shared/utils/logger';
 import { i18n } from '../src/shared/i18n';
@@ -98,6 +99,28 @@ function RootContent() {
   const setDebugVisible = useDebugStore((s) => s.setDebugVisible);
   const destinationId = useDestinationStore((s) => s.destination?.id ?? null);
   const { i18n: i18nInstance } = useTranslation();
+  const hasCompletedOnboarding = useOnboardingStore((s) => s.hasCompletedOnboarding);
+  const loadOnboardingState = useOnboardingStore((s) => s.loadOnboardingState);
+  const segments = useSegments();
+  const router = useRouter();
+
+  // #1780 — 첫 실행 온보딩 redirect.
+  // storage hydrate 완료 후 미완료 사용자는 onboarding으로 보낸다.
+  // 이미 onboarding 화면에 있으면 재진입하지 않는다.
+  useEffect(() => {
+    let cancelled = false;
+    loadOnboardingState().then(() => {
+      if (cancelled) return;
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    const isOnOnboarding = segments[0] === 'onboarding';
+    if (!hasCompletedOnboarding && !isOnOnboarding) {
+      router.replace('/onboarding');
+    }
+  }, [hasCompletedOnboarding, segments]);
 
   // #819 — "탑승했냐?" 응답 listener. boarding-prompt 카테고리 푸시의 [탑승]/[미탑승] 또는 탭을 받아
   // arvlCd 우선순위로 trainCode 자동 lock 또는 5분 silence POST. 미bound trip(destinationId=null)에서도

--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -1,0 +1,3 @@
+// expo-router route entry — 화면 본체는 src/screens/OnboardingScreen.tsx.
+// bulletproof-react "thin route + thick screen" 패턴.
+export { default } from '../src/screens/OnboardingScreen';

--- a/src/features/onboarding/components/OnboardingSplash1.tsx
+++ b/src/features/onboarding/components/OnboardingSplash1.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { useTheme, spacing, radius, typography } from '../../../shared/theme';
 
 interface Props {
-  onNext: () => void;
-  onSkip: () => void;
+  readonly onNext: () => void;
+  readonly onSkip: () => void;
 }
 
 /**

--- a/src/features/onboarding/components/OnboardingSplash1.tsx
+++ b/src/features/onboarding/components/OnboardingSplash1.tsx
@@ -1,0 +1,86 @@
+import { StyleSheet, Text, View, Pressable } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useTheme, spacing, radius, typography } from '../../../shared/theme';
+
+interface Props {
+  onNext: () => void;
+  onSkip: () => void;
+}
+
+/**
+ * 온보딩 Splash 1 — 앱 가치 안내.
+ * 앱이 무엇을 하는지 설명하고 "다음" CTA로 Splash 2로 진행.
+ */
+export function OnboardingSplash1({ onNext, onSkip }: Props) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.bg }]} testID="onboarding-splash1">
+      <View style={styles.content}>
+        <Text style={[typography.hero, { color: colors.accent }]}>
+          {t('onboarding.splash1.emoji')}
+        </Text>
+        <Text style={[typography.title, styles.title, { color: colors.ink }]}>
+          {t('onboarding.splash1.title')}
+        </Text>
+        <Text style={[typography.body, styles.description, { color: colors.muted }]}>
+          {t('onboarding.splash1.description')}
+        </Text>
+      </View>
+
+      <View style={styles.actions}>
+        <Pressable
+          style={[styles.primaryButton, { backgroundColor: colors.accent }]}
+          onPress={onNext}
+          testID="onboarding-splash1-next"
+        >
+          <Text style={[typography.body, { color: colors.onAccent }]}>
+            {t('onboarding.splash1.next')}
+          </Text>
+        </Pressable>
+        <Pressable onPress={onSkip} testID="onboarding-splash1-skip">
+          <Text style={[typography.bodySm, styles.skipText, { color: colors.subtle }]}>
+            {t('onboarding.skip')}
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.xxxl,
+    justifyContent: 'space-between',
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: spacing.lg,
+  },
+  title: {
+    textAlign: 'center',
+    marginTop: spacing.md,
+  },
+  description: {
+    textAlign: 'center',
+    lineHeight: 26,
+  },
+  actions: {
+    gap: spacing.md,
+    alignItems: 'center',
+  },
+  primaryButton: {
+    width: '100%',
+    paddingVertical: spacing.lg,
+    borderRadius: radius.pill,
+    alignItems: 'center',
+  },
+  skipText: {
+    textDecorationLine: 'underline',
+  },
+});

--- a/src/features/onboarding/components/OnboardingSplash1.tsx
+++ b/src/features/onboarding/components/OnboardingSplash1.tsx
@@ -1,6 +1,7 @@
-import { StyleSheet, Text, View, Pressable } from 'react-native';
+import { Text } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { useTheme, spacing, radius, typography } from '../../../shared/theme';
+import { useTheme, typography } from '../../../shared/theme';
+import { OnboardingSplashBase } from './OnboardingSplashBase';
 
 interface Props {
   readonly onNext: () => void;
@@ -16,71 +17,18 @@ export function OnboardingSplash1({ onNext, onSkip }: Props) {
   const { t } = useTranslation();
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.bg }]} testID="onboarding-splash1">
-      <View style={styles.content}>
-        <Text style={[typography.hero, { color: colors.accent }]}>
-          {t('onboarding.splash1.emoji')}
-        </Text>
-        <Text style={[typography.title, styles.title, { color: colors.ink }]}>
-          {t('onboarding.splash1.title')}
-        </Text>
-        <Text style={[typography.body, styles.description, { color: colors.muted }]}>
-          {t('onboarding.splash1.description')}
-        </Text>
-      </View>
-
-      <View style={styles.actions}>
-        <Pressable
-          style={[styles.primaryButton, { backgroundColor: colors.accent }]}
-          onPress={onNext}
-          testID="onboarding-splash1-next"
-        >
-          <Text style={[typography.body, { color: colors.onAccent }]}>
-            {t('onboarding.splash1.next')}
-          </Text>
-        </Pressable>
-        <Pressable onPress={onSkip} testID="onboarding-splash1-skip">
-          <Text style={[typography.bodySm, styles.skipText, { color: colors.subtle }]}>
-            {t('onboarding.skip')}
-          </Text>
-        </Pressable>
-      </View>
-    </View>
+    <OnboardingSplashBase
+      testID="onboarding-splash1"
+      emoji={t('onboarding.splash1.emoji')}
+      title={t('onboarding.splash1.title')}
+      primaryButtonTestID="onboarding-splash1-next"
+      primaryButtonLabel={t('onboarding.splash1.next')}
+      onPrimaryAction={onNext}
+      onSkip={onSkip}
+    >
+      <Text style={[typography.body, { color: colors.muted, textAlign: 'center', lineHeight: 26 }]}>
+        {t('onboarding.splash1.description')}
+      </Text>
+    </OnboardingSplashBase>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    paddingHorizontal: spacing.xl,
-    paddingVertical: spacing.xxxl,
-    justifyContent: 'space-between',
-  },
-  content: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: spacing.lg,
-  },
-  title: {
-    textAlign: 'center',
-    marginTop: spacing.md,
-  },
-  description: {
-    textAlign: 'center',
-    lineHeight: 26,
-  },
-  actions: {
-    gap: spacing.md,
-    alignItems: 'center',
-  },
-  primaryButton: {
-    width: '100%',
-    paddingVertical: spacing.lg,
-    borderRadius: radius.pill,
-    alignItems: 'center',
-  },
-  skipText: {
-    textDecorationLine: 'underline',
-  },
-});

--- a/src/features/onboarding/components/OnboardingSplash2.tsx
+++ b/src/features/onboarding/components/OnboardingSplash2.tsx
@@ -1,0 +1,116 @@
+import { StyleSheet, Text, View, Pressable } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useTheme, spacing, radius, typography } from '../../../shared/theme';
+import type { PermissionStep } from '../hooks/useOnboardingPermissions';
+
+interface Props {
+  step: PermissionStep;
+  onGrantPermissions: () => void;
+  onSkip: () => void;
+}
+
+/**
+ * 온보딩 Splash 2 — 권한 사전 맥락 안내.
+ * 위치 + 알림 권한이 왜 필요한지 설명하고 직렬 요청을 시작한다.
+ */
+export function OnboardingSplash2({ step, onGrantPermissions, onSkip }: Props) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+
+  const isRequesting = step === 'requesting-location' || step === 'requesting-notification';
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.bg }]} testID="onboarding-splash2">
+      <View style={styles.content}>
+        <Text style={[typography.hero, { color: colors.accent }]}>
+          {t('onboarding.splash2.emoji')}
+        </Text>
+        <Text style={[typography.title, styles.title, { color: colors.ink }]}>
+          {t('onboarding.splash2.title')}
+        </Text>
+
+        <View style={[styles.permissionCard, { backgroundColor: colors.card }]}>
+          <Text style={[typography.bodySm, styles.permissionLabel, { color: colors.muted }]}>
+            {t('onboarding.permissions.locationLabel')}
+          </Text>
+          <Text style={[typography.bodySm, { color: colors.ink }]}>
+            {t('onboarding.permissions.locationReason')}
+          </Text>
+        </View>
+
+        <View style={[styles.permissionCard, { backgroundColor: colors.card }]}>
+          <Text style={[typography.bodySm, styles.permissionLabel, { color: colors.muted }]}>
+            {t('onboarding.permissions.notificationLabel')}
+          </Text>
+          <Text style={[typography.bodySm, { color: colors.ink }]}>
+            {t('onboarding.permissions.notificationReason')}
+          </Text>
+        </View>
+      </View>
+
+      <View style={styles.actions}>
+        <Pressable
+          style={[
+            styles.primaryButton,
+            { backgroundColor: isRequesting ? colors.muted : colors.accent },
+          ]}
+          onPress={onGrantPermissions}
+          disabled={isRequesting}
+          testID="onboarding-splash2-grant"
+        >
+          <Text style={[typography.body, { color: colors.onAccent }]}>
+            {isRequesting
+              ? t('onboarding.permissions.requesting')
+              : t('onboarding.permissions.grant')}
+          </Text>
+        </Pressable>
+        <Pressable onPress={onSkip} testID="onboarding-splash2-skip">
+          <Text style={[typography.bodySm, styles.skipText, { color: colors.subtle }]}>
+            {t('onboarding.skip')}
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.xxxl,
+    justifyContent: 'space-between',
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: spacing.lg,
+  },
+  title: {
+    textAlign: 'center',
+    marginTop: spacing.md,
+  },
+  permissionCard: {
+    width: '100%',
+    padding: spacing.lg,
+    borderRadius: spacing.md,
+    gap: spacing.xs,
+  },
+  permissionLabel: {
+    fontWeight: '600',
+  },
+  actions: {
+    gap: spacing.md,
+    alignItems: 'center',
+  },
+  primaryButton: {
+    width: '100%',
+    paddingVertical: spacing.lg,
+    borderRadius: radius.pill,
+    alignItems: 'center',
+  },
+  skipText: {
+    textDecorationLine: 'underline',
+  },
+});

--- a/src/features/onboarding/components/OnboardingSplash2.tsx
+++ b/src/features/onboarding/components/OnboardingSplash2.tsx
@@ -1,6 +1,7 @@
-import { StyleSheet, Text, View, Pressable } from 'react-native';
+import { Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { useTheme, spacing, radius, typography } from '../../../shared/theme';
+import { useTheme, typography } from '../../../shared/theme';
+import { OnboardingSplashBase, splashBaseStyles } from './OnboardingSplashBase';
 import type { PermissionStep } from '../hooks/useOnboardingPermissions';
 
 interface Props {
@@ -18,99 +19,38 @@ export function OnboardingSplash2({ step, onGrantPermissions, onSkip }: Props) {
   const { t } = useTranslation();
 
   const isRequesting = step === 'requesting-location' || step === 'requesting-notification';
+  const buttonLabel = isRequesting
+    ? t('onboarding.permissions.requesting')
+    : t('onboarding.permissions.grant');
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.bg }]} testID="onboarding-splash2">
-      <View style={styles.content}>
-        <Text style={[typography.hero, { color: colors.accent }]}>
-          {t('onboarding.splash2.emoji')}
+    <OnboardingSplashBase
+      testID="onboarding-splash2"
+      emoji={t('onboarding.splash2.emoji')}
+      title={t('onboarding.splash2.title')}
+      primaryButtonTestID="onboarding-splash2-grant"
+      primaryButtonLabel={buttonLabel}
+      primaryButtonDisabled={isRequesting}
+      onPrimaryAction={onGrantPermissions}
+      onSkip={onSkip}
+    >
+      <View style={[splashBaseStyles.permissionCard, { backgroundColor: colors.card }]}>
+        <Text style={[typography.bodySm, splashBaseStyles.permissionLabel, { color: colors.muted }]}>
+          {t('onboarding.permissions.locationLabel')}
         </Text>
-        <Text style={[typography.title, styles.title, { color: colors.ink }]}>
-          {t('onboarding.splash2.title')}
+        <Text style={[typography.bodySm, { color: colors.ink }]}>
+          {t('onboarding.permissions.locationReason')}
         </Text>
-
-        <View style={[styles.permissionCard, { backgroundColor: colors.card }]}>
-          <Text style={[typography.bodySm, styles.permissionLabel, { color: colors.muted }]}>
-            {t('onboarding.permissions.locationLabel')}
-          </Text>
-          <Text style={[typography.bodySm, { color: colors.ink }]}>
-            {t('onboarding.permissions.locationReason')}
-          </Text>
-        </View>
-
-        <View style={[styles.permissionCard, { backgroundColor: colors.card }]}>
-          <Text style={[typography.bodySm, styles.permissionLabel, { color: colors.muted }]}>
-            {t('onboarding.permissions.notificationLabel')}
-          </Text>
-          <Text style={[typography.bodySm, { color: colors.ink }]}>
-            {t('onboarding.permissions.notificationReason')}
-          </Text>
-        </View>
       </View>
 
-      <View style={styles.actions}>
-        <Pressable
-          style={[
-            styles.primaryButton,
-            { backgroundColor: isRequesting ? colors.muted : colors.accent },
-          ]}
-          onPress={onGrantPermissions}
-          disabled={isRequesting}
-          testID="onboarding-splash2-grant"
-        >
-          <Text style={[typography.body, { color: colors.onAccent }]}>
-            {isRequesting
-              ? t('onboarding.permissions.requesting')
-              : t('onboarding.permissions.grant')}
-          </Text>
-        </Pressable>
-        <Pressable onPress={onSkip} testID="onboarding-splash2-skip">
-          <Text style={[typography.bodySm, styles.skipText, { color: colors.subtle }]}>
-            {t('onboarding.skip')}
-          </Text>
-        </Pressable>
+      <View style={[splashBaseStyles.permissionCard, { backgroundColor: colors.card }]}>
+        <Text style={[typography.bodySm, splashBaseStyles.permissionLabel, { color: colors.muted }]}>
+          {t('onboarding.permissions.notificationLabel')}
+        </Text>
+        <Text style={[typography.bodySm, { color: colors.ink }]}>
+          {t('onboarding.permissions.notificationReason')}
+        </Text>
       </View>
-    </View>
+    </OnboardingSplashBase>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    paddingHorizontal: spacing.xl,
-    paddingVertical: spacing.xxxl,
-    justifyContent: 'space-between',
-  },
-  content: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: spacing.lg,
-  },
-  title: {
-    textAlign: 'center',
-    marginTop: spacing.md,
-  },
-  permissionCard: {
-    width: '100%',
-    padding: spacing.lg,
-    borderRadius: spacing.md,
-    gap: spacing.xs,
-  },
-  permissionLabel: {
-    fontWeight: '600',
-  },
-  actions: {
-    gap: spacing.md,
-    alignItems: 'center',
-  },
-  primaryButton: {
-    width: '100%',
-    paddingVertical: spacing.lg,
-    borderRadius: radius.pill,
-    alignItems: 'center',
-  },
-  skipText: {
-    textDecorationLine: 'underline',
-  },
-});

--- a/src/features/onboarding/components/OnboardingSplash2.tsx
+++ b/src/features/onboarding/components/OnboardingSplash2.tsx
@@ -4,9 +4,9 @@ import { useTheme, spacing, radius, typography } from '../../../shared/theme';
 import type { PermissionStep } from '../hooks/useOnboardingPermissions';
 
 interface Props {
-  step: PermissionStep;
-  onGrantPermissions: () => void;
-  onSkip: () => void;
+  readonly step: PermissionStep;
+  readonly onGrantPermissions: () => void;
+  readonly onSkip: () => void;
 }
 
 /**

--- a/src/features/onboarding/components/OnboardingSplashBase.tsx
+++ b/src/features/onboarding/components/OnboardingSplashBase.tsx
@@ -1,0 +1,108 @@
+import { StyleSheet, Text, View, Pressable } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useTheme, spacing, radius, typography } from '../../../shared/theme';
+
+interface Props {
+  readonly testID: string;
+  readonly emoji: string;
+  readonly title: string;
+  readonly primaryButtonTestID: string;
+  readonly primaryButtonLabel: string;
+  readonly primaryButtonDisabled?: boolean;
+  readonly onPrimaryAction: () => void;
+  readonly onSkip: () => void;
+  readonly children?: React.ReactNode;
+}
+
+/**
+ * 온보딩 Splash 공통 스캐폴드.
+ * emoji + title + 슬롯(children) + primaryButton + skip CTA 구조를 공유한다.
+ * emoji, title, primaryButtonLabel은 호출 측에서 이미 번역된 문자열을 전달한다.
+ */
+export function OnboardingSplashBase({
+  testID,
+  emoji,
+  title,
+  primaryButtonTestID,
+  primaryButtonLabel,
+  primaryButtonDisabled = false,
+  onPrimaryAction,
+  onSkip,
+  children,
+}: Props) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.bg }]} testID={testID}>
+      <View style={styles.content}>
+        <Text style={[typography.hero, { color: colors.accent }]}>{emoji}</Text>
+        <Text style={[typography.title, styles.title, { color: colors.ink }]}>{title}</Text>
+        {children}
+      </View>
+
+      <View style={styles.actions}>
+        <Pressable
+          style={[
+            styles.primaryButton,
+            { backgroundColor: primaryButtonDisabled ? colors.muted : colors.accent },
+          ]}
+          onPress={onPrimaryAction}
+          disabled={primaryButtonDisabled}
+          testID={primaryButtonTestID}
+        >
+          <Text style={[typography.body, { color: colors.onAccent }]}>{primaryButtonLabel}</Text>
+        </Pressable>
+        <Pressable onPress={onSkip} testID={`${testID}-skip`}>
+          <Text style={[typography.bodySm, styles.skipText, { color: colors.subtle }]}>
+            {t('onboarding.skip')}
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+export const splashBaseStyles = StyleSheet.create({
+  permissionCard: {
+    width: '100%',
+    padding: spacing.lg,
+    borderRadius: spacing.md,
+    gap: spacing.xs,
+  },
+  permissionLabel: {
+    fontWeight: '600',
+  },
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.xxxl,
+    justifyContent: 'space-between',
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: spacing.lg,
+  },
+  title: {
+    textAlign: 'center',
+    marginTop: spacing.md,
+  },
+  actions: {
+    gap: spacing.md,
+    alignItems: 'center',
+  },
+  primaryButton: {
+    width: '100%',
+    paddingVertical: spacing.lg,
+    borderRadius: radius.pill,
+    alignItems: 'center',
+  },
+  skipText: {
+    textDecorationLine: 'underline',
+  },
+});

--- a/src/features/onboarding/components/__tests__/OnboardingSplash1.test.tsx
+++ b/src/features/onboarding/components/__tests__/OnboardingSplash1.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
+import { OnboardingSplash1 } from '../OnboardingSplash1';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('OnboardingSplash1', () => {
+  it('renders with testID', () => {
+    const { getByTestId } = renderWithTheme(
+      <OnboardingSplash1 onNext={jest.fn()} onSkip={jest.fn()} />,
+    );
+    expect(getByTestId('onboarding-splash1')).toBeTruthy();
+  });
+
+  it('calls onNext when next button is pressed', () => {
+    const onNext = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <OnboardingSplash1 onNext={onNext} onSkip={jest.fn()} />,
+    );
+    fireEvent.press(getByTestId('onboarding-splash1-next'));
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onSkip when skip is pressed', () => {
+    const onSkip = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <OnboardingSplash1 onNext={jest.fn()} onSkip={onSkip} />,
+    );
+    fireEvent.press(getByTestId('onboarding-splash1-skip'));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/onboarding/components/__tests__/OnboardingSplash2.test.tsx
+++ b/src/features/onboarding/components/__tests__/OnboardingSplash2.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
+import { OnboardingSplash2 } from '../OnboardingSplash2';
+import type { PermissionStep } from '../../hooks/useOnboardingPermissions';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('OnboardingSplash2', () => {
+  const defaultProps = {
+    step: 'idle' as PermissionStep,
+    onGrantPermissions: jest.fn(),
+    onSkip: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with testID', () => {
+    const { getByTestId } = renderWithTheme(<OnboardingSplash2 {...defaultProps} />);
+    expect(getByTestId('onboarding-splash2')).toBeTruthy();
+  });
+
+  it('calls onGrantPermissions when grant button is pressed (idle step)', () => {
+    const onGrantPermissions = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <OnboardingSplash2 {...defaultProps} onGrantPermissions={onGrantPermissions} />,
+    );
+    fireEvent.press(getByTestId('onboarding-splash2-grant'));
+    expect(onGrantPermissions).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables grant button while requesting-location', () => {
+    const onGrantPermissions = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <OnboardingSplash2
+        {...defaultProps}
+        step="requesting-location"
+        onGrantPermissions={onGrantPermissions}
+      />,
+    );
+    fireEvent.press(getByTestId('onboarding-splash2-grant'));
+    expect(onGrantPermissions).not.toHaveBeenCalled();
+  });
+
+  it('disables grant button while requesting-notification', () => {
+    const onGrantPermissions = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <OnboardingSplash2
+        {...defaultProps}
+        step="requesting-notification"
+        onGrantPermissions={onGrantPermissions}
+      />,
+    );
+    fireEvent.press(getByTestId('onboarding-splash2-grant'));
+    expect(onGrantPermissions).not.toHaveBeenCalled();
+  });
+
+  it('calls onSkip when skip is pressed', () => {
+    const onSkip = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <OnboardingSplash2 {...defaultProps} onSkip={onSkip} />,
+    );
+    fireEvent.press(getByTestId('onboarding-splash2-skip'));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it('is enabled when step is "done"', () => {
+    const onGrantPermissions = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <OnboardingSplash2
+        {...defaultProps}
+        step="done"
+        onGrantPermissions={onGrantPermissions}
+      />,
+    );
+    fireEvent.press(getByTestId('onboarding-splash2-grant'));
+    expect(onGrantPermissions).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/onboarding/components/__tests__/OnboardingSplashBase.test.tsx
+++ b/src/features/onboarding/components/__tests__/OnboardingSplashBase.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent } from '@testing-library/react-native';
+import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
+import { OnboardingSplashBase } from '../OnboardingSplashBase';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const baseProps = {
+  testID: 'test-splash',
+  emoji: '🚇',
+  title: 'Splash Title',
+  primaryButtonTestID: 'test-splash-primary',
+  primaryButtonLabel: 'Action',
+  onPrimaryAction: jest.fn(),
+  onSkip: jest.fn(),
+};
+
+describe('OnboardingSplashBase', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with given testID', () => {
+    const { getByTestId } = renderWithTheme(<OnboardingSplashBase {...baseProps} />);
+    expect(getByTestId('test-splash')).toBeTruthy();
+  });
+
+  it('calls onPrimaryAction when primary button is pressed', () => {
+    const onPrimaryAction = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <OnboardingSplashBase {...baseProps} onPrimaryAction={onPrimaryAction} />,
+    );
+    fireEvent.press(getByTestId('test-splash-primary'));
+    expect(onPrimaryAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onPrimaryAction when disabled', () => {
+    const onPrimaryAction = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <OnboardingSplashBase
+        {...baseProps}
+        primaryButtonDisabled={true}
+        onPrimaryAction={onPrimaryAction}
+      />,
+    );
+    fireEvent.press(getByTestId('test-splash-primary'));
+    expect(onPrimaryAction).not.toHaveBeenCalled();
+  });
+
+  it('calls onSkip when skip is pressed', () => {
+    const onSkip = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <OnboardingSplashBase {...baseProps} onSkip={onSkip} />,
+    );
+    fireEvent.press(getByTestId('test-splash-skip'));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders children inside content area', () => {
+    const { getByText } = renderWithTheme(
+      <OnboardingSplashBase {...baseProps}>
+        <></>
+      </OnboardingSplashBase>,
+    );
+    expect(getByText('Splash Title')).toBeTruthy();
+  });
+});

--- a/src/features/onboarding/hooks/__tests__/useOnboardingPermissions.test.ts
+++ b/src/features/onboarding/hooks/__tests__/useOnboardingPermissions.test.ts
@@ -1,0 +1,86 @@
+import { renderHook, act } from '@testing-library/react-native';
+import * as Location from 'expo-location';
+import * as Notifications from 'expo-notifications';
+import { useOnboardingPermissions } from '../useOnboardingPermissions';
+
+jest.mock('expo-location', () => ({
+  requestForegroundPermissionsAsync: jest.fn(),
+}));
+
+jest.mock('expo-notifications', () => ({
+  requestPermissionsAsync: jest.fn(),
+}));
+
+const mockRequestLocation = Location.requestForegroundPermissionsAsync as jest.Mock;
+const mockRequestNotification = Notifications.requestPermissionsAsync as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRequestLocation.mockResolvedValue({ status: 'granted' });
+  mockRequestNotification.mockResolvedValue({ status: 'granted' });
+});
+
+describe('useOnboardingPermissions', () => {
+  it('starts with step="idle"', () => {
+    const { result } = renderHook(() => useOnboardingPermissions());
+    expect(result.current.step).toBe('idle');
+  });
+
+  it('goes through all steps and ends at "done" when both permissions granted', async () => {
+    const { result } = renderHook(() => useOnboardingPermissions());
+
+    await act(async () => {
+      await result.current.requestPermissionsSequentially();
+    });
+
+    expect(result.current.step).toBe('done');
+    expect(mockRequestLocation).toHaveBeenCalledTimes(1);
+    expect(mockRequestNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues to "done" when location permission is denied', async () => {
+    mockRequestLocation.mockResolvedValue({ status: 'denied' });
+    const { result } = renderHook(() => useOnboardingPermissions());
+
+    await act(async () => {
+      await result.current.requestPermissionsSequentially();
+    });
+
+    expect(result.current.step).toBe('done');
+    expect(mockRequestNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues to "done" when notification permission is denied', async () => {
+    mockRequestNotification.mockResolvedValue({ status: 'denied' });
+    const { result } = renderHook(() => useOnboardingPermissions());
+
+    await act(async () => {
+      await result.current.requestPermissionsSequentially();
+    });
+
+    expect(result.current.step).toBe('done');
+  });
+
+  it('continues gracefully when location request throws', async () => {
+    mockRequestLocation.mockRejectedValue(new Error('location error'));
+    const { result } = renderHook(() => useOnboardingPermissions());
+
+    await act(async () => {
+      await result.current.requestPermissionsSequentially();
+    });
+
+    expect(result.current.step).toBe('done');
+    expect(mockRequestNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues gracefully when notification request throws', async () => {
+    mockRequestNotification.mockRejectedValue(new Error('notification error'));
+    const { result } = renderHook(() => useOnboardingPermissions());
+
+    await act(async () => {
+      await result.current.requestPermissionsSequentially();
+    });
+
+    expect(result.current.step).toBe('done');
+  });
+});

--- a/src/features/onboarding/hooks/useOnboardingPermissions.ts
+++ b/src/features/onboarding/hooks/useOnboardingPermissions.ts
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import * as Location from 'expo-location';
+import * as Notifications from 'expo-notifications';
+
+export type PermissionStep = 'idle' | 'requesting-location' | 'requesting-notification' | 'done';
+
+export interface OnboardingPermissionsResult {
+  step: PermissionStep;
+  requestPermissionsSequentially: () => Promise<void>;
+}
+
+/**
+ * 온보딩용 권한 직렬 요청 훅.
+ * foreground location → notification 순서로 요청한다.
+ * 사용자가 거부해도 오류 없이 다음 단계로 진행 (graceful).
+ */
+export function useOnboardingPermissions(): OnboardingPermissionsResult {
+  const [step, setStep] = useState<PermissionStep>('idle');
+
+  const requestPermissionsSequentially = async (): Promise<void> => {
+    setStep('requesting-location');
+    try {
+      await Location.requestForegroundPermissionsAsync();
+    } catch {
+      // 거부 또는 에러 — graceful 진행
+    }
+
+    setStep('requesting-notification');
+    try {
+      await Notifications.requestPermissionsAsync({
+        ios: { allowAlert: true, allowSound: true },
+      });
+    } catch {
+      // 거부 또는 에러 — graceful 진행
+    }
+
+    setStep('done');
+  };
+
+  return { step, requestPermissionsSequentially };
+}

--- a/src/features/onboarding/store/__tests__/useOnboardingStore.test.ts
+++ b/src/features/onboarding/store/__tests__/useOnboardingStore.test.ts
@@ -1,0 +1,57 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useOnboardingStore, ONBOARDING_COMPLETED_KEY } from '../useOnboardingStore';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+const mockGetItem = AsyncStorage.getItem as jest.Mock;
+const mockSetItem = AsyncStorage.setItem as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useOnboardingStore.setState({ hasCompletedOnboarding: false });
+});
+
+describe('useOnboardingStore', () => {
+  describe('loadOnboardingState', () => {
+    it('sets hasCompletedOnboarding=true when storage has "true"', async () => {
+      mockGetItem.mockResolvedValueOnce('true');
+      await useOnboardingStore.getState().loadOnboardingState();
+      expect(useOnboardingStore.getState().hasCompletedOnboarding).toBe(true);
+    });
+
+    it('keeps hasCompletedOnboarding=false when storage returns null', async () => {
+      mockGetItem.mockResolvedValueOnce(null);
+      await useOnboardingStore.getState().loadOnboardingState();
+      expect(useOnboardingStore.getState().hasCompletedOnboarding).toBe(false);
+    });
+
+    it('keeps hasCompletedOnboarding=false when storage returns non-"true" value', async () => {
+      mockGetItem.mockResolvedValueOnce('false');
+      await useOnboardingStore.getState().loadOnboardingState();
+      expect(useOnboardingStore.getState().hasCompletedOnboarding).toBe(false);
+    });
+
+    it('keeps hasCompletedOnboarding=false when AsyncStorage throws', async () => {
+      mockGetItem.mockRejectedValueOnce(new Error('storage error'));
+      await useOnboardingStore.getState().loadOnboardingState();
+      expect(useOnboardingStore.getState().hasCompletedOnboarding).toBe(false);
+    });
+  });
+
+  describe('completeOnboarding', () => {
+    it('sets hasCompletedOnboarding=true in state', async () => {
+      mockSetItem.mockResolvedValueOnce(undefined);
+      await useOnboardingStore.getState().completeOnboarding();
+      expect(useOnboardingStore.getState().hasCompletedOnboarding).toBe(true);
+    });
+
+    it('persists "true" to AsyncStorage under the correct key', async () => {
+      mockSetItem.mockResolvedValueOnce(undefined);
+      await useOnboardingStore.getState().completeOnboarding();
+      expect(mockSetItem).toHaveBeenCalledWith(ONBOARDING_COMPLETED_KEY, 'true');
+    });
+  });
+});

--- a/src/features/onboarding/store/useOnboardingStore.ts
+++ b/src/features/onboarding/store/useOnboardingStore.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const ONBOARDING_COMPLETED_KEY = 'subway-now:onboarding-completed';
+
+export interface OnboardingState {
+  hasCompletedOnboarding: boolean;
+  loadOnboardingState: () => Promise<void>;
+  completeOnboarding: () => Promise<void>;
+}
+
+export const useOnboardingStore = create<OnboardingState>((set) => ({
+  hasCompletedOnboarding: false,
+
+  loadOnboardingState: async () => {
+    try {
+      const raw = await AsyncStorage.getItem(ONBOARDING_COMPLETED_KEY);
+      set({ hasCompletedOnboarding: raw === 'true' });
+    } catch {
+      // 저장된 데이터 없음 — false 유지
+    }
+  },
+
+  completeOnboarding: async () => {
+    set({ hasCompletedOnboarding: true });
+    await AsyncStorage.setItem(ONBOARDING_COMPLETED_KEY, 'true');
+  },
+}));

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { useRouter } from 'expo-router';
+import { ScreenContainer } from '../shared/ui/ScreenContainer';
+import { OnboardingSplash1 } from '../features/onboarding/components/OnboardingSplash1';
+import { OnboardingSplash2 } from '../features/onboarding/components/OnboardingSplash2';
+import { useOnboardingPermissions } from '../features/onboarding/hooks/useOnboardingPermissions';
+import { useOnboardingStore } from '../features/onboarding/store/useOnboardingStore';
+
+type SplashPage = 1 | 2;
+
+/**
+ * 첫 실행 온보딩 화면.
+ * Splash 1: 앱 가치 안내 → Splash 2: 권한 사전 맥락 + 직렬 요청.
+ * 완료 또는 건너뛰기 시 AsyncStorage에 영속화 후 홈으로 이동.
+ */
+export default function OnboardingScreen() {
+  const [page, setPage] = useState<SplashPage>(1);
+  const { step, requestPermissionsSequentially } = useOnboardingPermissions();
+  const completeOnboarding = useOnboardingStore((s) => s.completeOnboarding);
+  const router = useRouter();
+
+  const finish = async () => {
+    await completeOnboarding();
+    router.replace('/');
+  };
+
+  const handleGrantPermissions = async () => {
+    await requestPermissionsSequentially();
+    await finish();
+  };
+
+  if (page === 1) {
+    return (
+      <ScreenContainer>
+        <OnboardingSplash1 onNext={() => setPage(2)} onSkip={finish} />
+      </ScreenContainer>
+    );
+  }
+
+  return (
+    <ScreenContainer>
+      <OnboardingSplash2
+        step={step}
+        onGrantPermissions={handleGrantPermissions}
+        onSkip={finish}
+      />
+    </ScreenContainer>
+  );
+}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -360,5 +360,27 @@
   "lockless": {
     "badge": "🔍 Searching",
     "tapToConfirm": "Confirm boarding"
+  },
+  "onboarding": {
+    "skip": "Skip",
+    "splash1": {
+      "emoji": "🚇",
+      "title": "Subway, now automatic",
+      "description": "We detect your current station via GPS and send transfer and arrival alerts automatically — even when the app is in the background.",
+      "next": "Next"
+    },
+    "splash2": {
+      "emoji": "🔔",
+      "title": "Two permissions needed",
+      "description": "Permissions are used only for alarms and are never shared externally."
+    },
+    "permissions": {
+      "locationLabel": "Location",
+      "locationReason": "Needed to detect the station you are currently on",
+      "notificationLabel": "Notifications",
+      "notificationReason": "Needed to send transfer and arrival alerts",
+      "grant": "Allow permissions",
+      "requesting": "Requesting..."
+    }
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -360,5 +360,27 @@
   "lockless": {
     "badge": "🔍 探索中",
     "tapToConfirm": "乗車を確認する"
+  },
+  "onboarding": {
+    "skip": "スキップ",
+    "splash1": {
+      "emoji": "🚇",
+      "title": "地下鉄、自動で管理",
+      "description": "GPSで現在乗車中の駅をリアルタイム検知し、乗換・到着アラームを自動でお届けします。アプリを開いたままにしなくて大丈夫です。",
+      "next": "次へ"
+    },
+    "splash2": {
+      "emoji": "🔔",
+      "title": "2つの権限が必要です",
+      "description": "権限はアラームの送信のみに使用され、外部に提供されません。"
+    },
+    "permissions": {
+      "locationLabel": "位置情報",
+      "locationReason": "現在乗車中の駅を検知するために必要です",
+      "notificationLabel": "通知",
+      "notificationReason": "乗換・到着アラームを受け取るために必要です",
+      "grant": "権限を許可する",
+      "requesting": "リクエスト中..."
+    }
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -360,5 +360,27 @@
   "lockless": {
     "badge": "🔍 탐색 중",
     "tapToConfirm": "탑승 확인하기"
+  },
+  "onboarding": {
+    "skip": "건너뛰기",
+    "splash1": {
+      "emoji": "🚇",
+      "title": "지하철, 이제 자동으로",
+      "description": "GPS로 현재 탑승 역을 실시간 감지하고\n환승·도착 알람을 자동으로 보내드려요.\n앱을 켜두지 않아도 괜찮아요.",
+      "next": "다음"
+    },
+    "splash2": {
+      "emoji": "🔔",
+      "title": "두 가지 권한이 필요해요",
+      "description": "권한은 알람 발송에만 사용되며\n외부에 전달되지 않아요."
+    },
+    "permissions": {
+      "locationLabel": "위치 권한",
+      "locationReason": "현재 탑승 중인 역을 감지하기 위해 필요해요",
+      "notificationLabel": "알림 권한",
+      "notificationReason": "환승·도착 알람을 받기 위해 필요해요",
+      "grant": "권한 허용하기",
+      "requesting": "요청 중..."
+    }
   }
 }

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -360,5 +360,27 @@
   "lockless": {
     "badge": "🔍 搜索中",
     "tapToConfirm": "确认乘车"
+  },
+  "onboarding": {
+    "skip": "跳过",
+    "splash1": {
+      "emoji": "🚇",
+      "title": "地铁，现在自动化",
+      "description": "通过GPS实时检测您当前乘坐的车站，自动发送换乘和到站提醒。即使在后台运行也没问题。",
+      "next": "下一步"
+    },
+    "splash2": {
+      "emoji": "🔔",
+      "title": "需要两项权限",
+      "description": "权限仅用于发送提醒，不会对外共享。"
+    },
+    "permissions": {
+      "locationLabel": "位置权限",
+      "locationReason": "用于检测您当前乘坐的车站",
+      "notificationLabel": "通知权限",
+      "notificationReason": "用于接收换乘和到站提醒",
+      "grant": "允许权限",
+      "requesting": "请求中..."
+    }
   }
 }


### PR DESCRIPTION
Closes #1780

## Summary
- 2-splash onboarding 화면 신설: Splash 1 (앱 가치 안내) → Splash 2 (권한 사전 맥락 + 직렬 요청)
- `useOnboardingStore` (Zustand + AsyncStorage 영속화) — 별도 store 신설 (ADR Phase 5 follow-up 정렬)
- foreground location → notification 직렬 요청, 거부 시 graceful 진행
- `_layout.tsx` 첫 실행 감지 redirect, i18n 4언어 추가

## Wire-completion 5단 체크
1. **Orphan 없음** — `npm run lint:orphan` pass. `app/` route entry는 기존 IGNORE_PATTERN 포함.
2. **V/X dashboard** — 온보딩 완료 여부: `subway-now:onboarding-completed` AsyncStorage key. DebugModal에서 직접 관찰 가능.
3. **의존 PR** — N/A
4. **측정 plan** — 첫 실행 사용자 전환율은 추후 funnel 이슈로 측정. 현재는 `hasCompletedOnboarding` 상태로 회귀 0 확인.
5. **Device verify** — 실기기 검증 필요: 첫 실행 시 onboarding redirect, 권한 다이얼로그 직렬 표시, 건너뛰기 후 홈 진입 확인.

## 변경 파일
- `app/onboarding.tsx` — thin route entry
- `src/screens/OnboardingScreen.tsx` — 2-splash controller
- `src/features/onboarding/components/OnboardingSplash1.tsx` — 가치 안내 화면
- `src/features/onboarding/components/OnboardingSplash2.tsx` — 권한 맥락 + 직렬 요청 화면
- `src/features/onboarding/hooks/useOnboardingPermissions.ts` — 직렬 권한 훅
- `src/features/onboarding/store/useOnboardingStore.ts` — 온보딩 완료 상태 + AsyncStorage
- `src/shared/i18n/locales/{ko,en,ja,zh}.json` — onboarding.* 키 추가
- `app/_layout.tsx` — 첫 실행 redirect 로직

## 검증
- `npm test` 381 suites, 7799 tests pass, coverage 100%
- `npm run type-check` — pass
- `npm run lint:orphan` — No orphan exports detected