### PR TITLE
fix: DebugModal share dump 누락 3 섹션 추가 (Feature Flag + Operation Dashboard + Fusion Tier 1h)

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -132,6 +132,10 @@ import type { NearestStationResult } from '../../../shared/types/station';
 import { useTheme, spacing, radius, typography } from '../../../shared/theme';
 // #1751 (M3 Sub 1) — Operation Dashboard 섹션.
 import { OperationDashboardSection } from './OperationDashboardSection';
+// Operation Dashboard alarmAccuracy(local) metric — share dump 재사용.
+// Modal UI 는 `useTripGroundTruthStore((s) => s.responses)` 를 통해 mount 시점 스냅샷 + subscribe.
+// share dump 는 handleShare 호출 시점 스냅샷만 필요하므로 store selector 로 참조 안정성 확보.
+import { useTripGroundTruthStore } from '../store/useTripGroundTruthStore';
 // #1956 (S-m3-1) — Operation Dashboard 4 metric → TripDetailModal drill-down 진입.
 import { TripDetailModal } from './TripDetailModal';
 import { useBarometer } from '../../../shared/hooks/useBarometer';
@@ -652,6 +656,47 @@ interface BuildDumpArgs {
    * 미전달/null은 (no snapshot)로 명시 — "한 번도 측정 안 됨" / "미지원" / "load 안 함" 구분 가능.
    */
   accelSnapshot?: AccelerometerSnapshot | null;
+  /**
+   * ADR-022 Feature Flag (arch:simple-arrival-v1) 상태. Modal render에 노출되는 3 값을
+   * share dump에도 포함 — 사용자가 dogfood 판정(env vs remote vs 최종 active)을 dump만으로
+   * 사후 재구성 가능.
+   *
+   * 미전달 시 (n/a)로 표기.
+   */
+  archFlag?: {
+    /** `EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH` env 값. */
+    env: boolean;
+    /** `arch:simple-arrival-v1` KV remote 값. undefined = 미조회/실패. */
+    remote: 'on' | 'off' | undefined;
+    /** remote fetch 결과 kind (`ok` / `unconfigured` / `error` / `loading`). */
+    remoteKind: string;
+    /** 최종 판정 — `isSimpleArchEnabled(remote)`. env=true 시 remote 무관 ON. */
+    active: boolean;
+  };
+  /**
+   * Operation Dashboard 4 metric 중 device-local 계산 가능한 것만 share dump에 포함.
+   * backend polling 결과(locklessMiss / boardableMiss / accelPattern / latency / laPush)는
+   * dump 시점에 sync 접근 불가 → dump에서는 (backend metrics: n/a in dump) 안내로 대체.
+   *
+   * 노출 metric:
+   *  - alarmAccuracy (local): tripGroundTruth store `responses` accurate/answered 비율
+   *  - silentPushReach (local): `countSilentPushOutcomes(logs)` fired/received
+   *
+   * 미전달 시 (n/a) — DebugModalInner 이 store snapshot 을 주입하지 않은 케이스 graceful.
+   */
+  operationDashboard?: {
+    /** 사용자 "정확했어요" 응답 수. */
+    groundTruthAccurateCount: number;
+    /** 응답 총 개수(unanswered 제외). */
+    groundTruthAnsweredCount: number;
+  };
+  /**
+   * Fusion picker tier 별 ring buffer entries. 최근 1h 윈도우 집계를 dump에 노출 —
+   * Modal render(line 2552)과 동일 SSOT(`formatFusionPickerTierDistribution`) 재사용.
+   *
+   * 미전달/빈 배열은 (none) 반환(포맷터 컨벤션 따라).
+   */
+  fusionTierLog?: readonly FusionTierLogEntry[];
 }
 
 /** dump 본체에서 사용하는 single builder 시그니처 — 본문 줄 배열을 반환. */
@@ -836,6 +881,62 @@ function buildAccelFingerprintSection(args: BuildDumpArgs): string[] {
     `sampleCount=${snapshot.sampleCount}`,
     `lastUpdate=${formatTime(snapshot.timestamp)}`,
   ];
