### PR TITLE
feat(#2032): backend Trip.sleepModeEnabled 저장 (monitoring 전용, ADR-023 정합)

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -212,6 +212,19 @@ describe('validateTrip', () => {
     expect(validateTrip(base())?.subsurface).toBeUndefined();
   });
 
+  // #2032 (Issue D) — sleepModeEnabled 필드 (monitoring 전용, ADR-023 결정 gate 미사용)
+  it('preserves boolean sleepModeEnabled (#2032)', () => {
+    expect(validateTrip({ ...base(), sleepModeEnabled: true })?.sleepModeEnabled).toBe(true);
+    expect(validateTrip({ ...base(), sleepModeEnabled: false })?.sleepModeEnabled).toBe(false);
+  });
+
+  it('drops non-boolean sleepModeEnabled and absent field stays undefined (#2032, legacy client graceful)', () => {
+    expect(validateTrip({ ...base(), sleepModeEnabled: 'yes' })?.sleepModeEnabled).toBeUndefined();
+    expect(validateTrip({ ...base(), sleepModeEnabled: 1 })?.sleepModeEnabled).toBeUndefined();
+    // Legacy client (필드 미송신) — 기존 동작 완전 보존.
+    expect(validateTrip(base())?.sleepModeEnabled).toBeUndefined();
+  });
+
   // #1193 — 중복역 trip의 waypoint occurrenceIdx stamping.
   describe('occurrenceIdx stamping (#1193)', () => {
     it('단일 등장 waypoints는 모두 occurrenceIdx=0', () => {
@@ -868,6 +881,38 @@ describe('POST /trips (#578 — preserve advance progress on re-register)', () =
     const finalTrip = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
     expect(finalTrip.consecutiveEtaMissing).toBe(expectedCount);
     expect(finalTrip.subsurface).toBe(expectedSubsurface);
+  });
+
+  // #2032 (Issue D) — sleepModeEnabled 저장 및 재등록 시 incoming 값 반영.
+  // ADR-023: monitoring 전용 필드 — merge는 `...incoming` spread로 자연 갱신 (별도 preserve 로직 불필요).
+  it('persists sleepModeEnabled on register (monitoring 전용, ADR-023)', async () => {
+    const env = makeKvEnv();
+    await post('/trips', { ...tripBody(), sleepModeEnabled: true }, env);
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    expect(stored.sleepModeEnabled).toBe(true);
+  });
+
+  it('updates sleepModeEnabled on same-session re-register (user toggled sleep)', async () => {
+    const env = makeKvEnv();
+    // 1) initial register: sleep OFF
+    await post('/trips', tripBody(), env);
+    const initial = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    expect(initial.sleepModeEnabled).toBeUndefined();
+    // 2) user turns sleep ON — same createdAt (same session)
+    await post('/trips', { ...tripBody(), sleepModeEnabled: true }, env);
+    const afterOn = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    expect(afterOn.sleepModeEnabled).toBe(true);
+    // 3) user turns sleep OFF again — same session
+    await post('/trips', { ...tripBody(), sleepModeEnabled: false }, env);
+    const afterOff = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    expect(afterOff.sleepModeEnabled).toBe(false);
+  });
+
+  it('legacy client (no sleepModeEnabled) 는 undefined 저장 (backward-compat 완전 보존)', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripBody(), env); // legacy client — 필드 미송신
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    expect(stored.sleepModeEnabled).toBeUndefined();
   });
 
   // POST /trips 거부 케이스 — 동일한 400 + error-code shape를 테이블로 검증(중복 제거).

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -2183,6 +2183,11 @@ export function validateTrip(input: unknown): Trip | null {
       obj.locale === 'ko' || obj.locale === 'en' || obj.locale === 'ja' || obj.locale === 'zh'
         ? obj.locale
         : undefined,
+    // #2032 (Issue D): device 취침모드 상태 저장 — monitoring 전용 (ADR-023).
+    // backend push 발사 결정에 사용 금지 (types.ts sleepModeEnabled 주석 + ADR-023).
+    // Legacy client (필드 미송신) 또는 비boolean은 undefined로 graceful — 기존 동작 완전 보존.
+    sleepModeEnabled:
+      typeof obj.sleepModeEnabled === 'boolean' ? obj.sleepModeEnabled : undefined,
   };
 }
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -999,6 +999,9 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       log('lifecycle: force-end (>9h)', {
         token: trip.token.slice(0, 8),
         elapsedMs: now - trip.createdAt,
+        // #2032 (Issue D) — monitoring dimension. skip 원인 분류 시 device sleep 상태 참조.
+        // ADR-023: backend는 이 값으로 발사 결정 X (log 전용).
+        sleepMode: trip.sleepModeEnabled,
       });
       await cleanupTripWithLa(trip, env, deps, stats, now, log, 'expired');
       continue;
@@ -1008,6 +1011,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       log('lifecycle: silence cycle skipped (>6h)', {
         token: trip.token.slice(0, 8),
         elapsedMs: now - trip.createdAt,
+        // #2032 (Issue D) — monitoring dimension. ADR-023: 발사 결정 X.
+        sleepMode: trip.sleepModeEnabled,
       });
       continue;
     }
