### PR TITLE
fix(#1933): cron LA heartbeat self-referential gap + outer deleteSsot guard

### DIFF
--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -806,6 +806,8 @@ describe('cleanupTripWithLa', () => {
       { reason: 'eta-missing' as const, expected: 'eta-missing' },
       { reason: 'destination-arrived' as const, expected: 'destination' },
       { reason: 'push-unrecoverable' as const, expected: 'push-unrecoverable' },
+      // #1933 — la-stale-backstop은 외부 contract `'expired'`로 매핑 (backward-compat).
+      { reason: 'la-stale-backstop' as const, expected: 'expired' },
     ];
 
     for (const { reason, expected } of reasonMatrix) {
@@ -846,6 +848,61 @@ describe('cleanupTripWithLa', () => {
         () => undefined,
       );
       expect(kv.store.has('tripStatus:devtoken')).toBe(false);
+    });
+
+    // #1933 — alert push payload의 reason 필드도 외부 contract 매핑이 적용된다. 내부 식별자
+    // `'la-stale-backstop'`을 그대로 송신하면 client mirror enum이 `'unknown'`으로 normalize되어
+    // user-facing 알림 메시지가 generic해진다. force-end 패턴과 동일하게 `'expired'`로 매핑해
+    // client 기존 graceful handler가 그대로 동작하도록 한다.
+    it('la-stale-backstop 호출 시 alert push payload reason은 expired로 송신', async () => {
+      const kv = new InMemoryKV();
+      const trip = makeTrip({ activityPushToken: undefined });
+      await kv.put('trip:devtoken', JSON.stringify(trip));
+      const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      await cleanupTripWithLa(
+        trip,
+        env,
+        makeDeps(fetchImpl as unknown as typeof fetch),
+        makeStats(),
+        NOW,
+        () => undefined,
+        'la-stale-backstop',
+      );
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      const call = fetchImpl.mock.calls[0] as unknown as [string, { body: string }];
+      const body = JSON.parse(call[1].body) as { data: { reason: string } };
+      expect(body.data.reason).toBe('expired');
+    });
+
+    // 기존 reason은 그대로 송신되는지 회귀 가드 — la-stale-backstop 매핑이 다른 reason에 leak되면 회귀.
+    it('expired/eta-missing 등 기존 reason은 alert push payload에 그대로 송신 (회귀 가드)', async () => {
+      const cases: Array<TripEndedReason> = [
+        'expired',
+        'eta-missing',
+        'destination-arrived',
+        'push-unrecoverable',
+        'seoul-outage',
+      ];
+      for (const reason of cases) {
+        const kv = new InMemoryKV();
+        const trip = makeTrip({ activityPushToken: undefined });
+        await kv.put('trip:devtoken', JSON.stringify(trip));
+        const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+        const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+        await cleanupTripWithLa(
+          trip,
+          env,
+          makeDeps(fetchImpl as unknown as typeof fetch),
+          makeStats(),
+          NOW,
+          () => undefined,
+          reason,
+        );
+        const call = fetchImpl.mock.calls[0] as unknown as [string, { body: string }];
+        const body = JSON.parse(call[1].body) as { data: { reason: string } };
+        expect(body.data.reason).toBe(reason);
+      }
     });
 
     it('logs but does not throw when status write fails (cleanup continues)', async () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -4253,6 +4253,259 @@ describe('runScheduled — #1652 staged lifecycle backstop', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #1933 — LA stale auto-end backstop (heartbeat self-referential gap)
+// ---------------------------------------------------------------------------
+
+describe('runScheduled — #1933 LA stale auto-end backstop', () => {
+  it('lastLaPushAt + 5min 경과 + lockMissing 분기 진입 → cleanupTripWithLa + laStaleAutoEnded++', async () => {
+    const kv = new InMemoryKV();
+    // lockMissing 분기 진입 보장: boardingLock 없음 + infoModeEnabled false.
+    // lastLaPushAt이 6분 전 → 5분 임계 초과.
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'la-stale-6m',
+        createdAt: NOW - 30 * 60_000,
+        expiresAt: NOW + 60 * 60_000,
+        alarmAtEpochMs: NOW + 60_000,
+        lastLaPushAt: NOW - 6 * 60_000,
+      }),
+    );
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+
+    expect(stats.laStaleAutoEnded).toBe(1);
+    // cleanupTripWithLa가 trip-ended alert push를 발사 ('la-stale-backstop' reason).
+    expect(apnsFetch).toHaveBeenCalled();
+    // trip이 KV에서 제거됐는지 — listTrips로 enumerate 시 비어있어야.
+    const remaining: Trip[] = [];
+    for await (const t of (await import('../trips')).listTrips(kv as unknown as KVNamespace)) {
+      remaining.push(t);
+    }
+    expect(remaining).toHaveLength(0);
+    // lockMissing 카운터는 backstop이 먼저 `continue` 하므로 증가하지 않는다.
+    expect(stats.lockMissing).toBe(0);
+  });
+
+  it('lastLaPushAt + 5min 미경과 (4분 전) → backstop skip, 기존 lockMissing flow 진행', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'la-fresh-4m',
+        createdAt: NOW - 30 * 60_000,
+        expiresAt: NOW + 60 * 60_000,
+        alarmAtEpochMs: NOW + 60_000,
+        lastLaPushAt: NOW - 4 * 60_000,
+      }),
+    );
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+
+    expect(stats.laStaleAutoEnded).toBe(0);
+    // 기존 lockMissing flow는 그대로 진행됐는지.
+    expect(stats.lockMissing).toBe(1);
+    // trip은 KV에 그대로 남아있어야.
+    const remaining: Trip[] = [];
+    for await (const t of (await import('../trips')).listTrips(kv as unknown as KVNamespace)) {
+      remaining.push(t);
+    }
+    expect(remaining).toHaveLength(1);
+  });
+
+  it('lastLaPushAt === undefined (첫 push 전) → backstop skip', async () => {
+    const kv = new InMemoryKV();
+    // lastLaPushAt 미설정 — 신규 trip이거나 첫 push 전.
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'la-never',
+        createdAt: NOW - 30 * 60_000,
+        expiresAt: NOW + 60 * 60_000,
+        alarmAtEpochMs: NOW + 60_000,
+        // lastLaPushAt 미지정 — undefined.
+      }),
+    );
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+
+    expect(stats.laStaleAutoEnded).toBe(0);
+    // 기존 lockMissing flow 진행.
+    expect(stats.lockMissing).toBe(1);
+  });
+
+  it('환승 직후 (advance reset) — lastLaPushAt이 undefined로 리셋된 trip은 lockMissing 진입해도 첫 5분간 보호', async () => {
+    // scheduled.ts:2654에서 waypoint advance 시 `trip.lastLaPushAt = undefined`로 reset.
+    // 그 다음 cycle에 boardingLock 만료/swap으로 lockMissing 분기 진입해도
+    // `lastLaPushAt === undefined` 분기에서 backstop이 skip되어 신규 trip처럼 첫 5분 보호.
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'la-reset',
+        createdAt: NOW - 2 * 60 * 60_000, // 환승 도중인 장거리 trip
+        expiresAt: NOW + 60 * 60_000,
+        alarmAtEpochMs: NOW + 60_000,
+        lastLaPushAt: undefined, // advance reset 직후 상태
+      }),
+    );
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+
+    expect(stats.laStaleAutoEnded).toBe(0);
+    expect(stats.lockMissing).toBe(1);
+  });
+
+  it('lockless opt-in trip + LA push 5min stale → backstop이 lockless 분기 진입 직전에 cleanup (lockless도 동일 보호)', async () => {
+    // 본문 회귀 정의 1번 "lock 활성 / lockless 둘 다 카테고리" 직접 매핑.
+    // infoModeEnabled true + lastLaPushAt 6분 전 → 정상 시 lockless intermediate push가
+    // 매 cycle 발사돼야 하지만 advance 게이트 차단으로 lockless도 fire 미발사 시나리오.
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'la-stale-lockless',
+        createdAt: NOW - 30 * 60_000,
+        expiresAt: NOW + 60 * 60_000,
+        alarmAtEpochMs: NOW + 60_000,
+        infoModeEnabled: true,
+        waypoints: [
+          { stationName: '강남', line: '2', kind: 'intermediate' },
+          { stationName: '선릉', line: '2', kind: 'destination' },
+        ],
+        lastLaPushAt: NOW - 6 * 60_000,
+      }),
+    );
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+
+    expect(stats.laStaleAutoEnded).toBe(1);
+    // lockless intermediate push 발사 분기 진입 전에 backstop이 잡혀 fire 0건.
+    expect(stats.locklessIntermediateFired).toBe(0);
+    // trip 자체가 cleanup되어 KV에서 사라짐.
+    const remaining: Trip[] = [];
+    for await (const t of (await import('../trips')).listTrips(kv as unknown as KVNamespace)) {
+      remaining.push(t);
+    }
+    expect(remaining).toHaveLength(0);
+  });
+
+  // 회귀 가드 — #1933 review finding. cleanupTripWithLa는 내부에서 deleteSsot을 try/catch로 감싸
+  // graceful swallow한다 (liveActivity.ts:322). 외부에서 추가 호출 시 비가드라 KV throw가 cron 루프를
+  // break-out 해 다음 trip이 평가되지 않는 회귀 위험. 본 가드 테스트는 ssot KV가 throw해도 backstop이
+  // 정상 cleanup하고 다음 trip이 평가되는지 검증.
+  it('ssot KV가 throw해도 backstop cleanup 정상 + 다음 trip이 평가 (cron break-out 차단)', async () => {
+    const kv = new InMemoryKV();
+    // Trip A — stale 대상 (cleanup 발동).
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'la-stale-a',
+        createdAt: NOW - 30 * 60_000,
+        expiresAt: NOW + 60 * 60_000,
+        alarmAtEpochMs: NOW + 60_000,
+        lastLaPushAt: NOW - 6 * 60_000,
+      }),
+    );
+    // Trip B — A 다음에 평가될 trip. backstop이 break-out하면 본 trip이 미평가됨.
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'la-stale-b',
+        createdAt: NOW - 30 * 60_000,
+        expiresAt: NOW + 60 * 60_000,
+        alarmAtEpochMs: NOW + 60_000,
+        lastLaPushAt: NOW - 6 * 60_000,
+      }),
+    );
+
+    // ssot:* delete가 throw하는 broken KV — cleanupTripWithLa 내부 try/catch가 swallow해야.
+    const realKv = kv;
+    const brokenKv: KVNamespace = {
+      get: realKv.get.bind(realKv),
+      put: realKv.put.bind(realKv),
+      delete: vi.fn(async (key: string) => {
+        if (key.startsWith('ssot:')) throw new Error('ssot kv down');
+        return realKv.delete(key);
+      }),
+      list: realKv.list.bind(realKv),
+    } as unknown as KVNamespace;
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(
+      { TRIPS: brokenKv } as unknown as Env,
+      {
+        seoul: makeSeoul([]),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+      },
+    );
+
+    // 두 trip 모두 backstop 평가 + cleanup. break-out 차단 확인.
+    expect(stats.laStaleAutoEnded).toBe(2);
+    expect(stats.scanned).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1933 — toTripStatusEndReason — la-stale-backstop external mapping
+// ---------------------------------------------------------------------------
+
+describe('toTripStatusEndReason — #1933 la-stale-backstop 외부 contract 매핑', () => {
+  it('la-stale-backstop → expired (client backward-compat)', async () => {
+    const { toTripStatusEndReason } = await import('../tripStatus');
+    expect(toTripStatusEndReason('la-stale-backstop')).toBe('expired');
+  });
+
+  it('destination-arrived → destination (기존 매핑 유지)', async () => {
+    const { toTripStatusEndReason } = await import('../tripStatus');
+    expect(toTripStatusEndReason('destination-arrived')).toBe('destination');
+  });
+
+  it('expired → expired (pass-through)', async () => {
+    const { toTripStatusEndReason } = await import('../tripStatus');
+    expect(toTripStatusEndReason('expired')).toBe('expired');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // #1680 — V8d backend cron stationary skip
 // ---------------------------------------------------------------------------
 
@@ -6988,7 +7241,7 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
     if (opts.setupSsot) await opts.setupSsot(kv, trip);
     const stats: ScheduledStats = {
       scanned: 0, polled: 0, pushed: 0, errors: 0, etaMissing: 0, envCorrected: 0,
-      lockMissing: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
+      lockMissing: 0, laStaleAutoEnded: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
       laPushSent: 0, laPushFailed: 0, laTokenCleared: 0,
       boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
       phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -358,6 +358,12 @@ async function fireTripEndedAlertPush(
     return;
   }
   const pushId = crypto.randomUUID();
+  // #1933 — 외부 contract 보호. `'la-stale-backstop'`은 backend 내부 식별자로만 사용하고
+  // alert push payload에는 client가 인식하는 기존 reason(`'expired'`)으로 매핑한다 —
+  // force-end(9h) 패턴과 동일한 backward-compat. client는 새 enum 분기를 추가하지 않아도
+  // `'unknown'`으로 normalize되지 않고 기존 graceful handler가 그대로 동작한다.
+  const externalReason: TripEndedReason =
+    reason === 'la-stale-backstop' ? 'expired' : reason;
   // JWT 서명 / network reject 등의 throw가 cleanup 흐름을 차단하지 않도록 swallow.
   // trip-ended push는 graceful fail-soft — graceful loss 시 클라는 다음 FG hydrate에서 회복.
   try {
@@ -369,7 +375,7 @@ async function fireTripEndedAlertPush(
         sendTripEndedAlertPush({
           deviceToken: trip.token,
           pushId,
-          reason,
+          reason: externalReason,
           sentAt: now,
           // race 가드(#868 P1-2) — push 도착 시점에 클라가 trip 갈아탔으면 ACTIVE_TRIP_KEY 불일치로 cleanup skip.
           tripToken: trip.token,

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -128,6 +128,25 @@ export const LA_PUSH_THRESHOLD_MS = 30_000;
 export const LA_HEARTBEAT_INTERVAL_MS = 90_000;
 
 /**
+ * #1933 — LA push 침묵 자동 종료 임계 (5분).
+ *
+ * 회귀(2026-06-27 "건대 환승" 9분 stuck): 첫 LA push 후 advance evidence 0건이라 backend SSoT가
+ * `건대입구 transfer`로 frozen, `maybeFireLiveActivityUpdate`가 호출돼도 ΔETA=0 분기 dedup으로
+ * 새 push 미발사 → ActivityKit이 last content-state(staleDate 75s 무시)를 9분간 유지 →
+ * 사용자 도착 시점까지 Dynamic Island가 "건대 환승" 표시.
+ *
+ * heartbeat가 "새 push에 의존해 새 push를 보낸다"는 self-referential gap이라 새 evidence가
+ * 들어와도 SSoT가 바뀌지 않으면 영구 freeze. `lastLaPushAt + LA_STALE_AUTO_END_MS` 경과 시
+ * 자동 cleanup → `cleanupTripWithLa` 내부 `fireLiveActivityDismissal`로 ActivityKit dismiss →
+ * device의 stale 표시를 강제 정리한다. 5분은 보수적 — 정상 동작 시 90s heartbeat 3회 안에
+ * push가 발사돼 stamp가 갱신되므로 본 backstop은 발동되지 않는다.
+ *
+ * 6h staged lifecycle(`lifecycleForceEnded`)보다 일찍 발동 → safety net. B(silent push 정상화)
+ * + #10(infoModeEnabled 강화) 정상 동작 시 0건 기대 (V5/V6/X3 강화).
+ */
+export const LA_STALE_AUTO_END_MS = 5 * 60 * 1000;
+
+/**
  * #1671 — 환승/도착 임박 즉시 trigger 임계 (초).
  * `waypoint.kind === 'transfer'` (환승) 또는
  * `waypoint.kind === 'destination' && etaSeconds <= LA_IMMEDIATE_TRIGGER_ETA_SEC` (도착 임박)
@@ -453,6 +472,14 @@ export interface ScheduledStats extends LiveActivityStats {
    * 사용자가 열차 미선택 상태에서 noise push가 발사되지 않도록 차단된 결과.
    */
   lockMissing: number;
+  /**
+   * #1933 — `lastLaPushAt`이 `LA_STALE_AUTO_END_MS` 이상 침묵해 cron이 자동 cleanup한 trip 수.
+   * lockMissing 분기 진입 시 평가. 정상 운영(silent push + LA heartbeat 작동)에서 0건 기대 —
+   * 0이 아니면 `lockMissing` 분기 잔여 케이스(advance gate freeze + heartbeat self-referential gap)에서
+   * LA가 frozen된 채 5분+ 표류한 trip 수 = 사용자 가치 손실 미니 회귀 차단 효과 측정.
+   * 1주 0건이면 본 backstop이 dual safety net으로 동작 중임을 확인.
+   */
+  laStaleAutoEnded: number;
   /**
    * #816 C — lockless opt-in 토글 ON trip에서 station-passed(intermediate) push가 발사된 횟수.
    * false-positive 측정 인프라 — 사용자 dismiss/탭률은 client alarmLog로 별도 적재된다.
@@ -798,6 +825,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     etaMissing: 0,
     envCorrected: 0,
     lockMissing: 0,
+    laStaleAutoEnded: 0,
     locklessIntermediateFired: 0,
     locklessMotionGateBlocked: 0,
     laPushSent: 0,
@@ -973,6 +1001,28 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     // Seoul polling/push 모두 skip. 디바이스는 lock 등록 후 train-code 단위로 정확히 추적하며,
     // lock 부재 상태에서의 phase-based push는 "탑승 전 노이즈"였다.
     if (!isBoardingLockActive(trip, now)) {
+      // #1933 — LA push 침묵 자동 종료 backstop. lockMissing 분기 진입 시 평가.
+      // backend SSoT가 advance 게이트로 frozen된 채 `maybeFireLiveActivityUpdate`가 ΔETA=0 분기
+      // dedup으로 새 push 미발사 → ActivityKit이 last content-state를 영구 유지하는
+      // heartbeat self-referential gap을 차단. lockless / lock-missing 둘 다 동일 보호.
+      // `lastLaPushAt === undefined`는 첫 push 전(또는 advance 직후 reset 직후) 상태 — skip.
+      //
+      // SSoT mirror cleanup은 `cleanupTripWithLa` 내부의 graceful `deleteSsot` 호출(try/catch
+      // swallow, liveActivity.ts:322)에 위임 — 외부 추가 호출은 redundant + KV throw 발생 시
+      // cron 루프 break-out 위험이라 두지 않는다.
+      if (
+        trip.lastLaPushAt !== undefined &&
+        now - trip.lastLaPushAt > LA_STALE_AUTO_END_MS
+      ) {
+        stats.laStaleAutoEnded += 1;
+        log('la-stale: auto-end after 5min push silence', {
+          token: trip.token.slice(0, 8),
+          elapsedMs: now - trip.lastLaPushAt,
+          station: pickActiveWaypoint(trip)?.stationName,
+        });
+        await cleanupTripWithLa(trip, env, deps, stats, now, log, 'la-stale-backstop');
+        continue;
+      }
       // #816 C — lockless opt-in trip은 게이트 우회. lock 없이도 intermediate waypoint 통과
       // 시 station-passed push 발사. 사용자가 명시 동의(client 토글)한 trip에 한정한다.
       // intermediate kind가 아니면(transfer/destination) 여전히 skip — trainCode 없이 발사하면

--- a/backend/alarm-worker/src/tripStatus.ts
+++ b/backend/alarm-worker/src/tripStatus.ts
@@ -51,9 +51,13 @@ export function tripStatusKey(token: string): string {
  * 클라이언트 API 응답은 `destination`으로 축약 — `destination-arrived`는 backend 내부 식별자라
  * 외부 노출 표면에는 단축형이 깔끔하다.
  * `seoul-outage` (#1663) — 1:1 pass-through. POST /trips 핸들러가 cooldown 면제 분기에 사용.
+ * `la-stale-backstop` (#1933) — 외부 contract는 `expired`로 매핑 — client 기존 graceful handler가
+ *   그대로 동작 (#1652 force-end가 'expired' 재사용한 backward-compat 패턴과 동일).
+ *   backend log/stat은 `la-stale-backstop` 그대로 유지해 회귀 분석 가시성 보존.
  */
 export function toTripStatusEndReason(reason: TripEndedReason): TripStatusEndReason {
   if (reason === 'destination-arrived') return 'destination';
+  if (reason === 'la-stale-backstop') return 'expired';
   return reason;
 }
 

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -346,6 +346,9 @@ export interface ReschedulePushPayload {
  *   - 'destination-arrived' — 목적지 도착 또는 마지막 intermediate 통과로 trip 종료
  *   - 'expired' — trip.expiresAt 시각 초과로 자동 만료
  *   - 'push-unrecoverable' — APNs unrecoverable error로 trip 폐기
+ *   - 'la-stale-backstop' (#1933) — LA push가 LA_STALE_AUTO_END_MS(5분) 이상 침묵 시 자동 종료
+ *                       (Dynamic Island content-state freeze 차단). 외부 contract는 'expired'로
+ *                       매핑 (backward-compat) — `toTripStatusEndReason`이 처리한다.
  *
  * 클라가 명시적으로 trip을 끝낸 경로(HTTP DELETE /trips/:token)는 발사 대상이 아님 —
  * 사용자가 destination을 clear하면 이미 클라이언트 store가 정리된 상태이기 때문.
@@ -355,7 +358,8 @@ export type TripEndedReason =
   | 'seoul-outage'
   | 'destination-arrived'
   | 'expired'
-  | 'push-unrecoverable';
+  | 'push-unrecoverable'
+  | 'la-stale-backstop';
 
 /**
  * Trip ended alert push payload (#1337). server-side trip 자동 종료 시 발사되는 alert push의


### PR DESCRIPTION
## Summary
- lastLaPushAt + 5min cron heartbeat 자동 종료 — LA 9분 stuck 차단
- scheduled.ts:1017 outer deleteSsot redundant 제거 — cron 루프 break-out 방지 (cleanupTripWithLa 내부 graceful 호출에 위임)
- la-stale-backstop reason 추가 + 외부 contract `expired` 매핑 (force-end 패턴, backward-compat)

Closes #1933

## Wire-completion 5단 체크
1. Orphan 없음 — `npm run lint:orphan` pass
2. V/X dashboard — wrangler tail / Cloudflare Dashboard cron 로그 + `laStaleAutoEnded` stat + `la-stale: auto-end after 5min push silence` 로그
3. 의존 PR — N/A (backend 단독)
4. 측정 plan — 1주: `laStaleAutoEnded` count + log token+elapsedMs+station 트래킹 → backstop 발동 케이스 분석. 기대 0건 (B + #10 정상 동작 시)
5. Device verify — N/A — backend cron only (단, 실기기 trip BG 5분+ Dynamic Island 자동 정리 evidence는 follow-up)

## Test plan
- [x] backend unit test 9개 pass (#1933 신규 + #1339 reasonMatrix 확장 + alert push payload 매핑 회귀 가드)
- [x] backend 전체 60 files / 2277 tests pass
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass
- [x] code-review low effort — finding 0