### PR TITLE
feat(#1957): 알람 정확성 metric — M2 정답지 기반 Yes/No 비율 (#1503 잔여 1/3)

### DIFF
--- a/backend/alarm-worker/src/__tests__/alarmLogStats.test.ts
+++ b/backend/alarm-worker/src/__tests__/alarmLogStats.test.ts
@@ -459,4 +459,66 @@ describe('computeAlarmLogStats', () => {
     expect(stats.boardableLookupCounts.ok).toBe(1);
     expect(stats.boardableLookupCounts.miss).toBe(0);
   });
+
+  // ── #1957 groundTruthCounts ──────────────────────────────────────────────────
+
+  it('#1957 — ground-truth-response outcome="fired"=yes, "suppressed"=no, "received"=pending', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/28/gt-1000.ndjson',
+        tripEndedAt: NOW - 5 * 60 * 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'ground-truth-response', outcome: 'fired', stationName: 'gt-yes' },
+            { source: 'ground-truth-response', outcome: 'fired', stationName: 'gt-yes' },
+            { source: 'ground-truth-response', outcome: 'suppressed', stationName: 'gt-no' },
+            { source: 'ground-truth-response', outcome: 'received', stationName: 'gt-pending' },
+            // 다른 source → groundTruth 집계 제외
+            { source: 'fg', outcome: 'fired' },
+          ],
+          NOW - 5 * 60 * 1000,
+        ),
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    expect(stats.groundTruthCounts.yes).toBe(2);
+    expect(stats.groundTruthCounts.no).toBe(1);
+    expect(stats.groundTruthCounts.pending).toBe(1);
+  });
+
+  it('#1957 — ground-truth-response entries 없으면 groundTruthCounts 모두 0', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/28/no-gt-1000.ndjson',
+        tripEndedAt: NOW - 5 * 60 * 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [{ source: 'fg', outcome: 'fired' }],
+          NOW - 5 * 60 * 1000,
+        ),
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    expect(stats.groundTruthCounts).toEqual({ yes: 0, no: 0, pending: 0 });
+  });
+
+  it('#1957 — ground-truth-response outcome 예상 외 값은 어느 슬롯에도 들어가지 않음', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/28/invalid-gt-1000.ndjson',
+        tripEndedAt: NOW - 5 * 60 * 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            // 'aborted'는 yes/no/pending 어느 슬롯에도 들어가지 않음
+            { source: 'ground-truth-response', outcome: 'aborted', stationName: 'gt-x' },
+            { source: 'ground-truth-response', outcome: 'fired', stationName: 'gt-yes' },
+          ],
+          NOW - 5 * 60 * 1000,
+        ),
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    expect(stats.groundTruthCounts.yes).toBe(1);
+    expect(stats.groundTruthCounts.no).toBe(0);
+    expect(stats.groundTruthCounts.pending).toBe(0);
+  });
 });

