### PR TITLE
fix(#1891): RC-1 autoLock self-fire 차단 + RC-14 leg 전환 prompt

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingLockAutoRelease.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockAutoRelease.test.tsx
@@ -8,6 +8,7 @@ import type { Station } from '../../../../shared/types/station';
 import {
   ARRIVAL_PROXIMITY_THRESHOLD_M,
   AUTO_RELEASE_GRACE_MS,
+  LEG_TRANSITION_STATIONARY_GATE_MS,
 } from '../../../../shared/constants/boardingLock';
 
 const mockLoggerInfo = jest.fn();
@@ -18,6 +19,11 @@ jest.mock('../../../../shared/utils/logger', () => ({
     warn: jest.fn(),
     error: jest.fn(),
   }),
+}));
+
+const mockLogLegTransition = jest.fn();
+jest.mock('../../utils/alarmLog', () => ({
+  logLegTransition: (input: unknown) => mockLogLegTransition(input),
 }));
 
 const lockA: BoardingLock = {
@@ -383,5 +389,107 @@ describe('useBoardingLockAutoRelease', () => {
       rerender(baseInputs({ releaseLock, distanceKm: proximityKm - 0.01 }));
     });
     expect(releaseLock).not.toHaveBeenCalled();
+  });
+
+  // ── #1887 (RC-14 paradigm 4) — transfer 분기 motion stationary 30s gate + leg-transition log ──
+
+  it('transfer 분기 + motionStationary=true + grace + 30s gate 모두 충족 시 release + leg-transition log', () => {
+    const releaseLock = jest.fn();
+    const inputs = baseInputs({
+      releaseLock,
+      currentStation: transferStation,
+      route: transferRoute,
+      motionStationary: true,
+    });
+    const { rerender } = mountAtT0(inputs);
+    // grace 만료 시점에 30s gate도 같이 충족되어야 release.
+    // T0 진입 → grace+30s 모두 같은 ts0에서 카운트 시작하므로 max(grace, gate) 시점에 fire.
+    const fireAt = T0 + Math.max(AUTO_RELEASE_GRACE_MS, LEG_TRANSITION_STATIONARY_GATE_MS);
+    withDateNow(fireAt, () => {
+      rerender({ ...inputs, distanceKm: proximityKm - 0.01 });
+    });
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+    expect(mockLogLegTransition).toHaveBeenCalledWith({
+      fromLine: '2',
+      transferStationName: '왕십리',
+    });
+  });
+
+  it('transfer 분기 + motionStationary=false면 grace 충족돼도 release 안 함 (30s gate 미충족)', () => {
+    const releaseLock = jest.fn();
+    const inputs = baseInputs({
+      releaseLock,
+      currentStation: transferStation,
+      route: transferRoute,
+      motionStationary: false,
+    });
+    const { rerender } = mountAtT0(inputs);
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS + LEG_TRANSITION_STATIONARY_GATE_MS, () => {
+      rerender({ ...inputs, distanceKm: proximityKm - 0.01 });
+    });
+    expect(releaseLock).not.toHaveBeenCalled();
+    expect(mockLogLegTransition).not.toHaveBeenCalled();
+  });
+
+  it('transfer 분기 + motionStationary=true 늦게 latch — gate 시작 ts부터 30s 충족 시 release', () => {
+    const releaseLock = jest.fn();
+    const inputs = baseInputs({
+      releaseLock,
+      currentStation: transferStation,
+      route: transferRoute,
+      motionStationary: false,
+    });
+    const { rerender } = mountAtT0(inputs);
+    // T0 + grace 시점에 motion이 stationary로 latch — gate ref가 이때부터 시작.
+    const latchAt = T0 + AUTO_RELEASE_GRACE_MS;
+    withDateNow(latchAt, () => {
+      rerender({ ...inputs, motionStationary: true });
+    });
+    // gate ms 충족 안 됨 (29s) — 아직 release X.
+    withDateNow(latchAt + LEG_TRANSITION_STATIONARY_GATE_MS - 1, () => {
+      rerender({ ...inputs, motionStationary: true, distanceKm: proximityKm - 0.01 });
+    });
+    expect(releaseLock).not.toHaveBeenCalled();
+    // gate ms 충족 — release fire.
+    withDateNow(latchAt + LEG_TRANSITION_STATIONARY_GATE_MS, () => {
+      rerender({ ...inputs, motionStationary: true, distanceKm: proximityKm - 0.02 });
+    });
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+    expect(mockLogLegTransition).toHaveBeenCalledWith({
+      fromLine: '2',
+      transferStationName: '왕십리',
+    });
+  });
+
+  it('transfer 분기 + motionStationary=undefined(미측정)면 기존 동작 (grace만 충족 시 release, log 없음 X — log는 transfer 분기 release 시 항상 적재)', () => {
+    const releaseLock = jest.fn();
+    const inputs = baseInputs({
+      releaseLock,
+      currentStation: transferStation,
+      route: transferRoute,
+      // motionStationary 미전달 → undefined
+    });
+    const { rerender } = mountAtT0(inputs);
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS, () => {
+      rerender({ ...inputs, distanceKm: proximityKm - 0.01 });
+    });
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+    // transfer 분기 release는 motionStationary 게이트와 무관하게 leg-transition log 적재.
+    expect(mockLogLegTransition).toHaveBeenCalledWith({
+      fromLine: '2',
+      transferStationName: '왕십리',
+    });
+  });
+
+  it('destination 분기는 motion stationary 게이트 미적용 (paradigm 4는 transfer 한정)', () => {
+    const releaseLock = jest.fn();
+    // destination 매칭 + motionStationary=false인데도 grace만으로 release 발화 — paradigm 4는 transfer 분기 전용.
+    const { rerender } = mountAtT0(baseInputs({ releaseLock, motionStationary: false }));
+    withDateNow(T0 + AUTO_RELEASE_GRACE_MS, () => {
+      rerender(baseInputs({ releaseLock, motionStationary: false, distanceKm: proximityKm - 0.01 }));
+    });
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+    // destination 분기 release는 leg-transition log 미적재.
+    expect(mockLogLegTransition).not.toHaveBeenCalled();
   });
 });

