### PR TITLE
fix(#2021): archFlag=on 시 backend payload boardingLine 3경로 봉인

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -11,6 +11,7 @@ import {
   validateTrip,
   verifyBoardingLockPersisted,
 } from '../index';
+import { ARCH_FLAG_KV_KEY } from '../archFlag';
 import { progressKey, type TripProgress } from '../progress';
 import { pendingKey, putPending, stampReceived } from '../pendingPushes';
 import { KV_MIN_CACHE_TTL_SEC } from '../kvConsistency';
@@ -2978,6 +2979,75 @@ describe('POST /boarding-lock/sync (#901)', () => {
       const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
       expect(stored.boardingLock).toBeUndefined();
     });
+
+    // #2021 (ADR-022) — archFlag='on' 시 handler 가 payload.boardingLine 을 무시하고 KV lock.line
+    // 을 유지한다. trainCode / consecutiveEtaMissing 갱신은 유지 (환승 leg 자동 종료 차단 목적은 flag 무관).
+    describe('#2021 archFlag boardingLine seal (ADR-022)', () => {
+      it("archFlag='on' KV 세팅 상태 → payload.boardingLine='7' 무시, KV lock.line='2' 유지", async () => {
+        const env = makeKvEnv();
+        await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
+        await post('/trips', tripWithLock(), env);
+        const res = await post(
+          '/boarding-lock/sync',
+          {
+            token: 'tok-sync',
+            observedStationName: '신촌',
+            observedAtMs: 1,
+            accuracy: 5,
+            trainCode: 'T-NEW',
+            boardingLine: '7',
+          },
+          env,
+        );
+        expect(res.status).toBe(200);
+        const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
+        expect(stored.boardingLock.trainCode).toBe('T-NEW');
+        // 봉인 정책: 기존 line 유지.
+        expect(stored.boardingLock.line).toBe('2');
+      });
+
+      it("archFlag='off' KV 세팅 상태 → 기존 동작 (payload.boardingLine='7' 반영)", async () => {
+        const env = makeKvEnv();
+        await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'off');
+        await post('/trips', tripWithLock(), env);
+        const res = await post(
+          '/boarding-lock/sync',
+          {
+            token: 'tok-sync',
+            observedStationName: '신촌',
+            observedAtMs: 1,
+            accuracy: 5,
+            trainCode: 'T-NEW',
+            boardingLine: '7',
+          },
+          env,
+        );
+        expect(res.status).toBe(200);
+        const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
+        expect(stored.boardingLock.line).toBe('7');
+      });
+
+      it('archFlag 미설정 → default(off) 로 fallback (기존 동작 유지)', async () => {
+        const env = makeKvEnv();
+        // KV 에 archFlag key 를 두지 않음 — getArchFlag 가 default 로 fallback.
+        await post('/trips', tripWithLock(), env);
+        const res = await post(
+          '/boarding-lock/sync',
+          {
+            token: 'tok-sync',
+            observedStationName: '신촌',
+            observedAtMs: 1,
+            accuracy: 5,
+            trainCode: 'T-NEW',
+            boardingLine: '7',
+          },
+          env,
+        );
+        expect(res.status).toBe(200);
+        const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
+        expect(stored.boardingLock.line).toBe('7');
+      });
+    });
   });
 
   // #1364 — read-after-write verification + expiresAt response field.
