### PR TITLE
fix(#2023): arc time-integration 폭주 감지 → hop 진행 pause (archFlag=on)

### DIFF
--- a/backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts
+++ b/backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts
@@ -18,6 +18,8 @@ import {
   type AdvanceStats,
   type WifiSsidEntry,
 } from '../advanceTripPosition';
+import { detectArcOvershoot } from '../positionSeries';
+import type { PositionPoint } from '../types';
 import {
   readSsot,
   seedSsot,
@@ -537,6 +539,227 @@ describe('advanceTripPosition — 6단 게이트 양방향 시나리오 (accepta
     );
     const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
     expect(after?.passedStations.filter((s) => s === '용마산').length).toBe(1);
+  });
+});
+
+describe('advanceTripPosition — #8 arc-overshoot 게이트 (#2023, archFlag)', () => {
+  /**
+   * #2023 — device arc 시간 적분 폭주 감지 → hop 진행 pause.
+   *
+   * 2026-07-03 evidence: 08:24 승차 후 08:32:45 arc=3998, 08:37:25 arc=4710 (Δ=712m 폭주,
+   * 실 이동 hop=1). 성수 조기 발사 여러 회. archFlag=on 시 arc overshoot 감지 시 hop pause,
+   * off 시 기존 동작 유지.
+   *
+   * 정책:
+   *   - archFlag='on' + evidence.arcOvershootDetected=true → blocked('arc-overshoot')
+   *   - archFlag='off' (또는 미제공) → 기존 동작 유지 (dormant, backward compat)
+   *   - archFlag='on' + arcOvershoot=false → 정상 advance
+   *   - archFlag='on' + arcOvershoot=undefined → dormant (caller가 stamp 안 함, backward compat)
+   */
+
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  async function seedForAdvance(): Promise<void> {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '용마산');
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: makeLock() }));
+  }
+
+  it("archFlag='on' + arcOvershoot=true → blocked('arc-overshoot')", async () => {
+    await seedForAdvance();
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence({ arcOvershootDetected: true }),
+      { gatePassed: true, lockAttachable: true, archFlag: 'on' },
+    );
+    expect(out.result).toBe('blocked');
+    expect(out.blockReason).toBe('arc-overshoot');
+    // SSoT mutate 없음
+    const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    expect(after?.currentStationId).toBe('용마산');
+  });
+
+  it("archFlag='off' + arcOvershoot=true → 기존 동작 유지 (advanced, backward compat)", async () => {
+    await seedForAdvance();
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence({ arcOvershootDetected: true }),
+      { gatePassed: true, lockAttachable: true, archFlag: 'off' },
+    );
+    expect(out.result).toBe('advanced');
+    expect(out.blockReason).toBeUndefined();
+  });
+
+  it('archFlag 미제공 + arcOvershoot=true → 기존 동작 유지 (dormant, backward compat)', async () => {
+    await seedForAdvance();
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence({ arcOvershootDetected: true }),
+      { gatePassed: true, lockAttachable: true },
+    );
+    expect(out.result).toBe('advanced');
+  });
+
+  it("archFlag='on' + arcOvershoot=false → 정상 advance", async () => {
+    await seedForAdvance();
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence({ arcOvershootDetected: false }),
+      { gatePassed: true, lockAttachable: true, archFlag: 'on' },
+    );
+    expect(out.result).toBe('advanced');
+  });
+
+  it("archFlag='on' + arcOvershoot 미stamp → dormant (caller migration 전 backward compat)", async () => {
+    await seedForAdvance();
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence(), // arcOvershootDetected 미stamp
+      { gatePassed: true, lockAttachable: true, archFlag: 'on' },
+    );
+    expect(out.result).toBe('advanced');
+  });
+});
+
+describe('#2023 evidence replay — 2026-07-03 arc 폭주 시계열 통합', () => {
+  /**
+   * 2026-07-03 evidence 시계열 replay: 08:32:45 arc=3998 → 08:37:25 arc=4710 (Δ=712m),
+   * 사용자 실 이동 distance haversine ≈ 100m (device 정지 판단 상태에서 arc 시간 적분만 누적).
+   *
+   * 통합 검증:
+   *   1. positionSeries.detectArcOvershoot이 폭주를 감지 (true)
+   *   2. 감지 결과를 evidence에 stamp → advanceTripPosition 게이트 #8이 hop pause
+   *   3. archFlag='off' 시 dormant → 조기 발사 회귀 그대로 (기존 동작 유지)
+   */
+
+  const EVIDENCE_TS_START = 1_720_000_000_000;
+  const TS_08_32_45 = EVIDENCE_TS_START;
+  // 08:37:25 = 08:32:45 + 4m 40s = +280_000ms
+  const TS_08_37_25 = EVIDENCE_TS_START + 4 * 60_000 + 40_000;
+
+  function buildTodayEvidenceSeries(): PositionPoint[] {
+    // 실 이동 ≈ 100m (약 0.001° lat 차이 ≈ 111m). arc 델타는 712m로 폭주.
+    return [
+      {
+        lat: 37.5,
+        lng: 127.0,
+        accuracy: 15,
+        ts: TS_08_32_45,
+        motion: 'stationary',
+        mapMatchedLine: '2',
+        mapMatchedArcM: 3998,
+      },
+      {
+        lat: 37.5009,
+        lng: 127.0,
+        accuracy: 15,
+        ts: TS_08_37_25,
+        motion: 'stationary',
+        mapMatchedLine: '2',
+        mapMatchedArcM: 4710,
+      },
+    ];
+  }
+
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  it('시계열 replay → detectArcOvershoot=true (evidence 재현)', () => {
+    const series = buildTodayEvidenceSeries();
+    expect(detectArcOvershoot(series)).toBe(true);
+  });
+
+  it("archFlag='on' + arc overshoot evidence stamp → 조기 발사 차단 (blocked arc-overshoot)", async () => {
+    // Trip + SSoT seed (moving으로 두어 motion 게이트 통과)
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '어린이대공원');
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        boardingLock: makeLock(),
+        waypoints: [
+          { stationName: '뚝섬', line: '2', kind: 'intermediate' },
+          { stationName: '성수', line: '2', kind: 'destination' },
+        ],
+      }),
+    );
+
+    // caller가 감지 후 stamp
+    const arcOvershoot = detectArcOvershoot(buildTodayEvidenceSeries());
+    expect(arcOvershoot).toBe(true);
+
+    const evidence = makeEvidence({
+      ts: TS_08_37_25,
+      arcOvershootDetected: arcOvershoot,
+      stationId: '성수',
+    });
+
+    // 성수(destination) advance 시도 — arc overshoot로 차단
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '성수',
+      evidence,
+      { gatePassed: true, lockAttachable: true, archFlag: 'on' },
+    );
+    expect(out.result).toBe('blocked');
+    expect(out.blockReason).toBe('arc-overshoot');
+
+    // SSoT 미 mutate — 조기 발사 회귀 차단
+    const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    expect(after?.currentStationId).toBe('어린이대공원');
+    expect(after?.passedStations).not.toContain('어린이대공원');
+  });
+
+  it("archFlag='off' + arc overshoot evidence → 기존 동작 유지 (advance) — rollback 안전", async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '어린이대공원');
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        boardingLock: makeLock(),
+        waypoints: [
+          { stationName: '뚝섬', line: '2', kind: 'intermediate' },
+          { stationName: '성수', line: '2', kind: 'destination' },
+        ],
+      }),
+    );
+
+    const arcOvershoot = detectArcOvershoot(buildTodayEvidenceSeries());
+    const evidence = makeEvidence({
+      ts: TS_08_37_25,
+      arcOvershootDetected: arcOvershoot,
+      stationId: '성수',
+    });
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '성수',
+      evidence,
+      { gatePassed: true, lockAttachable: true, archFlag: 'off' },
+    );
+    // archFlag=off이므로 arc 게이트 dormant → advance 통과 (기존 회귀 그대로)
+    expect(out.result).toBe('advanced');
+    expect(out.blockReason).toBeUndefined();
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/positionSeries.test.ts
+++ b/backend/alarm-worker/src/__tests__/positionSeries.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
   ACCURACY_CUTOFF_M,
