### PR TITLE
feat(#2004): Phase 4-1 fusion cascade dormant (flag ON 시 arrival + gps만)

### DIFF
--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -60,6 +60,7 @@ import {
   type FusionSignals,
   type FusionTierName,
 } from '../utils/pickFusionTier';
+import { isSimpleArchEnabled } from '../../../shared/config/archFlag';
 import {
   recordEnvironmentTransition,
   recordFusionTierAdopted,
@@ -1408,7 +1409,17 @@ export function useFusedNearestStation(
     hasBoardingLock: boardingLock != null,
     lockedTrainCode,
   };
-  const cascadeTierPick = pickFusionTier(cascadeEnvironment, fusionSignals);
+  // #2004 (Phase 4-1, ADR-022 A6) — flag ON 시 cascade 를 fused + gps-fallback 2-tier 로 축소.
+  //   arrival API SSoT 아키텍처: 다른 tier (position-train, backend-ssot, wifi, route,
+  //   detection-verdict, gps-fast-path, arvl-arrived-match, position-train-lock) 는 arrival
+  //   API 로 대체/중복이라 dormant. skip 은 진단용 debug 로그로만 관측 (완전 제거는 Phase 4b).
+  //
+  //   remote flag 반영은 후속 PR 에서 arg 로 전달 예정 (`useStationAlarm` 와 동일 정책, #2002).
+  const cascadeTierPick = pickFusionTier(
+    cascadeEnvironment,
+    fusionSignals,
+    isSimpleArchEnabled(),
+  );
   let result: NearestStationResult | null = cascadeTierPick.result;
   let confidence: FusionConfidence = cascadeTierPick.confidence;
   let source: FusionSource = cascadeTierPick.source;

--- a/src/features/nearest-station/utils/__tests__/pickFusionTier.test.ts
+++ b/src/features/nearest-station/utils/__tests__/pickFusionTier.test.ts
@@ -498,6 +498,222 @@ describe('pickFusionTier — cascade tier 결정', () => {
   });
 });
 
