### PR TITLE
fix(#1951): useStationMismatchDetector consensus 강화 — 5 cycle + barometer warmup quorum 가드

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useStationMismatchDetector.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useStationMismatchDetector.test.ts
@@ -525,7 +525,7 @@ describe('§6 alarmLog 적재 + dedup', () => {
 describe('§7 상수 export', () => {
   it.each([
     ['LINE_MISMATCH_THRESHOLD', LINE_MISMATCH_THRESHOLD, 3],
-    ['ENV_MISMATCH_THRESHOLD', ENV_MISMATCH_THRESHOLD, 3],
+    ['ENV_MISMATCH_THRESHOLD', ENV_MISMATCH_THRESHOLD, 5],
     ['ROUTE_DIVERGE_THRESHOLD', ROUTE_DIVERGE_THRESHOLD, 3],
     ['ROUTE_DIVERGE_HOP_THRESHOLD', ROUTE_DIVERGE_HOP_THRESHOLD, 3],
     ['MISMATCH_LOG_DEDUP_WINDOW_MS', MISMATCH_LOG_DEDUP_WINDOW_MS, 60 * 1000],
@@ -533,3 +533,174 @@ describe('§7 상수 export', () => {
     expect(actual).toBe(expected);
   });
 });
+
+// ── §8 #1951 barometer warmup quorum 가드 ───────────────────────────────────
+//
+// 옵션 C — environment-mismatch 정확성 게이트 강화. PR #1949 (#1932 G2) inferEnvironment
+// 우선순위 4(`subsurface=false` + 두 SSOT null → 'surface')가 도입한 spurious 'surface'
+// false positive를 차단한다.
+
+describe('§8 #1951 barometer warmup quorum 가드', () => {
+  const lock = makeLock({ boardingStationId: 'STN-UNDERGROUND' });
+  const countersZero = { routeDiverged: 0, lineMismatch: 0, envMismatch: 0 };
+
+  beforeEach(() => {
+    mockGetStationById.mockImplementation((id: string) => {
+      if (id === 'STN-UNDERGROUND') return UNDERGROUND_BOARDING_STATION;
+      return undefined;
+    });
+  });
+
+  it('barometerWarmupReady=true: 정상 mismatch — 5 cycle 누적 + warmup 합의 → detected=true', () => {
+    let counters = countersZero;
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-X', '2'),
+      arcStations: [],
+      currentHopIndex: null,
+      environment: 'surface',
+      barometerWarmupReady: true,
+    };
+    for (let i = 0; i < ENV_MISMATCH_THRESHOLD - 1; i++) {
+      counters = computeMismatch(input, counters).next;
+    }
+    expect(counters.envMismatch).toBe(ENV_MISMATCH_THRESHOLD - 1);
+    const { result, next } = computeMismatch(input, counters);
+    expect(next.envMismatch).toBe(ENV_MISMATCH_THRESHOLD);
+    expect(result.detected).toBe(true);
+    expect(result.reason).toBe('environment-mismatch');
+  });
+
+  it('barometerWarmupReady=true: 4 cycle만(5 미만) → detected=false', () => {
+    let counters = countersZero;
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-X', '2'),
+      arcStations: [],
+      currentHopIndex: null,
+      environment: 'surface',
+      barometerWarmupReady: true,
+    };
+    for (let i = 0; i < ENV_MISMATCH_THRESHOLD - 1; i++) {
+      const out = computeMismatch(input, counters);
+      counters = out.next;
+      expect(out.result.detected).toBe(false);
+    }
+    expect(counters.envMismatch).toBe(4);
+  });
+
+  it('barometerWarmupReady=false: 5 cycle 누적 + warmup 미합의 → 카운터 0 유지, detected=false', () => {
+    let counters = countersZero;
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-X', '2'),
+      arcStations: [],
+      currentHopIndex: null,
+      environment: 'surface',
+      barometerWarmupReady: false,
+    };
+    for (let i = 0; i < ENV_MISMATCH_THRESHOLD; i++) {
+      const out = computeMismatch(input, counters);
+      counters = out.next;
+      expect(out.result.detected).toBe(false);
+    }
+    // warmup 미합의 → 카운터 increment X
+    expect(counters.envMismatch).toBe(0);
+  });
+
+  it('false positive 시나리오: 지하 lock + spurious surface 3 cycle + warmup race → 트리거 X', () => {
+    // 이슈 본문 시나리오 재현:
+    //   1. 지하 station lock 활성 (boardingStation.environment='underground')
+    //   2. Barometer가 지하에서 spurious `subsurface=false` 발사 (보정 race / warmup jitter)
+    //   3. 두 SSOT 모두 warmup 미합의 → inferEnvironment 우선순위 4 → 'surface'
+    //   4. 본 detector가 3 cycle 누적해도 5 미만 + warmup quorum 미충족 → no trigger
+    let counters = countersZero;
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-X', '2'),
+      arcStations: [],
+      currentHopIndex: null,
+      environment: 'surface', // spurious surface
+      barometerWarmupReady: false, // warmup race
+    };
+    for (let i = 0; i < 3; i++) {
+      const out = computeMismatch(input, counters);
+      counters = out.next;
+    }
+    expect(counters.envMismatch).toBe(0); // increment 자체 차단
+    const { result } = computeMismatch(input, counters);
+    expect(result.detected).toBe(false);
+  });
+
+  it('warmup 미합의 → 카운터 reset도 X (neutral). underground 관측이 와도 기존 카운터 유지', () => {
+    // 기존 카운터가 비어있지 않은 상태에서 warmup 미합의 underground 관측이 와도 reset 안 함.
+    const counters = { ...countersZero, envMismatch: 2 };
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-X', '2'),
+      arcStations: [],
+      currentHopIndex: null,
+      environment: 'underground',
+      barometerWarmupReady: false,
+    };
+    const { next } = computeMismatch(input, counters);
+    expect(next.envMismatch).toBe(2); // neutral 유지
+  });
+
+  it('warmup 합의 → underground 관측 시 reset 정상 (기존 동작 보존)', () => {
+    const counters = { ...countersZero, envMismatch: 3 };
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-X', '2'),
+      arcStations: [],
+      currentHopIndex: null,
+      environment: 'underground',
+      barometerWarmupReady: true,
+    };
+    const { next } = computeMismatch(input, counters);
+    expect(next.envMismatch).toBe(0);
+  });
+
+  it('barometerWarmupReady 미지정(기본 true) → 기존 호출자 호환', () => {
+    // barometerWarmupReady 키 자체를 빼면 기본값 true가 적용돼 평가 정상 진행.
+    const counters = { ...countersZero, envMismatch: ENV_MISMATCH_THRESHOLD - 1 };
+    const input: UseStationMismatchDetectorInput = {
+      boardingLock: lock,
+      fusedResult: makeResult('STN-X', '2'),
+      arcStations: [],
+      currentHopIndex: null,
+      environment: 'surface',
+      // barometerWarmupReady omitted
+    };
+    const { result, next } = computeMismatch(input, counters);
+    expect(next.envMismatch).toBe(ENV_MISMATCH_THRESHOLD);
+    expect(result.detected).toBe(true);
+    expect(result.reason).toBe('environment-mismatch');
+  });
+
+  it('useStationMismatchDetector hook도 barometerWarmupReady 전달 + deps 반영', () => {
+    // hook level integration: warmup ready false에서 시작 → true로 flip 시 effect 재실행.
+    mockGetStationById.mockImplementation((id: string) => {
+      if (id === 'STN-UNDERGROUND') return UNDERGROUND_BOARDING_STATION;
+      return undefined;
+    });
+    const { result, rerender } = renderHook(
+      ({ warmup }: { warmup: boolean }) =>
+        useStationMismatchDetector({
+          boardingLock: lock,
+          fusedResult: makeResult('STN-X', '2'),
+          arcStations: [],
+          currentHopIndex: null,
+          environment: 'surface',
+          barometerWarmupReady: warmup,
+        }),
+      { initialProps: { warmup: false } },
+    );
+    // warmup 미합의 시 cycle 5회 — increment 차단
+    for (let i = 0; i < ENV_MISMATCH_THRESHOLD; i++) {
+      act(() => { rerender({ warmup: false }); });
+    }
+    expect(result.current.detected).toBe(false);
+  });
+});
+

