### PR TITLE
feat(#1796): iOS Lock Screen Widget + AOD 명도 감소

### DIFF
--- a/targets/subway-widget/Localizable.xcstrings
+++ b/targets/subway-widget/Localizable.xcstrings
@@ -1,6 +1,35 @@
 {
   "sourceLanguage" : "ko",
   "strings" : {
+    "widget.lockscreen.title" : {
+      "comment" : "Title shown in lock screen rectangular widget",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Subway"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "地下鉄"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "지하철"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "地铁"
+          }
+        }
+      }
+    },
     "widget.detecting" : {
       "comment" : "Placeholder station name while GPS detection is in progress",
       "localizations" : {

--- a/targets/subway-widget/SubwayLiveActivityWidget.swift
+++ b/targets/subway-widget/SubwayLiveActivityWidget.swift
@@ -78,6 +78,9 @@ struct SubwayLiveActivityWidget: Widget {
 private struct LockScreenView: View {
     let state: SubwayActivityAttributes.ContentState
 
+    // AOD (Always-On Display) 환경 감지 — isLuminanceReduced=true 시 명도 최소화
+    @Environment(\.isLuminanceReduced) var isLuminanceReduced
+
     var lineColor: Color {
         Color(hex: state.lineColorHex) ?? .gray
     }
@@ -87,19 +90,24 @@ private struct LockScreenView: View {
     }
 
     var urgentColor: Color {
-        state.alarmType == "destination" ? .red : .orange
+        // AOD 시 accent(색조)만 유지하되 배경을 거의 블랙으로 낮춘다
+        if isLuminanceReduced {
+            return state.alarmType == "destination" ? .red.opacity(0.7) : .orange.opacity(0.7)
+        }
+        return state.alarmType == "destination" ? .red : .orange
     }
 
     var urgentText: String {
         return state.alarmBody ?? ""
     }
 
+
     var body: some View {
         if isUrgent {
             // 긴급 모드
             HStack(spacing: 12) {
                 RoundedRectangle(cornerRadius: 4)
-                    .fill(.white.opacity(0.3))
+                    .fill(.white.opacity(isLuminanceReduced ? 0.15 : 0.3))
                     .frame(width: 6)
 
                 VStack(alignment: .leading, spacing: 4) {
@@ -109,7 +117,7 @@ private struct LockScreenView: View {
                         .foregroundColor(.white.opacity(0.9))
                         .padding(.horizontal, 8)
                         .padding(.vertical, 2)
-                        .background(.white.opacity(0.2))
+                        .background(.white.opacity(isLuminanceReduced ? 0.1 : 0.2))
                         .cornerRadius(10)
 
                     Text(state.stationName)
@@ -131,28 +139,29 @@ private struct LockScreenView: View {
                     .foregroundColor(.white)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 6)
-                    .background(.white.opacity(0.2))
+                    .background(.white.opacity(isLuminanceReduced ? 0.1 : 0.2))
                     .cornerRadius(8)
             }
             .padding(16)
-            .background(urgentColor)
+            // AOD 시 배경은 블랙(.opacity 0.9) + urgentColor accent strip
+            .background(isLuminanceReduced ? .black.opacity(0.9) : urgentColor)
         } else {
             // 일반 모드
             HStack(spacing: 16) {
-                // 노선 색상 바
+                // 노선 색상 바 — AOD 시 opacity 낮춤
                 RoundedRectangle(cornerRadius: 4)
-                    .fill(lineColor)
+                    .fill(lineColor.opacity(isLuminanceReduced ? 0.5 : 1.0))
                     .frame(width: 6)
 
                 VStack(alignment: .leading, spacing: 4) {
-                    // 노선 배지
+                    // 노선 배지 — AOD 시 배경 opacity 낮춤
                     Text(state.lineName)
                         .font(.caption2)
                         .fontWeight(.bold)
                         .foregroundColor(.white)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 2)
-                        .background(lineColor)
+                        .background(lineColor.opacity(isLuminanceReduced ? 0.4 : 1.0))
                         .cornerRadius(10)
 
                     // 역 이름
@@ -167,7 +176,7 @@ private struct LockScreenView: View {
                     } else {
                         Text(state.resolvedDistanceText ?? "")
                             .font(.subheadline)
-                            .foregroundColor(lineColor)
+                            .foregroundColor(lineColor.opacity(isLuminanceReduced ? 0.6 : 1.0))
                     }
 
                     // 데이터 출처 자백 (#327). 없으면 표시 생략.
@@ -194,7 +203,11 @@ private struct LockScreenView: View {
                 }
             }
             .padding(16)
-            .background(.black.opacity(0.85))
+            // AOD 시 배경: 거의 블랙 + 노선색 약한 tint / 일반: 기존 반투명 블랙
+            .background(
+                Color.black.opacity(isLuminanceReduced ? 0.9 : 0.85)
+                    .overlay(isLuminanceReduced ? lineColor.opacity(0.08) : Color.clear)
+            )
         }
     }
 }

--- a/targets/subway-widget/SubwayWidget.swift
+++ b/targets/subway-widget/SubwayWidget.swift
@@ -268,18 +268,123 @@ struct SubwayWidgetView: View {
     }
 }
 
+// MARK: - Lock Screen Widget Views (iOS 16+)
+
+@available(iOS 16.0, *)
+struct LockScreenRectangularView: View {
+    var entry: SubwayEntry
+
+    var lineColor: Color {
+        Color(hex: entry.lineColor) ?? .gray
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            // 노선 색 stripe
+            RoundedRectangle(cornerRadius: 2)
+                .fill(lineColor)
+                .frame(width: 4)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(NSLocalizedString("widget.lockscreen.title", comment: "Title shown in lock screen rectangular widget"))
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                Text(entry.stationName)
+                    .font(.headline)
+                    .fontWeight(.bold)
+                    .foregroundColor(.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .widgetAccentable()
+    }
+}
+
+@available(iOS 16.0, *)
+struct LockScreenCircularView: View {
+    var entry: SubwayEntry
+
+    var lineColor: Color {
+        Color(hex: entry.lineColor) ?? .gray
+    }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(lineColor)
+            Text(entry.stationName.prefix(2))
+                .font(.caption2)
+                .fontWeight(.bold)
+                .foregroundColor(.white)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+        }
+        .widgetAccentable()
+    }
+}
+
+// MARK: - Lock Screen Widget Entry View Router
+
+struct SubwayLockScreenWidgetView: View {
+    @Environment(\.widgetFamily) var family
+    var entry: SubwayEntry
+
+    var body: some View {
+        if #available(iOS 16.0, *) {
+            switch family {
+            case .accessoryRectangular:
+                LockScreenRectangularView(entry: entry)
+            case .accessoryCircular:
+                LockScreenCircularView(entry: entry)
+            default:
+                EmptyView()
+            }
+        }
+    }
+}
+
 // MARK: - Widget Configuration
 
 struct SubwayWidget: Widget {
     let kind = "SubwayWidget"
 
+    private var supportedFamilies: [WidgetFamily] {
+        if #available(iOS 16.0, *) {
+            return [.systemSmall, .systemMedium, .accessoryRectangular, .accessoryCircular]
+        }
+        return [.systemSmall, .systemMedium]
+    }
+
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: kind, provider: SubwayProvider()) { entry in
-            SubwayWidgetView(entry: entry)
+            if #available(iOS 16.0, *) {
+                SubwayWidgetEntryView(entry: entry)
+            } else {
+                SubwayWidgetView(entry: entry)
+            }
         }
         .configurationDisplayName(NSLocalizedString("widget.displayName", comment: "Widget configuration display name shown in the widget picker"))
         .description(NSLocalizedString("widget.description", comment: "Widget description shown in the widget picker"))