--- a/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
+++ b/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
@@ -62,6 +62,7 @@ describe('storeObservabilityMetrics + readObservabilityMetrics', () => {
       silentPushLatency: null,
       laPushDeliveryRatio: { sent: 10, failed: 2, ratio: 10 / 12 },
       silentPushReachRatio: { sent: 0, received: 0, joined: 0, ratio: 0 },
+      algorithmAccuracyRatio: { value: 7, total: 9, ratio: 7 / 9, answeredTotal: 12 },
       window: '24h' as const,
       timestamp: NOW,
     };
@@ -100,6 +101,7 @@ describe('storeObservabilityMetrics + readObservabilityMetrics', () => {
       silentPushLatency: null,
       laPushDeliveryRatio: { sent: 0, failed: 0, ratio: 0 },
       silentPushReachRatio: { sent: 0, received: 0, joined: 0, ratio: 0 },
+      algorithmAccuracyRatio: { value: 0, total: 0, ratio: 0, answeredTotal: 0 },
       window: '24h' as const,
       timestamp: NOW,
     };
@@ -595,6 +597,134 @@ describe('computeObservabilityMetrics — laPushDeliveryRatio (#1779)', () => {
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
+// computeObservabilityMetrics — algorithmAccuracyRatio (#1957, #1503 잔여 1/3)
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('computeObservabilityMetrics — algorithmAccuracyRatio (#1957)', () => {
+  it('empty R2 → 0/0 ratio=0, answeredTotal=0', async () => {
+    const r2 = makeEmptyFakeR2();
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    expect(result.algorithmAccuracyRatio).toEqual({
+      value: 0,
+      total: 0,
+      ratio: 0,
+      answeredTotal: 0,
+    });
+  });
+
+  it('ground-truth-response outcome="fired"(yes) + "suppressed"(no) → ratio = yes / (yes + no)', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/28/gt-x.ndjson',
+        tripEndedAt: NOW - 60_000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'ground-truth-response', outcome: 'fired', stationName: 'gt-yes' },
+            { source: 'ground-truth-response', outcome: 'fired', stationName: 'gt-yes' },
+            { source: 'ground-truth-response', outcome: 'fired', stationName: 'gt-yes' },
+            { source: 'ground-truth-response', outcome: 'suppressed', stationName: 'gt-no' },
+          ],
+          NOW - 60_000,
+        ),
+      },
+    ]);
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    // 3 yes + 1 no = 4 total, ratio = 3/4 = 0.75. pending 0 → answeredTotal = 4.
+    expect(result.algorithmAccuracyRatio.value).toBe(3);
+    expect(result.algorithmAccuracyRatio.total).toBe(4);
+    expect(result.algorithmAccuracyRatio.ratio).toBeCloseTo(0.75, 5);
+    expect(result.algorithmAccuracyRatio.answeredTotal).toBe(4);
+  });
+
+  it('pending(received)은 분모 제외, answeredTotal에는 포함', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/28/gt-y.ndjson',
+        tripEndedAt: NOW - 60_000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'ground-truth-response', outcome: 'fired', stationName: 'gt-yes' },
+            { source: 'ground-truth-response', outcome: 'suppressed', stationName: 'gt-no' },
+            { source: 'ground-truth-response', outcome: 'received', stationName: 'gt-pending' },
+            { source: 'ground-truth-response', outcome: 'received', stationName: 'gt-pending' },
+          ],
+          NOW - 60_000,
+        ),
+      },
+    ]);
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    // yes=1, no=1, pending=2. ratio = 1 / (1+1) = 0.5. answeredTotal = 4.
+    expect(result.algorithmAccuracyRatio.value).toBe(1);
+    expect(result.algorithmAccuracyRatio.total).toBe(2);
+    expect(result.algorithmAccuracyRatio.ratio).toBe(0.5);
+    expect(result.algorithmAccuracyRatio.answeredTotal).toBe(4);
+  });
+
+  it('전부 yes → ratio=1', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/28/gt-allyes.ndjson',
+        tripEndedAt: NOW - 60_000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'ground-truth-response', outcome: 'fired', stationName: 'gt-yes' },
+            { source: 'ground-truth-response', outcome: 'fired', stationName: 'gt-yes' },
+          ],
+          NOW - 60_000,
+        ),
+      },
+    ]);
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    expect(result.algorithmAccuracyRatio.ratio).toBe(1);
+    expect(result.algorithmAccuracyRatio.value).toBe(2);
+  });
+
+  it('전부 pending이면 분모 0 → ratio=0, answeredTotal>0', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/28/gt-allpending.ndjson',
+        tripEndedAt: NOW - 60_000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'ground-truth-response', outcome: 'received', stationName: 'gt-pending' },
+            { source: 'ground-truth-response', outcome: 'received', stationName: 'gt-pending' },
+          ],
+          NOW - 60_000,
+        ),
+      },
+    ]);
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    // division-by-zero 방어: yes+no=0 → ratio=0. answeredTotal=2 (pending만 있어도 응답률 시그널은 잡힌다).
+    expect(result.algorithmAccuracyRatio.total).toBe(0);
+    expect(result.algorithmAccuracyRatio.ratio).toBe(0);
+    expect(result.algorithmAccuracyRatio.answeredTotal).toBe(2);
+  });
+
+  it('다른 source는 algorithmAccuracyRatio에 영향 X', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/28/gt-mixed.ndjson',
+        tripEndedAt: NOW - 60_000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'fg-arvlcd', outcome: 'fired', stationName: '강남' },
+            { source: 'silent-push-fired', outcome: 'fired', stationName: '서초' },
+            { source: 'boardable-lookup', outcome: 'received', stationName: '왕십리' },
+            { source: 'ground-truth-response', outcome: 'fired', stationName: 'gt-yes' },
+            { source: 'ground-truth-response', outcome: 'suppressed', stationName: 'gt-no' },
+          ],
+          NOW - 60_000,
+        ),
+      },
+    ]);
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    expect(result.algorithmAccuracyRatio.value).toBe(1);
+    expect(result.algorithmAccuracyRatio.total).toBe(2);
+    expect(result.algorithmAccuracyRatio.ratio).toBe(0.5);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
 // tryStoreObservabilityMetrics + readLastSuccessfulMetrics (#1889 RC-19)
 // ──────────────────────────────────────────────────────────────────────────────
 
@@ -613,6 +743,7 @@ const SAMPLE_METRICS = {
   silentPushLatency: null,
   laPushDeliveryRatio: { sent: 0, failed: 0, ratio: 0 },
   silentPushReachRatio: { sent: 0, received: 0, joined: 0, ratio: 0 },
+  algorithmAccuracyRatio: { value: 0, total: 0, ratio: 0, answeredTotal: 0 },
   window: '24h' as const,
   timestamp: NOW,
 };

