### PR TITLE
fix(#2086): 매역 알림 apns-collapse-id 64바이트 한도 초과 위험 수정

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -81,6 +81,12 @@ const APNS_HOSTS = {
   sandbox: 'api.sandbox.push.apple.com',
 } as const;
 
+// #2086 — APNs apns-collapse-id 64B 한도 검증용 실물 길이(64 hex) mock device token.
+// 짧은 mock token('lock-tok' 등)은 slice(0, 16)가 no-op이라 축약 로직을 실제로 exercise하지
+// 못한다 — runtime constraint 시뮬 원칙(lesson_test_mock_must_validate_runtime)에 따라
+// 실제 device token 길이를 반영한 별도 상수를 collapse-id 전용 테스트에서 사용한다.
+const HEX64_TOKEN = '0123456789abcdef'.repeat(4);
+
 function makeEnv(kv: InMemoryKV, pending?: InMemoryKV): Env {
   return {
     TRIPS: kv as unknown as KVNamespace,
@@ -2267,7 +2273,7 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
       });
     }
 
-    it('sleepModeEnabled=true + legHopIndex>=1 + 직전역 arvlCd 진입 → visible alert + companion silent push 2건 발사', async () => {
+    it('sleepModeEnabled=true + 직전역 arvlCd 진입 → visible alert + companion silent push 2건 발사', async () => {
       const kv = new InMemoryKV();
       const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
       await putTrip(kv as unknown as KVNamespace, makeSleepAlarmTrip());
@@ -2306,6 +2312,30 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
       expect(companionData.tripToken).toBe('lock-tok');
       const companionHeaders = companionCall![1].headers as Record<string, string>;
       expect(companionHeaders['apns-push-type']).toBe('background');
+    });
+
+    // #2086 — 짧은 mock token('lock-tok')은 `slice(0, 16)`가 no-op이라 apns-collapse-id
+    // 축약 로직을 실제로 exercise하지 못한다. 실물 길이(64 hex) device token으로
+    // `alarm-<token16>-<station>` 형태 + APNs 64B 한도 준수를 직접 검증한다.
+    it('#2086 실물 길이(64 hex) device token → apns-collapse-id가 16 hex prefix로 축약되고 64B 이하', async () => {
+      const kv = new InMemoryKV();
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      await putTrip(kv as unknown as KVNamespace, makeSleepAlarmTrip({ token: HEX64_TOKEN }));
+      await runScheduled(makeEnv(kv), {
+        seoul: makeSeoulCombo([arrivalForLock('중곡', 0, 1)], []),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        now: () => NOW,
+        generatePushId: () => 'p-sleep-alarm-hex64',
+      });
+
+      const alertCall = findPushByKindOrAlert(fetchImpl, (body) => body.aps?.alert !== undefined);
+      expect(alertCall).toBeDefined();
+      const alertHeaders = alertCall![1].headers as Record<string, string>;
+      const collapseId = alertHeaders['apns-collapse-id'];
+      expect(collapseId).toBe(`alarm-${HEX64_TOKEN.slice(0, 16)}-군자`);
+      expect(new TextEncoder().encode(collapseId).length).toBeLessThanOrEqual(64);
     });
 
     // PR #2085 리뷰 P1-1 — leg-relative hop 카운터(legHopIndex) 게이트는 전면 제거됐다.
@@ -7144,6 +7174,23 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
     expect(data.sentAt).toBe(NOW);
     // dedup KV stamp 확인 (TTL은 InMemoryKV가 그대로 보관 — expiration 무시)
     expect(await kv.get(arvlCdFireKey('arvl-tok', '7246', '중곡', 1))).toBe('1');
+  });
+
+  // #2086 — 짧은 mock token('arvl-tok')은 `slice(0, 16)`가 no-op이라 apns-collapse-id
+  // 축약 로직을 실제로 exercise하지 못한다. 실물 길이(64 hex) device token으로
+  // `station-<token16>` 형태 + APNs 64B 한도 준수를 직접 검증한다.
+  it('#2086 실물 길이(64 hex) device token → apns-collapse-id가 16 hex prefix로 축약되고 64B 이하', async () => {
+    const { apnsFetch } = await runArvlScheduled({
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      trip: makeLockTripFixture(HEX64_TOKEN),
+      pushId: 'p-arvl-hex64',
+    });
+    const calls = getStationPassedCalls(apnsFetch);
+    expect(calls).toHaveLength(1);
+    const headers = calls[0][1].headers as Record<string, string>;
+    const collapseId = headers['apns-collapse-id'];
+    expect(collapseId).toBe(`station-${HEX64_TOKEN.slice(0, 16)}`);
+    expect(new TextEncoder().encode(collapseId).length).toBeLessThanOrEqual(64);
   });
 
   // Epic #1204 그룹 2 D3 (#1273)

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -1821,9 +1821,15 @@ export const STALE_LOCK_FIRE_THRESHOLD_MS = 3 * 60 * 1000;
  */
 export const STATION_NOTIF_COLLAPSE_ID_PREFIX = 'station-';
 
