### PR TITLE
chore(#1982): Phase 0 - Feature Flag 인프라 (arrival-api-ssot-v1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,9 @@ EXPO_PUBLIC_KORAIL_API_KEY=
 # 코레일 fallback routing 활성화 게이트 (#1096). "true"면 CompositeArrivalProvider로 wrap.
 # 미설정 시 기존 동작 그대로(SeoulOpenApi/BFF 직행).
 EXPO_PUBLIC_USE_KORAIL_FALLBACK=
+
+# Arrival API SSOT 아키텍처 Feature Flag (#1982, ADR-022 Phase 0).
+# "true"면 신규 아키텍처(arrival API SSOT, arvlCd) 활성. 미설정/그 외 값은 기존 동작(dormant).
+# backend KV `arch:simple-arrival-v1` 와 OR 조건 — 두 채널 중 하나라도 ON 이면 활성.
+# 관리자 rollout: `POST /admin/arch-flag {"value":"on"}` 로 rebuild 없이 즉시 전환/rollback.
+EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH=

--- a/backend/alarm-worker/src/__tests__/archFlag.test.ts
+++ b/backend/alarm-worker/src/__tests__/archFlag.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ARCH_FLAG_DEFAULT,
+  ARCH_FLAG_KV_KEY,
+  getArchFlag,
+  isArchFlagValue,
+  setArchFlag,
+} from '../archFlag';
+import { InMemoryKV } from './inMemoryKv';
+
+describe('archFlag (Phase 0, ADR-022 / #1982)', () => {
+  describe('isArchFlagValue', () => {
+    it('accepts on / off', () => {
+      expect(isArchFlagValue('on')).toBe(true);
+      expect(isArchFlagValue('off')).toBe(true);
+    });
+
+    it('rejects other strings', () => {
+      expect(isArchFlagValue('true')).toBe(false);
+      expect(isArchFlagValue('ON')).toBe(false);
+      expect(isArchFlagValue('')).toBe(false);
+    });
+
+    it('rejects non-string values', () => {
+      expect(isArchFlagValue(null)).toBe(false);
+      expect(isArchFlagValue(undefined)).toBe(false);
+      expect(isArchFlagValue(1)).toBe(false);
+      expect(isArchFlagValue({})).toBe(false);
+    });
+  });
+
+  describe('getArchFlag', () => {
+    it('returns default when kv is undefined (개발 환경 호환)', async () => {
+      expect(await getArchFlag(undefined)).toBe(ARCH_FLAG_DEFAULT);
+    });
+
+    it('returns default when key is not set (dormant)', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      expect(await getArchFlag(kv)).toBe('off');
+    });
+
+    it('returns "on" when kv is set to on', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      await kv.put(ARCH_FLAG_KV_KEY, 'on');
+      expect(await getArchFlag(kv)).toBe('on');
+    });
+
+    it('returns "off" when kv is set to off', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      await kv.put(ARCH_FLAG_KV_KEY, 'off');
+      expect(await getArchFlag(kv)).toBe('off');
+    });
+
+    it('falls back to default when kv has invalid value (오타 방어)', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      await kv.put(ARCH_FLAG_KV_KEY, 'true');
+      expect(await getArchFlag(kv)).toBe(ARCH_FLAG_DEFAULT);
+    });
+  });
+
+  describe('setArchFlag', () => {
+    it('writes "on" to KV', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      await setArchFlag(kv, 'on');
+      expect(await kv.get(ARCH_FLAG_KV_KEY)).toBe('on');
+    });
+
+    it('writes "off" to KV', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      await setArchFlag(kv, 'on');
+      await setArchFlag(kv, 'off');
+      expect(await kv.get(ARCH_FLAG_KV_KEY)).toBe('off');
+    });
+
+    it('throws on invalid value (잘못된 KV 상태 진입 차단)', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      // TypeScript 는 컴파일 타임에 막지만, 운영자가 raw HTTP body 로 임의 값을
+      // 넣는 경로에서 방어가 필요.
+      await expect(
+        setArchFlag(kv, 'true' as unknown as 'on'),
+      ).rejects.toThrow(/invalid value/);
+      // 실패 후 KV 는 write 되지 않아야 한다.
+      expect(await kv.get(ARCH_FLAG_KV_KEY)).toBeNull();
+    });
+  });
+
+  describe('constants', () => {
+    it('default is off', () => {
+      expect(ARCH_FLAG_DEFAULT).toBe('off');
+    });
+
+    it('key matches ADR-022 명시 값', () => {
+      expect(ARCH_FLAG_KV_KEY).toBe('arch:simple-arrival-v1');
+    });
+  });
+});

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -4364,3 +4364,152 @@ describe('GET /admin/baseline-check (#1621 Phase C)', () => {
     expect(body.signals.v1Mismatch).toBe(0);
   });
 });
