### PR TITLE
feat(#1872): barometer-stop hint — 이미 지하 사용자 subsurface 고착 해소

### DIFF
--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -1285,10 +1285,13 @@ export function useFusedNearestStation(
     // lock 활성 시 boardedAt 사용. lockless는 locklessTripStartRef 선언 이후 별도 처리.
     tripStartedAt: boardingLock?.boardedAt,
   });
-  const environment: Environment = inferEnvironment({
+  const { environment } = inferEnvironment({
     subsurface: barometerSubsurface,
     surfaceSSOT: surfaceSSOT !== null,
     undergroundSSOT: undergroundSSOT !== null,
+    // #1872 — barometer-stop hint: "이미 지하" 사용자 보완 신호.
+    tripActive,
+    barometerStop: barometerSignal?.stop,
   });
 
   // S13(#1546) — 환경 전환 Sentry breadcrumb. delta-only emit.

--- a/src/features/nearest-station/utils/__tests__/inferEnvironment.test.ts
+++ b/src/features/nearest-station/utils/__tests__/inferEnvironment.test.ts
@@ -1,57 +1,169 @@
 import { inferEnvironment } from '../inferEnvironment';
 
 describe('inferEnvironment', () => {
+  // ── 기존 경로 (backward-compat) ───────────────────────────────────────────
+
   it('subsurface=true 명시 → underground', () => {
     expect(
       inferEnvironment({ subsurface: true, surfaceSSOT: false, undergroundSSOT: false }),
-    ).toBe('underground');
+    ).toEqual({ environment: 'underground' });
   });
 
   it('subsurface=true는 surfaceSSOT가 활성이어도 underground 우선 (barometer 확정)', () => {
     expect(
       inferEnvironment({ subsurface: true, surfaceSSOT: true, undergroundSSOT: false }),
-    ).toBe('underground');
+    ).toEqual({ environment: 'underground' });
   });
 
   it('subsurface=false + surfaceSSOT 활성 → surface', () => {
     expect(
       inferEnvironment({ subsurface: false, surfaceSSOT: true, undergroundSSOT: false }),
-    ).toBe('surface');
+    ).toEqual({ environment: 'surface' });
   });
 
   it('subsurface=false + undergroundSSOT 활성(지상 SSOT 없음) → underground (지하상가)', () => {
     expect(
       inferEnvironment({ subsurface: false, surfaceSSOT: false, undergroundSSOT: true }),
-    ).toBe('underground');
+    ).toEqual({ environment: 'underground' });
   });
 
