### PR TITLE
fix(#2014): 관찰 11 boardingPrompt 9-AND 게이트 삭제 (ADR-022 B8, archFlag=on 시 arvlCd=1 즉시 fire)

### DIFF
--- a/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
+++ b/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
@@ -602,6 +602,96 @@ describe('evaluateBoardingPromptGates — #1820 motion grace (GPS-bypass 환경)
   });
 });
 
+/**
+ * #2014 (ADR-022 B8) — archFlag='on' 시 GPS/motion/speed 게이트(#3~#8) 전부 skip.
+ * #9 (fired/silenced) 만 평가. arvlCd=1 관측 자체는 caller 가 fetchArrivals + pickAutoTrainCode 로 별도 검증.
+ * archFlag='off' 또는 undefined 은 기존 게이트 동작 100% 유지 (회귀 방어).
+ */
+describe('evaluateBoardingPromptGates — #2014 (ADR-022 B8) archFlag', () => {
+  const now = 1_000_000;
+
+  it('archFlag=on: stale GPS + motion=stationary 여도 pass (모든 GPS/motion 게이트 skip)', () => {
+    const stationary = staleGpsSeries(now).map((p) => ({
+      ...p,
+      motion: 'stationary' as const,
+    }));
+    const r = evaluateBoardingPromptGates({
+      series: stationary,
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      environment: 'surface',
+      archFlag: 'on',
+    });
+    expect(r.pass).toBe(true);
+    if (r.pass) expect(r.fusedSpeedKmh).toBe(0);
+  });
+
+  it('archFlag=on: series=[] 여도 pass (window-too-small 차단 우회)', () => {
+    // 관찰 11 root cause 재현: 60s window sample 0건이라 legacy path 에선 no-candidates 로 100% 차단.
+    // archFlag=on 은 이 게이트를 skip 해야 한다.
+    const r = evaluateBoardingPromptGates({
+      series: [],
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      archFlag: 'on',
+    });
+    expect(r.pass).toBe(true);
+  });
+
+  it('archFlag=on: 이미 fired = already-fired (게이트 #9 는 여전히 평가)', () => {
+    const r = evaluateBoardingPromptGates({
+      series: happySeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      promptState: { fired: true, lastFiredAt: now - 1000 },
+      archFlag: 'on',
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('already-fired');
+  });
+
+  it('archFlag=on: silencedUntil 미래 = silenced (게이트 #9 는 여전히 평가)', () => {
+    const r = evaluateBoardingPromptGates({
+      series: happySeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      promptState: { silencedUntil: now + 60_000 },
+      archFlag: 'on',
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('silenced');
+  });
+
+  it('archFlag=off: stale GPS + surface → 기존 9단 AND (origin-too-far)', () => {
+    const r = evaluateBoardingPromptGates({
+      series: staleGpsSeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      environment: 'surface',
+      archFlag: 'off',
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('origin-too-far');
+  });
+
+  it('archFlag=off: happy series → 기존 통과 동작 유지 (fusedSpeedKmh > 0)', () => {
+    const r = evaluateBoardingPromptGates({
+      series: happySeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      archFlag: 'off',
+    });
+    expect(r.pass).toBe(true);
+    if (r.pass) expect(r.fusedSpeedKmh).toBeGreaterThan(5);
+  });
+});
+
 describe('markPromptFired / markPromptSilenced', () => {
   it('markPromptFired는 fired=true + lastFiredAt 설정', () => {
     expect(markPromptFired(1234)).toEqual({ fired: true, lastFiredAt: 1234 });

--- a/backend/alarm-worker/src/__tests__/consensusGate.test.ts
+++ b/backend/alarm-worker/src/__tests__/consensusGate.test.ts
@@ -170,6 +170,70 @@ describe('evaluateConsensusGate (ADR-015 §3/§4)', () => {
     });
   });
 
+  describe('#2014 (ADR-022 B8) — archFlag=on 시 환경 분기 우회', () => {
+    it('archFlag=on + surface + base 실패 → pass (base 게이트 무시)', () => {
+      // legacy 경로에선 base-gate-failed 로 reject. archFlag=on 은 arvlCd SSoT 로 우회.
+      expect(
+        evaluateConsensusGate(
+          'surface',
+          signals({ gateOutcome: FAIL_GATE }),
+          'on',
+        ).pass,
+      ).toBe(true);
+    });
+
+    it('archFlag=on + underground + arrival/lockAttachable 모두 없음 → pass', () => {
+      // legacy 경로에선 environment-no-gps-consensus. archFlag=on 은 우회.
+      expect(
+        evaluateConsensusGate(
+          'underground',
+          signals({
+            gateOutcome: FAIL_GATE,
+            arrivalSignalPresent: false,
+            lockAttachable: false,
+          }),
+          'on',
+        ).pass,
+      ).toBe(true);
+    });
+
+    it('archFlag=on + cellular contradict → pass (cellular vote 도 무시)', () => {
+      // legacy 경로에선 cellular-environment-contradicts. archFlag=on 은 우회.
+      expect(
+        evaluateConsensusGate(
+          'surface',
+          signals({ cellularEnvironmentVote: 'underground' }),
+          'on',
+        ).pass,
+      ).toBe(true);
+    });
+
+    it('archFlag=off → 기존 정책 유지 (base 실패 시 reject)', () => {
+      expect(
+        evaluateConsensusGate(
+          'surface',
+          signals({ gateOutcome: FAIL_GATE }),
+          'off',
+        ),
+      ).toEqual({
+        pass: false,
+        environment: 'surface',
+        reason: 'base-gate-failed',
+      });
+    });
+
+    it('archFlag undefined (legacy) → 기존 정책 유지', () => {
+      // 3-arg overload 없이 호출한 케이스와 동일.
+      expect(
+        evaluateConsensusGate('surface', signals({ gateOutcome: FAIL_GATE })),
+      ).toEqual({
+        pass: false,
+        environment: 'surface',
+        reason: 'base-gate-failed',
+      });
+    });
+  });
+
   describe('§7 토글 input X — backend는 trip 등록만 본다', () => {
     it.each<StationEnvironment>(['surface', 'underground', 'mixed'])(
       '%s: 동일 signals → 토글 ON/OFF / boardingPrompt 응답 유무와 무관하게 동일 결과',

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -3662,6 +3662,210 @@ describe('runScheduled — boarding-prompt 9단 게이트 (#819)', () => {
   });
 });
 
+/**
+ * #2014 (ADR-022 B8) — deps.archFlag='on' 시 boardingPrompt 게이트 축소.
+ *
+ * 관찰 11 root cause: `MIN_WINDOW_SAMPLES=1` 게이트가 60s window sample 0건 시 no-candidates 로 100% 차단.
+ * B8 정책: "arvlCd=1 도착 시 즉시 발사. motion / speed 게이트 없음".
+ *
+ * 본 describe 는 archFlag='on' 배선 시 실제 fire 경로가 열리는지 + FP 방어 유지되는지 검증.
+ */
+describe('runScheduled — #2014 (ADR-022 B8) archFlag=on 배선', () => {
+  function makeUnlockedTrip(overrides: Partial<Trip> = {}): Trip {
+    return makeTrip({
+      token: 'b8-tok',
+      promptGeoContext: {
+        origin: { lat: 0, lng: 0 },
+        nextStation: { lat: 0, lng: 0.01 },
+        direction: 'up',
+      },
+      promptDisplay: { originStation: '강남', line: '2' },
+      ...overrides,
+    });
+  }
+
+  // arvlCd=1 (ARRIVED) 도착 신호 — 단일 후보 (pickAutoTrainCode 통과).
+  const ARVL_ARRIVED_SINGLE: ArrivalEntry = {
+    destination: '성수',
+    arrivalSeconds: 0,
+    trainCode: 'B8-T1',
+    isUp: true,
+    subwayNm: '2호선',
+    arvlCd: 1,
+  };
+
+  function makeArchFlagDeps(
+    fetchImpl: typeof fetch,
+    seoul?: SeoulArrivalClient,
+    archFlag: 'on' | 'off' | undefined = 'on',
+  ) {
+    return {
+      seoul: seoul ?? makeSeoul([ARVL_ARRIVED_SINGLE]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      now: () => NOW,
+      fetchImpl,
+      generatePushId: () => 'b8-push-1',
+      archFlag,
+    };
+  }
+
+  it('archFlag=on + series=[] + arvlCd=1 → fire (관찰 11 회귀 fix)', async () => {
+    // 관찰 11 재현: series 0건 → legacy 는 no-candidates 로 100% blocked.
+    // archFlag=on 은 게이트 skip → 정상 fire.
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());
+    // series 시드하지 않음 → 빈 series.
+    const fetchImpl = vi.fn(
+      async () => new Response(null, { status: 200 }),
+    ) as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeArchFlagDeps(fetchImpl));
+
+    expect(stats.boardingPromptEvaluated).toBe(1);
+    expect(stats.boardingPromptFired).toBe(1);
+    expect(stats.boardingPromptBlocked).toBe(0);
+    // APNs fetch 1회 호출.
+    expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+    const persisted = JSON.parse((await kv.get('trip:b8-tok'))!);
+    expect(persisted.boardingPromptState).toEqual({ fired: true, lastFiredAt: NOW });
+  });
+
+  it('archFlag=off + series=[] → 기존 no-candidates 차단 유지 (회귀 방어)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+
+    const stats = await runScheduled(
+      makeEnv(kv),
+      makeArchFlagDeps(fetchImpl, undefined, 'off'),
+    );
+
+    expect(stats.boardingPromptEvaluated).toBe(1);
+    expect(stats.boardingPromptFired).toBe(0);
+    expect(stats.boardingPromptBlocked).toBe(1);
+    expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it('archFlag undefined + series=[] → 기존 no-candidates 차단 유지 (legacy 호환)', async () => {
+    // deps 에 archFlag 키 자체를 넣지 않음 (`makeArchFlagDeps` 기본값 'on' 회피).
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const legacyDeps = {
+      seoul: makeSeoul([ARVL_ARRIVED_SINGLE]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      now: () => NOW,
+      fetchImpl,
+      generatePushId: () => 'b8-push-1',
+    };
+
+    const stats = await runScheduled(makeEnv(kv), legacyDeps);
+
+    expect(stats.boardingPromptFired).toBe(0);
+    expect(stats.boardingPromptBlocked).toBe(1);
+  });
+
+  it('archFlag=on + already fired → skip (게이트 #9 유지)', async () => {
+    // silence/fired dedup 은 archFlag=on 에서도 반드시 평가.
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({
+        boardingPromptState: { fired: true, lastFiredAt: NOW - 60_000 },
+      }),
+    );
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeArchFlagDeps(fetchImpl));
+
+    expect(stats.boardingPromptFired).toBe(0);
+    expect(stats.boardingPromptBlocked).toBe(1);
+    expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it('archFlag=on + pickAutoTrainCode ambiguity → skip (FP guard 유지)', async () => {
+    // 같은 arvlCd=1 후보 2건 → pickAutoTrainCode null → fire skip.
+    const AMBIGUOUS_TRAIN_A: ArrivalEntry = {
+      ...ARVL_ARRIVED_SINGLE,
+      trainCode: 'AMB-A',
+    };
+    const AMBIGUOUS_TRAIN_B: ArrivalEntry = {
+      ...ARVL_ARRIVED_SINGLE,
+      trainCode: 'AMB-B',
+    };
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const deps = makeArchFlagDeps(
+      fetchImpl,
+      makeSeoul([AMBIGUOUS_TRAIN_A, AMBIGUOUS_TRAIN_B]),
+    );
+
+    const stats = await runScheduled(makeEnv(kv), deps);
+
+    expect(stats.boardingPromptEvaluated).toBe(1);
+    expect(stats.boardingPromptFired).toBe(0);
+    expect(stats.boardingPromptBlocked).toBe(1);
+    // ambiguity guard 로 skip — APNs fetch X.
+    expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it('archFlag=on + Seoul API 응답 0건 → boardingPromptSkippedEmpty (기존 guard 유지)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const deps = makeArchFlagDeps(fetchImpl, makeSeoul([]));
+
+    const stats = await runScheduled(makeEnv(kv), deps);
+
+    expect(stats.boardingPromptEvaluated).toBe(1);
+    expect(stats.boardingPromptFired).toBe(0);
+    expect(stats.boardingPromptSkippedEmpty).toBe(1);
+    expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it('archFlag=on + AUTO_PROMPT_DEDUP_WINDOW_MS 내부 → dedup skip', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({ lastAutoPromptedAt: NOW - 1_000 }), // 5분 미만
+    );
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeArchFlagDeps(fetchImpl));
+
+    // dedup skip — evaluated/fired/blocked 미증가.
+    expect(stats.boardingPromptEvaluated).toBe(0);
+    expect(stats.boardingPromptFired).toBe(0);
+    expect(stats.boardingPromptAutoDeduped).toBe(1);
+  });
+
+  it('archFlag=on + boardingLock 활성 → F2 defense skip (기존 정책 유지)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({
+        boardingLock: {
+          trainCode: 'T-expired',
+          line: '2',
+          subwayId: '1002',
+          selectedDepartureTime: NOW - 60_000,
+          segmentStations: ['역삼', '강남'],
+          expiresAt: NOW - 1, // 만료 → lockMissing 분기 진입
+        },
+      }),
+    );
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeArchFlagDeps(fetchImpl));
+
+    expect(stats.boardingPromptSkippedLockActive).toBe(1);
+    expect(stats.boardingPromptFired).toBe(0);
+  });
+});
+
 describe('runScheduled — evaluateAndMaybeFireBoardingPrompt Kalman KV 통합 (#824)', () => {
   /**
    * boarding-prompt 경로에서 Kalman state가 KV에 persist/read되는지 검증.

--- a/backend/alarm-worker/src/boardingPrompt.ts
+++ b/backend/alarm-worker/src/boardingPrompt.ts
@@ -28,6 +28,7 @@
  */
 
 import { ARRIVAL_CODE } from './alarm';
+import type { ArchFlagValue } from './archFlag';
 import type { StationEnvironment } from './consensusGate';
 import { fusedSpeed } from './fusedSpeed';
 import { matchLine } from './lineAlias';
@@ -114,6 +115,19 @@ export interface EvaluateBoardingPromptInputs {
    * lockAttachable 2-of-2 합의를 검증해야 한다(false positive 차단).
    */
   environment?: StationEnvironment;
+  /**
+   * #2014 (ADR-022 B8) — arrival API SSoT 아키텍처 활성화 여부.
+   *
+   * `'on'` 이면 GPS/motion/speed 게이트(#3~#8) 전부 skip, #9 (fired/silenced) 만 평가한다.
+   * B8 정책: "boardingPrompt 발사 = arvlCd=1 도착 시 즉시. motion / speed 게이트 없음".
+   * arvlCd=1 관측 자체는 caller(scheduled.ts) 가 fetchArrivals 후 별도 검사 — 본 게이트는
+   * `promptState.fired` / `silencedUntil` 만으로 dedup + silence 정책을 유지해 false-positive
+   * repeat push 를 차단한다.
+   *
+   * `'off'` 또는 undefined(legacy 호출자) 는 기존 9단 AND 게이트(또는 environment 분기) 그대로
+   * 평가 — 회귀 방어.
+   */
+  archFlag?: ArchFlagValue;
 }
 
 /**
@@ -222,6 +236,12 @@ function isGpsDependentBypassEnv(env: StationEnvironment | undefined): boolean {
  * fail 회귀 차단. 이 분기에서는 #8 motion + #9 silence/fired 만 평가하며, caller(scheduled.ts)
  * 가 evaluateConsensusGate(environment, signals) 로 arrival + lockAttachable 합의를 별도 검증해
  * false positive 를 차단해야 한다. `environment` 미지정 또는 'surface' 면 기존 9단 AND 평가.
+ *
+ * #2014 (ADR-022 B8) — `inputs.archFlag === 'on'` 시 GPS/motion/speed 게이트(#3~#8) 전부 skip.
+ * #9 (fired/silenced) 만 평가해 dedup + silence 만 유지. B8 정책 "arvlCd=1 도착 시 즉시 발사"
+ * 를 지원 — arvlCd 관측 자체는 caller 가 별도로 fetchArrivals + `pickAutoTrainCode` 로 검증.
+ * `fusedSpeedKmh=0` 으로 반환 (bypass 분기와 동일) — 호출자는 fusedSpeed 를 로깅 외 용도로
+ * 신뢰하지 않는다.
  */
 export function evaluateBoardingPromptGates(
   inputs: EvaluateBoardingPromptInputs,
@@ -230,10 +250,16 @@ export function evaluateBoardingPromptGates(
   const silenceOutcome = evaluateSilenceGate(inputs.promptState, inputs.now);
   if (silenceOutcome) return silenceOutcome;
 
-  const gpsDependentBypass = isGpsDependentBypassEnv(inputs.environment);
-
   // #833 — 호출자가 동일 series/now로 이미 evaluateWindow를 돌렸다면 결과 재사용.
   const metrics = inputs.metrics ?? evaluateWindow(inputs.series, inputs.now);
+
+  // #2014 (ADR-022 B8) — archFlag=on 시 #9 만 평가 후 즉시 pass. 나머지 게이트는 skip.
+  // arvlCd=1 관측 기반 fire 정책은 caller(scheduled.ts) 가 별도 검증한다.
+  if (inputs.archFlag === 'on') {
+    return { pass: true, metrics, fusedSpeedKmh: 0 };
+  }
+
+  const gpsDependentBypass = isGpsDependentBypassEnv(inputs.environment);
 
   // surface / undefined 만 GPS 의존 게이트 평가 — underground/mixed/unknown 은 byPass.
   if (!gpsDependentBypass) {

--- a/backend/alarm-worker/src/consensusGate.ts
+++ b/backend/alarm-worker/src/consensusGate.ts
@@ -39,6 +39,7 @@
  *   trip도 fire 권한이 자동 박탈되지 않는다.
  */
 
+import type { ArchFlagValue } from './archFlag';
 import type { GateOutcome } from './boardingPrompt';
 import type { BoardingLockMeta, LineNumber, Route, Trip, Waypoint } from './types';
 
@@ -134,7 +135,14 @@ function cellularContradictsEnvironment(
 export function evaluateConsensusGate(
   environment: StationEnvironment,
   signals: ConsensusSignals,
+  archFlag?: ArchFlagValue,
 ): ConsensusOutcome {
+  // #2014 (ADR-022 B8) — archFlag=on 시 arvlCd 자체가 SSoT. 환경 분기 / GPS 합의 / cellular vote
+  // 모두 우회한다. arrival API 신호(=arvlCd) 를 유일한 진실로 삼는다는 B8 정책 정합.
+  // caller(scheduled.ts) 가 실제 arvlCd 관측 + `pickAutoTrainCode` 로 별도 검증.
+  if (archFlag === 'on') {
+    return { pass: true, environment };
+  }
   // S10 #1543 — cellular vote가 환경과 정면 충돌하면 즉시 reject.
   // 본 게이트는 base 통과/미통과와 무관하게 적용 — 환경 자체가 신뢰 불가하다는 강한 신호.
   if (cellularContradictsEnvironment(environment, signals.cellularEnvironmentVote)) {

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -18,6 +18,7 @@ import { AUTO_PROMPT_DEDUP_WINDOW_MS } from './autoLock';
 import {
   evaluateBoardingPromptGates,
   markPromptFired,
+  pickAutoTrainCode,
   type GateSkipReason,
 } from './boardingPrompt';
 import {
@@ -3614,6 +3615,10 @@ export async function evaluateAndMaybeFireBoardingPrompt(
   // #1536 (S3) — 환경 분기. underground/unknown 은 GPS 의존 게이트(#3~#7) 를 byPass.
   // 결과(outcome.pass) 는 motion+silence/fired 만 보장하므로 caller 는 별도 consensusGate
   // 로 arrival+lockAttachable 합의를 검증해야 false positive 차단.
+  //
+  // #2014 (ADR-022 B8) — deps.archFlag='on' 시 GPS/motion/speed 게이트(#3~#8) 전부 skip,
+  // #9 (fired/silenced) 만 평가. arvlCd=1 관측 기반 fire 판정은 아래 fetchArrivals 후
+  // `pickAutoTrainCode` 로 별도 진행. 즉 gate 통과 = "silence/fired dedup OK"만 의미.
   const environment = deriveTripEnvironment(trip);
   const outcome = evaluateBoardingPromptGates({
     series: fusion.series,
@@ -3626,6 +3631,7 @@ export async function evaluateAndMaybeFireBoardingPrompt(
     // 그 결과를 그대로 재사용해 trip당 redundant window 평가를 제거 (동작 동치).
     metrics: fusion.posMetrics,
     environment,
+    archFlag: deps.archFlag,
   });
 
   if (!outcome.pass) {
@@ -3649,6 +3655,8 @@ export async function evaluateAndMaybeFireBoardingPrompt(
   const nextStation = trip.waypoints[0]?.stationName ?? null;
   let etaSeconds: number | null = null;
   let candidateTrains: BoardingPromptCandidate[] = [];
+  // #2014 — pool 을 catch 밖으로 export 해 archFlag=on ambiguity guard 에서 재사용.
+  let poolForArchFlagCheck: readonly ArrivalEntry[] = [];
   try {
     const arrivals = await deps.seoul.fetchArrivals(display.originStation);
     const directional = arrivals.filter(
@@ -3657,6 +3665,7 @@ export async function evaluateAndMaybeFireBoardingPrompt(
         (geo.direction === null || (geo.direction === 'up' ? a.isUp : !a.isUp)),
     );
     const pool = directional.length > 0 ? directional : arrivals.filter((a) => matchLine(a.subwayNm, display.line));
+    poolForArchFlagCheck = pool;
     if (pool.length > 0) {
       const best = pool.reduce((min, cur) => (cur.arrivalSeconds < min.arrivalSeconds ? cur : min), pool[0]);
       etaSeconds = best.arrivalSeconds;
@@ -3674,6 +3683,28 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       }));
   } catch {
     // Seoul API 장애 시 ETA 없이 push 발사 — 메시지 degradation만 발생, push 자체는 보존.
+  }
+
+  // #2014 (ADR-022 B8) — archFlag=on 시 arvlCd 우선순위 기반 단일 trainCode 수렴 검증.
+  // ambiguity(같은 우선순위 후보 2+) 면 fire skip — false positive 방어(기존 B9 게이트 유지).
+  // pool 이 비어 있으면 (Seoul API 실패 / 매칭 0건) 아래 candidateTrains 0건 guard 로 skip 됨 —
+  // 여기서는 pool.length > 0 인데 pickAutoTrainCode 가 null 인 케이스만 명시 차단해 counter 로
+  // 가시화한다.
+  if (
+    deps.archFlag === 'on' &&
+    poolForArchFlagCheck.length > 0 &&
+    pickAutoTrainCode(poolForArchFlagCheck, display.line, geo.direction) === null
+  ) {
+    stats.boardingPromptBlocked += 1;
+    log('boarding-prompt: skipped ambiguity (#2014 archFlag=on)', {
+      token: trip.token.slice(0, 8),
+      line: display.line,
+      originStation: display.originStation,
+      direction: geo.direction,
+      poolSize: poolForArchFlagCheck.length,
+    });
+    if (dirty) await putTrip(env.TRIPS, trip);
+    return;
   }
 
   // #1888 (RC-13) — 후보 0건이면 발사 skip. 사용자가 banner를 받아도 빈 BoardingTrainList만 보게 되는


### PR DESCRIPTION
Closes #2014

## Summary

ADR-022 (#1980) 결정 B8 실행. 관찰 11 (`boardingPrompt` 미발사, `no-candidates` blocked) fix.

- `evaluateBoardingPromptGates` 에 `archFlag` 파라미터 추가
- archFlag='on' 시 #9 (fired/silenced) 만 평가 → 나머지 게이트 skip
- archFlag='off' 시 기존 9-AND / 3-AND 유지 (회귀 방어)
- `evaluateAndMaybeFireBoardingPrompt` 에 `pickAutoTrainCode` ambiguity guard 추가 (FP 방어)
- `evaluateConsensusGate` 도 archFlag='on' 시 arvlCd 기반 fire path 우회 (arrival 자체가 SSoT)

## Acceptance 매핑

- [x] archFlag='on' + arvlCd=1 → boardingPrompt 즉시 fire (motion/speed/GPS 게이트 무관)
- [x] archFlag='off' → 기존 9-AND / 3-AND 회귀 방어
- [x] FP 방어 유지 — dedup / ambiguity / promptGeoContext / F2 lock defense / skippedEmpty
- [x] backend test 100% (관련 파일)
- [x] type-check clean

## Wire-completion 5단

1. **Orphan 없음** — 신규 export 없음. 기존 함수에 optional param 추가만. `npm run lint:orphan` pass.
2. **V/X dashboard** — `stats.boardingPromptFired` / `stats.boardingPromptBlocked` / `stats.boardingPromptEvaluated` wrangler tail. archFlag='on' 배포 후 24h 관측 → `no-candidates` reason 0 수렴 확인.
3. **의존 PR** — Phase 4-5 (#2011 dev 머지), Phase 0 archFlag (#1988 dev 머지) 완료.
4. **측정 plan** — archFlag='on' 배포 후 1주간 실기기 dogfood. `boardingPromptFired / boardingPromptEvaluated` 비율 목표 ≥ 99%.
5. **Device verify** — 실기기 필수 (backend 변경, deploy + KV flag ON). 지상/지하 각각 시나리오 검증 필요 (사용자 책임).

## Test plan

- [x] `backend/alarm-worker/` type-check clean (`tsc --noEmit`)
- [x] `backend/alarm-worker/` unit test all pass (2460 tests, 19 새 케이스 추가)
- [x] `evaluateBoardingPromptGates` archFlag on/off 매트릭스 — 6 케이스
- [x] `evaluateConsensusGate` archFlag on/off 매트릭스 — 5 케이스
- [x] `evaluateAndMaybeFireBoardingPrompt` archFlag on/off/undefined + fire/skip 매트릭스 — 8 케이스
- [x] FP guard 시나리오 (ambiguity / dedup / F2 defense / skippedEmpty) 통과
- [x] Root type-check + lint:orphan pass

## Refs

- Epic: #1980 (ADR-022)
- 선행 PR: #2011 (Phase 4-5 Kalman dormant)
- 병행 Phase 4-2: #2013 (client estimator dormant)
- 후속: Phase 2 dogfood (사용자 실기기 flag ON + 1주 관찰)