### PR TITLE
feat(#2006): Phase 4-4 WiFi/기압계 dormant (arrival API SSoT)

### DIFF
--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -1473,6 +1473,21 @@ describe('DebugModal — D9 UI sections (#1215)', () => {
     expect(screen.getAllByText('45').length).toBeGreaterThan(0);
   });
 
+  // #2006 (ADR-022 Phase 4-4) — flag ON 시 useBarometer 가 dormant 반환.
+  // DebugModal 은 unavailableReason 을 그대로 렌더링 → 'flag-on-dormant' 노출.
+  it('#2006 GPS 섹션: unavailableReason="flag-on-dormant" 노출 (arrival API SSOT dormant)', async () => {
+    mockUseBarometer.mockReturnValue({
+      subsurface: false,
+      stop: undefined,
+      unavailableReason: 'flag-on-dormant',
+      readingCount: 0,
+    });
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('subsurface reason')).toBeTruthy();
+    expect(screen.getAllByText('flag-on-dormant').length).toBeGreaterThan(0);
+  });
+
   it('fusionDetection 미전달 시 tier/signalMask = —', async () => {
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());

--- a/src/features/nearest-station/hooks/__tests__/useWifiStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useWifiStation.test.ts
@@ -21,20 +21,33 @@ jest.mock('../../utils/wifiSsidLookup', () => ({
 
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { useWifiStation } from '../useWifiStation';
+import { SIMPLE_ARRIVAL_ARCH_ENV_KEY } from '../../../../shared/config/archFlag';
 import type { Station } from '../../../../shared/types/station';
 
 const yongmasan: Station = { id: '7-yongmasan', name: '용마산', line: '7', lineColor: '#747F00', lat: 37.5, lng: 127 };
 const junggok: Station = { id: '7-junggok', name: '중곡', line: '7', lineColor: '#747F00', lat: 37.5, lng: 127.1 };
+
+const ORIGINAL_ARCH_ENV = process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
 
 describe('useWifiStation (#913)', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     mockGetSsid.mockReset();
     mockLookup.mockReset();
+    // #2006 — 각 테스트 전 flag 초기화 (기본 OFF).
+    delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
   });
 
   afterEach(() => {
     jest.useRealTimers();
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_ARCH_ENV === undefined) {
+      delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+    } else {
+      process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = ORIGINAL_ARCH_ENV;
+    }
   });
 
   it('초기 1회 호출 — SSID 매칭 시 station 반환', async () => {
@@ -161,5 +174,41 @@ describe('useWifiStation (#913)', () => {
       jest.advanceTimersByTime(15_000);
     });
     await waitFor(() => expect(result.current).toBe(yongmasan));
+  });
+
+  // #2006 (ADR-022 Phase 4-4) — flag ON 시 폴링 자체 skip. 배터리·권한 비용 0.
+  describe('flag guard (#2006)', () => {
+    it('flag ON — mount 시 getCurrentWifiSsid 호출 0 (폴링 skip)', async () => {
+      process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+      const { result } = renderHook(() => useWifiStation());
+
+      // mount 직후 즉시 확인 — flag ON 이면 tick 이 등록되지 않아 getCurrentWifiSsid 호출 0.
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockGetSsid).not.toHaveBeenCalled();
+      expect(mockLookup).not.toHaveBeenCalled();
+      expect(result.current).toBeNull();
+    });
+
+    it('flag ON — 15s / 60s 경과 후에도 폴링 호출 0 (인터벌 skip)', async () => {
+      process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+      renderHook(() => useWifiStation());
+
+      await act(async () => {
+        jest.advanceTimersByTime(60_000);
+      });
+      expect(mockGetSsid).not.toHaveBeenCalled();
+    });
+
+    it('flag OFF 명시 — 기존 폴링 동작 유지', async () => {
+      process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'false';
+      mockGetSsid.mockResolvedValue('T_subway_용마산');
+      mockLookup.mockReturnValue(yongmasan);
+
+      const { result } = renderHook(() => useWifiStation());
+      await waitFor(() => expect(result.current).toBe(yongmasan));
+      expect(mockGetSsid).toHaveBeenCalled();
+    });
   });
 });

--- a/src/features/nearest-station/hooks/useWifiStation.ts
+++ b/src/features/nearest-station/hooks/useWifiStation.ts
@@ -15,11 +15,17 @@
  *   - native 부재 / 권한 없음 → 결과 항상 null (suppress 안 함, GPS fallback)
  *   - SSID 매칭 실패 → null (다른 신호로 fallback)
  *   - unmount 시 polling cleanup
