### PR TITLE
fix(#1897): RC-5 APNs env (sandbox/production) token migration

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -3825,7 +3825,8 @@ describe('POST /trips — #1425 trip-recently-ended reject', () => {
 
     const res = await post('/trips', base(), env);
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true, token: 'tok' });
+    // #1897 (RC-5) — 응답에 confirmedEnv echo. base()는 apnsEnv 미설정이라 sandbox fallback.
+    expect(await res.json()).toEqual({ ok: true, token: 'tok', confirmedEnv: 'sandbox' });
     expect(await env.TRIPS.get('trip:tok')).not.toBeNull();
   });
 
@@ -3854,7 +3855,8 @@ describe('POST /trips — #1425 trip-recently-ended reject', () => {
 
     const res = await post('/trips', base(), env);
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true, token: 'tok' });
+    // #1897 (RC-5) — 응답에 confirmedEnv echo. base()는 apnsEnv 미설정이라 sandbox fallback.
+    expect(await res.json()).toEqual({ ok: true, token: 'tok', confirmedEnv: 'sandbox' });
     expect(await env.TRIPS.get('trip:tok')).not.toBeNull();
   });
 
@@ -3865,6 +3867,39 @@ describe('POST /trips — #1425 trip-recently-ended reject', () => {
     const res = await post('/trips', base(), env);
     expect(res.status).toBe(400);
     expect(await res.json()).toMatchObject({ error: 'trip-recently-ended' });
+  });
+});
+
+// #1897 (RC-5) — POST /trips 응답 confirmedEnv echo.
+// device 가 응답 confirmedEnv 를 stamp 해 다음 register POST 부터는 build env 대신 송신 →
+// backend self-heal(envCorrected) 발동 0 수렴.
+describe('POST /trips — #1897 confirmedEnv echo (RC-5)', () => {
+  it.each(['sandbox', 'production'] as const)(
+    'first register: incoming.apnsEnv=%s → 응답 confirmedEnv 동일 echo',
+    async (env) => {
+      const kvEnv = makeKvEnv();
+      const res = await post('/trips', { ...base(), apnsEnv: env }, kvEnv);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true, token: 'tok', confirmedEnv: env });
+    },
+  );
+
+  it('first register: apnsEnv 누락 → 응답 confirmedEnv=sandbox fallback', async () => {
+    const env = makeKvEnv();
+    const res = await post('/trips', base(), env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, token: 'tok', confirmedEnv: 'sandbox' });
+  });
+
+  it('existing.apnsEnv=sandbox + incoming.apnsEnv=production (build env drift) → existing 보존 echo', async () => {
+    const env = makeKvEnv();
+    // 첫 register: existing apnsEnv=sandbox (corrected 시뮬레이션)
+    await post('/trips', { ...base(), apnsEnv: 'sandbox' }, env);
+    // 둘째 register: device build env 가 production 으로 잘못 송신 → existing 우선 보존
+    const res = await post('/trips', { ...base(), apnsEnv: 'production' }, env);
+    expect(res.status).toBe(200);
+    // backend `existing.apnsEnv ?? incoming.apnsEnv` 정책 → sandbox 유지
+    expect(await res.json()).toEqual({ ok: true, token: 'tok', confirmedEnv: 'sandbox' });
   });
 });
 

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -696,7 +696,15 @@ app.post('/trips', async (c) => {
     hopIndex: trip.waypoints[0]?.hopIndex,
   });
 
