### PR TITLE
fix(#1826): LA BG update wire — lockless + lock-missing 경로 누락 수정

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -2868,6 +2868,132 @@ describe('runScheduled — Live Activity push integration (#586 D / #612)', () =
       expect(contentState.stationName).toBe('아차산');
     });
   });
+
+  describe('#1826 — lockless trip + activityPushToken → LA BG update 발사', () => {
+    /** lockless intermediate trip with LA token */
+    function makeLocklessLaTrip(overrides: Partial<Trip> = {}): Trip {
+      return makeTrip({
+        token: 'la-lockless',
+        route: { type: 'direct', line: '2', stops: 2 },
+        waypoints: [
+          { stationName: '강남', line: '2', kind: 'intermediate' },
+          { stationName: '역삼', line: '2', kind: 'destination' },
+        ],
+        infoModeEnabled: true,
+        activityPushToken: 'la-lockless-token',
+        activityState: 'live',
+        apnsEnv: 'sandbox',
+        ...overrides,
+      });
+    }
+
+    /** lockless trip 사이클 실행 + LA push 포함 fetch mock */
+    async function runLocklessLaCycle(trip: Trip, arrivalSeconds: number) {
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, trip);
+      // motion=automotive → lockless intermediate advance 허용
+      await seedLocklessMotionSeries(kv, trip.token, 'automotive');
+      const seoulArrivals: ArrivalEntry[] = [
+        {
+          destination: '역삼행',
+          arrivalSeconds,
+          trainCode: '7246',
+          isUp: true,
+          subwayNm: '지하철2호선',
+          arvlCd: 1, // ARRIVED → 발사 조건
+        },
+      ];
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }) as unknown as Response);
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeSeoul(seoulArrivals),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      return { kv, stats, fetchImpl };
+    }
+
+    it('lockless intermediate + activityPushToken 있으면 LA update push 발사', async () => {
+      const { stats, fetchImpl } = await runLocklessLaCycle(makeLocklessLaTrip(), 120);
+      // station-passed silent push 1건 + LA update 1건
+      expect(stats.locklessIntermediateFired).toBe(1);
+      expect(stats.laPushSent).toBe(1);
+      const laCalls = getLaCalls(fetchImpl);
+      expect(laCalls).toHaveLength(1);
+      const body = parseLaBody(laCalls[0]);
+      expect(body.aps.event).toBe('update');
+      const contentState = body.aps['content-state'] as Record<string, unknown>;
+      expect(contentState.stationName).toBe('강남');
+    });
+
+    it('lockless intermediate + activityPushToken 없으면 LA push 없음', async () => {
+      const trip = makeLocklessLaTrip({ activityPushToken: undefined, activityState: undefined });
+      const { stats, fetchImpl } = await runLocklessLaCycle(trip, 120);
+      expect(stats.locklessIntermediateFired).toBe(1);
+      expect(stats.laPushSent).toBe(0);
+      expect(getLaCalls(fetchImpl)).toHaveLength(0);
+    });
+
+    it('lock 없는 trip(boarding-prompt 대기) + activityPushToken → LA heartbeat 발사', async () => {
+      // infoModeEnabled=false: lockless opt-in 아님 → boarding-prompt 대기 경로
+      const trip = makeTrip({
+        token: 'la-prompt-wait',
+        route: { type: 'direct', line: '2', stops: 3 },
+        waypoints: [
+          { stationName: '역삼', line: '2', kind: 'intermediate' },
+          { stationName: '강남', line: '2', kind: 'destination' },
+        ],
+        infoModeEnabled: false,
+        activityPushToken: 'la-prompt-token',
+        activityState: 'live',
+        apnsEnv: 'sandbox',
+      });
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, trip);
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }) as unknown as Response);
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeSeoul([]), // 응답 없음 — Seoul 폴링은 boarding-prompt 경로
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      // boarding-prompt 대기(lockMissing) 경로 + LA heartbeat 발사
+      expect(stats.lockMissing).toBeGreaterThan(0);
+      expect(stats.laPushSent).toBe(1);
+      const laCalls = getLaCalls(fetchImpl);
+      expect(laCalls).toHaveLength(1);
+      expect(parseLaBody(laCalls[0]).aps.event).toBe('update');
+    });
+
+    it('lock 없는 trip + activityPushToken 없으면 LA push 없음', async () => {
+      const trip = makeTrip({
+        token: 'la-prompt-no-token',
+        route: { type: 'direct', line: '2', stops: 3 },
+        waypoints: [
+          { stationName: '역삼', line: '2', kind: 'intermediate' },
+          { stationName: '강남', line: '2', kind: 'destination' },
+        ],
+        infoModeEnabled: false,
+        activityPushToken: undefined,
+        activityState: undefined,
+        apnsEnv: 'sandbox',
+      });
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, trip);
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }) as unknown as Response);
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeSeoul([]),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      expect(stats.laPushSent).toBe(0);
+      expect(getLaCalls(fetchImpl)).toHaveLength(0);
+    });
+  });
 });
 
 // #1337 — server-side trip auto-end 경로에서 클라 state sync용 trip-ended alert push가 발사되는지.

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -924,6 +924,24 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
           token: trip.token.slice(0, 8),
         });
       }
