### PR TITLE
feat(#1883): RC-11 mid-trip route freeze + RC-16 push i18n 4언어

### DIFF
--- a/backend/alarm-worker/src/__tests__/i18n.test.ts
+++ b/backend/alarm-worker/src/__tests__/i18n.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeLocale, t, type SupportedLocale } from '../i18n';
+
+describe('normalizeLocale (#1895)', () => {
+  const SUPPORTED: SupportedLocale[] = ['ko', 'en', 'ja', 'zh'];
+
+  it.each(SUPPORTED)('지원 locale "%s"는 그대로 반환', (lc) => {
+    expect(normalizeLocale(lc)).toBe(lc);
+  });
+
+  it.each([
+    ['fr'],
+    ['de'],
+    ['EN'], // case-sensitive (i18next는 소문자만 송신하므로 대소문자 변환 X)
+    [''],
+    [null],
+    [undefined],
+    [123],
+    [{}],
+  ])('비지원/잘못된 입력 "%s" → ko fallback', (raw) => {
+    expect(normalizeLocale(raw)).toBe('ko');
+  });
+});
+
+describe('t() — boardingPromptTitle 4언어 분기 (#1895)', () => {
+  it('locale=ko → "탑승하셨나요?"', () => {
+    expect(t('ko').boardingPromptTitle).toBe('탑승하셨나요?');
+  });
+
+  it('locale=en → "Are you on board?"', () => {
+    expect(t('en').boardingPromptTitle).toBe('Are you on board?');
+  });
+
+  it('locale=ja → "ご乗車されましたか?"', () => {
+    expect(t('ja').boardingPromptTitle).toBe('ご乗車されましたか?');
+  });
+
+  it('locale=zh → "您已乘车了吗?"', () => {
+    expect(t('zh').boardingPromptTitle).toBe('您已乘车了吗?');
+  });
+
+  it('locale=undefined → ko fallback', () => {
+    expect(t(undefined).boardingPromptTitle).toBe('탑승하셨나요?');
+  });
+});
+
+describe('t() — boardingPromptBody nextStation+ETA 분기 (#1895)', () => {
+  const ETA_TIME = '07:15';
+  const ARGS = {
+    originStation: '시청',
+    line: '2',
+    nextStation: '강남',
+    etaTimeStr: ETA_TIME,
+  };
+
+  it('locale=ko → "출발역 [호선] → 다음역 방면 HH:MM 진입"', () => {
+    expect(t('ko').boardingPromptBody(ARGS)).toBe('시청 [2] → 강남 방면 07:15 진입');
+  });
+
+  it('locale=en → "originStation [line] → nextStation bound HH:MM arrival"', () => {
+    expect(
+      t('en').boardingPromptBody({ ...ARGS, originStation: 'City Hall', nextStation: 'Gangnam' }),
+    ).toBe('City Hall [2] → Gangnam bound 07:15 arrival');
+  });
+
+  it('locale=ja → "originStation [line] → nextStation方面 HH:MM進入"', () => {
+    expect(
+      t('ja').boardingPromptBody({ ...ARGS, originStation: '市庁', nextStation: '江南' }),
+    ).toBe('市庁 [2] → 江南方面 07:15進入');
+  });
+
+  it('locale=zh → "originStation [line] → nextStation方向 HH:MM到达"', () => {
+    expect(
+      t('zh').boardingPromptBody({ ...ARGS, originStation: '市厅', nextStation: '江南' }),
+    ).toBe('市厅 [2] → 江南方向 07:15到达');
+  });
+});
+
+describe('t() — boardingPromptBody nextStation null fallback (#1895)', () => {
+  const ARGS_NULL = {
+    originStation: '시청',
+    line: '2',
+    nextStation: null,
+    etaTimeStr: null,
+  };
+
+  it.each([
+    ['ko' as SupportedLocale],
+    ['en' as SupportedLocale],
+    ['ja' as SupportedLocale],
+    ['zh' as SupportedLocale],
+  ])('locale=%s → "${line} · ${originStation}" 공통 포맷 (nextStation null)', (lc) => {
+    expect(t(lc).boardingPromptBody(ARGS_NULL)).toBe('2 · 시청');
+  });
+});
+
+describe('t() — boardingPromptBody nextStation 있고 etaTimeStr null (#1895)', () => {
+  const ARGS_NO_TIME = {
+    originStation: '합정',
+    line: '6',
+    nextStation: '마포구청',
+    etaTimeStr: null,
+  };
+
+  it('locale=ko → 시간 없이 방면만', () => {
+    expect(t('ko').boardingPromptBody(ARGS_NO_TIME)).toBe('합정 [6] → 마포구청 방면');
+  });
+
+  it('locale=en → 시간 없이 bound만', () => {
+    expect(t('en').boardingPromptBody(ARGS_NO_TIME)).toBe('합정 [6] → 마포구청 bound');
+  });
+
+  it('locale=ja → 시간 없이 方面만', () => {
+    expect(t('ja').boardingPromptBody(ARGS_NO_TIME)).toBe('합정 [6] → 마포구청方面');
+  });
+
+  it('locale=zh → 시간 없이 方向만', () => {
+    expect(t('zh').boardingPromptBody(ARGS_NO_TIME)).toBe('합정 [6] → 마포구청方向');
+  });
+});

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -7327,38 +7327,38 @@ describe('runScheduled — #1707 destination GPS cross-check integration', () =>
   });
 });
 
