### PR TITLE
chore(#2054): backend cron 로그 idle-skip + heartbeat + jitter spike

### DIFF
--- a/backend/alarm-worker/src/__tests__/cronJitterAggregate.test.ts
+++ b/backend/alarm-worker/src/__tests__/cronJitterAggregate.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  HEARTBEAT_INTERVAL_MS,
+  JITTER_SAMPLES_MAX_LEN,
+  appendJitterSample,
+  computeJitterPercentiles,
+  readJitterSamples,
+  resetJitterSamples,
+  shouldEmitHeartbeat,
+  stampHeartbeat,
+} from '../cronJitterAggregate';
+import { InMemoryKV } from './inMemoryKv';
+
+describe('cronJitterAggregate (#2054)', () => {
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  describe('appendJitterSample + readJitterSamples', () => {
+    it('appends samples in order', async () => {
+      await appendJitterSample(kv as unknown as KVNamespace, 100);
+      await appendJitterSample(kv as unknown as KVNamespace, 200);
+      await appendJitterSample(kv as unknown as KVNamespace, 300);
+      const samples = await readJitterSamples(kv as unknown as KVNamespace);
+      expect(samples).toEqual([100, 200, 300]);
+    });
+
+    it('graceful no-op when kv is undefined', async () => {
+      await expect(appendJitterSample(undefined, 100)).resolves.toBeUndefined();
+      expect(await readJitterSamples(undefined)).toEqual([]);
+    });
+
+    it('caps samples at JITTER_SAMPLES_MAX_LEN (drops oldest)', async () => {
+      // 상한 초과 append — 첫 값이 drop 되어야.
+      for (let i = 0; i < JITTER_SAMPLES_MAX_LEN + 3; i++) {
+        await appendJitterSample(kv as unknown as KVNamespace, i);
+      }
+      const samples = await readJitterSamples(kv as unknown as KVNamespace);
+      expect(samples.length).toBe(JITTER_SAMPLES_MAX_LEN);
+      // 초기 3 값(0,1,2) 은 drop, 마지막 값은 유지.
+      expect(samples[0]).toBe(3);
+      expect(samples[samples.length - 1]).toBe(JITTER_SAMPLES_MAX_LEN + 2);
+    });
+
+    it('empty on corrupt json / non-array', async () => {
+      await (kv as unknown as KVNamespace).put('scheduled:jitter-samples', 'not-json');
+      expect(await readJitterSamples(kv as unknown as KVNamespace)).toEqual([]);
+      await (kv as unknown as KVNamespace).put('scheduled:jitter-samples', JSON.stringify({ not: 'array' }));
+      expect(await readJitterSamples(kv as unknown as KVNamespace)).toEqual([]);
+    });
+
+    it('filters non-number entries defensively', async () => {
+      await (kv as unknown as KVNamespace).put(
+        'scheduled:jitter-samples',
+        JSON.stringify([1, 'x', 2, null, 3, Number.NaN]),
+      );
+      const samples = await readJitterSamples(kv as unknown as KVNamespace);
+      expect(samples).toEqual([1, 2, 3]);
+    });
+
+    it('read graceful when kv.get throws', async () => {
+      const throwingKv = {
+        get: async () => {
+          throw new Error('kv down');
+        },
+      } as unknown as KVNamespace;
+      expect(await readJitterSamples(throwingKv)).toEqual([]);
+    });
+
+    it('append graceful when kv.put throws', async () => {
+      const throwingKv = {
+        get: async () => null,
+        put: async () => {
+          throw new Error('kv down');
+        },
+      } as unknown as KVNamespace;
+      await expect(appendJitterSample(throwingKv, 100)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('resetJitterSamples', () => {
+    it('clears samples', async () => {
+      await appendJitterSample(kv as unknown as KVNamespace, 100);
+      await resetJitterSamples(kv as unknown as KVNamespace);
+      expect(await readJitterSamples(kv as unknown as KVNamespace)).toEqual([]);
+    });
+
+    it('graceful no-op when kv is undefined', async () => {
+      await expect(resetJitterSamples(undefined)).resolves.toBeUndefined();
+    });
+
+    it('graceful when kv.delete throws', async () => {
+      const throwingKv = {
+        delete: async () => {
+          throw new Error('kv down');
+        },
+      } as unknown as KVNamespace;
+      await expect(resetJitterSamples(throwingKv)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('computeJitterPercentiles', () => {
+    it('returns null on empty input', () => {
+      expect(computeJitterPercentiles([])).toBeNull();
+    });
+
+    it('handles single sample', () => {
+      const result = computeJitterPercentiles([42]);
+      expect(result).toEqual({ p50: 42, p99: 42 });
+    });
+
+    it('returns p50 and p99 nearest-rank', () => {
+      const samples = Array.from({ length: 100 }, (_, i) => i + 1); // 1..100
+      const result = computeJitterPercentiles(samples);
+      expect(result).not.toBeNull();
+      // p50: ceil(0.5 * 100) - 1 = 49 → index 49 → value 50.
+      expect(result?.p50).toBe(50);
+      // p99: ceil(0.99 * 100) - 1 = 98 → index 98 → value 99.
+      expect(result?.p99).toBe(99);
+    });
+
+    it('sorts internally without mutating input', () => {
+      const samples = [30, 10, 20];
+      const snapshot = [...samples];
+      const result = computeJitterPercentiles(samples);
+      expect(samples).toEqual(snapshot);
+      expect(result?.p50).toBe(20);
+    });
+  });
+
+  describe('shouldEmitHeartbeat + stampHeartbeat', () => {
+    const NOW = 1_700_000_000_000;
+
+    it('returns false when kv is undefined', async () => {
+      expect(await shouldEmitHeartbeat(undefined, NOW)).toBe(false);
+    });
+
+    it('returns true when no last-heartbeat stamp exists', async () => {
+      expect(await shouldEmitHeartbeat(kv as unknown as KVNamespace, NOW)).toBe(true);
+    });
+
+    it('returns false within HEARTBEAT_INTERVAL_MS after stamp', async () => {
+      await stampHeartbeat(kv as unknown as KVNamespace, NOW);
+      expect(await shouldEmitHeartbeat(kv as unknown as KVNamespace, NOW + 60_000)).toBe(false);
+      expect(
+        await shouldEmitHeartbeat(kv as unknown as KVNamespace, NOW + HEARTBEAT_INTERVAL_MS - 1),
+      ).toBe(false);
+    });
+
+    it('returns true at/after HEARTBEAT_INTERVAL_MS since last stamp', async () => {
+      await stampHeartbeat(kv as unknown as KVNamespace, NOW);
+      expect(
+        await shouldEmitHeartbeat(kv as unknown as KVNamespace, NOW + HEARTBEAT_INTERVAL_MS),
+      ).toBe(true);
+    });
+
+    it('returns true when stamped value is corrupt (NaN)', async () => {
+      await (kv as unknown as KVNamespace).put('scheduled:last-heartbeat', 'not-a-number');
+      expect(await shouldEmitHeartbeat(kv as unknown as KVNamespace, NOW)).toBe(true);
+    });
+
+    it('returns false when kv.get throws (conservative)', async () => {
+      const throwingKv = {
+        get: async () => {
+          throw new Error('kv down');
+        },
+      } as unknown as KVNamespace;
+      expect(await shouldEmitHeartbeat(throwingKv, NOW)).toBe(false);
+    });
+
+    it('stampHeartbeat graceful when kv undefined or throws', async () => {
+      await expect(stampHeartbeat(undefined, NOW)).resolves.toBeUndefined();
+      const throwingKv = {
+        put: async () => {
+          throw new Error('kv down');
+        },
+      } as unknown as KVNamespace;
+      await expect(stampHeartbeat(throwingKv, NOW)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/backend/alarm-worker/src/__tests__/fallback.test.ts
+++ b/backend/alarm-worker/src/__tests__/fallback.test.ts
@@ -229,4 +229,34 @@ describe('runFallbackPushes (#572 P2c)', () => {
     });
     expect(stats.scanned).toBe(0);
   });
+
+  it('#2054 — idle cycle (scanned=0) suppresses `fallback run complete` log', async () => {
+    const logMessages: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    await runFallbackPushes(makeEnv(kv), {
+      apnsConfig: apnsConfig(),
+      apnsHosts: APNS_HOSTS,
+      now: () => NOW,
+      log: (msg, meta) => {
+        logMessages.push({ msg, meta });
+      },
+    });
+    expect(logMessages.some((l) => l.msg === 'fallback run complete')).toBe(false);
+  });
+
+  it('#2054 — non-idle cycle still emits `fallback run complete` log', async () => {
+    await putPending(
+      kv as unknown as KVNamespace,
+      makeEntry({ sentAt: NOW - (FALLBACK_THRESHOLD_MS - 1) }),
+    );
+    const logMessages: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    await runFallbackPushes(makeEnv(kv), {
+      apnsConfig: apnsConfig(),
+      apnsHosts: APNS_HOSTS,
+      now: () => NOW,
+      log: (msg, meta) => {
+        logMessages.push({ msg, meta });
+      },
+    });
+    expect(logMessages.some((l) => l.msg === 'fallback run complete')).toBe(true);
+  });
 });

--- a/backend/alarm-worker/src/__tests__/retryPushes.test.ts
+++ b/backend/alarm-worker/src/__tests__/retryPushes.test.ts
@@ -744,5 +744,51 @@ describe('retryPushes (#1721)', () => {
         expect(stats.rescheduled).toBe(1);
       });
     });
+
+    describe('#2054 — idle skip log', () => {
+      it('idle cycle (scanned=0) suppresses `retry-push run complete` log', async () => {
+        const logMessages: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+        const apnsFetch = vi.fn();
+        const stats = await runRetryPushes(makeEnv(kv), {
+          apnsConfig: makeApnsConfig(),
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW,
+          log: (msg, meta) => {
+            logMessages.push({ msg, meta });
+          },
+        });
+        expect(stats.scanned).toBe(0);
+        expect(logMessages.some((l) => l.msg === 'retry-push run complete')).toBe(false);
+      });
+
+      it('non-idle cycle still emits `retry-push run complete` log', async () => {
+        await kv.put(
+          'retry-push:p-log',
+          JSON.stringify({
+            pushId: 'p-log',
+            token: 'tok',
+            payload: makePayload({ pushId: 'p-log', kind: 'destination' }),
+            apnsEnv: 'sandbox',
+            attemptCount: 0,
+            nextAttemptAt: NOW,
+            originalSentAt: NOW,
+            lastErrorStatus: 429,
+          }),
+        );
+        const logMessages: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+        const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+        await runRetryPushes(makeEnv(kv), {
+          apnsConfig: makeApnsConfig(),
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW + 1,
+          log: (msg, meta) => {
+            logMessages.push({ msg, meta });
+          },
+        });
+        expect(logMessages.some((l) => l.msg === 'retry-push run complete')).toBe(true);
+      });
+    });
   });
 });

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -7811,8 +7811,8 @@ describe('runLocklessIntermediate passedStations 누적 (#1539 S6)', () => {
   });
 });
 
-describe('runScheduled cron jitter stat (#1539 S6)', () => {
-  it('stamps cronJitterMs on stats + logs it', async () => {
+describe('runScheduled cron jitter stat (#1539 S6 / #2054)', () => {
+  it('stamps cronJitterMs on stats without raw log (#2054 raw log 제거)', async () => {
     const kv = new InMemoryKV();
     const env = makeEnv(kv);
     const logMessages: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
@@ -7835,8 +7835,124 @@ describe('runScheduled cron jitter stat (#1539 S6)', () => {
     });
     const expectedJitter = computeCronJitterMs(NOW + 7_321);
     expect(stats.cronJitterMs).toBe(expectedJitter);
-    expect(logMessages.some((l) => l.msg === 'scheduled: cron jitter' && l.meta?.jitterMs === expectedJitter))
-      .toBe(true);
+    // #2054 — raw `scheduled: cron jitter` log 제거. spike 임계(45s) 미만이라 spike log 도 없음.
+    expect(logMessages.some((l) => l.msg === 'scheduled: cron jitter')).toBe(false);
+    expect(logMessages.some((l) => l.msg === 'scheduled: cron jitter spike')).toBe(false);
+  });
+
+  it('#2054 — emits `scheduled: cron jitter spike` when jitter exceeds 45s threshold', async () => {
+    const kv = new InMemoryKV();
+    const env = makeEnv(kv);
+    const logMessages: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    // 60s boundary 로부터 46_000ms 지난 시각을 강제. computeCronJitterMs 가 46_000 을 반환.
+    const spikeNow = Math.floor((NOW + 60_000) / 60_000) * 60_000 + 46_000;
+    await runScheduled(env, {
+      seoul: new SeoulArrivalClient({
+        apiKey: 'K',
+        host: 'h',
+        now: () => spikeNow,
+        fetchImpl: (async () =>
+          new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 })) as unknown as typeof fetch,
+      }),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => spikeNow,
+      log: (msg, meta) => {
+        logMessages.push({ msg, meta });
+      },
+    });
+    expect(logMessages.some((l) => l.msg === 'scheduled: cron jitter spike')).toBe(true);
+  });
+
+  it('#2054 — idle cycle (scanned=0) suppresses `scheduled run complete` log', async () => {
+    const kv = new InMemoryKV();
+    const env = makeEnv(kv);
+    const logMessages: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(env, {
+      seoul: new SeoulArrivalClient({
+        apiKey: 'K',
+        host: 'h',
+        now: () => NOW,
+        fetchImpl: (async () =>
+          new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 })) as unknown as typeof fetch,
+      }),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      log: (msg, meta) => {
+        logMessages.push({ msg, meta });
+      },
+    });
+    expect(stats.scanned).toBe(0);
+    expect(logMessages.some((l) => l.msg === 'scheduled run complete')).toBe(false);
+  });
+
+  it('#2054 — idle cycle emits `scheduled heartbeat` on first entry (no last-heartbeat stamp)', async () => {
+    const kv = new InMemoryKV();
+    const env = makeEnv(kv);
+    const logMessages: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    await runScheduled(env, {
+      seoul: new SeoulArrivalClient({
+        apiKey: 'K',
+        host: 'h',
+        now: () => NOW,
+        fetchImpl: (async () =>
+          new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 })) as unknown as typeof fetch,
+      }),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      log: (msg, meta) => {
+        logMessages.push({ msg, meta });
+      },
+    });
+    const hb = logMessages.find((l) => l.msg === 'scheduled heartbeat');
+    expect(hb).toBeDefined();
+    expect(hb?.meta?.alive).toBe(true);
+    expect(hb?.meta).toHaveProperty('jitterP50');
+    expect(hb?.meta).toHaveProperty('jitterP99');
+    expect(hb?.meta).toHaveProperty('samples');
+  });
+
+  it('#2054 — second idle cycle within 1h skips heartbeat (KV gate)', async () => {
+    const kv = new InMemoryKV();
+    const env = makeEnv(kv);
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const makeSeoul = (nowFn: () => number) =>
+      new SeoulArrivalClient({
+        apiKey: 'K',
+        host: 'h',
+        now: nowFn,
+        fetchImpl: (async () =>
+          new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 })) as unknown as typeof fetch,
+      });
+    // 1차 cycle: heartbeat 발화.
+    await runScheduled(env, {
+      seoul: makeSeoul(() => NOW),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    // 2차 cycle: 60s 후 — heartbeat gate 로 skip.
+    const secondLogs: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    await runScheduled(env, {
+      seoul: makeSeoul(() => NOW + 60_000),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW + 60_000,
+      log: (msg, meta) => {
+        secondLogs.push({ msg, meta });
+      },
+    });
+    expect(secondLogs.some((l) => l.msg === 'scheduled heartbeat')).toBe(false);
   });
 });
 

--- a/backend/alarm-worker/src/cronJitterAggregate.ts
+++ b/backend/alarm-worker/src/cronJitterAggregate.ts
@@ -1,0 +1,156 @@
+/**
+ * #2054 — cron jitter sample aggregate + scheduled heartbeat KV helpers.
+ *
+ * 배경: Cloudflare Workers Logs 가 매 cron cycle 5 개 로그를 무조건 발화 → 12h 3600+ 이벤트,
+ * 2000 cap 6h 소진. `scheduled: cron jitter` raw log 를 제거하고, 정상 jitter 값은 KV 에
+ * append 해뒀다가 시간당 1회 heartbeat 시 P50/P99 산출 + reset.
+ *
+ * 책임:
+ *  - `appendJitterSample` : 정상(≤ spike 임계) jitter 값 KV 배열 append.
+ *    KV 미바인딩 / read fail / write fail 시 모두 graceful (log skip 은 관찰 손실이지 서비스 영향 X).
+ *  - `readJitterSamples`  : heartbeat 시 배열 read (없으면 empty).
+ *  - `resetJitterSamples` : heartbeat log 발화 직후 배열 clear.
+ *  - `computeJitterPercentiles` : 순수 P50/P99 산출 (empty → null).
+ *
+ *  Heartbeat gate:
+ *  - `shouldEmitHeartbeat(kv, now)` : last-heartbeat KV timestamp 와 비교. 미존재 / >= interval 이면 true.
+ *  - `stampHeartbeat(kv, now)`       : timestamp write + TTL 7200s (2h) 로 자연 정리.
+ */
+
+const JITTER_SAMPLES_KEY = 'scheduled:jitter-samples';
+const LAST_HEARTBEAT_KEY = 'scheduled:last-heartbeat';
+
+/**
+ * jitter sample append 시 상한. cron 60s × 1h = 60 sample 이 정상.
+ * KV value 크기 방어용 상한 — spike 폭주로 samples 무한 증가 시 write 폭탄 방지.
+ */
+export const JITTER_SAMPLES_MAX_LEN = 240;
+
+/**
+ * spike 임계 (ms). 이 값 초과 시 heartbeat 대기 없이 즉시 `scheduled: cron jitter spike` log.
+ * 45s = Cloudflare scheduler 정상 부하 최대치 이상 (P99 정상 < 10s, spike 는 dashboard 육안 관측용).
+ */
+export const JITTER_SPIKE_THRESHOLD_MS = 45_000;
+
+/**
+ * heartbeat 간격 (ms). idle 시 이 간격마다 1회 `scheduled heartbeat` log 발화.
+ * 1h = 이슈 요구사항. cron 60s cycle 60 회당 1 회 heartbeat.
+ */
+export const HEARTBEAT_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * heartbeat KV TTL (초). interval 의 2 배 = 7200s. 만료돼도 다음 cycle 이 자연 재stamp.
+ */
+export const HEARTBEAT_KV_TTL_SEC = 7200;
+
+/**
+ * jitter samples KV TTL (초). heartbeat 발화되지 않아도 자연 정리되도록 24h.
+ */
+export const JITTER_SAMPLES_KV_TTL_SEC = 24 * 60 * 60;
+
+/** 정상 jitter sample 을 KV 배열에 append. graceful (KV 없음/실패 무시). */
+export async function appendJitterSample(
+  kv: KVNamespace | undefined,
+  jitterMs: number,
+): Promise<void> {
+  if (!kv) return;
+  try {
+    const samples = await readJitterSamples(kv);
+    samples.push(jitterMs);
+    // 상한 초과 시 oldest drop — write 크기 방어.
+    if (samples.length > JITTER_SAMPLES_MAX_LEN) {
+      samples.splice(0, samples.length - JITTER_SAMPLES_MAX_LEN);
+    }
+    await kv.put(JITTER_SAMPLES_KEY, JSON.stringify(samples), {
+      expirationTtl: JITTER_SAMPLES_KV_TTL_SEC,
+    });
+  } catch {
+    // KV I/O 실패는 관찰 손실 — 서비스 영향 X, silent skip.
+  }
+}
+
+/** 저장된 jitter samples 배열 read. 없거나 손상 시 empty. */
+export async function readJitterSamples(kv: KVNamespace | undefined): Promise<number[]> {
+  if (!kv) return [];
+  try {
+    const raw = await kv.get(JITTER_SAMPLES_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is number => typeof v === 'number' && Number.isFinite(v));
+  } catch {
+    return [];
+  }
+}
+
+/** heartbeat 발화 직후 samples clear. */
+export async function resetJitterSamples(kv: KVNamespace | undefined): Promise<void> {
+  if (!kv) return;
+  try {
+    await kv.delete(JITTER_SAMPLES_KEY);
+  } catch {
+    // silent
+  }
+}
+
+/**
+ * P50 / P99 산출. 입력 배열은 mutate 하지 않는다 (호출자 재사용 가능).
+ * empty → null.
+ *
+ * 단순 nearest-rank percentile — sort 후 index = ceil(p * n) - 1.
+ * n = 1 시 두 값 모두 유일 element.
+ */
+export function computeJitterPercentiles(
+  samples: readonly number[],
+): { p50: number; p99: number } | null {
+  if (samples.length === 0) return null;
+  const sorted = [...samples].sort((a, b) => a - b);
+  return {
+    p50: pickPercentile(sorted, 0.5),
+    p99: pickPercentile(sorted, 0.99),
+  };
+}
+
+function pickPercentile(sortedAsc: readonly number[], p: number): number {
+  const idx = Math.max(0, Math.ceil(p * sortedAsc.length) - 1);
+  return sortedAsc[Math.min(idx, sortedAsc.length - 1)];
+}
+
+/**
+ * heartbeat 발화 gate. last-heartbeat KV timestamp 기준:
+ *  - KV 미바인딩 → false (heartbeat log skip. idle idle log 폭발 방지).
+ *  - stamp 미존재 → true (첫 emission).
+ *  - `now - lastAt >= HEARTBEAT_INTERVAL_MS` → true.
+ *
+ * 손상 JSON / KV read 실패 → false (안전 방향). read 는 cacheTtl 미지정 (KV 기본 60s).
+ */
+export async function shouldEmitHeartbeat(
+  kv: KVNamespace | undefined,
+  now: number,
+): Promise<boolean> {
+  if (!kv) return false;
+  try {
+    const raw = await kv.get(LAST_HEARTBEAT_KEY);
+    if (!raw) return true;
+    const lastAt = Number.parseInt(raw, 10);
+    if (!Number.isFinite(lastAt)) return true;
+    return now - lastAt >= HEARTBEAT_INTERVAL_MS;
+  } catch {
+    return false;
+  }
+}
+
+/** heartbeat 발화 직후 last-heartbeat timestamp stamp. TTL 2h. */
+export async function stampHeartbeat(
+  kv: KVNamespace | undefined,
+  now: number,
+): Promise<void> {
+  if (!kv) return;
+  try {
+    await kv.put(LAST_HEARTBEAT_KEY, String(now), {
+      expirationTtl: HEARTBEAT_KV_TTL_SEC,
+    });
+  } catch {
+    // silent
+  }
+}

--- a/backend/alarm-worker/src/fallback.ts
+++ b/backend/alarm-worker/src/fallback.ts
@@ -90,7 +90,11 @@ export async function runFallbackPushes(env: Env, deps: FallbackDeps): Promise<F
     }
   }
 
-  log('fallback run complete', { ...stats });
+  // #2054 — idle skip. scanned=0 (pending queue empty) 시 로그 억제. Cloudflare Workers Logs
+  // cap 소진 방지. 활성 pending 있을 땐 기존대로 상세 log.
+  if (stats.scanned > 0) {
+    log('fallback run complete', { ...stats });
+  }
   return stats;
 }
 

