### PR TITLE
feat(#1973): 안내 시작/중단 명시 UX — WhileInUse + route 후 BG GPS 지속 (네이버 패턴)

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useBackgroundLocation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useBackgroundLocation.test.ts
@@ -1,3 +1,6 @@
+// #1973 — useBackgroundLocation은 cross-feature orchestrator로 route/store/useNavigationStore를
+// 명시적으로 소비. 테스트에서도 같은 store를 직접 set/read해야 navigationActive lifecycle을 검증할 수 있다.
+/* eslint-disable import/no-restricted-paths */
 import { renderHook, waitFor } from '@testing-library/react-native';
 import { Alert, Linking } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -9,11 +12,14 @@ const mockAlertAlert = jest.spyOn(Alert, 'alert').mockImplementation(() => undef
 const mockOpenSettings = jest.spyOn(Linking, 'openSettings').mockResolvedValue();
 
 // ── expo-location 모킹 ──
+const mockRequestForegroundPermissionsAsync = jest.fn();
 const mockRequestBackgroundPermissionsAsync = jest.fn();
 const mockStartLocationUpdatesAsync = jest.fn();
 const mockStopLocationUpdatesAsync = jest.fn();
 
 jest.mock('expo-location', () => ({
+  requestForegroundPermissionsAsync: (...args: unknown[]) =>
+    mockRequestForegroundPermissionsAsync(...args),
   requestBackgroundPermissionsAsync: (...args: unknown[]) =>
     mockRequestBackgroundPermissionsAsync(...args),
   startLocationUpdatesAsync: (...args: unknown[]) =>
@@ -51,6 +57,7 @@ jest.mock('../../../../shared/utils/logger', () => ({
 
 import { useBackgroundLocation } from '../useBackgroundLocation';
 import { LOCATION_TRACKING_OPTIONS } from '../../../../shared/constants/locationTracking';
+import { useNavigationStore } from '../../../route/store/useNavigationStore';
 
 // ── 픽스처 ──
 
@@ -72,15 +79,84 @@ const mockDestination2: Station = {
   lng: 127.028,
 };
 
-describe('useBackgroundLocation', () => {
+describe('useBackgroundLocation (#1973 명시 trigger)', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     // #791: dismiss flag는 AsyncStorage(영속)에 저장되므로 매 테스트마다 초기화.
     await AsyncStorage.clear();
     mockStopLocationUpdatesAsync.mockResolvedValue(undefined);
+    // 기본: Always granted (호환 — 기존 시나리오)
+    mockRequestForegroundPermissionsAsync.mockResolvedValue({ status: 'granted' });
     mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'granted' });
     mockIsTaskRegisteredAsync.mockResolvedValue(false);
     mockStartLocationUpdatesAsync.mockResolvedValue(undefined);
+    // #1973 — 매 테스트 navigationActive=true로 set (명시 trigger 후 시나리오가 default).
+    useNavigationStore.setState({ navigationActive: true });
+  });
+
+  afterEach(() => {
+    useNavigationStore.setState({ navigationActive: false });
+  });
+
+  // ── #1973 — navigationActive=false 시 자동 trigger 차단 ──
+
+  describe('#1973 — 명시 trigger 패러다임', () => {
+    it('navigationActive=false이면 destination 있어도 startLocationUpdatesAsync 미호출 (자동 trigger 차단)', async () => {
+      useNavigationStore.setState({ navigationActive: false });
+
+      renderHook(() => useBackgroundLocation(mockDestination));
+
+      await waitFor(() => {
+        expect(mockStopLocationUpdatesAsync).toHaveBeenCalledWith('background-location-task');
+      });
+
+      expect(mockRequestForegroundPermissionsAsync).not.toHaveBeenCalled();
+      expect(mockRequestBackgroundPermissionsAsync).not.toHaveBeenCalled();
+      expect(mockStartLocationUpdatesAsync).not.toHaveBeenCalled();
+    });
+
+    it('navigationActive false→true 전환 시 effect 재실행되어 startLocationUpdatesAsync 호출', async () => {
+      useNavigationStore.setState({ navigationActive: false });
+
+      const { rerender } = renderHook(() => useBackgroundLocation(mockDestination));
+
+      await waitFor(() => {
+        expect(mockStopLocationUpdatesAsync).toHaveBeenCalled();
+      });
+      expect(mockStartLocationUpdatesAsync).not.toHaveBeenCalled();
+
+      jest.clearAllMocks();
+      mockRequestForegroundPermissionsAsync.mockResolvedValue({ status: 'granted' });
+      mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'granted' });
+      mockIsTaskRegisteredAsync.mockResolvedValue(false);
+      mockStartLocationUpdatesAsync.mockResolvedValue(undefined);
+
+      useNavigationStore.setState({ navigationActive: true });
+      rerender({});
+
+      await waitFor(() => {
+        expect(mockStartLocationUpdatesAsync).toHaveBeenCalled();
+      });
+    });
+
+    it('navigationActive true→false 전환 시 stopLocationUpdatesAsync 호출 (안내 중단)', async () => {
+      const { rerender } = renderHook(() => useBackgroundLocation(mockDestination));
+
+      await waitFor(() => {
+        expect(mockStartLocationUpdatesAsync).toHaveBeenCalled();
+      });
+
+      jest.clearAllMocks();
+      mockStopLocationUpdatesAsync.mockResolvedValue(undefined);
+
+      useNavigationStore.setState({ navigationActive: false });
+      rerender({});
+
+      await waitFor(() => {
+        expect(mockStopLocationUpdatesAsync).toHaveBeenCalledWith('background-location-task');
+      });
+      expect(mockStartLocationUpdatesAsync).not.toHaveBeenCalled();
+    });
   });
 
   // ── destination이 null인 경우 ──
@@ -92,6 +168,7 @@ describe('useBackgroundLocation', () => {
       expect(mockStopLocationUpdatesAsync).toHaveBeenCalledWith('background-location-task');
     });
 
+    expect(mockRequestForegroundPermissionsAsync).not.toHaveBeenCalled();
     expect(mockRequestBackgroundPermissionsAsync).not.toHaveBeenCalled();
     expect(mockStartLocationUpdatesAsync).not.toHaveBeenCalled();
     unmount();
@@ -110,24 +187,22 @@ describe('useBackgroundLocation', () => {
     unmount();
   });
 
-  // ── 권한 허용 + 태스크 미등록: 정상 시작 ──
+  // ── #1973 권한 단계화: WhileInUse + Always 둘 다 granted (Always 사용자) ──
 
-  it('권한이 granted이고 태스크 미등록이면 startLocationUpdatesAsync를 호출한다', async () => {
+  it('Foreground granted + Background granted (Always 사용자) → startLocationUpdatesAsync 호출', async () => {
     renderHook(() => useBackgroundLocation(mockDestination));
 
     await waitFor(() => {
       expect(mockStartLocationUpdatesAsync).toHaveBeenCalled();
     });
 
+    expect(mockRequestForegroundPermissionsAsync).toHaveBeenCalled();
+    expect(mockRequestBackgroundPermissionsAsync).toHaveBeenCalled();
     expect(mockStartLocationUpdatesAsync).toHaveBeenCalledWith(
       'background-location-task',
       expect.any(Object),
     );
 
-    // 회귀 가드: 추적 옵션 형태를 LOCATION_TRACKING_OPTIONS 상수와 strict 비교.
-    // - 임의 키 추가(예: deferredUpdatesInterval 재유입) → toEqual 실패
-    // - 키 제거/변경 → toEqual 실패
-    // foregroundService는 i18n 의존이라 분리 검증.
     const callArgs = mockStartLocationUpdatesAsync.mock.calls[0]?.[1] as Record<string, unknown>;
     const { foregroundService, ...trackingOpts } = callArgs;
     expect(trackingOpts).toEqual(LOCATION_TRACKING_OPTIONS);
@@ -137,22 +212,38 @@ describe('useBackgroundLocation', () => {
     });
   });
 
-  // ── 권한 거부 ──
+  // ── #1973 권한 단계화: WhileInUse granted + Always denied (네이버 패턴 핵심) ──
 
-  it('권한이 denied이면 startLocationUpdatesAsync를 호출하지 않는다', async () => {
+  it('Foreground granted + Background denied (WhileInUse 사용자) → 그래도 startLocationUpdatesAsync 호출 (네이버 패턴)', async () => {
+    mockRequestForegroundPermissionsAsync.mockResolvedValueOnce({ status: 'granted' });
     mockRequestBackgroundPermissionsAsync.mockResolvedValueOnce({ status: 'denied' });
 
     renderHook(() => useBackgroundLocation(mockDestination));
 
     await waitFor(() => {
-      expect(mockRequestBackgroundPermissionsAsync).toHaveBeenCalled();
+      expect(mockStartLocationUpdatesAsync).toHaveBeenCalled();
+    });
+    // Background denied여도 Alert 띄우지 않음 (WhileInUse만으로 진행 — 네이버 패턴)
+    expect(mockAlertAlert).not.toHaveBeenCalled();
+  });
+
+  // ── #1973 권한 단계화: WhileInUse denied → 권한 안내 Alert + startLocationUpdatesAsync 미호출 ──
+
+  it('Foreground denied → startLocationUpdatesAsync 미호출 + Alert 노출 (#387 보존)', async () => {
+    mockRequestForegroundPermissionsAsync.mockResolvedValueOnce({ status: 'denied' });
+
+    renderHook(() => useBackgroundLocation(mockDestination));
+
+    await waitFor(() => {
+      expect(mockAlertAlert).toHaveBeenCalled();
     });
 
+    expect(mockRequestBackgroundPermissionsAsync).not.toHaveBeenCalled();
     expect(mockStartLocationUpdatesAsync).not.toHaveBeenCalled();
   });
 
-  it('권한이 denied이면 안내 Alert를 띄우고 "설정 열기" 탭 시 Linking.openSettings를 호출한다 (#387)', async () => {
-    mockRequestBackgroundPermissionsAsync.mockResolvedValueOnce({ status: 'denied' });
+  it('Foreground denied 시 "설정 열기" 탭 → Linking.openSettings 호출', async () => {
+    mockRequestForegroundPermissionsAsync.mockResolvedValueOnce({ status: 'denied' });
 
     renderHook(() => useBackgroundLocation(mockDestination));
 
@@ -162,14 +253,13 @@ describe('useBackgroundLocation', () => {
 
     const [, , buttons] = mockAlertAlert.mock.calls[0]!;
     expect(buttons).toHaveLength(2);
-    // 첫 번째 버튼은 닫기(cancel), 두 번째 버튼은 설정 열기.
     const openSettingsBtn = (buttons as Array<{ onPress?: () => void }>)[1];
     openSettingsBtn?.onPress?.();
     expect(mockOpenSettings).toHaveBeenCalled();
   });
 
-  it('같은 hook 라이프타임에서 denied가 반복돼도 Alert는 한 번만 노출한다 (#387)', async () => {
-    mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
+  it('Foreground denied 반복 시 dismiss flag로 Alert 한 번만 노출', async () => {
+    mockRequestForegroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
 
     const { rerender } = renderHook(
       ({ dest }: { dest: Station | null }) => useBackgroundLocation(dest),
@@ -183,7 +273,7 @@ describe('useBackgroundLocation', () => {
     rerender({ dest: mockDestination2 });
 
     await waitFor(() => {
-      expect(mockRequestBackgroundPermissionsAsync).toHaveBeenCalledTimes(2);
+      expect(mockRequestForegroundPermissionsAsync).toHaveBeenCalledTimes(2);
     });
 
     expect(mockAlertAlert).toHaveBeenCalledTimes(1);
@@ -191,7 +281,7 @@ describe('useBackgroundLocation', () => {
 
   // #791: dismiss 플래그가 AsyncStorage에 영속 저장되어 앱 재시작 후에도 Alert가 다시 뜨지 않는다.
   it('#791 첫 denied Alert 후 dismiss 플래그가 AsyncStorage에 저장된다', async () => {
-    mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
+    mockRequestForegroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
 
     renderHook(() => useBackgroundLocation(mockDestination));
 
@@ -203,20 +293,19 @@ describe('useBackgroundLocation', () => {
   });
 
   it('#791 새 hook instance(앱 재시작 시나리오)에서도 dismiss 플래그가 있으면 Alert 미노출', async () => {
-    mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
+    mockRequestForegroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
     await AsyncStorage.setItem(BG_PERMISSION_DENIED_DISMISSED_KEY, 'true');
 
     renderHook(() => useBackgroundLocation(mockDestination));
 
     await waitFor(() => {
-      expect(mockRequestBackgroundPermissionsAsync).toHaveBeenCalled();
+      expect(mockRequestForegroundPermissionsAsync).toHaveBeenCalled();
     });
-    // 권한 요청은 여전히 일어나지만 Alert는 띄우지 않는다.
     expect(mockAlertAlert).not.toHaveBeenCalled();
   });
 
   it('#791 AsyncStorage getItem 오류는 "미노출 이력 없음"으로 처리 → Alert 정상 노출', async () => {
-    mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
+    mockRequestForegroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
     const getItemSpy = jest
       .spyOn(AsyncStorage, 'getItem')
       .mockRejectedValueOnce(new Error('storage corrupt'));
@@ -231,7 +320,7 @@ describe('useBackgroundLocation', () => {
   });
 
   it('#791 AsyncStorage setItem 오류는 silent — Alert는 여전히 노출', async () => {
-    mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
+    mockRequestForegroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
     const setItemSpy = jest
       .spyOn(AsyncStorage, 'setItem')
       .mockRejectedValueOnce(new Error('disk full'));
@@ -246,7 +335,7 @@ describe('useBackgroundLocation', () => {
   });
 
   it('#791 hydrate 도중 unmount되면 Alert를 띄우지 않는다 (cancelled 가드)', async () => {
-    mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
+    mockRequestForegroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
     let resolveGetItem!: (value: string | null) => void;
     const getItemSpy = jest.spyOn(AsyncStorage, 'getItem').mockReturnValueOnce(
       new Promise<string | null>((resolve) => {
@@ -257,7 +346,7 @@ describe('useBackgroundLocation', () => {
     const { unmount } = renderHook(() => useBackgroundLocation(mockDestination));
 
     await waitFor(() => {
-      expect(mockRequestBackgroundPermissionsAsync).toHaveBeenCalled();
+      expect(mockRequestForegroundPermissionsAsync).toHaveBeenCalled();
     });
 
     unmount();
@@ -271,7 +360,7 @@ describe('useBackgroundLocation', () => {
   });
 
   it('#791 setItem(dismiss 저장) 도중 unmount되면 storage는 갱신되지만 Alert는 미노출', async () => {
-    mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
+    mockRequestForegroundPermissionsAsync.mockResolvedValue({ status: 'denied' });
     let resolveSetItem!: () => void;
     const setItemSpy = jest.spyOn(AsyncStorage, 'setItem').mockReturnValueOnce(
       new Promise<void>((resolve) => {
@@ -295,9 +384,9 @@ describe('useBackgroundLocation', () => {
     setItemSpy.mockRestore();
   });
 
-  it('cancelled(unmount race) 상태에서는 denied여도 Alert를 띄우지 않는다 (#387)', async () => {
+  it('cancelled(unmount race) 상태에서는 Foreground denied여도 Alert를 띄우지 않는다', async () => {
     let resolvePermission!: (value: { status: string }) => void;
-    mockRequestBackgroundPermissionsAsync.mockReturnValueOnce(
+    mockRequestForegroundPermissionsAsync.mockReturnValueOnce(
       new Promise<{ status: string }>((resolve) => {
         resolvePermission = resolve;
       }),
@@ -311,6 +400,29 @@ describe('useBackgroundLocation', () => {
     await Promise.resolve();
 
     expect(mockAlertAlert).not.toHaveBeenCalled();
+  });
+
+  it('#1973 — Background permission 응답 전 unmount 시 startLocationUpdatesAsync 미호출', async () => {
+    mockRequestForegroundPermissionsAsync.mockResolvedValueOnce({ status: 'granted' });
+    let resolveBackground!: (value: { status: string }) => void;
+    mockRequestBackgroundPermissionsAsync.mockReturnValueOnce(
+      new Promise<{ status: string }>((resolve) => {
+        resolveBackground = resolve;
+      }),
+    );
+
+    const { unmount } = renderHook(() => useBackgroundLocation(mockDestination));
+
+    await waitFor(() => {
+      expect(mockRequestBackgroundPermissionsAsync).toHaveBeenCalled();
+    });
+    unmount();
+    resolveBackground({ status: 'granted' });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockStartLocationUpdatesAsync).not.toHaveBeenCalled();
   });
 
   // ── 태스크가 이미 등록된 경우: GPS 추적 공백 방지를 위해 재시작하지 않음 ──
@@ -330,9 +442,8 @@ describe('useBackgroundLocation', () => {
   // ── cleanup: cancelled 플래그로 경쟁 조건 방지 ──
 
   it('useEffect 클린업이 실행되면 cancelled=true로 startLocationUpdatesAsync를 호출하지 않는다', async () => {
-    // 권한 요청이 느리게 resolve되는 동안 컴포넌트가 unmount된 경우를 시뮬레이션
     let resolvePermission!: (value: { status: string }) => void;
-    mockRequestBackgroundPermissionsAsync.mockReturnValueOnce(
+    mockRequestForegroundPermissionsAsync.mockReturnValueOnce(
       new Promise<{ status: string }>((resolve) => {
         resolvePermission = resolve;
       }),
@@ -340,11 +451,9 @@ describe('useBackgroundLocation', () => {
 
     const { unmount } = renderHook(() => useBackgroundLocation(mockDestination));
 
-    // unmount로 cleanup(cancelled=true) 실행 후 권한 응답
     unmount();
     resolvePermission({ status: 'granted' });
 
-    // 마이크로태스크가 처리될 시간을 준다
     await Promise.resolve();
     await Promise.resolve();
 
@@ -352,7 +461,7 @@ describe('useBackgroundLocation', () => {
   });
 
   it('isTaskRegisteredAsync 응답 전 unmount되면 startLocationUpdatesAsync를 호출하지 않는다', async () => {
-    // 권한은 즉시 허용되지만 isTaskRegistered가 느린 경우
+    mockRequestForegroundPermissionsAsync.mockResolvedValueOnce({ status: 'granted' });
     mockRequestBackgroundPermissionsAsync.mockResolvedValueOnce({ status: 'granted' });
     let resolveRegistered!: (value: boolean) => void;
     mockIsTaskRegisteredAsync.mockReturnValueOnce(
@@ -363,12 +472,11 @@ describe('useBackgroundLocation', () => {
 
     const { unmount } = renderHook(() => useBackgroundLocation(mockDestination));
 
-    // 권한 응답까지 기다린 후 unmount
     await waitFor(() => {
       expect(mockIsTaskRegisteredAsync).toHaveBeenCalled();
     });
     unmount();
-    resolveRegistered(false); // 등록 안 됨으로 응답 — 하지만 이미 cancelled
+    resolveRegistered(false);
 
     await Promise.resolve();
     await Promise.resolve();
@@ -389,6 +497,7 @@ describe('useBackgroundLocation', () => {
     });
 
     jest.clearAllMocks();
+    mockRequestForegroundPermissionsAsync.mockResolvedValue({ status: 'granted' });
     mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'granted' });
     mockIsTaskRegisteredAsync.mockResolvedValue(false);
     mockStartLocationUpdatesAsync.mockResolvedValue(undefined);
@@ -411,6 +520,7 @@ describe('useBackgroundLocation', () => {
     });
 
     jest.clearAllMocks();
+    mockRequestForegroundPermissionsAsync.mockResolvedValue({ status: 'granted' });
     mockRequestBackgroundPermissionsAsync.mockResolvedValue({ status: 'granted' });
     mockIsTaskRegisteredAsync.mockResolvedValue(false);
     mockStartLocationUpdatesAsync.mockResolvedValue(undefined);

--- a/src/features/nearest-station/hooks/useBackgroundLocation.ts
+++ b/src/features/nearest-station/hooks/useBackgroundLocation.ts
@@ -1,3 +1,6 @@
+// 본 hook은 cross-feature orchestrator — useNavigationStore(`route` slice) +
+// LOCATION_TRACKING_OPTIONS / locationTracking constants(`shared`)를 같이 소비한다.
+// eslint-disable-next-line import/no-restricted-paths
 import { useEffect } from 'react';
 import { Alert, Linking } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -9,6 +12,8 @@ import { BACKGROUND_LOCATION_TASK } from '../tasks/backgroundLocationTask';
 import { LOCATION_TRACKING_OPTIONS } from '../../../shared/constants/locationTracking';
 import { BG_PERMISSION_DENIED_DISMISSED_KEY } from '../../../shared/constants/storageKeys';
 import { createLogger } from '../../../shared/utils/logger';
+// eslint-disable-next-line import/no-restricted-paths
+import { useNavigationStore } from '../../route/store/useNavigationStore';
 
 const logger = createLogger('BackgroundLocation');
 
@@ -36,11 +41,26 @@ async function markDeniedAlertDismissed(): Promise<void> {
   }
 }
 
+/**
+ * #1973 — 안내 시작 버튼 명시 trigger 패러다임 (네이버 지도 패턴).
+ *
+ * destination이 설정돼도 자동으로 BG GPS를 시작하지 않는다. 사용자가 명시적으로
+ * "안내 시작"을 탭해야 (`useNavigationStore.navigationActive=true`) BG 추적을 시작.
+ *
+ * 권한 단계화 (`requestForegroundPermissionsAsync` → `requestBackgroundPermissionsAsync`):
+ *  1. Foreground (WhileInUse) — 거부 시 영구 dismiss 안내 + BG 추적 skip.
+ *  2. Background (Always) — 선택 — 거부해도 진행. WhileInUse만 있어도 iOS는
+ *     `allowsBackgroundLocationUpdates=true` + `showsBackgroundLocationIndicator=true`로
+ *     명시 trigger 후 BG GPS 지속 + 파란 알약 표시를 허용한다.
+ *  3. `startLocationUpdatesAsync` — 권한 하나라도 granted + navigationActive면 시작.
+ */
 export function useBackgroundLocation(destination: Station | null): void {
   const { t } = useTranslation();
+  const navigationActive = useNavigationStore((s) => s.navigationActive);
 
   useEffect(() => {
-    if (!destination) {
+    // 자동 trigger 차단: destination만 있고 navigationActive=false면 BG GPS 미시작 (paradigm).
+    if (!destination || !navigationActive) {
       Location.stopLocationUpdatesAsync(BACKGROUND_LOCATION_TASK).catch(noop);
       return;
     }
@@ -48,31 +68,35 @@ export function useBackgroundLocation(destination: Station | null): void {
     let cancelled = false;
 
     (async () => {
-      const { status } = await Location.requestBackgroundPermissionsAsync();
-      if (status !== 'granted' || cancelled) {
-        logger.info('백그라운드 위치 권한 거부 또는 취소됨');
-        if (status !== 'granted' && !cancelled) {
-          // #791: 영구 dismiss 플래그를 AsyncStorage에서 확인. 한 번 안내를 받은 사용자에게
-          // 매 destination 변경/앱 재시작마다 같은 Alert를 띄우는 것은 스팸 + WhileInUse 1차
-          // 시나리오 정책 위반. dismiss 이력이 있으면 silent.
-          const dismissed = await isDeniedAlertDismissed();
-          if (cancelled || dismissed) return;
-          await markDeniedAlertDismissed();
-          // setItem await 동안 cleanup이 실행됐을 수 있음. dismissed 플래그는 storage에 들어가도
-          // Alert 발사는 차단(정책: 누락 1회 허용 > 스팸).
-          if (cancelled) return;
-          Alert.alert(
-            t('permissions.backgroundDeniedTitle'),
-            t('permissions.backgroundDeniedBody'),
-            [
-              { text: t('common.close'), style: 'cancel' },
-              { text: t('permissions.openSettings'), onPress: () => Linking.openSettings() },
-            ],
-          );
-        }
+      // Phase 1: Foreground (WhileInUse) — 최소 보장. 거부 시 BG 추적 자체 불가.
+      const fg = await Location.requestForegroundPermissionsAsync();
+      if (cancelled) return;
+      if (fg.status !== 'granted') {
+        logger.info('Foreground 위치 권한 거부됨 — BG 추적 skip');
+        const dismissed = await isDeniedAlertDismissed();
+        if (cancelled || dismissed) return;
+        await markDeniedAlertDismissed();
+        if (cancelled) return;
+        Alert.alert(
+          t('permissions.backgroundDeniedTitle'),
+          t('permissions.backgroundDeniedBody'),
+          [
+            { text: t('common.close'), style: 'cancel' },
+            { text: t('permissions.openSettings'), onPress: () => Linking.openSettings() },
+          ],
+        );
         return;
       }
 
+      // Phase 2: Background (Always) — 선택. 거부해도 진행 (WhileInUse만 있어도 OK).
+      // iOS `allowsBackgroundLocationUpdates=true`로 명시 trigger 후 BG GPS 지속 가능.
+      const bg = await Location.requestBackgroundPermissionsAsync();
+      if (cancelled) return;
+      if (bg.status !== 'granted') {
+        logger.info('Background(Always) 권한 거부 — WhileInUse로 진행 (네이버 패턴)');
+      }
+
+      // Phase 3: startLocationUpdatesAsync — WhileInUse granted 시 시작.
       const isRegistered = await TaskManager.isTaskRegisteredAsync(BACKGROUND_LOCATION_TASK);
       if (isRegistered || cancelled) return;
 
@@ -86,7 +110,7 @@ export function useBackgroundLocation(destination: Station | null): void {
           notificationBody: t('background.body'),
         },
       });
-      logger.info('백그라운드 위치 추적 시작');
+      logger.info('백그라운드 위치 추적 시작 (navigationActive)');
     })();
 
     return () => {
@@ -94,5 +118,5 @@ export function useBackgroundLocation(destination: Station | null): void {
       Location.stopLocationUpdatesAsync(BACKGROUND_LOCATION_TASK).catch(noop);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [destination?.id]);
+  }, [destination?.id, navigationActive]);
 }

--- a/src/features/route/store/__tests__/useNavigationStore.test.ts
+++ b/src/features/route/store/__tests__/useNavigationStore.test.ts
@@ -1,0 +1,56 @@
+/**
+ * #1973 — useNavigationStore 테스트.
+ *
+ * 휘발성 in-memory store (persist 미적용) — start/stop 상태 전환만 검증.
+ * coverage 100% — initial / startNavigation / stopNavigation / idempotent transitions.
+ */
+import { useNavigationStore } from '../useNavigationStore';
+
+describe('useNavigationStore (#1973)', () => {
+  beforeEach(() => {
+    // zustand는 모듈 싱글톤 — 매 테스트마다 state reset.
+    useNavigationStore.setState({ navigationActive: false });
+  });
+
+  describe('initial state', () => {
+    it('navigationActive default false (cold start 시 명시 trigger 필요)', () => {
+      expect(useNavigationStore.getState().navigationActive).toBe(false);
+    });
+  });
+
+  describe('startNavigation', () => {
+    it('navigationActive false → true 전환', () => {
+      useNavigationStore.getState().startNavigation();
+      expect(useNavigationStore.getState().navigationActive).toBe(true);
+    });
+
+    it('이미 true 상태에서 startNavigation 호출 시 idempotent (true 유지)', () => {
+      useNavigationStore.setState({ navigationActive: true });
+      useNavigationStore.getState().startNavigation();
+      expect(useNavigationStore.getState().navigationActive).toBe(true);
+    });
+  });
+
+  describe('stopNavigation', () => {
+    it('navigationActive true → false 전환', () => {
+      useNavigationStore.setState({ navigationActive: true });
+      useNavigationStore.getState().stopNavigation();
+      expect(useNavigationStore.getState().navigationActive).toBe(false);
+    });
+
+    it('이미 false 상태에서 stopNavigation 호출 시 idempotent (false 유지)', () => {
+      useNavigationStore.getState().stopNavigation();
+      expect(useNavigationStore.getState().navigationActive).toBe(false);
+    });
+  });
+
+  describe('start → stop 사이클', () => {
+    it('startNavigation → stopNavigation 사이클 정합 (사용자 안내 시작 후 중단)', () => {
+      const { startNavigation, stopNavigation } = useNavigationStore.getState();
+      startNavigation();
+      expect(useNavigationStore.getState().navigationActive).toBe(true);
+      stopNavigation();
+      expect(useNavigationStore.getState().navigationActive).toBe(false);
+    });
+  });
+});

--- a/src/features/route/store/useNavigationStore.ts
+++ b/src/features/route/store/useNavigationStore.ts
@@ -1,0 +1,62 @@
+/**
+ * #1973 — 안내 시작/중단 명시 의향 SSoT store.
+ *
+ * 네이버 지도/카카오맵 패턴 정합: 사용자가 "안내 시작" 버튼을 명시적으로 눌러야
+ * 백그라운드 GPS 추적 + 자동 lock chain이 활성화된다. WhileInUse 권한 사용자도
+ * 안내 시작 후 BG GPS 지속이 가능하다 (iOS `allowsBackgroundLocationUpdates=true`
+ * + `showsBackgroundLocationIndicator=true` — 파란 알약 자동 표시).
+ *
+ * paradigm 정합:
+ *  - `navigationActive=true` = 사용자 명시 의향 표명. ADR-014 §X "lock 활성과
+ *    동급 정확도 보장 의무" 적용. `feedback_user_intent_equal_protection` 룰의
+ *    "BoardingTrainList 직접 탭" 시리즈에 "안내 시작 버튼 탭" 추가 — 동급 보호.
+ *  - `navigationActive=false` + lockless trip + fire 0건 → paradigm-intent
+ *    (silent push 0건 정상, `lesson_silent_push_zero_is_paradigm_intent`).
+ *
+ * Lifecycle:
+ *  - 사용자 안내 시작 탭: `startNavigation()` — memory state true. HomeScreen이
+ *    `setInfoModeEnabled(true)` 자동 wire (useUserIntentStore, #1923).
+ *  - 사용자 안내 중단 탭: `stopNavigation()` — memory state false. HomeScreen이
+ *    `setInfoModeEnabled(false)` 자동 wire.
+ *  - 앱 재시작 / trip 종료: 휘발성 false 유지 — persist 의도적 미적용. 명시 의향이
+ *    cold start 사이 leak되지 않도록.
+ *
+ * `useUserIntentStore`와 별개 store인 이유:
+ *  - infoModeEnabled는 trip-bound persist (boardingPrompt 응답/직접 탭 흐름에서도
+ *    사용). navigationActive는 명시 trigger 전용 + 휘발성.
+ *  - HomeScreen에서 두 store를 명시적으로 wire (startNavigation → setInfoModeEnabled(true))
+ *    해야 backend lockless intermediate gate 통과.
+ */
+
+import { create } from 'zustand';
+
+export interface NavigationState {
+  /**
+   * 사용자 명시 의향 토글. true면 useBackgroundLocation이 BG GPS 추적 활성화 +
+   * HomeScreen이 useUserIntentStore.setInfoModeEnabled(true) wire.
+   * 의도적으로 휘발성 (persist 미적용) — cold start 시 false로 reset.
+   */
+  navigationActive: boolean;
+  /**
+   * 안내 시작. 사용자가 HomeScreen "안내 시작" 버튼을 탭할 때 호출.
+   * memory state만 true로 set (persist 미적용).
+   */
+  startNavigation: () => void;
+  /**
+   * 안내 중단. 사용자가 HomeScreen "안내 중단" 버튼을 탭할 때 호출.
+   * memory state false로 set. HomeScreen이 useBackgroundLocation cleanup + infoMode reset wire.
+   */
+  stopNavigation: () => void;
+}
+
+export const useNavigationStore = create<NavigationState>((set) => ({
+  navigationActive: false,
+
+  startNavigation: () => {
+    set({ navigationActive: true });
+  },
+
+  stopNavigation: () => {
+    set({ navigationActive: false });
+  },
+}));

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -16,6 +16,7 @@ import { useDestinationStore } from '../features/route/store/useDestinationStore
 import { useAlarmEventStore } from '../features/alarm/store/useAlarmEventStore';
 import { useBoardingLockStore } from '../features/alarm/store/useBoardingLockStore';
 import { useUserIntentStore } from '../features/alarm/store/useUserIntentStore';
+import { useNavigationStore } from '../features/route/store/useNavigationStore';
 import { DestinationPicker } from '../features/route/components/DestinationPicker';
 import { findRouteCandidatesByCategory, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, getStationById, routeSignature, type Route, type CategorizedRoute, type RoutePreference } from '../shared/utils/stationRoute';
 import { pickArrivalAtOrigin } from '../features/arrival/utils/pickArrivalAtOrigin';
@@ -140,7 +141,13 @@ export default function HomeScreen() {
   // lockless intermediate gate(`trip.infoModeEnabled && waypoint.kind === 'intermediate'`)를 통과시킨다.
   // 트리거: tryAutoLock(boardingPrompt 응답) / createLockFromTrain(BoardingTrainList 탭) 양쪽에서 stamp.
   const infoModeEnabled = useUserIntentStore((s) => s.infoModeEnabled);
+  const setInfoModeEnabled = useUserIntentStore((s) => s.setInfoModeEnabled);
   const loadInfoModeEnabled = useUserIntentStore((s) => s.loadInfoModeEnabled);
+  // #1973 — 안내 시작/중단 명시 trigger SSoT. WhileInUse 권한 사용자도 안내 시작 후
+  // BG GPS 지속 가능 (네이버 패턴). startNavigation은 setInfoModeEnabled(true) 자동 wire.
+  const navigationActive = useNavigationStore((s) => s.navigationActive);
+  const startNavigation = useNavigationStore((s) => s.startNavigation);
+  const stopNavigation = useNavigationStore((s) => s.stopNavigation);
   // #746: 알람 dismiss → silence 시작점 기록. 같은 컴포넌트의 userLocation을 같이 캡처.
   const setDismissSilence = useAlarmEventStore((s) => s.setDismissSilence);
   // #746 reviewer P1: cold-start hydration — storage에 살아있는 silence 상태를
@@ -384,6 +391,17 @@ export default function HomeScreen() {
 
 
   const handleArrivalClear = useCallback(() => setDestination(null), [setDestination]);
+  // #1973 — 안내 시작/중단 명시 trigger. infoMode 자동 wire — backend lockless intermediate
+  // gate(`trip.infoModeEnabled && waypoint.kind === 'intermediate'`) 통과 보장. useBackgroundLocation은
+  // useNavigationStore.navigationActive를 deps로 보고 BG GPS lifecycle을 따른다.
+  const handleStartNavigation = useCallback(() => {
+    startNavigation();
+    void setInfoModeEnabled(true);
+  }, [startNavigation, setInfoModeEnabled]);
+  const handleStopNavigation = useCallback(() => {
+    stopNavigation();
+    void setInfoModeEnabled(false);
+  }, [stopNavigation, setInfoModeEnabled]);
   const { arrivedBanner } = useArrivalAutoClear({
     currentStationName: result?.station.name,
     distanceKm: result?.distanceKm,
@@ -1290,6 +1308,35 @@ export default function HomeScreen() {
                       })}
                     </View>
                   )}
+                  {/* #1973 — 안내 시작/중단 명시 trigger 버튼. categorized 보유 + route 선택됨 시 노출.
+                       네이버 패턴: 사용자가 명시적으로 안내 시작해야 BG GPS + 자동 lock chain 활성화.
+                       WhileInUse 권한 사용자도 안내 시작 후 BG GPS 지속 (iOS native 파란 알약 표시). */}
+                  {categorized.length > 0 && route && !navigationActive && (
+                    <Pressable
+                      testID="home-navigation-start"
+                      style={[styles.navigationButton, { backgroundColor: colors.accent }]}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('navigation.start')}
+                      onPress={handleStartNavigation}
+                    >
+                      <Text style={[typography.label, { color: colors.onAccent, fontWeight: '700' }]}>
+                        {t('navigation.start')}
+                      </Text>
+                    </Pressable>
+                  )}
+                  {navigationActive && (
+                    <Pressable
+                      testID="home-navigation-stop"
+                      style={[styles.navigationButton, { borderColor: colors.warn, borderWidth: 1 }]}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('navigation.stop')}
+                      onPress={handleStopNavigation}
+                    >
+                      <Text style={[typography.label, { color: colors.warn, fontWeight: '700' }]}>
+                        {t('navigation.stop')}
+                      </Text>
+                    </Pressable>
+                  )}
                   {journey && (() => {
                     const stops = journeyDisplayToStops(journey, { expanded: routeExpanded });
                     const selectedCandidate = categorized.find((r) => r.category.key === selectedKey)?.candidate;
@@ -1843,6 +1890,13 @@ const styles = StyleSheet.create({
   routePillSub: {
     ...typography.micro,
     marginTop: 2,
+  },
+  // #1973 — 안내 시작/중단 버튼. segment control 직후 노출되는 명시 trigger CTA.
+  navigationButton: {
+    marginTop: spacing.lg,
+    paddingVertical: spacing.md,
+    borderRadius: radius.md,
+    alignItems: 'center',
   },
   actionsRow: {
     flexDirection: 'row',

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -205,6 +205,11 @@
     "title": "Detecting subway location",
     "body": "Tracking your current station in the background"
   },
+  "navigation": {
+    "start": "Start guidance",
+    "stop": "Stop guidance",
+    "permissionPrompt": "Location permission is required to start guidance"
+  },
   "arrival": {
     "upbound": "Upbound",
     "downbound": "Downbound",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -205,6 +205,11 @@
     "title": "地下鉄の位置を検出中",
     "body": "バックグラウンドで現在駅を追跡しています"
   },
+  "navigation": {
+    "start": "案内を開始",
+    "stop": "案内を停止",
+    "permissionPrompt": "案内を開始するには位置情報の権限が必要です"
+  },
   "arrival": {
     "upbound": "上り",
     "downbound": "下り",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -205,6 +205,11 @@
     "title": "지하철 위치 감지 중",
     "body": "백그라운드에서 현재 역을 추적하고 있습니다"
   },
+  "navigation": {
+    "start": "안내 시작",
+    "stop": "안내 중단",
+    "permissionPrompt": "안내를 시작하려면 위치 권한이 필요합니다"
+  },
   "arrival": {
     "upbound": "상행",
     "downbound": "하행",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -205,6 +205,11 @@
     "title": "正在检测地铁位置",
     "body": "正在后台追踪当前车站"
   },
+  "navigation": {
+    "start": "开始导航",
+    "stop": "停止导航",
+    "permissionPrompt": "开始导航需要位置权限"
+  },
   "arrival": {
     "upbound": "上行",
     "downbound": "下行",


### PR DESCRIPTION
## Summary
- useNavigationStore 신규 (navigationActive + start/stop)
- useBackgroundLocation 권한 단계화 — WhileInUse OK + Always 선택
- HomeScreen "안내 시작/중단" 버튼 (categorized.length > 0 + route 선택 시 노출)
- infoMode 자동 wire (start → ON / stop → OFF)
- i18n 4 locale (ko/en/ja/zh) navigation 키 추가

Closes #1973

## paradigm 정합
- navigationActive=true = 사용자 명시 의향 (lock 활성 동급 정확도 보장 의무 — feedback_user_intent_equal_protection)
- iOS native 파란 알약 자동 표시 (showsBackgroundLocationIndicator=true 활용)
- WhileInUse 사용자도 안내 시작 후 BG GPS 지속 (네이버 지도 패턴)

## Wire-completion 5단 체크
1. Orphan 없음 — `npm run lint:orphan` pass. 신규 useNavigationStore export caller 존재 (HomeScreen + useBackgroundLocation)
2. V/X dashboard — DebugModal navigationActive row + BG location active 카운터 (follow-up PR로 wire 예정)
3. 의존 PR — #1923 P0 infoMode wire (머지됨) / #1942 useUserIntentStore (머지됨)
4. 측정 plan — 1주 사용자 비율: 안내 시작 누른 trip / 미사용 trip + WhileInUse + BG GPS 지속 카운트
5. Device verify — 실기기 trip 2회:
   - Always 권한 + 안내 시작 → 파란 알약 + 매역 알림 정확
   - WhileInUse + 안내 시작 → 파란 알약 + BG 진입 후 GPS 지속 + 알림 정확
   - 안내 중단 → 파란 알약 사라짐 + lock 해제

## Known risks (code-review medium 결과)
1. **trip 종료 시 navigationActive 자동 reset 미wire (P2)** — destination 지우거나 trip 종료해도 stopNavigation()이 호출 안 됨. categorized.length=0이면 "안내 시작" 버튼은 가드로 차단되지만 navigationActive=true 잔존 시 "안내 중단" 버튼만 보임 (사용자가 명시적으로 누르거나 앱 재시작 시 휘발성으로 해제). useBackgroundLocation은 destination=null 가드로 BG GPS는 정지하므로 동작 안전. 후속 trip-bound cleanup wire는 별도 PR로 분리.
2. **Foreground(WhileInUse) 거부 시 'permissions.backgroundDeniedTitle' 텍스트 노출 (P3)** — Foreground 자체 거부됐을 때 "백그라운드 위치 권한 필요" 메시지 노출. 메시지가 BG-specific이라 UX 정확도 떨어짐. i18n 키 분리는 후속 PR (이슈 본문 fix 5곳 scope 보존).

## Test plan
- [x] `npm test` 커버리지 100% (8774 tests pass)
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass (no orphan exports detected)
- [x] code-review medium 반영 (known risks P2/P3은 본 PR scope 밖으로 정합 — 별도 후속)