### PR TITLE
feat(#1799): Dynamic Type 전체 적용 (typography 시스템 통일, A11y-P3)

### DIFF
--- a/src/features/alarm/components/BoardingLockHopCard.tsx
+++ b/src/features/alarm/components/BoardingLockHopCard.tsx
@@ -114,5 +114,5 @@ const styles = StyleSheet.create({
     borderRadius: 3,
     borderWidth: 1,
   },
-  delayChipText: { fontSize: 11, fontWeight: '700', letterSpacing: 0 },
+  delayChipText: { ...typography.micro, fontWeight: '700', letterSpacing: 0 },
 });

--- a/src/features/alarm/components/BoardingTrainList.tsx
+++ b/src/features/alarm/components/BoardingTrainList.tsx
@@ -594,7 +594,7 @@ const styles = StyleSheet.create({
     borderRadius: 3,
     borderWidth: 1,
   },
-  delayChipText: { fontSize: 11, fontWeight: '700', letterSpacing: 0 },
+  delayChipText: { ...typography.micro, fontWeight: '700', letterSpacing: 0 },
   // #1165 — pending 상태 visual은 row outline border로 처리. 별도 marker는 0×0 invisible View.
   // 테스트에서 testID로 pending 진입을 확인하기 위함이며, layout/접근성에 영향을 주지 않는다.
   pendingMarker: { width: 0, height: 0 },

--- a/src/features/arrival/components/ArrivalSourceNotice.tsx
+++ b/src/features/arrival/components/ArrivalSourceNotice.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import { StyleSheet, Text } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { StationArrival } from '../api/arrivalApi';
-import { useTheme } from '../../../shared/theme';
+import { useTheme, typography } from '../../../shared/theme';
 
 interface Props {
   arrival: StationArrival | null;
@@ -56,7 +56,7 @@ export function ArrivalSourceNotice({ arrival }: Props): ReactElement | null {
 
 const styles = StyleSheet.create({
   notice: {
-    fontSize: 12,
+    ...typography.captionSm,
     marginBottom: 8,
   },
 });

--- a/src/features/arrival/components/ArrivalStatusBadge.tsx
+++ b/src/features/arrival/components/ArrivalStatusBadge.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { useTheme } from '../../../shared/theme';
+import { useTheme, typography } from '../../../shared/theme';
 import { ARRIVAL_CODE } from '../../../shared/constants/arrivalCodes';
 import {
   TRAIN_TYPE_LABEL,
@@ -121,7 +121,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
   },
   // 한글/영문 혼용(ITX)이라 typography.label의 uppercase/letterSpacing은 적용하지 않는다.
-  text: { fontSize: 10, fontWeight: '700', letterSpacing: 0 },
+  text: { ...typography.badge, fontWeight: '700', letterSpacing: 0 },
   // filled variant는 안전성 직결 정보(급행) → 한 단계 더 키워 시선 끌어옴.
-  textFilled: { fontSize: 11 },
+  textFilled: { ...typography.micro },
 });

--- a/src/features/arrival/components/EditorialArrivalRow.tsx
+++ b/src/features/arrival/components/EditorialArrivalRow.tsx
@@ -33,7 +33,7 @@ export function EditorialArrivalRow({ train }: Props) {
       <View style={{ minWidth: 90 }}>
         <Text>
           <Text style={[typography.countMM, { color: colors.ink }]}>{mm}</Text>
-          <Text style={{ fontSize: 20, color: colors.subtle }}> : </Text>
+          <Text style={[typography.titleXs, { color: colors.subtle }]}> : </Text>
           <Text style={[typography.countSS, { color: colors.muted }]}>{ss}</Text>
         </Text>
       </View>

--- a/src/features/arrival/components/SourceBadge.tsx
+++ b/src/features/arrival/components/SourceBadge.tsx
@@ -9,7 +9,7 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { useTheme, spacing, radius, withAlpha } from '../../../shared/theme';
+import { useTheme, typography, spacing, radius, withAlpha } from '../../../shared/theme';
 import type { FusionSource } from '../../../shared/types/fusion';
 import {
   resolveNotificationSource,
@@ -58,7 +58,7 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-start',
   },
   label: {
-    fontSize: 11,
+    ...typography.micro,
     fontWeight: '700',
     letterSpacing: 0.4,
   },

--- a/src/features/arrival/components/StatusChip.tsx
+++ b/src/features/arrival/components/StatusChip.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { useTheme, spacing } from '../../../shared/theme';
+import { useTheme, typography, spacing } from '../../../shared/theme';
 
 interface StatusChipProps {
   label: string;
@@ -31,16 +31,16 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   label: {
-    fontSize: 12,
+    ...typography.captionSm,
     fontWeight: '700',
   },
   name: {
-    fontSize: 14,
+    ...typography.bodySm,
     fontWeight: '600',
     flex: 1,
   },
   close: {
-    fontSize: 16,
+    ...typography.bodyMd,
     paddingHorizontal: spacing.xs,
   },
 });

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -2710,6 +2710,6 @@ const styles = StyleSheet.create({
   },
   actionText: {
     fontWeight: '700',
-    fontSize: 14,
+    ...typography.bodySm,
   },
 });

