### PR TITLE
fix(#1921): boardingPromptContext lock 활성 시 lock.boardingLine 우선 — cross-trip stale stamp 차단

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -3525,6 +3525,57 @@ describe('runScheduled — boarding-prompt 9단 게이트 (#819)', () => {
       expect(stats.boardingPromptSkippedEmpty).toBe(0);
     });
 
+    // #1921 — F2 backend defense. boarding-prompt는 boarding 이전 게이트 — lock이 이미 활성/존재인
+    // trip은 cron 진입 자체가 의미 없음. lockMissing 분기로 진입한다면 race(예: lock 만료 직후) —
+    // counter로 측정 + return.
+    it('#1921 F2 — trip.boardingLock 존재 시 즉시 return + boardingPromptSkippedLockActive +1', async () => {
+      const kv = new InMemoryKV();
+      // expired boardingLock 부착 → isBoardingLockActive=false (lockMissing 분기 진입) 보장,
+      // 그러나 trip.boardingLock !== undefined이므로 F2 defense가 즉시 return.
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeUnlockedTrip({
+          boardingLock: {
+            trainCode: 'T-expired',
+            line: '2',
+            subwayId: '1002',
+            selectedDepartureTime: NOW - 60_000,
+            segmentStations: ['역삼', '강남'],
+            expiresAt: NOW - 1, // 만료
+          },
+        }),
+      );
+      await seedHappySeries(kv);
+      const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+      const deps = makeBoardingPromptDeps(fetchImpl, makeSeoul([LINE_2_UP_ARRIVAL]));
+
+      const stats = await runScheduled(makeEnv(kv), deps);
+
+      // F2 defense — 즉시 return → evaluated/fired/blocked/skippedEmpty 모두 0.
+      expect(stats.boardingPromptEvaluated).toBe(0);
+      expect(stats.boardingPromptFired).toBe(0);
+      expect(stats.boardingPromptBlocked).toBe(0);
+      expect(stats.boardingPromptSkippedEmpty).toBe(0);
+      // F2 counter +1.
+      expect(stats.boardingPromptSkippedLockActive).toBe(1);
+      // APNs fetch X.
+      expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+    });
+
+    it('#1921 F2 — trip.boardingLock 없으면 F2 defense 미발동, 정상 fire 경로 진행', async () => {
+      // 정상 unlocked trip — F2 counter 0, 기존 fire 경로 그대로.
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());
+      await seedHappySeries(kv);
+      const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+      const deps = makeBoardingPromptDeps(fetchImpl, makeSeoul([LINE_2_UP_ARRIVAL]));
+
+      const stats = await runScheduled(makeEnv(kv), deps);
+
+      expect(stats.boardingPromptSkippedLockActive).toBe(0);
+      expect(stats.boardingPromptFired).toBe(1);
+    });
+
     it('candidateTrains payload wire — sorted by arrivalSeconds asc + max 5건', async () => {
       const kv = new InMemoryKV();
       await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());
@@ -6993,7 +7044,7 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
       boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
       phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
       autoLockSuccess: 0, autoLockFalsePositive: 0, boardingPromptAutoDeduped: 0,
-      boardingPromptSkippedEmpty: 0,
+      boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0,
       arvlCdFireSuccess: 0, arvlCdFireDedup: 0, arvlCdFireMismatch: 0,
       arvlCdFireBlocked: 0, arvlCdFireFired: 0,
       boardingLockWaypointAdvanceBlocked: 0, transferDestinationGateBlocked: 0,

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -514,6 +514,13 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   boardingPromptSkippedEmpty: number;
   /**
+   * #1921 — boarding-prompt는 boarding 이전 게이트(사용자 인지 요구 → lock 생성). lock이 이미
+   * 활성인 trip은 이미 탑승 확정 상태이므로 cron이 진입 자체가 의미 없다. 진입 시 즉시 return
+   * + counter +1 — F1(frontend stamp 정확화)이 완전히 wire되면 0에 수렴. 0이 아니면 frontend KV
+   * `boardingLock` 갱신 race 또는 lockMissing→lock 부착 transient cycle 잔재.
+   */
+  boardingPromptSkippedLockActive: number;
+  /**
    * #917 A2 — boardingLock 활성 trip에서 Seoul arrivals의 arvlCd∈{0(ENTERING), 1(ARRIVED)}
    * 신호로 매역 station-passed silent push가 성공 발사된 누적 횟수. 매역 알림 1차 source는
    * GPS가 아니라 이 신호 — 다운로드 가치 직결(지하/지상 무관).
@@ -813,6 +820,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     autoLockFalsePositive: 0,
     boardingPromptAutoDeduped: 0,
     boardingPromptSkippedEmpty: 0,
+    boardingPromptSkippedLockActive: 0,
     arvlCdFireSuccess: 0,
     arvlCdFireDedup: 0,
     arvlCdFireMismatch: 0,
@@ -3368,6 +3376,20 @@ export async function evaluateAndMaybeFireBoardingPrompt(
   log: Logger,
   generatePushId: () => string,
 ): Promise<void> {
+  // #1921 — F2 defense. boarding-prompt는 boarding 이전 게이트 — lock이 이미 활성인 trip은
+  // cron 진입 자체가 의미 없음. 호출 시점에서 lockMissing 분기를 통과했다는 사실은
+  // `isBoardingLockActive(trip, now) === false`라는 invariant이므로 정상 케이스에서 본 분기는
+  // 발동되지 않는다. lock-active trip이 lockMissing 분기로 진입한다면 race(예: lock 만료 직후
+  // 같은 cycle) 또는 isBoardingLockActive 판정 변경 — counter로 측정해 회귀 진단.
+  if (trip.boardingLock !== undefined) {
+    stats.boardingPromptSkippedLockActive += 1;
+    log('boarding-prompt: skip (lock active, F2 defense)', {
+      token: trip.token.slice(0, 8),
+      boardingLine: trip.boardingLock.line,
+    });
+    return;
+  }
+
   const geo = trip.promptGeoContext;
   const display = trip.promptDisplay;
   if (!geo || !display) return;

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -163,10 +163,14 @@ async function callRegister(input: RegisterCallInputs) {
   // #1028 / #1284: boarding-prompt 평가 컨텍스트 (#819). 둘 다 있어야 backend가 9단 게이트를
   // 돌리므로 항상 함께 송신. currentStation이 BG GPS 누락으로 일시 null이면 캐시된 컨텍스트를
   // fallback으로 사용 — backend cron 진입 전 최소 한 번은 컨텍스트가 stamped되도록 보장.
+  //
+  // #1921 — lock 활성 시 lock.boardingLine + currentStation 우선 stamp. cross-trip 자동 전환에서
+  // route 원본 line이 현재 leg와 어긋나도 stale stamp 회귀 차단.
   const freshContext = buildBoardingPromptContext({
     route: input.route,
     currentStation: input.currentStation,
     destination: input.destination,
+    lock: input.boardingLock,
   });
   const promptContext = freshContext ?? input.cachedPromptContext;
 
@@ -388,7 +392,8 @@ export function useApnsTripRegistration({
       const sessionKey = `${token}:${routeSig}:${destination.id}`;
       // #1284 — buildBoardingPromptContext가 성공하면 캐시 갱신. 이후 currentStation이
       // 일시 null이 돼도 cachedPromptContext로 fallback하여 backend 9단 게이트가 계속 진입 가능.
-      const freshCtx = buildBoardingPromptContext({ route, currentStation, destination });
+      // #1921 — lock 동봉. cross-trip 자동 전환 시 stale stamp 차단(callRegister 분기와 동일 입력).
+      const freshCtx = buildBoardingPromptContext({ route, currentStation, destination, lock: boardingLock });
       if (freshCtx) lastPromptContextRef.current = freshCtx;
       // R11-a (#1612): trip register 직전 backend SSoT mirror 강제 clean.
       // 스펙 docs/requirements/15-trip-alarm-notification.md:89 명시 요구사항 — "trip 등록(new)

--- a/src/features/alarm/utils/__tests__/boardingPromptContext.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingPromptContext.test.ts
@@ -5,7 +5,21 @@ import {
   makeTransferRoute,
 } from '../../../../testUtils/routeFixtures';
 import { getStationById } from '../../../../shared/utils/stationRoute';
+import { canonicalStationName } from '../../../../testUtils/canonicalStationName';
 import type { Station } from '../../../../shared/types/station';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+
+function makeLock(overrides: Partial<BoardingLock>): BoardingLock {
+  return {
+    destinationId: '2-022',
+    trainCode: '7246',
+    boardingStationId: '2-022',
+    boardingLine: '2',
+    boardedAt: 1_700_000_000_000,
+    expectedDurationMs: 600_000,
+    ...overrides,
+  };
+}
 
 function st(id: string): Station {
   const s = getStationById(id);
@@ -194,6 +208,217 @@ describe('buildBoardingPromptContext', () => {
       expect(ctx?.promptDisplay.line).toBe('3');
       const next = st('3-002');
       expect(ctx?.promptGeoContext.nextStation).toEqual({ lat: next.lat, lng: next.lng });
+    });
+  });
+
+  // #1921 — lock 활성 분기. cross-trip 자동 전환 시 route 원본 line이 현재 leg와 어긋나도
+  // lock.boardingLine 기준으로 정확한 stamp를 빌드해 stale lastPromptContextRef fallback을 차단.
+  describe('#1921 lock 활성 분기', () => {
+    it('lock 활성 + lock.boardingLine === route.firstLeg.line → 기존 path와 동등 stamp 결과 (보존)', () => {
+      const current = st('3-001'); // 대화
+      const dest = st('3-003'); // 정발산
+      const lock = makeLock({
+        destinationId: dest.id,
+        boardingStationId: current.id,
+        boardingLine: '3',
+      });
+      const ctx = buildBoardingPromptContext({
+        route: makeDirectRoute(2, '3'),
+        currentStation: current,
+        destination: dest,
+        lock,
+      });
+      expect(ctx).not.toBeNull();
+      expect(ctx?.promptDisplay.line).toBe('3');
+      expect(ctx?.promptDisplay.originStation).toBe('대화');
+      const next = st('3-002');
+      expect(ctx?.promptGeoContext.nextStation).toEqual({ lat: next.lat, lng: next.lng });
+      expect(ctx?.promptGeoContext.direction).toBe('down');
+    });
+
+    it('cross-trip 자동 전환: route 원본 line=3 multi-transfer, lock.boardingLine=2, currentStation=line2 → lock line으로 stamp', () => {
+      // route: 3호선 대화 → ... → 교대 (transfer) → 2호선 강남. 사용자가 교대 환승 후 lock=2 leg로 진입.
+      // currentStation: 서초(2-024)에서 교대(2-023)로 통과 후 다음 역(강남=2-022)이 next-station 예상.
+      const current = st('2-024'); // 서초 (line 2)
+      const dest = st('2-022'); // 강남 (line 2)
+      const lock = makeLock({
+        destinationId: dest.id,
+        boardingStationId: current.id,
+        boardingLine: '2',
+      });
+      const ctx = buildBoardingPromptContext({
+        route: makeMultiTransferRoute({
+          transfers: [
+            // 첫 leg: 3호선 firstLeg(line=3). lock이 line=2이라 기존 path는 line=3 기준으로 동작.
+            { transferName: canonicalStationName('교대', '3'), fromLine: '3', toLine: '2', stopsToTransfer: 31 },
+            { transferName: '강남', fromLine: '2', toLine: 'sinbundang', stopsToTransfer: 1 },
+          ],
+          stopsAfterLastTransfer: 0,
+        }),
+        currentStation: current,
+        destination: dest,
+        lock,
+      });
+      expect(ctx).not.toBeNull();
+      // lock.boardingLine=2 우선 stamp. 기존 path가 line='3'을 stamp하던 회귀 차단.
+      expect(ctx?.promptDisplay.line).toBe('2');
+      expect(ctx?.promptDisplay.originStation).toBe('서초');
+      // 서초(2-024) → 강남(2-022) 방향 다음 역은 교대(2-023).
+      const next = st('2-023');
+      expect(ctx?.promptGeoContext.nextStation).toEqual({ lat: next.lat, lng: next.lng });
+    });
+
+    it('lock 활성 + currentStation이 lock.boardingLine 위에 없음 → null (라인 일관성 깨짐)', () => {
+      const current = st('3-001'); // 대화 (line 3)
+      const dest = st('2-022'); // 강남
+      const lock = makeLock({
+        destinationId: dest.id,
+        boardingStationId: '2-024',
+        boardingLine: '2', // 사용자는 line 2에 lock 했는데 현재는 line 3 station — 비정상 상태
+      });
+      const ctx = buildBoardingPromptContext({
+        route: makeMultiTransferRoute({
+          transfers: [
+            { transferName: '교대', fromLine: '3', toLine: '2', stopsToTransfer: 31 },
+            { transferName: '강남', fromLine: '2', toLine: 'sinbundang', stopsToTransfer: 1 },
+          ],
+          stopsAfterLastTransfer: 0,
+        }),
+        currentStation: current,
+        destination: dest,
+        lock,
+      });
+      // lock.boardingLine=2 위에 "대화"가 없음 → next-station lookup fail → null
+      expect(ctx).toBeNull();
+    });
+
+    it('lock 활성 + lock.boardingLine이 TransferRoute segment 어느 것에도 일치 안 함 → null', () => {
+      const current = st('3-001'); // 대화 (line 3)
+      const dest = st('2-022'); // 강남
+      const lock = makeLock({
+        destinationId: dest.id,
+        boardingStationId: current.id,
+        boardingLine: '5' as const, // route fromLine=3, toLine=2인데 lock은 line=5
+      });
+      const ctx = buildBoardingPromptContext({
+        route: makeTransferRoute({
+          transferName: canonicalStationName('교대', '3'),
+          fromLine: '3',
+          toLine: '2',
+          stopsToTransfer: 31,
+          stopsFromTransfer: 2,
+        }),
+        currentStation: current,
+        destination: dest,
+        lock,
+      });
+      // findSegmentEndStationName이 line=5를 매칭 못 함 → segmentEndName=null → ctx=null
+      expect(ctx).toBeNull();
+    });
+
+    it('lock 활성 + lock.boardingLine이 MultiTransferRoute segment 어느 것에도 일치 안 함 → null', () => {
+      const current = st('3-001');
+      const dest = st('2-022');
+      const lock = makeLock({
+        destinationId: dest.id,
+        boardingStationId: current.id,
+        boardingLine: '5' as const,
+      });
+      const ctx = buildBoardingPromptContext({
+        route: makeMultiTransferRoute({
+          transfers: [
+            { transferName: canonicalStationName('교대', '3'), fromLine: '3', toLine: '2', stopsToTransfer: 31 },
+            { transferName: '강남', fromLine: '2', toLine: 'sinbundang', stopsToTransfer: 1 },
+          ],
+          stopsAfterLastTransfer: 0,
+        }),
+        currentStation: current,
+        destination: dest,
+        lock,
+      });
+      // multi-transfer 어느 segment에도 line=5 없음 → null
+      expect(ctx).toBeNull();
+    });
+
+    it('lock 활성 + currentStation === segmentEnd → null (이미 leg 끝 도달)', () => {
+      const current = st('3-003'); // 정발산 = destination
+      const dest = st('3-003'); // 정발산
+      const lock = makeLock({
+        destinationId: dest.id,
+        boardingStationId: current.id,
+        boardingLine: '3',
+      });
+      const ctx = buildBoardingPromptContext({
+        route: makeDirectRoute(0, '3'),
+        currentStation: current,
+        destination: dest,
+        lock,
+      });
+      // current === segmentEnd → getNextStationOnLine returns null → context null
+      expect(ctx).toBeNull();
+    });
+
+    it('lock null이면 기존 getFirstLeg path 호출 (회귀 방지)', () => {
+      const current = st('3-001');
+      const dest = st('3-003');
+      const ctx = buildBoardingPromptContext({
+        route: makeDirectRoute(2, '3'),
+        currentStation: current,
+        destination: dest,
+        lock: null,
+      });
+      // lock null이면 기존 path와 동등
+      expect(ctx).not.toBeNull();
+      expect(ctx?.promptDisplay.line).toBe('3');
+      expect(ctx?.promptDisplay.originStation).toBe('대화');
+    });
+
+    it('lock 활성 + TransferRoute boardingLine === toLine → destination을 segmentEnd로 사용', () => {
+      // route: 3호선 대화 → 교대(transfer) → 2호선 강남(destination)
+      // lock은 toLine=2 leg에 진입한 상태 (교대 환승 후, 사용자는 서초까지 진행)
+      const current = st('2-024'); // 서초 (line 2)
+      const dest = st('2-022'); // 강남 (line 2)
+      const lock = makeLock({
+        destinationId: dest.id,
+        boardingStationId: current.id,
+        boardingLine: '2',
+      });
+      const ctx = buildBoardingPromptContext({
+        route: makeTransferRoute({
+          transferName: canonicalStationName('교대', '3'),
+          fromLine: '3',
+          toLine: '2',
+          stopsToTransfer: 31,
+          stopsFromTransfer: 2,
+        }),
+        currentStation: current,
+        destination: dest,
+        lock,
+      });
+      expect(ctx).not.toBeNull();
+      expect(ctx?.promptDisplay.line).toBe('2');
+      expect(ctx?.promptDisplay.originStation).toBe('서초');
+    });
+
+    it('lock 활성 + 순환선(2호선) → inferLoopDirection fallback이 direction 채움', () => {
+      // 시청(2-001) → 을지로3가(2-003) 구간에 lock. 순환선이라 resolveTravelDirection null이지만
+      // inferLoopDirection이 down(외선순환)을 채워야 함.
+      const current = st('2-001');
+      const dest = st('2-003');
+      const lock = makeLock({
+        destinationId: dest.id,
+        boardingStationId: current.id,
+        boardingLine: '2',
+      });
+      const ctx = buildBoardingPromptContext({
+        route: makeDirectRoute(2, '2'),
+        currentStation: current,
+        destination: dest,
+        lock,
+      });
+      expect(ctx).not.toBeNull();
+      expect(ctx?.promptGeoContext.direction).toBe('down');
+      expect(ctx?.promptDisplay.line).toBe('2');
     });
   });
 });

--- a/src/features/alarm/utils/boardingPromptContext.ts
+++ b/src/features/alarm/utils/boardingPromptContext.ts
@@ -28,15 +28,18 @@
  * `currentStation === null`이거나 next/lookup 실패 시 null 반환 — backend는 자동 skip.
  */
 
+import type { BoardingLock } from '../../../shared/types/boardingLock';
 import type { Station } from '../../../shared/types/station';
 import type { Route } from '../../../shared/utils/stationRoute';
 import {
   findStationByNameAndLine,
   getFirstLeg,
   getNextStationName,
+  getNextStationOnLine,
 } from '../../../shared/utils/stationRoute';
 import { resolveTravelDirection } from '../../route/utils/travelDirection';
 import { inferLoopDirection } from '../../route/utils/loopDirection';
+import { findSegmentEndStationName } from './buildBoardingLockMeta';
 
 export interface BoardingPromptContext {
   promptGeoContext: {
@@ -54,15 +57,36 @@ interface BuildInputs {
   route: Route;
   currentStation: Station | null;
   destination: Station | null;
+  /**
+   * #1921 — 활성 BoardingLock이 있으면 lock.boardingLine + currentStation 기준으로 컨텍스트를 빌드.
+   *
+   * cross-trip 자동 전환 시 route는 RC-11 #1883 freeze 정책에 따라 원본 trip의 line을 유지하지만
+   * (예: 7호선 용마산→…→강변→2호선 잠실 multi-transfer) lock은 현재 진행 중인 leg의 line(2)을
+   * 가리킨다. 기존 `getFirstLeg(route, destination.name)` 경로는 route 원본 line(7)을 따라가서
+   * currentStation(2-012 강변)이 7호선에 없으면 nextName=null로 빠지고, 호출자(useApnsTripRegistration)
+   * 가 stale lastPromptContextRef로 fallback → backend KV가 옛 line/originStation으로 영원히 고정.
+   *
+   * lock이 있으면 line의 모호함이 사라지므로 우선 분기 — lock metadata는 별 wire(buildBoardingLockMeta)가
+   * 담당하고 본 컨텍스트는 prompt 전용 stamp만 갱신한다.
+   */
+  lock?: BoardingLock | null;
 }
 
 export function buildBoardingPromptContext({
   route,
   currentStation,
   destination,
+  lock,
 }: BuildInputs): BoardingPromptContext | null {
   if (!route || !currentStation || !destination) return null;
 
+  // #1921 — lock 활성 분기. route 원본 line이 lock leg와 어긋난 cross-trip 자동 전환에서
+  // currentStation 기준으로 lock.boardingLine 위의 다음 역 좌표 + direction을 stamp.
+  if (lock != null) {
+    return buildLockActiveContext({ route, currentStation, destination, lock });
+  }
+
+  // lock 미활성 — 기존 first-leg 기반 path 보존.
   const leg = getFirstLeg(route, destination.name);
   const nextName = getNextStationName(currentStation.id, destination.id, route);
   if (!nextName) return null;
@@ -87,6 +111,54 @@ export function buildBoardingPromptContext({
     promptDisplay: {
       originStation: currentStation.name,
       line: leg.line,
+    },
+  };
+}
+
+/**
+ * #1921 — lock 활성 분기. lock.boardingLine + currentStation을 기준 좌표로 사용해
+ * route의 어느 segment가 lock leg인지 찾고 그 segment의 끝 역(다음 환승역 or 최종 도착역)을
+ * direction 산출 anchor로 쓴다.
+ *
+ * 실패 조건 (모두 null 반환 — backend는 자동 skip):
+ *   - lock.boardingLine이 route segment 어느 것에도 일치 안 함 (비정상 schema)
+ *   - currentStation이 lock.boardingLine 위에 없음 (라인 일관성 깨짐)
+ *   - currentStation === segmentEnd (이미 leg 끝 도달 — 본 cycle은 prompt 대상 아님)
+ */
+function buildLockActiveContext({
+  route,
+  currentStation,
+  destination,
+  lock,
+}: {
+  route: NonNullable<Route>;
+  currentStation: Station;
+  destination: Station;
+  lock: BoardingLock;
+}): BoardingPromptContext | null {
+  const segmentEndName = findSegmentEndStationName(route, lock.boardingLine, destination.name);
+  if (segmentEndName == null) return null;
+
+  const nextName = getNextStationOnLine(lock.boardingLine, currentStation.name, segmentEndName);
+  if (nextName == null) return null;
+
+  const nextStation = findStationByNameAndLine(nextName, lock.boardingLine);
+  /* istanbul ignore next -- getNextStationOnLine이 lock.boardingLine 위에서 찾은 name이므로 재조회 실패 불가 */
+  if (nextStation == null) return null;
+
+  const direction =
+    resolveTravelDirection(lock.boardingLine, currentStation.name, segmentEndName)?.direction ??
+    inferLoopDirection(lock.boardingLine, currentStation.name, segmentEndName);
+
+  return {
+    promptGeoContext: {
+      origin: { lat: currentStation.lat, lng: currentStation.lng },
+      nextStation: { lat: nextStation.lat, lng: nextStation.lng },
+      direction,
+    },
+    promptDisplay: {
+      originStation: currentStation.name,
+      line: lock.boardingLine,
     },
   };
 }

--- a/src/shared/utils/stationRoute.ts
+++ b/src/shared/utils/stationRoute.ts
@@ -1140,7 +1140,7 @@ export function calculateETA(nextTrainMinutes: number, route: Route): number {
   return nextTrainMinutes + getTravelMinutes(route) + transferWait;
 }
 
-function getNextStationOnLine(
+export function getNextStationOnLine(
   line: LineNumber,
   currentName: string,
   targetName: string,


### PR DESCRIPTION
## Summary

`useApnsTripRegistration`이 cross-trip 자동 전환 시 `buildBoardingPromptContext`가 null 반환 → 직전 trip의 stale `lastPromptContextRef`로 fallback → backend KV가 옛 노선/역 stamp로 영원히 고정되어 `boarding-prompt: skipped empty candidates (#1888 RC-13)` 무한 반복 + boardingPrompt UI 0건 발사 회귀 차단.

**N=4/5 evidence** (6/26 T1·T3·T4 + 6/27 T1, T4는 `cold-start-mismatch | 2-003 | exp=line-mismatch` 결정적 로그). 

### F1 (frontend, 필수)

- `boardingPromptContext.ts`: `BuildInputs`에 `lock?: BoardingLock | null` 추가. `lock != null`이면 `lock.boardingLine` + `currentStation` 기준으로 segmentEnd / next station / direction을 산출 → `promptDisplay.line = lock.boardingLine` + `promptDisplay.originStation = currentStation.name` stamp.
- `findSegmentEndStationName` (`buildBoardingLockMeta.ts:23~41`) 재사용. `getNextStationOnLine` (`stationRoute.ts:1143`)을 internal → public export로 변경하여 caller 1건 추가.
- `useApnsTripRegistration.ts` callRegister + main effect 캐시 갱신 양쪽 site에서 `lock: input.boardingLock` / `lock: boardingLock` 동봉.

### F2 (backend defense)

- `evaluateAndMaybeFireBoardingPrompt` 진입부에 `if (trip.boardingLock !== undefined) { stats.boardingPromptSkippedLockActive += 1; return; }` — boarding-prompt는 boarding 이전 게이트이므로 lock 활성 trip cron 진입 자체 무의미. F1이 정상화되면 0에 수렴.
- 신규 `ScheduledStats.boardingPromptSkippedLockActive` counter + DebugModal/Sentry 노출 가능.

## Cross-impact 검증 (4 패턴 보존)

| 영향 | 검증 |
|---|---|
| RC-11 #1883 freeze | route mutation 없음. `boardingPromptContext`는 route 읽기 전용 소비. |
| PR #1918 RC-2 trip-scoped dedup | backend KV `trip.lastBoardingPromptAt` 키 영향 X (payload 정확화 + 진입 skip만). |
| silent push trip-ended | `setDestination(null)` → `route=null` → 기존 `if (!route) return null` 즉시 빠짐. F1 분기 미진입. |
| setDestination switch (ref reset) | `useApnsTripRegistration:353` `lastPromptContextRef.current = null` 그대로. F1은 ref 무관. |
| lock null 정상 trip | `if (lock != null)` 미진입 → 기존 `getFirstLeg(route, destination.name)` 보존. |

## Wire-completion 5단

### 1) Orphan 없음

- `getNextStationOnLine` export 추가 → caller 1건 (`boardingPromptContext.ts`).
- `findSegmentEndStationName` import (이미 buildBoardingLockMeta에 존재) → caller 1건 추가.
- `npm run lint:orphan` pass 확인.

### 2) V/X dashboard

- **wrangler tail**: `boarding-prompt: skip (lock active, F2 defense)` log 카운트 — 0건이 정상 (F1 effective).
- **wrangler tail**: `boarding-prompt: skipped empty candidates (#1888 RC-13)` + `line=7+lock=line2` 패턴 0건 = F1 effective.
- **Sentry**: `ScheduledStats.boardingPromptSkippedLockActive` Cloudflare Analytics 또는 future Sentry stat forward.

### 3) 의존 PR

N/A — frontend + backend single PR로 일괄.

### 4) 측정 plan

- **기간**: PR 머지 후 1주.
- **시나리오**: cross-trip 환승 trip 1회 이상 실기기 trip (7호선 → 2호선 환승) — `boardingPromptFired >= 1` + `boarding-prompt: skipped empty candidates` log 0건.
- **dashboard**: `boardingPromptSkippedLockActive` 추이 (F2 동작 확인).
- **회귀 신호**: `promptDisplay.line ≠ boardingLock.boardingLine` 1주 1건이라도 발생 시 사용자 trip 캡처 → re-open.

### 5) Device verify

- **필요**. 실기기 cross-trip 환승 trip 1회 boardingPrompt UI banner 캡처 (BG GPS + arvlcd timing 필요 — 시뮬레이터 재현 불가).

## Test plan

### Unit / Integration

- [x] `boardingPromptContext.test.ts` 7 신규 케이스:
  - lock + boardingLine === route.firstLeg.line → 기존 path 동등 (보존)
  - cross-trip 자동 전환 (lock=line2, route 원본=line3 multi-transfer) → lock line stamp
  - currentStation이 lock.boardingLine 위 없음 → null (라인 일관성 깨짐)
  - lock.boardingLine이 TransferRoute segment 어느 것에도 일치 X → null
  - lock.boardingLine이 MultiTransferRoute segment 어느 것에도 일치 X → null
  - lock + TransferRoute boardingLine === toLine → destination을 segmentEnd로
  - lock + 순환선(2호선) → inferLoopDirection fallback direction 채움
  - currentStation === segmentEnd → null (이미 leg 끝 도달)
  - lock null → 기존 path 회귀 방지
- [x] `scheduled.test.ts` 2 F2 케이스:
  - boardingLock 존재 시 즉시 return + `boardingPromptSkippedLockActive` +1 + APNs fetch X
  - boardingLock 없으면 F2 미발동 + 정상 fire 경로
- [x] 기존 80 `useApnsTripRegistration` + 14 `boardingPromptContext` + 10 boarding-prompt scheduled 테스트 그대로 통과 (총 frontend 8358, backend 2267).

### Verify

- [x] `npm test` 100% coverage (lines / branches / functions / statements).
- [x] `npm run type-check` clean.
- [x] backend `npx vitest run` 2267/2267 통과.
- [x] backend `npm run type-check` clean.
- [x] `npm run lint:orphan` pass.
- [ ] 사용자 실기기 cross-trip 환승 trip 1회 검증 (머지 후 1주 evidence).

Closes #1921