### PR TITLE
fix(#1924): scheduledAlarmReceiver/tripBoundScheduler dismissNotificationAsync 3곳 추가 — delivered tray reconcile 차단

### DIFF
--- a/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
+++ b/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
@@ -6,6 +6,9 @@ jest.mock('expo-notifications', () => ({
   addNotificationReceivedListener: jest.fn(),
   getPresentedNotificationsAsync: jest.fn(),
   cancelScheduledNotificationAsync: jest.fn(),
+  // #1924 — suppress 분기가 delivered tray entry도 정리해 다음 FG 복귀 drain이
+  // 같은 stale identifier를 다시 read 하지 않게 한다.
+  dismissNotificationAsync: jest.fn(),
 }));
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
@@ -101,6 +104,8 @@ const mockSetLastFiredAlarmStationName = setLastFiredAlarmStationName as jest.Mo
 const mockAddListener = Notifications.addNotificationReceivedListener as jest.Mock;
 const mockGetPresented = Notifications.getPresentedNotificationsAsync as jest.Mock;
 const mockCancelScheduled = Notifications.cancelScheduledNotificationAsync as jest.Mock;
+// #1924 — suppress 분기가 dismissNotificationAsync로 delivered tray entry도 cleanup.
+const mockDismissNotification = Notifications.dismissNotificationAsync as jest.Mock;
 const mockAsyncGetItem = AsyncStorage.getItem as jest.Mock;
 
 const DEST_JSON = JSON.stringify({ id: 'dest-1', name: '강남' });
@@ -170,6 +175,9 @@ beforeEach(async () => {
   mockAsyncGetItem.mockResolvedValue(DEST_JSON);
   mockCancelScheduled.mockReset();
   mockCancelScheduled.mockResolvedValue(undefined);
+  // #1924 — suppress 분기가 dismissNotificationAsync로 delivered tray entry 제거.
+  mockDismissNotification.mockReset();
+  mockDismissNotification.mockResolvedValue(undefined);
   // 모든 케이스 공통: addNotificationReceivedListener 기본 핸들. 콜백 캡쳐가 필요한 케이스는 mockImplementationOnce로 override.
   mockAddListener.mockReturnValue({ remove: jest.fn() });
 });
@@ -1295,5 +1303,126 @@ describe('#1354 suppress 시 OS scheduled queue cancel', () => {
     expect(mockSetLastFiredAlarmStationName).not.toHaveBeenCalled();
     // cancel만 발생.
     expect(mockCancelScheduled).toHaveBeenCalledWith('tba:imminent:강남');
+  });
+});
+
+// #1924 — suppress 분기가 OS pending queue cancel과 함께 delivered tray entry도 dismiss.
+// cancelScheduledNotificationAsync(=removePendingNotificationRequests)와
+// dismissNotificationAsync(=removeDeliveredNotifications)는 OS API 상 완전 직교 — pending cancel은
+// delivered tray에 silent no-op. 둘 다 호출하지 않으면 이미 fire 된 stale entry가 tray에 남아
+// 다음 FG 복귀마다 같은 항목이 drain에 read → suppress → alarm log 무한 재적재.
+// (2026-06-27 14:03 trip end 후 14:04~15:48 사이 revalidate-no-trip 56회 evidence.)
+describe('#1924 suppress 시 delivered tray dismiss', () => {
+  beforeEach(() => {
+    setStorageMap({
+      'subway-now:destination': DEST_JSON,
+      'subway-now:route': ROUTE_JSON,
+    });
+  });
+
+  it('F1 reconcile suppress 시 dismissNotificationAsync(identifier) 1회 호출', async () => {
+    mockGetRegisteredTripRouteSig.mockResolvedValueOnce('SIG-OLD');
+    mockRouteSignature.mockReturnValueOnce('SIG-NEW');
+
+    await reconcileScheduledAlarmDelivery('tba:imminent:강남');
+
+    expect(mockDismissNotification).toHaveBeenCalledTimes(1);
+    expect(mockDismissNotification).toHaveBeenCalledWith('tba:imminent:강남');
+    // cancel과 dismiss 둘 다 호출 (pending + delivered 직교 채널).
+    expect(mockCancelScheduled).toHaveBeenCalledWith('tba:imminent:강남');
+  });
+
+  it("F1 'pass' 경로에는 dismiss 호출 0회 (회귀 가드)", async () => {
+    await reconcileScheduledAlarmDelivery('tba:early:강남');
+
+    expect(mockDismissNotification).not.toHaveBeenCalled();
+    expect(mockCancelScheduled).not.toHaveBeenCalled();
+  });
+
+  it('F2 drain suppress 시 dismissNotificationAsync(identifier) 각 항목별 호출', async () => {
+    mockGetRegisteredTripRouteSig
+      .mockResolvedValueOnce('SIG-OLD') // 첫 suppress
+      .mockResolvedValueOnce('SIG-OLD'); // 두 번째 suppress
+    mockRouteSignature
+      .mockReturnValueOnce('SIG-NEW')
+      .mockReturnValueOnce('SIG-NEW');
+    mockGetPresented.mockResolvedValueOnce([
+      { date: 1, request: { identifier: 'tba:early:역A' } },
+      { date: 2, request: { identifier: 'tba:imminent:역B' } },
+    ]);
+
+    const handle = registerScheduledAlarmListener();
+    await awaitInitialScheduledAlarmDrain();
+
+    expect(mockDismissNotification).toHaveBeenCalledTimes(2);
+    expect(mockDismissNotification).toHaveBeenCalledWith('tba:early:역A');
+    expect(mockDismissNotification).toHaveBeenCalledWith('tba:imminent:역B');
+    handle.remove();
+  });
+
+  it("F2 drain 'pass' 항목에는 dismiss 호출 0회 (회귀 가드)", async () => {
+    mockGetPresented.mockResolvedValueOnce([
+      { date: 1, request: { identifier: 'tba:early:강남' } },
+    ]);
+    mockGetFiredAlarms.mockResolvedValueOnce(new Set());
+
+    const handle = registerScheduledAlarmListener();
+    await awaitInitialScheduledAlarmDrain();
+
+    expect(mockDismissNotification).not.toHaveBeenCalled();
+    expect(mockCancelScheduled).not.toHaveBeenCalled();
+    handle.remove();
+  });
+
+  it('F2 drain — suppress + pass 혼합 시 suppress된 항목만 dismiss', async () => {
+    mockGetRegisteredTripRouteSig
+      .mockResolvedValueOnce('SIG-OLD') // suppress
+      .mockResolvedValueOnce('SIG-A'); // pass
+    mockRouteSignature
+      .mockReturnValueOnce('SIG-NEW')
+      .mockReturnValueOnce('SIG-A');
+    mockGetPresented.mockResolvedValueOnce([
+      { date: 1, request: { identifier: 'tba:early:잘못된역' } },
+      { date: 2, request: { identifier: 'tba:imminent:강남' } },
+    ]);
+    mockGetFiredAlarms.mockResolvedValueOnce(new Set());
+
+    const handle = registerScheduledAlarmListener();
+    await awaitInitialScheduledAlarmDrain();
+
+    expect(mockDismissNotification).toHaveBeenCalledTimes(1);
+    expect(mockDismissNotification).toHaveBeenCalledWith('tba:early:잘못된역');
+    expect(mockDismissNotification).not.toHaveBeenCalledWith('tba:imminent:강남');
+    handle.remove();
+  });
+
+  // 호출 순서: pending cancel 먼저, delivered dismiss 다음 — drain의 자기-목적 차단을 위해
+  // dismiss는 cancel 직후 실행되어 다음 FG 복귀까지 stale entry가 남지 않음을 보장.
+  it('F1 호출 순서: cancelScheduledNotificationAsync → dismissNotificationAsync', async () => {
+    const callOrder: string[] = [];
+    mockGetRegisteredTripRouteSig.mockResolvedValueOnce('SIG-OLD');
+    mockRouteSignature.mockReturnValueOnce('SIG-NEW');
+    mockCancelScheduled.mockImplementationOnce(async () => {
+      callOrder.push('cancel');
+    });
+    mockDismissNotification.mockImplementationOnce(async () => {
+      callOrder.push('dismiss');
+    });
+
+    await reconcileScheduledAlarmDelivery('tba:imminent:강남');
+
+    expect(callOrder).toEqual(['cancel', 'dismiss']);
+  });
+
+  // 멱등성 — 같은 identifier로 두 번 호출해도 reject 없이 통과 (OS dismiss는 idempotent).
+  it('F1 멱등성: 같은 identifier 두 번 호출해도 dismiss 두 번 안전 호출', async () => {
+    mockGetRegisteredTripRouteSig.mockResolvedValue('SIG-OLD');
+    mockRouteSignature.mockReturnValue('SIG-NEW');
+
+    await reconcileScheduledAlarmDelivery('tba:imminent:강남');
+    await reconcileScheduledAlarmDelivery('tba:imminent:강남');
+
+    expect(mockDismissNotification).toHaveBeenCalledTimes(2);
+    expect(mockDismissNotification).toHaveBeenCalledWith('tba:imminent:강남');
   });
 });

