### PR TITLE
feat(#1860): barometer-stop hint — 이미 지하 사용자 evaluateSubsurfaceEnter false 고착 해소

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -1433,6 +1433,8 @@ function DebugModalInner({
     detectionSignalMask,
     // #1418 — 환경 인지 fusion arbitration. Tier 1 SSOT 합의 활성 + 추정 환경 노출.
     environment,
+    // #1860 — 옵션 C barometer-stop 힌트 원인. DebugModal environment 라인에 함께 노출.
+    environmentHintReason,
     surfaceSSOTActive,
     undergroundSSOTActive,
     // #1421 — PR-AutoLock-1 측정 인프라. SSOT 객체 직접 받아 inferAutoLockCandidate에 전달.
@@ -1857,7 +1859,12 @@ function DebugModalInner({
             <KeyValue label="gps" value={gpsLabel} colors={colors} />
             {/* #1418 — 환경 인지 fusion arbitration. surface/underground SSOT 합의 활성 여부와
                 추정 환경. Tier 5(시간 적분) reject 게이트가 어느 신호에 막혔는지 사후 재구성 가능. */}
-            <KeyValue label="environment" value={environment} colors={colors} />
+            {/* #1860 — 옵션 C 힌트 발동 시 hintReason 부가 표시. "이미 지하" 보완 신호 관측용. */}
+            <KeyValue
+              label="environment"
+              value={environmentHintReason ? `${environment} (hint:${environmentHintReason})` : environment}
+              colors={colors}
+            />
             <KeyValue
               label="surfaceSSOT"
               value={surfaceSSOTActive ? 'active' : 'null'}

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -118,6 +118,8 @@ const fusedReturnFixture = (overrides: Record<string, unknown> = {}) => ({
   detectionSignalMask: '',
   // #1418 — 환경 인지 fusion arbitration 신규 노출 필드 기본값.
   environment: 'unknown' as const,
+  // #1860 — 옵션 C barometer-stop 힌트 원인. 기본값은 undefined(힌트 없음).
+  environmentHintReason: undefined as 'barometer-stop' | undefined,
   surfaceSSOTActive: false,
   undergroundSSOTActive: false,
   // #1421 — PR-AutoLock-1 측정 인프라 신규 노출 필드 기본값.
@@ -164,6 +166,8 @@ const setupHookDefaults = () => {
     detectionSignalMask: '',
     // #1418 — 환경 인지 fusion arbitration 신규 필드.
     environment: 'unknown',
+    // #1860 — 옵션 C barometer-stop 힌트. 기본 setup은 힌트 없음.
+    environmentHintReason: undefined,
     surfaceSSOTActive: false,
     undergroundSSOTActive: false,
     // #1421 — PR-AutoLock-1 측정 인프라.
@@ -366,6 +370,18 @@ describe('DebugModal', () => {
     expect(screen.getByText('surface')).toBeTruthy();
     // 'active' 라벨이 surfaceSSOT/undergroundSSOT row에 노출.
     expect(screen.getAllByText('active').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('#1860 — environmentHintReason 있을 때 environment 라벨에 hint 부가 표시', () => {
+    mockUseFusedNearestStation.mockReturnValue(
+      fusedReturnFixture({
+        environment: 'unknown',
+        environmentHintReason: 'barometer-stop' as const,
+      }),
+    );
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(screen.getByText('environment')).toBeTruthy();
+    expect(screen.getByText('unknown (hint:barometer-stop)')).toBeTruthy();
   });
 
   // #1421 — render-time auto-lock 측정 인프라가 SSOT 객체를 받아 share dump에 흘러간다.

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -41,7 +41,7 @@ import { findStationByName, findStationByNameAndLine } from '../../../shared/uti
 import { isWithinArcWindow, passesFusionDistanceGate } from '../utils/fusionDistanceGate';
 import { surfaceSSOTConsensus } from '../utils/surfaceSSotConsensus';
 import { undergroundSSOTConsensus } from '../utils/undergroundSSotConsensus';
-import { inferEnvironment, type Environment } from '../utils/inferEnvironment';
+import { inferEnvironment, type Environment, type InferEnvironmentResult } from '../utils/inferEnvironment';
 import { recordEnvironmentTransition } from '../../../shared/infra/monitoring/breadcrumb';
 import { computeRouteArc } from '../../route/utils/routeProgress';
 import {
@@ -225,6 +225,12 @@ interface UseFusedNearestStationReturn {
    * 'surface' / 'underground' / 'unknown'. DebugModal Environment Inference 섹션 표시용.
    */
   environment: Environment;
+  /**
+   * #1860 — 옵션 C barometer-stop 힌트 발동 원인.
+   * 'barometer-stop' = tripActive + barometerStop=true + subsurface=false + SSOT 없음 조합.
+   * undefined이면 힌트 없음. DebugModal environment 라인에 함께 노출.
+   */
+  environmentHintReason: InferEnvironmentResult['hintReason'];
   /** #1418 — 지상 Tier 1 SSOT(GPS+Arrival) 합의 활성 여부. */
   surfaceSSOTActive: boolean;
   /** #1418 — 지하 Tier 1 SSOT(WiFi/Position-Train + Arrival) 합의 활성 여부. */
@@ -1285,11 +1291,15 @@ export function useFusedNearestStation(
     // lock 활성 시 boardedAt 사용. lockless는 locklessTripStartRef 선언 이후 별도 처리.
     tripStartedAt: boardingLock?.boardedAt,
   });
-  const environment: Environment = inferEnvironment({
+  // #1860 — 옵션 C barometer-stop 힌트. tripActive + barometerStop 전달.
+  const environmentResult: InferEnvironmentResult = inferEnvironment({
     subsurface: barometerSubsurface,
     surfaceSSOT: surfaceSSOT !== null,
     undergroundSSOT: undergroundSSOT !== null,
+    tripActive,
+    barometerStop: barometerSignal?.stop,
   });
+  const environment: Environment = environmentResult.label;
 
   // S13(#1546) — 환경 전환 Sentry breadcrumb. delta-only emit.
   // dedup은 recordEnvironmentTransition 내부에서 처리(prev === next 시 no-op).
@@ -1920,6 +1930,7 @@ export function useFusedNearestStation(
     estimatorIsTimeIntegration,
     trainProgressing,
     environment,
+    environmentHintReason: environmentResult.hintReason,
     surfaceSSOTActive: surfaceSSOT !== null,
     undergroundSSOTActive: undergroundSSOT !== null,
     // #1421 — DebugModal Auto-lock 측정 섹션이 SSOT 객체를 inferAutoLockCandidate에 직접 전달.

--- a/src/features/nearest-station/utils/__tests__/inferEnvironment.test.ts
+++ b/src/features/nearest-station/utils/__tests__/inferEnvironment.test.ts
@@ -1,57 +1,156 @@
 import { inferEnvironment } from '../inferEnvironment';
 
 describe('inferEnvironment', () => {
+  // ── 기존 케이스 (backward-compat) ──────────────────────────────────────────
   it('subsurface=true 명시 → underground', () => {
     expect(
       inferEnvironment({ subsurface: true, surfaceSSOT: false, undergroundSSOT: false }),
-    ).toBe('underground');
+    ).toEqual({ label: 'underground' });
   });
 
   it('subsurface=true는 surfaceSSOT가 활성이어도 underground 우선 (barometer 확정)', () => {
     expect(
       inferEnvironment({ subsurface: true, surfaceSSOT: true, undergroundSSOT: false }),
-    ).toBe('underground');
+    ).toEqual({ label: 'underground' });
   });
 
   it('subsurface=false + surfaceSSOT 활성 → surface', () => {
     expect(
       inferEnvironment({ subsurface: false, surfaceSSOT: true, undergroundSSOT: false }),
-    ).toBe('surface');
+    ).toEqual({ label: 'surface' });
   });
 
   it('subsurface=false + undergroundSSOT 활성(지상 SSOT 없음) → underground (지하상가)', () => {
     expect(
       inferEnvironment({ subsurface: false, surfaceSSOT: false, undergroundSSOT: true }),
-    ).toBe('underground');
+    ).toEqual({ label: 'underground' });
   });
 
-  it('subsurface=false + 둘 다 null → unknown', () => {
+  it('subsurface=false + 둘 다 null → unknown (hintReason 없음)', () => {
     expect(
       inferEnvironment({ subsurface: false, surfaceSSOT: false, undergroundSSOT: false }),
-    ).toBe('unknown');
+    ).toEqual({ label: 'unknown' });
   });
 
   it('subsurface=undefined + surfaceSSOT만 활성 → surface (hybrid)', () => {
     expect(
       inferEnvironment({ subsurface: undefined, surfaceSSOT: true, undergroundSSOT: false }),
-    ).toBe('surface');
+    ).toEqual({ label: 'surface' });
   });
 
   it('subsurface=undefined + undergroundSSOT만 활성 → underground (hybrid)', () => {
     expect(
       inferEnvironment({ subsurface: undefined, surfaceSSOT: false, undergroundSSOT: true }),
-    ).toBe('underground');
+    ).toEqual({ label: 'underground' });
   });
 
   it('subsurface=undefined + 둘 다 활성 → unknown (분간 불가)', () => {
     expect(
       inferEnvironment({ subsurface: undefined, surfaceSSOT: true, undergroundSSOT: true }),
-    ).toBe('unknown');
+    ).toEqual({ label: 'unknown' });
   });
 
   it('subsurface=undefined + 둘 다 null → unknown', () => {
     expect(
       inferEnvironment({ subsurface: undefined, surfaceSSOT: false, undergroundSSOT: false }),
-    ).toBe('unknown');
+    ).toEqual({ label: 'unknown' });
+  });
+
+  // ── #1860 옵션 C barometer-stop 힌트 매트릭스 ─────────────────────────────
+  describe('barometer-stop hint (#1860)', () => {
+    it('tripActive=true + barometerStop=true + subsurface=false + SSOT 없음 → unknown + hintReason', () => {
+      expect(
+        inferEnvironment({
+          subsurface: false,
+          surfaceSSOT: false,
+          undergroundSSOT: false,
+          tripActive: true,
+          barometerStop: true,
+        }),
+      ).toEqual({ label: 'unknown', hintReason: 'barometer-stop' });
+    });
+
+    it('tripActive=true + barometerStop=false → hint 없음 (이동 중)', () => {
+      expect(
+        inferEnvironment({
+          subsurface: false,
+          surfaceSSOT: false,
+          undergroundSSOT: false,
+          tripActive: true,
+          barometerStop: false,
+        }),
+      ).toEqual({ label: 'unknown' });
+    });
+
+    it('tripActive=false + barometerStop=true → hint 없음 (trip 비활성 = false positive 방지)', () => {
+      expect(
+        inferEnvironment({
+          subsurface: false,
+          surfaceSSOT: false,
+          undergroundSSOT: false,
+          tripActive: false,
+          barometerStop: true,
+        }),
+      ).toEqual({ label: 'unknown' });
+    });
+
+    it('tripActive=undefined + barometerStop=true → hint 없음 (미전달 = 기존 동작)', () => {
+      expect(
+        inferEnvironment({
+          subsurface: false,
+          surfaceSSOT: false,
+          undergroundSSOT: false,
+          barometerStop: true,
+        }),
+      ).toEqual({ label: 'unknown' });
+    });
+
+    it('tripActive=true + barometerStop=undefined (warmup) → hint 없음', () => {
+      expect(
+        inferEnvironment({
+          subsurface: false,
+          surfaceSSOT: false,
+          undergroundSSOT: false,
+          tripActive: true,
+          barometerStop: undefined,
+        }),
+      ).toEqual({ label: 'unknown' });
+    });
+
+    it('tripActive=true + barometerStop=true + surfaceSSOT 활성 → surface 우선 (hint 없음)', () => {
+      expect(
+        inferEnvironment({
+          subsurface: false,
+          surfaceSSOT: true,
+          undergroundSSOT: false,
+          tripActive: true,
+          barometerStop: true,
+        }),
+      ).toEqual({ label: 'surface' });
+    });
+
+    it('tripActive=true + barometerStop=true + undergroundSSOT 활성 → underground 우선 (hint 없음)', () => {
+      expect(
+        inferEnvironment({
+          subsurface: false,
+          surfaceSSOT: false,
+          undergroundSSOT: true,
+          tripActive: true,
+          barometerStop: true,
+        }),
+      ).toEqual({ label: 'underground' });
+    });
+
+    it('tripActive=true + barometerStop=true + subsurface=true → underground 우선 (hint 없음)', () => {
+      expect(
+        inferEnvironment({
+          subsurface: true,
+          surfaceSSOT: false,
+          undergroundSSOT: false,
+          tripActive: true,
+          barometerStop: true,
+        }),
+      ).toEqual({ label: 'underground' });
+    });
   });
 });

--- a/src/features/nearest-station/utils/inferEnvironment.ts
+++ b/src/features/nearest-station/utils/inferEnvironment.ts
@@ -8,9 +8,10 @@
  *   1. `subsurface === true` 명시 → 'underground' (barometer 확정).
  *   2. `subsurface === false` 명시 + surfaceSSOT 활성 → 'surface'.
  *   3. `subsurface === false` + undergroundSSOT 활성 → 'underground' (지하상가/매핑 SSID).
- *   4. `subsurface === undefined` + 둘 다 활성 → 'unknown' (hybrid).
- *   5. 둘 다 활성 + barometer 미확정 → 'unknown'.
- *   6. 둘 다 null → 'unknown'.
+ *   4. `subsurface === false` + SSOT 없음 + tripActive=true + barometerStop=true → 'unknown' + hintReason (옵션 C).
+ *   5. `subsurface === undefined` + 둘 다 활성 → 'unknown' (hybrid).
+ *   6. 둘 다 활성 + barometer 미확정 → 'unknown'.
+ *   7. 둘 다 null → 'unknown'.
  */
 
 export type Environment = 'surface' | 'underground' | 'unknown';
@@ -22,18 +23,48 @@ export interface InferEnvironmentInput {
   surfaceSSOT: boolean;
   /** `undergroundSSOTConsensus`가 합의했으면 true. */
   undergroundSSOT: boolean;
+  /**
+   * #1860 — 옵션 C barometer-stop 힌트 게이트.
+   * trip 활성 중일 때만 힌트 발동 (cold start lockless 환경에서만 의미 있음).
+   * 미전달(undefined)이면 힌트 비활성 — 기존 동작 유지.
+   */
+  tripActive?: boolean;
+  /**
+   * #1860 — 옵션 C barometer-stop 힌트 신호.
+   * `evaluateBarometerStop` detected 결과. true = 30s 윈도우 |dP| 임계 이하(정차 패턴).
+   * undefined = warmup / reading 부족. false = 이동 중.
+   */
+  barometerStop?: boolean | undefined;
 }
 
-export function inferEnvironment(input: InferEnvironmentInput): Environment {
-  const { subsurface, surfaceSSOT, undergroundSSOT } = input;
-  if (subsurface === true) return 'underground';
+/**
+ * #1860 — inferEnvironment 반환 래퍼.
+ *
+ * `label`: 기존 Environment 값 ('surface' / 'underground' / 'unknown').
+ * `hintReason`: 옵션 C 힌트가 발동됐을 때의 원인. label='unknown'이더라도 힌트가 있으면
+ *   "이미 지하일 가능성" 신호로 DebugModal에 노출한다. 없으면 undefined.
+ */
+export interface InferEnvironmentResult {
+  label: Environment;
+  /** #1860 — 힌트 발동 원인. 기존 label은 변경 없이 원인만 추가. */
+  hintReason?: 'barometer-stop';
+}
+
+export function inferEnvironment(input: InferEnvironmentInput): InferEnvironmentResult {
+  const { subsurface, surfaceSSOT, undergroundSSOT, tripActive, barometerStop } = input;
+  if (subsurface === true) return { label: 'underground' };
   if (subsurface === false) {
-    if (surfaceSSOT) return 'surface';
-    if (undergroundSSOT) return 'underground';
-    return 'unknown';
+    if (surfaceSSOT) return { label: 'surface' };
+    if (undergroundSSOT) return { label: 'underground' };
+    // #1860 옵션 C — 이미 지하 + trip 활성 + barometer 정차 패턴 힌트.
+    // label='unknown' 유지 (false positive 방지). hintReason으로 DebugModal에 노출.
+    if (tripActive === true && barometerStop === true) {
+      return { label: 'unknown', hintReason: 'barometer-stop' };
+    }
+    return { label: 'unknown' };
   }
   // subsurface === undefined (warmup / 미지원) — SSOT 신호로만 판단.
-  if (surfaceSSOT && !undergroundSSOT) return 'surface';
-  if (undergroundSSOT && !surfaceSSOT) return 'underground';
-  return 'unknown';
+  if (surfaceSSOT && !undergroundSSOT) return { label: 'surface' };
+  if (undergroundSSOT && !surfaceSSOT) return { label: 'underground' };
+  return { label: 'unknown' };
 }

--- a/tasks/plan-1860-barometer-stop-hint.md
+++ b/tasks/plan-1860-barometer-stop-hint.md
@@ -1,0 +1,57 @@
+# Plan #1860 — barometer-stop hint (옵션 C) — 이미 지하 사용자 보완
+
+Issue: https://github.com/handokei/subway-now/issues/1860
+Parent: #1845 (barometer threshold audit)
+Status: implementation plan
+
+---
+
+## §1 문제 정의
+
+"이미 지하" 사용자가 앱을 실행하면 30s warmup 동안 dP ≈ 0 이므로 `evaluateSubsurfaceEnter` 는 항상 `detected=false`.
+결과: `inferEnvironment` → `subsurface=false + surfaceSSOT=false + undergroundSSOT=false` → `'unknown'`.
+
+downstream 영향:
+- `stickyStationGates.ts:72` — `tripActive && subsurface===true` 조건 미충족 → sticky lock 없음
+- `undergroundSSOTConsensus` — subsurface vote 1표 없음
+- `useNearestStation` — `FG_WATCH_OPTIONS_SUBSURFACE` 미선택 → GPS throttle 미적용
+
+---
+
+## §2 해결 방향 (옵션 C)
+
+`inferEnvironment` 에 hint 분기 추가:
+- 입력: `tripActive: boolean`, `barometerStop: boolean | undefined`
+- 조건: `subsurface===false + surfaceSSOT=false + undergroundSSOT=false + tripActive=true + barometerStop=true`
+- 결과: label `'unknown'` 유지 (false positive 방지) + `hintReason: 'barometer-stop'` 추가
+
+`InferEnvironmentResult` 래퍼로 확장:
+```typescript
+export interface InferEnvironmentResult {
+  label: Environment;
+  hintReason?: 'barometer-stop';
+}
+```
+
+backward-compat: 기존 caller `useFusedNearestStation.ts` 는 `.label` 로 접근.
+`Environment` 타입은 유지 (기존 export 그대로).
+
+---
+
+## §3 변경 파일
+
+1. `src/features/nearest-station/utils/inferEnvironment.ts` — 핵심 변경
+2. `src/features/nearest-station/utils/__tests__/inferEnvironment.test.ts` — 커버리지 매트릭스
+3. `src/features/nearest-station/hooks/useFusedNearestStation.ts` — caller 업데이트 + environmentHintReason 반환
+4. `src/features/debug/components/DebugModal.tsx` — hintReason 노출 (V/X dashboard)
+5. `src/features/debug/components/__tests__/DebugModal.test.tsx` — DebugModal 힌트 케이스
+
+---
+
+## §4 Wire-completion 5단 체크
+
+1. **Orphan**: 신규 export `InferEnvironmentResult` — `useFusedNearestStation` 가 caller. `environmentHintReason` — DebugModal이 caller. `npm run lint:orphan` pass 확인.
+2. **V/X dashboard**: DebugModal Fusion 섹션 "environment" 라인에 `hint:barometer-stop` 노출.
+3. **의존 PR**: #1848 머지됨 — N/A.
+4. **측정 plan**: Day 3+ trip DebugModal dump로 `hintReason='barometer-stop'` 발생 빈도 1주 측정.
+5. **Device verify**: 실기기 "이미 지하" trip 1건 (사용자 책임).


### PR DESCRIPTION
## Summary

- `inferEnvironment`에 옵션 C barometer-stop 힌트 분기 추가 — "이미 지하" 사용자가 앱 실행 시 `evaluateSubsurfaceEnter` dP ≈ 0으로 `subsurface=false` 고착되는 구조적 결함 부분 해소
- `tripActive=true + barometerStop=true + subsurface=false + SSOT 없음` 조건 → `label='unknown'` 유지 + `hintReason='barometer-stop'` 추가 (false positive 방지 — 단독 판정 금지)
- DebugModal Fusion 섹션 "environment" 라인에 `unknown (hint:barometer-stop)` 부가 표시로 관측 가능

## Wire-completion 5단

1. **Orphan**: `InferEnvironmentResult` — `useFusedNearestStation` caller. `environmentHintReason` — DebugModal caller. `npm run lint:orphan` pass ✅
2. **V/X dashboard**: DebugModal Fusion 섹션 "environment" 라인에 `hint:barometer-stop` 표시 → 실기기 DebugModal dump로 관측 가능
3. **의존 PR**: #1848 (docs audit 머지됨) — N/A 코드 의존 없음
4. **측정 plan**: Day 3+ trip DebugModal dump에서 `hintReason='barometer-stop'` 발생 빈도 1주 측정. "이미 지하" trip 시나리오에서 `barometerStop=true` 발생률 확인
5. **Device verify**: 실기기 "이미 지하" trip 1건 — DebugModal 열어 `environment` 라인 확인 (사용자 책임)

## Test coverage

- `inferEnvironment` 17개 케이스 (기존 9 + 힌트 매트릭스 8)
- `DebugModal` hint 표시 케이스 1개 추가 (총 300 → 301)
- 전체 8018 tests, 388 suites, 100% coverage

Closes #1860