+      // #1826 — lock 없는 trip에서도 LA BG update heartbeat 발사.
+      // ETA 미지 → newArrivalEpoch=now: ΔETA 게이트는 첫 call에서 통과(last===undefined),
+      // 이후 heartbeat(90s) 게이트만 적용. putTrip dirty 여부와 무관하게 별도 persist.
+      if (trip.activityPushToken && trip.activityState === 'live') {
+        try {
+          const laHeartbeatDirty = await maybeFireLiveActivityUpdate(
+            trip, waypoint, now, deps, stats, now, log,
+          );
+          if (laHeartbeatDirty) {
+            await putTrip(env.TRIPS, trip);
+          }
+        } catch (e) {
+          log('la-heartbeat: error (lock-missing path)', {
+            error: String(e),
+            token: trip.token.slice(0, 8),
+          });
+        }
+      }
       continue;
     }
 
@@ -3074,6 +3092,11 @@ export async function runLocklessIntermediate(
   // #1539 (S6) — lockless intermediate 통과 시점도 동일하게 stationName 누적. lock 경로와 동등
   // 정확도 보장 의무(ADR-014: 사용자 명시 의향 trip = lock 활성과 동급).
   appendPassedStation(trip, waypoint.stationName);
+  // #1826 — lockless intermediate 경로에서도 LA BG update 발사.
+  // signal.etaSeconds를 ETA로 전달 — station-passed push와 동일 시점의 ETA 추정값.
+  // maybeFireLiveActivityUpdate 내 dedup(30s) + heartbeat(90s) 게이트가 중복 발사를 차단한다.
+  // 반환 dirty=true여도 trip의 lastLaPushEpoch/lastLaPushAt 갱신분은 아래 putTrip으로 일괄 persist.
+  await maybeFireLiveActivityUpdate(trip, waypoint, now + signal.etaSeconds * 1000, deps, stats, now, log);
   trip.waypoints.shift();
   if (trip.waypoints.length === 0) {
     // 마지막 intermediate까지 통과 — trip 종료. lockless는 destination을 직접 다루지 않는다.


### PR DESCRIPTION
## Summary

Closes #1826

### Audit 결과

| 항목 | 결과 |
|---|---|
| **A** — activityPushToken 등록 chain (device → backend POST /live-activity/register → KV) | ✅ 갭 없음 |
| **B** — APNs liveactivity 헤더 (`apns-push-type: liveactivity`, `.push-type.liveactivity` topic) | ✅ 갭 없음 |
| **C** — lock 없는 trip에서 `maybeFireLiveActivityUpdate` 미호출 | ❌ **Root Cause — Fix** |
| **D** — heartbeat/dedup/threshold (90s/30s) | ✅ 갭 없음 |

### Root Cause (C)

`maybeFireLiveActivityUpdate`가 오직 `runTrainCodeTracking` (lock 활성 경로)에서만 호출됨.

- **lockless trip** (`infoModeEnabled=true` + `kind=intermediate`): `runLocklessIntermediate` 경로에서 station-passed push 발사 후 LA update 없음
- **lock 없는 boarding-prompt 대기 trip**: `lockMissing` 경로에서 boarding-prompt 평가 후 LA update 없음

사용자 Day 2 dump `Silent Push received=0` (35분 trip) 동안 LA도 0건인 직접 원인.

### Fix

1. `runLocklessIntermediate` 성공 경로 끝에 `maybeFireLiveActivityUpdate` 호출 추가
   - ETA: `now + signal.etaSeconds * 1000` (station-passed push와 동일 시점)
   - 기존 dedup(30s) + heartbeat(90s) 게이트 공유 — 중복 발사 방지
2. `runScheduled` lockMissing 경로에 `activityPushToken && activityState==='live'` 조건부 heartbeat 추가
   - ETA 미지 → `newArrivalEpoch=now`: 첫 call은 `last===undefined`로 통과, 이후 heartbeat 게이트 담당

### 변경 파일

- `backend/alarm-worker/src/scheduled.ts` (+23 lines, 변경 2곳)
- `backend/alarm-worker/src/__tests__/scheduled.test.ts` (+4 테스트)

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (신규 export 없음)
2. **V/X dashboard** — backend wrangler tail `la-push` 카운터 + Day 3+ dump `Silent Push received > 0` + LA contentState BG 갱신 확인
3. **의존 PR** — N/A (backend만 변경)
4. **측정 plan** — Day 3+ dump `Silent Push received` > 0 + `laPushSent` wrangler tail 1주 관측
5. **Device verify** — 실기기 BG trip → 잠금 화면 LA contentState 매 분 갱신 필수 검증 (CI 미커버)

## Test plan

- [x] `npm test` 7832건 통과
- [x] `cd backend/alarm-worker && npm test` 2161건 통과 (신규 4건 포함)
- [x] `npm run type-check` 통과
- [x] `npm run lint:orphan` 0 orphan
- [ ] 실기기 BG trip → 잠금 화면 LA 갱신 확인