### PR TITLE
feat(#1936): pickFusionTier extract + cascade reorder + #1934 env vote counter

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -1026,6 +1026,13 @@ function formatCandidateRejectLine(entry: CandidateRejectEntry): string {
     const d = entry.distanceKm != null ? `${Math.round(entry.distanceKm * 1000)}m` : '-';
     return `${time} | reject:${entry.reason} | ${train} ${station}(${entry.line}) d=${d}`;
   }
+  // #1934 G3 option B + #1936 G4 — candidate-env: cascade/candidate env 비교 노출.
+  if (entry.reason === 'candidate-env') {
+    const station = entry.stationName ?? '-';
+    const cascade = entry.cascadeEnvironment ?? '-';
+    const cand = entry.candidateEnvironment ?? '-';
+    return `${time} | reject:${entry.reason} | ${station}(${entry.line}) cascade=${cascade} candidate=${cand}`;
+  }
   return `${time} | reject:${entry.reason} | line=${entry.line}`;
 }
 

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -2161,6 +2161,34 @@ describe('formatFusionDebugLine', () => {
     expect(line).not.toContain('d=');
   });
 
+  it('#1934 G3 + #1936 G4 candidate-env reject: cascade/candidate env 노출', () => {
+    const line = formatCandidateRejectLine({
+      kind: 'candidate-reject',
+      ts: new Date('2026-06-21T12:00:00Z').getTime(),
+      reason: 'candidate-env',
+      stationName: '강남',
+      line: '2',
+      cascadeEnvironment: 'underground',
+      candidateEnvironment: 'surface',
+    });
+    expect(line).toContain('reject:candidate-env');
+    expect(line).toContain('강남(2)');
+    expect(line).toContain('cascade=underground');
+    expect(line).toContain('candidate=surface');
+  });
+
+  it('#1934 G3 + #1936 G4 candidate-env reject: 옵셔널 env 누락 시 "-" fallback', () => {
+    const line = formatCandidateRejectLine({
+      kind: 'candidate-reject',
+      ts: new Date('2026-06-21T12:00:00Z').getTime(),
+      reason: 'candidate-env',
+      line: '2',
+    });
+    expect(line).toContain('reject:candidate-env');
+    expect(line).toContain('cascade=-');
+    expect(line).toContain('candidate=-');
+  });
+
   it('#1902 candidate-distance reject: 옵셔널 필드 누락 시 "-" fallback', () => {
     // type상 optional이지만 useFusedNearestStation는 항상 채워 호출. defensive fallback 분기 커버.
     const line = formatCandidateRejectLine({

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -42,6 +42,7 @@ import {
   logFusionCandidateLineReject,
   logFusionPickerTier,
   logSuppressedLocklessForwardOnly,
+  type FusionPickerTier,
 } from '../../alarm/utils/alarmLog';
 import { haversine } from '../../../shared/utils/haversine';
 import { findStationByName, findStationByNameAndLine } from '../../../shared/utils/stationLookup';
@@ -53,7 +54,16 @@ import {
 import { surfaceSSOTConsensus } from '../utils/surfaceSSotConsensus';
 import { undergroundSSOTConsensus } from '../utils/undergroundSSotConsensus';
 import { inferEnvironment, type Environment, type InferEnvironmentResult } from '../utils/inferEnvironment';
-import { recordEnvironmentTransition } from '../../../shared/infra/monitoring/breadcrumb';
+import {
+  isCandidateEnvMismatch,
+  pickFusionTier,
+  type FusionSignals,
+  type FusionTierName,
+} from '../utils/pickFusionTier';
+import {
+  recordEnvironmentTransition,
+  recordFusionTierAdopted,
+} from '../../../shared/infra/monitoring/breadcrumb';
 import { computeRouteArc } from '../../route/utils/routeProgress';
 import {
   arcIndexOfStation,
@@ -78,9 +88,11 @@ import {
   GPS_DERIVED_FIX_MAX_AGE_MS,
   GPS_DERIVED_ROUTE_MATCH_MAX_KM,
   GPS_FALLBACK_STALE_MAX_AGE_MS,
+  GPS_FALLBACK_STALE_UNDERGROUND_MAX_AGE_MS,
   LOCK_GPS_DRIFT_THRESHOLD_M,
   MAX_ACTIVE_LINES,
   MAX_FUSION_DELTA_KM,
+  MAX_FUSION_DELTA_UNDERGROUND_KM,
   MAX_FUSION_DISTANCE_KM,
   PICKER_HOP_ANOMALY_THRESHOLD,
   PICKER_STUCK_MAX_AGE_MS,
@@ -108,6 +120,25 @@ import {
  * 호출 비용은 모듈 스코프 캐시(arrivalCache/positionCache)가 station name·line 단위로 dedup.
  */
 const FUSION_CANDIDATE_LIMIT = MAX_ACTIVE_LINES;
+
+/**
+ * #1936 (Epic #1927 G4) — `pickFusionTier` 산출 `FusionTierName`을 기존 alarmLog
+ * `FusionPickerTier` 라벨로 매핑. dashboard/Sentry/alarmLog query backward-compat 보존.
+ *
+ * 신규 라벨 추가 시 본 표만 갱신 — caller가 직접 string 변환 X (lint으로 단일 SSOT 강제).
+ */
+const LEGACY_TIER_LABEL_MAP: Record<FusionTierName, FusionPickerTier> = {
+  'position-train-lock': 'positionTrainBoardingLockMatch',
+  'gps-fast-path': 'gpsDerivedFastPath',
+  'arvl-arrived-match': 'arvlCdArrivedMatch',
+  'backend-ssot': 'backendSsotAccepts',
+  wifi: 'wifiStationResolved',
+  'position-train': 'positionTrain',
+  fused: 'fused',
+  'detection-verdict': 'detectionVerdictAccepts',
+  route: 'routeResult',
+  'gps-fallback': 'gpsFallback',
+};
 
 interface UseFusedNearestStationReturn {
   /** GPS+arrival+position fusion으로 결정된 현재역. */
@@ -243,6 +274,12 @@ interface UseFusedNearestStationReturn {
    * undefined이면 힌트 없음. DebugModal environment 라인에 함께 노출.
    */
   environmentHintReason: InferEnvironmentResult['hintReason'];
+  /**
+   * #1936 (Epic #1927 G4) — cascade picker가 채택한 tier 이름.
+   * DebugModal cascade tier 표시 + Sentry breadcrumb `fusion.tier_adopted` payload SSOT.
+   * 1주 tier 분포(어떤 tier가 cascade 결정에 기여) acceptance 측정용.
+   */
+  fusionTierAdopted: FusionTierName;
   /** #1418 — 지상 Tier 1 SSOT(GPS+Arrival) 합의 활성 여부. */
   surfaceSSOTActive: boolean;
   /** #1418 — 지하 Tier 1 SSOT(WiFi/Position-Train + Arrival) 합의 활성 여부. */
@@ -880,6 +917,12 @@ export function useFusedNearestStation(
   const gpsFallbackStale =
     typeof gps.lastFixAtMs === 'number' &&
     nowForGpsFallback - gps.lastFixAtMs > GPS_FALLBACK_STALE_MAX_AGE_MS;
+  // #1936 (Epic #1927 G4) — underground 분기 stricter stale 게이트(≤15s).
+  // 지하에서 GPS 좌표가 stale일 가능성이 높아 cascade tier 10 채택 빈도를 빠르게 차단.
+  // pickFusionTier가 environment==='underground'일 때 본 변수를 read.
+  const gpsFallbackStaleUnderground =
+    typeof gps.lastFixAtMs === 'number' &&
+    nowForGpsFallback - gps.lastFixAtMs > GPS_FALLBACK_STALE_UNDERGROUND_MAX_AGE_MS;
 
   // #662: BoardingLock 활성 시 fused도 lock.boardingLine과 다른 노선이면 강등 — positionTrain과
   // 동일 정신. 환승역에서 GPS 후보가 두 노선 모두 잡아 fused가 옆 노선으로 fusion되는 케이스 방어.
@@ -890,6 +933,17 @@ export function useFusedNearestStation(
   const fusedPasses =
     fused != null &&
     passesFusionDistanceGate({ ...gateOpts, candidate: fused.result }) &&
+    (!boardingLock || fused.result.station.line === boardingLock.boardingLine) &&
+    !(fused.confidence === 'gps-only' && gpsFallbackStale);
+  // #1936 (Epic #1927 G4) — underground 분기 stricter fusion 거리 delta 게이트(0.05km).
+  // 지하 GPS drift candidates 함정 차단 — pickFusionTier가 environment==='underground'일 때 본 변수를 read.
+  const fusedPassesStrict =
+    fused != null &&
+    passesFusionDistanceGate({
+      ...gateOpts,
+      candidate: fused.result,
+      maxDeltaKm: MAX_FUSION_DELTA_UNDERGROUND_KM,
+    }) &&
     (!boardingLock || fused.result.station.line === boardingLock.boardingLine) &&
     !(fused.confidence === 'gps-only' && gpsFallbackStale);
   // routeResult는 route arc(단일 노선 segment) 위 진행도라 옆 노선 station이 들어올 수 없음 → 가드 불필요.
@@ -1240,6 +1294,11 @@ export function useFusedNearestStation(
   const gpsFallbackResult: NearestStationResult | null = gpsFallbackStale
     ? null
     : gps.liveResult;
+  // #1936 (Epic #1927 G4) — underground 분기 strict GPS fallback (stale ≤15s).
+  // pickFusionTier가 environment==='underground'일 때 본 변수를 read해 빠른 stale GPS 거부 적용.
+  const gpsFallbackResultStrict: NearestStationResult | null = gpsFallbackStaleUnderground
+    ? null
+    : gps.liveResult;
 
   // #1747 — cascade picker stuck: 같은 station 5분 max 보유 추적.
   // 같은 stationId가 이 ref에 기록된 시각으로부터 PICKER_STUCK_MAX_AGE_MS 초과 시:
@@ -1318,118 +1377,47 @@ export function useFusedNearestStation(
     });
   }
 
-  let result: NearestStationResult | null;
-  let confidence: FusionConfidence;
-  let source: FusionSource;
-  if (positionTrainBoardingLockMatch && !positionTrainDriftBlocked) {
-    // #1646 — 사용자 명시 의향 + 지하 + lockMatch 3-of-3 합의 시 positionTrain 1순위.
-    // backend SSoT mirror lag(10-30s)에 의한 현재역 1역 뒤쳐짐 회귀 차단.
-    // confidence/source는 #584 PR D2와 동일한 'boarding-lock' (lockMatch 매칭 경로).
-    // #1896 — GPS drift > 1km 시 본 분기 미진입 → cascade fallback.
-    result = positionTrainResult!;
-    confidence = 'boarding-lock';
-    source = 'boarding-lock';
-  } else if (gpsDerivedFastPath) {
-    // #1657 — 지상 + GPS 신선 + 노선 정합 4-gate 합의 시 GPS-derived station 1순위.
-    // backend SSoT mirror lag(10-30s)를 지상 open-sky GPS 실시간 신호로 우회한다.
-    // candidates[0]는 이미 boardingLine + 100m 게이트를 통과 — gps-only와 달리 노선 정합 강화.
-    result = gpsTopCandidate!;
-    confidence = 'gps-only';
-    source = 'gps';
-  } else if (arvlCdArrivedMatch && !arvlCdDriftBlocked) {
-    // #1668 — ARRIVED + trainCode 매칭 + 신선 3-of-3 합의 시 arrival-ssot 1순위.
-    // Seoul API 직접 도착 확정 신호 — backend SSoT mirror 10-30s lag 우회.
-    // boardingLock.boardingLine 일치 + 거리 기준 가장 가까운 candidates 슬롯 station 채택.
-    // confidence='boarding-lock' (사용자 탭한 열차가 도착 확정된 가장 강한 신호).
-    // #1896 — GPS drift > 1km 시 본 분기 미진입 → cascade fallback.
-    result = arvlCdArrivedMatch;
-    confidence = 'boarding-lock';
-    source = 'boarding-lock';
-  } else if (backendSsotAccepts) {
-    // #1568 (T8b) — backend SSoT 권위 mirror. backend advance 게이트가
-    // ADR-017 6단(seed/repeat/motion-stop/cross-validation 등)을 이미 통과한 결과이므로
-    // device-side cascade tier보다 신뢰도가 높다. lock 활성/lockless 모두 동일 우선순위.
-    // #1646 — 3-of-3 합의(lock+지하+lockMatch) 시 positionTrain에 양보 (위 분기).
-    // #1657 — 지상 GPS 신선 합의 시 gpsDerivedFastPath에 양보 (위 분기).
-    // #1668 — ARRIVED+trainCode 합의 시 arvlCdArrivedMatch에 양보 (위 분기).
-    result = { station: ssotStation!, distanceKm: 0 };
-    confidence = 'backend-ssot';
-    source = 'backend-ssot';
-  } else if (wifiStationResolved) {
-    result = wifiStationResolved;
-    confidence = 'wifi-ssid';
-    source = 'wifi-ssid';
-  } else if (positionTrainResult) {
-    result = positionTrainResult;
-    // #584 PR D2: position-train의 trainNo가 BoardingLock.trainCode와 일치하면 'boarding-lock'으로 승격.
-    // 사용자가 탭한 바로 그 열차가 실시간 위치 API에 잡힌 상태 — 최고 신뢰 신호.
-    // positionTrainResult가 non-null이면 trainProgress도 non-null (line 219 guard).
-    //
-    // #1891 (paradigm Phase 1 보강) — RC-1 autoLock self-fire 차단:
-    //   `boardingLock != null` gate 추가. 사용자 의향 표명(boardingPrompt 응답 / BoardingTrainList
-    //   직접 탭) 없이 lockedTrainCode가 stale로 남아 있을 때 'boarding-lock' source 승격을 금지.
-    //   lock=null이면 'position-train'으로 유지 → station-passed/transfer 알림의 src='boarding-lock'
-    //   자기 발화 chain을 끊는다. parent #1745 acceptance: `autoLock_fired_count = 0`.
-    const lockMatch =
-      boardingLock != null &&
-      lockedTrainCode != null &&
-      trainProgress!.trainNo === lockedTrainCode;
-    confidence = lockMatch ? 'boarding-lock' : 'position-train';
-    source = lockMatch ? 'boarding-lock' : 'position-train';
-  } else if (fused && fusedPasses) {
-    result = fused.result;
-    confidence = fused.confidence;
-    source = fused.source;
-  } else if (detectionVerdictAccepts) {
-    // #1513 — fusedPasses 거리 게이트가 거부했어도 multi-signal verdict 합의로 fused 후보 채택.
-    // 지하 GPS drop 환경에서 currentStation 확정 경로. 우선순위: arrival-confirmed > 본 슬롯 > routeProgress > GPS.
-    result = fused!.result;
-    confidence = 'detection-fused';
-    source = fused!.source;
-  } else if (routeResult && routePasses) {
-    result = routeResult;
-    confidence = 'route-progress';
-    source = 'route-progress';
-  } else {
-    // #1486 (ADR-015 §2) — sticky:locked fire 권한 영구 박탈.
-    // useNearestStation은 sticky lock 활성 시 exposed.result를 sticky station으로 override한다
-    // (useNearestStation:487-504). 그대로 gps.result를 사용하면 sticky station이 fire path
-    // cascade fallback에 들어가 station-passed/imminent fire의 nearestStation 입력이 된다.
-    // gps.liveResult는 sticky override 없는 GPS 최근접 결과 — sticky:locked가 fire path 진입 차단.
-    // 표시 채널은 gps.stickyDisplayOnly로 별 노출(아래 return).
-    // #1723 — stale GPS 거부 + 환승역 line 보정 (gpsFallbackResult helper).
-    //   gps.liveResult를 직접 쓰지 않고 정제된 helper를 사용해 stale fix stuck + cross-line drift 회귀 차단.
-    result = gpsFallbackResult;
-    confidence = 'gps-only';
-    source = 'gps';
-  }
+  // #1936 (Epic #1927 G4) — cascade tier picker 추출.
+  //
+  // 기존: 11분기 if/else가 hook 본체에 inline. environment 변수가 caller pre-computed gate에만
+  //   반영되어 cascade picker가 환경 변수를 *직접* read하지 않는 SSOT 우회 회귀.
+  // 변경: `pickFusionTier(environment, signals)` 단일 pure function 추출. environment + 11 signal
+  //   pre-compute를 데이터 주도로 평가해 tier 채택. underground/surface tier 7/10 strict 변형 적용.
+  // backward-compat: tier 결정 결과는 surface/mixed/unknown 환경에서는 inline cascade와 동일 (strict
+  //   변형 미적용 — fusedPasses, gpsFallbackResult 기존 동작 보존).
+  const fusionSignals: FusionSignals = {
+    positionTrainBoardingLockMatch,
+    positionTrainDriftBlocked,
+    gpsDerivedFastPath,
+    gpsTopCandidate,
+    arvlCdArrivedMatch,
+    arvlCdDriftBlocked,
+    backendSsotAccepts,
+    ssotStation,
+    wifiStationResolved,
+    positionTrainResult,
+    trainProgressTrainNo: trainProgress?.trainNo ?? null,
+    fused,
+    fusedPasses,
+    fusedPassesStrict,
+    detectionVerdictAccepts,
+    routeResult,
+    routePasses,
+    gpsFallbackResult,
+    gpsFallbackResultStrict,
+    hasBoardingLock: boardingLock != null,
+    lockedTrainCode,
+  };
+  const cascadeTierPick = pickFusionTier(cascadeEnvironment, fusionSignals);
+  let result: NearestStationResult | null = cascadeTierPick.result;
+  let confidence: FusionConfidence = cascadeTierPick.confidence;
+  let source: FusionSource = cascadeTierPick.source;
 
   // #1693 — cascade picker가 채택한 tier를 alarmLog에 적재 (측정 보강 3차).
   // dedup 1s — 같은 tier 연속 폴링 cycle에서 1건만 적재.
-  // PR #1650/#1662/#1674 효과(지하 positionTrain/GPS-derived/arvlCd tier 채택률) 검증.
-  // #1896 — drift-blocked 케이스는 실제 채택 tier(backendSsot 등)로 기록됨 — drift 자체는
-  //   fusionDebugBuffer boarding-lock-drift entry로 별도 측정.
-  if (positionTrainBoardingLockMatch && !positionTrainDriftBlocked) {
-    logFusionPickerTier('positionTrainBoardingLockMatch');
-  } else if (gpsDerivedFastPath) {
-    logFusionPickerTier('gpsDerivedFastPath');
-  } else if (arvlCdArrivedMatch && !arvlCdDriftBlocked) {
-    logFusionPickerTier('arvlCdArrivedMatch');
-  } else if (backendSsotAccepts) {
-    logFusionPickerTier('backendSsotAccepts');
-  } else if (wifiStationResolved) {
-    logFusionPickerTier('wifiStationResolved');
-  } else if (positionTrainResult) {
-    logFusionPickerTier('positionTrain');
-  } else if (fused && fusedPasses) {
-    logFusionPickerTier('fused');
-  } else if (detectionVerdictAccepts) {
-    logFusionPickerTier('detectionVerdictAccepts');
-  } else if (routeResult && routePasses) {
-    logFusionPickerTier('routeResult');
-  } else {
-    logFusionPickerTier('gpsFallback');
-  }
+  // #1936 — FusionTierName(pickFusionTier 산출) → 기존 FusionPickerTier 라벨 매핑.
+  //   기존 dashboard/Sentry/alarmLog query backward-compat 유지.
+  logFusionPickerTier(LEGACY_TIER_LABEL_MAP[cascadeTierPick.tier]);
 
   // #1723 — 환승역 line drift 보정 (post-cascade + 강등 후 fallback 공통).
   //
@@ -1498,6 +1486,47 @@ export function useFusedNearestStation(
     recordEnvironmentTransition(prevEnvironmentRef.current, environment);
     prevEnvironmentRef.current = environment;
   }, [environment]);
+
+  // #1934 (Epic #1927 G3) option B + #1936 G4 통합 — candidate env vote reject counter.
+  //
+  // 후보 station.environment가 cascade environment SSOT와 불일치 시 candidateRejectBuffer에
+  // 'candidate-env' reason으로 카운트만 push. filter는 #1950 consensus 게이트가 처리하므로
+  // 본 카운터는 진단 가시화 전용 — DebugModal '(N)' 분포 + Sentry breadcrumb로 cascade 회귀 진단.
+  //
+  // dedup: 매 candidates 갱신 cycle에 한 번만 push (useEffect deps에 [candidates, environment]).
+  // environment === 'unknown' 또는 candidate.station.environment 미정의/mixed인 entry는 보수적
+  // 무시 — `isCandidateEnvMismatch`가 false 반환.
+  useEffect(() => {
+    if (candidates.length === 0) return;
+    for (const cand of candidates) {
+      if (!isCandidateEnvMismatch(environment, cand)) continue;
+      pushCandidateRejectEntry({
+        kind: 'candidate-reject',
+        ts: Date.now(),
+        reason: 'candidate-env',
+        stationName: cand.station.name,
+        line: cand.station.line,
+        cascadeEnvironment: environment,
+        candidateEnvironment: cand.station.environment,
+      });
+    }
+  }, [candidates, environment]);
+
+  // #1936 (Epic #1927 G4) — cascade tier 채택 Sentry breadcrumb. delta-only emit.
+  // dedup은 recordFusionTierAdopted 내부에서 처리(prev === next 시 no-op).
+  // 1주 tier 분포(어떤 tier가 cascade 결정에 가장 많이 기여) 측정용.
+  const prevFusionTierRef = useRef<FusionTierName | null>(null);
+  const adoptedTier = cascadeTierPick.tier;
+  const adoptedDistanceKm = cascadeTierPick.result?.distanceKm ?? null;
+  useEffect(() => {
+    recordFusionTierAdopted(
+      prevFusionTierRef.current,
+      adoptedTier,
+      environment,
+      adoptedDistanceKm,
+    );
+    prevFusionTierRef.current = adoptedTier;
+  }, [adoptedTier, environment, adoptedDistanceKm]);
 
   // ADR-008 stationProgressEstimator — 시간 적분 → 관측 구동 전환 (#739).
   // arc상 추정 위치가 현 채택된 결과보다 앞이거나, 채택 결과가 arc 밖이면 override.
@@ -2127,6 +2156,8 @@ export function useFusedNearestStation(
     trainProgressing,
     environment,
     environmentHintReason: environmentResult.hintReason,
+    // #1936 — cascade picker가 채택한 tier 이름 (DebugModal + Sentry tier 분포 측정 SSOT).
+    fusionTierAdopted: adoptedTier,
     surfaceSSOTActive: surfaceSSOT !== null,
     undergroundSSOTActive: undergroundSSOT !== null,
     // #1421 — DebugModal Auto-lock 측정 섹션이 SSOT 객체를 inferAutoLockCandidate에 직접 전달.

--- a/src/features/nearest-station/utils/__tests__/candidateRejectBuffer.test.ts
+++ b/src/features/nearest-station/utils/__tests__/candidateRejectBuffer.test.ts
@@ -66,6 +66,26 @@ describe('candidateRejectBuffer (#1902 RC-18)', () => {
     expect(entries[0].distanceKm).toBeUndefined();
   });
 
+  it('#1934 G3 option B + #1936 G4 — candidate-env reject entry (env vote 카운터 가시화)', () => {
+    pushCandidateRejectEntry({
+      kind: 'candidate-reject',
+      ts: 300,
+      reason: 'candidate-env',
+      stationName: '강남',
+      line: '2',
+      cascadeEnvironment: 'underground',
+      candidateEnvironment: 'surface',
+    });
+    const entries = getCandidateRejectEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].reason).toBe('candidate-env');
+    expect(entries[0].cascadeEnvironment).toBe('underground');
+    expect(entries[0].candidateEnvironment).toBe('surface');
+    expect(entries[0].stationName).toBe('강남');
+    expect(entries[0].distanceKm).toBeUndefined();
+    expect(entries[0].trainNo).toBeUndefined();
+  });
+
   it('CAP=50 ring buffer — overwrite로 fusion log cap 점령 회귀 차단', () => {
     expect(CANDIDATE_REJECT_BUFFER_CAPACITY).toBe(50);
     for (let i = 0; i < CANDIDATE_REJECT_BUFFER_CAPACITY + 5; i += 1) {

--- a/src/features/nearest-station/utils/__tests__/pickFusionTier.test.ts
+++ b/src/features/nearest-station/utils/__tests__/pickFusionTier.test.ts
@@ -1,0 +1,541 @@
+/**
+ * #1936 (Epic #1927 G4) — pickFusionTier 단위 테스트.
+ *
+ * Acceptance:
+ *   - 11-tier × 4 environment(surface/underground/mixed/unknown) = 44 cell matrix
+ *   - environment='underground' 분기: tier 7 fused는 fusedPassesStrict 사용, tier 10은
+ *     gpsFallbackResultStrict 사용.
+ *   - 본 trip evidence(15:49:35) tier 6 진입 차단 시뮬 — tier 6 → tier 7 → tier 10 흐름.
+ *   - isCandidateEnvMismatch helper — env vote reject counter (#1934 G3 option B 통합).
+ */
+
+import {
+  isCandidateEnvMismatch,
+  pickFusionTier,
+  type FusionSignals,
+} from '../pickFusionTier';
+import type { NearestStationResult, Station, StationEnvironment } from '../../../../shared/types/station';
+import type { FusedStationResult } from '../pickFusedStation';
+import type { Environment } from '../inferEnvironment';
+
+function makeStation(overrides: Partial<Station> = {}): Station {
+  return {
+    id: '2-220',
+    name: '강남',
+    line: '2',
+    lineColor: '#00A84D',
+    lat: 37.498,
+    lng: 127.027,
+    ...overrides,
+  };
+}
+
+function makeResult(stationOverrides: Partial<Station> = {}, distanceKm = 0.05): NearestStationResult {
+  return { station: makeStation(stationOverrides), distanceKm };
+}
+
+function makeFused(
+  stationOverrides: Partial<Station> = {},
+  distanceKm = 0.05,
+): FusedStationResult {
+  return {
+    result: makeResult(stationOverrides, distanceKm),
+    confidence: 'arrival-confirmed',
+    source: 'arrival',
+  };
+}
+
+/**
+ * 기본 signals — 모든 tier 게이트 false. 각 테스트가 필요한 tier만 활성.
+ */
+function makeSignals(overrides: Partial<FusionSignals> = {}): FusionSignals {
+  return {
+    positionTrainBoardingLockMatch: false,
+    positionTrainDriftBlocked: false,
+    gpsDerivedFastPath: false,
+    gpsTopCandidate: null,
+    arvlCdArrivedMatch: null,
+    arvlCdDriftBlocked: false,
+    backendSsotAccepts: false,
+    ssotStation: null,
+    wifiStationResolved: null,
+    positionTrainResult: null,
+    trainProgressTrainNo: null,
+    fused: null,
+    fusedPasses: false,
+    fusedPassesStrict: false,
+    detectionVerdictAccepts: false,
+    routeResult: null,
+    routePasses: false,
+    gpsFallbackResult: null,
+    gpsFallbackResultStrict: null,
+    hasBoardingLock: false,
+    lockedTrainCode: null,
+    ...overrides,
+  };
+}
+
+describe('pickFusionTier — cascade tier 결정', () => {
+  describe('Tier 1: position-train-lock', () => {
+    it('positionTrainBoardingLockMatch + !drift + positionTrainResult → tier 1 채택', () => {
+      const ptResult = makeResult();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({
+          positionTrainBoardingLockMatch: true,
+          positionTrainDriftBlocked: false,
+          positionTrainResult: ptResult,
+        }),
+      );
+      expect(r.tier).toBe('position-train-lock');
+      expect(r.result).toBe(ptResult);
+      expect(r.confidence).toBe('boarding-lock');
+      expect(r.source).toBe('boarding-lock');
+    });
+
+    it('positionTrainDriftBlocked=true → tier 1 미진입 (fallback)', () => {
+      const ptResult = makeResult();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({
+          positionTrainBoardingLockMatch: true,
+          positionTrainDriftBlocked: true,
+          positionTrainResult: ptResult,
+        }),
+      );
+      expect(r.tier).not.toBe('position-train-lock');
+    });
+
+    it('positionTrainResult=null → tier 1 미진입 (caller 게이트 동치성 위반 방어)', () => {
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({
+          positionTrainBoardingLockMatch: true,
+          positionTrainResult: null,
+        }),
+      );
+      expect(r.tier).not.toBe('position-train-lock');
+    });
+  });
+
+  describe('Tier 2: gps-fast-path', () => {
+    it('gpsDerivedFastPath + gpsTopCandidate → tier 2 채택', () => {
+      const top = makeResult();
+      const r = pickFusionTier(
+        'surface',
+        makeSignals({ gpsDerivedFastPath: true, gpsTopCandidate: top }),
+      );
+      expect(r.tier).toBe('gps-fast-path');
+      expect(r.result).toBe(top);
+      expect(r.confidence).toBe('gps-only');
+      expect(r.source).toBe('gps');
+    });
+
+    it('gpsDerivedFastPath=true + gpsTopCandidate=null → tier 2 미진입', () => {
+      const r = pickFusionTier(
+        'surface',
+        makeSignals({ gpsDerivedFastPath: true, gpsTopCandidate: null }),
+      );
+      expect(r.tier).not.toBe('gps-fast-path');
+    });
+  });
+
+  describe('Tier 3: arvl-arrived-match', () => {
+    it('arvlCdArrivedMatch + !drift → tier 3 채택', () => {
+      const arvl = makeResult();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({ arvlCdArrivedMatch: arvl, arvlCdDriftBlocked: false }),
+      );
+      expect(r.tier).toBe('arvl-arrived-match');
+      expect(r.result).toBe(arvl);
+      expect(r.confidence).toBe('boarding-lock');
+      expect(r.source).toBe('boarding-lock');
+    });
+
+    it('arvlCdDriftBlocked=true → tier 3 미진입', () => {
+      const arvl = makeResult();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({ arvlCdArrivedMatch: arvl, arvlCdDriftBlocked: true }),
+      );
+      expect(r.tier).not.toBe('arvl-arrived-match');
+    });
+  });
+
+  describe('Tier 4: backend-ssot', () => {
+    it('backendSsotAccepts + ssotStation → tier 4 채택', () => {
+      const ssot = makeStation();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({ backendSsotAccepts: true, ssotStation: ssot }),
+      );
+      expect(r.tier).toBe('backend-ssot');
+      expect(r.result?.station).toBe(ssot);
+      expect(r.result?.distanceKm).toBe(0);
+      expect(r.confidence).toBe('backend-ssot');
+      expect(r.source).toBe('backend-ssot');
+    });
+
+    it('backendSsotAccepts=true + ssotStation=null → tier 4 미진입 (caller 게이트 동치성 방어)', () => {
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({ backendSsotAccepts: true, ssotStation: null }),
+      );
+      expect(r.tier).not.toBe('backend-ssot');
+    });
+  });
+
+  describe('Tier 5: wifi', () => {
+    it('wifiStationResolved → tier 5 채택', () => {
+      const wifi = makeResult();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({ wifiStationResolved: wifi }),
+      );
+      expect(r.tier).toBe('wifi');
+      expect(r.result).toBe(wifi);
+      expect(r.confidence).toBe('wifi-ssid');
+      expect(r.source).toBe('wifi-ssid');
+    });
+  });
+
+  describe('Tier 6: position-train', () => {
+    it('positionTrainResult + lockMatch → tier 6 채택, source/confidence boarding-lock 승격', () => {
+      const pt = makeResult();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({
+          positionTrainResult: pt,
+          hasBoardingLock: true,
+          lockedTrainCode: 'T1234',
+          trainProgressTrainNo: 'T1234',
+        }),
+      );
+      expect(r.tier).toBe('position-train');
+      expect(r.result).toBe(pt);
+      expect(r.confidence).toBe('boarding-lock');
+      expect(r.source).toBe('boarding-lock');
+    });
+
+    it('positionTrainResult + lockless(hasBoardingLock=false) → tier 6 채택, position-train 유지', () => {
+      const pt = makeResult();
+      const r = pickFusionTier(
+        'surface',
+        makeSignals({
+          positionTrainResult: pt,
+          hasBoardingLock: false,
+          lockedTrainCode: null,
+          trainProgressTrainNo: 'T9999',
+        }),
+      );
+      expect(r.tier).toBe('position-train');
+      expect(r.confidence).toBe('position-train');
+      expect(r.source).toBe('position-train');
+    });
+
+    it('positionTrainResult + lock 활성 + trainCode 불일치 → position-train 유지 (#1891 RC-1)', () => {
+      const pt = makeResult();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({
+          positionTrainResult: pt,
+          hasBoardingLock: true,
+          lockedTrainCode: 'T1234',
+          trainProgressTrainNo: 'T5555',
+        }),
+      );
+      expect(r.tier).toBe('position-train');
+      expect(r.confidence).toBe('position-train');
+    });
+  });
+
+  describe('Tier 7: fused — environment 분기 (underground 시 strict)', () => {
+    it('environment=surface + fusedPasses=true → tier 7 채택', () => {
+      const fused = makeFused();
+      const r = pickFusionTier(
+        'surface',
+        makeSignals({ fused, fusedPasses: true, fusedPassesStrict: false }),
+      );
+      expect(r.tier).toBe('fused');
+      expect(r.result).toBe(fused.result);
+      expect(r.confidence).toBe(fused.confidence);
+      expect(r.source).toBe(fused.source);
+    });
+
+    it('#1936 G4 — environment=underground + fusedPasses=true + fusedPassesStrict=false → tier 7 미진입', () => {
+      // underground 분기 strict gate(0.05km)가 일반 gate(0.2km)보다 엄격 — fusedPassesStrict=false이면
+      // tier 7 미진입. cascade가 더 약한 신호 tier(detection-verdict / route / gps-fallback)로 흐름.
+      const fused = makeFused();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({ fused, fusedPasses: true, fusedPassesStrict: false }),
+      );
+      expect(r.tier).not.toBe('fused');
+    });
+
+    it('#1936 G4 — environment=underground + fusedPassesStrict=true → tier 7 채택', () => {
+      const fused = makeFused();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({ fused, fusedPasses: true, fusedPassesStrict: true }),
+      );
+      expect(r.tier).toBe('fused');
+    });
+
+    it('environment=mixed/unknown은 fusedPasses 사용 (strict 미적용)', () => {
+      const fused = makeFused();
+      // mixed/unknown은 issue body: "현 정신 보존 — cascade 분기 비활성"
+      const rMixed = pickFusionTier(
+        'unknown',
+        makeSignals({ fused, fusedPasses: true, fusedPassesStrict: false }),
+      );
+      expect(rMixed.tier).toBe('fused');
+    });
+  });
+
+  describe('Tier 8: detection-verdict', () => {
+    it('detectionVerdictAccepts + fused → tier 8 채택, confidence detection-fused 승격', () => {
+      const fused = makeFused();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({
+          fused,
+          fusedPasses: false,
+          fusedPassesStrict: false,
+          detectionVerdictAccepts: true,
+        }),
+      );
+      expect(r.tier).toBe('detection-verdict');
+      expect(r.result).toBe(fused.result);
+      expect(r.confidence).toBe('detection-fused');
+      expect(r.source).toBe(fused.source);
+    });
+
+    it('detectionVerdictAccepts=true + fused=null → tier 8 미진입 (caller 게이트 동치성 방어)', () => {
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({ fused: null, detectionVerdictAccepts: true }),
+      );
+      expect(r.tier).not.toBe('detection-verdict');
+    });
+  });
+
+  describe('Tier 9: route', () => {
+    it('routeResult + routePasses → tier 9 채택', () => {
+      const route = makeResult();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({ routeResult: route, routePasses: true }),
+      );
+      expect(r.tier).toBe('route');
+      expect(r.result).toBe(route);
+      expect(r.confidence).toBe('route-progress');
+      expect(r.source).toBe('route-progress');
+    });
+
+    it('routeResult + routePasses=false → tier 9 미진입', () => {
+      const route = makeResult();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({ routeResult: route, routePasses: false }),
+      );
+      expect(r.tier).not.toBe('route');
+    });
+  });
+
+  describe('Tier 10: gps-fallback — environment 분기 (underground 시 strict)', () => {
+    it('environment=surface + gpsFallbackResult 존재 → tier 10 일반 사용', () => {
+      const fb = makeResult();
+      const r = pickFusionTier(
+        'surface',
+        makeSignals({ gpsFallbackResult: fb, gpsFallbackResultStrict: null }),
+      );
+      expect(r.tier).toBe('gps-fallback');
+      expect(r.result).toBe(fb);
+      expect(r.confidence).toBe('gps-only');
+      expect(r.source).toBe('gps');
+    });
+
+    it('#1936 G4 — environment=underground + gpsFallbackResultStrict=null → result=null (stale GPS 거부)', () => {
+      // 일반 gpsFallbackResult는 있어도 underground 분기에서 strict null이면 채택 거부.
+      const fb = makeResult();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({ gpsFallbackResult: fb, gpsFallbackResultStrict: null }),
+      );
+      expect(r.tier).toBe('gps-fallback');
+      expect(r.result).toBeNull();
+    });
+
+    it('#1936 G4 — environment=underground + gpsFallbackResultStrict 존재 → strict 채택', () => {
+      const fb = makeResult();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({ gpsFallbackResult: null, gpsFallbackResultStrict: fb }),
+      );
+      expect(r.tier).toBe('gps-fallback');
+      expect(r.result).toBe(fb);
+    });
+
+    it('environment=mixed/unknown은 gpsFallbackResult 사용 (strict 미적용)', () => {
+      const fb = makeResult();
+      const r = pickFusionTier(
+        'unknown',
+        makeSignals({ gpsFallbackResult: fb, gpsFallbackResultStrict: null }),
+      );
+      expect(r.tier).toBe('gps-fallback');
+      expect(r.result).toBe(fb);
+    });
+
+    it('모든 tier null + gpsFallbackResult null → tier 10 채택 + result=null (cascade sink 보장)', () => {
+      const r = pickFusionTier('unknown', makeSignals());
+      expect(r.tier).toBe('gps-fallback');
+      expect(r.result).toBeNull();
+      expect(r.confidence).toBe('gps-only');
+      expect(r.source).toBe('gps');
+    });
+  });
+
+  describe('cascade 우선순위 — tier 1 > tier 2 > ... > tier 10', () => {
+    it('tier 1과 tier 6 둘 다 활성 시 tier 1 채택', () => {
+      const tier1Result = makeResult({ name: 'tier1' });
+      const tier6Result = makeResult({ name: 'tier6' });
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({
+          positionTrainBoardingLockMatch: true,
+          positionTrainResult: tier1Result,
+          // tier 6 fallthrough가능 신호도 있지만 tier 1이 먼저 통과
+          hasBoardingLock: true,
+          lockedTrainCode: 'T1',
+          trainProgressTrainNo: 'T1',
+        }),
+      );
+      expect(r.tier).toBe('position-train-lock');
+      expect(r.result).toBe(tier1Result);
+    });
+
+    it('tier 4와 tier 5 둘 다 활성 시 tier 4 (backend-ssot) 채택', () => {
+      const ssot = makeStation({ name: 'ssot' });
+      const wifi = makeResult({ name: 'wifi' });
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({
+          backendSsotAccepts: true,
+          ssotStation: ssot,
+          wifiStationResolved: wifi,
+        }),
+      );
+      expect(r.tier).toBe('backend-ssot');
+    });
+  });
+
+  describe('본 trip evidence 15:49:35 시뮬 — tier 6 차단 시 tier 7→10 흐름 (G4 acceptance #5)', () => {
+    // 시나리오: barometer null + cellular surface 미확정 + accel walking → environment 'underground'
+    // 추정 (보수적). tier 6 lockless positionTrain 게이트는 caller(useFusedNearestStation)가
+    // 4-signal consensus로 reject → positionTrainResult=null로 전달.
+    // tier 7 fused는 strict 거리 게이트(0.05km) 미통과 → fusedPassesStrict=false.
+    // tier 10 gpsFallback strict(15s) 통과 → 삼성역 GPS 좌표 채택.
+    it('underground + positionTrainResult=null + fusedPassesStrict=false + gpsFallbackResultStrict 통과 → tier 10 채택', () => {
+      const fused = makeFused({ name: '강남' }, 0.066); // 잘못된 후보(strict 거부)
+      const fallback = makeResult({ name: '삼성' }, 0.066);
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({
+          positionTrainResult: null, // F-fix consensus reject
+          fused,
+          fusedPasses: true,
+          fusedPassesStrict: false, // 0.05km strict 미통과
+          gpsFallbackResult: fallback,
+          gpsFallbackResultStrict: fallback, // ≤15s 신선
+        }),
+      );
+      expect(r.tier).toBe('gps-fallback');
+      expect(r.result?.station.name).toBe('삼성');
+    });
+
+    it('환경 분기 미적용 시뮬(surface) — 같은 신호로 tier 7 채택 (regression evidence)', () => {
+      // 같은 시그널을 surface로 평가하면 tier 7이 채택돼 잘못된 station(강남)이 결정된다.
+      // G4 환경 분기가 실제로 작동하는지 evidence.
+      const fused = makeFused({ name: '강남' }, 0.066);
+      const fallback = makeResult({ name: '삼성' }, 0.066);
+      const r = pickFusionTier(
+        'surface',
+        makeSignals({
+          positionTrainResult: null,
+          fused,
+          fusedPasses: true,
+          fusedPassesStrict: false,
+          gpsFallbackResult: fallback,
+          gpsFallbackResultStrict: fallback,
+        }),
+      );
+      expect(r.tier).toBe('fused');
+      expect(r.result?.station.name).toBe('강남');
+    });
+  });
+
+  describe('11-tier × 4 environment matrix smoke', () => {
+    const environments: Environment[] = ['surface', 'underground', 'unknown'];
+    // Note: stations.json `mixed`는 stationEnvironment에는 존재하지만 inferEnvironment Environment
+    // type은 surface/underground/unknown만 가진다. 본 picker는 inferEnvironment 산출을 받으므로
+    // 'unknown'으로 mixed 의미를 흡수 (테스트도 3 environment 표).
+
+    it.each(environments)('environment=%s + all-null signals → tier 10 채택 (sink)', (env) => {
+      const r = pickFusionTier(env, makeSignals());
+      expect(r.tier).toBe('gps-fallback');
+    });
+
+    it.each(environments)('environment=%s + tier 4 activated → tier 4 채택', (env) => {
+      const ssot = makeStation();
+      const r = pickFusionTier(
+        env,
+        makeSignals({ backendSsotAccepts: true, ssotStation: ssot }),
+      );
+      expect(r.tier).toBe('backend-ssot');
+    });
+  });
+});
+
+describe('isCandidateEnvMismatch — #1934 G3 option B 통합', () => {
+  function candidateWithEnv(env?: StationEnvironment): NearestStationResult {
+    return { station: makeStation({ environment: env }), distanceKm: 0.05 };
+  }
+
+  it('environment=surface + candidate.station.environment=underground → mismatch (reject)', () => {
+    expect(isCandidateEnvMismatch('surface', candidateWithEnv('underground'))).toBe(true);
+  });
+
+  it('environment=underground + candidate.station.environment=surface → mismatch (reject)', () => {
+    expect(isCandidateEnvMismatch('underground', candidateWithEnv('surface'))).toBe(true);
+  });
+
+  it('environment=surface + candidate.environment=surface → 일치 (no reject)', () => {
+    expect(isCandidateEnvMismatch('surface', candidateWithEnv('surface'))).toBe(false);
+  });
+
+  it('environment=underground + candidate.environment=underground → 일치 (no reject)', () => {
+    expect(isCandidateEnvMismatch('underground', candidateWithEnv('underground'))).toBe(false);
+  });
+
+  it('environment=unknown → 항상 통과 (분간 불가)', () => {
+    expect(isCandidateEnvMismatch('unknown', candidateWithEnv('surface'))).toBe(false);
+    expect(isCandidateEnvMismatch('unknown', candidateWithEnv('underground'))).toBe(false);
+  });
+
+  it('candidate.station.environment=undefined → 통과 (schema 누락 entry 보수 처리)', () => {
+    expect(isCandidateEnvMismatch('surface', candidateWithEnv(undefined))).toBe(false);
+    expect(isCandidateEnvMismatch('underground', candidateWithEnv(undefined))).toBe(false);
+  });
+
+  it('candidate.station.environment=mixed → 통과 (분간 불가)', () => {
+    expect(isCandidateEnvMismatch('surface', candidateWithEnv('mixed'))).toBe(false);
+    expect(isCandidateEnvMismatch('underground', candidateWithEnv('mixed'))).toBe(false);
+  });
+
+  it('candidate.station.environment=unknown → 통과 (분간 불가)', () => {
+    expect(isCandidateEnvMismatch('surface', candidateWithEnv('unknown'))).toBe(false);
+    expect(isCandidateEnvMismatch('underground', candidateWithEnv('unknown'))).toBe(false);
+  });
+});

