### PR TITLE
feat(#1935): silentPushTask widget storage update wire — WhileInUse BG widget 회복

### DIFF
--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -139,6 +139,22 @@ jest.mock('../../utils/refreshLiveActivityFromBackgroundContext', () => ({
   refreshLiveActivityFromBackgroundContext: () => mockRefreshLa(),
 }));
 
+// #1935 — silent push finally에서 호출하는 widget update wire. mock로 호출 인자/횟수 검증.
+const mockUpdateWidget = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../widget/utils/updateWidgetFromSilentPush', () => ({
+  updateWidgetFromSilentPush: (...args: unknown[]) => mockUpdateWidget(...args),
+}));
+
+// #1935 — widget update 호출 전 storage context read. mock로 read 결과만 격리.
+const mockReadWidgetCtx = jest.fn().mockResolvedValue({
+  destination: null,
+  route: null,
+  bgContext: null,
+});
+jest.mock('../../utils/widgetRefreshContext', () => ({
+  readWidgetRefreshContext: () => mockReadWidgetCtx(),
+}));
+
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
     debug: jest.fn(),
@@ -3150,6 +3166,108 @@ describe('silentPushTask', () => {
         mockGetDismissSilence.mockResolvedValue(null);
         await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
         expect(mockCheckGate).toHaveBeenCalled();
+      });
+    });
+
+    // #1935 — silent push finally 블록에서 widget update wire 호출 검증.
+    // WhileInUse paradigm 충족 — 권한 무관 채널에서 BG widget 갱신.
+    describe('#1935 — widget update wire (finally 블록)', () => {
+      it('valid payload면 finally에서 updateWidgetFromSilentPush 호출 (ssot/bgContext/destination/route 전달)', async () => {
+        const ctx = {
+          destination: { id: 'd1', name: '잠실', line: '2', lineColor: '#0', lat: 37.5, lng: 127.1 },
+          route: { type: 'direct', line: '2', stops: 3, travelSeconds: 240 },
+          bgContext: { station: { id: 's1', name: '강남' }, distanceKm: 0.15, timestamp: 0 },
+        };
+        mockReadWidgetCtx.mockResolvedValueOnce(ctx);
+        // validSsotMirror가 narrow하는 필드만 사용 — currentStationLine은 mirror entry에만 추가됨(#1705)
+        // 이라 silent push payload validator는 drop. widget update는 name-only fallback으로 동작.
+        const ssotPayload = {
+          currentStationId: '역삼',
+          motionState: 'moving',
+          lastAdvanceEvidence: 'arc-overshoot',
+          lastAdvanceAt: 1_700_000_000_000,
+          passedStations: [],
+        };
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', ssot: ssotPayload }),
+        );
+        expect(mockReadWidgetCtx).toHaveBeenCalledTimes(1);
+        expect(mockUpdateWidget).toHaveBeenCalledTimes(1);
+        const [ssotArg, bgArg, destArg, routeArg] = mockUpdateWidget.mock.calls[0];
+        expect(ssotArg).toEqual(ssotPayload);
+        expect(bgArg).toBe(ctx.bgContext);
+        expect(destArg).toBe(ctx.destination);
+        expect(routeArg).toBe(ctx.route);
+      });
+
+      it('reschedule payload는 ssot 필드 없음 — undefined로 전달, BG context fallback', async () => {
+        mockReadWidgetCtx.mockResolvedValueOnce({
+          destination: null,
+          route: null,
+          bgContext: null,
+        });
+        await handleSilentPush({
+          data: bgTaskData({
+            kind: 'reschedule',
+            nextStation: '잠실',
+            newArrivalTimeEpoch: Date.now() + 60_000,
+            trainCode: 'T-1',
+            pushId: 'rs-1',
+          }),
+        });
+        expect(mockUpdateWidget).toHaveBeenCalledTimes(1);
+        expect(mockUpdateWidget.mock.calls[0][0]).toBeUndefined();
+      });
+
+      it('trip-ended payload도 ssot 없음 — undefined로 전달', async () => {
+        mockReadWidgetCtx.mockResolvedValueOnce({
+          destination: null,
+          route: null,
+          bgContext: null,
+        });
+        await handleSilentPush({
+          data: bgTaskData({
+            kind: 'trip-ended',
+            reason: 'destination-arrived',
+            pushId: 'te-1',
+          }),
+        });
+        expect(mockUpdateWidget).toHaveBeenCalledTimes(1);
+        expect(mockUpdateWidget.mock.calls[0][0]).toBeUndefined();
+      });
+
+      it('invalid payload (extract null)면 readWidgetRefreshContext / updateWidgetFromSilentPush 호출 안 함', async () => {
+        await handleSilentPush({ data: undefined });
+        expect(mockReadWidgetCtx).not.toHaveBeenCalled();
+        expect(mockUpdateWidget).not.toHaveBeenCalled();
+      });
+
+      it('input.error 분기에서도 widget update 호출 안 함 (payload 미extract)', async () => {
+        await handleSilentPush({ error: { message: 'boom' } });
+        expect(mockReadWidgetCtx).not.toHaveBeenCalled();
+        expect(mockUpdateWidget).not.toHaveBeenCalled();
+      });
+
+      it('updateWidgetFromSilentPush throw해도 본 흐름은 graceful (LA refresh도 호출됨)', async () => {
+        mockReadWidgetCtx.mockResolvedValueOnce({
+          destination: null,
+          route: null,
+          bgContext: null,
+        });
+        mockUpdateWidget.mockRejectedValueOnce(new Error('widget-fail'));
+        await expect(
+          handleSilentPush(payload({ kind: 'destination', phase: 'imminent' })),
+        ).resolves.toBeUndefined();
+        // LA refresh와 격리되어 둘 다 호출
+        expect(mockRefreshLa).toHaveBeenCalled();
+      });
+
+      it('readWidgetRefreshContext throw해도 graceful (LA refresh 동작 보존)', async () => {
+        mockReadWidgetCtx.mockRejectedValueOnce(new Error('storage-fail'));
+        await expect(
+          handleSilentPush(payload({ kind: 'destination', phase: 'imminent' })),
+        ).resolves.toBeUndefined();
+        expect(mockRefreshLa).toHaveBeenCalled();
       });
     });
   });

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -86,6 +86,8 @@ import type { Route } from '../../../shared/utils/stationRoute';
 import { alarmKey, type AlarmEvent } from '../utils/stationAlarm';
 import { buildAlarmContent, sendTripEndedNotification } from '../utils/stationNotification';
 import { refreshLiveActivityFromBackgroundContext } from '../utils/refreshLiveActivityFromBackgroundContext';
