### PR TITLE
fix(#1996): Phase 1-7 client boardingStationId 불변 (auto-swap/reanchored 금지)

### DIFF
--- a/src/features/alarm/store/__tests__/useBoardingLockStore.test.ts
+++ b/src/features/alarm/store/__tests__/useBoardingLockStore.test.ts
@@ -193,4 +193,158 @@ describe('useBoardingLockStore', () => {
       expect(expired).toBe(true);
     });
   });
+
+  /**
+   * Phase 1-7 (#1996, ADR-022 A4) — boardingStationId 불변 정책.
+   *
+   * `isSimpleArchEnabled()` flag OFF (default): 어떤 createLock이든 기존 lock 교체 (기존 동작).
+   * `isSimpleArchEnabled()` flag ON: 동일 destination/trainCode/boardingLine인데 boardingStationId만
+   *   다른 createLock은 auto-swap 시도로 간주 → skip. 정당한 route 재등록(trainCode/boardingLine 변경)은 통과.
+   */
+  describe('#1996 — boardingStationId 불변 (arch flag)', () => {
+    // real `isSimpleArchEnabled()` wire — env var로 flag 게이트.
+    const ENV_KEY = 'EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH';
+    const originalEnv = process.env[ENV_KEY];
+    afterEach(() => {
+      if (originalEnv === undefined) delete process.env[ENV_KEY];
+      else process.env[ENV_KEY] = originalEnv;
+    });
+
+    describe('flag OFF (기존 동작 보존)', () => {
+      beforeEach(() => {
+        delete process.env[ENV_KEY];
+      });
+
+      it('boardingStationId만 다른 createLock도 기존 lock을 교체한다', async () => {
+        await act(async () => {
+          await useBoardingLockStore.getState().createLock(sample);
+        });
+        const swapped: BoardingLock = { ...sample, boardingStationId: 'stn-DIFFERENT' };
+        await act(async () => {
+          await useBoardingLockStore.getState().createLock(swapped);
+        });
+        // flag OFF → 기존 동작 (교체 발생).
+        expect(useBoardingLockStore.getState().lock).toEqual(swapped);
+        expect(mockSetBoardingLock).toHaveBeenLastCalledWith(swapped);
+      });
+    });
+
+    describe('flag ON (immutability guard)', () => {
+      beforeEach(() => {
+        process.env[ENV_KEY] = 'true';
+      });
+
+      it('동일 destination/trainCode/boardingLine에서 boardingStationId만 다른 createLock은 skip한다', async () => {
+        await act(async () => {
+          await useBoardingLockStore.getState().createLock(sample);
+        });
+        mockSetBoardingLock.mockClear();
+        mockAddDomainBreadcrumb.mockClear();
+
+        const attemptedSwap: BoardingLock = { ...sample, boardingStationId: 'stn-DIFFERENT' };
+        await act(async () => {
+          await useBoardingLockStore.getState().createLock(attemptedSwap);
+        });
+
+        // 기존 lock은 그대로 유지, storage write 없음.
+        expect(useBoardingLockStore.getState().lock).toEqual(sample);
+        expect(useBoardingLockStore.getState().lock?.boardingStationId).toBe('stn-A');
+        expect(mockSetBoardingLock).not.toHaveBeenCalled();
+
+        // skip 이벤트 breadcrumb stamp.
+        expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('boarding', 'lock-create-skip-immutable', {
+          trainCode: sample.trainCode,
+          line: sample.boardingLine,
+          prevBoardingStationId: 'stn-A',
+          attemptedBoardingStationId: 'stn-DIFFERENT',
+        });
+      });
+
+      it('trainCode 변경(정당한 환승 leg)은 boardingStationId 변경을 허용한다', async () => {
+        await act(async () => {
+          await useBoardingLockStore.getState().createLock(sample);
+        });
+        const legitimateTransfer: BoardingLock = {
+          ...sample,
+          trainCode: 'T-999', // 새 열차 = 정당한 route 재등록.
+          boardingStationId: 'stn-TRANSFER',
+        };
+        await act(async () => {
+          await useBoardingLockStore.getState().createLock(legitimateTransfer);
+        });
+        expect(useBoardingLockStore.getState().lock).toEqual(legitimateTransfer);
+      });
+
+      it('boardingLine 변경(다른 노선 leg)은 boardingStationId 변경을 허용한다', async () => {
+        await act(async () => {
+          await useBoardingLockStore.getState().createLock(sample);
+        });
+        const transferLeg: BoardingLock = {
+          ...sample,
+          boardingLine: '7', // sample.boardingLine === '2' → 노선 변경.
+          boardingStationId: 'stn-TRANSFER',
+        };
+        await act(async () => {
+          await useBoardingLockStore.getState().createLock(transferLeg);
+        });
+        expect(useBoardingLockStore.getState().lock).toEqual(transferLeg);
+      });
+
+      it('destinationId 변경(다른 trip)은 boardingStationId 변경을 허용한다', async () => {
+        await act(async () => {
+          await useBoardingLockStore.getState().createLock(sample);
+        });
+        const differentTrip: BoardingLock = {
+          ...sample,
+          destinationId: 'dest-DIFFERENT',
+          boardingStationId: 'stn-DIFFERENT',
+        };
+        await act(async () => {
+          await useBoardingLockStore.getState().createLock(differentTrip);
+        });
+        expect(useBoardingLockStore.getState().lock).toEqual(differentTrip);
+      });
+
+      it('boardingStationId가 동일하면 다른 필드 갱신 시 정상 교체', async () => {
+        await act(async () => {
+          await useBoardingLockStore.getState().createLock(sample);
+        });
+        // 같은 leg 안에서 expectedDurationMs 등 다른 필드 갱신은 정당한 use case.
+        const sameStationUpdate: BoardingLock = { ...sample, expectedDurationMs: 999_999 };
+        await act(async () => {
+          await useBoardingLockStore.getState().createLock(sameStationUpdate);
+        });
+        expect(useBoardingLockStore.getState().lock).toEqual(sameStationUpdate);
+      });
+
+      it('첫 lock 생성(기존 lock 없음)은 정상 처리', async () => {
+        // lock=null 상태에서 createLock — 비교 대상이 없으므로 정책 우회 + 정상 생성.
+        await act(async () => {
+          await useBoardingLockStore.getState().createLock(sample);
+        });
+        expect(useBoardingLockStore.getState().lock).toEqual(sample);
+      });
+
+      it('다수 tick 동안 auto-swap 시도해도 boardingStationId 변경 시도 0건', async () => {
+        await act(async () => {
+          await useBoardingLockStore.getState().createLock(sample);
+        });
+        mockSetBoardingLock.mockClear();
+
+        // 여러 사이클에서 auto-swap 시도 (같은 leg + 다른 boardingStationId).
+        const swapAttempts = ['stn-X1', 'stn-X2', 'stn-X3', 'stn-X4', 'stn-X5'];
+        for (const stnId of swapAttempts) {
+          await act(async () => {
+            await useBoardingLockStore
+              .getState()
+              .createLock({ ...sample, boardingStationId: stnId });
+          });
+        }
+
+        // 원본 유지 + storage write 0건.
+        expect(useBoardingLockStore.getState().lock?.boardingStationId).toBe('stn-A');
+        expect(mockSetBoardingLock).not.toHaveBeenCalled();
+      });
+    });
+  });
 });

