### PR TITLE
fix(#1876): cellularTech LTE/NRNSA surface hard-reject → soft downgrade 전환

### DIFF
--- a/src/features/nearest-station/api/positionUpload.ts
+++ b/src/features/nearest-station/api/positionUpload.ts
@@ -107,14 +107,15 @@ export interface PositionUploadPayload {
   /**
    * #1543 (ADR-016 S10) — 디바이스 CTRadioAccessTechnology 환경 vote (`useCellularTech`).
    *
-   * - 'surface'      : 4G/5G 잡힘 → 지상 환경 vote
+   * - 'surface'      : NR (5G SA) — 지상 hard-reject
+   * - 'surface-weak' : LTE / NRNSA — 지하 DAS 중계 가능, soft downgrade (#1876)
    * - 'underground'  : 2G/3G fallback → 지하 환경 vote
    * - 'unknown' / 미전송 : vote 미투표 (게이트 영향 0)
    *
    * iOS only. Android / 미지원 디바이스 / native module 부재 시 omit (graceful).
    * backend `consensusGate`의 environment contradict 판정에 사용된다.
    */
-  cellularEnvironmentVote?: 'surface' | 'underground' | 'unknown';
+  cellularEnvironmentVote?: 'surface' | 'surface-weak' | 'underground' | 'unknown';
   /**
    * #1667 (ADR-015 strongDB wire) — WiFi SSID 매핑으로 결정한 역명.
    *

--- a/src/features/nearest-station/hooks/__tests__/useCellularTech.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useCellularTech.test.ts
@@ -49,9 +49,18 @@ describe('useCellularTech (#1543)', () => {
     expect(mockStop).not.toHaveBeenCalled();
   });
 
-  it('지원 — LTE 잡힘 시 surface vote', async () => {
+  it('지원 — LTE 잡힘 시 surface-weak vote (#1876 soft downgrade)', async () => {
     mockSupported.mockReturnValue(true);
     mockGet.mockReturnValue('CTRadioAccessTechnologyLTE');
+
+    const { result } = renderHook(() => useCellularTech());
+    await waitFor(() => expect(result.current).toBe('surface-weak'));
+    expect(mockStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('지원 — NR (5G SA) 잡힘 시 surface hard-reject vote', async () => {
+    mockSupported.mockReturnValue(true);
+    mockGet.mockReturnValue('CTRadioAccessTechnologyNR');
 
     const { result } = renderHook(() => useCellularTech());
     await waitFor(() => expect(result.current).toBe('surface'));
@@ -63,7 +72,7 @@ describe('useCellularTech (#1543)', () => {
     mockGet.mockReturnValue('CTRadioAccessTechnologyLTE');
 
     const { result } = renderHook(() => useCellularTech());
-    await waitFor(() => expect(result.current).toBe('surface'));
+    await waitFor(() => expect(result.current).toBe('surface-weak'));
 
     // 지하 진입 — native가 Edge로 떨어짐
     mockGet.mockReturnValue('CTRadioAccessTechnologyEdge');

--- a/src/features/nearest-station/hooks/useCellularTech.ts
+++ b/src/features/nearest-station/hooks/useCellularTech.ts
@@ -13,7 +13,8 @@
  *
  * 반환:
  *   - `'unknown'`       : 미지원 / 권한 거절 / native null — vote 미투표
- *   - `'surface'`       : 4G/5G — 지상 vote
+ *   - `'surface'`       : NR (5G SA) — 지상 hard-reject
+ *   - `'surface-weak'`  : LTE / NRNSA — 지하 DAS 중계 가능, soft downgrade (#1876)
  *   - `'underground'`   : 2G/3G — 지하 vote
  */
 

--- a/src/features/nearest-station/utils/__tests__/cellularTech.test.ts
+++ b/src/features/nearest-station/utils/__tests__/cellularTech.test.ts
@@ -4,7 +4,11 @@
  * 핵심 정책:
  *   - native module 부재 → 모든 API graceful (null / no-op / false)
  *   - 예외 → null / no-op (graceful)
- *   - classifyCellularEnvironment: 4G/5G→surface, 2G/3G→underground, 그 외→unknown
+ *   - classifyCellularEnvironment:
+ *       NR (5G SA) → 'surface' (hard-reject)
+ *       LTE / LTEAdvanced / NRNSA → 'surface-weak' (soft downgrade, #1876)
+ *       2G/3G → 'underground'
+ *       null / 미지 → 'unknown'
  */
 
 const mockNativeModule = {
@@ -137,14 +141,19 @@ describe('cellularTech native wrapper (#1543)', () => {
   });
 });
 
-describe('classifyCellularEnvironment (#1543)', () => {
+describe('classifyCellularEnvironment (#1543 + #1876 soft downgrade)', () => {
+  // NR (5G SA) — 지하 인프라 미비. hard-reject 유지 → 'surface'.
+  it('CTRadioAccessTechnologyNR → surface (5G SA hard-reject)', () => {
+    expect(classifyCellularEnvironment('CTRadioAccessTechnologyNR')).toBe('surface');
+  });
+
+  // LTE / LTEAdvanced / NRNSA — 서울 지하철 DAS 지하 중계. soft downgrade → 'surface-weak'.
   it.each([
     'CTRadioAccessTechnologyLTE',
     'CTRadioAccessTechnologyLTEAdvanced',
-    'CTRadioAccessTechnologyNR',
     'CTRadioAccessTechnologyNRNSA',
-  ])('%s → surface (4G/5G)', (tech) => {
-    expect(classifyCellularEnvironment(tech)).toBe('surface');
+  ])('%s → surface-weak (서울 DAS 지하 중계 — soft downgrade, #1876)', (tech) => {
+    expect(classifyCellularEnvironment(tech)).toBe('surface-weak');
   });
 
   it.each([

--- a/src/features/nearest-station/utils/__tests__/undergroundSSotConsensus.test.ts
+++ b/src/features/nearest-station/utils/__tests__/undergroundSSotConsensus.test.ts
@@ -4,12 +4,17 @@
  *   station pair: wifi+arrival, position+arrival
  *   env vote: barometer-stop, cellular-underground
  *   - station pair ≥ 1 + (station pair + env vote) ≥ 2 통과 시 채택
- *   - cellular surface vote → reject (환경 확정 모순)
+ *   - cellular 'surface' (NR SA) vote → reject (환경 확정 모순 — hard-reject)
+ *   - cellular 'surface-weak' (LTE/NRNSA) vote → envVotes −1 (soft downgrade, #1876)
  *   - station 우선순위: position > wifi
  * #1821 — warmup quorum 완화:
  *   - trip 시작 후 60s 이내 + station pair 1개 → underground 채택 (quorum=1)
  *   - 60s 이후 + station pair 1개 → null (steady quorum=2)
  *   - 60s 이내 + env vote 1개만 (station pair 0) → null (station pair ≥ 1 필수)
+ * #1876 — 'surface-weak' soft downgrade:
+ *   - 'surface-weak' 단독: envVotes=−1 → 다른 신호 없으면 quorum 미달
+ *   - barometer+accelerometer+surface-weak: 1+1−1=1 → steady quorum=2 미달
+ *   - barometer+accelerometer+surface-weak+position pair: 1+1−1=1 → 2-of-N pass (pair 1 + env 1 ≥ 2)
  */
 
 import { undergroundSSOTConsensus } from '../undergroundSSotConsensus';
@@ -145,7 +150,7 @@ describe('undergroundSSOTConsensus — 4-signal 2-of-N (#1574 ADR-017 T11)', () 
     expect(result?.trainCode).toBe('T1');
   });
 
-  it('Cellular surface → underground SSOT reject (환경 확정 모순)', () => {
+  it("Cellular 'surface' (NR SA) → underground SSOT hard-reject (환경 확정 모순)", () => {
     expect(
       undergroundSSOTConsensus({
         wifiStation: MOCK_STATIONS.gangnam,
@@ -284,7 +289,7 @@ describe('undergroundSSOTConsensus — accelerometer fingerprint (#1542 ADR-016 
     },
   );
 
-  it('accelerometer automotive + cellular surface → reject (환경 확정 모순 우선)', () => {
+  it("accelerometer automotive + cellular 'surface' (NR SA) → reject (환경 확정 모순 우선)", () => {
     const positionTrain = makeNearestResult('gangnam', 0.05);
     expect(
       undergroundSSOTConsensus({
@@ -418,7 +423,7 @@ describe('undergroundSSOTConsensus — warmup quorum (#1821)', () => {
     ).toBeNull();
   });
 
-  it('warmup + cellular surface → reject (환경 확정 모순이 warmup보다 우선)', () => {
+  it("warmup + cellular 'surface' (NR SA) → reject (환경 확정 모순이 warmup보다 우선)", () => {
     const positionTrain = makeNearestResult('gangnam', 0.05);
     expect(
       undergroundSSOTConsensus(
@@ -432,5 +437,131 @@ describe('undergroundSSOTConsensus — warmup quorum (#1821)', () => {
         NOW,
       ),
     ).toBeNull();
+  });
+});
+
+describe("undergroundSSOTConsensus — 'surface-weak' soft downgrade (#1876)", () => {
+  // 'surface-weak' (LTE/NRNSA) = envVotes −1. hard-reject 아님.
+  // 다른 신호가 충분하면 underground 채택 가능.
+
+  it("'surface-weak' 단독 (position pair 1 + envVotes=−1) → steady quorum=2 미달 → null", () => {
+    // position pair: 1. envVotes: 0−1=−1. total: 1+(−1)=0 < 2 → null.
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    expect(
+      undergroundSSOTConsensus({
+        wifiStation: null,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine2,
+        cellularEnvironmentVote: 'surface-weak',
+      }),
+    ).toBeNull();
+  });
+
+  it("position + barometer + 'surface-weak' → 1+1−1=1 → steady quorum=2 미달 → null", () => {
+    // barometer+1, surface-weak−1 → envVotes=0. total: pair 1 + env 0 = 1 < 2 → null.
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    expect(
+      undergroundSSOTConsensus({
+        wifiStation: null,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine2,
+        barometerStop: true,
+        cellularEnvironmentVote: 'surface-weak',
+      }),
+    ).toBeNull();
+  });
+
+  it("position + barometer + accelerometer + 'surface-weak' → pair 1 + (1+1−1)=1 → 2-of-N pass", () => {
+    // envVotes: baro+1 + accel+1 + surface-weak−1 = 1. total: pair 1 + env 1 = 2 ≥ 2 → pass.
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    const result = undergroundSSOTConsensus({
+      wifiStation: null,
+      positionTrainResult: positionTrain,
+      arrival: arrivalLine2,
+      barometerStop: true,
+      accelerometerPattern: 'automotive',
+      cellularEnvironmentVote: 'surface-weak',
+    });
+    expect(result?.station.id).toBe(positionTrain.station.id);
+    expect(result?.trainCode).toBe('T1');
+  });
+
+  it("wifi + position + 'surface-weak' → pair 2 + env −1 = 1 < 2 → null", () => {
+    // station pair 2이지만 env 감산으로 total=1 → quorum=2 미달.
+    const wifi = MOCK_STATIONS.gangnam;
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    expect(
+      undergroundSSOTConsensus({
+        wifiStation: wifi,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine2,
+        cellularEnvironmentVote: 'surface-weak',
+      }),
+    ).toBeNull();
+  });
+
+  it("wifi + position + barometer + 'surface-weak' → 2+1−1=2 ≥ 2 → pass (position 우선)", () => {
+    // pair: 2. envVotes: baro+1 + surface-weak−1 = 0. total: 2+0 = 2 ≥ 2 → pass.
+    const wifi = MOCK_STATIONS.gangnam;
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    const result = undergroundSSOTConsensus({
+      wifiStation: wifi,
+      positionTrainResult: positionTrain,
+      arrival: arrivalLine2,
+      barometerStop: true,
+      cellularEnvironmentVote: 'surface-weak',
+    });
+    // position 우선 → positionTrain.station
+    expect(result?.station.id).toBe(positionTrain.station.id);
+  });
+
+  it("'surface-weak' hard-reject 아님 — 'surface' (NR SA)와 달리 즉시 null 반환 X", () => {
+    // 'surface' → 즉시 null. 'surface-weak' → quorum 계산 진행.
+    // station pair 0이면 어차피 null이지만 이유는 'hard-reject'가 아닌 'station pair 0'.
+    const result = undergroundSSOTConsensus({
+      wifiStation: null,
+      positionTrainResult: null,
+      arrival: arrivalLine2,
+      cellularEnvironmentVote: 'surface-weak',
+    });
+    expect(result).toBeNull(); // station pair 0 → null (hard-reject X, quorum X)
+  });
+
+  it("warmup 60s 이내 + 'surface-weak' → quorum=1, pair=1, envVotes=−1 → total=0 < 1 → null", () => {
+    // warmup quorum=1. pair: 1. envVotes: −1. total: 1+(−1)=0 < 1 → null.
+    const NOW = 1_750_000_000_000;
+    const WARMUP_START = NOW - 30_000;
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    expect(
+      undergroundSSOTConsensus(
+        {
+          wifiStation: null,
+          positionTrainResult: positionTrain,
+          arrival: arrivalLine2,
+          cellularEnvironmentVote: 'surface-weak',
+          tripStartedAt: WARMUP_START,
+        },
+        NOW,
+      ),
+    ).toBeNull();
+  });
+
+  it("warmup 60s 이내 + 'surface-weak' + barometer → pair=1, envVotes=1−1=0 → total=1 ≥ quorum=1 → pass", () => {
+    // warmup quorum=1. pair: 1. envVotes: baro+1 + surface-weak−1 = 0. total: 1+0=1 ≥ 1 → pass.
+    const NOW = 1_750_000_000_000;
+    const WARMUP_START = NOW - 30_000;
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    const result = undergroundSSOTConsensus(
+      {
+        wifiStation: null,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine2,
+        barometerStop: true,
+        cellularEnvironmentVote: 'surface-weak',
+        tripStartedAt: WARMUP_START,
+      },
+      NOW,
+    );
+    expect(result?.station.id).toBe(positionTrain.station.id);
   });
 });

--- a/src/features/nearest-station/utils/cellularTech.ts
+++ b/src/features/nearest-station/utils/cellularTech.ts
@@ -8,8 +8,13 @@
  * 예외 모두 `null` / no-op로 처리. "모르는 상태"는 vote 미투표 (환경 판정 영향 0).
  *
  * 분류 정책 (Apple `CTRadioAccessTechnology*` 상수 기준):
- *   - `surface` (지상 vote)  : LTE, LTEAdvanced, NR(5G), NRNSA(5G NSA)
- *       → macro cell 안정 coverage. 지하 펨토셀로는 통상 NR/LTE 우선 안 잡힘.
+ *   - `surface` (지상 hard-reject): NR (5G SA)
+ *       → 2026년 기준 지하 인프라 거의 없음. hard-reject 유지.
+ *   - `surface-weak` (지상 soft downgrade): LTE, LTEAdvanced, NRNSA (5G NSA)
+ *       → 서울 지하철 DAS가 LTE/NRNSA를 지하에서도 중계 (100% 커버). 지하에서도 잡힘.
+ *       → hard-reject 대신 soft downgrade: undergroundSSOTConsensus에서 envVotes −1로 처리.
+ *       → 다른 신호(barometer/accelerometer)가 충분하면 underground 채택 허용.
+ *       (#1876 — plan-1846 §4.1 옵션 B 적용)
  *   - `underground` (지하 vote): GPRS, Edge, WCDMA, HSDPA, HSUPA, CDMA1x, eHRPD, CDMAEVDORev0/A/B
  *       → 지하 캐리어 펨토셀 / DAS 안테나가 흔히 fallback하는 2G/3G 신호.
  *   - `unknown`              : null / 빈 문자열 / 미지의 상수
@@ -74,8 +79,15 @@ export function getCurrentCellularTech(): string | null {
   }
 }
 
-/** 환경 vote 결과. consensusGate가 surface/underground 입력으로 사용. */
-export type CellularEnvironmentVote = 'surface' | 'underground' | 'unknown';
+/**
+ * 환경 vote 결과. consensusGate / undergroundSSOTConsensus 입력으로 사용.
+ *
+ * - `'surface'`      : NR (5G SA) — 지하 발생 낮음. hard-reject 유지.
+ * - `'surface-weak'` : LTE / LTEAdvanced / NRNSA — 지하에서도 잡힘(서울 DAS). soft downgrade.
+ * - `'underground'`  : 2G/3G — 지하 확정 1표.
+ * - `'unknown'`      : vote 미투표.
+ */
+export type CellularEnvironmentVote = 'surface' | 'surface-weak' | 'underground' | 'unknown';
 
 /**
  * Apple `CTRadioAccessTechnology` 상수 → 환경 vote 매핑.
@@ -85,10 +97,22 @@ export type CellularEnvironmentVote = 'surface' | 'underground' | 'unknown';
  *
  * 상수 prefix `CTRadioAccessTechnology`는 native가 그대로 string으로 반환한다.
  */
-const SURFACE_TECHS: ReadonlySet<string> = new Set([
+
+/**
+ * NR (5G SA) — 지하 인프라 미비 (2026년 기준). hard-reject 유지.
+ * 새 5G SA 기술이 지하 커버를 갖추기 전까지 이 분류를 유지한다.
+ */
+const SURFACE_HARD_TECHS: ReadonlySet<string> = new Set([
+  'CTRadioAccessTechnologyNR',
+]);
+
+/**
+ * LTE / LTEAdvanced / NRNSA — 서울 지하철 DAS 지하 중계로 지하에서도 흔히 수신.
+ * hard-reject 대신 soft downgrade (`'surface-weak'`).
+ */
+const SURFACE_WEAK_TECHS: ReadonlySet<string> = new Set([
   'CTRadioAccessTechnologyLTE',
   'CTRadioAccessTechnologyLTEAdvanced',
-  'CTRadioAccessTechnologyNR',
   'CTRadioAccessTechnologyNRNSA',
 ]);
 
@@ -108,13 +132,15 @@ const UNDERGROUND_TECHS: ReadonlySet<string> = new Set([
 /**
  * radio tech 코드 → 환경 vote 분류.
  *
- * - 4G/5G  → `'surface'`  (지상 vote)
- * - 2G/3G  → `'underground'` (지하 vote)
- * - null / 미지 코드 → `'unknown'` (vote 미투표)
+ * - NR (5G SA)       → `'surface'`      (hard-reject — 지하 발생 낮음)
+ * - LTE / NRNSA      → `'surface-weak'` (soft downgrade — 서울 지하 DAS 중계)
+ * - 2G/3G            → `'underground'`  (지하 1표)
+ * - null / 미지 코드  → `'unknown'`     (vote 미투표)
  */
 export function classifyCellularEnvironment(tech: string | null): CellularEnvironmentVote {
   if (!tech) return 'unknown';
-  if (SURFACE_TECHS.has(tech)) return 'surface';
+  if (SURFACE_HARD_TECHS.has(tech)) return 'surface';
+  if (SURFACE_WEAK_TECHS.has(tech)) return 'surface-weak';
   if (UNDERGROUND_TECHS.has(tech)) return 'underground';
   return 'unknown';
 }

--- a/src/features/nearest-station/utils/undergroundSSotConsensus.ts
+++ b/src/features/nearest-station/utils/undergroundSSotConsensus.ts
@@ -20,11 +20,14 @@
  *       (c) Barometer `stop=true` (FG/BG) — #1574
  *       (d) Cellular `underground` vote (FG/BG) — #1574
  *       (e) Accelerometer `automotive` pattern (FG/BG, BG location piggyback) — #1542
+ *   - Cellular `surface-weak` (LTE/NRNSA) — #1876 soft downgrade:
+ *       envVotes −1. 다른 신호 우세 시 underground 채택 허용 (hard-reject 아님).
  *
  * 합의 임계:
  *   - 2-of-N 통과 시 SSOT 채택 (station pair + env vote 어떤 조합이든 OK)
  *   - 단, 채택 station이 필요하므로 station pair ≥ 1 필수 (env vote만 2개로는 불가)
- *   - Cellular `surface` vote 시 underground SSOT 자체 reject (환경 확정 모순)
+ *   - Cellular `surface` vote (NR SA) 시 underground SSOT 자체 reject (환경 확정 모순)
+ *   - Cellular `surface-weak` vote (LTE/NRNSA) 시 envVotes −1 (soft downgrade)
  *   - GPS는 input set에서 reject (ADR-015 §5, backend `consensusGate.ts` 동일 정책)
  *
  * station 채택 우선순위: Position-Train > WiFi (강 → 약 신호).
@@ -69,7 +72,8 @@ export interface UndergroundSSOTInput {
   barometerStop?: boolean | undefined;
   /**
    * #1574 — `useCellularTech()` 환경 vote (CTRadioAccessTechnology 분류).
-   * 'surface'면 underground SSOT 자체 reject (환경 확정 모순).
+   * 'surface' (NR SA)면 underground SSOT 자체 reject (환경 확정 모순 — hard-reject).
+   * 'surface-weak' (LTE/NRNSA)면 envVotes −1 (soft downgrade — #1876).
    * 'underground'면 환경-확정 1표.
    * 'unknown'/undefined → vote 미투표.
    * iOS BG에서도 동작 (CTServiceRadioAccessTechnologyDidChangeNotification observer).
@@ -125,7 +129,8 @@ export function undergroundSSOTConsensus(
     tripStartedAt,
   } = input;
 
-  // 환경 확정 모순 — cellular가 surface면 underground SSOT 자체 candidate X.
+  // 환경 확정 모순 — cellular 'surface' (NR SA)면 underground SSOT 자체 candidate X.
+  // 'surface-weak' (LTE/NRNSA)는 hard-reject 아님 — soft downgrade (envVotes −1, 하단 처리).
   if (cellularEnvironmentVote === 'surface') return null;
 
   // Station pair 후보 — 채택 우선순위 순서. position-train > wifi.
@@ -144,9 +149,11 @@ export function undergroundSSOTConsensus(
   }
 
   // Environment-confirming votes (station 미제공). 신규 #1574 — BG WiFi 갭 해소 + #1542 accelerometer.
+  // #1876 — 'surface-weak' soft downgrade: LTE/NRNSA는 envVotes −1 (지하에서도 잡히므로 hard-reject X).
   let envVotes = 0;
   if (barometerStop === true) envVotes += 1;
   if (cellularEnvironmentVote === 'underground') envVotes += 1;
+  if (cellularEnvironmentVote === 'surface-weak') envVotes -= 1;
   if (accelerometerPattern === 'automotive') envVotes += 1;
 
   // Station pair ≥ 1 필수 (env vote만으로는 station 채택 불가).


### PR DESCRIPTION
Closes #1876

## 문제

서울 지하철은 LTE 100% 지하 커버 (DAS/중계기, 기간통신사업자 의무). 지하에서도 `CTRadioAccessTechnologyLTE` / `NRNSA` 수신이 매우 흔하다.

현재 코드: LTE/NRNSA → `'surface'` → `undergroundSSOTConsensus` **hard-reject** (즉시 `null`).

결과: 5G/LTE 환경 사용자가 지하 진입 시 → LTE 유지 → surface vote → underground SSOT null → environment=unknown 고착 (Day 2 35분 unknown 100% 원인 후보, plan-1846 §3.3/§4.3).

## 변경 내용

### `cellularTech.ts`
- `CellularEnvironmentVote` 타입에 `'surface-weak'` 추가
- **NR (5G SA)** → `'surface'` 유지 (지하 인프라 미비, hard-reject 유지)
- **LTE / LTEAdvanced / NRNSA** → `'surface-weak'` (서울 DAS 지하 중계 대응, soft downgrade)
- 2G/3G → `'underground'` 유지

### `undergroundSSotConsensus.ts`
- `'surface'` hard-reject: NR SA 전용으로 명확화 (기존 `=== 'surface'` 그대로)
- `'surface-weak'` → `envVotes -= 1` (soft downgrade — 다른 신호 충분 시 underground 허용)
- JSDoc + 인라인 주석 업데이트

### 효과 매트릭스

| 시나리오 | 변경 전 | 변경 후 |
|---|---|---|
| LTE 지하 + position 단독 (steady) | hard-reject → null | soft: pair 1 + env −1 = 0 < 2 → null |
| LTE 지하 + position + barometer (steady) | hard-reject → null | soft: pair 1 + (1−1)=0 → null |
| LTE 지하 + position + barometer + accelerometer | hard-reject → null | pair 1 + (1+1−1)=1 → **2 ≥ 2 → pass** |
| NR SA 지하 (5G SA) | hard-reject → null | hard-reject 유지 → null |
| LTE 지하 warmup 60s + position + barometer | hard-reject → null | pair 1 + (1−1)=0 → total=1 ≥ quorum=1 → **pass** |

### `positionUpload.ts`
- `cellularEnvironmentVote` 필드 타입에 `'surface-weak'` 추가 → backend wrangler tail 관측 가능

## Wire-completion 5단

1. **Orphan**: `npm run lint:orphan` pass. `CellularEnvironmentVote` 타입 확장 — caller(undergroundSSotConsensus, positionUpload, useCellularTech) 모두 이 PR에 포함.
2. **V/X dashboard**: `classifyCellularEnvironment` 결과 → `positionUpload.ts` → backend `cellularEnvironmentVote` 필드 (wrangler tail 관측 가능). `'surface-weak'` 값이 기존 `'surface'` 대신 전송되어 분포 변화 확인 가능.
3. **의존 PR**: #1849 (docs 머지됨). PR #1870 (rawSignalBuffer cellular 필드) 머지 후 본 PR 머지 권장.
4. **측정 plan**: 머지 후 1주 — wrangler tail `cellularEnvironmentVote=surface-weak` 비율 + underground SSOT 합의율 변화 측정. `environment=unknown` 비율 감소 확인.
5. **Device verify**: 실기기 LTE/5G NSA 환경 지하 trip 1건 (사용자 책임). DebugModal environment 값 관측.