+import { updateWidgetFromSilentPush } from '../../widget/utils/updateWidgetFromSilentPush';
+import { readWidgetRefreshContext } from '../utils/widgetRefreshContext';
 import { type NotificationSource } from '../utils/notificationSource';
 import { getFiredAlarms, setFiredAlarms } from '../utils/notificationState';
 import { getBoardingLock } from '../utils/boardingLockStorage';
@@ -752,6 +754,9 @@ async function loadApnsToken(): Promise<string | null> {
  * Task 콜백 본체 — 단위 테스트가 직접 호출할 수 있도록 export.
  */
 export async function handleSilentPush(input: NotificationBackgroundTaskData): Promise<void> {
+  // #1935 — finally 블록에서 widget update가 payload.ssot 또는 standard kind를 활용하려면
+  // payload가 outer scope에 있어야 한다. valid extract 후 assign; invalid면 null 유지.
+  let payload: ExtractedPayload | null = null;
   // #735 — BG task 시간 제약. 모든 종료 경로(early return, fire-with-gate, error)에서 적재된
   // alarmLog pending이 OS suspend로 손실되지 않도록 try/finally로 명시 flush.
   try {
@@ -760,7 +765,7 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
       return;
     }
 
-    const payload = extractPayload(input.data);
+    payload = extractPayload(input.data);
     if (!payload) {
       logger.info('payload missing or invalid — skip');
       return;
@@ -967,11 +972,41 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     // update가 ActivityKit lock으로 수 초 stall 가능. BG task 시간 예산(~25s)을 LA가 잠식하면
     // alarmLog가 손실(#735 회귀). 측정 인프라(alarmLog)가 항상 보호되도록 LA를 뒤에 둔다.
     await flushAlarmLog();
-    try {
-      await refreshLiveActivityFromBackgroundContext();
-    } catch (e) {
-      logger.error('refreshLiveActivityFromBackgroundContext 실패:', e);
+    // #1935 — LA + widget refresh. 권한(Always/WhileInUse) 무관 채널.
+    //   - LA: `refreshLiveActivityFromBackgroundContext`가 처리 (#900 Seam D, 기존 동작)
+    //   - widget: `updateWidgetFromSilentPush`가 처리 — WhileInUse 사용자 BG widget 회복
+    //     (paradigm `feedback_whileinuse_must_work` 정신 충족).
+    //
+    // Promise.allSettled로 격리해 한 채널 실패가 다른 채널을 막지 않게 한다. payload가
+    // null(invalid extract)인 경우 widget update는 skip — 신호 부재로 더 stale을 유발하지 않는다.
+    const tasks: Array<Promise<unknown>> = [
+      refreshLiveActivityFromBackgroundContext().catch((e) => {
+        logger.error('refreshLiveActivityFromBackgroundContext 실패:', e);
+      }),
+    ];
+    if (payload !== null) {
+      tasks.push(refreshWidgetForPayload(payload));
     }
+    await Promise.allSettled(tasks);
+  }
+}
+
+/**
+ * #1935 — silent push 채널 widget update wrapper.
+ *
+ * payload가 standard SilentPushPayload(ssot 필드 가능)일 때 SSoT를 우선 사용,
+ * reschedule / trip-ended payload는 ssot가 없으므로 BG context fallback만 활용.
+ * trip-ended는 trip을 종료시키지만 widget도 같은 신호로 freshness 갱신.
+ *
+ * `readWidgetRefreshContext` + `updateWidgetFromSilentPush` 조합. 예외는 swallow.
+ */
+async function refreshWidgetForPayload(payload: ExtractedPayload): Promise<void> {
+  try {
+    const ctx = await readWidgetRefreshContext();
+    const ssot = 'ssot' in payload ? payload.ssot : undefined;
+    await updateWidgetFromSilentPush(ssot, ctx.bgContext, ctx.destination, ctx.route);
+  } catch (e) {
+    logger.error('updateWidgetFromSilentPush 실패:', e);
   }
 }
 

--- a/src/features/alarm/utils/__tests__/widgetRefreshContext.test.ts
+++ b/src/features/alarm/utils/__tests__/widgetRefreshContext.test.ts
@@ -1,0 +1,136 @@
+/**
+ * #1935 — silent push handler가 widget update 시 필요한 BG 컨텍스트(destination/route/bgStation)를
+ * 1회 read로 묶어주는 helper 검증.
+ *
+ * AsyncStorage는 mock해 storage 결과별 narrow 분기 검증.
+ */
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { readWidgetRefreshContext } from '../widgetRefreshContext';
+import {
+  BG_LAST_STATION_KEY,
+  DESTINATION_KEY,
+  ROUTE_KEY,
+} from '../../../../shared/constants/storageKeys';
+import type { Station } from '../../../../shared/types/station';
+import type { Route } from '../../../../shared/utils/stationRoute';
+
+const destination: Station = {
+  id: '0220',
+  name: '잠실',
+  line: '2',
+  lineColor: '#009933',
+  lat: 37.513,
+  lng: 127.1,
+};
+
+const bgStation: Station = {
+  id: '0226',
+  name: '역삼',
+  line: '2',
+  lineColor: '#009933',
+  lat: 37.5,
+  lng: 127.04,
+};
+
+const directRoute: Route = { type: 'direct', line: '2', stops: 3, travelSeconds: 240 };
+
+function setupStorage(values: Partial<Record<string, string | null>>): void {
+  (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+    return values[key] ?? null;
+  });
+}
+
+describe('readWidgetRefreshContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('모두 정상이면 3개 필드 채워서 반환', async () => {
+    const bg = { station: bgStation, distanceKm: 0.15, timestamp: 1_700_000_000_000 };
+    setupStorage({
+      [DESTINATION_KEY]: JSON.stringify(destination),
+      [ROUTE_KEY]: JSON.stringify(directRoute),
+      [BG_LAST_STATION_KEY]: JSON.stringify(bg),
+    });
+    const result = await readWidgetRefreshContext();
+    expect(result.destination).toEqual(destination);
+    expect(result.route).toEqual(directRoute);
+    expect(result.bgContext).toEqual(bg);
+  });
+
+  it('모두 null이면 모두 null 필드로 반환', async () => {
+    setupStorage({});
+    const result = await readWidgetRefreshContext();
+    expect(result.destination).toBeNull();
+    expect(result.route).toBeNull();
+    expect(result.bgContext).toBeNull();
+  });
+
+  describe('destination narrow', () => {
+    it('손상 JSON → null', async () => {
+      setupStorage({ [DESTINATION_KEY]: '{{ broken' });
+      const result = await readWidgetRefreshContext();
+      expect(result.destination).toBeNull();
+    });
+
+    it('id 부재 → null', async () => {
+      setupStorage({ [DESTINATION_KEY]: JSON.stringify({ name: 'x' }) });
+      const result = await readWidgetRefreshContext();
+      expect(result.destination).toBeNull();
+    });
+  });
+
+  describe('route narrow', () => {
+    it('손상 JSON → null', async () => {
+      setupStorage({ [ROUTE_KEY]: '{{ broken' });
+      const result = await readWidgetRefreshContext();
+      expect(result.route).toBeNull();
+    });
+  });
+
+  describe('bgContext narrow', () => {
+    it('손상 JSON → null', async () => {
+      setupStorage({ [BG_LAST_STATION_KEY]: '{{ broken' });
+      const result = await readWidgetRefreshContext();
+      expect(result.bgContext).toBeNull();
+    });
+
+    it('distanceKm 비-number → null', async () => {
+      setupStorage({
+        [BG_LAST_STATION_KEY]: JSON.stringify({
+          station: bgStation,
+          distanceKm: 'not-a-number',
+        }),
+      });
+      const result = await readWidgetRefreshContext();
+      expect(result.bgContext).toBeNull();
+    });
+
+    it('station 부재 → null', async () => {
+      setupStorage({ [BG_LAST_STATION_KEY]: JSON.stringify({ distanceKm: 0.1 }) });
+      const result = await readWidgetRefreshContext();
+      expect(result.bgContext).toBeNull();
+    });
+
+    it('parsed 자체가 비-object(예: number) → null', async () => {
+      setupStorage({ [BG_LAST_STATION_KEY]: '42' });
+      const result = await readWidgetRefreshContext();
+      expect(result.bgContext).toBeNull();
+    });
+  });
+
+  it('AsyncStorage throw → 모두 null (graceful)', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValue(new Error('IO'));
+    const result = await readWidgetRefreshContext();
+    expect(result).toEqual({
+      destination: null,
+      route: null,
+      bgContext: null,
+    });
+  });
+});