-  return c.json({ ok: true, token: trip.token });
+  // #1897 (RC-5) — KV에 박힌 권위 apnsEnv 를 device로 echo. device 는 이를 stamp 해 다음
+  // register 시 build env 대신 송신 → backend self-heal(envCorrected) 발동을 0에 수렴.
+  // existing.apnsEnv 가 corrected 된 경우(#1370 L1) 그 값이 그대로 device 로 전달된다.
+  // 구 device는 응답에서 본 필드를 무시 (backward-compatible).
+  return c.json({
+    ok: true,
+    token: trip.token,
+    confirmedEnv: trip.apnsEnv ?? 'sandbox',
+  });
 });
 
 /**

--- a/src/features/alarm/api/__tests__/alarmBackend.test.ts
+++ b/src/features/alarm/api/__tests__/alarmBackend.test.ts
@@ -659,6 +659,86 @@ describe('alarmBackend', () => {
     });
   });
 
+  // #1897 (RC-5) — backend register 응답의 confirmedEnv echo → device stamp.
+  describe('confirmedEnv echo (#1897)', () => {
+    const LAST_CONFIRMED_APNS_ENV_KEY = 'subway-now:last-confirmed-apns-env';
+
+    beforeEach(async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+      await AsyncStorage.removeItem(LAST_CONFIRMED_APNS_ENV_KEY);
+    });
+
+    it.each(['sandbox', 'production'] as const)(
+      '응답 confirmedEnv=%s → AsyncStorage stamp + 결과에 echo',
+      async (env) => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: async () => ({ ok: true, token: 'token-hex', confirmedEnv: env }),
+        } as unknown as Response);
+
+        const result = await registerActiveTrip(SAMPLE_PAYLOAD);
+        expect(result.ok).toBe(true);
+        expect(result.confirmedEnv).toBe(env);
+        expect(await AsyncStorage.getItem(LAST_CONFIRMED_APNS_ENV_KEY)).toBe(env);
+      },
+    );
+
+    it('응답 confirmedEnv 부재 (구 backend) → stamp 없음 + 결과 confirmedEnv undefined (graceful)', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, token: 'token-hex' }),
+      } as unknown as Response);
+
+      const result = await registerActiveTrip(SAMPLE_PAYLOAD);
+      expect(result.ok).toBe(true);
+      expect(result.confirmedEnv).toBeUndefined();
+      expect(await AsyncStorage.getItem(LAST_CONFIRMED_APNS_ENV_KEY)).toBeNull();
+    });
+
+    it('응답 confirmedEnv 값 오류 → stamp 없음 (strict guard)', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, token: 'token-hex', confirmedEnv: 'bogus' }),
+      } as unknown as Response);
+
+      const result = await registerActiveTrip(SAMPLE_PAYLOAD);
+      expect(result.ok).toBe(true);
+      expect(result.confirmedEnv).toBeUndefined();
+      expect(await AsyncStorage.getItem(LAST_CONFIRMED_APNS_ENV_KEY)).toBeNull();
+    });
+
+    it('res.json throw → graceful (catch → undefined, stamp 없음)', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new Error('invalid json');
+        },
+      } as unknown as Response);
+
+      const result = await registerActiveTrip(SAMPLE_PAYLOAD);
+      expect(result.ok).toBe(true);
+      expect(result.confirmedEnv).toBeUndefined();
+      expect(await AsyncStorage.getItem(LAST_CONFIRMED_APNS_ENV_KEY)).toBeNull();
+    });
+
+    it('register 실패(non-2xx) → confirmedEnv 추출 skip (stamp 없음)', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({ confirmedEnv: 'production' }),
+      } as unknown as Response);
+
+      const result = await registerActiveTrip(SAMPLE_PAYLOAD);
+      expect(result.ok).toBe(false);
+      expect(result.confirmedEnv).toBeUndefined();
+      expect(await AsyncStorage.getItem(LAST_CONFIRMED_APNS_ENV_KEY)).toBeNull();
+    });
+  });
+
   // #1545 (S12) — TRIP_BOUND_CLEANUPS에 wiring될 production reset.
   describe('resetAlarmBackendDedup (#1545 S12)', () => {
     it('완료 hash를 초기화해 같은 페이로드 재등록 시 fetch가 다시 발사된다 (token 불필요)', async () => {

--- a/src/features/alarm/api/alarmBackend.ts
+++ b/src/features/alarm/api/alarmBackend.ts
@@ -10,7 +10,7 @@
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { Route } from '../../../shared/utils/stationRoute';
-import type { ApnsEnv } from '../../../shared/utils/apnsEnv';
+import { type ApnsEnv, setConfirmedApnsEnv } from '../../../shared/utils/apnsEnv';
 import { createLogger } from '../../../shared/utils/logger';
 import { ACTIVE_BOARDING_LINE_KEY } from '../../../shared/constants/storageKeys';
 import { instrumentBackendFetch } from '../../../shared/utils/instrumentBackendFetch';
@@ -119,6 +119,12 @@ export interface AlarmBackendResult {
   /** URL 미설정 등으로 호출이 건너뛰어진 경우 true. */
   skipped?: boolean;
   status?: number;
