### PR TITLE
feat(#2034): 환승역 하차 확인 boardingPrompt 발사 + UI + 응답 처리

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -1094,6 +1094,57 @@ describe('sendBoardingPromptPush (#819)', () => {
     const body = JSON.parse(call[1].body as string);
     expect('subtitle' in body.aps.alert).toBe(false);
   });
+
+  // #2034 — hop-end (환승역 하차) prompt payload 검증.
+  it('hopEndKind + nextLine + nextStation 을 payload 로 wire 한다 (#2034)', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    await sendBoardingPromptPush({
+      deviceToken: 'device-hex',
+      pushId: 'p-hop-end',
+      title: '성수에서 하차하셨나요?',
+      body: '2호선 성수에서 내려주세요. 다음은 수인분당선 왕십리 방면입니다.',
+      originStation: '성수',
+      line: '2',
+      tripToken: 'trip-hop',
+      sentAt: 0,
+      hopEndKind: 'disembark',
+      nextLine: 'K',
+      nextStation: '왕십리',
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.data.hopEndKind).toBe('disembark');
+    expect(body.data.nextLine).toBe('K');
+    expect(body.data.nextStation).toBe('왕십리');
+    // 기존 필드는 그대로 유지
+    expect(body.data.kind).toBe('boarding-prompt');
+    expect(body.data.originStation).toBe('성수');
+  });
+
+  it('hopEndKind 미지정 시 payload 에서 hop-end 필드 자연 누락 (#2034)', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    await sendBoardingPromptPush({
+      deviceToken: 'device-hex',
+      pushId: 'p-legacy',
+      title: 'T',
+      body: 'B',
+      originStation: 'O',
+      line: '2',
+      tripToken: 't',
+      sentAt: 0,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect('hopEndKind' in body.data).toBe(false);
+    expect('nextLine' in body.data).toBe(false);
+    expect('nextStation' in body.data).toBe(false);
+  });
 });
 
 // #2037 (Issue M / Wave 1 완결) — Focus / DND / 취침 fallback 채널. alert push 와 병렬 발사.

