### PR TITLE
feat(#1972): Lockless miss metric — userIntent 분기 + trip 종료 fire 0건 스탬프 (#1503 잔여 3/3)

### DIFF
--- a/backend/alarm-worker/src/__tests__/alarmLogStats.test.ts
+++ b/backend/alarm-worker/src/__tests__/alarmLogStats.test.ts
@@ -521,4 +521,85 @@ describe('computeAlarmLogStats', () => {
     expect(stats.groundTruthCounts.no).toBe(0);
     expect(stats.groundTruthCounts.pending).toBe(0);
   });
+
+  // ── #1972 locklessTripCounts ─────────────────────────────────────────────────
+
+  it('#1972 — lockless-trip-end outcome="fired"=fired, "suppressed"=miss, "received"=paradigmIntent', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/28/llte-1000.ndjson',
+        tripEndedAt: NOW - 5 * 60 * 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'lockless-trip-end', outcome: 'fired', stationName: '3:intent' },
+            { source: 'lockless-trip-end', outcome: 'fired', stationName: '7:intent' },
+            { source: 'lockless-trip-end', outcome: 'suppressed', stationName: '0:intent' },
+            { source: 'lockless-trip-end', outcome: 'received', stationName: '0:paradigm' },
+            { source: 'lockless-trip-end', outcome: 'received', stationName: '0:paradigm' },
+            // 다른 source → locklessTrip 집계 제외
+            { source: 'fg', outcome: 'fired' },
+          ],
+          NOW - 5 * 60 * 1000,
+        ),
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    expect(stats.locklessTripCounts.fired).toBe(2);
+    expect(stats.locklessTripCounts.miss).toBe(1);
+    expect(stats.locklessTripCounts.paradigmIntent).toBe(2);
+  });
+
+  it('#1972 — lockless-trip-end entries 없으면 locklessTripCounts 모두 0', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/28/no-llte-1000.ndjson',
+        tripEndedAt: NOW - 5 * 60 * 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [{ source: 'fg', outcome: 'fired' }],
+          NOW - 5 * 60 * 1000,
+        ),
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    expect(stats.locklessTripCounts).toEqual({ miss: 0, fired: 0, paradigmIntent: 0 });
+  });
+
+  it('#1972 — lockless-trip-end outcome 예상 외 값은 어느 슬롯에도 들어가지 않음', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/28/invalid-llte-1000.ndjson',
+        tripEndedAt: NOW - 5 * 60 * 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            // 'aborted'는 miss/fired/paradigmIntent 어느 슬롯에도 들어가지 않음
+            { source: 'lockless-trip-end', outcome: 'aborted', stationName: '0:x' },
+            { source: 'lockless-trip-end', outcome: 'fired', stationName: '2:intent' },
+          ],
+          NOW - 5 * 60 * 1000,
+        ),
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    expect(stats.locklessTripCounts.fired).toBe(1);
+    expect(stats.locklessTripCounts.miss).toBe(0);
+    expect(stats.locklessTripCounts.paradigmIntent).toBe(0);
+  });
+
+  it('#1972 — lockless-trip-end outcome=string이 아니면 silent drop', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/28/no-outcome-llte-1000.ndjson',
+        tripEndedAt: NOW - 5 * 60 * 1000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            // outcome 필드 자체 누락 — typeof check가 silent drop으로 처리.
+            { source: 'lockless-trip-end', stationName: '0:intent' } as never,
+          ],
+          NOW - 5 * 60 * 1000,
+        ),
+      },
+    ]);
+    const stats = await computeAlarmLogStats(r2, NOW);
+    expect(stats.locklessTripCounts).toEqual({ miss: 0, fired: 0, paradigmIntent: 0 });
+  });
 });

