### PR TITLE
fix(#2022): #2014 caller 완결 — arvlCd=1 관측 시 boardingPrompt 즉시 발사

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -8,6 +8,7 @@ import {
   ARVLCD_FIRE_DEDUP_TTL_SEC,
   ARVLCD_FIRE_KEY_PREFIX,
   ARVLCD_FIRE_ONCE_CYCLE_SLOT,
+  hasArrivedSignal,
   SAME_PHASE_STATION_DEDUP_WINDOW_MS,
   FALLBACK_ADVANCE_GRACE_CYCLES,
   FALLBACK_HOP_SEC,
@@ -3864,6 +3865,100 @@ describe('runScheduled — #2014 (ADR-022 B8) archFlag=on 배선', () => {
     expect(stats.boardingPromptSkippedLockActive).toBe(1);
     expect(stats.boardingPromptFired).toBe(0);
   });
+
+  /**
+   * #2022 — archFlag=on 시 arvlCd=1(ARRIVED) 관측 explicit check.
+   *
+   * 이슈 core: #2014 는 게이트 skip 만 구현. caller 에 "arvlCd=1 관측 시에만 fire"
+   * explicit check 가 없어 arvlCd=0(진입)/2(출발)/기타 상태에서도 fire 됨 → 사용자
+   * flow "A역 도착 판정 → boardingPrompt" 정합 어긋남. 아래 케이스로 갭 확정.
+   */
+  it('#2022 archFlag=on + arvlCd=0(ENTERING) 만 → fire skip (도착 안 함, 진입 중)', async () => {
+    // pool 에 arvlCd=1 없음 → boardingPrompt UI 노출 부적절.
+    const ENTERING_ONLY: ArrivalEntry = {
+      ...ARVL_ARRIVED_SINGLE,
+      trainCode: 'ENT-1',
+      arvlCd: 0, // ENTERING
+    };
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const deps = makeArchFlagDeps(fetchImpl, makeSeoul([ENTERING_ONLY]));
+
+    const stats = await runScheduled(makeEnv(kv), deps);
+
+    expect(stats.boardingPromptEvaluated).toBe(1);
+    expect(stats.boardingPromptFired).toBe(0);
+    expect(stats.boardingPromptBlocked).toBe(1);
+    // fire skip → APNs fetch X.
+    expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it('#2022 archFlag=on + arvlCd=2(DEPARTED) 만 → fire skip (열차 이미 출발)', async () => {
+    // 열차 이미 출발 = 사용자가 승차 못 함. boardingPrompt 발사 시 UI 오탐.
+    const DEPARTED_ONLY: ArrivalEntry = {
+      ...ARVL_ARRIVED_SINGLE,
+      trainCode: 'DEP-1',
+      arvlCd: 2, // DEPARTED
+    };
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const deps = makeArchFlagDeps(fetchImpl, makeSeoul([DEPARTED_ONLY]));
+
+    const stats = await runScheduled(makeEnv(kv), deps);
+
+    expect(stats.boardingPromptEvaluated).toBe(1);
+    expect(stats.boardingPromptFired).toBe(0);
+    expect(stats.boardingPromptBlocked).toBe(1);
+    expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it('#2022 archFlag=on + pool 에 arvlCd=1 포함 (다른 값과 혼재) → fire (도착 신호 존재)', async () => {
+    // arvlCd=0 후보 + arvlCd=1 후보 혼재 → arvlCd=1 존재하므로 fire.
+    // pickAutoTrainCode 우선순위(2 > 1 > 0)에서 arvlCd=1 후보가 단일이면 정상 fire.
+    const ENTERING_TRAIN: ArrivalEntry = {
+      ...ARVL_ARRIVED_SINGLE,
+      trainCode: 'ENT-x',
+      arvlCd: 0,
+    };
+    const ARRIVED_TRAIN: ArrivalEntry = {
+      ...ARVL_ARRIVED_SINGLE,
+      trainCode: 'ARR-y',
+      arvlCd: 1,
+    };
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());
+    const fetchImpl = vi.fn(
+      async () => new Response(null, { status: 200 }),
+    ) as unknown as typeof fetch;
+    const deps = makeArchFlagDeps(fetchImpl, makeSeoul([ENTERING_TRAIN, ARRIVED_TRAIN]));
+
+    const stats = await runScheduled(makeEnv(kv), deps);
+
+    expect(stats.boardingPromptFired).toBe(1);
+    expect(stats.boardingPromptBlocked).toBe(0);
+  });
+
+  it('#2022 archFlag=off + pool 에 arvlCd=1 없음 (arvlCd=0 만) → 기존 9-AND gate 로 진행 (arvlCd explicit check 비활성)', async () => {
+    // 회귀 방어: archFlag=off 시 arvlCd 값에 의존한 explicit check 는 적용 X.
+    // 기존 9단 AND 게이트에 의해 series 0건 → no-candidates 로 blocked 되는 기존 경로 그대로.
+    const ENTERING_ONLY: ArrivalEntry = {
+      ...ARVL_ARRIVED_SINGLE,
+      trainCode: 'ENT-legacy',
+      arvlCd: 0,
+    };
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const deps = makeArchFlagDeps(fetchImpl, makeSeoul([ENTERING_ONLY]), 'off');
+
+    const stats = await runScheduled(makeEnv(kv), deps);
+
+    // 9단 게이트 → 기존 no-candidates 로 차단 (arvlCd explicit check 로 차단된 것 아님).
+    expect(stats.boardingPromptFired).toBe(0);
+    expect(stats.boardingPromptBlocked).toBe(1);
+  });
 });
 
 describe('runScheduled — evaluateAndMaybeFireBoardingPrompt Kalman KV 통합 (#824)', () => {
@@ -6042,6 +6137,60 @@ describe('runScheduled — #916 follow-up B lastAutoPromptedAt dedup', () => {
 // realtimeArrivalList에서 추적해 next waypoint에서 ARRIVED/ENTERING 첫 관찰 시
 // station-passed silent push를 발사. dedup KV로 같은 신호 중복 차단.
 // ---------------------------------------------------------------------------
+
+describe('hasArrivedSignal (#2022 ADR-022 B8 caller fire trigger)', () => {
+  function entry(overrides: Partial<ArrivalEntry>): ArrivalEntry {
+    return {
+      destination: '성수',
+      arrivalSeconds: 60,
+      trainCode: 'T1',
+      isUp: true,
+      subwayNm: '2호선',
+      arvlCd: 1,
+      ...overrides,
+    };
+  }
+
+  it('빈 pool → false (관측 없음)', () => {
+    expect(hasArrivedSignal([])).toBe(false);
+  });
+
+  it('arvlCd=1(ARRIVED) 단일 → true (도착 신호 존재)', () => {
+    expect(hasArrivedSignal([entry({ arvlCd: 1 })])).toBe(true);
+  });
+
+  it('arvlCd=0(ENTERING) 단일 → false (진입 중, 아직 도착 X)', () => {
+    expect(hasArrivedSignal([entry({ arvlCd: 0 })])).toBe(false);
+  });
+
+  it('arvlCd=2(DEPARTED) 단일 → false (열차 이미 출발)', () => {
+    expect(hasArrivedSignal([entry({ arvlCd: 2 })])).toBe(false);
+  });
+
+  it('arvlCd=4/5(PREV_*) → false (1정거장 전 신호, 도착 아님)', () => {
+    expect(hasArrivedSignal([entry({ arvlCd: 4 })])).toBe(false);
+    expect(hasArrivedSignal([entry({ arvlCd: 5 })])).toBe(false);
+  });
+
+  it('혼합 pool 안에 arvlCd=1 이 최소 1개 존재 → true', () => {
+    expect(
+      hasArrivedSignal([
+        entry({ trainCode: 'A', arvlCd: 0 }),
+        entry({ trainCode: 'B', arvlCd: 1 }),
+        entry({ trainCode: 'C', arvlCd: 2 }),
+      ]),
+    ).toBe(true);
+  });
+
+  it('혼합 pool 안에 arvlCd=1 없음 → false', () => {
+    expect(
+      hasArrivedSignal([
+        entry({ trainCode: 'A', arvlCd: 0 }),
+        entry({ trainCode: 'B', arvlCd: 2 }),
+      ]),
+    ).toBe(false);
+  });
+});
 
 describe('arvlCdFireKey / ARVLCD_FIRE_KEY_PREFIX (#917 A2)', () => {
   it('prefix는 arvlcd-fire:', () => {

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -3538,6 +3538,21 @@ export function buildBoardingPromptMessage(
  * APNs 토큰 환경(sandbox/production)과 host가 어긋났을 때 Apple이 내는 시그널.
  * 이 조건에 한해서만 self-heal retry를 시도한다.
  */
+
+/**
+ * #2022 (ADR-022 B8 caller 완결) — archFlag=on 분기의 fire trigger.
+ *
+ * Seoul API pool 안에 arvlCd=1(ARRIVED) 신호가 최소 1개 이상 존재하는지 검사.
+ * 사용자 확정 flow "A역 도착 판정 → boardingPrompt" 정합 — arvlCd=0(진입 중)/
+ * arvlCd=2(출발)/기타 상태에서는 fire trigger 미충족 (UI 오탐 방지).
+ *
+ * caller 는 archFlag=on 분기에서만 호출. archFlag=off 는 기존 9-AND gate 가
+ * fire trigger 이므로 이 함수를 통과하지 않는다 (회귀 방어).
+ */
+export function hasArrivedSignal(pool: readonly ArrivalEntry[]): boolean {
+  return pool.some((entry) => entry.arvlCd === ARRIVAL_CODE.ARRIVED);
+}
+
 /**
  * "탑승했냐?" 푸시 평가 + 발사 (#819 B 슬라이스).
  *
@@ -3683,6 +3698,35 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       }));
   } catch {
     // Seoul API 장애 시 ETA 없이 push 발사 — 메시지 degradation만 발생, push 자체는 보존.
+  }
+
+  // #2022 (ADR-022 B8 caller 완결) — archFlag=on 시 arvlCd=1(ARRIVED) 관측 explicit check.
+  //
+  // #2014 는 게이트 skip 만 구현 — GPS/motion/speed 없이 통과. 그러나 사용자 확정 flow
+  // "A역 도착 판정 → boardingPrompt" 는 arvlCd=1 관측 시점에만 발사가 정합.
+  // arvlCd=0(진입 중) / arvlCd=2(출발) 상태에서 발사하면 UI 오탐 — "이미 출발한 열차에
+  // 탑승했나?" 같은 잘못된 프롬프트. hasArrivedSignal 이 archFlag=on 분기의 fire trigger.
+  //
+  // pool.length===0 케이스는 아래 candidateTrains 0건 guard 가 `boardingPromptSkippedEmpty`
+  // 로 별도 관측 (RC-13 카운터 의미론 유지) — 여기서는 pool 이 있는데도 arvlCd=1 이 없는
+  // 케이스만 명시 차단해 arvlCd 관점 skip 을 별도 counter 로 가시화.
+  //
+  // archFlag=off 는 기존 9-AND gate 통과가 fire trigger — 여기 check 는 skip (회귀 방어).
+  if (
+    deps.archFlag === 'on' &&
+    poolForArchFlagCheck.length > 0 &&
+    !hasArrivedSignal(poolForArchFlagCheck)
+  ) {
+    stats.boardingPromptBlocked += 1;
+    log('boarding-prompt: skipped no-arvlcd-arrived (#2022 archFlag=on)', {
+      token: trip.token.slice(0, 8),
+      line: display.line,
+      originStation: display.originStation,
+      direction: geo.direction,
+      poolSize: poolForArchFlagCheck.length,
+    });
+    if (dirty) await putTrip(env.TRIPS, trip);
+    return;
   }
 
   // #2014 (ADR-022 B8) — archFlag=on 시 arvlCd 우선순위 기반 단일 trainCode 수렴 검증.


### PR DESCRIPTION
## Summary
- #2014에서 boardingPrompt gate skip만 됐고 "arvlCd=1 즉시 fire" caller code 미구현
- caller(scheduled.ts)에 archFlag=on + arvlCd=1 explicit check + 즉시 fire 로직 추가

Closes #2022

## 변경
- `hasArrivedSignal(pool)` helper 신설 — 순수 함수, fire trigger 관심사 분리
- caller에서 archFlag=on + arvlCd=1(ARRIVED) 관측 시 boardingPrompt fire
- archFlag=off 시 기존 9-AND gate 유지 (regression 방어)
- 11개 신규 test

## Test plan
- [x] Backend tests 2471 pass
- [x] Backend type-check
- [x] Frontend tests 8970 pass, coverage 100%
- [x] Frontend type-check
- [x] Orphan lint
- [ ] Device verify: 실기기 arvlCd=1 관측 시 boardingPrompt UI 노출 확인

## Wire-completion 5단
1. Orphan 없음 (hasArrivedSignal caller 실 존재)
2. V/X dashboard - boarding-prompt fire count metric
3. 의존 PR - #2019, #2021과 병렬
4. 측정 plan - 1주 boardingPromptFired > 0, 응답 카운트 관찰
5. Device verify 필요

## 관련
- #2014 재작업 (caller 완결)
- ADR-022 B8 arvlCd=1 즉시 발사 정책
- 사용자 확정 flow: boardingPrompt 도달률 Layer 1