### PR TITLE
chore(#2055): Cloudflare Workers Logs persist=false 임시 토글

### DIFF
--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -112,6 +112,10 @@ crons = ["*/1 * * * *"]
 # `wrangler tail`은 실시간 1~2분 윈도우만 잡혀 retrospective 진단 불가.
 # logs만 활성화해 invocation logs를 Workers Logs에 영구 저장, dashboard에서 조회 가능.
 # traces는 비용/성능 영향 최소화 위해 일단 비활성. 필요 시 토글.
+#
+# #2055 임시 조치: persist=false — 매 분 5개 idle log 축적으로 2000 cap 6시간 소진 회귀.
+# #2054 (idle skip + heartbeat) 배포 완료 시 persist=true 복구 검토.
+# wrangler tail 실시간 진단은 여전히 동작.
 [observability]
 enabled = false
 head_sampling_rate = 1
@@ -119,7 +123,7 @@ head_sampling_rate = 1
 [observability.logs]
 enabled = true
 head_sampling_rate = 1
-persist = true
+persist = false
 invocation_logs = true
 
 [observability.traces]


### PR DESCRIPTION
Closes #2055

## Summary
- \`backend/alarm-worker/wrangler.toml\` [observability.logs] \`persist=true\` → \`false\`
- 매 분 5개 idle log 축적으로 2000 cap 6시간 소진 회귀 즉시 차단
- \`wrangler tail\` 실시간 진단은 여전히 동작 → 진단 능력 유지
- #2054 (근본 fix: idle skip + heartbeat) 배포 완료 시 persist=true 복구 검토

## 영향
- 알람 발사, 승차 감지, silent push, fusion tier — 코드 실행 경로 무변경
- Cloudflare Workers Logs dashboard 축적만 차단
- 배포 후 즉시 반영

## Wire-completion 5단
1. **Orphan**: N/A (설정 파일 1줄 변경)
2. **V/X dashboard**: Cloudflare Workers Logs 시계열 (배포 시점 이후 flatline 예상)
3. **의존 PR**: 없음. 후속 복구는 #2054 배포 완료 시
4. **측정 plan**: 배포 5분 이내 dashboard flatline 확인 → 24h 후 재확인 (누적 0)
5. **Device verify**: N/A — 로그 저장 옵션만 변경, 실행 로직 무영향

## Test plan
- [ ] CI: Type Check & Test pass
- [ ] CI: Data Validation pass
- [ ] 배포 후 5분: Cloudflare dashboard 로그 emission 중단 확인
- [ ] \`wrangler tail\` 로 실시간 로그 여전히 출력되는지 확인