+}
+
+/**
+ * ADR-022 Phase 0 — Feature Flag(arch:simple-arrival-v1) 상태 dump 라인.
+ *
+ * Modal render(line 2147-2163)의 3 KeyValue row와 동일 SSOT — dogfood 판정 사후 재구성:
+ *  - env      : `EXPO_PUBLIC_SIMPLE_ARRIVAL_ARCH` 환경변수 (true/false)
+ *  - remote   : `arch:simple-arrival-v1` KV 값 (`on` / `off`) 또는 kind fallback (`unconfigured` / `error` 등)
+ *  - active   : 최종 판정 (env OR remote='on')
+ *
+ * 미전달 시 (n/a) — hook 을 마운트하지 않은 호출자(단위 테스트 baseline) graceful.
+ */
+function buildFeatureFlagSection(args: BuildDumpArgs): string[] {
+  const flag = args.archFlag;
+  if (!flag) return ['(n/a)'];
+  const remoteLabel = flag.remote ?? `(${flag.remoteKind})`;
+  return [
+    `env=${flag.env ? 'true' : 'false'}`,
+    `remote=${remoteLabel}`,
+    `active=${flag.active ? 'ON' : 'OFF'}`,
+  ];
+}
+
+/**
+ * Operation Dashboard(Modal render line 2141-2143)의 device-local 계산 가능 metric dump.
+ *
+ * Modal이 노출하는 6+ metric 중 backend polling 결과(locklessMiss / boardableMiss / accelPattern /
+ * pushLatency / laPushDelivery / silentPushReachBackend / locklessTripMiss)는 dump 시점에 sync
+ * 접근 불가 → 본 섹션은 device-local snapshot 만 노출하고 backend metric 은 명시적으로 안내.
+ *
+ * 노출 metric:
+ *  - alarmAccuracy (local): tripGroundTruth store `responses` accurate/answered 비율
+ *  - silentPushReach (local): `countSilentPushOutcomes(logs)` fired/received
+ *
+ * 미전달 시 (n/a) — DebugModalInner 가 store snapshot 을 주입하지 않은 호출자 graceful.
+ */
+function buildOperationDashboardSection(args: BuildDumpArgs): string[] {
+  const op = args.operationDashboard;
+  if (!op) return ['(n/a)'];
+  const silentCounts = countSilentPushOutcomes(args.logs);
+  return [
+    `alarmAccuracy(local)=${op.groundTruthAccurateCount}/${op.groundTruthAnsweredCount}`,
+    `silentPushReach(local)=${silentCounts.fired}/${silentCounts.received}`,
+    '(backend metrics: locklessMiss/boardableMiss/accelPattern/pushLatency/laPush — see Modal UI, not dumped)',
+  ];
+}
+
+/**
+ * Fusion picker tier 채택 분포 dump (최근 1h). Modal render(line 2552-2560)와 동일 SSOT —
+ * `formatFusionPickerTierDistribution(fusionTierLog, nowMs)` 재사용해 UI/dump 정합성 보장.
+ *
+ * 미전달/빈 배열은 (none)로 명시(포맷터 컨벤션 따라).
+ */
+function buildFusionTierSection(args: BuildDumpArgs): string[] {
+  const entries = args.fusionTierLog ?? [];
+  return [formatFusionPickerTierDistribution(entries, args.nowMs ?? Date.now())];
 }
 
 function buildArrivalSection(args: BuildDumpArgs): string[] {
@@ -1443,6 +1544,13 @@ interface ShareSectionSpec {
 }
 
 const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
+  // ADR-022 Phase 0 — Feature Flag(arch:simple-arrival-v1) 상태. Modal render(line 2147-2163)와
+  // 동일 SSOT (env / remote / active). dogfood 판정을 dump 만으로 사후 재구성 가능.
+  // 최상단 배치 — Modal 첫 섹션(Operation Dashboard, Feature Flag) 순서 그대로.
+  { title: 'Feature Flag', build: buildFeatureFlagSection },
+  // #1751 (M3 Sub 1) — Operation Dashboard(Modal render line 2141-2143)의 device-local metric.
+  // backend polling metric 은 dump 시점 sync 접근 불가라 안내 라인만 포함.
+  { title: 'Operation Dashboard', build: buildOperationDashboardSection },
   { title: 'GPS', build: buildGpsSection },
   { title: 'Nearest', build: buildNearestSection },
   { title: 'Fusion', build: buildFusionSection },
@@ -1497,6 +1605,9 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
     build: buildFusionLogSection,
     suffix: (args) => ` (${args.fusionLog?.length ?? 0})`,
   },
