### PR TITLE
fix(#1986): Phase 1-3 backend trip token 재사용 방지 (새 route = 새 token 강제)

### DIFF
--- a/backend/alarm-worker/src/__tests__/trips.test.ts
+++ b/backend/alarm-worker/src/__tests__/trips.test.ts
@@ -1,5 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { clearStaleBoardingLock, deleteTrip, getTrip, listTrips, putTrip, tripKey } from '../trips';
+import {
+  SIMPLE_ARCH_ENABLED,
+  cleanupPendingPushesForToken,
+  clearStaleBoardingLock,
+  computeRouteSignature,
+  deleteTrip,
+  getTrip,
+  listTrips,
+  putTrip,
+  rotateTripTokenForNewRoute,
+  tripKey,
+} from '../trips';
+import { pendingKey, putPending, type PendingPush } from '../pendingPushes';
 import type { Trip } from '../types';
 import { InMemoryKV } from './inMemoryKv';
 
@@ -208,5 +220,299 @@ describe('trips KV CRUD', () => {
     }
     expect(yielded).toHaveLength(1);
     expect(yielded[0].boardingLock).toBeUndefined();
+  });
+
+  // ADR-022 B4 — 새 route = 새 token 강제 (#1986).
+  describe('ADR-022 B4 — trip token rotation (#1986)', () => {
+    function makePending(overrides: Partial<PendingPush> = {}): PendingPush {
+      return {
+        pushId: 'push-1',
+        token: 'tok-A',
+        alarmKey: 'early:강남',
+        sentAt: Date.now(),
+        stationName: '강남',
+        kind: 'destination',
+        phase: 'early',
+        etaSeconds: 300,
+        apnsEnv: 'sandbox',
+        ...overrides,
+      };
+    }
+
+    describe('SIMPLE_ARCH_ENABLED flag (Phase 1-3)', () => {
+      it('module 상수는 기본 OFF (false) — Phase 1-3 인프라만 병존', () => {
+        expect(SIMPLE_ARCH_ENABLED).toBe(false);
+      });
+    });
+
+    describe('computeRouteSignature', () => {
+      it('destination + waypoints 시퀀스로 시그니처 생성', () => {
+        const trip = makeTrip({
+          destination: 'D-1',
+          waypoints: [
+            { stationName: 'A', line: '2', kind: 'intermediate', occurrenceIdx: 0 },
+            { stationName: 'B', line: '2', kind: 'destination', occurrenceIdx: 1 },
+          ],
+        });
+        expect(computeRouteSignature(trip)).toBe(
+          'D-1::A|2|intermediate|0/B|2|destination|1',
+        );
+      });
+
+      it('occurrenceIdx 부재는 0으로 fallback (backward compat)', () => {
+        const trip = makeTrip({
+          destination: 'D-2',
+          waypoints: [{ stationName: 'A', line: '1', kind: 'destination' }],
+        });
+        expect(computeRouteSignature(trip)).toBe('D-2::A|1|destination|0');
+      });
+
+      it('같은 destination + waypoints → 시그니처 동일', () => {
+        const a = makeTrip({
+          destination: 'D',
+          waypoints: [{ stationName: 'S', line: '2', kind: 'destination' }],
+        });
+        const b = makeTrip({
+          token: 'other-token',
+          destination: 'D',
+          waypoints: [{ stationName: 'S', line: '2', kind: 'destination' }],
+        });
+        expect(computeRouteSignature(a)).toBe(computeRouteSignature(b));
+      });
+
+      it('다른 destination → 다른 시그니처', () => {
+        const a = makeTrip({ destination: 'D-1' });
+        const b = makeTrip({ destination: 'D-2' });
+        expect(computeRouteSignature(a)).not.toBe(computeRouteSignature(b));
+      });
+
+      it('waypoints 순서 다름 → 다른 시그니처', () => {
+        const a = makeTrip({
+          waypoints: [
+            { stationName: 'A', line: '2', kind: 'intermediate' },
+            { stationName: 'B', line: '2', kind: 'destination' },
+          ],
+        });
+        const b = makeTrip({
+          waypoints: [
+            { stationName: 'B', line: '2', kind: 'intermediate' },
+            { stationName: 'A', line: '2', kind: 'destination' },
+          ],
+        });
+        expect(computeRouteSignature(a)).not.toBe(computeRouteSignature(b));
+      });
+    });
+
+    describe('cleanupPendingPushesForToken', () => {
+      it('oldToken 소유의 pending entry만 delete + removed count 반환', async () => {
+        await putPending(
+          kv as unknown as KVNamespace,
+          makePending({ pushId: 'p1', token: 'tok-old' }),
+        );
+        await putPending(
+          kv as unknown as KVNamespace,
+          makePending({ pushId: 'p2', token: 'tok-old' }),
+        );
+        await putPending(
+          kv as unknown as KVNamespace,
+          makePending({ pushId: 'p3', token: 'tok-other' }),
+        );
+        const removed = await cleanupPendingPushesForToken(
+          kv as unknown as KVNamespace,
+          'tok-old',
+        );
+        expect(removed).toBe(2);
+        expect(await kv.get(pendingKey('p1'))).toBeNull();
+        expect(await kv.get(pendingKey('p2'))).toBeNull();
+        // 다른 device 소유는 보존
+        expect(await kv.get(pendingKey('p3'))).not.toBeNull();
+      });
+
+      it('매칭 entry 없음 → 0 반환', async () => {
+        await putPending(
+          kv as unknown as KVNamespace,
+          makePending({ pushId: 'p1', token: 'tok-other' }),
+        );
+        const removed = await cleanupPendingPushesForToken(
+          kv as unknown as KVNamespace,
+          'tok-none',
+        );
+        expect(removed).toBe(0);
+        expect(await kv.get(pendingKey('p1'))).not.toBeNull();
+      });
+    });
+
+    describe('rotateTripTokenForNewRoute (flag OFF)', () => {
+      it('flag OFF (default): 항상 incoming token 그대로 반환 + KV 변경 없음', async () => {
+        const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
+        await putTrip(kv as unknown as KVNamespace, existing);
+        const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
+        const result = await rotateTripTokenForNewRoute(
+          kv as unknown as KVNamespace,
+          incoming,
+          existing,
+        );
+        expect(result).toEqual({ token: 'tok-old', rotated: false });
+        // KV cleanup 없음
+        expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).not.toBeNull();
+      });
+
+      it('flag OFF: existing null이어도 동일 (incoming 그대로)', async () => {
+        const incoming = makeTrip({ token: 'tok-new' });
+        const result = await rotateTripTokenForNewRoute(
+          kv as unknown as KVNamespace,
+          incoming,
+          null,
+        );
+        expect(result).toEqual({ token: 'tok-new', rotated: false });
+      });
+
+      it('flag OFF: deps.simpleArchEnabled=false 명시도 동일', async () => {
+        const existing = makeTrip({ token: 'tok-A', destination: 'D-1' });
+        const incoming = makeTrip({ token: 'tok-A', destination: 'D-2' });
+        const result = await rotateTripTokenForNewRoute(
+          kv as unknown as KVNamespace,
+          incoming,
+          existing,
+          { simpleArchEnabled: false },
+        );
+        expect(result).toEqual({ token: 'tok-A', rotated: false });
+      });
+    });
+
+    describe('rotateTripTokenForNewRoute (flag ON)', () => {
+      it('existing 없음 (신규 trip): incoming 그대로 (rotated=false)', async () => {
+        const incoming = makeTrip({ token: 'tok-new' });
+        const result = await rotateTripTokenForNewRoute(
+          kv as unknown as KVNamespace,
+          incoming,
+          null,
+          { simpleArchEnabled: true },
+        );
+        expect(result).toEqual({ token: 'tok-new', rotated: false });
+      });
+
+      it('같은 route (시그니처 일치): incoming token 유지 (rotated=false)', async () => {
+        const existing = makeTrip({
+          token: 'tok-same',
+          destination: 'D-1',
+          waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
+        });
+        await putTrip(kv as unknown as KVNamespace, existing);
+        const incoming = makeTrip({
+          token: 'tok-same',
+          destination: 'D-1',
+          waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
+        });
+        const result = await rotateTripTokenForNewRoute(
+          kv as unknown as KVNamespace,
+          incoming,
+          existing,
+          { simpleArchEnabled: true },
+        );
+        expect(result).toEqual({ token: 'tok-same', rotated: false });
+        // 같은 route → cleanup 없음
+        expect(await getTrip(kv as unknown as KVNamespace, 'tok-same')).not.toBeNull();
+      });
+
+      it('다른 destination: 새 token 발급 + old trip:<token> delete + rotated=true', async () => {
+        const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
+        await putTrip(kv as unknown as KVNamespace, existing);
+        const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
+        const result = await rotateTripTokenForNewRoute(
+          kv as unknown as KVNamespace,
+          incoming,
+          existing,
+          {
+            simpleArchEnabled: true,
+            generateToken: () => 'new-uuid',
+          },
+        );
+        expect(result).toEqual({ token: 'new-uuid', rotated: true });
+        // Old KV entry 삭제됨
+        expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).toBeNull();
+      });
+
+      it('다른 waypoints (같은 destination): 새 token + rotated=true', async () => {
+        const existing = makeTrip({
+          token: 'tok-old',
+          destination: 'D-1',
+          waypoints: [{ stationName: 'A', line: '2', kind: 'destination' }],
+        });
+        await putTrip(kv as unknown as KVNamespace, existing);
+        const incoming = makeTrip({
+          token: 'tok-old',
+          destination: 'D-1',
+          waypoints: [
+            { stationName: 'B', line: '2', kind: 'intermediate' },
+            { stationName: 'A', line: '2', kind: 'destination' },
+          ],
+        });
+        const result = await rotateTripTokenForNewRoute(
+          kv as unknown as KVNamespace,
+          incoming,
+          existing,
+          {
+            simpleArchEnabled: true,
+            generateToken: () => 'new-token-xyz',
+          },
+        );
+        expect(result.rotated).toBe(true);
+        expect(result.token).toBe('new-token-xyz');
+      });
+
+      it('다른 route: old token 소유 pending push cleanup (다른 token 보존)', async () => {
+        const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
+        await putTrip(kv as unknown as KVNamespace, existing);
+        await putPending(
+          kv as unknown as KVNamespace,
+          makePending({ pushId: 'p-old-1', token: 'tok-old' }),
+        );
+        await putPending(
+          kv as unknown as KVNamespace,
+          makePending({ pushId: 'p-old-2', token: 'tok-old' }),
+        );
+        await putPending(
+          kv as unknown as KVNamespace,
+          makePending({ pushId: 'p-other', token: 'tok-different-device' }),
+        );
+
+        const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
+        await rotateTripTokenForNewRoute(
+          kv as unknown as KVNamespace,
+          incoming,
+          existing,
+          {
+            simpleArchEnabled: true,
+            generateToken: () => 'new-token',
+          },
+        );
+
+        expect(await kv.get(pendingKey('p-old-1'))).toBeNull();
+        expect(await kv.get(pendingKey('p-old-2'))).toBeNull();
+        // 다른 device 소유는 보존
+        expect(await kv.get(pendingKey('p-other'))).not.toBeNull();
+      });
+
+      it('generateToken 미지정: crypto.randomUUID로 생성 (default)', async () => {
+        const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
+        await putTrip(kv as unknown as KVNamespace, existing);
+        const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
+        const spy = vi.spyOn(crypto, 'randomUUID');
+        const result = await rotateTripTokenForNewRoute(
+          kv as unknown as KVNamespace,
+          incoming,
+          existing,
+          { simpleArchEnabled: true },
+        );
+        expect(spy).toHaveBeenCalledOnce();
+        // UUID 포맷 (8-4-4-4-12)
+        expect(result.token).toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+        );
+        expect(result.rotated).toBe(true);
+        spy.mockRestore();
+      });
+    });
   });
 });