--- a/backend/alarm-worker/src/retryPushes.ts
+++ b/backend/alarm-worker/src/retryPushes.ts
@@ -287,6 +287,10 @@ export async function runRetryPushes(env: Env, deps: RetryPushDeps): Promise<Ret
       });
     }
   }
-  log('retry-push run complete', { ...stats });
+  // #2054 — idle skip. scanned=0 (retry queue empty) 시 로그 억제. Cloudflare Workers Logs
+  // cap(2000/cycle 5 로그) 소진 방지. 활성 retry 있을 땐 기존대로 상세 log.
+  if (stats.scanned > 0) {
+    log('retry-push run complete', { ...stats });
+  }
   return stats;
 }

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -102,6 +102,15 @@ import {
   isSimpleArchEnabled,
   stampArvlCdFireOnce,
 } from './arvlcdFireOnceTtl';
+import {
+  appendJitterSample,
+  computeJitterPercentiles,
+  JITTER_SPIKE_THRESHOLD_MS,
+  readJitterSamples,
+  resetJitterSamples,
+  shouldEmitHeartbeat,
+  stampHeartbeat,
+} from './cronJitterAggregate';
 
 // pickApnsHost / flipApnsEnv는 ./apnsHost로 이동 (liveActivity.ts와 공유 SSOT, #482).
 // 외부(테스트 / index.ts 등)가 scheduled.ts 경유로 import하던 호환성 유지를 위해 re-export.
