### PR TITLE
chore(#2073): cron KV quota fix — listTrips 병합 + 진짜 idle skip + jitter 스로틀 + self-poll TTL

### DIFF
--- a/backend/alarm-worker/src/__tests__/cronIdleGate.test.ts
+++ b/backend/alarm-worker/src/__tests__/cronIdleGate.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { PUSH_ACTIVITY_TTL_SEC, readPushActivityRecent, stampPushActivity } from '../cronIdleGate';
+import { InMemoryKV } from './inMemoryKv';
+
+describe('cronIdleGate (#2073 Issue A)', () => {
+  let kv: InMemoryKV;
+  const NOW = 1_700_000_000_000;
+
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  describe('readPushActivityRecent', () => {
+    it('returns false when no marker was ever stamped', async () => {
+      expect(await readPushActivityRecent(kv as unknown as KVNamespace)).toBe(false);
+    });
+
+    it('returns true right after stampPushActivity', async () => {
+      await stampPushActivity(kv as unknown as KVNamespace, NOW);
+      expect(await readPushActivityRecent(kv as unknown as KVNamespace)).toBe(true);
+    });
+
+    it('returns false after marker TTL naturally expires', async () => {
+      await stampPushActivity(kv as unknown as KVNamespace, NOW);
+      const entry = kv.store.get('cron:push-activity');
+      expect(entry?.expiresAt).toBeGreaterThan(Date.now());
+      expect(entry?.expiresAt).toBeLessThanOrEqual(Date.now() + PUSH_ACTIVITY_TTL_SEC * 1000);
+      // simulate expiry by directly deleting (InMemoryKV expires based on wall clock, not `now` param).
+      kv.store.delete('cron:push-activity');
+      expect(await readPushActivityRecent(kv as unknown as KVNamespace)).toBe(false);
+    });
+
+    it('returns false when kv is undefined', async () => {
+      expect(await readPushActivityRecent(undefined)).toBe(false);
+    });
+
+    it('returns true (conservative — 활동 있을 수 있음으로 오판 방지) when kv.get throws', async () => {
+      const throwingKv = {
+        get: async () => {
+          throw new Error('kv down');
+        },
+      } as unknown as KVNamespace;
+      expect(await readPushActivityRecent(throwingKv)).toBe(true);
+    });
+  });
+
+  describe('stampPushActivity', () => {
+    it('graceful no-op when kv is undefined', async () => {
+      await expect(stampPushActivity(undefined, NOW)).resolves.toBeUndefined();
+    });
+
+    it('graceful when kv.put throws', async () => {
+      const throwingKv = {
+        put: async () => {
+          throw new Error('kv down');
+        },
+      } as unknown as KVNamespace;
+      await expect(stampPushActivity(throwingKv, NOW)).resolves.toBeUndefined();
+    });
+
+    it('re-stamping keeps the marker alive (readPushActivityRecent still true)', async () => {
+      await stampPushActivity(kv as unknown as KVNamespace, NOW);
+      await stampPushActivity(kv as unknown as KVNamespace, NOW + 60_000);
+      expect(await readPushActivityRecent(kv as unknown as KVNamespace)).toBe(true);
+    });
+  });
+});

--- a/backend/alarm-worker/src/__tests__/cronJitterAggregate.test.ts
+++ b/backend/alarm-worker/src/__tests__/cronJitterAggregate.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   HEARTBEAT_INTERVAL_MS,
+  JITTER_SAMPLE_EVERY_N_TICKS,
   JITTER_SAMPLES_MAX_LEN,
   appendJitterSample,
   computeJitterPercentiles,
   readJitterSamples,
   resetJitterSamples,
   shouldEmitHeartbeat,
+  shouldSampleJitterTick,
   stampHeartbeat,
 } from '../cronJitterAggregate';
 import { InMemoryKV } from './inMemoryKv';
@@ -177,6 +179,31 @@ describe('cronJitterAggregate (#2054)', () => {
         },
       } as unknown as KVNamespace;
       await expect(stampHeartbeat(throwingKv, NOW)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('shouldSampleJitterTick (#2073 Issue D)', () => {
+    const TICK_MS = 60_000;
+
+    it('samples true on tick index 0 (and every JITTER_SAMPLE_EVERY_N_TICKS multiple)', () => {
+      expect(shouldSampleJitterTick(0, TICK_MS)).toBe(true);
+      const tenthTick = TICK_MS * JITTER_SAMPLE_EVERY_N_TICKS;
+      expect(shouldSampleJitterTick(tenthTick, TICK_MS)).toBe(true);
+      const twentiethTick = TICK_MS * JITTER_SAMPLE_EVERY_N_TICKS * 2;
+      expect(shouldSampleJitterTick(twentiethTick, TICK_MS)).toBe(true);
+    });
+
+    it('samples false on non-multiple tick indices', () => {
+      for (let tick = 1; tick < JITTER_SAMPLE_EVERY_N_TICKS; tick++) {
+        expect(shouldSampleJitterTick(tick * TICK_MS, TICK_MS)).toBe(false);
+      }
+    });
+
+    it('is deterministic — only depends on now/tickIntervalMs, not call order', () => {
+      const now = 1_700_000_000_000;
+      const first = shouldSampleJitterTick(now, TICK_MS);
+      const second = shouldSampleJitterTick(now, TICK_MS);
+      expect(first).toBe(second);
     });
   });
 });