--- a/backend/alarm-worker/src/alarmLogStats.ts
+++ b/backend/alarm-worker/src/alarmLogStats.ts
@@ -50,6 +50,7 @@ interface AlarmLogEntryLike {
  * - `tripsScanned`: 윈도우 안 scan된 trip-evidence object 수
  * - `accelPatternCounts`: #1769 — source='accel-pattern-observed' 엔트리의 pattern별 카운트.
  * - `boardableLookupCounts`: #1503 (M3 Sub C wire) — source='boardable-lookup' outcome 분포.
+ * - `groundTruthCounts`: #1957 (#1503 잔여 1/3) — source='ground-truth-response' outcome 분포.
  */
 export interface AlarmLogStatsResponse {
   windowStart: number;
@@ -69,12 +70,22 @@ export interface AlarmLogStatsResponse {
    * `observabilityMetrics.boardableMissRatio = miss / (ok + miss)` 산출 원천.
    */
   boardableLookupCounts: { ok: number; miss: number };
+  /**
+   * #1957 (#1503 잔여 1/3) — M2 사용자 정답지(useTripGroundTruthStore) 응답 분포.
+   * source='ground-truth-response' + outcome 분기 누적:
+   *   outcome='fired'      → yes (정답 — "이번 trip 알람 정확했어요")
+   *   outcome='suppressed' → no  (오답 — "틀린 알람이 있었어요")
+   *   outcome='received'   → pending (응답 회피 / dismiss / 자동 만료)
+   * `observabilityMetrics.algorithmAccuracyRatio = yes / (yes + no)` 산출 원천.
+   * pending은 분모 제외 — 응답률(1주 30%+) 측정용 신호로 별도 보존.
+   */
+  groundTruthCounts: { yes: number; no: number; pending: number };
 }
 
 const ACCEL_PATTERNS = ['automotive', 'walking', 'stationary', 'unknown'] as const;
 type AccelPattern = (typeof ACCEL_PATTERNS)[number];
 
-/** parse 결과를 outcome/source/reason/accelPattern/boardableLookup 카운터에 누적. shape mismatch entry는 silent drop. */
+/** parse 결과를 outcome/source/reason/accelPattern/boardableLookup/groundTruth 카운터에 누적. shape mismatch entry는 silent drop. */
 function accumulateEntry(
   entry: AlarmLogEntryLike,
   outcomeCounts: Record<string, number>,
@@ -82,6 +93,7 @@ function accumulateEntry(
   sourceCounts: Record<string, number>,
   accelPatternCounts: { automotive: number; walking: number; stationary: number; unknown: number },
   boardableLookupCounts: { ok: number; miss: number },
+  groundTruthCounts: { yes: number; no: number; pending: number },
 ): void {
   if (typeof entry.outcome === 'string' && entry.outcome.length > 0) {
     outcomeCounts[entry.outcome] = (outcomeCounts[entry.outcome] ?? 0) + 1;
@@ -108,6 +120,18 @@ function accumulateEntry(
       boardableLookupCounts.ok += 1;
     } else if (entry.outcome === 'suppressed') {
       boardableLookupCounts.miss += 1;
+    }
+  }
+  // #1957 (#1503 잔여 1/3) — ground truth 응답 집계: source='ground-truth-response', outcome 분기.
+  // outcome='fired'=yes(정답), 'suppressed'=no(오답), 'received'=pending(응답 회피/dismiss).
+  // 그 외 outcome은 schema 진화 방어로 silent drop.
+  if (entry.source === 'ground-truth-response') {
+    if (entry.outcome === 'fired') {
+      groundTruthCounts.yes += 1;
+    } else if (entry.outcome === 'suppressed') {
+      groundTruthCounts.no += 1;
+    } else if (entry.outcome === 'received') {
+      groundTruthCounts.pending += 1;
     }
   }
 }
@@ -161,13 +185,14 @@ function topN(dict: Record<string, number>, n: number): Record<string, number> {
   return Object.fromEntries(sorted);
 }
 
-/** scan loop 누적 카운터 — outcome/reason/source/accelPattern/boardableLookup dict + totalEvents/tripsScanned. */
+/** scan loop 누적 카운터 — outcome/reason/source/accelPattern/boardableLookup/groundTruth dict + totalEvents/tripsScanned. */
 interface ScanAccumulator {
   outcomeCounts: Record<string, number>;
   reasonCounts: Record<string, number>;
   sourceCounts: Record<string, number>;
   accelPatternCounts: { automotive: number; walking: number; stationary: number; unknown: number };
   boardableLookupCounts: { ok: number; miss: number };
+  groundTruthCounts: { yes: number; no: number; pending: number };
   totalEvents: number;
   tripsScanned: number;
 }
@@ -196,6 +221,7 @@ async function scanTripEvidenceObject(
       acc.sourceCounts,
       acc.accelPatternCounts,
       acc.boardableLookupCounts,
+      acc.groundTruthCounts,
     );
   }
 }
@@ -225,6 +251,7 @@ export async function computeAlarmLogStats(
     sourceCounts: {},
     accelPatternCounts: { automotive: 0, walking: 0, stationary: 0, unknown: 0 },
     boardableLookupCounts: { ok: 0, miss: 0 },
+    groundTruthCounts: { yes: 0, no: 0, pending: 0 },
     totalEvents: 0,
     tripsScanned: 0,
   };
@@ -257,5 +284,6 @@ export async function computeAlarmLogStats(
     tripsScanned: acc.tripsScanned,
     accelPatternCounts: acc.accelPatternCounts,
     boardableLookupCounts: acc.boardableLookupCounts,
+    groundTruthCounts: acc.groundTruthCounts,
   };
 }

--- a/backend/alarm-worker/src/observabilityMetrics.ts
+++ b/backend/alarm-worker/src/observabilityMetrics.ts
@@ -92,6 +92,13 @@ export interface ObservabilityMetricsResponse {
    *  - PENDING_PUSHES binding 부재 시 placeholder { sent:0, received:0, joined:0, ratio:0 }.
    */
   silentPushReachRatio: { sent: number; received: number; joined: number; ratio: number };
+  /**
+   * #1957 (#1503 잔여 1/3) — 알고리즘 정확성 비율.
+   * M2 사용자 정답지(useTripGroundTruthStore) 응답에서 yes / (yes + no) — pending은 분모 제외.
+   * value=yes, total=yes+no. 분모 0이면 ratio=0 (graceful — 응답 0건 = 신뢰성 없음).
+   * 응답률(answeredTotal = yes+no+pending)은 별도 신호로 보존 (P5 가중치 학습 prereq #1763).
+   */
+  algorithmAccuracyRatio: { value: number; total: number; ratio: number; answeredTotal: number };
   window: '24h';
   timestamp: number;
 }
