### PR TITLE
feat(#1829): backend RAW_SIGNALS KV 활성화 + Sentry withSentry HOC wire

### DIFF
--- a/backend/alarm-worker/src/__tests__/sentry.test.ts
+++ b/backend/alarm-worker/src/__tests__/sentry.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import * as Sentry from '@sentry/cloudflare';
 import {
   sentryInit,
+  sentryOptions,
   captureXEvent,
+  captureBackendException,
+  addValidateRejectBreadcrumb,
   hashTripToken,
   isSentryInitialized,
   getConfiguredDsn,
@@ -12,6 +15,8 @@ import type { Env } from '../types';
 
 vi.mock('@sentry/cloudflare', () => ({
   captureMessage: vi.fn(),
+  captureException: vi.fn(),
+  addBreadcrumb: vi.fn(),
 }));
 
 function makeEnv(overrides: Partial<Env> = {}): Env {
@@ -105,5 +110,92 @@ describe('backend sentry (#1578)', () => {
       expect(hashTripToken('a').length).toBe(8);
       expect(hashTripToken('a')).not.toBe(hashTripToken('b'));
     });
+  });
+});
+
+describe('sentryOptions (#1829)', () => {
+  it('DSN 미설정 시 undefined 반환', () => {
+    const env = { APNS_HOST: '', APNS_HOST_SANDBOX: '', SEOUL_API_HOST: '', SEOUL_API_KEY: '', APNS_KEY_ID: '', APNS_TEAM_ID: '', APNS_PRIVATE_KEY: '', APNS_BUNDLE_ID: '', TRIPS: {} as KVNamespace };
+    expect(sentryOptions(env as Env)).toBeUndefined();
+  });
+
+  it('DSN 설정 시 options 반환 + environment production default', () => {
+    const env = { APNS_HOST: '', APNS_HOST_SANDBOX: '', SEOUL_API_HOST: '', SEOUL_API_KEY: '', APNS_KEY_ID: '', APNS_TEAM_ID: '', APNS_PRIVATE_KEY: '', APNS_BUNDLE_ID: '', TRIPS: {} as KVNamespace, SENTRY_DSN: 'https://x@s/1' };
+    const opts = sentryOptions(env as Env);
+    expect(opts).toBeDefined();
+    expect(opts?.dsn).toBe('https://x@s/1');
+    expect(opts?.environment).toBe('production');
+  });
+
+  it('APNS_HOST가 sandbox URL이면 environment=sandbox', () => {
+    const env = { APNS_HOST: 'api.sandbox.push.apple.com', APNS_HOST_SANDBOX: 'api.sandbox.push.apple.com', SEOUL_API_HOST: '', SEOUL_API_KEY: '', APNS_KEY_ID: '', APNS_TEAM_ID: '', APNS_PRIVATE_KEY: '', APNS_BUNDLE_ID: '', TRIPS: {} as KVNamespace, SENTRY_DSN: 'https://x@s/1' };
+    const opts = sentryOptions(env as Env);
+    expect(opts?.environment).toBe('sandbox');
+  });
+});
+
+describe('captureBackendException (#1829)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetSentryForTest();
+  });
+
+  afterEach(() => {
+    _resetSentryForTest();
+  });
+
+  it('init 안 됐으면 no-op', () => {
+    captureBackendException(new Error('boom'));
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('init 후 captureException 호출', () => {
+    const env = { APNS_HOST: '', APNS_HOST_SANDBOX: '', SEOUL_API_HOST: '', SEOUL_API_KEY: '', APNS_KEY_ID: '', APNS_TEAM_ID: '', APNS_PRIVATE_KEY: '', APNS_BUNDLE_ID: '', TRIPS: {} as KVNamespace, SENTRY_DSN: 'https://x@s/1' };
+    sentryInit(env as Env);
+    const err = new Error('cron failed');
+    captureBackendException(err, { path: 'scheduled/runScheduled' });
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      err,
+      expect.objectContaining({ extra: expect.objectContaining({ path: 'scheduled/runScheduled' }) }),
+    );
+  });
+
+  it('SDK throw 시 swallow', () => {
+    const env = { APNS_HOST: '', APNS_HOST_SANDBOX: '', SEOUL_API_HOST: '', SEOUL_API_KEY: '', APNS_KEY_ID: '', APNS_TEAM_ID: '', APNS_PRIVATE_KEY: '', APNS_BUNDLE_ID: '', TRIPS: {} as KVNamespace, SENTRY_DSN: 'https://x@s/1' };
+    sentryInit(env as Env);
+    vi.mocked(Sentry.captureException).mockImplementationOnce(() => { throw new Error('sdk crash'); });
+    expect(() => captureBackendException(new Error('original'))).not.toThrow();
+  });
+
+  it('context 없이 호출 가능', () => {
+    const env = { APNS_HOST: '', APNS_HOST_SANDBOX: '', SEOUL_API_HOST: '', SEOUL_API_KEY: '', APNS_KEY_ID: '', APNS_TEAM_ID: '', APNS_PRIVATE_KEY: '', APNS_BUNDLE_ID: '', TRIPS: {} as KVNamespace, SENTRY_DSN: 'https://x@s/1' };
+    sentryInit(env as Env);
+    captureBackendException(new Error('bare'));
+    expect(Sentry.captureException).toHaveBeenCalledWith(expect.any(Error), undefined);
+  });
+});
+
+describe('addValidateRejectBreadcrumb (#1829)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetSentryForTest();
+  });
+
+  afterEach(() => {
+    _resetSentryForTest();
+  });
+
+  it('init 안 됐으면 no-op', () => {
+    addValidateRejectBreadcrumb('missing_field', { field: 'token' });
+    expect(Sentry.addBreadcrumb).not.toHaveBeenCalled();
+  });
+
+  it('init 후 addBreadcrumb 호출', () => {
+    const env = { APNS_HOST: '', APNS_HOST_SANDBOX: '', SEOUL_API_HOST: '', SEOUL_API_KEY: '', APNS_KEY_ID: '', APNS_TEAM_ID: '', APNS_PRIVATE_KEY: '', APNS_BUNDLE_ID: '', TRIPS: {} as KVNamespace, SENTRY_DSN: 'https://x@s/1' };
+    sentryInit(env as Env);
+    addValidateRejectBreadcrumb('missing_field', { field: 'token' });
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({ category: 'trips-validate', level: 'warning' }),
+    );
   });
 });

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -51,7 +51,13 @@ import { writeMetric } from './analytics';
 import { deleteProgress, getProgress, putProgress, type TripProgress } from './progress';
 import { SeoulArrivalClient } from './seoul';
 import { runScheduled } from './scheduled';
