### PR TITLE
feat(#2045): Signal 4 backend-timeout self-end (관찰 22 BG kill 커버)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
@@ -2,6 +2,10 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { renderHook, waitFor } from '@testing-library/react-native';
 import { ACTIVE_TRIP_KEY } from '../../../../shared/constants/storageKeys';
 import {
+  SIGNAL_4_KTX_ETA_UPPER_BOUND_MS,
+  SIGNAL_4_SILENT_PUSH_TIMEOUT_MS,
+} from '../../../../shared/constants/realtime';
+import {
   runLaunchTripReconciliation,
   useLaunchTripReconciliation,
 } from '../useLaunchTripReconciliation';
@@ -17,6 +21,20 @@ jest.mock('../../utils/tripEndedSentinel', () => ({
   getTripEndedSentinel: (...args: unknown[]) => mockGetSentinel(...args),
   setTripEndedSentinel: (...args: unknown[]) => mockSetSentinel(...args),
   clearTripEndedSentinel: jest.fn(),
+}));
+
+// #2045 Signal 4 — silent push last-received stamp + trip started at.
+const mockGetLastSilentPushReceivedAt = jest.fn();
+jest.mock('../../utils/lastSilentPushReceivedAt', () => ({
+  getLastSilentPushReceivedAt: (...args: unknown[]) =>
+    mockGetLastSilentPushReceivedAt(...args),
+  setLastSilentPushReceivedAt: jest.fn(),
+  clearLastSilentPushReceivedAt: jest.fn(),
+}));
+
+const mockGetTripStartedAt = jest.fn();
+jest.mock('../../utils/tripStartStorage', () => ({
+  getTripStartedAt: (...args: unknown[]) => mockGetTripStartedAt(...args),
 }));
 
 const mockSendTripEnded = jest.fn();
@@ -81,6 +99,9 @@ beforeEach(async () => {
   mockRunTripBoundCleanups.mockResolvedValue(undefined);
   mockFlushSignalDumpOutbox.mockResolvedValue({ ok: false, skipped: true });
   mockClearBackendSsotMirror.mockResolvedValue(undefined);
+  // #2045 Signal 4 — 기본은 null(판정 skip). 각 test가 필요 시 override.
+  mockGetLastSilentPushReceivedAt.mockResolvedValue(null);
+  mockGetTripStartedAt.mockResolvedValue(null);
   process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
 });
 
@@ -254,6 +275,135 @@ describe('runLaunchTripReconciliation', () => {
     // runLaunchTripReconciliation은 outer try-catch로 보호되므로 예외는 silent fail로 흡수.
     mockFlushSignalDumpOutbox.mockRejectedValueOnce(new Error('boom'));
     await expect(runLaunchTripReconciliation()).resolves.toBeUndefined();
+  });
+
+  // #2045 Signal 4 — backend-timeout self-end. 관찰 22 BG kill 6h+ 커버.
+  // FG 유지 시 backstop인 #2044 3-signal과 상호 보완 — 본 chain은 launch 진입 시 판정.
+  describe('#2045 Signal 4 — backend-timeout self-end', () => {
+    const now = 2_000_000_000_000; // 2033-05-18. deterministic epoch.
+    const OVER_TIMEOUT = SIGNAL_4_SILENT_PUSH_TIMEOUT_MS + 60_000; // 31분+
+    const UNDER_TIMEOUT = SIGNAL_4_SILENT_PUSH_TIMEOUT_MS - 60_000; // 29분
+    const UNDER_KTX = SIGNAL_4_KTX_ETA_UPPER_BOUND_MS - 60_000; // 9h 59분
+    const OVER_KTX = SIGNAL_4_KTX_ETA_UPPER_BOUND_MS + 60_000; // 10h 1분
+
+    beforeEach(async () => {
+      jest.useFakeTimers().setSystemTime(now);
+      await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('silent push 30분+ 무음 + trip 10h 미만 → self-end (recall + cleanup + sentinel + active clear)', async () => {
+      // fetchTripStatus는 호출되면 안 됨 — Signal 4가 fetch 이전에 판정 & 종결.
+      mockGetLastSilentPushReceivedAt.mockResolvedValue(now - OVER_TIMEOUT);
+      mockGetTripStartedAt.mockResolvedValue(now - UNDER_KTX);
+      await runLaunchTripReconciliation();
+      expect(mockFetchTripStatus).not.toHaveBeenCalled();
+      expect(mockTriggerTripEndRecall).toHaveBeenCalledTimes(1);
+      expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+      expect(mockTriggerTripGroundTruthPrompt).toHaveBeenCalledTimes(1);
+      expect(mockSetSentinel).toHaveBeenCalledWith(now);
+      expect(await AsyncStorage.getItem(ACTIVE_TRIP_KEY)).toBeNull();
+      // Notification 미발사 — backend 무음 상태에서 "trip 종료" 알림은 사용자에게 잘못된 신호.
+      expect(mockSendTripEnded).not.toHaveBeenCalled();
+    });
+
+    it('self-end 시 호출 순서: recall → cleanup → prompt → sentinel → active clear', async () => {
+      mockGetLastSilentPushReceivedAt.mockResolvedValue(now - OVER_TIMEOUT);
+      mockGetTripStartedAt.mockResolvedValue(now - UNDER_KTX);
+      await runLaunchTripReconciliation();
+      const recallOrder = mockTriggerTripEndRecall.mock.invocationCallOrder[0];
+      const cleanupOrder = mockRunTripBoundCleanups.mock.invocationCallOrder[0];
+      const promptOrder = mockTriggerTripGroundTruthPrompt.mock.invocationCallOrder[0];
+      const sentinelOrder = mockSetSentinel.mock.invocationCallOrder[0];
+      expect(recallOrder).toBeLessThan(cleanupOrder);
+      expect(cleanupOrder).toBeLessThan(promptOrder);
+      expect(promptOrder).toBeLessThan(sentinelOrder);
+      expect(await AsyncStorage.getItem(ACTIVE_TRIP_KEY)).toBeNull();
+    });
+
+    it('silent push < 30분 (정상) → fetch로 흐름 이어짐 (self-end skip)', async () => {
+      mockGetLastSilentPushReceivedAt.mockResolvedValue(now - UNDER_TIMEOUT);
+      mockGetTripStartedAt.mockResolvedValue(now - UNDER_KTX);
+      mockFetchTripStatus.mockResolvedValue({ status: 'active', endedAt: null, endReason: null });
+      await runLaunchTripReconciliation();
+      expect(mockFetchTripStatus).toHaveBeenCalledWith('tk', 'https://api.test.dev');
+      expect(mockTriggerTripEndRecall).not.toHaveBeenCalled();
+      expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+      expect(mockSetSentinel).not.toHaveBeenCalled();
+      expect(await AsyncStorage.getItem(ACTIVE_TRIP_KEY)).toBe('tk');
+    });
+
+    it('KTX/장거리 (trip 10h+) → self-end skip, fetch로 흐름 이어짐 (false positive 방지)', async () => {
+      mockGetLastSilentPushReceivedAt.mockResolvedValue(now - OVER_TIMEOUT);
+      mockGetTripStartedAt.mockResolvedValue(now - OVER_KTX);
+      mockFetchTripStatus.mockResolvedValue({ status: 'active', endedAt: null, endReason: null });
+      await runLaunchTripReconciliation();
+      expect(mockFetchTripStatus).toHaveBeenCalledTimes(1);
+      expect(mockTriggerTripEndRecall).not.toHaveBeenCalled();
+      expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+      expect(mockSetSentinel).not.toHaveBeenCalled();
+    });
+
+    it('lastReceivedAt null (silent push 미수신) → self-end skip, fetch로 흐름 이어짐 (첫 launch or 새 trip 직후)', async () => {
+      mockGetLastSilentPushReceivedAt.mockResolvedValue(null);
+      mockGetTripStartedAt.mockResolvedValue(now - UNDER_KTX);
+      mockFetchTripStatus.mockResolvedValue({ status: 'active', endedAt: null, endReason: null });
+      await runLaunchTripReconciliation();
+      expect(mockFetchTripStatus).toHaveBeenCalledTimes(1);
+      expect(mockTriggerTripEndRecall).not.toHaveBeenCalled();
+      expect(mockSetSentinel).not.toHaveBeenCalled();
+    });
+
+    it('startedAt null (trip 시각 미기록) → self-end skip, fetch로 흐름 이어짐 (기존 recall에 위임)', async () => {
+      mockGetLastSilentPushReceivedAt.mockResolvedValue(now - OVER_TIMEOUT);
+      mockGetTripStartedAt.mockResolvedValue(null);
+      mockFetchTripStatus.mockResolvedValue({ status: 'active', endedAt: null, endReason: null });
+      await runLaunchTripReconciliation();
+      expect(mockFetchTripStatus).toHaveBeenCalledTimes(1);
+      expect(mockTriggerTripEndRecall).not.toHaveBeenCalled();
+      expect(mockSetSentinel).not.toHaveBeenCalled();
+    });
+
+    it('sentinel 기록 있음 → Signal 4 미진입 (fetch/self-end 모두 skip)', async () => {
+      mockGetSentinel.mockResolvedValue(1_700_000_000_000);
+      mockGetLastSilentPushReceivedAt.mockResolvedValue(now - OVER_TIMEOUT);
+      mockGetTripStartedAt.mockResolvedValue(now - UNDER_KTX);
+      await runLaunchTripReconciliation();
+      expect(mockFetchTripStatus).not.toHaveBeenCalled();
+      expect(mockTriggerTripEndRecall).not.toHaveBeenCalled();
+      expect(mockSetSentinel).not.toHaveBeenCalled();
+      // sentinel skip는 위 sentinel test에서도 커버 — Signal 4가 sentinel skip를 우회하지 않는지 검증.
+    });
+
+    it('경계값: 정확히 30분 gap → skip (>= 아닌 > 임계값)', async () => {
+      mockGetLastSilentPushReceivedAt.mockResolvedValue(now - SIGNAL_4_SILENT_PUSH_TIMEOUT_MS);
+      mockGetTripStartedAt.mockResolvedValue(now - UNDER_KTX);
+      mockFetchTripStatus.mockResolvedValue({ status: 'active', endedAt: null, endReason: null });
+      await runLaunchTripReconciliation();
+      // 30분 정확 = 30 * 60_000. now - lastReceived = 30분. 30분 > 30분 false → skip.
+      expect(mockTriggerTripEndRecall).not.toHaveBeenCalled();
+      expect(mockFetchTripStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it('경계값: 정확히 10h trip age → skip (< 아닌 < 임계값)', async () => {
+      mockGetLastSilentPushReceivedAt.mockResolvedValue(now - OVER_TIMEOUT);
+      mockGetTripStartedAt.mockResolvedValue(now - SIGNAL_4_KTX_ETA_UPPER_BOUND_MS);
+      mockFetchTripStatus.mockResolvedValue({ status: 'active', endedAt: null, endReason: null });
+      await runLaunchTripReconciliation();
+      // 10h 정확 = 10 * 60 * 60_000. now - startedAt = 10h. 10h < 10h false → skip.
+      expect(mockTriggerTripEndRecall).not.toHaveBeenCalled();
+      expect(mockFetchTripStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it('내부 예외 (recall reject) → silent fail (outer try/catch가 흡수)', async () => {
+      mockGetLastSilentPushReceivedAt.mockResolvedValue(now - OVER_TIMEOUT);
+      mockGetTripStartedAt.mockResolvedValue(now - UNDER_KTX);
+      mockTriggerTripEndRecall.mockRejectedValueOnce(new Error('boom'));
+      await expect(runLaunchTripReconciliation()).resolves.toBeUndefined();
+    });
   });
 });
 

--- a/src/features/alarm/hooks/useLaunchTripReconciliation.ts
+++ b/src/features/alarm/hooks/useLaunchTripReconciliation.ts
@@ -14,14 +14,19 @@
  * 흐름:
  *   1) ACTIVE_TRIP_KEY 조회. 없으면 미트립 — skip.
  *   2) tripEndedSentinel 확인. 이미 기록 있음 = silent push가 잘 도달한 케이스 — skip.
- *   3) `fetchTripStatus` 호출.
+ *   3) #2045 (Signal 4) — backend-timeout self-end 판정. 마지막 silent push 수신 후
+ *      SIGNAL_4_SILENT_PUSH_TIMEOUT_MS(30분) 초과 + trip 시작 후 SIGNAL_4_KTX_ETA_UPPER_BOUND_MS
+ *      (10h) 미만이면 backend가 실질적으로 이 trip을 놓친 것으로 간주 → 즉시 self-end.
+ *      status=ended 분기와 동일한 cleanup 시퀀스 (notification 미발사 — backend 무음 상태에서
+ *      "trip 종료" 알림은 사용자에게 잘못된 신호). 관찰 22 BG kill 6h+ 방치 후 launch 시나리오 커버.
+ *   4) `fetchTripStatus` 호출.
  *      - status='ended' → notification 발사 + trip-end recall + storage cleanup + sentinel 기록 +
  *        active trip clear. silent push handler와 같은 cleanup 시퀀스를 그대로 따라
  *        사전예약/route/destination 잔존을 차단한다 (#1351 R1).
  *      - null(404/410) → active trip clear만. notification은 발사하지 않는다 (이미 정리됨,
  *        과거 notification은 다른 채널로 도달했을 가능성 또는 retention 만료).
  *      - status='active' → 변경 없음.
- *   4) 네트워크 에러 → silent fail. 다음 launch에서 재시도.
+ *   5) 네트워크 에러 → silent fail. 다음 launch에서 재시도.
  *
  * 멱등성: sentinel이 기록되면 step 2에서 skip되므로 같은 trip에 대해 notification은 최대 1회.
  * triggerTripEndRecall/runTripBoundCleanups 자체도 멱등이라 silent push handler와 중복 호출 안전.
@@ -40,9 +45,15 @@ import { useEffect } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
 import {
+  SIGNAL_4_KTX_ETA_UPPER_BOUND_MS,
+  SIGNAL_4_SILENT_PUSH_TIMEOUT_MS,
+} from '../../../shared/constants/realtime';
+import {
   getTripEndedSentinel,
   setTripEndedSentinel,
 } from '../utils/tripEndedSentinel';
+import { getLastSilentPushReceivedAt } from '../utils/lastSilentPushReceivedAt';
+import { getTripStartedAt } from '../utils/tripStartStorage';
 import { sendTripEndedNotification } from '../utils/stationNotification';
 import { fetchTripStatus } from '../api/tripStatus';
 import { triggerTripEndRecall } from '../utils/triggerTripEndRecall';
@@ -96,6 +107,50 @@ export async function runLaunchTripReconciliation(): Promise<void> {
     const sentinel = await getTripEndedSentinel();
     if (sentinel !== null) {
       logger.info('skip — sentinel already recorded');
+      return;
+    }
+
+    // #2045 (Signal 4, Issue #2043 β 후속) — backend-timeout self-end 판정.
+    //
+    // 마지막 silent push 수신 후 30분+ 무음 AND trip 시작 후 10h 미만이면 backend가
+    // 실질적으로 이 trip을 놓친 것으로 판단해 device가 자체 종료. 관찰 22 시나리오
+    // (BG 6h+ 방치 or 앱 kill 후 launch) 커버 — #2044 FG 3-signal과 상호 보완.
+    //
+    // 두 임계 모두 만족 필요:
+    //   - lastReceivedAt !== null: silent push 한 번도 없으면 (첫 launch or 새 trip 직후)
+    //     판정 skip. 정상 silent push wire 확인 후에만 무음 판정.
+    //   - startedAt !== null: trip 시작 시각 없으면 판정 skip (기존 recall 처리에 위임).
+    //   - now - lastReceivedAt > 30분: backend 무음 확정 (cron ~30s cycle × 60).
+    //   - now - startedAt < 10h: KTX/장거리 실 trip 보호. 10h 이상은 force-end backstop(9h)에 위임.
+    //
+    // Sentinel 이후 배치: 위에서 sentinel !== null 이미 skip. 여기 도달 = sentinel 부재 상태.
+    // Self-end 성공 시 setTripEndedSentinel(now)로 다음 launch에서는 sentinel skip로 즉시 return.
+    //
+    // Notification 미발사: sendTripEndedNotification 호출 안 함. Backend가 무음 상태에서
+    // "trip 종료" 알림은 사용자에게 잘못된 신호(백엔드 outage인지 정상 종료인지 모름).
+    // status=ended 분기와 다른 점: cleanup + sentinel만 수행. UI는 다음 FG mount 시
+    // useStateRehydration이 sentinel 감지해 destination/lock reset하는 기존 chain에 위임.
+    const now = Date.now();
+    const [lastReceivedAt, startedAt] = await Promise.all([
+      getLastSilentPushReceivedAt(),
+      getTripStartedAt(),
+    ]);
+    if (
+      lastReceivedAt !== null &&
+      startedAt !== null &&
+      now - lastReceivedAt > SIGNAL_4_SILENT_PUSH_TIMEOUT_MS &&
+      now - startedAt < SIGNAL_4_KTX_ETA_UPPER_BOUND_MS
+    ) {
+      logger.info(
+        `Signal 4 backend-timeout self-end: silentPushGap=${now - lastReceivedAt}ms tripAge=${now - startedAt}ms`,
+      );
+      // 기존 status=ended 분기와 동일한 순서 — recall이 cleanup 이전이어야 storage 입력 유지.
+      await triggerTripEndRecall();
+      const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
+      await runTripBoundCleanups();
+      await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
+      await setTripEndedSentinel(now);
+      await AsyncStorage.removeItem(ACTIVE_TRIP_KEY);
       return;
     }
 

--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -26,6 +26,7 @@ import {
 import { clearAlarmLogWindows } from '../../utils/alarmLog';
 import { resetAlarmBackendDedup } from '../../api/alarmBackend';
 import { clearBackendSsotMirror } from '../../utils/backendSsotMirror';
+import { clearLastSilentPushReceivedAt } from '../../utils/lastSilentPushReceivedAt';
 import { useDestinationStore } from '../../../route/store/useDestinationStore';
 import { useBoardingLockStore } from '../useBoardingLockStore';
 import { useAlarmEventStore } from '../useAlarmEventStore';
@@ -410,6 +411,13 @@ describe('tripBoundCleanups', () => {
       expect(TRIP_BOUND_CLEANUPS).toContain(clearBackendSsotMirror);
     });
 
+    // #2045 (Signal 4) — 새 trip 시작 or 종료 시 last-silent-push-received stamp도 함께 제거.
+    // 누락 시 이전 trip의 stamp가 남아 새 trip의 backend-timeout 판정(useLaunchTripReconciliation)에서
+    // 오탐 발생 가능(가장 오래된 stamp 기준 30분+ 무음 판정 조기 발동).
+    it('#2045 (Signal 4): clearLastSilentPushReceivedAt가 TRIP_BOUND_CLEANUPS에 포함된다 (backend-timeout 판정 오염 차단)', () => {
+      expect(TRIP_BOUND_CLEANUPS).toContain(clearLastSilentPushReceivedAt);
+    });
+
     it('S12-8: enumeration 가드 — TRIP_BOUND_CLEANUPS 길이가 baseline 이하로 떨어지면 회귀', () => {
       // 새 cleanup 항목이 추가될 때마다 baseline을 한 줄로 갱신. 누군가 실수로 항목을 제거하면
       // 본 assertion이 빨갛게 깨져 의도된 제거인지 코드리뷰에서 확인하도록 강제한다.
@@ -420,7 +428,8 @@ describe('tripBoundCleanups', () => {
       // 종료-only trigger이므로 4 trip-end 호출 경로(setDestination switch/silentPushTask trip-ended/
       // useLaunchTripReconciliation/useStateRehydration sentinel+force-end)에서 명시 호출.
       // #1892 / #1885 — endLiveActivityCleanup 1 신규 (RC-9 LA orphan 26분 cascade fix).
-      const MIN_ITEMS = 26;
+      // #2045 — clearLastSilentPushReceivedAt 1 신규 (Signal 4 판정 오염 차단).
+      const MIN_ITEMS = 27;
       expect(TRIP_BOUND_CLEANUPS.length).toBeGreaterThanOrEqual(MIN_ITEMS);
     });
   });

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -30,6 +30,7 @@ import { clearFiredPushIds } from '../utils/firedPushIds';
 import { clearTripTrainCode } from '../../route/utils/tripTrainCode';
 import { clearDismissSilence as clearDismissSilenceStorage } from '../utils/dismissSilenceStorage';
 import { clearLaDismissSentinel } from '../utils/laDismissSentinel';
+import { clearLastSilentPushReceivedAt } from '../utils/lastSilentPushReceivedAt';
 import { clearPrescheduledLedger } from '../utils/prescheduledMetrics';
 import {
   getRegisteredBlRouteSig,
@@ -173,6 +174,11 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   // 4 cleanup 경로 (FG setDestination(null/switch) / silent push trip-ended /
   // useStateRehydration sentinel / useLaunchTripReconciliation cold-launch) 모두 자동 wire.
   resetUserIntentInfoMode,
+  // #2045 (Signal 4) — trip 종료 시 last-silent-push-received stamp 제거.
+  // 새 trip의 첫 launch reconciliation 시점에 이전 trip의 last-received가 남아 있으면
+  // (직전 trip이 정상 종료 후 새 trip 시작 X → 앱 launch) → 새 trip 판정 오염 방지.
+  // 새 trip 등록 후 첫 silent push 수신 시점부터 stamp 재갱신 → clean baseline.
+  clearLastSilentPushReceivedAt,
 ];
 
 /**

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -93,6 +93,15 @@ jest.mock('../../utils/tripEndedSentinel', () => ({
     mockClearTripEndedSentinel(...args),
 }));
 
+// #2045 (Signal 4) — silent push 수신 시각 stamp. handleSilentPush가 유효 payload 진입 시점에 write.
+const mockSetLastSilentPushReceivedAt = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../utils/lastSilentPushReceivedAt', () => ({
+  setLastSilentPushReceivedAt: (...args: unknown[]) =>
+    mockSetLastSilentPushReceivedAt(...args),
+  getLastSilentPushReceivedAt: jest.fn(),
+  clearLastSilentPushReceivedAt: jest.fn(),
+}));
+
 // #919 — trip-ended 분기는 cleanup 직전에 recall trigger를 호출한다.
 const mockTriggerTripEndRecall = jest.fn().mockResolvedValue({ uploaded: false });
 jest.mock('../../utils/triggerTripEndRecall', () => ({
@@ -1519,6 +1528,26 @@ describe('silentPushTask', () => {
       const arg = mockLogSilentPushReceived.mock.calls[0][0];
       expect(arg.sentAt).toBe(1_700_000_000_000);
       expect(typeof arg.receivedAt).toBe('number');
+    });
+
+    // #2045 (Signal 4) — 유효 payload 진입 시점에 last-received stamp 갱신 (kind 무관).
+    // useLaunchTripReconciliation이 launch 시 read해 backend-timeout self-end 판정 (관찰 22 BG kill 커버).
+    describe('#2045 Signal 4 — setLastSilentPushReceivedAt wire', () => {
+      it('유효 standard payload → setLastSilentPushReceivedAt 1회 호출 (숫자 인자)', async () => {
+        await handleSilentPush(payload({ kind: 'transfer', phase: 'early' }));
+        expect(mockSetLastSilentPushReceivedAt).toHaveBeenCalledTimes(1);
+        expect(typeof mockSetLastSilentPushReceivedAt.mock.calls[0][0]).toBe('number');
+      });
+
+      it('invalid payload → setLastSilentPushReceivedAt 호출 안 함 (유효 payload 진입점에서만 stamp)', async () => {
+        await handleSilentPush({ data: bgTaskData({ trigger: 'other' }) });
+        expect(mockSetLastSilentPushReceivedAt).not.toHaveBeenCalled();
+      });
+
+      it('input.error → setLastSilentPushReceivedAt 호출 안 함', async () => {
+        await handleSilentPush({ error: { message: 'boom' } });
+        expect(mockSetLastSilentPushReceivedAt).not.toHaveBeenCalled();
+      });
     });
 
     // #1438 (E5) — backend → device lock release sync 채널 통합.

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -67,6 +67,7 @@ import {
   setTripEndedSentinel,
   clearTripEndedSentinel,
 } from '../utils/tripEndedSentinel';
+import { setLastSilentPushReceivedAt } from '../utils/lastSilentPushReceivedAt';
 import { triggerTripEndRecall } from '../utils/triggerTripEndRecall';
 import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
 import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
@@ -1024,6 +1025,10 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     }
     const receivedAt = Date.now();
     addDomainBreadcrumb('push', 'silent-push', { kind: payload.kind ?? 'fire' });
+    // #2045 (Signal 4) — 유효 payload 진입 시점에 last-received stamp 갱신.
+    // useLaunchTripReconciliation이 launch 시 read해 backend-timeout self-end 판정 (관찰 22 BG kill 커버).
+    // fire-and-forget — write 실패해도 다음 push 수신에서 재갱신, 판정 실패는 9h force-end backstop 흡수.
+    void setLastSilentPushReceivedAt(receivedAt);
     const apnsToken = await loadApnsToken();
 
     // #1561 (T8, ADR-017 / S2 #1535 흡수) — backend SSoT 권위 mirror 저장.

--- a/src/features/alarm/utils/__tests__/lastSilentPushReceivedAt.test.ts
+++ b/src/features/alarm/utils/__tests__/lastSilentPushReceivedAt.test.ts
@@ -1,0 +1,77 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  clearLastSilentPushReceivedAt,
+  getLastSilentPushReceivedAt,
+  setLastSilentPushReceivedAt,
+} from '../lastSilentPushReceivedAt';
+import { LAST_SILENT_PUSH_RECEIVED_AT_KEY } from '../../../../shared/constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    setItem: jest.fn(),
+    getItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+const setItemMock = AsyncStorage.setItem as jest.Mock;
+const getItemMock = AsyncStorage.getItem as jest.Mock;
+const removeItemMock = AsyncStorage.removeItem as jest.Mock;
+
+describe('lastSilentPushReceivedAt (#2045 Signal 4)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setItemMock.mockResolvedValue(undefined);
+    removeItemMock.mockResolvedValue(undefined);
+  });
+
+  it('setLastSilentPushReceivedAt — at 인자를 문자열로 직렬화해 last-received 키에 저장', async () => {
+    await setLastSilentPushReceivedAt(1_700_000_000_000);
+    expect(setItemMock).toHaveBeenCalledWith(
+      LAST_SILENT_PUSH_RECEIVED_AT_KEY,
+      '1700000000000',
+    );
+  });
+
+  it('setLastSilentPushReceivedAt — 기본값은 Date.now()', async () => {
+    const now = 1_710_000_000_000;
+    const spy = jest.spyOn(Date, 'now').mockReturnValue(now);
+    try {
+      await setLastSilentPushReceivedAt();
+    } finally {
+      spy.mockRestore();
+    }
+    expect(setItemMock).toHaveBeenCalledWith(LAST_SILENT_PUSH_RECEIVED_AT_KEY, String(now));
+  });
+
+  it('setLastSilentPushReceivedAt — AsyncStorage 실패는 흡수 (graceful, 9h force-end backstop이 흡수)', async () => {
+    setItemMock.mockRejectedValueOnce(new Error('disk full'));
+    await expect(setLastSilentPushReceivedAt(1)).resolves.toBeUndefined();
+  });
+
+  it.each<[string, unknown, number | null]>([
+    ['숫자 문자열', '1700000000000', 1_700_000_000_000],
+    ['키 부재(null)', null, null],
+    ['NaN 문자열', 'abc', null],
+    ['빈 문자열은 Number("")=0이라 0 반환', '', 0],
+  ])('getLastSilentPushReceivedAt — %s → %s', async (_label, raw, expected) => {
+    getItemMock.mockResolvedValueOnce(raw);
+    await expect(getLastSilentPushReceivedAt()).resolves.toBe(expected);
+  });
+
+  it('getLastSilentPushReceivedAt — AsyncStorage 실패 시 null', async () => {
+    getItemMock.mockRejectedValueOnce(new Error('boom'));
+    await expect(getLastSilentPushReceivedAt()).resolves.toBeNull();
+  });
+
+  it('clearLastSilentPushReceivedAt — removeItem 호출', async () => {
+    await clearLastSilentPushReceivedAt();
+    expect(removeItemMock).toHaveBeenCalledWith(LAST_SILENT_PUSH_RECEIVED_AT_KEY);
+  });
+
+  it('clearLastSilentPushReceivedAt — 실패는 흡수', async () => {
+    removeItemMock.mockRejectedValueOnce(new Error('boom'));
+    await expect(clearLastSilentPushReceivedAt()).resolves.toBeUndefined();
+  });
+});

--- a/src/features/alarm/utils/lastSilentPushReceivedAt.ts
+++ b/src/features/alarm/utils/lastSilentPushReceivedAt.ts
@@ -1,0 +1,47 @@
+/**
+ * Last silent push received epoch ms storage (#2045, Signal 4 / Issue #2043 β 후속).
+ *
+ * `silentPushTask.handleSilentPush`가 유효 payload 진입 시점(receivedAt stamp)에 write,
+ * `useLaunchTripReconciliation`이 launch 시점에 read해 backend-timeout self-end 판정에 사용.
+ *
+ * 관찰 22 (BG kill 6h+ 방치 후 launch) 커버. FG 전용 3-signal(#2044)과 상호 보완:
+ *   - #2044: HomeScreen mount 3-signal (fusion + arc + ETA) — FG 유지 시 backstop
+ *   - #2045: launch reconciliation 확장 — BG kill 시나리오 커버
+ *
+ * SSOT key: storageKeys.LAST_SILENT_PUSH_RECEIVED_AT_KEY.
+ *
+ * 모든 함수는 AsyncStorage 실패를 graceful 흡수 — signal 4 판정은 보조 backstop이라
+ * 실패해도 기존 recall/sentinel chain 및 force-end backstop(9h)이 자연 흡수한다.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { LAST_SILENT_PUSH_RECEIVED_AT_KEY } from '../../../shared/constants/storageKeys';
+
+/** last-received stamp 저장. silent push handler 진입점에서 호출 (kind 무관). */
+export async function setLastSilentPushReceivedAt(at: number = Date.now()): Promise<void> {
+  try {
+    await AsyncStorage.setItem(LAST_SILENT_PUSH_RECEIVED_AT_KEY, String(at));
+  } catch {
+    // graceful — 다음 push 수신에서 재갱신 시도. 판정 실패해도 9h force-end backstop이 흡수.
+  }
+}
+
+/** last-received epoch ms 또는 null. 키 부재/NaN 모두 null. */
+export async function getLastSilentPushReceivedAt(): Promise<number | null> {
+  try {
+    const raw = await AsyncStorage.getItem(LAST_SILENT_PUSH_RECEIVED_AT_KEY);
+    if (raw === null) return null;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** last-received stamp 제거. tripBoundCleanups에서 새 trip 시작 또는 종료 시 호출. */
+export async function clearLastSilentPushReceivedAt(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(LAST_SILENT_PUSH_RECEIVED_AT_KEY);
+  } catch {
+    // graceful — 다음 cleanup에서 재시도.
+  }
+}

--- a/src/shared/constants/realtime.ts
+++ b/src/shared/constants/realtime.ts
@@ -210,6 +210,31 @@ export const LOCK_GPS_DRIFT_THRESHOLD_M = 1000;
 export const ESTIMATOR_STUCK_TIMEOUT_MS = 5 * 60_000;
 
 /**
+ * #2045 (Signal 4, Issue #2043 β 후속) — backend-timeout self-end 임계.
+ *
+ * 관찰 22 시나리오: BG 6h+ 방치 또는 앱 kill 상태에서 backend silent push가 도달하지 못한
+ * trip을 다음 launch 시점에 device가 자체 종료. `useLaunchTripReconciliation`이 판정.
+ *
+ * 두 임계 모두 동시 만족해야 self-end 발동:
+ *   - 마지막 silent push 수신 후 SILENT_PUSH_TIMEOUT_MS 초과 (backend 무음 확정)
+ *   - trip 시작 후 KTX_ETA_UPPER_BOUND_MS 미만 (KTX/장거리 실 trip 보호)
+ *
+ * 30분 SILENT_PUSH_TIMEOUT_MS:
+ *   - Backend cron ~30s cycle × 60 = 30분 무음이면 backend outage/kv 문제/route 무효 확정.
+ *   - 정상 trip은 매 hop마다 silent push 발사 → 30분 무음 = trip이 실질적으로 dead.
+ *   - PR #2044 β 3-signal ETA 임계(20-30분)와 정렬 — FG는 3-signal, BG는 본 signal.
+ *
+ * 10h KTX_ETA_UPPER_BOUND_MS:
+ *   - KTX 서울→부산 최장 ETA ~5-6h + 지연/환승 여유 → 10h. 이 이상 trip은 실질적 fake 잔재.
+ *   - TRIP_LIFECYCLE_FORCE_END_MS(9h)와 다른 목적 — 본 상수는 self-end 활성 상한(과잉 종료 방지),
+ *     force-end는 절대 종료 backstop. 10h > 9h 순서 유지 → force-end backstop이 self-end를 흡수.
+ *
+ * ADR-023 정합: device가 종료 결정 권한, backend는 정보 source (silent push 유무).
+ */
+export const SIGNAL_4_SILENT_PUSH_TIMEOUT_MS = 30 * 60_000;
+export const SIGNAL_4_KTX_ETA_UPPER_BOUND_MS = 10 * 60 * 60_000;
+
+/**
  * #1922 (M2) — lockless route-hop / re-anchored time-integration "stuck" 가드.
  *
  * `tryLocklessRouteHop`은 실측 신호(lastObserved) 없이 `tripStartedAt`만으로 시간 적분을 진행한다.

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -201,3 +201,10 @@ export const TRIP_GROUND_TRUTH_KEY = 'subway-now:trip-ground-truth';
 // trip 종료 시 runTripBoundCleanups에서 false로 reset (이전 trip의 의향 신호가 새 trip에 leak 차단).
 // 형식: 'true' 또는 키 부재(=false). ADR-014 §X "사용자 명시 의향 trip = lock 활성과 동급 정확도 보장 의무" 정합.
 export const USER_INTENT_INFO_MODE_KEY = 'subway-now:user-intent-info-mode';
+// #2045 (Signal 4, Issue #2043 β 후속) — 마지막 silent push 수신 시각 (epoch ms).
+// silentPushTask.handleSilentPush가 유효 payload 진입점(handleSilentPush)에서 stamp,
+// useLaunchTripReconciliation이 launch 시점에 read해 backend-timeout self-end 판정에 사용.
+// 관찰 22 (BG kill 6h+ 방치 후 launch) 커버. FG-전용 3-signal(#2044)과 상호 보완.
+// trip 종료 시 runTripBoundCleanups에서 제거 — 이전 trip의 수신 시각이 새 trip 판정 오염 차단.
+// 형식: 숫자 (epoch ms) 문자열. 키 부재 = silent push 미수신(첫 launch or 새 trip 시작 직후).
+export const LAST_SILENT_PUSH_RECEIVED_AT_KEY = 'subway-now:last-silent-push-received-at';


### PR DESCRIPTION
## 배경

**관찰 22 진짜 fix**: PR #2044 (Issue #2043 β) 3-signal (fusion + arc + ETA)이 `HomeScreen.tsx`에 mount → **FG 전용**. 관찰 22 진짜 시나리오 (BG 6h+ 방치 or 앱 kill)에서는 hook 미실행 → 미커버.

Signal 4는 **launch reconciliation 확장**으로 BG kill 시나리오를 커버 — #2044 FG 3-signal과 상호 보완.

Closes #2045

## 채택 옵션: β (Launch reconciliation 확장)

3 옵션 (α BG fetch / β launch reconciliation / γ 조합) 중 β 채택.

**이유**:
1. iOS 제약 없음 (launch = 확정 실행). α BG fetch는 배터리 상태 따라 skip 가능
2. 기존 `useLaunchTripReconciliation` (이미 `app/_layout.tsx:164` mount) 확장 → orphan 없음
3. 구현 간단 (5개 파일 편집 + 1개 신규)
4. HomeScreen mount 안 함 → β #2044 gap 재발 방지

## 판정 조건

sentinel skip 이후, `fetchTripStatus` 이전 게이트:

```
lastReceivedAt !== null AND
startedAt !== null AND
now - lastReceivedAt > 30분 AND
now - startedAt < 10h
```

- **30분 (SIGNAL_4_SILENT_PUSH_TIMEOUT_MS)**: Backend cron ~30s cycle × 60 = 30분 무음 = backend 실질적 dead. PR #2044 β ETA 임계(20-30분)와 정렬.
- **10h (SIGNAL_4_KTX_ETA_UPPER_BOUND_MS)**: KTX 서울→부산 최장 ETA ~5-6h + 여유. 10h+ trip은 force-end backstop(9h)에 위임 → 실 장거리 사용자 false positive 차단.

Self-end 시퀀스 (status=ended 분기와 동일 순서, notification 미발사만 다름):

```
recall → cleanup → prompt → sentinel → active clear → return
```

Notification 미발사 이유: backend 무음 상태에서 "trip 종료" 표시 X → 사용자 정보 정확도 유지. UI reset은 다음 FG mount 시 useStateRehydration이 sentinel 감지해 처리.

## 부작용 매트릭스

| 시나리오 | 반응 | 커버 |
|---|---|---|
| FG 유지 6h+ | γ' (#2041) + β 3-signal (#2044) 커버, Signal 4 미발동 (launch 아님) | O (기존) |
| BG active 6h+ 앱 열림 | launch → Signal 4 발동 | O (신규) |
| BG kill 6h+ 앱 열림 | launch → Signal 4 발동 (**관찰 22 커버**) | O (신규) |
| BG kill 6h+ 앱 안 열림 | 처리 X (iOS 근본 제약) | X (iOS 한계) |
| Backend outage 회복 정상 | lastReceived < 30분 → Signal 4 skip → fetchTripStatus로 흐름 | O |
| KTX 실 6h+ trip | trip < 10h → force-end backstop(9h)에 위임 | O |
| lastReceivedAt null (첫 launch) | Signal 4 skip → fetchTripStatus | O |
| startedAt null (기존 trip 정보 결손) | Signal 4 skip → 기존 recall에 위임 | O |
| Backend + Device 동시 도달 | sentinel guard → double-fire X | O |

## Idempotent Guard

- Sentinel: Signal 4 fire 시 `setTripEndedSentinel(now)`. 다음 launch에서 sentinel skip.
- `triggerTripEndRecall` / `runTripBoundCleanups` / `triggerTripGroundTruthPrompt` 모두 멱등 (기존 status=ended 분기와 동일 chain).
- `handleSilentPush`의 `void setLastSilentPushReceivedAt`: fire-and-forget. 실패해도 다음 push 수신에서 재갱신.
- `clearLastSilentPushReceivedAt` in `TRIP_BOUND_CLEANUPS`: 4 cleanup 경로 (FG setDestination / silent push trip-ended / useStateRehydration sentinel / useLaunchTripReconciliation) 자동 wire. baseline 26 → 27.

## 파일 편집

- 신규: `src/features/alarm/utils/lastSilentPushReceivedAt.ts` (tripEndedSentinel 패턴 재사용)
- 신규: `src/features/alarm/utils/__tests__/lastSilentPushReceivedAt.test.ts`
- 편집: `src/features/alarm/tasks/silentPushTask.ts` (import + 1줄 `void setLastSilentPushReceivedAt(receivedAt)`)
- 편집: `src/features/alarm/hooks/useLaunchTripReconciliation.ts` (Signal 4 branch 삽입, sentinel skip 직후)
- 편집: `src/features/alarm/store/tripBoundCleanups.ts` (import + cleanup 배열 1줄)
- 편집: `src/shared/constants/storageKeys.ts` (LAST_SILENT_PUSH_RECEIVED_AT_KEY)
- 편집: `src/shared/constants/realtime.ts` (2 상수 SIGNAL_4_SILENT_PUSH_TIMEOUT_MS / SIGNAL_4_KTX_ETA_UPPER_BOUND_MS)
- 편집: 테스트 3개 (useLaunchTripReconciliation 10 case 추가, silentPushTask wire 3 case, tripBoundCleanups 배열 포함 검증)

`HomeScreen.tsx` 편집 없음 확인 — β #2044 gap 재발 방지.

## Wire-completion 5단

1. **Orphan 없음** — `useLaunchTripReconciliation` 기존 `app/_layout.tsx:164` mount 재사용. `npm run lint:orphan` pass
2. **V/X dashboard** — `logger.info("Signal 4 backend-timeout self-end: ...")` (device 로그). 후속: alarmLog에 self-end reason 확장 검토
3. **의존 PR** — N/A. 오늘 open PR #2046 (Issue D, backend + `useApnsTripRegistration`)과 편집 파일 겹침 없음 (다른 hook)
4. **측정 plan** — 1주 관찰. Signal 4 fire count > 0 (관찰 22 재현 시). 정상 케이스 false positive 0. KTX/장거리(10h+) false positive 0
5. **Device verify** — 실기기 관찰 22 시나리오 (BG 6h+ 방치 후 launch → self-end 발동 → sentinel 기록 → UI reset)

## Verify

- `npm test` — 9155 tests / 424 suites pass. Coverage 100% (lines / functions / branches / statements)
- `npm run type-check` — pass
- `npm run lint:orphan` — 0 orphan
- `npm run lint` — 본 PR 유래 error 0 (기존 4 error pre-existing on origin/dev)

## Test Plan

- [ ] 실기기 시나리오 A: 정상 trip 등록 후 BG 6h+ 방치 (silent push 발사 정상) → launch → Signal 4 skip 확인 (lastReceived < 30분)
- [ ] 실기기 시나리오 B: backend outage 흉내 (network off after trip start 후 30분+) → launch → Signal 4 self-end 발동 확인
- [ ] 실기기 시나리오 C: KTX 유사 장거리 시나리오 (10h+ trip) → Signal 4 skip → force-end backstop 위임 확인
- [ ] alarmLog dump에서 self-end reason 관찰 (1주 evidence 수집)