--- a/src/features/alarm/hooks/useBoardingLockAutoRelease.ts
+++ b/src/features/alarm/hooks/useBoardingLockAutoRelease.ts
@@ -5,9 +5,11 @@ import type { Route } from '../../../shared/utils/stationRoute';
 import {
   ARRIVAL_PROXIMITY_THRESHOLD_M,
   AUTO_RELEASE_GRACE_MS,
+  LEG_TRANSITION_STATIONARY_GATE_MS,
 } from '../../../shared/constants/boardingLock';
 import { createLogger } from '../../../shared/utils/logger';
 import { getTransferLegs } from '../../../shared/utils/transferLegs';
+import { logLegTransition } from '../utils/alarmLog';
 
 const logger = createLogger('useBoardingLockAutoRelease');
 
@@ -27,6 +29,20 @@ export interface UseBoardingLockAutoReleaseInputs {
    * #899 (Seam C) — 환승 leg 도달 시 lock 자동 release을 위해 추가.
    */
   route?: Route;
+  /**
+   * #1887 (RC-14 paradigm 4 보강) — iOS CMMotionActivity stationary 신호.
+   *
+   * **transfer 분기에만** 적용되는 추가 게이트. 사용자 paradigm 4 "이동속도가 빠르지 않다면 판단 후에
+   * 자동 하차"의 정확 적용. 환승역 도달 + 거리/grace 조건이 충족돼도 motion stationary가
+   * `LEG_TRANSITION_STATIONARY_GATE_MS`(30s) 이상 지속되어야 leg 전환 release 발화.
+   *
+   * 도착(destination) 분기는 본 게이트 미적용 — 도착 시점에는 사용자가 짐 정리/하차 동작으로 motion이
+   * walking 변동 가능. transfer 분기는 환승 도보 전 정차 시간이 명확한 시그널이라 30s 이상 정지
+   * 신호를 release 조건에 추가해 paradigm 5 "1정거장 이내 deadline" 정확성 확보.
+   *
+   * `undefined`(미측정) 시 기존 동작(transfer 분기 release 즉시 평가) — backward-compat.
+   */
+  motionStationary?: boolean | undefined;
 }
 
 /**
@@ -70,19 +86,26 @@ export function useBoardingLockAutoRelease({
   distanceKm,
   releaseLock,
   route = null,
+  motionStationary,
 }: UseBoardingLockAutoReleaseInputs): void {
   const firstArrivedAtRef = useRef<number | null>(null);
   const lastTrainCodeRef = useRef<string | null>(null);
+  // #1887 (RC-14) — transfer 분기 진입 시점 ts 추적. motion stationary 30s gate에 사용.
+  // arrival ts와 별도 ref인 이유: 사용자가 환승역 진입 후 motion stationary가 늦게 latch되는
+  // 케이스에서 grace ms와 stationary gate ms가 독립 평가되어 각자 threshold를 채워야 fire.
+  const firstStationaryAtRef = useRef<number | null>(null);
 
   useEffect(() => {
     const trainCode = lock?.trainCode ?? null;
     if (lastTrainCodeRef.current !== trainCode) {
       lastTrainCodeRef.current = trainCode;
       firstArrivedAtRef.current = null;
+      firstStationaryAtRef.current = null;
     }
 
     if (!lock || !destinationId || !currentStation || distanceKm == null) {
       firstArrivedAtRef.current = null;
+      firstStationaryAtRef.current = null;
       return;
     }
 
@@ -95,21 +118,51 @@ export function useBoardingLockAutoRelease({
     const proximityOk = distanceKm * 1000 < ARRIVAL_PROXIMITY_THRESHOLD_M;
     if (matchKind === null || !proximityOk) {
       firstArrivedAtRef.current = null;
+      firstStationaryAtRef.current = null;
       return;
     }
 
     const now = Date.now();
     if (firstArrivedAtRef.current === null) {
       firstArrivedAtRef.current = now;
-      return;
     }
 
-    if (now - firstArrivedAtRef.current >= AUTO_RELEASE_GRACE_MS) {
-      firstArrivedAtRef.current = null;
-      logger.info(`${matchKind} grace 충족 → lock 자동 release`);
-      releaseLock();
+    // #1887 (RC-14) — transfer 분기 motion stationary 30s gate.
+    // motionStationary가 false면 ref 리셋 — 다음 stationary=true 진입에서 새로 카운트.
+    // motionStationary가 undefined(미측정)면 ref 리셋 — 게이트 미적용 분기로 폴백.
+    if (matchKind === 'transfer') {
+      if (motionStationary === true) {
+        if (firstStationaryAtRef.current === null) firstStationaryAtRef.current = now;
+      } else {
+        firstStationaryAtRef.current = null;
+      }
     }
-  }, [lock, destinationId, currentStation, distanceKm, releaseLock, route]);
+
+    const arrivedFor = now - firstArrivedAtRef.current;
+    if (arrivedFor < AUTO_RELEASE_GRACE_MS) return;
+
+    // transfer 분기 + motion stationary 측정 시: 30s gate도 동시 충족 필요.
+    // 미측정(undefined)이면 기존 동작(grace만으로 release) — backward-compat.
+    if (matchKind === 'transfer' && motionStationary !== undefined) {
+      const stationaryFor =
+        firstStationaryAtRef.current !== null ? now - firstStationaryAtRef.current : 0;
+      if (stationaryFor < LEG_TRANSITION_STATIONARY_GATE_MS) return;
+    }
+
+    firstArrivedAtRef.current = null;
+    firstStationaryAtRef.current = null;
+    logger.info(`${matchKind} grace 충족 → lock 자동 release`);
+    releaseLock();
+    // #1887 (RC-14) — leg 전환 evidence 적재. transfer 분기 release만 leg-transition으로 분류.
+    // device-side self-contained evidence — push notification fire는 backend cascade(RC-13/RC-16)
+    // 의존이라 본 PR 범위 외. alarmLog로 detect 시점 + 정거장 컨텍스트만 stamp.
+    if (matchKind === 'transfer') {
+      logLegTransition({
+        fromLine: lock.boardingLine,
+        transferStationName: currentStation.name,
+      });
+    }
+  }, [lock, destinationId, currentStation, distanceKm, releaseLock, route, motionStationary]);
 }
 
 /**

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -73,6 +73,7 @@ import {
   lastNReasons,
   logBoardingPromptFired,
   logBoardingPromptResponded,
+  logLegTransition,
   BOARDING_PROMPT_WINDOWS,
   countBoardingPromptByWindow,
   logBoardingPromptAutoLock,
@@ -2080,6 +2081,28 @@ describe('alarmLog', () => {
       expect(saved[0].source).toBe('boarding-prompt');
       expect(saved[0].outcome).toBe('fired');
       expect(saved[0].stationName).toBe('2·강남');
+    });
+
+    it('#1887 (RC-14): logLegTransition가 leg-transition entry를 적재한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logLegTransition({ fromLine: '2', transferStationName: '건대입구' });
+      await flushAlarmLog();
+      const saved = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
+      expect(saved).toHaveLength(1);
+      expect(saved[0].source).toBe('leg-transition');
+      expect(saved[0].outcome).toBe('fired');
+      expect(saved[0].stationName).toBe('2·건대입구');
+    });
+
+    it('#1887 (RC-14): leg-transition source는 silent push outcome 집계에서 제외 (null bucket)', () => {
+      const now = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        { ts: now - 1000, source: 'leg-transition', outcome: 'fired' },
+        { ts: now - 2000, source: 'silent-push-fired', outcome: 'fired' },
+      ];
+      const counts = countSilentPushOutcomes(entries);
+      // leg-transition은 SILENT_PUSH_OUTCOME_SOURCES에서 null bucket — silent push 카운터에 미반영.
+      expect(counts).toEqual({ received: 0, fired: 1, skipped: 0 });
     });
 
     it('countBoardingPromptByWindow가 윈도우별 발사 횟수를 집계한다', () => {

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -72,7 +72,12 @@ export type AlarmLogSource =
   | 'cross-trip-mirror-launch'
   // #1769 — accelerometer pattern 관찰 stamp. automotive/walking/stationary/unknown 4 pattern.
   // 1s dedup으로 같은 pattern 연속 시 1건만 적재 — 폴링 cycle마다 중복 log spam 방지.
-  | 'accel-pattern-observed';
+  | 'accel-pattern-observed'
+  // #1887 (RC-14 paradigm 4) — 환승역 도달 + motion stationary 30s + grace 충족 시 transfer
+  // 분기 자동 lock release 발생을 stamp. device-side self-contained evidence — push notification
+  // fire는 backend cascade(RC-13/RC-16) 의존이라 본 PR 범위 외. 7일 production 측정에서 detect
+  // 빈도(`leg_swap_prompt_fired` count)와 paradigm 1 회귀 점검(`autoLock_fired_count = 0`)을 같이 본다.
+  | 'leg-transition';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(#580): evaluateAlarmPhase의 firedAlarms 적중. destination/transfer phase alarm dedup
 // 발생 관찰. station-passed는 별도 메커니즘(lastNotifiedStationId)이라 'dedup-station' 사용.
@@ -1038,6 +1043,7 @@ const SILENT_PUSH_OUTCOME_SOURCES: Record<AlarmLogSource, keyof SilentPushOutcom
   'cross-trip-mirror-mismatch': null,
   'cross-trip-mirror-launch': null,
   'accel-pattern-observed': null,
+  'leg-transition': null,
 };
 
 export interface SilentPushOutcomeCounts {
@@ -1647,6 +1653,27 @@ export function logAccelPatternObserved(pattern: 'automotive' | 'walking' | 'sta
 /** 테스트용 — accel-pattern dedup 윈도우 리셋. */
 export function _resetAccelPatternWindowForTests(): void {
   lastAccelPatternTs.clear();
+}
+
+/**
+ * #1887 (RC-14 paradigm 4) — 환승역 도달 + motion stationary 30s + 거리/grace 모두 충족 시
+ * transfer 분기 자동 lock release 발생을 1건 stamp.
+ *
+ * device-side self-contained evidence — push notification fire는 backend cascade(RC-13/RC-16)
+ * 의존이라 본 PR 범위 외. 7일 production 측정에서:
+ *   - `leg_swap_prompt_fired` count > 0 (= leg 전환 detect 성공 빈도)
+ *   - `autoLock_fired_count = 0` (= RC-1 paradigm 1 회귀 없음) 와 같이 본다.
+ *
+ * stationName 슬롯에 `fromLine·transferStationName` 인코딩 — 기존 schema 확장 없이 DebugModal
+ * 가시화 (logBoardingPromptFired 패턴 재사용).
+ */
+export function logLegTransition(input: { fromLine: string; transferStationName: string }): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'leg-transition',
+    outcome: 'fired',
+    stationName: `${input.fromLine}·${input.transferStationName}`,
+  });
 }
 
 // ── CRUD ──

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
@@ -340,12 +340,15 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
         useFusedNearestStation(undefined, undefined, subRouteContext, 'T-ARC-MISS'),
       );
 
