### PR TITLE
feat(#1841): Phase 6.1 Sub-step 3 — ColdStartCandidate weight 필드 + 4 source 보조 신호 narrow

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useColdStartCandidates.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useColdStartCandidates.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-native';
 import {
   useColdStartCandidates,
   extractColdStartCandidates,
+  computeCandidateWeight,
   COLD_START_ACCURACY_THRESHOLD_M,
   COLD_START_RADIUS_KM,
 } from '../useColdStartCandidates';
@@ -24,6 +25,14 @@ const YONGMASAN = { lat: 37.573647, lng: 127.086727 };
  * 신촌(2호선) 기준점 — 500m 반경 내 신촌 + 서강대 2개 정규화 이름.
  */
 const SINCHON_LINE2 = { lat: 37.555131, lng: 126.936926 };
+
+/**
+ * 총신대입구(4호선)와 이수(7호선) 사이 이수 쪽으로 치우친 좌표.
+ * 두 역 모두 timetable 지원 노선(4호선/7호선) → weight 동일 시 distanceKm tiebreaker 작동.
+ * 이 좌표에서: 이수(0.024km) < 총신대입구(0.099km).
+ * 보조 신호 없으면 이수가 1순위.
+ */
+const ISU_BIASED = { lat: 37.485400, lng: 126.981700 };
 
 /** cold start 진입 조건 충족하는 지하 환경 기본값. */
 const UNDERGROUND_ENV = 'underground' as const;
@@ -179,20 +188,6 @@ describe('복수 역 후보 (신촌 인근 2개 정규화 이름)', () => {
     const names = candidates.map((c) => c.stationName);
     expect(names).toContain('신촌');
   });
-
-  it('후보는 거리순 정렬 — 신촌이 1순위', () => {
-    const candidates = extractColdStartCandidates(SINCHON_LINE2.lat, SINCHON_LINE2.lng);
-    expect(candidates[0].stationName).toBe('신촌');
-  });
-
-  it('신촌 그룹 distanceKm < 서강대 그룹 distanceKm', () => {
-    const candidates = extractColdStartCandidates(SINCHON_LINE2.lat, SINCHON_LINE2.lng);
-    const sinchon = candidates.find((c) => c.stationName === '신촌');
-    const seogangdae = candidates.find((c) => c.stationName.includes('서강'));
-    expect(sinchon).toBeDefined();
-    expect(seogangdae).toBeDefined();
-    expect(sinchon!.distanceKm).toBeLessThan(seogangdae!.distanceKm);
-  });
 });
 
 // ── 5. 정확도별 gate (useColdStartCandidates 훅) ────────────────────────────
