### PR TITLE
feat(#2005): Phase 4-3 motionGate/accel dormant (arrival API SSoT)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -5843,4 +5843,90 @@ describe('useStationAlarm', () => {
       await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
     });
   });
+
+  // ADR-022 Phase 4-3 (#2005) — motion gate dormant 통합 검증.
+  // flag OFF (기본) 시 motion=stationary 로 발사 차단 (#728) — 기존 동작 유지.
+  // flag ON 시 evaluateMovement 가 항상 reliable=true 를 반환해 motion gate 를 전면 bypass.
+  // 정적 상태(motion=stationary, speed=0)에서도 알람이 정상 발사되어야 한다 — arrival API SSoT.
+  describe('#2005 Phase 4-3 motionGate dormant flag', () => {
+    const route = makeDirectRoute(1, '2');
+    const onRouteStation = makeStation('S2-DST', '강남');
+
+    it('flag OFF (기본) + motionStationary=true → 기존 동작 (motion gate 차단 + movement-motion-stationary 적재)', async () => {
+      delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+      mockGetStoredTripTrainCode.mockResolvedValue('TRAIN-1');
+      mockIsImminentByArrivalCode.mockReturnValue(true);
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            speedMps: 0,
+            accuracyMeters: 50,
+            motionStationary: true,
+          }),
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockLogSuppressedMovement).toHaveBeenCalledWith(
+          expect.objectContaining({
+            reason: 'movement-motion-stationary',
+          }),
+        );
+      });
+      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    });
+
+    it('flag ON + motionStationary=true → motion gate bypass → 정상 발사 (arrival API SSoT)', async () => {
+      process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+      mockGetStoredTripTrainCode.mockResolvedValue('TRAIN-1');
+      mockIsImminentByArrivalCode.mockReturnValue(true);
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            speedMps: 0, // 정적
+            accuracyMeters: 50,
+            motionStationary: true, // OS 가속도계 정적 확정
+          }),
+        ),
+      );
+
+      // motion=stationary인데도 알람 발사 — arrival API SSoT 아키텍처는 arvlCd 단독 신호로 판정.
+      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      // movement 게이트 skip 로그 미적재 (dormant).
+      expect(mockLogSuppressedMovement).not.toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'movement-motion-stationary' }),
+      );
+    });
+
+    it('flag ON + speed=0 + station-passed → motion gate bypass → 정상 발사', async () => {
+      process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+
+      renderHook(() =>
+        useStationAlarm(
+          defaultInputs({
+            route,
+            destination,
+            nearestStation: onRouteStation,
+            speedMps: 0, // 정적
+            accuracyMeters: 50,
+          }),
+        ),
+      );
+
+      // speed=0인데도 station-passed 알람 발사 — flag ON 이면 movement gate 미적용.
+      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      expect(mockLogSuppressedMovement).not.toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'movement-static-speed' }),
+      );
+    });
+  });
 });

--- a/src/features/nearest-station/utils/__tests__/movementGate.test.ts
+++ b/src/features/nearest-station/utils/__tests__/movementGate.test.ts
@@ -9,6 +9,27 @@ import {
   STALE_AGE_MS,
   STATIC_SPEED_THRESHOLD_MPS,
 } from '../movementGate';