@@ -955,8 +964,16 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       stationUnknown: 0,
     },
   };
-  // #1539 (S6) — cron jitter 즉시 log. 누적 stat이 아니라 매 cycle 1줄 → tail에서 P50/P99 산출.
-  log('scheduled: cron jitter', { jitterMs: stats.cronJitterMs });
+  // #2054 — jitter raw log 제거. spike 임계 초과 시만 즉시 로그, 정상 값은 KV samples append 후
+  // heartbeat 시 P50/P99 산출. Cloudflare Workers Logs cap(2000 events / cycle 5 로그) 소진 방지.
+  if (stats.cronJitterMs > JITTER_SPIKE_THRESHOLD_MS) {
+    log('scheduled: cron jitter spike', {
+      jitterMs: stats.cronJitterMs,
+      thresholdMs: JITTER_SPIKE_THRESHOLD_MS,
+    });
+  } else {
+    await appendJitterSample(env.TRIPS, stats.cronJitterMs);
+  }
 
   // #1614 Phase A (S4 #1537) — 활성 trip line union 추출 + Seoul realtimePosition 전수 self-poll.
   // 1차 iterate: 활성 trip의 route + waypoints에서 line set 수집 (computeAllowedLines 활용 — 환승
@@ -1174,10 +1191,25 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     }
   }
 
