### PR TITLE
feat(#1956): DebugModal metric drill-down — TripDetailModal 신규 + onMetricClick wire

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -126,6 +126,8 @@ import type { NearestStationResult } from '../../../shared/types/station';
 import { useTheme, spacing, radius, typography } from '../../../shared/theme';
 // #1751 (M3 Sub 1) — Operation Dashboard 섹션.
 import { OperationDashboardSection } from './OperationDashboardSection';
+// #1956 (S-m3-1) — Operation Dashboard 4 metric → TripDetailModal drill-down 진입.
+import { TripDetailModal } from './TripDetailModal';
 import { useBarometer } from '../../../shared/hooks/useBarometer';
 import { useLowPowerMode } from '../../../shared/hooks/useLowPowerMode';
 import { RegressionsSection } from './RegressionsSection';
@@ -1901,6 +1903,16 @@ function DebugModalInner({
   // null = 아직 한 번도 dump 안 한 상태 → "Tap Refresh" placeholder 노출.
   const [scheduledDump, setScheduledDump] = useState<ScheduledNotificationDumpEntry[] | null>(null);
 
+  // #1956 — Operation Dashboard metric 클릭 시 진입할 TripDetailModal state.
+  // tripToken=null이면 modal 닫힘. set 시 visible+token이 함께 갱신된다.
+  const [tripDetailToken, setTripDetailToken] = useState<string | null>(null);
+  const handleMetricClick = useCallback((_key: string, token: string) => {
+    setTripDetailToken(token);
+  }, []);
+  const handleTripDetailClose = useCallback(() => {
+    setTripDetailToken(null);
+  }, []);
+
   const refreshScheduledDump = useCallback(async () => {
     setScheduledDump(await dumpScheduledNotifications());
   }, []);
@@ -2100,6 +2112,7 @@ function DebugModalInner({
   ]);
 
   return (
+    <>
     <Modal visible animationType="slide" onRequestClose={onClose} testID="debug-modal">
       <View style={[styles.container, { backgroundColor: colors.bg, paddingTop: insets.top }]}>
         <View style={[styles.header, { borderBottomColor: colors.hair }]}>
@@ -2115,8 +2128,9 @@ function DebugModalInner({
 
         <ScrollView contentContainerStyle={{ padding: spacing.xl }}>
           {/* #1751 (M3 Sub 1) — Operation Dashboard. toggle/opt-in 없이 항상 렌더. */}
+          {/* #1956 — onMetricClick wire: metric 클릭 → TripDetailModal 진입. */}
           <Section title="Operation Dashboard" colors={colors} testID="operation-dashboard-section-wrapper">
-            <OperationDashboardSection logs={logs} />
+            <OperationDashboardSection logs={logs} onMetricClick={handleMetricClick} />
           </Section>
 
           <Section title="GPS" colors={colors}>
@@ -2612,6 +2626,13 @@ function DebugModalInner({
         </ScrollView>
       </View>
     </Modal>
+    {/* #1956 — Operation Dashboard metric drill-down. visible은 token 유무로 결정. */}
+    <TripDetailModal
+      visible={tripDetailToken !== null}
+      tripToken={tripDetailToken}
+      onClose={handleTripDetailClose}
+    />
+    </>
   );
 }
 

--- a/src/features/debug/components/OperationDashboardSection.tsx
+++ b/src/features/debug/components/OperationDashboardSection.tsx
@@ -39,6 +39,8 @@ import {
   MetricDrillDownView,
   type DrillDownMetricKey,
 } from './MetricDrillDownView';
+import { getRawSignalEntries } from '../../observability/utils/rawSignalBuffer';
+import { UNKNOWN_CORR_ID_BUCKET } from '../utils/buildTripDetail';
 
 // ─── 상수 ─────────────────────────────────────────────────────────────────────
 
@@ -274,6 +276,29 @@ function PushLatencyRow({
 export interface OperationDashboardSectionProps {
   /** alarmLog entries — Silent push 도달률 계산에 사용. */
   logs: readonly AlarmLogEntry[];
+  /**
+   * #1956 — metric 차트 클릭 시 부모(DebugModal)에게 trip drill-down 진입 신호.
+   * 부모는 본 콜백을 받아 TripDetailModal을 열고 tripToken을 전달한다.
+   *
+   * tripToken은 rawSignalBuffer의 가장 최근 entry corrId — 매칭 entry가 없으면
+   * 'unknown' 버킷이 전달된다. caller(TripDetailModal)가 null fallback 렌더.
+   *
+   * 미전달 시 기존 inline MetricDrillDownView 토글만 동작(backward-compat).
+   */
+  onMetricClick?: (metricKey: DrillDownMetricKey, tripToken: string) => void;
+}
+
+/**
+ * 클릭된 metric에 대해 rawSignalBuffer 최신 entry의 corrId를 추출.
+ * corrId=null → UNKNOWN_CORR_ID_BUCKET 버킷.
+ * entries 0건 → UNKNOWN_CORR_ID_BUCKET 반환 (caller가 null fallback 렌더).
+ */
+function pickLatestTripToken(): string {
+  const entries = getRawSignalEntries();
+  if (entries.length === 0) return UNKNOWN_CORR_ID_BUCKET;
+  // 마지막 entry가 최신 (rawSignalBuffer는 ring buffer로 append 순서 유지).
+  const latest = entries[entries.length - 1];
+  return latest.corrId ?? UNKNOWN_CORR_ID_BUCKET;
 }
 
 // ─── 메인 컴포넌트 ────────────────────────────────────────────────────────────
@@ -284,7 +309,7 @@ export interface OperationDashboardSectionProps {
  * 4 metric을 ratio bar로 표시.
  * Sub 3: 마운트 시 backend polling + Refresh 버튼 + metric 클릭 drill-down.
  */
-export function OperationDashboardSection({ logs }: OperationDashboardSectionProps) {
+export function OperationDashboardSection({ logs, onMetricClick }: OperationDashboardSectionProps) {
   const { colors } = useTheme();
   const responses = useTripGroundTruthStore((s) => s.responses);
   const [backendState, setBackendState] = useState<BackendLoadState>({ kind: 'idle' });
@@ -376,9 +401,17 @@ export function OperationDashboardSection({ logs }: OperationDashboardSectionPro
 
   const metrics: MetricData[] = [alarmAccuracy, silentPushReach, locklessMiss, boardableMiss, laPushDelivery];
 
-  const handleMetricPress = useCallback((key: DrillDownMetricKey) => {
-    setDrillDownKey((prev) => (prev === key ? null : key));
-  }, []);
+  const handleMetricPress = useCallback(
+    (key: DrillDownMetricKey) => {
+      // 기존 inline drill-down 토글 — backward-compat 보존.
+      setDrillDownKey((prev) => (prev === key ? null : key));
+      // #1956 — 부모 TripDetailModal 진입 신호. tripToken은 rawSignalBuffer 최신 entry corrId.
+      if (onMetricClick !== undefined) {
+        onMetricClick(key, pickLatestTripToken());
+      }
+    },
+    [onMetricClick],
+  );
 
   const handleDrillDownClose = useCallback(() => {
     setDrillDownKey(null);

--- a/src/features/debug/components/TripDetailModal.tsx
+++ b/src/features/debug/components/TripDetailModal.tsx
@@ -1,0 +1,346 @@
+/**
+ * TripDetailModal (#1956, S-m3-1 P0 / Epic #1503).
+ *
+ * Operation Dashboard 4 metric 차트를 클릭하면 진입하는 metric drill-down 상세 화면.
+ * 4 영역을 한 modal에서 표시:
+ *
+ *   1) Token       — 클릭된 trip의 corrId (또는 'unknown' 버킷)
+ *   2) Lifecycle   — 첫 entry ts / 마지막 entry ts / duration / kind별 카운트
+ *   3) Raw signal  — RawSignalEntry 최신순 최대 TRIP_DETAIL_RAW_SIGNAL_LIMIT(30)건
+ *   4) Deep link   — Sentry/R2 외부 검사 URL (env 미설정 시 행 숨김)
+ *
+ * 데이터 흐름:
+ *   onMetricClick(metric, value, ts)  → DebugModal owner state(selectedTripToken)
+ *   ↓
+ *   <TripDetailModal tripToken=... onClose=... />
+ *   ↓
+ *   useTripDetail(tripToken) — rawSignalBuffer subscribe + buildTripDetail
+ *   ↓
+ *   buildTripDetail(entries, tripToken) → TripDetail (4 영역 derived data)
+ *
+ * MetricDrillDownView(corrId 그룹 목록)와 별 채널 — drill-down 흐름은:
+ *   metric 클릭 → MetricDrillDownView(전체 corrId 목록) → 행 클릭 → TripDetailModal(단일 trip 상세)
+ * 본 PR은 4 metric 차트 클릭 → 즉시 TripDetailModal 진입(가장 최근 trip 또는 null fallback).
+ *
+ * Deep link 정책:
+ *   - EXPO_PUBLIC_SENTRY_DSN 미설정이면 Sentry 행 자체 미렌더 (사용자 혼란 방지)
+ *   - R2는 deep link URL 자체가 사후 결정(backend admin) — 본 PR은 외부 검사 진입점만 표시
+ */
+import { useCallback } from 'react';
+import {
+  Linking,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useTheme, spacing, radius, typography } from '../../../shared/theme';
+import { formatClockTimeWithSeconds } from '../../../shared/utils/formatTime';
+import { useTripDetail } from '../hooks/useTripDetail';
+import type { TripDetail } from '../utils/buildTripDetail';
+import type { RawSignalEntry } from '../../observability/utils/rawSignalBuffer';
+
+/** Sentry deep link base URL — DSN 미설정 시 null. */
+const SENTRY_DSN_ENV_VAR = 'EXPO_PUBLIC_SENTRY_DSN';
+
+/** kind 라벨 — kindCounts row 표시용. */
+const KIND_LABELS = ['cycle', 'enter', 'exit'] as const;
+
+/** trip token이 null 또는 매칭 0건일 때의 fallback 메시지. */
+const NO_TRIP_LABEL = '(no trip)';
+
+export interface TripDetailModalProps {
+  /** modal 표시 여부. tripToken=null이어도 visible=true면 fallback UI 노출. */
+  visible: boolean;
+  /** 표시할 trip의 corrId 또는 'unknown' 버킷. null이면 fallback UI. */
+  tripToken: string | null;
+  /** 닫기 — backdrop / 닫기 버튼 / OS back. */
+  onClose: () => void;
+}
+
+/**
+ * Sentry deep link URL을 환경변수에서 derive. DSN 미설정이면 null.
+ *
+ * Sentry web에서 trip lifecycle event를 corrId 기반 검색하기 위한 base URL. 본 PR은
+ * "Sentry 진입점만 노출" — corrId 기반 query는 사용자가 Sentry web에서 수동 입력한다
+ * (Sentry deep-link search API는 별도 PR scope).
+ */
+function resolveSentryUrl(): string | null {
+  const dsn = process.env[SENTRY_DSN_ENV_VAR];
+  if (dsn === undefined || dsn === '') return null;
+  // DSN은 https://<key>@<host>/<project> 형태. host에서 organization slug를 derive하기
+  // 어렵기 때문에 일반 Sentry web base URL을 반환한다. 사용자는 web에서 corrId 검색.
+  return 'https://sentry.io/';
+}
+
+/**
+ * Token 영역 — corrId 한 줄 + label.
+ * tripToken=null이면 caller가 fallback을 그리므로 본 컴포넌트는 호출되지 않는다.
+ */
+function TokenRow({
+  tripToken,
+  colors,
+}: {
+  tripToken: string;
+  colors: ReturnType<typeof useTheme>['colors'];
+}) {
+  return (
+    <View style={styles.section} testID="trip-detail-section-token">
+      <Text style={[typography.label, { color: colors.muted }]}>Token</Text>
+      <Text
+        style={[typography.mono, { color: colors.ink }]}
+        numberOfLines={1}
+        testID="trip-detail-token-value"
+      >
+        {tripToken}
+      </Text>
+    </View>
+  );
+}
+
+/**
+ * Lifecycle 영역 — first/last ts + duration + kind counts.
+ * kind counts는 KIND_LABELS 순회로 출력 — 새 kind 추가 시 KIND_LABELS만 갱신.
+ */
+function LifecycleRow({
+  detail,
+  colors,
+}: {
+  detail: TripDetail;
+  colors: ReturnType<typeof useTheme>['colors'];
+}) {
+  return (
+    <View style={styles.section} testID="trip-detail-section-lifecycle">
+      <Text style={[typography.label, { color: colors.muted }]}>Lifecycle</Text>
+      <View style={styles.kvRow}>
+        <Text style={[typography.mono, { color: colors.subtle }]}>first</Text>
+        <Text style={[typography.mono, { color: colors.ink }]}>
+          {formatClockTimeWithSeconds(detail.firstTs)}
+        </Text>
+      </View>
+      <View style={styles.kvRow}>
+        <Text style={[typography.mono, { color: colors.subtle }]}>last</Text>
+        <Text style={[typography.mono, { color: colors.ink }]}>
+          {formatClockTimeWithSeconds(detail.lastTs)}
+        </Text>
+      </View>
+      <View style={styles.kvRow}>
+        <Text style={[typography.mono, { color: colors.subtle }]}>duration</Text>
+        <Text style={[typography.mono, { color: colors.ink }]}>
+          {`${Math.round(detail.durationMs / 1000)}s`}
+        </Text>
+      </View>
+      {KIND_LABELS.map((kind) => (
+        <View key={kind} style={styles.kvRow} testID={`trip-detail-kind-${kind}`}>
+          <Text style={[typography.mono, { color: colors.subtle }]}>{kind}</Text>
+          <Text style={[typography.mono, { color: colors.ink }]}>
+            {detail.kindCounts[kind]}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+/** 단일 RawSignalEntry 한 줄 — time | kind | stationId | source/confidence. */
+function RawSignalEntryRow({
+  entry,
+  colors,
+}: {
+  entry: RawSignalEntry;
+  colors: ReturnType<typeof useTheme>['colors'];
+}) {
+  const stationId = entry.stationId ?? '-';
+  const source = entry.source ?? '-';
+  const confidence = entry.confidence ?? '-';
+  return (
+    <View style={styles.kvRow}>
+      <Text style={[typography.mono, { color: colors.muted }]}>
+        {formatClockTimeWithSeconds(entry.ts)}
+      </Text>
+      <Text style={[typography.mono, { color: colors.subtle }]}>{entry.kind}</Text>
+      <Text style={[typography.mono, { color: colors.ink, flex: 1, textAlign: 'right' }]} numberOfLines={1}>
+        {`${stationId} ${source}/${confidence}`}
+      </Text>
+    </View>
+  );
+}
+
+/**
+ * Raw signal 영역 — entries 최신순.
+ * buildTripDetail은 매칭 entries가 0건이면 null을 반환하므로 detail이 non-null이면
+ * entries는 항상 ≥1. 별도 empty 분기 없이 list만 렌더.
+ */
+function RawSignalSection({
+  detail,
+  colors,
+}: {
+  detail: TripDetail;
+  colors: ReturnType<typeof useTheme>['colors'];
+}) {
+  return (
+    <View style={styles.section} testID="trip-detail-section-raw-signal">
+      <Text style={[typography.label, { color: colors.muted }]}>Raw signal</Text>
+      <ScrollView style={styles.entriesScroll} testID="trip-detail-raw-signal-list">
+        {detail.entries.map((entry, idx) => (
+          <RawSignalEntryRow
+            key={`${entry.ts}-${idx}`}
+            entry={entry}
+            colors={colors}
+          />
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+/** Deep link 영역 — Sentry (DSN 설정 시) + raw signal share dump 안내. */
+function DeepLinkSection({
+  sentryUrl,
+  colors,
+  onOpenUrl,
+}: {
+  sentryUrl: string | null;
+  colors: ReturnType<typeof useTheme>['colors'];
+  onOpenUrl: (url: string) => void;
+}) {
+  return (
+    <View style={styles.section} testID="trip-detail-section-deep-link">
+      <Text style={[typography.label, { color: colors.muted }]}>Deep link</Text>
+      {sentryUrl !== null ? (
+        <Pressable
+          onPress={() => onOpenUrl(sentryUrl)}
+          testID="trip-detail-deep-link-sentry"
+        >
+          <Text style={[typography.bodySm, { color: colors.accent }]}>
+            View in Sentry
+          </Text>
+        </Pressable>
+      ) : (
+        <Text
+          style={[typography.mono, { color: colors.muted }]}
+          testID="trip-detail-deep-link-sentry-unconfigured"
+        >
+          (Sentry DSN 미설정)
+        </Text>
+      )}
+      <Text
+        style={[typography.bodySm, { color: colors.muted, marginTop: spacing.xs }]}
+      >
+        share dump → R2 (DebugModal 상단)
+      </Text>
+    </View>
+  );
+}
+
+/**
+ * TripDetailModal — 단일 trip의 4 영역 drill-down 상세 화면.
+ *
+ * tripToken=null 또는 매칭 entry 0건 → 4 영역 대신 NO_TRIP_LABEL 표시.
+ * onClose는 backdrop / 닫기 버튼 / OS back 3 경로에서 모두 호출 가능.
+ */
+export function TripDetailModal({ visible, tripToken, onClose }: TripDetailModalProps) {
+  const { colors } = useTheme();
+  const detail = useTripDetail(tripToken);
+  const sentryUrl = resolveSentryUrl();
+
+  const handleOpenUrl = useCallback((url: string) => {
+    void Linking.openURL(url);
+  }, []);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <Pressable
+        style={styles.backdrop}
+        onPress={onClose}
+        testID="trip-detail-backdrop"
+      >
+        <Pressable
+          style={[
+            styles.card,
+            { backgroundColor: colors.bg, borderColor: colors.hair },
+          ]}
+          // 카드 내부 탭이 backdrop으로 propagate되지 않도록 onPress no-op.
+          onPress={() => {}}
+          testID="trip-detail-card"
+        >
+          {/* 헤더 */}
+          <View style={styles.header}>
+            <Text style={[typography.label, { color: colors.ink, flex: 1 }]}>
+              Trip detail
+            </Text>
+            <Pressable onPress={onClose} testID="trip-detail-close">
+              <Text style={[typography.bodySm, { color: colors.accent, fontWeight: '700' }]}>
+                닫기
+              </Text>
+            </Pressable>
+          </View>
+
+          {detail === null ? (
+            <Text
+              style={[typography.mono, { color: colors.muted, marginTop: spacing.sm }]}
+              testID="trip-detail-empty"
+            >
+              {NO_TRIP_LABEL}
+            </Text>
+          ) : (
+            <>
+              <TokenRow tripToken={detail.tripToken} colors={colors} />
+              <LifecycleRow detail={detail} colors={colors} />
+              <RawSignalSection detail={detail} colors={colors} />
+              <DeepLinkSection
+                sentryUrl={sentryUrl}
+                colors={colors}
+                onOpenUrl={handleOpenUrl}
+              />
+            </>
+          )}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.md,
+  },
+  card: {
+    width: '100%',
+    maxWidth: 420,
+    maxHeight: '85%',
+    borderRadius: radius.md,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: spacing.md,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.xs,
+  },
+  section: {
+    marginTop: spacing.sm,
+  },
+  kvRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 2,
+  },
+  entriesScroll: {
+    maxHeight: 180,
+    marginTop: spacing.xs,
+  },
+});

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -4997,4 +4997,47 @@ describe('DebugModal — #1501 Raw Signal 섹션', () => {
       });
     });
   });
+
+  // ── #1956 — TripDetailModal wire ─────────────────────────────────────────────
+
+  describe('#1956 — Operation Dashboard metric → TripDetailModal', () => {
+    const { __resetRawSignalForTests__ } = jest.requireActual(
+      '../../../observability/utils/rawSignalBuffer',
+    );
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      __resetRawSignalForTests__();
+      setupHookDefaults();
+      jest.spyOn(AppState, 'addEventListener').mockReturnValue({
+        remove: jest.fn(),
+      } as unknown as ReturnType<typeof AppState.addEventListener>);
+    });
+
+    afterEach(() => {
+      __resetRawSignalForTests__();
+    });
+
+    it('metric 클릭 시 TripDetailModal이 열린다 (handleMetricClick)', async () => {
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      await act(async () => {
+        fireEvent.press(screen.getByTestId('operation-metric-alarmAccuracy'));
+      });
+      expect(screen.getByTestId('trip-detail-card')).toBeTruthy();
+    });
+
+    it('TripDetailModal 닫기 → modal 사라짐 (handleTripDetailClose)', async () => {
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      await act(async () => {
+        fireEvent.press(screen.getByTestId('operation-metric-alarmAccuracy'));
+      });
+      expect(screen.getByTestId('trip-detail-card')).toBeTruthy();
+      await act(async () => {
+        fireEvent.press(screen.getByTestId('trip-detail-close'));
+      });
+      expect(screen.queryByTestId('trip-detail-card')).toBeNull();
+    });
+  });
 });

--- a/src/features/debug/components/__tests__/OperationDashboardSection.test.tsx
+++ b/src/features/debug/components/__tests__/OperationDashboardSection.test.tsx
@@ -21,7 +21,11 @@ import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
 import { useTripGroundTruthStore, type TripGroundTruthState } from '../../store/useTripGroundTruthStore';
 import type { AlarmLogEntry } from '../../../alarm/utils/alarmLog';
 import * as observabilityClient from '../../../observability/api/observabilityMetricsClient';
-import { __resetRawSignalForTests__ } from '../../../observability/utils/rawSignalBuffer';
+import {
+  __resetRawSignalForTests__,
+  pushRawSignal,
+  type RawSignalEntry,
+} from '../../../observability/utils/rawSignalBuffer';
 
 // ─── mock ─────────────────────────────────────────────────────────────────────
 
@@ -446,6 +450,99 @@ describe('OperationDashboardSection', () => {
       await waitFor(() => {
         expect(screen.getByTestId('operation-metric-laPushDelivery')).toBeTruthy();
       });
+    });
+  });
+
+  // ── #1956 onMetricClick wire ─────────────────────────────────────────────────
+
+  describe('#1956 — onMetricClick wire', () => {
+    it('metric 클릭 시 onMetricClick prop이 호출된다', async () => {
+      const onMetricClick = jest.fn();
+      renderWithTheme(
+        <OperationDashboardSection logs={[]} onMetricClick={onMetricClick} />,
+      );
+      await act(async () => { jest.runAllTimers(); });
+      fireEvent.press(screen.getByTestId('operation-metric-alarmAccuracy'));
+      expect(onMetricClick).toHaveBeenCalledTimes(1);
+      expect(onMetricClick).toHaveBeenCalledWith('alarmAccuracy', expect.any(String));
+    });
+
+    it('onMetricClick 미전달 시 기존 inline drill-down 토글만 작동한다', async () => {
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      // crash 없이 토글 가능해야 함 (regression — prop 추가 후 기존 동작 보존)
+      fireEvent.press(screen.getByTestId('operation-metric-locklessMiss'));
+      expect(screen.getByTestId('metric-drilldown-view')).toBeTruthy();
+    });
+
+    it('rawSignal 없음 → tripToken="unknown" 전달', async () => {
+      const onMetricClick = jest.fn();
+      renderWithTheme(
+        <OperationDashboardSection logs={[]} onMetricClick={onMetricClick} />,
+      );
+      await act(async () => { jest.runAllTimers(); });
+      fireEvent.press(screen.getByTestId('operation-metric-silentPushReach'));
+      expect(onMetricClick).toHaveBeenCalledWith('silentPushReach', 'unknown');
+    });
+
+    it('rawSignal 최신 entry corrId 전달 (corrId 있음)', async () => {
+      const baseEntry: RawSignalEntry = {
+        ts: 1_000,
+        corrId: 'corr-recent',
+        kind: 'cycle',
+        gps: null,
+        motion: null,
+        accelPattern: null,
+        cellular: null,
+        subsurface: null,
+        arvlCd: null,
+        line: null,
+        dir: null,
+        arcIdx: null,
+        arcProgress: null,
+        stationId: null,
+        source: null,
+        confidence: null,
+      };
+      pushRawSignal(baseEntry);
+
+      const onMetricClick = jest.fn();
+      renderWithTheme(
+        <OperationDashboardSection logs={[]} onMetricClick={onMetricClick} />,
+      );
+      await act(async () => { jest.runAllTimers(); });
+      fireEvent.press(screen.getByTestId('operation-metric-locklessMiss'));
+      expect(onMetricClick).toHaveBeenCalledWith('locklessMiss', 'corr-recent');
+    });
+
+    it('rawSignal 최신 entry corrId=null → "unknown" 전달', async () => {
+      const baseEntry: RawSignalEntry = {
+        ts: 1_000,
+        corrId: null,
+        kind: 'cycle',
+        gps: null,
+        motion: null,
+        accelPattern: null,
+        cellular: null,
+        subsurface: null,
+        arvlCd: null,
+        line: null,
+        dir: null,
+        arcIdx: null,
+        arcProgress: null,
+        stationId: null,
+        source: null,
+        confidence: null,
+      };
+      pushRawSignal(baseEntry);
+
+      const onMetricClick = jest.fn();
+      renderWithTheme(
+        <OperationDashboardSection logs={[]} onMetricClick={onMetricClick} />,
+      );
+      await act(async () => { jest.runAllTimers(); });
+      fireEvent.press(screen.getByTestId('operation-metric-boardableMiss'));
+      expect(onMetricClick).toHaveBeenCalledWith('boardableMiss', 'unknown');
     });
   });
 });

--- a/src/features/debug/components/__tests__/TripDetailModal.test.tsx
+++ b/src/features/debug/components/__tests__/TripDetailModal.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * TripDetailModal (#1956, S-m3-1 P0) 단위 테스트.
+ *
+ * 커버 (4 영역):
+ *   - visible=false → modal 미렌더
+ *   - tripToken=null + visible=true → (no trip) fallback
+ *   - 정상 trip → Token / Lifecycle / Raw signal / Deep link 4 영역 렌더
+ *   - kindCounts 표시 정확성 (cycle/enter/exit)
+ *   - Raw signal entries 0건일 때 (no entries) 표시 (정상 token, entries 0건 케이스)
+ *   - 닫기 버튼 → onClose 호출
+ *   - backdrop 탭 → onClose 호출
+ *   - Sentry DSN 설정 → deep link 행 렌더 + 클릭 → Linking.openURL
+ *   - Sentry DSN 미설정 → unconfigured 라벨
+ */
+import { fireEvent, screen } from '@testing-library/react-native';
+import { Linking } from 'react-native';
+import { TripDetailModal } from '../TripDetailModal';
+import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
+import {
+  __resetRawSignalForTests__,
+  pushRawSignal,
+  type RawSignalEntry,
+} from '../../../observability/utils/rawSignalBuffer';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+jest.spyOn(Linking, 'openURL').mockResolvedValue(true);
+
+function makeEntry(overrides?: Partial<RawSignalEntry>): RawSignalEntry {
+  return {
+    ts: 1_700_000_000_000,
+    corrId: 'corr-abc',
+    kind: 'cycle',
+    gps: null,
+    motion: null,
+    accelPattern: null,
+    cellular: null,
+    subsurface: null,
+    arvlCd: null,
+    line: null,
+    dir: null,
+    arcIdx: null,
+    arcProgress: null,
+    stationId: null,
+    source: null,
+    confidence: null,
+    ...overrides,
+  };
+}
+
+const originalDsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  __resetRawSignalForTests__();
+  delete process.env.EXPO_PUBLIC_SENTRY_DSN;
+  (Linking.openURL as jest.Mock).mockClear();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  if (originalDsn !== undefined) {
+    process.env.EXPO_PUBLIC_SENTRY_DSN = originalDsn;
+  }
+});
+
+describe('TripDetailModal', () => {
+  it('renders nothing when visible=false', () => {
+    renderWithTheme(
+      <TripDetailModal visible={false} tripToken="corr-1" onClose={jest.fn()} />,
+    );
+    expect(screen.queryByTestId('trip-detail-card')).toBeNull();
+  });
+
+  describe('fallback (no trip)', () => {
+    it('shows fallback when tripToken=null', () => {
+      renderWithTheme(
+        <TripDetailModal visible tripToken={null} onClose={jest.fn()} />,
+      );
+      expect(screen.getByTestId('trip-detail-empty')).toBeTruthy();
+    });
+
+    it('shows fallback when tripToken does not match any entry', () => {
+      renderWithTheme(
+        <TripDetailModal visible tripToken="corr-missing" onClose={jest.fn()} />,
+      );
+      expect(screen.getByTestId('trip-detail-empty')).toBeTruthy();
+    });
+  });
+
+  describe('full render — 4 sections', () => {
+    beforeEach(() => {
+      pushRawSignal(makeEntry({ corrId: 'corr-1', ts: 1_000, kind: 'enter' }));
+      pushRawSignal(makeEntry({ corrId: 'corr-1', ts: 2_000, kind: 'cycle' }));
+      pushRawSignal(makeEntry({ corrId: 'corr-1', ts: 3_000, kind: 'exit' }));
+    });
+
+    it('renders Token section with tripToken value', () => {
+      renderWithTheme(
+        <TripDetailModal visible tripToken="corr-1" onClose={jest.fn()} />,
+      );
+      expect(screen.getByTestId('trip-detail-section-token')).toBeTruthy();
+      expect(screen.getByTestId('trip-detail-token-value').props.children).toBe('corr-1');
+    });
+
+    it('renders Lifecycle section with kind counts', () => {
+      renderWithTheme(
+        <TripDetailModal visible tripToken="corr-1" onClose={jest.fn()} />,
+      );
+      expect(screen.getByTestId('trip-detail-section-lifecycle')).toBeTruthy();
+      expect(screen.getByTestId('trip-detail-kind-cycle')).toBeTruthy();
+      expect(screen.getByTestId('trip-detail-kind-enter')).toBeTruthy();
+      expect(screen.getByTestId('trip-detail-kind-exit')).toBeTruthy();
+    });
+
+    it('renders Raw signal section with the entry list', () => {
+      renderWithTheme(
+        <TripDetailModal visible tripToken="corr-1" onClose={jest.fn()} />,
+      );
+      expect(screen.getByTestId('trip-detail-section-raw-signal')).toBeTruthy();
+      expect(screen.getByTestId('trip-detail-raw-signal-list')).toBeTruthy();
+    });
+
+    it('renders Deep link section', () => {
+      renderWithTheme(
+        <TripDetailModal visible tripToken="corr-1" onClose={jest.fn()} />,
+      );
+      expect(screen.getByTestId('trip-detail-section-deep-link')).toBeTruthy();
+    });
+  });
+
+  describe('close interactions', () => {
+    beforeEach(() => {
+      pushRawSignal(makeEntry({ corrId: 'corr-1', ts: 1_000 }));
+    });
+
+    it('calls onClose when 닫기 button is pressed', () => {
+      const onClose = jest.fn();
+      renderWithTheme(
+        <TripDetailModal visible tripToken="corr-1" onClose={onClose} />,
+      );
+      fireEvent.press(screen.getByTestId('trip-detail-close'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when backdrop is pressed', () => {
+      const onClose = jest.fn();
+      renderWithTheme(
+        <TripDetailModal visible tripToken="corr-1" onClose={onClose} />,
+      );
+      fireEvent.press(screen.getByTestId('trip-detail-backdrop'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT call onClose when card body is pressed (propagation guard)', () => {
+      const onClose = jest.fn();
+      renderWithTheme(
+        <TripDetailModal visible tripToken="corr-1" onClose={onClose} />,
+      );
+      fireEvent.press(screen.getByTestId('trip-detail-card'));
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deep link — Sentry', () => {
+    beforeEach(() => {
+      pushRawSignal(makeEntry({ corrId: 'corr-1', ts: 1_000 }));
+    });
+
+    it('shows unconfigured label when EXPO_PUBLIC_SENTRY_DSN is unset', () => {
+      renderWithTheme(
+        <TripDetailModal visible tripToken="corr-1" onClose={jest.fn()} />,
+      );
+      expect(screen.getByTestId('trip-detail-deep-link-sentry-unconfigured')).toBeTruthy();
+    });
+
+    it('shows pressable link when EXPO_PUBLIC_SENTRY_DSN is set', () => {
+      process.env.EXPO_PUBLIC_SENTRY_DSN = 'https://abc@sentry.io/123';
+      renderWithTheme(
+        <TripDetailModal visible tripToken="corr-1" onClose={jest.fn()} />,
+      );
+      expect(screen.getByTestId('trip-detail-deep-link-sentry')).toBeTruthy();
+    });
+
+    it('opens Sentry URL when pressed', () => {
+      process.env.EXPO_PUBLIC_SENTRY_DSN = 'https://abc@sentry.io/123';
+      renderWithTheme(
+        <TripDetailModal visible tripToken="corr-1" onClose={jest.fn()} />,
+      );
+      fireEvent.press(screen.getByTestId('trip-detail-deep-link-sentry'));
+      expect(Linking.openURL).toHaveBeenCalledWith('https://sentry.io/');
+    });
+  });
+});

--- a/src/features/debug/hooks/__tests__/useTripDetail.test.ts
+++ b/src/features/debug/hooks/__tests__/useTripDetail.test.ts
@@ -1,0 +1,111 @@
+/**
+ * useTripDetail (#1956, S-m3-1 P0) 단위 테스트.
+ *
+ * 커버:
+ *   - tripToken=null → null
+ *   - rawSignalBuffer empty → null
+ *   - tripToken 변경 → snapshot 재계산
+ *   - pushRawSignal 호출 → subscribe 콜백 → re-render
+ *   - unmount → unsubscribe (이후 push가 setState 호출 안 함)
+ */
+import { act, renderHook } from '@testing-library/react-native';
+import { useTripDetail } from '../useTripDetail';
+import {
+  __resetRawSignalForTests__,
+  pushRawSignal,
+  type RawSignalEntry,
+} from '../../../observability/utils/rawSignalBuffer';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+function makeEntry(overrides?: Partial<RawSignalEntry>): RawSignalEntry {
+  return {
+    ts: 1_700_000_000_000,
+    corrId: 'corr-abc',
+    kind: 'cycle',
+    gps: null,
+    motion: null,
+    accelPattern: null,
+    cellular: null,
+    subsurface: null,
+    arvlCd: null,
+    line: null,
+    dir: null,
+    arcIdx: null,
+    arcProgress: null,
+    stationId: null,
+    source: null,
+    confidence: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  __resetRawSignalForTests__();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('useTripDetail', () => {
+  it('returns null when tripToken is null', () => {
+    pushRawSignal(makeEntry({ corrId: 'corr-1' }));
+    const { result } = renderHook(() => useTripDetail(null));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when rawSignalBuffer is empty', () => {
+    const { result } = renderHook(() => useTripDetail('corr-1'));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns a snapshot when tripToken matches existing entries', () => {
+    pushRawSignal(makeEntry({ corrId: 'corr-1', ts: 1_000 }));
+    pushRawSignal(makeEntry({ corrId: 'corr-1', ts: 2_000 }));
+    const { result } = renderHook(() => useTripDetail('corr-1'));
+    expect(result.current).not.toBeNull();
+    expect(result.current?.tripToken).toBe('corr-1');
+    expect(result.current?.entries).toHaveLength(2);
+  });
+
+  it('recomputes when tripToken changes', () => {
+    pushRawSignal(makeEntry({ corrId: 'corr-1', ts: 1_000 }));
+    pushRawSignal(makeEntry({ corrId: 'corr-2', ts: 2_000 }));
+    const { result, rerender } = renderHook(
+      ({ token }: { token: string | null }) => useTripDetail(token),
+      { initialProps: { token: 'corr-1' } },
+    );
+    expect(result.current?.tripToken).toBe('corr-1');
+    rerender({ token: 'corr-2' });
+    expect(result.current?.tripToken).toBe('corr-2');
+  });
+
+  it('re-renders when rawSignalBuffer pushes a new entry for the same token', () => {
+    pushRawSignal(makeEntry({ corrId: 'corr-1', ts: 1_000 }));
+    const { result } = renderHook(() => useTripDetail('corr-1'));
+    expect(result.current?.entries).toHaveLength(1);
+
+    act(() => {
+      pushRawSignal(makeEntry({ corrId: 'corr-1', ts: 2_000 }));
+    });
+    expect(result.current?.entries).toHaveLength(2);
+  });
+
+  it('unsubscribes on unmount (no further updates)', () => {
+    pushRawSignal(makeEntry({ corrId: 'corr-1', ts: 1_000 }));
+    const { result, unmount } = renderHook(() => useTripDetail('corr-1'));
+    expect(result.current?.entries).toHaveLength(1);
+
+    unmount();
+    // 언마운트 후 push는 result에 영향을 주지 않아야 함 — error 없이 끝나면 OK
+    act(() => {
+      pushRawSignal(makeEntry({ corrId: 'corr-1', ts: 2_000 }));
+    });
+    // 마지막 snapshot은 unmount 시점 — 갱신 안 됨
+    expect(result.current?.entries).toHaveLength(1);
+  });
+});

--- a/src/features/debug/hooks/useTripDetail.ts
+++ b/src/features/debug/hooks/useTripDetail.ts
@@ -1,0 +1,42 @@
+/**
+ * #1956 (S-m3-1, Epic #1503) — TripDetailModal 데이터 조회 hook.
+ *
+ * tripToken을 받아 rawSignalBuffer SSOT에서 매칭 entries를 추출하고 buildTripDetail로
+ * derived data를 만들어 반환한다. 매 rawSignalBuffer 변경 시 자동 re-render(subscribe).
+ *
+ * Wire:
+ *   - tripToken=null → detail=null. caller(TripDetailModal)가 빈 본문 렌더 책임.
+ *   - 매칭 entries 0건 → detail=null. 사용자가 modal을 열었을 때 "(no entries)" 표시.
+ *
+ * Re-render 정책 (rawSignalBuffer subscribe):
+ *   매 push마다 store가 deps 변경 신호를 보내고, hook은 다시 buildTripDetail을 실행해
+ *   최신 snapshot을 반환한다. fusion cycle(30s)마다 1회 push이므로 비용은 무시할 만함.
+ */
+import { useEffect, useState } from 'react';
+import {
+  getRawSignalEntries,
+  subscribeRawSignal,
+} from '../../observability/utils/rawSignalBuffer';
+import { buildTripDetail, type TripDetail } from '../utils/buildTripDetail';
+
+/**
+ * tripToken과 매칭되는 trip detail snapshot을 반환.
+ * rawSignalBuffer 변경 시 자동 갱신.
+ */
+export function useTripDetail(tripToken: string | null): TripDetail | null {
+  const [detail, setDetail] = useState<TripDetail | null>(() =>
+    buildTripDetail(getRawSignalEntries(), tripToken),
+  );
+
+  useEffect(() => {
+    // tripToken 변경 시 즉시 재계산.
+    setDetail(buildTripDetail(getRawSignalEntries(), tripToken));
+
+    const unsubscribe = subscribeRawSignal(() => {
+      setDetail(buildTripDetail(getRawSignalEntries(), tripToken));
+    });
+    return unsubscribe;
+  }, [tripToken]);
+
+  return detail;
+}

--- a/src/features/debug/utils/__tests__/buildTripDetail.test.ts
+++ b/src/features/debug/utils/__tests__/buildTripDetail.test.ts
@@ -1,0 +1,146 @@
+/**
+ * buildTripDetail (#1956, S-m3-1 P0) 단위 테스트.
+ *
+ * 커버:
+ *   - tripToken=null → null
+ *   - 매칭 entries 0건 → null
+ *   - tripToken='unknown' → corrId=null entries만 그룹화
+ *   - 매칭 entries 1+건 → firstTs/lastTs/duration/kindCounts 정확 산출
+ *   - entries 정렬 — 최신순(ts 내림차순)
+ *   - DISPLAY_LIMIT 적용 — TRIP_DETAIL_RAW_SIGNAL_LIMIT 초과 시 truncate
+ */
+import {
+  buildTripDetail,
+  TRIP_DETAIL_RAW_SIGNAL_LIMIT,
+  UNKNOWN_CORR_ID_BUCKET,
+} from '../buildTripDetail';
+import type { RawSignalEntry, RawSignalKind } from '../../../observability/utils/rawSignalBuffer';
+
+function makeEntry(overrides?: Partial<RawSignalEntry>): RawSignalEntry {
+  return {
+    ts: 1_700_000_000_000,
+    corrId: 'corr-abc',
+    kind: 'cycle',
+    gps: null,
+    motion: null,
+    accelPattern: null,
+    cellular: null,
+    subsurface: null,
+    arvlCd: null,
+    line: null,
+    dir: null,
+    arcIdx: null,
+    arcProgress: null,
+    stationId: null,
+    source: null,
+    confidence: null,
+    ...overrides,
+  };
+}
+
+describe('buildTripDetail', () => {
+  it('returns null when tripToken is null', () => {
+    expect(buildTripDetail([makeEntry()], null)).toBeNull();
+  });
+
+  it('returns null when no entries match the tripToken', () => {
+    const entries = [makeEntry({ corrId: 'corr-1' })];
+    expect(buildTripDetail(entries, 'corr-other')).toBeNull();
+  });
+
+  it('returns null when entries array is empty', () => {
+    expect(buildTripDetail([], 'corr-abc')).toBeNull();
+  });
+
+  describe('tripToken=unknown', () => {
+    it('groups entries whose corrId is null', () => {
+      const entries = [
+        makeEntry({ corrId: null, ts: 1_000 }),
+        makeEntry({ corrId: 'corr-1', ts: 2_000 }),
+        makeEntry({ corrId: null, ts: 3_000 }),
+      ];
+      const detail = buildTripDetail(entries, UNKNOWN_CORR_ID_BUCKET);
+      expect(detail).not.toBeNull();
+      expect(detail?.tripToken).toBe(UNKNOWN_CORR_ID_BUCKET);
+      expect(detail?.entries).toHaveLength(2);
+    });
+
+    it('returns null if no corrId=null entries exist', () => {
+      const entries = [makeEntry({ corrId: 'corr-1' })];
+      expect(buildTripDetail(entries, UNKNOWN_CORR_ID_BUCKET)).toBeNull();
+    });
+  });
+
+  describe('happy path', () => {
+    it('computes firstTs/lastTs/durationMs correctly', () => {
+      const entries = [
+        makeEntry({ corrId: 'corr-1', ts: 2_000 }),
+        makeEntry({ corrId: 'corr-1', ts: 1_000 }),
+        makeEntry({ corrId: 'corr-1', ts: 3_000 }),
+      ];
+      const detail = buildTripDetail(entries, 'corr-1');
+      expect(detail?.firstTs).toBe(1_000);
+      expect(detail?.lastTs).toBe(3_000);
+      expect(detail?.durationMs).toBe(2_000);
+    });
+
+    it('counts entries by kind correctly', () => {
+      const kinds: RawSignalKind[] = ['cycle', 'enter', 'exit', 'cycle'];
+      const entries = kinds.map((k, i) =>
+        makeEntry({ corrId: 'corr-1', ts: i * 1_000, kind: k }),
+      );
+      const detail = buildTripDetail(entries, 'corr-1');
+      expect(detail?.kindCounts).toEqual({ cycle: 2, enter: 1, exit: 1 });
+    });
+
+    it('sorts entries newest-first (ts descending)', () => {
+      const entries = [
+        makeEntry({ corrId: 'corr-1', ts: 1_000 }),
+        makeEntry({ corrId: 'corr-1', ts: 3_000 }),
+        makeEntry({ corrId: 'corr-1', ts: 2_000 }),
+      ];
+      const detail = buildTripDetail(entries, 'corr-1');
+      const timestamps = detail?.entries.map((e) => e.ts) ?? [];
+      expect(timestamps).toEqual([3_000, 2_000, 1_000]);
+    });
+
+    it('filters entries to only the matching tripToken', () => {
+      const entries = [
+        makeEntry({ corrId: 'corr-1', ts: 1_000 }),
+        makeEntry({ corrId: 'corr-2', ts: 2_000 }),
+        makeEntry({ corrId: 'corr-1', ts: 3_000 }),
+      ];
+      const detail = buildTripDetail(entries, 'corr-1');
+      expect(detail?.entries).toHaveLength(2);
+      detail?.entries.forEach((e) => expect(e.corrId).toBe('corr-1'));
+    });
+
+    it('preserves tripToken in the result', () => {
+      const entries = [makeEntry({ corrId: 'corr-xyz' })];
+      const detail = buildTripDetail(entries, 'corr-xyz');
+      expect(detail?.tripToken).toBe('corr-xyz');
+    });
+  });
+
+  describe('DISPLAY_LIMIT', () => {
+    it('truncates entries when count exceeds TRIP_DETAIL_RAW_SIGNAL_LIMIT', () => {
+      const overflowCount = TRIP_DETAIL_RAW_SIGNAL_LIMIT + 5;
+      const entries = Array.from({ length: overflowCount }, (_, i) =>
+        makeEntry({ corrId: 'corr-big', ts: i * 1_000 }),
+      );
+      const detail = buildTripDetail(entries, 'corr-big');
+      expect(detail?.entries).toHaveLength(TRIP_DETAIL_RAW_SIGNAL_LIMIT);
+    });
+
+    it('keeps the most recent entries after truncation', () => {
+      const overflowCount = TRIP_DETAIL_RAW_SIGNAL_LIMIT + 5;
+      const entries = Array.from({ length: overflowCount }, (_, i) =>
+        makeEntry({ corrId: 'corr-big', ts: i * 1_000 }),
+      );
+      const detail = buildTripDetail(entries, 'corr-big');
+      // 가장 최신(ts=max)이 첫 번째에 있어야 함
+      const expectedNewest = (overflowCount - 1) * 1_000;
+      expect(detail?.entries[0].ts).toBe(expectedNewest);
+    });
+  });
+});

--- a/src/features/debug/utils/buildTripDetail.ts
+++ b/src/features/debug/utils/buildTripDetail.ts
@@ -1,0 +1,111 @@
+/**
+ * #1956 (S-m3-1, Epic #1503) — TripDetailModal 데이터 변환 helper.
+ *
+ * Operation Dashboard 4 metric 차트 클릭 시 진입하는 TripDetailModal은 4 영역을 표시:
+ *   1) token   — 클릭된 trip의 corrId (또는 'unknown' 버킷)
+ *   2) timeline — trip lifecycle 시작/종료 + enter/exit/cycle 카운트
+ *   3) rawSignal — 해당 corrId의 RawSignalEntry 시간순 목록 (DISPLAY_LIMIT 적용)
+ *   4) deepLink  — Sentry/R2 사후 검사용 외부 URL (DSN 미설정 시 null)
+ *
+ * 본 helper는 입력 entries + tripToken을 받아 위 4 영역에 필요한 derived data를
+ * 즉시 사용 가능한 형태로 변환한다. View는 결과 객체의 필드를 그대로 렌더하면 된다.
+ *
+ * Wire 정합성:
+ *   - tripToken=null 또는 매칭 entry 0건 → null 반환 (caller가 fallback 화면 렌더)
+ *   - corrId=null 항목은 'unknown' 버킷으로 그룹화 (MetricDrillDownView와 동일 컨벤션)
+ *
+ * 순수 함수 — AsyncStorage / fetch / Date.now() 호출 없음. 모든 시각은 entry.ts에서 derive.
+ */
+import type { RawSignalEntry, RawSignalKind } from '../../observability/utils/rawSignalBuffer';
+
+/** corrId=null 항목이 그룹화되는 단일 버킷 이름. MetricDrillDownView와 공유. */
+export const UNKNOWN_CORR_ID_BUCKET = 'unknown';
+
+/** rawSignal 영역에 표시할 최대 entry 수. UI 스크롤 부담 + dump 분량 균형. */
+export const TRIP_DETAIL_RAW_SIGNAL_LIMIT = 30;
+
+/** RawSignalKind별 카운트 합계. lifecycle timeline에 cycle/enter/exit 빈도 표시. */
+export type RawSignalKindCounts = Record<RawSignalKind, number>;
+
+/**
+ * TripDetailModal에 전달할 변환된 trip 상세 데이터.
+ * tripToken과 매칭되는 entries가 0건이면 null이 반환되므로 객체 존재 자체가
+ * "최소 1건의 raw signal entry 존재"를 의미한다.
+ */
+export interface TripDetail {
+  /** corrId (예: `corr-abc123`) 또는 'unknown' 버킷. */
+  tripToken: string;
+  /** lifecycle: 첫 entry ts (epoch ms). */
+  firstTs: number;
+  /** lifecycle: 마지막 entry ts (epoch ms). */
+  lastTs: number;
+  /** lifecycle: 총 누적 시간 (lastTs - firstTs). */
+  durationMs: number;
+  /** lifecycle: kind별 entry 카운트 (cycle/enter/exit). */
+  kindCounts: RawSignalKindCounts;
+  /** rawSignal 영역에 표시할 entry 목록 — 최신순(lastTs 내림차순), 최대 TRIP_DETAIL_RAW_SIGNAL_LIMIT. */
+  entries: readonly RawSignalEntry[];
+}
+
+/**
+ * tripToken과 매칭되는 RawSignalEntry를 필터링.
+ * tripToken === UNKNOWN_CORR_ID_BUCKET이면 corrId=null entries만 반환.
+ * 그 외에는 corrId === tripToken인 entries만 반환.
+ */
+function filterEntriesByToken(
+  entries: readonly RawSignalEntry[],
+  tripToken: string,
+): readonly RawSignalEntry[] {
+  if (tripToken === UNKNOWN_CORR_ID_BUCKET) {
+    return entries.filter((e) => e.corrId === null);
+  }
+  return entries.filter((e) => e.corrId === tripToken);
+}
+
+/** kind별 카운트 집계 — 0 초기값에서 누적. */
+function countByKind(entries: readonly RawSignalEntry[]): RawSignalKindCounts {
+  const counts: RawSignalKindCounts = { cycle: 0, enter: 0, exit: 0 };
+  for (const entry of entries) {
+    counts[entry.kind] += 1;
+  }
+  return counts;
+}
+
+/**
+ * 주어진 tripToken에 대한 TripDetail snapshot을 빌드.
+ *
+ * 입력:
+ *   - entries: rawSignalBuffer 전체 snapshot (또는 caller가 제공한 subset)
+ *   - tripToken: corrId 문자열 또는 'unknown' 버킷
+ *
+ * 반환:
+ *   - 매칭 entries 0건 → null (caller가 빈 화면 fallback)
+ *   - 1건 이상 → TripDetail (entries는 최신순 + DISPLAY_LIMIT 적용)
+ */
+export function buildTripDetail(
+  entries: readonly RawSignalEntry[],
+  tripToken: string | null,
+): TripDetail | null {
+  if (tripToken === null) return null;
+
+  const matched = filterEntriesByToken(entries, tripToken);
+  if (matched.length === 0) return null;
+
+  const timestamps = matched.map((e) => e.ts);
+  const firstTs = Math.min(...timestamps);
+  const lastTs = Math.max(...timestamps);
+  const kindCounts = countByKind(matched);
+
+  // 최신순 정렬 + display limit
+  const sorted = [...matched].sort((a, b) => b.ts - a.ts);
+  const limited = sorted.slice(0, TRIP_DETAIL_RAW_SIGNAL_LIMIT);
+
+  return {
+    tripToken,
+    firstTs,
+    lastTs,
+    durationMs: lastTs - firstTs,
+    kindCounts,
+    entries: limited,
+  };
+}


### PR DESCRIPTION
## Summary
- TripDetailModal 신규 (token / lifecycle timeline / raw signal / deep link 4 영역)
- OperationDashboard `onMetricClick` prop wire — 4 metric 차트 각 클릭 → TripDetailModal 진입
- `useTripDetail` hook + `buildTripDetail` helper (순수 함수)
- DebugModal: `tripDetailToken` state + `handleMetricClick` / `handleTripDetailClose` 와이어

Closes #1956 (#1503 acceptance 잔여 — BG13 plan S-m3-1 P0)

## Files
- 신규: `src/features/debug/components/TripDetailModal.tsx`
- 신규: `src/features/debug/hooks/useTripDetail.ts`
- 신규: `src/features/debug/utils/buildTripDetail.ts`
- 수정: `src/features/debug/components/OperationDashboardSection.tsx` (`onMetricClick` prop 추가, optional)
- 수정: `src/features/debug/components/DebugModal.tsx` (TripDetailModal 마운트)
- 테스트 4종 (helper / hook / modal / wire 회귀)

## Wire-completion 5단 체크
1. **Orphan 없음** — `npm run lint:orphan` pass (`No orphan exports detected.`)
2. **V/X dashboard** — DebugModal Operation Dashboard 4 metric → metric 클릭 → TripDetailModal 진입 + 4 영역 표시 (token / lifecycle / raw signal / deep link)
3. **의존 PR** — #1754 / #1759 / #1766 (M3 sub) + #1955 (boardable miss) 모두 머지됨
4. **측정 plan** — drill-down 진입 빈도(1주 사용 카운트) + 회귀 감지 평균 시간 < 30분 검증 (1주 운영 후 Sentry / share dump trip token 사후 추적)
5. **Device verify** — 실기기 trip 1회 + 4 metric 차트 각 클릭 → TripDetailModal 4 영역 정합 확인 + Sentry 외부 link open 검증

## Known trade-offs (issue 본문에 명시된 scope)
- `pickLatestTripToken`은 클릭된 metric에 가장 최근의 rawSignal entry corrId를 사용한다. metric별 trip resolution은 backend join이 필요해 본 PR scope 초과 — 이슈 본문의 "본 PR은 4 metric 차트 클릭 → 즉시 TripDetailModal 진입(가장 최근 trip 또는 null fallback)" 명시.
- Sentry deep link는 `EXPO_PUBLIC_SENTRY_DSN` 설정 시 `https://sentry.io/` base URL을 연다 — corrId 기반 search query는 사용자가 web에서 수동 입력. (Sentry deep-link search API 통합은 별도 PR scope.)
- cold-launch 직후 rawSignalBuffer hydrate된 stale corrId가 token으로 선택될 수 있음 — TripDetailModal이 그대로 표시. 사용자가 진단 도구를 자발적으로 여는 컨텍스트라 허용.

## Test plan
- [x] `npm test` 커버리지 100% (전체 8653 tests pass)
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass
- [x] code-review high effort — 0 P1 finding (known trade-offs 모두 본문/코드 주석에 명시)