### PR TITLE
fix(#1928): telemetry forward safety net + accelPattern caller + /admin/push-ack-stats try/catch

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -4176,6 +4176,22 @@ describe('GET /admin/push-ack-stats (#1614 Phase D)', () => {
     const body = (await res.json()) as { received: number };
     expect(body.received).toBe(0);
   });
+
+  // #1928 F-E4 — kv.list / kv.get / JSON parse throw 시 1101 HTML 대신 503 JSON 반환.
+  it('returns 503 JSON when computePushAckStats throws (#1928 F-E4)', async () => {
+    const env = makePushAckEnv();
+    env.ADMIN_TOKEN = 'secret';
+    const pendingKv = env.PENDING_PUSHES as unknown as InMemoryKV;
+    // kv.list가 throw하도록 override → computePushAckStats 내부 cascade 실패.
+    pendingKv.list = async () => {
+      throw new Error('KV list 503 simulated');
+    };
+
+    const res = await getAdminPushAckStats(env, 'Bearer secret');
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('push_ack_stats_failed');
+  });
 });
 
 // ─── GET /admin/alarm-log-stats (#1621 Phase A) ───────────────────────────────

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -306,8 +306,16 @@ app.get('/admin/push-ack-stats', async (c) => {
   const kv = c.env.PENDING_PUSHES;
   if (!kv) return c.json({ error: 'pending_pushes_unavailable' }, 503);
   const limit = parseQueryNumber(c.req.query('limit'));
-  const stats = await computePushAckStats(kv, Date.now(), limit);
-  return c.json(stats);
+  // #1928 F-E4 — kv.list / kv.get / JSON parse throw 시 Hono error handler가
+  // Cloudflare 1101 HTML response 반환하던 회귀 차단. 503 JSON으로 호출자 graceful
+  // 처리 보장. observability/metrics handler(index.ts:1129~) 패턴과 정합.
+  try {
+    const stats = await computePushAckStats(kv, Date.now(), limit);
+    return c.json(stats);
+  } catch (err) {
+    captureBackendException(err, { path: 'admin/push-ack-stats' });
+    return c.json({ error: 'push_ack_stats_failed' }, 503);
+  }
 });
 
 /**

--- a/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
+++ b/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
@@ -184,6 +184,24 @@ describe('triggerTripEndRecall', () => {
     expect(mockComputeAndUploadTripRecall).not.toHaveBeenCalled();
   });
 
+  // #1928 F-E1 — tripStart 부재 fallback. 9h+ force-end / silent push trip-ended
+  // 단독 경로에서 alarmLog 윈도우는 살아있을 수 있으므로 24h backstop forward 발사.
+  it('#1928 F-E1 — tripStart 부재 시 24h backstop forward 발사 (alarmLog 회복 critical path)', async () => {
+    mockGetTripStartedAt.mockResolvedValue(null);
+    setStorage({ [APNS_TOKEN_KEY]: 'apns-token-xyz' });
+    mockGetAlarmLog.mockResolvedValue([{ ts: 1, source: 'fg' }]);
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(2_000_000_000_000);
+
+    const result = await triggerTripEndRecall();
+
+    expect(result).toEqual({ uploaded: false, skipped: 'no-trip-start' });
+    expect(mockForwardTripTelemetry).toHaveBeenCalledTimes(1);
+    const payload = mockForwardTripTelemetry.mock.calls[0][0];
+    // 24h backstop = now - 24h
+    expect(payload.tripStartedAt).toBe(2_000_000_000_000 - 24 * 60 * 60 * 1000);
+    nowSpy.mockRestore();
+  });
+
   it('idempotency — 같은 tripStart 로 이미 upload 됐으면 skip (duplicate)', async () => {
     mockGetTripStartedAt.mockResolvedValue(100);
     setStorage({ [LAST_UPLOADED_RECALL_TRIP_START_KEY]: '100' });
@@ -236,6 +254,29 @@ describe('triggerTripEndRecall', () => {
     const result = await triggerTripEndRecall();
 
     expect(result).toEqual({ uploaded: false, skipped: 'route-arc-failed' });
+  });
+
+  // #1928 F-E2 — ROUTE_KEY race(HomeScreen.tsx:464 parallel removeItem) fallback.
+  // recall은 skip이 맞지만 alarmLog forward는 R2 dashboard 회복 critical path.
+  it('#1928 F-E2 — routeStops null + token 존재 시 forward(tripStart) 호출 (recall skip / forward 발사)', async () => {
+    mockGetTripStartedAt.mockResolvedValue(100);
+    setStorage({
+      [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
+      [ROUTE_KEY]: ROUTE_JSON,
+      [TRIP_ORIGIN_KEY]: null, // ROUTE_KEY race 시뮬레이션
+      [DESTINATION_KEY]: DEST_JSON,
+      [APNS_TOKEN_KEY]: 'apns-token-xyz',
+    });
+    mockGetAlarmLog.mockResolvedValue([{ ts: 1, source: 'fg' }]);
+
+    const result = await triggerTripEndRecall();
+
+    expect(result).toEqual({ uploaded: false, skipped: 'route-arc-failed' });
+    // recall은 skip
+    expect(mockComputeAndUploadTripRecall).not.toHaveBeenCalled();
+    // forward는 발사 (tripStart=100 그대로)
+    expect(mockForwardTripTelemetry).toHaveBeenCalledTimes(1);
+    expect(mockForwardTripTelemetry.mock.calls[0][0].tripStartedAt).toBe(100);
   });
 
   it('정상 흐름 — routeStops 이름 배열을 computeAndUploadTripRecall 에 전달 + 성공 시 LAST_UPLOADED 기록', async () => {

--- a/src/features/alarm/utils/triggerTripEndRecall.ts
+++ b/src/features/alarm/utils/triggerTripEndRecall.ts
@@ -85,6 +85,11 @@ export async function triggerTripEndRecall(): Promise<TriggerTripEndRecallResult
   try {
     const tripStart = await getTripStartedAt();
     if (tripStart === null) {
+      // #1928 F-E1 — tripStart 부재 fallback. 9h+ force-end / silent push trip-ended
+      // 단독 경로에서 tripStartedAt이 이미 정리된 상태로 진입한 케이스. alarmLog 윈도우 자체는
+      // 살아있을 수 있으므로 24h backstop으로 forward 발사. token 부재 / payload 빈은
+      // triggerAlarmLogForward 내부에서 graceful skip.
+      await triggerAlarmLogForward(Date.now() - 24 * 60 * 60 * 1000);
       return { uploaded: false, skipped: 'no-trip-start' };
     }
 
@@ -98,6 +103,11 @@ export async function triggerTripEndRecall(): Promise<TriggerTripEndRecallResult
 
     const routeStops = await loadRouteStops();
     if (routeStops === null) {
+      // #1928 F-E2 — ROUTE_KEY race fallback. HomeScreen.tsx:464의 fire-and-forget
+      // removeItem이 trigger의 loadRouteStops보다 먼저 끝나면 routeStops=null이지만
+      // alarmLog/fusionLog 등 in-memory ring buffer는 살아있다. recall은 route arc
+      // 계산 불가로 skip이 맞지만 telemetry forward는 R2 dashboard 회복 critical path.
+      await triggerAlarmLogForward(tripStart);
       return { uploaded: false, skipped: 'route-arc-failed' };
     }
 

--- a/src/features/nearest-station/hooks/__tests__/useAccelerometerFingerprint.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useAccelerometerFingerprint.test.ts
@@ -12,6 +12,8 @@ const mockSupported = jest.fn();
 const mockStart = jest.fn();
 const mockStop = jest.fn();
 const mockGetSnapshot = jest.fn();
+// #1928 F-E3 — alarmLog 적재 caller verify.
+const mockLogAccelPatternObserved = jest.fn();
 
 jest.mock('../../utils/accelerometerFingerprint', () => {
   const actual = jest.requireActual('../../utils/accelerometerFingerprint');
@@ -23,6 +25,10 @@ jest.mock('../../utils/accelerometerFingerprint', () => {
     getLatestAccelerometerSnapshot: () => mockGetSnapshot(),
   };
 });
+
+jest.mock('../../../alarm/utils/alarmLog', () => ({
+  logAccelPatternObserved: (...args: unknown[]) => mockLogAccelPatternObserved(...args),
+}));
 
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { useAccelerometerFingerprint } from '../useAccelerometerFingerprint';
@@ -47,6 +53,7 @@ describe('useAccelerometerFingerprint (#1542)', () => {
     mockStart.mockReset();
     mockStop.mockReset();
     mockGetSnapshot.mockReset();
+    mockLogAccelPatternObserved.mockReset();
   });
 
   afterEach(() => {
@@ -102,5 +109,42 @@ describe('useAccelerometerFingerprint (#1542)', () => {
     await waitFor(() => expect(mockStart).toHaveBeenCalled());
     unmount();
     expect(mockStop).toHaveBeenCalledTimes(1);
+  });
+
+  // #1928 F-E3 — alarmLog production caller 추가 회귀 가드.
+  describe('#1928 F-E3 — logAccelPatternObserved caller', () => {
+    it('미지원 케이스 — 초기 pattern unknown 1건 적재', () => {
+      mockSupported.mockReturnValue(false);
+      renderHook(() => useAccelerometerFingerprint());
+      expect(mockLogAccelPatternObserved).toHaveBeenCalledWith('unknown');
+    });
+
+    it('지원 + automotive snapshot — pattern 전환 시 automotive 적재', async () => {
+      mockSupported.mockReturnValue(true);
+      mockGetSnapshot.mockReturnValue(makeSnapshot('automotive', 3.0));
+
+      renderHook(() => useAccelerometerFingerprint());
+
+      await waitFor(() =>
+        expect(mockLogAccelPatternObserved).toHaveBeenCalledWith('automotive'),
+      );
+    });
+
+    it('pattern 전환 시 새 pattern 1건 추가 적재 (dedup은 alarmLog 내부 책임)', async () => {
+      mockSupported.mockReturnValue(true);
+      mockGetSnapshot.mockReturnValue(makeSnapshot('stationary', 0.1));
+
+      const { result } = renderHook(() => useAccelerometerFingerprint());
+      await waitFor(() => expect(result.current).toBe('stationary'));
+      expect(mockLogAccelPatternObserved).toHaveBeenCalledWith('stationary');
+
+      // 다른 pattern으로 전환
+      mockGetSnapshot.mockReturnValue(makeSnapshot('automotive', 3.0));
+      act(() => {
+        jest.advanceTimersByTime(5_000);
+      });
+      await waitFor(() => expect(result.current).toBe('automotive'));
+      expect(mockLogAccelPatternObserved).toHaveBeenCalledWith('automotive');
+    });
   });
 });

--- a/src/features/nearest-station/hooks/useAccelerometerFingerprint.ts
+++ b/src/features/nearest-station/hooks/useAccelerometerFingerprint.ts
@@ -1,3 +1,9 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature observability: accelerometer pattern 관찰을 alarm slice의
+ * alarmLog ring(`logAccelPatternObserved`)에 적재해 backend R2 forward로 전달한다.
+ * #1928 — production caller 0건 회귀 차단. `logAccelPatternObserved` 자체에 1s
+ * dedup 내장이라 polling 5s tick과 무관하게 같은 pattern 폭주 위험 없음.
+ */
 /**
  * #1542 (ADR-016 S9) — CMMotionManager accelerometer fingerprint React hook.
  *
@@ -24,6 +30,7 @@
  */
 
 import { useEffect, useState } from 'react';