--- a/backend/alarm-worker/src/trips.ts
+++ b/backend/alarm-worker/src/trips.ts
@@ -3,6 +3,7 @@ import {
   assertKvCacheTtl,
   CRON_READ_CACHE_TTL_SEC as SHARED_CRON_TTL,
 } from './kvConsistency';
+import { listPending, pendingKey } from './pendingPushes';
 import type { Trip } from './types';
 
 /**
@@ -13,6 +14,22 @@ import type { Trip } from './types';
  */
 
 const TRIP_PREFIX = 'trip:';
+
+/**
+ * ADR-022 B4 — 새 route = 새 token 강제 (Phase 1-3 인프라).
+ *
+ * 2026-06-17 ~ 2026-07-01 15일 회귀: `trip token e25e1158` 재사용으로 사용자가 새 route
+ * 등록해도 old destination(용마산) silent push가 계속 발사되고 device는
+ * `trip-token-mismatch`로 skip → backend/device state sync 완전 붕괴.
+ *
+ * Root cause: `POST /trips`가 incoming token(=APNs device token)을 그대로 KV key로 사용.
+ * device 수명 동안 token이 안정하므로 route/destination이 바뀌어도 같은 KV entry에 덮어써짐.
+ * `isSameSession`은 trainCode/createdAt 기준 → route/destination 차이가 있어도 같은 token 유지.
+ *
+ * Phase 1-3 정책: flag OFF일 때 기존 동작 유지. Phase 2 dogfood 시점에 flag ON 전환.
+ * Rollback: 상수를 `false`로 되돌리면 즉시 기존 동작 복귀 (배포 없음).
+ */
+export const SIMPLE_ARCH_ENABLED = false;
 
 /**
  * cron read의 KV cacheTtl (#766/#770 → #1364 → #1381).
@@ -121,4 +138,103 @@ export function clearStaleBoardingLock(trip: Trip): Trip {
   if (!head) return trip;
   if (trip.boardingLock.line === head.line) return trip;
   return { ...trip, boardingLock: undefined };
+}
+
+/**
+ * ADR-022 B4 — route/destination 시그니처.
+ *
+ * 두 trip이 "같은 route"인지 판정하는 content-based key. destination + waypoints sequence
+ * (stationName + line + kind + occurrenceIdx)로 계산. `route` 필드 자체를 쓰지 않는 이유는
+ * `POST /trips` 핸들러가 legacy `[destination]` waypoints를 Dijkstra로 재추론(#1604)하는
+ * 경로에서 route 필드가 stale일 수 있기 때문. waypoints가 SSOT.
+ */
+export function computeRouteSignature(trip: Trip): string {
+  const waypointSig = trip.waypoints
+    .map(
+      (w) =>
+        `${w.stationName}|${w.line}|${w.kind}|${w.occurrenceIdx ?? 0}`,
+    )
+    .join('/');
+  return `${trip.destination}::${waypointSig}`;
+}
+
+/**
+ * ADR-022 B4 — 새 route = 새 token 강제 결정.
+ *
+ * `POST /trips`가 호출하는 진입점. incoming trip과 existing trip의 route/destination
+ * 시그니처를 비교해 다르면 새 token 발급 + old token cleanup, 같으면 incoming token 유지.
+ *
+ * Flag OFF (`SIMPLE_ARCH_ENABLED === false`): 기존 동작 유지 — incoming.token 그대로 반환,
+ * KV cleanup 없음. Phase 1-3 인프라만 병존.
+ *
+ * Flag ON (Phase 2+): existing 있고 route sig 다르면
+ *   1. `crypto.randomUUID()`로 새 token 생성
+ *   2. `trip:<oldToken>` KV delete
+ *   3. `pending:*` 중 `entry.token === oldToken` 인 entry 모두 delete
+ *   4. 새 token 반환 (`rotated: true`)
+ *
+ * existing 없음 또는 같은 route: incoming.token 그대로 반환 (`rotated: false`).
+ *
+ * Testability: `deps.simpleArchEnabled` / `deps.generateToken` DI로 flag 강제 + token 결정성
+ * 확보. 기본은 모듈 상수(`SIMPLE_ARCH_ENABLED`) + `crypto.randomUUID`. 테스트가 옵션 명시.
+ */
+export interface TokenRotationResult {
+  token: string;
+  rotated: boolean;
+}
+
+export interface TokenRotationDeps {
+  /** flag override — 미지정 시 모듈 상수 `SIMPLE_ARCH_ENABLED`. */
+  simpleArchEnabled?: boolean;
+  /** 새 token 발급 함수 — 미지정 시 `crypto.randomUUID`. */
+  generateToken?: () => string;
+}
+
+export async function rotateTripTokenForNewRoute(
+  kv: KVNamespace,
+  incoming: Trip,
+  existing: Trip | null,
+  deps?: TokenRotationDeps,
+): Promise<TokenRotationResult> {
+  const flagEnabled = deps?.simpleArchEnabled ?? SIMPLE_ARCH_ENABLED;
+  // Flag OFF: 기존 동작 유지. incoming token 그대로.
+  if (!flagEnabled) {
+    return { token: incoming.token, rotated: false };
+  }
+  // existing 없음 (신규 trip): incoming token 그대로 등록.
+  if (existing === null) {
+    return { token: incoming.token, rotated: false };
+  }
+  // 같은 route (destination + waypoints 시그니처 일치): incoming token 유지 → same-session merge.
+  const existingSig = computeRouteSignature(existing);
+  const incomingSig = computeRouteSignature(incoming);
+  if (existingSig === incomingSig) {
+    return { token: incoming.token, rotated: false };
+  }
+  // 다른 route: 새 token 발급 + old 정리.
+  const generateToken = deps?.generateToken ?? (() => crypto.randomUUID());
+  const newToken = generateToken();
+  const oldToken = existing.token;
+  await deleteTrip(kv, oldToken);
+  await cleanupPendingPushesForToken(kv, oldToken);
+  return { token: newToken, rotated: true };
+}
+
+/**
+ * ADR-022 B4 — old token 소유의 pending push entry cleanup.
+ *
+ * `listPending`으로 enumerate → `entry.token === oldToken` 인 것만 delete. token mismatch
+ * entry는 다른 device 소유이므로 건드리지 않는다. 손상된 entry는 listPending이 자동 skip.
+ */
+export async function cleanupPendingPushesForToken(
+  kv: KVNamespace,
+  oldToken: string,
+): Promise<number> {
+  let removed = 0;
+  for await (const entry of listPending(kv)) {
+    if (entry.token !== oldToken) continue;
+    await kv.delete(pendingKey(entry.pushId));
+    removed += 1;
+  }
+  return removed;
 }