--- a/backend/alarm-worker/src/__tests__/index.scheduledGate.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.scheduledGate.test.ts
@@ -1,0 +1,122 @@
+/**
+ * #2073 (Issue A) — `handler.scheduled`가 `runScheduled`의 `pendingActivityPossible` stat으로
+ * `runFallbackPushes`/`runRetryPushes` 호출 여부를 게이트하는지 검증.
+ *
+ * `runScheduled`/`runFallbackPushes`/`runRetryPushes`를 모킹해 index.ts의 게이트 배선(wiring)만
+ * 단위 격리 테스트한다 — 각 함수 내부 로직은 scheduled.test.ts / fallback.test.ts /
+ * retryPushes.test.ts가 이미 커버한다.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../types';
+import { InMemoryKV } from './inMemoryKv';
+import { readPushActivityRecent } from '../cronIdleGate';
+
+const runScheduledMock = vi.fn();
+const runFallbackPushesMock = vi.fn();
+const runRetryPushesMock = vi.fn();
+
+vi.mock('../scheduled', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../scheduled')>();
+  return { ...actual, runScheduled: (...args: unknown[]) => runScheduledMock(...args) };
+});
+vi.mock('../fallback', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../fallback')>();
+  return { ...actual, runFallbackPushes: (...args: unknown[]) => runFallbackPushesMock(...args) };
+});
+vi.mock('../retryPushes', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../retryPushes')>();
+  return { ...actual, runRetryPushes: (...args: unknown[]) => runRetryPushesMock(...args) };
+});
+
+// 모듈 모킹 이후 동적 import — vi.mock hoisting과의 순서 보장.
+const { handler } = await import('../index');
+
+function makeEnv(kv: InMemoryKV): Env {
+  return {
+    TRIPS: kv as unknown as Env['TRIPS'],
+    APNS_HOST: 'api.push.apple.com',
+    APNS_HOST_SANDBOX: 'api.sandbox.push.apple.com',
+    SEOUL_API_HOST: 'h',
+    SEOUL_API_KEY: 'k',
+    APNS_KEY_ID: 'k',
+    APNS_TEAM_ID: 't',
+    APNS_PRIVATE_KEY: 'p',
+    APNS_BUNDLE_ID: 'b',
+  };
+}
+
+function baseScheduledStats(overrides: Partial<{ pendingActivityPossible: boolean }> = {}) {
+  return {
+    scanned: 0,
+    pendingActivityPossible: true,
+    ...overrides,
+  };
+}
+
+// #2073 — Sentry.withSentry HOC가 default export와 named export `handler`를 같은 객체 참조로
+// mutate하므로, 여기서도 real ExecutionContext/ScheduledController 형태의 최소 stub이 필요하다
+// (empty object는 Sentry instrumentation 내부에서 throw).
+function makeExecutionContext(): ExecutionContext {
+  return {
+    waitUntil: () => {},
+    passThroughOnException: () => {},
+    props: {},
+  } as unknown as ExecutionContext;
+}
+
+function makeScheduledController(): ScheduledController {
+  return {
+    scheduledTime: Date.now(),
+    cron: '*/1 * * * *',
+    noRetry: () => {},
+  } as unknown as ScheduledController;
+}
+
+describe('handler.scheduled — #2073 idle-skip 게이트', () => {
+  beforeEach(() => {
+    runScheduledMock.mockReset();
+    runFallbackPushesMock.mockReset();
+    runRetryPushesMock.mockReset();
+    runFallbackPushesMock.mockResolvedValue({ scanned: 0, pushed: 0, errors: 0, deferred: 0 });
+    runRetryPushesMock.mockResolvedValue({
+      scanned: 0,
+      deferred: 0,
+      resent: 0,
+      rescheduled: 0,
+      exhausted: 0,
+    });
+  });
+
+  it('pendingActivityPossible=false — runFallbackPushes/runRetryPushes를 호출하지 않는다', async () => {
+    const kv = new InMemoryKV();
+    runScheduledMock.mockResolvedValue(baseScheduledStats({ pendingActivityPossible: false }));
+    await handler.scheduled(makeScheduledController(), makeEnv(kv), makeExecutionContext());
+    expect(runScheduledMock).toHaveBeenCalledTimes(1);
+    expect(runFallbackPushesMock).not.toHaveBeenCalled();
+    expect(runRetryPushesMock).not.toHaveBeenCalled();
+  });
+
+  it('pendingActivityPossible=true — runFallbackPushes/runRetryPushes를 호출한다', async () => {
+    const kv = new InMemoryKV();
+    runScheduledMock.mockResolvedValue(baseScheduledStats({ pendingActivityPossible: true }));
+    await handler.scheduled(makeScheduledController(), makeEnv(kv), makeExecutionContext());
+    expect(runFallbackPushesMock).toHaveBeenCalledTimes(1);
+    expect(runRetryPushesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('pendingActivityPossible=true + fallback/retry가 entry를 발견 — activity marker를 재stamp한다', async () => {
+    const kv = new InMemoryKV();
+    runScheduledMock.mockResolvedValue(baseScheduledStats({ pendingActivityPossible: true }));
+    runFallbackPushesMock.mockResolvedValue({ scanned: 1, pushed: 1, errors: 0, deferred: 0 });
+    await handler.scheduled(makeScheduledController(), makeEnv(kv), makeExecutionContext());
+    expect(await readPushActivityRecent(kv as unknown as KVNamespace)).toBe(true);
+  });
+
+  it('pendingActivityPossible=true + fallback/retry 모두 empty — marker를 재stamp하지 않는다', async () => {
+    const kv = new InMemoryKV();
+    runScheduledMock.mockResolvedValue(baseScheduledStats({ pendingActivityPossible: true }));
+    // runFallbackPushes/runRetryPushes 기본 mock 모두 scanned:0.
+    await handler.scheduled(makeScheduledController(), makeEnv(kv), makeExecutionContext());
+    expect(await readPushActivityRecent(kv as unknown as KVNamespace)).toBe(false);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -52,6 +52,8 @@ import {
 } from '../scheduled';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from '../seoul';
 import { ARVLCD_FIRE_ONCE_TTL_SEC, arvlCdFireOnceKey } from '../arvlcdFireOnceTtl';
+import { stampPushActivity, readPushActivityRecent } from '../cronIdleGate';
+import { JITTER_SAMPLE_EVERY_N_TICKS, readJitterSamples } from '../cronJitterAggregate';
 import { putTrip } from '../trips';
 import { readSsot, seedSsot, ssotKey, writeSsot, type TripPositionSSoT } from '../tripPositionSsot';
 import type { BoardingLockMeta, Env, PositionPoint, Trip, Waypoint } from '../types';
@@ -172,6 +174,8 @@ function makeFullEmptyStats(): ScheduledStats {
       noGps: 0,
       stationUnknown: 0,
     },
+    // #2073 (Issue A) — pending/retry push 존재 가능성 게이트. 기본 true(보수적).
+    pendingActivityPossible: true,
   };
 }
 
@@ -8805,6 +8809,8 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
         noGps: 0,
         stationUnknown: 0,
       },
+      // #2073 (Issue A) — pending/retry push 존재 가능성 게이트. 기본 true(보수적).
+      pendingActivityPossible: true,
     };
     const { dirty } = await fireArvlCdStationPush({
       trip,
@@ -9567,6 +9573,166 @@ describe('maybeFireHopEndPrompt (#2034)', () => {
     // 기존 legKey 는 유지, 새 legKey (`성수|5`) 는 신규 fired.
     expect(trip.hopEndPromptState?.['성수|K']?.fired).toBe(true);
     expect(trip.hopEndPromptState?.['성수|5']?.fired).toBe(true);
+  });
+});
+
+/**
+ * #2073 — cron KV quota fix (listTrips 병합 + 진짜 idle skip + jitter 스로틀).
+ *
+ * 2026-07-29 quota audit: 사용자 0명 상태에서도 KV list 720%/write 144% 초과.
+ *   - Issue B: listTrips가 collectActiveLines/collectActiveStations/main loop 각자 호출(3회) →
+ *     `runScheduled` 진입부에서 1회만 list해 배열로 공유.
+ *   - Issue A: #2054 idle-skip은 로그만 억제 — 진짜 idle(trip 0 + 직전 tick 근방 활동 없음)엔
+ *     `pendingActivityPossible=false`로 index.ts가 runFallbackPushes/runRetryPushes를 skip.
+ *   - Issue D: jitter sample write를 10 tick당 1회로 스로틀.
+ */
+describe('runScheduled — #2073 listTrips 병합 (Issue B)', () => {
+  it('활성 trip 1개 — trip: prefix kv.get 호출 횟수가 1회(=N)로 병합된다 (기존 3N 회귀 방지)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTrip());
+    const getSpy = vi.spyOn(kv, 'get');
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    const tripGetCalls = getSpy.mock.calls.filter((c) => String(c[0]).startsWith('trip:'));
+    // 병합 전엔 collectActiveLines + collectActiveStations + main loop 각자 listTrips를 순회해
+    // trip 1개당 3회 kv.get('trip:tok')이 발생했다. 병합 후엔 1회.
+    expect(tripGetCalls.length).toBe(1);
+  });
+
+  it('활성 trip 2개 — trip: prefix kv.get 호출 횟수가 2회(=N)로 병합된다', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ token: 'tok-a' }));
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ token: 'tok-b' }));
+    const getSpy = vi.spyOn(kv, 'get');
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    const tripGetCalls = getSpy.mock.calls.filter((c) => String(c[0]).startsWith('trip:'));
+    expect(tripGetCalls.length).toBe(2);
+  });
+
+  it('collectActiveLines/collectActiveStations 파생 결과는 병합 전과 동등 — self-poll fetch가 여전히 발생한다', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTrip());
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    // line union(2호선) + station union(강남) 이 여전히 병합된 trips 배열에서 파생돼
+    // self-poll fetch/stationPollFetch가 발생한다(0이 아님) — collectActiveLines/Stations가
+    // 여전히 정상 동작함을 간접 검증.
+    expect(stats.realtimePositionFetch + stats.selfPollCacheHit).toBeGreaterThan(0);
+    expect(stats.stationPollFetch + stats.stationPollCacheHit).toBeGreaterThan(0);
+  });
+});
+
+describe('runScheduled — #2073 진짜 idle skip 게이트 (Issue A)', () => {
+  it('idle tick(활성 trip 0 + marker 없음) — kv.list 1회, kv.put 0회, pendingActivityPossible=false', async () => {
+    const kv = new InMemoryKV();
+    // heartbeat가 이번 tick에 발화하지 않도록 직전 heartbeat를 미리 stamp(첫 진입 heartbeat put을
+    // "idle write 0" 검증에서 배제 — 이슈 본문도 heartbeat 시간당 1 put은 예외로 명시).
+    await (kv as unknown as KVNamespace).put('scheduled:last-heartbeat', String(NOW));
+    const listSpy = vi.spyOn(kv, 'list');
+    const putSpy = vi.spyOn(kv, 'put');
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.scanned).toBe(0);
+    expect(stats.pendingActivityPossible).toBe(false);
+    expect(listSpy).toHaveBeenCalledTimes(1);
+    expect(putSpy).not.toHaveBeenCalled();
+  });
+
+  it('활성 trip 존재 — pendingActivityPossible=true + activity marker stamp', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTrip());
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.pendingActivityPossible).toBe(true);
+    expect(await readPushActivityRecent(kv as unknown as KVNamespace)).toBe(true);
+  });
+
+  it('활성 trip 0이지만 직전 tick 근방 활동 marker 有 — pendingActivityPossible=true (idle 아님)', async () => {
+    const kv = new InMemoryKV();
+    await stampPushActivity(kv as unknown as KVNamespace, NOW - 30_000);
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    expect(stats.scanned).toBe(0);
+    expect(stats.pendingActivityPossible).toBe(true);
+  });
+});
+
+describe('runScheduled — #2073 jitter sample 10 tick당 1회 스로틀 (Issue D)', () => {
+  it('활성 trip 있는 tick도 sample tick이 아니면 jitter sample write를 skip한다', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTrip());
+    // tick index 1 (10의 배수가 아님) — CRON_NOMINAL_INTERVAL_MS(60_000) 경계 기준.
+    const nonSampleNow = 60_000 * 1; // tickIndex=1 → 1 % 10 !== 0
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => nonSampleNow,
+    });
+    const samples = await readJitterSamples(kv as unknown as KVNamespace);
+    expect(samples.length).toBe(0);
+  });
+
+  it('sample tick(tick index가 JITTER_SAMPLE_EVERY_N_TICKS의 배수)엔 jitter sample을 write한다', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTrip());
+    const sampleNow = 60_000 * JITTER_SAMPLE_EVERY_N_TICKS; // tickIndex=10 → 10 % 10 === 0
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => sampleNow,
+    });
+    const samples = await readJitterSamples(kv as unknown as KVNamespace);
+    expect(samples.length).toBe(1);
+  });
+
+  it('idle tick(활성 trip 없음)은 sample tick이어도 jitter sample write를 skip한다', async () => {
+    const kv = new InMemoryKV();
+    await (kv as unknown as KVNamespace).put('scheduled:last-heartbeat', String(60_000 * JITTER_SAMPLE_EVERY_N_TICKS));
+    const sampleNow = 60_000 * JITTER_SAMPLE_EVERY_N_TICKS;
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => sampleNow,
+    });
+    const samples = await readJitterSamples(kv as unknown as KVNamespace);
+    expect(samples.length).toBe(0);
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/selfPollPosition.test.ts
+++ b/backend/alarm-worker/src/__tests__/selfPollPosition.test.ts
@@ -117,6 +117,13 @@ describe('SELF_POLL_TTL_SEC', () => {
     // KV_MIN_CACHE_TTL_SEC=30 [[lesson_cron_cachettl_runtime_constraint]]
     expect(SELF_POLL_TTL_SEC).toBeGreaterThanOrEqual(30);
   });
