### PR TITLE
feat(#1842): Phase 6.1 Sub-step 4 — cold start 다중 후보 선택 UI (ColdStartCandidatePicker)

### DIFF
--- a/src/features/nearest-station/components/ColdStartCandidatePicker.tsx
+++ b/src/features/nearest-station/components/ColdStartCandidatePicker.tsx
@@ -1,0 +1,208 @@
+/**
+ * Phase 6.1 (#1842) Sub-step 4 — cold start 다중 후보 선택 UI.
+ *
+ * candidate count 분기:
+ *  - 0개 : 표시하지 않음 (caller가 visible=false 보장)
+ *  - 1개 : 기존 boardingPrompt 흐름 트리거 → onSingleCandidate 콜백 호출
+ *  - 2~5개: 역 카드 목록 — 역명 + LineBadge(호선) + 거리(km) 표시
+ *  - 6+개: 노선 검색 fallback 안내 메시지 + 버튼
+ *
+ * 선택 시 → onSelectCandidate(ColdStartCandidate) 호출.
+ * caller(HomeScreen)가 선택된 candidate의 stations[0]으로 setCustomOrigin을 수행해 trip chain을 시작한다.
+ */
+import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTheme, typography, spacing, radius } from '../../../shared/theme';
+import { LineBadge } from '../../../shared/ui/LineBadge';
+import type { ColdStartCandidate } from '../hooks/useColdStartCandidates';
+
+/** 다중 목록 표시 상한. 이 수 이상이면 fallback UI를 노출한다. */
+export const COLD_START_LIST_MAX = 5;
+
+interface Props {
+  readonly visible: boolean;
+  /** useColdStartCandidates 반환값 (null이면 표시 안 함 — caller가 visible=false로 제어). */
+  readonly candidates: readonly ColdStartCandidate[];
+  /** 후보 탭 시 호출. caller가 setCustomOrigin으로 연결. */
+  readonly onSelectCandidate: (candidate: ColdStartCandidate) => void;
+  /**
+   * 후보 1개일 때 호출 — 기존 boardingPrompt 흐름을 트리거하도록 caller에게 위임.
+   * candidates.length === 1 이면 컴포넌트가 자동으로 onSingleCandidate()를 호출하고 닫힌다.
+   */
+  readonly onSingleCandidate: (candidate: ColdStartCandidate) => void;
+  /** 6+개 fallback에서 노선 검색 버튼 탭 시 호출 — caller가 검색 피커를 열어야 한다. */
+  readonly onSearchFallback: () => void;
+  /** 모달 닫기 (헤더 닫기 버튼). */
+  readonly onClose: () => void;
+}
+
+export function ColdStartCandidatePicker({
+  visible,
+  candidates,
+  onSelectCandidate,
+  onSingleCandidate,
+  onSearchFallback,
+  onClose,
+}: Props) {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const { t } = useTranslation();
+
+  const count = candidates.length;
+  const isFallback = count > COLD_START_LIST_MAX;
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+      testID="cold-start-picker-modal"
+    >
+      <View style={[styles.backdrop, { backgroundColor: colors.overlay }]}>
+        <View
+          style={[
+            styles.sheet,
+            {
+              backgroundColor: colors.bg,
+              paddingTop: spacing.lg,
+              paddingBottom: insets.bottom + spacing.lg,
+            },
+          ]}
+        >
+          {/* Header */}
+          <View style={[styles.header, { borderBottomColor: colors.hair }]}>
+            <Text style={[typography.label, { color: colors.muted }]}>
+              {t('coldStartPicker.title')}
+            </Text>
+            <Pressable
+              onPress={onClose}
+              testID="cold-start-picker-close"
+              accessibilityRole="button"
+              accessibilityLabel={t('coldStartPicker.close')}
+            >
+              <Text style={[typography.body, { color: colors.accent, fontWeight: '600' }]}>
+                {t('coldStartPicker.close')}
+              </Text>
+            </Pressable>
+          </View>
+
+          {isFallback ? (
+            /* 6+개 fallback UI */
+            <View style={styles.fallback} testID="cold-start-picker-fallback">
+              <Text style={[typography.body, { color: colors.muted, textAlign: 'center' }]}>
+                {t('coldStartPicker.tooManyCandidates')}
+              </Text>
+              <Pressable
+                onPress={onSearchFallback}
+                style={[styles.searchButton, { borderColor: colors.accent }]}
+                testID="cold-start-picker-search-fallback"
+                accessibilityRole="button"
+              >
+                <Text style={[typography.body, { color: colors.accent, fontWeight: '600' }]}>
+                  {t('coldStartPicker.searchFallback')}
+                </Text>
+              </Pressable>
+            </View>
+          ) : (
+            /* 2~5개 목록 UI */
+            <ScrollView
+              style={styles.list}
+              testID="cold-start-picker-list"
+              showsVerticalScrollIndicator={false}
+            >
+              {candidates.map((candidate) => (
+                <Pressable
+                  key={candidate.stationName}
+                  onPress={() => onSelectCandidate(candidate)}
+                  style={[
+                    styles.card,
+                    {
+                      backgroundColor: colors.card,
+                      borderColor: colors.hair,
+                    },
+                  ]}
+                  testID={`cold-start-picker-item-${candidate.stationName}`}
+                  accessibilityRole="button"
+                >
+                  <View style={styles.cardInfo}>
+                    <Text style={[typography.body, { color: colors.ink, fontWeight: '600' }]}>
+                      {candidate.stationName}
+                    </Text>
+                    <View style={styles.lineBadges}>
+                      {candidate.lines.map((line) => (
+                        <LineBadge key={line} line={line} />
+                      ))}
+                    </View>
+                  </View>
+                  <Text style={[typography.bodySm, { color: colors.muted }]}>
+                    {t('coldStartPicker.distanceKm', {
+                      km: candidate.distanceKm.toFixed(2),
+                    })}
+                  </Text>
+                </Pressable>
+              ))}
+            </ScrollView>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+// 1개 케이스는 caller(useColdStartPickerController)가 처리. 컴포넌트는 순수 표시 전용.
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    borderTopLeftRadius: radius.lg,
+    borderTopRightRadius: radius.lg,
+    paddingHorizontal: spacing.lg,
+    gap: spacing.md,
+    maxHeight: '70%',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingBottom: spacing.sm,
+    borderBottomWidth: 1,
+  },
+  list: {
+    // gap은 ScrollView 하위라 StyleSheet.create에 쓸 수 없음 — card margin으로 처리
+  },
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: spacing.lg,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    marginBottom: spacing.sm,
+  },
+  cardInfo: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  lineBadges: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xs,
+    marginTop: spacing.xs,
+  },
+  fallback: {
+    alignItems: 'center',
+    gap: spacing.md,
+    paddingVertical: spacing.xl,
+  },
+  searchButton: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.md,
+    borderWidth: 1,
+  },
+});

