### PR TITLE
fix(#2037): boarding-prompt silent push wire 정합 (alert + silent 이중 발사)

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -6,6 +6,7 @@ import {
   resetApnsJwtCache,
   sendAlertPush,
   sendBoardingPromptPush,
+  sendBoardingPromptSilentPush,
   sendLiveActivityUpdate,
   sendReschedulePush,
   sendSilentPush,
@@ -1092,6 +1093,206 @@ describe('sendBoardingPromptPush (#819)', () => {
     const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
     const body = JSON.parse(call[1].body as string);
     expect('subtitle' in body.aps.alert).toBe(false);
+  });
+});
+
+// #2037 (Issue M / Wave 1 완결) — Focus / DND / 취침 fallback 채널. alert push 와 병렬 발사.
+// device silentPushTask 가 gate 무관 local notification 을 발사해 UI 도달률을 확보한다.
+describe('sendBoardingPromptSilentPush (#2037)', () => {
+  beforeEach(() => resetApnsJwtCache());
+
+  it('silent push 전용 headers (background + priority 5 + content-available)', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    const result = await sendBoardingPromptSilentPush({
+      deviceToken: 'device-hex',
+      pushId: 'p-silent-1',
+      title: 'Are you on board?',
+      body: '2 · 강남',
+      originStation: '강남',
+      line: '2',
+      tripToken: 'tok-silent',
+      sentAt: 4321,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ ok: true, status: 200 });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[0]).toBe(`https://${TEST_HOST}/3/device/device-hex`);
+    const headers = call[1].headers as Record<string, string>;
+    expect(headers['apns-push-type']).toBe('background');
+    expect(headers['apns-priority']).toBe('5');
+    expect(headers['apns-topic']).toBe('com.example.app');
+    const body = JSON.parse(call[1].body as string);
+    // silent push — aps.alert / aps.category / aps.sound 없이 content-available 1.
+    expect(body.aps).toEqual({ 'content-available': 1 });
+    // required 필드는 data 로 wire — device extractBoardingPromptPayload 정합.
+    expect(body.data).toEqual({
+      pushId: 'p-silent-1',
+      kind: 'boarding-prompt',
+      originStation: '강남',
+      line: '2',
+      tripToken: 'tok-silent',
+      sentAt: 4321,
+      title: 'Are you on board?',
+      body: '2 · 강남',
+    });
+  });
+
+  it('non-OK 응답은 status/reason 을 그대로 반환', async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 410 }),
+    );
+    const result = await sendBoardingPromptSilentPush({
+      deviceToken: 'device-hex',
+      pushId: 'p',
+      title: 'T',
+      body: 'B',
+      originStation: 'O',
+      line: 'L',
+      tripToken: 't',
+      sentAt: 0,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ ok: false, status: 410, reason: 'BadDeviceToken' });
+  });
+
+  it('non-json error body 처리 (reason undefined)', async () => {
+    const fetchImpl = vi.fn(async () => new Response('plain text', { status: 500 }));
+    const result = await sendBoardingPromptSilentPush({
+      deviceToken: 'device-hex',
+      pushId: 'p',
+      title: 'T',
+      body: 'B',
+      originStation: 'O',
+      line: 'L',
+      tripToken: 't',
+      sentAt: 0,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(500);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('apns-thread-id 헤더에 tripToken 이 그대로 전달된다 (alert push 와 같은 trip 그룹핑)', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    await sendBoardingPromptSilentPush({
+      deviceToken: 'device-hex',
+      pushId: 'p-thread',
+      title: 'T',
+      body: 'B',
+      originStation: 'O',
+      line: 'L',
+      tripToken: 'trip-boarding-silent-123',
+      sentAt: 0,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const headers = call[1].headers as Record<string, string>;
+    expect(headers['apns-thread-id']).toBe('trip-boarding-silent-123');
+  });
+
+  it.each([['cron' as const], ['instant' as const]])(
+    'triggerKind=%s payload.data.triggerKind forward',
+    async (triggerKind) => {
+      const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+      await sendBoardingPromptSilentPush({
+        deviceToken: 'device-hex',
+        pushId: 'p-trigger',
+        title: 'T',
+        body: 'B',
+        originStation: 'O',
+        line: 'L',
+        tripToken: 't',
+        sentAt: 0,
+        triggerKind,
+        config: makeConfig(),
+        host: TEST_HOST,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+      const body = JSON.parse(call[1].body as string);
+      expect(body.data.triggerKind).toBe(triggerKind);
+    },
+  );
+
+  it('destinationDirection 지정 시 data 에 wire (#1740 정합)', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    await sendBoardingPromptSilentPush({
+      deviceToken: 'device-hex',
+      pushId: 'p-dir',
+      title: 'T',
+      body: 'B',
+      originStation: 'O',
+      line: '2',
+      tripToken: 't',
+      sentAt: 0,
+      destinationDirection: 'up',
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.data.destinationDirection).toBe('up');
+  });
+
+  it('candidateTrains 1건 이상이면 data 에 배열로 wire (#1888 RC-13)', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    const candidateTrains = [
+      {
+        trainCode: '1234',
+        line: '2',
+        direction: 'up' as const,
+        nextArrivalEta: 60,
+      },
+    ];
+    await sendBoardingPromptSilentPush({
+      deviceToken: 'device-hex',
+      pushId: 'p-cand',
+      title: 'T',
+      body: 'B',
+      originStation: 'O',
+      line: '2',
+      tripToken: 't',
+      sentAt: 0,
+      candidateTrains,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.data.candidateTrains).toEqual(candidateTrains);
+  });
+
+  it('candidateTrains 빈 배열이면 data 에서 omit (구 device byte-level 호환)', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    await sendBoardingPromptSilentPush({
+      deviceToken: 'device-hex',
+      pushId: 'p-empty',
+      title: 'T',
+      body: 'B',
+      originStation: 'O',
+      line: '2',
+      tripToken: 't',
+      sentAt: 0,
+      candidateTrains: [],
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect('candidateTrains' in body.data).toBe(false);
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -3583,19 +3583,31 @@ describe('runScheduled — boarding-prompt 9단 게이트 (#819)', () => {
     expect(stats.boardingPromptFired).toBe(1);
     expect(stats.boardingPromptBlocked).toBe(0);
 
-    // 1회 fetch (APNs) — 후속 cron에서 dedup.
+    // #2037 (Wave 1 완결) — alert + silent 이중 발사. 첫 call = alert, 두 번째 = silent fallback.
     const fetchMock = fetchImpl as unknown as ReturnType<typeof vi.fn>;
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [, init] = fetchMock.mock.calls[0];
-    expect((init as RequestInit).headers).toMatchObject({
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [, alertInit] = fetchMock.mock.calls[0];
+    expect((alertInit as RequestInit).headers).toMatchObject({
       'apns-push-type': 'alert',
       'apns-priority': '10',
     });
-    const body = JSON.parse((init as RequestInit).body as string);
-    expect(body.aps.category).toBe('BOARDING_PROMPT');
-    expect(body.data.kind).toBe('boarding-prompt');
-    expect(body.data.originStation).toBe('강남');
-    expect(body.data.line).toBe('2');
+    const alertBody = JSON.parse((alertInit as RequestInit).body as string);
+    expect(alertBody.aps.category).toBe('BOARDING_PROMPT');
+    expect(alertBody.data.kind).toBe('boarding-prompt');
+    expect(alertBody.data.originStation).toBe('강남');
+    expect(alertBody.data.line).toBe('2');
+
+    // #2037 — silent fallback push. Focus / DND / 취침 시 device silentPushTask 가 gate 무관 발사.
+    const [, silentInit] = fetchMock.mock.calls[1];
+    expect((silentInit as RequestInit).headers).toMatchObject({
+      'apns-push-type': 'background',
+      'apns-priority': '5',
+    });
+    const silentBody = JSON.parse((silentInit as RequestInit).body as string);
+    expect(silentBody.aps).toEqual({ 'content-available': 1 });
+    expect(silentBody.data.kind).toBe('boarding-prompt');
+    expect(silentBody.data.originStation).toBe('강남');
+    expect(silentBody.data.line).toBe('2');
 
     const persisted = JSON.parse((await kv.get('trip:bp-tok'))!);
     expect(persisted.boardingPromptState).toEqual({ fired: true, lastFiredAt: NOW });
@@ -3799,7 +3811,8 @@ describe('runScheduled — boarding-prompt 9단 게이트 (#819)', () => {
       await runScheduled(makeEnv(kv), deps);
 
       const fetchMock = fetchImpl as unknown as ReturnType<typeof vi.fn>;
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+      // #2037 — alert + silent 이중 발사. candidateTrains 는 두 payload 모두에 동일하게 wire.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
       const [, init] = fetchMock.mock.calls[0];
       const body = JSON.parse((init as RequestInit).body as string);
       // 5건만 wire + arrivalSeconds 오름차순.
@@ -3882,8 +3895,8 @@ describe('runScheduled — #2014 (ADR-022 B8) archFlag=on 배선', () => {
     expect(stats.boardingPromptEvaluated).toBe(1);
     expect(stats.boardingPromptFired).toBe(1);
     expect(stats.boardingPromptBlocked).toBe(0);
-    // APNs fetch 1회 호출.
-    expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+    // #2037 (Wave 1 완결) — alert + silent 이중 발사. 2회 fetch.
+    expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(2);
     const persisted = JSON.parse((await kv.get('trip:b8-tok'))!);
     expect(persisted.boardingPromptState).toEqual({ fired: true, lastFiredAt: NOW });
   });

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -795,6 +795,77 @@ export async function sendBoardingPromptPush(
   return parseApnsError(response);
 }
 
+/**
+ * #2037 (Issue M / Wave 1 완결) — boarding-prompt silent push fallback 채널.
+ *
+ * 배경: `sendBoardingPromptPush`는 alert push(`apns-push-type: alert`)로 iOS 시스템 banner 를
+ * 직접 노출한다. 하지만 사용자 Focus / DND / 취침 등으로 alert 가 도달하지 않으면
+ * boardingPrompt 응답률이 0% 로 떨어진다(7일 evidence). silent push 는 `content-available: 1`
+ * 로 device silentPushTask BG handler 에 도달해 gate 무관 local notification 을 강제 발사한다.
+ *
+ * caller(scheduled.ts)는 alert push 완료 후 이 함수를 순차 발사한다. alert push 의 self-heal
+ * 이 정정한 env(sandbox↔production)를 그대로 재사용해 이중 self-heal 을 회피한다. alert 실패해도
+ * 이 silent push 는 독립적으로 발사되며 (역방향도 마찬가지), 두 채널 중 하나라도 도달하면 UX 회귀 없음.
+ *
+ * payload shape 은 `BoardingPromptPushPayload` 를 그대로 재사용해 device
+ * `extractBoardingPromptPayload` 파서 schema(kind + originStation + line + tripToken 필수,
+ * 나머지 optional)와 1:1 정합. title / body 도 data 에 실어 device 가 local notification
+ * 발사 시 사용 (없으면 device 정적 fallback).
+ *
+ * apns-push-type: 'background', priority: 5 — Apple silent push 표준.
+ * apns-thread-id: tripToken — alert push 와 같은 trip 으로 그룹핑.
+ */
+export async function sendBoardingPromptSilentPush(
+  options: SendBoardingPromptPushOptions,
+): Promise<SendPushResult> {
+  const jwt = await buildApnsJwt(options.config, options.now);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const url = `https://${options.host}/3/device/${options.deviceToken}`;
+
+  const data: BoardingPromptPushPayload = {
+    pushId: options.pushId,
+    kind: 'boarding-prompt',
+    originStation: options.originStation,
+    line: options.line,
+    tripToken: options.tripToken,
+    sentAt: options.sentAt,
+    triggerKind: options.triggerKind,
+    // #1740 — undefined면 payload에 키 자체가 생략됨 (JSON.stringify 동작). device backward compat.
+    destinationDirection: options.destinationDirection,
+    // #2037 — title / body 는 device 가 local notification 발사 시 사용. 미지정 시 device fallback.
+    ...(options.title !== undefined ? { title: options.title } : {}),
+    ...(options.body !== undefined ? { body: options.body } : {}),
+    // #1888 (RC-13) — candidateTrains는 0건이면 omit (device fallback 렌더용).
+    ...(options.candidateTrains !== undefined && options.candidateTrains.length > 0
+      ? { candidateTrains: options.candidateTrains }
+      : {}),
+  };
+
+  const body = JSON.stringify({
+    aps: {
+      'content-available': 1,
+    },
+    data,
+  });
+
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      authorization: `bearer ${jwt}`,
+      'apns-topic': options.config.bundleId,
+      'apns-push-type': 'background',
+      'apns-priority': '5',
+      'content-type': 'application/json',
+      // alert push 와 같은 trip 그룹핑.
+      'apns-thread-id': options.tripToken,
+    },
+    body,
+  });
+
+  if (response.ok) return { ok: true, status: response.status };
+  return parseApnsError(response);
+}
+
 async function parseApnsError(response: Response): Promise<SendPushResult> {
   let reason: string | undefined;
   try {

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -739,14 +739,31 @@ export interface SendBoardingPromptPushOptions {
   now?: number;
 }
 
-export async function sendBoardingPromptPush(
+/**
+ * #2037 — boarding-prompt payload data 는 alert push(`sendBoardingPromptPush`)와
+ * silent push(`sendBoardingPromptSilentPush`) 두 채널 모두 같은 `BoardingPromptPushPayload`
+ * schema 를 wire 한다(device `extractBoardingPromptPayload` 파서 재사용). alert push 는
+ * title/body 를 `aps.alert` 에 실어 시스템 banner 를 노출하고, silent push 는 title/body 를
+ * data 에도 실어 device 가 local notification 을 재구성한다. 공용 builder 를 통해 두 채널의
+ * data schema 를 강제 정합시켜 payload drift 회귀를 차단한다.
+ *
+ * `includeAlertContent` 가 true 이면 title/body 도 data 에 embed (silent 전용). alert push 는
+ * data 에 title/body 를 넣지 않아 payload 크기를 아낀다(iOS 는 aps.alert 에서 렌더).
+ */
+function buildBoardingPromptPushData(
   options: SendBoardingPromptPushOptions,
-): Promise<SendPushResult> {
-  const jwt = await buildApnsJwt(options.config, options.now);
-  const fetchImpl = options.fetchImpl ?? fetch;
-  const url = `https://${options.host}/3/device/${options.deviceToken}`;
-
-  const data: BoardingPromptPushPayload = {
+  includeAlertContent: boolean,
+): BoardingPromptPushPayload {
+  const hasCandidates =
+    options.candidateTrains === undefined ? false : options.candidateTrains.length > 0;
+  const embedTitle = includeAlertContent && options.title !== undefined;
+  const embedBody = includeAlertContent && options.body !== undefined;
+  const titleFragment = embedTitle ? { title: options.title } : {};
+  const bodyFragment = embedBody ? { body: options.body } : {};
+  const candidatesFragment = hasCandidates
+    ? { candidateTrains: options.candidateTrains }
+    : {};
+  return {
     pushId: options.pushId,
     kind: 'boarding-prompt',
     originStation: options.originStation,
@@ -756,11 +773,23 @@ export async function sendBoardingPromptPush(
     triggerKind: options.triggerKind,
     // #1740 — undefined면 payload에 키 자체가 생략됨 (JSON.stringify 동작). device backward compat.
     destinationDirection: options.destinationDirection,
+    // #2037 — silent 채널(includeAlertContent=true)에서만 title / body 를 data 에 embed.
+    // device local notification 재구성용. alert 채널은 aps.alert 에서 렌더하므로 data 제외.
+    ...titleFragment,
+    ...bodyFragment,
     // #1888 (RC-13) — candidateTrains는 0건이면 omit (구 device byte-level 호환 + payload 크기 보호).
-    ...(options.candidateTrains !== undefined && options.candidateTrains.length > 0
-      ? { candidateTrains: options.candidateTrains }
-      : {}),
+    ...candidatesFragment,
   };
+}
+
+export async function sendBoardingPromptPush(
+  options: SendBoardingPromptPushOptions,
+): Promise<SendPushResult> {
+  const jwt = await buildApnsJwt(options.config, options.now);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const url = `https://${options.host}/3/device/${options.deviceToken}`;
+
+  const data = buildBoardingPromptPushData(options, false);
 
   const body = JSON.stringify({
     aps: {
@@ -822,24 +851,7 @@ export async function sendBoardingPromptSilentPush(
   const fetchImpl = options.fetchImpl ?? fetch;
   const url = `https://${options.host}/3/device/${options.deviceToken}`;
 
-  const data: BoardingPromptPushPayload = {
-    pushId: options.pushId,
-    kind: 'boarding-prompt',
-    originStation: options.originStation,
-    line: options.line,
-    tripToken: options.tripToken,
-    sentAt: options.sentAt,
-    triggerKind: options.triggerKind,
-    // #1740 — undefined면 payload에 키 자체가 생략됨 (JSON.stringify 동작). device backward compat.
-    destinationDirection: options.destinationDirection,
-    // #2037 — title / body 는 device 가 local notification 발사 시 사용. 미지정 시 device fallback.
-    ...(options.title !== undefined ? { title: options.title } : {}),
-    ...(options.body !== undefined ? { body: options.body } : {}),
-    // #1888 (RC-13) — candidateTrains는 0건이면 omit (device fallback 렌더용).
-    ...(options.candidateTrains !== undefined && options.candidateTrains.length > 0
-      ? { candidateTrains: options.candidateTrains }
-      : {}),
-  };
+  const data = buildBoardingPromptPushData(options, true);
 
   const body = JSON.stringify({
     aps: {

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -6,6 +6,7 @@ import { ARRIVAL_CODE, TRAIN_STATUS } from './alarm';
 import { evaluateAccelWindow, readAccelSeries } from './accelSeries';
 import {
   sendBoardingPromptPush,
+  sendBoardingPromptSilentPush,
   sendReschedulePush,
   sendSilentPush,
   type ApnsConfig,
@@ -3899,6 +3900,51 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       reason: heal.result.reason,
     });
   }
+
+  // #2037 (Issue M / Wave 1 완결) — Focus / DND / 취침 등으로 alert push 가 사용자에게 도달하지
+  // 않는 경우를 대비한 silent push fallback. device silentPushTask 가 gate 무관 local notification
+  // 을 발사해 UI 도달률을 확보한다.
+  //
+  // alert push 완료 후 순차 발사 — 이유:
+  // 1. alert push 의 sendWithEnvHeal 이 정정한 env(heal.correctedEnv 반영)를 재사용해 이중
+  //    self-heal 을 회피 (silent push 는 alert 가 확정한 올바른 host 로 첫 시도부터 성공).
+  // 2. alert push 실패해도 silent push 는 독립적으로 발사 — 두 채널 중 하나만 도달해도 UX 회귀 없음.
+  // 3. alert push 결과가 stats.boardingPromptFired / dirty / boardingPromptState 를 결정 (기존 동작
+  //    보존). silent push 결과는 log 만 남기고 return path 를 바꾸지 않는다.
+  const silentPushHost = pickApnsHost(trip.apnsEnv, deps.apnsHosts);
+  const silentResult = await sendBoardingPromptSilentPush({
+    deviceToken: trip.token,
+    pushId,
+    title,
+    body,
+    originStation: display.originStation,
+    line: display.line,
+    tripToken: trip.token,
+    sentAt: now,
+    triggerKind: 'cron',
+    destinationDirection: geo.direction ?? undefined,
+    candidateTrains,
+    config: deps.apnsConfig,
+    host: silentPushHost,
+    fetchImpl: deps.fetchImpl,
+    now,
+  });
+  if (silentResult.ok) {
+    log('boarding-prompt: silent-fallback fired', {
+      token: trip.token.slice(0, 8),
+      line: display.line,
+      originStation: display.originStation,
+    });
+  } else {
+    // silent push 실패는 cron tail log 로 가시화 (V/X dashboard). alert push 만 성공해도 iOS
+    // 시스템 banner 로 사용자 도달 가능하므로 UX 회귀는 없다.
+    log('boarding-prompt: silent-fallback failed', {
+      token: trip.token.slice(0, 8),
+      status: silentResult.status,
+      reason: silentResult.reason,
+    });
+  }
+
   if (dirty) {
     await putTrip(env.TRIPS, trip);
   }

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -560,6 +560,24 @@ export interface BoardingPromptPushPayload {
    * 미지정(0건 또는 legacy 빌드) 시 device는 기존 동작(자체 API + empty placeholder).
    */
   candidateTrains?: BoardingPromptCandidate[];
+  /**
+   * #2037 (Issue M) — silent push fallback 채널에서 device 가 local notification 발사 시
+   * 그대로 사용할 title. backend 가 사용자 locale 로 i18n resolve 해서 넣어준다.
+   *
+   * silent push(`sendBoardingPromptSilentPush`)의 `data.title` 로 wire.
+   * alert push(`sendBoardingPromptPush`)는 `aps.alert.title` 를 사용하므로 payload 상 무의미하지만,
+   * 두 push 가 동일 payload 를 공유해 caller 가 한 번의 옵션 객체로 dual fire 하도록 형태 통일.
+   *
+   * 미지정 시 device 가 정적 fallback(`탑승하셨나요?`) 표시 (backward compat).
+   */
+  title?: string;
+  /**
+   * #2037 (Issue M) — silent push fallback 채널의 body. title 과 동일 규칙.
+   *
+   * silent push 의 `data.body` 로 wire. 미지정 시 device fallback
+   * (`${line}호선 ${originStation}에서 열차가 곧 도착합니다.`) 표시.
+   */
+  body?: string;
 }
 
 /**


### PR DESCRIPTION
## 배경

Issue M (#2037) — Wave 1 완결 결정적 wire.

### 확정된 wire gap
- **Backend** `sendBoardingPromptPush` (`backend/alarm-worker/src/apns.ts:742-796`)는 `apns-push-type: 'alert'` 만 발사.
- **Device** `silentPushTask.ts` 가 처리하는 handler 는 silent push handler (`aps.content-available: 1`).
- Issue E(PR #2030, commit b668de18)가 넣은 `extractBoardingPromptPayload` + `fireBoardingPromptLocalNotification` 는 backend 가 silent push 를 발사하지 않으므로 **도달 경로 없는 dead code**.

### 근거 evidence
- 7일 관찰: `boardingPrompt(all)` fired=0, displayed=0, responded=0.
- 사용자 Focus / DND / 취침 시 iOS 시스템 banner 가 도달하지 않아 응답률 0%.

## 결정 옵션 α — alert + silent 이중 발사 (채택)

1. `sendBoardingPromptSilentPush` 신규 (`content-available: 1`, `apns-push-type: background`, priority 5).
2. `scheduled.ts` caller 가 alert push 완료 후 silent push 를 순차 발사 (alert 의 self-heal 정정 env 재사용, 이중 self-heal 회피).
3. Alert 는 iOS 시스템 banner (기존), silent 는 device silentPushTask → gate 무관 local notification fallback.
4. Focus / DND / 취침 시 UI 도달률 확보 + backward compat 유지 (기존 alert push 동작 그대로).

### 다른 옵션 검토
| 옵션 | 채택 여부 | 이유 |
|---|---|---|
| α: alert + silent 이중 발사 | ✅ | Focus/DND/취침 fallback + backward compat |
| β: silent push 만 발사 | ❌ | 기존 alert 채널 destroy — 이미 도달 중인 사용자 회귀 |
| γ: alert 실패 시에만 silent fallback | ❌ | Focus/DND 상황은 alert 가 `200 OK` 로 성공 반환 (iOS 가 무음 처리) — silent trigger 판정 불가 |

## Wire-completion 5단

1. **Orphan 없음** — `sendBoardingPromptSilentPush` caller = `scheduled.ts` L3913. `npm run lint:orphan` pass (0 orphans).
2. **V/X dashboard** —
   - Backend cron tail log: `boarding-prompt: silent-fallback fired/failed`
   - Device silentPushTask log: `boarding-prompt fired/dedup/skipped` + `logBoardingPromptFired` (V acceptance 채널 반영)
3. **의존 PR** —
   - #2026 (Issue C — arvlCd=1 시 boardingPrompt fire caller, merged)
   - #2030 (Issue E — device silent push handler, merged)
   - #2029 (fixture — evidence_20260703, merged)
4. **측정 plan** — 1주 관찰.
   - Backend send count > 0 (log query on `boarding-prompt: silent-fallback fired`)
   - Device fired count > 0 (silentPushTask `boarding-prompt fired` log + `logBoardingPromptFired`)
   - boardingPrompt 응답률 (`displayed / fired > 0`) — Wave 1 완결 핵심 지표
5. **Device verify** — 실기기 trip 에서 boardingPrompt UI 실 노출 확인 필요 (Wave 1 최종 검증, 사용자 담당).
   - 시나리오: 취침모드 상태에서 승차역 도착 → silent push 수신 → local notification 노출 확인
   - 시나리오: Focus/DND ON 상태에서 승차역 도착 → silent push 수신 → 소리+진동+배너 노출 확인

## 변경 파일

- `backend/alarm-worker/src/apns.ts` — `sendBoardingPromptSilentPush` 신규 (+70 lines).
- `backend/alarm-worker/src/types.ts` — `BoardingPromptPushPayload` 에 `title`/`body` optional 추가 (+18 lines).
- `backend/alarm-worker/src/scheduled.ts` — dual-fire caller (alert 이후 silent 순차 발사, +43 lines).
- `backend/alarm-worker/src/__tests__/apns.test.ts` — silent push 8 케이스 신규 (+192 lines).
- `backend/alarm-worker/src/__tests__/scheduled.test.ts` — fetch=1 → fetch=2 assertion 갱신 3곳 + silent payload 검증.

## 검증

- Backend: `npx vitest run` — **2547 tests pass (66 files)**
- Backend type-check: `npx tsc --noEmit` — pass
- Frontend type-check: `npm run type-check` — pass
- Orphan lint: `npm run lint:orphan` — **0 orphans**

Closes #2037