-  it('subsurface=false + 둘 다 null → unknown', () => {
+  it('subsurface=false + 둘 다 null, tripActive/barometerStop 미제공 → unknown (힌트 없음)', () => {
     expect(
       inferEnvironment({ subsurface: false, surfaceSSOT: false, undergroundSSOT: false }),
-    ).toBe('unknown');
+    ).toEqual({ environment: 'unknown' });
   });
 
   it('subsurface=undefined + surfaceSSOT만 활성 → surface (hybrid)', () => {
     expect(
       inferEnvironment({ subsurface: undefined, surfaceSSOT: true, undergroundSSOT: false }),
-    ).toBe('surface');
+    ).toEqual({ environment: 'surface' });
   });
 
   it('subsurface=undefined + undergroundSSOT만 활성 → underground (hybrid)', () => {
     expect(
       inferEnvironment({ subsurface: undefined, surfaceSSOT: false, undergroundSSOT: true }),
-    ).toBe('underground');
+    ).toEqual({ environment: 'underground' });
   });
 
   it('subsurface=undefined + 둘 다 활성 → unknown (분간 불가)', () => {
     expect(
       inferEnvironment({ subsurface: undefined, surfaceSSOT: true, undergroundSSOT: true }),
-    ).toBe('unknown');
+    ).toEqual({ environment: 'unknown' });
   });
 
   it('subsurface=undefined + 둘 다 null → unknown', () => {
     expect(
       inferEnvironment({ subsurface: undefined, surfaceSSOT: false, undergroundSSOT: false }),
-    ).toBe('unknown');
+    ).toEqual({ environment: 'unknown' });
+  });
+
+  // ── #1872 barometer-stop hint 분기 ───────────────────────────────────────
+
+  it('tripActive=true + barometerStop=true + subsurface=false + SSOT 없음 → unknown + hintReason=barometer-stop', () => {
+    expect(
+      inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        tripActive: true,
+        barometerStop: true,
+      }),
+    ).toEqual({ environment: 'unknown', hintReason: 'barometer-stop' });
+  });
+
+  it('tripActive=false → barometerStop 무시 (false positive 차단)', () => {
+    expect(
+      inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        tripActive: false,
+        barometerStop: true,
+      }),
+    ).toEqual({ environment: 'unknown' });
+  });
+
+  it('tripActive=undefined → barometerStop 무시 (기존 caller backward-compat)', () => {
+    expect(
+      inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        barometerStop: true,
+      }),
+    ).toEqual({ environment: 'unknown' });
+  });
+
+  it('tripActive=true + barometerStop=false → 힌트 없음 (이동 중)', () => {
+    expect(
+      inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        tripActive: true,
+        barometerStop: false,
+      }),
+    ).toEqual({ environment: 'unknown' });
+  });
+
+  it('tripActive=true + barometerStop=undefined (warmup) → 힌트 없음', () => {
+    expect(
+      inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        tripActive: true,
+        barometerStop: undefined,
+      }),
+    ).toEqual({ environment: 'unknown' });
+  });
+
+  it('tripActive=true + barometerStop=true + surfaceSSOT=true → surface 우선 (힌트 없음)', () => {
+    expect(
+      inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: true,
+        undergroundSSOT: false,
+        tripActive: true,
+        barometerStop: true,
+      }),
+    ).toEqual({ environment: 'surface' });
+  });
+
+  it('tripActive=true + barometerStop=true + undergroundSSOT=true → underground 우선 (힌트 없음)', () => {
+    expect(
+      inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: false,
+        undergroundSSOT: true,
+        tripActive: true,
+        barometerStop: true,
+      }),
+    ).toEqual({ environment: 'underground' });
+  });
+
+  it('subsurface=true + tripActive=true + barometerStop=true → underground 우선 (subsurface 확정)', () => {
+    expect(
+      inferEnvironment({
+        subsurface: true,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        tripActive: true,
+        barometerStop: true,
+      }),
+    ).toEqual({ environment: 'underground' });
+  });
+
+  it('subsurface=undefined + tripActive=true + barometerStop=true → hint 비발동 (subsurface=false 경로만 hint)', () => {
+    // subsurface=undefined 경로는 SSOT 신호로만 판단 — stop hint 없음
+    expect(
+      inferEnvironment({
+        subsurface: undefined,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        tripActive: true,
+        barometerStop: true,
+      }),
+    ).toEqual({ environment: 'unknown' });
   });
 });

--- a/src/features/nearest-station/utils/inferEnvironment.ts
+++ b/src/features/nearest-station/utils/inferEnvironment.ts
@@ -8,12 +8,21 @@
  *   1. `subsurface === true` 명시 → 'underground' (barometer 확정).
  *   2. `subsurface === false` 명시 + surfaceSSOT 활성 → 'surface'.
  *   3. `subsurface === false` + undergroundSSOT 활성 → 'underground' (지하상가/매핑 SSID).
- *   4. `subsurface === undefined` + 둘 다 활성 → 'unknown' (hybrid).
- *   5. 둘 다 활성 + barometer 미확정 → 'unknown'.
- *   6. 둘 다 null → 'unknown'.
+ *   4. `subsurface === false` + tripActive + barometerStop — 두 SSOT 없음 → hint 부여.
+ *   5. `subsurface === undefined` + 둘 다 활성 → 'unknown' (hybrid).
+ *   6. 둘 다 활성 + barometer 미확정 → 'unknown'.
+ *   7. 둘 다 null → 'unknown'.
+ *
+ * #1872 — barometer-stop hint (옵션 C):
+ *   "이미 지하" 사용자는 앱 cold start 시 dP ≈ 0 → subsurface 고착.
+ *   tripActive=true + barometerStop=true 조합이 감지되면 hintReason을 반환해 downstream에서
+ *   보완 신호로 활용할 수 있게 한다. Environment 자체는 'unknown' — 단독 강제 판정 금지.
  */
 
 export type Environment = 'surface' | 'underground' | 'unknown';
