### PR TITLE
feat(#1836): Phase 6.1 지하 cold start 감지 + 후보 station 추출 (Sub-step 1+2)

### DIFF
--- a/scripts/check-orphan-exports.sh
+++ b/scripts/check-orphan-exports.sh
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 
-IGNORE_PATTERN='app/|modules/|providers/index\.ts|providers/types\.ts|providers/progress/index\.ts|theme/index\.ts|src/shared/types/|src/shared/constants/(e2e|storageKeys)\.ts|silentPushTask\.ts|movementGate\.ts'
+IGNORE_PATTERN='app/|modules/|providers/index\.ts|providers/types\.ts|providers/progress/index\.ts|theme/index\.ts|src/shared/types/|src/shared/constants/(e2e|storageKeys)\.ts|silentPushTask\.ts|movementGate\.ts|useColdStartCandidates\.ts'
 
 OUTPUT=$(npx --no-install ts-prune --ignore "$IGNORE_PATTERN" 2>&1 | grep -v "(used in module)" || true)
 

--- a/src/features/nearest-station/hooks/__tests__/useColdStartCandidates.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useColdStartCandidates.test.ts
@@ -1,0 +1,278 @@
+import { renderHook } from '@testing-library/react-native';
+import {
+  useColdStartCandidates,
+  extractColdStartCandidates,
+  COLD_START_ACCURACY_THRESHOLD_M,
+  COLD_START_RADIUS_KM,
+} from '../useColdStartCandidates';
+
+// ── 공통 픽스처 ───────────────────────────────────────────────────────────────
+
+/**
+ * 왕십리 기준점 — bundang 선 좌표 (stations.json 실재 값).
+ * 500m 반경 내 entries: 왕십리(성동구청)/line 2, 왕십리(성동구청)/line 5,
+ *   왕십리(성동구청)/gyeongui, 왕십리/bundang → 정규화 후 전부 '왕십리' (1개 그룹).
+ */
+const WANGSIMNI = { lat: 37.561827, lng: 127.038352 };
+
+/**
+ * 용마산 기준점 — 7호선 단독역. 500m 반경 내 다른 역 없음 (단일 후보).
+ */
+const YONGMASAN = { lat: 37.573647, lng: 127.086727 };
+
+/**
+ * 신촌(2호선) 기준점 — 500m 반경 내 신촌 + 서강대 2개 정규화 이름.
+ */
+const SINCHON_LINE2 = { lat: 37.555131, lng: 126.936926 };
+
+/** cold start 진입 조건 충족하는 지하 환경 기본값. */
+const UNDERGROUND_ENV = 'underground' as const;
+const UNKNOWN_ENV = 'unknown' as const;
+
+/** accuracy > 50m — cold start 게이트 통과. */
+const LOW_ACCURACY = COLD_START_ACCURACY_THRESHOLD_M + 1;
+
+// ── 1. cold start 감지 3 조건 AND ────────────────────────────────────────────
+
+describe('cold start 감지 조건 (3개 AND)', () => {
+  it('accuracy <= 50m 이면 null (cold start 아님)', () => {
+    const { result } = renderHook(() =>
+      useColdStartCandidates({
+        gps: { ...YONGMASAN, accuracy: COLD_START_ACCURACY_THRESHOLD_M },
+        environment: UNDERGROUND_ENV,
+        hasTrip: false,
+      }),
+    );
+    expect(result.current).toBeNull();
+  });
+
+  it('accuracy = 1 (GPS 정확) 이면 null', () => {
+    const { result } = renderHook(() =>
+      useColdStartCandidates({
+        gps: { ...YONGMASAN, accuracy: 1 },
+        environment: UNDERGROUND_ENV,
+        hasTrip: false,
+      }),
+    );
+    expect(result.current).toBeNull();
+  });
+
+  it('environment = surface 이면 null', () => {
+    const { result } = renderHook(() =>
+      useColdStartCandidates({
+        gps: { ...YONGMASAN, accuracy: LOW_ACCURACY },
+        environment: 'surface',
+        hasTrip: false,
+      }),
+    );
+    expect(result.current).toBeNull();
+  });
+
+  it('environment = hybrid 이면 null', () => {
+    const { result } = renderHook(() =>
+      useColdStartCandidates({
+        gps: { ...YONGMASAN, accuracy: LOW_ACCURACY },
+        environment: 'hybrid',
+        hasTrip: false,
+      }),
+    );
+    expect(result.current).toBeNull();
+  });
+
+  it('hasTrip = true 이면 null', () => {
+    const { result } = renderHook(() =>
+      useColdStartCandidates({
+        gps: { ...YONGMASAN, accuracy: LOW_ACCURACY },
+        environment: UNDERGROUND_ENV,
+        hasTrip: true,
+      }),
+    );
+    expect(result.current).toBeNull();
+  });
+
+  it('gps = null 이면 null', () => {
+    const { result } = renderHook(() =>
+      useColdStartCandidates({
+        gps: null,
+        environment: UNDERGROUND_ENV,
+        hasTrip: false,
+      }),
+    );
+    expect(result.current).toBeNull();
+  });
+
+  it('3 조건 모두 충족 시 후보 배열 반환 (underground)', () => {
+    const { result } = renderHook(() =>
+      useColdStartCandidates({
+        gps: { ...YONGMASAN, accuracy: LOW_ACCURACY },
+        environment: UNDERGROUND_ENV,
+        hasTrip: false,
+      }),
+    );
+    expect(result.current).not.toBeNull();
+    expect(Array.isArray(result.current)).toBe(true);
+  });
+
+  it('3 조건 모두 충족 시 후보 배열 반환 (unknown)', () => {
+    const { result } = renderHook(() =>
+      useColdStartCandidates({
+        gps: { ...YONGMASAN, accuracy: LOW_ACCURACY },
+        environment: UNKNOWN_ENV,
+        hasTrip: false,
+      }),
+    );
+    expect(result.current).not.toBeNull();
+  });
+});
+
+// ── 2. 환승 호선 dedup ────────────────────────────────────────────────────────
+
+describe('환승 호선 dedup (왕십리)', () => {
+  it('왕십리 entries (2/5/gyeongui/bundang) → 1개 그룹으로 dedup', () => {
+    const candidates = extractColdStartCandidates(WANGSIMNI.lat, WANGSIMNI.lng);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].stationName).toBe('왕십리');
+  });
+
+  it('왕십리 그룹에 4개 노선 포함 (2, 5, gyeongui, bundang)', () => {
+    const candidates = extractColdStartCandidates(WANGSIMNI.lat, WANGSIMNI.lng);
+    const { lines } = candidates[0];
+    expect(lines).toContain('2');
+    expect(lines).toContain('5');
+    expect(lines).toContain('gyeongui');
+    expect(lines).toContain('bundang');
+    expect(lines).toHaveLength(4);
+  });
+
+  it('왕십리 그룹의 stations 배열에 4개 entry 포함', () => {
+    const candidates = extractColdStartCandidates(WANGSIMNI.lat, WANGSIMNI.lng);
+    expect(candidates[0].stations).toHaveLength(4);
+  });
+
+  it('왕십리 그룹 distanceKm은 0에 가까움 (기준점이 역 좌표)', () => {
+    const candidates = extractColdStartCandidates(WANGSIMNI.lat, WANGSIMNI.lng);
+    expect(candidates[0].distanceKm).toBeLessThan(0.01);
+  });
+});
+
+// ── 3. 단일 역 (용마산) ────────────────────────────────────────────────────────
+
+describe('단일 역 후보 (용마산)', () => {
+  it('용마산 좌표에서 500m 반경 내 1개 후보 반환', () => {
+    const candidates = extractColdStartCandidates(YONGMASAN.lat, YONGMASAN.lng);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].stationName).toBe('용마산');
+  });
+
+  it('용마산 그룹 lines에 7호선 포함', () => {
+    const candidates = extractColdStartCandidates(YONGMASAN.lat, YONGMASAN.lng);
+    expect(candidates[0].lines).toContain('7');
+  });
+});
+
+// ── 4. 복수 역 (신촌 — 신촌 + 서강대) ────────────────────────────────────────
+
+describe('복수 역 후보 (신촌 인근 2개 정규화 이름)', () => {
+  it('신촌(2호선) 좌표에서 500m 반경 내 2개 unique name 반환', () => {
+    const candidates = extractColdStartCandidates(SINCHON_LINE2.lat, SINCHON_LINE2.lng);
+    expect(candidates.length).toBeGreaterThanOrEqual(2);
+    const names = candidates.map((c) => c.stationName);
+    expect(names).toContain('신촌');
+  });
+
+  it('후보는 거리순 정렬 — 신촌이 1순위', () => {
+    const candidates = extractColdStartCandidates(SINCHON_LINE2.lat, SINCHON_LINE2.lng);
+    expect(candidates[0].stationName).toBe('신촌');
+  });
+
+  it('신촌 그룹 distanceKm < 서강대 그룹 distanceKm', () => {
+    const candidates = extractColdStartCandidates(SINCHON_LINE2.lat, SINCHON_LINE2.lng);
+    const sinchon = candidates.find((c) => c.stationName === '신촌');
+    const seogangdae = candidates.find((c) => c.stationName.includes('서강'));
+    expect(sinchon).toBeDefined();
+    expect(seogangdae).toBeDefined();
+    expect(sinchon!.distanceKm).toBeLessThan(seogangdae!.distanceKm);
+  });
+});
+
+// ── 5. 정확도별 gate (useColdStartCandidates 훅) ────────────────────────────
+
+describe('accuracy gate — useColdStartCandidates 훅', () => {
+  it('accuracy = 51m (> 50m) → 후보 반환', () => {
+    const { result } = renderHook(() =>
+      useColdStartCandidates({
+        gps: { ...YONGMASAN, accuracy: 51 },
+        environment: UNDERGROUND_ENV,
+        hasTrip: false,
+      }),
+    );
+    expect(result.current).not.toBeNull();
+    expect(result.current!.length).toBeGreaterThan(0);
+  });
+
+  it('accuracy = 200m → 후보 반환 (지하 저정확도 대표값)', () => {
+    const { result } = renderHook(() =>
+      useColdStartCandidates({
+        gps: { ...YONGMASAN, accuracy: 200 },
+        environment: UNDERGROUND_ENV,
+        hasTrip: false,
+      }),
+    );
+    expect(result.current).not.toBeNull();
+  });
+
+  it('accuracy = 1000m → 후보 반환 (최악 정확도)', () => {
+    const { result } = renderHook(() =>
+      useColdStartCandidates({
+        gps: { ...YONGMASAN, accuracy: 1000 },
+        environment: UNDERGROUND_ENV,
+        hasTrip: false,
+      }),
+    );
+    expect(result.current).not.toBeNull();
+  });
+
+  it('accuracy = 50m (경계) → null', () => {
+    const { result } = renderHook(() =>
+      useColdStartCandidates({
+        gps: { ...YONGMASAN, accuracy: 50 },
+        environment: UNDERGROUND_ENV,
+        hasTrip: false,
+      }),
+    );
+    expect(result.current).toBeNull();
+  });
+});
+
+// ── 6. 반경 밖 위치 ─────────────────────────────────────────────────────────
+
+describe('반경 외 위치', () => {
+  it('한반도 외 좌표에서 0개 후보 → 빈 배열', () => {
+    const candidates = extractColdStartCandidates(0, 0);
+    expect(candidates).toHaveLength(0);
+  });
+
+  it('useColdStartCandidates: 역 없는 위치에서 빈 배열 반환 (null 아님)', () => {
+    const { result } = renderHook(() =>
+      useColdStartCandidates({
+        gps: { lat: 0, lng: 0, accuracy: LOW_ACCURACY },
+        environment: UNDERGROUND_ENV,
+        hasTrip: false,
+      }),
+    );
+    // cold start 조건 충족 + 반경 내 역 없음 → 빈 배열
+    expect(result.current).toEqual([]);
+  });
+});
+
+// ── 7. 상수 export 검증 ──────────────────────────────────────────────────────
+
+describe('exported constants', () => {
+  it('COLD_START_ACCURACY_THRESHOLD_M = 50', () => {
+    expect(COLD_START_ACCURACY_THRESHOLD_M).toBe(50);
+  });
+
+  it('COLD_START_RADIUS_KM = 0.5', () => {
+    expect(COLD_START_RADIUS_KM).toBe(0.5);
+  });
+});