@@ -1040,6 +1045,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
           token: trip.token.slice(0, 8),
           station: waypoint.stationName,
           kind: waypoint.kind,
+          // #2032 (Issue D) — monitoring dimension. ADR-023: 발사 결정 X.
+          sleepMode: trip.sleepModeEnabled,
         });
         continue;
       }
@@ -1067,6 +1074,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
           token: trip.token.slice(0, 8),
           elapsedMs: now - trip.lastLaPushAt,
           station: pickActiveWaypoint(trip)?.stationName,
+          // #2032 (Issue D) — monitoring dimension. ADR-023: 발사 결정 X.
+          sleepMode: trip.sleepModeEnabled,
         });
         await cleanupTripWithLa(trip, env, deps, stats, now, log, 'la-stale-backstop');
         continue;
@@ -1090,6 +1099,9 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
         station: waypoint.stationName,
         locklessOptIn: trip.infoModeEnabled === true,
         waypointKind: waypoint.kind,
+        // #2032 (Issue D) — monitoring dimension. skip 원인 분류(정상 sleep skip vs 회귀 skip)의 핵심 dimension.
+        // ADR-023: backend 발사 결정 X — device의 `shouldSuppressBySleepRule`가 실제 suppress gate.
+        sleepMode: trip.sleepModeEnabled,
       });
       // #819 — lock 미발생 trip에 boarding-prompt 9단 게이트 평가 분기. 게이트 통과 시 alert
       // push로 "탑승 중이세요?"를 묻고, 클라이언트가 사용자 응답으로 lock을 자동 생성한다.
@@ -1810,6 +1822,10 @@ export async function fireArvlCdStationPush(
     station: waypoint.stationName,
     arvlCd,
     kind: waypoint.kind,
+    // #2032 (Issue D) — monitoring dimension. backend fire 시 device sleep 상태 기록.
+    // ADR-023: backend는 sleep 무관 발사 (arvlCd 신호 기반). device의 shouldSuppressBySleepRule이 UI suppress 판정.
+    // fire log ↔ device suppress log를 sleepMode dimension으로 대조해 skip 원인 자동 분류.
+    sleepMode: trip.sleepModeEnabled,
   });
   // #1561 (T8, ADR-017 / S2 흡수) — fire 직전 SSoT 권위 스냅샷 forward.
   // #1614 Phase C — stale guard 단계에서 이미 read한 ssotForStale 재사용 (KV read 1회 절약).
