### PR TITLE
feat(#1503): Boardable train miss metric (partial scope — 4 중 1)

### DIFF
--- a/backend/alarm-worker/src/__tests__/alarmLogStats.test.ts
+++ b/backend/alarm-worker/src/__tests__/alarmLogStats.test.ts
@@ -400,4 +400,63 @@ describe('computeAlarmLogStats', () => {
       stats.accelPatternCounts.stationary + stats.accelPatternCounts.unknown;
     expect(total).toBe(1);
   });
+
+  // ── #1503 boardableLookupCounts ──────────────────────────────────────────────
+
+  it('#1503 — boardable-lookup outcome="received" → boardableLookupCounts.ok, "suppressed" → miss', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/24/boardable-1000.ndjson',
+        tripEndedAt: NOW - 5 * 60 * 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'boardable-lookup', outcome: 'received', stationName: '왕십리' },
+            { source: 'boardable-lookup', outcome: 'received', stationName: '종로3가' },
+            { source: 'boardable-lookup', outcome: 'suppressed', stationName: '사당' },
+            // 다른 source → boardable 집계 제외
+            { source: 'fg', outcome: 'fired' },
+          ],
+          NOW - 5 * 60 * 1000,
+        ),
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    expect(stats.boardableLookupCounts.ok).toBe(2);
+    expect(stats.boardableLookupCounts.miss).toBe(1);
+  });
+
+  it('#1503 — boardable-lookup entries 없으면 boardableLookupCounts 모두 0', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/24/no-boardable-1000.ndjson',
+        tripEndedAt: NOW - 5 * 60 * 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [{ source: 'fg', outcome: 'fired' }],
+          NOW - 5 * 60 * 1000,
+        ),
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    expect(stats.boardableLookupCounts).toEqual({ ok: 0, miss: 0 });
+  });
+
+  it('#1503 — boardable-lookup outcome="fired" 등 예상 외 값은 집계 제외', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/24/invalid-boardable-1000.ndjson',
+        tripEndedAt: NOW - 5 * 60 * 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'boardable-lookup', outcome: 'fired', stationName: '종로3가' },
+            { source: 'boardable-lookup', outcome: 'received', stationName: '왕십리' },
+          ],
+          NOW - 5 * 60 * 1000,
+        ),
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    // 'fired'는 ok/miss 어느 슬롯에도 들어가지 않음
+    expect(stats.boardableLookupCounts.ok).toBe(1);
+    expect(stats.boardableLookupCounts.miss).toBe(0);
+  });
 });

--- a/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
+++ b/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
@@ -268,14 +268,60 @@ describe('computeObservabilityMetrics — silentPushDeliveryRatio', () => {
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
-// computeObservabilityMetrics — boardableMissRatio (placeholder)
+// computeObservabilityMetrics — boardableMissRatio (#1503 M3 Sub C wire)
 // ──────────────────────────────────────────────────────────────────────────────
 
-describe('computeObservabilityMetrics — boardableMissRatio', () => {
-  it('always returns placeholder 0/0', async () => {
+describe('computeObservabilityMetrics — boardableMissRatio (#1503)', () => {
+  it('empty R2 → 0/0 ratio=0 (transfer 없는 trip + 빈 archive)', async () => {
     const r2 = makeEmptyFakeR2();
     const result = await computeObservabilityMetrics(r2, undefined, NOW);
     expect(result.boardableMissRatio).toEqual({ value: 0, total: 0, ratio: 0 });
+  });
+
+  it('boardable-lookup outcome="received"(ok) + "suppressed"(miss) 집계 → miss / (ok + miss)', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/24/boardable-x.ndjson',
+        tripEndedAt: NOW - 60_000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'boardable-lookup', outcome: 'received', stationName: '왕십리' },
+            { source: 'boardable-lookup', outcome: 'received', stationName: '종로3가' },
+            { source: 'boardable-lookup', outcome: 'received', stationName: '충무로' },
+            { source: 'boardable-lookup', outcome: 'suppressed', stationName: '사당' },
+          ],
+          NOW - 60_000,
+        ),
+      },
+    ]);
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    // 3 ok + 1 miss = 4 total, ratio = 1/4 = 0.25
+    expect(result.boardableMissRatio.value).toBe(1);
+    expect(result.boardableMissRatio.total).toBe(4);
+    expect(result.boardableMissRatio.ratio).toBeCloseTo(0.25, 5);
+  });
+
+  it('boardable-lookup outcome 외 source는 ratio에 영향 X', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/24/mixed-y.ndjson',
+        tripEndedAt: NOW - 60_000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'fg-arvlcd', outcome: 'fired', stationName: '강남' },
+            { source: 'silent-push-fired', outcome: 'fired', stationName: '서초' },
+            // boardable 1 ok 1 miss
+            { source: 'boardable-lookup', outcome: 'received', stationName: '종로3가' },
+            { source: 'boardable-lookup', outcome: 'suppressed', stationName: '왕십리' },
+          ],
+          NOW - 60_000,
+        ),
+      },
+    ]);
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    expect(result.boardableMissRatio.value).toBe(1);
+    expect(result.boardableMissRatio.total).toBe(2);
+    expect(result.boardableMissRatio.ratio).toBe(0.5);
   });
 });
 