+  /**
+   * #1897 (RC-5) — backend 가 응답으로 echo한 KV 권위 apnsEnv.
+   * `performRegisterFetch` 가 추출하여 호출자에게 노출. 구 backend 또는 parse 실패 시
+   * undefined (graceful — device 는 다음 register 시 build env fallback 사용).
+   */
+  confirmedEnv?: ApnsEnv;
 }
 
 /** 기본 트립 TTL — 2시간. 백엔드 KV expiration과 정렬. */
@@ -271,11 +277,34 @@ async function performRegisterFetch(
       return { ok: false, status: res.status };
     }
     lastRegisteredHash = hash;
-    return { ok: true, status: res.status };
+    // #1897 (RC-5) — backend 가 echo한 `confirmedEnv` 추출 + stamp.
+    // 구 backend 응답(confirmedEnv 부재) / parse 실패 시 graceful — device 는 다음 register
+    // 에서 build env(`resolveApnsEnv`)로 자연 fallback.
+    const confirmedEnv = await extractConfirmedEnv(res);
+    if (confirmedEnv) {
+      await setConfirmedApnsEnv(confirmedEnv);
+    }
+    return { ok: true, status: res.status, ...(confirmedEnv ? { confirmedEnv } : {}) };
   } catch (e) {
     log.warn('register error', e);
     return { ok: false };
   }
