### PR TITLE
fix(#1886): RC-2 boarding-prompt dedup trip-scoped + count<1 완화 (옵션 D)

### DIFF
--- a/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
+++ b/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
@@ -101,16 +101,29 @@ describe('evaluateBoardingPromptGates — 9단 AND 게이트', () => {
     expect(r.pass).toBe(true);
   });
 
-  it('#6: N<3 → window-too-small', () => {
-    const small = happySeries(now).slice(-2);
+  it('#6: N≥1이면 통과 — sample 2개도 OK (#1886 RC-2: MIN_WINDOW_SAMPLES=1)', () => {
+    // 옵션 D: 후보 1개 이상이면 발사. N=2 sample은 통과해야 한다.
+    const twoSamples = happySeries(now).slice(-2);
     const r = evaluateBoardingPromptGates({
-      series: small,
+      series: twoSamples,
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+    });
+    // 2 samples: accuracy/origin/direction/speed 조건 충족 시 통과.
+    // happySeries 2개는 direction cosine이 0.7 이상이고 accuracy/origin 조건도 충족.
+    expect(r.pass).toBe(true);
+  });
+
+  it('#6: N=0(빈 series) → no-candidates (#1886 RC-2: count=0만 차단)', () => {
+    const r = evaluateBoardingPromptGates({
+      series: [],
       origin: ORIGIN,
       nextStation: NEXT,
       now,
     });
     expect(r.pass).toBe(false);
-    if (!r.pass) expect(r.reason).toBe('window-too-small');
+    if (!r.pass) expect(r.reason).toBe('no-candidates');
   });
 
   it('#3: 평균 accuracy ≥ 50m → accuracy-too-poor', () => {

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -645,14 +645,15 @@ describe('POST /trips — lastAutoPromptedAt 보존 (#916 follow-up B)', () => {
     expect(stored.lastAutoPromptedAt).toBe(stamp);
   });
 
-  it('new session(createdAt drift > 5s) — window 안이면 보존', async () => {
+  it('new session(createdAt drift > 5s) — window 안이어도 보존하지 않음(undefined) (#1886 RC-2 옵션 D)', async () => {
     const env = makeKvEnv();
     const stamp = CREATED - WITHIN_WINDOW_MS;
     await seedExisting(env, { lastAutoPromptedAt: stamp });
-    // boardingPromptState는 새 세션에서 리셋되지만 dedup 마커는 살아남아야 한다.
+    // #1886 RC-2 옵션 D: 새 trip(isSameSession=false)은 lastAutoPromptedAt를 reset.
+    // T1→T2 연속 trip에서 T1의 dedup이 T2로 carry-over하던 회귀 차단.
     await post('/trips', tripBody({ createdAt: CREATED + 10_000 }), env);
     const stored = JSON.parse((await env.TRIPS.get(`trip:${TOKEN}`)) as string);
-    expect(stored.lastAutoPromptedAt).toBe(stamp);
+    expect(stored.lastAutoPromptedAt).toBeUndefined();
   });
 
   it('new session + window 밖 — 보존하지 않음(undefined)', async () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -5287,6 +5287,55 @@ describe('runScheduled — #916 follow-up B lastAutoPromptedAt dedup', () => {
     // 새 발사로 마커 갱신.
     expect(stored.lastAutoPromptedAt).toBe(NOW);
   });
+
+  // #1886 RC-2 옵션 D — trip-scoped dedup reset.
+  // 새 trip(lastAutoPromptedAt이 없음)은 30분 dedup이 없어 즉시 발사한다.
+  // index.ts에서 isSameSession=false 시 lastAutoPromptedAt을 reset하므로
+  // 다음 cron은 lastAutoPromptedAt=undefined인 trip을 받아 dedup 없이 평가.
+  it('#1886 RC-2 옵션 D: lastAutoPromptedAt=undefined(새 trip) → 30분 이내여도 dedup 없이 발사', async () => {
+    const kv = new InMemoryKV();
+    const token = 'fub-new-trip';
+    // 새 trip 시뮬레이션: index.ts가 isSameSession=false → lastAutoPromptedAt undefined로 reset.
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makePromptTrip({
+        token,
+        lastAutoPromptedAt: undefined, // reset 상태 — 새 trip 첫 평가
+        boardingPromptState: undefined,
+      }),
+    );
+    await seedHappySeries(kv, token);
+    const stats = await runOneCycle(kv, [
+      { destination: '선릉', arrivalSeconds: 60, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: 2 },
+    ]);
+    // dedup 없이 정상 발사.
+    expect(stats.boardingPromptAutoDeduped).toBe(0);
+    expect(stats.boardingPromptFired).toBe(1);
+    const stored = JSON.parse((await kv.get(`trip:${token}`)) as string) as Trip;
+    expect(stored.lastAutoPromptedAt).toBe(NOW);
+  });
+
+  // #1886 RC-2 옵션 D — 같은 trip 내 30분 dedup은 유지 (spam 방지).
+  // lastAutoPromptedAt이 있고 window 안이면 dedup 적용 — 이 동작은 변경 없음.
+  it('#1886 RC-2 옵션 D: 같은 trip 내 window 안 → dedup 유지 (spam 방지)', async () => {
+    const kv = new InMemoryKV();
+    const token = 'fub-same-trip-dedup';
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makePromptTrip({
+        token,
+        lastAutoPromptedAt: NOW - 2 * 60_000, // 2분 전 — 같은 trip 내 window 안
+        boardingPromptState: undefined,
+      }),
+    );
+    await seedHappySeries(kv, token);
+    const stats = await runOneCycle(kv, [
+      { destination: '선릉', arrivalSeconds: 60, trainCode: 'T', isUp: true, subwayNm: '지하철2호선', arvlCd: 2 },
+    ]);
+    // 같은 trip 내 30분 dedup — spam 방지.
+    expect(stats.boardingPromptAutoDeduped).toBe(1);
+    expect(stats.boardingPromptFired).toBe(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/backend/alarm-worker/src/boardingPrompt.ts
+++ b/backend/alarm-worker/src/boardingPrompt.ts
@@ -7,7 +7,7 @@
  *   3. GPS accuracy < 50m (윈도우 평균 기준)
  *   4. 출발역 100m 이내 (마지막 sample 기준 haversine)
  *   5. 방향 cosine ≥ 0.7 (velocity vector vs 출발역→다음역)
- *   6. 60s 윈도우 sample N≥3
+ *   6. 60s 윈도우 sample N≥1 (#1886 RC-2 옵션 D: 사용자 paradigm 1정거장 이내 발사)
  *   7. fused speed ≥ 5 km/h AND confidence ≠ 'low'
  *   8. motion ∈ {walking, automotive}
  *   9. trip당 1회 + 5분 silence
@@ -45,8 +45,12 @@ import type { BoardingPromptState, PositionPoint } from './types';
 export const ORIGIN_RADIUS_KM = 0.1;
 /** 게이트 #5 — 방향 cosine 임계. */
 export const DIRECTION_COSINE_THRESHOLD = 0.7;
-/** 게이트 #6 — 60s 윈도우 최소 sample. */
-export const MIN_WINDOW_SAMPLES = 3;
+/**
+ * 게이트 #6 — 60s 윈도우 최소 sample.
+ * #1886 RC-2 옵션 D: 3 → 1로 완화. 사용자 paradigm "1정거장 이내 발사" 충족을 위해
+ * 지하/지상 모두 sample 1개 이상이면 평가 진행. false positive는 #8 motion + consensusGate로 차단.
+ */
+export const MIN_WINDOW_SAMPLES = 1;
 /** 게이트 #7 — fused speed 임계 (km/h). */
 export const MIN_FUSED_SPEED_KMH = 5;
 /** 게이트 #9 — dismiss 후 silence 길이. */
@@ -59,6 +63,7 @@ export type GateOutcome =
 export type GateSkipReason =
   | 'no-series'
   | 'window-too-small'
+  | 'no-candidates'
   | 'accuracy-too-poor'
   | 'origin-too-far'
   | 'direction-mismatch'
@@ -140,12 +145,14 @@ function evaluateGpsGeometryGates(
   metrics: WindowedMetrics,
 ): GateOutcome | null {
   if (metrics.count < MIN_WINDOW_SAMPLES) {
-    return { pass: false, reason: 'window-too-small', metrics };
+    // #1886 RC-2 — MIN_WINDOW_SAMPLES=1이므로 count=0(데이터 전무) 만 여기서 차단.
+    // caller 및 GPS-bypass 분기의 count=0 체크와 동일 의미 — reason을 통일해 관측 편의 확보.
+    return { pass: false, reason: 'no-candidates', metrics };
   }
-  // window-too-small이 통과한 이후엔 start/end가 null이 될 수 없음(count ≥ 3).
+  // no-candidates가 통과한 이후엔 start/end가 null이 될 수 없음(count ≥ 1).
   // TypeScript narrowing을 위해 명시 assert로 진행.
   if (!metrics.start || !metrics.end) {
-    return { pass: false, reason: 'window-too-small', metrics };
+    return { pass: false, reason: 'no-candidates', metrics };
   }
   // #3 — accuracy. 평균 accuracy가 50m 이상이면 신뢰 불가.
   if (metrics.avgAccuracyMeters >= ACCURACY_CUTOFF_M) {
@@ -239,7 +246,8 @@ export function evaluateBoardingPromptGates(
   // GPS-bypass 환경(underground/mixed/unknown):
   //   iOS CMMotionActivity는 trip 시작 직후 5~10분 lag으로 unknown 상태가 normal.
   //   지하에서는 walking/automotive 수렴까지 시간이 더 필요하므로 unknown 허용.
-  //   단, count=0(series 완전 비어 있음)은 "warmup lag"이 아닌 "데이터 전무" — window-too-small로 차단.
+  //   단, count=0(series 완전 비어 있음)은 "warmup lag"이 아닌 "데이터 전무" — no-candidates로 차단.
+  //   (#1886 RC-2: window-too-small → no-candidates로 reason 통일)
   //   stationary만 차단 — 이동 중 아님이 확실한 경우만.
   //   caller consensusGate(arrival+lockAttachable 2-of-2)가 false positive를 추가 차단.
   //   (#1820: Day 2 production 36건 evidence — environment=unknown + motion=unknown 100% 차단)
@@ -248,7 +256,7 @@ export function evaluateBoardingPromptGates(
   //   기존 정책 유지 — walking/automotive만 통과.
   if (gpsDependentBypass) {
     if (metrics.count === 0) {
-      return { pass: false, reason: 'window-too-small', metrics };
+      return { pass: false, reason: 'no-candidates', metrics };
     }
     if (metrics.motion === 'stationary') {
       return { pass: false, reason: 'motion-stationary', metrics };

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -569,11 +569,16 @@ app.post('/trips', async (c) => {
 
   const existing = await getTrip(c.env.TRIPS, incoming.token);
   const isSameSession = existing !== null && evaluateSameSession(existing, incoming);
-  // #916 follow-up B — auto-prompt dedup 마커 보존. boardingPromptState와 달리 isSameSession=false
-  // 분기에서도 같은 token + AUTO_PROMPT_DEDUP_WINDOW_MS 안이면 보존한다. 사용자가 lock 클리어 후
-  // 목적지를 살짝 바꿔 새 createdAt으로 재등록하는 케이스에서 prompt 재발사를 차단 (fired+clear
-  // 분기 회복). 윈도우 만료/필드 부재면 undefined로 자연 리셋 — 새 trip은 fresh prompt 평가.
+  // #916 follow-up B — auto-prompt dedup 마커 보존. isSameSession=true(같은 trip 재등록)인 경우만
+  // window 안이면 보존한다. 사용자가 lock 클리어 후 같은 trip context로 재등록하는 케이스에서
+  // 중복 prompt 재발사를 차단 (fired+clear 분기 회복).
+  //
+  // #1886 RC-2 옵션 D — trip-scoped dedup reset.
+  // isSameSession=false(새 trip 등록: 다른 경로/목적지)는 lastAutoPromptedAt을 보존하지 않는다.
+  // T1→T2 연속 trip에서 T1의 dedup이 T2로 carry-over하던 회귀 차단.
+  // 윈도우 만료/필드 부재면 undefined로 자연 리셋.
   const preservedLastAutoPromptedAt =
+    isSameSession &&
     existing?.lastAutoPromptedAt !== undefined &&
     incoming.createdAt - existing.lastAutoPromptedAt < AUTO_PROMPT_DEDUP_WINDOW_MS
       ? existing.lastAutoPromptedAt


### PR DESCRIPTION
Closes #1886

## 요약

RC-2 boarding-prompt 두 가지 차단 원인 수정 (사용자 결정 옵션 D):

1. **count<3 → count<1 완화** (`boardingPrompt.ts:MIN_WINDOW_SAMPLES`): 사용자 paradigm "1정거장 이내 발사" 충족. 빈 series(count=0)만 `no-candidates`로 차단.
2. **dedup trip-scoped reset** (`index.ts:preservedLastAutoPromptedAt`): `isSameSession=false` (새 trip 등록) 시 `lastAutoPromptedAt` reset. T1→T2 연속 trip에서 T1의 30분 dedup이 T2로 carry-over하던 회귀 차단.

## 변경 파일

- `backend/alarm-worker/src/boardingPrompt.ts` — MIN_WINDOW_SAMPLES 3→1, GateSkipReason `no-candidates` 추가
- `backend/alarm-worker/src/index.ts` — `isSameSession &&` 조건 추가로 새 trip 시 dedup reset
- `backend/alarm-worker/src/__tests__/boardingPrompt.test.ts` — N=0 → no-candidates, N=2 통과 테스트
- `backend/alarm-worker/src/__tests__/index.test.ts` — new session dedup reset 동작 검증
- `backend/alarm-worker/src/__tests__/scheduled.test.ts` — trip-scoped dedup reset + 같은 trip dedup 유지 테스트

## Wire-completion 5단 체크

1. **Orphan 없음**: 신규 export 없음. `npm run lint:orphan` — 기존 함수 수정만. `no-candidates` reason은 `GateSkipReason` union 내부에만 존재.
2. **V/X dashboard**: 
   - V: `boarding-prompt: fired` count (wrangler tail + Cloudflare Dashboard)
   - X: `boarding-prompt: gate blocked reason=no-candidates` (기존 `window-too-small` 대체)
   - X: `boarding-prompt: auto-deduped` — trip 경계 carry-over 차단 후 감소 예상
3. **의존 PR**: N/A — 단독 backend PR. wrangler deploy 필요 (device 변경 없음).
4. **측정 plan**: 7일 production 측정 (이슈 §7):
   - `boardingPromptFiredCount` / `boardingPromptBlockedCount` reason 분포
   - `auto-deduped` count: 24건/day → 5건 이하 목표
   - fired/received ratio: 5.5% → 80% 목표
5. **Device verify**:
   - 시나리오 1: lockless trip 출발역 5분 대기 → boarding-prompt 발사 (count<1 완화 검증)
   - 시나리오 2: T1 종료 → T2 즉시 시작 → boarding-prompt 새 발사 (dedup carry-over 없음 검증)
   - backend-only fix. wrangler deploy 후 실기기 trip 시나리오 검증.

## backend wrangler deploy 의존

**본 PR의 fix는 wrangler deploy 후에만 production에서 효과 발생.** device 변경 없음.

```bash
wrangler deploy --env production
```