+import { SIMPLE_ARRIVAL_ARCH_ENV_KEY } from '../../../../shared/config/archFlag';
+
+const ORIGINAL_ARCH_ENV = process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+
+/** ADR-022 Phase 4-3 (#2005) — flag ON 상태에서 evaluateMovement 가 항상 reliable=true 를 반환하는지 검증. */
+function enableArchFlag(): void {
+  process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+}
+
+/** flag OFF (기본) — 명시적 해제해 다른 테스트 격리. */
+function disableArchFlag(): void {
+  delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+}
+
+afterEach(() => {
+  if (ORIGINAL_ARCH_ENV === undefined) {
+    delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+  } else {
+    process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = ORIGINAL_ARCH_ENV;
+  }
+});
 
 describe('movementGate', () => {
   describe('evaluateMovement', () => {
@@ -799,6 +820,82 @@ describe('movementGate', () => {
 
     it('reason=undefined(reliable=true 결과)에 대해 false', () => {
       expect(isStaticMovementResult(undefined)).toBe(false);
+    });
+  });
+
+  // ADR-022 Phase 4-3 (#2005) — arrival API SSoT flag guard 검증.
+  // flag ON 시 evaluateMovement 가 loc/신호와 무관하게 { reliable: true } 를 반환해
+  // motion gate 를 전면 bypass 하는지 확인. flag OFF (기본) 시 기존 로직 100% 유지.
+  describe('evaluateMovement — arch flag guard (Phase 4-3)', () => {
+    describe('flag OFF (기본) — 기존 로직 유지', () => {
+      beforeEach(() => {
+        disableArchFlag();
+      });
+
+      it('flag OFF + loc=null → 기존 no-location 판정 유지', () => {
+        expect(evaluateMovement(null)).toEqual({ reliable: false, reason: 'no-location' });
+      });
+
+      it('flag OFF + motionStationary=true → 기존 motion-stationary 판정 유지', () => {
+        const m = evaluateMovement({}, undefined, undefined, true);
+        expect(m).toEqual({ reliable: false, reason: 'motion-stationary' });
+      });
+
+      it('flag OFF + speedMps < 임계 → 기존 static-speed 판정 유지', () => {
+        const m = evaluateMovement({ speedMps: 0 });
+        expect(m.reliable).toBe(false);
+        expect(m.reason).toBe('static-speed');
+      });
+    });
+
+    describe('flag ON — motion gate 전면 bypass (arrival API SSoT)', () => {
+      beforeEach(() => {
+        enableArchFlag();
+      });
+
+      it('flag ON + loc=null → no-location 대신 reliable=true', () => {
+        expect(evaluateMovement(null)).toEqual({ reliable: true });
+      });
+
+      it('flag ON + motionStationary=true → motion-stationary 대신 reliable=true', () => {
+        const m = evaluateMovement({}, undefined, undefined, true);
+        expect(m).toEqual({ reliable: true });
+      });
+
+      it('flag ON + speedMps=0 (정적) → static-speed 대신 reliable=true', () => {
+        const m = evaluateMovement({ speedMps: 0 });
+        expect(m).toEqual({ reliable: true });
+      });
+
+      it('flag ON + positionStability=static → static-position 대신 reliable=true', () => {
+        const m = evaluateMovement({}, undefined, 'static');
+        expect(m).toEqual({ reliable: true });
+      });
+
+      it('flag ON + warmup 조건 (motion=undefined + speed=null + positionStability=unknown) → motion-warmup 대신 reliable=true', () => {
+        const m = evaluateMovement({}, undefined, 'unknown', undefined);
+        expect(m).toEqual({ reliable: true });
+      });
+
+      it('flag ON + stale timestamp → stale-timestamp 대신 reliable=true', () => {
+        const now = 2_000_000;
+        const m = evaluateMovement({ timestamp: now - STALE_AGE_MS - 1 }, now);
+        expect(m).toEqual({ reliable: true });
+      });
+
+      it('flag ON + accuracyM > MAX_ACCURACY_M → low-accuracy 대신 reliable=true', () => {
+        const m = evaluateMovement({ accuracyM: MAX_ACCURACY_M + 1 });
+        expect(m).toEqual({ reliable: true });
+      });
+
+      it('flag ON + 모든 신호 정상 (기존에도 reliable=true) → reliable=true 유지', () => {
+        const now = 1_000_000;
+        const m = evaluateMovement(
+          { timestamp: now - 5_000, accuracyM: 50, speedMps: 3 },
+          now,
+        );
+        expect(m).toEqual({ reliable: true });
+      });
     });
   });
 });

--- a/src/features/nearest-station/utils/movementGate.ts
+++ b/src/features/nearest-station/utils/movementGate.ts
@@ -49,8 +49,21 @@
  *
  * 입력 필드는 모두 옵션 — 호출자가 측정 가능한 신호만 전달하면 된다. 누락된 신호는
  * 해당 분기 검증을 skip (false negative보다 false positive 차단 우선).
+ *
+ * ADR-022 Phase 4-3 (#2005) — flag guard (dormant):
+ *   `isSimpleArchEnabled()` (env `EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH` OR backend KV
+ *   `arch:simple-arrival-v1`) 가 ON 이면 `evaluateMovement` 는 즉시 `{ reliable: true }` 를
+ *   반환한다. arrival API SSoT 아키텍처에서는 fire 판정이 backend `arvlCd` 만으로 결정되며
+ *   device motion / GPS speed / positionStability 는 오히려 정확한 알림을 억제한다
+ *   (예: 지하 깊은 구간에서 speed=-1 + motion=stationary 오검출로 정상 알림 miss).
+ *   flag OFF (기본) 시에는 기존 로직 100% 유지 — dormant.
+ *
+ *   `shouldDowngradeFusion` / `isStaticSpeedSignal` / `isStaticMovementResult` 는 fusion
+ *   downgrade layer 별개로 flag guard 미적용 — Phase 4 다른 sub-issue 에서 결정한다.
+ *   `accelMotion.ts` 의 pattern 판정도 DebugModal / backend 송신용으로 유지 (dormant).
  */
 
+import { isSimpleArchEnabled } from '../../../shared/config/archFlag';
 import type { PositionStability } from './positionStaticDetector';
 
 /** 30s 이전 좌표는 stale로 간주 (Bumble Tech 권고). 새 location이 timestamp 동반일 때만 검증. */
@@ -298,6 +311,13 @@ export function evaluateMovement(
    */
   trainProgressing?: boolean,
 ): MovementSignal {
+  // ADR-022 Phase 4-3 (#2005) — arrival API SSoT flag ON 시 motion gate 전면 bypass.
+  // fire 판정을 backend arvlCd 로 단일화하므로 device motion / GPS speed / warmup 게이트가
+  // 알림을 억제하면 오히려 miss 유발. flag OFF (기본) 시엔 이 분기 skip → 기존 로직 100% 유지.
+  if (isSimpleArchEnabled()) {
+    return { reliable: true };
+  }
+
   if (!loc) return { reliable: false, reason: 'no-location' };
 
   if (loc.timestamp != null) {


### PR DESCRIPTION
Closes #2005
Part of ADR-022 arrival API SSOT 재설계 (#1980), Phase 4a wave 1.

## 배경
`src/features/nearest-station/utils/movementGate.ts` `evaluateMovement()`이 device motion/GPS speed로 알람 발사 게이트. flag ON 시 arrival API SSoT라 motion 판정 불필요.

## 변경 (3 파일)
- `movementGate.ts` — `evaluateMovement` flag guard 추가. flag ON 시 항상 `{ reliable: true, reason: null }` 반환 (게이트 통과, 정적 상태에서도 발사 허용)
- `movementGate.test.ts` — flag OFF backward-compat + flag ON bypass 케이스 추가
- `useStationAlarm.test.ts` — 통합 검증 (flag ON 시 정적 상태에서 발사)

## 정책
- **파일 유지** (완전 삭제 Phase 4b에서)
- `isStaticMovementResult` / `shouldDowngradeFusion` 은 그대로 (tripBoundScheduler/boardingLockScheduler + fusion downgrade에서 참조, flag guard 밖)
- accelMotion pattern 판정 유지 (DebugModal 표시용)
- flag OFF 시 기존 motion/speed 판정 100% 동작

## acceptance
- [x] flag OFF 시 movementGate 기존 판정 유지 (test)
- [x] flag ON 시 evaluateMovement 항상 reliable=true (test)
- [x] useStationAlarm 통합 확인
- [x] accelMotion pattern 판정 유지 (DebugModal)
- [x] client test 100% coverage
- [x] type-check clean

## code-review medium 결과
0 findings (verify 3 candidates all refuted).

## refs
- ADR-022 A6 fusion/motion 삭제 대상
- Phase 4-1 fusion cascade #2004 (#2008 PR)
- Phase 4-4 WiFi/기압계, Phase 4-5 Kalman 병렬 진행