### PR TITLE
feat(#1781): Widget 목적지/환승 표시 (paradigm shift 후 schema 확장)

### DIFF
--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -73,6 +73,27 @@ export function saveWidgetStation(
   );
 }
 
+/**
+ * #1781 — trip 활성 시 위젯에 추가 맥락(현재역/환승역/도착역)을 전달.
+ * `saveWidgetStation`과 분리해 backward compat를 유지한다.
+ * - tripActive=false 또는 호출 생략 시 Swift 위젯이 기존 nearest station UI로 폴백.
+ */
+export function saveWidgetTripContext(
+  currentStationName: string | null,
+  destinationName: string | null,
+  nextTransferName: string | null,
+  tripActive: boolean,
+): Promise<void> {
+  return (
+    LiveActivityModule?.saveWidgetTripContext(
+      currentStationName,
+      destinationName,
+      nextTransferName,
+      tripActive,
+    ) ?? Promise.resolve()
+  );
+}
+
 export function clearWidgetStation(): Promise<void> {
   return LiveActivityModule?.clearWidgetStation() ?? Promise.resolve();
 }

--- a/modules/live-activity/ios/LiveActivityModule.swift
+++ b/modules/live-activity/ios/LiveActivityModule.swift
@@ -8,6 +8,11 @@ private let WIDGET_KEY_LINE_COLOR = "lineColor"
 private let WIDGET_KEY_DISTANCE_M = "distanceM"
 // 위젯 freshness 표시용. JS에서 epoch ms로 전달, UserDefaults에는 Double(초)로 저장.
 private let WIDGET_KEY_SAVED_AT = "savedAt"
+// #1781 — trip 활성 시 추가 필드. backward-compat: 키 없으면 위젯이 기존 UI 유지.
+private let WIDGET_KEY_CURRENT_STATION_NAME = "currentStationName"
+private let WIDGET_KEY_DESTINATION_NAME = "destinationName"
+private let WIDGET_KEY_NEXT_TRANSFER_NAME = "nextTransferName"
+private let WIDGET_KEY_TRIP_ACTIVE = "tripActive"
 
 public class LiveActivityModule: Module {
     public func definition() -> ModuleDefinition {
@@ -76,12 +81,42 @@ public class LiveActivityModule: Module {
             }
         }
 
+        // #1781 — trip 활성 시 추가 맥락(현재역/환승역/도착역)을 별도 함수로 write.
+        // saveWidgetStation 4-param 시그니처를 유지해 backward compat를 보존한다.
+        AsyncFunction("saveWidgetTripContext") { (currentStationName: String?, destinationName: String?, nextTransferName: String?, tripActive: Bool) in
+            guard let defaults = UserDefaults(suiteName: APP_GROUP) else { return }
+            defaults.set(tripActive, forKey: WIDGET_KEY_TRIP_ACTIVE)
+            if let name = currentStationName {
+                defaults.set(name, forKey: WIDGET_KEY_CURRENT_STATION_NAME)
+            } else {
+                defaults.removeObject(forKey: WIDGET_KEY_CURRENT_STATION_NAME)
+            }
+            if let name = destinationName {
+                defaults.set(name, forKey: WIDGET_KEY_DESTINATION_NAME)
+            } else {
+                defaults.removeObject(forKey: WIDGET_KEY_DESTINATION_NAME)
+            }
+            if let name = nextTransferName {
+                defaults.set(name, forKey: WIDGET_KEY_NEXT_TRANSFER_NAME)
+            } else {
+                defaults.removeObject(forKey: WIDGET_KEY_NEXT_TRANSFER_NAME)
+            }
+            // trip 맥락 변경 시에도 위젯 타임라인을 갱신한다.
+            if #available(iOS 14.0, *) {
+                WidgetCenter.shared.reloadAllTimelines()
+            }
+        }
+
         AsyncFunction("clearWidgetStation") { () -> Void in
             guard let defaults = UserDefaults(suiteName: APP_GROUP) else { return }
             defaults.removeObject(forKey: WIDGET_KEY_STATION_NAME)
             defaults.removeObject(forKey: WIDGET_KEY_LINE_COLOR)
             defaults.removeObject(forKey: WIDGET_KEY_DISTANCE_M)
             defaults.removeObject(forKey: WIDGET_KEY_SAVED_AT)
+            defaults.removeObject(forKey: WIDGET_KEY_TRIP_ACTIVE)
+            defaults.removeObject(forKey: WIDGET_KEY_CURRENT_STATION_NAME)
+            defaults.removeObject(forKey: WIDGET_KEY_DESTINATION_NAME)
+            defaults.removeObject(forKey: WIDGET_KEY_NEXT_TRANSFER_NAME)
             if #available(iOS 14.0, *) {
                 WidgetCenter.shared.reloadAllTimelines()
             }

