### PR TITLE
fix(#1901): silent push channel-agnostic dedup + RC-10a/RC-17

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -86,6 +86,8 @@ const mockLogSuppressedPassedEventOnLockOrigin = jest.fn();
 const mockLogSuppressedCrossCategoryDedup = jest.fn();
 const mockLogSuppressedCrossCategoryRecent = jest.fn();
 const mockLogSuppressedPhaseToPhaseDedup = jest.fn();
+const mockLogSuppressedChannelAgnosticDedup = jest.fn();
+const mockLogFiredAlarmsTripBoundaryReset = jest.fn();
 const mockLogSuppressedSsotFireGate = jest.fn();
 const mockLogSuppressedLocklessNoUserIntent = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
@@ -118,10 +120,22 @@ jest.mock('../../utils/alarmLog', () => ({
     mockLogSuppressedCrossCategoryRecent(...args),
   logSuppressedPhaseToPhaseDedup: (...args: unknown[]) =>
     mockLogSuppressedPhaseToPhaseDedup(...args),
+  logSuppressedChannelAgnosticDedup: (...args: unknown[]) =>
+    mockLogSuppressedChannelAgnosticDedup(...args),
+  logFiredAlarmsTripBoundaryReset: (...args: unknown[]) =>
+    mockLogFiredAlarmsTripBoundaryReset(...args),
   logSuppressedSsotFireGate: (...args: unknown[]) =>
     mockLogSuppressedSsotFireGate(...args),
   logSuppressedLocklessNoUserIntent: (...args: unknown[]) =>
     mockLogSuppressedLocklessNoUserIntent(...args),
+}));
+
+// #1893 (RC-17) — trip-boundary detection effect는 tripStartedAt storage를 read한다.
+// 기본: null (trip 미시작) — destination polling cycle에서 reset 시도 skip.
+// 개별 테스트는 mockGetTripStartedAt.mockResolvedValue(<epoch>)로 override.
+const mockGetTripStartedAt = jest.fn().mockResolvedValue(null);
+jest.mock('../../utils/tripStartStorage', () => ({
+  getTripStartedAt: () => mockGetTripStartedAt(),
 }));
 
 // #1572 (T9) — evaluateSsotFireGate mock. 기본 no-block (mirror-missing graceful).
@@ -847,6 +861,66 @@ describe('useStationAlarm', () => {
     expect(mockSendAlarmNotification).not.toHaveBeenCalled();
   });
 
+  it('#1901/#1900 channel-agnostic dedup — 같은 station + 같은 phase 8분 안 재발사는 차단', async () => {
+    // 2026-06-26 trip-3 동대문역사문화공원 evidence: silent state push + LA dirty update의
+    // cross-channel 중복(8m 14s 차)이 위 cross-category gates(30s/5s/3s) 모두 통과시킴 →
+    // channel-agnostic 8분 backstop만 차단. 본 테스트는 5분(=cross-cat 30s window 만료, 8분 backstop만 활성)
+    // 후 같은 station + 같은 phase 재발사 시도가 차단되는지 검증.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const dedup = require('../../utils/crossCategoryStationDedup');
+    const route = makeDirectRoute(1, '2');
+    const baseTime = 1_000_000;
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseTime);
+    // 직전 같은 station에 destination + early phase fire 시뮬레이션 (t=baseTime).
+    dedup.markStationFired(destination.id, earlyDest.stationName, 'destination', baseTime, 'early');
+    // 5분 후 — cross-cat 30s, trip-scoped 5s, phase-to-phase 3s 모두 만료. 8분 backstop만 활성.
+    nowSpy.mockReturnValue(baseTime + 5 * 60_000);
+
+    // 같은 station + 같은 phase(early) 재발사 시도. firedAlarms set 비어 있으면 진입부 add 후
+    // 8분 backstop에서 차단되어 delete 복구.
+    mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+    renderHook(() =>
+      useStationAlarm(
+        defaultInputs({ route, destination, userLocation: { lat: 37.4, lng: 127 }, speedMps: 5 }),
+      ),
+    );
+    await waitFor(() =>
+      expect(mockLogSuppressedChannelAgnosticDedup).toHaveBeenCalledWith({
+        source: 'fg',
+        stationName: earlyDest.stationName,
+        kind: 'destination',
+        phaseId: 'early',
+      }),
+    );
+    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    nowSpy.mockRestore();
+  });
+
+  it('#1901/#1900 channel-agnostic dedup — 다른 phaseId(early→imminent)는 정상 진행이라 통과', async () => {
+    // early destination 발사 후 imminent destination 진행은 정상이어야 함. backstop은 같은 phase
+    // 매칭 시에만 차단.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const dedup = require('../../utils/crossCategoryStationDedup');
+    const route = makeDirectRoute(1, '2');
+    const baseTime = 1_000_000;
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseTime);
+    dedup.markStationFired(destination.id, earlyDest.stationName, 'destination', baseTime, 'early');
+    // 5분 후 — cross-cat gate 만료, 8분 backstop만 활성. imminent로 진행 시도.
+    nowSpy.mockReturnValue(baseTime + 5 * 60_000);
+
+    mockEvaluateAlarmPhase.mockReturnValue(imminentDest);
+    renderHook(() =>
+      useStationAlarm(
+        defaultInputs({ route, destination, userLocation: { lat: 37.4, lng: 127 }, speedMps: 5 }),
+      ),
+    );
+    await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+    // imminent 정상 발사. channel-agnostic backstop이 잘못 차단하지 않음.
+    expect(mockSendAlarmNotification).toHaveBeenCalledWith(imminentDest, false, true, undefined);
+    expect(mockLogSuppressedChannelAgnosticDedup).not.toHaveBeenCalled();
+    nowSpy.mockRestore();
+  });
+
   it('destination 변경 시 새 destinationId로 re-hydrate 한다 (#462 destination scoped)', async () => {
     const route = makeDirectRoute(1, '2');
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
@@ -1464,6 +1538,125 @@ describe('useStationAlarm', () => {
 
       releaseHydration!();
       await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
+    });
+  });
+
+  // #1893 (RC-17) — firedAlarmsRef trip-boundary detection effect.
+  // 같은 destinationId로 trip 재시작 시(=목적지 그대로 두고 새 출발) hydration effect는 재실행되지
+  // 않는다. tripStartedAt이 ref stamp와 다르면 in-memory Set을 명시적으로 비우고 로그 1건 적재.
+  describe('#1893 firedAlarmsRef trip-boundary reset', () => {
+    const route = makeDirectRoute(1, '2');
+
+    it('tripStartedAt이 ref와 다르면 in-memory Set reset + 로그 1건 적재', async () => {
+      mockGetFiredAlarms.mockResolvedValue(new Set());
+      // 첫 hydration 시 tripStartedAt = 1_000_000 → ref에 stamp.
+      mockGetTripStartedAt.mockResolvedValueOnce(1_000_000);
+      // 첫 polling effect run (mount 시) — 같은 1_000_000 → ref stamp 후 비교 skip.
+      mockGetTripStartedAt.mockResolvedValueOnce(1_000_000);
+      // destinationArrival 변경으로 polling re-trigger 시 새 trip 2_000_000.
+      mockGetTripStartedAt.mockResolvedValueOnce(2_000_000);
+
+      const { rerender } = renderHook(
+        ({ inputs }: { inputs: UseStationAlarmInputs }) => useStationAlarm(inputs),
+        { initialProps: { inputs: defaultInputs({ route, destination }) } },
+      );
+
+      // hydration 완료 + 첫 ref stamp.
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+
+      // destinationArrival 변경(useArrivalInfo가 새 arrival 반환) → polling effect 재실행.
+      mockUseArrivalInfo.mockReturnValue({
+        arrival: { stationName: '강남', line: '2' as const, arrivals: [] },
+        loading: false,
+        isMock: false,
+      });
+      rerender({ inputs: defaultInputs({ route, destination, speedMps: 1 }) });
+
+      await waitFor(() =>
+        expect(mockLogFiredAlarmsTripBoundaryReset).toHaveBeenCalledWith({
+          source: 'fg',
+          destinationId: destination.id,
+          previousTripStartedAt: 1_000_000,
+          nextTripStartedAt: 2_000_000,
+        }),
+      );
+    });
+
+    it('tripStartedAt이 ref와 같으면 reset skip (정상 동일 trip 진행)', async () => {
+      mockGetFiredAlarms.mockResolvedValue(new Set());
+      // hydration과 polling 모두 같은 epoch.
+      mockGetTripStartedAt.mockResolvedValue(1_000_000);
+
+      const { rerender } = renderHook(
+        ({ inputs }: { inputs: UseStationAlarmInputs }) => useStationAlarm(inputs),
+        { initialProps: { inputs: defaultInputs({ route, destination }) } },
+      );
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+
+      mockUseArrivalInfo.mockReturnValue({
+        arrival: { stationName: '강남', line: '2' as const, arrivals: [] },
+        loading: false,
+        isMock: false,
+      });
+      rerender({ inputs: defaultInputs({ route, destination, speedMps: 1 }) });
+
+      await new Promise((r) => setImmediate(r));
+      expect(mockLogFiredAlarmsTripBoundaryReset).not.toHaveBeenCalled();
+    });
+
+    it('tripStartedAt=null(trip 종료) 분기에선 reset skip', async () => {
+      mockGetFiredAlarms.mockResolvedValue(new Set());
+      // 첫 hydration: ref에 1_000_000 stamp.
+      mockGetTripStartedAt.mockResolvedValueOnce(1_000_000);
+      // 첫 polling: hydration 미완료 OR same epoch (race graceful) — same epoch로 return.
+      mockGetTripStartedAt.mockResolvedValueOnce(1_000_000);
+      // re-trigger: trip 종료 → null → reset skip.
+      mockGetTripStartedAt.mockResolvedValueOnce(null);
+
+      const { rerender } = renderHook(
+        ({ inputs }: { inputs: UseStationAlarmInputs }) => useStationAlarm(inputs),
+        { initialProps: { inputs: defaultInputs({ route, destination }) } },
+      );
+      await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
+      mockUseArrivalInfo.mockReturnValue({
+        arrival: { stationName: '강남', line: '2' as const, arrivals: [] },
+        loading: false,
+        isMock: false,
+      });
+      rerender({ inputs: defaultInputs({ route, destination, speedMps: 1 }) });
+
+      await new Promise((r) => setImmediate(r));
+      expect(mockLogFiredAlarmsTripBoundaryReset).not.toHaveBeenCalled();
+    });
+
+    it('destinationId=null 분기에선 polling effect 자체가 skip', async () => {
+      // destination 없음 → effect early return.
+      mockGetTripStartedAt.mockResolvedValue(1_000_000);
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination: null })));
+
+      await new Promise((r) => setImmediate(r));
+      expect(mockLogFiredAlarmsTripBoundaryReset).not.toHaveBeenCalled();
+    });
+
+    it('hydration ref가 아직 null이면 polling effect는 reset skip (race graceful)', async () => {
+      mockGetFiredAlarms.mockResolvedValue(new Set());
+      // hydration은 늦게 끝나도록 — getTripStartedAt 첫 호출은 pending.
+      let releaseHydration: ((v: number | null) => void) | undefined;
+      mockGetTripStartedAt.mockReturnValueOnce(
+        new Promise<number | null>((resolve) => {
+          releaseHydration = resolve;
+        }),
+      );
+      // polling effect는 즉시 returns 2_000_000(but ref still null).
+      mockGetTripStartedAt.mockResolvedValueOnce(2_000_000);
+
+      renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
+
+      // polling effect는 ref=null 보고 return.
+      await new Promise((r) => setImmediate(r));
+      expect(mockLogFiredAlarmsTripBoundaryReset).not.toHaveBeenCalled();
+      // hydration 풀어줘서 cleanup.
+      releaseHydration!(1_000_000);
     });
   });
 

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -33,12 +33,15 @@ import {
   setFiredAlarms,
 } from '../utils/notificationState';
 import { awaitInitialScheduledAlarmDrain } from '../utils/scheduledAlarmReceiver';