+
+  it('#2073 (Issue TTL) — exceeds cron nominal interval (60s) so a stamp survives into the next tick', () => {
+    // 30s < 60s cron 주기라 매 tick 강제 재fetch/재write 를 유발하던 회귀(#2073) 방지.
+    const CRON_NOMINAL_INTERVAL_SEC = 60;
+    expect(SELF_POLL_TTL_SEC).toBeGreaterThan(CRON_NOMINAL_INTERVAL_SEC);
+    expect(SELF_POLL_TTL_SEC).toBe(90);
+  });
 });
 
 describe('readSelfPollPosition / writeSelfPollPosition round-trip', () => {
@@ -141,13 +148,12 @@ describe('readSelfPollPosition / writeSelfPollPosition round-trip', () => {
     expect(await readSelfPollPosition(kv as unknown as KVNamespace, '7')).toBeNull();
   });
 
-  it('writes with 30s expirationTtl', async () => {
+  it('writes with SELF_POLL_TTL_SEC (90s) expirationTtl', async () => {
     const kv = new InMemoryKV() as unknown as KVNamespace;
     await writeSelfPollPosition(kv, '7', [makePosition()], NOW);
     const entry = (kv as unknown as InMemoryKV).store.get(selfPollKey('7'));
     expect(entry?.expiresAt).toBeDefined();
-    // TTL 30s minimum.
-    expect(entry!.expiresAt! - Date.now()).toBeGreaterThan(25 * 1000);
+    expect(entry!.expiresAt! - Date.now()).toBeGreaterThan(85 * 1000);
   });
 });
 
@@ -173,12 +179,12 @@ describe('readSelfPollStationArrivals / writeSelfPollStationArrivals round-trip 
     expect(await readSelfPollStationArrivals(kv as unknown as KVNamespace, '신도림')).toBeNull();
   });
 
-  it('writes with 30s expirationTtl', async () => {
+  it('writes with SELF_POLL_TTL_SEC (90s) expirationTtl', async () => {
     const kv = new InMemoryKV() as unknown as KVNamespace;
     await writeSelfPollStationArrivals(kv, '신도림', [makeArrival()], NOW);
     const entry = (kv as unknown as InMemoryKV).store.get(selfPollStationKey('신도림'));
     expect(entry?.expiresAt).toBeDefined();
-    expect(entry!.expiresAt! - Date.now()).toBeGreaterThan(25 * 1000);
+    expect(entry!.expiresAt! - Date.now()).toBeGreaterThan(85 * 1000);
   });
 
   it('stamps empty arrivals gracefully (fallback path)', async () => {
@@ -284,6 +290,44 @@ describe('pollLinesAndStamp', () => {
     expect(stats.error).toBe(1);
     expect(stats.fetched).toBe(0);
     spy.mockRestore();
+  });
+
+  it('#2073 (Issue TTL) — re-received (within TTL) tick performs 0 KV puts', async () => {
+    // InMemoryKV expiry is wall-clock based — fake timers required to simulate tick spacing.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(NOW);
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      const seoul = makeSeoulClient({ positions: [makePosition()] });
+      await pollLinesAndStamp(kv, seoul, new Set(['7']), NOW);
+      // Next cron tick (60s later) — well within SELF_POLL_TTL_SEC(90s), so entry is still alive:
+      // existing !== null → cache-hit → fetch and put both skipped (0 writes this tick).
+      vi.setSystemTime(NOW + 60_000);
+      const putSpy = vi.spyOn(kv, 'put');
+      const stats = await pollLinesAndStamp(kv, seoul, new Set(['7']), NOW + 60_000);
+      expect(putSpy).not.toHaveBeenCalled();
+      expect(stats).toEqual({ fetched: 0, cacheHit: 1, error: 0 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('#2073 (Issue TTL) — tick after TTL expiry re-fetches and puts exactly once', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(NOW);
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      const seoul = makeSeoulClient({ positions: [makePosition()] });
+      await pollLinesAndStamp(kv, seoul, new Set(['7']), NOW);
+      // 91s later — past SELF_POLL_TTL_SEC(90s), entry naturally expired → cache-miss → 1 put.
+      vi.setSystemTime(NOW + 91_000);
+      const putSpy = vi.spyOn(kv, 'put');
+      const stats = await pollLinesAndStamp(kv, seoul, new Set(['7']), NOW + 91_000);
+      expect(putSpy).toHaveBeenCalledTimes(1);
+      expect(stats.fetched).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/backend/alarm-worker/src/cronIdleGate.ts
+++ b/backend/alarm-worker/src/cronIdleGate.ts
@@ -1,0 +1,63 @@
+/**
+ * #2073 — cron 진짜 idle skip 게이트.
+ *
+ * 배경: #2054 idle-skip은 함수 끝의 로그만 억제했고 KV 연산(listTrips 중복 3회, jitter write 등)은
+ * 하나도 skip하지 않았다 (2026-07-29 quota 계수 audit — 사용자 0명 상태에서도 KV list 720%,
+ * write 144% 초과).
+ *
+ * 본 모듈은 "활성 trip 부재 + 직전 tick 근방 fire/retry 기록 없음"을 진짜 idle로 판정하는
+ * marker를 제공한다. pending/retry push entry는 활성 trip이 존재하는 tick에서만 새로 생성된다
+ * (모든 fire 경로가 trip 기반) — 따라서 "trip 존재" 또는 "직전 tick 근방에 fire/retry 기록"
+ * 이면 pending/retry가 아직 남아있을 가능성이 있다고 보수적으로 판단한다.
+ *
+ * `runScheduled`(scheduled.ts)가 trip 존재 시 stamp하고, `index.ts`가 runFallbackPushes /
+ * runRetryPushes 가 실제로 entry를 발견했을 때 재stamp해 backoff가 긴 retry도 커버한다.
+ */
+
+const PUSH_ACTIVITY_KEY = 'cron:push-activity';
+
+/**
+ * marker TTL(초). cron 60s 주기의 최소 2 tick(120s) 이상 생존해야 "직전 tick" 판정이 다음
+ * cycle에서도 유효하다. entry 발견 시 매번 재stamp되므로 backoff가 이보다 긴 retry는 그
+ * 사이 cycle에서 계속 연장된다.
+ */
+export const PUSH_ACTIVITY_TTL_SEC = 120;
+
+/**
+ * 활성 trip 존재 또는 pending/retry backlog 발견 시 marker stamp.
+ * KV 미바인딩 / write 실패는 graceful — 다음 tick이 안전 방향(idle 아님)으로 판정되므로
+ * 서비스 영향 없음(관측 정밀도만 손실).
+ */
+export async function stampPushActivity(
+  kv: KVNamespace | undefined,
+  now: number,
+): Promise<void> {
+  if (!kv) return;
+  try {
+    await kv.put(PUSH_ACTIVITY_KEY, String(now), { expirationTtl: PUSH_ACTIVITY_TTL_SEC });
+  } catch {
+    // silent — 관측/게이트 정밀도만 손실.
+  }
+}
+
+/**
+ * marker가 살아있는지(=직전 tick 근방 fire/retry 활동 기록) 여부.
+ *
+ * KV 미바인딩은 false(활동 없음) — binding 자체가 없으면 marker 개념이 무의미하고, 호출자가
+ * `trips.length === 0 && !activityRecent`로 조합하므로 trip이 존재하면 어차피 idle이 아니다.
+ *
+ * read 실패(KV 장애)는 **true**를 반환한다 — "활동 기록을 확인할 수 없음"을 "활동 있을 수 있음"
+ * 으로 보수 판정해 idle 오판을 피한다. false를 반환하면 `trips.length === 0`인 tick에서
+ * `idle = true`가 되어 `runFallbackPushes`/`runRetryPushes`가 통째로 skip될 수 있고, 그 tick에
+ * 마침 pending/retry backlog가 남아 있었다면 사용자 push가 지연된다 — read 실패는 드물게라도
+ * fire/retry semantics에 영향을 줘선 안 된다(#2073 "하지 말 것").
+ */
+export async function readPushActivityRecent(kv: KVNamespace | undefined): Promise<boolean> {
+  if (!kv) return false;
+  try {
+    const raw = await kv.get(PUSH_ACTIVITY_KEY);
+    return raw !== null;
+  } catch {
+    return true;
+  }
+}

--- a/backend/alarm-worker/src/cronJitterAggregate.ts
+++ b/backend/alarm-worker/src/cronJitterAggregate.ts
@@ -48,6 +48,23 @@ export const HEARTBEAT_KV_TTL_SEC = 7200;
  */
 export const JITTER_SAMPLES_KV_TTL_SEC = 24 * 60 * 60;
 
+/**
+ * #2073 — jitter sample write 스로틀 주기(tick 수). appendJitterSample이 매 정상 tick 실행돼
+ * write 1,440/일(한도 1,000, 144%)을 유발했다(2026-07-29 quota audit). 10 tick당 1회로
+ * 샘플링해도 P50/P99 관측(halt 감지)에는 충분한 정밀도 — 순수 관측용 지표라 정밀도 저하가
+ * 사용자 가치에 영향 없음.
+ */
+export const JITTER_SAMPLE_EVERY_N_TICKS = 10;
+
+/**
+ * 절대 tick index(now / tickIntervalMs) 기준 결정적 샘플링 gate. KV 상태 없이 `now`만으로
+ * 계산해 마지막 write 성공 여부와 무관하게 항상 같은 tick에서 true를 반환한다(재시작/장애
+ * 후에도 sampling 주기가 흔들리지 않음).
+ */
+export function shouldSampleJitterTick(now: number, tickIntervalMs: number): boolean {
+  return Math.floor(now / tickIntervalMs) % JITTER_SAMPLE_EVERY_N_TICKS === 0;
+}
+
 /** 정상 jitter sample 을 KV 배열에 append. graceful (KV 없음/실패 무시). */
 export async function appendJitterSample(
   kv: KVNamespace | undefined,

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -18,6 +18,7 @@ import {
   recordBoardingPromptOutcome,
   validateBoardingPromptOutcome,
 } from './boardingPromptOutcome';
+import { stampPushActivity } from './cronIdleGate';
 import { runFallbackPushes } from './fallback';
 import { runRetryPushes } from './retryPushes';
 import {
@@ -2260,7 +2261,9 @@ function parseBoardingLock(raw: unknown): BoardingLockMeta | undefined {
   };
 }
 
-const handler = {
+// #2073 — named export(테스트 전용). default export는 Sentry.withSentry HOC로 감싸져 있어
+// `handler.scheduled`를 직접 단위 테스트하려면 HOC를 우회할 진입점이 필요하다.
+export const handler = {
   fetch: app.fetch,
   async scheduled(_controller: ScheduledController, env: Env, _ctx: ExecutionContext): Promise<void> {
     sentryInit(env);
@@ -2282,21 +2285,32 @@ const handler = {
     const log = (msg: string, meta?: Record<string, unknown>) =>
       console.log(JSON.stringify({ msg, ...meta, archFlag }));
 
+    let scheduledStats: Awaited<ReturnType<typeof runScheduled>>;
     try {
       // #1995 (ADR-022 Phase 1-2) — archFlag 를 runScheduled deps 로 forward.
       // 각 caller (arvlcd / vanish / transfer-release / lockless) 가 putPending / enqueueRetryIfTransient
       // 호출 시 이 값을 전달해 flag=on 시 destination 이외 kind 는 skip.
-      await runScheduled(env, { seoul, apnsConfig, apnsHosts, log, archFlag });
+      scheduledStats = await runScheduled(env, { seoul, apnsConfig, apnsHosts, log, archFlag });
     } catch (err) {
       void captureBackendException(env, err, { path: 'scheduled/runScheduled' });
       throw err;
     }
-    // #572 P2c — silent push 60s 미ACK entry를 alert로 fallback (#1894 30s→60s 완화). 같은 cron 사이클에서 실행.
-    await runFallbackPushes(env, { apnsConfig, apnsHosts, log });
-    // #1721 — silent push 발사 실패(429 / 5xx) 영구 lost 차단. retry-push: prefix entry 를 backoff 만기
-    // 시 재발사. KV binding 부재 시 graceful no-op (개발/테스트 환경 호환).
-    // #1995 (ADR-022 Phase 1-2) — runRetryPushes 자체 재 enqueue 도 flag=on 시 destination 만 유지.
-    await runRetryPushes(env, { apnsConfig, apnsHosts, log, archFlag });
+    // #2073 (Issue A) — 진짜 idle tick(활성 trip 0 + 직전 tick 근방 fire/retry 기록 없음)엔
+    // pending/retry push가 존재할 수 없으므로 listPending/listRetryPushes KV list 호출 자체를
+    // skip한다(2026-07-29 quota audit: KV list 720%/write 144% 초과, idle-skip이 로그만
+    // 억제하던 회귀). scanned>0(실제 entry 발견)이면 marker를 재stamp해 backoff가 긴 retry도
+    // 다음 tick들이 계속 idle-skip 대상에서 제외되도록 한다.
+    if (scheduledStats.pendingActivityPossible) {
+      // #572 P2c — silent push 60s 미ACK entry를 alert로 fallback (#1894 30s→60s 완화). 같은 cron 사이클에서 실행.
+      const fallbackStats = await runFallbackPushes(env, { apnsConfig, apnsHosts, log });
+      // #1721 — silent push 발사 실패(429 / 5xx) 영구 lost 차단. retry-push: prefix entry 를 backoff 만기
+      // 시 재발사. KV binding 부재 시 graceful no-op (개발/테스트 환경 호환).
+      // #1995 (ADR-022 Phase 1-2) — runRetryPushes 자체 재 enqueue 도 flag=on 시 destination 만 유지.
+      const retryStats = await runRetryPushes(env, { apnsConfig, apnsHosts, log, archFlag });
+      if (fallbackStats.scanned > 0 || retryStats.scanned > 0) {
+        await stampPushActivity(env.TRIPS, Date.now());
+      }
+    }
     // #972 — low-recall trip ratio 임계 위반 시 운영 webhook 발사. dedup KV(1h)로 spam 차단.
     // binding/secret 미설정 환경에서는 graceful no-op이라 회귀 없음.
     await evaluateAndMaybeAlert(env, { fetchImpl: fetch, now: () => Date.now(), log });

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -109,8 +109,10 @@ import {
   readJitterSamples,
   resetJitterSamples,
   shouldEmitHeartbeat,
+  shouldSampleJitterTick,
   stampHeartbeat,
 } from './cronJitterAggregate';
+import { readPushActivityRecent, stampPushActivity } from './cronIdleGate';
 
 // pickApnsHost / flipApnsEnv는 ./apnsHost로 이동 (liveActivity.ts와 공유 SSOT, #482).
 // 외부(테스트 / index.ts 등)가 scheduled.ts 경유로 import하던 호환성 유지를 위해 re-export.
@@ -799,6 +801,14 @@ export interface ScheduledStats extends LiveActivityStats {
     noGps: number;
     stationUnknown: number;
   };
+  /**
+   * #2073 (Issue A) — 이번 tick에 pending/retry push entry가 존재할 가능성이 있는지.
+   * `병합 listTrips 결과가 비어있음 AND 직전 tick 근방 fire/retry 기록 없음`일 때만 false —
+   * 그 외(활성 trip 존재 또는 최근 활동 marker 有)엔 true(보수적 기본값). `index.ts`의
+   * scheduled handler가 이 값으로 `runFallbackPushes`/`runRetryPushes` 호출 여부를 게이트해
+   * 진짜 idle tick의 KV list/write를 0으로 줄인다 (cron KV quota audit, 2026-07-29).
+   */
+  pendingActivityPossible: boolean;
 }
 
 /**
@@ -835,9 +845,11 @@ export interface ScheduledDeps {
 /**
  * #1614 Phase A — 활성 trip의 line union 수집.
  *
- * 다음 메인 루프와 같은 `listTrips`를 한 번 더 iterate해 route + waypoints의 모든 line을
- * `computeAllowedLines`로 union. 환승 route는 fromLine/toLine 모두 포함되므로 leg마다 별도 fetch
- * 필요 없이 한 cron tick에 trip이 다닐 수 있는 모든 line이 stamp된다.
+ * #2073 (Issue B) — 이전엔 `listTrips`를 별도로 한 번 더 iterate했으나(3중 listTrips 호출의
+ * 한 축), `runScheduled`가 1회 병합 list한 `trips` 배열을 그대로 받아 순회하는 순수 함수로
+ * 전환했다. route + waypoints의 모든 line을 `computeAllowedLines`로 union — 환승 route는
+ * fromLine/toLine 모두 포함되므로 leg마다 별도 fetch 없이 한 cron tick에 trip이 다닐 수 있는
+ * 모든 line이 stamp된다.
  *
  * `expiresAt` 만료 trip은 skip — 메인 루프의 cleanup 분기가 어차피 처리하므로 self-poll 대상 X.
  * `alarmAtEpochMs - now > POLLING_WINDOW_MS`(아직 알람 윈도우 진입 전) trip은 포함 — 미리 line의
@@ -848,9 +860,9 @@ export interface ScheduledDeps {
  *   - force-end(9h+): cleanupTripWithLa로 cleanup → 다음 cycle에 line union에서 자연 빠짐
  *   둘 다 Seoul 호출을 미리 줄여 quota 절감 + cron throughput 보호.
  */
-async function collectActiveLines(env: Env, now: number): Promise<Set<LineNumber>> {
+function collectActiveLines(trips: readonly Trip[], now: number): Set<LineNumber> {
   const lines = new Set<LineNumber>();
-  for await (const trip of listTrips(env.TRIPS)) {
+  for (const trip of trips) {
     if (trip.expiresAt <= now) continue;
     if (tripLifecyclePhase(trip, now) !== 'normal') continue;
     for (const line of computeAllowedLines(trip.route, trip.waypoints)) {
@@ -863,15 +875,18 @@ async function collectActiveLines(env: Env, now: number): Promise<Set<LineNumber
 /**
  * #1828 Phase 5 — 활성 trip route의 다음 N개 역 name union 수집.
  *
+ * #2073 (Issue B) — `collectActiveLines`와 동일하게 병합된 `trips` 배열을 순회하는 순수
+ * 함수로 전환 (기존 별도 listTrips iterate 제거).
+ *
  * `trip.waypoints`는 이미 shift된 잔여 waypoints 배열 — 맨 앞이 다음 알람 대상 역.
  * 각 trip에서 `N_STATION_LOOKAHEAD`개(최대)를 추출해 union dedup. 같은 역을 여러 trip이
  * 공유해도 Set으로 자연 dedup — Seoul fetchArrivals 중복 호출 방지.
  *
  * #1652 line-union과 동일 필터 — 만료 / lifecycle-abnormal trip은 skip.
  */
-async function collectActiveStations(env: Env, now: number): Promise<Set<string>> {
+function collectActiveStations(trips: readonly Trip[], now: number): Set<string> {
   const stations = new Set<string>();
-  for await (const trip of listTrips(env.TRIPS)) {
+  for (const trip of trips) {
     if (trip.expiresAt <= now) continue;
     if (tripLifecyclePhase(trip, now) !== 'normal') continue;
     for (const waypoint of trip.waypoints.slice(0, N_STATION_LOOKAHEAD)) {
@@ -963,23 +978,48 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       noGps: 0,
       stationUnknown: 0,
     },
+    // #2073 (Issue A) — 아래 idle 판정 이후 실제 값으로 덮어쓴다. 기본 true = 보수적(항상 실행).
+    pendingActivityPossible: true,
   };
+
+  // #2073 (Issue B) — listTrips 3중 호출(collectActiveLines/collectActiveStations/main loop 각자)을
+  // 1회 병합. 전체 trip을 배열로 확보해 아래 파생 함수 + main loop가 모두 이 배열을 재사용한다.
+  // 감축: list 5→3/tick, 활성 시 trip get 3N→N.
+  const trips: Trip[] = [];
+  for await (const trip of listTrips(env.TRIPS)) {
+    trips.push(trip);
+  }
+
+  // #2073 (Issue A) — 진짜 idle 판정. 활성 trip이 하나도 없고, 직전 tick 근방 fire/retry 기록도
+  // 없으면 pending/retry push가 존재할 수 없다(모든 fire 경로가 trip 기반이므로 trip 부재 tick엔
+  // 새 entry가 생기지 않는다). 이 tick엔 index.ts가 runFallbackPushes/runRetryPushes를 skip한다.
+  const activityRecent = await readPushActivityRecent(env.TRIPS);
+  const idle = trips.length === 0 && !activityRecent;
+  stats.pendingActivityPossible = !idle;
+  if (trips.length > 0) {
+    // 다음 tick(들)의 idle 판정이 이번 활성 tick을 근방 활동으로 인지하도록 marker 갱신.
+    await stampPushActivity(env.TRIPS, now);
+  }
+
   // #2054 — jitter raw log 제거. spike 임계 초과 시만 즉시 로그, 정상 값은 KV samples append 후
   // heartbeat 시 P50/P99 산출. Cloudflare Workers Logs cap(2000 events / cycle 5 로그) 소진 방지.
+  // #2073 (Issue A+D) — idle tick은 write 0 목표라 append 자체를 skip. 활성 tick도
+  // JITTER_SAMPLE_EVERY_N_TICKS(10)당 1회로 샘플링해 write 1,440→144/일로 절감.
   if (stats.cronJitterMs > JITTER_SPIKE_THRESHOLD_MS) {
     log('scheduled: cron jitter spike', {
       jitterMs: stats.cronJitterMs,
       thresholdMs: JITTER_SPIKE_THRESHOLD_MS,
     });
-  } else {
+  } else if (!idle && shouldSampleJitterTick(now, CRON_NOMINAL_INTERVAL_MS)) {
     await appendJitterSample(env.TRIPS, stats.cronJitterMs);
   }
 
   // #1614 Phase A (S4 #1537) — 활성 trip line union 추출 + Seoul realtimePosition 전수 self-poll.
-  // 1차 iterate: 활성 trip의 route + waypoints에서 line set 수집 (computeAllowedLines 활용 — 환승
-  // route는 transfers의 fromLine/toLine 모두 포함). 2차 iterate(아래 메인 루프)는 그대로 폴링 ·
-  // push 발사 흐름 유지. KV stamp는 advanceTripPosition site들이 lock.trainCode cross-match에 사용.
-  const activeLines = await collectActiveLines(env, now);
+  // #2073 (Issue B) — 위에서 병합한 `trips` 배열에서 파생(순수 함수, KV 재호출 없음). 폴링 ·
+  // push 발사 흐름은 그대로 유지. KV stamp는 advanceTripPosition site들이 lock.trainCode
+  // cross-match에 사용. idle tick은 trips가 비어 있어 아래 두 collect가 empty Set을 반환하고
+  // pollLinesAndStamp/pollStationsAndStamp는 empty set에서 자연히 KV 호출 없이 조기 반환한다.
+  const activeLines = collectActiveLines(trips, now);
   const selfPollStats = await pollLinesAndStamp(env.TRIPS, deps.seoul, activeLines, now);
   stats.realtimePositionFetch += selfPollStats.fetched;
   stats.selfPollCacheHit += selfPollStats.cacheHit;
@@ -996,7 +1036,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
   // #1828 Phase 5 — 활성 trip route 다음 N개 역 union 추출 + Seoul fetchArrivals station-level stamp.
   // line-unit polling(max 100 trains/call) 대신 station-unit(max 10 arrivals/call)으로 전환.
   // route bound 폴링으로 trip 무관 trains candidate-reject 감소 (Day 2 evidence: 53건/시간).
-  const activeStations = await collectActiveStations(env, now);
+  const activeStations = collectActiveStations(trips, now);
   const stationPollStats = await pollStationsAndStamp(env.TRIPS, deps.seoul, activeStations, now);
   stats.stationPollFetch += stationPollStats.fetched;
   stats.stationPollCacheHit += stationPollStats.cacheHit;
@@ -1010,7 +1050,9 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     });
   }
 
-  for await (const trip of listTrips(env.TRIPS)) {
+  // #2073 (Issue B) — 병합된 trips 배열 순회(3번째이자 마지막 listTrips 소비). 로직은 기존과
+  // 동일 — dedup/advance/fire semantics 변경 없음.
+  for (const trip of trips) {
     stats.scanned += 1;
 
     if (trip.expiresAt <= now) {

--- a/backend/alarm-worker/src/selfPollPosition.ts
+++ b/backend/alarm-worker/src/selfPollPosition.ts
@@ -50,12 +50,19 @@ const SELF_POLL_PREFIX = 'realtime-position:';
 const SELF_POLL_STATION_PREFIX = 'selfPoll:station:';
 
 /**
- * KV expirationTtl — Cloudflare 런타임 floor(`CRON_READ_CACHE_TTL_SEC=30`).
+ * KV expirationTtl (초).
  *
- * 같은 cron cycle 내 dedup + 다음 cycle 시작 직전까지 stale snapshot 활용. Seoul API rate
- * limit 보호도 겸한다 — 호선당 30s에 1회 fetch 보장.
+ * #2073 (Issue TTL) — 30s(cron 60s 주기보다 짧음)라 매 tick마다 KV entry가 항상 만료돼 있어
+ * `existing` cache-hit이 절대 성립하지 않고 line/station마다 매 tick 강제 재fetch + 재write를
+ * 유발했다(활성 trip 1개 = write 600~900/시간, station stamp ×5가 지배적, 2026-07-29 quota audit).
+ *
+ * 90s로 상향(cron 60s의 1.5배)하면 direct 다음 tick(60s 후)엔 entry가 아직 살아있어
+ * `pollLinesAndStamp`/`pollStationsAndStamp`의 기존 `existing` 캐시-히트 분기가 자연스럽게
+ * fetch·write를 모두 skip한다("조건부 put" — TTL이 다음 tick까지 생존하므로 재기록 불필요).
+ * entry가 실제로 만료된 tick(값이 바뀌었을 가능성이 있는 시점)에만 재fetch + 즉시 put해
+ * 신선도를 유지한다. Seoul API rate limit 보호는 그대로 유지 — 90s에 1회 fetch 보장.
  */
-export const SELF_POLL_TTL_SEC = CRON_READ_CACHE_TTL_SEC;
+export const SELF_POLL_TTL_SEC = 90;
 
 /**
  * Phase 5 (#1828) — trip waypoints 중 station-level polling 대상 최대 개수.


### PR DESCRIPTION
Closes #2073

## Summary

2026-07-29 quota audit — 사용자 0명 상태에서도 Cloudflare 무료 플랜 KV quota 초과(list 720%, write 144%)가 발생하고 있었다. 원인 4가지를 정확히 그만큼만 고쳤다 (audit 권고 B+A+D+TTL):

- **[B] listTrips 3회 → 1회 병합**: `runScheduled` 진입부에서 trip 전체를 1회 list·get해 배열로 확보. `collectActiveLines`/`collectActiveStations`는 이 배열을 순회하는 순수 함수로 전환, main loop도 같은 배열 재사용. (list 5→3/tick, 활성 시 trip get 3N→N)
- **[A] 진짜 idle 조기 return**: 병합 결과가 empty AND 직전 tick 근방 fire/retry 기록이 없으면(`cronIdleGate.ts`의 push-activity marker, KV 120s TTL) `ScheduledStats.pendingActivityPossible=false`로 `index.ts`가 `runFallbackPushes`/`runRetryPushes`(= `listPending`/`listRetryPushes`) 호출 자체를 skip. fallback/retry가 실제로 entry를 찾으면(`scanned>0`) marker를 재stamp해 backoff가 긴 retry도 계속 커버.
- **[D] jitter 샘플 스로틀**: `appendJitterSample`을 tick index(`now / 60_000`) 기준 10 tick당 1회로 샘플링(`shouldSampleJitterTick`). idle tick은 append 자체 skip. (write 1,440→144/일)
- **[TTL] self-poll 재기록 절감**: `SELF_POLL_TTL_SEC` 30→90s. cron 60s 주기보다 길어져 기존 cache-hit 분기(`existing !== null → skip`)가 다음 tick까지 자연스럽게 재fetch/재write를 skip.

## 변경 파일

- `backend/alarm-worker/src/scheduled.ts` — listTrips 병합, idle 게이트 판정, jitter 샘플링 조건부 적용
- `backend/alarm-worker/src/cronIdleGate.ts` (신규) — push-activity marker (`stampPushActivity`/`readPushActivityRecent`)
- `backend/alarm-worker/src/cronJitterAggregate.ts` — `shouldSampleJitterTick` + `JITTER_SAMPLE_EVERY_N_TICKS`
- `backend/alarm-worker/src/selfPollPosition.ts` — `SELF_POLL_TTL_SEC` 30→90
- `backend/alarm-worker/src/index.ts` — `handler.scheduled`가 `pendingActivityPossible`로 fallback/retry 스캔 게이트, `handler` named export 추가(테스트 전용, default export의 Sentry 래핑은 그대로)
- 테스트: `cronIdleGate.test.ts`(신규), `index.scheduledGate.test.ts`(신규), `scheduled.test.ts`/`selfPollPosition.test.ts`/`cronJitterAggregate.test.ts` 보강 — KV mock `list`/`get`/`put` 호출 횟수 계수 assertion

## 하지 않은 것 (이슈의 "하지 말 것" 준수)

- cron 주기(`wrangler.toml` `*/1`) 변경 없음
- trip index key 재설계 없음
- fire/dedup/advance 판정 semantics 변경 없음 — KV 연산 횟수만 감소, main loop 로직은 병합된 동일 trip 배열을 순회할 뿐 동일
- heartbeat(시간당 1 put) 제거 없음

## Wire-completion 5단

1. **Orphan 없음**: `npm run lint:orphan` pass (0 orphan). 신규 `handler` named export는 frontend orphan-export 스크립트가 backend를 스캔하지 않아 대상 외.
2. **V/X dashboard**: Cloudflare Dashboard KV metrics(list/write count) + `wrangler tail`에서 `cron: stationary skip`/`lifecycle` 등 기존 로그와 함께 idle tick의 `scheduled heartbeat`(시간당 1회) 로그로 관찰 가능. 신규 `pendingActivityPossible` 자체는 별도 로그 없음 — 필요 시 후속 PR에서 log 추가 가능.
3. **의존 PR**: N/A — epic #2061과 독립, 우선 처리
4. **측정 plan**: 배포 후 24h Cloudflare Dashboard에서 KV list/write 실측 확인 (이슈 본문 Acceptance 그대로 — idle 실측이 여전히 초과하면 index-key 이슈 별도 spawn)
5. **Device verify**: N/A — backend only. 배포 후 실기기 trip 1회로 매역 판정 회귀 없음 확인 권장(코드상 fire/advance 로직 변경 없음이나 실측 확인 권장)

## Test plan

- [x] `npm run type-check` (backend/alarm-worker `tsc --noEmit`) pass
- [x] `npm test` (backend/alarm-worker `vitest run`) — 2655 passed
- [x] 프론트 `npm run lint:orphan` pass (0 orphan)
- [x] 프론트 `npm run type-check` pass
- [x] 프론트 `npm test` — 9188 passed, coverage 100% (frontend 파일 변경 없음, 회귀 없음 확인용)
- [ ] 배포 후 24h Cloudflare Dashboard KV list/write 실측 (Acceptance)
