### PR TITLE
fix(#1984): Phase 1-4 client 채널 통합 fire path (fg 중복 fire race fix)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -4,7 +4,15 @@
  * ADR Phase 5 (#890) orchestration 컨벤션.
  */
 import { renderHook, waitFor } from '@testing-library/react-native';
-import { useStationAlarm, type UseStationAlarmInputs } from '../useStationAlarm';
+import {
+  __setSimpleArchEnabledForTests,
+  useStationAlarm,
+  type UseStationAlarmInputs,
+} from '../useStationAlarm';
+import {
+  _resetFireAlarmOnceForTests,
+  fireAlarmOnce,
+} from '../../utils/fireAlarmOnce';
 import { useSettingsStore } from '../../../settings/store/useSettingsStore';
 import { useAlarmEventStore } from '../../store/useAlarmEventStore';
 import type { Station } from '../../../../shared/types/station';
@@ -90,6 +98,7 @@ const mockLogSuppressedChannelAgnosticDedup = jest.fn();
 const mockLogFiredAlarmsTripBoundaryReset = jest.fn();
 const mockLogSuppressedSsotFireGate = jest.fn();
 const mockLogSuppressedLocklessNoUserIntent = jest.fn();
+const mockLogSuppressedFireAlarmOnce = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
   logFiredAlarmsHydrate: (...args: unknown[]) => mockLogFiredAlarmsHydrate(...args),
@@ -128,6 +137,8 @@ jest.mock('../../utils/alarmLog', () => ({
     mockLogSuppressedSsotFireGate(...args),
   logSuppressedLocklessNoUserIntent: (...args: unknown[]) =>
     mockLogSuppressedLocklessNoUserIntent(...args),
+  logSuppressedFireAlarmOnce: (...args: unknown[]) =>
+    mockLogSuppressedFireAlarmOnce(...args),
 }));
 
 // #1893 (RC-17) — trip-boundary detection effect는 tripStartedAt storage를 read한다.
@@ -245,6 +256,9 @@ describe('useStationAlarm', () => {
     // #1515 — cross-category dedup 모듈 in-memory 상태 리셋. mock하지 않은 실모듈 사용.
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     require('../../utils/crossCategoryStationDedup')._resetCrossCategoryDedupForTests();
+    // #1984 — fire-once ledger + flag OFF 리셋. 각 테스트가 필요한 경우 명시적으로 flag ON.
+    _resetFireAlarmOnceForTests();
+    __setSimpleArchEnabledForTests(false);
   });
 
   it('does not evaluate when route is null', () => {
@@ -5632,6 +5646,198 @@ describe('useStationAlarm', () => {
         ),
       );
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  // #1984 (Phase 1-4, ADR-022 B3) — simpleArchEnabled=true 시 unified fire ledger가 Phase ETA +
+  // API imminent 두 useEffect의 동일 (station+line+kind+phase) 재발사를 sync entry-guard로 차단.
+  // 회귀 evidence: 2026-07-01 08:32:09 성수 fg fired station-passed 2건 (#1980 코멘트 케이스 1).
+  describe('#1984 simpleArchEnabled unified fire path', () => {
+    const route = makeDirectRoute(3, '2');
+    const station = makeStation('S1', '시청');
+
+    it('flag OFF (기본): Phase ETA fire 정상 — fireAlarmOnce dedup 미적용 (backward-compat)', async () => {
+      __setSimpleArchEnabledForTests(false);
+      mockEvaluateAlarmPhase.mockReturnValue(imminentDest);
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
+      // fire ledger 미개입 확인 — logSuppressedFireAlarmOnce 미호출.
+      expect(mockLogSuppressedFireAlarmOnce).not.toHaveBeenCalled();
+    });
+
+    it('flag ON: 첫 fire 정상 발사 + logFiredAlarm', async () => {
+      __setSimpleArchEnabledForTests(true);
+      mockEvaluateAlarmPhase.mockReturnValue(imminentDest);
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+
+      await waitFor(() =>
+        expect(mockLogFiredAlarm).toHaveBeenCalledWith(
+          'fg',
+          expect.objectContaining({ phaseId: 'imminent', stationName: '강남', type: 'destination' }),
+          'eta',
+        ),
+      );
+      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+      expect(mockLogSuppressedFireAlarmOnce).not.toHaveBeenCalled();
+    });
+
+    it('flag ON: ledger에 이미 stamp된 (station+line+kind+phase) 조합의 Phase ETA fire는 차단', async () => {
+      // 같은 초 race 시나리오 재현: ledger가 다른 fire path(예: 앞서 실행된 다른 useEffect 또는
+      // 채널)로 이미 stamp된 상태에서 Phase ETA useEffect가 같은 조합으로 dispatch 시도 → 차단.
+      // 사용자 evidence(2026-07-01 08:32:09 성수 fg fired 2건)의 두 번째 fire 차단 검증.
+      __setSimpleArchEnabledForTests(true);
+      // ledger에 imminent destination 강남 (line=2) fire를 사전 stamp — 다른 채널이 먼저 발사한 상황.
+      await fireAlarmOnce(
+        {
+          stationName: '강남',
+          line: '2',
+          kind: 'destination',
+          phase: 'imminent',
+        },
+        () => Promise.resolve(),
+      );
+
+      // Phase ETA useEffect가 같은 조합의 imminentDest를 evaluate → fireViaUnifiedGate → ledger dedup.
+      mockEvaluateAlarmPhase.mockReturnValue(imminentDest);
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: station,
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+
+      // 두 번째 fire는 ledger dedup → logSuppressedFireAlarmOnce 적재.
+      await waitFor(() =>
+        expect(mockLogSuppressedFireAlarmOnce).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: 'fg',
+            stationName: '강남',
+            kind: 'destination',
+            phaseId: 'imminent',
+          }),
+        ),
+      );
+      // 사용자에게 노출된 알람 0건 — ledger가 fire callback 실행 자체를 차단.
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      // logFiredAlarm도 미호출 (fireAndLog 진입 X).
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+    });
+
+    it('flag ON: 다른 phase(early → imminent) 진행은 정상 통과 (정상 phase 진행 보존)', async () => {
+      __setSimpleArchEnabledForTests(true);
+      const { rerender } = renderHook(
+        ({ input }: { input: UseStationAlarmInputs }) => useStationAlarm(input),
+        {
+          initialProps: {
+            input: defaultInputs({
+              route,
+              destination,
+              userLocation: { lat: 37.4, lng: 127.0 },
+              speedMps: 10,
+              accuracyMeters: 50,
+            }),
+          },
+        },
+      );
+
+      // 첫 fire: early destination.
+      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
+      rerender({
+        input: defaultInputs({
+          route,
+          destination,
+          userLocation: { lat: 37.401, lng: 127.0 },
+          speedMps: 10,
+          accuracyMeters: 50,
+        }),
+      });
+      await waitFor(() =>
+        expect(mockLogFiredAlarm).toHaveBeenCalledWith(
+          'fg',
+          expect.objectContaining({ phaseId: 'early' }),
+          'eta',
+        ),
+      );
+
+      // 두 번째 fire: imminent destination — phase 다르므로 unified ledger 통과.
+      mockEvaluateAlarmPhase.mockReturnValue(imminentDest);
+      rerender({
+        input: defaultInputs({
+          route,
+          destination,
+          userLocation: { lat: 37.402, lng: 127.0 },
+          speedMps: 10,
+          accuracyMeters: 50,
+        }),
+      });
+      await waitFor(() =>
+        expect(mockLogFiredAlarm).toHaveBeenCalledWith(
+          'fg',
+          expect.objectContaining({ phaseId: 'imminent' }),
+          'eta',
+        ),
+      );
+      // 정상 progression — dedup 로그 없어야 함.
+      expect(mockLogSuppressedFireAlarmOnce).not.toHaveBeenCalled();
+    });
+
+    it('flag ON: rawEvent에 line=null 상황도 방어적 stringify로 정상 dedup', async () => {
+      __setSimpleArchEnabledForTests(true);
+      // nearestStation 미제공 + lock.boardingLine 미설정 → resolveCurrentLine = null.
+      mockGetBoardingLock.mockResolvedValue({
+        destinationId: 'D1',
+        trainCode: 'T-DEFAULT',
+        boardingStationId: 'S-DEFAULT',
+        boardingLine: null as unknown as '2',
+        boardedAt: 0,
+        expectedDurationMs: 60_000,
+      });
+      mockEvaluateAlarmPhase.mockReturnValue(imminentDest);
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            // nearestStation 없음
+            userLocation: { lat: 37.4, lng: 127.0 },
+            speedMps: 10,
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+
+      // line=null이어도 fire 정상 진행 — 방어적 stringify로 dedup key 산출.
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
     });
   });
 });

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -45,6 +45,7 @@ import {
   logSuppressedChannelAgnosticDedup,
   logSuppressedCrossCategoryDedup,
   logSuppressedCrossCategoryRecent,
+  logSuppressedFireAlarmOnce,
   logSuppressedPhaseToPhaseDedup,
   logSuppressedDedupAlarm,
   logSuppressedDedupStation,
@@ -60,6 +61,7 @@ import {
   logSuppressedLocklessNoUserIntent,
   type HydrationPhase,
 } from '../utils/alarmLog';
+import { fireAlarmOnce } from '../utils/fireAlarmOnce';
 import { evaluateSsotFireGate } from '../utils/ssotFireGate';
 import {
   isAnyChannelRecentlyFired,
@@ -84,6 +86,37 @@ import type { FusionConfidence, FusionSource } from '../../../shared/types/fusio
 import { resolveNotificationSource, type NotificationSource } from '../utils/notificationSource';
 
 const logger = createLogger('StationAlarm');
+
+/**
+ * #1984 (Phase 1-4, ADR-022 B3) — client 채널 통합 fire path flag.
+ *
+ * `false` (기본): 기존 fire 흐름 유지 (Phase ETA + API imminent 두 useEffect가 각각 `fireAndLog`
+ * 직접 호출). backward-compat 보장 — 본 PR은 flag OFF 상태로 머지.
+ *
+ * `true`: 두 useEffect가 `fireAlarmOnce` unified ledger를 통과한 뒤에만 `fireAndLog` 호출.
+ * ledger key = `${stationName}|${line}|${kind}|${phase}` — 같은 초 동시 dispatch race 차단.
+ * Phase 5 실기기 검증 후 별도 이슈에서 true로 전환 예정 (staged rollout).
+ *
+ * 회귀 evidence (2026-07-01 08:32:09 성수 fg fired station-passed 2건, #1980 코멘트 케이스 1).
+ *
+ * 테스트 전용 override: `__setSimpleArchEnabledForTests(true|false)`. production 호출 금지.
+ */
+let simpleArchEnabled = false;
+
+/**
+ * 테스트 전용 — SIMPLE_ARCH_ENABLED flag override.
+ * `useStationAlarm.test.ts`의 unified fire ledger 검증에서만 사용. production 코드는 호출 X.
+ *
+ * Finding #4 review 반영: production NODE_ENV 오호출 방지 guard. debug menu / accidental
+ * import 경로로 flag 우발 전환 차단.
+ */
+export function __setSimpleArchEnabledForTests(value: boolean): void {
+  /* istanbul ignore next -- production guard. jest는 NODE_ENV='test'이라 도달 불가. */
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('__setSimpleArchEnabledForTests must not be called in production');
+  }
+  simpleArchEnabled = value;
+}
 
 // #1010/#1316/#1645 — 하이드레이션 warmup. lock hydrate 완료 후 이 기간 동안 알람 발사를 차단한다.
 // 하이드레이션 직후 firedAlarms가 복원되기 전 GPS/ETA 신호와 동기화되는 과도 구간 false alarm 방지.
@@ -976,6 +1009,48 @@ export function useStationAlarm({
     logFiredAlarm('fg', event, trigger);
   }
 
+  /**
+   * #1984 (Phase 1-4, ADR-022 B3) — client 채널 통합 fire ledger gate.
+   *
+   * `simpleArchEnabled=false` (기본): 바로 `fireAndLog` 호출 — 기존 흐름 그대로.
+   * `simpleArchEnabled=true`: `fireAlarmOnce` ledger를 sync entry-guard로 통과한 뒤에만
+   * `fireAndLog` 호출. 같은 (stationName, line, kind, phase) 조합이 30s 안에 이미 fire됐으면
+   * skip + `logSuppressedFireAlarmOnce` 적재. Phase ETA + API imminent 두 useEffect가 같은
+   * 초에 dispatch 시도한 회귀(2026-07-01 08:32:09 성수 fg fired station-passed 2건)를 차단.
+   *
+   * currentLine = lock.boardingLine 우선(currentLockLine) → nearestStation.line fallback.
+   * `resolveCurrentLine` SSOT와 동일 규약.
+   */
+  async function fireViaUnifiedGate(
+    rawEvent: AlarmEvent,
+    trigger: 'api' | 'eta',
+    activeRoute: NonNullable<Route>,
+    activeDestination: Station,
+  ): Promise<void> {
+    if (!simpleArchEnabled) {
+      await fireAndLog(rawEvent, trigger, activeRoute, activeDestination);
+      return;
+    }
+    const line = resolveCurrentLine(currentLockLine, nearestStation);
+    const result = await fireAlarmOnce(
+      {
+        stationName: rawEvent.stationName,
+        line,
+        kind: rawEvent.type,
+        phase: rawEvent.phaseId,
+      },
+      () => fireAndLog(rawEvent, trigger, activeRoute, activeDestination),
+    );
+    if (result.deduped) {
+      logSuppressedFireAlarmOnce({
+        source: 'fg',
+        stationName: rawEvent.stationName,
+        kind: rawEvent.type,
+        phaseId: rawEvent.phaseId,
+      });
+    }
+  }
+
   // Phase 알람 효과: ETA 기반 phase 평가 + firedAlarms 갱신.
   // hydrationPhase!=='ready'인 동안에는 보류 — BG가 이미 발화한 phase를 빈 ref로 재발화하는 것을 막는다.
   // station-passed와 분리: 하이드레이션 완료로 인한 effect 재실행이 station-passed 중복 발사를
@@ -1063,6 +1138,8 @@ export function useStationAlarm({
     // #699: fireAndLog가 setFiredAlarms를 await하므로 promise를 명시적으로 흘려보낸다.
     // #754: in-flight dedup은 fireAndLog 진입부의 sync firedAlarmsRef.current.add(key) 가
     // 보장한다 (await getBoardingLock 전에 set에 들어가므로 같은 키의 동시 호출은 즉시 return).
+    // #1984: simpleArchEnabled=true 시 unified fire ledger(fireAlarmOnce)가 sync entry-guard로
+    // 같은 (station+line+kind+phase) 조합의 동일 초 재발사를 차단한 뒤에만 fireAndLog로 진행.
     if (rawEvent) {
       // #746 — dismiss silence 게이트. 사용자 dismiss 후 5분/200m 이내라면 모든 카테고리 차단.
       // movement/dedup보다 위 — 사용자 명시 정책이 데이터 정확성보다 우선.
@@ -1099,7 +1176,7 @@ export function useStationAlarm({
         });
         return;
       }
-      void fireAndLog(rawEvent, 'eta', route, destination);
+      void fireViaUnifiedGate(rawEvent, 'eta', route, destination);
     }
   }, [
     route,
@@ -1191,7 +1268,9 @@ export function useStationAlarm({
     const rawEvent: AlarmEvent = { phaseId: 'imminent', type: 'destination', stationName: destination.name };
     // #699: setFiredAlarms 영속화 완료를 await — silent push BG 핸들러가 같은 imminent를
     // 재발사하지 않도록 storage가 sync된 후 다음 cycle 진입.
-    void fireAndLog(rawEvent, 'api', route, destination);
+    // #1984: simpleArchEnabled=true 시 unified fire ledger가 Phase ETA effect와의 동일 초
+    // 재발사 race를 sync entry-guard로 차단.
+    void fireViaUnifiedGate(rawEvent, 'api', route, destination);
   }, [
     hydrationPhase,
     route,

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -32,6 +32,7 @@ import {
   logSuppressedChannelAgnosticDedup,
   logSuppressedCrossCategoryDedup,
   logSuppressedCrossCategoryRecent,
+  logSuppressedFireAlarmOnce,
   logSuppressedPhaseToPhaseDedup,
   logFiredAlarmsTripBoundaryReset,
   logSuppressedDedupStation,
@@ -683,6 +684,36 @@ describe('alarmLog', () => {
       const saved: AlarmLogEntry[] = JSON.parse(lastJson);
       const channelAgnostic = saved.filter((e) => e.reason === 'dedup-channel-agnostic');
       expect(channelAgnostic).toHaveLength(1);
+    });
+
+    it('#1984 logSuppressedFireAlarmOnce: reason=dedup-simple-arch-fire-once + kind/phase 보존', async () => {
+      _resetBurstSuppressWindowForTests();
+      logSuppressedFireAlarmOnce({
+        source: 'fg',
+        stationName: '성수',
+        kind: 'station-passed',
+        phaseId: 'imminent',
+      });
+      await expectLastSavedEntryMatches({
+        source: 'fg',
+        outcome: 'suppressed',
+        reason: 'dedup-simple-arch-fire-once',
+        stationName: '성수',
+        kind: 'station-passed',
+        phaseId: 'imminent',
+      });
+    });
+
+    it('#1984 logSuppressedFireAlarmOnce: 윈도우 내 같은 stationName 재호출은 drop', async () => {
+      _resetBurstSuppressWindowForTests();
+      logSuppressedFireAlarmOnce({ source: 'fg', stationName: '성수', kind: 'destination' });
+      logSuppressedFireAlarmOnce({ source: 'fg', stationName: '성수', kind: 'destination' });
+      await flushAlarmLog();
+      const calls = (AsyncStorage.setItem as jest.Mock).mock.calls;
+      const lastJson = calls[calls.length - 1][1];
+      const saved: AlarmLogEntry[] = JSON.parse(lastJson);
+      const fireOnce = saved.filter((e) => e.reason === 'dedup-simple-arch-fire-once');
+      expect(fireOnce).toHaveLength(1);
     });
 
     it('#1893 logFiredAlarmsTripBoundaryReset: reason=fired-alarms-trip-boundary-reset + epoch 슬롯 보존', async () => {

--- a/src/features/alarm/utils/__tests__/fireAlarmOnce.test.ts
+++ b/src/features/alarm/utils/__tests__/fireAlarmOnce.test.ts
@@ -1,0 +1,258 @@
+import {
+  FIRE_ONCE_WINDOW_MS,
+  _resetFireAlarmOnceForTests,
+  fireAlarmOnce,
+  makeFireAlarmOnceKey,
+} from '../fireAlarmOnce';
+
+const basePayload = {
+  stationName: '성수',
+  line: '2' as const,
+  kind: 'station-passed' as const,
+  phase: 'imminent' as const,
+};
+
+describe('fireAlarmOnce (#1984)', () => {
+  beforeEach(() => {
+    _resetFireAlarmOnceForTests();
+  });
+
+  describe('makeFireAlarmOnceKey', () => {
+    it('composes key with all four dimensions', () => {
+      expect(makeFireAlarmOnceKey(basePayload)).toBe('성수|2|station-passed|imminent');
+    });
+
+    it('serializes null line as string "null"', () => {
+      expect(makeFireAlarmOnceKey({ ...basePayload, line: null })).toBe(
+        '성수|null|station-passed|imminent',
+      );
+    });
+
+    it('differentiates by phase (early vs imminent)', () => {
+      const early = makeFireAlarmOnceKey({ ...basePayload, phase: 'early' });
+      const imminent = makeFireAlarmOnceKey({ ...basePayload, phase: 'imminent' });
+      expect(early).not.toBe(imminent);
+    });
+
+    it('differentiates by kind (destination vs transfer vs station-passed)', () => {
+      const dest = makeFireAlarmOnceKey({ ...basePayload, kind: 'destination' });
+      const transfer = makeFireAlarmOnceKey({ ...basePayload, kind: 'transfer' });
+      const passed = makeFireAlarmOnceKey({ ...basePayload, kind: 'station-passed' });
+      expect(new Set([dest, transfer, passed]).size).toBe(3);
+    });
+  });
+
+  describe('fireAlarmOnce', () => {
+    it('fires callback on first call and returns deduped=false', async () => {
+      const fire = jest.fn().mockResolvedValue(undefined);
+      const result = await fireAlarmOnce(basePayload, fire, 1_000);
+      expect(fire).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ deduped: false, fired: true });
+    });
+
+    it('dedups second call within the window (same key, same tick)', async () => {
+      const fire1 = jest.fn().mockResolvedValue(undefined);
+      const fire2 = jest.fn().mockResolvedValue(undefined);
+      const r1 = await fireAlarmOnce(basePayload, fire1, 1_000);
+      const r2 = await fireAlarmOnce(basePayload, fire2, 1_000);
+      expect(r1).toEqual({ deduped: false, fired: true });
+      expect(r2).toEqual({ deduped: true, fired: false });
+      expect(fire1).toHaveBeenCalledTimes(1);
+      expect(fire2).not.toHaveBeenCalled();
+    });
+
+    it('same-second race: two concurrent invocations — only first fires (sync entry-guard)', async () => {
+      // 회귀 재현: 2026-07-01 08:32:09 성수 fg fired station-passed 2건.
+      // 두 useEffect가 같은 tick에 진입해도 fireAlarmOnce의 sync ledger.set이 두 번째 호출을 즉시 dedup.
+      const fire1 = jest.fn().mockResolvedValue(undefined);
+      const fire2 = jest.fn().mockResolvedValue(undefined);
+      // 동시 dispatch — Promise.all로 병렬 실행.
+      const [r1, r2] = await Promise.all([
+        fireAlarmOnce(basePayload, fire1, 1_000),
+        fireAlarmOnce(basePayload, fire2, 1_000),
+      ]);
+      // 두 결과 중 하나만 fired, 다른 하나는 dedup.
+      const firedResults = [r1, r2].filter((r) => r.fired);
+      const dedupedResults = [r1, r2].filter((r) => r.deduped);
+      expect(firedResults).toHaveLength(1);
+      expect(dedupedResults).toHaveLength(1);
+      // 두 callback 중 정확히 1번만 실행 (총 실행 카운트 = 1).
+      expect(fire1.mock.calls.length + fire2.mock.calls.length).toBe(1);
+    });
+
+    it('allows fire again after window expiry', async () => {
+      const fire1 = jest.fn().mockResolvedValue(undefined);
+      const fire2 = jest.fn().mockResolvedValue(undefined);
+      await fireAlarmOnce(basePayload, fire1, 1_000);
+      const r2 = await fireAlarmOnce(basePayload, fire2, 1_000 + FIRE_ONCE_WINDOW_MS);
+      expect(r2).toEqual({ deduped: false, fired: true });
+      expect(fire2).toHaveBeenCalledTimes(1);
+    });
+
+    it('boundary — exactly at window edge blocks (< not <=)', async () => {
+      const fire1 = jest.fn().mockResolvedValue(undefined);
+      const fire2 = jest.fn().mockResolvedValue(undefined);
+      await fireAlarmOnce(basePayload, fire1, 1_000);
+      // 1s before window end: still dedup.
+      const r2 = await fireAlarmOnce(basePayload, fire2, 1_000 + FIRE_ONCE_WINDOW_MS - 1);
+      expect(r2).toEqual({ deduped: true, fired: false });
+      expect(fire2).not.toHaveBeenCalled();
+    });
+
+    it('different phase (early vs imminent) not deduped — 정상 phase 진행 보존', async () => {
+      const fireEarly = jest.fn().mockResolvedValue(undefined);
+      const fireImminent = jest.fn().mockResolvedValue(undefined);
+      await fireAlarmOnce({ ...basePayload, phase: 'early' }, fireEarly, 1_000);
+      const r2 = await fireAlarmOnce({ ...basePayload, phase: 'imminent' }, fireImminent, 1_010);
+      expect(r2).toEqual({ deduped: false, fired: true });
+      expect(fireImminent).toHaveBeenCalledTimes(1);
+    });
+
+    it('different station not deduped', async () => {
+      const fire1 = jest.fn().mockResolvedValue(undefined);
+      const fire2 = jest.fn().mockResolvedValue(undefined);
+      await fireAlarmOnce(basePayload, fire1, 1_000);
+      const r2 = await fireAlarmOnce({ ...basePayload, stationName: '왕십리' }, fire2, 1_010);
+      expect(r2).toEqual({ deduped: false, fired: true });
+    });
+
+    it('different line not deduped (환승역 line 분기 fire 보존)', async () => {
+      const fire1 = jest.fn().mockResolvedValue(undefined);
+      const fire2 = jest.fn().mockResolvedValue(undefined);
+      await fireAlarmOnce(basePayload, fire1, 1_000);
+      const r2 = await fireAlarmOnce({ ...basePayload, line: '5' }, fire2, 1_010);
+      expect(r2).toEqual({ deduped: false, fired: true });
+    });
+
+    it('different kind not deduped', async () => {
+      const fire1 = jest.fn().mockResolvedValue(undefined);
+      const fire2 = jest.fn().mockResolvedValue(undefined);
+      await fireAlarmOnce(basePayload, fire1, 1_000);
+      const r2 = await fireAlarmOnce({ ...basePayload, kind: 'destination' }, fire2, 1_010);
+      expect(r2).toEqual({ deduped: false, fired: true });
+    });
+
+    it('uses Date.now() as default when now not provided', async () => {
+      const fire = jest.fn().mockResolvedValue(undefined);
+      const spy = jest.spyOn(Date, 'now').mockReturnValue(5_000);
+      try {
+        const r = await fireAlarmOnce(basePayload, fire);
+        expect(r).toEqual({ deduped: false, fired: true });
+        expect(spy).toHaveBeenCalled();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('propagates fire callback rejection (Finding #2 fix: ledger unstamped on failure)', async () => {
+      const fire = jest.fn().mockRejectedValue(new Error('boom'));
+      await expect(fireAlarmOnce(basePayload, fire, 1_000)).rejects.toThrow('boom');
+      // 실패 시 ledger는 stamp되지 않아 다음 호출이 정상 fire 재시도 가능.
+      // transient failure(silence gate / notification permission race)에서 30s blackhole 회귀 차단.
+      const fire2 = jest.fn().mockResolvedValue(undefined);
+      const r2 = await fireAlarmOnce(basePayload, fire2, 1_010);
+      expect(r2).toEqual({ deduped: false, fired: true });
+      expect(fire2).toHaveBeenCalledTimes(1);
+    });
+
+    it('Finding #2: fire 성공 후에는 ledger stamp되어 재발사 차단 (retry는 실패 케이스만)', async () => {
+      const fire1 = jest.fn().mockResolvedValue(undefined);
+      const fire2 = jest.fn().mockResolvedValue(undefined);
+      const r1 = await fireAlarmOnce(basePayload, fire1, 1_000);
+      expect(r1).toEqual({ deduped: false, fired: true });
+      // 성공 후 재호출은 dedup — 30s window 내.
+      const r2 = await fireAlarmOnce(basePayload, fire2, 1_010);
+      expect(r2).toEqual({ deduped: true, fired: false });
+      expect(fire2).not.toHaveBeenCalled();
+    });
+
+    it('Finding #2: 두 번 연속 실패 후 세 번째 성공 시 정상 fire (재시도 회복)', async () => {
+      const fireFail = jest.fn().mockRejectedValue(new Error('transient'));
+      const fireOk = jest.fn().mockResolvedValue(undefined);
+      await expect(fireAlarmOnce(basePayload, fireFail, 1_000)).rejects.toThrow('transient');
+      await expect(fireAlarmOnce(basePayload, fireFail, 1_001)).rejects.toThrow('transient');
+      const r3 = await fireAlarmOnce(basePayload, fireOk, 1_002);
+      expect(r3).toEqual({ deduped: false, fired: true });
+      expect(fireOk).toHaveBeenCalledTimes(1);
+    });
+
+    it('Finding #2: in-flight reservation catches same-tick 재진입 (fire 실행 중)', async () => {
+      // fire callback이 오래 걸리는 상황(await 진행 중)에 같은 key로 재진입 → inFlight로 즉시 dedup.
+      let resolveFire!: () => void;
+      const firePending = jest.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFire = resolve;
+          }),
+      );
+      const fireSecond = jest.fn().mockResolvedValue(undefined);
+      const p1 = fireAlarmOnce(basePayload, firePending, 1_000);
+      // p1의 sync entry에서 inFlight.add는 완료. fire는 await 중.
+      const p2 = fireAlarmOnce(basePayload, fireSecond, 1_000);
+      const r2 = await p2;
+      expect(r2).toEqual({ deduped: true, fired: false });
+      expect(fireSecond).not.toHaveBeenCalled();
+      // p1 완료 유도.
+      resolveFire();
+      const r1 = await p1;
+      expect(r1).toEqual({ deduped: false, fired: true });
+    });
+
+    it('supports sync fire callback (void return)', async () => {
+      const fire = jest.fn().mockReturnValue(undefined);
+      const r = await fireAlarmOnce(basePayload, fire, 1_000);
+      expect(r).toEqual({ deduped: false, fired: true });
+      expect(fire).toHaveBeenCalledTimes(1);
+    });
+
+    it('sweeps expired entries when map exceeds cap (mixed fresh + expired)', async () => {
+      // FIRE_ONCE_MAP_CAP=256. cap+1 entry 삽입 시 sweep 진입.
+      // 절반은 매우 오래된 stamp(1_000) — sweep 통과해야 delete. 나머지는 fresh — 살아남아야 함.
+      // 두 분기(expired delete + fresh skip) 모두 커버.
+      const fire = jest.fn().mockResolvedValue(undefined);
+      const freshTs = 1_000 + FIRE_ONCE_WINDOW_MS * 2; // 만료 판정 기준 시각
+      // 첫 130개: 오래된 stamp — sweep 시 delete 대상.
+      for (let i = 0; i < 130; i++) {
+        await fireAlarmOnce(
+          { ...basePayload, stationName: `old-${i}` },
+          fire,
+          1_000, // stale ts
+        );
+      }
+      // 다음 130개: fresh stamp — sweep 시 살아남음.
+      for (let i = 0; i < 130; i++) {
+        await fireAlarmOnce(
+          { ...basePayload, stationName: `fresh-${i}` },
+          fire,
+          freshTs, // fresh ts
+        );
+      }
+      // fresh entry는 여전히 dedup 대상. old entry는 sweep으로 delete되어 다시 fire 가능.
+      const rFresh = await fireAlarmOnce(
+        { ...basePayload, stationName: 'fresh-0' },
+        fire,
+        freshTs + 100,
+      );
+      expect(rFresh).toEqual({ deduped: true, fired: false });
+      // old-0는 sweep으로 삭제 + fresh 시각에는 window 밖 → 다시 fire 가능.
+      const rOld = await fireAlarmOnce(
+        { ...basePayload, stationName: 'old-0' },
+        fire,
+        freshTs + 100,
+      );
+      expect(rOld).toEqual({ deduped: false, fired: true });
+    });
+  });
+
+  describe('_resetFireAlarmOnceForTests', () => {
+    it('clears ledger', async () => {
+      const fire1 = jest.fn().mockResolvedValue(undefined);
+      const fire2 = jest.fn().mockResolvedValue(undefined);
+      await fireAlarmOnce(basePayload, fire1, 1_000);
+      _resetFireAlarmOnceForTests();
+      const r = await fireAlarmOnce(basePayload, fire2, 1_010);
+      expect(r).toEqual({ deduped: false, fired: true });
+      expect(fire2).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -294,7 +294,12 @@ export type AlarmLogReason =
   // fired key를 유지해 새 trip의 첫 fire가 dedup으로 차단되거나 dump가 cross-trip carry-over로
   // 오염되던 회귀(2026-06-26 T4 dump에 T3 fired 2건 carry-over evidence). tripStartedAt 변경
   // detection을 기준으로 1회 적재 — 운영에서 trip 경계 reset 적중 횟수 측정.
-  | 'fired-alarms-trip-boundary-reset';
+  | 'fired-alarms-trip-boundary-reset'
+  // #1984 (Phase 1-4, ADR-022 B3) — client 채널 통합 fire ledger가 catch한 재발사 1건.
+  // Phase ETA + API imminent 두 useEffect가 같은 초에 동일 (station+line+kind+phase) 조합으로
+  // dispatch 시도한 케이스를 sync entry-guard로 차단. evidence: 2026-07-01 08:32:09 fg fired
+  // station-passed 성수 2건. SIMPLE_ARCH_ENABLED=true 상태에서만 발생 (flag OFF 시 dead code).
+  | 'dedup-simple-arch-fire-once';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -525,6 +530,34 @@ export function logSuppressedChannelAgnosticDedup(input: {
     source: input.source,
     outcome: 'suppressed',
     reason: 'dedup-channel-agnostic',
+    stationName: input.stationName,
+    kind: input.kind,
+    phaseId: input.phaseId,
+  });
+}
+
+/**
+ * #1984 (Phase 1-4, ADR-022 B3) — client 채널 통합 fire ledger 차단 1건 적재.
+ *
+ * 같은 (stationName, line, kind, phase) 조합이 FIRE_ONCE_WINDOW_MS(30s) 안에 이미 fire된 상태
+ * 에서 Phase ETA 또는 API imminent useEffect가 재발사를 시도한 case. sync entry-guard로 fire
+ * callback 실행 자체를 차단 — 사용자 체감 "같은 초 2건" 회귀 근본 차단.
+ *
+ * SIMPLE_ARCH_ENABLED=true(useStationAlarm) 상태에서만 발생. flag OFF 시 본 helper는 호출 X
+ * (dead code). burst dedup으로 같은 (source, stationName) 반복 로그는 1건만 적재.
+ */
+export function logSuppressedFireAlarmOnce(input: {
+  source: AlarmLogSource;
+  stationName: string;
+  kind: AlarmLogKind;
+  phaseId?: AlarmPhaseId;
+}): void {
+  if (isBurstDuplicate('dedup-simple-arch-fire-once', input.stationName)) return;
+  appendAlarmLog({
+    ts: Date.now(),
+    source: input.source,
+    outcome: 'suppressed',
+    reason: 'dedup-simple-arch-fire-once',
     stationName: input.stationName,
     kind: input.kind,
     phaseId: input.phaseId,

--- a/src/features/alarm/utils/fireAlarmOnce.ts
+++ b/src/features/alarm/utils/fireAlarmOnce.ts
@@ -1,0 +1,145 @@
+/**
+ * #1984 (Phase 1-4, ADR-022 B3) — Client 채널 통합 fire ledger.
+ *
+ * ## 문제 (2026-07-01 08:32:09 성수 evidence, #1980 코멘트 케이스 1)
+ * `useStationAlarm` 내부에 fg fire path 2개(Phase ETA + API imminent)가 같은 초에 동시 실행돼
+ * 사용자에게 같은 station 알람이 2번 노출되는 회귀. 기존 `fireAndLog` sync entry의
+ * `firedAlarmsRef.current.add(key)` (`${phaseId}:${stationName}`) 만으로는 phase가 다른 발사가
+ * 동일 station에 겹치는 경우(예: `early:성수` + `imminent:성수` 또는 두 effect가 다른 phase로
+ * dispatch)를 catch 못 함. 통합 dedup ledger가 station+line+kind+phase 조합으로 상위 backstop.
+ *
+ * ## 정책
+ * - **키**: `${stationName}|${line}|${kind}|${phase}` (기존 phaseId+stationName 보다 강화)
+ *   - `line`은 lock.boardingLine 우선 fallback nearestStation.line. null이면 문자열 `null`로 stringify
+ *     (환승역 무-노선 fire 케이스는 실무상 없음, 방어적 stringify).
+ * - **윈도우**: `FIRE_ONCE_WINDOW_MS = 30_000` — CROSS_CATEGORY dedup 윈도우와 동일. 같은 station+
+ *   phase 재발사가 사용자 체감 "같은 초 2건"의 root cause라 30s 안 재발사는 회귀로 본다. 정상 phase
+ *   진행(early → imminent)은 phase 필드가 달라 별도 키 → 통과.
+ * - **In-memory only**: AsyncStorage roundtrip race가 본 회귀 원인이라 의도적으로 storage 배제.
+ *   앱 재시작 시 reset되고 그 직후엔 hydration warmup(#1010/#1316)이 발사를 차단한다.
+ * - **flag guard**: 호출부(`useStationAlarm.ts`)의 `SIMPLE_ARCH_ENABLED` 상수 OFF 시 본 ledger는
+ *   dead code — 기존 fire 흐름이 그대로 동작 (backward-compat).
+ *
+ * ## API
+ * - `fireAlarmOnce(payload, fire)` — sync in-flight reservation → fire callback 실행 → 성공 시만
+ *   ledger 영구 stamp. fire 실패(throw/reject) 시 in-flight reservation 해제 → 다음 호출 재시도 가능.
+ *   반환값: `{ deduped: false, fired: true }` (실행) 또는 `{ deduped: true, fired: false }` (스킵).
+ * - `_resetFireAlarmOnceForTests()` — 테스트 전용 in-memory Map 리셋.
+ *
+ * ## Race 원자성 (Finding #2 review 반영)
+ * - **in-flight Set**: sync 진입 즉시 `inFlight.add(key)` — 같은 tick 재진입한 두 번째 호출은
+ *   즉시 dedup되도록. `ledger.set`은 fire 성공 후로 미룸.
+ * - **fire 실패**: catch에서 `inFlight.delete(key)` — reservation만 해제, ledger는 stamp 안 됨.
+ *   다음 호출은 정상 fire 재시도. transient failure(silence gate error / notification permission
+ *   race)에서 알람이 30s 동안 blackhole되는 회귀 차단.
+ * - **fire 성공**: `ledger.set(key, {ts})` + `inFlight.delete(key)` — 30s 재발사 차단으로 승격.
+ *
+ * ## 회귀 evidence
+ * - #1980 코멘트 케이스 1 (2026-07-01 08:32:09 성수 fg fired station-passed 2건)
+ * - ADR-022 B3 정책 (Device 채널 통합 fire path)
+ */
+
+import type { AlarmPhaseId } from './alarmPhases';
+import type { AlarmLogKind } from './alarmLog';
+import type { LineNumber } from '../../../shared/types/station';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('FireAlarmOnce');
+
+/** 같은 (station+line+kind+phase) 조합에 대한 재발사 차단 윈도우. */
+export const FIRE_ONCE_WINDOW_MS = 30_000;
+
+/** Map 무한 성장 cap. 정상 trip(역 수 ~수십) × phase 2종 × kind 3종 = 수백. cap 도달 시 만료 일괄 정리. */
+const FIRE_ONCE_MAP_CAP = 256;
+
+export interface FireAlarmOnceKeyInput {
+  stationName: string;
+  /** 라인 번호. null이면 문자열 `null`로 stringify — 방어적 처리(실무상 발생 X). */
+  line: LineNumber | null;
+  kind: AlarmLogKind;
+  phase: AlarmPhaseId;
+}
+
+export interface FireAlarmOnceResult {
+  /** true면 dedup 적중 — fire callback 미실행. false면 정상 fire. */
+  deduped: boolean;
+  /** true면 fire callback이 정상 실행됨. deduped와 상호 배타. */
+  fired: boolean;
+}
+
+interface LedgerRecord {
+  ts: number;
+}
+
+const ledger = new Map<string, LedgerRecord>();
+/**
+ * In-flight reservation Set. sync 진입 즉시 add — 같은 tick 재진입한 두 번째 호출을 즉시 catch.
+ * fire 성공 시 ledger로 승격 후 delete. fire 실패 시 delete만 — ledger 미stamp 상태로 다음 재시도 허용.
+ */
+const inFlight = new Set<string>();
+
+/**
+ * 키 생성 — station/line/kind/phase 조합. line은 문자열, phase/kind는 union 리터럴.
+ * 파이프(`|`) 구분자는 stationName에 등장하지 않는 문자(BLDN_NM 도메인 검증됨).
+ */
+export function makeFireAlarmOnceKey(input: FireAlarmOnceKeyInput): string {
+  const lineStr = input.line ?? 'null';
+  return `${input.stationName}|${lineStr}|${input.kind}|${input.phase}`;
+}
+
+function sweepExpired(now: number): void {
+  if (ledger.size <= FIRE_ONCE_MAP_CAP) return;
+  for (const [k, rec] of ledger) {
+    if (now - rec.ts >= FIRE_ONCE_WINDOW_MS) ledger.delete(k);
+  }
+}
+
+/**
+ * ledger + in-flight 확인 후 fire callback 실행.
+ *
+ * 원자성:
+ *   1. sync 진입 즉시 ledger(성공 stamp) 또는 inFlight(진행 중) 조회 → hit이면 즉시 dedup.
+ *   2. sync `inFlight.add(key)` — 같은 tick 재진입한 두 번째 호출을 즉시 catch (본 util의 핵심).
+ *   3. `await fire()` — 실제 알람 발사.
+ *   4-a. 성공: `ledger.set(key, {ts})` + `inFlight.delete(key)` → 30s 재발사 차단으로 승격.
+ *   4-b. 실패(throw/reject): `inFlight.delete(key)` + rethrow → ledger 미stamp, 다음 호출 재시도 허용.
+ *
+ * Finding #2 review 반영: 기존 구현은 ledger를 fire 전에 stamp해 fire 실패 시 30s 동안 알람이
+ * blackhole. 새 구현은 성공 시만 stamp — transient failure(silence gate error / notification
+ * permission race) 회복 가능.
+ */
+export async function fireAlarmOnce(
+  payload: FireAlarmOnceKeyInput,
+  fire: () => Promise<void> | void,
+  now: number = Date.now(),
+): Promise<FireAlarmOnceResult> {
+  const key = makeFireAlarmOnceKey(payload);
+  const rec = ledger.get(key);
+  if (rec !== undefined && now - rec.ts < FIRE_ONCE_WINDOW_MS) {
+    return { deduped: true, fired: false };
+  }
+  if (inFlight.has(key)) {
+    return { deduped: true, fired: false };
+  }
+  // sync reservation before await — 같은 tick 재진입한 두 번째 호출이 즉시 dedup되도록.
+  inFlight.add(key);
+  try {
+    await fire();
+    // 성공: ledger 승격 + reservation 해제. 30s 동안 재발사 차단.
+    ledger.set(key, { ts: now });
+    sweepExpired(now);
+    return { deduped: false, fired: true };
+  } catch (err) {
+    // 실패: reservation만 해제. ledger 미stamp → 다음 호출은 정상 재시도.
+    logger.error('fire failed, releasing in-flight reservation without ledger stamp', err);
+    throw err;
+  } finally {
+    inFlight.delete(key);
+  }
+}
+
+/** 테스트 전용 — 모듈 상태 리셋(ledger + inFlight). production 호출 금지. */
+export function _resetFireAlarmOnceForTests(): void {
+  ledger.clear();
+  inFlight.clear();
+}


### PR DESCRIPTION
Closes #1984

## Summary

- `useStationAlarm.ts` Phase ETA + API imminent 두 useEffect가 같은 초에 동일 (station+line+kind+phase) 조합으로 dispatch하는 회귀(2026-07-01 08:32:09 성수 fg fired station-passed 2건, #1980 코멘트 케이스 1) 차단
- 신규 `fireAlarmOnce` util — station+line+kind+phase 통합 dedup ledger + inFlight Set 2단 reservation (30s 윈도우)
- `simpleArchEnabled` flag (기본 `false`) 뒤에 wire — flag OFF 시 기존 흐름 유지 (backward-compat, staged rollout)

## Changes

| 파일 | 변경 |
|---|---|
| `src/features/alarm/utils/fireAlarmOnce.ts` (신규) | Unified fire ledger + fireAlarmOnce fn + in-flight reservation |
| `src/features/alarm/hooks/useStationAlarm.ts` | `simpleArchEnabled` flag + `fireViaUnifiedGate` 헬퍼 + Phase ETA/API imminent wire |
| `src/features/alarm/utils/alarmLog.ts` | `dedup-simple-arch-fire-once` reason + `logSuppressedFireAlarmOnce` helper |
| test files | fireAlarmOnce 21 unit + useStationAlarm 5 integration + alarmLog 2 helper |

## Code Review 반영 (medium effort, 4 findings)

### Finding #2 (critical, fix 적용)
`fireAlarmOnce.ts:100` `ledger.set` 이 `await fire()` 전에 stamp됐음 → fire 실패 시 30초간 알림 blackhole.

**Fix**: `ledger.set`을 fire 성공 후로 이동. `inFlight` Set 도입해 sync entry-guard(same-tick race 차단) 유지. 실패 시 `inFlight.delete`만 하고 ledger 미stamp → 다음 호출 재시도 허용.

테스트 추가:
- fire rejection 후 다음 호출 재시도 통과
- 두 번 실패 후 세 번째 성공 정상 fire (회복 시나리오)
- in-flight reservation이 fire 실행 중 재진입 catch

### Finding #4 (minor, fix 적용)
`useStationAlarm.ts:110` `__setSimpleArchEnabledForTests` production 오호출 방지.

**Fix**: `if (process.env.NODE_ENV === 'production') throw new Error(...)` guard 추가. jest는 `NODE_ENV='test'`라 통과, prod bundle 우발 호출 차단.

### Finding #1 (트레이드오프, fix 안 함)
`resolveCurrentLine(currentLockLine, nearestStation)`이 cold start 시 `line=null` 반환 가능 → 같은 초 Phase ETA (line=null) + API imminent (line='2') dispatch 시 ledger 키가 달라 dedup miss.

**결정**: fix 안 함. **근거**:
- 기존 `firedAlarmsRef.current.has(imminentKey)` early-return (line 1225)이 primary dedup 담당
- `fireAlarmOnce` ledger는 secondary backstop — firedAlarmsRef가 놓치는 destination-boundary race / hydration mismatch 시나리오 커버
- cold start(nearestStation null → 값) 시나리오는 hydration warmup(#1010/#1316)이 이미 발사 차단
- line 축을 dedup 키에서 제거하면 환승역 line 분기 fire(같은 stationName 다른 line, 정상 동작) 오차단 위험

### Finding #3 (트레이드오프, fix 안 함)
`sweepExpired`는 `ledger.size > FIRE_ONCE_MAP_CAP(256)` 조건에서만 iterate. cap 이하일 때 no-op → burst 시 window 내 unbounded 성장 가능.

**결정**: fix 안 함. **근거**:
- 정상 trip 다양성(~수십 역 × 3 kind × 2 phase) × 30s 윈도우 = 자연 bounded (실측 ~수백 entry max)
- 30s 후 sweep 진입 시 만료 일괄 정리 — 실효 상한 존재
- cap 이하 강제 sweep 시 매 호출마다 iterate → hot-path 낭비

## Wire-completion 5단

1. **Orphan 없음** — `fireAlarmOnce` / `logSuppressedFireAlarmOnce` / `__setSimpleArchEnabledForTests` 모두 `useStationAlarm.ts` 또는 test에서 import. `npm run lint:orphan` pass.
2. **V/X dashboard** — `dedup-simple-arch-fire-once` alarmLog reason으로 DebugModal Gates 섹션 자동 집계 + `countAlarmLogReasonsByWindow`로 backend `alarmLogStats` API에 노출.
3. **의존 PR** — N/A (독립 flag-gated PR)
4. **측정 plan** — flag OFF 상태 머지, 후속 이슈에서 flag ON 실기기 검증 시 alarmLog `outcome='fired'` + `kind='station-passed'` 같은 초 2건 이상 0건 확인. `logSuppressedFireAlarmOnce` 카운트 = ledger가 catch한 회귀 backstop.
5. **Device verify** — N/A (flag OFF PR은 type+unit only, code path 미변경). flag ON 이후 실기기 회귀 검증은 별도 이슈.

## Test plan

- [x] `npm test` PASS (8822 tests, 100% coverage, threshold 통과)
- [x] `npm run type-check` clean
- [x] `fireAlarmOnce` unit: 21 tests (key/ledger/inFlight/sweep/race/failure recovery)
- [x] `useStationAlarm` integration: 5 tests (flag OFF backward-compat / flag ON single fire / ledger dedup / phase progression / line=null 방어)
- [x] `alarmLog` helper: 2 tests (reason 보존 / burst dedup)
- [ ] 실기기 검증 — flag OFF 상태 머지, flag ON 전환 시 별도 이슈