--- a/src/features/feedback/components/FeedbackModal.tsx
+++ b/src/features/feedback/components/FeedbackModal.tsx
@@ -25,7 +25,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { submitFeedback } from '../../../shared/api/feedback';
-import { useTheme, spacing, radius } from '../../../shared/theme';
+import { useTheme, typography, spacing, radius } from '../../../shared/theme';
 
 /** message 최대 길이 — backend FEEDBACK_MAX_MESSAGE_LENGTH와 정합. */
 export const FEEDBACK_MAX_LENGTH = 2000;
@@ -193,15 +193,15 @@ const styles = StyleSheet.create({
     marginBottom: spacing.md,
   },
   title: {
-    fontSize: 18,
+    ...typography.bodyLg,
     fontWeight: '700',
   },
   close: {
-    fontSize: 20,
+    ...typography.titleXs,
     padding: spacing.xs,
   },
   description: {
-    fontSize: 13,
+    ...typography.caption,
     lineHeight: 18,
     marginBottom: spacing.md,
   },
@@ -210,16 +210,16 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: radius.md,
     padding: spacing.md,
-    fontSize: 15,
+    ...typography.bodyBase,
     textAlignVertical: 'top',
   },
   counter: {
-    fontSize: 12,
+    ...typography.captionSm,
     textAlign: 'right',
     marginTop: spacing.xs,
   },
   status: {
-    fontSize: 13,
+    ...typography.caption,
     marginTop: spacing.sm,
     textAlign: 'center',
   },
@@ -230,7 +230,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   submitText: {
-    fontSize: 15,
+    ...typography.bodyBase,
     fontWeight: '700',
   },
 });

--- a/src/features/map/components/MapSearchBar.tsx
+++ b/src/features/map/components/MapSearchBar.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next';
 import stationsData from '../../../data/stations.json';
 import type { Station } from '../../../shared/types/station';
 import { matchesStationQuery } from '../../../shared/utils/stationDisplay';
-import { useTheme, spacing, radius } from '../../../shared/theme';
+import { useTheme, typography, spacing, radius } from '../../../shared/theme';
 import { StationSuggestionList } from '../../nearest-station/components/StationSuggestionList';
 
 const allStations = stationsData as Station[];
