### PR TITLE
fix(#2076): GPS 품질 게이트 심부 지하 absence 타이머 + 급락 오탐 차단

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
@@ -1674,63 +1674,157 @@ describe('useNearestStation — #2070 GPS 품질 게이트 (결정 tier 입력)'
     expect(drops[0].dropReason).toBe('gps-quality-drop:stale');
   });
 
-  it('게이트 통과 fix 이후 accuracy가 100m 초과 급락하면 gpsQualityDegraded=true', async () => {
+  // #2076 결함2 — 급락(accuracy 1회성 급증) 단독은 더 이상 gpsQualityDegraded를 발동시키지
+  // 않는다. 지상 urban canyon(고층빌딩 사이 multipath)에서 accuracy가 1회 튀어도 지하로
+  // 오분류(inferEnvironment 우선순위 8 hint)되던 결함 차단.
+  it('급락(50→180m) 1회 단독으로는 gpsQualityDegraded=false 유지 (#2076 결함2 — urban canyon 오탐 차단)', async () => {
     const { result } = renderHook(() => useNearestStation());
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
     simulateGps(37.498, 127.0277, { accuracy: 50 });
     expect(result.current.gpsQualityDegraded).toBe(false);
 
-    simulateGps(37.4981, 127.0278, { accuracy: 200 });
-    expect(result.current.gpsQualityDegraded).toBe(true);
+    simulateGps(37.4981, 127.0278, { accuracy: 180 }); // 급락(130m > 100m 임계)
+    expect(result.current.gpsQualityDegraded).toBe(false);
+  });
+});
+
+describe('useNearestStation — #2076 GPS 품질 게이트 후속 (absence 독립 타이머 / hysteresis 해제)', () => {
+  const originalCurrentState = AppState.currentState;
+
+  const lastWatchOptionsAt = () => {
+    const calls = (Location.watchPositionAsync as jest.Mock).mock.calls;
+    return calls[calls.length - 1][0];
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await AsyncStorage.clear();
+    appStateCallback = null;
+    watchCallback = null;
+    mockNoLastKnownLocation();
+    mockSubscription.remove.mockClear();
+    (Location.watchPositionAsync as jest.Mock).mockImplementation(
+      async (_options: unknown, callback: typeof watchCallback) => {
+        watchCallback = callback;
+        return mockSubscription;
+      },
+    );
+    mockGranted();
+    (AppState as { currentState: string }).currentState = 'active';
+    jest.useFakeTimers();
   });
 
-  it('급락 후 다시 게이트 통과 fix가 들어오면 gpsQualityDegraded=false로 원복된다', async () => {
+  afterEach(() => {
+    (AppState as { currentState: string }).currentState = originalCurrentState;
+    jest.useRealTimers();
+  });
+
+  // #2076 결함1 — 심부 지하: fix가 완전히 끊겨도(watch 콜백 자체가 호출되지 않아도) 독립
+  // 타이머가 마지막 게이트 통과 fix 시각을 주기적으로 재평가해 absence 30s를 판정한다.
+  it('fix 완전 중단 30s+ → absence 독립 타이머가 gpsQualityDegraded=true로 전이시킨다 (심부 지하)', async () => {
     const { result } = renderHook(() => useNearestStation());
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
     simulateGps(37.498, 127.0277, { accuracy: 50 });
-    simulateGps(37.4981, 127.0278, { accuracy: 200 });
+    expect(result.current.gpsQualityDegraded).toBe(false);
+
+    // 이후 fix 없음(완전 유실) — 타이머만으로 30s+ 경과를 판정.
+    act(() => {
+      jest.advanceTimersByTime(40_000);
+    });
+
+    expect(result.current.gpsQualityDegraded).toBe(true);
+  });
+
+  // 표시 게이트(250m) drop fix도 품질 게이트 평가에는 공급돼야 hysteresis 카운터가 정확히
+  // 리셋된다 — 표시(userLocation)는 이 fix로 갱신되지 않는다(표시 경로 불변).
+  it('>250m fix는 표시(userLocation) 미갱신 + 품질 게이트 hysteresis 카운터를 리셋한다', async () => {
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+
+    // 최초 통과 fix로 lastPassAt 기준점을 세운다(콜드스타트에서는 absence 판정 자체가 보류된다).
+    simulateGps(37.4979, 127.0276, { accuracy: 50 });
+    expect(result.current.gpsQualityDegraded).toBe(false);
+    // 연속 통과 카운터를 0으로 리셋(이후 hysteresis 카운트를 1부터 검증하기 위해).
+    simulateGps(37.51, 127.05, { accuracy: 300 });
+
+    // absence로 degraded=true 유도.
+    act(() => {
+      jest.advanceTimersByTime(40_000);
+    });
     expect(result.current.gpsQualityDegraded).toBe(true);
 
-    simulateGps(37.4982, 127.0279, { accuracy: 50 });
+    // 통과 fix 1회 — hysteresis 미충족(1/2), 아직 해제 안 됨.
+    simulateGps(37.498, 127.0277, { accuracy: 50 });
+    expect(result.current.gpsQualityDegraded).toBe(true);
+    const locationAfterFirstPass = result.current.userLocation;
+
+    // >250m fix — 표시 미갱신 + 연속 통과 카운터 리셋(hysteresis 처음부터 다시 세야 함).
+    simulateGps(37.51, 127.05, { accuracy: 300 });
+    expect(result.current.userLocation).toEqual(locationAfterFirstPass);
+    expect(result.current.gpsQualityDegraded).toBe(true);
+
+    // 리셋되었으므로 통과 fix 1회로는 아직 해제 안 됨.
+    simulateGps(37.498, 127.0277, { accuracy: 50 });
+    expect(result.current.gpsQualityDegraded).toBe(true);
+
+    // 연속 2회째 통과 fix → 해제.
+    simulateGps(37.4981, 127.0278, { accuracy: 50 });
     expect(result.current.gpsQualityDegraded).toBe(false);
   });
 
-  it('게이트 통과 fix가 30s 이상 없으면(부재) gpsQualityDegraded=true', async () => {
-    const { state, restore } = setupGpsDropFakeNow();
-    try {
-      const { result } = renderHook(() => useNearestStation());
-      await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
+  it('hysteresis: 통과 fix 1회로는 해제 안 되고, 연속 2회째에 해제된다', async () => {
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
 
-      simulateGps(37.498, 127.0277, { accuracy: 50, timestamp: state.fakeNow });
-      expect(result.current.gpsQualityDegraded).toBe(false);
+    simulateGps(37.4979, 127.0276, { accuracy: 50 });
+    // 연속 통과 카운터를 0으로 리셋(이후 hysteresis 카운트를 1부터 검증하기 위해).
+    simulateGps(37.51, 127.05, { accuracy: 300 });
 
-      state.fakeNow += 31_000;
-      // 급락은 아닌(70m 상승, 100m 미만) accuracy로도 부재 조건만으로 degraded 전이.
-      simulateGps(37.4981, 127.0278, { accuracy: 120, timestamp: state.fakeNow });
+    act(() => {
+      jest.advanceTimersByTime(40_000);
+    });
+    expect(result.current.gpsQualityDegraded).toBe(true);
 
-      expect(result.current.gpsQualityDegraded).toBe(true);
-    } finally {
-      restore();
-    }
+    simulateGps(37.498, 127.0277, { accuracy: 50 });
+    expect(result.current.gpsQualityDegraded).toBe(true);
+
+    simulateGps(37.4981, 127.0278, { accuracy: 50 });
+    expect(result.current.gpsQualityDegraded).toBe(false);
   });
 
-  it('degraded 발생 시 FG watch가 지하 프로파일(High@12s)로 전환되고, 게이트 통과 fix 재등장 시 지상으로 원복된다', async () => {
+  it('degraded 발생(absence) 시 FG watch가 지하 프로파일(High@12s)로 전환되고, hysteresis 해제 시 지상으로 원복된다', async () => {
     renderHook(() => useNearestStation());
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1));
-    expect(lastWatchOptions()).toEqual(SURFACE_OPTIONS);
+    expect(lastWatchOptionsAt()).toEqual({
+      accuracy: Location.Accuracy.High,
+      distanceInterval: 0,
+      timeInterval: FG_WATCH_SURFACE_TIME_INTERVAL_MS,
+    });
 
-    simulateGps(37.498, 127.0277, { accuracy: 50 });
-    simulateGps(37.4981, 127.0278, { accuracy: 200 }); // 급락 → degraded=true
+    simulateGps(37.4979, 127.0276, { accuracy: 50 });
+
+    act(() => {
+      jest.advanceTimersByTime(40_000);
+    });
 
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(2));
-    expect(lastWatchOptions()).toEqual(SUBSURFACE_OPTIONS);
+    expect(lastWatchOptionsAt()).toEqual({
+      accuracy: Location.Accuracy.High,
+      distanceInterval: 0,
+      timeInterval: FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS,
+    });
 
-    simulateGps(37.4982, 127.0279, { accuracy: 50 }); // 게이트 통과 → 원복
+    simulateGps(37.498, 127.0277, { accuracy: 50 });
+    simulateGps(37.4981, 127.0278, { accuracy: 50 }); // 연속 2회 통과 → hysteresis 해제
 
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(3));
-    expect(lastWatchOptions()).toEqual(SURFACE_OPTIONS);
+    expect(lastWatchOptionsAt()).toEqual({
+      accuracy: Location.Accuracy.High,
+      distanceInterval: 0,
+      timeInterval: FG_WATCH_SURFACE_TIME_INTERVAL_MS,
+    });
   });
 
   it('barometerSubsurface=true가 이미 활성이면 gpsQualityDegraded 변화만으로는 재시작하지 않는다 (이미 지하 프로파일)', async () => {
@@ -1739,13 +1833,19 @@ describe('useNearestStation — #2070 GPS 품질 게이트 (결정 tier 입력)'
       { initialProps: { sub: true } },
     );
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1));
-    expect(lastWatchOptions()).toEqual(SUBSURFACE_OPTIONS);
+    expect(lastWatchOptionsAt()).toEqual({
+      accuracy: Location.Accuracy.High,
+      distanceInterval: 0,
+      timeInterval: FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS,
+    });
 
     await act(async () => {
       rerender({ sub: true });
     });
-    simulateGps(37.498, 127.0277, { accuracy: 50 });
-    simulateGps(37.4981, 127.0278, { accuracy: 200 }); // degraded=true여도 이미 subsurface 프로파일
+    simulateGps(37.4979, 127.0276, { accuracy: 50 });
+    act(() => {
+      jest.advanceTimersByTime(40_000); // degraded=true여도 이미 subsurface 프로파일
+    });
 
     // barometerSubsurface=true가 이미 throttle=true를 만들었으므로 추가 재시작 없음.
     expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1);

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -1148,9 +1148,12 @@ export function useFusedNearestStation(
     tripStartedAt: boardingLock?.boardedAt,
   });
   // #1860 — 옵션 C barometer-stop 힌트. tripActive + barometerStop 전달.
-  // #2070 — GPS 품질 저하 transition(gps.gpsQualityDegraded) 추가 입력. useNearestStation이
+  // #2070 — GPS 품질 저하(gps.gpsQualityDegraded) 추가 입력. useNearestStation이
   // raw fix 스트림만으로 자체 판정한 값을 그대로 전달 — 기존 barometer/SSOT 판정을 대체하지 않고
   // SSOT 무판정 구간(우선순위 8)에만 관여한다.
+  // #2076 — gpsQualityDegraded는 absence(게이트 통과 fix 30s+ 부재, 독립 타이머 구동) 단독으로만
+  // true가 된다. 급락(accuracy 1회성 급증) 단독으로는 true가 되지 않아(#2076 결함2) 지상 urban
+  // canyon 오탐이 이 hint를 발동시키지 않는다.
   const cascadeEnvironmentResult: InferEnvironmentResult = inferEnvironment({
     subsurface: barometerSubsurface,
     surfaceSSOT: cascadeSurfaceSSOT !== null,

--- a/src/features/nearest-station/hooks/useNearestStation.ts
+++ b/src/features/nearest-station/hooks/useNearestStation.ts
@@ -32,11 +32,15 @@ import { pushFusionDebugEntry } from '../utils/fusionDebugBuffer';
 import { pushGpsDropEntry } from '../utils/gpsDropBuffer';
 import { haversine } from '../../../shared/utils/haversine';
 import { useStickyStation } from './useStickyStation';
+import { usePolling } from '../../../shared/hooks/usePolling';
 import {
   isGpsQualityGateAcceptable,
   gpsQualityDropReason,
-  isGpsQualityDegradedTransition,
+  isGpsQualityJumpDegraded,
+  isGpsQualityAbsenceDegraded,
+  isGpsQualityHysteresisReleased,
 } from '../utils/gpsQualityGate';
+import { GPS_QUALITY_GATE_TIMER_INTERVAL_MS } from '../../../shared/constants/gpsQualityGate';
 
 /** #876 — useNearestStation 표시값의 출처. sticky lock된 역이면 'sticky', 아니면 GPS live.
  *  알람 트리거에는 영향 없음 — 호출자가 출처별 UX(예: "탑승 전 추정")를 분기할 수 있게 노출. */
@@ -129,10 +133,14 @@ interface UseNearestStationReturn {
   // #852: 마지막 신뢰 fix epoch ms. BG 진입 후 새 fix가 없으면 이 시각은 정지.
   // null = 한 번도 fix 없음(cold start). 디버그 모달 표기용.
   lastFixAtMs: number | null;
-  // #2070 — fusion 결정 tier 품질 게이트(100m/15s) 저하 transition 여부. 직전 게이트 통과 fix
-  // 대비 accuracy 급락(>100m) 또는 게이트 통과 fix 30s 부재 시 true. 호출자(useFusedNearestStation)가
+  // #2070 — fusion 결정 tier 품질 게이트(100m/15s) 저하 여부. 호출자(useFusedNearestStation)가
   // inferEnvironment의 추가 입력으로 사용 — 지하 진입 후보 신호이며, FG watch 폴링 프로파일도
   // 이 값으로 지하 프로파일 전환/원복된다.
+  //
+  // #2076 — true는 오직 게이트 통과 fix가 GPS_QUALITY_GATE_ABSENCE_MS(30s) 이상 없을 때만
+  // (독립 타이머 구동, fix 도착 이벤트에 의존하지 않음 — 결함1). 급락(accuracy 1회성 급증) 단독으로는
+  // true가 되지 않는다(결함2 — 지상 urban canyon 오탐 차단). false 복귀(해제)는 게이트 통과 fix가
+  // 연속 2회 이상일 때만(hysteresis — 단발 fix 플랩 방지).
   gpsQualityDegraded: boolean;
   // #876: result 출처. sticky lock된 역이면 'sticky', live GPS 최근접이면 'live'.
   // 호출자가 출처별 UX(예: 라벨 "탑승 전 추정")로 분기 가능. 알람 트리거에는 영향 없음.
@@ -248,11 +256,72 @@ export function useNearestStation(
     skipped: 0,
   });
   // #2070 — fusion 결정 tier 품질 게이트(100m/15s) SSOT. 직전 게이트 통과 fix의 accuracy/시각을
-  // ref로 들고 있다가 급락(>100m)/30s 부재 판정에 사용한다. gpsQualityDegraded는 폴링 프로파일
-  // 전환 effect의 deps로 쓰여야 해서 state로 노출한다.
+  // ref로 들고 있다가 급락(>100m 진단용)/30s 부재 판정에 사용한다. gpsQualityDegraded는 폴링
+  // 프로파일 전환 effect의 deps로 쓰여야 해서 state로 노출한다.
   const qualityGateLastPassAccuracyRef = useRef<number | null>(null);
   const qualityGateLastPassAtRef = useRef<number | null>(null);
+  // #2076 — hysteresis 해제용 연속 게이트 통과 fix 카운터. 게이트 미달 fix(급락/부재 관계없이
+  // 어떤 사유든)가 한 번이라도 끼면 0으로 리셋된다.
+  const qualityGateConsecutivePassRef = useRef(0);
   const [gpsQualityDegraded, setGpsQualityDegraded] = useState(false);
+
+  // #2076 — 게이트 통과/미달 판정 자체는 applyLocation(표시 게이트 통과 fix)과 watch 콜백의
+  // 표시 게이트 drop 분기(>250m fix) 양쪽에서 공유한다. 표시 상태(setUserLocation 등)는 절대
+  // 건드리지 않고, 오직 품질 게이트 SSOT(ref/gpsQualityDegraded)만 갱신한다.
+  //
+  // degraded=true는 이 함수가 아니라 아래 absence 타이머(usePolling)가 단독으로 설정한다 — 급락
+  // 단독으로 즉시 true가 되던 #2070 동작을 결함2로 판정해 제거했다. 이 함수는 게이트 통과 시
+  // hysteresis 카운터를 올려 임계(2연속) 도달 시에만 false로 해제한다.
+  const evaluateGpsQuality = useCallback(
+    (
+      accuracy: number | null | undefined,
+      fixTimestamp: number,
+      lat: number,
+      lng: number,
+      speed: number | null | undefined,
+      // #2076 — 표시 게이트(250m)에서 이미 자체 dedup/rate-limit 로그(dropReason
+      // 'low-accuracy-display')를 남기는 호출 경로(watch 콜백)는 중복 로그를 막기 위해 false로
+      // 전달한다. 게이트 판정/hysteresis 카운터 갱신은 로그 여부와 무관하게 항상 수행된다.
+      logDrop: boolean = true,
+    ) => {
+      const now = Date.now();
+      const ageMs = now - fixTimestamp;
+      if (isGpsQualityGateAcceptable(accuracy, ageMs)) {
+        qualityGateLastPassAccuracyRef.current = accuracy;
+        qualityGateLastPassAtRef.current = now;
+        qualityGateConsecutivePassRef.current += 1;
+        if (isGpsQualityHysteresisReleased(qualityGateConsecutivePassRef.current)) {
+          setGpsQualityDegraded((prev) => (prev ? false : prev));
+        }
+        return;
+      }
+      // #2076 결함2 — 급락 여부는 진단 로그에만 반영. degraded 상태를 직접 바꾸지 않는다.
+      const jumpDegraded = isGpsQualityJumpDegraded(qualityGateLastPassAccuracyRef.current, accuracy);
+      qualityGateConsecutivePassRef.current = 0;
+      if (!logDrop) return;
+      pushGpsDropEntry({
+        ts: now,
+        lat,
+        lng,
+        accuracyMeters: accuracy ?? null,
+        speedMps: isValidGpsSpeedMps(speed) ? speed : null,
+        dropReason: `gps-quality-drop:${gpsQualityDropReason(accuracy, ageMs)}${jumpDegraded ? '-jump' : ''}`,
+      });
+    },
+    [],
+  );
+
+  // #2076 결함1 — absence 판정을 fix 도착 이벤트에서 분리한 독립 타이머. GPS가 완전히 유실되면
+  // (심부 지하) fix 자체가 안 들어와 evaluateGpsQuality가 호출되지 않으므로, fix-driven 평가만으로는
+  // absence 30s 판정이 영영 발동하지 못한다. 이 타이머가 마지막 게이트 통과 fix 시각을 주기적으로
+  // 재평가해 fix 도착 여부와 무관하게 degraded=true를 설정한다. 해제는 여기서 하지 않는다(위
+  // evaluateGpsQuality의 hysteresis 경로 전담) — 그래야 "판정 즉시 통과 fix로 해제" 같은 단발
+  // flip이 재발하지 않는다.
+  usePolling(() => {
+    if (isGpsQualityAbsenceDegraded(qualityGateLastPassAtRef.current, Date.now())) {
+      setGpsQualityDegraded((prev) => (prev ? prev : true));
+    }
+  }, GPS_QUALITY_GATE_TIMER_INTERVAL_MS);
 
   const applyLocation = useCallback((coords: Location.LocationObjectCoords, timestamp: number) => {
     const { latitude, longitude, speed, accuracy } = coords;
@@ -293,29 +362,8 @@ export function useNearestStation(
     // 통과했지만 결정 tier 입력 기준(100m/15s)에는 못 미치는 fix를 판별한다. userLocation/
     // accuracyMeters/result 자체는 그대로 노출(표시 동작 불변) — 결정 tier 소비자
     // (useFusedNearestStation)가 gpsQualityDegraded를 별도로 참고해 판단한다.
-    const qualityGateNow = Date.now();
-    const qualityAgeMs = qualityGateNow - timestamp;
-    if (isGpsQualityGateAcceptable(accuracy, qualityAgeMs)) {
-      qualityGateLastPassAccuracyRef.current = accuracy;
-      qualityGateLastPassAtRef.current = qualityGateNow;
-      setGpsQualityDegraded((prev) => (prev ? false : prev));
-    } else {
-      pushGpsDropEntry({
-        ts: qualityGateNow,
-        lat: latitude,
-        lng: longitude,
-        accuracyMeters: accuracy ?? null,
-        speedMps: isValidGpsSpeedMps(speed) ? speed : null,
-        dropReason: `gps-quality-drop:${gpsQualityDropReason(accuracy, qualityAgeMs)}`,
-      });
-      const degraded = isGpsQualityDegradedTransition(
-        qualityGateLastPassAccuracyRef.current,
-        qualityGateLastPassAtRef.current,
-        accuracy,
-        qualityGateNow,
-      );
-      setGpsQualityDegraded((prev) => (prev === degraded ? prev : degraded));
-    }
+    // #2076 — 판정 로직은 evaluateGpsQuality로 추출(표시 게이트 drop 분기와 공유).
+    evaluateGpsQuality(accuracy, timestamp, latitude, longitude, speed);
 
     // 측정(#443): station 변화 시에만 push. 매 fix는 너무 자주 — 점프 시퀀스
     // (사가정→을지로4가→용마산) 재구성엔 station 단위면 충분.
@@ -333,7 +381,7 @@ export function useNearestStation(
         nearestDistanceKm: stationsResult?.distanceKm ?? null,
       });
     }
-  }, []);
+  }, [evaluateGpsQuality]);
 
   const stopWatch = useCallback(() => {
     subscriptionRef.current?.remove();
@@ -443,6 +491,18 @@ export function useNearestStation(
             // React 자동 bail-out은 hook 단위만 — 84+회/5분 reentry 시 useState reducer 호출
             // 자체가 reconcile 큐에 들어가는 부담을 명시 가드로 제거한다.
             setLocationUncertain((prev) => (prev ? prev : true));
+            // #2076 결함1 — 표시 게이트(250m)에서 drop되는 fix도 품질 게이트(100m/15s) 평가에는
+            // 반드시 공급한다. 표시 경로(setUserLocation/setResult 등)는 건드리지 않고 품질 게이트
+            // SSOT(ref/hysteresis 카운터/gps-drop 로그)만 갱신 — 심부 지하처럼 fix가 계속 >250m로만
+            // 들어오는 구간에서도 hysteresis 카운터가 정확히 리셋되고 진단 로그가 남는다.
+            evaluateGpsQuality(
+              location.coords.accuracy,
+              location.timestamp,
+              location.coords.latitude,
+              location.coords.longitude,
+              location.coords.speed,
+              false,
+            );
             // #443: 표시 게이트에 drop된 fix도 사후 진단에 필요(사가정 같은 부정확 fix로
             // 락된 의심 시점을 식별). 이 분기는 accuracy가 non-null 임계 초과인 경우만.
             const dropSpeed = location.coords.speed;
@@ -514,7 +574,7 @@ export function useNearestStation(
       setError('위치를 가져오는 데 실패했습니다.');
       setLoading(false);
     }
-  }, [applyLocation]);
+  }, [applyLocation, evaluateGpsQuality]);
 
   // 수동 새로고침: watch 중지 → one-shot → watch 재시작
   const refresh = useCallback(async () => {

--- a/src/features/nearest-station/utils/__tests__/gpsQualityGate.test.ts
+++ b/src/features/nearest-station/utils/__tests__/gpsQualityGate.test.ts
@@ -3,7 +3,7 @@ import {
   gpsQualityDropReason,
   isGpsQualityJumpDegraded,
   isGpsQualityAbsenceDegraded,
-  isGpsQualityDegradedTransition,
+  isGpsQualityHysteresisReleased,
 } from '../gpsQualityGate';
 
 describe('isGpsQualityGateAcceptable — #2070 경계값 (accuracy 99/100/101m x age 14/15/16s)', () => {
@@ -89,24 +89,20 @@ describe('isGpsQualityAbsenceDegraded', () => {
   });
 });
 
-describe('isGpsQualityDegradedTransition — #2070 급락/부재 발생·미발생', () => {
-  it('급락만 발생 → true', () => {
-    expect(isGpsQualityDegradedTransition(50, 0, 200, 1_000)).toBe(true);
+describe('isGpsQualityHysteresisReleased — #2076 degraded 해제 hysteresis', () => {
+  it('연속 통과 0회 → 해제 안 됨', () => {
+    expect(isGpsQualityHysteresisReleased(0)).toBe(false);
   });
 
-  it('부재만 발생 → true', () => {
-    expect(isGpsQualityDegradedTransition(50, 0, 60, 30_000)).toBe(true);
+  it('연속 통과 1회 → 해제 안 됨 (단발 fix 플랩 방지)', () => {
+    expect(isGpsQualityHysteresisReleased(1)).toBe(false);
   });
 
-  it('둘 다 발생 → true', () => {
-    expect(isGpsQualityDegradedTransition(50, 0, 300, 40_000)).toBe(true);
+  it('연속 통과 2회(임계) → 해제', () => {
+    expect(isGpsQualityHysteresisReleased(2)).toBe(true);
   });
 
-  it('둘 다 미발생 → false', () => {
-    expect(isGpsQualityDegradedTransition(50, 29_000, 80, 30_000)).toBe(false);
-  });
-
-  it('콜드스타트(통과 기록 없음) + 짧은 경과 → false', () => {
-    expect(isGpsQualityDegradedTransition(null, null, 300, 1_000)).toBe(false);
+  it('연속 통과 2회 초과 → 해제', () => {
+    expect(isGpsQualityHysteresisReleased(3)).toBe(true);
   });
 });

--- a/src/features/nearest-station/utils/gpsQualityGate.ts
+++ b/src/features/nearest-station/utils/gpsQualityGate.ts
@@ -3,6 +3,7 @@ import {
   GPS_QUALITY_GATE_MAX_AGE_MS,
   GPS_QUALITY_DEGRADE_JUMP_M,
   GPS_QUALITY_GATE_ABSENCE_MS,
+  GPS_QUALITY_GATE_HYSTERESIS_PASS_COUNT,
 } from '../../../shared/constants/gpsQualityGate';
 
 export type GpsQualityDropReason = 'accuracy' | 'stale';
@@ -38,6 +39,11 @@ export function gpsQualityDropReason(
 /**
  * #2070 — 직전 게이트 통과 fix 대비 accuracy가 GPS_QUALITY_DEGRADE_JUMP_M(100m) 초과로
  * 급락했는지. 직전 통과 기록이 없으면(콜드스타트 등) 판단 불가 → false.
+ *
+ * #2076 결함2 — 급락 단독은 더 이상 gpsQualityDegraded(underground hint)를 발동시키지 않는다.
+ * 지상 urban canyon(고층빌딩 사이 multipath)에서 accuracy가 1회성으로 급락해도 지하로
+ * 오분류되던 결함 차단. 이 함수의 결과는 진단 로그(gps-drop dropReason)에만 쓰이고, 게이트
+ * 미달 fix는 어차피 lastPassAt을 갱신하지 않으므로 absence 판정에 별도로 관여하지 않는다.
  */
 export function isGpsQualityJumpDegraded(
   lastPassAccuracyM: number | null,
@@ -61,18 +67,11 @@ export function isGpsQualityAbsenceDegraded(
 }
 
 /**
- * #2070 — 품질 저하 transition 이벤트. 급락 또는 30s 부재 중 하나라도 해당하면 true.
- * 기존 subsurface/environment 판정 로직(inferEnvironment)에 추가 입력으로 전달되며,
- * 판정 로직 자체를 대체하지 않는다.
+ * #2076 — degraded 해제(hysteresis) 판정. 연속 게이트 통과 fix 수가
+ * GPS_QUALITY_GATE_HYSTERESIS_PASS_COUNT(2) 이상이어야 해제로 인정한다. 통과 fix 1회만으로
+ * 해제하면 지하상가 틈에서 잠깐 잡힌 단발 fix에도 매번 플랩(degraded↔정상)해 FG watch
+ * 재시작 churn(#2076 개선3)을 유발한다.
  */
-export function isGpsQualityDegradedTransition(
-  lastPassAccuracyM: number | null,
-  lastPassAtMs: number | null,
-  currentAccuracyM: number | null | undefined,
-  nowMs: number,
-): boolean {
-  return (
-    isGpsQualityJumpDegraded(lastPassAccuracyM, currentAccuracyM) ||
-    isGpsQualityAbsenceDegraded(lastPassAtMs, nowMs)
-  );
+export function isGpsQualityHysteresisReleased(consecutivePassCount: number): boolean {
+  return consecutivePassCount >= GPS_QUALITY_GATE_HYSTERESIS_PASS_COUNT;
 }

--- a/src/features/nearest-station/utils/inferEnvironment.ts
+++ b/src/features/nearest-station/utils/inferEnvironment.ts
@@ -28,9 +28,12 @@
  * gate와 semantic equivalence 보존.
  *
  * #2070 — 우선순위 8이 추가됨. barometer warmup/미지원(subsurface===undefined) + SSOT 무판정
- * 구간에서 GPS 품질 저하 transition(급락 또는 게이트 통과 fix 30s 부재)이 관측되면 지하 진입
- * 후보로 간주한다. 기존 1~7 판정 로직은 그대로 유지되며 대체되지 않는다 — barometer/SSOT 명시
- * 신호가 있으면 항상 그 결과가 우선한다.
+ * 구간에서 GPS 품질 저하가 관측되면 지하 진입 후보로 간주한다. 기존 1~7 판정 로직은 그대로
+ * 유지되며 대체되지 않는다 — barometer/SSOT 명시 신호가 있으면 항상 그 결과가 우선한다.
+ *
+ * #2076 — GPS 품질 저하 입력(qualityDegraded)은 게이트 통과 fix가 30s 이상 부재(absence)할
+ * 때만 true다. accuracy 1회성 급락 단독으로는 true가 되지 않는다 — 지상 urban canyon(고층빌딩
+ * multipath)에서의 급락 1회가 지하로 오분류되던 결함(#2076 결함2) 차단.
  */
 
 export type Environment = 'surface' | 'underground' | 'unknown';
@@ -43,7 +46,7 @@ export interface InferEnvironmentResult {
    * 발동 조건: tripActive=true + barometerStop=true + subsurface=false + 두 SSOT 없음.
    *
    * #2070 — 'gps-quality-drop': subsurface===undefined + 두 SSOT 무판정 + GPS 품질 저하
-   * transition 관측 시 발동.
+   * (#2076 — absence 30s+ 단독. 급락 단독으로는 발동하지 않는다) 관측 시 발동.
    */
   hintReason?: 'barometer-stop' | 'gps-quality-drop';
 }
@@ -60,9 +63,9 @@ export interface InferEnvironmentInput {
   /** #1860 — BarometerSignal.stop. barometer-stop 힌트 발동 전제 조건. */
   barometerStop?: boolean;
   /**
-   * #2070 — GPS 품질 저하 transition(급락 또는 게이트 통과 fix 30s 부재) 관측 여부.
-   * subsurface===undefined + 두 SSOT 무판정 구간에서만 판정에 관여한다(우선순위 8).
-   * 미전달이면 false로 간주(기존 동작 보존).
+   * #2070 — GPS 품질 저하 관측 여부. #2076 — 게이트 통과 fix 30s+ 부재(absence)일 때만 true.
+   * 급락 단독으로는 true가 되지 않는다. subsurface===undefined + 두 SSOT 무판정 구간에서만
+   * 판정에 관여한다(우선순위 8). 미전달이면 false로 간주(기존 동작 보존).
    */
   qualityDegraded?: boolean;
 }

--- a/src/shared/constants/gpsQualityGate.ts
+++ b/src/shared/constants/gpsQualityGate.ts
@@ -16,3 +16,12 @@ export const GPS_QUALITY_GATE_MAX_AGE_MS = 15_000;
 export const GPS_QUALITY_DEGRADE_JUMP_M = 100;
 // 부재: 게이트 통과 fix가 이 시간(ms) 이상 없으면 부재로 판정.
 export const GPS_QUALITY_GATE_ABSENCE_MS = 30_000;
+
+// #2076 — absence 판정을 fix 도착 이벤트에서 분리하는 독립 타이머 주기. GPS 완전 유실(심부
+// 지하) 상태에서는 fix 자체가 안 들어와 fix-driven 평가가 영영 발동하지 못하는 결함(#2076
+// 결함1)을 차단한다. GPS_QUALITY_GATE_ABSENCE_MS(30s)보다 충분히 짧게 잡아 30~35s 내 판정.
+export const GPS_QUALITY_GATE_TIMER_INTERVAL_MS = 5_000;
+
+// #2076 — degraded 해제(hysteresis) 조건. 게이트 통과 fix 1회만으로 해제하면 단발성 fix
+// 플랩(지하상가 틈 GPS 한 번 잡힘 등)에 반복 flip한다 — 연속 통과 fix가 이 값 이상일 때만 해제.
+export const GPS_QUALITY_GATE_HYSTERESIS_PASS_COUNT = 2;


### PR DESCRIPTION
## 요약

Closes #2076

PR #2074(#2070) 사후 리뷰에서 발견된 결함 2건 + 개선 1건을 고친다.

- **결함1 (P2, borderline P1)**: `gpsQualityDegraded`가 `applyLocation` 내부(표시 게이트 통과 fix 도착 이벤트)에서만 세팅되어, GPS 완전 유실/accuracy>250m가 지속되는 심부 지하에서는 absence(30s) 판정이 영영 평가되지 않던 결함. absence 판정을 fix 도착 이벤트에서 분리해 `usePolling` 기반 독립 타이머(5s 주기)로 구동하도록 변경. 표시 게이트(250m)에서 drop되는 fix도 품질 게이트 평가(hysteresis 카운터 리셋)에는 공급하되 표시 경로(`setUserLocation`/`setResult` 등)는 절대 건드리지 않음.
- **결함2 (P2)**: `inferEnvironment` priority 8이 급락(accuracy 1회성 급증) 단독으로도 발동해, 지상 urban canyon(고층빌딩 사이 multipath)에서 accuracy가 1회 튀면 underground로 오분류되던 결함. 급락 단독으로는 더 이상 `gpsQualityDegraded=true`를 세팅하지 않도록 변경 — hint는 absence-degraded(게이트 통과 fix 30s+ 부재)일 때만 발동. 급락 정보는 gps-drop 진단 로그(`dropReason` `-jump` suffix)로만 남김.
- **개선3 (P3)**: degraded 해제(false 복귀)에 hysteresis 도입 — 게이트 통과 fix가 연속 2회 이상일 때만 해제(`GPS_QUALITY_GATE_HYSTERESIS_PASS_COUNT`). 기존 FG watch 재시작 skip 가드(`throttledRef` 비교)는 그대로 유지되며 flapping 자체가 hysteresis로 줄어들어 재시작 churn이 감소한다.
- **[리뷰 후속] P2-1 (resume 시 stale lastPassAt → 일시적 false underground + watch churn)**: 앱이 30s+ 백그라운드(watch 정지, `qualityGateLastPassAtRef` freeze)에 머문 뒤 FG로 복귀하면 fresh fix 도착 **전에** absence 독립 타이머가 먼저 tick해 stale lastPassAt 기준으로 즉시 degraded=true를 오판 → hysteresis 2-pass 해제까지 최대 ~24s 동안 false underground hint + FG watch subsurface↔surface 재시작 churn이 발생하던 결함. `stopWatch()` 시(백그라운드 전환 포함, refresh()/프로파일 전환 effect의 stopWatch→startWatch 경로도 동일) `qualityGateLastPassAtRef`/`qualityGateConsecutivePassRef`를 콜드스타트(null/0)로 리셋 — 콜드스타트 안전 원칙과 동일하게 첫 fresh 통과 fix가 re-prime하기 전까지 absence 판정이 보류된다.

## 변경 파일

- `src/shared/constants/gpsQualityGate.ts` — 신규 상수 `GPS_QUALITY_GATE_TIMER_INTERVAL_MS`(5s), `GPS_QUALITY_GATE_HYSTERESIS_PASS_COUNT`(2). 기존 100m/15s/30s 상수는 변경하지 않음.
- `src/features/nearest-station/utils/gpsQualityGate.ts` — `isGpsQualityDegradedTransition`(급락 OR 부재 결합) 제거, `isGpsQualityHysteresisReleased` 추가.
- `src/features/nearest-station/hooks/useNearestStation.ts` — `evaluateGpsQuality` 함수로 판정 로직 추출(applyLocation + watch 콜백 250m drop 분기 공유), absence 독립 타이머(`usePolling`) 추가. `stopWatch()`에 품질 게이트 콜드스타트 리셋 추가(P2-1).
- `src/features/nearest-station/utils/inferEnvironment.ts` — 문서 주석만 갱신(priority 1~7/8 발동 조건 코드는 불변, 입력 값의 의미만 상류에서 좁혀짐).
- `src/features/nearest-station/hooks/useFusedNearestStation.ts` — 문서 주석만 갱신.
- 테스트: `gpsQualityGate.test.ts`, `useNearestStation.test.ts` — 신규/수정 테스트 (absence 타이머, hysteresis, 급락 단독 미발동, >250m fix 공급).

## 하지 않은 것 (이슈 스펙 준수)

- 표시 경로(`setUserLocation`/`setAccuracyMeters`/`setResult`) 변경 없음
- `inferEnvironment` priority 1~7 로직 변경 없음
- 250m display 게이트 값/의미 변경 없음
- #2070 확정 상수(100m/15s/30s) 변경 없음 — 신규 상수만 추가

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass 확인.
2. **V/X dashboard** — DebugModal의 gps-quality-drop 로그(기존 wire 재사용) + `environmentHintReason`('gps-quality-drop') 노출. 급락 시 dropReason에 `-jump` suffix 추가로 진단 세분화.
3. **의존 PR** — N/A (#2074 머지 후속, 순수 프론트 변경).
4. **측정 plan** — 실기기 지하 trip에서 심부 구간 진입 시 hint 발동 로그(`environmentHintReason='gps-quality-drop'`) 확인 + 지상 trip에서 급락 1회로 오탐 발동하지 않는지 확인.
5. **Device verify** — 필요. 지하 구간 trip 1회(심부 진입 후 hint 발동 확인) + 지상 trip에서 급락 오탐 미발동 확인.

## 검증

- `npm test` — 9236 tests pass, coverage 100% (lines/functions/branches/statements)
- `npm run type-check` — pass
- `npm run lint:orphan` — pass (0 orphan)
- `npx eslint` (변경 파일) — clean

## Test plan

- [x] 심부 시나리오: fix 완전 중단 30s+ → 타이머 driven absence-degraded true assert
- [x] >250m fix만 도착 → 표시 미갱신 + absence 카운터(hysteresis) 계속 진행 assert
- [x] 지상 오탐: 급락 1회(50→180m) 단독 → underground hint 미발동 assert
- [x] hysteresis: 통과 fix 1회 → 해제 안 됨 / 연속 2회 → 해제
- [x] 기존 #2070 테스트 전부 green 유지
- [x] P2-1: BG 30s+ 후 FG 복귀 즉시 tick에도 degraded false 유지
- [x] P2-1: 복귀 후 게이트 통과 fix로 lastPassAt re-prime → 그 이후 실제 30s 부재 시에만 degraded true
- [ ] 실기기 지하 trip 1회 (사용자 검증 필요)
