### PR TITLE
fix(#2016): D5 환승 leg autoLock archFlag='on' 시 dormant (사용자 명시 의향 트리거만)

### DIFF
--- a/src/features/route/hooks/__tests__/useTransferTrainList.test.tsx
+++ b/src/features/route/hooks/__tests__/useTransferTrainList.test.tsx
@@ -11,10 +11,26 @@ import { useTransferTrainList, filterArrivalsByDirection } from '../useTransferT
 import { prefetchArrival, useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
 import { useBoardingLockStore } from '../../../alarm/store/useBoardingLockStore';
 import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute';
+import { SIMPLE_ARRIVAL_ARCH_ENV_KEY } from '../../../../shared/config/archFlag';
 import type { ArrivalInfo, StationArrival } from '../../../../shared/types/arrival';
 import type { BoardingLock } from '../../../../shared/types/boardingLock';
 import type { Station } from '../../../../shared/types/station';
 import { makeDirectRoute, makeTransferRoute } from '../../../../testUtils/routeFixtures';
+
+// #2016 — 각 테스트가 명시적으로 flag 를 셋하지 않는 한 dormant 기본값 유지 (flag OFF, 기존 D5 동작).
+const ORIGINAL_ARCH_ENV = process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+
+beforeEach(() => {
+  delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+});
+
+afterAll(() => {
+  if (ORIGINAL_ARCH_ENV === undefined) {
+    delete process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY];
+  } else {
+    process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = ORIGINAL_ARCH_ENV;
+  }
+});
 
 jest.mock('../../../arrival/hooks/useArrivalInfo');
 const mockUseArrival = useArrivalInfo as jest.Mock;
@@ -521,6 +537,89 @@ describe('#1211 D5 환승 leg autoLock 트리거', () => {
     );
     expect(mockCreateLock).toHaveBeenCalledTimes(1);
     expect(mockCreateLock).toHaveBeenCalledWith(expect.objectContaining({ trainCode: 'T-DIR-NULL' }));
+  });
+});
+
+/**
+ * #2016 (ADR-022 D5 dormant) — `isSimpleArchEnabled()` 활성 시 D5 autoLock effect skip.
+ *
+ * 배경: 관찰 11 fix (#2015) 로 arvlCd=1 즉시 boardingPrompt 가 fire 되면서 D5 autoLock 이
+ * 메꾸려던 lockless gap 자체가 사라짐. flag ON 시 사용자 명시 의향(boardingPrompt 응답 /
+ * BoardingTrainList 직접 탭) 만이 락 트리거.
+ *
+ * flag OFF (기본) 시 기존 D5 동작 100% 유지는 위 '#1211 D5' describe 가 이미 검증.
+ * 본 describe 는 flag ON 시 dormant + 수동 flow 정상 발동 만 박제.
+ */
+describe('#2016 (autoLock dormant) archFlag ON 시 D5 autoLock skip', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseArrival.mockReturnValue(arrivalRet(null));
+    mockPrefetchArrival.mockResolvedValue(undefined);
+    process.env[SIMPLE_ARRIVAL_ARCH_ENV_KEY] = 'true';
+  });
+
+  it('flag ON + context 활성 + arvlCd 단일 train(ARRIVED=1) → autoLock 발동 0건 (dormant)', () => {
+    // #1211 D5 baseline 시나리오. flag OFF 였으면 autoLock 1회 호출됐을 조건.
+    const arrived = makeTrain({ trainCode: 'T-ARRIVED', arrivalCode: 1, arrivalSeconds: 30 });
+    mockUseArrival.mockReturnValue(arrivalRet({ up: [arrived], down: [] }));
+    renderHook(() =>
+      useTransferTrainList({
+        lock,
+        route,
+        destinationName: '여의나루',
+        currentStation: gondeokOn6,
+      }),
+    );
+    expect(mockCreateLock).not.toHaveBeenCalled();
+  });
+
+  it('flag ON + BoardingTrainList 직접 탭 (createTransferLock) → 정상 락 발동 (수동 flow 유지)', () => {
+    mockUseArrival.mockReturnValue(arrivalRet({ up: [makeTrain({ trainCode: 'NEW' })], down: [] }));
+    const { result } = renderHook(() =>
+      useTransferTrainList({
+        lock,
+        route,
+        destinationName: '여의나루',
+        currentStation: gondeokOn6,
+      }),
+    );
+    // 자동 autoLock 은 dormant.
+    expect(mockCreateLock).not.toHaveBeenCalled();
+    // 사용자 명시 탭 → createTransferLock 직접 호출 시 정상 락 생성.
+    act(() => result.current.createTransferLock(makeTrain({ trainCode: 'NEW', arrivalSeconds: 240 })));
+    expect(mockCreateLock).toHaveBeenCalledTimes(1);
+    expect(mockCreateLock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        destinationId: 'dest-X',
+        trainCode: 'NEW',
+        boardingLine: '5',
+        expectedDurationMs: 6 * 60_000,
+        initialEtaSeconds: 240,
+      }),
+    );
+  });
+
+  it('flag ON + polling 반복(arrival 새 객체) → autoLock 0건 유지 (dormant 안정성)', () => {
+    // flag OFF 였으면 idempotency ref 로 1회만 호출. flag ON 이면 항상 0회.
+    const makeFreshArrival = (): { arrival: StationArrival; loading: boolean; isMock: boolean; refetch: jest.Mock } =>
+      arrivalRet({
+        up: [makeTrain({ trainCode: 'T-ARRIVED', arrivalCode: 1, arrivalSeconds: 30 })],
+        down: [],
+      }) as { arrival: StationArrival; loading: boolean; isMock: boolean; refetch: jest.Mock };
+    mockUseArrival.mockImplementation(() => makeFreshArrival());
+    const { rerender } = renderHook(
+      (props: { lock: BoardingLock }) =>
+        useTransferTrainList({
+          lock: props.lock,
+          route,
+          destinationName: '여의나루',
+          currentStation: gondeokOn6,
+        }),
+      { initialProps: { lock } },
+    );
+    rerender({ lock });
+    rerender({ lock });
+    expect(mockCreateLock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/features/route/hooks/useTransferTrainList.ts
+++ b/src/features/route/hooks/useTransferTrainList.ts
@@ -15,6 +15,7 @@ import {
   findUpcomingTransferPrefetch,
 } from '../utils/findActiveTransferContext';
 import { FALLBACK_BOARDING_DURATION_MINUTES } from '../../../shared/constants/boardingLock';
+import { isSimpleArchEnabled } from '../../../shared/config/archFlag';
 import { calculateRemainingLegETA } from '../../../shared/utils/stationRoute';
 import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
@@ -149,7 +150,13 @@ export function useTransferTrainList({
   );
 
   // #1211 D5 — autoLock 실제 트리거. createTransferLock 정의 이후에 effect 배치(클로저 캡처).
+  //
+  // #2016 (ADR-022 D5 dormant) — `isSimpleArchEnabled()` 활성 시 effect 자체 skip.
+  // 관찰 11 fix (#2015) 로 arvlCd=1 즉시 boardingPrompt 가 fire 되면서 D5 autoLock 이 메꾸려던
+  // lockless gap 자체가 사라짐. flag ON 에서는 사용자 명시 의향(boardingPrompt 응답 /
+  // BoardingTrainList 직접 탭) 만이 락 트리거. flag OFF (default) 시 기존 D5 100% 동작 유지.
   useEffect(() => {
+    if (isSimpleArchEnabled()) return;
     // transferKey가 truthy면 context도 활성 (transferKey가 context에서 도출).
     if (!transferKey) return;
     if (autoLockedTransferKeyRef.current === transferKey) return;


### PR DESCRIPTION
Closes #2016

## Summary

ADR-022 (#1980) 후속. 사용자 실기기 dogfood 관찰: 환승 시 사용자 응답/탭 없이 자동으로 가장 빠른 열차에 락 걸림.

- `useTransferTrainList.ts:152-166` D5 autoLock effect 진입 시 `isSimpleArchEnabled()` guard
- archFlag='on' 시 early return → createLock 호출 X
- archFlag='off' 시 기존 D5 autoLock 100% 동작 유지 (회귀 방어)
- 관찰 11 fix (#2015) 로 boardingPrompt 즉시 발동 확보 → D5 gap 메꾸기 목적 사라짐
- 락 트리거: boardingPrompt 응답 + BoardingTrainList 직접 탭만

## Acceptance 매핑

- [x] archFlag='off' 기존 11 시나리오 pass (회귀 방어)
- [x] archFlag='on' D5 autoLock 발동 0건
- [x] archFlag='on' 수동 flow (prompt 응답 / 직접 탭) 정상 락 발동
- [x] type-check clean
- [x] orphan lint clean
- [x] test coverage 100%

## Wire-completion 5단

1. **Orphan 없음** — 신규 export 없음. `isSimpleArchEnabled()` import만.
2. **V/X dashboard** — DebugModal boardingLock 라벨. archFlag='on' dogfood 에서 D5 autoLock label 채택 0건.
3. **의존 PR** — 관찰 11 fix (#2015 머지 완료), Phase 0 archFlag (#1988) 완료.
4. **측정 plan** — archFlag='on' dogfood 1주. D5 autoLock 발동 0건 + boardingPrompt 응답 락 발동 정상.
5. **Device verify** — 실기기 필수. 환승 시나리오 (A호선→B호선) 에서 boardingPrompt 뜨는지 + 응답 후 락 발동 확인.

## Test plan

- [x] archFlag='off' — 기존 D5 autoLock 11 시나리오 그대로 pass
- [x] archFlag='on' — D5 autoLock effect skip
- [x] archFlag='on' + BoardingTrainList 직접 탭 flow — 정상 락 발동
- [x] archFlag='on' + polling 반복 → dormant 안정성

## Refs

- Epic: #1980 (ADR-022)
- 선행 PR: #2015 (관찰 11 boardingPrompt B8 fix)
- 병행: #2013 (Phase 4-2 estimator dormant)
- D5 원본: #1211 → #1220 (2026-06-12 도입)