--- a/src/features/nearest-station/hooks/useStationMismatchDetector.ts
+++ b/src/features/nearest-station/hooks/useStationMismatchDetector.ts
@@ -23,7 +23,11 @@ import { getStationById } from '../../../shared/utils/stationRoute';
  * ====================
  * - 'route-diverged'        : observed 역이 arc 위 expected window(±HOP_THRESHOLD) 밖 — 3회 연속
  * - 'line-mismatch'         : lock.boardingLine ≠ fusedResult.station.line — 3회 연속
- * - 'environment-mismatch'  : lock 탑승역 type=underground + observed environment=surface — 3회 연속
+ * - 'environment-mismatch'  : lock 탑승역 type=underground + observed environment=surface — 5회 연속
+ *   (#1951 — 옵션 C consensus 강화. PR #1949 (#1932 G2) inferEnvironment 우선순위 4로
+ *   subsurface=false + 두 SSOT null 조합이 'surface' 라벨을 발사할 수 있는데 — 지하 lock 활성
+ *   trip에서 barometer warmup race / 환승 통로 일시 지상 등으로 spurious 'surface'가 3 cycle
+ *   누적될 가능성이 있음. 5 cycle + barometer warmup quorum 충족 시만 트리거.)
  *
  * 한 번 일치 → 해당 reason 카운터 reset (false positive 차단).
  *
