### PR TITLE
feat(#1958): Silent push 도달률 metric — corrId join sent vs received (#1503 잔여 2/3)

### DIFF
--- a/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
+++ b/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
@@ -61,6 +61,7 @@ describe('storeObservabilityMetrics + readObservabilityMetrics', () => {
       },
       silentPushLatency: null,
       laPushDeliveryRatio: { sent: 10, failed: 2, ratio: 10 / 12 },
+      silentPushReachRatio: { sent: 0, received: 0, joined: 0, ratio: 0 },
       window: '24h' as const,
       timestamp: NOW,
     };
@@ -98,6 +99,7 @@ describe('storeObservabilityMetrics + readObservabilityMetrics', () => {
       },
       silentPushLatency: null,
       laPushDeliveryRatio: { sent: 0, failed: 0, ratio: 0 },
+      silentPushReachRatio: { sent: 0, received: 0, joined: 0, ratio: 0 },
       window: '24h' as const,
       timestamp: NOW,
     };
@@ -264,6 +266,85 @@ describe('computeObservabilityMetrics — silentPushDeliveryRatio', () => {
     const r2 = makeEmptyFakeR2();
     const result = await computeObservabilityMetrics(r2, kv as unknown as KVNamespace, NOW);
     expect(result.silentPushDeliveryRatio).toEqual({ value: 0, total: 0, ratio: 0 });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// computeObservabilityMetrics — silentPushReachRatio (#1958)
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('computeObservabilityMetrics — silentPushReachRatio (#1958)', () => {
+  it('undefined pendingPushesKv → graceful placeholder (0/0/0)', async () => {
+    const r2 = makeEmptyFakeR2();
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    expect(result.silentPushReachRatio).toEqual({ sent: 0, received: 0, joined: 0, ratio: 0 });
+  });
+
+  it('5min 윈도우 안 sent 3건 / received 2건 → joined=2 ratio=2/3', async () => {
+    const kv = new InMemoryKV();
+    // 5min 윈도우 안 sent stamps (corrId = pushId)
+    kv.store.set('sent:p1', {
+      value: JSON.stringify({ pushId: 'p1', sentAt: NOW - 60_000 }),
+    });
+    kv.store.set('sent:p2', {
+      value: JSON.stringify({ pushId: 'p2', sentAt: NOW - 90_000 }),
+    });
+    kv.store.set('sent:p3', {
+      value: JSON.stringify({ pushId: 'p3', sentAt: NOW - 120_000 }),
+    });
+    // received stamps — p1, p2 만 ack 도착
+    kv.store.set('received:p1', {
+      value: JSON.stringify({
+        pushId: 'p1',
+        receivedAt: NOW - 50_000,
+        stationName: 'A',
+        phase: 'imminent',
+      }),
+    });
+    kv.store.set('received:p2', {
+      value: JSON.stringify({
+        pushId: 'p2',
+        receivedAt: NOW - 80_000,
+        stationName: 'B',
+        phase: 'imminent',
+      }),
+    });
+    const r2 = makeEmptyFakeR2();
+    const result = await computeObservabilityMetrics(r2, kv as unknown as KVNamespace, NOW);
+    expect(result.silentPushReachRatio.sent).toBe(3);
+    expect(result.silentPushReachRatio.received).toBe(2);
+    expect(result.silentPushReachRatio.joined).toBe(2);
+    expect(result.silentPushReachRatio.ratio).toBeCloseTo(2 / 3);
+  });
+
+  it('5min 윈도우 밖 sent → 분모에서 제외', async () => {
+    const kv = new InMemoryKV();
+    // 10min 전 sent — 윈도우 밖
+    kv.store.set('sent:old', {
+      value: JSON.stringify({ pushId: 'old', sentAt: NOW - 10 * 60_000 }),
+    });
+    const r2 = makeEmptyFakeR2();
+    const result = await computeObservabilityMetrics(r2, kv as unknown as KVNamespace, NOW);
+    expect(result.silentPushReachRatio.sent).toBe(0);
+    expect(result.silentPushReachRatio.ratio).toBe(0);
+  });
+
+  it('sent 없이 received만 있는 case (legacy / 누락) → 분자 제외 ratio=0', async () => {
+    const kv = new InMemoryKV();
+    kv.store.set('received:orphan', {
+      value: JSON.stringify({
+        pushId: 'orphan',
+        receivedAt: NOW - 30_000,
+        stationName: 'C',
+        phase: 'imminent',
+      }),
+    });
+    const r2 = makeEmptyFakeR2();
+    const result = await computeObservabilityMetrics(r2, kv as unknown as KVNamespace, NOW);
+    expect(result.silentPushReachRatio.sent).toBe(0);
+    expect(result.silentPushReachRatio.received).toBe(0);
+    expect(result.silentPushReachRatio.joined).toBe(0);
+    expect(result.silentPushReachRatio.ratio).toBe(0);
   });
 });
 
@@ -531,6 +612,7 @@ const SAMPLE_METRICS = {
   },
   silentPushLatency: null,
   laPushDeliveryRatio: { sent: 0, failed: 0, ratio: 0 },
+  silentPushReachRatio: { sent: 0, received: 0, joined: 0, ratio: 0 },
   window: '24h' as const,
   timestamp: NOW,
 };

--- a/backend/alarm-worker/src/__tests__/pendingPushes.test.ts
+++ b/backend/alarm-worker/src/__tests__/pendingPushes.test.ts
@@ -67,6 +67,20 @@ describe('pendingPushes (#566 P2a)', () => {
     it('kv === undefined면 graceful no-op (throw 없음)', async () => {
       await expect(putPending(undefined, makeEntry())).resolves.toBeUndefined();
     });
+
+    it('#1958 — pending: 적재와 동시에 sent:<pushId> stamp 도 적재 (5min TTL)', async () => {
+      const entry = makeEntry({ pushId: 'p-reach', sentAt: 1_700_000_000_000 });
+      await putPending(kv as unknown as KVNamespace, entry);
+      const sentRaw = kv.store.get('sent:p-reach');
+      expect(sentRaw).toBeDefined();
+      const parsed = JSON.parse(sentRaw!.value) as { pushId: string; sentAt: number };
+      expect(parsed.pushId).toBe('p-reach');
+      expect(parsed.sentAt).toBe(1_700_000_000_000);
+      // TTL이 5 * 60s 안쪽 (pending의 120s 보다 김)
+      const ttlMs = sentRaw!.expiresAt! - Date.now();
+      expect(ttlMs).toBeGreaterThan(4 * 60 * 1000);
+      expect(ttlMs).toBeLessThanOrEqual(5 * 60 * 1000);
+    });
   });
 
   describe('getPending', () => {

--- a/backend/alarm-worker/src/__tests__/silentPushReachMetric.test.ts
+++ b/backend/alarm-worker/src/__tests__/silentPushReachMetric.test.ts
@@ -1,0 +1,214 @@
+/**
+ * silentPushReachMetric.test.ts — #1958 silent push 5min 윈도우 corrId join 단위 테스트.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { InMemoryKV } from './inMemoryKv';
+import {
+  SENT_TTL_SEC,
+  SILENT_PUSH_REACH_WINDOW_MS,
+  computeSilentPushReachRatio,
+  sentKey,
+  stampSent,
+} from '../silentPushReachMetric';
+
+const NOW = 1_700_000_000_000;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// sentKey
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('sentKey', () => {
+  it('builds sent:<pushId> key', () => {
+    expect(sentKey('abc')).toBe('sent:abc');
+  });
+
+  it('empty pushId still prefixed', () => {
+    // 실제 caller는 비어 있지 않은 pushId를 전달 — fail-safe 표면만 확인.
+    expect(sentKey('')).toBe('sent:');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// stampSent
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('stampSent', () => {
+  it('writes sent:<pushId> entry with 5min TTL', async () => {
+    const kv = new InMemoryKV();
+    const beforePut = Date.now();
+    await stampSent(kv as unknown as KVNamespace, { pushId: 'p1', sentAt: NOW });
+    const afterPut = Date.now();
+    const entry = kv.store.get('sent:p1');
+    expect(entry).toBeDefined();
+    expect(JSON.parse(entry!.value)).toEqual({ pushId: 'p1', sentAt: NOW });
+    expect(entry!.expiresAt).toBeGreaterThanOrEqual(beforePut + SENT_TTL_SEC * 1000 - 100);
+    expect(entry!.expiresAt).toBeLessThanOrEqual(afterPut + SENT_TTL_SEC * 1000 + 100);
+  });
+
+  it('undefined KV → graceful no-op (no throw, no put)', async () => {
+    await expect(stampSent(undefined, { pushId: 'p1', sentAt: NOW })).resolves.toBeUndefined();
+  });
+
+  it('KV.put throw → silent swallow (측정 인프라가 본 발사 흐름 차단 X)', async () => {
+    const throwingKv = {
+      async put(): Promise<void> {
+        throw new Error('KV PUT failed: 429 daily write limit');
+      },
+    } as unknown as KVNamespace;
+    await expect(
+      stampSent(throwingKv, { pushId: 'p1', sentAt: NOW }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// computeSilentPushReachRatio
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('computeSilentPushReachRatio', () => {
+  it('빈 KV → sent=0 received=0 joined=0 ratio=0', async () => {
+    const kv = new InMemoryKV();
+    const result = await computeSilentPushReachRatio(kv as unknown as KVNamespace, NOW);
+    expect(result.sent).toBe(0);
+    expect(result.received).toBe(0);
+    expect(result.joined).toBe(0);
+    expect(result.ratio).toBe(0);
+    expect(result.windowStart).toBe(NOW - SILENT_PUSH_REACH_WINDOW_MS);
+    expect(result.windowEnd).toBe(NOW);
+  });
+
+  it('5min 윈도우 안 sent 2건 + matching received 2건 → ratio=1', async () => {
+    const kv = new InMemoryKV();
+    await stampSent(kv as unknown as KVNamespace, { pushId: 'a', sentAt: NOW - 60_000 });
+    await stampSent(kv as unknown as KVNamespace, { pushId: 'b', sentAt: NOW - 90_000 });
+    kv.store.set('received:a', {
+      value: JSON.stringify({ pushId: 'a', receivedAt: NOW - 50_000 }),
+    });
+    kv.store.set('received:b', {
+      value: JSON.stringify({ pushId: 'b', receivedAt: NOW - 80_000 }),
+    });
+    const result = await computeSilentPushReachRatio(kv as unknown as KVNamespace, NOW);
+    expect(result.sent).toBe(2);
+    expect(result.received).toBe(2);
+    expect(result.joined).toBe(2);
+    expect(result.ratio).toBe(1);
+  });
+
+  it('5min 윈도우 안 sent 3건 / received 1건 → ratio=1/3', async () => {
+    const kv = new InMemoryKV();
+    await stampSent(kv as unknown as KVNamespace, { pushId: 'a', sentAt: NOW - 60_000 });
+    await stampSent(kv as unknown as KVNamespace, { pushId: 'b', sentAt: NOW - 90_000 });
+    await stampSent(kv as unknown as KVNamespace, { pushId: 'c', sentAt: NOW - 120_000 });
+    kv.store.set('received:a', {
+      value: JSON.stringify({ pushId: 'a', receivedAt: NOW - 50_000 }),
+    });
+    const result = await computeSilentPushReachRatio(kv as unknown as KVNamespace, NOW);
+    expect(result.sent).toBe(3);
+    expect(result.received).toBe(1);
+    expect(result.joined).toBe(1);
+    expect(result.ratio).toBeCloseTo(1 / 3);
+  });
+
+  it('sent 윈도우 밖 → 분모/분자에서 제외', async () => {
+    const kv = new InMemoryKV();
+    // 10min 이전 sent — 윈도우(5min) 밖
+    kv.store.set('sent:old', {
+      value: JSON.stringify({ pushId: 'old', sentAt: NOW - 10 * 60_000 }),
+    });
+    // 1min 전 received — 같은 pushId 지만 sent 가 윈도우 밖이라 join 안 됨
+    kv.store.set('received:old', {
+      value: JSON.stringify({ pushId: 'old', receivedAt: NOW - 60_000 }),
+    });
+    const result = await computeSilentPushReachRatio(kv as unknown as KVNamespace, NOW);
+    expect(result.sent).toBe(0);
+    expect(result.received).toBe(0);
+    expect(result.ratio).toBe(0);
+  });
+
+  it('sent 없이 received만 (legacy / orphan) → 분자/joined에서 제외', async () => {
+    const kv = new InMemoryKV();
+    kv.store.set('received:orphan', {
+      value: JSON.stringify({ pushId: 'orphan', receivedAt: NOW - 30_000 }),
+    });
+    const result = await computeSilentPushReachRatio(kv as unknown as KVNamespace, NOW);
+    expect(result.sent).toBe(0);
+    expect(result.received).toBe(0);
+    expect(result.joined).toBe(0);
+    expect(result.ratio).toBe(0);
+  });
+
+  it('malformed sent JSON → skip 후 정상 처리', async () => {
+    const kv = new InMemoryKV();
+    kv.store.set('sent:bad', { value: '{not-json' });
+    kv.store.set('sent:good', {
+      value: JSON.stringify({ pushId: 'good', sentAt: NOW - 60_000 }),
+    });
+    kv.store.set('received:good', {
+      value: JSON.stringify({ pushId: 'good', receivedAt: NOW - 50_000 }),
+    });
+    const result = await computeSilentPushReachRatio(kv as unknown as KVNamespace, NOW);
+    expect(result.sent).toBe(1);
+    expect(result.received).toBe(1);
+    expect(result.ratio).toBe(1);
+  });
+
+  it('malformed received JSON → skip 후 정상 처리', async () => {
+    const kv = new InMemoryKV();
+    await stampSent(kv as unknown as KVNamespace, { pushId: 'p1', sentAt: NOW - 60_000 });
+    kv.store.set('received:p1', { value: '{not-json' });
+    const result = await computeSilentPushReachRatio(kv as unknown as KVNamespace, NOW);
+    expect(result.sent).toBe(1);
+    expect(result.received).toBe(0);
+    expect(result.ratio).toBe(0);
+  });
+
+  it('sent stamp 안 fields 누락 (pushId/sentAt) → skip', async () => {
+    const kv = new InMemoryKV();
+    kv.store.set('sent:invalid1', { value: JSON.stringify({ sentAt: NOW - 30_000 }) });
+    kv.store.set('sent:invalid2', { value: JSON.stringify({ pushId: 'x' }) });
+    kv.store.set('sent:invalid3', { value: JSON.stringify({ pushId: '', sentAt: NOW - 30_000 }) });
+    kv.store.set('sent:invalid4', {
+      value: JSON.stringify({ pushId: 'x', sentAt: Number.NaN }),
+    });
+    const result = await computeSilentPushReachRatio(kv as unknown as KVNamespace, NOW);
+    expect(result.sent).toBe(0);
+  });
+
+  it('received stamp 안 fields 누락 (pushId/receivedAt) → skip', async () => {
+    const kv = new InMemoryKV();
+    await stampSent(kv as unknown as KVNamespace, { pushId: 'p1', sentAt: NOW - 60_000 });
+    kv.store.set('received:bad1', { value: JSON.stringify({ receivedAt: NOW - 50_000 }) });
+    kv.store.set('received:bad2', { value: JSON.stringify({ pushId: 'p1' }) });
+    const result = await computeSilentPushReachRatio(kv as unknown as KVNamespace, NOW);
+    expect(result.sent).toBe(1);
+    expect(result.received).toBe(0);
+  });
+
+  it('빈 raw value (null) → skip', async () => {
+    const kv = new InMemoryKV();
+    // list에 key는 있지만 get 결과가 null인 케이스를 시뮬레이션할 수 없으므로 만료 entry 모사.
+    // expiresAt이 과거인 entry는 InMemoryKV.get이 null을 반환한다.
+    kv.store.set('sent:expired', {
+      value: JSON.stringify({ pushId: 'expired', sentAt: NOW - 60_000 }),
+      expiresAt: NOW - 1000,
+    });
+    const result = await computeSilentPushReachRatio(kv as unknown as KVNamespace, NOW);
+    expect(result.sent).toBe(0);
+  });
+
+  it('limit cap — 1000건 sent 적재 시 default limit(500) 내에서만 enumerate', async () => {
+    const kv = new InMemoryKV();
+    for (let i = 0; i < 700; i += 1) {
+      kv.store.set(`sent:p${i}`, {
+        value: JSON.stringify({ pushId: `p${i}`, sentAt: NOW - 60_000 - i }),
+      });
+    }
+    // pageSize를 작게 해서 enumeration 의 cursor 경로를 강제로 한 번 더 돌게 한다.
+    kv.pageSize = 200;
+    const result = await computeSilentPushReachRatio(kv as unknown as KVNamespace, NOW, 500);
+    expect(result.sent).toBe(500);
+    expect(result.received).toBe(0);
+    expect(result.ratio).toBe(0);
+  });
+});

--- a/backend/alarm-worker/src/observabilityMetrics.ts
+++ b/backend/alarm-worker/src/observabilityMetrics.ts
@@ -39,6 +39,7 @@
 
 import { computeAlarmLogStats } from './alarmLogStats';
 import { computePushAckStats } from './pushAckStats';
+import { computeSilentPushReachRatio } from './silentPushReachMetric';
 import { sumLaPushCounters } from './laPushCounters';
 
 /** 집계 KV 키 prefix. */
@@ -84,6 +85,13 @@ export interface ObservabilityMetricsResponse {
   silentPushLatency: { p50: number; p95: number; totalSamples: number } | null;
   /** #1779 — LA push 도달률 (sent / (sent + failed), 24h rolling window). */
   laPushDeliveryRatio: { sent: number; failed: number; ratio: number };
+  /**
+   * #1958 — silent push 도달률 5min 윈도우 corrId(pushId) join.
+   *  - `sent` / `received` / `joined` — `silentPushReachMetric.ts` 참고.
+   *  - `silentPushDeliveryRatio` 와 별도 metric: 도달 실패 검출이 목적 (window 5min, sent SSoT).
+   *  - PENDING_PUSHES binding 부재 시 placeholder { sent:0, received:0, joined:0, ratio:0 }.
+   */
+  silentPushReachRatio: { sent: number; received: number; joined: number; ratio: number };
   window: '24h';
   timestamp: number;
 }
@@ -123,14 +131,25 @@ export async function computeObservabilityMetrics(
   // 2. PENDING_PUSHES KV 1h 근사치 — silentPushDeliveryRatio + silentPushLatency 원천
   let silentPushDeliveryRatio: ObservabilityMetricsResponse['silentPushDeliveryRatio'];
   let silentPushLatency: ObservabilityMetricsResponse['silentPushLatency'] = null;
+  // #1958 — silent push 도달률 5min 윈도우 corrId join. computeSilentPushReachRatio가 PENDING_PUSHES
+  // KV의 `sent:` + `received:` prefix scan으로 산출. binding 부재 시 graceful placeholder.
+  let silentPushReachRatio: ObservabilityMetricsResponse['silentPushReachRatio'];
   if (pendingPushesKv !== undefined) {
     const pushStats = await computePushAckStats(pendingPushesKv, now, 500);
     const pushTotal = pushStats.received + pushStats.pending;
     silentPushDeliveryRatio = buildMetricBucket(pushStats.received, pushTotal);
     silentPushLatency = pushStats.silentPushLatency;
+    const reach = await computeSilentPushReachRatio(pendingPushesKv, now);
+    silentPushReachRatio = {
+      sent: reach.sent,
+      received: reach.received,
+      joined: reach.joined,
+      ratio: reach.ratio,
+    };
   } else {
     // binding 미설정 — graceful placeholder
     silentPushDeliveryRatio = buildMetricBucket(0, 0);
+    silentPushReachRatio = { sent: 0, received: 0, joined: 0, ratio: 0 };
   }
 
   // 3. boardableMissRatio — #1503 (M3 Sub C wire) — device boardable-lookup stamp 집계.
@@ -169,6 +188,7 @@ export async function computeObservabilityMetrics(
     accelPatternHitRatio,
     silentPushLatency,
     laPushDeliveryRatio,
+    silentPushReachRatio,
     window: '24h',
     timestamp: now,
   };

--- a/backend/alarm-worker/src/pendingPushes.ts
+++ b/backend/alarm-worker/src/pendingPushes.ts
@@ -14,6 +14,7 @@
 
 import type { AlarmPhase } from './alarm';
 import { assertCronCacheTtl, CRON_READ_CACHE_TTL_SEC as SHARED_CRON_TTL } from './kvConsistency';
+import { stampSent } from './silentPushReachMetric';
 import type { ApnsEnv } from './types';
 
 const PENDING_PREFIX = 'pending:';
@@ -74,6 +75,10 @@ export async function putPending(
   await kv.put(pendingKey(entry.pushId), JSON.stringify(entry), {
     expirationTtl: PENDING_TTL_SEC,
   });
+  // #1958 — silent push reach metric (5min 윈도우 corrId join) 용 sent stamp 동시 적재.
+  // `pending:` (120s TTL) 와 별도 prefix(`sent:`, 5min TTL)로 발사 fact 를 보존한다.
+  // 실패는 silent — `stampSent` 내부에서 swallow.
+  await stampSent(kv, { pushId: entry.pushId, sentAt: entry.sentAt });
 }
 
 export async function getPending(

--- a/backend/alarm-worker/src/silentPushReachMetric.ts
+++ b/backend/alarm-worker/src/silentPushReachMetric.ts
@@ -1,0 +1,234 @@
+/**
+ * Silent push reach metric — corrId(pushId) join (#1958, #1503 잔여 2/3).
+ *
+ * 배경
+ * ====
+ * 기존 `pushAckStats.ts` / `observabilityMetrics.ts`의 `silentPushDeliveryRatio`는
+ * `received / (received + pending)` 비율이다. `pending` KV TTL은 120s — push가 발사된 직후
+ * 60~120s 안에 ack를 받지 못한 entry는 자연 expire돼 분모에서 사라진다. 결과적으로 "발사했지만
+ * 도달 못 한" 케이스가 silent하게 누락된다.
+ *
+ * 본 모듈은 그 갭을 메우기 위해 **별도의 `sent:<pushId>` KV stamp(5min TTL)** 를 적재한다.
+ *   - sent stamp는 silent push 발사 직후 1건 적재 (corrId=pushId)
+ *   - received stamp는 device가 `/push/ack` outcome='received'로 echo 시 적재 (`pendingPushes.ts:stampReceived`)
+ *   - 5min 윈도우 안에서 sent count 와 received count 를 corrId(pushId)로 1:1 join하여
+ *     실제 도달률(`received / sent`) 산출
+ *
+ * 윈도우 5분
+ * ==========
+ * - 짧으면(60s): KV TTL 정합성은 좋지만 burst가 적은 trip에서 표본 0이 자주 발생
+ * - 길면(1h): pending TTL 120s가 잡지 못하는 진짜 미도달을 sent stamp가 살리지만, paradigm
+ *   회복 시간 측정에는 너무 길어 acuity 감소
+ * - **5min**: paradigm Phase 1+2(#1745) 회복 시간 측정 + burst가 있는 trip 1건의 도달률
+ *   baseline 확보에 적당. 사용자 trip 평균 35분 안에서 7건의 5min window 측정 가능.
+ *
+ * `silentPushDeliveryRatio` vs `silentPushReachRatio`
+ * ====================================================
+ * 두 metric 은 의도가 다르므로 동시에 유지한다.
+ *  - `silentPushDeliveryRatio` (기존, 1h): 운영 안정성. 1h window 안에서 "최근 도달 분포".
+ *  - `silentPushReachRatio` (신규, 5min): paradigm 측정. 5min window의 corrId-join 도달률.
+ *
+ * KV cost
+ * =======
+ * - sent stamp 1건 = 1 put (sendSilentPush가 호출되는 trip 1건당 ~수십 회). 5min TTL.
+ * - list scan은 cron(`computeSilentPushReachRatio`)이 1h마다 1회 호출. limit cap 보호.
+ *
+ * 회귀 차단
+ * =========
+ * - sent stamp 적재 실패는 silent push 본 발사 흐름을 막지 않는다 (graceful no-op).
+ * - KV namespace 미바인딩(`kv === undefined`) graceful no-op — 개발 환경 호환.
+ */
+
+import { CRON_READ_CACHE_TTL_SEC, assertCronCacheTtl } from './kvConsistency';
+
+/** `sent:<pushId>` KV stamp prefix. */
+const SENT_PREFIX = 'sent:';
+
+/** `received:<pushId>` stamp prefix — `pendingPushes.ts` 의 RECEIVED_PREFIX 와 동일. */
+const RECEIVED_PREFIX = 'received:';
+
+/**
+ * sent stamp TTL — 5min. 본 metric 윈도우와 동일.
+ * received stamp(`pendingPushes.ts:RECEIVED_TTL_SEC = 60 * 60`) 보다 짧다 — 5분 안에 ack 가
+ * 도착하지 않으면 미도달로 간주.
+ */
+export const SENT_TTL_SEC = 5 * 60;
+
+/** 5분 윈도우 — receivedAt - sentAt 비교 기준. ms 단위. */
+export const SILENT_PUSH_REACH_WINDOW_MS = 5 * 60 * 1000;
+
+/** KV list 호출 1회당 최대 enumerate entry 수 (cost 보호). */
+export const DEFAULT_LIST_LIMIT = 500;
+
+/** sent stamp 1건의 추적 정보. */
+export interface SentStamp {
+  pushId: string;
+  sentAt: number;
+}
+
+/**
+ * 5min 윈도우 corrId-join 결과.
+ *  - `sent`: 5min 윈도우 안에서 발사된 push 수 (sent stamp 기준)
+ *  - `received`: 5min 윈도우 안에서 device가 ack한 push 수 (received stamp + sentAt 윈도우 안)
+ *  - `joined`: corrId 기준 sent 와 received 둘 다 있는 push 수
+ *  - `ratio`: received / sent (sent=0 → 0). division-by-zero 방어.
+ *  - `windowStart` / `windowEnd`: 측정 윈도우 (epoch ms)
+ */
+export interface SilentPushReachRatio {
+  sent: number;
+  received: number;
+  joined: number;
+  ratio: number;
+  windowStart: number;
+  windowEnd: number;
+}
+
+export function sentKey(pushId: string): string {
+  return `${SENT_PREFIX}${pushId}`;
+}
+
+function receivedKeyFor(pushId: string): string {
+  return `${RECEIVED_PREFIX}${pushId}`;
+}
+
+/**
+ * silent push 발사 직후 호출 — sent stamp 1건 적재.
+ *
+ * 실패는 silent — KV throw / namespace 미바인딩 둘 다 graceful. push 본 발사 흐름과 격리.
+ * `putPending` 직후 호출하므로 두 stamp 가 byte-level 정합.
+ *
+ * @param kv PENDING_PUSHES KV namespace (`pendingPushes.ts:putPending` 와 동일 namespace)
+ * @param entry sent stamp 본문 (pushId + sentAt)
+ */
+export async function stampSent(
+  kv: KVNamespace | undefined,
+  entry: SentStamp,
+): Promise<void> {
+  if (!kv) return;
+  try {
+    await kv.put(sentKey(entry.pushId), JSON.stringify(entry), {
+      expirationTtl: SENT_TTL_SEC,
+    });
+  } catch {
+    // silent — 측정 인프라가 본 발사를 차단해서는 안 된다.
+  }
+}
+
+/** received stamp 1건의 partial shape — pendingPushes.ts `stampReceived` 와 호환. */
+interface ReceivedStampShape {
+  pushId: string;
+  receivedAt: number;
+}
+
+/**
+ * `received:<pushId>` raw JSON parse — corrId 와 receivedAt 만 필요.
+ * pendingPushes.ts 가 추가 메타(stationName/phase/latencyMs/...)도 stamp 하지만 본 모듈은
+ * 쓰지 않으므로 partial type 으로 narrow.
+ */
+function parseReceivedStamp(raw: string): ReceivedStampShape | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<ReceivedStampShape>;
+    if (typeof parsed.pushId !== 'string' || parsed.pushId.length === 0) return null;
+    if (typeof parsed.receivedAt !== 'number' || !Number.isFinite(parsed.receivedAt)) return null;
+    return { pushId: parsed.pushId, receivedAt: parsed.receivedAt };
+  } catch {
+    return null;
+  }
+}
+
+/** sent stamp raw JSON parse + 검증. */
+function parseSentStamp(raw: string): SentStamp | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<SentStamp>;
+    if (typeof parsed.pushId !== 'string' || parsed.pushId.length === 0) return null;
+    if (typeof parsed.sentAt !== 'number' || !Number.isFinite(parsed.sentAt)) return null;
+    return { pushId: parsed.pushId, sentAt: parsed.sentAt };
+  } catch {
+    return null;
+  }
+}
+
+/** prefix scan helper — cursor + cacheTtl 정합 (pushAckStats.ts 패턴). */
+async function listPrefixKeys(
+  kv: KVNamespace,
+  prefix: string,
+  limit: number,
+): Promise<string[]> {
+  const keys: string[] = [];
+  let cursor: string | undefined;
+  let enumerated = 0;
+  do {
+    const result = await kv.list({
+      prefix,
+      cursor,
+      limit: Math.min(limit - enumerated, 1000),
+    });
+    for (const key of result.keys) {
+      if (enumerated >= limit) break;
+      keys.push(key.name);
+      enumerated += 1;
+    }
+    cursor = result.list_complete || enumerated >= limit ? undefined : result.cursor;
+  } while (cursor);
+  return keys;
+}
+
+/**
+ * `sent:` + `received:` prefix scan으로 5min 윈도우 corrId-join 산출.
+ *
+ * sent stamp 가 부재한 received(legacy device / 누락)는 분자에서만 counted X — sent 가 SSoT.
+ * received stamp 가 부재한 sent 는 미도달로 간주.
+ *
+ * @param kv PENDING_PUSHES KV namespace
+ * @param now 현재 epoch ms
+ * @param limit 각 prefix scan 한 회당 최대 entry 수 (default DEFAULT_LIST_LIMIT)
+ */
+export async function computeSilentPushReachRatio(
+  kv: KVNamespace,
+  now: number,
+  limit: number = DEFAULT_LIST_LIMIT,
+): Promise<SilentPushReachRatio> {
+  const windowStart = now - SILENT_PUSH_REACH_WINDOW_MS;
+  const windowEnd = now;
+
+  // sent stamp scan — pushId → sentAt
+  assertCronCacheTtl(CRON_READ_CACHE_TTL_SEC);
+  const sentKeys = await listPrefixKeys(kv, SENT_PREFIX, limit);
+  const sentByPushId = new Map<string, number>();
+  for (const key of sentKeys) {
+    const raw = await kv.get(key, { cacheTtl: CRON_READ_CACHE_TTL_SEC });
+    if (!raw) continue;
+    const stamp = parseSentStamp(raw);
+    if (!stamp) continue;
+    if (stamp.sentAt < windowStart || stamp.sentAt > windowEnd) continue;
+    sentByPushId.set(stamp.pushId, stamp.sentAt);
+  }
+
+  // received stamp scan — pushId → receivedAt (sentAt 윈도우 포함 여부 분리)
+  const receivedKeys = await listPrefixKeys(kv, RECEIVED_PREFIX, limit);
+  let receivedCount = 0;
+  let joined = 0;
+  for (const key of receivedKeys) {
+    const raw = await kv.get(key, { cacheTtl: CRON_READ_CACHE_TTL_SEC });
+    if (!raw) continue;
+    const stamp = parseReceivedStamp(raw);
+    if (!stamp) continue;
+    const sentAt = sentByPushId.get(stamp.pushId);
+    // sent stamp 가 있고 5min 윈도우 안 → received as joined.
+    if (sentAt !== undefined && sentAt >= windowStart && sentAt <= windowEnd) {
+      receivedCount += 1;
+      joined += 1;
+    }
+  }
+
+  const sent = sentByPushId.size;
+  const ratio = sent === 0 ? 0 : receivedCount / sent;
+  return {
+    sent,
+    received: receivedCount,
+    joined,
+    ratio,
+    windowStart,
+    windowEnd,
+  };
+}

--- a/backend/alarm-worker/src/silentPushReachMetric.ts
+++ b/backend/alarm-worker/src/silentPushReachMetric.ts
@@ -87,10 +87,6 @@ export function sentKey(pushId: string): string {
   return `${SENT_PREFIX}${pushId}`;
 }
 
-function receivedKeyFor(pushId: string): string {
-  return `${RECEIVED_PREFIX}${pushId}`;
-}
-
 /**
  * silent push 발사 직후 호출 — sent stamp 1건 적재.
  *

--- a/src/features/debug/components/OperationDashboardSection.tsx
+++ b/src/features/debug/components/OperationDashboardSection.tsx
@@ -33,6 +33,7 @@ import {
   type ObservabilityMetricsBucket,
   type AccelPatternBucket,
   type LaPushDeliveryBucket,
+  type SilentPushReachBucket,
   type FetchMetricsResult,
 } from '../../observability/api/observabilityMetricsClient';
 import {
@@ -65,7 +66,16 @@ interface MetricData {
 type BackendLoadState =
   | { kind: 'idle' }
   | { kind: 'loading' }
-  | { kind: 'ok'; locklessMiss: ObservabilityMetricsBucket; boardableMiss: ObservabilityMetricsBucket; accelPattern: AccelPatternBucket; pushLatency: { p50: number; p95: number; totalSamples: number } | null; laPushDelivery: LaPushDeliveryBucket }
+  | {
+      kind: 'ok';
+      locklessMiss: ObservabilityMetricsBucket;
+      boardableMiss: ObservabilityMetricsBucket;
+      accelPattern: AccelPatternBucket;
+      pushLatency: { p50: number; p95: number; totalSamples: number } | null;
+      laPushDelivery: LaPushDeliveryBucket;
+      /** #1958 — backend 5min corrId join 도달률. backend가 응답하지 않으면 null. */
+      silentPushReach: SilentPushReachBucket | null;
+    }
   | { kind: 'unconfigured' }
   | { kind: 'error'; message: string };
 
@@ -330,6 +340,7 @@ export function OperationDashboardSection({ logs, onMetricClick }: OperationDash
         accelPattern: result.metrics.accelPatternHitRatio,
         pushLatency: result.metrics.silentPushLatency ?? null,
         laPushDelivery: result.metrics.laPushDeliveryRatio,
+        silentPushReach: result.metrics.silentPushReachRatio ?? null,
       });
     } else if (result.kind === 'unconfigured') {
       setBackendState({ kind: 'unconfigured' });
@@ -399,7 +410,39 @@ export function OperationDashboardSection({ logs, onMetricClick }: OperationDash
         }
       : { key: 'locklessMiss', label: 'laPushDelivery', ratio: null, numerator: 0, denominator: 0, isMock: true };
 
-  const metrics: MetricData[] = [alarmAccuracy, silentPushReach, locklessMiss, boardableMiss, laPushDelivery];
+  // Metric 8 — #1958 silent push 5min corrId join 도달률 (backend SSoT).
+  // 기존 client-side `silentPushReach`(local fired/received)와 별도 — backend가 `sent`를 권위 분모로 보유.
+  // backend가 silentPushReachRatio 필드를 응답하지 않으면(구 backend) placeholder.
+  const silentPushReachBackend: MetricData =
+    backendState.kind === 'ok' && backendState.silentPushReach !== null
+      ? {
+          key: 'silentPushReach',
+          label: 'silentPushReachBackend',
+          ratio: computeRatio(
+            backendState.silentPushReach.received,
+            backendState.silentPushReach.sent,
+          ),
+          numerator: backendState.silentPushReach.received,
+          denominator: backendState.silentPushReach.sent,
+          isMock: false,
+        }
+      : {
+          key: 'silentPushReach',
+          label: 'silentPushReachBackend',
+          ratio: null,
+          numerator: 0,
+          denominator: 0,
+          isMock: true,
+        };
+
+  const metrics: MetricData[] = [
+    alarmAccuracy,
+    silentPushReach,
+    silentPushReachBackend,
+    locklessMiss,
+    boardableMiss,
+    laPushDelivery,
+  ];
 
   const handleMetricPress = useCallback(
     (key: DrillDownMetricKey) => {

--- a/src/features/debug/components/__tests__/OperationDashboardSection.test.tsx
+++ b/src/features/debug/components/__tests__/OperationDashboardSection.test.tsx
@@ -93,21 +93,27 @@ function makeSuccessResult(
   pushLatency: { p50: number; p95: number; totalSamples: number } | null = null,
   laSent = 10,
   laFailed = 2,
+  // #1958 — backend 5min corrId join 도달률. null = 구 backend 응답 (필드 누락 simulating).
+  silentPushReach: observabilityClient.SilentPushReachBucket | null = {
+    sent: 0,
+    received: 0,
+    joined: 0,
+    ratio: 0,
+  },
 ): observabilityClient.FetchMetricsResult {
-  return {
-    kind: 'ok',
-    metrics: {
-      accuracyRatio: { value: 8, total: 10, ratio: 0.8 },
-      silentPushDeliveryRatio: { value: 5, total: 6, ratio: 0.833 },
-      locklessMissRatio: { value: locklessValue, total: locklessTotal, ratio: locklessValue / locklessTotal },
-      boardableMissRatio: { value: boardableValue, total: boardableTotal, ratio: boardableTotal === 0 ? 0 : boardableValue / boardableTotal },
-      accelPatternHitRatio: accelPattern,
-      silentPushLatency: pushLatency,
-      laPushDeliveryRatio: { sent: laSent, failed: laFailed, ratio: laSent / (laSent + laFailed) },
-      window: '24h',
-      timestamp: 1_700_000_000_000,
-    },
+  const metrics: observabilityClient.ObservabilityMetrics = {
+    accuracyRatio: { value: 8, total: 10, ratio: 0.8 },
+    silentPushDeliveryRatio: { value: 5, total: 6, ratio: 0.833 },
+    locklessMissRatio: { value: locklessValue, total: locklessTotal, ratio: locklessValue / locklessTotal },
+    boardableMissRatio: { value: boardableValue, total: boardableTotal, ratio: boardableTotal === 0 ? 0 : boardableValue / boardableTotal },
+    accelPatternHitRatio: accelPattern,
+    silentPushLatency: pushLatency,
+    laPushDeliveryRatio: { sent: laSent, failed: laFailed, ratio: laSent / (laSent + laFailed) },
+    window: '24h',
+    timestamp: 1_700_000_000_000,
+    ...(silentPushReach !== null ? { silentPushReachRatio: silentPushReach } : {}),
   };
+  return { kind: 'ok', metrics };
 }
 
 // ─── setup ────────────────────────────────────────────────────────────────────
@@ -129,11 +135,12 @@ afterEach(() => {
 
 describe('OperationDashboardSection', () => {
   describe('Sub 1 — 빈 데이터 상태 (4 metric 모두 0)', () => {
-    it('5개 metric row를 렌더한다 (laPushDelivery 포함)', async () => {
+    it('6개 metric row를 렌더한다 (laPushDelivery + silentPushReachBackend 포함)', async () => {
       renderWithTheme(<OperationDashboardSection logs={[]} />);
       await act(async () => { jest.runAllTimers(); });
       expect(screen.getByTestId('operation-metric-alarmAccuracy')).toBeTruthy();
       expect(screen.getByTestId('operation-metric-silentPushReach')).toBeTruthy();
+      expect(screen.getByTestId('operation-metric-silentPushReachBackend')).toBeTruthy();
       expect(screen.getByTestId('operation-metric-locklessMiss')).toBeTruthy();
       expect(screen.getByTestId('operation-metric-boardableMiss')).toBeTruthy();
       expect(screen.getByTestId('operation-metric-laPushDelivery')).toBeTruthy();
@@ -543,6 +550,67 @@ describe('OperationDashboardSection', () => {
       await act(async () => { jest.runAllTimers(); });
       fireEvent.press(screen.getByTestId('operation-metric-boardableMiss'));
       expect(onMetricClick).toHaveBeenCalledWith('boardableMiss', 'unknown');
+    });
+  });
+
+  // ── #1958 silentPushReachBackend metric (5min corrId join) ───────────────────
+
+  describe('#1958 — silentPushReachBackend metric', () => {
+    it('backend 미수신(unconfigured) → silentPushReachBackend row가 (no data) 표시', async () => {
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      expect(screen.getByTestId('operation-metric-silentPushReachBackend')).toBeTruthy();
+      // unconfigured 상태에서는 isMock=true + ratio=null → ratio-bar-na 가 적어도 1개 있어야 함
+      const naBars = screen.getAllByTestId('ratio-bar-na');
+      expect(naBars.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('fetch 성공 + silentPushReachRatio 필드 있음 → ratio bar 렌더 (received/sent)', async () => {
+      mockFetchMetrics.mockResolvedValue(
+        makeSuccessResult(2, 10, 0, 0, DEFAULT_ACCEL_PATTERN, null, 10, 2, {
+          sent: 5,
+          received: 4,
+          joined: 4,
+          ratio: 0.8,
+        }),
+      );
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      await waitFor(() => {
+        const tracks = screen.getAllByTestId('ratio-bar-track');
+        expect(tracks.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it('fetch 성공 but silentPushReachRatio 필드 누락 (구 backend) → (no data) 유지', async () => {
+      // silentPushReach=null → makeSuccessResult가 silentPushReachRatio 필드를 omit.
+      mockFetchMetrics.mockResolvedValue(
+        makeSuccessResult(2, 10, 0, 0, DEFAULT_ACCEL_PATTERN, null, 10, 2, null),
+      );
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      await waitFor(() => {
+        // silentPushReachBackend 가 isMock=true 로 fallback (필드 누락)
+        expect(screen.getByTestId('operation-metric-silentPushReachBackend')).toBeTruthy();
+      });
+    });
+
+    it('fetch 성공 + sent=0 → ratio=null (division-by-zero 방어) (no data) 표시', async () => {
+      mockFetchMetrics.mockResolvedValue(
+        makeSuccessResult(2, 10, 0, 0, DEFAULT_ACCEL_PATTERN, null, 10, 2, {
+          sent: 0,
+          received: 0,
+          joined: 0,
+          ratio: 0,
+        }),
+      );
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      await waitFor(() => {
+        // sent=0 → numerator=0 denominator=0 → ratio=null → ratio-bar-na 적어도 1개
+        const naBars = screen.getAllByTestId('ratio-bar-na');
+        expect(naBars.length).toBeGreaterThanOrEqual(1);
+      });
     });
   });
 });

--- a/src/features/observability/api/__tests__/observabilityMetricsClient.test.ts
+++ b/src/features/observability/api/__tests__/observabilityMetricsClient.test.ts
@@ -115,6 +115,29 @@ describe('fetchObservabilityMetrics', () => {
       }
     });
 
+    it('forwards silentPushReachRatio from response (#1958)', async () => {
+      const metrics = makeMetrics();
+      metrics.silentPushReachRatio = { sent: 7, received: 5, joined: 5, ratio: 5 / 7 };
+      mockFetchOk(metrics);
+      const result = await fetchObservabilityMetrics();
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.metrics.silentPushReachRatio?.sent).toBe(7);
+        expect(result.metrics.silentPushReachRatio?.received).toBe(5);
+        expect(result.metrics.silentPushReachRatio?.joined).toBe(5);
+        expect(result.metrics.silentPushReachRatio?.ratio).toBeCloseTo(5 / 7);
+      }
+    });
+
+    it('silentPushReachRatio 누락 (구 backend) → undefined graceful', async () => {
+      mockFetchOk(makeMetrics());
+      const result = await fetchObservabilityMetrics();
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.metrics.silentPushReachRatio).toBeUndefined();
+      }
+    });
+
     it('calls the correct endpoint URL with window=24h', async () => {
       mockFetchOk(makeMetrics());
       await fetchObservabilityMetrics();

--- a/src/features/observability/api/observabilityMetricsClient.ts
+++ b/src/features/observability/api/observabilityMetricsClient.ts
@@ -31,6 +31,19 @@ export interface LaPushDeliveryBucket {
   ratio: number;
 }
 
+/**
+ * #1958 — silent push 5min 윈도우 corrId(pushId) join 도달률 응답 bucket.
+ *  - `sent` / `received` / `joined`: backend `silentPushReachMetric.ts` 참고.
+ *  - `silentPushDeliveryRatio` (1h, received/(received+pending))와 별도 metric.
+ *  - 미설정 backend는 `silentPushReachRatio` 필드 자체가 누락 — UI는 optional 로 가드.
+ */
+export interface SilentPushReachBucket {
+  sent: number;
+  received: number;
+  joined: number;
+  ratio: number;
+}
+
 export interface ObservabilityMetrics {
   accuracyRatio: ObservabilityMetricsBucket;
   silentPushDeliveryRatio: ObservabilityMetricsBucket;
@@ -45,6 +58,11 @@ export interface ObservabilityMetrics {
   silentPushLatency?: { p50: number; p95: number; totalSamples: number } | null;
   /** #1779 — LA push 도달률 (sent / (sent + failed), 24h rolling window). */
   laPushDeliveryRatio: LaPushDeliveryBucket;
+  /**
+   * #1958 — silent push 5min 윈도우 corrId(pushId) join 도달률.
+   * 구 backend(필드 미응답) 호환 위해 optional — UI는 누락 시 placeholder 표시.
+   */
+  silentPushReachRatio?: SilentPushReachBucket;
   window: '24h';
   timestamp: number;
 }


### PR DESCRIPTION
## Summary
- backend `silentPushReachMetric.ts` 신규 — `sent:<pushId>` KV stamp(5min TTL) + 5min 윈도우 corrId(pushId) join 산출 (`computeSilentPushReachRatio`)
- backend `silentPushReachRatio` 필드 추가 (received/sent, division-by-zero 방어) — `/v1/observability/metrics` 응답에 포함
- backend `pendingPushes.putPending` 가 `stampSent` 도 동시 호출 — 3 send site(scheduled.ts:1750/2118/3232) 자동 수용, 신규 send 경로 추가 시 회귀 차단
- frontend `observabilityMetricsClient`: `SilentPushReachBucket` type + optional 필드 (구 backend 호환)
- frontend `OperationDashboardSection`: `silentPushReachBackend` 행 추가 (backend SSoT, 기존 client-side `silentPushReach` 와 별도)

Closes #1958 (#1503 잔여 2/3)

## 설계 결정

### 별도 metric 인 이유 (기존 silentPushDeliveryRatio 와 병존)
- 기존 `silentPushDeliveryRatio` (1h): `received / (received + pending)` — `pending` TTL 120s 라서 60~120s 안에 ack 못 받은 entry 가 자연 expire 돼 분모에서 사라짐 → 진짜 미도달 silent하게 누락
- 신규 `silentPushReachRatio` (5min): `received / sent` — 5min TTL `sent:<pushId>` stamp 가 발사 fact 를 보존 → 도달 실패 검출 정확도 ↑
- 두 metric 모두 유지 — 1h 운영 안정성 vs 5min paradigm 회복 시간 측정 (의도 다름)

### `received: <-> sent` corrId
- corrId = `pushId` (이미 `pendingPushes.PendingPush.pushId`, `silentPushTask.ts:826` 의 `ackOutcome('received', ...)` 가 echo 중)
- 신규 `reportSilentPushReceived` 헬퍼 추가하지 않고 기존 `ackOutcome` 채널 활용 — double-stamp 회피, surgical change
- 기존 `silentPushTask.ts:826` 의 `void ackOutcome(payload.pushId, apnsToken, 'received', undefined, latencyMs)` 가 backend `/push/ack` → `stampReceived` → `received:<pushId>` KV stamp 채널. 본 PR 신규 `sent:<pushId>` stamp 와 5min 윈도우 안에서 1:1 join.

### Known divergence — issue body vs 구현
- 이슈 body 는 frontend `reportSilentPushReceived(corrId)` 헬퍼 신규 추가 요구. 분석 결과 기존 `ackOutcome('received', ...)` 가 동일 corrId 채널이라 신규 헬퍼는 double-stamp 위험 + 회귀 가능성 → 기존 채널 그대로 사용. 본 PR 본문에 명시.
- 이슈 body 는 `/v1/silent-push-ack` 신규 endpoint 요구. 분석 결과 기존 `/push/ack` POST (Hono index.ts:1188) 가 `outcome='received'` 으로 분기 처리 중 — 신규 endpoint 추가 시 dual-channel 회귀 위험 → 기존 endpoint 그대로 활용. backend `silentPushReachRatio` 는 `/v1/observability/metrics` 응답에 포함.
- 드릴다운 라벨 `'Silent push 도달률 (24h)'` — 새 backend metric 은 5min 이지만 `MetricDrillDownView` 는 local alarmLog 기반 24h drill-down 이라 라벨 정확. 새 metric 클릭 시 같은 view 가 열리지만 backend 분모 컨텍스트는 dashboard 행 자체에서만 표시 — 라벨 변경하지 않음.

## Wire-completion 5단 체크
1. **Orphan 없음** — `npm run lint:orphan` pass
2. **V/X dashboard** — DebugModal Operation Dashboard 두 번째 metric(`silentPushReachBackend`, testID `operation-metric-silentPushReachBackend`) + corrId join 가시화 (backend `/v1/observability/metrics` 응답의 `silentPushReachRatio.sent / received / joined / ratio` 4 필드)
3. **의존 PR** — #1932 G2 / #1928 telemetry / Wave 1+2+3 silent push 정상화 PR 머지됨 (현재 dev 기준)
4. **측정 plan** — 1주 silent push 도달률 baseline + paradigm 회복 시간 측정 (#1745 prereq). backend 배포 후 cron 1h 주기 KV 적재 → DebugModal 5분 윈도우 5분 마다 polling.
5. **Device verify** — 실기기 trip 1회 + silent push V4 fire 후 DebugModal 도달률 차트 갱신 (backend OK 상태 → ratio bar 노출, sent=0 → no data placeholder)

## 측정 plan 상세
- backend 배포 후 즉시: `/v1/observability/metrics?window=24h` 응답에 `silentPushReachRatio: { sent, received, joined, ratio }` 포함 확인 (curl admin token)
- 1 trip 후: DebugModal `silentPushReachBackend` 행이 `received/sent` ratio bar 로 표시 (sent>0 인 경우)
- 1주 운영: backend cron 1h 주기로 KV bucket 적재 → silent push 도달률 baseline 확보 (#1745 paradigm Phase 1+2 회복 시간 측정 prereq)

## Test plan
- [x] `npm test` 커버리지 100% (frontend 8621 / backend 2313 tests pass)
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass
- [x] code-review medium 검토 — P1 finding 0 (자가 review)