+  ARC_OVERSHOOT_MIN_ARC_DELTA_M,
+  ARC_OVERSHOOT_RATIO_DEFAULT,
   appendPositionPoint,
   clearSeries,
   cosineDirection,
+  detectArcOvershoot,
   evaluateWindow,
   haversineKm,
   pickMotionMode,
@@ -519,6 +522,172 @@ describe('positionSeries — cellularEnvironmentVote field validation (#1543)', 
     const series = await readSeries(kv, 'tok');
     expect(series).toHaveLength(1);
     expect(series[0].cellularEnvironmentVote).toBeUndefined();
+  });
+});
+
+describe('detectArcOvershoot (#2023 arc time-integration overshoot guard)', () => {
+  /**
+   * arc 델타 vs 실제 haversine 이동 거리 비율로 device 시간 적분 폭주 감지.
+   *
+   * 2026-07-03 evidence 재현: device velocity=0 판단인데 arc가 시간 적분으로 계속 누적 →
+   * 성수 조기 발사. arc 델타 > haversine × 2 시 overshoot=true.
+   *
+   * 정책: series 부족 / arc 미부착 / 낮은 arc 델타는 false (graceful, false positive 차단).
+   */
+
+  const line = '2';
+
+  function makeSeries(
+    start: { arcM: number; lat: number; lng: number; ts: number },
+    end: { arcM: number; lat: number; lng: number; ts: number },
+  ): PositionPoint[] {
+    return [
+      {
+        lat: start.lat,
+        lng: start.lng,
+        accuracy: 10,
+        ts: start.ts,
+        motion: 'walking',
+        mapMatchedLine: line,
+        mapMatchedArcM: start.arcM,
+      },
+      {
+        lat: end.lat,
+        lng: end.lng,
+        accuracy: 10,
+        ts: end.ts,
+        motion: 'walking',
+        mapMatchedLine: line,
+        mapMatchedArcM: end.arcM,
+      },
+    ];
+  }
+
+  it('arc 델타 > haversine × 2 → overshoot=true (오늘 evidence 재현)', () => {
+    // 2026-07-03 evidence: 08:32:45 arc=3998 → 08:37:25 arc=4710 (Δ=712m)
+    // 실 이동 haversine ≈ 100m (사용자 정지 판단 상태에서 device 시간 적분만 증가)
+    // 712 / 100 = 7.12배 → overshoot=true (ratio 2 초과)
+    const series = makeSeries(
+      { arcM: 3998, lat: 37.5, lng: 127.0, ts: 0 },
+      { arcM: 4710, lat: 37.5009, lng: 127.0, ts: 4 * 60_000 + 40_000 },
+    );
+    expect(detectArcOvershoot(series)).toBe(true);
+  });
+
+  it('arc 델타 ≈ haversine → overshoot=false (정상 이동)', () => {
+    // 정상 이동: arc 델타와 haversine 거리 비슷.
+    // ~200m 이동, arc 델타 200m (ratio ~1) → false
+    const series = makeSeries(
+      { arcM: 1000, lat: 37.5, lng: 127.0, ts: 0 },
+      { arcM: 1200, lat: 37.5018, lng: 127.0, ts: 30_000 },
+    );
+    expect(detectArcOvershoot(series)).toBe(false);
+  });
+
+  it('arc 델타 = 0 → overshoot=false (변화 없음)', () => {
+    // arc 델타 0이면 폭주 아님. (기존 mapMatchedKmh 정책과 정렬)
+    const series = makeSeries(
+      { arcM: 500, lat: 37.5, lng: 127.0, ts: 0 },
+      { arcM: 500, lat: 37.5, lng: 127.0, ts: 30_000 },
+    );
+    expect(detectArcOvershoot(series)).toBe(false);
+  });
+
+  it('arc 델타 < min threshold → overshoot=false (신호 부족)', () => {
+    // 작은 arc 델타는 GPS/arc 노이즈 범위 — 판단 유보.
+    // ratio는 초과해도 절대값이 작으면 false positive 위험.
+    const series = makeSeries(
+      { arcM: 100, lat: 37.5, lng: 127.0, ts: 0 },
+      { arcM: 100 + ARC_OVERSHOOT_MIN_ARC_DELTA_M - 1, lat: 37.5, lng: 127.0, ts: 30_000 },
+    );
+    expect(detectArcOvershoot(series)).toBe(false);
+  });
+
+  it('series 길이 < 2 → overshoot=false (graceful)', () => {
+    expect(detectArcOvershoot([])).toBe(false);
+    expect(
+      detectArcOvershoot([
+        {
+          lat: 37.5,
+          lng: 127.0,
+          accuracy: 10,
+          ts: 0,
+          motion: 'walking',
+          mapMatchedLine: line,
+          mapMatchedArcM: 100,
+        },
+      ]),
+    ).toBe(false);
+  });
+
+  it('arc 미부착 (mapMatchedArcM=undefined) → overshoot=false (graceful)', () => {
+    // arc 없으면 판단 유보 (Phase 1 회귀 없음 정책과 정렬).
+    const series: PositionPoint[] = [
+      { lat: 37.5, lng: 127.0, accuracy: 10, ts: 0, motion: 'walking' },
+      { lat: 37.501, lng: 127.0, accuracy: 10, ts: 30_000, motion: 'walking' },
+    ];
+    expect(detectArcOvershoot(series)).toBe(false);
+  });
+
+  it('한쪽만 arc 있음 → overshoot=false (짝 정책과 정렬)', () => {
+    const series: PositionPoint[] = [
+      {
+        lat: 37.5,
+        lng: 127.0,
+        accuracy: 10,
+        ts: 0,
+        motion: 'walking',
+        mapMatchedLine: line,
+        mapMatchedArcM: 1000,
+      },
+      { lat: 37.501, lng: 127.0, accuracy: 10, ts: 30_000, motion: 'walking' },
+    ];
+    expect(detectArcOvershoot(series)).toBe(false);
+  });
+
+  it('환승역 disambiguate — 두 sample line이 다르면 false (mapMatchedKmh 정책과 정렬)', () => {
+    // 노선이 다르면 arc 자체를 신뢰 X → 폭주 판단 유보.
+    const series: PositionPoint[] = [
+      {
+        lat: 37.5,
+        lng: 127.0,
+        accuracy: 10,
+        ts: 0,
+        motion: 'walking',
+        mapMatchedLine: '2',
+        mapMatchedArcM: 1000,
+      },
+      {
+        lat: 37.5,
+        lng: 127.0,
+        accuracy: 10,
+        ts: 30_000,
+        motion: 'walking',
+        mapMatchedLine: '3',
+        mapMatchedArcM: 5000,
+      },
+    ];
+    expect(detectArcOvershoot(series)).toBe(false);
+  });
+
+  it('custom ratio threshold 지원 (더 엄격/느슨 config)', () => {
+    // arc 델타 = 700m, haversine ≈ 200m → ratio ≈ 3.5
+    const series = makeSeries(
+      { arcM: 1000, lat: 37.5, lng: 127.0, ts: 0 },
+      { arcM: 1700, lat: 37.5018, lng: 127.0, ts: 30_000 },
+    );
+    // 기본 ratio 2 → overshoot=true
+    expect(detectArcOvershoot(series)).toBe(true);
+    // 더 느슨한 ratio 5 → overshoot=false
+    expect(detectArcOvershoot(series, { ratioThreshold: 5 })).toBe(false);
+  });
+
+  it('ARC_OVERSHOOT_RATIO_DEFAULT 상수 노출 (caller 참조용)', () => {
+    expect(ARC_OVERSHOOT_RATIO_DEFAULT).toBeGreaterThan(1);
+  });
+
+  it('ARC_OVERSHOOT_MIN_ARC_DELTA_M 상수 노출 (caller 참조용)', () => {
+    expect(ARC_OVERSHOOT_MIN_ARC_DELTA_M).toBeGreaterThan(0);
   });
 });
 