+ *
+ * #2006 (ADR-022 Phase 4-4) — `isSimpleArchEnabled()` 활성 시 폴링 자체 skip. arrival API 가
+ * 지하도 SSOT 로 커버하므로 WiFi 대체 신호는 dormant. native SSID 조회는 배터리·권한 비용이
+ * 있어 `lookupStationBySsid` 게이트만으로는 부족 — hook 자체가 tick 을 skip 한다.
+ * flag OFF (default) 시 기존 15s 폴링 그대로.
  */
 
 import { useEffect, useState } from 'react';
 import { getCurrentWifiSsid } from '../utils/wifiSsidNative';
 import { lookupStationBySsid } from '../utils/wifiSsidLookup';
+import { isSimpleArchEnabled } from '../../../shared/config/archFlag';
 import type { Station } from '../../../shared/types/station';
 
 /** 폴링 주기 — 알람 평가(30s)의 절반. native 부하와 갱신 지연의 절충점. */
@@ -29,6 +35,11 @@ export function useWifiStation(): Station | null {
   const [station, setStation] = useState<Station | null>(null);
 
   useEffect(() => {
+    // #2006 (ADR-022 Phase 4-4) — flag ON 시 폴링 자체 skip. 배터리·권한 비용 0.
+    // flag toggle 은 재빌드/remount 이 트리거하므로 effect deps 는 유지 (mount time 판정).
+    if (isSimpleArchEnabled()) {
+      return;
+    }
     let cancelled = false;
 
     const tick = async () => {

--- a/src/features/nearest-station/utils/__tests__/wifiSsidLookup.test.ts
+++ b/src/features/nearest-station/utils/__tests__/wifiSsidLookup.test.ts
@@ -2,10 +2,23 @@ import {
   lookupStationBySsid,
   __resetWifiSsidLookupCacheForTest,
 } from '../wifiSsidLookup';
+import { SIMPLE_ARRIVAL_ARCH_ENV_KEY } from '../../../../shared/config/archFlag';
+
+const ORIGINAL_ARCH_ENV = process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
 
 describe('lookupStationBySsid', () => {
   beforeEach(() => {
     __resetWifiSsidLookupCacheForTest();
+    // #2006 — 각 테스트가 명시적으로 flag 를 셋하지 않는 한 dormant 기본값 유지 (flag OFF).
+    delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_ARCH_ENV === undefined) {
+      delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+    } else {
+      process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = ORIGINAL_ARCH_ENV;
+    }
   });
 
   describe('정상 매칭', () => {
@@ -100,6 +113,27 @@ describe('lookupStationBySsid', () => {
       __resetWifiSsidLookupCacheForTest();
       const result = lookupStationBySsid('T_subway_용마산');
       expect(result?.name).toBe('용마산');
+    });
+  });
+
+  // #2006 (ADR-022 Phase 4-4) — flag ON 시 dormant. arrival API SSOT 로 지하 커버.
+  describe('flag guard (#2006)', () => {
+    it('flag ON — 정상 매칭 가능 SSID 라도 null 반환 (dormant)', () => {
+      process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+      expect(lookupStationBySsid('T_subway_용마산')).toBeNull();
+      expect(lookupStationBySsid('Gangnam_Station')).toBeNull();
+    });
+
+    it('flag ON — null/empty/whitespace 입력도 null (기존 방어 동작 유지)', () => {
+      process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+      expect(lookupStationBySsid(null as unknown as string)).toBeNull();
+      expect(lookupStationBySsid('')).toBeNull();
+      expect(lookupStationBySsid('   ')).toBeNull();
+    });
+
+    it('flag OFF 명시 — 기존 매칭 동작 그대로', () => {
+      process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'false';
+      expect(lookupStationBySsid('T_subway_용마산')?.name).toBe('용마산');
     });
   });
 });

--- a/src/features/nearest-station/utils/wifiSsidLookup.ts
+++ b/src/features/nearest-station/utils/wifiSsidLookup.ts
@@ -8,10 +8,15 @@
  *
  * 본 유틸은 pure JS layer. 네이티브 SSID 조회 브릿지(NEHotspotNetwork / WifiManager)와
  * useNearestStation cascade wire는 후속 PR에서 추가한다.
+ *
+ * #2006 (ADR-022 Phase 4-4) — `isSimpleArchEnabled()` 활성 시 매칭 skip.
+ *   flag ON 시 arrival API 가 지하도 SSOT 로 커버하므로 WiFi 대체 신호는 dormant.
+ *   flag OFF (default) 시 기존 정규식 매칭 그대로 (backward-compat).
  */
 import wifiSsidMapRaw from '../../../data/subwayWifiSsidMap.json';
 import { applyStationAlias } from '../../../data/stationAliases';
 import { findStationByName } from '../../../shared/utils/stationLookup';
+import { isSimpleArchEnabled } from '../../../shared/config/archFlag';
 import type { Station } from '../../../shared/types/station';
 
 interface WifiSsidEntry {
@@ -43,9 +48,15 @@ function getCompiledEntries(): CompiledEntry[] {
 
 /**
  * 현재 wifi SSID 문자열을 받아 매칭되는 Station을 반환한다.
+ *
+ * #2006 — `isSimpleArchEnabled()` 활성 시 항상 null 반환 (매칭 skip). arrival API 가
+ * 지하도 커버하므로 WiFi 대체 신호는 dormant. flag OFF 시 기존 정규식 매칭 그대로.
+ *
  * @param ssid - 네이티브에서 조회한 현재 연결된 wifi SSID. null/empty/매칭 실패 시 null.
  */
 export function lookupStationBySsid(ssid: string | null | undefined): Station | null {
+  // #2006 (ADR-022 Phase 4-4) — flag ON 시 매칭 skip. arrival API SSOT dormant.
+  if (isSimpleArchEnabled()) return null;
   if (typeof ssid !== 'string') return null;
   const trimmed = ssid.trim();
   if (trimmed.length === 0) return null;

--- a/src/shared/hooks/__tests__/useBarometer.test.ts
+++ b/src/shared/hooks/__tests__/useBarometer.test.ts
@@ -21,6 +21,7 @@ jest.mock('../../utils/subsurfaceState', () => ({
 }));
 
 import { useBarometer } from '../useBarometer';
+import { SIMPLE_ARRIVAL_ARCH_ENV_KEY } from '../../config/archFlag';
 import {
   BAROMETER_SAMPLE_INTERVAL_MS,
   BAROMETER_DPDT_WINDOW_MS,
@@ -34,6 +35,8 @@ import {
 
 type Listener = (m: { pressure: number; timestamp: number }) => void;
 
+const ORIGINAL_ARCH_ENV = process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+
 beforeEach(() => {
   mockIsAvailable.mockReset();
   mockRequestPermissions.mockReset();
@@ -44,6 +47,16 @@ beforeEach(() => {
   mockSetSubsurfaceState.mockResolvedValue(undefined);
   mockAddListener.mockReturnValue({ remove: mockRemove });
   resetBarometerState();
+  // #2006 — 각 테스트 전 flag 초기화 (기본 OFF).
+  delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+});
+
+afterAll(() => {
+  if (ORIGINAL_ARCH_ENV === undefined) {
+    delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+  } else {
+    process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = ORIGINAL_ARCH_ENV;
+  }
 });
 
 async function flush(): Promise<void> {
@@ -440,6 +453,52 @@ describe('useBarometer (#875)', () => {
       expect(result.current.stop).toBeUndefined();
       expect(result.current.unavailableReason).toBe('readings');
       nowSpy.mockRestore();
+    });
+  });
+
+  // #2006 (ADR-022 Phase 4-4) — arrival-api-ssot-v1 flag ON 시 dormant. arrival API 가 지하도
+  // 커버하므로 기압계 SPOF 신호를 배터리 절약을 위해 listener 등록 자체를 skip.
+  describe('flag guard (#2006)', () => {
+    it('flag ON — Barometer.isAvailableAsync 호출 0 (native gate skip)', async () => {
+      process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+      // isAvailable 은 pending 상태로 유지 — 실제로 native 호출이 있었다면 등록될 것.
+      mockIsAvailable.mockImplementation(() => new Promise(() => {}));
+
+      const { result } = renderHook(() => useBarometer());
+      await flush();
+
+      expect(mockIsAvailable).not.toHaveBeenCalled();
+      expect(mockRequestPermissions).not.toHaveBeenCalled();
+      expect(mockSetUpdateInterval).not.toHaveBeenCalled();
+      expect(mockAddListener).not.toHaveBeenCalled();
+      // dormant 반환값 계약.
+      expect(result.current.subsurface).toBe(false);
+      expect(result.current.stop).toBeUndefined();
+      expect(result.current.readingCount).toBe(0);
+      expect(result.current.unavailableReason).toBe('flag-on-dormant');
+    });
+
+    it('flag ON — unmount 시에도 크래시 없이 종료 (subscription null)', async () => {
+      process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+      const { unmount } = renderHook(() => useBarometer());
+      await flush();
+      // native subscription 미등록 → remove 호출 없어야 함.
+      unmount();
+      expect(mockRemove).not.toHaveBeenCalled();
+    });
+
+    it('flag OFF 명시 — 기존 sensor 게이트 진입 (backward-compat)', async () => {
+      process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'false';
+      mockIsAvailable.mockResolvedValue(true);
+      mockRequestPermissions.mockResolvedValue({ granted: true });
+
+      const { result } = renderHook(() => useBarometer());
+      await flush();
+
+      expect(mockIsAvailable).toHaveBeenCalled();
+      expect(mockAddListener).toHaveBeenCalledTimes(1);
+      // 정상 등록 후 첫 tick 전 warmup: reason 'readings'.
+      expect(result.current.unavailableReason).toBe('readings');
     });
   });
 });

--- a/src/shared/hooks/useBarometer.ts
+++ b/src/shared/hooks/useBarometer.ts
@@ -37,6 +37,7 @@ import {
   BAROMETER_STOP_CONFIRM_SAMPLES,
   BAROMETER_SUBSURFACE_CONFIRM_SAMPLES,
 } from '../constants/barometer';
+import { isSimpleArchEnabled } from '../config/archFlag';
 
 /**
  * #1398 — 기압계 unavailable 원인 분해.
@@ -44,12 +45,17 @@ import {
  * `stop=undefined`(평가 불가) 원인을 device dump에 노출하기 위한 진단 필드.
  * 원인을 모르면 SPOF 회피 방향(WiFi 분리 / fusion verdict 결합) 튜닝이 불가능하다.
  *
- * - 'sensor'      : `Barometer.isAvailableAsync()` false (iPhone 6 이하 등 기기 미지원)
- * - 'permission'  : NSMotionUsageDescription 권한 거절
- * - 'readings'    : 센서 활성이지만 30s 윈도우를 채울 reading 부족 (warm-up 초기)
- * - undefined     : 정상 (stop이 true|false로 결정됨)
+ * - 'sensor'          : `Barometer.isAvailableAsync()` false (iPhone 6 이하 등 기기 미지원)
+ * - 'permission'      : NSMotionUsageDescription 권한 거절
+ * - 'readings'        : 센서 활성이지만 30s 윈도우를 채울 reading 부족 (warm-up 초기)
+ * - 'flag-on-dormant' : #2006 — arrival-api-ssot-v1 flag ON. 기압계 SPOF 배터리 절약.
+ * - undefined         : 정상 (stop이 true|false로 결정됨)
  */
-export type BarometerUnavailableReason = 'sensor' | 'permission' | 'readings';
+export type BarometerUnavailableReason =
+  | 'sensor'
+  | 'permission'
+  | 'readings'
+  | 'flag-on-dormant';
 
 /**
  * #903 — 외부 소비자에 노출되는 보조 신호 스냅샷.
@@ -95,14 +101,21 @@ export interface BarometerSignal {
  * sticky automotive · fusion confidence · backend payload를 한 신호로 일관되게 분기한다.
  */
 export function useBarometer(): BarometerSignal {
+  // #2006 (ADR-022 Phase 4-4) — arrival-api-ssot-v1 flag ON 시 dormant.
+  // mount time 판정 — flag toggle 은 재빌드/remount 이 트리거. hook 반환값 자체를 flag ON
+  // 시 dormant 상수 객체로 굳혀 useEffect / useState / useRef 오버헤드도 skip 한다.
+  // subsurface=false, stop=undefined, readingCount=0, unavailableReason='flag-on-dormant'.
+  const flagDormant = isSimpleArchEnabled();
+
   const [subsurface, setSubsurface] = useState<boolean>(false);
   // #921 — readings 부족 또는 unmount 직후는 undefined. fusion 입력 unavailable로 흘러간다.
   const [stop, setStop] = useState<boolean | undefined>(undefined);
   // #1398 — stop=undefined일 때의 원인. 초기값 'sensor'(아직 게이트 미통과). 게이트 단계별로
   // 'sensor' → 'permission' → 'readings' → undefined(정상)로 좁혀진다.
+  // #2006 — flag ON 시 초기값은 'flag-on-dormant' — listener 미등록이라 이후 갱신 없음.
   const [unavailableReason, setUnavailableReason] = useState<
     BarometerUnavailableReason | undefined
-  >('sensor');
+  >(flagDormant ? 'flag-on-dormant' : 'sensor');
   // #1398 — ring buffer 누적 reading 수. listener tick마다 갱신.
   const [readingCount, setReadingCount] = useState<number>(0);
   // #903 — hysteresis: 임계 부근 노이즈 진동 흡수. lastEmitted와 다른 verdict가 N회 연속
@@ -116,6 +129,11 @@ export function useBarometer(): BarometerSignal {
   const stopPendingRef = useRef<number>(0);
 
   useEffect(() => {
+    // #2006 — flag ON 시 native listener 등록 skip. 배터리 · 권한 prompt · ring buffer 비용 0.
+    // 초기 state 가 이미 dormant 조합이라 별도 setState 호출 불필요.
+    if (flagDormant) {
+      return;
+    }
     let cancelled = false;
     let subscription: { remove(): void } | null = null;
 


### PR DESCRIPTION
Closes #2006

## Summary

ADR-022 (#1980) A6 — Phase 4 WiFi SSID / 기압계 dormant (flag guard).

- WiFi SSID 매핑 (`wifiSsidLookup.ts` + `subwayWifiSsidMap.json`) — 지하 대체 신호
- 기압계 subsurface (`useBarometer.ts` + `barometerSubsurface.ts`) — 지하 감지

**flag ON** 시 arrival API 가 지하도 SSOT 로 커버 → 두 신호 dormant.
**flag OFF** (default) 시 기존 동작 100% 유지 (backward-compat).

## 변경 사항

### WiFi SSID
- `lookupStationBySsid()` — flag ON 시 항상 null 반환 (매칭 skip)
- `useWifiStation` hook — flag ON 시 폴링 자체 skip (배터리·권한 비용 0)
- 파일 유지 — 완전 삭제는 Phase 4b (dogfood 검증 후)

### 기압계
- `useBarometer` — flag ON 시 native listener 등록 skip (isAvailable / requestPermission / addListener 호출 0)
- `BarometerUnavailableReason` 타입에 `'flag-on-dormant'` 추가
- return 계약: `subsurface=false, stop=undefined, readingCount=0, unavailableReason='flag-on-dormant'`

### DebugModal
- 기존 `subsurface reason` 라인이 `unavailableReason ?? '—'` 로 자동 렌더링 → flag ON 시 `flag-on-dormant` 노출 (신규 UI 코드 X)

### useFusedNearestStation 조정 (Phase 4-1과 조정)
- 신규 flag guard 코드 X — `useBarometer`/`useWifiStation` 가 이미 dormant 값을 반환하므로 fusion 로직 (`barometerSubsurface === true` 등)이 자연스럽게 false로 평가되어 기존 우선순위 그대로 동작. Phase 4-1(#2004)이 별도 PR에서 fusion cascade 축소를 담당.

## Acceptance

- [x] flag OFF 시 WiFi/기압계 신호 기존 동작 유지 (backward-compat)
- [x] flag ON 시 WiFi 매칭 skip + 기압계 listener skip (배터리 절약) + test
- [x] DebugModal 상태 표시 (`flag-on-dormant` reason)
- [x] client test 100% coverage (8932 tests pass)
- [x] type-check clean

## Wire-completion 5단

1. **Orphan 없음** — 신규 export 없음 (`isSimpleArchEnabled` 재사용). `npm run lint:orphan` pass.
2. **V/X dashboard** — DebugModal GPS 섹션 `subsurface reason` 라인이 flag ON 시 `flag-on-dormant` 노출.
3. **의존 PR** — N/A (독립). Phase 4-1(#2004)은 fusion cascade dormant로 별개 관심사.
4. **측정 plan** — 1주 dogfood build에서 flag ON 시 barometer listener 등록 0건 + wifiSsidLookup 매칭 0건 확인 (battery 절약 검증). DebugModal share dump 로 관측 가능.
5. **Device verify** — N/A — type+unit only. flag OFF (default) 는 기존 동작 완벽 보존이라 회귀 위험 0. flag ON 검증은 dogfood 빌드 사용자 트립으로 별개 확인.

## Test plan

- [x] `npm test` — 8932 tests pass, 100% coverage
- [x] `npm run type-check` — clean
- [x] `npm run lint:orphan` — no orphan exports
- [ ] flag ON dogfood build 에서 실기기 1주 검증 (dev 머지 후 별도 진행)