### PR TITLE
fix(#1821): underground consensus warmup quorum + environment unknown_warmup label

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -1018,8 +1018,8 @@ function buildEnvironmentDistributionSection(args: BuildDumpArgs): string[] {
   const pct = snap.percentages;
   const t = snap.totals;
   return [
-    `surface=${formatPercentage(pct.surface)} underground=${formatPercentage(pct.underground)} hybrid=${formatPercentage(pct.hybrid)} unknown=${formatPercentage(pct.unknown)}`,
-    `totals: surface=${formatDurationMs(t.surface)} underground=${formatDurationMs(t.underground)} hybrid=${formatDurationMs(t.hybrid)} unknown=${formatDurationMs(t.unknown)}`,
+    `surface=${formatPercentage(pct.surface)} underground=${formatPercentage(pct.underground)} hybrid=${formatPercentage(pct.hybrid)} unknown=${formatPercentage(pct.unknown)} unknown_warmup=${formatPercentage(pct.unknown_warmup)}`,
+    `totals: surface=${formatDurationMs(t.surface)} underground=${formatDurationMs(t.underground)} hybrid=${formatDurationMs(t.hybrid)} unknown=${formatDurationMs(t.unknown)} unknown_warmup=${formatDurationMs(t.unknown_warmup)}`,
     `transitions=${snap.transitions}`,
     `observed=${formatDurationMs(snap.observedMs)}`,
   ];
@@ -1046,19 +1046,24 @@ function formatDurationMs(ms: number): string {
   return `${minutes}m${seconds}s`;
 }
 
+/** Warmup 윈도우 ms (#1821) — unknown 분류 시 60s 이내는 unknown_warmup으로 표기. */
+const ENV_WARMUP_WINDOW_MS = 60_000;
+
 /**
  * #1430 — SSOT 활성 cascade로 환경 state 결정. PR #1427의 `surfaceSSOTActive`/`undergroundSSOTActive`를
  * 그대로 입력으로 받아 1줄로 분류.
+ * #1821 — unknown 구간이 observedMs < 60s이면 'unknown_warmup'으로 분류 (가시화만, 분류 변경 없음).
  */
 function deriveEnvironmentState(input: {
   readonly surfaceSSOTActive: boolean;
   readonly undergroundSSOTActive: boolean;
+  readonly observedMs: number;
 }): EnvironmentDistributionState {
-  const { surfaceSSOTActive, undergroundSSOTActive } = input;
+  const { surfaceSSOTActive, undergroundSSOTActive, observedMs } = input;
   if (surfaceSSOTActive && undergroundSSOTActive) return 'hybrid';
   if (surfaceSSOTActive) return 'surface';
   if (undergroundSSOTActive) return 'underground';
-  return 'unknown';
+  return observedMs < ENV_WARMUP_WINDOW_MS ? 'unknown_warmup' : 'unknown';
 }
 
 /**
@@ -1071,9 +1076,12 @@ function buildEnvironmentDistributionMeta(input: {
   readonly counter: ReturnType<typeof createEnvironmentDistributionCounter>;
   readonly nowMs: number;
 }): EnvironmentDistributionSnapshot {
+  // observedMs는 현재 snapshot 기준 시간 기준 — tick 전 현재값 산출로 unknown_warmup 판정.
+  const currentObservedMs = input.counter.snapshot(input.nowMs).observedMs;
   const state = deriveEnvironmentState({
     surfaceSSOTActive: input.surfaceSSOTActive,
     undergroundSSOTActive: input.undergroundSSOTActive,
+    observedMs: currentObservedMs,
   });
   input.counter.tick(state, input.nowMs);
   return input.counter.snapshot(input.nowMs);

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -3634,10 +3634,13 @@ describe('DebugModal helpers — #1430 environment distribution', () => {
 
   describe('deriveEnvironmentState', () => {
     it.each([
-      [{ surfaceSSOTActive: true, undergroundSSOTActive: true }, 'hybrid'],
-      [{ surfaceSSOTActive: true, undergroundSSOTActive: false }, 'surface'],
-      [{ surfaceSSOTActive: false, undergroundSSOTActive: true }, 'underground'],
-      [{ surfaceSSOTActive: false, undergroundSSOTActive: false }, 'unknown'],
+      [{ surfaceSSOTActive: true, undergroundSSOTActive: true, observedMs: 0 }, 'hybrid'],
+      [{ surfaceSSOTActive: true, undergroundSSOTActive: false, observedMs: 0 }, 'surface'],
+      [{ surfaceSSOTActive: false, undergroundSSOTActive: true, observedMs: 0 }, 'underground'],
+      // observedMs < 60s → unknown_warmup (#1821)
+      [{ surfaceSSOTActive: false, undergroundSSOTActive: false, observedMs: 30_000 }, 'unknown_warmup'],
+      // observedMs >= 60s → unknown
+      [{ surfaceSSOTActive: false, undergroundSSOTActive: false, observedMs: 60_000 }, 'unknown'],
     ] as const)('%j → %p', (input, expected) => {
       expect(deriveEnvironmentState(input)).toBe(expected);
     });
@@ -3710,14 +3713,14 @@ describe('DebugModal buildDumpText — #1430 Environment Distribution 섹션', (
     {
       name: 'observedMs=0 + 빈 totals → 모든 state 0.0% + observed=0s',
       envDistribution: {
-        totals: { surface: 0, underground: 0, hybrid: 0, unknown: 0 },
-        percentages: { surface: 0, underground: 0, hybrid: 0, unknown: 0 },
+        totals: { surface: 0, underground: 0, hybrid: 0, unknown: 0, unknown_warmup: 0 },
+        percentages: { surface: 0, underground: 0, hybrid: 0, unknown: 0, unknown_warmup: 0 },
         transitions: 0,
         observedMs: 0,
       },
       contains: [
-        'surface=0.0% underground=0.0% hybrid=0.0% unknown=0.0%',
-        'totals: surface=0s underground=0s hybrid=0s unknown=0s',
+        'surface=0.0% underground=0.0% hybrid=0.0% unknown=0.0% unknown_warmup=0.0%',
+        'totals: surface=0s underground=0s hybrid=0s unknown=0s unknown_warmup=0s',
         'transitions=0',
         'observed=0s',
       ],
@@ -3730,14 +3733,15 @@ describe('DebugModal buildDumpText — #1430 Environment Distribution 섹션', (
           underground: 5 * 60_000 + 24_000, // 5m24s
           hybrid: 58_000, // 58s
           unknown: 10 * 60_000 + 54_000, // 10m54s
+          unknown_warmup: 0,
         },
-        percentages: { surface: 42.3, underground: 18.1, hybrid: 3.2, unknown: 36.4 },
+        percentages: { surface: 42.3, underground: 18.1, hybrid: 3.2, unknown: 36.4, unknown_warmup: 0 },
         transitions: 5,
         observedMs: 30 * 60_000 + 46_000, // 30m46s
       },
       contains: [
-        'surface=42.3% underground=18.1% hybrid=3.2% unknown=36.4%',
-        'totals: surface=12m30s underground=5m24s hybrid=58s unknown=10m54s',
+        'surface=42.3% underground=18.1% hybrid=3.2% unknown=36.4% unknown_warmup=0.0%',
+        'totals: surface=12m30s underground=5m24s hybrid=58s unknown=10m54s unknown_warmup=0s',
         'transitions=5',
         'observed=30m46s',
       ],
@@ -3745,12 +3749,12 @@ describe('DebugModal buildDumpText — #1430 Environment Distribution 섹션', (
     {
       name: 'surface 100% 단일 state → 다른 state 0.0%',
       envDistribution: {
-        totals: { surface: 60_000, underground: 0, hybrid: 0, unknown: 0 },
-        percentages: { surface: 100, underground: 0, hybrid: 0, unknown: 0 },
+        totals: { surface: 60_000, underground: 0, hybrid: 0, unknown: 0, unknown_warmup: 0 },
+        percentages: { surface: 100, underground: 0, hybrid: 0, unknown: 0, unknown_warmup: 0 },
         transitions: 0,
         observedMs: 60_000,
       },
-      contains: ['surface=100.0% underground=0.0% hybrid=0.0% unknown=0.0%', 'transitions=0'],
+      contains: ['surface=100.0% underground=0.0% hybrid=0.0% unknown=0.0% unknown_warmup=0.0%', 'transitions=0'],
     },
   ])('$name', ({ envDistribution, contains }) => {
     const section = dumpEnvSection(envDistribution);

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -1281,6 +1281,9 @@ export function useFusedNearestStation(
     // #1542 (ADR-016 S9) — accelerometer fingerprint env vote. 'automotive' = train 진동 1표,
     // 'stationary'/'walking'/'unknown'은 vote 미투표. 미지원/warmup 60s 동안 'unknown' fallback.
     accelerometerPattern,
+    // #1821 — warmup quorum 완화: trip 시작 후 60s 이내 station pair 단독 채택 허용.
+    // lock 활성 시 boardedAt 사용. lockless는 locklessTripStartRef 선언 이후 별도 처리.
+    tripStartedAt: boardingLock?.boardedAt,
   });
   const environment: Environment = inferEnvironment({
     subsurface: barometerSubsurface,

--- a/src/features/nearest-station/utils/__tests__/environmentDistributionCounter.test.ts
+++ b/src/features/nearest-station/utils/__tests__/environmentDistributionCounter.test.ts
@@ -2,6 +2,7 @@
  * #1430 — 환경 분포 측정 인프라 단위 테스트.
  *
  * State 4종 누적 정확성 + 전환 카운트 + 진행분 포함 snapshot + observedMs=0 시 percentage 0%.
+ * #1821 — unknown_warmup state 추가 테스트.
  */
 
 import {
@@ -15,8 +16,8 @@ describe('createEnvironmentDistributionCounter', () => {
   it('첫 snapshot은 totals/transitions/observedMs 모두 0', () => {
     const counter = createEnvironmentDistributionCounter();
     const snap = counter.snapshot(T0);
-    expect(snap.totals).toEqual({ surface: 0, underground: 0, hybrid: 0, unknown: 0 });
-    expect(snap.percentages).toEqual({ surface: 0, underground: 0, hybrid: 0, unknown: 0 });
+    expect(snap.totals).toEqual({ surface: 0, underground: 0, hybrid: 0, unknown: 0, unknown_warmup: 0 });
+    expect(snap.percentages).toEqual({ surface: 0, underground: 0, hybrid: 0, unknown: 0, unknown_warmup: 0 });
     expect(snap.transitions).toBe(0);
     expect(snap.observedMs).toBe(0);
   });
@@ -169,14 +170,60 @@ describe('createEnvironmentDistributionCounter', () => {
     const counter = createEnvironmentDistributionCounter();
     counter.tick('surface', T0);
     const snap: EnvironmentDistributionSnapshot = counter.snapshot(T0 + 1000);
-    // 컴파일 타임 타입 보장 + 런타임 키 존재 확인.
+    // 컴파일 타임 타입 보장 + 런타임 키 존재 확인 (#1821: unknown_warmup 포함).
     expect(Object.keys(snap.totals).sort((a, b) => a.localeCompare(b))).toEqual(
-      ['hybrid', 'surface', 'underground', 'unknown'],
+      ['hybrid', 'surface', 'underground', 'unknown', 'unknown_warmup'],
     );
     expect(Object.keys(snap.percentages).sort((a, b) => a.localeCompare(b))).toEqual(
-      ['hybrid', 'surface', 'underground', 'unknown'],
+      ['hybrid', 'surface', 'underground', 'unknown', 'unknown_warmup'],
     );
     expect(typeof snap.transitions).toBe('number');
     expect(typeof snap.observedMs).toBe('number');
+  });
+});
+
+describe('createEnvironmentDistributionCounter — unknown_warmup (#1821)', () => {
+  it('unknown_warmup state 누적', () => {
+    const counter = createEnvironmentDistributionCounter();
+    counter.tick('unknown_warmup', T0);
+    counter.tick('unknown_warmup', T0 + 5000);
+    const snap = counter.snapshot(T0 + 5000);
+    expect(snap.totals.unknown_warmup).toBe(5000);
+    expect(snap.totals.unknown).toBe(0);
+    expect(snap.observedMs).toBe(5000);
+  });
+
+  it('unknown_warmup → unknown 전환 시 transitions++', () => {
+    const counter = createEnvironmentDistributionCounter();
+    counter.tick('unknown_warmup', T0);
+    counter.tick('unknown', T0 + 30_000); // 30s warmup 누적
+    counter.tick('underground', T0 + 60_000); // unknown 30s 누적
+    const snap = counter.snapshot(T0 + 60_000);
+    expect(snap.totals.unknown_warmup).toBe(30_000);
+    expect(snap.totals.unknown).toBe(30_000);
+    expect(snap.transitions).toBe(2);
+  });
+
+  it('unknown_warmup percentage 합산에 포함', () => {
+    const counter = createEnvironmentDistributionCounter();
+    counter.tick('unknown_warmup', T0);
+    counter.tick('unknown', T0 + 5000); // unknown_warmup 5000ms
+    const snap = counter.snapshot(T0 + 10_000); // unknown 5000ms
+    expect(snap.percentages.unknown_warmup).toBeCloseTo(50, 5);
+    expect(snap.percentages.unknown).toBeCloseTo(50, 5);
+    const total =
+      snap.percentages.surface +
+      snap.percentages.underground +
+      snap.percentages.hybrid +
+      snap.percentages.unknown +
+      snap.percentages.unknown_warmup;
+    expect(total).toBeCloseTo(100, 5);
+  });
+
+  it('unknown_warmup 초기값 0', () => {
+    const counter = createEnvironmentDistributionCounter();
+    const snap = counter.snapshot(T0);
+    expect(snap.totals.unknown_warmup).toBe(0);
+    expect(snap.percentages.unknown_warmup).toBe(0);
   });
 });

--- a/src/features/nearest-station/utils/__tests__/undergroundSSotConsensus.test.ts
+++ b/src/features/nearest-station/utils/__tests__/undergroundSSotConsensus.test.ts
@@ -6,6 +6,10 @@
  *   - station pair ≥ 1 + (station pair + env vote) ≥ 2 통과 시 채택
  *   - cellular surface vote → reject (환경 확정 모순)
  *   - station 우선순위: position > wifi
+ * #1821 — warmup quorum 완화:
+ *   - trip 시작 후 60s 이내 + station pair 1개 → underground 채택 (quorum=1)
+ *   - 60s 이후 + station pair 1개 → null (steady quorum=2)
+ *   - 60s 이내 + env vote 1개만 (station pair 0) → null (station pair ≥ 1 필수)
  */
 
 import { undergroundSSOTConsensus } from '../undergroundSSotConsensus';
@@ -316,5 +320,117 @@ describe('undergroundSSOTConsensus — accelerometer fingerprint (#1542 ADR-016 
       arrival: arrivalLine2,
     });
     expect(result?.station.id).toBe(positionTrain.station.id);
+  });
+});
+
+describe('undergroundSSOTConsensus — warmup quorum (#1821)', () => {
+  const NOW = 1_750_000_000_000;
+  const WARMUP_START = NOW - 30_000; // trip 시작 30s 전 → 아직 warmup 60s 이내
+  const STEADY_START = NOW - 90_000; // trip 시작 90s 전 → steady 모드
+
+  it('warmup 60s 이내 + station pair 1개 → underground 채택 (quorum=1)', () => {
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    const result = undergroundSSOTConsensus(
+      {
+        wifiStation: null,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine2,
+        tripStartedAt: WARMUP_START,
+      },
+      NOW,
+    );
+    expect(result?.station.id).toBe(positionTrain.station.id);
+    expect(result?.trainCode).toBe('T1');
+  });
+
+  it('warmup 60s 이내 + WiFi station pair 단독 → underground 채택', () => {
+    const wifi = MOCK_STATIONS.gangnam;
+    const result = undergroundSSOTConsensus(
+      {
+        wifiStation: wifi,
+        positionTrainResult: null,
+        arrival: arrivalLine2,
+        tripStartedAt: WARMUP_START,
+      },
+      NOW,
+    );
+    expect(result?.station.id).toBe(wifi.id);
+  });
+
+  it('steady 60s 이후 + station pair 1개 → null (quorum=2 미달)', () => {
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    expect(
+      undergroundSSOTConsensus(
+        {
+          wifiStation: null,
+          positionTrainResult: positionTrain,
+          arrival: arrivalLine2,
+          tripStartedAt: STEADY_START,
+        },
+        NOW,
+      ),
+    ).toBeNull();
+  });
+
+  it('warmup 이내 + env vote 1개만 (station pair 0) → null (station pair ≥ 1 필수)', () => {
+    expect(
+      undergroundSSOTConsensus(
+        {
+          wifiStation: null,
+          positionTrainResult: null,
+          arrival: arrivalLine2,
+          barometerStop: true,
+          tripStartedAt: WARMUP_START,
+        },
+        NOW,
+      ),
+    ).toBeNull();
+  });
+
+  it('tripStartedAt undefined (미탑승) → steady quorum=2 적용', () => {
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    // station pair 1개만, env vote 0 → steady quorum=2 미달 → null
+    expect(
+      undergroundSSOTConsensus(
+        {
+          wifiStation: null,
+          positionTrainResult: positionTrain,
+          arrival: arrivalLine2,
+        },
+        NOW,
+      ),
+    ).toBeNull();
+  });
+
+  it('warmup 경계 정확히 60s → steady 전환 (quorum=2)', () => {
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    const exactBoundary = NOW - 60_000; // exactly 60s elapsed → NOT warmup
+    expect(
+      undergroundSSOTConsensus(
+        {
+          wifiStation: null,
+          positionTrainResult: positionTrain,
+          arrival: arrivalLine2,
+          tripStartedAt: exactBoundary,
+        },
+        NOW,
+      ),
+    ).toBeNull();
+  });
+
+  it('warmup + cellular surface → reject (환경 확정 모순이 warmup보다 우선)', () => {
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    expect(
+      undergroundSSOTConsensus(
+        {
+          wifiStation: null,
+          positionTrainResult: positionTrain,
+          arrival: arrivalLine2,
+          cellularEnvironmentVote: 'surface',
+          tripStartedAt: WARMUP_START,
+        },
+        NOW,
+      ),
+    ).toBeNull();
   });
 });

