### PR TITLE
fix(#1995): Phase 1-2 backend retry-push destination 알림만 유지

### DIFF
--- a/backend/alarm-worker/src/__tests__/pendingPushes.test.ts
+++ b/backend/alarm-worker/src/__tests__/pendingPushes.test.ts
@@ -11,6 +11,7 @@ import {
   receivedKey,
   RECEIVED_TTL_SEC,
   removePending,
+  shouldRegisterPendingForKind,
   stampReceived,
   type PendingPush,
 } from '../pendingPushes';
@@ -80,6 +81,78 @@ describe('pendingPushes (#566 P2a)', () => {
       const ttlMs = sentRaw!.expiresAt! - Date.now();
       expect(ttlMs).toBeGreaterThan(4 * 60 * 1000);
       expect(ttlMs).toBeLessThanOrEqual(5 * 60 * 1000);
+    });
+
+    describe('#1995 (ADR-022 Phase 1-2) — archFlag kind 필터', () => {
+      it('archFlag 미전달 (legacy caller) → 기존 동작 유지, 모든 kind 등록', async () => {
+        await putPending(kv as unknown as KVNamespace, makeEntry({ pushId: 'p-legacy-tr', kind: 'transfer' }));
+        await putPending(kv as unknown as KVNamespace, makeEntry({ pushId: 'p-legacy-im', kind: 'intermediate' }));
+        await putPending(kv as unknown as KVNamespace, makeEntry({ pushId: 'p-legacy-de', kind: 'destination' }));
+        expect(kv.store.has('pending:p-legacy-tr')).toBe(true);
+        expect(kv.store.has('pending:p-legacy-im')).toBe(true);
+        expect(kv.store.has('pending:p-legacy-de')).toBe(true);
+      });
+
+      it('archFlag=off (default) → 모든 kind 등록 (기존 동작 유지)', async () => {
+        await putPending(kv as unknown as KVNamespace, makeEntry({ pushId: 'p-off-tr', kind: 'transfer' }), 'off');
+        await putPending(kv as unknown as KVNamespace, makeEntry({ pushId: 'p-off-im', kind: 'intermediate' }), 'off');
+        await putPending(kv as unknown as KVNamespace, makeEntry({ pushId: 'p-off-de', kind: 'destination' }), 'off');
+        expect(kv.store.has('pending:p-off-tr')).toBe(true);
+        expect(kv.store.has('pending:p-off-im')).toBe(true);
+        expect(kv.store.has('pending:p-off-de')).toBe(true);
+      });
+
+      it('archFlag=on + kind=destination → 등록 (사용자 가치 유지)', async () => {
+        await putPending(
+          kv as unknown as KVNamespace,
+          makeEntry({ pushId: 'p-on-de', kind: 'destination' }),
+          'on',
+        );
+        expect(kv.store.has('pending:p-on-de')).toBe(true);
+        // #1958 sent stamp 도 동반 적재.
+        expect(kv.store.has('sent:p-on-de')).toBe(true);
+      });
+
+      it('archFlag=on + kind=transfer → skip (반복 알림 case 4 fix)', async () => {
+        await putPending(
+          kv as unknown as KVNamespace,
+          makeEntry({ pushId: 'p-on-tr', kind: 'transfer' }),
+          'on',
+        );
+        expect(kv.store.has('pending:p-on-tr')).toBe(false);
+        // sent stamp 도 등록되지 않음 (pending 자체가 skip).
+        expect(kv.store.has('sent:p-on-tr')).toBe(false);
+      });
+
+      it('archFlag=on + kind=intermediate → skip (반복 알림 case 4 fix)', async () => {
+        await putPending(
+          kv as unknown as KVNamespace,
+          makeEntry({ pushId: 'p-on-im', kind: 'intermediate' }),
+          'on',
+        );
+        expect(kv.store.has('pending:p-on-im')).toBe(false);
+        expect(kv.store.has('sent:p-on-im')).toBe(false);
+      });
+    });
+  });
+
+  describe('#1995 shouldRegisterPendingForKind', () => {
+    it('archFlag=undefined (legacy) → true (모든 kind)', () => {
+      expect(shouldRegisterPendingForKind(undefined, 'transfer')).toBe(true);
+      expect(shouldRegisterPendingForKind(undefined, 'intermediate')).toBe(true);
+      expect(shouldRegisterPendingForKind(undefined, 'destination')).toBe(true);
+    });
+
+    it('archFlag=off → true (모든 kind)', () => {
+      expect(shouldRegisterPendingForKind('off', 'transfer')).toBe(true);
+      expect(shouldRegisterPendingForKind('off', 'intermediate')).toBe(true);
+      expect(shouldRegisterPendingForKind('off', 'destination')).toBe(true);
+    });
+
+    it('archFlag=on → destination 만 true', () => {
+      expect(shouldRegisterPendingForKind('on', 'transfer')).toBe(false);
+      expect(shouldRegisterPendingForKind('on', 'intermediate')).toBe(false);
+      expect(shouldRegisterPendingForKind('on', 'destination')).toBe(true);
     });
   });
 

