### PR TITLE
feat(#1828): backend route-bound station-level Seoul API polling

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -561,11 +561,9 @@ describe('runScheduled', () => {
       expect(stats.lockMissing).toBe(1);
       expect(apnsFetch).not.toHaveBeenCalled();
       // #1614 Phase A — cron 진입부 self-poll로 realtimePosition fetch는 발생할 수 있음.
-      // 본 테스트의 진짜 의도는 arrivals fetch 0 + push 발사 0.
-      const arrivalsCalls = seoulFetch.mock.calls.filter((args: unknown[]) =>
-        String(args[0]).includes('/realtimeStationArrival/'),
-      );
-      expect(arrivalsCalls).toHaveLength(0);
+      // #1828 Phase 5 — cron 진입부 station-level arrivals fetch도 발생할 수 있음 (route bound polling).
+      // 본 테스트의 진짜 의도는 push 발사 0건 (lock 없는 trip은 알람 차단).
+      // Seoul arrivals API 호출 자체는 cron stamp 목적으로 허용됨 — push 경로와 무관.
     });
   });
 
@@ -6639,6 +6637,8 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
       vanishFallbackMotionGateBlocked: 0,
       cronJitterMs: 0, rescheduleBlockedMotion: 0, rescheduleFallbackNoSsot: 0,
       realtimePositionFetch: 0, selfPollCacheHit: 0, realtimePositionFetchError: 0,
+      // #1828 Phase 5 — station-level arrivals polling.
+      stationPollFetch: 0, stationPollCacheHit: 0, stationPollError: 0,
       staleLockFireSkipped: 0,
       // #1652 — staged lifecycle backstop.
       lifecycleSilenceSkipped: 0, lifecycleForceEnded: 0,

--- a/backend/alarm-worker/src/__tests__/selfPollPosition.test.ts
+++ b/backend/alarm-worker/src/__tests__/selfPollPosition.test.ts
@@ -1,17 +1,23 @@
 /**
  * selfPollPosition.test.ts — #1614 Phase A (S4 #1537) backend self-poll KV stamp + helper.
+ * #1828 Phase 5 — station-level arrivals polling.
  */
 
 import { describe, expect, it, vi } from 'vitest';
 import { InMemoryKV } from './inMemoryKv';
 import {
+  N_STATION_LOOKAHEAD,
   pollLinesAndStamp,
+  pollStationsAndStamp,
   readSelfPollPosition,
+  readSelfPollStationArrivals,
   selfPollKey,
+  selfPollStationKey,
   SELF_POLL_TTL_SEC,
   writeSelfPollPosition,
+  writeSelfPollStationArrivals,
 } from '../selfPollPosition';
-import { SeoulArrivalClient, type PositionEntry } from '../seoul';
+import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from '../seoul';
 
 const NOW = 1_700_000_000_000;
 
@@ -26,7 +32,24 @@ function makePosition(overrides: Partial<PositionEntry> = {}): PositionEntry {
   };
 }
 
-function makeSeoulClient(positions: PositionEntry[]): SeoulArrivalClient {
+function makeArrival(overrides: Partial<ArrivalEntry> = {}): ArrivalEntry {
+  return {
+    destination: '성수행',
+    arrivalSeconds: 90,
+    trainCode: '7246',
+    isUp: true,
+    subwayNm: '지하철2호선',
+    arvlCd: 2,
+    ...overrides,
+  };
+}
+
+function makeSeoulClient(options: {
+  positions?: PositionEntry[];
+  arrivals?: ArrivalEntry[];
+} = {}): SeoulArrivalClient {
+  const positions = options.positions ?? [];
+  const arrivals = options.arrivals ?? [];
   return new SeoulArrivalClient({
     apiKey: 'K',
     host: 'h',
@@ -46,6 +69,22 @@ function makeSeoulClient(positions: PositionEntry[]): SeoulArrivalClient {
           { status: 200 },
         );
       }
+      if (url.includes('/realtimeStationArrival/')) {
+        return new Response(
+          JSON.stringify({
+            realtimeArrivalList: arrivals.map((a) => ({
+              barvlDt: String(a.arrivalSeconds),
+              recptnDt: '',
+              updnLine: a.isUp ? '상행' : '하행',
+              trainLineNm: a.destination,
+              btrainNo: a.trainCode,
+              subwayNm: a.subwayNm,
+              arvlCd: a.arvlCd,
+            })),
+          }),
+          { status: 200 },
+        );
+      }
       return new Response('not found', { status: 404 });
     }) as unknown as typeof fetch,
   });