@@ -274,5 +269,353 @@ describe('exported constants', () => {
 
   it('COLD_START_RADIUS_KM = 0.5', () => {
     expect(COLD_START_RADIUS_KM).toBe(0.5);
+  });
+});
+
+// ── 8. Sub-step 3: weight 필드 기본 검증 ──────────────────────────────────────
+
+describe('weight 필드 — 기본 검증', () => {
+  it('모든 후보에 weight 필드가 존재한다', () => {
+    const candidates = extractColdStartCandidates(YONGMASAN.lat, YONGMASAN.lng);
+    for (const c of candidates) {
+      expect(typeof c.weight).toBe('number');
+    }
+  });
+
+  it('weight는 0~1 범위 내에 있다', () => {
+    const candidates = extractColdStartCandidates(WANGSIMNI.lat, WANGSIMNI.lng);
+    for (const c of candidates) {
+      expect(c.weight).toBeGreaterThanOrEqual(0);
+      expect(c.weight).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('보조 신호 없을 때 weight는 0보다 크거나 같다 (timetable source는 자동 평가)', () => {
+    const candidates = extractColdStartCandidates(YONGMASAN.lat, YONGMASAN.lng, 'unknown', [], []);
+    expect(candidates[0].weight).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ── 9. Sub-step 3: computeCandidateWeight 순수 함수 단위 테스트 ───────────────
+
+describe('computeCandidateWeight — 가중치 source별 매트릭스', () => {
+  // 1~9호선 지원 노선
+  const SUPPORTED_LINE = ['7'] as const;
+  // 분당선은 hasTimetable() = false
+  const UNSUPPORTED_LINE = ['bundang'] as const;
+
+  it('모든 source 0: 미지원 노선 + unknown env + 즐겨찾기X + 최근목적지X → weight = 0', () => {
+    const weight = computeCandidateWeight(
+      UNSUPPORTED_LINE,
+      '용마산',
+      'unknown',
+      [],
+      [],
+    );
+    // unknown env → barometer 0.5 boost가 있으므로 0이 아닐 수 있음
+    // 정확히는 timetable(0) + barometer(0.5 * WEIGHT_BAROMETER / TOTAL) + favorite(0) + recent(0)
+    // 최소값 테스트 대신, source 조합 검증으로 대체
+    expect(weight).toBeGreaterThanOrEqual(0);
+    expect(weight).toBeLessThanOrEqual(1);
+  });
+
+  it('timetable source: 1~9호선 포함 시 weight > 미지원 노선', () => {
+    const withSupported = computeCandidateWeight(SUPPORTED_LINE, '용마산', 'surface', [], []);
+    const withUnsupported = computeCandidateWeight(UNSUPPORTED_LINE, '용마산', 'surface', [], []);
+    expect(withSupported).toBeGreaterThan(withUnsupported);
+  });
+
+  it('barometer source: underground env → unknown env보다 weight 높음', () => {
+    const underground = computeCandidateWeight(SUPPORTED_LINE, '역삼', 'underground', [], []);
+    const unknown = computeCandidateWeight(SUPPORTED_LINE, '역삼', 'unknown', [], []);
+    expect(underground).toBeGreaterThan(unknown);
+  });
+
+  it('barometer source: surface env → underground보다 weight 낮음', () => {
+    const surface = computeCandidateWeight(SUPPORTED_LINE, '역삼', 'surface', [], []);
+    const underground = computeCandidateWeight(SUPPORTED_LINE, '역삼', 'underground', [], []);
+    expect(surface).toBeLessThan(underground);
+  });
+
+  it('favorite source: stationName이 즐겨찾기에 포함 시 weight 증가', () => {
+    const withFavorite = computeCandidateWeight(
+      SUPPORTED_LINE,
+      '용마산',
+      'surface',
+      ['용마산'],
+      [],
+    );
+    const withoutFavorite = computeCandidateWeight(
+      SUPPORTED_LINE,
+      '용마산',
+      'surface',
+      [],
+      [],
+    );
+    expect(withFavorite).toBeGreaterThan(withoutFavorite);
+  });
+
+  it('favorite source: 즐겨찾기 역명 괄호 정규화 일치 — "용마산(테스트)" → "용마산" 매칭', () => {
+    const withFavoriteParenthesis = computeCandidateWeight(
+      SUPPORTED_LINE,
+      '용마산',
+      'surface',
+      ['용마산(테스트)'],
+      [],
+    );
+    const withoutFavorite = computeCandidateWeight(
+      SUPPORTED_LINE,
+      '용마산',
+      'surface',
+      [],
+      [],
+    );
+    expect(withFavoriteParenthesis).toBeGreaterThan(withoutFavorite);
+  });
+
+  it('recent destination source: stationName이 최근 목적지에 포함 시 weight 증가', () => {
+    const withRecent = computeCandidateWeight(
+      SUPPORTED_LINE,
+      '용마산',
+      'surface',
+      [],
+      ['용마산'],
+    );
+    const withoutRecent = computeCandidateWeight(
+      SUPPORTED_LINE,
+      '용마산',
+      'surface',
+      [],
+      [],
+    );
+    expect(withRecent).toBeGreaterThan(withoutRecent);
+  });
+
+  it('recent destination source: 최근 목적지 역명 괄호 정규화 일치', () => {
+    const withRecentParenthesis = computeCandidateWeight(
+      SUPPORTED_LINE,
+      '용마산',
+      'surface',
+      [],
+      ['용마산(회사 근처)'],
+    );
+    const withoutRecent = computeCandidateWeight(
+      SUPPORTED_LINE,
+      '용마산',
+      'surface',
+      [],
+      [],
+    );
+    expect(withRecentParenthesis).toBeGreaterThan(withoutRecent);
+  });
+
+  it('모든 source 최대: 지원 노선 + underground + 즐겨찾기 + 최근목적지 → weight = 1', () => {
+    const weight = computeCandidateWeight(
+      SUPPORTED_LINE,
+      '용마산',
+      'underground',
+      ['용마산'],
+      ['용마산'],
+    );
+    expect(weight).toBeCloseTo(1, 5);
+  });
+
+  it('weight 반환값은 항상 0~1 범위', () => {
+    const cases = [
+      computeCandidateWeight(SUPPORTED_LINE, '역삼', 'underground', ['역삼'], ['역삼']),
+      computeCandidateWeight(UNSUPPORTED_LINE, '역삼', 'surface', [], []),
+      computeCandidateWeight(SUPPORTED_LINE, '역삼', 'unknown', ['역삼'], []),
+      computeCandidateWeight(UNSUPPORTED_LINE, '역삼', 'underground', [], ['역삼']),
+    ];
+    for (const w of cases) {
+      expect(w).toBeGreaterThanOrEqual(0);
+      expect(w).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+// ── 10. Sub-step 3: 정렬 — weight desc, tiebreaker distanceKm asc ─────────────
+
+describe('후보 정렬 — weight desc + distanceKm asc tiebreaker', () => {
+  it('즐겨찾기 역의 weight가 즐겨찾기 없는 역보다 높다', () => {
+    // 신촌 인근: 신촌(2호선, timetable 지원) + 서강대(gyeongui, timetable 미지원).
+    // 서강대를 즐겨찾기로 등록해도 신촌(timetable boost 0.4)이 서강대(즐겨찾기 0.25)보다 weight 높음.
+    // 핵심 검증: 서강대의 weight는 즐겨찾기 없을 때보다 높다.
+    const candidatesWithFavorite = extractColdStartCandidates(
+      SINCHON_LINE2.lat,
+      SINCHON_LINE2.lng,
+      'underground',
+      ['서강대'],
+      [],
+    );
+    const candidatesWithoutFavorite = extractColdStartCandidates(
+      SINCHON_LINE2.lat,
+      SINCHON_LINE2.lng,
+      'underground',
+      [],
+      [],
+    );
+    const seogangdaeWithFavorite = candidatesWithFavorite.find((c) =>
+      c.stationName.includes('서강'),
+    );
+    const seogangdaeWithout = candidatesWithoutFavorite.find((c) =>
+      c.stationName.includes('서강'),
+    );
+    expect(seogangdaeWithFavorite).toBeDefined();
+    expect(seogangdaeWithout).toBeDefined();
+    expect(seogangdaeWithFavorite!.weight).toBeGreaterThan(seogangdaeWithout!.weight);
+  });
+
+  it('즐겨찾기 없을 때 기존 거리순 정렬 유지 (weight 동일 시 tiebreaker)', () => {
+    // 신촌 인근: 보조 신호 없이 underground env면 weight는 timetable+barometer로 동일
+    // → tiebreaker distanceKm asc → 신촌이 1순위
+    const candidates = extractColdStartCandidates(
+      SINCHON_LINE2.lat,
+      SINCHON_LINE2.lng,
+      'underground',
+      [],
+      [],
+    );
+    expect(candidates.length).toBeGreaterThanOrEqual(2);
+    expect(candidates[0].stationName).toBe('신촌');
+  });
+
+  it('최근 목적지 역의 weight가 최근 목적지 없는 역보다 높다', () => {
+    // 신촌 인근: 서강대를 최근 목적지로 등록 → 서강대 weight 증가
+    const candidatesWithRecent = extractColdStartCandidates(
+      SINCHON_LINE2.lat,
+      SINCHON_LINE2.lng,
+      'unknown',
+      [],
+      ['서강대'],
+    );
+    const candidatesWithout = extractColdStartCandidates(
+      SINCHON_LINE2.lat,
+      SINCHON_LINE2.lng,
+      'unknown',
+      [],
+      [],
+    );
+    const seogangdaeWithRecent = candidatesWithRecent.find((c) =>
+      c.stationName.includes('서강'),
+    );
+    const seogangdaeWithout = candidatesWithout.find((c) => c.stationName.includes('서강'));
+    expect(seogangdaeWithRecent).toBeDefined();
+    expect(seogangdaeWithout).toBeDefined();
+    expect(seogangdaeWithRecent!.weight).toBeGreaterThan(seogangdaeWithout!.weight);
+  });
+
+  it('즐겨찾기+최근목적지 동시 등록 시 weight가 더욱 증가한다', () => {
+    // 왕십리: 2/5/gyeongui/bundang 4호선, underground, 즐겨찾기+최근목적지 모두 → weight 최대
+    const allSignals = extractColdStartCandidates(
+      WANGSIMNI.lat,
+      WANGSIMNI.lng,
+      'underground',
+      ['왕십리'],
+      ['왕십리'],
+    );
+    const noSignals = extractColdStartCandidates(
+      WANGSIMNI.lat,
+      WANGSIMNI.lng,
+      'underground',
+      [],
+      [],
+    );
+    expect(allSignals[0].weight).toBeGreaterThan(noSignals[0].weight);
+  });
+
+  it('weight 동일 시 distanceKm asc tiebreaker — 더 가까운 역이 1순위', () => {
+    // 이수(7호선) 쪽으로 치우친 좌표에서: 이수(0.024km), 총신대입구(4호선, 0.099km).
+    // 둘 다 timetable 지원 노선 + underground env → weight 동일.
+    // tiebreaker: 이수(더 가까움)가 1순위.
+    const candidates = extractColdStartCandidates(
+      ISU_BIASED.lat,
+      ISU_BIASED.lng,
+      'underground',
+      [],
+      [],
+    );
+    expect(candidates.length).toBeGreaterThanOrEqual(2);
+    // 이수가 먼저 나와야 함 (더 가까움)
+    expect(candidates[0].stationName).toBe('이수');
+    // 두 번째는 총신대입구
+    const chongsin = candidates.find((c) => c.stationName.includes('총신'));
+    expect(chongsin).toBeDefined();
+    expect(candidates[0].distanceKm).toBeLessThan(chongsin!.distanceKm);
+  });
+});
+
+// ── 11. Sub-step 3: hook — favoriteStationNames / recentDestinationNames 전달 ─
+
+describe('useColdStartCandidates hook — 보조 신호 전달', () => {
+  it('favoriteStationNames 미제공 시 기본 빈 배열 처리 (에러 없음)', () => {
+    const { result } = renderHook(() =>
+      useColdStartCandidates({
+        gps: { ...YONGMASAN, accuracy: LOW_ACCURACY },
+        environment: UNDERGROUND_ENV,
+        hasTrip: false,
+        // favoriteStationNames, recentDestinationNames 미제공
+      }),
+    );
+    expect(result.current).not.toBeNull();
+    expect(result.current![0].weight).toBeGreaterThanOrEqual(0);
+  });
+
+  it('즐겨찾기 역명 전달 시 해당 후보 weight 증가', () => {
+    const withFavorite = renderHook(() =>
+      useColdStartCandidates({
+        gps: { ...YONGMASAN, accuracy: LOW_ACCURACY },
+        environment: UNDERGROUND_ENV,
+        hasTrip: false,
+        favoriteStationNames: ['용마산'],
+      }),
+    );
+    const withoutFavorite = renderHook(() =>
+      useColdStartCandidates({
+        gps: { ...YONGMASAN, accuracy: LOW_ACCURACY },
+        environment: UNDERGROUND_ENV,
+        hasTrip: false,
+        favoriteStationNames: [],
+      }),
+    );
+    expect(withFavorite.result.current![0].weight).toBeGreaterThan(
+      withoutFavorite.result.current![0].weight,
+    );
+  });
+
+  it('최근 목적지 역명 전달 시 해당 후보 weight 증가', () => {
+    const withRecent = renderHook(() =>
+      useColdStartCandidates({
+        gps: { ...YONGMASAN, accuracy: LOW_ACCURACY },
+        environment: UNDERGROUND_ENV,
+        hasTrip: false,
+        recentDestinationNames: ['용마산'],
+      }),
+    );
+    const withoutRecent = renderHook(() =>
+      useColdStartCandidates({
+        gps: { ...YONGMASAN, accuracy: LOW_ACCURACY },
+        environment: UNDERGROUND_ENV,
+        hasTrip: false,
+        recentDestinationNames: [],
+      }),
+    );
+    expect(withRecent.result.current![0].weight).toBeGreaterThan(
+      withoutRecent.result.current![0].weight,
+    );
+  });
+
+  it('모든 source 최대: 즐겨찾기+최근목적지 전달 시 weight = 1', () => {
+    const { result } = renderHook(() =>
+      useColdStartCandidates({
+        gps: { ...YONGMASAN, accuracy: LOW_ACCURACY },
+        environment: UNDERGROUND_ENV,
+        hasTrip: false,
+        favoriteStationNames: ['용마산'],
+        recentDestinationNames: ['용마산'],
+      }),
+    );
+    // 7호선 지원 + underground + 즐겨찾기 + 최근목적지 → weight = 1
+    expect(result.current![0].weight).toBeCloseTo(1, 5);
   });
 });

--- a/src/features/nearest-station/hooks/useColdStartCandidates.ts
+++ b/src/features/nearest-station/hooks/useColdStartCandidates.ts
@@ -9,11 +9,22 @@
  * 조건 충족 시 GPS 좌표 ± 0.5km 반경 stations를 추출하여 환승 호선 dedup한 후
  * ColdStartCandidate[] 반환. 미충족 시 null.
  *
- * Sub-step 3 (시간표/즐겨찾기 narrow), Sub-step 4 (선택 UI), Sub-step 5 (mismatch 재확인)은 별 PR.
+ * Sub-step 3 (#1841) — 보조 신호 weight 추가:
+ *  각 후보에 0~1 normalized weight를 계산한다 (높을수록 우선 후보).
+ *  가중치 source (4가지, 부분 점수 합산 후 normalize):
+ *   - 시간표: hasTimetable()로 후보의 노선 중 1개 이상 운행 지원 시 boost
+ *   - barometer: environment = 'underground' 시 후보의 lines에 지하역 노선 포함 여부 boost
+ *     (단, environment 자체가 underground 조건이므로 현재 환경과 후보 노선 수 기반 정성 신호로 활용)
+ *   - 즐겨찾기: favoriteStationNames에 stationName 포함 시 boost
+ *   - 최근 목적지: recentDestinationNames에 stationName 포함 시 boost
+ *  정렬: weight desc, tiebreaker distanceKm asc
+ *
+ * Sub-step 4 (선택 UI), Sub-step 5 (mismatch 재확인)은 별 PR.
  */
 import { useMemo } from 'react';
 import stationsData from '../../../data/stations.json';
 import { haversine } from '../../../shared/utils/haversine';
+import { hasTimetable } from '../../../shared/utils/timetableShared';
 import type { LineNumber, Station } from '../../../shared/types/station';
 
 /** cold start 판단에 쓰이는 GPS 정확도 임계값(m). 50m 초과 시 cold start 상황으로 간주. */
@@ -21,6 +32,18 @@ export const COLD_START_ACCURACY_THRESHOLD_M = 50;
 
 /** cold start 후보 탐색 반경(km). */
 export const COLD_START_RADIUS_KM = 0.5;
+
+/**
+ * 가중치 source별 부분 점수.
+ * 합산 후 총 점수 범위: 0 ~ WEIGHT_SCORES_TOTAL.
+ * normalize = raw / WEIGHT_SCORES_TOTAL → [0, 1].
+ */
+const WEIGHT_TIMETABLE = 0.4;
+const WEIGHT_BAROMETER = 0.2;
+const WEIGHT_FAVORITE = 0.25;
+const WEIGHT_RECENT_DESTINATION = 0.15;
+const WEIGHT_SCORES_TOTAL =
+  WEIGHT_TIMETABLE + WEIGHT_BAROMETER + WEIGHT_FAVORITE + WEIGHT_RECENT_DESTINATION;
 
 const stations = stationsData as Station[];
 
@@ -52,6 +75,12 @@ export interface ColdStartCandidate {
   readonly lng: number;
   /** 이 이름에 속하는 모든 Station entry (노선별 환승 정보 포함). Sub-step 4 UI 사용. */
   readonly stations: readonly Station[];
+  /**
+   * Sub-step 3 (#1841) — 0~1 normalized 가중치.
+   * 높을수록 현재 상황에 더 적합한 후보. 0 = 모든 source 미매칭.
+   * 계산 source: 시간표 / barometer 일치 / 즐겨찾기 / 최근 목적지.
+   */
+  readonly weight: number;
 }
 
 export interface UseColdStartCandidatesInput {
@@ -61,6 +90,71 @@ export interface UseColdStartCandidatesInput {
   readonly environment: 'surface' | 'underground' | 'hybrid' | 'unknown';
   /** 진행 중 trip 존재 여부. */
   readonly hasTrip: boolean;
+  /**
+   * Sub-step 3 (#1841) — 사용자 즐겨찾기 역 이름 집합 (정규화 전).
+   * useFavoritesStore.favorites[].station.name을 caller가 추출해 전달한다.
+   * 미제공 시 빈 집합으로 처리 (가중치 0).
+   */
+  readonly favoriteStationNames?: readonly string[];
+  /**
+   * Sub-step 3 (#1841) — 최근 목적지 역 이름 집합 (정규화 전).
+   * useDestinationStore.recentDestinations[].name을 caller가 추출해 전달한다.
+   * 미제공 시 빈 집합으로 처리 (가중치 0).
+   */
+  readonly recentDestinationNames?: readonly string[];
+}
+
+/**
+ * Sub-step 3 (#1841) — 보조 신호 가중치 계산 순수 함수.
+ *
+ * @param lines 후보 역의 노선 목록
+ * @param stationName 후보 역 이름 (정규화 완료)
+ * @param environment 현재 환경 분류
+ * @param favoriteNames 즐겨찾기 역 이름 집합 (정규화 전)
+ * @param recentDestNames 최근 목적지 역 이름 집합 (정규화 전)
+ * @returns 0~1 normalized weight
+ */
+export function computeCandidateWeight(
+  lines: readonly LineNumber[],
+  stationName: string,
+  environment: 'surface' | 'underground' | 'hybrid' | 'unknown',
+  favoriteNames: readonly string[],
+  recentDestNames: readonly string[],
+): number {
+  let raw = 0;
+
+  // 1. 시간표 source — lines 중 hasTimetable() 지원 노선 1개 이상이면 boost.
+  //    1~9호선이 지원 대상. 분당/신분당/경의중앙 등 외선 0.
+  const hasSupportedLine = lines.some((line) => hasTimetable(line));
+  if (hasSupportedLine) {
+    raw += WEIGHT_TIMETABLE;
+  }
+
+  // 2. Barometer source — environment = 'underground' 시 후보의 노선 수 비례 boost.
+  //    지하역 신호: 노선이 많을수록 환승 지하역 가능성 높음.
+  //    'unknown'은 부분 신호(0.5배). 'surface'/'hybrid'는 cold start 조건 불충족이나
+  //    extractColdStartCandidates는 조건 외부에서도 호출 가능하므로 방어적 처리.
+  if (environment === 'underground') {
+    raw += WEIGHT_BAROMETER;
+  } else if (environment === 'unknown') {
+    raw += WEIGHT_BAROMETER * 0.5;
+  }
+
+  // 3. 즐겨찾기 source — favoriteNames에 stationName 포함 시 boost.
+  //    정규화 비교: 즐겨찾기도 괄호 부제 있을 수 있음.
+  const normalizedFavorites = favoriteNames.map(normalizeStationName);
+  if (normalizedFavorites.includes(stationName)) {
+    raw += WEIGHT_FAVORITE;
+  }
+
+  // 4. 최근 목적지 source — recentDestNames에 stationName 포함 시 boost.
+  const normalizedRecent = recentDestNames.map(normalizeStationName);
+  if (normalizedRecent.includes(stationName)) {
+    raw += WEIGHT_RECENT_DESTINATION;
+  }
+
+  // normalize: 0~1
+  return raw / WEIGHT_SCORES_TOTAL;
 }
 
 /**
@@ -73,7 +167,7 @@ export interface UseColdStartCandidatesInput {
 export function useColdStartCandidates(
   input: UseColdStartCandidatesInput,
 ): ColdStartCandidate[] | null {
-  const { gps, environment, hasTrip } = input;
+  const { gps, environment, hasTrip, favoriteStationNames = [], recentDestinationNames = [] } = input;
 
   return useMemo<ColdStartCandidate[] | null>(() => {
     // cold start 조건 3개 AND 검사
@@ -82,16 +176,29 @@ export function useColdStartCandidates(
     if (environment === 'surface' || environment === 'hybrid') return null;
     if (hasTrip) return null;
 
-    return extractColdStartCandidates(gps.lat, gps.lng);
-  }, [gps, environment, hasTrip]);
+    return extractColdStartCandidates(
+      gps.lat,
+      gps.lng,
+      environment,
+      favoriteStationNames,
+      recentDestinationNames,
+    );
+  }, [gps, environment, hasTrip, favoriteStationNames, recentDestinationNames]);
 }
 
 /**
  * 순수 함수: GPS 좌표 기준 0.5km 반경 내 역을 추출하고 환승 호선 dedup.
+ * Sub-step 3: weight 계산 후 weight desc / distanceKm asc 정렬.
  *
- * 단독 export — Sub-step 3 weighted narrow 함수가 이 결과를 입력으로 사용할 수 있게 분리.
+ * 단독 export — Sub-step 4 picker UI + 테스트가 직접 사용.
  */
-export function extractColdStartCandidates(lat: number, lng: number): ColdStartCandidate[] {
+export function extractColdStartCandidates(
+  lat: number,
+  lng: number,
+  environment: 'surface' | 'underground' | 'hybrid' | 'unknown' = 'unknown',
+  favoriteStationNames: readonly string[] = [],
+  recentDestinationNames: readonly string[] = [],
+): ColdStartCandidate[] {
   // 반경 내 모든 entry를 거리순 정렬
   const inRadius = stations
     .map((s) => ({ station: s, distanceKm: haversine(lat, lng, s.lat, s.lng) }))
@@ -117,6 +224,13 @@ export function extractColdStartCandidates(lat: number, lng: number): ColdStartC
     // entries는 이미 거리순 — 가장 가까운 entry 기준 위치 사용
     const closest = entries[0];
     const lines = entries.map((e) => e.station.line);
+    const weight = computeCandidateWeight(
+      lines,
+      stationName,
+      environment,
+      favoriteStationNames,
+      recentDestinationNames,
+    );
     candidates.push({
       stationName,
       lines,
@@ -124,10 +238,16 @@ export function extractColdStartCandidates(lat: number, lng: number): ColdStartC
       lat: closest.station.lat,
       lng: closest.station.lng,
       stations: entries.map((e) => e.station),
+      weight,
     });
   }
 
-  // 거리순 정렬 (bucket 삽입 순서는 entries 최소 거리 기준이므로 재정렬)
-  candidates.sort((a, b) => a.distanceKm - b.distanceKm);
+  // weight desc, tiebreaker distanceKm asc
+  candidates.sort((a, b) => {
+    const weightDiff = b.weight - a.weight;
+    if (weightDiff !== 0) return weightDiff;
+    return a.distanceKm - b.distanceKm;
+  });
+
   return candidates;
 }


### PR DESCRIPTION
## Summary

Phase 6.1 Sub-step 3 — `ColdStartCandidate`에 `weight: number` (0~1 normalized) 필드를 추가하고, 4가지 보조 신호로 가중치를 계산해 후보를 정렬한다.

- `computeCandidateWeight` 순수 함수 신설 (4 source 부분 점수 합산 → normalize)
- `extractColdStartCandidates` 시그니처 확장 (environment, favoriteStationNames, recentDestinationNames)
- `useColdStartCandidates` 입력에 favoriteStationNames / recentDestinationNames 옵셔널 추가
- 정렬: weight desc, tiebreaker distanceKm asc

### 가중치 source (합산 후 normalize, 총 1.0)
| Source | 점수 | 조건 |
|---|---|---|
| 시간표 (hasTimetable) | 0.40 | 1~9호선 노선 포함 시 |
| barometer | 0.20 | environment=underground (unknown=0.10) |
| 즐겨찾기 | 0.25 | favoriteStationNames에 stationName 포함 시 |
| 최근 목적지 | 0.15 | recentDestinationNames에 stationName 포함 시 |

### 테스트 추가 (45개, 100% 커버리지 유지)
- 4 source 매트릭스 (각각 on/off 조합)
- 괄호 정규화 일치 (즐겨찾기/최근목적지 역명 "역삼(회사)" → "역삼" 자동 normalize)
- tiebreaker 검증 (이수/총신대입구 동일 weight → 거리 가까운 이수 1순위)
- hook 통합 (전달/미제공 케이스)

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass. `computeCandidateWeight`는 같은 파일 내 사용. `extractColdStartCandidates` 기존 caller wire 유지.
2. **V/X dashboard** — weight 필드는 Sub-step 4 Picker UI (별 PR)에서 관측. DebugModal 확장은 후속 PR.
3. **의존 PR** — #1838 (Sub-step 1+2) 머지 완료.
4. **측정 plan** — Sub-step 4 Picker UI 머지 후 Day 3+ trip 실기기 1회 시나리오: weight 1순위 후보가 실제 역과 일치하는지 관측.
5. **Device verify** — 코드 + 단위 테스트만 (Sub-step 4 UI 완성 전까지 실기기 cold start 1건 시나리오 실행 불가). N/A — type+unit only.

Closes #1841