-        .supportedFamilies([.systemSmall, .systemMedium])
+        .supportedFamilies(supportedFamilies)
+    }
+}
+
+// Routes between home-screen and lock-screen families (iOS 16+).
+@available(iOS 16.0, *)
+private struct SubwayWidgetEntryView: View {
+    @Environment(\.widgetFamily) var family
+    var entry: SubwayEntry
+
+    var body: some View {
+        switch family {
+        case .accessoryRectangular, .accessoryCircular:
+            SubwayLockScreenWidgetView(entry: entry)
+        default:
+            SubwayWidgetView(entry: entry)
+        }
     }
 }
 


### PR DESCRIPTION
Closes #1796

## 변경 요약

### P1 — Lock Screen Widget
- `supportedFamilies`에 `.accessoryRectangular` + `.accessoryCircular` 추가 (iOS 16.0+)
- `LockScreenRectangularView`: 역명 + 호선 색 4px stripe 좌측 배치, `widgetAccentable()`
- `LockScreenCircularView`: 호선 색 원 배경 + 역명 앞 2글자, `widgetAccentable()`
- `SubwayWidgetEntryView`: family 분기 라우터 — accessory계열은 `SubwayLockScreenWidgetView`, 나머지는 기존 `SubwayWidgetView`
- `Localizable.xcstrings`: `widget.lockscreen.title` ko/en/ja/zh 추가

### P2 — AOD isLuminanceReduced
- `LockScreenView`에 `@Environment(\.isLuminanceReduced) var isLuminanceReduced` 주입
- 긴급 모드 AOD: 배경 `.black.opacity(0.9)` (urgentColor 대신), 오버레이/badge opacity 절반
- 일반 모드 AOD: 배경 `Color.black.opacity(0.9).overlay(lineColor.opacity(0.08))`, 노선 색 요소 opacity 낮춤
- 비-AOD 경로: 기존 동작 유지 (회귀 없음)

## Wire-completion 5단

1. **Orphan** — `npm run lint:orphan` → No orphan exports detected
2. **V/X dashboard** — 잠금화면 직접 확인 (시뮬레이터 위젯 갤러리 / 실기기 Lock Screen)
3. **의존 PR** — N/A
4. **측정 plan** — EAS development 빌드 후 잠금화면 위젯 갤러리에서 rectangular/circular 노출 확인; AOD는 Apple Watch Ultra 또는 iPhone 15 Pro AOD 켠 상태에서 LA 발사 후 명도 확인
5. **Device verify** — 실기기 필요 (Lock Screen 위젯은 시뮬레이터에서 부분 지원; AOD는 실기기 전용)

## 비고
- type-check: `expo-haptics` 타입 오류 6건은 base 브랜치 pre-existing (본 PR 변경과 무관)
- Swift 파일은 CI type-check 범위 외 (TypeScript-only); native compile은 사용자 EAS 빌드 시 검증