### PR TITLE
fix(#2019): POST /trips에 rotateTripTokenForNewRoute 호출 wire (ADR-022 B4)

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -3904,6 +3904,191 @@ describe('POST /trips — #1897 confirmedEnv echo (RC-5)', () => {
   });
 });
 
+// ADR-022 B4 (#2019 wire) — POST /trips 에서 rotateTripTokenForNewRoute 실제 호출.
+//
+// #1986 이 helper 정의를 도입했지만 프로덕션 caller 0개 (테스트 파일에서만 호출) 였고 2026-07-03
+// 사용자 실기기 trip(중곡→성수)에서 이전 trip 잔재 pending push 가 계속 발사돼 device 는
+// `BoardingLock active=no + boardingPrompt(all)=0` 상태였음에도 `08:37:25 bg fired
+// station-passed 성수` 관측. 원인: 새 route 등록 시 `trip:<oldToken>` KV entry 와
+// `pending:*` 잔재가 rotation helper 호출 부재로 정리되지 않음.
+//
+// 본 describe 는 wire 완결(POST handler 가 helper 호출) 을 검증한다. Helper 자체의 rotation
+// 로직 (route sig 계산 / KV delete / pending cleanup) 은 `trips.test.ts` 에서 커버.
+describe('POST /trips — #2019 rotateTripTokenForNewRoute wire (ADR-022 B4)', () => {
+  const TOKEN = 'tok-2019';
+  const ARCH_FLAG_KV_KEY = 'arch:simple-arrival-v1';
+
+  // Helper: incoming trip body 를 다른 destination/waypoints 로 변형.
+  function tripBodyFor(destination: string, stationName: string): Record<string, unknown> {
+    return {
+      ...base(),
+      token: TOKEN,
+      destination,
+      waypoints: [{ stationName, line: '2', kind: 'destination' }],
+    };
+  }
+
+  async function seedExistingTrip(
+    env: Env,
+    destination: string,
+    stationName: string,
+  ): Promise<void> {
+    const trip = {
+      token: TOKEN,
+      route: { type: 'direct', line: '2', stops: 3 },
+      destination,
+      waypoints: [{ stationName, line: '2', kind: 'destination' }],
+      expiresAt: FUTURE,
+      createdAt: Date.now(),
+      alarmAtEpochMs: FUTURE - 30 * 60 * 1000,
+    };
+    await env.TRIPS.put(`trip:${TOKEN}`, JSON.stringify(trip));
+  }
+
+  async function seedPending(env: Env, pushId: string, token: string): Promise<void> {
+    const entry = {
+      pushId,
+      token,
+      alarmKey: `early:${pushId}`,
+      sentAt: Date.now(),
+      stationName: '용마산',
+      kind: 'destination',
+      phase: 'early',
+      etaSeconds: 300,
+      apnsEnv: 'sandbox',
+    };
+    await env.TRIPS.put(`pending:${pushId}`, JSON.stringify(entry));
+  }
+
+  describe('archFlag=off (default) — dormant', () => {
+    it('existing + 다른 destination → 회전 없음 (`trip:<TOKEN>` 유지 + 응답 token 동일)', async () => {
+      const env = makeKvEnv();
+      await seedExistingTrip(env, '용마산-id', '용마산');
+      // KV 에 archFlag 미설정 → getArchFlag 는 default 'off' 반환.
+      const res = await post('/trips', tripBodyFor('성수-id', '성수'), env);
+      expect(res.status).toBe(200);
+      // 응답 token 은 그대로 (rotation 미발동).
+      expect(await res.json()).toEqual({
+        ok: true,
+        token: TOKEN,
+        confirmedEnv: 'sandbox',
+      });
+      // 기존 KV key 유지 — putTrip 이 같은 key 로 덮어씀.
+      const stored = await env.TRIPS.get(`trip:${TOKEN}`);
+      expect(stored).not.toBeNull();
+      // 새 destination 으로 갱신됐지만 token 은 그대로.
+      expect(JSON.parse(stored as string).destination).toBe('성수-id');
+    });
+
+    it('existing + pending push 잔재 + 다른 destination → pending 유지 (cleanup 미발동)', async () => {
+      // Wire dormant 상태에서 pending cleanup 이 발동하지 않는지 회귀 가드.
+      const env = makeKvEnv();
+      await seedExistingTrip(env, '용마산-id', '용마산');
+      await seedPending(env, 'p-legacy', TOKEN);
+      await post('/trips', tripBodyFor('성수-id', '성수'), env);
+      // flag=off → helper no-op → pending 잔재는 그대로 (기존 회귀 재현 시나리오).
+      expect(await env.TRIPS.get('pending:p-legacy')).not.toBeNull();
+    });
+  });
+
+  describe('archFlag=on — rotation active', () => {
+    beforeEach(async () => {
+      // 각 테스트는 자체 env 를 만들고 setup 에서 flag 를 KV 에 set 한다.
+    });
+
+    it('existing 없음 (신규 trip) → 회전 없음, incoming token 유지', async () => {
+      const env = makeKvEnv();
+      await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
+      const res = await post('/trips', tripBodyFor('성수-id', '성수'), env);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        ok: true,
+        token: TOKEN,
+        confirmedEnv: 'sandbox',
+      });
+      expect(await env.TRIPS.get(`trip:${TOKEN}`)).not.toBeNull();
+    });
+
+    it('existing + 같은 route (destination/waypoints 동일) → 회전 없음', async () => {
+      const env = makeKvEnv();
+      await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
+      await seedExistingTrip(env, '성수-id', '성수');
+      const res = await post('/trips', tripBodyFor('성수-id', '성수'), env);
+      expect(res.status).toBe(200);
+      // 같은 route sig → rotation dormant → token 유지.
+      expect(await res.json()).toEqual({
+        ok: true,
+        token: TOKEN,
+        confirmedEnv: 'sandbox',
+      });
+      expect(await env.TRIPS.get(`trip:${TOKEN}`)).not.toBeNull();
+    });
+
+    it('existing + 다른 destination → 회전 발동: 응답 token 이 새 UUID + trip:<oldToken> 삭제', async () => {
+      const env = makeKvEnv();
+      await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
+      await seedExistingTrip(env, '용마산-id', '용마산');
+      const res = await post('/trips', tripBodyFor('성수-id', '성수'), env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ok: true; token: string; confirmedEnv: string };
+      expect(body.ok).toBe(true);
+      // 응답 token 은 새 UUID (helper 가 crypto.randomUUID 사용).
+      expect(body.token).not.toBe(TOKEN);
+      expect(body.token).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      // 기존 KV entry 삭제됨.
+      expect(await env.TRIPS.get(`trip:${TOKEN}`)).toBeNull();
+      // 새 UUID key 에 새 destination 저장.
+      const newStored = await env.TRIPS.get(`trip:${body.token}`);
+      expect(newStored).not.toBeNull();
+      expect(JSON.parse(newStored as string).destination).toBe('성수-id');
+    });
+
+    it('evidence 재현 (2026-07-03) — 이전 trip pending push 잔재 존재 상태에서 새 route 등록 → pending cleanup', async () => {
+      // 오늘 evidence: 사용자 중곡→용마산 trip 후 새 중곡→성수 trip 시작. 이전 trip 관련 pending
+      // push (station-passed 성수) 가 남아있어 새 trip 이후에도 계속 발사.
+      // Wire 가 helper 의 `cleanupPendingPushesForToken` 호출을 발동시켜 잔재 pending 삭제.
+      const env = makeKvEnv();
+      await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
+      await seedExistingTrip(env, '용마산-id', '용마산');
+      // 이전 trip 관련 pending push 3건.
+      await seedPending(env, 'p-old-1', TOKEN);
+      await seedPending(env, 'p-old-2', TOKEN);
+      // 다른 device 소유 pending — 보존돼야 함.
+      await seedPending(env, 'p-other-device', 'tok-different');
+
+      const res = await post('/trips', tripBodyFor('성수-id', '성수'), env);
+      expect(res.status).toBe(200);
+
+      // 이전 token 소유 pending push 삭제됨 (jae재발사 차단).
+      expect(await env.TRIPS.get('pending:p-old-1')).toBeNull();
+      expect(await env.TRIPS.get('pending:p-old-2')).toBeNull();
+      // 다른 device pending 은 보존.
+      expect(await env.TRIPS.get('pending:p-other-device')).not.toBeNull();
+    });
+
+    it('archFlag=on 이 KV set → 회전 활성 (읽기 지점 검증)', async () => {
+      // Wire 가 실제로 `rotateTripTokenForNewRoute` 를 호출하는지 (getArchFlag → KV read)
+      // 간접 검증. KV 에 값을 넣기 전에는 회전 안 되지만 넣은 후 회전한다는 대비.
+      const env = makeKvEnv();
+      await seedExistingTrip(env, '용마산-id', '용마산');
+      // Round 1: flag 미설정 → default off → 회전 없음.
+      const res1 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
+      const body1 = (await res1.json()) as { token: string };
+      expect(body1.token).toBe(TOKEN);
+
+      // Reset: 새 existing 을 다시 seed 하고 flag on.
+      await seedExistingTrip(env, '용마산-id', '용마산');
+      await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
+      // Round 2: flag on → 회전 발동 → 새 UUID.
+      const res2 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
+      const body2 = (await res2.json()) as { token: string };
+      expect(body2.token).not.toBe(TOKEN);
+    });
+  });
+});
+
 function rawSignalsEnv(): Env {
   return makeEnv({ RAW_SIGNALS: new InMemoryKV() as unknown as KVNamespace });
 }

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -112,7 +112,7 @@ import {
   readObservabilityMetrics,
   tryStoreObservabilityMetrics,
 } from './observabilityMetrics';