@@ -3227,6 +3297,43 @@ describe('applyBoardingLockTrainCodeSwap (#1210)', () => {
     const result = applyBoardingLockTrainCodeSwap(
       trip,
       buildD4SwapPayload({ trainCode: 'T-NEW' }),
+    );
+    expect(result.boardingLock?.line).toBe('2');
+  });
+
+  // #2021 (ADR-022) — archFlag='on' 시 payload.boardingLine 무시, 기존 lock.line 유지.
+  // trainCode swap 자체는 flag 무관 유지 (환승 leg 자동 종료 차단은 공통 정책).
+  it("#2021 archFlag='on' → payload.boardingLine 무시, lock.line 유지 (trainCode/counter 는 갱신)", () => {
+    const trip = buildD4SwapBaseTrip();
+    const result = applyBoardingLockTrainCodeSwap(
+      trip,
+      buildD4SwapPayload({ trainCode: 'T-NEW', boardingLine: '7' }),
+      'on',
+    );
+    // trainCode 및 counter reset 은 유지 — 환승 leg 자동 종료 차단 목적은 flag 무관.
+    expect(result.boardingLock?.trainCode).toBe('T-NEW');
+    expect(result.consecutiveEtaMissing).toBe(0);
+    // line 은 device 가 sync 로 보낸 '7' 을 무시하고 기존 '2' 유지 — 봉인 정책.
+    expect(result.boardingLock?.line).toBe('2');
+  });
+
+  it("#2021 archFlag='off' → 기존 D4 동작 (payload.boardingLine 반영)", () => {
+    const trip = buildD4SwapBaseTrip();
+    const result = applyBoardingLockTrainCodeSwap(
+      trip,
+      buildD4SwapPayload({ trainCode: 'T-NEW', boardingLine: '7' }),
+      'off',
+    );
+    expect(result.boardingLock?.trainCode).toBe('T-NEW');
+    expect(result.boardingLock?.line).toBe('7');
+  });
+
+  it("#2021 archFlag='on' + boardingLine 미제공 → 기존 lock.line 유지 (no-op 동등)", () => {
+    const trip = buildD4SwapBaseTrip();
+    const result = applyBoardingLockTrainCodeSwap(
+      trip,
+      buildD4SwapPayload({ trainCode: 'T-NEW' }),
+      'on',
     );
     expect(result.boardingLock?.line).toBe('2');
   });

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -43,6 +43,7 @@ import {
   CRON_NOMINAL_INTERVAL_MS,
   toSilentPushSsot,
   shouldSkipStationary,
+  resolveBoardingLinePayload,
   type ScheduledDeps,
   type ScheduledStats,
 } from '../scheduled';
@@ -1487,6 +1488,75 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
       expect(stats.vanishFallbackFired).toBe(1);
     });
 