@@ -3408,6 +3424,9 @@ export async function runLocklessIntermediate(
     ...(currentStationName !== undefined ? { currentStation: currentStationName } : {}),
     arvlCd: signal.arvlCd,
     etaSeconds: signal.etaSeconds,
+    // #2032 (Issue D) — monitoring dimension. lockless fire 시 device sleep 상태 기록.
+    // ADR-023: backend는 sleep 무관 발사. device의 shouldSuppressBySleepRule이 UI suppress 판정.
+    sleepMode: trip.sleepModeEnabled,
   });
   // #1561 (T8, ADR-017 / S2 흡수) — lockless fire 직전 SSoT 권위 스냅샷 forward.
   const locklessSsot = await readSsot(env.TRIPS, trip.token, {
@@ -3757,6 +3776,8 @@ export async function evaluateAndMaybeFireBoardingPrompt(
     log('boarding-prompt: skip (lock active, F2 defense)', {
       token: trip.token.slice(0, 8),
       boardingLine: trip.boardingLock.line,
+      // #2032 (Issue D) — monitoring dimension. ADR-023: 발사 결정 X.
+      sleepMode: trip.sleepModeEnabled,
     });
     return;
   }
@@ -3823,6 +3844,8 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       token: trip.token.slice(0, 8),
       reason: outcome.reason satisfies GateSkipReason,
       environment,
+      // #2032 (Issue D) — monitoring dimension. gate block 원인 분류 시 device sleep 상태 참조.
+      sleepMode: trip.sleepModeEnabled,
     });
     if (dirty) await putTrip(env.TRIPS, trip);
     return;
@@ -4000,6 +4023,9 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       line: display.line,
       originStation: display.originStation,
       fusedSpeedKmh: Math.round(outcome.fusedSpeedKmh * 10) / 10,
