### PR TITLE
fix(#2018): 목적지 도착 후 route UI 즉시 종료 (γ' silent push FG store reset)

### DIFF
--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -76,9 +76,13 @@ jest.mock('../../store/tripBoundCleanups', () => ({
 }));
 
 // #899 (Seam C) — trip-ended 분기는 FG 복귀를 위한 sentinel을 작성한다.
+// #2018 γ' — FG 상태 시 sentinel 처리 완료 후 clearTripEndedSentinel 즉시 호출.
 const mockSetTripEndedSentinel = jest.fn().mockResolvedValue(undefined);
+const mockClearTripEndedSentinel = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../utils/tripEndedSentinel', () => ({
   setTripEndedSentinel: (...args: unknown[]) => mockSetTripEndedSentinel(...args),
+  clearTripEndedSentinel: (...args: unknown[]) =>
+    mockClearTripEndedSentinel(...args),
 }));
 
 // #919 — trip-ended 분기는 cleanup 직전에 recall trigger를 호출한다.
@@ -188,6 +192,27 @@ const mockStoreReleaseLock = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../store/useBoardingLockStore', () => ({
   useBoardingLockStore: {
     getState: () => ({ releaseLock: mockStoreReleaseLock }),
+  },
+}));
+
+// #2018 γ' — FG 상태에서 즉시 destination store setState. mock으로 호출 인자 검증.
+const mockDestinationSetState = jest.fn();
+jest.mock('../../../route/store/useDestinationStore', () => ({
+  useDestinationStore: {
+    setState: (...args: unknown[]) => mockDestinationSetState(...args),
+  },
+}));
+
+// #2018 γ' — FG/BG 조건 분기 검증을 위해 AppState.currentState를 테스트에서 조작한다.
+// 기본값 'background' — 기존 테스트가 γ' 분기에 진입하지 않도록 보수적 초기화.
+const mockAppStateHolder: { currentState: 'active' | 'background' | 'inactive' } = {
+  currentState: 'background',
+};
+jest.mock('react-native', () => ({
+  AppState: {
+    get currentState() {
+      return mockAppStateHolder.currentState;
+    },
   },
 }));
 
