### PR TITLE
feat(#1797): Widget Smart Stack relevance + widgetURL + StaleDate (P3+P4)

### DIFF
--- a/targets/subway-widget/SubwayWidget.swift
+++ b/targets/subway-widget/SubwayWidget.swift
@@ -16,6 +16,18 @@ struct SubwayEntry: TimelineEntry {
     let currentStationName: String?
     let destinationName: String?
     let nextTransferName: String?
+    // P4: staleDate — savedAt + 10분 초과 시 시스템 "stale" overlay 표시 차단 임계.
+    var staleDate: Date? { savedAt.map { $0.addingTimeInterval(EXPIRED_THRESHOLD_SECONDS) } }
+    // P3: Smart Stack relevance (iOS 17+). trip 활성+환승 임박 → 1.0, trip 활성 → 0.8, 평시 → 0.3.
+    var relevance: TimelineEntryRelevance? {
+        if tripActive && nextTransferName != nil {
+            return TimelineEntryRelevance(score: 1.0, duration: 60)
+        } else if tripActive {
+            return TimelineEntryRelevance(score: 0.8, duration: 60)
+        } else {
+            return TimelineEntryRelevance(score: 0.3, duration: 0)
+        }
+    }
 }
 
 // Freshness 3단계 임계. savedAt으로부터 경과 시간으로 tier를 결정한다.
@@ -146,14 +158,20 @@ struct SubwayWidgetView: View {
         freshness == .expired ? EXPIRED_CONTENT_OPACITY : 1.0
     }
 
+    // P4: 위젯 탭 시 앱 딥링크 — 현재역 상세 화면 진입.
+    private var deepLink: URL { URL(string: "subway-now://current-station")! }
+
     var body: some View {
         // iOS 17+는 위젯이 containerBackground를 채택하지 않으면
         // 시스템이 "Please adopt containerBackground API" placeholder를 대신 그린다.
         // 배포 타겟 15.1이라 availability 분기 필요.
         if #available(iOS 17.0, *) {
-            content.containerBackground(.background, for: .widget)
+            content
+                .containerBackground(.background, for: .widget)
+                .widgetURL(deepLink)
         } else {
             content
+                .widgetURL(deepLink)
         }
     }
 


### PR DESCRIPTION
## 개요

Closes #1797

Smart Stack relevance (P3) + widgetURL + staleDate (P4) 통합 구현.

## 변경 내용

### P3 — Smart Stack relevance (`TimelineEntryRelevance`)

`SubwayEntry`에 computed property `relevance` 추가:

| 상태 | score | duration |
|------|-------|----------|
| trip 활성 + 환승 임박(`nextTransferName != nil`) | 1.0 | 60s |
| trip 활성 | 0.8 | 60s |
| 평시 | 0.3 | 0 |

iOS 17+ Smart Stack이 이 값을 보고 위젯을 자동 최상단으로 승격.

### P4 — staleDate + widgetURL

- `staleDate` computed property: `savedAt + 10min` (기존 `EXPIRED_THRESHOLD_SECONDS` 상수 재사용)  
  시스템이 10분 이후 "stale" overlay를 그리는 것을 차단.
- `.widgetURL(URL(string: "subway-now://current-station")!)` modifier  
  iOS 17+ (`containerBackground`) / 이전 버전 분기 양쪽 모두 적용.

## Wire-completion 5단 체크

1. **Orphan 없음** — `npm run lint:orphan` → 0 orphan 확인
2. **V/X dashboard** — Swift native 코드. 실기기 위젯에서 Smart Stack 순위 + 탭 딥링크 진입으로 관측
3. **의존 PR** — N/A (단독 Swift widget 변경)
4. **측정 plan** — 실기기 trip 중 Smart Stack에서 위젯이 최상단 승격되는지 1회 확인; 위젯 탭 → 앱 현재역 화면 진입 확인
5. **Device verify** — Swift 위젯 변경. iOS 실기기에서 Smart Stack + widgetURL + staleDate 동작 확인 필요