--- a/src/features/nearest-station/utils/environmentDistributionCounter.ts
+++ b/src/features/nearest-station/utils/environmentDistributionCounter.ts
@@ -1,20 +1,20 @@
 /**
  * #1430 — 환경 분포 측정 인프라. 동작 변경 0: 측정만.
  *
- * Time-based counter — state(`surface` | `underground` | `hybrid` | `unknown`)별 누적 ms를
- * 적분한다. Tier 1 surface/underground SSOT 합의 활성 여부를 기반으로 호출자가 매 render time
- * tick을 push, snapshot은 dump 시 한 번씩 조회.
+ * Time-based counter — state(`surface` | `underground` | `hybrid` | `unknown` | `unknown_warmup`)별
+ * 누적 ms를 적분한다. Tier 1 surface/underground SSOT 합의 활성 여부를 기반으로 호출자가 매 render
+ * time tick을 push, snapshot은 dump 시 한 번씩 조회.
  *
  * 환경 결정 정책 (호출자가 결정 후 tick 인자로 전달):
  *   - surfaceSSOTActive && undergroundSSOTActive → 'hybrid'
  *   - surfaceSSOTActive only                     → 'surface'
  *   - undergroundSSOTActive only                 → 'underground'
- *   - 둘 다 미합의                                 → 'unknown'
+ *   - 둘 다 미합의 + observedMs < 60s             → 'unknown_warmup' (#1821)
+ *   - 둘 다 미합의 + observedMs ≥ 60s             → 'unknown'
  *
  * Transition 정책:
  *   - 동일 state 연속 tick: 누적만, transitions 증가 X.
- *   - 다른 state로 전환: transitions++ (`unknown` 경유 포함). 단순 정책 — barometer warmup
- *     일시 unknown으로 inflate 가능성이 있으나 별도 카운트 분리는 후속 작업.
+ *   - 다른 state로 전환: transitions++ (`unknown`/`unknown_warmup` 경유 포함). 단순 정책.
  *
  * 메모리: 모달 인스턴스마다 1개. 관찰자 효과 최소화를 위해 모달이 열려있는 동안만 동작.
  *
@@ -25,7 +25,12 @@ export type EnvironmentDistributionState =
   | 'surface'
   | 'underground'
   | 'hybrid'
-  | 'unknown';
+  | 'unknown'
+  /**
+   * #1821 — trip 시작 후 60s 이내 unknown 구간. "warmup 중"과 "진짜 unknown"을 caller가 구분
+   * 가능하게 한다. backend boardingPrompt 게이트가 warmup grace 적용 가능.
+   */
+  | 'unknown_warmup';
 
 export interface EnvironmentDistributionSnapshot {
   /** state별 누적 ms (snapshot 시점 진행분 포함). */
@@ -50,10 +55,11 @@ const ALL_STATES: readonly EnvironmentDistributionState[] = [
   'underground',
   'hybrid',
   'unknown',
+  'unknown_warmup',
 ];
 
 function emptyTotals(): Record<EnvironmentDistributionState, number> {
-  return { surface: 0, underground: 0, hybrid: 0, unknown: 0 };
+  return { surface: 0, underground: 0, hybrid: 0, unknown: 0, unknown_warmup: 0 };
 }
 
 function computePercentages(
@@ -61,7 +67,7 @@ function computePercentages(
   observedMs: number,
 ): Record<EnvironmentDistributionState, number> {
   if (observedMs <= 0) {
-    return { surface: 0, underground: 0, hybrid: 0, unknown: 0 };
+    return emptyTotals();
   }
   const pct = emptyTotals();
   for (const state of ALL_STATES) {
@@ -104,11 +110,8 @@ export function createEnvironmentDistributionCounter(): EnvironmentDistributionC
       if (currentState !== null && lastTickMs !== null && nowMs > lastTickMs) {
         snapshotTotals[currentState] += nowMs - lastTickMs;
       }
-      const observedMs =
-        snapshotTotals.surface +
-        snapshotTotals.underground +
-        snapshotTotals.hybrid +
-        snapshotTotals.unknown;
+      let observedMs = 0;
+      for (const state of ALL_STATES) observedMs += snapshotTotals[state];
       return {
         totals: snapshotTotals,
         percentages: computePercentages(snapshotTotals, observedMs),

--- a/src/features/nearest-station/utils/undergroundSSotConsensus.ts
+++ b/src/features/nearest-station/utils/undergroundSSotConsensus.ts
@@ -43,8 +43,16 @@ import type { AccelerometerPattern } from './accelerometerFingerprint';
 /** arvlCd "정착한 위치 보고" 코드 집합. surfaceSSotConsensus와 동일 — 향후 공용 추출 여지. */
 const ARVL_CD_STATIONARY = new Set<number>([1, 2, 3, 5]);
 
-/** 2-of-N quorum 임계 — 4 input 중 2개 이상 통과 시 합의 채택. */
+/** 2-of-N quorum 임계 — trip 안정화(60s 이후) 기본 임계. */
 const CONSENSUS_QUORUM = 2;
+/**
+ * Warmup quorum — trip 시작 후 60s 이내 완화 임계.
+ * station pair 단독 1개로 underground 채택 허용.
+ * 이유: BG 첫 60s는 WiFi nil + arrival 미수렴 + barometer 미정착 상태로 quorum 달성 불가 → unknown 고착.
+ */
+const CONSENSUS_QUORUM_WARMUP = 1;
+/** Warmup 윈도우 ms. */
+const WARMUP_WINDOW_MS = 60_000;
 
 export interface UndergroundSSOTInput {
   /** useWifiStation 매칭 결과. null이면 SSID 미매칭(또는 BG nil). */
@@ -75,6 +83,12 @@ export interface UndergroundSSOTInput {
    * iOS BG에서도 동작 (Background Location piggyback으로 raw 가속도 수신).
    */
   accelerometerPattern?: AccelerometerPattern | undefined;
+  /**
+   * #1821 — trip 시작 Unix ms 타임스탬프. undefined이면 warmup 완화 미적용(steady 모드).
+   * 첫 60s(WARMUP_WINDOW_MS) 이내 → CONSENSUS_QUORUM_WARMUP(1) 적용.
+   * 60s 이후 또는 미전달 → CONSENSUS_QUORUM(2) 기본 임계 적용.
+   */
+  tripStartedAt?: number | undefined;
 }
 
 export interface UndergroundSSOT {
@@ -97,7 +111,10 @@ function findStationaryTrain(
   return null;
 }
 
-export function undergroundSSOTConsensus(input: UndergroundSSOTInput): UndergroundSSOT | null {
+export function undergroundSSOTConsensus(
+  input: UndergroundSSOTInput,
+  nowMs: number = Date.now(),
+): UndergroundSSOT | null {
   const {
     wifiStation,
     positionTrainResult,
@@ -105,6 +122,7 @@ export function undergroundSSOTConsensus(input: UndergroundSSOTInput): Undergrou
     barometerStop,
     cellularEnvironmentVote,
     accelerometerPattern,
+    tripStartedAt,
   } = input;
 
   // 환경 확정 모순 — cellular가 surface면 underground SSOT 자체 candidate X.
@@ -131,9 +149,15 @@ export function undergroundSSOTConsensus(input: UndergroundSSOTInput): Undergrou
   if (cellularEnvironmentVote === 'underground') envVotes += 1;
   if (accelerometerPattern === 'automotive') envVotes += 1;
 
-  // 2-of-N quorum. station pair ≥ 1 필수 (env vote만으로는 station 채택 불가).
+  // Station pair ≥ 1 필수 (env vote만으로는 station 채택 불가).
   if (stationPairs.length === 0) return null;
-  if (stationPairs.length + envVotes < CONSENSUS_QUORUM) return null;
+
+  // Warmup 60s 이내 → quorum=1 (station pair 단독 채택 허용). 60s 이후 → steady quorum=2.
+  const isWarmup =
+    tripStartedAt !== undefined && nowMs - tripStartedAt < WARMUP_WINDOW_MS;
+  const quorum = isWarmup ? CONSENSUS_QUORUM_WARMUP : CONSENSUS_QUORUM;
+
+  if (stationPairs.length + envVotes < quorum) return null;
 
   // station 채택: position-train > wifi (stationPairs는 우선순위 순서로 push됨).
   return stationPairs[0];


### PR DESCRIPTION
## Summary

- `undergroundSSOTConsensus`: trip 시작 후 60s 이내 `CONSENSUS_QUORUM_WARMUP=1` 적용 — station pair 단독 1개로 underground 채택 허용. 60s 이후 기존 steady quorum=2 유지.
- `environmentDistributionCounter`: `EnvironmentDistributionState`에 `'unknown_warmup'` 추가 — observedMs < 60s 구간 unknown을 `unknown_warmup`으로 분류 (분류 로직 변경 없음, 가시화 전용).
- `useFusedNearestStation`: `undergroundSSOTConsensus` 호출에 `boardingLock?.boardedAt` 전달 (lock 활성 trip warmup cover).
- `DebugModal`: `deriveEnvironmentState`에 `observedMs` 추가, `buildEnvironmentDistributionSection` dump에 `unknown_warmup` 컬럼 추가.

Closes #1821

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` → 0 orphan. 신규 export 없음 (기존 함수 signature 확장).
2. **V/X dashboard** — DebugModal Environment Distribution 섹션에 `unknown_warmup` 컬럼 추가. dump 공유 시 warmup 구간 가시화 가능.
3. **의존 PR** — N/A. 독립 머지 가능 (잔여 회귀 #1 fix와 시너지지만 순서 무관).
4. **측정 plan** — production 1주: DebugModal dump에서 `underground > 0.0%` 회복 + `unknown_warmup` 구간이 60s 이후 `unknown` 또는 `underground`로 전환 확인.
5. **Device verify** — 실기기 지하 trip 1건 필수. 특히 trip 시작 직후 60s 이내에 DebugModal Environment Distribution에서 `underground` 비율이 올라오는지 확인.

## 변경 범위

| 파일 | 변경 내용 |
|---|---|
| `undergroundSSotConsensus.ts` | `CONSENSUS_QUORUM_WARMUP=1`, `WARMUP_WINDOW_MS=60_000` 추가. `tripStartedAt?` input 파라미터. quorum 분기 로직. |
| `environmentDistributionCounter.ts` | `'unknown_warmup'` state 추가. `ALL_STATES` 확장. `observedMs` 계산을 `ALL_STATES` 순회로 일반화. |
| `useFusedNearestStation.ts` | `tripStartedAt: boardingLock?.boardedAt` 전달. |
| `DebugModal.tsx` | `ENV_WARMUP_WINDOW_MS` 상수. `deriveEnvironmentState` `observedMs` 파라미터. dump 출력에 `unknown_warmup` 컬럼. |

## Follow-up audit (PR 본문 Future Work)

- **Option B (cellular 단독)**: `cellularTech.ts` 5G/LTE 신뢰성 — 5G NSA 환경에서 `underground` vote 오분류 가능성 별도 audit 필요.
- **Option D (barometer 임계 완화)**: `BAROMETER_SUBSURFACE_DP_THRESHOLD_HPA` 0.3 → 0.15 hPa — 천층 진입 시점 효과 vs 엘리베이터 false positive 트레이드오프, 1주 측정 후 결정.
- **environmentDistributionCounter observed window**: dump `observed=7s`가 왜 35분 trip에서 7s만 측정됐는지 — 모달이 열려있는 동안만 동작하는 설계 vs trip 전체 누적 필요성 별도 이슈 검토.
- **lockless trip warmup**: `locklessTripStartRef` 선언 순서 제약으로 lockless trip에서 `tripStartedAt` 미전달. lock 활성 trip만 커버. lockless warmup은 후속 refactor 필요.