+      // #2032 (Issue D) — monitoring dimension. fire 시 device sleep 상태 기록 (device suppress 여부와 대조 가능).
+      // ADR-023: backend는 sleep 무관 발사 유지. device의 shouldSuppressBySleepRule이 UI suppress 판정.
+      sleepMode: trip.sleepModeEnabled,
     });
   } else {
     stats.errors += 1;

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -236,6 +236,23 @@ export interface Trip {
    * silent push payload는 device-side i18n이 처리하므로 영향 없음.
    */
   locale?: 'ko' | 'en' | 'ja' | 'zh';
+  /**
+   * #2032 (Issue D) — 등록 시점 device 취침모드 상태. **monitoring 전용 (ADR-023)**.
+   *
+   * 저장 목적:
+   *   1) skip 원인 자동 분류 — cron/silent push log에 취침 여부 dimension을 얹어 "정상 sleep skip"과
+   *      "회귀 skip"을 backend 로그에서 즉시 구분 가능하게 한다.
+   *   2) evidence 재구성 자동화 — 사용자 trip 사후 분석 시 device sleep 상태를 backend 관점에서 재구성.
+   *
+   * **backend push 발사 결정에 사용 금지** — ADR-023 첫 원칙("Backend는 arvlCd 신호 기반 silent push를
+   * 무조건 발사, 취침모드 무관"). Device의 `shouldSuppressBySleepRule.ts`가 단일 gate. 이 필드로
+   * `if (trip.sleepModeEnabled)` 분기를 추가하면 backend가 정책 state를 소유하게 되어 device 토글 ↔
+   * backend KV 동기화 race window가 정확성 리스크로 전환된다(ADR-023 §"Backend 안 보냄 대안 미채택").
+   *
+   * 미송신/미지원(legacy client)은 `undefined`로 graceful 처리 — 기존 동작 완전 보존.
+   * `infoModeEnabled` / `subsurface` / `locale`과 동일 저장 전용 패턴.
+   */
+  sleepModeEnabled?: boolean;
 }
 
 /**

--- a/src/features/alarm/api/__tests__/alarmBackend.test.ts
+++ b/src/features/alarm/api/__tests__/alarmBackend.test.ts
@@ -290,6 +290,36 @@ describe('alarmBackend', () => {
         expect(global.fetch).toHaveBeenCalledTimes(1);
       });
 
+      // #2032 (Issue D) — device 취침모드 상태 forward. backend monitoring 전용 (ADR-023 결정 gate 미사용).
+      it('#2032 sleepModeEnabled=true 송신 시 body에 포함', async () => {
+        await registerActiveTrip({ ...SAMPLE_PAYLOAD, sleepModeEnabled: true });
+        const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+        expect(body.sleepModeEnabled).toBe(true);
+      });
+
+      it('#2032 sleepModeEnabled=false/미설정이면 body에 미포함 (graceful, backend undefined 유지)', async () => {
+        await registerActiveTrip({ ...SAMPLE_PAYLOAD, sleepModeEnabled: false });
+        const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+        expect(body.sleepModeEnabled).toBeUndefined();
+      });
+
+      it('#2032 sleepModeEnabled OFF→ON 전환 시 hash 갱신 → 재등록 (backend monitoring 값 즉시 동기화)', async () => {
+        const first = await registerActiveTrip({ ...SAMPLE_PAYLOAD, sleepModeEnabled: false });
+        expect(first.ok).toBe(true);
+        const second = await registerActiveTrip({ ...SAMPLE_PAYLOAD, sleepModeEnabled: true });
+        expect(second).toEqual({ ok: true, status: 200 });
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        const secondBody = JSON.parse((global.fetch as jest.Mock).mock.calls[1][1].body);
+        expect(secondBody.sleepModeEnabled).toBe(true);
+      });
+
+      it('#2032 동일 sleepModeEnabled 값 연속 호출 시 dedup (skipped=true)', async () => {
+        await registerActiveTrip({ ...SAMPLE_PAYLOAD, sleepModeEnabled: true });
+        const dedup = await registerActiveTrip({ ...SAMPLE_PAYLOAD, sleepModeEnabled: true });
+        expect(dedup).toEqual({ ok: true, skipped: true });
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+      });
+
       it('#701 in-flight dedup: 동일 페이로드 동시 호출 시 fetch는 1번만 발사된다', async () => {
         let resolveFetch: ((v: Response) => void) | null = null;
         (global.fetch as jest.Mock).mockImplementationOnce(

--- a/src/features/alarm/api/alarmBackend.ts
+++ b/src/features/alarm/api/alarmBackend.ts
@@ -127,6 +127,17 @@ export interface RegisterTripPayload {
    * backend는 미송신 시 graceful undefined → false 처리 (backward-compat).
    */
   infoModeEnabled?: boolean;
+  /**
+   * #2032 (Issue D) — 등록 시점 device 취침모드 상태. **backend monitoring 전용 (ADR-023)**.
+   *
+   * backend는 이 값을 저장(Trip.sleepModeEnabled)해 cron/silent push log에 dimension으로
+   * 얹는다 — skip 원인 자동 분류(정상 sleep skip vs 회귀 skip)와 evidence 재구성 자동화에 사용.
+   * backend push 발사 결정에는 사용하지 않는다(ADR-023: Backend는 arvlCd 신호 기반 silent push
+   * 무조건 발사, 취침모드 무관). Device의 `shouldSuppressBySleepRule`이 단일 gate.
+   *
+   * 미설정/false: 필드 미송신(graceful) — backend Trip.sleepModeEnabled는 undefined 유지.
+   */
+  sleepModeEnabled?: boolean;
 }
 
 export interface AlarmBackendResult {
@@ -189,6 +200,7 @@ function buildRegisterHash(body: {
   subsurface?: boolean;
   locale?: 'ko' | 'en' | 'ja' | 'zh';
   infoModeEnabled?: boolean;
+  sleepModeEnabled?: boolean;
 }): string {
   return JSON.stringify({
     token: body.token,
@@ -218,6 +230,10 @@ function buildRegisterHash(body: {
     // 사용자가 의향 표명 직후 backend lockless intermediate gate가 즉시 활성화되어야 다음
     // cron cycle부터 station-passed silent push 발사가 가능. 같은 값 연속 호출은 hash 동일 → skip.
     infoModeEnabled: body.infoModeEnabled === true,
+    // #2032 (Issue D) — sleepMode 토글 ON ↔ OFF 전환 시 즉시 재등록 보장.
+    // backend monitoring 값(Trip.sleepModeEnabled)이 즉시 갱신되어 이후 skip 원인 log가 정확.
+    // ADR-023: backend push 발사 결정에는 미영향(저장/log 전용). 같은 값 연속 호출은 hash 동일 → skip.
+    sleepModeEnabled: body.sleepModeEnabled === true,
   });
 }
 
@@ -287,6 +303,9 @@ async function performRegisterFetch(
     // #1923 — 사용자 명시 의향 토글. ON일 때만 송신. backend는 부재 시 false default 처리 (backward-compat).
     // device SSoT 동기화 시점에 false로 명시 송신 vs 미송신 둘 다 backend 동일 처리 → 송신 skip로 트래픽 절약.
     ...(payload.infoModeEnabled === true ? { infoModeEnabled: true } : {}),
+    // #2032 (Issue D) — device 취침모드 상태. ON일 때만 송신. backend는 monitoring 전용 저장 (ADR-023).
+    // 미송신 시 backend Trip.sleepModeEnabled는 undefined 유지 — 기존 동작 완전 보존.
+    ...(payload.sleepModeEnabled === true ? { sleepModeEnabled: true } : {}),
   };
 
   try {
@@ -361,6 +380,8 @@ export function registerActiveTrip(
     locale: payload.locale,
     // #1923 — infoModeEnabled 변경 시 hash 갱신해 재등록 보장 (의향 표명 직후 backend gate 즉시 활성화).
     infoModeEnabled: payload.infoModeEnabled,
+    // #2032 (Issue D) — sleepMode 변경 시 hash 갱신해 재등록 보장 (backend 저장값 즉시 동기화).
+    sleepModeEnabled: payload.sleepModeEnabled,
   });
   if (hash === lastRegisteredHash) {
     return Promise.resolve({ ok: true, skipped: true });

--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -1072,6 +1072,57 @@ describe('useApnsTripRegistration', () => {
     });
   });
 
+  // #2032 (Issue D) — device 취침모드 상태 backend forward (monitoring 전용, ADR-023 결정 gate 미사용).
+  describe('sleepMode (#2032)', () => {
+    const baseInputs = (sleepMode?: boolean) => ({
+      route: directRoute,
+      destination: station,
+      nextStationEtaSeconds: 120,
+      ...(sleepMode === undefined ? {} : { sleepMode }),
+    });
+    const renderSleep = (initial?: boolean) =>
+      renderHook(
+        ({ sm }: { sm?: boolean }) => useApnsTripRegistration(baseInputs(sm)),
+        { initialProps: { sm: initial } },
+      );
+
+    it.each([
+      { label: 'sleepMode=true → payload sleepModeEnabled=true 포함', sm: true, expected: true },
+      { label: 'sleepMode 미지정 → payload 미포함 (graceful)', sm: undefined, expected: undefined },
+      { label: 'sleepMode=false → payload 미포함 (graceful, backend legacy graceful 처리)', sm: false, expected: undefined },
+    ])('$label', async ({ sm, expected }) => {
+      renderSleep(sm);
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockRegister.mock.calls[0][0].sleepModeEnabled).toBe(expected);
+    });
+
+    it('OFF→ON 전환 시 즉시 재등록 (deps 반영 — backend monitoring 값 즉시 동기화)', async () => {
+      const { rerender } = renderSleep(false);
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockRegister.mock.calls[0][0].sleepModeEnabled).toBeUndefined();
+      rerender({ sm: true });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      expect(mockRegister.mock.calls[1][0].sleepModeEnabled).toBe(true);
+    });
+
+    it('token refresh 경로도 최신 sleepMode 값을 송신', async () => {
+      const { rerender } = renderSleep(false);
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      rerender({ sm: true });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      const listener = mockAddPushTokenListener.mock.calls[0][0];
+      await act(async () => {
+        listener({ data: 'token-SLEEP-NEW' });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const refreshed = mockRegister.mock.calls.find(
+        (c) => (c[0] as { token: string }).token === 'token-SLEEP-NEW',
+      );
+      expect(refreshed?.[0].sleepModeEnabled).toBe(true);
+    });
+  });
+
   describe('#1895 i18n locale 송신 (4언어 boarding-prompt)', () => {
     const baseInputs = {
       route: directRoute,

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -76,6 +76,14 @@ export interface UseApnsTripRegistrationInputs {
    * 미지정/false: 기존 동작 그대로 — boardingLock 부재 시 `lockMissing` skip.
    */
   infoModeEnabled?: boolean;
+  /**
+   * #2032 (Issue D) — 등록 시점 device 취침모드 상태. **monitoring 전용 (ADR-023)**.
+   * `useSettingsStore.sleepMode`를 그대로 전달. backend는 이 값으로 push 발사 결정을
+   * 바꾸지 않으며(오로지 저장/로그), skip 원인 자동 분류 + evidence 재구성에만 사용한다.
+   * ADR-023 §"Backend 발사 경로 5개 (모두 sleep 무관)" 유지.
+   * 미지정/false: 필드 미송신 (graceful) — backend 저장값 undefined 유지.
+   */
+  sleepMode?: boolean;
 }
 
 /**
@@ -101,6 +109,8 @@ interface RegisterCallInputs {
   subsurface: boolean;
   /** #1923 — 사용자 명시 의향 토글. true면 backend lockless intermediate gate 활성. */
   infoModeEnabled: boolean;
+  /** #2032 (Issue D) — device 취침모드 상태. backend monitoring 전용 (ADR-023 결정 gate 미사용). */
+  sleepMode: boolean;
   /** 같은 trip 세션 동안 고정되는 epoch ms. backend `isSameSession` 판정 키(#589). */
   createdAt: number;
   /**
@@ -214,6 +224,9 @@ async function callRegister(input: RegisterCallInputs) {
     ...(locale ? { locale } : {}),
     // #1923 — 사용자 명시 의향 토글 ON일 때만 송신. false/미설정은 필드 누락(graceful, backend는 false default).
     ...(input.infoModeEnabled ? { infoModeEnabled: true } : {}),
+    // #2032 (Issue D) — device 취침모드 상태. ON일 때만 송신. backend는 monitoring 전용으로 저장(ADR-023).
+    // false/미설정은 필드 누락(graceful) — backend Trip.sleepModeEnabled=undefined 유지.
+    ...(input.sleepMode ? { sleepModeEnabled: true } : {}),
   });
 }
 
@@ -225,6 +238,7 @@ export function useApnsTripRegistration({
   boardingLock = null,
   subsurface = false,
   infoModeEnabled = false,
+  sleepMode = false,
 }: UseApnsTripRegistrationInputs): void {
   // route 객체 reference가 categorized recompute로 자주 바뀌므로 내용 기반 signature로
   // 메모화 — register useEffect deps에 사용해 동일 경로 재등록(POST /trips 폭주) 방지.
@@ -233,9 +247,9 @@ export function useApnsTripRegistration({
   // alarmBackend dedup hash와 동일 필드 사용 (trainCode + line + boardedAt).
   const boardingLockSig = lockSig(boardingLock);
   // 최신 트립 입력을 ref에 보관 — pushTokenListener가 갱신 시 재등록에 사용한다.
-  const latestInputsRef = useRef({ route, destination, nextStationEtaSeconds, currentStation, boardingLock, subsurface, infoModeEnabled });
+  const latestInputsRef = useRef({ route, destination, nextStationEtaSeconds, currentStation, boardingLock, subsurface, infoModeEnabled, sleepMode });
   useEffect(() => {
-    latestInputsRef.current = { route, destination, nextStationEtaSeconds, currentStation, boardingLock, subsurface, infoModeEnabled };
+    latestInputsRef.current = { route, destination, nextStationEtaSeconds, currentStation, boardingLock, subsurface, infoModeEnabled, sleepMode };
   });
 
   // #589 — backend `isSameSession`(token+createdAt) 판정용. 같은 trip(같은
@@ -319,6 +333,7 @@ export function useApnsTripRegistration({
           boardingLock: bl,
           subsurface: sub,
           infoModeEnabled: ime,
+          sleepMode: sm,
         } = latestInputsRef.current;
         if (!r || !d) return;
         const sessionKey = `${token}:${routeSignature(r)}:${d.id}`;
@@ -331,6 +346,7 @@ export function useApnsTripRegistration({
           boardingLock: bl,
           subsurface: sub,
           infoModeEnabled: ime,
+          sleepMode: sm,
           createdAt: resolveTripCreatedAt(sessionKey),
           cachedPromptContext: lastPromptContextRef.current,
         });
@@ -432,6 +448,7 @@ export function useApnsTripRegistration({
         boardingLock,
         subsurface,
         infoModeEnabled,
+        sleepMode,
         createdAt: resolveTripCreatedAt(sessionKey),
         cachedPromptContext: lastPromptContextRef.current,
       });
@@ -487,6 +504,9 @@ export function useApnsTripRegistration({
     // #1923: infoModeEnabled 변화 시 backend lockless intermediate gate를 즉시 활성화해 다음 cron
     // cycle부터 station-passed silent push 발사가 가능. 토글 빈도는 사용자 명시 의향 표명/trip 종료
     // 시점만이므로 deps churn 위험 낮음. alarmBackend dedup hash가 미변화 사이클은 POST를 skip.
+    // #2032 (Issue D): sleepMode 변화 시 backend 저장값이 즉시 갱신되어 이후 log/skip 원인 분류가
+    // 정확해진다. **backend 발사 결정은 미영향 (ADR-023)** — device의 `shouldSuppressBySleepRule`만
+    // suppress 판정. 토글 빈도는 사용자 명시 설정 시점만이므로 deps churn 위험 낮음.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routeSig, destination?.id, boardingLockSig, subsurface, infoModeEnabled]);
+  }, [routeSig, destination?.id, boardingLockSig, subsurface, infoModeEnabled, sleepMode]);
 }

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -890,6 +890,9 @@ export default function HomeScreen() {
     // #1923 — 사용자 명시 의향 토글. backend가 lockless intermediate gate 진입에 사용 →
     // station-passed silent push 발사. 미stamp(false) trip은 기존 lockMissing skip 동작.
     infoModeEnabled,
+    // #2032 (Issue D) — device 취침모드 상태. backend monitoring 전용 저장 (ADR-023 결정 gate 미사용).
+    // skip 원인 분류 + evidence 재구성 자동화용. Device의 `shouldSuppressBySleepRule`이 실제 suppress gate.
+    sleepMode,
   });
 
   useEffect(() => {


### PR DESCRIPTION
Closes #2032

## 배경

사용자 확정 flow (2026-07-03) — 알림 발사 결정은 device UI 정책이지만, backend가 취침모드 저장은 monitoring 관점에서 유용:
- Skip 원인 자동 분류 (정상 sleep skip vs 회귀 skip)
- 사용자 trip evidence 재구성 자동화

**중요**: Backend는 이 정보로 push 발사 결정을 바꾸지 않음 (ADR-023 정합, 오로지 저장/모니터링).

## 변경 요약

### Backend
- `types.ts` — `Trip.sleepModeEnabled?: boolean` 추가 + ADR-023 monitoring 전용 원칙 명시 주석
- `index.ts validateTrip` — `typeof obj.sleepModeEnabled === 'boolean' ? ... : undefined` (legacy client graceful)
- `index.ts baseTrip merge` — `...incoming` spread로 자연 갱신 (같은 세션 재등록 시 최신 값 반영, `subsurface`/`locale`/`infoMode` 패턴 동일)
- `scheduled.ts` — 10개 skip/fire 로그에 `sleepMode: trip.sleepModeEnabled` context 추가 (decision branch 0개)

### Frontend
- `useApnsTripRegistration.ts` — `sleepMode?: boolean` prop 수용 + POST body 조건부 spread + deps 등록 + token-refresh 경로 동기화
- `alarmBackend.ts` — `RegisterTripPayload.sleepModeEnabled` 추가 + `buildRegisterHash`에 반영 (토글 변경 시 즉시 재등록)
- `HomeScreen.tsx` — `useSettingsStore.sleepMode`를 `useApnsTripRegistration`에 plumb

### Tests
- Backend (`index.test.ts`): validateTrip boolean 보존/graceful drop + POST /trips merge 3 시나리오 (첫 저장/OFF→ON→OFF 갱신/legacy 미송신)
- Backend (`__tests__/index.test.ts`): sleepModeEnabled 필드 파싱 3 케이스
- Frontend (`useApnsTripRegistration.test.ts`): payload 포함/graceful 미포함 + OFF→ON 재등록 + token-refresh 최신값
- Frontend (`alarmBackend.test.ts`): body 포함/미포함/hash 갱신/dedup 4 케이스

## ADR-023 정합 검증 (핵심)

```bash
# Decision branch check — 반드시 0개
grep -n "if.*trip\.sleepModeEnabled\|trip\.sleepModeEnabled\s*?" backend/alarm-worker/src/scheduled.ts
# 결과: (없음, exit 1)

# 모든 참조는 log context 안 (총 10건, 전부 log context)
grep -c "sleepModeEnabled" backend/alarm-worker/src/scheduled.ts
# 결과: 10
grep -c "sleepMode: trip\.sleepModeEnabled" backend/alarm-worker/src/scheduled.ts
# 결과: 10
```

10개 log 지점 (skip/fire 원인 분류에 유의미한 경계):
- `lifecycle: force-end (>9h)` / `lifecycle: silence cycle skipped (>6h)`
- `cron: stationary skip`
- `la-stale: auto-end after 5min push silence`
- `boarding-lock: skip cycle (lock missing or expired)`
- `boarding-prompt: skip (lock active, F2 defense)` / `boarding-prompt: gate blocked` / `boarding-prompt: fired`
- `arvlcd-fire: station-passed push`
- `lockless: station-passed push`

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass. `sleepMode` prop caller = `HomeScreen.tsx:895` 실 존재. `Trip.sleepModeEnabled` reader = scheduled.ts 10개 log call sites 실 존재.
2. **V/X dashboard** — `wrangler tail` + Cloudflare Dashboard에서 skip reason log에 `sleepMode` dimension 관측 가능. Skip 원인 자동 분류(정상 sleep skip vs 회귀 skip)에 사용.
3. **의존 PR** — 없음 (독립 신규 필드, backward-compat 완전 보존)
4. **측정 plan** — 1주 skip reason RCA 분류. `boarding-lock: skip cycle` log에서 sleepMode=true 비율 관측. 회귀 skip은 sleepMode=false/undefined임에도 skip 발생하는 케이스로 즉시 식별 가능.
5. **Device verify** — sleepMode ON/OFF 토글 시 POST /trips body에 `sleepModeEnabled: true` 필드 등장 여부 curl / wrangler tail로 검증. Backend Trip KV(`trip:{token}`)에서 sleepModeEnabled 저장 여부 확인.

## 관련

- ADR-023 (backend vs device sleep boundary) — 이미 존재. 본 PR은 §"Issue #2032" 정합 구현.
- Issue F (사용자 확정 flow 2026-07-03) — 취침모드 backend=저장용만 원칙.
- Pattern: `infoModeEnabled` (#816) / `subsurface` (#903) / `locale` (#1895) 저장 전용 필드와 동일.

## Test Plan

- [x] `cd backend/alarm-worker && npx vitest run` — 2582 tests pass
- [x] `npm test` — 9131 tests pass, coverage 100%
- [x] `npm run type-check` — pass (frontend)
- [x] `cd backend/alarm-worker && npm run type-check` — pass
- [x] `npm run lint:orphan` — 0 orphan
- [x] Decision branch check — 0 hits (grep)
- [ ] 실기기 sleepMode ON/OFF 토글 → POST body sleepModeEnabled 필드 curl/wrangler tail 검증
- [ ] Trip 등록 후 KV `trip:{token}`에서 sleepModeEnabled 저장 확인