+}
+
+/**
+ * #1897 (RC-5) — register 응답에서 `confirmedEnv` 추출.
+ * JSON parse 실패 / 필드 부재 / 값 오류 모두 graceful undefined — device 는 build env fallback.
+ */
+async function extractConfirmedEnv(res: Response): Promise<ApnsEnv | undefined> {
+  try {
+    const body = (await res.json()) as { confirmedEnv?: unknown };
+    if (body.confirmedEnv === 'sandbox' || body.confirmedEnv === 'production') {
+      return body.confirmedEnv;
+    }
+  } catch {
+    // graceful — 구 backend 응답 또는 parse 실패
+  }
+  return undefined;
 }
 
 /**

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -33,7 +33,7 @@ import { buildBoardingPromptContext, type BoardingPromptContext } from '../utils
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
 import { BOARDING_LOCK_RELEASE_DEBOUNCE_MS } from '../../../shared/constants/boardingLock';
 import { createLogger } from '../../../shared/utils/logger';
-import { resolveApnsEnv } from '../../../shared/utils/apnsEnv';
+import { getRegisteringApnsEnv } from '../../../shared/utils/apnsEnv';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
 
 /**
@@ -174,13 +174,17 @@ async function callRegister(input: RegisterCallInputs) {
   // backend는 미송신 시 ko fallback이므로 비지원 locale은 송신 자체 skip.
   const locale = resolveLocaleForBackend();
 
+  // #1897 (RC-5) — 마지막으로 backend가 confirm한 apnsEnv stamp 우선 사용. 부재 시 build env
+  // (`resolveApnsEnv()`)로 자연 fallback. self-heal 발동 횟수를 0에 수렴시키는 핵심 wire.
+  const apnsEnv = await getRegisteringApnsEnv();
+
   return registerActiveTrip({
     token: input.token,
     route: input.route,
     destination: input.destination.id,
     waypoints: routeToWaypoints(input.route, input.destination.name, input.currentStation),
     alarmAtEpochMs: deriveAlarmAtEpochMs(input.nextStationEtaSeconds, Date.now()),
-    apnsEnv: resolveApnsEnv(),
+    apnsEnv,
     createdAt: input.createdAt,
     ...(boardingLockMeta ? { boardingLock: boardingLockMeta } : {}),
     // #819 / #1028 — boarding-prompt 평가/표시 컨텍스트. 짝으로만 송신.

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -19,6 +19,12 @@ export const SLEEP_MODE_GUIDE_SHOWN_KEY = 'subway-now:sleep-mode-guide-shown';
 export const LOCALE_PREFERENCE_KEY = 'subway-now:locale-preference';
 export const ALARM_LOG_KEY = 'subway-now:alarm-log';
 export const APNS_TOKEN_KEY = 'subway-now:apns-token';
+// #1897 (RC-5) — 마지막으로 backend가 confirm한 APNs env(sandbox/production).
+// register 응답에서 backend가 `existing.apnsEnv ?? incoming.apnsEnv`로 결정한 KV 값을 echo →
+// device가 stamp. 다음 register에서 device build env(`resolveApnsEnv()`) 대신 이 값을 우선 송신해
+// backend self-heal 발동 횟수를 0에 수렴시킨다. 부재(첫 register / parse 실패) 시 fallback.
+// 형식: 'sandbox' 또는 'production' string.
+export const LAST_CONFIRMED_APNS_ENV_KEY = 'subway-now:last-confirmed-apns-env';
 export const ACTIVE_TRIP_KEY = 'subway-now:active-trip';
 export const TRIP_TRAIN_CODE_KEY = 'subway-now:trip-train-code';
 // #700 — useTripOrigin이 destination set 순간 캡처하는 trip origin Station.

--- a/src/shared/utils/__tests__/apnsEnv.test.ts
+++ b/src/shared/utils/__tests__/apnsEnv.test.ts
@@ -1,4 +1,16 @@
-import { resolveApnsEnv } from '../apnsEnv';
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  resolveApnsEnv,
+  getRegisteringApnsEnv,
+  setConfirmedApnsEnv,
+} from '../apnsEnv';
+import { LAST_CONFIRMED_APNS_ENV_KEY } from '../../constants/storageKeys';
 
 describe('resolveApnsEnv', () => {
   const original = process.env.EXPO_PUBLIC_APNS_ENV;
@@ -29,5 +41,65 @@ describe('resolveApnsEnv', () => {
   it('falls back to sandbox when env has unknown value', () => {
     process.env.EXPO_PUBLIC_APNS_ENV = 'bogus';
     expect(resolveApnsEnv()).toBe('sandbox');
+  });
+});
+
+// #1897 (RC-5) — backend가 confirm한 env stamp + register 송신 우선순위 검증.
+describe('getRegisteringApnsEnv / setConfirmedApnsEnv (#1897)', () => {
+  const original = process.env.EXPO_PUBLIC_APNS_ENV;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.EXPO_PUBLIC_APNS_ENV;
+    } else {
+      process.env.EXPO_PUBLIC_APNS_ENV = original;
+    }
+  });
+
+  it.each(['sandbox', 'production'] as const)(
+    'stamp=%s 면 AsyncStorage stamp를 1순위로 반환 (build env 무시)',
+    async (stamp) => {
+      // build env는 정반대로 설정해 우선순위 검증.
+      process.env.EXPO_PUBLIC_APNS_ENV = stamp === 'sandbox' ? 'production' : 'sandbox';
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(stamp);
+      await expect(getRegisteringApnsEnv()).resolves.toBe(stamp);
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith(LAST_CONFIRMED_APNS_ENV_KEY);
+    },
+  );
+
+  it('stamp 부재 (첫 register) → resolveApnsEnv() fallback', async () => {
+    process.env.EXPO_PUBLIC_APNS_ENV = 'production';
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    await expect(getRegisteringApnsEnv()).resolves.toBe('production');
+  });
+
+  it('stamp 값 오류 (legacy/오타) → resolveApnsEnv() fallback', async () => {
+    process.env.EXPO_PUBLIC_APNS_ENV = 'sandbox';
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue('bogus');
+    await expect(getRegisteringApnsEnv()).resolves.toBe('sandbox');
+  });
+
+  it('AsyncStorage.getItem 실패 → graceful resolveApnsEnv() fallback', async () => {
+    process.env.EXPO_PUBLIC_APNS_ENV = 'production';
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValue(new Error('disk'));
+    await expect(getRegisteringApnsEnv()).resolves.toBe('production');
+  });
+
+  it.each(['sandbox', 'production'] as const)(
+    'setConfirmedApnsEnv(%s) → AsyncStorage.setItem(KEY, env) 호출',
+    async (env) => {
+      (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+      await setConfirmedApnsEnv(env);
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(LAST_CONFIRMED_APNS_ENV_KEY, env);
+    },
+  );
+
+  it('setConfirmedApnsEnv: AsyncStorage 실패 → graceful (throw 없음)', async () => {
+    (AsyncStorage.setItem as jest.Mock).mockRejectedValue(new Error('disk'));
+    await expect(setConfirmedApnsEnv('sandbox')).resolves.toBeUndefined();
   });
 });

--- a/src/shared/utils/apnsEnv.ts
+++ b/src/shared/utils/apnsEnv.ts
@@ -9,11 +9,55 @@
  * 이를 production host로 보내면 `BadDeviceToken`(400)으로 거부된다. 'production'은
  * App Store/TestFlight 빌드에서만 의미가 있으므로, EAS production profile에서
  * `EXPO_PUBLIC_APNS_ENV=production`을 반드시 명시 설정해야 한다.
+ *
+ * #1897 (RC-5) — build env(`resolveApnsEnv`)와 별개로 backend가 push 시 self-heal로
+ * 정정한 env를 device가 영속 stamp(`LAST_CONFIRMED_APNS_ENV_KEY`)한다. iOS OS-issued
+ * token type(실제 sandbox/production)을 device가 직접 확인할 API가 없으므로 backend의
+ * confirm 결과를 1순위로 사용해 self-heal 발동 횟수를 0에 수렴시킨다.
  */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { LAST_CONFIRMED_APNS_ENV_KEY } from '../constants/storageKeys';