--- a/src/features/alarm/store/useBoardingLockStore.ts
+++ b/src/features/alarm/store/useBoardingLockStore.ts
@@ -8,6 +8,7 @@ import {
 } from '../utils/boardingLockStorage';
 import { clearDismissSilence } from '../utils/dismissSilenceStorage';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
+import { isSimpleArchEnabled } from '../../../shared/config/archFlag';
 
 /**
  * #1438 (E5) — release 사유 식별자.
@@ -59,6 +60,39 @@ export const useBoardingLockStore = create<BoardingLockState>((set, get) => ({
   lock: null,
 
   createLock: async (lock: BoardingLock) => {
+    // #1996 (Phase 1-7, ADR-022 A4) — boardingStationId 불변 정책 (flag ON 시).
+    //
+    // route 등록 시 확정된 boardingStationId는 절대 자동 변경 금지 (auto-swap / reanchored /
+    // fusion cascade 금지). 예외는 정당한 route 재등록:
+    //   1) trainCode 변경 (환승 leg 진입 → 새 열차 = 사실상 새 route)
+    //   2) boardingLine 변경 (환승 → 다른 노선 leg 진입)
+    //   3) destinationId 변경 (다른 trip)
+    // 위 3가지가 모두 동일한데 boardingStationId만 다른 createLock은 auto-swap 시도로 간주 → skip.
+    //
+    // Flag OFF (default) 시 기존 동작 유지 — 어떤 createLock이든 기존 lock을 교체.
+    // Flag ON 시 위 정책을 강제해 회귀 방어.
+    if (isSimpleArchEnabled()) {
+      const prev = get().lock;
+      if (
+        prev &&
+        prev.destinationId === lock.destinationId &&
+        prev.trainCode === lock.trainCode &&
+        prev.boardingLine === lock.boardingLine &&
+        prev.boardingStationId !== lock.boardingStationId
+      ) {
+        // 동일 route/leg에서 boardingStationId만 다른 lock 재생성 시도 → auto-swap 차단.
+        // 사용자 명시 route 재등록은 (trainCode 또는 boardingLine 변경)으로 감지되므로 정당한
+        // 환승/재탑승 경로는 그대로 통과. 본 분기는 순수 "같은 leg 안에서 boardingStationId만
+        // silently overwrite" 회귀 만 차단한다.
+        addDomainBreadcrumb('boarding', 'lock-create-skip-immutable', {
+          trainCode: lock.trainCode,
+          line: lock.boardingLine,
+          prevBoardingStationId: prev.boardingStationId,
+          attemptedBoardingStationId: lock.boardingStationId,
+        });
+        return;
+      }
+    }
     set({ lock });
     await setBoardingLock(lock);
     // #746: 새 lock 생성 = 사용자가 새 leg에 탑승 의사 명시 → 이전 dismiss silence는 무효.

--- a/src/features/route/utils/__tests__/stationProgressEstimator.test.ts
+++ b/src/features/route/utils/__tests__/stationProgressEstimator.test.ts
@@ -975,3 +975,118 @@ describe('arcIndexOfStation', () => {
     ).toBe(-1);
   });
 });
+
+/**
+ * Phase 1-7 (#1996, ADR-022 A4) — boardingStationId 불변 회귀 가드.
+ *
+ * estimator는 arc 위 hop index만 계산한다. reanchored-hop / default-hop / arrival-eta /
+ * lockless-route-hop 등 모든 strategy가 `lock.boardingStationId` 자체를 mutate하지 않아야 한다
+ * (route 등록 시 확정된 boardingStationId는 auto-swap / reanchored / fusion cascade에서 절대 자동 변경 금지).
+ *
+ * 회귀 신호: 사용자 관찰 `reanchored-hop | 어린이대공원 idx=3` (Estimator State) —
+ * 정상은 lock.boardingStationId 유지 + arc 위 idx=3 station을 return. 만약 미래 어떤 refactor에서
+ * estimator가 lock 객체를 직접 mutate하거나 새 boardingStationId를 담은 lock 객체를 wrap해 반환하면 본 test가 실패.
+ */
+describe('Phase 1-7 (#1996) — boardingStationId 불변 (estimator)', () => {
+  it('reanchored-hop 전략은 lock.boardingStationId를 mutate하지 않는다', () => {
+    const lock = makeLock({ boardingStationId: '7-001' });
+    const originalBoardingStationId = lock.boardingStationId;
+    const observedAt = T0 + 200_000;
+
+    // reanchored-hop 채택 조건: lastObserved 있음 + hop 진행.
+    const r = estimateStationProgress({
+      lock,
+      arcStations: ARC,
+      now: observedAt + 3 * HOP_TIME_MS,
+      trainProgress: null,
+      lockedTrainCode: '7093',
+      lastObserved: { arcIndex: 1, observedAtMs: observedAt },
+      hopTimeMsForHop: UNIFORM_HOP,
+      ...NO_ARRIVAL_INPUT,
+    });
+
+    // estimator는 arc 위 앞 station으로 hop 진행 결과를 return.
+    expect(r?.strategy).toBe('reanchored-hop');
+    expect(r?.index).toBe(4); // idx 1 + 3 hop
+    expect(r?.station).toBe(ARC[4]);
+
+    // 핵심: lock 객체 자체는 어떤 필드도 변경되지 않아야 한다.
+    expect(lock.boardingStationId).toBe(originalBoardingStationId);
+    expect(lock.boardingStationId).toBe('7-001');
+  });
+
+  it('default-hop 전략은 lock.boardingStationId를 mutate하지 않는다', () => {
+    const lock = makeLock({ boardingStationId: '7-001' });
+    const originalBoardingStationId = lock.boardingStationId;
+
+    // default-hop 채택 조건: lastObserved 없음.
+    const r = estimateStationProgress({
+      lock,
+      arcStations: ARC,
+      now: T0 + HOP_TIME_MS,
+      trainProgress: null,
+      lockedTrainCode: '7093',
+      lastObserved: null,
+      hopTimeMsForHop: UNIFORM_HOP,
+      ...NO_ARRIVAL_INPUT,
+    });
+
+    expect(r?.strategy).toBe('default-hop');
+    expect(r?.index).toBe(1);
+    // lock 객체 immutable.
+    expect(lock.boardingStationId).toBe(originalBoardingStationId);
+  });
+
+  it('live-position 전략은 lock.boardingStationId를 mutate하지 않는다', () => {
+    const lock = makeLock({ boardingStationId: '7-001' });
+    const originalBoardingStationId = lock.boardingStationId;
+
+    // live-position 채택 조건: trainProgress + lockedTrainCode 매칭.
+    const r = estimateStationProgress({
+      lock,
+      arcStations: ARC,
+      now: T0 + HOP_TIME_MS,
+      trainProgress: makeTrainProgress({ stationIdx: 2 }),
+      lockedTrainCode: '7093',
+      lastObserved: null,
+      hopTimeMsForHop: UNIFORM_HOP,
+      ...NO_ARRIVAL_INPUT,
+    });
+
+    expect(r?.strategy).toBe('live-position');
+    expect(r?.index).toBe(2);
+    // lock 객체 immutable.
+    expect(lock.boardingStationId).toBe(originalBoardingStationId);
+  });
+
+  it('estimator 다수 tick 반복해도 lock 원본 객체가 mutate되지 않는다 (frozen 동작)', () => {
+    const lock = makeLock({ boardingStationId: '7-001' });
+    // Object.freeze로 실제 write attempt 시 strict mode에서 throw — estimator가 write 시도 자체를 하지 않음을 강제.
+    Object.freeze(lock);
+
+    // 다양한 시점의 tick을 반복 — reanchored-hop / default-hop / live-position 모두 순회.
+    const inputs = [
+      { now: T0, lastObserved: null, trainProgress: null },
+      { now: T0 + HOP_TIME_MS, lastObserved: null, trainProgress: null },
+      { now: T0 + 2 * HOP_TIME_MS, lastObserved: { arcIndex: 0, observedAtMs: T0 }, trainProgress: null },
+      { now: T0 + 3 * HOP_TIME_MS, lastObserved: { arcIndex: 1, observedAtMs: T0 }, trainProgress: null },
+      { now: T0 + HOP_TIME_MS, lastObserved: null, trainProgress: makeTrainProgress({ stationIdx: 3 }) },
+    ];
+
+    // 각 tick에서 exception 없이 estimator가 결과를 return + lock은 여전히 원본 boardingStationId 유지.
+    expect(() => {
+      for (const input of inputs) {
+        estimateStationProgress({
+          lock,
+          arcStations: ARC,
+          hopTimeMsForHop: UNIFORM_HOP,
+          lockedTrainCode: '7093',
+          ...NO_ARRIVAL_INPUT,
+          ...input,
+        });
+      }
+    }).not.toThrow();
+
+    expect(lock.boardingStationId).toBe('7-001');
+  });
+});