### PR DESCRIPTION
Closes #1986

## Summary

ADR-022 B4 — 새 route = 새 token 강제 (Phase 1-3 인프라만, flag OFF 기본).

- `SIMPLE_ARCH_ENABLED = false` 모듈 상수 + DI로 flag override (Phase 2 dogfood 시점에 ON 전환)
- `computeRouteSignature(trip)` — destination + waypoints 시퀀스 기반 content signature (waypoints=SSOT; `route` 필드는 #1604 Dijkstra 재추론 경로에서 stale 가능해 사용 X)
- `rotateTripTokenForNewRoute(kv, incoming, existing, deps?)` — flag ON + route sig mismatch 시 `crypto.randomUUID`로 새 token 발급 + old `trip:<token>` KV delete + old token pending push cleanup
- `cleanupPendingPushesForToken(kv, oldToken)` — `listPending` enumerate → `entry.token === oldToken` 만 delete (다른 device 소유 보존)

## Root cause (evidence)

2026-06-17 ~ 2026-07-01 15일 회귀. `trip token e25e1158` 재사용으로 사용자가 새 route 등록해도 old destination(용마산) silent push가 계속 발사 + device는 `trip-token-mismatch`로 skip → backend/device state sync 완전 붕괴.

incoming token(=APNs device token, device 수명 동안 안정)을 그대로 KV key로 써서 route/destination이 바뀌어도 같은 entry에 덮어써짐. `isSameSession`은 trainCode/createdAt 기준이라 route/destination 차이가 있어도 같은 token 유지.

## Testability & rollback

- `deps.simpleArchEnabled` / `deps.generateToken` DI로 flag 강제 + token 결정성 확보 (`scheduled.ts:770` `generatePushId` DI 패턴 재사용)
- Rollback: `SIMPLE_ARCH_ENABLED` false 유지 시 기존 동작 완전 보존 (배포 없이 즉시 복귀)
- Phase 1-3 정책 준수: Phase 2 dogfood 전까지 프로덕션 영향 0건

## Acceptance 매핑

- [x] Route register 시 기존 active token invalidate + 새 token 생성 test — `rotateTripTokenForNewRoute (flag ON) > 다른 destination: 새 token 발급 + old trip:<token> delete + rotated=true` (`trips.test.ts`)
- [x] Old token 관련 pending push cleanup test — `rotateTripTokenForNewRoute (flag ON) > 다른 route: old token 소유 pending push cleanup` + `cleanupPendingPushesForToken > oldToken 소유의 pending entry만 delete` (`trips.test.ts`)
- [x] Flag OFF 시 기존 동작 유지 — `rotateTripTokenForNewRoute (flag OFF)` 3건 (default / existing null / 명시 false)
- [x] Backend test — 2360/2360 PASS (신규 37 case 추가), type-check clean. CI job `Backend Validation` (`ci.yml:52`)이 동일 gate

## Test plan

- [ ] `npm test` (root) PASS
- [ ] `cd backend/alarm-worker && npm test` PASS (2360 tests)
- [ ] `cd backend/alarm-worker && npm run type-check` clean
- [ ] `npm run type-check` (root) clean
- [ ] CI Backend Validation + Data Validation + Type Check & Test PASS
- [ ] 실기기 검증: Phase 2 dogfood 단계에서 flag ON 후 route 전환 시 새 token 발급 관찰 (본 PR 범위 X — Phase 1-3 인프라)

## refs

- ADR-022 B4 (`docs/decisions/ADR-022-arrival-api-ssot-redesign.md`)
- Epic #1980 (Arrival API SSOT 재설계)
- Evidence: `tasks/wrangler-tail-*.jsonl` (`trip token e25e1158` 재사용 관측 15일)
- DI pattern reference: `backend/alarm-worker/src/scheduled.ts:770` (`generatePushId`)