--- a/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
+++ b/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
@@ -3,6 +3,7 @@ import { ARRIVAL_CODE } from '../alarm';
 import {
   DISMISS_SILENCE_MS,
   evaluateBoardingPromptGates,
+  evaluateHopEndPromptGates,
   markPromptFired,
   markPromptSilenced,
   pickAutoTrainCode,
@@ -784,5 +785,41 @@ describe('pickAutoTrainCode — arvlCd 우선순위', () => {
   it('trainCode 빈 문자열 후보 → null', () => {
     const arrivals = [entry({ trainCode: '', arvlCd: 2 })];
     expect(pickAutoTrainCode(arrivals, '2호선', 'up')).toBeNull();
+  });
+});
+
+describe('evaluateHopEndPromptGates (#2034)', () => {
+  const NOW = 1_700_000_000_000;
+
+  it('promptState 없음 → pass=true', () => {
+    const r = evaluateHopEndPromptGates({ now: NOW });
+    expect(r.pass).toBe(true);
+    if (r.pass) expect(r.fusedSpeedKmh).toBe(0);
+  });
+
+  it('promptState.fired=true → already-fired 차단', () => {
+    const r = evaluateHopEndPromptGates({
+      promptState: { fired: true, lastFiredAt: NOW - 60_000 },
+      now: NOW,
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('already-fired');
+  });
+
+  it('promptState.silencedUntil 이 미래 → silenced 차단', () => {
+    const r = evaluateHopEndPromptGates({
+      promptState: { silencedUntil: NOW + 30_000 },
+      now: NOW,
+    });
+    expect(r.pass).toBe(false);
+    if (!r.pass) expect(r.reason).toBe('silenced');
+  });
+
+  it('promptState.silencedUntil 이 과거 → pass', () => {
+    const r = evaluateHopEndPromptGates({
+      promptState: { silencedUntil: NOW - 30_000 },
+      now: NOW,
+    });
+    expect(r.pass).toBe(true);
   });
 });

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -36,6 +36,8 @@ import {
   pickLatestCurrentStationName,
   resolveEtaMissingThreshold,
   buildBoardingPromptMessage,
+  buildHopEndPromptMessage,
+  maybeFireHopEndPrompt,
   runScheduled,
   tripLifecyclePhase,
   appendPassedStation,
@@ -141,6 +143,7 @@ function makeFullEmptyStats(): ScheduledStats {
     phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
     autoLockSuccess: 0, autoLockFalsePositive: 0, boardingPromptAutoDeduped: 0,
     boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0,
+    hopEndPromptFired: 0, hopEndPromptBlocked: 0,
     arvlCdFireSuccess: 0, arvlCdFireDedup: 0, arvlCdFireMismatch: 0,
     arvlCdFireBlocked: 0, arvlCdFireFired: 0,
     boardingLockWaypointAdvanceBlocked: 0, transferDestinationGateBlocked: 0,
@@ -8327,6 +8330,7 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
       phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
       autoLockSuccess: 0, autoLockFalsePositive: 0, boardingPromptAutoDeduped: 0,
       boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0,
+      hopEndPromptFired: 0, hopEndPromptBlocked: 0,
       arvlCdFireSuccess: 0, arvlCdFireDedup: 0, arvlCdFireMismatch: 0,
       arvlCdFireBlocked: 0, arvlCdFireFired: 0,
       boardingLockWaypointAdvanceBlocked: 0, transferDestinationGateBlocked: 0,
@@ -8917,6 +8921,212 @@ describe('buildBoardingPromptMessage (#1739 — 방면 + 시간 명시, #1895 �
   it('#1895 — locale=en + nextStation null → fallback 포맷 (locale 무관 공통 포맷)', () => {
     const { body } = buildBoardingPromptMessage('City Hall', '2', null, 90, BASE_NOW, 'en');
     expect(body).toBe('2 · City Hall');
+  });
+});
+
+describe('buildHopEndPromptMessage (#2034 — 환승역 하차 4언어)', () => {
+  it('ko 기본 — nextLine + nextStation 모두 있음', () => {
+    const { title, body } = buildHopEndPromptMessage('성수', '2', 'K', '왕십리');
+    expect(title).toBe('성수에서 하차하셨나요?');
+    expect(body).toBe('2호선 성수에서 내려주세요. 다음은 K호선 왕십리 방면입니다.');
+  });
+
+  it('ko — nextLine 있고 nextStation 없음 → line 만 노출', () => {
+    const { body } = buildHopEndPromptMessage('성수', '2', 'K', null);
+    expect(body).toBe('2호선 성수에서 내려주세요. 다음은 K호선 방면입니다.');
+  });
+
+  it('ko — nextLine null → 다음 leg 안내 생략', () => {
+    const { body } = buildHopEndPromptMessage('성수', '2', null, null);
+    expect(body).toBe('2호선 성수에서 내려주세요.');
+  });
+
+  it('en locale', () => {
+    const { title, body } = buildHopEndPromptMessage('Seongsu', '2', 'K', 'Wangsimni', 'en');
+    expect(title).toBe('Getting off at Seongsu?');
+    expect(body).toBe('Please transfer from line 2 at Seongsu. Next: line K toward Wangsimni.');
+  });
+
+  it('en — nextStation null', () => {
+    const { body } = buildHopEndPromptMessage('Seongsu', '2', 'K', null, 'en');
+    expect(body).toBe('Please transfer from line 2 at Seongsu. Next: line K.');
+  });
+
+  it('ja locale', () => {
+    const { title, body } = buildHopEndPromptMessage('聖水', '2', 'K', '往十里', 'ja');
+    expect(title).toBe('聖水で降りますか?');
+    expect(body).toBe('2号線 聖水で降車してください。 次はK号線 往十里方面です。');
+  });
+
+  it('ja — nextStation null', () => {
+    const { body } = buildHopEndPromptMessage('聖水', '2', 'K', null, 'ja');
+    expect(body).toBe('2号線 聖水で降車してください。 次はK号線です。');
+  });
+
+  it('zh locale', () => {
+    const { title, body } = buildHopEndPromptMessage('圣水', '2', 'K', '往十里', 'zh');
+    expect(title).toBe('您在圣水下车了吗?');
+    expect(body).toBe('请在2号线 圣水下车。 下一段: K号线 往十里方向。');
+  });
+
+  it('zh — nextStation null', () => {
+    const { body } = buildHopEndPromptMessage('圣水', '2', 'K', null, 'zh');
+    expect(body).toBe('请在2号线 圣水下车。 下一段: K号线。');
+  });
+
+  it('locale 미지정 → ko fallback', () => {
+    const { title } = buildHopEndPromptMessage('성수', '2', null, null, undefined);
+    expect(title).toBe('성수에서 하차하셨나요?');
+  });
+});
+
+describe('maybeFireHopEndPrompt (#2034)', () => {
+  function makeStats(): ScheduledStats {
+    return makeFullEmptyStats();
+  }
+
+  function makeDeps(fetchImpl: typeof fetch): ScheduledDeps {
+    return {
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl,
+      seoul: new SeoulArrivalClient({
+        host: 'seoul.api',
+        key: 'KEY',
+        fetchImpl,
+      }),
+      archFlag: 'off',
+    };
+  }
+
+  const transferWaypoint: Waypoint = {
+    stationName: '성수',
+    line: '2',
+    kind: 'transfer',
+  };
+
+  function makeTrip(): Trip {
+    return {
+      token: 'trip-hop-end',
+      createdAt: NOW,
+      waypoints: [
+        { stationName: '왕십리', line: 'K', kind: 'intermediate' },
+        { stationName: '수원', line: 'K', kind: 'destination' },
+      ],
+      apnsEnv: 'production',
+      registeredAt: NOW,
+    } as unknown as Trip;
+  }
+
+  it('promptState 없음 + APNs 200 → fired 카운터 증가 + hopEndPromptState[legKey] set', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    const trip = makeTrip();
+    const stats = makeStats();
+    await maybeFireHopEndPrompt({
+      trip,
+      transferWaypoint,
+      deps: makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      now: NOW,
+      log: () => {},
+      generatePushId: () => 'pid-hop',
+    });
+    expect(stats.hopEndPromptFired).toBe(1);
+    expect(stats.hopEndPromptBlocked).toBe(0);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    // legKey = "성수|K"
+    expect(trip.hopEndPromptState?.['성수|K']?.fired).toBe(true);
+    // payload wire 검증
+    const [, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.data.hopEndKind).toBe('disembark');
+    expect(body.data.nextLine).toBe('K');
+    expect(body.data.nextStation).toBe('왕십리');
+  });
+
+  it('promptState.fired=true → blocked 카운터 증가 + push 미발사', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    const trip = makeTrip();
+    trip.hopEndPromptState = { '성수|K': { fired: true, lastFiredAt: NOW - 60_000 } };
+    const stats = makeStats();
+    await maybeFireHopEndPrompt({
+      trip,
+      transferWaypoint,
+      deps: makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      now: NOW,
+      log: () => {},
+      generatePushId: () => 'pid-block',
+    });
+    expect(stats.hopEndPromptFired).toBe(0);
+    expect(stats.hopEndPromptBlocked).toBe(1);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('APNs 5xx → errors 카운터 증가 + hopEndPromptState 미갱신', async () => {
+    const fetchImpl = vi.fn(async () => new Response('bad', { status: 503 }));
+    const trip = makeTrip();
+    const stats = makeStats();
+    await maybeFireHopEndPrompt({
+      trip,
+      transferWaypoint,
+      deps: makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      now: NOW,
+      log: () => {},
+      generatePushId: () => 'pid-err',
+    });
+    expect(stats.errors).toBe(1);
+    expect(stats.hopEndPromptFired).toBe(0);
+    expect(trip.hopEndPromptState).toBeUndefined();
+  });
+
+  it('trip.waypoints 소진 (다음 leg 없음) → nextLine=null + nextStation=null', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    const trip = makeTrip();
+    trip.waypoints = [];
+    const stats = makeStats();
+    await maybeFireHopEndPrompt({
+      trip,
+      transferWaypoint,
+      deps: makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      now: NOW,
+      log: () => {},
+      generatePushId: () => 'pid-empty',
+    });
+    expect(stats.hopEndPromptFired).toBe(1);
+    const [, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect('nextLine' in body.data).toBe(false);
+    expect('nextStation' in body.data).toBe(false);
+    // legKey = "성수|"
+    expect(trip.hopEndPromptState?.['성수|']?.fired).toBe(true);
+  });
+
+  it('leg-key 별 dedup — 다른 nextLine 은 독립 발사', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    const trip = makeTrip();
+    // 첫 번째 leg (2 → K) 는 이미 fired.
+    trip.hopEndPromptState = { '성수|K': { fired: true, lastFiredAt: NOW - 60_000 } };
+    // 다음 leg 를 다른 노선 (5호선) 으로 변경.
+    trip.waypoints = [
+      { stationName: '아차산', line: '5', kind: 'intermediate' },
+    ];
+    const stats = makeStats();
+    await maybeFireHopEndPrompt({
+      trip,
+      transferWaypoint,
+      deps: makeDeps(fetchImpl as unknown as typeof fetch),
+      stats,
+      now: NOW,
+      log: () => {},
+      generatePushId: () => 'pid-diff-leg',
+    });
+    expect(stats.hopEndPromptFired).toBe(1);
+    // 기존 legKey 는 유지, 새 legKey (`성수|5`) 는 신규 fired.
+    expect(trip.hopEndPromptState?.['성수|K']?.fired).toBe(true);
+    expect(trip.hopEndPromptState?.['성수|5']?.fired).toBe(true);
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -8992,7 +8992,7 @@ describe('maybeFireHopEndPrompt (#2034)', () => {
       fetchImpl,
       seoul: new SeoulArrivalClient({
         host: 'seoul.api',
-        key: 'KEY',
+        apiKey: 'KEY',
         fetchImpl,
       }),
       archFlag: 'off',

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -733,6 +733,17 @@ export interface SendBoardingPromptPushOptions {
    * 미지정 또는 빈 배열이면 payload `data.candidateTrains` omit (구 device byte-level 호환).
    */
   candidateTrains?: BoardingPromptCandidate[];
+  /**
+   * #2034 — hop-end (환승역 하차) 프롬프트 분기 신호. 미지정 = 일반 boarding prompt (승차).
+   * 'disembark' = "하차했나요?" 프롬프트. device 가 payload 를 파싱해 title/body/버튼 액션 매핑을
+   * 분기 처리. hop-end 시 caller 는 `nextLine` / `nextStation` 도 함께 전달해 UI 에 "다음 열차:
+   * X 호선 Y 역" 정보 노출.
+   */
+  hopEndKind?: 'disembark';
+  /** #2034 — hop-end 시 다음 leg 노선. 미지정이면 device 가 `line` 을 fallback. */
+  nextLine?: string;
+  /** #2034 — hop-end 시 다음 leg 출발역. 미지정이면 device UI 에서 next-line 만 표시. */
+  nextStation?: string;
   config: ApnsConfig;
   host: string;
   fetchImpl?: typeof fetch;
@@ -779,6 +790,11 @@ function buildBoardingPromptPushData(
     ...bodyFragment,
     // #1888 (RC-13) — candidateTrains는 0건이면 omit (구 device byte-level 호환 + payload 크기 보호).
     ...candidatesFragment,
+    // #2034 — hop-end 프롬프트 (환승역 하차) 필드. 미지정이면 payload 에서 자연 누락 →
+    // 기존 boarding-prompt 소비 device 와 byte-level 호환.
+    ...(options.hopEndKind !== undefined ? { hopEndKind: options.hopEndKind } : {}),
+    ...(options.nextLine !== undefined ? { nextLine: options.nextLine } : {}),
+    ...(options.nextStation !== undefined ? { nextStation: options.nextStation } : {}),
   };
 }
 

--- a/backend/alarm-worker/src/boardingPrompt.ts
+++ b/backend/alarm-worker/src/boardingPrompt.ts
@@ -324,6 +324,29 @@ export function markPromptSilenced(
 }
 
 /**
+ * #2034 — hop-end (환승역 "하차했나요?") 프롬프트 게이트.
+ *
+ * 발사 조건은 boarding-prompt 대비 훨씬 단순하다 — transfer waypoint advance = "환승역 도착 판정"
+ * 은 이미 caller (scheduled.ts) 의 boarding-lock waypoint advance 게이트가 통과된 상태이므로
+ * ground truth 로 다뤄지고, GPS/motion/speed 는 재검증하지 않는다. false-positive 방어는:
+ *   - fired dedup (같은 leg 는 1회만 발사)
+ *   - silencedUntil (사용자 [아직] 응답 시 5 분 재발사 차단)
+ *
+ * caller 는 leg-key (예: `${originStation}|${nextLine}`) 로 `trip.hopEndPromptState[key]` 를 조회해
+ * 이 함수에 전달한다.
+ */
+export function evaluateHopEndPromptGates(inputs: {
+  promptState?: BoardingPromptState;
+  now: number;
+}): GateOutcome {
+  const silenceOutcome = evaluateSilenceGate(inputs.promptState, inputs.now);
+  if (silenceOutcome) return silenceOutcome;
+  // GPS/motion 게이트 없이 통과. fusedSpeed 는 caller 가 사용하지 않는 필드지만 GateOutcome
+  // 계약 준수를 위해 0 을 반환 (evaluateBoardingPromptGates bypass 분기와 동일 정책).
+  return { pass: true, metrics: evaluateWindow([], inputs.now), fusedSpeedKmh: 0 };
+}
+
+/**
  * arvlCd 우선순위로 trainCode 자동 선택 (ADR Section 1.2).
  *
  * 같은 line + 진행 방향 매칭하는 후보 중:

--- a/backend/alarm-worker/src/i18n.ts
+++ b/backend/alarm-worker/src/i18n.ts
@@ -31,9 +31,27 @@ export interface BoardingPromptArgs {
   etaTimeStr: string | null;
 }
 
+/**
+ * #2034 — hop-end prompt body 인자.
+ * - `transferStation`: 사용자가 하차해야 하는 환승역 이름
+ * - `line`: 직전 leg 노선 (하차 대상)
+ * - `nextLine`: 다음 leg 노선 (승차 대상). null 이면 UI 에서 next-leg 안내 생략.
+ * - `nextStation`: 다음 leg 첫 정거장. null 이면 line 만 노출.
+ */
+export interface HopEndPromptArgs {
+  transferStation: string;
+  line: string;
+  nextLine: string | null;
+  nextStation: string | null;
+}
+
 interface I18nStrings {
   boardingPromptTitle: string;
   boardingPromptBody: (args: BoardingPromptArgs) => string;
+  /** #2034 — hop-end (환승역 하차) 알림 title. */
+  hopEndPromptTitle: (args: { transferStation: string }) => string;
+  /** #2034 — hop-end (환승역 하차) 알림 body. */
+  hopEndPromptBody: (args: HopEndPromptArgs) => string;
 }
 
 /**
@@ -51,6 +69,13 @@ const I18N: Record<SupportedLocale, I18nStrings> = {
       const time = etaTimeStr ? ` ${etaTimeStr} 진입` : '';
       return `${originStation} [${line}] → ${nextStation} 방면${time}`;
     },
+    hopEndPromptTitle: ({ transferStation }) => `${transferStation}에서 하차하셨나요?`,
+    hopEndPromptBody: ({ transferStation, line, nextLine, nextStation }) => {
+      const from = `${line}호선 ${transferStation}에서 내려주세요.`;
+      if (!nextLine) return from;
+      const next = nextStation ? `${nextLine}호선 ${nextStation}` : `${nextLine}호선`;
+      return `${from} 다음은 ${next} 방면입니다.`;
+    },
   },
   en: {
     boardingPromptTitle: 'Are you on board?',
@@ -58,6 +83,13 @@ const I18N: Record<SupportedLocale, I18nStrings> = {
       if (!nextStation) return `${line} · ${originStation}`;
       const time = etaTimeStr ? ` ${etaTimeStr} arrival` : '';
       return `${originStation} [${line}] → ${nextStation} bound${time}`;
+    },
+    hopEndPromptTitle: ({ transferStation }) => `Getting off at ${transferStation}?`,
+    hopEndPromptBody: ({ transferStation, line, nextLine, nextStation }) => {
+      const from = `Please transfer from line ${line} at ${transferStation}.`;
+      if (!nextLine) return from;
+      const next = nextStation ? `line ${nextLine} toward ${nextStation}` : `line ${nextLine}`;
+      return `${from} Next: ${next}.`;
     },
   },
   ja: {
@@ -67,6 +99,13 @@ const I18N: Record<SupportedLocale, I18nStrings> = {
       const time = etaTimeStr ? ` ${etaTimeStr}進入` : '';
       return `${originStation} [${line}] → ${nextStation}方面${time}`;
     },
+    hopEndPromptTitle: ({ transferStation }) => `${transferStation}で降りますか?`,
+    hopEndPromptBody: ({ transferStation, line, nextLine, nextStation }) => {
+      const from = `${line}号線 ${transferStation}で降車してください。`;
+      if (!nextLine) return from;
+      const next = nextStation ? `${nextLine}号線 ${nextStation}方面` : `${nextLine}号線`;
+      return `${from} 次は${next}です。`;
+    },
   },
   zh: {
     boardingPromptTitle: '您已乘车了吗?',
@@ -74,6 +113,13 @@ const I18N: Record<SupportedLocale, I18nStrings> = {
       if (!nextStation) return `${line} · ${originStation}`;
       const time = etaTimeStr ? ` ${etaTimeStr}到达` : '';
       return `${originStation} [${line}] → ${nextStation}方向${time}`;
+    },
+    hopEndPromptTitle: ({ transferStation }) => `您在${transferStation}下车了吗?`,
+    hopEndPromptBody: ({ transferStation, line, nextLine, nextStation }) => {
+      const from = `请在${line}号线 ${transferStation}下车。`;
+      if (!nextLine) return from;
+      const next = nextStation ? `${nextLine}号线 ${nextStation}方向` : `${nextLine}号线`;
+      return `${from} 下一段: ${next}。`;
     },
   },
 };

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -18,6 +18,7 @@ import type { ArchFlagValue } from './archFlag';
 import { AUTO_PROMPT_DEDUP_WINDOW_MS } from './autoLock';
 import {
   evaluateBoardingPromptGates,
+  evaluateHopEndPromptGates,
   markPromptFired,
   pickAutoTrainCode,
   type GateSkipReason,
@@ -557,6 +558,17 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   boardingPromptSkippedLockActive: number;
   /**
+   * #2034 — 환승 waypoint advance 시점에 hop-end ("하차했나요?") prompt 게이트를 통과해 alert
+   * push 가 발사된 누적 횟수. leg 단위 dedup 이라 같은 trip 내 여러 환승도 각각 카운트.
+   * dashboard: `hop_end_prompt_fired`.
+   */
+  hopEndPromptFired: number;
+  /**
+   * #2034 — hop-end prompt 게이트가 dedup/silence 로 차단해 미발사한 누적 횟수. 사용자 [아직]
+   * 응답 후 5 분 silence 윈도우가 정상 동작하는지 관측용.
+   */
+  hopEndPromptBlocked: number;
+  /**
    * #917 A2 — boardingLock 활성 trip에서 Seoul arrivals의 arvlCd∈{0(ENTERING), 1(ARRIVED)}
    * 신호로 매역 station-passed silent push가 성공 발사된 누적 횟수. 매역 알림 1차 source는
    * GPS가 아니라 이 신호 — 다운로드 가치 직결(지하/지상 무관).
@@ -872,6 +884,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     boardingPromptAutoDeduped: 0,
     boardingPromptSkippedEmpty: 0,
     boardingPromptSkippedLockActive: 0,
+    hopEndPromptFired: 0,
+    hopEndPromptBlocked: 0,
     arvlCdFireSuccess: 0,
     arvlCdFireDedup: 0,
     arvlCdFireMismatch: 0,
@@ -2981,6 +2995,21 @@ export async function advanceBoardingLockWaypoint(
       );
     }
   }
+  // #2034 — 환승 waypoint advance = "환승역 도착". 사용자에게 "하차했나요?" hop-end 프롬프트를
+  // 발사해 다음 leg 진입을 명시 확인하도록 유도. lock 활성 여부와 무관 (transfer 직후 lock 은 이미
+  // release 됐거나 애초에 lockless leg 였다). 게이트는 leg-key (`${transferStation}|${nextLine}`)
+  // 로 fired/silence dedup 만 유지 — GPS/motion 검증 없이 waypoint advance = ground truth.
+  if (waypoint.kind === 'transfer') {
+    await maybeFireHopEndPrompt({
+      trip,
+      transferWaypoint: waypoint,
+      deps,
+      stats,
+      now,
+      log,
+      generatePushId: () => crypto.randomUUID(),
+    });
+  }
   // #1729 paradigm shift — 환승 직후 자동 trainCode swap 제거(Path B' 환승 버전).
   // 사용자가 BoardingTrainList에서 명시 탭하지 않은 trainCode에 backend가 자동으로 lock 부착 X.
   // 다음 cron cycle에서 lockMissing → evaluateAndMaybeFireBoardingPrompt → boardingPrompt push 발사.
@@ -3600,6 +3629,26 @@ export function buildBoardingPromptMessage(
 }
 
 /**
+ * #2034 — 환승역 hop-end ("하차했나요?") 알림 title/body 를 4언어 (ko/en/ja/zh) 로 빌드.
+ *
+ * caller (환승 waypoint advance 시점) 는 `transferStation` / `line` (직전 leg) / `nextLine` /
+ * `nextStation` 을 넘긴다. i18n 는 locale 자동 fallback.
+ */
+export function buildHopEndPromptMessage(
+  transferStation: string,
+  line: string,
+  nextLine: string | null,
+  nextStation: string | null,
+  locale?: SupportedLocale,
+): { title: string; body: string } {
+  const strings = t(locale);
+  return {
+    title: strings.hopEndPromptTitle({ transferStation }),
+    body: strings.hopEndPromptBody({ transferStation, line, nextLine, nextStation }),
+  };
+}
+
+/**
  * APNs 토큰 환경(sandbox/production)과 host가 어긋났을 때 Apple이 내는 시그널.
  * 이 조건에 한해서만 self-heal retry를 시도한다.
  */
@@ -3953,5 +4002,113 @@ export async function evaluateAndMaybeFireBoardingPrompt(
 
   if (dirty) {
     await putTrip(env.TRIPS, trip);
+  }
+}
+
+/**
+ * #2034 — hop-end (환승역 "하차했나요?") prompt 평가 + 발사.
+ *
+ * caller: 환승 waypoint advance 직후 (waypoint.kind === 'transfer' 로 shift 된 시점).
+ * transferWaypoint 는 방금 통과한 (직전 leg 끝) waypoint — trip.waypoints[0] 은 이미 다음 leg
+ * 첫 정거장. leg-key (`${transferStation}|${nextLine ?? ''}`) 로 dedup — 같은 trip 에 여러 환승이
+ * 있어도 각 환승은 독립적으로 발사.
+ *
+ * 게이트: `evaluateHopEndPromptGates` (fired dedup + silencedUntil 만). transfer waypoint advance
+ * 자체가 ground truth 이므로 GPS/motion/speed 재검증 없음. false-positive 방어는 caller (advance
+ * gate) + silence dedup 로 충분.
+ *
+ * 발사 성공:
+ *   - alert push (BOARDING_PROMPT category, hopEndKind='disembark') → device 가 payload 를 파싱해
+ *     "하차했나요?" 프롬프트 노출.
+ *   - trip.hopEndPromptState[key] = markPromptFired(now).
+ *   - stats.hopEndPromptFired += 1.
+ * 차단: stats.hopEndPromptBlocked += 1 + reason log.
+ */
+export async function maybeFireHopEndPrompt(inputs: {
+  trip: Trip;
+  transferWaypoint: Waypoint;
+  deps: ScheduledDeps;
+  stats: ScheduledStats;
+  now: number;
+  log: Logger;
+  generatePushId: () => string;
+}): Promise<void> {
+  const { trip, transferWaypoint, deps, stats, now, log, generatePushId } = inputs;
+  const nextWaypoint = trip.waypoints[0];
+  const nextLine = nextWaypoint?.line ?? null;
+  const nextStation = nextWaypoint?.stationName ?? null;
+  const legKey = `${transferWaypoint.stationName}|${nextLine ?? ''}`;
+  const stateMap = trip.hopEndPromptState ?? {};
+  const outcome = evaluateHopEndPromptGates({ promptState: stateMap[legKey], now });
+  if (!outcome.pass) {
+    stats.hopEndPromptBlocked += 1;
+    log('hop-end-prompt: gate blocked', {
+      token: trip.token.slice(0, 8),
+      legKey,
+      reason: outcome.reason,
+    });
+    return;
+  }
+  const { title, body } = buildHopEndPromptMessage(
+    transferWaypoint.stationName,
+    transferWaypoint.line,
+    nextLine,
+    nextStation,
+    trip.locale,
+  );
+  const pushId = generatePushId();
+  const heal = await sendWithEnvHeal(
+    (host) =>
+      sendBoardingPromptPush({
+        deviceToken: trip.token,
+        pushId,
+        title,
+        body,
+        // originStation 필드는 hop-end 시 "하차 대상 역 (환승역)" 으로 재해석 — device 가
+        // hopEndKind='disembark' 를 보고 이 의미로 파싱.
+        originStation: transferWaypoint.stationName,
+        line: transferWaypoint.line,
+        tripToken: trip.token,
+        sentAt: now,
+        triggerKind: 'cron',
+        hopEndKind: 'disembark',
+        ...(nextLine !== null ? { nextLine } : {}),
+        ...(nextStation !== null ? { nextStation } : {}),
+        config: deps.apnsConfig,
+        host,
+        fetchImpl: deps.fetchImpl,
+        now,
+      }),
+    trip.apnsEnv,
+    deps.apnsHosts,
+    log,
+    trip.token.slice(0, 8),
+  );
+  if (heal.correctedEnv) {
+    trip.apnsEnv = heal.correctedEnv;
+    stats.envCorrected += 1;
+  }
+  if (heal.result.ok) {
+    stats.hopEndPromptFired += 1;
+    stats.silentPushFiredByKind.boardingPrompt += 1;
+    trip.hopEndPromptState = {
+      ...stateMap,
+      [legKey]: markPromptFired(now),
+    };
+    log('hop-end-prompt: fired', {
+      token: trip.token.slice(0, 8),
+      transferStation: transferWaypoint.stationName,
+      line: transferWaypoint.line,
+      nextLine,
+      nextStation,
+    });
+  } else {
+    stats.errors += 1;
+    log('hop-end-prompt: push failed', {
+      token: trip.token.slice(0, 8),
+      legKey,
+      status: heal.result.status,
+      reason: heal.result.reason,
+    });
   }
 }

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -183,6 +183,13 @@ export interface Trip {
    */
   lastAutoPromptedAt?: number;
   /**
+   * #2034 — 환승역 "하차했나요?" hop-end 프롬프트 발사 상태. `boardingPromptState` 와 분리해
+   * 동일 trip 내에서 boarding 응답 후에도 hop-end 는 별도로 발사되도록 보장 (한 trip 에 여러 leg 가
+   * 있을 때 각 leg 종료마다 발사). key = `${originStation}|${nextLine ?? ''}` 로 leg 별 dedup.
+   * 미지정 = 아직 발사 안 됨.
+   */
+  hopEndPromptState?: Record<string, BoardingPromptState>;
+  /**
    * boarding-prompt 평가용 출발역/다음역 좌표 (#819 게이트 #4/#5).
    * backend는 stations.json을 갖지 않으므로 클라이언트가 trip 등록 시 함께 보낸다.
    * 부재 시 boarding-prompt 평가 자체를 skip — 좌표 없는 lockMissing trip은 silent.
@@ -527,13 +534,38 @@ export interface BoardingPromptCandidate {
 export interface BoardingPromptPushPayload {
   pushId: string;
   kind: 'boarding-prompt';
-  /** 사용자 출발역 (lock 생성 시 boardingStation으로 사용). */
+  /**
+   * 사용자 출발역. hop-end 프롬프트(#2034) 일 때는 "환승 지점 역명" 으로 재해석되며 (=사용자가
+   * 하차해야 하는 station). 일반 boarding-prompt 시엔 boardingStation 으로 그대로 사용.
+   */
   originStation: string;
-  /** 출발 노선 (lock 생성 시 boardingLine으로 사용). */
+  /**
+   * 노선. hop-end 프롬프트(#2034) 일 때는 "직전 leg 노선" (하차 대상). 일반 boarding-prompt 는
+   * 승차 대상 노선. `nextLine` 을 별도로 붙여 다음 leg 노선을 표시.
+   */
   line: string;
   /** trip 토큰 — 푸시 응답 시점에 trip 컨텍스트 복원용. */
   tripToken: string;
   sentAt: number;
+  /**
+   * #2034 — hop-end (환승역 하차) 프롬프트 분기. 미지정(legacy) = 기존 boarding (승차) 프롬프트.
+   * 'disembark' = 환승역 도착 → "하차했나요?" UI. device 는 이 필드로 title/body/response 처리를
+   * 분기하며, 응답이 hop-end 확정([하차함]) 시 다음 leg 로 진입.
+   *
+   * 확장 여지: 'destination-arrival' 등 도착 전 prompt 유형을 추가하는 경우에도 같은 payload 스키마
+   * 를 재사용할 수 있도록 union 형태로 유지.
+   */
+  hopEndKind?: 'disembark';
+  /**
+   * #2034 — hop-end 프롬프트에서 사용자가 [하차함] 시 다음에 탑승해야 하는 노선. line 과 다른 값 (환승).
+   * 미지정이면 device 가 line 을 그대로 fallback (동일 노선 계속).
+   */
+  nextLine?: string;
+  /**
+   * #2034 — hop-end 프롬프트에서 사용자가 [하차함] 시 다음에 탑승해야 하는 역. 다음 leg 의 출발역.
+   * 미지정이면 device 가 UI 에 next-line 만 표시.
+   */
+  nextStation?: string;
   /**
    * #1536 (S3, T13) — trigger source 구분.
    *

--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -62,15 +62,17 @@ jest.mock('../../../../shared/utils/logger', () => ({
 // 만들고, 테스트는 requireMock으로 접근한다.
 jest.mock('../../store/useBoardingLockStore', () => {
   const mockCreateLock = jest.fn();
+  const mockReleaseLock = jest.fn(() => Promise.resolve());
   return {
     useBoardingLockStore: Object.assign(
-      (selector: (state: { createLock: jest.Mock }) => unknown) =>
-        selector({ createLock: mockCreateLock }),
+      (selector: (state: { createLock: jest.Mock; releaseLock: jest.Mock }) => unknown) =>
+        selector({ createLock: mockCreateLock, releaseLock: mockReleaseLock }),
       {
-        getState: () => ({ createLock: mockCreateLock }),
+        getState: () => ({ createLock: mockCreateLock, releaseLock: mockReleaseLock }),
       },
     ),
     __mockCreateLock: mockCreateLock,
+    __mockReleaseLock: mockReleaseLock,
   };
 });
 
@@ -94,7 +96,7 @@ const {
 const { addDomainBreadcrumb } = jest.requireMock(
   '../../../../shared/infra/monitoring/breadcrumb',
 );
-const { __mockCreateLock: createLockMock } = jest.requireMock(
+const { __mockCreateLock: createLockMock, __mockReleaseLock: releaseLockMock } = jest.requireMock(
   '../../store/useBoardingLockStore',
 );
 const { __mockSetInfoModeEnabled: setInfoModeEnabledMock } = jest.requireMock(
@@ -723,10 +725,11 @@ describe('handleResponse — #1888 RC-13 Sentry breadcrumb evidence', () => {
   ])('%s → boarding_prompt_interactive_tap breadcrumb 발사', async (_label, action) => {
     (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
     await handleResponse(action, HANDLE_RESPONSE_PAYLOAD, makeHandleResponseDeps());
+    // #2034 — hopEndKind='boarding' 은 승차 prompt 기본값. hop-end 는 'disembark' 로 별개 test.
     expect(addDomainBreadcrumb).toHaveBeenCalledWith(
       'boarding',
       'boarding_prompt_interactive_tap',
-      { action, line: '2' },
+      { action, line: '2', hopEndKind: 'boarding' },
     );
   });
 
@@ -855,5 +858,169 @@ describe('handleResponse — #1888 RC-13 onBannerTap navigation', () => {
     await handleResponse(Notifications.DEFAULT_ACTION_IDENTIFIER, HANDLE_RESPONSE_PAYLOAD, deps);
     // destinationId null → tryAutoLock 진입 → dismiss POST → 그 뒤 onBannerTap 호출.
     expect(onBannerTap).toHaveBeenCalledTimes(1);
+  });
+});
+
+// #2034 — hop-end (환승역 "하차했나요?") 응답 처리.
+describe('handleResponse — #2034 hop-end', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const HOP_END_PAYLOAD = {
+    kind: 'boarding-prompt' as const,
+    originStation: '성수',
+    line: '2',
+    tripToken: 'tok-hop',
+    hopEndKind: 'disembark' as const,
+    nextLine: 'K',
+    nextStation: '왕십리',
+  };
+
+  it('extractBoardingPromptPayload — hopEndKind + nextLine + nextStation 보존', () => {
+    expect(
+      extractBoardingPromptPayload({
+        kind: 'boarding-prompt',
+        originStation: '성수',
+        line: '2',
+        tripToken: 'tok-hop',
+        hopEndKind: 'disembark',
+        nextLine: 'K',
+        nextStation: '왕십리',
+      }),
+    ).toEqual({
+      kind: 'boarding-prompt',
+      originStation: '성수',
+      line: '2',
+      tripToken: 'tok-hop',
+      destinationDirection: undefined,
+      hopEndKind: 'disembark',
+      nextLine: 'K',
+      nextStation: '왕십리',
+    });
+  });
+
+  it('extractBoardingPromptPayload — hopEndKind 이 아닌 값이면 undefined 로 정규화', () => {
+    const r = extractBoardingPromptPayload({
+      kind: 'boarding-prompt',
+      originStation: '성수',
+      line: '2',
+      tripToken: 'tok-hop',
+      hopEndKind: 'invalid',
+    });
+    expect(r?.hopEndKind).toBeUndefined();
+  });
+
+  it('[하차함] (BOARDED action) → releaseLock 호출 + tryAutoLock 진입 X + logBoardingPromptResponded(boarded)', async () => {
+    await handleResponse(
+      BOARDING_PROMPT_ACTION_BOARDED,
+      HOP_END_PAYLOAD,
+      makeHandleResponseDeps(),
+    );
+    expect(releaseLockMock).toHaveBeenCalledTimes(1);
+    expect(releaseLockMock).toHaveBeenCalledWith('user');
+    // hop-end 는 autoLock 시도 안 함 — createLock 는 호출되면 안 됨.
+    expect(createLockMock).not.toHaveBeenCalled();
+    expect(logBoardingPromptResponded).toHaveBeenCalledWith({ outcome: 'boarded' });
+    // dismiss POST 는 호출 안 함 — 이미 backend 가 fired stamp 완료.
+    expect(positionUpload.dismissBoardingPrompt).not.toHaveBeenCalled();
+  });
+
+  it('[아직] (NOT_BOARDED action) → dismissBoardingPrompt POST + logBoardingPromptResponded(dismissed)', async () => {
+    await handleResponse(
+      BOARDING_PROMPT_ACTION_NOT_BOARDED,
+      HOP_END_PAYLOAD,
+      makeHandleResponseDeps(),
+    );
+    expect(positionUpload.dismissBoardingPrompt).toHaveBeenCalledWith('tok-hop');
+    expect(logBoardingPromptResponded).toHaveBeenCalledWith({ outcome: 'dismissed' });
+    // releaseLock 은 [아직] 응답 시 호출 안 함 — lock 유지.
+    expect(releaseLockMock).not.toHaveBeenCalled();
+  });
+
+  it('$default (banner tap) → releaseLock + onBannerTap 호출', async () => {
+    const onBannerTap = jest.fn();
+    await handleResponse(
+      Notifications.DEFAULT_ACTION_IDENTIFIER,
+      HOP_END_PAYLOAD,
+      makeHandleResponseDeps({ onBannerTap }),
+    );
+    expect(releaseLockMock).toHaveBeenCalledTimes(1);
+    expect(onBannerTap).toHaveBeenCalledTimes(1);
+  });
+
+  it('알 수 없는 action → dismiss path 진입', async () => {
+    await handleResponse(
+      'UNKNOWN_ACTION',
+      HOP_END_PAYLOAD,
+      makeHandleResponseDeps(),
+    );
+    expect(positionUpload.dismissBoardingPrompt).toHaveBeenCalledWith('tok-hop');
+    expect(releaseLockMock).not.toHaveBeenCalled();
+  });
+
+  it('breadcrumb "boarding_prompt_interactive_tap" 에 hopEndKind=disembark 스탬프', async () => {
+    await handleResponse(
+      BOARDING_PROMPT_ACTION_BOARDED,
+      HOP_END_PAYLOAD,
+      makeHandleResponseDeps(),
+    );
+    expect(addDomainBreadcrumb).toHaveBeenCalledWith(
+      'boarding',
+      'boarding_prompt_interactive_tap',
+      { action: BOARDING_PROMPT_ACTION_BOARDED, line: '2', hopEndKind: 'disembark' },
+    );
+  });
+
+  it('breadcrumb "hop_end_prompt_confirmed" ([하차함] 시)', async () => {
+    await handleResponse(
+      BOARDING_PROMPT_ACTION_BOARDED,
+      HOP_END_PAYLOAD,
+      makeHandleResponseDeps(),
+    );
+    expect(addDomainBreadcrumb).toHaveBeenCalledWith(
+      'boarding',
+      'hop_end_prompt_confirmed',
+      { line: '2', nextLine: 'K' },
+    );
+  });
+
+  it('breadcrumb "hop_end_prompt_dismissed" ([아직] 시)', async () => {
+    await handleResponse(
+      BOARDING_PROMPT_ACTION_NOT_BOARDED,
+      HOP_END_PAYLOAD,
+      makeHandleResponseDeps(),
+    );
+    expect(addDomainBreadcrumb).toHaveBeenCalledWith(
+      'boarding',
+      'hop_end_prompt_dismissed',
+      { line: '2' },
+    );
+  });
+
+  it('releaseLock 실패해도 응답 처리 계속 진행 (graceful)', async () => {
+    releaseLockMock.mockImplementationOnce(() => Promise.reject(new Error('release failed')));
+    await expect(
+      handleResponse(
+        BOARDING_PROMPT_ACTION_BOARDED,
+        HOP_END_PAYLOAD,
+        makeHandleResponseDeps(),
+      ),
+    ).resolves.not.toThrow();
+    expect(logBoardingPromptResponded).toHaveBeenCalledWith({ outcome: 'boarded' });
+  });
+
+  it('nextLine 없음 → breadcrumb 에 nextLine="" 로 stamp (undefined 회피)', async () => {
+    const payloadNoNext = { ...HOP_END_PAYLOAD, nextLine: undefined };
+    await handleResponse(
+      BOARDING_PROMPT_ACTION_BOARDED,
+      payloadNoNext,
+      makeHandleResponseDeps(),
+    );
+    expect(addDomainBreadcrumb).toHaveBeenCalledWith(
+      'boarding',
+      'hop_end_prompt_confirmed',
+      { line: '2', nextLine: '' },
+    );
   });
 });

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -64,6 +64,15 @@ export interface BoardingPromptPayload {
    * 미지정 시 양방향 모두 후보로 허용 (backward compat).
    */
   destinationDirection?: 'up' | 'down';
+  /**
+   * #2034 — hop-end (환승역 하차) 분기 신호. 미지정 = 승차 프롬프트 (기존 동작).
+   * 'disembark' = "하차했나요?" — [탑승] 액션은 하차 확인 (다음 leg 진입), [미탑승] = 아직 도착 안 함.
+   */
+  hopEndKind?: 'disembark';
+  /** #2034 — hop-end 시 다음 leg 노선 (UI 표시 + 후속 동작 힌트). */
+  nextLine?: string;
+  /** #2034 — hop-end 시 다음 leg 출발역. */
+  nextStation?: string;
 }
 
 export function extractBoardingPromptPayload(
@@ -79,12 +88,20 @@ export function extractBoardingPromptPayload(
     o.destinationDirection === 'up' || o.destinationDirection === 'down'
       ? (o.destinationDirection as 'up' | 'down')
       : undefined;
+  const hopEndKind = o.hopEndKind === 'disembark' ? 'disembark' : undefined;
+  const nextLine =
+    typeof o.nextLine === 'string' && o.nextLine.length > 0 ? o.nextLine : undefined;
+  const nextStation =
+    typeof o.nextStation === 'string' && o.nextStation.length > 0 ? o.nextStation : undefined;
   return {
     kind: 'boarding-prompt',
     originStation: o.originStation,
     line: o.line,
     tripToken: o.tripToken,
     destinationDirection,
+    hopEndKind,
+    nextLine,
+    nextStation,
   };
 }
 
@@ -173,7 +190,15 @@ export async function handleResponse(
   addDomainBreadcrumb('boarding', 'boarding_prompt_interactive_tap', {
     action: actionIdentifier,
     line: payload.line,
+    hopEndKind: payload.hopEndKind ?? 'boarding',
   });
+
+  // #2034 — hop-end (환승역 하차) 분기 처리. 기존 boarding 승차 prompt 처리와 완전 분리해
+  // autoLock 시도를 skip 하고 [하차함]/[아직] 만 처리한다.
+  if (payload.hopEndKind === 'disembark') {
+    await handleHopEndResponse(actionIdentifier, payload, deps);
+    return;
+  }
 
   if (
     actionIdentifier === BOARDING_PROMPT_ACTION_BOARDED ||
@@ -202,6 +227,56 @@ export async function handleResponse(
   // [미탑승] 또는 dismiss — 5분 silence.
   // #1170 — dismissed 측정. dismiss POST 결과(네트워크 성공/실패)와 무관하게 사용자 인지 기준 적재.
   logBoardingPromptResponded({ outcome: 'dismissed' });
+  await dismissBoardingPrompt(payload.tripToken);
+}
+
+/**
+ * #2034 — hop-end (환승역 "하차했나요?") 응답 처리.
+ *
+ * - BOARDED action / $default (banner tap): [하차함] 확정. 기존 lock 을 clear (직전 leg 종료).
+ *   backend 는 이미 hop-end fire 성공 시 hopEndPromptState[legKey].fired=true 로 stamp 했으므로
+ *   추가 backend call 은 불필요. 다음 leg boardingPrompt 는 backend cron 이 다음 cycle 에 자연 발사.
+ * - NOT_BOARDED / dismiss: [아직] 응답. 5 분 silence 를 위해 dismissBoardingPrompt POST — backend
+ *   가 boardingPromptState.silencedUntil 로 재발사 차단.
+ *
+ * banner tap ($default) 은 사용자가 다음 leg 정보를 보고 싶다는 신호 → onBannerTap 으로 navigate.
+ */
+async function handleHopEndResponse(
+  actionIdentifier: string,
+  payload: BoardingPromptPayload,
+  deps: HandleDeps,
+): Promise<void> {
+  if (
+    actionIdentifier === BOARDING_PROMPT_ACTION_BOARDED ||
+    actionIdentifier === Notifications.DEFAULT_ACTION_IDENTIFIER
+  ) {
+    logBoardingPromptResponded({ outcome: 'boarded' });
+    addDomainBreadcrumb('boarding', 'hop_end_prompt_confirmed', {
+      line: payload.line,
+      nextLine: payload.nextLine ?? '',
+    });
+    // 기존 lock 이 남아 있으면 clear — backend 는 transfer waypoint advance 시 이미 release 했지만
+    // race 방어. releaseLock 은 idempotent (lock 없으면 no-op). reason='user' 로 stamp — 사용자
+    // 명시 [하차함] 응답이 트리거이므로 breadcrumb 상 user-initiated 로 분류.
+    // 참고: 승차 prompt 와 달리 hop-end 는 setInfoModeEnabled(true) 를 호출하지 않는다 — 다음 leg
+    // 는 새 승차 prompt 를 통해 사용자 명시 의향을 별도로 stamp 해야 함.
+    try {
+      await useBoardingLockStore.getState().releaseLock('user');
+    } catch (err) {
+      log.warn('hop-end releaseLock failed', err as Error);
+    }
+    if (
+      actionIdentifier === Notifications.DEFAULT_ACTION_IDENTIFIER &&
+      deps.onBannerTap !== undefined
+    ) {
+      deps.onBannerTap();
+    }
+    return;
+  }
+  logBoardingPromptResponded({ outcome: 'dismissed' });
+  addDomainBreadcrumb('boarding', 'hop_end_prompt_dismissed', {
+    line: payload.line,
+  });
   await dismissBoardingPrompt(payload.tripToken);
 }
 

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -1116,6 +1116,9 @@ describe('silentPushTask', () => {
           destinationDirection: 'up',
           title: '탑승하셨나요?',
           body: '2호선 강남에서 열차가 곧 도착합니다.',
+          hopEndKind: undefined,
+          nextLine: undefined,
+          nextStation: undefined,
         });
       });
 
@@ -1193,6 +1196,9 @@ describe('silentPushTask', () => {
           destinationDirection: undefined,
           title: undefined,
           body: undefined,
+          hopEndKind: undefined,
+          nextLine: undefined,
+          nextStation: undefined,
         });
       });
 
@@ -1223,6 +1229,57 @@ describe('silentPushTask', () => {
             }),
           ),
         ).toMatchObject({ title: undefined, body: undefined });
+      });
+
+      // #2034 — hop-end (환승역 하차) payload 확장.
+      it('hopEndKind + nextLine + nextStation 을 payload 로 정규화 (#2034)', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'boarding-prompt',
+              originStation: '성수',
+              line: '2',
+              tripToken: 'tok-hop',
+              hopEndKind: 'disembark',
+              nextLine: 'K',
+              nextStation: '왕십리',
+            }),
+          ),
+        ).toMatchObject({
+          hopEndKind: 'disembark',
+          nextLine: 'K',
+          nextStation: '왕십리',
+        });
+      });
+
+      it('hopEndKind 이 disembark 이 아니면 undefined 로 정규화 (#2034)', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'boarding-prompt',
+              originStation: '성수',
+              line: '2',
+              tripToken: 'tok',
+              hopEndKind: 'invalid',
+            }),
+          ),
+        ).toMatchObject({ hopEndKind: undefined });
+      });
+
+      it('nextLine/nextStation 이 빈 문자열이면 undefined 로 정규화 (#2034)', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'boarding-prompt',
+              originStation: '성수',
+              line: '2',
+              tripToken: 'tok',
+              hopEndKind: 'disembark',
+              nextLine: '',
+              nextStation: '',
+            }),
+          ),
+        ).toMatchObject({ nextLine: undefined, nextStation: undefined });
       });
     });
   });