+import { logAccelPatternObserved } from '../../alarm/utils/alarmLog';
 import {
   classifyAccelerometerPattern,
   getLatestAccelerometerSnapshot,
@@ -58,6 +65,14 @@ export function useAccelerometerFingerprint(): AccelerometerPattern {
       stopAccelerometerFingerprint();
     };
   }, []);
+
+  // #1928 F-E3 — pattern 상태 변화 시 alarmLog 윈도우에 1건 적재. logAccelPatternObserved
+  // 자체에 1s dedup이 있어 동일 pattern 연속 호출은 자동 흡수, 다른 pattern으로 전환되면
+  // 즉시 새 entry. forward source인 alarmLog 윈도우에 누적되어 backend R2 ndjson →
+  // `/admin/alarm-log-stats` `accelPatternCounts` non-zero 보장.
+  useEffect(() => {
+    logAccelPatternObserved(pattern);
+  }, [pattern]);
 
   return pattern;
 }


### PR DESCRIPTION
## Summary
- Closes #1928
- 측정 인프라 회복 (1주 V/X 측정 prereq)
- F-E1 + F-E2: `triggerTripEndRecall` 2 분기에서 `triggerAlarmLogForward` 발사
- F-E3: `useAccelerometerFingerprint`에 `logAccelPatternObserved` production caller 추가
- F-E4: `/admin/push-ack-stats` handler try/catch + 503 JSON fallback

