### PR TITLE
test(#2068): 다중소스 발사횟수 시퀀스 테스트 + dumpParser sleepMode 인식

### DIFF
--- a/src/features/alarm/utils/__tests__/fireSequence.test.ts
+++ b/src/features/alarm/utils/__tests__/fireSequence.test.ts
@@ -1,0 +1,302 @@
+/**
+ * #2068 — 다중소스 발사횟수 시퀀스 테스트 (Part of Epic #2061).
+ *
+ * ## 배경
+ *
+ * 사용자 체감 회귀 2건(#2061 본문): (1) 동일 알림 반복 발사 (2) 일반 모드에서 알람음.
+ * 기존 fixture chain harness(`fixtureChainRunner.ts`)는 DebugModal dump **스냅샷 평가기**라
+ * 이벤트 순서·발사 횟수·race를 재현할 수 없다(2026-07-29 4-audit). 본 파일은 fg polling /
+ * bg pipeline / silent push 3소스가 같은 물리적 station 이벤트를 각자 경로로 주입할 때 실제
+ * 발사(=expo-notifications mock 호출) 횟수를 assert한다.
+ *
+ * ## 소스별 gate 경로 (production 코드 그대로 mirror, 재구현 아님)
+ *
+ * 세 helper(`fireViaFgOrBgPath` / `fireViaOsScheduledPath` / `fireViaSilentPushPath`)는
+ * production caller가 실제로 호출하는 순서 그대로 real exported gate 함수
+ * (`crossCategoryStationDedup.ts`)를 호출한다 — 재구현이 아니라 "경유"다:
+ *
+ *   - fg polling(`useStationAlarm.ts:215` 부근) / bg pipeline(`stationPipeline.ts:319-499`):
+ *     `isStationRecentlyFired` → `isTripScopedCrossCategoryRecentlyFired` →
+ *     `isPhaseToPhaseCrossStationRecentlyFired` → `isAnyChannelRecentlyFired` →
+ *     (모두 통과 시) `markStationFired` + 알림 발사. 두 경로 모두 같은 gate 함수를 공유한다
+ *     (`silentPushTask.ts:1927` 주석 "FG fireAndLog / stationPipeline 모두에서
+ *     markStationFired로 적재").
+ *   - silent push(`silentPushTask.ts:1930-1986`): `isAnyChannelRecentlyFired`만 거치고
+ *     (isStationRecentlyFired 등 나머지 3 게이트는 호출하지 않음) `markStationFired` + 발사.
+ *   - **OS 사전예약**(`alarmScheduler.ts:152-168`, `tripBoundScheduler.ts`,
+ *     `boardingLockScheduler.ts`): 위 dedup 게이트를 **전혀 거치지 않고**
+ *     `Notifications.scheduleNotificationAsync`를 직접 호출한다 — 예약 후 OS가 자체 발사하기
+ *     때문에 런타임 dedup이 원천적으로 불가능(#2061 본문 "OS 사전예약 3종 ... 런타임 dedup
+ *     불가"). 본 파일은 이 gap을 직접 재현한다.
+ *
+ * ## 시나리오
+ *
+ *   (a) 같은 역 3소스(os-scheduled/fg/silent) 각 1회 주입 → 총 발사 ≤1 기대, 실제는 2건
+ *       (os-scheduled가 gate를 우회해 fg와 별개로 발사) → red.
+ *   (b) 앱 재시작 시뮬(`jest.isolateModules`로 모듈 registry만 새로 만들고 AsyncStorage mock
+ *       data는 outer 스코프에 유지 — `jest.resetModules` + "AsyncStorage 유지" 의도를 다른
+ *       테스트로 상태가 새지 않게 스코프 격리해 구현) 후 같은 이벤트 재주입 → 추가 발사 0
+ *       기대, 실제는 in-memory dedup(`crossCategoryStationDedup`의 lastFire Map) 소실로
+ *       재발사 → red. AsyncStorage 기반 `firedPushIds`는 대조군으로 재시작 후에도 dedup
+ *       상태가 보존됨을 함께 확인(harness sanity check, green).
+ *   (c) 일반 모드(sleepMode=off)에서 `sendAlarmNotification`(실제 production 함수, 재구현
+ *       아님) 호출 → sound=alarm.wav 0건 기대, 실제는 allowSpeaker 기본값 때문에 sleepMode
+ *       무관하게 sound='alarm.wav' → red.
+ *
+ * (a)(b)(c) 전부 `it.failing` — 현 코드 기준 red 재현. Phase 1(#2063/#2064)·Phase 2
+ * (#2066/#2067)가 완료되면 unskip한다.
+ */
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import {
+  isStationRecentlyFired,
+  isTripScopedCrossCategoryRecentlyFired,
+  isPhaseToPhaseCrossStationRecentlyFired,
+  isAnyChannelRecentlyFired,
+  markStationFired,
+  _resetCrossCategoryDedupForTests,
+  type FireCategory,
+} from '../crossCategoryStationDedup';
+import { addFiredPushId, hasFiredPushId } from '../firedPushIds';
+import { canonicalStationName } from '../../../../testUtils/canonicalStationName';
+
+jest.mock('expo-notifications');
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+// stationNotification.ts는 sendAlarmNotification 시나리오(c)에서만 필요 — 무거운 의존성
+// (live-activity, tts, alarmSound, breadcrumb 등)을 stationNotification.test.ts와 동일한
+// 패턴으로 mock한다.
+const mockVibrateAlarm = jest.fn();
+const mockStopVibration = jest.fn();
+jest.mock('../alarmSound', () => ({
+  vibrateAlarm: (...args: unknown[]) => mockVibrateAlarm(...args),
+  stopVibration: () => mockStopVibration(),
+}));
+
+const mockSpeakAlarm = jest.fn();
+jest.mock('../tts', () => ({
+  speakAlarm: (...args: unknown[]) => mockSpeakAlarm(...args),
+}));
+
+jest.mock('live-activity', () => ({
+  startLiveActivity: jest.fn().mockResolvedValue(undefined),
+  updateLiveActivity: jest.fn().mockResolvedValue(undefined),
+  endLiveActivity: jest.fn().mockResolvedValue(undefined),
+  isLiveActivityEnabled: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock('../liveActivityPushChannel', () => ({
+  ensureLiveActivityRegistered: jest.fn().mockResolvedValue(undefined),
+  endLiveActivityWithDeregister: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../../../shared/infra/monitoring/breadcrumb', () => ({
+  addLogBreadcrumb: jest.fn(),
+  addDomainBreadcrumb: jest.fn(),
+}));
+
+jest.mock('../../../widget/api/widgetStorage', () => ({
+  saveStationToWidget: jest.fn().mockResolvedValue(undefined),
+  clearWidgetStation: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../../../data/exitSide.json', () => ({}));
+jest.mock('../../../../data/platformExitSide.json', () => ({}));
+jest.mock('../../../../data/quickExit.json', () => ({}));
+
+// #2068 시나리오 (b) — "AsyncStorage mock 유지" 요구사항. 데이터 저장소를 이 테스트 파일의
+// 바깥 스코프(outer closure)에 두어 jest.resetModules() 이후에도(모듈 registry만 리셋되고
+// 이 변수는 real JS scope라 살아남는다) 동일 데이터를 유지한다 — 실기기의 AsyncStorage가
+// 프로세스 재시작(JS heap 초기화)에도 디스크에 남아있는 것과 동등한 시뮬레이션.
+// firedPushIds.ts는 real 구현을 그대로 사용(mock 안 함) — 이 AsyncStorage mock 위에서 동작.
+const mockAsyncStorageData: Record<string, string> = {};
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn((key: string) => Promise.resolve(mockAsyncStorageData[key] ?? null)),
+  setItem: jest.fn((key: string, value: string) => {
+    mockAsyncStorageData[key] = value;
+    return Promise.resolve();
+  }),
+  removeItem: jest.fn((key: string) => {
+    delete mockAsyncStorageData[key];
+    return Promise.resolve();
+  }),
+}));
+
+const DEST_ID = 'trip-fire-sequence';
+const LINE = '2' as const;
+
+function stationName(): string {
+  return canonicalStationName('성수', LINE);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  _resetCrossCategoryDedupForTests();
+  (Notifications.scheduleNotificationAsync as jest.Mock).mockResolvedValue('id');
+  (Notifications.dismissNotificationAsync as jest.Mock).mockResolvedValue(undefined);
+});
+
+/**
+ * fg polling(`useStationAlarm.ts`) / bg pipeline(`stationPipeline.ts`) 공통 gate 순서.
+ * 두 real caller가 동일한 4-게이트 체인 + `markStationFired`를 공유하므로(위 파일 docstring
+ * 근거) 단일 helper로 양쪽을 대표한다.
+ */
+function fireViaFgOrBgPath(
+  destId: string,
+  station: string,
+  category: FireCategory,
+  now: number,
+): boolean {
+  if (isStationRecentlyFired(destId, station, category, now)) return false;
+  if (isTripScopedCrossCategoryRecentlyFired(destId, station, category, now)) return false;
+  if (isPhaseToPhaseCrossStationRecentlyFired(destId, station, category, now)) return false;
+  if (isAnyChannelRecentlyFired(destId, station, category, now)) return false;
+  markStationFired(destId, station, category, now);
+  void Notifications.scheduleNotificationAsync({
+    content: { title: '알림', body: station },
+    trigger: null,
+  });
+  return true;
+}
+
+/** silent push(`silentPushTask.ts:1930-1986`) gate 순서 — isAnyChannelRecentlyFired만 통과. */
+function fireViaSilentPushPath(
+  destId: string,
+  station: string,
+  category: FireCategory,
+  now: number,
+): boolean {
+  if (isAnyChannelRecentlyFired(destId, station, category, now)) return false;
+  markStationFired(destId, station, category, now);
+  void Notifications.scheduleNotificationAsync({
+    content: { title: '알림(silent push)', body: station },
+    trigger: null,
+  });
+  return true;
+}
+
+/**
+ * OS 사전예약(`alarmScheduler.ts:152-168` 등) — dedup 게이트 없이 직접 스케줄.
+ * 실제로는 미래 trigger date로 예약하지만, 본 harness는 "게이트를 거치지 않고 발사
+ * 카운트에 반영된다"는 사실만 재현하면 충분해 trigger:null(즉시)로 단순화한다.
+ */
+function fireViaOsScheduledPath(station: string): void {
+  void Notifications.scheduleNotificationAsync({
+    content: { title: '알람', body: station, sound: 'alarm.wav' },
+    trigger: null,
+  });
+}
+
+describe('시나리오 (a): 같은 역 3소스 각 1회 주입 → 총 발사 ≤1', () => {
+  it.failing('os-scheduled + fg + silent 순차 주입 → 실제로는 2건 발사(gate 우회 gap)', () => {
+    const station = stationName();
+    const now = 1_000;
+
+    fireViaOsScheduledPath(station); // OS 사전예약 — gate 미경유, 무조건 1건.
+    fireViaFgOrBgPath(DEST_ID, station, 'station-passed', now); // gate open → 1건 더.
+    fireViaSilentPushPath(DEST_ID, station, 'station-passed', now + 10); // fg가 마킹 → dedup.
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('gate 우회 없이 fg만 단독 주입하면 정확히 1건(gate 자체는 정상 동작)', () => {
+    const station = stationName();
+    const now = 1_000;
+
+    const fgFired = fireViaFgOrBgPath(DEST_ID, station, 'station-passed', now);
+    const bgFired = fireViaFgOrBgPath(DEST_ID, station, 'station-passed', now + 5);
+    const silentFired = fireViaSilentPushPath(DEST_ID, station, 'station-passed', now + 10);
+
+    expect(fgFired).toBe(true);
+    expect(bgFired).toBe(false);
+    expect(silentFired).toBe(false);
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('시나리오 (b): 앱 재시작 시뮬 후 같은 이벤트 재주입 → 추가 발사 0', () => {
+  it.failing('in-memory dedup(crossCategoryStationDedup)은 재시작 시 소실 → 추가 1건 재발사', () => {
+    const station = stationName();
+    const now = 2_000;
+
+    // 재시작 전: fg 경로로 정상 발사 + 마킹.
+    const firstFired = fireViaFgOrBgPath(DEST_ID, station, 'station-passed', now);
+    expect(firstFired).toBe(true);
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+
+    // 앱 재시작 시뮬 — jest.isolateModules로 이 콜백 안에서만 모듈 registry를 새로 만든다
+    // (콜백 종료 후 원래 registry로 자동 복원 — scheduleFallback.test.ts:23-30과 동일 패턴,
+    // 다른 describe/it으로 상태가 새지 않는다). AsyncStorage(firedPushIds 등)는 mock data가
+    // 이 파일의 outer 스코프(`mockAsyncStorageData`)에 남아있어 유지되지만(대조군, 아래
+    // 테스트), in-memory-only 모듈(crossCategoryStationDedup)은 콜백 안에서 재요청 시 새
+    // 인스턴스로 lastFire Map이 빈다.
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- isolateModules
+      // 콜백 안에서 프로덕션 모듈을 재요청해 "재시작 후 최초 require" 상태를 재현.
+      const freshDedup = require('../crossCategoryStationDedup') as typeof import('../crossCategoryStationDedup');
+
+      // 재시작 후: 같은 station-passed 이벤트가 다시 들어온다(예: SSoT/GPS 재평가).
+      const afterRestartFired =
+        !freshDedup.isStationRecentlyFired(DEST_ID, station, 'station-passed', now + 100) &&
+        !freshDedup.isTripScopedCrossCategoryRecentlyFired(DEST_ID, station, 'station-passed', now + 100) &&
+        !freshDedup.isPhaseToPhaseCrossStationRecentlyFired(DEST_ID, station, 'station-passed', now + 100) &&
+        !freshDedup.isAnyChannelRecentlyFired(DEST_ID, station, 'station-passed', now + 100);
+      if (afterRestartFired) {
+        freshDedup.markStationFired(DEST_ID, station, 'station-passed', now + 100);
+        void Notifications.scheduleNotificationAsync({
+          content: { title: '알림', body: station },
+          trigger: null,
+        });
+      }
+    });
+
+    // 추가 발사 0건을 기대하지만(사용자가 이미 이 알림을 받았으므로), 실제로는 총 2건.
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('대조군 — AsyncStorage 기반 firedPushIds는 재시작 후에도 dedup 상태가 보존된다', async () => {
+    const pushId = 'push-fire-sequence-1';
+    await addFiredPushId(pushId, 3_000);
+    expect(await hasFiredPushId(pushId, 3_050)).toBe(true);
+
+    // jest.isolateModules 콜백은 동기라 await를 직접 쓸 수 없다 — 콜백 안에서 만든 Promise
+    // 참조만 밖으로 꺼내 await한다(freshFiredPushIds 자체는 콜백 스코프를 벗어나지 않음).
+    let pendingResult: Promise<boolean>;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const freshFiredPushIds = require('../firedPushIds') as typeof import('../firedPushIds');
+      // AsyncStorage mock의 데이터 저장소(`mockAsyncStorageData`)는 이 테스트 파일의 outer
+      // 스코프에 유지되므로, 모듈만 새로 불러와도 같은 pushId가 여전히 dedup된다.
+      pendingResult = freshFiredPushIds.hasFiredPushId(pushId, 3_100);
+    });
+
+    expect(await pendingResult!).toBe(true);
+  });
+});
+
+describe('시나리오 (c): 일반 모드(sleepMode=off)에서 알람류(sound 있는 알림) 발사 0', () => {
+  it.failing('sendAlarmNotification(실제 production 함수)이 sleepMode=off에도 sound=alarm.wav 발사', async () => {
+    jest.replaceProperty(Platform, 'OS', 'ios');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- 무거운 의존성 체인을
+    // 이 describe 블록에서만 로드하기 위해 지연 require.
+    const { sendAlarmNotification } = require('../stationNotification') as typeof import('../stationNotification');
+
+    await sendAlarmNotification(
+      { phaseId: 'imminent', type: 'transfer', stationName: stationName() },
+      /* sleepMode */ false,
+    );
+
+    const soundCalls = (Notifications.scheduleNotificationAsync as jest.Mock).mock.calls.filter(
+      ([arg]: [{ content?: { sound?: unknown } }]) => arg?.content?.sound === 'alarm.wav',
+    );
+    // 일반 모드(sleepMode=off)에서는 alarm.wav 발사가 0건이어야 한다(#2061 확정 스펙).
+    expect(soundCalls).toHaveLength(0);
+  });
+});

--- a/src/testUtils/__tests__/chainReport.test.ts
+++ b/src/testUtils/__tests__/chainReport.test.ts
@@ -31,8 +31,13 @@ describe('CHAIN_STAGE_IDS', () => {
     expect(CHAIN_STAGE_IDS).toContain('mismatch-detected');
   });
 
-  it('총 12개 (기존 6 + Phase 6.1 6)', () => {
-    expect(CHAIN_STAGE_IDS).toHaveLength(12);
+  it('Phase 6.1 stages를 포함한다 (#2068 mode-aware)', () => {
+    expect(CHAIN_STAGE_IDS).toContain('general-mode-no-alarm-sound');
+    expect(CHAIN_STAGE_IDS).toContain('sleep-mode-no-per-station-notification');
+  });
+
+  it('총 14개 (기존 6 + Phase 6.1 6 + #2068 mode-aware 2)', () => {
+    expect(CHAIN_STAGE_IDS).toHaveLength(14);
   });
 
   it('중복 없음', () => {
@@ -76,8 +81,8 @@ describe('buildChainReport', () => {
     expect(report.allPassed).toBe(false);
   });
 
-  it('마지막 stage만 실패 → firstStuck=mismatch-detected (Phase 6.1 마지막 stage)', () => {
-    // Phase 6.1 (#1875) 확장 후 마지막 stage는 mismatch-detected
+  it('마지막 stage만 실패 → firstStuck=sleep-mode-no-per-station-notification (#2068 마지막 stage)', () => {
+    // #2068 mode-aware stages 확장 후 마지막 stage는 sleep-mode-no-per-station-notification
     const last = CHAIN_STAGE_IDS.length - 1;
     const stages: ChainStageResult[] = CHAIN_STAGE_IDS.map((stage, i) => ({
       stage,
@@ -85,7 +90,7 @@ describe('buildChainReport', () => {
       evidence: 'test',
     }));
     const report = buildChainReport(stages);
-    expect(report.firstStuck).toBe('mismatch-detected');
+    expect(report.firstStuck).toBe('sleep-mode-no-per-station-notification');
   });
 
   it('stages 배열이 CHAIN_STAGE_IDS 순서와 동일하다', () => {

--- a/src/testUtils/__tests__/dumpParserSleepMode.test.ts
+++ b/src/testUtils/__tests__/dumpParserSleepMode.test.ts
@@ -1,0 +1,63 @@
+/**
+ * #2068 — dumpParser: `## Sleep` 섹션 sleepMode=on|off 파싱 검증.
+ *
+ * DebugModal `buildSleepSection`(components/DebugModal.tsx:826) 출력 포맷:
+ *   ## Sleep
+ *   sleepMode=on|off
+ *   firstHopApproaching=true|false
+ *
+ * sleep prop 미전달 시 `sleepMode=—`(UNKNOWN_LABEL) — on/off 매칭 실패 → undefined.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parseDumpFixture } from '../dumpParser';
+
+const FIXTURES_DIR = join(__dirname, '../fixtures/day2');
+
+function loadFixture(filename: string): string {
+  return readFileSync(join(FIXTURES_DIR, filename), 'utf-8');
+}
+
+describe('parseDumpFixture — sleepMode 파싱', () => {
+  it('sleepMode=off 파싱 (morning-trip.txt)', () => {
+    const fixture = parseDumpFixture(loadFixture('morning-trip.txt'));
+    expect(fixture.sleepMode).toBe('off');
+  });
+
+  it('sleepMode=off 파싱 (regression-general-mode-alarm-sound.txt)', () => {
+    const fixture = parseDumpFixture(loadFixture('regression-general-mode-alarm-sound.txt'));
+    expect(fixture.sleepMode).toBe('off');
+  });
+
+  it('sleepMode=on 파싱', () => {
+    const text = `[Subway debug] 2026-07-29T00:10:00.000Z
+
+## Sleep
+sleepMode=on
+firstHopApproaching=true
+`;
+    const fixture = parseDumpFixture(text);
+    expect(fixture.sleepMode).toBe('on');
+  });
+
+  it('## Sleep 섹션 부재 시 undefined', () => {
+    const text = `[Subway debug] 2026-07-29T00:10:00.000Z
+
+## GPS
+lat=37.5, lng=127.0, speed=- m/s, accuracy=10 m
+`;
+    const fixture = parseDumpFixture(text);
+    expect(fixture.sleepMode).toBeUndefined();
+  });
+
+  it('sleep prop 미전달 (sleepMode=—, UNKNOWN_LABEL) → undefined', () => {
+    const text = `[Subway debug] 2026-07-29T00:10:00.000Z
+
+## Sleep
+sleepMode=—
+firstHopApproaching=—
+`;
+    const fixture = parseDumpFixture(text);
+    expect(fixture.sleepMode).toBeUndefined();
+  });
+});

--- a/src/testUtils/__tests__/fixtureChainRunner.test.ts
+++ b/src/testUtils/__tests__/fixtureChainRunner.test.ts
@@ -164,8 +164,8 @@ describe('acceptance 5: Day 2 오전 trip (fix 적용 결과) → 기존 6 stage
 describe('runChainFromDump — stages 배열 길이 및 순서', () => {
   const report = loadAndRun('morning-trip.txt');
 
-  it('stages 배열이 CHAIN_STAGE_IDS 개수와 동일 (기존 6 + Phase 6.1 6 = 12)', () => {
-    expect(report.stages).toHaveLength(12);
+  it('stages 배열이 CHAIN_STAGE_IDS 개수와 동일 (기존 6 + Phase 6.1 6 + #2068 mode-aware 2 = 14)', () => {
+    expect(report.stages).toHaveLength(14);
   });
 
   it('stages[0].stage=trip-registered', () => {
@@ -180,7 +180,7 @@ describe('runChainFromDump — stages 배열 길이 및 순서', () => {
     expect(report.stages[6].stage).toBe('cold-start-detected');
   });
 
-  it('stages[11].stage=mismatch-detected (Phase 6.1 마지막 stage)', () => {
+  it('stages[11].stage=mismatch-detected (Phase 6.1 마지막 stage, #2068 mode-aware 앞)', () => {
     expect(report.stages[11].stage).toBe('mismatch-detected');
   });
 });
@@ -198,6 +198,7 @@ describe('runChainFromDump — undefined 필드 graceful (branch coverage)', () 
       silentPushReceived: undefined,
       silentPushFired: undefined,
       boardingLockActive: undefined,
+      sleepMode: undefined,
       alarmLogSources: {},
       notificationsFiredCount: undefined,
       notificationKinds: [],
@@ -221,6 +222,7 @@ describe('runChainFromDump — undefined 필드 graceful (branch coverage)', () 
       silentPushReceived: 0,
       silentPushFired: 0,
       boardingLockActive: false,
+      sleepMode: undefined,
       alarmLogSources: {},
       notificationsFiredCount: 0,
       notificationKinds: [],
@@ -242,6 +244,7 @@ describe('runChainFromDump — undefined 필드 graceful (branch coverage)', () 
       silentPushReceived: 0,
       silentPushFired: 0,
       boardingLockActive: false,
+      sleepMode: undefined,
       alarmLogSources: {},
       notificationsFiredCount: 0,
       notificationKinds: [],
@@ -263,6 +266,7 @@ describe('runChainFromDump — undefined 필드 graceful (branch coverage)', () 
       silentPushReceived: undefined,
       silentPushFired: undefined,
       boardingLockActive: undefined,
+      sleepMode: undefined,
       alarmLogSources: {},
       notificationsFiredCount: undefined,
       notificationKinds: [],
@@ -285,6 +289,7 @@ describe('runChainFromDump — undefined 필드 graceful (branch coverage)', () 
       silentPushReceived: 5,
       silentPushFired: 1,
       boardingLockActive: true,
+      sleepMode: undefined,
       alarmLogSources: { 'boarding-prompt': 1 },
       notificationsFiredCount: undefined,
       notificationKinds: [],

--- a/src/testUtils/__tests__/fixtureChainRunnerPhase61.test.ts
+++ b/src/testUtils/__tests__/fixtureChainRunnerPhase61.test.ts
@@ -41,12 +41,12 @@ describe('regression: 기존 6 stages 회귀 zero — morning-trip allPassed + �
     }
   });
 
-  it('CHAIN_STAGE_IDS 총 12개', () => {
-    expect(CHAIN_STAGE_IDS).toHaveLength(12);
+  it('CHAIN_STAGE_IDS 총 14개 (기존 6 + Phase 6.1 6 + #2068 mode-aware 2)', () => {
+    expect(CHAIN_STAGE_IDS).toHaveLength(14);
   });
 
-  it('stages 배열 총 12개', () => {
-    expect(report.stages).toHaveLength(12);
+  it('stages 배열 총 14개', () => {
+    expect(report.stages).toHaveLength(14);
   });
 
   it('stages[0].stage=trip-registered (기존 순서 유지)', () => {
@@ -61,7 +61,7 @@ describe('regression: 기존 6 stages 회귀 zero — morning-trip allPassed + �
     expect(report.stages[6].stage).toBe('cold-start-detected');
   });
 
-  it('stages[11].stage=mismatch-detected (Phase 6.1 마지막 stage)', () => {
+  it('stages[11].stage=mismatch-detected (Phase 6.1 마지막 stage, #2068 mode-aware 앞)', () => {
     expect(report.stages[11].stage).toBe('mismatch-detected');
   });
 });
@@ -212,6 +212,7 @@ describe('Phase 6.1 graceful: 모든 필드 undefined → cold start stages fals
     silentPushReceived: undefined,
     silentPushFired: undefined,
     boardingLockActive: undefined,
+    sleepMode: undefined,
     alarmLogSources: {},
     notificationsFiredCount: undefined,
     notificationKinds: [],
@@ -274,6 +275,7 @@ describe('매트릭스: cold start section 존재 시 각 필드 독립 판정',
     silentPushReceived: undefined,
     silentPushFired: undefined,
     boardingLockActive: undefined,
+    sleepMode: undefined,
     alarmLogSources: {},
     notificationsFiredCount: undefined,
     notificationKinds: [],
@@ -338,6 +340,7 @@ describe('매트릭스: cold-start-detected fallback 파생 (## Cold Start 섹�
     silentPushReceived: undefined,
     silentPushFired: undefined,
     boardingLockActive: undefined,
+    sleepMode: undefined,
     alarmLogSources: {},
     notificationsFiredCount: undefined,
     notificationKinds: [],

--- a/src/testUtils/__tests__/fixtureChainRunnerSleepMode.test.ts
+++ b/src/testUtils/__tests__/fixtureChainRunnerSleepMode.test.ts
@@ -1,0 +1,175 @@
+/**
+ * #2068 — mode-aware chain stage 검증: `general-mode-no-alarm-sound` /
+ * `sleep-mode-no-per-station-notification`.
+ *
+ * Epic #2061 확정 스펙(본문 표):
+ *   - 일반 모드(sleepMode=off): 알람류(transfer/destination, alarm.wav) 발사 0건이어야 한다.
+ *   - 취침 모드(sleepMode=on): 매역 notification(station-passed) 발사 0건이어야 한다.
+ *
+ * 현재 프로덕션 코드(Phase 1 #2063/#2064, Phase 2 #2066/#2067 미완)는 이 정책을 구현하지
+ * 않았다 — `sendAlarmNotification`(stationNotification.ts:591)의 sound는 sleepMode와
+ * 무관하게 allowSpeaker로만 결정된다. 따라서 `general-mode-no-alarm-sound` stage는 회귀
+ * fixture(regression-general-mode-alarm-sound.txt, sleepMode=off + transfer 알람 fired)에서
+ * red로 재현되며, `it.failing`으로 마킹한다. Phase 1·2 완료 후 해당 PR에서 unskip한다.
+ *
+ * `sleep-mode-no-per-station-notification`은 sleepMode=on fixture가 현재 저장소에 없어
+ * (모든 day2/phase61 fixture가 sleepMode=off) 오탐 없이 green — 회귀 fixture는 향후
+ * Phase 2 device verify에서 실기기 dump로 보강 예정.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parseDumpFixture } from '../dumpParser';
+import { runChainFromDump } from '../fixtureChainRunner';
+
+const DAY2_DIR = join(__dirname, '../fixtures/day2');
+
+function loadAndRun(filename: string) {
+  const text = readFileSync(join(DAY2_DIR, filename), 'utf-8');
+  return runChainFromDump(parseDumpFixture(text));
+}
+
+describe('general-mode-no-alarm-sound', () => {
+  // #2068 회귀 재현 — 현재 코드는 일반 모드에서도 alarm.wav(transfer/destination)를 발사한다.
+  // Phase 1·2 완료 전까지 fail이 정상. unskip 조건: #2063/#2064/#2066/#2067 전부 머지.
+  it.failing(
+    '일반 모드(sleepMode=off) + transfer 알람 fired → stage fail (Phase 1·2 완료 전 red)',
+    () => {
+      const report = loadAndRun('regression-general-mode-alarm-sound.txt');
+      const stage = report.stages.find((s) => s.stage === 'general-mode-no-alarm-sound');
+      expect(stage?.passed).toBe(true);
+    },
+  );
+
+  it('evidence에 sleepMode와 alarmKinds가 표시된다', () => {
+    const report = loadAndRun('regression-general-mode-alarm-sound.txt');
+    const stage = report.stages.find((s) => s.stage === 'general-mode-no-alarm-sound');
+    expect(stage?.evidence).toContain('sleepMode=off');
+    expect(stage?.evidence).toContain('transfer');
+  });
+
+  it('정상 trip(morning-trip.txt)도 transfer 알람이 fired라 현재는 동일하게 fail (회귀 범위 확인)', () => {
+    const report = loadAndRun('morning-trip.txt');
+    const stage = report.stages.find((s) => s.stage === 'general-mode-no-alarm-sound');
+    expect(stage?.passed).toBe(false);
+  });
+
+  it('sleepMode 신호 부재 fixture는 판정 보류(pass) — 오탐 방지', () => {
+    const report = runChainFromDump({
+      capturedAt: undefined,
+      tripStartedAt: undefined,
+      lifecyclePhase: undefined,
+      fusionConfidence: undefined,
+      subsurface: undefined,
+      gpsAccuracy: undefined,
+      environment: undefined,
+      silentPushReceived: undefined,
+      silentPushFired: undefined,
+      boardingLockActive: undefined,
+      sleepMode: undefined,
+      alarmLogSources: {},
+      notificationsFiredCount: undefined,
+      notificationKinds: ['transfer'],
+      coldStart: undefined,
+    });
+    const stage = report.stages.find((s) => s.stage === 'general-mode-no-alarm-sound');
+    expect(stage?.passed).toBe(true);
+  });
+
+  it('sleepMode=off + alarm kind 없음 → pass', () => {
+    const report = runChainFromDump({
+      capturedAt: undefined,
+      tripStartedAt: undefined,
+      lifecyclePhase: undefined,
+      fusionConfidence: undefined,
+      subsurface: undefined,
+      gpsAccuracy: undefined,
+      environment: undefined,
+      silentPushReceived: undefined,
+      silentPushFired: undefined,
+      boardingLockActive: undefined,
+      sleepMode: 'off',
+      alarmLogSources: {},
+      notificationsFiredCount: undefined,
+      notificationKinds: ['station-passed'],
+      coldStart: undefined,
+    });
+    const stage = report.stages.find((s) => s.stage === 'general-mode-no-alarm-sound');
+    expect(stage?.passed).toBe(true);
+  });
+});
+
+describe('sleep-mode-no-per-station-notification', () => {
+  it('sleepMode=on + station-passed fired → fail', () => {
+    const report = runChainFromDump({
+      capturedAt: undefined,
+      tripStartedAt: undefined,
+      lifecyclePhase: undefined,
+      fusionConfidence: undefined,
+      subsurface: undefined,
+      gpsAccuracy: undefined,
+      environment: undefined,
+      silentPushReceived: undefined,
+      silentPushFired: undefined,
+      boardingLockActive: undefined,
+      sleepMode: 'on',
+      alarmLogSources: {},
+      notificationsFiredCount: undefined,
+      notificationKinds: ['station-passed'],
+      coldStart: undefined,
+    });
+    const stage = report.stages.find((s) => s.stage === 'sleep-mode-no-per-station-notification');
+    expect(stage?.passed).toBe(false);
+    expect(stage?.evidence).toContain('sleepMode=on');
+    expect(stage?.evidence).toContain('station-passed-fired=true');
+  });
+
+  it('sleepMode=on + station-passed 없음 → pass', () => {
+    const report = runChainFromDump({
+      capturedAt: undefined,
+      tripStartedAt: undefined,
+      lifecyclePhase: undefined,
+      fusionConfidence: undefined,
+      subsurface: undefined,
+      gpsAccuracy: undefined,
+      environment: undefined,
+      silentPushReceived: undefined,
+      silentPushFired: undefined,
+      boardingLockActive: undefined,
+      sleepMode: 'on',
+      alarmLogSources: {},
+      notificationsFiredCount: undefined,
+      notificationKinds: ['transfer'],
+      coldStart: undefined,
+    });
+    const stage = report.stages.find((s) => s.stage === 'sleep-mode-no-per-station-notification');
+    expect(stage?.passed).toBe(true);
+  });
+
+  it('일반 모드(sleepMode=off) fixture는 항상 pass (stage 무관 통과)', () => {
+    const report = loadAndRun('morning-trip.txt');
+    const stage = report.stages.find((s) => s.stage === 'sleep-mode-no-per-station-notification');
+    expect(stage?.passed).toBe(true);
+  });
+
+  it('sleepMode 신호 부재 → 판정 보류(pass)', () => {
+    const report = runChainFromDump({
+      capturedAt: undefined,
+      tripStartedAt: undefined,
+      lifecyclePhase: undefined,
+      fusionConfidence: undefined,
+      subsurface: undefined,
+      gpsAccuracy: undefined,
+      environment: undefined,
+      silentPushReceived: undefined,
+      silentPushFired: undefined,
+      boardingLockActive: undefined,
+      sleepMode: undefined,
+      alarmLogSources: {},
+      notificationsFiredCount: undefined,
+      notificationKinds: ['station-passed'],
+      coldStart: undefined,
+    });
+    const stage = report.stages.find((s) => s.stage === 'sleep-mode-no-per-station-notification');
+    expect(stage?.passed).toBe(true);
+  });
+});

--- a/src/testUtils/chainReport.ts
+++ b/src/testUtils/chainReport.ts
@@ -36,6 +36,11 @@ export const CHAIN_STAGE_IDS = [
   'picker-shown',
   'user-selected',
   'mismatch-detected',
+  // ── #2068 mode-aware stages (sleepMode 회귀 재현) ───────────────────────
+  // Phase 1(#2063/#2064)·Phase 2(#2066/#2067) 완료 전에는 fail이 정상 —
+  // fixtureChainRunnerSleepMode.test.ts에서 it.failing으로 마킹.
+  'general-mode-no-alarm-sound',
+  'sleep-mode-no-per-station-notification',
 ] as const;
 
 export type ChainStageId = (typeof CHAIN_STAGE_IDS)[number];

--- a/src/testUtils/dumpParser.ts
+++ b/src/testUtils/dumpParser.ts
@@ -39,6 +39,13 @@ export interface DumpFixture {
   /** ## BoardingLock 섹션 */
   boardingLockActive: boolean | undefined; // active=yes → true
 
+  /**
+   * #2068 — ## Sleep 섹션 sleepMode=on|off. 섹션 부재/파싱 불가 시 undefined.
+   * mode-aware chain stage (일반 모드 알람류 발사 / 취침 모드 매역 notification 발사 회귀
+   * 재현)에서 사용.
+   */
+  sleepMode: 'on' | 'off' | undefined;
+
   /** ## Alarm log 섹션 sources 행. 예: "boarding-prompt=1, fg=30, ..." */
   alarmLogSources: Record<string, number>;
 
@@ -99,6 +106,7 @@ export function parseDumpFixture(text: string): DumpFixture {
     silentPushReceived: parseSilentPushCount(text, 'received'),
     silentPushFired: parseSilentPushCount(text, 'fired'),
     boardingLockActive: parseBoardingLockActive(text),
+    sleepMode: parseSleepMode(text),
     alarmLogSources: parseAlarmLogSources(text),
     notificationsFiredCount: parseNotificationsFiredCount(text),
     notificationKinds: parseNotificationKinds(text),
@@ -150,6 +158,20 @@ function parseBoardingLockActive(text: string): boolean | undefined {
   const m = section.match(/^active=(yes|no)$/m);
   if (!m) return undefined;
   return m[1] === 'yes';
+}
+
+/**
+ * #2068 — `## Sleep` 섹션 `sleepMode=on|off` 파싱.
+ *
+ * DebugModal `buildSleepSection`(components/DebugModal.tsx)이 `sleepMode=${on|off}` 또는
+ * (sleep prop 미전달 시) `sleepMode=—`(UNKNOWN_LABEL)를 출력한다. `on`/`off` 이외 값(또는
+ * 섹션 부재)은 undefined로 graceful 반환.
+ */
+function parseSleepMode(text: string): 'on' | 'off' | undefined {
+  const section = extractSection(text, 'Sleep');
+  if (!section) return undefined;
+  const m = section.match(/^sleepMode=(on|off)$/m);
+  return m ? (m[1] as 'on' | 'off') : undefined;
 }
 
 function parseAlarmLogSources(text: string): Record<string, number> {

--- a/src/testUtils/fixtureChainRunner.ts
+++ b/src/testUtils/fixtureChainRunner.ts
@@ -56,6 +56,13 @@ const COLD_START_ACCURACY_THRESHOLD_M = 50;
  *   - picker-shown: coldStart.pickerShown=yes (섹션 필요)
  *   - user-selected: coldStart.userSelected=yes (섹션 필요)
  *   - mismatch-detected: alarmLogSources['cold-start-mismatch'] >= 1
+ *
+ * #2068 mode-aware stages (Phase 1·2 완료 전 fail이 정상, expected-fail):
+ *   - general-mode-no-alarm-sound: sleepMode=off 인데 alarm류(transfer/destination) kind가
+ *     fired에 존재 → fail. 일반 모드에서는 alarm.wav 발사 0건이어야 한다(ADR 확정 스펙,
+ *     #2061 epic 본문 표).
+ *   - sleep-mode-no-per-station-notification: sleepMode=on 인데 station-passed kind가
+ *     fired에 존재 → fail. 취침 모드에서는 매역 notification이 mute돼야 한다.
  */
 const STAGE_CHECKERS: Record<ChainStageId, StageChecker> = {
   // ── 기존 6 stages ─────────────────────────────────────────────────────────
@@ -236,6 +243,35 @@ const STAGE_CHECKERS: Record<ChainStageId, StageChecker> = {
     return {
       passed: count >= 1,
       evidence: `alarmLog.cold-start-mismatch=${count}`,
+    };
+  },
+
+  // ── #2068 mode-aware stages ──────────────────────────────────────────────
+
+  /**
+   * general-mode-no-alarm-sound: 일반 모드(sleepMode=off)에서 alarm류(transfer/destination)
+   * kind가 발사되면 fail. sleepMode 미확인(undefined)이면 판정 불가 → pass(신호 없음, 보수적
+   * 미차단) — 기존 dump(## Sleep 섹션 없음)가 이 새 stage로 인해 잘못 fail 처리되지 않도록.
+   */
+  'general-mode-no-alarm-sound': (f) => {
+    const alarmKinds = f.notificationKinds.filter((k) => k === 'transfer' || k === 'destination');
+    const passed = f.sleepMode !== 'off' || alarmKinds.length === 0;
+    return {
+      passed,
+      evidence: `sleepMode=${f.sleepMode ?? '?'} alarmKinds=[${alarmKinds.join(',')}]`,
+    };
+  },
+
+  /**
+   * sleep-mode-no-per-station-notification: 취침 모드(sleepMode=on)에서 station-passed kind가
+   * 발사되면 fail. sleepMode 미확인(undefined)이면 판정 불가 → pass(보수적 미차단).
+   */
+  'sleep-mode-no-per-station-notification': (f) => {
+    const stationPassedFired = f.notificationKinds.includes('station-passed');
+    const passed = f.sleepMode !== 'on' || !stationPassedFired;
+    return {
+      passed,
+      evidence: `sleepMode=${f.sleepMode ?? '?'} station-passed-fired=${stationPassedFired}`,
     };
   },
 };

--- a/src/testUtils/fixtures/day2/regression-general-mode-alarm-sound.txt
+++ b/src/testUtils/fixtures/day2/regression-general-mode-alarm-sound.txt
@@ -1,0 +1,73 @@
+[Subway debug] 2026-07-29T08:12:03.000Z
+
+## GPS
+lat=37.54, lng=127.05, speed=12.3 m/s, accuracy=18.1 m
+fused=(no fused signal)
+state=fg, lastFix=08:12:01
+subsurface=false (readings=40)
+
+## Nearest
+성수 · 90 m
+variants: 성수(2)
+
+## Fusion
+confidence=gps-only, source=gps
+fused: 성수(2) · 90m
+gps:   성수(2) · 90m
+tier=low
+signalMask=UUF
+
+## Trip
+lockless=false
+tripStartedAt=08:01:10
+currentHopIndex=3
+route hop count=5
+displayOnlyEstimate=(none)
+lifecyclePhase=active
+
+## Sleep
+sleepMode=off
+firstHopApproaching=false
+
+## Arrival
+up: 성수행 - 건대입구방면 · 60s (1분 후)
+down: 성수행 - 뚝섬방면 · 120s (2분 후)
+
+## Silent Push
+permission=granted
+apnsToken=…35b3502c
+activeTrip=(none)
+apnsEnv=production
+taskRegistration=success
+route=(none)
+destination=(none)
+currentStation=(none)
+received=2 (last 08:11:40)
+receivedByKind=stn=1 xfer=1 dst=0 unk=0
+fired=0 (last (never))
+lastSkipped=(never)
+lowPowerMode=off
+
+## Backend SSoT
+(no recent SSoT push)
+
+## Scheduled queue (0)
+
+## Gates
+candidate-distance-reject=12
+
+## BoardingLock
+active=yes
+
+## Estimator State (2)
+08:11:55 | live-position | 성수(2) idx=3
+08:11:40 | arrival-eta | 건대입구(2) idx=2
+
+## Notifications fired (2)
+08:11:58 | fg | fired | station-passed | 성수
+08:11:20 | fg | fired | transfer | imminent | 건대입구
+
+## Alarm log (12)
+sources: fg=6, fg-evaluated=4, silent-push-received=2
+08:11:58 | fg | fired | station-passed | 성수
+08:11:20 | fg | fired | transfer | imminent | 건대입구


### PR DESCRIPTION
Closes #2068

## 요약

fg polling / bg pipeline / silent push / OS 사전예약 4개 발사 경로가 같은 물리적 station 이벤트에 대해 실제 발사(expo-notifications mock 호출) 횟수를 몇 건 만드는지 검증하는 하네스를 신설했다. 기존 `fixtureChainRunner.ts`는 DebugModal dump 스냅샷 평가기라 이벤트 순서·발사 횟수·race를 재현할 수 없어(2026-07-29 4-audit), 이번 PR은 별도 시퀀스 테스트로 이를 보완한다.

- `src/features/alarm/utils/__tests__/fireSequence.test.ts` 신설
  - 3개 helper(`fireViaFgOrBgPath` / `fireViaSilentPushPath` / `fireViaOsScheduledPath`)가 real production gate 함수(`crossCategoryStationDedup.ts`)를 실제 caller와 동일한 순서로 호출 — 재구현이 아니라 "경유"(각 helper docstring에 caller 파일:라인 근거 명시)
  - 시나리오 (a) 같은 역 3소스(os-scheduled/fg/silent) 각 1회 주입 → 총 발사 ≤1 기대, 실제 2건(OS 사전예약이 dedup 게이트를 우회)
  - 시나리오 (b) 앱 재시작 시뮬(`jest.isolateModules`로 모듈 registry만 새로 만들고 AsyncStorage mock data는 outer 스코프에 유지) 후 재주입 → 추가 발사 0 기대, 실제 1건 추가(in-memory dedup 소실). AsyncStorage 기반 `firedPushIds`는 대조군으로 재시작 후에도 dedup이 보존됨을 별도 green 테스트로 확인
  - 시나리오 (c) 일반 모드(sleepMode=off)에서 실제 production `sendAlarmNotification` 호출 → sound=alarm.wav 0건 기대, 실제로는 allowSpeaker 기본값 때문에 sleepMode 무관하게 발사
  - (a)(b)(c) 모두 `it.failing`으로 마킹 — Phase 1(#2063/#2064)·Phase 2(#2066/#2067) 완료 시 unskip
- `src/testUtils/dumpParser.ts`: `## Sleep` 섹션 `sleepMode=on|off` 파싱 추가 (`DumpFixture.sleepMode`)
- `src/testUtils/chainReport.ts` / `fixtureChainRunner.ts`: mode-aware stage 2개 신설
  - `general-mode-no-alarm-sound`: sleepMode=off인데 alarm류(transfer/destination) fired → fail
  - `sleep-mode-no-per-station-notification`: sleepMode=on인데 station-passed fired → fail
- `src/testUtils/fixtures/day2/regression-general-mode-alarm-sound.txt` 신설(일반 모드 + transfer 알람 fired 합성 dump)
- 기존 3개 테스트 파일(`chainReport.test.ts`/`fixtureChainRunner.test.ts`/`fixtureChainRunnerPhase61.test.ts`)의 `CHAIN_STAGE_IDS.toHaveLength(12)` 단언을 14로 갱신 + 리터럴 `DumpFixture` object 8곳에 `sleepMode: undefined` 필드 보강 — stage 개수가 늘어난 데 따른 기계적 변경이며 기존 stage·fixture의 판정(pass/fail)은 변경하지 않음

## Red 재현 케이스 (현 코드 기준 실패, `it.failing`)

1. `fireSequence.test.ts` 시나리오 (a) — OS 사전예약이 런타임 dedup을 우회해 같은 역에 2건 발사
2. `fireSequence.test.ts` 시나리오 (b) — 앱 재시작 후 in-memory dedup(crossCategoryStationDedup) 소실로 재발사
3. `fireSequence.test.ts` 시나리오 (c) — `sendAlarmNotification`이 sleepMode=off에도 sound='alarm.wav' 발사
4. `fixtureChainRunnerSleepMode.test.ts` — `general-mode-no-alarm-sound` stage가 `regression-general-mode-alarm-sound.txt`(및 기존 `morning-trip.txt`)에서 fail

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard** — 신규 테스트는 jest 실행 결과가 유일한 signal (device/production 연결 없음, 순수 테스트 하네스)
3. **의존 PR** — N/A
4. **측정 plan** — `npx jest src/testUtils/__tests__/` + `npx jest src/features/alarm/utils/__tests__/fireSequence.test.ts` 실행 결과로 확인. red 재현 케이스는 위 4건, Phase 1·2 PR에서 `it.failing` 제거 후 green 전환 여부로 진행 측정
5. **Device verify** — N/A — type+unit only

## 테스트 결과

```
npx jest src/testUtils/__tests__/                                    # 172 passed (dumpParser/chainReport/fixtureChainRunner 계열)
npx jest src/features/alarm/utils/__tests__/fireSequence.test.ts     # 5 passed (it.failing 3건 포함, 전부 기대대로 동작)
npm test                                                              # 427 suites / 9208 tests passed, coverage 100/100/100/100
npm run type-check                                                    # clean
npm run lint:orphan                                                   # No orphan exports detected.
```

## Test plan
- [x] `npm test` 커버리지 100%
- [x] `npm run type-check` 통과
- [x] `npm run lint:orphan` 통과
- [x] red 재현 케이스 4건 확인 (위 목록)