### PR TITLE
fix(#1890 follow-up): SubwayWidget compile-time iOS guard (#if os(iOS))

### DIFF
--- a/targets/subway-widget/SubwayWidget.swift
+++ b/targets/subway-widget/SubwayWidget.swift
@@ -1,3 +1,9 @@
+// #1890 — SourceKit이 macOS target 인덱싱 시 `accessoryRectangular` / `accessoryCircular`
+// 같은 iOS-only WidgetFamily case를 'unavailable in macOS'로 진단한다. `#available(iOS 16.0, *)`
+// 는 런타임 가드일 뿐 compile-time 차단이 아니므로, 파일 전체를 `#if os(iOS)`로 감싸 SourceKit/
+// SwiftPM의 macOS 변형에서 이 파일을 통째로 건너뛰게 한다. SubwayLiveActivityWidget.swift와
+// 동일한 patten.
+#if os(iOS)
 import WidgetKit
 import SwiftUI
 
@@ -451,4 +457,6 @@ private struct SubwayWidgetEntryView: View {
         }
     }
 }
+
+#endif
 


### PR DESCRIPTION
## 배경
PR #1911 머지 후 SourceKit diagnostics 2건 발견:
- `SubwayWidget.swift:420:51` — `accessoryRectangular is unavailable in macOS`
- `SubwayWidget.swift:420:74` — `accessoryCircular is unavailable in macOS`

`#available(iOS 16.0, *)` 런타임 가드만으로는 SourceKit이 macOS target indexing 시 unavailable 처리. **compile-time `#if os(iOS)` 가드 필요**.

## 변경
- `targets/subway-widget/SubwayWidget.swift` — 파일 전체를 `#if os(iOS) ... #endif`로 감쌌다. `SubwayLiveActivityWidget.swift`가 이미 동일 패턴(파일 단위 가드)을 사용 중이라 같은 컨벤션을 따른다(옵션 B — 8줄 추가).

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass. Swift 변경은 orphan 검출 대상 아님.
2. **V/X dashboard** — N/A (compile-time fix). 런타임 동작 영향 없음.
3. **의존 PR** — PR #1911 (#1890 RC-15 widget freshness) 머지 follow-up. 그 외 N/A.
4. **측정 plan** — SourceKit diagnostics 0건 유지. SubwayWidget.swift 파일 indexing 시 unavailable 경고 0건.
5. **Device verify** — N/A (compile-time only). 다음 iOS 빌드 시 widget extension 재컴파일되며 런타임 동작은 PR #1911과 동일.

## Test plan
- [x] `npm run type-check` pass
- [x] `npm test` — 392 suites / 8265 tests / coverage 100%
- [x] `npm run lint:orphan` — No orphan exports detected

Refs: PR #1911 (#1890 RC-15 widget freshness)