### PR TITLE
feat(#2036): 취침모드 환승 알람 (γ silent push handler gate-bypass local notification)

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -10,6 +10,7 @@ import {
   sendLiveActivityUpdate,
   sendReschedulePush,
   sendSilentPush,
+  sendSleepTransferAlarmPush,
   sendTripEndedAlertPush,
   type ApnsConfig,
 } from '../apns';
@@ -1442,5 +1443,147 @@ describe('sendTripEndedAlertPush (#1337)', () => {
     const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
     const headers = call[1].headers as Record<string, string>;
     expect(headers['apns-thread-id']).toBe('trip-ended-tok');
+  });
+});
+
+// #2036 (Issue I γ) — sleep-transfer-alarm silent push. 취침모드에서 환승 임박 시 device UI 발사용.
+// ADR-023: backend는 취침 무관 발사, device가 sleepMode read 후 결정.
+describe('sendSleepTransferAlarmPush (#2036)', () => {
+  beforeEach(() => resetApnsJwtCache());
+
+  it('background silent push headers + data payload byte-level contract', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    const result = await sendSleepTransferAlarmPush({
+      deviceToken: 'device-hex',
+      pushId: 'sta-1',
+      originStation: '성수',
+      nextLine: '2',
+      nextStation: '뚝섬',
+      tripToken: 'tok-sta',
+      sentAt: 1_700_000_000_000,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ ok: true, status: 200 });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[0]).toBe(`https://${TEST_HOST}/3/device/device-hex`);
+    const headers = call[1].headers as Record<string, string>;
+    expect(headers['apns-push-type']).toBe('background');
+    expect(headers['apns-priority']).toBe('5');
+    expect(headers['apns-thread-id']).toBe('tok-sta');
+    expect(headers['apns-topic']).toBe('com.example.app');
+    const body = JSON.parse(call[1].body as string);
+    expect(body.aps).toEqual({ 'content-available': 1 });
+    expect(body.data).toEqual({
+      kind: 'sleep-transfer-alarm',
+      originStation: '성수',
+      nextLine: '2',
+      nextStation: '뚝섬',
+      tripToken: 'tok-sta',
+      pushId: 'sta-1',
+      sentAt: 1_700_000_000_000,
+    });
+  });
+
+  it('title/body 지정 시 data payload에 forward', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    await sendSleepTransferAlarmPush({
+      deviceToken: 'device-hex',
+      pushId: 'sta-1',
+      originStation: '성수',
+      nextLine: '2',
+      nextStation: '뚝섬',
+      tripToken: 'tok-sta',
+      sentAt: 0,
+      title: '곧 환승역입니다',
+      body: '성수에서 2호선 뚝섬으로 환승',
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.data.title).toBe('곧 환승역입니다');
+    expect(body.data.body).toBe('성수에서 2호선 뚝섬으로 환승');
+  });
+
+  it('title/body 미지정 시 data payload에 omit (구 device fallback trigger)', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    await sendSleepTransferAlarmPush({
+      deviceToken: 'device-hex',
+      pushId: 'sta-1',
+      originStation: '성수',
+      nextLine: '2',
+      nextStation: '뚝섬',
+      tripToken: 'tok-sta',
+      sentAt: 0,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect('title' in body.data).toBe(false);
+    expect('body' in body.data).toBe(false);
+  });
+
+  it('non-OK 응답은 status/reason을 그대로 반환', async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 410 }),
+    );
+    const result = await sendSleepTransferAlarmPush({
+      deviceToken: 'device-hex',
+      pushId: 'sta-1',
+      originStation: 'O',
+      nextLine: '2',
+      nextStation: 'N',
+      tripToken: 't',
+      sentAt: 0,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result).toEqual({ ok: false, status: 410, reason: 'BadDeviceToken' });
+  });
+
+  it('5xx non-json body → reason undefined (parseApnsError branch)', async () => {
+    const fetchImpl = vi.fn(async () => new Response('upstream broken', { status: 503 }));
+    const result = await sendSleepTransferAlarmPush({
+      deviceToken: 'device-hex',
+      pushId: 'sta-1',
+      originStation: 'O',
+      nextLine: '2',
+      nextStation: 'N',
+      tripToken: 't',
+      sentAt: 0,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(503);
+    expect(result.reason).toBeUndefined();
+  });
+
+  // #1788 — apns-thread-id 헤더로 trip 알림 group.
+  it('apns-thread-id 헤더에 tripToken이 그대로 전달된다 (#1788)', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    await sendSleepTransferAlarmPush({
+      deviceToken: 'device-hex',
+      pushId: 'sta-thread',
+      originStation: 'O',
+      nextLine: '2',
+      nextStation: 'N',
+      tripToken: 'trip-sleep-999',
+      sentAt: 0,
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const headers = call[1].headers as Record<string, string>;
+    expect(headers['apns-thread-id']).toBe('trip-sleep-999');
   });
 });

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -2130,6 +2130,123 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
     expect(data.boardingLine).toBe('7');
   });
 
