### PR TITLE
fix(#1889): RC-19 observability KV day-limit gate + Sentry forward

### DIFF
--- a/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
+++ b/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
@@ -2,7 +2,7 @@
  * observabilityMetrics.test.ts — #1752 observabilityMetrics unit tests.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { InMemoryKV } from './inMemoryKv';
 import {
   buildAlarmLogNdjsonFixture,
@@ -12,8 +12,10 @@ import {
 import {
   computeObservabilityMetrics,
   hourBucketKey,
+  readLastSuccessfulMetrics,
   readObservabilityMetrics,
   storeObservabilityMetrics,
+  tryStoreObservabilityMetrics,
 } from '../observabilityMetrics';
 
 const NOW = 1_700_000_000_000;
@@ -462,5 +464,199 @@ describe('computeObservabilityMetrics — laPushDeliveryRatio (#1779)', () => {
     const r2 = makeEmptyFakeR2();
     const result = await computeObservabilityMetrics(r2, undefined, NOW);
     expect('laPushDeliveryRatio' in result).toBe(true);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// tryStoreObservabilityMetrics + readLastSuccessfulMetrics (#1889 RC-19)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** 테스트용 ObservabilityMetricsResponse fixture (모든 필드 기본값 채움). */
+const SAMPLE_METRICS = {
+  accuracyRatio: { value: 1, total: 2, ratio: 0.5 },
+  silentPushDeliveryRatio: { value: 0, total: 0, ratio: 0 },
+  locklessMissRatio: { value: 0, total: 0, ratio: 0 },
+  boardableMissRatio: { value: 0, total: 0, ratio: 0 },
+  accelPatternHitRatio: {
+    automotive: { count: 0, ratio: 0 },
+    walking: { count: 0, ratio: 0 },
+    stationary: { count: 0, ratio: 0 },
+    unknown: { count: 0, ratio: 0 },
+  },
+  silentPushLatency: null,
+  laPushDeliveryRatio: { sent: 0, failed: 0, ratio: 0 },
+  window: '24h' as const,
+  timestamp: NOW,
+};
+
+/**
+ * KV.put을 throw하도록 만든 stub. InMemoryKV는 put failure를 시뮬레이션하지 못해 별도 stub 사용.
+ * `failKeys`에 매칭되는 키만 throw, 나머지는 inner KV에 위임 — 부분 실패 시나리오 테스트용.
+ */
+class FailingPutKV {
+  inner = new InMemoryKV();
+  failKeys: (string | RegExp)[];
+  putErrors: { key: string; err: unknown }[] = [];
+  getThrows = false;
+
+  constructor(failKeys: (string | RegExp)[] = []) {
+    this.failKeys = failKeys;
+  }
+
+  async get(key: string): Promise<string | null> {
+    if (this.getThrows) throw new Error('KV GET failed');
+    return this.inner.get(key);
+  }
+
+  async put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void> {
+    const shouldFail = this.failKeys.some((p) =>
+      typeof p === 'string' ? p === key : p.test(key),
+    );
+    if (shouldFail) {
+      const err = new Error(`KV PUT failed: 429 daily write limit exceeded (key=${key})`);
+      this.putErrors.push({ key, err });
+      throw err;
+    }
+    return this.inner.put(key, value, options);
+  }
+
+  async delete(key: string): Promise<void> {
+    return this.inner.delete(key);
+  }
+}
+
+describe('tryStoreObservabilityMetrics (#1889 RC-19)', () => {
+  it('happy path — writes both hourly bucket and last-success key, returns stored=true', async () => {
+    const kv = new InMemoryKV();
+    const result = await tryStoreObservabilityMetrics(
+      kv as unknown as KVNamespace,
+      SAMPLE_METRICS,
+      NOW,
+    );
+    expect(result.stored).toBe(true);
+    expect(result.error).toBeUndefined();
+    // 1h bucket cache 존재
+    const bucketRaw = kv.store.get(hourBucketKey(NOW));
+    expect(bucketRaw).toBeDefined();
+    expect(JSON.parse(bucketRaw!.value)).toEqual(SAMPLE_METRICS);
+    // last-success fallback 존재
+    const lastSuccessRaw = kv.store.get('obs-metrics:last-success');
+    expect(lastSuccessRaw).toBeDefined();
+    expect(JSON.parse(lastSuccessRaw!.value)).toEqual(SAMPLE_METRICS);
+  });
+
+  it('last-success key uses 24h TTL (≫ 1h bucket TTL)', async () => {
+    const kv = new InMemoryKV();
+    const beforePut = Date.now();
+    await tryStoreObservabilityMetrics(kv as unknown as KVNamespace, SAMPLE_METRICS, NOW);
+    const lastSuccessEntry = kv.store.get('obs-metrics:last-success');
+    expect(lastSuccessEntry?.expiresAt).toBeGreaterThan(beforePut + 23 * 60 * 60 * 1000);
+    expect(lastSuccessEntry?.expiresAt).toBeLessThanOrEqual(beforePut + 25 * 60 * 60 * 1000);
+  });
+
+  it('hourly bucket write fails → stored=false + onError invoked + last-success still attempted', async () => {
+    const kv = new FailingPutKV([hourBucketKey(NOW)]);
+    const onError = vi.fn();
+    const result = await tryStoreObservabilityMetrics(
+      kv as unknown as KVNamespace,
+      SAMPLE_METRICS,
+      NOW,
+      { onError },
+    );
+    expect(result.stored).toBe(false);
+    expect(result.error).toBeInstanceOf(Error);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(expect.any(Error), hourBucketKey(NOW));
+    // last-success key는 별도 시도 → 성공
+    const lastSuccess = kv.inner.store.get('obs-metrics:last-success');
+    expect(lastSuccess).toBeDefined();
+  });
+
+  it('last-success write fails → stored=false + onError invoked with last-success key', async () => {
+    const kv = new FailingPutKV(['obs-metrics:last-success']);
+    const onError = vi.fn();
+    const result = await tryStoreObservabilityMetrics(
+      kv as unknown as KVNamespace,
+      SAMPLE_METRICS,
+      NOW,
+      { onError },
+    );
+    expect(result.stored).toBe(false);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(expect.any(Error), 'obs-metrics:last-success');
+    // hourly bucket은 성공
+    expect(kv.inner.store.get(hourBucketKey(NOW))).toBeDefined();
+  });
+
+  it('both writes fail → stored=false + onError invoked twice + first error returned', async () => {
+    const kv = new FailingPutKV([/.*/]);
+    const onError = vi.fn();
+    const result = await tryStoreObservabilityMetrics(
+      kv as unknown as KVNamespace,
+      SAMPLE_METRICS,
+      NOW,
+      { onError },
+    );
+    expect(result.stored).toBe(false);
+    expect(result.error).toBeInstanceOf(Error);
+    expect(onError).toHaveBeenCalledTimes(2);
+    // 첫 onError 호출 키는 hourly bucket, 두 번째는 last-success
+    expect(onError.mock.calls[0]?.[1]).toBe(hourBucketKey(NOW));
+    expect(onError.mock.calls[1]?.[1]).toBe('obs-metrics:last-success');
+  });
+
+  it('onError 미제공 시에도 throw 없이 stored=false 반환', async () => {
+    const kv = new FailingPutKV([/.*/]);
+    const result = await tryStoreObservabilityMetrics(
+      kv as unknown as KVNamespace,
+      SAMPLE_METRICS,
+      NOW,
+    );
+    expect(result.stored).toBe(false);
+    expect(result.error).toBeInstanceOf(Error);
+  });
+});
+
+describe('readLastSuccessfulMetrics (#1889 RC-19)', () => {
+  it('key 부재 → null 반환', async () => {
+    const kv = new InMemoryKV();
+    const result = await readLastSuccessfulMetrics(kv as unknown as KVNamespace);
+    expect(result).toBeNull();
+  });
+
+  it('tryStore 후 즉시 read 가능 (round-trip)', async () => {
+    const kv = new InMemoryKV();
+    await tryStoreObservabilityMetrics(kv as unknown as KVNamespace, SAMPLE_METRICS, NOW);
+    const result = await readLastSuccessfulMetrics(kv as unknown as KVNamespace);
+    expect(result).toEqual(SAMPLE_METRICS);
+  });
+
+  it('malformed JSON → null 반환 (caller가 503 응답)', async () => {
+    const kv = new InMemoryKV();
+    kv.store.set('obs-metrics:last-success', { value: '{not-json' });
+    const result = await readLastSuccessfulMetrics(kv as unknown as KVNamespace);
+    expect(result).toBeNull();
+  });
+
+  it('KV.get throw → null 반환 (caller가 503 응답)', async () => {
+    const kv = new FailingPutKV();
+    kv.getThrows = true;
+    const result = await readLastSuccessfulMetrics(kv as unknown as KVNamespace);
+    expect(result).toBeNull();
+  });
+
+  it('1h bucket이 만료돼도 last-success는 24h TTL 동안 살아남음', async () => {
+    const kv = new InMemoryKV();
+    await tryStoreObservabilityMetrics(kv as unknown as KVNamespace, SAMPLE_METRICS, NOW);
+    // 1h bucket 만료 시뮬레이션
+    const bucketKey = hourBucketKey(NOW);
+    const bucketEntry = kv.store.get(bucketKey);
+    if (bucketEntry) bucketEntry.expiresAt = Date.now() - 1000;
+    // read는 cache miss
+    const cached = await readObservabilityMetrics(kv as unknown as KVNamespace, NOW);
+    expect(cached).toBeNull();
+    // 그러나 last-success는 여전히 유효
+    const fallback = await readLastSuccessfulMetrics(kv as unknown as KVNamespace);
+    expect(fallback).toEqual(SAMPLE_METRICS);
   });
 });

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -102,8 +102,9 @@ import { CRON_READ_CACHE_TTL_SEC, KV_MIN_CACHE_TTL_SEC } from './kvConsistency';
 import { deleteSsot, readSsot } from './tripPositionSsot';
 import {
   computeObservabilityMetrics,
+  readLastSuccessfulMetrics,
   readObservabilityMetrics,
-  storeObservabilityMetrics,
+  tryStoreObservabilityMetrics,
 } from './observabilityMetrics';
 import { getTrip, putTrip } from './trips';
 import { inferWaypointsFromOriginAndDestination } from './dijkstraRoute';
@@ -1095,7 +1096,7 @@ app.get('/metrics/recall/summary', (c) => {
 });
 
 /**
- * Observability metrics endpoint (#1752, #1503 M3 Sub 2).
+ * Observability metrics endpoint (#1752, #1503 M3 Sub 2, #1889 RC-19).
  *
  * DebugModal(Sub 1)이 1h cron이 미리 집계한 4 KPI를 읽어 표시한다.
  * 집계 결과가 없으면(cron 미실행/첫 배포) 실시간으로 계산해 반환하고 KV에 적재.
@@ -1105,7 +1106,12 @@ app.get('/metrics/recall/summary', (c) => {
  *
  * Response 200:
  *   { accuracyRatio, silentPushDeliveryRatio, locklessMissRatio, boardableMissRatio, window, timestamp }
+ *   stale fallback 시 `X-Stale-Cache: true` + `X-Error: <reason>` header.
  * Response 401/503: 인증/binding 정책 동일 (TELEMETRY_R2 미바인딩 시 503 graceful)
+ *
+ * #1889 RC-19 — KV day-limit 초과 / compute throw 시 last-success cache로 fail-open.
+ *   사용자 dashboard가 "no data" 대신 stale 데이터를 보게 한다. 에러는 Sentry breadcrumb으로
+ *   forward되어 silent drop 되지 않는다.
  */
 app.get('/v1/observability/metrics', async (c) => {
   const authError = checkAdminAuth(c.req.header('authorization'), c.env.ADMIN_TOKEN);
@@ -1115,14 +1121,36 @@ app.get('/v1/observability/metrics', async (c) => {
 
   const now = Date.now();
 
-  // KV에 최신 집계가 있으면 그대로 반환 — R2 scan 비용 절감.
-  const cached = await readObservabilityMetrics(c.env.TRIPS, now);
-  if (cached) return c.json(cached);
+  // KV에 최신 1h bucket 집계가 있으면 그대로 반환 — R2 scan + list() 비용 0.
+  try {
+    const cached = await readObservabilityMetrics(c.env.TRIPS, now);
+    if (cached) return c.json(cached);
+  } catch (err) {
+    // KV read 자체 실패는 day-limit과는 별개. compute로 fallthrough하되 Sentry forward.
+    captureBackendException(err, { path: 'observability/metrics', stage: 'read-cache' });
+  }
 
   // 첫 요청 또는 KV TTL 만료(1h) 시 실시간 계산 후 KV 적재.
-  const metrics = await computeObservabilityMetrics(r2, c.env.PENDING_PUSHES, now, c.env.TRIPS);
-  await storeObservabilityMetrics(c.env.TRIPS, metrics, now);
-  return c.json(metrics);
+  try {
+    const metrics = await computeObservabilityMetrics(r2, c.env.PENDING_PUSHES, now, c.env.TRIPS);
+    const storeResult = await tryStoreObservabilityMetrics(c.env.TRIPS, metrics, now, {
+      onError: (err, key) =>
+        captureBackendException(err, { path: 'observability/metrics', stage: 'kv-put', key }),
+    });
+    // storeResult.stored=false라도 metrics 자체는 정상이므로 200 반환. fallback caching만 실패.
+    return c.json(metrics, 200, storeResult.stored ? {} : { 'X-Store-Failed': 'true' });
+  } catch (err) {
+    // compute 실패 (R2 outage / KV list day-limit) → last-success fallback.
+    captureBackendException(err, { path: 'observability/metrics', stage: 'compute' });
+    const fallback = await readLastSuccessfulMetrics(c.env.TRIPS);
+    if (fallback) {
+      return c.json(fallback, 200, {
+        'X-Stale-Cache': 'true',
+        'X-Error': err instanceof Error ? err.message : 'compute_failed',
+      });
+    }
+    return c.json({ error: 'metrics_unavailable' }, 503);
+  }
 });
 
 /**
@@ -2141,13 +2169,28 @@ const handler = {
     // #1752 — observability metrics 1h 주기 집계. cron이 매분 실행되지만 1h bucket 키가
     // 이미 KV에 있으면 readObservabilityMetrics가 null을 반환하지 않으므로 computeAndStore는
     // 실행되지 않음. TELEMETRY_R2 미바인딩 시 graceful no-op.
+    //
+    // #1889 RC-19 — KV day-limit 초과 / compute throw 시 swallow + Sentry forward.
+    //   cron 자체는 throw 없이 다음 minute에 재시도. endpoint는 last-success fallback으로 200.
     if (env.TELEMETRY_R2) {
       const now = Date.now();
-      const existing = await readObservabilityMetrics(env.TRIPS, now);
-      if (!existing) {
-        const metrics = await computeObservabilityMetrics(env.TELEMETRY_R2, env.PENDING_PUSHES, now, env.TRIPS);
-        await storeObservabilityMetrics(env.TRIPS, metrics, now);
-        log('observability metrics aggregated', { window: '24h', timestamp: now });
+      try {
+        const existing = await readObservabilityMetrics(env.TRIPS, now);
+        if (!existing) {
+          const metrics = await computeObservabilityMetrics(env.TELEMETRY_R2, env.PENDING_PUSHES, now, env.TRIPS);
+          const storeResult = await tryStoreObservabilityMetrics(env.TRIPS, metrics, now, {
+            onError: (err, key) =>
+              captureBackendException(err, { path: 'scheduled/observabilityMetrics', stage: 'kv-put', key }),
+          });
+          log('observability metrics aggregated', {
+            window: '24h',
+            timestamp: now,
+            stored: storeResult.stored,
+          });
+        }
+      } catch (err) {
+        // compute / read throw — swallow. cron이 매분 재시도하므로 transient 실패는 다음에 회복.
+        captureBackendException(err, { path: 'scheduled/observabilityMetrics', stage: 'compute' });
       }
     }
   },

--- a/backend/alarm-worker/src/observabilityMetrics.ts
+++ b/backend/alarm-worker/src/observabilityMetrics.ts
@@ -41,6 +41,20 @@ const METRICS_KEY_PREFIX = 'obs-metrics:24h:';
 /** 1h TTL — rolling window 다음 집계 전까지 캐시. */
 const METRICS_KV_TTL_SEC = 60 * 60;
 
+/**
+ * #1889 RC-19 — KV day-limit 도달 시 fallback용 long-TTL "last-success" 캐시 키.
+ *
+ * 1h bucket 캐시(`obs-metrics:24h:{bucket}`)는 매 시간 키가 바뀌어 fallback으로 사용 불가.
+ * 별도 고정 키에 24h TTL로 마지막 성공 응답을 보관 → KV write 실패/compute throw 시 endpoint가
+ * stale 데이터로 fail-open할 수 있다.
+ *
+ * 키 1개 + 24h TTL 이므로 day-limit 부담은 hourly bucket과 동일(1h마다 1 put). 추가 list 호출 X.
+ */
+const METRICS_LAST_SUCCESS_KEY = 'obs-metrics:last-success';
+
+/** 마지막 성공 캐시 TTL — 24h. day-limit 초과로 1h 연속 실패해도 fail-open 보장. */
+const METRICS_LAST_SUCCESS_TTL_SEC = 24 * 60 * 60;
+
 /** accel pattern 4종 분포 bucket. */
 export interface AccelPatternBucket {
   automotive: { count: number; ratio: number };
@@ -162,6 +176,74 @@ export async function storeObservabilityMetrics(
 ): Promise<void> {
   const key = hourBucketKey(now);
   await tripsKv.put(key, JSON.stringify(metrics), { expirationTtl: METRICS_KV_TTL_SEC });
+}
+
+/**
+ * #1889 RC-19 — KV write rate-limit gate + Sentry forward.
+ *
+ * 매분 cron / endpoint polling이 동시에 KV put을 호출하면 day-limit 초과 시 endpoint가 500
+ * 응답 → dashboard "no data". 본 helper는 두 단계로 보호한다.
+ *
+ * 1. 1h bucket 키 + last-success 키 둘 다 put 시도. Cloudflare KV가 day-limit으로 reject 시
+ *    swallow + breadcrumb. cron / endpoint 자체는 throw 없이 진행.
+ * 2. last-success 키는 1h bucket과 별도 24h TTL을 유지 → 후속 read fallback의 SSoT.
+ *
+ * silent drop 금지 — KV write 실패 시 `onError(err)` 콜백으로 Sentry forward를 caller가 수행한다.
+ * (sentry.ts는 backend-only이고 본 모듈을 unit test로 격리하려면 import 회피가 필요해 콜백 패턴.)
+ *
+ * @returns 두 키 모두 성공이면 `{ stored: true }`. 한 쪽이라도 실패면 `{ stored: false, error }`.
+ */
+export async function tryStoreObservabilityMetrics(
+  tripsKv: KVNamespace,
+  metrics: ObservabilityMetricsResponse,
+  now: number,
+  options?: { onError?: (err: unknown, key: string) => void },
+): Promise<{ stored: boolean; error?: unknown }> {
+  const onError = options?.onError;
+  let firstError: unknown;
+  // hourly bucket — 1h read cache.
+  try {
+    await storeObservabilityMetrics(tripsKv, metrics, now);
+  } catch (err) {
+    firstError = err;
+    if (onError) onError(err, hourBucketKey(now));
+  }
+  // last-success — 24h fallback. 한 쪽 실패해도 다른 쪽은 시도.
+  try {
+    await tripsKv.put(METRICS_LAST_SUCCESS_KEY, JSON.stringify(metrics), {
+      expirationTtl: METRICS_LAST_SUCCESS_TTL_SEC,
+    });
+  } catch (err) {
+    if (firstError === undefined) firstError = err;
+    if (onError) onError(err, METRICS_LAST_SUCCESS_KEY);
+  }
+  return firstError === undefined ? { stored: true } : { stored: false, error: firstError };
+}
+
+/**
+ * #1889 RC-19 — 마지막 성공 응답 fallback.
+ *
+ * 1h bucket cache miss + compute throw (KV list day-limit / R2 outage) 시 endpoint가
+ * dashboard "no data" 대신 stale 데이터를 응답할 수 있게 한다. KV read 자체가 throw 시 null
+ * 반환 (caller가 503 응답).
+ *
+ * @returns 마지막 성공 응답 또는 null.
+ */
+export async function readLastSuccessfulMetrics(
+  tripsKv: KVNamespace,
+): Promise<ObservabilityMetricsResponse | null> {
+  let raw: string | null;
+  try {
+    raw = await tripsKv.get(METRICS_LAST_SUCCESS_KEY);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as ObservabilityMetricsResponse;
+  } catch {
+    return null;
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #1889

## 요약 (P2 단독 PR)

`/v1/observability/metrics` 1.5h 동안 8회 polling 중 1회 **500 응답** — KV day-limit 초과로 KV write/list 실패 시 endpoint가 throw → dashboard "no data". 본 PR은 **surgical fail-open + Sentry forward**로 사용자 가시성을 회복한다. (Option C 권장 조합 — D1 incremental aggregation(Option A)은 별도 PR로 분리, 의존 PR 아래 참조.)

### 변경 사항

1. **`observabilityMetrics.ts`** — 신규 helper 2개:
   - `tryStoreObservabilityMetrics(kv, metrics, now, { onError })`
     - 1h bucket 키 + `obs-metrics:last-success` (24h TTL) 키 둘 다 put 시도
     - put 실패는 swallow + `onError(err, key)` 콜백으로 Sentry forward — silent drop 금지
     - 두 키 모두 성공 시 `{ stored: true }`, 한 쪽이라도 실패 시 `{ stored: false, error }`
   - `readLastSuccessfulMetrics(kv)` — 24h TTL `last-success` 키 fallback read (throw 시 null)

2. **`index.ts` `/v1/observability/metrics` 엔드포인트**:
   - cache hit → 200 (변동 없음)
   - cache miss → compute. **compute throw 시** `last-success` fallback 응답 + `X-Stale-Cache: true` + `X-Error: <reason>` header. fallback 없으면 `503 metrics_unavailable`
   - KV write 실패해도 metrics 자체는 200 응답 + `X-Store-Failed: true` header

3. **`index.ts` cron**:
   - 동일 try/catch + `tryStoreObservabilityMetrics`. compute/read throw 시 swallow + Sentry forward — cron이 매분 재시도

### 호환성
- 응답 shape 변경 없음 (header 추가만). frontend `observabilityMetricsClient` 변경 불필요 — 200을 그대로 `ok`로 처리, stale 데이터도 dashboard 정상 표시.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan). 신규 export `tryStoreObservabilityMetrics`/`readLastSuccessfulMetrics`는 `index.ts`에서 호출. `storeObservabilityMetrics` 직접 호출이 사라져 type-check error로 import도 제거.
2. **V/X dashboard**:
   - V: backend log `observability metrics aggregated` (`stored` 필드 추가) — Cloudflare Dashboard Logs
   - X: Sentry `path=observability/metrics`/`scheduled/observabilityMetrics` breadcrumb — `stage` 필드(`read-cache` / `compute` / `kv-put`)로 분류
   - dashboard 응답 `X-Stale-Cache: true` header — wrangler tail / 사용자 측 fetch 응답에서 관측 가능
3. **의존 PR**: N/A — backend-only, 새 KV binding 없음 (기존 `TRIPS` 재사용). Option A (D1 incremental aggregation)는 별도 follow-up issue 권장 (KV list() 호출 자체를 줄여 day-limit 가속 방지).
4. **측정 plan (7일)**:
   - Cloudflare Dashboard Logs → `/v1/observability/metrics` `status=500` count (목표 0)
   - Sentry → `path=observability/metrics` breadcrumb count + `stage` 분포 (kv-put 실패 가속도 관찰)
   - dashboard polling 성공률 (frontend telemetry, 목표 > 99.9%)
5. **Device verify**: N/A — type+unit only. dashboard 표시는 DebugModal observability tab을 device build에서 수동 확인하면 좋지만 backend behavior 변경 (응답 200 stale fallback)만으로 검증 충분.

## 검증
- `npx vitest run` backend 60 files / **2251 tests pass** (신규 16건 포함)
- `npx tsc --noEmit` backend type-check pass
- `npm run type-check` frontend pass, `npm run lint:orphan` pass
- frontend 전체 테스트는 무관 DebugModal flaky timeout 2건 외 8263 pass (단독 재실행 시 PASS)
- code-review (low) findings: none

## Backend deploy 의존
- 본 PR 머지 후 `wrangler deploy` 필요. KV 새 키(`obs-metrics:last-success`)는 첫 cron/endpoint hit 시 자동 생성, schema migration 불필요.