@@ -37,14 +41,22 @@ import { getStationById } from '../../../shared/utils/stationRoute';
  * =====================
  * - lock=null / fusedResult=null → 즉시 no-op(detected=false).
  * - arcStations 빈 배열 → route-diverged 감지 비활성 (arc 없으면 diverge 판단 불가).
+ * - barometerWarmupReady=false → environment-mismatch 카운터 증가 X (#1951 가드).
+ *   warmup 미합의 시 `subsurface=false` 신뢰도 낮음 → mismatch 판정 보류(neutral, 기존 카운터 유지).
  * - 1분 dedup 윈도우 — 같은 reason 연속 적재 차단.
  */
 
 /** line-mismatch 감지 연속 임계값. */
 export const LINE_MISMATCH_THRESHOLD = 3;
 
-/** environment-mismatch 감지 연속 임계값. */
-export const ENV_MISMATCH_THRESHOLD = 3;
+/**
+ * environment-mismatch 감지 연속 임계값.
+ *
+ * #1951 — 3 → 5 강화. PR #1949 (#1932 G2) inferEnvironment 우선순위 4 (subsurface=false +
+ * 두 SSOT null → 'surface') false positive 차단. barometer warmup race / 환승 통로 일시 지상
+ * 등으로 spurious 'surface'가 3 cycle 누적되더라도 reconfirm prompt 발사 X.
+ */
+export const ENV_MISMATCH_THRESHOLD = 5;
 
 /** route-diverged 감지 연속 임계값. */
 export const ROUTE_DIVERGE_THRESHOLD = 3;
@@ -75,6 +87,18 @@ export interface UseStationMismatchDetectorInput {
   currentHopIndex: number | null;
   /** 환경 분류. environment-mismatch 감지용. */
   environment: Environment;
+  /**
+   * #1951 — barometer warmup quorum 충족 여부. environment-mismatch 카운터 증가 prereq.
+   *
+   * - true  : barometer ring buffer가 `BAROMETER_MISMATCH_QUORUM_READINGS` 이상 누적 →
+   *           `subsurface` 신호 신뢰. environment-mismatch 정상 평가.
+   * - false : warmup 미충족 → spurious `subsurface=false` 가능성. environment-mismatch
+   *           카운터 증가 X, 기존 카운터 유지(neutral). reset도 안 함.
+   *
+   * 호출자는 `barometerSignal.readingCount`로 quorum 평가해 전달.
+   * 기본값 true — 기존 caller 호환 + 명시 안 한 시나리오에서는 평가 기존대로 진행.
+   */
+  barometerWarmupReady?: boolean;
 }
 
 const NO_MISMATCH: StationMismatchResult = { detected: false, reason: null };
@@ -92,7 +116,14 @@ export function computeMismatch(
   result: StationMismatchResult;
   next: { routeDiverged: number; lineMismatch: number; envMismatch: number };
 } {
-  const { boardingLock, fusedResult, arcStations, currentHopIndex, environment } = input;
+  const {
+    boardingLock,
+    fusedResult,
+    arcStations,
+    currentHopIndex,
+    environment,
+    barometerWarmupReady = true,
+  } = input;
 
   if (!boardingLock || !fusedResult) {
     return { result: NO_MISMATCH, next: { routeDiverged: 0, lineMismatch: 0, envMismatch: 0 } };
@@ -117,10 +148,16 @@ export function computeMismatch(
     observedLine !== boardingLock.boardingLine ? counters.lineMismatch + 1 : 0;
 
   // ── environment-mismatch ─────────────────────────────────────────────────────
-  // lock.boardingStationId로 탑승역 조회 → environment 확인
+  // lock.boardingStationId로 탑승역 조회 → environment 확인.
+  // #1951 — barometer warmup quorum 미충족 시 increment/reset 모두 보류(neutral).
+  //   spurious `subsurface=false` 가 우선순위 4(#1932)를 거쳐 surface로 평가될 수 있는 구간에서
+  //   카운터를 건드리지 않아 false positive 차단. 한 cycle 영향만 — warmup이 끝나면 다음 cycle부터
+  //   정상 평가 재개. 카운터 유지는 boardingStation 조회 실패와 동일 neutral 의미.
   const boardingStation = getStationById(boardingLock.boardingStationId);
   let envMismatch = counters.envMismatch;
-  if (boardingStation?.environment === 'underground' && environment === 'surface') {
+  if (!barometerWarmupReady) {
+    // neutral — 카운터 유지
+  } else if (boardingStation?.environment === 'underground' && environment === 'surface') {
     envMismatch = counters.envMismatch + 1;
   } else if (boardingStation !== undefined) {
     // 탑승역 조회 성공, 조건 미충족 → reset
@@ -156,11 +193,25 @@ export function useStationMismatchDetector(
   const lastLogRef = useRef<{ reason: MismatchReason; ts: number } | null>(null);
 
   // 입력 deps로 effect 재실행 — 매 polling tick마다 fusedResult/environment가 갱신됨
-  const { boardingLock, fusedResult, arcStations, currentHopIndex, environment } = input;
+  const {
+    boardingLock,
+    fusedResult,
+    arcStations,
+    currentHopIndex,
+    environment,
+    barometerWarmupReady,
+  } = input;
 
   useEffect(() => {
     const { result, next } = computeMismatch(
-      { boardingLock, fusedResult, arcStations, currentHopIndex, environment },
+      {
+        boardingLock,
+        fusedResult,
+        arcStations,
+        currentHopIndex,
+        environment,
+        barometerWarmupReady,
+      },
       countersRef.current,
     );
     countersRef.current = next;
@@ -185,7 +236,14 @@ export function useStationMismatchDetector(
       // expectedStationAtFire 슬롯에 reason 적재 — 기존 AlarmLogStamp 스키마 재사용
       expectedStationAtFire: result.reason,
     });
-  }, [boardingLock, fusedResult, arcStations, currentHopIndex, environment]);
+  }, [
+    boardingLock,
+    fusedResult,
+    arcStations,
+    currentHopIndex,
+    environment,
+    barometerWarmupReady,
+  ]);
 
   return resultRef.current;
 }

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -66,6 +66,7 @@ import { useBoardingLockSync } from '../features/alarm/hooks/useBoardingLockSync
 import { useFgPositionUpload } from '../features/alarm/hooks/useFgPositionUpload';
 import { useCurrentStationConfirmModal } from '../features/nearest-station/hooks/useCurrentStationConfirmModal';
 import { isStrongFusionConfidence } from '../shared/constants/fusionConfidenceStrength';
+import { BAROMETER_MISMATCH_QUORUM_READINGS } from '../shared/constants/barometer';
 import { useWifiStation } from '../features/nearest-station/hooks/useWifiStation';
 import { CurrentStationConfirmModal } from '../features/nearest-station/components/CurrentStationConfirmModal';
 import { ColdStartCandidatePicker } from '../features/nearest-station/components/ColdStartCandidatePicker';
@@ -225,14 +226,20 @@ export default function HomeScreen() {
   useV1MismatchDetector(result?.station.id ?? null, backendSsotCurrentStationId);
 
   // #1844 (Phase 6.1 Sub-step 5) — cold start 선택 역과 진행 중 신호 mismatch 감지.
-  // lock.boardingLine / arc / environment와 observed 신호가 3회 연속 불일치 시 detected=true.
+  // lock.boardingLine / arc와 observed 신호가 3회 연속 불일치(line / route-diverged) 또는
+  // 환경 5회 연속 불일치(#1951 env consensus 강화) 시 detected=true.
   // detected=true 시 배너로 재확인 prompt (ActionBanner). alarmLog reason='cold-start-mismatch'로 측정.
+  // #1951 — barometer warmup quorum 충족 시만 environment-mismatch 평가 (false positive 가드).
+  //   ring buffer가 `BAROMETER_MISMATCH_QUORUM_READINGS` 이상 쌓였을 때만 신뢰 가능.
+  const barometerWarmupReady =
+    (barometerSignal.readingCount ?? 0) >= BAROMETER_MISMATCH_QUORUM_READINGS;
   const coldStartMismatch = useStationMismatchDetector({
     boardingLock: fusionBoardingLock,
     fusedResult: result,
     arcStations,
     currentHopIndex,
     environment,
+    barometerWarmupReady,
   });
 
   // #914 (F4) — 1탭 현재역 확정 모달. 자동 추정이 locationUncertain으로 길어지면 후보 1~3개를

--- a/src/shared/constants/barometer.ts
+++ b/src/shared/constants/barometer.ts
@@ -124,3 +124,18 @@ export const BAROMETER_SUBSURFACE_CONFIRM_SAMPLES = 3;
  * 위해 2로 줄이는 식으로 각각 따로 조정 가능.
  */
 export const BAROMETER_STOP_CONFIRM_SAMPLES = 3;
+
+/**
+ * #1951 — environment-mismatch 가드용 barometer warmup quorum 최소 reading 수.
+ *
+ * 단위: 누적 sample 개수 (1Hz × 초).
+ *
+ * 근거:
+ *   - dP/dt 평가 윈도우(`BAROMETER_DPDT_WINDOW_MS` = 30_000ms) 정합.
+ *   - 1Hz polling 기준 30개 reading = 30s warmup 누적 → ring buffer가 윈도우를 채운 시점.
+ *   - 이 시점 이후의 `subsurface` 값은 warmup 노이즈가 빠진 신뢰 가능 신호.
+ *   - `useStationMismatchDetector`가 environment-mismatch 카운터 증가 prereq로 사용 —
+ *     warmup 미충족 시 spurious `subsurface=false` 가 우선순위 4(#1932)를 거쳐 surface로
+ *     평가되더라도 mismatch 트리거 X (false positive 차단).
+ */
+export const BAROMETER_MISMATCH_QUORUM_READINGS = 30;


### PR DESCRIPTION
## Summary
- 옵션 C 채택 — environment-mismatch 트리거 임계 3 cycle → 5 cycle + barometer warmup quorum 동의 시만
- false binary 차단 룰 + 정확성 게이트 보강 (feedback_decision_no_false_binary)
- 지하 lock + spurious subsurface=false race + 두 SSOT null → 'surface' (#1932 우선순위 4) false positive 차단
- line-mismatch / route-diverged threshold는 3 유지 (#1951 범위 = environment-mismatch 단독)

Closes #1951

## 변경 요약
| 파일 | 변경 |
|---|---|
| `src/features/nearest-station/hooks/useStationMismatchDetector.ts` | `ENV_MISMATCH_THRESHOLD` 3 → 5, `barometerWarmupReady?: boolean` input 추가, warmup 미합의 시 envMismatch 카운터 increment/reset 모두 보류(neutral) |
| `src/shared/constants/barometer.ts` | `BAROMETER_MISMATCH_QUORUM_READINGS = 30` 추가 (1Hz × 30s = `BAROMETER_DPDT_WINDOW_MS` 정합) |
| `src/screens/HomeScreen.tsx` | `barometerSignal.readingCount >= QUORUM` 평가해 mismatch detector에 wire |
| `__tests__/useStationMismatchDetector.test.ts` | §8 신규 8 케이스 (정상 mismatch / 4 cycle / 5 cycle + warmup race / underground reset 정상 / default true / hook deps) + §7 상수 검증 5로 갱신 |

## Wire-completion 5단 체크
1. **Orphan 없음** — `npm run lint:orphan` pass. `BAROMETER_MISMATCH_QUORUM_READINGS`는 `HomeScreen` 1곳 import.
2. **V/X dashboard** — DebugModal `cold-start-mismatch` 카운터 (기존 alarmLog reason). PR #1949 머지 후 1주 reconfirm prompt 빈도 + barometer warmup 중 mismatch trigger 카운트.
3. **의존 PR** — #1949 (#1932 G2 inferEnvironment SSOT) 머지됨. backend N/A.
4. **측정 plan** — 1주 production:
   - alarmLog `reason='cold-start-mismatch'` + `expectedStationAtFire='environment-mismatch'` 발사 카운트 (5-cycle threshold 변경 영향)
   - reconfirm prompt 사용자 노출 카운트 (목표: 지하 lock trip 0건)
   - `BarometerSignal.readingCount` 30 미만 구간에서 mismatch 카운터 증가 0건 확인
5. **Device verify** — 실기기 지하 lock trip 1회 (예: 강남역 ~ 잠실역 2호선 지하 구간) + reconfirm prompt 0건 + DebugModal mismatch counter 변동 없음 확인

## V/X acceptance 매핑
- **V8c (지하 lock 정확성)**: 지하 lock 활성 trip에서 reconfirm prompt 0건 — false positive 차단
- **X11 (lockless 6h+ 회귀)**: env-mismatch 카운터는 boardingLock 활성 시만 평가 → lockless 영향 X (회귀 가드)

## Known risk
- N/A — 옵션 C는 정확성 게이트 보강이라 false negative(실제 잘못된 역 선택을 못 잡음) 약간 증가 가능. 다만 line/route-diverged 두 채널이 3-cycle threshold 그대로 + 우선순위(route > line > env)로 env-mismatch는 다른 두 신호가 reset된 narrow 케이스에만 단독 트리거 → 실제 영향 미미.

## Test plan
- [x] `npm test` 405 suite / 8553 test pass, coverage 100%
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass (No orphan exports detected)
- [x] code-review (medium) — HomeScreen 주석 drift + test 중복 cleanup 반영 후 PR 생성