### PR TITLE
feat(#1881): 디버그 buffer cap 확대 + DebugLogSection read-more 패턴

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -218,10 +218,21 @@ export interface AutoLockDebugMeta {
 const UNKNOWN_LABEL = '—';
 
 /**
- * #1501 — Raw signal 섹션 UI/share dump에 노출할 최대 엔트리 수. PR-A의 buffer capacity(120)는
- * 7일 cold-launch 회귀 사후 재구성용이라 더 크고, 모달 진입 시점에는 직전 30건이면 충분.
+ * #1881 — DebugLogSection UI 표시 기본 cap. buffer 전체(최대 300~500)를 한 번에 렌더하면
+ * ScrollView 성능 저하. 100건이면 약 50분 분량 — 진단에 충분하고 UI 스크롤 부담도 적다.
+ * "더 보기" 버튼 탭 시 expanded state로 전환해 buffer 전체 표시.
+ * share dump는 별도 경로(buildDumpText)를 통해 buffer 전체를 그대로 포함.
  */
-const RAW_SIGNAL_DISPLAY_LIMIT = 30;
+const DEBUG_LOG_DISPLAY_LIMIT = 100;
+
+/**
+ * #1501 — Raw signal 섹션 share dump용 slice cap. build 섹션 함수가 share dump에 포함할 최대 수.
+ * UI는 DEBUG_LOG_DISPLAY_LIMIT(100)을 사용하고, share dump 섹션은 buffer 전체를 포함하도록
+ * buildRawSignalSection에서 slice 제거 (#1881).
+ *
+ * @deprecated 직접 사용 말 것 — 테스트 호환용으로만 export 유지. UI/dump 로직은 위 상수 참조.
+ */
+const RAW_SIGNAL_DISPLAY_LIMIT = DEBUG_LOG_DISPLAY_LIMIT;
 
 function formatOptionalBool(value: boolean | null | undefined): string {
   if (value === true) return 'true';
@@ -811,19 +822,14 @@ function buildAlarmLogReasonsSummarySection(args: BuildDumpArgs): string[] {
 }
 
 /**
- * #1501 — Raw signal 섹션. 직전 30건(혹은 그 이하)을 최신순으로 직렬화. 빈 buffer는
- * (empty)로 명시 — "한 번도 push 안 됨"과 "load 안 함"을 구분(Fusion log와 동일 컨벤션).
- *
- * 표시 범위는 buffer 전체가 아닌 상위 RAW_SIGNAL_DISPLAY_LIMIT — share dump가 모달
- * 모든 신호로 폭주하지 않도록. 사후 분석이 더 필요하면 PR-B의 dump 업로드 채널로.
+ * #1501 — Raw signal 섹션. buffer 전체를 최신순으로 직렬화해 share dump에 포함.
+ * #1881 — share dump는 buffer 전체를 포함 (UI는 별도 DEBUG_LOG_DISPLAY_LIMIT 적용).
+ * 빈 buffer는 (empty)로 명시 — "한 번도 push 안 됨"과 "load 안 함"을 구분.
  */
 function buildRawSignalSection(args: BuildDumpArgs): string[] {
   const entries = args.rawSignalLog ?? [];
   if (entries.length === 0) return ['(empty)'];
-  return [...entries]
-    .reverse()
-    .slice(0, RAW_SIGNAL_DISPLAY_LIMIT)
-    .map(formatRawSignalLine);
+  return [...entries].reverse().map(formatRawSignalLine);
 }
 
 /**
@@ -2268,11 +2274,12 @@ function DebugModalInner({
           {/* #1682 — Suppress Reasons: 1h 윈도우 top 5 suppress reason 분포 */}
           <SuppressReasonsSection logs={logs} colors={colors} />
 
-          {/* #1501 — PR-C. Raw signal 자동 표시 (toggle 없음). 직전 30건만 노출 — share dump에는
-              buffer 전체가 시간 역순으로 흐른다. Clear는 buffer + AsyncStorage 모두 wipe. */}
+          {/* #1501 — PR-C. Raw signal 자동 표시 (toggle 없음).
+              #1881 — 전체 buffer 전달. UI는 DebugLogSection의 DEBUG_LOG_DISPLAY_LIMIT(100) 적용.
+              Clear는 buffer + AsyncStorage 모두 wipe. */}
           <DebugLogSection
             title="Raw Signal"
-            logs={[...rawSignalLog].slice(-RAW_SIGNAL_DISPLAY_LIMIT)}
+            logs={rawSignalLog}
             formatLine={formatRawSignalLine}
             onClear={() => {
               clearRawSignalEntries();
@@ -2402,7 +2409,11 @@ function NotificationsFiredSection({
   );
 }
 
-/** 역방향(최신 → 오래된) 모노 로그 목록 섹션 — Estimator/Fusion 공통 패턴 (#1025). */
+/**
+ * #1025 — 역방향(최신 → 오래된) 모노 로그 목록 섹션 — Estimator/Fusion 공통 패턴.
+ * #1881 — DEBUG_LOG_DISPLAY_LIMIT(100) 기본 표시. 초과 시 "Show more (N)" 버튼 노출.
+ *          share dump는 호출부가 별도로 buffer 전체 주입(UI cap과 무관).
+ */
 function DebugLogSection<T extends { ts: number }>({
   title,
   logs,
@@ -2420,6 +2431,10 @@ function DebugLogSection<T extends { ts: number }>({
   entryTestId: string;
   colors: ReturnType<typeof useTheme>['colors'];
 }>) {
+  const [expanded, setExpanded] = useState(false);
+  const reversed = [...logs].reverse();
+  const displayed = expanded ? reversed : reversed.slice(0, DEBUG_LOG_DISPLAY_LIMIT);
+  const hidden = reversed.length - displayed.length;
   return (
     <Section
       title={`${title} (${logs.length})`}
@@ -2433,11 +2448,23 @@ function DebugLogSection<T extends { ts: number }>({
       {logs.length === 0 ? (
         <Text style={[typography.mono, { color: colors.muted }]}>(empty)</Text>
       ) : (
-        [...logs].reverse().map((entry, idx) => (
-          <MonoEntry key={`${entry.ts}-${idx}`} testID={entryTestId} colors={colors}>
-            {formatLine(entry)}
-          </MonoEntry>
-        ))
+        <>
+          {displayed.map((entry, idx) => (
+            <MonoEntry key={`${entry.ts}-${idx}`} testID={entryTestId} colors={colors}>
+              {formatLine(entry)}
+            </MonoEntry>
+          ))}
+          {hidden > 0 && (
+            <Pressable
+              onPress={() => setExpanded(true)}
+              testID={`${entryTestId}-show-more`}
+            >
+              <Text style={[typography.bodySm, { color: colors.accent, marginTop: spacing.xs }]}>
+                {`Show more (${hidden})`}
+              </Text>
+            </Pressable>
+          )}
+        </>
       )}
     </Section>
   );
@@ -2780,6 +2807,8 @@ export const __test__ = {
   buildBackendCallsSection,
   // #1501 — PR-C. Raw signal 라인 포맷 helper. share dump 단위 테스트에서 직접 호출.
   formatRawSignalLine,
+  // #1881 — UI 표시 cap (100). 기존 RAW_SIGNAL_DISPLAY_LIMIT alias로 테스트 호환 유지.
+  DEBUG_LOG_DISPLAY_LIMIT,
   RAW_SIGNAL_DISPLAY_LIMIT,
   // #1540 (S7) — gps-drop 별 buffer 포맷/섹션. 단위 테스트에서 직접 호출.
   formatGpsDropLine,

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -4108,18 +4108,21 @@ describe('DebugModal — #1501 Raw Signal 섹션', () => {
       expect(stationBIdx).toBeLessThan(stationAIdx);
     });
 
-    it(`상위 ${RAW_SIGNAL_DISPLAY_LIMIT}건만 dump (overflow 분리)`, () => {
-      const entries: RawEntry[] = Array.from({ length: RAW_SIGNAL_DISPLAY_LIMIT + 5 }, (_, i) =>
+    it('#1881 share dump는 buffer 전체 포함 (UI cap 제한과 무관)', () => {
+      // #1881 — share dump(buildDumpText)는 buffer 전체를 포함. UI는 DEBUG_LOG_DISPLAY_LIMIT(100)
+      // 적용이지만, buildDumpText는 별도 경로(buildRawSignalSection)로 buffer 전체를 직렬화.
+      const total = RAW_SIGNAL_DISPLAY_LIMIT + 5;
+      const entries: RawEntry[] = Array.from({ length: total }, (_, i) =>
         makeRawEntry({ ts: i * 1000, stationId: `S${i}` }),
       );
       const dump = buildDumpText(makeDumpArgs({ rawSignalLog: entries }));
-      // suffix는 buffer 전체 (35) — display limit과 분리.
-      expect(dump).toContain(`## Raw Signal (${RAW_SIGNAL_DISPLAY_LIMIT + 5})`);
+      // suffix는 buffer 전체 카운트.
+      expect(dump).toContain(`## Raw Signal (${total})`);
       const section = dump.slice(dump.indexOf('## Raw Signal'));
-      // 가장 오래된 entry(S0)는 dump에서 잘림.
-      expect(section).not.toContain('| S0 |');
-      // 가장 최신(S34)은 포함.
-      expect(section).toContain(`| S${RAW_SIGNAL_DISPLAY_LIMIT + 4} |`);
+      // 가장 오래된 entry(S0)도 dump에 포함 — share dump는 전체 buffer.
+      expect(section).toContain('| S0 |');
+      // 가장 최신(S{total-1})도 포함.
+      expect(section).toContain(`| S${total - 1} |`);
     });
 
     it('SHARE_SECTIONS에 Raw Signal 헤더 1회 + Environment Distribution 다음에 위치', () => {
@@ -4203,6 +4206,70 @@ describe('DebugModal — #1501 Raw Signal 섹션', () => {
       expect(msg).toContain('## Raw Signal (1)');
       expect(msg).toContain('SHARE-INTEGRATION');
       shareSpy.mockRestore();
+    });
+  });
+
+  // #1881 — DebugLogSection read-more 패턴
+  describe('#1881 DebugLogSection read-more 패턴', () => {
+    const {
+      pushRawSignal,
+      __resetRawSignalForTests__,
+    } = jest.requireActual('../../../observability/utils/rawSignalBuffer');
+    // DEBUG_LOG_DISPLAY_LIMIT은 __test__ export를 통해 접근 (module-level local 상수).
+    const { DEBUG_LOG_DISPLAY_LIMIT } = __test__;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      __resetRawSignalForTests__();
+      setupHookDefaults();
+      jest.spyOn(AppState, 'addEventListener').mockReturnValue({
+        remove: jest.fn(),
+      } as unknown as ReturnType<typeof AppState.addEventListener>);
+    });
+
+    afterEach(() => {
+      __resetRawSignalForTests__();
+    });
+
+    it('entries가 DEBUG_LOG_DISPLAY_LIMIT 이하면 "Show more" 버튼이 노출되지 않는다', async () => {
+      for (let i = 0; i < DEBUG_LOG_DISPLAY_LIMIT; i++) {
+        pushRawSignal(makeRawEntry({ ts: i * 1000, stationId: `S${i}` }));
+      }
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByText(`Raw Signal (${DEBUG_LOG_DISPLAY_LIMIT})`)).toBeTruthy());
+      expect(screen.queryByTestId('debug-raw-signal-entry-show-more')).toBeNull();
+    });
+
+    it('entries가 DEBUG_LOG_DISPLAY_LIMIT 초과 시 "Show more (N)" 버튼이 노출된다', async () => {
+      const total = DEBUG_LOG_DISPLAY_LIMIT + 10;
+      for (let i = 0; i < total; i++) {
+        pushRawSignal(makeRawEntry({ ts: i * 1000, stationId: `S${i}` }));
+      }
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByText(`Raw Signal (${total})`)).toBeTruthy());
+      // UI 표시 개수는 DEBUG_LOG_DISPLAY_LIMIT
+      const entries = screen.getAllByTestId('debug-raw-signal-entry');
+      expect(entries).toHaveLength(DEBUG_LOG_DISPLAY_LIMIT);
+      // "Show more (10)" 버튼 표시
+      expect(screen.getByTestId('debug-raw-signal-entry-show-more')).toBeTruthy();
+      expect(screen.getByText('Show more (10)')).toBeTruthy();
+    });
+
+    it('"Show more" 탭 시 전체 entries가 노출된다', async () => {
+      const total = DEBUG_LOG_DISPLAY_LIMIT + 5;
+      for (let i = 0; i < total; i++) {
+        pushRawSignal(makeRawEntry({ ts: i * 1000, stationId: `S${i}` }));
+      }
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByText(`Raw Signal (${total})`)).toBeTruthy());
+      act(() => {
+        fireEvent.press(screen.getByTestId('debug-raw-signal-entry-show-more'));
+      });
+      // expand 후 전체 entries 표시
+      const entries = screen.getAllByTestId('debug-raw-signal-entry');
+      expect(entries).toHaveLength(total);
+      // "Show more" 버튼이 사라짐
+      expect(screen.queryByTestId('debug-raw-signal-entry-show-more')).toBeNull();
     });
   });
 

--- a/src/features/nearest-station/utils/fusionDebugBuffer.ts
+++ b/src/features/nearest-station/utils/fusionDebugBuffer.ts
@@ -6,7 +6,8 @@ import { createDebugBuffer } from '../../../shared/utils/createDebugBuffer';
 // 콘솔 logger는 dev 빌드에서만 보이고 스탠드얼론 빌드/현장(지하철)에서는 확인 불가 —
 // 그 공백을 메우는 것이 목적.
 
-export const FUSION_DEBUG_BUFFER_CAPACITY = 200;
+// #1881 — 60분 trip × ~3 entry/tick(30s) = ~360 entry. 여유 확보 → 500.
+export const FUSION_DEBUG_BUFFER_CAPACITY = 500;
 
 /** 후보 신호 — 신호원이 늘면 key를 추가만 하면 됨(타입/포맷터 동시 수정 불필요). */
 export interface FusionCandidateMini {

--- a/src/features/nearest-station/utils/gpsDropBuffer.ts
+++ b/src/features/nearest-station/utils/gpsDropBuffer.ts
@@ -12,11 +12,11 @@ import { createDebugBuffer } from '../../../shared/utils/createDebugBuffer';
  *  - "low-accuracy fix도 사후 진단에 필요"라는 #443 주석은 유효하지만 다른 채널과
  *    cap을 공유하면 자기 목적(사후 진단)을 파괴한다.
  *
- * cap=100 — fusion(200)보다 작게 잡아 모듈 메모리 sum이 동일 수준에 머무르되 두 채널
- * 모두 충분한 history 확보. push 빈도 차이(drop ≫ fusion)를 감안해 별 buffer로 분리하면
- * 100건도 ~1분 진단 윈도우를 보장한다(rate limit 2/sec × 60s = 120 → 100 cap 약 50초).
+ * cap=200 (#1881) — 60분 trip 전체 커버. burst dedup(rate-limited)이 push 속도를 이미 제한하므로
+ * 200건은 충분한 진단 윈도우를 보장한다. fusionDebugBuffer(500)와 격리된 별 채널이라 메모리 합산
+ * 부담도 수용 범위 이내.
  */
-export const GPS_DROP_BUFFER_CAPACITY = 100;
+export const GPS_DROP_BUFFER_CAPACITY = 200;
 
 export interface GpsDropEntry {
   ts: number;

--- a/src/features/observability/utils/rawSignalBuffer.ts
+++ b/src/features/observability/utils/rawSignalBuffer.ts
@@ -7,7 +7,7 @@
  * 용마산 trip)처럼 cold-launch 사이 데이터가 끊기는 사고를 막는다.
  *
  * 정책:
- *  - capacity 120 (cycle ~1Hz × 2분 windowfusion + enter/exit stamps)
+ *  - capacity 300 (#1881: 60분 trip × 1 entry/cycle(30s) = 120 tick → 2× 여유 확보)
  *  - boot 시 1회 hydrate (`hydrateRawSignalBuffer()`)
  *  - push 후 1초 idle throttle write — burst push에서 storage IO 폭주 차단
  *  - 손상 JSON / 키 부재 = 빈 buffer로 시작 (graceful)
@@ -18,7 +18,7 @@ import { createDebugBuffer } from '../../../shared/utils/createDebugBuffer';
 import type { FusionConfidence, FusionSource } from '../../../shared/types/fusion';
 import type { CellularEnvironmentVote } from '../../nearest-station/utils/cellularTech';
 
-export const RAW_SIGNAL_BUFFER_CAPACITY = 120;
+export const RAW_SIGNAL_BUFFER_CAPACITY = 300;
 export const RAW_SIGNAL_WRITE_THROTTLE_MS = 1000;
 
 export type RawSignalKind = 'cycle' | 'enter' | 'exit';

--- a/src/features/route/utils/estimatorDebugBuffer.ts
+++ b/src/features/route/utils/estimatorDebugBuffer.ts
@@ -5,7 +5,8 @@
 import type { StationProgressStrategy } from './stationProgressEstimator';
 import { createDebugBuffer } from '../../../shared/utils/createDebugBuffer';
 
-export const ESTIMATOR_DEBUG_BUFFER_CAPACITY = 50;
+// #1881 — 60분 trip 분량 보존. estimator push 빈도는 낮지만(hop advance 시만) 여유 확보 → 150.
+export const ESTIMATOR_DEBUG_BUFFER_CAPACITY = 150;
 
 export interface EstimatorDebugEntry {
   ts: number;

--- a/src/shared/utils/backendCallBuffer.ts
+++ b/src/shared/utils/backendCallBuffer.ts
@@ -26,8 +26,8 @@ import {
   TRIP_STARTED_AT_KEY,
 } from '../constants/storageKeys';
 
-/** Ring buffer capacity. 100건은 1 trip(보통 ~30-50건) 한 사이클을 충분히 덮는다. */
-export const BACKEND_CALL_BUFFER_CAPACITY = 100;
+// #1881 — 60분 trip × ~100건 호출 → 2× 여유 확보. 200건은 연속 2 trip 분량.
+export const BACKEND_CALL_BUFFER_CAPACITY = 200;
 
 export type BackendCallEntryKind = 'call' | 'response' | 'error';
 


### PR DESCRIPTION
Closes #1881

## Summary
- **Buffer cap 확대**: 35분+ lockless trip에서 200 cap에 밀려 share dump가 잘리는 문제 수정
- **DebugLogSection read-more**: UI 100개 기본 표시 + "Show more (N)" 버튼으로 전체 expand
- **share dump 전체 포함**: buildRawSignalSection 등 share dump 경로는 buffer 전체 직렬화

## Buffer cap 변경
| Buffer | 이전 | 이후 | 근거 |
|---|---|---|---|
| fusionDebugBuffer | 200 | 500 | 60분 × ~3 entry/tick = ~360 → 여유 500 |
| rawSignalBuffer | 120 | 300 | 60분 = 120 tick → 2× 여유 |
| gpsDropBuffer | 100 | 200 | burst dedup 후 60분 진단 윈도우 |
| estimatorDebugBuffer | 50 | 150 | hop advance 빈도 낮지만 여유 확보 |
| backendCallBuffer | 100 | 200 | 60분 ~100건 × 2× 여유 |

## UI 변경
- `DebugLogSection`: 기본 100개 표시, 초과 시 "Show more (N)" 버튼 → 탭 시 전체 표시
- share dump(`buildDumpText`): buffer 전체 포함 (UI cap과 별도 경로)

## Wire-completion 5단
1. **Orphan 없음**: `npm run lint:orphan` — 0 orphan. cap 상수 변경은 export caller 영향 없음
2. **V/X dashboard**: DebugModal에서 35분+ trip의 더 많은 entry 보임 → 진단 evidence 손실 감소
3. **의존 PR**: N/A — standalone 변경
4. **측정 plan**: 다음 device share dump 시 buffer full 채워지는지 확인 (Raw Signal suffix가 cap에 가까운지)
5. **Device verify**: 실기기 60분 trip 1건 (사용자 책임). 코드 변경은 type+unit만 영향

## Test
- 8033 tests, 388 suites — all pass, 100% coverage
- 신규 3개 read-more 테스트 포함 (UI cap / show-more 버튼 / expand 동작)