### PR TITLE
chore(#2002): Wave 1 임시 flag 상수 → real helper wire (Phase 1-3, 1-4)

### DIFF
--- a/backend/alarm-worker/src/__tests__/trips.test.ts
+++ b/backend/alarm-worker/src/__tests__/trips.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ARCH_FLAG_KV_KEY } from '../archFlag';
 import {
-  SIMPLE_ARCH_ENABLED,
   cleanupPendingPushesForToken,
   clearStaleBoardingLock,
   computeRouteSignature,
@@ -239,9 +239,18 @@ describe('trips KV CRUD', () => {
       };
     }
 
-    describe('SIMPLE_ARCH_ENABLED flag (Phase 1-3)', () => {
-      it('module 상수는 기본 OFF (false) — Phase 1-3 인프라만 병존', () => {
-        expect(SIMPLE_ARCH_ENABLED).toBe(false);
+    describe('arch flag default (Phase 1-3, #2002 real helper wire)', () => {
+      it('KV 미설정 → default OFF: `rotateTripTokenForNewRoute` 기존 동작 유지', async () => {
+        // KV 에 arch flag 미설정 → getArchFlag 는 default 'off' 반환 → rotation 없음.
+        const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
+        await putTrip(kv as unknown as KVNamespace, existing);
+        const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
+        const result = await rotateTripTokenForNewRoute(
+          kv as unknown as KVNamespace,
+          incoming,
+          existing,
+        );
+        expect(result).toEqual({ token: 'tok-old', rotated: false });
       });
     });
 
@@ -343,7 +352,7 @@ describe('trips KV CRUD', () => {
     });
 
     describe('rotateTripTokenForNewRoute (flag OFF)', () => {
-      it('flag OFF (default): 항상 incoming token 그대로 반환 + KV 변경 없음', async () => {
+      it('flag OFF (KV 미설정 default): 항상 incoming token 그대로 반환 + KV 변경 없음', async () => {
         const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
         await putTrip(kv as unknown as KVNamespace, existing);
         const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
@@ -367,7 +376,9 @@ describe('trips KV CRUD', () => {
         expect(result).toEqual({ token: 'tok-new', rotated: false });
       });
 
-      it('flag OFF: deps.simpleArchEnabled=false 명시도 동일', async () => {
+      it('flag OFF: deps.simpleArchEnabled=false 명시도 동일 (DI 우선)', async () => {
+        // #2002 — KV 에 flag=on 있어도 deps 명시가 우선 → OFF 동작.
+        await kv.put(ARCH_FLAG_KV_KEY, 'on');
         const existing = makeTrip({ token: 'tok-A', destination: 'D-1' });
         const incoming = makeTrip({ token: 'tok-A', destination: 'D-2' });
         const result = await rotateTripTokenForNewRoute(
@@ -377,6 +388,20 @@ describe('trips KV CRUD', () => {
           { simpleArchEnabled: false },
         );
         expect(result).toEqual({ token: 'tok-A', rotated: false });
+      });
+
+      it('flag OFF: KV value 오타 (default fallback)도 OFF 동작', async () => {
+        // #2002 — getArchFlag 는 'on' | 'off' 외 값을 default 'off' 로 정규화 → rotation 없음.
+        await kv.put(ARCH_FLAG_KV_KEY, 'invalid-value');
+        const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
+        await putTrip(kv as unknown as KVNamespace, existing);
+        const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
+        const result = await rotateTripTokenForNewRoute(
+          kv as unknown as KVNamespace,
+          incoming,
+          existing,
+        );
+        expect(result).toEqual({ token: 'tok-old', rotated: false });
       });
     });
 
@@ -512,6 +537,23 @@ describe('trips KV CRUD', () => {
         );
         expect(result.rotated).toBe(true);
         spy.mockRestore();
+      });
+
+      it('#2002 — deps 미지정 + KV `arch:simple-arrival-v1`=on: 실제 helper 로 flag ON 동작', async () => {
+        // #2002 — real helper `getArchFlag(kv)` wire 검증. deps 미명시하면 KV 값으로 결정.
+        await kv.put(ARCH_FLAG_KV_KEY, 'on');
+        const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
+        await putTrip(kv as unknown as KVNamespace, existing);
+        const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
+        const result = await rotateTripTokenForNewRoute(
+          kv as unknown as KVNamespace,
+          incoming,
+          existing,
+          { generateToken: () => 'new-token-from-kv-flag' },
+        );
+        expect(result).toEqual({ token: 'new-token-from-kv-flag', rotated: true });
+        // Old KV entry 삭제됨
+        expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).toBeNull();
       });
     });
   });

--- a/backend/alarm-worker/src/trips.ts
+++ b/backend/alarm-worker/src/trips.ts
@@ -1,3 +1,4 @@
+import { getArchFlag } from './archFlag';
 import {
   assertCronCacheTtl,
   assertKvCacheTtl,
@@ -16,7 +17,7 @@ import type { Trip } from './types';
 const TRIP_PREFIX = 'trip:';
 
 /**
- * ADR-022 B4 — 새 route = 새 token 강제 (Phase 1-3 인프라).
+ * ADR-022 B4 — 새 route = 새 token 강제 (Phase 1-3, #2002 wire).
  *
  * 2026-06-17 ~ 2026-07-01 15일 회귀: `trip token e25e1158` 재사용으로 사용자가 새 route
  * 등록해도 old destination(용마산) silent push가 계속 발사되고 device는
@@ -26,10 +27,10 @@ const TRIP_PREFIX = 'trip:';
  * device 수명 동안 token이 안정하므로 route/destination이 바뀌어도 같은 KV entry에 덮어써짐.
  * `isSameSession`은 trainCode/createdAt 기준 → route/destination 차이가 있어도 같은 token 유지.
  *
- * Phase 1-3 정책: flag OFF일 때 기존 동작 유지. Phase 2 dogfood 시점에 flag ON 전환.
- * Rollback: 상수를 `false`로 되돌리면 즉시 기존 동작 복귀 (배포 없음).
+ * #2002 — 임시 상수 `SIMPLE_ARCH_ENABLED` 제거. Phase 0 (#1988) 머지 후 real helper
+ * `getArchFlag(kv)` 로 교체. flag 값은 KV `arch:simple-arrival-v1` 로 관리 (rollback = KV write).
+ * Rollback: `POST /admin/arch-flag {value:'off'}` 로 즉시 되돌린다 (배포 없음).
  */
-export const SIMPLE_ARCH_ENABLED = false;
 
 /**
  * cron read의 KV cacheTtl (#766/#770 → #1364 → #1381).
@@ -164,10 +165,10 @@ export function computeRouteSignature(trip: Trip): string {
  * `POST /trips`가 호출하는 진입점. incoming trip과 existing trip의 route/destination
  * 시그니처를 비교해 다르면 새 token 발급 + old token cleanup, 같으면 incoming token 유지.
  *
- * Flag OFF (`SIMPLE_ARCH_ENABLED === false`): 기존 동작 유지 — incoming.token 그대로 반환,
- * KV cleanup 없음. Phase 1-3 인프라만 병존.
+ * Flag OFF (default, KV `arch:simple-arrival-v1` !== 'on'): 기존 동작 유지 — incoming.token
+ * 그대로 반환, KV cleanup 없음. Phase 1-3 인프라만 병존.
  *
- * Flag ON (Phase 2+): existing 있고 route sig 다르면
+ * Flag ON (Phase 2+, KV `arch:simple-arrival-v1` === 'on'): existing 있고 route sig 다르면
  *   1. `crypto.randomUUID()`로 새 token 생성
  *   2. `trip:<oldToken>` KV delete
  *   3. `pending:*` 중 `entry.token === oldToken` 인 entry 모두 delete
@@ -176,7 +177,9 @@ export function computeRouteSignature(trip: Trip): string {
  * existing 없음 또는 같은 route: incoming.token 그대로 반환 (`rotated: false`).
  *
  * Testability: `deps.simpleArchEnabled` / `deps.generateToken` DI로 flag 강제 + token 결정성
- * 확보. 기본은 모듈 상수(`SIMPLE_ARCH_ENABLED`) + `crypto.randomUUID`. 테스트가 옵션 명시.
+ * 확보. 기본은 real helper `getArchFlag(kv)` + `crypto.randomUUID`. 테스트가 옵션 명시.
+ * #2002 — 임시 상수 대신 real helper wire. KV 미바인딩 / 미설정 견해는 `getArchFlag` 가
+ * default `'off'` 로 fallback → 기존 동작 유지.
  */
 export interface TokenRotationResult {
   token: string;
@@ -184,7 +187,7 @@ export interface TokenRotationResult {
 }
 
 export interface TokenRotationDeps {
-  /** flag override — 미지정 시 모듈 상수 `SIMPLE_ARCH_ENABLED`. */
+  /** flag override — 미지정 시 `getArchFlag(kv) === 'on'` 조회. */
   simpleArchEnabled?: boolean;
   /** 새 token 발급 함수 — 미지정 시 `crypto.randomUUID`. */
   generateToken?: () => string;
@@ -196,7 +199,11 @@ export async function rotateTripTokenForNewRoute(
   existing: Trip | null,
   deps?: TokenRotationDeps,
 ): Promise<TokenRotationResult> {
-  const flagEnabled = deps?.simpleArchEnabled ?? SIMPLE_ARCH_ENABLED;
+  // #2002 — real helper wire. deps.simpleArchEnabled DI 명시가 우선; 미지정 시 KV 조회.
+  // `getArchFlag` 는 KV 미바인딩/미설정/오타 모두 default `'off'` 로 fallback (dormant).
+  // 명시적 괄호: `??` 가 `===` 보다 tighter 로 파싱되므로 DI boolean 값 우선 사용을 보장한다.
+  const flagEnabled =
+    deps?.simpleArchEnabled ?? ((await getArchFlag(kv)) === 'on');
   // Flag OFF: 기존 동작 유지. incoming token 그대로.
   if (!flagEnabled) {
     return { token: incoming.token, rotated: false };

--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -5,7 +5,6 @@
  */
 import { renderHook, waitFor } from '@testing-library/react-native';
 import {
-  __setSimpleArchEnabledForTests,
   useStationAlarm,
   type UseStationAlarmInputs,
 } from '../useStationAlarm';
@@ -13,6 +12,7 @@ import {
   _resetFireAlarmOnceForTests,
   fireAlarmOnce,
 } from '../../utils/fireAlarmOnce';
+import { SIMPLE_ARRIVAL_ARCH_ENV_KEY } from '../../../../shared/config/archFlag';
 import { useSettingsStore } from '../../../settings/store/useSettingsStore';
 import { useAlarmEventStore } from '../../store/useAlarmEventStore';
 import type { Station } from '../../../../shared/types/station';
@@ -256,9 +256,11 @@ describe('useStationAlarm', () => {
     // #1515 — cross-category dedup 모듈 in-memory 상태 리셋. mock하지 않은 실모듈 사용.
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     require('../../utils/crossCategoryStationDedup')._resetCrossCategoryDedupForTests();
-    // #1984 — fire-once ledger + flag OFF 리셋. 각 테스트가 필요한 경우 명시적으로 flag ON.
+    // #1984 — fire-once ledger 리셋. 각 테스트가 필요한 경우 env 로 flag ON.
+    // #2002 — 임시 setter (`__setSimpleArchEnabledForTests`) 제거. real helper wire —
+    // `EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH` env 값으로 게이트.
     _resetFireAlarmOnceForTests();
-    __setSimpleArchEnabledForTests(false);
+    delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
   });
 
   it('does not evaluate when route is null', () => {
@@ -5649,15 +5651,16 @@ describe('useStationAlarm', () => {
     });
   });
 
-  // #1984 (Phase 1-4, ADR-022 B3) — simpleArchEnabled=true 시 unified fire ledger가 Phase ETA +
+  // #1984 (Phase 1-4, ADR-022 B3) — flag ON 시 unified fire ledger가 Phase ETA +
   // API imminent 두 useEffect의 동일 (station+line+kind+phase) 재발사를 sync entry-guard로 차단.
   // 회귀 evidence: 2026-07-01 08:32:09 성수 fg fired station-passed 2건 (#1980 코멘트 케이스 1).
-  describe('#1984 simpleArchEnabled unified fire path', () => {
+  // #2002 — 임시 setter 대신 `EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH` env 로 flag 게이트.
+  describe('#1984 isSimpleArchEnabled unified fire path', () => {
     const route = makeDirectRoute(3, '2');
     const station = makeStation('S1', '시청');
 
     it('flag OFF (기본): Phase ETA fire 정상 — fireAlarmOnce dedup 미적용 (backward-compat)', async () => {
-      __setSimpleArchEnabledForTests(false);
+      delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
       mockEvaluateAlarmPhase.mockReturnValue(imminentDest);
 
       renderHook(() =>
@@ -5678,7 +5681,7 @@ describe('useStationAlarm', () => {
     });
 
     it('flag ON: 첫 fire 정상 발사 + logFiredAlarm', async () => {
-      __setSimpleArchEnabledForTests(true);
+      process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
       mockEvaluateAlarmPhase.mockReturnValue(imminentDest);
 
       renderHook(() =>
@@ -5708,7 +5711,7 @@ describe('useStationAlarm', () => {
       // 같은 초 race 시나리오 재현: ledger가 다른 fire path(예: 앞서 실행된 다른 useEffect 또는
       // 채널)로 이미 stamp된 상태에서 Phase ETA useEffect가 같은 조합으로 dispatch 시도 → 차단.
       // 사용자 evidence(2026-07-01 08:32:09 성수 fg fired 2건)의 두 번째 fire 차단 검증.
-      __setSimpleArchEnabledForTests(true);
+      process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
       // ledger에 imminent destination 강남 (line=2) fire를 사전 stamp — 다른 채널이 먼저 발사한 상황.
       await fireAlarmOnce(
         {
@@ -5753,7 +5756,7 @@ describe('useStationAlarm', () => {
     });
 
     it('flag ON: 다른 phase(early → imminent) 진행은 정상 통과 (정상 phase 진행 보존)', async () => {
-      __setSimpleArchEnabledForTests(true);
+      process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
       const { rerender } = renderHook(
         ({ input }: { input: UseStationAlarmInputs }) => useStationAlarm(input),
         {
@@ -5811,7 +5814,7 @@ describe('useStationAlarm', () => {
     });
 
     it('flag ON: rawEvent에 line=null 상황도 방어적 stringify로 정상 dedup', async () => {
-      __setSimpleArchEnabledForTests(true);
+      process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
       // nearestStation 미제공 + lock.boardingLine 미설정 → resolveCurrentLine = null.
       mockGetBoardingLock.mockResolvedValue({
         destinationId: 'D1',

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -84,39 +84,27 @@ import { createLogger } from '../../../shared/utils/logger';
 import { isAccuracyAcceptable } from '../../nearest-station/utils/locationGates';
 import type { FusionConfidence, FusionSource } from '../../../shared/types/fusion';
 import { resolveNotificationSource, type NotificationSource } from '../utils/notificationSource';
+import { isSimpleArchEnabled } from '../../../shared/config/archFlag';
 
 const logger = createLogger('StationAlarm');
 
 /**
- * #1984 (Phase 1-4, ADR-022 B3) — client 채널 통합 fire path flag.
+ * #1984 (Phase 1-4, ADR-022 B3) — client 채널 통합 fire path.
  *
- * `false` (기본): 기존 fire 흐름 유지 (Phase ETA + API imminent 두 useEffect가 각각 `fireAndLog`
- * 직접 호출). backward-compat 보장 — 본 PR은 flag OFF 상태로 머지.
+ * flag OFF (default, `EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH !== 'true'`): 기존 fire 흐름 유지
+ * (Phase ETA + API imminent 두 useEffect가 각각 `fireAndLog` 직접 호출). backward-compat 보장.
  *
- * `true`: 두 useEffect가 `fireAlarmOnce` unified ledger를 통과한 뒤에만 `fireAndLog` 호출.
- * ledger key = `${stationName}|${line}|${kind}|${phase}` — 같은 초 동시 dispatch race 차단.
- * Phase 5 실기기 검증 후 별도 이슈에서 true로 전환 예정 (staged rollout).
+ * flag ON (`EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH === 'true'` — dogfood 빌드): 두 useEffect가
+ * `fireAlarmOnce` unified ledger를 통과한 뒤에만 `fireAndLog` 호출. ledger key =
+ * `${stationName}|${line}|${kind}|${phase}` — 같은 초 동시 dispatch race 차단.
  *
  * 회귀 evidence (2026-07-01 08:32:09 성수 fg fired station-passed 2건, #1980 코멘트 케이스 1).
  *
- * 테스트 전용 override: `__setSimpleArchEnabledForTests(true|false)`. production 호출 금지.
+ * #2002 — 임시 module-scope `let simpleArchEnabled` + `__setSimpleArchEnabledForTests` 삭제.
+ * Phase 0 real helper `isSimpleArchEnabled()` (`src/shared/config/archFlag.ts`) 로 교체 —
+ * env `EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH === 'true'` 또는 caller 가 remote flag 전달 시 활성.
+ * fire 시점에 매번 조회 — 매 시점 최신 flag 반영 (테스트에서 env 조작만으로 flag 전환 가능).
  */
-let simpleArchEnabled = false;
-
-/**
- * 테스트 전용 — SIMPLE_ARCH_ENABLED flag override.
- * `useStationAlarm.test.ts`의 unified fire ledger 검증에서만 사용. production 코드는 호출 X.
- *
- * Finding #4 review 반영: production NODE_ENV 오호출 방지 guard. debug menu / accidental
- * import 경로로 flag 우발 전환 차단.
- */
-export function __setSimpleArchEnabledForTests(value: boolean): void {
-  /* istanbul ignore next -- production guard. jest는 NODE_ENV='test'이라 도달 불가. */
-  if (process.env.NODE_ENV === 'production') {
-    throw new Error('__setSimpleArchEnabledForTests must not be called in production');
-  }
-  simpleArchEnabled = value;
-}
 
 // #1010/#1316/#1645 — 하이드레이션 warmup. lock hydrate 완료 후 이 기간 동안 알람 발사를 차단한다.
 // 하이드레이션 직후 firedAlarms가 복원되기 전 GPS/ETA 신호와 동기화되는 과도 구간 false alarm 방지.
@@ -1012,14 +1000,17 @@ export function useStationAlarm({
   /**
    * #1984 (Phase 1-4, ADR-022 B3) — client 채널 통합 fire ledger gate.
    *
-   * `simpleArchEnabled=false` (기본): 바로 `fireAndLog` 호출 — 기존 흐름 그대로.
-   * `simpleArchEnabled=true`: `fireAlarmOnce` ledger를 sync entry-guard로 통과한 뒤에만
+   * flag OFF (default): 바로 `fireAndLog` 호출 — 기존 흐름 그대로.
+   * flag ON: `fireAlarmOnce` ledger를 sync entry-guard로 통과한 뒤에만
    * `fireAndLog` 호출. 같은 (stationName, line, kind, phase) 조합이 30s 안에 이미 fire됐으면
    * skip + `logSuppressedFireAlarmOnce` 적재. Phase ETA + API imminent 두 useEffect가 같은
    * 초에 dispatch 시도한 회귀(2026-07-01 08:32:09 성수 fg fired station-passed 2건)를 차단.
    *
    * currentLine = lock.boardingLine 우선(currentLockLine) → nearestStation.line fallback.
    * `resolveCurrentLine` SSOT와 동일 규약.
+   *
+   * #2002 — fire 시점에 `isSimpleArchEnabled()` 호출 (env `EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH`
+   * 값 기반). remote flag 반영이 필요한 caller 는 후속 PR 에서 arg 로 전달 예정.
    */
   async function fireViaUnifiedGate(
     rawEvent: AlarmEvent,
@@ -1027,7 +1018,7 @@ export function useStationAlarm({
     activeRoute: NonNullable<Route>,
     activeDestination: Station,
   ): Promise<void> {
-    if (!simpleArchEnabled) {
+    if (!isSimpleArchEnabled()) {
       await fireAndLog(rawEvent, trigger, activeRoute, activeDestination);
       return;
     }
@@ -1138,7 +1129,7 @@ export function useStationAlarm({
     // #699: fireAndLog가 setFiredAlarms를 await하므로 promise를 명시적으로 흘려보낸다.
     // #754: in-flight dedup은 fireAndLog 진입부의 sync firedAlarmsRef.current.add(key) 가
     // 보장한다 (await getBoardingLock 전에 set에 들어가므로 같은 키의 동시 호출은 즉시 return).
-    // #1984: simpleArchEnabled=true 시 unified fire ledger(fireAlarmOnce)가 sync entry-guard로
+    // #1984: flag ON 시 unified fire ledger(fireAlarmOnce)가 sync entry-guard로
     // 같은 (station+line+kind+phase) 조합의 동일 초 재발사를 차단한 뒤에만 fireAndLog로 진행.
     if (rawEvent) {
       // #746 — dismiss silence 게이트. 사용자 dismiss 후 5분/200m 이내라면 모든 카테고리 차단.
@@ -1268,7 +1259,7 @@ export function useStationAlarm({
     const rawEvent: AlarmEvent = { phaseId: 'imminent', type: 'destination', stationName: destination.name };
     // #699: setFiredAlarms 영속화 완료를 await — silent push BG 핸들러가 같은 imminent를
     // 재발사하지 않도록 storage가 sync된 후 다음 cycle 진입.
-    // #1984: simpleArchEnabled=true 시 unified fire ledger가 Phase ETA effect와의 동일 초
+    // #1984: flag ON 시 unified fire ledger가 Phase ETA effect와의 동일 초
     // 재발사 race를 sync entry-guard로 차단.
     void fireViaUnifiedGate(rawEvent, 'api', route, destination);
   }, [

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -298,7 +298,8 @@ export type AlarmLogReason =
   // #1984 (Phase 1-4, ADR-022 B3) — client 채널 통합 fire ledger가 catch한 재발사 1건.
   // Phase ETA + API imminent 두 useEffect가 같은 초에 동일 (station+line+kind+phase) 조합으로
   // dispatch 시도한 케이스를 sync entry-guard로 차단. evidence: 2026-07-01 08:32:09 fg fired
-  // station-passed 성수 2건. SIMPLE_ARCH_ENABLED=true 상태에서만 발생 (flag OFF 시 dead code).
+  // station-passed 성수 2건. `isSimpleArchEnabled()` ON (env=true / KV=on) 상태에서만 발생
+  // — flag OFF 시 unified gate 는 dead code.
   | 'dedup-simple-arch-fire-once';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
@@ -543,7 +544,7 @@ export function logSuppressedChannelAgnosticDedup(input: {
  * 에서 Phase ETA 또는 API imminent useEffect가 재발사를 시도한 case. sync entry-guard로 fire
  * callback 실행 자체를 차단 — 사용자 체감 "같은 초 2건" 회귀 근본 차단.
  *
- * SIMPLE_ARCH_ENABLED=true(useStationAlarm) 상태에서만 발생. flag OFF 시 본 helper는 호출 X
+ * `isSimpleArchEnabled()` ON (useStationAlarm) 상태에서만 발생. flag OFF 시 본 helper는 호출 X
  * (dead code). burst dedup으로 같은 (source, stationName) 반복 로그는 1건만 적재.
  */
 export function logSuppressedFireAlarmOnce(input: {

--- a/src/features/alarm/utils/fireAlarmOnce.ts
+++ b/src/features/alarm/utils/fireAlarmOnce.ts
@@ -17,8 +17,8 @@
  *   진행(early → imminent)은 phase 필드가 달라 별도 키 → 통과.
  * - **In-memory only**: AsyncStorage roundtrip race가 본 회귀 원인이라 의도적으로 storage 배제.
  *   앱 재시작 시 reset되고 그 직후엔 hydration warmup(#1010/#1316)이 발사를 차단한다.
- * - **flag guard**: 호출부(`useStationAlarm.ts`)의 `SIMPLE_ARCH_ENABLED` 상수 OFF 시 본 ledger는
- *   dead code — 기존 fire 흐름이 그대로 동작 (backward-compat).
+ * - **flag guard**: 호출부(`useStationAlarm.ts`)의 `isSimpleArchEnabled()` OFF 시 본 ledger는
+ *   dead code — 기존 fire 흐름이 그대로 동작 (backward-compat). #2002 — Phase 0 real helper wire.
  *
  * ## API
  * - `fireAlarmOnce(payload, fire)` — sync in-flight reservation → fire callback 실행 → 성공 시만


### PR DESCRIPTION
Closes #2002

## Summary

ADR-022 Wave 1 Phase 1 sub-issue (#1986 backend token rotation, #1984 client unified fire ledger) 은 Phase 0 (Feature Flag 인프라 #1988) 머지 전 spawn 되어 각각 **임시 상수/setter** 로 flag 를 표현했다.

Phase 0 real helper (`getArchFlag` / `isSimpleArchEnabled`) 는 이미 dev 머지 완료 (`backend/alarm-worker/src/archFlag.ts`, `src/shared/config/archFlag.ts`). 다른 Phase 1 sub (#1996 `useBoardingLockStore`, #1994 `unifiedFireDedup`) 은 이미 real helper 를 사용 중.

본 chore 는 남은 두 파일 (Phase 1-3, 1-4) 을 Phase 0 real helper 로 통합한다.

## 변경 내역

### Phase 1-3 backend — `backend/alarm-worker/src/trips.ts`
- `export const SIMPLE_ARCH_ENABLED = false;` 상수 제거.
- `rotateTripTokenForNewRoute` 내부에서 `deps?.simpleArchEnabled ?? ((await getArchFlag(kv)) === 'on')` 로 real helper 조회.
- 명시적 괄호: `??` 가 `===` 보다 tighter 로 파싱되므로 DI boolean 값 우선 사용을 보장.
- test 조정: `SIMPLE_ARCH_ENABLED` import 제거 + 새 case ("KV=on 미지정 deps → 실제 helper 로 flag ON 동작", "KV 오타 fallback OFF 확인") 추가.

### Phase 1-4 client — `src/features/alarm/hooks/useStationAlarm.ts` + `src/features/alarm/utils/fireAlarmOnce.ts`
- module-scope `let simpleArchEnabled = false;` 제거.
- `__setSimpleArchEnabledForTests` 함수 제거.
- `fireViaUnifiedGate` 가 fire 시점에 `isSimpleArchEnabled()` (env `EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH`) 호출.
- test 조정: 임시 setter 호출 → `process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true'/'false'` (`useBoardingLockStore.test.ts` 패턴 재사용).

### 주변 주석 정리
- `alarmLog.ts`, `fireAlarmOnce.ts`: `SIMPLE_ARCH_ENABLED=true` 표기 → `isSimpleArchEnabled()` ON (env=true / KV=on).

## Acceptance

- [x] Phase 1-3 backend `trips.ts` 임시 상수 삭제 + `getArchFlag(kv)` wire + test 조정
- [x] Phase 1-4 client `useStationAlarm.ts` + `fireAlarmOnce.ts` 임시 상수 삭제 + `isSimpleArchEnabled()` wire + test 조정
- [x] `__setSimpleArchEnabledForTests` 함수 삭제 (Phase 1-4)
- [x] 기존 test 통과 (mock 방식만 조정, 기능 동작 동일) — backend 2431 tests / client 8922 tests PASS
- [x] flag OFF 시 기존 동작 유지 (helper OFF 이면 두 sub 동작 없음) — KV 미바인딩/미설정/오타 모두 `getArchFlag` 가 `'off'` 로 정규화
- [x] flag ON 시 두 sub 실제로 활성 — env `EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH=true` (client) / KV `arch:simple-arrival-v1=on` (backend)
- [x] backend + client 100% coverage
- [x] type-check clean (`npm run type-check`, `cd backend/alarm-worker && npx tsc --noEmit`)

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass. 새 export 없음; 삭제된 export (`SIMPLE_ARCH_ENABLED`, `__setSimpleArchEnabledForTests`) 는 test-only 였으므로 production caller 없음.
2. **V/X dashboard** — 변경 없음. DebugModal 이 이미 `isSimpleArchEnabled(archFlagRemote.value)` 표시.
3. **의존 PR** — Phase 0 #1988 (dev 머지 완료). Wave 1 sub #1984, #1986 (dev 머지 완료).
4. **측정 plan** — Phase 2 dogfood 시점에 env=true 빌드로 로컬 검증. 이후 KV write 로 rollout. 본 PR 자체는 flag OFF 라 회귀 신호 미발생 (기존 동작 그대로).
5. **Device verify** — N/A — type+unit only. flag OFF default 라 device runtime 무영향. remote flag plumbing 은 후속 PR 에서 처리 (`isSimpleArchEnabled()` 가 env-only 참조).

## Test plan

- [x] `cd backend/alarm-worker && npm test` PASS (2431 tests)
- [x] `npm test` PASS (8922 tests, 100% coverage)
- [x] `npm run type-check` PASS
- [x] `npm run lint:orphan` PASS
- [x] `code-review medium` 완료 — findings 0건 (deferred remote-flag plumbing 은 sibling 코드베이스 패턴과 일치)

## 후속 참고

- 4 lint errors 는 pre-existing (`tripBoundCleanups.test.ts`, `DebugModal.tsx`, `positionUpload.test.ts`, `computeBoardableWaitsForRoute.test.ts`) — 본 PR 변경 밖.
- client 측 remote flag (KV=on) 반영은 후속 PR 에서 `useArchFlagRemote()` 를 `useStationAlarm` 에 배선해야 함 (`fireViaUnifiedGate` 가 `isSimpleArchEnabled(remoteFlag)` 로 확장). 현재는 sibling `useBoardingLockStore` (env-only) 패턴과 일관.