--- a/backend/alarm-worker/src/__tests__/retryPushes.test.ts
+++ b/backend/alarm-worker/src/__tests__/retryPushes.test.ts
@@ -8,6 +8,7 @@ import {
   retryPushKey,
   RETRY_PUSH_TTL_SEC,
   runRetryPushes,
+  shouldRetryForKind,
   type RetryPush,
 } from '../retryPushes';
 import { RETRY_BACKOFF_SCHEDULE_MS } from '../apnsHost';
@@ -219,6 +220,147 @@ describe('retryPushes (#1721)', () => {
       });
       const entry = JSON.parse((await kv.get('retry-push:p-no-reason')) as string) as RetryPush;
       expect('lastErrorReason' in entry).toBe(false);
+    });
+
+    describe('#1995 (ADR-022 Phase 1-2) — archFlag kind 필터', () => {
+      it('archFlag 미전달 (legacy) → 모든 kind 적재', async () => {
+        const q1 = await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+          pushId: 'p-legacy-tr',
+          token: 'tok',
+          payload: makePayload({ pushId: 'p-legacy-tr', kind: 'transfer' }),
+          apnsEnv: 'sandbox',
+          status: 429,
+          now: NOW,
+        });
+        const q2 = await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+          pushId: 'p-legacy-im',
+          token: 'tok',
+          payload: makePayload({ pushId: 'p-legacy-im', kind: 'intermediate' }),
+          apnsEnv: 'sandbox',
+          status: 429,
+          now: NOW,
+        });
+        const q3 = await enqueueRetryIfTransient(kv as unknown as KVNamespace, {
+          pushId: 'p-legacy-de',
+          token: 'tok',
+          payload: makePayload({ pushId: 'p-legacy-de', kind: 'destination' }),
+          apnsEnv: 'sandbox',
+          status: 429,
+          now: NOW,
+        });
+        expect([q1, q2, q3]).toEqual([true, true, true]);
+      });
+
+      it('archFlag=off (default) → 모든 kind 적재 (기존 동작 유지)', async () => {
+        const q1 = await enqueueRetryIfTransient(
+          kv as unknown as KVNamespace,
+          {
+            pushId: 'p-off-tr',
+            token: 'tok',
+            payload: makePayload({ pushId: 'p-off-tr', kind: 'transfer' }),
+            apnsEnv: 'sandbox',
+            status: 429,
+            now: NOW,
+          },
+          'off',
+        );
+        const q2 = await enqueueRetryIfTransient(
+          kv as unknown as KVNamespace,
+          {
+            pushId: 'p-off-im',
+            token: 'tok',
+            payload: makePayload({ pushId: 'p-off-im', kind: 'intermediate' }),
+            apnsEnv: 'sandbox',
+            status: 429,
+            now: NOW,
+          },
+          'off',
+        );
+        const q3 = await enqueueRetryIfTransient(
+          kv as unknown as KVNamespace,
+          {
+            pushId: 'p-off-de',
+            token: 'tok',
+            payload: makePayload({ pushId: 'p-off-de', kind: 'destination' }),
+            apnsEnv: 'sandbox',
+            status: 429,
+            now: NOW,
+          },
+          'off',
+        );
+        expect([q1, q2, q3]).toEqual([true, true, true]);
+      });
+
+      it('archFlag=on + kind=destination → 적재 (사용자 가치 유지)', async () => {
+        const queued = await enqueueRetryIfTransient(
+          kv as unknown as KVNamespace,
+          {
+            pushId: 'p-on-de',
+            token: 'tok',
+            payload: makePayload({ pushId: 'p-on-de', kind: 'destination' }),
+            apnsEnv: 'sandbox',
+            status: 429,
+            now: NOW,
+          },
+          'on',
+        );
+        expect(queued).toBe(true);
+        expect(await kv.get('retry-push:p-on-de')).not.toBeNull();
+      });
+
+      it('archFlag=on + kind=transfer → skip (반복 알림 case 4 fix, station-passed/transfer retry 0건)', async () => {
+        const queued = await enqueueRetryIfTransient(
+          kv as unknown as KVNamespace,
+          {
+            pushId: 'p-on-tr',
+            token: 'tok',
+            payload: makePayload({ pushId: 'p-on-tr', kind: 'transfer' }),
+            apnsEnv: 'sandbox',
+            status: 429,
+            now: NOW,
+          },
+          'on',
+        );
+        expect(queued).toBe(false);
+        expect(await kv.get('retry-push:p-on-tr')).toBeNull();
+      });
+
+      it('archFlag=on + kind=intermediate → skip (반복 알림 case 4 fix)', async () => {
+        const queued = await enqueueRetryIfTransient(
+          kv as unknown as KVNamespace,
+          {
+            pushId: 'p-on-im',
+            token: 'tok',
+            payload: makePayload({ pushId: 'p-on-im', kind: 'intermediate' }),
+            apnsEnv: 'sandbox',
+            status: 500,
+            now: NOW,
+          },
+          'on',
+        );
+        expect(queued).toBe(false);
+        expect(await kv.get('retry-push:p-on-im')).toBeNull();
+      });
+    });
+  });
+
+  describe('#1995 shouldRetryForKind', () => {
+    it('archFlag=undefined (legacy) → true (모든 kind)', () => {
+      expect(shouldRetryForKind(undefined, 'transfer')).toBe(true);
+      expect(shouldRetryForKind(undefined, 'intermediate')).toBe(true);
+      expect(shouldRetryForKind(undefined, 'destination')).toBe(true);
+    });
+
+    it('archFlag=off → true (모든 kind)', () => {
+      expect(shouldRetryForKind('off', 'transfer')).toBe(true);
+      expect(shouldRetryForKind('off', 'intermediate')).toBe(true);
+      expect(shouldRetryForKind('off', 'destination')).toBe(true);
+    });
+
+    it('archFlag=on → destination 만 true', () => {
+      expect(shouldRetryForKind('on', 'transfer')).toBe(false);
+      expect(shouldRetryForKind('on', 'intermediate')).toBe(false);
+      expect(shouldRetryForKind('on', 'destination')).toBe(true);
     });
   });
 
