### PR TITLE
fix(#1929): widget tripContext wire 4곳 + buildTripContext helper

### DIFF
--- a/src/features/alarm/api/__tests__/notificationRouter.test.ts
+++ b/src/features/alarm/api/__tests__/notificationRouter.test.ts
@@ -5,7 +5,7 @@ import {
   getNotificationRouter,
 } from '../notificationRouter';
 import { __resetDeliveryLogForTest } from '../../../notice/store/notificationDeliveryLog';
-import { BACKEND_SSOT_MIRROR_KEY } from '../../../../shared/constants/storageKeys';
+import { BACKEND_SSOT_MIRROR_KEY, ROUTE_KEY } from '../../../../shared/constants/storageKeys';
 
 jest.mock('@react-native-async-storage/async-storage', () =>
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -30,6 +30,14 @@ jest.mock('../../store/useAlarmEventStore', () => ({
   },
 }));
 
+// #1929 F-W4: notification widget surface가 useDestinationStore.getState().destination로 tripContext 구성.
+const mockDestinationGetState = jest.fn(() => ({ destination: null as { id: string; name: string } | null }));
+jest.mock('../../../route/store/useDestinationStore', () => ({
+  useDestinationStore: {
+    getState: () => mockDestinationGetState(),
+  },
+}));
+
 const scheduleSpy = Notifications.scheduleNotificationAsync as jest.Mock;
 
 describe('notificationRouter wiring (#1575 T12)', () => {
@@ -41,6 +49,7 @@ describe('notificationRouter wiring (#1575 T12)', () => {
     mockSaveStationToWidget.mockClear();
     mockClearWidgetStation.mockClear();
     mockSetAlarmEvent.mockClear();
+    mockDestinationGetState.mockReturnValue({ destination: null });
   });
 
   it('getNotificationRouter returns same singleton on repeat call', () => {
@@ -80,7 +89,7 @@ describe('notificationRouter wiring (#1575 T12)', () => {
     });
   });
 
-  it('widget surface calls saveStationToWidget when station + distanceKm present', async () => {
+  it('widget surface calls saveStationToWidget when station + distanceKm present (destination null → tripContext undefined)', async () => {
     const router = getNotificationRouter();
     const station = { id: '0228', name: '강남', lat: 0, lng: 0 };
     await router.deliver({
@@ -90,7 +99,101 @@ describe('notificationRouter wiring (#1575 T12)', () => {
       content: { title: 'T', body: 'B', data: { station, distanceKm: 0.05 } },
       source: 'fg',
     });
-    expect(mockSaveStationToWidget).toHaveBeenCalledWith(station, 0.05);
+    // #1929 F-W4: destination null → buildWidgetTripContext returns null → undefined forward
+    expect(mockSaveStationToWidget).toHaveBeenCalledWith(station, 0.05, undefined, undefined, undefined);
+  });
+
+  it('#1929 F-W4 — destination + route(direct) 있으면 tripContext stamp (nextTransferName undefined)', async () => {
+    const router = getNotificationRouter();
+    const station = { id: '0228', name: '강남', lat: 0, lng: 0 };
+    const destination = { id: '0240', name: '잠실', lat: 0, lng: 0 };
+    mockDestinationGetState.mockReturnValue({ destination });
+    await AsyncStorage.setItem(
+      ROUTE_KEY,
+      JSON.stringify({ type: 'direct', stops: 5, line: '2', travelSeconds: 600 }),
+    );
+    await router.deliver({
+      alarmId: 'a-3a',
+      eventKey: 'e',
+      surface: 'widget',
+      content: { title: 'T', body: 'B', data: { station, distanceKm: 0.05 } },
+      source: 'fg',
+    });
+    expect(mockSaveStationToWidget).toHaveBeenCalledWith(
+      station,
+      0.05,
+      undefined,
+      undefined,
+      expect.objectContaining({
+        tripActive: true,
+        currentStationName: '강남',
+        destinationName: '잠실',
+        nextTransferName: undefined,
+      }),
+    );
+  });
+
+  it('#1929 F-W4 — destination + route(transfer) 있으면 tripContext에 nextTransferName stamp', async () => {
+    const router = getNotificationRouter();
+    const station = { id: '0228', name: '강남', lat: 0, lng: 0 };
+    const destination = { id: '0240', name: '잠실', lat: 0, lng: 0 };
+    mockDestinationGetState.mockReturnValue({ destination });
+    await AsyncStorage.setItem(
+      ROUTE_KEY,
+      JSON.stringify({
+        type: 'transfer',
+        transferName: '교대',
+        fromLine: '2',
+        toLine: '3',
+        stopsToTransfer: 3,
+        stopsFromTransfer: 4,
+        secondsToTransfer: 360,
+        secondsFromTransfer: 480,
+      }),
+    );
+    await router.deliver({
+      alarmId: 'a-3b',
+      eventKey: 'e',
+      surface: 'widget',
+      content: { title: 'T', body: 'B', data: { station, distanceKm: 0.05 } },
+      source: 'fg',
+    });
+    expect(mockSaveStationToWidget).toHaveBeenCalledWith(
+      station,
+      0.05,
+      undefined,
+      undefined,
+      expect.objectContaining({
+        tripActive: true,
+        nextTransferName: '교대',
+      }),
+    );
+  });
+
+  it('#1929 F-W4 — ROUTE_KEY parse 실패 → route null로 graceful (tripContext에 nextTransferName undefined)', async () => {
+    const router = getNotificationRouter();
+    const station = { id: '0228', name: '강남', lat: 0, lng: 0 };
+    const destination = { id: '0240', name: '잠실', lat: 0, lng: 0 };
+    mockDestinationGetState.mockReturnValue({ destination });
+    await AsyncStorage.setItem(ROUTE_KEY, 'not-json-{{{{');
+    await router.deliver({
+      alarmId: 'a-3c',
+      eventKey: 'e',
+      surface: 'widget',
+      content: { title: 'T', body: 'B', data: { station, distanceKm: 0.05 } },
+      source: 'fg',
+    });
+    // graceful: route null이어도 tripContext는 활성 (destination + currentStation 있음)
+    expect(mockSaveStationToWidget).toHaveBeenCalledWith(
+      station,
+      0.05,
+      undefined,
+      undefined,
+      expect.objectContaining({
+        tripActive: true,
+        nextTransferName: undefined,
+      }),
+    );
   });
 
   it('widget surface no-ops when station or distanceKm missing', async () => {

--- a/src/features/alarm/api/notificationRouter.ts
+++ b/src/features/alarm/api/notificationRouter.ts
@@ -8,6 +8,7 @@
  */
 
 import * as Notifications from 'expo-notifications';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   createNotificationRouter,
   type RouterSsotMirror,
@@ -18,9 +19,30 @@ import {
   clearWidgetStation,
   saveStationToWidget,
 } from '../../widget/api/widgetStorage';
+import { buildWidgetTripContext } from '../../widget/utils/buildTripContext';
+import { useDestinationStore } from '../../route/store/useDestinationStore';
+import { ROUTE_KEY } from '../../../shared/constants/storageKeys';
+import type { Route } from '../../../shared/utils/stationRoute';
 import { readBackendSsotMirror } from '../utils/backendSsotMirror';
 import { useAlarmEventStore } from '../store/useAlarmEventStore';
 import type { AlarmEvent } from '../../../shared/types/alarm';
+import type { Station } from '../../../shared/types/station';
+
+/**
+ * #1929 — notification widget surface(F-W4)에서 ROUTE_KEY storage를 hydrate.
+ * router는 store에 route slice가 없어 async storage access가 유일한 경로.
+ * 미존재 / parse 실패는 graceful null — buildWidgetTripContext가 route undefined로 처리해
+ * nextTransferName undefined로 stamp (trip은 여전히 활성, 환승 정보만 누락).
+ */
+async function readRouteFromStorage(): Promise<Route | null> {
+  try {
+    const raw = await AsyncStorage.getItem(ROUTE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as Route;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * SSoT mirror reader adapter — notice 슬라이스가 alarm의 backendSsotMirror를 직접 못 import하므로
@@ -71,9 +93,22 @@ function buildDefaultSurfaces(): RouterSurfaceFns {
         typeof station === 'object' &&
         typeof distanceKm === 'number'
       ) {
+        // #1929 (F-W4) — tripContext stamp로 SubwayWidget.swift:229 RC-15 expired-gate 활성화.
+        // notification surface는 async caller — destination은 store sync access,
+        // route는 ROUTE_KEY storage에서 async hydrate. 모두 graceful (실패 시 undefined tripContext).
+        const destination = useDestinationStore.getState().destination;
+        const route = await readRouteFromStorage();
+        const tripContext = buildWidgetTripContext({
+          destination,
+          currentStation: station as Station,
+          route,
+        });
         await saveStationToWidget(
-          station as Parameters<typeof saveStationToWidget>[0],
+          station as Station,
           distanceKm,
+          undefined,
+          undefined,
+          tripContext,
         );
       }
     },

--- a/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
@@ -804,7 +804,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   // ── #1237 Phase 2: BG widget writer ──
 
   describe('#1237 — BG tick에서 위젯 SSOT(saveStationToWidget) 갱신', () => {
-    it('nearest 정상 → saveStationToWidget(station, distanceKm) 호출', async () => {
+    it('nearest 정상 → saveStationToWidget(station, distanceKm, undefined, undefined, tripContext) 호출 (#1929 F-W3)', async () => {
       mockStorageValues(JSON.stringify(mockDestination));
       mockProcessLocationUpdate.mockResolvedValue({
         alarmEvent: null,
@@ -816,7 +816,82 @@ describe('backgroundLocationTask defineTask 콜백', () => {
         error: null,
       });
 
-      expect(mockSaveStationToWidget).toHaveBeenCalledWith(mockStation, 0.42);
+      // #1929 F-W3: tripContext stamp — destination 있고 currentStation=nearest이면 tripActive: true
+      expect(mockSaveStationToWidget).toHaveBeenCalledWith(
+        mockStation,
+        0.42,
+        undefined,
+        undefined,
+        expect.objectContaining({
+          tripActive: true,
+          destinationName: mockDestination.name,
+          currentStationName: mockStation.name,
+        }),
+      );
+    });
+
+    it('#1929 F-W3 — direct route(transfer 0개) → nextTransferName undefined로 stamp', async () => {
+      const directRoute = {
+        type: 'direct',
+        stops: 5,
+        line: '2',
+        travelSeconds: 600,
+      };
+      mockStorageValues(JSON.stringify(mockDestination), null, JSON.stringify(directRoute), null);
+      mockProcessLocationUpdate.mockResolvedValue({
+        alarmEvent: null,
+        nearest: { station: mockStation, distanceKm: 0.42 },
+      });
+
+      await taskCallback({
+        data: { locations: [makeLocation(37.498, 127.028)] },
+        error: null,
+      });
+
+      expect(mockSaveStationToWidget).toHaveBeenCalledWith(
+        mockStation,
+        0.42,
+        undefined,
+        undefined,
+        expect.objectContaining({
+          tripActive: true,
+          nextTransferName: undefined,
+        }),
+      );
+    });
+
+    it('#1929 F-W3 — transfer route → nextTransferName으로 transferName stamp', async () => {
+      const transferRoute = {
+        type: 'transfer',
+        transferName: '교대',
+        fromLine: '2',
+        toLine: '3',
+        stopsToTransfer: 3,
+        stopsFromTransfer: 4,
+        secondsToTransfer: 360,
+        secondsFromTransfer: 480,
+      };
+      mockStorageValues(JSON.stringify(mockDestination), null, JSON.stringify(transferRoute), null);
+      mockProcessLocationUpdate.mockResolvedValue({
+        alarmEvent: null,
+        nearest: { station: mockStation, distanceKm: 0.42 },
+      });
+
+      await taskCallback({
+        data: { locations: [makeLocation(37.498, 127.028)] },
+        error: null,
+      });
+
+      expect(mockSaveStationToWidget).toHaveBeenCalledWith(
+        mockStation,
+        0.42,
+        undefined,
+        undefined,
+        expect.objectContaining({
+          tripActive: true,
+          nextTransferName: '교대',
+        }),
+      );
     });
 
     it('nearest가 null이면 saveStationToWidget 호출 X (clearWidgetStation도 호출 X)', async () => {

--- a/src/features/nearest-station/tasks/backgroundLocationTask.ts
+++ b/src/features/nearest-station/tasks/backgroundLocationTask.ts
@@ -33,6 +33,7 @@ import { evaluateMovement } from '../utils/movementGate';
 // #1237 — BG tick에서도 위젯 SSOT(App Groups UserDefaults)를 갱신해 FG 진입 전까지 stale로 남지 않게 한다.
 // cross-feature import는 파일 헤더의 file-level eslint-disable로 옵트인 (orchestrator 본질).
 import { saveStationToWidget } from '../../widget/api/widgetStorage';
+import { buildWidgetTripContext } from '../../widget/utils/buildTripContext';
 // #1281 — BG 환승 자동 detect. FG `useTransferAutoDetect`와 같은 `evaluateTransferSwap` pure 결정을
 // 공유하는 route 슬라이스 orchestrator. cross-feature import는 본 파일 헤더 file-level disable로 옵트인.
 import { evaluateBackgroundTransferSwap } from '../../route/utils/backgroundTransferSwap';
@@ -288,7 +289,15 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
       // #1237 (Phase 2) — 위젯 SSOT 갱신. saveStationToWidget의 module-level 50m bucket dedupe
       // + FRESHNESS_REFRESH_MS는 FG/BG 같은 인스턴스라 자연 동작. null nearest는 호출 X
       // (FG/BG transient null로 widget zap 방지, Phase 3 clear 정책 완화와 정합성).
-      await saveStationToWidget(nearest.station, nearest.distanceKm);
+      // #1929 (F-W3) — tripContext stamp로 SubwayWidget.swift:229 RC-15 expired-gate 활성화.
+      // BG는 React state 없으므로 위에서 hydrate된 destination + storedRoute로 helper 호출.
+      // currentStation은 BG에서 sticky lock이 없어 nearest로 근사 (위젯은 SSoT mirror, FG fusion이 정확성 보장).
+      const bgTripContext = buildWidgetTripContext({
+        destination,
+        currentStation: nearest.station,
+        route: storedRoute,
+      });
+      await saveStationToWidget(nearest.station, nearest.distanceKm, undefined, undefined, bgTripContext);
     }
 
     // #1281 — BG 환승 자동 detect. 주머니 속 환승에서 FG hook 진입점이 없어 옛 노선 lock이

--- a/src/features/widget/utils/__tests__/buildTripContext.test.ts
+++ b/src/features/widget/utils/__tests__/buildTripContext.test.ts
@@ -1,0 +1,154 @@
+import { buildWidgetTripContext } from '../buildTripContext';
+import { MOCK_STATIONS } from '../../../../testUtils/fixtures';
+import type {
+  DirectRoute,
+  TransferRoute,
+  MultiTransferRoute,
+} from '../../../../shared/utils/stationRoute';
+
+describe('buildWidgetTripContext (#1929 RC-15 widget tripContext wire helper)', () => {
+  describe('null 분기 — trip 비활성', () => {
+    it('destination null이면 undefined 반환 (호출자는 5th arg 그대로 forward)', () => {
+      expect(
+        buildWidgetTripContext({
+          destination: null,
+          currentStation: MOCK_STATIONS.gangnam,
+        }),
+      ).toBeUndefined();
+    });
+
+    it('currentStation null이면 undefined 반환 (안전 — current 없이 trip 표시 무의미)', () => {
+      expect(
+        buildWidgetTripContext({
+          destination: MOCK_STATIONS.chungmuro,
+          currentStation: null,
+        }),
+      ).toBeUndefined();
+    });
+
+    it('destination + currentStation 모두 null이면 undefined 반환', () => {
+      expect(
+        buildWidgetTripContext({
+          destination: null,
+          currentStation: null,
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('활성 분기 — trip 활성 + tripActive: true stamp', () => {
+    it('route undefined: nextTransferName undefined로 stamp', () => {
+      const result = buildWidgetTripContext({
+        destination: MOCK_STATIONS.chungmuro,
+        currentStation: MOCK_STATIONS.gangnam,
+      });
+      expect(result).toEqual({
+        currentStationName: '강남',
+        destinationName: '충무로',
+        nextTransferName: undefined,
+        tripActive: true,
+      });
+    });
+
+    it('route null: nextTransferName undefined로 stamp', () => {
+      const result = buildWidgetTripContext({
+        destination: MOCK_STATIONS.chungmuro,
+        currentStation: MOCK_STATIONS.gangnam,
+        route: null,
+      });
+      expect(result).toEqual({
+        currentStationName: '강남',
+        destinationName: '충무로',
+        nextTransferName: undefined,
+        tripActive: true,
+      });
+    });
+
+    it('직통 경로(direct): nextTransferName undefined', () => {
+      const directRoute: DirectRoute = {
+        type: 'direct',
+        stops: 5,
+        line: '2',
+        travelSeconds: 600,
+      };
+      const result = buildWidgetTripContext({
+        destination: MOCK_STATIONS.chungmuro,
+        currentStation: MOCK_STATIONS.gangnam,
+        route: directRoute,
+      });
+      expect(result?.nextTransferName).toBeUndefined();
+      expect(result?.tripActive).toBe(true);
+    });
+
+    it('환승 1회(transfer): route.transferName으로 stamp', () => {
+      const transferRoute: TransferRoute = {
+        type: 'transfer',
+        transferName: '교대',
+        fromLine: '2',
+        toLine: '3',
+        stopsToTransfer: 3,
+        stopsFromTransfer: 4,
+        secondsToTransfer: 360,
+        secondsFromTransfer: 480,
+      };
+      const result = buildWidgetTripContext({
+        destination: MOCK_STATIONS.chungmuro,
+        currentStation: MOCK_STATIONS.gangnam,
+        route: transferRoute,
+      });
+      expect(result).toEqual({
+        currentStationName: '강남',
+        destinationName: '충무로',
+        nextTransferName: '교대',
+        tripActive: true,
+      });
+    });
+
+    it('다중 환승(multi-transfer): transfers[0].transferName으로 stamp', () => {
+      const multiRoute: MultiTransferRoute = {
+        type: 'multi-transfer',
+        transfers: [
+          {
+            transferName: '교대',
+            fromLine: '2',
+            toLine: '3',
+            stopsToTransfer: 3,
+            secondsToTransfer: 360,
+          },
+          {
+            transferName: '동대문',
+            fromLine: '3',
+            toLine: '4',
+            stopsToTransfer: 2,
+            secondsToTransfer: 240,
+          },
+        ],
+        stopsAfterLastTransfer: 5,
+        secondsAfterLastTransfer: 600,
+      };
+      const result = buildWidgetTripContext({
+        destination: MOCK_STATIONS.chungmuro,
+        currentStation: MOCK_STATIONS.gangnam,
+        route: multiRoute,
+      });
+      expect(result?.nextTransferName).toBe('교대');
+      expect(result?.tripActive).toBe(true);
+    });
+
+    it('다중 환승이지만 transfers 빈 배열: nextTransferName undefined (defensive)', () => {
+      const emptyMulti: MultiTransferRoute = {
+        type: 'multi-transfer',
+        transfers: [],
+        stopsAfterLastTransfer: 5,
+        secondsAfterLastTransfer: 600,
+      };
+      const result = buildWidgetTripContext({
+        destination: MOCK_STATIONS.chungmuro,
+        currentStation: MOCK_STATIONS.gangnam,
+        route: emptyMulti,
+      });
+      expect(result?.nextTransferName).toBeUndefined();
+      expect(result?.tripActive).toBe(true);
+    });
+  });
+});

--- a/src/features/widget/utils/buildTripContext.ts
+++ b/src/features/widget/utils/buildTripContext.ts
@@ -1,0 +1,62 @@
+import type { Station } from '../../../shared/types/station';
+import type { Route } from '../../../shared/utils/stationRoute';
+import type { WidgetTripContext } from '../api/widgetStorage';
+
+/**
+ * #1929 — widget tripContext wire helper.
+ *
+ * 4곳의 호출자(useWidgetMirror, HomeScreen AppState force, backgroundLocationTask,
+ * notificationRouter)가 동일 로직으로 `WidgetTripContext`를 구성해 `saveStationToWidget`의
+ * 5th arg로 forward하기 위한 DRY 진입점.
+ *
+ * 입력 매트릭스 (4 시나리오):
+ *  - destination null → undefined (trip 비활성, 호출자는 그대로 5th arg에 forward)
+ *  - currentStation null → undefined (안전 — current 없이는 trip 표시 무의미)
+ *  - route direct (transfer 0개) → `nextTransferName: undefined`, 직통 trip 활성
+ *  - route transfer/multi-transfer → `nextTransferName: route.transferName ?? transfers[0].transferName`, 환승 trip 활성
+ *
+ * 반환 타입이 `WidgetTripContext | undefined`인 이유: `saveStationToWidget`의 5th arg가
+ * `WidgetTripContext | undefined`이므로 null 대신 undefined를 반환해 호출부에서 `?? undefined`
+ * 같은 임시 변환을 제거한다 (호출자는 결과를 그대로 5th arg에 forward 가능).
+ *
+ * 위젯 측 `SubwayWidget.swift:229` `if entry.tripActive, ..., freshness != .expired`
+ * 가드는 본 helper가 `tripActive: true`를 stamp해야만 진입 가능 — RC-15 효과는 4곳
+ * 동시 wire 후에야 작동한다.
+ */
+export interface BuildTripContextArgs {
+  destination: Station | null;
+  currentStation: Station | null;
+  /**
+   * 사용자 현재 trip의 route. 4 호출자 모두 같은 source 사용 시 동일 로직 보장.
+   *  - FG: HomeScreen `route` (selectedKey 기반 derive).
+   *  - BG: `ROUTE_KEY` AsyncStorage 파싱.
+   *  - notification: store/payload에서 read.
+   *
+   * null/undefined 또는 direct 타입이면 `nextTransferName` undefined.
+   */
+  route?: Route | null;
+}
+
+/**
+ * 환승 정보가 있는 Route에서 다음 환승역 이름 추출. 호출자에서 깊은 체이닝 회피 + DRY.
+ */
+function extractNextTransferName(route: Route | null | undefined): string | undefined {
+  if (!route) return undefined;
+  if (route.type === 'direct') return undefined;
+  if (route.type === 'transfer') return route.transferName;
+  const firstSegment = route.transfers[0];
+  return firstSegment?.transferName;
+}
+
+export function buildWidgetTripContext(
+  args: BuildTripContextArgs,
+): WidgetTripContext | undefined {
+  const { destination, currentStation, route } = args;
+  if (!destination || !currentStation) return undefined;
+  return {
+    currentStationName: currentStation.name,
+    destinationName: destination.name,
+    nextTransferName: extractNextTransferName(route),
+    tripActive: true,
+  };
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -26,6 +26,7 @@ import { getStationDisplayName } from '../shared/utils/stationDisplay';
 import { initStationNotification, updateStationNotification, clearStationNotification, clearAlarmNotification } from '../features/alarm/utils/stationNotification';
 import { useWidgetMirror } from '../features/widget/hooks/useWidgetMirror';
 import { saveStationToWidget } from '../features/widget/api/widgetStorage';
+import { buildWidgetTripContext } from '../features/widget/utils/buildTripContext';
 import { useStationAlarm } from '../features/alarm/hooks/useStationAlarm';
 import { useMotionActivity } from '../features/nearest-station/hooks/useMotionActivity';
 import { useAccelerometer } from '../features/nearest-station/hooks/useAccelerometer';
@@ -376,6 +377,12 @@ export default function HomeScreen() {
   // 위젯 currentStation을 강제 동기화. listener는 단일-바인딩이라 latest liveResult를 ref로 stamp.
   const liveResultRef = useRef(liveResult);
   liveResultRef.current = liveResult;
+  // #1929 (F-W2) — AppState force 경로에서 tripContext stamp 위해 destination/route 최신값 ref.
+  // useEffect [] 안에 위치한 listener는 destination/route를 직접 못 잡으므로 ref로 forward.
+  const destinationRef = useRef(destination);
+  destinationRef.current = destination;
+  const routeRef = useRef(route);
+  routeRef.current = route;
   // #1755 — lockless badge tap → scroll to boarding list. ScrollView ref + target Y.
   const scrollViewRef = useRef<ScrollView>(null);
   const boardingListYRef = useRef<number>(0);
@@ -839,9 +846,15 @@ export default function HomeScreen() {
         // useWidgetMirror가 같은 bucket/station이면 reload skip이라 BG에서 FG 복귀 시 위젯이
         // 잘못된 station에 stuck되는 회귀(2026-06-19 반포 stuck) 발생. force=true로 dedupe 우회.
         // liveResult는 raw GPS 최근접(sticky override 없음) — useWidgetMirror와 동일 SSoT.
+        // #1929 (F-W2) — tripContext를 5th arg로 forward해 RC-15 widget expired-gate(SubwayWidget.swift:229) 활성화.
         const live = liveResultRef.current;
         if (live) {
-          void saveStationToWidget(live.station, live.distanceKm, Date.now(), { force: true }).catch((e) =>
+          const tripContext = buildWidgetTripContext({
+            destination: destinationRef.current,
+            currentStation: live.station,
+            route: routeRef.current,
+          });
+          void saveStationToWidget(live.station, live.distanceKm, Date.now(), { force: true }, tripContext).catch((e) =>
             logger.error('R9-a force-save 실패:', e),
           );
         }
@@ -862,7 +875,19 @@ export default function HomeScreen() {
   // #1568 (T8b, Epic ADR-017 #1553) — sticky 격리: fused result는 sticky:locked override가 들어가
   // 위젯에 stuck되는 회귀("반포 stuck") 회피하려고 raw GPS 최근접(liveResult)을 전달한다.
   // 위젯은 boardingLock·trip context와 무관한 ambient display 채널이라 sticky override 의무 없음.
-  useWidgetMirror(liveResult?.station ?? null, liveResult?.distanceKm ?? null);
+  //
+  // #1929 (F-W1) — trip 활성 시 tripContext를 forward해 SubwayWidget.swift:229 RC-15 expired-gate 진입.
+  // trip 비활성(destination/currentStation null)이면 helper가 undefined 반환 → 기존 nearest UI 유지.
+  const widgetTripContext = useMemo(
+    () =>
+      buildWidgetTripContext({
+        destination,
+        currentStation: liveResult?.station ?? null,
+        route,
+      }),
+    [destination, liveResult?.station, route],
+  );
+  useWidgetMirror(liveResult?.station ?? null, liveResult?.distanceKm ?? null, widgetTripContext);
 
   useEffect(() => {
     const prevDestId = prevDestIdRef.current;


### PR DESCRIPTION
## Summary
- 4 호출자 tripContext wire + buildWidgetTripContext helper 신규
- PR #1911 RC-15 widget timestamp staleness gate (`SubwayWidget.swift:229` `if entry.tripActive, ..., freshness != .expired`) **dead branch 복구**
- `WidgetTripContext` interface(widgetStorage.ts:59) + native `saveWidgetTripContext`(LiveActivityModule.swift:86) 둘 다 존재했으나, production 호출자 4곳 모두 `tripContext` 인자(5th arg) 미전달 → `tripActive` 항상 false → 가드 dead branch
- helper 단일 진입점 사용으로 새 호출자 추가 시 DRY 보존 (Karpathy Skills #3 extensibility)

### Wire 위치
| 호출자 | 위치 | 매핑 |
|---|---|---|
| F-W1 useWidgetMirror | `src/screens/HomeScreen.tsx:879` | useMemo tripContext → hook 3rd arg |
| F-W2 AppState force | `src/screens/HomeScreen.tsx:844` | destinationRef/routeRef → 5th arg |
| F-W3 backgroundLocationTask | `src/features/nearest-station/tasks/backgroundLocationTask.ts:296` | destination + storedRoute → 5th arg |
| F-W4 notificationRouter | `src/features/alarm/api/notificationRouter.ts:96` | useDestinationStore.getState() + ROUTE_KEY async hydrate |

Closes #1929

## Wire-completion 5단 체크
1. **Orphan 없음** — `npm run lint:orphan` pass (확인 완료). helper 신규 추가 시 caller 4곳 동시 wire하므로 자동 차단.
2. **V/X dashboard** — DebugModal widget surface 섹션 + SharedGroupPreferences `tripActive` 키. 위젯 freshness tier (fresh/stale/expired) 표시 follow-up.
3. **의존 PR** — PR #1911 (RC-15 widget timestamp staleness gate) + PR #1781 (`saveWidgetTripContext` native API) 둘 다 머지됨.
4. **측정 plan** — 1주 trip 종료 후:
   - widget `tripActive` 키 stamped 카운트 (`defaults read group.com.subwaynow.app tripActive` 시뮬레이터 확인)
   - expired tier(10분+) 진입 시 trip 분기 차단되어 nearestStation 분기로 폴백되는지 캡처
   - boardingPrompt 1주 0건 + widget stale UI evidence 1건 이상
5. **Device verify** — 실기기 trip 등록 후 위젯 화면 캡처 + AppState 'active' 복귀 시 갱신 + 종료 10분 후 expired UI(opacity 0.45 + "정보 오래됨" caption) 확인.

## Test plan
- [x] `npm test` 커버리지 100% (8363/8363 PASS)
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass (0 orphan)
- [x] code-review: 0 critical findings
- [ ] 실기기 trip 1회 등록 → widget 화면 trip context 표시 확인
- [ ] trip 종료 10분 후 expired tier UI 확인 (RC-15 효과)

## 변경 파일
- `src/features/widget/utils/buildTripContext.ts` (신규)
- `src/features/widget/utils/__tests__/buildTripContext.test.ts` (신규, 9 cases)
- `src/screens/HomeScreen.tsx` (F-W1 + F-W2)
- `src/features/nearest-station/tasks/backgroundLocationTask.ts` (F-W3)
- `src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts` (F-W3 신규 케이스 2)
- `src/features/alarm/api/notificationRouter.ts` (F-W4)
- `src/features/alarm/api/__tests__/notificationRouter.test.ts` (F-W4 신규 케이스 3)