### PR TITLE
fix(#1925): getLastKnownPositionAsync maxAge 적용 — cached lastFix 1h+ stale 노출 차단

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
@@ -443,6 +443,22 @@ describe('useNearestStation', () => {
     expect(result.current.result?.station.name).toBe('강남');
   });
 
+  it('#1925: getLastKnownPositionAsync에 MAX_LOCATION_AGE_MS를 maxAge로 전달한다', async () => {
+    // 회귀: 무인자 호출 시 expo-location 내부 기본값이 `.greatestFiniteMagnitude`라
+    // OS가 1h+ stale cached fix를 그대로 반환. JS-level isLocationFresh 게이트 외에
+    // OS-level maxAge로도 차단해 defense-in-depth. silentPushLocationGate.ts:140과 동일 패턴.
+    mockGranted();
+    mockLastKnownLocation(37.4980, 127.0277);
+
+    renderHook(() => useNearestStation());
+
+    await waitFor(() => expect(Location.getLastKnownPositionAsync).toHaveBeenCalled());
+
+    expect(Location.getLastKnownPositionAsync).toHaveBeenCalledWith({
+      maxAge: MAX_LOCATION_AGE_MS,
+    });
+  });
+
   it('캐시된 위치가 없으면 watchPositionAsync 시작 후 loading이 false가 된다', async () => {
     mockGranted();
     mockNoLastKnownLocation();

--- a/src/features/nearest-station/hooks/useNearestStation.ts
+++ b/src/features/nearest-station/hooks/useNearestStation.ts
@@ -15,6 +15,7 @@ import {
 import {
   MAX_ACCURACY_M,
   MAX_ACCURACY_M_DISPLAY,
+  MAX_LOCATION_AGE_MS,
   MAX_STATION_DISTANCE_KM,
   FG_WATCH_SURFACE_TIME_INTERVAL_MS,
   FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS,
@@ -334,7 +335,14 @@ export function useNearestStation(
       //   - 표시 게이트 초과 → 진단 로그 + 무시 (오정보 방지)
       // watch가 fresh fix를 보내면 uncertain이 false로 복귀하며 정정 가능.
       // 사용자 정책 "실시간성 우선, 나쁜 좌표 거부"와 일치 — 250m도 거부, 그 이하만 hydrate.
-      const lastKnown = await Location.getLastKnownPositionAsync();
+      //
+      // #1925 — maxAge 명시. 무인자 호출은 expo-location 내부 기본값이
+      // `.greatestFiniteMagnitude`라 OS가 1h+ stale cached fix를 그대로 반환할 수 있어
+      // (LastKnownLocationRequirements.swift:6), JS 게이트는 통과하지만 timestamp 자체가
+      // 1h 전인 fix가 hydrate되는 회귀를 만든다. OS-level + JS-level 두 게이트로 defense-in-depth.
+      const lastKnown = await Location.getLastKnownPositionAsync({
+        maxAge: MAX_LOCATION_AGE_MS,
+      });
       if (lastKnown) {
         const fresh = isLocationFresh(lastKnown.timestamp);
         const strictlyAcceptable = isAccuracyAcceptable(lastKnown.coords.accuracy);


### PR DESCRIPTION
## Summary
- `useNearestStation.ts:343` — `Location.getLastKnownPositionAsync()` → `{ maxAge: MAX_LOCATION_AGE_MS }`
- 무인자 호출 시 expo-location 내부 기본값이 `.greatestFiniteMagnitude`로 OS가 1h+ stale cached fix를 그대로 반환하는 회귀 차단 (LastKnownLocationRequirements.swift:6 evidence)
- 기존 상수 `MAX_LOCATION_AGE_MS=15_000` 재사용 — `silentPushLocationGate.ts:140` 동일 패턴
- OS-level + JS-level (`isLocationFresh`) 두 게이트로 defense-in-depth

## Evidence (issue body)
- Dump 1: lastFix timestamp 14:03:03, dump 시각 ~15:03 → age ~1h cached fix가 fresh로 노출
- Dump 2: 15:46:47 / 15:48:15 동일 좌표(`삼성 d=66m acc=37m`) 반복 → OS가 같은 cached snapshot 재반환

## Root cause chain
1. App cold start / BG → FG / hydration 시점에 line 343 호출
2. 무인자라 OS가 무제한 stale cached fix(1h+) 반환
3. JS-level `isLocationFresh(lastKnown.timestamp)` 게이트는 통과 가능 (timestamp 비교 자체가 OS가 timestamp 갱신 없이 같은 snapshot 재발급하는 quirk를 잡지 못함)
4. 1h 전 좌표가 fresh로 hydrate → 사용자 잘못된 위치 노출

## Test plan
- [x] Unit: `useNearestStation` mock — `Location.getLastKnownPositionAsync`가 `{ maxAge: MAX_LOCATION_AGE_MS }`로 호출됨 verify
- [x] `npm test` 100% coverage pass (397 suites / 8350 tests)
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass
- [ ] Device: BG 1h+ → FG 진입 시 stale 좌표 노출 0건 (사용자 trip 1주 측정 — 별 close 게이트)

## Wire-completion 5단

### 1) Orphan
- `MAX_LOCATION_AGE_MS`는 이미 caller 다수 (`backgroundLocationTask.ts`, `locationGates.ts`, 등). 본 PR import 1개 추가 → orphan 추가 0.
- `npm run lint:orphan` pass 확인.

### 2) V/X dashboard
- 본 변경은 OS-level call 인자 한 줄. 측정 채널은 기존 `lastKnownStaleCountRef` (line 358 — `lastKnown rejected: stale` 로그) — DebugModal에서 surface 가능.
- 이슈 본문 §7-2의 DebugModal `lastFix age` 표시 추가는 surgical change 원칙상 별도 PR 분리 (본 PR scope 외).

### 3) 의존 PR
- 없음. 단독 머지 가능.

### 4) 측정 plan (1주)
- A: 사용자 trip evidence — BG 1h+ → FG 진입 시 stale 좌표 노출 0건
- B: log query — `lastKnown rejected: stale` 로그 카운트 누적 (drop 정상 동작 evidence)
- 목표: hydration 후 30s 내 fresh fix 도달 비율 ≥ 95%

### 5) Device verify
- **필수.** 사용자 실기기 1회:
  1. 앱을 1h+ BG/kill 유지 → FG 진입
  2. DebugModal GPS lastFix age가 15s 이내 OR `locationUncertain=true` UI 노출 확인
  3. 1h 전 좌표(dump 1처럼 14:03 origin)가 fresh로 표시되지 않음 확인

## Cross-impact
- 영역 G (환경 SSOT): 합집합 — 모든 hydration 진입점에서 stale fix 차단이 prereq
- 위젯 (#8 W): hook의 OS-level maxAge가 widget 정합성도 보장 (widget이 별도 sample 미수집 시)
- LA (#9): LA가 `useNearestStation` 결과 mirror → stale 좌표 mirror 회귀 동시 차단
- V8a (POST /position): `watchPositionAsync` stream 기준 → 영향 0

Closes #1925