@@ -180,6 +187,21 @@ export async function computeObservabilityMetrics(
     laPushDeliveryRatio = { sent: 0, failed: 0, ratio: 0 };
   }
 
+  // 6. #1957 — algorithmAccuracyRatio. M2 정답지 응답 yes/no 비율 (pending 분모 제외).
+  //    alarmStats.groundTruthCounts = { yes, no, pending } (source='ground-truth-response').
+  //    pending은 응답률 신호(answeredTotal)로 노출, 정확도 분모에서는 제외.
+  const groundTruthDenominator =
+    alarmStats.groundTruthCounts.yes + alarmStats.groundTruthCounts.no;
+  const algorithmAccuracyRatio = {
+    value: alarmStats.groundTruthCounts.yes,
+    total: groundTruthDenominator,
+    ratio: groundTruthDenominator === 0 ? 0 : alarmStats.groundTruthCounts.yes / groundTruthDenominator,
+    answeredTotal:
+      alarmStats.groundTruthCounts.yes +
+      alarmStats.groundTruthCounts.no +
+      alarmStats.groundTruthCounts.pending,
+  };
+
   return {
     accuracyRatio,
     silentPushDeliveryRatio,
@@ -189,6 +211,7 @@ export async function computeObservabilityMetrics(
     silentPushLatency,
     laPushDeliveryRatio,
     silentPushReachRatio,
+    algorithmAccuracyRatio,
     window: '24h',
     timestamp: now,
   };

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -89,6 +89,7 @@ import {
   logBoardableLookupResult,
   _resetBoardableLookupWindowForTests,
   BOARDABLE_LOOKUP_DEDUP_MS,
+  logGroundTruthResult,
   ALARM_LOG_BUFFER_SIZE,
   type AlarmLogEntry,
   type AlarmLogStamp,
@@ -2985,6 +2986,56 @@ describe('alarmLog', () => {
       await flushAlarmLog();
       const stored = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string) as AlarmLogEntry[];
       const matches = stored.filter((e) => e.source === 'boardable-lookup');
+      expect(matches).toHaveLength(2);
+    });
+  });
+
+  // ── #1957 logGroundTruthResult ──────────────────────────────────────────────
+
+  describe('logGroundTruthResult (#1957)', () => {
+    it('outcome="accurate" → source=ground-truth-response / outcome=fired / corrId in stationName', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logGroundTruthResult({ corrId: 'trip-abc-1234', outcome: 'accurate' });
+      await flushAlarmLog();
+      const stored = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string) as AlarmLogEntry[];
+      expect(stored).toHaveLength(1);
+      expect(stored[0].source).toBe('ground-truth-response');
+      expect(stored[0].outcome).toBe('fired');
+      expect(stored[0].stationName).toBe('trip-abc-1234');
+    });
+
+    it('outcome="inaccurate" → outcome=suppressed', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logGroundTruthResult({ corrId: 'trip-def-5678', outcome: 'inaccurate' });
+      await flushAlarmLog();
+      const stored = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string) as AlarmLogEntry[];
+      expect(stored).toHaveLength(1);
+      expect(stored[0].source).toBe('ground-truth-response');
+      expect(stored[0].outcome).toBe('suppressed');
+      expect(stored[0].stationName).toBe('trip-def-5678');
+    });
+
+    it('outcome="unanswered" → outcome=received', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logGroundTruthResult({ corrId: 'trip-ghi-9012', outcome: 'unanswered' });
+      await flushAlarmLog();
+      const stored = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string) as AlarmLogEntry[];
+      expect(stored).toHaveLength(1);
+      expect(stored[0].source).toBe('ground-truth-response');
+      expect(stored[0].outcome).toBe('received');
+      expect(stored[0].stationName).toBe('trip-ghi-9012');
+    });
+
+    it('연속 호출은 모두 적재 (dedup 없음)', async () => {
+      // 같은 corrId 동일 outcome으로 두 번 호출해도 dedup 없이 둘 다 적재되는지 검증.
+      // 실제 운영에서는 store.respond가 pendingPrompt를 null로 비워 두 번째 호출 차단하지만,
+      // 본 함수 단위에서는 raw 호출 1:1을 보장한다.
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      logGroundTruthResult({ corrId: 'trip-abc', outcome: 'accurate' });
+      logGroundTruthResult({ corrId: 'trip-abc', outcome: 'accurate' });
+      await flushAlarmLog();
+      const stored = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string) as AlarmLogEntry[];
+      const matches = stored.filter((e) => e.source === 'ground-truth-response');
       expect(matches).toHaveLength(2);
     });
   });

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -82,7 +82,15 @@ export type AlarmLogSource =
   // computeBoardableWaitsForRoute가 transfer leg마다 calculateBoardableTrainETA 호출 후
   // status에 따라 outcome='received'(ok) 또는 outcome='suppressed'(miss) 적재. backend
   // alarmLogStats가 source='boardable-lookup' + outcome로 boardableMissRatio 산출.