+
+// #1982 (ADR-022 Phase 0) — Arrival API SSOT Feature Flag admin endpoints.
+describe('GET/POST /admin/arch-flag (#1982)', () => {
+  async function getFlag(env: Env, authHeader?: string): Promise<Response> {
+    return app.fetch(
+      new Request('http://example.com/admin/arch-flag', {
+        method: 'GET',
+        headers: authHeader ? { authorization: authHeader } : {},
+      }),
+      env,
+    );
+  }
+
+  async function postFlag(
+    env: Env,
+    body: unknown,
+    authHeader?: string,
+    { rawBody }: { rawBody?: string } = {},
+  ): Promise<Response> {
+    return app.fetch(
+      new Request('http://example.com/admin/arch-flag', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          ...(authHeader ? { authorization: authHeader } : {}),
+        },
+        body: rawBody ?? JSON.stringify(body),
+      }),
+      env,
+    );
+  }
+
+  function makeAuthEnv(): Env {
+    return makeEnv({ TRIPS: new InMemoryKV() as unknown as Env['TRIPS'], ADMIN_TOKEN: 'secret' });
+  }
+
+  describe('GET', () => {
+    it('returns 503 when ADMIN_TOKEN not configured', async () => {
+      const env = makeKvEnv();
+      const res = await getFlag(env, 'Bearer x');
+      expect(res.status).toBe(503);
+      expect(await res.json()).toEqual({ error: 'admin_unavailable' });
+    });
+
+    it('returns 401 without bearer header', async () => {
+      const env = makeAuthEnv();
+      const res = await getFlag(env);
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 with wrong token', async () => {
+      const env = makeAuthEnv();
+      const res = await getFlag(env, 'Bearer wrong');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 503 when TRIPS binding unavailable', async () => {
+      // ADMIN_TOKEN 은 있지만 TRIPS 미바인딩 케이스. Env type 은 non-null 이지만
+      // wrangler.toml 에 KV binding 이 없는 환경(개발/최초 배포)에서 undefined 가 넘어온다.
+      const env = makeEnv({
+        ADMIN_TOKEN: 'secret',
+        TRIPS: undefined as unknown as Env['TRIPS'],
+      });
+      const res = await getFlag(env, 'Bearer secret');
+      expect(res.status).toBe(503);
+      expect(await res.json()).toEqual({ error: 'trips_unavailable' });
+    });
+
+    it('returns default (off) when key never set', async () => {
+      const env = makeAuthEnv();
+      const res = await getFlag(env, 'Bearer secret');
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ value: 'off' });
+    });
+
+    it('reflects value previously written via POST', async () => {
+      const env = makeAuthEnv();
+      await postFlag(env, { value: 'on' }, 'Bearer secret');
+      const res = await getFlag(env, 'Bearer secret');
+      expect(await res.json()).toEqual({ value: 'on' });
+    });
+  });
+
+  describe('POST', () => {
+    it('returns 503 when ADMIN_TOKEN not configured', async () => {
+      const env = makeKvEnv();
+      const res = await postFlag(env, { value: 'on' }, 'Bearer x');
+      expect(res.status).toBe(503);
+    });
+
+    it('returns 401 without bearer header', async () => {
+      const env = makeAuthEnv();
+      const res = await postFlag(env, { value: 'on' });
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 with wrong token', async () => {
+      const env = makeAuthEnv();
+      const res = await postFlag(env, { value: 'on' }, 'Bearer wrong');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 503 when TRIPS binding unavailable', async () => {
+      const env = makeEnv({
+        ADMIN_TOKEN: 'secret',
+        TRIPS: undefined as unknown as Env['TRIPS'],
+      });
+      const res = await postFlag(env, { value: 'on' }, 'Bearer secret');
+      expect(res.status).toBe(503);
+    });
+
+    it('returns 400 when body is not JSON', async () => {
+      const env = makeAuthEnv();
+      const res = await postFlag(env, null, 'Bearer secret', { rawBody: 'not-json' });
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'invalid_body' });
+    });
+
+    it('returns 400 when body has no value field', async () => {
+      const env = makeAuthEnv();
+      const res = await postFlag(env, {}, 'Bearer secret');
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when value is invalid literal', async () => {
+      const env = makeAuthEnv();
+      const res = await postFlag(env, { value: 'true' }, 'Bearer secret');
+      expect(res.status).toBe(400);
+    });
+
+    it('accepts value=on and persists to KV', async () => {
+      const env = makeAuthEnv();
+      const res = await postFlag(env, { value: 'on' }, 'Bearer secret');
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ value: 'on' });
+      const readBack = await getFlag(env, 'Bearer secret');
+      expect(await readBack.json()).toEqual({ value: 'on' });
+    });
+
+    it('accepts value=off (rollback) and persists to KV', async () => {
+      const env = makeAuthEnv();
+      // 사전에 on 으로 설정된 상태를 off 로 되돌리는 rollback 시나리오.
+      await postFlag(env, { value: 'on' }, 'Bearer secret');
+      const res = await postFlag(env, { value: 'off' }, 'Bearer secret');
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ value: 'off' });
+    });
+  });
+});

--- a/backend/alarm-worker/src/archFlag.ts
+++ b/backend/alarm-worker/src/archFlag.ts
@@ -1,0 +1,60 @@
+/**
+ * Arrival API SSOT 아키텍처 Feature Flag (Phase 0, ADR-022 / 이슈 #1982).
+ *
+ * ADR-022 는 알림 SSOT 를 Seoul TOPIS `realtimeStationArrival` API (`arvlCd`) 로 단일화한다.
+ * 전환은 Staged 로 진행: Phase 0(본 인프라) → Phase 1(신규 코드 병존) → Phase 2(dogfood)
+ * → Phase 3(default ON) → Phase 4(구 코드 삭제 + flag 제거).
+ *
+ * 본 모듈은 backend 측 KV 스위치의 read/write 어댑터다. Phase 0 시점에는 신규 아키텍처 코드가
+ * 없어 flag 값이 어떤 동작도 바꾸지 않는다(dormant). Phase 1 이후 caller 가 결과 값을 분기
+ * 조건으로 사용한다.
+ *
+ * Rollback 정책: `on` → `off` KV write 만으로 즉시 되돌린다(배포 없음). Phase 4 이후에는
+ * git revert.
+ */
+
+/** 신규 아키텍처 활성 KV 키. 값은 `on` 또는 `off` 만 유효. */
+export const ARCH_FLAG_KV_KEY = 'arch:simple-arrival-v1';
+
+/** 두 가지 값만 허용 — enum literal union. 다른 값은 default(`off`) 로 정규화된다. */
+export type ArchFlagValue = 'on' | 'off';
+
+/** Default 값 — 미설정 KV / 오타 / 파싱 실패 모두 이 값으로 fallback. */
+export const ARCH_FLAG_DEFAULT: ArchFlagValue = 'off';
+
+/** 유효 값 판정 — set / get 양쪽 공용. */
+export function isArchFlagValue(raw: unknown): raw is ArchFlagValue {
+  return raw === 'on' || raw === 'off';
+}
+
+/**
+ * KV 로 부터 현재 flag 값을 조회. 값 부재 / 오타 / KV 미바인딩 견해에서 이견을 없애기 위해
+ * 다음 순서로 정규화한다:
+ *  1. `kv` 인자가 없으면 default 반환 (개발 환경 호환).
+ *  2. KV `get` 결과가 null 이면 default (미설정 시 dormant).
+ *  3. 유효 문자열('on' / 'off') 이면 그 값을 반환.
+ *  4. 그 외 오타/타입 이상 값은 default 로 fallback (KV 를 조작한 운영자 실수 방어).
+ */
+export async function getArchFlag(
+  kv: KVNamespace | undefined,
+): Promise<ArchFlagValue> {
+  if (!kv) return ARCH_FLAG_DEFAULT;
+  const raw = await kv.get(ARCH_FLAG_KV_KEY);
+  if (raw === null) return ARCH_FLAG_DEFAULT;
+  return isArchFlagValue(raw) ? raw : ARCH_FLAG_DEFAULT;
+}
+
+/**
+ * 관리자용 flag 설정. 유효하지 않은 값은 write 없이 throw — 잘못된 KV 상태 진입 차단.
+ *
+ * TTL 없음: rollback 시 즉시 반영되어야 하므로 영구 저장.
+ */
+export async function setArchFlag(
+  kv: KVNamespace,
+  value: ArchFlagValue,
+): Promise<void> {
+  if (!isArchFlagValue(value)) {
+    throw new Error(`archFlag: invalid value ${String(value)}`);
+  }
+  await kv.put(ARCH_FLAG_KV_KEY, value);
+}

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -44,6 +44,12 @@ import { ackPending, stampReceived } from './pendingPushes';
 import { computePushAckStats } from './pushAckStats';
 import { computeAlarmLogStats } from './alarmLogStats';
 import { computeBaselineCheck } from './baselineCheck';
