### PR TITLE
fix(critical): SplashScreen.hideAsync() 호출 누락 — splash 영구 잔류 회귀 (PR #1787)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { DevSettings } from 'react-native';
 import * as Notifications from 'expo-notifications';
 import { Redirect, Stack, useSegments } from 'expo-router';
@@ -116,13 +116,22 @@ function RootContent() {
   const segments = useSegments();
 
   // #1780 — 첫 실행 온보딩: storage에서 완료 여부 로드.
+  // hydrated=true 시점에 SplashScreen.hideAsync() 호출하여 splash가 영구 잔류하는 회귀 차단.
+  const [hydrated, setHydrated] = useState(false);
+
   useEffect(() => {
     let cancelled = false;
-    loadOnboardingState().then(() => {
-      if (cancelled) return;
+    loadOnboardingState().finally(() => {
+      if (!cancelled) setHydrated(true);
     });
     return () => { cancelled = true; };
   }, []);
+
+  useEffect(() => {
+    if (hydrated) {
+      SplashScreen.hideAsync().catch((e) => layoutLogger.warn('SplashScreen.hideAsync 실패', e));
+    }
+  }, [hydrated]);
 
   // #819 — "탑승했냐?" 응답 listener. boarding-prompt 카테고리 푸시의 [탑승]/[미탑승] 또는 탭을 받아
   // arvlCd 우선순위로 trainCode 자동 lock 또는 5분 silence POST. 미bound trip(destinationId=null)에서도


### PR DESCRIPTION
## 원인

`app/_layout.tsx:61` `SplashScreen.preventAutoHideAsync()` 호출됐으나 PR #1787(#1780 onboarding) 머지 시 `SplashScreen.hideAsync()` 호출이 누락됨 → splash가 영구적으로 사라지지 않음.

추가로 `useOnboardingStore` 초기값 `hasCompletedOnboarding: false` + `loadOnboardingState()` 비동기 → 첫 render에서 Redirect 발사 후에도 hydrate 완료 신호가 없어 hideAsync 타이밍 불확실.

## Fix

`RootContent` 안에 `hydrated` state를 추가하고:

1. 기존 `loadOnboardingState().then()` → `.finally()`로 교체 — AsyncStorage throw 시나리오에서도 hydrate 완료 보장
2. `hydrated=true` 시점에 `SplashScreen.hideAsync()` 호출 (warn-only, 앱 crash 없음)

변경 위치: `app/_layout.tsx` +12 / -3 (순 +9줄)

## 시나리오 검증

| 시나리오 | 동작 |
|---|---|
| 첫 실행 (AsyncStorage 비어있음) | loadOnboardingState 완료 → hideAsync → onboarding screen 노출 |
| 재실행 (completed=true) | loadOnboardingState 완료 → hideAsync → 메인 screen 노출 |
| AsyncStorage throw | finally() 실행 → hideAsync → onboarding screen 노출 (false 유지) |

## Wire-completion 5단

1. **Orphan** — `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard** — splash hide는 device 화면에서 직접 확인. 코드 경로 상 `layoutLogger.warn` 로그로 hideAsync 실패 관측 가능
3. **의존 PR** — N/A
4. **측정 plan** — 실기기 cold-launch 3회 시나리오(첫 실행/재실행/AS throw) 수동 확인
5. **Device verify** — 실기기 필수: splash 사라지고 onboarding 또는 메인 화면 정상 노출 여부

Closes #1787 (회귀)

**CRITICAL — 즉시 머지 필요 (splash stuck으로 앱 진입 불가)**