### PR TITLE
chore(#1994): Phase 1-9 UI 현재역 탭 역이름 textSize 축소

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1160,8 +1160,21 @@ export default function HomeScreen() {
                   : t('home.originNearest')}
               </Text>
               <View style={styles.heroRow}>
+                {/* #1994 Phase 1-9 — hero fontSize 44 → 36으로 축소 (사용자 관찰: 위 잘림).
+                    lineHeight를 fontSize보다 크게(36 * 1.1) 잡아 상단 clip 방지. 전역
+                    typography.hero 토큰은 AlarmOverlay/OnboardingSplashBase에서도 쓰이므로
+                    본 사용처만 인라인 override로 국한. */}
                 <Text
-                  style={[typography.hero, { color: colors.ink, flex: 1, fontWeight: '900' }]}
+                  style={[
+                    typography.hero,
+                    {
+                      color: colors.ink,
+                      flex: 1,
+                      fontWeight: '900',
+                      fontSize: 36,
+                      lineHeight: 36 * 1.1,
+                    },
+                  ]}
                   testID="home-origin-station-name"
                 >
                   {getStationDisplayName(effectiveOrigin)}


### PR DESCRIPTION
Closes #1994

## Summary

ADR-022(#1980) Phase 1-9 A5/B5 — 사용자 관찰 "현재역 텍스트 위쪽 잘림" 시각 fix.

`src/screens/HomeScreen.tsx` 홈 hero station name Text에 인라인 스타일 override로 `fontSize` 축소 + `lineHeight` 확장:

| 항목 | before | after | 근거 |
|---|---|---|---|
| `fontSize` | 44 | **36** | 사용자 관찰 (긴 역명 상단 clip). ~-18% 축소로 layout 안정 |
| `lineHeight` | `44 * 0.95 = 41.8` (< fontSize) | **`36 * 1.1 = 39.6` (> fontSize)** | lineHeight < fontSize 조합이 위 잘림 원인. iOS `900` 가중치 폰트에서 특히 상단 baseline 여백 부족 |

전역 `typography.hero` 토큰은 미변경 — 다른 사용처(`AlarmOverlay.tsx:111`, `OnboardingSplashBase.tsx:39`) 회귀 방지 (isolation).

## Test plan

- [x] `npm run type-check` clean
- [x] `npm test` — 419 suite / 8881 test PASS, coverage 100% 유지
- [x] `npm run lint:orphan` — No orphan exports
- [x] `src/shared/theme/__tests__/theme.test.ts` — `typography.hero` 토큰 assertion 유지 (변경 없음)
- [ ] Device verify — 사용자 실기기에서 홈 hero 영역 시각 확인 (긴 역명 포함, 라이트/다크 모두)

## Wire-completion 5단

1. **Orphan 없음** — 신규 export 없음. `npm run lint:orphan` pass
2. **V/X dashboard** — N/A (UI 스타일 override만)
3. **의존 PR** — N/A
4. **측정 plan** — 사용자 실기기 시각 확인 (긴 역명 e.g. "이수(총신대입구)" 렌더링 시 상단 clip 재발 0건)
5. **Device verify** — 필요. 홈 hero 영역 육안 확인. code-only 회귀 위험 낮음(스타일만)

## 변경 파일

- `src/screens/HomeScreen.tsx` (+14 -1) — hero Text 인라인 스타일 override