--- a/backend/alarm-worker/src/__tests__/locklessMissMetric.test.ts
+++ b/backend/alarm-worker/src/__tests__/locklessMissMetric.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for backend lockless miss metric helper (#1972, #1503 잔여 3/3).
+ *
+ * outcome → bucket 데이터 주도 매핑 + buildLocklessTripMissBucket의 division-by-zero 방어를 검증.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  LOCKLESS_TRIP_END_OUTCOME_TO_BUCKET,
+  LOCKLESS_TRIP_END_SOURCE,
+  buildLocklessTripMissBucket,
+} from '../locklessMissMetric';
+
+describe('LOCKLESS_TRIP_END_SOURCE', () => {
+  it('source 식별자가 device alarmLog source와 정합', () => {
+    expect(LOCKLESS_TRIP_END_SOURCE).toBe('lockless-trip-end');
+  });
+});
+
+describe('LOCKLESS_TRIP_END_OUTCOME_TO_BUCKET', () => {
+  const cases: Array<[string, 'miss' | 'fired' | 'paradigmIntent']> = [
+    ['fired', 'fired'],
+    ['suppressed', 'miss'],
+    ['received', 'paradigmIntent'],
+  ];
+  it.each(cases)('outcome=%s → bucket=%s', (outcome, expected) => {
+    expect(LOCKLESS_TRIP_END_OUTCOME_TO_BUCKET[outcome]).toBe(expected);
+  });
+
+  it('알 수 없는 outcome은 undefined (schema 진화 방어 — silent drop)', () => {
+    expect(LOCKLESS_TRIP_END_OUTCOME_TO_BUCKET['unknown-outcome']).toBeUndefined();
+  });
+});
+
+describe('buildLocklessTripMissBucket', () => {
+  it('정상 분기 — miss + fired 합산으로 ratio 산출', () => {
+    const result = buildLocklessTripMissBucket({ miss: 3, fired: 7, paradigmIntent: 5 });
+    expect(result).toEqual({
+      miss: 3,
+      fired: 7,
+      paradigmIntent: 5,
+      ratio: 0.3, // 3 / (3 + 7)
+    });
+  });
+
+  it('paradigmIntent는 분모/분자 모두 제외 — lesson_silent_push_zero_is_paradigm_intent', () => {
+    // miss=0, fired=10 + paradigmIntent=999 — paradigmIntent 가 ratio 에 영향 X.
+    const result = buildLocklessTripMissBucket({ miss: 0, fired: 10, paradigmIntent: 999 });
+    expect(result.ratio).toBe(0);
+    expect(result.paradigmIntent).toBe(999);
+  });
+
+  it('miss + fired = 0 → ratio=0 (division-by-zero 방어)', () => {
+    const result = buildLocklessTripMissBucket({ miss: 0, fired: 0, paradigmIntent: 0 });
+    expect(result.ratio).toBe(0);
+  });
+
+  it('paradigmIntent만 있을 때도 ratio=0 — 분모 0 보장', () => {
+    const result = buildLocklessTripMissBucket({ miss: 0, fired: 0, paradigmIntent: 42 });
+    expect(result).toEqual({
+      miss: 0,
+      fired: 0,
+      paradigmIntent: 42,
+      ratio: 0,
+    });
+  });
+
+  it('모든 trip이 miss인 케이스 — ratio=1', () => {
+    const result = buildLocklessTripMissBucket({ miss: 5, fired: 0, paradigmIntent: 0 });
+    expect(result.ratio).toBe(1);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
+++ b/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
@@ -63,6 +63,7 @@ describe('storeObservabilityMetrics + readObservabilityMetrics', () => {
       laPushDeliveryRatio: { sent: 10, failed: 2, ratio: 10 / 12 },
       silentPushReachRatio: { sent: 0, received: 0, joined: 0, ratio: 0 },
       algorithmAccuracyRatio: { value: 7, total: 9, ratio: 7 / 9, answeredTotal: 12 },
+      locklessTripMissRatio: { miss: 0, fired: 0, paradigmIntent: 0, ratio: 0 },
       window: '24h' as const,
       timestamp: NOW,
     };
@@ -102,6 +103,7 @@ describe('storeObservabilityMetrics + readObservabilityMetrics', () => {
       laPushDeliveryRatio: { sent: 0, failed: 0, ratio: 0 },
       silentPushReachRatio: { sent: 0, received: 0, joined: 0, ratio: 0 },
       algorithmAccuracyRatio: { value: 0, total: 0, ratio: 0, answeredTotal: 0 },
+      locklessTripMissRatio: { miss: 0, fired: 0, paradigmIntent: 0, ratio: 0 },
       window: '24h' as const,
       timestamp: NOW,
     };
@@ -725,6 +727,155 @@ describe('computeObservabilityMetrics — algorithmAccuracyRatio (#1957)', () =>
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
+// computeObservabilityMetrics — locklessTripMissRatio (#1972, #1503 잔여 3/3)
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('computeObservabilityMetrics — locklessTripMissRatio (#1972)', () => {
+  it('empty R2 → 0/0 ratio=0, paradigmIntent=0', async () => {
+    const r2 = makeEmptyFakeR2();
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    expect(result.locklessTripMissRatio).toEqual({
+      miss: 0,
+      fired: 0,
+      paradigmIntent: 0,
+      ratio: 0,
+    });
+  });
+
+  it('userIntent ON + lockless + fire ≥ 1 → fired 카운터 증가', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/28/llte-fired.ndjson',
+        tripEndedAt: NOW - 60_000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'lockless-trip-end', outcome: 'fired', stationName: '5:intent' },
+            { source: 'lockless-trip-end', outcome: 'fired', stationName: '2:intent' },
+          ],
+          NOW - 60_000,
+        ),
+      },
+    ]);
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    expect(result.locklessTripMissRatio.fired).toBe(2);
+    expect(result.locklessTripMissRatio.miss).toBe(0);
+    expect(result.locklessTripMissRatio.ratio).toBe(0);
+  });
+
+  it('userIntent ON + lockless + fire 0건 → miss 카운터 (진짜 miss)', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/28/llte-miss.ndjson',
+        tripEndedAt: NOW - 60_000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'lockless-trip-end', outcome: 'suppressed', stationName: '0:intent' },
+            { source: 'lockless-trip-end', outcome: 'fired', stationName: '3:intent' },
+          ],
+          NOW - 60_000,
+        ),
+      },
+    ]);
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    // miss=1, fired=1 → ratio = 1 / (1+1) = 0.5
+    expect(result.locklessTripMissRatio.miss).toBe(1);
+    expect(result.locklessTripMissRatio.fired).toBe(1);
+    expect(result.locklessTripMissRatio.ratio).toBe(0.5);
+  });
+
+  it('userIntent OFF + lockless + fire 0건 → paradigmIntent 카운터 (분모/분자 제외)', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/28/llte-paradigm.ndjson',
+        tripEndedAt: NOW - 60_000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'lockless-trip-end', outcome: 'received', stationName: '0:paradigm' },
+            { source: 'lockless-trip-end', outcome: 'received', stationName: '0:paradigm' },
+            { source: 'lockless-trip-end', outcome: 'received', stationName: '0:paradigm' },
+            // fired 1건 추가 — paradigmIntent가 ratio에 영향 X 검증
+            { source: 'lockless-trip-end', outcome: 'fired', stationName: '4:intent' },
+          ],
+          NOW - 60_000,
+        ),
+      },
+    ]);
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    expect(result.locklessTripMissRatio.paradigmIntent).toBe(3);
+    expect(result.locklessTripMissRatio.fired).toBe(1);
+    expect(result.locklessTripMissRatio.miss).toBe(0);
+    // miss=0, fired=1 → ratio=0. paradigmIntent는 분모/분자 모두 제외.
+    expect(result.locklessTripMissRatio.ratio).toBe(0);
+  });
+
+  it('전부 paradigmIntent → ratio=0 (division-by-zero 방어, dashboard "no data" 차단)', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/28/llte-allparadigm.ndjson',
+        tripEndedAt: NOW - 60_000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'lockless-trip-end', outcome: 'received', stationName: '0:paradigm' },
+            { source: 'lockless-trip-end', outcome: 'received', stationName: '0:paradigm' },
+          ],
+          NOW - 60_000,
+        ),
+      },
+    ]);
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    expect(result.locklessTripMissRatio.miss).toBe(0);
+    expect(result.locklessTripMissRatio.fired).toBe(0);
+    expect(result.locklessTripMissRatio.paradigmIntent).toBe(2);
+    expect(result.locklessTripMissRatio.ratio).toBe(0);
+  });
+
+  it('전부 miss → ratio=1', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/28/llte-allmiss.ndjson',
+        tripEndedAt: NOW - 60_000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'lockless-trip-end', outcome: 'suppressed', stationName: '0:intent' },
+            { source: 'lockless-trip-end', outcome: 'suppressed', stationName: '0:intent' },
+            { source: 'lockless-trip-end', outcome: 'suppressed', stationName: '0:intent' },
+          ],
+          NOW - 60_000,
+        ),
+      },
+    ]);
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    expect(result.locklessTripMissRatio.miss).toBe(3);
+    expect(result.locklessTripMissRatio.fired).toBe(0);
+    expect(result.locklessTripMissRatio.ratio).toBe(1);
+  });
+
+  it('다른 source는 locklessTripMissRatio에 영향 X', async () => {
+    const r2 = makeFakeR2([
+      {
+        key: 'trip-evidence/2026/06/28/llte-mixed.ndjson',
+        tripEndedAt: NOW - 60_000,
+        body: buildAlarmLogNdjsonFixture(
+          [
+            { source: 'fg-arvlcd', outcome: 'fired', stationName: '강남' },
+            { source: 'silent-push-fired', outcome: 'fired', stationName: '서초' },
+            { source: 'ground-truth-response', outcome: 'fired', stationName: 'gt-yes' },
+            { source: 'lockless-trip-end', outcome: 'fired', stationName: '7:intent' },
+            { source: 'lockless-trip-end', outcome: 'suppressed', stationName: '0:intent' },
+          ],
+          NOW - 60_000,
+        ),
+      },
+    ]);
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    // fg-arvlcd / silent-push-fired / ground-truth-response는 lockless 분기 제외.
+    expect(result.locklessTripMissRatio.fired).toBe(1);
+    expect(result.locklessTripMissRatio.miss).toBe(1);
+    expect(result.locklessTripMissRatio.ratio).toBe(0.5);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
 // tryStoreObservabilityMetrics + readLastSuccessfulMetrics (#1889 RC-19)
 // ──────────────────────────────────────────────────────────────────────────────
 
@@ -744,6 +895,7 @@ const SAMPLE_METRICS = {
   laPushDeliveryRatio: { sent: 0, failed: 0, ratio: 0 },
   silentPushReachRatio: { sent: 0, received: 0, joined: 0, ratio: 0 },
   algorithmAccuracyRatio: { value: 0, total: 0, ratio: 0, answeredTotal: 0 },
+  locklessTripMissRatio: { miss: 0, fired: 0, paradigmIntent: 0, ratio: 0 },
   window: '24h' as const,
   timestamp: NOW,
 };

--- a/backend/alarm-worker/src/alarmLogStats.ts
+++ b/backend/alarm-worker/src/alarmLogStats.ts
@@ -27,6 +27,11 @@
  * 개별 trip identifier/원문 미포함.
  */
 
+import {
+  LOCKLESS_TRIP_END_OUTCOME_TO_BUCKET,
+  LOCKLESS_TRIP_END_SOURCE,
+} from './locklessMissMetric';
+
 const TRIP_EVIDENCE_PREFIX = 'trip-evidence/';
 const MS_PER_HOUR = 60 * 60 * 1000;
 
@@ -80,12 +85,22 @@ export interface AlarmLogStatsResponse {
    * pending은 분모 제외 — 응답률(1주 30%+) 측정용 신호로 별도 보존.
    */
   groundTruthCounts: { yes: number; no: number; pending: number };
+  /**
+   * #1972 (#1503 잔여 3/3) — lockless trip 종료 stamp 분포.
+   * source='lockless-trip-end' + outcome 분기 누적 ([[locklessMissMetric.ts]] 참고):
+   *   outcome='fired'      → fired         (정상 — fire ≥ 1)
+   *   outcome='suppressed' → miss          (진짜 miss — fire 0 + userIntent ON)
+   *   outcome='received'   → paradigmIntent (paradigm — fire 0 + userIntent OFF)
+   * `observabilityMetrics.locklessTripMissRatio = miss / (miss + fired)` 산출 원천.
+   * paradigmIntent는 분모/분자 제외 ([[lesson_silent_push_zero_is_paradigm_intent]]).
+   */
+  locklessTripCounts: { miss: number; fired: number; paradigmIntent: number };
 }
 
 const ACCEL_PATTERNS = ['automotive', 'walking', 'stationary', 'unknown'] as const;
 type AccelPattern = (typeof ACCEL_PATTERNS)[number];
 
-/** parse 결과를 outcome/source/reason/accelPattern/boardableLookup/groundTruth 카운터에 누적. shape mismatch entry는 silent drop. */
+/** parse 결과를 outcome/source/reason/accelPattern/boardableLookup/groundTruth/locklessTrip 카운터에 누적. shape mismatch entry는 silent drop. */
 function accumulateEntry(
   entry: AlarmLogEntryLike,
   outcomeCounts: Record<string, number>,
@@ -94,6 +109,7 @@ function accumulateEntry(
   accelPatternCounts: { automotive: number; walking: number; stationary: number; unknown: number },
   boardableLookupCounts: { ok: number; miss: number },
   groundTruthCounts: { yes: number; no: number; pending: number },
+  locklessTripCounts: { miss: number; fired: number; paradigmIntent: number },
 ): void {
   if (typeof entry.outcome === 'string' && entry.outcome.length > 0) {
     outcomeCounts[entry.outcome] = (outcomeCounts[entry.outcome] ?? 0) + 1;
@@ -132,6 +148,15 @@ function accumulateEntry(
       groundTruthCounts.no += 1;
     } else if (entry.outcome === 'received') {
       groundTruthCounts.pending += 1;
+    }
+  }
+  // #1972 (#1503 잔여 3/3) — lockless trip 종료 stamp 집계.
+  // outcome 분기는 LOCKLESS_TRIP_END_OUTCOME_TO_BUCKET Record가 SSoT (locklessMissMetric.ts).
+  // null bucket(미지원 outcome)은 silent drop — schema 진화 방어.
+  if (entry.source === LOCKLESS_TRIP_END_SOURCE && typeof entry.outcome === 'string') {
+    const bucket = LOCKLESS_TRIP_END_OUTCOME_TO_BUCKET[entry.outcome];
+    if (bucket !== null && bucket !== undefined) {
+      locklessTripCounts[bucket] += 1;
     }
   }
 }
@@ -185,7 +210,7 @@ function topN(dict: Record<string, number>, n: number): Record<string, number> {
   return Object.fromEntries(sorted);
 }
 
-/** scan loop 누적 카운터 — outcome/reason/source/accelPattern/boardableLookup/groundTruth dict + totalEvents/tripsScanned. */
+/** scan loop 누적 카운터 — outcome/reason/source/accelPattern/boardableLookup/groundTruth/locklessTrip dict + totalEvents/tripsScanned. */
 interface ScanAccumulator {
   outcomeCounts: Record<string, number>;
   reasonCounts: Record<string, number>;
@@ -193,6 +218,7 @@ interface ScanAccumulator {
   accelPatternCounts: { automotive: number; walking: number; stationary: number; unknown: number };
   boardableLookupCounts: { ok: number; miss: number };
   groundTruthCounts: { yes: number; no: number; pending: number };
+  locklessTripCounts: { miss: number; fired: number; paradigmIntent: number };
   totalEvents: number;
   tripsScanned: number;
 }
@@ -222,6 +248,7 @@ async function scanTripEvidenceObject(
       acc.accelPatternCounts,
       acc.boardableLookupCounts,
       acc.groundTruthCounts,
+      acc.locklessTripCounts,
     );
   }
 }
@@ -252,6 +279,7 @@ export async function computeAlarmLogStats(
     accelPatternCounts: { automotive: 0, walking: 0, stationary: 0, unknown: 0 },
     boardableLookupCounts: { ok: 0, miss: 0 },
     groundTruthCounts: { yes: 0, no: 0, pending: 0 },
+    locklessTripCounts: { miss: 0, fired: 0, paradigmIntent: 0 },
     totalEvents: 0,
     tripsScanned: 0,
   };
@@ -285,5 +313,6 @@ export async function computeAlarmLogStats(
     accelPatternCounts: acc.accelPatternCounts,
     boardableLookupCounts: acc.boardableLookupCounts,
     groundTruthCounts: acc.groundTruthCounts,
+    locklessTripCounts: acc.locklessTripCounts,
   };
 }

--- a/backend/alarm-worker/src/locklessMissMetric.ts
+++ b/backend/alarm-worker/src/locklessMissMetric.ts
@@ -1,0 +1,76 @@
+/**
+ * Lockless miss metric — trip 종료 시 fire 0건 분기 카운터 (#1972, #1503 잔여 3/3).
+ *
+ * 배경
+ * ====
+ * 기존 `observabilityMetrics.locklessMissRatio`는 alarmLog reason='lockless-forward-only-block'
+ * 비율(event-level)을 추적한다. 하지만 *trip 단위*에서 lockless trip이 종료될 때 fire 알람이
+ * 한 건도 없었는지(진짜 miss)와 사용자가 informational mode를 끈 상태(paradigm intent)인지를
+ * 구분하지 못한다.
+ *
+ * 본 모듈은 device가 trip 종료 시 적재한 `source='lockless-trip-end'` stamp(`alarmLog.ts`의
+ * `logLocklessTripEnd`)의 outcome 분기를 데이터 주도로 매핑하는 helper만 export한다.
+ * 실제 누적은 `alarmLogStats.ts`의 `locklessTripCounts`가, ratio 산출은
+ * `observabilityMetrics.ts`의 `locklessTripMissRatio`가 담당한다.
+ *
+ * outcome 분기 (device side `logLocklessTripEnd` 가 결정)
+ * ========================================================
+ *   outcome='fired'      → fired         (정상 동작 — fire ≥ 1)
+ *   outcome='suppressed' → miss          (진짜 miss — fire 0 + userIntent ON)
+ *   outcome='received'   → paradigmIntent (paradigm — fire 0 + userIntent OFF)
+ *
+ * Ratio
+ * =====
+ * locklessTripMissRatio = miss / (miss + fired)
+ *   - paradigmIntent 는 분모/분자 모두 제외 ([[lesson_silent_push_zero_is_paradigm_intent]]).
+ *   - division-by-zero 방어 — (miss + fired) === 0 이면 ratio=0.
+ *
+ * 데이터 주도 분류
+ * ===============
+ * `LOCKLESS_TRIP_END_OUTCOME_TO_BUCKET` Record 가 SSoT. 새 outcome 추가 시 한 줄만 더한다.
+ */
+
+import type { AlarmLogStatsResponse } from './alarmLogStats';
+
+/** `source='lockless-trip-end'` entry 의 outcome → counter bucket 매핑. */
+export const LOCKLESS_TRIP_END_SOURCE = 'lockless-trip-end';
+
+export type LocklessTripBucket = 'miss' | 'fired' | 'paradigmIntent';
+
+/**
+ * outcome → bucket 데이터 주도 매핑.
+ *
+ *   'fired'      → fired         (사용자에게 노출된 알람이 1건 이상)
+ *   'suppressed' → miss          (lockless + userIntent ON + fire 0건 — 진짜 miss)
+ *   'received'   → paradigmIntent (lockless + userIntent OFF + fire 0건 — paradigm intent)
+ *
+ * schema 진화 방어 — 위 3 outcome 외에는 silent drop (`null`).
+ */
+export const LOCKLESS_TRIP_END_OUTCOME_TO_BUCKET: Readonly<
+  Record<string, LocklessTripBucket | null>
+> = {
+  fired: 'fired',
+  suppressed: 'miss',
+  received: 'paradigmIntent',
+};
+
+/**
+ * locklessTripMissRatio 산출 — miss / (miss + fired). paradigmIntent 는 제외.
+ *
+ * - (miss + fired) === 0 → ratio=0 (division-by-zero 방어, dashboard "no data" 대신 0%).
+ * - paradigmIntent 는 분모에서 제외해 [[lesson_silent_push_zero_is_paradigm_intent]] 정합.
+ *
+ * @returns { miss, fired, paradigmIntent, ratio } — 4 값을 한 번에 노출해 caller 가 raw count 도 보존.
+ */
+export function buildLocklessTripMissBucket(
+  counts: AlarmLogStatsResponse['locklessTripCounts'],
+): { miss: number; fired: number; paradigmIntent: number; ratio: number } {
+  const denominator = counts.miss + counts.fired;
+  const ratio = denominator === 0 ? 0 : counts.miss / denominator;
+  return {
+    miss: counts.miss,
+    fired: counts.fired,
+    paradigmIntent: counts.paradigmIntent,
+    ratio,
+  };
+}

--- a/backend/alarm-worker/src/observabilityMetrics.ts
+++ b/backend/alarm-worker/src/observabilityMetrics.ts
@@ -38,6 +38,7 @@
  */
 
 import { computeAlarmLogStats } from './alarmLogStats';
+import { buildLocklessTripMissBucket } from './locklessMissMetric';
 import { computePushAckStats } from './pushAckStats';
 import { computeSilentPushReachRatio } from './silentPushReachMetric';
 import { sumLaPushCounters } from './laPushCounters';
@@ -99,6 +100,18 @@ export interface ObservabilityMetricsResponse {
    * 응답률(answeredTotal = yes+no+pending)은 별도 신호로 보존 (P5 가중치 학습 prereq #1763).
    */
   algorithmAccuracyRatio: { value: number; total: number; ratio: number; answeredTotal: number };
+  /**
+   * #1972 (#1503 잔여 3/3) — lockless trip 종료 fire 0건 분기 비율.
+   * device `logLocklessTripEnd` stamp(source='lockless-trip-end') outcome 분기 누적:
+   *   miss          (suppressed) — userIntent ON + fire 0건 (진짜 miss)
+   *   fired         (fired)      — fire ≥ 1건 (정상 동작)
+   *   paradigmIntent (received)  — userIntent OFF + fire 0건 (paradigm intent)
+   * ratio = miss / (miss + fired). paradigmIntent는 분모/분자 모두 제외
+   * ([[lesson_silent_push_zero_is_paradigm_intent]]). 분모 0이면 ratio=0.
+   * 기존 `locklessMissRatio`(event-level reason='lockless-forward-only-block')와 별도 metric —
+   * trip-level userIntent 분기 측정 ([[feedback_user_intent_equal_protection]]).
+   */
+  locklessTripMissRatio: { miss: number; fired: number; paradigmIntent: number; ratio: number };
   window: '24h';
   timestamp: number;
 }
@@ -202,6 +215,11 @@ export async function computeObservabilityMetrics(
       alarmStats.groundTruthCounts.pending,
   };
 
+  // 7. #1972 — locklessTripMissRatio. trip-level fire 0건 분기 비율.
+  //    miss / (miss + fired). paradigmIntent는 분모/분자 제외 (lesson_silent_push_zero_is_paradigm_intent).
+  //    buildLocklessTripMissBucket이 division-by-zero 방어 — 분모 0이면 ratio=0.
+  const locklessTripMissRatio = buildLocklessTripMissBucket(alarmStats.locklessTripCounts);
+
   return {
     accuracyRatio,
     silentPushDeliveryRatio,
@@ -212,6 +230,7 @@ export async function computeObservabilityMetrics(
     laPushDeliveryRatio,
     silentPushReachRatio,
     algorithmAccuracyRatio,
+    locklessTripMissRatio,
     window: '24h',
     timestamp: now,
   };

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -90,6 +90,8 @@ import {
   _resetBoardableLookupWindowForTests,
   BOARDABLE_LOOKUP_DEDUP_MS,
   logGroundTruthResult,
+  logLocklessTripEnd,
+  countFiredAlarms,
   ALARM_LOG_BUFFER_SIZE,
   type AlarmLogEntry,
   type AlarmLogStamp,
@@ -3037,6 +3039,116 @@ describe('alarmLog', () => {
       const stored = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string) as AlarmLogEntry[];
       const matches = stored.filter((e) => e.source === 'ground-truth-response');
       expect(matches).toHaveLength(2);
+    });
+  });
+
+  // ── #1972 logLocklessTripEnd ─────────────────────────────────────────────────
+
+  describe('logLocklessTripEnd (#1972)', () => {
+    it('fireCount >= 1 → outcome=fired (정상 동작)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logLocklessTripEnd({ fireCount: 5, userIntentDeclared: true });
+      await flushAlarmLog();
+      const stored = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string) as AlarmLogEntry[];
+      expect(stored).toHaveLength(1);
+      expect(stored[0].source).toBe('lockless-trip-end');
+      expect(stored[0].outcome).toBe('fired');
+      expect(stored[0].stationName).toBe('5:intent');
+    });
+
+    it('fireCount=0 + userIntentDeclared=true → outcome=suppressed (진짜 miss)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logLocklessTripEnd({ fireCount: 0, userIntentDeclared: true });
+      await flushAlarmLog();
+      const stored = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string) as AlarmLogEntry[];
+      expect(stored).toHaveLength(1);
+      expect(stored[0].source).toBe('lockless-trip-end');
+      expect(stored[0].outcome).toBe('suppressed');
+      expect(stored[0].stationName).toBe('0:intent');
+    });
+
+    it('fireCount=0 + userIntentDeclared=false → outcome=received (paradigm intent)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logLocklessTripEnd({ fireCount: 0, userIntentDeclared: false });
+      await flushAlarmLog();
+      const stored = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string) as AlarmLogEntry[];
+      expect(stored).toHaveLength(1);
+      expect(stored[0].source).toBe('lockless-trip-end');
+      expect(stored[0].outcome).toBe('received');
+      expect(stored[0].stationName).toBe('0:paradigm');
+    });
+
+    it('fireCount=10 + userIntentDeclared=false → outcome=fired (fire ≥ 1이면 분기 무관)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logLocklessTripEnd({ fireCount: 10, userIntentDeclared: false });
+      await flushAlarmLog();
+      const stored = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string) as AlarmLogEntry[];
+      expect(stored).toHaveLength(1);
+      expect(stored[0].outcome).toBe('fired');
+      expect(stored[0].stationName).toBe('10:paradigm');
+    });
+
+    it('연속 호출은 모두 적재 (trip 1건당 1 stamp, dedup 없음)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      logLocklessTripEnd({ fireCount: 0, userIntentDeclared: true });
+      logLocklessTripEnd({ fireCount: 3, userIntentDeclared: true });
+      await flushAlarmLog();
+      const stored = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1] as string) as AlarmLogEntry[];
+      const matches = stored.filter((e) => e.source === 'lockless-trip-end');
+      expect(matches).toHaveLength(2);
+    });
+  });
+
+  // ── #1972 countFiredAlarms ───────────────────────────────────────────────────
+
+  describe('countFiredAlarms (#1972)', () => {
+    it('빈 entries → 0', () => {
+      expect(countFiredAlarms([])).toBe(0);
+    });
+
+    it('outcome=fired + FIRED_ALARM_SOURCES=true source만 카운트', () => {
+      const entries: AlarmLogEntry[] = [
+        { ts: 1, source: 'fg', outcome: 'fired' },
+        { ts: 2, source: 'bg', outcome: 'fired' },
+        { ts: 3, source: 'fg-arvlcd', outcome: 'fired' },
+        { ts: 4, source: 'silent-push-fired', outcome: 'fired' },
+        { ts: 5, source: 'alert-fallback-fired', outcome: 'fired' },
+        { ts: 6, source: 'fg-evaluated', outcome: 'fired' },
+        { ts: 7, source: 'bg-scheduled', outcome: 'fired' },
+      ];
+      expect(countFiredAlarms(entries)).toBe(7);
+    });
+
+    it('outcome=suppressed/received는 분모 제외', () => {
+      const entries: AlarmLogEntry[] = [
+        { ts: 1, source: 'fg', outcome: 'fired' },
+        { ts: 2, source: 'fg', outcome: 'suppressed' },
+        { ts: 3, source: 'fg', outcome: 'received' },
+      ];
+      expect(countFiredAlarms(entries)).toBe(1);
+    });
+
+    it('metadata source(boarding-prompt / accel-pattern-observed / boardable-lookup / ground-truth-response / lockless-trip-end 등)는 분모 제외', () => {
+      const entries: AlarmLogEntry[] = [
+        { ts: 1, source: 'boarding-prompt', outcome: 'fired' },
+        { ts: 2, source: 'accel-pattern-observed', outcome: 'fired' },
+        { ts: 3, source: 'boardable-lookup', outcome: 'fired' },
+        { ts: 4, source: 'ground-truth-response', outcome: 'fired' },
+        { ts: 5, source: 'lockless-trip-end', outcome: 'fired' },
+        { ts: 6, source: 'leg-transition', outcome: 'fired' },
+        { ts: 7, source: 'cross-trip-mirror-register', outcome: 'fired' },
+        { ts: 8, source: 'cross-trip-mirror-mismatch', outcome: 'fired' },
+        { ts: 9, source: 'cross-trip-mirror-launch', outcome: 'fired' },
+        { ts: 10, source: 'lifecycle-backstop', outcome: 'fired' },
+        { ts: 11, source: 'fusion-candidate-reject', outcome: 'fired' },
+        { ts: 12, source: 'fg-hydrate', outcome: 'fired' },
+        { ts: 13, source: 'fg-ref-mismatch', outcome: 'fired' },
+        { ts: 14, source: 'silent-push-received', outcome: 'fired' },
+        { ts: 15, source: 'silent-push-skipped', outcome: 'fired' },
+        // 실제 fire 1건
+        { ts: 16, source: 'fg', outcome: 'fired' },
+      ];
+      expect(countFiredAlarms(entries)).toBe(1);
     });
   });
 });

