### PR TITLE
fix(#1824): Seoul API outage 시 lock-active trip schedule-hop LA fallback 보강

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1116,6 +1116,47 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
     expect(stats.pushed).toBe(0);
   });
 
+  it('#1824 Seoul outage(arrivals+positions 모두 empty) → scheduleEtaFallback 증가 + consecutiveEtaMissing 증가 (auto-end 로직 보존)', async () => {
+    // Seoul API outage 시: arrivals 빈 응답 + positions 빈 응답 → schedule-hop fallback.
+    // scheduleEtaFallback stat 증가 + etaMissing 증가 (auto-end 로직 보존).
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: makeOkFetch() as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p1824',
+    });
+    // schedule-hop fallback 발동 확인.
+    expect(stats.scheduleEtaFallback).toBe(1);
+    // consecutiveEtaMissing은 기존대로 증가 (auto-end 보존).
+    expect(stats.etaMissing).toBe(1);
+  });
+
+  it('#1824 Seoul outage + LA live trip → schedule-hop LA heartbeat 발사', async () => {
+    // LA live trip에서 Seoul outage → schedule-hop ETA로 LA heartbeat 발사.
+    const kv = new InMemoryKV();
+    // makeLockedLaTrip: 2호선 강남 lock + activityPushToken + activityState='live'.
+    await putTrip(kv as unknown as KVNamespace, makeLockedLaTrip());
+    const apnsFetch = makeOkFetch();
+    const stats = await runLaScheduled(kv, {
+      // arrivals + positions 모두 empty (Seoul outage 시뮬레이션).
+      seoul: new SeoulArrivalClient({
+        apiKey: 'K', host: 'h', now: () => NOW,
+        fetchImpl: (async () =>
+          new Response(JSON.stringify({ realtimeArrivalList: [], realtimePositionList: [] }), { status: 200 })
+        ) as unknown as typeof fetch,
+      }),
+      fetchImpl: apnsFetch,
+    });
+    // LA heartbeat 발사 확인.
+    expect(stats.laPushSent).toBe(1);
+    // schedule-hop fallback 발동 확인.
+    expect(stats.scheduleEtaFallback).toBe(1);
+  });
+
   // #706 — 운행 시간대 외(새벽 등)에 trainCode가 사라지면 trip이 무한 폴링됐던 회귀 방지.
   // 연속 etaMissing 카운트 + 임계 초과 시 cleanupTripWithLa로 자동 종료.
   describe('#706 consecutiveEtaMissing auto-end', () => {
@@ -5131,6 +5172,28 @@ describe('estimateBoardingLockArrival arvlCd exposure (#917 A2)', () => {
     expect(result?.arvlCd).toBeNull();
     expect(result?.arrived).toBe(true);
   });
+
+  it('#1824 arrivals + positions 모두 훈련 코드 없음 → null 반환 (schedule-hop은 runTrainCodeTracking 레벨에서 처리)', async () => {
+    // Seoul API outage 시: arrivals 빈 응답 + positions 빈 응답 → estimateBoardingLockArrival은 null.
+    // schedule-hop ETA 발사는 runTrainCodeTracking에서 stats.scheduleEtaFallback 누적과 함께 처리됨.
+    const emptySeoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () =>
+        new Response(
+          JSON.stringify({ realtimeArrivalList: [], realtimePositionList: [] }),
+          { status: 200 },
+        )) as unknown as typeof fetch,
+    });
+    const result = await estimateBoardingLockArrival(
+      makeArrivalDeps(emptySeoul),
+      lock,
+      waypoint,
+      NOW,
+    );
+    expect(result).toBeNull();
+  });
 });
 
 describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
@@ -6652,6 +6715,8 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
         boardingPrompt: 0,
         reschedule: 0,
       },