+import { createLogger } from './logger';
+
 export type ApnsEnv = 'sandbox' | 'production';
+
+const logger = createLogger('apnsEnv');
 
 export function resolveApnsEnv(): ApnsEnv {
   const raw = process.env.EXPO_PUBLIC_APNS_ENV;
   if (raw === 'production' || raw === 'sandbox') return raw;
   return 'sandbox';
+}
+
+/**
+ * #1897 (RC-5) — 마지막으로 backend가 confirm한 APNs env를 stamp.
+ * register 응답의 `confirmedEnv` 필드를 받아 호출. AsyncStorage 실패는 graceful warn —
+ * 다음 register는 build env fallback으로 자연 동작.
+ */
+export async function setConfirmedApnsEnv(env: ApnsEnv): Promise<void> {
+  try {
+    await AsyncStorage.setItem(LAST_CONFIRMED_APNS_ENV_KEY, env);
+  } catch (e) {
+    logger.warn('persist confirmed apns env failed:', e);
+  }
+}
+
+/**
+ * #1897 (RC-5) — register POST 시 송신할 apnsEnv 결정.
+ *
+ * 우선순위:
+ *   1) AsyncStorage stamp (이전 register 응답의 confirmedEnv) — backend가 OS token type을
+ *      이미 확인한 권위 값. self-heal 발동 차단.
+ *   2) `resolveApnsEnv()` (build env) — 첫 register / parse 실패 / 신규 token fallback.
+ *
+ * AsyncStorage 실패는 graceful — build env fallback으로 자연 동작.
+ */
+export async function getRegisteringApnsEnv(): Promise<ApnsEnv> {
+  try {
+    const stamped = await AsyncStorage.getItem(LAST_CONFIRMED_APNS_ENV_KEY);
+    if (stamped === 'sandbox' || stamped === 'production') return stamped;
+  } catch (e) {
+    logger.warn('read confirmed apns env failed:', e);
+  }
+  return resolveApnsEnv();
 }


### PR DESCRIPTION
Closes #1897
Parent epic: #1832 (silent push received=0 chain wire audit)

## Summary

T2 trip (2026-06-26 KST 12:14~12:27) backend log evidence: 9회 `env-mismatch-corrected` self-heal 발동. device build env=production이지만 OS-issued APNs token이 sandbox-bound로 매 push마다 1초 retry 지연 발생.

**Fix**: backend register 응답에 `confirmedEnv` echo → device가 AsyncStorage stamp → 다음 register POST부터 build env 대신 stamp 값 송신 → backend self-heal 발동 횟수를 0에 수렴.

### 결정 옵션 (false binary 차단)

1. **Option A**: device side `lastRegisteredEnv` stamp + build env 변경 detect (이슈 본문 Fix 4) → build env transition만 cover, OS token type drift는 미해결.
2. **Option B (채택)**: backend register response `confirmedEnv` echo → device cache → 다음 register시 송신. backend가 이미 보유한 권위 KV값(`existing.apnsEnv ?? incoming.apnsEnv`)을 SSoT로 활용. iOS OS-issued token type을 device가 직접 확인할 API 부재 → backend confirm 결과를 1순위로 사용.
3. **Option C**: backend self-heal 후 silent push로 device에 corrected env 통지 → Option B 변형, 더 무거움 (별도 push 채널 추가).

