### PR TITLE
fix(critical): onboarding redirect crash on launch

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { DevSettings } from 'react-native';
 import * as Notifications from 'expo-notifications';
-import { Stack, useRouter, useSegments } from 'expo-router';
+import { Redirect, Stack, useSegments } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import * as SplashScreen from 'expo-splash-screen';
 import { I18nextProvider, useTranslation } from 'react-i18next';
@@ -114,11 +114,8 @@ function RootContent() {
   const hasCompletedOnboarding = useOnboardingStore((s) => s.hasCompletedOnboarding);
   const loadOnboardingState = useOnboardingStore((s) => s.loadOnboardingState);
   const segments = useSegments();
-  const router = useRouter();
 
-  // #1780 — 첫 실행 온보딩 redirect.
-  // storage hydrate 완료 후 미완료 사용자는 onboarding으로 보낸다.
-  // 이미 onboarding 화면에 있으면 재진입하지 않는다.
+  // #1780 — 첫 실행 온보딩: storage에서 완료 여부 로드.
   useEffect(() => {
     let cancelled = false;
     loadOnboardingState().then(() => {
@@ -126,13 +123,6 @@ function RootContent() {
     });
     return () => { cancelled = true; };
   }, []);
-
-  useEffect(() => {
-    const isOnOnboarding = segments[0] === 'onboarding';
-    if (!hasCompletedOnboarding && !isOnOnboarding) {
-      router.replace('/onboarding');
-    }
-  }, [hasCompletedOnboarding, segments]);
 
   // #819 — "탑승했냐?" 응답 listener. boarding-prompt 카테고리 푸시의 [탑승]/[미탑승] 또는 탭을 받아
   // arvlCd 우선순위로 trainCode 자동 lock 또는 5분 silence POST. 미bound trip(destinationId=null)에서도
@@ -176,6 +166,14 @@ function RootContent() {
   useEffect(() => {
     refreshNotificationChannels().catch((e) => layoutLogger.error('알림 채널 갱신 실패:', e));
   }, [i18nInstance.language]);
+
+  // #1780 — 첫 실행 온보딩 redirect.
+  // router.replace(useEffect) 대신 Redirect 컴포넌트로 render path 안에서 처리.
+  // Stack 마운트 전 navigate 호출로 인한 "Attempted to navigate before mounting the Root Layout" crash 방지.
+  const isOnOnboarding = segments[0] === 'onboarding';
+  if (!hasCompletedOnboarding && !isOnOnboarding) {
+    return <Redirect href="/onboarding" />;
+  }
 
   return (
     <>


### PR DESCRIPTION
## 문제 (실기기 스크린샷 evidence)

```
Render Error
Attempted to navigate before mounting the Root Layout component.
Ensure the Root Layout component is rendering a Slot, or other navigator on the first render.

위치: app/_layout.tsx:133:21
> 133 |   router.replace('/onboarding');
```

PR #1787 (#1780 onboarding) 머지로 도입된 `useEffect` + `router.replace` 패턴이 expo-router `Stack`(Slot) 마운트 전에 navigate를 호출 → 앱 launch crash.

## 원인

`useEffect`는 render 완료 후 실행되지만, Root Layout의 navigator(Stack)가 아직 실제로 마운트되지 않은 시점에 `router.replace`가 호출됨. expo-router는 Root Layout 첫 render에서 navigator가 반드시 render돼야 한다.

## Fix — 옵션 A: `<Redirect>` 컴포넌트 (expo-router 권장 패턴)

`useEffect` + `router.replace` 제거 → render path 안에서 `<Redirect href="/onboarding" />` 조건부 렌더.

```tsx
// Before (crash)
useEffect(() => {
  if (!hasCompletedOnboarding && !isOnOnboarding) {
    router.replace('/onboarding'); // Stack 마운트 전 호출
  }
}, [hasCompletedOnboarding, segments]);

// After (fix)
const isOnOnboarding = segments[0] === 'onboarding';
if (!hasCompletedOnboarding && !isOnOnboarding) {
  return <Redirect href="/onboarding" />;
}
return <Stack screenOptions={{ headerShown: false }} />;
```

## 변경 파일

- `app/_layout.tsx`: 10 insertions, 12 deletions (순 -2줄)
  - `useRouter` import 제거 → `Redirect` 추가
  - redirect useEffect 제거
  - render path에 `Redirect` 컴포넌트 조건부 렌더 추가

## 3 시나리오 커버

| 시나리오 | 동작 |
|----------|------|
| 첫 실행 (`hasCompletedOnboarding=false`) | `<Redirect href="/onboarding" />` 렌더 → onboarding 진입 |
| 재실행 (`hasCompletedOnboarding=true`) | Redirect 건너뜀 → Stack 정상 렌더 |
| Onboarding 중 (`segments[0]==='onboarding'`) | `isOnOnboarding=true` → redirect loop 방지 |

## Wire-completion 5단 체크

1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard** — crash fix. 관측: 앱 launch 성공 여부 (실기기)
3. **의존 PR** — N/A
4. **측정 plan** — 실기기 첫 실행 시나리오 수동 검증. crash Sentry에서 재발 0건 확인
5. **Device verify** — **CRITICAL**: 첫 실행(설치 직후) + 재실행 시나리오 실기기 필수

## 검증 결과

- `npm run type-check` — pass
- `npm run lint:orphan` — 0 orphan
- `npm test` — 383 suites, 7855 tests, 100% coverage pass

Closes #1780 (회귀)