### PR TITLE
fix(#1894): RC-20 alert fallback ACK + RC-18 candidate line filter

### DIFF
--- a/backend/alarm-worker/src/__tests__/pendingPushes.test.ts
+++ b/backend/alarm-worker/src/__tests__/pendingPushes.test.ts
@@ -48,20 +48,20 @@ describe('pendingPushes (#566 P2a)', () => {
   });
 
   describe('putPending', () => {
-    it('KV에 pending:<pushId> 키로 저장하고 TTL을 60초로 둔다', async () => {
+    it('KV에 pending:<pushId> 키로 저장하고 TTL을 PENDING_TTL_SEC로 둔다', async () => {
       const entry = makeEntry({ pushId: 'p1' });
       await putPending(kv as unknown as KVNamespace, entry);
       const raw = kv.store.get('pending:p1');
       expect(raw).toBeDefined();
       expect(JSON.parse(raw!.value)).toEqual(entry);
       expect(raw!.expiresAt).toBeDefined();
-      // TTL 정확히 60초 ± 1초 허용 (Date.now 시점 차이).
+      // PENDING_TTL_SEC 정확히 ± 1초 허용 (Date.now 시점 차이).
       expect(raw!.expiresAt! - Date.now()).toBeGreaterThan((PENDING_TTL_SEC - 1) * 1000);
       expect(raw!.expiresAt! - Date.now()).toBeLessThanOrEqual(PENDING_TTL_SEC * 1000);
     });
 
-    it('PENDING_TTL_SEC가 60초로 노출된다', () => {
-      expect(PENDING_TTL_SEC).toBe(60);
+    it('PENDING_TTL_SEC가 120초로 노출된다 (#1894 — FALLBACK_THRESHOLD_MS 60s + cron 60s backstop 정합)', () => {
+      expect(PENDING_TTL_SEC).toBe(120);
     });
 
     it('kv === undefined면 graceful no-op (throw 없음)', async () => {

--- a/backend/alarm-worker/src/alertContent.ts
+++ b/backend/alarm-worker/src/alertContent.ts
@@ -1,7 +1,7 @@
 /**
  * Alert push 본문 생성 (#570 P2d).
  *
- * 채널 2(alert fallback)가 silent push 30s 미ACK 케이스에서 발사할 alert push의
+ * 채널 2(alert fallback)가 silent push 60s 미ACK 케이스에서 발사할 alert push의 (#1894 30s→60s 완화)
  * title/body를 만든다. 디바이스 측 `src/utils/stationNotification.ts:buildAlarmContent`
  * + `src/i18n/locales/ko.json`의 문자열과 **바이트 동일**.
  *

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -59,7 +59,7 @@ export interface SilentPushPayload {
   /**
    * push 1건의 unique 식별자 (#566 P2a).
    * 디바이스는 처리 결과를 `POST /push/ack`로 보낼 때 이 id를 echo한다.
-   * P2c가 30s 미ACK push를 alert fallback으로 재발사할 때 dedup 키로도 사용.
+   * P2c가 60s 미ACK push를 alert fallback으로 재발사할 때 dedup 키로도 사용 (#1894 30s→60s 완화).
    */
   pushId: string;
   /**
@@ -262,7 +262,7 @@ export type LockReleasedReason = 'transfer' | 'vanish';
  * | `vanish-release`     | trainCode 소실 + hop 미경과 lock release 직전 floor fire   |
  * | `lockless`           | lockless intermediate fire                                  |
  * | `reschedule`         | ETA shift threshold 초과 reschedule push                    |
- * | `alert-fallback`     | 30s ACK 미수신 후 alert push fallback                       |
+ * | `alert-fallback`     | 60s ACK 미수신 후 alert push fallback (#1894 30s→60s 완화)  |
  *
  * 새 origin 추가 시 device alarmLog의 expected enum도 함께 갱신해야 한다.
  */

--- a/backend/alarm-worker/src/fallback.ts
+++ b/backend/alarm-worker/src/fallback.ts
@@ -1,11 +1,20 @@
 /**
  * Alert push fallback 발사 (#572 P2c).
  *
- * silent push가 30s 안에 디바이스 ACK되지 않으면 alert push로 fallback 발사한다.
+ * silent push가 60s 안에 디바이스 ACK되지 않으면 alert push로 fallback 발사한다.
  * cron 1회 실행 = 한 trip을 처리하는 scheduled.ts의 한 사이클에 이어 runFallbackPushes를 호출.
  *
- * 30s 임계는 sentAt 시각 기준 — cron 자체는 1분 단위라 첫 폴링까지 최대 60s 지연 발생 가능.
- * 사용자 입장에선 알람 못 받는 것보단 60s 늦게라도 받는 게 낫다는 절충.
+ * #1894 (2026-06-26 RC-20) — 30s → 60s 완화.
+ *   iOS는 silent push 처리 시간을 약 30s 이내로 강제하며, BG suspended 상태에서 task 시작
+ *   직전 OS schedule 지연 + ACK fetch 네트워크 round-trip을 합치면 ageMs=63s 케이스가 관찰됨
+ *   (T1 trip 1.5h에 1건, ageMs=63319ms). 30s 임계는 정상 처리 push까지 false fallback을
+ *   유발해 사용자가 "silent + alert" 중복 알람을 받게 한다. silent push는 backend SSoT
+ *   forward 단일 채널(`lesson_silent_push_is_ssot_forward_channel`)이라 false fallback이
+ *   fusion tier 채택 0건과 cascade될 위험도 있다. iOS 처리 시간 상한(약 30s) + 네트워크
+ *   round-trip 여유(약 30s)를 더한 60s가 정상 trip의 ACK latency를 모두 흡수한다.
+ *
+ * 60s 임계는 sentAt 시각 기준 — cron 자체는 1분 단위라 첫 폴링까지 최대 60s 지연 발생 가능.
+ * 사용자 입장에선 알람 못 받는 것보단 늦게라도 받는 게 낫다는 절충(최대 약 2분).
  *
  * 발사 후 entry는 즉시 삭제 — 다음 cron에서 재발사 방지 (KV TTL 60s에 의존하지 않음).
  * 발사 실패도 entry 삭제 — 재시도 폭주 방지 (다음 silent push 사이클에서 자연 회복).
@@ -16,8 +25,13 @@ import { buildAlertContent } from './alertContent';
 import { listPending, removePending, type PendingPush } from './pendingPushes';
 import type { ApnsEnv, Env } from './types';
 
-/** silent push 발사 시점에서 30s 이상 지나면 fallback 후보. */
-export const FALLBACK_THRESHOLD_MS = 30_000;
+/**
+ * silent push 발사 시점에서 60s 이상 지나면 fallback 후보 (#1894 / 2026-06-26 RC-20).
+ *
+ * 30_000ms 시절 false fallback 회귀: iOS BG silent push 처리 약 30s + ACK round-trip ≥ 임계 → alert 중복 발사.
+ * 60_000ms 로 완화해 정상 trip의 ACK latency를 모두 흡수.
+ */
+export const FALLBACK_THRESHOLD_MS = 60_000;
 
 export interface FallbackDeps {
   apnsConfig: ApnsConfig;

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -2121,7 +2121,7 @@ const handler = {
       captureBackendException(err, { path: 'scheduled/runScheduled' });
       throw err;
     }
-    // #572 P2c — silent push 30s 미ACK entry를 alert로 fallback. 같은 cron 사이클에서 실행.
+    // #572 P2c — silent push 60s 미ACK entry를 alert로 fallback (#1894 30s→60s 완화). 같은 cron 사이클에서 실행.
     await runFallbackPushes(env, { apnsConfig, apnsHosts, log });
     // #1721 — silent push 발사 실패(429 / 5xx) 영구 lost 차단. retry-push: prefix entry 를 backoff 만기
     // 시 재발사. KV binding 부재 시 graceful no-op (개발/테스트 환경 호환).

--- a/backend/alarm-worker/src/pendingPushes.ts
+++ b/backend/alarm-worker/src/pendingPushes.ts
@@ -2,13 +2,14 @@
  * KV CRUD for pending silent pushes (#566 P2a).
  *
  * 발사한 silent push 1건마다 `pending:<pushId>` entry를 기록한다.
- * P2c가 이 entry를 폴링해 30s 안에 디바이스 ACK가 안 오면 alert push fallback을 발사한다.
+ * P2c가 이 entry를 폴링해 60s 안에 디바이스 ACK가 안 오면 alert push fallback을 발사한다.
  * 디바이스 ACK 도달 시 P2a /push/ack 라우트가 entry를 삭제한다.
  *
  * 모든 함수는 `kv === undefined`(미바인딩)일 때 graceful no-op — 개발 환경 호환.
  *
  * Key format: pending:<pushId>
- * TTL: 60s (Cloudflare KV 최소값). P2c는 30s 임계는 sentAt 시각 기준으로 판단.
+ * TTL: 120s (#1894로 60s ACK 임계와 분리). P2c는 60s 임계는 sentAt 시각 기준으로 판단.
+ *   PENDING_TTL_SEC(120s) ≥ FALLBACK_THRESHOLD_MS(60s) + cron 1분 backstop 여유를 보장.
  */
 
 import type { AlarmPhase } from './alarm';
@@ -16,7 +17,14 @@ import { assertCronCacheTtl, CRON_READ_CACHE_TTL_SEC as SHARED_CRON_TTL } from '
 import type { ApnsEnv } from './types';
 
 const PENDING_PREFIX = 'pending:';
-export const PENDING_TTL_SEC = 60;
+/**
+ * KV TTL. #1894로 FALLBACK_THRESHOLD_MS가 30s → 60s로 완화되면서, cron(1분 주기) backstop을
+ * 더한 최악 시각 ≈ 120s에 fallback cron이 entry를 봐야 한다. TTL=60s이면 임계 도달 직후 KV가
+ * 자연 expire돼 후속 cron이 entry 못 보고 fallback 1회 누락 위험. 60s → 120s 상향.
+ *
+ * 정합: PENDING_TTL_SEC(120s) ≥ FALLBACK_THRESHOLD_MS(60s) + 최악 cron 지연(60s).
+ */
+export const PENDING_TTL_SEC = 120;
 
 /**
  * cron read의 KV cacheTtl (#766/#770). trips.ts와 같은 이유 — silent push 발사 직후 putPending된

--- a/backend/alarm-worker/src/retryPushes.ts
+++ b/backend/alarm-worker/src/retryPushes.ts
@@ -14,7 +14,7 @@
  * 기존 binding 을 prefix 로 재사용한다 (운영 manual step 0).
  *
  * 책임 분리:
- *   - `pendingPushes.ts` (`pending:` prefix): silent push 발사 직후 ACK 추적 (30s 미ACK alert fallback).
+ *   - `pendingPushes.ts` (`pending:` prefix): silent push 발사 직후 ACK 추적 (60s 미ACK alert fallback; #1894 30s→60s 완화).
  *   - `retryPushes.ts`   (`retry-push:` prefix): silent push 발사 자체 실패 시 transient retry 큐.
  *
  * 두 prefix 는 disjoint — 같은 pushId 가 두 큐에 동시 등록되지 않는다 (발사 성공 → pending, 실패 → retry).

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -1686,7 +1686,7 @@ export async function fireArvlCdStationPush(
   } else if (waypoint.kind === 'destination') {
     stats.silentPushFiredByKind.destination += 1;
   }
-  // #1402 — 30s alert fallback 안전망 등록. silent push가 30s 내 ACK되지 않으면
+  // #1402 — alert fallback 안전망 등록. silent push가 60s(#1894로 30s→60s 완화) 내 ACK되지 않으면
   // runFallbackPushes가 alert(소리) push를 발사. arvlCd 경로는 가장 흔한 발사 경로이므로
   // 여기서도 안전망을 가동해 "하차 침묵 0" acceptance를 보강한다.
   await putPending(env.PENDING_PUSHES, {
@@ -2053,7 +2053,7 @@ export async function fireVanishFallbackStationPush(
     hopIndex: waypoint.hopIndex,
     staleMs: ssot?.lastAdvanceAt ? now - ssot.lastAdvanceAt : undefined,
   });
-  // #1402 — 30s alert fallback 안전망 등록. listPending → runFallbackPushes가 30s 내 ACK
+  // #1402 — alert fallback 안전망 등록. listPending → runFallbackPushes가 60s(#1894로 30s→60s 완화) 내 ACK
   // 없으면 alert(소리) fallback 발사. vanish 경로는 silent push가 가장 잘 누락되는 경로라
   // 안전망 가동이 acceptance("하차 침묵 0")의 핵심. PENDING_PUSHES 미바인딩(dev/test 호환)
   // 시 putPending은 graceful no-op.
@@ -2243,7 +2243,7 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
     // #1402 — lock release 전 floor station-passed push를 보장 발사한다. 종전 release 경로는
     // push 0건으로 device가 stale 채로 lockless 인계만 받았고, lockless 인계 직후 GPS가 잠시라도
     // 추가 누락되면 다음 station push까지 침묵 ≥ 1 cycle. release 직전 floor push 1건이
-    // PENDING_PUSHES에 등록되면 30s 내 ACK 없을 때 alert fallback이 자동 발사돼 "하차 침묵 0"
+    // PENDING_PUSHES에 등록되면 60s(#1894로 30s→60s 완화) 내 ACK 없을 때 alert fallback이 자동 발사돼 "하차 침묵 0"
     // acceptance를 충족(2026-06-17 군자/용마산 회귀). 발사 자체가 false positive를 만들 수
     // 있어 ADR-010 "false positive / miss 동급" 원칙에 따라 lock-active fallback과 같은
     // motion gate(`isFallbackAdvanceBlockedByMotion`)를 통과한 경우에만 fire.
@@ -3168,7 +3168,7 @@ export async function runLocklessIntermediate(
   stats.locklessIntermediateFired += 1;
   // #1683 — lockless intermediate kind 카운터.
   stats.silentPushFiredByKind.intermediate += 1;
-  // #1402 — 30s alert fallback 안전망 등록. shift 전 stationName으로 등록해 alert 본문이
+  // #1402 — alert fallback 안전망 등록 (60s 임계, #1894로 30s→60s 완화). shift 전 stationName으로 등록해 alert 본문이
   // 사용자가 실제로 통과한 station을 가리키게 한다. lockless intermediate는 lock 경로보다
   // device-side validation이 느슨해 silent push 누락 시 안전망 가동이 더 절실한 경로.
   await putPending(env.PENDING_PUSHES, {

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -580,7 +580,7 @@ export interface Env {
   TELEMETRY?: AnalyticsEngineWriter;
   /**
    * 발사한 silent push의 pending 추적 (#566 P2a).
-   * P2c에서 30s 미ACK push를 alert로 fallback 발사하기 위한 그릇.
+   * P2c에서 60s 미ACK push를 alert로 fallback 발사하기 위한 그릇 (#1894 30s→60s 완화).
    * 미바인딩 시 모든 pending 경로는 graceful no-op (개발 환경 호환).
    * 생성: `wrangler kv:namespace create PENDING_PUSHES`
    */

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -54,6 +54,7 @@ import {
   logSuppressedHopWindowNoSource,
   logSuppressedLocklessForwardOnly,
   logFusionCandidateDistanceReject,
+  logFusionCandidateLineReject,
   logFusionPickerTier,
   _resetFusionPickerTierWindowForTests,
   formatFusionPickerTierDistribution,
@@ -984,6 +985,47 @@ describe('alarmLog', () => {
       const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
       const saved: AlarmLogEntry[] = JSON.parse(savedJson);
       const matching = saved.filter((e) => e.reason === 'candidate-distance-reject');
+      expect(matching).toHaveLength(3);
+    });
+
+    it('#1902 logFusionCandidateLineReject: reason=candidate-line-reject + source=fusion-candidate-reject + line stamp in stationName', async () => {
+      _resetBurstSuppressWindowForTests();
+      logFusionCandidateLineReject({ line: '6' });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fusion-candidate-reject',
+        outcome: 'suppressed',
+        reason: 'candidate-line-reject',
+        stationName: 'line:6',
+      });
+    });
+
+    it('#1902 logFusionCandidateLineReject: burst dedup per line — same line within window dropped', async () => {
+      _resetBurstSuppressWindowForTests();
+      logFusionCandidateLineReject({ line: '6' });
+      logFusionCandidateLineReject({ line: '6' });
+      logFusionCandidateLineReject({ line: '6' });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      const matching = saved.filter((e) => e.reason === 'candidate-line-reject');
+      expect(matching).toHaveLength(1);
+    });
+
+    it('#1902 logFusionCandidateLineReject: different lines are NOT deduped', async () => {
+      _resetBurstSuppressWindowForTests();
+      logFusionCandidateLineReject({ line: '5' });
+      logFusionCandidateLineReject({ line: '6' });
+      logFusionCandidateLineReject({ line: '7' });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      const matching = saved.filter((e) => e.reason === 'candidate-line-reject');
       expect(matching).toHaveLength(3);
     });
 

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -234,6 +234,10 @@ export type AlarmLogReason =
   // #1628 — fusion candidate distance hard gate(R12-a) reject 사유. distanceKm/trainNo/stationName/line은
   // 엔트리 컨텍스트로 별도 적재되지 않으므로 dedup 키는 (trainNo|stationName)으로 station 단위 burst 차단.
   | 'candidate-distance-reject'
+  // #1902 (RC-18) — fusion candidate line filter reject. trip route 활성 line 화이트리스트
+  // (`allowedLinesFromRoute`)와 무관한 line 후보가 enumerate 단계에서 차단됐을 때 적재.
+  // burst dedup 키는 line 단위 — 같은 line이 5s 안에 반복 reject되면 첫 1건만 적재.
+  | 'candidate-line-reject'
   // #1628 — R11 cross-trip mirror skip(PR #1613) 차단 1건. 같은 site에서 burst 발사하는 race 케이스를
   // 차단하기 위해 5s 윈도우 burst dedup 적용.
   | 'cross-trip-mirror-skip'
@@ -707,6 +711,32 @@ export function logFusionCandidateDistanceReject(input: { stationName: string })
     outcome: 'suppressed',
     reason: 'candidate-distance-reject',
     stationName: input.stationName,
+  });
+}
+
+/**
+ * #1902 (RC-18) — fusion candidate line filter reject 1건 적재.
+ *
+ * `useFusedNearestStation.ts`의 candidateTrains useMemo가 `allowedLinesFromRoute`로 trip 경로
+ * 외 line 후보를 enumerate 단계에서 차단할 때 호출. RC-18 evidence(T4 trip 18 line cross-blast)
+ * 회복 측정용 — `/admin/alarm-log-stats` reason='candidate-line-reject' 카운트로 line filter
+ * 효과 추적.
+ *
+ * burst dedup: line 키 — 같은 line이 5s 윈도우 안에 반복 reject되면 첫 1건만 적재. enumerate
+ * 단계라 polling cycle마다 같은 line이 다발로 들어와도 측정 의미는 line 단위 카운트.
+ *
+ * stationName slot에 `line:<n>` prefix로 line을 stamp — `appendAlarmLog`의 inline burst dedup이
+ * `stationName` key까지 비교하므로 line별 분포가 entry 단위로 보존된다(distance reject와 같은 패턴).
+ * dump에서도 line 정보가 가시.
+ */
+export function logFusionCandidateLineReject(input: { line: string }): void {
+  if (isBurstDuplicate('candidate-line-reject', input.line)) return;
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'fusion-candidate-reject',
+    outcome: 'suppressed',
+    reason: 'candidate-line-reject',
+    stationName: `line:${input.line}`,
   });
 }
 

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -86,6 +86,13 @@ import {
   subscribeGpsDrop,
   type GpsDropEntry,
 } from '../../../features/nearest-station/utils/gpsDropBuffer';
+// #1902 (RC-18) — candidate-reject 전용 buffer. fusionDebugBuffer 200 cap 점령 자기 파괴 차단.
+import {
+  clearCandidateRejectEntries,
+  getCandidateRejectEntries,
+  subscribeCandidateReject,
+  type CandidateRejectEntry,
+} from '../../../features/nearest-station/utils/candidateRejectBuffer';
 // #1518 — device → backend HTTP 호출 ring buffer. 모든 backend fetch chokepoint가 entry를 push.
 import {
   clearBackendCallEntries,
@@ -312,12 +319,8 @@ function formatFusionDebugLine(entry: FusionDebugEntry): string {
     const sp = entry.speedMps != null ? `${entry.speedMps.toFixed(1)}m/s` : '-';
     return `${time} | sticky:${entry.event} | ${entry.stationName}(${entry.line}) acc=${acc} sp=${sp}`;
   }
-  if (entry.kind === 'candidate-reject') {
-    // #1616 (R12-a) — pickCandidateTrains에서 candidate.currentStation GPS 거리가 threshold 초과로
-    // reject된 case. trainNo / station / 측정 거리 같이 보여 사용자 trip 사후 misfire 차단 검증.
-    const d = `${Math.round(entry.distanceKm * 1000)}m`;
-    return `${time} | reject:${entry.reason} | ${entry.trainNo} ${entry.stationName}(${entry.line}) d=${d}`;
-  }
+  // #1902 (RC-18) — candidate-reject 분기는 candidateRejectBuffer로 이전(별 buffer + 별 섹션).
+  // fusion 분기는 fusion decision entry만 처리한다.
   const station = entry.stationName ? `${entry.stationName}(${entry.line ?? '-'})` : '-';
   const d = entry.distanceKm != null ? `${Math.round(entry.distanceKm * 1000)}m` : '-';
   const acc =
@@ -595,6 +598,11 @@ interface BuildDumpArgs {
    * fusionDebugBuffer와 분리된 채널이라 dump에서도 별도 섹션으로 노출한다.
    */
   gpsDropLog?: readonly GpsDropEntry[];
+  /**
+   * #1902 (RC-18) — candidate reject ring buffer entries (distance/line). 미전달/빈 배열은 (empty)로 출력.
+   * fusionDebugBuffer와 분리된 채널이라 dump에서도 별도 섹션으로 노출.
+   */
+  candidateRejectLog?: readonly CandidateRejectEntry[];
 }
 
 /** dump 본체에서 사용하는 single builder 시그니처 — 본문 줄 배열을 반환. */
@@ -910,6 +918,28 @@ function buildGpsDropLogSection(args: BuildDumpArgs): string[] {
   const entries = args.gpsDropLog ?? [];
   if (entries.length === 0) return ['(empty)'];
   return [...entries].reverse().map(formatGpsDropLine);
+}
+
+/**
+ * #1902 (RC-18) — candidate reject 한 줄 포맷. reason별로 다른 컬럼:
+ *   - candidate-distance: trainNo + station + 측정 거리 (R12-a, #1616).
+ *   - candidate-line: line만 노출 — enumerate 단계 reject라 train picking 전.
+ */
+function formatCandidateRejectLine(entry: CandidateRejectEntry): string {
+  const time = formatTime(entry.ts);
+  if (entry.reason === 'candidate-distance') {
+    const train = entry.trainNo ?? '-';
+    const station = entry.stationName ?? '-';
+    const d = entry.distanceKm != null ? `${Math.round(entry.distanceKm * 1000)}m` : '-';
+    return `${time} | reject:${entry.reason} | ${train} ${station}(${entry.line}) d=${d}`;
+  }
+  return `${time} | reject:${entry.reason} | line=${entry.line}`;
+}
+
+function buildCandidateRejectLogSection(args: BuildDumpArgs): string[] {
+  const entries = args.candidateRejectLog ?? [];
+  if (entries.length === 0) return ['(empty)'];
+  return [...entries].reverse().map(formatCandidateRejectLine);
 }
 
 /**
@@ -1308,6 +1338,12 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
     build: buildGpsDropLogSection,
     suffix: (args) => ` (${args.gpsDropLog?.length ?? 0})`,
   },
+  // #1902 (RC-18) — candidate-reject 별 buffer (distance + line). fusionDebugBuffer 점령 회귀 차단.
+  {
+    title: 'Candidate rejects',
+    build: buildCandidateRejectLogSection,
+    suffix: (args) => ` (${args.candidateRejectLog?.length ?? 0})`,
+  },
   // #1518 — device → backend HTTP 호출 ring buffer. 직전 trip의 register/sync/telemetry 호출
   // 흔적이 dump만 보고 재구성 가능해야 #622 transfer-leg sync 같은 회귀 진단이 가능하다.
   {
@@ -1662,6 +1698,10 @@ function DebugModalInner({
   const [gpsDropLogs, setGpsDropLogs] = useState<readonly GpsDropEntry[]>(() =>
     getGpsDropEntries(),
   );
+  // #1902 (RC-18) — candidate-reject ring buffer. fusionLogs와 동일 패턴.
+  const [candidateRejectLogs, setCandidateRejectLogs] = useState<readonly CandidateRejectEntry[]>(() =>
+    getCandidateRejectEntries(),
+  );
   const [estimatorLogs, setEstimatorLogs] = useState<readonly EstimatorDebugEntry[]>(() =>
     getEstimatorEntries(),
   );
@@ -1696,6 +1736,13 @@ function DebugModalInner({
   // #1540 (S7) — gps-drop buffer 구독. push/clear 어느 쪽이든 같은 listener로 반응.
   useEffect(() => {
     return subscribeGpsDrop(() => setGpsDropLogs([...getGpsDropEntries()]));
+  }, []);
+
+  // #1902 (RC-18) — candidate-reject buffer 구독. gps-drop과 동일 패턴.
+  useEffect(() => {
+    return subscribeCandidateReject(() =>
+      setCandidateRejectLogs([...getCandidateRejectEntries()]),
+    );
   }, []);
 
   useEffect(() => {
@@ -1798,6 +1845,8 @@ function DebugModalInner({
       fusionLog: fusionLogs,
       // #1540 (S7) — gps-drop entries를 share에 포함. 별 buffer라 fusion log와 동시 dump.
       gpsDropLog: gpsDropLogs,
+      // #1902 (RC-18) — candidate-reject entries를 share에 포함. 별 buffer라 fusion log와 동시 dump.
+      candidateRejectLog: candidateRejectLogs,
       // #1413 — UI에만 노출되던 BoardingLock/Estimator/Boarding Prompt(+Acceptance)/Counters를 share에 포함.
       boardingLock: lock,
       estimatorLog: estimatorLogs,
@@ -1845,6 +1894,8 @@ function DebugModalInner({
     fusionLogs,
     // #1540 (S7) — gps-drop entries 변경 시 share 텍스트 자동 갱신.
     gpsDropLogs,
+    // #1902 (RC-18) — candidate-reject entries 변경 시 share 텍스트 자동 갱신.
+    candidateRejectLogs,
     // #1413 — BoardingLock/Estimator 신규 캡쳐.
     lock,
     estimatorLogs,
@@ -2161,6 +2212,20 @@ function DebugModalInner({
             }}
             clearTestId="debug-gps-drop-log-clear"
             entryTestId="debug-gps-drop-log-entry"
+            colors={colors}
+          />
+
+          {/* #1902 (RC-18) — candidate-reject 별 buffer. fusion log cap 점령 회귀 차단용 별 채널 표시. */}
+          <DebugLogSection
+            title="Candidate rejects"
+            logs={candidateRejectLogs}
+            formatLine={formatCandidateRejectLine}
+            onClear={() => {
+              clearCandidateRejectEntries();
+              setCandidateRejectLogs([]);
+            }}
+            clearTestId="debug-candidate-reject-log-clear"
+            entryTestId="debug-candidate-reject-log-entry"
             colors={colors}
           />
 
@@ -2813,6 +2878,9 @@ export const __test__ = {
   // #1540 (S7) — gps-drop 별 buffer 포맷/섹션. 단위 테스트에서 직접 호출.
   formatGpsDropLine,
   buildGpsDropLogSection,
+  // #1902 (RC-18) — candidate-reject 별 buffer 포맷/섹션. 단위 테스트에서 직접 호출.
+  formatCandidateRejectLine,
+  buildCandidateRejectLogSection,
 };
 
 const styles = StyleSheet.create({

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -2029,7 +2029,7 @@ describe('DebugModal backend calls section — #1518', () => {
 });
 
 describe('formatFusionDebugLine', () => {
-  const { formatFusionDebugLine } = __test__;
+  const { formatFusionDebugLine, formatCandidateRejectLine } = __test__;
 
   it('gps-fix 엔트리: station/distance/accuracy 포함', () => {
     const line = formatFusionDebugLine({
@@ -2094,8 +2094,8 @@ describe('formatFusionDebugLine', () => {
     },
   );
 
-  it('#1616 (R12-a) candidate-reject 엔트리: reject reason / trainNo / station / distance 포함', () => {
-    const line = formatFusionDebugLine({
+  it('#1616/#1902 (R12-a + RC-18) candidate-distance reject: formatter는 별 buffer 포맷터 사용', () => {
+    const line = formatCandidateRejectLine({
       kind: 'candidate-reject',
       ts: new Date('2026-06-21T12:00:00Z').getTime(),
       reason: 'candidate-distance',
@@ -2108,6 +2108,33 @@ describe('formatFusionDebugLine', () => {
     expect(line).toContain('T-2099');
     expect(line).toContain('강변(동서울터미널)(2)');
     expect(line).toContain('d=5400m');
+  });
+
+  it('#1902 (RC-18) candidate-line reject: line만 포함 (enumerate 단계 reject)', () => {
+    const line = formatCandidateRejectLine({
+      kind: 'candidate-reject',
+      ts: new Date('2026-06-21T12:00:00Z').getTime(),
+      reason: 'candidate-line',
+      line: '6',
+    });
+    expect(line).toContain('reject:candidate-line');
+    expect(line).toContain('line=6');
+    // candidate-line은 trainNo/distanceKm을 갖지 않는다.
+    expect(line).not.toContain('d=');
+  });
+
+  it('#1902 candidate-distance reject: 옵셔널 필드 누락 시 "-" fallback', () => {
+    // type상 optional이지만 useFusedNearestStation는 항상 채워 호출. defensive fallback 분기 커버.
+    const line = formatCandidateRejectLine({
+      kind: 'candidate-reject',
+      ts: new Date('2026-06-21T12:00:00Z').getTime(),
+      reason: 'candidate-distance',
+      line: '2',
+      // trainNo / stationName / distanceKm 모두 누락
+    });
+    expect(line).toContain('reject:candidate-distance');
+    expect(line).toContain('- -(2)');
+    expect(line).toContain('d=-');
   });
 
   it('gps 엔트리: nearestStation/distance/accuracy 누락 시 "-" 표기', () => {
@@ -4461,6 +4488,96 @@ describe('DebugModal — #1501 Raw Signal 섹션', () => {
         fireEvent.press(screen.getByTestId('debug-gps-drop-log-clear'));
       });
       expect(screen.getByText('GPS drops (0)')).toBeTruthy();
+    });
+  });
+
+  // #1902 (RC-18) — candidate-reject 별 buffer. fusion log cap 점령 회귀 차단용 별 채널.
+  describe('Candidate rejects 섹션 (#1902)', () => {
+    const { formatCandidateRejectLine, buildCandidateRejectLogSection, buildDumpText } = __test__;
+    type RejectEntry =
+      import('../../../nearest-station/utils/candidateRejectBuffer').CandidateRejectEntry;
+
+    const makeDistance = (overrides: Partial<RejectEntry> = {}): RejectEntry => ({
+      kind: 'candidate-reject',
+      ts: 1_700_000_000_000,
+      reason: 'candidate-distance',
+      trainNo: 'T-9001',
+      stationName: '강변',
+      line: '2',
+      distanceKm: 5.4,
+      ...overrides,
+    });
+
+    const makeLineReject = (overrides: Partial<RejectEntry> = {}): RejectEntry => ({
+      kind: 'candidate-reject',
+      ts: 1_700_000_000_000,
+      reason: 'candidate-line',
+      line: '6',
+      ...overrides,
+    });
+
+    it('buildCandidateRejectLogSection: 미전달/빈 배열 모두 (empty)', () => {
+      expect(buildCandidateRejectLogSection(baselineDumpArgs)).toEqual(['(empty)']);
+      expect(
+        buildCandidateRejectLogSection({ ...baselineDumpArgs, candidateRejectLog: [] }),
+      ).toEqual(['(empty)']);
+    });
+
+    it('buildCandidateRejectLogSection: 최신이 위로 정렬 + distance/line 동시 노출', () => {
+      const result = buildCandidateRejectLogSection({
+        ...baselineDumpArgs,
+        candidateRejectLog: [
+          makeDistance({ ts: 1000 }),
+          makeLineReject({ ts: 2000, line: '7' }),
+        ],
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0]).toContain('reject:candidate-line');
+      expect(result[0]).toContain('line=7');
+      expect(result[1]).toContain('reject:candidate-distance');
+    });
+
+    it('share dump가 Candidate rejects 섹션을 포함한다 (suffix는 buffer 길이)', () => {
+      const dump = buildDumpText(
+        makeDumpArgs({
+          candidateRejectLog: [makeDistance({ distanceKm: 4.2 })],
+        }),
+      );
+      expect(dump).toContain('## Candidate rejects (1)');
+      expect(dump).toContain('d=4200m');
+    });
+
+    it('share dump: candidateRejectLog 미전달 시 헤더(0) + (empty)', () => {
+      const dump = buildDumpText(makeDumpArgs());
+      expect(dump).toContain('## Candidate rejects (0)');
+      const section = dump.slice(dump.indexOf('## Candidate rejects'));
+      expect(section).toContain('(empty)');
+    });
+
+    it('UI: 비어있으면 (0) 표시, push 시 entry 노출, Clear가 비운다', async () => {
+      const {
+        clearCandidateRejectEntries,
+        pushCandidateRejectEntry,
+      } = jest.requireActual('../../../nearest-station/utils/candidateRejectBuffer');
+      clearCandidateRejectEntries();
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      expect(screen.getByText('Candidate rejects (0)')).toBeTruthy();
+      act(() => {
+        pushCandidateRejectEntry({
+          kind: 'candidate-reject',
+          ts: new Date('2026-06-26T13:00:00Z').getTime(),
+          reason: 'candidate-line',
+          line: '6',
+        });
+      });
+      expect(screen.getByText('Candidate rejects (1)')).toBeTruthy();
+      const entries = screen.getAllByTestId('debug-candidate-reject-log-entry');
+      expect(entries[0].props.children).toContain('line=6');
+      act(() => {
+        fireEvent.press(screen.getByTestId('debug-candidate-reject-log-clear'));
+      });
+      expect(screen.getByText('Candidate rejects (0)')).toBeTruthy();
     });
   });
 });

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.candidateLineFilter.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.candidateLineFilter.test.ts
@@ -1,0 +1,227 @@
+/* eslint-disable import/no-restricted-paths -- cross-feature orchestration (#890) */
+
+/**
+ * #1902 (RC-18) — candidate-generator line filter 회귀 가드.
+ *
+ * 배경: T4 trip evidence — 사용자 trip line=2인데 5/6/7호선 + 공항철도 + 경의중앙선 후보가
+ *   enumerate 단계에서 무차별 reject. reject 카운트 trip 길이 비례 폭증(T1 14건 → T4 66건),
+ *   fusionDebugBuffer 200 cap 점령 자기 파괴 회귀.
+ *
+ * 검증:
+ *   1. routeContext 없으면 line filter 우회 — 자유 화면 동작 보존 (기존 fusion 흐름).
+ *   2. routeContext direct (line=2) — line 7 후보가 enumerate 차단되고 candidateRejectBuffer/alarmLog 적재.
+ *   3. routeContext transfer (line=2 → line=7) — 양 line 모두 허용 (환승역 cross-line 자연 통과).
+ *   4. line 2 후보는 그대로 통과 (정상 trip 영향 0).
+ */
+
+import { renderHook } from '@testing-library/react-native';
+import { useFusedNearestStation } from '../useFusedNearestStation';
+import { useNearestStation } from '../useNearestStation';
+import { useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
+import { useTrainPositions } from '../../../route/hooks/useTrainPositions';
+import { findTopNearestStations } from '../../utils/findNearestStation';
+import { findStationByNameAndLine } from '../../../../shared/utils/stationLookup';
+import {
+  arrivalRet,
+  positionRet,
+  makeTrain,
+  GPS_BASE_DEFAULTS,
+} from '../../../../testUtils/positionApiFixtures';
+import { TRAIN_STATUS } from '../../../../shared/constants/trainStatus';
+import {
+  clearCandidateRejectEntries,
+  getCandidateRejectEntries,
+} from '../../utils/candidateRejectBuffer';
+import {
+  getFusionDebugEntries,
+  clearFusionDebugEntries,
+} from '../../utils/fusionDebugBuffer';
+import type { LinePositions } from '../../api/positionApi';
+import type { FusedRouteContext } from '../useFusedNearestStation';
+import type { DirectRoute, TransferRoute } from '../../../../shared/utils/stationRoute';
+
+jest.mock('../../utils/findNearestStation', () => ({
+  findTopNearestStations: jest.fn(),
+}));
+jest.mock('../useNearestStation');
+jest.mock('../../../arrival/hooks/useArrivalInfo');
+jest.mock('../../../route/hooks/useTrainPositions');
+jest.mock('../../../alarm/utils/tripStartStorage', () => ({
+  getTripStartedAt: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../../../alarm/utils/backendSsotMirror', () => ({
+  readBackendSsotMirror: jest.fn().mockResolvedValue(null),
+}));
+
+const mockNearest = useNearestStation as jest.Mock;
+const mockArrival = useArrivalInfo as jest.Mock;
+const mockPos = useTrainPositions as jest.Mock;
+const mockFindTop = findTopNearestStations as jest.Mock;
+
+const gangnam2 = findStationByNameAndLine('강남', '2')!;
+const yongmasan7 = findStationByNameAndLine('용마산', '7')!;
+const junggok7 = findStationByNameAndLine('중곡', '7')!;
+const gunja7 = findStationByNameAndLine('군자', '7')!;
+
+const T0 = 1_700_000_000_000;
+
+function setupGpsAt(stationLat: number, stationLng: number) {
+  mockNearest.mockReturnValue({
+    result: null,
+    liveResult: null,
+    stickyDisplayOnly: null,
+    variants: [],
+    userLocation: { lat: stationLat, lng: stationLng },
+    ...GPS_BASE_DEFAULTS,
+    lastFixAtMs: T0,
+    refresh: jest.fn(),
+  });
+  mockFindTop.mockReturnValue([]);
+  mockArrival.mockReturnValue(arrivalRet(null));
+}
+
+/** line 7 positions response (사용자 trip route에 line 7이 포함되지 않은 케이스 검증용). */
+function line7Positions(): LinePositions {
+  return {
+    line: '7',
+    trains: [
+      makeTrain('용마산', TRAIN_STATUS.DEPARTED, {
+        trainNo: 'T-7-1',
+        receivedAtMs: T0,
+      }),
+    ],
+  };
+}
+
+/** line 2 positions response. */
+function line2Positions(): LinePositions {
+  return {
+    line: '2',
+    trains: [
+      makeTrain('강남', TRAIN_STATUS.DEPARTED, {
+        trainNo: 'T-2-1',
+        receivedAtMs: T0,
+      }),
+    ],
+  };
+}
+
+describe('#1902 candidate-generator line filter (RC-18)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(T0);
+    clearCandidateRejectEntries();
+    clearFusionDebugEntries();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('routeContext 없으면 line filter 우회 — 자유 화면 fusion 보존', () => {
+    setupGpsAt(yongmasan7.lat, yongmasan7.lng);
+    mockPos.mockImplementation((line: string | null) => {
+      if (line === '7') return positionRet(line7Positions());
+      return positionRet(null);
+    });
+
+    // routeContext 미전달 — allowedLines = undefined → filter 자연 우회.
+    renderHook(() => useFusedNearestStation());
+
+    // candidateRejectBuffer에 line filter reject entry 없음.
+    const rejects = getCandidateRejectEntries();
+    const lineRejects = rejects.filter((r) => r.reason === 'candidate-line');
+    expect(lineRejects).toHaveLength(0);
+  });
+
+  it('routeContext direct line=2: line 7 후보가 enumerate 단계에서 차단되고 reject buffer 적재', () => {
+    // GPS는 line 7 station(용마산) 근처지만 trip route는 direct line 2.
+    // 사용자 trip route 변경 후 stale lp.line=7 자료가 useTrainPositions에 남는 race 시뮬레이션.
+    // `useTrainPositions` mock을 line 입력 무관 항상 line 7 lp 반환 → lps에 line=7 entry 진입.
+    setupGpsAt(yongmasan7.lat, yongmasan7.lng);
+    mockPos.mockImplementation(() => positionRet(line7Positions()));
+
+    const route: DirectRoute = {
+      type: 'direct',
+      stops: 5,
+      line: '2',
+      travelSeconds: 600,
+    };
+    const ctx: FusedRouteContext = {
+      route,
+      origin: gangnam2,
+      destination: gangnam2,
+    };
+    renderHook(() => useFusedNearestStation(undefined, undefined, ctx));
+
+    const rejects = getCandidateRejectEntries();
+    const lineRejects = rejects.filter((r) => r.reason === 'candidate-line');
+    // line 7 후보가 차단됐어야 함 (≥1건).
+    expect(lineRejects.length).toBeGreaterThanOrEqual(1);
+    expect(lineRejects[0].line).toBe('7');
+    // fusionDebugBuffer는 candidate-reject 적재 X (별 buffer로 이전).
+    const fusionEntries = getFusionDebugEntries();
+    const fusionRejects = fusionEntries.filter(
+      (e: { kind: string }) => e.kind === 'candidate-reject',
+    );
+    expect(fusionRejects).toHaveLength(0);
+  });
+
+  it('routeContext transfer line=2→7: 양 line 후보 모두 enumerate 허용 (환승역 cross-line)', () => {
+    setupGpsAt(gunja7.lat, gunja7.lng);
+    mockPos.mockImplementation((line: string | null) => {
+      if (line === '7') return positionRet(line7Positions());
+      if (line === '2') return positionRet(line2Positions());
+      return positionRet(null);
+    });
+
+    const route: TransferRoute = {
+      type: 'transfer',
+      transferName: '강변',
+      fromLine: '2',
+      toLine: '7',
+      stopsToTransfer: 3,
+      stopsFromTransfer: 4,
+      secondsToTransfer: 300,
+      secondsFromTransfer: 400,
+    };
+    const ctx: FusedRouteContext = {
+      route,
+      origin: gangnam2,
+      destination: junggok7,
+    };
+    renderHook(() => useFusedNearestStation(undefined, undefined, ctx));
+
+    const rejects = getCandidateRejectEntries();
+    const lineRejects = rejects.filter((r) => r.reason === 'candidate-line');
+    // line 2와 line 7 둘 다 allowedLines에 포함 → enumerate 차단 0건.
+    expect(lineRejects).toHaveLength(0);
+  });
+
+  it('routeContext direct line=2: line 2 후보는 그대로 통과 (정상 trip 영향 0)', () => {
+    setupGpsAt(gangnam2.lat, gangnam2.lng);
+    mockPos.mockImplementation((line: string | null) => {
+      if (line === '2') return positionRet(line2Positions());
+      return positionRet(null);
+    });
+
+    const route: DirectRoute = {
+      type: 'direct',
+      stops: 5,
+      line: '2',
+      travelSeconds: 600,
+    };
+    const ctx: FusedRouteContext = {
+      route,
+      origin: gangnam2,
+      destination: gangnam2,
+    };
+    renderHook(() => useFusedNearestStation(undefined, undefined, ctx));
+
+    const rejects = getCandidateRejectEntries();
+    const lineRejects = rejects.filter((r) => r.reason === 'candidate-line');
+    // line 2는 allowed에 포함 → reject 없음.
+    expect(lineRejects).toHaveLength(0);
+  });
+});

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -11,6 +11,8 @@ import {
   pushFusionDebugEntry,
   type FusionCandidateMini,
 } from '../utils/fusionDebugBuffer';
+// #1902 (RC-18) — candidate reject 별 buffer. fusionDebugBuffer 200 cap 점령 자기 파괴 차단.
+import { pushCandidateRejectEntry } from '../utils/candidateRejectBuffer';
 import { pushRawSignal, type MotionLabel } from '../../observability/utils/rawSignalBuffer';
 import { getCurrentCellularTech } from '../utils/cellularTech';
 import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
@@ -34,6 +36,7 @@ import { trackTrainProgress } from '../../route/utils/trackTrainProgress';
 import { estimateArcStationsFromRoute } from '../../route/utils/arcEstimation';
 import {
   logFusionCandidateDistanceReject,
+  logFusionCandidateLineReject,
   logFusionPickerTier,
   logSuppressedLocklessForwardOnly,
 } from '../../alarm/utils/alarmLog';
@@ -572,9 +575,28 @@ export function useFusedNearestStation(
     const out: CandidateTrain[] = [];
     // #1616 (R12-a): candidate별 GPS 거리 hard gate. userLocation + line별 station 좌표 lookup을
     // pickCandidateTrains에 전달해 anchor GPS drift 시 잘못된 영역 train 후보 진입을 차단.
-    // pushFusionDebugEntry로 reject 측정 — DebugModal에서 'reject:candidate-distance' 표시.
+    // candidateRejectBuffer로 reject 측정 — DebugModal에서 'reject:candidate-distance' 표시.
+    //
+    // #1902 (RC-18): trip route 활성 line 필터. allowedLines(`allowedLinesFromRoute`)에 없는
+    //   line은 enumerate 단계에서 차단해 무차별 후보 reject(T4 evidence: 5/6/7호선 + 공항철도 +
+    //   경의중앙선 18건 mega-blast)와 fusionDebugBuffer 자기 점령을 차단. allowedLines undefined
+    //   (trip 비활성/route 없음)일 때는 자유 화면 동작 보존(기존 fusion 흐름 그대로).
+    //   환승역 cross-line은 `allowedLinesFromRoute`가 transfer.fromLine + toLine을 모두 포함하므로
+    //   자연 허용 — paradigm Phase 4(호선 자동 전환) 정합.
     for (const lp of lps) {
       if (!lp) continue;
+      if (allowedLines && !allowedLines.has(lp.line)) {
+        // #1902 (RC-18) — trip route 외 line 후보를 enumerate 단계에서 차단.
+        pushCandidateRejectEntry({
+          kind: 'candidate-reject',
+          ts: Date.now(),
+          reason: 'candidate-line',
+          line: lp.line,
+        });
+        // alarmLog mirror — `/admin/alarm-log-stats` 운영 가시성용.
+        logFusionCandidateLineReject({ line: lp.line });
+        continue;
+      }
       const anchor = candidates.find((c) => c.station.line === lp.line)?.station.name;
       const lineStations = getStationsOnLine(lp.line);
       const stationCoordinates = new Map<string, { lat: number; lng: number }>(
@@ -600,7 +622,8 @@ export function useFusedNearestStation(
             info.line,
             (consecutiveRejectByLineRef.current.get(info.line) ?? 0) + 1,
           );
-          pushFusionDebugEntry({
+          // #1902 — candidate-reject 별 buffer로 이전. fusionDebugBuffer 200 cap 보호.
+          pushCandidateRejectEntry({
             kind: 'candidate-reject',
             ts: Date.now(),
             reason: 'candidate-distance',
@@ -621,7 +644,7 @@ export function useFusedNearestStation(
       out.push(...picked);
     }
     return out;
-  }, [candidates, p0.positions, p1.positions, p2.positions, gps.userLocation]);
+  }, [candidates, p0.positions, p1.positions, p2.positions, gps.userLocation, allowedLines]);
 
   // #1017: arcStations를 trackTrainProgress forward-only 가드에 넘기기 위해 trainProgress 이전에 선언.
   // 기존 arcStations useMemo(ADR-008 estimator용)는 아래에서 이 값을 재사용한다.

--- a/src/features/nearest-station/utils/__tests__/candidateRejectBuffer.test.ts
+++ b/src/features/nearest-station/utils/__tests__/candidateRejectBuffer.test.ts
@@ -1,0 +1,101 @@
+/**
+ * #1902 (RC-18) — candidate-reject 별 buffer 단위 테스트.
+ *
+ * 검증:
+ *   1. distance reject entry append (`candidate-distance` reason).
+ *   2. line filter reject entry append (`candidate-line` reason, 옵셔널 필드 graceful).
+ *   3. cap=50 ring buffer overwrite — 점령 회귀 차단(fusionDebugBuffer 200 cap과 독립).
+ *   4. subscribe + clear가 fusionDebugBuffer와 분리된 채로 동작.
+ */
+import {
+  CANDIDATE_REJECT_BUFFER_CAPACITY,
+  clearCandidateRejectEntries,
+  getCandidateRejectEntries,
+  pushCandidateRejectEntry,
+  subscribeCandidateReject,
+  type CandidateRejectEntry,
+} from '../candidateRejectBuffer';
+
+describe('candidateRejectBuffer (#1902 RC-18)', () => {
+  beforeEach(() => {
+    clearCandidateRejectEntries();
+  });
+
+  function makeDistance(overrides: Partial<CandidateRejectEntry> = {}): CandidateRejectEntry {
+    return {
+      kind: 'candidate-reject',
+      ts: 100,
+      reason: 'candidate-distance',
+      trainNo: 'T-9001',
+      stationName: '강변',
+      line: '2',
+      distanceKm: 5.4,
+      ...overrides,
+    };
+  }
+
+  function makeLineReject(overrides: Partial<CandidateRejectEntry> = {}): CandidateRejectEntry {
+    return {
+      kind: 'candidate-reject',
+      ts: 200,
+      reason: 'candidate-line',
+      line: '6',
+      ...overrides,
+    };
+  }
+
+  it('#1616 (R12-a) candidate-distance reject entry — trainNo/station/거리 필수 컨텍스트 보존', () => {
+    pushCandidateRejectEntry(makeDistance());
+    const entries = getCandidateRejectEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].reason).toBe('candidate-distance');
+    expect(entries[0].trainNo).toBe('T-9001');
+    expect(entries[0].distanceKm).toBe(5.4);
+    expect(entries[0].line).toBe('2');
+  });
+
+  it('candidate-line reject entry — trip route 외 line 후보 enumerate 차단 (옵셔널 필드 graceful)', () => {
+    pushCandidateRejectEntry(makeLineReject());
+    const entries = getCandidateRejectEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].reason).toBe('candidate-line');
+    expect(entries[0].line).toBe('6');
+    // candidate-line은 enumerate 단계라 trainNo/stationName/distanceKm 모두 옵셔널.
+    expect(entries[0].trainNo).toBeUndefined();
+    expect(entries[0].stationName).toBeUndefined();
+    expect(entries[0].distanceKm).toBeUndefined();
+  });
+
+  it('CAP=50 ring buffer — overwrite로 fusion log cap 점령 회귀 차단', () => {
+    expect(CANDIDATE_REJECT_BUFFER_CAPACITY).toBe(50);
+    for (let i = 0; i < CANDIDATE_REJECT_BUFFER_CAPACITY + 5; i += 1) {
+      pushCandidateRejectEntry(makeDistance({ ts: i, trainNo: `T-${i}` }));
+    }
+    const entries = getCandidateRejectEntries();
+    expect(entries).toHaveLength(CANDIDATE_REJECT_BUFFER_CAPACITY);
+    // 가장 오래된 5건이 evict — 최신 cap건만 유지.
+    expect(entries[0].trainNo).toBe('T-5');
+    expect(entries[entries.length - 1].trainNo).toBe(`T-${CANDIDATE_REJECT_BUFFER_CAPACITY + 4}`);
+  });
+
+  it('subscribe — push/clear 모두 listener 호출', () => {
+    const listener = jest.fn();
+    const unsub = subscribeCandidateReject(listener);
+    pushCandidateRejectEntry(makeDistance());
+    expect(listener).toHaveBeenCalledTimes(1);
+    pushCandidateRejectEntry(makeLineReject());
+    expect(listener).toHaveBeenCalledTimes(2);
+    clearCandidateRejectEntries();
+    expect(listener).toHaveBeenCalledTimes(3);
+    unsub();
+    pushCandidateRejectEntry(makeDistance());
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
+
+  it('clearCandidateRejectEntries — 비어있어도 graceful (listener 호출 없음)', () => {
+    const listener = jest.fn();
+    subscribeCandidateReject(listener);
+    clearCandidateRejectEntries();
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/nearest-station/utils/__tests__/fusionDebugBuffer.test.ts
+++ b/src/features/nearest-station/utils/__tests__/fusionDebugBuffer.test.ts
@@ -73,23 +73,9 @@ describe('fusionDebugBuffer', () => {
     expect(listener).toHaveBeenCalledTimes(3);
   });
 
-  it('#1616 (R12-a) accepts candidate-reject entries with distance/trainNo/reason', () => {
-    pushFusionDebugEntry({
-      kind: 'candidate-reject',
-      ts: 100,
-      reason: 'candidate-distance',
-      trainNo: 'T-9001',
-      stationName: '강변(동서울터미널)',
-      line: '2',
-      distanceKm: 5.4,
-    });
-    const entries = getFusionDebugEntries();
-    expect(entries).toHaveLength(1);
-    const entry = entries[0];
-    expect(entry.kind).toBe('candidate-reject');
-    expect((entry as { trainNo: string }).trainNo).toBe('T-9001');
-    expect((entry as { distanceKm: number }).distanceKm).toBe(5.4);
-  });
+  // #1902 (RC-18) — candidate-reject 별 buffer(candidateRejectBuffer.ts)로 이전.
+  // fusionDebugBuffer는 fusion/gps/sticky 3 kind만 다룬다. candidate-reject 테스트는
+  // utils/__tests__/candidateRejectBuffer.test.ts 참조.
 
   it('accepts gps-fix and gps-drop entries', () => {
     pushFusionDebugEntry({

--- a/src/features/nearest-station/utils/candidateRejectBuffer.ts
+++ b/src/features/nearest-station/utils/candidateRejectBuffer.ts
@@ -1,0 +1,56 @@
+import { createDebugBuffer } from '../../../shared/utils/createDebugBuffer';
+import type { LineNumber } from '../../../shared/types/station';
+
+/**
+ * #1902 (2026-06-26 RC-18) — candidate reject 전용 ring buffer.
+ *
+ * 배경: fusionDebugBuffer(cap=200) 단일 채널이 `candidate-reject` entry로 점령되면
+ * fusion decision / sticky / gps-fix 등 진단 1순위 entry가 evict되어 사후 분석이 불가능해진다
+ * (T4 trip evidence: reject 66건 / 200 cap = 33% 점유).
+ *
+ * 해결: gpsDropBuffer 패턴과 동일하게 별 buffer로 분리. cap=50은 정상 trip(60+분) 동안의
+ * reject(line filter 적용 후) 카운트를 모두 보관하면서도 fusionDebugBuffer cap을 점령하지 않는다.
+ *
+ * 두 종류:
+ *  - `candidate-distance`: 사용자 GPS 거리 hard gate(#1616 R12-a). anchor drift 차단.
+ *  - `candidate-line` (#1902): trip route 활성 line 화이트리스트(`allowedLinesFromRoute`)와
+ *    무관한 line 후보를 enumerate 단계에서 차단. T4 trip에서 5/6/7호선 + 공항철도 +
+ *    경의중앙선 후보 18개 무차별 reject 회귀 차단용.
+ *
+ * 두 reason을 같은 buffer로 묶은 이유: 둘 다 사용자 GPS / route 기반 후보 정확도 보강 신호로
+ * 진단 시점에 비교 관찰이 유효. DebugModal에서 reason 키별 분포 표시.
+ */
+export const CANDIDATE_REJECT_BUFFER_CAPACITY = 50;
+
+export type CandidateRejectReason = 'candidate-distance' | 'candidate-line';
+
+export interface CandidateRejectEntry {
+  kind: 'candidate-reject';
+  ts: number;
+  reason: CandidateRejectReason;
+  /** trainNo는 `candidate-line` reason에서 enumerate 단계 reject라 train picking 전이므로 옵셔널. */
+  trainNo?: string;
+  /** `candidate-line` reason에서 사용자 trip route 외 후보 station — 진단용. */
+  stationName?: string;
+  line: LineNumber;
+  /** `candidate-distance` reason 한정 — 사용자 GPS와 candidate.currentStation 거리. */
+  distanceKm?: number;
+}
+
+const db = createDebugBuffer<CandidateRejectEntry>(CANDIDATE_REJECT_BUFFER_CAPACITY);
+
+export function pushCandidateRejectEntry(entry: CandidateRejectEntry): void {
+  db.push(entry);
+}
+
+export function getCandidateRejectEntries(): readonly CandidateRejectEntry[] {
+  return db.get();
+}
+
+export function clearCandidateRejectEntries(): void {
+  db.clear();
+}
+
+export function subscribeCandidateReject(listener: () => void): () => void {
+  return db.subscribe(listener);
+}

--- a/src/features/nearest-station/utils/fusionDebugBuffer.ts
+++ b/src/features/nearest-station/utils/fusionDebugBuffer.ts
@@ -92,32 +92,17 @@ export interface StickyStationEntry {
 }
 
 /**
- * #1616 (R12-a) — candidate별 GPS 거리 hard gate가 reject한 entry.
+ * #1616 (R12-a) candidate distance reject + #1902 (RC-18) candidate line reject는
+ * 별 buffer로 분리됐다. `candidateRejectBuffer.ts` 참조.
  *
- * pickCandidateTrains에서 anchorIdx ± window 통과 후 candidate.currentStation의 GPS 좌표가
- * 사용자 마지막 known location 기준 CANDIDATE_DISTANCE_THRESHOLD_KM(3.0km)을 초과해 reject된
- * 케이스. anchor GPS drift 시 잘못된 영역 train이 후보 진입하는 cascade(2026-06-19 trip evidence:
- * pt/fu/gp 다 이수) 차단을 사후 측정.
- *
- * fusion decision과 분리한 이유: reject 자체는 결정 entry가 아니라 입력 단계 reject. fusion
- * decision 이력과 합치면 DebugModal 시각화에서 둘이 섞여 신호 구분 어려움.
+ * 배경: 단일 ring buffer가 reject entry 점령으로 fusion decision/sticky/gps-fix 진단을
+ * 잃는 자기 파괴 회귀(T4 evidence: 66건 / 200 cap = 33%). cap 분리로 진단 1순위 보호.
  */
-export interface CandidateRejectEntry {
-  kind: 'candidate-reject';
-  ts: number;
-  /** reject 사유 — 후속 확장 가능 (예: 'lockless-direction-reject' 등). */
-  reason: 'candidate-distance';
-  trainNo: string;
-  stationName: string;
-  line: string;
-  distanceKm: number;
-}
 
 export type FusionDebugEntry =
   | FusionDecisionEntry
   | GpsFixEntry
-  | StickyStationEntry
-  | CandidateRejectEntry;
+  | StickyStationEntry;
 
 const db = createDebugBuffer<FusionDebugEntry>(FUSION_DEBUG_BUFFER_CAPACITY);
 


### PR DESCRIPTION
## Summary

cascade 통합 PR — RC-20 (alert fallback false fire) + RC-18 (candidate-generator mega-blast).

- **RC-20** (#1894): backend `FALLBACK_THRESHOLD_MS` 30s → 60s 완화. iOS BG silent push 처리 시간(~30s) + ACK round-trip 여유를 흡수해 정상 trip의 alert 중복 발사 차단. T1 trip evidence(ageMs=63319ms) 회복.
- **RC-20 cascade fix**: `PENDING_TTL_SEC` 60s → 120s 상향. 임계 60s 직후 KV expire로 fallback 누락 가능성 차단 (자체 code review 발견).
- **RC-18** (#1902): `useFusedNearestStation` candidateTrains useMemo에 `allowedLinesFromRoute` line filter 추가. trip route 외 line 후보를 enumerate 단계에서 차단해 T4 trip 18 line mega-blast 회귀 차단.
- **RC-18 self-pollution fix**: `candidateRejectBuffer` (cap=50) 별 buffer 신설. `fusionDebugBuffer`(200 cap) 점령 자기 파괴 차단 (gpsDropBuffer 패턴).

`Closes #1894`
`Closes #1902`

## 변경 파일

### Backend (alarm-worker, 9 files)
- `fallback.ts` — FALLBACK_THRESHOLD_MS 30_000 → 60_000 + doc
- `pendingPushes.ts` — PENDING_TTL_SEC 60 → 120 + doc 정합
- `apns.ts` / `retryPushes.ts` / `scheduled.ts`(4곳) / `types.ts` / `index.ts` / `alertContent.ts` — 30s 주석 일관 갱신
- `__tests__/pendingPushes.test.ts` — TTL 120 assertion 갱신

### Frontend (10 files)
- `useFusedNearestStation.ts` — candidateTrains useMemo에 allowedLines filter + 신규 buffer push
- `candidateRejectBuffer.ts` (신규) — cap=50 ring buffer
- `fusionDebugBuffer.ts` — CandidateRejectEntry 제거 (별 buffer로 이전)
- `alarmLog.ts` — reason 'candidate-line-reject' + helper `logFusionCandidateLineReject`
- `DebugModal.tsx` — 신규 Candidate rejects 섹션 + formatter + section builder
- 신규 테스트 3 파일 + 기존 테스트 3 갱신 (fusionDebugBuffer / alarmLog / DebugModal)

## Self-review findings

자체 code-review 9 angles + sweep로 본 PR 본문 fix를 끌어냄:
1. **PENDING_TTL_SEC 60s → 120s** — RC-20 직접 cascade. surfaced and fixed in this PR.
2. candidateRejectBuffer cap=50 multi-transfer 다 lines 진입 시 빠르게 점령 가능성 — line filter 활성 시 distance reject 자체 감소로 정상 trip 50개 미만 예상. follow-up: burst dedup 도입 검토.
3. `logFusionCandidateLineReject` stationName 컬럼에 `line:<n>` stamp — source='fusion-candidate-reject' 격리되어 안전, 향후 alarmLog entry에 line 필드 정식 추가 검토 (out of scope).

## Wire-completion 5단

1. **Orphan 없음** — npm test pass, lint:orphan 영향 받는 신규 export(`pushCandidateRejectEntry`, `getCandidateRejectEntries`, `subscribeCandidateReject`, `clearCandidateRejectEntries`, `CANDIDATE_REJECT_BUFFER_CAPACITY`, `CandidateRejectEntry`, `logFusionCandidateLineReject`, `formatCandidateRejectLine`, `buildCandidateRejectLogSection`)는 모두 `useFusedNearestStation.ts` + `DebugModal.tsx` + alarmLog test에서 직접 호출됨.
2. **V/X dashboard**:
   - V: backend log `alert fallback fire pushId=... ageMs=...` count → wrangler tail / Cloudflare Dashboard Logs filter `kind=alert-fallback`.
   - V: DebugModal `Candidate rejects` 신규 섹션 — distance/line reject 별 buffer 직접 노출.
   - X: `/admin/alarm-log-stats` reason='candidate-line-reject' / 'candidate-distance-reject' 카운트.
3. **의존 PR**:
   - **#1916 (feat/#1898 DebugModal 노선 + accel dashboard)** — same DebugModal.tsx + DebugModal.test.tsx 영역 변경. 본 PR이 먼저 머지되면 #1916가 SHARE_SECTIONS 추가 위치 / import block 변경 시 conflict 가능. 본 PR 머지 후 #1916 rebase 권장. 본 PR은 gpsDropBuffer 패턴을 그대로 따라 신규 섹션을 GPS drops 직후에 추가 → #1916가 다른 위치에 dashboard 섹션 추가 시 자연 양립.
   - backend: N/A (frontend는 신규 backend endpoint 없음, alarmLog는 device side mirror만).
4. **측정 plan** (1주 production):
   - **RC-20**: backend `alert fallback fire` count baseline 측정. PR 전 1.5h에 1건 = 약 16건/주 → 5건/주 미만 target. Cloudflare Dashboard `kind=alert-fallback` daily chart.
   - **RC-18**: alarmLog reason='candidate-line-reject' count baseline (신규). T4 시나리오 reject 60+ → 5건 미만 target. DebugModal `Candidate rejects` 점유율 < 30% (200 cap 보호 acceptance).
   - **회귀 escalation signal**: alert fallback fire > 5건/주 OR candidate-line-reject > T4 baseline 20% — P1.
5. **Device verify**:
   - 시나리오 1 (RC-20): silent push 발사 → device BG에서 ACK 송신 → 60s 임계 도달 전 backend log `ACK received`. T1 시나리오 ageMs=63s 케이스 false fallback 0건 확인.
   - 시나리오 2 (RC-18): lock 활성 line=2 trip 30분+ 진행 → DebugModal `Candidate rejects` 섹션에서 line=2/내부 stations 외 line(예: 5/6/7/공항) reject 0건 확인. 환승역(건대입구) 진입 시 transfer.toLine 후보 허용 확인.
   - **Day 3 trip 시나리오 (#1879 evidence)** 재현 — RC-20 + RC-18 evidence 매트릭스 기반.

## Test results

- Frontend: 8283 / 8283 PASS, coverage 100% (lines/branches/functions/statements)
- Backend: 2240 / 2240 PASS
- Type-check: PASS

## Notes
- Co-Authored-By 없음 (CLAUDE.md 룰 준수).
- main repo 직접 변경 0건 (worktree only).
- PR #1906 (weighted vote + surface-weak)는 fetch 시점 이미 origin/dev에 머지 — fusion useMemo 영역 conflict 없음.