### PR TITLE
fix(#2079): self-poll position staleness gate + idle gate cacheTtl/short-circuit

### DIFF
--- a/backend/alarm-worker/src/__tests__/cronIdleGate.test.ts
+++ b/backend/alarm-worker/src/__tests__/cronIdleGate.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PUSH_ACTIVITY_TTL_SEC, readPushActivityRecent, stampPushActivity } from '../cronIdleGate';
+import { CRON_READ_CACHE_TTL_SEC } from '../kvConsistency';
 import { InMemoryKV } from './inMemoryKv';
 
 describe('cronIdleGate (#2073 Issue A)', () => {
@@ -41,6 +42,13 @@ describe('cronIdleGate (#2073 Issue A)', () => {
         },
       } as unknown as KVNamespace;
       expect(await readPushActivityRecent(throwingKv)).toBe(true);
+    });
+
+    // #2079 (P3-1) — 레포 컨벤션(assertCronCacheTtl)대로 명시적 cacheTtl 없이 kv.get하던 회귀.
+    it('#2079 (P3-1) reads with explicit cacheTtl (kvConsistency 컨벤션)', async () => {
+      const spy = vi.spyOn(kv, 'get');
+      await readPushActivityRecent(kv as unknown as KVNamespace);
+      expect(spy).toHaveBeenCalledWith('cron:push-activity', { cacheTtl: CRON_READ_CACHE_TTL_SEC });
     });
   });
 

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -9688,6 +9688,37 @@ describe('runScheduled — #2073 진짜 idle skip 게이트 (Issue A)', () => {
   });
 });
 
