### PR TITLE
feat(#1844): Phase 6.1 Sub-step 5 — cold start mismatch 감지 + 재확인 prompt

### DIFF
--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -245,7 +245,12 @@ export type AlarmLogReason =
   // lock=null + boardingPrompt 미응답 + BoardingTrainList 미탭 = 사용자가 열차 선택 의향을 밝히지 않은 상태.
   // 이 상태에서 FG fg/fg-phase/subsurface 3 path가 역 통과·환승·도착 알람을 발사하던 회귀 차단.
   // lock 활성(lock !== null) trip은 fire 허용 — 사용자 명시 의향 = lock 동급 (ADR-010 §1, ADR-014 §B3).
-  | 'lockless-no-user-intent';
+  | 'lockless-no-user-intent'
+  // #1844 (Phase 6.1 Sub-step 5) — cold start 선택 역과 진행 중 신호 mismatch 감지.
+  // useStationMismatchDetector가 3회 연속 불일치 확인 시 적재. expectedStationAtFire 슬롯에
+  // reason 문자열(route-diverged / line-mismatch / environment-mismatch) stamp.
+  // 1주 production 빈도 측정 — `/admin/alarm-log-stats` reason='cold-start-mismatch' 카운트.
+  | 'cold-start-mismatch';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.

--- a/src/features/nearest-station/hooks/__tests__/useStationMismatchDetector.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useStationMismatchDetector.test.ts
@@ -1,0 +1,535 @@
+/**
+ * #1844 (Phase 6.1 Sub-step 5) — useStationMismatchDetector 단위 테스트.
+ *
+ * 커버 시나리오:
+ *   §1 감지 비활성 (null guard)
+ *   §2 line-mismatch — 3회 연속 threshold + reset
+ *   §3 environment-mismatch — underground 선택 + surface 관측
+ *   §4 route-diverged — arc 이탈 + 한 번 일치 reset
+ *   §5 우선순위 — route-diverged > line-mismatch > environment-mismatch
+ *   §6 alarmLog 적재 + dedup
+ *   §7 상수 export 검증
+ */
+
+const mockAppend = jest.fn();
+jest.mock('../../../alarm/utils/alarmLog', () => ({
+  appendAlarmLog: (entry: unknown) => mockAppend(entry),
+}));
+
+// getStationById 는 boardingStation.environment 조회에 사용
+const mockGetStationById = jest.fn();
+jest.mock('../../../../shared/utils/stationRoute', () => ({
+  getStationById: (id: string) => mockGetStationById(id),
+}));
+
+import { renderHook, act } from '@testing-library/react-native';
+import {
+  useStationMismatchDetector,
+  computeMismatch,
+  LINE_MISMATCH_THRESHOLD,
+  ENV_MISMATCH_THRESHOLD,
+  ROUTE_DIVERGE_THRESHOLD,
+  ROUTE_DIVERGE_HOP_THRESHOLD,
+  MISMATCH_LOG_DEDUP_WINDOW_MS,
+  type MismatchReason,
+  type UseStationMismatchDetectorInput,
+} from '../useStationMismatchDetector';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+import type { NearestStationResult, Station } from '../../../../shared/types/station';
+
+// ── 픽스처 ────────────────────────────────────────────────────────────────────
+
+const makeLock = (overrides: Partial<BoardingLock> = {}): BoardingLock => ({
+  destinationId: 'DST-001',
+  trainCode: 'T001',
+  boardingStationId: 'STN-UNDERGROUND',
+  boardingLine: '2',
+  boardedAt: Date.now(),
+  expectedDurationMs: 30 * 60 * 1000,
+  ...overrides,
+});
+
+const makeStation = (id: string, line: string = '2'): Station => ({
+  id,
+  name: `역-${id}`,
+  line: line as Station['line'],
+  lineColor: '#00af64',
+  lat: 37.5,
+  lng: 127.0,
+});
+
+const makeResult = (stationId: string, line: string = '2'): NearestStationResult => ({
+  station: makeStation(stationId, line),
+  distanceKm: 0.1,
+});
+
+const makeArc = (ids: string[]): Station[] => ids.map((id) => makeStation(id));
+
+/** underground environment를 반환하는 mock boarding station. */
+const UNDERGROUND_BOARDING_STATION: Station = {
+  ...makeStation('STN-UNDERGROUND'),
+  environment: 'underground',
+};
+
+/** surface environment boarding station (환경 불일치 없음 케이스용). */
+const SURFACE_BOARDING_STATION: Station = {
+  ...makeStation('STN-SURFACE'),
+  environment: 'surface',
+};
+
+// ── §1 감지 비활성 ─────────────────────────────────────────────────────────────
+
+describe('§1 감지 비활성 (null guard)', () => {
+  const BASE_INPUT: UseStationMismatchDetectorInput = {
+    boardingLock: makeLock(),
+    fusedResult: makeResult('STN-A'),
+    arcStations: [],
+    currentHopIndex: null,
+    environment: 'underground',
+  };
+
+  it('boardingLock=null → detected=false', () => {
+    const { result } = renderHook(() =>
+      useStationMismatchDetector({ ...BASE_INPUT, boardingLock: null }),
+    );
+    expect(result.current.detected).toBe(false);
+    expect(result.current.reason).toBeNull();
+  });
+
+  it('fusedResult=null → detected=false', () => {
+    const { result } = renderHook(() =>
+      useStationMismatchDetector({ ...BASE_INPUT, fusedResult: null }),
+    );
+    expect(result.current.detected).toBe(false);
+  });
+
+  it('둘 다 null → detected=false', () => {
+    const { result } = renderHook(() =>
+      useStationMismatchDetector({ ...BASE_INPUT, boardingLock: null, fusedResult: null }),
+    );
+    expect(result.current.detected).toBe(false);
+  });
+});
+
+// ── §2 line-mismatch ──────────────────────────────────────────────────────────
+
+describe('§2 line-mismatch', () => {
+  const lock = makeLock({ boardingLine: '2' });
+  const countersZero = { routeDiverged: 0, lineMismatch: 0, envMismatch: 0 };
+
+  beforeEach(() => {
+    mockGetStationById.mockReturnValue(undefined); // env-mismatch 비활성
+  });
+
+  it('노선 일치 → lineMismatch 카운터 0 유지', () => {
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-A', '2'),
+      arcStations: [],
+      currentHopIndex: null,
+      environment: 'underground',
+    };
+    const { next } = computeMismatch(input, countersZero);
+    expect(next.lineMismatch).toBe(0);
+  });
+
+  it('노선 불일치 1회 → 카운터 1, detected=false', () => {
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-A', '5'),
+      arcStations: [],
+      currentHopIndex: null,
+      environment: 'underground',
+    };
+    const { result, next } = computeMismatch(input, countersZero);
+    expect(next.lineMismatch).toBe(1);
+    expect(result.detected).toBe(false);
+  });
+
+  it(`노선 불일치 ${LINE_MISMATCH_THRESHOLD}회 연속 → detected=true, reason='line-mismatch'`, () => {
+    let counters = countersZero;
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-A', '5'),
+      arcStations: [],
+      currentHopIndex: null,
+      environment: 'underground',
+    };
+    for (let i = 0; i < LINE_MISMATCH_THRESHOLD - 1; i++) {
+      const out = computeMismatch(input, counters);
+      expect(out.result.detected).toBe(false);
+      counters = out.next;
+    }
+    const { result } = computeMismatch(input, counters);
+    expect(result.detected).toBe(true);
+    expect(result.reason).toBe('line-mismatch');
+  });
+
+  it('불일치 2회 후 일치 1회 → 카운터 reset → detected=false', () => {
+    let counters = countersZero;
+    const mismatchInput: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-A', '5'),
+      arcStations: [],
+      currentHopIndex: null,
+      environment: 'underground',
+    };
+    const matchInput: UseStationMismatchDetectorInput = {
+      ...mismatchInput,
+      fusedResult: makeResult('STN-A', '2'),
+    };
+    counters = computeMismatch(mismatchInput, counters).next;
+    counters = computeMismatch(mismatchInput, counters).next;
+    expect(counters.lineMismatch).toBe(2);
+    // 일치
+    const { next, result } = computeMismatch(matchInput, counters);
+    expect(next.lineMismatch).toBe(0);
+    expect(result.detected).toBe(false);
+  });
+});
+
+// ── §3 environment-mismatch ───────────────────────────────────────────────────
+
+describe('§3 environment-mismatch', () => {
+  const lock = makeLock({ boardingStationId: 'STN-UNDERGROUND' });
+  const countersZero = { routeDiverged: 0, lineMismatch: 0, envMismatch: 0 };
+
+  beforeEach(() => {
+    mockGetStationById.mockImplementation((id: string) => {
+      if (id === 'STN-UNDERGROUND') return UNDERGROUND_BOARDING_STATION;
+      if (id === 'STN-SURFACE') return SURFACE_BOARDING_STATION;
+      return undefined;
+    });
+  });
+
+  it('underground 선택 + surface 관측 → envMismatch 카운터 증가', () => {
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-X', '2'),
+      arcStations: [],
+      currentHopIndex: null,
+      environment: 'surface',
+    };
+    const { next } = computeMismatch(input, countersZero);
+    expect(next.envMismatch).toBe(1);
+  });
+
+  it(`surface 관측 ${ENV_MISMATCH_THRESHOLD}회 연속 → detected=true, reason='environment-mismatch'`, () => {
+    let counters = countersZero;
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-X', '2'),
+      arcStations: [],
+      currentHopIndex: null,
+      environment: 'surface',
+    };
+    for (let i = 0; i < ENV_MISMATCH_THRESHOLD - 1; i++) {
+      counters = computeMismatch(input, counters).next;
+    }
+    const { result } = computeMismatch(input, counters);
+    expect(result.detected).toBe(true);
+    expect(result.reason).toBe('environment-mismatch');
+  });
+
+  it('underground 관측 → reset', () => {
+    let counters = { ...countersZero, envMismatch: 2 };
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-X', '2'),
+      arcStations: [],
+      currentHopIndex: null,
+      environment: 'underground',
+    };
+    const { next, result } = computeMismatch(input, counters);
+    expect(next.envMismatch).toBe(0);
+    expect(result.detected).toBe(false);
+  });
+
+  it('surface 선택역(환경=surface) + surface 관측 → envMismatch 카운터 증가 X', () => {
+    const surfaceLock = makeLock({ boardingStationId: 'STN-SURFACE' });
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: surfaceLock,
+      fusedResult: makeResult('STN-X', '2'),
+      arcStations: [],
+      currentHopIndex: null,
+      environment: 'surface',
+    };
+    const { next } = computeMismatch(input, countersZero);
+    // surface 선택 + surface 관측 → 조건 미충족 → reset(0)
+    expect(next.envMismatch).toBe(0);
+  });
+
+  it('boardingStation 조회 실패(undefined) → envMismatch 카운터 유지 (neutral)', () => {
+    mockGetStationById.mockReturnValue(undefined);
+    const counters = { ...countersZero, envMismatch: 1 };
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-X', '2'),
+      arcStations: [],
+      currentHopIndex: null,
+      environment: 'surface',
+    };
+    const { next } = computeMismatch(input, counters);
+    // 조회 실패 = neutral → 이전 카운터 + 1 (increment path 진입)
+    expect(next.envMismatch).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ── §4 route-diverged ─────────────────────────────────────────────────────────
+
+describe('§4 route-diverged', () => {
+  const lock = makeLock();
+  const countersZero = { routeDiverged: 0, lineMismatch: 0, envMismatch: 0 };
+
+  beforeEach(() => {
+    mockGetStationById.mockReturnValue(undefined);
+  });
+
+  it('arcStations 빈 배열 → route-diverged 감지 비활성 (카운터=0)', () => {
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-OUT'),
+      arcStations: [],
+      currentHopIndex: null,
+      environment: 'underground',
+    };
+    const { next } = computeMismatch(input, countersZero);
+    expect(next.routeDiverged).toBe(0);
+  });
+
+  it('currentHopIndex=null → route-diverged 감지 비활성', () => {
+    const arc = makeArc(['STN-A', 'STN-B', 'STN-C']);
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-OUT'),
+      arcStations: arc,
+      currentHopIndex: null,
+      environment: 'underground',
+    };
+    const { next } = computeMismatch(input, countersZero);
+    expect(next.routeDiverged).toBe(0);
+  });
+
+  it('observed 역이 arc 위 expected window 안 (±HOP_THRESHOLD 이내) → diverge 아님', () => {
+    const arc = makeArc(['STN-A', 'STN-B', 'STN-C', 'STN-D', 'STN-E']);
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-B'), // idx=1, currentHopIndex=2, 차이=1
+      arcStations: arc,
+      currentHopIndex: 2,
+      environment: 'underground',
+    };
+    const { next } = computeMismatch(input, countersZero);
+    expect(next.routeDiverged).toBe(0);
+  });
+
+  it('observed 역이 arc 위 expected window 밖 → diverge 카운터 증가', () => {
+    const arc = makeArc(['STN-A', 'STN-B', 'STN-C', 'STN-D', 'STN-E']);
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      // currentHopIndex=0, observed=STN-E(idx=4), 차이=4 > HOP_THRESHOLD=3
+      fusedResult: makeResult('STN-E'),
+      arcStations: arc,
+      currentHopIndex: 0,
+      environment: 'underground',
+    };
+    const { next } = computeMismatch(input, countersZero);
+    expect(next.routeDiverged).toBe(1);
+  });
+
+  it('observed 역이 arc에 없음 → diverge 카운터 증가', () => {
+    const arc = makeArc(['STN-A', 'STN-B', 'STN-C']);
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-OUTSIDE'),
+      arcStations: arc,
+      currentHopIndex: 1,
+      environment: 'underground',
+    };
+    const { next } = computeMismatch(input, countersZero);
+    expect(next.routeDiverged).toBe(1);
+  });
+
+  it(`route-diverged ${ROUTE_DIVERGE_THRESHOLD}회 연속 → detected=true, reason='route-diverged'`, () => {
+    const arc = makeArc(['STN-A', 'STN-B', 'STN-C']);
+    let counters = countersZero;
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-OUTSIDE'),
+      arcStations: arc,
+      currentHopIndex: 0,
+      environment: 'underground',
+    };
+    for (let i = 0; i < ROUTE_DIVERGE_THRESHOLD - 1; i++) {
+      counters = computeMismatch(input, counters).next;
+    }
+    const { result } = computeMismatch(input, counters);
+    expect(result.detected).toBe(true);
+    expect(result.reason).toBe('route-diverged');
+  });
+
+  it('이탈 2회 후 arc 일치 1회 → reset', () => {
+    const arc = makeArc(['STN-A', 'STN-B', 'STN-C']);
+    let counters = { ...countersZero, routeDiverged: 2 };
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      // STN-B is at idx=1, currentHopIndex=1 → 차이=0 → window 안
+      fusedResult: makeResult('STN-B'),
+      arcStations: arc,
+      currentHopIndex: 1,
+      environment: 'underground',
+    };
+    const { next, result } = computeMismatch(input, counters);
+    expect(next.routeDiverged).toBe(0);
+    expect(result.detected).toBe(false);
+  });
+});
+
+// ── §5 우선순위 ───────────────────────────────────────────────────────────────
+
+describe('§5 우선순위 (route-diverged > line-mismatch > environment-mismatch)', () => {
+  beforeEach(() => {
+    mockGetStationById.mockReturnValue(UNDERGROUND_BOARDING_STATION);
+  });
+
+  it('route-diverged + line-mismatch 동시 → reason=route-diverged', () => {
+    const lock = makeLock({ boardingLine: '2' });
+    const arc = makeArc(['STN-A', 'STN-B', 'STN-C']);
+    const counters = {
+      routeDiverged: ROUTE_DIVERGE_THRESHOLD - 1,
+      lineMismatch: LINE_MISMATCH_THRESHOLD - 1,
+      envMismatch: 0,
+    };
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-OUTSIDE', '5'), // 노선 불일치 + arc 이탈
+      arcStations: arc,
+      currentHopIndex: 0,
+      environment: 'underground',
+    };
+    const { result } = computeMismatch(input, counters);
+    expect(result.detected).toBe(true);
+    expect(result.reason).toBe('route-diverged');
+  });
+
+  it('line-mismatch + environment-mismatch 동시 → reason=line-mismatch', () => {
+    const lock = makeLock({ boardingLine: '2', boardingStationId: 'STN-UNDERGROUND' });
+    const counters = {
+      routeDiverged: 0,
+      lineMismatch: LINE_MISMATCH_THRESHOLD - 1,
+      envMismatch: ENV_MISMATCH_THRESHOLD - 1,
+    };
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-X', '5'), // 노선 불일치
+      arcStations: [],
+      currentHopIndex: null,
+      environment: 'surface', // 환경 불일치도
+    };
+    const { result } = computeMismatch(input, counters);
+    expect(result.detected).toBe(true);
+    expect(result.reason).toBe('line-mismatch');
+  });
+});
+
+// ── §6 alarmLog 적재 + dedup ─────────────────────────────────────────────────
+
+/**
+ * 훅 내부에서 LINE_MISMATCH_THRESHOLD회 연속 불일치가 누적될 때까지 rerender를 구동하는 헬퍼.
+ * 초기 render=1회 이므로 (THRESHOLD-1)회 추가 rerender가 필요.
+ */
+function renderHookUntilDetected(lock: BoardingLock) {
+  const hookResult = renderHook(
+    ({ line }: { line: string }) =>
+      useStationMismatchDetector({
+        boardingLock: lock,
+        fusedResult: makeResult('STN-A', line),
+        arcStations: [],
+        currentHopIndex: null,
+        environment: 'underground',
+      }),
+    { initialProps: { line: '5' } }, // 노선 불일치
+  );
+  // threshold-1 추가 rerender → 누적 LINE_MISMATCH_THRESHOLD회 → detected=true
+  for (let i = 0; i < LINE_MISMATCH_THRESHOLD - 1; i++) {
+    act(() => { hookResult.rerender({ line: '5' }); });
+  }
+  return hookResult;
+}
+
+describe('§6 alarmLog 적재 + dedup', () => {
+  beforeEach(() => {
+    mockAppend.mockReset();
+    mockGetStationById.mockReturnValue(undefined);
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-06-26T10:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('detected=false 상태 → appendAlarmLog 미호출', () => {
+    const lock = makeLock({ boardingLine: '2' });
+    renderHook(() =>
+      useStationMismatchDetector({
+        boardingLock: lock,
+        fusedResult: makeResult('STN-A', '2'), // 일치
+        arcStations: [],
+        currentHopIndex: null,
+        environment: 'underground',
+      }),
+    );
+    expect(mockAppend).not.toHaveBeenCalled();
+  });
+
+  it('LINE_MISMATCH_THRESHOLD회 연속 불일치 → appendAlarmLog 1건 (reason=cold-start-mismatch)', () => {
+    const lock = makeLock({ boardingLine: '2' });
+    renderHookUntilDetected(lock);
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+    const entry = mockAppend.mock.calls[0][0];
+    expect(entry.source).toBe('fg-evaluated');
+    expect(entry.outcome).toBe('suppressed');
+    expect(entry.reason).toBe('cold-start-mismatch');
+    expect(entry.expectedStationAtFire).toBe('line-mismatch');
+  });
+
+  it('detected=true 후 dedup 윈도우 안에 동일 reason 재발생 → 추가 적재 X', () => {
+    const lock = makeLock({ boardingLine: '2' });
+    const { rerender } = renderHookUntilDetected(lock);
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+    // dedup 윈도우 안에서 추가 rerender (deps 안 바뀌어 effect 재실행 없음)
+    act(() => { rerender({ line: '5' }); });
+    act(() => { rerender({ line: '5' }); });
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedup 윈도우 만료 후 같은 reason 재진입 → 추가 적재 O', () => {
+    const lock = makeLock({ boardingLine: '2' });
+    const { rerender } = renderHookUntilDetected(lock);
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+    // 윈도우 만료
+    jest.setSystemTime(new Date(Date.now() + MISMATCH_LOG_DEDUP_WINDOW_MS + 1));
+    // 일치 → reset
+    act(() => { rerender({ line: '2' }); });
+    // 다시 THRESHOLD회 불일치
+    for (let i = 0; i < LINE_MISMATCH_THRESHOLD; i++) {
+      act(() => { rerender({ line: '5' }); });
+    }
+    expect(mockAppend).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── §7 상수 export 검증 ──────────────────────────────────────────────────────
+
+describe('§7 상수 export', () => {
+  it.each([
+    ['LINE_MISMATCH_THRESHOLD', LINE_MISMATCH_THRESHOLD, 3],
+    ['ENV_MISMATCH_THRESHOLD', ENV_MISMATCH_THRESHOLD, 3],
+    ['ROUTE_DIVERGE_THRESHOLD', ROUTE_DIVERGE_THRESHOLD, 3],
+    ['ROUTE_DIVERGE_HOP_THRESHOLD', ROUTE_DIVERGE_HOP_THRESHOLD, 3],
+    ['MISMATCH_LOG_DEDUP_WINDOW_MS', MISMATCH_LOG_DEDUP_WINDOW_MS, 60 * 1000],
+  ])('%s = %i', (_name, actual, expected) => {
+    expect(actual).toBe(expected);
+  });
+});

--- a/src/features/nearest-station/hooks/useStationMismatchDetector.ts
+++ b/src/features/nearest-station/hooks/useStationMismatchDetector.ts
@@ -1,0 +1,191 @@
+/* eslint-disable import/no-restricted-paths --
+ * Phase 6.1 (#1844) Sub-step 5 — cold start 선택 역과 진행 중 신호 mismatch 감지.
+ * alarm slice의 appendAlarmLog를 사용해 측정 적재. useStationAlarm / useFusedNearestStation 등
+ * 다른 cross-feature orchestrator와 동일 패턴 — CLAUDE.md `디렉토리 경계 룰` 헤더 opt-in.
+ */
+import { useEffect, useRef } from 'react';
+import { appendAlarmLog } from '../../alarm/utils/alarmLog';
+import type { BoardingLock } from '../../../shared/types/boardingLock';
+import type { NearestStationResult, Station } from '../../../shared/types/station';
+import type { Environment } from '../utils/inferEnvironment';
+import { getStationById } from '../../../shared/utils/stationRoute';
+
+/**
+ * Phase 6.1 Sub-step 5 (#1844) — cold start 선택 역과 진행 중 신호 mismatch 감지.
+ *
+ * 배경
+ * ====
+ * cold start 환경(지하·GPS 약)에서 사용자가 잘못된 역을 선택한 채 trip이 진행되면
+ * lock.boardingLine / arcStations 기반 알람이 계속 오발사된다. 진행 중 신호(fusion
+ * 결과·environment·arc 진행)와 선택 시작점이 N회 연속 불일치하면 재확인 prompt를 trigger.
+ *
+ * Mismatch Reason 정의
+ * ====================
+ * - 'route-diverged'        : observed 역이 arc 위 expected window(±HOP_THRESHOLD) 밖 — 3회 연속
+ * - 'line-mismatch'         : lock.boardingLine ≠ fusedResult.station.line — 3회 연속
+ * - 'environment-mismatch'  : lock 탑승역 type=underground + observed environment=surface — 3회 연속
+ *
+ * 한 번 일치 → 해당 reason 카운터 reset (false positive 차단).
+ *
+ * Wire-completion
+ * ===============
+ * HomeScreen / trip controller에서 useStationMismatchDetector를 호출한다.
+ * detected=true 시 ActionBanner("재선택")를 표시해 사용자에게 재확인 기회를 준다.
+ * alarmLog reason='cold-start-mismatch'로 1주 production 빈도 측정.
+ *
+ * Race condition guards
+ * =====================
+ * - lock=null / fusedResult=null → 즉시 no-op(detected=false).
+ * - arcStations 빈 배열 → route-diverged 감지 비활성 (arc 없으면 diverge 판단 불가).
+ * - 1분 dedup 윈도우 — 같은 reason 연속 적재 차단.
+ */
+
+/** line-mismatch 감지 연속 임계값. */
+export const LINE_MISMATCH_THRESHOLD = 3;
+
+/** environment-mismatch 감지 연속 임계값. */
+export const ENV_MISMATCH_THRESHOLD = 3;
+
+/** route-diverged 감지 연속 임계값. */
+export const ROUTE_DIVERGE_THRESHOLD = 3;
+
+/** arc 위 ±N hop 이탈 시 diverge 카운트 증가. */
+export const ROUTE_DIVERGE_HOP_THRESHOLD = 3;
+
+/** alarmLog 중복 적재 차단 윈도우(ms). */
+export const MISMATCH_LOG_DEDUP_WINDOW_MS = 60 * 1000;
+
+export type MismatchReason = 'route-diverged' | 'line-mismatch' | 'environment-mismatch';
+
+export interface StationMismatchResult {
+  /** mismatch 감지 여부. */
+  detected: boolean;
+  /** 감지 사유. detected=false 시 null. */
+  reason: MismatchReason | null;
+}
+
+export interface UseStationMismatchDetectorInput {
+  /** 현재 진행 중 lock. null이면 감지 비활성. */
+  boardingLock: BoardingLock | null;
+  /** useFusedNearestStation 결과 현재역. null이면 감지 비활성. */
+  fusedResult: NearestStationResult | null;
+  /** 현재 arc(탑승~waypoint). 빈 배열이면 route-diverged 감지 비활성. */
+  arcStations: readonly Station[];
+  /** 현재 추정 hop index. null이면 route-diverged 감지 비활성. */
+  currentHopIndex: number | null;
+  /** 환경 분류. environment-mismatch 감지용. */
+  environment: Environment;
+}
+
+const NO_MISMATCH: StationMismatchResult = { detected: false, reason: null };
+
+/**
+ * 감지 결과를 계산하는 순수 함수.
+ * 모든 카운터를 외부에서 받아 side effect 없이 다음 카운터를 반환.
+ *
+ * 우선순위: route-diverged > line-mismatch > environment-mismatch
+ */
+export function computeMismatch(
+  input: UseStationMismatchDetectorInput,
+  counters: { routeDiverged: number; lineMismatch: number; envMismatch: number },
+): {
+  result: StationMismatchResult;
+  next: { routeDiverged: number; lineMismatch: number; envMismatch: number };
+} {
+  const { boardingLock, fusedResult, arcStations, currentHopIndex, environment } = input;
+
+  if (!boardingLock || !fusedResult) {
+    return { result: NO_MISMATCH, next: { routeDiverged: 0, lineMismatch: 0, envMismatch: 0 } };
+  }
+
+  // ── route-diverged ───────────────────────────────────────────────────────────
+  let routeDiverged = counters.routeDiverged;
+  if (arcStations.length > 0 && currentHopIndex !== null) {
+    const observedIdx = arcStations.findIndex((s) => s.id === fusedResult.station.id);
+    const isDiverged =
+      observedIdx === -1 ||
+      Math.abs(observedIdx - currentHopIndex) > ROUTE_DIVERGE_HOP_THRESHOLD;
+    routeDiverged = isDiverged ? routeDiverged + 1 : 0;
+  } else {
+    // arc 없음 / hopIndex 없음 → route-diverged 감지 비활성, 카운터 유지 안 함
+    routeDiverged = 0;
+  }
+
+  // ── line-mismatch ────────────────────────────────────────────────────────────
+  const observedLine = fusedResult.station.line;
+  const lineMismatch =
+    observedLine !== boardingLock.boardingLine ? counters.lineMismatch + 1 : 0;
+
+  // ── environment-mismatch ─────────────────────────────────────────────────────
+  // lock.boardingStationId로 탑승역 조회 → environment 확인
+  const boardingStation = getStationById(boardingLock.boardingStationId);
+  let envMismatch = counters.envMismatch;
+  if (boardingStation?.environment === 'underground' && environment === 'surface') {
+    envMismatch = counters.envMismatch + 1;
+  } else if (boardingStation !== undefined) {
+    // 탑승역 조회 성공, 조건 미충족 → reset
+    envMismatch = 0;
+  }
+  // boardingStation=undefined 시 카운터 유지 (조회 실패는 neutral)
+
+  const next = { routeDiverged, lineMismatch, envMismatch };
+
+  // ── 우선순위 판정 ────────────────────────────────────────────────────────────
+  if (routeDiverged >= ROUTE_DIVERGE_THRESHOLD) {
+    return { result: { detected: true, reason: 'route-diverged' }, next };
+  }
+  if (lineMismatch >= LINE_MISMATCH_THRESHOLD) {
+    return { result: { detected: true, reason: 'line-mismatch' }, next };
+  }
+  if (envMismatch >= ENV_MISMATCH_THRESHOLD) {
+    return { result: { detected: true, reason: 'environment-mismatch' }, next };
+  }
+  return { result: NO_MISMATCH, next };
+}
+
+/**
+ * cold start 선택 역과 진행 중 신호 mismatch를 감지한다.
+ *
+ * @returns StationMismatchResult — detected=true 시 재확인 UI를 트리거.
+ */
+export function useStationMismatchDetector(
+  input: UseStationMismatchDetectorInput,
+): StationMismatchResult {
+  const countersRef = useRef({ routeDiverged: 0, lineMismatch: 0, envMismatch: 0 });
+  const resultRef = useRef<StationMismatchResult>(NO_MISMATCH);
+  const lastLogRef = useRef<{ reason: MismatchReason; ts: number } | null>(null);
+
+  // 입력 deps로 effect 재실행 — 매 polling tick마다 fusedResult/environment가 갱신됨
+  const { boardingLock, fusedResult, arcStations, currentHopIndex, environment } = input;
+
+  useEffect(() => {
+    const { result, next } = computeMismatch(
+      { boardingLock, fusedResult, arcStations, currentHopIndex, environment },
+      countersRef.current,
+    );
+    countersRef.current = next;
+    resultRef.current = result;
+
+    if (!result.detected || !result.reason) return;
+
+    // alarmLog 적재 (dedup 60s 윈도우)
+    const now = Date.now();
+    const last = lastLogRef.current;
+    if (last?.reason === result.reason && now - last.ts < MISMATCH_LOG_DEDUP_WINDOW_MS) return;
+    lastLogRef.current = { reason: result.reason, ts: now };
+
+    // fusedResult는 detected=true 시 항상 non-null (null guard at top of computeMismatch).
+    appendAlarmLog({
+      ts: now,
+      source: 'fg-evaluated',
+      outcome: 'suppressed',
+      reason: 'cold-start-mismatch',
+      // stationName 슬롯에 관측된 현재역 id 적재 — 디버그 시 "어떤 역에서 mismatch?" 가시
+      stationName: fusedResult!.station.id,
+      // expectedStationAtFire 슬롯에 reason 적재 — 기존 AlarmLogStamp 스키마 재사용
+      expectedStationAtFire: result.reason,
+    });
+  }, [boardingLock, fusedResult, arcStations, currentHopIndex, environment]);
+
+  return resultRef.current;
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -5,6 +5,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import { useTranslation } from 'react-i18next';
 import { useFusedNearestStation } from '../features/nearest-station/hooks/useFusedNearestStation';
 import { useV1MismatchDetector } from '../features/nearest-station/hooks/useV1MismatchDetector';
+import { useStationMismatchDetector } from '../features/nearest-station/hooks/useStationMismatchDetector';
 import { useArrivalInfo } from '../features/arrival/hooks/useArrivalInfo';
 import type { ArrivalInfo } from '../features/arrival/api/arrivalApi';
 import { useArrivalCountdown } from '../features/arrival/hooks/useArrivalCountdown';
@@ -39,6 +40,7 @@ import { ROUTE_KEY } from '../shared/constants/storageKeys';
 import { AlarmOverlay } from '../features/alarm/components/AlarmOverlay';
 import { createLogger } from '../shared/utils/logger';
 import { useTheme, typography, spacing, radius } from '../shared/theme';
+import { ActionBanner } from '../shared/ui/ActionBanner';
 import { LineBadge } from '../shared/ui/LineBadge';
 import { LocationStateView } from '../shared/ui/LocationStateView';
 import { ServiceWindowBanner } from '../shared/ui/ServiceWindowBanner';
@@ -198,12 +200,23 @@ export default function HomeScreen() {
   // #1677 — silent push 60s+ 미수신 감지. FG 시 backendSsotAccepts 강제 false → device tier fallback.
   // 신규 폴링 없음 — 기존 arrival/position 30s cycle 재사용.
   const { healthy: silentPushHealthy } = useSilentPushHealthCheck();
-  const { result, liveResult, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source, currentHopIndex, arcStations, trainProgressing, estimatorIsTimeIntegration, backendSsotCurrentStationId } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal }, wifiStation, silentPushHealthy);
+  const { result, liveResult, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source, currentHopIndex, arcStations, trainProgressing, estimatorIsTimeIntegration, backendSsotCurrentStationId, environment } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal }, wifiStation, silentPushHealthy);
 
   // #1621 Phase B — V1 mismatch 자동 측정. UI currentStation(cascade picker)이 backend SSoT
   // 권위 mirror와 일치하지 않으면 alarmLog 'v1-mismatch' reason으로 1분 dedup 적재.
   // R2 archive 후 `/admin/alarm-log-stats` 응답으로 1주 production 측정.
   useV1MismatchDetector(result?.station.id ?? null, backendSsotCurrentStationId);
+
+  // #1844 (Phase 6.1 Sub-step 5) — cold start 선택 역과 진행 중 신호 mismatch 감지.
+  // lock.boardingLine / arc / environment와 observed 신호가 3회 연속 불일치 시 detected=true.
+  // detected=true 시 배너로 재확인 prompt (ActionBanner). alarmLog reason='cold-start-mismatch'로 측정.
+  const coldStartMismatch = useStationMismatchDetector({
+    boardingLock: fusionBoardingLock,
+    fusedResult: result,
+    arcStations,
+    currentHopIndex,
+    environment,
+  });
 
   // #914 (F4) — 1탭 현재역 확정 모달. 자동 추정이 locationUncertain으로 길어지면 후보 1~3개를
   // 카드로 노출, 1탭 = customOrigin 적용.
@@ -495,6 +508,10 @@ export default function HomeScreen() {
     motionStationary,
     speedMps,
   });
+  // #1844 — cold start mismatch 재확인: lock 해제 → 사용자가 다시 탑승 선택 가능.
+  const handleColdStartMismatchReselect = useCallback(() => {
+    releaseBoardingLock?.();
+  }, [releaseBoardingLock]);
   // #915 (C1 destination-only baseline UX) — destination 설정 직후 backend로 좋은 fix sync 발사.
   // backend cron이 9단 게이트 통과 시 autoLockCandidate 응답에 부착(#916) → 사용자 명시 탭 없이
   // boardingLock hydrate. lock 활성 여부와 무관하게 trip 활성 동안 폴링.
@@ -1038,6 +1055,28 @@ export default function HomeScreen() {
             {destination && !boardingLock && (
               <View style={{ paddingHorizontal: spacing.xxl, paddingBottom: spacing.md }}>
                 <LocklessBadge onPress={handleLocklessBadgePress} />
+              </View>
+            )}
+
+            {/* #1844 (Phase 6.1 Sub-step 5) — cold start mismatch 재확인 배너.
+                 lock 활성 + mismatch 감지 시 노출. 탑승역 재선택 → lock 해제. */}
+            {boardingLock && coldStartMismatch.detected && (
+              <View style={{ paddingHorizontal: spacing.xxl, paddingBottom: spacing.md }}>
+                <ActionBanner
+                  accent={colors.warn}
+                  actionLabel={t('home.coldStartMismatch.reselect', { defaultValue: '재선택' })}
+                  onActionPress={handleColdStartMismatchReselect}
+                  testID="cold-start-mismatch-banner"
+                  actionTestID="cold-start-mismatch-banner-action"
+                  accessibilityLabel={t('home.coldStartMismatch.message', { defaultValue: '탑승역이 현재 위치와 다릅니다. 다시 선택해 주세요.' })}
+                >
+                  <Text style={[typography.bodySm, { color: colors.ink, fontWeight: '600' }]}>
+                    {t('home.coldStartMismatch.title', { defaultValue: '탑승역 확인' })}
+                  </Text>
+                  <Text style={[typography.caption, { color: colors.muted }]}>
+                    {t('home.coldStartMismatch.message', { defaultValue: '탑승역이 현재 위치와 다릅니다. 다시 선택해 주세요.' })}
+                  </Text>
+                </ActionBanner>
               </View>
             )}
 

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -68,6 +68,11 @@
       "undo": "Undo"
     },
     "lockCorrectionToast": "Boarding train corrected: {{prev}} → {{next}}",
+    "coldStartMismatch": {
+      "title": "Check boarding station",
+      "message": "Your boarding station does not match your current location. Please reselect.",
+      "reselect": "Reselect"
+    },
     "congestion": {
       "level": {
         "low": "Light",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -68,6 +68,11 @@
       "undo": "元に戻す"
     },
     "lockCorrectionToast": "乗車中の列車を {{prev}} → {{next}} に修正しました",
+    "coldStartMismatch": {
+      "title": "乗車駅を確認",
+      "message": "乗車駅が現在地と一致しません。再選択してください。",
+      "reselect": "再選択"
+    },
     "congestion": {
       "level": {
         "low": "余裕",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -68,6 +68,11 @@
       "undo": "되돌리기"
     },
     "lockCorrectionToast": "탑승 열차가 {{prev}} → {{next}}로 정정되었어요",
+    "coldStartMismatch": {
+      "title": "탑승역 확인",
+      "message": "탑승역이 현재 위치와 다릅니다. 다시 선택해 주세요.",
+      "reselect": "재선택"
+    },
     "congestion": {
       "level": {
         "low": "여유",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -68,6 +68,11 @@
       "undo": "撤销"
     },
     "lockCorrectionToast": "已将乘车列车修正为 {{prev}} → {{next}}",
+    "coldStartMismatch": {
+      "title": "确认乘车站",
+      "message": "乘车站与当前位置不符，请重新选择。",
+      "reselect": "重新选择"
+    },
     "congestion": {
       "level": {
         "low": "宽松",

--- a/tasks/plan-1844-cold-start-mismatch-detector.md
+++ b/tasks/plan-1844-cold-start-mismatch-detector.md
@@ -1,0 +1,187 @@
+# Plan #1844 — Phase 6.1 Sub-step 5: Cold Start Mismatch Detector
+
+## §1 목적 / 사용자 가치
+
+cold start 선택 오류를 사용자가 지속 탑승 중에 자동으로 감지해 재확인 기회를 준다.
+
+- **수혜자**: cold start 환경(지하·GPS 약)에서 잘못된 역을 선택한 사용자
+- **가치**: 잘못된 출발역 기준 알람이 계속 발사되는 것을 조기 차단 → 정확도 게이트 유지
+- **ADR-010 동급 원칙**: 사용자 명시 의향 trip(boardingPrompt 응답)은 lock 활성과 동급 정확도 보장
+
+---
+
+## §2 설계 원칙
+
+1. **false positive 우선 방어**: mismatch 1~2회 flicker로 재확인 트리거 금지 — 연속 N회 일치 실패 조건
+2. **한 번 일치 → reset**: 일치 판정이 나오면 해당 reason 카운터를 0으로 초기화 (bouncing 방지)
+3. **pure hook**: 감지 로직은 순수 함수 + useRef 카운터. side effect 없음
+4. **alarmLog 측정**: mismatch 적재로 1주 production 빈도 측정 가능
+
+---
+
+## §3 Mismatch Reason 정의
+
+| Reason | 감지 조건 | 연속 임계 |
+|--------|-----------|-----------|
+| `route-diverged` | lock.boardingLine의 arc station 위치가 observed 현재역보다 3 hop 이상 벗어남 | 3회 연속 |
+| `line-mismatch` | lock.boardingLine ≠ observed(fusedResult) station.line | 3회 연속 |
+| `environment-mismatch` | lock boarding station.environment='underground' + observed environment='surface' | 3회 연속 |
+
+**한 번 일치 → reset**: 각 reason마다 독립 카운터. 일치 판정이 나오면 해당 카운터=0.
+
+---
+
+## §4 Hook 인터페이스
+
+```ts
+// src/features/nearest-station/hooks/useStationMismatchDetector.ts
+
+export type MismatchReason =
+  | 'route-diverged'   // arc 위치 3 hop 초과 이탈
+  | 'line-mismatch'    // 관측 노선 ≠ lock 노선
+  | 'environment-mismatch'; // 지하 선택 + 지상 관측
+
+export interface StationMismatchResult {
+  /** mismatch 감지 여부. false일 때 다른 필드는 의미 없음. */
+  detected: boolean;
+  /** mismatch 사유. detected=false 시 null. */
+  reason: MismatchReason | null;
+}
+
+export interface UseStationMismatchDetectorInput {
+  /** 현재 진행 중 lock. null이면 감지 비활성. */
+  boardingLock: BoardingLock | null;
+  /** useFusedNearestStation 결과 현재역. null이면 감지 비활성. */
+  fusedResult: NearestStationResult | null;
+  /** 현재 arc(탑승~waypoint). 빈 배열이면 route-diverged 감지 비활성. */
+  arcStations: readonly Station[];
+  /** 현재 추정 hop index. null이면 route-diverged 감지 비활성. */
+  currentHopIndex: number | null;
+  /** 환경 분류. environment-mismatch 감지용. */
+  environment: Environment;
+}
+```
+
+---
+
+## §5 감지 알고리즘
+
+### 5.1 line-mismatch
+
+```
+if (lock.boardingLine !== fusedResult.station.line)
+  lineMismatchCount++
+else
+  lineMismatchCount = 0
+detected = lineMismatchCount >= LINE_MISMATCH_THRESHOLD
+```
+
+### 5.2 environment-mismatch
+
+```
+lockBoardingEnv = lock boarding station 조회 (stationLookup by id + line)
+if (lockBoardingEnv === 'underground' && observed === 'surface')
+  envMismatchCount++
+else
+  envMismatchCount = 0
+detected = envMismatchCount >= ENV_MISMATCH_THRESHOLD
+```
+
+### 5.3 route-diverged
+
+```
+if (arcStations.length > 0 && currentHopIndex !== null) {
+  expectedIdx = nearest arc idx matching fusedResult.station.id
+  if (expectedIdx === -1 || |expectedIdx - currentHopIndex| > ROUTE_DIVERGE_HOP_THRESHOLD)
+    routeDivergedCount++
+  else
+    routeDivergedCount = 0
+  detected = routeDivergedCount >= ROUTE_DIVERGE_THRESHOLD
+}
+```
+
+### 5.4 우선순위
+
+`route-diverged` > `line-mismatch` > `environment-mismatch` 순서로 첫 번째 detected reason 반환.
+
+---
+
+## §6 상수
+
+| 상수 | 값 | 의미 |
+|------|-----|------|
+| `LINE_MISMATCH_THRESHOLD` | 3 | 3회 연속 노선 불일치 |
+| `ENV_MISMATCH_THRESHOLD` | 3 | 3회 연속 환경 불일치 |
+| `ROUTE_DIVERGE_THRESHOLD` | 3 | 3회 연속 arc 이탈 |
+| `ROUTE_DIVERGE_HOP_THRESHOLD` | 3 | arc 위 ±3 hop 이탈 |
+
+---
+
+## §7 caller wire (HomeScreen)
+
+```tsx
+// src/screens/HomeScreen.tsx 또는 trip controller
+const mismatch = useStationMismatchDetector({
+  boardingLock: lock,
+  fusedResult: result,
+  arcStations,
+  currentHopIndex,
+  environment,
+});
+
+{mismatch.detected && (
+  <ActionBanner
+    accent={colors.warning}
+    actionLabel="재선택"
+    onActionPress={onTriggerReselect}
+    testID="mismatch-banner"
+    actionTestID="mismatch-banner-action"
+  >
+    <Text>출발역이 맞지 않습니다. 현재 위치를 다시 선택해 주세요.</Text>
+  </ActionBanner>
+)}
+```
+
+Sub-step 4 picker 미머지 시 fallback: 재선택 탭 시 useBoardingPromptResponder reset + trigger.
+
+---
+
+## §8 테스트 매트릭스
+
+### 8.1 감지 비활성 (null guard)
+- lock=null → detected=false
+- fusedResult=null → detected=false
+
+### 8.2 line-mismatch
+- 노선 일치 → 감지 없음
+- 1~2회 불일치 → 아직 감지 없음
+- 3회 연속 불일치 → detected=true, reason='line-mismatch'
+- 2회 불일치 후 1회 일치 → reset → 감지 없음
+
+### 8.3 environment-mismatch
+- underground 선택 + surface 3회 연속 → detected=true
+- surface 선택 → 감지 없음 (지상 선택은 정상)
+- underground 선택 + underground 관측 → 감지 없음
+- 2회 surface 후 1회 underground → reset
+
+### 8.4 route-diverged
+- arc 없음 → 감지 비활성
+- arc 위 ±3 hop 이내 → 감지 없음
+- arc 밖 (arc idx 없음) 3회 → detected=true
+- 2회 이탈 후 1회 일치 → reset
+
+### 8.5 우선순위
+- route-diverged + line-mismatch 동시 → reason='route-diverged'
+
+### 8.6 alarmLog 적재
+- detected 직후 appendAlarmLog 1건 (dedup 60s)
+
+---
+
+## §9 Wire-completion 체크
+
+1. **Orphan**: useStationMismatchDetector → HomeScreen caller 반드시 wire
+2. **V/X dashboard**: alarmLog reason='cold-start-mismatch' → `/admin/alarm-log-stats` 집계
+3. **의존 PR**: #1838 (Phase 6.1 Sub-step 1+2 머지). Sub-step 3/4와 독립 가능
+4. **측정 plan**: 1주 trip에서 mismatch 감지 비율 ≤5% 목표 (FP 차단 지표)
+5. **Device verify**: 의도적 오선택 trip 1건 — 재확인 배너 표시 확인


### PR DESCRIPTION
## Summary

- `useStationMismatchDetector` 신규 훅: cold start 선택 역과 진행 중 신호(노선/환경/arc 위치) 3회 연속 불일치 시 감지
- `computeMismatch` 순수 함수 분리: 3 reason 우선순위 (`route-diverged` > `line-mismatch` > `environment-mismatch`)
- 한 번 일치 → 해당 reason 카운터 reset (false positive 차단)
- `HomeScreen` caller wire: `detected=true` 시 `ActionBanner("재선택")` 표시
- `alarmLog reason='cold-start-mismatch'` 적재 (60s dedup) → 1주 production 빈도 측정
- i18n 4개국어 (ko/en/ja/zh) 키 추가
- 테스트 30건, 커버리지 100%

## Wire-completion 5단

1. **Orphan 없음** — `useStationMismatchDetector`를 `HomeScreen`에 caller wire. `npm run lint:orphan` 0 orphan.
2. **V/X dashboard** — `alarmLog reason='cold-start-mismatch'` → `/admin/alarm-log-stats` 집계. `expectedStationAtFire` 슬롯에 구체 reason 적재.
3. **의존 PR** — `#1838` (Phase 6.1 Sub-step 1+2). Sub-step 3/4와 독립 가능.
4. **측정 plan** — Day 3+ trip에서 `reason='cold-start-mismatch'` 적재 비율 1주 측정. false positive 차단 지표 목표 ≤5%.
5. **Device verify** — 실기기: 의도적 오선택 trip 1건 → 3 polling tick 후 재확인 배너 표시 확인.

## Mismatch 감지 기준

| Reason | 조건 | 연속 임계 |
|--------|------|-----------|
| `route-diverged` | arc 위 expected window(±3 hop) 밖 | 3회 연속 |
| `line-mismatch` | `lock.boardingLine ≠ fusedResult.station.line` | 3회 연속 |
| `environment-mismatch` | lock 탑승역 `environment=underground` + observed `environment=surface` | 3회 연속 |

Closes #1844