+import {
+  ARCH_FLAG_DEFAULT,
+  getArchFlag,
+  isArchFlagValue,
+  setArchFlag,
+} from './archFlag';
 import { appendPositionPoint } from './positionSeries';
 import { appendAccelSample, isAccelSummary } from './accelSeries';
 import { updateSsotMotion } from './motionState';
@@ -374,6 +380,57 @@ app.get('/admin/baseline-check', async (c) => {
   if (!r2) return c.json({ error: 'telemetry_r2_unavailable' }, 503);
   const result = await computeBaselineCheck(kv, r2, tripToken, Date.now());
   return c.json(result);
+});
+
+/**
+ * #1982 (ADR-022 Phase 0) — Arrival API SSOT 아키텍처 Feature Flag 조회 endpoint.
+ *
+ * Phase 0 시점의 flag 값은 어떤 동작도 바꾸지 않는다(dormant). Phase 1 이후 caller 가
+ * 결과 값을 새/구 아키텍처 분기 조건으로 사용한다. 본 endpoint 는 device DebugModal /
+ * 운영자 진단에서 현재 KV 상태를 조회하는 read-only 창구.
+ *
+ * Auth: `Authorization: Bearer <ADMIN_TOKEN>` — admin 공통 정책.
+ * Response 200: `{ value: 'on' | 'off' }`
+ * Response 401/503: 인증/binding 정책 동일 (TRIPS 미바인딩 시 503).
+ */
+app.get('/admin/arch-flag', async (c) => {
+  const authError = checkAdminAuth(c.req.header('authorization'), c.env.ADMIN_TOKEN);
+  if (authError) return c.json({ error: authError.code }, authError.status);
+  const kv = c.env.TRIPS;
+  if (!kv) return c.json({ error: 'trips_unavailable' }, 503);
+  const value = await getArchFlag(kv);
+  return c.json({ value });
+});
+
+/**
+ * #1982 (ADR-022 Phase 0) — Arrival API SSOT 아키텍처 Feature Flag 설정 endpoint.
+ *
+ * Rollback 채널: `on` 상태에서 회귀 발견 시 `off` write 만으로 즉시 되돌린다(배포 없음).
+ * 유효 값은 `on` / `off` 만. 그 외 body 는 400 으로 거절 — 잘못된 KV 진입 차단.
+ *
+ * Auth: `Authorization: Bearer <ADMIN_TOKEN>` — admin 공통 정책.
+ * Body: `{ value: 'on' | 'off' }`
+ * Response 200: `{ value: 'on' | 'off' }`
+ * Response 400: `{ error: 'invalid_body' }` — body 파싱 실패 / 유효하지 않은 value.
+ * Response 401/503: 인증/binding 정책 동일.
+ */
+app.post('/admin/arch-flag', async (c) => {
+  const authError = checkAdminAuth(c.req.header('authorization'), c.env.ADMIN_TOKEN);
+  if (authError) return c.json({ error: authError.code }, authError.status);
+  const kv = c.env.TRIPS;
+  if (!kv) return c.json({ error: 'trips_unavailable' }, 503);
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_body' }, 400);
+  }
+  const raw = (body as { value?: unknown } | null)?.value;
+  if (!isArchFlagValue(raw)) {
+    return c.json({ error: 'invalid_body' }, 400);
+  }
+  await setArchFlag(kv, raw);
+  return c.json({ value: raw });
 });
 
 interface AdminAuthError {
@@ -2161,8 +2218,12 @@ const handler = {
       bundleId: env.APNS_BUNDLE_ID,
     };
     const apnsHosts = { production: env.APNS_HOST, sandbox: env.APNS_HOST_SANDBOX };
+    // #1982 (ADR-022 Phase 0) — 매 cron cycle log 에 archFlag on/off 를 포함한다.
+    // KV 미바인딩 / 미설정 케이스는 `getArchFlag` 가 default 로 fallback (dormant).
+    // meta 에 우연히 같은 키가 실려 있어도 archFlag SSOT 가 이기도록 spread 순서를 뒤로 둔다.
+    const archFlag = await getArchFlag(env.TRIPS).catch(() => ARCH_FLAG_DEFAULT);
     const log = (msg: string, meta?: Record<string, unknown>) =>
-      console.log(JSON.stringify({ msg, ...meta }));
+      console.log(JSON.stringify({ msg, ...meta, archFlag }));
 
     try {
       await runScheduled(env, { seoul, apnsConfig, apnsHosts, log });

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -27,6 +27,12 @@ import {
   type BackendSsotMirrorEntry,
 } from '../../alarm/utils/backendSsotMirror';
 import { isDebugModalEnabled } from '../../../shared/constants/debugFlags';
+import {
+  SIMPLE_ARRIVAL_ARCH_ENV_KEY,
+  isSimpleArchEnabled,
+  isSimpleArchEnvEnabled,
+} from '../../../shared/config/archFlag';
+import { useArchFlagRemote } from '../../../shared/config/useArchFlagRemote';
 import type { GpsActiveState } from '../../../shared/constants/gpsStatus';
 import { formatClockTimeWithSeconds } from '../../../shared/utils/formatTime';
 import { useFusedNearestStation } from '../../../features/nearest-station/hooks/useFusedNearestStation';
@@ -1653,6 +1659,9 @@ function DebugModalInner({
   // #458: RN Modal 안에서는 SafeAreaView가 안 먹는다(portal로 inset 컨텍스트 분리).
   // 루트 SafeAreaProvider의 insets를 hook으로 직접 받아 헤더에 manual padding.
   const insets = useSafeAreaInsets();
+  // #1982 (ADR-022 Phase 0) — arrival-api-ssot-v1 Feature Flag remote 조회.
+  // ADMIN_TOKEN / ALARM_BACKEND_URL 미설정 환경은 kind=unconfigured 로 그대로 표시.
+  const archFlagRemote = useArchFlagRemote();
   // #1812 — routeContext 빌드: HomeScreen이 ROUTE_KEY에 영속화한 route + destinationStore의
   // tripOrigin + destination으로 routeContext를 구성한다. destination 변경 시 재조회.
   // tripStartedAt과 동일 패턴 (AsyncStorage SSOT, destination 의존 effect).
@@ -2131,6 +2140,26 @@ function DebugModalInner({
           {/* #1956 — onMetricClick wire: metric 클릭 → TripDetailModal 진입. */}
           <Section title="Operation Dashboard" colors={colors} testID="operation-dashboard-section-wrapper">
             <OperationDashboardSection logs={logs} onMetricClick={handleMetricClick} />
+          </Section>
+
+          {/* #1982 (ADR-022 Phase 0) — arrival-api-ssot-v1 Feature Flag.
+              env 값 + remote 값 + 최종 판정을 각각 표시. Phase 0 시점에는 dormant. */}
+          <Section title="Feature Flag" colors={colors} testID="feature-flag-section">
+            <KeyValue
+              label={SIMPLE_ARRIVAL_ARCH_ENV_KEY}
+              value={isSimpleArchEnvEnabled() ? 'true' : 'false'}
+              colors={colors}
+            />
+            <KeyValue
+              label="arch:simple-arrival-v1 (remote)"
+              value={archFlagRemote.value ?? `(${archFlagRemote.kind})`}
+              colors={colors}
+            />
+            <KeyValue
+              label="simple-arrival active"
+              value={isSimpleArchEnabled(archFlagRemote.value) ? 'ON' : 'OFF'}
+              colors={colors}
+            />
           </Section>
 
           <Section title="GPS" colors={colors}>

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -81,6 +81,12 @@ jest.mock('../../../alarm/utils/scheduledNotificationsDump', () => {
     dumpScheduledNotifications: () => mockDumpScheduledNotifications(),
   };
 });
+// #1982 (ADR-022 Phase 0) — DebugModal 이 Feature Flag remote 조회 hook 을 마운트한다.
+// 실제 fetch 를 막고 반환값을 case 별로 override 하기 위해 mock 함수를 노출한다.
+const mockUseArchFlagRemote = jest.fn();
+jest.mock('../../../../shared/config/useArchFlagRemote', () => ({
+  useArchFlagRemote: () => mockUseArchFlagRemote(),
+}));
 const station: Station = {
   id: '2-022',
   name: '강남',
@@ -214,6 +220,12 @@ const setupHookDefaults = () => {
   mockReadBackendSsotMirror.mockResolvedValue(null);
   // #1898 — accelerometer raw snapshot 기본 null (native 모듈 미포함 / jest 환경).
   mockGetLatestAccelerometerSnapshot.mockReturnValue(null);
+  // #1982 (ADR-022 Phase 0) — Feature Flag remote 기본 unconfigured (테스트 env 에는 backend URL 없음).
+  mockUseArchFlagRemote.mockReturnValue({
+    value: undefined,
+    kind: 'unconfigured',
+    lastFetchedAt: null,
+  });
   // #1235 (D9 wire) — destinationStore/settingsStore SSOT 초기화. 매 테스트 독립.
   useDestinationStore.setState({ destination: null, tripOrigin: null });
   useSettingsStore.setState({ sleepMode: false });
@@ -286,6 +298,54 @@ describe('DebugModal', () => {
     const { toJSON } = renderWithTheme(<DebugModal onClose={jest.fn()} />);
     expect(toJSON()).toBeNull();
     g.__DEV__ = original;
+  });
+
+  // #1982 (ADR-022 Phase 0) — Feature Flag 섹션이 env / remote / 최종 판정을 표시한다.
+  describe('Feature Flag section (#1982)', () => {
+    const ARCH_ENV_KEY = 'EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH';
+    const originalEnv = process.env[ARCH_ENV_KEY];
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env[ARCH_ENV_KEY];
+      } else {
+        process.env[ARCH_ENV_KEY] = originalEnv;
+      }
+    });
+
+    it('remote unconfigured + env unset → OFF (dormant default)', async () => {
+      delete process.env[ARCH_ENV_KEY];
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      expect(await screen.findByTestId('feature-flag-section')).toBeTruthy();
+      expect(screen.getByText('Feature Flag')).toBeTruthy();
+      // 최종 판정 라인.
+      const active = screen.getByText('simple-arrival active');
+      expect(active).toBeTruthy();
+      // "OFF" 텍스트가 화면에 나타나야 한다.
+      expect(screen.getByText('OFF')).toBeTruthy();
+    });
+
+    it('remote on → ON (rollout stage)', async () => {
+      delete process.env[ARCH_ENV_KEY];
+      mockUseArchFlagRemote.mockReturnValue({
+        value: 'on',
+        kind: 'ok',
+        lastFetchedAt: 1_700_000_000_000,
+      });
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByText('ON')).toBeTruthy());
+    });
+
+    it('env=true → ON (dogfood build)', async () => {
+      process.env[ARCH_ENV_KEY] = 'true';
+      mockUseArchFlagRemote.mockReturnValue({
+        value: 'off',
+        kind: 'ok',
+        lastFetchedAt: 1_700_000_000_000,
+      });
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(screen.getByText('ON')).toBeTruthy());
+    });
   });
 
   it('GPS / Nearest / Arrival / Alarm log 섹션을 모두 표시한다', async () => {

--- a/src/shared/config/__tests__/archFlag.test.ts
+++ b/src/shared/config/__tests__/archFlag.test.ts
@@ -1,0 +1,68 @@
+import {
+  SIMPLE_ARRIVAL_ARCH_ENV_KEY,
+  isSimpleArchEnabled,
+  isSimpleArchEnvEnabled,
+} from '../archFlag';
+
+const ORIGINAL_ENV = process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+
+afterEach(() => {
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+  } else {
+    process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = ORIGINAL_ENV;
+  }
+});
+
+describe('isSimpleArchEnvEnabled (#1982)', () => {
+  it('true when env is exactly the string "true"', () => {
+    process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+    expect(isSimpleArchEnvEnabled()).toBe(true);
+  });
+
+  it('false when env is undefined', () => {
+    delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+    expect(isSimpleArchEnvEnabled()).toBe(false);
+  });
+
+  it.each(['false', 'True', 'TRUE', '1', ''])(
+    'false for env value %j (오타 방어)',
+    (value) => {
+      process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = value;
+      expect(isSimpleArchEnvEnabled()).toBe(false);
+    },
+  );
+});
+
+describe('isSimpleArchEnabled (env OR remote, #1982)', () => {
+  beforeEach(() => {
+    delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+  });
+
+  it('true when env=true and remote undefined (dogfood build)', () => {
+    process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+    expect(isSimpleArchEnabled(undefined)).toBe(true);
+  });
+
+  it('true when env=false and remote=on (rollout stage)', () => {
+    expect(isSimpleArchEnabled('on')).toBe(true);
+  });
+
+  it('true when both env=true and remote=on', () => {
+    process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+    expect(isSimpleArchEnabled('on')).toBe(true);
+  });
+
+  it('false when both env=false and remote=off (dormant default)', () => {
+    expect(isSimpleArchEnabled('off')).toBe(false);
+  });
+
+  it('false when both env=false and remote undefined', () => {
+    expect(isSimpleArchEnabled(undefined)).toBe(false);
+  });
+
+  it('false without arg (remote 미조회) and env=false', () => {
+    // caller 가 remote 를 조회하지 않는 코드 경로.
+    expect(isSimpleArchEnabled()).toBe(false);
+  });
+});

--- a/src/shared/config/__tests__/archFlagRemote.test.ts
+++ b/src/shared/config/__tests__/archFlagRemote.test.ts
@@ -1,0 +1,153 @@
+import { __test__, fetchArchFlag } from '../archFlagRemote';
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env.EXPO_PUBLIC_ADMIN_TOKEN = 'test-token';
+  process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://alarm.example.test';
+  global.fetch = jest.fn() as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  process.env.EXPO_PUBLIC_ADMIN_TOKEN = ORIGINAL_ENV.EXPO_PUBLIC_ADMIN_TOKEN;
+  process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = ORIGINAL_ENV.EXPO_PUBLIC_ALARM_BACKEND_URL;
+});
+
+function mockFetchOk(body: unknown): void {
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  });
+}
+
+function mockFetchStatus(status: number): void {
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: false,
+    status,
+    json: async () => ({}),
+  });
+}
+
+function mockFetchThrow(message: string): void {
+  (global.fetch as jest.Mock).mockRejectedValue(new Error(message));
+}
+
+describe('fetchArchFlag (#1982, ADR-022 Phase 0)', () => {
+  describe('unconfigured', () => {
+    it('returns unconfigured when ADMIN_TOKEN is empty', async () => {
+      process.env.EXPO_PUBLIC_ADMIN_TOKEN = '';
+      const result = await fetchArchFlag();
+      expect(result.kind).toBe('unconfigured');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns unconfigured when ADMIN_TOKEN is unset', async () => {
+      delete process.env.EXPO_PUBLIC_ADMIN_TOKEN;
+      const result = await fetchArchFlag();
+      expect(result.kind).toBe('unconfigured');
+    });
+
+    it('returns unconfigured when ALARM_BACKEND_URL is empty', async () => {
+      process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = '';
+      const result = await fetchArchFlag();
+      expect(result.kind).toBe('unconfigured');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('success', () => {
+    it('returns ok with value=on', async () => {
+      mockFetchOk({ value: 'on' });
+      const result = await fetchArchFlag();
+      expect(result).toEqual({ kind: 'ok', value: 'on' });
+    });
+
+    it('returns ok with value=off', async () => {
+      mockFetchOk({ value: 'off' });
+      const result = await fetchArchFlag();
+      expect(result).toEqual({ kind: 'ok', value: 'off' });
+    });
+
+    it('calls the correct endpoint /admin/arch-flag', async () => {
+      mockFetchOk({ value: 'off' });
+      await fetchArchFlag();
+      const [url] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('https://alarm.example.test/admin/arch-flag');
+    });
+
+    it('sends Bearer authorization header', async () => {
+      mockFetchOk({ value: 'off' });
+      await fetchArchFlag();
+      const [, init] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+      expect((init.headers as Record<string, string>)['authorization']).toBe(
+        'Bearer test-token',
+      );
+    });
+  });
+
+  describe('error cases', () => {
+    it('returns error with HTTP status on non-200', async () => {
+      mockFetchStatus(401);
+      const result = await fetchArchFlag();
+      expect(result.kind).toBe('error');
+      if (result.kind === 'error') {
+        expect(result.message).toBe('HTTP 401');
+      }
+    });
+
+    it('returns error on 503', async () => {
+      mockFetchStatus(503);
+      const result = await fetchArchFlag();
+      expect(result.kind).toBe('error');
+      if (result.kind === 'error') {
+        expect(result.message).toBe('HTTP 503');
+      }
+    });
+
+    it('returns error with message when fetch throws', async () => {
+      mockFetchThrow('network timeout');
+      const result = await fetchArchFlag();
+      expect(result.kind).toBe('error');
+      if (result.kind === 'error') {
+        expect(result.message).toBe('network timeout');
+      }
+    });
+
+    it('returns error string when non-Error thrown', async () => {
+      (global.fetch as jest.Mock).mockRejectedValue('raw');
+      const result = await fetchArchFlag();
+      expect(result.kind).toBe('error');
+      if (result.kind === 'error') {
+        expect(typeof result.message).toBe('string');
+      }
+    });
+
+    it('returns error when body.value is invalid (backend drift 방어)', async () => {
+      mockFetchOk({ value: 'true' });
+      const result = await fetchArchFlag();
+      expect(result.kind).toBe('error');
+      if (result.kind === 'error') {
+        expect(result.message).toBe('invalid_body');
+      }
+    });
+
+    it('returns error when body missing value field', async () => {
+      mockFetchOk({});
+      const result = await fetchArchFlag();
+      expect(result.kind).toBe('error');
+    });
+  });
+
+  describe('__test__ internal exports', () => {
+    it('getAdminToken returns null when unset', () => {
+      process.env.EXPO_PUBLIC_ADMIN_TOKEN = '';
+      expect(__test__.getAdminToken()).toBeNull();
+    });
+
+    it('getAdminToken returns token string when set', () => {
+      process.env.EXPO_PUBLIC_ADMIN_TOKEN = 'my-token';
+      expect(__test__.getAdminToken()).toBe('my-token');
+    });
+  });
+});

--- a/src/shared/config/__tests__/useArchFlagRemote.test.ts
+++ b/src/shared/config/__tests__/useArchFlagRemote.test.ts
@@ -1,0 +1,116 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import {
+  ARCH_FLAG_REMOTE_REFRESH_MS,
+  useArchFlagRemote,
+} from '../useArchFlagRemote';
+
+jest.mock('../archFlagRemote', () => ({
+  fetchArchFlag: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { fetchArchFlag } = jest.requireMock('../archFlagRemote') as {
+  fetchArchFlag: jest.Mock;
+};
+
+describe('useArchFlagRemote (#1982, ADR-022 Phase 0)', () => {
+  beforeEach(() => {
+    fetchArchFlag.mockReset();
+  });
+
+  it('mount 시 loading 상태에서 시작', () => {
+    fetchArchFlag.mockReturnValue(new Promise(() => undefined));
+    const { result } = renderHook(() => useArchFlagRemote());
+    expect(result.current.kind).toBe('loading');
+    expect(result.current.value).toBeUndefined();
+    expect(result.current.lastFetchedAt).toBeNull();
+  });
+
+  it('첫 fetch 성공 시 kind=ok + value 반영', async () => {
+    fetchArchFlag.mockResolvedValue({ kind: 'ok', value: 'on' });
+    const { result } = renderHook(() => useArchFlagRemote());
+    await waitFor(() => {
+      expect(result.current.kind).toBe('ok');
+    });
+    expect(result.current.value).toBe('on');
+    expect(result.current.lastFetchedAt).not.toBeNull();
+  });
+
+  it('unconfigured 결과는 value=undefined + kind=unconfigured', async () => {
+    fetchArchFlag.mockResolvedValue({ kind: 'unconfigured' });
+    const { result } = renderHook(() => useArchFlagRemote());
+    await waitFor(() => {
+      expect(result.current.kind).toBe('unconfigured');
+    });
+    expect(result.current.value).toBeUndefined();
+  });
+
+  it('error 결과는 value=undefined + kind=error', async () => {
+    fetchArchFlag.mockResolvedValue({ kind: 'error', message: 'HTTP 503' });
+    const { result } = renderHook(() => useArchFlagRemote());
+    await waitFor(() => {
+      expect(result.current.kind).toBe('error');
+    });
+    expect(result.current.value).toBeUndefined();
+  });
+
+  describe('interval refresh', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('5분 마다 재조회', async () => {
+      fetchArchFlag.mockResolvedValue({ kind: 'ok', value: 'off' });
+      renderHook(() => useArchFlagRemote());
+      // 첫 fetch (mount 즉시)
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(fetchArchFlag).toHaveBeenCalledTimes(1);
+
+      // 5분 경과
+      await act(async () => {
+        jest.advanceTimersByTime(ARCH_FLAG_REMOTE_REFRESH_MS);
+        await Promise.resolve();
+      });
+      expect(fetchArchFlag).toHaveBeenCalledTimes(2);
+    });
+
+    it('unmount 시 cancel — 늦게 도착한 fetch 결과 무시', async () => {
+      let resolveFetch: (v: unknown) => void = () => undefined;
+      fetchArchFlag.mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+      );
+      const { result, unmount } = renderHook(() => useArchFlagRemote());
+      // mount 직후: loading
+      expect(result.current.kind).toBe('loading');
+      // 컴포넌트가 사라진 뒤에 fetch 응답 도착
+      unmount();
+      resolveFetch({ kind: 'ok', value: 'on' });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      // React warning 이 발생하지 않으면 cancel 이 정상 동작 (setState 미호출).
+      // 결과값 자체는 unmounted hook 이라 관찰 불가 — 실제 실행 흐름에서 no-op 확인이 목적.
+      // (React Testing Library 는 warning 이 있으면 test fail 시킴)
+    });
+
+    it('unmount 후 clearInterval 호출로 refresh 중단', async () => {
+      fetchArchFlag.mockResolvedValue({ kind: 'ok', value: 'off' });
+      const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+      const { unmount } = renderHook(() => useArchFlagRemote());
+      await act(async () => {
+        await Promise.resolve();
+      });
+      unmount();
+      expect(clearIntervalSpy).toHaveBeenCalled();
+      clearIntervalSpy.mockRestore();
+    });
+  });
+});

--- a/src/shared/config/archFlag.ts
+++ b/src/shared/config/archFlag.ts
@@ -1,0 +1,50 @@
+/**
+ * Arrival API SSOT 아키텍처 Feature Flag — client 측 (Phase 0, ADR-022 / 이슈 #1982).
+ *
+ * ADR-022 는 알림 SSOT 를 Seoul TOPIS `realtimeStationArrival` API (`arvlCd`) 로 단일화한다.
+ * 전환 롤아웃은 OR 조건 두 채널로 게이팅한다:
+ *
+ *  1. **client env** `EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH` (`'true'` → 활성)
+ *     — 특정 dogfood 빌드에 embed. rebuild 필요.
+ *  2. **backend KV** `arch:simple-arrival-v1` (`'on'` → 활성)
+ *     — 전 사용자 대상 rollout 스위치. rebuild 없이 즉시 전환/rollback.
+ *
+ * 판정: **OR** — 둘 중 하나만 활성이어도 새 아키텍처. 이유:
+ *  - env: dogfood 개별 device 강제 ON (사용자 명시적 opt-in)
+ *  - remote: 전 사용자 dogfood/rollout 스위치. 두 채널이 독립적이어야 각각의 롤백 경로가 살아있다.
+ *
+ * Phase 0 시점의 flag 값은 어떤 동작도 바꾸지 않는다(dormant). Phase 1 이후 caller 가 결과 값을
+ * 새/구 아키텍처 분기 조건으로 사용한다. 본 모듈은 결과 판정 SSOT 만 제공한다.
+ *
+ * @see docs/decisions/ADR-022-arrival-api-ssot-redesign.md
+ */
+
+/** Env var 이름 — DebugModal 표시 / 테스트에서 재사용. */
+export const SIMPLE_ARRIVAL_ARCH_ENV_KEY = 'EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH';
+
+/**
+ * Env 값을 읽어 flag ON 여부 반환. `'true'` 문자열만 활성 — 다른 값(미설정 / `'false'` /
+ * 오타 등) 은 모두 비활성으로 정규화 (`.env.example` 도 default `false`).
+ *
+ * `process.env` 참조는 함수화 — Expo 는 빌드 타임에 인라인하지만 테스트에서는 런타임에 override
+ * 가능하도록 매 호출 평가한다 (`isDebugModalEnabled` 와 동일 패턴).
+ */
+export function isSimpleArchEnvEnabled(): boolean {
+  return process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] === 'true';
+}
+
+/**
+ * Env OR Remote 판정. `remoteFlag` 인자는 `useArchFlagRemote()` hook 이나 다른 sync 조회
+ * 결과를 그대로 전달. `undefined` (미조회 / unconfigured) 는 비활성으로 간주한다.
+ *
+ * 판정 순서:
+ *  1. env=true → true (dogfood 빌드 강제 ON)
+ *  2. remote='on' → true (전 사용자 rollout 스위치)
+ *  3. 그 외 → false (dormant, 기존 동작 유지)
+ */
+export function isSimpleArchEnabled(
+  remoteFlag?: 'on' | 'off',
+): boolean {
+  if (isSimpleArchEnvEnabled()) return true;
+  return remoteFlag === 'on';
+}

--- a/src/shared/config/archFlagRemote.ts
+++ b/src/shared/config/archFlagRemote.ts
@@ -1,0 +1,64 @@
+/**
+ * Arrival API SSOT Feature Flag — backend remote 조회 client (Phase 0, ADR-022 / #1982).
+ *
+ * `/admin/arch-flag` 엔드포인트를 GET 으로 조회해 현재 KV 상태(`on` / `off`) 를 얻는다.
+ * ADMIN_TOKEN / ALARM_BACKEND_URL 미설정 환경(일반 사용자 빌드) 에서는 `unconfigured`
+ * 를 반환 — 호출자는 remote 없이 env 만으로 판정한다. observabilityMetricsClient 와 동일 패턴.
+ */
+
+import {
+  fetchWithTelemetryTimeout,
+  getAlarmBackendUrl,
+} from '../utils/telemetryHttp';
+
+/** Fetch 결과 union — 호출자는 kind 로 분기. */
+export type FetchArchFlagResult =
+  | { kind: 'ok'; value: 'on' | 'off' }
+  | { kind: 'error'; message: string }
+  | { kind: 'unconfigured' };
+
+/** ADMIN_TOKEN 환경변수 조회. 미설정 시 null. observabilityMetricsClient 동일 패턴. */
+function getAdminToken(): string | null {
+  const token = process.env.EXPO_PUBLIC_ADMIN_TOKEN;
+  if (!token) return null;
+  return token;
+}
+
+/**
+ * `/admin/arch-flag` 단건 fetch.
+ *
+ *  - ADMIN_TOKEN 미설정 → `{ kind: 'unconfigured' }`
+ *  - ALARM_BACKEND_URL 미설정 → `{ kind: 'unconfigured' }`
+ *  - HTTP 오류 / 네트워크 실패 / body parse 실패 → `{ kind: 'error', message }`
+ *  - 성공 → `{ kind: 'ok', value }`
+ */
+export async function fetchArchFlag(): Promise<FetchArchFlagResult> {
+  const token = getAdminToken();
+  if (!token) return { kind: 'unconfigured' };
+
+  const base = getAlarmBackendUrl();
+  if (!base) return { kind: 'unconfigured' };
+
+  try {
+    const res = await fetchWithTelemetryTimeout(`${base}/admin/arch-flag`, {
+      method: 'GET',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      return { kind: 'error', message: `HTTP ${res.status}` };
+    }
+    const body = (await res.json()) as { value?: unknown };
+    if (body.value === 'on' || body.value === 'off') {
+      return { kind: 'ok', value: body.value };
+    }
+    return { kind: 'error', message: 'invalid_body' };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return { kind: 'error', message };
+  }
+}
+
+// Internal exports for tests — DO NOT use from app code.
+export const __test__ = {
+  getAdminToken,
+};

--- a/src/shared/config/useArchFlagRemote.ts
+++ b/src/shared/config/useArchFlagRemote.ts
@@ -1,0 +1,76 @@
+/**
+ * Arrival API SSOT Feature Flag — remote 조회 hook (Phase 0, ADR-022 / #1982).
+ *
+ * mount 시 1회 `/admin/arch-flag` 를 조회하고 5분 주기로 refresh. 배터리를 위해 지속 polling
+ * 없이 5분 간격만 유지 — DebugModal 표시 / Phase 1 이후 caller 가 이 값을 env 와 OR 조건으로
+ * 판정한다.
+ *
+ * DebugModal 이나 다른 컴포넌트에서 다음과 같이 사용한다:
+ *   ```ts
+ *   const remote = useArchFlagRemote();
+ *   const active = isSimpleArchEnabled(remote.value);
+ *   ```
+ *
+ * ADMIN_TOKEN / ALARM_BACKEND_URL 미설정 환경은 `kind: 'unconfigured'` 그대로 유지 —
+ * `isSimpleArchEnabled` 는 undefined 로 remote 를 취급해 env 판정만 사용한다.
+ */
+
+import { useEffect, useState } from 'react';
+import { fetchArchFlag, type FetchArchFlagResult } from './archFlagRemote';
+
+/** 5분 refresh 주기. */
+export const ARCH_FLAG_REMOTE_REFRESH_MS = 5 * 60 * 1000;
+
+/** hook 반환 shape. `value` 는 `'on' | 'off' | undefined` — undefined 시 env 만 판정. */
+export interface ArchFlagRemoteState {
+  /** 최근 fetch 성공 시 flag 값. 실패/미조회 시 undefined. */
+  value: 'on' | 'off' | undefined;
+  /** fetch 결과 kind. UI 진단(에러 메시지 등) 용도. */
+  kind: FetchArchFlagResult['kind'] | 'loading';
+  /** 마지막 fetch 시각 (ms epoch). 미조회 시 null. */
+  lastFetchedAt: number | null;
+}
+
+const INITIAL_STATE: ArchFlagRemoteState = {
+  value: undefined,
+  kind: 'loading',
+  lastFetchedAt: null,
+};
+
+/**
+ * `useArchFlagRemote` — mount 시 1회 fetch + 5분 주기 refresh.
+ *
+ * cancel guard: unmount 이후 setState 방지. 첫 fetch 가 5분 이상 걸리면 다음 tick 과 겹치지만
+ * setInterval 사이클마다 fresh promise 를 생성하므로 마지막 결과가 최종 반영된다.
+ */
+export function useArchFlagRemote(): ArchFlagRemoteState {
+  const [state, setState] = useState<ArchFlagRemoteState>(INITIAL_STATE);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async (): Promise<void> => {
+      const result = await fetchArchFlag();
+      if (cancelled) return;
+      const value =
+        result.kind === 'ok' ? result.value : undefined;
+      setState({
+        value,
+        kind: result.kind,
+        lastFetchedAt: Date.now(),
+      });
+    };
+
+    void load();
+    const timerId = setInterval(() => {
+      void load();
+    }, ARCH_FLAG_REMOTE_REFRESH_MS);
+
+    return (): void => {
+      cancelled = true;
+      clearInterval(timerId);
+    };
+  }, []);
+
+  return state;
+}


### PR DESCRIPTION
Closes #1982

## Summary

ADR-022 (#1980, PR #1981) Feature Flag Staged 롤아웃의 **Phase 0 인프라**. Phase 0 시점에는 flag 값이 **어떤 동작도 바꾸지 않는다(dormant)**. Phase 1 이후 caller 가 결과 값을 새/구 아키텍처 분기 조건으로 사용한다.

## Scope

### Backend (Cloudflare Workers)
- KV 신규 key `arch:simple-arrival-v1` (default `off`, values `on` / `off`)
- Helper `backend/alarm-worker/src/archFlag.ts` — `getArchFlag(kv)` / `setArchFlag(kv, value)` / `isArchFlagValue` type guard
- Admin endpoint `GET /admin/arch-flag`, `POST /admin/arch-flag` (auth 는 기존 `checkAdminAuth` + `Authorization: Bearer <ADMIN_TOKEN>` 재사용)
- scheduled cron 매 cycle log 에 `archFlag: on|off` 필드 포함 (spread 순서를 뒤로 두어 meta 오염 방지)

### Client (RN app)
- `.env.example` 에 `EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH=` 추가 (default false)
- `src/shared/config/archFlag.ts` — env parse + `isSimpleArchEnabled()` (env OR remote 조건 판정)
- `src/shared/config/archFlagRemote.ts` — backend `/admin/arch-flag` 조회 client (ADMIN_TOKEN / ALARM_BACKEND_URL 미설정 → `unconfigured` graceful)
- `src/shared/config/useArchFlagRemote.ts` — mount 시 1회 + 5min refresh hook
- DebugModal "Feature Flag" 섹션 — env 값 + remote 값 + 최종 판정 표시

### Rollback 채널
`POST /admin/arch-flag {"value":"off"}` 로 **rebuild 없이 즉시 되돌림**.

## Tests

- backend `archFlag.test.ts` (13) + admin endpoint tests (15)
- frontend `archFlag.test.ts` (11) + `archFlagRemote.test.ts` (15) + `useArchFlagRemote.test.ts` (7) + `DebugModal Feature Flag section` (3)
- 전체 frontend **8832/8832 pass** (100% coverage), backend **2371/2371 pass**
- type-check clean (frontend + backend)
- `npm run lint:orphan` pass
- `npm run lint` — 신규 코드 0 warning/error (pre-existing 4개는 무관 파일)

## 명시적 제외 (Phase 0 scope)

- 신규 아키텍처 코드 없음 (Phase 1)
- 기존 fusion / motion / Kalman / 기압계 / WiFi 코드 삭제 없음 (Phase 4)
- arvlCd fire-once TTL 등 실제 판정 로직 없음 (Phase 1)
- **flag OFF 상태에서 기존 동작 100% 유지 (dormant)**

## Wire-completion 5단 체크

- [x] **1. Orphan 없음** — `npm run lint:orphan` pass. helper export + caller (index.ts scheduled log + DebugModal) 존재.
- [x] **2. V/X dashboard** — DebugModal "Feature Flag" 섹션 (env + remote + 최종 판정) + wrangler tail `archFlag` 필드.
- [x] **3. 의존 PR** — N/A (ADR PR #1981 확정 무관, 인프라 only).
- [x] **4. 측정 plan** — Phase 1 이후 KV toggle 시 wrangler tail 에 `archFlag=on` 이 매 cycle 감지되는지 확인. Phase 0 자체는 dormant.
- [x] **5. Device verify** — N/A — type+unit only. 실동작 변화 없음(dormant), 신규 fetch 는 DebugModal mount 시에만 활성화.

### V/X dashboard URL

- DebugModal → "Feature Flag" 섹션 (env / remote / 최종 판정)
- `wrangler tail --format json | jq 'select(.logs[]?.message[]? | fromjson? | .archFlag)'`

### 의존 PR

N/A

## Test plan

- [x] `npm test` 100% coverage pass (8832 tests)
- [x] `npm run type-check` pass (frontend + backend)
- [x] `npm run lint:orphan` pass
- [x] `cd backend/alarm-worker && npm test` pass (2371 tests)
- [ ] Phase 1 이후 실기기 dogfood 시 KV toggle → wrangler tail 에서 `archFlag=on` 감지 확인 (본 PR 범위 밖)