### PR TITLE
fix(#1997): Phase 1-5 client dedup key 통일 (stationName 정규화 + trainCode 격리)

### DIFF
--- a/src/features/alarm/utils/__tests__/unifiedFireDedup.test.ts
+++ b/src/features/alarm/utils/__tests__/unifiedFireDedup.test.ts
@@ -1,0 +1,331 @@
+import {
+  observeArvlCd,
+  getCurrentCycle,
+  hasFiredForCycle,
+  markFiredForCycle,
+  clearUnifiedFireDedup,
+  _resetUnifiedFireDedupForTests,
+  UNIFIED_FIRE_DEDUP_TTL_MS,
+} from '../unifiedFireDedup';
+import { SIMPLE_ARRIVAL_ARCH_ENV_KEY } from '../../../../shared/config/archFlag';
+
+const ORIGINAL_ENV = process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+
+/** flag=ON 을 위해 env 를 'true' 로 세팅. */
+function enableFlag(): void {
+  process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+}
+
+/** flag=OFF (기본) — env 를 명시적으로 제거. */
+function disableFlag(): void {
+  delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+}
+
+afterEach(() => {
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+  } else {
+    process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = ORIGINAL_ENV;
+  }
+  _resetUnifiedFireDedupForTests();
+});
+
+const STATION = '성수';
+const LINE = '2';
+const TRAIN = '2001';
+
+describe('unifiedFireDedup — arvlCd cycle 추적 (#1997)', () => {
+  it('최초 관측 시 cycle = 0 초기화', () => {
+    observeArvlCd(STATION, LINE, TRAIN, 0);
+    expect(getCurrentCycle(STATION, LINE, TRAIN)).toBe(0);
+  });
+
+  it('관측 전엔 cycle 0 (default)', () => {
+    expect(getCurrentCycle(STATION, LINE, TRAIN)).toBe(0);
+  });
+
+  it('0 → 1 → 2 → 5 monotone 시퀀스는 cycle 유지', () => {
+    observeArvlCd(STATION, LINE, TRAIN, 0);
+    observeArvlCd(STATION, LINE, TRAIN, 1);
+    observeArvlCd(STATION, LINE, TRAIN, 2);
+    observeArvlCd(STATION, LINE, TRAIN, 5);
+    expect(getCurrentCycle(STATION, LINE, TRAIN)).toBe(0);
+  });
+
+  it('5 → 0 전환 시 cycle +1 (다음 train)', () => {
+    observeArvlCd(STATION, LINE, TRAIN, 5);
+    observeArvlCd(STATION, LINE, TRAIN, 0);
+    expect(getCurrentCycle(STATION, LINE, TRAIN)).toBe(1);
+  });
+
+  it('5 → 0 여러 번 반복 시 cycle 계속 +1', () => {
+    observeArvlCd(STATION, LINE, TRAIN, 5);
+    observeArvlCd(STATION, LINE, TRAIN, 0);
+    observeArvlCd(STATION, LINE, TRAIN, 5);
+    observeArvlCd(STATION, LINE, TRAIN, 0);
+    observeArvlCd(STATION, LINE, TRAIN, 5);
+    observeArvlCd(STATION, LINE, TRAIN, 0);
+    expect(getCurrentCycle(STATION, LINE, TRAIN)).toBe(3);
+  });
+
+  it('같은 값 반복은 cycle 유지 (e.g. 1 → 1 → 1)', () => {
+    observeArvlCd(STATION, LINE, TRAIN, 1);
+    observeArvlCd(STATION, LINE, TRAIN, 1);
+    observeArvlCd(STATION, LINE, TRAIN, 1);
+    expect(getCurrentCycle(STATION, LINE, TRAIN)).toBe(0);
+  });
+
+  it('non-5→0 전환은 cycle 유지 (e.g. 2 → 0 은 새 cycle 아님)', () => {
+    // 방어적: monotone 시퀀스 밖에서 5→0 만 전환 신호로 인식.
+    observeArvlCd(STATION, LINE, TRAIN, 2);
+    observeArvlCd(STATION, LINE, TRAIN, 0);
+    expect(getCurrentCycle(STATION, LINE, TRAIN)).toBe(0);
+  });
+
+  it('(station, line, trainCode) 조합 별로 독립적 cycle 추적', () => {
+    observeArvlCd(STATION, LINE, TRAIN, 5);
+    observeArvlCd(STATION, LINE, TRAIN, 0);
+    // 다른 station: cycle 그대로 0
+    observeArvlCd('건대입구', LINE, TRAIN, 5);
+    expect(getCurrentCycle(STATION, LINE, TRAIN)).toBe(1);
+    expect(getCurrentCycle('건대입구', LINE, TRAIN)).toBe(0);
+    // 다른 line, 같은 station: 독립
+    observeArvlCd(STATION, '7', TRAIN, 3);
+    expect(getCurrentCycle(STATION, '7', TRAIN)).toBe(0);
+  });
+
+  it('line=null 조합도 지원 (환승역 무-노선 방어)', () => {
+    observeArvlCd(STATION, null, TRAIN, 5);
+    observeArvlCd(STATION, null, TRAIN, 0);
+    expect(getCurrentCycle(STATION, null, TRAIN)).toBe(1);
+    // (station, null) 은 (station, LINE) 과 별개 key
+    expect(getCurrentCycle(STATION, LINE, TRAIN)).toBe(0);
+  });
+});
+
+describe('unifiedFireDedup — trainCode 격리 (Finding #2)', () => {
+  beforeEach(() => {
+    enableFlag();
+  });
+
+  /**
+   * wire PR 에서 caller 가 실수로 arrival.up[] + arrival.down[] 를 iterate 해 여러 train 의
+   * arvlCd 를 섞어 넣더라도 사용자 target train (BoardingLock.trainCode) 의 cycle 은
+   * 다른 train row 의 관측에 영향받지 않아야 한다.
+   */
+  it('두 train 이 같은 station 에 있어도 각자의 cycle 은 독립적', () => {
+    const TARGET = '2001'; // 사용자 target
+    const OTHER = '2099'; // 옆에 서 있는 다른 train
+    // 실수 시나리오: caller 가 OTHER train arvlCd=5 관측 후 TARGET arvlCd=0 관측.
+    // Finding #2 이전 (trainCode 없음) 이라면 prev=5, curr=0 → cycle=1 로 잘못 전환.
+    // trainCode 격리 후: OTHER 의 5 는 TARGET timeline 에 영향 없음.
+    observeArvlCd(STATION, LINE, OTHER, 5);
+    observeArvlCd(STATION, LINE, TARGET, 0);
+    expect(getCurrentCycle(STATION, LINE, TARGET)).toBe(0);
+    expect(getCurrentCycle(STATION, LINE, OTHER)).toBe(0);
+  });
+
+  it('TARGET train 이 실제로 5→0 전환한 경우만 cycle 증가', () => {
+    const TARGET = '2001';
+    observeArvlCd(STATION, LINE, TARGET, 5);
+    observeArvlCd(STATION, LINE, TARGET, 0);
+    expect(getCurrentCycle(STATION, LINE, TARGET)).toBe(1);
+  });
+
+  it('같은 station, 같은 line 에서 두 train 이 각자 fire 판정', () => {
+    const TRAIN_A = '2001';
+    const TRAIN_B = '2099';
+    markFiredForCycle(STATION, LINE, TRAIN_A);
+    // A 는 dedup, B 는 통과
+    expect(hasFiredForCycle(STATION, LINE, TRAIN_A)).toBe(true);
+    expect(hasFiredForCycle(STATION, LINE, TRAIN_B)).toBe(false);
+  });
+});
+
+describe('unifiedFireDedup — stationName 정규화 (Finding #1)', () => {
+  beforeEach(() => {
+    enableFlag();
+  });
+
+  /**
+   * wire PR 에서 caller 에 따라 서로 다른 source (arrival.stationName vs
+   * route.waypoint.stationName) 를 쓸 수 있다. 표기 variant (괄호 부제) 가
+   * 같은 물리적 역으로 취급돼야 kind-agnostic dedup 이 유지된다.
+   */
+  it("'서울역(1)' 과 '서울역' 은 같은 cycle timeline 으로 처리", () => {
+    // caller A: 정규화 이전 원문
+    markFiredForCycle('서울역(1)', '1', TRAIN);
+    // caller B: 정규화된 이름
+    expect(hasFiredForCycle('서울역', '1', TRAIN)).toBe(true);
+  });
+
+  it("괄호 이전에 observe 한 cycle 이 괄호 없는 조회에도 반영", () => {
+    observeArvlCd('사당(4·2)', LINE, TRAIN, 5);
+    observeArvlCd('사당(4·2)', LINE, TRAIN, 0);
+    // 다른 caller 가 괄호 없는 이름으로 조회
+    expect(getCurrentCycle('사당', LINE, TRAIN)).toBe(1);
+  });
+
+  it('trailing whitespace 도 정규화되어 같은 key', () => {
+    markFiredForCycle('성수 ', LINE, TRAIN);
+    expect(hasFiredForCycle('성수', LINE, TRAIN)).toBe(true);
+  });
+});
+
+describe('unifiedFireDedup — flag OFF (기존 5 채널만 동작)', () => {
+  beforeEach(() => {
+    disableFlag();
+  });
+
+  it('flag OFF 면 hasFiredForCycle 항상 false — mark 여부 무관', () => {
+    markFiredForCycle(STATION, LINE, TRAIN);
+    expect(hasFiredForCycle(STATION, LINE, TRAIN)).toBe(false);
+  });
+
+  it('flag OFF + remote undefined 도 false', () => {
+    markFiredForCycle(STATION, LINE, TRAIN);
+    expect(hasFiredForCycle(STATION, LINE, TRAIN, undefined)).toBe(false);
+  });
+
+  it('flag OFF + remote=off 도 false (backward-compat)', () => {
+    markFiredForCycle(STATION, LINE, TRAIN);
+    expect(hasFiredForCycle(STATION, LINE, TRAIN, 'off')).toBe(false);
+  });
+});
+
+describe('unifiedFireDedup — flag ON kind 무관 1 fire (#1997)', () => {
+  beforeEach(() => {
+    enableFlag();
+  });
+
+  it('첫 fire 는 통과 (mark 이전)', () => {
+    expect(hasFiredForCycle(STATION, LINE, TRAIN)).toBe(false);
+  });
+
+  it('mark 후 같은 cycle 재조회는 true (kind 무관 backstop)', () => {
+    // kind1 fire simulation
+    expect(hasFiredForCycle(STATION, LINE, TRAIN)).toBe(false);
+    markFiredForCycle(STATION, LINE, TRAIN);
+    // kind2 fire attempt → 통합 dedup 이 차단
+    expect(hasFiredForCycle(STATION, LINE, TRAIN)).toBe(true);
+  });
+
+  it('3+ 케이스 — destination / transfer / station-passed kind 무관 같은 cycle 1 fire', () => {
+    // simulation: caller 가 kind 별로 fire 시도. helper 는 kind 를 몰라도 첫 fire 만 통과.
+    // 1. destination kind 첫 fire
+    expect(hasFiredForCycle(STATION, LINE, TRAIN)).toBe(false);
+    markFiredForCycle(STATION, LINE, TRAIN);
+    // 2. transfer kind 시도 → dedup
+    expect(hasFiredForCycle(STATION, LINE, TRAIN)).toBe(true);
+    // 3. station-passed kind 시도 → dedup
+    expect(hasFiredForCycle(STATION, LINE, TRAIN)).toBe(true);
+  });
+
+  it('remote=on 만으로도 flag 활성 (env 없어도)', () => {
+    disableFlag();
+    markFiredForCycle(STATION, LINE, TRAIN);
+    expect(hasFiredForCycle(STATION, LINE, TRAIN, 'on')).toBe(true);
+  });
+
+  it('5→0 전환 시 새 cycle → 재발사 허용 (kind 무관)', () => {
+    // cycle 0 fire
+    markFiredForCycle(STATION, LINE, TRAIN);
+    expect(hasFiredForCycle(STATION, LINE, TRAIN)).toBe(true);
+    // 다음 train 도착 시퀀스
+    observeArvlCd(STATION, LINE, TRAIN, 5);
+    observeArvlCd(STATION, LINE, TRAIN, 0);
+    expect(getCurrentCycle(STATION, LINE, TRAIN)).toBe(1);
+    // 새 cycle 은 fire 되지 않은 상태
+    expect(hasFiredForCycle(STATION, LINE, TRAIN)).toBe(false);
+    // 새 cycle mark 후 재조회
+    markFiredForCycle(STATION, LINE, TRAIN);
+    expect(hasFiredForCycle(STATION, LINE, TRAIN)).toBe(true);
+  });
+
+  it('(station, line, trainCode) 조합 별로 독립적 fire 판정', () => {
+    markFiredForCycle(STATION, LINE, TRAIN);
+    expect(hasFiredForCycle(STATION, LINE, TRAIN)).toBe(true);
+    // 다른 station 은 fire 안 됨
+    expect(hasFiredForCycle('건대입구', LINE, TRAIN)).toBe(false);
+    // 다른 line, 같은 station 도 fire 안 됨
+    expect(hasFiredForCycle(STATION, '7', TRAIN)).toBe(false);
+    // 다른 trainCode 도 fire 안 됨
+    expect(hasFiredForCycle(STATION, LINE, '9999')).toBe(false);
+  });
+
+  it('TTL 만료 시 fire 허용 (5 분 이상)', () => {
+    const t0 = 1_700_000_000_000;
+    markFiredForCycle(STATION, LINE, TRAIN, t0);
+    expect(hasFiredForCycle(STATION, LINE, TRAIN, undefined, t0)).toBe(true);
+    // TTL 직전
+    expect(
+      hasFiredForCycle(STATION, LINE, TRAIN, undefined, t0 + UNIFIED_FIRE_DEDUP_TTL_MS - 1),
+    ).toBe(true);
+    // TTL 초과
+    expect(
+      hasFiredForCycle(STATION, LINE, TRAIN, undefined, t0 + UNIFIED_FIRE_DEDUP_TTL_MS),
+    ).toBe(false);
+  });
+
+  it('line=null 조합에서도 정상 dedup', () => {
+    markFiredForCycle(STATION, null, TRAIN);
+    expect(hasFiredForCycle(STATION, null, TRAIN)).toBe(true);
+    // (station, LINE) 은 별개 key
+    expect(hasFiredForCycle(STATION, LINE, TRAIN)).toBe(false);
+  });
+});
+
+describe('unifiedFireDedup — clearUnifiedFireDedup', () => {
+  beforeEach(() => {
+    enableFlag();
+  });
+
+  it('clear 후 모든 cycle state / fire ledger 초기화', async () => {
+    observeArvlCd(STATION, LINE, TRAIN, 5);
+    observeArvlCd(STATION, LINE, TRAIN, 0);
+    markFiredForCycle(STATION, LINE, TRAIN);
+    expect(getCurrentCycle(STATION, LINE, TRAIN)).toBe(1);
+    expect(hasFiredForCycle(STATION, LINE, TRAIN)).toBe(true);
+
+    await clearUnifiedFireDedup();
+
+    expect(getCurrentCycle(STATION, LINE, TRAIN)).toBe(0);
+    expect(hasFiredForCycle(STATION, LINE, TRAIN)).toBe(false);
+  });
+});
+
+describe('unifiedFireDedup — cap sweep', () => {
+  beforeEach(() => {
+    enableFlag();
+  });
+
+  it('cap 도달 시 만료 entry 를 sweep 하고 live entry 는 보존', () => {
+    const t0 = 1_700_000_000_000;
+    // 만료 예정 entry 를 대량 stamp
+    for (let i = 0; i < 520; i++) {
+      markFiredForCycle(`station-${i}`, LINE, TRAIN, t0);
+    }
+    // live entry 를 5 분 후 stamp — 이 시점에 sweep 이 발동해 옛 entry 삭제, live 는 유지.
+    const tLive = t0 + UNIFIED_FIRE_DEDUP_TTL_MS + 1;
+    markFiredForCycle('live-station', LINE, TRAIN, tLive);
+
+    // live entry 는 여전히 fire 상태
+    expect(hasFiredForCycle('live-station', LINE, TRAIN, undefined, tLive)).toBe(true);
+    // 만료된 entry 는 fire 없음 (sweep 되어 lookup 실패)
+    expect(hasFiredForCycle('station-0', LINE, TRAIN, undefined, tLive)).toBe(false);
+  });
+
+  it('cycle state Map cap 도달 시 만료 entry sweep', () => {
+    const t0 = 1_700_000_000_000;
+    for (let i = 0; i < 520; i++) {
+      observeArvlCd(`station-${i}`, LINE, TRAIN, 1, t0);
+    }
+    const tLive = t0 + UNIFIED_FIRE_DEDUP_TTL_MS + 1;
+    observeArvlCd('live-station', LINE, TRAIN, 5, tLive);
+    observeArvlCd('live-station', LINE, TRAIN, 0, tLive);
+    // live entry cycle 은 유지
+    expect(getCurrentCycle('live-station', LINE, TRAIN)).toBe(1);
+    // 옛 entry 는 sweep 되어 default 0 반환
+    expect(getCurrentCycle('station-0', LINE, TRAIN)).toBe(0);
+  });
+});

