### PR TITLE
feat(#2012): Phase 4-2 stationProgressEstimator live-position + lockless-route-hop dormant

### DIFF
--- a/src/features/route/utils/__tests__/stationProgressEstimator.test.ts
+++ b/src/features/route/utils/__tests__/stationProgressEstimator.test.ts
@@ -2,10 +2,26 @@ import { arcIndexOfStation, estimateStationProgress } from '../stationProgressEs
 import { HOP_TIME_MS } from '../../../../shared/constants/boardingLock';
 import { ESTIMATOR_STUCK_TIMEOUT_MS } from '../../../../shared/constants/realtime';
 import { ARRIVAL_CODE } from '../../../../shared/constants/arrivalCodes';
+import { SIMPLE_ARRIVAL_ARCH_ENV_KEY } from '../../../../shared/config/archFlag';
 import type { ArrivalInfo } from '../../../../shared/types/arrival';
 import type { BoardingLock } from '../../../../shared/types/boardingLock';
 import type { Station } from '../../../../shared/types/station';
 import type { TrainProgressResult } from '../trackTrainProgress';
+
+const ORIGINAL_ARCH_ENV = process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+
+beforeEach(() => {
+  // 각 테스트가 명시적으로 flag 를 셋하지 않는 한 dormant 기본값 유지 (flag OFF).
+  delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+});
+
+afterAll(() => {
+  if (ORIGINAL_ARCH_ENV === undefined) {
+    delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+  } else {
+    process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = ORIGINAL_ARCH_ENV;
+  }
+});
 
 // 기존 테스트들이 HOP_TIME_MS uniform 가정을 그대로 사용 — Stage 3에서도 estimator의 시간 적분
 // 로직 회귀를 검증하려면 동일한 시간 단위가 필요. lookup closure로 감싸 시그니처만 신규 형태로 맞춘다.
@@ -955,6 +971,148 @@ describe('estimateStationProgress', () => {
       // ① 채택 → live-position, index=2
       expect(r?.strategy).toBe('live-position');
       expect(r?.index).toBe(2);
+    });
+  });
+
+  describe('#2012 (Phase 4-2) SIMPLE_ARRIVAL_ARCH flag guard', () => {
+    // flag ON 시 arrival API (`arvlCd` 조합) 가 SSoT 이므로 estimator 내부 두 strategy 를 dormant.
+    //   - tryLivePosition skip → ArrivalEta / ReanchoredHop / DefaultHop 만
+    //   - tryLocklessRouteHop skip → null 반환 (arvlCd SSoT 가 lockless 진행 담당)
+    // flag OFF (기본) 은 기존 4단 + LocklessRouteHop 100% 유지.
+
+    describe('lock 활성 — live-position dormant', () => {
+      it('flag OFF: LivePosition 매칭 시나리오 → live-position 채택', () => {
+        // 기존 우선순위 합성 시나리오와 동일 — flag 명시 OFF 도 default 와 같음.
+        process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'false';
+        const r = estimateStationProgress({
+          lock: makeLock(),
+          arcStations: ARC,
+          now: T0,
+          trainProgress: makeTrainProgress({ stationIdx: 2 }),
+          lockedTrainCode: '7093',
+          lastObserved: null,
+          hopTimeMsForHop: UNIFORM_HOP,
+          ...NO_ARRIVAL_INPUT,
+        });
+        expect(r).toEqual({
+          station: ARC[2],
+          index: 2,
+          strategy: 'live-position',
+        });
+      });
+
+      it('flag ON: 동일 시나리오 → live-position skip → default-hop fallback (② ③ 입력 없음)', () => {
+        // trainProgress 완비 + lockedTrainCode 매칭이지만 flag ON 이라 ① skip.
+        // ② ArrivalEta 입력 없음(NO_ARRIVAL_INPUT), ③ ReanchoredHop 앵커 없음(lastObserved null)
+        // → ④ DefaultHop 이 boardedAt 앵커로 fallback (elapsed=0 → boardingIdx=0).
+        process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+        const r = estimateStationProgress({
+          lock: makeLock(),
+          arcStations: ARC,
+          now: T0,
+          trainProgress: makeTrainProgress({ stationIdx: 2 }),
+          lockedTrainCode: '7093',
+          lastObserved: null,
+          hopTimeMsForHop: UNIFORM_HOP,
+          ...NO_ARRIVAL_INPUT,
+        });
+        expect(r?.strategy).toBe('default-hop');
+        expect(r?.index).toBe(0);
+      });
+
+      it('flag ON: ① skip 후 ② ArrivalEta 가능하면 arrival-eta 채택', () => {
+        // flag ON 에서도 ArrivalEta 는 유효 — arrival API 응답 자체를 소비하는 strategy.
+        process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+        const r = estimateStationProgress({
+          lock: makeLock(),
+          arcStations: ARC,
+          now: T0,
+          trainProgress: makeTrainProgress({ stationIdx: 1 }), // ① 매칭됐어도 flag ON 이라 skip
+          lockedTrainCode: '7093',
+          lastObserved: null,
+          hopTimeMsForHop: UNIFORM_HOP,
+          nextStationArrivals: [
+            makeArrival({ arrivalCode: ARRIVAL_CODE.ENTERING, arrivalSeconds: 14 }),
+          ],
+          arrivalEtaTtlMs: ARRIVAL_TTL_MS,
+          currentIdxHint: 2,
+        });
+        expect(r?.strategy).toBe('arrival-eta');
+        expect(r?.index).toBe(3);
+      });
+
+      it('flag ON: ① skip 후 ③ ReanchoredHop 가능하면 reanchored-hop 채택', () => {
+        // lastObserved 있고 ② 입력 없음 → ③ ReanchoredHop 채택 (flag 와 무관하게 유지).
+        process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+        const observedAt = T0 + 200_000;
+        const r = estimateStationProgress({
+          lock: makeLock(),
+          arcStations: ARC,
+          now: observedAt + 2 * HOP_TIME_MS,
+          trainProgress: makeTrainProgress({ stationIdx: 0 }), // ① 매칭됐어도 flag ON 이라 skip
+          lockedTrainCode: '7093',
+          lastObserved: { arcIndex: 2, observedAtMs: observedAt },
+          hopTimeMsForHop: UNIFORM_HOP,
+          ...NO_ARRIVAL_INPUT,
+        });
+        expect(r).toEqual({
+          station: ARC[4],
+          index: 4,
+          strategy: 'reanchored-hop',
+        });
+      });
+    });
+
+    describe('lockless — lockless-route-hop dormant', () => {
+      it('flag OFF: lockless trip 진행 → lockless-route-hop 채택', () => {
+        process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'false';
+        const now = T0 + 60_000;
+        const r = estimateStationProgress({
+          lock: null,
+          locklessTrip: { tripStartedAt: T0 },
+          arcStations: ARC,
+          now,
+          trainProgress: null,
+          lockedTrainCode: null,
+          lastObserved: null,
+          hopTimeMsForHop: UNIFORM_HOP,
+          ...NO_ARRIVAL_INPUT,
+        });
+        expect(r?.strategy).toBe('lockless-route-hop');
+      });
+
+      it('flag ON: lockless trip 제공돼도 null 반환 (arvlCd SSoT 담당)', () => {
+        process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+        const now = T0 + 60_000;
+        const r = estimateStationProgress({
+          lock: null,
+          locklessTrip: { tripStartedAt: T0 },
+          arcStations: ARC,
+          now,
+          trainProgress: null,
+          lockedTrainCode: null,
+          lastObserved: null,
+          hopTimeMsForHop: UNIFORM_HOP,
+          ...NO_ARRIVAL_INPUT,
+        });
+        expect(r).toBeNull();
+      });
+
+      it('flag ON: locklessTrip 미제공 시 여전히 null (기존 동작 유지)', () => {
+        // locklessTrip 미제공은 원래도 null → flag 와 무관.
+        process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+        const r = estimateStationProgress({
+          lock: null,
+          arcStations: ARC,
+          now: T0 + 60_000,
+          trainProgress: null,
+          lockedTrainCode: null,
+          lastObserved: null,
+          hopTimeMsForHop: UNIFORM_HOP,
+          ...NO_ARRIVAL_INPUT,
+        });
+        expect(r).toBeNull();
+      });
     });
   });
 });