@@ -3446,6 +3503,99 @@ describe('silentPushTask', () => {
         mockScheduleNotificationAsync.mockRejectedValueOnce(new Error('schedule fail'));
         await handleSilentPush(boardingPromptPayload({ pushId: 'bp-1' }));
         expect(mockLogBoardingPromptFired).not.toHaveBeenCalled();
+      });
+
+      // #2034 — hop-end (환승역 하차) 시나리오.
+      describe('#2034 hop-end (환승역 "하차했나요?")', () => {
+        function hopEndPayload(extra: Record<string, unknown> = {}) {
+          return boardingPromptPayload({
+            hopEndKind: 'disembark',
+            originStation: '성수',
+            line: '2',
+            tripToken: 'tok-hop',
+            nextLine: 'K',
+            nextStation: '왕십리',
+            ...extra,
+          });
+        }
+
+        it('hopEndKind=disembark → fallback title "성수에서 하차하셨나요?"', async () => {
+          await handleSilentPush(hopEndPayload({ pushId: 'hop-1' }));
+          const call = mockScheduleNotificationAsync.mock.calls[0][0] as {
+            content: { title: string; body: string };
+          };
+          expect(call.content.title).toBe('성수에서 하차하셨나요?');
+          expect(call.content.body).toContain('성수에서 내려주세요');
+          expect(call.content.body).toContain('K호선 왕십리');
+        });
+
+        it('hopEndKind=disembark + nextStation 없음 → line 만 fallback body', async () => {
+          await handleSilentPush(hopEndPayload({ pushId: 'hop-2', nextStation: undefined }));
+          const call = mockScheduleNotificationAsync.mock.calls[0][0] as {
+            content: { body: string };
+          };
+          expect(call.content.body).toContain('K호선');
+          expect(call.content.body).not.toContain('왕십리');
+        });
+
+        it('hopEndKind=disembark + nextLine 없음 → 다음 leg 안내 생략', async () => {
+          await handleSilentPush(
+            hopEndPayload({ pushId: 'hop-3', nextLine: undefined, nextStation: undefined }),
+          );
+          const call = mockScheduleNotificationAsync.mock.calls[0][0] as {
+            content: { body: string };
+          };
+          expect(call.content.body).toBe('2호선 성수에서 내려주세요.');
+        });
+
+        it('backend title/body 우선 (backend i18n resolve 정합)', async () => {
+          await handleSilentPush(
+            hopEndPayload({
+              pushId: 'hop-4',
+              title: 'Getting off at Seongsu?',
+              body: 'Transfer here.',
+            }),
+          );
+          const call = mockScheduleNotificationAsync.mock.calls[0][0] as {
+            content: { title: string; body: string };
+          };
+          expect(call.content.title).toBe('Getting off at Seongsu?');
+          expect(call.content.body).toBe('Transfer here.');
+        });
+
+        it('data payload 에 hopEndKind + nextLine + nextStation 전달', async () => {
+          await handleSilentPush(hopEndPayload({ pushId: 'hop-5' }));
+          const call = mockScheduleNotificationAsync.mock.calls[0][0] as {
+            content: { data: Record<string, unknown> };
+          };
+          expect(call.content.data.hopEndKind).toBe('disembark');
+          expect(call.content.data.nextLine).toBe('K');
+          expect(call.content.data.nextStation).toBe('왕십리');
+        });
+
+        it('hop-end dedup 은 leg-key (tripToken|hop-end|line) — 같은 tripToken 다른 line 은 각 발사', async () => {
+          await handleSilentPush(hopEndPayload({ pushId: 'hop-a', line: '2' }));
+          await handleSilentPush(hopEndPayload({ pushId: 'hop-b', line: '5' }));
+          expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(2);
+        });
+
+        it('hop-end 이후 승차 prompt (같은 tripToken) 은 별개 dedup 채널 → 각 발사', async () => {
+          await handleSilentPush(hopEndPayload({ pushId: 'hop-x' }));
+          await handleSilentPush(
+            boardingPromptPayload({
+              pushId: 'bp-x',
+              tripToken: 'tok-hop', // 같은 trip
+              // hopEndKind 없음 → 승차 prompt
+            }),
+          );
+          expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(2);
+        });
+
+        it('같은 leg-key 두 번째 발사는 dedup skip', async () => {
+          await handleSilentPush(hopEndPayload({ pushId: 'hop-p' }));
+          await handleSilentPush(hopEndPayload({ pushId: 'hop-q' }));
+          expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+        });
       });
     });
 

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -282,9 +282,14 @@ export interface RescheduleSilentPushPayload {
  */
 export interface BoardingPromptSilentPushPayload {
   kind: 'boarding-prompt';
-  /** 사용자 출발역 (BoardingPrompt 응답 flow에서 lock 생성 시 boardingStation으로 사용). */
+  /**
+   * 사용자 출발역. hop-end 분기(#2034) 에서는 "환승 지점 역명" (=사용자가 하차해야 하는 station)
+   * 으로 재해석. hopEndKind 필드로 분기 처리.
+   */
   originStation: string;
-  /** 출발 노선 (lock 생성 시 boardingLine으로 사용). */
+  /**
+   * 노선. hop-end(#2034) 시엔 직전 leg 노선 (하차 대상). 일반 boarding-prompt 는 승차 대상 노선.
+   */
   line: string;
   /** trip 토큰 — dedup key + boarding-prompt 응답 시 trip 컨텍스트 복원용. */
   tripToken: string;
@@ -307,6 +312,15 @@ export interface BoardingPromptSilentPushPayload {
    * backend `sendBoardingPromptPush`의 body와 동형.
    */
   body?: string;
+  /**
+   * #2034 — hop-end (환승역 하차) 프롬프트 분기. 미지정(legacy) = 승차 프롬프트. 'disembark'
+   * = "하차했나요?" UI. device 는 이 필드로 title/body/응답 처리를 분기.
+   */
+  hopEndKind?: 'disembark';
+  /** #2034 — hop-end 시 다음 leg 노선. 미지정이면 UI 에서 line 만 fallback 노출. */
+  nextLine?: string;
+  /** #2034 — hop-end 시 다음 leg 출발역. 미지정이면 UI 에서 next-line 만 표시. */
+  nextStation?: string;
 }
 
 /**
@@ -684,7 +698,19 @@ function extractTripEndedPayload(
 function extractBoardingPromptPayload(
   obj: Record<string, unknown>,
 ): BoardingPromptSilentPushPayload | null {
-  const { originStation, line, tripToken, pushId, sentAt, destinationDirection, title, body } = obj;
+  const {
+    originStation,
+    line,
+    tripToken,
+    pushId,
+    sentAt,
+    destinationDirection,
+    title,
+    body,
+    hopEndKind,
+    nextLine,
+    nextStation,
+  } = obj;
   if (typeof originStation !== 'string' || originStation.length === 0) return null;
   if (typeof line !== 'string' || line.length === 0) return null;
   if (typeof tripToken !== 'string' || tripToken.length === 0) return null;
@@ -701,6 +727,11 @@ function extractBoardingPromptPayload(
         : undefined,
     title: typeof title === 'string' && title.length > 0 ? title : undefined,
     body: typeof body === 'string' && body.length > 0 ? body : undefined,
+    // #2034 — hop-end 필드. 미지정 시 undefined (legacy = 승차 prompt).
+    hopEndKind: hopEndKind === 'disembark' ? 'disembark' : undefined,
+    nextLine: typeof nextLine === 'string' && nextLine.length > 0 ? nextLine : undefined,
+    nextStation:
+      typeof nextStation === 'string' && nextStation.length > 0 ? nextStation : undefined,
   };
 }
 
@@ -1261,6 +1292,19 @@ function parseDestinationName(raw: string | null): string | null {
 }
 
 /**
+ * #2034 — hop-end (환승역 하차) prompt 의 device fallback body. backend title/body 가 없을 때만
+ * 사용. nextLine/nextStation 이 있으면 "다음: N호선 S 방면" 포함, 없으면 하차 안내만.
+ */
+function buildHopEndFallbackBody(payload: BoardingPromptSilentPushPayload): string {
+  const from = `${payload.line}호선 ${payload.originStation}에서 내려주세요.`;
+  if (!payload.nextLine) return from;
+  const next = payload.nextStation
+    ? `${payload.nextLine}호선 ${payload.nextStation}`
+    : `${payload.nextLine}호선`;
+  return `${from} 다음은 ${next} 방면입니다.`;
+}
+
+/**
  * #2028 — boarding-prompt silent push 수신 시 gate 무관 local notification schedule.
  *
  * 도달률 우선 — location / silence / motion / FIRED_ALARMS dedup 모두 skip. 사용자에게 UI가
@@ -1276,30 +1320,44 @@ function parseDestinationName(raw: string | null): string | null {
  *
  * title/body는 backend payload에서 우선 사용 (backend가 사용자 locale로 i18n resolve).
  * 미지정 시 device fallback — "탑승하셨나요?" 정적 문자열. graceful — 어떤 값이 오든 알림 발사 보장.
+ *
+ * #2034 — hop-end (환승역 하차) 분기. payload.hopEndKind === 'disembark' 이면 title/body/dedup-key
+ * 를 hop-end 시나리오로 분기. 응답 처리는 `useBoardingPromptResponder` 가 hopEndKind 필드로 분기.
  */
 async function fireBoardingPromptLocalNotification(
   payload: BoardingPromptSilentPushPayload,
   apnsToken: string | null,
 ): Promise<void> {
-  // tripToken 세션 dedup — 이미 발사됐으면 skip. dedup 목적: backend cron 재시도(3회) 시 중복 방지.
-  if (boardingPromptFiredTripTokens.has(payload.tripToken)) {
+  // dedup key — hop-end 는 leg 단위이므로 tripToken 만으로는 다중 환승을 놓친다. hopEndKind
+  // 필드가 있으면 `${tripToken}|hop-end|${line}` 를 사용해 leg 별 dedup, 없으면 tripToken 그대로.
+  const dedupKey = payload.hopEndKind === 'disembark'
+    ? `${payload.tripToken}|hop-end|${payload.line}`
+    : payload.tripToken;
+  // tripToken (혹은 leg key) 세션 dedup — 이미 발사됐으면 skip. dedup 목적: backend cron 재시도(3회) 시 중복 방지.
+  if (boardingPromptFiredTripTokens.has(dedupKey)) {
     logger.info(
-      `boarding-prompt dedup: tripToken=${payload.tripToken.slice(0, 8)} already fired in session — skip`,
+      `boarding-prompt dedup: key=${dedupKey.slice(0, 24)} already fired in session — skip`,
     );
     void ackOutcome(payload.pushId, apnsToken, 'skipped', 'boarding-prompt-dedup');
     return;
   }
 
   // dedup 등록 먼저 — scheduleNotificationAsync 실패해도 재시도로 반복 발사되지 않도록.
-  boardingPromptFiredTripTokens.add(payload.tripToken);
+  boardingPromptFiredTripTokens.add(dedupKey);
 
   // 사용자 표시 문구. backend 우선 → device fallback (backend가 locale resolve해서 넘겨줌).
-  const title = payload.title ?? '탑승하셨나요?';
-  const body =
-    payload.body ?? `${payload.line}호선 ${payload.originStation}에서 열차가 곧 도착합니다.`;
+  const isHopEnd = payload.hopEndKind === 'disembark';
+  const fallbackTitle = isHopEnd
+    ? `${payload.originStation}에서 하차하셨나요?`
+    : '탑승하셨나요?';
+  const fallbackBody = isHopEnd
+    ? buildHopEndFallbackBody(payload)
+    : `${payload.line}호선 ${payload.originStation}에서 열차가 곧 도착합니다.`;
+  const title = payload.title ?? fallbackTitle;
+  const body = payload.body ?? fallbackBody;
 
   // data payload는 `useBoardingPromptResponder`의 extractBoardingPromptPayload가 파싱하는 schema.
-  // kind + originStation + line + tripToken 필수, destinationDirection optional.
+  // kind + originStation + line + tripToken 필수, destinationDirection + hopEndKind + nextLine + nextStation optional.
   const data: Record<string, unknown> = {
     kind: 'boarding-prompt',
     originStation: payload.originStation,
@@ -1308,6 +1366,15 @@ async function fireBoardingPromptLocalNotification(
   };
   if (payload.destinationDirection !== undefined) {
     data.destinationDirection = payload.destinationDirection;
+  }
+  if (payload.hopEndKind !== undefined) {
+    data.hopEndKind = payload.hopEndKind;
+  }
+  if (payload.nextLine !== undefined) {
+    data.nextLine = payload.nextLine;
+  }
+  if (payload.nextStation !== undefined) {
+    data.nextStation = payload.nextStation;
   }
 
   try {


### PR DESCRIPTION
## Summary

Issue G (#2034) — 환승역 "하차했나요?" boardingPrompt UI 구현. **옵션 A (기존 boardingPrompt 아키텍처 확장)** 채택.

사용자 확정 flow: 환승역 도착 → 분기로 "하차했나요?" 확인 → [하차함] 시 다음 leg 정보 노출 + lock release. 자동 lock 없음.

Closes #2034

---

## 변경 스코프

### Backend (fire chain)
- `types.ts` — `BoardingPromptPushPayload` 에 `hopEndKind` / `nextLine` / `nextStation` 필드 추가. `Trip` 에 `hopEndPromptState: Record<string, BoardingPromptState>` (leg-key 별 dedup) 추가.
- `apns.ts` — `sendBoardingPromptPush` 가 hop-end 필드 payload wire. 미지정 시 필드 자연 누락 (구 device byte-level 호환).
- `boardingPrompt.ts` — `evaluateHopEndPromptGates` 신규. GPS/motion/speed 없이 `fired` + `silencedUntil` 만 검사. transfer waypoint advance 자체가 ground truth.
- `i18n.ts` — 4 언어 (ko/en/ja/zh) hop-end title/body 문구.
- `scheduled.ts` — `buildHopEndPromptMessage` + `maybeFireHopEndPrompt` 신규. `advanceBoardingLockWaypoint` 에서 `waypoint.kind === 'transfer'` 진입 시 호출. `stats.hopEndPromptFired` / `hopEndPromptBlocked` 카운터.

### Frontend (UI + response chain)
- `silentPushTask.ts` — `BoardingPromptSilentPushPayload` 에 hop-end 필드 확장. `extractBoardingPromptPayload` 가 정규화. `fireBoardingPromptLocalNotification` 이 hop-end 분기 시 title/body fallback 을 하차 문구로 변경. dedup key 도 `${tripToken}|hop-end|${line}` (leg 별).
- `useBoardingPromptResponder.ts` — `BoardingPromptPayload` 확장 + `handleHopEndResponse` 분기. [하차함]/$default → `releaseLock('user')` + `hop_end_prompt_confirmed` breadcrumb. [아직] → `dismissBoardingPrompt` POST + `hop_end_prompt_dismissed` breadcrumb. autoLock 시도 skip.

### 스코프 제외 (별도 이슈)
- Timeout 처리 (5분 후 auto-release / auto-dismiss)
- Issue H (D5 auto-lock 제거) 연동
- Production 메트릭 dashboard 자동화

---

## Wire-completion 5단 체크

- [x] **1. Orphan 없음** — `npm run lint:orphan` pass. `maybeFireHopEndPrompt` 는 `scheduled.ts:2992` 에서 caller 존재. `handleHopEndResponse` 는 `handleResponse` 에서 `hopEndKind === 'disembark'` 분기 진입.
- [x] **2. V/X dashboard** — 
  - Backend log: `wrangler tail | grep hop-end-prompt` — "fired" / "gate blocked" / "push failed" 3 line.
  - Backend stats: `stats.hopEndPromptFired` / `stats.hopEndPromptBlocked` (매 cron cycle).
  - Device breadcrumb (Sentry): `hop_end_prompt_confirmed` / `hop_end_prompt_dismissed` / `boarding-prompt-silent-fired` (Silent push fallback 발사분).
- [x] **3. 의존 PR** — #2022 (arvlCd fire immediate, 머지 완료), #2030 (silent-push local notification fallback, 머지 완료). Issue M (#2037, silent push 이중 발사 진행 중) — 다른 함수/필드 편집이라 rebase conflict 낮음.
- [x] **4. 측정 plan** — 1주 관찰:
  - **성공 신호**: 실기기 환승 trip (예: 강남→성수→내방) 완주 후 `hopEndPromptFired > 0` + Sentry `hop_end_prompt_confirmed` breadcrumb > 0. 
  - **회귀 신호**: `hopEndPromptFired > 0` 인데 `hop_end_prompt_confirmed + hop_end_prompt_dismissed = 0` (사용자에게 UI 미도달) → boardingPromptCategory 미등록 / Focus DND 관통 실패 회귀.
- [x] **5. Device verify** — 실기기 필요. 시나리오:
  1. 환승 있는 route 등록 (강남→성수→내방 or 서울역→신도림→가양).
  2. 첫 leg 진행 → boardingPrompt (승차) 발사 → [탑승] 응답.
  3. 환승역 도착 → **hop-end prompt "성수에서 하차하셨나요?" 알림 노출 확인** ← 본 PR 검증 포인트.
  4. [하차함] 응답 → lock release + 다음 leg 진입 → 다음 leg 승차 prompt 자연 발사.
  
  코드-only 는 backend gate + payload wire + frontend fallback rendering.

---

## Test plan

- [x] `npm test` 100% coverage pass (9027 tests)
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass
- [x] Backend `npx vitest run` pass (2559 tests, +25 신규)
- Device verify (사용자):
  - [ ] 실기기 환승 trip 완주 (강남→성수→내방 or 유사 시나리오)
  - [ ] `hop-end-prompt: fired` wrangler tail 로그 관측
  - [ ] Focus/DND 조건에서 silent push fallback body ("성수에서 내려주세요") 노출 확인

---

## 참고

- 사용자 확정 flow: `memory/project_2026_07_03_user_manual_action_flow.md`
- `feedback_user_intent_equal_protection.md`: 사용자 명시 응답 = lock 활성 동급 정확도 보장 의무
- `feedback_no_partial_fix_full_chain_wire_matrix.md`: 전 chain 커버 필수 (backend fire → device UI → 응답 → 후속 처리)