### PR TITLE
fix(#1983): Phase 1-6 Location.Accuracy.Balanced → High 통일 (GPS 저정확도 fix)

### DIFF
--- a/src/features/alarm/utils/__tests__/silentPushLocationGate.test.ts
+++ b/src/features/alarm/utils/__tests__/silentPushLocationGate.test.ts
@@ -4,7 +4,9 @@ const mockGetCurrentPositionAsync = jest.fn();
 jest.mock('expo-location', () => ({
   getLastKnownPositionAsync: (...args: unknown[]) => mockGetLastKnownPositionAsync(...args),
   getCurrentPositionAsync: (...args: unknown[]) => mockGetCurrentPositionAsync(...args),
-  Accuracy: { Balanced: 3 },
+  // expo-location Accuracy enum 실측값 mirror. Balanced=3, High=4 (expo-location 소스). #1983에서
+  // fresh fetch를 Balanced→High로 통일하며 both 값을 노출해 regression test가 두 값 모두 참조 가능.
+  Accuracy: { Balanced: 3, High: 4 },
 }));
 
 const mockFindStationByName = jest.fn();
@@ -144,6 +146,24 @@ describe('checkSilentPushLocationGate', () => {
     expect(result.pass).toBe(true);
     expect(result.locationSource).toBe('fresh');
     expect(result.locationAgeMs).toBe(0);
+  });
+
+  // #1983 (ADR-022 A3) — fresh fetch accuracy는 High. 이전엔 Balanced였으나 (100m~수km,
+  // cellular triangulation) 지상 fix까지 1000~1600m 저정확도로 오염되는 회귀 발생. 값 자체를
+  // pin해 Balanced 회귀를 조기 차단한다.
+  it('#1983 fresh fetch는 Accuracy.High로 호출한다 (Balanced 회귀 차단)', async () => {
+    mockGetLastKnownPositionAsync.mockResolvedValue(null);
+    mockGetCurrentPositionAsync.mockResolvedValue(
+      makePosition(NEAR_GANGNAM.lat, NEAR_GANGNAM.lng, 0),
+    );
+    await checkSilentPushLocationGate({
+      stationName: '강남',
+      kind: 'destination',
+      phase: 'imminent',
+    });
+    expect(mockGetCurrentPositionAsync).toHaveBeenCalledWith({
+      accuracy: (jest.requireMock('expo-location') as { Accuracy: { High: number } }).Accuracy.High,
+    });
   });
 
   it('캐시 throw 시에도 fresh fetch fallback', async () => {

--- a/src/features/alarm/utils/silentPushLocationGate.ts
+++ b/src/features/alarm/utils/silentPushLocationGate.ts
@@ -152,8 +152,12 @@ async function resolveUserPosition(): Promise<UserPosition | null> {
     logger.warn('getLastKnownPositionAsync 실패 — fresh fetch 시도:', e);
   }
   try {
+    // #1983 (ADR-022 A3) — Balanced(100m~수km, cellular triangulation)는 지상 fix까지 1000~1600m
+    // 저정확도로 오염시키는 회귀 발생 (7/1 오후, 6/30 여러). silent push imminent 게이트가 잘못된
+    // 좌표로 거리 판정하면 out-of-range 오거부/오통과 모두 회귀 요인이라 Accuracy.High 통일한다.
+    // BG 3s 타임아웃 유지 — High도 OS 캐시 hit이면 즉답, 콜드 fetch면 timeout으로 안전 skip.
     const fresh = await withTimeout(
-      Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced }),
+      Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High }),
       FRESH_FETCH_TIMEOUT_MS,
     );
     return {

--- a/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
@@ -1467,14 +1467,15 @@ describe('useNearestStation — #903 Seam G barometer→sticky', () => {
 });
 
 describe('useNearestStation — #1313 subsurface GPS throttle', () => {
-  // 지상 기본값: High@2s. 지하 throttle: Balanced@12s. interval은 상수에서 가져와 매직넘버 회피.
+  // 지상 기본값: High@2s. 지하 throttle: High@12s (#1983 ADR-022 A3 — Balanced→High 통일).
+  // accuracy는 지상/지하 동일 High, interval만 subsurface에서 확장. 상수에서 가져와 매직넘버 회피.
   const SURFACE_OPTIONS = {
     accuracy: Location.Accuracy.High,
     distanceInterval: 0,
     timeInterval: FG_WATCH_SURFACE_TIME_INTERVAL_MS,
   };
   const SUBSURFACE_OPTIONS = {
-    accuracy: Location.Accuracy.Balanced,
+    accuracy: Location.Accuracy.High,
     distanceInterval: 0,
     timeInterval: FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS,
   };
@@ -1509,10 +1510,12 @@ describe('useNearestStation — #1313 subsurface GPS throttle', () => {
   });
 
   // 마운트 시 subsurface 값에 따른 초기 watch 옵션 — undefined/false는 절대 throttle하지 않는다(안전 기본값).
+  // #1983 (ADR-022 A3): subsurface=true도 accuracy=High로 통일. 이전엔 Balanced였으나 지상 fix까지
+  // 1000~1600m 오염 회귀로 High 통일. subsurface 차이는 timeInterval만(2s→12s).
   it.each([
     { label: 'subsurface 미전달(undefined) → High@2s', props: {}, expected: () => SURFACE_OPTIONS },
     { label: 'subsurface=false → High@2s', props: { barometerSubsurface: false }, expected: () => SURFACE_OPTIONS },
-    { label: 'subsurface=true → Balanced@12s', props: { barometerSubsurface: true }, expected: () => SUBSURFACE_OPTIONS },
+    { label: 'subsurface=true → High@12s (#1983 Balanced→High 통일)', props: { barometerSubsurface: true }, expected: () => SUBSURFACE_OPTIONS },
   ])('마운트 $label', async ({ props, expected }) => {
     renderHook(() => useNearestStation(props));
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
@@ -1521,7 +1524,7 @@ describe('useNearestStation — #1313 subsurface GPS throttle', () => {
     expect(lastWatchOptions()).toEqual(expected());
   });
 
-  it('subsurface false→true flip 시 watch를 teardown 후 Balanced@12s로 재시작한다', async () => {
+  it('subsurface false→true flip 시 watch를 teardown 후 High@12s로 재시작한다 (#1983)', async () => {
     const { rerender } = renderHook(
       ({ sub }: { sub: boolean }) => useNearestStation({ barometerSubsurface: sub }),
       { initialProps: { sub: false } },
@@ -1580,10 +1583,21 @@ describe('useNearestStation — #1313 subsurface GPS throttle', () => {
     expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1);
     expect(mockSubscription.remove).not.toHaveBeenCalled();
 
-    // FG 복귀 시 'active' 핸들러 refresh→startWatch가 throttledRef를 읽어 Balanced@12s로 반영.
+    // FG 복귀 시 'active' 핸들러 refresh→startWatch가 throttledRef를 읽어 High@12s로 반영.
     (AppState as { currentState: string }).currentState = 'active';
     await act(async () => { appStateCallback?.('active'); });
     await waitFor(() => expect(lastWatchOptions()).toEqual(SUBSURFACE_OPTIONS));
+  });
+
+  // #1983 (ADR-022 A3) — subsurface에서도 accuracy=High. Balanced로 회귀하면 지상 fix까지
+  // 1000~1600m 저정확도로 오염되므로 accuracy 값 자체를 pin해 회귀를 조기 차단한다.
+  it.each([
+    { label: 'surface(subsurface=false)', props: { barometerSubsurface: false } },
+    { label: 'subsurface(subsurface=true)', props: { barometerSubsurface: true } },
+  ])('#1983 $label 에서 watch accuracy는 High (Balanced 회귀 차단)', async ({ props }) => {
+    renderHook(() => useNearestStation(props));
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+    expect(lastWatchOptions().accuracy).toBe(Location.Accuracy.High);
   });
 });
 

--- a/src/features/nearest-station/hooks/useNearestStation.ts
+++ b/src/features/nearest-station/hooks/useNearestStation.ts
@@ -57,13 +57,18 @@ const GPS_DROP_WINDOW_MS = 1000;
 // useStationAlarm effect short-circuit으로 별개 layer에서 해소됐으므로 GPS callback throttle을
 // 제거해도 cascade가 재발하지 않는다.
 // subsurface는 동일하게 distanceInterval=0 — 지하 indoor positioning 보강 동안에는 매 fix가 필요.
+// #1983 (ADR-022 A3) — subsurface에서도 Accuracy.High. 이전엔 Balanced로 배터리 세이빙(#1313)
+// 이었으나 Balanced(100m~수km, cellular triangulation)는 지상 fix까지 1000~1600m 저정확도로
+// 오염시키는 회귀(7/1 오후, 6/30 여러 로그) 발생. subsurface는 timeInterval 12s로만 throttle하고
+// accuracy는 High 통일 — 지하에서 GPS fix 자체가 없을 땐 OS가 자연스레 fallback하므로 High도
+// 배터리 부담 크지 않다. 배터리 실측 회귀 시 별도 이슈로 대응.
 const FG_WATCH_OPTIONS_SURFACE: Location.LocationOptions = {
   accuracy: Location.Accuracy.High,
   distanceInterval: 0,
   timeInterval: FG_WATCH_SURFACE_TIME_INTERVAL_MS,
 };
 const FG_WATCH_OPTIONS_SUBSURFACE: Location.LocationOptions = {
-  accuracy: Location.Accuracy.Balanced,
+  accuracy: Location.Accuracy.High,
   distanceInterval: 0,
   timeInterval: FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS,
 };
@@ -379,9 +384,11 @@ export function useNearestStation(
       //  좌표를 최대한 자주 흘려보낸다 (foreground 한정, 화면 켜진 동안만).
       //  High는 GPS hardware fix가 없으면 WiFi BSSID / Cell tower triangulation으로 fallback
       //  → 지하 구간에서도 ~50~100m 위치가 들어옴 (BestForNavigation은 fallback 없이 stale).
-      // 지하(subsurface 확정, #1313): Balanced + timeInterval:12000으로 throttle — GPS가 무의미한
-      //  구간에서 full-power watch가 배터리를 태우는 것을 막는다. throttledRef가 현재 throttle 여부를
-      //  들고 있어 flip 시 effect가 stopWatch→startWatch로 재구성한다(아래 useEffect).
+      // 지하(subsurface 확정, #1313 + #1983): High + timeInterval:12000으로 throttle. accuracy는
+      //  지상과 동일하게 High 유지 (#1983 ADR-022 A3) — Balanced는 지상 fix까지 1000~1600m로
+      //  오염시키는 회귀 발생. GPS fix 자체가 없을 때는 OS가 자연 fallback하므로 High도 지하 배터리
+      //  부담 크지 않다. throttledRef가 현재 throttle 여부를 들고 있어 flip 시 effect가
+      //  stopWatch→startWatch로 재구성한다(아래 useEffect).
       // 참고: pausesUpdatesAutomatically / activityType은 expo-location foreground 옵션에
       //  노출되지 않아 적용 불가. background task 옵션에서만 사용 가능.
       subscriptionRef.current = await Location.watchPositionAsync(


### PR DESCRIPTION
Closes #1983

## Summary

- `useNearestStation` FG_WATCH_OPTIONS_SUBSURFACE accuracy: **Balanced → High**
- `silentPushLocationGate` fresh fetch accuracy: **Balanced → High**
- Balanced (100m~수km, cellular triangulation)가 지상 fix까지 1000~1600m 저정확도로 오염시키는 회귀 (7/1 오후, 6/30 여러 로그)
- ADR-022 (#1980) A3 — 재설계 arrival API SSOT와 별개 immediate fix
- flag guard 불필요, 항상 High
- BG `LOCATION_TRACKING_OPTIONS`는 이미 High → 이제 FG surface/subsurface + silent push 모두 High로 정책 통일

## Why Balanced was used (git blame 확인)
- `useNearestStation.ts` (#1313 perf): "subsurface 시 FG GPS watch throttle" — 지하 GPS 무의미 구간 배터리 세이빙 목적. subsurface는 timeInterval 12s throttle로 배터리 대응, accuracy는 High 통일
- `silentPushLocationGate.ts` (#1066 서비스 윈도우 배너): fresh fetch 초기 구현부터 Balanced. 명시적 근거 없음. BG 3s 타임아웃 유지 → 콜드 fetch면 timeout으로 안전 skip, 캐시 hit이면 즉답 (High도 무해)

## Acceptance
- [x] `useNearestStation.ts:66` Accuracy.Balanced → High
- [x] `silentPushLocationGate.ts:156` Accuracy.Balanced → High
- [x] 기존 test PASS + Accuracy 관련 test 확장 — surface/subsurface 두 경로 모두 accuracy=High pin (regression 차단) + silentPushLocationGate fresh fetch 호출 인자 검증
- [x] type-check clean, coverage 100% (8797 tests pass)

## Test plan
- [x] `npm test` — 415 suites / 8797 tests all pass, coverage 100%
- [x] `npm run type-check` — clean
- [x] `npm run lint:orphan` — 0 orphan
- [ ] 실기기 검증 (필요): 지하 trip에서 accuracy 1000~1600m stuck 재발 여부 로그로 확인
- [ ] 실기기 검증 (필요): 지하 배터리 실측 회귀 (subsurface High + timeInterval 12s 조합)

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` PASS
2. **V/X dashboard** — DebugModal GPS 섹션의 `accuracyMeters` 값. 실기기 지하 trip에서 이전 회귀 조건(1000~1600m stuck) 재발 안 하는지 관찰
3. **의존 PR** — N/A (독립 immediate fix, ADR-022 재설계와 별개)
4. **측정 plan** — 1주 실기기 지하 trip 로그에서 subsurface accuracy 분포 확인. Balanced 회귀 값(1000~1600m)이 관찰되지 않으면 성공. 배터리 실측(6시간 지하 trip drain %)이 회귀 시 별도 이슈
5. **Device verify** — 필요. 지하 trip에서 accuracy 개선 + 배터리 회귀 없음 확인 (사용자 몫)

## Refs
- ADR-022: #1980
- Phase 1-6 A3 (직접 Accuracy 통일)
- 기존 High policy: `src/shared/constants/locationTracking.ts:25` (BG 이미 High)