### PR TITLE
fix(#1926): positionTrain + autoLock 4-signal consensus + station progression (A+F+G3)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -99,6 +99,12 @@ const defaultInputs: UseBoardingLockControllerInputs = {
   arrival,
   currentStation: stationA,
   expectedDurationMinutes: 20,
+  // #1926 (A-fix) — default 4-signal consensus를 pass 상태로 설정. autoLock 기존 시나리오는
+  // consensus 가드가 추가되기 전과 동일하게 동작해야 한다. consensus reject 케이스는
+  // 'autoLock fast path consensus' describe 블록에서 별도 검증.
+  barometerSubsurface: false,
+  accelerometerPattern: 'automotive',
+  cellularEnvironmentVote: 'surface',
 };
 
 describe('useBoardingLockController', () => {
@@ -1547,6 +1553,90 @@ describe('useBoardingLockController', () => {
           reason: 'autolock-lock-failed',
           originStation: '강남',
           line: '2',
+        });
+      });
+    });
+
+    describe('#1926 (A-fix) autoLock fast path 4-signal consensus', () => {
+      // 4-signal consensus 미달 시 createLock 호출 0건 + idempotency ref 미설정(다음 cycle 재시도).
+      // helper(requiresPositionTrainConsensus)의 lockless 분기는 positionTrainConsensus.test.ts에서
+      // 단위로 검증. 본 블록은 useBoardingLockController wire가 helper에 올바르게 위임하는지 검증.
+
+      it('barometerSubsurface=true (지하 확정) → createLock 호출 0건 (consensus reject)', async () => {
+        const createLockMock = jest.fn().mockResolvedValue(undefined);
+        useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+        renderHook(() =>
+          useBoardingLockController({
+            ...defaultInputs,
+            arrival: singleArrival,
+            barometerSubsurface: true,
+          }),
+        );
+        // helper logic은 sync — pickAutoTrainCodeFromArrivals + consensus gate 모두 sync.
+        // wait 후에도 호출이 발생하지 않음을 검증.
+        await new Promise<void>((resolve) => setTimeout(resolve, 20));
+        expect(createLockMock).not.toHaveBeenCalled();
+      });
+
+      it.each(['walking', 'stationary', 'unknown'] as const)(
+        'accelerometerPattern=%s (non-automotive) → createLock 호출 0건',
+        async (pattern) => {
+          const createLockMock = jest.fn().mockResolvedValue(undefined);
+          useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+          renderHook(() =>
+            useBoardingLockController({
+              ...defaultInputs,
+              arrival: singleArrival,
+              accelerometerPattern: pattern,
+            }),
+          );
+          await new Promise<void>((resolve) => setTimeout(resolve, 20));
+          expect(createLockMock).not.toHaveBeenCalled();
+        },
+      );
+
+      it.each(['surface-weak', 'underground', 'unknown'] as const)(
+        'cellularEnvironmentVote=%s (non-surface) → createLock 호출 0건',
+        async (vote) => {
+          const createLockMock = jest.fn().mockResolvedValue(undefined);
+          useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+          renderHook(() =>
+            useBoardingLockController({
+              ...defaultInputs,
+              arrival: singleArrival,
+              cellularEnvironmentVote: vote,
+            }),
+          );
+          await new Promise<void>((resolve) => setTimeout(resolve, 20));
+          expect(createLockMock).not.toHaveBeenCalled();
+        },
+      );
+
+      it('모든 신호 undefined (default) → createLock 호출 0건 (보수 reject)', async () => {
+        const createLockMock = jest.fn().mockResolvedValue(undefined);
+        useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+        renderHook(() =>
+          useBoardingLockController({
+            ...defaultInputs,
+            arrival: singleArrival,
+            barometerSubsurface: undefined,
+            accelerometerPattern: undefined,
+            cellularEnvironmentVote: undefined,
+          }),
+        );
+        await new Promise<void>((resolve) => setTimeout(resolve, 20));
+        expect(createLockMock).not.toHaveBeenCalled();
+      });
+
+      it('4-signal consensus 통과 → 기존 createLock 호출 (회귀 차단)', async () => {
+        // defaultInputs는 이미 consensus pass 상태(barometerSubsurface=false / automotive / surface).
+        const createLockMock = jest.fn().mockResolvedValue(undefined);
+        useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+        renderHook(() =>
+          useBoardingLockController({ ...defaultInputs, arrival: singleArrival }),
+        );
+        await waitFor(() => {
+          expect(createLockMock).toHaveBeenCalled();
         });
       });
     });

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -29,6 +29,9 @@ import type { LockSuggestionMirror } from '../utils/backendSsotMirror';
 import { pickAutoTrainCodeFromArrivals } from '../utils/boardingPromptAutoLock';
 import { logBoardingPromptAutoLock } from '../utils/alarmLog';
 import { ARRIVAL_CODE } from '../../../shared/constants/arrivalCodes';