-import { getTrip, putTrip } from './trips';
+import { getTrip, putTrip, rotateTripTokenForNewRoute } from './trips';
 import { inferWaypointsFromOriginAndDestination } from './dijkstraRoute';
 import { checkTripRegisterRateLimit } from './tripRegisterRateLimit';
 import {
@@ -632,7 +632,42 @@ app.post('/trips', async (c) => {
     }
   }
 
-  const existing = await getTrip(c.env.TRIPS, incoming.token);
+  const rawExisting = await getTrip(c.env.TRIPS, incoming.token);
+
+  // ADR-022 B4 (#2019 wire, #1986 rotation helper) — 새 route 감지 시 token rotation.
+  //
+  // archFlag=on + existing 있음 + route sig 다름 → 새 UUID 발급 + `trip:<oldToken>` delete +
+  // `pending:*` 중 oldToken 소유 entry cleanup (helper 내부 로직).
+  //
+  // archFlag=off (default): helper 는 `{ token: incoming.token, rotated: false }` no-op 반환
+  // → 기존 동작 100% 유지 (Phase 1-3 dormant).
+  //
+  // rotated=true 케이스 처리:
+  //   - `existing = null` 로 강등해 downstream `isSameSession=false` + progress skip 경로 진입
+  //     (helper 가 이미 `trip:<oldToken>` 을 delete 했으므로 same-session merge 는 무의미).
+  //   - `incoming.token` 을 새 UUID 로 갱신 → 후속 `putTrip` 이 `trip:<newToken>` 키로 쓴다.
+  //   - progress/SSoT KV(oldToken 키) 는 TTL 로 자연 만료 — 후속 cron push 는 새 token trip
+  //     기준 waypoints/destination 을 참조하므로 사용자에게 이전 목적지 push 재발사 없음.
+  //
+  // 오늘 evidence(2026-07-03): 사용자 중곡→성수 trip 시작 시 이전 trip(중곡→용마산) 잔재
+  // pending push 가 계속 발사돼 `08:37:25 bg fired station-passed 성수` 관측. rotation 이
+  // helper 의 `cleanupPendingPushesForToken` 을 실제 호출해 잔재 pending 제거.
+  const rotation = await rotateTripTokenForNewRoute(
+    c.env.TRIPS,
+    incoming,
+    rawExisting,
+  );
+  if (rotation.rotated) {
+    console.log(
+      JSON.stringify({
+        msg: 'trip-register: route rotation (#2019, ADR-022 B4)',
+        oldTokenPrefix: tokenPrefix(incoming.token),
+        newTokenPrefix: tokenPrefix(rotation.token),
+      }),
+    );
+    incoming.token = rotation.token;
+  }
+  const existing = rotation.rotated ? null : rawExisting;
   const isSameSession = existing !== null && evaluateSameSession(existing, incoming);
   // #916 follow-up B — auto-prompt dedup 마커 보존. isSameSession=true(같은 trip 재등록)인 경우만
   // window 안이면 보존한다. 사용자가 lock 클리어 후 같은 trip context로 재등록하는 케이스에서


### PR DESCRIPTION
## Summary
- Root cause: `backend/alarm-worker/src/trips.ts:196` `rotateTripTokenForNewRoute` helper 함수가 정의만 있고 **프로덕션 caller 0개** (테스트만 호출). 새 route 등록 시 old token 재사용 → 이전 destination push 스팸 재발.
- Fix: `POST /trips` handler에 rotation helper 호출 wire. archFlag=on 시 새 route 감지 → 새 UUID 발급 + `trip:<oldToken>` delete + `pending:*` cleanup.

Closes #2019

## Evidence (2026-07-03 08:24 KST 실기기 trip)
- 사용자 실기기 trip: 중곡 → 성수 이동
- Device dump: `BoardingLock active=no` + `boardingPrompt(all)=0` (7일)
- BUT: `08:37:25 | bg | fired | station-passed | 성수` 발사됨
- Backend Version ID `ed72c3bb` (archFlag=on 배포 완료)
- 이전 lock/token 잔재로 인한 old destination 발사 관찰 → 이 fix로 새 trip 시작 시 이전 token cleanup

## 변경 파일
- `backend/alarm-worker/src/index.ts` (+38 -1): POST /trips handler wire + import
- `backend/alarm-worker/src/__tests__/index.test.ts` (+185 -1): 7 신규 tests

### 신규 테스트 (7)
- **archFlag=off 회귀 가드 (2)**: rotation dormant / pending 유지 (기존 동작 유지)
- **archFlag=on rotation 활성 (5)**: 신규 trip / 같은 route / 다른 destination / evidence 재현 / KV read

## Test plan
- [x] Backend tests: `cd backend/alarm-worker && npm test` (2467 pass, 신규 7 포함, 0 fail)
- [x] Backend type-check: `cd backend/alarm-worker && npm run type-check` (clean)
- [x] Frontend tests: `npm test` (8970 pass, coverage 100%)
- [x] Frontend type-check: `npm run type-check` (clean)
- [x] Orphan lint: `npm run lint:orphan` (no orphans)
- [x] Code review medium: P0/P1 없음. Push OK.
- [ ] **Device verify**: 목적지 변경 → 새 trip 시작 → 이전 destination push 재발사 없는지 실기기 관찰

## Wire-completion 5단
1. **Orphan 없음** — `rotateTripTokenForNewRoute` caller가 이제 `index.ts:655`에 실 존재. Orphan lint pass.
2. **V/X dashboard** — 회전 발동 시 backend log `trip-register: route rotation (#2019, ADR-022 B4)` (wrangler tail / Cloudflare Dashboard 관측)
3. **의존 PR** — N/A (helper는 #1986에서 이미 완성)
4. **측정 plan** — 1주 관찰: `wrangler tail | grep 'route rotation'` 로그 등장 + 실기기 evidence(중곡→성수 시나리오) 재발 0건 확인
5. **Device verify** — 필요: KV archFlag=on 확인 후 목적지 변경 → 새 trip 시작 → 이전 destination(예: 용마산) push 재발사 없는지 관찰

## 사용자 확정 flow 정합 (code review 확인)
- 자동 승차 감지 부활 X (rotation은 사용자 명시 POST /trips 트리거에만 반응)
- 자동 lock chain 강화 X (rotation은 KV cleanup만)
- 사용자 명시 응답 없이 hop advance X (rotation은 새 route 시작 시점, hop advance와 무관)
- archFlag=off 시 100% 기존 동작 유지 (dormant, 회귀 가드 테스트)

## Post-merge follow-up (P2 findings, 별도 이슈 후보)
1. `incoming.token` mutation → `const activeToken` 변수로 명시 (원본 payload 오염 방지)
2. Rotation 로그에 destination/waypoint pair 추가 (디버깅 편의)
3. SSoT/progress rotation orphan counter → dashboard 관측 metric
4. `cleanupPendingPushesForToken` prefix scan p95 latency 관측 (rotation 빈도 증가 대비)

## 관련
- ADR-022 (Arrival API SSOT) Phase 1-3 wire 완결
- Backend Version ID `ed72c3bb` (2026-07-03 15:45 KST 배포)
- KV `arch:simple-arrival-v1` = `on`