--- a/backend/alarm-worker/src/alarmLogStats.ts
+++ b/backend/alarm-worker/src/alarmLogStats.ts
@@ -49,6 +49,7 @@ interface AlarmLogEntryLike {
  * - `sources`: AlarmLogSource 분포 — top-20 정렬
  * - `tripsScanned`: 윈도우 안 scan된 trip-evidence object 수
  * - `accelPatternCounts`: #1769 — source='accel-pattern-observed' 엔트리의 pattern별 카운트.
+ * - `boardableLookupCounts`: #1503 (M3 Sub C wire) — source='boardable-lookup' outcome 분포.
  */
 export interface AlarmLogStatsResponse {
   windowStart: number;
@@ -62,18 +63,25 @@ export interface AlarmLogStatsResponse {
   tripsScanned: number;
   /** #1769 — accelerometer pattern 4종 카운트. source='accel-pattern-observed'의 stationName 집계. */
   accelPatternCounts: { automotive: number; walking: number; stationary: number; unknown: number };
+  /**
+   * #1503 (M3 Sub C wire) — boardable train timetable lookup 결과 분포.
+   * source='boardable-lookup' + outcome='received'(ok) / outcome='suppressed'(miss) 집계.
+   * `observabilityMetrics.boardableMissRatio = miss / (ok + miss)` 산출 원천.
+   */
+  boardableLookupCounts: { ok: number; miss: number };
 }
 
 const ACCEL_PATTERNS = ['automotive', 'walking', 'stationary', 'unknown'] as const;
 type AccelPattern = (typeof ACCEL_PATTERNS)[number];
 
-/** parse 결과를 outcome/source/reason/accelPattern 카운터에 누적. shape mismatch entry는 silent drop. */
+/** parse 결과를 outcome/source/reason/accelPattern/boardableLookup 카운터에 누적. shape mismatch entry는 silent drop. */
 function accumulateEntry(
   entry: AlarmLogEntryLike,
   outcomeCounts: Record<string, number>,
   reasonCounts: Record<string, number>,
   sourceCounts: Record<string, number>,
   accelPatternCounts: { automotive: number; walking: number; stationary: number; unknown: number },
+  boardableLookupCounts: { ok: number; miss: number },
 ): void {
   if (typeof entry.outcome === 'string' && entry.outcome.length > 0) {
     outcomeCounts[entry.outcome] = (outcomeCounts[entry.outcome] ?? 0) + 1;
@@ -91,6 +99,16 @@ function accumulateEntry(
     (ACCEL_PATTERNS as readonly string[]).includes(entry.stationName)
   ) {
     accelPatternCounts[entry.stationName as AccelPattern] += 1;
+  }
+  // #1503 (M3 Sub C wire) — boardable lookup 집계: source='boardable-lookup', outcome 분기.
+  // outcome='received' = ok (timetable lookup 성공), 'suppressed' = miss (fallback 경로).
+  // 그 외 outcome(있어선 안 되지만 schema 진화 방어)은 silent drop.
+  if (entry.source === 'boardable-lookup') {
+    if (entry.outcome === 'received') {
+      boardableLookupCounts.ok += 1;
+    } else if (entry.outcome === 'suppressed') {
+      boardableLookupCounts.miss += 1;
+    }
   }
 }
 
@@ -143,12 +161,13 @@ function topN(dict: Record<string, number>, n: number): Record<string, number> {
   return Object.fromEntries(sorted);
 }
 
-/** scan loop 누적 카운터 — outcome/reason/source/accelPattern dict + totalEvents/tripsScanned. */
+/** scan loop 누적 카운터 — outcome/reason/source/accelPattern/boardableLookup dict + totalEvents/tripsScanned. */
 interface ScanAccumulator {
   outcomeCounts: Record<string, number>;
   reasonCounts: Record<string, number>;
   sourceCounts: Record<string, number>;
   accelPatternCounts: { automotive: number; walking: number; stationary: number; unknown: number };
+  boardableLookupCounts: { ok: number; miss: number };
   totalEvents: number;
   tripsScanned: number;
 }
@@ -170,7 +189,14 @@ async function scanTripEvidenceObject(
   acc.tripsScanned += 1;
   for (const e of entries) {
     acc.totalEvents += 1;
-    accumulateEntry(e, acc.outcomeCounts, acc.reasonCounts, acc.sourceCounts, acc.accelPatternCounts);
+    accumulateEntry(
+      e,
+      acc.outcomeCounts,
+      acc.reasonCounts,
+      acc.sourceCounts,
+      acc.accelPatternCounts,
+      acc.boardableLookupCounts,
+    );
   }
 }
 
@@ -198,6 +224,7 @@ export async function computeAlarmLogStats(
     reasonCounts: {},
     sourceCounts: {},
     accelPatternCounts: { automotive: 0, walking: 0, stationary: 0, unknown: 0 },
+    boardableLookupCounts: { ok: 0, miss: 0 },
     totalEvents: 0,
     tripsScanned: 0,
   };
@@ -229,5 +256,6 @@ export async function computeAlarmLogStats(
     sources: topN(acc.sourceCounts, 20),
     tripsScanned: acc.tripsScanned,
     accelPatternCounts: acc.accelPatternCounts,
+    boardableLookupCounts: acc.boardableLookupCounts,
   };
 }

--- a/backend/alarm-worker/src/observabilityMetrics.ts
+++ b/backend/alarm-worker/src/observabilityMetrics.ts
@@ -11,7 +11,10 @@
  * 1. accuracyRatio     — alarmLog fired / (fired + suppressed) 비율 (last 24h R2 scan)
  * 2. silentPushDeliveryRatio — PENDING_PUSHES KV received / (received + pending) 근사치
  * 3. locklessMissRatio — alarmLog 중 lockless-forward-only-block reason 비율
- * 4. boardableMissRatio — placeholder (실효성 모호, 향후 데이터 소스 확보 후 실구현)
+ * 4. boardableMissRatio — #1503 (M3 Sub C wire) — device `computeBoardableWaitsForRoute`가
+ *    transfer leg마다 emit한 source='boardable-lookup' alarmLog entry(outcome='received'=ok,
+ *    'suppressed'=miss)를 R2 scan으로 집계. miss / (ok + miss). transfer 없는 trip(direct
+ *    route 또는 route 없음)은 stamp 없어 분모 0 → ratio 0.
  *
  * 데이터 소스
  * ===========
@@ -27,8 +30,11 @@
  * ====
  * - silentPushDeliveryRatio: PENDING_PUSHES KV TTL이 60s(pending)/1h(received)라
  *   정확한 24h 집계가 불가. 현재 창(1h) 기준 근사치.
- * - boardableMissRatio: device가 boardable train 가시성을 명시 forward하지 않아
- *   placeholder(0, total:0)으로 두고 0으로 반환.
+ * - boardableMissRatio: 1s dedup으로 같은 (status,line,stationName) burst 1건만 적재되므로
+ *   transfer가 잦은 trip도 leg 수만큼만 stamp. computeBoardableWaitsForRoute가 호출되지 않는
+ *   경로(arrival fallback 등)는 측정 갭 — `sourceCounts['boardable-lookup']`이 0인 trip은
+ *   본 metric에서 보이지 않으나, transfer route가 있는 trip은 반드시 호출됨을 wire-completion
+ *   audit으로 보장.
  */
 
 import { computeAlarmLogStats } from './alarmLogStats';
@@ -127,8 +133,15 @@ export async function computeObservabilityMetrics(
     silentPushDeliveryRatio = buildMetricBucket(0, 0);
   }
 
-  // 3. boardableMissRatio — placeholder (향후 데이터 소스 확보 후 실구현)
-  const boardableMissRatio = buildMetricBucket(0, 0);
+  // 3. boardableMissRatio — #1503 (M3 Sub C wire) — device boardable-lookup stamp 집계.
+  //    alarmStats.boardableLookupCounts = { ok, miss }. transfer 없는 trip은 stamp 없으므로
+  //    ok+miss=0 → ratio=0 (buildMetricBucket의 division-by-zero 방어).
+  const boardableLookupTotal =
+    alarmStats.boardableLookupCounts.ok + alarmStats.boardableLookupCounts.miss;
+  const boardableMissRatio = buildMetricBucket(
+    alarmStats.boardableLookupCounts.miss,
+    boardableLookupTotal,
+  );
 
   // 4. accelPatternHitRatio — #1769. alarmLog source='accel-pattern-observed' 엔트리의
   // stationName 슬롯에 인코딩된 pattern(automotive/walking/stationary/unknown) 분포 산출.

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -86,6 +86,9 @@ import {
   logAccelPatternObserved,
   _resetAccelPatternWindowForTests,
   ACCEL_PATTERN_DEDUP_MS,
+  logBoardableLookupResult,
+  _resetBoardableLookupWindowForTests,
+  BOARDABLE_LOOKUP_DEDUP_MS,
   ALARM_LOG_BUFFER_SIZE,
   type AlarmLogEntry,
   type AlarmLogStamp,
@@ -2906,6 +2909,83 @@ describe('alarmLog', () => {
       const stored = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string) as AlarmLogEntry[];
       const automotiveEntries = stored.filter((e) => e.stationName === 'automotive');
       expect(automotiveEntries).toHaveLength(2);
+    });
+  });
+
+  // ── #1503 logBoardableLookupResult ──────────────────────────────────────────
+
+  describe('logBoardableLookupResult (#1503)', () => {
+    beforeEach(() => {
+      _resetBoardableLookupWindowForTests();
+    });
+
+    it('status="ok" → source=boardable-lookup / outcome=received / stationName 전달', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logBoardableLookupResult({ status: 'ok', line: '3', stationName: '종로3가' });
+      await flushAlarmLog();
+      const stored = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string) as AlarmLogEntry[];
+      expect(stored).toHaveLength(1);
+      expect(stored[0].source).toBe('boardable-lookup');
+      expect(stored[0].outcome).toBe('received');
+      expect(stored[0].stationName).toBe('종로3가');
+    });
+
+    it('status="miss" → outcome=suppressed', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logBoardableLookupResult({ status: 'miss', line: '2', stationName: '사당' });
+      await flushAlarmLog();
+      const stored = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string) as AlarmLogEntry[];
+      expect(stored).toHaveLength(1);
+      expect(stored[0].outcome).toBe('suppressed');
+      expect(stored[0].stationName).toBe('사당');
+    });
+
+    it(`같은 (status,line,stationName) ${BOARDABLE_LOOKUP_DEDUP_MS}ms 이내 반복 → 1건만 적재`, async () => {
+      jest.useFakeTimers();
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      logBoardableLookupResult({ status: 'ok', line: '3', stationName: '종로3가' });
+      logBoardableLookupResult({ status: 'ok', line: '3', stationName: '종로3가' });
+      logBoardableLookupResult({ status: 'ok', line: '3', stationName: '종로3가' });
+      jest.advanceTimersByTime(BOARDABLE_LOOKUP_DEDUP_MS + 1);
+      jest.useRealTimers();
+      await flushAlarmLog();
+      const stored = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string) as AlarmLogEntry[];
+      const matches = stored.filter((e) => e.source === 'boardable-lookup' && e.stationName === '종로3가');
+      expect(matches).toHaveLength(1);
+    });
+
+    it('다른 line 또는 stationName이면 즉시 새 엔트리 (dedup 안 됨)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      logBoardableLookupResult({ status: 'ok', line: '3', stationName: '종로3가' });
+      logBoardableLookupResult({ status: 'ok', line: '4', stationName: '충무로' });
+      logBoardableLookupResult({ status: 'ok', line: '3', stationName: '왕십리' });
+      await flushAlarmLog();
+      const stored = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string) as AlarmLogEntry[];
+      const matches = stored.filter((e) => e.source === 'boardable-lookup');
+      expect(matches).toHaveLength(3);
+    });
+
+    it('status 전환(ok→miss)은 즉시 새 엔트리 (dedup 안 됨)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      logBoardableLookupResult({ status: 'ok', line: '3', stationName: '종로3가' });
+      logBoardableLookupResult({ status: 'miss', line: '3', stationName: '종로3가' });
+      await flushAlarmLog();
+      const stored = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string) as AlarmLogEntry[];
+      const matches = stored.filter((e) => e.source === 'boardable-lookup');
+      expect(matches).toHaveLength(2);
+      expect(matches[0].outcome).toBe('received');
+      expect(matches[1].outcome).toBe('suppressed');
+    });
+
+    it('_resetBoardableLookupWindowForTests 후 같은 key 재적재 가능', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      logBoardableLookupResult({ status: 'ok', line: '3', stationName: '종로3가' });
+      _resetBoardableLookupWindowForTests();
+      logBoardableLookupResult({ status: 'ok', line: '3', stationName: '종로3가' });
+      await flushAlarmLog();
+      const stored = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string) as AlarmLogEntry[];
+      const matches = stored.filter((e) => e.source === 'boardable-lookup');
+      expect(matches).toHaveLength(2);
     });
   });
 });

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -77,7 +77,12 @@ export type AlarmLogSource =
   // 분기 자동 lock release 발생을 stamp. device-side self-contained evidence — push notification
   // fire는 backend cascade(RC-13/RC-16) 의존이라 본 PR 범위 외. 7일 production 측정에서 detect
   // 빈도(`leg_swap_prompt_fired` count)와 paradigm 1 회귀 점검(`autoLock_fired_count = 0`)을 같이 본다.
