### PR TITLE
fix(#1857): ColdStartCandidatePicker test factory weight 필드 추가 — 머지 race hotfix

### DIFF
--- a/src/features/nearest-station/components/__tests__/ColdStartCandidatePicker.test.tsx
+++ b/src/features/nearest-station/components/__tests__/ColdStartCandidatePicker.test.tsx
@@ -17,6 +17,7 @@ function makeCandidate(
     lat: 37.5,
     lng: 127.0,
     stations: [],
+    weight: 0,
   };
 }
 


### PR DESCRIPTION
## 원인 (머지 race)

- PR #1853 (Sub-step 3 weighted narrow): \`ColdStartCandidate.weight: number\` required 필드 추가
- PR #1850 (Sub-step 4 picker UI): test factory가 weight 없이 생성

둘 다 origin/dev base에서 작업 → 머지 후 type-check fail.

## 에러
\`\`\`
src/features/nearest-station/components/__tests__/ColdStartCandidatePicker.test.tsx:13:3
  - error TS2741: Property 'weight' is missing in type ... but required in type 'ColdStartCandidate'.
\`\`\`

## 수정
\`makeCandidate\` factory에 \`weight: 0\` 추가. 정렬은 distance tiebreaker로 동작 (테스트 시나리오 영향 없음).

## 검증
- \`tsc --noEmit\` ✅
- ColdStartCandidatePicker.test.tsx 21/21 pass ✅

## Wire-completion 5단
1. **Orphan**: N/A (테스트 fixture)
2. **V/X dashboard**: N/A
3. **의존 PR**: PR #1850 / #1853 둘 다 머지됨
4. **측정 plan**: N/A — hotfix
5. **Device verify**: N/A — type-check pass 복구

Closes #1857