+  // #1693/#1706 — Fusion picker tier 채택 분포 (최근 1h). Modal render(line 2552-2560)와 동일
+  // SSOT (`formatFusionPickerTierDistribution`). 별 ring buffer(fusionTierLog) — alarmLog 점령 회귀 차단.
+  { title: 'Fusion Tier (1h)', build: buildFusionTierSection },
   // #1540 (S7) — gps-drop 채널. fusionDebugBuffer 점령 회귀 차단용 별 buffer를 dump에 그대로 노출.
   {
     title: 'GPS drops',
@@ -1662,6 +1773,10 @@ function DebugModalInner({
   // #1982 (ADR-022 Phase 0) — arrival-api-ssot-v1 Feature Flag remote 조회.
   // ADMIN_TOKEN / ALARM_BACKEND_URL 미설정 환경은 kind=unconfigured 로 그대로 표시.
   const archFlagRemote = useArchFlagRemote();
+  // Operation Dashboard(local alarmAccuracy) 계산용 tripGroundTruth 응답 subscribe.
+  // Modal render 는 OperationDashboardSection 이 자체 store subscribe, share dump 는 handleShare
+  // 호출 시점 스냅샷만 필요하므로 responses 참조가 안정적으로 갱신되면 dump 도 갱신된다.
+  const groundTruthResponses = useTripGroundTruthStore((s) => s.responses);
   // #1812 — routeContext 빌드: HomeScreen이 ROUTE_KEY에 영속화한 route + destinationStore의
   // tripOrigin + destination으로 routeContext를 구성한다. destination 변경 시 재조회.
   // tripStartedAt과 동일 패턴 (AsyncStorage SSOT, destination 의존 effect).
@@ -2066,6 +2181,21 @@ function DebugModalInner({
       // UI 표시와 동일 SSOT.
       routeLines,
       accelSnapshot,
+      // ADR-022 Phase 0 — Feature Flag 상태(env / remote / active). Modal render 와 동일 SSOT.
+      archFlag: {
+        env: isSimpleArchEnvEnabled(),
+        remote: archFlagRemote.value,
+        remoteKind: archFlagRemote.kind,
+        active: isSimpleArchEnabled(archFlagRemote.value),
+      },
+      // Operation Dashboard 의 device-local metric (alarmAccuracy local). backend polling metric 은
+      // dump 시점 sync 접근 불가라 안내 라인으로 대체 (buildOperationDashboardSection 참조).
+      operationDashboard: {
+        groundTruthAccurateCount: groundTruthResponses.filter((r) => r.outcome === 'accurate').length,
+        groundTruthAnsweredCount: groundTruthResponses.filter((r) => r.outcome !== 'unanswered').length,
+      },
+      // Fusion Tier (1h) — Modal render 와 동일 별 ring buffer(alarmLog 점령 회귀 차단).
+      fusionTierLog: fusionTierLogs,
     });
     void Share.share({ message });
   }, [
@@ -2118,6 +2248,12 @@ function DebugModalInner({
     // #1898 — routeLines/accelSnapshot 변경 시 share 텍스트 자동 갱신.
     routeLines,
     accelSnapshot,
+    // ADR-022 Phase 0 — archFlag remote 갱신 시 dump 텍스트 자동 갱신.
+    archFlagRemote,
+    // Operation Dashboard alarmAccuracy(local) — 사용자가 정답지 응답 시 dump 텍스트 자동 갱신.
+    groundTruthResponses,
+    // Fusion Tier (1h) — fusion picker tier 별 ring buffer 변경 시 dump 텍스트 자동 갱신.
+    fusionTierLogs,
   ]);
 
   return (
@@ -3254,6 +3390,11 @@ export const __test__ = {
   buildRouteLinesSummary,
   buildRouteLinesSection,
   buildAccelFingerprintSection,
+  // Share dump 누락 3 섹션(#2044-scope) — Feature Flag(ADR-022) + Operation Dashboard(#1751) +
+  // Fusion Tier (1h)(#1693/#1706). 단위 테스트에서 각 builder 직접 검증.
+  buildFeatureFlagSection,
+  buildOperationDashboardSection,
+  buildFusionTierSection,
 };
 
 const styles = StyleSheet.create({

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -6,6 +6,8 @@ import { DebugModal, __test__ } from '../DebugModal';
 import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
 import { useSettingsStore } from '../../../settings/store/useSettingsStore';
 import { useDestinationStore } from '../../../route/store/useDestinationStore';
+// Operation Dashboard alarmAccuracy(local) 계산 store — share dump payload 자동 wire 검증.
+import { useTripGroundTruthStore } from '../../store/useTripGroundTruthStore';
 import { ROUTE_KEY } from '../../../../shared/constants/storageKeys';
 import type { AlarmLogEntry } from '../../../../features/alarm/utils/alarmLog';
 import type { Station, NearestStationResult } from '../../../../shared/types/station';
@@ -3245,6 +3247,11 @@ describe('DebugModal share SSOT (#1346)', () => {
     expect(dump).toContain('## Auto-lock Candidate');
     // #1682 — suppress reason 1h 윈도우 섹션.
     expect(dump).toContain('## Suppress Reasons (1h)');
+    // 누락 3 섹션 wire (#2044 스코프) — Feature Flag(ADR-022) + Operation Dashboard(#1751) +
+    // Fusion Tier (1h)(#1693/#1706). Modal render 만 있고 dump 누락되던 회귀 차단.
+    expect(dump).toContain('## Feature Flag');
+    expect(dump).toContain('## Operation Dashboard');
+    expect(dump).toContain('## Fusion Tier (1h)');
     // suppressed reason 없으면 Gates 헤더 자체 생략(omitIfEmpty=true).
     expect(dump).not.toContain('## Gates');
   });
@@ -5113,6 +5120,375 @@ describe('DebugModal — #1501 Raw Signal 섹션', () => {
         fireEvent.press(screen.getByTestId('trip-detail-close'));
       });
       expect(screen.queryByTestId('trip-detail-card')).toBeNull();
+    });
+  });
+});
+
+// Share dump 누락 3 섹션 wire (#2044-scope) — Feature Flag(ADR-022) + Operation Dashboard(#1751) +
+// Fusion Tier (1h)(#1693/#1706). Modal render 는 있었지만 SHARE_SECTIONS 미등록 회귀 차단.
+describe('DebugModal share dump — 누락 3 섹션 wire (#2044-scope)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // handleShare 통합 테스트가 Modal 마운트 → 실제 hook 을 호출하므로 default fixture 재설정.
+    setupHookDefaults();
+    jest.spyOn(AppState, 'addEventListener').mockReturnValue({
+      remove: jest.fn(),
+    } as unknown as ReturnType<typeof AppState.addEventListener>);
+  });
+
+  // outer scope factory — SonarCloud nested function 회피(공통 baseline 패턴).
+  type DumpArgs = Parameters<typeof __test__.buildDumpText>[0];
+  const dumpBaseline: DumpArgs = {
+    userLocation: null,
+    speedMps: null,
+    accuracyMeters: null,
+    nearestName: null,
+    nearestDistanceM: null,
+    variants: [],
+    fusion: {
+      confidence: 'gps-only' as const,
+      source: 'gps' as const,
+      fusedLabel: '-',
+      gpsLabel: '-',
+      differs: false,
+      candidateTrains: null,
+    },
+    arrivalSummary: '-',
+    isMock: false,
+    silentPush: {
+      apnsToken: null,
+      activeTripToken: null,
+      apnsEnv: 'sandbox' as const,
+      apnsEnvStamped: null,
+      permissionStatus: null,
+      taskRegistrationState: 'unknown' as const,
+      taskRegistrationError: null,
+      lastReceivedAt: null,
+      lastFiredAt: null,
+      lastSkippedAt: null,
+      hasRoute: false,
+      destinationId: null,
+      lastNotifiedStationId: null,
+    },
+    logs: [],
+  };
+  const makeArgs = (overrides: Partial<DumpArgs> = {}): DumpArgs => ({
+    ...dumpBaseline,
+    ...overrides,
+  });
+
+  describe('buildFeatureFlagSection (ADR-022)', () => {
+    it('archFlag 미전달 시 (n/a) 반환 — hook 을 마운트하지 않은 baseline graceful', () => {
+      expect(__test__.buildFeatureFlagSection(makeArgs())).toEqual(['(n/a)']);
+    });
+
+    it('remote unconfigured — env=false / remote=(unconfigured) / active=OFF', () => {
+      expect(
+        __test__.buildFeatureFlagSection(
+          makeArgs({
+            archFlag: {
+              env: false,
+              remote: undefined,
+              remoteKind: 'unconfigured',
+              active: false,
+            },
+          }),
+        ),
+      ).toEqual(['env=false', 'remote=(unconfigured)', 'active=OFF']);
+    });
+
+    it('remote on — env=false / remote=on / active=ON (rollout 시나리오)', () => {
+      expect(
+        __test__.buildFeatureFlagSection(
+          makeArgs({
+            archFlag: {
+              env: false,
+              remote: 'on',
+              remoteKind: 'ok',
+              active: true,
+            },
+          }),
+        ),
+      ).toEqual(['env=false', 'remote=on', 'active=ON']);
+    });
+
+    it('env=true — dogfood 빌드 환경변수 override', () => {
+      expect(
+        __test__.buildFeatureFlagSection(
+          makeArgs({
+            archFlag: {
+              env: true,
+              remote: 'off',
+              remoteKind: 'ok',
+              active: true,
+            },
+          }),
+        ),
+      ).toEqual(['env=true', 'remote=off', 'active=ON']);
+    });
+
+    it('remote error — kind fallback 표기', () => {
+      expect(
+        __test__.buildFeatureFlagSection(
+          makeArgs({
+            archFlag: {
+              env: false,
+              remote: undefined,
+              remoteKind: 'error',
+              active: false,
+            },
+          }),
+        ),
+      ).toEqual(['env=false', 'remote=(error)', 'active=OFF']);
+    });
+  });
+
+  describe('buildOperationDashboardSection (#1751)', () => {
+    it('operationDashboard 미전달 시 (n/a) 반환 — store snapshot 미주입 graceful', () => {
+      expect(__test__.buildOperationDashboardSection(makeArgs())).toEqual(['(n/a)']);
+    });
+
+    it('alarmAccuracy(local) 0/0 + silentPushReach(local) 0/0 + backend 안내 라인', () => {
+      const result = __test__.buildOperationDashboardSection(
+        makeArgs({
+          operationDashboard: { groundTruthAccurateCount: 0, groundTruthAnsweredCount: 0 },
+        }),
+      );
+      expect(result).toEqual([
+        'alarmAccuracy(local)=0/0',
+        'silentPushReach(local)=0/0',
+        '(backend metrics: locklessMiss/boardableMiss/accelPattern/pushLatency/laPush — see Modal UI, not dumped)',
+      ]);
+    });
+
+    it('alarmAccuracy(local) 3/5 반영 — 사용자 정답지 응답 반영', () => {
+      const result = __test__.buildOperationDashboardSection(
+        makeArgs({
+          operationDashboard: { groundTruthAccurateCount: 3, groundTruthAnsweredCount: 5 },
+        }),
+      );
+      expect(result[0]).toBe('alarmAccuracy(local)=3/5');
+    });
+
+    it('silentPushReach(local) 은 args.logs 로 계산 — fired/received 반영', () => {
+      const result = __test__.buildOperationDashboardSection(
+        makeArgs({
+          operationDashboard: { groundTruthAccurateCount: 0, groundTruthAnsweredCount: 0 },
+          logs: [
+            { ts: 1, source: 'silent-push-received', outcome: 'received' },
+            { ts: 2, source: 'silent-push-received', outcome: 'received' },
+            { ts: 3, source: 'silent-push-fired', outcome: 'fired' },
+          ],
+        }),
+      );
+      expect(result[1]).toBe('silentPushReach(local)=1/2');
+    });
+  });
+
+  describe('buildFusionTierSection (#1693/#1706)', () => {
+    it('fusionTierLog 미전달 시 (none) 반환 — formatFusionPickerTierDistribution 컨벤션', () => {
+      expect(__test__.buildFusionTierSection(makeArgs())).toEqual(['(none)']);
+    });
+
+    it('빈 배열도 (none) 표기', () => {
+      expect(__test__.buildFusionTierSection(makeArgs({ fusionTierLog: [] }))).toEqual(['(none)']);
+    });
+
+    it('tier 3건 분포를 count 내림차순으로 노출', () => {
+      const now = 1_700_000_000_000;
+      const result = __test__.buildFusionTierSection(
+        makeArgs({
+          fusionTierLog: [
+            { ts: now - 100, tier: 'gpsFallback' },
+            { ts: now - 200, tier: 'gpsFallback' },
+            { ts: now - 300, tier: 'backendSsotAccepts' },
+          ],
+          nowMs: now,
+        }),
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0]).toContain('tier-gpsFallback=2');
+      expect(result[0]).toContain('tier-backendSsotAccepts=1');
+    });
+
+    it('1h 윈도우 밖 entries 는 집계에서 제외', () => {
+      const now = 1_700_000_000_000;
+      const result = __test__.buildFusionTierSection(
+        makeArgs({
+          fusionTierLog: [
+            { ts: now - 100, tier: 'gpsFallback' },
+            // 2h 이전 — 윈도우 밖.
+            { ts: now - 2 * 60 * 60 * 1000, tier: 'positionTrain' },
+          ],
+          nowMs: now,
+        }),
+      );
+      expect(result[0]).toContain('tier-gpsFallback=1');
+      expect(result[0]).not.toContain('positionTrain');
+    });
+  });
+
+  describe('SHARE_SECTIONS 등록 — buildDumpText 통합', () => {
+    it('archFlag 전달 시 dump 에 Feature Flag 섹션이 env/remote/active 라인으로 노출', () => {
+      const dump = __test__.buildDumpText(
+        makeArgs({
+          archFlag: {
+            env: true,
+            remote: 'on',
+            remoteKind: 'ok',
+            active: true,
+          },
+        }),
+      );
+      expect(dump).toContain('## Feature Flag');
+      const section = dump.slice(dump.indexOf('## Feature Flag'));
+      expect(section).toContain('env=true');
+      expect(section).toContain('remote=on');
+      expect(section).toContain('active=ON');
+    });
+
+    it('operationDashboard 전달 시 dump 에 alarmAccuracy(local) + silentPushReach(local) 노출', () => {
+      const dump = __test__.buildDumpText(
+        makeArgs({
+          operationDashboard: { groundTruthAccurateCount: 2, groundTruthAnsweredCount: 3 },
+          logs: [
+            { ts: 1, source: 'silent-push-received', outcome: 'received' },
+            { ts: 2, source: 'silent-push-fired', outcome: 'fired' },
+          ],
+        }),
+      );
+      expect(dump).toContain('## Operation Dashboard');
+      const section = dump.slice(dump.indexOf('## Operation Dashboard'));
+      expect(section).toContain('alarmAccuracy(local)=2/3');
+      expect(section).toContain('silentPushReach(local)=1/1');
+    });
+
+    it('fusionTierLog 전달 시 dump 에 Fusion Tier (1h) 섹션이 분포 라인으로 노출', () => {
+      const now = 1_700_000_000_000;
+      const dump = __test__.buildDumpText(
+        makeArgs({
+          fusionTierLog: [
+            { ts: now - 100, tier: 'gpsFallback' },
+            { ts: now - 200, tier: 'gpsFallback' },
+          ],
+          nowMs: now,
+        }),
+      );
+      expect(dump).toContain('## Fusion Tier (1h)');
+      const section = dump.slice(dump.indexOf('## Fusion Tier (1h)'));
+      expect(section).toContain('tier-gpsFallback=2');
+    });
+
+    it('3 섹션 순서 — Feature Flag / Operation Dashboard 는 상단, Fusion Tier (1h) 는 Fusion log 다음', () => {
+      const dump = __test__.buildDumpText(makeArgs());
+      const featureFlagIdx = dump.indexOf('## Feature Flag');
+      const operationDashboardIdx = dump.indexOf('## Operation Dashboard');
+      const gpsIdx = dump.indexOf('## GPS');
+      const fusionLogIdx = dump.indexOf('## Fusion log');
+      const fusionTierIdx = dump.indexOf('## Fusion Tier (1h)');
+      // Feature Flag / Operation Dashboard 는 GPS 앞 (Modal render 첫 두 섹션 순서 그대로).
+      expect(featureFlagIdx).toBeGreaterThan(-1);
+      expect(operationDashboardIdx).toBeGreaterThan(featureFlagIdx);
+      expect(gpsIdx).toBeGreaterThan(operationDashboardIdx);
+      // Fusion Tier (1h) 는 Fusion log 다음(공통 fusion 도메인 그루핑).
+      expect(fusionTierIdx).toBeGreaterThan(fusionLogIdx);
+    });
+  });
+
+  describe('handleShare 통합 — Modal 마운트 → 실제 Share.share 호출 payload', () => {
+    it('remote unconfigured (기본 test env) → dump 에 Feature Flag env=false / remote=(unconfigured) / active=OFF', async () => {
+      const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      fireEvent.press(screen.getByTestId('debug-share-dump'));
+      await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+      const { message } = shareSpy.mock.calls[0][0] as { message: string };
+      expect(message).toContain('## Feature Flag');
+      const section = message.slice(message.indexOf('## Feature Flag'));
+      expect(section).toContain('env=false');
+      expect(section).toContain('remote=(unconfigured)');
+      expect(section).toContain('active=OFF');
+      shareSpy.mockRestore();
+    });
+
+    it('handleShare payload 에 Operation Dashboard 섹션이 항상 포함(자동 wire)', async () => {
+      const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      fireEvent.press(screen.getByTestId('debug-share-dump'));
+      await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+      const { message } = shareSpy.mock.calls[0][0] as { message: string };
+      expect(message).toContain('## Operation Dashboard');
+      // groundTruth store 기본 [] → 0/0 표기.
+      const section = message.slice(message.indexOf('## Operation Dashboard'));
+      expect(section).toContain('alarmAccuracy(local)=0/0');
+      expect(section).toContain('silentPushReach(local)=0/0');
+      shareSpy.mockRestore();
+    });
+
+    it('handleShare payload 에 Fusion Tier (1h) 섹션이 항상 포함(자동 wire)', async () => {
+      const now = Date.now();
+      mockGetFusionTierLog.mockReturnValue([
+        { ts: now - 100, tier: 'gpsFallback' },
+      ]);
+      const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      fireEvent.press(screen.getByTestId('debug-share-dump'));
+      await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+      const { message } = shareSpy.mock.calls[0][0] as { message: string };
+      expect(message).toContain('## Fusion Tier (1h)');
+      const section = message.slice(message.indexOf('## Fusion Tier (1h)'));
+      expect(section).toContain('tier-gpsFallback=1');
+      shareSpy.mockRestore();
+    });
+
+    it('remote on 시 dump active=ON — archFlagRemote hook 결과가 payload 로 흘러감', async () => {
+      mockUseArchFlagRemote.mockReturnValue({
+        value: 'on',
+        kind: 'ok',
+        lastFetchedAt: 1_700_000_000_000,
+      });
+      const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      fireEvent.press(screen.getByTestId('debug-share-dump'));
+      await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+      const { message } = shareSpy.mock.calls[0][0] as { message: string };
+      const section = message.slice(message.indexOf('## Feature Flag'));
+      expect(section).toContain('remote=on');
+      expect(section).toContain('active=ON');
+      shareSpy.mockRestore();
+    });
+
+    it('groundTruth store 응답 반영 — alarmAccuracy(local)=1/2 (1 accurate + 1 inaccurate)', async () => {
+      // .filter((r) => r.outcome === 'accurate') / (r) => r.outcome !== 'unanswered' 두 콜백을
+      // 실제 데이터로 실행 — coverage 100% 확보.
+      useTripGroundTruthStore.setState({
+        hydrated: true,
+        pendingPrompt: null,
+        responses: [
+          { corrId: 'a', endedAt: 1, respondedAt: 2, outcome: 'accurate' },
+          { corrId: 'b', endedAt: 3, respondedAt: 4, outcome: 'inaccurate' },
+          { corrId: 'c', endedAt: 5, respondedAt: 6, outcome: 'unanswered' },
+        ],
+      });
+      const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({ action: 'sharedAction' });
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      fireEvent.press(screen.getByTestId('debug-share-dump'));
+      await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+      const { message } = shareSpy.mock.calls[0][0] as { message: string };
+      const section = message.slice(message.indexOf('## Operation Dashboard'));
+      // 1 accurate / 2 answered (inaccurate + accurate, unanswered 제외).
+      expect(section).toContain('alarmAccuracy(local)=1/2');
+      shareSpy.mockRestore();
+      // 다른 테스트에 영향 없도록 store 리셋.
+      useTripGroundTruthStore.setState({
+        hydrated: false,
+        pendingPrompt: null,
+        responses: [],
+      });
     });
   });
 });


