### PR TITLE
feat(#2063): 매역 알림 silent→visible 전환 + sleepMode mute (Phase 1-backend)

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -206,13 +206,17 @@ function makeArvlCdFireSeoul(
   });
 }
 
-/** arvlCd fire silent push (background, kind=intermediate/destination, phase=imminent) 호출만 추출. */
+/**
+ * arvlCd fire push (kind=intermediate/destination, phase=imminent) 호출만 추출.
+ * #2063 (ADR-023 개정) — silent(background) → visible(alert) 전환. apns-push-type 이 바뀌었지만
+ * data payload shape(phase/kind 포함)는 그대로 forward 되므로 헤더 조건만 갱신.
+ */
 function getArvlCdStationPassedCalls(
   fetchImpl: ReturnType<typeof vi.fn>,
 ): [string, RequestInit][] {
   return (fetchImpl.mock.calls as unknown as [string, RequestInit][]).filter((c) => {
     const headers = (c[1]?.headers ?? {}) as Record<string, string>;
-    if (headers['apns-push-type'] !== 'background') return false;
+    if (headers['apns-push-type'] !== 'alert') return false;
     try {
       const body = JSON.parse(c[1]?.body as string) as {
         data?: { phase?: string; kind?: string };
@@ -1838,26 +1842,30 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
         expect(stored.consecutiveEtaMissing).toBe(0);
       });
 
-      it('#1402 hop 시간 미경과 + motion=automotive → release floor fire 발사 + PENDING_PUSHES 등록', async () => {
+      it('#2063 (ADR-023 개정) hop 시간 미경과 + motion=automotive → release floor fire visible alert 직접 발사, PENDING_PUSHES 미등록', async () => {
         // release 경로의 floor fire는 motion gate(stationary 차단)를 통과한 경우에만 fire.
-        // 발사 성공 시 PENDING_PUSHES에 등록돼 30s 내 ACK 없으면 alert fallback 가동.
+        // #2063 — silent → visible alert 직접 발사로 전환돼 60s ACK 기반 PENDING_PUSHES 안전망이 불필요.
         const pending = new InMemoryKV();
+        const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
         const { stats, stored } = await runFallbackMotionScenario({
           motion: 'automotive',
           hopElapsed: false,
           pushId: 'p1402-release',
           pending,
+          apnsFetch,
         });
         // floor fire 발사 (release 경로)
         expect(stats.vanishReleaseFired).toBe(1);
         expect(stats.vanishFallbackFired).toBe(0);
         expect(stats.pushed).toBeGreaterThanOrEqual(1);
-        // PENDING_PUSHES에 30s alert fallback 안전망 entry 등록
+        // visible alert push 직접 발사 확인 (apns-push-type: alert)
+        const alertCalls = (apnsFetch.mock.calls as unknown as [string, RequestInit][]).filter(
+          (c) => (c[1]?.headers as Record<string, string>)['apns-push-type'] === 'alert',
+        );
+        expect(alertCalls.length).toBe(1);
+        // PENDING_PUSHES 등록 없음 (ACK 개념 불필요)
         const pendingEntry = await pending.get('pending:p1402-release');
-        expect(pendingEntry).not.toBeNull();
-        const parsed = JSON.parse(pendingEntry!) as { stationName: string; phase: string };
-        expect(parsed.stationName).toBe('중곡');
-        expect(parsed.phase).toBe('imminent');
+        expect(pendingEntry).toBeNull();
         // lock release는 정상 진행
         expect(stored.boardingLock).toBeUndefined();
       });
@@ -7530,22 +7538,22 @@ describe('runScheduled — #1402 인프라 안전망 (pendingPushes wire-up + pa
     return JSON.parse(match![1].body as string);
   }
 
-  it('arvlCd 발사 성공 시 PENDING_PUSHES에 30s alert fallback entry 등록', async () => {
+  it('#2063 (ADR-023 개정) arvlCd 발사 성공 시 visible alert 직접 발사, PENDING_PUSHES 미등록', async () => {
     const pending = new InMemoryKV();
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
     const { stats } = await runArvlCdScenario({
       token: 'arvl-1402',
       pushId: 'p1402-arvl',
       pending,
+      apnsFetch,
     });
     expect(stats.arvlCdFireSuccess).toBe(1);
     const entry = await pending.get('pending:p1402-arvl');
-    expect(entry).not.toBeNull();
-    const parsed = JSON.parse(entry!) as {
-      stationName: string; phase: string; kind: string; sentAt: number;
-    };
-    expect(parsed.stationName).toBe('중곡');
-    expect(parsed.phase).toBe('imminent');
-    expect(parsed.sentAt).toBe(NOW);
+    expect(entry).toBeNull();
+    const body = findApnsCallByPushId(apnsFetch, 'p1402-arvl');
+    expect((body.data as { nextWaypoint: string }).nextWaypoint).toBe('중곡');
+    expect((body.data as { phase: string }).phase).toBe('imminent');
+    expect((body.data as { sentAt: number }).sentAt).toBe(NOW);
   });
 
   it('arvlCd 페이로드에 origin=arvlcd stamp', async () => {

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -311,6 +311,83 @@ export interface SendPushResult {
   reason?: string;
 }
 
+/**
+ * #2063 (ADR-023 개정) — `SilentPushPayload` → wire `data` 필드 정규화. 기존 `sendSilentPush`
+ * 본문 빌드 로직을 추출해 station-notif(visible alert) 채널(`sendAlertPush`의 `data` 옵션)도
+ * 동일한 optional-field omission 규칙(undefined/false/빈 배열은 자연 누락)을 공유한다 — 채널이
+ * silent→alert로 바뀌어도 device 소비 코드(SSoT cascade picker 등)가 받는 wire shape은 불변.
+ */
+export function buildSilentPushData(payload: SilentPushPayload): Record<string, unknown> {
+  return {
+    nextWaypoint: payload.nextWaypoint,
+    etaSeconds: payload.etaSeconds,
+    phase: payload.phase,
+    kind: payload.kind,
+    sentAt: payload.sentAt,
+    pushId: payload.pushId,
+    // Epic #1204 그룹 2 D3 (#1273) — payload.hopIndex가 정의된 경우에만 wire.
+    // 구 backend 호환을 위해 optional이라 undefined일 땐 JSON에서 자연 누락된다.
+    ...(payload.hopIndex === undefined ? {} : { hopIndex: payload.hopIndex }),
+    // #1365 — occupiedLine은 정의된 경우에만 wire. 미전달 시 JSON에서 자연 누락 →
+    // 구 client(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환.
+    ...(payload.occupiedLine === undefined ? {} : { occupiedLine: payload.occupiedLine }),
+    // #1307 — subsurface는 true일 때만 wire. false/undefined는 JSON에서 자연 누락 →
+    // 구 client(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환.
+    ...(payload.subsurface === true ? { subsurface: true } : {}),
+    // #1322 — boardingLine/trainCode는 정의된 경우에만 wire (lock-path fire). 미전달 시
+    // JSON에서 자연 누락 → 구 client(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환.
+    ...(payload.boardingLine === undefined ? {} : { boardingLine: payload.boardingLine }),
+    ...(payload.trainCode === undefined ? {} : { trainCode: payload.trainCode }),
+    // #1399 — tripToken은 정의된 경우에만 wire (좀비 알림 cleanup). 미전달 시 JSON에서 자연
+    // 누락 → 구 client(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환.
+    ...(payload.tripToken === undefined ? {} : { tripToken: payload.tripToken }),
+    // #1402 — origin은 정의된 경우에만 wire (좀비 알림 RCA). 구 backend 호환을 위해 optional —
+    // 미전달 시 JSON에서 자연 누락, device는 `'unknown'`으로 분류.
+    ...(payload.origin === undefined ? {} : { origin: payload.origin }),
+    // #1438 (E5) — lockReleasedReason은 정의된 경우에만 wire. 미전달 시 JSON에서 자연 누락 →
+    // 구 device(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환.
+    ...(payload.lockReleasedReason === undefined
+      ? {}
+      : { lockReleasedReason: payload.lockReleasedReason }),
+    // #1539 (S6) — passedStations는 non-empty 배열일 때만 wire. 빈 배열/누락은 JSON에서 자연
+    // 누락 → 구 device(필드 무시) 호환. device는 사전 예약 큐 backfill에 사용한다(후속 PR).
+    ...(payload.passedStations && payload.passedStations.length > 0
+      ? { passedStations: [...payload.passedStations] }
+      : {}),
+    // #1561 (T8, ADR-017 / S2 흡수) — ssot은 정의된 경우에만 wire. 미전달 시 JSON에서 자연 누락 →
+    // 구 device(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환. device cascade picker가
+    // `backend-ssot` tier(최상위)로 채택한다.
+    ...(payload.ssot === undefined
+      ? {}
+      : {
+          ssot: {
+            currentStationId: payload.ssot.currentStationId,
+            motionState: payload.ssot.motionState,
+            lastAdvanceEvidence: payload.ssot.lastAdvanceEvidence,
+            lastAdvanceAt: payload.ssot.lastAdvanceAt,
+            passedStations: [...payload.ssot.passedStations],
+            // #1705 — currentStationLine 정의된 경우에만 wire (구 device 호환 위해 optional).
+            ...(payload.ssot.currentStationLine === undefined
+              ? {}
+              : { currentStationLine: payload.ssot.currentStationLine }),
+            // #1572 (T9) — alarmEvents 정의된 경우에만 wire. 빈 배열도 wire(device 측 게이트가
+            // 빈 list와 미정의를 구분하지 않으므로 동일 graceful — 단 backend 호환 위해 forward).
+            // 같은 패턴: undefined는 omit, 정의됨(빈 배열 포함)은 forward.
+            ...(payload.ssot.alarmEvents === undefined
+              ? {}
+              : {
+                  alarmEvents: payload.ssot.alarmEvents.map((e) => ({
+                    alarmId: e.alarmId,
+                    stationId: e.stationId,
+                    type: e.type,
+                    decidedAt: e.decidedAt,
+                  })),
+                }),
+          },
+        }),
+  };
+}
+
 export async function sendSilentPush(options: SendPushOptions): Promise<SendPushResult> {
   const jwt = await buildApnsJwt(options.config, options.now);
   const fetchImpl = options.fetchImpl ?? fetch;
@@ -318,78 +395,7 @@ export async function sendSilentPush(options: SendPushOptions): Promise<SendPush
 
   const body = JSON.stringify({
     aps: { 'content-available': 1 },
-    data: {
-      nextWaypoint: options.payload.nextWaypoint,
-      etaSeconds: options.payload.etaSeconds,
-      phase: options.payload.phase,
-      kind: options.payload.kind,
-      sentAt: options.payload.sentAt,
-      pushId: options.payload.pushId,
-      // Epic #1204 그룹 2 D3 (#1273) — payload.hopIndex가 정의된 경우에만 wire.
-      // 구 backend 호환을 위해 optional이라 undefined일 땐 JSON에서 자연 누락된다.
-      ...(options.payload.hopIndex === undefined ? {} : { hopIndex: options.payload.hopIndex }),
-      // #1365 — occupiedLine은 정의된 경우에만 wire. 미전달 시 JSON에서 자연 누락 →
-      // 구 client(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환.
-      ...(options.payload.occupiedLine === undefined
-        ? {}
-        : { occupiedLine: options.payload.occupiedLine }),
-      // #1307 — subsurface는 true일 때만 wire. false/undefined는 JSON에서 자연 누락 →
-      // 구 client(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환.
-      ...(options.payload.subsurface === true ? { subsurface: true } : {}),
-      // #1322 — boardingLine/trainCode는 정의된 경우에만 wire (lock-path fire). 미전달 시
-      // JSON에서 자연 누락 → 구 client(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환.
-      ...(options.payload.boardingLine === undefined
-        ? {}
-        : { boardingLine: options.payload.boardingLine }),
-      ...(options.payload.trainCode === undefined ? {} : { trainCode: options.payload.trainCode }),
-      // #1399 — tripToken은 정의된 경우에만 wire (좀비 알림 cleanup). 미전달 시 JSON에서 자연
-      // 누락 → 구 client(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환.
-      ...(options.payload.tripToken === undefined ? {} : { tripToken: options.payload.tripToken }),
-      // #1402 — origin은 정의된 경우에만 wire (좀비 알림 RCA). 구 backend 호환을 위해 optional —
-      // 미전달 시 JSON에서 자연 누락, device는 `'unknown'`으로 분류.
-      ...(options.payload.origin === undefined ? {} : { origin: options.payload.origin }),
-      // #1438 (E5) — lockReleasedReason은 정의된 경우에만 wire. 미전달 시 JSON에서 자연 누락 →
-      // 구 device(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환.
-      ...(options.payload.lockReleasedReason === undefined
-        ? {}
-        : { lockReleasedReason: options.payload.lockReleasedReason }),
-      // #1539 (S6) — passedStations는 non-empty 배열일 때만 wire. 빈 배열/누락은 JSON에서 자연
-      // 누락 → 구 device(필드 무시) 호환. device는 사전 예약 큐 backfill에 사용한다(후속 PR).
-      ...(options.payload.passedStations && options.payload.passedStations.length > 0
-        ? { passedStations: [...options.payload.passedStations] }
-        : {}),
-      // #1561 (T8, ADR-017 / S2 흡수) — ssot은 정의된 경우에만 wire. 미전달 시 JSON에서 자연 누락 →
-      // 구 device(필드 무시) 및 구 backend payload(미존재)와 byte-level 호환. device cascade picker가
-      // `backend-ssot` tier(최상위)로 채택한다.
-      ...(options.payload.ssot === undefined
-        ? {}
-        : {
-            ssot: {
-              currentStationId: options.payload.ssot.currentStationId,
-              motionState: options.payload.ssot.motionState,
-              lastAdvanceEvidence: options.payload.ssot.lastAdvanceEvidence,
-              lastAdvanceAt: options.payload.ssot.lastAdvanceAt,
-              passedStations: [...options.payload.ssot.passedStations],
-              // #1705 — currentStationLine 정의된 경우에만 wire (구 device 호환 위해 optional).
-              ...(options.payload.ssot.currentStationLine === undefined
-                ? {}
-                : { currentStationLine: options.payload.ssot.currentStationLine }),
-              // #1572 (T9) — alarmEvents 정의된 경우에만 wire. 빈 배열도 wire(device 측 게이트가
-              // 빈 list와 미정의를 구분하지 않으므로 동일 graceful — 단 backend 호환 위해 forward).
-              // 같은 패턴: undefined는 omit, 정의됨(빈 배열 포함)은 forward.
-              ...(options.payload.ssot.alarmEvents === undefined
-                ? {}
-                : {
-                    alarmEvents: options.payload.ssot.alarmEvents.map((e) => ({
-                      alarmId: e.alarmId,
-                      stationId: e.stationId,
-                      type: e.type,
-                      decidedAt: e.decidedAt,
-                    })),
-                  }),
-            },
-          }),
-    },
+    data: buildSilentPushData(options.payload),
   });
 
   const response = await fetchImpl(url, {
@@ -437,6 +443,34 @@ export interface SendAlertPushOptions {
    * 미지정 시 aps.category 필드를 omit (구 caller backward compat).
    */
   category?: string;
+  /**
+   * #2063 (ADR-023 개정) — sound 옵션화. undefined(생략) 시 기존 `'default'` 유지(구 caller
+   * backward compat). `null` 명시 시 aps.sound 필드 자체를 생략 — 매역 알림(station-notif)은
+   * 무소리 배너로 발사한다.
+   */
+  sound?: string | null;
+  /**
+   * #2063 — iOS interruption level. 매역 알림은 `'active'`. 미지정 시 aps에서 필드 생략
+   * (구 caller backward compat).
+   */
+  interruptionLevel?: 'active' | 'passive' | 'time-sensitive' | 'critical';
+  /**
+   * #2063 — `apns-collapse-id` 헤더. 같은 값의 후속 push가 알림센터에서 최신 것으로 교체된다.
+   * 매역 알림은 `station-<tripToken>`을 사용해 같은 trip의 매역 알림 스택을 방지한다.
+   * 미지정 시 헤더 생략 (구 caller backward compat).
+   */
+  collapseId?: string;
+  /**
+   * #2063 — `apns-expiration` 헤더 값(epoch seconds). 지하 데이터 순단 후 stale 알림이 뒤늦게
+   * 표시되는 것을 방지한다. 미지정 시 헤더 생략(APNs 기본 폐기 정책 유지, 구 caller backward compat).
+   */
+  expirationEpochSec?: number;
+  /**
+   * #2063 — `data` 필드에 `pushId` 외 추가로 실을 payload. 매역 알림은 기존 silent push가
+   * forward하던 SSoT/게이트 필드를 alert 채널에서도 동일하게 forward해 device 소비 코드(cascade
+   * picker 등)가 영향받지 않게 한다. 미지정 시 `data`는 `{ pushId }` 그대로(구 caller backward compat).
+   */
+  data?: Record<string, unknown>;
   config: ApnsConfig;
   host: string;
   fetchImpl?: typeof fetch;
@@ -451,11 +485,16 @@ export async function sendAlertPush(options: SendAlertPushOptions): Promise<Send
   const body = JSON.stringify({
     aps: {
       alert: { title: options.title, body: options.body },
-      sound: 'default',
+      // #2063 — sound===null이면 aps.sound 필드 자체를 생략(무소리). undefined면 기존 'default'.
+      ...(options.sound === null ? {} : { sound: options.sound ?? 'default' }),
       // #1798 P2 — category는 정의된 경우에만 wire. 미전달 시 JSON에서 자연 누락.
       ...(options.category !== undefined ? { category: options.category } : {}),
+      // #2063 — interruption-level은 정의된 경우에만 wire.
+      ...(options.interruptionLevel !== undefined
+        ? { 'interruption-level': options.interruptionLevel }
+        : {}),
     },
-    data: { pushId: options.pushId },
+    data: { pushId: options.pushId, ...options.data },
   });
 
   const response = await fetchImpl(url, {
@@ -468,6 +507,12 @@ export async function sendAlertPush(options: SendAlertPushOptions): Promise<Send
       'content-type': 'application/json',
       // #1788 — thread-id groups notifications by trip.
       ...(options.tripToken !== undefined ? { 'apns-thread-id': options.tripToken } : {}),
+      // #2063 — apns-collapse-id: 같은 trip의 매역 알림을 알림센터에서 최신으로 교체.
+      ...(options.collapseId !== undefined ? { 'apns-collapse-id': options.collapseId } : {}),
+      // #2063 — apns-expiration: stale 매역 알림이 뒤늦게 표시되는 것을 방지.
+      ...(options.expirationEpochSec !== undefined
+        ? { 'apns-expiration': String(options.expirationEpochSec) }
+        : {}),
     },
     body,
   });

--- a/backend/alarm-worker/src/fallback.ts
+++ b/backend/alarm-worker/src/fallback.ts
@@ -18,6 +18,14 @@
  *
  * 발사 후 entry는 즉시 삭제 — 다음 cron에서 재발사 방지 (KV TTL 60s에 의존하지 않음).
  * 발사 실패도 entry 삭제 — 재시도 폭주 방지 (다음 silent push 사이클에서 자연 회복).
+ *
+ * #2063 (ADR-023 개정) — 매역 알림(station-notif, arvlCd 기반 `fireArvlCdStationPush` /
+ * `fireVanishFallbackStationPush`)은 silent → visible alert push 직접 발사로 전환되며
+ * PENDING_PUSHES 등록 자체를 하지 않는다(호출부 참고) — 직접 alert를 발사하므로 60s ACK 기반
+ * fallback 개념이 불필요하기 때문. 본 모듈은 여전히 lockless intermediate 경로(silent push 유지,
+ * device-side validation이 느슨해 안전망이 더 절실)의 pending entry를 그대로 처리한다 — kind 값
+ * (transfer/destination/intermediate) 자체로는 origin을 구분할 수 없으므로, 매역 알림 계열의
+ * "제외"는 등록 시점(호출부)에서 이뤄지고 본 모듈의 처리 로직은 변경하지 않는다.
  */
 
 import { sendAlertPush, type ApnsConfig, type SendPushResult } from './apns';

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -5,6 +5,8 @@
 import { ARRIVAL_CODE, TRAIN_STATUS } from './alarm';
 import { evaluateAccelWindow, readAccelSeries } from './accelSeries';
 import {
+  buildSilentPushData,
+  sendAlertPush,
   sendBoardingPromptPush,
   sendBoardingPromptSilentPush,
   sendReschedulePush,
@@ -14,6 +16,7 @@ import {
   type PushOrigin,
   type SilentPushPayload,
 } from './apns';
+import { buildAlertContent } from './alertContent';
 import { flipApnsEnv, pickApnsHost, sendWithEnvHeal } from './apnsHost';
 import type { ArchFlagValue } from './archFlag';
 import { AUTO_PROMPT_DEDUP_WINDOW_MS } from './autoLock';
@@ -1748,11 +1751,51 @@ export interface FireArvlCdStationPushInputs {
  */
 export const STALE_LOCK_FIRE_THRESHOLD_MS = 3 * 60 * 1000;
 
-// Backend는 취침모드 무관 발사 (device shouldSuppressBySleepRule 단일 gate, ADR-023).
+/**
+ * #2063 (ADR-023 개정) — 매역 알림(station-notif) apns-collapse-id prefix.
+ * 같은 trip 의 매역 알림은 알림센터에서 최신 것으로 교체(스택 방지).
+ */
+export const STATION_NOTIF_COLLAPSE_ID_PREFIX = 'station-';
+
+/** #2063 — 매역 알림 apns-collapse-id 빌더. */
+export function stationNotifCollapseId(tripToken: string): string {
+  return `${STATION_NOTIF_COLLAPSE_ID_PREFIX}${tripToken}`;
+}
+
+/**
+ * #2063 — 매역 알림 apns-expiration 유예(ms). 지하 데이터 순단 후 stale 알림이 뒤늦게
+ * 표시되는 것을 방지한다 (now + 90s 이후 APNs가 폐기).
+ */
+export const STATION_NOTIF_EXPIRATION_MS = 90 * 1000;
+
+/**
+ * #2063 (ADR-023 개정) — 매역 알림(station-notif) 전용 title/body 빌더.
+ * 디바이스가 기존 silent push 수신 시 렌더하던 것과 동일한 문구 체계
+ * (`alertContent.buildAlertContent`, ko.json byte-identical)를 재사용한다.
+ * arvlCd 기반 매역 fire는 항상 phase='imminent' — intermediate는 phase 자체가 없다
+ * (discriminated union, `buildAlertContent` 참고).
+ */
+function buildStationNotifContent(waypoint: Waypoint): { title: string; body: string } {
+  if (waypoint.kind === 'intermediate') {
+    return buildAlertContent({ kind: 'intermediate', stationName: waypoint.stationName });
+  }
+  return buildAlertContent({ kind: waypoint.kind, phase: 'imminent', stationName: waypoint.stationName });
+}
+
+// #2063 (ADR-023 개정) — 매역 알림(station-notif) 전용 sleep mute. sleep-transfer(B4)·
+// boarding-prompt(B7/B8) 게이트와는 완전히 별개 — 이 분기는 arvlCd 기반 station-notif fire
+// path(본 함수 + fireVanishFallbackStationPush)에만 적용한다.
 export async function fireArvlCdStationPush(
   inputs: FireArvlCdStationPushInputs,
 ): Promise<{ dirty: boolean }> {
   const { trip, waypoint, lock, arvlCd, env, deps, stats, now, log, generatePushId } = inputs;
+  if (trip.sleepModeEnabled === true) {
+    log('station-notif skip: sleep', {
+      token: trip.token.slice(0, 8),
+      station: waypoint.stationName,
+    });
+    return { dirty: false };
+  }
   // #1614 Phase C — stale SSoT 가드. SSoT.lastAdvanceAt > 0 이고 3분 초과면 fire skip.
   // transferDestinationGate (60s) 보다 보수적이지만 intermediate 까지 보호. lazy-seed (==0) 통과.
   // SSoT 부재 trip (legacy) 도 통과 — 본 가드는 SSoT 활성화 후 stale 진단 만.
@@ -1889,11 +1932,25 @@ export async function fireArvlCdStationPush(
     // #2021 (ADR-022) — flag=on 시 boardingLine 봉인, device lockless-opt-out gate 존중.
     archFlag: deps.archFlag,
   });
+  // #2063 (ADR-023 개정) — silent → visible alert push 직접 발사. device silentPushTask 미기동
+  // (앱 kill/throttle) 상태에서도 OS가 직접 배너를 렌더한다. 무소리 + interruption-level=active +
+  // apns-collapse-id로 같은 trip의 매역 알림을 알림센터에서 최신으로 교체(스택 방지) + apns-expiration
+  // 90s로 지하 데이터 순단 후 stale 알림 늦은 표시를 방지한다. data는 기존 silent payload를 그대로
+  // forward해 device SSoT/게이트 소비 코드(cascade picker 등)가 영향받지 않게 한다.
+  const stationNotifContent = buildStationNotifContent(waypoint);
   const heal = await sendWithEnvHeal(
     (host) =>
-      sendSilentPush({
+      sendAlertPush({
         deviceToken: trip.token,
-        payload: arvlcdPayload,
+        title: stationNotifContent.title,
+        body: stationNotifContent.body,
+        pushId,
+        tripToken: trip.token,
+        sound: null,
+        interruptionLevel: 'active',
+        collapseId: stationNotifCollapseId(trip.token),
+        expirationEpochSec: Math.floor((now + STATION_NOTIF_EXPIRATION_MS) / 1000),
+        data: buildSilentPushData(arvlcdPayload),
         config: deps.apnsConfig,
         host,
         fetchImpl: deps.fetchImpl,
@@ -1953,25 +2010,9 @@ export async function fireArvlCdStationPush(
   } else if (waypoint.kind === 'destination') {
     stats.silentPushFiredByKind.destination += 1;
   }
-  // #1402 — alert fallback 안전망 등록. silent push가 60s(#1894로 30s→60s 완화) 내 ACK되지 않으면
-  // runFallbackPushes가 alert(소리) push를 발사. arvlCd 경로는 가장 흔한 발사 경로이므로
-  // 여기서도 안전망을 가동해 "하차 침묵 0" acceptance를 보강한다.
-  // #1995 (ADR-022 Phase 1-2) — flag=on 시 destination 만 pending 등록.
-  await putPending(
-    env.PENDING_PUSHES,
-    {
-      pushId,
-      token: trip.token,
-      alarmKey: buildAlarmKey(waypoint.stationName, 'imminent'),
-      sentAt: now,
-      stationName: waypoint.stationName,
-      kind: waypoint.kind,
-      phase: 'imminent',
-      etaSeconds: 0,
-      apnsEnv: trip.apnsEnv ?? 'sandbox',
-    },
-    deps.archFlag,
-  );
+  // #2063 (ADR-023 개정) — visible alert push 직접 발사이므로 60s ACK 기반 alert fallback
+  // 안전망(runFallbackPushes)은 더 이상 필요 없다 — PENDING_PUSHES 등록을 생략한다
+  // (fallback.ts는 이 push kind를 등록 대상에서 자연히 제외).
   // dedup stamp — 같은 cycle에서 Seoul API 갱신 지연으로 같은 신호가 재노출돼도 차단.
   await env.TRIPS.put(key, '1', { expirationTtl: ARVLCD_FIRE_DEDUP_TTL_SEC });
   // ADR-022 Phase 1-1 (#1985) — fire-once TTL stamp (flag=ON 시에만). 성공 fire 직후 stamp
@@ -2114,7 +2155,7 @@ async function tryAdvanceAndFireArvlcd(inputs: {
     environment: deriveEvidenceEnvironment(trip),
     hopIndex: waypoint.hopIndex,
   });
-  // Backend는 취침모드 무관 발사 (device shouldSuppressBySleepRule 단일 gate, ADR-023).
+  // #2063 (ADR-023 개정) — 매역 알림(station-notif)은 backend가 sleepModeEnabled로 mute 분기.
   return fireArvlCdStationPush({
     trip,
     waypoint,
@@ -2201,11 +2242,20 @@ export function vanishReleaseFireKey(
   return `${VANISH_RELEASE_FIRE_KEY_PREFIX}${token}|${trainCode}|${stationName}`;
 }
 
-// Backend는 취침모드 무관 발사 (device shouldSuppressBySleepRule 단일 gate, ADR-023).
+// #2063 (ADR-023 개정) — 매역 알림(station-notif) 전용 sleep mute. fireArvlCdStationPush와
+// 동일 분기 — sleep-transfer(B4)·boarding-prompt(B7/B8) 게이트와는 완전히 별개.
 export async function fireVanishFallbackStationPush(
   inputs: FireVanishFallbackStationPushInputs,
 ): Promise<void> {
   const { trip, waypoint, lock, env, deps, stats, now, log, generatePushId, origin } = inputs;
+  if (trip.sleepModeEnabled === true) {
+    log('station-notif skip: sleep', {
+      token: trip.token.slice(0, 8),
+      station: waypoint.stationName,
+      origin,
+    });
+    return;
+  }
   const key =
     origin === 'vanish-release'
       ? vanishReleaseFireKey(trip.token, lock.trainCode, waypoint.stationName)
@@ -2276,11 +2326,21 @@ export async function fireVanishFallbackStationPush(
     // #2021 (ADR-022) — flag=on 시 boardingLine 봉인, device lockless-opt-out gate 존중.
     archFlag: deps.archFlag,
   });
+  // #2063 (ADR-023 개정) — silent → visible alert push 직접 발사 (fireArvlCdStationPush와 동일 정책).
+  const vanishStationNotifContent = buildStationNotifContent(waypoint);
   const heal = await sendWithEnvHeal(
     (host) =>
-      sendSilentPush({
+      sendAlertPush({
         deviceToken: trip.token,
-        payload: vanishPayload,
+        title: vanishStationNotifContent.title,
+        body: vanishStationNotifContent.body,
+        pushId,
+        tripToken: trip.token,
+        sound: null,
+        interruptionLevel: 'active',
+        collapseId: stationNotifCollapseId(trip.token),
+        expirationEpochSec: Math.floor((now + STATION_NOTIF_EXPIRATION_MS) / 1000),
+        data: buildSilentPushData(vanishPayload),
         config: deps.apnsConfig,
         host,
         fetchImpl: deps.fetchImpl,
@@ -2347,26 +2407,9 @@ export async function fireVanishFallbackStationPush(
     hopIndex: waypoint.hopIndex,
     staleMs: ssot?.lastAdvanceAt ? now - ssot.lastAdvanceAt : undefined,
   });
-  // #1402 — alert fallback 안전망 등록. listPending → runFallbackPushes가 60s(#1894로 30s→60s 완화) 내 ACK
-  // 없으면 alert(소리) fallback 발사. vanish 경로는 silent push가 가장 잘 누락되는 경로라
-  // 안전망 가동이 acceptance("하차 침묵 0")의 핵심. PENDING_PUSHES 미바인딩(dev/test 호환)
-  // 시 putPending은 graceful no-op.
-  // #1995 (ADR-022 Phase 1-2) — flag=on 시 destination 만 pending 등록.
-  await putPending(
-    env.PENDING_PUSHES,
-    {
-      pushId,
-      token: trip.token,
-      alarmKey: buildAlarmKey(waypoint.stationName, 'imminent'),
-      sentAt: now,
-      stationName: waypoint.stationName,
-      kind: waypoint.kind,
-      phase: 'imminent',
-      etaSeconds: 0,
-      apnsEnv: trip.apnsEnv ?? 'sandbox',
-    },
-    deps.archFlag,
-  );
+  // #2063 (ADR-023 개정) — visible alert push 직접 발사이므로 60s ACK 기반 alert fallback
+  // 안전망(runFallbackPushes)은 더 이상 필요 없다 — PENDING_PUSHES 등록을 생략한다
+  // (fallback.ts는 이 push kind를 등록 대상에서 자연히 제외).
   await env.TRIPS.put(key, '1', { expirationTtl: ARVLCD_FIRE_DEDUP_TTL_SEC });
 }
 
@@ -2506,7 +2549,7 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
       // 사용자는 종착역 하차 알림을 받지 못한다. station-passed imminent push를 destination에도
       // 발사해 device 측 banner 발사 경로(채널 2)도 확보한다. surface 중복은 device 측
       // pushId/firedPushIds dedup으로 흡수.
-      // Backend는 취침모드 무관 발사 (device shouldSuppressBySleepRule 단일 gate, ADR-023).
+      // #2063 (ADR-023 개정) — 매역 알림(station-notif)은 backend가 sleepModeEnabled로 mute 분기.
       await fireVanishFallbackStationPush({
         trip,
         waypoint,
@@ -2550,7 +2593,7 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
     const releaseMotionSeries = await readSeries(env.TRIPS, trip.token);
     const releaseMotion = evaluateWindow(releaseMotionSeries, now).motion;
     if (!isFallbackAdvanceBlockedByMotion(releaseMotion)) {
-      // Backend는 취침모드 무관 발사 (device shouldSuppressBySleepRule 단일 gate, ADR-023).
+      // #2063 (ADR-023 개정) — 매역 알림(station-notif)은 backend가 sleepModeEnabled로 mute 분기.
       await fireVanishFallbackStationPush({
         trip,
         waypoint,


### PR DESCRIPTION
## Summary

Closes #2063

매역 진입 알림(`fireArvlCdStationPush` / `fireVanishFallbackStationPush`)을 silent push(`sendSilentPush`)에서 visible alert push(`sendAlertPush`) 직접 발사로 전환한다. device `silentPushTask` 미기동(앱 kill/throttle) 상태에서도 OS가 배너를 직접 렌더하도록 하는 것이 목적 (Epic #2061).

- **`apns.ts`**: `sendAlertPush` 옵션 확장 — `sound`(nullable, 매역 알림은 무소리) / `interruptionLevel`('active') / `apns-collapse-id`(`station-<tripToken>`) / `apns-expiration`(now+90s) / `data`(passthrough). 기존 `sendSilentPush`의 wire 정규화 로직(optional-field omission)을 `buildSilentPushData` 헬퍼로 추출해 alert 채널도 동일 규칙을 공유 — device 소비 필드(SSoT/게이트 등)가 채널 전환에 영향받지 않음. 모든 신규 옵션은 backward-compatible(미지정 시 기존 동작).
- **`scheduled.ts` `fireArvlCdStationPush` / `fireVanishFallbackStationPush`**: `sendSilentPush` → `sendAlertPush`로 전환. title/body는 device가 기존에 렌더하던 문구(`alertContent.buildAlertContent`)를 그대로 재사용. `trip.sleepModeEnabled === true`면 매역 알림 발사를 skip하고 `station-notif skip: sleep` 로그 (sleep-transfer/boarding-prompt 게이트와는 완전히 별개 분기). 기존 dedup(`arvlCdFireKey` KV 1h + fireOnce 5min + cross-window 45s)은 키/TTL 변경 없이 그대로 유지.
- **visible push 직접 발사**이므로 60s ACK 기반 alert fallback 안전망(`PENDING_PUSHES` 등록, `putPending`)이 더 이상 필요 없어 두 함수의 `putPending` 호출을 제거. `PendingPush.kind`(transfer/destination/intermediate)만으로는 origin(arvlcd/vanish vs lockless)을 구분할 수 없어, `fallback.ts` 자체의 처리 로직(`runFallbackPushes`)은 변경하지 않았다 — lockless intermediate 경로(여전히 silent push, device-side validation이 느슨해 안전망이 더 절실)의 안전망을 보존하기 위함. "매역 계열 kind를 fallback 등록 대상에서 제외"는 등록 호출부(scheduled.ts) 제거로 자연히 달성되며, `fallback.ts` 모듈 docstring에 이 invariant를 명시했다.

## 스펙 대비 이탈 (판단 근거)

이슈 item 4는 "fallback.ts에서 매역 계열 kind를 등록 대상에서 제외"라고 명시했으나, `PendingPush.kind`가 origin을 구분하지 못해 문자 그대로 kind 기반 필터를 `fallback.ts`에 추가하면 (범위 밖인) lockless intermediate 경로의 ACK fallback 안전망까지 함께 무력화된다. 대신 등록 호출부(scheduled.ts, 본 이슈 명시 범위) 제거로 동일 결과를 달성하고 `fallback.ts`는 문서만 갱신했다 — lockless 경로는 이슈의 "하지 말 것" 범위 밖이라 건드리지 않음.

## Wire-completion 5단

1. **Orphan 없음** — 백엔드는 프론트 `lint:orphan` 스크립트 범위 밖(frontend `src/`만 스캔). `npm run lint:orphan` 로컬 pass(무영향) 확인. 신규 export(`buildSilentPushData`, `stationNotifCollapseId`, `STATION_NOTIF_COLLAPSE_ID_PREFIX`, `STATION_NOTIF_EXPIRATION_MS`)는 모두 `scheduled.ts`/`apns.ts` 내부 caller 존재.
2. **V/X dashboard** — wrangler tail의 `arvlcd-fire: station-passed push` / `vanish-fallback-fire: station-passed push` / `vanish-release-fire: station-passed push` 로그로 발사 관측, `station-notif skip: sleep` 로그로 sleep mute skip 관측.
3. **의존 PR** — Phase 0 (#2062 APNs env self-heal evidence, 선행 게이트). ADR-023 개정 문서화는 #2065(독립 진행 중)가 담당.
4. **측정 plan** — wrangler tail에서 `station-notif skip: sleep` 발생 빈도(취침모드 trip에서만 발생해야 함) + `arvlcd-fire`/`vanish-*-fire` 로그의 `apns-push-type` 확인.
5. **Device verify** — 필요. 실기기 일반 모드 trip에서 매역 알림 배너 도달(특히 앱 kill 상태) + 취침 모드 trip에서 매역 알림 0건 확인. Phase 1-device(#2064)가 device-side 정리를 담당하므로, 본 PR 단독 상태에서는 device가 여전히 `data` payload를 기존 방식으로 소비할 수 있는지(하위호환)도 함께 확인 필요.

## Test plan

- [x] `backend/alarm-worker`: `npx vitest run` — 67 files, 2628 tests pass
- [x] `backend/alarm-worker`: `npm run type-check` pass
- [x] root `npm test` — 426 suites, 9234 tests pass (frontend 무변경 확인)
- [x] root `npm run type-check` pass
- [x] root `npm run lint:orphan` pass