+  // #2036 (Issue I γ) — 취침모드 환승 알람 silent push. transfer waypoint advance 시 device로
+  // sleep-transfer-alarm kind push를 발사해 device가 sleepMode=true 시 gate 무관 로컬 알림 발사.
+  // ADR-023 정합: backend는 취침 무관 발사 (본 caller는 sleepMode 조회하지 않음).
+  it('#2036 — transfer waypoint advance 시 sleep-transfer-alarm silent push 발사 (kind + originStation + nextLine + nextStation + tripToken)', async () => {
+    const kv = new InMemoryKV();
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({
+        waypoints: [
+          { stationName: '군자', line: '7', kind: 'transfer' },
+          { stationName: '아차산', line: '5', kind: 'destination' },
+        ],
+      }),
+    );
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('군자', 0, 1)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-sleep-transfer',
+    });
+    const sleepTransferCall = (fetchImpl.mock.calls as unknown as [string, RequestInit][]).find(
+      (call) => {
+        const init = call[1];
+        if (!init?.body) return false;
+        try {
+          const body = JSON.parse(init.body as string);
+          return body?.data?.kind === 'sleep-transfer-alarm';
+        } catch {
+          return false;
+        }
+      },
+    );
+    expect(sleepTransferCall).toBeDefined();
+    const data = JSON.parse(sleepTransferCall![1].body as string).data as Record<string, unknown>;
+    expect(data.kind).toBe('sleep-transfer-alarm');
+    expect(data.originStation).toBe('군자');
+    expect(data.nextLine).toBe('5');
+    expect(data.nextStation).toBe('아차산');
+    expect(data.tripToken).toBe('lock-tok');
+    // background silent push headers (사용자 UI는 device fallback + gate 무관 발사가 담당).
+    const headers = sleepTransferCall![1].headers as Record<string, string>;
+    expect(headers['apns-push-type']).toBe('background');
+    expect(headers['apns-priority']).toBe('5');
+  });
+
+  it('#2036 — waypoints 소진(마지막 intermediate 통과) 시 sleep-transfer-alarm 미발사 (destination path 위임)', async () => {
+    const kv = new InMemoryKV();
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    // 유일 waypoint가 transfer지만 이후 waypoint 없음 → 발사 대상 X (다음 leg 없음).
+    // 실제로는 transfer kind는 destination이 뒤에 있어야 정상 route지만, 방어적으로 nextWaypoint 부재 시 skip 검증.
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({
+        waypoints: [{ stationName: '군자', line: '7', kind: 'transfer' }],
+      }),
+    );
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('군자', 0, 1)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-sleep-transfer-only',
+    });
+    const sleepTransferCall = (fetchImpl.mock.calls as unknown as [string, RequestInit][]).find(
+      (call) => {
+        const init = call[1];
+        if (!init?.body) return false;
+        try {
+          const body = JSON.parse(init.body as string);
+          return body?.data?.kind === 'sleep-transfer-alarm';
+        } catch {
+          return false;
+        }
+      },
+    );
+    expect(sleepTransferCall).toBeUndefined();
+  });
+
+  it('#2036 — intermediate waypoint advance 시 sleep-transfer-alarm 미발사 (transfer 전용)', async () => {
+    const kv = new InMemoryKV();
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({
+        waypoints: [
+          { stationName: '중곡', line: '7', kind: 'intermediate' },
+          { stationName: '군자', line: '7', kind: 'destination' },
+        ],
+      }),
+    );
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('중곡', 0, 1)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-sleep-intermediate',
+    });
+    const sleepTransferCall = (fetchImpl.mock.calls as unknown as [string, RequestInit][]).find(
+      (call) => {
+        const init = call[1];
+        if (!init?.body) return false;
+        try {
+          const body = JSON.parse(init.body as string);
+          return body?.data?.kind === 'sleep-transfer-alarm';
+        } catch {
+          return false;
+        }
+      },
+    );
+    expect(sleepTransferCall).toBeUndefined();
+  });
+
   it('#864 — intermediate waypoint advance 시 boardingLock은 유지 (같은 train 계속 추적)', async () => {
     const kv = new InMemoryKV();
     await runArrivedScenario(

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -894,6 +894,89 @@ export async function sendBoardingPromptSilentPush(
   return parseApnsError(response);
 }
 
+/**
+ * 취침모드 환승 알람 silent push (#2036 Issue I γ).
+ *
+ * 사용자 확정 flow: "환승역 → 취침모드 시 알람 발사, 일반모드는 일반 상황과 동일".
+ * device silentPushTask가 payload 수신 → `SLEEP_MODE_KEY` AsyncStorage read → sleepMode=true 시
+ * gate 무관 로컬 알림(alarm.wav sound + repeat vibration + timeSensitive interruptionLevel) 발사.
+ *
+ * ADR-023 정합: backend는 취침 무관 발사 (본 함수 호출부는 사용자 sleep 상태 조회하지 않음).
+ *
+ * headers는 일반 silent push와 동일 (background + priority 5). data payload는 discriminator
+ * `kind: 'sleep-transfer-alarm'` + originStation + nextLine + nextStation + tripToken 필수.
+ * pushId / sentAt / title / body 는 optional (구 device 호환).
+ *
+ * dedup은 device 측 in-memory Set(`${tripToken}::${nextStation}`)이 담당 — backend는 idempotent 발사.
+ */
+export interface SendSleepTransferAlarmPushOptions {
+  deviceToken: string;
+  pushId: string;
+  /** 사용자가 지금 있는 역(환승 waypoint 도달 시점). */
+  originStation: string;
+  /** 환승 후 다음 leg의 노선. 알림 본문 노출용. */
+  nextLine: string;
+  /** 환승 후 첫 도착역. 알림 본문 + dedup key. */
+  nextStation: string;
+  /** trip 토큰 — device dedup key + `apns-thread-id` grouping. */
+  tripToken: string;
+  sentAt: number;
+  /**
+   * 사용자 표시용 제목. 미지정 시 device fallback ('곧 환승역입니다').
+   * i18n resolve는 backend caller가 담당 (locale 정보 전파 시).
+   */
+  title?: string;
+  /**
+   * 사용자 표시용 본문. 미지정 시 device fallback (`${originStation}에서 ${nextLine}호선 ${nextStation}으로 환승`).
+   */
+  body?: string;
+  config: ApnsConfig;
+  host: string;
+  fetchImpl?: typeof fetch;
+  now?: number;
+}
+
+export async function sendSleepTransferAlarmPush(
+  options: SendSleepTransferAlarmPushOptions,
+): Promise<SendPushResult> {
+  const jwt = await buildApnsJwt(options.config, options.now);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const url = `https://${options.host}/3/device/${options.deviceToken}`;
+
+  const body = JSON.stringify({
+    aps: { 'content-available': 1 },
+    data: {
+      kind: 'sleep-transfer-alarm',
+      originStation: options.originStation,
+      nextLine: options.nextLine,
+      nextStation: options.nextStation,
+      tripToken: options.tripToken,
+      pushId: options.pushId,
+      sentAt: options.sentAt,
+      // title/body 는 정의된 경우만 wire (미지정 시 device fallback).
+      ...(options.title !== undefined ? { title: options.title } : {}),
+      ...(options.body !== undefined ? { body: options.body } : {}),
+    },
+  });
+
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      authorization: `bearer ${jwt}`,
+      'apns-topic': options.config.bundleId,
+      'apns-push-type': 'background',
+      'apns-priority': '5',
+      'content-type': 'application/json',
+      // #1788 — thread-id groups notifications by trip.
+      'apns-thread-id': options.tripToken,
+    },
+    body,
+  });
+
+  if (response.ok) return { ok: true, status: response.status };
+  return parseApnsError(response);
+}
+
 async function parseApnsError(response: Response): Promise<SendPushResult> {
   let reason: string | undefined;
   try {

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -9,6 +9,7 @@ import {
   sendBoardingPromptSilentPush,
   sendReschedulePush,
   sendSilentPush,
+  sendSleepTransferAlarmPush,
   type ApnsConfig,
   type PushOrigin,
   type SilentPushPayload,
@@ -3009,6 +3010,59 @@ export async function advanceBoardingLockWaypoint(
       log,
       generatePushId: () => crypto.randomUUID(),
     });
+  }
+  // #2036 (Issue I γ) — 취침모드 환승 알람 silent push. 사용자 확정 flow:
+  //   "환승역 → 취침모드 시 알람 발사, 일반모드는 일반 상황과 동일".
+  //
+  // 정책 (ADR-023 정합):
+  //   - Backend는 취침 무관 발사 (본 블록은 sleepMode 조회하지 않음).
+  //   - Device silentPushTask가 payload 수신 → SLEEP_MODE_KEY read → sleepMode=true 시에만 발사.
+  //   - waypoint.kind === 'transfer' + 다음 waypoint(=leg 2 첫 역) 존재해야 발사 대상.
+  //   - waypoint 소진(waypoints.length === 0) 케이스는 destination-arrived path로 위임 (본 push 미발사).
+  //
+  // dedup은 device 측 in-memory Set(`${tripToken}::${nextStation}`)가 담당 — backend는 idempotent 발사.
+  // 실패해도 별 채널(transfer-release, LA update)이 leg-transition sync를 지속하므로 retry queue 미적재.
+  if (waypoint.kind === 'transfer' && trip.waypoints.length > 0) {
+    const nextHop = trip.waypoints[0];
+    const sleepPushId = crypto.randomUUID();
+    const sleepHeal = await sendWithEnvHeal(
+      (host) =>
+        sendSleepTransferAlarmPush({
+          deviceToken: trip.token,
+          pushId: sleepPushId,
+          originStation: waypoint.stationName,
+          nextLine: nextHop.line,
+          nextStation: nextHop.stationName,
+          tripToken: trip.token,
+          sentAt: now,
+          config: deps.apnsConfig,
+          host,
+          fetchImpl: deps.fetchImpl,
+          now,
+        }),
+      trip.apnsEnv,
+      deps.apnsHosts,
+      log,
+      trip.token.slice(0, 8),
+    );
+    if (sleepHeal.correctedEnv) {
+      trip.apnsEnv = sleepHeal.correctedEnv;
+      stats.envCorrected += 1;
+    }
+    if (sleepHeal.result.ok) {
+      log('boarding-lock: sleep-transfer-alarm fired', {
+        token: trip.token.slice(0, 8),
+        originStation: waypoint.stationName,
+        nextLine: nextHop.line,
+        nextStation: nextHop.stationName,
+      });
+    } else {
+      log('boarding-lock: sleep-transfer-alarm push failed', {
+        token: trip.token.slice(0, 8),
+        status: sleepHeal.result.status,
+        reason: sleepHeal.result.reason,
+      });
+    }
   }
   // #1729 paradigm shift — 환승 직후 자동 trainCode swap 제거(Path B' 환승 버전).
   // 사용자가 BoardingTrainList에서 명시 탭하지 않은 trainCode에 backend가 자동으로 lock 부착 X.

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -40,6 +40,7 @@ const mockLogSilentPushSkipped = jest.fn();
 const mockLogCrossTripMirrorSkip = jest.fn();
 const mockLogSuppressedChannelAgnosticDedup = jest.fn();
 const mockLogBoardingPromptFired = jest.fn();
+const mockLogSleepTransferAlarmFired = jest.fn();
 const mockFlushAlarmLog = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../utils/alarmLog', () => ({
   logSilentPushReceived: (...args: unknown[]) => mockLogSilentPushReceived(...args),
@@ -53,7 +54,14 @@ jest.mock('../../utils/alarmLog', () => ({
   logSuppressedChannelAgnosticDedup: (...args: unknown[]) =>
     mockLogSuppressedChannelAgnosticDedup(...args),
   logBoardingPromptFired: (...args: unknown[]) => mockLogBoardingPromptFired(...args),
+  logSleepTransferAlarmFired: (...args: unknown[]) => mockLogSleepTransferAlarmFired(...args),
   flushAlarmLog: () => mockFlushAlarmLog(),
+}));
+
+// #2036 (Issue I γ) — sleep-transfer-alarm 발사 시 vibrateAlarm(true) 호출. mock으로 호출 횟수 검증.
+const mockVibrateAlarm = jest.fn();
+jest.mock('../../utils/alarmSound', () => ({
+  vibrateAlarm: (...args: unknown[]) => mockVibrateAlarm(...args),
 }));
 
 // #1901/#1900 (RC-7/RC-10a) — channel-agnostic 8분 backstop. silent push fire 직전 gate +
@@ -270,6 +278,7 @@ jest.mock('i18next', () => ({
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   __resetBoardingPromptSilentPushDedup,
+  __resetSleepTransferAlarmSilentPushDedup,
   extractPayload,
   getSilentPushRegistrationStatus,
   handleSilentPush,
@@ -285,6 +294,7 @@ import {
   BACKEND_SSOT_MIRROR_KEY,
   DESTINATION_KEY,
   ROUTE_KEY,
+  SLEEP_MODE_KEY,
 } from '../../../../shared/constants/storageKeys';
 
 const DEFAULT_APNS_TOKEN = 'apns-tok-hex';
@@ -1310,6 +1320,173 @@ describe('silentPushTask', () => {
             }),
           ),
         ).toMatchObject({ nextLine: undefined, nextStation: undefined });
+      });
+    });
+
+    // #2036 (Issue I γ) — sleep-transfer-alarm silent push payload (취침모드 환승 알람 채널).
+    describe('sleep-transfer-alarm kind (#2036)', () => {
+      it('정상 sleep-transfer-alarm payload → SleepTransferAlarmSilentPushPayload', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'sleep-transfer-alarm',
+              originStation: '성수',
+              nextLine: '2',
+              nextStation: '뚝섬',
+              tripToken: 'tok-sta',
+              sentAt: 1_780_000_000_000,
+              pushId: 'uuid-sta',
+              title: '곧 환승역입니다',
+              body: '성수에서 2호선 뚝섬으로 환승',
+            }),
+          ),
+        ).toEqual({
+          kind: 'sleep-transfer-alarm',
+          originStation: '성수',
+          nextLine: '2',
+          nextStation: '뚝섬',
+          tripToken: 'tok-sta',
+          sentAt: 1_780_000_000_000,
+          pushId: 'uuid-sta',
+          title: '곧 환승역입니다',
+          body: '성수에서 2호선 뚝섬으로 환승',
+        });
+      });
+
+      it('originStation 누락/빈 문자열이면 null', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'sleep-transfer-alarm',
+              nextLine: '2',
+              nextStation: '뚝섬',
+              tripToken: 'T',
+            }),
+          ),
+        ).toBeNull();
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'sleep-transfer-alarm',
+              originStation: '',
+              nextLine: '2',
+              nextStation: '뚝섬',
+              tripToken: 'T',
+            }),
+          ),
+        ).toBeNull();
+      });
+
+      it('nextLine 누락/빈 문자열이면 null', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'sleep-transfer-alarm',
+              originStation: '성수',
+              nextStation: '뚝섬',
+              tripToken: 'T',
+            }),
+          ),
+        ).toBeNull();
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'sleep-transfer-alarm',
+              originStation: '성수',
+              nextLine: '',
+              nextStation: '뚝섬',
+              tripToken: 'T',
+            }),
+          ),
+        ).toBeNull();
+      });
+
+      it('nextStation 누락/빈 문자열이면 null', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'sleep-transfer-alarm',
+              originStation: '성수',
+              nextLine: '2',
+              tripToken: 'T',
+            }),
+          ),
+        ).toBeNull();
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'sleep-transfer-alarm',
+              originStation: '성수',
+              nextLine: '2',
+              nextStation: '',
+              tripToken: 'T',
+            }),
+          ),
+        ).toBeNull();
+      });
+
+      it('tripToken 누락/빈 문자열이면 null (dedup key 필수)', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'sleep-transfer-alarm',
+              originStation: '성수',
+              nextLine: '2',
+              nextStation: '뚝섬',
+            }),
+          ),
+        ).toBeNull();
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'sleep-transfer-alarm',
+              originStation: '성수',
+              nextLine: '2',
+              nextStation: '뚝섬',
+              tripToken: '',
+            }),
+          ),
+        ).toBeNull();
+      });
+
+      it('optional 필드(sentAt/pushId/title/body) 누락 시 undefined', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'sleep-transfer-alarm',
+              originStation: '성수',
+              nextLine: '2',
+              nextStation: '뚝섬',
+              tripToken: 'T',
+            }),
+          ),
+        ).toEqual({
+          kind: 'sleep-transfer-alarm',
+          originStation: '성수',
+          nextLine: '2',
+          nextStation: '뚝섬',
+          tripToken: 'T',
+          sentAt: undefined,
+          pushId: undefined,
+          title: undefined,
+          body: undefined,
+        });
+      });
+
+      it('title/body가 빈 문자열이면 undefined로 정규화 (fallback 트리거)', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'sleep-transfer-alarm',
+              originStation: '성수',
+              nextLine: '2',
+              nextStation: '뚝섬',
+              tripToken: 'T',
+              title: '',
+              body: '',
+            }),
+          ),
+        ).toMatchObject({ title: undefined, body: undefined });
       });
     });
   });