+      // #1824 — Seoul API outage schedule hop fallback.
+      scheduleEtaFallback: 0,
       // #1707 — destination cross-check 결과 분포.
       destinationCrossCheck: {
         within: 0,

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -657,6 +657,13 @@ export interface ScheduledStats extends LiveActivityStats {
     reschedule: number;
   };
   /**
+   * #1824 — Seoul API outage 시 arrivals + positions 모두 없어 FALLBACK_HOP_SEC 기반
+   * 스케줄 ETA 추정을 사용한 누적 횟수. 0이 아니면 Seoul API 장애로 실시간 신호 대신
+   * hop 추정값으로 reschedule push / LA heartbeat가 유지된 기간 = outage 진단 신호.
+   * cron tail에서 1주 0건이면 Seoul API가 정상 작동 중임을 확인.
+   */
+  scheduleEtaFallback: number;
+  /**
    * #1707 — destination 도달 자동 종료 시 device GPS cross-check 결과 분포.
    *
    * - `within`         : GPS 좌표 ≤ 500m → 정상 종료
@@ -790,6 +797,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       boardingPrompt: 0,
       reschedule: 0,
     },
+    // #1824 — Seoul API outage 시 schedule hop ETA fallback 사용 횟수.
+    scheduleEtaFallback: 0,
     // #1707 — destination 도달 cross-check 결과 분포 (회귀 차단 측정).
     destinationCrossCheck: {
       within: 0,
@@ -2237,6 +2246,19 @@ export async function runTrainCodeTracking(
     }
   }
   if (estimate === null) {
+    // #1824 — Seoul API outage 시 arrivals + positions 모두 없어도 FALLBACK_HOP_SEC(90s) 기반
+    // 스케줄 ETA로 LA heartbeat를 유지한다. consecutiveEtaMissing 카운터는 그대로 증가
+    // (auto-end 로직 보존). reschedule push는 trip.lastTrackedArrivalEpoch side-effect가
+    // handleEtaMissing time-based fallback과 충돌하므로 skip — LA만 유지.
+    const scheduleHopEpoch = now + FALLBACK_HOP_SEC * 1000;
+    stats.scheduleEtaFallback += 1;
+    log('boarding-lock: schedule-hop-fallback used (Seoul outage)', {
+      token: trip.token.slice(0, 8),
+      waypoint: waypoint.stationName,
+      epochOffset: FALLBACK_HOP_SEC,
+    });
+    // LA heartbeat는 trip.lastLaPushEpoch 기준이라 handleEtaMissing과 충돌하지 않음.
+    await maybeFireLiveActivityUpdate(trip, waypoint, scheduleHopEpoch, deps, stats, now, log);
     await handleEtaMissing({
       trip,
       waypoint,


### PR DESCRIPTION
## Summary

- Seoul API outage(Day 2 self-poll 36건 error) 시 lock-active trip의 LA heartbeat가 끊기던 문제 수정
- `runTrainCodeTracking`에서 arrivals+positions 모두 empty인 경우 FALLBACK_HOP_SEC(90s) 기반 schedule-hop ETA로 `maybeFireLiveActivityUpdate` 호출 유지
- `ScheduledStats.scheduleEtaFallback` 카운터 추가로 outage 진단 가시성 확보
- acceptance 테스트 2건 추가 (scheduleEtaFallback stat 증가 + LA live trip heartbeat 발사)

Closes #1824

## Audit 결과 (옵션 조정)

**옵션 B (device side) — 이미 작동 중**: `BffArrivalProvider`가 BFF empty 응답 시 `getFallbackArrival` → `buildScheduleArrival` 경로를 이미 사용 중. 추가 구현 불필요.

**옵션 A (backend side) — 구현 범위 조정**:
- lockless 경로: Seoul API의 ENTERING/ARRIVED arvlCd가 없으면 station-passed push 발사 불가 — schedule fallback으로 대체 불가 (false advance 위험). 기존 동작 유지.
- lock-active 경로: LA heartbeat는 `lastLaPushEpoch` 기준이라 schedule-hop ETA 사용 시 기존 `handleEtaMissing` 로직(auto-end)과 충돌 없음. schedule-hop으로 LA 유지.
- reschedule push: `lastTrackedArrivalEpoch` side-effect가 `handleEtaMissing` time-based fallback과 충돌 → skip.

## Wire-completion 5단

1. **Orphan**: `scheduleEtaFallback` 필드는 기존 `ScheduledStats` interface 확장. `npm run lint:orphan` — No orphan exports detected.
2. **V/X dashboard**: `stats.scheduleEtaFallback` — Cloudflare Dashboard / wrangler tail에서 `boarding-lock: schedule-hop-fallback used` 로그로 관측 가능.
3. **의존 PR**: N/A — 독립 변경.
4. **측정 plan**: production 1주, `scheduleEtaFallback` > 0이면 Seoul outage 중 LA heartbeat 유지됨 확인. 0이면 Seoul API 정상 복구.
5. **Device verify**: N/A — type+unit only (backend Worker, 실기기 Seoul outage 시뮬레이션 불가).