-import { addValidateRejectBreadcrumb, sentryInit } from './sentry';
+import * as Sentry from '@sentry/cloudflare';
+import {
+  addValidateRejectBreadcrumb,
+  captureBackendException,
+  sentryInit,
+  sentryOptions,
+} from './sentry';
 import {
   recordRecallUpload,
   validateRecallUpload,
@@ -964,7 +970,12 @@ app.post('/signals/dump', async (c) => {
   const payload = validateSignalDumpUpload(body);
   if (!payload) return c.json({ error: 'invalid_payload' }, 400);
 
-  await storeSignalDump(kv, payload, Date.now());
+  try {
+    await storeSignalDump(kv, payload, Date.now());
+  } catch (err) {
+    captureBackendException(err, { path: 'signals/dump', corrId: payload.corrId });
+    return c.json({ error: 'store_failed' }, 500);
+  }
 
   console.log(
     JSON.stringify({
@@ -2080,7 +2091,7 @@ function parseBoardingLock(raw: unknown): BoardingLockMeta | undefined {
   };
 }
 
-export default {
+const handler = {
   fetch: app.fetch,
   async scheduled(_controller: ScheduledController, env: Env, _ctx: ExecutionContext): Promise<void> {
     sentryInit(env);
@@ -2098,7 +2109,12 @@ export default {
     const log = (msg: string, meta?: Record<string, unknown>) =>
       console.log(JSON.stringify({ msg, ...meta }));
 
-    await runScheduled(env, { seoul, apnsConfig, apnsHosts, log });
+    try {
+      await runScheduled(env, { seoul, apnsConfig, apnsHosts, log });
+    } catch (err) {
+      captureBackendException(err, { path: 'scheduled/runScheduled' });
+      throw err;
+    }
     // #572 P2c — silent push 30s 미ACK entry를 alert로 fallback. 같은 cron 사이클에서 실행.
     await runFallbackPushes(env, { apnsConfig, apnsHosts, log });
     // #1721 — silent push 발사 실패(429 / 5xx) 영구 lost 차단. retry-push: prefix entry 를 backoff 만기
@@ -2130,3 +2146,10 @@ export default {
     }
   },
 };
+
+/**
+ * #1829 — withSentry HOC bind.
+ * DSN 미설정(sentryOptions가 undefined 반환) 시 HOC no-op — production 동작 그대로.
+ * SENTRY_DSN secret 등록 즉시 자동 활성 (redeploy 필요 없음 — wrangler secret은 실시간 반영).
+ */
+export default Sentry.withSentry(sentryOptions, handler);

--- a/backend/alarm-worker/src/sentry.ts
+++ b/backend/alarm-worker/src/sentry.ts
@@ -1,5 +1,5 @@
 /**
- * #1578 — Phase 0 P0-2: Backend Sentry wire.
+ * #1578/#1829 — Backend Sentry wire (Phase 1 완성).
  *
  * V/X acceptance 표(X3 stale, X8 6h+ 좀비 등)의 backend-side 실시간 alert.
  *
@@ -11,14 +11,14 @@
  *   - `env.SENTRY_DSN` 미설정 시 init/capture 모두 no-op.
  *   - SDK 호출 실패 시 swallow + console.warn (cron path 영향 X).
  *
- * **Cloudflare SDK 사용 방식 (Phase 0 minimal)**:
- *   `@sentry/cloudflare`는 `withSentry` HOC + `CloudflareClient` 패턴을 권장한다.
- *   Phase 0에서는 `captureMessage` (from `@sentry/core` re-export)와 자체 bound flag만
- *   사용한다. 정식 `withSentry` 적용은 후속 PR(Phase 1 측정 인프라 통합)에서.
- *   현재 모듈은 DSN 부재 시 100% no-op이라 production runtime 영향 없음.
+ * **Cloudflare SDK 사용 방식 (#1829 Phase 1)**:
+ *   `withSentry` HOC + `CloudflareClient` 패턴.
+ *   `index.ts`의 `export default`를 `Sentry.withSentry(sentryOptions, handler)` 로 wrap.
+ *   `sentryInit`은 하위 호환 유지 (middleware + scheduled에서 idempotent 호출).
  */
 
-import { addBreadcrumb, captureMessage } from '@sentry/cloudflare';
+import { addBreadcrumb, captureException, captureMessage } from '@sentry/cloudflare';
+import type { CloudflareOptions } from '@sentry/cloudflare';
 import {
   hashTripToken,
   sanitizeContext,
@@ -44,16 +44,49 @@ let initialized = false;
 let configuredDsn: string | null = null;
 
 /**
- * cron `scheduled()` / `fetch` 진입부에서 1회 호출. DSN 부재 시 no-op.
+ * `withSentry` HOC에 전달하는 options 콜백. DSN 미설정 시 undefined 반환 → HOC no-op.
  *
- * Phase 0: DSN 존재 여부만 stamp + console.info. 실제 `withSentry` HOC bind는 후속 PR.
- * 본 구현은 captureMessage 호출 시 SDK 내부에서 active client가 없으면 no-op이므로 안전.
+ * `index.ts`의 `export default`를 `Sentry.withSentry(sentryOptions, handler)` 로 wrap한다.
+ * environment: APNS_HOST_SANDBOX 포함 여부로 sandbox 추론 (별도 APNS_ENV 필드 없음).
+ * APNS_HOST가 sandbox.push.apple.com 이면 'sandbox', 아니면 'production'.
+ */
+export function sentryOptions(env: Env): CloudflareOptions | undefined {
+  if (!env.SENTRY_DSN) return undefined;
+  const isSandbox = env.APNS_HOST.includes('sandbox');
+  return {
+    dsn: env.SENTRY_DSN,
+    environment: isSandbox ? 'sandbox' : 'production',
+  };
+}
+
+/**
+ * cron `scheduled()` / `fetch` middleware 에서 1회 호출. DSN 부재 시 no-op.
+ * `withSentry` HOC가 SDK를 초기화하므로, 본 함수는 모듈 스코프 flag만 stamp한다.
+ * captureXEvent / addValidateRejectBreadcrumb 의 guard로 계속 사용.
  */
 export function sentryInit(env: Env): void {
   if (initialized) return;
   if (!env.SENTRY_DSN) return;
   configuredDsn = env.SENTRY_DSN;
   initialized = true;
+}
+
+/**
+ * 예외를 Sentry로 포착. DSN 미설정 / initialized 이전 시 no-op.
+ *
+ * 핵심 path(cron, /trips, /signals/dump, /live-activity/register)의 catch block에서 사용.
+ * SDK 자체 throw 시 swallow — cron path 영향 없음.
+ */
+export function captureBackendException(
+  err: unknown,
+  context?: BackendXEventContext,
+): void {
+  if (!initialized) return;
+  try {
+    captureException(err, context ? { extra: sanitizeContext(context) } : undefined);
+  } catch (e) {
+    console.warn(JSON.stringify({ msg: 'sentry captureException failed', err: String(e) }));
+  }
 }
 
 /**

--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -49,14 +49,16 @@ preview_id = "d38f190e3f7f4fd3b6e7f6485dd1733d"
 # `GET /admin/signals/export?corrId=`로 운영자가 7일 회귀 사후 분석.
 # 코드는 `if (env.RAW_SIGNALS)` 분기로 graceful — binding 없으면 endpoint가 503 반환.
 #
-# 운영자 1회성 등록 절차:
+# 운영자 1회성 등록 절차 (PR #1829):
 #   1) `wrangler kv namespace create RAW_SIGNALS`
+#      → 출력된 id를 아래 id = "..." 에 채운다.
 #   2) `wrangler kv namespace create RAW_SIGNALS --preview`
-#   3) 출력된 id / preview_id를 아래 두 줄에 채워 binding 활성화.
-# [[kv_namespaces]]
-# binding = "RAW_SIGNALS"
-# id = ""
-# preview_id = ""
+#      → 출력된 id를 아래 preview_id = "..." 에 채운다.
+#   3) `wrangler deploy`
+[[kv_namespaces]]
+binding = "RAW_SIGNALS"
+id = "FILL_IN_AFTER_wrangler_kv_namespace_create_RAW_SIGNALS"
+preview_id = "FILL_IN_AFTER_wrangler_kv_namespace_create_RAW_SIGNALS_preview"
 
 # Analytics Engine: V/X acceptance 시계열 dataset (#1577, Phase 0 epic #1576)
 # advance / fire / suppress / motion-transition / position-upload / trip-mutation 6 event를


### PR DESCRIPTION
Closes #1829

## Audit 결과

| 항목 | 결과 |
|---|---|
| `@sentry/cloudflare` SDK | package.json `^10.59.0` 명시됨, `npm install`로 설치 완료 |
| 기존 `sentry.ts` Phase 0 stub | `captureMessage`/`addBreadcrumb` 사용, `sentryInit`은 DSN stamp만. 본 PR에서 `sentryOptions` + `captureBackendException` 추가로 통합 |
| backend test `withSentry` 호환 | `vi.mock('@sentry/cloudflare')` 기반 — SDK 설치 없이도 동작. `captureException`/`addBreadcrumb` mock 추가로 회귀 0 |
| cron/fetch 구분 | `export default { fetch, scheduled }` 객체 형태 → `Sentry.withSentry(sentryOptions, handler)`로 한 번에 wrap 가능 |

## 변경 사항

### Phase A — RAW_SIGNALS KV 활성화

`backend/alarm-worker/wrangler.toml`: 주석 해제 + id/preview_id placeholder 명시.

운영자 1회성 절차 (머지 후):
```bash
# 1) namespace 생성
wrangler kv namespace create RAW_SIGNALS
# → 출력된 id를 wrangler.toml id = "..." 에 채운다

wrangler kv namespace create RAW_SIGNALS --preview
# → 출력된 id를 wrangler.toml preview_id = "..." 에 채운다

# 2) wrangler.toml commit (id 채운 후 별도 커밋 또는 직접 수정)
# 3) wrangler deploy
```

활성화 후: `POST /signals/dump` 성공 (이전 503 graceful 해제), `GET /admin/signals/export?corrId=<id>` 조회 가능.

### Phase B — Sentry withSentry HOC wire

**`sentry.ts`** 변경:
- `sentryOptions(env)`: `withSentry` HOC 전달용 콜백. DSN 미설정 시 `undefined` → HOC no-op. `APNS_HOST`로 sandbox 판별.
- `captureBackendException(err, context?)`: 핵심 path catch block용. init 전/SDK throw 모두 swallow.
- 기존 `sentryInit` / `captureXEvent` / `addValidateRejectBreadcrumb` 하위 호환 유지.

**`index.ts`** 변경:
- `export default` → `const handler = { fetch, scheduled }; export default Sentry.withSentry(sentryOptions, handler)`
- `scheduled`: `runScheduled` try/catch + `captureBackendException` (throw re-throw)
- `POST /signals/dump`: `storeSignalDump` try/catch + `captureBackendException` (500 반환)

운영자 절차 (Sentry DSN 등록):
```bash
# 1) sentry.io 에서 프로젝트 생성 (또는 기존 device project DSN 재사용)
# 2) DSN 복사
wrangler secret put SENTRY_DSN
# → DSN 입력

# 3) wrangler deploy

# 4) 의도적 throw로 verify
# Sentry dashboard에서 exception 수신 확인
```

## Wire-completion 5단

1. **Orphan**: `sentryOptions` / `captureBackendException` 모두 `index.ts`에서 사용. `npm run lint:orphan` pass (0 orphans).
2. **V/X dashboard**: Sentry dashboard에서 backend exception 수신 확인 가능 (`withSentry` HOC가 unhandled exception 자동 포착). `runScheduled` / `storeSignalDump` 실패는 명시 captureException.
3. **의존 PR**: N/A (backend only, 독립 변경).
4. **측정 plan**: 1주 후 Sentry exception 분포 확인 → 우선순위 큰 backend 에러 식별. DSN 미설정 시 no-op이므로 배포 즉시 회귀 없음.
5. **Device verify**: N/A — backend only. type-check + unit (2166 tests pass) 검증.

## 테스트 결과

- backend `npm test`: 2166/2166 pass
- backend `npm run type-check`: pass
- root `npm test`: 7832/7832 pass
- `npm run lint:orphan`: 0 orphans