### PR TITLE
fix(#1820): backend boarding-prompt GPS-bypass 환경 motion=unknown 허용

### DIFF
--- a/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
+++ b/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
@@ -419,7 +419,7 @@ describe('evaluateBoardingPromptGates — #1536 (S3) 환경 분기', () => {
     if (r.pass) expect(r.fusedSpeedKmh).toBe(0);
   });
 
-  it('underground: motion=stationary 면 #8 게이트로 차단 (motion-not-moving)', () => {
+  it('underground: motion=stationary 면 #8 게이트로 차단 (motion-stationary)', () => {
     const stationary = staleGpsSeries(now).map((p) => ({
       ...p,
       motion: 'stationary' as const,
@@ -432,7 +432,7 @@ describe('evaluateBoardingPromptGates — #1536 (S3) 환경 분기', () => {
       environment: 'underground',
     });
     expect(r.pass).toBe(false);
-    if (!r.pass) expect(r.reason).toBe('motion-not-moving');
+    if (!r.pass) expect(r.reason).toBe('motion-stationary');
   });
 
   it('underground: 이미 fired = already-fired (게이트 #9 우선 평가)', () => {
@@ -503,6 +503,89 @@ describe('evaluateBoardingPromptGates — #1536 (S3) 환경 분기', () => {
     });
     expect(r.pass).toBe(true);
     if (r.pass) expect(r.fusedSpeedKmh).toBeGreaterThan(5);
+  });
+});
+
+/**
+ * #1820 — GPS-bypass 환경(underground/mixed/unknown)에서 motion=unknown 허용.
+ * Day 2 production 36건 evidence: environment=unknown + motion=unknown → 100% 차단 회귀.
+ * 옵션 A: bypass 환경에서 stationary만 차단, walking/automotive/unknown 통과.
+ */
+describe('evaluateBoardingPromptGates — #1820 motion grace (GPS-bypass 환경)', () => {
+  const now = 1_000_000;
+
+  // underground stale GPS series (모든 motion=unknown 로 덮어쓸 것)
+  function unknownMotionSeries(n: number): PositionPoint[] {
+    return staleGpsSeries(n).map((p) => ({ ...p, motion: 'unknown' as const }));
+  }
+
+  it('underground + motion=unknown → pass (warmup grace)', () => {
+    const r = evaluateBoardingPromptGates({
+      series: unknownMotionSeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      environment: 'underground',
+    });
+    expect(r.pass).toBe(true);
+    if (r.pass) expect(r.fusedSpeedKmh).toBe(0);
+  });
+
+  it('underground + motion=stationary → fail (motion-stationary)', () => {
+    const stationary = staleGpsSeries(now).map((p) => ({
+      ...p,
+      motion: 'stationary' as const,
+    }));
+    const r = evaluateBoardingPromptGates({
+      series: stationary,
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      environment: 'underground',
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('motion-stationary');
+  });
+
+  it('underground + motion=walking → pass', () => {
+    const walking = staleGpsSeries(now).map((p) => ({
+      ...p,
+      motion: 'walking' as const,
+    }));
+    const r = evaluateBoardingPromptGates({
+      series: walking,
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      environment: 'underground',
+    });
+    expect(r.pass).toBe(true);
+  });
+
+  it('surface + motion=unknown → fail (motion-not-moving, 기존 정책 유지)', () => {
+    const unknown = happySeries(now).map((p) => ({ ...p, motion: 'unknown' as const }));
+    const r = evaluateBoardingPromptGates({
+      series: unknown,
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      environment: 'surface',
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('motion-not-moving');
+  });
+
+  it('surface + motion=walking → pass (기존 정책 유지)', () => {
+    // happySeries는 이미 motion=automotive이므로 walking으로 교체
+    const walking = happySeries(now).map((p) => ({ ...p, motion: 'walking' as const }));
+    const r = evaluateBoardingPromptGates({
+      series: walking,
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      environment: 'surface',
+    });
+    expect(r.pass).toBe(true);
   });
 });
 

--- a/backend/alarm-worker/src/boardingPrompt.ts
+++ b/backend/alarm-worker/src/boardingPrompt.ts
@@ -64,6 +64,7 @@ export type GateSkipReason =
   | 'direction-mismatch'
   | 'speed-too-low'
   | 'motion-not-moving'
+  | 'motion-stationary'
   | 'silenced'
   | 'already-fired';
 
@@ -225,9 +226,6 @@ export function evaluateBoardingPromptGates(
   const gpsDependentBypass = isGpsDependentBypassEnv(inputs.environment);
 
   // #833 — 호출자가 동일 series/now로 이미 evaluateWindow를 돌렸다면 결과 재사용.
-  // #1536 — series 가 비어 있을 수 있는 지하 환경에서도 metrics 자체는 산출 가능
-  // (count=0). GPS bypass 분기는 motion 평가에 metrics.motion 가 'unknown'(window-too-small의
-  // 자연 결과)이라도 #8 motion 게이트가 자연 차단.
   const metrics = inputs.metrics ?? evaluateWindow(inputs.series, inputs.now);
 
   // surface / undefined 만 GPS 의존 게이트 평가 — underground/mixed/unknown 은 byPass.
@@ -236,11 +234,30 @@ export function evaluateBoardingPromptGates(
     if (geomOutcome) return geomOutcome;
   }
 
-  // #8 — motion ∈ {walking, automotive}. GPS bypass 분기에서도 평가 — CMMotionActivity
-  // 기반 신호는 지하에서도 작동 (mem `lesson_motion_activity_intermittent_signal` 의 5~10분
-  // 주기 뒤집힘 한계는 caller 의 consensusGate 가 arrival+lockAttachable 합의로 보완).
-  if (metrics.motion !== 'walking' && metrics.motion !== 'automotive') {
-    return { pass: false, reason: 'motion-not-moving', metrics };
+  // #8 — motion 게이트. 환경에 따라 정책이 다르다.
+  //
+  // GPS-bypass 환경(underground/mixed/unknown):
+  //   iOS CMMotionActivity는 trip 시작 직후 5~10분 lag으로 unknown 상태가 normal.
+  //   지하에서는 walking/automotive 수렴까지 시간이 더 필요하므로 unknown 허용.
+  //   단, count=0(series 완전 비어 있음)은 "warmup lag"이 아닌 "데이터 전무" — window-too-small로 차단.
+  //   stationary만 차단 — 이동 중 아님이 확실한 경우만.
+  //   caller consensusGate(arrival+lockAttachable 2-of-2)가 false positive를 추가 차단.
+  //   (#1820: Day 2 production 36건 evidence — environment=unknown + motion=unknown 100% 차단)
+  //
+  // GPS 환경(surface/undefined):
+  //   기존 정책 유지 — walking/automotive만 통과.
+  if (gpsDependentBypass) {
+    if (metrics.count === 0) {
+      return { pass: false, reason: 'window-too-small', metrics };
+    }
+    if (metrics.motion === 'stationary') {
+      return { pass: false, reason: 'motion-stationary', metrics };
+    }
+    // walking / automotive / unknown 모두 통과
+  } else {
+    if (metrics.motion !== 'walking' && metrics.motion !== 'automotive') {
+      return { pass: false, reason: 'motion-not-moving', metrics };
+    }
   }
 
   // #7 — fused speed. GPS bypass 분기는 fusedSpeed 산출 자체가 의미 없어 0 으로 표기.


### PR DESCRIPTION
## 요약

- **문제**: backend boarding-prompt cron이 GPS-bypass 환경(underground/mixed/unknown)에서 `motion=unknown`을 100% 차단. Day 2 production에서 36건 evidence (KST 14:19~14:23, environment=unknown + motion=unknown 조합).
- **원인**: iOS CMMotionActivity trip 시작 직후 5~10분 lag → `unknown` 상태가 정상인데 기존 게이트가 `walking/automotive`만 허용.
- **fix**: GPS-bypass 환경에서 `stationary`만 차단, `walking/automotive/unknown` 통과. `count=0`(series 완전 비어 있음)은 "warmup lag"이 아닌 데이터 전무이므로 `window-too-small` 차단 유지.

## 변경 파일

- `backend/alarm-worker/src/boardingPrompt.ts`
  - `GateSkipReason`에 `'motion-stationary'` 추가
  - `#8 motion 게이트`를 환경 분기로 교체 (~10 LOC)
- `backend/alarm-worker/src/__tests__/boardingPrompt.test.ts`
  - 기존 `underground + stationary` reason `motion-not-moving` → `motion-stationary` 갱신
  - `#1820 acceptance 5건` 추가

## Wire-completion 5단 체크

1. **Orphan 없음** — 기존 함수 내 분기 추가만. 신규 export 없음. `npm run lint:orphan` 0건 확인.
2. **V/X dashboard** — `boarding-prompt: gate blocked` reason 분포를 wrangler tail / Cloudflare Dashboard로 관측. `motion-not-moving + environment=unknown` 차단이 0건으로 수렴하는지 1주 측정.
3. **의존 PR** — N/A. 잔여 #2(environment 분류 회복)와 독립적으로 동작.
4. **측정 plan** — production cron 1주, `reason=motion-not-moving + environment=unknown` 차단 0건 수렴 확인. 잔여 #2 fix 후 bypass 환경 자체가 줄어들며 자연 정상화.
5. **Device verify** — N/A — backend type+unit only.

## 테스트

```
Tests  2157 passed (2157)
```

- `npm run type-check` 통과
- `npm run lint:orphan` 0건

Closes #1820