### PR TITLE
fix(#1930): stations.json environment 필드 schema audit + Station type 결정

### DIFF
--- a/src/data/__tests__/stations.environment.test.ts
+++ b/src/data/__tests__/stations.environment.test.ts
@@ -1,0 +1,87 @@
+/**
+ * #1930 G1 — stations.json `environment` 필드 schema 정합 박제.
+ *
+ * Epic #1927 (fusion environment SSOT 다층 paradigm) G1 sub-issue.
+ *
+ * scripts/validate-stations.js의 런타임 CI assertion(enum + 누락)과 별도로,
+ * type-level + 분포 정체 + mixed 엔트리 identity를 unit 레이어에서 박제한다.
+ * 데이터 갱신 시 본 테스트가 drift를 즉시 가시화하여 후속 G2~G4 cascade가
+ * environment 변수를 기반으로 의사결정할 때 hidden regression을 차단.
+ *
+ * 박제 대상:
+ *   1. entry count (533 = 528 운영 단위 역 + 환승 line variant 5)
+ *   2. 모든 entry에 environment 필드 존재 (typing이 optional이지만 runtime 100%)
+ *   3. environment ∈ STATION_ENVIRONMENTS enum
+ *   4. mixed=1 엔트리 정체 박제 (`gyeongui-021` 가좌 — 경의중앙선 split platform)
+ *   5. unknown=0 (검수 완료)
+ *   6. 지하 우세 sanity (underground 비율 > 60%, 서울 지하철 일반 분포)
+ */
+
+import stationsData from '../stations.json';
+import { STATION_ENVIRONMENTS, type Station, type StationEnvironment } from '../../shared/types/station';
+
+const stations = stationsData as Station[];
+
+describe('stations.json environment schema (#1930 G1)', () => {
+  it('533 entries — 528 운영 단위 역 + 환승 line variant 5', () => {
+    expect(stations.length).toBe(533);
+  });
+
+  it('모든 entry에 environment 필드가 채워져 있다', () => {
+    const missing = stations.filter((s) => s.environment === undefined || s.environment === null);
+    expect(missing).toEqual([]);
+  });
+
+  it('모든 environment 값이 enum 안에 있다', () => {
+    const allowed = new Set<StationEnvironment>(STATION_ENVIRONMENTS);
+    const offending = stations.filter(
+      (s) => s.environment !== undefined && !allowed.has(s.environment),
+    );
+    expect(offending).toEqual([]);
+  });
+
+  it('environment 분포가 박제된 값과 일치한다 (drift detector)', () => {
+    const counts: Record<StationEnvironment, number> = {
+      surface: 0,
+      underground: 0,
+      mixed: 0,
+      unknown: 0,
+    };
+    for (const s of stations) {
+      if (s.environment !== undefined) counts[s.environment] += 1;
+    }
+    expect(counts).toEqual({
+      surface: 157,
+      underground: 375,
+      mixed: 1,
+      unknown: 0,
+    });
+  });
+
+  it('mixed=1 엔트리는 가좌 경의중앙선 (KRRIC split platform)', () => {
+    const mixedEntries = stations.filter((s) => s.environment === 'mixed');
+    expect(mixedEntries).toHaveLength(1);
+    const [entry] = mixedEntries;
+    expect(entry).toMatchObject({
+      id: 'gyeongui-021',
+      name: '가좌',
+      line: 'gyeongui',
+    });
+  });
+
+  it('unknown=0 — 사용자 검수 placeholder 잔여 없음', () => {
+    const unknown = stations.filter((s) => s.environment === 'unknown');
+    expect(unknown).toEqual([]);
+  });
+
+  it('지하 우세 sanity — underground 비율 > 60%', () => {
+    const undergroundCount = stations.filter((s) => s.environment === 'underground').length;
+    const ratio = undergroundCount / stations.length;
+    expect(ratio).toBeGreaterThan(0.6);
+  });
+
+  it('id가 unique — validate-stations.js id 중복 룰 데이터 박제', () => {
+    const ids = stations.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/src/shared/types/station.ts
+++ b/src/shared/types/station.ts
@@ -16,13 +16,20 @@ export type LineNumber =
 /**
  * 역 환경 (ADR-015 §1 Deterministic Environment SSOT).
  *
- * - `surface`: 지상 (CSV 층수 F prefix)
- * - `underground`: 지하 (CSV 층수 B prefix)
- * - `mixed`: 지상·지하 복합 (CSV 층수 F+B, 예: 동묘앞 5FB2)
- * - `unknown`: 데이터 출처 매칭 실패 — 사용자 검수 대상
+ * - `surface`: 지상 (KRRIC `지상구분=지상`, seoul CSV 층수 F prefix)
+ * - `underground`: 지하 (KRRIC `지상구분=지하`, seoul CSV 층수 B prefix)
+ * - `mixed`: 지상·지하 복합 승강장 (KRRIC 상행/하행 row가 서로 다름,
+ *   또는 seoul CSV 층수 F+B 동시 표기). 한 역에서 같은 line의 두 방향이
+ *   지상/지하로 분리된 경우. #1930 G1 audit 시점 기준 stations.json에 1건
+ *   — `gyeongui-021` 가좌 (경의중앙선). KRRIC `krric-gyeongui-platform.csv`에서
+ *   지하/지상 row 둘 다 가짐.
+ * - `unknown`: 데이터 출처 매칭 실패 — 사용자 검수 대상. #1930 audit 시점 기준
+ *   stations.json에 0건.
  *
- * 데이터 SSOT는 `src/data/stations.json`. 빌드 스크립트는
- * `scripts/build-station-environment.js` 참조.
+ * 데이터 SSOT는 `src/data/stations.json` (총 533 entries: 528 운영 단위 역 +
+ * 환승역의 line별 variant 5건. id는 unique — `validate-stations.js`가 id 중복
+ * 시 error로 fail. 같은 line 내 name 중복은 warning만 발행).
+ * 빌드 스크립트는 `scripts/build-station-environment.js` 참조.
  */
 export type StationEnvironment = 'surface' | 'underground' | 'mixed' | 'unknown';
 
@@ -41,10 +48,20 @@ export interface Station {
   /**
    * ADR-015 §1 — Deterministic Environment SSOT.
    *
-   * `src/data/stations.json`의 모든 entry는 본 필드를 가진다 (CI assertion).
+   * `src/data/stations.json`의 모든 entry는 본 필드를 가진다 (CI assertion —
+   * `scripts/validate-stations.js`가 ALLOWED_ENVIRONMENTS enum + 누락 검사, 추가로
+   * `src/data/__tests__/stations.environment.test.ts`가 분포 + mixed 엔트리 정체 박제).
+   *
    * 타입 정의에서는 선언적 옵셔널 — 인메모리 fixture/mock이 일일이 채울 필요
    * 없게 하여 surgical change 원칙을 보존한다. 실제 런타임에서는 stations.json
-   * 데이터를 사용하므로 항상 존재한다.
+   * 데이터(`as Station[]` 캐스트)를 사용하므로 항상 존재한다.
+   *
+   * #1930 G1 결정: 옵셔널 유지. 사유 = (1) fixture mock 50+ 곳 동시 수정 회피
+   * (surgical change 원칙 §4 보존). (2) CI 양단 assertion(validate-stations.js
+   * 런타임 + stations.environment.test.ts data drift)으로 runtime 100% 보장 동등.
+   * (3) `as Station[]` 캐스트 한 곳만 환경 보장 책임 — 외부 입력 가드 X.
+   * 후속 G2~G4에서 fusion cascade가 environment를 직접 read할 때, stations.json
+   * 데이터를 거쳐 가므로 본 옵셔널 정의는 안전.
    */
   environment?: StationEnvironment;
 }


### PR DESCRIPTION
## Summary

Epic #1927 (fusion environment SSOT 다층 paradigm) G1 sub-issue. `stations.json`의 `environment` 필드 schema audit + Station type 정식 typing 결정 + mixed=1 엔트리 정체 박제. 후속 G2~G4 cascade가 environment 변수 기반 의사결정 시 hidden regression을 unit 레이어에서 즉시 가시화.

### G1 acceptance 처리

1. **533 vs 528 정합** — 528 운영 단위 역 + 환승역 line별 variant 5건(왕십리 3 라인, 서울역 4 라인 등). `validate-stations.js`가 id 중복 시 error. `src/shared/types/station.ts` JSDoc 명문화.
2. **Station type `environment` 정식 typing 결정** — **옵셔널 유지**. 사유 3항(JSDoc 박제):
   - fixture/mock 50+ 곳 동시 수정 회피 (surgical change 원칙 §4 보존)
   - CI 양단 assertion(`validate-stations.js` 런타임 + `stations.environment.test.ts` data drift)으로 runtime 100% 보장 동등
   - `as Station[]` 캐스트 단일 환경 보장 책임 — 외부 입력 가드 X
3. **mixed=1 정체** — `gyeongui-021` **가좌 (경의중앙선)** 확정. KRRIC `krric-gyeongui-platform.csv`에서 같은 line의 상행/하행이 지상/지하 양쪽 row를 가짐 — 진짜 split platform 운영. 이슈 본문이 추측한 동묘앞(5FB2)이 아님. G2에서 fusion cascade가 mixed 환경을 어떻게 처리할지 결정 시 본 entry가 기준 fixture.
4. **data source 검증** — `scripts/build-station-environment.js` 출처 3-tier (override → KRRIC CSV → seoul CSV → unknown). 결정성 보장(네트워크 의존 X, CSV deterministic). 1차 source는 KRRIC 국가철도공단 승강장 정보(공공데이터포털, 1~9호선/분당/신분당/공항/경의중앙). 2차 fallback은 서울교통공사 역사건축정보(층수 컬럼). 외부 노선 + CSV 누락은 `ENVIRONMENT_OVERRIDES` 명시.
5. **CI Data Validation env assertion** — `validate-stations.js`가 이미 #1434에서 ALLOWED_ENVIRONMENTS enum + 누락 검사 enforcement. 본 PR은 추가로 `src/data/__tests__/stations.environment.test.ts`로 분포 + mixed 엔트리 identity + 지하 우세 sanity를 unit 레이어 박제.

Closes #1930

---

## Wire-completion 5단 체크

- [x] **1. Orphan 없음** — `npm run lint:orphan` pass. 신규 export 0건(audit + 단위 테스트만 추가).
- [x] **2. V/X dashboard** — CI `Data Validation` job + 신규 unit test. 본 PR 자체는 device 측정 신호 X. 후속 G3/G4 DebugModal `environment` 필드 표시 prereq.
- [x] **3. 의존 PR** — N/A. Epic #1927 첫 sub-issue. 후속 #1932 (G2) prereq.
- [x] **4. 측정 plan** — `Data Validation` CI job + 신규 분포 drift detector(`stations.environment.test.ts`)가 stations.json 재빌드/수정 시 regression 즉시 가시화. 1주 production 측정 불필요(infra audit).
- [x] **5. Device verify** — N/A — type+unit+CI assertion only. 실기기 검증 불필요.

### V/X dashboard URL

- 신규 `src/data/__tests__/stations.environment.test.ts` — env 필드 분포 박제(surface=157/underground=375/mixed=1/unknown=0)
- 기존 `scripts/__tests__/validate-stations.test.js` — env enum + 누락 enforcement (#1434, #1434 ALLOWED_ENVIRONMENTS)

### 의존 PR

N/A — Epic #1927 첫 sub-issue. 본 PR 머지 후 G2(#1932) 진입.

---

## Test plan

- [x] `npm test` 100% coverage pass (398 suites, 8357 tests)
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass
- [x] `node scripts/validate-stations.js` pass (533 stations OK, env enum 검증)
- [x] code-review medium — 1 doc accuracy gap(name+line 중복 enforcement 표현) 발견 후 수정 반영