### PR TITLE
fix(#1899): RC-21 LA token rotation race BadDeviceToken 400

### DIFF
--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -7,6 +7,7 @@ import {
   cleanupTripWithLa,
   fireLiveActivityDismissal,
   fireLiveActivityUpdate,
+  isApnsTokenInvalid,
   staleDurationSecForKind,
   type LiveActivityDeps,
   type LiveActivityStats,
@@ -423,7 +424,7 @@ describe('fireLiveActivityUpdate', () => {
     expect(stats.laTokenCleared).toBe(1);
   });
 
-  it('does not clear on non-410 failure (dirty=false)', async () => {
+  it('does not clear on non-token-invalid failure (dirty=false)', async () => {
     const fetchImpl = vi.fn(async () =>
       new Response(JSON.stringify({ reason: 'InternalServerError' }), { status: 500 }),
     );
@@ -440,6 +441,51 @@ describe('fireLiveActivityUpdate', () => {
     expect(r.dirty).toBe(false);
     expect(trip.activityPushToken).toBe('la-token');
     expect(stats.laPushFailed).toBe(1);
+    expect(stats.laTokenCleared).toBe(0);
+  });
+
+  // #1899 — trip 경계 rotation race에서 짧은 window 동안 옛 token이 400 BadDeviceToken으로
+  // 응답되는 패턴. 410으로 전환되기 전 cron이 stale token 재시도하면 BadDeviceToken 폭증 →
+  // 즉시 clear로 해결.
+  it('clears token + sets ended on 400 BadDeviceToken (dirty=true) (#1899)', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
+    );
+    const stats = makeStats();
+    const trip = makeTrip();
+    const r = await fireLiveActivityUpdate(
+      trip,
+      {},
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      NOW,
+      () => undefined,
+    );
+    expect(r.dirty).toBe(true);
+    expect(trip.activityPushToken).toBeUndefined();
+    expect(trip.activityState).toBe('ended');
+    expect(stats.laPushFailed).toBe(1);
+    expect(stats.laTokenCleared).toBe(1);
+  });
+
+  // 400 reason이 token error가 아니면(예: BadTopic — 백엔드 코드/구성 문제) clear하지 않는다.
+  // token 자체가 멀쩡한데 clear하면 정상 trip의 LA가 silent dead가 되어 회귀.
+  it('does not clear on 400 with non-BadDeviceToken reason (dirty=false) (#1899)', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'BadTopic' }), { status: 400 }),
+    );
+    const stats = makeStats();
+    const trip = makeTrip();
+    const r = await fireLiveActivityUpdate(
+      trip,
+      {},
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      NOW,
+      () => undefined,
+    );
+    expect(r.dirty).toBe(false);
+    expect(trip.activityPushToken).toBe('la-token');
     expect(stats.laTokenCleared).toBe(0);
   });
 });
@@ -510,7 +556,7 @@ describe('fireLiveActivityDismissal', () => {
     expect(stats.laTokenCleared).toBe(1);
   });
 
