### PR TITLE
feat(#1798): Push category 분리 + subtitle (P2+P3)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -24,7 +24,11 @@ import { registerScheduledAlarmListener } from '../src/features/alarm/utils/sche
 import { cancelScheduledAlarms } from '../src/features/alarm/utils/alarmScheduler';
 import { unregisterAlarmRefreshTask } from '../src/features/alarm/tasks/alarmRefreshTask';
 import { stopVibration } from '../src/features/alarm/utils/alarmSound';
-import { setupBoardingPromptCategory } from '../src/features/alarm/utils/notificationCategory';
+import {
+  setupAlarmCategory,
+  setupBoardingPromptCategory,
+  setupTripEndedCategory,
+} from '../src/features/alarm/utils/notificationCategory';
 import { useBoardingPromptResponder } from '../src/features/alarm/hooks/useBoardingPromptResponder';
 import { useBoardingPromptDisplayLogger } from '../src/features/alarm/hooks/useBoardingPromptDisplayLogger';
 import { useStateRehydration } from '../src/shared/hooks/useStateRehydration';
@@ -62,6 +66,14 @@ registerSilentPushTask().catch((e) => layoutLogger.warn('silent push task 등록
 // #819 — "탑승했냐?" 푸시의 BOARDING_PROMPT category 등록. 액션 [탑승]/[미탑승]을 노출.
 setupBoardingPromptCategory().catch((e) =>
   layoutLogger.warn('boarding-prompt category 등록 실패(#819):', e),
+);
+// #1798 P2 — transfer/destination 알람 ALARM_CATEGORY 등록. 액션 [확인]/[trip 종료]을 노출.
+setupAlarmCategory().catch((e) =>
+  layoutLogger.warn('alarm category 등록 실패(#1798):', e),
+);
+// #1798 P2 — trip 종료 TRIP_ENDED_CATEGORY 등록. 액션 [다음 여정 시작]을 노출.
+setupTripEndedCategory().catch((e) =>
+  layoutLogger.warn('trip-ended category 등록 실패(#1798):', e),
 );
 // 사전 예약 alarm receiver는 잔존 예약 발사 시 FIRED_ALARMS 갱신만 담당.
 registerScheduledAlarmListener();

--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -712,6 +712,40 @@ describe('sendAlertPush (#572 P2c)', () => {
     const headers = call[1].headers as Record<string, string>;
     expect('apns-thread-id' in headers).toBe(false);
   });
+
+  // #1798 P2 — category 필드 wire 검증.
+  it('category 지정 시 aps.category에 전달된다 (#1798)', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await sendAlertPush({
+      deviceToken: 't',
+      title: 'T',
+      body: 'B',
+      pushId: 'p',
+      category: 'ALARM_CATEGORY',
+      config: makeConfig(),
+      host: TEST_HOST_2,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.aps.category).toBe('ALARM_CATEGORY');
+  });
+
+  it('category 미지정 시 aps.category omit (#1798)', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await sendAlertPush({
+      deviceToken: 't',
+      title: 'T',
+      body: 'B',
+      pushId: 'p',
+      config: makeConfig(),
+      host: TEST_HOST_2,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect('category' in body.aps).toBe(false);
+  });
 });
 
 describe('sendReschedulePush (#585)', () => {
@@ -1017,6 +1051,48 @@ describe('sendBoardingPromptPush (#819)', () => {
       expect(body.data.triggerKind).toBe(triggerKind);
     },
   );
+
+  // #1798 P3 — subtitle wire 검증.
+  it('subtitle 지정 시 aps.alert.subtitle에 전달된다 (#1798)', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    await sendBoardingPromptPush({
+      deviceToken: 'device-hex',
+      pushId: 'p-sub',
+      title: 'T',
+      body: 'B',
+      originStation: 'O',
+      line: '2',
+      tripToken: 't',
+      sentAt: 0,
+      subtitle: '2호선 상행방면',
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.aps.alert.subtitle).toBe('2호선 상행방면');
+  });
+
+  it('subtitle 미지정 시 aps.alert.subtitle omit (#1798)', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    await sendBoardingPromptPush({
+      deviceToken: 'device-hex',
+      pushId: 'p-nosub',
+      title: 'T',
+      body: 'B',
+      originStation: 'O',
+      line: '2',
+      tripToken: 't',
+      sentAt: 0,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect('subtitle' in body.aps.alert).toBe(false);
+  });
 });
 
 // #1337 — trip-ended를 silent → alert로 전환. killed 앱에 OS banner로 즉시 표시.

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -431,6 +431,11 @@ export interface SendAlertPushOptions {
    * 미지정 시 apns-thread-id 헤더를 omit (구 caller backward compat).
    */
   tripToken?: string;
+  /**
+   * #1798 P2 — iOS UNNotificationCategory 식별자. 지정 시 액션 버튼 노출.
+   * 미지정 시 aps.category 필드를 omit (구 caller backward compat).
+   */
+  category?: string;
   config: ApnsConfig;
   host: string;
   fetchImpl?: typeof fetch;
@@ -446,6 +451,8 @@ export async function sendAlertPush(options: SendAlertPushOptions): Promise<Send
     aps: {
       alert: { title: options.title, body: options.body },
       sound: 'default',
+      // #1798 P2 — category는 정의된 경우에만 wire. 미전달 시 JSON에서 자연 누락.
+      ...(options.category !== undefined ? { category: options.category } : {}),
     },
     data: { pushId: options.pushId },
   });
@@ -715,6 +722,11 @@ export interface SendBoardingPromptPushOptions {
    * 미지정(legacy / direction null) 시 payload에 포함하지 않아 device가 양방향 허용.
    */
   destinationDirection?: 'up' | 'down';
+  /**
+   * #1798 P3 — 호선 + 방향 subtitle. `"${line}호선 ${direction}방면"` 형태로 caller가 빌드해 전달.
+   * 미지정(direction 없는 경우 등) 시 aps.alert.subtitle을 omit해 구 device와 byte-level 호환.
+   */
+  subtitle?: string;
   config: ApnsConfig;
   host: string;
   fetchImpl?: typeof fetch;
@@ -742,7 +754,13 @@ export async function sendBoardingPromptPush(
 
   const body = JSON.stringify({
     aps: {
-      alert: { title: options.title, body: options.body },
+      alert: {
+        title: options.title,
+        body: options.body,
+        // #1798 P3 — subtitle(호선+방향)은 정의된 경우에만 wire. 미전달 시 JSON에서 자연 누락 →
+        // 구 device(필드 무시) 및 subtitle 없는 케이스와 byte-level 호환.
+        ...(options.subtitle !== undefined ? { subtitle: options.subtitle } : {}),
+      },
       sound: 'default',
       category: BOARDING_PROMPT_CATEGORY,
     },

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -3353,6 +3353,11 @@ export async function evaluateAndMaybeFireBoardingPrompt(
         triggerKind: 'cron',
         // #1740 — geo.direction이 null이면 undefined 전달 → device 양방향 허용 (backward compat).
         destinationDirection: geo.direction ?? undefined,
+        // #1798 P3 — subtitle: "${line}호선 ${direction}방면". direction이 있을 때만 첨부.
+        subtitle:
+          geo.direction !== null
+            ? `${display.line}호선 ${geo.direction === 'up' ? '상행' : '하행'}방면`
+            : undefined,
         config: deps.apnsConfig,
         host,
         fetchImpl: deps.fetchImpl,

--- a/src/features/alarm/utils/__tests__/notificationCategory.test.ts
+++ b/src/features/alarm/utils/__tests__/notificationCategory.test.ts
@@ -1,9 +1,16 @@
 import * as Notifications from 'expo-notifications';
 import {
+  ALARM_ACTION_ACKNOWLEDGE,
+  ALARM_ACTION_END_TRIP,
+  ALARM_CATEGORY,
   BOARDING_PROMPT_ACTION_BOARDED,
   BOARDING_PROMPT_ACTION_NOT_BOARDED,
   BOARDING_PROMPT_CATEGORY,
+  setupAlarmCategory,
   setupBoardingPromptCategory,
+  setupTripEndedCategory,
+  TRIP_ENDED_ACTION_NEXT_TRIP,
+  TRIP_ENDED_CATEGORY,
 } from '../notificationCategory';
 
 jest.mock('expo-notifications', () => ({
@@ -37,5 +44,61 @@ describe('setupBoardingPromptCategory (#819)', () => {
       new Error('not supported'),
     );
     await expect(setupBoardingPromptCategory()).resolves.toBeUndefined();
+  });
+});
+
+describe('setupAlarmCategory (#1798 P2)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('ALARM_CATEGORY 식별자로 [확인]/[trip 종료] 액션 등록', async () => {
+    await setupAlarmCategory();
+    expect(Notifications.setNotificationCategoryAsync).toHaveBeenCalledWith(
+      ALARM_CATEGORY,
+      expect.arrayContaining([
+        expect.objectContaining({
+          identifier: ALARM_ACTION_ACKNOWLEDGE,
+          options: expect.objectContaining({ opensAppToForeground: false }),
+        }),
+        expect.objectContaining({
+          identifier: ALARM_ACTION_END_TRIP,
+          options: expect.objectContaining({ opensAppToForeground: false, isDestructive: true }),
+        }),
+      ]),
+    );
+  });
+
+  it('Notifications가 throw해도 graceful (no throw)', async () => {
+    (Notifications.setNotificationCategoryAsync as jest.Mock).mockRejectedValueOnce(
+      new Error('not supported'),
+    );
+    await expect(setupAlarmCategory()).resolves.toBeUndefined();
+  });
+});
+
+describe('setupTripEndedCategory (#1798 P2)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('TRIP_ENDED_CATEGORY 식별자로 [다음 여정 시작] 액션 등록', async () => {
+    await setupTripEndedCategory();
+    expect(Notifications.setNotificationCategoryAsync).toHaveBeenCalledWith(
+      TRIP_ENDED_CATEGORY,
+      expect.arrayContaining([
+        expect.objectContaining({
+          identifier: TRIP_ENDED_ACTION_NEXT_TRIP,
+          options: expect.objectContaining({ opensAppToForeground: true }),
+        }),
+      ]),
+    );
+  });
+
+  it('Notifications가 throw해도 graceful (no throw)', async () => {
+    (Notifications.setNotificationCategoryAsync as jest.Mock).mockRejectedValueOnce(
+      new Error('not supported'),
+    );
+    await expect(setupTripEndedCategory()).resolves.toBeUndefined();
   });
 });

--- a/src/features/alarm/utils/notificationCategory.ts
+++ b/src/features/alarm/utils/notificationCategory.ts
@@ -1,11 +1,16 @@
 /**
- * iOS UNNotificationCategory 등록 (#819 B 슬라이스).
+ * iOS UNNotificationCategory 등록 (#819 B 슬라이스, #1798 P2 카테고리 분리).
  *
  * APNs alert payload의 `aps.category`가 식별자와 매칭되면 푸시 알림에 우리가 등록한
  * 액션 버튼이 노출된다. 사용자가 액션을 탭하면 `Notifications.addNotificationResponseReceivedListener`가
  * `actionIdentifier`를 받아 분기 처리.
  *
  * Android는 expo-notifications가 category를 무시 — graceful no-op.
+ *
+ * 카테고리 3종:
+ *   - BOARDING_PROMPT  : "탑승했냐?" 푸시 (기존)
+ *   - ALARM_CATEGORY   : transfer / destination 알람 — "확인" / "trip 종료" (#1798 P2)
+ *   - TRIP_ENDED_CATEGORY: trip 종료 알림 — "다음 여정 시작" 딥링크 (#1798 P2)
  */
 
 import * as Notifications from 'expo-notifications';
@@ -17,6 +22,18 @@ export const BOARDING_PROMPT_CATEGORY = 'BOARDING_PROMPT';
 export const BOARDING_PROMPT_ACTION_BOARDED = 'BOARDING_PROMPT_BOARDED';
 /** [미탑승] 액션 식별자. */
 export const BOARDING_PROMPT_ACTION_NOT_BOARDED = 'BOARDING_PROMPT_NOT_BOARDED';
+
+/** #1798 P2 — transfer / destination 알람 카테고리. backend `ALARM_CATEGORY`와 동기. */
+export const ALARM_CATEGORY = 'ALARM_CATEGORY';
+/** [확인] 액션 식별자 — 알람 인지. */
+export const ALARM_ACTION_ACKNOWLEDGE = 'ALARM_ACTION_ACKNOWLEDGE';
+/** [trip 종료] 액션 식별자 — 사용자가 알람을 받고 trip을 즉시 종료. */
+export const ALARM_ACTION_END_TRIP = 'ALARM_ACTION_END_TRIP';
+
+/** #1798 P2 — trip 종료 알림 카테고리. backend `TRIP_ENDED_CATEGORY`와 동기. */
+export const TRIP_ENDED_CATEGORY = 'TRIP_ENDED_CATEGORY';
+/** [다음 여정 시작] 액션 식별자 — 앱을 FG로 열어 새 경로 탐색을 시작. */
+export const TRIP_ENDED_ACTION_NEXT_TRIP = 'TRIP_ENDED_ACTION_NEXT_TRIP';
 
 /**
  * BOARDING_PROMPT category 등록. 앱 부팅 시 1회 호출.
@@ -40,6 +57,54 @@ export async function setupBoardingPromptCategory(): Promise<void> {
           // FG로 열지 않음 — 사용자가 푸시만 닫고 silent dismiss POST가 backend로 가게 한다.
           opensAppToForeground: false,
           isDestructive: true,
+        },
+      },
+    ]);
+  } catch {
+    // graceful — Android/예외 시 기본 동작으로 폴백.
+  }
+}
+
+/**
+ * #1798 P2 — ALARM_CATEGORY 등록. transfer / destination 알람에 [확인] / [trip 종료] 버튼 노출.
+ * 앱 부팅 시 1회 호출. 실패는 graceful — 미등록 시 액션 없는 alert로 폴백.
+ */
+export async function setupAlarmCategory(): Promise<void> {
+  try {
+    await Notifications.setNotificationCategoryAsync(ALARM_CATEGORY, [
+      {
+        identifier: ALARM_ACTION_ACKNOWLEDGE,
+        buttonTitle: '확인',
+        options: {
+          opensAppToForeground: false,
+        },
+      },
+      {
+        identifier: ALARM_ACTION_END_TRIP,
+        buttonTitle: 'trip 종료',
+        options: {
+          opensAppToForeground: false,
+          isDestructive: true,
+        },
+      },
+    ]);
+  } catch {
+    // graceful — Android/예외 시 기본 동작으로 폴백.
+  }
+}
+
+/**
+ * #1798 P2 — TRIP_ENDED_CATEGORY 등록. trip 종료 알림에 [다음 여정 시작] 딥링크 버튼 노출.
+ * 앱 부팅 시 1회 호출. 실패는 graceful — 미등록 시 액션 없는 alert로 폴백.
+ */
+export async function setupTripEndedCategory(): Promise<void> {
+  try {
+    await Notifications.setNotificationCategoryAsync(TRIP_ENDED_CATEGORY, [
+      {
+        identifier: TRIP_ENDED_ACTION_NEXT_TRIP,
+        buttonTitle: '다음 여정 시작',
+        options: {
+          opensAppToForeground: true,
         },
       },
     ]);

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -205,7 +205,12 @@
     "transferEarlyTitle": "Transfer alert",
     "arrivalEarlyTitle": "Arrival alert",
     "transferImminentTitle": "Transfer imminent",
-    "arrivalImminentTitle": "Arrival imminent"
+    "arrivalImminentTitle": "Arrival imminent",
+    "actions": {
+      "acknowledge": "OK",
+      "endTrip": "End trip",
+      "nextTrip": "Start next trip"
+    }
   },
   "journey": {
     "transferNote": "Transfer",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -205,7 +205,12 @@
     "transferEarlyTitle": "乗換アラーム",
     "arrivalEarlyTitle": "到着アラーム",
     "transferImminentTitle": "まもなく乗換",
-    "arrivalImminentTitle": "まもなく到着"
+    "arrivalImminentTitle": "まもなく到着",
+    "actions": {
+      "acknowledge": "確認",
+      "endTrip": "trip終了",
+      "nextTrip": "次の旅程を開始"
+    }
   },
   "journey": {
     "transferNote": "乗換",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -205,7 +205,12 @@
     "transferEarlyTitle": "환승 알림",
     "arrivalEarlyTitle": "하차 알림",
     "transferImminentTitle": "환승 임박",
-    "arrivalImminentTitle": "도착 임박"
+    "arrivalImminentTitle": "도착 임박",
+    "actions": {
+      "acknowledge": "확인",
+      "endTrip": "trip 종료",
+      "nextTrip": "다음 여정 시작"
+    }
   },
   "journey": {
     "transferNote": "환승",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -205,7 +205,12 @@
     "transferEarlyTitle": "换乘提醒",
     "arrivalEarlyTitle": "到达提醒",
     "transferImminentTitle": "即将换乘",
-    "arrivalImminentTitle": "即将到达"
+    "arrivalImminentTitle": "即将到达",
+    "actions": {
+      "acknowledge": "确认",
+      "endTrip": "结束旅程",
+      "nextTrip": "开始下一段旅程"
+    }
   },
   "journey": {
     "transferNote": "换乘",


### PR DESCRIPTION
Closes #1798

## 변경 사항

### P2: Category 분리
- `ALARM_CATEGORY` 신규 등록 — transfer/destination 알람에 [확인] / [trip 종료] 액션 버튼 노출
- `TRIP_ENDED_CATEGORY` 신규 등록 — trip 종료 알림에 [다음 여정 시작] 딥링크 버튼 노출
- `app/_layout.tsx` 부팅 시 `setupAlarmCategory()` + `setupTripEndedCategory()` 호출 추가
- backend `sendAlertPush`에 optional `category` 필드 추가 (aps.category wire)

### P3: Subtitle (호선 + 방향)
- backend `sendBoardingPromptPush`에 optional `subtitle` 필드 추가 (aps.alert.subtitle wire)
- `scheduled.ts` boardingPrompt 발사 시 `subtitle="${line}호선 상행/하행방면"` forward (geo.direction 있을 때만, null이면 omit)

### i18n
- `notifications.actions.acknowledge` / `notifications.actions.endTrip` / `notifications.actions.nextTrip` 4언어(ko/en/ja/zh) 추가

## Wire-completion 5단 체크

1. **Orphan 없음** — `npm run lint:orphan` → No orphan exports detected. `setupAlarmCategory` / `setupTripEndedCategory`는 `app/_layout.tsx`에서 즉시 호출.
2. **V/X dashboard** — 실기기 알림 수신 시 iOS 잠금화면/알림센터에서 액션 버튼 시각화. wrangler tail에서 `sendAlertPush category` 필드 확인 가능.
3. **의존 PR** — N/A (self-contained).
4. **측정 plan** — 실기기에서 transfer/destination 알람 수신 후 [확인]/[trip 종료] 버튼 노출 확인. boardingPrompt 수신 후 subtitle "호선 방면" 노출 확인.
5. **Device verify** — 실기기 검증 필요. 시나리오: (a) transfer 알람 발사 → iOS에서 [확인]/[trip 종료] 버튼 표시 확인, (b) boardingPrompt 발사 → subtitle에 "2호선 상행방면" 표시 확인.

## 검증 결과
- frontend: `npm test` 383 suites / 7855 tests ALL PASS (coverage 100%)
- backend: `npm test` 57 files / 2152 tests ALL PASS
- type-check: frontend/backend 모두 신규 에러 0 (expo-haptics TS2307는 pre-existing)
- lint:orphan: No orphan exports detected