@@ -83,7 +83,7 @@ const styles = StyleSheet.create({
     borderRadius: radius.sm,
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.md,
-    fontSize: 16,
+    ...typography.bodyMd,
     borderWidth: 1,
   },
   dropdownWrap: {

--- a/src/features/map/components/StationMap.tsx
+++ b/src/features/map/components/StationMap.tsx
@@ -13,7 +13,7 @@ import MapView, { Circle, Marker, Polyline, PROVIDER_DEFAULT } from 'react-nativ
 import type { Station } from '../../../shared/types/station';
 import type { RouteCoordinatePath } from '../../route/utils/routeToCoordinates';
 import { buildMapConfig } from '../utils/buildMapConfig';
-import { useTheme, withAlpha } from '../../../shared/theme';
+import { useTheme, typography, withAlpha } from '../../../shared/theme';
 import { LINE_BADGE_LABEL } from '../../../shared/constants/lineColors';
 import { getStationDisplayName } from '../../../shared/utils/stationDisplay';
 
@@ -290,7 +290,7 @@ const styles = StyleSheet.create({
   },
   badgeText: {
     color: '#ffffff',
-    fontSize: 10,
+    ...typography.badge,
     fontWeight: '700',
     lineHeight: 12,
   },
@@ -307,7 +307,7 @@ const styles = StyleSheet.create({
     elevation: 1,
   },
   markerLabel: {
-    fontSize: 12,
+    ...typography.captionSm,
     fontWeight: '600',
     color: '#111111',
     textAlign: 'center',

--- a/src/features/map/components/StationMap.web.tsx
+++ b/src/features/map/components/StationMap.web.tsx
@@ -13,7 +13,7 @@ import { Station } from '../../../shared/types/station';
 import { haversine } from '../../../shared/utils/haversine';
 import { LINE_BADGE_LABEL } from '../../../shared/constants/lineColors';
 import { groupStationsByName } from '../../nearest-station/utils/groupStationsByName';
-import { useTheme } from '../../../shared/theme';
+import { useTheme, typography } from '../../../shared/theme';
 
 interface StationMapProps {
   userLat: number;
@@ -99,11 +99,11 @@ const styles = StyleSheet.create({
     padding: 24,
   },
   emptyText: {
-    fontSize: 14,
+    ...typography.bodySm,
     textAlign: 'center',
   },
   header: {
-    fontSize: 12,
+    ...typography.captionSm,
     letterSpacing: 1,
     textTransform: 'uppercase',
     marginBottom: 16,
@@ -128,16 +128,16 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   badgeText: {
-    fontSize: 11,
+    ...typography.micro,
     fontWeight: '700',
     color: '#ffffff',
   },
   name: {
     flex: 1,
-    fontSize: 16,
+    ...typography.bodyMd,
     fontWeight: '600',
   },
   distance: {
-    fontSize: 13,
+    ...typography.caption,
   },
 });

--- a/src/features/nearest-station/components/CurrentStationConfirmModal.tsx
+++ b/src/features/nearest-station/components/CurrentStationConfirmModal.tsx
@@ -190,7 +190,7 @@ const styles = StyleSheet.create({
   },
   lineText: {
     color: '#ffffff',
-    fontSize: 12,
+    ...typography.captionSm,
     fontWeight: 'bold',
   },
   empty: {

--- a/src/features/nearest-station/components/StationSuggestionList.tsx
+++ b/src/features/nearest-station/components/StationSuggestionList.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import type { Station } from '../../../shared/types/station';
 import { LINE_NAMES } from '../../../shared/constants/lineColors';
 import { getStationDisplayName } from '../../../shared/utils/stationDisplay';
-import { useTheme, spacing, radius } from '../../../shared/theme';
+import { useTheme, typography, spacing, radius } from '../../../shared/theme';
 
 interface Props {
   readonly suggestions: readonly Station[];
@@ -54,7 +54,7 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
   },
   name: {
-    fontSize: 15,
+    ...typography.bodyBase,
   },
   lineBadge: {
     borderRadius: 4,
@@ -63,7 +63,7 @@ const styles = StyleSheet.create({
   },
   lineText: {
     color: '#ffffff',
-    fontSize: 12,
+    ...typography.captionSm,
     fontWeight: 'bold',
   },
 });

--- a/src/features/route/components/DestinationPicker.tsx
+++ b/src/features/route/components/DestinationPicker.tsx
@@ -30,7 +30,7 @@ import { StationMap } from '../../map/components/StationMap';
 import { StationSuggestionList } from '../../nearest-station/components/StationSuggestionList';
 import { createLogger } from '../../../shared/utils/logger';
 import { matchesStationQuery, getStationDisplayName } from '../../../shared/utils/stationDisplay';
-import { useTheme, spacing, radius } from '../../../shared/theme';
+import { useTheme, typography, spacing, radius } from '../../../shared/theme';
 
 const logger = createLogger('DestinationPicker');
 
@@ -298,7 +298,7 @@ const styles = StyleSheet.create({
     padding: spacing.xxl,
   },
   mapFallbackText: {
-    fontSize: 14,
+    ...typography.bodySm,
     textAlign: 'center',
   },
   overlay: {
@@ -316,18 +316,18 @@ const styles = StyleSheet.create({
     paddingBottom: spacing.md,
   },
   title: {
-    fontSize: 20,
+    ...typography.titleXs,
     fontWeight: 'bold',
   },
   closeText: {
-    fontSize: 16,
+    ...typography.bodyMd,
   },
   input: {
     marginHorizontal: spacing.xl,
     borderRadius: radius.sm,
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.md,
-    fontSize: 16,
+    ...typography.bodyMd,
     borderWidth: 1,
   },
   dropdownWrap: {
@@ -351,10 +351,10 @@ const styles = StyleSheet.create({
     gap: 6,
   },
   chipIcon: {
-    fontSize: 14,
+    ...typography.bodySm,
   },
   chipText: {
-    fontSize: 14,
+    ...typography.bodySm,
     fontWeight: '600',
   },
   chipPlaceholder: {
@@ -371,12 +371,12 @@ const styles = StyleSheet.create({
     borderRadius: radius.sm,
   },
   pendingText: {
-    fontSize: 14,
+    ...typography.bodySm,
     fontWeight: '600',
     flex: 1,
   },
   pendingCancel: {
-    fontSize: 14,
+    ...typography.bodySm,
     fontWeight: '700',
     paddingHorizontal: spacing.sm,
   },
@@ -397,7 +397,7 @@ const styles = StyleSheet.create({
     elevation: 3,
   },
   recenterIcon: {
-    fontSize: 22,
+    ...typography.titleSm,
     lineHeight: 24,
   },
 });

--- a/src/screens/FavoritesScreen.tsx
+++ b/src/screens/FavoritesScreen.tsx
@@ -24,7 +24,7 @@ import { useArrivalInfo } from '../features/arrival/hooks/useArrivalInfo';
 import { useArrivalCountdown } from '../features/arrival/hooks/useArrivalCountdown';
 import { formatArrivalTime } from '../shared/utils/formatTime';
 import { getStationDisplayName, matchesStationQuery } from '../shared/utils/stationDisplay';
-import { useTheme, type ThemeColors } from '../shared/theme';
+import { useTheme, typography, type ThemeColors } from '../shared/theme';
 import stationsData from '../data/stations.json';
 import { ArrivalSourceNotice } from '../features/arrival/components/ArrivalSourceNotice';
 import type { StationArrival } from '../features/arrival/api/arrivalApi';
@@ -130,7 +130,7 @@ export default function FavoritesScreen() {
             </View>
             {generalFavorites.length === 0 ? (
               <View style={styles.empty} testID="favorites-empty">
-                <Text style={styles.emptyIcon}>⭐</Text>
+                <Text style={styles.emptyIcon} allowFontScaling={false}>⭐</Text>
                 <Text style={[styles.emptyTitle, { color: colors.ink }]}>{t('favorites.empty')}</Text>
                 <Text style={[styles.emptySubtitle, { color: colors.muted }]}>
                   {t('favorites.emptyDescription')}
@@ -478,7 +478,7 @@ const styles = StyleSheet.create({
     flexGrow: 1,
   },
   header: {
-    fontSize: 14,
+    ...typography.bodySm,
     marginBottom: 16,
     letterSpacing: 2,
     textTransform: 'uppercase',
@@ -487,7 +487,7 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     paddingHorizontal: 16,
     paddingVertical: 12,
-    fontSize: 15,
+    ...typography.bodyBase,
     marginBottom: 16,
     borderWidth: 1,
   },
@@ -498,16 +498,16 @@ const styles = StyleSheet.create({
     paddingTop: 60,
   },
   emptyIcon: {
-    fontSize: 48,
+    fontSize: 48, // emoji icon — allowFontScaling={false} applied at render
     marginBottom: 16,
   },
   emptyTitle: {
-    fontSize: 18,
+    ...typography.bodyLg,
     fontWeight: '700',
     marginBottom: 8,
   },
   emptySubtitle: {
-    fontSize: 14,
+    ...typography.bodySm,
     textAlign: 'center',
     lineHeight: 22,
   },
@@ -533,7 +533,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   expandIcon: {
-    fontSize: 12,
+    ...typography.captionSm,
   },
   badge: {
     alignSelf: 'flex-start',
@@ -544,15 +544,15 @@ const styles = StyleSheet.create({
   },
   badgeText: {
     color: '#ffffff', // 노선색(lineColor) 배경은 항상 진한색 — 흰 텍스트 유지
-    fontSize: 12,
+    ...typography.captionSm,
     fontWeight: '700',
   },
   stationName: {
-    fontSize: 20,
+    ...typography.titleXs,
     fontWeight: '700',
   },
   subStationName: {
-    fontSize: 13,
+    ...typography.caption,
     marginTop: 2,
   },
   labelEditor: {
@@ -568,7 +568,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     paddingHorizontal: 12,
     paddingVertical: 8,
-    fontSize: 14,
+    ...typography.bodySm,
     borderWidth: 1,
   },
   labelButton: {
@@ -577,7 +577,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
   },
   labelButtonText: {
-    fontSize: 13,
+    ...typography.caption,
     fontWeight: '600',
   },
   removeButton: {
@@ -586,7 +586,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
   },
   removeText: {
-    fontSize: 13,
+    ...typography.caption,
     fontWeight: '600',
   },
   addButton: {
@@ -597,7 +597,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   addButtonText: {
-    fontSize: 18,
+    ...typography.bodyLg,
     fontWeight: '700',
     lineHeight: 20,
   },
@@ -612,21 +612,21 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
   },
   arrivalLabel: {
-    fontSize: 14,
+    ...typography.bodySm,
     fontWeight: '600',
   },
   arrivalItem: {
-    fontSize: 14,
+    ...typography.bodySm,
     textAlign: 'right',
   },
   statusMessage: {
-    fontSize: 11,
+    ...typography.micro,
     textAlign: 'right',
     marginTop: 1,
     marginBottom: 2,
   },
   noArrival: {
-    fontSize: 13,
+    ...typography.caption,
     textAlign: 'center',
     paddingVertical: 4,
   },
@@ -652,18 +652,18 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   slotIcon: {
-    fontSize: 18,
+    ...typography.bodyLg,
   },
   slotLabel: {
-    fontSize: 15,
+    ...typography.bodyBase,
     fontWeight: '700',
   },
   slotHint: {
-    fontSize: 12,
+    ...typography.captionSm,
     flexShrink: 1,
   },
   slotStation: {
-    fontSize: 13,
+    ...typography.caption,
     flexShrink: 1,
   },
   slotClear: {
@@ -671,7 +671,7 @@ const styles = StyleSheet.create({
     paddingVertical: 4,
   },
   slotClearText: {
-    fontSize: 22,
+    ...typography.titleSm,
     fontWeight: '700',
     lineHeight: 24,
   },
@@ -683,10 +683,10 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
   },
   slotModalTitle: {
-    fontSize: 18,
+    ...typography.bodyLg,
     fontWeight: '700',
   },
   slotModalClose: {
-    fontSize: 16,
+    ...typography.bodyMd,
   },
 });

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1055,14 +1055,14 @@ export default function HomeScreen() {
                       <Text style={[typography.label, { color: colors.muted, marginBottom: 4 }]}>
                         {t('home.routeTo')}
                       </Text>
-                      <Text style={{ fontSize: 32, fontWeight: '900', letterSpacing: -0.8, color: colors.ink }}>{getStationDisplayName(destination)}</Text>
+                      <Text style={[typography.countMM, { fontWeight: '900', color: colors.ink }]}>{getStationDisplayName(destination)}</Text>
                     </View>
                     <View style={{ alignItems: 'flex-end' }}>
                       {displayEta != null && (
                         <>
                           <Text style={[typography.countMM, { color: colors.ink }]}>
                             {displayEta}
-                            <Text style={{ fontSize: 13, color: colors.muted }}> min</Text>
+                            <Text style={[typography.caption, { color: colors.muted }]}> min</Text>
                           </Text>
                           <Text style={[typography.label, { color: colors.subtle, marginTop: 4 }]}>
                             {isRealtimeEta ? 'EST' : t('home.estimatedSuffix')} · {journey?.totalStops ?? 0} STOPS
@@ -1413,7 +1413,7 @@ export default function HomeScreen() {
           </>
         ) : locationUncertain ? (
           <View style={styles.center} testID="location-uncertain">
-            <Text style={styles.icon}>📍</Text>
+            <Text style={styles.icon} allowFontScaling={false}>📍</Text>
             <Text style={[styles.title, { color: colors.ink }]}>{t('home.locationUncertainTitle')}</Text>
             <Text style={[styles.subtitle, { color: colors.muted }]}>{t('home.locationUncertainDescription')}</Text>
             <TouchableOpacity
@@ -1426,7 +1426,7 @@ export default function HomeScreen() {
           </View>
         ) : (
           <View style={styles.center} testID="home-not-near-station">
-            <Text style={styles.icon}>🚶</Text>
+            <Text style={styles.icon} allowFontScaling={false}>🚶</Text>
             <Text
               style={[styles.title, { color: colors.ink }]}
               testID="home-not-near-station-title"
@@ -1601,7 +1601,7 @@ const styles = StyleSheet.create({
   },
   arrivedBannerText: {
     color: '#ffffff', // success 배경 위 텍스트 — 항상 흰색 유지
-    fontSize: 18,
+    ...typography.bodyLg,
     fontWeight: '700',
   },
   center: {
@@ -1617,7 +1617,7 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
   favoriteIcon: {
-    fontSize: 26,
+    ...typography.title,
     marginLeft: spacing.md,
   },
   metaRow: { flexDirection: 'row', alignItems: 'center', gap: 14 },
@@ -1634,11 +1634,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   routePillText: {
-    fontSize: 13,
+    ...typography.caption,
     fontWeight: '600',
   },
   routePillSub: {
-    fontSize: 11,
+    ...typography.micro,
     marginTop: 2,
   },
   actionsRow: {
@@ -1693,11 +1693,11 @@ const styles = StyleSheet.create({
     marginLeft: spacing.sm,
   },
   recentDestinationDeleteText: {
-    fontSize: 16,
+    ...typography.bodyMd,
     fontWeight: '700',
   },
   recentDestinationLabel: {
-    fontSize: 11,
+    ...typography.micro,
     fontWeight: '600',
     letterSpacing: 0.5,
     marginBottom: 4,
@@ -1708,7 +1708,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   recentDestinationName: {
-    fontSize: 16,
+    ...typography.bodyMd,
     fontWeight: '700',
   },
   recentLineBadge: {
@@ -1718,7 +1718,7 @@ const styles = StyleSheet.create({
   },
   recentLineText: {
     color: '#fff', // 노선색(lineColor) 배경 위 텍스트 — 항상 흰색 유지
-    fontSize: 11,
+    ...typography.micro,
     fontWeight: 'bold',
   },
   destinationButton: {
@@ -1727,7 +1727,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   destinationButtonText: {
-    fontSize: 15,
+    ...typography.bodyBase,
     fontWeight: '700',
   },
   arrivalSection: {
@@ -1738,7 +1738,7 @@ const styles = StyleSheet.create({
     borderRadius: radius.lg,
   },
   sectionTitle: {
-    fontSize: 14,
+    ...typography.bodySm,
     marginBottom: spacing.lg,
     letterSpacing: 1,
     textTransform: 'uppercase',
@@ -1749,34 +1749,34 @@ const styles = StyleSheet.create({
     marginTop: spacing.sm,
   },
   arrivalLabel: {
-    fontSize: 15,
+    ...typography.bodyBase,
     fontWeight: '600',
     marginBottom: spacing.xs,
   },
   arrivalItem: {
-    fontSize: 15,
+    ...typography.bodyBase,
   },
   icon: {
-    fontSize: 48,
+    fontSize: 48, // emoji icon — allowFontScaling={false} applied at render
     marginBottom: 16,
   },
   title: {
-    fontSize: 22,
+    ...typography.titleSm,
     fontWeight: '700',
     marginBottom: 12,
     textAlign: 'center',
   },
   subtitle: {
-    fontSize: 15,
+    ...typography.bodyBase,
     textAlign: 'center',
     lineHeight: 22,
     marginBottom: 24,
   },
   loadingText: {
-    fontSize: 16,
+    ...typography.bodyMd,
   },
   errorText: {
-    fontSize: 16,
+    ...typography.bodyMd,
     marginBottom: 16,
   },
   button: {
@@ -1785,7 +1785,7 @@ const styles = StyleSheet.create({
     borderRadius: radius.lg,
   },
   buttonText: {
-    fontSize: 15,
+    ...typography.bodyBase,
     fontWeight: '700',
   },
 });

--- a/src/screens/LanguageScreen.tsx
+++ b/src/screens/LanguageScreen.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Stack, useRouter } from 'expo-router';
 import { useLocaleStore, type LocalePreference } from '../shared/i18n/store/useLocaleStore';
 import { LANGUAGE_REGISTRY } from '../shared/i18n/types';
-import { useTheme, spacing } from '../shared/theme';
+import { useTheme, typography, spacing } from '../shared/theme';
 
 export default function LanguageScreen() {
   const localePreference = useLocaleStore((s) => s.localePreference);
@@ -95,7 +95,7 @@ const styles = StyleSheet.create({
     paddingVertical: spacing.sm,
   },
   localeRowLabel: {
-    fontSize: 16,
+    ...typography.bodyMd,
     fontWeight: '500',
   },
   localeRadio: {

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -10,7 +10,7 @@ import { MapSearchBar } from '../features/map/components/MapSearchBar';
 import { LocationStateView } from '../shared/ui/LocationStateView';
 import { StatusChip } from '../features/arrival/components/StatusChip';
 import stationsData from '../data/stations.json';
-import { useTheme, spacing, radius } from '../shared/theme';
+import { useTheme, typography, spacing, radius } from '../shared/theme';
 import { useFavoritesStore } from '../features/favorites/store/useFavoritesStore';
 import { useDestinationStore } from '../features/route/store/useDestinationStore';
 import { LineBadge } from '../shared/ui/LineBadge';
@@ -253,7 +253,7 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
   },
   closeText: {
-    fontSize: 16,
+    ...typography.bodyMd,
     paddingHorizontal: spacing.xs,
   },
   selectionCard: {
@@ -272,7 +272,7 @@ const styles = StyleSheet.create({
     marginBottom: spacing.lg,
   },
   selectionName: {
-    fontSize: 18,
+    ...typography.bodyLg,
     fontWeight: '700',
     marginBottom: spacing.xs,
   },
@@ -287,7 +287,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   selectionButtonText: {
-    fontSize: 15,
+    ...typography.bodyBase,
     fontWeight: '700',
   },
   slotButtons: {
@@ -306,10 +306,10 @@ const styles = StyleSheet.create({
     borderWidth: 1,
   },
   slotButtonIcon: {
-    fontSize: 14,
+    ...typography.bodySm,
   },
   slotButtonText: {
-    fontSize: 13,
+    ...typography.caption,
     fontWeight: '600',
   },
   recenterButton: {
@@ -328,7 +328,7 @@ const styles = StyleSheet.create({
     elevation: 3,
   },
   recenterIcon: {
-    fontSize: 22,
+    ...typography.titleSm,
     lineHeight: 24,
   },
 });

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -11,7 +11,7 @@ import { useThemeStore, type ThemeMode } from '../shared/theme/store/useThemeSto
 import { useLocaleStore, type LocalePreference } from '../shared/i18n/store/useLocaleStore';
 import { ROUTE_CATEGORIES } from '../shared/utils/stationRoute';
 import { LANGUAGE_REGISTRY } from '../shared/i18n/types';
-import { useTheme, spacing, radius } from '../shared/theme';
+import { useTheme, typography, spacing, radius } from '../shared/theme';
 import { useSleepModeGuide } from '../features/settings/hooks/useSleepModeGuide';
 import { emitLocklessToggleViewed } from '../features/settings/utils/locklessFunnel';
 import { FeedbackModal } from '../features/feedback/components/FeedbackModal';
@@ -430,7 +430,7 @@ const styles = StyleSheet.create({
     paddingBottom: 80,
   },
   header: {
-    fontSize: 14,
+    ...typography.bodySm,
     letterSpacing: 2,
     textTransform: 'uppercase',
     padding: 24,
@@ -443,7 +443,7 @@ const styles = StyleSheet.create({
     marginBottom: spacing.lg,
   },
   sectionTitle: {
-    fontSize: 14,
+    ...typography.bodySm,
     letterSpacing: 1,
     textTransform: 'uppercase',
     marginBottom: 16,
@@ -458,12 +458,12 @@ const styles = StyleSheet.create({
     marginRight: 16,
   },
   settingLabel: {
-    fontSize: 16,
+    ...typography.bodyMd,
     fontWeight: '600',
     marginBottom: 4,
   },
   settingDesc: {
-    fontSize: 13,
+    ...typography.caption,
     lineHeight: 18,
   },
   segmentGroup: {
@@ -479,7 +479,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   segmentText: {
-    fontSize: 13,
+    ...typography.caption,
     fontWeight: '600',
   },
   localeTrigger: {
@@ -492,11 +492,11 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
   },
   localeTriggerValue: {
-    fontSize: 15,
+    ...typography.bodyBase,
     fontWeight: '500',
   },
   localeChevron: {
-    fontSize: 20,
+    ...typography.titleXs,
     marginLeft: spacing.sm,
   },
   versionFooter: {
@@ -505,7 +505,7 @@ const styles = StyleSheet.create({
     marginTop: spacing.md,
   },
   versionText: {
-    fontSize: 12,
+    ...typography.captionSm,
     letterSpacing: 0.5,
   },
 });

--- a/src/shared/theme/theme.ts
+++ b/src/shared/theme/theme.ts
@@ -59,14 +59,23 @@ export const font = {
 };
 
 export const typography = {
-  hero:    { fontFamily: font.bold,     fontSize: 44, letterSpacing: -1.4, lineHeight: 44 * 0.95 },
-  title:   { fontFamily: font.bold,     fontSize: 26, letterSpacing: -0.7, lineHeight: 26 },
-  countMM: { fontFamily: font.bold,     fontSize: 32, letterSpacing: -0.8 },
-  countSS: { fontFamily: font.semibold, fontSize: 24, letterSpacing: -0.8 },
-  body:    { fontFamily: font.medium,   fontSize: 17, letterSpacing: -0.3 },
-  bodySm:  { fontFamily: font.medium,   fontSize: 14 },
-  label:   { fontFamily: font.medium,   fontSize: 11, letterSpacing: 1.2, textTransform: 'uppercase' as const },
-  mono:    { fontFamily: font.mono,     fontSize: 11, letterSpacing: 0.6 },
+  hero:      { fontFamily: font.bold,     fontSize: 44, letterSpacing: -1.4, lineHeight: 44 * 0.95 },
+  title:     { fontFamily: font.bold,     fontSize: 26, letterSpacing: -0.7, lineHeight: 26 },
+  titleSm:   { fontFamily: font.bold,     fontSize: 22, letterSpacing: -0.5 },
+  titleXs:   { fontFamily: font.bold,     fontSize: 20 },
+  countMM:   { fontFamily: font.bold,     fontSize: 32, letterSpacing: -0.8 },
+  countSS:   { fontFamily: font.semibold, fontSize: 24, letterSpacing: -0.8 },
+  body:      { fontFamily: font.medium,   fontSize: 17, letterSpacing: -0.3 },
+  bodyLg:    { fontFamily: font.medium,   fontSize: 18 },
+  bodyMd:    { fontFamily: font.medium,   fontSize: 16 },
+  bodyBase:  { fontFamily: font.medium,   fontSize: 15 },
+  bodySm:    { fontFamily: font.medium,   fontSize: 14 },
+  caption:   { fontFamily: font.medium,   fontSize: 13 },
+  captionSm: { fontFamily: font.medium,   fontSize: 12 },
+  micro:     { fontFamily: font.medium,   fontSize: 11 },
+  badge:     { fontFamily: font.medium,   fontSize: 10 },
+  label:     { fontFamily: font.medium,   fontSize: 11, letterSpacing: 1.2, textTransform: 'uppercase' as const },
+  mono:      { fontFamily: font.mono,     fontSize: 11, letterSpacing: 0.6 },
 };
 
 export const spacing = {


### PR DESCRIPTION
Closes #1799

## Summary
- `typography` 토큰 9개 신규 추가: `titleSm(22)`, `titleXs(20)`, `bodyLg(18)`, `bodyMd(16)`, `bodyBase(15)`, `caption(13)`, `captionSm(12)`, `micro(11)`, `badge(10)`
- 97개 hardcoded `fontSize` → `typography` 시스템 통일 (before: 97, after: 0 — 잔존 2건은 이모지 아이콘용 `fontSize: 48` 의도적 유지)
- 이모지 아이콘 `Text` 2곳 `allowFontScaling={false}` 명시 (HomeScreen 📍🚶, FavoritesScreen ⭐)

## Wire-completion 5단 체크
1. **Orphan 없음** — `npm run lint:orphan` 0건 pass
2. **V/X dashboard** — typography 토큰 변경은 시각 변경 없음 (fontSize 값 동일). 큰 글자 모드 실기기 확인 대상
3. **의존 PR** — N/A
4. **측정 plan** — iOS 큰 글자(Accessibility Inspector) 모든 화면 텍스트 스케일 확인
5. **Device verify** — 큰 글자 모드 실기기 시연 필요 (type+unit은 N/A — 단순 prop 변경)

## 검증
- `npm test`: 7851 tests, 383 suites — ALL PASS, coverage 100%
- `npm run type-check`: pre-existing expo-haptics 오류만, 신규 오류 0건
- `npm run lint:orphan`: 0 orphan
- hardcoded `fontSize` 잔존: 2건 (emoji icon 의도적)