-  | 'boardable-lookup';
+  | 'boardable-lookup'
+  // #1957 (#1503 잔여 1/3) — M2 사용자 정답지 응답 stamp. useTripGroundTruthStore.respond()가
+  // 호출 후 outcome 분기로 적재:
+  //   'accurate'   → outcome='fired'      (yes 정답)
+  //   'inaccurate' → outcome='suppressed' (no 오답)
+  //   'unanswered' → outcome='received'   (pending 회피/dismiss/자동 만료)
+  // backend alarmLogStats가 source='ground-truth-response' + outcome로 groundTruthCounts 누적,
+  // observabilityMetrics.algorithmAccuracyRatio = yes / (yes + no) 산출.
+  | 'ground-truth-response';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(#580): evaluateAlarmPhase의 firedAlarms 적중. destination/transfer phase alarm dedup
 // 발생 관찰. station-passed는 별도 메커니즘(lastNotifiedStationId)이라 'dedup-station' 사용.
@@ -1147,6 +1155,7 @@ const SILENT_PUSH_OUTCOME_SOURCES: Record<AlarmLogSource, keyof SilentPushOutcom
   'accel-pattern-observed': null,
   'leg-transition': null,
   'boardable-lookup': null,
+  'ground-truth-response': null,
 };
 
 export interface SilentPushOutcomeCounts {
@@ -1799,6 +1808,41 @@ export function logBoardableLookupResult(input: {
 /** 테스트용 — boardable lookup dedup 윈도우 리셋. */
 export function _resetBoardableLookupWindowForTests(): void {
   lastBoardableLookupTs.clear();
+}
+
+// #1957 (#1503 잔여 1/3) — ground-truth-response outcome 매핑.
+// useTripGroundTruthStore의 outcome union('accurate'/'inaccurate'/'unanswered')을 alarmLog
+// outcome 슬롯('fired'/'suppressed'/'received')으로 변환. backend alarmLogStats가 outcome 분기로
+// groundTruthCounts(yes/no/pending) 누적. 데이터 주도 매핑 — 새 outcome 추가 시 이 record만 수정.
+const GROUND_TRUTH_OUTCOME_TO_ALARM_LOG_OUTCOME: Readonly<
+  Record<'accurate' | 'inaccurate' | 'unanswered', AlarmLogOutcome>
+> = {
+  accurate: 'fired', // yes (정답)
+  inaccurate: 'suppressed', // no (오답)
+  unanswered: 'received', // pending (회피/dismiss/자동 만료)
+};
+
+/**
+ * #1957 (#1503 잔여 1/3) — M2 사용자 정답지 응답 1건 적재.
+ *
+ * `useTripGroundTruthStore.respond()`가 호출 직후 alarmLog에 stamp한다.
+ * trip corrId가 stationName 슬롯에 인코딩 — backend alarmLogStats가 outcome 분기만 보고
+ * groundTruthCounts(yes/no/pending) 누적, observabilityMetrics.algorithmAccuracyRatio
+ * = yes / (yes + no) 산출. corrId는 RCA용 (어느 trip에서 inaccurate 빈발).
+ *
+ * dedup 없음 — 응답 1건당 1 stamp가 1:1 신호. 사용자가 동일 trip에 대해 두 번 응답할 수
+ * 없으므로 (store.respond가 pendingPrompt를 null로 비워서 차단) burst 가능성 없음.
+ */
+export function logGroundTruthResult(input: {
+  corrId: string;
+  outcome: 'accurate' | 'inaccurate' | 'unanswered';
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'ground-truth-response',
+    outcome: GROUND_TRUTH_OUTCOME_TO_ALARM_LOG_OUTCOME[input.outcome],
+    stationName: input.corrId,
+  });
 }
 
 /**

--- a/src/features/debug/components/OperationDashboardSection.tsx
+++ b/src/features/debug/components/OperationDashboardSection.tsx
@@ -34,6 +34,7 @@ import {
   type AccelPatternBucket,
   type LaPushDeliveryBucket,
   type SilentPushReachBucket,
+  type AlgorithmAccuracyBucket,
   type FetchMetricsResult,
 } from '../../observability/api/observabilityMetricsClient';
 import {
@@ -75,6 +76,8 @@ type BackendLoadState =
       laPushDelivery: LaPushDeliveryBucket;
       /** #1958 — backend 5min corrId join 도달률. backend가 응답하지 않으면 null. */
       silentPushReach: SilentPushReachBucket | null;
+      /** #1957 — backend 24h algorithm accuracy. backend가 응답하지 않으면 null (구버전). */
+      algorithmAccuracy: AlgorithmAccuracyBucket | null;
     }
   | { kind: 'unconfigured' }
   | { kind: 'error'; message: string };
@@ -341,6 +344,7 @@ export function OperationDashboardSection({ logs, onMetricClick }: OperationDash
         pushLatency: result.metrics.silentPushLatency ?? null,
         laPushDelivery: result.metrics.laPushDeliveryRatio,
         silentPushReach: result.metrics.silentPushReachRatio ?? null,
+        algorithmAccuracy: result.metrics.algorithmAccuracyRatio ?? null,
       });
     } else if (result.kind === 'unconfigured') {
       setBackendState({ kind: 'unconfigured' });
@@ -354,16 +358,34 @@ export function OperationDashboardSection({ logs, onMetricClick }: OperationDash
     void doFetch();
   }, [doFetch]);
 