--- a/backend/alarm-worker/src/advanceTripPosition.ts
+++ b/backend/alarm-worker/src/advanceTripPosition.ts
@@ -13,7 +13,7 @@
  * 본 T2는 단일 진입점 `advanceTripPosition`을 도입해 6단 게이트를 강제한다.
  * 본 PR은 함수 + 테스트만 추가하고 기존 fire path를 변경하지 않는다 (T4~T7가 reader migration).
  *
- * 6단 게이트 (순서 강제, ADR-017)
+ * 게이트 (순서 강제, ADR-017 / ADR-022)
  * ===============================
  *   #1 Seed 게이트         — SSoT 미존재 / currentStationId 없으면 blocked('no-seed')
  *   #2 Motion 게이트       — motionState==='stationary' 이고 userIntentDeclared=false면 blocked('motion-stationary')
@@ -26,6 +26,11 @@
  *   #5 Train identity 게이트 — lock 활성 + arvlcd-confirmed-train evidence면 trainCode 일치 필수
  *   #6 Lockless arvlcd 단독 게이트 — lock 없는 trip에서 arvlcd-lockless 단독은 60s 윈도우 내
  *                                    strong evidence 1+개가 추가로 있어야 통과
+ *   #8 arc-overshoot 게이트 (#2023, ADR-022) — device `mapMatchedArcM` 시간 적분 폭주 감지.
+ *      options.archFlag='on' + evidence.arcOvershootDetected=true 시 blocked('arc-overshoot').
+ *      archFlag='off' / 미제공 시 dormant — backward compat 및 rollback 안전.
+ *      #7보다 먼저 배치: position-train jump/stale은 특수 evidence type 케이스, arc overshoot은
+ *      모든 evidence type의 신호 신뢰도 회귀이므로 광범위 게이트가 우선.
  *   #7 position-train jump/stale 게이트 — position-train evidence에만 적용 (#1665):
  *      (a) Jump 가드: candidate stationId가 ssot.currentStationId 기준 hop 거리 ≥ 3 → blocked
  *          ('position-train-jump'). express 9호선은 1-2 hop이 전형 → 3 미만 임계는 보수적.