+import { getTripStartedAt } from '../utils/tripStartStorage';
 import {
   logFiredAlarm,
   logFiredAlarmsHydrate,
+  logFiredAlarmsTripBoundaryReset,
   logFiredStationPassed,
   logHydrationTransition,
   logRefMismatch,
+  logSuppressedChannelAgnosticDedup,
   logSuppressedCrossCategoryDedup,
   logSuppressedCrossCategoryRecent,
   logSuppressedPhaseToPhaseDedup,
@@ -58,6 +61,7 @@ import {
 } from '../utils/alarmLog';
 import { evaluateSsotFireGate } from '../utils/ssotFireGate';
 import {
+  isAnyChannelRecentlyFired,
   isStationRecentlyFired,
   isPhaseToPhaseCrossStationRecentlyFired,
   isTripScopedCrossCategoryRecentlyFired,
@@ -512,6 +516,13 @@ export function useStationAlarm({
   // 클로저로 진입한다. ref id가 현재 destinationId와 다르면 stale state — phase 평가를 보류해
   // 옛 ref로 새 destination에 잘못된 알람을 발사하는 race를 차단한다.
   const firedAlarmsRefDestIdRef = useRef<string | null>(null);
+  // #1893 (RC-17) — firedAlarmsRef 내용이 어느 trip(tripStartedAt epoch ms)에 속하는지 추적.
+  // 같은 destinationId로 trip 재시작 시(destinationId 변경 없음) 기존 destination hydrate
+  // effect는 재실행되지 않아 in-memory Set이 이전 trip의 fired key를 보존하던 회귀(2026-06-26
+  // T4 dump에 T3 fired 2건 carry-over). destination polling cycle(`destinationArrival` 30s)에서
+  // tripStartedAt 변동을 감지해 명시적 reset + alarmLog 적재한다. backend trip-ended cleanup이
+  // storage(FIRED_ALARMS_KEY)를 비우는 시점과 1:1 매칭.
+  const firedAlarmsRefTripStartedAtRef = useRef<number | null>(null);
   // #1010/#1316: 하이드레이션 완료 시각(ms). null이면 미완료.
   // warmup window(HYDRATE_WARMUP_MS) 동안 station-passed effect(#1010)와 phase 알람 effect(#1316)가
   // 즉시 차단된다. #1316 — phase 알람은 기존 isFirstAlarmEvalRef 단발 suppress(첫 eval만 차단)였으나,
@@ -617,6 +628,9 @@ export function useStationAlarm({
       if (cancelled) return;
       firedAlarmsRef.current = stored;
       firedAlarmsRefDestIdRef.current = destinationId;
+      // #1893 (RC-17) — hydration 시점의 tripStartedAt을 ref에 stamp. 이후 destinationArrival
+      // polling effect(아래)가 storage tripStartedAt과 비교해 같은 destinationId 재시작을 감지한다.
+      firedAlarmsRefTripStartedAtRef.current = await getTripStartedAt();
       // #580: hydration 시점 진단 — 같은 destinationId에서 size가 다시 0으로 떨어지면 storage race.
       logFiredAlarmsHydrate(destinationId, stored.size);
       // #1010/#1316: warmup 시작 — 하이드레이션 완료 시각 기록. station-passed/phase 알람 effect 공용.
@@ -629,6 +643,45 @@ export function useStationAlarm({
       cancelled = true;
     };
   }, [destinationId]);
+
+  // #1893 (RC-17) — trip 경계 detection + firedAlarmsRef in-memory Set reset.
+  //
+  // 같은 destinationId로 trip을 재시작한 경우(=목적지는 그대로 두고 새 출발) 위 hydration effect가
+  // 재실행되지 않아 React `firedAlarmsRef.current`는 이전 trip의 fired key를 보존한다. backend가
+  // trip-ended 시 storage(FIRED_ALARMS_KEY)는 비워지지만 in-memory ref와 storage가 unsync → 다음
+  // fire가 dedup으로 차단되거나 DebugModal dump가 cross-trip carry-over로 오염 (2026-06-26 T4
+  // dump L75-76에 T3 시각 fired 2건 carry-over evidence).
+  //
+  // destination polling cycle(`destinationArrival` 30s)에 hook해 storage tripStartedAt을 read,
+  // ref에 stamp한 epoch와 다르면 in-memory Set을 명시적으로 비우고 alarmLog 1건 적재. 동일 trip 안
+  // (epoch 동일)에서는 no-op — 정상 fire 흐름에 영향 0. destinationId 변경 분기는 위 hydration effect
+  // 가 hydrate 시점에 tripStartedAt도 함께 stamp하므로 중복 reset 발생 X.
+  useEffect(() => {
+    if (!destinationId) return;
+    let cancelled = false;
+    void (async () => {
+      const currentTripStartedAt = await getTripStartedAt();
+      if (cancelled) return;
+      // hydration effect가 ref에 stamp한 시점과 비교. ref가 null이면 hydration 미완료 — skip.
+      const prevTripStartedAt = firedAlarmsRefTripStartedAtRef.current;
+      if (prevTripStartedAt === null) return;
+      // 같은 trip(epoch 동일) 또는 trip 종료(currentTripStartedAt === null) → 후자는 hydration effect의
+      // destinationId=null 분기가 자연 처리. epoch가 다를 때만 새 trip 시작 → reset.
+      if (currentTripStartedAt === null) return;
+      if (currentTripStartedAt === prevTripStartedAt) return;
+      firedAlarmsRef.current = new Set();
+      firedAlarmsRefTripStartedAtRef.current = currentTripStartedAt;
+      logFiredAlarmsTripBoundaryReset({
+        source: 'fg',
+        destinationId,
+        previousTripStartedAt: prevTripStartedAt,
+        nextTripStartedAt: currentTripStartedAt,
+      });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [destinationId, destinationArrival]);
 
   // 알람 발사 + 로깅 헬퍼. ETA effect와 API 신호 effect가 동일 시퀀스를 수행하므로 통합.
   // route/destination은 호출자가 가드 후 non-null로 전달 — 함수 내부 가드 중복 제거.
@@ -754,6 +807,31 @@ export function useStationAlarm({
       });
       return;
     }
+    // #1901/#1900 (RC-7/RC-10a) — channel-agnostic 8분 backstop. 위 cross-category gates는
+    // window가 짧거나(30s/5s/3s) phase↔SP 같은 cross-category 조합만 cover한다. silent state push +
+    // LA dirty update가 같은 station + 같은 kind를 8분 차로 cross-channel 발사하는 회귀(2026-06-26
+    // trip-3 동대문역사문화공원 12:17:58/12:26:12)는 윈도우 밖. 본 게이트는 station+kind level fire
+    // 자체를 8분 안에 단 1회만 통과시킨다 — channel(silent/FG/LA) 무관 backstop. 다른 kind는
+    // cross-category gate(30s)가 별도 차단. 같은 kind 안의 phase 진행(early→imminent)은 본 gate
+    // 가 차단할 수 있지만, 회귀 evidence는 정확히 같은 kind 중복이라 acceptance와 정합.
+    if (
+      isAnyChannelRecentlyFired(
+        activeDestination.id,
+        rawEvent.stationName,
+        rawEvent.type,
+        Date.now(),
+        rawEvent.phaseId,
+      )
+    ) {
+      firedAlarmsRef.current.delete(key);
+      logSuppressedChannelAgnosticDedup({
+        source: 'fg',
+        stationName: rawEvent.stationName,
+        kind: rawEvent.type,
+        phaseId: rawEvent.phaseId,
+      });
+      return;
+    }
     // #1572 (T9) — backend SSoT 권위 게이트 (Path D fireAndLog phase ETA / imminent).
     // AlarmEvent.type은 'transfer' | 'destination'만 (station-passed는 별도 effect).
     // Gate A(alarmId 매칭)만 적용 — transfer/destination은 환승역에서 같은 station이 여러 hop을
@@ -778,8 +856,15 @@ export function useStationAlarm({
       return;
     }
     // race 차단 reservation — send 전에 윈도우 갱신해 await 동안 다른 effect가 같은 station을 발사
-    // 못하게 한다. category=phase type → 후속 station-passed 차단.
-    markStationFired(activeDestination.id, rawEvent.stationName, rawEvent.type, Date.now());
+    // 못하게 한다. category=phase type → 후속 station-passed 차단. #1901 — phaseId도 stamp해
+    // channel-agnostic 8분 backstop이 정상 phase 진행(early→imminent)을 통과시킬 수 있도록 한다.
+    markStationFired(
+      activeDestination.id,
+      rawEvent.stationName,
+      rawEvent.type,
+      Date.now(),
+      rawEvent.phaseId,
+    );
     // 좌/우 안내 방향. nearestStation 미정이면 direction 미부착(본문에 좌/우 라인 생략).
     const direction = nearestStation
       ? resolveAlarmDirection(rawEvent, {

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -38,6 +38,7 @@ const mockLogSilentPushTripEndedReceived = jest.fn();
 const mockLogSilentPushFired = jest.fn();
 const mockLogSilentPushSkipped = jest.fn();
 const mockLogCrossTripMirrorSkip = jest.fn();
+const mockLogSuppressedChannelAgnosticDedup = jest.fn();
 const mockFlushAlarmLog = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../utils/alarmLog', () => ({
   logSilentPushReceived: (...args: unknown[]) => mockLogSilentPushReceived(...args),
@@ -48,7 +49,19 @@ jest.mock('../../utils/alarmLog', () => ({
   logSilentPushFired: (...args: unknown[]) => mockLogSilentPushFired(...args),
   logSilentPushSkipped: (...args: unknown[]) => mockLogSilentPushSkipped(...args),
   logCrossTripMirrorSkip: (...args: unknown[]) => mockLogCrossTripMirrorSkip(...args),
+  logSuppressedChannelAgnosticDedup: (...args: unknown[]) =>
+    mockLogSuppressedChannelAgnosticDedup(...args),
   flushAlarmLog: () => mockFlushAlarmLog(),
+}));
+
+// #1901/#1900 (RC-7/RC-10a) — channel-agnostic 8분 backstop. silent push fire 직전 gate +
+// fire 직후 markStationFired. FG fireAndLog / stationPipeline과 lastFire Map 공유.
+const mockIsAnyChannelRecentlyFired = jest.fn<boolean, unknown[]>(() => false);
+const mockMarkStationFired = jest.fn<void, unknown[]>();
+jest.mock('../../utils/crossCategoryStationDedup', () => ({
+  isAnyChannelRecentlyFired: (...args: unknown[]) =>
+    mockIsAnyChannelRecentlyFired(...args),
+  markStationFired: (...args: unknown[]) => mockMarkStationFired(...args),
 }));
 
 // #868 — trip-ended payload 수신 시 trip-bound storage cleanup.
@@ -1630,6 +1643,121 @@ describe('silentPushTask', () => {
           reason: 'dedup-already-fired',
           permissionMode: 'always',
         });
+      });
+
+      // #1901/#1900 (RC-7/RC-10a) — channel-agnostic 8분 backstop. FIRED_ALARMS dedup이 통과해도
+      // lastFire Map에 같은 station이 8분 안에 적재돼 있으면 silent push 발사 차단.
+      // backend가 같은 station-pass 1건에 silent state push + LA dirty update 2채널 발사 →
+      // device가 silent push로 같은 station을 2회 받는 회귀(2026-06-26 trip-3 동대문역사문화공원).
+      it('#1901/#1900 isAnyChannelRecentlyFired=true 시 silent push 발사 차단 + skipped ack', async () => {
+        mockGetFiredAlarms.mockResolvedValue(new Set()); // FIRED_ALARMS는 비어 있음
+        mockIsAnyChannelRecentlyFired.mockReturnValueOnce(true);
+        await handleSilentPush(
+          payload({
+            kind: 'destination',
+            phase: 'imminent',
+            pushId: 'p-channel-agnostic',
+          }),
+        );
+        expect(mockLogSuppressedChannelAgnosticDedup).toHaveBeenCalledWith({
+          source: 'silent-push-skipped',
+          stationName: '강남',
+          kind: 'destination',
+          phaseId: 'imminent',
+        });
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          ackCall('p-channel-agnostic', 'skipped', 'dedup-already-fired'),
+        );
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        // markStationFired는 fire 직후에만 호출 — skip 분기에서 호출 안 됨.
+        expect(mockMarkStationFired).not.toHaveBeenCalled();
+      });
+
+      // #1901/#1900 — intermediate(station-passed) 분기도 channel-agnostic gate 적용.
+      // FIRED_ALARMS dedup은 dedupKey=null이라 우회되지만 8분 backstop은 차단.
+      it('#1901/#1900 intermediate kind도 channel-agnostic gate로 차단됨', async () => {
+        mockGetFiredAlarms.mockResolvedValue(new Set());
+        mockIsAnyChannelRecentlyFired.mockReturnValueOnce(true);
+        await handleSilentPush(
+          payload({
+            kind: 'intermediate',
+            phase: 'imminent',
+            pushId: 'p-intermediate-agnostic',
+          }),
+        );
+        expect(mockLogSuppressedChannelAgnosticDedup).toHaveBeenCalledWith({
+          source: 'silent-push-skipped',
+          stationName: '강남',
+          kind: 'station-passed',
+          phaseId: 'imminent',
+        });
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          ackCall('p-intermediate-agnostic', 'skipped', 'dedup-already-fired'),
+        );
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockMarkStationFired).not.toHaveBeenCalled();
+      });
+
+      // #1901/#1900 — channel-agnostic dedup skip branch에서 pushId 미정의 케이스. addFiredPushId
+      // 조건부 호출의 falsy 분기 커버.
+      it('#1901/#1900 channel-agnostic skip + pushId 부재 시 addFiredPushId 미호출', async () => {
+        mockGetFiredAlarms.mockResolvedValue(new Set());
+        mockIsAnyChannelRecentlyFired.mockReturnValueOnce(true);
+        await handleSilentPush(
+          payload({
+            kind: 'destination',
+            phase: 'imminent',
+            // pushId 명시 안 함 — undefined.
+          }),
+        );
+        expect(mockLogSuppressedChannelAgnosticDedup).toHaveBeenCalled();
+        // pushId 부재라 addFiredPushId 미호출 검증.
+        expect(mockAddFiredPushId).not.toHaveBeenCalled();
+      });
+
+      // #1901/#1900 — fire 직후 markStationFired 호출 → FG fireAndLog / stationPipeline이 같은
+      // station 8분 backstop으로 cross-channel 중복 차단 (lastFire Map 공유).
+      it('#1901/#1900 fire 후 markStationFired 호출 (lastFire Map 갱신)', async () => {
+        mockGetFiredAlarms.mockResolvedValue(new Set());
+        mockIsAnyChannelRecentlyFired.mockReturnValueOnce(false);
+        await handleSilentPush(
+          payload({
+            kind: 'destination',
+            phase: 'imminent',
+            pushId: 'p-mark',
+          }),
+        );
+        // intermediate가 아닌 destination → category='destination'으로 mark. phaseId도 stamp.
+        expect(mockMarkStationFired).toHaveBeenCalledWith(
+          destStation.id,
+          '강남',
+          'destination',
+          expect.any(Number),
+          'imminent',
+        );
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          ackCall('p-mark', 'fired'),
+        );
+      });
+
+      // #1901/#1900 — intermediate fire는 'station-passed' category로 mark.
+      it('#1901/#1900 intermediate fire 후 markStationFired는 station-passed category로 호출', async () => {
+        mockGetFiredAlarms.mockResolvedValue(new Set());
+        mockIsAnyChannelRecentlyFired.mockReturnValueOnce(false);
+        await handleSilentPush(
+          payload({
+            kind: 'intermediate',
+            phase: 'imminent',
+            pushId: 'p-intermediate-mark',
+          }),
+        );
+        expect(mockMarkStationFired).toHaveBeenCalledWith(
+          destStation.id,
+          '강남',
+          'station-passed',
+          expect.any(Number),
+          'imminent',
+        );
       });
 
       it('payload-missing-kind 시 sendPushAck(outcome=skipped, reason=payload-missing-kind)', async () => {

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -50,8 +50,13 @@ import {
   logSilentPushTripEndedReceived,
   logSilentPushFired,
   logSilentPushSkipped,
+  logSuppressedChannelAgnosticDedup,
   type AlarmLogReason,
 } from '../utils/alarmLog';
+import {
+  isAnyChannelRecentlyFired,
+  markStationFired,
+} from '../utils/crossCategoryStationDedup';
 import { runTripBoundCleanups, cancelTripBoundOsQueue } from '../store/tripBoundCleanups';
 import { setTripEndedSentinel } from '../utils/tripEndedSentinel';
 import { triggerTripEndRecall } from '../utils/triggerTripEndRecall';
@@ -1335,6 +1340,39 @@ async function fireWithGate(
     await setFiredAlarms(destinationId, fired);
   }
 
+  // #1901/#1900 (RC-7/RC-10a) — channel-agnostic 8분 backstop. FIRED_ALARMS dedup은
+  // `phaseId + stationName + hopIndex` 기반이라 backend가 같은 station-pass 1건에 silent state
+  // push + LA dirty update 2채널을 발사하거나 phase만 다른 cross-channel 중복을 통과시킨다.
+  // (lastFire) Map은 FG fireAndLog / stationPipeline 모두에서 markStationFired로 적재되므로
+  // 본 게이트가 silent push도 station-level 8분 backstop으로 cross-channel 중복을 차단한다.
+  // intermediate(station-passed) 분기는 dedupKey=null이라 destinationId만으로도 보호 필요 —
+  // intermediate도 같은 station 8분 차 cross-channel 중복 evidence(2026-06-26 trip-3 동대문역사문화공원).
+  const channelAgnosticKind: 'destination' | 'transfer' | 'station-passed' =
+    payload.kind === 'intermediate' ? 'station-passed' : payload.kind;
+  if (
+    destinationId &&
+    isAnyChannelRecentlyFired(
+      destinationId,
+      payload.nextWaypoint,
+      channelAgnosticKind,
+      Date.now(),
+      payload.phase,
+    )
+  ) {
+    logSuppressedChannelAgnosticDedup({
+      source: 'silent-push-skipped',
+      stationName: payload.nextWaypoint,
+      kind: channelAgnosticKind,
+      phaseId: payload.phase,
+    });
+    void ackOutcome(payload.pushId, apnsToken, 'skipped', 'dedup-already-fired');
+    if (payload.pushId) void addFiredPushId(payload.pushId);
+    logger.info(
+      `dedup channel-agnostic: ${payload.nextWaypoint} fired within 8m — skip`,
+    );
+    return;
+  }
+
   const content =
     payload.kind === 'intermediate'
       ? buildIntermediateContent(payload.nextWaypoint)
@@ -1351,6 +1389,20 @@ async function fireWithGate(
     content: { title: content.title, body: content.body },
     trigger: null,
   });
+
+  // #1901/#1900 (RC-7/RC-10a) — channel-agnostic dedup window 갱신. silent push fire를 lastFire
+  // Map에 적재해 후속 FG fireAndLog / stationPipeline 발사가 같은 station+kind+phase 8분 backstop
+  // 으로 차단됨. intermediate는 'station-passed' 카테고리로 마킹(기존 cross-category dedup 의미 유지).
+  // phaseId(payload.phase)도 stamp해 정상 phase 진행은 통과시킴.
+  if (destinationId) {
+    markStationFired(
+      destinationId,
+      payload.nextWaypoint,
+      channelAgnosticKind,
+      Date.now(),
+      payload.phase,
+    );
+  }
 
   logSilentPushFired({
     stationName: payload.nextWaypoint,

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -29,9 +29,11 @@ import {
   DEDUP_LOG_WINDOW_MS,
   FLUSH_DEBOUNCE_MS,
   FLUSH_MAX_DELAY_MS,
+  logSuppressedChannelAgnosticDedup,
   logSuppressedCrossCategoryDedup,
   logSuppressedCrossCategoryRecent,
   logSuppressedPhaseToPhaseDedup,
+  logFiredAlarmsTripBoundaryReset,
   logSuppressedDedupStation,
   logSuppressedDismissSilence,
   logSuppressedSleepFirstTransfer,
@@ -635,6 +637,78 @@ describe('alarmLog', () => {
       const saved: AlarmLogEntry[] = JSON.parse(lastJson);
       const p2p = saved.filter((e) => e.reason === 'dedup-phase-to-phase');
       expect(p2p).toHaveLength(1);
+    });
+
+    it('#1901/#1900 logSuppressedChannelAgnosticDedup: reason=dedup-channel-agnostic + kind/phase 보존', async () => {
+      _resetBurstSuppressWindowForTests();
+      logSuppressedChannelAgnosticDedup({
+        source: 'fg',
+        stationName: '동대문역사문화공원',
+        kind: 'station-passed',
+        phaseId: 'imminent',
+      });
+      await expectLastSavedEntryMatches({
+        source: 'fg',
+        outcome: 'suppressed',
+        reason: 'dedup-channel-agnostic',
+        stationName: '동대문역사문화공원',
+        kind: 'station-passed',
+        phaseId: 'imminent',
+      });
+    });
+
+    it('#1901/#1900 logSuppressedChannelAgnosticDedup: 윈도우 내 같은 stationName 재호출은 drop', async () => {
+      _resetBurstSuppressWindowForTests();
+      logSuppressedChannelAgnosticDedup({
+        source: 'fg',
+        stationName: '동대문역사문화공원',
+        kind: 'destination',
+      });
+      logSuppressedChannelAgnosticDedup({
+        source: 'silent-push-skipped',
+        stationName: '동대문역사문화공원',
+        kind: 'station-passed',
+      });
+      await flushAlarmLog();
+      const calls = (AsyncStorage.setItem as jest.Mock).mock.calls;
+      const lastJson = calls[calls.length - 1][1];
+      const saved: AlarmLogEntry[] = JSON.parse(lastJson);
+      const channelAgnostic = saved.filter((e) => e.reason === 'dedup-channel-agnostic');
+      expect(channelAgnostic).toHaveLength(1);
+    });
+
+    it('#1893 logFiredAlarmsTripBoundaryReset: reason=fired-alarms-trip-boundary-reset + epoch 슬롯 보존', async () => {
+      logFiredAlarmsTripBoundaryReset({
+        source: 'fg',
+        destinationId: 'dest-1',
+        previousTripStartedAt: 1_000_000,
+        nextTripStartedAt: 2_000_000,
+      });
+      await expectLastSavedEntryMatches({
+        source: 'fg',
+        outcome: 'suppressed',
+        reason: 'fired-alarms-trip-boundary-reset',
+        destinationId: 'dest-1',
+        sentAt: 1_000_000,
+        receivedAt: 2_000_000,
+      });
+    });
+
+    it('#1893 logFiredAlarmsTripBoundaryReset: previousTripStartedAt=null → sentAt=undefined', async () => {
+      logFiredAlarmsTripBoundaryReset({
+        source: 'fg',
+        destinationId: 'dest-1',
+        previousTripStartedAt: null,
+        nextTripStartedAt: 2_000_000,
+      });
+      await flushAlarmLog();
+      const calls = (AsyncStorage.setItem as jest.Mock).mock.calls;
+      const lastJson = calls[calls.length - 1][1];
+      const saved: AlarmLogEntry[] = JSON.parse(lastJson);
+      const entry = saved.find((e) => e.reason === 'fired-alarms-trip-boundary-reset');
+      expect(entry?.destinationId).toBe('dest-1');
+      expect(entry?.sentAt).toBeUndefined();
+      expect(entry?.receivedAt).toBe(2_000_000);
     });
 
     it('logSuppressedDedupAlarm: reason=dedup-alarm, phase+type+stationName 적재 (#580)', async () => {

--- a/src/features/alarm/utils/__tests__/crossCategoryStationDedup.test.ts
+++ b/src/features/alarm/utils/__tests__/crossCategoryStationDedup.test.ts
@@ -1,9 +1,11 @@
 import {
+  CHANNEL_AGNOSTIC_DEDUP_WINDOW_MS,
   CROSS_CATEGORY_DEDUP_WINDOW_MS,
   PHASE_TO_PHASE_CROSS_STATION_WINDOW_MS,
   TRIP_SCOPED_CROSS_CATEGORY_WINDOW_MS,
   _resetCrossCategoryDedupForTests,
   clearCrossCategoryDedup,
+  isAnyChannelRecentlyFired,
   isStationRecentlyFired,
   isPhaseToPhaseCrossStationRecentlyFired,
   isTripScopedCrossCategoryRecentlyFired,
@@ -108,6 +110,150 @@ describe('crossCategoryStationDedup (#1515)', () => {
     expect(isStationRecentlyFired('dest-1', '강남', 'station-passed', 2_000)).toBe(true);
     await expect(clearCrossCategoryDedup()).resolves.toBeUndefined();
     expect(isStationRecentlyFired('dest-1', '강남', 'station-passed', 2_000)).toBe(false);
+  });
+
+  // #1901/#1900 (RC-7/RC-10a) — channel-agnostic 8분 backstop. silent state push + LA dirty update
+  // 같은 kind cross-channel 중복(2026-06-26 trip-3 동대문역사문화공원 8분 차) 회귀 차단용.
+  describe('isAnyChannelRecentlyFired (#1901/#1900)', () => {
+    it('returns false when no fire has been recorded', () => {
+      expect(isAnyChannelRecentlyFired('dest-1', '성수', 'destination', 1_000)).toBe(false);
+    });
+
+    // 같은 station + 같은 category가 8분 안에 fire됐으면 차단. 다른 category는 cross-category gate가 담당.
+    it.each<[Category, Category, boolean, string]>([
+      ['destination', 'destination', true, 'same-kind D→D within 8m blocked (cross-channel evidence)'],
+      ['transfer', 'transfer', true, 'same-kind T→T within 8m blocked'],
+      ['station-passed', 'station-passed', true, 'same-kind SP→SP within 8m blocked (cross-channel)'],
+      // 다른 kind는 cross-category gate(30s)가 cover하므로 본 backstop은 통과 — phase 진행이나
+      // cross-category(D ↔ SP)는 다른 gate에서 dedup.
+      ['destination', 'station-passed', false, 'cross-kind D→SP NOT blocked here (handled by 30s gate)'],
+      ['station-passed', 'destination', false, 'cross-kind SP→D NOT blocked here (handled by 30s gate)'],
+      ['destination', 'transfer', false, 'cross-kind D→T NOT blocked here'],
+    ])('first=%s, second=%s: blocked=%s (%s)', (firstCat, secondCat, blocked) => {
+      markStationFired('dest-1', '동대문역사문화공원', firstCat, 1_000);
+      expect(
+        isAnyChannelRecentlyFired('dest-1', '동대문역사문화공원', secondCat, 1_000 + 60_000),
+      ).toBe(blocked);
+    });
+
+    it('blocks within 8m window edge (just under window)', () => {
+      markStationFired('dest-1', '성수', 'destination', 1_000);
+      expect(
+        isAnyChannelRecentlyFired(
+          'dest-1',
+          '성수',
+          'destination',
+          1_000 + CHANNEL_AGNOSTIC_DEDUP_WINDOW_MS - 1,
+        ),
+      ).toBe(true);
+    });
+
+    it('unblocks once 8m window has elapsed', () => {
+      markStationFired('dest-1', '성수', 'destination', 1_000);
+      expect(
+        isAnyChannelRecentlyFired(
+          'dest-1',
+          '성수',
+          'destination',
+          1_000 + CHANNEL_AGNOSTIC_DEDUP_WINDOW_MS,
+        ),
+      ).toBe(false);
+    });
+
+    it('isolates entries by destinationId', () => {
+      markStationFired('dest-1', '성수', 'destination', 1_000);
+      expect(isAnyChannelRecentlyFired('dest-2', '성수', 'destination', 1_500)).toBe(false);
+    });
+
+    it('isolates entries by stationName', () => {
+      markStationFired('dest-1', '성수', 'destination', 1_000);
+      expect(isAnyChannelRecentlyFired('dest-1', '왕십리', 'destination', 1_500)).toBe(false);
+    });
+
+    it('normalizes station name (parenthetical suffix)', () => {
+      markStationFired('dest-1', '왕십리(성동구청)', 'destination', 1_000);
+      expect(isAnyChannelRecentlyFired('dest-1', '왕십리', 'destination', 1_500)).toBe(true);
+    });
+
+    it('accepts custom window override (override < default window)', () => {
+      markStationFired('dest-1', '성수', 'destination', 1_000);
+      // 100ms override — 200ms 후 query는 통과.
+      expect(
+        isAnyChannelRecentlyFired('dest-1', '성수', 'destination', 1_200, undefined, 100),
+      ).toBe(false);
+      // 50ms 후 query는 차단.
+      expect(
+        isAnyChannelRecentlyFired('dest-1', '성수', 'destination', 1_050, undefined, 100),
+      ).toBe(true);
+    });
+
+    // phaseId 비교 — 같은 station + 같은 kind + 다른 phaseId는 정상 phase 진행이라 통과.
+    it('passes when phaseId differs (정상 phase 진행 early→imminent)', () => {
+      markStationFired('dest-1', '동대문역사문화공원', 'destination', 1_000, 'early');
+      expect(
+        isAnyChannelRecentlyFired('dest-1', '동대문역사문화공원', 'destination', 1_100, 'imminent'),
+      ).toBe(false);
+    });
+
+    it('blocks when phaseId matches (same phase cross-channel)', () => {
+      markStationFired('dest-1', '동대문역사문화공원', 'destination', 1_000, 'early');
+      expect(
+        isAnyChannelRecentlyFired('dest-1', '동대문역사문화공원', 'destination', 1_100, 'early'),
+      ).toBe(true);
+    });
+
+    // record phaseId 미정의 + query phaseId 정의 — 보수적 차단 (markStationFired 호출자가 phaseId
+    // 안 전달한 케이스. SP path 등 phaseId 자체가 없을 때 backstop이 작동해야 함).
+    it('blocks when record phaseId is undefined (conservative)', () => {
+      markStationFired('dest-1', '동대문역사문화공원', 'station-passed', 1_000);
+      expect(
+        isAnyChannelRecentlyFired('dest-1', '동대문역사문화공원', 'station-passed', 1_100),
+      ).toBe(true);
+    });
+
+    // query phaseId 미정의 — record가 정의돼 있어도 query 미정의면 보수적 차단.
+    it('blocks when query phaseId is undefined (conservative)', () => {
+      markStationFired('dest-1', '동대문역사문화공원', 'destination', 1_000, 'early');
+      expect(
+        isAnyChannelRecentlyFired('dest-1', '동대문역사문화공원', 'destination', 1_100),
+      ).toBe(true);
+    });
+
+    it('is cleared by clearCrossCategoryDedup (TRIP_BOUND_CLEANUPS wiring)', async () => {
+      markStationFired('dest-1', '동대문역사문화공원', 'destination', 1_000);
+      expect(
+        isAnyChannelRecentlyFired('dest-1', '동대문역사문화공원', 'destination', 2_000),
+      ).toBe(true);
+      await clearCrossCategoryDedup();
+      expect(
+        isAnyChannelRecentlyFired('dest-1', '동대문역사문화공원', 'destination', 2_000),
+      ).toBe(false);
+    });
+
+    // 2026-06-26 trip-3 evidence 회귀 재현: 동일 station + 동일 kind(station-passed)가 8분 차로
+    // cross-channel(silent state + LA dirty update) 발사된 경우. 8분 윈도우 안 차단.
+    it('blocks 8m gap cross-channel duplicate (trip-3 동대문역사문화공원 evidence)', () => {
+      const t1 = 1_000;
+      markStationFired('dest-1', '동대문역사문화공원', 'station-passed', t1);
+      // 윈도우 끝 1ms 전 — 차단.
+      expect(
+        isAnyChannelRecentlyFired(
+          'dest-1',
+          '동대문역사문화공원',
+          'station-passed',
+          t1 + CHANNEL_AGNOSTIC_DEDUP_WINDOW_MS - 1,
+        ),
+      ).toBe(true);
+      // 8분 1ms 지나서 — 통과(같은 station 재방문은 윈도우 후 정상 발사).
+      expect(
+        isAnyChannelRecentlyFired(
+          'dest-1',
+          '동대문역사문화공원',
+          'station-passed',
+          t1 + CHANNEL_AGNOSTIC_DEDUP_WINDOW_MS + 1,
+        ),
+      ).toBe(false);
+    });
   });
 
   // #1643 — trip-scoped cross-category + cross-station 즉시 cascade window (5s).

--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -79,6 +79,7 @@ const mockLogSuppressedDismissSilence = jest.fn();
 const mockLogSuppressedCrossCategoryDedup = jest.fn();
 const mockLogSuppressedCrossCategoryRecent = jest.fn();
 const mockLogSuppressedPhaseToPhaseDedup = jest.fn();
+const mockLogSuppressedChannelAgnosticDedup = jest.fn();
 jest.mock('../alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
   logFiredStationPassed: (...args: unknown[]) => mockLogFiredStationPassed(...args),
@@ -95,6 +96,8 @@ jest.mock('../alarmLog', () => ({
     mockLogSuppressedCrossCategoryRecent(...args),
   logSuppressedPhaseToPhaseDedup: (...args: unknown[]) =>
     mockLogSuppressedPhaseToPhaseDedup(...args),
+  logSuppressedChannelAgnosticDedup: (...args: unknown[]) =>
+    mockLogSuppressedChannelAgnosticDedup(...args),
 }));
 
 import { processLocationUpdate, resolveNextTarget } from '../stationPipeline';
@@ -1023,6 +1026,106 @@ describe('processLocationUpdate', () => {
       await call({ source: 'bg' });
       // phase↔phase dedup은 발동 안 됨 — same station은 firedAlarms가 담당.
       expect(mockLogSuppressedPhaseToPhaseDedup).not.toHaveBeenCalled();
+    });
+  });
+
+  // #1901/#1900 (RC-7/RC-10a) — channel-agnostic 8분 backstop. silent state push + LA dirty update
+  // cross-channel 중복(2026-06-26 trip-3 동대문역사문화공원 8분 차) BG path 동등 차단.
+  describe('#1901/#1900 channel-agnostic 8분 backstop dedup (BG path)', () => {
+    const stationA: Station = { ...mockStation, name: '동대문역사문화공원', id: 'station-1' };
+    let nowSpy: jest.SpyInstance<number, []>;
+
+    beforeEach(() => {
+      mockFindRoute.mockReturnValue(mockRoute);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    });
+
+    afterEach(() => {
+      nowSpy.mockRestore();
+    });
+
+    it('phase 알람 발사 후 31s~8분 사이 같은 station 같은 phase 재발사는 channel-agnostic backstop으로 차단', async () => {
+      mockFindNearestStation.mockReturnValue({ station: stationA, distanceKm: 0.05 });
+      // 1st: imminent destination 발사 (t=1_000_000).
+      mockEvaluateAlarmPhase.mockReturnValueOnce({
+        phaseId: 'imminent',
+        type: 'destination',
+        stationName: stationA.name,
+      });
+      mockIsStationOnRoute.mockReturnValueOnce(false);
+      await call({ source: 'fg-evaluated' });
+      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+
+      // t = 1_000_000 + 60_000 (1분 후) — 30s cross-category window는 만료, 8분 backstop은 활성.
+      nowSpy.mockReturnValue(1_000_000 + 60_000);
+
+      // 2nd: 같은 station 같은 phase imminent — cross-channel 중복 시뮬레이션. cross-category 30s
+      // 만료 후 8분 backstop만 활성. phaseId 정확 매칭이라 차단.
+      mockEvaluateAlarmPhase.mockReturnValueOnce({
+        phaseId: 'imminent',
+        type: 'destination',
+        stationName: stationA.name,
+      });
+      mockIsStationOnRoute.mockReturnValueOnce(false);
+      await call({ source: 'fg-evaluated' });
+      expect(mockLogSuppressedChannelAgnosticDedup).toHaveBeenCalledWith({
+        source: 'fg-evaluated',
+        stationName: stationA.name,
+        kind: 'destination',
+        phaseId: 'imminent',
+      });
+      // 두 번째 발사 없음.
+      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+    });
+
+    it('phase 알람 발사 후 같은 station 다른 phase는 정상 phase 진행이라 통과', async () => {
+      mockFindNearestStation.mockReturnValue({ station: stationA, distanceKm: 0.05 });
+      // 1st: early destination 발사.
+      mockEvaluateAlarmPhase.mockReturnValueOnce({
+        phaseId: 'early',
+        type: 'destination',
+        stationName: stationA.name,
+      });
+      mockIsStationOnRoute.mockReturnValueOnce(false);
+      await call({ source: 'fg-evaluated' });
+      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+
+      // 2nd: 같은 station imminent destination — 다른 phaseId라 channel-agnostic backstop 통과.
+      // cross-category 30s window는 만료시켜 phase 변경만 backstop 영향 받는지 격리.
+      nowSpy.mockReturnValue(1_000_000 + 60_000);
+      mockEvaluateAlarmPhase.mockReturnValueOnce({
+        phaseId: 'imminent',
+        type: 'destination',
+        stationName: stationA.name,
+      });
+      mockIsStationOnRoute.mockReturnValueOnce(false);
+      await call({ source: 'fg-evaluated' });
+      // 두 번째 발사가 진행됨 — channel-agnostic dedup은 phase 진행 통과.
+      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(2);
+      expect(mockLogSuppressedChannelAgnosticDedup).not.toHaveBeenCalled();
+    });
+
+    it('station-passed 발사 후 31s~8분 사이 같은 station station-passed는 channel-agnostic backstop으로 차단', async () => {
+      mockFindNearestStation.mockReturnValue({ station: stationA, distanceKm: 0.05 });
+      mockEvaluateAlarmPhase.mockReturnValue(null);
+      mockIsStationOnRoute.mockReturnValue(true);
+      // 1st: station-passed 발사 → markStationFired (t=1_000_000).
+      await call({ source: 'bg' });
+      expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+
+      // t = 1_000_000 + 60_000 — 30s cross-category 만료, lastNotifiedStationId가 다른 stationId면
+      // 그 dedup도 통과 → channel-agnostic 8분 backstop이 차단해야 함.
+      nowSpy.mockReturnValue(1_000_000 + 60_000);
+      mockGetLastNotifiedStationId.mockResolvedValue('other-station');
+      await call({ source: 'bg' });
+      expect(mockLogSuppressedChannelAgnosticDedup).toHaveBeenCalledWith({
+        source: 'bg',
+        stationName: stationA.name,
+        kind: 'station-passed',
+      });
+      // 두 번째 발사 없음.
+      expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -250,7 +250,20 @@ export type AlarmLogReason =
   // useStationMismatchDetector가 3회 연속 불일치 확인 시 적재. expectedStationAtFire 슬롯에
   // reason 문자열(route-diverged / line-mismatch / environment-mismatch) stamp.
   // 1주 production 빈도 측정 — `/admin/alarm-log-stats` reason='cold-start-mismatch' 카운트.
-  | 'cold-start-mismatch';
+  | 'cold-start-mismatch'
+  // #1901/#1900 (RC-7/RC-10a) — channel-agnostic station dedup 차단 1건.
+  // 같은 (destinationId, stationName)이 CHANNEL_AGNOSTIC_DEDUP_WINDOW_MS(8분) 안에 어떤
+  // channel/category로든 이미 fire됐을 때 후속 발사 차단(2026-06-26 trip-3 동대문역사문화공원
+  // 8분 차 cross-channel 중복 회귀). 기존 'dedup-station-unified'(30s, cross-category 한정)는
+  // phase↔SP만 dedup해 silent state push + LA dirty update 같은 cross-channel 중복을 통과
+  // 시켰음. burst dedup으로 같은 (source, stationName) 반복 로그는 1건만 적재.
+  | 'dedup-channel-agnostic'
+  // #1893 (RC-17) — trip 경계에서 firedAlarmsRef in-memory Set이 reset된 1건. 같은 destinationId
+  // 로 trip 재시작 시 BG가 storage(FIRED_ALARMS_KEY)는 비웠지만 FG React useRef는 이전 trip의
+  // fired key를 유지해 새 trip의 첫 fire가 dedup으로 차단되거나 dump가 cross-trip carry-over로
+  // 오염되던 회귀(2026-06-26 T4 dump에 T3 fired 2건 carry-over evidence). tripStartedAt 변경
+  // detection을 기준으로 1회 적재 — 운영에서 trip 경계 reset 적중 횟수 측정.
+  | 'fired-alarms-trip-boundary-reset';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -456,6 +469,60 @@ export function logSuppressedPhaseToPhaseDedup(input: {
     stationName: input.stationName,
     kind: input.kind,
     phaseId: input.phaseId,
+  });
+}
+
+/**
+ * #1901/#1900 (RC-7/RC-10a) — channel-agnostic station dedup 차단 1건 적재.
+ *
+ * 같은 (destinationId, stationName)이 CHANNEL_AGNOSTIC_DEDUP_WINDOW_MS(8분) 안에 channel/category
+ * 무관 fire됐을 때 후속 발사를 차단한 case. 'dedup-station-unified'(30s, phase↔SP 한정)와 다른
+ * 신호 — cross-channel(silent state push + LA dirty update) 중복 fire를 station 단위 8분 backstop
+ * 으로 잡는다. 2026-06-26 trip-3 동대문역사문화공원 8분 차 fired 2건 evidence.
+ *
+ * burst dedup 윈도우로 같은 (source, stationName) 반복 로그는 1건만 적재.
+ */
+export function logSuppressedChannelAgnosticDedup(input: {
+  source: AlarmLogSource;
+  stationName: string;
+  kind: AlarmLogKind;
+  phaseId?: AlarmPhaseId;
+}): void {
+  if (isBurstDuplicate('dedup-channel-agnostic', input.stationName)) return;
+  appendAlarmLog({
+    ts: Date.now(),
+    source: input.source,
+    outcome: 'suppressed',
+    reason: 'dedup-channel-agnostic',
+    stationName: input.stationName,
+    kind: input.kind,
+    phaseId: input.phaseId,
+  });
+}
+
+/**
+ * #1893 (RC-17) — trip 경계 firedAlarmsRef in-memory Set reset 1건 적재.
+ *
+ * 같은 destinationId로 trip 재시작 detection 시점에 호출. 운영에서 trip 경계 reset 적중 횟수를
+ * 측정 — backend trip-ended 신호 (storage clear) 대비 FG ref reset 1:1 매칭 확인용. burst dedup 미적용
+ * (trip 경계는 trip당 1회만 적재되므로 자연 dedup).
+ */
+export function logFiredAlarmsTripBoundaryReset(input: {
+  source: AlarmLogSource;
+  destinationId: string;
+  previousTripStartedAt: number | null;
+  nextTripStartedAt: number;
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: input.source,
+    outcome: 'suppressed',
+    reason: 'fired-alarms-trip-boundary-reset',
+    destinationId: input.destinationId,
+    // sentAt/receivedAt 슬롯을 재사용해 prev/next tripStartedAt epoch 보존 — DebugModal/admin
+    // dashboard에서 trip 경계 시각 추적 가능.
+    sentAt: input.previousTripStartedAt ?? undefined,
+    receivedAt: input.nextTripStartedAt,
   });
 }
 

--- a/src/features/alarm/utils/crossCategoryStationDedup.ts
+++ b/src/features/alarm/utils/crossCategoryStationDedup.ts
@@ -47,6 +47,34 @@ function normalizeStationName(name: string): string {
 export const CROSS_CATEGORY_DEDUP_WINDOW_MS = 30_000;
 
 /**
+ * #1901/#1900 (RC-7/RC-10a) — channel-agnostic station dedup 윈도우.
+ *
+ * 같은 (destinationId, stationName)에 대한 fire가 channel/category 무관하게 8분 안에 1회만 통과
+ * 하도록 잡는 backstop 윈도우. 기존 게이트들이 cover하지 못하는 회귀를 차단한다:
+ *
+ *   1) backend가 같은 station-pass 1건에 silent state push + LA dirty update 2채널을 발사 →
+ *      device가 FG handler/silent push handler/LA dismiss handler로 별개 path 진입 → 같은
+ *      station이 phase는 다르거나 channel만 다르면 기존 dedup(firedAlarms / lastNotifiedStationId
+ *      / cross-category 30s)를 통과해 8분 안에 2회 fire(2026-06-26 trip-3 12:17:58/12:26:12
+ *      동대문역사문화공원 evidence).
+ *   2) 같은 station을 backend가 trigger 두 번 발사하거나 device가 cross-channel로 받아도 8분 한
+ *      윈도우 안에서는 단 1회 fire를 보장.
+ *
+ * 윈도우 8분 산정 근거:
+ *   - 사용자 trip-3 evidence: 같은 station 2회 fire 간격 = 8m 14s. 8분 이상 두면 같은 station
+ *     재방문(루프선 등 정상 케이스)을 차단하지 않으면서 회귀 100% 커버.
+ *   - 정상 trip: 같은 station 진행은 30s cycle 단위 phase 변환(early→imminent) — 이는 `lastFire`
+ *     윈도우(30s)가 이미 처리 중. 8분은 그 위에 cross-channel/cross-trip race만 잡는 backstop.
+ *   - false positive 위험 평가: 같은 trip의 같은 stationName 8분 내 중복 fire가 "정상"인 케이스는
+ *     없음(환승 후 동일 stationName 재방문은 환승역 한정이고 그 환승은 markStationFired의
+ *     stationName normalize로 같은 키에 묶임).
+ *
+ * ADR-010 §1 (false positive ↔ miss 동급) 정합 — 회귀 evidence가 false positive(중복 fire)이고,
+ * 8분 윈도우는 정상 trip 진행에 영향을 주지 않는 conservative 값.
+ */
+export const CHANNEL_AGNOSTIC_DEDUP_WINDOW_MS = 8 * 60_000;
+
+/**
  * #1643 — trip-scoped 즉시 cascade 윈도우.
  * 같은 trip(destinationId) 안에서 **다른 station + cross-category(phase↔SP)** 알람이 같은 cycle/
  * 즉시 cascade로 발사되는 회귀(2026-06-20 12:31 어대 "군자 도착"(SP)+"곧 성수 도착"(D imminent))를 차단한다.
@@ -84,6 +112,11 @@ export type FireCategory = 'destination' | 'transfer' | 'station-passed';
 interface FireRecord {
   ts: number;
   category: FireCategory;
+  // #1901/#1900 (RC-7/RC-10a) — channel-agnostic backstop이 같은 phase 재발사만 차단하고
+  // phase 진행(예: early destination → imminent destination)은 통과시키도록 phase 식별자도
+  // 보관. 호출자가 phase를 알지 못하면 markStationFired에서 undefined로 적재 — 그 경우 본
+  // backstop은 phase 비교 skip(보수적 차단).
+  phaseId?: string;
 }
 
 const lastFire = new Map<string, FireRecord>();
@@ -184,8 +217,9 @@ export function markStationFired(
   stationName: string,
   category: FireCategory,
   now: number,
+  phaseId?: string,
 ): void {
-  lastFire.set(makeKey(destinationId, stationName), { ts: now, category });
+  lastFire.set(makeKey(destinationId, stationName), { ts: now, category, phaseId });
   lastTripFire.set(destinationId, {
     ts: now,
     category,
@@ -271,6 +305,47 @@ export function isPhaseToPhaseCrossStationRecentlyFired(
   // 같은 station 진행(early→imminent on same station)은 통과 — firedAlarms set이 dedup.
   if (rec.stationName === normalizeStationName(stationName)) return false;
   // 여기까지 오면: 직전=phase, 현재=phase, 다른 station, 윈도우 안 → 차단.
+  return true;
+}
+
+/**
+ * #1901/#1900 (RC-7/RC-10a) — channel-agnostic station+category+phase dedup 차단 판정.
+ *
+ * 같은 (destinationId, stationName) + 같은 category(kind) + 같은 phaseId가 windowMs(기본
+ * CHANNEL_AGNOSTIC_DEDUP_WINDOW_MS=8분) 안에 fire됐다면 true. channel(silent state push / LA dirty
+ * update / FG / OS scheduled) 무관 backstop. 정상 phase 진행(예: early destination → imminent
+ * destination)은 다른 phaseId라 통과 — backstop은 **완전히 같은 phase 발사 중복**만 잡는다.
+ *
+ * 사용자 체감 회귀(2026-06-26 trip-3 동대문역사문화공원): 같은 station에 같은 phase + 같은 kind가
+ * 8분 차로 cross-channel(silent state push + LA dirty update) 발사. 위 cross-category gates는
+ * 30s/5s/3s 윈도우라 8분 차 중복은 통과시켰음.
+ *
+ * 다른 category(예: destination → station-passed)는 cross-category gate(30s)가 별도로 담당하므로
+ * 본 backstop은 통과 — 같은 kind 같은 phase 정확 매칭만.
+ *
+ * phaseId가 record에 stamp되지 않은 entry(legacy 또는 호출자 미전달)에 대해 query phaseId가
+ * 정의돼 있어도 보수적으로 차단 — 미정의 record는 채널 추적 의도 없음이라 8분 안 같은 station+
+ * category 재발사 자체를 회귀로 본다.
+ *
+ * fire 직전 호출 — true면 호출자는 발사 skip + 'dedup-channel-agnostic' 로그.
+ */
+export function isAnyChannelRecentlyFired(
+  destinationId: string,
+  stationName: string,
+  category: FireCategory,
+  now: number,
+  phaseId?: string,
+  windowMs: number = CHANNEL_AGNOSTIC_DEDUP_WINDOW_MS,
+): boolean {
+  const rec = lastFire.get(makeKey(destinationId, stationName));
+  if (rec === undefined) return false;
+  if (now - rec.ts >= windowMs) return false;
+  if (rec.category !== category) return false;
+  // 둘 다 phaseId 정의 & 다르면 정상 phase 진행 → 통과. 그 외(한쪽이라도 미정의 또는 둘 다 동일)는
+  // 같은 phase 재발사로 보고 차단.
+  if (rec.phaseId !== undefined && phaseId !== undefined && rec.phaseId !== phaseId) {
+    return false;
+  }
   return true;
 }
 

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -17,6 +17,7 @@ import { getLastNotifiedStationId, setLastNotifiedStationId } from './notificati
 import {
   logFiredAlarm,
   logFiredStationPassed,
+  logSuppressedChannelAgnosticDedup,
   logSuppressedCrossCategoryDedup,
   logSuppressedCrossCategoryRecent,
   logSuppressedPhaseToPhaseDedup,
@@ -28,6 +29,7 @@ import {
   type AlarmLogSource,
 } from './alarmLog';
 import {
+  isAnyChannelRecentlyFired,
   isStationRecentlyFired,
   isPhaseToPhaseCrossStationRecentlyFired,
   isTripScopedCrossCategoryRecentlyFired,
@@ -359,8 +361,32 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
         kind: alarmEvent.type,
         phaseId: alarmEvent.phaseId,
       });
+    } else if (
+      isAnyChannelRecentlyFired(
+        destination.id,
+        alarmEvent.stationName,
+        alarmEvent.type,
+        Date.now(),
+        alarmEvent.phaseId,
+      )
+    ) {
+      // #1901/#1900 (RC-7/RC-10a) — channel-agnostic 8분 backstop. silent state push + LA dirty
+      // update의 cross-channel 같은 kind+phase 중복(2026-06-26 trip-3 동대문역사문화공원
+      // 12:17:58/12:26:12)을 정확 매칭으로 차단. 정상 phase 진행(early→imminent)은 phaseId 다름 → 통과.
+      logSuppressedChannelAgnosticDedup({
+        source,
+        stationName: alarmEvent.stationName,
+        kind: alarmEvent.type,
+        phaseId: alarmEvent.phaseId,
+      });
     } else {
-      markStationFired(destination.id, alarmEvent.stationName, alarmEvent.type, Date.now());
+      markStationFired(
+        destination.id,
+        alarmEvent.stationName,
+        alarmEvent.type,
+        Date.now(),
+        alarmEvent.phaseId,
+      );
       await sendAlarmNotification(alarmEvent, sleepMode, allowSpeaker, notificationSource);
       logFiredAlarm(source, alarmEvent);
     }
@@ -429,6 +455,23 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
         // 직후 어대 station-passed 발사 같은 회귀 차단. same-category(SP→SP) cross-station은 통과 —
         // 정상 trip 폴링 진행 보존.
         logSuppressedCrossCategoryRecent({
+          source,
+          stationName: nearest.station.name,
+          kind: 'station-passed',
+        });
+      } else if (
+        isAnyChannelRecentlyFired(
+          destination.id,
+          nearest.station.name,
+          'station-passed',
+          Date.now(),
+        )
+      ) {
+        // #1901/#1900 (RC-7/RC-10a) — channel-agnostic 8분 backstop (BG path 동등 가드).
+        // 같은 station + 같은 kind(station-passed)가 8분 안에 cross-channel(silent state push +
+        // LA dirty update)로 재발사되는 회귀(2026-06-26 trip-3 동대문역사문화공원 12:17:58/12:26:12)
+        // 를 BG path에서도 동등 차단. lock 활성/lockless 동급 (ADR-014).
+        logSuppressedChannelAgnosticDedup({
           source,
           stationName: nearest.station.name,
           kind: 'station-passed',


### PR DESCRIPTION
## 개요

3건 cascade 통합 PR — frontend-only channel-agnostic dedup backstop.

- Closes #1901 (RC-7 silent×2 채널 cross-channel 중복)
- Closes #1900 (RC-10a 동일 root audit — lock 활성 + cross-channel)
- Closes #1893 (RC-17 fired log carry-over — trip-scoped 아닌 device-scoped 누적)

사용자 결정 2026-06-26 #1901 Option A — Device dedup channel-agnostic 단기 채택 (https://github.com/handokei/subway-now/issues/1901#issuecomment-4806745103).

## 핵심 변경

### 1) `crossCategoryStationDedup.ts`
- `CHANNEL_AGNOSTIC_DEDUP_WINDOW_MS = 8 * 60_000` (8분) 도입
- `isAnyChannelRecentlyFired(destId, stationName, category, now, phaseId?, windowMs?)` 신규 helper — 같은 (destId, stationName) + 같은 category + 같은 phaseId가 8분 안에 fire됐다면 차단
- `markStationFired` signature 확장 — phaseId optional stamp. 정상 phase 진행(early→imminent)은 다른 phaseId라 backstop 통과
- 기존 30s `lastFire` Map 재사용 — 추가 storage 없음, 메모리 영향 0

### 2) `useStationAlarm.ts:fireAndLog`
- 기존 cross-category gates(30s/5s/3s) 직후에 channel-agnostic gate 호출 추가
- `markStationFired` 호출에 `rawEvent.phaseId` 전달
- **RC-17 fix**: `firedAlarmsRefTripStartedAtRef` 추가 + `destinationArrival` polling cycle effect 신규. 같은 destinationId로 trip 재시작 시(=hydration effect 미재실행) in-memory Set 명시적 reset + alarmLog 1건 적재
- hydration effect에서도 tripStartedAt을 ref에 stamp해 polling effect 비교 기준 마련

### 3) `silentPushTask.ts:fireWithGate`
- FIRED_ALARMS dedup 직후, schedule 직전에 channel-agnostic gate 추가 — `intermediate`(=`station-passed`) 포함 모든 kind 차단 가능
- fire 직후 `markStationFired(destId, station, kind, now, phase)` 호출 — `lastFire` Map 공유로 FG fireAndLog / stationPipeline이 cross-channel 중복 차단

### 4) `stationPipeline.ts`
- phase 분기 + station-passed 분기 둘 다 channel-agnostic gate 추가 (BG path 동등 가드)
- `markStationFired` 호출에 `alarmEvent.phaseId` 전달

### 5) `alarmLog.ts`
- `dedup-channel-agnostic` reason + `logSuppressedChannelAgnosticDedup` helper
- `fired-alarms-trip-boundary-reset` reason + `logFiredAlarmsTripBoundaryReset` helper (epoch ms 슬롯 재사용)

## Wire-completion 5단 체크

1. **Orphan 없음** — `npm run lint:orphan` pass (`No orphan exports detected.`). 신규 helper 4개(`isAnyChannelRecentlyFired`, `logSuppressedChannelAgnosticDedup`, `logFiredAlarmsTripBoundaryReset`, `CHANNEL_AGNOSTIC_DEDUP_WINDOW_MS`) 모두 caller(useStationAlarm/stationPipeline/silentPushTask + tests) 존재.

2. **V/X dashboard** — alarmLog 신규 reason 2종으로 `/admin/alarm-log-stats` (kind='alarmLog')에서 카운트:
   - `reason='dedup-channel-agnostic'` channel별 query: 같은 station + 같은 phase가 8분 안에 cross-channel 차단된 횟수. silent state push + LA dirty update 회귀 dedup 적중 evidence.
   - `reason='fired-alarms-trip-boundary-reset'`: trip 경계 in-memory reset 횟수. backend trip-ended push 발사 횟수와 1:1 매칭 (backend tail vs alarmLog ratio).
   - DebugModal `## Notifications fired` 섹션 — current trip 알람만 표시 (trip-boundary reset 적용 후).

3. **의존 PR** — N/A (frontend-only). backend 변경 없음 (Option A — device dedup으로 backend channel 2개 유지하면서 device가 차단).

4. **측정 plan** (1주 production):
   - Seoul outage 시나리오 (#1901 본문 12:17:58/12:26:12 evidence) 재현 시 `dedup-channel-agnostic` 적중 카운트 > 0 → backstop 작동 confirmed.
   - 같은 station 8분 차 cross-channel 중복 fired log entry **0건** (목표). DebugModal `Notifications fired` 섹션 dump로 직접 검증.
   - cooldown reject 6회 → 1회 이하 (issue #1901 cooldown_reject_count metric, T2/T3 evidence 대비).
   - 정상 phase 진행(early→imminent) 누락 0건 — channel-agnostic gate가 정상 fire 차단하지 않는지 검증 (사용자 trip 실측).

5. **Device verify** — 필수. Day 3 T2/T3 시나리오 재현:
   - T2: 충정로 → 동대문역사문화공원 통과 → station-passed 1회만 fire 확인 (DebugModal Notifications fired 섹션).
   - T3: 군자 → 용마산 도착 임박 → 1회만 fire 확인 + 환승 임박 1회만.
   - T3 → T4 transition trip: T4 dump fired 섹션에 T3 carry-over 0건 확인.

## 테스트 + 커버리지

- 새 분기 테스트 추가: crossCategoryStationDedup(+14), alarmLog(+4), stationPipeline(+3), silentPushTask(+5), useStationAlarm(+6)
- 전체 388 suites / 8068 tests pass (커버리지 100% statements/branches/lines/functions)
- `npm run type-check` pass
- `npm run lint:orphan` pass

## Acceptance criteria (3 이슈 통합)

### #1901 (RC-7)
- 동일 station 8분 이내 cross-channel 중복 0건 — channel-agnostic backstop이 cover
- T3 용마산 하차 5건 → 1건 (1주 evidence 측정)
- 7일 production fired/received < 1.2

### #1900 (RC-10a)
- lock 활성 trip cross-channel dedup 통합 — same root, same fix (channel-agnostic)
- WhileInUse / Always × FG / BG 모든 권한 매트릭스 동일 (helper에 권한 의존 분기 없음)

### #1893 (RC-17)
- 새 trip 시작 시 firedAlarmsRef current dedup set 빈 set (AC1)
- DebugModal "Notifications fired" 섹션 current trip only (AC3) — backend trip-ended cleanup이 storage 비우는 시점과 in-memory ref reset 1:1 매칭

## 의존성 / 제약

- backend 변경 없음 — Option A 채택. backend가 silent×2 (state + LA dirty) 유지해도 device backstop이 차단
- Co-Authored-By 미포함 (CLAUDE.md 룰)
- worktree 격리 작업 — main repo 변경 없음

Closes #1901
Closes #1900
Closes #1893