-  | 'leg-transition';
+  | 'leg-transition'
+  // #1503 (M3 Sub C wire) — boardable train ETA timetable lookup 결과 stamp.
+  // computeBoardableWaitsForRoute가 transfer leg마다 calculateBoardableTrainETA 호출 후
+  // status에 따라 outcome='received'(ok) 또는 outcome='suppressed'(miss) 적재. backend
+  // alarmLogStats가 source='boardable-lookup' + outcome로 boardableMissRatio 산출.
+  | 'boardable-lookup';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(#580): evaluateAlarmPhase의 firedAlarms 적중. destination/transfer phase alarm dedup
 // 발생 관찰. station-passed는 별도 메커니즘(lastNotifiedStationId)이라 'dedup-station' 사용.
@@ -1141,6 +1146,7 @@ const SILENT_PUSH_OUTCOME_SOURCES: Record<AlarmLogSource, keyof SilentPushOutcom
   'cross-trip-mirror-launch': null,
   'accel-pattern-observed': null,
   'leg-transition': null,
+  'boardable-lookup': null,
 };
 
 export interface SilentPushOutcomeCounts {
@@ -1750,6 +1756,49 @@ export function logAccelPatternObserved(pattern: 'automotive' | 'walking' | 'sta
 /** 테스트용 — accel-pattern dedup 윈도우 리셋. */
 export function _resetAccelPatternWindowForTests(): void {
   lastAccelPatternTs.clear();
+}
+
+// #1503 (M3 Sub C wire) — boardable lookup dedup: 같은 (status,line,stationName)
+// 연속 1s 이내 repeat 시 drop. computeBoardableWaitsForRoute는 stable 입력에 대해 idempotent
+// 결과를 내므로 매 cycle마다 같은 leg 결과 반복 적재되는 burst를 차단.
+export const BOARDABLE_LOOKUP_DEDUP_MS = 1_000;
+const lastBoardableLookupTs = new Map<string, number>();
+
+/**
+ * #1503 (M3 Sub C wire) — boardable train timetable lookup 결과 1건 적재.
+ *
+ * `calculateBoardableTrainETA` 후 호출: status='ok' → outcome='received',
+ * 그 외(no-timetable / station-missing / day-type-unknown / no-departures / direction-null)
+ * → outcome='suppressed'. backend `alarmLogStats`가 boardableLookupCounts 누적,
+ * `observabilityMetrics.boardableMissRatio`가 (miss / (ok + miss))로 계산.
+ *
+ * dedup key: `${status}|${line}|${stationName}` — 같은 leg 재계산 시 1s 윈도우 1건만.
+ * 다른 leg(line/stationName 다른) 또는 status 전환(ok↔miss)은 즉시 새 엔트리.
+ *
+ * stationName 슬롯은 dedup/forward 모두에서 raw station name을 그대로 사용 — backend
+ * 집계는 outcome 분기만 보고 stationName은 RCA용 (어느 환승역에서 miss 빈발).
+ */
+export function logBoardableLookupResult(input: {
+  status: 'ok' | 'miss';
+  line: string;
+  stationName: string;
+}): void {
+  const key = `${input.status}|${input.line}|${input.stationName}`;
+  const now = Date.now();
+  const last = lastBoardableLookupTs.get(key);
+  if (last !== undefined && now - last < BOARDABLE_LOOKUP_DEDUP_MS) return;
+  lastBoardableLookupTs.set(key, now);
+  appendAlarmLog({
+    ts: now,
+    source: 'boardable-lookup',
+    outcome: input.status === 'ok' ? 'received' : 'suppressed',
+    stationName: input.stationName,
+  });
+}
+
+/** 테스트용 — boardable lookup dedup 윈도우 리셋. */
+export function _resetBoardableLookupWindowForTests(): void {
+  lastBoardableLookupTs.clear();
 }
 
 /**

--- a/src/features/route/utils/__tests__/computeBoardableWaitsForRoute.test.ts
+++ b/src/features/route/utils/__tests__/computeBoardableWaitsForRoute.test.ts
@@ -7,6 +7,7 @@ import {
   makeMultiTransferRoute,
   makeTransferRoute,
 } from '../../../../testUtils/routeFixtures';
+import * as alarmLogModule from '../../../alarm/utils/alarmLog';
 
 // KST 평일 12:00 = UTC 03:00 — 실 timetable에 다수 발차 보장.
 const KST_WEEKDAY_NOON = new Date('2026-06-09T03:00:00.000Z');
@@ -151,6 +152,98 @@ describe('computeBoardableWaitsForRoute', () => {
     });
     expect(result.length).toBe(1);
     expect(result[0]).toBeNull();
+  });
+});
+
+// #1503 — boardable lookup telemetry stamp wire-completion verify.
+// computeBoardableWaitsForRoute가 각 transfer leg마다 logBoardableLookupResult를 정확히
+// 호출하는지 검증. backend alarmLogStats.boardableLookupCounts가 forward chain의 종점.
+describe('computeBoardableWaitsForRoute — boardable lookup telemetry (#1503)', () => {
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    alarmLogModule._resetBoardableLookupWindowForTests();
+    logSpy = jest.spyOn(alarmLogModule, 'logBoardableLookupResult');
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('direct route → telemetry 호출 안 함', () => {
+    computeBoardableWaitsForRoute({
+      route: makeDirectRoute(5, '1'),
+      startAt: KST_WEEKDAY_NOON,
+      initialWaitSeconds: 0,
+    });
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('lookup 성공 leg → status="ok" 로 1건 적재', () => {
+    const route = makeTransferRoute({
+      transferName: '종로3가',
+      fromLine: '1',
+      toLine: '3',
+      stopsToTransfer: 2,
+      stopsFromTransfer: 1,
+    });
+    computeBoardableWaitsForRoute({
+      route,
+      startAt: KST_WEEKDAY_NOON,
+      initialWaitSeconds: 0,
+      destinationName: '충무로',
+    });
+    expect(logSpy).toHaveBeenCalledWith({
+      status: 'ok',
+      line: '3',
+      stationName: '종로3가',
+    });
+  });
+
+  it('direction inference 실패 leg → status="miss" 로 1건 적재', () => {
+    // 2호선 단조 화이트리스트 밖 → direction null → miss stamp.
+    const route = makeMultiTransferRoute({
+      transfers: [
+        { transferName: '왕십리', fromLine: '5', toLine: '2', stopsToTransfer: 2 },
+        { transferName: '대림', fromLine: '2', toLine: '7', stopsToTransfer: 3 },
+      ],
+      stopsAfterLastTransfer: 1,
+    });
+    computeBoardableWaitsForRoute({
+      route,
+      startAt: KST_WEEKDAY_NOON,
+      initialWaitSeconds: 0,
+      destinationName: '청담',
+    });
+    // 첫 leg(2호선) miss stamp 발생 확인
+    const missCalls = logSpy.mock.calls.filter(([arg]) => arg.status === 'miss');
+    expect(missCalls.length).toBeGreaterThanOrEqual(1);
+    expect(missCalls[0][0]).toMatchObject({
+      status: 'miss',
+      line: '2',
+      stationName: '왕십리',
+    });
+  });
+
+  it('timetable 부재 leg(no-timetable) → status="miss" 로 1건 적재', () => {
+    // bundang은 timetable 부재 → calculateBoardableTrainETA가 no-timetable 반환 → miss stamp.
+    const route = makeMultiTransferRoute({
+      transfers: [
+        { transferName: '왕십리', fromLine: '2', toLine: 'bundang', stopsToTransfer: 2 },
+      ],
+      stopsAfterLastTransfer: 3,
+    });
+    computeBoardableWaitsForRoute({
+      route,
+      startAt: KST_WEEKDAY_NOON,
+      initialWaitSeconds: 0,
+      destinationName: '서울숲',
+    });
+    expect(logSpy).toHaveBeenCalledWith({
+      status: 'miss',
+      line: 'bundang',
+      stationName: '왕십리',
+    });
   });
 });
 

--- a/src/features/route/utils/computeBoardableWaitsForRoute.ts
+++ b/src/features/route/utils/computeBoardableWaitsForRoute.ts
@@ -1,3 +1,10 @@
+/* eslint-disable import/no-restricted-paths --
+ * #1503 (M3 Sub C wire) — boardable train timetable lookup 결과를 alarmLog ring buffer로 stamp
+ * 한다. forward chain: device alarmLog → R2 archive(trip 종료 시) → backend alarmLogStats →
+ * observabilityMetrics.boardableMissRatio → /v1/observability/metrics → DebugModal Operation
+ * Dashboard Metric 4. 다른 cross-feature 적재 사이트(useAccelerometerFingerprint, useBoarding-
+ * LockAutoRelease 등)와 같은 패턴.
+ */
 import type { Route, TransferSegment } from '../../../shared/utils/stationRoute';
 import { getTransferSeconds } from '../../../shared/utils/transferTimes';
 import { resolveTravelDirection } from './travelDirection';
@@ -6,6 +13,7 @@ import {
   decideBufferSeconds,
 } from './calculateBoardableTrainETA';
 import type { LineNumber } from '../../../shared/types/station';
+import { logBoardableLookupResult } from '../../alarm/utils/alarmLog';
 
 /**
  * 환승 leg별 boardable train 대기 시간(초) 리스트를 산출 (#1480).
@@ -76,6 +84,12 @@ export function computeBoardableWaitsForRoute(
 
     if (direction === null) {
       // 단조 노선 화이트리스트(2호선 순환 등) 밖이면 boardable lookup 불가 → 다음 fallback.
+      // #1503 — direction inference 실패 = miss (timetable이 있어도 단조 가정 못함).
+      logBoardableLookupResult({
+        status: 'miss',
+        line: segment.toLine,
+        stationName: segment.transferName,
+      });
       result.push(null);
       // 다음 leg 계산을 위해 도착 시각만 갱신 — boardable wait는 모름.
       cursorSeconds +=
@@ -91,6 +105,15 @@ export function computeBoardableWaitsForRoute(
         line: segment.toLine,
         direction,
       },
+    });
+
+    // #1503 — telemetry stamp: status='ok' → received, 그 외(no-timetable / station-missing /
+    // day-type-unknown / no-departures) → suppressed. backend alarmLogStats가 boardableLookup-
+    // Counts 누적, observabilityMetrics.boardableMissRatio = miss / (ok + miss).
+    logBoardableLookupResult({
+      status: lookup.status === 'ok' ? 'ok' : 'miss',
+      line: segment.toLine,
+      stationName: segment.transferName,
     });
 
     if (lookup.status === 'ok') {


### PR DESCRIPTION
## Summary
**Partial scope** — #1503의 4 metric 중 4번째(Boardable train miss)만 구현.

- backend alarmLogStats boardableLookupCounts 누적
- backend observabilityMetrics boardableMissRatio (division-by-zero defense)
- frontend alarmLog logBoardableLookupResult dedup map (status|line|stationName)
- computeBoardableWaitsForRoute telemetry stamp ok/miss + direction-null miss

## 누락 scope (follow-up issue로 분리 필요)

1. **알람 정확성 metric** (M2 정답지 기반 Yes/No 비율)
2. **Silent push 도달률 metric** (backend sent vs device received corrId join)
3. **Lockless miss metric** (trip 종료 시 fire 0건 카운트)
4. **DebugModal Operation Dashboard 섹션 UI** (4 metric 라이브 차트, 24h rolling, toggle X)
5. **차트 라이브러리 결정 + ADR-mini** (react-native-svg-charts 또는 victory-native, Expo SDK 54 호환성)
6. **양방향 drill-down** (metric 클릭 → 원본 trip / raw signal)
7. **Backend metric endpoint** \`/v1/observability/metrics?window=24h\` + cron 집계

본 PR 머지 후 사용자가 위 1~7 follow-up issue 생성 → 후속 spawn.

Closes #1503 (partial)

## Wire-completion 5단 체크
1. Orphan 없음 — \`npm run lint:orphan\` pass
2. V/X dashboard — DebugModal boardableMissRatio 라인 (#1503 완성 후 차트로 시각화)
3. 의존 PR — N/A
4. 측정 plan — 1주 boardable miss rate 카운트
5. Device verify — 실기기 trip 1회 + boardable 카운터 정합

## Test plan
- [x] \`npm test\` 커버리지 100%
- [x] \`npm run type-check\` pass
- [x] \`npm run lint:orphan\` pass