### PR TITLE
fix(#1910): boarding-prompt cold-start router defer until Stack mount

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -32,6 +32,7 @@ import {
 import { useBoardingPromptResponder } from '../src/features/alarm/hooks/useBoardingPromptResponder';
 import { useBoardingPromptDisplayLogger } from '../src/features/alarm/hooks/useBoardingPromptDisplayLogger';
 import { useStateRehydration } from '../src/shared/hooks/useStateRehydration';
+import { useDeferredNavigate } from '../src/shared/hooks/useDeferredNavigate';
 import { useLaunchTripReconciliation } from '../src/features/alarm/hooks/useLaunchTripReconciliation';
 import { fetchArrivalInfo } from '../src/features/arrival/api/arrivalApi';
 import { FALLBACK_BOARDING_DURATION_MINUTES } from '../src/shared/constants/boardingLock';
@@ -133,23 +134,19 @@ function RootContent() {
     }
   }, [hydrated]);
 
+  // #1910 — cold-start gate: hydrated=false 시 navigate 요청을 defer, hydrated=true 후 flush.
+  // useDeferredNavigate가 pending ref + flush effect를 캡슐화한다.
+  const requestNavigate = useDeferredNavigate(hydrated, () => router.navigate('/'));
+
   // #819 — "탑승했냐?" 응답 listener. boarding-prompt 카테고리 푸시의 [탑승]/[미탑승] 또는 탭을 받아
   // arvlCd 우선순위로 trainCode 자동 lock 또는 5분 silence POST. 미bound trip(destinationId=null)에서도
   // 마운트 — payload만 들어오면 silence POST는 동작.
   // #1888 (RC-13) — banner를 직접 탭한 경우 home 화면으로 navigate해 BoardingTrainList를 노출.
-  // expo-router의 `router.navigate('/')` 사용 — useRouter는 effect 안에서만 안전하지만 router export는
-  // 모듈 레벨에서도 사용 가능(expo-router 6 패턴). 자동 lock 성공/실패 무관 호출 → 실패 시 fallback UI 노출.
   useBoardingPromptResponder({
     fetchArrivalsForStation: (stationName) => fetchArrivalInfo(stationName),
     destinationId,
     expectedDurationMs: FALLBACK_BOARDING_DURATION_MINUTES * 60_000,
-    onBannerTap: () => {
-      try {
-        router.navigate('/');
-      } catch (e) {
-        layoutLogger.warn('boarding-prompt banner tap navigate 실패(#1888):', e);
-      }
-    },
+    onBannerTap: requestNavigate,
   });
 
   // #1385 — boardingPrompt displayed 카운트. FG에서 actionable notification 수신 시 즉시

