### PR TITLE
chore(#1793): 미사용 i18n key 6건 삭제 (permissions.* + a11y.route.*)

### DIFF
--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -12,10 +12,7 @@
     "settings": "Settings"
   },
   "permissions": {
-    "locationRequiredTitle": "Location permission required",
     "locationRequiredShort": "Location permission required.",
-    "locationRequiredDescription": "Please allow location permission in Settings.\nLocation permission is required to detect your current station.",
-    "request": "Grant permission",
     "locating": "Locating...",
     "backgroundDeniedTitle": "Background location required",
     "backgroundDeniedBody": "To receive background alarms, set location access to \"Always\" in Settings.",
@@ -326,12 +323,9 @@
       "assignSlotLabel": "Assign {{label}} slot",
       "assignSlotHint": "Saves the next selected station to this slot",
       "favoriteChipHint": "Tap to set this station as destination",
-      "misBoardingCloseLabel": "Close",
-      "misBoardingCloseHint": "Cancels reselection",
       "misBoardingBannerLabel": "Cannot identify your train. Please reselect.",
       "misBoardingReselectLabel": "Reselect boarding train",
-      "misBoardingReselectHint": "Reopens the boarding train picker",
-      "titleHeaderRole": "header"
+      "misBoardingReselectHint": "Reopens the boarding train picker"
     }
   },
   "service": {

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -12,10 +12,7 @@
     "settings": "設定"
   },
   "permissions": {
-    "locationRequiredTitle": "位置情報の許可が必要です",
     "locationRequiredShort": "位置情報の許可が必要です。",
-    "locationRequiredDescription": "設定で位置情報の利用を許可してください。\n現在の駅を検出するために位置情報が必要です。",
-    "request": "許可する",
     "locating": "位置情報を取得中...",
     "backgroundDeniedTitle": "バックグラウンド位置情報の許可が必要です",
     "backgroundDeniedBody": "バックグラウンドでアラームを受け取るには、設定で位置情報を「常に許可」にしてください。",
@@ -326,12 +323,9 @@
       "assignSlotLabel": "{{label}} スロットを指定",
       "assignSlotHint": "次に選択する駅をこのスロットに保存します",
       "favoriteChipHint": "タップしてこの駅を目的地に設定",
-      "misBoardingCloseLabel": "閉じる",
-      "misBoardingCloseHint": "再選択をキャンセルします",
       "misBoardingBannerLabel": "乗車中の列車を特定できません。再選択してください。",
       "misBoardingReselectLabel": "乗車列車を再選択",
-      "misBoardingReselectHint": "乗車列車選択画面を再度開きます",
-      "titleHeaderRole": "header"
+      "misBoardingReselectHint": "乗車列車選択画面を再度開きます"
     }
   },
   "service": {

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -12,10 +12,7 @@
     "settings": "설정"
   },
   "permissions": {
-    "locationRequiredTitle": "위치 권한 필요",
     "locationRequiredShort": "위치 권한이 필요합니다.",
-    "locationRequiredDescription": "설정에서 위치 권한을 허용해 주세요.\n현재 탑승 중인 역을 감지하려면\n위치 권한이 필요합니다.",
-    "request": "권한 요청",
     "locating": "위치 확인 중...",
     "backgroundDeniedTitle": "백그라운드 위치 권한 필요",
     "backgroundDeniedBody": "백그라운드에서 알람을 받으려면 설정에서 위치 권한을 '항상 허용'으로 설정해 주세요.",
@@ -326,12 +323,9 @@
       "assignSlotLabel": "{{label}} 슬롯 지정",
       "assignSlotHint": "다음에 선택할 역을 이 슬롯에 저장합니다",
       "favoriteChipHint": "탭하여 이 역을 목적지로 선택",
-      "misBoardingCloseLabel": "닫기",
-      "misBoardingCloseHint": "재선택을 취소합니다",
       "misBoardingBannerLabel": "탑승 열차를 확인할 수 없습니다. 다시 선택하세요.",
       "misBoardingReselectLabel": "탑승 열차 재선택",
-      "misBoardingReselectHint": "탑승 열차 선택 화면을 다시 엽니다",
-      "titleHeaderRole": "header"
+      "misBoardingReselectHint": "탑승 열차 선택 화면을 다시 엽니다"
     }
   },
   "service": {

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -12,10 +12,7 @@
     "settings": "设置"
   },
   "permissions": {
-    "locationRequiredTitle": "需要位置权限",
     "locationRequiredShort": "需要位置权限。",
-    "locationRequiredDescription": "请在设置中允许位置权限。\n要检测您当前的车站，需要位置权限。",
-    "request": "授予权限",
     "locating": "正在定位...",
     "backgroundDeniedTitle": "需要后台位置权限",
     "backgroundDeniedBody": "要在后台接收闹钟，请在设置中将位置访问设为\"始终允许\"。",
@@ -326,12 +323,9 @@
       "assignSlotLabel": "指定 {{label}} 槽位",
       "assignSlotHint": "将下次选择的车站保存到此槽位",
       "favoriteChipHint": "点击将此站设为目的地",
-      "misBoardingCloseLabel": "关闭",
-      "misBoardingCloseHint": "取消重新选择",
       "misBoardingBannerLabel": "无法识别乘坐的列车，请重新选择。",
       "misBoardingReselectLabel": "重新选择乘坐列车",
-      "misBoardingReselectHint": "重新打开乘坐列车选择界面",
-      "titleHeaderRole": "header"
+      "misBoardingReselectHint": "重新打开乘坐列车选择界面"
     }
   },
   "service": {


### PR DESCRIPTION
## Summary

- `permissions.locationRequiredTitle`, `permissions.locationRequiredDescription`, `permissions.request` 3 key 삭제
- `a11y.route.misBoardingCloseLabel`, `a11y.route.misBoardingCloseHint`, `a11y.route.titleHeaderRole` 3 key 삭제
- ko/en/ja/zh 4 locale 파일 동기 삭제, 각 파일 -6 lines (삭제 7, 나머지 JSON 구조 정리)

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (No orphan exports detected)
2. **V/X dashboard** — N/A (key 삭제, 런타임 신호 없음)
3. **의존 PR** — N/A
4. **측정 plan** — N/A (삭제 전용, 회귀 신호 없음)
5. **Device verify** — N/A — type+unit only (i18n key 삭제)

## 검증

- `grep -rn "permissions.locationRequiredTitle|..."` → 0건 확인
- 7631 tests pass (4 suite failures는 worktree expo-haptics 환경 이슈, dev 브랜치 동일)
- `lint:orphan` pass

Closes #1793