### PR DESCRIPTION
Closes #1996

## 배경

사용자 관찰(fusion Estimator State): `reanchored-hop | 어린이대공원 idx=3` 등 나타남 → `reanchored-hop` 로직이 `boardingStationId` 자체를 변경할 가능성 우려.

**정책**: route 등록 시 확정된 `boardingStationId`는 절대 자동 변경 금지 (auto-swap / reanchored / fusion cascade 금지).

## 조사 결과

`boardingStationId` mutation 경로 grep 결과:

| 위치 | 판정 |
|---|---|
| `stationProgressEstimator.ts` — `reanchored-hop` / `default-hop` / `live-position` / `arrival-eta` / `lockless-route-hop` | **safe** — hop index만 계산, `lock.boardingStationId` 읽기만 |
| `useFusedNearestStation.ts` | **safe** — fusion result의 station override는 display 전용, lock 자체 read-only |
| `useBoardingLockStore.createLock` | 유일한 mutation entry — 여기에 flag-guarded 정책 추가 |
| `useBoardingLockController` (5개 auto-lock 경로) | 모두 `if (lock) return` idempotent guard로 기존 lock 보호 |
| `useTransferTrainList.createTransferLock` | 정당한 route 재등록 (환승 waypoint 도달) |
| `backgroundTransferSwap` | client store에 직접 write X, backend sync만 |