+
+/** barometer-stop hint reason. 향후 hint 종류 추가 시 union 확장. */
+export type EnvironmentHintReason = 'barometer-stop';
 
 export interface InferEnvironmentInput {
   /** barometer `subsurface` 신호. undefined = warmup / 미지원. */
@@ -22,18 +31,47 @@ export interface InferEnvironmentInput {
   surfaceSSOT: boolean;
   /** `undergroundSSOTConsensus`가 합의했으면 true. */
   undergroundSSOT: boolean;
+  /**
+   * #1872 — trip 활성 여부. false positive 차단 gate.
+   * tripActive=false이면 barometerStop 힌트 발동 안 됨.
+   * optional: 기존 호출자 backward-compat.
+   */
+  tripActive?: boolean;
+  /**
+   * #1872 — `evaluateBarometerStop` 결과 (stop.detected).
+   * undefined = warmup / reading 부족. false = 이동 중.
+   * optional: 기존 호출자 backward-compat.
+   */
+  barometerStop?: boolean | undefined;
 }
 
-export function inferEnvironment(input: InferEnvironmentInput): Environment {
-  const { subsurface, surfaceSSOT, undergroundSSOT } = input;
-  if (subsurface === true) return 'underground';
+export interface InferEnvironmentResult {
+  environment: Environment;
+  /**
+   * #1872 — 힌트 이유. barometer-stop 분기 진입 시에만 설정.
+   * undefined = 힌트 없음 (일반 경로).
+   */
+  hintReason?: EnvironmentHintReason;
+}
+
+export function inferEnvironment(input: InferEnvironmentInput): InferEnvironmentResult {
+  const { subsurface, surfaceSSOT, undergroundSSOT, tripActive, barometerStop } = input;
+
+  if (subsurface === true) return { environment: 'underground' };
+
   if (subsurface === false) {
-    if (surfaceSSOT) return 'surface';
-    if (undergroundSSOT) return 'underground';
-    return 'unknown';
+    if (surfaceSSOT) return { environment: 'surface' };
+    if (undergroundSSOT) return { environment: 'underground' };
+    // #1872 — barometer-stop hint: tripActive + barometerStop 조합.
+    // false positive 차단: tripActive 필수 (lockless cold start 환경에서만 발동).
+    if (tripActive && barometerStop === true) {
+      return { environment: 'unknown', hintReason: 'barometer-stop' };
+    }
+    return { environment: 'unknown' };
   }
+
   // subsurface === undefined (warmup / 미지원) — SSOT 신호로만 판단.
-  if (surfaceSSOT && !undergroundSSOT) return 'surface';
-  if (undergroundSSOT && !surfaceSSOT) return 'underground';
-  return 'unknown';
+  if (surfaceSSOT && !undergroundSSOT) return { environment: 'surface' };
+  if (undergroundSSOT && !surfaceSSOT) return { environment: 'underground' };
+  return { environment: 'unknown' };
 }


### PR DESCRIPTION
## 요약

Closes #1872

PR #1848 (`docs/#1845` barometer threshold audit) 결론 옵션 C 구현.

\"이미 지하\" 사용자는 cold start 시 `dP ≈ 0` → `subsurface=false` 고착. 이 PR은
`inferEnvironment.ts`에 barometer-stop hint 분기를 추가해 `tripActive=true + barometerStop=true`
조합을 downstream에 노출한다.

## 변경 파일

- `src/features/nearest-station/utils/inferEnvironment.ts` — 신규 input 필드 + hint 분기
- `src/features/nearest-station/hooks/useFusedNearestStation.ts` — caller 업데이트
- `src/features/nearest-station/utils/__tests__/inferEnvironment.test.ts` — 테스트 9→18

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` 0 orphan pass. `InferEnvironmentResult` 타입은 기존 `type Environment`와 함께 동일 파일에서 export되며 `useFusedNearestStation`가 즉시 소비.

2. **V/X dashboard** — `environment` 변수는 `recordEnvironmentTransition` → Sentry breadcrumb (S13/#1546) 로 그대로 흐름. `hintReason`은 현재 DebugModal에 미노출 — 1주 측정 후 필요 시 별 PR에 추가.

3. **의존 PR** — #1848 머지됨. F1 PR(cellular wire)과 inferEnvironment 영역 겹치지 않음 (F1은 rawSignalBuffer 영역).

4. **측정 plan** — Day 3+ trip에서 `stop=true + tripActive=true + subsurface=false` 동시 발생 빈도 alarmLog/Sentry에서 확인. 현재 hint는 `environment='unknown'`을 유지하므로 downstream 판정 변화 없음 — 안전한 관측 단계.

5. **Device verify** — 실기기 \"이미 지하\" trip 1건 (사용자 책임). DebugModal에서 `stop=true + subsurface=false`로 hint 트리거 조건 확인 가능.

## 구현 노트

- `inferEnvironment` 반환 타입 `Environment` → `InferEnvironmentResult { environment, hintReason? }` 로 변경.
- 기존 caller (`useFusedNearestStation`)는 `const { environment } = inferEnvironment(...)` 구조 분해로 backward-compat.
- `tripActive=false` / `barometerStop=undefined(warmup)` / `barometerStop=false(이동 중)` 케이스는 힌트 없음 — false positive 차단.
- `subsurface=true` / `surfaceSSOT=true` / `undergroundSSOT=true` 가 먼저 평가되므로 hint는 최후 fallback 위치에만 발동.