### PR TITLE
fix(#1890): RC-15 widget timestamp staleness gate

### DIFF
--- a/targets/subway-widget/SubwayWidget.swift
+++ b/targets/subway-widget/SubwayWidget.swift
@@ -76,19 +76,57 @@ struct SubwayProvider: TimelineProvider {
     }
 
     func getSnapshot(in context: Context, completion: @escaping (SubwayEntry) -> Void) {
-        completion(makeEntry())
+        completion(makeEntry(at: Date()))
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<SubwayEntry>) -> Void) {
-        let entry = makeEntry()
+        let now = Date()
+        let entry = makeEntry(at: now)
         // 앱이 종료된 상태에서도 freshness 표시(10분 임계)가 비교적 빨리 반영되도록
         // 5분 간격으로 재평가한다. 앱이 살아있으면 saveWidgetStation이 호출되며 즉시 reload.
-        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 5, to: Date()) ?? Date()
-        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+        var entries: [SubwayEntry] = [entry]
+        // #1890 (RC-15) — savedAt 기반 stale/expired 전이 시점에 추가 entry를 삽입해,
+        // 앱이 종료되어 reloadAllTimelines가 호출되지 않는 상황에서도 OS가 freshness 변화 직후
+        // UI를 재구성하도록 한다. tripActive trip 컨텍스트가 expired로 진입하는 시점이 핵심 경계 —
+        // 사용자는 trip 정보 stale을 가장 즉시 인식한다.
+        if let savedAt = entry.savedAt {
+            let staleAt = savedAt.addingTimeInterval(STALE_THRESHOLD_SECONDS)
+            if staleAt > now {
+                entries.append(SubwayEntry(
+                    date: staleAt,
+                    stationName: entry.stationName,
+                    lineColor: entry.lineColor,
+                    distanceM: entry.distanceM,
+                    isAvailable: entry.isAvailable,
+                    savedAt: entry.savedAt,
+                    tripActive: entry.tripActive,
+                    currentStationName: entry.currentStationName,
+                    destinationName: entry.destinationName,
+                    nextTransferName: entry.nextTransferName
+                ))
+            }
+            let expiredAt = savedAt.addingTimeInterval(EXPIRED_THRESHOLD_SECONDS)
+            if expiredAt > now {
+                entries.append(SubwayEntry(
+                    date: expiredAt,
+                    stationName: entry.stationName,
+                    lineColor: entry.lineColor,
+                    distanceM: entry.distanceM,
+                    isAvailable: entry.isAvailable,
+                    savedAt: entry.savedAt,
+                    tripActive: entry.tripActive,
+                    currentStationName: entry.currentStationName,
+                    destinationName: entry.destinationName,
+                    nextTransferName: entry.nextTransferName
+                ))
+            }
+        }
+        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 5, to: now) ?? now
+        let timeline = Timeline(entries: entries, policy: .after(nextUpdate))
         completion(timeline)
     }
 