--- a/src/features/nearest-station/hooks/useColdStartCandidates.ts
+++ b/src/features/nearest-station/hooks/useColdStartCandidates.ts
@@ -1,0 +1,133 @@
+/**
+ * Phase 6.1 (#1836) — 지하 cold start 감지 + 후보 station 추출 (Sub-step 1+2).
+ *
+ * cold start 조건 3개 AND:
+ *  1. GPS 정확도 > 50m  — 지하 + 5G/LTE 환경 전형적 범위
+ *  2. environment = 'underground' | 'unknown'
+ *  3. hasTrip = false  — 진행 중 trip 없음
+ *
+ * 조건 충족 시 GPS 좌표 ± 0.5km 반경 stations를 추출하여 환승 호선 dedup한 후
+ * ColdStartCandidate[] 반환. 미충족 시 null.
+ *
+ * Sub-step 3 (시간표/즐겨찾기 narrow), Sub-step 4 (선택 UI), Sub-step 5 (mismatch 재확인)은 별 PR.
+ */
+import { useMemo } from 'react';
+import stationsData from '../../../data/stations.json';
+import { haversine } from '../../../shared/utils/haversine';
+import type { LineNumber, Station } from '../../../shared/types/station';
+
+/** cold start 판단에 쓰이는 GPS 정확도 임계값(m). 50m 초과 시 cold start 상황으로 간주. */
+export const COLD_START_ACCURACY_THRESHOLD_M = 50;
+
+/** cold start 후보 탐색 반경(km). */
+export const COLD_START_RADIUS_KM = 0.5;
+
+const stations = stationsData as Station[];
+
+/**
+ * 역 이름 정규화 — 후행 괄호 부제 제거.
+ * "왕십리(성동구청)" → "왕십리"
+ * groupStationsByName의 normalize와 동일 로직.
+ */
+function normalizeStationName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed.endsWith(')')) return trimmed;
+  const open = trimmed.lastIndexOf('(');
+  /* istanbul ignore next — 실제 역명에서 '(' 없이 ')'로 끝나는 케이스 없음 (방어적 guard) */
+  if (open === -1) return trimmed;
+  return trimmed.slice(0, open).trimEnd();
+}
+
+/** 환승 호선 dedup 후 하나의 cold start 후보를 나타내는 그룹. */
+export interface ColdStartCandidate {
+  /** 정규화된 역 이름 (괄호 부제 제거). 예: "왕십리" */
+  readonly stationName: string;
+  /** 이 역을 경유하는 노선 목록. 환승역은 복수. */
+  readonly lines: readonly LineNumber[];
+  /** GPS 좌표 기준 가장 가까운 entry까지의 거리(km). */
+  readonly distanceKm: number;
+  /** 가장 가까운 entry의 위도. */
+  readonly lat: number;
+  /** 가장 가까운 entry의 경도. */
+  readonly lng: number;
+  /** 이 이름에 속하는 모든 Station entry (노선별 환승 정보 포함). Sub-step 4 UI 사용. */
+  readonly stations: readonly Station[];
+}
+
+export interface UseColdStartCandidatesInput {
+  /** 현재 GPS 좌표 및 정확도. */
+  readonly gps: { readonly lat: number; readonly lng: number; readonly accuracy: number } | null;
+  /** 환경 분류. */
+  readonly environment: 'surface' | 'underground' | 'hybrid' | 'unknown';
+  /** 진행 중 trip 존재 여부. */
+  readonly hasTrip: boolean;
+}
+
+/**
+ * 지하 cold start 상태를 감지하고 반경 내 역 후보를 추출한다.
+ *
+ * 반환값:
+ *  - `ColdStartCandidate[]` — cold start 조건 충족 + 1개 이상 후보 존재
+ *  - `null` — cold start 조건 미충족 (정확도 양호 / trip 진행 중 / 지상 환경)
+ */
+export function useColdStartCandidates(
+  input: UseColdStartCandidatesInput,
+): ColdStartCandidate[] | null {
+  const { gps, environment, hasTrip } = input;
+
+  return useMemo<ColdStartCandidate[] | null>(() => {
+    // cold start 조건 3개 AND 검사
+    if (gps === null) return null;
+    if (gps.accuracy <= COLD_START_ACCURACY_THRESHOLD_M) return null;
+    if (environment === 'surface' || environment === 'hybrid') return null;
+    if (hasTrip) return null;
+
+    return extractColdStartCandidates(gps.lat, gps.lng);
+  }, [gps, environment, hasTrip]);
+}
+
+/**
+ * 순수 함수: GPS 좌표 기준 0.5km 반경 내 역을 추출하고 환승 호선 dedup.
+ *
+ * 단독 export — Sub-step 3 weighted narrow 함수가 이 결과를 입력으로 사용할 수 있게 분리.
+ */
+export function extractColdStartCandidates(lat: number, lng: number): ColdStartCandidate[] {
+  // 반경 내 모든 entry를 거리순 정렬
+  const inRadius = stations
+    .map((s) => ({ station: s, distanceKm: haversine(lat, lng, s.lat, s.lng) }))
+    .filter((r) => r.distanceKm <= COLD_START_RADIUS_KM)
+    .sort((a, b) => a.distanceKm - b.distanceKm);
+
+  if (inRadius.length === 0) return [];
+
+  // 정규화된 역 이름 기준으로 그룹화 (환승 호선 dedup)
+  const buckets = new Map<string, { entries: Array<{ station: Station; distanceKm: number }> }>();
+  for (const r of inRadius) {
+    const key = normalizeStationName(r.station.name);
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = { entries: [] };
+      buckets.set(key, bucket);
+    }
+    bucket.entries.push(r);
+  }
+
+  const candidates: ColdStartCandidate[] = [];
+  for (const [stationName, { entries }] of buckets) {
+    // entries는 이미 거리순 — 가장 가까운 entry 기준 위치 사용
+    const closest = entries[0];
+    const lines = entries.map((e) => e.station.line);
+    candidates.push({
+      stationName,
+      lines,
+      distanceKm: closest.distanceKm,
+      lat: closest.station.lat,
+      lng: closest.station.lng,
+      stations: entries.map((e) => e.station),
+    });
+  }
+
+  // 거리순 정렬 (bucket 삽입 순서는 entries 최소 거리 기준이므로 재정렬)
+  candidates.sort((a, b) => a.distanceKm - b.distanceKm);
+  return candidates;
+}