-describe('buildBoardingPromptMessage (#1739 — 방면 + 시간 명시)', () => {
+describe('buildBoardingPromptMessage (#1739 — 방면 + 시간 명시, #1895 — i18n 4언어)', () => {
   const BASE_NOW = 1_700_000_000_000; // 2023-11-14T22:13:20.000Z → KST 07:13
 
-  it('nextStation + etaSeconds 둘 다 있음 → "출발역 [호선] → 다음역 방면 HH:MM 진입"', () => {
+  it('nextStation + etaSeconds 둘 다 있음 → "출발역 [호선] → 다음역 방면 HH:MM 진입" (ko 기본)', () => {
     // BASE_NOW + 120s → KST 07:15:20 → HH:MM = 07:15
     const { title, body } = buildBoardingPromptMessage('시청', '2', '강남', 120, BASE_NOW);
-    expect(title).toBe('Are you on board?');
+    expect(title).toBe('탑승하셨나요?');
     expect(body).toBe('시청 [2] → 강남 방면 07:15 진입');
   });
 
   it('nextStation 없음 (null) → 기존 포맷 fallback "${line} · ${originStation}"', () => {
     const { title, body } = buildBoardingPromptMessage('왕십리', '5', null, 90, BASE_NOW);
-    expect(title).toBe('Are you on board?');
+    expect(title).toBe('탑승하셨나요?');
     expect(body).toBe('5 · 왕십리');
   });
 
   it('nextStation 있지만 etaSeconds null → 시간 없이 방면만 표시', () => {
     const { title, body } = buildBoardingPromptMessage('합정', '6', '마포구청', null, BASE_NOW);
-    expect(title).toBe('Are you on board?');
+    expect(title).toBe('탑승하셨나요?');
     expect(body).toBe('합정 [6] → 마포구청 방면');
   });
 
   it('환승 leg — 다른 호선 nextStation + ETA', () => {
     // BASE_NOW + 180s → KST 07:16:20 → HH:MM = 07:16
     const { title, body } = buildBoardingPromptMessage('왕십리', '5', '마장', 180, BASE_NOW);
-    expect(title).toBe('Are you on board?');
+    expect(title).toBe('탑승하셨나요?');
     expect(body).toBe('왕십리 [5] → 마장 방면 07:16 진입');
   });
 
   it('etaSeconds=0 → now 시각 그대로 표시 (즉시 진입)', () => {
     const { title, body } = buildBoardingPromptMessage('시청', '2', '을지로입구', 0, BASE_NOW);
-    expect(title).toBe('Are you on board?');
+    expect(title).toBe('탑승하셨나요?');
     expect(body).toBe('시청 [2] → 을지로입구 방면 07:13 진입');
   });
 
@@ -7373,6 +7373,40 @@ describe('buildBoardingPromptMessage (#1739 — 방면 + 시간 명시)', () => 
   it('non-numeric line name (gyeongui) — fallback 포맷 정상', () => {
     const { body } = buildBoardingPromptMessage('회기', 'gyeongui', null, null, BASE_NOW);
     expect(body).toBe('gyeongui · 회기');
+  });
+
+  it('#1895 — locale=en → 영어 본문 ("Are you on board?" / "bound" suffix)', () => {
+    const { title, body } = buildBoardingPromptMessage('City Hall', '2', 'Gangnam', 120, BASE_NOW, 'en');
+    expect(title).toBe('Are you on board?');
+    expect(body).toBe('City Hall [2] → Gangnam bound 07:15 arrival');
+  });
+
+  it('#1895 — locale=ja → 일본어 본문', () => {
+    const { title, body } = buildBoardingPromptMessage('市庁', '2', '江南', 120, BASE_NOW, 'ja');
+    expect(title).toBe('ご乗車されましたか?');
+    expect(body).toBe('市庁 [2] → 江南方面 07:15進入');
+  });
+
+  it('#1895 — locale=zh → 중국어 본문', () => {
+    const { title, body } = buildBoardingPromptMessage('市厅', '2', '江南', 120, BASE_NOW, 'zh');
+    expect(title).toBe('您已乘车了吗?');
+    expect(body).toBe('市厅 [2] → 江南方向 07:15到达');
+  });
+
+  it('#1895 — locale=ko 명시 → 한국어 본문 (DEFAULT_LOCALE과 동일)', () => {
+    const { title, body } = buildBoardingPromptMessage('시청', '2', '강남', 120, BASE_NOW, 'ko');
+    expect(title).toBe('탑승하셨나요?');
+    expect(body).toBe('시청 [2] → 강남 방면 07:15 진입');
+  });
+
+  it('#1895 — locale 미지정 → ko fallback', () => {
+    const { title } = buildBoardingPromptMessage('시청', '2', '강남', 120, BASE_NOW, undefined);
+    expect(title).toBe('탑승하셨나요?');
+  });
+
+  it('#1895 — locale=en + nextStation null → fallback 포맷 (locale 무관 공통 포맷)', () => {
+    const { body } = buildBoardingPromptMessage('City Hall', '2', null, 90, BASE_NOW, 'en');
+    expect(body).toBe('2 · City Hall');
   });
 });
 

--- a/backend/alarm-worker/src/alertContent.ts
+++ b/backend/alarm-worker/src/alertContent.ts
@@ -14,9 +14,12 @@
  *   - intermediate        ↔ ko.json route.intermediatePassedTitle + route.intermediatePassedBody
  *   - trip-ended          ↔ ko.json route.tripEndedTitle + route.tripEndedBody
  *
- * 백엔드에는 i18next가 없고 사용자 locale도 알 수 없어 한국어 정적 문자열로 고정.
- * 영문 locale 지원이 필요해지면 디바이스 register 시점에 locale을 trip에 함께 저장하고
- * 여기서 lookup하도록 확장한다.
+ * 본 파일의 alert 본문은 silent push fallback 채널 — 한국어 정적 문자열로 유지.
+ * #1895(boarding-prompt push) 이후 backend i18n 4언어 분기 인프라가 도입됐으나(`i18n.ts`),
+ * 본 fallback 본문은 디바이스 i18n과 byte-identical을 유지해야 silent push가 device에서
+ * 발사된 본문과 alert fallback이 어긋나지 않으므로 한국어 고정 — 변경 시 디바이스 ko.json도 함께 수정.
+ * 다른 push kind(station-passed, arrival, transfer, alighting)의 4언어 분기는 device-side
+ * stationNotification.ts가 처리한다(silent push payload → device가 본문 빌드).
  *
  * exitSide/quickHint suffix는 백엔드에 GPS 정보가 없어 생략 — alert는 보조 채널이라
  * "어느 문으로 하차" 같은 정밀 정보 없이도 충분히 의미를 전달한다.

--- a/backend/alarm-worker/src/i18n.ts
+++ b/backend/alarm-worker/src/i18n.ts
@@ -1,0 +1,87 @@
+/**
+ * Backend push notification i18n string table (#1895).
+ *
+ * 디바이스 register POST /trips 시점에 `locale`을 함께 송신한다(`src/features/alarm/api/alarmBackend.ts`).
+ * backend는 trip 객체에 locale을 저장하고, push 본문 생성 시 `t(trip.locale)`로 4언어 (ko/en/ja/zh)
+ * 분기한다. locale 미지정/비지원이면 ko로 fallback (한국어 사용자 기본).
+ *
+ * 디바이스 측 i18n(`src/shared/i18n/locales/{ko,en,ja,zh}.json`)과 1:1 매핑.
+ * 동기화 주의: 본 파일과 디바이스 i18n 모두 손대야 silent push fallback과 alert push의 본문이
+ * 어긋나지 않는다.
+ */
+
+/** 지원 locale — 디바이스 SUPPORTED_LANGUAGES와 1:1 매핑. */
+export type SupportedLocale = 'ko' | 'en' | 'ja' | 'zh';
+
+/** Locale fallback — 한국 운영 서비스 기본. */
+const DEFAULT_LOCALE: SupportedLocale = 'ko';
+
+/** 입력 raw locale을 SupportedLocale로 정규화. 미지원/undefined → DEFAULT_LOCALE. */
+export function normalizeLocale(raw: unknown): SupportedLocale {
+  if (raw === 'ko' || raw === 'en' || raw === 'ja' || raw === 'zh') return raw;
+  return DEFAULT_LOCALE;
+}
+
+/** Boarding-prompt body 인자. */
+export interface BoardingPromptArgs {
+  originStation: string;
+  line: string;
+  nextStation: string | null;
+  /** etaIso8601 또는 HH:MM 시각 표기 문자열. 없으면 미표시. */
+  etaTimeStr: string | null;
+}
+
+interface I18nStrings {
+  boardingPromptTitle: string;
+  boardingPromptBody: (args: BoardingPromptArgs) => string;
+}
+
+/**
+ * 4언어 string table. 각 push kind 별로 title/body를 분리한다.
+ *
+ * boardingPromptBody는 `nextStation`이 있으면 "출발역 [호선] → 다음역 방면 (HH:MM 진입)",
+ * 없으면 "${line} · ${originStation}" fallback — 기존 buildBoardingPromptMessage의 한국어 포맷을
+ * 4언어로 확장.
+ */
+const I18N: Record<SupportedLocale, I18nStrings> = {
+  ko: {
+    boardingPromptTitle: '탑승하셨나요?',
+    boardingPromptBody: ({ originStation, line, nextStation, etaTimeStr }) => {
+      if (!nextStation) return `${line} · ${originStation}`;
+      const time = etaTimeStr ? ` ${etaTimeStr} 진입` : '';
+      return `${originStation} [${line}] → ${nextStation} 방면${time}`;
+    },
+  },
+  en: {
+    boardingPromptTitle: 'Are you on board?',
+    boardingPromptBody: ({ originStation, line, nextStation, etaTimeStr }) => {
+      if (!nextStation) return `${line} · ${originStation}`;
+      const time = etaTimeStr ? ` ${etaTimeStr} arrival` : '';
+      return `${originStation} [${line}] → ${nextStation} bound${time}`;
+    },
+  },
+  ja: {
+    boardingPromptTitle: 'ご乗車されましたか?',
+    boardingPromptBody: ({ originStation, line, nextStation, etaTimeStr }) => {
+      if (!nextStation) return `${line} · ${originStation}`;
+      const time = etaTimeStr ? ` ${etaTimeStr}進入` : '';
+      return `${originStation} [${line}] → ${nextStation}方面${time}`;
+    },
+  },
+  zh: {
+    boardingPromptTitle: '您已乘车了吗?',
+    boardingPromptBody: ({ originStation, line, nextStation, etaTimeStr }) => {
+      if (!nextStation) return `${line} · ${originStation}`;
+      const time = etaTimeStr ? ` ${etaTimeStr}到达` : '';
+      return `${originStation} [${line}] → ${nextStation}方向${time}`;
+    },
+  },
+};
+
+/**
+ * 주어진 locale에 매핑된 string table 반환. 미지원/undefined는 DEFAULT_LOCALE.
+ * caller는 `t(trip.locale).boardingPromptTitle` 형태로 사용.
+ */
+export function t(locale: SupportedLocale | undefined): I18nStrings {
+  return I18N[locale ?? DEFAULT_LOCALE];
+}

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -2019,6 +2019,12 @@ export function validateTrip(input: unknown): Trip | null {
     // #903 (Seam G): 클라이언트 기압계가 보고한 지하 진입 신호. 미송신/비boolean이면 undefined(default OFF).
     // scheduled.ts가 이 값으로 consecutiveEtaMissing threshold(5 vs 10)를 분기한다.
     subsurface: typeof obj.subsurface === 'boolean' ? obj.subsurface : undefined,
+    // #1895: device locale (ko/en/ja/zh). boarding-prompt push 본문 생성에 사용.
+    // 미지원/undefined는 t() 호출 시점에 ko fallback (default).
+    locale:
+      obj.locale === 'ko' || obj.locale === 'en' || obj.locale === 'ja' || obj.locale === 'zh'
+        ? obj.locale
+        : undefined,
   };
 }
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -89,6 +89,7 @@ import type {
 import { RESCHEDULE_CHANNELS_DEFAULT } from './types';
 import { writeMetric } from './analytics';
 import { accumulateLaPushCounters } from './laPushCounters';
+import { t, type SupportedLocale } from './i18n';
 
 // pickApnsHost / flipApnsEnv는 ./apnsHost로 이동 (liveActivity.ts와 공유 SSOT, #482).
 // 외부(테스트 / index.ts 등)가 scheduled.ts 경유로 import하던 호환성 유지를 위해 re-export.
@@ -3297,15 +3298,19 @@ function toKstHhmm(epochMs: number): string {
 /**
  * boardingPrompt push 메시지 빌드 (#1739 — 방면 + 시간 명시).
  *
- * title: 항상 영문 raw (backend raw 원칙 — i18n는 client 담당).
- * body:  nextStation이 있으면 "출발역 [호선] → 다음역 방면 HH:MM 진입",
- *        없으면 기존 포맷 "${line} · ${originStation}" fallback.
+ * #1895 — i18n 4언어 분기 (ko/en/ja/zh). trip.locale 기반으로 `t(locale)` lookup해 본문 생성.
+ * locale 미지정/비지원 시 ko fallback (한국 운영 기본).
+ *
+ * title: locale별 분기 ("탑승하셨나요?" / "Are you on board?" / "ご乗車されましたか?" / "您已乘车了吗?").
+ * body:  nextStation이 있으면 "출발역 [호선] → 다음역 방면 HH:MM 진입" (locale별 어미 분기),
+ *        없으면 fallback "${line} · ${originStation}".
  *
  * @param originStation  display.originStation (출발역 표시명)
  * @param line           display.line ("2", "gyeongui" 등)
  * @param nextStation    trip.waypoints[0].stationName (다음 정거장 — 방면 표시)
  * @param etaSeconds     arrivals에서 추출한 도착 잔여 초 (null = 정보 없음)
  * @param now            현재 epoch ms (ETA 절대 시각 계산용)
+ * @param locale         #1895 — trip.locale (ko/en/ja/zh). 미지정 시 ko fallback.
  */
 export function buildBoardingPromptMessage(
   originStation: string,
@@ -3313,14 +3318,15 @@ export function buildBoardingPromptMessage(
   nextStation: string | null,
   etaSeconds: number | null,
   now: number,
+  locale?: SupportedLocale,
 ): { title: string; body: string } {
-  const title = 'Are you on board?';
-  if (!nextStation) {
-    return { title, body: `${line} · ${originStation}` };
-  }
-  const timeStr =
-    etaSeconds === null ? '' : ` ${toKstHhmm(now + etaSeconds * 1000)} 진입`;
-  return { title, body: `${originStation} [${line}] → ${nextStation} 방면${timeStr}` };
+  const strings = t(locale);
+  const etaTimeStr =
+    etaSeconds === null ? null : toKstHhmm(now + etaSeconds * 1000);
+  return {
+    title: strings.boardingPromptTitle,
+    body: strings.boardingPromptBody({ originStation, line, nextStation, etaTimeStr }),
+  };
 }
 
 /**
@@ -3441,6 +3447,7 @@ export async function evaluateAndMaybeFireBoardingPrompt(
     nextStation,
     etaSeconds,
     now,
+    trip.locale,
   );
 
   // 9단 통과 — alert push 발사.

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -222,6 +222,13 @@ export interface Trip {
    * 부재(레거시 trip / 신규 trip 첫 cycle 전) → undefined → device는 backfill 자연 skip.
    */
   passedStations?: string[];
+  /**
+   * #1895 — 사용자 device locale (ko / en / ja / zh). 디바이스 register 시점에 송신.
+   * backend는 push 본문 생성 시 `t(trip.locale)`로 4언어 분기한다. 부재/비지원이면 ko
+   * fallback (한국 운영 기본). 본 필드는 alert push(boarding-prompt) 본문 생성에만 사용 —
+   * silent push payload는 device-side i18n이 처리하므로 영향 없음.
+   */
+  locale?: 'ko' | 'en' | 'ja' | 'zh';
 }
 
 /**

--- a/src/features/alarm/api/__tests__/alarmBackend.test.ts
+++ b/src/features/alarm/api/__tests__/alarmBackend.test.ts
@@ -228,6 +228,38 @@ describe('alarmBackend', () => {
         expect(body.subsurface).toBeUndefined();
       });
 
+      it.each(['ko', 'en', 'ja', 'zh'] as const)(
+        '#1895 locale=%s 송신 시 body.locale에 포함',
+        async (locale) => {
+          await registerActiveTrip({ ...SAMPLE_PAYLOAD, locale });
+          const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+          expect(body.locale).toBe(locale);
+        },
+      );
+
+      it('#1895 locale 미지정이면 body에 미포함 (backend ko fallback)', async () => {
+        await registerActiveTrip(SAMPLE_PAYLOAD);
+        const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+        expect(body.locale).toBeUndefined();
+      });
+
+      it('#1895 locale 변경 시 hash 갱신 → 재등록', async () => {
+        const first = await registerActiveTrip({ ...SAMPLE_PAYLOAD, locale: 'ko' });
+        expect(first.ok).toBe(true);
+        const second = await registerActiveTrip({ ...SAMPLE_PAYLOAD, locale: 'en' });
+        expect(second).toEqual({ ok: true, status: 200 });
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        const secondBody = JSON.parse((global.fetch as jest.Mock).mock.calls[1][1].body);
+        expect(secondBody.locale).toBe('en');
+      });
+
+      it('#1895 동일 locale 재호출 시 dedup', async () => {
+        await registerActiveTrip({ ...SAMPLE_PAYLOAD, locale: 'ja' });
+        const dedup = await registerActiveTrip({ ...SAMPLE_PAYLOAD, locale: 'ja' });
+        expect(dedup).toEqual({ ok: true, skipped: true });
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+      });
+
       it('#701 in-flight dedup: 동일 페이로드 동시 호출 시 fetch는 1번만 발사된다', async () => {
         let resolveFetch: ((v: Response) => void) | null = null;
         (global.fetch as jest.Mock).mockImplementationOnce(

--- a/src/features/alarm/api/alarmBackend.ts
+++ b/src/features/alarm/api/alarmBackend.ts
@@ -106,6 +106,12 @@ export interface RegisterTripPayload {
    * false/미설정은 기존 동작 그대로 — 기압계 미지원/권한 거절 환경 graceful.
    */
   subsurface?: boolean;
+  /**
+   * #1895 — device locale (ko/en/ja/zh). backend가 boarding-prompt push 본문을
+   * 4언어 분기 (`backend/alarm-worker/src/i18n.ts`)에 사용한다. 미지정/비지원은
+   * backend가 ko로 fallback (한국 운영 기본). 디바이스 i18next.language 값을 그대로 송신.
+   */
+  locale?: 'ko' | 'en' | 'ja' | 'zh';
 }
 
 export interface AlarmBackendResult {
@@ -160,6 +166,7 @@ function buildRegisterHash(body: {
   boardingLock?: AlarmBoardingLock;
   promptDisplay?: { originStation: string; line: string };
   subsurface?: boolean;
+  locale?: 'ko' | 'en' | 'ja' | 'zh';
 }): string {
   return JSON.stringify({
     token: body.token,
@@ -182,6 +189,9 @@ function buildRegisterHash(body: {
     // #903 (Seam G) — subsurface 토글이 바뀌면 backend threshold가 즉시 갱신되도록 dedup 키 포함.
     // 빈번한 ON/OFF jitter는 useBarometer의 60s 윈도우 평가가 자체 흡수하므로 폭주 위험 낮음.
     subsurface: body.subsurface === true,
+    // #1895 — locale 전환 (사용자가 device 언어 변경 후 재등록) 시 즉시 backend로 propagate되도록 hash에 포함.
+    // 같은 trip 중 locale 변경 빈도는 낮으므로 폭주 위험 없음.
+    locale: body.locale ?? null,
   });
 }
 
@@ -245,6 +255,9 @@ async function performRegisterFetch(
     ...(payload.promptDisplay ? { promptDisplay: payload.promptDisplay } : {}),
     // #903 (Seam G) — 지하 진입 신호. ON일 때만 송신. backend는 부재 시 false default로 기존 threshold(5) 적용.
     ...(payload.subsurface === true ? { subsurface: true } : {}),
+    // #1895 — device locale. 송신 시 backend가 boarding-prompt 본문을 4언어 분기 (ko/en/ja/zh).
+    // 미송신 시 backend는 ko fallback.
+    ...(payload.locale ? { locale: payload.locale } : {}),
   };
 
   try {
@@ -292,6 +305,8 @@ export function registerActiveTrip(
     boardingLock: payload.boardingLock,
     promptDisplay: payload.promptDisplay,
     subsurface: payload.subsurface,
+    // #1895 — locale 변경 시 hash 갱신해 재등록 보장.
+    locale: payload.locale,
   });
   if (hash === lastRegisteredHash) {
     return Promise.resolve({ ok: true, skipped: true });

--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -48,6 +48,7 @@ jest.mock('../../../../shared/utils/logger', () => ({
 }));
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import i18next from 'i18next';
 import { useApnsTripRegistration } from '../useApnsTripRegistration';
 import type { Station } from '../../../../shared/types/station';
 import type { Route } from '../../../../shared/utils/stationRoute';
@@ -1017,6 +1018,53 @@ describe('useApnsTripRegistration', () => {
         (c) => (c[0] as { token: string }).token === 'token-NEW2',
       );
       expect(refreshed?.[0].subsurface).toBe(true);
+    });
+  });
+
+  describe('#1895 i18n locale 송신 (4언어 boarding-prompt)', () => {
+    const baseInputs = {
+      route: directRoute,
+      destination: station,
+      nextStationEtaSeconds: 120,
+    };
+
+    afterEach(async () => {
+      // i18next 전역 상태 복원 — 다른 describe 블록과 격리.
+      await i18next.changeLanguage('ko');
+    });
+
+    it.each(['ko', 'en', 'ja', 'zh'] as const)(
+      'i18next.language=%s → registerActiveTrip payload.locale에 동일 값 송신',
+      async (lang) => {
+        await i18next.changeLanguage(lang);
+        renderHook(() => useApnsTripRegistration(baseInputs));
+        await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+        expect(mockRegister.mock.calls[0][0].locale).toBe(lang);
+      },
+    );
+
+    it('i18next.language=비지원 string (fallbackLng 미작동 강제) → payload.locale 미포함', async () => {
+      // 실제 production에서 i18next는 fallbackLng='en'으로 비지원 locale을 'en'으로 떨어뜨린다.
+      // 본 테스트는 resolveLocaleForBackend()의 strict guard만 검증 — i18next 내부 fallback 동작과
+      // 무관하게 비지원 코드 그 자체가 들어왔을 때 undefined 반환하는지 본다. 직접 language 필드를
+      // override해 i18next의 fallback 동작을 우회한다.
+      const original = i18next.language;
+      Object.defineProperty(i18next, 'language', {
+        value: 'fr',
+        writable: true,
+        configurable: true,
+      });
+      try {
+        renderHook(() => useApnsTripRegistration(baseInputs));
+        await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+        expect(mockRegister.mock.calls[0][0].locale).toBeUndefined();
+      } finally {
+        Object.defineProperty(i18next, 'language', {
+          value: original,
+          writable: true,
+          configurable: true,
+        });
+      }
     });
   });
 

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -19,6 +19,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import * as Notifications from 'expo-notifications';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import i18next from 'i18next';
 import type { Station } from '../../../shared/types/station';
 import type { Route } from '../../../shared/utils/stationRoute';
 import { routeSignature, getStationById } from '../../../shared/utils/stationRoute';
@@ -34,6 +35,17 @@ import { BOARDING_LOCK_RELEASE_DEBOUNCE_MS } from '../../../shared/constants/boa
 import { createLogger } from '../../../shared/utils/logger';
 import { resolveApnsEnv } from '../../../shared/utils/apnsEnv';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
+
+/**
+ * #1895 — i18next.language를 backend가 인식하는 SupportedLocale로 정규화.
+ * SUPPORTED_LANGUAGES (`src/shared/i18n/types.ts`)와 1:1 매핑. 미지원/undefined는 backend가
+ * ko fallback 처리하므로 송신 자체를 skip해 트래픽 절약 (graceful — payload 미포함).
+ */
+function resolveLocaleForBackend(): 'ko' | 'en' | 'ja' | 'zh' | undefined {
+  const lang = i18next.language;
+  if (lang === 'ko' || lang === 'en' || lang === 'ja' || lang === 'zh') return lang;
+  return undefined;
+}
 
 const logger = createLogger('ApnsTripRegistration');
 
@@ -158,6 +170,10 @@ async function callRegister(input: RegisterCallInputs) {
   });
   const promptContext = freshContext ?? input.cachedPromptContext;
 
+  // #1895 — i18next.language를 backend가 인식하는 SupportedLocale로 정규화.
+  // backend는 미송신 시 ko fallback이므로 비지원 locale은 송신 자체 skip.
+  const locale = resolveLocaleForBackend();
+
   return registerActiveTrip({
     token: input.token,
     route: input.route,
@@ -176,6 +192,8 @@ async function callRegister(input: RegisterCallInputs) {
       : {}),
     // #903 (Seam G) — 기압계 subsurface ON일 때만 송신. OFF/false는 필드 누락(graceful).
     ...(input.subsurface ? { subsurface: true } : {}),
+    // #1895 — device locale (boarding-prompt push 본문 4언어 분기용). 미지원 locale은 송신 skip.
+    ...(locale ? { locale } : {}),
   });
 }
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -451,15 +451,29 @@ export default function HomeScreen() {
   const originVariants = !isCustomOrigin && variants.length > 1 ? variants : effectiveOrigin ? [effectiveOrigin] : [];
   const variantIds = originVariants.map((v) => v.id).join(',');
 
+  // #1883 (RC-11) — 마지막으로 route를 계산한 trip session id (`${destinationId}|${routePreference}`).
+  // trip session이 같으면 effectiveOrigin / variants 갱신으로 인한 mid-trip route mutation을 차단.
+  // 사용자가 destination 또는 routePreference를 명시적으로 바꾸면 다른 session id가 되어 가드 통과.
+  const lastComputedRouteSessionRef = useRef<string | null>(null);
   useEffect(() => {
     // #1379: destination 종료(=실제 trip 종료)일 때만 ROUTE_KEY removeItem.
     // effectiveOrigin null은 GPS 일시 누락일 수 있으므로 storage는 보존하고 계산만 skip한다.
     if (!destination) {
       setCategorized([]);
+      lastComputedRouteSessionRef.current = null;
       AsyncStorage.removeItem(ROUTE_KEY).catch(() => {});
       return;
     }
     if (!effectiveOrigin) {
+      return;
+    }
+    // #1883 (RC-11) — mid-trip route mutation 차단 (사용자 paradigm 2).
+    // trip이 시작된 후(이 session id로 이미 1회 계산 완료) effectiveOrigin 변화 / variants
+    // 갱신으로 route를 재계산하면 환승역이 바뀌어 "건대입구 → 군자" 같은 회귀가 발생한다.
+    // session id(`destinationId|routePreference`)가 동일하면 route는 freeze — 사용자 명시
+    // destination 또는 routePreference 변경 시에만 재계산. lockless / lock 활성 둘 다 동일 보호.
+    const sessionKey = `${destination.id}|${routePreference}`;
+    if (lastComputedRouteSessionRef.current === sessionKey) {
       return;
     }
     const interactionStart = performance.now();
@@ -474,6 +488,7 @@ export default function HomeScreen() {
       const preferred = result.find((r) => r.category.key === routePreference) ?? result[0];
       if (preferred) {
         setSelectedKey(preferred.category.key);
+        lastComputedRouteSessionRef.current = sessionKey;
         AsyncStorage.setItem(ROUTE_KEY, JSON.stringify(preferred.candidate.route)).catch(() => {});
       } else {
         AsyncStorage.removeItem(ROUTE_KEY).catch(() => {});


### PR DESCRIPTION
## 요약
- RC-11 (#1883): paradigm 2 — trip 시작 후 mid-trip route mutation 차단 (session-stamped freeze + 사용자 명시 destination/routePreference 변경 시에만 재계산)
- RC-16 (#1895): paradigm 6 — push 본문 4언어 (ko/en/ja/zh) device locale 분기

## 변경 범위
- **frontend**:
  - `src/screens/HomeScreen.tsx` — route useEffect에 `lastComputedRouteSessionRef` 추가, session key `${destination.id}|${routePreference}`로 mid-trip mutation 차단
  - `src/features/alarm/api/alarmBackend.ts` — RegisterTripPayload에 `locale` 추가, buildRegisterHash + performRegisterFetch가 locale propagate
  - `src/features/alarm/hooks/useApnsTripRegistration.ts` — `resolveLocaleForBackend()`가 i18next.language를 SupportedLocale로 정규화, 비지원 locale은 송신 skip (backend ko fallback)
- **backend**:
  - `backend/alarm-worker/src/i18n.ts` — **신규**. 4언어 string table + `t()` lookup + `normalizeLocale()`
  - `backend/alarm-worker/src/scheduled.ts` — `buildBoardingPromptMessage`가 locale 파라미터 받아 4언어 분기, `evaluateAndMaybeFireBoardingPrompt`가 `trip.locale` 전달
  - `backend/alarm-worker/src/index.ts` — `validateTrip`이 ko/en/ja/zh strict parse, 비지원/누락은 undefined로 graceful skip
  - `backend/alarm-worker/src/types.ts` — Trip type에 `locale?: 'ko' | 'en' | 'ja' | 'zh'` 추가
  - `backend/alarm-worker/src/alertContent.ts` — 주석 갱신 (silent push fallback 본문은 device i18n과 byte-identical 유지 정책 명시)

## Test 검증
- frontend: 388 suites / 8042 tests pass, **100% coverage** (lines/functions/branches/statements)
- backend: 60 suites / 2236 tests pass
- 신규 backend `i18n.test.ts` 29 tests (normalize fallback + 4언어 boardingPrompt title/body 분기 + nextStation null fallback)
- 신규 frontend `alarmBackend.test.ts` 6 tests (locale 4언어 송신 + 미지정 → 미포함 + 변경 시 재등록 + 동일 dedup)
- 신규 frontend `useApnsTripRegistration.test.ts` 5 tests (i18next 4언어 propagate + 비지원 → 송신 skip)
- 갱신 backend `scheduled.test.ts` 6 tests (boardingPrompt ko 기본 + en/ja/zh/locale 명시/undefined fallback)
- `npm run type-check` (frontend + backend) clean, `npm run lint:orphan` 0 orphan

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard** — Sentry breadcrumb `mid_trip_mutation_reject` count (사용자 명시 변경 vs auto mutation 분리) + backend wrangler tail의 push locale 분포 (ko/en/ja/zh 발화 비율)
3. **의존 PR** — backend wrangler deploy 필요 (사용자가 직접 `wrangler deploy alarm-worker` — i18n.ts 신규 + Trip schema locale 필드 + buildBoardingPromptMessage 시그니처)
4. **측정 plan** — 1주 production:
   - mid_trip_mutation_reject 0건이지만 trip active 중 ROUTE_KEY rewrite 0건 → RC-11 작동
   - push locale 분포 (ko ≫ en/ja/zh): 비-ko locale 발화 확인 → RC-16 작동
   - Day 3 T3 시나리오 (충정로→용마산 lockless) 재현 → 환승역 변경 0건
5. **Device verify** — paradigm 2 시나리오:
   - T3 환승역 변경 시도 (effectiveOrigin 변화) → ROUTE_KEY 불변
   - device locale 4개 (ko/en/ja/zh) 모두 iOS Settings → General → Language & Region 변경 후 push 본문 확인

Closes #1883
Closes #1895