+describe('pickFusionTier — #2004 (Phase 4-1, ADR-022 A6) simpleArch flag dormant', () => {
+  describe('flag OFF (기본) — 기존 10-tier cascade 그대로', () => {
+    it('backendSsotAccepts=true → tier 4 채택 (flag OFF backward-compat)', () => {
+      const ssot = makeStation();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({ backendSsotAccepts: true, ssotStation: ssot }),
+        false,
+      );
+      expect(r.tier).toBe('backend-ssot');
+    });
+
+    it('wifiStationResolved 활성 → tier 5 채택 (flag OFF)', () => {
+      const wifi = makeResult();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({ wifiStationResolved: wifi }),
+        false,
+      );
+      expect(r.tier).toBe('wifi');
+    });
+
+    it('positionTrainResult 활성 → tier 6 채택 (flag OFF)', () => {
+      const pt = makeResult();
+      const r = pickFusionTier(
+        'surface',
+        makeSignals({ positionTrainResult: pt }),
+        false,
+      );
+      expect(r.tier).toBe('position-train');
+    });
+
+    it('flag param 미전달(default false) → 기존 cascade 그대로', () => {
+      const wifi = makeResult();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({ wifiStationResolved: wifi }),
+        // no third arg → default false
+      );
+      expect(r.tier).toBe('wifi');
+    });
+  });
+
+  describe('flag ON — arrival(fused) + gps-fallback 2-tier 만 활성', () => {
+    it('flag ON + fused 활성 → tier 7 채택', () => {
+      const fused = makeFused();
+      const r = pickFusionTier(
+        'surface',
+        makeSignals({ fused, fusedPasses: true, fusedPassesStrict: true }),
+        true,
+      );
+      expect(r.tier).toBe('fused');
+      expect(r.confidence).toBe('arrival-confirmed');
+    });
+
+    it('flag ON + backendSsotAccepts=true(skip 대상) + fused 활성 → tier 7 채택 (backend-ssot skip)', () => {
+      const ssot = makeStation({ name: 'backend-ssot-station' });
+      const fused = makeFused({ name: 'fused-station' });
+      const r = pickFusionTier(
+        'surface',
+        makeSignals({
+          backendSsotAccepts: true,
+          ssotStation: ssot,
+          fused,
+          fusedPasses: true,
+          fusedPassesStrict: true,
+        }),
+        true,
+      );
+      expect(r.tier).toBe('fused');
+      expect(r.result?.station.name).toBe('fused-station');
+    });
+
+    it('flag ON + wifi/positionTrain/route 활성(skip 대상) + gps-fallback → tier 10 채택', () => {
+      const wifi = makeResult({ name: 'wifi-station' });
+      const pt = makeResult({ name: 'pt-station' });
+      const route = makeResult({ name: 'route-station' });
+      const fallback = makeResult({ name: 'gps-station' });
+      const r = pickFusionTier(
+        'surface',
+        makeSignals({
+          wifiStationResolved: wifi,
+          positionTrainResult: pt,
+          routeResult: route,
+          routePasses: true,
+          gpsFallbackResult: fallback,
+        }),
+        true,
+      );
+      expect(r.tier).toBe('gps-fallback');
+      expect(r.result?.station.name).toBe('gps-station');
+      expect(r.confidence).toBe('gps-only');
+    });
+
+    it('flag ON + 모든 skip tier 활성(position-train-lock/gps-fast-path/arvl-arrived/backend-ssot/wifi/position-train/detection-verdict/route) + fused=null + fallback → tier 10 gps-fallback 채택', () => {
+      const ptResult = makeResult({ name: 'pt-lock' });
+      const gpsTop = makeResult({ name: 'gps-fast' });
+      const arvl = makeResult({ name: 'arvl' });
+      const ssot = makeStation({ name: 'backend' });
+      const wifi = makeResult({ name: 'wifi' });
+      const pt = makeResult({ name: 'pt' });
+      const route = makeResult({ name: 'route' });
+      const fallback = makeResult({ name: 'gps-fallback' });
+      const r = pickFusionTier(
+        'surface',
+        makeSignals({
+          positionTrainBoardingLockMatch: true,
+          positionTrainResult: ptResult,
+          gpsDerivedFastPath: true,
+          gpsTopCandidate: gpsTop,
+          arvlCdArrivedMatch: arvl,
+          backendSsotAccepts: true,
+          ssotStation: ssot,
+          wifiStationResolved: wifi,
+          hasBoardingLock: true,
+          lockedTrainCode: 'T1',
+          trainProgressTrainNo: 'T1',
+          routeResult: route,
+          routePasses: true,
+          gpsFallbackResult: fallback,
+          // fused null → tier 7 미진입 → sink 로 gps-fallback 채택
+        }),
+        true,
+      );
+      expect(r.tier).toBe('gps-fallback');
+      expect(r.result?.station.name).toBe('gps-fallback');
+    });
+
+    it('flag ON + detection-verdict 활성(skip 대상) → tier 8 미진입', () => {
+      const fused = makeFused();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({
+          fused,
+          fusedPasses: false,
+          fusedPassesStrict: false, // tier 7 게이트 미통과
+          detectionVerdictAccepts: true, // tier 8 활성이나 flag ON 시 skip
+        }),
+        true,
+      );
+      expect(r.tier).not.toBe('detection-verdict');
+      expect(r.tier).toBe('gps-fallback');
+    });
+
+    it('flag ON + arvlCdArrivedMatch(tier 3, skip) 활성 + fused → tier 7 fused 채택', () => {
+      const arvl = makeResult({ name: 'arvl-lock' });
+      const fused = makeFused({ name: 'fused-station' });
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({
+          arvlCdArrivedMatch: arvl,
+          arvlCdDriftBlocked: false,
+          fused,
+          fusedPasses: true,
+          fusedPassesStrict: true,
+        }),
+        true,
+      );
+      expect(r.tier).toBe('fused');
+      expect(r.result?.station.name).toBe('fused-station');
+    });
+
+    it('flag ON + 모든 tier null → tier 10 gps-fallback sink (result=null)', () => {
+      const r = pickFusionTier('unknown', makeSignals(), true);
+      expect(r.tier).toBe('gps-fallback');
+      expect(r.result).toBeNull();
+    });
+
+    it('flag ON + fusedPasses=false + detectionVerdictAccepts=true(skip) + route+routePasses(skip) → gps-fallback', () => {
+      const fused = makeFused();
+      const route = makeResult();
+      const r = pickFusionTier(
+        'surface',
+        makeSignals({
+          fused,
+          fusedPasses: false,
+          fusedPassesStrict: false,
+          detectionVerdictAccepts: true,
+          routeResult: route,
+          routePasses: true,
+        }),
+        true,
+      );
+      expect(r.tier).toBe('gps-fallback');
+    });
+
+    it('flag ON + underground fused strict gate 통과 → tier 7 채택 (env 분기 유지)', () => {
+      const fused = makeFused();
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({
+          fused,
+          fusedPasses: true,
+          fusedPassesStrict: true,
+        }),
+        true,
+      );
+      expect(r.tier).toBe('fused');
+    });
+
+    it('flag ON + underground gps-fallback strict → strict 변형 그대로 사용 (env 분기 유지)', () => {
+      const fb = makeResult({ name: 'strict-fb' });
+      const r = pickFusionTier(
+        'underground',
+        makeSignals({
+          gpsFallbackResult: null,
+          gpsFallbackResultStrict: fb,
+        }),
+        true,
+      );
+      expect(r.tier).toBe('gps-fallback');
+      expect(r.result?.station.name).toBe('strict-fb');
+    });
+  });
+});
+
 describe('isCandidateEnvMismatch — #1934 G3 option B 통합', () => {
   function candidateWithEnv(env?: StationEnvironment): NearestStationResult {
     return { station: makeStation({ environment: env }), distanceKm: 0.05 };

--- a/src/features/nearest-station/utils/pickFusionTier.ts
+++ b/src/features/nearest-station/utils/pickFusionTier.ts
@@ -24,12 +24,23 @@
  *
  * #1934 (Epic #1927 G3) option B 통합 — candidate enumeration 단계 env vote reject counter는
  * caller(`useFusedNearestStation`) 책임. 본 picker는 cascade 단계만 담당.
+ *
+ * #2004 (Phase 4-1, ADR-022 A6) — `simpleArch` flag dormant.
+ *   - flag OFF: 기존 10-tier cascade 그대로 (backward-compat).
+ *   - flag ON: arrival API SSoT 아키텍처에서는 arrival 결과(fused = arrival-confirmed/
+ *     arrival-arriving) 와 GPS fallback (gps-only) 두 tier 만 신뢰. 다른 tier (position-train,
+ *     backend-ssot, wifi, route, detection-verdict) 는 arrival API 로 중복/대체되므로 skip.
+ *     skip 된 tier 는 진단용으로 `logger.debug('cascade-skip: flag-on', tier)` 로만 관측.
+ *   완전 제거는 Phase 4b (dogfood 검증 후) 로 분리.
  */
 
 import type { LineNumber, NearestStationResult, Station } from '../../../shared/types/station';
 import type { FusionConfidence, FusionSource } from '../../../shared/types/fusion';
 import type { FusedStationResult } from './pickFusedStation';
 import type { Environment } from './inferEnvironment';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('pickFusionTier');
 
 /**
  * cascade tier 이름. 채택 trace + Sentry breadcrumb + DebugModal에서 단일 식별자.
@@ -297,6 +308,19 @@ const TIER_DEFINITIONS: readonly TierDefinition[] = [
 ] as const;
 
 /**
+ * #2004 (Phase 4-1, ADR-022 A6) — flag ON 시 활성 tier 화이트리스트.
+ *
+ * `fused` (arrival-confirmed / arrival-arriving) 와 `gps-fallback` (gps-only) 만 유지.
+ * 다른 tier 는 arrival API SSoT 로 대체 (dormant, skip). 완전 삭제는 Phase 4b.
+ *
+ * 신규 tier 를 이 목록에 추가할 때는 arrival API SSoT 원칙(다른 신호 X)이 유지되는지 확인.
+ */
+const SIMPLE_ARCH_ALLOWED_TIERS: ReadonlySet<FusionTierName> = new Set([
+  'fused',
+  'gps-fallback',
+]);
+
+/**
  * cascade tier picker — environment + 사전 계산된 신호로 채택 tier 결정.
  *
  * 순서 규칙:
@@ -309,14 +333,26 @@ const TIER_DEFINITIONS: readonly TierDefinition[] = [
  * 마지막 tier(`gps-fallback`)는 항상 평가되며 `result`가 null이어도 tier만 채택 (caller가 fallback
  * 처리). `pickFusionTier`는 절대 null 반환하지 않는다 (gps-fallback이 sink).
  *
+ * #2004 (Phase 4-1, ADR-022 A6) — `simpleArch` flag ON 시:
+ *   - `SIMPLE_ARCH_ALLOWED_TIERS` 화이트리스트(`fused`, `gps-fallback`) 만 evaluate.
+ *   - 다른 tier 는 skip + `logger.debug('cascade-skip: flag-on', name)` 진단 로그.
+ *   - `TIER_DEFINITIONS` 순서는 그대로 유지 — 낮은 index tier 만 skip 대상.
+ *   - gps-fallback 은 sink 로 항상 마지막에 평가되므로 flag ON 이어도 sink 동작 보존.
+ *
  * @param environment cascadeEnvironment SSOT (`inferEnvironment` 결과)
  * @param signals caller pre-computed tier별 신호 묶음
+ * @param simpleArch true 시 flag ON — arrival + gps 2-tier 만 활성. 기본 false (backward-compat).
  */
 export function pickFusionTier(
   environment: Environment,
   signals: FusionSignals,
+  simpleArch = false,
 ): FusionTierResult {
   for (const def of TIER_DEFINITIONS) {
+    if (simpleArch && !SIMPLE_ARCH_ALLOWED_TIERS.has(def.name)) {
+      logger.debug('cascade-skip: flag-on', def.name);
+      continue;
+    }
     const picked = def.evaluate(environment, signals);
     if (picked != null) return picked;
   }


### PR DESCRIPTION
Closes #2004

## Summary

ADR-022 (#1980) A6 — Phase 4-1 fusion cascade 축소 (dormant, flag guard).

- `pickFusionTier` 에 `simpleArch` optional param 추가 (기본 false, backward-compat).
- flag ON 시 `SIMPLE_ARCH_ALLOWED_TIERS` (`fused` + `gps-fallback`) 만 evaluate.
- 다른 tier (position-train-lock / gps-fast-path / arvl-arrived-match /
  backend-ssot / wifi / position-train / detection-verdict / route) 는 skip +
  `logger.debug('cascade-skip: flag-on', tier)` 진단 로그.
- `useFusedNearestStation` 이 `isSimpleArchEnabled()` 호출로 flag guard wire.

## Acceptance 매핑

- [x] **flag OFF 시 기존 10-tier cascade 100% 동작 유지** — test `flag OFF (기본) — 기존 10-tier cascade 그대로` 4개 (backend-ssot / wifi / position-train / default param).
- [x] **flag ON 시 arrival(fused) + gps 2-tier만** — test `flag ON — arrival(fused) + gps-fallback 2-tier 만 활성` 10개.
  - 다른 layer 진입 0건 확인 (skip 대상 tier 모두 활성 시나리오 포함).
- [x] **`isSimpleArchEnabled()` wire** — `useFusedNearestStation.ts` L1418.
- [x] **client test 100% coverage** — `pickFusionTier.ts` 100% (58 tests).
- [x] **type-check clean** — `npm run type-check` pass.

## Wire-completion 5단

1. **Orphan 없음** — 신규 export 없음 (기존 함수에 optional param 추가만).
2. **V/X dashboard** — DebugModal cascade tier 표시 그대로 유지. flag ON dogfood 빌드에서 tier 7/10 만 노출 확인. Sentry `fusion.tier_adopted` breadcrumb 도 동일.
3. **의존 PR** — N/A. Phase 0/1 real helper (`isSimpleArchEnabled`) 이미 dev 에 존재.
4. **측정 plan** — 1주 dogfood build 에서 flag ON 시 cascade tier 분포 (Sentry `fusion.tier_adopted` breadcrumb) — tier 7 (`fused`) + tier 10 (`gps-fallback`) 만 발화 확인. 다른 tier 발화 시 회귀.
5. **Device verify** — N/A — type+unit only. flag OFF 시 기존 동작 완벽 보존 (테스트로 검증). flag ON 은 dogfood 검증 (env `EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH=true` 로컬 rebuild).

## Test plan

- [x] `npm test` — 8936 tests pass, 100% coverage
- [x] `npm run type-check` — clean
- [x] `npm run lint:orphan` — no orphan exports
- [x] pickFusionTier: 58 tests (기존 40 + 신규 18) — flag OFF/ON matrix 모두 커버

## Refs

- Epic: #1980 (ADR-022)
- Wave 1: #2003 (real helper wire)
- Phase 1-5 dedup: #2001