### PR TITLE
feat(#1923): infoModeEnabled wire 신규 — RegisterTripPayload + device store + backend SSoT cascade 정상화

### DIFF
--- a/src/features/alarm/api/__tests__/alarmBackend.test.ts
+++ b/src/features/alarm/api/__tests__/alarmBackend.test.ts
@@ -260,6 +260,36 @@ describe('alarmBackend', () => {
         expect(global.fetch).toHaveBeenCalledTimes(1);
       });
 
+      // #1923 — 사용자 명시 의향 토글 (infoModeEnabled) 송신/dedup
+      it('#1923 infoModeEnabled=true 송신 시 body에 포함', async () => {
+        await registerActiveTrip({ ...SAMPLE_PAYLOAD, infoModeEnabled: true });
+        const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+        expect(body.infoModeEnabled).toBe(true);
+      });
+
+      it('#1923 infoModeEnabled=false/미설정이면 body에 미포함 (graceful, backend false default)', async () => {
+        await registerActiveTrip({ ...SAMPLE_PAYLOAD, infoModeEnabled: false });
+        const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+        expect(body.infoModeEnabled).toBeUndefined();
+      });
+
+      it('#1923 infoModeEnabled OFF→ON 전환 시 hash 갱신 → 재등록 (의향 표명 직후 backend gate 즉시 활성화)', async () => {
+        const first = await registerActiveTrip({ ...SAMPLE_PAYLOAD, infoModeEnabled: false });
+        expect(first.ok).toBe(true);
+        const second = await registerActiveTrip({ ...SAMPLE_PAYLOAD, infoModeEnabled: true });
+        expect(second).toEqual({ ok: true, status: 200 });
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        const secondBody = JSON.parse((global.fetch as jest.Mock).mock.calls[1][1].body);
+        expect(secondBody.infoModeEnabled).toBe(true);
+      });
+
+      it('#1923 동일 infoModeEnabled 값 연속 호출 시 dedup (skipped=true)', async () => {
+        await registerActiveTrip({ ...SAMPLE_PAYLOAD, infoModeEnabled: true });
+        const dedup = await registerActiveTrip({ ...SAMPLE_PAYLOAD, infoModeEnabled: true });
+        expect(dedup).toEqual({ ok: true, skipped: true });
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+      });
+
       it('#701 in-flight dedup: 동일 페이로드 동시 호출 시 fetch는 1번만 발사된다', async () => {
         let resolveFetch: ((v: Response) => void) | null = null;
         (global.fetch as jest.Mock).mockImplementationOnce(

--- a/src/features/alarm/api/alarmBackend.ts
+++ b/src/features/alarm/api/alarmBackend.ts
@@ -112,6 +112,21 @@ export interface RegisterTripPayload {
    * backend가 ko로 fallback (한국 운영 기본). 디바이스 i18next.language 값을 그대로 송신.
    */
   locale?: 'ko' | 'en' | 'ja' | 'zh';
+  /**
+   * #1923 — 사용자 명시 의향 trip의 lockless intermediate station-passed
+   * silent push 발사 허용 토글. ADR-014 §X "사용자 명시 의향 trip = lock 활성과
+   * 동급 정확도 보장 의무" 정합. 사용자가 [C 토글 ON / boardingPrompt 응답 /
+   * BoardingTrainList 직접 탭] 중 하나라도 행하면 device SSoT(`useUserIntentStore`)가
+   * true로 stamp되며 본 필드를 통해 backend로 forward된다.
+   *
+   * backend 분기: `trip.infoModeEnabled && waypoint.kind === 'intermediate'`
+   *   → runLocklessIntermediate 진입 → station-passed silent push 발사
+   * (backend/alarm-worker/src/scheduled.ts:980)
+   *
+   * 미설정/false: 기존 동작 그대로 — boardingLock 부재 시 `lockMissing` skip.
+   * backend는 미송신 시 graceful undefined → false 처리 (backward-compat).
+   */
+  infoModeEnabled?: boolean;
 }
 
 export interface AlarmBackendResult {
@@ -173,6 +188,7 @@ function buildRegisterHash(body: {
   promptDisplay?: { originStation: string; line: string };
   subsurface?: boolean;
   locale?: 'ko' | 'en' | 'ja' | 'zh';
+  infoModeEnabled?: boolean;
 }): string {
   return JSON.stringify({
     token: body.token,
@@ -198,6 +214,10 @@ function buildRegisterHash(body: {
     // #1895 — locale 전환 (사용자가 device 언어 변경 후 재등록) 시 즉시 backend로 propagate되도록 hash에 포함.
     // 같은 trip 중 locale 변경 빈도는 낮으므로 폭주 위험 없음.
     locale: body.locale ?? null,
+    // #1923 — infoModeEnabled 토글 ON ↔ OFF 전환 시 즉시 재등록 보장 + dedup 폭주 차단.
+    // 사용자가 의향 표명 직후 backend lockless intermediate gate가 즉시 활성화되어야 다음
+    // cron cycle부터 station-passed silent push 발사가 가능. 같은 값 연속 호출은 hash 동일 → skip.
+    infoModeEnabled: body.infoModeEnabled === true,
   });
 }
 
@@ -264,6 +284,9 @@ async function performRegisterFetch(
     // #1895 — device locale. 송신 시 backend가 boarding-prompt 본문을 4언어 분기 (ko/en/ja/zh).
     // 미송신 시 backend는 ko fallback.
     ...(payload.locale ? { locale: payload.locale } : {}),
+    // #1923 — 사용자 명시 의향 토글. ON일 때만 송신. backend는 부재 시 false default 처리 (backward-compat).
+    // device SSoT 동기화 시점에 false로 명시 송신 vs 미송신 둘 다 backend 동일 처리 → 송신 skip로 트래픽 절약.
+    ...(payload.infoModeEnabled === true ? { infoModeEnabled: true } : {}),
   };
 
   try {
@@ -336,6 +359,8 @@ export function registerActiveTrip(
     subsurface: payload.subsurface,
     // #1895 — locale 변경 시 hash 갱신해 재등록 보장.
     locale: payload.locale,
+    // #1923 — infoModeEnabled 변경 시 hash 갱신해 재등록 보장 (의향 표명 직후 backend gate 즉시 활성화).
+    infoModeEnabled: payload.infoModeEnabled,
   });
   if (hash === lastRegisteredHash) {
     return Promise.resolve({ ok: true, skipped: true });

--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -1021,6 +1021,57 @@ describe('useApnsTripRegistration', () => {
     });
   });
 
+  // #1923 — 사용자 명시 의향 토글 (infoModeEnabled) backend forward 검증.
+  describe('infoModeEnabled (#1923)', () => {
+    const baseInputs = (infoModeEnabled?: boolean) => ({
+      route: directRoute,
+      destination: station,
+      nextStationEtaSeconds: 120,
+      ...(infoModeEnabled === undefined ? {} : { infoModeEnabled }),
+    });
+    const renderInfo = (initial?: boolean) =>
+      renderHook(
+        ({ ime }: { ime?: boolean }) => useApnsTripRegistration(baseInputs(ime)),
+        { initialProps: { ime: initial } },
+      );
+
+    it.each([
+      { label: 'infoModeEnabled=true → payload에 포함', ime: true, expected: true },
+      { label: 'infoModeEnabled 미지정 → payload에 미포함 (graceful)', ime: undefined, expected: undefined },
+      { label: 'infoModeEnabled=false → payload에 미포함 (graceful)', ime: false, expected: undefined },
+    ])('$label', async ({ ime, expected }) => {
+      renderInfo(ime);
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockRegister.mock.calls[0][0].infoModeEnabled).toBe(expected);
+    });
+
+    it('OFF→ON 전환 시 즉시 재등록 (deps 반영 — backend lockless intermediate gate 즉시 활성화)', async () => {
+      const { rerender } = renderInfo(false);
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockRegister.mock.calls[0][0].infoModeEnabled).toBeUndefined();
+      rerender({ ime: true });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      expect(mockRegister.mock.calls[1][0].infoModeEnabled).toBe(true);
+    });
+
+    it('token refresh 경로도 최신 infoModeEnabled 값을 송신', async () => {
+      const { rerender } = renderInfo(false);
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      rerender({ ime: true });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      const listener = mockAddPushTokenListener.mock.calls[0][0];
+      await act(async () => {
+        listener({ data: 'token-INFO-NEW' });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const refreshed = mockRegister.mock.calls.find(
+        (c) => (c[0] as { token: string }).token === 'token-INFO-NEW',
+      );
+      expect(refreshed?.[0].infoModeEnabled).toBe(true);
+    });
+  });
+
   describe('#1895 i18n locale 송신 (4언어 boarding-prompt)', () => {
     const baseInputs = {
       route: directRoute,

--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -47,6 +47,20 @@ jest.mock('../../../nearest-station/utils/movementGate', () => ({
   STATIC_SPEED_THRESHOLD_MPS: 0.5,
 }));
 
+// #1923 — useUserIntentStore mock. createLockFromTrain 진입 시 setInfoModeEnabled(true) 호출 검증.
+jest.mock('../../store/useUserIntentStore', () => {
+  const mockSetInfoModeEnabled = jest.fn(() => Promise.resolve());
+  return {
+    useUserIntentStore: {
+      getState: () => ({ setInfoModeEnabled: mockSetInfoModeEnabled }),
+    },
+    __mockSetInfoModeEnabled: mockSetInfoModeEnabled,
+  };
+});
+const { __mockSetInfoModeEnabled: setInfoModeEnabledMock } = jest.requireMock(
+  '../../store/useUserIntentStore',
+);
+
 function makeTrain(overrides: Partial<ArrivalInfo> = {}): ArrivalInfo {
   return {
     destination: '종착',
@@ -217,6 +231,7 @@ describe('useBoardingLockController', () => {
   describe('createLockFromTrain', () => {
     beforeEach(() => {
       jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+      setInfoModeEnabledMock.mockClear();
     });
     afterEach(() => {
       (Date.now as jest.Mock).mockRestore();
@@ -424,6 +439,48 @@ describe('useBoardingLockController', () => {
         expect(mockSetBoardingLock).toHaveBeenCalled();
       });
       expect(Haptics.notificationAsync).not.toHaveBeenCalled();
+    });
+
+    // #1923 — BoardingTrainList 직접 탭은 lock 활성과 동급 사용자 명시 의향 표명.
+    // setInfoModeEnabled(true) stamp는 createLock 시도와 별경로로 발사되어
+    // lock 실패/만료해 lockless 전환되어도 backend lockless intermediate gate가 활성화된다.
+    describe('#1923 infoModeEnabled stamp (사용자 명시 의향)', () => {
+      it('createLockFromTrain 성공 시 setInfoModeEnabled(true) 1회 호출', async () => {
+        const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+        await act(async () => {
+          result.current.createLockFromTrain(makeTrain({ trainCode: 'T-INFO' }));
+        });
+        expect(setInfoModeEnabledMock).toHaveBeenCalledWith(true);
+        expect(setInfoModeEnabledMock).toHaveBeenCalledTimes(1);
+      });
+
+      it('createLock 실패해도 setInfoModeEnabled(true)는 여전히 stamp (의향 표명 사실은 store 실패와 무관)', async () => {
+        mockSetBoardingLock.mockRejectedValueOnce(new Error('store fail'));
+        const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+        await act(async () => {
+          result.current.createLockFromTrain(makeTrain({ trainCode: 'T-INFO-FAIL' }));
+        });
+        expect(setInfoModeEnabledMock).toHaveBeenCalledWith(true);
+      });
+
+      it('destinationId null이면 stamp 안 함 (createLock 진입 전 early return)', async () => {
+        const { result } = renderHook(() =>
+          useBoardingLockController({ ...defaultInputs, destinationId: null }),
+        );
+        await act(async () => {
+          result.current.createLockFromTrain(makeTrain());
+        });
+        expect(setInfoModeEnabledMock).not.toHaveBeenCalled();
+      });
+
+      it('#1449 trip route 외 line은 stamp 안 함 (createLock 진입 전 line filter reject)', async () => {
+        const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+        await act(async () => {
+          // route는 line=2. line=9 train은 allowedLines filter에서 reject되어 stamp 도달 안 함.
+          result.current.createLockFromTrain(makeTrain({ trainCode: 'T-WRONG', line: '9' }));
+        });
+        expect(setInfoModeEnabledMock).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -74,6 +74,17 @@ jest.mock('../../store/useBoardingLockStore', () => {
   };
 });
 
+// #1923 — useUserIntentStore mock. tryAutoLock 진입 시 setInfoModeEnabled(true) 호출 검증.
+jest.mock('../../store/useUserIntentStore', () => {
+  const mockSetInfoModeEnabled = jest.fn(() => Promise.resolve());
+  return {
+    useUserIntentStore: {
+      getState: () => ({ setInfoModeEnabled: mockSetInfoModeEnabled }),
+    },
+    __mockSetInfoModeEnabled: mockSetInfoModeEnabled,
+  };
+});
+
 const { findStationByNameAndLine } = jest.requireMock('../../../../shared/utils/stationLookup');
 const {
   logBoardingPromptAutoLock,
@@ -85,6 +96,9 @@ const { addDomainBreadcrumb } = jest.requireMock(
 );
 const { __mockCreateLock: createLockMock } = jest.requireMock(
   '../../store/useBoardingLockStore',
+);
+const { __mockSetInfoModeEnabled: setInfoModeEnabledMock } = jest.requireMock(
+  '../../store/useUserIntentStore',
 );
 const displayLoggerMock = jest.requireMock('../useBoardingPromptDisplayLogger');
 
@@ -650,6 +664,45 @@ describe('handleResponse — #1170 응답 telemetry (logBoardingPromptResponded)
     (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
     await handleResponse(action, HANDLE_RESPONSE_PAYLOAD, makeHandleResponseDeps());
     expect(logBoardingPromptResponded).toHaveBeenCalledWith({ outcome });
+  });
+});
+
+// #1923 — 사용자 명시 의향 stamp. boarded path 진입 시 setInfoModeEnabled(true) 호출 검증.
+// dismissed path는 stamp 안 함 (의향 표명 없음).
+describe('handleResponse — #1923 infoModeEnabled stamp (사용자 명시 의향)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each<[string, string]>([
+    ['[탑승] 액션', BOARDING_PROMPT_ACTION_BOARDED],
+    ['기본 탭 ($default)', Notifications.DEFAULT_ACTION_IDENTIFIER],
+  ])('%s → useUserIntentStore.setInfoModeEnabled(true) 호출', async (_label, action) => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+    await handleResponse(action, HANDLE_RESPONSE_PAYLOAD, makeHandleResponseDeps());
+    expect(setInfoModeEnabledMock).toHaveBeenCalledWith(true);
+  });
+
+  it.each<[string, string]>([
+    ['[미탑승] 액션', BOARDING_PROMPT_ACTION_NOT_BOARDED],
+    ['알 수 없는 액션', 'SOME_OTHER_ACTION'],
+  ])('%s → setInfoModeEnabled 호출 안 함 (dismissed path는 의향 표명 없음)', async (_label, action) => {
+    await handleResponse(action, HANDLE_RESPONSE_PAYLOAD, makeHandleResponseDeps());
+    expect(setInfoModeEnabledMock).not.toHaveBeenCalled();
+  });
+
+  it('tryAutoLock 실패(arrivals null)해도 setInfoModeEnabled(true)는 호출 (의향 표명 사실은 실패와 무관)', async () => {
+    const deps = makeHandleResponseDeps({
+      fetchArrivalsForStation: jest.fn(async () => null),
+    });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, HANDLE_RESPONSE_PAYLOAD, deps);
+    expect(setInfoModeEnabledMock).toHaveBeenCalledWith(true);
+  });
+
+  it('destinationId null + [탑승] → setInfoModeEnabled(true)는 여전히 호출 (사용자가 boarded로 응답한 사실은 stamp)', async () => {
+    const deps = makeHandleResponseDeps({ destinationId: null });
+    await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, HANDLE_RESPONSE_PAYLOAD, deps);
+    expect(setInfoModeEnabledMock).toHaveBeenCalledWith(true);
   });
 });
 

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -68,6 +68,14 @@ export interface UseApnsTripRegistrationInputs {
    * 미설정/false면 기존 threshold(5) 유지 — 기압계 미지원 환경 graceful.
    */
   subsurface?: boolean;
+  /**
+   * #1923 — 사용자 명시 의향 토글 (C 토글 ON / boardingPrompt [탑승] 응답 /
+   * BoardingTrainList 직접 탭 중 하나라도 행하면 true). `useUserIntentStore`에서
+   * 읽어 전달. backend가 lockless intermediate station-passed silent push 발사
+   * 분기에 사용 (`trip.infoModeEnabled && waypoint.kind === 'intermediate'`).
+   * 미지정/false: 기존 동작 그대로 — boardingLock 부재 시 `lockMissing` skip.
+   */
+  infoModeEnabled?: boolean;
 }
 
 /**
@@ -91,6 +99,8 @@ interface RegisterCallInputs {
   boardingLock: BoardingLock | null;
   /** #903 (Seam G) — 기압계 subsurface 신호. true면 backend threshold 5→10. */
   subsurface: boolean;
+  /** #1923 — 사용자 명시 의향 토글. true면 backend lockless intermediate gate 활성. */
+  infoModeEnabled: boolean;
   /** 같은 trip 세션 동안 고정되는 epoch ms. backend `isSameSession` 판정 키(#589). */
   createdAt: number;
   /**
@@ -198,6 +208,8 @@ async function callRegister(input: RegisterCallInputs) {
     ...(input.subsurface ? { subsurface: true } : {}),
     // #1895 — device locale (boarding-prompt push 본문 4언어 분기용). 미지원 locale은 송신 skip.
     ...(locale ? { locale } : {}),
+    // #1923 — 사용자 명시 의향 토글 ON일 때만 송신. false/미설정은 필드 누락(graceful, backend는 false default).
+    ...(input.infoModeEnabled ? { infoModeEnabled: true } : {}),
   });
 }
 
@@ -208,6 +220,7 @@ export function useApnsTripRegistration({
   currentStation = null,
   boardingLock = null,
   subsurface = false,
+  infoModeEnabled = false,
 }: UseApnsTripRegistrationInputs): void {
   // route 객체 reference가 categorized recompute로 자주 바뀌므로 내용 기반 signature로
   // 메모화 — register useEffect deps에 사용해 동일 경로 재등록(POST /trips 폭주) 방지.
@@ -216,9 +229,9 @@ export function useApnsTripRegistration({
   // alarmBackend dedup hash와 동일 필드 사용 (trainCode + line + boardedAt).
   const boardingLockSig = lockSig(boardingLock);
   // 최신 트립 입력을 ref에 보관 — pushTokenListener가 갱신 시 재등록에 사용한다.
-  const latestInputsRef = useRef({ route, destination, nextStationEtaSeconds, currentStation, boardingLock, subsurface });
+  const latestInputsRef = useRef({ route, destination, nextStationEtaSeconds, currentStation, boardingLock, subsurface, infoModeEnabled });
   useEffect(() => {
-    latestInputsRef.current = { route, destination, nextStationEtaSeconds, currentStation, boardingLock, subsurface };
+    latestInputsRef.current = { route, destination, nextStationEtaSeconds, currentStation, boardingLock, subsurface, infoModeEnabled };
   });
 
   // #589 — backend `isSameSession`(token+createdAt) 판정용. 같은 trip(같은
@@ -296,6 +309,7 @@ export function useApnsTripRegistration({
           currentStation: cs,
           boardingLock: bl,
           subsurface: sub,
+          infoModeEnabled: ime,
         } = latestInputsRef.current;
         if (!r || !d) return;
         const sessionKey = `${token}:${routeSignature(r)}:${d.id}`;
@@ -307,6 +321,7 @@ export function useApnsTripRegistration({
           currentStation: cs,
           boardingLock: bl,
           subsurface: sub,
+          infoModeEnabled: ime,
           createdAt: resolveTripCreatedAt(sessionKey),
           cachedPromptContext: lastPromptContextRef.current,
         });
@@ -406,6 +421,7 @@ export function useApnsTripRegistration({
         currentStation,
         boardingLock,
         subsurface,
+        infoModeEnabled,
         createdAt: resolveTripCreatedAt(sessionKey),
         cachedPromptContext: lastPromptContextRef.current,
       });
@@ -458,6 +474,9 @@ export function useApnsTripRegistration({
     // #903 (Seam G): subsurface 변화 시 backend threshold(5→10)를 빨리 갱신해 지하 진입 직후
     // 일시 GPS/arrival 누락에 인내. useBarometer의 60s 윈도우 평가가 토글 폭주를 자체 흡수하므로
     // deps churn 위험 낮음. alarmBackend의 dedup hash가 subsurface 미변화 사이클은 POST를 skip.
+    // #1923: infoModeEnabled 변화 시 backend lockless intermediate gate를 즉시 활성화해 다음 cron
+    // cycle부터 station-passed silent push 발사가 가능. 토글 빈도는 사용자 명시 의향 표명/trip 종료
+    // 시점만이므로 deps churn 위험 낮음. alarmBackend dedup hash가 미변화 사이클은 POST를 skip.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routeSig, destination?.id, boardingLockSig, subsurface]);
+  }, [routeSig, destination?.id, boardingLockSig, subsurface, infoModeEnabled]);
 }

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { AppState, type AppStateStatus } from 'react-native';
 import * as Haptics from 'expo-haptics';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
+import { useUserIntentStore } from '../store/useUserIntentStore';
 import { resolveTripDirection } from '../../route/utils/tripDirection';
 import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import { allowedLinesFromRoute } from '../../../shared/utils/stationRoute';
@@ -271,6 +272,12 @@ export function useBoardingLockController({
       // train arrival을 directionalArrivals에 섞어 노출한 경우 lock 채택을 차단한다.
       // allowedLines === undefined는 trip 비활성 → 필터 미적용(free-trip 등 기존 UX 유지).
       if (allowedLines && !allowedLines.has(train.line)) return;
+      // #1923 — 사용자 명시 의향 stamp. BoardingTrainList 직접 탭은 lock 활성과 동급 의향 표명.
+      // ADR-014 §X "사용자 명시 의향 trip = lock 활성과 동급 정확도 보장 의무" 정합.
+      // setInfoModeEnabled는 memory + storage atomic — graceful 실패(다음 cycle에서 자연 재시도).
+      // lock 활성 trip은 backend가 boardingLock 분기로 처리하므로 본 stamp는 graceful surplus,
+      // 단 lock이 실패/만료해 lockless 전환되면 즉시 lockless intermediate gate 활성화 보장.
+      void useUserIntentStore.getState().setInfoModeEnabled(true);
       const durationMin = expectedDurationMinutes ?? FALLBACK_BOARDING_DURATION_MINUTES;
       // #663: boardingLine은 사용자가 실제로 탭한 train의 line을 사용. currentStation.line은 fusion
       // 추정이라 환승역에서 옆 노선으로 잘못 잠긴 상태일 수 있다 (#662). train.line은 어댑터가 subwayId로

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -27,6 +27,7 @@ import * as Notifications from 'expo-notifications';
 import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival';
 import { dismissBoardingPrompt } from '../../nearest-station/api/positionUpload';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
+import { useUserIntentStore } from '../store/useUserIntentStore';
 import { pickAutoTrainCodeFromArrivals } from '../utils/boardingPromptAutoLock';
 import {
   logBoardingPromptAutoLock,
@@ -181,6 +182,11 @@ export async function handleResponse(
     // #1170 — 응답률/탑승률 measurement. autolock 시도 성공/실패와 무관하게 "사용자가 boarded로
     // 응답했다"는 사실 기록. boardedRate = boarded / (boarded+dismissed)는 게이트 정확도 proxy.
     logBoardingPromptResponded({ outcome: 'boarded' });
+    // #1923 — 사용자 명시 의향 stamp. tryAutoLock 성공/실패와 무관하게 의향 표명 사실이 backend로
+    // forward되어야 lockless intermediate trip에서도 station-passed silent push가 발사된다.
+    // ADR-014 §X "사용자 명시 의향 trip = lock 활성과 동급 정확도 보장 의무" 정합.
+    // setInfoModeEnabled는 memory + storage atomic — graceful 실패(다음 cycle에서 재시도).
+    void useUserIntentStore.getState().setInfoModeEnabled(true);
     await tryAutoLock(payload, deps);
     // #1888 (RC-13) — banner 탭($default) 케이스만 home 화면으로 navigate. 사용자가 list를 보고 싶다는
     // 명시 의향(action button BOARDED는 silent autolock으로 끝, navigation은 surplus).

--- a/src/features/alarm/store/__tests__/useUserIntentStore.test.ts
+++ b/src/features/alarm/store/__tests__/useUserIntentStore.test.ts
@@ -1,0 +1,134 @@
+/**
+ * #1923 — useUserIntentStore 테스트.
+ *
+ * memory + AsyncStorage 동시 mutation + cold-start hydrate + reset helper 모두 cover.
+ * coverage 100% — set true/false, load valid/invalid, persist 실패 graceful, resetUserIntentInfoMode wrapper.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  useUserIntentStore,
+  resetUserIntentInfoMode,
+} from '../useUserIntentStore';
+import { USER_INTENT_INFO_MODE_KEY } from '../../../../shared/constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+describe('useUserIntentStore (#1923)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // 매 테스트마다 store memory state reset (zustand는 모듈 싱글톤이라 leak 차단).
+    useUserIntentStore.setState({ infoModeEnabled: false });
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+    (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+  });
+
+  describe('setInfoModeEnabled', () => {
+    it('true → memory state + AsyncStorage 동기화 ("true" 영속화)', async () => {
+      await useUserIntentStore.getState().setInfoModeEnabled(true);
+      expect(useUserIntentStore.getState().infoModeEnabled).toBe(true);
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(USER_INTENT_INFO_MODE_KEY, 'true');
+      expect(AsyncStorage.removeItem).not.toHaveBeenCalled();
+    });
+
+    it('false → memory state + AsyncStorage removeItem (키 삭제)', async () => {
+      // 먼저 true로 set (선행 조건)
+      await useUserIntentStore.getState().setInfoModeEnabled(true);
+      (AsyncStorage.setItem as jest.Mock).mockClear();
+      (AsyncStorage.removeItem as jest.Mock).mockClear();
+
+      await useUserIntentStore.getState().setInfoModeEnabled(false);
+      expect(useUserIntentStore.getState().infoModeEnabled).toBe(false);
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(USER_INTENT_INFO_MODE_KEY);
+      expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+    });
+
+    it('setItem 실패해도 throw 없이 graceful (memory는 반영 유지)', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('disk full'));
+      await expect(
+        useUserIntentStore.getState().setInfoModeEnabled(true),
+      ).resolves.toBeUndefined();
+      // memory는 이미 true로 반영됨
+      expect(useUserIntentStore.getState().infoModeEnabled).toBe(true);
+    });
+
+    it('removeItem 실패해도 throw 없이 graceful (memory는 false 유지)', async () => {
+      // 사전 조건: true 상태
+      useUserIntentStore.setState({ infoModeEnabled: true });
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('disk error'));
+      await expect(
+        useUserIntentStore.getState().setInfoModeEnabled(false),
+      ).resolves.toBeUndefined();
+      expect(useUserIntentStore.getState().infoModeEnabled).toBe(false);
+    });
+  });
+
+  describe('loadInfoModeEnabled', () => {
+    it('storage에 "true" 있으면 memory state true로 hydrate', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('true');
+      await useUserIntentStore.getState().loadInfoModeEnabled();
+      expect(useUserIntentStore.getState().infoModeEnabled).toBe(true);
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith(USER_INTENT_INFO_MODE_KEY);
+    });
+
+    it('storage가 키 부재(null)면 memory state false 유지', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      await useUserIntentStore.getState().loadInfoModeEnabled();
+      expect(useUserIntentStore.getState().infoModeEnabled).toBe(false);
+    });
+
+    it('storage value가 "true"가 아니면 false로 hydrate (strict guard)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('false');
+      await useUserIntentStore.getState().loadInfoModeEnabled();
+      expect(useUserIntentStore.getState().infoModeEnabled).toBe(false);
+    });
+
+    it('storage value가 임의 string이면 false로 hydrate', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('garbage-value');
+      await useUserIntentStore.getState().loadInfoModeEnabled();
+      expect(useUserIntentStore.getState().infoModeEnabled).toBe(false);
+    });
+
+    it('getItem 실패해도 throw 없이 graceful (false 유지)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('disk error'));
+      await expect(
+        useUserIntentStore.getState().loadInfoModeEnabled(),
+      ).resolves.toBeUndefined();
+      expect(useUserIntentStore.getState().infoModeEnabled).toBe(false);
+    });
+  });
+
+  describe('resetUserIntentInfoMode (trip-bound cleanup helper)', () => {
+    it('현재 true 상태에서 호출 시 false로 reset + AsyncStorage removeItem', async () => {
+      useUserIntentStore.setState({ infoModeEnabled: true });
+      await resetUserIntentInfoMode();
+      expect(useUserIntentStore.getState().infoModeEnabled).toBe(false);
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(USER_INTENT_INFO_MODE_KEY);
+    });
+
+    it('이미 false 상태에서 호출해도 idempotent (memory 그대로 false)', async () => {
+      await resetUserIntentInfoMode();
+      expect(useUserIntentStore.getState().infoModeEnabled).toBe(false);
+      // removeItem은 false set 시에도 호출됨 (멱등 — 키 부재 시 graceful no-op).
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(USER_INTENT_INFO_MODE_KEY);
+    });
+
+    it('Promise를 반환해 TRIP_BOUND_CLEANUPS 배열 shape에 맞음', () => {
+      const result = resetUserIntentInfoMode();
+      expect(result).toBeInstanceOf(Promise);
+    });
+  });
+});

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -48,6 +48,7 @@ import { getNotificationRouter } from '../api/notificationRouter';
 import { useDestinationStore } from '../../route/store/useDestinationStore';
 import { useBoardingLockStore } from './useBoardingLockStore';
 import { useAlarmEventStore } from './useAlarmEventStore';
+import { resetUserIntentInfoMode } from './useUserIntentStore';
 import { createLogger } from '../../../shared/utils/logger';
 
 const log = createLogger('tripBoundCleanups');
@@ -167,6 +168,11 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   // useStateRehydration이 sentinel을 보고 destination/lock만 reset — alarmEvent 등은 누락).
   // 본 wiring으로 BG 경로에서도 메모리/storage가 동시에 일관 상태가 된다.
   clearTripBoundStoreMemory,
+  // #1923 — trip 종료 시 사용자 명시 의향 토글 reset.
+  // 이전 trip의 의향 신호가 새 trip에 leak되지 않도록 memory + storage 동시 false 처리.
+  // 4 cleanup 경로 (FG setDestination(null/switch) / silent push trip-ended /
+  // useStateRehydration sentinel / useLaunchTripReconciliation cold-launch) 모두 자동 wire.
+  resetUserIntentInfoMode,
 ];
 
 /**

--- a/src/features/alarm/store/useUserIntentStore.ts
+++ b/src/features/alarm/store/useUserIntentStore.ts
@@ -1,0 +1,86 @@
+/**
+ * #1923 — 사용자 명시 의향 토글 (infoModeEnabled) SSoT store.
+ *
+ * paradigm Phase 6 (단독 사용자 모드) device-only chain의 진원지. 사용자가
+ * boardingPrompt [탑승] 응답 / BoardingTrainList 직접 탭 중 하나라도 행하면
+ * 본 store에 `infoModeEnabled=true`로 stamp된다. `useApnsTripRegistration`이 이
+ * 값을 읽어 `RegisterTripPayload.infoModeEnabled`로 backend에 송신하며, backend는
+ * cron lockless intermediate gate(`trip.infoModeEnabled && waypoint.kind === 'intermediate'`)
+ * 가 통과되어 station-passed silent push를 발사한다.
+ *
+ * ADR-014 §X "사용자 명시 의향 trip = lock 활성과 동급 정확도 보장 의무" 정합.
+ *
+ * Lifecycle:
+ *  - mount: `loadInfoModeEnabled()` — AsyncStorage hydrate (cold start 보장).
+ *  - 사용자 의향 표명: `setInfoModeEnabled(true)` — memory + storage atomic.
+ *  - trip 종료: `runTripBoundCleanups()`에서 `setInfoModeEnabled(false)` —
+ *    이전 trip의 의향 신호가 새 trip에 leak되지 않도록.
+ *
+ * `useBoardingLockStore`와 다른 lifecycle (lock 없어도 의향만 살아있을 수 있음) —
+ * 책임 분리 위해 별도 store. 옵션 C-2 (이슈 #1923 §3.2 Fix C).
+ */
+
+import { create } from 'zustand';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { USER_INTENT_INFO_MODE_KEY } from '../../../shared/constants/storageKeys';
+import { createLogger } from '../../../shared/utils/logger';
+
+const log = createLogger('useUserIntentStore');
+
+/** AsyncStorage value 표기 — 'true' string 또는 키 부재(=false). */
+const STORAGE_VALUE_TRUE = 'true';
+
+export interface UserIntentState {
+  /**
+   * 사용자 명시 의향 토글. true면 backend lockless intermediate gate 통과 →
+   * station-passed silent push 발사 path 활성.
+   */
+  infoModeEnabled: boolean;
+  /**
+   * memory state 갱신 + AsyncStorage 동기 영속화. storage write 실패는 graceful —
+   * 메모리는 즉시 반영되며 다음 cold start에서 stale 'true'/false로 fallback.
+   */
+  setInfoModeEnabled: (enabled: boolean) => Promise<void>;
+  /**
+   * cold start 시 storage hydrate. parse 실패/키 부재는 false 유지.
+   */
+  loadInfoModeEnabled: () => Promise<void>;
+}
+
+export const useUserIntentStore = create<UserIntentState>((set) => ({
+  infoModeEnabled: false,
+
+  setInfoModeEnabled: async (enabled: boolean) => {
+    set({ infoModeEnabled: enabled });
+    try {
+      if (enabled) {
+        await AsyncStorage.setItem(USER_INTENT_INFO_MODE_KEY, STORAGE_VALUE_TRUE);
+      } else {
+        await AsyncStorage.removeItem(USER_INTENT_INFO_MODE_KEY);
+      }
+    } catch (e) {
+      // graceful — 메모리는 이미 반영. 다음 cold start에서 stale fallback.
+      log.warn('persist failed', e);
+    }
+  },
+
+  loadInfoModeEnabled: async () => {
+    try {
+      const raw = await AsyncStorage.getItem(USER_INTENT_INFO_MODE_KEY);
+      set({ infoModeEnabled: raw === STORAGE_VALUE_TRUE });
+    } catch (e) {
+      // graceful — 키 부재/parse 실패는 false 유지 (안전한 default).
+      log.warn('hydrate failed', e);
+    }
+  },
+}));
+
+/**
+ * #1923 — trip 종료 시 `runTripBoundCleanups`에서 호출하는 cleanup helper.
+ *
+ * `setInfoModeEnabled(false)`를 직접 호출하는 thin wrapper로 `TRIP_BOUND_CLEANUPS` 배열의
+ * `() => Promise<void>` shape에 맞춘다. memory + storage 동시 reset 보장.
+ */
+export function resetUserIntentInfoMode(): Promise<void> {
+  return useUserIntentStore.getState().setInfoModeEnabled(false);
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -15,6 +15,7 @@ import { useSettingsStore } from '../features/settings/store/useSettingsStore';
 import { useDestinationStore } from '../features/route/store/useDestinationStore';
 import { useAlarmEventStore } from '../features/alarm/store/useAlarmEventStore';
 import { useBoardingLockStore } from '../features/alarm/store/useBoardingLockStore';
+import { useUserIntentStore } from '../features/alarm/store/useUserIntentStore';
 import { DestinationPicker } from '../features/route/components/DestinationPicker';
 import { findRouteCandidatesByCategory, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, getStationById, routeSignature, type Route, type CategorizedRoute, type RoutePreference } from '../shared/utils/stationRoute';
 import { pickArrivalAtOrigin } from '../features/arrival/utils/pickArrivalAtOrigin';
@@ -130,6 +131,11 @@ export default function HomeScreen() {
   const alarmEvent = useAlarmEventStore((s) => s.alarmEvent);
   const clearAlarmEvent = useAlarmEventStore((s) => s.clearAlarmEvent);
   const loadAlarmEvent = useAlarmEventStore((s) => s.loadAlarmEvent);
+  // #1923 — 사용자 명시 의향 토글 SSoT. useApnsTripRegistration이 본 값을 backend로 forward해
+  // lockless intermediate gate(`trip.infoModeEnabled && waypoint.kind === 'intermediate'`)를 통과시킨다.
+  // 트리거: tryAutoLock(boardingPrompt 응답) / createLockFromTrain(BoardingTrainList 탭) 양쪽에서 stamp.
+  const infoModeEnabled = useUserIntentStore((s) => s.infoModeEnabled);
+  const loadInfoModeEnabled = useUserIntentStore((s) => s.loadInfoModeEnabled);
   // #746: 알람 dismiss → silence 시작점 기록. 같은 컴포넌트의 userLocation을 같이 캡처.
   const setDismissSilence = useAlarmEventStore((s) => s.setDismissSilence);
   // #746 reviewer P1: cold-start hydration — storage에 살아있는 silence 상태를
@@ -799,6 +805,9 @@ export default function HomeScreen() {
     currentStation: result?.station ?? null,
     boardingLock,
     subsurface: barometerSubsurface,
+    // #1923 — 사용자 명시 의향 토글. backend가 lockless intermediate gate 진입에 사용 →
+    // station-passed silent push 발사. 미stamp(false) trip은 기존 lockMissing skip 동작.
+    infoModeEnabled,
   });
 
   useEffect(() => {
@@ -816,6 +825,11 @@ export default function HomeScreen() {
     loadRecentDestinations();
     loadAlarmEvent();
     loadDismissSilence();
+    // #1923 — cold start 시 사용자 명시 의향 토글 hydrate. 앱이 BG로 종료된 상태에서
+    // 의향 표명 후 재시작했을 때 토글이 false로 stale되지 않도록 storage에서 복원.
+    // trip 종료 시 runTripBoundCleanups가 storage를 정리하므로 cold start hydrate 결과는
+    // 의향이 살아있는 trip만 true. graceful — 키 부재/parse 실패는 false 유지.
+    void loadInfoModeEnabled();
     // iOS가 BG에서 앱을 메모리 압박으로 종료하면 Zustand 상태는 휘발되지만
     // DESTINATION_KEY는 디스크에 남는다. 콜드/웜 부팅 시 복원해 trip을 이어간다 (#541).
     // #700 — tripOrigin을 먼저 await으로 hydrate한 다음 destination을 set한다.

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -193,3 +193,11 @@ export const NOTIFICATION_DELIVERY_LOG_KEY = 'subway-now:notification-delivery-l
 // 응답을 누적. ADR-015 §10 P5 가중치 자동 학습의 label(=ground truth)이다.
 // 형식: { pendingPrompt: { corrId, endedAt } | null, responses: TripGroundTruthResponse[] } JSON.
 export const TRIP_GROUND_TRUTH_KEY = 'subway-now:trip-ground-truth';
+// #1923 — 사용자 명시 의향 토글 (infoModeEnabled) SSoT.
+// boardingPrompt [탑승] 응답 / BoardingTrainList 직접 탭 시 true로 stamp.
+// useApnsTripRegistration이 본 키를 읽어 RegisterTripPayload.infoModeEnabled로 backend에 송신 →
+// backend lockless intermediate gate가 통과되어 station-passed silent push가 발사된다
+// (backend/alarm-worker/src/scheduled.ts:980 `trip.infoModeEnabled && waypoint.kind === 'intermediate'`).
+// trip 종료 시 runTripBoundCleanups에서 false로 reset (이전 trip의 의향 신호가 새 trip에 leak 차단).
+// 형식: 'true' 또는 키 부재(=false). ADR-014 §X "사용자 명시 의향 trip = lock 활성과 동급 정확도 보장 의무" 정합.
+export const USER_INTENT_INFO_MODE_KEY = 'subway-now:user-intent-info-mode';


### PR DESCRIPTION
## Summary

- Closes #1923
- **P0 hard-blocker** — N=5/5 trip evidence (6/26 4건 + 6/27 1건 모두 silent push `fired=0`)
- 회귀 진원지 fix: `RegisterTripPayload`에 `infoModeEnabled` field 부재 → device 송신 path 0건 → backend `lockMissing` skip 100% cascade
- `RegisterTripPayload` interface + `useUserIntentStore` 신설 + `useApnsTripRegistration` payload forward + 2 stamp 진입점 (tryAutoLock / createLockFromTrain) wire

## 변경 요약

| File | 줄수 | 책임 |
| --- | --- | --- |
| `src/features/alarm/api/alarmBackend.ts` | +15 | `RegisterTripPayload.infoModeEnabled` 필드 + dedup hash + send body |
| `src/features/alarm/store/useUserIntentStore.ts` (신규) | +90 | SSoT 신설 (zustand + AsyncStorage + `resetUserIntentInfoMode` helper) |
| `src/features/alarm/hooks/useApnsTripRegistration.ts` | +20 | input 필드 + callRegister wire + token-refresh propagate + deps |
| `src/features/alarm/hooks/useBoardingPromptResponder.ts` | +6 | tryAutoLock 직전 `setInfoModeEnabled(true)` stamp |
| `src/features/alarm/hooks/useBoardingLockController.ts` | +7 | createLockFromTrain 진입 시 stamp |
| `src/features/alarm/store/tripBoundCleanups.ts` | +6 | `resetUserIntentInfoMode` cleanup wire |
| `src/screens/HomeScreen.tsx` | +14 | `useUserIntentStore` 읽기 + `loadInfoModeEnabled` mount hydrate |
| `src/shared/constants/storageKeys.ts` | +8 | `USER_INTENT_INFO_MODE_KEY` |
| Test files (5 그룹 추가) | +191 | coverage 100% 신규 분기 모두 |

총 **+499 / -3**.

## Root cause chain (이슈 §2 그대로)

```
사용자 명시 의향 표명 (C 토글 ON / boardingPrompt [탑승] / BoardingTrainList 탭)
  ↓ device SSoT (useUserIntentStore 신설)
  ↓ RegisterTripPayload.infoModeEnabled (신설)
  ↓ backend parseTrip 분기 (이미 구현, #1669)
  ↓ scheduled.ts cron `trip.infoModeEnabled && waypoint.kind === 'intermediate'`
  ↓ runLocklessIntermediate → station-passed silent push 발사
```

Backend는 이미 8 누적 deploy로 wire 완료 — device frontend 한 PR로 chain 진원지 fix.

## Test plan

- [x] **Unit test 100% coverage** — 398 suites / 8380 tests pass
  - `alarmBackend.test.ts`: 4 신규 case (`infoModeEnabled=true` 송신 / `false` 미포함 / OFF→ON 재등록 / 동일 값 dedup)
  - `useUserIntentStore.test.ts`: 신규 12 case (set true/false + load valid/invalid/null + storage 실패 graceful + reset helper)
  - `useApnsTripRegistration.test.ts`: 5 신규 case (input 송신 / OFF→ON 재등록 / token refresh propagate)
  - `useBoardingPromptResponder.test.ts`: 6 신규 case (boarded path stamp / dismissed path no-stamp / arrivals null도 stamp / destinationId null도 stamp)
  - `useBoardingLockController.test.tsx`: 4 신규 case (성공 시 stamp / 실패 시 stamp / destinationId null 차단 / line filter 차단)
- [x] **Type check** — pass (`npm run type-check` clean)
- [x] **Orphan check** — pass (`npm run lint:orphan` clean)
- [ ] 사용자 실기기 trip 1회 (V4 evidence)

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass. 신규 `useUserIntentStore` export caller 4곳:
   - `useBoardingPromptResponder.ts` (boardingPrompt 응답 stamp)
   - `useBoardingLockController.ts` (BoardingTrainList 탭 stamp)
   - `tripBoundCleanups.ts` (trip 종료 reset)
   - `HomeScreen.tsx` (callsite read + mount hydrate)
2. **V/X dashboard** — 변경 신호 관측 위치:
   - **wrangler tail / Cloudflare Dashboard**: backend cron `boarding-lock: skip cycle` log의 `locklessOptIn` 필드. 본 PR 머지 후 의향 표명 trip은 `locklessOptIn=True` 변화 (gate 통과 시 skip 자체 안 됨 → log 0).
   - **backend admin metric**: `stats.locklessIntermediateFired` SUM (1주 누적 ≥ 1 trip당).
   - **device dump**: POST `/trips` body에 `"infoModeEnabled":true` 포함 (사용자 dump grep).
3. **의존 PR** — N/A (backend 이미 8 누적 deploy 완성, device frontend 단독 PR로 chain 정상화)
4. **측정 plan** (1주):
   - Metric 1: 의향 표명 trip 중 `runLocklessIntermediate` 진입 비율 = 5/5 → 100% 목표
   - Metric 2: `boarding-lock: skip cycle` log 중 `locklessOptIn=True` 비율 (의향 trip은 0건이어야 정상 — gate 통과)
   - Metric 3: device dump의 POST `/trips` body에 `"infoModeEnabled":true` 포함률 (의향 표명 trip 100%)
5. **Device verify** — 실기기 verify **필요**. 시나리오:
   - boardingPrompt [탑승] 또는 BoardingTrainList 탭
   - trip 중 1개 이상 intermediate 역 통과
   - alarm log capture
   - evidence 4건 충족: `runLocklessIntermediate ≥ 1` + `station-passed silent push fire ≥ 1` + device alarm log station-passed ≥ 1 + LA/Lock Screen 통과 역 표시 갱신 ≥ 1

## 정합 ADR/Memory

- **ADR-014 §X** — "사용자 명시 의향 trip = lock 활성과 동급 정확도 보장 의무": 본 PR이 의향 신호 device→backend forward path를 신설하여 정합.
- **ADR-015 §X** — silent push SSoT 단일 채널: 본 PR이 `infoModeEnabled` wire로 lockless intermediate 채널 정상화.
- `feedback_user_intent_equal_protection` — chain 시작 prereq fix.
- `feedback_paradigm_phase_6_intent` — 단독 사용자 모드 device-only chain 진원지 fix.
- `feedback_decision_no_false_binary` — §3.2 Fix C 3 옵션 (C-1/C-2/C-3) 제시 후 C-2 채택.

## 결정 옵션 (false binary 금지)

§3.2 Fix C `useUserIntentStore` 위치 — 3 옵션 평가:
| 옵션 | 위치 | 결정 |
| --- | --- | --- |
| C-1 | `useDestinationStore`에 slice 추가 | ✗ DestinationState 책임 비대화 |
| **C-2** | **신규 `useUserIntentStore`** | **✓ 채택 — 책임 분리 / lock과 다른 lifecycle / 50~80줄 medium effort** |
| C-3 | `useBoardingLockStore`에 합류 | ✗ BoardingLock과 lifecycle 다름 (lock 없어도 의향만 살아있을 수 있음) |