--- a/src/features/alarm/utils/unifiedFireDedup.ts
+++ b/src/features/alarm/utils/unifiedFireDedup.ts
@@ -1,0 +1,273 @@
+/**
+ * Unified fire dedup — ADR-022 Phase 1-5 (#1997).
+ *
+ * ## 배경
+ *
+ * #1980 코멘트 "동일 알림 반복 발사 근본 원인" 케이스 3 (채널 간 dedup 부족). 현 client
+ * dedup 5 채널 (`dedup-station`, `dedup-station-unified`, `dedup-alarm`,
+ * `dedup-channel-agnostic`, `dedup-cross-category-recent`) 은 각각 별개 판정하며 kind 가
+ * 다르면 통과한다. `station-passed` vs `destination` vs `imminent` 등 kind 만 다르면
+ * 같은 (station, line) 조합에서 여러 번 fire.
+ *
+ * ## 정책
+ *
+ * 통합 dedup key = `{stationName}|{line}|{trainCode}|{arvlCdCycle}` (kind 무관).
+ *
+ * - `stationName` 은 `normalizeStationName` (`src/shared/utils/normalizeStationName.js`,
+ *   전 프로젝트 SSOT) 로 정규화 — `'서울역(1)'` vs `'서울역'` 같은 표기 variant 를
+ *   하나의 cycle timeline 으로 묶어 wire PR 에서 caller 마다 다른 source (arrival API
+ *   응답 vs route.waypoint) 를 써도 dedup 이 성립하도록.
+ * - `trainCode` = `BoardingLock.trainCode` (사용자 target train). 같은 station 에 여러
+ *   train 이 동시에 있을 수 있어 (예: `arrival.up[]` + `arrival.down[]` 두 방향) train 간
+ *   arvlCd 값이 섞이면 cycle 추적이 오작동. `stationName + line + trainCode` 로 격리해
+ *   trip 안 사용자 target train 만 관측한다.
+ * - `arvlCdCycle` = per-(station, line, trainCode) 정수 counter. arvlCd 시퀀스
+ *   `0→1→2→5` monotone 관측. `5→0` 전환 시 +1 — 다음 train 도착 = 새 cycle.
+ *   (같은 trainCode 가 같은 station 을 재방문할 수 없어 실무적으로 `5→0` 은 재현 안
+ *   되지만 방어적으로 남긴다. 다음 train 은 다른 trainCode → 별개 timeline.)
+ * - 같은 (station, line, trainCode, cycle) 조합에서 **kind 무관 1 fire** 만 통과.
+ *
+ * ## 기존 5 채널 dedup 관계
+ *
+ * 별개 유지 — 통합 dedup 는 **layer 하나 더 추가** (additive backstop). 기존 채널이
+ * 각자의 회귀 (per-station race, cross-category cascade, phase-to-phase 등) 를 담당하고
+ * 본 통합 layer 는 kind-agnostic 최상위 backstop 이다.
+ *
+ * ## Flag guard
+ *
+ * Phase 0 (#1982) 의 real `isSimpleArchEnabled()` (`src/shared/config/archFlag.ts`).
+ *
+ * - flag OFF (기본) → `hasFiredForCycle` 항상 `false` (기존 5 채널만 동작, backward-compat).
+ * - flag ON → 통합 dedup layer 활성.
+ *
+ * `observeArvlCd` / `markFiredForCycle` 자체는 flag 무관하게 in-memory state 를 갱신한다.
+ * flag OFF 시에는 `hasFiredForCycle` 이 무조건 `false` 를 반환해 dead code — production
+ * 무영향.
+ *
+ * ## In-memory + TTL sweep
+ *
+ * AsyncStorage roundtrip race 를 배제해 in-memory Map 만 사용. 앱 재시작 시 reset 되며
+ * 그 직후엔 hydration warmup (#1010/#1316) 이 발사를 차단한다 (Phase 1-4 fireAlarmOnce 와
+ * 동일 설계).
+ *
+ * Entry 만료: `UNIFIED_FIRE_DEDUP_TTL_MS` (5 분, backend Phase 1-1
+ * `ARVLCD_FIRE_ONCE_TTL_SEC` 와 정합). Train 이 물리적으로 같은 station 을 5 분 안에
+ * 재방문할 수 없음이 근거. Map cap 도달 시 만료 entry 를 sweep — live cycle state 는 보존.
+ *
+ * Trip 종료 시엔 별도 `clearUnifiedFireDedup` API 로 전체 초기화 (후속 wire PR 에서
+ * `TRIP_BOUND_CLEANUPS` 등록 예정).
+ */
+
+import type { LineNumber } from '../../../shared/types/station';
+import { isSimpleArchEnabled } from '../../../shared/config/archFlag';
+// SSOT — 런타임(stationRoute.ts, transferTimes.ts, stationLookup.ts)과 빌드 스크립트
+// (build-transfer-times.js) 가 공유하는 정규화. 괄호 부제 제거 + trim.
+import { normalizeStationName } from '../../../shared/utils/normalizeStationName';
+
+/**
+ * arvlCd 시퀀스 monotone: 0 진입 → 1 도착 → 2 출발 → 5 전역도착. `5→0` 전환은 다음
+ * train 이 진입한 것 = 새 cycle. (본 모듈은 trainCode 별로 timeline 을 격리하므로
+ * `5→0` 은 실무상 재현 안 되지만 방어적으로 유지.)
+ *
+ * `ARRIVAL_CODE` (`src/shared/constants/arrivalCodes.ts`) 리터럴 값을 그대로 재사용하지
+ * 않은 이유: 본 모듈은 cycle 전환 판정만 담당하며 API 응답 값 상수와 결합도를 낮춰
+ * refactor 시 spec drift 를 격리한다. 값이 바뀌면 test 가 감지한다.
+ */
+const ARVL_CD_ENTERING = 0;
+const ARVL_CD_PREV_ARRIVED = 5;
+
+/**
+ * Entry TTL — 5 분. backend Phase 1-1 (#1985) `ARVLCD_FIRE_ONCE_TTL_SEC` 와 정합.
+ * Train 이 물리적으로 같은 station 을 5 분 안에 재방문할 수 없다는 실제 운영 특성 기반.
+ */
+export const UNIFIED_FIRE_DEDUP_TTL_MS = 5 * 60_000;
+
+/** Map cap — 도달 시 만료 entry 만 sweep (live 는 보존). 정상 trip 수백 개면 충분. */
+const MAP_CAP = 512;
+
+interface CycleState {
+  /** 현재 cycle 번호 (0 부터 시작, 5→0 전환 시 +1). */
+  cycle: number;
+  /** 마지막 관측된 arvlCd. cycle 전환 판정 (5 → 0) 용. */
+  lastArvlCd: number;
+  /** 마지막 갱신 timestamp. TTL sweep 용. */
+  ts: number;
+}
+
+const cycleStates = new Map<string, CycleState>();
+
+/**
+ * `${stationName}|${line}|${trainCode}` — 정규화된 stationName + line + trainCode
+ * 3-tuple 로 timeline 격리. wire PR 에서 caller 는 반드시 `BoardingLock.trainCode`
+ * (사용자 target train) 를 전달해야 한다 — 자세한 caller 룰은 `observeArvlCd` docstring 참조.
+ */
+function stateKey(
+  stationName: string,
+  line: LineNumber | null,
+  trainCode: string,
+): string {
+  const lineStr = line ?? 'null';
+  return `${normalizeStationName(stationName)}|${lineStr}|${trainCode}`;
+}
+
+interface FiredLedgerRecord {
+  cycle: number;
+  /** stamp timestamp. TTL sweep 용. */
+  ts: number;
+}
+
+/**
+ * fire 기록 ledger. key = `${stationName}|${line}|${trainCode}|${cycle}`. cycle 단위 캡슐화.
+ *
+ * cycle 이 전환 (예: 0 → 1) 되면 이전 cycle 의 fired stamp 는 그대로 남아있지만 새 cycle
+ * 은 별개 entry 라 다시 fire 가능. 오래된 entry 는 TTL sweep 대상.
+ */
+const firedLedger = new Map<string, FiredLedgerRecord>();
+
+function ledgerKey(
+  stationName: string,
+  line: LineNumber | null,
+  trainCode: string,
+  cycle: number,
+): string {
+  const lineStr = line ?? 'null';
+  return `${normalizeStationName(stationName)}|${lineStr}|${trainCode}|${cycle}`;
+}
+
+/**
+ * cap 도달 시 만료 entry (TTL 초과) 만 삭제. live entry 는 보존.
+ * cap 미달 이면 skip — 정상 trip 내엔 sweep 오버헤드 없음.
+ */
+function sweepExpired(now: number): void {
+  if (cycleStates.size > MAP_CAP) {
+    for (const [k, rec] of cycleStates) {
+      if (now - rec.ts >= UNIFIED_FIRE_DEDUP_TTL_MS) cycleStates.delete(k);
+    }
+  }
+  if (firedLedger.size > MAP_CAP) {
+    for (const [k, rec] of firedLedger) {
+      if (now - rec.ts >= UNIFIED_FIRE_DEDUP_TTL_MS) firedLedger.delete(k);
+    }
+  }
+}
+
+/**
+ * arvlCd 시퀀스 관측 — `5→0` 전환 시 cycle counter +1.
+ *
+ * **CALLER 룰 (필수 준수)**:
+ *   - **MUST** 사용자 target train 의 arvlCd 만 관측. `BoardingLock.trainCode` 로
+ *     `arrival.up[] + arrival.down[]` 중 매칭 row 를 하나 골라 그 row 의 `arvlCd` 를 넘긴다
+ *     (`findFgArvlCdFireSignal` 패턴, `fgArvlCdFastPath.ts:31` 참조).
+ *   - **DO NOT** `arrival.up[] + arrival.down[]` 를 iterate 해 매 train row 마다 호출하지
+ *     않는다. 여러 train 의 arvlCd 값이 섞이면 cycle 전환 (`prev.lastArvlCd=5 && arvlCd=0`)
+ *     이 잘못 트리거되고 사용자 target train 의 fire 가 dedup 되지 않는 회귀 발생.
+ *   - `trainCode` param 은 명시적으로 요구된다 — timeline 을 (station, line, trainCode) 3-tuple
+ *     로 격리해 다른 train row 관측이 실수로 섞여도 사용자 target train 에는 영향 없도록.
+ *
+ * 최초 관측 시 cycle = 0 로 초기화.
+ *
+ * 순차 관측 규칙:
+ *   - 이전 arvlCd = 5, 현재 arvlCd = 0 → cycle +1 (다음 train 진입).
+ *   - 그 외 전환 (0→1, 1→2, 2→5, 같은 값 반복 등) → cycle 유지.
+ *
+ * flag 무관하게 상태 갱신 — flag OFF 시에도 state 는 warm 상태로 유지되며 flag 전환
+ * 즉시 정확 판정 가능. state 축적 자체는 무해 (in-memory, TTL sweep).
+ */
+export function observeArvlCd(
+  stationName: string,
+  line: LineNumber | null,
+  trainCode: string,
+  arvlCd: number,
+  now: number = Date.now(),
+): void {
+  const key = stateKey(stationName, line, trainCode);
+  const prev = cycleStates.get(key);
+  if (prev === undefined) {
+    cycleStates.set(key, { cycle: 0, lastArvlCd: arvlCd, ts: now });
+    sweepExpired(now);
+    return;
+  }
+  const isCycleTransition =
+    prev.lastArvlCd === ARVL_CD_PREV_ARRIVED && arvlCd === ARVL_CD_ENTERING;
+  const nextCycle = isCycleTransition ? prev.cycle + 1 : prev.cycle;
+  cycleStates.set(key, { cycle: nextCycle, lastArvlCd: arvlCd, ts: now });
+  sweepExpired(now);
+}
+
+/**
+ * 현재 cycle 조회. 관측 이전이면 0.
+ *
+ * `hasFiredForCycle` / `markFiredForCycle` 이 내부적으로 호출하며, 외부에서도 log/debug
+ * 용도로 사용 가능.
+ */
+export function getCurrentCycle(
+  stationName: string,
+  line: LineNumber | null,
+  trainCode: string,
+): number {
+  const state = cycleStates.get(stateKey(stationName, line, trainCode));
+  return state?.cycle ?? 0;
+}
+
+/**
+ * 같은 (station, line, trainCode, current cycle) 조합에서 이미 fire 됐는지 판정.
+ *
+ * **Flag guard**: `isSimpleArchEnabled()` 가 `false` 면 항상 `false` 반환 — 기존 5 채널
+ * dedup 만 동작. Phase 1-5 는 flag OFF 상태로 머지, 후속 wire PR 에서 flag ON 후 caller
+ * 가 본 helper 를 backstop gate 로 사용.
+ *
+ * TTL 만료된 stamp 는 fire 를 허용 — 5 분 이상 지난 entry 는 새 cycle 관측이 없어도
+ * 재발사 통과 (실무 안전 마진).
+ *
+ * @param remoteFlag `useArchFlagRemote()` 결과. 미조회 시 `undefined` — env 만 참조.
+ * @returns true → dedup 적중 (skip 필요). false → 정상 fire 가능.
+ */
+export function hasFiredForCycle(
+  stationName: string,
+  line: LineNumber | null,
+  trainCode: string,
+  remoteFlag?: 'on' | 'off',
+  now: number = Date.now(),
+): boolean {
+  if (!isSimpleArchEnabled(remoteFlag)) return false;
+  const cycle = getCurrentCycle(stationName, line, trainCode);
+  const rec = firedLedger.get(ledgerKey(stationName, line, trainCode, cycle));
+  if (rec === undefined) return false;
+  return now - rec.ts < UNIFIED_FIRE_DEDUP_TTL_MS;
+}
+
+/**
+ * 성공 fire 직후 현재 cycle 을 stamp — 같은 (station, line, trainCode, cycle) 에 대한
+ * 후속 fire 는 `hasFiredForCycle` 이 true 를 반환하도록.
+ *
+ * flag 무관하게 stamp — flag OFF 시에도 state 는 warm 상태로 유지 (state 축적 무해).
+ * flag 전환 즉시 정확 판정 가능.
+ */
+export function markFiredForCycle(
+  stationName: string,
+  line: LineNumber | null,
+  trainCode: string,
+  now: number = Date.now(),
+): void {
+  const cycle = getCurrentCycle(stationName, line, trainCode);
+  firedLedger.set(ledgerKey(stationName, line, trainCode, cycle), { cycle, ts: now });
+  sweepExpired(now);
+}
+
+/**
+ * trip 종료 / 전환 시 호출 — 모든 cycle state 및 fire ledger 초기화. trip 간 leak 차단.
+ *
+ * caller 는 `TRIP_BOUND_CLEANUPS` (`src/features/alarm/store/tripBoundCleanups.ts`) 에
+ * 후속 wire PR 에서 등록. 본 helper 자체는 fire-and-forget Promise 로 반환.
+ */
+export function clearUnifiedFireDedup(): Promise<void> {
+  cycleStates.clear();
+  firedLedger.clear();
+  return Promise.resolve();
+}
+
+/** 테스트 전용 — 모듈 상태 리셋. production 호출 금지. */
+export function _resetUnifiedFireDedupForTests(): void {
+  cycleStates.clear();
+  firedLedger.clear();
+}