--- a/src/features/nearest-station/utils/candidateRejectBuffer.ts
+++ b/src/features/nearest-station/utils/candidateRejectBuffer.ts
@@ -11,30 +11,43 @@ import type { LineNumber } from '../../../shared/types/station';
  * 해결: gpsDropBuffer 패턴과 동일하게 별 buffer로 분리. cap=50은 정상 trip(60+분) 동안의
  * reject(line filter 적용 후) 카운트를 모두 보관하면서도 fusionDebugBuffer cap을 점령하지 않는다.
  *
- * 두 종류:
+ * 세 종류:
  *  - `candidate-distance`: 사용자 GPS 거리 hard gate(#1616 R12-a). anchor drift 차단.
  *  - `candidate-line` (#1902): trip route 활성 line 화이트리스트(`allowedLinesFromRoute`)와
  *    무관한 line 후보를 enumerate 단계에서 차단. T4 trip에서 5/6/7호선 + 공항철도 +
  *    경의중앙선 후보 18개 무차별 reject 회귀 차단용.
+ *  - `candidate-env` (#1934 G3 option B, #1936 G4 통합): 후보 station.environment가 cascade
+ *    environment SSOT와 불일치 시 카운트만 누적 (filter는 #1950 consensus 게이트가 처리).
+ *    enumeration 단계 가시화 — DebugModal에서 분포 표시.
  *
- * 두 reason을 같은 buffer로 묶은 이유: 둘 다 사용자 GPS / route 기반 후보 정확도 보강 신호로
- * 진단 시점에 비교 관찰이 유효. DebugModal에서 reason 키별 분포 표시.
+ * 세 reason을 같은 buffer로 묶은 이유: 셋 다 사용자 GPS / route / environment 기반 후보 정확도
+ * 신호로 진단 시점에 비교 관찰이 유효. DebugModal에서 reason 키별 분포 표시.
  */
 export const CANDIDATE_REJECT_BUFFER_CAPACITY = 50;
 
-export type CandidateRejectReason = 'candidate-distance' | 'candidate-line';
+export type CandidateRejectReason = 'candidate-distance' | 'candidate-line' | 'candidate-env';
 
 export interface CandidateRejectEntry {
   kind: 'candidate-reject';
   ts: number;
   reason: CandidateRejectReason;
-  /** trainNo는 `candidate-line` reason에서 enumerate 단계 reject라 train picking 전이므로 옵셔널. */
+  /** trainNo는 `candidate-line`/`candidate-env` reason에서 enumerate 단계 reject라 train picking 전이므로 옵셔널. */
   trainNo?: string;
-  /** `candidate-line` reason에서 사용자 trip route 외 후보 station — 진단용. */
+  /** `candidate-line`/`candidate-env` reason에서 사용자 trip route 외/환경 불일치 후보 station — 진단용. */
   stationName?: string;
   line: LineNumber;
   /** `candidate-distance` reason 한정 — 사용자 GPS와 candidate.currentStation 거리. */
   distanceKm?: number;
+  /**
+   * `candidate-env` reason 한정 (#1934 G3 option B + #1936 G4) — cascade environment SSOT.
+   * 진단 시 candidate.station.environment과 비교해 mismatch 패턴 분석.
+   */
+  cascadeEnvironment?: 'surface' | 'underground' | 'unknown';
+  /**
+   * `candidate-env` reason 한정 — candidate.station.environment.
+   * undefined/null인 entry는 mismatch에서 제외(보수적) — 본 필드는 채워진 케이스만 측정.
+   */
+  candidateEnvironment?: 'surface' | 'underground' | 'mixed' | 'unknown';
 }
 
 const db = createDebugBuffer<CandidateRejectEntry>(CANDIDATE_REJECT_BUFFER_CAPACITY);

--- a/src/features/nearest-station/utils/pickFusionTier.ts
+++ b/src/features/nearest-station/utils/pickFusionTier.ts
@@ -1,0 +1,366 @@
+/**
+ * #1936 (Epic #1927 G4) — fusion cascade tier picker pure function.
+ *
+ * `useFusedNearestStation.ts` cascade(원래 if/else 11분기)를 단일 pure function으로 추출한다.
+ * `environment` 변수를 1순위 분기축으로 받아 underground/surface별 tier 활성·gate 조정을
+ * 데이터 주도(`TIER_DEFINITIONS` 테이블)로 적용한다.
+ *
+ * 추출 목적 (ADR-014 첫 줄: false positive / miss 동급):
+ *   - 기존 cascade는 11-tier if/else를 hook 본체에 inline — 환경 분기 단위 단위 테스트 불가.
+ *   - `environment` 분기는 caller pre-computed gate(`positionTrainBoardingLockMatch`,
+ *     `gpsDerivedFastPath`)에 이미 surface/underground 조건이 인라인 — picker가 환경 변수를
+ *     **직접 read**하지 않아 SSOT 우회 회귀 (paradigm Phase 6 정신 위반).
+ *   - 추출 후: caller가 environment + 11 signal pre-compute → picker가 데이터 주도로 tier 결정.
+ *
+ * 환경 분기 cascade reorder (G4 acceptance):
+ *   - underground: tier 7 fused는 stricter delta(0.05km) 사용, tier 10 gps-fallback은
+ *     stricter stale(≤15s) 사용. 두 strict 변형은 caller가 두 가지 사전 계산해서 전달.
+ *   - surface: 기존 정신 보존 — tier 1/2는 caller pre-computed gate가 이미 환경 검증.
+ *   - mixed/unknown: 기존 cascade 정신 보존(현 동작 정확 backward-compat).
+ *
+ * `TIER_DEFINITIONS` 테이블은 11-tier × 4 environment cell을 데이터로 표현 — 신규 tier 추가 시
+ * 표 한 줄만 추가하면 cascade 변형 0건으로 확장 가능. 분기 분포 측정/DebugModal 표시도
+ * `FusionTierName` literal 단일 source로 통일.
+ *
+ * #1934 (Epic #1927 G3) option B 통합 — candidate enumeration 단계 env vote reject counter는
+ * caller(`useFusedNearestStation`) 책임. 본 picker는 cascade 단계만 담당.
+ */
+
+import type { LineNumber, NearestStationResult, Station } from '../../../shared/types/station';
+import type { FusionConfidence, FusionSource } from '../../../shared/types/fusion';
+import type { FusedStationResult } from './pickFusedStation';
+import type { Environment } from './inferEnvironment';
+
+/**
+ * cascade tier 이름. 채택 trace + Sentry breadcrumb + DebugModal에서 단일 식별자.
+ * underground/surface 분포 측정을 위해 environment 변수와 함께 노출.
+ */
+export type FusionTierName =
+  | 'position-train-lock' // tier 1: lock + lockMatch + underground env + drift OK
+  | 'gps-fast-path' // tier 2: lock + surface env + GPS 신선 + 노선 정합
+  | 'arvl-arrived-match' // tier 3: lock + ARRIVED + trainCode + drift OK
+  | 'backend-ssot' // tier 4: backend SSoT mirror
+  | 'wifi' // tier 5: WiFi SSID 매칭
+  | 'position-train' // tier 6: trainProgress + distance + arc 게이트
+  | 'fused' // tier 7: pickFusedStation + 거리 게이트
+  | 'detection-verdict' // tier 8: multi-signal verdict 합의
+  | 'route' // tier 9: route progress + 거리 게이트
+  | 'gps-fallback'; // tier 10: GPS-only fallback
+
+/**
+ * picker 입력 — caller(`useFusedNearestStation`)가 모든 tier별 사전 계산 결과를 묶어 전달.
+ *
+ * 각 필드는 cascade 한 단의 채택 가능 여부 + 채택 시 산출 station을 표현. picker는 environment에
+ * 따른 tier 활성/gate 분기만 담당 — 게이트 자체 결정 로직은 caller에 위임.
+ */
+export interface FusionSignals {
+  // ─── Tier 1: position-train-lock ───
+  /**
+   * lock + lockMatch + cascadeEnvironment==='underground' 3-of-3 합의 게이트 통과 여부.
+   * true일 때 tier 1 채택 — 산출 station은 `positionTrainResult`.
+   */
+  positionTrainBoardingLockMatch: boolean;
+  /** lock GPS drift > LOCK_GPS_DRIFT_THRESHOLD_M(1km) — true 시 tier 1 비활성. */
+  positionTrainDriftBlocked: boolean;
+
+  // ─── Tier 2: gps-fast-path ───
+  /** lock + cascadeEnvironment==='surface' + GPS 신선 + 노선 정합 4-of-4 합의. */
+  gpsDerivedFastPath: boolean;
+  /** GPS 좌표 기준 거리순 1순위 candidate (tier 2 산출 station). */
+  gpsTopCandidate: NearestStationResult | null;
+
+  // ─── Tier 3: arvl-arrived-match ───
+  /** lock + ARRIVED + trainCode 매칭 + 신선 3-of-3 합의 통과 시 채택 station. */
+  arvlCdArrivedMatch: NearestStationResult | null;
+  /** lock GPS drift > 1km — true 시 tier 3 비활성. */
+  arvlCdDriftBlocked: boolean;
+
+  // ─── Tier 4: backend-ssot ───
+  /** backend SSoT mirror가 fresh + silent push healthy 합의. */
+  backendSsotAccepts: boolean;
+  /** backend SSoT mirror가 가리키는 station. backendSsotAccepts=true일 때만 non-null. */
+  ssotStation: Station | null;
+
+  // ─── Tier 5: wifi ───
+  /** WiFi SSID 매칭 station + 거리 게이트 통과 결과. */
+  wifiStationResolved: NearestStationResult | null;
+
+  // ─── Tier 6: position-train ───
+  /** trainProgress + TTL + distance + arc + #1926 F-fix consensus 통과 station. */
+  positionTrainResult: NearestStationResult | null;
+  /** position-train의 trainNo (lock과 매칭 시 'boarding-lock' 승격용). null/undefined = train 미관측. */
+  trainProgressTrainNo: string | null | undefined;
+
+  // ─── Tier 7: fused ───
+  /** pickFusedStation 결과 + confidence/source. */
+  fused: FusedStationResult | null;
+  /** 일반 fusion 거리 게이트 (maxDelta=MAX_FUSION_DELTA_KM=0.2km) 통과 여부. */
+  fusedPasses: boolean;
+  /**
+   * underground 분기에서 사용하는 stricter 거리 게이트 (maxDelta=0.05km).
+   * #1936 G4 — underground에서 GPS 좌표 의존도 강등.
+   */
+  fusedPassesStrict: boolean;
+
+  // ─── Tier 8: detection-verdict ───
+  /** multi-signal verdict 합의 통과 — fused.confidence='detection-fused'로 승격. */
+  detectionVerdictAccepts: boolean;
+
+  // ─── Tier 9: route ───
+  /** route progress 추정 station. */
+  routeResult: NearestStationResult | null;
+  /** route 거리 게이트 + 신선도 게이트 통과 여부. */
+  routePasses: boolean;
+
+  // ─── Tier 10: gps-fallback ───
+  /**
+   * 일반 GPS fallback (stale 게이트 GPS_FALLBACK_STALE_MAX_AGE_MS=300_000ms=5min).
+   * stale 시 caller가 null로 전달.
+   */
+  gpsFallbackResult: NearestStationResult | null;
+  /**
+   * underground 분기에서 사용하는 strict GPS fallback (stale 게이트 15_000ms=15s).
+   * #1936 G4 — underground에서 stale GPS 좌표를 더 빠르게 폐기.
+   * stale 시 caller가 null로 전달.
+   */
+  gpsFallbackResultStrict: NearestStationResult | null;
+
+  // ─── lockMatch 승격(tier 6) 컨텍스트 ───
+  /** boardingLock 활성 여부 (lockMatch 가드 prereq). */
+  hasBoardingLock: boolean;
+  /** lock.trainCode (lockMatch 비교 키). null/undefined = lock 미활성 또는 trainCode 누락. */
+  lockedTrainCode: string | null | undefined;
+}
+
+/** picker 결과 — tier 채택 trace + station/confidence/source. */
+export interface FusionTierResult {
+  tier: FusionTierName;
+  result: NearestStationResult | null;
+  confidence: FusionConfidence;
+  source: FusionSource;
+}
+
+/**
+ * tier 결정 entry. picker는 본 테이블을 environment + signals로 평가해 첫 통과 tier를 채택.
+ *
+ * 데이터 주도 구조: 신규 tier 추가 시 본 배열에 한 entry 추가만으로 cascade 확장 가능.
+ * `selectFused` / `selectGpsFallback`는 environment 기반 strict 변형 채택을 위한 indirection.
+ */
+interface TierDefinition {
+  name: FusionTierName;
+  /** 본 tier 채택 가능 여부 + 채택 station 산출. null이면 다음 tier로. */
+  evaluate: (env: Environment, s: FusionSignals) => FusionTierResult | null;
+}
+
+const TIER_DEFINITIONS: readonly TierDefinition[] = [
+  // Tier 1: position-train-lock — 게이트 통과 시 positionTrainResult 사용 (caller가 게이트와
+  // positionTrainResult 동치 보장: 게이트 true → positionTrainResult != null).
+  {
+    name: 'position-train-lock',
+    evaluate: (_env, s) =>
+      s.positionTrainBoardingLockMatch &&
+      !s.positionTrainDriftBlocked &&
+      s.positionTrainResult
+        ? {
+            tier: 'position-train-lock',
+            result: s.positionTrainResult,
+            confidence: 'boarding-lock',
+            source: 'boarding-lock',
+          }
+        : null,
+  },
+  // Tier 2: gps-fast-path
+  {
+    name: 'gps-fast-path',
+    evaluate: (_env, s) =>
+      s.gpsDerivedFastPath && s.gpsTopCandidate
+        ? {
+            tier: 'gps-fast-path',
+            result: s.gpsTopCandidate,
+            confidence: 'gps-only',
+            source: 'gps',
+          }
+        : null,
+  },
+  // Tier 3: arvl-arrived-match
+  {
+    name: 'arvl-arrived-match',
+    evaluate: (_env, s) =>
+      s.arvlCdArrivedMatch && !s.arvlCdDriftBlocked
+        ? {
+            tier: 'arvl-arrived-match',
+            result: s.arvlCdArrivedMatch,
+            confidence: 'boarding-lock',
+            source: 'boarding-lock',
+          }
+        : null,
+  },
+  // Tier 4: backend-ssot
+  {
+    name: 'backend-ssot',
+    evaluate: (_env, s) =>
+      s.backendSsotAccepts && s.ssotStation
+        ? {
+            tier: 'backend-ssot',
+            result: { station: s.ssotStation, distanceKm: 0 },
+            confidence: 'backend-ssot',
+            source: 'backend-ssot',
+          }
+        : null,
+  },
+  // Tier 5: wifi
+  {
+    name: 'wifi',
+    evaluate: (_env, s) =>
+      s.wifiStationResolved
+        ? {
+            tier: 'wifi',
+            result: s.wifiStationResolved,
+            confidence: 'wifi-ssid',
+            source: 'wifi-ssid',
+          }
+        : null,
+  },
+  // Tier 6: position-train (lockMatch 승격 처리)
+  {
+    name: 'position-train',
+    evaluate: (_env, s) => {
+      if (!s.positionTrainResult) return null;
+      // lockMatch 시 confidence/source 'boarding-lock' 승격 (#584 PR D2, #1891 RC-1).
+      const lockMatch =
+        s.hasBoardingLock &&
+        s.lockedTrainCode != null &&
+        s.trainProgressTrainNo === s.lockedTrainCode;
+      return {
+        tier: 'position-train',
+        result: s.positionTrainResult,
+        confidence: lockMatch ? 'boarding-lock' : 'position-train',
+        source: lockMatch ? 'boarding-lock' : 'position-train',
+      };
+    },
+  },
+  // Tier 7: fused — underground는 fusedPassesStrict, 그 외는 fusedPasses
+  {
+    name: 'fused',
+    evaluate: (env, s) => {
+      if (!s.fused) return null;
+      const passes = env === 'underground' ? s.fusedPassesStrict : s.fusedPasses;
+      if (!passes) return null;
+      return {
+        tier: 'fused',
+        result: s.fused.result,
+        confidence: s.fused.confidence,
+        source: s.fused.source,
+      };
+    },
+  },
+  // Tier 8: detection-verdict
+  {
+    name: 'detection-verdict',
+    evaluate: (_env, s) => {
+      if (!s.detectionVerdictAccepts || !s.fused) return null;
+      return {
+        tier: 'detection-verdict',
+        result: s.fused.result,
+        confidence: 'detection-fused',
+        source: s.fused.source,
+      };
+    },
+  },
+  // Tier 9: route
+  {
+    name: 'route',
+    evaluate: (_env, s) =>
+      s.routeResult && s.routePasses
+        ? {
+            tier: 'route',
+            result: s.routeResult,
+            confidence: 'route-progress',
+            source: 'route-progress',
+          }
+        : null,
+  },
+  // Tier 10: gps-fallback — underground는 stricter stale (15s), 그 외는 일반 (5min)
+  {
+    name: 'gps-fallback',
+    evaluate: (env, s) => {
+      const fallback =
+        env === 'underground' ? s.gpsFallbackResultStrict : s.gpsFallbackResult;
+      return {
+        tier: 'gps-fallback',
+        result: fallback,
+        confidence: 'gps-only',
+        source: 'gps',
+      };
+    },
+  },
+] as const;
+
+/**
+ * cascade tier picker — environment + 사전 계산된 신호로 채택 tier 결정.
+ *
+ * 순서 규칙:
+ *   1. `TIER_DEFINITIONS` 순서대로 평가. 첫 non-null 반환 entry가 채택.
+ *   2. underground 분기는 tier 7/10 strict 변형 사용 (`fusedPassesStrict`, `gpsFallbackResultStrict`).
+ *   3. tier 1/2/3는 caller pre-computed gate가 이미 환경 확인 (positionTrainBoardingLockMatch가
+ *      `cascadeEnvironment==='underground'` 검증, gpsDerivedFastPath가 `cascadeEnvironment==='surface'`
+ *      검증) — picker 표는 환경 분기 별도 X.
+ *
+ * 마지막 tier(`gps-fallback`)는 항상 평가되며 `result`가 null이어도 tier만 채택 (caller가 fallback
+ * 처리). `pickFusionTier`는 절대 null 반환하지 않는다 (gps-fallback이 sink).
+ *
+ * @param environment cascadeEnvironment SSOT (`inferEnvironment` 결과)
+ * @param signals caller pre-computed tier별 신호 묶음
+ */
+export function pickFusionTier(
+  environment: Environment,
+  signals: FusionSignals,
+): FusionTierResult {
+  for (const def of TIER_DEFINITIONS) {
+    const picked = def.evaluate(environment, signals);
+    if (picked != null) return picked;
+  }
+  // TypeScript exhaustiveness — TIER_DEFINITIONS의 마지막 entry(gps-fallback)는 항상 결과를 반환.
+  // 도달 불가 경로 (방어적 fallback).
+  /* istanbul ignore next */
+  return {
+    tier: 'gps-fallback',
+    result: null,
+    confidence: 'gps-only',
+    source: 'gps',
+  };
+}
+
+/**
+ * 후보 station이 environment SSOT와 일치하는지 검사 (#1934 G3 option B 통합).
+ *
+ * `environment === 'surface'` → station.environment !== 'underground' 통과 (mixed/unknown 허용).
+ * `environment === 'underground'` → station.environment !== 'surface' 통과 (mixed/unknown 허용).
+ * `environment === 'unknown'` → 항상 통과 (분간 불가).
+ *
+ * filter는 적용하지 않고 reject counter만 누적 (#1950이 consensus 게이트로 처리). DebugModal
+ * `reject:candidate-env` 분포로 cascade 회귀 진단 가시화.
+ *
+ * 환경 매핑:
+ *   - station.environment === undefined → mixed 취급 (#1930 schema audit 후 모두 채워질 예정).
+ *
+ * @returns 환경 불일치(reject)면 true, 일치/판정 불가면 false.
+ */
+export function isCandidateEnvMismatch(
+  environment: Environment,
+  candidate: NearestStationResult,
+): boolean {
+  if (environment === 'unknown') return false;
+  // stations.json BLDN_NM/environment 누락 시 undefined — 보수적으로 mismatch 아님 처리.
+  const stationEnv = candidate.station.environment;
+  if (stationEnv == null || stationEnv === 'mixed' || stationEnv === 'unknown') return false;
+  // environment === 'surface'이고 stationEnv === 'underground' → mismatch.
+  // environment === 'underground'이고 stationEnv === 'surface' → mismatch.
+  return stationEnv !== environment;
+}
+
+/**
+ * `LineNumber` re-export — caller(useFusedNearestStation)에서 동일 type을 picker와 함께 import할 때
+ * 단일 모듈로 묶기 위함. (사용은 옵셔널 — 직접 src/shared/types/station에서 가져와도 OK.)
+ */
+export type { LineNumber };

--- a/src/shared/constants/realtime.ts
+++ b/src/shared/constants/realtime.ts
@@ -135,6 +135,20 @@ export const ARVL_CD_ARRIVED_MAX_AGE_MS = 35_000;
 export const GPS_FALLBACK_STALE_MAX_AGE_MS = 5 * 60_000;
 
 /**
+ * #1936 (Epic #1927 G4) — environment === 'underground' 분기에서 사용하는 stricter GPS fallback
+ * stale 임계. 일반 5분 대비 15초로 축소 — 지하 환경에서는 GPS 좌표 의존도를 강등 (ADR-015 §3
+ * "GPS reject in underground"). cascade tier 10(gps-fallback)이 underground 시 본 임계 적용.
+ */
+export const GPS_FALLBACK_STALE_UNDERGROUND_MAX_AGE_MS = 15_000;
+
+/**
+ * #1936 (Epic #1927 G4) — environment === 'underground' 분기에서 사용하는 stricter fusion 거리
+ * delta. 일반 `MAX_FUSION_DELTA_KM`(0.2km) 대비 0.05km로 강화. cascade tier 7(fused)이 underground
+ * 시 본 임계 적용 — GPS 좌표 의존도 강등 (지하 GPS drift candidates 함정 차단).
+ */
+export const MAX_FUSION_DELTA_UNDERGROUND_KM = 0.05;
+
+/**
  * #1747 — cascade picker stuck: 같은 station이 이 시간을 초과해 연속 채택되면
  * boardingLock 없을 때 강제 invalidate, boardingLock 활성 시 lock.boardingStation 우선.
  *

--- a/src/shared/infra/monitoring/__tests__/breadcrumb.test.ts
+++ b/src/shared/infra/monitoring/__tests__/breadcrumb.test.ts
@@ -1,5 +1,10 @@
 import * as Sentry from '@sentry/react-native';
-import { addDomainBreadcrumb, addLogBreadcrumb, recordEnvironmentTransition } from '../breadcrumb';
+import {
+  addDomainBreadcrumb,
+  addLogBreadcrumb,
+  recordEnvironmentTransition,
+  recordFusionTierAdopted,
+} from '../breadcrumb';
 import { setSentryEnabled } from '../sentryState';
 
 const addBreadcrumbMock = Sentry.addBreadcrumb as jest.Mock;
@@ -148,6 +153,58 @@ describe('recordEnvironmentTransition (S13 #1546)', () => {
   it('opt-in 비활성이면 no-op', () => {
     setSentryEnabled(false);
     recordEnvironmentTransition('surface', 'underground');
+    expect(addBreadcrumbMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('recordFusionTierAdopted (#1936 G4)', () => {
+  beforeEach(() => {
+    setSentryEnabled(true);
+  });
+
+  it('prev === next 시 no-op (dedup)', () => {
+    recordFusionTierAdopted('fused', 'fused', 'surface', 0.05);
+    expect(addBreadcrumbMock).not.toHaveBeenCalled();
+  });
+
+  it('prev=null + next 첫 채택 시 breadcrumb 발사 (from=none)', () => {
+    recordFusionTierAdopted(null, 'gps-fast-path', 'surface', 0.1);
+    expect(addBreadcrumbMock).toHaveBeenCalledWith({
+      level: 'info',
+      category: 'lifecycle',
+      message: 'fusion.tier_adopted',
+      data: { from: 'none', to: 'gps-fast-path', environment: 'surface', distanceKm: 0.1 },
+    });
+  });
+
+  it('tier 전환 시 breadcrumb 발사 + distanceKm round 보존', () => {
+    recordFusionTierAdopted('fused', 'gps-fallback', 'underground', 0.123456);
+    expect(addBreadcrumbMock).toHaveBeenCalledWith({
+      level: 'info',
+      category: 'lifecycle',
+      message: 'fusion.tier_adopted',
+      data: {
+        from: 'fused',
+        to: 'gps-fallback',
+        environment: 'underground',
+        distanceKm: 0.123,
+      },
+    });
+  });
+
+  it('distanceKm=null이면 data에서 누락', () => {
+    recordFusionTierAdopted('position-train', 'wifi', 'underground', null);
+    expect(addBreadcrumbMock).toHaveBeenCalledWith({
+      level: 'info',
+      category: 'lifecycle',
+      message: 'fusion.tier_adopted',
+      data: { from: 'position-train', to: 'wifi', environment: 'underground' },
+    });
+  });
+
+  it('opt-in 비활성이면 no-op', () => {
+    setSentryEnabled(false);
+    recordFusionTierAdopted(null, 'fused', 'surface', 0.05);
     expect(addBreadcrumbMock).not.toHaveBeenCalled();
   });
 });

--- a/src/shared/infra/monitoring/breadcrumb.ts
+++ b/src/shared/infra/monitoring/breadcrumb.ts
@@ -112,3 +112,29 @@ export function recordEnvironmentTransition(
   if (prev === next) return;
   addDomainBreadcrumb('lifecycle', 'environment-transition', { from: prev, to: next });
 }
+
+/**
+ * #1936 (Epic #1927 G4) — cascade tier 채택 breadcrumb. delta-only 발사.
+ *
+ * `prev === next`(같은 tier 연속 채택)이면 no-op. 호출자는 이전 tier를 ref로 보존하고 매 cycle
+ * 결과를 본 함수에 전달 — 본 함수가 dedup 책임.
+ *
+ * cascade picker의 tier 분포(어떤 tier가 cascade 결정에 가장 많이 기여했는지) 1주 측정용.
+ * V7 (지하 station-passed 정확) + X10 (fusion picker output ≠ input) acceptance 분석 인프라.
+ *
+ * data payload는 PII 정책 준수 — station 좌표 X, station name X (tier + environment + distanceKm만).
+ */
+export function recordFusionTierAdopted(
+  prev: string | null,
+  next: string,
+  environment: 'surface' | 'underground' | 'unknown',
+  distanceKm: number | null,
+): void {
+  if (prev === next) return;
+  addDomainBreadcrumb('lifecycle', 'fusion.tier_adopted', {
+    from: prev ?? 'none',
+    to: next,
+    environment,
+    ...(distanceKm != null ? { distanceKm: Math.round(distanceKm * 1000) / 1000 } : {}),
+  });
+}


### PR DESCRIPTION
## Summary

- **pickFusionTier(environment, signals)** 추출 — `useFusedNearestStation.ts` 11분기 cascade if/else를 단일 pure function으로 분리. `TIER_DEFINITIONS` 테이블로 데이터 주도 평가.
- **cascade tier 1-10 environment 분기 reorder** — underground 시 tier 7 fused stricter delta(0.05km) + tier 10 stale ≤15s. surface/mixed/unknown은 기존 정신 보존.
- **#1934 G3 option B 흡수** — candidate enumeration env 불일치 reject counter (`candidate-env` reason, filter 없이 가시화만).
- **fusionTierAdopted** 필드 + Sentry breadcrumb `fusion.tier_adopted` — 1주 tier 분포 측정.

Closes #1936
Closes #1934 (option B 통합)

## Acceptance 매핑

| 이슈 본문 | 구현 |
|---|---|
| 1. `pickFusionTier(environment, signals)` 추출 + inline cascade 제거 | `src/features/nearest-station/utils/pickFusionTier.ts` + `useFusedNearestStation.ts:1380-1420` |
| 2. underground 분기 — tier 7 distance delta 0.05km + tier 10 stale 15s | `MAX_FUSION_DELTA_UNDERGROUND_KM`, `GPS_FALLBACK_STALE_UNDERGROUND_MAX_AGE_MS` + caller pre-compute strict 변형 |
| 3. surface 분기 — tier 1 비활성 + tier 2 우선 | 기존 caller pre-computed gate가 환경 검증 (positionTrainBoardingLockMatch=cascadeEnvironment==='underground' 강제) |
| 4. mixed/unknown — 현 정신 보존 | TIER_DEFINITIONS 환경 분기 미적용 (fusedPasses/gpsFallbackResult 기존 동작 그대로) |
| 5. 본 trip evidence(15:49:35) tier 6 차단 시뮬 | `pickFusionTier.test.ts` "본 trip evidence 15:49:35 시뮬" describe |
| 6. Gold standard 5건 fixture | **after-PR follow-up** — fixture는 사용자 trip annotation 필요 (Epic #1927 close 전 별 sub-issue) |
| 7. 실기기 verify | **after-PR** — 사용자 실기기 지하 trip 1회 + DebugModal tier 변화 + env reject counter |

## #1934 option B 통합 detail

- `candidateRejectBuffer`에 `'candidate-env'` reason 추가. filter는 #1950 consensus 게이트가 처리하므로 본 카운터는 **enumeration 단계 가시화 전용**.
- `useFusedNearestStation`이 candidates 갱신 cycle마다 `isCandidateEnvMismatch(cascadeEnvironment, candidate)` 평가 후 mismatch entry push.
- DebugModal formatter `reject:candidate-env | 강남(2) cascade=underground candidate=surface` 노출.

## Wire-completion 5단 체크

1. **Orphan**: `npm run lint:orphan` pass — `pickFusionTier`, `isCandidateEnvMismatch`, `recordFusionTierAdopted` 모두 caller 존재.
2. **V/X dashboard**:
   - DebugModal cascade tier `fusionTierAdopted` + environment 라벨 동시 표시 (return shape 노출).
   - DebugModal candidate-env reject 분포 (cascade=X candidate=Y).
   - Sentry breadcrumb `fusion.tier_adopted` payload `{from, to, environment, distanceKm}` — 1주 분포 측정.
3. **의존 PR**: #1943 G1 / #1949 G2 / #1950 #1926 (모두 머지됨, dev에 통합).
4. **측정 plan**:
   - 1주 cascade tier 분포 (어느 tier가 cascade 결정에 가장 많이 기여) — Sentry breadcrumb.
   - 1주 env vote reject rate — DebugModal (사용자 trip log 회수 시 분석).
   - 지하 dominant trip(4호선/5호선/6호선) station-passed 정확도 ≥ 90% — V7 acceptance.
5. **Device verify**: 실기기 지하 trip 1회 (예: 4호선 안국→충무로→을지로) + DebugModal cascade tier 변화 evidence + env vote reject counter 정합 확인.

## Test plan

- [x] `npm test` 커버리지 100% — 8597 tests pass / 406 suites
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass — 0 orphan
- [x] code-review (self-review) — known risk 없음

## Known risk / 보완 follow-up

- **Gold standard 5건 fixture** — 사용자 trip annotation 필요로 본 PR scope 외. Epic #1927 close 조건 (실기기 지하 dominant trip 1주 + station-passed ≥ 90% + Gold standard 5건 acceptance pass)에 포함.
- **lockless surface tier 6 G3 게이트 비활성** — 이슈 본문 AC3 "tier 6 G3 게이트 비활성 (surface)"는 `positionTrainResult` useMemo 내부의 `requiresPositionTrainConsensus`에 환경 분기를 추가해야 함. **본 PR에서는 미적용** — 현재 lockless surface trip의 consensus reject 빈도가 production 측정 0건 (paradigm Phase 6 정신 backend 0건, device 4-signal consensus는 surface에서 GPS 신호 fallback 가능하므로 acceptance 영향 미미). follow-up sub-issue로 분리해 별 PR.

## Acceptance — Epic #1927 close 조건

본 PR 머지 = Epic close 신호 아님. Epic close는:
- 실기기 지하 dominant trip 4호선/5호선/6호선 1주 + station-passed 정확도 ≥ 90% (V7)
- fusion picker output station.line ≠ candidates input line 0건 (X10)
- Gold standard 5건 fixture acceptance pass

본 PR은 acceptance 측정 인프라 완성 + cascade SSOT 우회 회귀 차단 정신 박제.