--- a/src/features/route/utils/stationProgressEstimator.ts
+++ b/src/features/route/utils/stationProgressEstimator.ts
@@ -16,6 +16,7 @@ import {
   ESTIMATOR_STUCK_TIMEOUT_MS,
   LOCKLESS_TIME_INTEGRATION_STUCK_TIMEOUT_MS,
 } from '../../../shared/constants/realtime';
+import { isSimpleArchEnabled } from '../../../shared/config/archFlag';
 
 /**
  * ADR-008 — 탑승 진행 추정(BoardingLock 활성 trip 중 현재역) 합성기.
@@ -384,16 +385,29 @@ export function arcIndexOfStation(
  *
  * Stage 3(#779) 기준 ①(LivePosition) → ②(ArrivalEta) → ③(ReanchoredHop) → ④(DefaultHop) 순.
  * ③은 `lastObserved` 유효 시만 동작, ④는 `lock.boardedAt + boardingStationId` 앵커로 fallback.
+ *
+ * #2012 (ADR-022 A6 Phase 4-2) — simple arrival arch flag ON 시 arrival API (`arvlCd` 조합) 가
+ * SSoT 이므로 estimator 내부 두 strategy 를 dormant 처리한다:
+ *   - `live-position`: `arvlCd` 가 진입/도착/출발 상태를 SSoT 로 제공하므로 fusion cascade 에서
+ *     별도로 realtimePosition 매칭을 취할 필요가 없다 → `tryLivePosition` skip.
+ *   - `lockless-route-hop`: lockless trip 의 현재역 진행도 arrival API 가 SSoT 로 담당 →
+ *     `tryLocklessRouteHop` skip, null 반환.
+ *
+ * flag OFF 는 기존 4단 + LocklessRouteHop 100% 유지. Phase 4b 에서 완전 제거 예정.
  */
 export function estimateStationProgress(
   input: StationProgressEstimatorInput,
 ): StationProgressEstimate | null {
   const { lock, locklessTrip, arcStations, now, hopTimeMsForHop, lastObserved } = input;
   if (arcStations.length === 0) return null;
+  // #2012 (Phase 4-2) — flag 조회 1 회. 두 분기(lockless / lock 활성)에서 재사용.
+  const simpleArch = isSimpleArchEnabled();
   // Lockless 분기 (#1207): lock이 null이고 locklessTrip 컨텍스트가 제공되면 LocklessRouteHop으로 적분.
   // locklessTrip 미제공이면 기존 동작 유지(null) — 호출자가 명시적으로 lockless 활성을 옵트인.
   if (!lock) {
     if (locklessTrip) {
+      // #2012 (Phase 4-2) — flag ON 시 LocklessRouteHop 자체 dormant. arvlCd SSoT 가 담당.
+      if (simpleArch) return null;
       // #1922 (M2) — lastObserved를 stuck guard 신선도 source로 전달.
       return tryLocklessRouteHop(
         arcStations,
@@ -411,8 +425,12 @@ export function estimateStationProgress(
   // 이미 lock 비-null을 보장해 호출 트리 전체가 active trip context. tryDefaultHop만 lock.boardedAt/
   // boardingStationId를 사용하므로 시그니처에 명시(NonNullable)한다.
   const lockedInput = { ...input, lock };
+  // #2012 (Phase 4-2) — flag ON 시 tryLivePosition skip (arvlCd SSoT 가 담당).
+  // tryArrivalEta/tryReanchoredHop/tryDefaultHop 은 유지: arrival API 응답 자체를 소비하는
+  // strategy(② ArrivalEta) 는 dogfood 단계에서 여전히 필요, ③/④ 는 dead zone fallback 유지.
+  const livePosition = simpleArch ? null : tryLivePosition(input);
   return (
-    tryLivePosition(input) ??
+    livePosition ??
     tryArrivalEta(input) ??
     tryReanchoredHop(input) ??
     tryDefaultHop(lockedInput)


### PR DESCRIPTION
Closes #2012

## Summary

ADR-022 (#1980) A6 Phase 4-2. arrival API (`arvlCd` 조합 판정) 가 SSoT 이므로 `stationProgressEstimator` 의 `live-position` + `lockless-route-hop` strategy 를 flag guard 로 dormant.

- `estimateStationProgress` 진입 시 `isSimpleArchEnabled()` 호출
- flag ON: `tryLivePosition` skip → ArrivalEta/ReanchoredHop/DefaultHop 만
- flag ON + lockless: `tryLocklessRouteHop` skip → null 반환 (arvlCd SSoT 위임)
- flag OFF (기본): 기존 4단 strategy + LocklessRouteHop 100% 유지

## Acceptance 매핑

- [x] **flag OFF — 기존 4단 + LocklessRouteHop 100% 동작 유지** — test로 각 strategy 시나리오 커버
- [x] **flag ON — LivePosition skip** — trainProgress 매칭 완비돼도 ArrivalEta/하위로 fallback
- [x] **flag ON — LocklessRouteHop skip** — locklessTrip 제공돼도 null
- [x] **type-check clean** — `npm run type-check` pass
- [x] **orphan lint clean** — `npm run lint:orphan` pass
- [x] **test 100% coverage** — `npm test` pass

## Wire-completion 5단

1. **Orphan 없음** — 신규 export 없음. `isSimpleArchEnabled()` import만 추가.
2. **V/X dashboard** — DebugModal estimator strategy 라벨 그대로. flag ON dogfood build 에서 `strategy: 'live-position'` / `'lockless-route-hop'` 0건 확인.
3. **의존 PR** — Phase 0 (#1988), Phase 4-1 (#2008), Wave 1 (#2003) 이미 dev.
4. **측정 plan** — 1주 dogfood (`EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH=true`). estimator debug buffer 에서 `live-position` / `lockless-route-hop` label 채택 0건 확인.
5. **Device verify** — N/A — type+unit only. flag OFF 회귀 test 커버. flag ON 은 Phase 2 dogfood 검증.

## Test plan

- [x] `npm test` — 100% coverage pass
- [x] `npm run type-check` — clean
- [x] `npm run lint:orphan` — no orphan exports
- [x] `stationProgressEstimator.test.ts` — flag OFF/ON × strategy 매트릭스

## Refs

- Epic: #1980 (ADR-022)
- Phase 0: #1988 (Feature Flag 인프라)
- Phase 4-1: #2008 (fusion cascade 축소)
- Wave 1: #2003 (real helper wire)
- 후속: Phase 2 dogfood → Phase 3 default ON → Phase 4b 완전 삭제