### PR TITLE
docs: CLAUDE.md ADR 경로 정정 (docs/adr/ → docs/decisions/)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Default vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-
 
 ### Domain docs
 
-Single-context — `docs/adr/` at repo root. See `docs/agents/domain.md`.
+Single-context — `docs/decisions/` at repo root (ADR-001~). See `docs/agents/domain.md`.
 
 ---
 


### PR DESCRIPTION
## 변경
CLAUDE.md Domain docs 섹션의 ADR 경로를 `docs/adr/` → `docs/decisions/`로 정정.

## 근거
- 실제 ADR 코퍼스는 `docs/decisions/` (ADR-001~ADR-023 소재, git 추적됨)
- `docs/adr/`는 `.gitignore:69 docs/*` 대상 + 미존재 — 이 낡은 표기가 이슈 #2065 본문 오기를 유발 (에이전트 audit으로 발견, 이슈는 정정 완료)

## 비고
asset-only(문서 1줄) PR — 이슈 생략 룰 적용. Wire-completion: N/A (docs only)