@@ -55,6 +94,21 @@ describe('selfPollKey', () => {
   it('builds stable key for line', () => {
     expect(selfPollKey('7')).toBe('realtime-position:7');
     expect(selfPollKey('bundang')).toBe('realtime-position:bundang');
+  });
+});
+
+describe('selfPollStationKey (#1828)', () => {
+  it('builds stable key for station name', () => {
+    expect(selfPollStationKey('신도림')).toBe('selfPoll:station:신도림');
+    expect(selfPollStationKey('강남')).toBe('selfPoll:station:강남');
+  });
+});
+
+describe('N_STATION_LOOKAHEAD (#1828)', () => {
+  it('is a positive integer between 3 and 10', () => {
+    expect(N_STATION_LOOKAHEAD).toBeGreaterThanOrEqual(3);
+    expect(N_STATION_LOOKAHEAD).toBeLessThanOrEqual(10);
+    expect(Number.isInteger(N_STATION_LOOKAHEAD)).toBe(true);
   });
 });
 
@@ -97,10 +151,48 @@ describe('readSelfPollPosition / writeSelfPollPosition round-trip', () => {
   });
 });
 
+describe('readSelfPollStationArrivals / writeSelfPollStationArrivals round-trip (#1828)', () => {
+  it('returns null when no stamp', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    expect(await readSelfPollStationArrivals(kv, '신도림')).toBeNull();
+  });
+
+  it('round-trips arrivals + fetchedAt', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const arrivals = [makeArrival()];
+    await writeSelfPollStationArrivals(kv, '신도림', arrivals, NOW);
+    const stamp = await readSelfPollStationArrivals(kv, '신도림');
+    expect(stamp).not.toBeNull();
+    expect(stamp?.arrivals).toEqual(arrivals);
+    expect(stamp?.fetchedAt).toBe(NOW);
+  });
+
+  it('returns null when JSON is malformed', async () => {
+    const kv = new InMemoryKV();
+    kv.store.set(selfPollStationKey('신도림'), { value: '{broken-json' });
+    expect(await readSelfPollStationArrivals(kv as unknown as KVNamespace, '신도림')).toBeNull();
+  });
+
+  it('writes with 30s expirationTtl', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await writeSelfPollStationArrivals(kv, '신도림', [makeArrival()], NOW);
+    const entry = (kv as unknown as InMemoryKV).store.get(selfPollStationKey('신도림'));
+    expect(entry?.expiresAt).toBeDefined();
+    expect(entry!.expiresAt! - Date.now()).toBeGreaterThan(25 * 1000);
+  });
+
+  it('stamps empty arrivals gracefully (fallback path)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await writeSelfPollStationArrivals(kv, '강남', [], NOW);
+    const stamp = await readSelfPollStationArrivals(kv, '강남');
+    expect(stamp?.arrivals).toEqual([]);
+  });
+});
+
 describe('pollLinesAndStamp', () => {
   it('returns zero counts for empty line set', async () => {
     const kv = new InMemoryKV() as unknown as KVNamespace;
-    const seoul = makeSeoulClient([]);
+    const seoul = makeSeoulClient();
     const stats = await pollLinesAndStamp(kv, seoul, new Set(), NOW);
     expect(stats).toEqual({ fetched: 0, cacheHit: 0, error: 0 });
   });
@@ -111,7 +203,7 @@ describe('pollLinesAndStamp', () => {
     { lines: ['7', '5', '2'], expectedFetched: 3 },
   ])('fetches each line once on cache miss (lines=$lines)', async ({ lines, expectedFetched }) => {
     const kv = new InMemoryKV() as unknown as KVNamespace;
-    const seoul = makeSeoulClient([makePosition()]);
+    const seoul = makeSeoulClient({ positions: [makePosition()] });
     const stats = await pollLinesAndStamp(kv, seoul, new Set(lines), NOW);
     expect(stats.fetched).toBe(expectedFetched);
     expect(stats.cacheHit).toBe(0);
@@ -120,7 +212,7 @@ describe('pollLinesAndStamp', () => {
 
   it('skips fetch when KV stamp exists (cacheHit++)', async () => {
     const kv = new InMemoryKV() as unknown as KVNamespace;
-    const seoul = makeSeoulClient([makePosition()]);
+    const seoul = makeSeoulClient({ positions: [makePosition()] });
     // First call — fetches.
     await pollLinesAndStamp(kv, seoul, new Set(['7']), NOW);
     // Second call — KV hit (stamp still alive).
@@ -131,7 +223,7 @@ describe('pollLinesAndStamp', () => {
   it('stamps fetched positions into KV (caller can readSelfPollPosition)', async () => {
     const kv = new InMemoryKV() as unknown as KVNamespace;
     const positions = [makePosition({ trainCode: '7246' }), makePosition({ trainCode: '7248' })];
-    const seoul = makeSeoulClient(positions);
+    const seoul = makeSeoulClient({ positions });
     await pollLinesAndStamp(kv, seoul, new Set(['7']), NOW);
     const stamp = await readSelfPollPosition(kv, '7');
     expect(stamp).not.toBeNull();
@@ -173,7 +265,7 @@ describe('pollLinesAndStamp', () => {
 
   it('writes through canonicalLineName — unmapped line returns empty positions (counts as fetched)', async () => {
     const kv = new InMemoryKV() as unknown as KVNamespace;
-    const seoul = makeSeoulClient([]);
+    const seoul = makeSeoulClient();
     // unmapped line — SeoulArrivalClient returns empty array (not throw).
     const stats = await pollLinesAndStamp(kv, seoul, new Set(['unmapped-line']), NOW);
     expect(stats.fetched).toBe(1);
@@ -185,12 +277,126 @@ describe('pollLinesAndStamp', () => {
 
   it('counts error when KV write fails after successful fetch', async () => {
     const kv = new InMemoryKV() as unknown as KVNamespace;
-    const seoul = makeSeoulClient([makePosition()]);
+    const seoul = makeSeoulClient({ positions: [makePosition()] });
     // Spy on KV.put to throw on second call (first call from cron, no second normally).
     const spy = vi.spyOn(kv, 'put').mockRejectedValueOnce(new Error('KV write failed'));
     const stats = await pollLinesAndStamp(kv, seoul, new Set(['7']), NOW);
     expect(stats.error).toBe(1);
     expect(stats.fetched).toBe(0);
     spy.mockRestore();
+  });
+});
+
+describe('pollStationsAndStamp (#1828 Phase 5)', () => {
+  it('returns zero counts for empty station set', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const seoul = makeSeoulClient();
+    const stats = await pollStationsAndStamp(kv, seoul, new Set(), NOW);
+    expect(stats).toEqual({ fetched: 0, cacheHit: 0, error: 0 });
+  });
+
+  it.each([
+    { stations: ['신도림'], expectedFetched: 1 },
+    { stations: ['신도림', '강남'], expectedFetched: 2 },
+    { stations: ['신도림', '강남', '홍대입구'], expectedFetched: 3 },
+  ])('fetches each station once on cache miss (stations=$stations)', async ({ stations, expectedFetched }) => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const seoul = makeSeoulClient({ arrivals: [makeArrival()] });
+    const stats = await pollStationsAndStamp(kv, seoul, new Set(stations), NOW);
+    expect(stats.fetched).toBe(expectedFetched);
+    expect(stats.cacheHit).toBe(0);
+    expect(stats.error).toBe(0);
+  });
+
+  it('skips fetch when KV stamp exists (cacheHit++)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const seoul = makeSeoulClient({ arrivals: [makeArrival()] });
+    // First call — fetches.
+    await pollStationsAndStamp(kv, seoul, new Set(['신도림']), NOW);
+    // Second call — KV hit.
+    const second = await pollStationsAndStamp(kv, seoul, new Set(['신도림']), NOW + 1000);
+    expect(second).toEqual({ fetched: 0, cacheHit: 1, error: 0 });
+  });
+
+  it('stamps fetched arrivals into KV (caller can readSelfPollStationArrivals)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const arrivals = [makeArrival({ trainCode: 'A' }), makeArrival({ trainCode: 'B' })];
+    const seoul = makeSeoulClient({ arrivals });
+    await pollStationsAndStamp(kv, seoul, new Set(['신도림']), NOW);
+    const stamp = await readSelfPollStationArrivals(kv, '신도림');
+    expect(stamp).not.toBeNull();
+    expect(stamp?.arrivals.map((a) => a.trainCode).sort()).toEqual(['A', 'B']);
+  });
+
+  it('stamps empty arrivals on Seoul empty response (graceful fallback)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const seoul = makeSeoulClient({ arrivals: [] });
+    const stats = await pollStationsAndStamp(kv, seoul, new Set(['신도림']), NOW);
+    expect(stats.fetched).toBe(1);
+    expect(stats.error).toBe(0);
+    const stamp = await readSelfPollStationArrivals(kv, '신도림');
+    expect(stamp?.arrivals).toEqual([]);
+  });
+
+  it('counts error when Seoul fetchArrivals throws', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () => {
+        throw new Error('network-error');
+      }) as unknown as typeof fetch,
+    });
+    const stats = await pollStationsAndStamp(kv, seoul, new Set(['신도림']), NOW);
+    expect(stats.error).toBe(1);
+    expect(stats.fetched).toBe(0);
+  });
+
+  it('Promise.allSettled — one station failure does not block others', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async (url: string) => {
+        if (url.includes(encodeURIComponent('강남'))) throw new Error('boom');
+        return new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+    const stats = await pollStationsAndStamp(kv, seoul, new Set(['신도림', '강남']), NOW);
+    expect(stats.fetched).toBe(1);
+    expect(stats.error).toBe(1);
+  });
+
+  it('counts error when KV write fails after successful fetch', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const seoul = makeSeoulClient({ arrivals: [makeArrival()] });
+    const spy = vi.spyOn(kv, 'put').mockRejectedValueOnce(new Error('KV write failed'));
+    const stats = await pollStationsAndStamp(kv, seoul, new Set(['신도림']), NOW);
+    expect(stats.error).toBe(1);
+    expect(stats.fetched).toBe(0);
+    spy.mockRestore();
+  });
+
+  it('dedup across multiple stations in same set — each station fetched once', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const fetchSpy = vi.fn(async () =>
+      new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 }),
+    );
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+    });
+    const stats = await pollStationsAndStamp(
+      kv,
+      seoul,
+      new Set(['신도림', '강남', '홍대입구']),
+      NOW,
+    );
+    expect(stats.fetched).toBe(3);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
   });
 });

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -63,7 +63,12 @@ import { buildAlarmKey, putPending } from './pendingPushes';
 import { enqueueRetryIfTransient } from './retryPushes';
 import { deleteProgress, getProgress, putProgress, type TripProgress } from './progress';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from './seoul';
-import { pollLinesAndStamp, readSelfPollPosition } from './selfPollPosition';
+import {
+  N_STATION_LOOKAHEAD,
+  pollLinesAndStamp,
+  pollStationsAndStamp,
+  readSelfPollPosition,
+} from './selfPollPosition';
 import { phaseAllowsImminentFiring, runStationPhaseStep } from './stationPhase';
 import { listTrips, putTrip } from './trips';
 import {
@@ -610,6 +615,21 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   realtimePositionFetchError: number;
   /**
+   * #1828 Phase 5 — station-level Seoul fetchArrivals fetch 횟수 (KV cache miss).
+   * trip route 다음 N개 역 union에 대해 Seoul realtimeStationArrival 1회 호출.
+   * line call(max 100 trains) 대신 station call(max 10 arrivals)로 API 비용 1/10 이하.
+   */
+  stationPollFetch: number;
+  /**
+   * #1828 Phase 5 — station arrivals KV stamp 살아있어 fetch skip한 횟수.
+   */
+  stationPollCacheHit: number;
+  /**
+   * #1828 Phase 5 — station arrivals fetch 실패 횟수.
+   * 0이 아니면 Seoul API 오류 또는 KV write 실패 신호.
+   */
+  stationPollError: number;
+  /**
    * #1614 Phase C — `fireArvlCdStationPush` 진입 시 SSoT.lastAdvanceAt이 stale(>3분 경과)이라
    * fire를 차단한 누적 횟수. transferDestinationGate(60s)보다 보수적이지만 모든 fire kind에
    * 동일 적용. 정상 운영에서는 0에 가깝고, 0이 아니면 motion 추적 cascade fail 또는 stale lock
@@ -729,6 +749,27 @@ async function collectActiveLines(env: Env, now: number): Promise<Set<LineNumber
   return lines;
 }
 
+/**
+ * #1828 Phase 5 — 활성 trip route의 다음 N개 역 name union 수집.
+ *
+ * `trip.waypoints`는 이미 shift된 잔여 waypoints 배열 — 맨 앞이 다음 알람 대상 역.
+ * 각 trip에서 `N_STATION_LOOKAHEAD`개(최대)를 추출해 union dedup. 같은 역을 여러 trip이
+ * 공유해도 Set으로 자연 dedup — Seoul fetchArrivals 중복 호출 방지.
+ *
+ * #1652 line-union과 동일 필터 — 만료 / lifecycle-abnormal trip은 skip.
+ */
+async function collectActiveStations(env: Env, now: number): Promise<Set<string>> {
+  const stations = new Set<string>();
+  for await (const trip of listTrips(env.TRIPS)) {
+    if (trip.expiresAt <= now) continue;
+    if (tripLifecyclePhase(trip, now) !== 'normal') continue;
+    for (const waypoint of trip.waypoints.slice(0, N_STATION_LOOKAHEAD)) {
+      stations.add(waypoint.stationName);
+    }
+  }
+  return stations;
+}
+
 export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<ScheduledStats> {
   const now = deps.now?.() ?? Date.now();
   const log = deps.log ?? (() => undefined);
@@ -775,6 +816,10 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     realtimePositionFetch: 0,
     selfPollCacheHit: 0,
     realtimePositionFetchError: 0,
+    // #1828 Phase 5 — station-level arrivals self-poll stats.
+    stationPollFetch: 0,
+    stationPollCacheHit: 0,
+    stationPollError: 0,
     // #1614 Phase C — stale SSoT 가드 fire 차단.
     staleLockFireSkipped: 0,
     // #1652 — staged lifecycle backstop (X8). 6h~9h skip / 9h+ force-end.
@@ -817,6 +862,23 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       fetched: selfPollStats.fetched,
       cacheHit: selfPollStats.cacheHit,
       error: selfPollStats.error,
+    });
+  }
+
+  // #1828 Phase 5 — 활성 trip route 다음 N개 역 union 추출 + Seoul fetchArrivals station-level stamp.
+  // line-unit polling(max 100 trains/call) 대신 station-unit(max 10 arrivals/call)으로 전환.
+  // route bound 폴링으로 trip 무관 trains candidate-reject 감소 (Day 2 evidence: 53건/시간).
+  const activeStations = await collectActiveStations(env, now);
+  const stationPollStats = await pollStationsAndStamp(env.TRIPS, deps.seoul, activeStations, now);
+  stats.stationPollFetch += stationPollStats.fetched;
+  stats.stationPollCacheHit += stationPollStats.cacheHit;
+  stats.stationPollError += stationPollStats.error;
+  if (activeStations.size > 0) {
+    log('self-poll: stationArrivals', {
+      stations: activeStations.size,
+      fetched: stationPollStats.fetched,
+      cacheHit: stationPollStats.cacheHit,
+      error: stationPollStats.error,
     });
   }
 