### PR DESCRIPTION
## 배경

DebugModal audit 결과, Modal 에서 render 되는 3 개 섹션이 share dump 텍스트에 **누락** — 사용자가 evidence 공유 시 사후 분석 불가능:

| 섹션 | Modal render Line | 이전 상태 |
|---|---|---|
| **Feature Flag** (ADR-022) | 2147-2163 | SHARE_SECTIONS 미등록 |
| **Operation Dashboard** (#1751) | 2141-2143 | SHARE_SECTIONS 미등록 |
| **Fusion Tier (1h)** (#1693/#1706) | 2552-2560 | SHARE_SECTIONS 미등록 |

Share dump 진단 완결도 26/35 → 29/35 (74% → 83%).

## 변경 요약

### 1. `BuildDumpArgs` 확장 (3 필드)

- `archFlag?: { env, remote, remoteKind, active }` — ADR-022 Feature Flag 3 값
- `operationDashboard?: { groundTruthAccurateCount, groundTruthAnsweredCount }` — device-local metric
- `fusionTierLog?: readonly FusionTierLogEntry[]` — 별 ring buffer entries

모두 optional — 단위 테스트 baseline / 호환성 graceful.

### 2. 3 신규 builder

**`buildFeatureFlagSection`** (\`## Feature Flag\`)

env=on/off / remote=on/off/(unconfigured|error) / active=ON/OFF — Modal render 3 KeyValue row 와 동일 SSOT.

**`buildOperationDashboardSection`** (\`## Operation Dashboard\`)

alarmAccuracy(local) + silentPushReach(local) 2 라인 + backend polling metric 은 sync 접근 불가라 명시 안내 라인 (locklessMiss / boardableMiss / accelPattern / pushLatency / laPush) — Modal UI 참조 유도.

**`buildFusionTierSection`** (\`## Fusion Tier (1h)\`)

\`formatFusionPickerTierDistribution(fusionTierLog, nowMs)\` 재사용 — Modal UI 와 100% 동일 SSOT. 별 ring buffer 이므로 alarmLog 점령 회귀 차단 정책 유지.

### 3. SHARE_SECTIONS 확장 (3 항목)

- \`Feature Flag\` — 최상단 (Modal 첫 섹션)
- \`Operation Dashboard\` — Feature Flag 다음 (Modal 순서 그대로)
- \`Fusion Tier (1h)\` — Fusion log 다음 (fusion 도메인 그루핑)

### 4. `handleShare` payload + useCallback deps

- payload: archFlag / operationDashboard / fusionTierLog 3 필드 추가
- deps: archFlagRemote / groundTruthResponses / fusionTierLogs 3 개 추가
- 신규 hook: \`useTripGroundTruthStore((s) => s.responses)\` — Modal 열려있는 동안만 subscribe (관찰자 효과 없음)

## 신규 evidence — share dump 텍스트 샘플

새로 dump 되는 3 섹션 실제 출력 (test fixture 기반):

```
## Feature Flag
env=false
remote=(unconfigured)
active=OFF

## Operation Dashboard
alarmAccuracy(local)=1/2
silentPushReach(local)=1/2
(backend metrics: locklessMiss/boardableMiss/accelPattern/pushLatency/laPush — see Modal UI, not dumped)

## Fusion Tier (1h)
tier-gpsFallback=2, tier-backendSsotAccepts=1
```

## Wire-completion 5단

1. **Orphan 없음** — 3 builder 함수 SHARE_SECTIONS 배열에 등록 + \`__test__\` 재노출. \`npm run lint:orphan\` pass 확인.
2. **V/X dashboard** — share dump 진단 완결도 26/35 → 29/35 (74% → 83%). 신규 3 섹션이 사용자 evidence 공유 dump 에서 즉시 확인 가능.
3. **의존 PR** — 없음 (DebugModal.tsx self-contained fix).
4. **측정 plan** — 다음 사용자 evidence trip 공유 dump 에 3 섹션 실제 노출 확인 (Feature Flag / Operation Dashboard / Fusion Tier (1h) 헤더 3 개 grep).
5. **Device verify** — N/A. 순수 dump 텍스트 생성 로직 확장 (no runtime behavior change). type-check + unit 만.

## 테스트

- 22 개 신규 test (builder unit + SHARE_SECTIONS 통합 + handleShare 통합)
- 373 개 전체 pass (기존 351 개 regression 0)
- DebugModal.tsx 커버리지 100/100/100/100
- 전체 9177 tests pass

## 파일 충돌 주의 (동시 진행 PR)

B agent (worktree `a37ac9fd50c1aa17f`)가 같은 파일 DebugModal.tsx 편집 중 — 편집 라인 다름 (A: SHARE_SECTIONS + builder + deps + payload / B: `<Section>` render). B 나중 머지 시 rebase 필요할 수 있음.

## Effort

Medium. 3 builder 함수 + test 확장.

Closes N/A (audit-scope fix).