@@ -50,6 +55,7 @@
  *   payload에 `wifiSsid` 추가 + backend wire) 또는 별도 데이터 module로 분리한다.
  */
 
+import type { ArchFlagValue } from './archFlag';
 import { evaluateConsensusGate, type StationEnvironment } from './consensusGate';
 import type { ArrivalEntry, PositionEntry } from './seoul';
 import {
@@ -132,6 +138,14 @@ export interface AdvanceEvidence {
   cellularTechVote?: CellularTechVote;
   /** accel fingerprint 식별자 (S9, type='accel-fingerprint' 시). */
   accelFingerprint?: string;
+  /**
+   * #2023 — device `mapMatchedArcM` 시간 적분 폭주 감지 결과 (`positionSeries.detectArcOvershoot`).
+   *
+   * caller가 미리 계산해 stamp. 값이 true + options.archFlag='on' 시 게이트 #8이
+   * blocked('arc-overshoot')을 반환한다. undefined(미stamp)면 게이트 dormant — backward compat.
+   * archFlag='off' 시에도 dormant — flag rollback 안전.
+   */
+  arcOvershootDetected?: boolean;
 }
 
 /** advance 시도 결과. */
@@ -147,7 +161,8 @@ export type AdvanceBlockReason =
   | 'train-mismatch'
   | 'lockless-arvlcd-alone'
   | 'position-train-jump'
-  | 'position-train-stale';
+  | 'position-train-stale'
+  | 'arc-overshoot';
 
 /** advance 호출 결과 — caller가 SSoT 후속 작업(fire 발사 등)을 진행할지 결정. */
 export interface AdvanceOutcome {
@@ -369,7 +384,7 @@ export async function advanceTripPosition(
   token: string,
   candidateStationId: string,
   evidence: AdvanceEvidence,
-  options: { gatePassed: boolean; lockAttachable: boolean },
+  options: { gatePassed: boolean; lockAttachable: boolean; archFlag?: ArchFlagValue },
 ): Promise<AdvanceOutcome> {
   const ssot = await readSsot(kv, token);
 
@@ -421,6 +436,19 @@ export async function advanceTripPosition(
     if (otherStrong < 1) {
       return { result: 'blocked', blockReason: 'lockless-arvlcd-alone', ssot };
     }
+  }
+
+  // #8 arc-overshoot 게이트 (#2023)
+  // device `mapMatchedArcM` 시간 적분 폭주 감지 시 hop 진행 pause. archFlag='on' 시에만 활성.
+  // 미stamp 또는 archFlag != 'on' 시 dormant (backward compat).
+  //
+  // Rationale: 2026-07-03 evidence — device velocity=0 판단인데 arc 시간 적분만 계속 누적 →
+  // fusedSpeed/hop 판정 왜곡 → 실 위치보다 여러 정거장 조기 발사. arc guard로 hop pause 후
+  // GPS/다른 신호가 회복될 때까지 대기.
+  //
+  // ADR-022 rollback 안전: archFlag='off'로 KV write 시 즉시 dormant.
+  if (options.archFlag === 'on' && evidence.arcOvershootDetected === true) {
+    return { result: 'blocked', blockReason: 'arc-overshoot', ssot };
   }
 
   // #7 position-train jump / stale 게이트 (#1665)

--- a/backend/alarm-worker/src/positionSeries.ts
+++ b/backend/alarm-worker/src/positionSeries.ts
@@ -273,6 +273,64 @@ export function pickMotionMode(
 }
 
 /**
+ * #2023 — arc time-integration overshoot 감지 기본 비율 임계.
+ *
+ * device의 `mapMatchedArcM` 시간 적분 값이 실제 이동 haversine 거리 대비 이 배수를 초과하면
+ * overshoot으로 판정. 2026-07-03 evidence: 실 이동 ≈ 1km인데 arc 3998→4710 폭주 → 성수 조기
+ * 발사. ratio 2는 GPS jitter/urban canyon 여유를 남기면서 실질 폭주(3배 이상)를 잡는 임계.
+ */
+export const ARC_OVERSHOOT_RATIO_DEFAULT = 2;
+
+/**
+ * #2023 — overshoot 판정에 필요한 최소 arc 델타 (m).
+ *
+ * 절대값이 작으면 GPS/arc 산출 노이즈 범위이므로 판정 유보 (false positive 차단). 250m는 서울
+ * 지하철 한 정거장 평균 hop(700~1200m)의 1/3 정도 — 노이즈와 실 신호를 구분하는 하한.
+ */
+export const ARC_OVERSHOOT_MIN_ARC_DELTA_M = 250;
+
+/**
+ * #2023 — device의 `mapMatchedArcM` 시간 적분 폭주 감지.
+ *
+ * 배경: device velocity=0 판단 상태에서도 시간 적분 방식으로 arc가 지속 누적되는 회귀
+ * ([[lesson_arc_time_integration_overshoot]]). 실 이동은 미미한데 arc 값만 폭주 → backend
+ * fusedSpeed/hop advance 판단이 왜곡되어 사용자 실 위치보다 여러 정거장 조기 판정.
+ *
+ * 정의: 첫 sample과 마지막 sample 사이 arc 델타가 haversine 거리 × ratioThreshold를 초과하면
+ * overshoot=true. arc 절대 델타 < ARC_OVERSHOOT_MIN_ARC_DELTA_M 은 노이즈 범위로 유보(false).
+ *
+ * Graceful 정책 (false positive 우선):
+ *   - series.length < 2 → false
+ *   - arc 미부착 (mapMatchedArcM=undefined) → false
+ *   - 한쪽만 arc 있음 → false (짝 정책, mapMatchedKmh와 정렬)
+ *   - 두 sample line 다름 → false (환승 disambiguate, mapMatchedKmh와 정렬)
+ *   - arc 델타 = 0 → false
+ *   - arc 델타 절대값 < 최소 임계 → false
+ *   - haversine 거리 = 0 (동일 좌표) 이지만 arc 델타 ≥ 최소 임계 → true (완전 정지인데 arc 폭주 = 명백한 시간 적분 회귀)
+ */
+export function detectArcOvershoot(
+  series: readonly PositionPoint[],
+  options?: { ratioThreshold?: number },
+): boolean {
+  if (series.length < 2) return false;
+  const start = series[0];
+  const end = series[series.length - 1];
+  const { mapMatchedLine: startLine, mapMatchedArcM: startArc } = start;
+  const { mapMatchedLine: endLine, mapMatchedArcM: endArc } = end;
+  if (startLine === undefined || startArc === undefined) return false;
+  if (endLine === undefined || endArc === undefined) return false;
+  if (startLine !== endLine) return false;
+  const arcDeltaM = Math.abs(endArc - startArc);
+  if (arcDeltaM === 0) return false;
+  if (arcDeltaM < ARC_OVERSHOOT_MIN_ARC_DELTA_M) return false;
+  const ratioThreshold = options?.ratioThreshold ?? ARC_OVERSHOOT_RATIO_DEFAULT;
+  const haversineM = haversineKm(start.lat, start.lng, end.lat, end.lng) * 1000;
+  // haversine = 0 (완전 정지) 인데 arc 델타가 최소 임계 이상 = 명백한 시간 적분 회귀 → true
+  if (haversineM === 0) return true;
+  return arcDeltaM > haversineM * ratioThreshold;
+}
+
+/**
  * 진행 방향 cosine — `velocity vector(start→end)` 대 `expected vector(origin→nextStation)` (게이트 #5).
  *
  * 길이 0(정지/동일점)은 0으로 강등해 게이트 ≥ 0.7 차단. atan2 vs degree 변환 노이즈를

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -54,6 +54,7 @@ import {
   type TripPositionSSoT,
 } from './tripPositionSsot';
 import {
+  detectArcOvershoot,
   evaluateWindow,
   haversineKm,
   readSeries,
@@ -1944,6 +1945,10 @@ async function tryAdvanceAndFireArvlcd(inputs: {
       return { dirty: false };
     }
   }
+  // #2023 — device `mapMatchedArcM` 시간 적분 폭주 감지. archFlag='on' 시 게이트 #8이 hop pause.
+  // series read + 감지 결과를 evidence에 stamp. archFlag='off' 시 dormant (기존 동작 유지).
+  const arcOvershootSeries = await readSeries(env.TRIPS, trip.token);
+  const arcOvershootDetected = detectArcOvershoot(arcOvershootSeries);
   const outcome = await advanceTripPosition(
     env.TRIPS,
     trip.token,
@@ -1955,6 +1960,7 @@ async function tryAdvanceAndFireArvlcd(inputs: {
       environment: deriveEvidenceEnvironment(trip),
       arvlcdTrainCode: lock.trainCode,
       arvlCd,
+      arcOvershootDetected,
     },
     {
       // lock 활성 = base 합의 surrogate. consensusGate가 surface는 base만으로, underground는
@@ -1962,6 +1968,8 @@ async function tryAdvanceAndFireArvlcd(inputs: {
       // 검증. lock 활성 trip에서 lockAttachable 단일 trainCode 수렴은 lock 부착 자체가 증거.
       gatePassed: true,
       lockAttachable: true,
+      // #2023 (ADR-022) — archFlag='on' 시 arc 게이트 활성. 미wire caller는 dormant.
+      archFlag: deps.archFlag,
     },
   );
   if (outcome.result !== 'advanced') {
@@ -2736,15 +2744,29 @@ export async function advanceBoardingLockWaypoint(
         currentStationId: waypoint.stationName,
       });
     }
+    // #2023 — evidence.arcOvershootDetected 가 이미 stamp되어 있으면 그대로 유지(caller가
+    // 감지한 값 존중). 미stamp이면 series read + detectArcOvershoot로 채워 넣는다. 게이트 #8은
+    // options.archFlag='on'일 때만 활성(archFlag=off/미제공 dormant → backward compat).
+    const advanceEvidence: AdvanceEvidence =
+      evidence.arcOvershootDetected !== undefined
+        ? evidence
+        : {
+            ...evidence,
+            arcOvershootDetected: detectArcOvershoot(
+              await readSeries(env.TRIPS, trip.token),
+            ),
+          };
     const outcome = await advanceTripPosition(
       env.TRIPS,
       trip.token,
       waypoint.stationName,
-      evidence,
+      advanceEvidence,
       {
         // lock 활성 = base 합의 surrogate (T4 `tryAdvanceAndFireArvlcd` 와 같은 정책).
         gatePassed: true,
         lockAttachable: trip.boardingLock !== undefined,
+        // #2023 (ADR-022) — archFlag='on' 시 arc overshoot 게이트 활성. off/미제공 dormant.
+        archFlag: deps.archFlag,
       },
     );
     if (outcome.result !== 'advanced') {


### PR DESCRIPTION
## Summary
- 오늘 evidence: 08:32:45 arc=3998m → 08:37:25 arc=4710m (haversine 100m, ratio 7.12배)
- 정지 상태에서 arc(time-integration) 폭주 → backend hop 계산 왜곡 → 성수 조기 발사
- archFlag=on 시 arc overshoot 감지 → hop advance blocked

Closes #2023

## 변경
- `positionSeries.ts` — `detectArcOvershoot` pure helper + `ARC_OVERSHOOT_RATIO_DEFAULT=2` + `ARC_OVERSHOOT_MIN_ARC_DELTA_M=250`
- `advanceTripPosition.ts` — 게이트 #8 (arc-overshoot), evidence stamp, archFlag forward
- `scheduled.ts` — series read + detectArcOvershoot + archFlag forward (tryAdvanceAndFireArvlcd, advanceBoardingLockWaypoint)
- 19개 신규 test:
  - positionSeries: 11 tests (evidence replay, 정상 이동, arc=0, false positive 차단)
  - advanceTripPosition: 8 tests (게이트 #8 + 오늘 evidence 시계열 replay 3건)

## False positive 차단
- series < 2, arc 미부착, 한쪽만 arc, 노선 불일치, arc delta = 0, arc delta < 250m → 모두 false
- Haversine = 0 + arc 폭주 = 명백한 회귀 → true

## Test plan
- [x] Backend 2479 pass, type-check
- [x] Frontend 8970 pass, coverage 100%, type-check
- [x] Orphan lint pass
- [ ] Fixture replay test (#2024) 통과 확인 필요 — J 관련 `test.fails()` 마킹 해제 예상
- [ ] Device verify: 실기기 arc 폭주 상황 재현 시 조기 발사 방지

## Wire-completion 5단
1. Orphan 없음 (detectArcOvershoot caller 실 존재)
2. V/X dashboard — AdvanceBlockReason 'arc-overshoot' backend log
3. 의존 PR — #2019, #2021, #2022 병렬. #2024 fixture와 상호 검증
4. 측정 plan — 1주 arc-overshoot count 관찰, 조기 발사 재발 0건
5. Device verify 필요

## 관련
- lesson_arc_time_integration_overshoot.md
- lesson_lockless_route_hop_time_integration_ssot_assumption.md
- 사용자 확정 flow: trainCode 기반 arvlCd 추적 (arc 무관)