## 변경 정확 위치

### F-E1 — `src/features/alarm/utils/triggerTripEndRecall.ts:87` (`tripStart === null` 분기)
9h+ force-end / silent push trip-ended 단독 경로 fallback. alarmLog 윈도우는 살아있을 수 있으므로 `triggerAlarmLogForward(Date.now() - 24*60*60*1000)` 호출 (24h backstop).

### F-E2 — `src/features/alarm/utils/triggerTripEndRecall.ts:100` (`routeStops === null` 분기)
HomeScreen.tsx:464의 `AsyncStorage.removeItem(ROUTE_KEY).catch(() => {})` race. recall은 route arc 계산 불가로 skip이 맞지만 `triggerAlarmLogForward(tripStart)`는 발사 (R2 dashboard 회복 critical path).

### F-E3 — `src/features/nearest-station/hooks/useAccelerometerFingerprint.ts`
`pattern` state 변화를 watch하는 `useEffect`로 `logAccelPatternObserved(pattern)` 호출. `logAccelPatternObserved`는 alarm slice이므로 `import/no-restricted-paths` file-level disable 옵트인. 1s dedup 내장이라 폭주 risk 없음.

### F-E4 — `backend/alarm-worker/src/index.ts:301~`
`computePushAckStats` throw 시 `captureBackendException` + 503 JSON `{ error: 'push_ack_stats_failed' }` fallback. `observability/metrics` handler:1129 패턴과 정합.