채택 이유: backward-compatible (구 backend 응답 부재 시 build env fallback) + minimal wire (응답 1 필드 추가) + 자기 수렴 (stamp 부정확 시 1회 self-heal 후 새 corrected echo로 자동 수정).

## 변경 파일 (8)

### Backend
- `backend/alarm-worker/src/index.ts` — `/trips` 응답에 `confirmedEnv: trip.apnsEnv ?? 'sandbox'` echo.

### Device
- `src/shared/utils/apnsEnv.ts` — `getRegisteringApnsEnv()` (stamp 우선, build env fallback) + `setConfirmedApnsEnv()` 추가.
- `src/shared/constants/storageKeys.ts` — `LAST_CONFIRMED_APNS_ENV_KEY` 추가.
- `src/features/alarm/api/alarmBackend.ts` — `performRegisterFetch`가 응답 confirmedEnv 추출 + stamp + `AlarmBackendResult.confirmedEnv` echo.
- `src/features/alarm/hooks/useApnsTripRegistration.ts` — `resolveApnsEnv()` → `getRegisteringApnsEnv()` 교체. 단일 site (callRegister).

### Tests
- `backend/alarm-worker/src/__tests__/index.test.ts` — confirmedEnv echo 3 케이스 (sandbox/production/누락 fallback + existing 보존). 기존 2 곳 strict matcher 갱신.
- `src/shared/utils/__tests__/apnsEnv.test.ts` — `getRegisteringApnsEnv` / `setConfirmedApnsEnv` 7 케이스 (stamp 우선 + 부재/오타 fallback + AsyncStorage 실패 graceful).
- `src/features/alarm/api/__tests__/alarmBackend.test.ts` — 응답 confirmedEnv 추출 5 케이스 (sandbox/production stamp + 구 backend graceful + 값 오류 strict guard + json throw + non-2xx skip).

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass. 새 export(`getRegisteringApnsEnv`/`setConfirmedApnsEnv`)는 모두 caller 존재 (alarmBackend → useApnsTripRegistration → registerActiveTrip 체인).
2. **V/X dashboard** — X12 (env-mismatch self-heal 발동률) backend `envCorrected` 카운터로 Cloudflare Dashboard 측정. 현재 9회/1.5h → 목표 < 1건/주.
3. **의존 PR** — backend wrangler deploy + device EAS production build 둘 다 필요. 머지 후 사용자 직접 deploy. backward-compat이라 device-only 또는 backend-only 단독 deploy도 graceful 자연 fallback.
4. **측정 plan** — 7일 production 측정. Cloudflare Dashboard `kind=apns AND reason=env-mismatch-corrected` 카운트 추이. backend metric `sendWithEnvHeal first-try success rate > 99.5%`. device side: AsyncStorage `LAST_CONFIRMED_APNS_ENV_KEY` 변경 이벤트 확인.
5. **Device verify** — 실기기 검증 필요 (Release build + 첫 register → 둘째 register 시 stamp 송신 확인). Debug 시나리오: DebugModal `apnsEnv` 라인은 build env(`resolveApnsEnv()`)이므로 stamp 검증은 wrangler tail로 incoming.apnsEnv 추적.

## Acceptance

- backend telemetry: 7일 `env-mismatch-corrected` 발생 < 1건/주 (현재 9회/1.5h).
- backend metric: `sendWithEnvHeal` first-try success rate > 99.5%.
- 권한 매트릭스: WhileInUse/Always × FG/BG/취침 모두 acceptance (env wire는 권한 독립).
- 환경 매트릭스: production/development/TestFlight build 모두 정확 stamp + 자동 수렴.

## 검증 결과 (이 PR)

- **Device test**: 392 suites / 8279 tests PASS, coverage 100%.
- **Backend test**: 60 files / 2244 tests PASS.
- **Type-check**: device + backend 모두 pass.
- **Orphan check**: 0건.
- **ESLint**: clean.
- **code-reviewer (medium effort)**: no defects (empty findings).

## Backward compatibility

- 구 backend (confirmedEnv 응답 부재): device가 build env fallback → 기존 동작.
- 구 device (응답 무시): backend는 항상 confirmedEnv echo, 구 device는 응답 필드 무시 (byte-level 호환).
- KV legacy entry (apnsEnv 부재): backend `existing.apnsEnv ?? incoming.apnsEnv` → incoming 채택 (기존 정책 유지).