-  // Metric 1 — 알람 정확성 (M2 구현 기반)
-  const accurateCount = responses.filter((r) => r.outcome === 'accurate').length;
-  const answeredCount = responses.filter((r) => r.outcome !== 'unanswered').length;
-  const alarmAccuracy: MetricData = {
-    key: 'alarmAccuracy',
-    label: 'alarmAccuracy',
-    ratio: computeRatio(accurateCount, answeredCount),
-    numerator: accurateCount,
-    denominator: answeredCount,
-  };
+  // Metric 1 — 알람 정확성 (M2 구현 기반).
+  // #1957 — backend `algorithmAccuracyRatio` 우선, 미수신 시 local store(`responses`) fallback.
+  // backend는 24h R2 archive 집계로 다중 device 합산 신호 (SSoT), local store는 본 device
+  // 직전 50건만 — 응답 직후 즉시 갱신용 fallback. backend wire(`backendState.algorithmAccuracy`)가
+  // null이면 (구버전 응답 / 미수신) local store 사용해 라이브 응답을 즉시 반영.
+  const localAccurateCount = responses.filter((r) => r.outcome === 'accurate').length;
+  const localAnsweredCount = responses.filter((r) => r.outcome !== 'unanswered').length;
+  const backendAlgorithmAccuracy =
+    backendState.kind === 'ok' ? backendState.algorithmAccuracy : null;
+  const alarmAccuracy: MetricData =
+    backendAlgorithmAccuracy !== null
+      ? {
+          key: 'alarmAccuracy',
+          label: 'alarmAccuracy',
+          ratio: computeRatio(backendAlgorithmAccuracy.value, backendAlgorithmAccuracy.total),
+          numerator: backendAlgorithmAccuracy.value,
+          denominator: backendAlgorithmAccuracy.total,
+          isMock: false,
+        }
+      : {
+          key: 'alarmAccuracy',
+          label: 'alarmAccuracy',
+          ratio: computeRatio(localAccurateCount, localAnsweredCount),
+          numerator: localAccurateCount,
+          denominator: localAnsweredCount,
+          // backend 미수신 시 local store 기반 임시 표시 — [mock] suffix로 명시.
+          isMock: backendState.kind !== 'ok',
+        };
 
   // Metric 2 — Silent push 도달률 (received 중 fired 비율)
   const silentCounts = countSilentPushOutcomes(logs);

--- a/src/features/debug/components/__tests__/OperationDashboardSection.test.tsx
+++ b/src/features/debug/components/__tests__/OperationDashboardSection.test.tsx
@@ -100,6 +100,8 @@ function makeSuccessResult(
     joined: 0,
     ratio: 0,
   },