-  log('scheduled run complete', {
-    ...stats,
-    seoulCalls: deps.seoul.stats.callCount,
-  });
+  // #2054 — idle skip + heartbeat. scanned=0 (활성 trip 없음) 시 매 cycle 로그를 억제하고,
+  // 시간당 1회 `scheduled heartbeat` 로 halt 감지 능력만 유지. 활성 trip 있을 땐 기존대로 상세 log.
+  if (stats.scanned > 0) {
+    log('scheduled run complete', {
+      ...stats,
+      seoulCalls: deps.seoul.stats.callCount,
+    });
+  } else if (await shouldEmitHeartbeat(env.TRIPS, now)) {
+    const samples = await readJitterSamples(env.TRIPS);
+    const percentiles = computeJitterPercentiles(samples);
+    log('scheduled heartbeat', {
+      alive: true,
+      jitterP50: percentiles?.p50 ?? null,
+      jitterP99: percentiles?.p99 ?? null,
+      samples: samples.length,
+    });
+    await stampHeartbeat(env.TRIPS, now);
+    await resetJitterSamples(env.TRIPS);
+  }
 
   // #1779 — LA push 도달률 Analytics Engine forward.
   // cron cycle 합산(laPushSent / laPushFailed)을 단일 la-push 이벤트로 적재.