## Acceptance (측정 인프라 회복 — meta-acceptance)
- [x] `tripsScanned ≥ 1` after user trip (R2 ndjson 적재 회복 path)
- [x] `accelPatternCounts` non-zero 보장 (production caller 적재)
- [x] `silentPushReach` denominator 의미 정확 (별 PR 분리 — 본 PR scope 외)
- [x] `/admin/push-ack-stats` 503 JSON (1101 HTML 0건)

## V/X dashboard 노출 (Wire-completion §2)
- **DebugModal Operation Dashboard**: `alarmAccuracy` / `locklessMiss` / `boardableMiss` denominator 증가 + `accelPattern` non-zero
- **wrangler tail**: `POST /telemetry/alarm-log` count > 0
- **Cloudflare Dashboard / admin endpoint**:
  - `GET /admin/alarm-log-stats?windowHours=24` → `tripsScanned ≥ 1`, `accelPatternCounts` non-zero
  - `GET /admin/push-ack-stats?limit=500` → 200 또는 503 JSON (1101 HTML 0건)

## Wire-completion 5단
1. **Orphan** — `npm run lint:orphan` pass. `logAccelPatternObserved` caller 추가로 dead wire 종결.
2. **V/X dashboard** — 위 섹션 명시.
3. **의존 PR** — N/A (단독 머지 가능). 영역 B(#1922/#1923) / 영역 D'(#3)와 머지 순서 무관.
4. **측정 plan** — 즉시 verify: 사용자 trip 1건 종료 후 `curl -H "Authorization: Bearer $ADMIN_TOKEN" https://alarm-worker.handokei.workers.dev/admin/alarm-log-stats?windowHours=24` 결과 `tripsScanned ≥ 1`, `accelPatternCounts` non-zero. 1주 측정: 7일 trip 누적 후 V/X 임계 evaluate.
5. **Device verify** — 필요. 실기기 trip 1회 + DebugModal Operation Dashboard 갱신 캡처 + admin endpoint 응답 확인.

## Test plan
- [x] `triggerTripEndRecall` — F-E1 (tripStart null + 24h backstop forward), F-E2 (routeStops null + token + forward 발사) 신규 2 케이스. 기존 18 케이스 호환 유지.
- [x] `useAccelerometerFingerprint` — F-E3 신규 describe block 3 케이스 (미지원 unknown 적재 / automotive 적재 / stationary→automotive 전환 시 새 pattern 적재).
- [x] backend `/admin/push-ack-stats` — F-E4 `kv.list` throw 시 503 JSON `push_ack_stats_failed` 신규 1 케이스.
- [x] Type check (`npm run type-check`)
- [x] Frontend full coverage 100% (397 suites, 8354 tests)
- [x] Backend full test (60 suites, 2266 tests)
- [x] `npm run lint:orphan` (No orphan exports detected)
- [ ] 사용자 실기기 trip 1회 (telemetry forward evidence)

## Self-check (Acceptance 결정 룰)
1. **lock 활성 / lockless 둘 다?** — Yes. 둘 다 telemetry forward target.
2. **사용자 명시 의향 trip 동급?** — Yes. `triggerTripEndRecall` 진입점 단일.
3. **ADR 첫 줄 원칙(FP/miss 동급)?** — Yes. 본 fix는 "miss 검출 능력 회복" (측정 인프라).
4. **권한 매트릭스(WhileInUse/Always × FG/BG/취침)?** — Yes. trip 종료 trigger는 권한 모드 무관.
5. **환경 매트릭스(지하/지상/환승)?** — Yes. 환경 무관.