+  // #1957 — backend 24h algorithm accuracy. undefined = 구 backend 응답 (필드 누락 simulating).
+  algorithmAccuracy: observabilityClient.AlgorithmAccuracyBucket | undefined = undefined,
 ): observabilityClient.FetchMetricsResult {
   const metrics: observabilityClient.ObservabilityMetrics = {
     accuracyRatio: { value: 8, total: 10, ratio: 0.8 },
@@ -109,6 +111,7 @@ function makeSuccessResult(
     accelPatternHitRatio: accelPattern,
     silentPushLatency: pushLatency,
     laPushDeliveryRatio: { sent: laSent, failed: laFailed, ratio: laSent / (laSent + laFailed) },
+    algorithmAccuracyRatio: algorithmAccuracy,
     window: '24h',
     timestamp: 1_700_000_000_000,
     ...(silentPushReach !== null ? { silentPushReachRatio: silentPushReach } : {}),
@@ -611,6 +614,62 @@ describe('OperationDashboardSection', () => {
         const naBars = screen.getAllByTestId('ratio-bar-na');
         expect(naBars.length).toBeGreaterThanOrEqual(1);
       });
+    });
+  });
+
+  // #1957 — backend algorithmAccuracyRatio metric 우선 사용, local store fallback
+  // 10번째 param algorithmAccuracy 사용 — #1958이 9번째 silentPushReach 추가 후 우리는 한 칸 밀려서 10번째.
+  describe('#1957 — algorithmAccuracyRatio metric (backend SSoT + local fallback)', () => {
+    it('backend algorithmAccuracyRatio 수신 → ratio bar 렌더 (mock 아님)', async () => {
+      // backend에서 yes=8, no=2, ratio=0.8, answeredTotal=12 수신.
+      mockFetchMetrics.mockResolvedValue(
+        makeSuccessResult(
+          2,
+          10,
+          0,
+          0,
+          DEFAULT_ACCEL_PATTERN,
+          null,
+          10,
+          2,
+          null, // silentPushReach=null (구 backend simulating으로 필드 omit)
+          { value: 8, total: 10, ratio: 0.8, answeredTotal: 12 },
+        ),
+      );
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      await waitFor(() => {
+        expect(screen.getByTestId('operation-metric-alarmAccuracy')).toBeTruthy();
+      });
+      // backend 수신 시 isMock=false → [mock] 라벨 없음. ratio bar 렌더 확인.
+      const tracks = screen.getAllByTestId('ratio-bar-track');
+      expect(tracks.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('backend algorithmAccuracyRatio 미수신 (구버전 backend) → local store fallback', async () => {
+      // makeSuccessResult 기본은 algorithmAccuracy=undefined → 구버전 응답 시나리오.
+      setupStore([
+        { outcome: 'accurate' },
+        { outcome: 'accurate' },
+        { outcome: 'inaccurate' },
+      ]);
+      mockFetchMetrics.mockResolvedValue(makeSuccessResult());
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      // store fallback: accurate=2, answered=3 → ratio bar 렌더.
+      const tracks = screen.getAllByTestId('ratio-bar-track');
+      expect(tracks.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('backend 응답 전 (idle/unconfigured) → local store fallback', async () => {
+      setupStore([{ outcome: 'accurate' }, { outcome: 'inaccurate' }]);
+      // unconfigured 응답: backend 미수신 → local fallback 사용.
+      mockFetchMetrics.mockResolvedValue({ kind: 'unconfigured' });
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      const tracks = screen.getAllByTestId('ratio-bar-track');
+      // 1/2 = 0.5 비율 ratio bar 1건 + 다른 metric bar들 포함.
+      expect(tracks.length).toBeGreaterThanOrEqual(1);
     });
   });
 });

--- a/src/features/debug/store/__tests__/useTripGroundTruthStore.test.ts
+++ b/src/features/debug/store/__tests__/useTripGroundTruthStore.test.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { TRIP_GROUND_TRUTH_KEY } from '../../../../shared/constants/storageKeys';
+import { logGroundTruthResult } from '../../../alarm/utils/alarmLog';
 import {
   RESPONSE_BUFFER_CAPACITY,
   getRecentResponses,
@@ -12,8 +13,15 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   setItem: jest.fn(),
 }));
 
+// #1957 — store.respond가 backend metric forward 위해 logGroundTruthResult를 호출.
+// 본 store unit test에서는 alarmLog 적재까지 검증하지 않고 호출 자체만 검증 (alarmLog 단위 테스트가 따로).
+jest.mock('../../../alarm/utils/alarmLog', () => ({
+  logGroundTruthResult: jest.fn(),
+}));
+
 const mockGetItem = AsyncStorage.getItem as jest.MockedFunction<typeof AsyncStorage.getItem>;
 const mockSetItem = AsyncStorage.setItem as jest.MockedFunction<typeof AsyncStorage.setItem>;
+const mockLogGroundTruthResult = logGroundTruthResult as jest.MockedFunction<typeof logGroundTruthResult>;
 
 describe('useTripGroundTruthStore (#1502 M2)', () => {
   beforeEach(() => {
@@ -25,6 +33,7 @@ describe('useTripGroundTruthStore (#1502 M2)', () => {
     mockGetItem.mockReset();
     mockSetItem.mockReset();
     mockSetItem.mockResolvedValue();
+    mockLogGroundTruthResult.mockReset();
   });
 
   describe('enqueuePrompt', () => {
@@ -102,6 +111,44 @@ describe('useTripGroundTruthStore (#1502 M2)', () => {
         .enqueuePrompt({ corrId: 'c2', endedAt: 200 });
       await useTripGroundTruthStore.getState().respond('unanswered');
       expect(useTripGroundTruthStore.getState().responses[1].outcome).toBe('unanswered');
+    });
+
+    // #1957 — backend algorithmAccuracyRatio metric wire
+    it('#1957 — pending 있을 때 응답 시 logGroundTruthResult(corrId, outcome) 호출', async () => {
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'wire-c1', endedAt: 100 });
+      await useTripGroundTruthStore.getState().respond('accurate');
+      expect(mockLogGroundTruthResult).toHaveBeenCalledTimes(1);
+      expect(mockLogGroundTruthResult).toHaveBeenCalledWith({
+        corrId: 'wire-c1',
+        outcome: 'accurate',
+      });
+    });
+
+    it('#1957 — inaccurate / unanswered도 그대로 forward', async () => {
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'wire-c2', endedAt: 200 });
+      await useTripGroundTruthStore.getState().respond('inaccurate');
+      expect(mockLogGroundTruthResult).toHaveBeenLastCalledWith({
+        corrId: 'wire-c2',
+        outcome: 'inaccurate',
+      });
+
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'wire-c3', endedAt: 300 });
+      await useTripGroundTruthStore.getState().respond('unanswered');
+      expect(mockLogGroundTruthResult).toHaveBeenLastCalledWith({
+        corrId: 'wire-c3',
+        outcome: 'unanswered',
+      });
+    });
+
+    it('#1957 — pending 없을 때 응답 시 logGroundTruthResult 호출되지 않음', async () => {
+      await useTripGroundTruthStore.getState().respond('accurate');
+      expect(mockLogGroundTruthResult).not.toHaveBeenCalled();
     });
 
     it('ring buffer가 capacity를 넘으면 오래된 것부터 drop', async () => {

--- a/src/features/debug/store/useTripGroundTruthStore.ts
+++ b/src/features/debug/store/useTripGroundTruthStore.ts
@@ -18,6 +18,11 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { create } from 'zustand';
 import { TRIP_GROUND_TRUTH_KEY } from '../../../shared/constants/storageKeys';
 import { createLogger } from '../../../shared/utils/logger';
+// #1957 (#1503 잔여 1/3) — M2 정답지 응답을 alarmLog로 stamp해 P0-3 forward → R2 archive →
+// backend alarmLogStats.groundTruthCounts 누적 → observabilityMetrics.algorithmAccuracyRatio.
+// debug 슬라이스의 정답지 응답 1건이 backend 정확도 metric의 원천 신호. cross-feature wire이지만
+// OperationDashboardSection.tsx 패턴과 동일하게 alarm/utils import 사용.
+import { logGroundTruthResult } from '../../alarm/utils/alarmLog';
 
 const logger = createLogger('tripGroundTruth');
 
@@ -123,6 +128,9 @@ export const useTripGroundTruthStore = create<TripGroundTruthState>((set, get) =
     ]);
     set({ pendingPrompt: null, responses: nextResponses });
     await persist({ pendingPrompt: null, responses: nextResponses });
+    // #1957 — 응답 1건을 alarmLog로 stamp해 backend algorithmAccuracyRatio metric의 원천 신호로
+    // forward. AsyncStorage persist와 무관하게 best-effort (graceful, throw 없음).
+    logGroundTruthResult({ corrId: pendingPrompt.corrId, outcome });
   },
 
   hydrate: async () => {

--- a/src/features/observability/api/observabilityMetricsClient.ts
+++ b/src/features/observability/api/observabilityMetricsClient.ts
@@ -44,6 +44,18 @@ export interface SilentPushReachBucket {
   ratio: number;
 }
 
+/**
+ * #1957 (#1503 잔여 1/3) — 알고리즘 정확성 응답 bucket.
+ * value = yes(정답) 건수, total = yes+no, ratio = value/total (분모 0이면 0).
+ * answeredTotal = yes+no+pending — 응답률 신호 (1주 30%+ acceptance).
+ */
+export interface AlgorithmAccuracyBucket {
+  value: number;
+  total: number;
+  ratio: number;
+  answeredTotal: number;
+}
+
 export interface ObservabilityMetrics {
   accuracyRatio: ObservabilityMetricsBucket;
   silentPushDeliveryRatio: ObservabilityMetricsBucket;
@@ -63,6 +75,11 @@ export interface ObservabilityMetrics {
    * 구 backend(필드 미응답) 호환 위해 optional — UI는 누락 시 placeholder 표시.
    */
   silentPushReachRatio?: SilentPushReachBucket;
+  /**
+   * #1957 (#1503 잔여 1/3) — 알고리즘 정확성. M2 정답지 응답 yes/(yes+no).
+   * 신규 필드 — 구버전 backend는 미수신할 수 있으므로 optional.
+   */
+  algorithmAccuracyRatio?: AlgorithmAccuracyBucket;
   window: '24h';
   timestamp: number;
 }


### PR DESCRIPTION
## Summary
- backend algorithmAccuracyRatio metric (yes / (yes+no), pending 분모 제외 + answeredTotal 노출)
- backend groundTruthCounts (yes/no/pending) 누적 (source='ground-truth-response' + outcome 분기)
- frontend logGroundTruthResult(corrId, outcome) wire + OperationDashboard 라인 (backend 우선, local store fallback)

Closes #1957 (#1503 잔여 1/3)

## 구현 결정

### outcome 매핑 (데이터 주도)
M2 store의 `accurate`/`inaccurate`/`unanswered`를 기존 `AlarmLogOutcome` union(`fired`/`suppressed`/`received`)에 매핑:
- `accurate` → `outcome='fired'` (yes 정답)
- `inaccurate` → `outcome='suppressed'` (no 오답)
- `unanswered` → `outcome='received'` (pending 회피/dismiss/자동 만료)

새 outcome 타입 추가 안 함 — 기존 union 재사용. boardable-lookup이 이미 같은 패턴 사용.

### Backend `answeredTotal` 별도 노출
- `algorithmAccuracyRatio.total` = yes + no (정확도 분모)
- `algorithmAccuracyRatio.answeredTotal` = yes + no + pending (응답률 신호)
이슈 acceptance "1주 응답률 30%+"를 별도 측정 가능. P5 가중치 학습(#1763) prereq.

### Frontend backend SSoT + local fallback
- backend `algorithmAccuracyRatio` 수신 → SSoT (24h R2 archive 다중 device 합산)
- backend 미수신(unconfigured/error/구버전) → local store responses fallback ([mock] label)
- 응답 직후 즉시 라이브 반영 — backend cron 1h 주기 대비 user feedback 즉각 가시.

## Wire-completion 5단 체크
1. **Orphan 없음** — `npm run lint:orphan` pass
2. **V/X dashboard** — DebugModal Operation Dashboard 첫 번째 metric 라인 (alarmAccuracy)
3. **의존 PR** — M2 #1502 머지됨. PR #1955 (boardable miss) 같은 영역 — dev 기준 작업 + cherry-pick 없음
4. **측정 plan** — 1주 응답률 30%+ + algorithmAccuracyRatio 신뢰성. backend `/v1/observability/metrics` GET 호출 또는 R2 `trip-evidence/*.ndjson` 스캔에서 `source='ground-truth-response'` 카운트
5. **Device verify** — 실기기 trip 1회 + Yes/No 응답 → DebugModal alarmAccuracy 행 갱신 확인 (backend 미수신 시 [mock] suffix 표시)

## Test plan
- [x] `npm test` 커버리지 100% (8625 passed)
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass (No orphan exports detected)
- [x] backend `npx vitest run alarmLogStats observabilityMetrics` 75 passed

## Known risks
- frontend backend node_modules가 worktree에 미설치 (jose/hono/@sentry/cloudflare) → 변경 무관, CI는 메인에서 통과
- 구버전 backend 응답에 `algorithmAccuracyRatio` 누락 → frontend `?` optional이라 graceful (local store fallback)
- KV cached 응답에 신규 키 누락 가능 → 다음 cron(1h)에 갱신, 즉시는 fallback 경로

## 관련
- Epic #1500 / Parent #1503 잔여 1/3
- M2 #1502 (정답지 UI 머지)
- PR #1955 (boardable miss) 패턴 그대로 따름