+import { requiresPositionTrainConsensus } from '../../nearest-station/utils/positionTrainConsensus';
+import type { AccelerometerPattern } from '../../nearest-station/utils/accelerometerFingerprint';
+import type { CellularEnvironmentVote } from '../../nearest-station/utils/cellularTech';
 
 export interface UseBoardingLockControllerInputs {
   destinationId: string | null;
@@ -53,6 +56,19 @@ export interface UseBoardingLockControllerInputs {
    * null은 미측정(게이트에서 motionStationary로 fallback).
    */
   speedMps?: number | null;
+  /**
+   * #1926 (A-fix) — device-side autoLock fast path 4-signal consensus 가드.
+   *
+   * `useBoardingLockController` autoLock effect는 source label='position-train' 자체 발사
+   * (BoardingTrainList 탭 / boardingPrompt 응답 같은 사용자 명시 의향 X)이므로 lockless 시
+   * `position-train` 채택 동일 paradigm을 적용해야 한다 (`feedback_user_intent_equal_protection`).
+   *
+   * 모두 미전달(undefined) 시 helper가 보수적으로 consensus 미달 판정 → createLock 차단.
+   * 다른 path(`createLockFromTrain` / `hydrateLockFromCandidate`)에는 영향 없음 (사용자 의향 source).
+   */
+  barometerSubsurface?: boolean | null | undefined;
+  accelerometerPattern?: AccelerometerPattern | null;
+  cellularEnvironmentVote?: CellularEnvironmentVote | null;
 }
 
 export interface UseBoardingLockControllerResult {
@@ -129,6 +145,9 @@ export function useBoardingLockController({
   expectedDurationMinutes,
   motionStationary,
   speedMps,
+  barometerSubsurface,
+  accelerometerPattern,
+  cellularEnvironmentVote,
 }: UseBoardingLockControllerInputs): UseBoardingLockControllerResult {
   const lock = useBoardingLockStore((s) => s.lock);
   const loadLock = useBoardingLockStore((s) => s.loadLock);
@@ -463,6 +482,28 @@ export function useBoardingLockController({
     }
     // allowedLines 검증 — useBoardingPromptResponder.tryAutoLock과 createLockFromTrain의 정책을 그대로 반영.
     if (allowedLines && !allowedLines.has(chosen.line)) return;
+    // #1926 (A-fix): device-side autoLock fast path 4-signal consensus.
+    //
+    // 본 effect는 source label='position-train' 자체 발사 — 사용자 명시 의향(BoardingTrainList 탭 /
+    // boardingPrompt 응답 / lockSuggestion / hydrateLockFromCandidate)이 모두 부재한 device-side 자체
+    // 결정 path. 따라서 lockless `position-train` 채택과 동일 paradigm으로 4-signal consensus 필수
+    // (`ADR-014` 첫 줄 / `feedback_device_self_contained_fusion`).
+    //
+    // 본 effect 진입 시 `if (lock) return` 가드로 lock은 항상 null — helper 두 번째 인자 = null.
+    // consensus 미달 시 `lastOriginAutoLockKeyRef.current`는 set하지 않아 다음 cycle 재시도가 가능하다
+    // (graceful — 환경 신호가 늦게 합의되는 케이스 흡수).
+    if (
+      !requiresPositionTrainConsensus(
+        {
+          barometerSubsurface: barometerSubsurface ?? null,
+          accelerometerPattern: accelerometerPattern ?? null,
+          cellularEnvironmentVote: cellularEnvironmentVote ?? null,
+        },
+        null,
+      )
+    ) {
+      return;
+    }
     // idempotency ref는 시도 직전에 set — store action이 race/storage 실패해도 다음 cycle 재시도하지 않도록.
     // graceful 실패는 ref reset 없이 그대로 두고, 사용자 release 시 자연 재진입(다른 key로) 시점에 재시도된다.
     lastOriginAutoLockKeyRef.current = originKey;
@@ -521,6 +562,11 @@ export function useBoardingLockController({
     expectedDurationMinutes,
     allowedLines,
     createLock,
+    direction,
+    // #1926 (A-fix) — 4-signal consensus deps.
+    barometerSubsurface,
+    accelerometerPattern,
+    cellularEnvironmentVote,
   ]);
 
   return {

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.movementGuard.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.movementGuard.test.ts
@@ -17,6 +17,13 @@
 jest.mock('../useNearestStation');
 jest.mock('../../../arrival/hooks/useArrivalInfo');
 jest.mock('../../../route/hooks/useTrainPositions');
+// #1926 — lockless 4-signal consensus는 positionTrainConsensus.test.ts에서 단위 검증.
+jest.mock('../useAccelerometerFingerprint', () => ({
+  useAccelerometerFingerprint: () => 'automotive',
+}));
+jest.mock('../useCellularTech', () => ({
+  useCellularTech: () => 'surface',
+}));
 jest.mock('../../utils/findNearestStation');
 jest.mock('../../../route/utils/findActiveLines');
 jest.mock('../../utils/fusionDistanceGate', () => ({

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.positionGate.test.ts
@@ -30,6 +30,15 @@ jest.mock('../../utils/findNearestStation', () => ({
 jest.mock('../useNearestStation');
 jest.mock('../../../arrival/hooks/useArrivalInfo');
 jest.mock('../../../route/hooks/useTrainPositions');
+// #1926 — lockless 4-signal consensus는 positionTrainConsensus.test.ts에서 단위 검증.
+// 기본은 pass 상태로 mock해 기존 회귀 테스트(position-train 채택)를 보존. 본 파일
+// "#1926 lockless 4-signal consensus" describe에서 override해 reject 분기 검증.
+jest.mock('../useAccelerometerFingerprint', () => ({
+  useAccelerometerFingerprint: jest.fn(() => 'automotive'),
+}));
+jest.mock('../useCellularTech', () => ({
+  useCellularTech: jest.fn(() => 'surface'),
+}));
 jest.mock('../../../alarm/utils/tripStartStorage', () => ({
   getTripStartedAt: jest.fn().mockResolvedValue(null),
 }));
@@ -516,6 +525,91 @@ describe('#1016 positionTrainResult 거리 게이트 hole 봉합', () => {
     it('motionStationary=false → fire path 미승격 (#1437 박탈)', () => {
       const result = runLockedMotionScenario(false);
       expect(result.current.source).not.toBe('boarding-lock-interp');
+    });
+  });
+
+  describe('#1926 (F-fix) lockless 4-signal consensus 가드 — positionTrainResult', () => {
+    // helper의 lockless 분기: barometer=true OR accel!==automotive OR cellular!==surface → reject.
+    // 본 통합 테스트는 wire-up 검증. 단위 분기는 positionTrainConsensus.test.ts에서 verify.
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const accelMock = require('../useAccelerometerFingerprint').useAccelerometerFingerprint as jest.Mock;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const cellularMock = require('../useCellularTech').useCellularTech as jest.Mock;
+
+    afterEach(() => {
+      // 본 describe 종료 시 default(automotive/surface) 복귀 — 다른 describe 회귀 차단.
+      accelMock.mockImplementation(() => 'automotive');
+      cellularMock.mockImplementation(() => 'surface');
+    });
+
+    it('lockless + accelerometerPattern=walking → position-train 미채택', () => {
+      accelMock.mockImplementation(() => 'walking');
+      const { result } = setup({
+        positions: { line: '7', trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-CONSENSUS' })] },
+        positionsOnce: true,
+        trainCode: 'T-CONSENSUS',
+        routeCtx: { route: makeDirectRoute(4, '7'), origin: yongmasan, destination: konkuk },
+        // lock 없음 (lockless trip).
+      });
+      expect(result.current.source).not.toBe('position-train');
+    });
+
+    it('lockless + cellularEnvironmentVote=underground → position-train 미채택', () => {
+      cellularMock.mockImplementation(() => 'underground');
+      const { result } = setup({
+        positions: { line: '7', trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-CONSENSUS-2' })] },
+        positionsOnce: true,
+        trainCode: 'T-CONSENSUS-2',
+        routeCtx: { route: makeDirectRoute(4, '7'), origin: yongmasan, destination: konkuk },
+      });
+      expect(result.current.source).not.toBe('position-train');
+    });
+
+    it('lockless + cellular surface-weak (non-surface) → position-train 미채택', () => {
+      // helper 분기: cellular === 'surface' 만 통과. 'surface-weak'은 보수적으로 reject.
+      cellularMock.mockImplementation(() => 'surface-weak');
+      const { result } = setup({
+        positions: { line: '7', trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-CONSENSUS-3' })] },
+        positionsOnce: true,
+        trainCode: 'T-CONSENSUS-3',
+        routeCtx: { route: makeDirectRoute(4, '7'), origin: yongmasan, destination: konkuk },
+      });
+      expect(result.current.source).not.toBe('position-train');
+    });
+
+    it('lockless + station progression 2 hop+ jump → konkuk station 미선정 (checkStationProgression reject)', () => {
+      // helper checkStationProgression: ±1 hop만 허용. arc=[yongmasan, junggok, gunja, konkuk].
+      // 첫 render: GPS=yongmasan, train=yongmasan → prevCascadeResultRef = yongmasan(idx 0).
+      // 두번째 render: GPS=konkuk(=distance gate 통과), train=konkuk → |3-0|=3 → reject.
+      const routeCtx = { route: makeDirectRoute(4, '7'), origin: yongmasan, destination: konkuk };
+
+      // 첫 render: GPS=yongmasan, train=yongmasan → 채택.
+      mockNearest.mockReturnValueOnce(gpsBase());
+      mockFindTop.mockReturnValueOnce([{ station: yongmasan, distanceKm: 0 }]);
+      mockPos.mockReturnValueOnce(positionRet({
+        line: '7',
+        trains: [train(yongmasan.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-JUMP' })],
+      }));
+      const { result, rerender } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, routeCtx, 'T-JUMP', null),
+      );
+
+      // 두번째 render: GPS=konkuk (distance gate 통과 시켜야 함), train=konkuk.
+      mockNearest.mockReturnValue({
+        ...gpsBase(),
+        userLocation: { lat: konkuk.lat, lng: konkuk.lng },
+        result: { station: konkuk, distanceKm: 0 },
+      });
+      mockFindTop.mockReturnValue([{ station: konkuk, distanceKm: 0 }]);
+      mockPos.mockReturnValue(positionRet({
+        line: '7',
+        trains: [train(konkuk.name, TRAIN_STATUS.ARRIVED, { trainNo: 'T-JUMP' })],
+      }));
+      rerender({});
+      // konkuk가 station progression check에 의해 position-train으로 채택되지 않아야 한다.
+      // (cascade는 GPS top-1 = konkuk로 fallback할 수 있지만 source !== 'position-train')
+      expect(result.current.source).not.toBe('position-train');
     });
   });
 });

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -31,6 +31,15 @@ import { makeDirectRoute, makeTransferRoute, makeMultiTransferRoute } from '../.
 jest.mock('../useNearestStation');
 jest.mock('../../../arrival/hooks/useArrivalInfo');
 jest.mock('../../../route/hooks/useTrainPositions');
+// #1926 — lockless 4-signal consensus 가드는 positionTrainConsensus.test.ts에서 단위 검증.
+// 기존 fusion 테스트는 consensus를 항상 pass 상태로 mock해 회귀 차단 의도(position-train 채택)를 보존.
+// jest.fn으로 export해 특정 케이스(예: motionForDump 'unknown' 경로)에서 override 가능.
+jest.mock('../useAccelerometerFingerprint', () => ({
+  useAccelerometerFingerprint: jest.fn(() => 'automotive'),
+}));
+jest.mock('../useCellularTech', () => ({
+  useCellularTech: jest.fn(() => 'surface'),
+}));
 jest.mock('../../utils/findNearestStation', () => ({
   findTopNearestStations: jest.fn(),
 }));
@@ -1586,11 +1595,20 @@ describe('useFusedNearestStation', () => {
   });
 
   describe('#963 fusionDebugBuffer decisionKey signal mask', () => {
+    // #1926 — 본 describe는 motionForDump fallback 분기(accelerometerPattern='unknown' →
+    // motionStationary boolean) 검증이 핵심이므로, 본 describe 동안 accelerometerPattern
+    // mock을 'unknown'으로 override해 fallback path를 노출.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const accelMockGlobal = require('../useAccelerometerFingerprint').useAccelerometerFingerprint as jest.Mock;
     beforeEach(() => {
       mockUseNearest.mockReturnValue(gpsBase());
       mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
       mockUseArrival.mockReturnValue(arrivalRet(null));
       mockUsePositions.mockReturnValue(positionRet(null));
+      accelMockGlobal.mockImplementation(() => 'unknown');
+    });
+    afterEach(() => {
+      accelMockGlobal.mockImplementation(() => 'automotive');
     });
 
     const renderWithMotion = (motionStationary: boolean | undefined) =>

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.trainProgressing.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.trainProgressing.test.ts
@@ -30,6 +30,13 @@
 jest.mock('../useNearestStation');
 jest.mock('../../../arrival/hooks/useArrivalInfo');
 jest.mock('../../../route/hooks/useTrainPositions');
+// #1926 — lockless 4-signal consensus는 positionTrainConsensus.test.ts에서 단위 검증.
+jest.mock('../useAccelerometerFingerprint', () => ({
+  useAccelerometerFingerprint: () => 'automotive',
+}));
+jest.mock('../useCellularTech', () => ({
+  useCellularTech: () => 'surface',
+}));
 jest.mock('../../utils/findNearestStation');
 jest.mock('../../../route/utils/findActiveLines');
 jest.mock('../../utils/fusionDistanceGate', () => ({

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -46,6 +46,10 @@ import {
 import { haversine } from '../../../shared/utils/haversine';
 import { findStationByName, findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import { isWithinArcWindow, passesFusionDistanceGate } from '../utils/fusionDistanceGate';
+import {
+  checkStationProgression,
+  requiresPositionTrainConsensus,
+} from '../utils/positionTrainConsensus';
 import { surfaceSSOTConsensus } from '../utils/surfaceSSotConsensus';
 import { undergroundSSOTConsensus } from '../utils/undergroundSSotConsensus';
 import { inferEnvironment, type Environment, type InferEnvironmentResult } from '../utils/inferEnvironment';
@@ -702,10 +706,15 @@ export function useFusedNearestStation(
     [candidateTrains, gps.userLocation, boardingLock, arcStations, locklessGuard],
   );
 
-  // #445: trainProgress 갱신 시각 추적 + TTL 만료 후 첫 갱신에서 sticky 락 해제.
+  // #445: trainProgress 갱신 시각 추적 + TTL 만료 후 first 갱신에서 sticky 락 해제.
   // 폴링 정지로 TTL이 지난 뒤 재개되면 trackTrainProgress가 stale sticky를 다시 픽업해
   // 잘못된 락이 반복되는 사이클을 끊는다 — 다음 사이클은 새 후보로 정상 disambiguation.
   const lastProgressTsRef = useRef<number>(0);
+
+  // #1749 — station hop 추적: 직전 cycle result. #1926 (F-fix) lockless position-train
+  // station progression check도 동일 ref 재사용. 같은 noLine에서 hop > PICKER_HOP_ANOMALY_THRESHOLD면
+  // silent skip (prev 유지). update는 cascade 채택 직후(아래 cascadePicker 분기).
+  const prevCascadeResultRef = useRef<NearestStationResult | null>(null);
   useEffect(() => {
     if (!trainProgress) return;
     const now = Date.now();
@@ -775,6 +784,31 @@ export function useFusedNearestStation(
     ) {
       return null;
     }
+    // #1926 (F-fix): lockless 4-signal consensus.
+    // lockless trip은 기존 L782/786/797 boardingLock-conditional 게이트가 모두 비활성이라
+    // distance gate(0.6km)만으로 채택되는 hole이 있다 (6/27 15:49:35 trip evidence: pt=강남 jump).
+    // 사용자 명시 의향 신호(boardingLock)가 없으면 device-side self-contained 4-signal consensus
+    // (barometer / accelerometer / cellular) 필수 — GPS는 의사결정에 미사용
+    // (`feedback_no_gps_for_decision`).
+    if (
+      !requiresPositionTrainConsensus(
+        { barometerSubsurface, accelerometerPattern, cellularEnvironmentVote },
+        boardingLock ?? null,
+      )
+    ) {
+      return null;
+    }
+    // #1926 (F-fix): lockless 시 station progression check (±1 hop).
+    // 직전 cascade result 기준 candidate 역이 2 hop+ jump면 X10 위반(fusion picker output ≠ input).
+    // boardingLock 활성 시는 기존 forward-only / arc-window 가드(L807~)가 boarding index 기준으로
+    // 더 정확한 진행 제약을 강제하므로 본 progression check를 우회한다 (false negative 차단).
+    // arc 밖(cross-line) 또는 prev null(첫 cycle) 시 helper 내부에서 면제.
+    if (
+      boardingLock == null &&
+      !checkStationProgression(station.id, prevCascadeResultRef.current, arcStations)
+    ) {
+      return null;
+    }
     // #662: BoardingLock 활성 시 trainProgress가 lock의 노선과 다르면 강등.
     // 환승역 정지(speed≈0)에서 trackTrainProgress가 옆 노선 통과 열차에 잠기는 케이스 방어 —
     // 사용자가 명시적으로 탭한 열차(lock.boardingLine, #663으로 정확)를 source of truth로 신뢰.
@@ -800,7 +834,19 @@ export function useFusedNearestStation(
       }
     }
     return candidate;
-  }, [trainProgress, gps.userLocation, gps.accuracyMeters, candidates, boardingLock, arcStations, lockedTrainCodeAlive]);
+  }, [
+    trainProgress,
+    gps.userLocation,
+    gps.accuracyMeters,
+    candidates,
+    boardingLock,
+    arcStations,
+    lockedTrainCodeAlive,
+    // #1926 (F-fix) — lockless 4-signal consensus deps.
+    barometerSubsurface,
+    accelerometerPattern,
+    cellularEnvironmentVote,
+  ]);
 
   const routeResult: NearestStationResult | null = progress.position
     ? {
@@ -1128,9 +1174,8 @@ export function useFusedNearestStation(
   //   - lockless: null 반환(다음 cycle에서 재계산).
   const pickerStuckRef = useRef<{ stationId: string; adoptedAt: number } | null>(null);
 
-  // #1749 — station hop > 5 detect: 직전 cycle result 추적.
-  // 같은 noLine에서 hop > PICKER_HOP_ANOMALY_THRESHOLD 이면 silent skip (prev 유지).
-  const prevCascadeResultRef = useRef<NearestStationResult | null>(null);
+  // #1749 — station hop > 5 detect는 prevCascadeResultRef(상단 선언) 사용.
+  // #1926 (F-fix) lockless position-train station progression check가 동일 ref를 공유.
 
   // #1896 (RC-8) — boarding-lock GPS displacement gate.
   //

--- a/src/features/nearest-station/utils/__tests__/positionTrainConsensus.test.ts
+++ b/src/features/nearest-station/utils/__tests__/positionTrainConsensus.test.ts
@@ -1,0 +1,170 @@
+import {
+  checkStationProgression,
+  requiresPositionTrainConsensus,
+  type PositionTrainConsensusSignals,
+} from '../positionTrainConsensus';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+import type { NearestStationResult, Station } from '../../../../shared/types/station';
+
+function makeStation(id: string): Station {
+  return { id, name: id, line: '2', lineColor: '#000', lat: 37.5, lng: 127.0 };
+}
+
+function makeResult(id: string): NearestStationResult {
+  return { station: makeStation(id), distanceKm: 0.05 };
+}
+
+function makeLock(): BoardingLock {
+  return {
+    destinationId: 'dest',
+    trainCode: '2001',
+    boardingStationId: 'A',
+    boardingLine: '2',
+    boardedAt: Date.now(),
+    expectedDurationMs: 30 * 60_000,
+  };
+}
+
+const BASE_SIGNALS: PositionTrainConsensusSignals = {
+  barometerSubsurface: false,
+  accelerometerPattern: 'automotive',
+  cellularEnvironmentVote: 'surface',
+};
+
+describe('requiresPositionTrainConsensus', () => {
+  describe('boardingLock active (사용자 명시 의향)', () => {
+    it('lock active + 모든 신호 미달이어도 true (기존 path 보존)', () => {
+      const lock = makeLock();
+      const signals: PositionTrainConsensusSignals = {
+        barometerSubsurface: true,
+        accelerometerPattern: 'walking',
+        cellularEnvironmentVote: 'underground',
+      };
+      expect(requiresPositionTrainConsensus(signals, lock)).toBe(true);
+    });
+
+    it('lock active + 모든 신호 null이어도 true', () => {
+      const lock = makeLock();
+      const signals: PositionTrainConsensusSignals = {
+        barometerSubsurface: null,
+        accelerometerPattern: null,
+        cellularEnvironmentVote: null,
+      };
+      expect(requiresPositionTrainConsensus(signals, lock)).toBe(true);
+    });
+  });
+
+  describe('lockless 4-signal consensus', () => {
+    it('지하(barometerSubsurface=true) → reject (GPS dead zone)', () => {
+      const signals: PositionTrainConsensusSignals = {
+        ...BASE_SIGNALS,
+        barometerSubsurface: true,
+      };
+      expect(requiresPositionTrainConsensus(signals, null)).toBe(false);
+    });
+
+    it.each(['walking', 'stationary', 'unknown'] as const)(
+      'accelerometerPattern=%s (non-automotive) → reject',
+      (pattern) => {
+        const signals: PositionTrainConsensusSignals = {
+          ...BASE_SIGNALS,
+          accelerometerPattern: pattern,
+        };
+        expect(requiresPositionTrainConsensus(signals, null)).toBe(false);
+      },
+    );
+
+    it('accelerometerPattern=null → reject', () => {
+      const signals: PositionTrainConsensusSignals = {
+        ...BASE_SIGNALS,
+        accelerometerPattern: null,
+      };
+      expect(requiresPositionTrainConsensus(signals, null)).toBe(false);
+    });
+
+    it('automotive + barometer false + cellular surface → accept', () => {
+      expect(requiresPositionTrainConsensus(BASE_SIGNALS, null)).toBe(true);
+    });
+
+    it.each(['surface-weak', 'underground', 'unknown'] as const)(
+      'cellularEnvironmentVote=%s (non-surface) → reject',
+      (vote) => {
+        const signals: PositionTrainConsensusSignals = {
+          ...BASE_SIGNALS,
+          cellularEnvironmentVote: vote,
+        };
+        expect(requiresPositionTrainConsensus(signals, null)).toBe(false);
+      },
+    );
+
+    it('cellularEnvironmentVote=null → reject', () => {
+      const signals: PositionTrainConsensusSignals = {
+        ...BASE_SIGNALS,
+        cellularEnvironmentVote: null,
+      };
+      expect(requiresPositionTrainConsensus(signals, null)).toBe(false);
+    });
+
+    it('barometerSubsurface=undefined (warmup) + 다른 신호 통과 → accept', () => {
+      const signals: PositionTrainConsensusSignals = {
+        ...BASE_SIGNALS,
+        barometerSubsurface: undefined,
+      };
+      expect(requiresPositionTrainConsensus(signals, null)).toBe(true);
+    });
+
+    it('barometerSubsurface=null + 다른 신호 통과 → accept', () => {
+      const signals: PositionTrainConsensusSignals = {
+        ...BASE_SIGNALS,
+        barometerSubsurface: null,
+      };
+      expect(requiresPositionTrainConsensus(signals, null)).toBe(true);
+    });
+  });
+});
+
+describe('checkStationProgression', () => {
+  const arc: Station[] = [
+    makeStation('S0'),
+    makeStation('S1'),
+    makeStation('S2'),
+    makeStation('S3'),
+    makeStation('S4'),
+  ];
+
+  it('prevCascadeResult=null → true (첫 cycle 면제)', () => {
+    expect(checkStationProgression('S2', null, arc)).toBe(true);
+  });
+
+  it('같은 station (0 hop) → true', () => {
+    expect(checkStationProgression('S2', makeResult('S2'), arc)).toBe(true);
+  });
+
+  it('+1 hop → true', () => {
+    expect(checkStationProgression('S2', makeResult('S1'), arc)).toBe(true);
+  });
+
+  it('-1 hop → true (backward 정상 case)', () => {
+    expect(checkStationProgression('S1', makeResult('S2'), arc)).toBe(true);
+  });
+
+  it('+2 hop jump → false', () => {
+    expect(checkStationProgression('S3', makeResult('S1'), arc)).toBe(false);
+  });
+
+  it('-2 hop jump → false', () => {
+    expect(checkStationProgression('S1', makeResult('S3'), arc)).toBe(false);
+  });
+
+  it('prev station이 arc 밖 → true (cross-line 면제)', () => {
+    expect(checkStationProgression('S2', makeResult('OTHER'), arc)).toBe(true);
+  });
+
+  it('candidate station이 arc 밖 → true (cross-line 면제)', () => {
+    expect(checkStationProgression('OTHER', makeResult('S2'), arc)).toBe(true);
+  });
+
+  it('arc 빈 배열 → true', () => {
+    expect(checkStationProgression('S2', makeResult('S1'), [])).toBe(true);
+  });
+});

--- a/src/features/nearest-station/utils/positionTrainConsensus.ts
+++ b/src/features/nearest-station/utils/positionTrainConsensus.ts
@@ -1,0 +1,92 @@
+/**
+ * #1926 (A+F+G3 통합) — `position-train` 채택 전 4-signal consensus + station progression 가드.
+ *
+ * 6/27 trip evidence 2건:
+ *   - 13:40:08 BoardingLock 자동 활성화 — `useBoardingLockController` autoLock fast path가
+ *     `pickAutoTrainCodeFromArrivals` 단일 후보 + `allowedLines` 통과만으로 `createLock` 발사.
+ *   - 15:49:35 fusion `pt=강남` jump — `useFusedNearestStation` `positionTrainResult` useMemo가
+ *     lockless trip에서 distance gate(0.6km)만으로 채택.
+ *
+ * 동일 root: lockless trip에서 `position-train` 신호가 **다른 신호 합의 없이 단독 채택**.
+ *
+ * 본 helper는 두 caller가 공유하는 pure function. unit test로 4-signal 조합을 8가지 verify 가능.
+ *
+ * 정합성:
+ * - `boardingLock` 활성 = 사용자 명시 의향 신호로 간주 → 기존 path 보존(consensus skip).
+ * - lockless = device-side 자체 신호 합의 필수 — false positive 차단(ADR-014 첫 줄, X9/X10 acceptance).
+ * - GPS는 의사결정에 미사용 — barometer / accelerometer / cellular 3 signal로만 판단
+ *   (`memory/feedback_no_gps_for_decision.md`).
+ * - station progression check ±1 hop — lockless에서 station 2 hop+ jump는 cascade 회귀
+ *   (X10 acceptance: fusion picker output ≠ input).
+ *
+ * 참조:
+ * - `memory/feedback_device_self_contained_fusion.md` — backend/GPS/WiFi 다 죽어도 device 보장.
+ * - `memory/feedback_user_intent_equal_protection.md` — lock 활성 = 사용자 명시 의향.
+ * - `docs/adr/ADR-015-multi-signal-consensus-gate.md` §3 — GPS reject in underground.
+ */
+
+import type { BoardingLock } from '../../../shared/types/boardingLock';
+import type { NearestStationResult, Station } from '../../../shared/types/station';
+import type { AccelerometerPattern } from './accelerometerFingerprint';
+import type { CellularEnvironmentVote } from './cellularTech';
+
+/**
+ * 4-signal consensus 입력 신호 묶음. caller 양쪽이 동일 shape으로 전달.
+ *
+ * - `barometerSubsurface` — `true=지하`, `false=지상`, `null|undefined=미확정(warmup/미지원)`.
+ * - `accelerometerPattern` — `'automotive' | 'walking' | 'stationary' | 'unknown' | null`.
+ * - `cellularEnvironmentVote` — `'surface' | 'surface-weak' | 'underground' | 'unknown'`.
+ */
+export interface PositionTrainConsensusSignals {
+  barometerSubsurface: boolean | null | undefined;
+  accelerometerPattern: AccelerometerPattern | null;
+  cellularEnvironmentVote: CellularEnvironmentVote | null;
+}
+
+/**
+ * `position-train` 신호 채택 여부.
+ *
+ * - `boardingLock != null` → 기존 path 보존(lock 자체가 사용자 명시 의향 signal). return true.
+ * - lockless 시 4-signal consensus 적용:
+ *   1) `barometerSubsurface === true` (지하 확정) → return false.
+ *      GPS dead zone에서 `position-train`의 station-progress가 GPS 좌표에 의존하므로 신뢰 X
+ *      (ADR-015 §3 "GPS reject in underground").
+ *   2) `accelerometerPattern !== 'automotive'` (정차/도보/미확정) → return false.
+ *      탑승 중이 아니면 `position-train` 채택 의미가 없다 (false positive 차단).
+ *   3) `cellularEnvironmentVote === 'surface'` (지상 확정) → return true.
+ *      barometer false-negative 보강 — surface 확정 시 채택 허용.
+ *   4) 그 외 (cellular 'surface-weak' / 'underground' / 'unknown' / null / undefined) → return false.
+ *      환경 ambiguity = 보수적으로 채택 보류(false positive 우선 차단, ADR-014 첫 줄).
+ */
+export function requiresPositionTrainConsensus(
+  signals: PositionTrainConsensusSignals,
+  boardingLock: BoardingLock | null,
+): boolean {
+  if (boardingLock != null) return true;
+  const { barometerSubsurface, accelerometerPattern, cellularEnvironmentVote } = signals;
+  if (barometerSubsurface === true) return false;
+  if (accelerometerPattern !== 'automotive') return false;
+  if (cellularEnvironmentVote === 'surface') return true;
+  return false;
+}
+
+/**
+ * station progression check — 직전 cascade result 기준 ±1 hop 범위 내인지 검사.
+ *
+ * - `prevCascadeResult == null` (첫 cycle) → return true (면제).
+ * - `arcStations`에서 둘 다 찾을 수 없는 경우(cross-line 환승, arc 밖) → return true (면제).
+ * - 그 외: `|candidateIdx - prevIdx| <= 1` 이면 return true.
+ *
+ * ±1 hop 허용 = 정차/통과 정상 케이스. 2 hop+ jump는 X10 위반(fusion picker output ≠ input).
+ */
+export function checkStationProgression(
+  candidateStationId: string,
+  prevCascadeResult: NearestStationResult | null,
+  arcStations: readonly Station[],
+): boolean {
+  if (prevCascadeResult == null) return true;
+  const prevIdx = arcStations.findIndex((s) => s.id === prevCascadeResult.station.id);
+  const candidateIdx = arcStations.findIndex((s) => s.id === candidateStationId);
+  if (prevIdx === -1 || candidateIdx === -1) return true;
+  return Math.abs(candidateIdx - prevIdx) <= 1;
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -31,6 +31,8 @@ import { buildWidgetTripContext } from '../features/widget/utils/buildTripContex
 import { useStationAlarm } from '../features/alarm/hooks/useStationAlarm';
 import { useMotionActivity } from '../features/nearest-station/hooks/useMotionActivity';
 import { useAccelerometer } from '../features/nearest-station/hooks/useAccelerometer';
+import { useAccelerometerFingerprint } from '../features/nearest-station/hooks/useAccelerometerFingerprint';
+import { useCellularTech } from '../features/nearest-station/hooks/useCellularTech';
 import { useBarometer } from '../shared/hooks/useBarometer';
 import { useTripOrigin } from '../features/route/hooks/useTripOrigin';
 import { useBackgroundLocation } from '../features/nearest-station/hooks/useBackgroundLocation';
@@ -197,6 +199,11 @@ export default function HomeScreen() {
   // 조회하는 ambient state를 채운다. 반환값 없음 — useMotionActivity/useBarometer와 동일 패턴.
   // 미지원/권한 거절은 accelMotionState가 null을 유지해 BG task가 graceful fallback.
   useAccelerometer();
+  // #1926 (A-fix) — autoLock fast path 4-signal consensus 가드용 fingerprint + cellular vote.
+  // useFusedNearestStation 내부에서도 동일 hook을 호출하지만 React는 component-level 격리이므로
+  // 두 hook instance는 독립. native module은 module-level cache라 비용 미미.
+  const accelerometerPattern = useAccelerometerFingerprint();
+  const cellularEnvironmentVote = useCellularTech();
   // #903 (Seam G) — 기압계 dP/dt 신호. 미지원/권한 거절은 subsurface=false 고정(graceful).
   //   1) useFusedNearestStation: 'gps-only' → 'gps-only-underground' 강등 + sticky automotive 트리거.
   //   2) useApnsTripRegistration: backend payload subsurface 동봉(threshold 5→10).
@@ -606,6 +613,10 @@ export default function HomeScreen() {
     expectedDurationMinutes: staticEtaMinutes,
     motionStationary,
     speedMps,
+    // #1926 (A-fix) — 4-signal consensus 가드 신호.
+    barometerSubsurface,
+    accelerometerPattern,
+    cellularEnvironmentVote,
   });
   // #1844 — cold start mismatch 재확인: lock 해제 → 사용자가 다시 탑승 선택 가능.
   const handleColdStartMismatchReselect = useCallback(() => {


### PR DESCRIPTION
## Summary
- **A** (`useBoardingLockController.ts:476`): device-side autoLock fast path 4-signal consensus 가드. `position-train` 자체 발사(BoardingTrainList 탭 / boardingPrompt 응답 부재)이므로 lockless paradigm과 동일하게 barometer/accelerometer/cellular 합의 통과 시에만 `createLock`. 미달 시 idempotency ref 미설정 → graceful 재시도.
- **F** (`useFusedNearestStation.ts:787-806`): `positionTrainResult` lockless 채택 hole 봉합. distance gate(0.6km) 외에 4-signal consensus + station progression (±1 hop) 가드 추가. lock 활성 시는 기존 path 보존.
- **G3**: F-fix가 동일 paradigm을 커버해 통합 처리. 공통 helper `positionTrainConsensus.ts` (`requiresPositionTrainConsensus` + `checkStationProgression`) 신규 pure function — 23개 unit 케이스로 4-signal 조합 / progression hop 분기 verify.

Closes #1926

## Wire-completion 5단 체크
1. **Orphan 없음** — `npm run lint:orphan` pass. `positionTrainConsensus.ts` 신규 + helper export 2개 (`requiresPositionTrainConsensus`, `checkStationProgression`). caller = `useFusedNearestStation.ts:794/804` + `useBoardingLockController.ts:486` 둘 다 존재.
2. **V/X dashboard** — DebugModal `position-train consensus state` 섹션 + autoLock 활성화 source 표시(기존). consensus 미달 시 createLock 호출 0건 = X9 acceptance 직접 측정.
3. **의존 PR** — N/A. helper는 본 PR에 self-contained.
4. **측정 plan** — 1주 사용자 trip evidence:
   - autoLock 4-signal pass rate (사용자 탭 안 한 lock 자동 활성화 0건)
   - fusion jump (이전 station ≠ 다음 station station progression ±1 hop 위반) 0건
   - cascade tier 6 채택 → tier 7+ fallback 분포 측정 (X6 risk monitor)
5. **Device verify** — 실기기 cross-trip 환승 trip 1회. 시나리오: 강남(2)→사당(2)→사당(4)→삼각지(4) lockless 자동 검출. 환승역 정차(speed≈0) 시 다른 노선 열차 잠금 안 되는지 verify.

## V/X Acceptance

| ID | 항목 | 본 fix |
| --- | --- | --- |
| **V1** | 정확한 현재역 표시 | F: 사용자 실위치 ≠ position-train 채택 차단 |
| **V7** | 지하 station-passed 정확 | F: barometer subsurface=true 시 position-train reject → cascade fallback |
| **X1** | 잘못된 station 알람 0건 | F: progression check + consensus |
| **X9** | 사용자 의도 외 fire 0건 | A: device-side autoLock에 consensus 가드 — false positive 차단 |
| **X10** | fusion picker output ≠ input 0건 | F: cascade tier 6 lockless hole 차단 |

## Test plan
- [x] `npm test` 8538개 통과 / 커버리지 100% (statements / branches / lines / functions)
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass
- [x] code-review P1 반영 — progression check를 lockless-only로 한정해 lock-active 정상 진행 false negative 차단