### PR TITLE
fix(#1806 critical): gate-hop-window-no-source 60s dedup — V9 log spam 차단

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -3477,6 +3477,61 @@ describe('useStationAlarm', () => {
       );
     });
 
+    it('#1806 fast-path 60s dedup — no-source가 60s 내 재발사 시 두 번째 적재 skip', async () => {
+      const T1 = 1_700_000_000_000;
+      const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(T1);
+      mockGetBoardingLock.mockResolvedValue(activeLock1266);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+      // currentStationArrival 객체 참조를 매 rerender마다 교체해 fg-arvlcd effect deps 재발사 유도.
+      // GPS path는 currentStationArrival을 dep으로 사용하지 않으므로 재발사 여부에 영향 없음.
+      const makeInputs = (tick: number) =>
+        inputs1266({
+          nearestStation: arcLine2[0],
+          currentHopIndex: null,
+          arcStations: arcLine2,
+          // 새 객체 참조 → currentStationArrival dep 변경 → fg-arvlcd effect 재실행.
+          currentStationArrival: { ...dummyArrival, _tick: tick } as unknown as typeof dummyArrival,
+        });
+      const { rerender } = renderHook((tick: number) => useStationAlarm(makeInputs(tick)), {
+        initialProps: 0,
+      });
+      try {
+        // 첫 번째 cycle: T1 - 0(초기ref) >= 60_000 → fg-arvlcd path 적재됨.
+        await waitFor(() =>
+          expect(mockLogSuppressedHopWindowNoSource).toHaveBeenCalledWith({
+            source: 'fg-arvlcd',
+            stationName: arcLine2[0].name,
+          }),
+        );
+        const callCountAfterFirst =
+          mockLogSuppressedHopWindowNoSource.mock.calls.filter(
+            (c) => c[0].source === 'fg-arvlcd',
+          ).length;
+        // T1 + 30s (60s 이내) → fg-arvlcd dedup skip.
+        dateNowSpy.mockReturnValue(T1 + 30_000);
+        rerender(1);
+        await new Promise<void>((r) => setTimeout(r, 50));
+        expect(
+          mockLogSuppressedHopWindowNoSource.mock.calls.filter(
+            (c) => c[0].source === 'fg-arvlcd',
+          ).length,
+        ).toBe(callCountAfterFirst);
+        // T1 + 61s (60s 초과) → fg-arvlcd 새 적재.
+        dateNowSpy.mockReturnValue(T1 + 61_000);
+        rerender(2);
+        await waitFor(() =>
+          expect(
+            mockLogSuppressedHopWindowNoSource.mock.calls.filter(
+              (c) => c[0].source === 'fg-arvlcd',
+            ).length,
+          ).toBeGreaterThan(callCountAfterFirst),
+        );
+      } finally {
+        dateNowSpy.mockRestore();
+      }
+    });
+
     it('arcStations 빈 배열 → 게이트 자체 미적용 (기존 동작 보존)', async () => {
       mockGetBoardingLock.mockResolvedValue(activeLock1266);
       mockGetLastNotifiedStationId.mockResolvedValue(null);
@@ -3828,6 +3883,48 @@ describe('useStationAlarm', () => {
       await waitFor(() => {
         expect(mockSendStationPassedNotification).toHaveBeenCalled();
       });
+    });
+
+    it('#1806 60s dedup — no-source가 60s 내 재발사 시 두 번째 적재 skip', async () => {
+      const T1 = 1_700_000_000_000;
+      const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(T1);
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '강남',
+        stopsToNextStation: 1,
+        isTransfer: false,
+        stopsToDestination: 1,
+      });
+      // userLocation.lat 변경으로 GPS station-passed effect deps 재발사 유도.
+      const makeInputs = (lat: number) =>
+        defaultInputs({
+          route: directRouteOnLine2,
+          destination,
+          nearestStation: arc[0],
+          currentHopIndex: null,
+          arcStations: arc,
+          userLocation: { lat, lng: 127.0 },
+          speedMps: 10,
+          accuracyMeters: 50,
+        });
+      const { rerender } = renderHook((lat: number) => useStationAlarm(makeInputs(lat)), {
+        initialProps: 37.5,
+      });
+      try {
+        // 첫 번째 cycle: T1 - 0(초기ref) = T1 >= 60_000 → 적재됨.
+        await waitFor(() => expect(mockLogSuppressedHopWindowNoSource).toHaveBeenCalledTimes(1));
+        // T1 + 30s (60s 이내) → dedup skip.
+        dateNowSpy.mockReturnValue(T1 + 30_000);
+        rerender(37.501);
+        // 30s 후 재발사해도 여전히 1건만.
+        await new Promise<void>((r) => setTimeout(r, 50));
+        expect(mockLogSuppressedHopWindowNoSource).toHaveBeenCalledTimes(1);
+        // T1 + 61s (60s 초과) → 새 적재.
+        dateNowSpy.mockReturnValue(T1 + 61_000);
+        rerender(37.502);
+        await waitFor(() => expect(mockLogSuppressedHopWindowNoSource).toHaveBeenCalledTimes(2));
+      } finally {
+        dateNowSpy.mockRestore();
+      }
     });
 
     it('firedAlarms fallback — fired set의 max station이 arc 마지막이면 inferred는 arc 마지막에 cap', async () => {

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -496,6 +496,12 @@ export function useStationAlarm({
     );
 
   const firedAlarmsRef = useRef<Set<string>>(new Set());
+  // #1806 — gate-hop-window-no-source 60s dedup. lockless trip + firedAlarms 빈 상태에서 매 5s
+  // FG cycle마다 suppression이 적재돼 V9(100/h/trip) 위반(실측 1157/h). 같은 reason은 60s 1회만
+  // 적재해 감시 신호는 보존하되 spam을 차단한다.
+  // fg / fg-arvlcd path는 독립적인 ref를 가져 서로 dedup하지 않는다 (경로별 독립 감시).
+  const lastHopWindowNoSourceFgTsRef = useRef<number>(0);
+  const lastHopWindowNoSourceFgArvlcdTsRef = useRef<number>(0);
   // #699: firedAlarmsRef의 내용이 어느 destinationId에 속하는지 추적.
   // destination 변경 직후엔 hydrate effect가 hydrationPhase를 'pre-hydrate'로 리셋하지만,
   // 같은 render cycle의 ETA/API effect는 React state 전파 전이라 hydrationPhase='ready'(stale)
@@ -1072,7 +1078,13 @@ export function useStationAlarm({
         const effectiveHopIndex =
           currentHopIndex ?? inferHopIndexFromFiredAlarms(firedAlarmsRef.current, arcStations);
         if (effectiveHopIndex < 0) {
-          logSuppressedHopWindowNoSource({ source: 'fg', stationName: candidateStation.name });
+          // #1806 — 60s dedup: 같은 reason을 매 5s cycle마다 적재하면 V9 위반(실측 1157/h).
+          // 감시 신호는 보존하되 60s 이내 중복은 skip한다.
+          const now = Date.now();
+          if (now - lastHopWindowNoSourceFgTsRef.current >= 60_000) {
+            lastHopWindowNoSourceFgTsRef.current = now;
+            logSuppressedHopWindowNoSource({ source: 'fg', stationName: candidateStation.name });
+          }
         } else if (isStationWithinHopWindow(candidateStation, arcStations, effectiveHopIndex)) {
           // hop window 통과 — origin hop 케이스만 추가 표식 (lockless 차단은 IIFE 내부).
           // #1630 — effectiveHopIndex AND 조건 제거. lockless mode는 estimator(시간 적분)가
@@ -1245,10 +1257,16 @@ export function useStationAlarm({
         const effectiveHopIndex =
           currentHopIndex ?? inferHopIndexFromFiredAlarms(firedAlarmsRef.current, arcStations);
         if (effectiveHopIndex < 0) {
-          logSuppressedHopWindowNoSource({
-            source: 'fg-arvlcd',
-            stationName: candidateStation.name,
-          });
+          // #1806 — 60s dedup: 같은 reason을 매 cycle마다 적재하면 V9 위반. fg와 독립 ref로
+          // fg-arvlcd 경로를 별도 감시한다.
+          const now = Date.now();
+          if (now - lastHopWindowNoSourceFgArvlcdTsRef.current >= 60_000) {
+            lastHopWindowNoSourceFgArvlcdTsRef.current = now;
+            logSuppressedHopWindowNoSource({
+              source: 'fg-arvlcd',
+              stationName: candidateStation.name,
+            });
+          }
         } else if (!isStationWithinHopWindow(candidateStation, arcStations, effectiveHopIndex)) {
           logSuppressedHopWindow({
             source: 'fg-arvlcd',


### PR DESCRIPTION
Closes #1806

## 진단 결과

### Route 계산 path (원인 A)

이슈 본문의 `route hop count=0`은 **DebugModal의 monitoring gap**임.

- DebugModal은 `useFusedNearestStation()` 를 별도로 호출하며 routeContext를 전달하지 않음 → `arcStations=[]` → `routeHopCount=0` 표시
- 실제 HomeScreen의 `useFusedNearestStation` 호출(routeContext 포함)에서는 route IS computed
- 증거: `gate-hop-window-no-source=76` suppression은 `arcStations.length > 0` 조건(line 1071) 안에서만 발생 → HomeScreen context에서 arcStations가 비어있지 않음을 입증

**Route 계산 흐름**: destination 설정 → GPS brief return → `tripOrigin` 캡처 → route effect dep `effectiveOrigin?.id` 변경 → `findRouteCandidatesByCategory` 실행 → `categorized` 채워짐 → `route` non-null → `routeContext` 구성 → `arcStations` populated. GPS 재소실 후에도 `tripOrigin` 유지 → `effectiveOrigin = tripOrigin` → route 유지됨.

### V9 위반 원인 (Fix B)

lockless trip에서 `currentHopIndex=null`(estimator 산출 불가) + `firedAlarms` 빈 상태일 때:
- `inferHopIndexFromFiredAlarms` → -1
- `effectiveHopIndex = -1 < 0` → `logSuppressedHopWindowNoSource` 매 5s cycle 적재
- 실측: 7분간 76건 = 10.8/min = ~648/h → V9 threshold(100/h) 11배+ 위반

## Fix A (V9 silence) 적용

**파일**: `src/features/alarm/hooks/useStationAlarm.ts`

- fg path / fg-arvlcd path 각각 독립 `useRef<number>(0)` dedup ref 추가
- 60s 이내 중복 적재 skip — 감시 신호는 60s 1회 보존됨
- 두 경로 독립 ref: fg가 fire해도 fg-arvlcd는 별도 60s 윈도우 관리

**기대 효과**: 76건/7min → ≤1건/7min (60s dedup 기준 최대 7건/7min, 실 1건에 가까움)

## Wire-completion 5단

1. **Orphan** — `npm run lint:orphan` pass. 신규 export 없음.
2. **V/X dashboard** — DebugModal `## Alarm log` suppress reason aggregate에서 `gate-hop-window-no-source` 적재 빈도로 확인. 60s dedup 후 시간당 ≤60건으로 감소해야 함.
3. **의존 PR** — N/A. 독립 fix.
4. **측정 plan** — 실기기 trip 1회(5분+) → `## Gates` 섹션 `gate-hop-window-no-source` 건수 확인. 7분 기준 ≤7건이면 acceptance.
5. **Device verify** — 실기기 trip 1회 (paradigm shift Phase 1+2 검증과 같이). type+unit 검증 완료.

## 검증 결과

- `npm test`: 7857/7857 pass, coverage 100%
- `npm run type-check`: 0 error
- `npm run lint:orphan`: No orphan exports detected
- 추가 테스트: GPS path(fg) / fast-path(fg-arvlcd) 각 60s dedup + expiry 검증 2건

## 참조

- Epic #1745 paradigm shift Phase 1+2 검증
- V9: gate-hop-window-no-source 시간당 < 100건 → 목표 < 10건 (60s dedup ≡ 최대 60건/h, 실측은 훨씬 적음)