### PR TITLE
docs(#2033): ADR-023 — Backend vs Device 알림 역할 경계

### DIFF
--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -1672,6 +1672,7 @@ export interface FireArvlCdStationPushInputs {
  */
 export const STALE_LOCK_FIRE_THRESHOLD_MS = 3 * 60 * 1000;
 
+// Backend는 취침모드 무관 발사 (device shouldSuppressBySleepRule 단일 gate, ADR-023).
 export async function fireArvlCdStationPush(
   inputs: FireArvlCdStationPushInputs,
 ): Promise<{ dirty: boolean }> {
@@ -2033,6 +2034,7 @@ async function tryAdvanceAndFireArvlcd(inputs: {
     environment: deriveEvidenceEnvironment(trip),
     hopIndex: waypoint.hopIndex,
   });
+  // Backend는 취침모드 무관 발사 (device shouldSuppressBySleepRule 단일 gate, ADR-023).
   return fireArvlCdStationPush({
     trip,
     waypoint,
@@ -2119,6 +2121,7 @@ export function vanishReleaseFireKey(
   return `${VANISH_RELEASE_FIRE_KEY_PREFIX}${token}|${trainCode}|${stationName}`;
 }
 
+// Backend는 취침모드 무관 발사 (device shouldSuppressBySleepRule 단일 gate, ADR-023).
 export async function fireVanishFallbackStationPush(
   inputs: FireVanishFallbackStationPushInputs,
 ): Promise<void> {
@@ -2423,6 +2426,7 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
       // 사용자는 종착역 하차 알림을 받지 못한다. station-passed imminent push를 destination에도
       // 발사해 device 측 banner 발사 경로(채널 2)도 확보한다. surface 중복은 device 측
       // pushId/firedPushIds dedup으로 흡수.
+      // Backend는 취침모드 무관 발사 (device shouldSuppressBySleepRule 단일 gate, ADR-023).
       await fireVanishFallbackStationPush({
         trip,
         waypoint,
@@ -2466,6 +2470,7 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
     const releaseMotionSeries = await readSeries(env.TRIPS, trip.token);
     const releaseMotion = evaluateWindow(releaseMotionSeries, now).motion;
     if (!isFallbackAdvanceBlockedByMotion(releaseMotion)) {
+      // Backend는 취침모드 무관 발사 (device shouldSuppressBySleepRule 단일 gate, ADR-023).
       await fireVanishFallbackStationPush({
         trip,
         waypoint,
@@ -3224,6 +3229,7 @@ export async function maybeReschedulePush(
  * 발사 성공 시: waypoint shift + lastFiredPhase reset + trip 저장. waypoint 0이면 trip cleanup.
  * 사양상 transfer/destination kind는 호출 전에 분기로 차단됨 — 이 함수는 intermediate에 한정.
  */
+// Backend는 취침모드 무관 발사 (device shouldSuppressBySleepRule 단일 gate, ADR-023).
 export async function runLocklessIntermediate(
   trip: Trip,
   waypoint: Waypoint,

--- a/docs/decisions/ADR-023-backend-vs-device-sleep-mode-boundary.md
+++ b/docs/decisions/ADR-023-backend-vs-device-sleep-mode-boundary.md
@@ -1,0 +1,93 @@
+# ADR-023 — 취침모드 역할 경계: Backend Silent Push vs Device UI Decision
+
+## 상태
+
+Accepted — 이슈 #2033, 2026-07-04. Stage G/H audit 결과 현재 아키텍처가 이미 원칙 정합. 코드 변경 없음, 문서화 + code comment 보강만.
+
+## 배경
+
+취침모드(sleepMode) 알림 억제 로직이 backend와 device 어느 쪽에 위치해야 하는지에 대한 의문:
+
+- **Backend** (`backend/alarm-worker/src/scheduled.ts`): Seoul TOPIS API `arvlCd` (0=진입, 1=도착) 신호를 관측해 silent push를 발사한다.
+- **Device** (`src/features/alarm/utils/shouldSuppressBySleepRule.ts`): silent push 수신 후 취침모드 규칙에 따라 UI 발사(alert/haptic) 여부를 결정한다.
+- 의문: "Backend가 취침모드 상태를 이미 알고 있다면(#2032, Issue D), 아예 silent push를 보내지 않는 편이 낫지 않은가?"
+
+Issue D(#2032)로 backend `Trip.sleepModeEnabled` 저장이 완료되면 backend에서 취침 상태 참조 가능. 그럼에도 device 단일 gate 정책을 유지할지 결정 필요.
+
+## 결정
+
+**Backend + Device 분담 유지** — 현재 방식(현재 아키텍처가 이미 원칙 정합).
+
+1. **Backend는 arvlCd 신호 기반 silent push를 무조건 발사** (취침모드 무관). `scheduled.ts` 5개 발사 경로 모두 sleep 참조 없음.
+2. **Device가 `shouldSuppressBySleepRule` 단일 gate에서 필터링** — FG/BG/Scheduler 3개 호출처 모두 동일 함수 위임.
+3. **Exception: destination kind는 device도 차단하지 않음** — 도착 알림 누락 → 최종 하차역 놓침(critical). transfer/station-passed 첫 hop만 suppress.
+
+Issue D(#2032)의 `Trip.sleepModeEnabled`는 저장/monitoring 전용. Backend 발사 gate에 사용하지 않는다.
+
+## 이유
+
+### "Backend 안 보냄" 대안을 채택하지 않는 이유
+
+| 측면 | 현재 (Backend 발사 + Device 차단) | 대안 (Backend 발사 안 함) | Winner |
+|---|---|---|---|
+| 네트워크 비용 | silent push 1회 | push 0회 | 대안 |
+| 배터리 비용 | wake + parse | sleep 유지 | 대안 |
+| Monitoring | backend signal 자동 수집 (skip 원인 분류 가능) | device only | **현재** |
+| Fallback safety | device logic bug 시 silent push는 도달 → recovery 가능 | backend에서 skip되면 device 못 복구 | **현재** |
+| Debug 용이성 | backend log + device log 양쪽 대조 | device log만 | **현재** |
+| Separation of concerns | Backend = 신호 관측, Device = 정책 판정 (clean) | Backend가 정책 state machine 소유 (coupling) | **현재** |
+
+정확도(false positive / miss 동급, ADR-010 첫 줄 원칙)를 위한 fallback safety + observability 우위가 미미한 네트워크/배터리 비용을 압도.
+
+### "Backend 무조건 발사"의 3가지 근거
+
+1. **Clean separation of concerns** — Backend는 Seoul TOPIS 신호 관측기, Device는 사용자 UI 정책 결정자. Backend가 취침 상태 state machine을 소유하면 device sleep 토글 시점과 backend KV 동기화 race window가 정확성 리스크로 전환된다.
+2. **Fallback safety** — Device의 `shouldSuppressBySleepRule` 로직에 버그가 있어도 silent push 자체는 backend에서 도달하므로 device 측 log/monitoring으로 감지 가능. Backend에서 skip하면 device는 아예 신호를 못 받아 침묵 회귀(2026-06-17 군자/용마산 유형)를 재현할 위험.
+3. **Observability** — silent push 발사 통계(`scheduled.ts` stats.silentPushFiredByKind)와 device suppress log(`alarmLog.ts:143` `logSuppressedSleepFirstTransfer`)를 backend + device 양쪽에서 수집. 회귀 발생 시 backend 발사 여부와 device 차단 여부를 독립 확인 가능.
+
+## Exception: Destination Kind
+
+Device의 `shouldSuppressBySleepRule.ts` 정책 (line 55–59):
+
+```ts
+// transfer / station-passed 첫 hop → suppress (취침 중 환승 침묵)
+// destination → 항상 fire (도착 놓칠 위험 방지)
+```
+
+이유:
+- 취침 중 도착 알림을 놓치면 최종 하차역을 지나쳐 overshoot 발생 → 사용자 실질적 손해(재탑승 시간/비용).
+- 반면 transfer 침묵은 최악의 경우 다음 hop에서 다시 안내 (recovery 가능).
+- 도착 후 취침 알람 재개 로직은 별도 device layer (Issue I: 취침모드 환승 알람).
+
+## 구현 지점
+
+### Backend 발사 경로 5개 (모두 sleep 무관)
+
+| 경로 | 파일:라인 | Waypoint Kind | Sleep 참조 |
+|---|---|---|---|
+| `fireArvlCdStationPush` 함수 | `scheduled.ts:1675` | all (intermediate/transfer/destination) | 없음 |
+| ARV 단일 진입 → 위임 호출 | `scheduled.ts:2036` | all | 없음 |
+| Vanish fallback fire | `scheduled.ts:2426` | all | 없음 |
+| Vanish release fire | `scheduled.ts:2469` | all | 없음 |
+| `runLocklessIntermediate` 함수 | `scheduled.ts:3227` | intermediate only | 없음 |
+
+라인 번호는 audit 시점(2026-07-04) 기준. 리팩터링으로 이동 가능하므로 관계 확인은 grep으로.
+
+### Device 필터 3경로 (`shouldSuppressBySleepRule` 단일화)
+
+| 호출처 | 파일:라인 | Kind 필터 | Sleep 차단 대상 |
+|---|---|---|---|
+| FG GPS/ARV `useStationAlarm` | `src/features/alarm/hooks/useStationAlarm.ts:831` | transfer, station-passed | 첫 hop 전용 |
+| BG station pipeline | `src/features/alarm/utils/stationPipeline.ts:305`, `:413` | transfer, station-passed | 첫 hop 전용 |
+| Scheduler 사전 예약 wrapper | `src/features/alarm/utils/boardingLockScheduler.ts:239` | transfer, station-passed | 첫 hop 전용 |
+
+정책 소스: `src/features/alarm/utils/shouldSuppressBySleepRule.ts:55-59`. 3개 호출처 모두 동일 함수 위임 — 정책 drift 원천 차단.
+
+## 관련
+
+- **ADR-010** — Sensor fusion 정책 (false positive / miss 동급 원칙 첫 줄).
+- **ADR-017** — Trip Position SSoT 설계.
+- **ADR-022** — Arrival API SSOT 재설계 (arvlCd 단일 신호 근거).
+- **Issue #2032 (Issue D)** — Backend `Trip.sleepModeEnabled` 저장. 본 ADR의 결정에 따라 monitoring 전용, 발사 gate 미사용.
+- **Issue #2033 (본 이슈)** — Stage G/H audit 결과 문서화.
+- **Issue I** — 취침모드 환승 알람 (transfer wake-up logic, device-only layer).

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -827,6 +827,7 @@ export function useStationAlarm({
       });
       return;
     }
+    // Sleep rule 단일 gate (ADR-023). transfer/station-passed 첫 hop만 suppress. destination은 항상 fire.
     if (
       shouldSuppressBySleepRule({
         lock,

--- a/src/features/alarm/utils/boardingLockScheduler.ts
+++ b/src/features/alarm/utils/boardingLockScheduler.ts
@@ -236,6 +236,7 @@ function shouldSkipFirstTransferForSleep(
   hop: CurrentTarget,
   lock: BoardingLock,
 ): boolean {
+  // Sleep rule 단일 gate (ADR-023). transfer/station-passed 첫 hop만 suppress. destination은 항상 fire.
   const suppress = shouldSuppressBySleepRule({
     lock,
     event: { type: hop.alarmType, stationName: hop.name },

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -301,6 +301,7 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
     // #750: 공통 sleep 룰 게이트. scheduler 사전 예약이 skip한 transfer를 BG 즉시 발사 path가
     // 우회 발사하던 회귀 차단. 첫 hop 판정은 route의 첫 waypoint와 stationName 일치로 — lock
     // 활성 동안 leg가 갱신되면 lock도 갱신되므로 route 첫 leg의 endName이 곧 현재 leg의 첫 hop.
+    // Sleep rule 단일 gate (ADR-023). transfer/station-passed 첫 hop만 suppress. destination은 항상 fire.
     const isFirstHop = isSameStationName(getFirstLeg(route, destination.name).endName, alarmEvent.stationName);
     const suppressBySleep = shouldSuppressBySleepRule({
       lock: lockForLineGuard,
@@ -409,6 +410,7 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
     // lockless BG: estimator output 부재 → currentHopIndex null로 전달, 게이트는 자동 비적용(보수적).
     // dedup(lastNotifiedStationId) 위에 위치 — sleep으로 차단되면 lastNotifiedStationId 갱신 안 함
     // → sleep OFF 토글 후 정상 첫 hop 알림이 재발사 가능.
+    // Sleep rule 단일 gate (ADR-023). transfer/station-passed 첫 hop만 suppress. destination은 항상 fire.
     if (
       shouldSuppressBySleepRule({
         lock: lockForLineGuard,


### PR DESCRIPTION
## Summary
- ADR-023 신규 문서: Backend는 `arvlCd` 신호 기반 silent push를 취침모드 무관 발사, Device가 `shouldSuppressBySleepRule` 단일 gate에서 filter 담당.
- Stage G/H audit 결과 **현재 아키텍처가 이미 정합**. 코드 로직 변경 없음, 문서 + code comment 보강만.
- Exception: destination kind는 device도 suppress 안 함 (도착 놓칠 위험 방지).

## Audit 결과

### Backend 발사 경로 5개 (모두 sleep 무관)
| 경로 | 파일:라인 | Waypoint Kind | Sleep 참조 |
|---|---|---|---|
| `fireArvlCdStationPush` 정의 | `scheduled.ts:1675` | all | 없음 |
| ARV 위임 호출 | `scheduled.ts:2036` | all | 없음 |
| Vanish fallback fire | `scheduled.ts:2426` | all | 없음 |
| Vanish release fire | `scheduled.ts:2469` | all | 없음 |
| `runLocklessIntermediate` 정의 | `scheduled.ts:3227` | intermediate only | 없음 |

### Device 필터 3경로 (`shouldSuppressBySleepRule` 단일화)
| 호출처 | 파일:라인 | Kind 필터 |
|---|---|---|
| FG GPS/ARV `useStationAlarm` | `useStationAlarm.ts:831` | transfer, station-passed 첫 hop |
| BG station pipeline | `stationPipeline.ts:305`, `:413` | transfer, station-passed 첫 hop |
| Scheduler 사전 예약 wrapper | `boardingLockScheduler.ts:239` | transfer, station-passed 첫 hop |

정책 소스: `shouldSuppressBySleepRule.ts:55-59`. 3개 호출처 모두 동일 함수 위임 → 정책 drift 원천 차단.

## 아키텍처 평가: "발사+차단" vs "안 보냄"
| 측면 | 현재 (발사+차단) | 대안 (안 보냄) | Winner |
|---|---|---|---|
| 네트워크 비용 | push 1회 | 0회 | 대안 |
| 배터리 비용 | wake+parse | sleep | 대안 |
| Monitoring | backend signal 수집 | device만 | **현재** |
| Fallback safety | device bug시 recovery | backend bug시 silent | **현재** |
| Debug 용이성 | backend + device log | device only | **현재** |
| Separation of concerns | Backend=신호, Device=정책 | Backend가 state 소유 (coupling) | **현재** |

**결론: 현재 방식 유지** — fallback safety + observability 우위가 미미한 비용을 압도. ADR-010 "false positive / miss 동급" 원칙 정합.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — 문서화만. 기존 alarmLog `logSuppressedSleepFirstTransfer` (`alarmLog.ts:143`) 및 backend `stats.silentPushFiredByKind` counter가 관측 지점.
3. **의존 PR** — N/A. Issue D(#2032) `Trip.sleepModeEnabled` 저장과 독립. 본 ADR은 sleepModeEnabled를 monitoring 전용으로 명시.
4. **측정 plan** — 회귀 조기 감지: backend `silentPushFiredByKind` vs device `logSuppressedSleepFirstTransfer` 카운트 dashboard 비교. 1주 관찰 시 backend fire > 0 이지만 device suppress = 0 발견 시 device gate wire 회귀.
5. **Device verify** — N/A — type+unit only (comment 보강만, 로직 변경 없음).

## Test/Lint 검증
- `npm run type-check` — pass
- `npm test` — 421 suites / 9005 tests all pass, coverage 100%
- `npm run lint:orphan` — pass (0 orphan)
- `npm run lint` — 기존 pre-existing 4건 (본 PR과 무관, dev 브랜치 동일 재현)

Closes #2033