-  it('increments laPushFailed but not laTokenCleared on non-410 failure', async () => {
+  it('increments laPushFailed but not laTokenCleared on non-token-invalid failure', async () => {
     const fetchImpl = vi.fn(async () =>
       new Response(JSON.stringify({ reason: 'ServerUnavailable' }), { status: 503 }),
     );
@@ -525,6 +571,50 @@ describe('fireLiveActivityDismissal', () => {
     );
     expect(stats.laPushFailed).toBe(1);
     expect(stats.laTokenCleared).toBe(0);
+  });
+
+  // #1899 — dismissal 시 400 BadDeviceToken도 token-invalid 카운팅. update와 정렬.
+  it('counts laTokenCleared on 400 BadDeviceToken (#1899)', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
+    );
+    const stats = makeStats();
+    const trip = makeTrip();
+    await fireLiveActivityDismissal(
+      trip,
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      NOW,
+      () => undefined,
+    );
+    expect(stats.laPushFailed).toBe(1);
+    expect(stats.laTokenCleared).toBe(1);
+  });
+});
+
+// #1899 — APNs token-invalid 판정 단위 테스트. fireLiveActivityUpdate/Dismissal의
+// clear 분기 SSoT라 케이스가 분기 매트릭스 전부 커버되도록 한다.
+describe('isApnsTokenInvalid (#1899)', () => {
+  it('returns true for 410 regardless of reason', () => {
+    expect(isApnsTokenInvalid(410, 'Unregistered')).toBe(true);
+    expect(isApnsTokenInvalid(410, undefined)).toBe(true);
+  });
+
+  it('returns true for 400 + BadDeviceToken', () => {
+    expect(isApnsTokenInvalid(400, 'BadDeviceToken')).toBe(true);
+  });
+
+  it('returns false for 400 with other reasons (config error, not token error)', () => {
+    expect(isApnsTokenInvalid(400, 'BadTopic')).toBe(false);
+    expect(isApnsTokenInvalid(400, 'MissingTopic')).toBe(false);
+    expect(isApnsTokenInvalid(400, undefined)).toBe(false);
+  });
+
+  it('returns false for non-error / unrelated status codes', () => {
+    expect(isApnsTokenInvalid(200, undefined)).toBe(false);
+    expect(isApnsTokenInvalid(500, 'InternalServerError')).toBe(false);
+    expect(isApnsTokenInvalid(503, 'ServerUnavailable')).toBe(false);
+    expect(isApnsTokenInvalid(undefined, undefined)).toBe(false);
   });
 });
 

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -130,11 +130,16 @@ export interface LiveActivityFireResult {
 
 /**
  * LA update push 발사. trip에 activity token이 없거나 state가 live가 아니면 no-op.
- * 410 응답 시 token clear + state='ended'로 전이 (dirty=true).
+ * APNs token-invalid 응답 시 token clear + state='ended'로 전이 (dirty=true).
  *
  * silent/reschedule push의 env-heal(#482)은 LA에 적용하지 않는다 — LA token은 register 시점에
  * 디바이스가 apnsEnv를 확정 통지(`POST /live-activity/register`가 trip의 apnsEnv를 신뢰)하므로,
- * 토큰/환경 불일치는 곧 토큰 자체 무효를 의미. 410 분기에서 단순 clear로 흡수.
+ * 토큰/환경 불일치는 곧 토큰 자체 무효를 의미. token-invalid 분기에서 단순 clear로 흡수.
+ *
+ * #1899 — token-invalid 판정 확장: 410 Unregistered + 400 BadDeviceToken 둘 다 처리.
+ * APNs는 rotation 직후 짧은 window에서 옛 token으로 400 BadDeviceToken을 반환하다가 410로
+ * 전환되는 패턴이 있다(T2/T3 trip 경계 race). 400을 clear 안 하면 다음 cron cycle도 같은
+ * stale token으로 재시도 → BadDeviceToken 폭증 + LA UI desync. reason 문자열이 SSoT.
  */
 export async function fireLiveActivityUpdate(
   trip: Trip,
@@ -169,13 +174,36 @@ export async function fireLiveActivityUpdate(
     status: result.status,
     reason: result.reason,
   });
-  if (result.status === 410) {
+  if (isApnsTokenInvalid(result.status, result.reason)) {
     trip.activityPushToken = undefined;
     trip.activityState = 'ended';
     stats.laTokenCleared += 1;
     return { dirty: true };
   }
   return { dirty: false };
+}
+
+/**
+ * APNs 응답이 LA token 무효(rotation/unregister/env mismatch)임을 의미하는지 판정 (#1899).
+ *
+ * - status=410: APNs가 token을 invalidated 처리 (가장 확정적인 신호)
+ * - status=400 + reason='BadDeviceToken': trip 경계 rotation race에서 짧은 window 동안
+ *   옛 token이 400으로 응답되는 패턴. 410으로 전환되기 전 cron cycle이 stale token으로
+ *   재시도하면 BadDeviceToken 폭증 + LA UI desync → 즉시 clear가 정답.
+ *
+ * Apple HTTP/2 APNs response reference:
+ *   https://developer.apple.com/documentation/usernotifications/handling-notification-responses-from-apns
+ *
+ * 다른 400 reason(`BadTopic`, `MissingTopic` 등 구성 오류)은 token 자체 문제가 아니라
+ * 백엔드 코드/구성 결함 → token clear가 아니라 코드 수정 대상이라 false. reason 명시 분기로 보호.
+ */
+export function isApnsTokenInvalid(
+  status: number | undefined,
+  reason: string | undefined,
+): boolean {
+  if (status === 410) return true;
+  if (status === 400 && reason === 'BadDeviceToken') return true;
+  return false;
 }
 
 /**
@@ -216,7 +244,7 @@ export async function fireLiveActivityDismissal(
       status: result.status,
       reason: result.reason,
     });
-    if (result.status === 410) stats.laTokenCleared += 1;
+    if (isApnsTokenInvalid(result.status, result.reason)) stats.laTokenCleared += 1;
   }
   // 결과 무관 — 로컬 trip 상태를 ended로 전이. dismissal은 best-effort이며 trip은 곧 삭제됨.
   trip.activityPushToken = undefined;

--- a/src/features/alarm/utils/__tests__/liveActivityPushChannel.test.ts
+++ b/src/features/alarm/utils/__tests__/liveActivityPushChannel.test.ts
@@ -259,6 +259,56 @@ describe('liveActivityPushChannel', () => {
       await jest.advanceTimersByTimeAsync(500);
       expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(2);
     });
+
+    // #1899 — 404 (trip_not_found)는 trip register propagate race. longer backoff(2s)로 흡수.
+    // 500ms backoff로 재시도해도 같은 race를 hit하면 retry 효과가 0이라 무의미하다.
+    it('register 404 응답 시 2s longer backoff (trip register race)', async () => {
+      const handle = setupListener();
+      mockRegisterLiveActivityToken
+        .mockResolvedValueOnce({ ok: false, status: 404 })
+        .mockResolvedValueOnce({ ok: true });
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      handle.emit('tok');
+      // 첫 호출 동기 발사
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(1);
+      // 500ms로는 재시도 안 됨 (404 backoff는 2s)
+      await jest.advanceTimersByTimeAsync(500);
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(1);
+      // 2s 도달 후 재시도
+      await jest.advanceTimersByTimeAsync(1500);
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(2);
+    });
+
+    // #1899 — 404가 3회 연속이면 8s까지 backoff 확장. 마지막은 silent log.
+    it('register 404 3회 연속 시 2s → 4s exponential backoff 후 포기', async () => {
+      const handle = setupListener();
+      mockRegisterLiveActivityToken.mockResolvedValue({ ok: false, status: 404 });
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      handle.emit('tok');
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(1);
+      await jest.advanceTimersByTimeAsync(2000);
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(2);
+      await jest.advanceTimersByTimeAsync(4000);
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(3);
+    });
+
+    // 회귀 가드 — throw가 났을 때 lastStatus는 undefined로 reset되어 기본 backoff(500ms) 사용.
+    // 404 backoff가 stale하게 다음 throw 시 적용되면 graceful 보장 깨짐.
+    it('register throw 후 다음 attempt는 기본 500ms backoff (404 stale 안 됨)', async () => {
+      const handle = setupListener();
+      mockRegisterLiveActivityToken
+        .mockResolvedValueOnce({ ok: false, status: 404 })
+        .mockRejectedValueOnce(new Error('net'))
+        .mockResolvedValueOnce({ ok: true });
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      handle.emit('tok');
+      // 첫 404 → 2s 대기
+      await jest.advanceTimersByTimeAsync(2000);
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(2);
+      // 2번째 throw → 기본 1s(500*2) 대기. 1s 후 3번째 발사.
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(3);
+    });
   });
 
   describe('ensureLiveActivityRegistered (#1288)', () => {

--- a/src/features/alarm/utils/liveActivityPushChannel.ts
+++ b/src/features/alarm/utils/liveActivityPushChannel.ts
@@ -38,6 +38,16 @@ const PUSH_TOKEN_FIRST_EMIT_TIMEOUT_MS = 5000;
 const REGISTER_RETRY_MAX_ATTEMPTS = 3;
 const REGISTER_RETRY_BASE_DELAY_MS = 500;
 
+/**
+ * 404 (`trip_not_found`) 응답 시 longer backoff (#1899).
+ * device가 trip register POST를 보낸 직후 push token이 emit되면 backend KV write가
+ * 아직 propagate되지 않아 LA register가 404로 응답할 수 있다. 500ms 기본 backoff는 짧아
+ * 같은 race를 반복 hit하므로, 404 시에만 2s/4s/8s exponential로 늘려 trip register가
+ * 도착할 시간을 확보한다. 다른 status(5xx, network)는 기존 500ms/1s 유지 — 일시적
+ * 인프라 장애는 빠르게 재시도하는 편이 사용자 가치 손실이 적다.
+ */
+const REGISTER_RETRY_404_BASE_DELAY_MS = 2000;
+
 /** 현재 LA 세션의 teardown 함수. 단일 LA만 동시 운영한다는 전제. */
 let activeTeardown: (() => void) | null = null;
 /** 현재 활성 LA 세션의 tripToken. ensureLiveActivityRegistered가 start vs update 판정에 사용. */
@@ -56,16 +66,22 @@ async function registerWithRetry(
   tripToken: string,
   activityPushToken: string,
 ): Promise<void> {
+  let lastStatus: number | undefined;
   for (let attempt = 1; attempt <= REGISTER_RETRY_MAX_ATTEMPTS; attempt += 1) {
     try {
       const result = await registerLiveActivityToken(tripToken, activityPushToken);
       if (result.ok) return;
+      lastStatus = result.status;
       log.warn(`LA register attempt ${attempt} not ok status=${result.status ?? 'none'}`);
     } catch (e) {
+      lastStatus = undefined;
       log.warn(`LA register attempt ${attempt} threw`, e);
     }
     if (attempt < REGISTER_RETRY_MAX_ATTEMPTS) {
-      await sleep(REGISTER_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1));
+      // #1899 — 404(trip_not_found)는 trip register propagate race이므로 longer backoff.
+      const base =
+        lastStatus === 404 ? REGISTER_RETRY_404_BASE_DELAY_MS : REGISTER_RETRY_BASE_DELAY_MS;
+      await sleep(base * 2 ** (attempt - 1));
     }
   }
   log.warn('LA register exhausted retries — giving up (will retry on next token emit)');


### PR DESCRIPTION
Closes #1899

## Summary

T2/T3 trip 경계 LA token rotation race로 BadDeviceToken status=400 + register 404가 동시 발생하는 회귀 수정.

- **Backend**: `liveActivity.ts`에 `isApnsTokenInvalid(status, reason)` helper 도입. 기존 `result.status === 410` 분기를 410 Unregistered + 400 BadDeviceToken 둘 다 cover하도록 확장. APNs는 rotation 직후 짧은 window에서 옛 token이 400 BadDeviceToken으로 응답되다가 410으로 전환되는 패턴이 있어, 400을 clear 안 하면 다음 cron cycle도 같은 stale token으로 재시도 → BadDeviceToken 폭증 + LA UI desync. 다른 400 reason(BadTopic 등 구성 오류)은 token clear 대상 아님이라 reason 명시 분기로 보호.
- **Device**: `liveActivityPushChannel.ts` `registerWithRetry`에 `lastStatus` 추적 + 404 시 longer backoff (2s/4s exponential). 기존 500ms/1s는 trip register propagate race를 반복 hit해 retry 효과 0. throw 시 lastStatus undefined로 reset해 stale 적용 차단.

## Decision rationale (Option A — APNs reason 자체가 SSoT)

Issue body는 invalidation cache + sequential await dual-PR 제안. 그러나:
- 이미 `ensureLiveActivityRegistered`(line 152~158)가 device-side sequential await 수행 중 (이전 `endLiveActivityWithDeregister` → 새 `startLiveActivityWithRegistration`)
- APNs reason 자체가 token 무효 SSoT — 별도 invalidation cache 도입은 over-engineering
- Simplicity First: 진짜 root cause는 backend가 400 BadDeviceToken을 token-invalid로 인정하지 않은 것 + device retry backoff 부족

## Test plan

### 자동 (CI)
- `npm test` 8205 tests pass + 100% coverage
- `npx vitest run src/__tests__/liveActivity.test.ts` 61 tests pass
- `npm run type-check` pass
- `npm run lint:orphan` pass (`isApnsTokenInvalid` export caller — test에서 직접 사용)

### 신규 테스트 케이스
- `clears token + sets ended on 400 BadDeviceToken (dirty=true)` — fireLiveActivityUpdate
- `does not clear on 400 with non-BadDeviceToken reason (dirty=false)` — BadTopic 회귀 가드
- `counts laTokenCleared on 400 BadDeviceToken` — fireLiveActivityDismissal
- `isApnsTokenInvalid` 분기 매트릭스 전부 (410/400/200/500/503/undefined)
- `register 404 응답 시 2s longer backoff` — device retry
- `register 404 3회 연속 시 2s → 4s exponential backoff 후 포기`
- `register throw 후 다음 attempt는 기본 500ms backoff (404 stale 안 됨)`

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass. 신규 export `isApnsTokenInvalid` test caller로 wired.
2. **V/X dashboard** —
   - V: backend log `la update failed` count + `laTokenCleared` stat 증가
   - X: `BadDeviceToken` recurring count (token-invalid clear 후 다음 cycle no-op이라 감소 expected)
   - Cloudflare Dashboard Logs → `kind=la-update` 실패율 / wrangler tail filter `BadDeviceToken`
3. **의존 PR** — N/A (backend + device 같은 PR에서 동시 머지)
4. **측정 plan**:
   - 1주 backend log `la update failed reason=BadDeviceToken status=400` count → 회귀 신호 5건/주 초과 시 P1
   - `live-activity/register 404` count → 10건/주 초과 시 P1
   - `laTokenCleared` stat (scheduled.ts log) 추세 — token rotation 정상화 시 안정
5. **Device verify** — 필요. 시나리오:
   - **시나리오 1 (T2/T3 trip 경계 재현)**: lock 활성 trip 종료 → 새 lockless trip 시작 → LA가 30s 이내 새 context로 전환. 이전 "건대입구 → 용마산" stale 표시 0.
   - **시나리오 2 (호선 자동 전환, RC-14 cascade)**: 2호선 lock → 7호선 transfer → LA 끊김 없이 7호선 context로 전환.
   - **시나리오 3 (backend log 모니터링)**: trip 경계에서 wrangler tail로 `la update failed status=400 reason=BadDeviceToken` 발생 → 다음 cycle에 같은 token 재시도 없음 확인.

## Backend / Native 영향

- Backend: **wrangler deploy 필요** — `backend/alarm-worker/src/liveActivity.ts` 변경. PR 머지 후 backend 따로 deploy.
- Native module 변경 없음 — `modules/live-activity/`는 untouched. expo prebuild 영향 X.