--- a/src/shared/hooks/__tests__/useDeferredNavigate.test.ts
+++ b/src/shared/hooks/__tests__/useDeferredNavigate.test.ts
@@ -1,0 +1,167 @@
+/**
+ * #1910 — cold-start navigate gate tests.
+ *
+ * 시나리오:
+ *   A. cold-start: hydrated=false 시 banner tap → queue → hydrated=true → flush (1회 navigate)
+ *   B. hot path: hydrated=true 시 banner tap → 즉시 navigate
+ *   C. dedup: 같은 trip 내 banner tap 2회 → 1회만 navigate
+ */
+
+import { act, renderHook } from '@testing-library/react-native';
+import { useDeferredNavigate } from '../useDeferredNavigate';
+
+jest.mock('../../infra/monitoring/breadcrumb', () => ({
+  addDomainBreadcrumb: jest.fn(),
+}));
+jest.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const { addDomainBreadcrumb } = jest.requireMock('../../infra/monitoring/breadcrumb') as {
+  addDomainBreadcrumb: jest.Mock;
+};
+
+describe('useDeferredNavigate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // 시나리오 A: cold-start — banner tap이 hydrated=false 시점에 fire됨.
+  it('cold-start: hydrated=false 시 tap → queue → hydrated=true 로 전환 시 1회 navigate (flush)', () => {
+    const navigate = jest.fn();
+
+    const { result, rerender } = renderHook(
+      ({ hydrated }: { hydrated: boolean }) => useDeferredNavigate(hydrated, navigate),
+      { initialProps: { hydrated: false } },
+    );
+
+    const requestNavigate = result.current;
+
+    // cold-start tap — hydrated=false이므로 즉시 navigate 호출 안 됨.
+    act(() => {
+      requestNavigate();
+    });
+    expect(navigate).not.toHaveBeenCalled();
+    expect(addDomainBreadcrumb).toHaveBeenCalledWith('lifecycle', 'cold_start_navigate_deferred');
+
+    // hydrated=true 전환 — flush effect 실행.
+    rerender({ hydrated: true });
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(addDomainBreadcrumb).toHaveBeenCalledWith(
+      'lifecycle',
+      'cold_start_navigate_deferred_flushed',
+    );
+  });
+
+  // 시나리오 B: hot path — 이미 hydrated=true인 상태에서 tap.
+  it('hot path: hydrated=true 시 tap → 즉시 navigate (defer 없음)', () => {
+    const navigate = jest.fn();
+
+    const { result } = renderHook(() => useDeferredNavigate(true, navigate));
+
+    act(() => {
+      result.current();
+    });
+    expect(navigate).toHaveBeenCalledTimes(1);
+    // deferred breadcrumb은 발사되지 않아야 한다.
+    expect(addDomainBreadcrumb).not.toHaveBeenCalledWith(
+      'lifecycle',
+      'cold_start_navigate_deferred',
+    );
+  });
+
+  // 시나리오 C: dedup — 같은 trip 내 banner tap 2회 → hydrated 전환 시 1회만 navigate.
+  it('dedup: cold-start 중 tap 2회 → hydrated=true 후 1회만 navigate', () => {
+    const navigate = jest.fn();
+
+    const { result, rerender } = renderHook(
+      ({ hydrated }: { hydrated: boolean }) => useDeferredNavigate(hydrated, navigate),
+      { initialProps: { hydrated: false } },
+    );
+
+    const requestNavigate = result.current;
+
+    act(() => {
+      requestNavigate(); // 1st tap
+      requestNavigate(); // 2nd tap — ref는 이미 true, 중복 기록 없음
+    });
+    expect(navigate).not.toHaveBeenCalled();
+
+    rerender({ hydrated: true });
+    // boolean ref → flush 1회만 실행.
+    expect(navigate).toHaveBeenCalledTimes(1);
+  });
+
+  // 경계: tap 없이 hydrated=true로 전환 → navigate 호출 없음 (no false flush).
+  it('tap 없이 hydrated=true 전환 → navigate 호출 없음', () => {
+    const navigate = jest.fn();
+
+    const { rerender } = renderHook(
+      ({ hydrated }: { hydrated: boolean }) => useDeferredNavigate(hydrated, navigate),
+      { initialProps: { hydrated: false } },
+    );
+
+    rerender({ hydrated: true });
+    expect(navigate).not.toHaveBeenCalled();
+    expect(addDomainBreadcrumb).not.toHaveBeenCalledWith(
+      'lifecycle',
+      'cold_start_navigate_deferred_flushed',
+    );
+  });
+
+  // 경계: navigate 함수가 예외를 던져도 swallow (사용자 UX 차단 안 함).
+  it('navigate 예외 → swallow (hook 재귀 예외 없음)', () => {
+    const navigate = jest.fn(() => {
+      throw new Error('navigate before mount');
+    });
+
+    const { result } = renderHook(() => useDeferredNavigate(true, navigate));
+
+    expect(() => {
+      act(() => {
+        result.current();
+      });
+    }).not.toThrow();
+  });
+
+  // 경계: cold-start flush 후 동일 tap 재시도 → navigate 호출 안 함 (ref가 이미 reset됨).
+  it('flush 완료 후 재tap 시도 없으면 navigate 2회 호출 안 함', () => {
+    const navigate = jest.fn();
+
+    const { result, rerender } = renderHook(
+      ({ hydrated }: { hydrated: boolean }) => useDeferredNavigate(hydrated, navigate),
+      { initialProps: { hydrated: false } },
+    );
+
+    act(() => { result.current(); }); // tap once during cold-start
+    rerender({ hydrated: true }); // flush → 1회 navigate
+    expect(navigate).toHaveBeenCalledTimes(1);
+
+    // hydrated 유지 상태에서 hydrated 재렌더 — flush effect는 pendingRef=false이므로 no-op.
+    rerender({ hydrated: true });
+    expect(navigate).toHaveBeenCalledTimes(1);
+  });
+
+  // 경계: cold-start flush 시 navigate 예외 → swallow (UX 차단 안 함).
+  it('cold-start flush 시 navigate 예외 → swallow', () => {
+    const navigate = jest.fn(() => {
+      throw new Error('navigate before mount');
+    });
+
+    const { result, rerender } = renderHook(
+      ({ hydrated }: { hydrated: boolean }) => useDeferredNavigate(hydrated, navigate),
+      { initialProps: { hydrated: false } },
+    );
+
+    act(() => { result.current(); }); // tap during cold-start → queue
+
+    expect(() => {
+      rerender({ hydrated: true }); // flush → navigate throws → swallow
+    }).not.toThrow();
+  });
+});

