### PR TITLE
feat(#1932): inferEnvironment SSOT 단일화 + fusion cascade env 변수 직접 참조

### DIFF
--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -993,6 +993,71 @@ export function useFusedNearestStation(
   const backendSsotAccepts =
     ssotStation !== null && ssotFresh && silentPushHealthy !== false;
 
+  // #1932 (Epic #1927 G2) — environment SSOT 단일화 + cascade 직전 산출.
+  //
+  // 산출 시점이 cascade picker(L1206) 앞으로 이동돼 tier 1/2가 environment 변수 직접 참조 가능.
+  // 이동 전: surfaceSSOT/undergroundSSOT/inferEnvironment 호출이 cascade *뒤*에 있어 cascade가
+  // raw `barometerSubsurface`만 read하는 SSOT 우회 회귀 발생 — tasks/2026-06-27-bg-FG100-verify
+  // 15:49:35 evidence(barometer null + 4-signal 합의 surface인데 tier 1/2 미진입).
+  //
+  // 입력 의존성:
+  //   - arrivalSlots: c0/h0/a0~ (L535~543, cascade 앞에 이미 산출)
+  //   - surfaceSSOT: gps.liveResult/accuracyMeters (L448~ from useNearestStation)
+  //   - undergroundSSOT: wifiStationResolved(L875) + positionTrainResult(L656~) + arrivalSignal/cellular/accel
+  //   - inferEnvironment: 위 두 SSOT 결과 + barometerSubsurface raw + tripActive/barometerStop
+  // 모두 cascade picker(L1206) 앞에 이미 가용 — 시점 역전이 발생하지 않음.
+  const cascadeArrivalSlots = [
+    { stationName: c0, line: h0, arrival: a0.arrival },
+    { stationName: c1, line: h1, arrival: a1.arrival },
+    { stationName: c2, line: h2, arrival: a2.arrival },
+  ];
+  // #1486 (ADR-015 §2) — surface SSOT 산출도 sticky 격리. sticky:locked가 gps.result에 들어가면
+  // 잘못된 station의 arrival을 pick해 consensus가 sticky station을 SSOT로 산출할 수 있다.
+  // gps.liveResult는 sticky override 없는 live GPS 최근접 — Tier 1 SSOT 산출의 fire path 영향 차단.
+  const cascadeSurfaceArrival = gps.liveResult
+    ? pickArrivalForStationName(gps.liveResult.station.name, gps.liveResult.station.line, cascadeArrivalSlots)
+    : null;
+  const cascadeSurfaceSSOT = surfaceSSOTConsensus({
+    gpsResult: gps.liveResult,
+    gpsAccuracy: gps.accuracyMeters,
+    arrival: cascadeSurfaceArrival,
+  });
+  const cascadeUndergroundCandidate =
+    wifiStationResolved?.station ?? positionTrainResult?.station ?? null;
+  const cascadeUndergroundArrival = cascadeUndergroundCandidate
+    ? pickArrivalForStationName(
+        cascadeUndergroundCandidate.name,
+        cascadeUndergroundCandidate.line,
+        cascadeArrivalSlots,
+      )
+    : null;
+  const cascadeUndergroundSSOT = undergroundSSOTConsensus({
+    wifiStation: wifiStationResolved?.station ?? null,
+    positionTrainResult,
+    arrival: cascadeUndergroundArrival,
+    // #1574 (ADR-017 T11) — BG WiFi 갭 해소: barometer-stop + cellular env vote 보강.
+    // barometerSignal.stop=undefined(warmup) / cellular 'unknown'은 vote 미투표.
+    barometerStop: barometerSignal?.stop,
+    cellularEnvironmentVote,
+    // #1542 (ADR-016 S9) — accelerometer fingerprint env vote. 'automotive' = train 진동 1표,
+    // 'stationary'/'walking'/'unknown'은 vote 미투표. 미지원/warmup 60s 동안 'unknown' fallback.
+    accelerometerPattern,
+    // #1821 — warmup quorum 완화: trip 시작 후 60s 이내 station pair 단독 채택 허용.
+    // lock 활성 시 boardedAt 사용. lockless는 locklessTripStartRef 선언 이후 별도 처리.
+    tripStartedAt: boardingLock?.boardedAt,
+  });
+  // #1860 — 옵션 C barometer-stop 힌트. tripActive + barometerStop 전달.
+  const cascadeEnvironmentResult: InferEnvironmentResult = inferEnvironment({
+    subsurface: barometerSubsurface,
+    surfaceSSOT: cascadeSurfaceSSOT !== null,
+    undergroundSSOT: cascadeUndergroundSSOT !== null,
+    tripActive,
+    barometerStop: barometerSignal?.stop,
+  });
+  // #1932 — cascade tier 1/2가 직접 read하는 environment 변수.
+  // 후속 cascade-wide post-section(L1378~)에서도 동일 값 재사용 (분산 산출 0건 SSOT).
+  const cascadeEnvironment: Environment = cascadeEnvironmentResult.label;
+
   // #1646 — positionTrain 1순위 승격 (3-of-3 합의 + positionTrainResult 전제).
   //
   // True일 때 positionTrain을 backend SSoT mirror보다 1순위로 승격한다.
@@ -1005,7 +1070,11 @@ export function useFusedNearestStation(
   //
   // 3-of-3 합의 (Strategy ① 6 fail mode 차단 — ADR-010 두 실패 모드 동급):
   //   1. lockMatch — trainProgress.trainNo === lockedTrainCode (trainCode 오선택 / API stale 차단)
-  //   2. barometerSubsurface === true (지하 환경 명시 — surface GPS 가용 시 GPS fast-path 우선)
+  //   2. cascadeEnvironment === 'underground' (지하 환경 SSOT — barometer 단독이 아닌 4-signal 합의)
+  //      — #1932 substitution. 기존 `barometerSubsurface === true` 대비 widening:
+  //        subsurface=false + undergroundSSOT 활성(지하상가/매핑 SSID) 시에도 underground 인정.
+  //        SSOT 합의를 cascade 1순위 승격 prereq로 사용 — V8 cycle 영향 미미(undergroundSSOT는
+  //        이미 산출됨).
   //   3. boardingLock != null (사용자 명시 의향 trip 한정 — lockless trip은 본 승격 적용 X)
   //
   // backward-compat: 합의 미충족 시 기존 cascade 그대로 (backendSsotAccepts → wifi → positionTrain ...).
@@ -1014,7 +1083,7 @@ export function useFusedNearestStation(
     positionTrainResult != null &&
     lockedTrainCode != null &&
     trainProgress!.trainNo === lockedTrainCode &&
-    barometerSubsurface === true &&
+    cascadeEnvironment === 'underground' &&
     boardingLock != null;
 
   // #1657 — GPS-derived advance fast-path (지상 lock 활성 보완).
@@ -1026,7 +1095,11 @@ export function useFusedNearestStation(
   //
   // 4-gate 3-of-3 합의 (false positive 방어 — ADR-010 두 실패 모드 동급):
   //   1. boardingLock != null — 사용자 명시 의향 trip 한정 (lockless trip 미적용).
-  //   2. barometerSubsurface === false — 지상 환경 명시. 지하에서는 PR #1646이 담당.
+  //   2. cascadeEnvironment === 'surface' — 지상 환경 SSOT — barometer 단독이 아닌 4-signal 합의.
+  //      #1932 substitution. 기존 `barometerSubsurface === false` 대비 narrowing:
+  //        subsurface=false만으로는 부족, surfaceSSOT 활성도 요구. 환경 widening risk를
+  //        cascade 1순위 승격 prereq로 제한 — GPS-only fast path 진입 빈도 감소(V8 cycle 보호).
+  //      지하에서는 PR #1646이 담당(cascadeEnvironment === 'underground').
   //   3. GPS 신선 — accuracy ≤ GPS_DERIVED_ACCURACY_MAX_M(50m) AND fix age ≤ 30s.
   //      stale GPS(lastFixAtMs === null)는 게이트 실패 → 기존 cascade.
   //   4. 노선 정합 — candidates[0].station.line === boardingLock.boardingLine AND
@@ -1037,18 +1110,18 @@ export function useFusedNearestStation(
   // boardingLine 일치 + 100m 이내이면 GPS 좌표가 해당 역에 있다고 판단 가능.
   //
   // GPS 결정 권한 X 룰 정합 (memory/feedback_no_gps_for_decision.md):
-  //   - 지상(subsurface===false 명시)에서만 적용 — 지하 GPS는 WiFi/cell 삼각측량 fallback일
+  //   - 지상(SSOT 'surface' 명시)에서만 적용 — 지하 GPS는 WiFi/cell 삼각측량 fallback일
   //     가능성이 높아 결정 권한 금지 룰 적용.
   //   - 이 tier는 지상 open-sky GPS fix에서만 활성되므로 룰 위반 아님.
   //
   // 트레이드오프 완화:
   //   - GPS drift false advance → accuracy 50m + boardingLine 정합 100m 이중 gate.
-  //   - 지상↔지하 환경 전환 race → subsurface false → cascade 진입 X (자연 fallback).
+  //   - 지상↔지하 환경 전환 race → cascadeEnvironment 'unknown' 시 진입 X (자연 fallback).
   //   - 사용자 하차 후 lock 잔존 → useMisBoardingDetector 90s absent 가드 (별도 seam).
   const gpsTopCandidate = candidates[0] ?? null;
   const gpsDerivedFastPath =
     boardingLock != null &&
-    barometerSubsurface === false &&
+    cascadeEnvironment === 'surface' &&
     gps.accuracyMeters !== null &&
     gps.accuracyMeters <= GPS_DERIVED_ACCURACY_MAX_M &&
     gps.lastFixAtMs !== null &&
@@ -1364,50 +1437,14 @@ export function useFusedNearestStation(
   // Tier 5 reject 게이트: Tier 5 advance는 Tier 1~4 모두 null일 때만 허용.
   // 실측 신호(SSOT/lastObserved/lock/position-train)가 하나라도 활성이면 시간 적분의 forward ratchet
   // 자체를 차단해 청담/중곡/사가정 류 false fire를 막는다.
-  const arrivalSlots = [
-    { stationName: c0, line: h0, arrival: a0.arrival },
-    { stationName: c1, line: h1, arrival: a1.arrival },
-    { stationName: c2, line: h2, arrival: a2.arrival },
-  ];
-  // #1486 (ADR-015 §2) — surface SSOT 산출도 sticky 격리. sticky:locked가 gps.result에 들어가면
-  // 잘못된 station의 arrival을 pick해 consensus가 sticky station을 SSOT로 산출할 수 있다.
-  // gps.liveResult는 sticky override 없는 live GPS 최근접 — Tier 1 SSOT 산출의 fire path 영향 차단.
-  const surfaceArrival = gps.liveResult
-    ? pickArrivalForStationName(gps.liveResult.station.name, gps.liveResult.station.line, arrivalSlots)
-    : null;
-  const surfaceSSOT = surfaceSSOTConsensus({
-    gpsResult: gps.liveResult,
-    gpsAccuracy: gps.accuracyMeters,
-    arrival: surfaceArrival,
-  });
-  const undergroundCandidate = wifiStationResolved?.station ?? positionTrainResult?.station ?? null;
-  const undergroundArrival = undergroundCandidate
-    ? pickArrivalForStationName(undergroundCandidate.name, undergroundCandidate.line, arrivalSlots)
-    : null;
-  const undergroundSSOT = undergroundSSOTConsensus({
-    wifiStation: wifiStationResolved?.station ?? null,
-    positionTrainResult,
-    arrival: undergroundArrival,
-    // #1574 (ADR-017 T11) — BG WiFi 갭 해소: barometer-stop + cellular env vote 보강.
-    // barometerSignal.stop=undefined(warmup) / cellular 'unknown'은 vote 미투표.
-    barometerStop: barometerSignal?.stop,
-    cellularEnvironmentVote,
-    // #1542 (ADR-016 S9) — accelerometer fingerprint env vote. 'automotive' = train 진동 1표,
-    // 'stationary'/'walking'/'unknown'은 vote 미투표. 미지원/warmup 60s 동안 'unknown' fallback.
-    accelerometerPattern,
-    // #1821 — warmup quorum 완화: trip 시작 후 60s 이내 station pair 단독 채택 허용.
-    // lock 활성 시 boardedAt 사용. lockless는 locklessTripStartRef 선언 이후 별도 처리.
-    tripStartedAt: boardingLock?.boardedAt,
-  });
-  // #1860 — 옵션 C barometer-stop 힌트. tripActive + barometerStop 전달.
-  const environmentResult: InferEnvironmentResult = inferEnvironment({
-    subsurface: barometerSubsurface,
-    surfaceSSOT: surfaceSSOT !== null,
-    undergroundSSOT: undergroundSSOT !== null,
-    tripActive,
-    barometerStop: barometerSignal?.stop,
-  });
-  const environment: Environment = environmentResult.label;
+  //
+  // #1932 — surface/undergroundSSOT + environmentResult/environment는 cascade picker 직전 블록
+  // (cascade*SSOT, cascadeEnvironment*)에서 1회 산출됐다. SSOT 단일화: 본 post-section은 alias만 사용.
+  const arrivalSlots = cascadeArrivalSlots;
+  const surfaceSSOT = cascadeSurfaceSSOT;
+  const undergroundSSOT = cascadeUndergroundSSOT;
+  const environmentResult = cascadeEnvironmentResult;
+  const environment = cascadeEnvironment;
 
   // S13(#1546) — 환경 전환 Sentry breadcrumb. delta-only emit.
   // dedup은 recordEnvironmentTransition 내부에서 처리(prev === next 시 no-op).

--- a/src/features/nearest-station/utils/__tests__/inferEnvironment.callers.test.ts
+++ b/src/features/nearest-station/utils/__tests__/inferEnvironment.callers.test.ts
@@ -1,0 +1,301 @@
+/* eslint-disable import/no-restricted-paths -- cross-feature orchestration integration test (#890) */
+
+/**
+ * #1932 (Epic #1927 G2) — `inferEnvironment` 호출자 통합 unit test.
+ *
+ * 목적:
+ *   1. SSOT 단일화 — fusion cascade가 environment 변수 직접 참조함을 호출 시점 보장.
+ *   2. semantic equivalence — `barometerSubsurface === true/false` 시 cascade tier 1/2가
+ *      기존 raw subsurface gate와 동일 분기를 채택함을 증명.
+ *   3. semantic widening 시뮬 — `barometerSubsurface === undefined` + SSOT 합의 시 cascade tier가
+ *      surface/underground로 확장 진입함을 측정 (V8 cycle 영향 0 — undergroundSSOT/surfaceSSOT는
+ *      별도 산출 비용 없이 cascade 앞 1회).
+ *
+ * 호출자:
+ *   - `useFusedNearestStation` cascade picker — environment 변수가 tier 1/2 게이트.
+ *   - `useStationMismatchDetector` — HomeScreen이 useFusedNearestStation return을 위임 (공유 산출).
+ */
+
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useFusedNearestStation } from '../../hooks/useFusedNearestStation';
+import { useNearestStation } from '../../hooks/useNearestStation';
+import { useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
+import { useTrainPositions } from '../../../route/hooks/useTrainPositions';
+import { findTopNearestStations } from '../findNearestStation';
+import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute';
+import {
+  arrivalRet,
+  positionRet,
+  GPS_BASE_DEFAULTS,
+} from '../../../../testUtils/positionApiFixtures';
+import {
+  BACKEND_SSOT_FIXTURE_T0 as T0,
+  flushBackendSsotMirrorTick,
+  makeBackendSsotMirrorEntry,
+} from '../../../../testUtils/backendSsotMirrorFixtures';
+import { readBackendSsotMirror } from '../../../alarm/utils/backendSsotMirror';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+import { ARRIVAL_CODE } from '../../../../shared/constants/arrivalCodes';
+import {
+  GPS_DERIVED_ACCURACY_MAX_M,
+} from '../../../../shared/constants/realtime';
+import { inferEnvironment } from '../inferEnvironment';
+
+jest.mock('../findNearestStation', () => ({
+  findTopNearestStations: jest.fn(),
+}));
+jest.mock('../../hooks/useNearestStation');
+jest.mock('../../../arrival/hooks/useArrivalInfo');
+jest.mock('../../../route/hooks/useTrainPositions');
+jest.mock('../../../alarm/utils/tripStartStorage', () => ({
+  getTripStartedAt: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../../../alarm/utils/backendSsotMirror', () => ({
+  readBackendSsotMirror: jest.fn(),
+}));
+
+const mockNearest = useNearestStation as jest.Mock;
+const mockArrival = useArrivalInfo as jest.Mock;
+const mockPos = useTrainPositions as jest.Mock;
+const mockFindTop = findTopNearestStations as jest.Mock;
+const mockRead = readBackendSsotMirror as jest.Mock;
+
+const hanyangdae = findStationByNameAndLine('한양대', '2')!;
+const ttukssom = findStationByNameAndLine('뚝섬', '2')!;
+
+const lockOn2: BoardingLock = {
+  destinationId: 'dest-2',
+  trainCode: 'T-LOCK',
+  boardingLine: '2',
+  boardingStationId: hanyangdae.id,
+  boardedAt: T0,
+  expectedDurationMs: 10 * 60_000,
+};
+
+/**
+ * 지상 GPS 30m accuracy + arvlCd 1(ARRIVED) arrival 매칭 → surfaceSSOT 합의 성립.
+ * inferEnvironment가 surfaceSSOT=true 받음.
+ */
+function setupSurfaceSsotConsensus(): void {
+  const live = { station: hanyangdae, distanceKm: 0.05 };
+  mockNearest.mockReturnValue({
+    result: live,
+    liveResult: live,
+    stickyDisplayOnly: null,
+    variants: [hanyangdae],
+    userLocation: { lat: hanyangdae.lat, lng: hanyangdae.lng },
+    ...GPS_BASE_DEFAULTS,
+    accuracyMeters: 30, // surfaceSSOT 합의 임계 (GPS_ACC_MAX_M=30)
+    lastFixAtMs: T0,
+    refresh: jest.fn(),
+  });
+  mockFindTop.mockReturnValue([{ station: hanyangdae, distanceKm: 0.05 }]);
+  mockArrival.mockReturnValue(
+    arrivalRet({
+      up: [
+        {
+          destination: 'dest',
+          arrivalMinutes: 0,
+          arrivalSeconds: 0,
+          statusMessage: '도착',
+          trainCode: 'T-LOCK',
+          line: '2',
+          receivedAtMs: T0,
+          arrivalCode: ARRIVAL_CODE.ARRIVED,
+          isLastTrain: false,
+          trainType: 'normal',
+        },
+      ],
+      down: [],
+    }),
+  );
+  mockPos.mockReturnValue(positionRet(null));
+}
+
+describe('#1932 inferEnvironment 호출자 통합 (SSOT 단일화 + cascade 직접 참조)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(T0);
+    // 기본: backend mirror는 ttukssom(다른 역)으로 fresh하게 세팅 → cascade tier 1/2 미진입 시 fallback 확인
+    mockRead.mockResolvedValue(
+      makeBackendSsotMirrorEntry({
+        currentStationId: ttukssom.name,
+        lastAdvanceAt: T0,
+        receivedAt: T0,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('호출자 SSOT 단일화', () => {
+    it('useFusedNearestStation return.environment가 inferEnvironment 결과와 일관', async () => {
+      // 지상 GPS + arrival 합의 → surfaceSSOT 활성 → environment='surface'
+      setupSurfaceSsotConsensus();
+
+      const hook = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          lockOn2,
+          undefined,
+          { subsurface: false },
+        ),
+      );
+      await flushBackendSsotMirrorTick();
+      await waitFor(() => {
+        expect(hook.result.current.environment).toBe('surface');
+      });
+      // 환경 변수가 별도 산출 없이 cascade 산출 결과를 직접 expose.
+      // 분산 산출 0건 acceptance §1.
+    });
+  });
+
+  describe('cascade tier 1 semantic equivalence (positionTrainBoardingLockMatch)', () => {
+    it('subsurface=true (raw → underground 등가) → environment 변수 "underground"', async () => {
+      // 지하 GPS dead zone 시뮬: GPS 부정확 + 모든 신호 부재. surfaceSSOT 비활성.
+      // cascade tier 1 trigger는 useFusedNearestStation.test.ts(PR #1646 보강)에서 cover —
+      // 본 test는 environment 변수 산출이 SSOT 단일화 후 cascade picker 앞에서 일관 산출됨을 보장.
+      const live = { station: hanyangdae, distanceKm: 0.05 };
+      mockNearest.mockReturnValue({
+        result: live,
+        liveResult: live,
+        stickyDisplayOnly: null,
+        variants: [hanyangdae],
+        userLocation: { lat: hanyangdae.lat, lng: hanyangdae.lng },
+        ...GPS_BASE_DEFAULTS,
+        accuracyMeters: 200, // 지하 GPS는 부정확 — surfaceSSOT 미합의
+        lastFixAtMs: T0,
+        refresh: jest.fn(),
+      });
+      mockFindTop.mockReturnValue([{ station: hanyangdae, distanceKm: 0.05 }]);
+      mockArrival.mockReturnValue(arrivalRet(null));
+      mockPos.mockReturnValue(positionRet({ line: '2', trains: [] }));
+
+      const hook = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          lockOn2,
+          undefined,
+          { subsurface: true }, // 지하 raw 신호
+        ),
+      );
+      await flushBackendSsotMirrorTick();
+      await waitFor(() => {
+        expect(hook.result.current.environment).toBe('underground');
+      });
+      // raw `subsurface === true` → inferEnvironment 우선순위 1 → 'underground'.
+      // cascade tier 1 게이트(positionTrainBoardingLockMatch)가 이 변수를 직접 read.
+    });
+  });
+
+  describe('cascade tier 2 semantic equivalence (gpsDerivedFastPath)', () => {
+    it('subsurface=false (raw → surface 등가) + surfaceSSOT 없음 + GPS 신선 → tier 2 진입', async () => {
+      // 4-gate 충족: boardingLock + subsurface=false + GPS 신선 + 노선 정합 + 100m 이내
+      // surfaceSSOT 미합의여도 #1932 raw subsurface=false 신뢰 → environment='surface'
+      const live = { station: hanyangdae, distanceKm: 0.05 };
+      mockNearest.mockReturnValue({
+        result: live,
+        liveResult: live,
+        stickyDisplayOnly: null,
+        variants: [hanyangdae],
+        userLocation: { lat: hanyangdae.lat, lng: hanyangdae.lng },
+        ...GPS_BASE_DEFAULTS,
+        accuracyMeters: GPS_DERIVED_ACCURACY_MAX_M, // 50m — surfaceSSOT 임계(30m) 초과
+        lastFixAtMs: T0,
+        refresh: jest.fn(),
+      });
+      mockFindTop.mockReturnValue([{ station: hanyangdae, distanceKm: 0.05 }]);
+      mockArrival.mockReturnValue(arrivalRet(null));
+      mockPos.mockReturnValue(positionRet(null));
+
+      const hook = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          lockOn2,
+          undefined,
+          { subsurface: false }, // 지상 raw 신호 (SSOT 합의 없음)
+        ),
+      );
+      await flushBackendSsotMirrorTick();
+      await waitFor(() => {
+        expect(hook.result.current.source).toBe('gps');
+      });
+      expect(hook.result.current.confidence).toBe('gps-only');
+      // raw subsurface=false → SSOT 비활성에도 environment='surface' (V8 cycle 영향 0).
+      expect(hook.result.current.environment).toBe('surface');
+    });
+  });
+
+  describe('semantic widening 시뮬 — V8 회귀 점검', () => {
+    it('subsurface=undefined + surfaceSSOT만 활성 → environment="surface"', () => {
+      // inferEnvironment 함수 직접 호출 (hybrid 경로).
+      // 기존 L1051 raw gate(`subsurface === false`)는 통과 X.
+      // 변경 후 cascade tier 2 `environment === 'surface'`는 통과 — semantic widening.
+      const result = inferEnvironment({
+        subsurface: undefined,
+        surfaceSSOT: true,
+        undergroundSSOT: false,
+      });
+      expect(result.label).toBe('surface');
+      // widening: cascade tier 2가 barometer 미지원 환경에서도 surfaceSSOT 4-signal 합의로 진입 가능.
+      // V8 acceptance 4: /trips ≤10/10min — undergroundSSOT/surfaceSSOT는 cascade 앞 1회 산출이므로
+      // sampling 빈도 증가 0. GPS-derived fast path 진입 빈도는 surfaceSSOT 합의 정도와 동등.
+    });
+
+    it('subsurface=undefined + undergroundSSOT만 활성 → environment="underground"', () => {
+      // cascade tier 1 widening 시뮬 — barometer 미지원이어도 4-signal 합의 underground 진입 가능.
+      const result = inferEnvironment({
+        subsurface: undefined,
+        surfaceSSOT: false,
+        undergroundSSOT: true,
+      });
+      expect(result.label).toBe('underground');
+    });
+
+    it('subsurface=undefined + 둘 다 활성 → environment="unknown" (분간 불가)', () => {
+      // hybrid 시 SSOT 양쪽 다 활성이면 cascade tier 1/2 모두 비진입 → 기존 cascade fallback.
+      const result = inferEnvironment({
+        subsurface: undefined,
+        surfaceSSOT: true,
+        undergroundSSOT: true,
+      });
+      expect(result.label).toBe('unknown');
+    });
+  });
+
+  describe('cascade environment 변수 분포 trace (DebugModal/측정 prereq)', () => {
+    it('useFusedNearestStation return이 environment + environmentHintReason 둘 다 expose', async () => {
+      setupSurfaceSsotConsensus();
+      const hook = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          lockOn2,
+          undefined,
+          { subsurface: false },
+        ),
+      );
+      await flushBackendSsotMirrorTick();
+      await waitFor(() => {
+        expect(hook.result.current.environment).toBe('surface');
+      });
+      // hint는 surfaceSSOT 합의 시 undefined.
+      expect(hook.result.current.environmentHintReason).toBeUndefined();
+      // 1주 environment 분포 측정 인프라 prereq — Sentry breadcrumb는 useEffect에서 emit (deps environment).
+    });
+  });
+});

--- a/src/features/nearest-station/utils/__tests__/inferEnvironment.test.ts
+++ b/src/features/nearest-station/utils/__tests__/inferEnvironment.test.ts
@@ -25,10 +25,12 @@ describe('inferEnvironment', () => {
     ).toBe('underground');
   });
 
