### PR TITLE
feat(#1985): Phase 1-1 backend arvlCd fire-once TTL (반복 알림 fix)

### DIFF
--- a/backend/alarm-worker/src/__tests__/arvlcdFireOnceTtl.test.ts
+++ b/backend/alarm-worker/src/__tests__/arvlcdFireOnceTtl.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ARVLCD_FIRE_ONCE_KEY_PREFIX,
+  ARVLCD_FIRE_ONCE_TTL_SEC,
+  arvlCdFireOnceKey,
+  checkArvlCdFireOnce,
+  isSimpleArchEnabled,
+  stampArvlCdFireOnce,
+} from '../arvlcdFireOnceTtl';
+import { InMemoryKV } from './inMemoryKv';
+
+const NOW = 1_700_000_000_000;
+const TOKEN = 'trip-tok-1';
+const STATION = '어린이대공원';
+const CYCLE = 0;
+
+describe('ARVLCD_FIRE_ONCE_TTL_SEC (#1985)', () => {
+  it('is 300s (5 min) — physical train cannot revisit station within 5 min', () => {
+    expect(ARVLCD_FIRE_ONCE_TTL_SEC).toBe(5 * 60);
+  });
+});
+
+describe('ARVLCD_FIRE_ONCE_KEY_PREFIX (#1985)', () => {
+  it('is "fireOnce:" — isolated namespace from arvlcd-fire: legacy dedup', () => {
+    expect(ARVLCD_FIRE_ONCE_KEY_PREFIX).toBe('fireOnce:');
+  });
+});
+
+describe('arvlCdFireOnceKey (#1985)', () => {
+  it('formats key as fireOnce:{token}:{station}:{cycle}', () => {
+    expect(arvlCdFireOnceKey(TOKEN, STATION, CYCLE)).toBe(
+      `fireOnce:${TOKEN}:${STATION}:${CYCLE}`,
+    );
+  });
+
+  it('different tokens produce different keys — cross-trip leak 차단', () => {
+    expect(arvlCdFireOnceKey('trip-a', STATION, CYCLE)).not.toBe(
+      arvlCdFireOnceKey('trip-b', STATION, CYCLE),
+    );
+  });
+
+  it('different stations produce different keys — 같은 trip 다른 역 각각 fire', () => {
+    expect(arvlCdFireOnceKey(TOKEN, '어린이대공원', CYCLE)).not.toBe(
+      arvlCdFireOnceKey(TOKEN, '건대입구', CYCLE),
+    );
+  });
+
+  it('different cycles produce different keys — 미래-확장 slot 동작 확인', () => {
+    expect(arvlCdFireOnceKey(TOKEN, STATION, 0)).not.toBe(
+      arvlCdFireOnceKey(TOKEN, STATION, 1),
+    );
+  });
+});
+
+describe('checkArvlCdFireOnce (#1985)', () => {
+  it('returns false when key is absent (첫 관측 fire 진행 가능)', async () => {
+    const kv = new InMemoryKV();
+    const result = await checkArvlCdFireOnce(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      STATION,
+      CYCLE,
+    );
+    expect(result).toBe(false);
+  });
+
+  it('returns true when key is present (같은 cycle 이내 재관측 → skip)', async () => {
+    const kv = new InMemoryKV();
+    await kv.put(arvlCdFireOnceKey(TOKEN, STATION, CYCLE), String(NOW));
+    const result = await checkArvlCdFireOnce(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      STATION,
+      CYCLE,
+    );
+    expect(result).toBe(true);
+  });
+
+  it('cross-trip isolation — trip A stamp 는 trip B check 에 영향 X', async () => {
+    const kv = new InMemoryKV();
+    await kv.put(arvlCdFireOnceKey('trip-a', STATION, CYCLE), String(NOW));
+    const bResult = await checkArvlCdFireOnce(
+      kv as unknown as KVNamespace,
+      'trip-b',
+      STATION,
+      CYCLE,
+    );
+    expect(bResult).toBe(false);
+  });
+
+  it('cross-station isolation — station A stamp 는 station B check 에 영향 X', async () => {
+    const kv = new InMemoryKV();
+    await kv.put(arvlCdFireOnceKey(TOKEN, '어린이대공원', CYCLE), String(NOW));
+    const bResult = await checkArvlCdFireOnce(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '건대입구',
+      CYCLE,
+    );
+    expect(bResult).toBe(false);
+  });
+});
+
+describe('stampArvlCdFireOnce (#1985)', () => {
+  it('writes value=now with 5-min TTL', async () => {
+    const kv = new InMemoryKV();
+    await stampArvlCdFireOnce(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      STATION,
+      CYCLE,
+      NOW,
+    );
+    const entry = kv.store.get(arvlCdFireOnceKey(TOKEN, STATION, CYCLE));
+    expect(entry).toBeDefined();
+    expect(entry?.value).toBe(String(NOW));
+    // expirationTtl 300s → expiresAt = Date.now() + 300_000 (InMemoryKV 는 Date.now()로 stamp)
+    expect(entry?.expiresAt).toBeGreaterThan(Date.now());
+    expect(entry?.expiresAt).toBeLessThanOrEqual(Date.now() + 300_000 + 100);
+  });
+
+  it('after stamp, checkArvlCdFireOnce returns true (round-trip)', async () => {
+    const kv = new InMemoryKV();
+    expect(
+      await checkArvlCdFireOnce(kv as unknown as KVNamespace, TOKEN, STATION, CYCLE),
+    ).toBe(false);
+    await stampArvlCdFireOnce(kv as unknown as KVNamespace, TOKEN, STATION, CYCLE, NOW);
+    expect(
+      await checkArvlCdFireOnce(kv as unknown as KVNamespace, TOKEN, STATION, CYCLE),
+    ).toBe(true);
+  });
+
+  it('TTL 만료 후 check 는 false (naturally expires)', async () => {
+    // InMemoryKV 의 만료는 Date.now() 기준 — vi.useFakeTimers 로 시간 진행.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(NOW);
+      const kv = new InMemoryKV();
+      await stampArvlCdFireOnce(kv as unknown as KVNamespace, TOKEN, STATION, CYCLE, NOW);
+      // 5분 초과 진행
+      vi.setSystemTime(NOW + ARVLCD_FIRE_ONCE_TTL_SEC * 1000 + 1);
+      expect(
+        await checkArvlCdFireOnce(kv as unknown as KVNamespace, TOKEN, STATION, CYCLE),
+      ).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('isSimpleArchEnabled (#1985 임시 flag)', () => {
+  it('returns false — Phase 0 (#1982) 미머지 상태, production 무영향 default', () => {
+    expect(isSimpleArchEnabled()).toBe(false);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -7,6 +7,7 @@ import type { WindowedMetrics } from '../positionSeries';
 import {
   ARVLCD_FIRE_DEDUP_TTL_SEC,
   ARVLCD_FIRE_KEY_PREFIX,
+  ARVLCD_FIRE_ONCE_CYCLE_SLOT,
   SAME_PHASE_STATION_DEDUP_WINDOW_MS,
   FALLBACK_ADVANCE_GRACE_CYCLES,
   FALLBACK_HOP_SEC,
@@ -46,6 +47,7 @@ import {
   type ScheduledStats,
 } from '../scheduled';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from '../seoul';
+import { ARVLCD_FIRE_ONCE_TTL_SEC, arvlCdFireOnceKey } from '../arvlcdFireOnceTtl';
 import { putTrip } from '../trips';
 import { readSsot, seedSsot, ssotKey, writeSsot, type TripPositionSSoT } from '../tripPositionSsot';
 import type { BoardingLockMeta, Env, PositionPoint, Trip, Waypoint } from '../types';
@@ -120,6 +122,51 @@ function makeEstimateArrivalDeps(seoul: SeoulArrivalClient): ScheduledDeps {
     apnsConfig,
     apnsHosts: APNS_HOSTS,
     fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+  };
+}
+
+/**
+ * `fireArvlCdStationPush` 등 직접 호출 테스트용 full-shape stats. `ScheduledStats` 필드 추가 시
+ * runScheduled 초기값과 동시에 갱신 필요 — 두 사이트가 drift 하지 않도록 헬퍼화. 기존 fixture 인
+ * `makeEmptyStats` (partial cast, kalmanDriftWarning만 참조) 와는 별개 목적.
+ */
+function makeFullEmptyStats(): ScheduledStats {
+  return {
+    scanned: 0, polled: 0, pushed: 0, errors: 0, etaMissing: 0, envCorrected: 0,
+    lockMissing: 0, laStaleAutoEnded: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
+    laPushSent: 0, laPushFailed: 0, laTokenCleared: 0,
+    boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
+    phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
+    autoLockSuccess: 0, autoLockFalsePositive: 0, boardingPromptAutoDeduped: 0,
+    boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0,
+    arvlCdFireSuccess: 0, arvlCdFireDedup: 0, arvlCdFireMismatch: 0,
+    arvlCdFireBlocked: 0, arvlCdFireFired: 0,
+    boardingLockWaypointAdvanceBlocked: 0, transferDestinationGateBlocked: 0,
+    vanishFallbackFired: 0, vanishReleaseFired: 0, vanishLocklessTakeover: 0,
+    vanishFallbackMotionGateBlocked: 0,
+    cronJitterMs: 0, rescheduleBlockedMotion: 0, rescheduleFallbackNoSsot: 0,
+    realtimePositionFetch: 0, selfPollCacheHit: 0, realtimePositionFetchError: 0,
+    stationPollFetch: 0, stationPollCacheHit: 0, stationPollError: 0,
+    staleLockFireSkipped: 0,
+    // ADR-022 Phase 1-1 (#1985) — arvlCd fire-once TTL 게이트 (flag=OFF 시 항상 0).
+    arvlCdFireOnceSkipped: 0,
+    lifecycleSilenceSkipped: 0, lifecycleForceEnded: 0,
+    lifecycleStationarySkipped: 0,
+    silentPushFiredByKind: {
+      intermediate: 0,
+      transfer: 0,
+      destination: 0,
+      boardingPrompt: 0,
+      reschedule: 0,
+    },
+    scheduleEtaFallback: 0,
+    destinationCrossCheck: {
+      within: 0,
+      gpsFar: 0,
+      staleGps: 0,
+      noGps: 0,
+      stationUnknown: 0,
+    },
   };
 }
 
@@ -6121,6 +6168,256 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
 });
 
 
+/**
+ * ADR-022 Phase 1-1 (#1985) — arvlCd fire-once TTL 게이트 (flag=ON 시).
+ *
+ * `isSimpleArchEnabled` 는 `arvlcdFireOnceTtl.ts` 의 임시 flag (현재 항상 false 반환). 본 describe
+ * 블록은 `vi.spyOn` 으로 flag=ON 을 강제 → 동일 (trip, station, cycle) 조합의 2회 이상 fire 가
+ * 차단되는지 검증. Phase 0 (#1982) 머지 후속 PR 에서 real `getArchFlag(env.KV)` 로 wire 되면
+ * 본 flag mock 은 자연스럽게 KV 시드 방식으로 교체 예정.
+ */
+describe('runScheduled — ADR-022 Phase 1-1 fire-once TTL (#1985)', () => {
+  const TOKEN = 'arvl-fireonce-tok';
+  const makeLockTrip = (overrides: Partial<Trip> = {}) => makeLockTripFixture(TOKEN, overrides);
+  const makeArrivalSeoul = makeArvlCdFireSeoul;
+  const getStationPassedCalls = getArvlCdStationPassedCalls;
+
+  async function runWithFlagOn(opts: {
+    seoul: SeoulArrivalClient;
+    trip?: Trip;
+    apnsFetch?: ReturnType<typeof vi.fn>;
+    pushId?: string;
+    seedKv?: (kv: InMemoryKV) => Promise<void>;
+  }): Promise<{
+    stats: ScheduledStats;
+    kv: InMemoryKV;
+    apnsFetch: ReturnType<typeof vi.fn>;
+  }> {
+    // flag=ON 을 spy 로 강제. `isSimpleArchEnabled` 를 * as import 하지 않고 destructured 로
+    // scheduled.ts 가 import 하지만, vitest 는 ESM live bindings 를 통해 spy 를 적용한다.
+    const mod = await import('../arvlcdFireOnceTtl');
+    const spy = vi.spyOn(mod, 'isSimpleArchEnabled').mockReturnValue(true);
+    try {
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, opts.trip ?? makeLockTrip());
+      if (opts.seedKv) await opts.seedKv(kv);
+      const apnsFetch = opts.apnsFetch ?? vi.fn(async () => new Response('', { status: 200 }));
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: opts.seoul,
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => opts.pushId ?? 'p-fireonce-1',
+      });
+      return { stats, kv, apnsFetch };
+    } finally {
+      spy.mockRestore();
+    }
+  }
+
+  it('flag=OFF (default) → 기존 로직 그대로. 새 stat 카운터는 항상 0', async () => {
+    // 별도 spy 없이 실행 = default flag=OFF. 기존 동작 (arvlCdFireSuccess=1) 그대로.
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-flag-off',
+    });
+    expect(stats.arvlCdFireSuccess).toBe(1);
+    // fire-once 게이트는 flag=OFF 이므로 관여 X — 카운터 0.
+    expect(stats.arvlCdFireOnceSkipped).toBe(0);
+    // fireOnce KV key 도 stamp 되지 않음.
+    expect(await kv.get(arvlCdFireOnceKey(TOKEN, '중곡', ARVLCD_FIRE_ONCE_CYCLE_SLOT))).toBeNull();
+  });
+
+  it('flag=ON, 첫 관측 → fire 진행 + fireOnce KV stamp', async () => {
+    const { stats, kv, apnsFetch } = await runWithFlagOn({
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      pushId: 'p-fireonce-first',
+    });
+    expect(stats.arvlCdFireSuccess).toBe(1);
+    expect(stats.arvlCdFireOnceSkipped).toBe(0);
+    expect(getStationPassedCalls(apnsFetch)).toHaveLength(1);
+    // 5분 TTL stamp 확인 (InMemoryKV 는 value 를 그대로 보존).
+    const stamped = await kv.get(arvlCdFireOnceKey(TOKEN, '중곡', ARVLCD_FIRE_ONCE_CYCLE_SLOT));
+    expect(stamped).toBe(String(NOW));
+  });
+
+  it('flag=ON, 같은 (trip, station, cycle) 2회 fire → 2번째는 skip (arvlCdFireOnceSkipped++)', async () => {
+    const { stats, apnsFetch } = await runWithFlagOn({
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      pushId: 'p-fireonce-dup',
+      seedKv: async (kv) => {
+        // 이전 cycle 에서 이미 fire-once stamp 된 상태.
+        await kv.put(
+          arvlCdFireOnceKey(TOKEN, '중곡', ARVLCD_FIRE_ONCE_CYCLE_SLOT),
+          String(NOW - 30_000),
+          { expirationTtl: ARVLCD_FIRE_ONCE_TTL_SEC },
+        );
+      },
+    });
+    expect(stats.arvlCdFireSuccess).toBe(0);
+    expect(stats.arvlCdFireOnceSkipped).toBe(1);
+    // 매역 push 발사 X.
+    expect(getStationPassedCalls(apnsFetch)).toHaveLength(0);
+  });
+
+  it('flag=ON, arvlCd=0 fire 후 같은 cycle 이내 arvlCd=1 재관측 → 통합 게이트 skip', async () => {
+    // 기존 `arvlCdFireKey` dedup 은 arvlCd=0 과 arvlCd=1 을 별 entry 로 stamp 해 둘 다 fire 하지만,
+    // fire-once TTL 은 cycle 통합 → 같은 (trip, station, cycle) 조합은 통합 skip.
+    // 이는 어린이대공원 반복 4회 fire (#1980) 회귀 차단의 핵심 정책.
+    //
+    // 검증 방식: `fireArvlCdStationPush` 를 직접 호출 (waypoint advance 부작용 격리) — 첫 호출 =
+    // arvlCd=0 fire + fire-once stamp, 두 번째 호출 = arvlCd=1 통합 skip.
+    const mod = await import('../arvlcdFireOnceTtl');
+    const spy = vi.spyOn(mod, 'isSimpleArchEnabled').mockReturnValue(true);
+    try {
+      const kv = new InMemoryKV();
+      const trip = makeLockTrip();
+      await putTrip(kv as unknown as KVNamespace, trip);
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      const commonInputs = {
+        trip,
+        waypoint: trip.waypoints[0],
+        lock: trip.boardingLock!,
+        env: makeEnv(kv),
+        deps: {
+          seoul: makeArrivalSeoul('중곡', 0, 1),
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW,
+        },
+        now: NOW,
+        log: () => undefined,
+        generatePushId: () => 'p-direct-cycle',
+      };
+      const statsFirst = makeFullEmptyStats();
+      await fireArvlCdStationPush({ ...commonInputs, stats: statsFirst, arvlCd: 0 });
+      expect(statsFirst.arvlCdFireSuccess).toBe(1);
+      expect(statsFirst.arvlCdFireOnceSkipped).toBe(0);
+      // fire-once stamp 확인.
+      expect(
+        await kv.get(arvlCdFireOnceKey(TOKEN, '중곡', ARVLCD_FIRE_ONCE_CYCLE_SLOT)),
+      ).toBe(String(NOW));
+      // 두 번째 호출: 같은 station 에서 arvlCd=1 재관측 (cycle 안 monotone 진행).
+      const statsSecond = makeFullEmptyStats();
+      const { dirty } = await fireArvlCdStationPush({
+        ...commonInputs,
+        stats: statsSecond,
+        arvlCd: 1,
+      });
+      // arvlCd=1 은 fire-once TTL 로 통합 skip — push 미발사.
+      expect(statsSecond.arvlCdFireSuccess).toBe(0);
+      expect(statsSecond.arvlCdFireOnceSkipped).toBe(1);
+      expect(dirty).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('flag=ON, cross-trip 격리 — trip A stamp 는 trip B fire 를 차단하지 X', async () => {
+    // 두 사용자가 같은 station 을 같은 cycle 에 통과. token 이 key 에 포함되므로 각 trip 이 각각 fire.
+    const { stats, apnsFetch } = await runWithFlagOn({
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      trip: makeLockTrip({ token: 'user-a' }),
+      pushId: 'p-fireonce-cross',
+      seedKv: async (kv) => {
+        await putTrip(kv as unknown as KVNamespace, makeLockTripFixture('user-b'));
+      },
+    });
+    // 두 trip 모두 각각 fire (fire-once 는 trip 단위 격리).
+    expect(stats.arvlCdFireSuccess).toBe(2);
+    expect(stats.arvlCdFireOnceSkipped).toBe(0);
+    expect(getStationPassedCalls(apnsFetch)).toHaveLength(2);
+  });
+
+  it('flag=ON, cross-station 격리 — 다른 station 은 각각 fire (fire-once 는 station 단위)', async () => {
+    // 첫 fire: 중곡. KV stamp 후 다른 station (건대입구) 관측 → 각 station 은 별 fire-once entry.
+    // (참고: `SAME_PHASE_STATION_DEDUP_WINDOW_MS` cross-station 게이트가 걸리므로 별 fire 검증은
+    // trip fixture 를 조정해 SAME_PHASE 윈도우 밖에 두어 확인.)
+    const tripOldFire = makeLockTrip({
+      lastFiredStation: {
+        stationName: '건대입구',
+        epochMs: NOW - SAME_PHASE_STATION_DEDUP_WINDOW_MS - 1,
+      },
+    });
+    const { stats, kv } = await runWithFlagOn({
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      trip: tripOldFire,
+      pushId: 'p-fireonce-station-x',
+      seedKv: async (kv) => {
+        // 이전 station(건대입구) fire-once 는 stamp 되어 있어도 중곡 fire 는 진행 가능해야 함.
+        await kv.put(
+          arvlCdFireOnceKey(TOKEN, '건대입구', ARVLCD_FIRE_ONCE_CYCLE_SLOT),
+          String(NOW - 30_000),
+          { expirationTtl: ARVLCD_FIRE_ONCE_TTL_SEC },
+        );
+      },
+    });
+    expect(stats.arvlCdFireSuccess).toBe(1);
+    expect(stats.arvlCdFireOnceSkipped).toBe(0);
+    // 중곡은 새로 stamp.
+    expect(
+      await kv.get(arvlCdFireOnceKey(TOKEN, '중곡', ARVLCD_FIRE_ONCE_CYCLE_SLOT)),
+    ).toBe(String(NOW));
+    // 건대입구 stamp 는 그대로 유지.
+    expect(
+      await kv.get(arvlCdFireOnceKey(TOKEN, '건대입구', ARVLCD_FIRE_ONCE_CYCLE_SLOT)),
+    ).toBe(String(NOW - 30_000));
+  });
+
+  it('flag=ON, fire-once TTL 만료 → 다음 cycle fire 진행 (자연 회수)', async () => {
+    // TTL 5분 만료 시나리오 — InMemoryKV 는 Date.now() 로 만료 판정. vi.useFakeTimers 사용.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(NOW);
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+      // 5분+1ms 전 stamp — 만료된 상태.
+      await kv.put(
+        arvlCdFireOnceKey(TOKEN, '중곡', ARVLCD_FIRE_ONCE_CYCLE_SLOT),
+        String(NOW - ARVLCD_FIRE_ONCE_TTL_SEC * 1000 - 1),
+        { expirationTtl: 1 }, // 즉시 만료 처리 (Date.now() > expiresAt).
+      );
+      // 만료 시점 진행.
+      vi.setSystemTime(NOW + 10_000);
+      const mod = await import('../arvlcdFireOnceTtl');
+      const spy = vi.spyOn(mod, 'isSimpleArchEnabled').mockReturnValue(true);
+      try {
+        const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+        const stats = await runScheduled(makeEnv(kv), {
+          seoul: makeArrivalSeoul('중곡', 0, 1),
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW,
+          generatePushId: () => 'p-fireonce-ttl-expire',
+        });
+        // TTL 만료로 첫 관측 취급 → fire 진행.
+        expect(stats.arvlCdFireSuccess).toBe(1);
+        expect(stats.arvlCdFireOnceSkipped).toBe(0);
+      } finally {
+        spy.mockRestore();
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('ARVLCD_FIRE_ONCE_CYCLE_SLOT (#1985)', () => {
+  it('is 0 — 현재는 미래-확장 slot placeholder (5분 TTL 이 cycle 경계 처리)', () => {
+    expect(ARVLCD_FIRE_ONCE_CYCLE_SLOT).toBe(0);
+  });
+});
+
 describe('#1363 — pickLatestCurrentStationName (log 진단 이원화 helper)', () => {
   const base = { lat: 37.5, lng: 127.0, accuracy: 10, ts: 1000, motion: 'walking' } as const;
 
@@ -7308,6 +7605,8 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
       // #1828 Phase 5 — station-level arrivals polling.
       stationPollFetch: 0, stationPollCacheHit: 0, stationPollError: 0,
       staleLockFireSkipped: 0,
+      // ADR-022 Phase 1-1 (#1985) — arvlCd fire-once TTL 게이트 (flag=OFF 시 항상 0).
+      arvlCdFireOnceSkipped: 0,
       // #1652 — staged lifecycle backstop.
       lifecycleSilenceSkipped: 0, lifecycleForceEnded: 0,
       // #1680 — stationary cron skip.

--- a/backend/alarm-worker/src/arvlcdFireOnceTtl.ts
+++ b/backend/alarm-worker/src/arvlcdFireOnceTtl.ts
@@ -1,0 +1,112 @@
+/**
+ * arvlCd fire-once TTL helper — ADR-022 Phase 1-1 (#1985).
+ *
+ * ## 배경
+ *
+ * ADR-022 (#1980) — Seoul TOPIS `realtimeStationArrival` API (arvlCd) 를 알림 SSOT 로 단일화하는
+ * 아키텍처 재설계. Issue #1980 코멘트 "동일 알림 반복 발사 근본 원인" 케이스 2:
+ *
+ *   13:31:14 silent-push-received 어린이대공원
+ *   13:32:14 silent-push-received 어린이대공원   ← 1분 후 또
+ *   13:37:14 silent-push-received 어린이대공원   ← 5분 후 또
+ *   13:38:14 silent-push-received station-passed imminent 어린이대공원
+ *
+ * Backend cron 60s 폴링 + arvlCd=1 지속(~30초) — 매 폴링마다 감지 시 push 재발사. 기존
+ * `arvlCdFireKey` dedup 은 `arvlCd` 값을 key 에 포함해 0(진입) 과 1(도착) 을 별 entry 로 분리
+ * stamp → 같은 train 이 한 station 을 지나가는 동안 최소 2번 fire 가능.
+ *
+ * ## 정책
+ *
+ * 같은 (`tripToken`, `stationName`) 에서 한 arvlCd cycle (0진입→1도착→2출발→5전역도착 monotone
+ * 시퀀스) 동안 fire 를 **1회로 강제**. 5분 TTL 로 자연 회수 — TTL 만료 시 다음 관측이 새 cycle
+ * 시작 (train 이 물리적으로 같은 station 을 5분 안에 재방문할 수 없음).
+ *
+ * `cycle` 파라미터는 미래-확장 slot — 현재는 `0` 고정 상수 caller 가 전달. 5분 TTL 이 사실상
+ * cycle 경계를 처리하므로 stateful cycle counter 는 불필요. 후속 PR 에서 cross-cron cycle
+ * 추적이 필요해지면 slot 을 활용해 정수 카운터로 확장 가능.
+ *
+ * ## Feature flag
+ *
+ * 본 helper 자체는 flag 를 알지 않는다 — caller (`fireArvlCdStationPush`) 가 `isSimpleArchEnabled()`
+ * 로 게이트한다. Phase 0 (#1982) 머지 후속 PR 에서 real `getArchFlag(env.KV)` wire.
+ *
+ * ## 관측
+ *
+ * skip 발생 시 caller 가 `writeMetric(env, { eventType: 'suppress', reason: 'fire-once-cycle-already' })`
+ * 로 wrangler tail 관측. `arvlCdFireOnceSkipped` stat 카운터도 별도 누적.
+ */
+
+/**
+ * 5분 (300s). Train 이 같은 station 을 5분 안에 재방문할 수 없다는 실제 운영 특성 기반.
+ * `ARVLCD_FIRE_DEDUP_TTL_SEC` (1시간, per-arvlCd key) 와 별개 정책 — 이 TTL 은 cycle 단위
+ * 전체를 커버하며 flag=ON 시에만 적용된다.
+ */
+export const ARVLCD_FIRE_ONCE_TTL_SEC = 5 * 60;
+
+/**
+ * KV key prefix. 형식: `fireOnce:{tripToken}:{stationName}:{arvlCdCycle}`.
+ *
+ * 주의: `arvlCdFireKey` (`arvlcd-fire:` prefix, per-arvlCd 분리) 와 namespace 격리 —
+ * 두 dedup layer 가 동일 KV 에서 서로 오염하지 않는다.
+ */
+export const ARVLCD_FIRE_ONCE_KEY_PREFIX = 'fireOnce:';
+
+/**
+ * Fire-once KV key 빌더.
+ *
+ * @param token       trip token (per-trip isolation — cross-trip leak 차단).
+ * @param stationName waypoint station name (표준 어휘, `stations.json` BLDN_NM).
+ * @param cycle       arvlCd cycle bucket (현재는 `0` 고정 slot, 5분 TTL 이 cycle 경계 처리).
+ */
+export function arvlCdFireOnceKey(
+  token: string,
+  stationName: string,
+  cycle: number,
+): string {
+  return `${ARVLCD_FIRE_ONCE_KEY_PREFIX}${token}:${stationName}:${cycle}`;
+}
+
+/**
+ * KV 에 이미 fire-once stamp 가 있는지 확인.
+ *
+ * @returns true — 이미 fire 됨 (skip 필요). false — 미stamp (fire 진행 가능).
+ */
+export async function checkArvlCdFireOnce(
+  kv: KVNamespace,
+  token: string,
+  stationName: string,
+  cycle: number,
+): Promise<boolean> {
+  const key = arvlCdFireOnceKey(token, stationName, cycle);
+  const existing = await kv.get(key);
+  return existing !== null;
+}
+
+/**
+ * Fire-once stamp 를 5분 TTL 로 write. 성공 fire 직후 caller 가 호출.
+ *
+ * value 는 stamp 시각 ms — 관측 시 몇 초 전에 stamp 됐는지 tail 에서 즉시 확인.
+ */
+export async function stampArvlCdFireOnce(
+  kv: KVNamespace,
+  token: string,
+  stationName: string,
+  cycle: number,
+  now: number,
+): Promise<void> {
+  const key = arvlCdFireOnceKey(token, stationName, cycle);
+  await kv.put(key, String(now), { expirationTtl: ARVLCD_FIRE_ONCE_TTL_SEC });
+}
+
+/**
+ * ADR-022 Phase 1-1 임시 flag. `false` = 기존 로직 (per-arvlCd dedup) 그대로.
+ * Phase 0 (#1982) 머지 후속 PR 에서 `getArchFlag(env.KV)` 로 real wire — 그 시점 이전엔
+ * production 무영향.
+ *
+ * 함수로 노출한 이유: 테스트에서 `vi.spyOn(module, 'isSimpleArchEnabled')` 로 flag=ON 시나리오
+ * 검증. Phase 1-2 follow-up PR 에서 signature 를 `isSimpleArchEnabled(env: Env)` 로 확장하고
+ * 내부를 `await getArchFlag(env.KV)` 로 교체 (call site 는 이미 `env` 를 갖고 있음).
+ */
+export function isSimpleArchEnabled(): boolean {
+  return false;
+}

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -91,6 +91,11 @@ import { RESCHEDULE_CHANNELS_DEFAULT } from './types';
 import { writeMetric } from './analytics';
 import { accumulateLaPushCounters } from './laPushCounters';
 import { t, type SupportedLocale } from './i18n';
+import {
+  checkArvlCdFireOnce,
+  isSimpleArchEnabled,
+  stampArvlCdFireOnce,
+} from './arvlcdFireOnceTtl';
 
 // pickApnsHost / flipApnsEnv는 ./apnsHost로 이동 (liveActivity.ts와 공유 SSOT, #482).
 // 외부(테스트 / index.ts 등)가 scheduled.ts 경유로 import하던 호환성 유지를 위해 re-export.
@@ -680,6 +685,13 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   staleLockFireSkipped: number;
   /**
+   * ADR-022 Phase 1-1 (#1985) — flag=ON 시 fire-once TTL 게이트가 차단한 누적 횟수.
+   * 같은 (tripToken, stationName, arvlCd cycle) 조합에서 이미 5분 이내 fire 된 경우 skip.
+   * flag=OFF (default) 상태에서는 항상 0 — Phase 0 (#1982) 머지 후속 PR 에서 실제 wire.
+   * 0이 아니면 arvlCd 반복 노출로 인한 중복 발사가 차단된 케이스 수 = ADR-022 정책 발동 신호.
+   */
+  arvlCdFireOnceSkipped: number;
+  /**
    * #1652 — staged lifecycle backstop. trip이 createdAt > 6h이라 silence cycle로 skip된 누적 횟수.
    * Seoul polling + push 발사 모두 skip된 cycle 수 = 6h+ 잔존 trip × 분당 1 cycle. 정상 운영에선
    * 일반적으로 0에 수렴 (대부분 trip이 6h 이내 종료). 0이 아니면 KTX/장거리 trip 또는 좀비 trip이
@@ -875,6 +887,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     stationPollError: 0,
     // #1614 Phase C — stale SSoT 가드 fire 차단.
     staleLockFireSkipped: 0,
+    // ADR-022 Phase 1-1 (#1985) — arvlCd fire-once TTL 게이트 차단 (flag=OFF 시 항상 0).
+    arvlCdFireOnceSkipped: 0,
     // #1652 — staged lifecycle backstop (X8). 6h~9h skip / 9h+ force-end.
     lifecycleSilenceSkipped: 0,
     lifecycleForceEnded: 0,
@@ -1382,6 +1396,16 @@ export const SAME_PHASE_STATION_DEDUP_WINDOW_MS = 45_000;
 export const ARVLCD_FIRE_KEY_PREFIX = 'arvlcd-fire:';
 
 /**
+ * ADR-022 Phase 1-1 (#1985) — fire-once TTL key 의 cycle slot 값.
+ *
+ * arvlCd cycle 은 (0진입→1도착→2출발→5전역도착) monotone 시퀀스로 한 pass 를 이룬다. 현재
+ * backend cron 은 stateful cycle counter 를 유지하지 않고 5분 TTL 로 cycle 경계를 자연 처리
+ * 하므로, key 의 cycle slot 은 미래-확장 자리 표시자로 `0` 고정. 후속 PR 에서 cross-cron
+ * cycle 추적이 필요해지면 slot 을 정수 카운터로 확장 가능하다.
+ */
+export const ARVLCD_FIRE_ONCE_CYCLE_SLOT = 0;
+
+/**
  * dedup KV key 빌더. arvlCd 0(ENTERING) vs 1(ARRIVED)은 별 entry로 분리(둘 다 신호).
  * token은 trip 단위 격리 — 같은 train 다른 trip이 서로 silence하지 않도록.
  */
@@ -1616,6 +1640,38 @@ export async function fireArvlCdStationPush(
     });
     return { dirty: false };
   }
+  // ADR-022 Phase 1-1 (#1985) — arvlCd fire-once TTL 게이트.
+  // flag=ON 시 같은 (tripToken, stationName, arvlCd cycle) 조합에서 5분 이내 이미 fire 된 경우
+  // skip. arvlCd 0/1 을 별 entry 로 stamp 하던 기존 `arvlCdFireKey` dedup 과 달리, cycle 전체
+  // (0→1→2→5) 를 하나의 fire 이벤트로 통합 — 어린이대공원 반복 4회 fire (#1980) 회귀 차단.
+  // flag=OFF (default, Phase 0 #1982 미머지 상태) 에서는 조기 return 으로 무영향.
+  const fireOnceCycle = ARVLCD_FIRE_ONCE_CYCLE_SLOT;
+  if (isSimpleArchEnabled()) {
+    const alreadyFired = await checkArvlCdFireOnce(
+      env.TRIPS,
+      trip.token,
+      waypoint.stationName,
+      fireOnceCycle,
+    );
+    if (alreadyFired) {
+      stats.arvlCdFireOnceSkipped += 1;
+      log('arvlcd-fire: fire-once cycle already', {
+        token: trip.token.slice(0, 8),
+        trainCode: lock.trainCode,
+        station: waypoint.stationName,
+        arvlCd,
+        cycle: fireOnceCycle,
+      });
+      writeMetric(env, {
+        eventType: 'suppress',
+        tripToken: trip.token,
+        stationId: waypoint.stationName,
+        reason: 'fire-once-cycle-already',
+        hopIndex: waypoint.hopIndex,
+      });
+      return { dirty: false };
+    }
+  }
   const key = arvlCdFireKey(trip.token, lock.trainCode, waypoint.stationName, arvlCd);
   const existing = await env.TRIPS.get(key);
   if (existing !== null) {
@@ -1760,6 +1816,12 @@ export async function fireArvlCdStationPush(
   });
   // dedup stamp — 같은 cycle에서 Seoul API 갱신 지연으로 같은 신호가 재노출돼도 차단.
   await env.TRIPS.put(key, '1', { expirationTtl: ARVLCD_FIRE_DEDUP_TTL_SEC });
+  // ADR-022 Phase 1-1 (#1985) — fire-once TTL stamp (flag=ON 시에만). 성공 fire 직후 stamp
+  // 해 다음 cycle 이내 arvlCd 재노출을 통합 차단. flag=OFF 시 이 write 는 실행되지 않아
+  // production 무영향.
+  if (isSimpleArchEnabled()) {
+    await stampArvlCdFireOnce(env.TRIPS, trip.token, waypoint.stationName, fireOnceCycle, now);
+  }
   // #1367 — cross-station dedup용 마지막 fire 마커. 성공 시에만 stamp(실패는 다음 cycle 재시도 허용).
   trip.lastFiredStation = { stationName: waypoint.stationName, epochMs: now };
   dirty = true;


### PR DESCRIPTION
## Summary

ADR-022 (#1980) Phase 1-1 — arvlCd cycle 단위 fire-once TTL 게이트 도입. Backend cron 60s 폴링 + arvlCd 지속 노출로 인한 동일 station 반복 fire (2026-07-01 어린이대공원 4회 등, #1980 코멘트 케이스 2) 회귀 차단.

## 배경

기존 \`arvlCdFireKey\` dedup 은 \`arvlCd\` 값을 key 에 포함해 0(진입) 과 1(도착) 을 별 entry 로 stamp → 같은 train 이 한 station 을 지나가는 동안 최소 2번 fire 가능. 본 PR 은 cycle 전체 (0→1→2→5) 를 하나의 fire 이벤트로 통합하는 5분 TTL 게이트를 신규 KV namespace (\`fireOnce:\`) 에 구현한다.

## 변경 사항

### 신규 파일
- \`backend/alarm-worker/src/arvlcdFireOnceTtl.ts\` — helper (\`checkArvlCdFireOnce\` / \`stampArvlCdFireOnce\` / \`isSimpleArchEnabled\`)
- \`backend/alarm-worker/src/__tests__/arvlcdFireOnceTtl.test.ts\` — helper 14 tests

### 수정 파일
- \`backend/alarm-worker/src/scheduled.ts\`
  - Import 추가 + \`ARVLCD_FIRE_ONCE_CYCLE_SLOT=0\` 상수 (미래-확장 slot)
  - \`ScheduledStats.arvlCdFireOnceSkipped\` 신규 카운터 (flag=OFF 시 항상 0)
  - \`fireArvlCdStationPush\` 에 flag=ON 시 fire-once TTL 게이트 (stale SSoT 가드 뒤, 기존 \`arvlcdFireKey\` dedup 앞) + 성공 fire 직후 stamp
  - \`writeMetric\` suppress event \`reason='fire-once-cycle-already'\` 로 관측
- \`backend/alarm-worker/src/__tests__/scheduled.test.ts\` — full-shape stats helper (\`makeFullEmptyStats\`) + 통합 7 tests (flag ON/OFF, 첫 관측/재관측/cross-trip/cross-station/TTL 만료/arvlCd 0→1 통합 skip)

### Feature flag 정책

\`isSimpleArchEnabled()\` 는 임시 상수 \`false\` 반환. Phase 0 (#1982) 머지 후속 PR 에서 real \`getArchFlag(env.KV)\` wire 예정. 현재 상태에서는 flag OFF default 이므로 production 무영향.

## 스펙 매핑

| 스펙 항목 | 구현 |
|---|---|
| KV key \`fireOnce:{tripToken}:{stationName}:{arvlCdCycle}\` | \`arvlCdFireOnceKey(token, stationName, cycle)\` |
| TTL 5분 (\`expirationTtl: 300\`) | \`ARVLCD_FIRE_ONCE_TTL_SEC = 5 * 60\` |
| arvlCdCycle (0진입→1도착→2출발→5전역도착 순환) | \`ARVLCD_FIRE_ONCE_CYCLE_SLOT=0\` 고정 slot — 5분 TTL 이 cycle 경계 자연 처리 (train physical constraint: 같은 station 5분 이내 재방문 불가) |
| Check 순서 (arvlCd 감지 → check → skip or fire → stamp) | \`fireArvlCdStationPush\` 진입부 (line 1643-1674) + 성공 fire 직후 stamp (line 1822-1824) |
| Flag guard 임시 \`SIMPLE_ARCH_ENABLED=false\` | \`isSimpleArchEnabled()\` 함수 (테스트 spy 가능하도록 함수화, Phase 1-2 에서 \`(env)\` signature 로 확장 예정) |

## acceptance 매핑

- [x] fire-once TTL 5분 helper 함수 + 통합 test — \`arvlcdFireOnceTtl.ts\` + \`arvlcdFireOnceTtl.test.ts\` (14 tests)
- [x] \`scheduled.ts\` fire 조건에 wire (flag=OFF 일 때 기존 동작 유지) — 통합 test \`flag=OFF (default) → 기존 로직 그대로\`
- [x] flag=ON 시 같은 (trip, station, cycle) 조합 2회 이상 fire 0건 (test) — 통합 test \`같은 (trip, station, cycle) 2회 fire → 2번째는 skip\` + \`arvlCd=0 fire 후 같은 cycle 이내 arvlCd=1 재관측 → 통합 게이트 skip\`
- [x] backend test 100% coverage — \`arvlcdFireOnceTtl.ts\` 100% (stmts/branch/funcs/lines) + \`scheduled.ts\` 새 lines 100% branch
- [x] flag OFF 상태 CI ALL GREEN — backend 전체 2365 tests PASS, type-check clean

## Wire-completion 5단 (#1582)

1. **Orphan** — 신규 helper 는 \`scheduled.ts\` 에서 import. 신규 export 는 모두 caller 존재.
2. **V/X dashboard** — \`stats.arvlCdFireOnceSkipped\` (cron log) + \`writeMetric\` suppress event \`reason='fire-once-cycle-already'\` (wrangler tail + Cloudflare Analytics Engine) 로 관측.
3. **의존 PR** — Phase 0 #1982 (Feature Flag 인프라). 본 PR 은 flag OFF default 이므로 #1982 미머지 상태에서도 production 무영향. Phase 0 머지 후 후속 PR 에서 \`isSimpleArchEnabled()\` 내부를 \`getArchFlag(env.KV)\` 로 교체.
4. **측정 plan** — Phase 0 머지 → 본 PR flag=ON wire → 사용자 dogfood 1주 실기기: 어린이대공원 반복 4회 케이스 재현 시나리오에서 \`arvlCdFireOnceSkipped\` > 0 + station-passed push 중복 0건 확인.
5. **Device verify** — N/A — backend-only, type+unit only. 실기기 검증은 후속 Phase 1 전체 wire (device 채널 통합 fire path 등) 후 사용자 실기기.

## refs

- ADR-022 (#1980): \`docs/decisions/ADR-022-arrival-api-ssot-redesign.md\`
- Issue #1980 코멘트 "동일 알림 반복 발사 근본 원인" 케이스 2 (어린이대공원 4회 fire)
- Phase 0 인프라 #1982 (선행 PR — 본 PR 후속 wire 에서 참조)

Closes #1985