@@ -406,6 +431,11 @@ describe('silentPushTask', () => {
     mockSendTripEndedNotification.mockResolvedValue(undefined);
     mockHasFiredPushId.mockResolvedValue(false);
     mockAddFiredPushId.mockResolvedValue(undefined);
+    // #2018 γ' — 기본 BG로 설정해 기존 테스트가 FG 분기 진입하지 않도록.
+    mockAppStateHolder.currentState = 'background';
+    // clearAllMocks가 mockImplementation을 reset하지 않으므로 명시 복구.
+    mockSetTripEndedSentinel.mockResolvedValue(undefined);
+    mockClearTripEndedSentinel.mockResolvedValue(undefined);
   });
 
   it('defineTask가 SILENT_PUSH_TASK 이름으로 콜백을 등록한다', () => {
@@ -2972,6 +3002,87 @@ describe('silentPushTask', () => {
         expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
         expect(mockSetTripEndedSentinel).toHaveBeenCalledTimes(1);
         expect(mockSetTripEndedSentinel).toHaveBeenCalledWith(expect.any(Number));
+      });
+
+      // #2018 γ' — FG 상태(active)에서 trip-ended 수신 시 sentinel 저장 후 즉시 in-memory
+      // store를 reset해야 한다. useStateRehydration은 AppState 'active' 이벤트 시에만 실행되므로
+      // FG dogfood 시나리오(관찰 20, 성수→성수)에서 sentinel이 저장돼도 재수화가 트리거되지 않아
+      // destination store가 stale로 남는 회귀 차단.
+      describe('#2018 γ\' — FG 상태 즉시 in-memory store reset', () => {
+        it('AppState=active 시 destination store setState({destination:null, customOrigin:null, tripOrigin:null}) 호출', async () => {
+          mockAppStateHolder.currentState = 'active';
+          await handleSilentPush(tripEndedPayload({ reason: 'destination-arrived' }));
+          expect(mockDestinationSetState).toHaveBeenCalledTimes(1);
+          expect(mockDestinationSetState).toHaveBeenCalledWith({
+            destination: null,
+            customOrigin: null,
+            tripOrigin: null,
+          });
+        });
+
+        it('AppState=active 시 boardingLockStore.releaseLock 호출', async () => {
+          mockAppStateHolder.currentState = 'active';
+          mockStoreReleaseLock.mockClear();
+          await handleSilentPush(tripEndedPayload({ reason: 'expired' }));
+          expect(mockStoreReleaseLock).toHaveBeenCalledTimes(1);
+        });
+
+        it('AppState=active 시 setTripEndedSentinel 이후 clearTripEndedSentinel 호출 (중복 처리 방지)', async () => {
+          mockAppStateHolder.currentState = 'active';
+          const callOrder: string[] = [];
+          mockSetTripEndedSentinel.mockImplementation(async () => {
+            callOrder.push('set-sentinel');
+          });
+          mockClearTripEndedSentinel.mockImplementation(async () => {
+            callOrder.push('clear-sentinel');
+          });
+          await handleSilentPush(tripEndedPayload({ reason: 'expired' }));
+          expect(mockSetTripEndedSentinel).toHaveBeenCalledTimes(1);
+          expect(mockClearTripEndedSentinel).toHaveBeenCalledTimes(1);
+          expect(callOrder).toEqual(['set-sentinel', 'clear-sentinel']);
+        });
+
+        it('AppState=background 시 setState / releaseLock / clearSentinel 호출 안 함 (기존 BG 경로 유지)', async () => {
+          mockAppStateHolder.currentState = 'background';
+          mockStoreReleaseLock.mockClear();
+          await handleSilentPush(tripEndedPayload({ reason: 'expired' }));
+          expect(mockSetTripEndedSentinel).toHaveBeenCalledTimes(1);
+          expect(mockDestinationSetState).not.toHaveBeenCalled();
+          expect(mockStoreReleaseLock).not.toHaveBeenCalled();
+          expect(mockClearTripEndedSentinel).not.toHaveBeenCalled();
+        });
+
+        it('AppState=inactive 시 FG 분기 미진입 (active 조건 strict)', async () => {
+          mockAppStateHolder.currentState = 'inactive';
+          await handleSilentPush(tripEndedPayload({ reason: 'expired' }));
+          expect(mockDestinationSetState).not.toHaveBeenCalled();
+          expect(mockClearTripEndedSentinel).not.toHaveBeenCalled();
+        });
+
+        it('AppState=active setState throw 시 graceful — 전체 흐름 계속 (sentinel은 유지)', async () => {
+          mockAppStateHolder.currentState = 'active';
+          mockDestinationSetState.mockImplementation(() => {
+            throw new Error('store boom');
+          });
+          await expect(
+            handleSilentPush(tripEndedPayload({ reason: 'expired', pushId: 'te-uuid' })),
+          ).resolves.toBeUndefined();
+          // 다음 흐름(surface + ack)은 그대로 진행.
+          expect(mockSendTripEndedNotification).toHaveBeenCalledTimes(1);
+        });
+
+        it('AppState=active tripToken mismatch 시 setState도 호출 안 함 (cleanup skip 경로)', async () => {
+          mockAppStateHolder.currentState = 'active';
+          (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+            if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+            if (key === ACTIVE_TRIP_KEY) return 'NEW-TRIP-TOKEN';
+            return null;
+          });
+          await handleSilentPush(
+            tripEndedPayload({ pushId: 'te-uuid', tripToken: 'OLD-TRIP-TOKEN' }),
+          );
+          expect(mockDestinationSetState).not.toHaveBeenCalled();
+        });
       });
 
       it('#899 (Seam C) — tripToken mismatch로 cleanup skip 시 sentinel도 작성 안 함', async () => {

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -29,6 +29,7 @@ import * as Location from 'expo-location';
 import * as Battery from 'expo-battery';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import i18next from 'i18next';
+import { AppState } from 'react-native';
 import {
   persistBackendSsotMirror,
   parseAlarmEventsMirror,
@@ -59,7 +60,10 @@ import {
   markStationFired,
 } from '../utils/crossCategoryStationDedup';
 import { runTripBoundCleanups, cancelTripBoundOsQueue } from '../store/tripBoundCleanups';
-import { setTripEndedSentinel } from '../utils/tripEndedSentinel';
+import {
+  setTripEndedSentinel,
+  clearTripEndedSentinel,
+} from '../utils/tripEndedSentinel';
 import { triggerTripEndRecall } from '../utils/triggerTripEndRecall';
 import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
 import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
@@ -94,6 +98,7 @@ import { type NotificationSource } from '../utils/notificationSource';
 import { getFiredAlarms, setFiredAlarms } from '../utils/notificationState';
 import { getBoardingLock } from '../utils/boardingLockStorage';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
+import { useDestinationStore } from '../../route/store/useDestinationStore';
 import { getSubsurfaceState } from '../../../shared/utils/subsurfaceState';
 import { findStationByName, findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
@@ -1007,6 +1012,29 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
       // #899 (Seam C) — BG에서는 zustand store에 접근 불가. FG 복귀 시점에
       // useStateRehydration이 이 sentinel을 보고 destination/lock store도 reset.
       await setTripEndedSentinel(receivedAt);
+      // #2018 γ' — FG 상태에서는 useStateRehydration의 AppState 'active' 이벤트가
+      // 발생하지 않아 sentinel이 다음 BG/FG cycle까지 처리되지 않는다. 그동안 in-memory
+      // destination store가 stale로 남아 UI가 "현재역 → 현재역 0정거장" 형태로 잔존
+      // (2026-07-02 dogfood 관찰 20 성수→성수 evidence). FG 진행 중이면 setState를
+      // 여기서 즉시 수행해 store를 정리하고 sentinel을 그 자리에서 clear한다.
+      // BG 상태에서는 zustand runtime 접근이 불확실하므로 sentinel만 남기고 기존
+      // useStateRehydration 경로에 의존 — 기존 회귀 표면 없음.
+      if (AppState.currentState === 'active') {
+        try {
+          useDestinationStore.setState({
+            destination: null,
+            customOrigin: null,
+            tripOrigin: null,
+          });
+          addDomainBreadcrumb('trip', 'end', {
+            reason: 'silent-push-fg-immediate',
+          });
+          await useBoardingLockStore.getState().releaseLock();
+          await clearTripEndedSentinel();
+        } catch (e) {
+          logger.warn('FG 즉시 store reset 실패 (graceful — sentinel 유지):', e);
+        }
+      }
       // #1323 — trip 종료 user-facing surface. running/backgrounded 앱 backstop 경로.
       // #1337 PR1 — alert payload는 iOS가 시스템 banner를 직접 표시하므로 surface skip;
       // 단 동일 pushId의 silent backstop이 race로 도달해도 중복 surface 안 되도록 dedup store에는 기록.


### PR DESCRIPTION
## Root cause

**관찰 20 evidence (2026-07-02 dogfood)**:
> 도착하고 나서 [UI 가] 계속 떠. 성수 도착했으면 안내 종료가 떠야 하는데 "성수 → 성수 0정거장 4분 소요예정" 이런 식으로 나와.

**Chain 분석**:
- Backend `scheduled.ts:2868` cleanup 신호 발사 O
- Silent push handler (`silentPushTask.ts:1014`) `setTripEndedSentinel(receivedAt)` sentinel 저장 O
- **`useStateRehydration`은 AppState 'active' 이벤트 시에만 실행** (`useStateRehydration.ts:60`)
- **FG dogfood 시나리오에서 앱이 이미 active라 이벤트 미발생** → sentinel 감지 안 됨 → store reset 안 됨
- `useArrivalInfo`, `useFusedNearestStation` closure가 stale destination 값 보유 → 8-18초간 "성수→성수 0정거장 4분" 렌더

**silentPushTask.ts:1007 기존 주석**:
```
// #899 (Seam C) — BG에서는 zustand store에 접근 불가. FG 복귀 시점에
// useStateRehydration이 이 sentinel을 보고 destination/lock store도 reset.
```

주석의 "BG 접근 불가"는 별도 BG task runtime 기준. **FG 상태에서 silent push handler는 앱 JS runtime에서 실행 → zustand 접근 가능**.

## 채택: γ' layer

`silentPushTask.handleSilentPush`의 trip-ended 분기에서 sentinel 저장 직후 `AppState.currentState === 'active'` 조건 시 in-memory store를 즉시 reset:

- `useDestinationStore.setState({destination:null, customOrigin:null, tripOrigin:null})`
- `addDomainBreadcrumb('trip', 'end', {reason: 'silent-push-fg-immediate'})`
- `useBoardingLockStore.getState().releaseLock()` (useStateRehydration pattern 통일)
- `clearTripEndedSentinel()` (다음 active 진입 시 중복 처리 방지)

BG 상태에서는 기존 sentinel 경로 유지 — 회귀 표면 없음. setState throw 시 graceful catch로 sentinel 유지 backstop.

## α layer (hook polling abort backstop) 스킵 rationale

Plan은 완전성 위해 α layer도 요구했지만:
- **Destination store는 zustand** → setState 시 subscribers (HomeScreen 등) 자동 rerender.
- HomeScreen → routeContext.destination=null → `useArrivalInfo(stationName===null)` / `useFusedNearestStation`은 이미 null 처리 있음 (useArrivalInfo.ts:116-121).
- α를 hook 내부에 추가하면 features/arrival → features/route 직접 import → architecture violation (import/no-restricted-paths).
- **γ' 만으로 완전 fix**. Simplicity First 원칙.

## 관찰 22 (6시간 미종료)와의 관계

Explore agent가 "동일 root cause 확정"이라고 했지만 미검증. 본 fix는 **관찰 20 (FG dogfood) 확실 fix**. 관찰 22는:
- Silent push 미도달 or 앱 kill 후 6h+ 미실행 시 → lifecycle backstop 9h+ force-end만 유효
- 별도 이슈 후속 처리 필요

## Wire-completion 5단

1. **Orphan 없음** — `clearTripEndedSentinel` 기존 caller(`useStateRehydration.ts:89`) 존재. `npm run lint:orphan` pass.
2. **V/X dashboard** — Sentry breadcrumb `domain='trip', action='end', meta.reason='silent-push-fg-immediate'` 관측 가능. FG immediate reset과 sentinel-rehydration/lifecycle-9h-force-end/user-clear 구분.
3. **의존 PR** — 없음. Issue G (#2040)와 silentPushTask.ts 편집 라인 다름 (본 fix line 1015 근처, Issue G line 1037 boarding-prompt 분기) → rebase 시 3-way merge 자동 해결 예상. 최악 시 사용자 수동 conflict 해결 필요.
4. **측정 plan** — 1주 실기기 dogfood 관찰 20 재발 0건 (사용자 verify).
5. **Device verify** — 실기기 dogfood 필수 (관찰 20 재현 X, 성수→성수 시나리오). 사용자 담당.

## Test

- `silentPushTask.ts` **100% coverage** 유지 (314 tests all pass)
- **6개 신규 테스트** (`#2018 γ' — FG 상태 즉시 in-memory store reset` describe):
  - AppState=active 시 destination store setState 호출
  - AppState=active 시 boardingLockStore.releaseLock 호출
  - AppState=active 시 setTripEndedSentinel 이후 clearTripEndedSentinel 순서 보장
  - AppState=background 시 setState/releaseLock/clearSentinel 호출 안 함 (BG 경로 유지)
  - AppState=inactive 시 FG 분기 미진입 (active 조건 strict)
  - AppState=active setState throw 시 graceful (전체 흐름 계속)
  - AppState=active tripToken mismatch 시 setState 미진입 (cleanup skip 경로)
- `type-check` pass
- `lint:orphan` pass (0 orphan)
- Full test suite: 421 suites, 9012 tests all pass

## 파일 변경

- `src/features/alarm/tasks/silentPushTask.ts` — γ' 로직 (+30줄)
- `src/features/alarm/tasks/__tests__/silentPushTask.test.ts` — mock 추가 + 신규 테스트 (+111줄)

Closes #2018