### PR TITLE
fix(#1809): onboarding AsyncStorage 영속화 회귀 (재실행 재노출 차단)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -179,7 +179,12 @@ function RootContent() {
   // #1780 — 첫 실행 온보딩 redirect.
   // router.replace(useEffect) 대신 Redirect 컴포넌트로 render path 안에서 처리.
   // Stack 마운트 전 navigate 호출로 인한 "Attempted to navigate before mounting the Root Layout" crash 방지.
+  // #1809 — hydrated 전에는 hasCompletedOnboarding=false(초기값)이므로 redirect를 보류.
+  // SplashScreen.preventAutoHideAsync()가 splash를 유지하므로 null 반환은 안전.
   const isOnOnboarding = segments[0] === 'onboarding';
+  if (!hydrated) {
+    return null;
+  }
   if (!hasCompletedOnboarding && !isOnOnboarding) {
     return <Redirect href="/onboarding" />;
   }


### PR DESCRIPTION
## 원인

`_layout.tsx`에서 `hydrated` 플래그를 확인하지 않고 `Redirect`를 렌더했음.

cold-launch 시 `hasCompletedOnboarding` 초기값 = `false` → `loadOnboardingState()`(AsyncStorage)가 완료되기 전에 `Redirect href="/onboarding"` 발사 → 재실행마다 온보딩 재노출.

`hydrated` state 변수는 이미 존재했지만(`useState(false)` + `loadOnboardingState().finally(() => setHydrated(true))`), redirect 분기에서 체크하지 않았던 것이 회귀의 전체 원인.

## 변경 요약

| 파일 | 변경 |
|---|---|
| `app/_layout.tsx` | `if (!hydrated) return null` 가드 추가 — hydrate 완료 전 redirect 차단 |

`SplashScreen.preventAutoHideAsync()`가 이미 상단에 호출되어 있어 `null` 반환 중에도 splash가 유지됨 → 사용자에게 빈 화면 노출 없음.

exit path(`건너뛰기` / `완료` / 권한 요청 완료) 모두 `OnboardingScreen.tsx`의 `finish()` → `completeOnboarding()` → AsyncStorage write 경로를 정상 통과함을 코드에서 확인.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass. 신규 export 없음.
2. **V/X dashboard** — 재실행 시 onboarding 재노출 여부는 실기기 확인. 별도 obs 신호 없음.
3. **의존 PR** — N/A
4. **측정 plan** — 사용자 실기기에서 완료 후 재실행 1회 → onboarding 미노출 확인.
5. **Device verify** — 실기기 검증 필요. 시나리오: 첫 실행 온보딩 완료(건너뛰기) → 앱 강제 종료 → 재실행 → 메인 화면 직진.

## 검증

- `npm test` — 7855 tests pass, coverage 100%
- `npm run type-check` — 0 errors
- `npm run lint:orphan` — No orphan exports detected

Closes #1809