-/** #2063 — 매역 알림 apns-collapse-id 빌더. */
+/**
+ * #2063 — 매역 알림 apns-collapse-id 빌더.
+ * #2086 — device token(64 hex)을 통째로 넣으면 `station-<64hex>` ≈ 72B로 APNs
+ * `apns-collapse-id` 64B 한도를 초과할 수 있어 `slice(0, 16)`로 축약한다
+ * (`sleepAlarmCollapseId`와 동일 패턴, PR #2085 리뷰 P2-2). collapse는 같은 trip 내
+ * 최신으로 교체하는 용도라 16 hex prefix로 유니크성 충분.
+ */
 export function stationNotifCollapseId(tripToken: string): string {
-  return `${STATION_NOTIF_COLLAPSE_ID_PREFIX}${tripToken}`;
+  return `${STATION_NOTIF_COLLAPSE_ID_PREFIX}${tripToken.slice(0, 16)}`;
 }
 
 /**


### PR DESCRIPTION
Closes #2086

## 배경
#2078이 도입한 매역 알림 visible push의 `apns-collapse-id: station-${trip.token}`은 device token(64 hex) 전체 포함으로 ~72B — APNs collapse-id 64바이트 한도 초과 소지. 초과 시 400 BadCollapseId로 push 거부 → 매역 알림 미도달. 짧은 mock token 테스트는 이를 검출하지 못했다.

취침 알람(`alarm-<token>-<station>`)의 동일 문제는 PR #2085(P2-2)에서 이미 `slice(0, 16)`로 수정됨 — 본 PR은 매역(`station-`) 경로를 동일 패턴으로 정렬한다.

## 변경
1. `scheduled.ts` `stationNotifCollapseId`: `station-${tripToken}` → `station-${tripToken.slice(0, 16)}` (16 hex prefix로 같은 trip 내 유니크성 충분)
2. 테스트: 매역(`station-`)/취침 알람(`alarm-`) 두 경로 모두 **64-hex 실물 길이 mock token**으로 collapse-id 값 + `≤64B` assert 추가 (PR #2085 재검증 P3 편입)
3. `scheduled.test.ts:2270` stale 테스트 이름(`legHopIndex>=1` — PR #2085에서 이미 제거된 게이트 언급) 정리

## Wire-completion 5단
1. **Orphan** — `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard** — wrangler tail에서 `arvlcd-fire` 로그의 push 성공/실패(APNs 응답 코드)로 관측 가능. collapse-id 값 자체는 non-2xx APNs 응답(400 BadCollapseId) 발생 여부로 간접 확인.
3. **의존 PR** — N/A (backend 단독 fix, #2085는 이미 머지됨)
4. **측정 plan** — 1주간 wrangler tail/Cloudflare Dashboard에서 매역 알림 발사 시 APNs 400 응답 0건 확인. 이슈 본문 "선행 확인" 항목(실기기 도달 여부)은 사용자 실기기 검증 별도 진행.
5. **Device verify** — N/A (type+unit only). 실기기 매역 배너 도달 검증은 사용자 책임(이슈 본문 "선행 확인" 참고).

## 검증
- `npm test` (backend/alarm-worker): 69 files / 2692 tests pass
- `npm run type-check` (backend + root): pass
- `npm run lint:orphan`: 0 orphan

## 하지 않은 것
- 이슈 본문에 명시된 대로 #2085(취침 알람) 자체 로직은 접촉하지 않음 — 이미 머지된 `sleepAlarmCollapseId` 축약 코드는 그대로 두고, 동일 패턴으로 검증하는 테스트만 추가.