### PR TITLE
fix(#1922): gate-hop 4-mitigation + direction-aware + schedule source 명시

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -4214,6 +4214,213 @@ describe('useStationAlarm', () => {
     });
   });
 
+  // #1922 (M1+M3) — transfer route에서 시간 적분 estimator가 stuck돼도 candidate(실측)는 fire 허용.
+  // 환승 leg 진입 직후 estimator가 idx=2 (1번째 leg 마지막)로 stuck하고, 실제 사용자는 leg 2 진행해
+  // candidate idx=4(2번째 leg 1정거장 진행)인 경우, 기본 windowSize=1로는 |4-2|=2 > 1이라 reject.
+  // computeHopWindowSize가 transfer crossover를 감지해 windowSize를 동적 확장해 통과.
+  describe('#1922 (M1+M3) transfer leg hop window 동적 확장', () => {
+    // arc 구성: [S0, S1, T(line=2), T(line=4), S4, S5]
+    // S0~T(line=2)는 line 2, T(line=4)~S5는 line 4. T가 transfer crossover.
+    const buildTransferArc = (): Station[] => [
+      { id: 'X-0', name: 'S0', line: '2', lineColor: '#x', lat: 37.5, lng: 127.0 },
+      { id: 'X-1', name: 'S1', line: '2', lineColor: '#x', lat: 37.501, lng: 127.001 },
+      { id: 'X-2', name: 'TP', line: '2', lineColor: '#x', lat: 37.502, lng: 127.002 },
+      { id: 'X-3', name: 'TP', line: '4', lineColor: '#x', lat: 37.502, lng: 127.002 },
+      { id: 'X-4', name: 'S4', line: '4', lineColor: '#x', lat: 37.503, lng: 127.003 },
+      { id: 'X-5', name: 'S5', line: '4', lineColor: '#x', lat: 37.504, lng: 127.004 },
+    ];
+    const transferRoute = makeTransferRoute({
+      transferName: 'TP',
+      fromLine: '2',
+      toLine: '4',
+      stopsToTransfer: 2,
+      stopsFromTransfer: 2,
+    });
+
+    it('M1: transfer route + estimator stuck(time-integration) + crossover → windowSize 확장으로 통과', async () => {
+      // estimator stuck at idx=2 (1번째 leg 마지막), candidate at idx=4 (2번째 leg 진행).
+      // 기본 windowSize=1로는 |4-2|=2 > 1 → reject. M1으로 확장 후 통과.
+      const arcWithTransfer = buildTransferArc();
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: transferRoute,
+            destination,
+            nearestStation: arcWithTransfer[4],
+            currentHopIndex: 2,
+            arcStations: arcWithTransfer,
+            currentHopStrategy: 'lockless-route-hop',
+            userLocation: { lat: 37.503, lng: 127.003 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      });
+      expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
+    });
+
+    it('M3 신뢰도 게이트: live-position strategy면 확장 X → 격차 ≥ 2일 때 정상 reject', async () => {
+      // live-position(실측)에서 격차 2 = abnormal jump 신호 (GPS jitter / wrong train) → 확장 금지.
+      const arcWithTransfer = buildTransferArc();
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: transferRoute,
+            destination,
+            nearestStation: arcWithTransfer[4],
+            currentHopIndex: 2,
+            arcStations: arcWithTransfer,
+            currentHopStrategy: 'live-position',
+            userLocation: { lat: 37.503, lng: 127.003 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+      await waitFor(() => {
+        expect(mockLogSuppressedHopWindow).toHaveBeenCalledWith({
+          source: 'fg',
+          stationName: arcWithTransfer[4].name,
+          currentHopIndex: 2,
+          candidateIndex: 4,
+        });
+      });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('direct route → 확장 X (M1 게이트 조건 미충족) → 격차 ≥ 2일 때 정상 reject', async () => {
+      // direct route는 환승 없음 → 확장 의미 없음. 기존 동작 보존.
+      const arc7 = Array.from({ length: 7 }, (_, i) =>
+        makeStation(`DR-A${i}`, `DRname${i}`, 37.5 + i * 0.001, 127.0 + i * 0.001),
+      );
+      const directRoute = makeDirectRoute(6, '2');
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: directRoute,
+            destination,
+            nearestStation: arc7[4],
+            currentHopIndex: 2,
+            arcStations: arc7,
+            currentHopStrategy: 'lockless-route-hop',
+            userLocation: { lat: 37.5, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+      await waitFor(() => {
+        expect(mockLogSuppressedHopWindow).toHaveBeenCalledWith({
+          source: 'fg',
+          stationName: arc7[4].name,
+          currentHopIndex: 2,
+          candidateIndex: 4,
+        });
+      });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('transfer route + crossover 없음(같은 leg 내 격차) → 확장 X', async () => {
+      // 같은 leg 내 격차는 정상 estimator 진행으로 처리해야 함. transfer point 끼어 있지 않음.
+      // arc[1] → arc[3] 사이에는 transfer 있지만, arc[0] → arc[1]은 leg 1 내. estimator 0 + candidate 1
+      // 은 격차 1이라 windowSize=1로도 통과 (M1 트리거 자체 안 됨).
+      // 격차 ≥ 2 + 같은 leg 격차 케이스: candidate=arc[1] (leg 1) + estimator=arc[0] (leg 1) — 격차 1 통과.
+      // 격차 2 + 같은 leg: 환승 leg는 4 stops밖에 안 되므로 leg 1 내 격차 2가 nontrivial.
+      // 검증: arc 길이 6 (S0~S5), candidate=arc[5] (leg 2 끝), estimator=arc[3] (leg 2 시작). 격차 2.
+      // arc[3]과 arc[5] 사이에 transfer crossover 없음 → 확장 X → reject.
+      const arcWithTransfer = buildTransferArc();
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: transferRoute,
+            destination,
+            nearestStation: arcWithTransfer[5],
+            currentHopIndex: 3,
+            arcStations: arcWithTransfer,
+            currentHopStrategy: 'lockless-route-hop',
+            userLocation: { lat: 37.504, lng: 127.004 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+      await waitFor(() => {
+        expect(mockLogSuppressedHopWindow).toHaveBeenCalledWith({
+          source: 'fg',
+          stationName: arcWithTransfer[5].name,
+          currentHopIndex: 3,
+          candidateIndex: 5,
+        });
+      });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+
+    it('currentHopStrategy 미전달 → 기본 windowSize 유지 (backward-compat)', async () => {
+      // currentHopStrategy=null → live-position 검사도 안 되지만, 동시에 dynamic 확장 자체 트리거 안 됨.
+      // 실제로는 strategy unset이면 M3 게이트 통과해서 M1 격차 확장 가능.
+      // 본 테스트는 backward-compat 확인 — strategy 없이 transfer route + crossover이면 확장 동작.
+      const arcWithTransfer = buildTransferArc();
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: transferRoute,
+            destination,
+            nearestStation: arcWithTransfer[4],
+            currentHopIndex: 2,
+            arcStations: arcWithTransfer,
+            // currentHopStrategy 생략
+            userLocation: { lat: 37.503, lng: 127.003 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+      // strategy 미전달은 live-position 아니므로 M3 게이트 통과 → M1 확장 적용 → 통과.
+      await waitFor(() => {
+        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      });
+      expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
+    });
+
+    it('candidate가 arc 밖(arcIndexOf=-1) → 기본 windowSize → isStationWithinHopWindow가 false 처리', async () => {
+      // candidate가 route line에는 있지만 arc 안에는 없는 케이스(예: boarding 이전 / destination 이후 역).
+      // computeHopWindowSize의 candidateIndex < 0 가드가 LOCKLESS_HOP_WINDOW_DEFAULT 반환.
+      // isStationWithinHopWindow가 candidate가 arc에 없으면 false → reject 정상 처리.
+      const arcWithTransfer = buildTransferArc();
+      const offArcButOnLine: Station = {
+        id: 'X-99',
+        name: 'OffArc',
+        line: '2',
+        lineColor: '#x',
+        lat: 37.6,
+        lng: 127.1,
+      };
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route: transferRoute,
+            destination,
+            nearestStation: offArcButOnLine,
+            currentHopIndex: 2,
+            arcStations: arcWithTransfer,
+            currentHopStrategy: 'lockless-route-hop',
+            userLocation: { lat: 37.6, lng: 127.1 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+      // candidate is off-arc → isStationWithinHopWindow false → suppress.
+      await waitFor(() => {
+        expect(mockLogSuppressedHopWindow).toHaveBeenCalled();
+      });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+  });
+
   // #1514 — 2026-06-19 용마산 회귀: lockless trip 출발역(arc[0]) station-passed false fire 차단.
   // GPS path에서 currentHopIndex=0 + candidateIndex=0이면 estimator default-hop 신호이므로
   // lock 부재 시 fire 차단. lock 활성은 boardingStationId 기준 origin 알림이 정당이라 우회.

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -13,6 +13,7 @@ import {
   isSameStationName,
   isStationWithinHopWindow,
   arcIndexOf,
+  LOCKLESS_HOP_WINDOW_DEFAULT,
 } from '../../../shared/utils/stationRoute';
 import type { Route } from '../../../shared/utils/stationRoute';
 import type { Station } from '../../../shared/types/station';
@@ -383,6 +384,70 @@ function inferHopIndexFromFiredAlarms(
   return Math.min(maxIdx + 1, arcStations.length - 1);
 }
 
+/**
+ * #1922 (M1+M3) — station-passed hop window 동적 확장.
+ *
+ * 환승 leg에서 estimator가 시간 적분 strategy로 stuck됐을 때 (live-position이 아닌 strategy +
+ * effectiveHopIndex와 candidateIndex 사이에 transfer point가 끼어 있음), 기본 windowSize(1)로는
+ * 정상 진행 candidate(실측)도 reject된다. 본 helper가 동적으로 windowSize를 확장해 dump line
+ * 169~244의 61회 suppress 회귀를 차단한다.
+ *
+ * 게이트:
+ *   1. route.type이 'transfer' 또는 'multi-transfer' — direct route는 환승 없음, 동적 확장 의미 X.
+ *   2. currentHopStrategy !== 'live-position' — live-position에서 격차 큰 경우는 GPS jitter / wrong
+ *      train 같은 abnormal jump 신호. 확장하면 false positive 알람 발생. (M3 신뢰도 게이트)
+ *   3. effectiveHopIndex와 candidateIndex 사이 arc에 transfer point가 끼어 있음 — 인접 station이
+ *      같은 name + 다른 line이면 transfer point (computeRouteArc는 양쪽 노선 entry 모두 보존).
+ *
+ * 모두 충족 시 windowSize = max(LOCKLESS_HOP_WINDOW_DEFAULT, |candidateIndex - effectiveHopIndex|)로
+ * 확장. 한 가지라도 미충족이면 기본 windowSize 유지.
+ *
+ * arc에 candidate가 없으면 (-1), 호출자가 어차피 isStationWithinHopWindow에서 false 반환하므로
+ * 본 helper는 -1을 받아도 안전(기본 windowSize 반환).
+ */
+function computeHopWindowSize(
+  arcStations: readonly Station[],
+  route: Route,
+  effectiveHopIndex: number,
+  candidateIndex: number,
+  currentHopStrategy:
+    | import('../../route/utils/stationProgressEstimator').StationProgressStrategy
+    | null,
+): number {
+  // M1 게이트 1: transfer/multi-transfer route만 동적 확장 대상.
+  if (!route || route.type === 'direct') return LOCKLESS_HOP_WINDOW_DEFAULT;
+  // M3 신뢰도 게이트: live-position 실측 strategy에서는 확장 X (abnormal jump 신호).
+  if (currentHopStrategy === 'live-position') return LOCKLESS_HOP_WINDOW_DEFAULT;
+  // 인덱스 가드: candidate가 arc 밖이면 default — isStationWithinHopWindow가 어차피 false.
+  if (candidateIndex < 0 || effectiveHopIndex < 0) return LOCKLESS_HOP_WINDOW_DEFAULT;
+  /* istanbul ignore next -- 호출 시점 invariant: arcIndexOf 결과 candidate는 arc 내부.
+     effectiveHopIndex도 currentHopIndex(estimator 또는 firedAlarms inferred, 둘 다 clamp) 후
+     사용되므로 out-of-bounds 도달 불가. 방어적 가드 — 직접 호출자 추가 시 안전. */
+  if (candidateIndex >= arcStations.length || effectiveHopIndex >= arcStations.length) {
+    return LOCKLESS_HOP_WINDOW_DEFAULT;
+  }
+
+  // M1 게이트 3: effectiveHopIndex와 candidateIndex 사이 transfer crossover 감지.
+  // computeRouteArc는 환승 시 fromLine 쪽 + toLine 쪽 entry 둘 다 push하므로
+  // 인접 station이 같은 name + 다른 line이면 transfer crossover 표지다.
+  const lo = Math.min(effectiveHopIndex, candidateIndex);
+  const hi = Math.max(effectiveHopIndex, candidateIndex);
+  let crossesTransfer = false;
+  for (let i = lo; i < hi; i++) {
+    const a = arcStations[i];
+    const b = arcStations[i + 1];
+    if (isSameStationName(a.name, b.name) && a.line !== b.line) {
+      crossesTransfer = true;
+      break;
+    }
+  }
+  if (!crossesTransfer) return LOCKLESS_HOP_WINDOW_DEFAULT;
+
+  // 모든 게이트 통과 → windowSize를 격차만큼 확장.
+  const gap = hi - lo;
+  return Math.max(LOCKLESS_HOP_WINDOW_DEFAULT, gap);
+}
+
 export interface UseStationAlarmInputs {
   route: Route;
   destination: Station | null;
@@ -466,6 +531,20 @@ export interface UseStationAlarmInputs {
    * Day 1 evidence: 13:49:38 fu=마장 gp=왕십리 mismatch → 마장 destination early false fire (1m 36s).
    */
   estimatorIsTimeIntegration?: boolean;
+  /**
+   * #1922 (M1+M3) — useFusedNearestStation.estimatorStrategy 패스스루.
+   *
+   * station-passed gate(`isStationWithinHopWindow`)의 동적 windowSize 계산 입력.
+   * route.type이 transfer/multi-transfer + strategy가 live-position이 아닐 때 환승 leg 진입 직후
+   * stuck된 effectiveHopIndex와 candidate idx 사이에 transfer point가 끼어 있으면 windowSize를
+   * 동적으로 확장해 dump line 169~244의 61회 suppress 회귀를 차단한다.
+   *
+   * M3 신뢰도 게이트: strategy === 'live-position'은 실측 신호이므로 격차가 크면 abnormal jump(=
+   * GPS jitter / wrong train) 신호라 windowSize 확장 X. 시간 적분 strategy일 때만 확장 허용.
+   *
+   * 미전달/null이면 기본 windowSize(LOCKLESS_HOP_WINDOW_DEFAULT=1) 유지 → backward-compat.
+   */
+  currentHopStrategy?: import('../../route/utils/stationProgressEstimator').StationProgressStrategy | null;
 }
 
 export function useStationAlarm({
@@ -487,6 +566,7 @@ export function useStationAlarm({
   subsurfaceStationDetected = false,
   trainProgressing = false,
   estimatorIsTimeIntegration = false,
+  currentHopStrategy = null,
 }: UseStationAlarmInputs): void {
   // #1405 — 동일 5-arg evaluateMovement 호출 helper. Phase ETA / API imminent / movementSuppressionReason
   // 3곳에서 같은 인자로 호출돼 SonarCloud CPD가 dup 검출. helper로 추출해 회피.
@@ -1198,20 +1278,31 @@ export function useStationAlarm({
             lastHopWindowNoSourceFgTsRef.current = now;
             logSuppressedHopWindowNoSource({ source: 'fg', stationName: candidateStation.name });
           }
-        } else if (isStationWithinHopWindow(candidateStation, arcStations, effectiveHopIndex)) {
-          // hop window 통과 — lockless origin hop 차단은 IIFE 내부의 broad !lock 가드가 담당.
-          // #1630 — effectiveHopIndex AND 조건 제거. lockless mode는 estimator(시간 적분)가
-          // idx를 임의 진행 — 출발역에 머물러도 idx>=1 정상 산출(2026-06-22 08:34:18 용마산
-          // evidence: estimator idx=1, 사용자는 출발 직후 = X1 위반). lock 활성 trip은
-          // boardingStationId 기준 origin 검사를 IIFE lock 가드가 처리.
         } else {
-          logSuppressedHopWindow({
-            source: 'fg',
-            stationName: candidateStation.name,
-            currentHopIndex: effectiveHopIndex,
-            candidateIndex: arcIndexOf(arcStations, candidateStation),
-          });
-          return;
+          // #1922 (M1+M3) — transfer leg에서 estimator stuck 시 windowSize 동적 확장.
+          const candidateIndex = arcIndexOf(arcStations, candidateStation);
+          const windowSize = computeHopWindowSize(
+            arcStations,
+            route,
+            effectiveHopIndex,
+            candidateIndex,
+            currentHopStrategy,
+          );
+          if (isStationWithinHopWindow(candidateStation, arcStations, effectiveHopIndex, windowSize)) {
+            // hop window 통과 — lockless origin hop 차단은 IIFE 내부의 broad !lock 가드가 담당.
+            // #1630 — effectiveHopIndex AND 조건 제거. lockless mode는 estimator(시간 적분)가
+            // idx를 임의 진행 — 출발역에 머물러도 idx>=1 정상 산출(2026-06-22 08:34:18 용마산
+            // evidence: estimator idx=1, 사용자는 출발 직후 = X1 위반). lock 활성 trip은
+            // boardingStationId 기준 origin 검사를 IIFE lock 가드가 처리.
+          } else {
+            logSuppressedHopWindow({
+              source: 'fg',
+              stationName: candidateStation.name,
+              currentHopIndex: effectiveHopIndex,
+              candidateIndex,
+            });
+            return;
+          }
         }
       }
 
@@ -1292,6 +1383,8 @@ export function useStationAlarm({
     userLocation?.lng,
     currentHopIndex,
     arcStations,
+    // #1922 (M1+M3) — strategy 변동 시 windowSize 재계산.
+    currentHopStrategy,
   ]);
 
   // #917 A2 follow-up — FG fast path: lock.trainCode가 currentStationArrival의 row에
@@ -1373,14 +1466,25 @@ export function useStationAlarm({
               stationName: candidateStation.name,
             });
           }
-        } else if (!isStationWithinHopWindow(candidateStation, arcStations, effectiveHopIndex)) {
-          logSuppressedHopWindow({
-            source: 'fg-arvlcd',
-            stationName: candidateStation.name,
-            currentHopIndex: effectiveHopIndex,
-            candidateIndex: arcIndexOf(arcStations, candidateStation),
-          });
-          return;
+        } else {
+          // #1922 (M1+M3) — fg-arvlcd 경로도 동일하게 transfer leg windowSize 동적 확장 적용.
+          const candidateIndex = arcIndexOf(arcStations, candidateStation);
+          const windowSize = computeHopWindowSize(
+            arcStations,
+            route,
+            effectiveHopIndex,
+            candidateIndex,
+            currentHopStrategy,
+          );
+          if (!isStationWithinHopWindow(candidateStation, arcStations, effectiveHopIndex, windowSize)) {
+            logSuppressedHopWindow({
+              source: 'fg-arvlcd',
+              stationName: candidateStation.name,
+              currentHopIndex: effectiveHopIndex,
+              candidateIndex,
+            });
+            return;
+          }
         }
       }
 
@@ -1438,6 +1542,8 @@ export function useStationAlarm({
     currentHopIndex,
     // #1266 — fast-path hop window 게이트 입력. arcStations 변화 시(환승 후 leg 전환 등) 재평가.
     arcStations,
+    // #1922 (M1+M3) — fg-arvlcd 경로 동적 windowSize 재계산.
+    currentHopStrategy,
   ]);
 
   // #1290/#1298 — subsurface verdict 기반 station-passed 발사.

--- a/src/features/arrival/components/ArrivalSourceNotice.tsx
+++ b/src/features/arrival/components/ArrivalSourceNotice.tsx
@@ -9,6 +9,27 @@ interface Props {
 }
 
 /**
+ * #1922 — ETA 행을 사용자 UI에 노출할지 결정. `true` 반환 = 숨김, `false` = 노출.
+ *
+ * MOCK_ARRIVALS(`isMock=true && source 미지정`)는 데모용 정적 값이라 실측이 전혀 아니다.
+ * 사용자에게 "도착 예정 13:54 / 5분 남았다" 같은 모순된 ETA가 노출되는 회귀를 차단하기 위해
+ * 호출자는 본 helper로 ETA 행 자체를 숨긴다.
+ *
+ * 반환값 (true = 숨김 / false = 노출):
+ *   - arrival === null: true (숨김) — 표시할 데이터 자체 없음.
+ *   - source === 'closed': true (숨김) — 운행 종료, ETA 의미 없음.
+ *   - isMock === true + source 미지정: true (숨김) — hardcoded MOCK_ARRIVALS 정적 값.
+ *   - source === 'schedule': false (노출) — wall-clock anchor 기반 정상 카운트다운.
+ *   - source === 'realtime' 또는 기본 (isMock=false): false (노출).
+ */
+export function shouldHideArrivalEta(arrival: StationArrival | null): boolean {
+  if (!arrival) return true;
+  if (arrival.source === 'closed') return true;
+  if (arrival.isMock === true && arrival.source !== 'schedule') return true;
+  return false;
+}
+
+/**
  * 도착정보의 source(실시간/시간표/운행종료)에 따라 사용자에게 적절한 알림 텍스트를 노출.
  * 홈/favorites/위젯 등 여러 화면에서 동일한 라벨 분기 로직을 공유하기 위해 분리.
  * source가 'realtime'이거나 arrival이 null이면 null 반환.

--- a/src/features/arrival/components/__tests__/ArrivalSourceNotice.test.tsx
+++ b/src/features/arrival/components/__tests__/ArrivalSourceNotice.test.tsx
@@ -1,5 +1,5 @@
 import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
-import { ArrivalSourceNotice } from '../ArrivalSourceNotice';
+import { ArrivalSourceNotice, shouldHideArrivalEta } from '../ArrivalSourceNotice';
 import type { StationArrival } from '../../api/arrivalApi';
 
 const base: StationArrival = { up: [], down: [] };
@@ -37,5 +37,33 @@ describe('ArrivalSourceNotice', () => {
       <ArrivalSourceNotice arrival={{ ...base, isMock: true }} />,
     );
     expect(getByTestId('arrival-mock-notice')).toBeTruthy();
+  });
+});
+
+describe('shouldHideArrivalEta (#1922)', () => {
+  // 사용자에게 ETA를 노출해도 되는지 판정. MOCK_ARRIVALS(source 미지정 + isMock=true)는 정적 데모값이라 ETA 자체 비공개.
+
+  it('arrival이 null이면 ETA 숨김 (true)', () => {
+    expect(shouldHideArrivalEta(null)).toBe(true);
+  });
+
+  it('source=realtime이면 ETA 노출 (false)', () => {
+    expect(shouldHideArrivalEta({ ...base, source: 'realtime' })).toBe(false);
+  });
+
+  it('source=schedule이면 ETA 노출 (false) — wall-clock anchor라 정상 카운트다운', () => {
+    expect(shouldHideArrivalEta({ ...base, source: 'schedule', isMock: true })).toBe(false);
+  });
+
+  it('source=closed면 ETA 숨김 (true) — 운행 종료', () => {
+    expect(shouldHideArrivalEta({ ...base, source: 'closed', isMock: true })).toBe(true);
+  });
+
+  it('source 미지정 + isMock=true면 ETA 숨김 (true) — MOCK_ARRIVALS hardcoded', () => {
+    expect(shouldHideArrivalEta({ ...base, isMock: true })).toBe(true);
+  });
+
+  it('source 미지정 + isMock=false면 ETA 노출 (false) — 기본 동작', () => {
+    expect(shouldHideArrivalEta({ ...base })).toBe(false);
   });
 });

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
@@ -419,7 +419,9 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
 
     it('#1437 lock 없음 + routeCtx + 시간 경과 → lockless-route-hop이 displayOnly 채널에 노출', () => {
       // estimator closure 호출 경로 커버는 유지 — 다만 fire path는 GPS, estimator는 displayOnly.
-      const result = runEstimatorScenario({ elapsedMs: 5 * 60_000 });
+      // #1922 (M2) — elapsedMs는 LOCKLESS_TIME_INTEGRATION_STUCK_TIMEOUT_MS(90s) 이내로 유지해야
+      // tryLocklessRouteHop의 stuck guard에 걸리지 않는다 (lastObserved 부재 시 trip 초기 90s 허용).
+      const result = runEstimatorScenario({ elapsedMs: 60_000 });
       expect(result.current.source).not.toBe('boarding-lock-interp');
       expect(result.current.displayOnlyEstimate?.strategy).toBe('lockless-route-hop');
     });
@@ -463,7 +465,8 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
         useFusedNearestStation(undefined, undefined, routeCtx),
       );
 
-      jest.setSystemTime(T0 + 5 * 60_000);
+      // #1922 (M2) — 90s 이내 경과로 stuck guard 우회 (lastObserved 부재 시 trip 초기 90s 허용).
+      jest.setSystemTime(T0 + 60_000);
       rerender({});
 
       jest.useRealTimers();

--- a/src/features/route/utils/__tests__/stationProgressEstimator.test.ts
+++ b/src/features/route/utils/__tests__/stationProgressEstimator.test.ts
@@ -531,15 +531,17 @@ describe('estimateStationProgress', () => {
   describe('Strategy ⑤ LocklessRouteHop — lock 없는 trip 시간 적분 (#1207, Epic #1204 D1)', () => {
     it('lock null + locklessTrip 5분 경과 + 60s/hop → hop index 5 (종착으로 clamp, arc 길이 5)', () => {
       // arcLength=5, lastIdx=4. 300_000ms / 60_000ms = 5 hop → idx 5 > 4 → clamp to 4.
+      // #1922 (M2) — 5분 경과지만 lastObserved를 fresh(now-10s)로 줘서 stuck guard 통과.
       const hop60s = (_fromIdx: number) => 60_000;
+      const now = T0 + 5 * 60_000;
       const r = estimateStationProgress({
         lock: null,
         locklessTrip: { tripStartedAt: T0 },
         arcStations: ARC,
-        now: T0 + 5 * 60_000,
+        now,
         trainProgress: null,
         lockedTrainCode: null,
-        lastObserved: null,
+        lastObserved: { arcIndex: 4, observedAtMs: now - 10_000 },
         hopTimeMsForHop: hop60s,
         ...NO_ARRIVAL_INPUT,
       });
@@ -552,6 +554,7 @@ describe('estimateStationProgress', () => {
 
     it('lock null + locklessTrip + arc 충분히 길고 60s/hop → 정확한 hop index (5분에 5번째 hop)', () => {
       // 긴 arc로 종착 clamp가 아닌 정확한 hop index 검증.
+      // #1922 (M2) — lastObserved 신선해야 5분 경과해도 stuck guard 통과.
       const longArc: Station[] = Array.from({ length: 10 }, (_v, i) => ({
         id: `7-${i}`,
         name: `역${i}`,
@@ -561,14 +564,15 @@ describe('estimateStationProgress', () => {
         lng: 0,
       }));
       const hop60s = (_fromIdx: number) => 60_000;
+      const now = T0 + 5 * 60_000;
       const r = estimateStationProgress({
         lock: null,
         locklessTrip: { tripStartedAt: T0 },
         arcStations: longArc,
-        now: T0 + 5 * 60_000,
+        now,
         trainProgress: null,
         lockedTrainCode: null,
-        lastObserved: null,
+        lastObserved: { arcIndex: 5, observedAtMs: now - 10_000 },
         hopTimeMsForHop: hop60s,
         ...NO_ARRIVAL_INPUT,
       });
@@ -630,14 +634,16 @@ describe('estimateStationProgress', () => {
 
     it('lock null + locklessTrip + elapsed가 arc 전체 길이 초과 → 마지막 인덱스로 clamp', () => {
       // arcLength=5, 100 hop 경과 → idx 100을 lastIdx=4로 clamp.
+      // #1922 (M2) — lastObserved fresh로 stuck guard 통과 후 종착 clamp 검증.
+      const now = T0 + 100 * HOP_TIME_MS;
       const r = estimateStationProgress({
         lock: null,
         locklessTrip: { tripStartedAt: T0 },
         arcStations: ARC,
-        now: T0 + 100 * HOP_TIME_MS,
+        now,
         trainProgress: null,
         lockedTrainCode: null,
-        lastObserved: null,
+        lastObserved: { arcIndex: 4, observedAtMs: now - 10_000 },
         hopTimeMsForHop: UNIFORM_HOP,
         ...NO_ARRIVAL_INPUT,
       });
@@ -699,21 +705,93 @@ describe('estimateStationProgress', () => {
     it('lock null + locklessTrip + variable hop time (환승 leg) → segment별 적분', () => {
       // arc에 환승 leg 가정. fromIdx 0,1: 60s, fromIdx 2,3: 120s.
       // 240s 경과 → 60+60+120=240 정확히 → 3 hop → idx 3.
+      // #1922 (M2) — lastObserved fresh로 stuck guard 통과 후 segment별 적분 검증.
       const variableHop = (fromIdx: number) =>
         fromIdx >= 2 ? 120_000 : 60_000;
+      const now = T0 + 240_000;
       const r = estimateStationProgress({
         lock: null,
         locklessTrip: { tripStartedAt: T0 },
         arcStations: ARC,
-        now: T0 + 240_000,
+        now,
         trainProgress: null,
         lockedTrainCode: null,
-        lastObserved: null,
+        lastObserved: { arcIndex: 2, observedAtMs: now - 10_000 },
         hopTimeMsForHop: variableHop,
         ...NO_ARRIVAL_INPUT,
       });
       expect(r?.strategy).toBe('lockless-route-hop');
       expect(r?.index).toBe(3);
+    });
+
+    describe('#1922 (M2) — 실측 신호 부재 90s+ stuck guard', () => {
+      // 환승 leg 진입 후 lastObserved 끊긴 상태로 90s+ 지속되면 시간 적분 자체를 null 반환.
+      // dump line 169~244의 estimator stuck → station-passed gate 매역 reject(61회) 회귀 차단.
+
+      it('lastObserved 없음 + tripStartedAt 기준 90s 초과 → null', () => {
+        const now = T0 + 91_000;
+        const r = estimateStationProgress({
+          lock: null,
+          locklessTrip: { tripStartedAt: T0 },
+          arcStations: ARC,
+          now,
+          trainProgress: null,
+          lockedTrainCode: null,
+          lastObserved: null, // 실측 신호 부재
+          hopTimeMsForHop: UNIFORM_HOP,
+          ...NO_ARRIVAL_INPUT,
+        });
+        expect(r).toBeNull();
+      });
+
+      it('lastObserved 없음 + tripStartedAt 기준 90s 이내 → 정상 lockless-route-hop', () => {
+        // lockless trip 초기 90s 안에는 시간 적분 허용 (첫 실측 신호 도착 전 grace window).
+        const now = T0 + 60_000;
+        const r = estimateStationProgress({
+          lock: null,
+          locklessTrip: { tripStartedAt: T0 },
+          arcStations: ARC,
+          now,
+          trainProgress: null,
+          lockedTrainCode: null,
+          lastObserved: null,
+          hopTimeMsForHop: UNIFORM_HOP,
+          ...NO_ARRIVAL_INPUT,
+        });
+        expect(r?.strategy).toBe('lockless-route-hop');
+      });
+
+      it('lastObserved 있지만 90s 초과 stale → null', () => {
+        const now = T0 + 200_000;
+        const r = estimateStationProgress({
+          lock: null,
+          locklessTrip: { tripStartedAt: T0 },
+          arcStations: ARC,
+          now,
+          trainProgress: null,
+          lockedTrainCode: null,
+          lastObserved: { arcIndex: 1, observedAtMs: now - 95_000 }, // 95s 전 = stale
+          hopTimeMsForHop: UNIFORM_HOP,
+          ...NO_ARRIVAL_INPUT,
+        });
+        expect(r).toBeNull();
+      });
+
+      it('lastObserved fresh (90s 이내) → 정상 lockless-route-hop', () => {
+        const now = T0 + 5 * 60_000; // 5분 경과 (오래)
+        const r = estimateStationProgress({
+          lock: null,
+          locklessTrip: { tripStartedAt: T0 },
+          arcStations: ARC,
+          now,
+          trainProgress: null,
+          lockedTrainCode: null,
+          lastObserved: { arcIndex: 3, observedAtMs: now - 30_000 }, // 30s 전 = fresh
+          hopTimeMsForHop: UNIFORM_HOP,
+          ...NO_ARRIVAL_INPUT,
+        });
+        expect(r?.strategy).toBe('lockless-route-hop');
+      });
     });
   });
 

--- a/src/features/route/utils/__tests__/tripDirection.test.ts
+++ b/src/features/route/utils/__tests__/tripDirection.test.ts
@@ -54,4 +54,95 @@ describe('resolveTripDirection', () => {
     });
     expect(resolveTripDirection(route, '강남', '1-001')).toBe('down');
   });
+
+  describe('#1922 — closed loop (2호선 환상선) direction', () => {
+    // 2호선 본선 closed loop은 id 사전순 정렬이 wraparound와 일치하지 않을 수 있으므로
+    // shortestLinePathIndices로 짧은 쪽 path를 산출해 방향 결정.
+    // 강변(2-014) → 잠실나루(2-015)는 short forward (path[1] > currIdx) → 'down'.
+    // 잠실나루(2-015) → 강변(2-014)는 short backward (path[1] < currIdx) → 'up'.
+
+    it('환승 후 leg(2호선) — 강변 → 잠실나루 = down (외선)', () => {
+      // 7→2 transfer route. 현재 위치가 강변(2-014)일 때 두 번째 leg(2호선)으로 direction 산출.
+      const route = makeTransferRoute({
+        transferName: '건대입구',
+        fromLine: '7',
+        toLine: '2',
+        stopsToTransfer: 5,
+        stopsFromTransfer: 3,
+      });
+      // destination = 잠실나루(2-015), current = 강변(2-014) → 'down' (외선 방향)
+      expect(resolveTripDirection(route, '잠실나루', '2-014')).toBe('down');
+    });
+
+    it('환승 후 leg(2호선) — 잠실나루 → 강변 = up (내선)', () => {
+      // 7→2 transfer route. destination = 강변(2-014), current = 잠실나루(2-015) → 'up'
+      const route = makeTransferRoute({
+        transferName: '건대입구',
+        fromLine: '7',
+        toLine: '2',
+        stopsToTransfer: 5,
+        stopsFromTransfer: 1,
+      });
+      expect(resolveTripDirection(route, '강변(동서울터미널)', '2-015')).toBe('up');
+    });
+
+    it('direct 2호선 환상선 leg 내 정상 방향 결정', () => {
+      // direct route on line 2: 강변 → 잠실나루 = down (외선)
+      const route = makeDirectRoute(1, '2');
+      expect(resolveTripDirection(route, '잠실나루', '2-014')).toBe('down');
+    });
+  });
+
+  describe('#1922 — multi-transfer post-transfer leg direction', () => {
+    // multi-transfer route에서도 current.line이 두 번째 또는 마지막 leg에 진입한 경우
+    // pickLegForCurrentLine이 해당 leg을 선택해 direction 결정.
+
+    it('multi-transfer 마지막 leg(current.line === last.toLine) 진입 후 direction 결정', () => {
+      // 1호선 → 4호선 → 2호선 multi-transfer. current가 2호선(마지막 leg toLine)에 있으면
+      // 마지막 leg(toLine=2)로 direction 결정. 강변(2-014) → 잠실나루(2-015) = down.
+      const route = makeMultiTransferRoute({
+        transfers: [
+          { transferName: '서울역', fromLine: '1', toLine: '4', stopsToTransfer: 5 },
+          { transferName: '동대문역사문화공원', fromLine: '4', toLine: '2', stopsToTransfer: 3 },
+        ],
+        stopsAfterLastTransfer: 5,
+      });
+      // current 강변(2-014, 2호선), destination 잠실나루
+      expect(resolveTripDirection(route, '잠실나루', '2-014')).toBe('down');
+    });
+
+    it('current가 어느 leg에도 없으면 first-leg fallback', () => {
+      // 1호선 → 4호선 multi-transfer. current가 7호선(어느 leg에도 없음) → 첫 leg fallback.
+      // 첫 leg은 line 1, endName='서울역'. current가 line 7이라 currIdx=-1 → null 반환 (정상).
+      const route = makeMultiTransferRoute({
+        transfers: [
+          { transferName: '서울역', fromLine: '1', toLine: '4', stopsToTransfer: 5 },
+          { transferName: '동대문역사문화공원', fromLine: '4', toLine: '2', stopsToTransfer: 3 },
+        ],
+        stopsAfterLastTransfer: 5,
+      });
+      // 7-015는 line 7 station. 어느 leg에도 없는 line → first-leg(line 1)로 fallback → currIdx=-1 → null.
+      expect(resolveTripDirection(route, '잠실나루', '7-015')).toBeNull();
+    });
+
+    it('transfer route 두 번째 leg(toLine) 진입 후 direction 결정', () => {
+      // 1호선 → 2호선 transfer. current가 2호선에 있으면 toLine으로 direction 결정.
+      const route = makeTransferRoute({
+        transferName: '서울역',
+        fromLine: '1',
+        toLine: '2',
+        stopsToTransfer: 5,
+        stopsFromTransfer: 3,
+      });
+      // current 강변(2-014, 2호선), destination 잠실나루(2-015) → 'down'
+      expect(resolveTripDirection(route, '잠실나루', '2-014')).toBe('down');
+    });
+
+    it('currentStationId가 stations.json에 없으면 first-leg fallback (방어 분기)', () => {
+      // getStationById가 undefined를 반환하면 pickLegForCurrentLine을 건너뛰고 getFirstLeg 사용.
+      // first-leg(line 1) + non-existent id → currIdx=-1 → null.
+      const route = makeDirectRoute(5, '1');
+      expect(resolveTripDirection(route, '서울역', 'NON-EXISTENT-XYZ')).toBeNull();
+    });
+  });
 });

--- a/src/features/route/utils/stationProgressEstimator.ts
+++ b/src/features/route/utils/stationProgressEstimator.ts
@@ -12,7 +12,10 @@ import type { Station } from '../../../shared/types/station';
 import type { TrainProgressResult } from './trackTrainProgress';
 import { projectArrivalEtaStation } from '../../arrival/utils/arrivalEtaProjection';
 import { hopsElapsedFrom } from './hopTime';
-import { ESTIMATOR_STUCK_TIMEOUT_MS } from '../../../shared/constants/realtime';
+import {
+  ESTIMATOR_STUCK_TIMEOUT_MS,
+  LOCKLESS_TIME_INTEGRATION_STUCK_TIMEOUT_MS,
+} from '../../../shared/constants/realtime';
 
 /**
  * ADR-008 — 탑승 진행 추정(BoardingLock 활성 trip 중 현재역) 합성기.
@@ -327,6 +330,7 @@ function tryLocklessRouteHop(
   tripStartedAt: number,
   now: number,
   hopTimeMsForHop: (fromIdx: number) => number,
+  lastObserved: { arcIndex: number; observedAtMs: number } | null,
 ): StationProgressEstimate | null {
   // 상위 estimateStationProgress가 arcStations.length === 0을 미리 차단하므로 본 가드는
   // 도달 불가하지만 방어적 유지 — 직접 호출자가 추가될 때 안전.
@@ -340,6 +344,19 @@ function tryLocklessRouteHop(
   if (arcStations.length === 1) return null;
   const elapsedMs = now - tripStartedAt;
   if (elapsedMs < 0) return null;
+
+  // #1922 (M2) — 실측 신호 부재가 LOCKLESS_TIME_INTEGRATION_STUCK_TIMEOUT_MS(90s) 이상 지속되면
+  // 시간 적분 자체를 null 반환. estimator stale 값이 silent forward되어 station-passed gate가
+  // 매역 reject(dump line 169~244, 61회)되는 회귀 차단.
+  //
+  // 신선도 source 우선순위:
+  //   1) lastObserved.observedAtMs — LivePosition 직전 관측. 있으면 그 시점 기준 age 계산.
+  //   2) tripStartedAt — lastObserved 없으면 trip 시작 시점 기준 age 계산 (lockless trip 초기 90s 허용).
+  //
+  // 임계 초과 시 null → useFusedNearestStation cascade가 fusion fallback(실측 idx)을 forward.
+  const stalenessAnchorMs = lastObserved?.observedAtMs ?? tripStartedAt;
+  if (now - stalenessAnchorMs > LOCKLESS_TIME_INTEGRATION_STUCK_TIMEOUT_MS) return null;
+
   const hops = hopsElapsedFrom(arcStations.length, 0, elapsedMs, hopTimeMsForHop);
   const lastIdx = arcStations.length - 1;
   const idx = Math.min(hops, lastIdx);
@@ -371,13 +388,20 @@ export function arcIndexOfStation(
 export function estimateStationProgress(
   input: StationProgressEstimatorInput,
 ): StationProgressEstimate | null {
-  const { lock, locklessTrip, arcStations, now, hopTimeMsForHop } = input;
+  const { lock, locklessTrip, arcStations, now, hopTimeMsForHop, lastObserved } = input;
   if (arcStations.length === 0) return null;
   // Lockless 분기 (#1207): lock이 null이고 locklessTrip 컨텍스트가 제공되면 LocklessRouteHop으로 적분.
   // locklessTrip 미제공이면 기존 동작 유지(null) — 호출자가 명시적으로 lockless 활성을 옵트인.
   if (!lock) {
     if (locklessTrip) {
-      return tryLocklessRouteHop(arcStations, locklessTrip.tripStartedAt, now, hopTimeMsForHop);
+      // #1922 (M2) — lastObserved를 stuck guard 신선도 source로 전달.
+      return tryLocklessRouteHop(
+        arcStations,
+        locklessTrip.tripStartedAt,
+        now,
+        hopTimeMsForHop,
+        lastObserved,
+      );
     }
     return null;
   }

--- a/src/features/route/utils/tripDirection.ts
+++ b/src/features/route/utils/tripDirection.ts
@@ -1,28 +1,98 @@
+import type { LineNumber } from '../../../shared/types/station';
 import type { Route } from '../../../shared/utils/stationRoute';
-import { getFirstLeg, getStationsOnLine } from '../../../shared/utils/stationRoute';
+import { getFirstLeg, getStationsOnLine, getStationById } from '../../../shared/utils/stationRoute';
+import { isClosedLoopMainStation, shortestLinePathIndices } from '../../../shared/utils/lineLoopPath';
 
 export type TripDirection = 'up' | 'down';
 
 /**
- * 현재 위치 station id와 경로의 첫 구간을 비교해 진행 방향(상행/하행)을 유도한다.
+ * #1922 — currentStationId의 노선에 맞는 leg의 line + endName을 산출한다.
+ *
+ * 기본은 `getFirstLeg`(첫 leg)이지만, 환승 후 leg에 진입하면 current station은 다른 line이 된다.
+ * 본 함수가 current 노선에 일치하는 leg를 선택해 환승 후에도 direction 추론을 가능하게 한다.
+ *
+ * 산출 규칙:
+ *   - direct: 항상 첫 leg(=유일 leg).
+ *   - transfer: current.line === fromLine → 첫 leg(fromLine, transferName).
+ *               current.line === toLine → 두 번째 leg(toLine, destinationName).
+ *               그 외 → 첫 leg fallback(기존 동작 유지).
+ *   - multi-transfer: 첫 leg부터 순회해 current.line이 일치하는 leg를 채택. fromLine은
+ *     transfers[i].fromLine, endName은 transfers[i].transferName. 마지막 leg는 toLine,
+ *     endName=destinationName.
+ */
+function pickLegForCurrentLine(
+  route: NonNullable<Route>,
+  destinationName: string,
+  currentLine: LineNumber,
+): { line: LineNumber; endName: string } {
+  if (route.type === 'direct') {
+    return { line: route.line, endName: destinationName };
+  }
+  if (route.type === 'transfer') {
+    if (currentLine === route.toLine) {
+      return { line: route.toLine, endName: destinationName };
+    }
+    return { line: route.fromLine, endName: route.transferName };
+  }
+  // multi-transfer
+  const { transfers } = route;
+  for (let i = 0; i < transfers.length; i++) {
+    if (currentLine === transfers[i].fromLine) {
+      return { line: transfers[i].fromLine, endName: transfers[i].transferName };
+    }
+  }
+  const last = transfers[transfers.length - 1];
+  if (currentLine === last.toLine) {
+    return { line: last.toLine, endName: destinationName };
+  }
+  // current가 어느 leg에도 없으면 첫 leg fallback (기존 동작).
+  return getFirstLeg(route, destinationName);
+}
+
+/**
+ * 현재 위치 station id와 경로의 활성 leg(=current.line에 일치하는 leg)을 비교해 진행 방향(상행/하행)을 유도한다.
  *
  * 노선별 station id 정렬상의 index를 기준으로 판정:
  *   - 다음 waypoint index > 현재 station index → 'down'
  *   - 그 반대 → 'up'
- *   - 현재가 다른 노선이거나 인덱스 동일 → null (호출자는 양방향 합산으로 폴백)
+ *   - 현재가 leg line에 없거나 인덱스 동일 → null (호출자는 양방향 합산으로 폴백)
  *
- * 환상선(2호선 등)은 index 단방향성이 깨질 수 있으므로 정확하지 않을 수 있다.
- * 정확한 방향 정보를 강제할 수 없는 경계 케이스는 null로 안전 폴백한다.
+ * #1922 — 2호선 본선처럼 closed loop(환상선)인 경우, 단순 index 비교로는 wraparound 방향을
+ * 잘못 판정할 수 있다. 양 끝점이 모두 closed loop 본선이면 `shortestLinePathIndices`로 wraparound
+ * 짧은 쪽 경로를 산출해 첫 step의 방향(idx 증가/감소)으로 'up'/'down'을 결정한다.
+ *
+ * #1922 — 환승 후 leg(current.line이 route 두 번째 이후 leg)에서도 direction을 결정할 수 있다.
+ * 기존엔 첫 leg(`getFirstLeg`)만 봐서 환승 후엔 current.id가 첫 leg line에 없어 null이었다.
+ * `pickLegForCurrentLine`이 current.line과 일치하는 leg을 선택해 환상선 leg에서도 direction을 산출.
+ *
+ * 정확한 방향 정보를 강제할 수 없는 경계 케이스(다른 노선/같은 idx)는 null로 안전 폴백한다.
  */
 export function resolveTripDirection(
   route: NonNullable<Route>,
   destinationName: string,
   currentStationId: string,
 ): TripDirection | null {
-  const { line, endName } = getFirstLeg(route, destinationName);
+  // #1922 — current.line에 맞는 leg을 선택. current가 stations.json에 없으면 기존 first-leg fallback.
+  const currentStation = getStationById(currentStationId);
+  const { line, endName } = currentStation
+    ? pickLegForCurrentLine(route, destinationName, currentStation.line)
+    : getFirstLeg(route, destinationName);
   const lineStations = getStationsOnLine(line);
   const currIdx = lineStations.findIndex((s) => s.id === currentStationId);
   const nextIdx = lineStations.findIndex((s) => s.name === endName);
   if (currIdx < 0 || nextIdx < 0 || currIdx === nextIdx) return null;
+
+  // #1922 — closed loop 본선 양 끝점: wraparound 짧은 쪽 path의 첫 step 방향으로 결정.
+  // 2호선 강변 → 잠실나루 같은 short forward path는 path[1] > currIdx → 'down'(외선 외향).
+  // 신촌 → 시청 같은 wraparound는 path[1] < currIdx → 'up'(내선 외향).
+  const currId = lineStations[currIdx].id;
+  const nextId = lineStations[nextIdx].id;
+  if (isClosedLoopMainStation(line, currId) && isClosedLoopMainStation(line, nextId)) {
+    const path = shortestLinePathIndices(lineStations, currIdx, nextIdx, line);
+    // shortestLinePathIndices invariant: currIdx !== nextIdx → path.length >= 2
+    const firstStepIdx = path[1];
+    return firstStepIdx > currIdx ? 'down' : 'up';
+  }
+
   return nextIdx > currIdx ? 'down' : 'up';
 }

--- a/src/screens/FavoritesScreen.tsx
+++ b/src/screens/FavoritesScreen.tsx
@@ -26,7 +26,7 @@ import { formatArrivalTime } from '../shared/utils/formatTime';
 import { getStationDisplayName, matchesStationQuery } from '../shared/utils/stationDisplay';
 import { useTheme, typography, type ThemeColors } from '../shared/theme';
 import stationsData from '../data/stations.json';
-import { ArrivalSourceNotice } from '../features/arrival/components/ArrivalSourceNotice';
+import { ArrivalSourceNotice, shouldHideArrivalEta } from '../features/arrival/components/ArrivalSourceNotice';
 import type { StationArrival } from '../features/arrival/api/arrivalApi';
 
 const allStations = stationsData as Station[];
@@ -226,7 +226,8 @@ function FavoriteCard({
   const { station, label } = entry;
   const [editing, setEditing] = useState(false);
   const [draftLabel, setDraftLabel] = useState(label ?? '');
-  const showRows = arrival != null && arrival.source !== 'closed';
+  // #1922 — MOCK_ARRIVALS는 ETA 자체 비공개(데모용 정적값). schedule/realtime은 노출.
+  const showRows = arrival != null && !shouldHideArrivalEta(arrival);
   const emptyArrival =
     showRows && arrival.up.length === 0 && arrival.down.length === 0;
   const stationDisplay = getStationDisplayName(station);

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -48,7 +48,7 @@ import { PermissionChangeBanner } from '../shared/ui/PermissionChangeBanner';
 import { useLocationPermissionWatcher } from '../shared/hooks/useLocationPermissionWatcher';
 import { SourceBadge } from '../features/arrival/components/SourceBadge';
 import { resolveNotificationSource } from '../features/alarm/utils/notificationSource';
-import { ArrivalSourceNotice } from '../features/arrival/components/ArrivalSourceNotice';
+import { ArrivalSourceNotice, shouldHideArrivalEta } from '../features/arrival/components/ArrivalSourceNotice';
 import { useSleepModeGuide } from '../features/settings/hooks/useSleepModeGuide';
 import { useSilentPushHealthCheck } from '../features/alarm/hooks/useSilentPushHealthCheck';
 import { useArrivalAutoClear } from '../features/arrival/hooks/useArrivalAutoClear';
@@ -203,7 +203,7 @@ export default function HomeScreen() {
   // #1677 — silent push 60s+ 미수신 감지. FG 시 backendSsotAccepts 강제 false → device tier fallback.
   // 신규 폴링 없음 — 기존 arrival/position 30s cycle 재사용.
   const { healthy: silentPushHealthy } = useSilentPushHealthCheck();
-  const { result, liveResult, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source, currentHopIndex, arcStations, trainProgressing, estimatorIsTimeIntegration, backendSsotCurrentStationId, environment } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal }, wifiStation, silentPushHealthy);
+  const { result, liveResult, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source, currentHopIndex, arcStations, trainProgressing, estimatorIsTimeIntegration, estimatorStrategy, backendSsotCurrentStationId, environment } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal }, wifiStation, silentPushHealthy);
 
   // #1621 Phase B — V1 mismatch 자동 측정. UI currentStation(cascade picker)이 backend SSoT
   // 권위 mirror와 일치하지 않으면 alarmLog 'v1-mismatch' reason으로 1분 dedup 적재.
@@ -571,6 +571,8 @@ export default function HomeScreen() {
     trainProgressing,
     // #1817 — 시간 적분 estimator 활성 시 fusion/GPS mismatch로 destination/transfer early 조기 발사 차단.
     estimatorIsTimeIntegration,
+    // #1922 (M1+M3) — station-passed hop window 동적 확장 입력(transfer leg estimator stuck 대응).
+    currentHopStrategy: estimatorStrategy,
   });
 
   // #584 PR B — BoardingLock 진입점. UI 렌더링/lock 생성만 담당하며,
@@ -1513,7 +1515,8 @@ export default function HomeScreen() {
                   <Text style={[styles.arrivalItem, { color: colors.ink }]}>{t('home.loading')}</Text>
                 )}
                 <ArrivalSourceNotice arrival={arrival} />
-                {arrival && arrival.source !== 'closed' && (
+                {/* #1922 — MOCK_ARRIVALS(source 미지정 + isMock=true)는 데모용 정적값이라 ETA 자체 비공개. */}
+                {arrival && !shouldHideArrivalEta(arrival) && (
                   <>
                     <ArrivalDirectionGroup
                       label={t('arrival.upbound')}

--- a/src/shared/constants/realtime.ts
+++ b/src/shared/constants/realtime.ts
@@ -194,3 +194,25 @@ export const LOCK_GPS_DRIFT_THRESHOLD_M = 1000;
  *   - tryLivePosition/ArrivalEta가 살아있으면 이 분기 미도달 — tryDefaultHop(dead zone)에서만 적용.
  */
 export const ESTIMATOR_STUCK_TIMEOUT_MS = 5 * 60_000;
+
+/**
+ * #1922 (M2) — lockless route-hop / re-anchored time-integration "stuck" 가드.
+ *
+ * `tryLocklessRouteHop`은 실측 신호(lastObserved) 없이 `tripStartedAt`만으로 시간 적분을 진행한다.
+ * 환승 leg 진입 직후 estimator가 시간 적분으로 fall-through되면 candidate idx가 더 진행해도
+ * `effectiveHopIndex`가 stuck하여 station-passed gate(`isStationWithinHopWindow`)가 매역 reject
+ * 한다 (#1922 dump line 169~244: 61회 suppress evidence).
+ *
+ * 본 임계 이상 실측 신호 부재가 지속되면 시간 적분 자체를 null 반환 → useFusedNearestStation
+ * cascade가 fusion fallback(실측 idx)을 forward하도록 유도. estimator stale 값이 silent하게
+ * forward되는 회귀를 차단한다.
+ *
+ * 90s 임계 (인접역 평균 hop time ~90s):
+ *   - 한 hop 통과 시간 동안 실측 신호(SSoT mirror / lastObserved / arrivalCode arrived) 없으면
+ *     "estimator가 stuck하기에 충분히 stale"이라 판단.
+ *   - 90s 초과 시 시간 적분 자체를 null 반환 → 다음 tier가 결정 권한 회수.
+ *   - lastObserved.observedAtMs가 부재하면 tripStartedAt 기준 90s 경과 시 null (lockless trip 초기
+ *     "아직 첫 실측 신호 전" 구간만 시간 적분 허용).
+ *   - reanchored-hop / default-hop은 lock 기반이므로 본 게이트는 lockless 전략에만 적용.
+ */
+export const LOCKLESS_TIME_INTEGRATION_STUCK_TIMEOUT_MS = 90_000;

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -45,7 +45,7 @@
     "arrivalInfoTitle": "Train arrivals",
     "loading": "Loading...",
     "mockNotice": "Showing estimated data — real-time unavailable",
-    "scheduleNotice": "Showing schedule · loading real-time",
+    "scheduleNotice": "Schedule-based · no real-time response",
     "closedNotice": "Service hours have ended",
     "noArrivalInfo": "No arrival info",
     "notNearStationTitle": "Not near a subway station",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -45,7 +45,7 @@
     "arrivalInfoTitle": "列車到着情報",
     "loading": "読み込み中...",
     "mockNotice": "リアルタイムデータが取得できないため予想データを表示しています",
-    "scheduleNotice": "ダイヤに基づく表示 · リアルタイム情報を取得中",
+    "scheduleNotice": "ダイヤに基づく表示 · リアルタイム応答なし",
     "closedNotice": "運行時間外です",
     "noArrivalInfo": "到着情報なし",
     "notNearStationTitle": "地下鉄駅の近くではありません",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -45,7 +45,7 @@
     "arrivalInfoTitle": "열차 도착 정보",
     "loading": "불러오는 중...",
     "mockNotice": "실시간 데이터를 불러올 수 없어 예상 데이터를 표시합니다",
-    "scheduleNotice": "시간표 기준 · 실시간 정보 불러오는 중",
+    "scheduleNotice": "시간표 기반 · 실시간 응답 없음",
     "closedNotice": "운행이 종료된 시간대입니다",
     "noArrivalInfo": "도착 정보 없음",
     "notNearStationTitle": "지하철역 근처가 아닙니다",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -45,7 +45,7 @@
     "arrivalInfoTitle": "列车到达信息",
     "loading": "加载中...",
     "mockNotice": "无法获取实时数据,显示预测数据",
-    "scheduleNotice": "按时刻表显示 · 正在加载实时信息",
+    "scheduleNotice": "基于时刻表 · 无实时响应",
     "closedNotice": "已超出运营时间",
     "noArrivalInfo": "无到达信息",
     "notNearStationTitle": "附近没有地铁站",


### PR DESCRIPTION
## Summary
- **M2 root cause**: `tryLocklessRouteHop`에 90s stuck guard 추가 — 실측 신호(`lastObserved`) 부재가 `LOCKLESS_TIME_INTEGRATION_STUCK_TIMEOUT_MS`(90s) 이상 지속 시 시간 적분 자체 null 반환. dump line 169~244 estimator stuck → station-passed gate 매역 reject(61회) 회귀 차단. `useFusedNearestStation` cascade가 fusion fallback(실측 idx)을 forward하도록 유도.
- **M1+M3 동적 windowSize 확장**: `useStationAlarm`에 `computeHopWindowSize` helper 추가. `transfer`/`multi-transfer` route + non-live-position strategy + arc 내 transfer crossover 감지 시 windowSize를 격차만큼 확장. `live-position` 실측 strategy에서는 abnormal jump 차단을 위해 확장 X (M3 신뢰도 게이트). `currentHopStrategy` prop 신규 추가 (default null, backward-compat).
- **`resolveTripDirection` 환상선 + 환승 후 leg 지원**: `pickLegForCurrentLine`으로 `current.line`에 일치하는 leg 선택해 환승 후 leg(예: 7→2 transfer 후 line 2에 진입)에서도 direction 결정. closed loop 본선 양 끝점(2호선 등)은 `shortestLinePathIndices`로 wraparound 짧은 쪽 path의 첫 step 방향으로 'up'/'down' 산출. IMG_9059/9060 양방향 노출 회귀 차단.
- **`shouldHideArrivalEta` helper 추가**: MOCK_ARRIVALS(`isMock=true && source` 미지정)는 정적 데모값이라 ETA 자체 비공개. `HomeScreen`/`FavoritesScreen`이 helper로 ETA 행 가드. `13:54 / 5분 남았다` 모순 노출 회귀 차단.
- **i18n locales(ko/en/ja/zh)** `scheduleNotice` 명확화 ("시간표 기반 · 실시간 응답 없음" 류).

Closes #1922

## Wire-completion 5단 체크
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan). `shouldHideArrivalEta` / `computeHopWindowSize` 모두 caller 존재.
2. **V/X dashboard** — gate-hop-window suppress count는 기존 `logSuppressedHopWindow`로 적재. `DebugModal Estimator State`가 `estimatorStrategy=null` 빈도(M2 작동)와 `currentHopIndex` SSoT 변동(fusion fallback forward)을 그대로 노출. `lastNotifiedStationId` / `firedAlarms` 행이 fire 신호를 노출.
3. **의존 PR** — N/A (단독 머지 가능, M2가 root cause 차단).
4. **측정 plan** —
   - **A1**: gate-hop-window suppress ≤ 12/trip (61→0~12 회귀)
   - **A2**: station-passed fire ≤ arc+1
   - **A3**: 미통과 fire 0
   - **A4**: estimator strategy 분포 — `time-integration` 90s+ stuck 0건
   - 1주 N≥10 trip evidence 누적 후 X4 (61→0) 회귀 0건 확인.
5. **Device verify** — 실기기 환승 leg trip 1회 (7→2호선 강변/잠실나루 경로).
   - station-passed fire: 강변/잠실나루 진입 시 silent push 1회씩 fire.
   - 양방향 표시: IMG_9059/9060 시나리오 재현 → 한쪽 direction만 노출 확인.
   - ETA label: Seoul API outage(mock 강제) 시 "시간표 기반 · 실시간 응답 없음" 라벨 노출 확인.

## Test plan
- [x] `npm test` 커버리지 100% (statements/branches/lines/functions). 8372 tests pass.
- [x] `npm run type-check` pass.
- [x] `npm run lint:orphan` pass.
- [x] code-review agent — 단일 P1 (`shouldHideArrivalEta` docstring 반환 의미 반전) 반영 완료.