### PR TITLE
refactor(#2064): 매역 알림 device 발사 제거 (D4·D10) + FG 원격 표시 정책

### DIFF
--- a/src/features/alarm/__tests__/evidence_20260703_replay.test.ts
+++ b/src/features/alarm/__tests__/evidence_20260703_replay.test.ts
@@ -319,9 +319,16 @@ describe('Issue B (#2021) — device lockless-opt-out gate 동작 검증', () =>
     mockRunTripBoundCleanups.mockResolvedValue(undefined);
   });
 
-  it('target payload (boardingLine=undefined) — lockless-opt-out skip 정상 동작', async () => {
-    // Wave 1 완결 후 backend 가 발사할 shape. lock=null + boardingLine=undefined →
-    // silentPushTask 의 lockless-opt-out gate 로 즉시 skip → scheduleNotificationAsync 호출 X.
+  // #2064 (Phase 1-device) — 매역 알림 backend visible push 단일 채널 전환으로 silentPushTask의
+  // fireWithGate(lockless-opt-out 포함 전체 gate 체계)가 제거됐다. transfer/destination/intermediate
+  // kind는 이제 lock 상태·boardingLine 유무와 무관하게 항상 'legacy-station-kind-ignored' no-op으로
+  // 처리된다 — 아래 세 테스트는 이 evidence replay가 여전히 "device 로컬 알림 0건"을 보장하는지
+  // 갱신된 reason으로 재확인한다. fixture 데이터(payload shape) 자체는 evidence 원본 그대로 보존.
+
+  it('target payload (boardingLine=undefined) — device는 로컬 알림 미발사(legacy-station-kind-ignored no-op)', async () => {
+    // Wave 1 완결 후 backend 가 발사할 shape. lock=null + boardingLine=undefined.
+    // #2064 이전: lockless-opt-out gate로 skip. #2064 이후: kind 유무만으로 무조건 no-op skip.
+    // 결과(알림 미발사)는 동일하게 유지 — reason만 새 스펙에 맞게 갱신.
     await handleSilentPush(
       makeBgTaskInput(TARGET_PUSH_STATION_PASSED_SEONGSU_LOCKLESS_OPT_OUT),
     );
@@ -331,23 +338,25 @@ describe('Issue B (#2021) — device lockless-opt-out gate 동작 검증', () =>
     expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
       expect.objectContaining({
         stationName: '성수',
-        reason: 'lockless-opt-out',
+        reason: 'legacy-station-kind-ignored',
       }),
     );
     // ack 는 skip reason 과 함께 (backend pending push cleanup 용).
     expect(mockSendPushAck).toHaveBeenCalledWith(
       expect.objectContaining({
         outcome: 'skipped',
-        reason: 'lockless-opt-out',
+        reason: 'legacy-station-kind-ignored',
       }),
     );
   });
 
-  it('destination-early payload — lock=null 상태에서 lockless-opt-out skip (정책 유지)', async () => {
+  it('destination-early payload — lock=null + boardingLine 실린 상태에서도 device는 로컬 알림 미발사 (#2064로 근본 차단)', async () => {
     // REGRESSION_PUSH_DESTINATION_EARLY_SEONGSU: boardingLine='2' 실린 상태.
-    // 하지만 device 는 destination kind 도 lockless-opt-out gate 를 통과해야 함.
-    // 오늘 dump 는 lockless-no-user-intent gate 로 fg-evaluated 에서 suppress → 스팸 반복.
-    // 이 test 는 silent push handler 단일 채널에서 lock=null + destination push 처리 시나리오 검증.
+    // #2064 이전(오늘 evidence): device가 payload.boardingLine을 authoritative로 받아 line guard를
+    // 통과시켜 fire — Issue B의 device-side 증상이었다(재발 재현 대상).
+    // #2064 이후: kind가 destination이면 lock/boardingLine 상태와 무관하게 fireWithGate 자체가
+    // 없으므로 항상 no-op. Issue B의 backend 근본 원인(boardingLine을 실어 보내는 것) 수정 여부와
+    // 무관하게, device 레이어의 증상(로컬 오발사)은 본 PR로 완전히 닫힌다.
     mockFindStationByNameAndLine.mockReturnValue({
       name: '성수',
       line: '2',
@@ -361,27 +370,20 @@ describe('Issue B (#2021) — device lockless-opt-out gate 동작 검증', () =>
 
     await handleSilentPush(makeBgTaskInput(REGRESSION_PUSH_DESTINATION_EARLY_SEONGSU));
 
-    // received 는 log 되지만 fire 되면 안 됨 (실 alarm log 에서는 dismiss-silence 로 suppress).
-    // 이 assertion 은 destination-early 스팸을 device layer 에서 잡는지 확인.
+    // received 는 여전히 log 됨(상태 sync 유지) — 로컬 알림만 발사되지 않는다.
     expect(mockLogSilentPushReceived).toHaveBeenCalled();
-    // lock=null + boardingLine 실린 destination push → device 는 payload.boardingLine 을 authoritative
-    // 로 받아 line guard 통과 → fire 시도. Issue J/K fix 후 backend 가 이 payload 를 발사하지 않게 됨.
-    // 지금은 device 층에서는 skip 하지 않고 통과 → 재발 재현.
-    expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+    expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+    expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'legacy-station-kind-ignored' }),
+    );
   });
 
-  it('regression payload (boardingLine 실린 상태) — 오늘 evidence 재현. Wave 1 완결 후 skip 이어야 함', async () => {
-    // 오늘 실 backend payload 상태 (Issue B fix 전).
-    // lock=null 인데도 backend 가 boardingLine='2' 를 실은 station-passed push 발사.
-    // 현재 device 코드: payload.boardingLine !== undefined → line guard 통과 → fire 시도.
-    //
-    // 이 test 는 "현재 회귀 재현" 을 assertion. Issue B fix 후 backend 가 boardingLine 을
-    // 실지 않도록 봉인하면 이 payload shape 자체가 발생하지 않게 됨.
-    //
-    // 검증: mockFindStationByNameAndLine 이 lock line ('2') 으로 성수 lookup → non-null 반환
-    // (성수는 실제 2호선 역) → line guard 통과 → intermediate kind → 이후 dismiss silence/location gate
-    // 모두 통과 → 최종 fire.
-    // (실 stations.json 검증은 다른 test 에서 커버 — 여기서는 mock 으로 lookup 성공 시나리오만 재현.)
+  it('regression payload (boardingLine 실린 상태) — 오늘 evidence 였던 fire가 #2064로 원천 차단됨', async () => {
+    // 오늘(evidence 채집 시점) 실 backend payload 상태 (Issue B fix 전, #2064 이전 device 코드).
+    // 당시 device: payload.boardingLine !== undefined → line guard 통과 → fire (`08:37:25 bg fired
+    // station-passed 성수` evidence). #2064로 fireWithGate 자체가 삭제되어 이 payload shape가 오늘도
+    // 재발한다 해도 device는 더 이상 로컬 알림을 발사하지 않는다 — Issue B의 device-side 증상은
+    // backend 근본 수정과 별개로 본 PR로 닫힌다.
     mockFindStationByNameAndLine.mockReturnValue({
       name: '성수',
       line: '2',
@@ -397,9 +399,11 @@ describe('Issue B (#2021) — device lockless-opt-out gate 동작 검증', () =>
       makeBgTaskInput(REGRESSION_PUSH_STATION_PASSED_SEONGSU_WITH_LINE),
     );
 
-    // 오늘 evidence 재현: fire 됨 (`08:37:25 bg fired station-passed 성수`).
-    // Issue B fix 후에는 backend 가 이 payload 를 발사하지 않게 되어 root cause 차단.
-    // 이 assertion 은 "device 는 boardingLine 실린 payload 를 authoritative 로 통과시킴" 을 명시.
+    // #2064 이전 evidence: fire 됨. #2064 이후: 항상 no-op skip.
+    expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+    expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'legacy-station-kind-ignored' }),
+    );
     expect(mockLogSilentPushSkipped).not.toHaveBeenCalledWith(
       expect.objectContaining({ reason: 'lockless-opt-out' }),
     );

--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -242,6 +242,11 @@ describe('useStationAlarm', () => {
     mockEvaluateAlarmPhase.mockReturnValue(null);
     mockResolveAlarmDirection.mockReturnValue(undefined);
     mockResolveNextTarget.mockReturnValue(null);
+    // #2064 — jest.clearAllMocks()는 mockResolvedValueOnce 등으로 큐잉된 반환값을 비우지 않는다.
+    // 일부 race/cancel 테스트가 소비되지 않은 once 큐(cancelled 가드에 막혀 실제 호출이 발생하지
+    // 않는 IIFE)를 남길 수 있어, 다음 테스트로 새는 것을 막기 위해 명시적으로 mockReset 후
+    // 기본값을 재설정한다.
+    mockGetLastNotifiedStationId.mockReset();
     mockGetLastNotifiedStationId.mockResolvedValue(null);
     mockSetLastNotifiedStationId.mockResolvedValue(undefined);
     mockGetFiredAlarms.mockResolvedValue(new Set<string>());
@@ -310,7 +315,7 @@ describe('useStationAlarm', () => {
     const route = makeDirectRoute(1, '2');
     const onRouteStation = makeStation('S2-DST', '강남'); // route+dest 매칭
 
-    it('GPS 게이트 차단 + arrivalConfidence=arrival-confirmed → station-passed 알람 발화', async () => {
+    it('GPS 게이트 차단 + arrivalConfidence=arrival-confirmed → station-passed 감지 (#2064 알림은 미발사)', async () => {
       mockGetLastNotifiedStationId.mockResolvedValue(null);
       renderHook(() =>
         useStationAlarm(
@@ -323,12 +328,15 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      // #2064 (Phase 1-device) — station-passed 로컬 알림 제거. 감지 성공은 dedup bookkeeping
+      // (setLastNotifiedStationId) 호출로 검증한다.
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
       // Phase 알람은 GPS 필요하므로 호출 안 됨
       expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
     });
 
-    it('GPS 게이트 차단 + arrivalConfidence=boarding-lock → station-passed 알람 발화 (#584 PR D2)', async () => {
+    it('GPS 게이트 차단 + arrivalConfidence=boarding-lock → station-passed 감지 (#584 PR D2, #2064 알림은 미발사)', async () => {
       mockGetLastNotifiedStationId.mockResolvedValue(null);
       renderHook(() =>
         useStationAlarm(
@@ -341,7 +349,8 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
     it('GPS 게이트 차단 + arrivalConfidence=arrival-arriving → 발화 안 함 (확정 아님)', () => {
@@ -391,7 +400,9 @@ describe('useStationAlarm', () => {
         ),
       );
       await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      // #2064 — station-passed 감지 성공은 dedup bookkeeping으로 검증(로컬 알림 미발사).
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
     it('arrival-confirmed 트리거도 lastNotifiedStationId dedup 적용 (GPS와 중복 발화 방지)', async () => {
@@ -1149,16 +1160,18 @@ describe('useStationAlarm', () => {
       stopsToDestination: 3,
     };
 
-    it('fires when nearest station changes (notificationState dedup)', async () => {
+    // #2064 (Phase 1-device) — station-passed 로컬 알림 제거. 감지 성공은 notificationState
+    // dedup bookkeeping(setLastNotifiedStationId)만으로 검증한다.
+    it('records dedup bookkeeping when nearest station changes (does not send local notification)', async () => {
       const route = makeDirectRoute(3, '2');
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
       renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
 
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalledWith('역삼', '강남', directTarget, undefined);
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, 'S1');
       });
-      expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, 'S1');
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
     it('does not fire when stored lastNotifiedStationId equals nearest station', async () => {
@@ -1176,7 +1189,7 @@ describe('useStationAlarm', () => {
       expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
-    it('fires again when nearest station changes to a different one', async () => {
+    it('records dedup bookkeeping again when nearest station changes to a different one', async () => {
       const route = makeDirectRoute(3, '2');
       const station1 = makeStation('S1', '역삼');
       const station2 = makeStation('S2', '선릉');
@@ -1187,7 +1200,7 @@ describe('useStationAlarm', () => {
         { initialProps: { s: station1 } },
       );
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalledTimes(1);
       });
 
       const nextTarget = {
@@ -1199,9 +1212,10 @@ describe('useStationAlarm', () => {
       mockResolveNextTarget.mockReturnValue(nextTarget);
       rerender({ s: station2 });
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(2);
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalledTimes(2);
       });
-      expect(mockSendStationPassedNotification).toHaveBeenLastCalledWith('선릉', '강남', nextTarget, undefined);
+      expect(mockSetLastNotifiedStationId).toHaveBeenLastCalledWith(destination.id, 'S2');
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
     it('does not fire when nearestStation is null', () => {
@@ -1226,18 +1240,26 @@ describe('useStationAlarm', () => {
       expect(mockGetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
-    it('passes null target when resolveNextTarget returns null', async () => {
+    // #2064 — resolveNextTarget은 더 이상 dispatchStationPassed에서 호출되지 않는다(로컬 알림
+    // 본문 생성용이었던 호출부 자체가 제거됨). resolveNextTarget 고유 로직의 정확성은
+    // `stationPipeline.test.ts`의 별도 describe('resolveNextTarget', ...)가 계속 커버 — 여기서는
+    // resolveNextTarget이 무엇을 반환하든(null 포함) dedup bookkeeping이 영향받지 않음을 검증한다.
+    it('dedup bookkeeping proceeds regardless of resolveNextTarget return value (no longer consumed)', async () => {
       const route = makeDirectRoute(3, '2');
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(null);
       renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalledWith('역삼', '강남', null, undefined);
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, 'S1');
       });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
-    it('handles sendStationPassedNotification rejection gracefully', async () => {
-      mockSendStationPassedNotification.mockRejectedValueOnce(new Error('알림 실패'));
+    // #2064 — 로컬 알림(sendStationPassedNotification)이 제거되어 그 rejection 경로도 함께
+    // 사라졌다. 남은 async 경계(setLastNotifiedStationId write)의 rejection도 hook이 throw 없이
+    // 흡수하는지 검증으로 대체.
+    it('handles setLastNotifiedStationId rejection gracefully', async () => {
+      mockSetLastNotifiedStationId.mockRejectedValueOnce(new Error('storage 실패'));
       const route = makeDirectRoute(3, '2');
       const station = makeStation('S1', '역삼');
       mockResolveNextTarget.mockReturnValue(directTarget);
@@ -1245,7 +1267,7 @@ describe('useStationAlarm', () => {
         renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station }))),
       ).not.toThrow();
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalled();
       });
     });
 
@@ -1348,46 +1370,19 @@ describe('useStationAlarm', () => {
 
       rerender({ s: onRouteStation });
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalledTimes(1);
       });
-      expect(mockSendStationPassedNotification).toHaveBeenCalledWith('서울', '강남', transferTarget, undefined);
+      expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, onRouteStation.id);
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
-    it('알림 발송 후에만 notificationState에 저장한다 (실패 시 재시도 가능)', async () => {
-      const route = makeDirectRoute(3, '2');
-      const station = makeStation('S1', '역삼');
-      mockResolveNextTarget.mockReturnValue(directTarget);
-      mockSendStationPassedNotification.mockRejectedValueOnce(new Error('알림 발송 실패'));
-
-      renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
-
-      await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalled();
-      });
-      // 알림 발송 실패 시 storage write를 하지 않아 다음 폴링에서 재시도 가능
-      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
-    });
-
-    it('알림 발송이 성공하면 그 후에 notificationState에 저장한다', async () => {
-      const route = makeDirectRoute(3, '2');
-      const station = makeStation('S1', '역삼');
-      mockResolveNextTarget.mockReturnValue(directTarget);
-
-      const callOrder: string[] = [];
-      mockSendStationPassedNotification.mockImplementationOnce(async () => {
-        callOrder.push('notify');
-      });
-      mockSetLastNotifiedStationId.mockImplementationOnce(async () => {
-        callOrder.push('write');
-      });
-
-      renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
-
-      await waitFor(() => {
-        expect(mockSetLastNotifiedStationId).toHaveBeenCalled();
-      });
-      expect(callOrder).toEqual(['notify', 'write']);
-    });
+    // #2064 — 아래 두 테스트("알림 발송 후에만 저장" / "알림 발송이 성공하면 그 후에 저장")는
+    // dispatchStationPassed의 옛 notify→write 순차 구조(실패 시 storage write 스킵)를 검증했다.
+    // 로컬 알림(sendStationPassedNotification) 호출 자체가 제거되어 그 순차 구조가 더 이상
+    // 존재하지 않는다 — markStationFired(sync) → isCancelled() → setLastNotifiedStationId(write)
+    // 만 남았고, write를 막는 "실패 가능한 이전 단계"가 없다. 두 테스트 모두 관찰 목적을 잃어
+    // 제거. write 자체의 rejection-safety는 위 'handles setLastNotifiedStationId rejection
+    // gracefully'가 커버.
 
     function deferred<T>() {
       let resolve!: (value: T) => void;
@@ -1425,10 +1420,11 @@ describe('useStationAlarm', () => {
       readA2.resolve(null);
 
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalledTimes(1);
       });
-      // 처음 두 IIFE는 cancelled 가드에 막혀 마지막(A) 한 번만 알림 발사
-      expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남A', '강남', directTarget, undefined);
+      // 처음 두 IIFE는 cancelled 가드에 막혀 마지막(A) 한 번만 dedup bookkeeping 수행.
+      expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, stationA.id);
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
     it('cancel 플래그: read 완료 전 언마운트되면 알림을 발송하지 않는다', async () => {
@@ -1454,31 +1450,14 @@ describe('useStationAlarm', () => {
       expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
-    it('cancel 플래그: notify 완료 전 언마운트되면 storage write를 하지 않는다', async () => {
-      const route = makeDirectRoute(3, '2');
-      const station = makeStation('S1', '역삼');
-      mockResolveNextTarget.mockReturnValue(directTarget);
-
-      const notify = deferred<void>();
-      mockSendStationPassedNotification.mockReturnValueOnce(notify.promise);
-
-      const { unmount } = renderHook(() =>
-        useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
-      );
-
-      // notify가 시작될 때까지 기다림
-      await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalled();
-      });
-
-      unmount();
-      notify.resolve();
-
-      await Promise.resolve();
-      await Promise.resolve();
-
-      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
-    });
+    // #2064 — 이 위치에 있던 'cancel 플래그: notify 완료 전 언마운트되면 storage write를 하지
+    // 않는다' 테스트는 옛 dispatchStationPassed의 notify await 경계(isCancelled() 재확인 지점이
+    // notify 이후에 있었음)를 이용했다. 새 코드는 markStationFired(sync) → isCancelled() →
+    // setLastNotifiedStationId(await)만 남았고, 이 cancelled 재확인은 setLastNotifiedStationId
+    // "이전"에 위치 — 즉 getLastNotifiedStationId await 직후의 cancelled 게이트(바로 위
+    // 'read 완료 전 언마운트' 테스트)와 완전히 동일한 경계다. setLastNotifiedStationId 호출
+    // "이후"에는 재확인 지점이 없어(가장 마지막 statement) 재현할 별도 race window가 없다 —
+    // 중복 커버라 제거.
   });
 
   // ── BG↔FG firedAlarms 단일 출처 (#336 회귀 가드) ──
@@ -1693,7 +1672,9 @@ describe('useStationAlarm', () => {
       });
     });
 
-    it('역 통과 알림 발사 시 logFiredStationPassed(fg, station)을 호출한다', async () => {
+    // #2064 (Phase 1-device) — station-passed 로컬 알림 제거로 logFiredStationPassed(alarmLog
+    // 'fired' 엔트리) 호출부도 함께 제거됨. dedup bookkeeping(setLastNotifiedStationId)은 유지.
+    it('역 통과 감지 시에도 logFiredStationPassed는 호출하지 않는다 (dedup bookkeeping만 수행)', async () => {
       mockEvaluateAlarmPhase.mockReturnValue(null);
       mockGetLastNotifiedStationId.mockResolvedValue(null);
       mockSetLastNotifiedStationId.mockResolvedValue(undefined);
@@ -1709,8 +1690,9 @@ describe('useStationAlarm', () => {
       );
 
       await waitFor(() => {
-        expect(mockLogFiredStationPassed).toHaveBeenCalledWith('fg', station);
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, station.id);
       });
+      expect(mockLogFiredStationPassed).not.toHaveBeenCalled();
     });
 
     it('lastNotifiedStationId 일치로 skip 시 logSuppressedDedupStation(fg, station)을 호출한다', async () => {
@@ -2071,7 +2053,9 @@ describe('useStationAlarm', () => {
       );
     });
 
-    it('역 통과 알림에도 notificationSource가 전달된다', async () => {
+    // #2064 (Phase 1-device) — station-passed 로컬 알림 제거로 notificationSource 전파 대상도
+    // 사라짐(sendAlarmNotification 경로만 notificationSource를 계속 사용).
+    it('역 통과 감지에는 더 이상 notificationSource가 전달되지 않는다 (알림 자체가 없음)', async () => {
       const route = makeDirectRoute(5, '2');
       const destination = makeStation('D1', '강남');
       const station = makeStation('S1', '역삼');
@@ -2093,13 +2077,9 @@ describe('useStationAlarm', () => {
         ),
       );
       await waitFor(() =>
-        expect(mockSendStationPassedNotification).toHaveBeenCalledWith(
-          '역삼',
-          '강남',
-          directTarget,
-          'routeProgress',
-        ),
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, station.id),
       );
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
   });
 
@@ -2513,16 +2493,18 @@ describe('useStationAlarm', () => {
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
-    it('station-passed + 정적 신호 + arrivalConfirmed면 movement gate skip → 정상 발사', async () => {
+    it('station-passed + 정적 신호 + arrivalConfirmed면 movement gate skip → 정상 감지 (#2064 알림은 미발사)', async () => {
       renderStationPassedHook({ speedMps: 0, arrivalConfidence: 'arrival-confirmed' });
 
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
-    it('station-passed + 이동 신호(speed=5)면 정상 발사', async () => {
+    it('station-passed + 이동 신호(speed=5)면 정상 감지 (#2064 알림은 미발사)', async () => {
       renderStationPassedHook({ speedMps: 5 });
 
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
   });
 
@@ -2623,7 +2605,7 @@ describe('useStationAlarm', () => {
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
-    it('motionStationary=false면 차단 안 함 (이동 신호 정상)', async () => {
+    it('motionStationary=false면 차단 안 함 (이동 신호 정상, #2064 알림은 미발사)', async () => {
       mockGetLastNotifiedStationId.mockResolvedValue(null);
       renderHook(() =>
         useStationAlarm(
@@ -2638,10 +2620,11 @@ describe('useStationAlarm', () => {
         ),
       );
 
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
-    it('motionStationary 미전달 — 기존 동작 유지 (graceful fallback)', async () => {
+    it('motionStationary 미전달 — 기존 동작 유지 (graceful fallback, #2064 알림은 미발사)', async () => {
       mockGetLastNotifiedStationId.mockResolvedValue(null);
       renderHook(() =>
         useStationAlarm(
@@ -2655,10 +2638,11 @@ describe('useStationAlarm', () => {
         ),
       );
 
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
-    it('station-passed + motionStationary=true + arrivalConfirmed면 motion gate skip → 정상 발사', async () => {
+    it('station-passed + motionStationary=true + arrivalConfirmed면 motion gate skip → 정상 감지 (#2064 알림은 미발사)', async () => {
       mockGetLastNotifiedStationId.mockResolvedValue(null);
       // arrivalConfirmed는 motion gate 자체를 우회 (기존 정책 — arrival API 단독 신호 보호).
       renderHook(() =>
@@ -2675,7 +2659,8 @@ describe('useStationAlarm', () => {
         ),
       );
 
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
   });
 
@@ -2776,7 +2761,7 @@ describe('useStationAlarm', () => {
       await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
     });
 
-    it('station-passed + motionStationary=true + trainProgressing=true → 정상 발사', async () => {
+    it('station-passed + motionStationary=true + trainProgressing=true → 정상 감지 (#2064 알림은 미발사)', async () => {
       mockGetLastNotifiedStationId.mockResolvedValue(null);
 
       renderTrainProgressingAlarm({
@@ -2786,7 +2771,8 @@ describe('useStationAlarm', () => {
         trainProgressing: true,
       });
 
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
     it('trainProgressing=false면 기존 동작 (motion=stationary 차단 그대로)', async () => {
@@ -2878,7 +2864,7 @@ describe('useStationAlarm', () => {
       expect(mockLogSuppressedStationPassedWarmup).toHaveBeenCalledWith(station.name);
     });
 
-    it('skipWarmupGuard=true면 warmup window 안에서도 즉시 발사', async () => {
+    it('skipWarmupGuard=true면 warmup window 안에서도 즉시 감지 (#2064 알림은 미발사)', async () => {
       const baseTs = 1_700_000_000_000;
       jest.spyOn(Date, 'now').mockReturnValue(baseTs);
       mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 2, isTransfer: false, stopsToDestination: 2 });
@@ -2895,10 +2881,11 @@ describe('useStationAlarm', () => {
         ),
       );
 
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
-    it('warmup window 경과 후 발사 허용 (hydratedAt + 10s 이후)', async () => {
+    it('warmup window 경과 후 감지 허용 (hydratedAt + 10s 이후, #2064 알림은 미발사)', async () => {
       const baseTs = 1_700_000_000_000;
       const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseTs);
       mockResolveNextTarget.mockReturnValue({ nextStationName: '강남', stopsToNextStation: 2, isTransfer: false, stopsToDestination: 2 });
@@ -2924,7 +2911,8 @@ describe('useStationAlarm', () => {
       nowSpy.mockReturnValue(baseTs + 10_001);
       rerender({ s: station });
 
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
   });
 
@@ -3223,7 +3211,10 @@ describe('useStationAlarm', () => {
     // fast path 발사 여부만 가린다. GPS path는 sendStationPassedNotification을 'fg' source로 logFiredStationPassed
     // 호출하므로 mock 호출 인자로 식별 가능.
 
-    it('lock 활성 + arvlCd 신호 → station-passed 알림 발사 + lastNotifiedStationId 갱신', async () => {
+    // #2064 (Phase 1-device) — station-passed 로컬 알림(sendStationPassedNotification) +
+    // alarmLog 'fired' 엔트리(logFiredStationPassed) 모두 제거. 감지 성공은 dedup bookkeeping
+    // (setLastNotifiedStationId) 1회 호출로만 검증한다.
+    it('lock 활성 + arvlCd 신호 → station-passed 감지 + lastNotifiedStationId 갱신 (알림 미발사)', async () => {
       mockGetBoardingLock.mockResolvedValue(activeLock);
       mockGetLastNotifiedStationId.mockResolvedValue(null);
       mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
@@ -3231,15 +3222,13 @@ describe('useStationAlarm', () => {
       renderHook(() => useStationAlarm(fastPathInputs()));
 
       // #1515 — cross-category station-level dedup으로 GPS path와 fast-path 중 먼저 reservation을
-      // 점유한 쪽만 발사된다(같은 station, 같은 destination, 30s 윈도우). 발사 1회 + 호출 인자만 검증.
-      await waitFor(() => expect(mockLogFiredStationPassed).toHaveBeenCalled());
-      expect(mockLogFiredStationPassed).toHaveBeenCalledTimes(1);
-      expect(mockLogFiredStationPassed).toHaveBeenCalledWith(
-        expect.stringMatching(/^fg(-arvlcd)?$/),
-        onRouteStation,
+      // 점유한 쪽만 dedup bookkeeping을 완료한다(같은 station, 같은 destination, 30s 윈도우).
+      await waitFor(() =>
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, onRouteStation.id),
       );
-      expect(mockSendStationPassedNotification).toHaveBeenCalled();
-      expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, onRouteStation.id);
+      expect(mockSetLastNotifiedStationId).toHaveBeenCalledTimes(1);
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredStationPassed).not.toHaveBeenCalled();
     });
 
     // #640 회귀 가드 — 본 PR의 핵심.
@@ -3257,8 +3246,7 @@ describe('useStationAlarm', () => {
       await waitFor(() => expect(mockGetBoardingLock).toHaveBeenCalled());
       await Promise.resolve();
       await Promise.resolve();
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
     it('#640 회귀 가드 — findFgArvlCdFireSignal이 null 반환(trainCode 불일치/arvlCd 불일치)면 발사 X', async () => {
@@ -3270,8 +3258,7 @@ describe('useStationAlarm', () => {
 
       await waitFor(() => expect(mockGetBoardingLock).toHaveBeenCalled());
       await Promise.resolve();
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
     it('lastNotifiedStationId가 같은 station.id면 fast path dedup → fg-arvlcd dedup 로그', async () => {
@@ -3284,8 +3271,7 @@ describe('useStationAlarm', () => {
       await waitFor(() =>
         expect(mockLogSuppressedDedupStation).toHaveBeenCalledWith('fg-arvlcd', onRouteStation),
       );
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
     it('currentStationArrival 미전달(undefined)이면 fast path no-op (arvlCd fire X)', async () => {
@@ -3299,8 +3285,7 @@ describe('useStationAlarm', () => {
       await Promise.resolve();
       // #1236 — GPS station-passed path도 sleep 룰 게이트 위해 getBoardingLock을 호출하므로
       // 'getBoardingLock 미호출' 대신 'fast path fire 미발생'으로 검증한다.
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
     it('currentStationArrival null이면 fast path no-op', async () => {
@@ -3312,8 +3297,7 @@ describe('useStationAlarm', () => {
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
       await Promise.resolve();
       await Promise.resolve();
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
     it('nearestStation null이면 fast path no-op (fire 대상 station 결정 불가)', async () => {
@@ -3325,8 +3309,7 @@ describe('useStationAlarm', () => {
       await Promise.resolve();
       // #1272 (N8) — destinationId 기반 lock mirror effect가 destinationId 설정 시 lock을
       // 1회 prefetch 한다. fast path 발사 자체는 nearestStation null이므로 발생하지 않음.
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
     it('nearestStation이 route 밖이면(line 불일치) fast path no-op', async () => {
@@ -3336,8 +3319,7 @@ describe('useStationAlarm', () => {
 
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
       await Promise.resolve();
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
     it('route 또는 destination 미설정이면 fast path no-op', async () => {
@@ -3347,8 +3329,7 @@ describe('useStationAlarm', () => {
 
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
       await Promise.resolve();
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
     it('destination 미설정이면 fast path no-op', async () => {
@@ -3379,8 +3360,7 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
     it('dismiss silence 활성 시 fast path 발사 X + logSuppressedDismissSilence(fg-arvlcd)', async () => {
@@ -3408,8 +3388,7 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
     it('hydration 미완료 시 fast path 보류 (firedHydrated=false)', async () => {
@@ -3424,8 +3403,7 @@ describe('useStationAlarm', () => {
       // #1272 (N8) — destinationId 기반 lock mirror effect는 hydration과 무관하게 destinationId
       // 설정 시 lock을 prefetch하므로 getBoardingLock 호출 자체는 발생할 수 있다. 단 fast path
       // 발사는 발생하지 않음(logFiredStationPassed fg-arvlcd 호출 0).
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
     it('내부 storage read/send 실패 시 catch로 swallow (logger.error 분기 커버)', async () => {
@@ -3442,8 +3420,7 @@ describe('useStationAlarm', () => {
       await waitFor(() => expect(mockGetLastNotifiedStationId).toHaveBeenCalled());
       await Promise.resolve();
       await Promise.resolve();
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
     it('effect cleanup (unmount) 후엔 후속 작업이 fast path 발사 안 함', async () => {
@@ -3468,8 +3445,7 @@ describe('useStationAlarm', () => {
       for (let i = 0; i < 8; i++) await Promise.resolve();
 
       // fast path의 logFiredStationPassed('fg-arvlcd', ...)이 호출되지 않아야 한다.
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
     it('getLastNotifiedStationId 후 cleanup 되면 dedup/send 분기 진입 안 함 (cancelled gate line 720)', async () => {
@@ -3495,39 +3471,19 @@ describe('useStationAlarm', () => {
       // resolve 후 microtask 충분히 돌려 `if (cancelled) return;` 진입(line 720).
       for (let i = 0; i < 8; i++) await Promise.resolve();
 
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
       // dedup 로그도 호출되지 않아야 한다 (cancelled로 early return).
       const arvlCdDedups = mockLogSuppressedDedupStation.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
       expect(arvlCdDedups).toHaveLength(0);
     });
 
-    it('sendStationPassedNotification 후 cleanup 되면 setLastNotifiedStationId 미호출 (cancelled gate line 736)', async () => {
-      // send pending 동안 unmount → setLastNotifiedStationId 미호출 + logFiredStationPassed 미호출.
-      // GPS effect와 fast path effect 둘 다 send 호출하므로 mockImplementation으로 전체 pending.
-      const resolvers: Array<() => void> = [];
-      mockGetBoardingLock.mockResolvedValue(activeLock);
-      mockGetLastNotifiedStationId.mockResolvedValue(null);
-      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
-      mockSendStationPassedNotification.mockImplementation(
-        () =>
-          new Promise<void>((r) => {
-            resolvers.push(r);
-          }),
-      );
-
-      const { unmount } = renderHook(() => useStationAlarm(fastPathInputs()));
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
-      unmount();
-      // 모든 pending send를 해제 — 각 effect는 cancelled=true를 보고 setLastNotifiedStationId skip.
-      resolvers.forEach((r) => r());
-      await Promise.resolve();
-      await Promise.resolve();
-
-      // setLastNotifiedStationId와 logFiredStationPassed('fg-arvlcd', ...) 모두 미호출.
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
-    });
+    // #2064 — 이 위치에 있던 'sendStationPassedNotification 후 cleanup 되면 setLastNotifiedStationId
+    // 미호출' 테스트는 옛 dispatchStationPassed의 notify await 경계를 이용해 cancel-mid-flight를
+    // 재현했다. 로컬 알림 호출 자체가 제거되어 그 경계가 사라졌고(mockSendStationPassedNotification이
+    // 더 이상 호출되지 않아 waitFor가 타임아웃), 새 코드의 유일한 cancelled 재확인 지점은
+    // getLastNotifiedStationId await 직후로 옮겨갔다 — 바로 위 'getLastNotifiedStationId 후
+    // cleanup 되면 dedup/send 분기 진입 안 함' 테스트가 GPS+fast-path 양쪽 모두에 대해 이미
+    // 이 경계를 검증하므로 중복 제거.
 
     it('destination 변경 직후 firedAlarmsRef.destId 미일치 시점에는 fast path 보류 (line 671)', async () => {
       // hydration mock: 첫 destination에 대해 hydrate 완료 → ref id 일치.
@@ -3550,13 +3506,15 @@ describe('useStationAlarm', () => {
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
 
       // destination 교체. 새 destination의 hydrate는 pending → firedHydrated=false 또는 ref.id 불일치.
-      mockLogFiredStationPassed.mockClear();
+      // #2064 — 첫 destination의 정상 dispatch가 이미 setLastNotifiedStationId를 1회 호출했을 수
+      // 있으므로(로컬 알림 대신 dedup bookkeeping이 proxy) rerender 전 호출 기록을 clear해
+      // "교체 직후에는 추가 호출이 없다"만 검증한다.
+      mockSetLastNotifiedStationId.mockClear();
       rerender({ dest: altDestination });
       await Promise.resolve();
       await Promise.resolve();
 
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
   });
@@ -3631,8 +3589,7 @@ describe('useStationAlarm', () => {
           candidateIndex: 4,
         });
       });
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
     it('22:31 회귀 차단 — currentHopIndex=0 + nearestStation=arc[6] (+6 hop 미래) → fast-path suppressed', async () => {
@@ -3658,8 +3615,7 @@ describe('useStationAlarm', () => {
           candidateIndex: 6,
         });
       });
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
     it('정상 case — currentHopIndex=3 + nearestStation=arc[3] (동일 hop) → fast-path fire (정상 동작 보존)', async () => {
@@ -3677,12 +3633,12 @@ describe('useStationAlarm', () => {
         ),
       );
 
-      // #1515 — cross-category dedup으로 GPS path/fast-path 중 먼저 reservation 점유한 쪽만 발사.
-      await waitFor(() => expect(mockLogFiredStationPassed).toHaveBeenCalled());
-      expect(mockLogFiredStationPassed).toHaveBeenCalledWith(
-        expect.stringMatching(/^fg(-arvlcd)?$/),
-        arcLine2[3],
+      // #1515 — cross-category dedup으로 GPS path/fast-path 중 먼저 reservation 점유한 쪽만
+      // dedup bookkeeping 완료. #2064 — 로컬 알림(logFiredStationPassed)은 제거되어 미호출.
+      await waitFor(() =>
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, arcLine2[3].id),
       );
+      expect(mockLogFiredStationPassed).not.toHaveBeenCalled();
       expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
     });
 
@@ -3707,12 +3663,12 @@ describe('useStationAlarm', () => {
           stationName: arcLine2[0].name,
         });
       });
-      // 게이트 미적용이므로 정상 발사. #1515 — GPS path/fast-path 중 reservation을 먼저 잡은 쪽만 fire.
-      await waitFor(() => expect(mockLogFiredStationPassed).toHaveBeenCalled());
-      expect(mockLogFiredStationPassed).toHaveBeenCalledWith(
-        expect.stringMatching(/^fg(-arvlcd)?$/),
-        arcLine2[0],
+      // 게이트 미적용이므로 정상 감지. #1515 — GPS path/fast-path 중 reservation을 먼저 잡은 쪽만
+      // dedup bookkeeping 완료. #2064 — 로컬 알림은 제거되어 미호출.
+      await waitFor(() =>
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, arcLine2[0].id),
       );
+      expect(mockLogFiredStationPassed).not.toHaveBeenCalled();
     });
 
     it('#1806 fast-path 60s dedup — no-source가 60s 내 재발사 시 두 번째 적재 skip', async () => {
@@ -3784,12 +3740,12 @@ describe('useStationAlarm', () => {
         ),
       );
 
-      // #1515 — GPS path/fast-path 중 reservation을 먼저 잡은 쪽만 fire.
-      await waitFor(() => expect(mockLogFiredStationPassed).toHaveBeenCalled());
-      expect(mockLogFiredStationPassed).toHaveBeenCalledWith(
-        expect.stringMatching(/^fg(-arvlcd)?$/),
-        arcLine2[0],
+      // #1515 — GPS path/fast-path 중 reservation을 먼저 잡은 쪽만 dedup bookkeeping 완료.
+      // #2064 — 로컬 알림은 제거되어 미호출.
+      await waitFor(() =>
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, arcLine2[0].id),
       );
+      expect(mockLogFiredStationPassed).not.toHaveBeenCalled();
       expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
       expect(mockLogSuppressedHopWindowNoSource).not.toHaveBeenCalled();
     });
@@ -4025,9 +3981,11 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
+      // #2064 — 로컬 알림 제거. dedup bookkeeping(setLastNotifiedStationId)으로 성공을 검증.
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalled();
       });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
       expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
     });
 
@@ -4059,9 +4017,11 @@ describe('useStationAlarm', () => {
         });
       });
       // 게이트 미적용이므로 알람은 정상 발사된다.
+      // #2064 — 로컬 알림 제거. dedup bookkeeping(setLastNotifiedStationId)으로 성공을 검증.
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalled();
       });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
     it('arcStations 빈 배열 → 게이트 자체 미적용 (기존 동작 보존)', async () => {
@@ -4085,9 +4045,11 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
+      // #2064 — 로컬 알림 제거. dedup bookkeeping(setLastNotifiedStationId)으로 성공을 검증.
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalled();
       });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
       expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
       expect(mockLogSuppressedHopWindowNoSource).not.toHaveBeenCalled();
     });
@@ -4118,9 +4080,11 @@ describe('useStationAlarm', () => {
         expect(mockLogSuppressedHopWindowNoSource).toHaveBeenCalled();
       });
       // 게이트 미적용 → 알람 정상 발사.
+      // #2064 — 로컬 알림 제거. dedup bookkeeping(setLastNotifiedStationId)으로 성공을 검증.
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalled();
       });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
     it('#1806 60s dedup — no-source가 60s 내 재발사 시 두 번째 적재 skip', async () => {
@@ -4188,9 +4152,11 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
+      // #2064 — 로컬 알림 제거. dedup bookkeeping(setLastNotifiedStationId)으로 성공을 검증.
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalled();
       });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
       expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
     });
 
@@ -4272,9 +4238,11 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
+      // #2064 — 로컬 알림 제거. dedup bookkeeping(setLastNotifiedStationId)으로 성공을 검증.
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalled();
       });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
       expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
     });
 
@@ -4395,9 +4363,11 @@ describe('useStationAlarm', () => {
         ),
       );
       // strategy 미전달은 live-position 아니므로 M3 게이트 통과 → M1 확장 적용 → 통과.
+      // #2064 — 로컬 알림 제거. dedup bookkeeping(setLastNotifiedStationId)으로 성공을 검증.
       await waitFor(() => {
-        expect(mockSendStationPassedNotification).toHaveBeenCalled();
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalled();
       });
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
       expect(mockLogSuppressedHopWindow).not.toHaveBeenCalled();
     });
 
@@ -4698,7 +4668,9 @@ describe('useStationAlarm', () => {
         // lock-origin guard는 sleep gate보다 위에 있어 sleep stamp는 발생하지 않음.
         expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
       } else {
-        await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+        // #2064 — station-passed 감지 성공은 dedup bookkeeping으로 검증(로컬 알림 미발사).
+        await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+        expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
         expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
         expect(mockLogSuppressedPassedEventOnLockOrigin).not.toHaveBeenCalled();
       }
@@ -4733,10 +4705,7 @@ describe('useStationAlarm', () => {
           const calls = mockLogSuppressedPassedEventOnLockOrigin.mock.calls;
           expect(calls.some((c) => c[0]?.source === 'fg-arvlcd')).toBe(true);
         });
-        const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter(
-          (c) => c[0] === 'fg-arvlcd',
-        );
-        expect(arvlCdFires).toHaveLength(0);
+        expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
         expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
         // lock-origin guard가 sleep gate보다 위에 있어 sleep stamp는 발생하지 않음.
         expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
@@ -4801,7 +4770,9 @@ describe('useStationAlarm', () => {
 
       renderHook(() => useStationAlarm(subsurfaceInputs()));
 
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      // #2064 — 로컬 알림 제거. dedup bookkeeping(setLastNotifiedStationId)으로 성공을 검증.
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
       // GPS phase 알람은 accuracyMeters=500으로 차단
       expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
     });
@@ -4926,7 +4897,9 @@ describe('useStationAlarm', () => {
           useStationAlarm(subsurfaceInputs({ destination: dest })),
         { initialProps: { dest: destination } },
       );
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      // #2064 — 로컬 알림 제거. dedup bookkeeping(setLastNotifiedStationId)으로 성공을 검증.
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
 
       // 2) destination 교체 → hydration 리셋(pre-hydrate). pending getFiredAlarms로 ready 미진입.
       mockGetFiredAlarms.mockReturnValue(new Promise(() => {}));
@@ -5039,7 +5012,9 @@ describe('useStationAlarm', () => {
         ),
       );
 
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      // #2064 — 로컬 알림 제거. dedup bookkeeping(setLastNotifiedStationId)으로 성공을 검증.
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
       expect(mockLogSuppressedSsotFireGate).not.toHaveBeenCalled();
     });
 
@@ -5204,8 +5179,7 @@ describe('useStationAlarm', () => {
       for (let i = 0; i < 12; i++) await Promise.resolve();
 
       // arvlCd fast-path silent — dispatch X
-      const arvlCdFires = mockLogFiredStationPassed.mock.calls.filter((c) => c[0] === 'fg-arvlcd');
-      expect(arvlCdFires).toHaveLength(0);
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
     it('Path C (subsurface) evaluateSsotFireGate pending 중 unmount → cancelled guard (line 1245)', async () => {
@@ -5305,7 +5279,10 @@ describe('useStationAlarm', () => {
       mockEvaluateSsotFireGate.mockResolvedValue({ blocked: false, reason: 'mirror-missing' as const });
     });
 
-    it('3개 역 순차 통과 → sendStationPassedNotification 정확히 3회', async () => {
+    // #2064 (Phase 1-device) — 로컬 알림(sendStationPassedNotification) 제거로 순차 통과 카운트
+    // 검증은 dedup bookkeeping(setLastNotifiedStationId) 호출 횟수로 대체한다. N개 역 순차 감지가
+    // 정확히 N회 bookkeeping을 수행하고(누락 없음) 초과 호출이 없음(spam 없음)을 그대로 보존한다.
+    it('3개 역 순차 통과 → setLastNotifiedStationId 정확히 3회 (알림은 항상 미발사)', async () => {
       const route = makeDirectRoute(3, '2');
       const nextTarget = {
         nextStationName: '강남',
@@ -5325,16 +5302,17 @@ describe('useStationAlarm', () => {
           useStationAlarm(defaultInputs({ route, destination, nearestStation: s })),
         { initialProps: { s: stations[0] } },
       );
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalledTimes(1));
 
       rerender({ s: stations[1] });
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(2));
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalledTimes(2));
 
       rerender({ s: stations[2] });
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(3));
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalledTimes(3));
 
-      // 정확히 3회 — 초과 없음 (X4 spam 보조 검증).
-      expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(3);
+      // 정확히 3회 — 초과 없음 (X4 spam 보조 검증). 로컬 알림은 한 번도 발사되지 않는다.
+      expect(mockSetLastNotifiedStationId).toHaveBeenCalledTimes(3);
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
   });
 
@@ -5445,7 +5423,9 @@ describe('useStationAlarm', () => {
         ),
       );
       // station-passed는 별도 effect — 시간 적분 게이트 영향 없이 발화.
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      // #2064 — 로컬 알림 제거. dedup bookkeeping(setLastNotifiedStationId)으로 성공을 검증.
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
       // phase alarm은 차단.
       expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
     });
@@ -5591,7 +5571,9 @@ describe('useStationAlarm', () => {
         ),
       );
 
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      // #2064 — 로컬 알림 제거. dedup bookkeeping(setLastNotifiedStationId)으로 성공을 검증.
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
       expect(mockLogSuppressedLocklessNoUserIntent).not.toHaveBeenCalled();
     });
 
@@ -5923,7 +5905,9 @@ describe('useStationAlarm', () => {
       );
 
       // speed=0인데도 station-passed 알람 발사 — flag ON 이면 movement gate 미적용.
-      await waitFor(() => expect(mockSendStationPassedNotification).toHaveBeenCalled());
+      // #2064 — 로컬 알림 제거. dedup bookkeeping(setLastNotifiedStationId)으로 성공을 검증.
+      await waitFor(() => expect(mockSetLastNotifiedStationId).toHaveBeenCalled());
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
       expect(mockLogSuppressedMovement).not.toHaveBeenCalledWith(
         expect.objectContaining({ reason: 'movement-static-speed' }),
       );

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -20,7 +20,6 @@ import type { Station } from '../../../shared/types/station';
 import { alarmKey, parseAlarmKey, evaluateAlarmPhase, type AlarmEvent } from '../utils/stationAlarm';
 import { resolveAlarmDirection } from '../utils/alarmDirection';
 import { distanceMetersBetween, estimateEtaSeconds } from '../../../shared/utils/stationEta';
-import { resolveNextTarget } from '../utils/stationPipeline';
 import { sendAlarmNotification } from '../utils/stationNotification';
 import { isImminentByArrivalCode } from '../../arrival/utils/imminentArrivalSignal';
 import { findFgArvlCdFireSignal } from '../utils/fgArvlCdFastPath';
@@ -39,7 +38,6 @@ import {
   logFiredAlarm,
   logFiredAlarmsHydrate,
   logFiredAlarmsTripBoundaryReset,
-  logFiredStationPassed,
   logHydrationTransition,
   logRefMismatch,
   logSuppressedChannelAgnosticDedup,
@@ -83,7 +81,7 @@ import { useAlarmEventStore } from '../store/useAlarmEventStore';
 import { createLogger } from '../../../shared/utils/logger';
 import { isAccuracyAcceptable } from '../../nearest-station/utils/locationGates';
 import type { FusionConfidence, FusionSource } from '../../../shared/types/fusion';
-import { resolveNotificationSource, type NotificationSource } from '../utils/notificationSource';
+import { resolveNotificationSource } from '../utils/notificationSource';
 import { isSimpleArchEnabled } from '../../../shared/config/archFlag';
 
 const logger = createLogger('StationAlarm');
@@ -1303,9 +1301,7 @@ export function useStationAlarm({
     // A→B→A 빠른 변동 시 이전 IIFE들이 cancelled로 차단되고 최신 candidate만 알림을 보낸다.
     if (nearestStation && isStationOnRoute(nearestStation, route)) {
       const candidateStation = nearestStation;
-      const capturedRoute = route;
       const capturedDestinationId = destination.id;
-      const capturedDestinationName = destination.name;
 
       // #1208 (Epic #1204 D2) — trip 진행도 hop window 게이트.
       // isStationOnRoute는 candidate가 route 노선 위에 있는지만 검사 → 이미 지나간 hop이나
@@ -1464,9 +1460,7 @@ export function useStationAlarm({
     if (!isStationOnRoute(nearestStation, route)) return;
 
     const candidateStation = nearestStation;
-    const capturedRoute = route;
     const capturedDestinationId = destination.id;
-    const capturedDestinationName = destination.name;
 
     let cancelled = false;
     void (async () => {
@@ -1604,9 +1598,7 @@ export function useStationAlarm({
     if (!isStationOnRoute(nearestStation, route)) return;
 
     const candidateStation = nearestStation;
-    const capturedRoute = route;
     const capturedDestinationId = destination.id;
-    const capturedDestinationName = destination.name;
 
     let cancelled = false;
     void (async () => {

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -21,7 +21,7 @@ import { alarmKey, parseAlarmKey, evaluateAlarmPhase, type AlarmEvent } from '..
 import { resolveAlarmDirection } from '../utils/alarmDirection';
 import { distanceMetersBetween, estimateEtaSeconds } from '../../../shared/utils/stationEta';
 import { resolveNextTarget } from '../utils/stationPipeline';
-import { sendAlarmNotification, sendStationPassedNotification } from '../utils/stationNotification';
+import { sendAlarmNotification } from '../utils/stationNotification';
 import { isImminentByArrivalCode } from '../../arrival/utils/imminentArrivalSignal';
 import { findFgArvlCdFireSignal } from '../utils/fgArvlCdFastPath';
 import type { StationArrival } from '../../../shared/types/arrival';
@@ -183,20 +183,14 @@ function logSuppressedStationPassedLockless(stationName: string): void {
 async function dispatchStationPassed(params: {
   source: 'fg' | 'fg-arvlcd';
   candidateStation: Station;
-  capturedRoute: Route;
   capturedDestinationId: string;
-  capturedDestinationName: string;
-  notificationSource: NotificationSource | undefined;
   isCancelled: () => boolean;
   errorLogPrefix: string;
 }): Promise<void> {
   const {
     source,
     candidateStation,
-    capturedRoute,
     capturedDestinationId,
-    capturedDestinationName,
-    notificationSource,
     isCancelled,
     errorLogPrefix,
   } = params;
@@ -245,9 +239,9 @@ async function dispatchStationPassed(params: {
       });
       return;
     }
-    // race 차단: send 도중 동일 effect/다른 path가 진입해 같은 station을 발사하는 것을 막기 위해
-    // send 전에 윈도우 갱신(reservation). send 실패 시에도 30s 동안 cross-category 재발사 차단 —
-    // 이슈 acceptance "같은 station 30s 내 cross-category fire 1건 이하"에 정합.
+    // #2064 (Phase 1-device) — 매역 알림은 backend visible push 단일 채널로 전환. FG station-passed
+    // 감지는 이제 사용자 노출 알림을 발사하지 않고 cross-category dedup 윈도우 + lastNotifiedStationId
+    // bookkeeping만 수행한다(다른 카테고리 알람/게이트가 여전히 이 상태를 읽는다).
     // category='station-passed' → 후속 destination/transfer 발사 차단.
     markStationFired(
       capturedDestinationId,
@@ -255,22 +249,10 @@ async function dispatchStationPassed(params: {
       'station-passed',
       Date.now(),
     );
-    // #796: candidateStation.line을 전달해 multi-transfer 환승역 정확 식별.
-    const target = resolveNextTarget(
-      capturedRoute,
-      capturedDestinationName,
-      candidateStation.line,
-    );
-    // 알림 발송 성공 후에만 storage write — 발송 실패 시 다음 폴링에서 재시도 가능.
-    await sendStationPassedNotification(
-      candidateStation.name,
-      capturedDestinationName,
-      target,
-      notificationSource,
-    );
-    if (isCancelled()) return;
+    // #2064 — markStationFired부터 여기까지는 await 없는 순수 동기 구간이라 cancelled는 위
+    // isCancelled() 체크(getLastNotifiedStationId await 직후) 이후 바뀔 수 없다. 별도 재확인 불필요
+    // — await setLastNotifiedStationId 진입 시점에만 다시 확인하면 충분.
     await setLastNotifiedStationId(capturedDestinationId, candidateStation.id);
-    logFiredStationPassed(source, candidateStation);
   } catch (e) {
     logger.error(errorLogPrefix, e);
   }
@@ -286,10 +268,7 @@ async function dispatchStationPassed(params: {
 async function runSilenceGateAndDispatch(params: {
   source: 'fg' | 'fg-arvlcd';
   candidateStation: Station;
-  capturedRoute: Route;
   capturedDestinationId: string;
-  capturedDestinationName: string;
-  notificationSource: NotificationSource | undefined;
   isCancelled: () => boolean;
   errorLogPrefix: string;
   dismissSilence: import('../utils/dismissSilenceStorage').DismissSilenceState | null;
@@ -330,10 +309,7 @@ async function runSilenceGateAndDispatch(params: {
   await dispatchStationPassed({
     source: params.source,
     candidateStation: params.candidateStation,
-    capturedRoute: params.capturedRoute,
     capturedDestinationId: params.capturedDestinationId,
-    capturedDestinationName: params.capturedDestinationName,
-    notificationSource: params.notificationSource,
     isCancelled: params.isCancelled,
     errorLogPrefix: params.errorLogPrefix,
   });
@@ -1422,10 +1398,7 @@ export function useStationAlarm({
         await runSilenceGateAndDispatch({
           source: 'fg',
           candidateStation,
-          capturedRoute,
           capturedDestinationId,
-          capturedDestinationName,
-          notificationSource,
           isCancelled: () => cancelled,
           errorLogPrefix: '역 통과 알림 실패:',
           dismissSilence,
@@ -1578,10 +1551,7 @@ export function useStationAlarm({
       await runSilenceGateAndDispatch({
         source: 'fg-arvlcd',
         candidateStation,
-        capturedRoute,
         capturedDestinationId,
-        capturedDestinationName,
-        notificationSource,
         isCancelled: () => cancelled,
         errorLogPrefix: 'FG arvlCd fast-path 알림 실패:',
         dismissSilence,
@@ -1663,10 +1633,7 @@ export function useStationAlarm({
       await runSilenceGateAndDispatch({
         source: 'fg',
         candidateStation,
-        capturedRoute,
         capturedDestinationId,
-        capturedDestinationName,
-        notificationSource,
         isCancelled: () => cancelled,
         errorLogPrefix: 'subsurface station-passed 알림 실패:',
         dismissSilence,

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -38,7 +38,6 @@ const mockLogSilentPushTripEndedReceived = jest.fn();
 const mockLogSilentPushFired = jest.fn();
 const mockLogSilentPushSkipped = jest.fn();
 const mockLogCrossTripMirrorSkip = jest.fn();
-const mockLogSuppressedChannelAgnosticDedup = jest.fn();
 const mockLogBoardingPromptFired = jest.fn();
 const mockLogSleepTransferAlarmFired = jest.fn();
 const mockFlushAlarmLog = jest.fn().mockResolvedValue(undefined);
@@ -51,8 +50,6 @@ jest.mock('../../utils/alarmLog', () => ({
   logSilentPushFired: (...args: unknown[]) => mockLogSilentPushFired(...args),
   logSilentPushSkipped: (...args: unknown[]) => mockLogSilentPushSkipped(...args),
   logCrossTripMirrorSkip: (...args: unknown[]) => mockLogCrossTripMirrorSkip(...args),
-  logSuppressedChannelAgnosticDedup: (...args: unknown[]) =>
-    mockLogSuppressedChannelAgnosticDedup(...args),
   logBoardingPromptFired: (...args: unknown[]) => mockLogBoardingPromptFired(...args),
   logSleepTransferAlarmFired: (...args: unknown[]) => mockLogSleepTransferAlarmFired(...args),
   flushAlarmLog: () => mockFlushAlarmLog(),
@@ -62,16 +59,6 @@ jest.mock('../../utils/alarmLog', () => ({
 const mockVibrateAlarm = jest.fn();
 jest.mock('../../utils/alarmSound', () => ({
   vibrateAlarm: (...args: unknown[]) => mockVibrateAlarm(...args),
-}));
-
-// #1901/#1900 (RC-7/RC-10a) — channel-agnostic 8분 backstop. silent push fire 직전 gate +
-// fire 직후 markStationFired. FG fireAndLog / stationPipeline과 lastFire Map 공유.
-const mockIsAnyChannelRecentlyFired = jest.fn<boolean, unknown[]>(() => false);
-const mockMarkStationFired = jest.fn<void, unknown[]>();
-jest.mock('../../utils/crossCategoryStationDedup', () => ({
-  isAnyChannelRecentlyFired: (...args: unknown[]) =>
-    mockIsAnyChannelRecentlyFired(...args),
-  markStationFired: (...args: unknown[]) => mockMarkStationFired(...args),
 }));
 
 // #868 — trip-ended payload 수신 시 trip-bound storage cleanup.
@@ -119,32 +106,9 @@ jest.mock('../../../debug/utils/triggerTripGroundTruthPrompt', () => ({
     mockTriggerTripGroundTruthPrompt(...args),
 }));
 
-const mockCheckGate = jest.fn();
-jest.mock('../../utils/silentPushLocationGate', () => ({
-  checkSilentPushLocationGate: (...args: unknown[]) => mockCheckGate(...args),
-}));
-
-// #1307 — BG에서 stale 되는 로컬 subsurface stamp. 기본 false(미지하).
-const mockGetSubsurfaceState = jest.fn();
-jest.mock('../../../../shared/utils/subsurfaceState', () => ({
-  getSubsurfaceState: (...args: unknown[]) => mockGetSubsurfaceState(...args),
-}));
-
-const mockGetFiredAlarms = jest.fn();
-const mockSetFiredAlarms = jest.fn();
-jest.mock('../../utils/notificationState', () => ({
-  getFiredAlarms: (...args: unknown[]) => mockGetFiredAlarms(...args),
-  setFiredAlarms: (...args: unknown[]) => mockSetFiredAlarms(...args),
-}));
-
-const mockBuildAlarmContent = jest.fn((event: { stationName: string; type: string; phaseId: string }, _source?: string) => ({
-  title: `[${event.type}/${event.phaseId}]`,
-  body: `${event.stationName} 알람`,
-}));
 // #1323 — trip 종료 user-facing surface. mock으로 호출 인자/횟수만 검증.
 const mockSendTripEndedNotification = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../utils/stationNotification', () => ({
-  buildAlarmContent: (...args: unknown[]) => mockBuildAlarmContent(...(args as Parameters<typeof mockBuildAlarmContent>)),
   sendTripEndedNotification: (...args: unknown[]) => mockSendTripEndedNotification(...args),
 }));
 
@@ -190,12 +154,6 @@ jest.mock('../../../../shared/utils/logger', () => ({
 const mockSendPushAck = jest.fn();
 jest.mock('../../api/alarmBackend', () => ({
   sendPushAck: (...args: unknown[]) => mockSendPushAck(...args),
-}));
-
-// #728 — motionActivity 신호. 기본 false (=== "stationary 아님"), 특정 테스트에서만 true로 override.
-const mockGetMotionStationary = jest.fn(() => false);
-jest.mock('../../../nearest-station/utils/motionActivity', () => ({
-  getCurrentMotionStationary: () => mockGetMotionStationary(),
 }));
 
 const mockGetBoardingLock = jest.fn();
@@ -251,20 +209,6 @@ const mockCancelTbaByStationPhase = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../utils/tripBoundScheduler', () => ({
   rescheduleTripBoundAlarm: (...args: unknown[]) => mockRescheduleTripBoundAlarm(...args),
   cancelTbaByStationPhase: (...args: unknown[]) => mockCancelTbaByStationPhase(...args),
-}));
-
-const mockGetDismissSilence = jest.fn();
-const mockClearDismissSilence = jest.fn();
-jest.mock('../../utils/dismissSilenceStorage', () => ({
-  getDismissSilence: (...args: unknown[]) => mockGetDismissSilence(...args),
-  clearDismissSilence: (...args: unknown[]) => mockClearDismissSilence(...args),
-}));
-
-const mockFindStationByNameAndLine = jest.fn();
-const mockFindStationByName = jest.fn();
-jest.mock('../../../../shared/utils/stationLookup', () => ({
-  findStationByNameAndLine: (...args: unknown[]) => mockFindStationByNameAndLine(...args),
-  findStationByName: (...args: unknown[]) => mockFindStationByName(...args),
 }));
 
 const mockAddDomainBreadcrumb = jest.fn();
@@ -391,18 +335,9 @@ function bgTaskData(fields: Record<string, unknown>) {
   };
 }
 
-const PASSING_GATE = {
-  pass: true,
-  distanceM: 150,
-  thresholdM: 800,
-  locationSource: 'cache' as const,
-  locationAgeMs: 10_000,
-};
-
 describe('silentPushTask', () => {
-  // #816 C — 기본 lock을 부여해 기존 fire 테스트가 lockless 가드(lock null + non-intermediate 차단)에
-  // 막히지 않도록 한다. lockless 분기는 별도 describe에서 lock=null로 명시 override해 검증.
-  // line 가드는 lookup 반환값이 두 함수 모두 null이면 graceful pass (#707 — stations.json miss 케이스).
+  // #2064 (Phase 1-device) — reschedule의 applyRescheduleBl(#698)만 boardingLock을 여전히 읽는다.
+  // fire-path line 가드(#707)는 제거됐지만 reschedule bl 채널의 trainCode 매칭에는 lock이 필요.
   const defaultBoardingLock = {
     destinationId: '0228',
     trainCode: 'T-default',
@@ -415,24 +350,13 @@ describe('silentPushTask', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockScheduleNotificationAsync.mockResolvedValue('id');
-    mockCheckGate.mockResolvedValue(PASSING_GATE);
-    mockGetSubsurfaceState.mockResolvedValue(false);
-    mockGetFiredAlarms.mockResolvedValue(new Set<string>());
-    mockSetFiredAlarms.mockResolvedValue(undefined);
     (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
       if (key === DESTINATION_KEY) return JSON.stringify(destStation);
       if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
       return null;
     });
     mockSendPushAck.mockResolvedValue({ ok: true });
-    // 기본: lock 활성. lockless 가드를 우회하려면 lock 부여가 필요(stations.json 미존재 가정).
     mockGetBoardingLock.mockResolvedValue(defaultBoardingLock);
-    // 기본 lookup 모두 null → line 가드는 graceful pass(stations.json 어디에도 없음 가정).
-    mockFindStationByNameAndLine.mockReturnValue(null);
-    mockFindStationByName.mockReturnValue(null);
-    // #746 — 기본 silence 없음.
-    mockGetDismissSilence.mockResolvedValue(null);
-    mockClearDismissSilence.mockResolvedValue(undefined);
     // #919 — recall trigger 기본 graceful skip.
     mockTriggerTripEndRecall.mockResolvedValue({ uploaded: false });
     // #698 — 기본 graceful: 1건 cancel + 1건 schedule. 개별 테스트에서 override.
@@ -1501,16 +1425,14 @@ describe('silentPushTask', () => {
   });
 
   describe('handleSilentPush', () => {
-    it('error 있으면 즉시 종료 (gate 호출 안 됨)', async () => {
+    it('error 있으면 즉시 종료', async () => {
       await handleSilentPush({ error: { message: 'boom' } });
-      expect(mockCheckGate).not.toHaveBeenCalled();
       expect(mockLogSilentPushReceived).not.toHaveBeenCalled();
     });
 
     it('payload 없으면 skip', async () => {
       await handleSilentPush({ data: undefined });
       expect(mockLogSilentPushReceived).not.toHaveBeenCalled();
-      expect(mockCheckGate).not.toHaveBeenCalled();
     });
 
     it('invalid payload면 skip', async () => {
@@ -1590,8 +1512,10 @@ describe('silentPushTask', () => {
             lockReleasedReason: 'transfer',
           }),
         );
-        // gate 평가까지 도달 = 본 처리 흐름 차단되지 않음.
-        expect(mockCheckGate).toHaveBeenCalled();
+        // #2064 — releaseLock throw 이후에도 no-op skip 경로까지 도달 = 본 처리 흐름 차단되지 않음.
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'legacy-station-kind-ignored' }),
+        );
       });
     });
 
@@ -1603,612 +1527,69 @@ describe('silentPushTask', () => {
       expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
         expect.objectContaining({ reason: 'payload-missing-kind' }),
       );
-      expect(mockCheckGate).not.toHaveBeenCalled();
       expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
     });
 
-    it('게이트 통과 시 destination 즉시 발사 + fired 로그 + FIRED_ALARMS 갱신', async () => {
-      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-
-      expect(mockCheckGate).toHaveBeenCalledWith({
-        stationName: '강남',
-        kind: 'destination',
-        phase: 'imminent',
-        isLockless: false,
-        payloadHopIndex: undefined,
-        subsurface: false,
-        occupiedLine: undefined,
-        // #1365 — lock 활성 시 lock.boardingLine을 estimatorLine으로 전달.
-        estimatorLine: '2',
-      });
-      expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
-      const call = mockScheduleNotificationAsync.mock.calls[0][0];
-      expect(call.trigger).toBeNull();
-      expect(call.content.body).toContain('강남');
-      expect(mockLogSilentPushFired).toHaveBeenCalledWith(
-        expect.objectContaining({
+    // #2064 (Phase 1-device) — 매역 알림 backend visible push 단일 채널 전환.
+    // transfer/destination/intermediate kind는 device가 더 이상 로컬 알림을 발사하지 않는다
+    // (fireWithGate 전체 삭제 — line 가드/lockless/SSoT 게이트/location 게이트/movement 게이트/
+    // motion-stationary 게이트/dismiss-silence 게이트/FIRED_ALARMS dedup/channel-agnostic dedup
+    // 전부 제거). 수신 자체(logSilentPushReceived)와 상태 sync(lockReleasedReason/LA/widget)는
+    // 그대로 동작 — no-op이지 early-return이 아니다.
+    describe('#2064 (Phase 1-device) — legacy station kind no-op', () => {
+      it.each<['transfer' | 'destination' | 'intermediate', string]>([
+        ['transfer', 'transfer'],
+        ['destination', 'destination'],
+        ['intermediate', 'station-passed'],
+      ])('kind=%s → scheduleNotificationAsync 미호출 + logSilentPushSkipped(kind=%s, reason=legacy-station-kind-ignored)', async (kind, loggedKind) => {
+        await handleSilentPush(
+          payload({ kind, phase: 'imminent', nextWaypoint: '강남', pushId: `p-${kind}` }),
+        );
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith({
           stationName: '강남',
-          kind: 'destination',
+          kind: loggedKind,
           phaseId: 'imminent',
-          distanceM: 150,
-          thresholdM: 800,
-          locationSource: 'cache',
-          locationAgeMs: 10_000,
-        }),
-      );
-      expect(mockSetFiredAlarms).toHaveBeenCalledTimes(1);
-      const [, savedSet] = mockSetFiredAlarms.mock.calls[0];
-      expect(Array.from(savedSet as Set<string>)).toEqual(['imminent:강남']);
-    });
-
-    it('alarm 경로(destination/transfer)는 buildAlarmContent에 positionTrain source 전달 (#327)', async () => {
-      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-      expect(mockBuildAlarmContent).toHaveBeenCalledWith(
-        expect.objectContaining({ phaseId: 'imminent', type: 'destination' }),
-        'positionTrain',
-      );
-    });
-
-    it('intermediate는 i18n key로 본문 생성 + FIRED_ALARMS dedup 안 씀', async () => {
-      await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent', nextWaypoint: '중곡' }));
-
-      const call = mockScheduleNotificationAsync.mock.calls[0][0];
-      expect(call.content.title).toBe('route.intermediatePassedTitle');
-      // positionTrain은 #327 UX 정책상 자백 대상이 아니라 suffix 미부착.
-      expect(call.content.body).toBe('route.intermediatePassedBody:중곡');
-      expect(mockGetFiredAlarms).not.toHaveBeenCalled();
-      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
-      expect(mockLogSilentPushFired).toHaveBeenCalledWith(
-        expect.objectContaining({ kind: 'station-passed' }),
-      );
-    });
-
-    it('intermediate가 게이트 fail이면 skip 적재 kind=station-passed', async () => {
-      mockCheckGate.mockResolvedValue({ pass: false, reason: 'out-of-range' });
-      await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent', nextWaypoint: '중곡' }));
-      expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-        expect.objectContaining({ kind: 'station-passed', reason: 'gate-out-of-range' }),
-      );
-    });
-
-    it('게이트 fail(out-of-range)이면 skip 적재 + 발사 안 함', async () => {
-      mockCheckGate.mockResolvedValue({
-        pass: false,
-        reason: 'out-of-range',
-        distanceM: 5_000,
-        thresholdM: 400,
-        locationSource: 'cache',
-        locationAgeMs: 5_000,
+          reason: 'legacy-station-kind-ignored',
+        });
       });
 
-      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-
-      expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-      expect(mockLogSilentPushFired).not.toHaveBeenCalled();
-      expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-        expect.objectContaining({
-          reason: 'gate-out-of-range',
-          distanceM: 5_000,
-          thresholdM: 400,
-        }),
-      );
-      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
-    });
-
-    it.each([
-      ['unknown-station', 'gate-unknown-station'],
-      ['no-location', 'gate-no-location'],
-      ['stale-location', 'gate-stale-location'],
-      ['out-of-range', 'gate-out-of-range'],
-      // #1365 — line-mismatch는 환승역 line cross-validation 실패로 차단된 케이스.
-      ['line-mismatch', 'gate-line-mismatch'],
-    ])('게이트 reason=%s → logSkipped reason=%s', async (gateReason, logReason) => {
-      mockCheckGate.mockResolvedValue({ pass: false, reason: gateReason });
-      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-      expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-        expect.objectContaining({ reason: logReason }),
-      );
-    });
-
-    it('FIRED_ALARMS에 이미 같은 키 있으면 발사 안 함 (dedup, GPS 발화와 키 공유)', async () => {
-      mockGetFiredAlarms.mockResolvedValue(new Set(['imminent:강남']));
-      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-      expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-      expect(mockSetFiredAlarms).not.toHaveBeenCalled();
-      expect(mockLogSilentPushFired).not.toHaveBeenCalled();
-    });
-
-    it('destination AsyncStorage 없으면 dedup 건너뛰고 발사 (보수적 진행)', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
-      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-      expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
-      expect(mockGetFiredAlarms).not.toHaveBeenCalled();
-    });
-
-    it('destination JSON 손상 시 dedup 건너뛰고 발사', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue('not-json{');
-      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-      expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
-      expect(mockGetFiredAlarms).not.toHaveBeenCalled();
-    });
-
-    it('destination에 id 없으면 dedup 건너뛰고 발사', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify({ name: 'x' }));
-      await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-      expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
-      expect(mockGetFiredAlarms).not.toHaveBeenCalled();
-    });
-
-    it('scheduleNotificationAsync throw 시 graceful (전체 throw 안 함)', async () => {
-      mockScheduleNotificationAsync.mockRejectedValue(new Error('boom'));
-      await expect(
-        handleSilentPush(payload({ kind: 'destination', phase: 'imminent' })),
-      ).resolves.toBeUndefined();
-    });
-
-    it('transfer + early — 기존 사전예약 호출(scheduleAlarmsForRoute) 없음', async () => {
-      await handleSilentPush(payload({ kind: 'transfer', phase: 'early' }));
-      // 발사는 됨
-      expect(mockScheduleNotificationAsync).toHaveBeenCalled();
-      // 사전예약은 import도 안 함 — 호출 검증은 import 부재로 충분하나, 추가 안전망:
-      // alarmScheduler 모듈을 jest.mock하지 않았기 때문에 호출 시 ReferenceError가 났을 것.
-    });
-
-    describe('#707 BoardingLock line 가드', () => {
-      const lockOnLine7 = {
-        destinationId: '0228',
-        trainCode: 'T-7',
-        boardingStationId: 'station-on-7',
-        boardingLine: '7' as const,
-        boardedAt: 1_700_000_000_000,
-        expectedDurationMs: 600_000,
-      };
-
-      it('lock 활성 + nextWaypoint가 lock.boardingLine에 정차 안 함 → skip + ack(lock-line-mismatch)', async () => {
-        mockGetBoardingLock.mockResolvedValue(lockOnLine7);
-        // line 7에는 없음, 다른 line에는 존재 → 라인 mismatch.
-        mockFindStationByNameAndLine.mockReturnValue(null);
-        mockFindStationByName.mockReturnValue({ id: 'other-line-stop', name: '강남', line: '2' });
-
+      it('pushId + apnsToken 있으면 ackOutcome(skipped, legacy-station-kind-ignored) 전송', async () => {
         await handleSilentPush(
-          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-mismatch' }),
+          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-legacy' }),
         );
-
-        expect(mockFindStationByNameAndLine).toHaveBeenCalledWith('강남', '7');
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockLogSilentPushFired).not.toHaveBeenCalled();
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'lock-line-mismatch', kind: 'destination' }),
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          ackCall('p-legacy', 'skipped', 'legacy-station-kind-ignored'),
         );
-        expect(mockSendPushAck).toHaveBeenCalledWith({
-          pushId: 'p-mismatch',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'skipped',
-          reason: 'lock-line-mismatch',
-          permissionMode: 'always',
-        });
       });
 
-      it('lock 활성 + nextWaypoint가 lock.boardingLine에 정차(환승역 양쪽 호선 stop 존재) → 통과 후 발사', async () => {
-        mockGetBoardingLock.mockResolvedValue(lockOnLine7);
-        // line 7 stop이 존재 → 환승역에서 line 7로도 정차하는 정상 케이스(transfer 등).
-        mockFindStationByNameAndLine.mockReturnValue({
-          id: 'stop-on-7',
-          name: '강남',
-          line: '7',
-        });
-
+      it('logSilentPushReceived는 no-op 이전에 그대로 적재 (수신 자체는 유지)', async () => {
         await handleSilentPush(payload({ kind: 'transfer', phase: 'early' }));
-
-        expect(mockFindStationByNameAndLine).toHaveBeenCalledWith('강남', '7');
-        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
-        expect(mockLogSilentPushFired).toHaveBeenCalled();
+        expect(mockLogSilentPushReceived).toHaveBeenCalledTimes(1);
       });
 
-      it('lock 활성 + nextWaypoint가 stations.json 어디에도 없으면 line 가드는 통과시키고 일반 게이트가 unknown-station으로 처리', async () => {
-        mockGetBoardingLock.mockResolvedValue(lockOnLine7);
-        mockFindStationByNameAndLine.mockReturnValue(null);
-        mockFindStationByName.mockReturnValue(null);
-        // 일반 게이트가 unknown-station 반환 가정.
-        mockCheckGate.mockResolvedValue({ pass: false, reason: 'unknown-station' });
-
-        await handleSilentPush(
-          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-unknown' }),
-        );
-
-        // line 가드의 skip 사유가 아닌, 기존 게이트 사유로 분류돼야 한다.
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'gate-unknown-station' }),
-        );
-        expect(mockLogSilentPushSkipped).not.toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'lock-line-mismatch' }),
-        );
-      });
-
-      it('lock 없음 + intermediate → line 가드 skip + lockless-opt-out (#1810 paradigm shift)', async () => {
-        mockGetBoardingLock.mockResolvedValue(null);
+      it('finally 블록의 LA/widget refresh는 no-op 경로에서도 그대로 호출', async () => {
         await handleSilentPush(payload({ kind: 'intermediate', phase: 'imminent' }));
-        expect(mockFindStationByNameAndLine).not.toHaveBeenCalled();
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'lockless-opt-out' }),
-        );
+        expect(mockRefreshLa).toHaveBeenCalledTimes(1);
+        expect(mockUpdateWidget).toHaveBeenCalledTimes(1);
       });
 
-      it('intermediate kind도 lock line mismatch 시 station-passed로 skip 적재', async () => {
-        mockGetBoardingLock.mockResolvedValue(lockOnLine7);
-        mockFindStationByNameAndLine.mockReturnValue(null);
-        mockFindStationByName.mockReturnValue({ id: 'x', name: '중곡', line: '5' });
-
-        await handleSilentPush(
-          payload({ kind: 'intermediate', phase: 'imminent', nextWaypoint: '중곡' }),
-        );
-
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ kind: 'station-passed', reason: 'lock-line-mismatch' }),
-        );
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-      });
-    });
-
-    // #1810 — paradigm shift Phase 1+2: lockless 분기는 항상 skip
-    describe('#1810 — lockless 분기 (lock 없음, 항상 skip)', () => {
-      type SkipCase = {
-        name: string;
-        kind: 'destination' | 'transfer' | 'intermediate';
-        pushId?: string;
-      };
-
-      const skipCases: SkipCase[] = [
-        { name: 'intermediate', kind: 'intermediate', pushId: 'p-int' },
-        { name: 'transfer', kind: 'transfer', pushId: 'p-tx' },
-        { name: 'destination', kind: 'destination', pushId: 'p-dst' },
-      ];
-
-      it.each(skipCases)('lock 없음 + $name → lockless-opt-out (#1810)', async ({ kind, pushId }) => {
-        mockGetBoardingLock.mockResolvedValue(null);
-        await handleSilentPush(payload({ kind, phase: 'imminent', ...(pushId ? { pushId } : {}) }));
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'lockless-opt-out', kind: 'station-passed' }),
-        );
-        if (pushId) {
-          expect(mockSendPushAck).toHaveBeenCalledWith({
-            pushId,
-            token: DEFAULT_APNS_TOKEN,
-            outcome: 'skipped',
-            reason: 'lockless-opt-out',
-            permissionMode: 'always',
-          });
-        }
-      });
-    });
-
-    // #1322 — 로컬 lock 없이 payload.boardingLine(self-describing push)으로 line 가드 수행.
-    // 지하 auto-lock hydration window에서 backend lock-path push(transfer/destination)를 발사.
-    describe('#1322 — self-describing push (lock 없음 + payload.boardingLine)', () => {
-      beforeEach(() => {
-        mockGetBoardingLock.mockResolvedValue(null);
-      });
-
-      it('lock 없음 + payload.boardingLine에 정차하는 transfer → line 가드 통과 후 발사', async () => {
-        // payload.boardingLine='7'에 nextWaypoint가 정차 → 정상 lock-path fire.
-        mockFindStationByNameAndLine.mockReturnValue({ id: 'stop-on-7', name: '강남', line: '7' });
-
-        await handleSilentPush(
-          payload({ kind: 'transfer', phase: 'imminent', boardingLine: '7', pushId: 'p-self' }),
-        );
-
-        expect(mockFindStationByNameAndLine).toHaveBeenCalledWith('강남', '7');
-        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
-        expect(mockLogSilentPushFired).toHaveBeenCalled();
-      });
-
-      it('lock 없음 + payload.boardingLine line-mismatch → skip + ack(lock-line-mismatch)', async () => {
-        // line 7에는 없고 다른 line에만 존재 → mismatch.
-        mockFindStationByNameAndLine.mockReturnValue(null);
-        mockFindStationByName.mockReturnValue({ id: 'other', name: '강남', line: '2' });
-
-        await handleSilentPush(
-          payload({ kind: 'destination', phase: 'imminent', boardingLine: '7', pushId: 'p-mm' }),
-        );
-
-        expect(mockFindStationByNameAndLine).toHaveBeenCalledWith('강남', '7');
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'lock-line-mismatch', kind: 'destination' }),
-        );
-        expect(mockSendPushAck).toHaveBeenCalledWith({
-          pushId: 'p-mm',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'skipped',
-          reason: 'lock-line-mismatch',
-          permissionMode: 'always',
-        });
-      });
-
-      it('lock 없음 + payload.boardingLine + nextWaypoint가 stations.json 부재 → 가드 통과 후 발사', async () => {
-        // 양쪽 lookup 모두 null → graceful pass(일반 게이트로 위임), 게이트 통과 가정 → 발사.
-        mockFindStationByNameAndLine.mockReturnValue(null);
-        mockFindStationByName.mockReturnValue(null);
-
-        await handleSilentPush(payload({ kind: 'transfer', phase: 'imminent', boardingLine: '7' }));
-
-        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
-        expect(mockLogSilentPushFired).toHaveBeenCalled();
-      });
-
-      it('lock 없음 + payload.boardingLine 통과 시 발사 (#1322 lock-path fire)', async () => {
-        // backend가 lock을 보유한 lock-path fire이므로 lockless skip 없이 발사.
-        mockFindStationByNameAndLine.mockReturnValue({ id: 'stop-on-7', name: '강남', line: '7' });
-
-        await handleSilentPush(payload({ kind: 'transfer', phase: 'imminent', boardingLine: '7' }));
-
-        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
-        expect(mockLogSilentPushFired).toHaveBeenCalled();
-      });
-
-      it('lock 없음 + payload.boardingLine 부재 → lockless-opt-out skip (#1810)', async () => {
-        // #1810 — boardingLine 없으면 lockless 분기로 빠져 항상 skip.
-        await handleSilentPush(
-          payload({ kind: 'transfer', phase: 'imminent', pushId: 'p-nolock-noline' }),
-        );
-
-        expect(mockFindStationByNameAndLine).not.toHaveBeenCalled();
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'lockless-opt-out' }),
-        );
-      });
-    });
-
-    // #1399 — 좀비 알림 cleanup: tripToken stamp + ACTIVE_TRIP_KEY mismatch drop.
-    describe('#1399 — tripToken mismatch 가드 (좀비 알림 cleanup)', () => {
-      it('payload.tripToken === ACTIVE_TRIP_KEY → 가드 통과 후 발사', async () => {
-        setAsyncStorageMap({ [ACTIVE_TRIP_KEY]: 'active-token-123' });
+      it('lockReleasedReason sync는 no-op 이전에 그대로 수행', async () => {
         await handleSilentPush(
           payload({
             kind: 'destination',
             phase: 'imminent',
-            tripToken: 'active-token-123',
-            pushId: 'p-match',
+            lockReleasedReason: 'transfer',
           }),
         );
-        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
-        expect(mockLogSilentPushFired).toHaveBeenCalled();
-      });
-
-      it('payload.tripToken 다른 token → trip-token-mismatch skip', async () => {
-        setAsyncStorageMap({ [ACTIVE_TRIP_KEY]: 'active-token-NEW' });
-        await handleSilentPush(
-          payload({
-            kind: 'intermediate',
-            phase: 'imminent',
-            tripToken: 'stale-token-OLD',
-            pushId: 'p-stale',
-          }),
-        );
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockStoreReleaseLock).toHaveBeenCalledWith('transfer');
         expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'trip-token-mismatch', kind: 'station-passed' }),
+          expect.objectContaining({ reason: 'legacy-station-kind-ignored' }),
         );
-        expect(mockSendPushAck).toHaveBeenCalledWith(
-          ackCall('p-stale', 'skipped', 'trip-token-mismatch'),
-        );
-      });
-
-      it('ACTIVE_TRIP_KEY null (이미 cleanup됨) + payload.tripToken 있음 → drop', async () => {
-        setAsyncStorageMap({ [ACTIVE_TRIP_KEY]: null });
-        await handleSilentPush(
-          payload({
-            kind: 'transfer',
-            phase: 'imminent',
-            tripToken: 'orphan-token',
-            pushId: 'p-orphan',
-          }),
-        );
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'trip-token-mismatch', kind: 'transfer' }),
-        );
-      });
-
-      it('payload.tripToken 미전달 (구 backend) → 가드 skip, 발사 진행', async () => {
-        setAsyncStorageMap({ [ACTIVE_TRIP_KEY]: 'active-token-x' });
-        // payload에 tripToken 미전달 → undefined → 가드 자연 skip.
-        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
       });
     });
 
     describe('#568 P2b — push ACK', () => {
-      it('fire 성공 시 sendPushAck(outcome=fired) 호출, reason 없음', async () => {
-        await handleSilentPush(
-          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-fire' }),
-        );
-        expect(mockSendPushAck).toHaveBeenCalledWith(ackCall('p-fire', 'fired'));
-      });
-
-      it('게이트 fail 시 sendPushAck(outcome=skipped, reason=게이트사유)', async () => {
-        mockCheckGate.mockResolvedValue({
-          pass: false,
-          reason: 'out-of-range',
-          distanceM: 5_000,
-          thresholdM: 400,
-        });
-        await handleSilentPush(
-          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-gate' }),
-        );
-        expect(mockSendPushAck).toHaveBeenCalledWith(
-          ackCall('p-gate', 'skipped', 'gate-out-of-range'),
-        );
-      });
-
-      it('FIRED_ALARMS dedup 시 sendPushAck(outcome=skipped, reason=dedup-already-fired)', async () => {
-        mockGetFiredAlarms.mockResolvedValue(new Set(['imminent:강남']));
-        await handleSilentPush(
-          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-dedup' }),
-        );
-        expect(mockSendPushAck).toHaveBeenCalledWith(
-          ackCall('p-dedup', 'skipped', 'dedup-already-fired'),
-        );
-      });
-
-      // #1367 — hopIndex>=1이면 alarmKey가 `phase:station#n` 형식이라 default(0) dedup과 collide하지 않는다.
-      it('#1367 hopIndex>=1 silent push는 default dedup key(`phase:station`)와 collide하지 않음 — 발사 진행', async () => {
-        mockGetFiredAlarms.mockResolvedValue(new Set(['imminent:강남']));
-        await handleSilentPush(
-          payload({
-            kind: 'destination',
-            phase: 'imminent',
-            pushId: 'p-hop-1',
-            hopIndex: 1,
-          }),
-        );
-        expect(mockSendPushAck).toHaveBeenCalledWith({
-          pushId: 'p-hop-1',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'fired',
-          permissionMode: 'always',
-        });
-      });
-
-      // #1367 cross-channel — OS scheduled receiver가 hopIndex=2로 fire 후 fired set에 등록되어 있을 때
-      // 같은 hopIndex의 silent push가 도달하면 dedup 적중 (silent push + OS queue 통합 공간).
-      it('#1367 cross-channel — fired set에 `phase:station#n` 등록 시 같은 hopIndex silent push는 dedup', async () => {
-        mockGetFiredAlarms.mockResolvedValue(new Set(['imminent:강남#2']));
-        await handleSilentPush(
-          payload({
-            kind: 'destination',
-            phase: 'imminent',
-            pushId: 'p-cross-channel',
-            hopIndex: 2,
-          }),
-        );
-        expect(mockSendPushAck).toHaveBeenCalledWith({
-          pushId: 'p-cross-channel',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'skipped',
-          reason: 'dedup-already-fired',
-          permissionMode: 'always',
-        });
-      });
-
-      // #1901/#1900 (RC-7/RC-10a) — channel-agnostic 8분 backstop. FIRED_ALARMS dedup이 통과해도
-      // lastFire Map에 같은 station이 8분 안에 적재돼 있으면 silent push 발사 차단.
-      // backend가 같은 station-pass 1건에 silent state push + LA dirty update 2채널 발사 →
-      // device가 silent push로 같은 station을 2회 받는 회귀(2026-06-26 trip-3 동대문역사문화공원).
-      it('#1901/#1900 isAnyChannelRecentlyFired=true 시 silent push 발사 차단 + skipped ack', async () => {
-        mockGetFiredAlarms.mockResolvedValue(new Set()); // FIRED_ALARMS는 비어 있음
-        mockIsAnyChannelRecentlyFired.mockReturnValueOnce(true);
-        await handleSilentPush(
-          payload({
-            kind: 'destination',
-            phase: 'imminent',
-            pushId: 'p-channel-agnostic',
-          }),
-        );
-        expect(mockLogSuppressedChannelAgnosticDedup).toHaveBeenCalledWith({
-          source: 'silent-push-skipped',
-          stationName: '강남',
-          kind: 'destination',
-          phaseId: 'imminent',
-        });
-        expect(mockSendPushAck).toHaveBeenCalledWith(
-          ackCall('p-channel-agnostic', 'skipped', 'dedup-already-fired'),
-        );
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        // markStationFired는 fire 직후에만 호출 — skip 분기에서 호출 안 됨.
-        expect(mockMarkStationFired).not.toHaveBeenCalled();
-      });
-
-      // #1901/#1900 — intermediate(station-passed) 분기도 channel-agnostic gate 적용.
-      // FIRED_ALARMS dedup은 dedupKey=null이라 우회되지만 8분 backstop은 차단.
-      it('#1901/#1900 intermediate kind도 channel-agnostic gate로 차단됨', async () => {
-        mockGetFiredAlarms.mockResolvedValue(new Set());
-        mockIsAnyChannelRecentlyFired.mockReturnValueOnce(true);
-        await handleSilentPush(
-          payload({
-            kind: 'intermediate',
-            phase: 'imminent',
-            pushId: 'p-intermediate-agnostic',
-          }),
-        );
-        expect(mockLogSuppressedChannelAgnosticDedup).toHaveBeenCalledWith({
-          source: 'silent-push-skipped',
-          stationName: '강남',
-          kind: 'station-passed',
-          phaseId: 'imminent',
-        });
-        expect(mockSendPushAck).toHaveBeenCalledWith(
-          ackCall('p-intermediate-agnostic', 'skipped', 'dedup-already-fired'),
-        );
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockMarkStationFired).not.toHaveBeenCalled();
-      });
-
-      // #1901/#1900 — channel-agnostic dedup skip branch에서 pushId 미정의 케이스. addFiredPushId
-      // 조건부 호출의 falsy 분기 커버.
-      it('#1901/#1900 channel-agnostic skip + pushId 부재 시 addFiredPushId 미호출', async () => {
-        mockGetFiredAlarms.mockResolvedValue(new Set());
-        mockIsAnyChannelRecentlyFired.mockReturnValueOnce(true);
-        await handleSilentPush(
-          payload({
-            kind: 'destination',
-            phase: 'imminent',
-            // pushId 명시 안 함 — undefined.
-          }),
-        );
-        expect(mockLogSuppressedChannelAgnosticDedup).toHaveBeenCalled();
-        // pushId 부재라 addFiredPushId 미호출 검증.
-        expect(mockAddFiredPushId).not.toHaveBeenCalled();
-      });
-
-      // #1901/#1900 — fire 직후 markStationFired 호출 → FG fireAndLog / stationPipeline이 같은
-      // station 8분 backstop으로 cross-channel 중복 차단 (lastFire Map 공유).
-      it('#1901/#1900 fire 후 markStationFired 호출 (lastFire Map 갱신)', async () => {
-        mockGetFiredAlarms.mockResolvedValue(new Set());
-        mockIsAnyChannelRecentlyFired.mockReturnValueOnce(false);
-        await handleSilentPush(
-          payload({
-            kind: 'destination',
-            phase: 'imminent',
-            pushId: 'p-mark',
-          }),
-        );
-        // intermediate가 아닌 destination → category='destination'으로 mark. phaseId도 stamp.
-        expect(mockMarkStationFired).toHaveBeenCalledWith(
-          destStation.id,
-          '강남',
-          'destination',
-          expect.any(Number),
-          'imminent',
-        );
-        expect(mockSendPushAck).toHaveBeenCalledWith(
-          ackCall('p-mark', 'fired'),
-        );
-      });
-
-      // #1901/#1900 — intermediate fire는 'station-passed' category로 mark.
-      it('#1901/#1900 intermediate fire 후 markStationFired는 station-passed category로 호출', async () => {
-        mockGetFiredAlarms.mockResolvedValue(new Set());
-        mockIsAnyChannelRecentlyFired.mockReturnValueOnce(false);
-        await handleSilentPush(
-          payload({
-            kind: 'intermediate',
-            phase: 'imminent',
-            pushId: 'p-intermediate-mark',
-          }),
-        );
-        expect(mockMarkStationFired).toHaveBeenCalledWith(
-          destStation.id,
-          '강남',
-          'station-passed',
-          expect.any(Number),
-          'imminent',
-        );
-      });
-
       it('payload-missing-kind 시 sendPushAck(outcome=skipped, reason=payload-missing-kind)', async () => {
         await handleSilentPush({
           data: bgTaskData({
@@ -2249,7 +1630,10 @@ describe('silentPushTask', () => {
         await handleSilentPush(
           payload({ kind: 'destination', phase: 'imminent', pushId: 'p-throw' }),
         );
-        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
+        // apnsToken이 null로 fallback돼도 no-op skip 처리(로그 적재)는 그대로 진행.
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'legacy-station-kind-ignored' }),
+        );
         expect(mockSendPushAck).not.toHaveBeenCalled();
       });
 
@@ -2288,28 +1672,33 @@ describe('silentPushTask', () => {
         });
 
         it('resolvePermissionMode throw → permissionMode 누락(undefined), ack는 계속 전송', async () => {
-          // 모든 resolvePermissionMode 호출에서 throw (received + fired 양쪽 ack).
+          // 모든 resolvePermissionMode 호출에서 throw (received + skipped 양쪽 ack).
           mockGetForegroundPermissions.mockRejectedValue(new Error('location-api-fail'));
-          await handleSilentPush(
-            payload({ kind: 'destination', phase: 'imminent', pushId: 'p-throw-perm' }),
-          );
-          // fired ack가 전송됐는지 확인 — permissionMode는 undefined여야 한다.
-          const call = mockSendPushAck.mock.calls.find(
-            (c: unknown[]) =>
-              (c[0] as { pushId?: string }).pushId === 'p-throw-perm' &&
-              (c[0] as { outcome?: string }).outcome === 'fired',
-          );
-          expect(call).toBeDefined();
-          // permissionMode가 undefined이므로 sendPushAck payload에 포함되지 않는다.
-          expect((call![0] as Record<string, unknown>).permissionMode).toBeUndefined();
-          // 기본 mock 복원 (다른 테스트에 영향 없도록).
-          mockGetForegroundPermissions.mockResolvedValue({ status: 'granted' });
+          try {
+            await handleSilentPush(
+              payload({ kind: 'destination', phase: 'imminent', pushId: 'p-throw-perm' }),
+            );
+            // skipped(no-op) ack가 전송됐는지 확인 — permissionMode는 undefined여야 한다.
+            const call = mockSendPushAck.mock.calls.find(
+              (c: unknown[]) =>
+                (c[0] as { pushId?: string }).pushId === 'p-throw-perm' &&
+                (c[0] as { outcome?: string }).outcome === 'skipped',
+            );
+            expect(call).toBeDefined();
+            // permissionMode가 undefined이므로 sendPushAck payload에 포함되지 않는다.
+            expect((call![0] as Record<string, unknown>).permissionMode).toBeUndefined();
+          } finally {
+            // 기본 mock 복원 (다른 테스트에 영향 없도록) — assertion 실패로도 반드시 실행.
+            mockGetForegroundPermissions.mockResolvedValue({ status: 'granted' });
+          }
         });
       });
     });
 
     describe('#1370 L5 — silent push 도달 stamp (received outcome)', () => {
-      it('standard payload + pushId + apnsToken 모두 있으면 gate 평가 전 received ack 발사', async () => {
+      // #2064 — fire-with-gate가 제거돼 후속 outcome은 항상 skipped(legacy-station-kind-ignored)다.
+      // received ack가 그 이전에 먼저 발사된다는 순서 보장만 검증.
+      it('standard payload + pushId + apnsToken 모두 있으면 no-op 평가 전 received ack 발사', async () => {
         await handleSilentPush(
           payload({ kind: 'destination', phase: 'imminent', pushId: 'p-recv' }),
         );
@@ -2317,25 +1706,9 @@ describe('silentPushTask', () => {
         expect(mockSendPushAck).toHaveBeenCalledWith(
           expect.objectContaining(ackCall('p-recv', 'received')),
         );
-        // 후속 outcome(fired) ack도 그대로 발사 — 별개 호출.
-        expect(mockSendPushAck).toHaveBeenCalledWith(ackCall('p-recv', 'fired'));
-      });
-
-      it('게이트 fail로 outcome=skipped여도 received ack는 먼저 발사', async () => {
-        mockCheckGate.mockResolvedValue({
-          pass: false,
-          reason: 'out-of-range',
-          distanceM: 5_000,
-          thresholdM: 400,
-        });
-        await handleSilentPush(
-          payload({ kind: 'destination', phase: 'imminent', pushId: 'p-recv-skip' }),
-        );
+        // 후속 outcome(skipped) ack도 그대로 발사 — 별개 호출.
         expect(mockSendPushAck).toHaveBeenCalledWith(
-          expect.objectContaining(ackCall('p-recv-skip', 'received')),
-        );
-        expect(mockSendPushAck).toHaveBeenCalledWith(
-          ackCall('p-recv-skip', 'skipped', 'gate-out-of-range'),
+          ackCall('p-recv', 'skipped', 'legacy-station-kind-ignored'),
         );
       });
 
@@ -2473,257 +1846,13 @@ describe('silentPushTask', () => {
         await handleSilentPush(
           payload({ kind: 'destination', phase: 'imminent', pushId: 'p-fired-nobatt' }),
         );
-        const firedCall = mockSendPushAck.mock.calls.find(
+        const skippedCall = mockSendPushAck.mock.calls.find(
           (c: unknown[]) =>
             (c[0] as { pushId?: string }).pushId === 'p-fired-nobatt' &&
-            (c[0] as { outcome?: string }).outcome === 'fired',
+            (c[0] as { outcome?: string }).outcome === 'skipped',
         );
-        expect(firedCall).toBeDefined();
-        expect((firedCall![0] as { batteryState?: string }).batteryState).toBeUndefined();
-      });
-    });
-
-    describe('#727 정적 misfire 가드 (movement)', () => {
-      it('gate가 speed=0 노출하면 movement-static-speed로 skip + 발사 안 함', async () => {
-        mockCheckGate.mockResolvedValue({
-          ...PASSING_GATE,
-          speedMps: 0,
-          accuracyM: 30,
-        });
-
-        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockLogSilentPushFired).not.toHaveBeenCalled();
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({
-            reason: 'movement-static-speed',
-            stationName: '강남',
-            kind: 'destination',
-            phaseId: 'imminent',
-            distanceM: 150,
-            thresholdM: 800,
-          }),
-        );
-      });
-
-      it('gate가 accuracy=999 노출하면 movement-low-accuracy로 skip', async () => {
-        mockCheckGate.mockResolvedValue({
-          ...PASSING_GATE,
-          speedMps: 2,
-          accuracyM: 999,
-        });
-
-        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'movement-low-accuracy' }),
-        );
-      });
-
-      it('speed 미노출 + accuracy=999만 노출돼도 movement-low-accuracy로 skip', async () => {
-        // speedMps undefined → log line의 ?? '-' fallback 분기 커버
-        mockCheckGate.mockResolvedValue({
-          ...PASSING_GATE,
-          accuracyM: 999,
-        });
-
-        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'movement-low-accuracy' }),
-        );
-      });
-
-      it('movement skip은 pushId 있으면 ACK 전송', async () => {
-        mockCheckGate.mockResolvedValue({
-          ...PASSING_GATE,
-          speedMps: 0,
-        });
-
-        await handleSilentPush(
-          payload({ kind: 'destination', phase: 'imminent', pushId: 'movement-skip' }),
-        );
-
-        expect(mockSendPushAck).toHaveBeenCalledWith({
-          pushId: 'movement-skip',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'skipped',
-          reason: 'movement-static-speed',
-          permissionMode: 'always',
-        });
-      });
-
-      it('gate가 speed/accuracy 미노출(undefined)이면 movement 가드 통과해 정상 발사', async () => {
-        mockCheckGate.mockResolvedValue(PASSING_GATE); // speed/accuracy 없음
-
-        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-
-        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
-        expect(mockLogSilentPushFired).toHaveBeenCalled();
-      });
-
-      it('intermediate도 movement-static-speed 시 kind=station-passed로 매핑되어 skip', async () => {
-        mockCheckGate.mockResolvedValue({
-          ...PASSING_GATE,
-          speedMps: 0.1,
-        });
-
-        await handleSilentPush(
-          payload({ kind: 'intermediate', phase: 'imminent', nextWaypoint: '중곡' }),
-        );
-
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({
-            kind: 'station-passed',
-            reason: 'movement-static-speed',
-          }),
-        );
-      });
-    });
-
-    // #728 — CMMotionActivity motion=stationary가 BG silent push 발사도 차단.
-    // FG에서 useMotionActivity가 startUpdates를 호출했다면 native cache에 최신 activity가 있고,
-    // BG handleSilentPush 진입 시 getCurrentMotionStationary가 그 값을 보고한다.
-    describe('#728 motion-stationary 가드 (CMMotionActivity)', () => {
-      it('motionStationary=true + speed=0.69 (임계 우회) → movement-motion-stationary로 skip', async () => {
-        mockGetMotionStationary.mockReturnValue(true);
-        mockCheckGate.mockResolvedValue({
-          ...PASSING_GATE,
-          speedMps: 0.69, // STATIC_SPEED_THRESHOLD_MPS=0.5 우회
-          accuracyM: 30,
-        });
-
-        await handleSilentPush(
-          payload({ kind: 'destination', phase: 'imminent', pushId: 'motion-skip' }),
-        );
-
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockLogSilentPushFired).not.toHaveBeenCalled();
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({
-            reason: 'movement-motion-stationary',
-            stationName: '강남',
-            kind: 'destination',
-            phaseId: 'imminent',
-          }),
-        );
-        expect(mockSendPushAck).toHaveBeenCalledWith({
-          pushId: 'motion-skip',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'skipped',
-          reason: 'movement-motion-stationary',
-          permissionMode: 'always',
-        });
-      });
-
-      it('motionStationary=false (default) — 기존 speed/accuracy 가드만 동작', async () => {
-        // 명시적으로 false 설정 — speed/accuracy 정상이면 정상 발사
-        mockGetMotionStationary.mockReturnValue(false);
-        mockCheckGate.mockResolvedValue({
-          ...PASSING_GATE,
-          speedMps: 5,
-          accuracyM: 30,
-        });
-
-        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-
-        expect(mockScheduleNotificationAsync).toHaveBeenCalled();
-        expect(mockLogSilentPushFired).toHaveBeenCalled();
-      });
-
-      it('motionStationary=true는 speed 정상값보다 우선 — 차단', async () => {
-        mockGetMotionStationary.mockReturnValue(true);
-        mockCheckGate.mockResolvedValue({
-          ...PASSING_GATE,
-          speedMps: 5, // 명백한 이동 신호인데 motion=stationary
-          accuracyM: 30,
-        });
-
-        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'movement-motion-stationary' }),
-        );
-      });
-    });
-
-    // #1356 E1 — silent push suppress 분기에서 같은 station+phase의 사전 예약(tba: / bl:)도 cancel.
-    // backend는 정적/out-of-range를 인식해 다음 silent push를 발사하지 않지만, 이미 OS queue에 있는
-    // 사전 예약은 시간이 되면 자체 발사 → stale "다음 역" 알람. 단건 cancel(해당 station+phase만).
-    describe('#1356 E1 — suppress 시 같은 station 사전 예약 cancel', () => {
-      it('motion=stationary suppress 시 cancelTbaByStationPhase + cancelBlByStationPhase가 1회씩 호출된다', async () => {
-        mockGetMotionStationary.mockReturnValue(true);
-        mockCheckGate.mockResolvedValue({
-          ...PASSING_GATE,
-          speedMps: 0.69,
-          accuracyM: 30,
-        });
-
-        await handleSilentPush(
-          payload({ kind: 'destination', phase: 'imminent', pushId: 'motion-cancel' }),
-        );
-
-        expect(mockCancelTbaByStationPhase).toHaveBeenCalledTimes(1);
-        expect(mockCancelTbaByStationPhase).toHaveBeenCalledWith('강남', 'imminent');
-        expect(mockCancelBlByStationPhase).toHaveBeenCalledTimes(1);
-        expect(mockCancelBlByStationPhase).toHaveBeenCalledWith('강남', 'imminent');
-      });
-
-      it('gate-out-of-range suppress 시 cancelTbaByStationPhase + cancelBlByStationPhase가 1회씩 호출된다', async () => {
-        mockCheckGate.mockResolvedValue({
-          pass: false,
-          reason: 'out-of-range',
-          distanceM: 1500,
-          thresholdM: 800,
-          locationSource: 'cache' as const,
-          locationAgeMs: 10_000,
-        });
-
-        await handleSilentPush(
-          payload({ kind: 'destination', phase: 'early', pushId: 'gate-cancel' }),
-        );
-
-        expect(mockCancelTbaByStationPhase).toHaveBeenCalledTimes(1);
-        expect(mockCancelTbaByStationPhase).toHaveBeenCalledWith('강남', 'early');
-        expect(mockCancelBlByStationPhase).toHaveBeenCalledTimes(1);
-        expect(mockCancelBlByStationPhase).toHaveBeenCalledWith('강남', 'early');
-      });
-
-      it('valid silent push pass (정상 발사) 시 cancel은 호출되지 않는다 (회귀)', async () => {
-        mockGetMotionStationary.mockReturnValue(false);
-        mockCheckGate.mockResolvedValue({
-          ...PASSING_GATE,
-          speedMps: 5,
-          accuracyM: 30,
-        });
-
-        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-
-        expect(mockLogSilentPushFired).toHaveBeenCalled();
-        expect(mockCancelTbaByStationPhase).not.toHaveBeenCalled();
-        expect(mockCancelBlByStationPhase).not.toHaveBeenCalled();
-      });
-
-      it('line 가드 suppress(lock-line-mismatch) 등 다른 분기는 cancel 미호출 (out of scope 가드)', async () => {
-        // payload.boardingLine='3' 으로 lock(boardingLine='2') 노선과 mismatch.
-        // findStationByNameAndLine은 null, findStationByName은 어떤 station 반환.
-        mockFindStationByNameAndLine.mockReturnValue(null);
-        mockFindStationByName.mockReturnValue({ name: '강남', line: '3', lat: 37.5, lng: 127.0 });
-
-        await handleSilentPush(
-          payload({ kind: 'destination', phase: 'imminent', pushId: 'line-mismatch' }),
-        );
-
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'lock-line-mismatch' }),
-        );
-        // E1 cancel은 motion/gate suppress 분기만 적용. 다른 suppress는 변경 없음.
-        expect(mockCancelTbaByStationPhase).not.toHaveBeenCalled();
-        expect(mockCancelBlByStationPhase).not.toHaveBeenCalled();
+        expect(skippedCall).toBeDefined();
+        expect((skippedCall![0] as { batteryState?: string }).batteryState).toBeUndefined();
       });
     });
 
@@ -2756,7 +1885,6 @@ describe('silentPushTask', () => {
         expect(typeof arg.receivedAt).toBe('number');
         // standard 발사 경로는 호출되지 않아야 함.
         expect(mockLogSilentPushReceived).not.toHaveBeenCalled();
-        expect(mockCheckGate).not.toHaveBeenCalled();
         expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
         expect(mockLogSilentPushFired).not.toHaveBeenCalled();
         expect(mockLogSilentPushSkipped).not.toHaveBeenCalled();
@@ -3148,7 +2276,6 @@ describe('silentPushTask', () => {
         expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
         // standard 발사 경로는 호출되지 않아야 함.
         expect(mockLogSilentPushReceived).not.toHaveBeenCalled();
-        expect(mockCheckGate).not.toHaveBeenCalled();
         expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
         expect(mockLogSilentPushFired).not.toHaveBeenCalled();
         expect(mockLogSilentPushSkipped).not.toHaveBeenCalled();
@@ -3656,7 +2783,6 @@ describe('silentPushTask', () => {
         await handleSilentPush(boardingPromptPayload({ pushId: 'bp-1' }));
         expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
         // standard 발사 경로는 호출되지 않아야 함.
-        expect(mockCheckGate).not.toHaveBeenCalled();
         expect(mockLogSilentPushReceived).not.toHaveBeenCalled();
         expect(mockLogSilentPushFired).not.toHaveBeenCalled();
       });
@@ -3720,13 +2846,6 @@ describe('silentPushTask', () => {
         expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(2);
       });
 
-      it('gate/location 등 다른 mock은 호출 안 됨 (unconditional path)', async () => {
-        await handleSilentPush(boardingPromptPayload({ pushId: 'bp-1' }));
-        expect(mockCheckGate).not.toHaveBeenCalled();
-        expect(mockGetDismissSilence).not.toHaveBeenCalled();
-        expect(mockGetMotionStationary).not.toHaveBeenCalled();
-        expect(mockGetFiredAlarms).not.toHaveBeenCalled();
-      });
 
       it('pushId 있으면 ack(fired, boarding-prompt) 전송', async () => {
         await handleSilentPush(boardingPromptPayload({ pushId: 'bp-1' }));
@@ -3957,7 +3076,6 @@ describe('silentPushTask', () => {
         await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
         expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
         // standard 발사 경로는 호출되지 않아야 함.
-        expect(mockCheckGate).not.toHaveBeenCalled();
         expect(mockLogSilentPushReceived).not.toHaveBeenCalled();
         expect(mockLogSilentPushFired).not.toHaveBeenCalled();
       });
@@ -4075,14 +3193,6 @@ describe('silentPushTask', () => {
         expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(2);
       });
 
-      it('gate/location 등 다른 mock은 호출 안 됨 (unconditional path)', async () => {
-        setSleepMode(true);
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
-        expect(mockCheckGate).not.toHaveBeenCalled();
-        expect(mockGetDismissSilence).not.toHaveBeenCalled();
-        expect(mockGetMotionStationary).not.toHaveBeenCalled();
-        expect(mockGetFiredAlarms).not.toHaveBeenCalled();
-      });
 
       it('pushId 있으면 ack(fired, sleep-transfer-alarm) 전송', async () => {
         setSleepMode(true);
@@ -4174,62 +3284,6 @@ describe('silentPushTask', () => {
         setSleepMode(false);
         await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
         expect(mockRefreshLa).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    describe('#746 dismiss silence 게이트 (BG silent push)', () => {
-      it('silence 활성이면 발사 차단 + logSilentPushSkipped(reason=dismiss-silence) + ACK skip', async () => {
-        mockGetDismissSilence.mockResolvedValue({
-          sinceTs: Date.now(),
-          sinceLat: null,
-          sinceLng: null,
-        });
-        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent', pushId: 'p1' }));
-        expect(mockCheckGate).not.toHaveBeenCalled();
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({
-            reason: 'dismiss-silence',
-            stationName: '강남',
-            kind: 'destination',
-            phaseId: 'imminent',
-          }),
-        );
-        expect(mockSendPushAck).toHaveBeenCalledWith(
-          expect.objectContaining({ outcome: 'skipped', reason: 'dismiss-silence' }),
-        );
-      });
-
-      it('silence 만료 시 clear 호출 + 정상 발사 path로 진입(checkGate 호출)', async () => {
-        mockGetDismissSilence.mockResolvedValue({
-          sinceTs: Date.now() - 10 * 60_000,
-          sinceLat: null,
-          sinceLng: null,
-        });
-        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-        expect(mockClearDismissSilence).toHaveBeenCalledTimes(1);
-        expect(mockCheckGate).toHaveBeenCalled();
-      });
-
-      it('intermediate 카테고리도 silence가 차단(kind=station-passed로 log)', async () => {
-        mockGetDismissSilence.mockResolvedValue({
-          sinceTs: Date.now(),
-          sinceLat: null,
-          sinceLng: null,
-        });
-        await handleSilentPush(payload({ kind: 'intermediate', phase: 'early', pushId: 'p2' }));
-        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
-          expect.objectContaining({
-            reason: 'dismiss-silence',
-            kind: 'station-passed',
-          }),
-        );
-      });
-
-      it('silence state null이면 정상 path로 진입', async () => {
-        mockGetDismissSilence.mockResolvedValue(null);
-        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
-        expect(mockCheckGate).toHaveBeenCalled();
       });
     });
 
@@ -4379,30 +3433,16 @@ describe('silentPushTask', () => {
 
   describe('#900 Seam D — refreshLiveActivityFromBackgroundContext invocation', () => {
     // payload kind 전반에서 LA refresh가 정확히 1회 호출됨을 검증.
-    // 데이터 주도: 각 row가 (label, taskData, mock setup)을 정의해 동일 assertion 반복.
-    function lockMismatchPayload() {
-      mockFindStationByNameAndLine.mockReturnValueOnce(null);
-      mockFindStationByName.mockReturnValueOnce({} as never);
-      return payload({ kind: 'transfer' });
-    }
-    function gateSkipPayload() {
-      mockCheckGate.mockResolvedValueOnce({
-        pass: false,
-        reason: 'out-of-range',
-        distanceM: 5000,
-        thresholdM: 800,
-        locationSource: 'cache',
-        locationAgeMs: 5000,
-      });
-      return payload({ kind: 'transfer' });
-    }
+    // 데이터 주도: 각 row가 (label, taskData)를 정의해 동일 assertion 반복.
+    // #2064 — transfer/destination/intermediate는 모두 동일한 no-op skip 경로를 타므로
+    // 세 kind 모두 포함해 no-op이 LA refresh를 막지 않음을 증명한다.
     const cases: Array<{ label: string; build: () => unknown }> = [
-      { label: '정상 fire', build: () => payload({ kind: 'destination' }) },
+      { label: 'destination kind (no-op)', build: () => payload({ kind: 'destination' }) },
+      { label: 'transfer kind (no-op)', build: () => payload({ kind: 'transfer' }) },
+      { label: 'intermediate kind (no-op)', build: () => payload({ kind: 'intermediate' }) },
       { label: 'reschedule kind', build: () => payload({ kind: 'reschedule', nextStation: '강남', newArrivalTimeEpoch: 1, trainCode: 'T1' }) },
       { label: 'trip-ended kind', build: () => payload({ kind: 'trip-ended', reason: 'expired' }) },
       { label: 'payload missing(invalid)', build: () => ({ data: { data: { data: {}, dataString: null }, notification: null, aps: { 'content-available': 1 } } }) },
-      { label: 'lock-line-mismatch skip', build: () => lockMismatchPayload() },
-      { label: 'gate skip', build: () => gateSkipPayload() },
     ];
     it.each(cases)('$label 후에도 refreshLiveActivityFromBackgroundContext 1회 호출', async ({ build }) => {
       await handleSilentPush(build() as never);
@@ -4532,7 +3572,6 @@ describe('silentPushTask', () => {
     it('handleSilentPush persists SSoT mirror when payload.ssot is present', async () => {
       (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
       (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
-      mockCheckGate.mockReturnValue({ allow: false, skip: 'gate-no-location' });
       await handleSilentPush(
         bgTaskData({
           nextWaypoint: '강남',
@@ -4554,7 +3593,6 @@ describe('silentPushTask', () => {
     it('handleSilentPush does not persist mirror when payload.ssot is absent', async () => {
       (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
       (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
-      mockCheckGate.mockReturnValue({ allow: false, skip: 'gate-no-location' });
       await handleSilentPush(
         bgTaskData({
           nextWaypoint: '강남',
@@ -4592,7 +3630,6 @@ describe('silentPushTask', () => {
           if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
           return null;
         });
-        mockCheckGate.mockReturnValue({ allow: false, skip: 'gate-no-location' });
         // tripToken undefined일 때 'tripToken' in payload는 true가 되지만 코드 가드는
         // `payload.tripToken !== undefined`로 분기 — 구 backend 호환 path 그대로 검증.
         const fields: Record<string, unknown> = {
@@ -4668,126 +3705,6 @@ describe('silentPushTask', () => {
       expect(validSsotMirror(123)).toBeUndefined();
     });
 
-    // #1572 (T9, ADR-017) — Path E SSoT 게이트 통합 acceptance.
-    describe('Path E SSoT fire gate (#1572 T9)', () => {
-      const NOW = 1_700_000_000_000;
-
-      function makeFreshMirror(overrides: Record<string, unknown>): string {
-        return JSON.stringify({
-          currentStationId: '중곡',
-          motionState: 'moving',
-          lastAdvanceEvidence: 'arvlcd-confirmed-train',
-          lastAdvanceAt: NOW,
-          passedStations: [],
-          receivedAt: NOW,
-          ...overrides,
-        });
-      }
-
-      beforeEach(() => {
-        jest.spyOn(Date, 'now').mockReturnValue(NOW);
-      });
-
-      afterEach(() => {
-        jest.spyOn(Date, 'now').mockRestore();
-      });
-
-      it('mirror에 같은 stationId가 station-passed로 결정됨 → silent push fire 차단 (Gate B)', async () => {
-        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
-          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
-          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
-          if (key === BACKEND_SSOT_MIRROR_KEY)
-            return makeFreshMirror({ passedStations: ['용마산'] });
-          return null;
-        });
-        await handleSilentPush(
-          bgTaskData({
-            nextWaypoint: '용마산',
-            etaSeconds: 0,
-            phase: 'imminent',
-            kind: 'intermediate',
-            sentAt: NOW,
-            pushId: 'p1',
-          }),
-        );
-        // location gate 도달 전 SSoT gate가 block → checkSilentPushLocationGate 미호출.
-        expect(mockCheckGate).not.toHaveBeenCalled();
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-      });
-
-      it('mirror.alarmEvents에 같은 alarmId 결정됨 → fire 차단 (Gate A)', async () => {
-        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
-          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
-          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
-          if (key === BACKEND_SSOT_MIRROR_KEY)
-            return makeFreshMirror({
-              alarmEvents: [
-                {
-                  alarmId: 'transfer:군자',
-                  stationId: '군자',
-                  type: 'transfer',
-                  decidedAt: NOW,
-                },
-              ],
-            });
-          return null;
-        });
-        await handleSilentPush(
-          bgTaskData({
-            nextWaypoint: '군자',
-            etaSeconds: 0,
-            phase: 'imminent',
-            kind: 'transfer',
-            sentAt: NOW,
-            pushId: 'p2',
-          }),
-        );
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-      });
-
-      it('mirror 부재 → SSoT 게이트 graceful no-block → 후속 게이트로 진행', async () => {
-        // 기본 mock(`(AsyncStorage.getItem ...) return null`)는 BACKEND_SSOT_MIRROR_KEY가 null이라
-        // readBackendSsotMirror가 null → mirror-missing graceful pass.
-        await handleSilentPush(
-          bgTaskData({
-            nextWaypoint: '강남',
-            etaSeconds: 0,
-            phase: 'imminent',
-            kind: 'intermediate',
-            sentAt: NOW,
-            pushId: 'p3',
-          }),
-        );
-        // 후속 location gate가 호출됐는지 — SSoT gate가 차단하지 않았다는 증거.
-        expect(mockCheckGate).toHaveBeenCalled();
-      });
-
-      it('mirror stale(>180s) → SSoT 게이트 graceful no-block', async () => {
-        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
-          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
-          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
-          if (key === BACKEND_SSOT_MIRROR_KEY)
-            return makeFreshMirror({
-              passedStations: ['용마산'],
-              receivedAt: NOW - 200_000,
-            });
-          return null;
-        });
-        await handleSilentPush(
-          bgTaskData({
-            nextWaypoint: '용마산',
-            etaSeconds: 0,
-            phase: 'imminent',
-            kind: 'intermediate',
-            sentAt: NOW,
-            pushId: 'p4',
-          }),
-        );
-        // SSoT gate가 mirror-stale로 no-block — location gate가 호출됨.
-        expect(mockCheckGate).toHaveBeenCalled();
-      });
-    });
-
     // #1572 (T9, ADR-017) — alarmEvents validator.
     describe('alarmEvents validator (#1572 T9)', () => {
       it('validSsotMirror: alarmEvents 정의된 valid 배열 → narrow 통과', () => {
@@ -4828,7 +3745,6 @@ describe('silentPushTask', () => {
       it('handleSilentPush persists alarmEvents in mirror when payload.ssot.alarmEvents present', async () => {
         (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
         (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
-        mockCheckGate.mockReturnValue({ allow: false, skip: 'gate-no-location' });
         const ssotWithEvents = {
           ...validSsot,
           alarmEvents: [

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -15,12 +15,12 @@
  * data: { nextWaypoint, etaSeconds, phase, kind, sentAt }
  * ```
  *
- * 동작 (#478 PR 1-2 — 사전예약 완전 폐기):
+ * 동작 (#2064 Phase 1-device — 매역 알림 backend visible push 단일 채널 전환):
  *   1. payload 검증 + 수신 로그 적재 (#478 측정 인프라)
- *   2. 위치 게이트(`silentPushLocationGate`) 통과 여부 확인
- *      - 통과: trigger:null 즉시 알림 발사 + FIRED_ALARMS dedup 갱신 + logSilentPushFired
- *      - 실패: logSilentPushSkipped(reason)
- *   3. 사전예약(scheduleAlarmsForRoute) 호출 없음
+ *   2. kind(transfer/destination/intermediate)는 device 로컬 알림을 발사하지 않는다.
+ *      logSilentPushSkipped(reason='legacy-station-kind-ignored') 적재 후 no-op.
+ *   3. boarding-prompt / sleep-transfer-alarm 등 별도 discriminator 채널은 기존대로 gate 무관 발사.
+ *   4. 상태 sync(lock-release/widget/LA refresh)는 kind 무관 항상 수행.
  */
 
 import * as Notifications from 'expo-notifications';
@@ -51,17 +51,12 @@ import {
   logSilentPushReceived,
   logSilentPushRescheduleReceived,
   logSilentPushTripEndedReceived,
-  logSilentPushFired,
   logSilentPushSkipped,
   logSleepTransferAlarmFired,
   logSuppressedChannelAgnosticDedup,
   type AlarmLogReason,
 } from '../utils/alarmLog';
 import { vibrateAlarm } from '../utils/alarmSound';
-import {
-  isAnyChannelRecentlyFired,
-  markStationFired,
-} from '../utils/crossCategoryStationDedup';
 import { runTripBoundCleanups, cancelTripBoundOsQueue } from '../store/tripBoundCleanups';
 import {
   setTripEndedSentinel,
@@ -71,16 +66,7 @@ import { setLastSilentPushReceivedAt } from '../utils/lastSilentPushReceivedAt';
 import { triggerTripEndRecall } from '../utils/triggerTripEndRecall';
 import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
 import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
-import { evaluateDismissSilence } from '../utils/dismissSilenceGate';
-import { clearDismissSilence, getDismissSilence } from '../utils/dismissSilenceStorage';
-import { evaluateSsotFireGate } from '../utils/ssotFireGate';
-import { evaluateMovement, MOVEMENT_TO_ALARM_LOG_REASON } from '../../nearest-station/utils/movementGate';
-import { getCurrentMotionStationary } from '../../nearest-station/utils/motionActivity';
 import { addFiredPushId, hasFiredPushId } from '../utils/firedPushIds';
-import {
-  checkSilentPushLocationGate,
-  type GateSkipReason,
-} from '../utils/silentPushLocationGate';
 import {
   rescheduleHopForLock,
   cancelBlByStationPhase,
@@ -92,24 +78,15 @@ import {
 import { ALARM_PHASES } from '../utils/alarmPhases';
 import { ROUTE_KEY } from '../../../shared/constants/storageKeys';
 import type { Route } from '../../../shared/utils/stationRoute';
-import { alarmKey, type AlarmEvent } from '../utils/stationAlarm';
-import { buildAlarmContent, sendTripEndedNotification } from '../utils/stationNotification';
+import { sendTripEndedNotification } from '../utils/stationNotification';
 import { BOARDING_PROMPT_CATEGORY } from '../utils/notificationCategory';
 import { refreshLiveActivityFromBackgroundContext } from '../utils/refreshLiveActivityFromBackgroundContext';
 import { updateWidgetFromSilentPush } from '../../widget/utils/updateWidgetFromSilentPush';
 import { readWidgetRefreshContext } from '../utils/widgetRefreshContext';
-import { type NotificationSource } from '../utils/notificationSource';
-import { getFiredAlarms, setFiredAlarms } from '../utils/notificationState';
 import { getBoardingLock } from '../utils/boardingLockStorage';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import { useDestinationStore } from '../../route/store/useDestinationStore';
-import { getSubsurfaceState } from '../../../shared/utils/subsurfaceState';
-import { findStationByName, findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
-
-// silent push는 서버가 train data 기반으로 발사하므로 라벨도 'positionTrain'으로 고정.
-// 향후 GPS 게이트 경로 등 다른 출처가 생기면 인자화 한다.
-const SILENT_PUSH_SOURCE: NotificationSource = 'positionTrain';
 
 const logger = createLogger('SilentPushTask');
 
@@ -185,17 +162,14 @@ export interface SilentPushPayload {
   hopIndex?: number;
   /**
    * #1307 — 발사 시점 trip의 지하(subsurface) 판정. server-authoritative.
-   * 위치 게이트는 이 server flag를 우선하고, 부재 시 디바이스 로컬 stamp
-   * (`getSubsurfaceState`)로 fallback한다. true + intermediate면 GPS 거리 검증을 우회해
-   * 지하 stale/spoof GPS로 인한 out-of-range 오거부를 막는다. 구 backend 호환 위해 optional.
+   * #2064 (Phase 1-device) — 이 필드를 소비하던 device 위치 게이트(`fireWithGate`)가 매역
+   * 알림 backend visible push 전환으로 제거됨. 구 backend 호환을 위한 payload schema만 유지.
    */
   subsurface?: boolean;
   /**
    * #1322 — backend lock-path fire가 실어 보내는 boardingLock 노선 (server-authoritative).
-   * 로컬 lock이 없을 때(지하 auto-lock hydration window) 이 line으로 sanity-guard를 돌려
-   * non-intermediate push도 발사한다 (`fireWithGate`). backend가 선택해 발사한 push이므로
-   * authoritative — 디바이스는 자체 lock 없이도 honor한다. 구 backend 호환 위해 optional —
-   * 누락 시 기존 보수 동작(lock 없으면 non-intermediate skip)으로 fallback.
+   * #2064 (Phase 1-device) — 이 필드를 소비하던 device line sanity-guard(`fireWithGate`)가
+   * 매역 알림 backend visible push 전환으로 제거됨. 구 backend 호환을 위한 payload schema만 유지.
    */
   boardingLine?: string;
   /**
@@ -683,8 +657,7 @@ function validTripToken(value: unknown): string | undefined {
 
 /**
  * #1322 — payload.boardingLine 검증. 비어있지 않은 string만 통과 (LineNumber 표기).
- * backend는 lock-path fire에서만 wire하므로 누락/형식 오류는 undefined로 정규화 →
- * `fireWithGate`가 lock 없을 때 기존 보수 동작(non-intermediate skip)으로 fallback.
+ * #2064 (Phase 1-device) — 소비하던 device 게이트(`fireWithGate`) 제거됨. schema 파싱만 유지.
  */
 function validBoardingLine(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
@@ -901,38 +874,6 @@ function validSentAt(sentAt: unknown): number | undefined {
 
 function validPushId(pushId: unknown): string | undefined {
   return typeof pushId === 'string' && pushId.length > 0 ? pushId : undefined;
-}
-
-/**
- * 게이트 skip reason → alarmLog reason 매핑.
- * 1:1 매핑 — 다른 곳에서 재사용하지 않으므로 silentPushTask 내부에 둔다.
- */
-function mapGateReason(reason: GateSkipReason): AlarmLogReason {
-  switch (reason) {
-    case 'unknown-station':
-      return 'gate-unknown-station';
-    case 'no-location':
-      return 'gate-no-location';
-    case 'stale-location':
-      return 'gate-stale-location';
-    case 'out-of-range':
-      return 'gate-out-of-range';
-    case 'line-mismatch':
-      return 'gate-line-mismatch';
-  }
-}
-
-/**
- * intermediate(중간역 통과) 알림 content. AlarmEvent 모델에 없는 종류라
- * buildAlarmContent를 못 쓰고 별도 i18n 키로 빌드한다.
- */
-function buildIntermediateContent(stationName: string): { title: string; body: string } {
-  // SILENT_PUSH_SOURCE=positionTrain은 #327 UX 정책상 자백 대상이 아님 → suffix 미부착.
-  // shouldDiscloseNotificationSource이 false라 라벨 노이즈 회피.
-  return {
-    title: i18next.t('route.intermediatePassedTitle'),
-    body: i18next.t('route.intermediatePassedBody', { name: stationName }),
-  };
 }
 
 /**
@@ -1270,14 +1211,20 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
       return;
     }
 
-    try {
-      await fireWithGate(
-        payload as Required<Pick<SilentPushPayload, 'kind'>> & SilentPushPayload,
-        apnsToken,
-      );
-    } catch (e) {
-      logger.error('silent push fire 실패:', e);
-    }
+    // #2064 (Phase 1-device) — 매역 알림 backend visible push 전환. transfer/destination/
+    // intermediate kind는 더 이상 device가 로컬 알림을 발사하지 않는다(이중 발사 제거).
+    // 수신 자체는 유지(위 logSilentPushReceived + finally의 LA/widget refresh)해 상태 sync는
+    // 그대로 동작한다. 전환기 구버전 backend가 여전히 이 kind를 보내는 경우를 대비한 no-op.
+    logSilentPushSkipped({
+      stationName: payload.nextWaypoint,
+      kind: payload.kind === 'intermediate' ? 'station-passed' : payload.kind,
+      phaseId: payload.phase,
+      reason: 'legacy-station-kind-ignored',
+    });
+    void ackOutcome(payload.pushId, apnsToken, 'skipped', 'legacy-station-kind-ignored');
+    logger.info(
+      `legacy station kind ignored: kind=${payload.kind} station=${payload.nextWaypoint}`,
+    );
   } finally {
     // #900 Seam D — 권한 무관 LA refresh. 모든 silent push 종료 경로(정상/early-return/error)
     // 끝에서 한 번 호출. **순서 중요**: flushAlarmLog 먼저 await — 지하 환경에서 native LA
@@ -1684,338 +1631,6 @@ async function fireSleepTransferAlarmLocalNotification(
   }
 }
 
-/**
- * 위치 게이트 통과 시 즉시 발사, 실패 시 logSilentPushSkipped.
- * kind/dedup/i18n을 한 곳에서 처리.
- */
-async function fireWithGate(
-  payload: SilentPushPayload & { kind: NonNullable<SilentPushPayload['kind']> },
-  apnsToken: string | null,
-): Promise<void> {
-  // #1399 — 좀비 알림 cleanup. backend가 push 발사 시점에 stamp한 active trip token이 device의
-  // ACTIVE_TRIP_KEY와 mismatch면 만료 token push로 판정해 drop. 시나리오: backend vanish + GPS
-  // 동결 + 트립 종료 → 종료 push 도착 → device cleanup → 지상 재진입 후 OS queue/네트워크에 잔존
-  // 하던 stale silent push가 늦게 도착해도 ACTIVE_TRIP_KEY가 null 또는 다른 token이면 발사 차단
-  // (S8 14:19 회귀). 구 backend(payload.tripToken 누락) 호환 — undefined면 가드 skip.
-  if (payload.tripToken !== undefined) {
-    const activeTripToken = await AsyncStorage.getItem(ACTIVE_TRIP_KEY);
-    if (activeTripToken === null || activeTripToken !== payload.tripToken) {
-      const logKind = payload.kind === 'intermediate' ? 'station-passed' : payload.kind;
-      logSilentPushSkipped({
-        stationName: payload.nextWaypoint,
-        kind: logKind,
-        phaseId: payload.phase,
-        reason: 'trip-token-mismatch',
-      });
-      void ackOutcome(payload.pushId, apnsToken, 'skipped', 'trip-token-mismatch');
-      logger.info(
-        `trip-token mismatch skip: payload=${payload.tripToken.slice(0, 8)} active=${activeTripToken?.slice(0, 8) ?? 'null'} station=${payload.nextWaypoint}`,
-      );
-      return;
-    }
-  }
-
-  // #707/#1322: line sanity-guard. nextWaypoint가 boarding 노선에 정차하는지 검증한다.
-  // 노선 출처는 (1) 로컬 BoardingLock, 또는 (2) #1322 — backend lock-path fire가 실어 보낸
-  // payload.boardingLine (지하 auto-lock hydration window 등으로 로컬 lock이 없는 경우).
-  // 환승역 등에서 같은 nextWaypoint name이 여러 line stop을 가질 수 있다 — stations.json 매칭으로
-  // 다른 line stop만 존재하면 다른 leg/노선의 silent push로 판정해 차단.
-  // station name 자체가 stations.json에 없으면 line 가드는 통과시키고 일반 게이트의 unknown-station로 위임.
-  const lock = await getBoardingLock();
-  // guardLine 출처가 로컬 lock(LineNumber)이거나 wire payload(string)라 타입은 string으로 합쳐진다.
-  // findStationByNameAndLine은 `s.line === line` 엄격 비교라 LineNumber가 아닌 임의 문자열은
-  // 어떤 station에도 매칭되지 않아 안전하게 no-match(null)된다 → LineNumber로 좁혀도 무해.
-  const guardLine = (lock ? lock.boardingLine : payload.boardingLine) as LineNumber | undefined;
-  if (guardLine !== undefined) {
-    const onBoardingLine = findStationByNameAndLine(payload.nextWaypoint, guardLine);
-    if (!onBoardingLine && findStationByName(payload.nextWaypoint)) {
-      const logKind = payload.kind === 'intermediate' ? 'station-passed' : payload.kind;
-      logSilentPushSkipped({
-        stationName: payload.nextWaypoint,
-        kind: logKind,
-        phaseId: payload.phase,
-        reason: 'lock-line-mismatch',
-      });
-      void ackOutcome(payload.pushId, apnsToken, 'skipped', 'lock-line-mismatch');
-      logger.info(
-        `lock line mismatch skip: nextWaypoint=${payload.nextWaypoint} boardingLine=${guardLine}`,
-      );
-      return;
-    }
-    // #1322 — 로컬 lock 없이 payload.boardingLine만으로 통과한 경우: backend가 train을 선택해
-    // 발사한 lock-path push이므로 authoritative. lockless opt-in 토글은 lock 없는 trip 전용이라
-    // 적용하지 않고(backend lock 보유) line 가드 통과 후 바로 위치/movement 게이트로 진행한다.
-  } else {
-    // #1810 — paradigm shift Phase 1+2: 사용자 명시 의향(lock 활성)만 알림.
-    // lockless trip에서는 station-passed silent push를 항상 skip.
-    logSilentPushSkipped({
-      stationName: payload.nextWaypoint,
-      kind: 'station-passed',
-      phaseId: payload.phase,
-      reason: 'lockless-opt-out',
-    });
-    void ackOutcome(payload.pushId, apnsToken, 'skipped', 'lockless-opt-out');
-    logger.info(`lockless skip (paradigm shift #1810): station=${payload.nextWaypoint}`);
-    return;
-  }
-
-  // #1572 (T9, ADR-017) — backend SSoT 권위 게이트 (Path E silent push). BG 경로가 backend가
-  // 이미 결정한 alarmId/stationId를 재발사하는 회귀 차단. lock/lockless 분기 통과 후 dismiss silence
-  // 게이트 진입 직전 평가 — silence/위치/movement 게이트 전에 위치해 가장 강한 권위 정책 적용.
-  // intermediate payload는 'station-passed'로 매핑(device convention과 일치). fireWithGate signature
-  // 가 payload.kind NonNullable 강제 — undefined 케이스 없음.
-  const ssotGateKind: 'station-passed' | 'transfer' | 'destination' | 'imminent' =
-    payload.kind === 'intermediate' ? 'station-passed' : payload.kind;
-  const ssotGateOutcome = await evaluateSsotFireGate({
-    alarmId: `${ssotGateKind}:${payload.nextWaypoint}`,
-    stationId: payload.nextWaypoint,
-    type: ssotGateKind,
-  });
-  if (ssotGateOutcome.blocked) {
-    const logKind = payload.kind === 'intermediate' ? 'station-passed' : payload.kind;
-    const reason = ssotGateOutcome.reason as
-      | 'gate-alarm-already-decided'
-      | 'gate-station-already-passed';
-    logSilentPushSkipped({
-      stationName: payload.nextWaypoint,
-      kind: logKind,
-      phaseId: payload.phase,
-      reason,
-    });
-    void ackOutcome(payload.pushId, apnsToken, 'skipped', reason);
-    logger.info(`SSoT fire gate skip reason=${reason} station=${payload.nextWaypoint}`);
-    return;
-  }
-
-  // #746 — dismiss silence 게이트. BG path는 좌표 신뢰성이 낮아 시간 조건만 평가
-  //   (currentPosition=null). lock/lockless 분기 통과 후 위치 게이트보다 위에 위치해
-  //   사용자 정책이 데이터 정확성보다 우선되도록 한다.
-  const dismissSilenceState = await getDismissSilence();
-  const silenceDecision = evaluateDismissSilence(dismissSilenceState, Date.now(), null);
-  if (!silenceDecision.silenced && silenceDecision.expired) {
-    await clearDismissSilence();
-  }
-  if (silenceDecision.silenced) {
-    const logKind = payload.kind === 'intermediate' ? 'station-passed' : payload.kind;
-    logSilentPushSkipped({
-      stationName: payload.nextWaypoint,
-      kind: logKind,
-      phaseId: payload.phase,
-      reason: 'dismiss-silence',
-    });
-    void ackOutcome(payload.pushId, apnsToken, 'skipped', 'dismiss-silence');
-    logger.info(`dismiss-silence skip: station=${payload.nextWaypoint}`);
-    return;
-  }
-
-  // #1209 D3 — lockless 경로는 sticky station 좌표 drift 수용 위해 widened 임계값 사용.
-  // #1273 D3 — payloadHopIndex는 백엔드 silent push payload의 절대 시퀀스 SSOT. wire.
-  // currentHopIndex는 D1(#1207) hop estimator 미연결 단계라 undefined — 둘 중 하나라도
-  // 없으면 gate가 거리 기반 widened fallback 경로로 동작한다.
-  // #1307 — subsurface는 server flag(payload.subsurface)를 우선하고, 부재 시 디바이스
-  // 로컬 stamp로 fallback한다. server flag가 이겨야 FG-only stamp가 BG에서 stale 되어도
-  // 지하 intermediate 우회가 동작한다.
-  const subsurface = payload.subsurface ?? (await getSubsurfaceState());
-  // #1365 — estimatorLine. lock 활성 시 lock.boardingLine을 신뢰(사용자 명시 탭). lock 부재 시
-  // 디바이스에 결정적 line SSOT가 없으므로 undefined — gate cross-check 자연 skip(graceful).
-  // 추후 lockless도 fusion result line이 BG로 전파되면 그 값을 사용.
-  const estimatorLine = lock?.boardingLine;
-  const gate = await checkSilentPushLocationGate({
-    stationName: payload.nextWaypoint,
-    kind: payload.kind,
-    phase: payload.phase,
-    isLockless: !lock,
-    payloadHopIndex: payload.hopIndex,
-    subsurface,
-    occupiedLine: payload.occupiedLine,
-    estimatorLine,
-  });
-
-  if (!gate.pass) {
-    const reason = mapGateReason(gate.reason!);
-    logSilentPushSkipped({
-      stationName: payload.nextWaypoint,
-      kind: payload.kind === 'intermediate' ? 'station-passed' : payload.kind,
-      phaseId: payload.phase,
-      reason,
-      distanceM: gate.distanceM,
-      thresholdM: gate.thresholdM,
-      locationSource: gate.locationSource,
-      locationAgeMs: gate.locationAgeMs,
-    });
-    void ackOutcome(payload.pushId, apnsToken, 'skipped', reason);
-    logger.info(`gate skip reason=${gate.reason} distance=${gate.distanceM ?? '-'}`);
-    // #1356 E1 — silent fire가 suppress되는 동안 같은 station의 사전 예약(`tba:`/`bl:`)도 OS queue
-    // 에서 cancel. backend는 정적/out-of-range를 인식해 다음 silent push를 발사하지 않지만, OS queue에
-    // 잔존한 사전 예약은 시간이 되면 자체 발사 → stale "다음 역" 알람. nextWaypoint/phase는 본 분기
-    // 에서 항상 존재(SilentPushPayload 필수 필드).
-    await cancelTbaByStationPhase(payload.nextWaypoint, payload.phase);
-    await cancelBlByStationPhase(payload.nextWaypoint, payload.phase);
-    return;
-  }
-
-  // #727 — 정적 misfire 가드. gate는 거리/freshness만 검증하지만 사용자가 정적이면 잘못된
-  // trainCode/fusion lock으로 잘못 발사될 수 있다. expo-location LocationObject의 speed/
-  // accuracy가 있으면 평가 — 미측정(`speed === -1` 등)이면 skip하고 graceful pass.
-  // #728 — CMMotionActivity motion=stationary 신호 동시 적용. BG에선 hook 못쓰니 직접 호출 — native
-  // module이 startUpdates된 상태(FG에서 useMotionActivity가 시작)에서 latest cache된 값을 반환.
-  // 권한 미부여/미지원/native fault 시 false → 기존 가드만 동작 (graceful fallback).
-  const motionStationary = getCurrentMotionStationary();
-  const movement = evaluateMovement(
-    {
-      speedMps: gate.speedMps,
-      accuracyM: gate.accuracyM,
-    },
-    undefined,
-    undefined,
-    motionStationary,
-  );
-  if (!movement.reliable && movement.reason) {
-    const movementReason = MOVEMENT_TO_ALARM_LOG_REASON[movement.reason];
-    logSilentPushSkipped({
-      stationName: payload.nextWaypoint,
-      kind: payload.kind === 'intermediate' ? 'station-passed' : payload.kind,
-      phaseId: payload.phase,
-      reason: movementReason,
-      distanceM: gate.distanceM,
-      thresholdM: gate.thresholdM,
-      locationSource: gate.locationSource,
-      locationAgeMs: gate.locationAgeMs,
-    });
-    void ackOutcome(payload.pushId, apnsToken, 'skipped', movementReason);
-    logger.info(
-      `movement skip: reason=${movementReason} speed=${gate.speedMps ?? '-'} accuracy=${gate.accuracyM ?? '-'}`,
-    );
-    // #1356 E1 — motion=stationary suppress 동안 같은 station 사전 예약도 cancel. (gate 분기와 동일 의도)
-    await cancelTbaByStationPhase(payload.nextWaypoint, payload.phase);
-    await cancelBlByStationPhase(payload.nextWaypoint, payload.phase);
-    return;
-  }
-
-  // FIRED_ALARMS dedup — destination scope. intermediate는 dedup 대상 아님(통과는 1회성).
-  // dedup 키는 alarmKey({phaseId, stationName, occurrenceIdx}) — FG GPS·OS scheduled fire와 동일
-  // 출처 공유. #1367 — payload.hopIndex로 같은 stationName이 route에 중복 등장하는 trip에서
-  // hop별 dedup이 collide하지 않도록 occurrenceIdx로 분리. backend가 hopIndex를 보내지 않는 구
-  // 호환 분기는 occurrenceIdx=0 (legacy 동작 보존).
-  const destinationId = await loadDestinationId();
-  const dedupKey =
-    payload.kind === 'intermediate'
-      ? null
-      : alarmKey({
-          phaseId: payload.phase,
-          stationName: payload.nextWaypoint,
-          occurrenceIdx: payload.hopIndex ?? 0,
-        });
-
-  if (dedupKey && destinationId) {
-    const fired = await getFiredAlarms(destinationId);
-    if (fired.has(dedupKey)) {
-      // 다른 채널(FG GPS 등)이 이미 발사 — backend 입장에선 fallback 불필요. ACK로 정리.
-      void ackOutcome(payload.pushId, apnsToken, 'skipped', 'dedup-already-fired');
-      // P2e — 동일 pushId의 alert가 race로 도달하면 FG에서 중복 표시 차단되도록 기록.
-      if (payload.pushId) void addFiredPushId(payload.pushId);
-      logger.info(`dedup: ${dedupKey} already fired — skip`);
-      return;
-    }
-    fired.add(dedupKey);
-    await setFiredAlarms(destinationId, fired);
-  }
-
-  // #1901/#1900 (RC-7/RC-10a) — channel-agnostic 8분 backstop. FIRED_ALARMS dedup은
-  // `phaseId + stationName + hopIndex` 기반이라 backend가 같은 station-pass 1건에 silent state
-  // push + LA dirty update 2채널을 발사하거나 phase만 다른 cross-channel 중복을 통과시킨다.
-  // (lastFire) Map은 FG fireAndLog / stationPipeline 모두에서 markStationFired로 적재되므로
-  // 본 게이트가 silent push도 station-level 8분 backstop으로 cross-channel 중복을 차단한다.
-  // intermediate(station-passed) 분기는 dedupKey=null이라 destinationId만으로도 보호 필요 —
-  // intermediate도 같은 station 8분 차 cross-channel 중복 evidence(2026-06-26 trip-3 동대문역사문화공원).
-  const channelAgnosticKind: 'destination' | 'transfer' | 'station-passed' =
-    payload.kind === 'intermediate' ? 'station-passed' : payload.kind;
-  if (
-    destinationId &&
-    isAnyChannelRecentlyFired(
-      destinationId,
-      payload.nextWaypoint,
-      channelAgnosticKind,
-      Date.now(),
-      payload.phase,
-    )
-  ) {
-    logSuppressedChannelAgnosticDedup({
-      source: 'silent-push-skipped',
-      stationName: payload.nextWaypoint,
-      kind: channelAgnosticKind,
-      phaseId: payload.phase,
-    });
-    void ackOutcome(payload.pushId, apnsToken, 'skipped', 'dedup-already-fired');
-    if (payload.pushId) void addFiredPushId(payload.pushId);
-    logger.info(
-      `dedup channel-agnostic: ${payload.nextWaypoint} fired within 8m — skip`,
-    );
-    return;
-  }
-
-  const content =
-    payload.kind === 'intermediate'
-      ? buildIntermediateContent(payload.nextWaypoint)
-      : buildAlarmContent(
-          {
-            phaseId: payload.phase,
-            type: payload.kind,
-            stationName: payload.nextWaypoint,
-          } as AlarmEvent,
-          SILENT_PUSH_SOURCE,
-        );
-
-  await Notifications.scheduleNotificationAsync({
-    content: { title: content.title, body: content.body },
-    trigger: null,
-  });
-
-  // #1901/#1900 (RC-7/RC-10a) — channel-agnostic dedup window 갱신. silent push fire를 lastFire
-  // Map에 적재해 후속 FG fireAndLog / stationPipeline 발사가 같은 station+kind+phase 8분 backstop
-  // 으로 차단됨. intermediate는 'station-passed' 카테고리로 마킹(기존 cross-category dedup 의미 유지).
-  // phaseId(payload.phase)도 stamp해 정상 phase 진행은 통과시킴.
-  if (destinationId) {
-    markStationFired(
-      destinationId,
-      payload.nextWaypoint,
-      channelAgnosticKind,
-      Date.now(),
-      payload.phase,
-    );
-  }
-
-  logSilentPushFired({
-    stationName: payload.nextWaypoint,
-    kind: payload.kind === 'intermediate' ? 'station-passed' : payload.kind,
-    phaseId: payload.phase,
-    distanceM: gate.distanceM!,
-    thresholdM: gate.thresholdM!,
-    locationSource: gate.locationSource!,
-    locationAgeMs: gate.locationAgeMs!,
-  });
-  void ackOutcome(payload.pushId, apnsToken, 'fired');
-  // P2e — alert fallback이 race로 도달해도 FG에서 중복 표시 차단되도록 기록.
-  if (payload.pushId) void addFiredPushId(payload.pushId);
-  logger.info(
-    `fired: kind=${payload.kind} phase=${payload.phase} station=${payload.nextWaypoint} distance=${gate.distanceM}m`,
-  );
-}
-
-/**
- * AsyncStorage에서 destination.id만 안전하게 꺼낸다.
- * 파싱 실패/구조 손상 시 null — dedup 건너뜀(발사는 진행).
- */
-async function loadDestinationId(): Promise<string | null> {
-  try {
-    const json = await AsyncStorage.getItem(DESTINATION_KEY);
-    if (!json) return null;
-    const parsed = JSON.parse(json) as Partial<Station> | null;
-    return parsed && typeof parsed.id === 'string' ? parsed.id : null;
-  } catch {
-    return null;
-  }
-}
 
 /** Task 등록 — 모듈 로드 시점에 한 번 실행. */
 TaskManager.defineTask(SILENT_PUSH_TASK, handleSilentPush);

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -28,7 +28,6 @@ import * as TaskManager from 'expo-task-manager';
 import * as Location from 'expo-location';
 import * as Battery from 'expo-battery';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import i18next from 'i18next';
 import { AppState } from 'react-native';
 import {
   persistBackendSsotMirror,
@@ -53,7 +52,6 @@ import {
   logSilentPushTripEndedReceived,
   logSilentPushSkipped,
   logSleepTransferAlarmFired,
-  logSuppressedChannelAgnosticDedup,
   type AlarmLogReason,
 } from '../utils/alarmLog';
 import { vibrateAlarm } from '../utils/alarmSound';

--- a/src/features/alarm/utils/__tests__/stationNotification.test.ts
+++ b/src/features/alarm/utils/__tests__/stationNotification.test.ts
@@ -7,7 +7,6 @@ import {
   clearStationNotification,
   sendAlarmNotification,
   clearAlarmNotification,
-  sendStationPassedNotification,
   sendTripEndedNotification,
   buildAlarmContent,
 } from '../stationNotification';
@@ -912,95 +911,9 @@ describe('stationNotification', () => {
     });
   });
 
-  describe('sendStationPassedNotification', () => {
-    it('마지막 구간(isTransfer=false)이면 목적지까지 남은 정거장 수를 body에 표시한다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendStationPassedNotification('역삼', '강남', {
-        nextStationName: '강남',
-        stopsToNextStation: 3,
-        isTransfer: false,
-        stopsToDestination: 3,
-      });
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
-        identifier: 'station-passed',
-        content: { title: '역삼역 도착', body: '강남까지 3정거장 남음', sound: false },
-        trigger: null,
-      });
-    });
-
-    it('환승 전 구간(isTransfer=true)이면 환승역과 최종 목적지를 모두 표시한다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendStationPassedNotification('용마산', '이대', {
-        nextStationName: '군자',
-        stopsToNextStation: 2,
-        isTransfer: true,
-        stopsToDestination: 11,
-      });
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
-        identifier: 'station-passed',
-        content: {
-          title: '용마산역 도착',
-          body: '군자 환승까지 2정거장 · 이대까지 11정거장',
-          sound: false,
-        },
-        trigger: null,
-      });
-    });
-
-    it('target이 null이면 현재 역만 표시한다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendStationPassedNotification('역삼', '강남', null);
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
-        identifier: 'station-passed',
-        content: { title: '역삼역 도착', body: '현재 역삼역', sound: false },
-        trigger: null,
-      });
-    });
-
-    it('Android에서는 channelId와 priority DEFAULT가 포함된다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'android');
-      await sendStationPassedNotification('역삼', '강남', {
-        nextStationName: '강남',
-        stopsToNextStation: 3,
-        isTransfer: false,
-        stopsToDestination: 3,
-      });
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
-        identifier: 'station-passed',
-        content: {
-          title: '역삼역 도착',
-          body: '강남까지 3정거장 남음',
-          sound: false,
-          channelId: 'station-passed',
-          priority: 'default',
-        },
-        trigger: null,
-      });
-    });
-
-    // #1224 — station-passed = 잠 깨우지 말 것. 진동 0 / 사운드 0 / 배너만
-    it('#1224 — iOS scheduleNotification 호출에 sound: false가 포함된다 (잠 안 깨우기)', async () => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendStationPassedNotification('역삼', '강남', null);
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
-        expect.objectContaining({
-          content: expect.objectContaining({ sound: false }),
-        }),
-      );
-    });
-
-    it('#1224 — Android 채널은 sound: null + enableVibrate: false (진동/사운드 OFF)', async () => {
-      // refreshNotificationChannels는 initStationNotification에서 호출되어 별도 단위로 검증되지만,
-      // 정책 SSOT가 한 곳에 모이도록 동등 가드를 여기서도 명시한다.
-      jest.replaceProperty(Platform, 'OS', 'android');
-      (Notifications.deleteNotificationChannelAsync as jest.Mock).mockResolvedValue(undefined);
-      await initStationNotification();
-      expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledWith(
-        'station-passed',
-        expect.objectContaining({ sound: null, enableVibrate: false }),
-      );
-    });
-  });
+  // #2064 (Phase 1-device) — sendStationPassedNotification 제거(매역 알림 backend visible push 단일
+  // 채널 전환). STATION_PASSED_CHANNEL_ID 채널 설정 자체(sound:null/enableVibrate:false, #1224)는
+  // 'Android 채널 재생성' 테스트(위, refreshNotificationChannels 전체 assert)가 계속 커버한다.
 
   // #1323 — trip 종료 user-facing surface. backend trip-ended push가 silent라 알림이 안 뜨던 회귀 차단.
   describe('sendTripEndedNotification', () => {
@@ -1154,20 +1067,6 @@ describe('stationNotification', () => {
       jest.replaceProperty(Platform, 'OS', 'ios');
       await sendAlarmNotification(earlyDest, false, true, source);
       expectAlarmNotification('하차 알림', baseBody, { interruptionLevel: 'timeSensitive' });
-    });
-
-    it.each([
-      ['gpsOnly' as const, '현재 역삼역 · GPS 추정'],
-      ['positionTrain' as const, '현재 역삼역'],
-      [undefined, '현재 역삼역'],
-    ])('sendStationPassedNotification source=%s → body=%s', async (source, expectedBody) => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendStationPassedNotification('역삼', '강남', null, source);
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
-        identifier: 'station-passed',
-        content: { title: '역삼역 도착', body: expectedBody, sound: false },
-        trigger: null,
-      });
     });
 
     it.each([

--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -239,7 +239,13 @@ describe('processLocationUpdate', () => {
     // #796 P1-1: resolveNextTarget도 같은 lock-degraded currentLine을 사용해야 함.
     // BG GPS jitter로 nearest가 옆 노선 station(예: 5호선 군자)을 잡아도 lock(7호선) SSOT로
     // segment 식별하여 다음-다음 transfer로 잘못 넘어가지 않는다.
-    it('#796 P1-1 lock 활성 시 resolveNextTarget의 currentLine도 lock.boardingLine 사용', async () => {
+    //
+    // #2064 (Phase 1-device) — sendStationPassedNotification 제거로 resolveNextTarget의 결과값이
+    // processLocationUpdate 밖으로 더 이상 노출되지 않는다(내부 dedup/hop-advance bookkeeping
+    // gate로만 소비). currentLine 선택 로직(lock.boardingLine 우선) 자체의 정확성은
+    // `resolveNextTarget` 직접 단위 테스트(아래 '#796 currentLine 기반 segment 식별' describe)가
+    // 계속 커버 — 여기서는 lock 활성 시 station-passed dedup bookkeeping이 정상 진행됨을 검증한다.
+    it('#796 P1-1 lock 활성 시에도 station-passed dedup bookkeeping이 정상 진행된다 (target resolve 성공)', async () => {
       // 7→5→8 multi-transfer route. GPS는 5호선 군자 station(line='5')으로 jitter됐지만
       // 실제 사용자는 7호선 탑승 중이라 lock.boardingLine='7'.
       const multiRoute = makeMultiTransferRoute({
@@ -258,14 +264,10 @@ describe('processLocationUpdate', () => {
 
       await call();
 
-      // raw GPS line이라면 transfer[1]=천호로 잘못 넘어갔을 것 (segment[1].fromLine='5'와 매칭).
-      // lock SSOT 적용으로 transfer[0]=군자 안내가 유지된다.
-      expect(mockSendStationPassedNotification).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(String),
-        expect.objectContaining({ nextStationName: '군자', isTransfer: true }),
-        undefined,
-      );
+      // target이 null이었다면(resolveNextTarget 실패) setLastNotifiedStationId가 호출되지 않는다.
+      // lock SSOT currentLine 적용으로 두 segment 중 하나가 정상 매칭돼 target이 resolve된다.
+      expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith('station-2', stationOn5.id);
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
   });
 
@@ -436,19 +438,16 @@ describe('processLocationUpdate', () => {
     expect(mockFindRoute).toHaveBeenCalledWith('station-1', 'station-2');
   });
 
-  it('sends station-passed notification and writes to notificationState when station changes', async () => {
+  // #2064 (Phase 1-device) — 매역 알림은 backend visible push 단일 채널로 전환. station-passed 감지는
+  // 더 이상 사용자 노출 알림을 발사하지 않고 notificationState(dedup) bookkeeping만 수행한다.
+  it('does not send station-passed notification but still writes to notificationState when station changes', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
     mockGetLastNotifiedStationId.mockResolvedValue('other-station');
 
     await call();
 
-    expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남', '시청', {
-      nextStationName: '시청',
-      stopsToNextStation: 3,
-      isTransfer: false,
-      stopsToDestination: 3,
-    }, undefined);
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(mockDestination.id, 'station-1');
   });
 
@@ -463,19 +462,14 @@ describe('processLocationUpdate', () => {
     expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
   });
 
-  it('sends station-passed notification when stored lastNotifiedStationId is null', async () => {
+  it('does not send station-passed notification but writes notificationState when stored lastNotifiedStationId is null', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
     mockGetLastNotifiedStationId.mockResolvedValue(null);
 
     await call();
 
-    expect(mockSendStationPassedNotification).toHaveBeenCalledWith('강남', '시청', {
-      nextStationName: '시청',
-      stopsToNextStation: 3,
-      isTransfer: false,
-      stopsToDestination: 3,
-    }, undefined);
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(mockDestination.id, 'station-1');
   });
 
@@ -618,14 +612,17 @@ describe('processLocationUpdate', () => {
       expect(mockLogFiredAlarm).toHaveBeenCalledWith('bg', mockAlarmEvent);
     });
 
-    it('역 통과 알림 발사 시 logFiredStationPassed(source, station)를 호출한다', async () => {
+    // #2064 (Phase 1-device) — station-passed 로컬 알림 제거로 logFiredStationPassed(alarmLog
+    // 'fired' 엔트리) 호출부도 함께 제거됨. dedup bookkeeping(setLastNotifiedStationId)은 유지.
+    it('역 통과 감지 시에도 logFiredStationPassed는 호출하지 않는다 (dedup bookkeeping만 수행)', async () => {
       mockFindNearestStation.mockReturnValue(mockNearestResult);
       mockFindRoute.mockReturnValue(mockRoute);
       mockGetLastNotifiedStationId.mockResolvedValue(null);
 
       await call();
 
-      expect(mockLogFiredStationPassed).toHaveBeenCalledWith('bg', mockStation);
+      expect(mockLogFiredStationPassed).not.toHaveBeenCalled();
+      expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(mockDestination.id, mockStation.id);
     });
 
     it('lastNotifiedStationId 일치로 skip되면 logSuppressedDedupStation을 호출한다', async () => {
@@ -711,19 +708,16 @@ describe('processLocationUpdate', () => {
       );
     });
 
-    it('역 통과 알림에도 notificationSource가 전달된다', async () => {
+    // #2064 (Phase 1-device) — station-passed 로컬 알림 제거로 notificationSource 전파 대상도
+    // 사라짐(sendAlarmNotification 경로만 notificationSource를 계속 사용).
+    it('역 통과 감지에는 더 이상 notificationSource가 전달되지 않는다 (알림 자체가 없음)', async () => {
       mockFindNearestStation.mockReturnValue(mockNearestResult);
       mockFindRoute.mockReturnValue(mockRoute);
       mockGetLastNotifiedStationId.mockResolvedValue(null);
 
       await call({ fusionSource: 'route-progress' });
 
-      expect(mockSendStationPassedNotification).toHaveBeenCalledWith(
-        mockStation.name,
-        mockDestination.name,
-        expect.any(Object),
-        'routeProgress',
-      );
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
   });
 
@@ -879,10 +873,11 @@ describe('processLocationUpdate', () => {
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
     });
 
-    it('station-passed 발사 후 같은 station phase 알람은 cross-category dedup으로 차단', async () => {
-      // 1st: station-passed 발사 → mark.
+    it('station-passed 감지 후 같은 station phase 알람은 cross-category dedup으로 차단', async () => {
+      // 1st: station-passed 감지(#2064 — 로컬 알림은 미발사, markStationFired는 계속 mark).
       await call({ source: 'bg' });
-      expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(mockDestination.id, passedStation.id);
 
       // 2nd: phase 알람 같은 station — cross-cat 차단. (다른 destination이라 lastNotifiedStationId
       // 게이트는 다른 키, isStationOnRoute false로 station-passed 분기 회피.)
@@ -916,12 +911,13 @@ describe('processLocationUpdate', () => {
       mockGetLastNotifiedStationId.mockResolvedValue(null);
     });
 
-    it('station-passed 발사(군자) 후 5s 안 phase 알람(성수=다른 station, cross-cat)은 trip-scoped dedup으로 차단', async () => {
-      // 1st: 군자 station-passed 발사 → trip-scoped mark.
+    it('station-passed 감지(군자) 후 5s 안 phase 알람(성수=다른 station, cross-cat)은 trip-scoped dedup으로 차단', async () => {
+      // 1st: 군자 station-passed 감지 → trip-scoped mark(#2064 — 로컬 알림은 미발사).
       mockFindNearestStation.mockReturnValue({ station: passedStation, distanceKm: 0.05 });
       mockEvaluateAlarmPhase.mockReturnValue(null);
       await call({ source: 'bg' });
-      expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(mockDestination.id, passedStation.id);
 
       // 2nd: 다른 station(성수) phase 알람 — cross-station + cross-cat이라 trip-scoped 차단.
       mockFindNearestStation.mockReturnValue({ station: otherStation, distanceKm: 0.05 });
@@ -1106,13 +1102,14 @@ describe('processLocationUpdate', () => {
       expect(mockLogSuppressedChannelAgnosticDedup).not.toHaveBeenCalled();
     });
 
-    it('station-passed 발사 후 31s~8분 사이 같은 station station-passed는 channel-agnostic backstop으로 차단', async () => {
+    it('station-passed 감지 후 31s~8분 사이 같은 station station-passed는 channel-agnostic backstop으로 차단', async () => {
       mockFindNearestStation.mockReturnValue({ station: stationA, distanceKm: 0.05 });
       mockEvaluateAlarmPhase.mockReturnValue(null);
       mockIsStationOnRoute.mockReturnValue(true);
-      // 1st: station-passed 발사 → markStationFired (t=1_000_000).
+      // 1st: station-passed 감지 → markStationFired (t=1_000_000). #2064 — 로컬 알림은 미발사.
       await call({ source: 'bg' });
-      expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockSetLastNotifiedStationId).toHaveBeenCalledTimes(1);
 
       // t = 1_000_000 + 60_000 — 30s cross-category 만료, lastNotifiedStationId가 다른 stationId면
       // 그 dedup도 통과 → channel-agnostic 8분 backstop이 차단해야 함.
@@ -1124,8 +1121,10 @@ describe('processLocationUpdate', () => {
         stationName: stationA.name,
         kind: 'station-passed',
       });
-      // 두 번째 발사 없음.
-      expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+      // 알림은 두 호출 모두 미발사(#2064). 2nd call은 backstop 차단으로 setLastNotifiedStationId도
+      // 갱신되지 않는다 — 1st 호출분(1회)만 유지.
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockSetLastNotifiedStationId).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -1162,27 +1161,30 @@ describe('processLocationUpdate', () => {
       });
     });
 
-    it('sleep OFF + lock 활성 + candidate=boardingStation → 정상 발사 (sleep off 우선)', async () => {
+    it('sleep OFF + lock 활성 + candidate=boardingStation → 정상 진행 (sleep off 우선, #2064 알림은 미발사)', async () => {
       mockGetBoardingLock.mockResolvedValue(lockOnStation1);
       await call({ sleepMode: false });
-      expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockSetLastNotifiedStationId).toHaveBeenCalled();
       expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
     });
 
-    it('sleep ON + lock 활성 + candidate≠boardingStation → 정상 발사 (첫 hop 아님)', async () => {
+    it('sleep ON + lock 활성 + candidate≠boardingStation → 정상 진행 (첫 hop 아님, #2064 알림은 미발사)', async () => {
       const lockOnOther = { ...lockOnStation1, boardingStationId: 'station-other' };
       mockGetBoardingLock.mockResolvedValue(lockOnOther);
       await call({ sleepMode: true });
-      expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockSetLastNotifiedStationId).toHaveBeenCalled();
       expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
     });
 
-    it('sleep ON + lock null (lockless) → BG는 currentHopIndex SSOT 부재라 graceful 통과', async () => {
+    it('sleep ON + lock null (lockless) → BG는 currentHopIndex SSOT 부재라 graceful 통과 (#2064 알림은 미발사)', async () => {
       // BG path는 estimator hopIndex 입력이 없어 lockless trip을 차단하지 않는다(보수적 graceful).
       // FG path가 currentHopIndex로 동급 보장(useStationAlarm 테스트에서 검증).
       mockGetBoardingLock.mockResolvedValue(null);
       await call({ sleepMode: true });
-      expect(mockSendStationPassedNotification).toHaveBeenCalled();
+      expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+      expect(mockSetLastNotifiedStationId).toHaveBeenCalled();
       expect(mockLogSuppressedSleepStationPassed).not.toHaveBeenCalled();
     });
 

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -316,7 +316,12 @@ export type AlarmLogReason =
   // dispatch 시도한 케이스를 sync entry-guard로 차단. evidence: 2026-07-01 08:32:09 fg fired
   // station-passed 성수 2건. `isSimpleArchEnabled()` ON (env=true / KV=on) 상태에서만 발생
   // — flag OFF 시 unified gate 는 dead code.
-  | 'dedup-simple-arch-fire-once';
+  | 'dedup-simple-arch-fire-once'
+  // #2064 (Phase 1-device) — 매역 알림이 backend visible push 단일 채널로 전환됨에 따라
+  // silent push kind(transfer/destination/intermediate)가 도달해도 device는 더 이상 로컬
+  // 알림을 발사하지 않는다. 전환기 구버전 backend가 여전히 이 kind를 보내는 경우를 대비한
+  // no-op 처리 1건 적재 — 상태 sync(lock-release/widget/LA)는 정상 진행.
+  | 'legacy-station-kind-ignored';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.

--- a/src/features/alarm/utils/stationNotification.ts
+++ b/src/features/alarm/utils/stationNotification.ts
@@ -13,7 +13,6 @@ import { Station } from '../../../shared/types/station';
 import { LINE_COLORS, LINE_NAMES } from '../../../shared/constants/lineColors';
 import { DirectRoute, TransferRoute, MultiTransferRoute, normalizeStationName } from '../../../shared/utils/stationRoute';
 import type { AlarmEvent } from './stationAlarm';
-import type { NextTarget } from './stationPipeline';
 import type { TripEndedReason } from '../tasks/silentPushTask';
 import * as LiveActivity from 'live-activity';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -484,46 +483,6 @@ export async function clearStationNotification(): Promise<void> {
   notifLogger.info('Android 알림 해제');
   await Notifications.dismissNotificationAsync(NOTIFICATION_ID);
   await dismissStationPassedNotification();
-}
-
-export async function sendStationPassedNotification(
-  stationName: string,
-  destinationName: string,
-  target: NextTarget | null,
-  source?: NotificationSource,
-): Promise<void> {
-  // 사용자 노출 텍스트이므로 현재 언어로 변환. caller는 한글 역명을 그대로 전달.
-  const displayStation = getStationDisplayNameByName(stationName, allStations);
-  const displayDestination = getStationDisplayNameByName(destinationName, allStations);
-  let body: string;
-  if (target == null) {
-    body = i18next.t('route.atCurrentStation', { name: displayStation });
-  } else if (target.isTransfer) {
-    body = i18next.t('route.stopsRemainingViaTransfer', {
-      transfer: getStationDisplayNameByName(target.nextStationName, allStations),
-      transferStops: target.stopsToNextStation,
-      destination: displayDestination,
-      totalStops: target.stopsToDestination,
-    });
-  } else {
-    body = i18next.t('route.stopsRemainingToDestination', {
-      destination: displayDestination,
-      count: target.stopsToDestination,
-    });
-  }
-  body = appendNotificationSource(body, source);
-
-  // #1224 — 매역 알림은 잠을 깨우지 말 것: 진동 0 / 사운드 0 / 배너만
-  await scheduleNotification(STATION_PASSED_NOTIFICATION_ID, {
-    title: i18next.t('route.stationPassed', { name: displayStation }),
-    body,
-    sound: false,
-    ...(Platform.OS === 'android' && {
-      channelId: STATION_PASSED_CHANNEL_ID,
-      priority: Notifications.AndroidNotificationPriority.DEFAULT,
-    }),
-  });
-  notifLogger.info('역 통과 알림:', stationName, body);
 }
 
 /**

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -9,14 +9,13 @@
 import { findNearestStation } from '../../nearest-station/utils/findNearestStation';
 import { findRoute, calculateStaticETA, getFirstLeg, isSameStationName, isStationOnRoute, updateRouteFromPosition } from '../../../shared/utils/stationRoute';
 import { evaluateAlarmPhase, resolveAllTargets } from './stationAlarm';
-import { sendAlarmNotification, sendStationPassedNotification, updateStationNotification } from './stationNotification';
+import { sendAlarmNotification, updateStationNotification } from './stationNotification';
 import { distanceMetersBetween, estimateEtaSeconds } from '../../../shared/utils/stationEta';
 import { advanceHopWindow } from './boardingLockScheduler';
 import { getBoardingLock } from './boardingLockStorage';
 import { getLastNotifiedStationId, setLastNotifiedStationId } from './notificationState';
 import {
   logFiredAlarm,
-  logFiredStationPassed,
   logSuppressedChannelAgnosticDedup,
   logSuppressedCrossCategoryDedup,
   logSuppressedCrossCategoryRecent,
@@ -479,26 +478,19 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
           kind: 'station-passed',
         });
       } else {
-        // #796: 환승역 도착 timing의 segment 정확 식별. evaluateAlarmPhase(:233)와 동일한
-        // currentLine 결정 — lock.boardingLine 우선 → BG GPS jitter로 nearest가 옆 노선 station을
-        // 잡아도 잘못된 다음-다음 transfer 안내를 차단. lock 없으면 nearest.station.line fallback.
+        // #2064 (Phase 1-device) — 매역 알림은 backend visible push 단일 채널로 전환. 이 station-passed
+        // 감지는 이제 사용자 노출 알림(sendStationPassedNotification)을 발사하지 않고 trip 진행
+        // 상태 bookkeeping(dedup 갱신 + hop advance)만 수행한다. #796 currentLine 결정은 advanceHopWindow가
+        // 정확한 통과 waypoint를 찾기 위해 여전히 필요.
         const target = resolveNextTarget(
           route,
           destination.name,
           lockForLineGuard?.boardingLine ?? nearest.station.line,
         );
         if (target) {
-          // #1515 — race reservation: send 전에 cross-category 윈도우 갱신. category='station-passed'.
+          // #1515 — cross-category 윈도우 갱신. category='station-passed'.
           markStationFired(destination.id, nearest.station.name, 'station-passed', Date.now());
-          // 알림 발송 성공 후에만 storage write — 발송 실패 시 다음 폴링에서 재시도 가능.
-          await sendStationPassedNotification(
-            nearest.station.name,
-            destination.name,
-            target,
-            notificationSource,
-          );
           await setLastNotifiedStationId(destination.id, nearest.station.id);
-          logFiredStationPassed(source, nearest.station);
 
           // #624 BG-safe stale alarm 차단 — 통과한 waypoint의 pre-scheduled bl:* 알람을
           // 능동 cancel. useBoardingLockAdvancer는 FG only(React hook)지만 stationPipeline은

--- a/src/features/nearest-station/tasks/__tests__/foregroundBackgroundTransition.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/foregroundBackgroundTransition.test.ts
@@ -116,6 +116,7 @@ jest.mock('../../../../shared/utils/logger', () => ({
 import '../../tasks/backgroundLocationTask';
 import { processLocationUpdate } from '../../../alarm/utils/stationPipeline';
 import { alarmKey } from '../../../alarm/utils/stationAlarm';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   DESTINATION_KEY,
   LAST_NOTIFIED_STATION_KEY,
@@ -127,6 +128,17 @@ import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
 // ── 테스트 버퍼 상수: 임계값 안쪽/바깥쪽임을 이름으로 드러낸다 ──
 const FRESH_MARGIN_MS = 1_000;
 const STALE_MARGIN_MS = 5_000;
+
+// #2064 (Phase 1-device) — 매역 알림은 backend visible push 단일 채널로 전환되어 device가
+// sendStationPassedNotification을 더 이상 호출하지 않는다. 이 파일이 회귀 가드하던 "FG/BG dedup
+// 단일 출처" 계약은 여전히 유효 — station-passed 감지가 성공할 때마다 정확히 1회
+// setLastNotifiedStationId(AsyncStorage LAST_NOTIFIED_STATION_KEY write)가 일어나고, dedup으로
+// 차단되면 write가 일어나지 않는다. 이 헬퍼로 알림 호출 횟수 대신 write 횟수를 관찰한다.
+function countLastNotifiedStationWrites(): number {
+  return (AsyncStorage.setItem as jest.Mock).mock.calls.filter(
+    ([key]: [string]) => key === LAST_NOTIFIED_STATION_KEY,
+  ).length;
+}
 const NEAR_STATION_KM = 0.05;
 const ACCURATE_MARGIN_M = 50;
 
@@ -242,52 +254,65 @@ beforeEach(() => {
   mockSendStationPassedNotification.mockClear();
   mockSendAlarmNotification.mockClear();
   mockUpdateStationNotification.mockClear();
+  (AsyncStorage.setItem as jest.Mock).mockClear();
   // #1515 — cross-category dedup module 인메모리 상태 리셋(테스트 간 격리).
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   require('../../../alarm/utils/crossCategoryStationDedup')._resetCrossCategoryDedupForTests();
 });
 
-describe('FG↔BG 통합: 알림 dedup (notificationState 단일 출처)', () => {
+// #2064 (Phase 1-device) — 매역 알림은 backend visible push 단일 채널로 전환되어 device는
+// sendStationPassedNotification을 더 이상 호출하지 않는다. 이 describe가 회귀 가드하던 "FG/BG
+// dedup 단일 출처" 계약(notificationState.setLastNotifiedStationId)은 여전히 유효하므로,
+// 알림 호출 횟수 대신 LAST_NOTIFIED_STATION_KEY write 횟수로 dedup을 관찰한다.
+describe('FG↔BG 통합: station-passed dedup bookkeeping (notificationState 단일 출처)', () => {
   beforeEach(() => {
     mockStorage.set(DESTINATION_KEY, JSON.stringify(fakeDestination));
   });
 
-  it('FG에서 알림 발사 후 BG가 같은 역 받으면 중복 발사하지 않는다', async () => {
+  it('FG에서 station-passed 감지 후 BG가 같은 역 받으면 dedup되어 재기록하지 않는다', async () => {
     await runFgPipelineAt(fakeStation);
-    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    expect(countLastNotifiedStationWrites()).toBe(1);
     expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBe(JSON.stringify({ destinationId: fakeDestination.id, stationId: fakeStation.id }));
 
     await runBgTaskAt(fakeStation);
 
-    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    // 같은 역 재감지는 dedup으로 차단 — write가 늘지 않는다.
+    expect(countLastNotifiedStationWrites()).toBe(1);
   });
 
-  it('BG에서 알림 발사 후 FG가 같은 역 받으면 중복 발사하지 않는다', async () => {
+  it('BG에서 station-passed 감지 후 FG가 같은 역 받으면 dedup되어 재기록하지 않는다', async () => {
     await runBgTaskAt(fakeStation);
-    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    expect(countLastNotifiedStationWrites()).toBe(1);
     expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBe(JSON.stringify({ destinationId: fakeDestination.id, stationId: fakeStation.id }));
 
     await runFgPipelineAt(fakeStation);
 
-    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    expect(countLastNotifiedStationWrites()).toBe(1);
   });
 
-  it('FG 알림 후 다른 역으로 진입하면 FG/BG 어디서 받든 새 알림이 발사된다', async () => {
+  it('FG 감지 후 다른 역으로 진입하면 FG/BG 어디서 받든 새로 기록된다', async () => {
     await runFgPipelineAt(fakeStation);
-    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    expect(countLastNotifiedStationWrites()).toBe(1);
 
     await runBgTaskAt(fakeNextStation);
 
-    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(2);
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    expect(countLastNotifiedStationWrites()).toBe(2);
     expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBe(JSON.stringify({ destinationId: fakeDestination.id, stationId: fakeNextStation.id }));
   });
 
-  it('AsyncStorage가 비어 있는 cold start(swipe-kill 직후)에는 BG 첫 콜백이 알림을 발사한다', async () => {
+  it('AsyncStorage가 비어 있는 cold start(swipe-kill 직후)에는 BG 첫 콜백이 dedup 상태를 기록한다', async () => {
     expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBeUndefined();
 
     await runBgTaskAt(fakeStation);
 
-    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    expect(countLastNotifiedStationWrites()).toBe(1);
     expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBe(JSON.stringify({ destinationId: fakeDestination.id, stationId: fakeStation.id }));
   });
 });
@@ -328,10 +353,13 @@ describe('FG↔BG 통합: 게이트 비대칭 (BG timeInterval 30s × age 15s, a
     mockStorage.set(DESTINATION_KEY, JSON.stringify(fakeDestination));
   });
 
-  it('age < MAX_LOCATION_AGE_MS인 신선한 좌표는 BG 게이트를 통과해 알림으로 이어진다', async () => {
+  // #2064 — device는 station-passed 로컬 알림을 더 이상 발사하지 않으므로 게이트 통과 증거는
+  // dedup write(LAST_NOTIFIED_STATION_KEY) 발생 여부로 관찰한다.
+  it('age < MAX_LOCATION_AGE_MS인 신선한 좌표는 BG 게이트를 통과해 dedup 기록으로 이어진다', async () => {
     await runBgTaskAt(fakeStation, { ageMs: MAX_LOCATION_AGE_MS - FRESH_MARGIN_MS });
 
-    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    expect(countLastNotifiedStationWrites()).toBe(1);
   });
 
   it('age > MAX_LOCATION_AGE_MS인 stale 좌표(BG timeInterval 30s로 인한 캐시 fix)는 게이트가 drop한다', async () => {
@@ -345,7 +373,8 @@ describe('FG↔BG 통합: 게이트 비대칭 (BG timeInterval 30s × age 15s, a
   it('accuracy <= MAX_ACCURACY_M인 좌표는 BG 게이트를 통과한다', async () => {
     await runBgTaskAt(fakeStation, { accuracy: MAX_ACCURACY_M - ACCURATE_MARGIN_M });
 
-    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    expect(countLastNotifiedStationWrites()).toBe(1);
   });
 
   it('accuracy > MAX_ACCURACY_M인 저정확도 좌표는 BG 게이트가 drop한다', async () => {
@@ -357,14 +386,15 @@ describe('FG↔BG 통합: 게이트 비대칭 (BG timeInterval 30s × age 15s, a
   });
 
   // iOS deferred 배치에 stale + fresh 좌표가 섞여 들어올 때, BG task는 locations[length-1]만
-  // 처리한다. 마지막 좌표가 fresh면 통과해 알림, stale이면 drop — 이 계약을 회귀 가드한다.
-  it('multi-location 배치의 마지막 좌표가 fresh면 통과해 알림으로 이어진다', async () => {
+  // 처리한다. 마지막 좌표가 fresh면 통과해 dedup 기록, stale이면 drop — 이 계약을 회귀 가드한다.
+  it('multi-location 배치의 마지막 좌표가 fresh면 통과해 dedup 기록으로 이어진다', async () => {
     await runBgTaskBatch([
       { station: fakeStation, ageMs: MAX_LOCATION_AGE_MS + STALE_MARGIN_MS },
       { station: fakeStation, ageMs: MAX_LOCATION_AGE_MS - FRESH_MARGIN_MS },
     ]);
 
-    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    expect(countLastNotifiedStationWrites()).toBe(1);
   });
 
   it('multi-location 배치의 마지막 좌표가 stale이면 drop된다 (앞쪽 fresh 무시)', async () => {
@@ -387,19 +417,23 @@ describe('FG↔BG 통합: swipe-kill 후 재진입 (AsyncStorage 영속성)', ()
     mockStorage.set(DESTINATION_KEY, JSON.stringify(fakeDestination));
   });
 
-  it('BG가 lastNotifiedStationId 기록 후 모듈 상태가 전부 리셋돼도 FG 재진입 시 중복 알림 없음', async () => {
+  // #2064 — device는 station-passed 로컬 알림을 더 이상 발사하지 않으므로 "재진입 후 재기록 없음"
+  // 증거는 LAST_NOTIFIED_STATION_KEY write 미발생으로 관찰한다.
+  it('BG가 lastNotifiedStationId 기록 후 모듈 상태가 전부 리셋돼도 FG 재진입 시 재기록 없음', async () => {
     await runBgTaskAt(fakeStation);
-    expect(mockSendStationPassedNotification).toHaveBeenCalledTimes(1);
+    expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    expect(countLastNotifiedStationWrites()).toBe(1);
     const persistedId = mockStorage.get(LAST_NOTIFIED_STATION_KEY);
     expect(persistedId).toBe(JSON.stringify({ destinationId: fakeDestination.id, stationId: fakeStation.id }));
 
-    // swipe-kill 시뮬레이션: AsyncStorage는 보존, send mock 만 리셋해 "재진입 후 새 send" 검증.
-    mockSendStationPassedNotification.mockClear();
+    // swipe-kill 시뮬레이션: AsyncStorage는 보존, write 카운터만 리셋해 "재진입 후 새 write" 검증.
+    (AsyncStorage.setItem as jest.Mock).mockClear();
     expect(mockStorage.get(LAST_NOTIFIED_STATION_KEY)).toBe(persistedId);
 
     await runFgPipelineAt(fakeStation);
 
     expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
+    expect(countLastNotifiedStationWrites()).toBe(0);
   });
 
   it('BG 알람 발사 후 swipe-kill을 거쳐 FG 재진입해도 firedAlarms는 영속 dedup된다', async () => {


### PR DESCRIPTION
⚠️ **머지 게이트**: backend #2078+#2084 visible 전환 배포 확인 후 머지 (배포 완료됨 — Version e2795aa2. draft 해제 판단은 리뷰 후)

Closes #2064
Part of #2061 (Phase 1-device)

## 변경
- **D4 제거**: silentPushTask fireWithGate 계열 — intermediate/transfer/destination/imminent kind 수신 시 로컬 알림 생성 삭제, no-op + `legacy-station-kind-ignored` 로그 (구버전 backend 호환). silent 수신 자체는 상태 sync용으로 유지
- **D10 제거**: sendStationPassedNotification + FG(useStationAlarm)·BG(stationPipeline) 호출부. dedup/hop-advance 부기는 유지
- **FG 표시 정책**: 원격 alert push를 FG에서도 배너 표시 (기존 코드로 이미 충족 — PR 코멘트로 근거 기록)
- 테스트: evidence_20260703_replay는 fixture 보존, assertion만 새 스펙(device 매역 발사 0)으로 갱신

## 검증
- npm test 9,181 pass + coverage 100% / type-check ✓ / lint:orphan 0

## Wire-completion 5단
1. lint:orphan pass
2. V/X: DebugModal alarm log — station-passed/fireWithGate source 소멸 확인
3. 의존 PR: #2078+#2084 (머지·배포 완료)
4. 측정 plan: 실기기 FG trip에서 매역 배너 정확히 1회(backend발, 이중 아님)
5. Device verify: 필요 — FG/BG/kill 각 매역 배너 1회

*작성: 구현은 BG 에이전트, 최종 검증·커밋·PR은 main 세션이 인수 (에이전트 stall 반복)*