### PR DESCRIPTION
Closes #2054

## Summary
- `scheduled: cron jitter` raw log 제거 → 정상 jitter는 KV `scheduled:jitter-samples` append, `>45s` spike 시만 즉시 `scheduled: cron jitter spike` 로그
- `scheduled run complete` / `retry-push run complete` / `fallback run complete` — `stats.scanned === 0` 시 로그 skip
- Idle cycle에 시간당 1회 `scheduled heartbeat { alive, jitterP50, jitterP99, samples }` — KV `scheduled:last-heartbeat` gate (TTL 7200s), 발화 직후 samples reset
- 신규 util `cronJitterAggregate.ts` — append/read/reset + P50/P99 (nearest-rank) + heartbeat gate/stamp (graceful, KV I/O 실패 silent)

## Wire-completion 5단
1. **Orphan**: `npm run lint:orphan` pass (신규 exports 모두 scheduled.ts caller 존재)
2. **V/X dashboard**: Cloudflare Workers Logs 대시보드 시계열 (전/후 비교). 예상 감소율 95%+ (idle 시 5→0 로그/cycle, 시간당 1 heartbeat)
3. **의존 PR**: #2056 (persist=false 임시 토글, dev 머지 대기)
4. **측정 plan**: 배포 후 1주 관찰
   - 로그량 하루 30~500건 (idle 다수 or trip 활성)
   - Heartbeat gap > 90분 발생 여부 (halt 감지 유지)
   - `scheduled: cron jitter spike` 발생 분포
5. **Device verify**: N/A — backend 로그 emission만 변경, device 통신/알람 발사 로직 무영향

## Test plan
- [x] backend type-check pass (`npx tsc --noEmit`)
- [x] backend test suite pass (2624/2624, cronJitterAggregate 21 신규 케이스)
- [x] `npm run lint:orphan` pass
- [ ] CI: Type Check & Test pass
- [ ] CI: Data Validation pass