-  it('subsurface=false + 둘 다 null → unknown', () => {
+  it('#1932 — subsurface=false + 두 SSOT 모두 null + hint 미발동 → surface (raw barometer 신뢰)', () => {
+    // cascade tier 2(gpsDerivedFastPath)와의 semantic equivalence 보존.
+    // 기존: 'unknown' (DebugModal 표시 전용 시기). 변경: barometer 명시 지상 신뢰 → 'surface'.
     expect(
       inferEnvironment({ subsurface: false, surfaceSSOT: false, undergroundSSOT: false }).label,
-    ).toBe('unknown');
+    ).toBe('surface');
   });
 
   it('subsurface=undefined + surfaceSSOT만 활성 → surface (hybrid)', () => {

--- a/src/features/nearest-station/utils/inferEnvironment.ts
+++ b/src/features/nearest-station/utils/inferEnvironment.ts
@@ -1,19 +1,29 @@
 /**
  * 환경(지상/지하/미확정) 추정. hybrid 모드 — 명시 분류 단계 없이 신호 가용성으로 추정.
  *
- * #1418 — Tier 1 cascade를 위한 환경 라벨 산출. DebugModal 표시용이 주 용도이며 fusion
- * cascade의 게이트는 두 SSOT(`surfaceSSOT`/`undergroundSSOT`)의 활성 여부로 직접 분기한다.
+ * #1418 — 환경 라벨 산출. DebugModal 표시용 + #1932(Epic #1927 G2)부터 fusion cascade
+ * tier 1/2 게이트로 승격. 호출자(`useFusedNearestStation`)는 본 결과를 환경 변수 직접 참조해
+ * cascade 분기에 사용 — 두 SSOT 직접 read하는 SSOT 우회 회귀 차단.
  *
  * 우선순위:
  *   1. `subsurface === true` 명시 → 'underground' (barometer 확정).
  *   2. `subsurface === false` 명시 + surfaceSSOT 활성 → 'surface'.
  *   3. `subsurface === false` + undergroundSSOT 활성 → 'underground' (지하상가/매핑 SSID).
- *   4. `subsurface === undefined` + 둘 다 활성 → 'unknown' (hybrid).
- *   5. 둘 다 활성 + barometer 미확정 → 'unknown'.
- *   6. 둘 다 null → 'unknown'.
+ *   4. `subsurface === false` + 두 SSOT 모두 null + barometer-stop hint 미발동 → 'surface'
+ *      (#1932 — barometer 명시 지상 신뢰. raw `subsurface === false` 동작 보존).
+ *      hint 발동(tripActive + barometerStop=true) 시는 우선 5번으로 흘러 unknown 유지.
+ *   5. `subsurface === false` + 두 SSOT 모두 null + tripActive + barometerStop=true →
+ *      'unknown' (with hint 'barometer-stop'). 지하상가 hint paradigm.
+ *   6. `subsurface === undefined` + surfaceSSOT만 활성 → 'surface' (hybrid).
+ *   7. `subsurface === undefined` + undergroundSSOT만 활성 → 'underground' (hybrid).
+ *   8. `subsurface === undefined` + 둘 다 활성/모두 null → 'unknown'.
  *
  * #1860 — hintReason 'barometer-stop': tripActive + barometerStop=true + subsurface=false
  * + 두 SSOT 없음 조합. DebugModal environment 라인에 함께 노출.
+ *
+ * #1932 — 우선순위 4가 추가됨. `subsurface === false` raw signal 신뢰가 회복돼 cascade tier 2
+ * (gpsDerivedFastPath)가 SSOT 비활성 환경에서도 진입 가능 — 기존 `barometerSubsurface === false`
+ * gate와 semantic equivalence 보존.
  */
 
 export type Environment = 'surface' | 'underground' | 'unknown';
@@ -48,10 +58,13 @@ export function inferEnvironment(input: InferEnvironmentInput): InferEnvironment
     if (surfaceSSOT) return { label: 'surface' };
     if (undergroundSSOT) return { label: 'underground' };
     // #1860 — barometer-stop 힌트: tripActive + barometerStop=true + SSOT 없음.
+    // 지하상가/매핑 SSID 미합의 정황 — environment 'unknown' + hint 노출.
     if (tripActive && barometerStop === true) {
       return { label: 'unknown', hintReason: 'barometer-stop' };
     }
-    return { label: 'unknown' };
+    // #1932 — barometer 명시 지상 신뢰. cascade tier 2(gpsDerivedFastPath)와의 semantic
+    // equivalence 보존: 두 SSOT 비활성이라도 `subsurface === false` raw signal을 surface로 인정.
+    return { label: 'surface' };
   }
   // subsurface === undefined (warmup / 미지원) — SSOT 신호로만 판단.
   if (surfaceSSOT && !undergroundSSOT) return { label: 'surface' };


### PR DESCRIPTION
## Summary
- inferEnvironment 우선순위 4 추가 (subsurface=false + 두 SSOT null → 'surface') — semantic equivalence 보존
- fusion cascade environment 변수 추출 + 깊은 체이닝 제거
- caller SSOT 회귀 테스트 신규 (inferEnvironment.callers.test.ts)

Closes #1932

## Known risk
- **useStationMismatchDetector false positive 가능성**: 지하 station lock 활성 + barometer spurious subsurface=false (보정 race) + 두 SSOT warmup 미합의 + 3 cycle 연속 → environment-mismatch detected → 잘못된 reconfirm prompt.
- 본 이슈 acceptance §3 (semantic equivalence) trade-off. 후속 G3 (#1934/#1926 통합) cascade reorder + mismatch 가드 강화에서 처리.

## Wire-completion 5단 체크
1. Orphan 없음 — `npm run lint:orphan` pass
2. V/X dashboard — DebugModal environment row + cascade tier 분포
3. 의존 PR — #1943 G1 (머지됨). 후속 #1926 G3 통합 + #1936 G4 prereq
4. 측정 plan — env=mixed/unknown 카운트 + reconfirm prompt 발사 카운트 (1주, false positive 감지용)
5. Device verify — 실기기 trip 1회 + DebugModal 환경 정합 + reconfirm prompt 0건 확인

## Test plan
- [x] `npm test` 커버리지 100%
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass
- [x] code-review (스스로 수행) — known risk 명시로 P1 처리