--- a/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
+++ b/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
@@ -24,6 +24,11 @@ const mockGetFusionTierLog = jest.fn();
 const mockGetFusionDebugEntries = jest.fn();
 const mockGetGpsDropEntries = jest.fn();
 const mockReadBackendSsotMirror = jest.fn();
+// #1972 — lockless trip-end stamp dependencies.
+const mockLogLocklessTripEnd = jest.fn();
+const mockCountFiredAlarms = jest.fn();
+const mockBoardingLockGetState = jest.fn();
+const mockUserIntentGetState = jest.fn();
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   __esModule: true,
@@ -82,6 +87,21 @@ jest.mock('../alarmLog', () => ({
   getAlarmLog: (...args: unknown[]) => mockGetAlarmLog(...args),
   // #1706 — 별 ring reader. test가 명시적으로 entries 주입.
   getFusionTierLog: (...args: unknown[]) => mockGetFusionTierLog(...args),
+  // #1972 — lockless trip 분기 stamp + fire counter.
+  logLocklessTripEnd: (...args: unknown[]) => mockLogLocklessTripEnd(...args),
+  countFiredAlarms: (...args: unknown[]) => mockCountFiredAlarms(...args),
+}));
+
+jest.mock('../../store/useBoardingLockStore', () => ({
+  useBoardingLockStore: {
+    getState: () => mockBoardingLockGetState(),
+  },
+}));
+
+jest.mock('../../store/useUserIntentStore', () => ({
+  useUserIntentStore: {
+    getState: () => mockUserIntentGetState(),
+  },
 }));
 
 jest.mock('../../../nearest-station/utils/fusionDebugBuffer', () => ({
@@ -173,6 +193,15 @@ describe('triggerTripEndRecall', () => {
     mockGetGpsDropEntries.mockReturnValue([]);
     mockReadBackendSsotMirror.mockReset();
     mockReadBackendSsotMirror.mockResolvedValue(null);
+    // #1972 — lockless stamp defaults: lockless trip (lock=null) + infoModeEnabled=false +
+    // fireCount=0 → paradigm intent stamp.
+    mockLogLocklessTripEnd.mockReset();
+    mockCountFiredAlarms.mockReset();
+    mockCountFiredAlarms.mockReturnValue(0);
+    mockBoardingLockGetState.mockReset();
+    mockBoardingLockGetState.mockReturnValue({ lock: null });
+    mockUserIntentGetState.mockReset();
+    mockUserIntentGetState.mockReturnValue({ infoModeEnabled: false });
   });
 
   it('tripStart 부재 시 즉시 skip (no-trip-start)', async () => {
@@ -636,6 +665,81 @@ describe('triggerTripEndRecall', () => {
       const result = await triggerTripEndRecall();
       expect(result.uploaded).toBe(true);
       expect(mockForwardTripTelemetry).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── #1972 logLocklessTripEnd wire ────────────────────────────────────────────
+
+  describe('#1972 lockless trip-end stamp (FE wire)', () => {
+    it('lock=null + infoModeEnabled=true + fireCount>=1 → logLocklessTripEnd(fireCount, true)', async () => {
+      setupHappyPath();
+      mockBoardingLockGetState.mockReturnValue({ lock: null });
+      mockUserIntentGetState.mockReturnValue({ infoModeEnabled: true });
+      mockCountFiredAlarms.mockReturnValue(5);
+
+      await triggerTripEndRecall();
+
+      expect(mockLogLocklessTripEnd).toHaveBeenCalledTimes(1);
+      expect(mockLogLocklessTripEnd).toHaveBeenCalledWith({
+        fireCount: 5,
+        userIntentDeclared: true,
+      });
+    });
+
+    it('lock=null + infoModeEnabled=true + fireCount=0 → logLocklessTripEnd(0, true) (진짜 miss)', async () => {
+      setupHappyPath();
+      mockBoardingLockGetState.mockReturnValue({ lock: null });
+      mockUserIntentGetState.mockReturnValue({ infoModeEnabled: true });
+      mockCountFiredAlarms.mockReturnValue(0);
+
+      await triggerTripEndRecall();
+
+      expect(mockLogLocklessTripEnd).toHaveBeenCalledWith({
+        fireCount: 0,
+        userIntentDeclared: true,
+      });
+    });
+
+    it('lock=null + infoModeEnabled=false + fireCount=0 → logLocklessTripEnd(0, false) (paradigm intent)', async () => {
+      setupHappyPath();
+      mockBoardingLockGetState.mockReturnValue({ lock: null });
+      mockUserIntentGetState.mockReturnValue({ infoModeEnabled: false });
+      mockCountFiredAlarms.mockReturnValue(0);
+
+      await triggerTripEndRecall();
+
+      expect(mockLogLocklessTripEnd).toHaveBeenCalledWith({
+        fireCount: 0,
+        userIntentDeclared: false,
+      });
+    });
+
+    it('lock 활성 trip은 lockless 분류 X → logLocklessTripEnd 미호출', async () => {
+      setupHappyPath();
+      mockBoardingLockGetState.mockReturnValue({
+        lock: { trainCode: '0001', boardingLine: '2' },
+      });
+      mockUserIntentGetState.mockReturnValue({ infoModeEnabled: true });
+      mockCountFiredAlarms.mockReturnValue(3);
+
+      await triggerTripEndRecall();
+
+      expect(mockLogLocklessTripEnd).not.toHaveBeenCalled();
+    });
+
+    it('APNS token 부재 시 stamp 호출 안 함 (forward 자체가 skip)', async () => {
+      setupHappyPath();
+      setStorage({
+        [LAST_UPLOADED_RECALL_TRIP_START_KEY]: null,
+        [ROUTE_KEY]: ROUTE_JSON,
+        [TRIP_ORIGIN_KEY]: ORIGIN_JSON,
+        [DESTINATION_KEY]: DEST_JSON,
+        [APNS_TOKEN_KEY]: null,
+      });
+
+      await triggerTripEndRecall();
+
+      expect(mockLogLocklessTripEnd).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -90,7 +90,16 @@ export type AlarmLogSource =
   //   'unanswered' → outcome='received'   (pending 회피/dismiss/자동 만료)
   // backend alarmLogStats가 source='ground-truth-response' + outcome로 groundTruthCounts 누적,
   // observabilityMetrics.algorithmAccuracyRatio = yes / (yes + no) 산출.
-  | 'ground-truth-response';
+  | 'ground-truth-response'
+  // #1972 (#1503 잔여 3/3) — lockless trip 종료 stamp. boarding-lock 미활성 trip 종료 시
+  // `triggerTripEndRecall`이 alarmLog ring fireCount + userIntentDeclared 분기로 1건 적재:
+  //   fireCount >= 1                              → outcome='fired'      (정상 동작)
+  //   fireCount == 0 && userIntentDeclared=true   → outcome='suppressed' (진짜 miss)
+  //   fireCount == 0 && userIntentDeclared=false  → outcome='received'   (paradigm intent)
+  // backend alarmLogStats가 source='lockless-trip-end' + outcome로 locklessTripCounts 누적,
+  // observabilityMetrics.locklessTripMissRatio = miss / (miss + fired) 산출.
+  // lesson_silent_push_zero_is_paradigm_intent: fire 0건이 본질적 의도(paradigm)인지 miss인지 구분.
+  | 'lockless-trip-end';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(#580): evaluateAlarmPhase의 firedAlarms 적중. destination/transfer phase alarm dedup
 // 발생 관찰. station-passed는 별도 메커니즘(lastNotifiedStationId)이라 'dedup-station' 사용.
@@ -1156,6 +1165,7 @@ const SILENT_PUSH_OUTCOME_SOURCES: Record<AlarmLogSource, keyof SilentPushOutcom
   'leg-transition': null,
   'boardable-lookup': null,
   'ground-truth-response': null,
+  'lockless-trip-end': null,
 };
 
 export interface SilentPushOutcomeCounts {
@@ -1173,6 +1183,61 @@ export function countSilentPushOutcomes(
     if (bucket !== null) counts[bucket] += 1;
   }
   return counts;
+}
+
+/**
+ * #1972 (#1503 잔여 3/3) — 실제 사용자에게 노출된 알람 fire source 분류 (데이터 주도).
+ *
+ * fire 분모: 매역 안내/도착 임박/사전 예약 등 사용자에게 실제로 알림이 노출된 source만 카운트.
+ * Metadata source (boarding-prompt / hydrate / ref-mismatch / accel-pattern / leg-transition /
+ * boardable-lookup / ground-truth-response / fusion-candidate-reject / cross-trip-mirror /
+ * lifecycle-backstop / lockless-trip-end 자체)는 fire 분모에서 제외 — 실제 알람이 아니라 측정/진단 stamp.
+ *
+ * 새 source 추가 시 본 Record에 한 줄만 더하면 자동 반영 (글로벌 룰 3 — 데이터 주도).
+ */
+const FIRED_ALARM_SOURCES: Record<AlarmLogSource, boolean> = {
+  fg: true,
+  bg: true,
+  'fg-evaluated': true,
+  'bg-scheduled': true,
+  'fg-arvlcd': true,
+  'silent-push-fired': true,
+  'alert-fallback-fired': true,
+  // metadata / 진단 / 측정 source — 실제 알람 아님.
+  'silent-push-received': false,
+  'silent-push-skipped': false,
+  'fg-hydrate': false,
+  'fg-ref-mismatch': false,
+  'boarding-prompt': false,
+  'lifecycle-backstop': false,
+  'fusion-candidate-reject': false,
+  'cross-trip-mirror-register': false,
+  'cross-trip-mirror-mismatch': false,
+  'cross-trip-mirror-launch': false,
+  'accel-pattern-observed': false,
+  'leg-transition': false,
+  'boardable-lookup': false,
+  'ground-truth-response': false,
+  'lockless-trip-end': false,
+};
+
+/**
+ * #1972 (#1503 잔여 3/3) — alarmLog ring scan으로 trip 동안 fired outcome 알람 수 산출.
+ *
+ * `triggerTripEndRecall`이 호출 — lockless trip 분기 stamp(`logLocklessTripEnd`)의 입력.
+ * FIRED_ALARM_SOURCES Record가 source를 데이터 주도로 분류해 metadata stamp가 분모를 오염하지 않게 한다.
+ *
+ * @param entries alarmLog ring buffer entries (getAlarmLog() snapshot).
+ * @returns outcome='fired' && FIRED_ALARM_SOURCES[source]=true 인 entries 수.
+ */
+export function countFiredAlarms(entries: readonly AlarmLogEntry[]): number {
+  let count = 0;
+  for (const entry of entries) {
+    if (entry.outcome !== 'fired') continue;
+    if (!FIRED_ALARM_SOURCES[entry.source]) continue;
+    count += 1;
+  }
+  return count;
 }
 
 /**
@@ -1842,6 +1907,45 @@ export function logGroundTruthResult(input: {
     source: 'ground-truth-response',
     outcome: GROUND_TRUTH_OUTCOME_TO_ALARM_LOG_OUTCOME[input.outcome],
     stationName: input.corrId,
+  });
+}
+
+/**
+ * #1972 (#1503 잔여 3/3) — lockless trip 종료 시 fire counter == 0 분기 stamp.
+ *
+ * `triggerTripEndRecall`이 trip telemetry forward 직전에 호출한다. 입력 분기:
+ *   - fireCount >= 1                              → outcome='fired'      (정상 동작)
+ *   - fireCount == 0 && userIntentDeclared=true   → outcome='suppressed' (진짜 miss)
+ *   - fireCount == 0 && userIntentDeclared=false  → outcome='received'   (paradigm intent)
+ *
+ * `lesson_silent_push_zero_is_paradigm_intent` 패턴 — 사용자가 informational mode 토글을 끈 상태
+ * (infoModeEnabled=false)에서 lockless trip 종료 시 fire 0건은 본질적 동작(paradigm intent)이며
+ * miss로 분류해서는 안 된다. backend alarmLogStats가 outcome 분기로 locklessTripCounts
+ * { miss, fired, paradigmIntent }를 누적, observabilityMetrics.locklessTripMissRatio
+ * = miss / (miss + fired) 산출 (paradigmIntent는 분모/분자 모두 제외).
+ *
+ * stationName 슬롯에 `fireCount:userIntent` 인코딩 — DebugModal RCA용.
+ *
+ * dedup 없음 — trip 1건당 1 stamp가 1:1 신호. trip 종료 자체가 1회성 이벤트.
+ *
+ * @param input.fireCount alarmLog ring scan으로 산출한 trip 동안 fired outcome 알람 수.
+ * @param input.userIntentDeclared `useUserIntentStore.infoModeEnabled` 값. paradigm intent 분기 기준.
+ */
+export function logLocklessTripEnd(input: {
+  fireCount: number;
+  userIntentDeclared: boolean;
+}): void {
+  const outcome: AlarmLogOutcome =
+    input.fireCount >= 1
+      ? 'fired'
+      : input.userIntentDeclared
+        ? 'suppressed'
+        : 'received';
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'lockless-trip-end',
+    outcome,
+    stationName: `${input.fireCount}:${input.userIntentDeclared ? 'intent' : 'paradigm'}`,
   });
 }
 

--- a/src/features/alarm/utils/triggerTripEndRecall.ts
+++ b/src/features/alarm/utils/triggerTripEndRecall.ts
@@ -53,10 +53,17 @@ import {
   buildDeviceMetadata,
   forwardTripTelemetry,
 } from '../api/telemetryForward';
-import { getAlarmLog, getFusionTierLog } from './alarmLog';
+import {
+  countFiredAlarms,
+  getAlarmLog,
+  getFusionTierLog,
+  logLocklessTripEnd,
+} from './alarmLog';
 import { getFusionDebugEntries } from '../../nearest-station/utils/fusionDebugBuffer';
 import { getGpsDropEntries } from '../../nearest-station/utils/gpsDropBuffer';
 import { readBackendSsotMirror } from './backendSsotMirror';
+import { useBoardingLockStore } from '../store/useBoardingLockStore';
+import { useUserIntentStore } from '../store/useUserIntentStore';
 
 const log = createLogger('triggerTripEndRecall');
 
@@ -220,11 +227,19 @@ async function triggerAlarmLogForward(tripStart: number): Promise<void> {
       getAlarmLog(),
       readBackendSsotMirror(),
     ]);
+    // #1972 (#1503 잔여 3/3) — lockless trip 분기 stamp. boarding-lock 미활성 trip이
+    // 종료될 때만 1건 적재. 이 stamp는 본 함수의 alarmLog snapshot에는 포함되지 않지만
+    // appendAlarmLog의 동기 push로 ring에 즉시 들어가 다음 trip의 forward에 반영된다 —
+    // 본 PR의 R2 forward 기준 시점에서는 한 cycle 지연. backend는 R2 ndjson 도착 순서로
+    // window 집계하므로 정합. paradigm shift 기록을 forward와 떼지 않기 위해 동기 호출.
+    stampLocklessTripEndIfApplicable(alarmLog);
+    // stamp 직후 다시 getAlarmLog()를 부르면 동기 ring 에 막 추가된 entry가 포함된다.
+    const alarmLogWithStamp = await getAlarmLog();
     await forwardTripTelemetry({
       token,
       tripStartedAt: tripStart,
       tripEndedAt: Date.now(),
-      alarmLog,
+      alarmLog: alarmLogWithStamp,
       fusionLog: getFusionDebugEntries(),
       // #1706 — fusion picker tier 별 ring buffer. alarmLog ring 점령 회귀 차단용 채널 분리.
       fusionTierLog: getFusionTierLog(),
@@ -235,6 +250,28 @@ async function triggerAlarmLogForward(tripStart: number): Promise<void> {
   } catch (e) {
     log.warn('alarm log forward trigger error', e);
   }
+}
+
+/**
+ * #1972 (#1503 잔여 3/3) — lockless trip 종료 분기 stamp helper.
+ *
+ * boarding-lock 활성 trip은 분류 X (early return) — backendSsotSnapshot의 lock 정보는
+ * 이미 R2 forward에 포함되며, lockless miss는 lock 없는 trip만의 metric.
+ *
+ * fireCount는 trip 동안 사용자에게 노출된 알람 수 (countFiredAlarms 기반).
+ * userIntentDeclared는 `useUserIntentStore.infoModeEnabled` 현재 값.
+ *
+ * stamp 자체는 fire-and-forget — 실패해도 forward critical path 차단 안 함.
+ */
+function stampLocklessTripEndIfApplicable(
+  alarmLog: readonly Parameters<typeof countFiredAlarms>[0][number][],
+): void {
+  // lock 활성 trip은 lockless 분류 X — silent return.
+  const lockActive = useBoardingLockStore.getState().lock !== null;
+  if (lockActive) return;
+  const userIntentDeclared = useUserIntentStore.getState().infoModeEnabled;
+  const fireCount = countFiredAlarms(alarmLog);
+  logLocklessTripEnd({ fireCount, userIntentDeclared });
 }
 
 /**

--- a/src/features/debug/components/OperationDashboardSection.tsx
+++ b/src/features/debug/components/OperationDashboardSection.tsx
@@ -35,6 +35,7 @@ import {
   type LaPushDeliveryBucket,
   type SilentPushReachBucket,
   type AlgorithmAccuracyBucket,
+  type LocklessTripMissBucket,
   type FetchMetricsResult,
 } from '../../observability/api/observabilityMetricsClient';
 import {
@@ -78,6 +79,8 @@ type BackendLoadState =
       silentPushReach: SilentPushReachBucket | null;
       /** #1957 — backend 24h algorithm accuracy. backend가 응답하지 않으면 null (구버전). */
       algorithmAccuracy: AlgorithmAccuracyBucket | null;
+      /** #1972 — backend 24h lockless trip miss (userIntent 분기). 구버전 backend는 null. */
+      locklessTripMiss: LocklessTripMissBucket | null;
     }
   | { kind: 'unconfigured' }
   | { kind: 'error'; message: string };
@@ -345,6 +348,7 @@ export function OperationDashboardSection({ logs, onMetricClick }: OperationDash
         laPushDelivery: result.metrics.laPushDeliveryRatio,
         silentPushReach: result.metrics.silentPushReachRatio ?? null,
         algorithmAccuracy: result.metrics.algorithmAccuracyRatio ?? null,
+        locklessTripMiss: result.metrics.locklessTripMissRatio ?? null,
       });
     } else if (result.kind === 'unconfigured') {
       setBackendState({ kind: 'unconfigured' });
@@ -457,11 +461,40 @@ export function OperationDashboardSection({ logs, onMetricClick }: OperationDash
           isMock: true,
         };
 
+  // Metric 9 — #1972 lockless trip miss (trip-level + userIntent 분기, backend SSoT).
+  // 기존 `locklessMiss` (event-level reason='lockless-forward-only-block')와 별도 metric —
+  // trip 종료 시점에 fire counter == 0 + userIntent 분기로 진짜 miss / paradigm intent 구분.
+  // miss/(miss+fired) 비율 + paradigmIntent 별도 노출 (lesson_silent_push_zero_is_paradigm_intent).
+  // backend가 locklessTripMissRatio 필드를 응답하지 않으면 placeholder.
+  const locklessTripMiss: MetricData =
+    backendState.kind === 'ok' && backendState.locklessTripMiss !== null
+      ? {
+          key: 'locklessMiss',
+          label: `locklessTripMiss (paradigm=${backendState.locklessTripMiss.paradigmIntent})`,
+          ratio: computeRatio(
+            backendState.locklessTripMiss.miss,
+            backendState.locklessTripMiss.miss + backendState.locklessTripMiss.fired,
+          ),
+          numerator: backendState.locklessTripMiss.miss,
+          denominator:
+            backendState.locklessTripMiss.miss + backendState.locklessTripMiss.fired,
+          isMock: false,
+        }
+      : {
+          key: 'locklessMiss',
+          label: 'locklessTripMiss',
+          ratio: null,
+          numerator: 0,
+          denominator: 0,
+          isMock: true,
+        };
+
   const metrics: MetricData[] = [
     alarmAccuracy,
     silentPushReach,
     silentPushReachBackend,
     locklessMiss,
+    locklessTripMiss,
     boardableMiss,
     laPushDelivery,
   ];

--- a/src/features/debug/components/__tests__/OperationDashboardSection.test.tsx
+++ b/src/features/debug/components/__tests__/OperationDashboardSection.test.tsx
@@ -102,6 +102,8 @@ function makeSuccessResult(
   },
   // #1957 — backend 24h algorithm accuracy. undefined = 구 backend 응답 (필드 누락 simulating).
   algorithmAccuracy: observabilityClient.AlgorithmAccuracyBucket | undefined = undefined,
+  // #1972 — backend 24h lockless trip miss. undefined = 구 backend 응답.
+  locklessTripMiss: observabilityClient.LocklessTripMissBucket | undefined = undefined,
 ): observabilityClient.FetchMetricsResult {
   const metrics: observabilityClient.ObservabilityMetrics = {
     accuracyRatio: { value: 8, total: 10, ratio: 0.8 },
@@ -115,6 +117,7 @@ function makeSuccessResult(
     window: '24h',
     timestamp: 1_700_000_000_000,
     ...(silentPushReach !== null ? { silentPushReachRatio: silentPushReach } : {}),
+    ...(locklessTripMiss !== undefined ? { locklessTripMissRatio: locklessTripMiss } : {}),
   };
   return { kind: 'ok', metrics };
 }
@@ -670,6 +673,65 @@ describe('OperationDashboardSection', () => {
       const tracks = screen.getAllByTestId('ratio-bar-track');
       // 1/2 = 0.5 비율 ratio bar 1건 + 다른 metric bar들 포함.
       expect(tracks.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('#1972 — locklessTripMiss metric', () => {
+    it('backend 미수신 (구버전) → locklessTripMiss row가 (no data) 표시', async () => {
+      // unconfigured / kind!=ok → locklessTripMiss placeholder mock 상태.
+      mockFetchMetrics.mockResolvedValue({ kind: 'unconfigured' });
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      // label은 'locklessTripMiss' (paradigm suffix 미포함).
+      expect(screen.getByTestId('operation-metric-locklessTripMiss')).toBeTruthy();
+    });
+
+    it('backend 수신 + miss=3, fired=7, paradigmIntent=5 → ratio=0.3 + paradigm 표시', async () => {
+      mockFetchMetrics.mockResolvedValue(
+        makeSuccessResult(
+          0, 0, 0, 0, DEFAULT_ACCEL_PATTERN, null, 10, 2,
+          { sent: 0, received: 0, joined: 0, ratio: 0 },
+          undefined,
+          { miss: 3, fired: 7, paradigmIntent: 5, ratio: 0.3 },
+        ),
+      );
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      // paradigm count는 label에 인코딩.
+      expect(
+        screen.getByTestId('operation-metric-locklessTripMiss (paradigm=5)'),
+      ).toBeTruthy();
+    });
+
+    it('backend 수신 + miss=0, fired=0 (paradigm만) → ratio bar (no data) 유지', async () => {
+      mockFetchMetrics.mockResolvedValue(
+        makeSuccessResult(
+          0, 0, 0, 0, DEFAULT_ACCEL_PATTERN, null, 10, 2,
+          { sent: 0, received: 0, joined: 0, ratio: 0 },
+          undefined,
+          { miss: 0, fired: 0, paradigmIntent: 3, ratio: 0 },
+        ),
+      );
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      // miss=0+fired=0 → ratio=null (computeRatio가 0/0=null), na 1건 이상.
+      const naTexts = screen.getAllByTestId('ratio-bar-na');
+      expect(naTexts.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('backend 수신 + miss=2, fired=8 → ratio=0.2 fill bar', async () => {
+      mockFetchMetrics.mockResolvedValue(
+        makeSuccessResult(
+          0, 0, 0, 0, DEFAULT_ACCEL_PATTERN, null, 10, 2,
+          { sent: 0, received: 0, joined: 0, ratio: 0 },
+          undefined,
+          { miss: 2, fired: 8, paradigmIntent: 0, ratio: 0.2 },
+        ),
+      );
+      renderWithTheme(<OperationDashboardSection logs={[]} />);
+      await act(async () => { jest.runAllTimers(); });
+      const fills = screen.getAllByTestId('ratio-bar-fill');
+      expect(fills.length).toBeGreaterThanOrEqual(1);
     });
   });
 });

--- a/src/features/observability/api/__tests__/observabilityMetricsClient.test.ts
+++ b/src/features/observability/api/__tests__/observabilityMetricsClient.test.ts
@@ -138,6 +138,34 @@ describe('fetchObservabilityMetrics', () => {
       }
     });
 
+    it('forwards locklessTripMissRatio from response (#1972)', async () => {
+      const metrics = makeMetrics();
+      metrics.locklessTripMissRatio = {
+        miss: 3,
+        fired: 7,
+        paradigmIntent: 5,
+        ratio: 0.3,
+      };
+      mockFetchOk(metrics);
+      const result = await fetchObservabilityMetrics();
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.metrics.locklessTripMissRatio?.miss).toBe(3);
+        expect(result.metrics.locklessTripMissRatio?.fired).toBe(7);
+        expect(result.metrics.locklessTripMissRatio?.paradigmIntent).toBe(5);
+        expect(result.metrics.locklessTripMissRatio?.ratio).toBeCloseTo(0.3);
+      }
+    });
+
+    it('locklessTripMissRatio 누락 (구 backend) → undefined graceful', async () => {
+      mockFetchOk(makeMetrics());
+      const result = await fetchObservabilityMetrics();
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.metrics.locklessTripMissRatio).toBeUndefined();
+      }
+    });
+
     it('calls the correct endpoint URL with window=24h', async () => {
       mockFetchOk(makeMetrics());
       await fetchObservabilityMetrics();

--- a/src/features/observability/api/observabilityMetricsClient.ts
+++ b/src/features/observability/api/observabilityMetricsClient.ts
@@ -56,6 +56,20 @@ export interface AlgorithmAccuracyBucket {
   answeredTotal: number;
 }
 
+/**
+ * #1972 (#1503 잔여 3/3) — lockless trip 종료 fire 0건 분기 응답 bucket.
+ * miss = userIntent ON + fire 0건 (진짜 miss).
+ * fired = fire ≥ 1건 (정상).
+ * paradigmIntent = userIntent OFF + fire 0건 (paradigm intent, 분모/분자 제외).
+ * ratio = miss / (miss + fired) — 분모 0이면 0.
+ */
+export interface LocklessTripMissBucket {
+  miss: number;
+  fired: number;
+  paradigmIntent: number;
+  ratio: number;
+}
+
 export interface ObservabilityMetrics {
   accuracyRatio: ObservabilityMetricsBucket;
   silentPushDeliveryRatio: ObservabilityMetricsBucket;
@@ -80,6 +94,12 @@ export interface ObservabilityMetrics {
    * 신규 필드 — 구버전 backend는 미수신할 수 있으므로 optional.
    */
   algorithmAccuracyRatio?: AlgorithmAccuracyBucket;
+  /**
+   * #1972 (#1503 잔여 3/3) — lockless trip 종료 fire 0건 분기 비율.
+   * source='lockless-trip-end' outcome 분기 누적. userIntent 분기로 진짜 miss vs paradigm 구분.
+   * 신규 필드 — 구버전 backend는 미수신할 수 있으므로 optional.
+   */
+  locklessTripMissRatio?: LocklessTripMissBucket;
   window: '24h';
   timestamp: number;
 }


### PR DESCRIPTION
## Summary
- backend `locklessMissMetric` 신규 — outcome → bucket 데이터 주도 매핑 helper (`LOCKLESS_TRIP_END_OUTCOME_TO_BUCKET`)
- backend `alarmLogStats.locklessTripCounts { miss, fired, paradigmIntent }` 누적
- backend `observabilityMetrics.locklessTripMissRatio = miss / (miss + fired)` (paradigmIntent 분모/분자 제외)
- frontend `logLocklessTripEnd` — `source='lockless-trip-end'` outcome 분기 (fireCount/userIntent)
- frontend `countFiredAlarms` — `FIRED_ALARM_SOURCES` Record 데이터 주도 (글로벌 룰 3)
- frontend `triggerTripEndRecall` lockless trip 분기 stamp wire (lock 활성 trip 스킵)
- frontend `OperationDashboardSection` `locklessTripMiss` row + paradigm count 표시
- frontend `observabilityMetricsClient.LocklessTripMissBucket` type + optional 응답

Closes #1972 (#1503 잔여 3/3 — 코드 acceptance 완성)

## userIntent 분기
- `infoModeEnabled=false` + lockless + fire 0건 → `paradigmIntent` (분모/분자 제외)
- `infoModeEnabled=true` + lockless + fire 0건 → 진짜 `miss`
- `fire ≥ 1` → `fired` (정상)
- `lesson_silent_push_zero_is_paradigm_intent` 적용

## Wire-completion 5단 체크
1. **Orphan 없음** — `npm run lint:orphan` pass
2. **V/X dashboard** — DebugModal `operation-metric-locklessTripMiss (paradigm=N)` row + `locklessTripMissRatio` 분리 카운터
3. **의존 PR** — #1955 / #1970 / #1971 머지됨 (직렬 룰 충족)
4. **측정 plan** — 1주 lockless miss rate baseline + paradigm-intent fraction (DebugModal 라이브 + R2 archive `source='lockless-trip-end'` scan)
5. **Device verify** — 실기기 lockless trip 2회 필요 (`infoMode` ON/OFF 양쪽)

## Test plan
- [x] `npm test` 커버리지 100% (frontend 414 suites / 8783 tests)
- [x] backend `vitest run` 63 files / 2343 tests pass
- [x] `npm run type-check` pass (frontend + backend)
- [x] `npm run lint:orphan` pass
- [x] code-review medium effort — 3 known risk 등록 (아래)

## Known risk (code-review medium effort)

1. **`accuracyRatio` 분자 누적 오염** — 기존 backend `accuracyRatio = alarmStats.fired / (fired + suppressed)`는 모든 source 합산. lockless-trip-end stamp가 outcome='fired'/'suppressed'/'received' 1건씩 누적 → 분자/분모 minor 오염. boardable-lookup/ground-truth-response도 같은 패턴 — 기존 회귀. fix(metadata source 가중치 제외) 별도 PR 범위 — `feedback_acceptance_drives_code` per 후속 사용자 가치 검증 후 결정.

2. **`stampLocklessTripEndIfApplicable` 타입 표현 우회** — `readonly Parameters<typeof countFiredAlarms>[0][number][]`로 작성. 작동하나 가독성 저하. `AlarmLogEntry` 직접 import + `readonly AlarmLogEntry[]` 사용이 명시적. cleanup follow-up 후보.

3. **OperationDashboardSection `locklessTripMiss (paradigm=N)` 동적 label** — `testID=operation-metric-${label}` 패턴에서 paradigm 값 변하면 testID 변경. 본 PR 테스트는 fixture 매칭으로 정합. 운영 stable label로 분리하는 follow-up 가능.

## 직전 PR (#1955 / #1970 / #1971) cross-impact
- `alarmLogStats` `accumulateEntry` 시그니처 확장 (인자 +1, 호출자 1곳 동일 갱신)
- `observabilityMetricsResponse` 신규 field `locklessTripMissRatio` (구 backend는 미응답 → frontend optional graceful)
- 기존 fixture 3 곳 (storeObservabilityMetrics + readObservabilityMetrics + tryStore RC-19) `locklessTripMissRatio: { miss:0, fired:0, paradigmIntent:0, ratio:0 }` 추가