**결론**: 현재 코드에 `boardingStationId` in-place auto-mutate 경로는 없음. 사용자 관찰 `reanchored-hop | 어린이대공원 idx=3`은 정상 동작 — lock.boardingStationId 유지 + arc 위 hop index 진행.

## 변경 사항

### 1) store `createLock` 정책 (`useBoardingLockStore.ts`)

`isSimpleArchEnabled()` flag ON 시: 동일 `destinationId`/`trainCode`/`boardingLine`에서 `boardingStationId`만 다른 `createLock`은 auto-swap 시도로 간주 → skip + `lock-create-skip-immutable` breadcrumb stamp.

정당한 route 재등록 (trainCode 변경 = 환승 leg / boardingLine 변경 = 다른 노선 leg / destinationId 변경 = 다른 trip)은 그대로 통과.

flag OFF (default): 기존 동작 100% 유지 → 회귀 0.

### 2) regression test

- `stationProgressEstimator.test.ts` — reanchored-hop / default-hop / live-position 각 strategy가 lock.boardingStationId를 mutate하지 않음 + `Object.freeze(lock)` 다수 tick 반복해도 throw 없음
- `useBoardingLockStore.test.ts` — flag OFF/ON 두 경로 커버 (skip 시나리오 + 3가지 정당한 재등록 통과 + 다수 auto-swap 시도 storage write 0건)