### PR DESCRIPTION
Closes #1997
Part of ADR-022 arrival API SSOT 재설계 (#1980), Phase 1 wave 2 마지막 sub-issue.

## 배경

Dedup 채널 5개 각각 별개 동작 (`dedup-station`, `dedup-station-unified`, `dedup-alarm`, `dedup-channel-agnostic`, `dedup-cross-category-recent`). **kind 다르면 dedup 통과** → 같은 station이 station-passed / destination / imminent 각각 fire.

7/1 오후 어린이대공원 silent-push-received 4번 반복 (`unk` 3번 + `station-passed imminent` 1번)이 이 케이스.

## 변경

### 신규: `src/features/alarm/utils/unifiedFireDedup.ts`
- **통합 dedup key**: `{normalizeStationName(stationName)}|{line}|{trainCode}` (kind 무관)
- **arvlCd cycle 추적**: `observeArvlCd(stationName, line, trainCode, arvlCd)` — 0→1→2→5 순환 판정. cycle 전환 감지 시 새 cycle 시작
- **fire ledger**: `markFiredForCycle` / `hasFiredForCycle` — 같은 (station, line, trainCode, cycle) 조합 kind 무관 1 fire
- **flag guard**: `isSimpleArchEnabled()` — flag OFF 시 helper 자체 무동작 (dormant), flag ON 시 wire PR 호출자 사용

### 정책 요약
- 5 기존 채널 dedup은 그대로 유지 (기존 동작 보존)
- 통합 dedup은 wire PR (Phase 1-5 후속)에서 layer 하나 더 추가
- **stationName 정규화**: `normalizeStationName` 재사용 → "서울역(1)" vs "서울역" 같은 cycle
- **trainCode 격리**: 다른 train arvlCd 섞여도 target train만 cycle 전환

## Finding 처리 (code-review medium)

### 초기 finding 2개 (fix 완료)
| # | Finding | 처리 |
|---|---------|------|
| 1 | stationName 정규화 부재 | **fix** — `normalizeStationName` 재사용 (key 생성 전 항상 정규화) |
| 2 | `observeArvlCd` docstring + trainCode explicit param | **fix** — trainCode explicit param 추가, state key = `stationName + line + trainCode` |

### 후속 finding 2개 (트레이드오프)
| # | Finding | 처리 근거 |
|---|---------|-----------|
| 3 | Empty trainCode 미검증 (lockless trip) | **wire PR concern** — helper 자체 레벨 아님. wire PR에서 lockless 시 helper 미사용 or 별도 처리 |
| 4 | `ARVL_CD_ENTERING`/`ARVL_CD_PREV_ARRIVED` 리터럴 duplicate | **디자인 선택** — 모듈 decoupling 유지 (docstring L72-74). 필요 시 후속 refactor로 `ARRIVAL_CODE` import + local alias 전환 |

## acceptance
- [x] 통합 dedup helper + key builder + test
- [x] real `isSimpleArchEnabled()` wire (helper 레벨)
- [x] flag OFF 기존 동작 유지 (helper dormant)
- [x] flag ON 시 같은 (station, line, trainCode, cycle) 조합 kind 무관 1 fire (test)
- [x] stationName 정규화 (variants 같은 cycle 처리)
- [x] trainCode 격리 (다른 train 간섭 방지)

## 검증
- `npm test` PASS + coverage 100%
- `npm run type-check` clean
- `code-review medium` — 후속 finding 2개는 트레이드오프로 명시

## 다음 (wire PR)
Phase 1-5 helper 자체는 dormant. 후속 wire PR에서 `useStationAlarm` / `silentPushTask` 호출자에 통합 layer 추가.

## refs
- ADR-022 (#1980) A6 / B3 정책
- Phase 1-1 arvlCd fire-once TTL (#1985) — backend 대응
- Phase 1-4 fireAlarmOnce ledger (#1984) — client fg race fix
- 반복 알림 조사 (#1980 comment) — 이 sub의 case 3 (kind 다르면 dedup 통과)