--- a/src/features/nearest-station/components/__tests__/ColdStartCandidatePicker.test.tsx
+++ b/src/features/nearest-station/components/__tests__/ColdStartCandidatePicker.test.tsx
@@ -1,0 +1,206 @@
+import { fireEvent } from '@testing-library/react-native';
+import { ColdStartCandidatePicker, COLD_START_LIST_MAX } from '../ColdStartCandidatePicker';
+import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
+import type { ColdStartCandidate } from '../../hooks/useColdStartCandidates';
+
+// ── 픽스처 ────────────────────────────────────────────────────────────────────
+
+function makeCandidate(
+  stationName: string,
+  lines: string[],
+  distanceKm: number,
+): ColdStartCandidate {
+  return {
+    stationName,
+    lines: lines as ColdStartCandidate['lines'],
+    distanceKm,
+    lat: 37.5,
+    lng: 127.0,
+    stations: [],
+  };
+}
+
+const SINCHON = makeCandidate('신촌', ['2'], 0.05);
+const HONGIK = makeCandidate('홍대입구', ['2', 'airport', 'gyeongui'], 0.42);
+const WANGSIMNI = makeCandidate('왕십리', ['2', '5', 'gyeongui', 'bundang'], 0.1);
+const SADANG = makeCandidate('사당', ['2', '4'], 0.3);
+const YAKSU = makeCandidate('약수', ['3', '6'], 0.45);
+const EXTRA = makeCandidate('extra1', ['7'], 0.48);
+
+const TWO_TO_FIVE = [SINCHON, WANGSIMNI, SADANG, YAKSU];
+const SIX_PLUS = [SINCHON, HONGIK, WANGSIMNI, SADANG, YAKSU, EXTRA];
+
+// ── 공통 render 헬퍼 ──────────────────────────────────────────────────────────
+
+function renderPicker(overrides: {
+  visible?: boolean;
+  candidates?: readonly ColdStartCandidate[];
+  onSelectCandidate?: (c: ColdStartCandidate) => void;
+  onSingleCandidate?: (c: ColdStartCandidate) => void;
+  onSearchFallback?: () => void;
+  onClose?: () => void;
+} = {}) {
+  return renderWithTheme(
+    <ColdStartCandidatePicker
+      visible={overrides.visible ?? true}
+      candidates={overrides.candidates ?? TWO_TO_FIVE}
+      onSelectCandidate={overrides.onSelectCandidate ?? jest.fn()}
+      onSingleCandidate={overrides.onSingleCandidate ?? jest.fn()}
+      onSearchFallback={overrides.onSearchFallback ?? jest.fn()}
+      onClose={overrides.onClose ?? jest.fn()}
+    />,
+  );
+}
+
+// ── 1. 기본 렌더 ───────────────────────────────────────────────────────────────
+
+describe('ColdStartCandidatePicker — 기본 렌더', () => {
+  it('visible=true 이면 모달이 표시된다', () => {
+    const { getByTestId } = renderPicker();
+    expect(getByTestId('cold-start-picker-modal')).toBeTruthy();
+  });
+
+  it('visible=false 이면 Modal의 visible prop이 false다', () => {
+    const { UNSAFE_getByType } = renderPicker({ visible: false });
+    const ModalRN: typeof import('react-native').Modal = require('react-native').Modal;
+    expect(UNSAFE_getByType(ModalRN).props.visible).toBe(false);
+  });
+
+  it('닫기 버튼이 있다', () => {
+    const { getByTestId } = renderPicker();
+    expect(getByTestId('cold-start-picker-close')).toBeTruthy();
+  });
+
+  it('닫기 버튼 탭 시 onClose 호출', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = renderPicker({ onClose });
+    fireEvent.press(getByTestId('cold-start-picker-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── 2. 2~5개 목록 UI ──────────────────────────────────────────────────────────
+
+describe('ColdStartCandidatePicker — 2~5개 목록 UI', () => {
+  it('후보가 2~5개면 목록 컨테이너가 렌더된다', () => {
+    const { getByTestId } = renderPicker({ candidates: TWO_TO_FIVE });
+    expect(getByTestId('cold-start-picker-list')).toBeTruthy();
+  });
+
+  it('fallback UI는 표시되지 않는다', () => {
+    const { queryByTestId } = renderPicker({ candidates: TWO_TO_FIVE });
+    expect(queryByTestId('cold-start-picker-fallback')).toBeNull();
+  });
+
+  it('각 후보의 역명으로 testID 카드가 렌더된다', () => {
+    const { getByTestId } = renderPicker({ candidates: TWO_TO_FIVE });
+    for (const candidate of TWO_TO_FIVE) {
+      expect(getByTestId(`cold-start-picker-item-${candidate.stationName}`)).toBeTruthy();
+    }
+  });
+
+  it('후보 카드 탭 시 해당 candidate로 onSelectCandidate 호출', () => {
+    const onSelectCandidate = jest.fn();
+    const { getByTestId } = renderPicker({ candidates: TWO_TO_FIVE, onSelectCandidate });
+    fireEvent.press(getByTestId(`cold-start-picker-item-${SINCHON.stationName}`));
+    expect(onSelectCandidate).toHaveBeenCalledWith(SINCHON);
+  });
+
+  it('다른 카드 탭 시 해당 candidate로 onSelectCandidate 호출', () => {
+    const onSelectCandidate = jest.fn();
+    const { getByTestId } = renderPicker({ candidates: TWO_TO_FIVE, onSelectCandidate });
+    fireEvent.press(getByTestId(`cold-start-picker-item-${WANGSIMNI.stationName}`));
+    expect(onSelectCandidate).toHaveBeenCalledWith(WANGSIMNI);
+  });
+
+  it('환승역(복수 노선) 카드도 정상 렌더 — 왕십리 4호선', () => {
+    const { getByTestId } = renderPicker({ candidates: [WANGSIMNI] });
+    expect(getByTestId(`cold-start-picker-item-${WANGSIMNI.stationName}`)).toBeTruthy();
+  });
+
+  it('2개 후보 — 2개 카드만 렌더', () => {
+    const two = [SINCHON, WANGSIMNI];
+    const { getByTestId, queryByTestId } = renderPicker({ candidates: two });
+    expect(getByTestId(`cold-start-picker-item-${SINCHON.stationName}`)).toBeTruthy();
+    expect(getByTestId(`cold-start-picker-item-${WANGSIMNI.stationName}`)).toBeTruthy();
+    expect(queryByTestId(`cold-start-picker-item-${SADANG.stationName}`)).toBeNull();
+  });
+
+  it(`${COLD_START_LIST_MAX}개(상한) 후보 — 목록 UI 렌더 (fallback 미표시)`, () => {
+    const atMax = [SINCHON, HONGIK, WANGSIMNI, SADANG, YAKSU];
+    expect(atMax).toHaveLength(COLD_START_LIST_MAX);
+    const { getByTestId, queryByTestId } = renderPicker({ candidates: atMax });
+    expect(getByTestId('cold-start-picker-list')).toBeTruthy();
+    expect(queryByTestId('cold-start-picker-fallback')).toBeNull();
+  });
+});
+
+// ── 3. 6+개 fallback UI ───────────────────────────────────────────────────────
+
+describe('ColdStartCandidatePicker — 6+개 fallback UI', () => {
+  it('6개 이상이면 fallback UI가 렌더된다', () => {
+    const { getByTestId } = renderPicker({ candidates: SIX_PLUS });
+    expect(getByTestId('cold-start-picker-fallback')).toBeTruthy();
+  });
+
+  it('목록 UI는 표시되지 않는다', () => {
+    const { queryByTestId } = renderPicker({ candidates: SIX_PLUS });
+    expect(queryByTestId('cold-start-picker-list')).toBeNull();
+  });
+
+  it('검색 fallback 버튼이 있다', () => {
+    const { getByTestId } = renderPicker({ candidates: SIX_PLUS });
+    expect(getByTestId('cold-start-picker-search-fallback')).toBeTruthy();
+  });
+
+  it('검색 fallback 버튼 탭 시 onSearchFallback 호출', () => {
+    const onSearchFallback = jest.fn();
+    const { getByTestId } = renderPicker({ candidates: SIX_PLUS, onSearchFallback });
+    fireEvent.press(getByTestId('cold-start-picker-search-fallback'));
+    expect(onSearchFallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('개별 역 카드 testID가 존재하지 않는다 (fallback 이므로)', () => {
+    const { queryByTestId } = renderPicker({ candidates: SIX_PLUS });
+    expect(queryByTestId(`cold-start-picker-item-${SINCHON.stationName}`)).toBeNull();
+  });
+});
+
+// ── 4. 빈 배열 edge case ─────────────────────────────────────────────────────
+
+describe('ColdStartCandidatePicker — 빈 배열', () => {
+  it('candidates=[] 이면 목록과 fallback 모두 미표시 (caller가 visible=false 보장)', () => {
+    // 컴포넌트 자체는 빈 배열 시 목록 컨테이너를 렌더하되 카드가 0개인 상태가 될 수 있다.
+    // 빈 배열은 count=0 이므로 isFallback=false, 목록 UI 경로 진입.
+    const { getByTestId, queryByTestId } = renderPicker({ candidates: [] });
+    // 빈 배열 시 목록 컨테이너는 존재하지만 카드가 없다.
+    expect(getByTestId('cold-start-picker-list')).toBeTruthy();
+    expect(queryByTestId(`cold-start-picker-item-신촌`)).toBeNull();
+    expect(queryByTestId('cold-start-picker-fallback')).toBeNull();
+  });
+});
+
+// ── 5. COLD_START_LIST_MAX 상수 ───────────────────────────────────────────────
+
+describe('COLD_START_LIST_MAX 상수', () => {
+  it('COLD_START_LIST_MAX = 5', () => {
+    expect(COLD_START_LIST_MAX).toBe(5);
+  });
+});
+
+// ── 6. onSingleCandidate props 검증 ─────────────────────────────────────────
+
+describe('ColdStartCandidatePicker — onSingleCandidate prop 전달', () => {
+  it('1개 후보 시 목록 UI 렌더 (카드 1개)', () => {
+    // 컴포넌트 자체는 1개도 목록 UI로 표시. caller(useColdStartPickerController)가 onSingleCandidate 분기.
+    const { getByTestId } = renderPicker({ candidates: [SINCHON] });
+    expect(getByTestId(`cold-start-picker-item-${SINCHON.stationName}`)).toBeTruthy();
+  });
+
+  it('1개 후보 카드 탭 시 onSelectCandidate 호출 (1개 case caller wire 검증)', () => {
+    const onSelectCandidate = jest.fn();
+    const { getByTestId } = renderPicker({ candidates: [SINCHON], onSelectCandidate });
+    fireEvent.press(getByTestId(`cold-start-picker-item-${SINCHON.stationName}`));
+    expect(onSelectCandidate).toHaveBeenCalledWith(SINCHON);
+  });
+});

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -62,6 +62,9 @@ import { useCurrentStationConfirmModal } from '../features/nearest-station/hooks
 import { isStrongFusionConfidence } from '../shared/constants/fusionConfidenceStrength';
 import { useWifiStation } from '../features/nearest-station/hooks/useWifiStation';
 import { CurrentStationConfirmModal } from '../features/nearest-station/components/CurrentStationConfirmModal';
+import { ColdStartCandidatePicker } from '../features/nearest-station/components/ColdStartCandidatePicker';
+import { useColdStartCandidates } from '../features/nearest-station/hooks/useColdStartCandidates';
+import type { ColdStartCandidate } from '../features/nearest-station/hooks/useColdStartCandidates';
 import { MisBoardingBanner } from '../features/route/components/MisBoardingBanner';
 import { MisBoardingReselectModal } from '../features/route/components/MisBoardingReselectModal';
 import { ShareTripButton } from '../features/route/components/ShareTripButton';
@@ -198,7 +201,7 @@ export default function HomeScreen() {
   // #1677 — silent push 60s+ 미수신 감지. FG 시 backendSsotAccepts 강제 false → device tier fallback.
   // 신규 폴링 없음 — 기존 arrival/position 30s cycle 재사용.
   const { healthy: silentPushHealthy } = useSilentPushHealthCheck();
-  const { result, liveResult, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source, currentHopIndex, arcStations, trainProgressing, estimatorIsTimeIntegration, backendSsotCurrentStationId } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal }, wifiStation, silentPushHealthy);
+  const { result, liveResult, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source, currentHopIndex, arcStations, trainProgressing, estimatorIsTimeIntegration, backendSsotCurrentStationId, environment } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal }, wifiStation, silentPushHealthy);
 
   // #1621 Phase B — V1 mismatch 자동 측정. UI currentStation(cascade picker)이 backend SSoT
   // 권위 mirror와 일치하지 않으면 alarmLog 'v1-mismatch' reason으로 1분 dedup 적재.
@@ -277,6 +280,72 @@ export default function HomeScreen() {
     [setCustomOrigin],
   );
   const handleOriginPickerClose = useCallback(() => setOriginPickerVisible(false), []);
+
+  // #1842 Phase 6.1 Sub-step 4 — cold start 다중 후보 선택 UI.
+  // trip 활성 중 / customOrigin 확정 후에는 picker를 표시하지 않는다.
+  const coldStartCandidates = useColdStartCandidates({
+    gps: userLocation && accuracyMeters != null
+      ? { lat: userLocation.lat, lng: userLocation.lng, accuracy: accuracyMeters }
+      : null,
+    environment,
+    hasTrip: destination !== null,
+  });
+  const [coldStartPickerVisible, setColdStartPickerVisible] = useState(false);
+  // cold start 조건이 충족되고 2개 이상 후보가 나타나면 picker 자동 표시.
+  // 이미 customOrigin이 설정됐거나 picker가 닫힌 후 재오픈하지 않도록 dismissedRef로 가드.
+  const coldStartPickerDismissedRef = useRef(false);
+  useEffect(() => {
+    if (!coldStartCandidates) {
+      // cold start 조건 해제 시 가드 리셋 (다음 cold start 에피소드를 위해)
+      coldStartPickerDismissedRef.current = false;
+      setColdStartPickerVisible(false);
+      return;
+    }
+    if (coldStartPickerDismissedRef.current) return;
+    if (customOrigin) return;
+    if (destination !== null) return;
+    // 2개 이상 후보가 있을 때만 picker 표시 (1개는 boardingPrompt 흐름, 0개는 표시 안 함)
+    if (coldStartCandidates.length >= 2) {
+      setColdStartPickerVisible(true);
+    }
+  }, [coldStartCandidates, customOrigin, destination]);
+
+  const handleColdStartSelectCandidate = useCallback(
+    (candidate: ColdStartCandidate) => {
+      // 가장 가까운 entry의 stations[0]으로 setCustomOrigin 호출 → trip chain 시작.
+      const firstStation = candidate.stations[0];
+      if (firstStation) {
+        setCustomOrigin(firstStation);
+      }
+      coldStartPickerDismissedRef.current = true;
+      setColdStartPickerVisible(false);
+    },
+    [setCustomOrigin],
+  );
+
+  const handleColdStartSingleCandidate = useCallback(
+    (candidate: ColdStartCandidate) => {
+      // 1개 케이스: boardingPrompt 흐름과 동일하게 setCustomOrigin 적용.
+      const firstStation = candidate.stations[0];
+      if (firstStation) {
+        setCustomOrigin(firstStation);
+      }
+      coldStartPickerDismissedRef.current = true;
+      setColdStartPickerVisible(false);
+    },
+    [setCustomOrigin],
+  );
+
+  const handleColdStartSearchFallback = useCallback(() => {
+    coldStartPickerDismissedRef.current = true;
+    setColdStartPickerVisible(false);
+    setOriginPickerVisible(true);
+  }, []);
+
+  const handleColdStartPickerClose = useCallback(() => {
+    coldStartPickerDismissedRef.current = true;
+    setColdStartPickerVisible(false);
+  }, []);
 
 
   const handleArrivalClear = useCallback(() => setDestination(null), [setDestination]);
@@ -1458,6 +1527,16 @@ export default function HomeScreen() {
           }}
         />
       )}
+
+      {/* #1842 Phase 6.1 Sub-step 4 — cold start 다중 후보 선택 UI. */}
+      <ColdStartCandidatePicker
+        visible={coldStartPickerVisible}
+        candidates={coldStartCandidates ?? []}
+        onSelectCandidate={handleColdStartSelectCandidate}
+        onSingleCandidate={handleColdStartSingleCandidate}
+        onSearchFallback={handleColdStartSearchFallback}
+        onClose={handleColdStartPickerClose}
+      />
 
       {/* #914 (F4) — 1탭 현재역 확정. wifi 단일 매칭은 자동 확정 + toast 노출,
            GPS 다중 후보는 모달 1탭 확정, 후보 0개는 검색 fallback 안내(#977 wire). */}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -181,6 +181,14 @@
     "close": "Close",
     "autoConfirmed": "Confirmed as {{name}}"
   },
+  "coldStartPicker": {
+    "title": "Which station are you at?",
+    "subtitle": "Select a nearby station to start tracking",
+    "distanceKm": "{{km}} km",
+    "tooManyCandidates": "Too many nearby stations.\nPlease search for your station.",
+    "searchFallback": "Search station",
+    "close": "Close"
+  },
   "sleepModeGuide": {
     "title": "Sleep mode notice",
     "message": "If earphones are not connected, the alarm may play through the speaker.\n\nIf you do not want speaker output, turn off 'Allow speaker output' under Settings > Alarm.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -181,6 +181,14 @@
     "close": "閉じる",
     "autoConfirmed": "{{name}}に確定しました"
   },
+  "coldStartPicker": {
+    "title": "今どの駅にいますか？",
+    "subtitle": "近くの駅を選ぶと乗車情報をすぐに繋げます",
+    "distanceKm": "{{km}}km",
+    "tooManyCandidates": "近くに駅が多すぎます。\n駅名を検索して選んでください。",
+    "searchFallback": "駅を検索",
+    "close": "閉じる"
+  },
   "sleepModeGuide": {
     "title": "おやすみモードのご案内",
     "message": "イヤホンが接続されていない場合、アラームがスピーカーで再生されることがあります。\n\nスピーカー出力を希望しない場合は、設定 > アラームで「スピーカー出力を許可」をオフにしてください。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -181,6 +181,14 @@
     "close": "닫기",
     "autoConfirmed": "{{name}}으로 확정됨"
   },
+  "coldStartPicker": {
+    "title": "지금 어느 역에 계세요?",
+    "subtitle": "근처 역을 선택하면 탑승 정보를 바로 연결해 드립니다",
+    "distanceKm": "{{km}}km",
+    "tooManyCandidates": "주변에 역이 너무 많아요.\n역 이름을 검색해서 선택해 주세요.",
+    "searchFallback": "역 검색으로 선택",
+    "close": "닫기"
+  },
   "sleepModeGuide": {
     "title": "취침 모드 안내",
     "message": "이어폰이 연결되지 않은 경우 알람이 스피커로 재생될 수 있습니다.\n\n스피커 출력을 원하지 않으시면 설정 > 알람에서 '스피커 출력 허용'을 꺼주세요.",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -181,6 +181,14 @@
     "close": "关闭",
     "autoConfirmed": "已确认为{{name}}"
   },
+  "coldStartPicker": {
+    "title": "您现在在哪个车站？",
+    "subtitle": "选择附近的车站即可开始追踪",
+    "distanceKm": "{{km}}公里",
+    "tooManyCandidates": "附近车站太多了。\n请搜索车站名称进行选择。",
+    "searchFallback": "搜索车站",
+    "close": "关闭"
+  },
   "sleepModeGuide": {
     "title": "睡眠模式提示",
     "message": "如果未连接耳机,提醒可能通过扬声器播放。\n\n如不希望扬声器输出,请在 设置 > 提醒 中关闭'允许扬声器输出'。",


### PR DESCRIPTION
## Summary
- Phase 6.1 Sub-step 4 완성 — `ColdStartCandidatePicker` 컴포넌트 + HomeScreen caller wire
- `useColdStartCandidates` (PR #1838) 산출물을 사용자에게 노출하는 최종 UI 레이어

## 변경 사항

### 신규
- `src/features/nearest-station/components/ColdStartCandidatePicker.tsx`
  - 2~5개: 역명 + LineBadge(호선) + 거리(km) 카드 목록
  - 6+개: 검색 fallback 안내 메시지 + 버튼
  - `COLD_START_LIST_MAX = 5` 상수 export
- `src/features/nearest-station/components/__tests__/ColdStartCandidatePicker.test.tsx` — 21개 테스트

### 수정
- `src/screens/HomeScreen.tsx`
  - `useFusedNearestStation` 반환에서 `environment` 추가 추출
  - `useColdStartCandidates` 연결 (gps/environment/hasTrip)
  - 2개+ 후보 시 picker 자동 표시, `dismissedRef` 가드로 재오픈 차단
  - `onSelectCandidate` / `onSingleCandidate` → `setCustomOrigin` (trip chain 시작)
  - `onSearchFallback` → 기존 `originPickerVisible` 재사용
- i18n 4언어 `coldStartPicker.*` 키 추가 (ko/en/ja/zh)

## Wire-completion 5단

1. **Orphan 없음** — `ColdStartCandidatePicker`를 `HomeScreen`에 wire. `npm run lint:orphan` 0건 확인
2. **V/X dashboard** — 선택 결과는 `setCustomOrigin` → `effectiveOrigin` 경로로 HomeScreen hero section에 즉시 표시됨
3. **의존 PR** — #1838 (Sub-step 1+2) 머지 필요
4. **측정 plan** — Day 3+ 실기기 cold start trip 1건, picker 표시 + 선택 → `setCustomOrigin` → trip chain 시작 1주 측정
5. **Device verify** — 실기기 지하 cold start: `accuracy > 50m + underground/unknown + hasTrip=false` 조건 충족 시 picker 표시, 역 선택 → hero section 즉시 반영 확인

## Test
- `npm test` 386 suites / 7952 tests — 100% coverage
- `npm run type-check` — pass
- `npm run lint:orphan` — 0 orphan

Closes #1842