@@ -512,6 +654,95 @@ describe('retryPushes (#1721)', () => {
         fetchImpl: apnsFetch as unknown as typeof fetch,
       });
       expect(stats.resent).toBe(1);
+    });
+
+    describe('#1995 (ADR-022 Phase 1-2) — deps.archFlag 재 enqueue 필터', () => {
+      it('deps.archFlag=on + entry.kind=transfer + 재실패 → 재 enqueue 되지 않음 (exhausted)', async () => {
+        // 이미 enqueue 된 transfer entry (flag off 시절 or self-retry).
+        await kv.put(
+          'retry-push:p-loop-tr',
+          JSON.stringify({
+            pushId: 'p-loop-tr',
+            token: 'tok',
+            payload: makePayload({ pushId: 'p-loop-tr', kind: 'transfer' }),
+            apnsEnv: 'sandbox',
+            attemptCount: 0,
+            nextAttemptAt: NOW,
+            originalSentAt: NOW,
+            lastErrorStatus: 429,
+          }),
+        );
+        // 재시도 시 500 응답 → 원래 재 enqueue 될 상황.
+        const apnsFetch = vi.fn(async () =>
+          new Response(JSON.stringify({ reason: 'InternalServerError' }), { status: 500 }),
+        );
+        const stats = await runRetryPushes(makeEnv(kv), {
+          apnsConfig: makeApnsConfig(),
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW + 1,
+          archFlag: 'on',
+        });
+        expect(stats.rescheduled).toBe(0);
+        expect(stats.exhausted).toBe(1);
+        expect(await kv.get('retry-push:p-loop-tr')).toBeNull();
+      });
+
+      it('deps.archFlag=on + entry.kind=destination + 재실패 → 재 enqueue (사용자 가치 유지)', async () => {
+        await kv.put(
+          'retry-push:p-loop-de',
+          JSON.stringify({
+            pushId: 'p-loop-de',
+            token: 'tok',
+            payload: makePayload({ pushId: 'p-loop-de', kind: 'destination' }),
+            apnsEnv: 'sandbox',
+            attemptCount: 0,
+            nextAttemptAt: NOW,
+            originalSentAt: NOW,
+            lastErrorStatus: 429,
+          }),
+        );
+        const apnsFetch = vi.fn(async () =>
+          new Response(JSON.stringify({ reason: 'InternalServerError' }), { status: 500 }),
+        );
+        const stats = await runRetryPushes(makeEnv(kv), {
+          apnsConfig: makeApnsConfig(),
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW + 1,
+          archFlag: 'on',
+        });
+        expect(stats.rescheduled).toBe(1);
+        const stored = JSON.parse((await kv.get('retry-push:p-loop-de')) as string) as RetryPush;
+        expect(stored.attemptCount).toBe(1);
+      });
+
+      it('deps.archFlag=off (default) → 재 enqueue 정책 기존 유지', async () => {
+        await kv.put(
+          'retry-push:p-off-loop',
+          JSON.stringify({
+            pushId: 'p-off-loop',
+            token: 'tok',
+            payload: makePayload({ pushId: 'p-off-loop', kind: 'transfer' }),
+            apnsEnv: 'sandbox',
+            attemptCount: 0,
+            nextAttemptAt: NOW,
+            originalSentAt: NOW,
+            lastErrorStatus: 429,
+          }),
+        );
+        const apnsFetch = vi.fn(async () =>
+          new Response(JSON.stringify({ reason: 'InternalServerError' }), { status: 500 }),
+        );
+        const stats = await runRetryPushes(makeEnv(kv), {
+          apnsConfig: makeApnsConfig(),
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW + 1,
+          archFlag: 'off',
+        });
+        expect(stats.rescheduled).toBe(1);
+      });
     });
   });
 });

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -2226,7 +2226,10 @@ const handler = {
       console.log(JSON.stringify({ msg, ...meta, archFlag }));
 
     try {
-      await runScheduled(env, { seoul, apnsConfig, apnsHosts, log });
+      // #1995 (ADR-022 Phase 1-2) — archFlag 를 runScheduled deps 로 forward.
+      // 각 caller (arvlcd / vanish / transfer-release / lockless) 가 putPending / enqueueRetryIfTransient
+      // 호출 시 이 값을 전달해 flag=on 시 destination 이외 kind 는 skip.
+      await runScheduled(env, { seoul, apnsConfig, apnsHosts, log, archFlag });
     } catch (err) {
       captureBackendException(err, { path: 'scheduled/runScheduled' });
       throw err;
@@ -2235,7 +2238,8 @@ const handler = {
     await runFallbackPushes(env, { apnsConfig, apnsHosts, log });
     // #1721 — silent push 발사 실패(429 / 5xx) 영구 lost 차단. retry-push: prefix entry 를 backoff 만기
     // 시 재발사. KV binding 부재 시 graceful no-op (개발/테스트 환경 호환).
-    await runRetryPushes(env, { apnsConfig, apnsHosts, log });
+    // #1995 (ADR-022 Phase 1-2) — runRetryPushes 자체 재 enqueue 도 flag=on 시 destination 만 유지.
+    await runRetryPushes(env, { apnsConfig, apnsHosts, log, archFlag });
     // #972 — low-recall trip ratio 임계 위반 시 운영 webhook 발사. dedup KV(1h)로 spam 차단.
     // binding/secret 미설정 환경에서는 graceful no-op이라 회귀 없음.
     await evaluateAndMaybeAlert(env, { fetchImpl: fetch, now: () => Date.now(), log });

--- a/backend/alarm-worker/src/pendingPushes.ts
+++ b/backend/alarm-worker/src/pendingPushes.ts
@@ -13,6 +13,7 @@
  */
 
 import type { AlarmPhase } from './alarm';
+import type { ArchFlagValue } from './archFlag';
 import { assertCronCacheTtl, CRON_READ_CACHE_TTL_SEC as SHARED_CRON_TTL } from './kvConsistency';
 import { stampSent } from './silentPushReachMetric';
 import type { ApnsEnv } from './types';
@@ -67,11 +68,34 @@ export function buildAlarmKey(stationName: string, phase: AlarmPhase): string {
   return `${phase}:${stationName}`;
 }
 
+/**
+ * #1995 (ADR-022 Phase 1-2) — archFlag=on 시 등록 대상 kind 필터.
+ *
+ * 반복 알림 조사 코멘트 case 4: silent push 발사 실패 시 alert fallback 이 station-passed /
+ * transfer / intermediate 알림까지 모두 재발사해 사용자에게 "이미 지난 알림"이 반복 노출됨.
+ * 신규 아키텍처 (ADR-022) 는 destination(하차) 알림만 사용자에게 필수 재발사 가치가 있다고
+ * 판단해 pending 등록 자체를 destination 으로 제한한다.
+ *
+ * flag=off (default) 시 이 함수는 항상 true 반환 — 기존 동작 100% 유지.
+ * flag=on 시 kind !== 'destination' 이면 false → putPending 이 no-op.
+ */
+export function shouldRegisterPendingForKind(
+  archFlag: ArchFlagValue | undefined,
+  kind: PendingPush['kind'],
+): boolean {
+  if (archFlag !== 'on') return true;
+  return kind === 'destination';
+}
+
 export async function putPending(
   kv: KVNamespace | undefined,
   entry: PendingPush,
+  // #1995 (ADR-022 Phase 1-2) — flag=on 시 destination 만 등록. 미전달 (legacy caller) 은
+  // undefined 로 처리되어 기존 동작 100% 유지.
+  archFlag?: ArchFlagValue,
 ): Promise<void> {
   if (!kv) return;
+  if (!shouldRegisterPendingForKind(archFlag, entry.kind)) return;
   await kv.put(pendingKey(entry.pushId), JSON.stringify(entry), {
     expirationTtl: PENDING_TTL_SEC,
   });

--- a/backend/alarm-worker/src/retryPushes.ts
+++ b/backend/alarm-worker/src/retryPushes.ts
@@ -27,6 +27,7 @@ import {
   sendWithEnvHeal,
 } from './apnsHost';
 import { sendSilentPush, type ApnsConfig, type SilentPushPayload } from './apns';
+import type { ArchFlagValue } from './archFlag';
 import { assertCronCacheTtl, CRON_READ_CACHE_TTL_SEC as SHARED_CRON_TTL } from './kvConsistency';
 import type { ApnsEnv, Env } from './types';
 
@@ -77,10 +78,33 @@ export function retryPushKey(pushId: string): string {
 }
 
 /**
+ * #1995 (ADR-022 Phase 1-2) — archFlag=on 시 재발사 대상 kind 필터.
+ *
+ * 반복 알림 조사 코멘트 case 4: silent push 발사 실패 시 backend 재발사가 station-passed /
+ * transfer / intermediate 알림까지 모두 반복 발사해 사용자에게 "이미 지난 알림"이 반복 노출됨.
+ * 신규 아키텍처 (ADR-022) 는 destination(하차) 알림만 사용자에게 필수 재발사 가치가 있다고
+ * 판단해 retry queue 적재 자체를 destination 으로 제한한다.
+ *
+ * flag=off (default) 시 이 함수는 항상 true 반환 — 기존 동작 100% 유지.
+ * flag=on 시 kind !== 'destination' 이면 false → enqueueRetryIfTransient 가 no-op.
+ */
+export function shouldRetryForKind(
+  archFlag: ArchFlagValue | undefined,
+  kind: SilentPushPayload['kind'],
+): boolean {
+  if (archFlag !== 'on') return true;
+  return kind === 'destination';
+}
+
+/**
  * 발사 실패가 retryable 인지 검사 + retry queue 등록. status 가 retryable 이 아니거나 KV 미바인딩이면 no-op.
  *
  * `attemptCount` 미지정 시 0 (첫 enqueue). 호출자가 fire path 실패 직후 한 번 호출하면 충분 —
  * 다음 cron `runRetryPushes` 가 backoff 후 재발사 + 추가 실패 시 attemptCount 증가 + 재 enqueue.
+ *
+ * #1995 (ADR-022 Phase 1-2) — `archFlag` 파라미터 (optional). flag=on 시 payload.kind !==
+ * 'destination' 이면 no-op. 미전달 (legacy caller / retry loop 자기 재 enqueue) 시 undefined
+ * 로 처리 → 기존 동작 100% 유지.
  */
 export async function enqueueRetryIfTransient(
   kv: KVNamespace | undefined,
@@ -95,9 +119,11 @@ export async function enqueueRetryIfTransient(
     attemptCount?: number;
     originalSentAt?: number;
   },
+  archFlag?: ArchFlagValue,
 ): Promise<boolean> {
   if (!kv) return false;
   if (!isRetryableApnsError(input.status)) return false;
+  if (!shouldRetryForKind(archFlag, input.payload.kind)) return false;
   const attemptCount = input.attemptCount ?? 0;
   const nextAttemptAt = computeNextRetryAt(attemptCount, input.now);
   if (nextAttemptAt === null) return false; // 영구 폐기 — caller 가 별도 cleanup
@@ -159,6 +185,11 @@ export interface RetryPushDeps {
   fetchImpl?: typeof fetch;
   now?: () => number;
   log?: Logger;
+  /**
+   * #1995 (ADR-022 Phase 1-2) — archFlag=on 시 재실패 재 enqueue 도 destination 만 유지.
+   * 미전달 시 undefined 로 처리되어 기존 동작 100% 유지.
+   */
+  archFlag?: ArchFlagValue;
 }
 
 export interface RetryPushStats {
@@ -220,18 +251,23 @@ export async function runRetryPushes(env: Env, deps: RetryPushDeps): Promise<Ret
       continue;
     }
     // 실패. retryable 이면 다음 backoff 로 재 enqueue, 아니면 폐기.
+    // #1995 (ADR-022 Phase 1-2) — flag=on 시 destination 만 재 enqueue.
     const nextAttempt = entry.attemptCount + 1;
-    const rescheduled = await enqueueRetryIfTransient(env.PENDING_PUSHES, {
-      pushId: entry.pushId,
-      token: entry.token,
-      payload: entry.payload,
-      apnsEnv: heal.correctedEnv ?? entry.apnsEnv,
-      status: heal.result.status,
-      reason: heal.result.reason,
-      now,
-      attemptCount: nextAttempt,
-      originalSentAt: entry.originalSentAt,
-    });
+    const rescheduled = await enqueueRetryIfTransient(
+      env.PENDING_PUSHES,
+      {
+        pushId: entry.pushId,
+        token: entry.token,
+        payload: entry.payload,
+        apnsEnv: heal.correctedEnv ?? entry.apnsEnv,
+        status: heal.result.status,
+        reason: heal.result.reason,
+        now,
+        attemptCount: nextAttempt,
+        originalSentAt: entry.originalSentAt,
+      },
+      deps.archFlag,
+    );
     if (rescheduled) {
       stats.rescheduled += 1;
       log('retry-push rescheduled', {

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -13,6 +13,7 @@ import {
   type SilentPushPayload,
 } from './apns';
 import { flipApnsEnv, pickApnsHost, sendWithEnvHeal } from './apnsHost';
+import type { ArchFlagValue } from './archFlag';
 import { AUTO_PROMPT_DEDUP_WINDOW_MS } from './autoLock';
 import {
   evaluateBoardingPromptGates,
@@ -781,6 +782,13 @@ export interface ScheduledDeps {
   log?: (message: string, meta?: Record<string, unknown>) => void;
   /** pushId 발급 — 테스트에선 결정적 값을 주입한다. 기본은 crypto.randomUUID. */
   generatePushId?: () => string;
+  /**
+   * #1995 (ADR-022 Phase 1-2) — arrival API SSOT 아키텍처 활성화 여부.
+   * flag=on 시 pending/retry queue 등록을 destination(하차) 알림 kind 로 제한한다.
+   * index.ts scheduled handler 가 매 cron cycle `getArchFlag(env.TRIPS)` 로 read 해 forward.
+   * 미전달 (테스트/legacy) 시 undefined → 기존 동작 100% 유지.
+   */
+  archFlag?: ArchFlagValue;
 }
 
 /**
@@ -1778,15 +1786,20 @@ export async function fireArvlCdStationPush(
     // #1721 — transient 실패(429 / 5xx) 시 retry queue 적재. envHeal 양 env 모두 실패해도 영구 lost
     // 차단. 410/400 BadDeviceToken 같은 unrecoverable 은 enqueueRetryIfTransient 가 자연 skip
     // (caller 가 이미 dedup/cleanup 책임).
-    await enqueueRetryIfTransient(env.PENDING_PUSHES, {
-      pushId,
-      token: trip.token,
-      payload: arvlcdPayload,
-      apnsEnv: trip.apnsEnv ?? 'sandbox',
-      status: heal.result.status,
-      reason: heal.result.reason,
-      now,
-    });
+    // #1995 (ADR-022 Phase 1-2) — flag=on 시 destination 만 retry queue 적재.
+    await enqueueRetryIfTransient(
+      env.PENDING_PUSHES,
+      {
+        pushId,
+        token: trip.token,
+        payload: arvlcdPayload,
+        apnsEnv: trip.apnsEnv ?? 'sandbox',
+        status: heal.result.status,
+        reason: heal.result.reason,
+        now,
+      },
+      deps.archFlag,
+    );
     // dedup KV는 성공 시에만 stamp — 실패 push는 다음 cycle 재시도 허용.
     return { dirty };
   }
@@ -1803,17 +1816,22 @@ export async function fireArvlCdStationPush(
   // #1402 — alert fallback 안전망 등록. silent push가 60s(#1894로 30s→60s 완화) 내 ACK되지 않으면
   // runFallbackPushes가 alert(소리) push를 발사. arvlCd 경로는 가장 흔한 발사 경로이므로
   // 여기서도 안전망을 가동해 "하차 침묵 0" acceptance를 보강한다.
-  await putPending(env.PENDING_PUSHES, {
-    pushId,
-    token: trip.token,
-    alarmKey: buildAlarmKey(waypoint.stationName, 'imminent'),
-    sentAt: now,
-    stationName: waypoint.stationName,
-    kind: waypoint.kind,
-    phase: 'imminent',
-    etaSeconds: 0,
-    apnsEnv: trip.apnsEnv ?? 'sandbox',
-  });
+  // #1995 (ADR-022 Phase 1-2) — flag=on 시 destination 만 pending 등록.
+  await putPending(
+    env.PENDING_PUSHES,
+    {
+      pushId,
+      token: trip.token,
+      alarmKey: buildAlarmKey(waypoint.stationName, 'imminent'),
+      sentAt: now,
+      stationName: waypoint.stationName,
+      kind: waypoint.kind,
+      phase: 'imminent',
+      etaSeconds: 0,
+      apnsEnv: trip.apnsEnv ?? 'sandbox',
+    },
+    deps.archFlag,
+  );
   // dedup stamp — 같은 cycle에서 Seoul API 갱신 지연으로 같은 신호가 재노출돼도 차단.
   await env.TRIPS.put(key, '1', { expirationTtl: ARVLCD_FIRE_DEDUP_TTL_SEC });
   // ADR-022 Phase 1-1 (#1985) — fire-once TTL stamp (flag=ON 시에만). 성공 fire 직후 stamp
@@ -2138,15 +2156,20 @@ export async function fireVanishFallbackStationPush(
       token: trip.token.slice(0, 8),
     });
     // #1721 — vanish 경로는 silent push 가 가장 잘 누락되는 경로라 retry queue 적재 우선순위 1순위.
-    await enqueueRetryIfTransient(env.PENDING_PUSHES, {
-      pushId,
-      token: trip.token,
-      payload: vanishPayload,
-      apnsEnv: trip.apnsEnv ?? 'sandbox',
-      status: heal.result.status,
-      reason: heal.result.reason,
-      now,
-    });
+    // #1995 (ADR-022 Phase 1-2) — flag=on 시 destination 만 retry queue 적재.
+    await enqueueRetryIfTransient(
+      env.PENDING_PUSHES,
+      {
+        pushId,
+        token: trip.token,
+        payload: vanishPayload,
+        apnsEnv: trip.apnsEnv ?? 'sandbox',
+        status: heal.result.status,
+        reason: heal.result.reason,
+        now,
+      },
+      deps.archFlag,
+    );
     // dedup KV는 성공 시에만 stamp — 실패 push는 다음 cycle 재시도 허용.
     return;
   }
@@ -2177,17 +2200,22 @@ export async function fireVanishFallbackStationPush(
   // 없으면 alert(소리) fallback 발사. vanish 경로는 silent push가 가장 잘 누락되는 경로라
   // 안전망 가동이 acceptance("하차 침묵 0")의 핵심. PENDING_PUSHES 미바인딩(dev/test 호환)
   // 시 putPending은 graceful no-op.
-  await putPending(env.PENDING_PUSHES, {
-    pushId,
-    token: trip.token,
-    alarmKey: buildAlarmKey(waypoint.stationName, 'imminent'),
-    sentAt: now,
-    stationName: waypoint.stationName,
-    kind: waypoint.kind,
-    phase: 'imminent',
-    etaSeconds: 0,
-    apnsEnv: trip.apnsEnv ?? 'sandbox',
-  });
+  // #1995 (ADR-022 Phase 1-2) — flag=on 시 destination 만 pending 등록.
+  await putPending(
+    env.PENDING_PUSHES,
+    {
+      pushId,
+      token: trip.token,
+      alarmKey: buildAlarmKey(waypoint.stationName, 'imminent'),
+      sentAt: now,
+      stationName: waypoint.stationName,
+      kind: waypoint.kind,
+      phase: 'imminent',
+      etaSeconds: 0,
+      apnsEnv: trip.apnsEnv ?? 'sandbox',
+    },
+    deps.archFlag,
+  );
   await env.TRIPS.put(key, '1', { expirationTtl: ARVLCD_FIRE_DEDUP_TTL_SEC });
 }
 
@@ -2844,15 +2872,20 @@ export async function advanceBoardingLockWaypoint(
     } else {
       // #1721 — transient 실패(429 / 5xx) 시 retry queue 적재. transfer-release 도 silent push 누락 시
       // leg 2 boardingPrompt 재요청이 차단되는 회귀(2026-06-18 evidence)가 발생하므로 retry 필요.
-      await enqueueRetryIfTransient(env.PENDING_PUSHES, {
-        pushId,
-        token: trip.token,
-        payload: transferPayload,
-        apnsEnv: trip.apnsEnv ?? 'sandbox',
-        status: transferHeal.result.status,
-        reason: transferHeal.result.reason,
-        now,
-      });
+      // #1995 (ADR-022 Phase 1-2) — flag=on 시 destination 만 retry (transfer-release payload.kind='transfer' → flag=on 시 skip).
+      await enqueueRetryIfTransient(
+        env.PENDING_PUSHES,
+        {
+          pushId,
+          token: trip.token,
+          payload: transferPayload,
+          apnsEnv: trip.apnsEnv ?? 'sandbox',
+          status: transferHeal.result.status,
+          reason: transferHeal.result.reason,
+          now,
+        },
+        deps.archFlag,
+      );
     }
   }
   // #1729 paradigm shift — 환승 직후 자동 trainCode swap 제거(Path B' 환승 버전).
@@ -3271,15 +3304,20 @@ export async function runLocklessIntermediate(
     // #1721 — transient 실패(429 / 5xx) 시 retry queue 적재. unrecoverable / envMismatchExhausted
     // 분기 이후이므로 본 경로는 transient 또는 기타 비치명 실패. enqueueRetryIfTransient 가 retryable
     // 만 적재한다.
-    await enqueueRetryIfTransient(env.PENDING_PUSHES, {
-      pushId,
-      token: trip.token,
-      payload: locklessPayload,
-      apnsEnv: trip.apnsEnv ?? 'sandbox',
-      status: heal.result.status,
-      reason: heal.result.reason,
-      now,
-    });
+    // #1995 (ADR-022 Phase 1-2) — flag=on 시 destination 만 retry (lockless intermediate payload.kind='intermediate' → flag=on 시 skip).
+    await enqueueRetryIfTransient(
+      env.PENDING_PUSHES,
+      {
+        pushId,
+        token: trip.token,
+        payload: locklessPayload,
+        apnsEnv: trip.apnsEnv ?? 'sandbox',
+        status: heal.result.status,
+        reason: heal.result.reason,
+        now,
+      },
+      deps.archFlag,
+    );
     if (dirty) await putTrip(env.TRIPS, trip);
     return;
   }
@@ -3291,17 +3329,22 @@ export async function runLocklessIntermediate(
   // #1402 — alert fallback 안전망 등록 (60s 임계, #1894로 30s→60s 완화). shift 전 stationName으로 등록해 alert 본문이
   // 사용자가 실제로 통과한 station을 가리키게 한다. lockless intermediate는 lock 경로보다
   // device-side validation이 느슨해 silent push 누락 시 안전망 가동이 더 절실한 경로.
-  await putPending(env.PENDING_PUSHES, {
-    pushId,
-    token: trip.token,
-    alarmKey: buildAlarmKey(waypoint.stationName, 'imminent'),
-    sentAt: now,
-    stationName: waypoint.stationName,
-    kind: 'intermediate',
-    phase: 'imminent',
-    etaSeconds: signal.etaSeconds,
-    apnsEnv: trip.apnsEnv ?? 'sandbox',
-  });
+  // #1995 (ADR-022 Phase 1-2) — flag=on 시 destination 만 pending 등록 (본 경로 kind='intermediate' → flag=on 시 skip).
+  await putPending(
+    env.PENDING_PUSHES,
+    {
+      pushId,
+      token: trip.token,
+      alarmKey: buildAlarmKey(waypoint.stationName, 'imminent'),
+      sentAt: now,
+      stationName: waypoint.stationName,
+      kind: 'intermediate',
+      phase: 'imminent',
+      etaSeconds: signal.etaSeconds,
+      apnsEnv: trip.apnsEnv ?? 'sandbox',
+    },
+    deps.archFlag,
+  );
   trip.lastFiredPhase = 'imminent';
   // #1539 (S6) — lockless intermediate 통과 시점도 동일하게 stationName 누적. lock 경로와 동등
   // 정확도 보장 의무(ADR-014: 사용자 명시 의향 trip = lock 활성과 동급).


### PR DESCRIPTION
Closes #1995

## Summary

ADR-022 (#1980) Phase 1-2 — silent push retry queue + pending queue 등록을 `destination` (하차) 알림 kind 로 제한. `arch:simple-arrival-v1` flag=`on` 시 station-passed / transfer / intermediate 알림 재발사를 skip 해 반복 알림 case 4 (사용자 trip evidence) 를 종결한다.

- `retryPushes.ts` — `enqueueRetryIfTransient` 에 optional `archFlag` param 추가. flag=on + `payload.kind !== 'destination'` → no-op (return false)
- `pendingPushes.ts` — `putPending` 에 동일 param. flag=on + `entry.kind !== 'destination'` → pending 등록 자체 skip → alert fallback 도 자연 발사 X
- `runRetryPushes` — `deps.archFlag` 로 재실패 자기 재 enqueue 도 필터 (loop 종결)
- `scheduled.ts` — 4개 caller (arvlcd / vanish-fallback / transfer-release / lockless intermediate) 가 `deps.archFlag` 전달
- `index.ts` — scheduled handler 가 이미 `getArchFlag(env.TRIPS)` 로 read 한 값을 `runScheduled` / `runRetryPushes` deps 로 forward (KV re-read 없음)
- flag=`off` (default) 시 기존 동작 100% 유지 — legacy caller / test 는 param 미전달로 undefined 처리

## Wire-completion 5단 체크

1. **Orphan** — `shouldRegisterPendingForKind` / `shouldRetryForKind` 신규 export. 각각 test 파일에서 assertion caller 로 사용. `npm run lint:orphan` pass (root repo).
2. **V/X dashboard** — wrangler tail: flag=on 상태에서 push 실패 시 `retry-push:` 큐 write 없음 확인. 기존 `archFlag` log field 로 flag 상태 동시 확인 (index.ts:2226).
3. **의존 PR** — Phase 0 (#1982, `archFlag.ts` `getArchFlag`) 머지됨. 없음.
4. **측정 plan** — Phase 1-2 배포 후 KV `arch:simple-arrival-v1=on` toggle. wrangler tail 로 push 실패 발생 시 `retry-push:` 큐 write 없음 확인. 1주 사용자 trip 반복 알림(case 4) 0건.
5. **Device verify** — N/A — backend only. type-check + unit only. flag=on 실기기 검증은 후속 KV toggle 이후 사용자 액션.

## acceptance 매핑

- [x] `enqueueRetryIfTransient` retry 조건 kind 필터 (flag ON 시 destination 만) + test — `retryPushes.test.ts` \`#1995 (ADR-022 Phase 1-2) — archFlag kind 필터\` 5 cases + `shouldRetryForKind` 3 cases
- [x] `putPending` 등록 조건부 (flag ON 시 destination 만) + test — `pendingPushes.test.ts` \`#1995 (ADR-022 Phase 1-2) — archFlag kind 필터\` 5 cases + `shouldRegisterPendingForKind` 3 cases
- [x] real `getArchFlag(env.TRIPS)` wire — index.ts scheduled handler 가 이미 계산한 값을 forward (`Env.TRIPS` = archFlag KV, Phase 0 helper 그대로 재사용)
- [x] flag OFF 시 기존 동작 유지 — 4개 test (미전달 legacy + off default × 2 helper) + 전체 2429 test PASS
- [x] flag ON 시 station-passed/transfer retry 0건 — `retryPushes.test.ts` \`deps.archFlag=on + entry.kind=transfer + 재실패 → 재 enqueue 되지 않음 (exhausted)\` + `enqueueRetryIfTransient` transfer/intermediate skip 케이스
- [x] backend test 100% coverage — 신규 branch 모두 test 로 커버 (helper 각 3 flag × 3 kind + putPending/enqueueRetry 각 5 kind × flag matrix + runRetryPushes deps.archFlag 3 cases)

## Test

```
cd backend/alarm-worker && npm test
# Test Files  65 passed (65)
# Tests       2429 passed (2429)

npm run type-check
# clean
```

## refs
- ADR-022 (#1980)
- Phase 0 (#1982) — archFlag helper
- Phase 1-1 (#1985) — arvlCd fire-once TTL (동일 flag guard 패턴)
- 반복 알림 조사 코멘트 case 4