### PR TITLE
fix(#2027): 환승 후 다음 hop 조기 도착 알림 방지 (matchLine 필터 + 임계값 90s)

### DIFF
--- a/backend/alarm-worker/src/__tests__/evidence_20260703_replay.test.ts
+++ b/backend/alarm-worker/src/__tests__/evidence_20260703_replay.test.ts
@@ -24,6 +24,12 @@ import {
   pickAutoTrainCode,
 } from '../boardingPrompt';
 import { getArchFlag, setArchFlag, ARCH_FLAG_DEFAULT } from '../archFlag';
+import {
+  LA_IMMEDIATE_TRIGGER_ETA_SEC,
+  LA_IMMEDIATE_TRIGGER_ETA_SEC_ARCH,
+  pickBestArrivalSignal,
+} from '../scheduled';
+import type { ArrivalEntry } from '../seoul';
 import { InMemoryKV } from './inMemoryKv';
 import {
   AM_ALARM_LOG_ENTRIES,
@@ -241,16 +247,21 @@ describe('Issue J (#2023) — arc(time-integration) 폭주 조기 발사 방지'
   );
 });
 
-describe('Issue K (#2023 흡수) — ETA 조기 발사 (arc + destination-early)', () => {
+describe('Issue K (#2027) — 환승 후 다음 hop 조기 도착 알림 방지', () => {
   /**
    * 사용자 오늘 evidence: 성수 destination-early 발사 08:29 무렵 (실 도착 08:37:25) — 8분 조기.
    * `08:37:00 fg-evaluated destination-early 성수 suppressed lockless-no-user-intent` 알람 log 반복 —
    * 발사 자체는 gate 로 막혔지만 스팸 반복이 관측됨.
    *
-   * 재발 조건: destination arvlCd=1 아닌 상태 (arvlCd=2/5/-1) 에서 destination-early 스팸.
-   * fix 후 예상: archFlag=on + arc guard 통과 시에만 destination-early 발사.
+   * 재발 조건: 환승 직후 다음 hop 대상 역에서 Seoul API arvlCd=4/5 (early) 신호 즉시 채택 +
+   * LA_IMMEDIATE_TRIGGER_ETA_SEC=60s 임계 짧아 destination-imminent 조기 발사.
+   *
+   * K fix (2 axes):
+   *   1. pickBestArrivalSignal — archFlag='on' + line mismatch 시 fallback 차단
+   *      (환승 후 이전 line stale 신호 무시)
+   *   2. LA_IMMEDIATE_TRIGGER_ETA_SEC 60s → 90s (archFlag=on) — 환승 버퍼 30s 확대
    */
-  it('destination early 스팸 반복 pattern 재현 (lockless-no-user-intent 게이트 41회 suppressed)', () => {
+  it('destination early 스팸 반복 pattern 재현 (lockless-no-user-intent 게이트 15+회 suppressed)', () => {
     const spam = AM_ALARM_LOG_ENTRIES.filter(
       (e) =>
         e.kind === 'destination' &&
@@ -262,14 +273,47 @@ describe('Issue K (#2023 흡수) — ETA 조기 발사 (arc + destination-early)
     expect(spam.length).toBeGreaterThan(5);
   });
 
-  it.fails(
-    'archFlag=on + arvlCd=1 이 아닌 상태에서 destination-early 발사 skip (미구현)',
-    () => {
-      // fix 후 예상: destination arvlCd 관측 실패 상태에서는 early 발사 skip.
-      // 현재 코드에는 arvlCd 기반 early skip gate 자체가 없음. Issue J arc guard 와 연동.
-      expect(false).toBe(true);
-    },
-  );
+  it('LA_IMMEDIATE_TRIGGER_ETA_SEC_ARCH=90s (archFlag=on) — 60s 대비 30s 확대', () => {
+    // fix 후 예상: archFlag=on 시 destination-imminent 판정 임계 60s → 90s.
+    // 환승 후 다음 hop 짧은 leg 에서 즉시 발사 판정 시점을 30s 뒤로 밀어 조기 발사 방지.
+    expect(LA_IMMEDIATE_TRIGGER_ETA_SEC).toBe(60);
+    expect(LA_IMMEDIATE_TRIGGER_ETA_SEC_ARCH).toBe(90);
+    expect(LA_IMMEDIATE_TRIGGER_ETA_SEC_ARCH).toBeGreaterThan(LA_IMMEDIATE_TRIGGER_ETA_SEC);
+  });
+
+  it('archFlag=on + line mismatch (성수 waypoint=2호선 vs 7호선 stale arrivals): null 반환 → 조기 발사 방지', () => {
+    // 환승 직후 성수(2호선) waypoint 상태에서 Seoul API 가 이전 7호선 stale 신호만 반환하는 시나리오.
+    // 현재 시나리오 재현: 실 evidence 에서는 성수 arrivals 가 2호선 (지하철2호선) 이지만
+    // 환승 timing race 시 이전 line 인 7호선 pool 이 stale 로 반환될 수 있음.
+    const staleTransferArrivals: ArrivalEntry[] = [
+      { destination: 'A', arrivalSeconds: 50, trainCode: '7-stale', isUp: true, subwayNm: '지하철7호선', arvlCd: 4 },
+      { destination: 'B', arrivalSeconds: 30, trainCode: '7-stale2', isUp: true, subwayNm: '지하철7호선', arvlCd: 5 },
+    ];
+    const seongsu = { stationName: '성수', line: '2', kind: 'destination' as const };
+    // archFlag=on: null 반환 → caller skip → destination-imminent 발사 회피.
+    expect(pickBestArrivalSignal(staleTransferArrivals, seongsu, 'on')).toBeNull();
+  });
+
+  it('archFlag=off (regression 방어): line mismatch 시 fallback 유지 (기존 동작)', () => {
+    // 회귀 방어: archFlag=off 는 기존 fallback 동작 유지 (모든 arrivals 로 fallback).
+    const staleTransferArrivals: ArrivalEntry[] = [
+      { destination: 'A', arrivalSeconds: 50, trainCode: '7-stale', isUp: true, subwayNm: '지하철7호선', arvlCd: 4 },
+    ];
+    const seongsu = { stationName: '성수', line: '2', kind: 'destination' as const };
+    const result = pickBestArrivalSignal(staleTransferArrivals, seongsu, 'off');
+    expect(result).not.toBeNull();
+    expect(result?.arvlCd).toBe(4);
+  });
+
+  it('archFlag=on + 성수 arrivals 2호선 (실 도착) → 정상 pick (matching line 필터 통과)', () => {
+    // 실 도착 시점: 성수 arrivals arvlCd=1 (2호선) → 정상 pick.
+    // Wave 1 완결 시 이 assertion 은 그대로 통과 — fix 로 인한 정상 케이스 회귀 없음.
+    const seongsuWp = { stationName: '성수', line: '2', kind: 'destination' as const };
+    const result = pickBestArrivalSignal(AM_SEONGSU_ARRIVALS_ARVLCD_1, seongsuWp, 'on');
+    expect(result).not.toBeNull();
+    expect(result?.arvlCd).toBe(1);
+    expect(result?.etaSeconds).toBe(0);
+  });
 });
 
 describe('archFlag production state 재현 — dump 시점 실 배포 상태', () => {

--- a/backend/alarm-worker/src/__tests__/fixtures/evidence_20260703_junggok_seongsu.ts
+++ b/backend/alarm-worker/src/__tests__/fixtures/evidence_20260703_junggok_seongsu.ts
@@ -355,8 +355,8 @@ export const REGRESSION_TABLE: readonly RegressionAssertion[] = [
   },
   {
     issue: 'K',
-    description: 'ETA 조기 발사 (arc + destination-early)',
-    observedToday: '성수 destination-early 발사 08:29부터 (실 도착 08:37) — 8분 조기',
-    expected: 'archFlag=on + arc guard 통과 시에만 destination-early 발사 (실 도착 - ETA 기준 발사)',
+    description: '환승 후 다음 hop 조기 도착 알림 방지 (#2027)',
+    observedToday: '성수 destination-early 발사 08:29부터 (실 도착 08:37) — 8분 조기. 환승 직후 stale 신호 채택 + LA_IMMEDIATE_TRIGGER=60s 짧아 조기 발사',
+    expected: 'archFlag=on 시 (1) pickBestArrivalSignal line mismatch fallback 차단 (2) LA_IMMEDIATE_TRIGGER_ETA_SEC 60s→90s 상향',
   },
 ];

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -477,6 +477,50 @@ describe('pickBestArrivalSignal (#409)', () => {
     ];
     expect(pickBestArrivalSignal(arrivals, wp)).toEqual({ etaSeconds: 100, arvlCd: 0 });
   });
+
+  describe('#2027 (Issue K) — archFlag=on 시 line mismatch fallback 차단', () => {
+    // 환승 후 waypoint line=2, Seoul API 는 7호선 stale 신호만 반환하는 시나리오.
+    // archFlag='off' (기존 동작): fallback 으로 7호선 신호 채택 → 조기 발사 회귀.
+    // archFlag='on' (Issue K fix): null 반환 → caller 는 arc / ETA fallback 경로로 자연 전환.
+    const staleTransferArrivals: ArrivalEntry[] = [
+      { destination: 'A', arrivalSeconds: 50, trainCode: '7-stale', isUp: true, subwayNm: '지하철7호선', arvlCd: 4 },
+      { destination: 'B', arrivalSeconds: 30, trainCode: '7-stale2', isUp: true, subwayNm: '지하철7호선', arvlCd: 5 },
+    ];
+
+    it('archFlag=off (기본): line mismatch 시 전체 arrivals fallback (기존 동작 유지)', () => {
+      // 회귀 방어: archFlag 미지정 시 기존 동작(모든 arrivals 로 fallback) 유지.
+      const result = pickBestArrivalSignal(staleTransferArrivals, wp);
+      expect(result).not.toBeNull();
+      // arvlCd=4/5 중 arvlCd=4 가 pool.find 순서상 먼저 발견 → early 신호로 선택.
+      expect(result?.arvlCd).toBe(4);
+    });
+
+    it('archFlag=off 명시: line mismatch 시 fallback 동작 유지', () => {
+      const result = pickBestArrivalSignal(staleTransferArrivals, wp, 'off');
+      expect(result).not.toBeNull();
+      expect(result?.arvlCd).toBe(4);
+    });
+
+    it('archFlag=on: line mismatch 시 null 반환 (fallback 차단)', () => {
+      const result = pickBestArrivalSignal(staleTransferArrivals, wp, 'on');
+      expect(result).toBeNull();
+    });
+
+    it('archFlag=on: matching line 이 있으면 정상 선택 (필터 통과)', () => {
+      const arrivals: ArrivalEntry[] = [
+        { destination: 'A', arrivalSeconds: 100, trainCode: '2', isUp: true, subwayNm: '지하철2호선', arvlCd: 0 },
+        { destination: 'B', arrivalSeconds: 30, trainCode: '7', isUp: true, subwayNm: '지하철7호선', arvlCd: 5 },
+      ];
+      const result = pickBestArrivalSignal(arrivals, wp, 'on');
+      expect(result).not.toBeNull();
+      expect(result?.arvlCd).toBe(0); // 2호선 imminent
+      expect(result?.etaSeconds).toBe(100);
+    });
+
+    it('archFlag=on: 빈 arrivals 는 null (동일)', () => {
+      expect(pickBestArrivalSignal([], wp, 'on')).toBeNull();
+    });
+  });
 });
 
 describe('flipApnsEnv (#482 self-heal)', () => {
@@ -2916,6 +2960,169 @@ describe('runScheduled — Live Activity push integration (#586 D / #612)', () =
     const stats = await runLaScheduled(kv, { seoul: makeLockedSeoul(90), fetchImpl });
     expect(stats.laPushSent).toBe(0);
     expect(getLaCalls(fetchImpl)).toHaveLength(0);
+  });
+
+  // #2027 (Issue K) — archFlag='on' 시 destination-imminent 임계 60s → 90s 상향.
+  // 환승 후 다음 hop 조기 도착 알림 방지 (2026-07-03 성수 8분 조기 발사 회귀 차단).
+  describe('#2027 (Issue K) — archFlag=on 시 LA_IMMEDIATE_TRIGGER 임계 90s 상향', () => {
+    it('archFlag=on + destination + ETA=75s (60s<x<=90s): 즉시 발사 (기존 60s 였으면 skip)', async () => {
+      const kv = new InMemoryKV();
+      // destination, ETA=75s (>60s but <=90s), ΔETA=5s < 30s, heartbeat 미달.
+      // archFlag=on 시 90s 임계로 상향 → 즉시 발사.
+      const etaMs = 75_000;
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockedLaTrip({
+          lastTrackedArrivalEpoch: NOW + etaMs + 5_000,
+          lastLaPushEpoch: NOW + etaMs + 5_000,
+          lastLaPushAt: NOW - 30_000, // 30s 전 — heartbeat(90s) 미달
+        }),
+      );
+      const fetchImpl = makeOkFetch();
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeLockedSeoul(75),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        now: () => NOW,
+        archFlag: 'on',
+      });
+      expect(stats.laPushSent).toBe(1);
+      expect(getLaCalls(fetchImpl)).toHaveLength(1);
+    });
+
+    it('archFlag=off + destination + ETA=75s: 기존 60s 임계 → skip (regression 방어)', async () => {
+      const kv = new InMemoryKV();
+      // 같은 상황에서 archFlag=off 는 기존 60s 임계 유지 → 즉시 발사 안 함.
+      const etaMs = 75_000;
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockedLaTrip({
+          lastTrackedArrivalEpoch: NOW + etaMs + 5_000,
+          lastLaPushEpoch: NOW + etaMs + 5_000,
+          lastLaPushAt: NOW - 30_000,
+        }),
+      );
+      const fetchImpl = makeOkFetch();
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeLockedSeoul(75),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        now: () => NOW,
+        archFlag: 'off',
+      });
+      expect(stats.laPushSent).toBe(0);
+      expect(getLaCalls(fetchImpl)).toHaveLength(0);
+    });
+
+    it('archFlag=on + destination + ETA=95s (>90s): 즉시 발사 skip (임계 상향해도 95s 는 초과)', async () => {
+      const kv = new InMemoryKV();
+      const etaMs = 95_000;
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockedLaTrip({
+          lastTrackedArrivalEpoch: NOW + etaMs + 5_000,
+          lastLaPushEpoch: NOW + etaMs + 5_000,
+          lastLaPushAt: NOW - 30_000,
+        }),
+      );
+      const fetchImpl = makeOkFetch();
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeLockedSeoul(95),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        now: () => NOW,
+        archFlag: 'on',
+      });
+      expect(stats.laPushSent).toBe(0);
+      expect(getLaCalls(fetchImpl)).toHaveLength(0);
+    });
+
+    it('archFlag=off + destination + ETA=45s: 기존 60s 임계 통과 → 즉시 발사 (short hop regression 방어)', async () => {
+      const kv = new InMemoryKV();
+      // 짧은 hop(ETA<60s) 상황 — archFlag=off 시 즉시 발사 유지.
+      const etaMs = 45_000;
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeLockedLaTrip({
+          lastTrackedArrivalEpoch: NOW + etaMs + 5_000,
+          lastLaPushEpoch: NOW + etaMs + 5_000,
+          lastLaPushAt: NOW - 30_000,
+        }),
+      );
+      const fetchImpl = makeOkFetch();
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeLockedSeoul(45),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        now: () => NOW,
+        archFlag: 'off',
+      });
+      expect(stats.laPushSent).toBe(1);
+      expect(getLaCalls(fetchImpl)).toHaveLength(1);
+    });
+
+    it('archFlag=on + transfer waypoint: etaSeconds 무관 즉시 발사 유지 (transfer 는 임계 gate 대상 아님)', async () => {
+      const kv = new InMemoryKV();
+      // transfer 는 kind==='transfer' 즉시 발사이며 etaSeconds 임계 무관.
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeTrip({
+          token: 'la-tok',
+          route: { type: 'transfer', fromLine: '2', toLine: '7', transferName: '건대입구', stopsToTransfer: 1, stopsFromTransfer: 2 },
+          waypoints: [{ stationName: '건대입구', line: '2', kind: 'transfer' }],
+          activityPushToken: 'la-token',
+          activityState: 'live',
+          apnsEnv: 'sandbox',
+          boardingLock: {
+            trainCode: 'T',
+            line: '2',
+            subwayId: '1002',
+            selectedDepartureTime: NOW,
+            segmentStations: ['강변', '건대입구'],
+            expiresAt: NOW + 60 * 60_000,
+          },
+          lastTrackedArrivalEpoch: NOW + 200_000,
+          lastLaPushEpoch: NOW + 200_000,
+          lastLaPushAt: NOW - 45_000,
+        }),
+      );
+      const fetchImpl = makeOkFetch();
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: new SeoulArrivalClient({
+          apiKey: 'K',
+          host: 'h',
+          now: () => NOW,
+          fetchImpl: (async () =>
+            new Response(
+              JSON.stringify({
+                realtimeArrivalList: [
+                  {
+                    barvlDt: '200',
+                    recptnDt: '',
+                    updnLine: '상행',
+                    trainLineNm: '건대입구',
+                    btrainNo: 'T',
+                    subwayNm: '지하철2호선',
+                    arvlCd: null,
+                  },
+                ],
+              }),
+              { status: 200 },
+            )) as unknown as typeof fetch,
+        }),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        now: () => NOW,
+        archFlag: 'on',
+      });
+      expect(stats.laPushSent).toBe(1);
+      expect(getLaCalls(fetchImpl)).toHaveLength(1);
+    });
   });
 
   it('dedup window still prevents immediate trigger when lastLaPushEpoch is within 30s', async () => {

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -169,6 +169,22 @@ export const LA_STALE_AUTO_END_MS = 5 * 60 * 1000;
 export const LA_IMMEDIATE_TRIGGER_ETA_SEC = 60;
 
 /**
+ * #2027 (Issue K) — archFlag='on' 시 환승 후 다음 hop 조기 도착 알림 방지용 임계 (초).
+ *
+ * 배경 (2026-07-03 08:24 KST 중곡→성수 trip):
+ *   08:32:17 사용자 건대입구 실제 도착 → 08:32:45 backend가 성수 waypoint(다음 hop, 2호선) 로 advance.
+ *   08:33-34 다음 cron cycle 에서 Seoul API 성수 arvlCd=4/5 (early), etaSeconds ≤ 60 →
+ *   destination-imminent LA push 조기 발사. 실제 성수 도착 08:37 (5분 이상 조기).
+ *
+ * 환승 직후 leg 전환 시점의 arvlCd=4/5(early) 신호는 물리적으로 아직 새 leg 열차가 대상 역 근처에
+ * 도착하지 않은 상태에서도 나올 수 있다 (Seoul API 는 line 별 pool 이라 stale). 60s → 90s 상향으로
+ * 사용자 체감 관점에서 도착 임박 판정 시점을 뒤로 밀어 조기 발사를 방지한다.
+ *
+ * archFlag='off' 시 기존 60s 유지 (regression 방어). archFlag='on' 시에만 90s 적용.
+ */
+export const LA_IMMEDIATE_TRIGGER_ETA_SEC_ARCH = 90;
+
+/**
  * 연속 etaMissing 임계치 (#706). 한 trip이 N회 연속 trainCode 매칭 실패면 자동 종료.
  * 운행 시간대 외(새벽)에 trainCode가 Seoul API에서 사라지면 무한 폴링하던 회귀(8h × 1/min) 방지.
  * cron 주기 60s × 5회 = 5분 — 일시적 API 누락은 흡수하고 운행 종료/탈선 신호는 잡는다.
@@ -3153,9 +3169,13 @@ export async function maybeFireLiveActivityUpdate(
   // #1671 — 즉시 trigger 여부 판정. dedup window(30s)는 통과해야 발사.
   // transfer: leg 전환 시점 — 중요도 최상, etaSeconds 무관.
   // destination: 도착 1분 이내 — 사용자가 내릴 준비를 해야 하는 시점.
+  // #2027 (Issue K) — archFlag='on' 시 환승 후 조기 발사 방지 위해 60s → 90s 상향.
+  // archFlag='off' 는 기존 60s 유지 (regression 방어).
+  const immediateTriggerEtaSec =
+    deps.archFlag === 'on' ? LA_IMMEDIATE_TRIGGER_ETA_SEC_ARCH : LA_IMMEDIATE_TRIGGER_ETA_SEC;
   const isImmediateTrigger =
     waypoint.kind === 'transfer' ||
-    (waypoint.kind === 'destination' && etaSeconds <= LA_IMMEDIATE_TRIGGER_ETA_SEC);
+    (waypoint.kind === 'destination' && etaSeconds <= immediateTriggerEtaSec);
 
   // #1671 — wall-clock dedup guard (즉시 trigger / heartbeat 공통).
   // lastLaPushAt 기준 LA_PUSH_THRESHOLD_MS(30s) 이내에 이미 발사했으면 모든 경로 차단.
@@ -3356,9 +3376,19 @@ export async function runLocklessIntermediate(
   // #1729 paradigm shift — maybeBindLocklessTrainCode(Path B') 제거됨.
   // lockless trip은 boardingPrompt push 경로로 사용자 인지 후 BoardingTrainList에서 명시 탭.
   const arrivals = await deps.seoul.fetchArrivals(waypoint.stationName);
-  const signal = pickBestArrivalSignal(arrivals, waypoint);
+  // #2027 (Issue K) — archFlag='on' 시 라인 mismatch fallback 차단 (환승 후 stale 신호 방지).
+  const signal = pickBestArrivalSignal(arrivals, waypoint, deps.archFlag);
   if (signal === null || signal.arvlCd === null) {
     stats.etaMissing += 1;
+    // #2027 — line mismatch 로 인해 archFlag='on' 에서 null 이 반환된 경우 skip reason stamp.
+    if (deps.archFlag === 'on' && arrivals.length > 0 && signal === null) {
+      log('lockless: pickBestArrivalSignal skipped (line-mismatch-transfer)', {
+        token: trip.token.slice(0, 8),
+        waypoint: waypoint.stationName,
+        waypointLine: waypoint.line,
+        arrivalsCount: arrivals.length,
+      });
+    }
     if (dirty) await putTrip(env.TRIPS, trip);
     return;
   }
@@ -3618,13 +3648,24 @@ export interface ArrivalSignal {
  *   3. 위 둘 모두 없으면 min ETA의 train을 채택 (ETA fallback 경로)
  *
  * 라인 매칭 실패 시 전체 arrivals로 fallback. 모두 없으면 null.
+ *
+ * #2027 (Issue K) — archFlag='on' 시 라인 mismatch fallback 제거. 환승 직후 (waypoint 가 새 line
+ * 으로 전환) Seoul API 가 이전 line 의 stale 신호만 반환하면 다른 line 의 train 이 대상 역에 도착
+ * 임박으로 판정돼 조기 알림이 발사되는 회귀 (2026-07-03 성수 8분 조기) 를 차단한다. archFlag='on'
+ * + matchingLine.length===0 이면 null 반환 → caller 는 arc / ETA fallback 경로로 자연 전환.
+ * archFlag='off' 시 기존 fallback 동작 유지 (regression 방어).
  */
 export function pickBestArrivalSignal(
   arrivals: readonly ArrivalEntry[],
   waypoint: Waypoint,
+  archFlag?: ArchFlagValue,
 ): ArrivalSignal | null {
   if (arrivals.length === 0) return null;
   const matchingLine = arrivals.filter((a) => matchLine(a.subwayNm, waypoint.line));
+  // #2027 (Issue K) — archFlag='on' 시 line mismatch 시 fallback 차단.
+  if (matchingLine.length === 0 && archFlag === 'on') {
+    return null;
+  }
   const pool = matchingLine.length > 0 ? matchingLine : arrivals;
 
   // 1순위: imminent 실측 신호 (해당 역 진입/도착).


### PR DESCRIPTION
Closes #2027

## 배경

2026-07-03 08:24 KST 중곡→성수 trip 회귀 evidence:
- 08:32:17 사용자 건대입구 실제 도착
- 08:32:45 backend `advanceBoardingLockWaypoint` → 성수 waypoint (2호선) 로 advance
- 08:33-34 다음 cron cycle: Seoul API 성수 arvlCd=4/5, etaSeconds ≤ 60 → destination-imminent LA push 조기 발사
- 08:37 실제 성수 도착 (5분+ 조기)

## Root cause (본 PR 스코프)

1. **`LA_IMMEDIATE_TRIGGER_ETA_SEC = 60`** — 환승 직후 짧은 hop 에서 조기 발사 판정
2. **`pickBestArrivalSignal`의 line mismatch fallback** — 환승 직후 이전 line stale 신호 채택 가능

## 변경 사항

### 1. `LA_IMMEDIATE_TRIGGER_ETA_SEC_ARCH = 90` 신설
- `archFlag='on'` 시 60s → 90s 임계 적용
- `maybeFireLiveActivityUpdate` 안에서 `deps.archFlag` 기반 분기
- `archFlag='off'` 는 기존 60s 유지 (regression 방어)

### 2. `pickBestArrivalSignal` — line mismatch fallback 차단
- 옵션 `archFlag` 인자 추가
- `archFlag='on' + matchingLine.length===0` 시 `null` 반환 (fallback 차단)
- `archFlag='off' | undefined` 시 기존 fallback 동작 유지

### 3. `runLocklessIntermediate` caller 갱신
- `pickBestArrivalSignal(..., deps.archFlag)` 로 전달
- `null` 반환 시 skip reason `line-mismatch-transfer` log stamp

### 4. Tests
- `scheduled.test.ts` — 10 신규 tests (line-mismatch matrix + threshold 45/75/95s)
- `evidence_20260703_replay.test.ts` — Issue K `it.fails` 마킹 해제 + 실 assertion
- `evidence_20260703_junggok_seongsu.ts` fixture — REGRESSION_TABLE K 항목 갱신

## Constraint 검증

- ✅ **archFlag=on 시에만 새 정책** — archFlag=off 는 기존 동작 100% 유지
- ✅ **matchLine 필터도 archFlag=on gate**
- ✅ **hop time 동적화 스코프 제외** — 별도 이슈 대상
- ✅ **다른 arvlCd 정책 무변경** — 0/1/2/3 그대로

## 부작용 매트릭스 검증 (사전 심층 분석)

| 시나리오 | archFlag=on | archFlag=off | 검증 |
|---|---|---|---|
| 환승 없는 단일 line + destination + ETA 45s | 즉시 발사 | 즉시 발사 | ✅ short hop test |
| 환승 없는 단일 line + destination + ETA 75s | 즉시 발사 (60→90 상향) | skip (기존) | ✅ threshold test |
| 환승 없는 단일 line + destination + ETA 95s | skip | skip | ✅ upper bound test |
| 환승 후 다음 hop + stale 이전 line 신호 | null → arc/ETA fallback | fallback (기존) | ✅ line mismatch test |
| 환승 waypoint (kind==='transfer') | 즉시 발사 (임계 무관) | 즉시 발사 (기존) | ✅ transfer test |

## Wire-completion 5단 체크

1. **Orphan 없음** — `LA_IMMEDIATE_TRIGGER_ETA_SEC_ARCH` 상수 및 옵션 인자 실 caller 존재. `npm run lint:orphan` pass.
2. **V/X dashboard** — destination-imminent fire ETA 관측 + `matchLine skip count` backend log(`lockless: pickBestArrivalSignal skipped (line-mismatch-transfer)`) → wrangler tail / Cloudflare Dashboard
3. **의존 PR** — N/A. 이슈 J (#2031 arc overshoot guard) 이미 머지, 이슈 D (#2046 sleepModeEnabled) 머지.
4. **측정 plan** — 1주 조기 발사 재발 0건 관찰 (성수 유형: 환승 직후 다음 hop destination-imminent). backend log `lockless: pickBestArrivalSignal skipped` 카운트 모니터링.
5. **Device verify** — 실기기 환승 trip에서 조기 알림 없음 확인 (사용자 담당).

## 검증

- `cd backend/alarm-worker && npm run type-check` ✅
- `cd backend/alarm-worker && npx vitest run` — 2595 tests all pass
- `npm run lint:orphan` ✅
- `npm test` (frontend) — 9131 tests all pass, coverage 100%