### PR TITLE
feat(#2043): device self-contained 자동종료 (3-signal fusion, β 옵션)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useDeviceSelfEnd.test.ts
+++ b/src/features/alarm/hooks/__tests__/useDeviceSelfEnd.test.ts
@@ -1,0 +1,500 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useDeviceSelfEnd, type UseDeviceSelfEndInputs } from '../useDeviceSelfEnd';
+import type { Station } from '../../../../shared/types/station';
+
+const mockGetSentinel = jest.fn();
+const mockSetSentinel = jest.fn();
+jest.mock('../../utils/tripEndedSentinel', () => ({
+  getTripEndedSentinel: (...args: unknown[]) => mockGetSentinel(...args),
+  setTripEndedSentinel: (...args: unknown[]) => mockSetSentinel(...args),
+  clearTripEndedSentinel: jest.fn(),
+}));
+
+const mockGetTripStartedAt = jest.fn();
+jest.mock('../../utils/tripStartStorage', () => ({
+  getTripStartedAt: (...args: unknown[]) => mockGetTripStartedAt(...args),
+}));
+
+const mockRunTripBoundCleanups = jest.fn();
+jest.mock('../../store/tripBoundCleanups', () => ({
+  runTripBoundCleanups: (...args: unknown[]) => mockRunTripBoundCleanups(...args),
+}));
+
+const mockTriggerTripEndRecall = jest.fn();
+jest.mock('../../utils/triggerTripEndRecall', () => ({
+  triggerTripEndRecall: (...args: unknown[]) => mockTriggerTripEndRecall(...args),
+}));
+
+const mockGetCurrentTripCorrIdSync = jest.fn(() => null);
+jest.mock('../../../observability/utils/tripCorrId', () => ({
+  getCurrentTripCorrIdSync: () => mockGetCurrentTripCorrIdSync(),
+}));
+
+const mockTriggerTripGroundTruthPrompt = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../debug/utils/triggerTripGroundTruthPrompt', () => ({
+  triggerTripGroundTruthPrompt: (...args: unknown[]) =>
+    mockTriggerTripGroundTruthPrompt(...args),
+}));
+
+const mockAppendAlarmLog = jest.fn();
+jest.mock('../../utils/alarmLog', () => ({
+  appendAlarmLog: (...args: unknown[]) => mockAppendAlarmLog(...args),
+}));
+
+const mockAddDomainBreadcrumb = jest.fn();
+jest.mock('../../../../shared/infra/monitoring/breadcrumb', () => ({
+  addDomainBreadcrumb: (...args: unknown[]) => mockAddDomainBreadcrumb(...args),
+}));
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+// destination / boardingLock store mocks — 실제 zustand 대신 반환값 제어.
+let mockDestinationState: Station | null = null;
+const mockDestinationSetState = jest.fn();
+const mockReleaseLock = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../../route/store/useDestinationStore', () => {
+  function useDestinationStore(selector: (s: { destination: Station | null }) => unknown): unknown {
+    return selector({ destination: mockDestinationState });
+  }
+  useDestinationStore.setState = (...args: unknown[]) => mockDestinationSetState(...args);
+  useDestinationStore.getState = () => ({ destination: mockDestinationState });
+  return { useDestinationStore };
+});
+
+jest.mock('../../store/useBoardingLockStore', () => {
+  function useBoardingLockStore(
+    selector: (s: { releaseLock: () => Promise<void> }) => unknown,
+  ): unknown {
+    return selector({ releaseLock: mockReleaseLock });
+  }
+  return { useBoardingLockStore };
+});
+
+const DESTINATION: Station = {
+  id: 'seongsu',
+  name: '성수',
+  line: '2',
+  lineColor: '#000',
+  lat: 37.544,
+  lng: 127.055,
+};
+
+const T0 = 1_700_000_000_000;
+
+function withDateNow<T>(value: number, fn: () => T): T {
+  const spy = jest.spyOn(Date, 'now').mockReturnValue(value);
+  try {
+    return fn();
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+function baseInputs(overrides: Partial<UseDeviceSelfEndInputs> = {}): UseDeviceSelfEndInputs {
+  return {
+    currentStation: null,
+    confidence: null,
+    arcProgress: null,
+    positionStability: 'unknown',
+    expectedTripDurationMs: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDestinationState = null;
+  mockGetSentinel.mockResolvedValue(null);
+  mockSetSentinel.mockResolvedValue(undefined);
+  mockGetTripStartedAt.mockResolvedValue(null);
+  mockRunTripBoundCleanups.mockResolvedValue(undefined);
+  mockTriggerTripEndRecall.mockResolvedValue({ uploaded: false });
+});
+
+describe('useDeviceSelfEnd', () => {
+  describe('destination null (no active trip)', () => {
+    it('destination null이면 signal trigger 조건 충족돼도 fire 안 함', async () => {
+      mockDestinationState = null;
+      withDateNow(T0, () => {
+        renderHook(() =>
+          useDeviceSelfEnd(
+            baseInputs({
+              currentStation: DESTINATION,
+              confidence: 'backend-ssot',
+              positionStability: 'static',
+            }),
+          ),
+        );
+      });
+      // 마이크로태스크 다음 tick까지 대기
+      await Promise.resolve();
+      expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+      expect(mockSetSentinel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('idempotent guard (sentinel already recorded)', () => {
+    it('sentinel non-null이면 signal trigger돼도 cleanup skip', async () => {
+      mockDestinationState = DESTINATION;
+      mockGetSentinel.mockResolvedValue(T0 - 60_000);
+      // Signal 1 트리거 조건: destination match + strong confidence + 30s 지속.
+      // 각 rerender에 새 currentStation 객체를 전달해 useEffect deps 변경을 유도(production
+      // 에서는 fusion result가 매 tick 새 객체).
+      const { rerender } = withDateNow(T0, () =>
+        renderHook(
+          (p: UseDeviceSelfEndInputs) => useDeviceSelfEnd(p),
+          {
+            initialProps: baseInputs({
+              currentStation: { ...DESTINATION },
+              confidence: 'backend-ssot',
+              positionStability: 'unknown',
+            }),
+          },
+        ),
+      );
+      withDateNow(T0 + 30_000, () => {
+        rerender(
+          baseInputs({
+            currentStation: { ...DESTINATION },
+            confidence: 'backend-ssot',
+            positionStability: 'unknown',
+          }),
+        );
+      });
+      // sentinel check가 async라 대기
+      await waitFor(() => expect(mockGetSentinel).toHaveBeenCalled());
+      // sentinel 존재 → cleanup chain 미호출
+      expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+      expect(mockSetSentinel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Signal 1 — fusion-destination trigger', () => {
+    it('destination match + strong confidence + 30s 지속 → runTripBoundCleanups + setTripEndedSentinel 호출', async () => {
+      mockDestinationState = DESTINATION;
+      const { rerender } = withDateNow(T0, () =>
+        renderHook(
+          (p: UseDeviceSelfEndInputs) => useDeviceSelfEnd(p),
+          {
+            initialProps: baseInputs({
+              currentStation: { ...DESTINATION },
+              confidence: 'backend-ssot',
+              positionStability: 'unknown',
+            }),
+          },
+        ),
+      );
+      // 각 rerender에 새 currentStation 객체를 전달해 useEffect deps 변경 (production 재현).
+      withDateNow(T0 + 30_000, () => {
+        rerender(
+          baseInputs({
+            currentStation: { ...DESTINATION },
+            confidence: 'backend-ssot',
+            positionStability: 'unknown',
+          }),
+        );
+      });
+      await waitFor(() => expect(mockRunTripBoundCleanups).toHaveBeenCalled());
+      expect(mockTriggerTripEndRecall).toHaveBeenCalled();
+      expect(mockSetSentinel).toHaveBeenCalled();
+      expect(mockDestinationSetState).toHaveBeenCalledWith({
+        destination: null,
+        customOrigin: null,
+        tripOrigin: null,
+      });
+      expect(mockReleaseLock).toHaveBeenCalled();
+      expect(mockAppendAlarmLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'lifecycle-backstop',
+          outcome: 'fired',
+          reason: 'trip-device-self-end-fusion-destination',
+        }),
+      );
+    });
+
+    it('gps-only confidence는 강 신호 화이트리스트에 없어 trigger X', async () => {
+      mockDestinationState = DESTINATION;
+      const { rerender } = withDateNow(T0, () =>
+        renderHook(
+          (p: UseDeviceSelfEndInputs) => useDeviceSelfEnd(p),
+          {
+            initialProps: baseInputs({
+              currentStation: { ...DESTINATION },
+              confidence: 'gps-only',
+              positionStability: 'unknown',
+            }),
+          },
+        ),
+      );
+      withDateNow(T0 + 60_000, () => {
+        rerender(
+          baseInputs({
+            currentStation: { ...DESTINATION },
+            confidence: 'gps-only',
+            positionStability: 'unknown',
+          }),
+        );
+      });
+      await Promise.resolve();
+      expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Signal 2 — arc-completion trigger', () => {
+    it('arc 0.95 + stationary 60s → cleanup 호출', async () => {
+      mockDestinationState = DESTINATION;
+      const { rerender } = withDateNow(T0, () =>
+        renderHook(
+          (p: UseDeviceSelfEndInputs) => useDeviceSelfEnd(p),
+          {
+            initialProps: baseInputs({
+              arcProgress: 0.96,
+              positionStability: 'static',
+            }),
+          },
+        ),
+      );
+      // arcProgress를 살짝 변경(0.96 → 0.97)해 deps 변경 유도.
+      withDateNow(T0 + 60_000, () => {
+        rerender(
+          baseInputs({
+            arcProgress: 0.97,
+            positionStability: 'static',
+          }),
+        );
+      });
+      await waitFor(() => expect(mockRunTripBoundCleanups).toHaveBeenCalled());
+      expect(mockAppendAlarmLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: 'trip-device-self-end-arc-completion',
+        }),
+      );
+    });
+
+    it('arc 0.95 + moving → trigger X (stationary 요구)', async () => {
+      mockDestinationState = DESTINATION;
+      const { rerender } = withDateNow(T0, () =>
+        renderHook(
+          (p: UseDeviceSelfEndInputs) => useDeviceSelfEnd(p),
+          {
+            initialProps: baseInputs({
+              arcProgress: 0.96,
+              positionStability: 'moving',
+            }),
+          },
+        ),
+      );
+      withDateNow(T0 + 60_000, () => {
+        rerender(
+          baseInputs({
+            arcProgress: 0.97,
+            positionStability: 'moving',
+          }),
+        );
+      });
+      await Promise.resolve();
+      expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Signal 3 — eta-backstop trigger', () => {
+    it('elapsed > eta × 2 + stationary 5분 → cleanup 호출', async () => {
+      mockDestinationState = DESTINATION;
+      const ETA = 30 * 60_000; // 30분
+      // trip 시작이 90분 전 (elapsed = 90분 > eta × 2 = 60분)
+      mockGetTripStartedAt.mockResolvedValue(T0 - 90 * 60_000);
+
+      const { rerender } = withDateNow(T0, () =>
+        renderHook(
+          (p: UseDeviceSelfEndInputs) => useDeviceSelfEnd(p),
+          {
+            initialProps: baseInputs({
+              positionStability: 'static',
+              expectedTripDurationMs: ETA,
+            }),
+          },
+        ),
+      );
+      // useEffect 마운트 후 tripStartedAt loading await
+      await waitFor(() => expect(mockGetTripStartedAt).toHaveBeenCalled());
+
+      // stationary 5분 지속 시뮬레이션 — deps 변경을 위해 expectedTripDurationMs 살짝 다르게.
+      withDateNow(T0 + 5 * 60_000, () => {
+        rerender(
+          baseInputs({
+            positionStability: 'static',
+            expectedTripDurationMs: ETA + 1,
+          }),
+        );
+      });
+      await waitFor(() => expect(mockRunTripBoundCleanups).toHaveBeenCalled());
+      expect(mockAppendAlarmLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: 'trip-device-self-end-eta-backstop',
+        }),
+      );
+    });
+  });
+
+  describe('destination id 변경 시 tracker reset', () => {
+    it('destination id 변경 시 firedForDestinationId ref 리셋 → 새 trip에서 재발화 가능', async () => {
+      mockDestinationState = DESTINATION;
+      const { rerender } = withDateNow(T0, () =>
+        renderHook(
+          (p: UseDeviceSelfEndInputs) => useDeviceSelfEnd(p),
+          {
+            initialProps: baseInputs({
+              currentStation: { ...DESTINATION },
+              confidence: 'backend-ssot',
+            }),
+          },
+        ),
+      );
+      withDateNow(T0 + 30_000, () => {
+        rerender(
+          baseInputs({
+            currentStation: { ...DESTINATION },
+            confidence: 'backend-ssot',
+          }),
+        );
+      });
+      await waitFor(() => expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1));
+
+      // destination을 다른 station으로 변경 — destinationState 자체를 store에서 바꾸고, 새 currentStation 전달.
+      const OTHER: Station = {
+        id: 'gundae',
+        name: '건대입구',
+        line: '2',
+        lineColor: '#000',
+        lat: 37.54,
+        lng: 127.07,
+      };
+      mockDestinationState = OTHER;
+      // destinationId가 selector로 다시 읽히지 않으므로 rerender 시 useDestinationStore가 재호출되어야 함.
+      // React 컴포넌트 재렌더링을 유발하는 prop 변경 + destinationState 변경.
+      withDateNow(T0 + 60_000, () => {
+        rerender(
+          baseInputs({
+            currentStation: { ...OTHER },
+            confidence: 'backend-ssot',
+          }),
+        );
+      });
+      withDateNow(T0 + 90_000, () => {
+        rerender(
+          baseInputs({
+            currentStation: { ...OTHER },
+            confidence: 'backend-ssot',
+          }),
+        );
+      });
+      await waitFor(() => expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(2));
+    });
+  });
+
+  describe('unmount race — cancelled guard', () => {
+    it('마운트 직후 unmount 시 tripStartedAt setState skip (cancelled=true)', async () => {
+      mockDestinationState = DESTINATION;
+      // 응답을 지연시켜 unmount가 promise resolve 이전에 발생하도록.
+      let resolveTripStarted!: (v: number | null) => void;
+      mockGetTripStartedAt.mockReturnValue(
+        new Promise((r) => {
+          resolveTripStarted = r;
+        }),
+      );
+      const { unmount } = withDateNow(T0, () =>
+        renderHook(() =>
+          useDeviceSelfEnd(
+            baseInputs({ currentStation: { ...DESTINATION }, confidence: 'backend-ssot' }),
+          ),
+        ),
+      );
+      // unmount 후에 promise resolve — setTripStartedAt_ 는 cancelled=true라 skip.
+      unmount();
+      resolveTripStarted(T0 - 60_000);
+      await Promise.resolve();
+      // 특별한 assertion 없이 crash 없이 통과 = cancelled guard가 setState skip 성공.
+    });
+  });
+
+  describe('same trip 재발화 억제', () => {
+    it('같은 trip에서 signal 재trigger 시 두 번째는 skip (firedForDestinationIdRef)', async () => {
+      mockDestinationState = DESTINATION;
+      const { rerender } = withDateNow(T0, () =>
+        renderHook(
+          (p: UseDeviceSelfEndInputs) => useDeviceSelfEnd(p),
+          {
+            initialProps: baseInputs({
+              currentStation: { ...DESTINATION },
+              confidence: 'backend-ssot',
+            }),
+          },
+        ),
+      );
+      withDateNow(T0 + 30_000, () => {
+        rerender(
+          baseInputs({
+            currentStation: { ...DESTINATION },
+            confidence: 'backend-ssot',
+          }),
+        );
+      });
+      await waitFor(() => expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1));
+
+      // 같은 destination 유지 + fusion signal 계속 매칭 → firedForDestinationIdRef guard로 skip.
+      withDateNow(T0 + 60_000, () => {
+        rerender(
+          baseInputs({
+            currentStation: { ...DESTINATION },
+            confidence: 'backend-ssot',
+          }),
+        );
+      });
+      // 추가 호출 없음
+      await Promise.resolve();
+      expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('graceful error handling', () => {
+    it('runTripBoundCleanups reject해도 hook crash 안 함', async () => {
+      mockDestinationState = DESTINATION;
+      mockRunTripBoundCleanups.mockRejectedValue(new Error('boom'));
+      const { rerender } = withDateNow(T0, () =>
+        renderHook(
+          (p: UseDeviceSelfEndInputs) => useDeviceSelfEnd(p),
+          {
+            initialProps: baseInputs({
+              currentStation: { ...DESTINATION },
+              confidence: 'backend-ssot',
+            }),
+          },
+        ),
+      );
+      withDateNow(T0 + 30_000, () => {
+        rerender(
+          baseInputs({
+            currentStation: { ...DESTINATION },
+            confidence: 'backend-ssot',
+          }),
+        );
+      });
+      await waitFor(() => expect(mockRunTripBoundCleanups).toHaveBeenCalled());
+      // graceful → setSentinel 은 catch 뒤에 실행 안 됨 (chain중단)
+      // 하지만 hook 자체는 crash 없이 정상 종료. Domain breadcrumb는 이미 log됨.
+      expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith(
+        'trip',
+        'device-self-end',
+        { reason: 'fusion-destination' },
+      );
+    });
+  });
+});

--- a/src/features/alarm/hooks/useDeviceSelfEnd.ts
+++ b/src/features/alarm/hooks/useDeviceSelfEnd.ts
@@ -1,0 +1,269 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration (#2043): device self-contained 자동종료 hook은 route (destination /
+ * arc / progressM) + nearest-station (positionStability) + alarm (runTripBoundCleanups + sentinel +
+ * alarmLog) 3개 슬라이스 신호를 묶어 fire path 없이 trip 종료 chain을 발화한다.
+ *
+ * useLaunchTripReconciliation / useStateRehydration 과 동형의 orchestrator 패턴이라 file-level
+ * disable 옵트인 (ADR Phase 5). 후속 orchestration 슬라이스 이전 예정.
+ */
+/**
+ * Device self-contained 자동종료 hook (#2043, β 옵션).
+ *
+ * 배경 (관찰 22):
+ *   - PR #2041(γ' fix): silent push 도달한 케이스의 FG UI 잔존 8-18초 해결.
+ *   - 관찰 22 잔여 gap: silent push 미도달 or 앱 kill 6h+ → sentinel 저장 안 됨 → 9h+
+ *     lifecycle backstop만 유일 backup. 사용자가 몇 시간 앱 재개해도 UI 안내가 안 사라짐.
+ *
+ * Paradigm 정합 ([[feedback-device-self-contained-fusion]]):
+ *   "backend/GPS/WiFi 다 죽어도 device 보장" → 자동종료도 device self-contained 확장.
+ *
+ * 3-Signal fusion (β 옵션 초기 스코프):
+ *   Signal 1 fusion-destination: fusion === destination + 강 confidence + 30s 지속
+ *   Signal 2 arc-completion:     arc ≥ 0.95 + stationary 60s 지속
+ *   Signal 3 eta-backstop:       elapsed > expectedEta × 2 + stationary 5분 지속
+ *
+ *   Signal 4 backend-timeout은 silentPushTask.ts 4-way 편집 충돌 회피로 후속 이슈 분리.
+ *
+ * Idempotent guard:
+ *   - trigger 전 `getTripEndedSentinel()` 확인 → non-null 이면 이미 backend cleanup 실행 → skip.
+ *   - trigger 시 `runTripBoundCleanups()` + `setTripEndedSentinel(now)` 호출 → backend가 뒤늦게
+ *     cleanup 시도해도 이미 정리돼 no-op.
+ *   - useLaunchTripReconciliation / useStateRehydration lifecycle backstop / silent push trip-ended
+ *     3개 chain과 동일 시퀀스 사용 — 중복 호출 안전(멱등).
+ *
+ * False positive 방어:
+ *   - Signal 1: FusionConfidence 강 신호 화이트리스트만 통과 (gps-only/gps-only-underground 배제).
+ *   - Signal 2: stationary 60s 지속 요구 — 움직임 중이면 trigger X.
+ *   - Signal 3: eta × 2 gate + stationary 5분 — KTX 등 실 장거리 trip은 eta 자체가 커서 자연 방어.
+ *
+ * 마운트: HomeScreen (fusion 신호 이미 생성). useStationAlarm 과 동형 배치.
+ *
+ * 호출 시점: fusion 신호 변경 tick마다 평가. 신호 지속 시간은 ref로 유지 (첫 진입 tick의 ts 저장,
+ * 다음 tick에서 elapsed 계산). 매 render마다 storage read를 피하려 tripStartedAt은 destinationId
+ * 변경 감지 effect로 한 번만 load.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Station } from '../../../shared/types/station';
+import type { FusionConfidence } from '../../../shared/types/fusion';
+import type { PositionStability } from '../../nearest-station/utils/positionStaticDetector';
+import { createLogger } from '../../../shared/utils/logger';
+import {
+  fusionDestinationSignal,
+  arcCompletionSignal,
+  etaBackstopSignal,
+  shouldTriggerSelfEnd,
+  type SelfEndSignalReason,
+} from '../utils/deviceSelfEndSignals';
+import { getTripStartedAt } from '../utils/tripStartStorage';
+import {
+  getTripEndedSentinel,
+  setTripEndedSentinel,
+} from '../utils/tripEndedSentinel';
+import { runTripBoundCleanups } from '../store/tripBoundCleanups';
+import { triggerTripEndRecall } from '../utils/triggerTripEndRecall';
+import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
+import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
+import { appendAlarmLog } from '../utils/alarmLog';
+import { useDestinationStore } from '../../route/store/useDestinationStore';
+import { useBoardingLockStore } from '../store/useBoardingLockStore';
+import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
+
+const logger = createLogger('useDeviceSelfEnd');
+
+const REASON_TO_ALARM_LOG_REASON: Record<
+  SelfEndSignalReason,
+  'trip-device-self-end-fusion-destination'
+  | 'trip-device-self-end-arc-completion'
+  | 'trip-device-self-end-eta-backstop'
+> = {
+  'fusion-destination': 'trip-device-self-end-fusion-destination',
+  'arc-completion': 'trip-device-self-end-arc-completion',
+  'eta-backstop': 'trip-device-self-end-eta-backstop',
+};
+
+export interface UseDeviceSelfEndInputs {
+  /** Fusion result.station.id (또는 fusion result 자체). null이면 아직 판정 불가. */
+  currentStation: Station | null;
+  /** Fusion confidence 라벨. */
+  confidence: FusionConfidence | null;
+  /** Route arc 진행도 0~1. useRouteProgress의 progressM / arc.totalM. null이면 미활성. */
+  arcProgress: number | null;
+  /** Position stability. 'static' 이면 stationary=true. */
+  positionStability: PositionStability;
+  /**
+   * Trip 예상 소요 시간 (ms). Signal 3(eta-backstop) gate에 사용. null이면 Signal 3 skip.
+   * 호출자(HomeScreen)가 route.totalTimeSec × 1000 등으로 계산해 전달.
+   */
+  expectedTripDurationMs: number | null;
+}
+
+/**
+ * device self-end 자동종료 hook.
+ *
+ * fusion signal 변경 tick마다 3-signal 판정 → 하나라도 trigger면 idempotent guard 통과 후
+ * runTripBoundCleanups + setTripEndedSentinel 시퀀스 발화.
+ *
+ * @param inputs.currentStation           fusion nearestStation
+ * @param inputs.confidence               fusion confidence
+ * @param inputs.arcProgress              route arc 0~1
+ * @param inputs.positionStability        static/moving/unknown
+ * @param inputs.expectedTripDurationMs   trip 예상 소요 (Signal 3 backstop)
+ */
+export function useDeviceSelfEnd(inputs: UseDeviceSelfEndInputs): void {
+  const destination = useDestinationStore((s) => s.destination);
+  const releaseLock = useBoardingLockStore((s) => s.releaseLock);
+  const [tripStartedAt, setTripStartedAt_] = useState<number | null>(null);
+
+  // signal 지속 시간 tracker refs — 각 signal 최초 진입 tick의 ts.
+  const destinationMatchStartedAtRef = useRef<number | null>(null);
+  const stationaryStartedAtRef = useRef<number | null>(null);
+  const stationary5minStartedAtRef = useRef<number | null>(null);
+
+  // trigger fired guard — 같은 trip에서 중복 호출 방지 (idempotent chain 자체도 안전하지만
+  // 불필요 storage/log I/O 회피).
+  const firedForDestinationIdRef = useRef<string | null>(null);
+
+  // destination id 변경 감지 → tripStartedAt 재로드 + ref 리셋 (새 trip은 카운트 처음부터).
+  const destinationId = destination?.id ?? null;
+  useEffect(() => {
+    destinationMatchStartedAtRef.current = null;
+    stationaryStartedAtRef.current = null;
+    stationary5minStartedAtRef.current = null;
+    firedForDestinationIdRef.current = null;
+    if (destinationId === null) {
+      setTripStartedAt_(null);
+      return;
+    }
+    let cancelled = false;
+    void getTripStartedAt().then((v) => {
+      if (!cancelled) setTripStartedAt_(v);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [destinationId]);
+
+  const performSelfEnd = useCallback(
+    async (reason: SelfEndSignalReason, capturedDestinationId: string): Promise<void> => {
+      // Ref를 async guard 전에 즉시 stamp — sentinel await 대기 사이 useEffect 재실행으로 인한
+      // 중복 performSelfEnd 호출 방지. 두 번째 effect tick은 이 ref 값으로 useEffect 진입 guard
+      // (firedForDestinationIdRef.current === destinationId)를 통과하지 못하고 return.
+      // sentinel이 이미 있어 skip되는 케이스에도 ref는 stamp된 채로 남지만, 그 경우 이미 backend
+      // cleanup이 실행됐거나 진행 중이라 재발화도 스킵되어야 정합.
+      firedForDestinationIdRef.current = capturedDestinationId;
+      try {
+        // Idempotent guard: sentinel 이미 있으면 backend cleanup 완료 상태 → skip.
+        const sentinel = await getTripEndedSentinel();
+        if (sentinel !== null) {
+          logger.info(`skip — sentinel already recorded reason=${reason}`);
+          return;
+        }
+
+        const now = Date.now();
+        logger.info(`device self-end fired reason=${reason}`);
+        addDomainBreadcrumb('trip', 'device-self-end', { reason });
+        appendAlarmLog({
+          ts: now,
+          source: 'lifecycle-backstop',
+          outcome: 'fired',
+          reason: REASON_TO_ALARM_LOG_REASON[reason],
+        });
+
+        // silent push trip-ended / lifecycle-backstop force-end 와 동일 시퀀스.
+        // recall이 cleanup 전에 호출돼야 ROUTE_KEY / DESTINATION_KEY / TRIP_STARTED_AT_KEY 를 읽을 수 있다.
+        await triggerTripEndRecall();
+        const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
+        await runTripBoundCleanups();
+        await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
+        useDestinationStore.setState({
+          destination: null,
+          customOrigin: null,
+          tripOrigin: null,
+        });
+        await releaseLock();
+        await setTripEndedSentinel(now);
+      } catch (e) {
+        // graceful — 다음 tick 재평가에서 다시 시도. sentinel/refs 상태에 따라 자연 dedup.
+        logger.warn('device self-end 실패 (graceful)', e);
+      }
+    },
+    [releaseLock],
+  );
+
+  // 매 render tick에서 fusion 신호 평가. 신호 변경마다 실행되며, 매 evaluation 시점의 fresh input으로
+  // 3-signal OR 판정. 첫 진입 tick의 ts는 ref에 저장하고 다음 tick부터 elapsed 누적 계산.
+  useEffect(() => {
+    if (destinationId === null) return;
+    if (firedForDestinationIdRef.current === destinationId) return; // 이미 fire 완료 — 동일 trip에서 재발화 억제.
+
+    const now = Date.now();
+    const currentStationId = inputs.currentStation?.id ?? null;
+    const isStationary = inputs.positionStability === 'static';
+
+    // Signal 1 — destination match 지속 시간 tracker 갱신.
+    const isDestinationMatch =
+      currentStationId !== null &&
+      currentStationId === destinationId &&
+      inputs.confidence !== null;
+    if (isDestinationMatch) {
+      if (destinationMatchStartedAtRef.current === null) {
+        destinationMatchStartedAtRef.current = now;
+      }
+    } else {
+      destinationMatchStartedAtRef.current = null;
+    }
+
+    // Signal 2 — stationary 60s tracker (arc completion).
+    if (isStationary) {
+      if (stationaryStartedAtRef.current === null) {
+        stationaryStartedAtRef.current = now;
+      }
+    } else {
+      stationaryStartedAtRef.current = null;
+    }
+
+    // Signal 3 — stationary 5분 tracker (eta backstop). 별도 ref로 유지해 Signal 2와 독립 카운트.
+    if (isStationary) {
+      if (stationary5minStartedAtRef.current === null) {
+        stationary5minStartedAtRef.current = now;
+      }
+    } else {
+      stationary5minStartedAtRef.current = null;
+    }
+
+    const s1 = fusionDestinationSignal(
+      currentStationId,
+      destinationId,
+      inputs.confidence,
+      destinationMatchStartedAtRef.current,
+      now,
+    );
+    const s2 = arcCompletionSignal(
+      inputs.arcProgress,
+      isStationary,
+      stationaryStartedAtRef.current,
+      now,
+    );
+    const s3 = etaBackstopSignal(
+      tripStartedAt,
+      inputs.expectedTripDurationMs,
+      stationary5minStartedAtRef.current,
+      now,
+    );
+
+    const verdict = shouldTriggerSelfEnd([s1, s2, s3]);
+    if (verdict.trigger && verdict.reason !== null) {
+      void performSelfEnd(verdict.reason, destinationId);
+    }
+  }, [
+    destinationId,
+    inputs.currentStation,
+    inputs.confidence,
+    inputs.arcProgress,
+    inputs.positionStability,
+    inputs.expectedTripDurationMs,
+    tripStartedAt,
+    performSelfEnd,
+  ]);
+}

--- a/src/features/alarm/utils/__tests__/deviceSelfEndSignals.test.ts
+++ b/src/features/alarm/utils/__tests__/deviceSelfEndSignals.test.ts
@@ -1,0 +1,331 @@
+import {
+  fusionDestinationSignal,
+  arcCompletionSignal,
+  etaBackstopSignal,
+  shouldTriggerSelfEnd,
+  isStrongFusionConfidenceForSelfEnd,
+} from '../deviceSelfEndSignals';
+import type { FusionConfidence } from '../../../../shared/types/fusion';
+
+const NOW = 1_000_000;
+const STATION_ID = 'seongsu';
+const DESTINATION_ID = 'seongsu';
+const OTHER_ID = 'gundae';
+
+describe('isStrongFusionConfidenceForSelfEnd', () => {
+  it.each<[FusionConfidence, boolean]>([
+    ['backend-ssot', true],
+    ['boarding-lock', true],
+    ['boarding-lock-interp', true],
+    ['position-train', true],
+    ['arrival-confirmed', true],
+    ['arrival-arriving', true],
+    ['route-progress', true],
+    ['wifi-ssid', true],
+    ['detection-fused', true],
+    ['gps-only', false],
+    ['gps-only-underground', false],
+  ])('confidence=%s => %s', (c, expected) => {
+    expect(isStrongFusionConfidenceForSelfEnd(c)).toBe(expected);
+  });
+});
+
+describe('fusionDestinationSignal', () => {
+  it('destinationId null이면 trigger false (no active trip)', () => {
+    const v = fusionDestinationSignal(
+      STATION_ID,
+      null,
+      'backend-ssot',
+      NOW - 60_000,
+      NOW,
+    );
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('currentStation null이면 trigger false', () => {
+    const v = fusionDestinationSignal(
+      null,
+      DESTINATION_ID,
+      'backend-ssot',
+      NOW - 60_000,
+      NOW,
+    );
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('mismatch (다른 station) → trigger false', () => {
+    const v = fusionDestinationSignal(
+      OTHER_ID,
+      DESTINATION_ID,
+      'backend-ssot',
+      NOW - 60_000,
+      NOW,
+    );
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('confidence null → trigger false', () => {
+    const v = fusionDestinationSignal(
+      STATION_ID,
+      DESTINATION_ID,
+      null,
+      NOW - 60_000,
+      NOW,
+    );
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('gps-only confidence → trigger false (약 신호 배제)', () => {
+    const v = fusionDestinationSignal(
+      STATION_ID,
+      DESTINATION_ID,
+      'gps-only',
+      NOW - 60_000,
+      NOW,
+    );
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('gps-only-underground → trigger false', () => {
+    const v = fusionDestinationSignal(
+      STATION_ID,
+      DESTINATION_ID,
+      'gps-only-underground',
+      NOW - 60_000,
+      NOW,
+    );
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('destinationMatchStartedAt null → trigger false (첫 tick, 아직 match 시작 전)', () => {
+    const v = fusionDestinationSignal(
+      STATION_ID,
+      DESTINATION_ID,
+      'backend-ssot',
+      null,
+      NOW,
+    );
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('duration < 30s → trigger false', () => {
+    const v = fusionDestinationSignal(
+      STATION_ID,
+      DESTINATION_ID,
+      'backend-ssot',
+      NOW - 29_999,
+      NOW,
+    );
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('duration = 30s → trigger true', () => {
+    const v = fusionDestinationSignal(
+      STATION_ID,
+      DESTINATION_ID,
+      'backend-ssot',
+      NOW - 30_000,
+      NOW,
+    );
+    expect(v).toEqual({ trigger: true, reason: 'fusion-destination' });
+  });
+
+  it('duration > 30s + arrival-arriving confidence → trigger true', () => {
+    const v = fusionDestinationSignal(
+      STATION_ID,
+      DESTINATION_ID,
+      'arrival-arriving',
+      NOW - 60_000,
+      NOW,
+    );
+    expect(v).toEqual({ trigger: true, reason: 'fusion-destination' });
+  });
+
+  it('requiredDurationMs override (10s)', () => {
+    const v = fusionDestinationSignal(
+      STATION_ID,
+      DESTINATION_ID,
+      'backend-ssot',
+      NOW - 10_000,
+      NOW,
+      10_000,
+    );
+    expect(v.trigger).toBe(true);
+  });
+});
+
+describe('arcCompletionSignal', () => {
+  it('arc null → trigger false', () => {
+    const v = arcCompletionSignal(null, true, NOW - 60_000, NOW);
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('arc < 0.95 → trigger false', () => {
+    const v = arcCompletionSignal(0.94, true, NOW - 60_000, NOW);
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('arc >= 0.95 + moving (stationary false) → trigger false', () => {
+    const v = arcCompletionSignal(0.95, false, NOW - 60_000, NOW);
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('arc >= 0.95 + stationary but stationaryStartedAt null → trigger false', () => {
+    const v = arcCompletionSignal(0.95, true, null, NOW);
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('arc >= 0.95 + stationary < 60s → trigger false', () => {
+    const v = arcCompletionSignal(0.95, true, NOW - 59_999, NOW);
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('arc >= 0.95 + stationary 60s → trigger true', () => {
+    const v = arcCompletionSignal(0.95, true, NOW - 60_000, NOW);
+    expect(v).toEqual({ trigger: true, reason: 'arc-completion' });
+  });
+
+  it('arc = 1.0 + stationary > 60s → trigger true', () => {
+    const v = arcCompletionSignal(1.0, true, NOW - 90_000, NOW);
+    expect(v).toEqual({ trigger: true, reason: 'arc-completion' });
+  });
+
+  it('progressThreshold override (0.9)', () => {
+    const v = arcCompletionSignal(0.91, true, NOW - 60_000, NOW, 60_000, 0.9);
+    expect(v.trigger).toBe(true);
+  });
+});
+
+describe('etaBackstopSignal', () => {
+  const ETA_MS = 30 * 60_000; // 30분 예상 trip
+
+  it('tripStartedAt null → trigger false', () => {
+    const v = etaBackstopSignal(null, ETA_MS, NOW - 5 * 60_000, NOW);
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('expectedEtaMs null → trigger false', () => {
+    const v = etaBackstopSignal(NOW - ETA_MS * 3, null, NOW - 5 * 60_000, NOW);
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('expectedEtaMs <= 0 → trigger false (invalid input)', () => {
+    const v = etaBackstopSignal(NOW - ETA_MS * 3, 0, NOW - 5 * 60_000, NOW);
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('elapsed <= eta × 2 → trigger false', () => {
+    const v = etaBackstopSignal(NOW - ETA_MS * 2, ETA_MS, NOW - 5 * 60_000, NOW);
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('elapsed > eta × 2 + stationary5minStartedAt null → trigger false', () => {
+    const v = etaBackstopSignal(NOW - ETA_MS * 3, ETA_MS, null, NOW);
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('elapsed > eta × 2 + stationary < 5min → trigger false', () => {
+    const v = etaBackstopSignal(
+      NOW - ETA_MS * 3,
+      ETA_MS,
+      NOW - 5 * 60_000 + 1,
+      NOW,
+    );
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('elapsed > eta × 2 + stationary 5min → trigger true', () => {
+    const v = etaBackstopSignal(
+      NOW - ETA_MS * 3,
+      ETA_MS,
+      NOW - 5 * 60_000,
+      NOW,
+    );
+    expect(v).toEqual({ trigger: true, reason: 'eta-backstop' });
+  });
+
+  it('KTX 시나리오: expectedEta 3h → elapsed 6h (== eta × 2) → trigger false (자연 방어)', () => {
+    const ktxEta = 3 * 60 * 60_000;
+    const v = etaBackstopSignal(
+      NOW - ktxEta * 2,
+      ktxEta,
+      NOW - 5 * 60_000,
+      NOW,
+    );
+    expect(v.trigger).toBe(false);
+  });
+
+  it('KTX 시나리오: expectedEta 3h → elapsed 6h + 1s → trigger true', () => {
+    const ktxEta = 3 * 60 * 60_000;
+    const v = etaBackstopSignal(
+      NOW - ktxEta * 2 - 1_000,
+      ktxEta,
+      NOW - 5 * 60_000,
+      NOW,
+    );
+    expect(v.trigger).toBe(true);
+  });
+
+  it('stationaryDurationMs override (1min)', () => {
+    const v = etaBackstopSignal(
+      NOW - ETA_MS * 3,
+      ETA_MS,
+      NOW - 60_000,
+      NOW,
+      60_000,
+    );
+    expect(v.trigger).toBe(true);
+  });
+});
+
+describe('shouldTriggerSelfEnd', () => {
+  it('empty → trigger false', () => {
+    const v = shouldTriggerSelfEnd([]);
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('모두 false → trigger false', () => {
+    const v = shouldTriggerSelfEnd([
+      { trigger: false, reason: null },
+      { trigger: false, reason: null },
+      { trigger: false, reason: null },
+    ]);
+    expect(v).toEqual({ trigger: false, reason: null });
+  });
+
+  it('Signal 1만 trigger → fusion-destination', () => {
+    const v = shouldTriggerSelfEnd([
+      { trigger: true, reason: 'fusion-destination' },
+      { trigger: false, reason: null },
+      { trigger: false, reason: null },
+    ]);
+    expect(v).toEqual({ trigger: true, reason: 'fusion-destination' });
+  });
+
+  it('Signal 2만 trigger → arc-completion', () => {
+    const v = shouldTriggerSelfEnd([
+      { trigger: false, reason: null },
+      { trigger: true, reason: 'arc-completion' },
+      { trigger: false, reason: null },
+    ]);
+    expect(v).toEqual({ trigger: true, reason: 'arc-completion' });
+  });
+
+  it('Signal 3만 trigger → eta-backstop', () => {
+    const v = shouldTriggerSelfEnd([
+      { trigger: false, reason: null },
+      { trigger: false, reason: null },
+      { trigger: true, reason: 'eta-backstop' },
+    ]);
+    expect(v).toEqual({ trigger: true, reason: 'eta-backstop' });
+  });
+
+  it('여러 signal trigger → 첫 signal 우선 (배열 순서 = 우선순위)', () => {
+    const v = shouldTriggerSelfEnd([
+      { trigger: true, reason: 'fusion-destination' },
+      { trigger: true, reason: 'arc-completion' },
+      { trigger: true, reason: 'eta-backstop' },
+    ]);
+    expect(v).toEqual({ trigger: true, reason: 'fusion-destination' });
+  });
+});

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -235,6 +235,17 @@ export type AlarmLogReason =
   //   'trip-lifecycle-force-ended'    : 9h+ 잔존 trip 강제 종료 (runTripBoundCleanups + sentinel).
   | 'trip-lifecycle-silence'
   | 'trip-lifecycle-force-ended'
+  // #2043 (β 옵션) — device self-contained 자동종료 3-signal fusion 발화 stamp.
+  // silent push miss + 9h+ 만 유일 backup이던 기존 backstop을 device 신호로 확장.
+  //   'trip-device-self-end-fusion-destination': fusion nearestStation === destination + 강 confidence 30s 지속.
+  //   'trip-device-self-end-arc-completion'   : routeProgress arc ≥ 0.95 + stationary 60s 지속.
+  //   'trip-device-self-end-eta-backstop'     : elapsed > expectedEta × 2 + stationary 5분 지속.
+  // source='lifecycle-backstop'로 적재해 FIRED_ALARM_SOURCES에서 자동으로 fire 분모 제외
+  // (측정/진단 stamp이지 사용자 노출 알람 아님). backend timeout signal은 4-way 편집 충돌
+  // 회피 위해 후속 이슈로 분리 — 초기 스코프 3-signal.
+  | 'trip-device-self-end-fusion-destination'
+  | 'trip-device-self-end-arc-completion'
+  | 'trip-device-self-end-eta-backstop'
   // #1572 (T9, ADR-017) — device fire path SSoT 게이트 차단 사유.
   //   'gate-alarm-already-decided' : backend mirror.alarmEvents에 같은 alarmId가 이미 있어 fire 차단(X2).
   //   'gate-station-already-passed': backend mirror.passedStations/alarmEvents에 같은 stationId가

--- a/src/features/alarm/utils/deviceSelfEndSignals.ts
+++ b/src/features/alarm/utils/deviceSelfEndSignals.ts
@@ -1,0 +1,169 @@
+/**
+ * Device self-contained 자동종료 signal 판정 helpers (#2043).
+ *
+ * Backend silent push `trip-ended`가 도달하지 못하는 시나리오 backstop:
+ *   - 앱 kill + APNs 미도달 (관찰 22)
+ *   - 6h+ 잔존 후 사용자가 재개
+ *   - 9h+ lifecycle backstop만 유일 backup (KTX 등 장거리 trip 보호 목적이라 자동종료 늦음)
+ *
+ * ADR-023 (backend vs device 역할 경계) + [[feedback-device-self-contained-fusion]] paradigm:
+ * "backend/GPS/WiFi 다 죽어도 device 보장". 자동종료도 device self-contained 확장.
+ *
+ * 초기 스코프: 3-signal (Signal 4 backend-timeout은 silentPushTask.ts 4-way 편집 충돌 회피
+ * 후속 이슈로 분리).
+ *
+ *   Signal 1 fusion-destination: fusion nearestStation === destination + confidence 강 + 30s 지속
+ *   Signal 2 arc-completion:     routeProgress.arc >= 0.95 + stationary 60s 지속
+ *   Signal 3 eta-backstop:       currentTime - tripStartedAt > expectedEta × 2 + stationary 5min
+ *
+ * OR 조건 — 하나라도 trigger면 self-end. 각 signal은 순수 함수라 host hook이 상태 지속 시간을
+ * 별도로 관리하고 여기서는 "현재 tick input"만 평가한다.
+ *
+ * False positive 방어:
+ *   - Signal 1: FusionConfidence 강 신호(backend-ssot/boarding-lock/position-train/arrival-*
+ *     /wifi-ssid/route-progress) 화이트리스트 — gps-only/gps-only-underground 배제
+ *   - Signal 2: stationary 60s 지속 요구 — 움직임 중이면 trigger X
+ *   - Signal 3: eta × 2 gate + stationary 5min — KTX 등 실 6h+ trip은 eta 자체가 커서 자연 방어
+ */
+
+import type { FusionConfidence } from '../../../shared/types/fusion';
+
+/**
+ * 강 fusion confidence 화이트리스트 — 자동종료 Signal 1의 최소 요구.
+ *
+ * 'gps-only' 및 'gps-only-underground'는 지하 fix / wifi/cell 삼각측량이 흔한 좌표원이라
+ * destination 오버랩 시 false positive 위험 → 배제. 나머지는 arrival/position/wifi 실측 신호
+ * 기반이라 destination 근접 판정에 신뢰 가능.
+ */
+const STRONG_CONFIDENCES: readonly FusionConfidence[] = [
+  'backend-ssot',
+  'boarding-lock',
+  'boarding-lock-interp',
+  'position-train',
+  'arrival-confirmed',
+  'arrival-arriving',
+  'route-progress',
+  'wifi-ssid',
+  'detection-fused',
+];
+
+export function isStrongFusionConfidenceForSelfEnd(confidence: FusionConfidence): boolean {
+  return STRONG_CONFIDENCES.includes(confidence);
+}
+
+/** Signal 반환 shape. trigger=true 시 reason 라벨로 fired count 분류. */
+export interface SelfEndSignalVerdict {
+  trigger: boolean;
+  reason: SelfEndSignalReason | null;
+}
+
+export type SelfEndSignalReason =
+  | 'fusion-destination'
+  | 'arc-completion'
+  | 'eta-backstop';
+
+/**
+ * Signal 1 — fusion nearestStation이 destination과 일치하면서 강 confidence + N초 지속.
+ *
+ * @param currentStationId  fusion result.station.id (없으면 null)
+ * @param destinationId     활성 trip destination.id (없으면 null → trip 없음, trigger false)
+ * @param confidence        fusion confidence 라벨
+ * @param destinationMatchStartedAt  matching 최초 tick의 epoch ms (host hook이 유지). null이면
+ *                                    아직 match 시작 전.
+ * @param now               기준 시각 (테스트 결정성)
+ * @param requiredDurationMs 지속 요구 시간 (기본 30s)
+ */
+export function fusionDestinationSignal(
+  currentStationId: string | null,
+  destinationId: string | null,
+  confidence: FusionConfidence | null,
+  destinationMatchStartedAt: number | null,
+  now: number,
+  requiredDurationMs: number = 30_000,
+): SelfEndSignalVerdict {
+  if (destinationId === null) return { trigger: false, reason: null };
+  if (currentStationId === null) return { trigger: false, reason: null };
+  if (currentStationId !== destinationId) return { trigger: false, reason: null };
+  if (confidence === null) return { trigger: false, reason: null };
+  if (!isStrongFusionConfidenceForSelfEnd(confidence)) {
+    return { trigger: false, reason: null };
+  }
+  if (destinationMatchStartedAt === null) return { trigger: false, reason: null };
+  if (now - destinationMatchStartedAt < requiredDurationMs) {
+    return { trigger: false, reason: null };
+  }
+  return { trigger: true, reason: 'fusion-destination' };
+}
+
+/**
+ * Signal 2 — routeProgress arc가 종점에 근접(≥0.95) + stationary N초 지속.
+ *
+ * @param arcProgress            0~1 (progressM / totalArcM). arc 없으면 null.
+ * @param isStationary           positionStability === 'static'
+ * @param stationaryStartedAt    stationary 최초 tick의 epoch ms (host hook 유지). null이면
+ *                                아직 stationary 진입 전 또는 움직임 중.
+ * @param now                    기준 시각
+ * @param requiredDurationMs     지속 요구 시간 (기본 60s)
+ * @param progressThreshold      arc 완료 임계 (기본 0.95)
+ */
+export function arcCompletionSignal(
+  arcProgress: number | null,
+  isStationary: boolean,
+  stationaryStartedAt: number | null,
+  now: number,
+  requiredDurationMs: number = 60_000,
+  progressThreshold: number = 0.95,
+): SelfEndSignalVerdict {
+  if (arcProgress === null) return { trigger: false, reason: null };
+  if (arcProgress < progressThreshold) return { trigger: false, reason: null };
+  if (!isStationary) return { trigger: false, reason: null };
+  if (stationaryStartedAt === null) return { trigger: false, reason: null };
+  if (now - stationaryStartedAt < requiredDurationMs) {
+    return { trigger: false, reason: null };
+  }
+  return { trigger: true, reason: 'arc-completion' };
+}
+
+/**
+ * Signal 3 — trip 시작 후 expectedEta × 2 초과 + stationary 5분 지속.
+ *
+ * 위치/도착 신호가 아무것도 안 잡히는 최후 backstop. KTX 등 실 장거리 trip은 expectedEta 자체가
+ * 크므로 eta×2 gate가 자연 방어. stationary 5분 조건으로 이동 중 false trigger 차단.
+ *
+ * @param tripStartedAt         epoch ms. null이면 미기록 → skip.
+ * @param expectedEtaMs         trip 예상 소요 시간 (ms). null이면 skip.
+ * @param stationary5minStartedAt stationary 5분 지속 최초 tick의 epoch ms (host hook 유지).
+ * @param now                   기준 시각
+ * @param stationaryDurationMs  stationary 지속 요구 (기본 5분)
+ */
+export function etaBackstopSignal(
+  tripStartedAt: number | null,
+  expectedEtaMs: number | null,
+  stationary5minStartedAt: number | null,
+  now: number,
+  stationaryDurationMs: number = 5 * 60_000,
+): SelfEndSignalVerdict {
+  if (tripStartedAt === null) return { trigger: false, reason: null };
+  if (expectedEtaMs === null) return { trigger: false, reason: null };
+  if (expectedEtaMs <= 0) return { trigger: false, reason: null };
+  const elapsed = now - tripStartedAt;
+  if (elapsed <= expectedEtaMs * 2) return { trigger: false, reason: null };
+  if (stationary5minStartedAt === null) return { trigger: false, reason: null };
+  if (now - stationary5minStartedAt < stationaryDurationMs) {
+    return { trigger: false, reason: null };
+  }
+  return { trigger: true, reason: 'eta-backstop' };
+}
+
+/**
+ * OR fusion — signal 배열 중 첫 trigger를 반환. 모두 false면 trigger=false / reason=null.
+ * 배열 순서가 우선순위 — Signal 1(fusion-destination)이 가장 신뢰 높아 앞에 둔다.
+ */
+export function shouldTriggerSelfEnd(
+  signals: readonly SelfEndSignalVerdict[],
+): SelfEndSignalVerdict {
+  for (const s of signals) {
+    if (s.trigger) return s;
+  }
+  return { trigger: false, reason: null };
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -64,6 +64,7 @@ import { useTripBoundAlarmScheduler } from '../features/alarm/hooks/useTripBound
 import { useBoardingLockAdvancer } from '../features/alarm/hooks/useBoardingLockAdvancer';
 import { useBoardingLockAutoRelease } from '../features/alarm/hooks/useBoardingLockAutoRelease';
 import { useDestinationAutoClear } from '../features/alarm/hooks/useDestinationAutoClear';
+import { useDeviceSelfEnd } from '../features/alarm/hooks/useDeviceSelfEnd';
 import { useBoardingLockSync } from '../features/alarm/hooks/useBoardingLockSync';
 import { useFgPositionUpload } from '../features/alarm/hooks/useFgPositionUpload';
 import { useCurrentStationConfirmModal } from '../features/nearest-station/hooks/useCurrentStationConfirmModal';
@@ -719,6 +720,32 @@ export default function HomeScreen() {
     // #1887 (RC-14) — transfer 분기에 motion stationary 30s 게이트 추가.
     // paradigm 4 "이동속도가 빠르지 않다면 판단 후에 자동 하차" 정확 적용.
     motionStationary,
+  });
+  // #2043 (β 옵션) — device self-contained 자동종료 3-signal fusion.
+  //   Signal 1 fusion-destination: fusion === destination + 강 confidence + 30s 지속
+  //   Signal 2 arc-completion:     arcProgress ≥ 0.95 + stationary 60s 지속
+  //   Signal 3 eta-backstop:       elapsed > expectedEta × 2 + stationary 5분 지속
+  // Idempotent guard: getTripEndedSentinel non-null 시 skip. backend가 먼저 발사하면 no-op.
+  // 관찰 22 backstop: silent push 미도달 + 6h+ 방치 케이스에서 9h+ lifecycle backstop 전에 자연 정리.
+  const arcProgress = useMemo<number | null>(() => {
+    if (arcStations.length < 2) return null;
+    if (currentHopIndex === null) return null;
+    // arcStations = [origin, ..., destination]. index 0 → 0%, index length-1 → 100%.
+    return currentHopIndex / (arcStations.length - 1);
+  }, [arcStations.length, currentHopIndex]);
+  const expectedTripDurationMs = useMemo<number | null>(() => {
+    const selectedCandidate = categorized.find(
+      (r) => r.category.key === selectedKey,
+    )?.candidate;
+    if (!selectedCandidate) return null;
+    return selectedCandidate.travelMinutes * 60_000;
+  }, [categorized, selectedKey]);
+  useDeviceSelfEnd({
+    currentStation: result?.station ?? null,
+    confidence,
+    arcProgress,
+    positionStability,
+    expectedTripDurationMs,
   });
   // #925 (C2 wire) — destination 자동 하차 감지. arvlCd=0/1 + 역 50m 이내 + 60s motion stationary
   // 4-신호 AND 게이트 통과 시 setDestination(null) 호출 → 후속 LA end / trip-end recall은


### PR DESCRIPTION
## 배경

**관찰 22** 잔여 gap: silent push 미도달 or 앱 kill 6h+ 방치 → sentinel 저장 안 됨 → 9h+ lifecycle backstop만 유일 backup. 사용자가 몇 시간 후 앱 재개해도 UI 안내 잔존.

PR #2041 (γ' fix)은 silent push가 **도달한** 케이스의 FG UI 잔존 8-18초를 해결했지만, silent push **미도달** 케이스는 backstop 부재.

## Paradigm 정합

[[feedback-device-self-contained-fusion]] "backend/GPS/WiFi 다 죽어도 device 보장"을 자동종료에도 확장. [[feedback-user-intent-equal-protection]] 위반 없음 — 사용자 명시 의향 없이 자동 supplement가 아니라 관찰 22 실기기 gap의 backstop.

## 채택 옵션: β (Device fusion 종료 signal)

3-signal 초기 스코프 (Signal 4 backend-timeout은 후속 분리):

| Signal | 조건 | 지속 |
|---|---|---|
| 1. fusion-destination | fusion === destination + 강 confidence 화이트리스트 | 30s |
| 2. arc-completion | arcProgress ≥ 0.95 + stationary | 60s |
| 3. eta-backstop | elapsed > expectedEta × 2 + stationary | 5분 |

OR fusion — 하나라도 trigger면 self-end.

## Idempotent guard

- `getTripEndedSentinel()` non-null 시 skip → backend가 먼저 발사하면 no-op.
- `firedForDestinationIdRef`를 async sentinel await **전에** 즉시 stamp → useEffect 재실행 race 차단 (code-review medium 발견).
- Cleanup chain: `triggerTripEndRecall → runTripBoundCleanups → triggerTripGroundTruthPrompt → useDestinationStore.setState(null들) → releaseLock → setTripEndedSentinel`. `useStateRehydration` lifecycle-backstop force-end 와 동일 시퀀스.

## False positive 방어

- Signal 1: FusionConfidence 강 신호 화이트리스트만 통과 (`gps-only`/`gps-only-underground` 배제).
- Signal 2: stationary 60s 지속 요구 — 움직임 중 trigger X.
- Signal 3: eta × 2 gate + stationary 5분 — **KTX 등 실 장거리 trip은 eta 자체 커서 자연 방어**. 3h ETA면 6h+ 방치 + 5분 정지해야 trigger.

## Signal 4 (backend-timeout) 후속 분리 이유

`silentPushTask.ts`는 동시 진행 PR (#2039 M, #2040 G, #2041 γ', #2042 I γ) 4-way 편집 hotspot. 본 PR은 신규 파일만 추가 + `alarmLog.ts` reason type 3개 + `HomeScreen.tsx` mount로 충돌 최소화. Signal 4 (`lastSilentPushReceivedAt.ts` + `silentPushTask.ts` handler 1줄 편집)는 hotspot 해소 후 후속 이슈로 등록 예정.

## Wire-completion 5단

1. **Orphan 없음** — `useDeviceSelfEnd` HomeScreen 마운트, `npm run lint:orphan` pass.
2. **V/X dashboard** — `alarmLog` reason 3개 (`trip-device-self-end-{fusion-destination,arc-completion,eta-backstop}`) → backend `/admin/alarm-log-stats` 응답에서 signal별 fired count 분포.
3. **의존 PR** — N/A (device-only, backend 편집 없음).
4. **측정 plan** — 1주 관찰: `trip-device-self-end-*` fired count > 0 + KTX/장거리 trip 사용자 피드백 false positive 0.
5. **Device verify** — 실기기 관찰 22 시나리오 (6h+ 방치 후 재개 시 UI 자동 정리). PR body evidence acceptance 매핑 필수.

## 변경 파일

- `src/features/alarm/utils/deviceSelfEndSignals.ts` (신규, 3 순수 함수)
- `src/features/alarm/utils/__tests__/deviceSelfEndSignals.test.ts` (신규, 46 tests)
- `src/features/alarm/hooks/useDeviceSelfEnd.ts` (신규, orchestrator)
- `src/features/alarm/hooks/__tests__/useDeviceSelfEnd.test.ts` (신규, 11 tests)
- `src/features/alarm/utils/alarmLog.ts` (reason 3개 추가, `source='lifecycle-backstop'` 재사용 → FIRED_ALARM_SOURCES 자동 fire 분모 제외)
- `src/screens/HomeScreen.tsx` (`useDeviceSelfEnd` mount + `arcProgress`/`expectedTripDurationMs` 파생)

## 검증

- `npm test`: 9091 tests pass, 100% coverage (신규 파일 포함).
- `npm run type-check`: pass.
- `npm run lint:orphan`: 0 orphan.
- Backend 편집 없음.

## Follow-up 이슈 등록 필요

Signal 4 (backend-timeout, `lastSilentPushReceivedAt` + `silentPushTask.ts` handler wire) — silent push handler hotspot(#2039/#2040/#2041/#2042) 안정화 후 별도 PR.

Closes #2043