--- a/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/tripBoundScheduler.test.ts
@@ -65,6 +65,14 @@ const mockedGetAll = Notifications.getAllScheduledNotificationsAsync as jest.Moc
 const mockedCancel = Notifications.cancelScheduledNotificationAsync as jest.MockedFunction<
   typeof Notifications.cancelScheduledNotificationAsync
 >;
+// #1924 — cancelTripBoundAlarms가 delivered tray cleanup도 수행하므로 두 API mock 필요.
+// 기본은 빈 배열 / no-op resolve — 기존 테스트가 delivered tray entry 없음을 가정.
+const mockedGetPresented = Notifications.getPresentedNotificationsAsync as jest.MockedFunction<
+  typeof Notifications.getPresentedNotificationsAsync
+>;
+const mockedDismiss = Notifications.dismissNotificationAsync as jest.MockedFunction<
+  typeof Notifications.dismissNotificationAsync
+>;
 
 const NOW = new Date('2026-06-05T09:00:00Z').getTime();
 
@@ -387,6 +395,10 @@ describe('cancelTripBoundAlarms', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockLoggerInfo.mockClear();
+    // #1924 — delivered tray cleanup 기본은 entry 없음 + dismiss no-op (tray cleanup이
+    // 기존 cancel 동작 회귀 없게 보장).
+    mockedGetPresented.mockResolvedValue([]);
+    mockedDismiss.mockResolvedValue(undefined);
   });
 
   it('tba: prefix 알람만 취소하고 다른 prefix는 건드리지 않는다', async () => {
@@ -408,7 +420,7 @@ describe('cancelTripBoundAlarms', () => {
     expect(mockedCancel).not.toHaveBeenCalledWith('bl:T1:0:early:강남');
     expect(mockedCancel).not.toHaveBeenCalledWith('current-station');
     expect(mockLoggerInfo).toHaveBeenCalledWith(
-      expect.stringContaining('cancelled 2 trip-bound alarms'),
+      expect.stringContaining('cancelled 2 pending + dismissed 0 delivered trip-bound alarms'),
     );
   });
 
@@ -470,7 +482,7 @@ describe('cancelTripBoundAlarms', () => {
       // Fix 3 — reject된 id 재시도 후 success → cancelled 카운트 3건 모두 반영.
       expect(gangNamCallCount).toBe(2);
       expect(mockLoggerInfo).toHaveBeenCalledWith(
-        expect.stringContaining('cancelled 3 trip-bound alarms'),
+        expect.stringContaining('cancelled 3 pending + dismissed 0 delivered trip-bound alarms'),
       );
       // Fix 3 — pass-1 rejected 명시 로그.
       expect(mockLoggerWarn).toHaveBeenCalledWith(
@@ -504,7 +516,7 @@ describe('cancelTripBoundAlarms', () => {
       expect(gangnamCalls).toHaveLength(2);
       // fulfilled 1건만 카운트.
       expect(mockLoggerInfo).toHaveBeenCalledWith(
-        expect.stringContaining('cancelled 1 trip-bound alarms'),
+        expect.stringContaining('cancelled 1 pending + dismissed 0 delivered trip-bound alarms'),
       );
       // pass-1 + pass-2 warn 로그 둘 다 적재.
       expect(mockLoggerWarn).toHaveBeenCalledWith(
@@ -542,6 +554,163 @@ describe('cancelTripBoundAlarms', () => {
     } finally {
       mockedCancel.mockReset();
     }
+  });
+
+  // #1924 — delivered tray cleanup. pending queue cancel과 직교 채널이므로 함께 정리해야
+  // trip end 직후 stale entry가 다음 FG 복귀 drain에 또 read 되어 alarm log를 오염시키지 않는다.
+  describe('#1924 delivered tray cleanup', () => {
+    it('tba: prefix delivered notification만 dismiss하고 다른 prefix는 건드리지 않는다', async () => {
+      mockedGetAll.mockResolvedValue([]);
+      mockedGetPresented.mockResolvedValue([
+        { request: { identifier: 'tba:early:강남' } },
+        { request: { identifier: 'tba:imminent:서울역' } },
+        { request: { identifier: 'alarm:early:강남' } },
+        { request: { identifier: 'bl:T1:0:early:강남' } },
+        { request: { identifier: 'current-station' } },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any);
+
+      await cancelTripBoundAlarms();
+
+      expect(mockedDismiss).toHaveBeenCalledTimes(2);
+      expect(mockedDismiss).toHaveBeenCalledWith('tba:early:강남');
+      expect(mockedDismiss).toHaveBeenCalledWith('tba:imminent:서울역');
+      expect(mockedDismiss).not.toHaveBeenCalledWith('alarm:early:강남');
+      expect(mockedDismiss).not.toHaveBeenCalledWith('bl:T1:0:early:강남');
+      expect(mockedDismiss).not.toHaveBeenCalledWith('current-station');
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        expect.stringContaining('cancelled 0 pending + dismissed 2 delivered trip-bound alarms'),
+      );
+    });
+
+    it('pending + delivered 둘 다 있으면 둘 다 cleanup하고 합산 로그 발화', async () => {
+      mockedGetAll.mockResolvedValue([
+        { identifier: 'tba:early:강남' },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any);
+      mockedGetPresented.mockResolvedValue([
+        { request: { identifier: 'tba:imminent:서울역' } },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any);
+
+      await cancelTripBoundAlarms();
+
+      expect(mockedCancel).toHaveBeenCalledWith('tba:early:강남');
+      expect(mockedDismiss).toHaveBeenCalledWith('tba:imminent:서울역');
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        expect.stringContaining('cancelled 1 pending + dismissed 1 delivered trip-bound alarms'),
+      );
+    });
+
+    it('delivered tray가 비어 있으면 dismiss를 호출하지 않는다', async () => {
+      mockedGetAll.mockResolvedValue([]);
+      mockedGetPresented.mockResolvedValue([]);
+
+      await cancelTripBoundAlarms();
+
+      expect(mockedDismiss).not.toHaveBeenCalled();
+      // pending 0 + dismissed 0 → info 로그도 없음.
+      expect(mockLoggerInfo).not.toHaveBeenCalled();
+    });
+
+    it('per-identifier dismiss reject가 나머지 dismiss를 막지 않는다 (Promise.allSettled)', async () => {
+      mockedGetAll.mockResolvedValue([]);
+      mockedGetPresented.mockResolvedValue([
+        { request: { identifier: 'tba:early:A' } },
+        { request: { identifier: 'tba:early:B' } },
+        { request: { identifier: 'tba:early:C' } },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any);
+      // 첫 항목 reject, 나머지 fulfilled.
+      mockedDismiss
+        .mockRejectedValueOnce(new Error('OS busy'))
+        .mockResolvedValue(undefined);
+
+      await expect(cancelTripBoundAlarms()).resolves.toBeUndefined();
+
+      expect(mockedDismiss).toHaveBeenCalledTimes(3);
+      // 2건 success → dismissed 카운트 2.
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        expect.stringContaining('cancelled 0 pending + dismissed 2 delivered trip-bound alarms'),
+      );
+    });
+
+    // F3.1 — getPresentedNotificationsAsync 자체 실패 시 pending cancel은 보존하고 sig clear까지 진행.
+    it('F3.1 getPresentedNotificationsAsync가 throw해도 pending cancel + sig clear는 진행', async () => {
+      mockedGetAll.mockResolvedValue([
+        { identifier: 'tba:early:강남' },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any);
+      mockedGetPresented.mockRejectedValueOnce(new Error('OS unavailable'));
+      const removeSpy = jest.spyOn(AsyncStorage, 'removeItem');
+
+      await expect(cancelTripBoundAlarms()).resolves.toBeUndefined();
+
+      // pending cancel은 이미 완료 — 1건 발사됨.
+      expect(mockedCancel).toHaveBeenCalledWith('tba:early:강남');
+      // dismiss는 호출되지 않음 (조회 실패로 skip).
+      expect(mockedDismiss).not.toHaveBeenCalled();
+      // tray 조회 실패 warn 로그.
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining('delivered tray 조회 실패'),
+      );
+      // sig storage clear는 부분 진행 보존을 위해 항상 실행.
+      expect(removeSpy).toHaveBeenCalledWith(TRIP_BOUND_ROUTE_SIG_KEY);
+      // pending cancel 1건은 로그 발화.
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        expect.stringContaining('cancelled 1 pending + dismissed 0 delivered trip-bound alarms'),
+      );
+      removeSpy.mockRestore();
+    });
+
+    it('cancel 호출 순서: pending cancel 먼저 완료 후 delivered cleanup 진입', async () => {
+      const callOrder: string[] = [];
+      mockedGetAll.mockResolvedValue([
+        { identifier: 'tba:early:강남' },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any);
+      mockedCancel.mockImplementation(async () => {
+        callOrder.push('cancel');
+      });
+      mockedGetPresented.mockImplementation(async () => {
+        callOrder.push('getPresented');
+        return [
+          { request: { identifier: 'tba:early:서울역' } },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ] as any;
+      });
+      mockedDismiss.mockImplementation(async () => {
+        callOrder.push('dismiss');
+      });
+
+      try {
+        await cancelTripBoundAlarms();
+
+        // pending cancel이 delivered cleanup 진입 전에 완료되어야 한다.
+        expect(callOrder).toEqual(['cancel', 'getPresented', 'dismiss']);
+      } finally {
+        mockedCancel.mockReset();
+      }
+    });
+
+    // 멱등성 — 동일 입력으로 두 번 호출해도 같은 cleanup이 반복 가능 (no side-effect leak).
+    it('멱등성: 두 번 연속 호출해도 같은 결과 (cleanup 후 다시 호출)', async () => {
+      mockedGetAll.mockResolvedValue([
+        { identifier: 'tba:early:강남' },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any);
+      mockedGetPresented.mockResolvedValue([
+        { request: { identifier: 'tba:imminent:서울역' } },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any);
+
+      await cancelTripBoundAlarms();
+      await cancelTripBoundAlarms();
+
+      // 두 번 호출 = cancel + dismiss 각 2회.
+      expect(mockedCancel).toHaveBeenCalledTimes(2);
+      expect(mockedDismiss).toHaveBeenCalledTimes(2);
+    });
   });
 });
 

--- a/src/features/alarm/utils/scheduledAlarmReceiver.ts
+++ b/src/features/alarm/utils/scheduledAlarmReceiver.ts
@@ -402,6 +402,12 @@ export async function reconcileScheduledAlarmDelivery(
     // 발사되어 정적 misfire가 영구 재발한다. 사전 예약은 fire-and-forget이므로 명시 cancel 필요.
     // cancelScheduledNotificationAsync는 이미 발사된 항목에도 안전 (tripBoundScheduler.ts:681).
     await Notifications.cancelScheduledNotificationAsync(identifier);
+    // #1924 — delivered tray에서도 제거. cancelScheduledNotificationAsync는 pending queue
+    // (removePendingNotificationRequests) 만 대상이라 이미 OS가 자체 fire 한 항목은 delivered
+    // tray(removeDeliveredNotifications) 에 그대로 남는다. 사용자가 swipe-dismiss 하지 않는 한
+    // 다음 FG 복귀 drain 시 같은 identifier를 또 read → 같은 reason으로 다시 suppress →
+    // alarm log "revalidate-*" 무한 재적재 (2026-06-27 dump 56회 evidence).
+    await Notifications.dismissNotificationAsync(identifier);
     return;
   }
 
@@ -456,6 +462,11 @@ async function drainDeliveredScheduledAlarms(): Promise<void> {
       // #1354 — drain 경로도 reconcile과 동형으로 suppress 시 OS queue cancel. 같은 identifier를
       // OS가 보존하면 다음 ETA마다 재발사되어 영구 misfire 재발.
       await Notifications.cancelScheduledNotificationAsync(n.request.identifier);
+      // #1924 — drain은 직전 getPresentedNotificationsAsync로 delivered tray를 read한 항목을
+      // 처리한다. suppress 시 pending queue 만 cancel하면 같은 tray entry가 정리되지 않아 다음
+      // FG 복귀 drain 시 또 read → 같은 reason으로 또 suppress → alarm log 재적재
+      // (2026-06-27 14:03 trip end 후 14:04~15:48 사이 7 FG 복귀 × 8 entry = 56회 evidence).
+      await Notifications.dismissNotificationAsync(n.request.identifier);
       continue;
     }
     accepted.push(parsed);

--- a/src/features/alarm/utils/tripBoundScheduler.ts
+++ b/src/features/alarm/utils/tripBoundScheduler.ts
@@ -753,6 +753,13 @@ export async function rescheduleTripBoundAlarm(
  * 예약 알람을 OS 큐에서 제거한다. 다른 prefix(alarm:, bl:)는 건드리지 않는다.
  *
  * cancelScheduledNotificationAsync는 idempotent — 이미 발사된 알람도 안전하게 통과한다.
+ *
+ * #1924 — pending queue cancel 후 delivered tray(이미 fire 된 알람)도 함께 cleanup.
+ * cancelScheduledNotificationAsync(=removePendingNotificationRequests)는 pending queue만
+ * 대상이라 OS가 ETA 도달로 자체 fire 한 `tba:` 알람은 trip end 시점에도 delivered tray에 그대로
+ * 남는다. tray entry는 사용자가 직접 swipe-dismiss 하지 않는 한 영구 보존 → 다음 FG 복귀 시
+ * scheduledAlarmReceiver의 drain 경로가 stale entry를 또 read → suppress → 알람 로그 재적재
+ * 무한 루프 (2026-06-27 14:03 trip end 후 14:04~15:48 7 FG 복귀 × 8 entry = 56회 evidence).
  */
 export async function cancelTripBoundAlarms(): Promise<void> {
   const all = await Notifications.getAllScheduledNotificationsAsync();
@@ -770,8 +777,35 @@ export async function cancelTripBoundAlarms(): Promise<void> {
     targets.map((req) => req.identifier),
     'tba',
   );
-  if (cancelled > 0) {
-    logger.info(`cancelled ${cancelled} trip-bound alarms`);
+
+  // #1924 — delivered tray cleanup. getPresentedNotificationsAsync는 OS의 delivered
+  // notifications()를 조회 — pending queue와는 직교 채널이다. tray 조회 자체가 실패하면
+  // pending cancel은 이미 완료된 상태이므로 부분 진행을 보존하고 sig clear까지만 수행한다
+  // (drainDeliveredScheduledAlarms의 try/catch 패턴과 동형 — scheduledAlarmReceiver.ts:432).
+  let dismissedCount = 0;
+  try {
+    const presented = await Notifications.getPresentedNotificationsAsync();
+    const tbaDelivered = presented.filter((n) =>
+      n.request.identifier.startsWith(TRIP_BOUND_ALARM_PREFIX),
+    );
+    if (tbaDelivered.length > 0) {
+      // per-identifier reject가 나머지 dismiss를 막지 않도록 Promise.allSettled 사용
+      // (#1525 cancel 패턴과 동형).
+      const results = await Promise.allSettled(
+        tbaDelivered.map((n) => Notifications.dismissNotificationAsync(n.request.identifier)),
+      );
+      for (const r of results) {
+        if (r.status === 'fulfilled') dismissedCount++;
+      }
+    }
+  } catch (e) {
+    logger.warn(`cancelTripBoundAlarms: delivered tray 조회 실패, pending cancel만 적용: ${e}`);
+  }
+
+  if (cancelled > 0 || dismissedCount > 0) {
+    logger.info(
+      `cancelled ${cancelled} pending + dismissed ${dismissedCount} delivered trip-bound alarms`,
+    );
   }
   // #918 A3 PR2: sig storage도 함께 cleanup — 다음 reconcile 시 stale sig가 남지 않게.
   await clearRegisteredTripRouteSig();


### PR DESCRIPTION
## Summary

- **F1** `scheduledAlarmReceiver.reconcileScheduledAlarmDelivery` (line 404) suppress 분기에 `dismissNotificationAsync(identifier)` 추가
- **F2** `scheduledAlarmReceiver.drainDeliveredScheduledAlarms` (line 458) suppress 분기에 `dismissNotificationAsync(n.request.identifier)` 추가
- **F3** `tripBoundScheduler.cancelTripBoundAlarms` (line 757) — `getPresentedNotificationsAsync()` + `TRIP_BOUND_ALARM_PREFIX` filter + `Promise.allSettled` dismiss 추가
- **F3.1** `getPresentedNotificationsAsync` try/catch — 조회 실패해도 pending cancel + sig clear는 진행

## 회귀 evidence (2026-06-27 device dump)

- 14:03 trip end 후 14:04 ~ 15:48 사이 1 시간 40 분 동안 alarm log `revalidate-no-trip` **56 회** (= 7 회 FG 복귀 × 8 알림) 재처리
- `scheduledNotificationsDump = 0` (pending queue 깔끔) + drain 56 회 = 정확한 root cause = **delivered tray 잔존**

## Root cause

`cancelScheduledNotificationAsync` (= pending queue 제거) 와 `dismissNotificationAsync` (= delivered tray 제거) 는 iOS/Android OS API 상 **완전 직교**. pending cancel 은 delivered tray 에 silent no-op (Apple `UNUserNotificationCenter.removePendingNotificationRequests` 명시: "This method does not affect notifications that the system already delivered"). 두 cleanup API 를 모두 호출해야 한 알림이 OS 양쪽에서 사라진다. 기존 suppress 분기 + `cancelTripBoundAlarms` 는 pending 만 다루고 delivered tray 를 미정리 → 매 FG 복귀 시 같은 stale entry 가 다시 reconcile → 무한 재처리 + alarm log buffer 점령.

## V/X acceptance 매핑

| acceptance | 영향 | 현재 (regression) | F1+F2+F3 fix 후 |
|---|---|---|---|
| **X1** 잘못된 station 알람 0 건 | 보존 | 56 회 reconcile 이 alarm log 만 오염 (UI 미발사) | 0 회 |
| **X2** 중복 알람 0 건 | 보존 | OS suppress 가 사용자 UI 노출 차단, log 만 56 회 | 0 회 |
| **X5** 이전 trip 정보 오염 0 건 | **핵심** | 직전 trip 의 7 호선 8 entry 가 새 trip 진행 중 alarm log 오염 | tray cleanup 으로 차단 |
| **X9** 사용자 의도 외 fire 0 건 | 보존 | reconcile 56 회는 suppress 로 사용자 fire 없음, log 만 오염 | 0 회 |
| **X11** trip waypoint 변경 시 BG queue 잔존 0 건 | **핵심** | tray 잔존 = waypoint 변경 후에도 stale entry 7 회 reconcile 진입 | tray cleanup 후 0 |

## Wire-completion 5 단

1. **Orphan 없음** — `npm run lint:orphan` pass. `dismissNotificationAsync` / `getPresentedNotificationsAsync` 는 기존 `expo-notifications` import 로 사용. 신규 export 추가 없음.
2. **V/X dashboard** — DebugModal 의 `scheduledNotificationsDump` (pending) + `presentedNotificationsDump` (delivered) 두 section 이 이미 표시. trip end 후 둘 다 0 이어야 함.
3. **의존 PR** — N/A (D' 단독 fix).
4. **측정 plan** — 1 주 evidence. 사용자 trip end 후 1 시간 BG 유지 → FG 복귀 시 DebugModal alarm log 에서 `revalidate-no-trip` 발생 ≤ 1 회 확인 (현재 56 회 → 0 ~ 1, upper bound 1 회 허용 이유: cleanup 진행 중 새 fire race).
5. **Device verify** — 필수. tray API 는 Jest mock 으로 OS API 동작(delivered vs pending 격리) 시뮬레이션 불가. 시나리오: trip 등록 + tba: 사전 예약 발사 대기 → OS 가 ETA 도달로 자체 fire (BG 또는 lock screen) → 알림 swipe-dismiss **하지 않고** trip end → 1 시간 BG 유지 → FG 복귀 7 회 → DebugModal 의 alarm log 에서 `revalidate-no-trip` count 확인 → 0 또는 1.

## Test plan

- [x] F1 reconcile suppress → dismissNotificationAsync 호출 검증
- [x] F1 pass 경로 → dismiss 미호출 회귀 가드
- [x] F1 호출 순서: cancelScheduledNotificationAsync → dismissNotificationAsync
- [x] F1 멱등성: 동일 identifier 두 번 호출 시 dismiss 두 번 안전 호출
- [x] F2 drain suppress → 각 항목별 dismiss 호출
- [x] F2 drain pass → dismiss 미호출 회귀 가드
- [x] F2 drain — suppress + pass 혼합 시 suppress 만 dismiss
- [x] F3 tba: prefix 만 dismiss, 다른 prefix(alarm:/bl:/current-station) 보존
- [x] F3 pending + delivered 둘 다 있으면 둘 다 cleanup + 합산 로그 형식
- [x] F3 delivered tray 비었으면 dismiss 미호출 + info 로그 미발화
- [x] F3 Promise.allSettled — per-identifier dismiss reject 가 나머지 dismiss 차단 X
- [x] F3.1 getPresentedNotificationsAsync throw 시 pending cancel + sig clear 는 진행
- [x] F3 호출 순서: pending cancel 먼저 완료 후 delivered cleanup 진입
- [x] F3 멱등성: 두 번 연속 호출해도 같은 결과
- [x] 기존 `cancelled N trip-bound alarms` 로그 형식 변경 → `cancelled N pending + dismissed M delivered trip-bound alarms` (기존 #1525 / R1 / 4 건 이상 reject 테스트 동기화)
- [x] `npm test` (8363 tests) + `npm run type-check` + `npm run lint:orphan` + ESLint pass
- [ ] 실기기 1 주 evidence — `revalidate-no-trip` ≤ 1 회 (사용자)

Closes #1924