--- a/src/features/alarm/utils/widgetRefreshContext.ts
+++ b/src/features/alarm/utils/widgetRefreshContext.ts
@@ -1,0 +1,85 @@
+/**
+ * #1935 — silent push handler가 widget update 시 필요한 BG 컨텍스트(destination/route/bgStation)를
+ * AsyncStorage에서 한 번에 읽어오는 단일 진입점.
+ *
+ * `refreshLiveActivityFromBackgroundContext`도 같은 storage 3개 키를 읽지만 그 내부 readers가
+ * private이라 외부 caller(silent push handler)가 재사용할 수 없었다. 본 helper는 read-only
+ * pure 변환 — silent push handler가 LA refresh와 widget update 양쪽에 동일한 컨텍스트를
+ * 1회 read로 공급하도록 한다 (BG task 시간 예산 보호).
+ *
+ * 손상 / 부재 시 각 필드 null. caller no-op (`updateWidgetFromSilentPush`가 graceful skip).
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  BG_LAST_STATION_KEY,
+  DESTINATION_KEY,
+  ROUTE_KEY,
+} from '../../../shared/constants/storageKeys';
+import type { Station } from '../../../shared/types/station';
+import type { Route } from '../../../shared/utils/stationRoute';
+import type { BgLastStationContext } from '../../../shared/types/widgetRefresh';
+
+export interface WidgetRefreshContext {
+  destination: Station | null;
+  route: Route;
+  bgContext: BgLastStationContext | null;
+}
+
+function safeParse<T>(raw: string | null): T | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * destination: id 필드까지 narrow. id 부재 시 null (corrupt entry 자동 폐기).
+ */
+function parseDestination(raw: string | null): Station | null {
+  const parsed = safeParse<Partial<Station>>(raw);
+  if (!parsed || typeof parsed.id !== 'string') return null;
+  return parsed as Station;
+}
+
+/**
+ * BG_LAST_STATION_KEY 형식 narrow. `backgroundLocationTask`가 적재한 형태와 1:1
+ * (`refreshLiveActivityFromBackgroundContext`의 `BgLastStation`과 동일 shape).
+ *
+ * - parsed가 null / 비-object / distanceKm 비-number / station 부재 → null.
+ */
+function parseBgLastStation(raw: string | null): BgLastStationContext | null {
+  const parsed = safeParse<unknown>(raw);
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    typeof (parsed as { distanceKm?: unknown }).distanceKm !== 'number' ||
+    !(parsed as { station?: unknown }).station
+  ) {
+    return null;
+  }
+  return parsed as BgLastStationContext;
+}
+
+/**
+ * silent push finally 블록에서 호출. read 실패는 swallow — silent push 본 흐름을 막지 않는다.
+ * BG task 시간 예산 보호를 위해 3개 키를 병렬 read.
+ */
+export async function readWidgetRefreshContext(): Promise<WidgetRefreshContext> {
+  try {
+    const [destRaw, routeRaw, bgRaw] = await Promise.all([
+      AsyncStorage.getItem(DESTINATION_KEY),
+      AsyncStorage.getItem(ROUTE_KEY),
+      AsyncStorage.getItem(BG_LAST_STATION_KEY),
+    ]);
+    return {
+      destination: parseDestination(destRaw),
+      route: safeParse<Route>(routeRaw),
+      bgContext: parseBgLastStation(bgRaw),
+    };
+  } catch {
+    return { destination: null, route: null, bgContext: null };
+  }
+}