@@ -3707,6 +3884,267 @@ describe('silentPushTask', () => {
           await handleSilentPush(hopEndPayload({ pushId: 'hop-q' }));
           expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
         });
+      });
+    });
+
+    // #2036 (Issue I γ) — sleep-transfer-alarm silent push: gate 무관 로컬 알림 (sleepMode=true 시).
+    describe('sleep-transfer-alarm kind (#2036) — 취침모드 환승 알람 채널', () => {
+      function sleepTransferPayload(extra: Record<string, unknown> = {}) {
+        return {
+          data: {
+            data: {
+              data: {
+                kind: 'sleep-transfer-alarm',
+                originStation: '성수',
+                nextLine: '2',
+                nextStation: '뚝섬',
+                tripToken: 'tok-sta',
+                ...extra,
+              },
+              dataString: null,
+            },
+            notification: null,
+            aps: { 'content-available': 1 },
+          },
+        };
+      }
+
+      /** sleepMode=true를 AsyncStorage에 세팅한다. 기본 destStation/APNS token 유지. */
+      function setSleepMode(enabled: boolean): void {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          if (key === SLEEP_MODE_KEY) return JSON.stringify(enabled);
+          return null;
+        });
+      }
+
+      beforeEach(() => {
+        __resetSleepTransferAlarmSilentPushDedup();
+      });
+
+      it('sleepMode=true 수신 → scheduleNotificationAsync 즉시 호출 (gate 무관)', async () => {
+        setSleepMode(true);
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+        expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+        // standard 발사 경로는 호출되지 않아야 함.
+        expect(mockCheckGate).not.toHaveBeenCalled();
+        expect(mockLogSilentPushReceived).not.toHaveBeenCalled();
+        expect(mockLogSilentPushFired).not.toHaveBeenCalled();
+      });
+
+      it('sleepMode=false 수신 → 알림 발사 안 함 + ack(skipped, not-sleep-mode)', async () => {
+        setSleepMode(false);
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockVibrateAlarm).not.toHaveBeenCalled();
+        expect(mockLogSleepTransferAlarmFired).not.toHaveBeenCalled();
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'sta-1',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'skipped',
+          reason: 'sleep-transfer-not-sleep-mode',
+          permissionMode: 'always',
+        });
+      });
+
+      it('SLEEP_MODE_KEY 저장값 없음 → 취침 아님으로 판정 (fail-closed)', async () => {
+        // 기본 mock — SLEEP_MODE_KEY 는 null 반환.
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          expect.objectContaining({ outcome: 'skipped', reason: 'sleep-transfer-not-sleep-mode' }),
+        );
+      });
+
+      it('SLEEP_MODE_KEY read throw → 취침 아님으로 판정 (fail-closed graceful)', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          if (key === SLEEP_MODE_KEY) throw new Error('storage-fail');
+          return null;
+        });
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+      });
+
+      it('scheduleNotificationAsync content: title/body/sound/data/interruptionLevel 포함', async () => {
+        setSleepMode(true);
+        await handleSilentPush(
+          sleepTransferPayload({
+            pushId: 'sta-1',
+            title: '곧 환승역입니다',
+            body: '성수에서 2호선 뚝섬으로 환승',
+          }),
+        );
+        expect(mockScheduleNotificationAsync).toHaveBeenCalledWith({
+          identifier: 'sleep-transfer-alarm-silent-push',
+          content: {
+            title: '곧 환승역입니다',
+            body: '성수에서 2호선 뚝섬으로 환승',
+            sound: 'alarm.wav',
+            data: {
+              kind: 'sleep-transfer-alarm',
+              originStation: '성수',
+              nextLine: '2',
+              nextStation: '뚝섬',
+              tripToken: 'tok-sta',
+            },
+            interruptionLevel: 'timeSensitive',
+          },
+          trigger: null,
+        });
+      });
+
+      it('title/body 누락 시 device fallback 문자열 사용', async () => {
+        setSleepMode(true);
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+        const call = mockScheduleNotificationAsync.mock.calls[0][0] as {
+          content: { title: string; body: string };
+        };
+        expect(call.content.title).toBe('곧 환승역입니다');
+        expect(call.content.body).toContain('성수');
+        expect(call.content.body).toContain('2호선');
+        expect(call.content.body).toContain('뚝섬');
+      });
+
+      it('발사 시 vibrateAlarm(true) 호출 (사용자 확정 flow: 소리+진동)', async () => {
+        setSleepMode(true);
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+        expect(mockVibrateAlarm).toHaveBeenCalledWith(true);
+      });
+
+      it('발사 시 logSleepTransferAlarmFired 호출 (Acceptance dashboard 반영)', async () => {
+        setSleepMode(true);
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+        expect(mockLogSleepTransferAlarmFired).toHaveBeenCalledWith({
+          originStation: '성수',
+          nextStation: '뚝섬',
+          nextLine: '2',
+        });
+      });
+
+      it('같은 tripToken + nextStation 세션 내 두 번째 수신은 dedup skip', async () => {
+        setSleepMode(true);
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-2' }));
+        expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+        expect(mockVibrateAlarm).toHaveBeenCalledTimes(1);
+      });
+
+      it('같은 tripToken + 다른 nextStation은 각각 발사 (다음 환승 hop 커버)', async () => {
+        setSleepMode(true);
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1', nextStation: '뚝섬' }));
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-2', nextStation: '한양대' }));
+        expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(2);
+      });
+
+      it('다른 tripToken 수신은 각각 발사', async () => {
+        setSleepMode(true);
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1', tripToken: 'tok-A' }));
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-2', tripToken: 'tok-B' }));
+        expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(2);
+      });
+
+      it('gate/location 등 다른 mock은 호출 안 됨 (unconditional path)', async () => {
+        setSleepMode(true);
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+        expect(mockCheckGate).not.toHaveBeenCalled();
+        expect(mockGetDismissSilence).not.toHaveBeenCalled();
+        expect(mockGetMotionStationary).not.toHaveBeenCalled();
+        expect(mockGetFiredAlarms).not.toHaveBeenCalled();
+      });
+
+      it('pushId 있으면 ack(fired, sleep-transfer-alarm) 전송', async () => {
+        setSleepMode(true);
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'sta-1',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'fired',
+          reason: 'sleep-transfer-alarm',
+          permissionMode: 'always',
+        });
+      });
+
+      it('pushId 없으면 fired ack 호출 안 함 (구 backend 호환) — schedule은 진행', async () => {
+        setSleepMode(true);
+        await handleSilentPush(sleepTransferPayload());
+        const firedCalls = mockSendPushAck.mock.calls.filter(
+          (call) => (call[0] as { outcome?: string }).outcome === 'fired',
+        );
+        expect(firedCalls).toHaveLength(0);
+        expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+      });
+
+      it('dedup skip 시 ack(skipped, sleep-transfer-dedup) 전송', async () => {
+        setSleepMode(true);
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+        mockSendPushAck.mockClear();
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-2' }));
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'sta-2',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'skipped',
+          reason: 'sleep-transfer-dedup',
+          permissionMode: 'always',
+        });
+      });
+
+      it('scheduleNotificationAsync throw해도 후속 흐름 차단 안 함 + ack skipped 전송', async () => {
+        setSleepMode(true);
+        mockScheduleNotificationAsync.mockRejectedValueOnce(new Error('schedule fail'));
+        await expect(
+          handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' })),
+        ).resolves.toBeUndefined();
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'sta-1',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'skipped',
+          reason: 'sleep-transfer-schedule-failed',
+          permissionMode: 'always',
+        });
+      });
+
+      it('schedule 실패로 dedup 등록 상태 — 재시도가 새 알림을 발사하지 않음', async () => {
+        setSleepMode(true);
+        mockScheduleNotificationAsync.mockRejectedValueOnce(new Error('schedule fail'));
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+        mockScheduleNotificationAsync.mockClear();
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-2' }));
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+      });
+
+      it('domain breadcrumb 발사 (dashboard 관측)', async () => {
+        setSleepMode(true);
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+        expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith(
+          'push',
+          'sleep-transfer-alarm-fired',
+          { nextLine: '2', originStation: '성수', nextStation: '뚝섬' },
+        );
+      });
+
+      it('sleepMode=false 시 dedup 등록 안 함 → 이후 sleepMode=true 전환 재시도는 정상 발사', async () => {
+        setSleepMode(false);
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        // 사용자가 취침모드 ON 후 backend 재시도.
+        setSleepMode(true);
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-2' }));
+        expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+      });
+
+      it('sleep-transfer-alarm 발사 후에도 refreshLiveActivityFromBackgroundContext 1회 호출 (#1935 정합)', async () => {
+        setSleepMode(true);
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+        expect(mockRefreshLa).toHaveBeenCalledTimes(1);
+      });
+
+      it('sleepMode=false skip 후에도 refreshLA 1회 호출 (#1935 정합)', async () => {
+        setSleepMode(false);
+        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+        expect(mockRefreshLa).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -40,6 +40,7 @@ import {
   APNS_TOKEN_KEY,
   ACTIVE_TRIP_KEY,
   DESTINATION_KEY,
+  SLEEP_MODE_KEY,
 } from '../../../shared/constants/storageKeys';
 import { sendPushAck } from '../api/alarmBackend';
 import { createLogger } from '../../../shared/utils/logger';
@@ -52,9 +53,11 @@ import {
   logSilentPushTripEndedReceived,
   logSilentPushFired,
   logSilentPushSkipped,
+  logSleepTransferAlarmFired,
   logSuppressedChannelAgnosticDedup,
   type AlarmLogReason,
 } from '../utils/alarmLog';
+import { vibrateAlarm } from '../utils/alarmSound';
 import {
   isAnyChannelRecentlyFired,
   markStationFired,
@@ -118,6 +121,12 @@ export const SILENT_PUSH_TASK = 'silent-push-reschedule';
 const BOARDING_PROMPT_NOTIFICATION_ID = 'boarding-prompt-silent-push';
 
 /**
+ * #2036 (Issue I γ) — 취침모드 환승 알람 local notification identifier.
+ * 같은 identifier로 schedule하면 iOS가 이전 알림을 대체 — 사용자 tray에 1건만 유지.
+ */
+const SLEEP_TRANSFER_ALARM_NOTIFICATION_ID = 'sleep-transfer-alarm-silent-push';
+
+/**
  * #2028 — tripToken 세션 스코프 dedup. 같은 tripToken으로 여러 backend cron 재시도가 도달해도
  * 로컬 알림을 1회만 발사한다. in-memory Set — 앱 재시작(cold-launch) 시 자연 초기화되지만
  * backend `boardingPromptState.promptedAt` dedup이 자체 재발사를 차단하므로 회귀 없음.
@@ -125,9 +134,29 @@ const BOARDING_PROMPT_NOTIFICATION_ID = 'boarding-prompt-silent-push';
  */
 const boardingPromptFiredTripTokens = new Set<string>();
 
+/**
+ * #2036 (Issue I γ) — 취침모드 환승 알람 dedup. tripToken + nextStation 조합 스코프.
+ * 같은 trip의 다른 환승역(예: 강남→성수 후 성수→내방)은 별 hop이라 nextStation이 다르므로
+ * 각각 발사됨. backend cron retry(같은 hop 재시도)만 dedup 대상. in-memory Set — 앱 재시작
+ * 시 자연 초기화되지만 backend가 waypoint advance 후 재발사하지 않으므로 회귀 없음.
+ */
+const sleepTransferAlarmFiredKeys = new Set<string>();
+
+function sleepTransferAlarmDedupKey(tripToken: string, nextStation: string): string {
+  return `${tripToken}::${nextStation}`;
+}
+
 /** 테스트 격리용 — dedup set을 비운다. production 코드에서는 호출하지 않는다. */
 export function __resetBoardingPromptSilentPushDedup(): void {
   boardingPromptFiredTripTokens.clear();
+}
+
+/**
+ * #2036 (Issue I γ) — 테스트 격리용. sleep-transfer alarm dedup set을 비운다.
+ * production 코드에서는 호출하지 않는다.
+ */
+export function __resetSleepTransferAlarmSilentPushDedup(): void {
+  sleepTransferAlarmFiredKeys.clear();
 }
 
 export interface SilentPushPayload {
@@ -329,6 +358,51 @@ export interface BoardingPromptSilentPushPayload {
 }
 
 /**
+ * 취침모드 환승 알람 silent push payload (#2036 Issue I γ).
+ *
+ * 사용자 확정 flow: "환승역 → 분기 → 취침모드 시 알람 발사, 일반모드는 일반 상황과 동일".
+ * 즉 취침모드에서 환승 임박 시 소리+진동+잠금화면 알림이 필요.
+ *
+ * 정책 (ADR-023 정합):
+ *  - **Backend는 취침 무관 발사** (기존 arvlCd/vanish/lockless 발사기가 취침 상태 조회하지 않음).
+ *  - **Device가 sleepMode=true 확인 후 발사 결정** (`SLEEP_MODE_KEY` AsyncStorage read).
+ *  - **destination은 별 채널** — 기존 station-passed dedup으로 처리, 본 payload는 transfer 전용.
+ *  - gate 무관 (location / silence / motion / dedup 모두 skip) — 도달률 우선. boarding-prompt와 같은 정책.
+ *
+ * Critical alert entitlement 없이 최대 UX 근사: `interruptionLevel: 'timeSensitive'` + `sound: 'alarm.wav'`
+ * + `vibrateAlarm(sleepMode=true)`(반복 진동). Focus/DND 완전 우회는 Apple entitlement 승인 필요 — 별 track.
+ *
+ * dedup: `${tripToken}::${nextStation}` 조합 — 같은 hop의 backend cron 재시도만 차단, trip 안의 다른
+ * 환승 hop(강남→성수→내방 같은 케이스)은 각각 발사.
+ */
+export interface SleepTransferAlarmSilentPushPayload {
+  kind: 'sleep-transfer-alarm';
+  /** 사용자가 지금 있는 역(환승 waypoint 도달 시점). 사용자 컨텍스트/dedup 기록용. */
+  originStation: string;
+  /** 환승 후 다음 leg의 노선. 알림 본문에 노출. */
+  nextLine: string;
+  /** 환승 후 첫 도착역. 알림 본문 + dedup key로 사용. */
+  nextStation: string;
+  /** trip 토큰 — dedup key. backend cron retry 차단용. */
+  tripToken: string;
+  /**
+   * push의 unique 식별자. backend `/push/ack`에 필요.
+   * 구 backend 호환 위해 optional — 누락 시 ACK skip.
+   */
+  pushId?: string;
+  /** 백엔드 발사 시점 epoch ms. 구 backend 호환 위해 optional. */
+  sentAt?: number;
+  /**
+   * 사용자 표시 title (backend가 i18n resolve해서 넣어줌). 미지정 시 device fallback.
+   */
+  title?: string;
+  /**
+   * 사용자 표시 body (backend가 i18n resolve해서 넣어줌). 미지정 시 device fallback.
+   */
+  body?: string;
+}
+
+/**
  * Trip ended silent push payload (#868). 백엔드가 server-side로 trip을 자동 종료했을 때
  * 클라이언트의 route/destination/lock state를 동기화하라는 신호. backend `apns.ts`의
  * `TripEndedPushPayload`와 1:1.
@@ -362,12 +436,13 @@ export type TripEndedReason =
   | 'push-unrecoverable'
   | 'unknown';
 
-/** extractPayload 결과 — standard silent push / reschedule push / trip-ended push / boarding-prompt push. */
+/** extractPayload 결과 — standard silent push / reschedule / trip-ended / boarding-prompt / sleep-transfer-alarm. */
 export type ExtractedPayload =
   | SilentPushPayload
   | RescheduleSilentPushPayload
   | TripEndedSilentPushPayload
-  | BoardingPromptSilentPushPayload;
+  | BoardingPromptSilentPushPayload
+  | SleepTransferAlarmSilentPushPayload;
 
 /**
  * expo-notifications iOS의 `BackgroundEventTransformer.swift`가 APNs payload를
@@ -431,6 +506,10 @@ function isBoardingPromptCandidate(rec: Record<string, unknown>): boolean {
   return rec.kind === 'boarding-prompt';
 }
 
+function isSleepTransferAlarmCandidate(rec: Record<string, unknown>): boolean {
+  return rec.kind === 'sleep-transfer-alarm';
+}
+
 function findFieldsLayer(
   taskData: NotificationBackgroundTaskData['data'],
 ): Record<string, unknown> | null {
@@ -450,7 +529,8 @@ function findFieldsLayer(
       isStandardCandidate(rec) ||
       isRescheduleCandidate(rec) ||
       isTripEndedCandidate(rec) ||
-      isBoardingPromptCandidate(rec)
+      isBoardingPromptCandidate(rec) ||
+      isSleepTransferAlarmCandidate(rec)
     ) {
       return rec;
     }
@@ -476,6 +556,8 @@ export function extractPayload(
   if (obj.kind === 'trip-ended') return extractTripEndedPayload(obj);
   // boarding-prompt 분기 (#2028) — Layer 2 사용자 도달. discriminator는 kind === 'boarding-prompt'.
   if (obj.kind === 'boarding-prompt') return extractBoardingPromptPayload(obj);
+  // sleep-transfer-alarm 분기 (#2036 Issue I γ) — 취침 시 환승 알람. discriminator는 kind === 'sleep-transfer-alarm'.
+  if (obj.kind === 'sleep-transfer-alarm') return extractSleepTransferAlarmPayload(obj);
   return extractStandardPayload(obj);
 }
 
@@ -737,6 +819,35 @@ function extractBoardingPromptPayload(
     nextLine: typeof nextLine === 'string' && nextLine.length > 0 ? nextLine : undefined,
     nextStation:
       typeof nextStation === 'string' && nextStation.length > 0 ? nextStation : undefined,
+  };
+}
+
+/**
+ * sleep-transfer-alarm payload 추출 (#2036 Issue I γ). schema — kind + originStation + nextLine +
+ * nextStation + tripToken은 필수. pushId / sentAt / title / body 는 optional (구 backend 호환).
+ *
+ * 필수 필드(originStation/nextLine/nextStation/tripToken) 중 하나라도 비어 있으면 null → 발사 skip.
+ * 발사에 필요한 최소 정보(사용자 컨텍스트/dedup)를 갖추지 못한 payload는 backend 정상 wire 문제로
+ * 판정 — device는 조용히 drop.
+ */
+function extractSleepTransferAlarmPayload(
+  obj: Record<string, unknown>,
+): SleepTransferAlarmSilentPushPayload | null {
+  const { originStation, nextLine, nextStation, tripToken, pushId, sentAt, title, body } = obj;
+  if (typeof originStation !== 'string' || originStation.length === 0) return null;
+  if (typeof nextLine !== 'string' || nextLine.length === 0) return null;
+  if (typeof nextStation !== 'string' || nextStation.length === 0) return null;
+  if (typeof tripToken !== 'string' || tripToken.length === 0) return null;
+  return {
+    kind: 'sleep-transfer-alarm',
+    originStation,
+    nextLine,
+    nextStation,
+    tripToken,
+    pushId: validPushId(pushId),
+    sentAt: validSentAt(sentAt),
+    title: typeof title === 'string' && title.length > 0 ? title : undefined,
+    body: typeof body === 'string' && body.length > 0 ? body : undefined,
   };
 }
 
@@ -1098,6 +1209,21 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
       return;
     }
 
+    // sleep-transfer-alarm 분기 (#2036 Issue I γ) — 취침모드 환승 알람. gate 무관 로컬 알림 발사.
+    //
+    // 정책 (ADR-023 정합):
+    //  - Backend는 취침 무관 발사 (기존 arvlCd/vanish 경로는 sleep 조회 없음).
+    //  - Device가 `SLEEP_MODE_KEY` AsyncStorage read로 sleepMode=true 확인 후에만 발사.
+    //  - sleepMode=false면 일반모드 = 기존 station-passed silent push가 처리 → 본 분기는 no-op skip.
+    //  - dedup: `${tripToken}::${nextStation}` — 같은 hop의 backend cron retry 차단, trip 안 다른 환승 hop은 각각 발사.
+    if (payload.kind === 'sleep-transfer-alarm') {
+      logger.info(
+        `sleep-transfer-alarm received: originStation=${payload.originStation} nextLine=${payload.nextLine} nextStation=${payload.nextStation} tripToken=${payload.tripToken.slice(0, 8)} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
+      );
+      await fireSleepTransferAlarmLocalNotification(payload, apnsToken);
+      return;
+    }
+
     logger.info(
       `received: kind=${payload.kind ?? 'unknown'} phase=${payload.phase} station=${payload.nextWaypoint} eta=${payload.etaSeconds} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
     );
@@ -1438,6 +1564,118 @@ async function fireBoardingPromptLocalNotification(
   } catch (e) {
     logger.error('boarding-prompt local notification schedule 실패:', e);
     void ackOutcome(payload.pushId, apnsToken, 'skipped', 'boarding-prompt-schedule-failed');
+  }
+}
+
+/**
+ * #2036 (Issue I γ) — AsyncStorage에서 sleepMode 값 읽기 (BG-safe).
+ *
+ * silent push handler는 BG task라 zustand store 접근 불가 — AsyncStorage 직접 read.
+ * `useSettingsStore.setSleepMode`가 JSON.stringify(boolean)으로 저장하므로 그대로 파싱.
+ * 저장값 부재 / 파싱 실패는 false 반환 — 취침 아님으로 판정해 발사 skip (보수적).
+ */
+async function readSleepModeFromStorage(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(SLEEP_MODE_KEY);
+    if (!raw) return false;
+    return JSON.parse(raw) === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * #2036 (Issue I γ) — 취침모드 환승 알람 silent push 수신 시 로컬 알림 발사.
+ *
+ * 절차:
+ *   1. sleepMode=false → 일반모드 = 기존 station-passed silent push가 이미 처리 → skip.
+ *   2. dedup key(`${tripToken}::${nextStation}`) 확인 → 이미 발사 시 skip (backend cron retry 차단).
+ *   3. dedup 등록 + Notifications.scheduleNotificationAsync 발사.
+ *      - sound: 'alarm.wav' (loud, boarding-prompt의 'default'보다 강함)
+ *      - interruptionLevel: 'timeSensitive' (Focus 관통, DND 부분 관통)
+ *      - vibrateAlarm(true) — 반복 진동 (사용자 확정 flow: 소리+진동)
+ *   4. 실패 시 dedup 유지 + ack skipped — cron retry가 재발사하지 않도록 함.
+ *
+ * gate 무관 (location / silence / motion / dedup 모두 skip) — boarding-prompt와 같은 도달률 우선 정책.
+ * 사용자 확정 flow (`project_2026_07_03_user_manual_action_flow`): "환승역 → 취침 시 알람 발사".
+ *
+ * ADR-023 정합: backend는 취침 무관 발사, device가 필터 → 본 함수가 device 필터의 결정 지점.
+ */
+async function fireSleepTransferAlarmLocalNotification(
+  payload: SleepTransferAlarmSilentPushPayload,
+  apnsToken: string | null,
+): Promise<void> {
+  // sleepMode=false → 일반모드. 기존 경로가 처리 — 본 채널은 no-op.
+  const sleepMode = await readSleepModeFromStorage();
+  if (!sleepMode) {
+    logger.info(
+      `sleep-transfer-alarm skip: sleepMode=false (일반모드는 기존 station-passed 경로 처리)`,
+    );
+    void ackOutcome(payload.pushId, apnsToken, 'skipped', 'sleep-transfer-not-sleep-mode');
+    return;
+  }
+
+  // dedup — tripToken + nextStation 조합. 같은 hop의 backend cron retry만 차단.
+  const dedupKey = sleepTransferAlarmDedupKey(payload.tripToken, payload.nextStation);
+  if (sleepTransferAlarmFiredKeys.has(dedupKey)) {
+    logger.info(
+      `sleep-transfer-alarm dedup: tripToken=${payload.tripToken.slice(0, 8)} nextStation=${payload.nextStation} already fired in session — skip`,
+    );
+    void ackOutcome(payload.pushId, apnsToken, 'skipped', 'sleep-transfer-dedup');
+    return;
+  }
+
+  // dedup 등록 먼저 — scheduleNotificationAsync 실패해도 재시도로 반복 발사되지 않도록.
+  sleepTransferAlarmFiredKeys.add(dedupKey);
+
+  // 사용자 표시 문구. backend 우선 → device fallback.
+  const title = payload.title ?? '곧 환승역입니다';
+  const body =
+    payload.body ??
+    `${payload.originStation}에서 ${payload.nextLine}호선 ${payload.nextStation}으로 환승`;
+
+  const data: Record<string, unknown> = {
+    kind: 'sleep-transfer-alarm',
+    originStation: payload.originStation,
+    nextLine: payload.nextLine,
+    nextStation: payload.nextStation,
+    tripToken: payload.tripToken,
+  };
+
+  try {
+    await Notifications.scheduleNotificationAsync({
+      identifier: SLEEP_TRANSFER_ALARM_NOTIFICATION_ID,
+      content: {
+        title,
+        body,
+        // 취침모드 알람 — loud sound. 일반 알람과 동일한 파일(`stationNotification.ts:602`) 사용.
+        sound: 'alarm.wav',
+        data,
+        // Focus 관통 (Sleep Focus 부분 관통). Critical alert entitlement 승인 시 'critical'로 승격 예정.
+        interruptionLevel: 'timeSensitive',
+      },
+      trigger: null,
+    });
+    // 사용자 확정 flow: 소리+진동. sleepMode=true → repeat 진동.
+    vibrateAlarm(true);
+    // #2036 Acceptance dashboard — sleep-transfer-alarm fired 카운트.
+    logSleepTransferAlarmFired({
+      originStation: payload.originStation,
+      nextStation: payload.nextStation,
+      nextLine: payload.nextLine,
+    });
+    addDomainBreadcrumb('push', 'sleep-transfer-alarm-fired', {
+      nextLine: payload.nextLine,
+      originStation: payload.originStation,
+      nextStation: payload.nextStation,
+    });
+    logger.info(
+      `sleep-transfer-alarm fired: originStation=${payload.originStation} nextLine=${payload.nextLine} nextStation=${payload.nextStation} tripToken=${payload.tripToken.slice(0, 8)}`,
+    );
+    void ackOutcome(payload.pushId, apnsToken, 'fired', 'sleep-transfer-alarm');
+  } catch (e) {
+    logger.error('sleep-transfer-alarm local notification schedule 실패:', e);
+    void ackOutcome(payload.pushId, apnsToken, 'skipped', 'sleep-transfer-schedule-failed');
   }
 }
 

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -77,6 +77,7 @@ import {
   lastNReasons,
   logBoardingPromptFired,
   logBoardingPromptResponded,
+  logSleepTransferAlarmFired,
   logLegTransition,
   BOARDING_PROMPT_WINDOWS,
   countBoardingPromptByWindow,
@@ -2234,6 +2235,42 @@ describe('alarmLog', () => {
       expect(saved[0].source).toBe('boarding-prompt');
       expect(saved[0].outcome).toBe('fired');
       expect(saved[0].stationName).toBe('2·강남');
+    });
+
+    it('#2036 (Issue I γ): logSleepTransferAlarmFired가 sleep-transfer-alarm entry를 적재한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logSleepTransferAlarmFired({
+        originStation: '성수',
+        nextStation: '뚝섬',
+        nextLine: '2',
+      });
+      await flushAlarmLog();
+      const saved = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
+      expect(saved).toHaveLength(1);
+      expect(saved[0].source).toBe('sleep-transfer-alarm');
+      expect(saved[0].outcome).toBe('fired');
+      expect(saved[0].stationName).toBe('2·뚝섬');
+    });
+
+    it('#2036 (Issue I γ): sleep-transfer-alarm source는 silent push outcome 집계에서 제외 (null bucket)', () => {
+      const now = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        { ts: now - 1000, source: 'sleep-transfer-alarm', outcome: 'fired' },
+        { ts: now - 2000, source: 'silent-push-fired', outcome: 'fired' },
+      ];
+      const counts = countSilentPushOutcomes(entries);
+      // sleep-transfer-alarm은 SILENT_PUSH_OUTCOME_SOURCES에서 null bucket — silent push 카운터에 미반영.
+      expect(counts).toEqual({ received: 0, fired: 1, skipped: 0 });
+    });
+
+    it('#2036 (Issue I γ): sleep-transfer-alarm은 fire 분모에 포함 (실제 사용자 노출 알람)', () => {
+      const now = 1_700_000_000_000;
+      const entries: AlarmLogEntry[] = [
+        { ts: now - 1000, source: 'sleep-transfer-alarm', outcome: 'fired' },
+        { ts: now - 2000, source: 'boarding-prompt', outcome: 'fired' },
+      ];
+      // FIRED_ALARM_SOURCES: sleep-transfer-alarm=true, boarding-prompt=false → 1건만 카운트.
+      expect(countFiredAlarms(entries)).toBe(1);
     });
 
     it('#1887 (RC-14): logLegTransition가 leg-transition entry를 적재한다', async () => {

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -99,7 +99,12 @@ export type AlarmLogSource =
   // backend alarmLogStats가 source='lockless-trip-end' + outcome로 locklessTripCounts 누적,
   // observabilityMetrics.locklessTripMissRatio = miss / (miss + fired) 산출.
   // lesson_silent_push_zero_is_paradigm_intent: fire 0건이 본질적 의도(paradigm)인지 miss인지 구분.
-  | 'lockless-trip-end';
+  | 'lockless-trip-end'
+  // #2036 (Issue I γ) — 취침모드 환승 알람 발사 stamp. backend가 취침 무관 발사한 sleep-transfer
+  // silent push를 device silentPushTask가 sleepMode=true 확인 후 gate 무관 로컬 알림으로 발사한
+  // 경우 1건 적재. fireCount 분모에 포함(실제 사용자에게 노출되는 알람). ADR-023 정합 —
+  // backend 필터 없이 device 결정.
+  | 'sleep-transfer-alarm';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(#580): evaluateAlarmPhase의 firedAlarms 적중. destination/transfer phase alarm dedup
 // 발생 관찰. station-passed는 별도 메커니즘(lastNotifiedStationId)이라 'dedup-station' 사용.
@@ -1200,6 +1205,8 @@ const SILENT_PUSH_OUTCOME_SOURCES: Record<AlarmLogSource, keyof SilentPushOutcom
   'boardable-lookup': null,
   'ground-truth-response': null,
   'lockless-trip-end': null,
+  // #2036 (Issue I γ) — sleep-transfer-alarm은 device UI 발사이므로 silent push outcome 통계에서 제외.
+  'sleep-transfer-alarm': null,
 };
 
 export interface SilentPushOutcomeCounts {
@@ -1253,6 +1260,8 @@ const FIRED_ALARM_SOURCES: Record<AlarmLogSource, boolean> = {
   'boardable-lookup': false,
   'ground-truth-response': false,
   'lockless-trip-end': false,
+  // #2036 (Issue I γ) — sleep-transfer-alarm 은 실제 사용자에게 노출되는 알람이므로 fire 분모에 포함.
+  'sleep-transfer-alarm': true,
 };
 
 /**
@@ -1704,6 +1713,28 @@ export function logBoardingPromptFired(input: { originStation: string; line: str
     source: 'boarding-prompt',
     outcome: 'fired',
     stationName: `${input.line}·${input.originStation}`,
+  });
+}
+
+/**
+ * #2036 (Issue I γ) — 취침모드 환승 알람 발사 1건 적재.
+ *
+ * device silentPushTask가 backend sleep-transfer-alarm silent push 수신 후 sleepMode=true
+ * 확인 → gate 무관 로컬 알림 발사 시 호출. dashboard/observabilityMetrics는
+ * `source='sleep-transfer-alarm' + outcome='fired'` 로 sleep-transfer wake count 산출.
+ *
+ * stationName은 `${nextLine}·${nextStation}` 형태로 인코딩해 boarding-prompt 패턴과 동일.
+ */
+export function logSleepTransferAlarmFired(input: {
+  originStation: string;
+  nextStation: string;
+  nextLine: string;
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'sleep-transfer-alarm',
+    outcome: 'fired',
+    stationName: `${input.nextLine}·${input.nextStation}`,
   });
 }
 


### PR DESCRIPTION
## Summary

사용자 확정 flow **"환승역 → 취침모드 시 알람 발사"** 를 옵션 γ(silent push handler gate-bypass local notification)로 구현. Apple Critical Alert entitlement 승인 없이 `interruptionLevel: 'timeSensitive'` + `sound: 'alarm.wav'` + `vibrateAlarm(true)`(반복 진동) 조합으로 최대 UX 근사.

- Backend: `sendSleepTransferAlarmPush` 신규 + `advanceBoardingLockWaypoint` transfer 분기 wire (idempotent 발사, sleep 무관 — ADR-023 정합).
- Device: `SleepTransferAlarmSilentPushPayload` union 추가. `handleSilentPush` 수신 시 `readSleepModeFromStorage`로 device 결정 — sleepMode=false는 skip(일반모드는 기존 station-passed 경로 처리), sleepMode=true는 gate 무관 로컬 알림 발사.
- dedup: `${tripToken}::${nextStation}` in-memory Set — backend cron retry 차단, 같은 trip 다른 환승 hop(강남→성수→내방)은 각각 발사.

## ADR-023 정합

- Backend는 취침 상태 조회 없이 발사 (5 발사 경로 sleep 무관 원칙 유지).
- Device의 `shouldSuppressBySleepRule` 3경로(FG/BG/scheduler)는 변경 없음 — γ는 별 channel(silent push handler).
- 기존 transfer/station-passed suppress 정책 유지, 신규 sleep-transfer-alarm 채널만 sleep 시 발사.

## 옵션 γ 채택 이유 (false binary 회피 3개 옵션 비교)

| 옵션 | 설명 | 리스크 | Winner |
|---|---|---|---|
| α 로직 반전 (Issue body 원 안) | shouldSuppressBySleepRule transfer 허용 반전 + Focus mode 관통 위해 critical alert entitlement | Apple entitlement 승인 어려움 (재난/의료 대상) | X |
| β Critical alert만 도입 | timeSensitive/critical 분기 없이 무조건 critical | entitlement 미승인 시 그대로 timeSensitive fallback (승인 시간 별도) | O (승인 후) |
| γ silent push handler 별 channel | backend가 별도 kind 발사 → device가 gate 무관 로컬 알림 (본 PR) | Focus/DND 완전 우회 X (부분 관통) | **채택** |

γ는 entitlement 승인 없이 최대 UX 근사 + boarding-prompt(#2028) 패턴 재사용 + 기존 정책 변경 최소화.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` PASS. `sendSleepTransferAlarmPush` caller = backend `scheduled.ts` `advanceBoardingLockWaypoint`, `fireSleepTransferAlarmLocalNotification` caller = device `silentPushTask.ts` `handleSilentPush`.
2. **V/X dashboard** — 
   - device: `logSleepTransferAlarmFired` → alarmLog ring buffer(source=`sleep-transfer-alarm`, outcome=`fired`). DebugModal + backend `/admin/alarm-log-stats` 응답에 집계.
   - device: `addDomainBreadcrumb('push', 'sleep-transfer-alarm-fired', ...)` → Sentry.
   - backend: `log('boarding-lock: sleep-transfer-alarm fired', ...)` → wrangler tail.
3. **의존 PR** — N/A. 독립적으로 배포 가능. backend 배포 후 device는 unknown kind로 자연 drop, device 배포 후 backend는 발사 시 새 payload가 정상 처리됨 (양방향 호환).
4. **측정 plan** — 1주 관찰. 취침모드 사용자 환승 시나리오에서 device `alarmLogStats?source=sleep-transfer-alarm` fired count. 목표: 환승 waypoint 통과 시 sleepMode=true 사용자 100% 발사.
5. **Device verify** — 실기기 취침모드 환승 시나리오 (예: 강남→성수→내방) 사용자 담당. 예상 UX:
   - 성수 도착 시 backend가 sleep-transfer-alarm 발사.
   - device가 SLEEP_MODE_KEY=true 확인 → `alarm.wav` 소리 + 반복 진동 + 잠금화면에 "곧 환승역입니다 / 성수에서 2호선 뚝섬으로 환승" 배너 노출.

## 파일 hotspot rebase 위험 (동시 진행 PR)

- `silentPushTask.ts` — Issue G (PR #2040), Issue M (PR #2039), #2018 fix (PR #2041)와 편집. 본 PR도 편집 (payload union + handler + dedup + fire fn). 다른 위치이므로 3-way merge 자동 예상.
- `scheduled.ts` — Issue M (PR #2039)와 편집. 본 PR도 편집 (transfer-release 직후 sleep-transfer-alarm 발사). 다른 위치이므로 자동 병합 예상.
- `apns.ts` — Issue M (PR #2039)와 편집. 본 PR은 파일 끝에 신규 함수 추가. 자동 병합 예상.
- 충돌 발생 시 사용자 개입 report.

## 검증

- `npm test` — 9,036 device tests PASS, 100% coverage 유지.
- `cd backend/alarm-worker && npx vitest run` — 2,547 backend tests PASS.
- `npm run type-check` — device + backend 양쪽 PASS.
- `npm run lint:orphan` — 0 orphan.

## Test plan
- [ ] 실기기 취침모드 환승 시나리오 (예: 강남→성수→내방) 발사 확인
- [ ] sleepMode=false 상태에서 환승 시 기존 alert 경로만 발사 (본 PR channel skip)
- [ ] backend cron retry 3회 시 device 로컬 알림 1회만 발사 (dedup 검증)
- [ ] 같은 trip 다른 환승 hop(예: 강남→성수→내방→...→...) 각각 발사

Closes #2036