### PR TITLE
fix(#2063): 매역 알림 i18n 4언어 렌더 + 코드리뷰 P1 테스트 보강

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -748,6 +748,182 @@ describe('sendAlertPush (#572 P2c)', () => {
     const body = JSON.parse(call[1].body as string);
     expect('category' in body.aps).toBe(false);
   });
+
+  // #2063 (ADR-023 개정) — 매역 알림(station-notif) 전용 옵션 wire 검증.
+  describe('#2063 station-notif 옵션 (sound/interruptionLevel/collapseId/expiration/data)', () => {
+    it('sound 미지정 시 기존 default 유지 (backward compat)', async () => {
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      await sendAlertPush({
+        deviceToken: 't',
+        title: 'T',
+        body: 'B',
+        pushId: 'p',
+        config: makeConfig(),
+        host: TEST_HOST_2,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+      const body = JSON.parse(call[1].body as string);
+      expect(body.aps.sound).toBe('default');
+    });
+
+    it('sound=null 지정 시 aps.sound 필드 자체가 생략된다 (매역 알림 무소리)', async () => {
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      await sendAlertPush({
+        deviceToken: 't',
+        title: 'T',
+        body: 'B',
+        pushId: 'p',
+        sound: null,
+        config: makeConfig(),
+        host: TEST_HOST_2,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+      const body = JSON.parse(call[1].body as string);
+      expect('sound' in body.aps).toBe(false);
+    });
+
+    it('interruptionLevel 지정 시 aps.interruption-level로 wire', async () => {
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      await sendAlertPush({
+        deviceToken: 't',
+        title: 'T',
+        body: 'B',
+        pushId: 'p',
+        interruptionLevel: 'active',
+        config: makeConfig(),
+        host: TEST_HOST_2,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+      const body = JSON.parse(call[1].body as string);
+      expect(body.aps['interruption-level']).toBe('active');
+    });
+
+    it('interruptionLevel 미지정 시 aps.interruption-level omit', async () => {
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      await sendAlertPush({
+        deviceToken: 't',
+        title: 'T',
+        body: 'B',
+        pushId: 'p',
+        config: makeConfig(),
+        host: TEST_HOST_2,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+      const body = JSON.parse(call[1].body as string);
+      expect('interruption-level' in body.aps).toBe(false);
+    });
+
+    it('collapseId 지정 시 apns-collapse-id 헤더로 wire (station-<tripToken> 형태)', async () => {
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      await sendAlertPush({
+        deviceToken: 't',
+        title: 'T',
+        body: 'B',
+        pushId: 'p',
+        collapseId: 'station-trip-abc',
+        config: makeConfig(),
+        host: TEST_HOST_2,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+      const headers = call[1].headers as Record<string, string>;
+      expect(headers['apns-collapse-id']).toBe('station-trip-abc');
+    });
+
+    it('collapseId 미지정 시 apns-collapse-id 헤더 omit', async () => {
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      await sendAlertPush({
+        deviceToken: 't',
+        title: 'T',
+        body: 'B',
+        pushId: 'p',
+        config: makeConfig(),
+        host: TEST_HOST_2,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+      const headers = call[1].headers as Record<string, string>;
+      expect('apns-collapse-id' in headers).toBe(false);
+    });
+
+    it('expirationEpochSec 지정 시 apns-expiration 헤더로 wire (epoch seconds, now+90s)', async () => {
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      const now = 1_700_000_000_000;
+      const expirationEpochSec = Math.floor((now + 90_000) / 1000);
+      await sendAlertPush({
+        deviceToken: 't',
+        title: 'T',
+        body: 'B',
+        pushId: 'p',
+        expirationEpochSec,
+        config: makeConfig(),
+        host: TEST_HOST_2,
+        now,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+      const headers = call[1].headers as Record<string, string>;
+      expect(headers['apns-expiration']).toBe(String(expirationEpochSec));
+    });
+
+    it('expirationEpochSec 미지정 시 apns-expiration 헤더 omit', async () => {
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      await sendAlertPush({
+        deviceToken: 't',
+        title: 'T',
+        body: 'B',
+        pushId: 'p',
+        config: makeConfig(),
+        host: TEST_HOST_2,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+      const headers = call[1].headers as Record<string, string>;
+      expect('apns-expiration' in headers).toBe(false);
+    });
+
+    it('data 지정 시 pushId와 함께 병합돼 wire (SSoT/게이트 필드 forward)', async () => {
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      await sendAlertPush({
+        deviceToken: 't',
+        title: 'T',
+        body: 'B',
+        pushId: 'p',
+        data: { nextWaypoint: '중곡', kind: 'intermediate', phase: 'imminent' },
+        config: makeConfig(),
+        host: TEST_HOST_2,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+      const body = JSON.parse(call[1].body as string);
+      expect(body.data).toEqual({
+        pushId: 'p',
+        nextWaypoint: '중곡',
+        kind: 'intermediate',
+        phase: 'imminent',
+      });
+    });
+
+    it('data 미지정 시 data는 { pushId }만 (backward compat)', async () => {
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      await sendAlertPush({
+        deviceToken: 't',
+        title: 'T',
+        body: 'B',
+        pushId: 'p',
+        config: makeConfig(),
+        host: TEST_HOST_2,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+      const body = JSON.parse(call[1].body as string);
+      expect(body.data).toEqual({ pushId: 'p' });
+    });
+  });
 });
 
 describe('sendReschedulePush (#585)', () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1874,6 +1874,46 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
         expect(stored.boardingLock).toBeUndefined();
       });
 
+      // #2063 (ADR-023 개정) — vanish 경로(fireVanishFallbackStationPush) sleep mute 분기.
+      describe('#2063 (ADR-023 개정) sleepModeEnabled 매역 알림 mute (vanish-fallback)', () => {
+        it('sleepModeEnabled=true → vanish-fallback 매역 push skip', async () => {
+          const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+          const { stats } = await runFallbackMotionScenario({
+            motion: 'automotive',
+            hopElapsed: true,
+            pushId: 'p2063-vf-sleep',
+            tripOverrides: { sleepModeEnabled: true },
+            apnsFetch,
+          });
+          expect(stats.vanishFallbackFired).toBe(0);
+          expect(stats.pushed).toBe(0);
+          expect(apnsFetch.mock.calls.length).toBe(0);
+        });
+
+        it('sleepModeEnabled=false → vanish-fallback 매역 push 정상 발사', async () => {
+          const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+          const { stats } = await runFallbackMotionScenario({
+            motion: 'automotive',
+            hopElapsed: true,
+            pushId: 'p2063-vf-nosleep',
+            tripOverrides: { sleepModeEnabled: false },
+            apnsFetch,
+          });
+          expect(stats.vanishFallbackFired).toBe(1);
+        });
+
+        it('sleepModeEnabled 미지정(undefined) → vanish-fallback 매역 push 정상 발사 (기존 동작 보존)', async () => {
+          const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+          const { stats } = await runFallbackMotionScenario({
+            motion: 'automotive',
+            hopElapsed: true,
+            pushId: 'p2063-vf-undef',
+            apnsFetch,
+          });
+          expect(stats.vanishFallbackFired).toBe(1);
+        });
+      });
+
       // vanish-release/vanish-fallback 양 origin의 push payload 검증용 헬퍼.
       // SonarCloud duplication 차단: 시나리오 실행 + 매칭 call body 추출을 한 곳에 모음.
       async function capturePushBody(setup: {
@@ -7149,6 +7189,72 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
     expect(getStationPassedCalls(apnsFetch)).toHaveLength(2);
   });
 
+  // #2063 (ADR-023 개정) — 매역 알림(station-notif) sleep mute 분기.
+  describe('#2063 (ADR-023 개정) sleepModeEnabled 매역 알림 mute', () => {
+    it('sleepModeEnabled=true → 매역 push skip (push 미발사, dedup KV 미stamp)', async () => {
+      const { stats, kv, apnsFetch } = await runArvlScheduled({
+        seoul: makeArrivalSeoul('중곡', 0, 1),
+        trip: makeLockTrip({ sleepModeEnabled: true }),
+        pushId: 'p-arvl-sleep',
+      });
+      expect(stats.arvlCdFireSuccess).toBe(0);
+      expect(stats.pushed).toBe(0);
+      expect(getStationPassedCalls(apnsFetch)).toHaveLength(0);
+      expect(await kv.get(arvlCdFireKey('arvl-tok', '7246', '중곡', 1))).toBeNull();
+    });
+
+    it('sleepModeEnabled=false → 매역 push 정상 발사', async () => {
+      const { stats, apnsFetch } = await runArvlScheduled({
+        seoul: makeArrivalSeoul('중곡', 0, 1),
+        trip: makeLockTrip({ sleepModeEnabled: false }),
+        pushId: 'p-arvl-nosleep',
+      });
+      expect(stats.arvlCdFireSuccess).toBe(1);
+      expect(getStationPassedCalls(apnsFetch)).toHaveLength(1);
+    });
+
+    it('sleepModeEnabled 미지정(undefined) → 매역 push 정상 발사 (기존 동작 보존)', async () => {
+      const { stats, apnsFetch } = await runArvlScheduled({
+        seoul: makeArrivalSeoul('중곡', 0, 1),
+        trip: makeLockTrip(),
+        pushId: 'p-arvl-undef-sleep',
+      });
+      expect(stats.arvlCdFireSuccess).toBe(1);
+      expect(getStationPassedCalls(apnsFetch)).toHaveLength(1);
+    });
+  });
+
+  // #2063 (ADR-023 개정) P1 — i18n 4언어 매역 알림 문구 (locale별).
+  describe('#2063 매역 알림 locale별 title/body 렌더', () => {
+    it.each<['ko' | 'en' | 'ja' | 'zh', string, string]>([
+      ['ko', '역 통과', '중곡역을 지나고 있어요'],
+      ['en', 'Passing station', 'Passing through 중곡'],
+      ['ja', '駅通過', '중곡駅を通過しています'],
+      ['zh', '经过站点', '正在经过중곡站'],
+    ])('locale=%s → intermediate title/body 4언어 렌더', async (locale, title, body) => {
+      const { apnsFetch } = await runArvlScheduled({
+        seoul: makeArrivalSeoul('중곡', 0, 1),
+        trip: makeLockTrip({ locale }),
+        pushId: `p-arvl-locale-${locale}`,
+      });
+      const call = getStationPassedCalls(apnsFetch)[0];
+      const parsedBody = JSON.parse(call[1].body as string) as { aps: { alert: { title: string; body: string } } };
+      expect(parsedBody.aps.alert.title).toBe(title);
+      expect(parsedBody.aps.alert.body).toBe(body);
+    });
+
+    it('locale 미지정 → ko fallback', async () => {
+      const { apnsFetch } = await runArvlScheduled({
+        seoul: makeArrivalSeoul('중곡', 0, 1),
+        trip: makeLockTrip(),
+        pushId: 'p-arvl-locale-fallback',
+      });
+      const call = getStationPassedCalls(apnsFetch)[0];
+      const parsedBody = JSON.parse(call[1].body as string) as { aps: { alert: { title: string; body: string } } };
+      expect(parsedBody.aps.alert.title).toBe('역 통과');
+    });
+  });
+
   it('arvlCd=1이지만 lock 만료된 trip은 lockMissing 게이트로 차단 (fire 경로 미진입)', async () => {
     const { stats, apnsFetch } = await runArvlScheduled({
       seoul: makeArrivalSeoul('중곡', 0, 1),
@@ -7574,6 +7680,7 @@ describe('runScheduled — #1402 인프라 안전망 (pendingPushes wire-up + pa
   it('vanish-fallback advance(hop-elapsed) 페이로드에 origin=vanish-fallback stamp', async () => {
     const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
     const kv = new InMemoryKV();
+    const pending = new InMemoryKV();
     await putTrip(
       kv as unknown as KVNamespace,
       makeLockTripFixture('lock-tok', {
@@ -7582,7 +7689,7 @@ describe('runScheduled — #1402 인프라 안전망 (pendingPushes wire-up + pa
       }),
     );
     // arrivals/positions 모두 empty → vanish, hopElapsed=true → fallback advance fire
-    await runScheduled(makeEnv(kv), {
+    await runScheduled(makeEnv(kv, pending), {
       seoul: new SeoulArrivalClient({
         apiKey: 'K',
         host: 'h',
@@ -7598,6 +7705,8 @@ describe('runScheduled — #1402 인프라 안전망 (pendingPushes wire-up + pa
     });
     const body = findApnsCallByPushId(apnsFetch, 'p1402-vf');
     expect((body.data as { origin: string }).origin).toBe('vanish-fallback');
+    // #2063 (ADR-023 개정) — visible alert 직접 발사이므로 PENDING_PUSHES 등록 없음.
+    expect(await pending.get('pending:p1402-vf')).toBeNull();
   });
 });
 

--- a/backend/alarm-worker/src/i18n.ts
+++ b/backend/alarm-worker/src/i18n.ts
@@ -45,6 +45,14 @@ export interface HopEndPromptArgs {
   nextStation: string | null;
 }
 
+/**
+ * #2063 (ADR-023 개정) — 매역 알림(station-notif) waypoint kind. `Waypoint.kind`와 1:1.
+ * arvlCd 기반 매역 fire는 항상 phase='imminent'라 phase 분기는 두지 않는다
+ * (device `route.intermediatePassedTitle` / `notifications.arrivalImminentTitle` /
+ * `notifications.transferImminentTitle` 과 1:1 매핑, `alertContent.ts` byte-identical 문구 재사용).
+ */
+export type StationNotifKind = 'intermediate' | 'transfer' | 'destination';
+
 interface I18nStrings {
   boardingPromptTitle: string;
   boardingPromptBody: (args: BoardingPromptArgs) => string;
@@ -52,6 +60,10 @@ interface I18nStrings {
   hopEndPromptTitle: (args: { transferStation: string }) => string;
   /** #2034 — hop-end (환승역 하차) 알림 body. */
   hopEndPromptBody: (args: HopEndPromptArgs) => string;
+  /** #2063 — 매역 알림(station-notif) title. kind별 분기. */
+  stationNotifTitle: (kind: StationNotifKind) => string;
+  /** #2063 — 매역 알림(station-notif) body. kind별 분기 + station 삽입. */
+  stationNotifBody: (kind: StationNotifKind, stationName: string) => string;
 }
 
 /**
@@ -76,6 +88,19 @@ const I18N: Record<SupportedLocale, I18nStrings> = {
       const next = nextStation ? `${nextLine}호선 ${nextStation}` : `${nextLine}호선`;
       return `${from} 다음은 ${next} 방면입니다.`;
     },
+    // #2063 — device ko.json route.intermediatePassedTitle / notifications.arrivalImminentTitle /
+    // notifications.transferImminentTitle 과 byte-identical.
+    stationNotifTitle: (kind) => {
+      if (kind === 'intermediate') return '역 통과';
+      if (kind === 'transfer') return '환승 임박';
+      return '도착 임박';
+    },
+    // device ko.json route.intermediatePassedBody / alarms.imminentArrivalBody / alarms.imminentTransferBody.
+    stationNotifBody: (kind, stationName) => {
+      if (kind === 'intermediate') return `${stationName}역을 지나고 있어요`;
+      if (kind === 'transfer') return `곧 ${stationName}에 도착합니다. 환승 준비하세요!`;
+      return `곧 ${stationName}에 도착합니다. 하차 준비하세요!`;
+    },
   },
   en: {
     boardingPromptTitle: 'Are you on board?',
@@ -90,6 +115,18 @@ const I18N: Record<SupportedLocale, I18nStrings> = {
       if (!nextLine) return from;
       const next = nextStation ? `line ${nextLine} toward ${nextStation}` : `line ${nextLine}`;
       return `${from} Next: ${next}.`;
+    },
+    // #2063 — device en.json route.intermediatePassedTitle / notifications.arrivalImminentTitle /
+    // notifications.transferImminentTitle 과 byte-identical.
+    stationNotifTitle: (kind) => {
+      if (kind === 'intermediate') return 'Passing station';
+      if (kind === 'transfer') return 'Transfer imminent';
+      return 'Arrival imminent';
+    },
+    stationNotifBody: (kind, stationName) => {
+      if (kind === 'intermediate') return `Passing through ${stationName}`;
+      if (kind === 'transfer') return `Arriving at ${stationName} — transfer soon!`;
+      return `Arriving at ${stationName} — exit soon!`;
     },
   },
   ja: {
@@ -106,6 +143,18 @@ const I18N: Record<SupportedLocale, I18nStrings> = {
       const next = nextStation ? `${nextLine}号線 ${nextStation}方面` : `${nextLine}号線`;
       return `${from} 次は${next}です。`;
     },
+    // #2063 — device ja.json route.intermediatePassedTitle / notifications.arrivalImminentTitle /
+    // notifications.transferImminentTitle 과 byte-identical.
+    stationNotifTitle: (kind) => {
+      if (kind === 'intermediate') return '駅通過';
+      if (kind === 'transfer') return 'まもなく乗換';
+      return 'まもなく到着';
+    },
+    stationNotifBody: (kind, stationName) => {
+      if (kind === 'intermediate') return `${stationName}駅を通過しています`;
+      if (kind === 'transfer') return `まもなく${stationName}に到着します。乗換の準備をしてください!`;
+      return `まもなく${stationName}に到着します。下車の準備をしてください!`;
+    },
   },
   zh: {
     boardingPromptTitle: '您已乘车了吗?',
@@ -120,6 +169,18 @@ const I18N: Record<SupportedLocale, I18nStrings> = {
       if (!nextLine) return from;
       const next = nextStation ? `${nextLine}号线 ${nextStation}方向` : `${nextLine}号线`;
       return `${from} 下一段: ${next}。`;
+    },
+    // #2063 — device zh.json route.intermediatePassedTitle / notifications.arrivalImminentTitle /
+    // notifications.transferImminentTitle 과 byte-identical.
+    stationNotifTitle: (kind) => {
+      if (kind === 'intermediate') return '经过站点';
+      if (kind === 'transfer') return '即将换乘';
+      return '即将到达';
+    },
+    stationNotifBody: (kind, stationName) => {
+      if (kind === 'intermediate') return `正在经过${stationName}站`;
+      if (kind === 'transfer') return `即将到达${stationName}。请准备换乘!`;
+      return `即将到达${stationName}。请准备下车!`;
     },
   },
 };

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -16,7 +16,6 @@ import {
   type PushOrigin,
   type SilentPushPayload,
 } from './apns';
-import { buildAlertContent } from './alertContent';
 import { flipApnsEnv, pickApnsHost, sendWithEnvHeal } from './apnsHost';
 import type { ArchFlagValue } from './archFlag';
 import { AUTO_PROMPT_DEDUP_WINDOW_MS } from './autoLock';
@@ -1812,16 +1811,24 @@ export const STATION_NOTIF_EXPIRATION_MS = 90 * 1000;
 
 /**
  * #2063 (ADR-023 개정) — 매역 알림(station-notif) 전용 title/body 빌더.
- * 디바이스가 기존 silent push 수신 시 렌더하던 것과 동일한 문구 체계
- * (`alertContent.buildAlertContent`, ko.json byte-identical)를 재사용한다.
- * arvlCd 기반 매역 fire는 항상 phase='imminent' — intermediate는 phase 자체가 없다
- * (discriminated union, `buildAlertContent` 참고).
+ *
+ * P1 수정(코드리뷰) — 최초 구현은 `alertContent.buildAlertContent`(한국어 고정, alert fallback
+ * 채널용)를 재사용해 en/ja/zh 사용자에게도 한국어 배너가 발사되는 i18n 회귀가 있었다. #1895
+ * boarding-prompt(`buildBoardingPromptMessage`)와 동일 패턴으로 `t(locale)` 4언어 lookup으로
+ * 전환 — locale 미지정/비지원 시 ko fallback(`t()`의 `DEFAULT_LOCALE` 처리에 위임).
+ *
+ * arvlCd 기반 매역 fire는 항상 phase='imminent' — `i18n.ts`의 `stationNotifTitle`/`stationNotifBody`도
+ * 그에 맞춰 kind 단일 분기만 제공한다(early phase 없음).
  */
-function buildStationNotifContent(waypoint: Waypoint): { title: string; body: string } {
-  if (waypoint.kind === 'intermediate') {
-    return buildAlertContent({ kind: 'intermediate', stationName: waypoint.stationName });
-  }
-  return buildAlertContent({ kind: waypoint.kind, phase: 'imminent', stationName: waypoint.stationName });
+function buildStationNotifContent(
+  waypoint: Waypoint,
+  locale: SupportedLocale | undefined,
+): { title: string; body: string } {
+  const strings = t(locale);
+  return {
+    title: strings.stationNotifTitle(waypoint.kind),
+    body: strings.stationNotifBody(waypoint.kind, waypoint.stationName),
+  };
 }
 
 // #2063 (ADR-023 개정) — 매역 알림(station-notif) 전용 sleep mute. sleep-transfer(B4)·
@@ -1979,7 +1986,7 @@ export async function fireArvlCdStationPush(
   // apns-collapse-id로 같은 trip의 매역 알림을 알림센터에서 최신으로 교체(스택 방지) + apns-expiration
   // 90s로 지하 데이터 순단 후 stale 알림 늦은 표시를 방지한다. data는 기존 silent payload를 그대로
   // forward해 device SSoT/게이트 소비 코드(cascade picker 등)가 영향받지 않게 한다.
-  const stationNotifContent = buildStationNotifContent(waypoint);
+  const stationNotifContent = buildStationNotifContent(waypoint, trip.locale);
   const heal = await sendWithEnvHeal(
     (host) =>
       sendAlertPush({
@@ -2369,7 +2376,7 @@ export async function fireVanishFallbackStationPush(
     archFlag: deps.archFlag,
   });
   // #2063 (ADR-023 개정) — silent → visible alert push 직접 발사 (fireArvlCdStationPush와 동일 정책).
-  const vanishStationNotifContent = buildStationNotifContent(waypoint);
+  const vanishStationNotifContent = buildStationNotifContent(waypoint, trip.locale);
   const heal = await sendWithEnvHeal(
     (host) =>
       sendAlertPush({


### PR DESCRIPTION
## Summary

Follow-up to #2078 (closes review action items for #2063). **#2078은 이 코드리뷰 수정이 준비되기 전에 이미 머지되어** 같은 브랜치(`feat/#2063-station-notif-visible`)에 수정 커밋을 이어붙일 수 없었다 — PR이 이미 MERGED/closed 상태라 신규 커밋을 반영할 방법이 없어, `origin/dev`(머지 완료 상태) 기준으로 새 브랜치를 따 동일 fix 커밋을 cherry-pick했다. `feat/#2063-station-notif-visible`는 정리하지 않고 그대로 둔다(이미 머지됨, 추가 조치 불요).

### 코드리뷰 P1-1 (i18n 회귀) 수정

`buildStationNotifContent`(scheduled.ts)가 `alertContent.buildAlertContent`(한국어 고정, alert fallback 채널 전용 문구)를 그대로 재사용해 en/ja/zh locale 사용자도 한국어 매역 알림 배너를 받는 회귀가 있었다.

- `backend/alarm-worker/src/i18n.ts`: `I18nStrings`에 `stationNotifTitle(kind)` / `stationNotifBody(kind, stationName)` 4언어(ko/en/ja/zh) 테이블 추가. device `src/shared/i18n/locales/{ko,en,ja,zh}.json`의 `route.intermediatePassedTitle/Body`, `notifications.arrivalImminentTitle` + `alarms.imminentArrivalBody`, `notifications.transferImminentTitle` + `alarms.imminentTransferBody`와 byte-identical하게 이식(arvlCd 기반 매역 fire는 항상 phase='imminent'라 phase 분기 불필요).
- `backend/alarm-worker/src/scheduled.ts`: `buildStationNotifContent(waypoint, locale)`로 시그니처 변경, `t(trip.locale)` lookup으로 전환(#1895 `buildBoardingPromptMessage`와 동일 패턴, locale 미지정/비지원 시 ko fallback). 미사용 `alertContent.buildAlertContent` import 제거.

### 코드리뷰 P1-2 (누락 테스트) 추가

- `backend/alarm-worker/src/__tests__/scheduled.test.ts`:
  - `sleepModeEnabled` true→skip / false·undefined→발사 — **arvlCd 경로**(`#2063 (ADR-023 개정) sleepModeEnabled 매역 알림 mute` describe, 3 tests) + **vanish-fallback 경로**(`#2063 (ADR-023 개정) sleepModeEnabled 매역 알림 mute (vanish-fallback)` describe, 3 tests)
  - locale별 4언어 문구 렌더 검증(`#2063 매역 알림 locale별 title/body 렌더` describe — ko/en/ja/zh 4-case `it.each` + locale 미지정 ko fallback)
  - vanish-fallback(non-release) 경로 `PENDING_PUSHES` 미등록 assert 추가(release 경로는 #2078에서 이미 커버)
- `backend/alarm-worker/src/__tests__/apns.test.ts`: `sendAlertPush` 신규 옵션 단위테스트 11건 추가 — `sound`(default 유지 / `null`→omit), `interruptionLevel`(wire/omit), `collapseId`→`apns-collapse-id` 헤더(wire/omit), `expirationEpochSec`→`apns-expiration` 헤더(epoch seconds, wire/omit), `data`(pushId와 병합/미지정 시 `{pushId}`만)

### P2-2 (관측성, 코드 변경 없음)

`fireArvlCdStationPush`/`fireVanishFallbackStationPush`에서 `putPending` 호출 제거(visible push 직접 발사라 60s ACK fallback 불필요, #2078)로 인해 **`silentPushDeliveryRatio` 계열 관측 지표는 이제 lockless intermediate 경로만 반영**한다(arvlcd/vanish 매역 알림은 더 이상 이 지표에 잡히지 않음). 매역 알림 도달 관측은 대신 wrangler tail의 `arvlcd-fire: station-passed push` / `vanish-fallback-fire: station-passed push` / `vanish-release-fire: station-passed push` 발사 로그 + `station-notif skip: sleep` skip 로그로 대체한다.

## Wire-completion 5단

1. **Orphan 없음** — 신규 export(`i18n.ts`의 `stationNotifTitle`/`stationNotifBody`는 `I18nStrings` 인터페이스 필드, 별도 export 아님) 없음. `npm run lint:orphan` pass(frontend 무변경이므로 무영향).
2. **V/X dashboard** — locale별 배너 문구는 wrangler tail의 `arvlcd-fire`/`vanish-*-fire` 로그 body(`aps.alert.title`/`body`)로 관측 가능. sleep skip은 `station-notif skip: sleep` 로그.
3. **의존 PR** — #2078 (머지 완료). ADR-023 개정 문서(#2065)는 독립 진행 중.
4. **측정 plan** — wrangler tail에서 non-ko locale trip의 `arvlcd-fire` 로그 body 문구가 해당 언어로 렌더되는지 확인.
5. **Device verify** — 필요. en/ja/zh 사용자 실기기 trip에서 매역 알림 배너가 설정 언어로 표시되는지 확인 (기존 ko 사용자는 #2078에서 이미 검증 대상).

## Test plan

- [x] `backend/alarm-worker`: `npx tsc --noEmit` pass
- [x] `backend/alarm-worker`: `npx vitest run` — 69 files, 2676 tests pass
- [x] root `npm run type-check` pass
- [x] root `npm run lint:orphan` pass
- [x] root `npm test` — 429 suites, 9254 tests pass (frontend 무변경 확인, 100% coverage)