### PR TITLE
fix(#1817): destination/transfer early false fire 차단 (estimator 시간 적분 gate)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -4895,4 +4895,90 @@ describe('useStationAlarm', () => {
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
   });
+
+  describe('#1817 — estimatorIsTimeIntegration gate (destination/transfer early false fire 차단)', () => {
+    it('estimatorIsTimeIntegration=true → evaluateAlarmPhase 미호출 + gate 로그 기록 (phase ETA effect 차단)', async () => {
+      // Day 1 evidence: 13:49:38 fu=마장 gp=왕십리 mismatch → 마장 destination early false fire (1m 36s).
+      // lockless-route-hop 시간 적분으로 fusion=마장이 됐지만 GPS=왕십리인 상황.
+      // hydration 완료 후 estimatorIsTimeIntegration 게이트가 phase ETA effect를 차단한다.
+      const route = makeDirectRoute(3, '2');
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 100,
+            estimatorIsTimeIntegration: true,
+          }),
+        ),
+      );
+      // hydration 완료 후 gate 로그 확인 — 게이트 차단 시 evaluateAlarmPhase 미호출.
+      await waitFor(() =>
+        expect(mockLogSuppressedPhaseGate).toHaveBeenCalledWith(
+          'gate-phase-time-integration',
+          expect.any(String),
+        ),
+      );
+      expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+    });
+
+    it('estimatorIsTimeIntegration=false → evaluateAlarmPhase 정상 호출 (실관측 advance)', async () => {
+      // 시간 적분 비활성 — 실관측(boarding-lock / backend-ssot 등) advance 시 phase fire 허용.
+      const route = makeDirectRoute(3, '2');
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 100,
+            estimatorIsTimeIntegration: false,
+          }),
+        ),
+      );
+      await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
+    });
+
+    it('estimatorIsTimeIntegration 미전달(기본=false) → evaluateAlarmPhase 정상 호출 (기존 동작 유지)', async () => {
+      // 기존 caller에 prop 미전달 시 기존 동작 보존 — graceful fallback.
+      const route = makeDirectRoute(3, '2');
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 100,
+          }),
+        ),
+      );
+      await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
+    });
+
+    it('estimatorIsTimeIntegration=true → station-passed(GPS path)는 차단되지 않음 (phase 게이트만 적용)', async () => {
+      // phase ETA 게이트는 station-passed effect에 영향 없음. 독립적 차단.
+      const route = makeDirectRoute(1, '2');
+      const onRouteStation = makeStation('S2-DST', '강남');
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 100,
+            estimatorIsTimeIntegration: true,
+          }),
+        ),
+      );
+      // station-passed는 별도 effect — 시간 적분 게이트 영향 없이 발화.
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      // phase alarm은 차단.
+      expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -459,6 +459,17 @@ export interface UseStationAlarmInputs {
    * 회귀(역삼 13:37) 차단. 미전달/false면 기존 동작 유지.
    */
   trainProgressing?: boolean;
+  /**
+   * #1817 — useFusedNearestStation.estimatorIsTimeIntegration 패스스루.
+   * true이면 현재 fusion station이 lockless-route-hop / default-hop / reanchored-hop 시간 적분으로
+   * 산출된 것 — GPS station(실관측)과 mismatch될 수 있다.
+   * destination early / transfer early fire는 fusion station 기반 ETA 계산이므로,
+   * 시간 적분 활성 시 GPS 실측과 다른 역을 목표로 발사할 위험이 있다.
+   * true면 phase ETA effect를 차단. 미전달/false면 기존 동작 유지.
+   *
+   * Day 1 evidence: 13:49:38 fu=마장 gp=왕십리 mismatch → 마장 destination early false fire (1m 36s).
+   */
+  estimatorIsTimeIntegration?: boolean;
 }
 
 export function useStationAlarm({
@@ -479,6 +490,7 @@ export function useStationAlarm({
   arcStations,
   subsurfaceStationDetected = false,
   trainProgressing = false,
+  estimatorIsTimeIntegration = false,
 }: UseStationAlarmInputs): void {
   // #1405 — 동일 5-arg evaluateMovement 호출 helper. Phase ETA / API imminent / movementSuppressionReason
   // 3곳에서 같은 인자로 호출돼 SonarCloud CPD가 dup 검출. helper로 추출해 회피.
@@ -830,6 +842,17 @@ export function useStationAlarm({
       return;
     }
 
+    // #1817 — 시간 적분 estimator(lockless-route-hop / default-hop / reanchored-hop) 활성 시
+    // fusion station이 GPS 실관측 station과 다를 수 있다. destination/transfer early는
+    // fusion station 기반 ETA 계산을 사용하므로, GPS station과 mismatch인 상황에서 조기 fire를
+    // 차단한다. Day 1 evidence: fu=마장 gp=왕십리 → 왕십리 대기 중 마장 destination early false fire.
+    // 실관측(boarding-lock / backend-ssot / position-train / wifi-ssid / fused / route-progress)
+    // 기반 advance만 phase fire 허용 — #1813과 동일 원칙의 phase alarm 확장.
+    if (estimatorIsTimeIntegration) {
+      logSuppressedPhaseGate('gate-phase-time-integration', destination.name);
+      return;
+    }
+
     let etaSeconds: number | null = null;
     if (userLocation) {
       const distM = distanceMetersBetween(
@@ -932,6 +955,8 @@ export function useStationAlarm({
     // #903 — degraded 평가는 arrivalConfidence에서 파생. 지하 진입으로 'gps-only'→
     // 'gps-only-underground' 단독 전환 시(다른 deps 정적) 본 effect 재실행되어 차단 정책 즉시 반영.
     arrivalConfidence,
+    // #1817 — 시간 적분 → 실관측 전환 시(estimatorIsTimeIntegration false→true→false) 즉시 재평가.
+    estimatorIsTimeIntegration,
   ]);
 
   // #396: 도착정보 API 신호로 imminent 발사.

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -129,6 +129,9 @@ export type AlarmLogReason =
   | 'dismiss-silence'
   | 'gate-phase-accuracy'
   | 'gate-phase-warmup'
+  // #1817 — 시간 적분 estimator(lockless-route-hop / default-hop / reanchored-hop) 활성 시
+  // fusion station이 GPS station과 mismatch될 수 있어 destination/transfer early fire 차단.
+  | 'gate-phase-time-integration'
   // #1010 — station-passed effect가 lock hydrate 직후 30s warmup window 동안 차단된 발사.
   | 'gate-station-passed-warmup'
   // #1208 (Epic #1204 D2) — station-passed가 trip 진행도 hop window 밖이라 차단된 발사.
@@ -1096,9 +1099,10 @@ export function logSuppressedGate(
  * FG phase ETA effect의 진입 게이트 차단 1건 적재 (#1019).
  * 'gate-phase-accuracy': isAccuracyAcceptable(accuracyMeters) 실패.
  * 'gate-phase-warmup': 첫 trigger suppress (warmup window).
+ * 'gate-phase-time-integration': 시간 적분 estimator 활성 시 fusion/GPS mismatch 가드 (#1817).
  * isBurstDuplicate로 DEDUP_LOG_WINDOW_MS 안의 같은 reason+station 중복 drop.
  */
-export function logSuppressedPhaseGate(reason: 'gate-phase-accuracy' | 'gate-phase-warmup', stationName: string | undefined): void {
+export function logSuppressedPhaseGate(reason: 'gate-phase-accuracy' | 'gate-phase-warmup' | 'gate-phase-time-integration', stationName: string | undefined): void {
   const name = stationName ?? '(unknown)';
   if (isBurstDuplicate(reason, name)) return;
   appendAlarmLog({ ts: Date.now(), source: 'fg-evaluated', outcome: 'suppressed', reason, stationName: name });

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -194,6 +194,12 @@ interface UseFusedNearestStationReturn {
    */
   subsurfaceStationDetected: boolean;
   /**
+   * #1817 — 현재 estimator strategy가 시간 적분(lockless-route-hop / default-hop / reanchored-hop)인지.
+   * true이면 fusion station이 GPS 실관측 station과 다를 수 있어 destination/transfer early fire 차단.
+   * useStationAlarm이 phase ETA effect 진입 게이트로 사용한다.
+   */
+  estimatorIsTimeIntegration: boolean;
+  /**
    * #1401 (Epic #1396 sub 5/6) — 직전 tick 대비 fusion result가 arc 위에서 advance(idx 증가)했는지.
    * true일 때 호출자(useStationAlarm/silentPushTask/backgroundLocationTask)는 evaluateMovement에
    * trainProgressing=true로 전달해 device 모션/GPS speed 정적 신호 가드를 우회시킨다.
@@ -1907,6 +1913,8 @@ export function useFusedNearestStation(
     detectionSignalMask: detectionVerdict.signalMask,
     subsurface: barometerSubsurface,
     subsurfaceStationDetected,
+    // #1817 — phase alarm false fire 차단 입력. useStationAlarm이 시간 적분 활성 시 ETA phase 진입을 차단.
+    estimatorIsTimeIntegration,
     trainProgressing,
     environment,
     surfaceSSOTActive: surfaceSSOT !== null,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -198,7 +198,7 @@ export default function HomeScreen() {
   // #1677 — silent push 60s+ 미수신 감지. FG 시 backendSsotAccepts 강제 false → device tier fallback.
   // 신규 폴링 없음 — 기존 arrival/position 30s cycle 재사용.
   const { healthy: silentPushHealthy } = useSilentPushHealthCheck();
-  const { result, liveResult, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source, currentHopIndex, arcStations, trainProgressing, backendSsotCurrentStationId } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal }, wifiStation, silentPushHealthy);
+  const { result, liveResult, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source, currentHopIndex, arcStations, trainProgressing, estimatorIsTimeIntegration, backendSsotCurrentStationId } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal }, wifiStation, silentPushHealthy);
 
   // #1621 Phase B — V1 mismatch 자동 측정. UI currentStation(cascade picker)이 backend SSoT
   // 권위 mirror와 일치하지 않으면 alarmLog 'v1-mismatch' reason으로 1분 dedup 적재.
@@ -472,6 +472,8 @@ export default function HomeScreen() {
     // #1401 — 열차 진행 신호. fusion arc advance가 확인되면 evaluateMovement가 device 모션/GPS
     // speed 정적 가드를 우회 — 지하철 내부에서 device 신호 불신뢰성 보완(역삼 13:37 미발사 회귀).
     trainProgressing,
+    // #1817 — 시간 적분 estimator 활성 시 fusion/GPS mismatch로 destination/transfer early 조기 발사 차단.
+    estimatorIsTimeIntegration,
   });
 
   // #584 PR B — BoardingLock 진입점. UI 렌더링/lock 생성만 담당하며,


### PR DESCRIPTION
## Closes #1817

## 변경 사항

### Root cause
`lockless-route-hop` 시간 적분 estimator 활성 시 `fusion station`(마장)이 GPS 실관측 `station`(왕십리)과 mismatch될 수 있다. 기존 `evaluateAlarmPhase`(phase ETA effect)는 fusion station 기반 ETA로 destination/transfer early를 판정하므로, GPS station과 다른 역을 목표로 조기 발사했다.

**Day 1 evidence:** `13:49:38 fu=마장 gp=왕십리 (mismatch) → 마장 destination early false fire (사용자 왕십리 대기 중, 1m 36s 조기)`

### 수정 내용

| 파일 | 변경 |
|------|------|
| `useStationAlarm.ts` | `estimatorIsTimeIntegration` prop 추가 + phase ETA effect 게이트 삽입 |
| `useFusedNearestStation.ts` | `estimatorIsTimeIntegration` return type + return object 추가 |
| `HomeScreen.tsx` | `estimatorIsTimeIntegration` destructure + `useStationAlarm` 전달 wire-up |
| `alarmLog.ts` | `'gate-phase-time-integration'` reason 추가 |
| `useStationAlarm.test.ts` | 4케이스 추가 |

### 가드 정책

`estimatorIsTimeIntegration=true` 시 phase ETA effect(destination early / transfer early) 진입 차단. **station-passed effect는 독립** — 시간 적분 게이트 영향 없음.

`#1813`과 동일 원칙(`lockless-route-hop / default-hop / reanchored-hop` = 실관측 아닌 시간 적분 → fire 권한 박탈)을 phase alarm으로 확장.

---

## Wire-completion 5단 체크

1. **Orphan 없음** — `npm run lint:orphan` 0 orphan 확인
2. **V/X dashboard** — `logSuppressedPhaseGate('gate-phase-time-integration')` → DebugModal alarmLog에서 `gate-phase-time-integration` reason으로 관측 가능
3. **의존 PR** — `#1813` (station-passed lockless-route-hop 차단) 머지됨 (선행 충족)
4. **측정 plan** — DebugModal alarmLog `gate-phase-time-integration` reason 적재 확인 + 1주 trip 재발 0건
5. **Device verify** — N/A — type+unit only (phase gate 로직). 실기기에서 왕십리 대기 중 마장 destination early 재현 시나리오로 추가 검증 권장

## 검증

- `npm test` — 7814 tests all pass (coverage 100%)
- `npm run type-check` — 0 error
- `npm run lint:orphan` — 0 orphan