+    // #2021 (ADR-022) — vanish-fallback 경로도 archFlag='on' 시 boardingLine 봉인.
+    // vanish-fallback 은 arvlCd 관측 없이 시간 경과로 발사되는 경로라 flag=on 정책 우회 위험이
+    // 높다 (arvlcd fire-once TTL 게이트에 걸리지 않음). 명시 매트릭스로 확인.
+    it('#2021 archFlag=on 시 vanish-fallback payload.boardingLine 봉인', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({
+          consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+          lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
+        }),
+      );
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      await runScheduled(makeEnv(kv), {
+        seoul: makeSeoulCombo([], []),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p2021-vanish-on',
+        archFlag: 'on',
+      });
+      const calls = apnsFetch.mock.calls as unknown as Array<[string, RequestInit]>;
+      const stationPassedCall = calls.find((c) => {
+        const body = JSON.parse(c[1].body as string);
+        return body.data?.nextWaypoint === '중곡' && body.data?.phase === 'imminent';
+      });
+      expect(stationPassedCall).toBeDefined();
+      const data = JSON.parse(stationPassedCall![1].body as string).data as Record<
+        string,
+        unknown
+      >;
+      expect('boardingLine' in data).toBe(false);
+      expect(data.trainCode).toBe('7246');
+    });
+
+    // #2021 — archFlag='off' (default) 명시 시 vanish-fallback 도 기존 동작 유지 회귀 가드.
+    it('#2021 archFlag=off 시 vanish-fallback payload.boardingLine=lock.line 유지', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockTrip({
+          consecutiveEtaMissing: FALLBACK_TRIGGER - 1,
+          lastTrackedArrivalEpoch: LAST_EPOCH_ELAPSED,
+        }),
+      );
+      const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+      await runScheduled(makeEnv(kv), {
+        seoul: makeSeoulCombo([], []),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p2021-vanish-off',
+        archFlag: 'off',
+      });
+      const calls = apnsFetch.mock.calls as unknown as Array<[string, RequestInit]>;
+      const stationPassedCall = calls.find((c) => {
+        const body = JSON.parse(c[1].body as string);
+        return body.data?.nextWaypoint === '중곡' && body.data?.phase === 'imminent';
+      });
+      expect(stationPassedCall).toBeDefined();
+      const data = JSON.parse(stationPassedCall![1].body as string).data as Record<
+        string,
+        unknown
+      >;
+      expect(data.boardingLine).toBe('7');
+    });
+
     it('#1370 L2 — vanish fallback push dedup (같은 station 두 번 발사 안 됨)', async () => {
       // 같은 waypoint에 대해 다시 vanish fallback이 trigger돼도 dedup KV로 차단.
       const kv = new InMemoryKV();
@@ -1968,6 +2038,92 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
     const body = JSON.parse(transferReleaseCall![1].body as string);
     expect(body.data.lockReleasedReason).toBe('transfer');
     expect(body.data.origin).toBe('transfer-release');
+  });
+
+  // #2021 (ADR-022) — transfer-release 경로도 archFlag='on' 시 boardingLine 봉인.
+  // advanceBoardingLockWaypoint 안의 buildStationPassedImminentPayload 호출이 deps.archFlag 를
+  // 그대로 forward 하는지 매트릭스로 회귀 차단.
+  it('#2021 archFlag=on 시 transfer-release payload.boardingLine 봉인', async () => {
+    const kv = new InMemoryKV();
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({
+        waypoints: [
+          { stationName: '군자', line: '7', kind: 'transfer' },
+          { stationName: '아차산', line: '5', kind: 'destination' },
+        ],
+      }),
+    );
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('군자', 0, 1)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p2021-transfer-on',
+      archFlag: 'on',
+    });
+    const transferReleaseCall = (fetchImpl.mock.calls as unknown as [string, RequestInit][]).find(
+      (call) => {
+        const init = call[1];
+        if (!init?.body) return false;
+        try {
+          const body = JSON.parse(init.body as string);
+          return body?.data?.origin === 'transfer-release';
+        } catch {
+          return false;
+        }
+      },
+    );
+    expect(transferReleaseCall).toBeDefined();
+    const data = JSON.parse(transferReleaseCall![1].body as string).data as Record<
+      string,
+      unknown
+    >;
+    expect('boardingLine' in data).toBe(false);
+    expect(data.trainCode).toBe('7246');
+  });
+
+  it('#2021 archFlag=off 시 transfer-release payload.boardingLine=lock.line 유지', async () => {
+    const kv = new InMemoryKV();
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({
+        waypoints: [
+          { stationName: '군자', line: '7', kind: 'transfer' },
+          { stationName: '아차산', line: '5', kind: 'destination' },
+        ],
+      }),
+    );
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('군자', 0, 1)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p2021-transfer-off',
+      archFlag: 'off',
+    });
+    const transferReleaseCall = (fetchImpl.mock.calls as unknown as [string, RequestInit][]).find(
+      (call) => {
+        const init = call[1];
+        if (!init?.body) return false;
+        try {
+          const body = JSON.parse(init.body as string);
+          return body?.data?.origin === 'transfer-release';
+        } catch {
+          return false;
+        }
+      },
+    );
+    expect(transferReleaseCall).toBeDefined();
+    const data = JSON.parse(transferReleaseCall![1].body as string).data as Record<
+      string,
+      unknown
+    >;
+    expect(data.boardingLine).toBe('7');
   });
 
   it('#864 — intermediate waypoint advance 시 boardingLock은 유지 (같은 train 계속 추적)', async () => {
@@ -6307,6 +6463,54 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
     expect(data.trainCode).toBe('7246');
   });
 