-    private func makeEntry() -> SubwayEntry {
+    private func makeEntry(at date: Date) -> SubwayEntry {
         let defaults = UserDefaults(suiteName: appGroup)
         let name = defaults?.string(forKey: "stationName") ?? ""
         let color = defaults?.string(forKey: "lineColor") ?? "#888888"
@@ -105,7 +143,7 @@ struct SubwayProvider: TimelineProvider {
         let nextTransferName = defaults?.string(forKey: "nextTransferName")
 
         return SubwayEntry(
-            date: Date(),
+            date: date,
             stationName: isAvailable ? name : NSLocalizedString("widget.detecting", comment: "Placeholder station name while GPS detection is in progress"),
             lineColor: color,
             distanceM: distance,
@@ -177,7 +215,15 @@ struct SubwayWidgetView: View {
 
     private var content: some View {
         Group {
-            if entry.tripActive, let currentStation = entry.currentStationName, let destination = entry.destinationName {
+            // #1890 (RC-15) — trip 분기는 freshness가 expired가 아닐 때만 사용한다.
+            // backend trip-ended silent push가 device에 도달하지 못한 경우(예: APNs 지연/네트워크 단절/
+            // 앱 종료), trip 정보가 19분 이상 stale로 위젯에 그대로 노출되는 회귀(2026-06-26 T4 evidence)를
+            // 차단한다. expired tier에 진입하면 trip 컨텍스트를 숨기고 nearestStation 분기의 placeholder/
+            // dim UI로 폴백 — savedAt 기반 자율 stale 감지라 push가 dropped여도 device 단독으로 회복한다.
+            if entry.tripActive,
+               let currentStation = entry.currentStationName,
+               let destination = entry.destinationName,
+               freshness != .expired {
                 tripActiveContent(currentStation: currentStation, destination: destination)
             } else {
                 nearestStationContent


### PR DESCRIPTION
Closes #1890

## Summary

T4 evidence (2026-06-26 13:20 KST) — 위젯이 19분 stale 표시("지하철 건대입구 18m 오후 1:01"). backend trip이 12:53 auto-end 됐는데도 device가 silent push `trip-ended`를 받지 못해 위젯이 "건대입구 → 용마산" trip 컨텍스트로 stuck. backend → device push chain은 dropable channel이므로 위젯 자체가 savedAt 기반으로 자율 stale 감지하여 trip 컨텍스트를 끄도록 한다.

### 변경

- **`SubwayWidget.swift` content 분기 freshness gate**: `entry.tripActive && currentStation && destination`에 `freshness != .expired` 가드 추가. expired tier(savedAt > 10분 경과) 진입 시 trip 컨텍스트 숨기고 nearestStation placeholder/dim UI로 폴백.
- **multi-entry timeline**: `getTimeline`이 savedAt+STALE / savedAt+EXPIRED 시점에 future entry를 추가 emit해, 앱이 종료되어 `reloadAllTimelines`가 호출되지 않는 상황에서도 OS가 freshness 변화 직후 UI를 재구성.
- **`makeEntry(at:)` 시그니처 변경**: entry.date를 호출자가 명시 — placeholder/snapshot/timeline 모두 적절한 date 주입.
- **(fixup `85f9ecba`)** SourceKit이 macOS target 인덱싱 시 WidgetFamily의 `accessoryRectangular` / `accessoryCircular` case를 'unavailable in macOS'로 진단해 빨갛게 잡히는 diagnostics 2건 차단. `#available(iOS 16.0, *)`는 런타임 가드일 뿐 compile-time 차단이 아니므로, 파일 전체를 `#if os(iOS) ... #endif`로 감쌌다. `SubwayLiveActivityWidget.swift` 동일 패턴(옵션 B — 파일 단위 가드).

### 범위 한정

본 PR은 **device-side 자율 stale 차단** 범위만. 이슈 본문이 언급한 backend trip auto-end 시 widget clear push 추가는 #1885 RC-9(LA/widget orphan 26분) cascade 범위에서 별도 작업 (`scheduled.ts` 변경 필요).

## Wire-completion 5단

1. **Orphan 없음** — TS 코드 0줄 변경. `npm run lint:orphan` pass (No orphan exports detected). Swift 변경은 orphan 검출 대상 아님.
2. **V/X dashboard** — 위젯 UI 자체 (홈 화면). expired tier 진입 시점에 "정보 오래됨" 캡션 + 본문 dim이 사용자에게 즉시 가시화. DebugModal/Sentry/wrangler tail 같은 별도 observer 없음 — widget UI가 SSoT.
3. **의존 PR** — N/A. 본 PR은 자율 device-side fix. backend trip-ended push 추가(이슈 본문 §5 Step 3)는 #1885 RC-9 cascade 범위 별도 PR.
4. **측정 plan** — Day 3 T4 시나리오 실기기 재현 (backend trip 강제 종료 후 device push drop 시뮬레이션 / 또는 앱 kill 상태에서 10분 이상 경과). 1주 production 측정: production widget snapshot에서 savedAt > 10분 경과 + tripActive=true 상태 0건 확인. Widget 자체 로그 채널 없음 → 사용자 trip evidence 캡처로 회귀 검출.
5. **Device verify** — 실기기 필수. EAS production 빌드 후 시나리오:
   - (a) trip 등록 → backend force trip-end (`wrangler` 또는 cron) → APNs 응답 강제 drop → 10분 후 위젯 확인 → trip 컨텍스트 사라지고 "정보 오래됨" + nearestStation 표시 확인.
   - (b) 정상 경로(backend push 도달) — 기존 chain 유지. trip 정상 종료 시 즉시 사라짐.

## Native config 영향

- **expo prebuild 영향**: Swift 코드만 변경. `Info.plist` / `expo-target.config.json` / entitlements 미변경 → prebuild diff 없음.
- **native compile 필요**: SubwayWidget.swift 변경이라 EAS production/development 빌드에서 위젯 extension 재컴파일됨. `npm run ios` 시 Pods 재설치 불필요.
- 회귀 위험: SwiftUI `Group` / `Timeline` API는 iOS 14+ stable. multi-entry 추가는 Apple WidgetKit 공식 패턴(`getTimeline`이 entries 배열을 받음).

## Test plan

- [x] `npm run type-check` pass
- [x] `npm test` — 392 suites / 8265 tests / coverage 100%
- [x] `npm run lint:orphan` — No orphan exports detected
- [ ] **Device** — EAS dev 빌드 후 T4 시나리오 재현 (사용자 검증)
- [ ] **1주 production 측정** — widget stale > 10분 + tripActive=true 캡처 0건