### PR TITLE
refactor(#2070): fusion 지하 위치 신호 재정의 - 품질 게이트 + 지하 진입 이벤트 + 폴링 하향

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.gpsQualityGate.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.gpsQualityGate.test.ts
@@ -1,0 +1,130 @@
+/* eslint-disable import/no-restricted-paths -- cross-feature orchestration integration test (#890) */
+
+/**
+ * #2070 — useNearestStation이 자체 산출한 gpsQualityDegraded가 useFusedNearestStation의
+ * inferEnvironment 호출에 추가 입력으로 전달됨을 검증. barometer/SSOT 명시 판정이 없는
+ * (subsurface===undefined, 두 SSOT 무판정) 구간에서만 관여하고, 다른 판정(surfaceSSOT 등)이
+ * 있으면 여전히 그 결과가 우선한다.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useFusedNearestStation } from '../useFusedNearestStation';
+import { useNearestStation } from '../useNearestStation';
+import { useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
+import { useTrainPositions } from '../../../route/hooks/useTrainPositions';
+import { findTopNearestStations } from '../../utils/findNearestStation';
+import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute';
+import { arrivalRet, positionRet, GPS_BASE_DEFAULTS } from '../../../../testUtils/positionApiFixtures';
+import {
+  BACKEND_SSOT_FIXTURE_T0 as T0,
+  flushBackendSsotMirrorTick,
+  makeBackendSsotMirrorEntry,
+} from '../../../../testUtils/backendSsotMirrorFixtures';
+import { readBackendSsotMirror } from '../../../alarm/utils/backendSsotMirror';
+
+jest.mock('../../utils/findNearestStation', () => ({
+  findTopNearestStations: jest.fn(),
+}));
+jest.mock('../useNearestStation');
+jest.mock('../../../arrival/hooks/useArrivalInfo');
+jest.mock('../../../route/hooks/useTrainPositions');
+jest.mock('../../../alarm/utils/tripStartStorage', () => ({
+  getTripStartedAt: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../../../alarm/utils/backendSsotMirror', () => ({
+  readBackendSsotMirror: jest.fn(),
+}));
+
+const mockNearest = useNearestStation as jest.Mock;
+const mockArrival = useArrivalInfo as jest.Mock;
+const mockPos = useTrainPositions as jest.Mock;
+const mockFindTop = findTopNearestStations as jest.Mock;
+const mockRead = readBackendSsotMirror as jest.Mock;
+
+const hanyangdae = findStationByNameAndLine('한양대', '2')!;
+const ttukssom = findStationByNameAndLine('뚝섬', '2')!;
+
+function setupNearest(gpsQualityDegraded: boolean): void {
+  const live = { station: hanyangdae, distanceKm: 0.05 };
+  mockNearest.mockReturnValue({
+    result: live,
+    liveResult: live,
+    stickyDisplayOnly: null,
+    variants: [hanyangdae],
+    userLocation: { lat: hanyangdae.lat, lng: hanyangdae.lng },
+    ...GPS_BASE_DEFAULTS,
+    accuracyMeters: 200, // surfaceSSOT/undergroundSSOT 둘 다 미합의 (부정확 GPS)
+    lastFixAtMs: T0,
+    gpsQualityDegraded,
+    refresh: jest.fn(),
+  });
+  mockFindTop.mockReturnValue([{ station: hanyangdae, distanceKm: 0.05 }]);
+  mockArrival.mockReturnValue(arrivalRet(null));
+  mockPos.mockReturnValue(positionRet(null));
+}
+
+describe('#2070 useFusedNearestStation — gpsQualityDegraded → inferEnvironment 추가 입력', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(T0);
+    // backend mirror는 다른 역으로 fresh하게 세팅 — cascade tier 1/2 미진입 시 fallback 확인.
+    mockRead.mockResolvedValue(
+      makeBackendSsotMirrorEntry({
+        currentStationId: ttukssom.name,
+        lastAdvanceAt: T0,
+        receivedAt: T0,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('subsurface 미전달 + SSOT 무판정 + gpsQualityDegraded=true → environment=underground (hint gps-quality-drop)', async () => {
+    setupNearest(true);
+
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushBackendSsotMirrorTick();
+
+    await waitFor(() => {
+      expect(hook.result.current.environment).toBe('underground');
+    });
+    expect(hook.result.current.environmentHintReason).toBe('gps-quality-drop');
+  });
+
+  it('subsurface 미전달 + SSOT 무판정 + gpsQualityDegraded=false → environment=unknown (기존 동작 보존)', async () => {
+    setupNearest(false);
+
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushBackendSsotMirrorTick();
+
+    await waitFor(() => {
+      expect(hook.result.current.environment).toBe('unknown');
+    });
+    expect(hook.result.current.environmentHintReason).toBeUndefined();
+  });
+
+  it('barometer.subsurface=false 명시 시 gpsQualityDegraded=true여도 surface 우선 (기존 판정 대체 아님)', async () => {
+    setupNearest(true);
+
+    const hook = renderHook(() =>
+      useFusedNearestStation(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { subsurface: false },
+      ),
+    );
+    await flushBackendSsotMirrorTick();
+
+    await waitFor(() => {
+      expect(hook.result.current.environment).toBe('surface');
+    });
+    expect(hook.result.current.environmentHintReason).toBeUndefined();
+  });
+});

--- a/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
@@ -1601,6 +1601,157 @@ describe('useNearestStation — #1313 subsurface GPS throttle', () => {
   });
 });
 
+describe('useNearestStation — #2070 GPS 품질 게이트 (결정 tier 입력)', () => {
+  // 지상 기본값: High@2s. 지하 throttle: High@12s. #1313 describe와 동일 값 — 매직넘버 회피 위해
+  // 상수에서 가져온다(#2070은 barometerSubsurface OR gpsQualityDegraded로 트리거를 확장).
+  const SURFACE_OPTIONS = {
+    accuracy: Location.Accuracy.High,
+    distanceInterval: 0,
+    timeInterval: FG_WATCH_SURFACE_TIME_INTERVAL_MS,
+  };
+  const SUBSURFACE_OPTIONS = {
+    accuracy: Location.Accuracy.High,
+    distanceInterval: 0,
+    timeInterval: FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS,
+  };
+  const originalCurrentState = AppState.currentState;
+
+  const lastWatchOptions = () => {
+    const calls = (Location.watchPositionAsync as jest.Mock).mock.calls;
+    return calls[calls.length - 1][0];
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await AsyncStorage.clear();
+    appStateCallback = null;
+    watchCallback = null;
+    mockNoLastKnownLocation();
+    mockSubscription.remove.mockClear();
+    (Location.watchPositionAsync as jest.Mock).mockImplementation(
+      async (_options: unknown, callback: typeof watchCallback) => {
+        watchCallback = callback;
+        return mockSubscription;
+      },
+    );
+    mockGranted();
+    (AppState as { currentState: string }).currentState = 'active';
+  });
+
+  afterEach(() => {
+    (AppState as { currentState: string }).currentState = originalCurrentState;
+  });
+
+  it('표시 게이트(250m)는 통과하지만 품질 게이트(100m) 미달 fix는 gps-quality-drop:accuracy를 남긴다', async () => {
+    const { clearGpsDropEntries, getGpsDropEntries } =
+      jest.requireActual('../../utils/gpsDropBuffer');
+    clearGpsDropEntries();
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    simulateGps(37.498, 127.0277, { accuracy: 150 });
+
+    // 표시/결과는 그대로 갱신 — 결정 tier 제외는 gpsQualityDegraded/gps-drop 로그로 별도 노출.
+    expect(result.current.userLocation).not.toBeNull();
+    const drops = getGpsDropEntries();
+    expect(drops).toHaveLength(1);
+    expect(drops[0].dropReason).toBe('gps-quality-drop:accuracy');
+    // 콜드스타트(직전 통과 기록 없음) — false positive 방지로 아직 degraded=false.
+    expect(result.current.gpsQualityDegraded).toBe(false);
+  });
+
+  it('accuracy는 통과하지만 fix가 15s 이상 오래되면 gps-quality-drop:stale', async () => {
+    const { clearGpsDropEntries, getGpsDropEntries } =
+      jest.requireActual('../../utils/gpsDropBuffer');
+    clearGpsDropEntries();
+    renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    simulateGps(37.498, 127.0277, { accuracy: 50, timestamp: Date.now() - 16_000 });
+
+    const drops = getGpsDropEntries();
+    expect(drops).toHaveLength(1);
+    expect(drops[0].dropReason).toBe('gps-quality-drop:stale');
+  });
+
+  it('게이트 통과 fix 이후 accuracy가 100m 초과 급락하면 gpsQualityDegraded=true', async () => {
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    simulateGps(37.498, 127.0277, { accuracy: 50 });
+    expect(result.current.gpsQualityDegraded).toBe(false);
+
+    simulateGps(37.4981, 127.0278, { accuracy: 200 });
+    expect(result.current.gpsQualityDegraded).toBe(true);
+  });
+
+  it('급락 후 다시 게이트 통과 fix가 들어오면 gpsQualityDegraded=false로 원복된다', async () => {
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    simulateGps(37.498, 127.0277, { accuracy: 50 });
+    simulateGps(37.4981, 127.0278, { accuracy: 200 });
+    expect(result.current.gpsQualityDegraded).toBe(true);
+
+    simulateGps(37.4982, 127.0279, { accuracy: 50 });
+    expect(result.current.gpsQualityDegraded).toBe(false);
+  });
+
+  it('게이트 통과 fix가 30s 이상 없으면(부재) gpsQualityDegraded=true', async () => {
+    const { state, restore } = setupGpsDropFakeNow();
+    try {
+      const { result } = renderHook(() => useNearestStation());
+      await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+      simulateGps(37.498, 127.0277, { accuracy: 50, timestamp: state.fakeNow });
+      expect(result.current.gpsQualityDegraded).toBe(false);
+
+      state.fakeNow += 31_000;
+      // 급락은 아닌(70m 상승, 100m 미만) accuracy로도 부재 조건만으로 degraded 전이.
+      simulateGps(37.4981, 127.0278, { accuracy: 120, timestamp: state.fakeNow });
+
+      expect(result.current.gpsQualityDegraded).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  it('degraded 발생 시 FG watch가 지하 프로파일(High@12s)로 전환되고, 게이트 통과 fix 재등장 시 지상으로 원복된다', async () => {
+    renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1));
+    expect(lastWatchOptions()).toEqual(SURFACE_OPTIONS);
+
+    simulateGps(37.498, 127.0277, { accuracy: 50 });
+    simulateGps(37.4981, 127.0278, { accuracy: 200 }); // 급락 → degraded=true
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(2));
+    expect(lastWatchOptions()).toEqual(SUBSURFACE_OPTIONS);
+
+    simulateGps(37.4982, 127.0279, { accuracy: 50 }); // 게이트 통과 → 원복
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(3));
+    expect(lastWatchOptions()).toEqual(SURFACE_OPTIONS);
+  });
+
+  it('barometerSubsurface=true가 이미 활성이면 gpsQualityDegraded 변화만으로는 재시작하지 않는다 (이미 지하 프로파일)', async () => {
+    const { rerender } = renderHook(
+      ({ sub }: { sub: boolean }) => useNearestStation({ barometerSubsurface: sub }),
+      { initialProps: { sub: true } },
+    );
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1));
+    expect(lastWatchOptions()).toEqual(SUBSURFACE_OPTIONS);
+
+    await act(async () => {
+      rerender({ sub: true });
+    });
+    simulateGps(37.498, 127.0277, { accuracy: 50 });
+    simulateGps(37.4981, 127.0278, { accuracy: 200 }); // degraded=true여도 이미 subsurface 프로파일
+
+    // barometerSubsurface=true가 이미 throttle=true를 만들었으므로 추가 재시작 없음.
+    expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('useNearestStation — #1363 sticky input memo 안정성 (cascade 차단)', () => {
   // useStickyStation에 전달되는 fix/motion object가 inline literal이면 매 render 새 ref가 되어
   // sticky 평가 effect가 매 render 재실행 → 9시간 trip ~16만회 emit. useMemo로 안정화되면

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -1148,12 +1148,16 @@ export function useFusedNearestStation(
     tripStartedAt: boardingLock?.boardedAt,
   });
   // #1860 — 옵션 C barometer-stop 힌트. tripActive + barometerStop 전달.
+  // #2070 — GPS 품질 저하 transition(gps.gpsQualityDegraded) 추가 입력. useNearestStation이
+  // raw fix 스트림만으로 자체 판정한 값을 그대로 전달 — 기존 barometer/SSOT 판정을 대체하지 않고
+  // SSOT 무판정 구간(우선순위 8)에만 관여한다.
   const cascadeEnvironmentResult: InferEnvironmentResult = inferEnvironment({
     subsurface: barometerSubsurface,
     surfaceSSOT: cascadeSurfaceSSOT !== null,
     undergroundSSOT: cascadeUndergroundSSOT !== null,
     tripActive,
     barometerStop: barometerSignal?.stop,
+    qualityDegraded: gps.gpsQualityDegraded,
   });
   // #1932 — cascade tier 1/2가 직접 read하는 environment 변수.
   // 후속 cascade-wide post-section(L1378~)에서도 동일 값 재사용 (분산 산출 0건 SSOT).

--- a/src/features/nearest-station/hooks/useNearestStation.ts
+++ b/src/features/nearest-station/hooks/useNearestStation.ts
@@ -32,6 +32,11 @@ import { pushFusionDebugEntry } from '../utils/fusionDebugBuffer';
 import { pushGpsDropEntry } from '../utils/gpsDropBuffer';
 import { haversine } from '../../../shared/utils/haversine';
 import { useStickyStation } from './useStickyStation';
+import {
+  isGpsQualityGateAcceptable,
+  gpsQualityDropReason,
+  isGpsQualityDegradedTransition,
+} from '../utils/gpsQualityGate';
 
 /** #876 — useNearestStation 표시값의 출처. sticky lock된 역이면 'sticky', 아니면 GPS live.
  *  알람 트리거에는 영향 없음 — 호출자가 출처별 UX(예: "탑승 전 추정")를 분기할 수 있게 노출. */
@@ -124,6 +129,11 @@ interface UseNearestStationReturn {
   // #852: 마지막 신뢰 fix epoch ms. BG 진입 후 새 fix가 없으면 이 시각은 정지.
   // null = 한 번도 fix 없음(cold start). 디버그 모달 표기용.
   lastFixAtMs: number | null;
+  // #2070 — fusion 결정 tier 품질 게이트(100m/15s) 저하 transition 여부. 직전 게이트 통과 fix
+  // 대비 accuracy 급락(>100m) 또는 게이트 통과 fix 30s 부재 시 true. 호출자(useFusedNearestStation)가
+  // inferEnvironment의 추가 입력으로 사용 — 지하 진입 후보 신호이며, FG watch 폴링 프로파일도
+  // 이 값으로 지하 프로파일 전환/원복된다.
+  gpsQualityDegraded: boolean;
   // #876: result 출처. sticky lock된 역이면 'sticky', live GPS 최근접이면 'live'.
   // 호출자가 출처별 UX(예: 라벨 "탑승 전 추정")로 분기 가능. 알람 트리거에는 영향 없음.
   source: NearestStationSource;
@@ -237,6 +247,12 @@ export function useNearestStation(
     timestamps: [],
     skipped: 0,
   });
+  // #2070 — fusion 결정 tier 품질 게이트(100m/15s) SSOT. 직전 게이트 통과 fix의 accuracy/시각을
+  // ref로 들고 있다가 급락(>100m)/30s 부재 판정에 사용한다. gpsQualityDegraded는 폴링 프로파일
+  // 전환 effect의 deps로 쓰여야 해서 state로 노출한다.
+  const qualityGateLastPassAccuracyRef = useRef<number | null>(null);
+  const qualityGateLastPassAtRef = useRef<number | null>(null);
+  const [gpsQualityDegraded, setGpsQualityDegraded] = useState(false);
 
   const applyLocation = useCallback((coords: Location.LocationObjectCoords, timestamp: number) => {
     const { latitude, longitude, speed, accuracy } = coords;
@@ -273,6 +289,34 @@ export function useNearestStation(
       lastDistanceRef.current = newDistance;
       applyNearestResult(stationsResult, setResult, setVariants);
     }
+    // #2070 — fusion 결정 tier 품질 게이트. 기존 표시 게이트(MAX_ACCURACY_M_DISPLAY=250m)는
+    // 통과했지만 결정 tier 입력 기준(100m/15s)에는 못 미치는 fix를 판별한다. userLocation/
+    // accuracyMeters/result 자체는 그대로 노출(표시 동작 불변) — 결정 tier 소비자
+    // (useFusedNearestStation)가 gpsQualityDegraded를 별도로 참고해 판단한다.
+    const qualityGateNow = Date.now();
+    const qualityAgeMs = qualityGateNow - timestamp;
+    if (isGpsQualityGateAcceptable(accuracy, qualityAgeMs)) {
+      qualityGateLastPassAccuracyRef.current = accuracy;
+      qualityGateLastPassAtRef.current = qualityGateNow;
+      setGpsQualityDegraded((prev) => (prev ? false : prev));
+    } else {
+      pushGpsDropEntry({
+        ts: qualityGateNow,
+        lat: latitude,
+        lng: longitude,
+        accuracyMeters: accuracy ?? null,
+        speedMps: isValidGpsSpeedMps(speed) ? speed : null,
+        dropReason: `gps-quality-drop:${gpsQualityDropReason(accuracy, qualityAgeMs)}`,
+      });
+      const degraded = isGpsQualityDegradedTransition(
+        qualityGateLastPassAccuracyRef.current,
+        qualityGateLastPassAtRef.current,
+        accuracy,
+        qualityGateNow,
+      );
+      setGpsQualityDegraded((prev) => (prev === degraded ? prev : degraded));
+    }
+
     // 측정(#443): station 변화 시에만 push. 매 fix는 너무 자주 — 점프 시퀀스
     // (사가정→을지로4가→용마산) 재구성엔 station 단위면 충분.
     if (stationChanged || noStation) {
@@ -544,14 +588,19 @@ export function useNearestStation(
   //  - throttle boolean이 실제로 바뀐 경우만 동작 → mount 시 중복 start 방지 + warmup(undefined)→false no-op.
   //  - AppState 'active'일 때만 재시작 → BG 중 flip이 FG watch를 켜 'background'→stopWatch 규약을 깨는 것 방지.
   //    (FG 복귀 시 'active' 핸들러의 refresh→startWatch가 ref를 읽어 현재 옵션으로 자연 반영.)
+  //
+  // #2070 — 지하 프로파일 트리거를 barometerSubsurface OR gpsQualityDegraded로 확장. 기존
+  // FG_WATCH_OPTIONS_SUBSURFACE를 그대로 재사용한다(barometer 확정 지하와 배터리 절감 목적이
+  // 동일 — 신규 profile 값을 중복 정의하지 않는다). gpsQualityDegraded가 false로 복귀하면(품질
+  // 게이트 통과 fix 재등장) barometerSubsurface도 true가 아닌 한 지상 프로파일로 원복된다.
   useEffect(() => {
-    const next = inputs.barometerSubsurface === true;
+    const next = inputs.barometerSubsurface === true || gpsQualityDegraded;
     if (next === throttledRef.current) return;
     throttledRef.current = next;
     if (AppState.currentState !== 'active') return;
     stopWatch();
     void startWatch();
-  }, [inputs.barometerSubsurface, startWatch, stopWatch]);
+  }, [inputs.barometerSubsurface, gpsQualityDegraded, startWatch, stopWatch]);
 
   // #876 — 매 fix를 sticky 훅에 전달. lock된 역이 있으면 result를 그것으로 override.
   // fusion candidates는 useFusedNearestStation에서 userLocation 기반으로 별도 계산하므로 영향 없음.
@@ -629,6 +678,7 @@ export function useNearestStation(
     locationUncertain,
     gpsActive,
     lastFixAtMs,
+    gpsQualityDegraded,
     source: exposed.source,
     refresh,
     requestCurrentLocation,

--- a/src/features/nearest-station/utils/__tests__/gpsQualityGate.test.ts
+++ b/src/features/nearest-station/utils/__tests__/gpsQualityGate.test.ts
@@ -1,0 +1,112 @@
+import {
+  isGpsQualityGateAcceptable,
+  gpsQualityDropReason,
+  isGpsQualityJumpDegraded,
+  isGpsQualityAbsenceDegraded,
+  isGpsQualityDegradedTransition,
+} from '../gpsQualityGate';
+
+describe('isGpsQualityGateAcceptable — #2070 경계값 (accuracy 99/100/101m x age 14/15/16s)', () => {
+  it.each([
+    [99, 14_000, true],
+    [99, 15_000, false],
+    [99, 16_000, false],
+    [100, 14_000, false],
+    [100, 15_000, false],
+    [100, 16_000, false],
+    [101, 14_000, false],
+    [101, 15_000, false],
+    [101, 16_000, false],
+  ])('accuracy=%dm age=%dms → %s', (accuracy, ageMs, expected) => {
+    expect(isGpsQualityGateAcceptable(accuracy, ageMs)).toBe(expected);
+  });
+
+  it('accuracy=null → false (미측정은 통과 불가)', () => {
+    expect(isGpsQualityGateAcceptable(null, 0)).toBe(false);
+  });
+
+  it('accuracy=undefined → false', () => {
+    expect(isGpsQualityGateAcceptable(undefined, 0)).toBe(false);
+  });
+});
+
+describe('gpsQualityDropReason', () => {
+  it('accuracy=null → accuracy', () => {
+    expect(gpsQualityDropReason(null, 0)).toBe('accuracy');
+  });
+
+  it('accuracy=100(임계 이상) → accuracy', () => {
+    expect(gpsQualityDropReason(100, 0)).toBe('accuracy');
+  });
+
+  it('accuracy 통과 + age=15000(임계 이상) → stale', () => {
+    expect(gpsQualityDropReason(50, 15_000)).toBe('stale');
+  });
+
+  it('accuracy 통과 + age 통과(전제 위반 방어) → stale fallback', () => {
+    expect(gpsQualityDropReason(50, 1_000)).toBe('stale');
+  });
+});
+
+describe('isGpsQualityJumpDegraded', () => {
+  it('직전 통과 기록 없음 → false', () => {
+    expect(isGpsQualityJumpDegraded(null, 300)).toBe(false);
+  });
+
+  it('현재 accuracy 없음 → false', () => {
+    expect(isGpsQualityJumpDegraded(50, null)).toBe(false);
+    expect(isGpsQualityJumpDegraded(50, undefined)).toBe(false);
+  });
+
+  it('급락 100m 초과 → true', () => {
+    expect(isGpsQualityJumpDegraded(50, 151)).toBe(true);
+  });
+
+  it('급락 정확히 100m(경계) → false (초과만 인정)', () => {
+    expect(isGpsQualityJumpDegraded(50, 150)).toBe(false);
+  });
+
+  it('급락 100m 미만 → false', () => {
+    expect(isGpsQualityJumpDegraded(50, 100)).toBe(false);
+  });
+});
+
+describe('isGpsQualityAbsenceDegraded', () => {
+  it('통과 기록 없음(콜드스타트) → false', () => {
+    expect(isGpsQualityAbsenceDegraded(null, 100_000)).toBe(false);
+  });
+
+  it('30s 미만 경과 → false', () => {
+    expect(isGpsQualityAbsenceDegraded(0, 29_999)).toBe(false);
+  });
+
+  it('정확히 30s 경과(경계) → true', () => {
+    expect(isGpsQualityAbsenceDegraded(0, 30_000)).toBe(true);
+  });
+
+  it('30s 초과 경과 → true', () => {
+    expect(isGpsQualityAbsenceDegraded(0, 30_001)).toBe(true);
+  });
+});
+
+describe('isGpsQualityDegradedTransition — #2070 급락/부재 발생·미발생', () => {
+  it('급락만 발생 → true', () => {
+    expect(isGpsQualityDegradedTransition(50, 0, 200, 1_000)).toBe(true);
+  });
+
+  it('부재만 발생 → true', () => {
+    expect(isGpsQualityDegradedTransition(50, 0, 60, 30_000)).toBe(true);
+  });
+
+  it('둘 다 발생 → true', () => {
+    expect(isGpsQualityDegradedTransition(50, 0, 300, 40_000)).toBe(true);
+  });
+
+  it('둘 다 미발생 → false', () => {
+    expect(isGpsQualityDegradedTransition(50, 29_000, 80, 30_000)).toBe(false);
+  });
+
+  it('콜드스타트(통과 기록 없음) + 짧은 경과 → false', () => {
+    expect(isGpsQualityDegradedTransition(null, null, 300, 1_000)).toBe(false);
+  });
+});

--- a/src/features/nearest-station/utils/__tests__/inferEnvironment.test.ts
+++ b/src/features/nearest-station/utils/__tests__/inferEnvironment.test.ts
@@ -57,6 +57,84 @@ describe('inferEnvironment', () => {
     ).toBe('unknown');
   });
 
+  describe('#2070 gps-quality-drop hintReason', () => {
+    it('subsurface=undefined + 둘 다 null + qualityDegraded=true → underground (hint gps-quality-drop)', () => {
+      const result = inferEnvironment({
+        subsurface: undefined,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        qualityDegraded: true,
+      });
+      expect(result.label).toBe('underground');
+      expect(result.hintReason).toBe('gps-quality-drop');
+    });
+
+    it('subsurface=undefined + 둘 다 활성 + qualityDegraded=true → underground (분간 불가 구간 보강)', () => {
+      const result = inferEnvironment({
+        subsurface: undefined,
+        surfaceSSOT: true,
+        undergroundSSOT: true,
+        qualityDegraded: true,
+      });
+      expect(result.label).toBe('underground');
+      expect(result.hintReason).toBe('gps-quality-drop');
+    });
+
+    it('subsurface=undefined + 둘 다 null + qualityDegraded=false → unknown (기존 동작 보존)', () => {
+      const result = inferEnvironment({
+        subsurface: undefined,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        qualityDegraded: false,
+      });
+      expect(result.label).toBe('unknown');
+      expect(result.hintReason).toBeUndefined();
+    });
+
+    it('qualityDegraded 미전달 시 기존 동작(unknown) 보존', () => {
+      const result = inferEnvironment({
+        subsurface: undefined,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+      });
+      expect(result.label).toBe('unknown');
+      expect(result.hintReason).toBeUndefined();
+    });
+
+    it('surfaceSSOT만 활성이면 qualityDegraded=true여도 surface 우선 (기존 판정 대체 아님)', () => {
+      const result = inferEnvironment({
+        subsurface: undefined,
+        surfaceSSOT: true,
+        undergroundSSOT: false,
+        qualityDegraded: true,
+      });
+      expect(result.label).toBe('surface');
+      expect(result.hintReason).toBeUndefined();
+    });
+
+    it('subsurface=true(barometer 확정)면 qualityDegraded=true여도 판정 불변', () => {
+      const result = inferEnvironment({
+        subsurface: true,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        qualityDegraded: true,
+      });
+      expect(result.label).toBe('underground');
+      expect(result.hintReason).toBeUndefined();
+    });
+
+    it('subsurface=false + SSOT 없음이면 qualityDegraded=true여도 surface 우선 (raw barometer 신뢰)', () => {
+      const result = inferEnvironment({
+        subsurface: false,
+        surfaceSSOT: false,
+        undergroundSSOT: false,
+        qualityDegraded: true,
+      });
+      expect(result.label).toBe('surface');
+      expect(result.hintReason).toBeUndefined();
+    });
+  });
+
   describe('#1860 barometer-stop hintReason', () => {
     it('tripActive + barometerStop=true + subsurface=false + SSOT 없음 → hintReason 발동', () => {
       const result = inferEnvironment({

--- a/src/features/nearest-station/utils/gpsQualityGate.ts
+++ b/src/features/nearest-station/utils/gpsQualityGate.ts
@@ -1,0 +1,78 @@
+import {
+  GPS_QUALITY_GATE_MAX_ACCURACY_M,
+  GPS_QUALITY_GATE_MAX_AGE_MS,
+  GPS_QUALITY_DEGRADE_JUMP_M,
+  GPS_QUALITY_GATE_ABSENCE_MS,
+} from '../../../shared/constants/gpsQualityGate';
+
+export type GpsQualityDropReason = 'accuracy' | 'stale';
+
+/**
+ * #2070 — fusion 결정 tier 입력 품질 게이트. horizontalAccuracy < 100m AND fix age < 15s
+ * 모두 충족해야 통과. 미달 좌표는 결정 tier(useFusedNearestStation cascade) 입력에서 제외한다.
+ *
+ * 경계값은 엄격 부등호(<) — accuracy/age가 정확히 임계값이면 미달로 취급한다.
+ */
+export function isGpsQualityGateAcceptable(
+  accuracy: number | null | undefined,
+  ageMs: number,
+): accuracy is number {
+  if (accuracy == null) return false;
+  return accuracy < GPS_QUALITY_GATE_MAX_ACCURACY_M && ageMs < GPS_QUALITY_GATE_MAX_AGE_MS;
+}
+
+/**
+ * #2070 — 게이트 미달 fix의 drop 사유. accuracy 자체가 임계 초과(또는 미측정)면 'accuracy',
+ * accuracy는 통과했지만 fix가 오래됐으면 'stale'. 호출 전제: 게이트가 이미 미달 판정된 fix.
+ */
+export function gpsQualityDropReason(
+  accuracy: number | null | undefined,
+  ageMs: number,
+): GpsQualityDropReason {
+  if (accuracy == null || accuracy >= GPS_QUALITY_GATE_MAX_ACCURACY_M) return 'accuracy';
+  if (ageMs >= GPS_QUALITY_GATE_MAX_AGE_MS) return 'stale';
+  // 전제 위반(사실은 게이트 통과) 방어적 fallback — accuracy는 fine이니 stale로 귀결.
+  return 'stale';
+}
+
+/**
+ * #2070 — 직전 게이트 통과 fix 대비 accuracy가 GPS_QUALITY_DEGRADE_JUMP_M(100m) 초과로
+ * 급락했는지. 직전 통과 기록이 없으면(콜드스타트 등) 판단 불가 → false.
+ */
+export function isGpsQualityJumpDegraded(
+  lastPassAccuracyM: number | null,
+  currentAccuracyM: number | null | undefined,
+): boolean {
+  if (lastPassAccuracyM === null || currentAccuracyM == null) return false;
+  return currentAccuracyM - lastPassAccuracyM > GPS_QUALITY_DEGRADE_JUMP_M;
+}
+
+/**
+ * #2070 — 게이트 통과 fix가 GPS_QUALITY_GATE_ABSENCE_MS(30s) 이상 없었는지. 통과 기록이
+ * 아예 없으면(콜드스타트) 근거 부족으로 간주해 false — "판단 불가 시 지하로 단정하지 않는다"
+ * 원칙(memory/feedback_no_gps_for_decision.md)과 일관.
+ */
+export function isGpsQualityAbsenceDegraded(
+  lastPassAtMs: number | null,
+  nowMs: number,
+): boolean {
+  if (lastPassAtMs === null) return false;
+  return nowMs - lastPassAtMs >= GPS_QUALITY_GATE_ABSENCE_MS;
+}
+
+/**
+ * #2070 — 품질 저하 transition 이벤트. 급락 또는 30s 부재 중 하나라도 해당하면 true.
+ * 기존 subsurface/environment 판정 로직(inferEnvironment)에 추가 입력으로 전달되며,
+ * 판정 로직 자체를 대체하지 않는다.
+ */
+export function isGpsQualityDegradedTransition(
+  lastPassAccuracyM: number | null,
+  lastPassAtMs: number | null,
+  currentAccuracyM: number | null | undefined,
+  nowMs: number,
+): boolean {
+  return (
+    isGpsQualityJumpDegraded(lastPassAccuracyM, currentAccuracyM) ||
+    isGpsQualityAbsenceDegraded(lastPassAtMs, nowMs)
+  );
+}

--- a/src/features/nearest-station/utils/inferEnvironment.ts
+++ b/src/features/nearest-station/utils/inferEnvironment.ts
@@ -16,7 +16,9 @@
  *      'unknown' (with hint 'barometer-stop'). 지하상가 hint paradigm.
  *   6. `subsurface === undefined` + surfaceSSOT만 활성 → 'surface' (hybrid).
  *   7. `subsurface === undefined` + undergroundSSOT만 활성 → 'underground' (hybrid).
- *   8. `subsurface === undefined` + 둘 다 활성/모두 null → 'unknown'.
+ *   8. `subsurface === undefined` + 둘 다 활성/모두 null + GPS 품질 저하 transition(#2070) →
+ *      'underground' (with hint 'gps-quality-drop').
+ *   9. 그 외(#8 미해당) → 'unknown'.
  *
  * #1860 — hintReason 'barometer-stop': tripActive + barometerStop=true + subsurface=false
  * + 두 SSOT 없음 조합. DebugModal environment 라인에 함께 노출.
@@ -24,6 +26,11 @@
  * #1932 — 우선순위 4가 추가됨. `subsurface === false` raw signal 신뢰가 회복돼 cascade tier 2
  * (gpsDerivedFastPath)가 SSOT 비활성 환경에서도 진입 가능 — 기존 `barometerSubsurface === false`
  * gate와 semantic equivalence 보존.
+ *
+ * #2070 — 우선순위 8이 추가됨. barometer warmup/미지원(subsurface===undefined) + SSOT 무판정
+ * 구간에서 GPS 품질 저하 transition(급락 또는 게이트 통과 fix 30s 부재)이 관측되면 지하 진입
+ * 후보로 간주한다. 기존 1~7 판정 로직은 그대로 유지되며 대체되지 않는다 — barometer/SSOT 명시
+ * 신호가 있으면 항상 그 결과가 우선한다.
  */
 
 export type Environment = 'surface' | 'underground' | 'unknown';
@@ -34,8 +41,11 @@ export interface InferEnvironmentResult {
   /**
    * 옵션 C barometer-stop 힌트 발동 시 'barometer-stop'. 힌트 없으면 undefined.
    * 발동 조건: tripActive=true + barometerStop=true + subsurface=false + 두 SSOT 없음.
+   *
+   * #2070 — 'gps-quality-drop': subsurface===undefined + 두 SSOT 무판정 + GPS 품질 저하
+   * transition 관측 시 발동.
    */
-  hintReason?: 'barometer-stop';
+  hintReason?: 'barometer-stop' | 'gps-quality-drop';
 }
 
 export interface InferEnvironmentInput {
@@ -49,10 +59,17 @@ export interface InferEnvironmentInput {
   tripActive?: boolean;
   /** #1860 — BarometerSignal.stop. barometer-stop 힌트 발동 전제 조건. */
   barometerStop?: boolean;
+  /**
+   * #2070 — GPS 품질 저하 transition(급락 또는 게이트 통과 fix 30s 부재) 관측 여부.
+   * subsurface===undefined + 두 SSOT 무판정 구간에서만 판정에 관여한다(우선순위 8).
+   * 미전달이면 false로 간주(기존 동작 보존).
+   */
+  qualityDegraded?: boolean;
 }
 
 export function inferEnvironment(input: InferEnvironmentInput): InferEnvironmentResult {
-  const { subsurface, surfaceSSOT, undergroundSSOT, tripActive, barometerStop } = input;
+  const { subsurface, surfaceSSOT, undergroundSSOT, tripActive, barometerStop, qualityDegraded } =
+    input;
   if (subsurface === true) return { label: 'underground' };
   if (subsurface === false) {
     if (surfaceSSOT) return { label: 'surface' };
@@ -69,5 +86,10 @@ export function inferEnvironment(input: InferEnvironmentInput): InferEnvironment
   // subsurface === undefined (warmup / 미지원) — SSOT 신호로만 판단.
   if (surfaceSSOT && !undergroundSSOT) return { label: 'surface' };
   if (undergroundSSOT && !surfaceSSOT) return { label: 'underground' };
+  // #2070 — SSOT 무판정(둘 다 활성 또는 둘 다 비활성) 구간 보강. 기존 판정을 대체하지 않고
+  // 판정 불가였던 이 구간에만 GPS 품질 저하 transition을 추가 입력으로 반영한다.
+  if (qualityDegraded === true) {
+    return { label: 'underground', hintReason: 'gps-quality-drop' };
+  }
   return { label: 'unknown' };
 }

--- a/src/shared/constants/gpsQualityGate.ts
+++ b/src/shared/constants/gpsQualityGate.ts
@@ -1,0 +1,18 @@
+// #2070 — fusion 결정 tier 입력용 GPS 품질 게이트.
+// 2026-07-29 지하 위치서비스 리서치: 지하 CLLocation은 65m~km 오차 + 최대 2분+ 지연·결측이 흔하다.
+// 좌표값 자체는 결정에 쓰지 않는 원칙(memory/feedback_no_gps_for_decision.md)을 유지하되,
+// "게이트 미달" 자체를 지하 진입 후보 신호로 재활용한다.
+//
+// 100m: Apple Core Location 가이드 기준 통상 신뢰 구간 상한. 지상 fix는 대부분 10~50m로
+// 여유 있게 통과하고, 지하 WiFi/Cell 삼각측량(수백m~수km)은 확실히 배제한다.
+export const GPS_QUALITY_GATE_MAX_ACCURACY_M = 100;
+// 15s: MAX_LOCATION_AGE_MS(location.ts)와 동일 기준 — 환승 알람 동기화 수준의 신선도 요구.
+export const GPS_QUALITY_GATE_MAX_AGE_MS = 15_000;
+
+// #2070 — 품질 저하 transition 이벤트 임계값. 두 조건 중 하나라도 충족하면 "지하 진입 후보"로
+// 간주해 기존 subsurface/environment 판정 로직에 입력으로 추가한다(판정 로직 대체 아님).
+//
+// 급락: 직전 게이트 통과 fix 대비 accuracy가 이 값(m) 초과로 나빠지면 급락으로 판정.
+export const GPS_QUALITY_DEGRADE_JUMP_M = 100;
+// 부재: 게이트 통과 fix가 이 시간(ms) 이상 없으면 부재로 판정.
+export const GPS_QUALITY_GATE_ABSENCE_MS = 30_000;


### PR DESCRIPTION
Closes #2070

## 요약

- **fusion 결정 tier 품질 게이트 신설** — `useNearestStation.applyLocation`에서 매 fix에 `horizontalAccuracy < 100m AND age < 15s`(둘 다 엄격 부등호) 게이트를 적용. 기존 표시 게이트(250m)는 통과했지만 이 게이트에 미달하는 fix는 `gpsDropBuffer`에 `gps-quality-drop:accuracy` 또는 `gps-quality-drop:stale` 사유로 로그. 표시(userLocation/accuracyMeters/result)는 그대로 유지 — 결정 tier 소비자가 별도로 `gpsQualityDegraded`를 참고.
- **품질 저하 transition 이벤트** — 직전 게이트 통과 fix 대비 accuracy 급락(>100m) 또는 게이트 통과 fix 30s 부재 시 `gpsQualityDegraded=true`. `useFusedNearestStation`이 이 값을 `inferEnvironment`의 새 입력(`qualityDegraded`)으로 전달 — 기존 barometer/SSOT 판정(우선순위 1~7)은 그대로 유지되며, SSOT 무판정 구간(우선순위 8, 신규)에만 관여해 `underground` + `hintReason: 'gps-quality-drop'`를 부여.
- **지하 폴링 하향 + 지상 복귀 원복** — FG watch 재시작 트리거를 `barometerSubsurface === true` OR `gpsQualityDegraded`로 확장. 기존 `FG_WATCH_OPTIONS_SUBSURFACE`(High@12s)를 재사용(신규 profile 값 중복 정의 없음). 게이트 통과 fix가 재등장하면 자동 원복.

## 하지 않은 것 (이슈 범위 준수)

- fusion tier 구조/우선순위(`FUSION_TIER_PRIORITY`) 개편 없음
- 알람/알림 발사 경로 미수정
- barometer/motion 로직 미수정
- `inferEnvironment`의 기존 1~7 우선순위 로직 미변경 (8번만 추가)

## 변경 파일

- `src/shared/constants/gpsQualityGate.ts` (신규) — 게이트/transition 임계값 상수
- `src/features/nearest-station/utils/gpsQualityGate.ts` (신규) — 순수 게이트/transition 판정 함수
- `src/features/nearest-station/hooks/useNearestStation.ts` — 게이트 평가 + drop 로그 + `gpsQualityDegraded` 노출 + 폴링 트리거 확장
- `src/features/nearest-station/utils/inferEnvironment.ts` — `qualityDegraded` 입력 + 우선순위 8 추가
- `src/features/nearest-station/hooks/useFusedNearestStation.ts` — `inferEnvironment` 호출에 `gps.gpsQualityDegraded` 전달 (1줄)
- 테스트: `gpsQualityGate.test.ts`(순수 함수, 경계값 매트릭스), `useNearestStation.test.ts`(게이트/transition/폴링 전환·원복 wiring), `inferEnvironment.test.ts`(신규 우선순위 8), `useFusedNearestStation.gpsQualityGate.test.ts`(cascade 전달 wiring)

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (아래 출력)
2. **V/X dashboard** — DebugModal이 `useFusedNearestStation()`을 직접 호출해 `environment`/`environmentHintReason`을 그대로 노출하므로 `gps-quality-drop` hint가 기존 environment 라인(`environment=underground (hint:gps-quality-drop)`)에 자동 표시. `gps-drop` 로그 섹션도 `dropReason` 자유 문자열을 그대로 렌더링해 `gps-quality-drop:accuracy|stale`이 자동 표시됨 — DebugModal 코드 변경 없이 기존 SSOT 재사용으로 wire됨. 폴링 프로파일 자체의 별도 UI 표시는 미구현(범위 밖) — 대신 gps-drop 로그 볼륨/environment 분포로 간접 관측 가능.
3. **의존 PR** — N/A (독립)
4. **측정 plan** — 실기기 지하 trip에서 `fusionDebugBuffer`/`gpsDropBuffer`의 `gps-quality-drop` 발생 빈도 + `environment=underground(hint:gps-quality-drop)` 관측 빈도, 지상 복귀 시 원복 여부를 1주 관찰
5. **Device verify** — 필요. 지하 구간 trip 1회 — 게이트 drop 로그 발생, environment underground 전이, FG watch 폴링 간격(12s) 전환/원복 확인

## 검증

```
npm test        # 9234 passed, 100% coverage (lines/branches/functions/statements)
npm run type-check   # 통과
npm run lint:orphan  # No orphan exports detected.
npx eslint --ext .ts,.tsx <변경 파일 전체> --max-warnings=0  # 0 warnings
```

## 테스트 계획

- [x] 게이트 경계값 (accuracy 99/100/101m × age 14/15/16s) — `gpsQualityGate.test.ts`
- [x] transition 급락/부재 각각 발생·미발생 — `gpsQualityGate.test.ts` + `useNearestStation.test.ts`
- [x] 폴링 프로파일 전환(지하) / 원복(지상) — `useNearestStation.test.ts`
- [x] `inferEnvironment` 신규 우선순위 8(기존 1~7 판정 우선 보존 포함) — `inferEnvironment.test.ts`
- [x] cascade(`useFusedNearestStation`) wiring — `useFusedNearestStation.gpsQualityGate.test.ts`
- [ ] 실기기 지하 구간 trip 1회 (사용자 검증)