--- a/src/shared/hooks/useDeferredNavigate.ts
+++ b/src/shared/hooks/useDeferredNavigate.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from 'react';
+import { addDomainBreadcrumb } from '../infra/monitoring/breadcrumb';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('useDeferredNavigate');
+
+/**
+ * #1910 — cold-start navigate gate.
+ *
+ * `addNotificationResponseReceivedListener`는 cold-start 시 동기적으로 fire된다.
+ * hydrated=false 시점에 router.navigate를 호출하면 "Attempted to navigate before mounting
+ * the Root Layout" 예외가 발생하고 try/catch swallow → navigation lost.
+ *
+ * 이 hook은 navigate 요청을 hydrated=false 시점에 ref에 queue하고 hydrated=true 후 flush한다.
+ * boolean ref로 충분 — 같은 trip 내 2회 요청도 1회만 navigate (dedup 자동).
+ *
+ * 사용 패턴:
+ *   const requestNavigate = useDeferredNavigate(hydrated, () => router.navigate('/'));
+ *   // onBannerTap에 requestNavigate 주입
+ *
+ * @param hydrated - Stack mount 완료 여부. false일 때 요청을 queue, true로 전환 시 flush.
+ * @param navigate - 실제 navigation 실행 함수 (caller 주입 — 테스트 격리를 위해 DI).
+ * @returns requestNavigate — onBannerTap 등 trigger callback에 할당.
+ */
+export function useDeferredNavigate(hydrated: boolean, navigate: () => void): () => void {
+  const pendingRef = useRef(false);
+  const navigateRef = useRef(navigate);
+  navigateRef.current = navigate;
+
+  // hydrated=true 전환 시 pending flush.
+  useEffect(() => {
+    if (!hydrated) return;
+    if (!pendingRef.current) return;
+    pendingRef.current = false;
+    addDomainBreadcrumb('lifecycle', 'cold_start_navigate_deferred_flushed');
+    try {
+      navigateRef.current();
+    } catch (e) {
+      log.warn('cold-start deferred navigate 실패(#1910):', e);
+    }
+  }, [hydrated]);
+
+  return () => {
+    if (!hydrated) {
+      addDomainBreadcrumb('lifecycle', 'cold_start_navigate_deferred');
+      pendingRef.current = true;
+      return;
+    }
+    try {
+      navigateRef.current();
+    } catch (e) {
+      log.warn('navigate 실패(#1910):', e);
+    }
+  };
+}


### PR DESCRIPTION
## 개요

Closes #1910
Related #1888 (RC-13 boarding-prompt Interactive + 빈 리스트 wire)

cold-start 시 `addNotificationResponseReceivedListener`가 동기적으로 fire되어
Stack mount 전 `router.navigate('/')` 호출 → "Attempted to navigate before mounting
the Root Layout" 예외 → try/catch swallow → navigation lost 회귀를 수정한다.

## 변경 사항

### `src/shared/hooks/useDeferredNavigate.ts` (신규)

hydrated ref gate hook.

- `hydrated=false` 시 navigate 요청을 `pendingRef`(boolean)에 queue
- `hydrated=true` 전환 시 flush useEffect가 실제 navigate 실행
- boolean ref → 같은 trip 내 2회 tap 자동 dedup (1회만 navigate)
- Sentry breadcrumb: `cold_start_navigate_deferred` / `cold_start_navigate_deferred_flushed` (`lifecycle` category)
- navigate 예외는 try/catch swallow (UX 차단 방지)

### `app/_layout.tsx`

```ts
// 변경 전
onBannerTap: () => {
  try { router.navigate('/'); } catch (e) { layoutLogger.warn(...); }
}

// 변경 후
const requestNavigate = useDeferredNavigate(hydrated, () => router.navigate('/'));
// ...
onBannerTap: requestNavigate,
```

### `src/shared/hooks/__tests__/useDeferredNavigate.test.ts` (신규)

7개 테스트:
- 시나리오 A: cold-start tap → queue → hydrated=true 전환 → 1회 navigate
- 시나리오 B: hot path (hydrated=true) → 즉시 navigate
- 시나리오 C: 2회 tap → 1회만 navigate (dedup)
- 경계: tap 없이 hydrated=true → navigate 없음
- 경계: hot path navigate 예외 → swallow
- 경계: flush 후 재렌더 → navigate 추가 호출 없음
- 경계: flush 시 navigate 예외 → swallow

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` 0 orphan 확인. `useDeferredNavigate`는 `_layout.tsx`에서 import/사용됨.
2. **V/X dashboard** — Sentry breadcrumb `cold_start_navigate_deferred` + `cold_start_navigate_deferred_flushed` (`lifecycle` category). cold-start tap → flush 비율로 회귀 관측.
3. **의존 PR** — N/A
4. **측정 plan** — 1주 production: Sentry `cold_start_navigate_deferred` > 0 발생 + "Attempted to navigate before mounting" warn 로그 0건. 비율 cold_start_navigate_deferred_flushed / cold_start_navigate_deferred 를 user engagement 지표로.
5. **Device verify** — app kill → boarding-prompt OS banner tap → BoardingTrainList 화면 진입 확인 (cold-start 시나리오). 에이전트 검증 범위 외 — 사용자 실기기 검증 필요.

## 코드 리뷰 결과

code-review agent medium effort 실행. 1 PLAUSIBLE finding:

> **S1**: 최초 사용자(onboarding 미완료) + boarding-prompt tap cold-start 시, flush effect `router.navigate('/')` 가 `<Redirect href="/onboarding">` render 이후에 실행되어 onboarding 화면을 override할 수 있음.
>
> 실용적 발생 확률 거의 0 — boarding-prompt는 활성 trip이 있어야 발송되고 활성 trip은 onboarding 완료를 전제로 함. 구조적 보완이 필요하다면 flush effect에 `hasCompletedOnboarding` guard 추가 가능.