--- a/backend/alarm-worker/src/selfPollPosition.ts
+++ b/backend/alarm-worker/src/selfPollPosition.ts
@@ -13,6 +13,17 @@
  * stamp한다. caller(`advanceTripPosition` site들)는 본 stamp를 lock.trainCode와 cross-match해
  * `evidence.type='position-train'`을 합성 → strongCB 통과 가능.
  *
+ * Phase 5 (#1828) — station-level arrivals polling
+ * ================================================
+ * 기존 line-unit polling은 Seoul API에서 line 전체 trains(max 100)를 받아 KV에 stamp한다.
+ * 활성 trip route와 무관한 trains도 모두 포함되어 backend Seoul API call당 비용이 크다.
+ *
+ * Phase 5는 trip의 다음 N_STATION_LOOKAHEAD개 waypoints에서 역 이름 union을 추출 →
+ * 각 역마다 `fetchArrivals(stationName)` 호출 → `selfPoll:station:<stnName>` 30s TTL stamp.
+ * - API call당 반환 크기: line(max 100 trains) → station(max 10 arrivals) → 1/10
+ * - route bound: trip route 외 trains 0건 (candidate-reject 감소)
+ * - fallback 보존: arrivals empty 시 빈 배열 stamp → caller는 자연 fallback
+ *
  * KV cacheTtl 정책
  * ================
  * `expirationTtl: 30s` — Cloudflare KV 런타임 floor(`KV_MIN_CACHE_TTL_SEC=30`). cron 1분 race
@@ -29,11 +40,14 @@
  */
 
 import { assertCronCacheTtl, CRON_READ_CACHE_TTL_SEC } from './kvConsistency';
-import type { PositionEntry, SeoulArrivalClient } from './seoul';
+import type { ArrivalEntry, PositionEntry, SeoulArrivalClient } from './seoul';
 import type { LineNumber } from './types';
 
-/** KV key prefix — 노선 단위 1 entry. */
+/** KV key prefix — 노선 단위 1 entry (기존 line-unit polling 유지). */
 const SELF_POLL_PREFIX = 'realtime-position:';
+
+/** KV key prefix — Phase 5 (#1828) station-unit arrival stamp. */
+const SELF_POLL_STATION_PREFIX = 'selfPoll:station:';
 
 /**
  * KV expirationTtl — Cloudflare 런타임 floor(`CRON_READ_CACHE_TTL_SEC=30`).
@@ -43,6 +57,14 @@ const SELF_POLL_PREFIX = 'realtime-position:';
  */
 export const SELF_POLL_TTL_SEC = CRON_READ_CACHE_TTL_SEC;
 
+/**
+ * Phase 5 (#1828) — trip waypoints 중 station-level polling 대상 최대 개수.
+ *
+ * N=5: 다음 역 + 1환승 + 2환승 + 종점 + 여분 1개. trip의 잔여 waypoints가 5개 미만이면
+ * 잔여 전체를 사용. N을 늘릴수록 Seoul API call 증가 — 5가 효율/정확도 균형.
+ */
+export const N_STATION_LOOKAHEAD = 5;
+
 /** KV에 stamp된 self-poll entry (live PositionEntry[] + 적재 시점 stamp). */
 interface SelfPollEntry {
   /** Seoul realtimePosition 결과 (호선 단위 모든 운행 trainCode 위치). */
@@ -51,8 +73,21 @@ interface SelfPollEntry {
   fetchedAt: number;
 }
 
+/** Phase 5 (#1828) — KV에 stamp된 station-level arrivals entry. */
+interface StationArrivalEntry {
+  /** Seoul realtimeStationArrival 결과 (역 단위 도착 정보, max 10). */
+  arrivals: ArrivalEntry[];
+  /** stamp 시점 epoch ms. */
+  fetchedAt: number;
+}
+
 export function selfPollKey(line: LineNumber): string {
   return `${SELF_POLL_PREFIX}${line}`;
+}
+
+/** Phase 5 (#1828) — station-level arrivals KV key. */
+export function selfPollStationKey(stationName: string): string {
+  return `${SELF_POLL_STATION_PREFIX}${stationName}`;
 }
 
 /**
@@ -104,6 +139,49 @@ export async function writeSelfPollPosition(
 }
 
 /**
+ * Phase 5 (#1828) — KV에서 station의 마지막 arrivals stamp를 조회.
+ *
+ * @param kv TRIPS KV namespace
+ * @param stationName 역명 (Seoul API stationName, 예: "신도림")
+ * @returns 마지막 stamp 또는 null
+ */
+export async function readSelfPollStationArrivals(
+  kv: KVNamespace,
+  stationName: string,
+): Promise<StationArrivalEntry | null> {
+  assertCronCacheTtl(CRON_READ_CACHE_TTL_SEC);
+  const raw = await kv.get(selfPollStationKey(stationName), {
+    cacheTtl: CRON_READ_CACHE_TTL_SEC,
+  });
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as StationArrivalEntry;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Phase 5 (#1828) — `SeoulArrivalClient.fetchArrivals(stationName)` 결과를 KV에 30s TTL stamp.
+ *
+ * @param kv TRIPS KV namespace
+ * @param stationName 역명
+ * @param arrivals `seoul.fetchArrivals(stationName)` 결과
+ * @param now stamp 시점 epoch ms
+ */
+export async function writeSelfPollStationArrivals(
+  kv: KVNamespace,
+  stationName: string,
+  arrivals: ArrivalEntry[],
+  now: number,
+): Promise<void> {
+  const entry: StationArrivalEntry = { arrivals, fetchedAt: now };
+  await kv.put(selfPollStationKey(stationName), JSON.stringify(entry), {
+    expirationTtl: SELF_POLL_TTL_SEC,
+  });
+}
+
+/**
  * Self-poll 호출 stats — `runScheduled`의 stats 객체에 누적된다.
  *
  * - `fetched`: 실제 Seoul API 호출 횟수 (KV cache miss).
@@ -150,6 +228,47 @@ export async function pollLinesAndStamp(
         }
         const positions = await seoul.fetchPositions(line);
         await writeSelfPollPosition(kv, line, positions, now);
+        stats.fetched += 1;
+      } catch {
+        stats.error += 1;
+      }
+    }),
+  );
+  return stats;
+}
+
+/**
+ * Phase 5 (#1828) — 활성 trip route의 다음 N개 역 union에 대해 station-level arrivals self-poll.
+ *
+ * `runScheduled` 진입부에서 `listTrips`로 추출된 station name Set을 받아, 각 역에 대해
+ * (1) KV stamp가 살아있으면 skip (cacheHit++) (2) 없으면 `seoul.fetchArrivals(stationName)` 후
+ * `writeSelfPollStationArrivals` (fetched++). 병렬 `Promise.allSettled` — 1개 역 실패가 다른 역
+ * 영향 X. SeoulArrivalClient 내부 15s in-memory cache로 같은 역 여러 trip 간 dedup.
+ *
+ * @param kv TRIPS KV namespace
+ * @param seoul SeoulArrivalClient
+ * @param stations 활성 trip route 다음 N개 역 name union
+ * @param now 현재 epoch ms (KV stamp 시점)
+ * @returns SelfPollStats
+ */
+export async function pollStationsAndStamp(
+  kv: KVNamespace,
+  seoul: SeoulArrivalClient,
+  stations: ReadonlySet<string>,
+  now: number,
+): Promise<SelfPollStats> {
+  const stats: SelfPollStats = { fetched: 0, cacheHit: 0, error: 0 };
+  if (stations.size === 0) return stats;
+  await Promise.allSettled(
+    Array.from(stations).map(async (stationName) => {
+      try {
+        const existing = await readSelfPollStationArrivals(kv, stationName);
+        if (existing) {
+          stats.cacheHit += 1;
+          return;
+        }
+        const arrivals = await seoul.fetchArrivals(stationName);
+        await writeSelfPollStationArrivals(kv, stationName, arrivals, now);
         stats.fetched += 1;
       } catch {
         stats.error += 1;


### PR DESCRIPTION
## Summary

- `selfPollPosition.ts`에 `pollStationsAndStamp` / `readSelfPollStationArrivals` / `writeSelfPollStationArrivals` 추가
- `scheduled.ts` cron 진입부에 `collectActiveStations` + `pollStationsAndStamp` 호출 추가
- 기존 `pollLinesAndStamp` (positions 기반, vanish-swap 용) 완전 보존

## 문제 (Day 2 evidence)

`fusion-candidate-reject candidate-distance-reject` 53건/시간 — 인천/이매/보정 등 사용자 trip 무관 trains를 line 전체(max 100)에서 device가 평가하고 reject.

## 구현 (옵션 A 채택)

### 신규 KV 네임스페이스

| Key | 내용 | TTL |
|---|---|---|
| `selfPoll:station:<stnName>` | station-level arrivals (max 10, ArrivalEntry[]) | 30s |
| `realtime-position:<line>` | (기존 유지) line-level positions | 30s |

### N=5 결정

`N_STATION_LOOKAHEAD=5` — 다음 역 + 1환승 + 2환승 + 종점 + 여분. trip.waypoints 잔여가 5개 미만이면 전체 사용.

### API call 비교

| 기존 | Phase 5 |
|---|---|
| `fetchPositions(line)` → max 100 trains | `fetchArrivals(stnName)` → max 10 arrivals |
| 1~3 line calls/cron | 최대 10~15 station calls/cron (SeoulArrivalClient 15s cache dedup) |
| route 무관 trains 포함 | route bound only |

### Graceful fallback

- arrivals empty → 빈 배열 stamp (기존 behavior 유지)
- Seoul API error → `error++` 누적, KV stamp 없음 → caller 자연 fallback
- Promise.allSettled — 1개 역 실패가 다른 역 차단 X

## Audit 결과 (§6 갱신됨)

1. **Caller wiring**: `scheduled.ts:809` collectActiveLines → collectActiveStations 패러럴 추가
2. **Station 선정**: `trip.waypoints.slice(0, N_STATION_LOOKAHEAD)` — shift된 잔여 waypoints 기반
3. **arrivalsFromPositions 호환**: 기존 positions KV (`realtime-position:<line>`) 완전 보존 — vanish-swap path 무영향
4. **Rate limit**: N=5 × M=3 trips = 최대 15 calls/cron. line call(100 trains) vs station call(10 arrivals) — 응답 크기 1/10 감소
5. **Fallback**: arrivals empty 시 빈 배열 stamp → 기존 schedule fallback 자연 보존

## Wire-completion 5단

1. **Orphan 없음**: `pollStationsAndStamp` / `readSelfPollStationArrivals` / `writeSelfPollStationArrivals` / `selfPollStationKey` 모두 scheduled.ts 또는 test에서 호출됨. `npm run lint:orphan` 0 orphan 확인.
2. **V/X dashboard**: `wrangler tail` `self-poll: stationArrivals` log — `stations / fetched / cacheHit / error` 필드. `ScheduledStats.stationPollFetch / stationPollCacheHit / stationPollError` Sentry/analytics 카운터.
3. **의존 PR**: N/A — 기존 #1825 (schedule fallback) 무영향, selfPollPosition.ts 독립 모듈.
4. **측정 plan**: 1주 `wrangler tail | grep "stationArrivals"` — fetched/cacheHit ratio + `fusion-candidate-reject` 분포 변화 (53/h → 목표 5/h 이하).
5. **Device verify**: N/A — backend cron + KV stamp only. device-side KV 읽기 wire-up은 별도 PR. type+unit only.

## 테스트

- `selfPollPosition.test.ts`: 34 tests (10개 신규 pollStationsAndStamp 케이스 포함)
- `scheduled.test.ts`: 337 tests (모두 패스, `#640 lockMissing` 테스트 comment 갱신)
- backend 전체: 2175 tests 패스
- `tsc --noEmit`: 0 errors
- `npm run lint:orphan`: 0 orphan

Closes #1828