--- a/src/features/widget/api/__tests__/widgetStorage.test.ts
+++ b/src/features/widget/api/__tests__/widgetStorage.test.ts
@@ -1,13 +1,21 @@
 import { Platform } from 'react-native';
-import { saveStationToWidget, clearWidgetStation } from '../widgetStorage';
+import { saveStationToWidget, clearWidgetStation, type WidgetTripContext } from '../widgetStorage';
 import { Station } from '../../../../shared/types/station';
 
 const mockSave = jest.fn().mockResolvedValue(undefined);
 const mockClear = jest.fn().mockResolvedValue(undefined);
+const mockSaveTripContext = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('live-activity', () => ({
   saveWidgetStation: (...args: unknown[]) => mockSave(...args),
   clearWidgetStation: () => mockClear(),
+}));
+
+// #1781 — saveWidgetTripContext는 requireOptionalNativeModule 직접 참조로 호출됨
+jest.mock('expo-modules-core', () => ({
+  requireOptionalNativeModule: () => ({
+    saveWidgetTripContext: (...args: unknown[]) => mockSaveTripContext(...args),
+  }),
 }));
 
 const station: Station = {
@@ -19,6 +27,33 @@ const station: Station = {
   lng: 127.0276,
 };
 
+// #1781 — LiveActivityNative 모듈 레벨 분기: android 경로(LiveActivityNative=null) 커버
+describe('widgetStorage (android — LiveActivityNative null 분기)', () => {
+  it('Android에서는 LiveActivityNative가 null이고 모든 native 호출 없이 종료된다', async () => {
+    const mockSaveAndroid = jest.fn().mockResolvedValue(undefined);
+    let save: (s: Station, d: number) => Promise<void>;
+    jest.isolateModules(() => {
+      jest.doMock('react-native', () => ({ Platform: { OS: 'android' } }));
+      jest.doMock('expo-modules-core', () => ({
+        requireOptionalNativeModule: () => null,
+      }));
+      jest.doMock('live-activity', () => ({
+        saveWidgetStation: mockSaveAndroid,
+        clearWidgetStation: jest.fn().mockResolvedValue(undefined),
+      }));
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const mod = require('../widgetStorage') as { saveStationToWidget: typeof save };
+      save = mod.saveStationToWidget;
+    });
+    const androidStation: Station = {
+      id: '2-001', name: '강남', line: '2', lineColor: '#009933', lat: 37.497, lng: 127.027,
+    };
+    await expect(save!(androidStation, 0.1)).resolves.toBeUndefined();
+    // Platform.OS !== 'ios' → early return, no native calls
+    expect(mockSaveAndroid).not.toHaveBeenCalled();
+  });
+});
+
 describe('widgetStorage (native)', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -26,6 +61,7 @@ describe('widgetStorage (native)', () => {
     // 모듈 스코프 dedupe 캐시 리셋
     await clearWidgetStation();
     mockClear.mockClear();
+    mockSaveTripContext.mockClear();
   });
 
   describe('saveStationToWidget', () => {
@@ -39,12 +75,12 @@ describe('widgetStorage (native)', () => {
       const before = Date.now();
       await saveStationToWidget(station, 0.1);
       const after = Date.now();
-      const args = mockSave.mock.calls[0];
-      expect(args[0]).toBe('강남');
-      expect(args[1]).toBe('#009933');
-      expect(args[2]).toBe(100);
-      expect(args[3]).toBeGreaterThanOrEqual(before);
-      expect(args[3]).toBeLessThanOrEqual(after);
+      const [name, color, dist, savedAt] = mockSave.mock.calls[0];
+      expect(name).toBe('강남');
+      expect(color).toBe('#009933');
+      expect(dist).toBe(100);
+      expect(savedAt).toBeGreaterThanOrEqual(before);
+      expect(savedAt).toBeLessThanOrEqual(after);
     });
 
     it('음수 거리는 0으로 보정된다', async () => {
@@ -99,6 +135,51 @@ describe('widgetStorage (native)', () => {
       await clearWidgetStation();
       await saveStationToWidget(station, 0.1, 1);
       expect(mockSave).toHaveBeenCalledTimes(2);
+    });
+
+    // #1781 — tripContext 전달 시 saveWidgetTripContext로 trip 맥락 별도 write
+    describe('#1781 — tripContext', () => {
+      const tripFull: WidgetTripContext = {
+        currentStationName: '강남',
+        destinationName: '잠실',
+        nextTransferName: '건대입구',
+        tripActive: true,
+      };
+
+      const tripDirect: WidgetTripContext = {
+        currentStationName: '강남',
+        destinationName: '잠실',
+        tripActive: true,
+      };
+
+      it('trip 활성 + 환승 있음: saveWidgetTripContext에 currentStation/destination/nextTransfer/tripActive 전달', async () => {
+        const t = 1_700_000_000_000;
+        await saveStationToWidget(station, 0.1, t, undefined, tripFull);
+        expect(mockSave).toHaveBeenCalledWith('강남', '#009933', 100, t);
+        expect(mockSaveTripContext).toHaveBeenCalledWith('강남', '잠실', '건대입구', true);
+      });
+
+      it('trip 활성 + 직통(환승 없음): nextTransferName=null', async () => {
+        const t = 1_700_000_000_000;
+        await saveStationToWidget(station, 0.1, t, undefined, tripDirect);
+        expect(mockSaveTripContext).toHaveBeenCalledWith('강남', '잠실', null, true);
+      });
+
+      it('tripContext 미전달(trip 비활성): saveWidgetTripContext에 null/false 전달 (backward compat)', async () => {
+        const t = 1_700_000_000_000;
+        await saveStationToWidget(station, 0.1, t);
+        expect(mockSave).toHaveBeenCalledWith('강남', '#009933', 100, t);
+        expect(mockSaveTripContext).toHaveBeenCalledWith(null, null, null, false);
+      });
+
+      it('dedupe 게이트에 걸려 save가 skip되면 saveWidgetTripContext도 skip된다', async () => {
+        const t = 1_700_000_000_000;
+        await saveStationToWidget(station, 0.1, t, undefined, tripFull);
+        // 같은 역/bucket, freshness 윈도우 내 → skip
+        await saveStationToWidget(station, 0.1, t + 1_000, undefined, tripFull);
+        expect(mockSave).toHaveBeenCalledTimes(1);
+        expect(mockSaveTripContext).toHaveBeenCalledTimes(1);
+      });
     });
 
     // R9-a (#1612) — force 옵션 시 module-level dedupe 우회. AppState 'active' 복귀 시 위젯 FG stale 차단.

--- a/src/features/widget/api/widgetStorage.ts
+++ b/src/features/widget/api/widgetStorage.ts
@@ -1,6 +1,22 @@
 import { Platform } from 'react-native';
+import { requireOptionalNativeModule } from 'expo-modules-core';
 import * as LiveActivity from 'live-activity';
 import { Station } from '../../../shared/types/station';
+
+// #1781 — trip 맥락 write를 위한 native module 직접 참조.
+// live-activity/index.ts의 4-param saveWidgetStation 시그니처를 변경하지 않고
+// saveWidgetTripContext를 네이티브에 직접 호출한다 (backward compat 보존).
+const LiveActivityNative =
+  Platform.OS === 'ios'
+    ? (requireOptionalNativeModule('LiveActivity') as {
+        saveWidgetTripContext?: (
+          currentStationName: string | null,
+          destinationName: string | null,
+          nextTransferName: string | null,
+          tripActive: boolean,
+        ) => Promise<void>;
+      } | null)
+    : null;
 
 // 위젯 거리 표시는 50m 단위로 의미가 있다고 보고, 같은 역 + 같은 50m 버킷일 때만
 // WidgetCenter.reloadAllTimelines 호출을 dedupe 한다. 같은 역이라도 버킷이
@@ -31,11 +47,28 @@ export interface SaveStationToWidgetOptions {
   force?: boolean;
 }
 
+/**
+ * #1781 — trip 활성 시 위젯에 추가로 전달하는 맥락 정보.
+ * trip 비활성 시에는 생략하면 위젯이 기존 nearest station UI를 유지한다.
+ *
+ * - `currentStationName`: 현재 탑승 중인 역 이름 (nearest station과 별개 표시용).
+ * - `destinationName`: 목적지 역 이름.
+ * - `nextTransferName`: 다음 환승역 이름. 직통 경로면 undefined.
+ * - `tripActive`: trip 활성 여부 — Swift UI 분기 신호.
+ */
+export interface WidgetTripContext {
+  currentStationName: string;
+  destinationName: string;
+  nextTransferName?: string;
+  tripActive: boolean;
+}
+
 export async function saveStationToWidget(
   station: Station,
   distanceKm: number,
   savedAt: number = Date.now(),
   options?: SaveStationToWidgetOptions,
+  tripContext?: WidgetTripContext,
 ): Promise<void> {
   if (Platform.OS !== 'ios') return;
   const key = `${station.id}:${distanceBucket(distanceKm)}`;
@@ -52,6 +85,13 @@ export async function saveStationToWidget(
     station.lineColor,
     Math.max(0, Math.round(distanceKm * 1000)),
     savedAt,
+  );
+  // #1781 — trip 맥락 별도 write. saveWidgetStation 4-param 시그니처 보존.
+  await LiveActivityNative?.saveWidgetTripContext?.(
+    tripContext?.currentStationName ?? null,
+    tripContext?.destinationName ?? null,
+    tripContext?.nextTransferName ?? null,
+    tripContext?.tripActive ?? false,
   );
 }
 

--- a/src/features/widget/hooks/__tests__/useWidgetMirror.test.ts
+++ b/src/features/widget/hooks/__tests__/useWidgetMirror.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-native';
 import type { Station } from '../../../../shared/types/station';
+import type { WidgetTripContext } from '../../api/widgetStorage';
 
 const mockSave = jest.fn().mockResolvedValue(undefined);
 const mockClear = jest.fn().mockResolvedValue(undefined);
@@ -38,9 +39,9 @@ beforeEach(() => {
 });
 
 describe('useWidgetMirror', () => {
-  it('station 감지 시 saveStationToWidget을 호출한다', () => {
+  it('station 감지 시 saveStationToWidget을 호출한다 (tripContext 없음)', () => {
     renderHook(() => useWidgetMirror(station, 0.1));
-    expect(mockSave).toHaveBeenCalledWith(station, 0.1);
+    expect(mockSave).toHaveBeenCalledWith(station, 0.1, undefined, undefined, undefined);
     expect(mockClear).not.toHaveBeenCalled();
   });
 
@@ -84,7 +85,7 @@ describe('useWidgetMirror', () => {
     );
     rerender({ s: other });
     expect(mockSave).toHaveBeenCalledTimes(2);
-    expect(mockSave).toHaveBeenLastCalledWith(other, 0.1);
+    expect(mockSave).toHaveBeenLastCalledWith(other, 0.1, undefined, undefined, undefined);
   });
 
   it('station → null 전환 시에도 clear 호출하지 않음 (위젯은 마지막 역 유지)', () => {
@@ -103,5 +104,62 @@ describe('useWidgetMirror', () => {
     renderHook(() => useWidgetMirror(station, 0.1));
     await new Promise((r) => setImmediate(r));
     expect(mockLoggerError).toHaveBeenCalledWith('save 실패:', expect.any(Error));
+  });
+
+  // #1781 — tripContext 전달 시 saveStationToWidget에 context 포함
+  describe('#1781 — tripContext mirror', () => {
+    const tripFull: WidgetTripContext = {
+      currentStationName: '강남',
+      destinationName: '잠실',
+      nextTransferName: '건대입구',
+      tripActive: true,
+    };
+
+    const tripDirect: WidgetTripContext = {
+      currentStationName: '강남',
+      destinationName: '잠실',
+      tripActive: true,
+    };
+
+    it('tripContext 전달 시 saveStationToWidget에 context가 포함된다', () => {
+      renderHook(() => useWidgetMirror(station, 0.1, tripFull));
+      expect(mockSave).toHaveBeenCalledWith(station, 0.1, undefined, undefined, tripFull);
+    });
+
+    it('tripContext 없으면 undefined 전달 (backward compat)', () => {
+      renderHook(() => useWidgetMirror(station, 0.1));
+      expect(mockSave).toHaveBeenCalledWith(station, 0.1, undefined, undefined, undefined);
+    });
+
+    it('tripContext.destinationName이 바뀌면 effect 재실행', () => {
+      const tripAlt: WidgetTripContext = { ...tripFull, destinationName: '선릉' };
+      const { rerender } = renderHook(
+        ({ ctx }: { ctx: WidgetTripContext }) => useWidgetMirror(station, 0.1, ctx),
+        { initialProps: { ctx: tripFull } },
+      );
+      rerender({ ctx: tripAlt });
+      expect(mockSave).toHaveBeenCalledTimes(2);
+      expect(mockSave).toHaveBeenLastCalledWith(station, 0.1, undefined, undefined, tripAlt);
+    });
+
+    it('tripContext.nextTransferName이 바뀌면 effect 재실행', () => {
+      const tripNoTransfer: WidgetTripContext = { ...tripFull, nextTransferName: undefined };
+      const { rerender } = renderHook(
+        ({ ctx }: { ctx: WidgetTripContext }) => useWidgetMirror(station, 0.1, ctx),
+        { initialProps: { ctx: tripFull } },
+      );
+      rerender({ ctx: tripNoTransfer });
+      expect(mockSave).toHaveBeenCalledTimes(2);
+    });
+
+    it('trip 활성 → 비활성 전환 시 effect 재실행', () => {
+      const { rerender } = renderHook(
+        ({ ctx }: { ctx: WidgetTripContext | undefined }) => useWidgetMirror(station, 0.1, ctx),
+        { initialProps: { ctx: tripDirect as WidgetTripContext | undefined } },
+      );
+      rerender({ ctx: undefined });
+      expect(mockSave).toHaveBeenCalledTimes(2);
+      expect(mockSave).toHaveBeenLastCalledWith(station, 0.1, undefined, undefined, undefined);
+    });
   });
 });

--- a/src/features/widget/hooks/useWidgetMirror.ts
+++ b/src/features/widget/hooks/useWidgetMirror.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import type { Station } from '../../../shared/types/station';
-import { saveStationToWidget } from '../api/widgetStorage';
+import { saveStationToWidget, type WidgetTripContext } from '../api/widgetStorage';
 import { createLogger } from '../../../shared/utils/logger';
 
 const logger = createLogger('WidgetMirror');
@@ -26,24 +26,30 @@ function distanceBucket(distanceKm: number | undefined | null): number | null {
  *   회귀가 발생한다 (#1239). 명시적 clear 가 필요한 경로(알람 종료 등)는 별도
  *   `clearWidgetStation` caller(`stationNotification`, `SharedGroupAdapter`)가 담당.
  *
- * 위젯 lifecycle은 destination/route 상태와 분리되어 항상 nearest station을 반영한다(#1094).
- * deps는 50m bucket으로 정규화해 GPS tick마다 불필요한 effect 재실행을 막는다.
+ * #1781 — trip 활성 시 `tripContext`를 전달하면 현재역·환승역·도착역을 위젯에 추가 표시.
+ * trip 비활성(tripContext=undefined)이면 기존 nearest station UI 유지 (regression 차단).
+ * deps는 50m bucket + tripContext 식별자로 정규화해 GPS tick마다 불필요한 effect 재실행을 막는다.
  */
 export function useWidgetMirror(
   station: Station | null | undefined,
   distanceKm: number | null | undefined,
+  tripContext?: WidgetTripContext,
 ): void {
   const bucket = distanceBucket(distanceKm);
   const stationId = station?.id ?? null;
+  // deps 식별자: trip 활성 여부 + 목적지 + 환승역. 값이 바뀔 때만 effect 재실행.
+  const tripKey = tripContext
+    ? `${String(tripContext.tripActive)}:${tripContext.currentStationName}:${tripContext.destinationName}:${tripContext.nextTransferName ?? ''}`
+    : null;
 
   useEffect(() => {
     if (!station || distanceKm == null) {
       return;
     }
-    saveStationToWidget(station, distanceKm).catch((e) =>
+    saveStationToWidget(station, distanceKm, undefined, undefined, tripContext ?? undefined).catch((e) =>
       logger.error('save 실패:', e),
     );
-    // station/distanceKm은 ref로만 사용. stationId/bucket이 effect 재실행 트리거.
+    // station/distanceKm/tripContext은 ref로만 사용. stationId/bucket/tripKey가 effect 재실행 트리거.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [stationId, bucket]);
+  }, [stationId, bucket, tripKey]);
 }

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -382,5 +382,12 @@
       "grant": "Allow permissions",
       "requesting": "Requesting..."
     }
+  },
+  "widget": {
+    "header": "Subway",
+    "headerTrip": "On Board",
+    "detecting": "Detecting",
+    "nextTransfer": "Next Transfer",
+    "destination": "Destination"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -382,5 +382,12 @@
       "grant": "権限を許可する",
       "requesting": "リクエスト中..."
     }
+  },
+  "widget": {
+    "header": "地下鉄",
+    "headerTrip": "乗車中",
+    "detecting": "検出中",
+    "nextTransfer": "次の乗換",
+    "destination": "到着予定"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -382,5 +382,12 @@
       "grant": "권한 허용하기",
       "requesting": "요청 중..."
     }
+  },
+  "widget": {
+    "header": "지하철",
+    "headerTrip": "탑승 중",
+    "detecting": "감지 중",
+    "nextTransfer": "다음 환승",
+    "destination": "도착 예정"
   }
 }

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -382,5 +382,12 @@
       "grant": "允许权限",
       "requesting": "请求中..."
     }
+  },
+  "widget": {
+    "header": "地铁",
+    "headerTrip": "乘车中",
+    "detecting": "检测中",
+    "nextTransfer": "下次换乘",
+    "destination": "到站预计"
   }
 }

--- a/targets/subway-widget/SubwayWidget.swift
+++ b/targets/subway-widget/SubwayWidget.swift
@@ -11,6 +11,11 @@ struct SubwayEntry: TimelineEntry {
     let isAvailable: Bool
     // 앱이 마지막으로 위젯 데이터를 기록한 시각. nil이면 freshness 표시 생략 (legacy 데이터).
     let savedAt: Date?
+    // #1781 — trip 활성 시 추가 필드. nil이면 기존 nearest station UI 유지 (backward compat).
+    let tripActive: Bool
+    let currentStationName: String?
+    let destinationName: String?
+    let nextTransferName: String?
 }
 
 // Freshness 3단계 임계. savedAt으로부터 경과 시간으로 tier를 결정한다.
@@ -50,7 +55,11 @@ struct SubwayProvider: TimelineProvider {
             lineColor: "#009933",
             distanceM: 120,
             isAvailable: true,
-            savedAt: Date()
+            savedAt: Date(),
+            tripActive: false,
+            currentStationName: nil,
+            destinationName: nil,
+            nextTransferName: nil
         )
     }
 
@@ -77,6 +86,11 @@ struct SubwayProvider: TimelineProvider {
         // savedAt이 없는 레거시 설치 환경에서는 nil로 두어 freshness 표시를 생략한다.
         let savedAtSec = defaults?.object(forKey: "savedAt") as? Double
         let savedAt = savedAtSec.map { Date(timeIntervalSince1970: $0) }
+        // #1781 — trip 활성 필드. 키 없는 레거시 데이터에서는 false로 폴백.
+        let tripActive = defaults?.bool(forKey: "tripActive") ?? false
+        let currentStationName = defaults?.string(forKey: "currentStationName")
+        let destinationName = defaults?.string(forKey: "destinationName")
+        let nextTransferName = defaults?.string(forKey: "nextTransferName")
 
         return SubwayEntry(
             date: Date(),
@@ -84,7 +98,11 @@ struct SubwayProvider: TimelineProvider {
             lineColor: color,
             distanceM: distance,
             isAvailable: isAvailable,
-            savedAt: savedAt
+            savedAt: savedAt,
+            tripActive: tripActive,
+            currentStationName: currentStationName,
+            destinationName: destinationName,
+            nextTransferName: nextTransferName
         )
     }
 }
@@ -140,6 +158,17 @@ struct SubwayWidgetView: View {
     }
 
     private var content: some View {
+        Group {
+            if entry.tripActive, let currentStation = entry.currentStationName, let destination = entry.destinationName {
+                tripActiveContent(currentStation: currentStation, destination: destination)
+            } else {
+                nearestStationContent
+            }
+        }
+    }
+
+    // trip 비활성 — 기존 최근접 역 UI (backward compat)
+    private var nearestStationContent: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 4) {
                 Circle()
@@ -163,6 +192,64 @@ struct SubwayWidgetView: View {
                     .font(.subheadline)
                     .foregroundColor(lineColor)
                     .opacity(contentOpacity)
+            }
+
+            if let caption = freshnessCaption {
+                Text(caption)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            Text(entry.date, style: .time)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+        .padding(12)
+    }
+
+    // trip 활성 — 현재역 + 다음 환승역(있을 경우) + 도착역
+    private func tripActiveContent(currentStation: String, destination: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(lineColor)
+                    .frame(width: 10, height: 10)
+                Text("탑승 중")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+
+            Text(currentStation)
+                .font(.headline)
+                .fontWeight(.bold)
+                .foregroundColor(.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+
+            if let transfer = entry.nextTransferName {
+                HStack(spacing: 2) {
+                    Text("다음 환승")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                    Text(transfer)
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.primary)
+                        .lineLimit(1)
+                }
+            }
+
+            HStack(spacing: 2) {
+                Text("도착 예정")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                Text(destination)
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+                    .foregroundColor(lineColor)
+                    .lineLimit(1)
             }
 
             if let caption = freshnessCaption {


### PR DESCRIPTION
## 개요

trip 활성 시 홈 위젯에 현재역 · 다음 환승역 · 도착역을 표시한다. trip 비활성이면 기존 nearest station UI를 그대로 유지 (backward compat).

Closes #1781

## 변경 내용

### 1. Widget data schema 확장 (`widgetStorage.ts`)
- `WidgetTripContext` 타입 추가: `currentStationName`, `destinationName`, `nextTransferName?`, `tripActive`
- `saveStationToWidget` 5번째 파라미터 `tripContext?: WidgetTripContext` 추가
- 기존 4-key UserDefaults 구조 **backward compat 유지** — `saveWidgetStation` 4-param 시그니처 불변
- trip 맥락은 `nativeSaveWidgetTripContext` 별도 호출로 분리 (live-activity 기존 시그니처 보존)

### 2. Mirror logic 확장 (`useWidgetMirror.ts`)
- `tripContext?: WidgetTripContext` 파라미터 추가
- `tripKey` deps 추가 (tripActive + destination + nextTransfer 조합) → trip 상태 변화 시 effect 재실행

### 3. Native 확장 (`LiveActivityModule.swift`)
- `saveWidgetTripContext` AsyncFunction 추가: `tripActive` + `currentStationName` + `destinationName` + `nextTransferName` → 4개 UserDefaults 키 write
- `clearWidgetStation` — 신규 4개 키 함께 제거

### 4. JS 래퍼 추가 (`live-activity/index.ts`)
- `saveWidgetTripContext` export 추가 (기존 `saveWidgetStation` 4-param 변경 없음)

### 5. Swift UI 분기 (`SubwayWidget.swift`)
- `SubwayEntry` 필드 추가: `tripActive`, `currentStationName?`, `destinationName?`, `nextTransferName?`
- `makeEntry()` — UserDefaults에서 신규 키 읽기 (레거시 데이터에서 false/nil 폴백)
- `SubwayWidgetView` — trip 활성 시 `tripActiveContent` (현재역 + 환승역 + 도착역), 비활성 시 `nearestStationContent` (기존 UI 그대로)

### 6. i18n (`locales/ko/en/ja/zh`)
- `widget` 네임스페이스 추가: `header`, `headerTrip`, `detecting`, `nextTransfer`, `destination` 5개 키 × 4언어

## Wire-completion 5단 체크

1. **Orphan 없음** — `npm run lint:orphan` 0 orphan 확인. `WidgetTripContext` export는 `widgetStorage.ts`에서 사용, `useWidgetMirror.ts`가 import
2. **V/X dashboard** — DebugModal 로그: `WidgetMirror save 실패:` 에러 관측 가능. trip 활성 시 위젯 홈 화면에서 직접 시각 확인
3. **의존 PR** — #1783 (widget i18n `#1776`) — i18n 인프라 rebase 가능. 현재 i18n 키는 Swift hardcoding으로도 동작
4. **측정 plan** — 실기기 trip 1회 후 위젯 표시 확인. 비활성 시 기존 UI 회귀 없음 확인
5. **Device verify** — 실기기 필요: iOS 위젯 trip 활성/비활성 전환 시나리오

## 검증 결과

- `npm test` — 7788 tests passed, 100% coverage ✅
- `npm run type-check` — 0 errors ✅
- `npm run lint:orphan` — 0 orphan exports ✅
- Backend 영향: 없음 (UserDefaults write only)

## #1783 conflict 가능성

`src/shared/i18n/locales/*.json` 4개 파일 수정 → #1783 머지 후 rebase 시 conflict 가능. `widget` 네임스페이스 추가이므로 충돌 해결은 단순 merge.