### PR TITLE
feat(#1859): rawSignalBuffer cellular 필드 + DebugModal Cellular Tech Distribution

### DIFF
--- a/src/features/alarm/api/__tests__/signalDumpBackend.test.ts
+++ b/src/features/alarm/api/__tests__/signalDumpBackend.test.ts
@@ -30,6 +30,7 @@ function entry(ts: number, kind: RawSignalEntry['kind'] = 'cycle'): RawSignalEnt
     gps: null,
     motion: null,
     accelPattern: null,
+    cellular: null,
     subsurface: null,
     arvlCd: null,
     line: null,

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -324,9 +324,9 @@ function formatFusionDebugLine(entry: FusionDebugEntry): string {
 
 /**
  * #1501 — Raw signal ring buffer entry를 한 줄 텍스트로. 필드 순서:
- *   `HH:MM:SS | kind | stationId | source/confidence | gps(acc/speed) | motion | subsurface | arvlCd | arcProgress`
- * 누락 필드는 `-`로 출력 — Fusion log와 동일 컨벤션. line/dir/corrId는 share dump 본문에
- * 추가 정보가 필요할 때 별도 PR로 확장한다(본 PR-C는 필수 9필드만 노출).
+ *   `HH:MM:SS | kind | stationId | source/confidence | gps(acc/speed) | motion | sub | arvlCd | arc | cell`
+ * 누락 필드는 `-`로 출력 — Fusion log와 동일 컨벤션.
+ * #1859 — cellular 필드 추가: `cell=<tech_short>/<vote>` (예: `cell=LTE/surface`, `cell=-/unknown`).
  */
 function formatRawSignalLine(entry: RawSignalEntry): string {
   const time = formatTime(entry.ts);
@@ -342,7 +342,11 @@ function formatRawSignalLine(entry: RawSignalEntry): string {
   const arvlCd = entry.arvlCd != null ? String(entry.arvlCd) : '-';
   const progress =
     entry.arcProgress != null ? entry.arcProgress.toFixed(2) : '-';
-  return `${time} | ${entry.kind} | ${stationId} | ${source}/${confidence} | gps(${acc}/${speed}) | ${motion} | sub=${subsurface} | arvlCd=${arvlCd} | arc=${progress}`;
+  // #1859 — tech 상수에서 'CTRadioAccessTechnology' prefix를 제거해 라인 압축.
+  const cellular = entry.cellular != null
+    ? `cell=${(entry.cellular.tech ?? '').replace('CTRadioAccessTechnology', '') || '-'}/${entry.cellular.vote}`
+    : 'cell=-';
+  return `${time} | ${entry.kind} | ${stationId} | ${source}/${confidence} | gps(${acc}/${speed}) | ${motion} | sub=${subsurface} | arvlCd=${arvlCd} | arc=${progress} | ${cellular}`;
 }
 
 /**
@@ -823,6 +827,58 @@ function buildRawSignalSection(args: BuildDumpArgs): string[] {
 }
 
 /**
+ * #1859 — Cellular Tech Distribution 집계 순수 함수. rawSignalLog entries에서 cellular 필드를
+ * 집계해 tech별 발생 빈도와 vote 분포 라인 목록을 반환.
+ *
+ * 구버전 엔트리(cellular=null): 'legacy' 버킷으로 분리 집계.
+ *
+ * 출력 형식 (tech 빈도 내림차순):
+ *   LTE: 45x (vote=surface)
+ *   NRNSA: 12x (vote=surface)
+ *   WCDMA: 3x (vote=underground)
+ *   legacy(no field): 5x
+ *   total=65 measured=60 surface=57 underground=3 unknown=0 legacy=5
+ */
+export function computeCellularTechDistribution(entries: readonly RawSignalEntry[]): string[] {
+  if (entries.length === 0) return ['(empty)'];
+
+  const techStats = new Map<string, { count: number; vote: string }>();
+  let legacyCount = 0;
+  let surfaceCount = 0;
+  let undergroundCount = 0;
+  let unknownCount = 0;
+
+  for (const entry of entries) {
+    if (entry.cellular == null) {
+      legacyCount += 1;
+      continue;
+    }
+    const { tech, vote } = entry.cellular;
+    const techKey = tech != null ? tech.replace('CTRadioAccessTechnology', '') : '(null)';
+    const existing = techStats.get(techKey);
+    techStats.set(techKey, { count: (existing?.count ?? 0) + 1, vote });
+    if (vote === 'surface') surfaceCount += 1;
+    else if (vote === 'underground') undergroundCount += 1;
+    else unknownCount += 1;
+  }
+
+  const lines: string[] = [];
+  const sorted = [...techStats.entries()].sort((a, b) => b[1].count - a[1].count);
+  for (const [tech, { count, vote }] of sorted) {
+    lines.push(`${tech}: ${count}x (vote=${vote})`);
+  }
+  if (legacyCount > 0) lines.push(`legacy(no field): ${legacyCount}x`);
+  const measured = entries.length - legacyCount;
+  lines.push(`total=${entries.length} measured=${measured} surface=${surfaceCount} underground=${undergroundCount} unknown=${unknownCount} legacy=${legacyCount}`);
+  return lines;
+}
+
+/** #1859 — SHARE_SECTIONS builder wrapper. */
+function buildCellularTechDistributionSection(args: BuildDumpArgs): string[] {
+  return computeCellularTechDistribution(args.rawSignalLog ?? []);
+}
+
+/**
  * #1346 — Fusion log 섹션. 빈 buffer일 때 (empty)로 명시 출력해 "한 번도 push 안 됨"과
  * "load 안 함"을 구분한다(scheduled queue 컨벤션 따라).
  */
@@ -1272,6 +1328,12 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
     build: buildRawSignalSection,
     suffix: (args) => ` (${args.rawSignalLog?.length ?? 0})`,
   },
+  // #1859 — Cellular Tech Distribution. rawSignalLog에서 cellular 분포 집계.
+  // 1주 측정 → LTE/NRNSA surface hard-reject 재검토 evidence.
+  {
+    title: 'Cellular Tech Distribution',
+    build: buildCellularTechDistributionSection,
+  },
 ];
 
 function buildDumpText(args: BuildDumpArgs): string {
@@ -1433,6 +1495,8 @@ function DebugModalInner({
     detectionSignalMask,
     // #1418 — 환경 인지 fusion arbitration. Tier 1 SSOT 합의 활성 + 추정 환경 노출.
     environment,
+    // #1860 — 옵션 C barometer-stop 힌트 원인. DebugModal environment 라인에 함께 노출.
+    environmentHintReason,
     surfaceSSOTActive,
     undergroundSSOTActive,
     // #1421 — PR-AutoLock-1 측정 인프라. SSOT 객체 직접 받아 inferAutoLockCandidate에 전달.
@@ -1857,7 +1921,12 @@ function DebugModalInner({
             <KeyValue label="gps" value={gpsLabel} colors={colors} />
             {/* #1418 — 환경 인지 fusion arbitration. surface/underground SSOT 합의 활성 여부와
                 추정 환경. Tier 5(시간 적분) reject 게이트가 어느 신호에 막혔는지 사후 재구성 가능. */}
-            <KeyValue label="environment" value={environment} colors={colors} />
+            {/* #1860 — 옵션 C 힌트 발동 시 hintReason 부가 표시. "이미 지하" 보완 신호 관측용. */}
+            <KeyValue
+              label="environment"
+              value={environmentHintReason ? `${environment} (hint:${environmentHintReason})` : environment}
+              colors={colors}
+            />
             <KeyValue
               label="surfaceSSOT"
               value={surfaceSSOTActive ? 'active' : 'null'}
@@ -2213,6 +2282,26 @@ function DebugModalInner({
             entryTestId="debug-raw-signal-entry"
             colors={colors}
           />
+
+          {/* #1859 — Cellular Tech Distribution. rawSignalLog cellular 분포 집계.
+              1주 측정 → LTE/NRNSA surface hard-reject 재검토 결정 evidence. */}
+          <Section
+            title="Cellular Tech Distribution"
+            colors={colors}
+            testID="debug-cellular-tech-distribution"
+          >
+            {computeCellularTechDistribution(rawSignalLog).map((line, idx) => (
+              <Text
+                // eslint-disable-next-line react/no-array-index-key
+                key={idx}
+                style={[typography.mono, { color: colors.ink }]}
+                selectable
+                testID="debug-cellular-tech-entry"
+              >
+                {line}
+              </Text>
+            ))}
+          </Section>
 
           {/* #1263 (Epic #1204 그룹 0 PR C): Regressions 4종 추이 */}
           <RegressionsSection />

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -127,6 +127,8 @@ const fusedReturnFixture = (overrides: Record<string, unknown> = {}) => ({
   displayOnlyEstimate: null,
   // #1678 — S9 accelerometer fingerprint. 기본값은 unknown(미지원/미수렴).
   accelerometerPattern: 'unknown' as const,
+  // #1859 — environmentHintReason. 기본값은 null(hint 없음).
+  environmentHintReason: null as string | null,
   ...overrides,
 });
 const arrivalDefaults = {
@@ -173,6 +175,8 @@ const setupHookDefaults = () => {
     displayOnlyEstimate: null,
     // #1678 — S9 accelerometer fingerprint. 기본값은 unknown(미지원/미수렴).
     accelerometerPattern: 'unknown',
+    // #1859 — environmentHintReason. 기본값은 null(hint 없음).
+    environmentHintReason: null,
   });
   mockUseArrivalInfo.mockReturnValue({ arrival: baseArrival, loading: false, isMock: false });
   mockUseSilentPushDiagnostics.mockReturnValue({
@@ -366,6 +370,17 @@ describe('DebugModal', () => {
     expect(screen.getByText('surface')).toBeTruthy();
     // 'active' 라벨이 surfaceSSOT/undergroundSSOT row에 노출.
     expect(screen.getAllByText('active').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('#1859 — environmentHintReason 있을 때 environment 값에 hint 부가 표시', () => {
+    mockUseFusedNearestStation.mockReturnValue(
+      fusedReturnFixture({
+        environment: 'underground',
+        environmentHintReason: 'barometer-stop',
+      }),
+    );
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByText('underground (hint:barometer-stop)')).toBeTruthy();
   });
 
   // #1421 — render-time auto-lock 측정 인프라가 SSOT 객체를 받아 share dump에 흘러간다.
@@ -3982,6 +3997,7 @@ describe('DebugModal — #1501 Raw Signal 섹션', () => {
     gps: { lat: 37.5, lng: 127, accM: 25, speedMps: 8.3 },
     motion: 'automotive',
     accelPattern: 'automotive',
+    cellular: null,
     subsurface: false,
     arvlCd: 99,
     line: '7',
@@ -4187,6 +4203,97 @@ describe('DebugModal — #1501 Raw Signal 섹션', () => {
       expect(msg).toContain('## Raw Signal (1)');
       expect(msg).toContain('SHARE-INTEGRATION');
       shareSpy.mockRestore();
+    });
+  });
+
+  // #1859 — cellular 필드 + computeCellularTechDistribution
+  describe('#1859 cellular 필드 + Cellular Tech Distribution', () => {
+    const { computeCellularTechDistribution } = jest.requireActual('../DebugModal') as typeof import('../DebugModal');
+
+    describe('formatRawSignalLine — cellular 토큰', () => {
+      it('cellular=null → cell=- 표기', () => {
+        const line = formatRawSignalLine(makeRawEntry({ cellular: null }));
+        expect(line).toContain('cell=-');
+      });
+
+      it('cellular LTE surface → cell=LTE/surface (prefix 제거)', () => {
+        const line = formatRawSignalLine(
+          makeRawEntry({ cellular: { tech: 'CTRadioAccessTechnologyLTE', vote: 'surface' } }),
+        );
+        expect(line).toContain('cell=LTE/surface');
+      });
+
+      it('cellular NRNSA surface → cell=NRNSA/surface', () => {
+        const line = formatRawSignalLine(
+          makeRawEntry({ cellular: { tech: 'CTRadioAccessTechnologyNRNSA', vote: 'surface' } }),
+        );
+        expect(line).toContain('cell=NRNSA/surface');
+      });
+
+      it('cellular WCDMA underground → cell=WCDMA/underground', () => {
+        const line = formatRawSignalLine(
+          makeRawEntry({ cellular: { tech: 'CTRadioAccessTechnologyWCDMA', vote: 'underground' } }),
+        );
+        expect(line).toContain('cell=WCDMA/underground');
+      });
+
+      it('cellular tech=null unknown → cell=-/unknown', () => {
+        const line = formatRawSignalLine(
+          makeRawEntry({ cellular: { tech: null, vote: 'unknown' } }),
+        );
+        expect(line).toContain('cell=-/unknown');
+      });
+    });
+
+    describe('computeCellularTechDistribution', () => {
+      it('빈 배열 → (empty)', () => {
+        expect(computeCellularTechDistribution([])).toEqual(['(empty)']);
+      });
+
+      it('cellular=null 엔트리만 → legacy 버킷만 + total 라인', () => {
+        const entries = [makeRawEntry({ cellular: null }), makeRawEntry({ cellular: null })];
+        const lines = computeCellularTechDistribution(entries);
+        expect(lines.some((l) => l.startsWith('legacy(no field): 2x'))).toBe(true);
+        expect(lines[lines.length - 1]).toContain('total=2');
+        expect(lines[lines.length - 1]).toContain('legacy=2');
+        expect(lines[lines.length - 1]).toContain('measured=0');
+      });
+
+      it('LTE surface 3건 + WCDMA underground 1건 → 빈도 내림차순 + summary', () => {
+        const lteEntry = makeRawEntry({ cellular: { tech: 'CTRadioAccessTechnologyLTE', vote: 'surface' } });
+        const wcdmaEntry = makeRawEntry({ cellular: { tech: 'CTRadioAccessTechnologyWCDMA', vote: 'underground' } });
+        const entries = [lteEntry, lteEntry, lteEntry, wcdmaEntry];
+        const lines = computeCellularTechDistribution(entries);
+        expect(lines[0]).toContain('LTE: 3x (vote=surface)');
+        expect(lines[1]).toContain('WCDMA: 1x (vote=underground)');
+        const summary = lines[lines.length - 1];
+        expect(summary).toContain('total=4');
+        expect(summary).toContain('surface=3');
+        expect(summary).toContain('underground=1');
+        expect(summary).toContain('unknown=0');
+        expect(summary).toContain('legacy=0');
+      });
+
+      it('cellular null 혼합 → legacy 버킷 분리 + measured 정확', () => {
+        const entries = [
+          makeRawEntry({ cellular: { tech: 'CTRadioAccessTechnologyLTE', vote: 'surface' } }),
+          makeRawEntry({ cellular: null }),
+          makeRawEntry({ cellular: { tech: null, vote: 'unknown' } }),
+        ];
+        const lines = computeCellularTechDistribution(entries);
+        expect(lines.some((l) => l.startsWith('legacy(no field): 1x'))).toBe(true);
+        const summary = lines[lines.length - 1];
+        expect(summary).toContain('total=3');
+        expect(summary).toContain('measured=2');
+        expect(summary).toContain('legacy=1');
+      });
+
+      it('share dump에 ## Cellular Tech Distribution 섹션 포함', () => {
+        const lteEntry = makeRawEntry({ cellular: { tech: 'CTRadioAccessTechnologyLTE', vote: 'surface' } });
+        const dump = buildDumpText(makeDumpArgs({ rawSignalLog: [lteEntry] }));
+        expect(dump).toContain('## Cellular Tech Distribution');
+        expect(dump).toContain('LTE: 1x (vote=surface)');
+      });
     });
   });
 

--- a/src/features/debug/components/__tests__/MetricDrillDownView.test.tsx
+++ b/src/features/debug/components/__tests__/MetricDrillDownView.test.tsx
@@ -31,6 +31,7 @@ function makeEntry(overrides?: Partial<RawSignalEntry>): RawSignalEntry {
     gps: null,
     motion: null,
     accelPattern: null,
+    cellular: null,
     subsurface: null,
     arvlCd: null,
     line: '2',

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -12,6 +12,7 @@ import {
   type FusionCandidateMini,
 } from '../utils/fusionDebugBuffer';
 import { pushRawSignal, type MotionLabel } from '../../observability/utils/rawSignalBuffer';
+import { getCurrentCellularTech } from '../utils/cellularTech';
 import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
 import { pushEstimatorEntry } from '../../route/utils/estimatorDebugBuffer';
 import { useNearestStation } from './useNearestStation';
@@ -41,7 +42,7 @@ import { findStationByName, findStationByNameAndLine } from '../../../shared/uti
 import { isWithinArcWindow, passesFusionDistanceGate } from '../utils/fusionDistanceGate';
 import { surfaceSSOTConsensus } from '../utils/surfaceSSotConsensus';
 import { undergroundSSOTConsensus } from '../utils/undergroundSSotConsensus';
-import { inferEnvironment, type Environment } from '../utils/inferEnvironment';
+import { inferEnvironment, type Environment, type InferEnvironmentResult } from '../utils/inferEnvironment';
 import { recordEnvironmentTransition } from '../../../shared/infra/monitoring/breadcrumb';
 import { computeRouteArc } from '../../route/utils/routeProgress';
 import {
@@ -225,6 +226,12 @@ interface UseFusedNearestStationReturn {
    * 'surface' / 'underground' / 'unknown'. DebugModal Environment Inference 섹션 표시용.
    */
   environment: Environment;
+  /**
+   * #1860 — 옵션 C barometer-stop 힌트 발동 원인.
+   * 'barometer-stop' = tripActive + barometerStop=true + subsurface=false + SSOT 없음 조합.
+   * undefined이면 힌트 없음. DebugModal environment 라인에 함께 노출.
+   */
+  environmentHintReason: InferEnvironmentResult['hintReason'];
   /** #1418 — 지상 Tier 1 SSOT(GPS+Arrival) 합의 활성 여부. */
   surfaceSSOTActive: boolean;
   /** #1418 — 지하 Tier 1 SSOT(WiFi/Position-Train + Arrival) 합의 활성 여부. */
@@ -1285,11 +1292,15 @@ export function useFusedNearestStation(
     // lock 활성 시 boardedAt 사용. lockless는 locklessTripStartRef 선언 이후 별도 처리.
     tripStartedAt: boardingLock?.boardedAt,
   });
-  const environment: Environment = inferEnvironment({
+  // #1860 — 옵션 C barometer-stop 힌트. tripActive + barometerStop 전달.
+  const environmentResult: InferEnvironmentResult = inferEnvironment({
     subsurface: barometerSubsurface,
     surfaceSSOT: surfaceSSOT !== null,
     undergroundSSOT: undergroundSSOT !== null,
+    tripActive,
+    barometerStop: barometerSignal?.stop,
   });
+  const environment: Environment = environmentResult.label;
 
   // S13(#1546) — 환경 전환 Sentry breadcrumb. delta-only emit.
   // dedup은 recordEnvironmentTransition 내부에서 처리(prev === next 시 no-op).
@@ -1825,6 +1836,9 @@ export function useFusedNearestStation(
       fusionArrival?.up[0]?.arrivalCode ?? fusionArrival?.down[0]?.arrivalCode ?? null;
     const arcProgressForDump = progress.progressM ?? null;
     const ts = Date.now();
+    // #1859 — CTRadioAccessTechnology 스냅샷. tech는 native 캐시에서 동기 읽기.
+    // vote는 useCellularTech()가 이미 산출한 값을 그대로 사용(재분류 없음).
+    const cellularForDump = { tech: getCurrentCellularTech(), vote: cellularEnvironmentVote };
     const prevStationId = lastStationIdRef.current;
     const nextStationId = resultStationId;
     if (prevStationId !== null && result !== null && nextStationId !== null && prevStationId !== nextStationId) {
@@ -1835,6 +1849,7 @@ export function useFusedNearestStation(
         gps: gpsForDump,
         motion: motionForDump,
         accelPattern: accelerometerPattern,
+        cellular: cellularForDump,
         subsurface: barometerSubsurface ?? null,
         arvlCd: arvlCdForDump,
         line: null,
@@ -1852,6 +1867,7 @@ export function useFusedNearestStation(
         gps: gpsForDump,
         motion: motionForDump,
         accelPattern: accelerometerPattern,
+        cellular: cellularForDump,
         subsurface: barometerSubsurface ?? null,
         arvlCd: arvlCdForDump,
         line: result.station.line,
@@ -1871,6 +1887,7 @@ export function useFusedNearestStation(
       gps: gpsForDump,
       motion: motionForDump,
       accelPattern: accelerometerPattern,
+      cellular: cellularForDump,
       subsurface: barometerSubsurface ?? null,
       arvlCd: arvlCdForDump,
       line: result?.station.line ?? null,
@@ -1920,6 +1937,7 @@ export function useFusedNearestStation(
     estimatorIsTimeIntegration,
     trainProgressing,
     environment,
+    environmentHintReason: environmentResult.hintReason,
     surfaceSSOTActive: surfaceSSOT !== null,
     undergroundSSOTActive: undergroundSSOT !== null,
     // #1421 — DebugModal Auto-lock 측정 섹션이 SSOT 객체를 inferAutoLockCandidate에 직접 전달.

--- a/src/features/nearest-station/utils/__tests__/inferEnvironment.test.ts
+++ b/src/features/nearest-station/utils/__tests__/inferEnvironment.test.ts
@@ -3,55 +3,114 @@ import { inferEnvironment } from '../inferEnvironment';
 describe('inferEnvironment', () => {
   it('subsurface=true 명시 → underground', () => {
     expect(
-      inferEnvironment({ subsurface: true, surfaceSSOT: false, undergroundSSOT: false }),
+      inferEnvironment({ subsurface: true, surfaceSSOT: false, undergroundSSOT: false }).label,
     ).toBe('underground');
   });
 
   it('subsurface=true는 surfaceSSOT가 활성이어도 underground 우선 (barometer 확정)', () => {
     expect(
-      inferEnvironment({ subsurface: true, surfaceSSOT: true, undergroundSSOT: false }),
+      inferEnvironment({ subsurface: true, surfaceSSOT: true, undergroundSSOT: false }).label,
     ).toBe('underground');
   });
 
   it('subsurface=false + surfaceSSOT 활성 → surface', () => {
     expect(
-      inferEnvironment({ subsurface: false, surfaceSSOT: true, undergroundSSOT: false }),
+      inferEnvironment({ subsurface: false, surfaceSSOT: true, undergroundSSOT: false }).label,
     ).toBe('surface');
   });
 
   it('subsurface=false + undergroundSSOT 활성(지상 SSOT 없음) → underground (지하상가)', () => {
     expect(
-      inferEnvironment({ subsurface: false, surfaceSSOT: false, undergroundSSOT: true }),
+      inferEnvironment({ subsurface: false, surfaceSSOT: false, undergroundSSOT: true }).label,
     ).toBe('underground');
   });
 
   it('subsurface=false + 둘 다 null → unknown', () => {
     expect(
-      inferEnvironment({ subsurface: false, surfaceSSOT: false, undergroundSSOT: false }),
+      inferEnvironment({ subsurface: false, surfaceSSOT: false, undergroundSSOT: false }).label,
     ).toBe('unknown');
   });
 
   it('subsurface=undefined + surfaceSSOT만 활성 → surface (hybrid)', () => {
     expect(
-      inferEnvironment({ subsurface: undefined, surfaceSSOT: true, undergroundSSOT: false }),
+      inferEnvironment({ subsurface: undefined, surfaceSSOT: true, undergroundSSOT: false }).label,
     ).toBe('surface');
   });
 
   it('subsurface=undefined + undergroundSSOT만 활성 → underground (hybrid)', () => {
     expect(
-      inferEnvironment({ subsurface: undefined, surfaceSSOT: false, undergroundSSOT: true }),
+      inferEnvironment({ subsurface: undefined, surfaceSSOT: false, undergroundSSOT: true }).label,
     ).toBe('underground');
   });
 
   it('subsurface=undefined + 둘 다 활성 → unknown (분간 불가)', () => {
     expect(
-      inferEnvironment({ subsurface: undefined, surfaceSSOT: true, undergroundSSOT: true }),
+      inferEnvironment({ subsurface: undefined, surfaceSSOT: true, undergroundSSOT: true }).label,
     ).toBe('unknown');
   });
 
   it('subsurface=undefined + 둘 다 null → unknown', () => {
     expect(
-      inferEnvironment({ subsurface: undefined, surfaceSSOT: false, undergroundSSOT: false }),
+      inferEnvironment({ subsurface: undefined, surfaceSSOT: false, undergroundSSOT: false }).label,
     ).toBe('unknown');
+  });
+
+  describe('#1860 barometer-stop hintReason', () => {
+    it('tripActive + barometerStop=true + subsurface=false + SSOT 없음 → hintReason 발동', () => {
+      const result = inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        tripActive: true,
+        barometerStop: true,
+      });
+      expect(result.label).toBe('unknown');
+      expect(result.hintReason).toBe('barometer-stop');
+    });
+
+    it('tripActive=false이면 hintReason 미발동', () => {
+      const result = inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        tripActive: false,
+        barometerStop: true,
+      });
+      expect(result.hintReason).toBeUndefined();
+    });
+
+    it('barometerStop=false이면 hintReason 미발동', () => {
+      const result = inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        tripActive: true,
+        barometerStop: false,
+      });
+      expect(result.hintReason).toBeUndefined();
+    });
+
+    it('surfaceSSOT 활성 시 hintReason 미발동 (surface 반환 우선)', () => {
+      const result = inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: true,
+        undergroundSSOT: false,
+        tripActive: true,
+        barometerStop: true,
+      });
+      expect(result.label).toBe('surface');
+      expect(result.hintReason).toBeUndefined();
+    });
+
+    it('hintReason은 subsurface=false 경로에서만 발동 (undefined는 미발동)', () => {
+      const result = inferEnvironment({
+        subsurface: undefined,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        tripActive: true,
+        barometerStop: true,
+      });
+      expect(result.hintReason).toBeUndefined();
+    });
   });
 });

--- a/src/features/nearest-station/utils/inferEnvironment.ts
+++ b/src/features/nearest-station/utils/inferEnvironment.ts
@@ -11,9 +11,22 @@
  *   4. `subsurface === undefined` + 둘 다 활성 → 'unknown' (hybrid).
  *   5. 둘 다 활성 + barometer 미확정 → 'unknown'.
  *   6. 둘 다 null → 'unknown'.
+ *
+ * #1860 — hintReason 'barometer-stop': tripActive + barometerStop=true + subsurface=false
+ * + 두 SSOT 없음 조합. DebugModal environment 라인에 함께 노출.
  */
 
 export type Environment = 'surface' | 'underground' | 'unknown';
+
+/** #1860 — inferEnvironment 반환값. label = 환경 라벨, hintReason = 힌트 발동 원인. */
+export interface InferEnvironmentResult {
+  label: Environment;
+  /**
+   * 옵션 C barometer-stop 힌트 발동 시 'barometer-stop'. 힌트 없으면 undefined.
+   * 발동 조건: tripActive=true + barometerStop=true + subsurface=false + 두 SSOT 없음.
+   */
+  hintReason?: 'barometer-stop';
+}
 
 export interface InferEnvironmentInput {
   /** barometer `subsurface` 신호. undefined = warmup / 미지원. */
@@ -22,18 +35,26 @@ export interface InferEnvironmentInput {
   surfaceSSOT: boolean;
   /** `undergroundSSOTConsensus`가 합의했으면 true. */
   undergroundSSOT: boolean;
+  /** #1860 — trip 활성 여부. barometer-stop 힌트 발동 전제 조건. */
+  tripActive?: boolean;
+  /** #1860 — BarometerSignal.stop. barometer-stop 힌트 발동 전제 조건. */
+  barometerStop?: boolean;
 }
 
-export function inferEnvironment(input: InferEnvironmentInput): Environment {
-  const { subsurface, surfaceSSOT, undergroundSSOT } = input;
-  if (subsurface === true) return 'underground';
+export function inferEnvironment(input: InferEnvironmentInput): InferEnvironmentResult {
+  const { subsurface, surfaceSSOT, undergroundSSOT, tripActive, barometerStop } = input;
+  if (subsurface === true) return { label: 'underground' };
   if (subsurface === false) {
-    if (surfaceSSOT) return 'surface';
-    if (undergroundSSOT) return 'underground';
-    return 'unknown';
+    if (surfaceSSOT) return { label: 'surface' };
+    if (undergroundSSOT) return { label: 'underground' };
+    // #1860 — barometer-stop 힌트: tripActive + barometerStop=true + SSOT 없음.
+    if (tripActive && barometerStop === true) {
+      return { label: 'unknown', hintReason: 'barometer-stop' };
+    }
+    return { label: 'unknown' };
   }
   // subsurface === undefined (warmup / 미지원) — SSOT 신호로만 판단.
-  if (surfaceSSOT && !undergroundSSOT) return 'surface';
-  if (undergroundSSOT && !surfaceSSOT) return 'underground';
-  return 'unknown';
+  if (surfaceSSOT && !undergroundSSOT) return { label: 'surface' };
+  if (undergroundSSOT && !surfaceSSOT) return { label: 'underground' };
+  return { label: 'unknown' };
 }

--- a/src/features/observability/utils/__tests__/rawSignalBuffer.test.ts
+++ b/src/features/observability/utils/__tests__/rawSignalBuffer.test.ts
@@ -24,6 +24,7 @@ function entry(overrides?: Partial<RawSignalEntry>): RawSignalEntry {
     gps: { lat: 37.5, lng: 127, accM: 30, speedMps: 1.2 },
     motion: null,
     accelPattern: null,
+    cellular: null,
     subsurface: false,
     arvlCd: null,
     line: '2',
@@ -247,6 +248,41 @@ describe('rawSignalBuffer (#1501 PR-A)', () => {
       (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(stored));
       await hydrateRawSignalBuffer();
       expect(getRawSignalEntries()[0].accelPattern).toBe('walking');
+    });
+  });
+
+  // ── #1859 cellular 필드 ──────────────────────────────────────────────────────
+
+  describe('cellular field (#1859)', () => {
+    it('cellular=null 값이 push/get에 보존된다', () => {
+      pushRawSignal(entry({ cellular: null }));
+      expect(getRawSignalEntries()[0].cellular).toBeNull();
+    });
+
+    it('cellular LTE surface 값이 push/get에 보존된다', () => {
+      const cellular = { tech: 'CTRadioAccessTechnologyLTE', vote: 'surface' } as const;
+      pushRawSignal(entry({ cellular }));
+      expect(getRawSignalEntries()[0].cellular).toEqual(cellular);
+    });
+
+    it('cellular WCDMA underground 값이 push/get에 보존된다', () => {
+      const cellular = { tech: 'CTRadioAccessTechnologyWCDMA', vote: 'underground' } as const;
+      pushRawSignal(entry({ cellular }));
+      expect(getRawSignalEntries()[0].cellular).toEqual(cellular);
+    });
+
+    it('cellular tech=null unknown 값이 push/get에 보존된다', () => {
+      const cellular = { tech: null, vote: 'unknown' } as const;
+      pushRawSignal(entry({ cellular }));
+      expect(getRawSignalEntries()[0].cellular).toEqual(cellular);
+    });
+
+    it('cellular이 hydration 후 복원된다', async () => {
+      const cellular = { tech: 'CTRadioAccessTechnologyNRNSA', vote: 'surface' } as const;
+      const stored = [entry({ cellular })];
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(stored));
+      await hydrateRawSignalBuffer();
+      expect(getRawSignalEntries()[0].cellular).toEqual(cellular);
     });
   });
 });

--- a/src/features/observability/utils/rawSignalBuffer.ts
+++ b/src/features/observability/utils/rawSignalBuffer.ts
@@ -16,6 +16,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { RAW_SIGNAL_BUFFER_KEY } from '../../../shared/constants/storageKeys';
 import { createDebugBuffer } from '../../../shared/utils/createDebugBuffer';
 import type { FusionConfidence, FusionSource } from '../../../shared/types/fusion';
+import type { CellularEnvironmentVote } from '../../nearest-station/utils/cellularTech';
 
 export const RAW_SIGNAL_BUFFER_CAPACITY = 120;
 export const RAW_SIGNAL_WRITE_THROTTLE_MS = 1000;
@@ -31,6 +32,16 @@ export interface RawSignalGps {
   speedMps: number | null;
 }
 
+/**
+ * #1859 — CTRadioAccessTechnology 스냅샷. rawSignalBuffer entry당 1회 기록.
+ * tech: native가 반환한 raw 상수 문자열 (예: 'CTRadioAccessTechnologyLTE') 또는 null(미확정).
+ * vote: classifyCellularEnvironment 결과 ('surface'|'underground'|'unknown').
+ */
+export interface RawSignalCellular {
+  tech: string | null;
+  vote: CellularEnvironmentVote;
+}
+
 export interface RawSignalEntry {
   ts: number;
   corrId: string | null;
@@ -39,6 +50,8 @@ export interface RawSignalEntry {
   motion: MotionLabel | null;
   /** #1769 — accelerometer fingerprint 분류 결과 (classifyAccelerometerPattern). motion(CMMotionActivity)과 별도 채널. */
   accelPattern: MotionLabel | null;
+  /** #1859 — CTRadioAccessTechnology 스냅샷 + 환경 vote. null이면 미지원(Android/jest/old 엔트리). */
+  cellular: RawSignalCellular | null;
   subsurface: boolean | null;
   arvlCd: number | null;
   line: string | null;


### PR DESCRIPTION
## Summary

- `RawSignalEntry` schema에 `cellular: { tech: string | null; vote: CellularEnvironmentVote } | null` 필드 추가
- `useFusedNearestStation` `pushRawSignal` 3곳(cycle/enter/exit)에 `cellular` 주입 — `getCurrentCellularTech()` 동기 read로 tech 스냅샷 캡처
- `formatRawSignalLine` — `cell=LTE/surface` 형식 토큰 추가 (`CTRadioAccessTechnology` prefix 제거)
- `computeCellularTechDistribution` 순수 함수 + `SHARE_SECTIONS` 등록 → share dump에 `## Cellular Tech Distribution` 자동 포함
- DebugModal UI에 `Cellular Tech Distribution` 섹션 추가 (rawSignalLog entries에서 tech별 발생 빈도 + vote 분포 집계)

## 배경

`plan-1846-cellular-tech-vote-audit.md` §4.5 action item:
- LTE/NRNSA → `surface` hard-reject가 서울 지하철 지하 100% LTE 환경에서 false positive 위험
- Day 2 trip에서 cellular vote 값이 dump에 노출되지 않아 실제 분포를 알 수 없었음
- 본 PR은 1주 측정 인프라 — `surface` hard-reject 전환 결정은 측정 후 별도 PR

## Wire-completion 5단

1. **Orphan**: `rawSignalBuffer.ts` callers 3곳 모두 cellular 필드 추가 완료. `npm run lint:orphan` 0 orphan 확인
2. **V/X dashboard**: DebugModal "Cellular Tech Distribution" 섹션 신규 — tech별 발생 빈도 + vote 분포 + total summary 실시간 표시
3. **의존 PR**: #1849 (plan-1846 audit doc 머지됨) — 독립 실행 가능
4. **측정 plan**: 1주 실기기 trip → DebugModal "Cellular Tech Distribution" 섹션에서 LTE/NRNSA surface 비율 확인 → 높으면 surface hard-reject → soft downgrade 전환 결정 (별도 PR)
5. **Device verify**: 실기기 5G/LTE trip 1건에서 `cell=LTE/surface` 토큰 DebugModal 표시 확인 (사용자 책임)

Closes #1859