+  // #2021 (ADR-022) — archFlag='on' 시 arvlCd fire 경로에서 boardingLine 봉인. device 의
+  // lockless-opt-out gate 존중. trainCode 는 유지 (device 가 진단/UI 에서 참조하는 필드).
+  // 2026-07-03 08:24 성수 오발사 evidence 회귀 차단.
+  it('#2021 archFlag=on 시 payload.boardingLine 봉인, boardingLine 필드 자체 누락', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    await runScheduled(makeEnv(kv), {
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-arvl-flag-on',
+      archFlag: 'on',
+    });
+    const data = parseStationPassedData(getStationPassedCalls(apnsFetch)[0]) as Record<
+      string,
+      unknown
+    >;
+    // boardingLine 은 payload 에서 자연 누락 (apns.ts JSON serializer 가 undefined 필드 omit).
+    expect('boardingLine' in data).toBe(false);
+    // trainCode 는 유지 — device 진단/UI 참조 필드로 flag 무관.
+    expect(data.trainCode).toBe('7246');
+  });
+
+  // #2021 — archFlag='off' (default) 시 기존 동작 100% 유지 회귀 방지 가드.
+  it('#2021 archFlag=off (명시) → 기존 동작 (boardingLine=lock.line) 유지', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    await runScheduled(makeEnv(kv), {
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-arvl-flag-off',
+      archFlag: 'off',
+    });
+    const data = parseStationPassedData(getStationPassedCalls(apnsFetch)[0]) as Record<
+      string,
+      unknown
+    >;
+    expect(data.boardingLine).toBe('7');
+    expect(data.trainCode).toBe('7246');
+  });
+
   it('arvlCd=0(ENTERING) → 매역 push 발사 (arvlCd=0 dedup key)', async () => {
     const { stats, kv } = await runArvlScheduled({
       seoul: makeArrivalSeoul('중곡', 0, 0),
@@ -7144,6 +7348,24 @@ describe('runScheduled cron jitter stat (#1539 S6)', () => {
     expect(stats.cronJitterMs).toBe(expectedJitter);
     expect(logMessages.some((l) => l.msg === 'scheduled: cron jitter' && l.meta?.jitterMs === expectedJitter))
       .toBe(true);
+  });
+});
+
+// #2021 (ADR-022) — payload.boardingLine 정책 게이트 단위 테스트.
+//
+// 검증 범위: archFlag='on' → undefined (device lockless-opt-out gate 존중), else → lockLine
+// (기존 #1322 동작 유지). 3개 fire 경로 + Seam E swap 이 모두 본 helper 를 통과한다.
+describe('resolveBoardingLinePayload (#2021 ADR-022)', () => {
+  it("returns undefined when archFlag='on'", () => {
+    expect(resolveBoardingLinePayload('on', '7')).toBeUndefined();
+  });
+
+  it("returns lockLine when archFlag='off'", () => {
+    expect(resolveBoardingLinePayload('off', '7')).toBe('7');
+  });
+
+  it('returns lockLine when archFlag is undefined (legacy / test / no KV binding)', () => {
+    expect(resolveBoardingLinePayload(undefined, '2')).toBe('2');
   });
 });
 

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -46,6 +46,7 @@ import { computeAlarmLogStats } from './alarmLogStats';
 import { computeBaselineCheck } from './baselineCheck';
 import {
   ARCH_FLAG_DEFAULT,
+  type ArchFlagValue,
   getArchFlag,
   isArchFlagValue,
   setArchFlag,
@@ -1551,8 +1552,13 @@ app.post('/boarding-lock/sync', async (c) => {
   // autoLockCandidate에 `from: 'transfer-swap'` hint 첨부. client는 hint가 있으면
   // motion gate(#1014 RC2 Gate #2)를 우회한다 — 환승 직후 사용자가 이동 중인 상태에서
   // hydrate가 영구 차단되는 회귀(피드백 7, 22:53 transfer skip)를 차단.
+  //
+  // #2021 (ADR-022) — archFlag='on' 시 payload.boardingLine 을 무시해 device 가 backend lock
+  // 의 line 을 임의로 갱신하지 못하도록 봉인. flag 로드 실패 (KV race) 는 default('off') 로
+  // fallback → 기존 동작 유지 (사용자에게 dogfood 회귀 대신 legacy 동작 노출).
+  const archFlag = await getArchFlag(c.env.TRIPS).catch(() => ARCH_FLAG_DEFAULT);
   const preSwapTrainCode = working.boardingLock?.trainCode;
-  working = applyBoardingLockTrainCodeSwap(working, payload);
+  working = applyBoardingLockTrainCodeSwap(working, payload, archFlag);
   const transferSwapApplied =
     preSwapTrainCode !== undefined &&
     working.boardingLock !== undefined &&
@@ -1702,10 +1708,17 @@ export function validateBoardingLockSync(input: unknown): BoardingLockSyncPayloa
  * Seam E sync로 새 trainCode를 보내면 KV를 즉시 갱신해 자동 종료를 차단한다.
  *
  * 순수 함수 — 호출자(handler)가 putTrip으로 영속화한다.
+ *
+ * #2021 (ADR-022) — archFlag='on' 시 payload.boardingLine 을 무시하고 기존 lock.line 을 그대로
+ * 유지한다. Seam E 는 device 가 지상 GPS 관측을 backend 로 sync 하는 채널인데, flag=on 정책은
+ * "trainCode 확정 없이는 어떤 알림도 발사 X" 이므로 device 가 보낸 line 값이 backend lock 을
+ * 임의로 갱신하지 못하도록 봉인. flag=off (기본) / archFlag 미전달 시 기존 동작 100% 유지.
+ * trainCode swap 자체는 flag 무관 유지 — 환승 leg 자동 종료 차단 목적은 flag on/off 공통.
  */
 export function applyBoardingLockTrainCodeSwap(
   trip: Trip,
   payload: BoardingLockSyncPayload,
+  archFlag?: ArchFlagValue,
 ): Trip {
   const incomingTrainCode = payload.trainCode;
   if (!incomingTrainCode) return trip;
@@ -1713,13 +1726,17 @@ export function applyBoardingLockTrainCodeSwap(
   if (!lock) return trip;
   if (lock.trainCode === incomingTrainCode) return trip;
   // 환승 leg 감지 → lock 교체 + 카운터 reset.
+  // #2021 — flag=on 시 payload.boardingLine 무시, 기존 lock.line 유지. flag=off (기본) 는
+  //   payload.boardingLine ?? lock.line (기존 D4 정책).
+  const nextLine =
+    archFlag === 'on' ? lock.line : payload.boardingLine ?? lock.line;
   return {
     ...trip,
     boardingLock: {
       ...lock,
       trainCode: incomingTrainCode,
       // boardingLine은 optional payload — 미제공 시 기존 line 유지.
-      line: payload.boardingLine ?? lock.line,
+      line: nextLine,
     },
     consecutiveEtaMissing: 0,
   };

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -1519,6 +1519,34 @@ interface BuildStationPassedImminentPayloadInputs {
    * 부재한 trip(seed 전 / KV race)도 push 발사 자체는 막지 않는다(graceful).
    */
   ssot?: TripPositionSSoT | null;
+  /**
+   * #2021 (ADR-022) — archFlag='on' 시 payload.boardingLine 을 undefined 로 실어 device 의
+   * `lockless-opt-out` gate 를 존중한다. flag=off (기본) / 미전달 시 기존 동작 (lock.line forward)
+   * 100% 유지 — Phase 4-x 이하 legacy 배선에서 회귀 발생 없음.
+   *
+   * device 는 payload.boardingLine !== undefined 를 "backend authoritative" 신호로 간주해
+   * lockless-opt-out gate 를 우회하므로, boardingPrompt 응답 없이 lock 이 null 인 상태에서
+   * backend push 가 boardingLine 을 실으면 알림이 잘못 fire 된다 (2026-07-03 08:24 evidence,
+   * 중곡→성수 trip 의 성수 알림). flag=on 배포 시 이 경로를 봉인.
+   */
+  archFlag?: ArchFlagValue;
+}
+
+/**
+ * #2021 (ADR-022) — payload.boardingLine 실는 정책 게이트.
+ *
+ * archFlag='on' → undefined (device 의 lockless-opt-out gate 존중, "trainCode 확정 없이는
+ * 어떤 알림도 발사 X" 사용자 명시 flow 유지). archFlag='off' 또는 undefined → 기존 동작
+ * (lock.line 그대로 forward, #1322 "지하 auto-lock hydration window" 용도).
+ *
+ * 순수 함수 — flag 정책 변경 시 단일 지점 갱신. 3개 fire 경로(arvlcd / vanish-fallback /
+ * transfer-release) + Seam E swap 이 모두 본 helper 를 통과한다.
+ */
+export function resolveBoardingLinePayload(
+  archFlag: ArchFlagValue | undefined,
+  lockLine: string,
+): string | undefined {
+  return archFlag === 'on' ? undefined : lockLine;
 }
 /**
  * #1561 (T8) — silent push payload에 forward되는 SSoT 스냅샷의 passedStations 최근 N개 한도.
@@ -1558,7 +1586,7 @@ export function toSilentPushSsot(
 function buildStationPassedImminentPayload(
   inputs: BuildStationPassedImminentPayloadInputs,
 ): Parameters<typeof sendSilentPush>[0]['payload'] {
-  const { trip, waypoint, lock, pushId, now, origin, lockReleasedReason, ssot } = inputs;
+  const { trip, waypoint, lock, pushId, now, origin, lockReleasedReason, ssot, archFlag } = inputs;
   return {
     nextWaypoint: waypoint.stationName,
     // arvlCd∈{0,1}은 "지금 진입/도착" 신호 — eta는 사실상 0. vanish-fallback도 동일 의미.
@@ -1579,7 +1607,9 @@ function buildStationPassedImminentPayload(
     subsurface: trip.subsurface === true,
     // #1322 — lock-path fire의 노선/열차를 self-describing으로 전달. 디바이스가 로컬 lock
     // 없이도(지하 auto-lock hydration window) line sanity-guard를 돌려 발사할 수 있게 한다.
-    boardingLine: lock.line,
+    // #2021 (ADR-022) — archFlag=on 시 undefined 로 forward 하여 device 의
+    // lockless-opt-out gate 를 존중. `resolveBoardingLinePayload` 단일 지점 정책 게이트.
+    boardingLine: resolveBoardingLinePayload(archFlag, lock.line),
     trainCode: lock.trainCode,
     // #1399 — 좀비 알림 cleanup. push 발사 시점의 active trip token을 stamp해 device가
     // ACTIVE_TRIP_KEY와 비교해 만료 token push를 drop. trip-ended cleanup 후 늦게 도착한
@@ -1774,6 +1804,8 @@ export async function fireArvlCdStationPush(
     now,
     origin: 'arvlcd',
     ssot: ssotForStale,
+    // #2021 (ADR-022) — flag=on 시 boardingLine 봉인, device lockless-opt-out gate 존중.
+    archFlag: deps.archFlag,
   });
   const heal = await sendWithEnvHeal(
     (host) =>
@@ -2150,6 +2182,8 @@ export async function fireVanishFallbackStationPush(
     origin,
     lockReleasedReason,
     ssot,
+    // #2021 (ADR-022) — flag=on 시 boardingLine 봉인, device lockless-opt-out gate 존중.
+    archFlag: deps.archFlag,
   });
   const heal = await sendWithEnvHeal(
     (host) =>
@@ -2870,6 +2904,8 @@ export async function advanceBoardingLockWaypoint(
       origin: 'transfer-release',
       lockReleasedReason: 'transfer',
       ssot: ssotForTransfer,
+      // #2021 (ADR-022) — flag=on 시 boardingLine 봉인, device lockless-opt-out gate 존중.
+      archFlag: deps.archFlag,
     });
     const transferHeal = await sendWithEnvHeal(
       (host) =>


### PR DESCRIPTION
## Summary
- Backend 3곳(fireArvlCdStationPush / fireVanishFallbackStationPush / Seam E swap)에서 payload builder가 lock.line unconditional 실음 → 사용자 응답 없이 backend authoritative로 fire
- archFlag=on 시 boardingLine=undefined 처리 → device lockless-opt-out gate로 skip

Closes #2021

## 변경
- `resolveBoardingLinePayload` helper 추출 + archFlag=on 시 undefined 반환
- 4개 경로 (arvlcd / vanish-fallback / transfer-release / Seam E)에서 archFlag forward
- 15개 신규 test

## Test plan
- [x] Backend tests 2475 pass
- [x] Backend type-check
- [x] Frontend tests 8970 pass, coverage 100%
- [x] Frontend type-check
- [x] Orphan lint
- [x] Code review medium P0/P1 없음
- [ ] Device verify: boardingPrompt 미응답 상태에서 trip 진행 → 알림 fire X 확인

## Wire-completion 5단
1. Orphan 없음 (helper caller 실 존재)
2. V/X dashboard - archFlag=on 시 payload.boardingLine=undefined 관측
3. 의존 PR - #2019 (rotation wire) 병렬
4. 측정 plan - 1주 lock=null 상태 fire 0건 관찰
5. Device verify 필요

## 관련
- 사용자 확정 flow: trainCode 확정 없이 어떤 알림도 발사 X
- Issue #2019 rotation wire와 상호 보완 (stale lock 잔재 청소)