-      // positionTrainResult = 용마산 → lockedTrainCode 매칭으로 source='boarding-lock' 채택.
+      // positionTrainResult = 용마산 → cascade가 positionTrain 분기로 채택.
       // #1207 (Epic #1204 D1): lock 없음 + routeCtx 있음 → lockless-route-hop estimator 활성.
       // #1418 — positionTrainResult(=Tier 4 실측)가 활성이면 lockless-route-hop(Tier 5)의 forward
-      //         ratchet은 차단된다. 결과는 cascade가 산출한 'boarding-lock'(lockedTrainCode 매칭).
-      //         앵커(lastObservedRef)는 arcIndexOfStation=-1 반환으로 미갱신 — line 487 early return 유지.
-      expect(result.current.source).toBe('boarding-lock');
+      //         ratchet은 차단된다. 앵커(lastObservedRef)는 arcIndexOfStation=-1 반환으로 미갱신
+      //         — line 487 early return 유지.
+      // #1891 (RC-1 paradigm 1): boardingLock=null 상태에서는 lockedTrainCode 매칭이 있어도
+      //         'boarding-lock' source 승격 차단 — 사용자 명시 의향 표명 없는 self-fire 방지.
+      //         lockless trip cascade는 'position-train' source로 떨어진다 (autoLock_fired_count=0 정합).
+      expect(result.current.source).toBe('position-train');
     });
   });
 

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -255,15 +255,33 @@ describe('useFusedNearestStation', () => {
   describe('#584 PR D2: boarding-lock 라벨', () => {
     const setupPositionTrain = setupPositionTrainTransferStation;
 
-    it('lockedTrainCode가 position-train의 trainNo와 일치하면 boarding-lock으로 승격', () => {
+    it('lockedTrainCode가 position-train의 trainNo와 일치 + boardingLock 활성 → boarding-lock으로 승격', () => {
       // R13-a (#1612): setupPositionTrainTransferStation는 실 chungmuro GPS + accuracy=50으로
-      // 변경됐다 — strict 면제 가능. lock 미전달이라 boarding-lock 승격은 lockedTrainCode 매칭만.
+      // 변경됐다 — strict 면제 가능.
+      // #1891 (RC-1 paradigm 1) — boardingLock 인자 전달이 'boarding-lock' 승격의 필수 게이트.
+      // 사용자 명시 의향 trip(lock 활성)에서만 lockMatch 승격. lock 미전달 시 차단(아래 별도 케이스).
       setupPositionTrain('T-LOCKED');
+      const lockWithTrainCode: import('../../../../shared/types/boardingLock').BoardingLock = {
+        ...mockLockForUnderground,
+        trainCode: 'T-LOCKED',
+      };
       const { result } = renderHook(() =>
-        useFusedNearestStation(undefined, undefined, undefined, 'T-LOCKED'),
+        useFusedNearestStation(undefined, undefined, undefined, 'T-LOCKED', lockWithTrainCode),
       );
       expect(result.current.confidence).toBe('boarding-lock');
       expect(result.current.source).toBe('boarding-lock');
+    });
+
+    it('#1891 (RC-1): boardingLock=null + lockedTrainCode 매칭이어도 position-train 유지 (autoLock self-fire 차단)', () => {
+      // paradigm 1 (자동락 제거 유지) 보강 — lock 비활성 시 lockedTrainCode가 stale로 남아도
+      // 'boarding-lock' source 자기 발화 차단. parent #1745 acceptance: `autoLock_fired_count = 0`.
+      // station-passed / transfer 알림의 src='boarding-lock' self-attach chain 단절.
+      setupPositionTrain('T-LOCKED');
+      const { result } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, undefined, 'T-LOCKED', null),
+      );
+      expect(result.current.confidence).toBe('position-train');
+      expect(result.current.source).toBe('position-train');
     });
 
     it('lockedTrainCode가 다르면 position-train 유지', () => {

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -1149,8 +1149,16 @@ export function useFusedNearestStation(
     // #584 PR D2: position-train의 trainNo가 BoardingLock.trainCode와 일치하면 'boarding-lock'으로 승격.
     // 사용자가 탭한 바로 그 열차가 실시간 위치 API에 잡힌 상태 — 최고 신뢰 신호.
     // positionTrainResult가 non-null이면 trainProgress도 non-null (line 219 guard).
+    //
+    // #1891 (paradigm Phase 1 보강) — RC-1 autoLock self-fire 차단:
+    //   `boardingLock != null` gate 추가. 사용자 의향 표명(boardingPrompt 응답 / BoardingTrainList
+    //   직접 탭) 없이 lockedTrainCode가 stale로 남아 있을 때 'boarding-lock' source 승격을 금지.
+    //   lock=null이면 'position-train'으로 유지 → station-passed/transfer 알림의 src='boarding-lock'
+    //   자기 발화 chain을 끊는다. parent #1745 acceptance: `autoLock_fired_count = 0`.
     const lockMatch =
-      lockedTrainCode != null && trainProgress!.trainNo === lockedTrainCode;
+      boardingLock != null &&
+      lockedTrainCode != null &&
+      trainProgress!.trainNo === lockedTrainCode;
     confidence = lockMatch ? 'boarding-lock' : 'position-train';
     source = lockMatch ? 'boarding-lock' : 'position-train';
   } else if (fused && fusedPasses) {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -640,6 +640,9 @@ export default function HomeScreen() {
     distanceKm: result?.distanceKm ?? null,
     releaseLock: releaseBoardingLock,
     route,
+    // #1887 (RC-14) — transfer 분기에 motion stationary 30s 게이트 추가.
+    // paradigm 4 "이동속도가 빠르지 않다면 판단 후에 자동 하차" 정확 적용.
+    motionStationary,
   });
   // #925 (C2 wire) — destination 자동 하차 감지. arvlCd=0/1 + 역 50m 이내 + 60s motion stationary
   // 4-신호 AND 게이트 통과 시 setDestination(null) 호출 → 후속 LA end / trip-end recall은

--- a/src/shared/constants/boardingLock.ts
+++ b/src/shared/constants/boardingLock.ts
@@ -56,6 +56,26 @@ export const ARRIVAL_PROXIMITY_THRESHOLD_M = 300;
 export const AUTO_RELEASE_GRACE_MS = 45_000;
 
 /**
+ * #1887 (RC-14 paradigm 4) — transfer 분기 자동 release에 추가되는 motion stationary 게이트(ms).
+ *
+ * 사용자 paradigm 4 "이동속도가 빠르지 않다면 판단 후에 자동 하차"의 정확 적용. 환승역 도달 +
+ * `ARRIVAL_PROXIMITY_THRESHOLD_M`(300m) 거리 + `AUTO_RELEASE_GRACE_MS`(45s) grace에 더해
+ * iOS CMMotionActivity stationary가 `LEG_TRANSITION_STATIONARY_GATE_MS` 이상 지속되어야 release.
+ *
+ * 30_000ms로 둔 이유:
+ *  - 사용자 paradigm 5 "1정거장 이내 deadline" 정합 — 환승역에서 도보 시작 직전 정차 시간이 짧으면
+ *    사용자가 곧바로 다음 leg로 이동한다는 신호이므로 release를 미뤄야 함.
+ *  - 30s는 사용자 issue body T4 시나리오의 "30초~수분 stationary" 정신 정확 매칭.
+ *  - 너무 짧으면(예: 10s) 정차 직전 한 사이클만 stationary로 잡혀도 release 발화 위험 — paradigm 4
+ *    의 "판단 후" 정신 위반.
+ *  - 너무 길면(예: 120s) 사용자가 이미 환승 통로로 이동했는데 lock이 남는 시간이 길어짐.
+ *
+ * 도착(destination) 분기에는 미적용 — 도착 시점에는 사용자가 짐 정리/하차 동작으로 motion이 walking
+ * 변동 가능. transfer 분기만 환승 도보 전 정차 시간이 명확한 시그널.
+ */
+export const LEG_TRANSITION_STATIONARY_GATE_MS = 30_000;
+
+/**
  * #767 — boardingLock 해제(non-null → null) 시 register POST를 지연하는 debounce(ms).
  *
  * 배경(PR #765 evidence): 사용자가 옛 lock을 release하고 즉시 새 lock을 잡는 swap 흐름에서


### PR DESCRIPTION
## Summary

paradigm cross-fix — **autoLock false-positive (RC-1) + leg 자동전환/prompt (RC-14)**. 동일 영역 (lock lifecycle) cascade 통합.

### RC-1 (#1891) — `boarding-lock` source self-fire 차단

- `src/features/nearest-station/hooks/useFusedNearestStation.ts:1147-1166`
- `positionTrainResult` fallback 분기의 `lockMatch` 조건에 **`boardingLock != null` gate 추가**
- 사용자 의향 표명(boardingPrompt 응답 / BoardingTrainList 직접 탭) 없이 `lockedTrainCode`가 stale로 남아 있을 때 `'boarding-lock'` source 자기 발화 차단
- `station-passed` / `transfer` 알림의 `src='boarding-lock'` self-attach chain 단절
- **paradigm 1 (자동락 제거 유지) 보강** — parent #1745 acceptance: `autoLock_fired_count = 0`

### RC-14 (#1887) — leg 전환 motion stationary gate + alarmLog evidence

- `src/features/alarm/hooks/useBoardingLockAutoRelease.ts` — transfer 분기에 `motionStationary` 30s gate 추가
- `src/shared/constants/boardingLock.ts` — 신규 상수 `LEG_TRANSITION_STATIONARY_GATE_MS = 30_000`
- `src/features/alarm/utils/alarmLog.ts` — 신규 source `'leg-transition'` + `logLegTransition` 함수
- `src/screens/HomeScreen.tsx` — `motionStationary` wire
- **paradigm 4 (호선 자동 전환) device-side 보강** — "이동속도가 빠르지 않다면 판단 후에 자동 하차" 정확 적용
- backend push fire (boarding-prompt push trigger)는 cascade 의존 PR (RC-13/RC-16)에 위임 — **본 PR은 device self-contained scope**

### 결정 사항 매핑 (#1887 본문 L433-438)

| 사용자 결정 | 본 PR 처리 |
|---|---|
| ❌ autoLock B/B'/D 부활 X | ✅ RC-1 fix로 paradigm 1 유지 |
| ✅ leg 전환 시 boarding-prompt 자동 trigger | 🔁 backend cascade (RC-13/RC-16) 의존 — device alarmLog evidence만 적재 |
| ✅ 이동속도 게이트로 "자동 하차" detect | ✅ 30s motion stationary gate로 lock cleanup |
| ✅ 호선 자동 변경 | ✅ `useTransferTrainList` 기존 wire 유지 (lock cleanup 후 `transferContext.nextLine` 자동 노출) |

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass. 신규 export 2건(`LEG_TRANSITION_STATIONARY_GATE_MS`, `logLegTransition`) 모두 caller 존재
2. **V/X dashboard** — alarmLog source `'leg-transition'` 적재 (DebugModal 가시화), Sentry breadcrumb `autoLock_self_fire_reject` count + `leg_swap_prompt_fired` count
3. **의존 PR** — N/A (parent #1745 paradigm shift Phase 1+2 머지 완료, PR #1738/#1741/#1742). RC-13/RC-16은 push fire wire용 후속 cascade
4. **측정 plan** — 7일 production:
   - `autoLock_fired_count = 0` 유지 (RC-1 paradigm 1 회귀 0건)
   - `leg_swap_prompt_fired > 0` 발생 (RC-14 leg 전환 detect 빈도)
   - trip dump `## Fusion Tier (1h)` evidence + alarmLog `'leg-transition'` 카운트
5. **Device verify** — 실기기 필수:
   - **Day 3 T1** (autoLock 회귀) — 출발지(충정로 부근)에서 5분 대기 + 의향 표명 0회 → fusion log `src=boarding-lock` 발화 0건 확인
   - **Day 3 T4** (건대→용마산 환승) — lock=2호선 active + 건대입구 도착 + 30초 stationary → lock cleanup + 7호선 BoardingTrainList 자동 노출 확인

## Tests

- coverage 100% (lines / functions / branches / statements 모두 강제)
- `npx jest` 8038 tests pass (388 suites)
- `npm run type-check` pass
- `npm run lint:orphan` pass
- 신규 케이스 7개:
  - **RC-1 회귀 차단** (`useFusedNearestStation.test.ts`): boardingLock 활성 시 lockMatch 승격 + boardingLock=null 시 position-train 유지
  - **RC-14 게이트** (`useBoardingLockAutoRelease.test.tsx`): motion stationary 30s gate + late latch + undefined backward-compat + destination 분기 격리
  - **leg-transition log** (`alarmLog.test.ts`): entry 적재 + silent push 집계 격리

## Refs

- Closes #1891
- Closes #1887
- Parent: #1745 (paradigm shift Phase 1+2 검증 + 1주 production 측정)