### PR TITLE
fix(#2049): DebugModal UI 누락 4 섹션 render 추가 (Auto-lock + Env Distribution + BoardingLock Drift + Alarm Log Reasons 1h)

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -1023,12 +1023,22 @@ function buildAlarmLogSection(args: BuildDumpArgs): string[] {
  *
  * nowMs 미전달 시 Date.now() 사용 — 테스트 결정적 출력 확보.
  * 1h 윈도우 내 suppressed 항목이 없으면 (empty) 반환.
+ *
+ * #2049 — dump builder(#1692)와 UI section이 공유하는 SSoT helper로 추출.
+ * `buildAlarmLogReasonsSummarySection`는 args unpack만 담당하는 thin wrapper.
  */
-function buildAlarmLogReasonsSummarySection(args: BuildDumpArgs): string[] {
-  const now = args.nowMs ?? Date.now();
-  const counters = countAlarmLogReasonsByWindow(args.logs, 60 * 60 * 1000, now);
+function computeAlarmLogReasonsLines(
+  logs: readonly AlarmLogEntry[],
+  nowMs?: number,
+): string[] {
+  const now = nowMs ?? Date.now();
+  const counters = countAlarmLogReasonsByWindow(logs, 60 * 60 * 1000, now);
   if (counters.length === 0) return ['(empty)'];
   return counters.map(({ reason, count }) => `${reason}: ${count}`);
+}
+
+function buildAlarmLogReasonsSummarySection(args: BuildDumpArgs): string[] {
+  return computeAlarmLogReasonsLines(args.logs, args.nowMs);
 }
 
 /**
@@ -1291,17 +1301,23 @@ function buildSuppressReasonsSection(args: BuildDumpArgs): string[] {
  * device-side auto-lock 측정 상태를 dump.
  *
  * meta 미전달 시 (n/a) — 호출자가 측정 비활성 또는 SSOT 객체 미주입.
+ *
+ * #2049 — dump builder(#1421)와 UI section이 공유하는 SSoT helper로 추출.
+ * `buildAutoLockSection`는 args unpack만 담당하는 thin wrapper.
  */
-function buildAutoLockSection(args: BuildDumpArgs): string[] {
-  const m = args.autoLockMeta;
-  if (!m) return ['(n/a)'];
-  const ssotLine = `ssot=${formatSSOTLabel(m.surfaceSSOTActive, m.undergroundSSOTActive)}`;
-  const stabilityLine = `stability=${m.stability.stable ? 'stable' : 'pending'} count=${m.stability.count} stationId=${m.stability.stationId ?? UNKNOWN_LABEL}`;
-  const directionLine = formatDirectionLine(m.direction);
-  const candidateLine = m.candidate
-    ? `candidate=trainCode=${m.candidate.candidate.trainCode} line=${m.candidate.candidate.line} source=${m.candidate.source} path=${m.candidate.path}`
-    : `candidate=null reason=${m.nullReason ?? UNKNOWN_LABEL}`;
+function computeAutoLockLines(meta: AutoLockDebugMeta | undefined): string[] {
+  if (!meta) return ['(n/a)'];
+  const ssotLine = `ssot=${formatSSOTLabel(meta.surfaceSSOTActive, meta.undergroundSSOTActive)}`;
+  const stabilityLine = `stability=${meta.stability.stable ? 'stable' : 'pending'} count=${meta.stability.count} stationId=${meta.stability.stationId ?? UNKNOWN_LABEL}`;
+  const directionLine = formatDirectionLine(meta.direction);
+  const candidateLine = meta.candidate
+    ? `candidate=trainCode=${meta.candidate.candidate.trainCode} line=${meta.candidate.candidate.line} source=${meta.candidate.source} path=${meta.candidate.path}`
+    : `candidate=null reason=${meta.nullReason ?? UNKNOWN_LABEL}`;
   return [ssotLine, stabilityLine, directionLine, candidateLine];
+}
+
+function buildAutoLockSection(args: BuildDumpArgs): string[] {
+  return computeAutoLockLines(args.autoLockMeta);
 }
 
 function formatDirectionLine(direction: VerifyTrainDirectionResult | null): string {
@@ -1328,9 +1344,13 @@ function formatSSOTLabel(surface: boolean, underground: boolean): string {
  *   totals: surface=12m30s underground=5m24s hybrid=58s unknown=10m54s
  *   transitions=5
  *   observed=30m0s
+ *
+ * #2049 — dump builder(#1430)와 UI section이 공유하는 SSoT helper로 추출.
+ * `buildEnvironmentDistributionSection`는 args unpack만 담당하는 thin wrapper.
  */
-function buildEnvironmentDistributionSection(args: BuildDumpArgs): string[] {
-  const snap = args.envDistribution;
+function computeEnvironmentDistributionLines(
+  snap: EnvironmentDistributionSnapshot | undefined,
+): string[] {
   if (!snap) return ['(n/a)'];
   const pct = snap.percentages;
   const t = snap.totals;
@@ -1340,6 +1360,10 @@ function buildEnvironmentDistributionSection(args: BuildDumpArgs): string[] {
     `transitions=${snap.transitions}`,
     `observed=${formatDurationMs(snap.observedMs)}`,
   ];
+}
+
+function buildEnvironmentDistributionSection(args: BuildDumpArgs): string[] {
+  return computeEnvironmentDistributionLines(args.envDistribution);
 }
 
 /** Percentage 표기 — 소수 1자리 고정. */
@@ -2011,6 +2035,11 @@ function DebugModalInner({
   const [candidateRejectLogs, setCandidateRejectLogs] = useState<readonly CandidateRejectEntry[]>(() =>
     getCandidateRejectEntries(),
   );
+  // #2049 — boarding-lock-drift ring buffer. #1896 (RC-8) 별 buffer를 UI/dump에 노출.
+  // fusionLogs와 동일 패턴 (snapshot + subscribe + clear button).
+  const [boardingLockDriftLog, setBoardingLockDriftLog] = useState<readonly BoardingLockDriftEntry[]>(() =>
+    getBoardingLockDriftEntries(),
+  );
   const [estimatorLogs, setEstimatorLogs] = useState<readonly EstimatorDebugEntry[]>(() =>
     getEstimatorEntries(),
   );
@@ -2061,6 +2090,13 @@ function DebugModalInner({
   useEffect(() => {
     return subscribeCandidateReject(() =>
       setCandidateRejectLogs([...getCandidateRejectEntries()]),
+    );
+  }, []);
+
+  // #2049 — boarding-lock-drift buffer 구독. candidate-reject와 동일 패턴.
+  useEffect(() => {
+    return subscribeBoardingLockDrift(() =>
+      setBoardingLockDriftLog([...getBoardingLockDriftEntries()]),
     );
   }, []);
 
@@ -2166,6 +2202,8 @@ function DebugModalInner({
       gpsDropLog: gpsDropLogs,
       // #1902 (RC-18) — candidate-reject entries를 share에 포함. 별 buffer라 fusion log와 동시 dump.
       candidateRejectLog: candidateRejectLogs,
+      // #2049 (#1896 RC-8) — boarding-lock-drift entries를 share에 포함. 별 buffer라 fusion log와 동시 dump.
+      boardingLockDriftLog,
       // #1413 — UI에만 노출되던 BoardingLock/Estimator/Boarding Prompt(+Acceptance)/Counters를 share에 포함.
       boardingLock: lock,
       estimatorLog: estimatorLogs,
@@ -2234,6 +2272,8 @@ function DebugModalInner({
     gpsDropLogs,
     // #1902 (RC-18) — candidate-reject entries 변경 시 share 텍스트 자동 갱신.
     candidateRejectLogs,
+    // #2049 (#1896 RC-8) — boarding-lock-drift entries 변경 시 share 텍스트 자동 갱신.
+    boardingLockDriftLog,
     // #1413 — BoardingLock/Estimator 신규 캡쳐.
     lock,
     estimatorLogs,
@@ -2608,6 +2648,20 @@ function DebugModalInner({
             colors={colors}
           />
 
+          {/* #2049 (#1896 RC-8) — boarding-lock-drift 별 buffer. candidate-reject와 동일 표시 패턴. */}
+          <DebugLogSection
+            title="Boarding-Lock Drift"
+            logs={boardingLockDriftLog}
+            formatLine={formatBoardingLockDriftLine}
+            onClear={() => {
+              clearBoardingLockDriftEntries();
+              setBoardingLockDriftLog([]);
+            }}
+            clearTestId="debug-boarding-lock-drift-log-clear"
+            entryTestId="debug-boarding-lock-drift-log-entry"
+            colors={colors}
+          />
+
           {/* #1518 — device → backend HTTP 호출 ring buffer. 토글 없이 직전 entries 자동 표시. */}
           <DebugLogSection
             title="Backend Calls"
@@ -2717,6 +2771,18 @@ function DebugModalInner({
 
           {/* #1682 — Suppress Reasons: 1h 윈도우 top 5 suppress reason 분포 */}
           <SuppressReasonsSection logs={logs} colors={colors} />
+
+          {/* #2049 (#1692) — Alarm Log Reasons (1h): suppress reason 집계 요약.
+              buildAlarmLogReasonsSummarySection과 동일 SSOT (내부 helper 재사용). */}
+          <AlarmLogReasonsSummarySection logs={logs} colors={colors} />
+
+          {/* #2049 (#1421) — Auto-lock Candidate: SSOT/stability/direction/candidate 4줄.
+              buildAutoLockSection과 동일 SSOT (내부 helper 재사용). */}
+          <AutoLockCandidateSection meta={autoLockMeta} colors={colors} />
+
+          {/* #2049 (#1430) — Environment Distribution: SSOT 활성 cascade state별 누적 시간.
+              buildEnvironmentDistributionSection과 동일 SSOT (내부 helper 재사용). */}
+          <EnvironmentDistributionSection snapshot={envDistribution} colors={colors} />
 
           {/* #1501 — PR-C. Raw signal 자동 표시 (toggle 없음).
               #1881 — 전체 buffer 전달. UI는 DebugLogSection의 DEBUG_LOG_DISPLAY_LIMIT(100) 적용.
@@ -3290,6 +3356,114 @@ function SuppressReasonsSection({
 }
 
 /**
+ * #2049 — dump builder가 return하는 sentinel line. UI에서 empty state로 렌더한다.
+ * dump builder는 항상 최소 1개 라인 반환 (empty buffer도 `['(empty)']`) — sentinel 매칭만으로 판정.
+ */
+const DUMP_EMPTY_LINES: ReadonlySet<string> = new Set(['(n/a)', '(empty)']);
+
+/**
+ * #2049 — dump text section 공통 표시. 각 dump builder(string[])의 결과를 그대로 monospace로 노출.
+ * builder를 UI와 share dump 둘 다에서 재사용해 SSoT 유지 — UI/dump가 어긋날 여지가 없다.
+ * 단일 sentinel 라인(`(n/a)` / `(empty)`)이면 muted 톤으로 표시.
+ */
+function DumpTextSection({
+  title,
+  lines,
+  entryTestId,
+  colors,
+}: Readonly<{
+  title: string;
+  lines: readonly string[];
+  entryTestId: string;
+  colors: ReturnType<typeof useTheme>['colors'];
+}>) {
+  const firstLine = lines[0];
+  const isEmpty = firstLine !== undefined && lines.length === 1 && DUMP_EMPTY_LINES.has(firstLine);
+  return (
+    <Section title={title} colors={colors} testID={`${entryTestId}-section`}>
+      {isEmpty ? (
+        <Text
+          style={[typography.mono, { color: colors.muted }]}
+          testID={`${entryTestId}-empty`}
+        >
+          {firstLine}
+        </Text>
+      ) : (
+        lines.map((line, idx) => (
+          <MonoEntry
+            key={`${entryTestId}-${idx}`}
+            testID={entryTestId}
+            colors={colors}
+          >
+            {line}
+          </MonoEntry>
+        ))
+      )}
+    </Section>
+  );
+}
+
+/**
+ * #2049 (#1421) — Auto-lock Candidate UI section. computeAutoLockLines helper를 dump builder와 공유.
+ */
+function AutoLockCandidateSection({
+  meta,
+  colors,
+}: Readonly<{
+  meta: AutoLockDebugMeta | undefined;
+  colors: ReturnType<typeof useTheme>['colors'];
+}>) {
+  return (
+    <DumpTextSection
+      title="Auto-lock Candidate"
+      lines={computeAutoLockLines(meta)}
+      entryTestId="debug-auto-lock-candidate"
+      colors={colors}
+    />
+  );
+}
+
+/**
+ * #2049 (#1430) — Environment Distribution UI section. computeEnvironmentDistributionLines helper를 공유.
+ */
+function EnvironmentDistributionSection({
+  snapshot,
+  colors,
+}: Readonly<{
+  snapshot: EnvironmentDistributionSnapshot | undefined;
+  colors: ReturnType<typeof useTheme>['colors'];
+}>) {
+  return (
+    <DumpTextSection
+      title="Environment Distribution"
+      lines={computeEnvironmentDistributionLines(snapshot)}
+      entryTestId="debug-environment-distribution"
+      colors={colors}
+    />
+  );
+}
+
+/**
+ * #2049 (#1692) — Alarm Log Reasons (1h) UI section. computeAlarmLogReasonsLines helper를 공유.
+ */
+function AlarmLogReasonsSummarySection({
+  logs,
+  colors,
+}: Readonly<{
+  logs: readonly AlarmLogEntry[];
+  colors: ReturnType<typeof useTheme>['colors'];
+}>) {
+  return (
+    <DumpTextSection
+      title="Alarm Log Reasons (1h)"
+      lines={computeAlarmLogReasonsLines(logs)}
+      entryTestId="debug-alarm-log-reasons-1h"
+      colors={colors}
+    />
+  );
+}
+
+/**
  * #1170 — boarding-prompt acceptance dashboard.
  *
  * 표시: displayed / responded / 응답률 / 탑승률 + 최근 7일 일별 표 (export 진입점).
@@ -3395,6 +3569,10 @@ export const __test__ = {
   buildFeatureFlagSection,
   buildOperationDashboardSection,
   buildFusionTierSection,
+  // #2049 — dump builder와 UI section이 공유하는 SSoT helper. UI/dump 라인 일치 검증에 사용.
+  computeAutoLockLines,
+  computeEnvironmentDistributionLines,
+  computeAlarmLogReasonsLines,
 };
 
 const styles = StyleSheet.create({

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -5492,3 +5492,155 @@ describe('DebugModal share dump — 누락 3 섹션 wire (#2044-scope)', () => {
     });
   });
 });
+
+// #2049 — Modal UI render 검증. dump text에는 포함되지만 UI section 미노출이던 4 섹션 회귀 차단.
+describe('DebugModal — #2049 UI 누락 4 섹션 render', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupHookDefaults();
+  });
+
+  it('Auto-lock Candidate 섹션이 UI에 노출된다', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('Auto-lock Candidate')).toBeTruthy();
+    // Section wrapper testID 존재 = UI에 section 붙어있다는 결정적 signal.
+    expect(screen.getByTestId('debug-auto-lock-candidate-section')).toBeTruthy();
+    // setupHookDefaults의 SSOT 미합의 상태 → computeAutoLockLines가 4줄 반환 → entry testID 존재.
+    const entries = screen.getAllByTestId('debug-auto-lock-candidate');
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  it('Environment Distribution 섹션이 UI에 노출된다', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('Environment Distribution')).toBeTruthy();
+    expect(screen.getByTestId('debug-environment-distribution-section')).toBeTruthy();
+    // envDistribution counter는 modal 열림 즉시 tick — snapshot 존재하므로 entry render.
+    expect(screen.getAllByTestId('debug-environment-distribution').length).toBeGreaterThan(0);
+  });
+
+  it('Alarm Log Reasons (1h) 섹션이 UI에 노출된다 (logs 없으면 (empty))', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText('Alarm Log Reasons (1h)')).toBeTruthy();
+    expect(screen.getByTestId('debug-alarm-log-reasons-1h-empty')).toBeTruthy();
+  });
+
+  it('Alarm Log Reasons (1h) 섹션이 suppress reason 집계를 표시한다', async () => {
+    const now = Date.now();
+    mockGetAlarmLog.mockResolvedValue([
+      { ts: now - 1_000, source: 'boarding-prompt', outcome: 'suppressed', reason: 'gate-accuracy' },
+      { ts: now - 2_000, source: 'boarding-prompt', outcome: 'suppressed', reason: 'gate-accuracy' },
+      { ts: now - 3_000, source: 'boarding-prompt', outcome: 'suppressed', reason: 'stationary' },
+    ]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    // logs가 refresh되기까지 잠시 기다림. UI section에 entry가 최소 1개 이상 등장.
+    await waitFor(() => {
+      const entries = screen.queryAllByTestId('debug-alarm-log-reasons-1h');
+      expect(entries.length).toBeGreaterThan(0);
+    });
+    const entries = screen.getAllByTestId('debug-alarm-log-reasons-1h');
+    const joined = entries.map((e) => e.props.children).join(' ');
+    expect(joined).toContain('gate-accuracy');
+    expect(joined).toContain('stationary');
+  });
+
+  it('Boarding-Lock Drift 섹션이 UI에 노출된다 (buffer 비어 있으면 (empty))', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    // DebugLogSection은 header에 count(0) suffix를 붙임 → 'Boarding-Lock Drift (0)' 존재 확인.
+    expect(screen.getByText(/Boarding-Lock Drift \(\d+\)/)).toBeTruthy();
+  });
+
+  it('Boarding-Lock Drift buffer push → UI 반영 + clear 버튼이 buffer를 비운다', async () => {
+    // buffer는 module-level singleton. 매 테스트 시작 시 clear로 격리.
+    const {
+      pushBoardingLockDriftEntry,
+      clearBoardingLockDriftEntries,
+      getBoardingLockDriftEntries,
+    } = jest.requireActual('../../../nearest-station/utils/boardingLockDriftBuffer');
+    clearBoardingLockDriftEntries();
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    // buffer push → subscribe listener 트리거 → setBoardingLockDriftLog 콜백 실행.
+    await act(async () => {
+      pushBoardingLockDriftEntry({
+        kind: 'boarding-lock-drift',
+        ts: Date.now(),
+        branch: 'positionTrain',
+        lockStationName: '강남',
+        lockStationLine: '2',
+        driftMeters: 42,
+      });
+    });
+    expect(getBoardingLockDriftEntries().length).toBe(1);
+    // clear 버튼 press → clearBoardingLockDriftEntries + setBoardingLockDriftLog([]) 실행.
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('debug-boarding-lock-drift-log-clear'));
+    });
+    expect(getBoardingLockDriftEntries().length).toBe(0);
+  });
+});
+
+// #2049 — dump builder와 UI section이 동일한 helper를 공유해 SSoT를 유지하는지 검증.
+describe('DebugModal — #2049 SSoT helper 검증', () => {
+  const {
+    computeAutoLockLines,
+    computeEnvironmentDistributionLines,
+    computeAlarmLogReasonsLines,
+    buildDumpText,
+  } = __test__;
+
+  it('computeAutoLockLines: meta 미전달 시 (n/a)', () => {
+    expect(computeAutoLockLines(undefined)).toEqual(['(n/a)']);
+  });
+
+  it('computeEnvironmentDistributionLines: snapshot 미전달 시 (n/a)', () => {
+    expect(computeEnvironmentDistributionLines(undefined)).toEqual(['(n/a)']);
+  });
+
+  it('computeAlarmLogReasonsLines: logs 미전달 시 (empty)', () => {
+    expect(computeAlarmLogReasonsLines([])).toEqual(['(empty)']);
+  });
+
+  it('computeAlarmLogReasonsLines: suppress reason 카운트를 라인으로 반환', () => {
+    const now = Date.now();
+    const logs: AlarmLogEntry[] = [
+      { ts: now, source: 'boarding-prompt', outcome: 'suppressed', reason: 'gate-accuracy' },
+      { ts: now - 100, source: 'boarding-prompt', outcome: 'suppressed', reason: 'gate-accuracy' },
+      { ts: now - 200, source: 'boarding-prompt', outcome: 'suppressed', reason: 'gate-accuracy' },
+    ];
+    const lines = computeAlarmLogReasonsLines(logs, now);
+    expect(lines).toContain('gate-accuracy: 3');
+  });
+
+  it('dump builder와 UI helper 라인 일치 — Auto-lock', () => {
+    // dump text의 Auto-lock section 라인과 computeAutoLockLines(meta) 결과가 완전히 동일해야 SSoT 유지.
+    type AutoLockMeta = NonNullable<Parameters<typeof buildDumpText>[0]['autoLockMeta']>;
+    const meta: AutoLockMeta = {
+      surfaceSSOTActive: true,
+      undergroundSSOTActive: false,
+      stability: { stable: true, stationId: '0201', count: 3 },
+      direction: { matched: true, reason: 'forward' as const },
+      candidate: {
+        candidate: { trainCode: '2001', line: '2', subwayId: '1002' },
+        source: 'device-ssot' as const,
+        stationId: '0201',
+        path: 'direction-matched' as const,
+      },
+      nullReason: null,
+    };
+    const helperLines = computeAutoLockLines(meta);
+    const dump = buildDumpText(makeDumpArgs({ autoLockMeta: meta }));
+    const section = dump.slice(dump.indexOf('## Auto-lock Candidate'));
+    // helper의 각 라인이 dump section 내부에 순서대로 등장.
+    let cursor = 0;
+    for (const line of helperLines) {
+      const idx = section.indexOf(line, cursor);
+      expect(idx).toBeGreaterThan(-1);
+      cursor = idx + line.length;
+    }
+  });
+});


### PR DESCRIPTION
Closes #2049

## 배경

DebugModal audit 결과, 아래 4개 섹션이 **share dump 텍스트에는 포함되지만 Modal UI render에서 누락**된 상태였습니다. 사용자가 dump 이메일을 기다리지 않고 modal에서 즉시 확인할 수 있어야 하는 진단 데이터가 UI에서 숨겨져 있었습니다.

## 누락 4 섹션

| 섹션 | Dump Builder | Modal render 현황 (변경 전) | 조치 |
|---|---|---|---|
| **Auto-lock Candidate** | `buildAutoLockSection` (#1421) | `autoLockMeta` 매 render 산출되지만 `<Section>` render 없음 | `<AutoLockCandidateSection>` 신설 |
| **Environment Distribution** | `buildEnvironmentDistributionSection` (#1430) | `envDistribution` 매 render 산출되지만 `<Section>` render 없음 | `<EnvironmentDistributionSection>` 신설 |
| **Boarding-Lock Drift** | `buildBoardingLockDriftLogSection` (#1896 RC-8) | buffer state + subscribe 없이 dead import 상태 | state + subscribe wire + `<DebugLogSection>` render + handleShare payload 추가 |
| **Alarm Log Reasons (1h)** | `buildAlarmLogReasonsSummarySection` (#1692) | 최근 1h 억제 이유 top-N 집계 UI 미노출 | `<AlarmLogReasonsSummarySection>` 신설 |

## 구현 요약

### 1) 3개 dump builder → SSoT helper 추출
`buildAutoLockSection`, `buildEnvironmentDistributionSection`, `buildAlarmLogReasonsSummarySection` 각각을 args unpack만 담당하는 thin wrapper로 변경하고, 실제 라인 계산 로직을 `computeAutoLockLines`, `computeEnvironmentDistributionLines`, `computeAlarmLogReasonsLines` helper로 추출. UI section과 dump builder가 동일 helper를 호출하므로 UI/dump 라인이 어긋날 여지가 없음.

### 2) `DumpTextSection` 공통 렌더러
sentinel line `(n/a)` / `(empty)`는 muted 톤으로 표시, 그 외 라인들은 `MonoEntry` 리스트로 노출. 3개 신규 컴포넌트가 이 렌더러를 재사용.

### 3) `Boarding-Lock Drift` 완전 wire
- `boardingLockDriftLog` state + `subscribeBoardingLockDrift` useEffect (candidate-reject와 동일 패턴)
- `handleShare` payload + deps에 `boardingLockDriftLog` 추가 (기존 SHARE_SECTIONS spec은 존재하나 payload 미주입 상태였음)
- Candidate rejects 섹션 다음에 `<DebugLogSection>` 재사용해 render (clear 버튼 포함)

## Wire-completion 5단

1. **Orphan 없음** — `subscribeBoardingLockDrift` / `getBoardingLockDriftEntries` / `clearBoardingLockDriftEntries` import된 채 미호출이었는데 이번 PR에서 caller 연결. `npm run lint:orphan` pass.
2. **V/X dashboard** — Modal UI 진단 완결도 4 section 즉시 확인 가능. share dump 이메일 대기 없이 device 진단 loop 단축.
3. **의존 PR** — A agent PR #2050 (fix/debug-modal-share-dump-missing-sections) 병렬 진행 중. 편집 라인 겹치지 않음 (본 PR은 line 1898~ state/subscribe + 2515~ render + 3222~ 신규 컴포넌트 정의; A agent PR은 다른 3 dump 섹션 wire). 둘 중 먼저 머지되는 쪽 기준으로 나머지가 rebase 필요할 수 있음.
4. **측정 plan** — 사용자 실기기 modal 열람 시 4 section 즉시 확인 가능. dump text/UI 라인 일치 SSoT 헬퍼 test로 회귀 차단.
5. **Device verify** — N/A (UI 표시만, no runtime behavior change).

## 검증

- `npm test` — 424 test suites / 9166 tests pass, coverage 100% (lines/functions/branches/statements)
- `npm run type-check` — pass
- `npm run lint:orphan` — 0 orphan
- `npm run lint` — pre-existing errors 동일 (`react/no-array-index-key` rule 미등록, 본 PR과 무관); 본 PR이 유발한 신규 error 0건

## Test 확장 (11 신규)

- `Auto-lock Candidate` / `Environment Distribution` / `Alarm Log Reasons (1h)` UI 노출 검증
- `Alarm Log Reasons (1h)`: suppressed reason 집계 표시 검증
- `Boarding-Lock Drift`: buffer push → UI 반영 + clear 버튼 → buffer 비움 통합 검증
- `computeAutoLockLines` / `computeEnvironmentDistributionLines` / `computeAlarmLogReasonsLines` sentinel branch 유닛
- `computeAlarmLogReasonsLines`: suppress reason 카운트 라인 반환
- `dump builder와 UI helper 라인 일치` (SSoT 검증) — `buildDumpText`의 Auto-lock section에 `computeAutoLockLines`의 각 라인이 순서대로 등장하는지 확인