+describe('runScheduled — #2079 (P3-2) readPushActivityRecent short-circuit', () => {
+  it('활성 trip 1개 tick — readPushActivityRecent 호출 0회 (idle 판정이 trips.length>0으로 이미 확정)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTrip());
+    const getSpy = vi.spyOn(kv, 'get');
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    const activityGetCalls = getSpy.mock.calls.filter((c) => c[0] === 'cron:push-activity');
+    expect(activityGetCalls.length).toBe(0);
+  });
+
+  it('idle tick(활성 trip 0) — readPushActivityRecent 호출 1회', async () => {
+    const kv = new InMemoryKV();
+    const getSpy = vi.spyOn(kv, 'get');
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: (async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    const activityGetCalls = getSpy.mock.calls.filter((c) => c[0] === 'cron:push-activity');
+    expect(activityGetCalls.length).toBe(1);
+  });
+});
+
 describe('runScheduled — #2073 jitter sample 10 tick당 1회 스로틀 (Issue D)', () => {
   it('활성 trip 있는 tick도 sample tick이 아니면 jitter sample write를 skip한다', async () => {
     const kv = new InMemoryKV();

--- a/backend/alarm-worker/src/__tests__/selfPollPosition.test.ts
+++ b/backend/alarm-worker/src/__tests__/selfPollPosition.test.ts
@@ -9,10 +9,12 @@ import {
   N_STATION_LOOKAHEAD,
   pollLinesAndStamp,
   pollStationsAndStamp,
+  readFreshSelfPollPosition,
   readSelfPollPosition,
   readSelfPollStationArrivals,
   selfPollKey,
   selfPollStationKey,
+  SELF_POLL_POSITION_MAX_AGE_SEC,
   SELF_POLL_TTL_SEC,
   writeSelfPollPosition,
   writeSelfPollStationArrivals,
@@ -154,6 +156,55 @@ describe('readSelfPollPosition / writeSelfPollPosition round-trip', () => {
     const entry = (kv as unknown as InMemoryKV).store.get(selfPollKey('7'));
     expect(entry?.expiresAt).toBeDefined();
     expect(entry!.expiresAt! - Date.now()).toBeGreaterThan(85 * 1000);
+  });
+});
+
+describe('readFreshSelfPollPosition (#2079 P2 — staleness 게이트)', () => {
+  it('meets floor of 60s', () => {
+    expect(SELF_POLL_POSITION_MAX_AGE_SEC).toBe(60);
+  });
+
+  it('returns null when no stamp', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    expect(await readFreshSelfPollPosition(kv, '7', NOW)).toBeNull();
+  });
+
+  it('fetchedAt 59s 전 — positions 반환 (TTL 90s 안쪽이고 staleness 게이트도 통과)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    const positions = [makePosition()];
+    await writeSelfPollPosition(kv, '7', positions, NOW);
+    const stamp = await readFreshSelfPollPosition(kv, '7', NOW + 59_000);
+    expect(stamp).not.toBeNull();
+    expect(stamp?.positions).toEqual(positions);
+  });
+
+  it('fetchedAt 61s 전 — undefined 취급 (KV TTL 90s 안쪽이라도 stale로 게이트)', async () => {
+    const kv = new InMemoryKV() as unknown as KVNamespace;
+    await writeSelfPollPosition(kv, '7', [makePosition()], NOW);
+    const stamp = await readFreshSelfPollPosition(kv, '7', NOW + 61_000);
+    expect(stamp).toBeNull();
+  });
+
+  it('pollLinesAndStamp의 내부 cache-hit 체크(raw readSelfPollPosition)는 60s 게이트 영향 없음 — write 감축 유지', async () => {
+    // #2079 P2 doc — readFreshSelfPollPosition의 staleness 게이트를 pollLinesAndStamp의 내부
+    // existing 체크에 적용하면 cron 60s tick과 60s 임계값이 겹쳐 #2073 회귀(매 tick 재fetch)가
+    // 재발한다. raw readSelfPollPosition은 게이트 없이 TTL(90s)만 본다.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(NOW);
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      const seoul = makeSeoulClient({ positions: [makePosition()] });
+      await pollLinesAndStamp(kv, seoul, new Set(['7']), NOW);
+      // 61s 후 — readFreshSelfPollPosition consumer 관점에선 stale이지만, raw reader는 여전히
+      // TTL(90s) 안쪽이라 cache-hit → 재fetch/재write 없음.
+      vi.setSystemTime(NOW + 61_000);
+      const putSpy = vi.spyOn(kv, 'put');
+      const stats = await pollLinesAndStamp(kv, seoul, new Set(['7']), NOW + 61_000);
+      expect(putSpy).not.toHaveBeenCalled();
+      expect(stats).toEqual({ fetched: 0, cacheHit: 1, error: 0 });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/backend/alarm-worker/src/cronIdleGate.ts
+++ b/backend/alarm-worker/src/cronIdleGate.ts
@@ -14,6 +14,8 @@
  * runRetryPushes 가 실제로 entry를 발견했을 때 재stamp해 backoff가 긴 retry도 커버한다.
  */
 
+import { assertCronCacheTtl, CRON_READ_CACHE_TTL_SEC } from './kvConsistency';
+
 const PUSH_ACTIVITY_KEY = 'cron:push-activity';
 
 /**
@@ -55,7 +57,10 @@ export async function stampPushActivity(
 export async function readPushActivityRecent(kv: KVNamespace | undefined): Promise<boolean> {
   if (!kv) return false;
   try {
-    const raw = await kv.get(PUSH_ACTIVITY_KEY);
+    // #2079 (P3-1) — 레포 컨벤션(assertCronCacheTtl)대로 cron KV read에 명시적 cacheTtl.
+    // marker TTL(120s) 대비 30s 안전 마진.
+    assertCronCacheTtl(CRON_READ_CACHE_TTL_SEC);
+    const raw = await kv.get(PUSH_ACTIVITY_KEY, { cacheTtl: CRON_READ_CACHE_TTL_SEC });
     return raw !== null;
   } catch {
     return true;

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -73,7 +73,7 @@ import {
   N_STATION_LOOKAHEAD,
   pollLinesAndStamp,
   pollStationsAndStamp,
-  readSelfPollPosition,
+  readFreshSelfPollPosition,
 } from './selfPollPosition';
 import { phaseAllowsImminentFiring, runStationPhaseStep } from './stationPhase';
 import { listTrips, putTrip } from './trips';
@@ -993,7 +993,9 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
   // #2073 (Issue A) — 진짜 idle 판정. 활성 trip이 하나도 없고, 직전 tick 근방 fire/retry 기록도
   // 없으면 pending/retry push가 존재할 수 없다(모든 fire 경로가 trip 기반이므로 trip 부재 tick엔
   // 새 entry가 생기지 않는다). 이 tick엔 index.ts가 runFallbackPushes/runRetryPushes를 skip한다.
-  const activityRecent = await readPushActivityRecent(env.TRIPS);
+  // #2079 (P3-2) — trips.length > 0이면 idle이 어차피 false로 확정되므로 결과가 폐기된다.
+  // short-circuit으로 불필요한 KV read를 건너뛴다.
+  const activityRecent = trips.length === 0 ? await readPushActivityRecent(env.TRIPS) : false;
   const idle = trips.length === 0 && !activityRecent;
   stats.pendingActivityPossible = !idle;
   if (trips.length > 0) {
@@ -2430,7 +2432,9 @@ async function attemptVanishSwap(
   if (previousMissCount + 1 < VANISH_RE_ATTACH_THRESHOLD) return null;
   // #1702 (B2-A) — Seoul 단방향/0건 arrivals fallback. attachTrainCodeForLeg 가 candidate 를
   // 찾지 못하면 line 의 realtimePosition snapshot 에서 segmentStations 기반 합성을 시도.
-  const selfPollPositions = await readSelfPollPosition(env.TRIPS, waypoint.line);
+  // #2079 (P2) — staleness 게이트 적용 reader. 90s TTL 안쪽이어도 fetchedAt이 60s 초과면
+  // stale로 간주(vanish-reattach 오lock 방지).
+  const selfPollPositions = await readFreshSelfPollPosition(env.TRIPS, waypoint.line, now);
   const swapped = await attachTrainCodeForLeg({
     trip,
     targetWaypoint: waypoint,

--- a/backend/alarm-worker/src/selfPollPosition.ts
+++ b/backend/alarm-worker/src/selfPollPosition.ts
@@ -65,6 +65,22 @@ const SELF_POLL_STATION_PREFIX = 'selfPoll:station:';
 export const SELF_POLL_TTL_SEC = 90;
 
 /**
+ * #2079 (P2, #2077 사후 리뷰 follow-up) — position consumer용 staleness 게이트(초).
+ *
+ * `SELF_POLL_TTL_SEC` 90s 상향(#2073) 이후 `pollLinesAndStamp`의 cache-hit 분기가 정상 동작하면
+ * KV entry가 최대 90s까지 재fetch 없이 살아남는다. 이 자체는 write 감축 의도대로지만, trainCode
+ * 재합성처럼 "현재 위치"를 근거로 판단하는 consumer(예: vanish-reattach `attachTrainCodeForLeg`)가
+ * 그 90s 전 snapshot을 staleness 게이트 없이 그대로 쓰면 이미 waypoint를 통과한 열차의 trainCode를
+ * 재합성해 잘못된 lock으로 이어질 수 있다(vanish-reattach 오lock).
+ *
+ * `readFreshSelfPollPosition`이 이 상수로 consumer 측에서만 게이트한다 — `pollLinesAndStamp`의
+ * 내부 cache-hit 체크(`readSelfPollPosition` 직접 사용)는 그대로 두어 TTL 90s의 write 감축 효과를
+ * 보존한다(게이트를 그 경로에도 적용하면 cron 60s 주기와 60s 임계값이 거의 겹쳐 매 tick 재fetch로
+ * 되돌아가 #2073 회귀가 재발한다).
+ */
+export const SELF_POLL_POSITION_MAX_AGE_SEC = 60;
+
+/**
  * Phase 5 (#1828) — trip waypoints 중 station-level polling 대상 최대 개수.
  *
  * N=5: 다음 역 + 1환승 + 2환승 + 종점 + 여분 1개. trip의 잔여 waypoints가 5개 미만이면
@@ -100,8 +116,12 @@ export function selfPollStationKey(stationName: string): string {
 /**
  * KV에서 line의 마지막 self-poll position 결과를 조회.
  *
- * `expirationTtl=30s` 안쪽이면 stamp가 살아 있고, 초과 시 KV가 자동 삭제 → null 반환.
- * caller(advanceTripPosition site들)가 trainCode cross-match 시도용.
+ * `expirationTtl=SELF_POLL_TTL_SEC`(90s) 안쪽이면 stamp가 살아 있고, 초과 시 KV가 자동 삭제 →
+ * null 반환. `pollLinesAndStamp`의 내부 cache-hit 체크가 이 raw 함수를 직접 사용한다 — staleness
+ * 게이트를 적용하지 않아 TTL 90s의 write 감축 효과를 그대로 보존한다.
+ *
+ * trainCode 재합성처럼 "현재 위치" 판단에 쓰는 consumer는 이 함수 대신
+ * `readFreshSelfPollPosition`(#2079 P2 staleness 게이트 적용)을 사용한다.
  *
  * @param kv TRIPS KV namespace
  * @param line `LineNumber` (canonicalLineName로 정규화된 값)
@@ -119,6 +139,34 @@ export async function readSelfPollPosition(
   } catch {
     return null;
   }
+}
+
+/**
+ * #2079 (P2) — position consumer(예: vanish-reattach `attachTrainCodeForLeg`)용 staleness
+ * 게이트가 적용된 `readSelfPollPosition` wrapper.
+ *
+ * `entry.fetchedAt`이 `now` 기준 `SELF_POLL_POSITION_MAX_AGE_SEC`(60s)를 초과하면 KV entry가
+ * TTL(90s) 안쪽에 살아 있어도 stale로 간주해 `null`을 반환한다. "현재 위치"를 근거로 trainCode를
+ * 재합성하는 모든 consumer는 이 함수를 사용해야 한다(단일 게이트 지점).
+ *
+ * `pollLinesAndStamp`의 내부 cache-hit 체크에는 적용하지 않는다 — write 감축 목적은 raw
+ * `readSelfPollPosition`으로 유지한다.
+ *
+ * @param kv TRIPS KV namespace
+ * @param line `LineNumber`
+ * @param now 판정 시점 epoch ms (caller의 tick `now`)
+ * @returns staleness 게이트를 통과한 stamp 또는 null(부재/malformed/stale)
+ */
+export async function readFreshSelfPollPosition(
+  kv: KVNamespace,
+  line: LineNumber,
+  now: number,
+): Promise<SelfPollEntry | null> {
+  const entry = await readSelfPollPosition(kv, line);
+  if (!entry) return null;
+  const ageSec = (now - entry.fetchedAt) / 1000;
+  if (ageSec > SELF_POLL_POSITION_MAX_AGE_SEC) return null;
+  return entry;
 }
 
 /**


### PR DESCRIPTION
Closes #2079

## 배경

PR #2077(이슈 #2073, 머지됨) 사후 리뷰 findings. 모두 `backend/alarm-worker/`.

## 변경 사항

### P2: self-poll position staleness 게이트 (vanish-reattach 오lock 방지)
- `selfPollPosition.ts`: `readFreshSelfPollPosition(kv, line, now)` 신규 export. `SELF_POLL_POSITION_MAX_AGE_SEC = 60` 초과 시 KV TTL(90s) 안쪽이라도 stale로 간주해 `null` 반환.
- `pollLinesAndStamp`의 내부 cache-hit 체크는 raw `readSelfPollPosition`을 그대로 사용 — staleness 게이트를 그 경로에 적용하면 cron 60s tick과 60s 임계값이 겹쳐 #2073 write 감축 회귀가 재발하므로 의도적으로 분리(consumer 측에서만 게이트).
- `scheduled.ts`의 `attemptVanishSwap`(vanish-reattach)가 `readFreshSelfPollPosition`을 사용하도록 교체.
- `readSelfPollPosition` doc 주석의 "expirationTtl=30s" 서술을 실제 값(90s) 기준으로 갱신.

### P3-1: `cronIdleGate.ts` cacheTtl 명시
- `readPushActivityRecent`가 `assertCronCacheTtl` + `cacheTtl: CRON_READ_CACHE_TTL_SEC(30)`을 명시 (kvConsistency 컨벤션 준수, marker TTL 120s 대비 안전 마진).

### P3-2: `readPushActivityRecent` short-circuit
- `scheduled.ts`: `trips.length === 0 ? await readPushActivityRecent(...) : false` — trips가 있으면 idle이 어차피 false로 확정되므로 불필요한 KV read를 skip.

## 하지 말 것 (준수)
- TTL 값(90s) 원복 없음
- fire/advance/dedup 로직 변경 없음 — staleness 게이트만 추가
- `fireArvlCdStationPush`/`apns.ts` 미변경 (#2078 영역 침범 없음)

## 테스트
- staleness: fetchedAt 59s(반환) / 61s(undefined) 경계 테스트
- `pollLinesAndStamp` write 감축 유지 회귀 가드 (raw reader가 60s 게이트 영향 안 받음)
- cronIdleGate: `readPushActivityRecent`가 `cacheTtl: 30`으로 호출됨을 assert
- short-circuit: 활성 trip 1개 tick에서 `readPushActivityRecent`(`cron:push-activity` get) 0회, idle tick에서 1회
- 전체 backend 스위트 2663 tests green (기존 vanish-reattach 테스트 포함)

## Wire-completion 5단
1. **Orphan 없음**: 신규 export(`readFreshSelfPollPosition`, `SELF_POLL_POSITION_MAX_AGE_SEC`) 모두 `scheduled.ts`/테스트에서 사용됨. `tsconfig.json`이 `backend/`를 exclude하므로 root `lint:orphan`(ts-prune) 스캔 범위 밖 — `tsc --noEmit`으로 backend 자체 타입 검증만 적용, clean.
2. **V/X dashboard**: wrangler tail — vanish-reattach 시 `readFreshSelfPollPosition`이 stale로 판정해 `null` 반환하면 `attachTrainCodeForLeg`의 `selfPollPositions: undefined` 로그 경로로 자연 관측 가능. cacheTtl/short-circuit은 KV quota audit(2026-07-29 방식)으로 write/read 횟수 재측정.
3. **의존 PR**: N/A (#2077 머지 후속)
4. **측정 plan**: 실기기 trip에서 vanish-reattach 발생 시 trainCode 정합 확인 (기존 DebugModal). backend quota는 1주 wrangler tail/Cloudflare Dashboard 관측.
5. **Device verify**: N/A — backend only, 배포 후 tail 관측

## Test plan
- [x] `npx vitest run` (backend/alarm-worker) — 69 files, 2663 tests pass
- [x] `npx tsc --noEmit` (backend/alarm-worker) — clean
- [ ] 배포 후 wrangler tail로 stale-drop 로그 확인 (사용자 몫)