### PR TITLE
fix(#1816 critical): device fire path lockless 가드 (paradigm shift Phase 1 보강)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -87,6 +87,7 @@ const mockLogSuppressedCrossCategoryDedup = jest.fn();
 const mockLogSuppressedCrossCategoryRecent = jest.fn();
 const mockLogSuppressedPhaseToPhaseDedup = jest.fn();
 const mockLogSuppressedSsotFireGate = jest.fn();
+const mockLogSuppressedLocklessNoUserIntent = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
   logFiredAlarmsHydrate: (...args: unknown[]) => mockLogFiredAlarmsHydrate(...args),
@@ -119,6 +120,8 @@ jest.mock('../../utils/alarmLog', () => ({
     mockLogSuppressedPhaseToPhaseDedup(...args),
   logSuppressedSsotFireGate: (...args: unknown[]) =>
     mockLogSuppressedSsotFireGate(...args),
+  logSuppressedLocklessNoUserIntent: (...args: unknown[]) =>
+    mockLogSuppressedLocklessNoUserIntent(...args),
 }));
 
 // #1572 (T9) — evaluateSsotFireGate mock. 기본 no-block (mirror-missing graceful).
@@ -180,6 +183,17 @@ const earlyDest: AlarmEvent = { phaseId: 'early', type: 'destination', stationNa
 const earlyTransfer: AlarmEvent = { phaseId: 'early', type: 'transfer', stationName: '시청' };
 const imminentDest: AlarmEvent = { phaseId: 'imminent', type: 'destination', stationName: '강남' };
 
+// #1816 — 테스트 기본 lock. lock 활성 trip은 paradigm shift 가드를 통과해 fire path에 진입.
+// lock=null(lockless)을 명시적으로 테스트하는 케이스는 개별적으로 mockGetBoardingLock.mockResolvedValue(null) 재설정.
+const DEFAULT_LOCK = {
+  destinationId: 'D1',
+  trainCode: 'T-DEFAULT',
+  boardingStationId: 'S-DEFAULT',
+  boardingLine: '2' as const,
+  boardedAt: 0,
+  expectedDurationMs: 60_000,
+};
+
 function defaultInputs(overrides: Partial<UseStationAlarmInputs> = {}): UseStationAlarmInputs {
   return {
     route: null,
@@ -210,7 +224,8 @@ describe('useStationAlarm', () => {
     mockIsImminentByArrivalCode.mockReturnValue(false);
     mockGetStoredTripTrainCode.mockResolvedValue(null);
     mockUseArrivalInfo.mockReturnValue({ arrival: null, loading: false, isMock: false });
-    mockGetBoardingLock.mockResolvedValue(null);
+    // #1816 — 기본 lock 활성. lockless(lock=null) 케이스는 개별 테스트에서 명시적으로 재설정.
+    mockGetBoardingLock.mockResolvedValue(DEFAULT_LOCK);
     mockFindFgArvlCdFireSignal.mockReturnValue(null);
     mockAwaitInitialScheduledAlarmDrain.mockResolvedValue(undefined);
     // #1515 — cross-category dedup 모듈 in-memory 상태 리셋. mock하지 않은 실모듈 사용.
@@ -944,15 +959,10 @@ describe('useStationAlarm', () => {
       expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
-    // Sonar cpd 통합 — sleep OFF는 lock 유무와 무관하게 게이트 비활성 → 정상 발사.
-    // #1214 (Epic #1204 D8): lock=null 조기 종료가 제거됐으므로 "sleep ON + lock null" 케이스는
-    // 별도 신규 케이스(아래)에서 suppress=true 로 검증.
-    it.each([
-      { name: 'sleep OFF + lock 활성 + 첫 hop transfer → 정상 발사', sleepMode: false, lockValue: lock },
-      { name: 'sleep OFF + lock null + 첫 hop transfer → 정상 발사', sleepMode: false, lockValue: null },
-    ])('$name', async ({ sleepMode, lockValue }) => {
-      useSettingsStore.setState({ sleepMode });
-      mockGetBoardingLock.mockResolvedValue(lockValue);
+    // #1816 — sleep OFF + lock 활성 + 첫 hop transfer → 정상 발사 (lock 활성 trip은 sleep 게이트 비활성).
+    it('sleep OFF + lock 활성 + 첫 hop transfer → 정상 발사', async () => {
+      useSettingsStore.setState({ sleepMode: false });
+      mockGetBoardingLock.mockResolvedValue(lock);
       const route = makeTransferRoute({
         transferName: '시청',
         fromLine: '2',
@@ -967,9 +977,9 @@ describe('useStationAlarm', () => {
       expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
     });
 
-    it('sleep ON + lock null + 첫 hop transfer → suppress (#1214 lockless 적용)', async () => {
-      // #1214 (Epic #1204 D8): 사용자 명시 의향 trip(lockless)도 lock 활성과 동급 정확도 보장.
-      // getFirstLeg.endName === stationName 이면 lockless에서도 isFirstHop=true → suppress.
+    it('sleep ON + lock null + 첫 hop transfer → lockless-no-user-intent suppress (#1816)', async () => {
+      // #1816 — lock=null(lockless trip) 시 sleep 게이트에 도달하기 전에 lockless-no-user-intent로 차단.
+      // 기존 #1214: sleep ON + lockless → sleep-first-transfer 차단 → 이제 lockless guard가 앞서 차단.
       useSettingsStore.setState({ sleepMode: true });
       mockGetBoardingLock.mockResolvedValue(null);
       const route = makeTransferRoute({
@@ -983,16 +993,19 @@ describe('useStationAlarm', () => {
       renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
 
       await waitFor(() =>
-        expect(mockLogSuppressedSleepFirstTransfer).toHaveBeenCalledWith(
+        expect(mockLogSuppressedLocklessNoUserIntent).toHaveBeenCalledWith(
           expect.objectContaining({
-            source: 'fg',
+            source: 'fg-evaluated',
             stationName: '시청',
+            kind: 'transfer',
             phaseId: 'early',
           }),
         ),
       );
       expect(mockSendAlarmNotification).not.toHaveBeenCalled();
       expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+      // lockless guard가 앞서 차단하므로 sleep gate는 호출 안 됨.
+      expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
     });
 
     it('sleep ON + lock 활성 + destination 카테고리 → 정상 발사 (transfer 외 영향 없음)', async () => {
@@ -2146,7 +2159,15 @@ describe('useStationAlarm', () => {
     it('조기 발사로 오염되지 않아 window 경과 후 실제 도착에서 destination 정상 발사', async () => {
       const baseTs = 1_700_000_000_000;
       const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseTs);
-      mockGetBoardingLock.mockResolvedValue(null);
+      // #1816 — lock 활성 trip: lockless-no-user-intent 가드를 통과해야 warmup 이후 발사 검증 가능.
+      mockGetBoardingLock.mockResolvedValue({
+        destinationId: destination.id,
+        trainCode: 'T-WARMUP',
+        boardingStationId: 'S-BOARD',
+        boardingLine: '2' as const,
+        boardedAt: baseTs,
+        expectedDurationMs: 60_000,
+      });
       // 트립 시작 시점: early destination 조건 매칭(조기 발사 시도).
       mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
 
@@ -2705,8 +2726,16 @@ describe('useStationAlarm', () => {
       // race 시뮬레이션: evaluateAlarmPhase mock이 firedAlarms를 honor 안 함으로써 같은
       // rawEvent를 매 evaluation마다 반환 (production race에서 in-flight fireAndLog가 add 전에
       // 다음 evaluation이 들어오는 상황과 동치). fireAndLog 진입 가드가 차단해야 한다.
+      // #1816 — lock 활성 trip: lockless-no-user-intent 가드를 통과해야 in-flight dedup 검증 가능.
       mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
-      mockGetBoardingLock.mockResolvedValue(null);
+      mockGetBoardingLock.mockResolvedValue({
+        destinationId: destination.id,
+        trainCode: 'T-DEDUP',
+        boardingStationId: 'S-BOARD',
+        boardingLine: '2' as const,
+        boardedAt: Date.now(),
+        expectedDurationMs: 60_000,
+      });
       const route = makeDirectRoute(1, '2');
 
       const { rerender } = renderHook(
@@ -4027,17 +4056,24 @@ describe('useStationAlarm', () => {
       });
     };
 
-    it('lockless + currentHopIndex=0 + candidate arc[0] → suppressed (gate-origin-hop-lockless)', async () => {
+    it('lockless + currentHopIndex=0 + candidate arc[0] → suppressed (lockless-no-user-intent, #1816 broad guard)', async () => {
+      // #1816 — lock=null 시 origin hop 여부와 무관하게 lockless-no-user-intent 가드로 차단.
+      // 기존 gate-origin-hop-lockless(#1514)는 lockless-no-user-intent broad guard의 subset이 됨.
       mockGetBoardingLock.mockResolvedValue(null);
       renderOriginHopCase(0, 0);
       await waitFor(() => {
-        expect(mockLogSuppressedOriginHopLockless).toHaveBeenCalledWith({
-          source: 'fg',
-          stationName: arcOrigin[0].name,
-        });
+        expect(mockLogSuppressedLocklessNoUserIntent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: 'fg',
+            stationName: arcOrigin[0].name,
+            kind: 'station-passed',
+          }),
+        );
       });
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
       expect(mockLogFiredStationPassed).not.toHaveBeenCalledWith('fg', arcOrigin[0]);
+      // broad guard가 앞서 차단하므로 narrow origin-hop guard는 호출 안 됨.
+      expect(mockLogSuppressedOriginHopLockless).not.toHaveBeenCalled();
     });
 
     // #1630 — lockless mode는 estimator(시간 적분)가 idx를 임의 진행할 수 있으므로 출발역
@@ -4045,16 +4081,21 @@ describe('useStationAlarm', () => {
     // candidate가 arc[0]이면 effectiveHopIndex 값과 무관하게 차단해야 한다 (ADR-014 §4).
     // effectiveHopIndex가 hop window 범위(±1)를 넘으면 별도 gate-hop-window 가드가 먼저 차단하므로
     // 본 가드 직접 cover는 effectiveHopIndex=1 케이스 (직전 trip evidence와 정합).
-    it('#1630 lockless + currentHopIndex=1 + candidate arc[0] → suppressed (estimator overshoot, 2026-06-22 용마산 evidence)', async () => {
+    it('#1630 lockless + currentHopIndex=1 + candidate arc[0] → suppressed (lockless-no-user-intent, #1816 broad guard)', async () => {
+      // #1816 — lock=null 시 candidate index와 무관하게 lockless-no-user-intent 가드로 차단.
       mockGetBoardingLock.mockResolvedValue(null);
       renderOriginHopCase(0, 1);
       await waitFor(() => {
-        expect(mockLogSuppressedOriginHopLockless).toHaveBeenCalledWith({
-          source: 'fg',
-          stationName: arcOrigin[0].name,
-        });
+        expect(mockLogSuppressedLocklessNoUserIntent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: 'fg',
+            stationName: arcOrigin[0].name,
+            kind: 'station-passed',
+          }),
+        );
       });
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockLogSuppressedOriginHopLockless).not.toHaveBeenCalled();
     });
 
     // #1630 회귀 가드 — lock 활성 + currentHopIndex=1 + candidate arc[0]: isOriginHopCandidate=true이지만
@@ -4105,24 +4146,31 @@ describe('useStationAlarm', () => {
       expect(mockLogSuppressedOriginHopLockless).not.toHaveBeenCalled();
     });
 
-    it('lockless + currentHopIndex=0 + candidate arc[1] (다음 hop) → 통과 (정상 진행 신호)', async () => {
+    it('lockless + currentHopIndex=0 + candidate arc[1] (다음 hop) → lockless-no-user-intent 차단 (#1816)', async () => {
+      // #1816 — lock=null이면 candidate index와 무관하게 lockless-no-user-intent 가드로 차단.
+      // 기존: 다음 hop은 통과(origin hop만 차단). 변경: lockless trip 자체가 fire X.
       mockGetBoardingLock.mockResolvedValue(null);
       mockNextTargetStops(3);
       renderOriginHopCase(1, 0);
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+        expect(mockLogSuppressedLocklessNoUserIntent).toHaveBeenCalledWith(
+          expect.objectContaining({ source: 'fg', kind: 'station-passed' }),
+        );
       });
-      expect(mockLogSuppressedOriginHopLockless).not.toHaveBeenCalled();
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
-    it('lockless + currentHopIndex=2 + candidate arc[2] (중간 hop origin 아님) → 통과 (기존 동작 보존)', async () => {
+    it('lockless + currentHopIndex=2 + candidate arc[2] (중간 hop) → lockless-no-user-intent 차단 (#1816)', async () => {
+      // #1816 — lock=null이면 중간 hop도 lockless-no-user-intent 가드로 차단.
       mockGetBoardingLock.mockResolvedValue(null);
       mockNextTargetStops(2);
       renderOriginHopCase(2, 2);
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+        expect(mockLogSuppressedLocklessNoUserIntent).toHaveBeenCalledWith(
+          expect.objectContaining({ source: 'fg', kind: 'station-passed' }),
+        );
       });
-      expect(mockLogSuppressedOriginHopLockless).not.toHaveBeenCalled();
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
   });
 
@@ -4157,14 +4205,16 @@ describe('useStationAlarm', () => {
       });
     }
 
-    type ExpectGate = 'sleep' | 'lock-origin' | 'none';
+    type ExpectGate = 'lockless' | 'lock-origin' | 'none';
     it.each([
       {
-        name: 'FG GPS path — lockless + sleep ON + currentHopIndex=0 → station-passed 차단 (사가정 22:11:56 evidence)',
+        // #1816 — lockless trip은 sleep gate 진입 전에 lockless-no-user-intent 가드가 먼저 차단.
+        // 기존: 'sleep gate로 차단' → 변경: 'lockless-no-user-intent로 차단'.
+        name: 'FG GPS path — lockless + sleep ON + currentHopIndex=0 → lockless-no-user-intent 차단 (#1816)',
         sleepMode: true,
-        lockValue: null,
+        lockValue: null as typeof lockOnSagajeong | null,
         currentHopIndex: 0 as number | null,
-        expectGate: 'sleep' as ExpectGate,
+        expectGate: 'lockless' as ExpectGate,
       },
       {
         // #1599 band-aid — lock 활성 + candidate=boardingStation은 sleep gate 진입 전에
@@ -4176,18 +4226,20 @@ describe('useStationAlarm', () => {
         expectGate: 'lock-origin' as ExpectGate,
       },
       {
-        name: 'FG GPS path — sleep OFF + lockless + currentHopIndex=0 → 정상 발사',
+        // #1816 — lockless trip은 sleep OFF여도 lockless-no-user-intent 가드로 차단.
+        name: 'FG GPS path — sleep OFF + lockless + currentHopIndex=0 → lockless-no-user-intent 차단 (#1816)',
         sleepMode: false,
-        lockValue: null,
+        lockValue: null as typeof lockOnSagajeong | null,
         currentHopIndex: 0 as number | null,
-        expectGate: 'none' as ExpectGate,
+        expectGate: 'lockless' as ExpectGate,
       },
       {
-        name: 'FG GPS path — sleep ON + lockless + currentHopIndex=3 → 정상 발사 (첫 hop 아님)',
+        // #1816 — lockless trip은 hop index와 무관하게 lockless-no-user-intent 가드로 차단.
+        name: 'FG GPS path — sleep ON + lockless + currentHopIndex=3 → lockless-no-user-intent 차단 (#1816)',
         sleepMode: true,
-        lockValue: null,
+        lockValue: null as typeof lockOnSagajeong | null,
         currentHopIndex: 3 as number | null,
-        expectGate: 'none' as ExpectGate,
+        expectGate: 'lockless' as ExpectGate,
       },
       {
         name: 'FG GPS path — sleep ON + lock 활성 + candidate≠boardingStation → 정상 발사',
@@ -4208,15 +4260,16 @@ describe('useStationAlarm', () => {
 
       renderHook(() => useStationAlarm(withSleepGateInputs({ currentHopIndex })));
 
-      if (expectGate === 'sleep') {
+      if (expectGate === 'lockless') {
         await waitFor(() =>
-          expect(mockLogSuppressedSleepStationPassed).toHaveBeenCalledWith({
-            source: 'fg',
-            stationName: onRouteStation.name,
-          }),
+          expect(mockLogSuppressedLocklessNoUserIntent).toHaveBeenCalledWith(
+            expect.objectContaining({ source: 'fg', kind: 'station-passed' }),
+          ),
         );
         expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
         expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
+        // lockless guard가 앞서 차단하므로 sleep gate는 호출 안 됨.
+        expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
       } else if (expectGate === 'lock-origin') {
         await waitFor(() =>
           expect(mockLogSuppressedPassedEventOnLockOrigin).toHaveBeenCalledWith({
@@ -4979,6 +5032,206 @@ describe('useStationAlarm', () => {
       await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
       // phase alarm은 차단.
       expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
+    });
+  });
+
+  // #1816 (paradigm shift Phase 1 보강) — lockless trip + 사용자 명시 의향 없음 시 FG device fire path 차단.
+  // Acceptance:
+  //   1. lockless + 사용자 명시 의향 X → station-passed / transfer / destination fire = 0건
+  //   2. lock 활성 trip → 기존 fire 흐름 유지 (backward compat)
+  describe('#1816 lockless-no-user-intent 가드 (paradigm shift Phase 1 보강)', () => {
+    const onRouteStation = makeStation('S-PASS', '한양대', 37.5, 127.0);
+    const routeDirect = makeDirectRoute(3, '2');
+
+    it('lockless + 사용자 명시 의향 X → station-passed FG GPS path fire X (logSuppressedLocklessNoUserIntent)', async () => {
+      // Day 1 trip evidence: 13:46:32 fg fired station-passed 한양대 (lock=null, boardingPrompt=0).
+      mockGetBoardingLock.mockResolvedValue(null);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '왕십리',
+        stopsToNextStation: 1,
+        isTransfer: false,
+        stopsToDestination: 3,
+      });
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: routeDirect,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 50,
+            speedMps: 10,
+          }),
+        ),
+      );
+
+      await waitFor(() =>
+        expect(mockLogSuppressedLocklessNoUserIntent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: 'fg',
+            stationName: onRouteStation.name,
+            kind: 'station-passed',
+          }),
+        ),
+      );
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('lockless + 사용자 명시 의향 X → transfer phase ETA fire X (logSuppressedLocklessNoUserIntent)', async () => {
+      // Day 1 trip evidence: 13:46:37 fg fired transfer early 왕십리 (lock=null, boardingPrompt=0).
+      // earlyTransfer mock은 stationName='시청'으로 고정 — evaluateAlarmPhase mock이 반환하는 값.
+      mockGetBoardingLock.mockResolvedValue(null);
+      mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer); // earlyTransfer.stationName = '시청'
+
+      const route = makeTransferRoute({
+        transferName: '시청',
+        fromLine: '5',
+        toLine: '2',
+        stopsToTransfer: 1,
+        stopsFromTransfer: 3,
+      });
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            userLocation: { lat: 37.5, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+
+      await waitFor(() =>
+        expect(mockLogSuppressedLocklessNoUserIntent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: 'fg-evaluated',
+            stationName: '시청',
+            kind: 'transfer',
+          }),
+        ),
+      );
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    it('lockless + 사용자 명시 의향 X → destination phase ETA fire X (logSuppressedLocklessNoUserIntent)', async () => {
+      // Day 1 trip evidence: 13:49:38 fg fired destination early 마장 (lock=null, boardingPrompt=0).
+      mockGetBoardingLock.mockResolvedValue(null);
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: routeDirect,
+            destination,
+            userLocation: { lat: 37.498, lng: 127.028 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+
+      await waitFor(() =>
+        expect(mockLogSuppressedLocklessNoUserIntent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: 'fg-evaluated',
+            stationName: destination.name,
+            kind: 'destination',
+          }),
+        ),
+      );
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    it('lock 활성 trip → station-passed FG GPS path 정상 발사 (backward compat)', async () => {
+      // lock !== null = 사용자 명시 의향(BoardingTrainList 탭 / boardingPrompt 응답).
+      mockGetBoardingLock.mockResolvedValue({
+        destinationId: destination.id,
+        trainCode: 'T-ACTIVE',
+        boardingStationId: 'S-BOARD',
+        boardingLine: '2' as const,
+        boardedAt: Date.now(),
+        expectedDurationMs: 60_000,
+      });
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockResolveNextTarget.mockReturnValue({
+        nextStationName: '강남',
+        stopsToNextStation: 2,
+        isTransfer: false,
+        stopsToDestination: 2,
+      });
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: routeDirect,
+            destination,
+            nearestStation: onRouteStation,
+            accuracyMeters: 50,
+            speedMps: 10,
+          }),
+        ),
+      );
+
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      expect(mockLogSuppressedLocklessNoUserIntent).not.toHaveBeenCalled();
+    });
+
+    it('lock 활성 trip → destination phase ETA 정상 발사 (backward compat)', async () => {
+      mockGetBoardingLock.mockResolvedValue({
+        destinationId: destination.id,
+        trainCode: 'T-ACTIVE',
+        boardingStationId: 'S-BOARD',
+        boardingLine: '2' as const,
+        boardedAt: Date.now(),
+        expectedDurationMs: 60_000,
+      });
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: routeDirect,
+            destination,
+            userLocation: { lat: 37.498, lng: 127.028 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      expect(mockLogSuppressedLocklessNoUserIntent).not.toHaveBeenCalled();
+    });
+
+    it('lockless + 사용자 명시 의향 X → subsurface station-passed fire X (subsurface path guard)', async () => {
+      // subsurface verdict path: subsurfaceStationDetected=true 시 lock=null 차단.
+      mockGetBoardingLock.mockResolvedValue(null);
+      const subsurfaceStation = makeStation('S-SUB', '지하역', 37.5, 127.0);
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: routeDirect,
+            destination,
+            nearestStation: subsurfaceStation,
+            subsurfaceStationDetected: true,
+          }),
+        ),
+      );
+
+      await waitFor(() =>
+        expect(mockLogSuppressedLocklessNoUserIntent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: 'fg',
+            stationName: subsurfaceStation.name,
+            kind: 'station-passed',
+          }),
+        ),
+      );
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -47,14 +47,13 @@ import {
   logSuppressedDismissSilence,
   logSuppressedHopWindow,
   logSuppressedHopWindowNoSource,
-  logSuppressedOriginHopLockless,
   logSuppressedPassedEventOnLockOrigin,
   logSuppressedMovement,
   logSuppressedPhaseGate,
   logSuppressedSleepFirstTransfer,
-  logSuppressedSleepStationPassed,
   logSuppressedSsotFireGate,
   logSuppressedStationPassedWarmup,
+  logSuppressedLocklessNoUserIntent,
   type HydrationPhase,
 } from '../utils/alarmLog';
 import { evaluateSsotFireGate } from '../utils/ssotFireGate';
@@ -69,7 +68,7 @@ import { getBoardingLock } from '../utils/boardingLockStorage';
 import { resolveCurrentLine } from '../utils/resolveCurrentLine';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
 import type { LineNumber } from '../../../shared/types/station';
-import { isStationPassedFirstHop, shouldSuppressBySleepRule } from '../utils/shouldSuppressBySleepRule';
+import { shouldSuppressBySleepRule } from '../utils/shouldSuppressBySleepRule';
 import { evaluateMovement, MOVEMENT_TO_ALARM_LOG_REASON } from '../../nearest-station/utils/movementGate';
 import type { PositionStability } from '../../nearest-station/utils/positionStaticDetector';
 import { useSettingsStore } from '../../settings/store/useSettingsStore';
@@ -257,11 +256,7 @@ async function runSilenceGateAndDispatch(params: {
   dismissSilence: import('../utils/dismissSilenceStorage').DismissSilenceState | null;
   userLocation: { lat: number; lng: number } | null;
   clearDismissSilenceAction: () => Promise<void>;
-  // #1236 (Epic #1204 D8 wire) — station-passed sleep 룰 게이트 context.
-  // 호출자가 lock/sleepMode/currentHopIndex를 수집해 전달한다. 게이트 통과 시 dispatch.
-  sleepMode: boolean;
-  currentHopIndex: number | null;
-  /** lock=null이면 lockless trip — currentHopIndex===0으로 판정. lock 활성이면 boardingStationId 비교. */
+  /** #1816 — lock 활성 trip만 진입. gate-passed-event-on-lock-origin에서 boardingStationId 비교. */
   lock: import('../../../shared/types/boardingLock').BoardingLock | null;
 }): Promise<void> {
   // #1599 — boardingLock active 시 candidate가 lock origin(= boardingStationId)이면 station-passed 차단.
@@ -275,26 +270,10 @@ async function runSilenceGateAndDispatch(params: {
     });
     return;
   }
-  // #1236 — sleep 룰 게이트. dismiss silence 위 — silence 만료/위치 무관하게 sleep 첫 hop은 정책상 차단.
-  // sleep 룰은 정확성 게이트(ADR-013 §B3 / ADR-014)라 silence 만료 부수효과(clear)를 막아도 무방.
-  if (
-    shouldSuppressBySleepRule({
-      lock: params.lock,
-      event: { type: 'station-passed', stationName: params.candidateStation.name },
-      sleepMode: params.sleepMode,
-      isFirstHop: isStationPassedFirstHop({
-        lock: params.lock,
-        candidateStationId: params.candidateStation.id,
-        currentHopIndex: params.currentHopIndex,
-      }),
-    })
-  ) {
-    logSuppressedSleepStationPassed({
-      source: params.source,
-      stationName: params.candidateStation.name,
-    });
-    return;
-  }
+  // #1816 — #1236 sleep 룰 게이트(station-passed 첫 hop lockless 차단)가 이 경로에 도달하려면
+  // lock=null + currentHopIndex=0이 필요하다. #1816 broad guard가 먼저 차단해 이 함수는
+  // lock 활성 trip만 진입하므로 sleep-station-passed 분기는 도달 불가 — 제거.
+  // (lock 활성 + candidate=boardingStation은 위 gate-passed-event-on-lock-origin이 먼저 차단)
   const silenceGate = applySilenceGate(
     params.dismissSilence,
     Date.now(),
@@ -667,6 +646,20 @@ export function useStationAlarm({
     // 모두 첫 hop과 일치 (transferName 또는 collapsed destination).
     const isFirstHop = isSameStationName(getFirstLeg(activeRoute, activeDestination.name).endName, rawEvent.stationName);
     const lock = await getBoardingLock();
+    // #1816 (paradigm shift Phase 1 보강) — lockless trip + 사용자 명시 의향 없음 시 ETA/imminent phase 발사 차단.
+    // lock=null = boardingPrompt 미응답 + BoardingTrainList 미탭. 이 상태에서 transfer/destination
+    // phase 알람(ETA 기반 early/imminent + API imminent)을 fire하면 paradigm shift 위반.
+    // firedAlarmsRef.current.delete(key): 진입부 add를 복구해 storage net-zero 유지 (sleep/cross-category 차단과 동일 패턴).
+    if (!lock) {
+      firedAlarmsRef.current.delete(key);
+      logSuppressedLocklessNoUserIntent({
+        source: 'fg-evaluated',
+        stationName: rawEvent.stationName,
+        kind: rawEvent.type,
+        phaseId: rawEvent.phaseId,
+      });
+      return;
+    }
     if (
       shouldSuppressBySleepRule({
         lock,
@@ -1152,12 +1145,14 @@ export function useStationAlarm({
       void (async () => {
         const lock = await getBoardingLock();
         if (cancelled) return;
-        // #1514 — lockless origin hop 차단 (2026-06-19 용마산 evidence).
-        // lock 활성 시는 boardingStationId 기준 origin 알림이 정당이므로 우회 (ADR-014 §4 동급 보장).
-        if (isOriginHopCandidate && !lock) {
-          logSuppressedOriginHopLockless({
+        // #1816 (paradigm shift Phase 1 보강) — lockless trip + 사용자 명시 의향 없음 시 station-passed 차단.
+        // lock=null = boardingPrompt 미응답 + BoardingTrainList 미탭. paradigm shift 정합.
+        // #1514 — origin hop lockless 차단(용마산 evidence)은 본 broad guard의 subset이 되어 하나로 통합.
+        if (!lock) {
+          logSuppressedLocklessNoUserIntent({
             source: 'fg',
             stationName: candidateStation.name,
+            kind: 'station-passed',
           });
           return;
         }
@@ -1186,8 +1181,6 @@ export function useStationAlarm({
           dismissSilence,
           userLocation,
           clearDismissSilenceAction,
-          sleepMode: sleepModeRef.current,
-          currentHopIndex,
           lock,
         });
       })();
@@ -1331,8 +1324,6 @@ export function useStationAlarm({
         dismissSilence,
         userLocation,
         clearDismissSilenceAction,
-        sleepMode: sleepModeRef.current,
-        currentHopIndex,
         lock,
       });
     })();
@@ -1386,6 +1377,16 @@ export function useStationAlarm({
     void (async () => {
       const lock = await getBoardingLock();
       if (cancelled) return;
+      // #1816 (paradigm shift Phase 1 보강) — lockless trip + 사용자 명시 의향 없음 시 subsurface station-passed 차단.
+      // lock=null = boardingPrompt 미응답 + BoardingTrainList 미탭. paradigm shift 정합.
+      if (!lock) {
+        logSuppressedLocklessNoUserIntent({
+          source: 'fg',
+          stationName: candidateStation.name,
+          kind: 'station-passed',
+        });
+        return;
+      }
       // #1572 (T9) — backend SSoT 권위 게이트 (Path C subsurface verdict). subsurface fusion이
       // backend가 이미 결정한 alarmId/stationId를 재발사하는 회귀 차단. dispatch helper 진입 직전 평가.
       // #1572 — 3 path 공통 helper로 통합 (SonarCloud CPD 회피).
@@ -1410,8 +1411,6 @@ export function useStationAlarm({
         dismissSilence,
         userLocation,
         clearDismissSilenceAction,
-        sleepMode: sleepModeRef.current,
-        currentHopIndex,
         lock,
       });
     })();

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -133,6 +133,19 @@ function logClearFailure(e: unknown): void {
 }
 
 /**
+ * #1816 — lockless trip + 사용자 명시 의향 없음 시 station-passed 억제 로그 헬퍼.
+ * fg / fg-subsurface 두 경로에서 동일한 4행 블록이 반복되어 SonarCloud CPD 해소.
+ * lock=null = boardingPrompt 미응답 + BoardingTrainList 미탭.
+ */
+function logSuppressedStationPassedLockless(stationName: string): void {
+  logSuppressedLocklessNoUserIntent({
+    source: 'fg',
+    stationName,
+    kind: 'station-passed',
+  });
+}
+
+/**
  * #917 follow-up — station-passed 알림 dedup → resolve → send → setLast → log 시퀀스 추출.
  * GPS station-passed effect와 FG arvlCd fast-path effect가 동일한 5단 시퀀스를 반복하던 것
  * (Sonar cpd 27/25 line 블록)을 단일 함수로 통합. source 라벨만 다르고 dedup 키는
@@ -1089,9 +1102,6 @@ export function useStationAlarm({
       //   1. currentHopIndex prop (D1 estimator 또는 lock 활성 시 interp 결과 — 호출자가 결정)
       //   2. firedAlarms set 기반 fallback (graceful, false negative risk)
       //   3. 둘 다 부재 + arcStations 없음 → 게이트 미적용 (gate-hop-window-no-source)
-      // #1514 — 출발역(arc[0]) origin hop fire 차단. lock 활성 trip은 boardingStationId 기준
-      // origin 알림이 정당 신호이므로 IIFE 안에서 추가 검사 (lock fetch 후).
-      let isOriginHopCandidate = false;
       if (arcStations && arcStations.length > 0) {
         const effectiveHopIndex =
           currentHopIndex ?? inferHopIndexFromFiredAlarms(firedAlarmsRef.current, arcStations);
@@ -1104,14 +1114,11 @@ export function useStationAlarm({
             logSuppressedHopWindowNoSource({ source: 'fg', stationName: candidateStation.name });
           }
         } else if (isStationWithinHopWindow(candidateStation, arcStations, effectiveHopIndex)) {
-          // hop window 통과 — origin hop 케이스만 추가 표식 (lockless 차단은 IIFE 내부).
+          // hop window 통과 — lockless origin hop 차단은 IIFE 내부의 broad !lock 가드가 담당.
           // #1630 — effectiveHopIndex AND 조건 제거. lockless mode는 estimator(시간 적분)가
           // idx를 임의 진행 — 출발역에 머물러도 idx>=1 정상 산출(2026-06-22 08:34:18 용마산
-          // evidence: estimator idx=1, 사용자는 출발 직후 = X1 위반). candidate가 arc[0]이면
-          // effectiveHopIndex 값과 무관하게 origin hop으로 판정 (ADR-014 §4: 출발역 자체에
-          // station-passed fire는 X1). lock 활성 trip은 line 1042 `!lock` 가드가 별도 차단.
-          const candidateIndex = arcIndexOf(arcStations, candidateStation);
-          isOriginHopCandidate = candidateIndex === 0;
+          // evidence: estimator idx=1, 사용자는 출발 직후 = X1 위반). lock 활성 trip은
+          // boardingStationId 기준 origin 검사를 IIFE lock 가드가 처리.
         } else {
           logSuppressedHopWindow({
             source: 'fg',
@@ -1149,11 +1156,7 @@ export function useStationAlarm({
         // lock=null = boardingPrompt 미응답 + BoardingTrainList 미탭. paradigm shift 정합.
         // #1514 — origin hop lockless 차단(용마산 evidence)은 본 broad guard의 subset이 되어 하나로 통합.
         if (!lock) {
-          logSuppressedLocklessNoUserIntent({
-            source: 'fg',
-            stationName: candidateStation.name,
-            kind: 'station-passed',
-          });
+          logSuppressedStationPassedLockless(candidateStation.name);
           return;
         }
         // #1572 (T9) — backend SSoT 권위 게이트 (Path A). mirror.alarmEvents에 같은 alarmId가
@@ -1380,11 +1383,7 @@ export function useStationAlarm({
       // #1816 (paradigm shift Phase 1 보강) — lockless trip + 사용자 명시 의향 없음 시 subsurface station-passed 차단.
       // lock=null = boardingPrompt 미응답 + BoardingTrainList 미탭. paradigm shift 정합.
       if (!lock) {
-        logSuppressedLocklessNoUserIntent({
-          source: 'fg',
-          stationName: candidateStation.name,
-          kind: 'station-passed',
-        });
+        logSuppressedStationPassedLockless(candidateStation.name);
         return;
       }
       // #1572 (T9) — backend SSoT 권위 게이트 (Path C subsurface verdict). subsurface fusion이

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -61,6 +61,7 @@ import {
   logCrossTripMirrorSkip,
   logSuppressedOriginHopLockless,
   logSuppressedPassedEventOnLockOrigin,
+  logSuppressedLocklessNoUserIntent,
   logSuppressedSsotFireGate,
   logSuppressedTbaRevalidation,
   summarizeAlarmLogBySource,
@@ -985,6 +986,27 @@ describe('alarmLog', () => {
         reason: 'gate-passed-event-on-lock-origin',
         stationName: '용마산',
         kind: 'station-passed',
+      });
+    });
+
+    it('#1816 logSuppressedLocklessNoUserIntent: reason=lockless-no-user-intent + kind/phaseId 보존', async () => {
+      logSuppressedLocklessNoUserIntent({
+        source: 'fg-evaluated',
+        stationName: '한양대',
+        kind: 'transfer',
+        phaseId: 'early',
+      });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fg-evaluated',
+        outcome: 'suppressed',
+        reason: 'lockless-no-user-intent',
+        stationName: '한양대',
+        kind: 'transfer',
+        phaseId: 'early',
       });
     });
 

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -240,7 +240,12 @@ export type AlarmLogReason =
   // #1656 — phase↔phase cross-station 즉시 cascade 윈도우(PHASE_TO_PHASE_CROSS_STATION_WINDOW_MS=3s)
   // 안에서 다른 station에 두 phase 알람(transfer + destination 또는 역방향)이 leg 전환 race로
   // 연이어 발사되는 회귀 차단(2026-06-20 12:32 건대+성수, 2026-06-19 15:37 이수+사당).
-  | 'dedup-phase-to-phase';
+  | 'dedup-phase-to-phase'
+  // #1816 (paradigm shift Phase 1 보강) — lockless trip + 사용자 명시 의향 없음 시 FG device fire 차단.
+  // lock=null + boardingPrompt 미응답 + BoardingTrainList 미탭 = 사용자가 열차 선택 의향을 밝히지 않은 상태.
+  // 이 상태에서 FG fg/fg-phase/subsurface 3 path가 역 통과·환승·도착 알람을 발사하던 회귀 차단.
+  // lock 활성(lock !== null) trip은 fire 허용 — 사용자 명시 의향 = lock 동급 (ADR-010 §1, ADR-014 §B3).
+  | 'lockless-no-user-intent';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -1289,6 +1294,36 @@ export function logSuppressedOriginHopLockless(input: {
     reason: 'gate-origin-hop-lockless',
     stationName: input.stationName,
     kind: 'station-passed',
+  });
+}
+
+/**
+ * #1816 (paradigm shift Phase 1 보강) — lockless trip + 사용자 명시 의향 없음으로 FG device fire 차단.
+ *
+ * lock=null 상태(boardingPrompt 미응답 + BoardingTrainList 미탭)에서 FG 3 path
+ * (GPS station-passed / ETA phase / subsurface verdict)가 역 통과·환승·도착 알람을 발사하던 회귀 차단.
+ * lock 활성(lock !== null) trip은 gate 미통과 — ADR-010 §1, ADR-014 §B3 동급 보장.
+ *
+ * source는 호출 path별로:
+ *   'fg'         : GPS station-passed / subsurface verdict
+ *   'fg-evaluated': ETA phase / API imminent (fireAndLog 내부)
+ *
+ * kind는 호출자가 명시 — station-passed / transfer / destination 분포 측정.
+ */
+export function logSuppressedLocklessNoUserIntent(input: {
+  source: AlarmLogSource;
+  stationName: string;
+  kind: AlarmLogKind;
+  phaseId?: AlarmPhaseId;
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: input.source,
+    outcome: 'suppressed',
+    reason: 'lockless-no-user-intent',
+    stationName: input.stationName,
+    kind: input.kind,
+    phaseId: input.phaseId,
   });
 }
 


### PR DESCRIPTION
## Summary

- Day 1 trip evidence(13:46:17 lockless, boardingPrompt=0): `lock=null` 상태에서 station-passed·transfer·destination FG device fire 3건 발생 — paradigm shift Phase 1 정합 위반
- GPS station-passed / ETA phase / subsurface verdict 3 FG path에 `lock === null → lockless-no-user-intent 차단` 가드 추가
- fg-arvlcd fast-path는 기존 #640 `if (!lock) return` 가드가 이미 차단 중 — 변경 없음

## Changes

| 파일 | 변경 |
|---|---|
| `useStationAlarm.ts` | GPS station-passed IIFE / `fireAndLog` / subsurface verdict IIFE에 `!lock` 가드 추가; `runSilenceGateAndDispatch` dead code(sleep-station-passed) 제거 |
| `alarmLog.ts` | `'lockless-no-user-intent'` reason 추가; `logSuppressedLocklessNoUserIntent` export |
| `useStationAlarm.test.ts` | beforeEach 기본값 `DEFAULT_LOCK` 변경; #1816 acceptance 6개 시나리오 + 기존 lockless 테스트 16건 업데이트 |
| `alarmLog.test.ts` | `logSuppressedLocklessNoUserIntent` 테스트 추가 |

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard** — Alarm Log `reason=lockless-no-user-intent` count → DebugModal Counters section에서 측정. production에서 lockless trip fire 0건 evidence
3. **의존 PR** — #1738 paradigm shift Phase 1 (머지됨)
4. **측정 plan** — 1주 production: Day 1 trip 재현 시 lockless trip fire count = 0 / lock 활성 trip 매역 알림 정상
5. **Device verify** — 실기기 trip 1회(lockless: boardingPrompt/탭 X) → fire 0 확인; lock 탭 후 → 매역 알림 정상

## Test

- `npm test` — 7816 tests, 100% coverage
- `npm run type-check` — pass
- `npm run lint:orphan` — 0 orphan

Closes #1816