### PR DESCRIPTION
## Summary

- `useColdStartCandidates` 훅 신규: GPS 정확도 > 50m + environment underground/unknown + !hasTrip 3조건 AND 감지
- `extractColdStartCandidates` 순수 함수: 0.5km 반경 역 추출 + 환승 호선 dedup (정규화 이름 기준)
- `ColdStartCandidate` 타입: Sub-step 4 UI가 바로 사용할 수 있는 `stationName/lines/distanceKm/stations` 구조
- 25개 테스트 100% 커버 (gate 3조건, 왕십리 dedup 4→1, 거리순 정렬, 경계값, 반경 외)

Closes #1836

---

## Audit 결과 요약 (plan §10)

| 항목 | 결과 |
|---|---|
| 정확도 게이트 위치 | `useNearestStation.ts:382` — `isAccuracyAcceptableForDisplay` 초과 시 fix drop → cold start 시 chain 0건 root |
| trigger 위치 | 별 hook (`useColdStartCandidates`) — 기존 hook 미수정 |
| 반경 추출 | O(533) iterate + haversine. cold start one-shot → spatial index 불필요 |
| dedup 기준 | 정규화(후행 `()` 제거): "왕십리(성동구청)" × 3 + "왕십리" × 1 → 1개 그룹 (실증) |
| ColdStartCandidate | `stationName/lines/distanceKm/lat/lng/stations` |
| D1 wire | 별 PR (Sub-step 4 이후 caller에서 적재) |

---

## Wire-completion 5단

1. **Orphan**: `useColdStartCandidates.ts`를 `scripts/check-orphan-exports.sh` IGNORE_PATTERN에 추가. Sub-step 4 (선택 UI)가 caller — 별 PR. `npm run lint:orphan` 0 orphan 확인.
2. **V/X dashboard**: Sub-step 4 PR에서 DebugModal "Cold Start Candidates" 섹션 추가. 본 PR은 데이터 산출 only.
3. **의존 PR**: N/A — device-only, backend 의존 없음. Sub-step 3~5는 별 PR.
4. **측정 plan**: Sub-step 4 머지 + EAS rebuild 후 실기기 trip 1건에서 candidates 개수 분포 확인 (1주).
5. **Device verify**: N/A — type+unit only. 실기기 검증은 Sub-step 4 UI 연결 후 (지하 cold start trip 1건).

---

## 옵션 채택

plan §6 결정(A — Cold start 전용 path + 후보 선택 UI) 유지. 변경 없음.

Sub-step 3~5는 별 PR:
- Sub-step 3: 시간표 + barometer + 즐겨찾기 weighted narrow
- Sub-step 4: 다중 station 선택 UI (boardingPrompt 확장)
- Sub-step 5: mismatch 재확인 prompt