## Acceptance 매핑

- [x] reanchored-hop 로직 조사 결과 (boardingStationId 변경 여부) — **변경 X** (hop index만 계산)
- [x] boardingStationId 자동 변경 코드 경로 삭제/차단 + test — store guard + 회귀 test
- [x] hopIndex/currentStation 등 다른 필드는 계속 update — 기존 동작 유지 (기존 test 그대로 pass)
- [x] real `isSimpleArchEnabled()` wire — `EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH` env
- [x] flag OFF 시 기존 동작 유지 — test 커버
- [x] flag ON 시 boardingStationId 변경 시도 0건 — test 커버 (다수 tick auto-swap 시도 storage write 0건)
- [x] client test 100% coverage — `npm test` PASS

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass
2. **V/X dashboard** — flag ON skip 시 `lock-create-skip-immutable` domain breadcrumb → Sentry에서 관측 가능
3. **의존 PR** — N/A (client only, flag OFF default라 배포 즉시 영향 X)
4. **측정 plan** — flag rollout 후 Sentry `lock-create-skip-immutable` breadcrumb 카운트 관찰 (기대값: 0, 발생 시 auto-swap 회귀 신호)
5. **Device verify** — N/A — type+unit only, flag OFF default라 device 동작 변경 없음. flag ON rollout 시점에 별도 실기기 회귀 검증 필요

## Follow-up 후보 (별도 이슈)

- `useBoardingLockController.createLockFromTrain`의 `.then(() => Haptics.Success)`는 store가 skip해도 fire — flag ON rollout 시점에 사용자 피드백 정합성 필요할 수 있음. 다만 skip 시나리오 자체가 매우 좁고 (dest/train/line 모두 같은데 boardingStationId만 다른 사용자 명시 탭 = fusion drift edge case) 정책 목표와 정합하므로 rollout 관찰 후 결정.