### PR TITLE
fix(#1892): trip auto-end LA/widget cleanup wire + RC-9 orphan 26분 차단

### DIFF
--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -31,6 +31,7 @@ import { useBoardingLockStore } from '../useBoardingLockStore';
 import { useAlarmEventStore } from '../useAlarmEventStore';
 
 const mockClearWidgetStation = jest.fn().mockResolvedValue(undefined);
+const mockEndLiveActivity = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock')
@@ -38,6 +39,10 @@ jest.mock('@react-native-async-storage/async-storage', () =>
 jest.mock('expo-notifications');
 jest.mock('../../../widget/api/widgetStorage', () => ({
   clearWidgetStation: () => mockClearWidgetStation(),
+}));
+// #1892 / #1885 — Live Activity dismiss 호출 가드 (RC-9 cascade 회귀 차단).
+jest.mock('live-activity', () => ({
+  endLiveActivity: () => mockEndLiveActivity(),
 }));
 
 describe('tripBoundCleanups', () => {
@@ -414,9 +419,30 @@ describe('tripBoundCleanups', () => {
       // #1597 — triggerTripGroundTruthPrompt 제거 (trip-start 경로에서 false fire 회귀 차단).
       // 종료-only trigger이므로 4 trip-end 호출 경로(setDestination switch/silentPushTask trip-ended/
       // useLaunchTripReconciliation/useStateRehydration sentinel+force-end)에서 명시 호출.
-      const MIN_ITEMS = 25;
+      // #1892 / #1885 — endLiveActivityCleanup 1 신규 (RC-9 LA orphan 26분 cascade fix).
+      const MIN_ITEMS = 26;
       expect(TRIP_BOUND_CLEANUPS.length).toBeGreaterThanOrEqual(MIN_ITEMS);
     });
+  });
+
+  // #1892 / #1885 — silent push trip-ended 경로에서 LA dismiss wire 가드.
+  // RC-9 cascade root: Seoul outage → trip auto-end → runTripBoundCleanups → storage cleanup만,
+  // native LA 인스턴스 dismiss 없음 → 사용자 LA "건대입구→용마산" 26분 orphan.
+  // 본 케이스가 깨지면 cleanup 배열에서 endLiveActivityCleanup 누락 회귀.
+  it('#1892 / #1885 — runTripBoundCleanups 실행 시 Live Activity dismiss를 호출한다 (RC-9 orphan 차단)', async () => {
+    mockEndLiveActivity.mockClear();
+    await runTripBoundCleanups();
+    expect(mockEndLiveActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it('#1892 / #1885 — LA dismiss가 reject해도 다른 cleanup이 진행되고 호출자에게 reject 전파 안 함', async () => {
+    // native LA module이 throw해도(예: 이미 ended 상태에서 race) 나머지 cleanup이 차단되면 안 됨.
+    // helper 내부 swallow + Promise.allSettled 2중 안전.
+    mockEndLiveActivity.mockClear();
+    mockEndLiveActivity.mockRejectedValueOnce(new Error('already-ended'));
+    (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+    await expect(runTripBoundCleanups()).resolves.toBeUndefined();
+    expect(mockEndLiveActivity).toHaveBeenCalledTimes(1);
   });
 
   it('runTripBoundCleanups: 한 항목이 reject해도 나머지 항목이 모두 실행된다', async () => {
@@ -437,7 +463,8 @@ describe('tripBoundCleanups', () => {
     // module-level/memory 클리어라 removeItem 카운트에 기여하지 않는다. 신규 항목 수만큼
     // 임계값을 낮춰 기존 invariant(storage 기반 항목 모두 실행)는 유지.
     // #1597 — triggerTripGroundTruthPrompt 제거로 NON_STORAGE 5→4.
-    const NON_STORAGE_CLEANUPS = 4;
+    // #1892 / #1885 — endLiveActivityCleanup 신규 (native LA dismiss, storage write 없음) → 4→5.
+    const NON_STORAGE_CLEANUPS = 5;
     expect((AsyncStorage.removeItem as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(
       TRIP_BOUND_CLEANUPS.length - NON_STORAGE_CLEANUPS,
     );

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -7,6 +7,7 @@
  * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as LiveActivity from 'live-activity';
 import {
   ROUTE_KEY,
   DESTINATION_KEY,
@@ -135,6 +136,16 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   // 저장하므로 trip 끝나도 위젯에는 trip 중 마지막 역이 남는다. clearWidgetStation으로 즉시
   // "감지 중" 상태로 전환해 다음 fresh fix가 들어올 때까지 정확하지 않은 현재역 노출을 막는다.
   clearWidgetStation,
+  // #1892 / #1885 — trip 종료 시 Live Activity dismiss. RC-9 cascade (Seoul outage → trip
+  // auto-end → LA orphan 26분) root cause. backend trip auto-end 시 silent push `trip-ended`
+  // 분기에서 runTripBoundCleanups가 호출되지만 기존엔 storage만 정리되고 native Live Activity
+  // 인스턴스는 dismiss되지 않아 사용자에게 "건대입구 → 용마산"이 26분 동안 stuck 노출됨.
+  // 4 entry point (FG setDestination(null/switch) / silent push trip-ended /
+  // useStateRehydration sentinel / useLaunchTripReconciliation)에서 LA dismiss가 자동 wire되며
+  // 멱등 — LA 비활성 또는 이미 ended 상태도 graceful 통과.
+  // refreshLiveActivityFromBackgroundContext는 destination 없으면 endLiveActivity를 호출하지만
+  // trip-ended 분기 자체는 이를 호출하지 않으므로 cleanup 배열로 wire가 본질 fix.
+  endLiveActivityCleanup,
   // #1545 (S12) — 모듈-level in-memory dedup 윈도우 클리어.
   // 같은 destination/같은 phase로 새 trip을 즉시 시작할 때 직전 trip의 fire 기록이
   // 새 trip 첫 fire를 silence하는 회귀 차단. BG silent push trip-ended 경로에서도
@@ -157,6 +168,24 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   // 본 wiring으로 BG 경로에서도 메모리/storage가 동시에 일관 상태가 된다.
   clearTripBoundStoreMemory,
 ];
+
+/**
+ * #1892 / #1885 — Live Activity 인스턴스 dismiss helper.
+ *
+ * silent push `trip-ended` 경로(silentPushTask.ts:889 runTripBoundCleanups 호출) +
+ * FG setDestination(null/switch) 경로 모두 LA를 명시적으로 dismiss하지 않으면 사용자가 trip
+ * 종료 후에도 "건대입구 → 용마산" 같은 stale LA를 26분 동안 보게 된다 (2026-06-26 T3/T4 회귀).
+ *
+ * `LiveActivity.endLiveActivity()`는 native module에서 이미 멱등 (활성 인스턴스 없으면
+ * graceful no-op, 비-iOS 또는 모듈 미설치 시 즉시 Promise.resolve()). LA가 비활성이거나
+ * 호출이 실패해도 reject를 swallow해 cleanup 흐름을 차단하지 않는다 — Promise.allSettled가
+ * 일관성 보강하지만 본 helper 자체가 swallow하므로 단독 호출(예: 테스트)에서도 안전.
+ */
+function endLiveActivityCleanup(): Promise<void> {
+  return LiveActivity.endLiveActivity().catch((e) => {
+    log.warn('endLiveActivity threw', e);
+  });
+}
 
 /**
  * #1545 (S12) — trip-bound zustand store의 in-memory mirror를 일괄 클리어.


### PR DESCRIPTION
Closes #1892
Closes #1885

## 1. 변경 요약

`TRIP_BOUND_CLEANUPS` 배열에 `endLiveActivityCleanup` 항목 1개 추가. 4 entry point (FG `setDestination(null/switch)` / silent push `trip-ended` / `useStateRehydration` sentinel / `useLaunchTripReconciliation`)에서 LA dismiss가 자동 wire된다.

### 변경 파일

- `src/features/alarm/store/tripBoundCleanups.ts` — `endLiveActivityCleanup` helper 추가 + cleanup 배열 entry
- `src/features/alarm/store/__tests__/tripBoundCleanups.test.ts` — LA dismiss wire 가드 2건 + baseline 갱신

## 2. RC-9 cascade root cause

### 박제된 cascade

1. **Stage 1 (Seoul outage)**: backend `trainCode=3237 station=건대입구 trainCode not found` 5분 지속 (2026-06-26 03:49:43Z~03:53:42Z)
2. **Stage 2 (trip auto-end)**: backend `consecutiveEtaMissing >= 5` → `trip auto-ended endReason=eta-missing threshold=5`
3. **Stage 3 (silent push trip-ended)**: backend가 `kind: 'trip-ended'` silent push 발사 → device가 `silentPushTask.ts:889 runTripBoundCleanups` 호출
4. **Stage 4 (LA orphan)**: `runTripBoundCleanups`가 storage 24+ 항목 정리하지만 **native LA 인스턴스는 dismiss되지 않음** — cleanup 배열에 LA dismiss helper 누락
5. **Stage 5 (RC-15 cascade)**: 사용자 LA "건대입구 → 용마산" 26분 동안 stuck (13:19 trip 종료 ~ 13:34+ orphan 계속)

### Root cause = wire 누락

`runTripBoundCleanups`는 `silentPushTask` trip-ended 분기 + FG `setDestination(null)` switch 분기 둘 다에서 호출되는 단일 cleanup source. cleanup 배열에 storage / sentinel / store memory mirror가 다 등록되어 있지만 **native LA `endLiveActivity` 호출만 누락**.

`stationNotification.ts:475` 또는 `refreshLiveActivityFromBackgroundContext.ts:116`은 destination 없을 때 LA dismiss하지만, silent push `trip-ended` 분기 자체는 `refreshLiveActivityFromBackgroundContext`를 호출하지 않음 → wire 단절.

## 3. Fix 디자인

```ts
// src/features/alarm/store/tripBoundCleanups.ts
function endLiveActivityCleanup(): Promise<void> {
  return LiveActivity.endLiveActivity().catch((e) => {
    log.warn('endLiveActivity threw', e);
  });
}

export const TRIP_BOUND_CLEANUPS = [
  // ... 24 기존 항목
  clearWidgetStation,      // #1524 (이미 있음)
  endLiveActivityCleanup,  // #1892 / #1885 (신규)
  // ... 후속 항목
];
```

### 디자인 선택 (3개 옵션 검토, false binary 금지)

| 옵션 | 설명 | 채택 여부 |
|------|------|-----------|
| A. silent push 분기에 inline LA dismiss | `silentPushTask.ts:889` 옆에 `LiveActivity.endLiveActivity()` 1줄 추가 | ✗ FG `setDestination(null)` 경로 누락 → 4 entry point 중 1개만 wire |
| B. cleanup 배열 entry 추가 (채택) | `TRIP_BOUND_CLEANUPS`에 helper 1개 추가 → 4 entry point 자동 wire | ✓ altitude 올바른 추상화 깊이 |
| C. 신규 hook (`useLaTripEndCleanup`) | RN hook으로 lifecycle 관찰 | ✗ BG silent push 경로 unreachable |

### 멱등성 + 비-iOS 호환

- `LiveActivity.endLiveActivity()`는 native module wrapper (`modules/live-activity/index.ts:53`)에서 비-iOS 시 `Promise.resolve()` 반환, 활성 인스턴스 없을 때 graceful no-op
- helper 내부 `.catch(log.warn)` + `Promise.allSettled` 2중 안전 — LA 실패가 다른 cleanup 차단 안 함

## 4. Acceptance / 회귀 정의

### 사용자 가치
- destination 도착 / Seoul outage trip auto-end / 사용자 직접 trip 해제 시 LA가 **자동**으로 dismiss됨 (사용자가 직접 끄지 않아도 됨)
- backend trip dead 후 device가 silent push 받자마자 LA dismiss (26분 orphan 차단)

### 회귀 정의
- **AC1**: backend trip auto-end silent push 수신 시 `runTripBoundCleanups` 통해 LA dismiss
- **AC2**: 사용자 FG `setDestination(null)` 시 즉시 LA dismiss
- **AC3**: useStateRehydration sentinel 발견 시 + useLaunchTripReconciliation 'ended' 분기 시 LA dismiss
- **AC4**: LA 비활성 또는 이미 ended 상태에서도 graceful 통과 (멱등)
- **AC5**: 7일 production 측정: LA orphan > 5분 발생 0건

### 권한 매트릭스 (paradigm self-contained)

| 권한 | FG 지하 | FG 지상 | BG 지하 | BG 지상 | 취침 |
|------|---------|---------|---------|---------|------|
| WhileInUse | acceptance pass (FG setDestination 경로) | pass | silent push 미수신 시 backend 의존 | silent push 의존 | silent push 의존 |
| Always | pass (모든 경로) | pass | pass | pass | pass |

paradigm 6 (device self-contained): FG `setDestination(null)` 경로는 backend 의존 없이 device 자체 cleanup. BG는 silent push 의존이지만 useLaunchTripReconciliation cold-launch backstop이 push miss 회복.

## 5. Wire-completion 5단 체크

1. **Orphan 없음** — `npm run lint:orphan` PASS (0 orphan). `endLiveActivityCleanup`은 file-local function이며 `TRIP_BOUND_CLEANUPS` 배열에서 reference. helper 자체는 export 안 함.

2. **V/X dashboard**:
   - V dashboard: V6 (LA cleanup latency) — `tripBoundCleanups` logger의 `endLiveActivity threw` warn 카운트
   - X dashboard: X7 (LA orphan > 5분 detection) — Sentry `la_orphan_detected` 별도 PR로 wire 가능 (본 PR은 fix만)
   - 측정: backend Cloudflare Dashboard `trip auto-ended` 카운트 vs device LA dismiss event timing (DebugModal `tripBoundCleanups` log)

3. **의존 PR** — N/A. 단독 머지 가능. backend 변경 불필요 (기존 silent push trip-ended path 그대로 사용).

4. **측정 plan**:
   - 시나리오: T4 (건대입구 → 용마산) 또는 Seoul outage simulate (backend mock trainCode not found 5분)
   - 측정 신호: device 로그 `tripBoundCleanups` warn 빈도 (목표 0) + LA 표시 trip 종료 latency (목표 < 5초)
   - 기간: 1주

5. **Device verify** — **필요**. 실기기 시나리오:
   - (a) Seoul outage 재현: backend 또는 GPS mock으로 trainCode not found 5분 inject → trip auto-end silent push 수신 → LA dismiss 확인
   - (b) FG 정상 종료: 사용자 destination 도착 후 destination autoclear → LA dismiss 확인
   - (c) cold-launch reconciliation: BG에서 trip auto-end push miss → 앱 재시작 → fetchTripStatus 'ended' → LA dismiss 확인

## 6. 검증 결과

- `npm test`: **388 suites / 8032 tests PASS / coverage 100%**
- `npm run type-check`: **PASS**
- `npm run lint:orphan`: **0 orphan**
- 신규 테스트 2건 추가:
  - `runTripBoundCleanups 실행 시 Live Activity dismiss를 호출한다 (RC-9 orphan 차단)`
  - `LA dismiss가 reject해도 다른 cleanup이 진행되고 호출자에게 reject 전파 안 함`

## 7. 알려진 follow-up (out of scope)

`endLiveActivityCleanup`은 `LiveActivity.endLiveActivity()` (native module)를 직접 호출하지만 `liveActivityPushChannel`의 module-level state (`activeTeardown`, `activeTripToken`, push token subscription)는 정리하지 않는다. 이는 **본 PR 이전부터 존재하던 wire 갭** (silent push trip-ended 분기 자체가 LA dismiss를 안 했음). 본 PR은 사용자 가시 회귀(LA UI orphan 26분)를 우선 fix하며, push subscription / backend token deregister는 별도 follow-up 이슈로 분리.

## 8. Refs

- Parent: #1832 (silent push received=0 chain wire audit) + #1396 (교대→용마산 trip 회귀 RCA epic)
- Cascade: RC-4 (Seoul outage backend tolerance — 별도 backend PR), RC-15 (widget timestamp stale)
- Evidence 매트릭스: `/tmp/subway-rc-evidence-2026-06-26.md` RC-9 section
- 관련 memory:
  - `feedback_device_self_contained_fusion.md` — paradigm 6
  - `lesson_seoul_outage_user_blackhole_chain.md` — 8단계 chain
  - `feedback_wire_completion_gate.md` — 5단 검증