--- a/src/features/widget/utils/__tests__/lookupStationFromSsot.test.ts
+++ b/src/features/widget/utils/__tests__/lookupStationFromSsot.test.ts
@@ -1,0 +1,120 @@
+/**
+ * #1935 — silent push payload SSoT + BG context fallback로 widget update용 station/distance를
+ * 결정하는 helper 검증.
+ *
+ * stationLookup은 stations.json 의존이라 직접 mock해 분기 검증을 격리.
+ */
+
+const mockFindByName = jest.fn();
+const mockFindByNameAndLine = jest.fn();
+jest.mock('../../../../shared/utils/stationLookup', () => ({
+  findStationByName: (...args: unknown[]) => mockFindByName(...args),
+  findStationByNameAndLine: (...args: unknown[]) => mockFindByNameAndLine(...args),
+}));
+
+import {
+  lookupStationFromSsot,
+  type BgLastStationContext,
+  type SsotStationInput,
+} from '../lookupStationFromSsot';
+import type { Station } from '../../../../shared/types/station';
+
+const ssotStation: Station = {
+  id: '0226',
+  name: '역삼',
+  line: '2',
+  lineColor: '#009933',
+  lat: 37.5,
+  lng: 127.04,
+};
+
+const bgStation: Station = {
+  id: '0228',
+  name: '강남',
+  line: '2',
+  lineColor: '#009933',
+  lat: 37.498,
+  lng: 127.027,
+};
+
+const bgContext: BgLastStationContext = {
+  station: bgStation,
+  distanceKm: 0.15,
+  timestamp: 1_700_000_000_000,
+};
+
+describe('lookupStationFromSsot', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindByName.mockReturnValue(null);
+    mockFindByNameAndLine.mockReturnValue(null);
+  });
+
+  describe('SSoT 우선', () => {
+    it('SSoT에 currentStationLine 있으면 findStationByNameAndLine으로 line 정확 매칭, distance=0', () => {
+      mockFindByNameAndLine.mockReturnValue(ssotStation);
+      const ssot: SsotStationInput = {
+        currentStationId: '역삼',
+        currentStationLine: '2',
+      };
+      const result = lookupStationFromSsot(ssot, bgContext);
+      expect(mockFindByNameAndLine).toHaveBeenCalledWith('역삼', '2');
+      expect(mockFindByName).not.toHaveBeenCalled();
+      expect(result).toEqual({ station: ssotStation, distanceKm: 0 });
+    });
+
+    it('SSoT에 currentStationLine 없으면 findStationByName으로 name-only fallback', () => {
+      mockFindByName.mockReturnValue(ssotStation);
+      const ssot: SsotStationInput = { currentStationId: '역삼' };
+      const result = lookupStationFromSsot(ssot, bgContext);
+      expect(mockFindByName).toHaveBeenCalledWith('역삼');
+      expect(mockFindByNameAndLine).not.toHaveBeenCalled();
+      expect(result).toEqual({ station: ssotStation, distanceKm: 0 });
+    });
+
+    it('SSoT lookup 실패 → BG context fallback (line 매칭 실패 케이스)', () => {
+      mockFindByNameAndLine.mockReturnValue(null);
+      const ssot: SsotStationInput = {
+        currentStationId: '존재안함',
+        currentStationLine: '99' as unknown as string,
+      };
+      const result = lookupStationFromSsot(ssot, bgContext);
+      expect(result).toEqual({ station: bgStation, distanceKm: 0.15 });
+    });
+
+    it('SSoT lookup 실패 (name-only) → BG context fallback', () => {
+      mockFindByName.mockReturnValue(null);
+      const ssot: SsotStationInput = { currentStationId: '존재안함' };
+      const result = lookupStationFromSsot(ssot, bgContext);
+      expect(result).toEqual({ station: bgStation, distanceKm: 0.15 });
+    });
+  });
+
+  describe('BG context fallback', () => {
+    it('SSoT null이면 BG context 사용', () => {
+      const result = lookupStationFromSsot(null, bgContext);
+      expect(mockFindByName).not.toHaveBeenCalled();
+      expect(mockFindByNameAndLine).not.toHaveBeenCalled();
+      expect(result).toEqual({ station: bgStation, distanceKm: 0.15 });
+    });
+
+    it('SSoT undefined도 BG context 사용', () => {
+      const result = lookupStationFromSsot(undefined, bgContext);
+      expect(result).toEqual({ station: bgStation, distanceKm: 0.15 });
+    });
+  });
+
+  describe('둘 다 없음', () => {
+    it('SSoT null + BG context null → null', () => {
+      const result = lookupStationFromSsot(null, null);
+      expect(result).toBeNull();
+    });
+
+    it('SSoT lookup 실패 + BG context null → null', () => {
+      mockFindByName.mockReturnValue(null);
+      const ssot: SsotStationInput = { currentStationId: '존재안함' };
+      const result = lookupStationFromSsot(ssot, null);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/features/widget/utils/__tests__/updateWidgetFromSilentPush.test.ts
+++ b/src/features/widget/utils/__tests__/updateWidgetFromSilentPush.test.ts
@@ -1,0 +1,212 @@
+/**
+ * #1935 — silent push 채널 widget storage update wire 검증.
+ *
+ * payload SSoT 우선 + BG context fallback + destination/route 기반 tripContext 구성.
+ * saveStationToWidget + lookupStationFromSsot는 mock으로 격리해 wire 자체만 검증.
+ */
+
+const mockSaveStationToWidget = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../api/widgetStorage', () => ({
+  saveStationToWidget: (...args: unknown[]) => mockSaveStationToWidget(...args),
+}));
+
+const mockLookup = jest.fn();
+jest.mock('../lookupStationFromSsot', () => ({
+  lookupStationFromSsot: (...args: unknown[]) => mockLookup(...args),
+}));
+
+import { updateWidgetFromSilentPush } from '../updateWidgetFromSilentPush';
+import type { BgLastStationContext, SsotStationInput } from '../lookupStationFromSsot';
+import type { Station } from '../../../../shared/types/station';
+import type { Route } from '../../../../shared/utils/stationRoute';
+
+const station: Station = {
+  id: '0226',
+  name: '역삼',
+  line: '2',
+  lineColor: '#009933',
+  lat: 37.5,
+  lng: 127.04,
+};
+
+const destination: Station = {
+  id: '0220',
+  name: '잠실',
+  line: '2',
+  lineColor: '#009933',
+  lat: 37.513,
+  lng: 127.1,
+};
+
+const ssot: SsotStationInput = {
+  currentStationId: '역삼',
+  currentStationLine: '2',
+};
+
+const bgContext: BgLastStationContext = {
+  station,
+  distanceKm: 0.15,
+  timestamp: 1_700_000_000_000,
+};
+
+const directRoute: Route = { type: 'direct', line: '2', stops: 3, travelSeconds: 240 };
+const transferRoute: Route = {
+  type: 'transfer',
+  transferName: '건대입구',
+  fromLine: '2',
+  toLine: '7',
+  stopsToTransfer: 2,
+  stopsFromTransfer: 5,
+  secondsToTransfer: 180,
+  secondsFromTransfer: 360,
+};
+const multiTransferRoute: Route = {
+  type: 'multi-transfer',
+  transfers: [
+    {
+      transferName: '왕십리',
+      fromLine: '2',
+      toLine: '5',
+      stopsToTransfer: 1,
+      secondsToTransfer: 100,
+    },
+    {
+      transferName: '천호',
+      fromLine: '5',
+      toLine: '8',
+      stopsToTransfer: 4,
+      secondsToTransfer: 320,
+    },
+  ],
+  stopsAfterLastTransfer: 2,
+  secondsAfterLastTransfer: 180,
+};
+
+describe('updateWidgetFromSilentPush', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLookup.mockReturnValue({ station, distanceKm: 0 });
+  });
+
+  it('SSoT 우선 사용 → saveStationToWidget 호출 + force:true', async () => {
+    await updateWidgetFromSilentPush(ssot, bgContext, destination, directRoute, 1_700_000_000_000);
+    expect(mockLookup).toHaveBeenCalledWith(ssot, bgContext);
+    expect(mockSaveStationToWidget).toHaveBeenCalledWith(
+      station,
+      0,
+      1_700_000_000_000,
+      { force: true },
+      {
+        currentStationName: '역삼',
+        destinationName: '잠실',
+        tripActive: true,
+      },
+    );
+  });
+
+  it('SSoT 없으면 BG context fallback (lookup이 결정) — saveStationToWidget 호출', async () => {
+    mockLookup.mockReturnValue({ station, distanceKm: 0.15 });
+    await updateWidgetFromSilentPush(null, bgContext, destination, directRoute, 1_700_000_000_000);
+    expect(mockLookup).toHaveBeenCalledWith(null, bgContext);
+    expect(mockSaveStationToWidget).toHaveBeenCalledWith(
+      station,
+      0.15,
+      1_700_000_000_000,
+      { force: true },
+      expect.objectContaining({ tripActive: true }),
+    );
+  });
+
+  it('SSoT undefined 도 lookup이 결정 — saveStationToWidget 호출', async () => {
+    mockLookup.mockReturnValue({ station, distanceKm: 0.15 });
+    await updateWidgetFromSilentPush(undefined, bgContext, destination, directRoute, 1_700_000_000_000);
+    expect(mockLookup).toHaveBeenCalledWith(undefined, bgContext);
+    expect(mockSaveStationToWidget).toHaveBeenCalledTimes(1);
+  });
+
+  it('lookup이 null 반환 → saveStationToWidget 호출 안 함 (no-op)', async () => {
+    mockLookup.mockReturnValue(null);
+    await updateWidgetFromSilentPush(ssot, null, destination, directRoute);
+    expect(mockSaveStationToWidget).not.toHaveBeenCalled();
+  });
+
+  describe('tripContext 구성', () => {
+    it('destination 없음 → tripActive=false + destinationName 비움', async () => {
+      await updateWidgetFromSilentPush(ssot, bgContext, null, directRoute, 1);
+      expect(mockSaveStationToWidget).toHaveBeenCalledWith(
+        station,
+        0,
+        1,
+        { force: true },
+        {
+          currentStationName: '역삼',
+          destinationName: '',
+          tripActive: false,
+        },
+      );
+    });
+
+    it('direct route + destination → nextTransferName 미포함 (직통)', async () => {
+      await updateWidgetFromSilentPush(ssot, bgContext, destination, directRoute, 1);
+      const call = mockSaveStationToWidget.mock.calls[0];
+      const tripContext = call[4];
+      expect(tripContext).not.toHaveProperty('nextTransferName');
+      expect(tripContext.tripActive).toBe(true);
+    });
+
+    it('transfer route → nextTransferName=첫 환승역', async () => {
+      await updateWidgetFromSilentPush(ssot, bgContext, destination, transferRoute, 1);
+      const call = mockSaveStationToWidget.mock.calls[0];
+      expect(call[4]).toEqual({
+        currentStationName: '역삼',
+        destinationName: '잠실',
+        nextTransferName: '건대입구',
+        tripActive: true,
+      });
+    });
+
+    it('multi-transfer route → nextTransferName=transfers[0].transferName', async () => {
+      await updateWidgetFromSilentPush(ssot, bgContext, destination, multiTransferRoute, 1);
+      const call = mockSaveStationToWidget.mock.calls[0];
+      expect(call[4]).toEqual({
+        currentStationName: '역삼',
+        destinationName: '잠실',
+        nextTransferName: '왕십리',
+        tripActive: true,
+      });
+    });
+
+    it('route null + destination 있음 → nextTransferName 미포함', async () => {
+      await updateWidgetFromSilentPush(ssot, bgContext, destination, null, 1);
+      const call = mockSaveStationToWidget.mock.calls[0];
+      expect(call[4]).not.toHaveProperty('nextTransferName');
+      expect(call[4].tripActive).toBe(true);
+    });
+  });
+
+  it('savedAt 인자 생략 시 Date.now()로 호출', async () => {
+    const before = Date.now();
+    await updateWidgetFromSilentPush(ssot, bgContext, destination, directRoute);
+    const after = Date.now();
+    const savedAt = mockSaveStationToWidget.mock.calls[0][2];
+    expect(savedAt).toBeGreaterThanOrEqual(before);
+    expect(savedAt).toBeLessThanOrEqual(after);
+  });
+
+  it('saveStationToWidget throw도 caller로 전파 안 함 (graceful)', async () => {
+    mockSaveStationToWidget.mockRejectedValueOnce(new Error('native'));
+    await expect(
+      updateWidgetFromSilentPush(ssot, bgContext, destination, directRoute, 1),
+    ).resolves.toBeUndefined();
+  });
+
+  it('lookup 자체가 throw해도 graceful', async () => {
+    mockLookup.mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+    await expect(
+      updateWidgetFromSilentPush(ssot, bgContext, destination, directRoute, 1),
+    ).resolves.toBeUndefined();
+    expect(mockSaveStationToWidget).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/widget/utils/lookupStationFromSsot.ts
+++ b/src/features/widget/utils/lookupStationFromSsot.ts
@@ -1,0 +1,58 @@
+/**
+ * #1935 — silent push payload + BG context에서 widget update용 Station/distance를 결정한다.
+ *
+ * 우선순위:
+ *  1. payload `ssot.currentStationId` (backend가 4-tier fusion 결과를 forward한 권위 신호).
+ *     `ssot.currentStationLine`이 있으면 line 정확 매칭(`findStationByNameAndLine`) —
+ *     동명 환승역(합정 2/6호선 등) cross-line confusion 차단.
+ *     SSoT 경로는 backend가 advance한 시점이므로 거리 신호는 0으로 stamp(역 도착).
+ *  2. BG context (`BG_LAST_STATION_KEY` mirror) — Always 권한 사용자의
+ *     `backgroundLocationTask`가 적재해 둔 마지막 GPS-derived station + distance.
+ *     WhileInUse 사용자는 보통 비어 있다(BG task 미등록) → null로 떨어진다.
+ *
+ * 둘 다 결정 불가 → null (caller no-op, 위젯 마지막 정상 상태 유지).
+ *
+ * 본 helper는 expo-notifications / expo-task-manager / AsyncStorage 의존성이 없어
+ * silent push handler / FG state freshness 호출자 양쪽 모두 import 가능하다.
+ */
+
+import { findStationByName, findStationByNameAndLine } from '../../../shared/utils/stationLookup';
+import type { LineNumber, Station } from '../../../shared/types/station';
+import type { BgLastStationContext, SsotStationInput } from '../../../shared/types/widgetRefresh';
+
+export type { BgLastStationContext, SsotStationInput };
+
+export interface ResolvedWidgetStation {
+  station: Station;
+  distanceKm: number;
+}
+
+/**
+ * SSoT → BG context 순으로 시도. 둘 다 결정 불가 시 null.
+ */
+export function lookupStationFromSsot(
+  ssot: SsotStationInput | null | undefined,
+  bgContext: BgLastStationContext | null,
+): ResolvedWidgetStation | null {
+  const fromSsot = resolveFromSsot(ssot);
+  if (fromSsot) return fromSsot;
+  if (bgContext) {
+    return { station: bgContext.station, distanceKm: bgContext.distanceKm };
+  }
+  return null;
+}
+
+/**
+ * SSoT field 우선. currentStationLine이 있으면 line 정확 매칭, 없으면 name-only fallback.
+ * silent push가 backend advance 신호이므로 거리 신호는 0(역 도착).
+ */
+function resolveFromSsot(
+  ssot: SsotStationInput | null | undefined,
+): ResolvedWidgetStation | null {
+  if (!ssot) return null;
+  const station = ssot.currentStationLine
+    ? findStationByNameAndLine(ssot.currentStationId, ssot.currentStationLine as LineNumber)
+    : findStationByName(ssot.currentStationId);
+  if (!station) return null;
+  return { station, distanceKm: 0 };
+}

--- a/src/features/widget/utils/updateWidgetFromSilentPush.ts
+++ b/src/features/widget/utils/updateWidgetFromSilentPush.ts
@@ -1,0 +1,110 @@
+/**
+ * #1935 — silent push 채널에서 widget storage update를 호출하는 단일 진입점.
+ *
+ * `feedback_whileinuse_must_work` paradigm 충족 — WhileInUse 권한 사용자도 silent push
+ * 도달 시점에 BG widget이 갱신되도록 보장. backend silent push는 권한에 무관하게 도달하므로
+ * 본 채널에 widget update를 wire해 BG GPS 미작동 보완.
+ *
+ * 동작:
+ *  1. SSoT 또는 BG context로 station/distance 결정 (`lookupStationFromSsot`)
+ *  2. destination/route 기반 tripContext 구성 (#1781 widget tripContext wire)
+ *  3. `saveStationToWidget(station, distance, savedAt, { force: true }, tripContext)`
+ *     `force: true` — silent push 도달은 명시적 freshness 갱신 trigger (dedupe 우회).
+ *
+ * 결정 불가 시 no-op (위젯 마지막 정상 상태 유지). 예외는 caller로 전파하지 않는다.
+ */
+
+import type { Route } from '../../../shared/utils/stationRoute';
+import { getFirstLeg } from '../../../shared/utils/stationRoute';
+import type { Station } from '../../../shared/types/station';
+import type { BgLastStationContext, SsotStationInput } from '../../../shared/types/widgetRefresh';
+import { createLogger } from '../../../shared/utils/logger';
+import { saveStationToWidget, type WidgetTripContext } from '../api/widgetStorage';
+import { lookupStationFromSsot } from './lookupStationFromSsot';
+
+const logger = createLogger('SilentPushWidget');
+
+/**
+ * Wire entry — silent push handler가 호출. SSoT 우선, BG context fallback.
+ *
+ * tripContext.currentStationName은 resolved station 기준(SSoT가 advance한 권위 역).
+ * nextTransferName은 route에서 첫 환승(direct route → undefined). destination 없으면
+ * tripActive=false로 stamp해 widget UI가 nearest-station 모드로 fallback.
+ *
+ * @param ssot       silent push payload `ssot` 슬라이스 (currentStationId/Line). null이면 BG fallback만.
+ * @param bgContext  BG_LAST_STATION_KEY mirror. WhileInUse 사용자는 보통 null.
+ * @param destination DESTINATION_KEY parsed. null이면 trip 비활성.
+ * @param route      ROUTE_KEY parsed. null이면 환승 정보 없음(direct로 간주).
+ * @param savedAt    widget storage savedAt epoch ms. 기본 Date.now().
+ */
+export async function updateWidgetFromSilentPush(
+  ssot: SsotStationInput | null | undefined,
+  bgContext: BgLastStationContext | null,
+  destination: Station | null,
+  route: Route,
+  savedAt: number = Date.now(),
+): Promise<void> {
+  try {
+    const resolved = lookupStationFromSsot(ssot, bgContext);
+    if (!resolved) {
+      logger.info('skip: station resolve failed (no SSoT, no BG context)');
+      return;
+    }
+    const tripContext = buildTripContext(resolved.station, destination, route);
+    await saveStationToWidget(
+      resolved.station,
+      resolved.distanceKm,
+      savedAt,
+      { force: true },
+      tripContext,
+    );
+    logger.info(`widget updated: ${resolved.station.name} (tripActive=${tripContext.tripActive})`);
+  } catch (e) {
+    logger.warn('update failed:', e);
+  }
+}
+
+/**
+ * tripContext shape (#1781) — destination 부재 시 tripActive=false로 stamp.
+ *
+ * `nextTransferName`:
+ *  - direct route → undefined (직통)
+ *  - transfer / multi-transfer → 첫 환승역 이름 (`getFirstLeg`로 일관 추출)
+ *
+ * route helper(`getFirstLeg`)를 재사용해 route 형태별 분기를 본 모듈에서 반복하지 않는다
+ * (글로벌 룰 3 — 확장성/재사용성).
+ */
+function buildTripContext(
+  currentStation: Station,
+  destination: Station | null,
+  route: Route,
+): WidgetTripContext {
+  if (!destination) {
+    return {
+      currentStationName: currentStation.name,
+      destinationName: '',
+      tripActive: false,
+    };
+  }
+  const nextTransferName = resolveNextTransferName(route, destination.name);
+  return {
+    currentStationName: currentStation.name,
+    destinationName: destination.name,
+    ...(nextTransferName !== undefined ? { nextTransferName } : {}),
+    tripActive: true,
+  };
+}
+
+/**
+ * direct route → undefined (직통, 환승 없음).
+ * transfer / multi-transfer → 첫 환승역 이름.
+ *
+ * route null도 undefined (환승 정보 없음 → 위젯이 직통 표시).
+ */
+function resolveNextTransferName(route: Route, destinationName: string): string | undefined {
+  if (!route) return undefined;
+  const firstLeg = getFirstLeg(route, destinationName);
+  // direct route는 endName이 destinationName 자체 → 환승 아님. undefined로 신호.
+  if (route.type === 'direct') return undefined;
+  return firstLeg.endName;
+}

--- a/src/shared/types/widgetRefresh.ts
+++ b/src/shared/types/widgetRefresh.ts
@@ -1,0 +1,34 @@
+/**
+ * #1935 — silent push 채널 widget refresh 시 alarm / widget 양쪽이 공유하는 입력 type.
+ *
+ * - `BgLastStationContext`: `BG_LAST_STATION_KEY` mirror shape. `backgroundLocationTask`가
+ *   적재하고, silent push handler가 read해 widget update / LA refresh에 fallback으로 사용.
+ *   (WhileInUse 사용자는 BG task 미등록이라 보통 null로 떨어진다.)
+ * - `SsotStationInput`: silent push payload `ssot` 슬라이스에서 widget update가 필요한 narrow
+ *   subset (currentStationId + 선택적 currentStationLine). 전체 `SilentPushSsotMirror`를
+ *   import하면 alarm feature 의존이 widget에 생기므로 shape만 빌려온다.
+ *
+ * 두 type 모두 alarm slice의 storage write 형식과 1:1로 정렬돼 있다.
+ */
+
+import type { Station } from './station';
+
+/**
+ * `BG_LAST_STATION_KEY`에 적재된 형태. `backgroundLocationTask`가 write,
+ * `refreshLiveActivityFromBackgroundContext` / widget update가 read.
+ */
+export interface BgLastStationContext {
+  station: Station;
+  distanceKm: number;
+  timestamp: number;
+}
+
+/**
+ * silent push payload `ssot` 슬라이스에서 widget station lookup이 필요한 두 필드.
+ * 전체 SSoT mirror entry shape와 부분 호환 — currentStationLine은 #1705에서 추가되며
+ * 부재 시 lookup은 name-only fallback.
+ */
+export interface SsotStationInput {
+  currentStationId: string;
+  currentStationLine?: string;
+}


### PR DESCRIPTION
## Summary
- silent push handler finally 블록에 `saveStationToWidget` 호출 추가 — WhileInUse 권한 사용자도 BG silent push 도달 시점에 위젯이 갱신되도록 보장
- `updateWidgetFromSilentPush` helper — payload SSoT(`ssot.currentStationId`) 우선, BG_LAST_STATION fallback. destination/route 기반 tripContext + `force: true` (silent push = 명시적 freshness 갱신 trigger)
- `feedback_whileinuse_must_work` paradigm 충족 — BG GPS 미작동(WhileInUse) → silent push 채널로 widget BG 갱신 보완

Closes #1935

## Wire-completion 5단 체크
1. **Orphan 없음** — `npm run lint:orphan` pass (No orphan exports detected)
2. **V/X dashboard** — DebugModal에 widget surface trace 추가 follow-up. 현 PR은 logger.info에서 widget update 호출 시점 + resolved station / tripActive stamp (`SilentPushWidget` 채널). silent push 도달과 widget update의 cross-verify는 wrangler tail(backend push) + device logger 매칭으로
3. **의존 PR** — N/A (device-only fix). 본 PR은 #1929 widget tripContext shape 이미 머지된 dev에 정렬. backend deploy 8건 누적 미반영은 device 측 SSoT 활용 코드에 무관 (graceful fallback: BG context → name-only lookup)
4. **측정 plan** — 1주 WhileInUse 권한 사용자 trip 종료 후 위젯 stale 0건 evidence. 시나리오: 강남 → 잠실 trip 활성 + 앱 BG 진입 → silent push 도달 → 홈 화면 위젯이 다음 역으로 갱신 확인. log query: `SilentPushWidget` 채널 `widget updated:` 로그 확인 + `SilentPush` 채널 `received:` 매칭
5. **Device verify** — 필요. WhileInUse 권한 + BG 상태(홈 화면) + trip 활성에서 silent push 수신 후 위젯 station name이 갱신되는지 1주 trip 1회 이상 확인

## 변경 요약
- `src/features/alarm/tasks/silentPushTask.ts` — finally 블록을 `Promise.allSettled`로 LA refresh + widget refresh 격리. payload null(invalid) 시 widget update skip
- `src/features/widget/utils/updateWidgetFromSilentPush.ts` — 새 wire entry. SSoT → BG context fallback + tripContext 구성 + `saveStationToWidget(..., { force: true }, tripContext)`
- `src/features/widget/utils/lookupStationFromSsot.ts` — SSoT 우선 station 결정 (currentStationLine 있으면 line 정확 매칭, 없으면 name-only). 둘 다 실패 시 null
- `src/features/alarm/utils/widgetRefreshContext.ts` — DESTINATION/ROUTE/BG_LAST_STATION 1회 병렬 read helper (BG task 시간 예산 보호)
- `src/shared/types/widgetRefresh.ts` — BgLastStationContext + SsotStationInput shared shape (ESLint 디렉토리 경계 준수)

## Test plan
- [x] `npm test` 커버리지 100% (400 suites / 8386 tests pass)
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass (No orphan exports detected)
- [x] code-review medium — correctness bug 없음. BG distance stale (#4 H maxAge 의존)은 본 PR 범위 밖 cross-impact