### PR TITLE
refactor(#2067): 알람 로컬 정리 - D1 제거 + companion 전환 + AlarmLocalAuthority

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -23,13 +23,13 @@ import {
   makeTransferRoute,
 } from '../../../../testUtils/routeFixtures';
 
-const mockSendAlarmNotification = jest.fn().mockResolvedValue(undefined);
+// #2067 (Phase 2-device, D1) — sendAlarmNotification 제거로 useStationAlarm.ts는 더 이상
+// stationNotification.ts를 import하지 않는다. sendStationPassedNotification mock은 #2064에서
+// 이미 실제 export가 아니게 됐지만(레거시 잔재), 아래 mock 없이도 nothing require이 없어
+// 안전 — 기존 assertion(`mockSendStationPassedNotification).not.toHaveBeenCalled()`)은
+// "결코 wire되지 않은 mock"이라 항상 통과하는 vacuous 검증이 된다. 값 자체는 유지하되 real
+// module mock은 제거해 dead jest.mock을 남기지 않는다.
 const mockSendStationPassedNotification = jest.fn().mockResolvedValue(undefined);
-
-jest.mock('../../utils/stationNotification', () => ({
-  sendAlarmNotification: (...args: unknown[]) => mockSendAlarmNotification(...args),
-  sendStationPassedNotification: (...args: unknown[]) => mockSendStationPassedNotification(...args),
-}));
 
 const mockEvaluateAlarmPhase = jest.fn();
 jest.mock('../../utils/stationAlarm', () => {
@@ -504,7 +504,7 @@ describe('useStationAlarm', () => {
 
   // #1773 (D) — fire path A confidence 화이트리스트 회귀 가드.
   // gps-only-underground 강등 시 GPS 정확도 게이트(500m > 200m)가 already 차단하므로
-  // station-passed 알람(mockSendStationPassedNotification)과 phase 알람(mockSendAlarmNotification)
+  // station-passed 알람(mockSendStationPassedNotification)과 phase 알람(logFiredAlarm)
   // 모두 발화 안 됨을 명시 검증. 지상(gps-only/detection-fused)은 정상 진입.
   describe('#1773 (D) fire path A — confidence 기반 silence 검증', () => {
     const route = makeDirectRoute(1, '2');
@@ -526,7 +526,7 @@ describe('useStationAlarm', () => {
         ),
       );
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('D2: gps-only (지상) + accuracy=100m → evaluateAlarmPhase 호출 + phase fire 경로 진입', async () => {
@@ -595,7 +595,7 @@ describe('useStationAlarm', () => {
         ),
       );
       expect(mockSendStationPassedNotification).not.toHaveBeenCalled();
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
   });
 
@@ -709,7 +709,7 @@ describe('useStationAlarm', () => {
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     await waitFor(() =>
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, false, true, undefined),
+      expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', earlyDest, expect.any(String)),
     );
   });
 
@@ -720,11 +720,10 @@ describe('useStationAlarm', () => {
     mockResolveAlarmDirection.mockReturnValue('up');
     renderHook(() => useStationAlarm(defaultInputs({ route, destination, nearestStation: station })));
     await waitFor(() =>
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith(
+      expect(mockLogFiredAlarm).toHaveBeenCalledWith(
+        'fg',
         { ...earlyDest, direction: 'up' },
-        false,
-        true,
-        undefined,
+        expect.any(String),
       ),
     );
   });
@@ -740,7 +739,7 @@ describe('useStationAlarm', () => {
     mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     await waitFor(() =>
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyTransfer, false, true, undefined),
+      expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', earlyTransfer, expect.any(String)),
     );
   });
 
@@ -755,7 +754,7 @@ describe('useStationAlarm', () => {
     mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
     await waitFor(() =>
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyTransfer, false, true, undefined),
+      expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', earlyTransfer, expect.any(String)),
     );
   });
 
@@ -763,9 +762,9 @@ describe('useStationAlarm', () => {
     const route = makeDirectRoute(1, '2');
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     const { rerender } = renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
-    await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1));
     rerender({});
-    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+    expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
   });
 
   it('fires imminent after early for the same waypoint', async () => {
@@ -780,7 +779,7 @@ describe('useStationAlarm', () => {
       },
     );
     await waitFor(() =>
-      expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(earlyDest, false, true, undefined),
+      expect(mockLogFiredAlarm).toHaveBeenLastCalledWith('fg', earlyDest, expect.any(String)),
     );
 
     mockEvaluateAlarmPhase.mockReturnValueOnce(imminentDest);
@@ -788,9 +787,9 @@ describe('useStationAlarm', () => {
       inputs: defaultInputs({ route, destination, userLocation: { lat: 37.49, lng: 127.025 }, speedMps: 20 }),
     });
     await waitFor(() =>
-      expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(imminentDest, false, true, undefined),
+      expect(mockLogFiredAlarm).toHaveBeenLastCalledWith('fg', imminentDest, expect.any(String)),
     );
-    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(2);
+    expect(mockLogFiredAlarm).toHaveBeenCalledTimes(2);
   });
 
   it('#1515 cross-category dedup — 같은 station에 station-passed가 직전 fire됐다면 phase 알람 차단', async () => {
@@ -813,7 +812,7 @@ describe('useStationAlarm', () => {
         phaseId: 'early',
       }),
     );
-    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    expect(mockLogFiredAlarm).not.toHaveBeenCalled();
   });
 
   it('#1643 trip-scoped dedup — 직전 5s 안 다른 station에서 station-passed fire됐다면 phase 알람 차단', async () => {
@@ -838,7 +837,7 @@ describe('useStationAlarm', () => {
         phaseId: 'early',
       }),
     );
-    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    expect(mockLogFiredAlarm).not.toHaveBeenCalled();
   });
 
   it('#1643 trip-scoped dedup — 직전 5s 안 다른 station에서 phase fire됐다면 station-passed 차단', async () => {
@@ -885,7 +884,7 @@ describe('useStationAlarm', () => {
         phaseId: 'early',
       }),
     );
-    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    expect(mockLogFiredAlarm).not.toHaveBeenCalled();
   });
 
   it('#1901/#1900 channel-agnostic dedup — 같은 station + 같은 phase 8분 안 재발사는 차단', async () => {
@@ -919,7 +918,7 @@ describe('useStationAlarm', () => {
         phaseId: 'early',
       }),
     );
-    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     nowSpy.mockRestore();
   });
 
@@ -941,9 +940,9 @@ describe('useStationAlarm', () => {
         defaultInputs({ route, destination, userLocation: { lat: 37.4, lng: 127 }, speedMps: 5 }),
       ),
     );
-    await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+    await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
     // imminent 정상 발사. channel-agnostic backstop이 잘못 차단하지 않음.
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith(imminentDest, false, true, undefined);
+    expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', imminentDest, expect.any(String));
     expect(mockLogSuppressedChannelAgnosticDedup).not.toHaveBeenCalled();
     nowSpy.mockRestore();
   });
@@ -955,26 +954,16 @@ describe('useStationAlarm', () => {
       ({ dest }: { dest: Station }) => useStationAlarm(defaultInputs({ route, destination: dest })),
       { initialProps: { dest: destination } },
     );
-    await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1));
     expect(mockGetFiredAlarms).toHaveBeenCalledWith(destination.id);
 
     const altEvent: AlarmEvent = { phaseId: 'early', type: 'destination', stationName: '잠실' };
     mockEvaluateAlarmPhase.mockReturnValue(altEvent);
     rerender({ dest: altDestination });
-    await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(2));
-    expect(mockSendAlarmNotification).toHaveBeenLastCalledWith(altEvent, false, true, undefined);
+    await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalledTimes(2));
+    expect(mockLogFiredAlarm).toHaveBeenLastCalledWith('fg', altEvent, expect.any(String));
     // destination 변경 → 새 id로 storage 재읽기 (저장된 entry는 옛 destinationId라 빈 set 반환 → 자동 isolation).
     expect(mockGetFiredAlarms).toHaveBeenCalledWith(altDestination.id);
-  });
-
-  it('passes sleepMode to sendAlarmNotification', async () => {
-    useSettingsStore.setState({ sleepMode: true });
-    const route = makeDirectRoute(1, '2');
-    mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
-    renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
-    await waitFor(() =>
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, true, true, undefined),
-    );
   });
 
   it('sets alarmEvent in store when sleepMode is on', async () => {
@@ -990,36 +979,19 @@ describe('useStationAlarm', () => {
     const route = makeDirectRoute(1, '2');
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
-    await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+    await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
     expect(useAlarmEventStore.getState().alarmEvent).toBeNull();
-  });
-
-  it('passes allowSpeaker=false from store', async () => {
-    useSettingsStore.setState({ allowSpeaker: false });
-    const route = makeDirectRoute(1, '2');
-    mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
-    renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
-    await waitFor(() =>
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, false, false, undefined),
-    );
   });
 
   it('does not re-fire when sleepMode toggles after first fire', async () => {
     const route = makeDirectRoute(1, '2');
     mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
     const { rerender } = renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
-    await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1));
 
     useSettingsStore.setState({ sleepMode: true });
     rerender({});
-    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
-  });
-
-  it('handles sendAlarmNotification rejection gracefully', () => {
-    mockSendAlarmNotification.mockRejectedValueOnce(new Error('알림 실패'));
-    const route = makeDirectRoute(1, '2');
-    mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
-    expect(() => renderHook(() => useStationAlarm(defaultInputs({ route, destination })))).not.toThrow();
+    expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
   });
 
   // #750 — 공통 sleep 룰 게이트가 FG 즉시 발사 path도 차단한다.
@@ -1056,7 +1028,7 @@ describe('useStationAlarm', () => {
           phaseId: 'early',
         }),
       );
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
       expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
@@ -1074,7 +1046,7 @@ describe('useStationAlarm', () => {
       mockEvaluateAlarmPhase.mockReturnValue(earlyTransfer);
       renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
 
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
       expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
     });
 
@@ -1103,7 +1075,7 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
       expect(mockLogFiredAlarm).not.toHaveBeenCalled();
       // lockless guard가 앞서 차단하므로 sleep gate는 호출 안 됨.
       expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
@@ -1116,7 +1088,7 @@ describe('useStationAlarm', () => {
       mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
       renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
 
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
       expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
     });
 
@@ -1147,7 +1119,7 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
       expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
     });
   });
@@ -1492,7 +1464,7 @@ describe('useStationAlarm', () => {
       await waitFor(() => expect(mockGetFiredAlarms).toHaveBeenCalled());
       // hydrated 이후 evaluator가 호출되더라도 동일 키가 들어있어 null 반환 → 미발화.
       await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('FG에서 phase 발화 시 setFiredAlarms(destinationId, set)로 동기화한다 (#462)', async () => {
@@ -1501,7 +1473,7 @@ describe('useStationAlarm', () => {
 
       renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
 
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1));
       expect(mockSetFiredAlarms).toHaveBeenCalledWith(destination.id, expect.any(Set));
       // 발화된 alarmKey가 storage로 흘러갔는지 확인.
       const lastCall = mockSetFiredAlarms.mock.calls.at(-1)!;
@@ -1514,7 +1486,7 @@ describe('useStationAlarm', () => {
 
       await waitFor(() => expect(mockEvaluateAlarmPhase).toHaveBeenCalled());
       // BG 적재로 인해 evaluator가 null 반환 → 미발화.
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('destination 변경 직후 hydration 완료 전에는 evaluator가 호출되지 않는다 (race guard, #462)', async () => {
@@ -1793,7 +1765,7 @@ describe('useStationAlarm', () => {
           'api',
         );
       });
-      expect(mockSendAlarmNotification).toHaveBeenCalled();
+      expect(mockLogFiredAlarm).toHaveBeenCalled();
     });
 
     // #727 — speed/accuracy 가드. 정적 사용자의 잘못된 trainCode/fusion 신호로 인한 misfire 차단.
@@ -1824,7 +1796,7 @@ describe('useStationAlarm', () => {
           }),
         );
       });
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
       const apiCalls = mockLogFiredAlarm.mock.calls.filter((c) => c[2] === 'api');
       expect(apiCalls).toHaveLength(0);
     });
@@ -1850,7 +1822,7 @@ describe('useStationAlarm', () => {
           expect.objectContaining({ reason: 'movement-low-accuracy' }),
         );
       });
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('#727 speed/accuracy 모두 누락(null)이어도 API imminent 발사 (graceful pass)', async () => {
@@ -1920,7 +1892,7 @@ describe('useStationAlarm', () => {
         useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
       );
 
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('sleepMode면 setAlarmEvent도 함께 호출', async () => {
@@ -1951,11 +1923,10 @@ describe('useStationAlarm', () => {
       );
 
       await waitFor(() => {
-        expect(mockSendAlarmNotification).toHaveBeenCalledWith(
+        expect(mockLogFiredAlarm).toHaveBeenCalledWith(
+          'fg',
           expect.objectContaining({ direction: 'up' }),
-          expect.anything(),
-          expect.anything(),
-          undefined,
+          expect.any(String),
         );
       });
     });
@@ -1980,30 +1951,11 @@ describe('useStationAlarm', () => {
       );
 
       await waitFor(() => {
-        expect(mockSendAlarmNotification).toHaveBeenCalled();
+        expect(mockLogFiredAlarm).toHaveBeenCalled();
       });
       // nearestStation null이면 direction 분기를 거치지 않음
-      const apiSendCall = mockSendAlarmNotification.mock.calls[0];
-      expect(apiSendCall[0]).not.toHaveProperty('direction');
-    });
-
-    it('sendAlarmNotification rejection은 logger.error로 swallowed (회귀 가드)', async () => {
-      mockSendAlarmNotification.mockRejectedValueOnce(new Error('boom'));
-      mockGetStoredTripTrainCode.mockResolvedValue('TRAIN-1');
-      mockIsImminentByArrivalCode.mockReturnValue(true);
-
-      renderHook(() =>
-        useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
-      );
-
-      await waitFor(() => {
-        expect(mockSendAlarmNotification).toHaveBeenCalled();
-      });
-      // rejection이 swallow돼 후속 로깅이 정상 호출되는지 확인
-      await waitFor(() => {
-        const apiCalls = mockLogFiredAlarm.mock.calls.filter((c) => c[2] === 'api');
-        expect(apiCalls.length).toBeGreaterThan(0);
-      });
+      const apiLogCall = mockLogFiredAlarm.mock.calls[0];
+      expect(apiLogCall[1]).not.toHaveProperty('direction');
     });
 
     it('destinationId 없으면 trackedTrainCode를 null로 리셋한다', async () => {
@@ -2027,31 +1979,9 @@ describe('useStationAlarm', () => {
   });
 
   describe('fusionSource 라벨 전파 (#327)', () => {
-    it('fusionSource=gps 전달 시 sendAlarmNotification에 gpsOnly가 4번째 인자로 전달된다', async () => {
-      const route = makeDirectRoute(5, '2');
-      const destination = makeStation('D1', '강남');
-      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
-      renderHook(() =>
-        useStationAlarm(defaultInputs({ route, destination, fusionSource: 'gps' })),
-      );
-      await waitFor(() =>
-        expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, false, true, 'gpsOnly'),
-      );
-    });
-
-    it('locationUncertain=true 전달 시 source 무시하고 uncertain 전달', async () => {
-      const route = makeDirectRoute(5, '2');
-      const destination = makeStation('D1', '강남');
-      mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
-      renderHook(() =>
-        useStationAlarm(
-          defaultInputs({ route, destination, fusionSource: 'position-train', locationUncertain: true }),
-        ),
-      );
-      await waitFor(() =>
-        expect(mockSendAlarmNotification).toHaveBeenCalledWith(earlyDest, false, true, 'uncertain'),
-      );
-    });
+    // #2067 (Phase 2-device, D1) — sendAlarmNotification 제거로 notificationSource가 실제로
+    // 소비되던 유일한 경로가 사라졌다. notificationSource 계산 자체(useMemo)는 향후 재사용을
+    // 위해 보존하되, "sendAlarmNotification에 전달됨"을 검증하던 아래 두 테스트는 대상이 없어 제거.
 
     // #2064 (Phase 1-device) — station-passed 로컬 알림 제거로 notificationSource 전파 대상도
     // 사라짐(sendAlarmNotification 경로만 notificationSource를 계속 사용).
@@ -2191,7 +2121,7 @@ describe('useStationAlarm', () => {
       await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
       const etaCalls = mockLogFiredAlarm.mock.calls.filter((c) => c[2] === 'eta');
       expect(etaCalls).toHaveLength(1);
-      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+      expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
     });
 
     it('setFiredAlarms가 reject되어도 notification은 발사된다 (영속화 실패 graceful)', async () => {
@@ -2200,7 +2130,7 @@ describe('useStationAlarm', () => {
 
       renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
 
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1));
       await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', earlyDest, 'eta'));
     });
 
@@ -2342,7 +2272,7 @@ describe('useStationAlarm', () => {
       // 핵심: evaluate 진입 차단 → firedAlarms 슬롯 점유 없음(setFiredAlarms 미호출) → 발사 없음.
       expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
       expect(mockSetFiredAlarms).not.toHaveBeenCalled();
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('조기 발사로 오염되지 않아 window 경과 후 실제 도착에서 destination 정상 발사', async () => {
@@ -2370,13 +2300,13 @@ describe('useStationAlarm', () => {
       await waitFor(() =>
         expect(mockLogSuppressedPhaseGate).toHaveBeenCalledWith('gate-phase-warmup', destination.name),
       );
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
 
       // 실제 도착 시점: window 경과 + 좌표 갱신. firedAlarms가 비어 있으므로 dedup 없이 발사돼야 한다.
       nowSpy.mockReturnValue(baseTs + 10_001);
       rerender({ loc: { lat: 37.498, lng: 127.028 } });
 
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
       expect(mockLogFiredAlarm).toHaveBeenCalledWith('fg', earlyDest, 'eta');
     });
   });
@@ -2415,7 +2345,7 @@ describe('useStationAlarm', () => {
           }),
         );
       });
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('Phase rawEvent 있음 + speed=0이면 차단 + movement-static-speed 적재', async () => {
@@ -2432,14 +2362,14 @@ describe('useStationAlarm', () => {
           }),
         );
       });
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('Phase rawEvent 있음 + speed>=0.5(이동)이면 정상 발사 (positionStability=static 무시)', async () => {
       mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
       renderPhaseHook({ speedMps: 5, positionStability: 'static' });
 
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
     });
   });
 
@@ -2542,7 +2472,7 @@ describe('useStationAlarm', () => {
           }),
         );
       });
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('Phase rawEvent (early destination) + motionStationary=true → 차단 + movement-motion-stationary 적재', async () => {
@@ -2575,7 +2505,7 @@ describe('useStationAlarm', () => {
           }),
         );
       });
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('station-passed + motionStationary=true → 차단 + movement-motion-stationary 적재', async () => {
@@ -2703,7 +2633,7 @@ describe('useStationAlarm', () => {
         trainProgressing: true,
       });
 
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
       expect(mockLogSuppressedMovement).not.toHaveBeenCalledWith(
         expect.objectContaining({ reason: 'movement-motion-stationary' }),
       );
@@ -2719,7 +2649,7 @@ describe('useStationAlarm', () => {
         trainProgressing: true,
       });
 
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
       expect(mockLogSuppressedMovement).not.toHaveBeenCalledWith(
         expect.objectContaining({ reason: 'movement-static-speed' }),
       );
@@ -2737,7 +2667,7 @@ describe('useStationAlarm', () => {
         trainProgressing: true,
       });
 
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
       expect(mockLogSuppressedMovement).not.toHaveBeenCalledWith(
         expect.objectContaining({ reason: 'movement-static-position' }),
       );
@@ -2758,7 +2688,7 @@ describe('useStationAlarm', () => {
         trainProgressing: true,
       });
 
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
     });
 
     it('station-passed + motionStationary=true + trainProgressing=true → 정상 감지 (#2064 알림은 미발사)', async () => {
@@ -2791,7 +2721,7 @@ describe('useStationAlarm', () => {
           expect.objectContaining({ reason: 'movement-motion-stationary' }),
         );
       });
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('trainProgressing=undefined(기본값)면 기존 동작 (graceful fallback)', async () => {
@@ -2809,7 +2739,7 @@ describe('useStationAlarm', () => {
           expect.objectContaining({ reason: 'movement-static-speed' }),
         );
       });
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
   });
 
@@ -2948,7 +2878,7 @@ describe('useStationAlarm', () => {
       );
 
       // 첫 fire 완료까지 대기 — firedAlarmsRef에 'early:강남' 적재.
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1));
       expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
 
       // mock이 firedAlarms를 무시하므로 evaluateAlarmPhase는 다시 같은 rawEvent 반환 → fireAndLog 호출.
@@ -2960,7 +2890,7 @@ describe('useStationAlarm', () => {
       // microtask + effect 사이클 flush. setTimeout(0)으로 macrotask queue까지 비운다.
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+      expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
       expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
     });
 
@@ -2998,14 +2928,14 @@ describe('useStationAlarm', () => {
       );
 
       await waitFor(() => expect(mockLogSuppressedSleepFirstTransfer).toHaveBeenCalled());
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
 
       // sleep OFF 토글 → firedAlarms.delete가 sync 적용됐다면 다음 evaluation은 정상 발사.
       // delete가 빠지면 같은 키가 firedAlarms에 남아 진입 가드가 영구 봉쇄 → 회귀.
       useSettingsStore.setState({ sleepMode: false });
       rerender({ lat: 37.50001 });
 
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
     });
   });
 
@@ -3058,7 +2988,7 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('API imminent path: silence 활성이면 imminent도 차단', async () => {
@@ -3074,7 +3004,7 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('station-passed path: silence 활성이면 알림 차단 + lastNotifiedStationId 갱신 보존', async () => {
@@ -3099,7 +3029,7 @@ describe('useStationAlarm', () => {
       seedExpiredSilence();
       mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
       renderForSilence();
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
       expect(setStateSpy).toHaveBeenCalled();
       setStateSpy.mockRestore();
     });
@@ -3109,7 +3039,7 @@ describe('useStationAlarm', () => {
       seedExpiredSilence();
       setupApiImminent();
       renderForSilence();
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
       expect(clearSpy).toHaveBeenCalled();
       clearSpy.mockRestore();
     });
@@ -3127,14 +3057,14 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
     });
 
     it('silence state 없음 → 게이트 통과 (정상 발사)', async () => {
       useAlarmEventStore.setState({ dismissSilence: null });
       mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
       renderForSilence();
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
       expect(mockLogSuppressedDismissSilence).not.toHaveBeenCalled();
     });
 
@@ -3147,7 +3077,7 @@ describe('useStationAlarm', () => {
       mockEvaluateAlarmPhase.mockReturnValue(earlyDest);
       renderForSilence();
       // reject되어도 silence는 통과되어 알람 정상 발사.
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
       expect(clearSpy).toHaveBeenCalled();
       clearSpy.mockRestore();
     });
@@ -3797,7 +3727,7 @@ describe('useStationAlarm', () => {
       expect(phases).not.toContain('storage-synced');
       expect(phases).not.toContain('ready');
       // 'ready' 미도달 → phase 알람 보류.
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
       expect(mockEvaluateAlarmPhase).not.toHaveBeenCalled();
     });
 
@@ -3808,7 +3738,7 @@ describe('useStationAlarm', () => {
       renderHook(() => useStationAlarm(defaultInputs({ route, destination })));
 
       // 'ready' 도달 후 발사.
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1));
       const phases = mockLogHydrationTransition.mock.calls.map((c) => c[0]);
       expect(phases[phases.length - 1]).toBe('ready');
     });
@@ -5093,7 +5023,7 @@ describe('useStationAlarm', () => {
         expect(phaseBlocks.length).toBeGreaterThan(0);
       });
       // phase 알람 dispatch(sendAlarmNotification) 미호출.
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('Path C (subsurface verdict): SSoT 게이트 block 시 dispatch X', async () => {
@@ -5509,7 +5439,7 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('lockless + 사용자 명시 의향 X → destination phase ETA fire X (logSuppressedLocklessNoUserIntent)', async () => {
@@ -5538,7 +5468,7 @@ describe('useStationAlarm', () => {
           }),
         ),
       );
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('lock 활성 trip → station-passed FG GPS path 정상 발사 (backward compat)', async () => {
@@ -5600,7 +5530,7 @@ describe('useStationAlarm', () => {
         ),
       );
 
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
       expect(mockLogSuppressedLocklessNoUserIntent).not.toHaveBeenCalled();
     });
 
@@ -5657,7 +5587,7 @@ describe('useStationAlarm', () => {
         ),
       );
 
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1));
       // fire ledger 미개입 확인 — logSuppressedFireAlarmOnce 미호출.
       expect(mockLogSuppressedFireAlarmOnce).not.toHaveBeenCalled();
     });
@@ -5685,7 +5615,7 @@ describe('useStationAlarm', () => {
           'eta',
         ),
       );
-      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+      expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
       expect(mockLogSuppressedFireAlarmOnce).not.toHaveBeenCalled();
     });
 
@@ -5732,7 +5662,7 @@ describe('useStationAlarm', () => {
         ),
       );
       // 사용자에게 노출된 알람 0건 — ledger가 fire callback 실행 자체를 차단.
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
       // logFiredAlarm도 미호출 (fireAndLog 진입 X).
       expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
@@ -5822,7 +5752,7 @@ describe('useStationAlarm', () => {
       );
 
       // line=null이어도 fire 정상 진행 — 방어적 stringify로 dedup key 산출.
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1));
     });
   });
 
@@ -5859,7 +5789,7 @@ describe('useStationAlarm', () => {
           }),
         );
       });
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('flag ON + motionStationary=true → motion gate bypass → 정상 발사 (arrival API SSoT)', async () => {
@@ -5881,7 +5811,7 @@ describe('useStationAlarm', () => {
       );
 
       // motion=stationary인데도 알람 발사 — arrival API SSoT 아키텍처는 arvlCd 단독 신호로 판정.
-      await waitFor(() => expect(mockSendAlarmNotification).toHaveBeenCalled());
+      await waitFor(() => expect(mockLogFiredAlarm).toHaveBeenCalled());
       // movement 게이트 skip 로그 미적재 (dormant).
       expect(mockLogSuppressedMovement).not.toHaveBeenCalledWith(
         expect.objectContaining({ reason: 'movement-motion-stationary' }),

--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -1978,14 +1978,11 @@ describe('useStationAlarm', () => {
     });
   });
 
-  describe('fusionSource 라벨 전파 (#327)', () => {
-    // #2067 (Phase 2-device, D1) — sendAlarmNotification 제거로 notificationSource가 실제로
-    // 소비되던 유일한 경로가 사라졌다. notificationSource 계산 자체(useMemo)는 향후 재사용을
-    // 위해 보존하되, "sendAlarmNotification에 전달됨"을 검증하던 아래 두 테스트는 대상이 없어 제거.
-
-    // #2064 (Phase 1-device) — station-passed 로컬 알림 제거로 notificationSource 전파 대상도
-    // 사라짐(sendAlarmNotification 경로만 notificationSource를 계속 사용).
-    it('역 통과 감지에는 더 이상 notificationSource가 전달되지 않는다 (알림 자체가 없음)', async () => {
+  // #2067 (Phase 2-device, D1) — sendAlarmNotification 제거로 fusionSource → notificationSource
+  // 라벨을 조립하던 useMemo 자체가 죽은 코드가 되어 제거됨(#2067 리뷰 P2-1, 투기적 보존 금지).
+  // fusionSource 입력값이 station-passed dedup bookkeeping을 깨지 않는지만 남겨 검증한다.
+  describe('fusionSource 입력 시 station-passed dedup bookkeeping (#327 잔여)', () => {
+    it('fusionSource 전달돼도 station-passed는 알림 없이 dedup bookkeeping만 수행', async () => {
       const route = makeDirectRoute(5, '2');
       const destination = makeStation('D1', '강남');
       const station = makeStation('S1', '역삼');

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -20,7 +20,6 @@ import type { Station } from '../../../shared/types/station';
 import { alarmKey, parseAlarmKey, evaluateAlarmPhase, type AlarmEvent } from '../utils/stationAlarm';
 import { resolveAlarmDirection } from '../utils/alarmDirection';
 import { distanceMetersBetween, estimateEtaSeconds } from '../../../shared/utils/stationEta';
-import { sendAlarmNotification } from '../utils/stationNotification';
 import { isImminentByArrivalCode } from '../../arrival/utils/imminentArrivalSignal';
 import { findFgArvlCdFireSignal } from '../utils/fgArvlCdFastPath';
 import type { StationArrival } from '../../../shared/types/arrival';
@@ -637,22 +636,16 @@ export function useStationAlarm({
     [fusionSource, locationUncertain],
   );
   const sleepMode = useSettingsStore((s) => s.sleepMode);
-  const allowSpeaker = useSettingsStore((s) => s.allowSpeaker);
   const setAlarmEvent = useAlarmEventStore((s) => s.setAlarmEvent);
   // #746 — dismiss silence 게이트 평가용 in-memory state. clear는 만료 시점에
   // store action을 통해 호출(storage도 함께 정리). 게이트 자체는 pure 함수.
   const dismissSilence = useAlarmEventStore((s) => s.dismissSilence);
   const clearDismissSilenceAction = useAlarmEventStore((s) => s.clearDismissSilence);
   const sleepModeRef = useRef(sleepMode);
-  const allowSpeakerRef = useRef(allowSpeaker);
 
   useEffect(() => {
     sleepModeRef.current = sleepMode;
   }, [sleepMode]);
-
-  useEffect(() => {
-    allowSpeakerRef.current = allowSpeaker;
-  }, [allowSpeaker]);
 
   // #396: 트립 trainCode lock-in 상태를 destination 도착정보 갱신마다 재로드.
   // lock-in은 첫 valid arrival 캡처 시점에 일어나므로, arrival이 들어올 때마다 확인하면
@@ -959,16 +952,8 @@ export function useStationAlarm({
     if (sleepModeRef.current) {
       setAlarmEvent(event);
     }
-    try {
-      await sendAlarmNotification(
-        event,
-        sleepModeRef.current,
-        allowSpeakerRef.current,
-        notificationSource,
-      );
-    } catch (e) {
-      logger.error('알람 알림 실패:', e);
-    }
+    // #2067 (Phase 2-device, D1) — sendAlarmNotification 제거. 알람 배너는 원격 visible push가
+    // 담당(Phase 2-backend). FG는 이제 dedup ledger 기록 + in-app store stamp만 수행한다.
     logFiredAlarm('fg', event, trigger);
   }
 

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -80,7 +80,6 @@ import { useAlarmEventStore } from '../store/useAlarmEventStore';
 import { createLogger } from '../../../shared/utils/logger';
 import { isAccuracyAcceptable } from '../../nearest-station/utils/locationGates';
 import type { FusionConfidence, FusionSource } from '../../../shared/types/fusion';
-import { resolveNotificationSource } from '../utils/notificationSource';
 import { isSimpleArchEnabled } from '../../../shared/config/archFlag';
 
 const logger = createLogger('StationAlarm');
@@ -630,11 +629,6 @@ export function useStationAlarm({
   // destinationArrival 갱신)로 sync 한다. lock 부재면 null → resolveCurrentLine이
   // nearestStation.line으로 자연 fallback.
   const [currentLockLine, setCurrentLockLine] = useState<LineNumber | null>(null);
-  // fusion source → 알람 본문 라벨. 두 effect(phase / station-passed)가 공유.
-  const notificationSource = useMemo(
-    () => (fusionSource ? resolveNotificationSource(fusionSource, locationUncertain) : undefined),
-    [fusionSource, locationUncertain],
-  );
   const sleepMode = useSettingsStore((s) => s.sleepMode);
   const setAlarmEvent = useAlarmEventStore((s) => s.setAlarmEvent);
   // #746 — dismiss silence 게이트 평가용 in-memory state. clear는 만료 시점에
@@ -1557,7 +1551,6 @@ export function useStationAlarm({
     clearDismissSilenceAction,
     userLocation?.lat,
     userLocation?.lng,
-    notificationSource,
     // #1236 — currentHopIndex 변화가 sleep 룰 게이트 isFirstHop 판정에 영향.
     currentHopIndex,
     // #1266 — fast-path hop window 게이트 입력. arcStations 변화 시(환승 후 leg 전환 등) 재평가.
@@ -1634,7 +1627,6 @@ export function useStationAlarm({
     clearDismissSilenceAction,
     userLocation?.lat,
     userLocation?.lng,
-    notificationSource,
     currentHopIndex,
   ]);
 }

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -39,7 +39,7 @@ const mockLogSilentPushFired = jest.fn();
 const mockLogSilentPushSkipped = jest.fn();
 const mockLogCrossTripMirrorSkip = jest.fn();
 const mockLogBoardingPromptFired = jest.fn();
-const mockLogSleepTransferAlarmFired = jest.fn();
+const mockLogCompanionAlarmFired = jest.fn();
 const mockFlushAlarmLog = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../utils/alarmLog', () => ({
   logSilentPushReceived: (...args: unknown[]) => mockLogSilentPushReceived(...args),
@@ -51,14 +51,15 @@ jest.mock('../../utils/alarmLog', () => ({
   logSilentPushSkipped: (...args: unknown[]) => mockLogSilentPushSkipped(...args),
   logCrossTripMirrorSkip: (...args: unknown[]) => mockLogCrossTripMirrorSkip(...args),
   logBoardingPromptFired: (...args: unknown[]) => mockLogBoardingPromptFired(...args),
-  logSleepTransferAlarmFired: (...args: unknown[]) => mockLogSleepTransferAlarmFired(...args),
+  logCompanionAlarmFired: (...args: unknown[]) => mockLogCompanionAlarmFired(...args),
   flushAlarmLog: () => mockFlushAlarmLog(),
 }));
 
-// #2036 (Issue I γ) — sleep-transfer-alarm 발사 시 vibrateAlarm(true) 호출. mock으로 호출 횟수 검증.
-const mockVibrateAlarm = jest.fn();
-jest.mock('../../utils/alarmSound', () => ({
-  vibrateAlarm: (...args: unknown[]) => mockVibrateAlarm(...args),
+// #2067 (Phase 2-device, D3) — sleep-alarm-companion 수신 시 AlarmLocalAuthority가 단일 진입점.
+// 기본은 sleepMode gate 통과 + dedup 미적중(fired=true)로 동작하도록 mock.
+const mockFireCompanionAlarm = jest.fn().mockResolvedValue({ fired: true });
+jest.mock('../../utils/alarmLocalAuthority', () => ({
+  fireCompanionAlarm: (...args: unknown[]) => mockFireCompanionAlarm(...args),
 }));
 
 // #868 — trip-ended payload 수신 시 trip-bound storage cleanup.
@@ -231,7 +232,6 @@ jest.mock('i18next', () => ({
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   __resetBoardingPromptSilentPushDedup,
-  __resetSleepTransferAlarmSilentPushDedup,
   extractPayload,
   getSilentPushRegistrationStatus,
   handleSilentPush,
@@ -247,7 +247,6 @@ import {
   BACKEND_SSOT_MIRROR_KEY,
   DESTINATION_KEY,
   ROUTE_KEY,
-  SLEEP_MODE_KEY,
 } from '../../../../shared/constants/storageKeys';
 
 const DEFAULT_APNS_TOKEN = 'apns-tok-hex';
@@ -1256,14 +1255,15 @@ describe('silentPushTask', () => {
       });
     });
 
-    // #2036 (Issue I γ) — sleep-transfer-alarm silent push payload (취침모드 환승 알람 채널).
-    describe('sleep-transfer-alarm kind (#2036)', () => {
-      it('정상 sleep-transfer-alarm payload → SleepTransferAlarmSilentPushPayload', () => {
+    // #2036 (Issue I γ) → #2067 (Phase 2-device D3) — sleep-alarm-companion silent push payload.
+    describe('sleep-alarm-companion kind (#2067)', () => {
+      it('정상 sleep-alarm-companion payload → SleepAlarmCompanionSilentPushPayload', () => {
         expect(
           extractPayload(
             bgTaskData({
-              kind: 'sleep-transfer-alarm',
+              kind: 'sleep-alarm-companion',
               originStation: '성수',
+              targetKind: 'transfer',
               nextLine: '2',
               nextStation: '뚝섬',
               tripToken: 'tok-sta',
@@ -1274,8 +1274,9 @@ describe('silentPushTask', () => {
             }),
           ),
         ).toEqual({
-          kind: 'sleep-transfer-alarm',
+          kind: 'sleep-alarm-companion',
           originStation: '성수',
+          targetKind: 'transfer',
           nextLine: '2',
           nextStation: '뚝섬',
           tripToken: 'tok-sta',
@@ -1290,7 +1291,8 @@ describe('silentPushTask', () => {
         expect(
           extractPayload(
             bgTaskData({
-              kind: 'sleep-transfer-alarm',
+              kind: 'sleep-alarm-companion',
+              targetKind: 'transfer',
               nextLine: '2',
               nextStation: '뚝섬',
               tripToken: 'T',
@@ -1300,8 +1302,35 @@ describe('silentPushTask', () => {
         expect(
           extractPayload(
             bgTaskData({
-              kind: 'sleep-transfer-alarm',
+              kind: 'sleep-alarm-companion',
               originStation: '',
+              targetKind: 'transfer',
+              nextLine: '2',
+              nextStation: '뚝섬',
+              tripToken: 'T',
+            }),
+          ),
+        ).toBeNull();
+      });
+
+      it('targetKind 누락/유효하지 않은 값이면 null', () => {
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'sleep-alarm-companion',
+              originStation: '성수',
+              nextLine: '2',
+              nextStation: '뚝섬',
+              tripToken: 'T',
+            }),
+          ),
+        ).toBeNull();
+        expect(
+          extractPayload(
+            bgTaskData({
+              kind: 'sleep-alarm-companion',
+              originStation: '성수',
+              targetKind: 'unknown-kind',
               nextLine: '2',
               nextStation: '뚝섬',
               tripToken: 'T',
@@ -1314,8 +1343,9 @@ describe('silentPushTask', () => {
         expect(
           extractPayload(
             bgTaskData({
-              kind: 'sleep-transfer-alarm',
+              kind: 'sleep-alarm-companion',
               originStation: '성수',
+              targetKind: 'transfer',
               nextStation: '뚝섬',
               tripToken: 'T',
             }),
@@ -1324,8 +1354,9 @@ describe('silentPushTask', () => {
         expect(
           extractPayload(
             bgTaskData({
-              kind: 'sleep-transfer-alarm',
+              kind: 'sleep-alarm-companion',
               originStation: '성수',
+              targetKind: 'transfer',
               nextLine: '',
               nextStation: '뚝섬',
               tripToken: 'T',
@@ -1338,8 +1369,9 @@ describe('silentPushTask', () => {
         expect(
           extractPayload(
             bgTaskData({
-              kind: 'sleep-transfer-alarm',
+              kind: 'sleep-alarm-companion',
               originStation: '성수',
+              targetKind: 'transfer',
               nextLine: '2',
               tripToken: 'T',
             }),
@@ -1348,8 +1380,9 @@ describe('silentPushTask', () => {
         expect(
           extractPayload(
             bgTaskData({
-              kind: 'sleep-transfer-alarm',
+              kind: 'sleep-alarm-companion',
               originStation: '성수',
+              targetKind: 'transfer',
               nextLine: '2',
               nextStation: '',
               tripToken: 'T',
@@ -1358,12 +1391,13 @@ describe('silentPushTask', () => {
         ).toBeNull();
       });
 
-      it('tripToken 누락/빈 문자열이면 null (dedup key 필수)', () => {
+      it('tripToken 누락/빈 문자열이면 null (식별자 필수)', () => {
         expect(
           extractPayload(
             bgTaskData({
-              kind: 'sleep-transfer-alarm',
+              kind: 'sleep-alarm-companion',
               originStation: '성수',
+              targetKind: 'transfer',
               nextLine: '2',
               nextStation: '뚝섬',
             }),
@@ -1372,8 +1406,9 @@ describe('silentPushTask', () => {
         expect(
           extractPayload(
             bgTaskData({
-              kind: 'sleep-transfer-alarm',
+              kind: 'sleep-alarm-companion',
               originStation: '성수',
+              targetKind: 'transfer',
               nextLine: '2',
               nextStation: '뚝섬',
               tripToken: '',
@@ -1386,16 +1421,18 @@ describe('silentPushTask', () => {
         expect(
           extractPayload(
             bgTaskData({
-              kind: 'sleep-transfer-alarm',
+              kind: 'sleep-alarm-companion',
               originStation: '성수',
+              targetKind: 'destination',
               nextLine: '2',
               nextStation: '뚝섬',
               tripToken: 'T',
             }),
           ),
         ).toEqual({
-          kind: 'sleep-transfer-alarm',
+          kind: 'sleep-alarm-companion',
           originStation: '성수',
+          targetKind: 'destination',
           nextLine: '2',
           nextStation: '뚝섬',
           tripToken: 'T',
@@ -1410,8 +1447,9 @@ describe('silentPushTask', () => {
         expect(
           extractPayload(
             bgTaskData({
-              kind: 'sleep-transfer-alarm',
+              kind: 'sleep-alarm-companion',
               originStation: '성수',
+              targetKind: 'transfer',
               nextLine: '2',
               nextStation: '뚝섬',
               tripToken: 'T',
@@ -3035,15 +3073,18 @@ describe('silentPushTask', () => {
       });
     });
 
-    // #2036 (Issue I γ) — sleep-transfer-alarm silent push: gate 무관 로컬 알림 (sleepMode=true 시).
-    describe('sleep-transfer-alarm kind (#2036) — 취침모드 환승 알람 채널', () => {
-      function sleepTransferPayload(extra: Record<string, unknown> = {}) {
+    // #2036 (Issue I γ) → #2067 (Phase 2-device D3) — sleep-alarm-companion silent push:
+    // AlarmLocalAuthority가 sleepMode gate + dedup ledger를 단일 진입점으로 담당(mock).
+    // 본 describe는 handleSilentPush가 그 결과를 올바르게 소비/분기하는지만 검증한다.
+    describe('sleep-alarm-companion kind (#2067) — 취침모드 companion 알람 채널', () => {
+      function companionPayload(extra: Record<string, unknown> = {}) {
         return {
           data: {
             data: {
               data: {
-                kind: 'sleep-transfer-alarm',
+                kind: 'sleep-alarm-companion',
                 originStation: '성수',
+                targetKind: 'transfer',
                 nextLine: '2',
                 nextStation: '뚝섬',
                 tripToken: 'tok-sta',
@@ -3057,232 +3098,142 @@ describe('silentPushTask', () => {
         };
       }
 
-      /** sleepMode=true를 AsyncStorage에 세팅한다. 기본 destStation/APNS token 유지. */
-      function setSleepMode(enabled: boolean): void {
+      beforeEach(() => {
         (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
           if (key === DESTINATION_KEY) return JSON.stringify(destStation);
           if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
-          if (key === SLEEP_MODE_KEY) return JSON.stringify(enabled);
           return null;
         });
-      }
-
-      beforeEach(() => {
-        __resetSleepTransferAlarmSilentPushDedup();
+        mockFireCompanionAlarm.mockResolvedValue({ fired: true });
       });
 
-      it('sleepMode=true 수신 → scheduleNotificationAsync 즉시 호출 (gate 무관)', async () => {
-        setSleepMode(true);
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
-        expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+      it('수신 → fireCompanionAlarm에 tripToken/station/kind/body 전달', async () => {
+        await handleSilentPush(companionPayload({ pushId: 'sta-1' }));
+        expect(mockFireCompanionAlarm).toHaveBeenCalledWith({
+          tripToken: 'tok-sta',
+          station: '뚝섬',
+          kind: 'transfer',
+          body: '성수에서 2호선 뚝섬으로 환승',
+        });
         // standard 발사 경로는 호출되지 않아야 함.
         expect(mockLogSilentPushReceived).not.toHaveBeenCalled();
         expect(mockLogSilentPushFired).not.toHaveBeenCalled();
       });
 
-      it('sleepMode=false 수신 → 알림 발사 안 함 + ack(skipped, not-sleep-mode)', async () => {
-        setSleepMode(false);
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockVibrateAlarm).not.toHaveBeenCalled();
-        expect(mockLogSleepTransferAlarmFired).not.toHaveBeenCalled();
+      it('body 지정 시 backend 문구 그대로 전달 (device fallback 미사용)', async () => {
+        await handleSilentPush(
+          companionPayload({ pushId: 'sta-1', body: '커스텀 문구' }),
+        );
+        expect(mockFireCompanionAlarm).toHaveBeenCalledWith(
+          expect.objectContaining({ body: '커스텀 문구' }),
+        );
+      });
+
+      it('targetKind=destination이면 kind=destination으로 전달', async () => {
+        await handleSilentPush(
+          companionPayload({ pushId: 'sta-1', targetKind: 'destination' }),
+        );
+        expect(mockFireCompanionAlarm).toHaveBeenCalledWith(
+          expect.objectContaining({ kind: 'destination' }),
+        );
+      });
+
+      it('fired=true → nextStation의 OS 안전망 예약(tba/bl)을 ALARM_PHASES 전체 cancel', async () => {
+        await handleSilentPush(companionPayload({ pushId: 'sta-1' }));
+        // ALARM_PHASES = [early, imminent] → 각 2회 호출, 모두 nextStation='뚝섬' 대상.
+        expect(mockCancelTbaByStationPhase).toHaveBeenCalledTimes(2);
+        expect(mockCancelTbaByStationPhase).toHaveBeenNthCalledWith(1, '뚝섬', 'early');
+        expect(mockCancelTbaByStationPhase).toHaveBeenNthCalledWith(2, '뚝섬', 'imminent');
+        expect(mockCancelBlByStationPhase).toHaveBeenCalledTimes(2);
+        expect(mockCancelBlByStationPhase).toHaveBeenNthCalledWith(1, '뚝섬', 'early');
+        expect(mockCancelBlByStationPhase).toHaveBeenNthCalledWith(2, '뚝섬', 'imminent');
+      });
+
+      it('fired=false(not-sleep-mode) → OS 안전망 cancel 안 함 + ack(skipped, not-sleep-mode)', async () => {
+        mockFireCompanionAlarm.mockResolvedValueOnce({ fired: false, reason: 'not-sleep-mode' });
+        await handleSilentPush(companionPayload({ pushId: 'sta-1' }));
+        expect(mockCancelTbaByStationPhase).not.toHaveBeenCalled();
+        expect(mockCancelBlByStationPhase).not.toHaveBeenCalled();
+        expect(mockLogCompanionAlarmFired).not.toHaveBeenCalled();
         expect(mockSendPushAck).toHaveBeenCalledWith({
           pushId: 'sta-1',
           token: DEFAULT_APNS_TOKEN,
           outcome: 'skipped',
-          reason: 'sleep-transfer-not-sleep-mode',
+          reason: 'sleep-alarm-companion-not-sleep-mode',
           permissionMode: 'always',
         });
       });
 
-      it('SLEEP_MODE_KEY 저장값 없음 → 취침 아님으로 판정 (fail-closed)', async () => {
-        // 기본 mock — SLEEP_MODE_KEY 는 null 반환.
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        expect(mockSendPushAck).toHaveBeenCalledWith(
-          expect.objectContaining({ outcome: 'skipped', reason: 'sleep-transfer-not-sleep-mode' }),
-        );
-      });
-
-      it('SLEEP_MODE_KEY read throw → 취침 아님으로 판정 (fail-closed graceful)', async () => {
-        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
-          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
-          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
-          if (key === SLEEP_MODE_KEY) throw new Error('storage-fail');
-          return null;
-        });
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-      });
-
-      it('scheduleNotificationAsync content: title/body/sound/data/interruptionLevel 포함', async () => {
-        setSleepMode(true);
-        await handleSilentPush(
-          sleepTransferPayload({
-            pushId: 'sta-1',
-            title: '곧 환승역입니다',
-            body: '성수에서 2호선 뚝섬으로 환승',
-          }),
-        );
-        expect(mockScheduleNotificationAsync).toHaveBeenCalledWith({
-          identifier: 'sleep-transfer-alarm-silent-push',
-          content: {
-            title: '곧 환승역입니다',
-            body: '성수에서 2호선 뚝섬으로 환승',
-            sound: 'alarm.wav',
-            data: {
-              kind: 'sleep-transfer-alarm',
-              originStation: '성수',
-              nextLine: '2',
-              nextStation: '뚝섬',
-              tripToken: 'tok-sta',
-            },
-            interruptionLevel: 'timeSensitive',
-          },
-          trigger: null,
+      it('fired=false(dedup) → OS 안전망 cancel 안 함 + ack(skipped, dedup)', async () => {
+        mockFireCompanionAlarm.mockResolvedValueOnce({ fired: false, reason: 'dedup' });
+        await handleSilentPush(companionPayload({ pushId: 'sta-1' }));
+        expect(mockCancelTbaByStationPhase).not.toHaveBeenCalled();
+        expect(mockCancelBlByStationPhase).not.toHaveBeenCalled();
+        expect(mockSendPushAck).toHaveBeenCalledWith({
+          pushId: 'sta-1',
+          token: DEFAULT_APNS_TOKEN,
+          outcome: 'skipped',
+          reason: 'sleep-alarm-companion-dedup',
+          permissionMode: 'always',
         });
       });
 
-      it('title/body 누락 시 device fallback 문자열 사용', async () => {
-        setSleepMode(true);
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
-        const call = mockScheduleNotificationAsync.mock.calls[0][0] as {
-          content: { title: string; body: string };
-        };
-        expect(call.content.title).toBe('곧 환승역입니다');
-        expect(call.content.body).toContain('성수');
-        expect(call.content.body).toContain('2호선');
-        expect(call.content.body).toContain('뚝섬');
-      });
-
-      it('발사 시 vibrateAlarm(true) 호출 (사용자 확정 flow: 소리+진동)', async () => {
-        setSleepMode(true);
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
-        expect(mockVibrateAlarm).toHaveBeenCalledWith(true);
-      });
-
-      it('발사 시 logSleepTransferAlarmFired 호출 (Acceptance dashboard 반영)', async () => {
-        setSleepMode(true);
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
-        expect(mockLogSleepTransferAlarmFired).toHaveBeenCalledWith({
+      it('fired=true → logCompanionAlarmFired 호출 (Acceptance dashboard 반영)', async () => {
+        await handleSilentPush(companionPayload({ pushId: 'sta-1' }));
+        expect(mockLogCompanionAlarmFired).toHaveBeenCalledWith({
           originStation: '성수',
           nextStation: '뚝섬',
           nextLine: '2',
         });
       });
 
-      it('같은 tripToken + nextStation 세션 내 두 번째 수신은 dedup skip', async () => {
-        setSleepMode(true);
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-2' }));
-        expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
-        expect(mockVibrateAlarm).toHaveBeenCalledTimes(1);
-      });
-
-      it('같은 tripToken + 다른 nextStation은 각각 발사 (다음 환승 hop 커버)', async () => {
-        setSleepMode(true);
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1', nextStation: '뚝섬' }));
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-2', nextStation: '한양대' }));
-        expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(2);
-      });
-
-      it('다른 tripToken 수신은 각각 발사', async () => {
-        setSleepMode(true);
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1', tripToken: 'tok-A' }));
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-2', tripToken: 'tok-B' }));
-        expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(2);
-      });
-
-
-      it('pushId 있으면 ack(fired, sleep-transfer-alarm) 전송', async () => {
-        setSleepMode(true);
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+      it('pushId 있으면 ack(fired, sleep-alarm-companion) 전송', async () => {
+        await handleSilentPush(companionPayload({ pushId: 'sta-1' }));
         expect(mockSendPushAck).toHaveBeenCalledWith({
           pushId: 'sta-1',
           token: DEFAULT_APNS_TOKEN,
           outcome: 'fired',
-          reason: 'sleep-transfer-alarm',
+          reason: 'sleep-alarm-companion',
           permissionMode: 'always',
         });
       });
 
-      it('pushId 없으면 fired ack 호출 안 함 (구 backend 호환) — schedule은 진행', async () => {
-        setSleepMode(true);
-        await handleSilentPush(sleepTransferPayload());
+      it('pushId 없으면 fired ack 호출 안 함 (구 backend 호환) — 처리는 진행', async () => {
+        await handleSilentPush(companionPayload());
         const firedCalls = mockSendPushAck.mock.calls.filter(
           (call) => (call[0] as { outcome?: string }).outcome === 'fired',
         );
         expect(firedCalls).toHaveLength(0);
-        expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
-      });
-
-      it('dedup skip 시 ack(skipped, sleep-transfer-dedup) 전송', async () => {
-        setSleepMode(true);
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
-        mockSendPushAck.mockClear();
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-2' }));
-        expect(mockSendPushAck).toHaveBeenCalledWith({
-          pushId: 'sta-2',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'skipped',
-          reason: 'sleep-transfer-dedup',
-          permissionMode: 'always',
-        });
-      });
-
-      it('scheduleNotificationAsync throw해도 후속 흐름 차단 안 함 + ack skipped 전송', async () => {
-        setSleepMode(true);
-        mockScheduleNotificationAsync.mockRejectedValueOnce(new Error('schedule fail'));
-        await expect(
-          handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' })),
-        ).resolves.toBeUndefined();
-        expect(mockSendPushAck).toHaveBeenCalledWith({
-          pushId: 'sta-1',
-          token: DEFAULT_APNS_TOKEN,
-          outcome: 'skipped',
-          reason: 'sleep-transfer-schedule-failed',
-          permissionMode: 'always',
-        });
-      });
-
-      it('schedule 실패로 dedup 등록 상태 — 재시도가 새 알림을 발사하지 않음', async () => {
-        setSleepMode(true);
-        mockScheduleNotificationAsync.mockRejectedValueOnce(new Error('schedule fail'));
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
-        mockScheduleNotificationAsync.mockClear();
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-2' }));
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockFireCompanionAlarm).toHaveBeenCalledTimes(1);
       });
 
       it('domain breadcrumb 발사 (dashboard 관측)', async () => {
-        setSleepMode(true);
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+        await handleSilentPush(companionPayload({ pushId: 'sta-1' }));
         expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith(
           'push',
-          'sleep-transfer-alarm-fired',
+          'sleep-alarm-companion-fired',
           { nextLine: '2', originStation: '성수', nextStation: '뚝섬' },
         );
       });
 
-      it('sleepMode=false 시 dedup 등록 안 함 → 이후 sleepMode=true 전환 재시도는 정상 발사', async () => {
-        setSleepMode(false);
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
-        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
-        // 사용자가 취침모드 ON 후 backend 재시도.
-        setSleepMode(true);
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-2' }));
-        expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+      it('fired=false 시에는 fired breadcrumb 발사 안 함', async () => {
+        mockFireCompanionAlarm.mockResolvedValueOnce({ fired: false, reason: 'not-sleep-mode' });
+        await handleSilentPush(companionPayload({ pushId: 'sta-1' }));
+        expect(mockAddDomainBreadcrumb).not.toHaveBeenCalledWith(
+          'push',
+          'sleep-alarm-companion-fired',
+          expect.anything(),
+        );
       });
 
-      it('sleep-transfer-alarm 발사 후에도 refreshLiveActivityFromBackgroundContext 1회 호출 (#1935 정합)', async () => {
-        setSleepMode(true);
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+      it('sleep-alarm-companion 발사 후에도 refreshLiveActivityFromBackgroundContext 1회 호출 (#1935 정합)', async () => {
+        await handleSilentPush(companionPayload({ pushId: 'sta-1' }));
         expect(mockRefreshLa).toHaveBeenCalledTimes(1);
       });
 
-      it('sleepMode=false skip 후에도 refreshLA 1회 호출 (#1935 정합)', async () => {
-        setSleepMode(false);
-        await handleSilentPush(sleepTransferPayload({ pushId: 'sta-1' }));
+      it('skip 후에도 refreshLA 1회 호출 (#1935 정합)', async () => {
+        mockFireCompanionAlarm.mockResolvedValueOnce({ fired: false, reason: 'not-sleep-mode' });
+        await handleSilentPush(companionPayload({ pushId: 'sta-1' }));
         expect(mockRefreshLa).toHaveBeenCalledTimes(1);
       });
     });

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -19,7 +19,7 @@
  *   1. payload 검증 + 수신 로그 적재 (#478 측정 인프라)
  *   2. kind(transfer/destination/intermediate)는 device 로컬 알림을 발사하지 않는다.
  *      logSilentPushSkipped(reason='legacy-station-kind-ignored') 적재 후 no-op.
- *   3. boarding-prompt / sleep-transfer-alarm 등 별도 discriminator 채널은 기존대로 gate 무관 발사.
+ *   3. boarding-prompt / sleep-alarm-companion 등 별도 discriminator 채널은 기존대로 gate 무관 발사.
  *   4. 상태 sync(lock-release/widget/LA refresh)는 kind 무관 항상 수행.
  */
 
@@ -39,7 +39,6 @@ import {
   APNS_TOKEN_KEY,
   ACTIVE_TRIP_KEY,
   DESTINATION_KEY,
-  SLEEP_MODE_KEY,
 } from '../../../shared/constants/storageKeys';
 import { sendPushAck } from '../api/alarmBackend';
 import { createLogger } from '../../../shared/utils/logger';
@@ -51,10 +50,10 @@ import {
   logSilentPushRescheduleReceived,
   logSilentPushTripEndedReceived,
   logSilentPushSkipped,
-  logSleepTransferAlarmFired,
+  logCompanionAlarmFired,
   type AlarmLogReason,
 } from '../utils/alarmLog';
-import { vibrateAlarm } from '../utils/alarmSound';
+import { fireCompanionAlarm } from '../utils/alarmLocalAuthority';
 import { runTripBoundCleanups, cancelTripBoundOsQueue } from '../store/tripBoundCleanups';
 import {
   setTripEndedSentinel,
@@ -97,12 +96,6 @@ export const SILENT_PUSH_TASK = 'silent-push-reschedule';
 const BOARDING_PROMPT_NOTIFICATION_ID = 'boarding-prompt-silent-push';
 
 /**
- * #2036 (Issue I γ) — 취침모드 환승 알람 local notification identifier.
- * 같은 identifier로 schedule하면 iOS가 이전 알림을 대체 — 사용자 tray에 1건만 유지.
- */
-const SLEEP_TRANSFER_ALARM_NOTIFICATION_ID = 'sleep-transfer-alarm-silent-push';
-
-/**
  * #2028 — tripToken 세션 스코프 dedup. 같은 tripToken으로 여러 backend cron 재시도가 도달해도
  * 로컬 알림을 1회만 발사한다. in-memory Set — 앱 재시작(cold-launch) 시 자연 초기화되지만
  * backend `boardingPromptState.promptedAt` dedup이 자체 재발사를 차단하므로 회귀 없음.
@@ -110,29 +103,9 @@ const SLEEP_TRANSFER_ALARM_NOTIFICATION_ID = 'sleep-transfer-alarm-silent-push';
  */
 const boardingPromptFiredTripTokens = new Set<string>();
 
-/**
- * #2036 (Issue I γ) — 취침모드 환승 알람 dedup. tripToken + nextStation 조합 스코프.
- * 같은 trip의 다른 환승역(예: 강남→성수 후 성수→내방)은 별 hop이라 nextStation이 다르므로
- * 각각 발사됨. backend cron retry(같은 hop 재시도)만 dedup 대상. in-memory Set — 앱 재시작
- * 시 자연 초기화되지만 backend가 waypoint advance 후 재발사하지 않으므로 회귀 없음.
- */
-const sleepTransferAlarmFiredKeys = new Set<string>();
-
-function sleepTransferAlarmDedupKey(tripToken: string, nextStation: string): string {
-  return `${tripToken}::${nextStation}`;
-}
-
 /** 테스트 격리용 — dedup set을 비운다. production 코드에서는 호출하지 않는다. */
 export function __resetBoardingPromptSilentPushDedup(): void {
   boardingPromptFiredTripTokens.clear();
-}
-
-/**
- * #2036 (Issue I γ) — 테스트 격리용. sleep-transfer alarm dedup set을 비운다.
- * production 코드에서는 호출하지 않는다.
- */
-export function __resetSleepTransferAlarmSilentPushDedup(): void {
-  sleepTransferAlarmFiredKeys.clear();
 }
 
 export interface SilentPushPayload {
@@ -331,32 +304,31 @@ export interface BoardingPromptSilentPushPayload {
 }
 
 /**
- * 취침모드 환승 알람 silent push payload (#2036 Issue I γ).
+ * 취침모드 companion 알람 silent push payload (#2036 Issue I γ → #2067 Phase 2-device D3 전환).
  *
- * 사용자 확정 flow: "환승역 → 분기 → 취침모드 시 알람 발사, 일반모드는 일반 상황과 동일".
- * 즉 취침모드에서 환승 임박 시 소리+진동+잠금화면 알림이 필요.
+ * 사용자 확정 flow: "환승역/도착역 임박 → 취침모드 시 알람 발사, 일반모드는 일반 상황과 동일".
+ * 주 채널은 원격 visible push(`sound: alarm.wav`, #2066)로 전환됐고, 본 payload는 device가
+ * 깨어있을 때 TTS/진동으로 소리를 보강하고 OS 안전망 예약을 cancel하는 companion 채널이다.
  *
  * 정책 (ADR-023 정합):
  *  - **Backend는 취침 무관 발사** (기존 arvlCd/vanish/lockless 발사기가 취침 상태 조회하지 않음).
- *  - **Device가 sleepMode=true 확인 후 발사 결정** (`SLEEP_MODE_KEY` AsyncStorage read).
- *  - **destination은 별 채널** — 기존 station-passed dedup으로 처리, 본 payload는 transfer 전용.
- *  - gate 무관 (location / silence / motion / dedup 모두 skip) — 도달률 우선. boarding-prompt와 같은 정책.
+ *  - **Device가 sleepMode=true 확인 후 발사 결정** — `AlarmLocalAuthority.fireCompanionAlarm`이 게이트.
+ *  - 알림(배너) 생성 없음 — TTS + Haptics 진동만. dedup은 `AlarmLocalAuthority`의 persisted ledger(TTL 1h).
+ *  - gate 무관 (location / silence / motion 모두 skip) — 도달률 우선. boarding-prompt와 같은 정책.
  *
- * Critical alert entitlement 없이 최대 UX 근사: `interruptionLevel: 'timeSensitive'` + `sound: 'alarm.wav'`
- * + `vibrateAlarm(sleepMode=true)`(반복 진동). Focus/DND 완전 우회는 Apple entitlement 승인 필요 — 별 track.
- *
- * dedup: `${tripToken}::${nextStation}` 조합 — 같은 hop의 backend cron 재시도만 차단, trip 안의 다른
- * 환승 hop(강남→성수→내방 같은 케이스)은 각각 발사.
+ * targetKind — 알람 대상이 환승역인지 도착역인지(#2066). device는 문구/식별자 분기에 사용.
  */
-export interface SleepTransferAlarmSilentPushPayload {
-  kind: 'sleep-transfer-alarm';
-  /** 사용자가 지금 있는 역(환승 waypoint 도달 시점). 사용자 컨텍스트/dedup 기록용. */
+export interface SleepAlarmCompanionSilentPushPayload {
+  kind: 'sleep-alarm-companion';
+  /** 사용자가 지금 있는 역(직전 역, arvlCd 진입/도착 확정 시점). 사용자 컨텍스트/식별자 기록용. */
   originStation: string;
-  /** 환승 후 다음 leg의 노선. 알림 본문에 노출. */
+  /** 알람 대상이 환승역인지 도착역인지. device 문구/식별자 분기용. */
+  targetKind: 'transfer' | 'destination';
+  /** 알람 대상 역의 노선. 알림 본문에 노출. */
   nextLine: string;
-  /** 환승 후 첫 도착역. 알림 본문 + dedup key로 사용. */
+  /** 알람 대상 역(환승역 또는 도착역). 알림 본문 + 식별자로 사용. */
   nextStation: string;
-  /** trip 토큰 — dedup key. backend cron retry 차단용. */
+  /** trip 토큰 — 식별자 구성 + `AlarmLocalAuthority` ledger key로 사용. */
   tripToken: string;
   /**
    * push의 unique 식별자. backend `/push/ack`에 필요.
@@ -409,13 +381,13 @@ export type TripEndedReason =
   | 'push-unrecoverable'
   | 'unknown';
 
-/** extractPayload 결과 — standard silent push / reschedule / trip-ended / boarding-prompt / sleep-transfer-alarm. */
+/** extractPayload 결과 — standard silent push / reschedule / trip-ended / boarding-prompt / sleep-alarm-companion. */
 export type ExtractedPayload =
   | SilentPushPayload
   | RescheduleSilentPushPayload
   | TripEndedSilentPushPayload
   | BoardingPromptSilentPushPayload
-  | SleepTransferAlarmSilentPushPayload;
+  | SleepAlarmCompanionSilentPushPayload;
 
 /**
  * expo-notifications iOS의 `BackgroundEventTransformer.swift`가 APNs payload를
@@ -479,8 +451,8 @@ function isBoardingPromptCandidate(rec: Record<string, unknown>): boolean {
   return rec.kind === 'boarding-prompt';
 }
 
-function isSleepTransferAlarmCandidate(rec: Record<string, unknown>): boolean {
-  return rec.kind === 'sleep-transfer-alarm';
+function isSleepAlarmCompanionCandidate(rec: Record<string, unknown>): boolean {
+  return rec.kind === 'sleep-alarm-companion';
 }
 
 function findFieldsLayer(
@@ -503,7 +475,7 @@ function findFieldsLayer(
       isRescheduleCandidate(rec) ||
       isTripEndedCandidate(rec) ||
       isBoardingPromptCandidate(rec) ||
-      isSleepTransferAlarmCandidate(rec)
+      isSleepAlarmCompanionCandidate(rec)
     ) {
       return rec;
     }
@@ -529,8 +501,9 @@ export function extractPayload(
   if (obj.kind === 'trip-ended') return extractTripEndedPayload(obj);
   // boarding-prompt 분기 (#2028) — Layer 2 사용자 도달. discriminator는 kind === 'boarding-prompt'.
   if (obj.kind === 'boarding-prompt') return extractBoardingPromptPayload(obj);
-  // sleep-transfer-alarm 분기 (#2036 Issue I γ) — 취침 시 환승 알람. discriminator는 kind === 'sleep-transfer-alarm'.
-  if (obj.kind === 'sleep-transfer-alarm') return extractSleepTransferAlarmPayload(obj);
+  // sleep-alarm-companion 분기 (#2036 Issue I γ → #2067 D3) — 취침 시 companion 알람.
+  // discriminator는 kind === 'sleep-alarm-companion'.
+  if (obj.kind === 'sleep-alarm-companion') return extractSleepAlarmCompanionPayload(obj);
   return extractStandardPayload(obj);
 }
 
@@ -795,24 +768,28 @@ function extractBoardingPromptPayload(
 }
 
 /**
- * sleep-transfer-alarm payload 추출 (#2036 Issue I γ). schema — kind + originStation + nextLine +
- * nextStation + tripToken은 필수. pushId / sentAt / title / body 는 optional (구 backend 호환).
+ * sleep-alarm-companion payload 추출 (#2036 Issue I γ → #2067 D3). schema — kind + originStation +
+ * targetKind + nextLine + nextStation + tripToken은 필수. pushId / sentAt / title / body 는
+ * optional (구 backend 호환).
  *
- * 필수 필드(originStation/nextLine/nextStation/tripToken) 중 하나라도 비어 있으면 null → 발사 skip.
- * 발사에 필요한 최소 정보(사용자 컨텍스트/dedup)를 갖추지 못한 payload는 backend 정상 wire 문제로
+ * 필수 필드 중 하나라도 비어 있거나 targetKind가 'transfer'/'destination'이 아니면 null → 발사 skip.
+ * 발사에 필요한 최소 정보(사용자 컨텍스트/식별자)를 갖추지 못한 payload는 backend 정상 wire 문제로
  * 판정 — device는 조용히 drop.
  */
-function extractSleepTransferAlarmPayload(
+function extractSleepAlarmCompanionPayload(
   obj: Record<string, unknown>,
-): SleepTransferAlarmSilentPushPayload | null {
-  const { originStation, nextLine, nextStation, tripToken, pushId, sentAt, title, body } = obj;
+): SleepAlarmCompanionSilentPushPayload | null {
+  const { originStation, targetKind, nextLine, nextStation, tripToken, pushId, sentAt, title, body } =
+    obj;
   if (typeof originStation !== 'string' || originStation.length === 0) return null;
+  if (targetKind !== 'transfer' && targetKind !== 'destination') return null;
   if (typeof nextLine !== 'string' || nextLine.length === 0) return null;
   if (typeof nextStation !== 'string' || nextStation.length === 0) return null;
   if (typeof tripToken !== 'string' || tripToken.length === 0) return null;
   return {
-    kind: 'sleep-transfer-alarm',
+    kind: 'sleep-alarm-companion',
     originStation,
+    targetKind,
     nextLine,
     nextStation,
     tripToken,
@@ -1153,18 +1130,19 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
       return;
     }
 
-    // sleep-transfer-alarm 분기 (#2036 Issue I γ) — 취침모드 환승 알람. gate 무관 로컬 알림 발사.
+    // sleep-alarm-companion 분기 (#2036 Issue I γ → #2067 Phase 2-device D3) — 취침모드 companion
+    // 알람. 알림(배너) 생성 없이 TTS/진동만 부가하고 OS 안전망 예약을 cancel한다.
     //
     // 정책 (ADR-023 정합):
     //  - Backend는 취침 무관 발사 (기존 arvlCd/vanish 경로는 sleep 조회 없음).
-    //  - Device가 `SLEEP_MODE_KEY` AsyncStorage read로 sleepMode=true 확인 후에만 발사.
-    //  - sleepMode=false면 일반모드 = 기존 station-passed silent push가 처리 → 본 분기는 no-op skip.
-    //  - dedup: `${tripToken}::${nextStation}` — 같은 hop의 backend cron retry 차단, trip 안 다른 환승 hop은 각각 발사.
-    if (payload.kind === 'sleep-transfer-alarm') {
+    //  - Device가 `AlarmLocalAuthority.fireCompanionAlarm`이 sleepMode=true 확인 후에만 발사.
+    //  - sleepMode=false면 일반모드 = 원격 visible push(#2066)가 주 채널 담당 → 본 분기는 no-op skip.
+    //  - dedup: `AlarmLocalAuthority`의 persisted ledger(TTL 1h) — 앱 재시작 생존.
+    if (payload.kind === 'sleep-alarm-companion') {
       logger.info(
-        `sleep-transfer-alarm received: originStation=${payload.originStation} nextLine=${payload.nextLine} nextStation=${payload.nextStation} tripToken=${payload.tripToken.slice(0, 8)} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
+        `sleep-alarm-companion received: originStation=${payload.originStation} targetKind=${payload.targetKind} nextLine=${payload.nextLine} nextStation=${payload.nextStation} tripToken=${payload.tripToken.slice(0, 8)} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
       );
-      await fireSleepTransferAlarmLocalNotification(payload, apnsToken);
+      await fireSleepAlarmCompanion(payload, apnsToken);
       return;
     }
 
@@ -1518,115 +1496,66 @@ async function fireBoardingPromptLocalNotification(
 }
 
 /**
- * #2036 (Issue I γ) — AsyncStorage에서 sleepMode 값 읽기 (BG-safe).
- *
- * silent push handler는 BG task라 zustand store 접근 불가 — AsyncStorage 직접 read.
- * `useSettingsStore.setSleepMode`가 JSON.stringify(boolean)으로 저장하므로 그대로 파싱.
- * 저장값 부재 / 파싱 실패는 false 반환 — 취침 아님으로 판정해 발사 skip (보수적).
- */
-async function readSleepModeFromStorage(): Promise<boolean> {
-  try {
-    const raw = await AsyncStorage.getItem(SLEEP_MODE_KEY);
-    if (!raw) return false;
-    return JSON.parse(raw) === true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * #2036 (Issue I γ) — 취침모드 환승 알람 silent push 수신 시 로컬 알림 발사.
+ * #2067 (Phase 2-device, D3) — 취침모드 companion 알람 silent push 수신 시 처리.
  *
  * 절차:
- *   1. sleepMode=false → 일반모드 = 기존 station-passed silent push가 이미 처리 → skip.
- *   2. dedup key(`${tripToken}::${nextStation}`) 확인 → 이미 발사 시 skip (backend cron retry 차단).
- *   3. dedup 등록 + Notifications.scheduleNotificationAsync 발사.
- *      - sound: 'alarm.wav' (loud, boarding-prompt의 'default'보다 강함)
- *      - interruptionLevel: 'timeSensitive' (Focus 관통, DND 부분 관통)
- *      - vibrateAlarm(true) — 반복 진동 (사용자 확정 flow: 소리+진동)
- *   4. 실패 시 dedup 유지 + ack skipped — cron retry가 재발사하지 않도록 함.
+ *   1. `AlarmLocalAuthority.fireCompanionAlarm` 호출 — sleepMode gate + persisted ledger dedup +
+ *      TTS/진동 발사를 단일 진입점이 담당한다. 알림(배너) 생성 없음.
+ *   2. 발사 성공 시 해당 station의 OS 안전망 예약(tba/bl)을 cancel — companion 도달 = 사용자가
+ *      이미 소리/진동으로 인지했으므로 중복 안전망 알림이 불필요하다 (#2089로 분리된 통합 전까지는
+ *      기존 3종 스케줄러의 cancel 헬퍼를 그대로 재사용).
+ *   3. skip 사유(not-sleep-mode / dedup)에 따라 ack outcome을 분기.
  *
- * gate 무관 (location / silence / motion / dedup 모두 skip) — boarding-prompt와 같은 도달률 우선 정책.
- * 사용자 확정 flow (`project_2026_07_03_user_manual_action_flow`): "환승역 → 취침 시 알람 발사".
+ * gate 무관 (location / silence / motion 모두 skip) — boarding-prompt와 같은 도달률 우선 정책.
+ * 사용자 확정 flow (`project_2026_07_03_user_manual_action_flow`): "환승역/도착역 → 취침 시 알람 발사".
  *
- * ADR-023 정합: backend는 취침 무관 발사, device가 필터 → 본 함수가 device 필터의 결정 지점.
+ * ADR-023 정합: backend는 취침 무관 발사, device가 필터 → `fireCompanionAlarm`이 필터의 결정 지점.
  */
-async function fireSleepTransferAlarmLocalNotification(
-  payload: SleepTransferAlarmSilentPushPayload,
+async function fireSleepAlarmCompanion(
+  payload: SleepAlarmCompanionSilentPushPayload,
   apnsToken: string | null,
 ): Promise<void> {
-  // sleepMode=false → 일반모드. 기존 경로가 처리 — 본 채널은 no-op.
-  const sleepMode = await readSleepModeFromStorage();
-  if (!sleepMode) {
-    logger.info(
-      `sleep-transfer-alarm skip: sleepMode=false (일반모드는 기존 station-passed 경로 처리)`,
-    );
-    void ackOutcome(payload.pushId, apnsToken, 'skipped', 'sleep-transfer-not-sleep-mode');
-    return;
-  }
-
-  // dedup — tripToken + nextStation 조합. 같은 hop의 backend cron retry만 차단.
-  const dedupKey = sleepTransferAlarmDedupKey(payload.tripToken, payload.nextStation);
-  if (sleepTransferAlarmFiredKeys.has(dedupKey)) {
-    logger.info(
-      `sleep-transfer-alarm dedup: tripToken=${payload.tripToken.slice(0, 8)} nextStation=${payload.nextStation} already fired in session — skip`,
-    );
-    void ackOutcome(payload.pushId, apnsToken, 'skipped', 'sleep-transfer-dedup');
-    return;
-  }
-
-  // dedup 등록 먼저 — scheduleNotificationAsync 실패해도 재시도로 반복 발사되지 않도록.
-  sleepTransferAlarmFiredKeys.add(dedupKey);
-
-  // 사용자 표시 문구. backend 우선 → device fallback.
-  const title = payload.title ?? '곧 환승역입니다';
   const body =
     payload.body ??
     `${payload.originStation}에서 ${payload.nextLine}호선 ${payload.nextStation}으로 환승`;
 
-  const data: Record<string, unknown> = {
-    kind: 'sleep-transfer-alarm',
-    originStation: payload.originStation,
-    nextLine: payload.nextLine,
-    nextStation: payload.nextStation,
+  const result = await fireCompanionAlarm({
     tripToken: payload.tripToken,
-  };
+    station: payload.nextStation,
+    kind: payload.targetKind,
+    body,
+  });
 
-  try {
-    await Notifications.scheduleNotificationAsync({
-      identifier: SLEEP_TRANSFER_ALARM_NOTIFICATION_ID,
-      content: {
-        title,
-        body,
-        // 취침모드 알람 — loud sound. 일반 알람과 동일한 파일(`stationNotification.ts:602`) 사용.
-        sound: 'alarm.wav',
-        data,
-        // Focus 관통 (Sleep Focus 부분 관통). Critical alert entitlement 승인 시 'critical'로 승격 예정.
-        interruptionLevel: 'timeSensitive',
-      },
-      trigger: null,
-    });
-    // 사용자 확정 flow: 소리+진동. sleepMode=true → repeat 진동.
-    vibrateAlarm(true);
-    // #2036 Acceptance dashboard — sleep-transfer-alarm fired 카운트.
-    logSleepTransferAlarmFired({
-      originStation: payload.originStation,
-      nextStation: payload.nextStation,
-      nextLine: payload.nextLine,
-    });
-    addDomainBreadcrumb('push', 'sleep-transfer-alarm-fired', {
-      nextLine: payload.nextLine,
-      originStation: payload.originStation,
-      nextStation: payload.nextStation,
-    });
+  if (!result.fired) {
+    const reason =
+      result.reason === 'dedup' ? 'sleep-alarm-companion-dedup' : 'sleep-alarm-companion-not-sleep-mode';
     logger.info(
-      `sleep-transfer-alarm fired: originStation=${payload.originStation} nextLine=${payload.nextLine} nextStation=${payload.nextStation} tripToken=${payload.tripToken.slice(0, 8)}`,
+      `sleep-alarm-companion skip: reason=${result.reason} nextStation=${payload.nextStation}`,
     );
-    void ackOutcome(payload.pushId, apnsToken, 'fired', 'sleep-transfer-alarm');
-  } catch (e) {
-    logger.error('sleep-transfer-alarm local notification schedule 실패:', e);
-    void ackOutcome(payload.pushId, apnsToken, 'skipped', 'sleep-transfer-schedule-failed');
+    void ackOutcome(payload.pushId, apnsToken, 'skipped', reason);
+    return;
   }
+
+  // companion 도달 = 사용자가 이미 소리/진동으로 인지 → 남은 OS 안전망 예약(tba/bl)을 정리.
+  for (const phase of ALARM_PHASES) {
+    await cancelTbaByStationPhase(payload.nextStation, phase.id);
+    await cancelBlByStationPhase(payload.nextStation, phase.id);
+  }
+
+  logCompanionAlarmFired({
+    originStation: payload.originStation,
+    nextStation: payload.nextStation,
+    nextLine: payload.nextLine,
+  });
+  addDomainBreadcrumb('push', 'sleep-alarm-companion-fired', {
+    nextLine: payload.nextLine,
+    originStation: payload.originStation,
+    nextStation: payload.nextStation,
+  });
+  logger.info(
+    `sleep-alarm-companion fired: originStation=${payload.originStation} nextLine=${payload.nextLine} nextStation=${payload.nextStation} tripToken=${payload.tripToken.slice(0, 8)}`,
+  );
+  void ackOutcome(payload.pushId, apnsToken, 'fired', 'sleep-alarm-companion');
 }
 
 

--- a/src/features/alarm/utils/__tests__/alarmLocalAuthority.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLocalAuthority.test.ts
@@ -1,0 +1,211 @@
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+jest.mock('../alarmSound', () => ({
+  vibrateAlarm: jest.fn(),
+}));
+
+jest.mock('../tts', () => ({
+  speakAlarm: jest.fn(),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  buildAlarmLocalId,
+  hasFiredLocally,
+  fireCompanionAlarm,
+  __resetAlarmLocalLedgerForTest,
+  ALARM_LOCAL_LEDGER_TTL_MS,
+} from '../alarmLocalAuthority';
+import { vibrateAlarm } from '../alarmSound';
+import { speakAlarm } from '../tts';
+import { ALARM_LOCAL_LEDGER_KEY, SLEEP_MODE_KEY } from '../../../../shared/constants/storageKeys';
+
+const mockedGetItem = AsyncStorage.getItem as jest.Mock;
+const mockedSetItem = AsyncStorage.setItem as jest.Mock;
+const mockedRemoveItem = AsyncStorage.removeItem as jest.Mock;
+const mockedVibrate = vibrateAlarm as jest.Mock;
+const mockedSpeak = speakAlarm as jest.Mock;
+
+const NOW = 1_700_000_000_000;
+
+function mockStorage(values: Record<string, string | null>): void {
+  mockedGetItem.mockImplementation(async (key: string) => values[key] ?? null);
+}
+
+describe('buildAlarmLocalId', () => {
+  it('결정적 identifier를 조립한다', () => {
+    expect(buildAlarmLocalId('trip-1', '강남', 'transfer')).toBe('alarm-trip-1-강남-transfer');
+    expect(buildAlarmLocalId('trip-1', '성수', 'destination')).toBe('alarm-trip-1-성수-destination');
+  });
+});
+
+describe('hasFiredLocally', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedSetItem.mockResolvedValue(undefined);
+  });
+
+  it('ledger가 비어있으면 false', async () => {
+    mockStorage({});
+    expect(await hasFiredLocally('id-1', NOW)).toBe(false);
+  });
+
+  it('storage read 실패 시 false (graceful)', async () => {
+    mockedGetItem.mockRejectedValue(new Error('boom'));
+    expect(await hasFiredLocally('id-1', NOW)).toBe(false);
+  });
+
+  it('malformed JSON이면 false', async () => {
+    mockStorage({ [ALARM_LOCAL_LEDGER_KEY]: 'not-json' });
+    expect(await hasFiredLocally('id-1', NOW)).toBe(false);
+  });
+
+  it('배열이 아닌 값이면 false', async () => {
+    mockStorage({ [ALARM_LOCAL_LEDGER_KEY]: JSON.stringify({ foo: 'bar' }) });
+    expect(await hasFiredLocally('id-1', NOW)).toBe(false);
+  });
+
+  it('형식이 잘못된 entry는 필터링된다', async () => {
+    mockStorage({
+      [ALARM_LOCAL_LEDGER_KEY]: JSON.stringify([
+        { id: 'id-1' }, // firedAt 누락
+        null,
+        'string-entry',
+        { id: 'id-2', firedAt: NOW },
+      ]),
+    });
+    expect(await hasFiredLocally('id-1', NOW)).toBe(false);
+    expect(await hasFiredLocally('id-2', NOW)).toBe(true);
+  });
+
+  it('TTL 이내 entry는 true', async () => {
+    mockStorage({
+      [ALARM_LOCAL_LEDGER_KEY]: JSON.stringify([{ id: 'id-1', firedAt: NOW - 1000 }]),
+    });
+    expect(await hasFiredLocally('id-1', NOW)).toBe(true);
+  });
+
+  it('TTL 만료 entry는 false', async () => {
+    mockStorage({
+      [ALARM_LOCAL_LEDGER_KEY]: JSON.stringify([
+        { id: 'id-1', firedAt: NOW - ALARM_LOCAL_LEDGER_TTL_MS - 1 },
+      ]),
+    });
+    expect(await hasFiredLocally('id-1', NOW)).toBe(false);
+  });
+});
+
+describe('fireCompanionAlarm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedSetItem.mockResolvedValue(undefined);
+  });
+
+  it('sleepMode off면 skip (not-sleep-mode)', async () => {
+    mockStorage({ [SLEEP_MODE_KEY]: JSON.stringify(false) });
+    const result = await fireCompanionAlarm({
+      tripToken: 'trip-1',
+      station: '강남',
+      kind: 'transfer',
+      body: '곧 강남입니다',
+    });
+    expect(result).toEqual({ fired: false, reason: 'not-sleep-mode' });
+    expect(mockedVibrate).not.toHaveBeenCalled();
+    expect(mockedSpeak).not.toHaveBeenCalled();
+  });
+
+  it('sleepMode 키 부재면 not-sleep-mode로 skip', async () => {
+    mockStorage({});
+    const result = await fireCompanionAlarm({
+      tripToken: 'trip-1',
+      station: '강남',
+      kind: 'transfer',
+      body: '곧 강남입니다',
+    });
+    expect(result.reason).toBe('not-sleep-mode');
+  });
+
+  it('sleepMode 읽기 실패 시 not-sleep-mode로 보수적 skip', async () => {
+    mockedGetItem.mockRejectedValue(new Error('boom'));
+    const result = await fireCompanionAlarm({
+      tripToken: 'trip-1',
+      station: '강남',
+      kind: 'transfer',
+      body: '곧 강남입니다',
+    });
+    expect(result.reason).toBe('not-sleep-mode');
+  });
+
+  it('sleepMode on + 최초 수신 → TTS + 진동 발사', async () => {
+    mockStorage({ [SLEEP_MODE_KEY]: JSON.stringify(true) });
+    const result = await fireCompanionAlarm({
+      tripToken: 'trip-1',
+      station: '강남',
+      kind: 'transfer',
+      body: '곧 강남입니다',
+    });
+    expect(result).toEqual({ fired: true });
+    expect(mockedVibrate).toHaveBeenCalledWith(true);
+    expect(mockedSpeak).toHaveBeenCalledWith('곧 강남입니다', {
+      sleepMode: false,
+      allowSpeaker: true,
+    });
+    expect(mockedSetItem).toHaveBeenCalledWith(
+      ALARM_LOCAL_LEDGER_KEY,
+      expect.stringContaining('alarm-trip-1-강남-transfer'),
+    );
+  });
+
+  it('같은 id 재수신 → dedup으로 skip', async () => {
+    const values: Record<string, string | null> = {
+      [SLEEP_MODE_KEY]: JSON.stringify(true),
+      [ALARM_LOCAL_LEDGER_KEY]: JSON.stringify([
+        { id: 'alarm-trip-1-강남-transfer', firedAt: Date.now() },
+      ]),
+    };
+    mockStorage(values);
+    const result = await fireCompanionAlarm({
+      tripToken: 'trip-1',
+      station: '강남',
+      kind: 'transfer',
+      body: '곧 강남입니다',
+    });
+    expect(result).toEqual({ fired: false, reason: 'dedup' });
+    expect(mockedVibrate).not.toHaveBeenCalled();
+    expect(mockedSpeak).not.toHaveBeenCalled();
+  });
+
+  it('ledger write 실패해도 예외를 던지지 않는다 (graceful)', async () => {
+    mockStorage({ [SLEEP_MODE_KEY]: JSON.stringify(true) });
+    mockedSetItem.mockRejectedValue(new Error('write failed'));
+    await expect(
+      fireCompanionAlarm({
+        tripToken: 'trip-1',
+        station: '강남',
+        kind: 'destination',
+        body: '도착했습니다',
+      }),
+    ).resolves.toEqual({ fired: true });
+  });
+});
+
+describe('__resetAlarmLocalLedgerForTest', () => {
+  it('ledger key를 제거한다', async () => {
+    mockedRemoveItem.mockResolvedValue(undefined);
+    await __resetAlarmLocalLedgerForTest();
+    expect(mockedRemoveItem).toHaveBeenCalledWith(ALARM_LOCAL_LEDGER_KEY);
+  });
+});

--- a/src/features/alarm/utils/__tests__/alarmLocalAuthority.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLocalAuthority.test.ts
@@ -31,7 +31,11 @@ import {
 } from '../alarmLocalAuthority';
 import { vibrateAlarm } from '../alarmSound';
 import { speakAlarm } from '../tts';
-import { ALARM_LOCAL_LEDGER_KEY, SLEEP_MODE_KEY } from '../../../../shared/constants/storageKeys';
+import {
+  ALARM_LOCAL_LEDGER_KEY,
+  SLEEP_MODE_KEY,
+  ALLOW_SPEAKER_KEY,
+} from '../../../../shared/constants/storageKeys';
 
 const mockedGetItem = AsyncStorage.getItem as jest.Mock;
 const mockedSetItem = AsyncStorage.setItem as jest.Mock;
@@ -167,6 +171,77 @@ describe('fireCompanionAlarm', () => {
       ALARM_LOCAL_LEDGER_KEY,
       expect.stringContaining('alarm-trip-1-강남-transfer'),
     );
+  });
+
+  // speakAlarm 자체(mock)는 게이트 로직이 없다 — 실제 skip 동작은 tts.test.ts가 검증.
+  // 본 테스트는 fireCompanionAlarm이 저장된 사용자 설정을 speakAlarm에 정확히 전달하는지만 확인.
+  it('#2067 리뷰 P1: allowSpeaker=false → speakAlarm에 allowSpeaker:false 전달 + 진동은 그대로 발생', async () => {
+    mockStorage({
+      [SLEEP_MODE_KEY]: JSON.stringify(true),
+      [ALLOW_SPEAKER_KEY]: JSON.stringify(false),
+    });
+    const result = await fireCompanionAlarm({
+      tripToken: 'trip-2',
+      station: '역삼',
+      kind: 'transfer',
+      body: '곧 역삼입니다',
+    });
+    expect(result).toEqual({ fired: true });
+    expect(mockedVibrate).toHaveBeenCalledWith(true);
+    expect(mockedSpeak).toHaveBeenCalledWith('곧 역삼입니다', {
+      sleepMode: false,
+      allowSpeaker: false,
+    });
+  });
+
+  it('#2067 리뷰 P1: allowSpeaker=true → TTS 1회 발화 (사용자 설정 반영)', async () => {
+    mockStorage({
+      [SLEEP_MODE_KEY]: JSON.stringify(true),
+      [ALLOW_SPEAKER_KEY]: JSON.stringify(true),
+    });
+    const result = await fireCompanionAlarm({
+      tripToken: 'trip-3',
+      station: '선릉',
+      kind: 'destination',
+      body: '곧 선릉입니다',
+    });
+    expect(result).toEqual({ fired: true });
+    expect(mockedSpeak).toHaveBeenCalledWith('곧 선릉입니다', {
+      sleepMode: false,
+      allowSpeaker: true,
+    });
+  });
+
+  it('#2067 리뷰 P1: ALLOW_SPEAKER_KEY 저장값 없음 → true(허용)로 보수적 fallback', async () => {
+    mockStorage({ [SLEEP_MODE_KEY]: JSON.stringify(true) });
+    await fireCompanionAlarm({
+      tripToken: 'trip-4',
+      station: '삼성',
+      kind: 'transfer',
+      body: '곧 삼성입니다',
+    });
+    expect(mockedSpeak).toHaveBeenCalledWith('곧 삼성입니다', {
+      sleepMode: false,
+      allowSpeaker: true,
+    });
+  });
+
+  it('#2067 리뷰 P1: ALLOW_SPEAKER_KEY 읽기 실패 → true(허용)로 보수적 fallback', async () => {
+    mockedGetItem.mockImplementation(async (key: string) => {
+      if (key === SLEEP_MODE_KEY) return JSON.stringify(true);
+      if (key === ALLOW_SPEAKER_KEY) throw new Error('boom');
+      return null;
+    });
+    await fireCompanionAlarm({
+      tripToken: 'trip-5',
+      station: '종합운동장',
+      kind: 'destination',
+      body: '곧 종합운동장입니다',
+    });
+    expect(mockedSpeak).toHaveBeenCalledWith('곧 종합운동장입니다', {
+      sleepMode: false,
+      allowSpeaker: true,
+    });
   });
 
   it('같은 id 재수신 → dedup으로 skip', async () => {

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -77,7 +77,7 @@ import {
   lastNReasons,
   logBoardingPromptFired,
   logBoardingPromptResponded,
-  logSleepTransferAlarmFired,
+  logCompanionAlarmFired,
   logLegTransition,
   BOARDING_PROMPT_WINDOWS,
   countBoardingPromptByWindow,
@@ -2237,9 +2237,9 @@ describe('alarmLog', () => {
       expect(saved[0].stationName).toBe('2·강남');
     });
 
-    it('#2036 (Issue I γ): logSleepTransferAlarmFired가 sleep-transfer-alarm entry를 적재한다', async () => {
+    it('#2067 (Phase 2-device, D3): logCompanionAlarmFired가 companion entry를 적재한다', async () => {
       (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
-      logSleepTransferAlarmFired({
+      logCompanionAlarmFired({
         originStation: '성수',
         nextStation: '뚝섬',
         nextLine: '2',
@@ -2247,29 +2247,29 @@ describe('alarmLog', () => {
       await flushAlarmLog();
       const saved = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
       expect(saved).toHaveLength(1);
-      expect(saved[0].source).toBe('sleep-transfer-alarm');
+      expect(saved[0].source).toBe('companion');
       expect(saved[0].outcome).toBe('fired');
       expect(saved[0].stationName).toBe('2·뚝섬');
     });
 
-    it('#2036 (Issue I γ): sleep-transfer-alarm source는 silent push outcome 집계에서 제외 (null bucket)', () => {
+    it('#2067 (Phase 2-device, D3): companion source는 silent push outcome 집계에서 제외 (null bucket)', () => {
       const now = 1_700_000_000_000;
       const entries: AlarmLogEntry[] = [
-        { ts: now - 1000, source: 'sleep-transfer-alarm', outcome: 'fired' },
+        { ts: now - 1000, source: 'companion', outcome: 'fired' },
         { ts: now - 2000, source: 'silent-push-fired', outcome: 'fired' },
       ];
       const counts = countSilentPushOutcomes(entries);
-      // sleep-transfer-alarm은 SILENT_PUSH_OUTCOME_SOURCES에서 null bucket — silent push 카운터에 미반영.
+      // companion은 SILENT_PUSH_OUTCOME_SOURCES에서 null bucket — silent push 카운터에 미반영.
       expect(counts).toEqual({ received: 0, fired: 1, skipped: 0 });
     });
 
-    it('#2036 (Issue I γ): sleep-transfer-alarm은 fire 분모에 포함 (실제 사용자 노출 알람)', () => {
+    it('#2067 (Phase 2-device, D3): companion은 fire 분모에 포함 (실제 사용자 노출 알람)', () => {
       const now = 1_700_000_000_000;
       const entries: AlarmLogEntry[] = [
-        { ts: now - 1000, source: 'sleep-transfer-alarm', outcome: 'fired' },
+        { ts: now - 1000, source: 'companion', outcome: 'fired' },
         { ts: now - 2000, source: 'boarding-prompt', outcome: 'fired' },
       ];
-      // FIRED_ALARM_SOURCES: sleep-transfer-alarm=true, boarding-prompt=false → 1건만 카운트.
+      // FIRED_ALARM_SOURCES: companion=true, boarding-prompt=false → 1건만 카운트.
       expect(countFiredAlarms(entries)).toBe(1);
     });
 

--- a/src/features/alarm/utils/__tests__/fireSequence.test.ts
+++ b/src/features/alarm/utils/__tests__/fireSequence.test.ts
@@ -43,11 +43,12 @@
  *       아님) 호출 → sound=alarm.wav 0건 기대, 실제는 allowSpeaker 기본값 때문에 sleepMode
  *       무관하게 sound='alarm.wav' → red.
  *
- * (a)(b)(c) 전부 `it.failing` — 현 코드 기준 red 재현. Phase 1(#2063/#2064)·Phase 2
- * (#2066/#2067)가 완료되면 unskip한다.
+ * (a)(b) `it.failing` — 현 코드 기준 red 재현. Phase 1(#2063/#2064)·Phase 2(#2066)가 완료되면
+ * unskip한다. (c)는 #2067(Phase 2-device D1)에서 `sendAlarmNotification` 자체를 삭제해 —
+ * "재구현 없이 실제 함수를 호출해 검증"하던 원래 harness 전제가 성립하지 않게 됐다. 함수가
+ * 없으므로 발사 경로 자체가 사라졌다는 것을 export 부재로 직접 확인하는 passing 테스트로 전환.
  */
 import * as Notifications from 'expo-notifications';
-import { Platform } from 'react-native';
 import {
   isStationRecentlyFired,
   isTripScopedCrossCategoryRecentlyFired,
@@ -70,9 +71,8 @@ jest.mock('../../../../shared/utils/logger', () => ({
   }),
 }));
 
-// stationNotification.ts는 sendAlarmNotification 시나리오(c)에서만 필요 — 무거운 의존성
-// (live-activity, tts, alarmSound, breadcrumb 등)을 stationNotification.test.ts와 동일한
-// 패턴으로 mock한다.
+// stationNotification.ts는 시나리오(c)에서만 필요 — 무거운 의존성(live-activity, tts,
+// alarmSound, breadcrumb 등)을 stationNotification.test.ts와 동일한 패턴으로 mock한다.
 const mockVibrateAlarm = jest.fn();
 const mockStopVibration = jest.fn();
 jest.mock('../alarmSound', () => ({
@@ -282,21 +282,12 @@ describe('시나리오 (b): 앱 재시작 시뮬 후 같은 이벤트 재주입 
 });
 
 describe('시나리오 (c): 일반 모드(sleepMode=off)에서 알람류(sound 있는 알림) 발사 0', () => {
-  it.failing('sendAlarmNotification(실제 production 함수)이 sleepMode=off에도 sound=alarm.wav 발사', async () => {
-    jest.replaceProperty(Platform, 'OS', 'ios');
+  it('#2067 (Phase 2-device D1) — sendAlarmNotification 자체가 제거되어 발사 경로가 존재하지 않는다', () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports -- 무거운 의존성 체인을
     // 이 describe 블록에서만 로드하기 위해 지연 require.
-    const { sendAlarmNotification } = require('../stationNotification') as typeof import('../stationNotification');
-
-    await sendAlarmNotification(
-      { phaseId: 'imminent', type: 'transfer', stationName: stationName() },
-      /* sleepMode */ false,
-    );
-
-    const soundCalls = (Notifications.scheduleNotificationAsync as jest.Mock).mock.calls.filter(
-      ([arg]: [{ content?: { sound?: unknown } }]) => arg?.content?.sound === 'alarm.wav',
-    );
-    // 일반 모드(sleepMode=off)에서는 alarm.wav 발사가 0건이어야 한다(#2061 확정 스펙).
-    expect(soundCalls).toHaveLength(0);
+    const stationNotificationModule = require('../stationNotification') as Record<string, unknown>;
+    // 일반 모드(sleepMode=off)에서 alarm.wav를 쏘던 유일한 caller(sendAlarmNotification)가
+    // #2067 D1에서 삭제됐다 — export 자체가 없으므로 이 회귀는 재발 불가능.
+    expect(stationNotificationModule.sendAlarmNotification).toBeUndefined();
   });
 });

--- a/src/features/alarm/utils/__tests__/stationNotification.test.ts
+++ b/src/features/alarm/utils/__tests__/stationNotification.test.ts
@@ -5,7 +5,6 @@ import {
   initStationNotification,
   updateStationNotification,
   clearStationNotification,
-  sendAlarmNotification,
   clearAlarmNotification,
   sendTripEndedNotification,
   buildAlarmContent,
@@ -141,14 +140,6 @@ function expectNotificationContent(title: string, body: string) {
   expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
     expect.objectContaining({ content: { title, body } }),
   );
-}
-
-function expectAlarmNotification(title: string, body: string, extra?: Record<string, unknown>) {
-  expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
-    identifier: 'station-alarm',
-    content: { title, body, sound: 'alarm.wav', ...extra },
-    trigger: null,
-  });
 }
 
 describe('stationNotification', () => {
@@ -682,164 +673,105 @@ describe('stationNotification', () => {
     });
   });
 
-  describe('sendAlarmNotification', () => {
+  // #2067 (Phase 2-device, D1) — sendAlarmNotification 제거(알람 배너는 원격 visible push가 담당).
+  // 본 함수가 감싸던 buildAlarmContent(exit side / quick hint / phase 문구 조립)는 여전히
+  // alarmScheduler/tripBoundScheduler/boardingLockScheduler(#2089 대상, 이번 PR 범위 밖)가
+  // 소비하므로 stationNotification.ts에 남아있다 — 아래는 그 로직을 직접 검증한다.
+  describe('buildAlarmContent', () => {
     const earlyDest = { phaseId: 'early' as const, type: 'destination' as const, stationName: '강남' };
     const earlyTransfer = { phaseId: 'early' as const, type: 'transfer' as const, stationName: '시청' };
     const imminentDest = { phaseId: 'imminent' as const, type: 'destination' as const, stationName: '강남' };
     const imminentTransfer = { phaseId: 'imminent' as const, type: 'transfer' as const, stationName: '시청' };
 
-    it('early destination이면 하차 알림을 보낸다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification(earlyDest);
-      expectAlarmNotification('하차 알림', '다음 역 강남에서 하차하세요!', { interruptionLevel: 'timeSensitive' });
-      expect(mockVibrateAlarm).toHaveBeenCalledWith(false);
-    });
-
-    it('early transfer이면 환승 알림을 보낸다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification(earlyTransfer);
-      expectAlarmNotification('환승 알림', '다음 역 시청에서 환승하세요!', { interruptionLevel: 'timeSensitive' });
-    });
-
-    it('sleepMode가 true이면 vibrateAlarm에 true를 전달한다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification(earlyDest, true);
-      expect(mockVibrateAlarm).toHaveBeenCalledWith(true);
-    });
-
-    it('Android에서는 channelId와 priority MAX가 포함된다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'android');
-      await sendAlarmNotification(earlyDest);
-      expectAlarmNotification('하차 알림', '다음 역 강남에서 하차하세요!', { channelId: 'station-alarm', priority: 'max' });
-    });
-
-    it('dismiss 실패해도 schedule은 호출된다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      (Notifications.dismissNotificationAsync as jest.Mock).mockRejectedValueOnce(new Error('없음'));
-      await sendAlarmNotification(earlyDest);
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
-    });
-
-    it('imminent destination이면 도착 임박 알림을 보낸다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification(imminentDest);
-      expectAlarmNotification('도착 임박', '곧 강남에 도착합니다. 하차 준비하세요!', { interruptionLevel: 'timeSensitive' });
-    });
-
-    it('imminent transfer이면 환승 임박 알림을 보낸다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification(imminentTransfer);
-      expectAlarmNotification('환승 임박', '곧 시청에 도착합니다. 환승 준비하세요!', { interruptionLevel: 'timeSensitive' });
-    });
-
-    it('imminent + sleepMode이면 vibrateAlarm에 true를 전달한다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification(imminentDest, true);
-      expect(mockVibrateAlarm).toHaveBeenCalledWith(true);
-    });
-
-    it('imminent + Android에서는 channelId와 priority MAX가 포함된다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'android');
-      await sendAlarmNotification(imminentDest);
-      expectAlarmNotification('도착 임박', '곧 강남에 도착합니다. 하차 준비하세요!', { channelId: 'station-alarm', priority: 'max' });
-    });
-
-    it('allowSpeaker=false이면 iOS에서 sound를 false로 설정한다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification(earlyDest, false, false);
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
-        identifier: 'station-alarm',
-        content: { title: '하차 알림', body: '다음 역 강남에서 하차하세요!', sound: false, interruptionLevel: 'timeSensitive' },
-        trigger: null,
+    it('early destination이면 하차 문구를 만든다', () => {
+      expect(buildAlarmContent(earlyDest)).toEqual({
+        title: '하차 알림',
+        body: '다음 역 강남에서 하차하세요!',
       });
     });
 
-    it('allowSpeaker=false이면 Android에서 무음 채널을 사용한다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'android');
-      await sendAlarmNotification(earlyDest, false, false);
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
-        identifier: 'station-alarm',
-        content: { title: '하차 알림', body: '다음 역 강남에서 하차하세요!', sound: false, channelId: 'station-alarm-silent', priority: 'max' },
-        trigger: null,
+    it('early transfer이면 환승 문구를 만든다', () => {
+      expect(buildAlarmContent(earlyTransfer)).toEqual({
+        title: '환승 알림',
+        body: '다음 역 시청에서 환승하세요!',
       });
     });
 
-    it('TTS는 알람 body를 sleepMode/allowSpeaker와 함께 호출한다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification(earlyDest, false, true);
-      expect(mockSpeakAlarm).toHaveBeenCalledWith('다음 역 강남에서 하차하세요!', {
-        sleepMode: false,
-        allowSpeaker: true,
+    it('imminent destination이면 도착 임박 문구를 만든다', () => {
+      expect(buildAlarmContent(imminentDest)).toEqual({
+        title: '도착 임박',
+        body: '곧 강남에 도착합니다. 하차 준비하세요!',
       });
     });
 
-    it('TTS는 silent 게이트(sleepMode/allowSpeaker)를 그대로 전달한다', async () => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification(earlyDest, true, false);
-      expect(mockSpeakAlarm).toHaveBeenCalledWith('다음 역 강남에서 하차하세요!', {
-        sleepMode: true,
-        allowSpeaker: false,
+    it('imminent transfer이면 환승 임박 문구를 만든다', () => {
+      expect(buildAlarmContent(imminentTransfer)).toEqual({
+        title: '환승 임박',
+        body: '곧 시청에 도착합니다. 환승 준비하세요!',
       });
     });
 
     describe('좌/우 하차 라인 (exitSide)', () => {
-      it('event.direction이 없으면 본문에 좌/우 라인을 추가하지 않는다', async () => {
-        jest.replaceProperty(Platform, 'OS', 'ios');
-        await sendAlarmNotification(earlyDest);
-        expectAlarmNotification('하차 알림', '다음 역 강남에서 하차하세요!', { interruptionLevel: 'timeSensitive' });
+      it('event.direction이 없으면 본문에 좌/우 라인을 추가하지 않는다', () => {
+        expect(buildAlarmContent(earlyDest).body).toBe('다음 역 강남에서 하차하세요!');
       });
 
-      it('event.direction이 있고 데이터가 매칭되면 좌측 라인이 추가된다', async () => {
-        jest.replaceProperty(Platform, 'OS', 'ios');
-        await sendAlarmNotification({ ...earlyDest, direction: 'up' });
-        expectAlarmNotification('하차 알림', '다음 역 강남에서 하차하세요!\n왼쪽 문으로 하차하세요', { interruptionLevel: 'timeSensitive' });
+      it('event.direction이 있고 데이터가 매칭되면 좌측 라인이 추가된다', () => {
+        expect(buildAlarmContent({ ...earlyDest, direction: 'up' }).body).toBe(
+          '다음 역 강남에서 하차하세요!\n왼쪽 문으로 하차하세요',
+        );
       });
 
-      it('하행이면 오른쪽 라인이 추가된다', async () => {
-        jest.replaceProperty(Platform, 'OS', 'ios');
-        await sendAlarmNotification({ ...earlyDest, direction: 'down' });
-        expectAlarmNotification('하차 알림', '다음 역 강남에서 하차하세요!\n오른쪽 문으로 하차하세요', { interruptionLevel: 'timeSensitive' });
+      it('하행이면 오른쪽 라인이 추가된다', () => {
+        expect(buildAlarmContent({ ...earlyDest, direction: 'down' }).body).toBe(
+          '다음 역 강남에서 하차하세요!\n오른쪽 문으로 하차하세요',
+        );
       });
 
-      it('섬식(both)이면 양쪽 라인이 추가된다', async () => {
-        jest.replaceProperty(Platform, 'OS', 'ios');
-        await sendAlarmNotification({ ...earlyTransfer, direction: 'up' });
-        expectAlarmNotification('환승 알림', '다음 역 시청에서 환승하세요!\n양쪽 문이 열립니다', { interruptionLevel: 'timeSensitive' });
+      it('섬식(both)이면 양쪽 라인이 추가된다', () => {
+        expect(buildAlarmContent({ ...earlyTransfer, direction: 'up' }).body).toBe(
+          '다음 역 시청에서 환승하세요!\n양쪽 문이 열립니다',
+        );
       });
 
-      it('데이터에 없는 방향이면 본문에 좌/우 라인을 추가하지 않는다', async () => {
-        jest.replaceProperty(Platform, 'OS', 'ios');
-        await sendAlarmNotification({ ...earlyTransfer, direction: 'down' });
-        expectAlarmNotification('환승 알림', '다음 역 시청에서 환승하세요!', { interruptionLevel: 'timeSensitive' });
+      it('데이터에 없는 방향이면 본문에 좌/우 라인을 추가하지 않는다', () => {
+        expect(buildAlarmContent({ ...earlyTransfer, direction: 'down' }).body).toBe(
+          '다음 역 시청에서 환승하세요!',
+        );
       });
 
       // #1504 — direction-agnostic platformExitSide.json fallback.
       describe('platformExitSide fallback', () => {
-        it('direction이 없어도 platformExitSide에 등록된 역이면 fallback이 적용된다', async () => {
-          jest.replaceProperty(Platform, 'OS', 'ios');
-          await sendAlarmNotification({ phaseId: 'early', type: 'destination', stationName: '잠실' });
+        it('direction이 없어도 platformExitSide에 등록된 역이면 fallback이 적용된다', () => {
           // 잠실(2-016)='right' fixture. quickExit 힌트도 같이 등록돼 있어 함께 표시된다.
-          expectAlarmNotification('하차 알림', '다음 역 잠실에서 하차하세요!\n오른쪽 문으로 하차하세요\n출구가 빠른 위치에서 하차하세요', { interruptionLevel: 'timeSensitive' });
+          expect(
+            buildAlarmContent({ phaseId: 'early', type: 'destination', stationName: '잠실' }).body,
+          ).toBe('다음 역 잠실에서 하차하세요!\n오른쪽 문으로 하차하세요\n출구가 빠른 위치에서 하차하세요');
         });
 
-        it('primary가 매칭되면 fallback을 무시하고 primary 결과를 사용한다', async () => {
-          jest.replaceProperty(Platform, 'OS', 'ios');
+        it('primary가 매칭되면 fallback을 무시하고 primary 결과를 사용한다', () => {
           // 강남: primary up='left' / platformExitSide fixture 미등록 — primary 단독.
-          await sendAlarmNotification({ ...earlyDest, direction: 'up' });
-          expectAlarmNotification('하차 알림', '다음 역 강남에서 하차하세요!\n왼쪽 문으로 하차하세요', { interruptionLevel: 'timeSensitive' });
+          expect(buildAlarmContent({ ...earlyDest, direction: 'up' }).body).toBe(
+            '다음 역 강남에서 하차하세요!\n왼쪽 문으로 하차하세요',
+          );
         });
 
-        it('primary가 unmatched여도 platformExitSide에 매핑이 있으면 fallback이 적용된다', async () => {
-          jest.replaceProperty(Platform, 'OS', 'ios');
+        it('primary가 unmatched여도 platformExitSide에 매핑이 있으면 fallback이 적용된다', () => {
           // 왕십리(2-008): primary 미등록 / fallback='both'. direction이 있어도 primary null → fallback.
-          await sendAlarmNotification({ phaseId: 'early', type: 'transfer', stationName: '왕십리(성동구청)', direction: 'up' });
-          expectAlarmNotification('환승 알림', '다음 역 왕십리(성동구청)에서 환승하세요!\n양쪽 문이 열립니다\n환승이 빠른 위치에서 하차하세요', { interruptionLevel: 'timeSensitive' });
+          expect(
+            buildAlarmContent({
+              phaseId: 'early',
+              type: 'transfer',
+              stationName: '왕십리(성동구청)',
+              direction: 'up',
+            }).body,
+          ).toBe('다음 역 왕십리(성동구청)에서 환승하세요!\n양쪽 문이 열립니다\n환승이 빠른 위치에서 하차하세요');
         });
 
-        it('stations.json에 없는 역은 fallback도 발화하지 않는다', async () => {
-          jest.replaceProperty(Platform, 'OS', 'ios');
-          await sendAlarmNotification({ phaseId: 'early', type: 'destination', stationName: '없는역' });
-          expectAlarmNotification('하차 알림', '다음 역 없는역에서 하차하세요!', { interruptionLevel: 'timeSensitive' });
+        it('stations.json에 없는 역은 fallback도 발화하지 않는다', () => {
+          expect(
+            buildAlarmContent({ phaseId: 'early', type: 'destination', stationName: '없는역' }).body,
+          ).toBe('다음 역 없는역에서 하차하세요!');
         });
       });
     });
@@ -874,39 +806,8 @@ describe('stationNotification', () => {
           'imminent', 'destination', '잠실',
           '도착 임박', '곧 잠실에 도착합니다. 하차 준비하세요!\n오른쪽 문으로 하차하세요\n출구가 빠른 위치에서 하차하세요',
         ],
-      ] as const)('%s', async (_label, phaseId, type, stationName, title, body) => {
-        jest.replaceProperty(Platform, 'OS', 'ios');
-        await sendAlarmNotification({ phaseId, type, stationName });
-        expectAlarmNotification(title, body, { interruptionLevel: 'timeSensitive' });
-      });
-    });
-
-    describe('domain breadcrumb', () => {
-      beforeEach(() => {
-        mockAddDomainBreadcrumb.mockClear();
-        jest.replaceProperty(Platform, 'OS', 'ios');
-      });
-
-      it('alarm fire 시 alarm 카테고리 breadcrumb 추가', async () => {
-        await sendAlarmNotification(earlyDest, true);
-        expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('alarm', 'fire', {
-          type: 'destination',
-          phase: 'early',
-          station: '강남',
-          sleepMode: true,
-          source: undefined,
-        });
-      });
-
-      it('source가 있으면 breadcrumb data에 포함', async () => {
-        await sendAlarmNotification(earlyTransfer, false, true, 'positionTrain');
-        expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('alarm', 'fire', {
-          type: 'transfer',
-          phase: 'early',
-          station: '시청',
-          sleepMode: false,
-          source: 'positionTrain',
-        });
+      ] as const)('%s', (_label, phaseId, type, stationName, title, body) => {
+        expect(buildAlarmContent({ phaseId, type, stationName })).toEqual({ title, body });
       });
     });
   });
@@ -999,16 +900,6 @@ describe('stationNotification', () => {
       });
     });
 
-    it('sendAlarmNotification(transfer/destination)은 sound: alarm.wav 유지', async () => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification({ phaseId: 'early', type: 'destination', stationName: '강남' });
-      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
-        expect.objectContaining({
-          identifier: 'station-alarm',
-          content: expect.objectContaining({ sound: 'alarm.wav' }),
-        }),
-      );
-    });
   });
 
   describe('clearAlarmNotification', () => {
@@ -1053,20 +944,16 @@ describe('stationNotification', () => {
     it.each([
       ['gpsOnly', 'GPS 추정'],
       ['uncertain', '위치 확인 중'],
-    ] as const)('sendAlarmNotification source=%s → body 끝에 "%s" 부착 (자백 대상)', async (source, label) => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification(earlyDest, false, true, source);
-      expectAlarmNotification('하차 알림', `${baseBody} · ${label}`, { interruptionLevel: 'timeSensitive' });
+    ] as const)('buildAlarmContent source=%s → body 끝에 "%s" 부착 (자백 대상)', (source, label) => {
+      expect(buildAlarmContent(earlyDest, source).body).toBe(`${baseBody} · ${label}`);
     });
 
     it.each<['positionTrain' | 'routeProgress' | undefined]>([
       ['positionTrain'],
       ['routeProgress'],
       [undefined],
-    ])('sendAlarmNotification source=%s → 라벨 부착 안 함 (정상 케이스 노이즈 회피)', async (source) => {
-      jest.replaceProperty(Platform, 'OS', 'ios');
-      await sendAlarmNotification(earlyDest, false, true, source);
-      expectAlarmNotification('하차 알림', baseBody, { interruptionLevel: 'timeSensitive' });
+    ])('buildAlarmContent source=%s → 라벨 부착 안 함 (정상 케이스 노이즈 회피)', (source) => {
+      expect(buildAlarmContent(earlyDest, source).body).toBe(baseBody);
     });
 
     it.each([

--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -53,11 +53,9 @@ jest.mock('../boardingLockScheduler', () => ({
   advanceHopWindow: (...args: unknown[]) => mockAdvanceHopWindow(...args),
 }));
 
-const mockSendAlarmNotification = jest.fn();
 const mockUpdateStationNotification = jest.fn();
 const mockSendStationPassedNotification = jest.fn();
 jest.mock('../stationNotification', () => ({
-  sendAlarmNotification: (...args: unknown[]) => mockSendAlarmNotification(...args),
   updateStationNotification: (...args: unknown[]) => mockUpdateStationNotification(...args),
   sendStationPassedNotification: (...args: unknown[]) => mockSendStationPassedNotification(...args),
 }));
@@ -146,7 +144,6 @@ describe('processLocationUpdate', () => {
     // #1515 — cross-category dedup module 상태는 mock 대상이 아니므로 명시 리셋.
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     require('../crossCategoryStationDedup')._resetCrossCategoryDedupForTests();
-    mockSendAlarmNotification.mockResolvedValue(undefined);
     mockUpdateStationNotification.mockResolvedValue(undefined);
     mockSendStationPassedNotification.mockResolvedValue(undefined);
     mockCalculateStaticETA.mockReturnValue(10);
@@ -173,7 +170,7 @@ describe('processLocationUpdate', () => {
     const result = await call();
     expect(result).toEqual({ alarmEvent: null, nearest: null });
     expect(mockFindRoute).not.toHaveBeenCalled();
-    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    expect(mockLogFiredAlarm).not.toHaveBeenCalled();
   });
 
   it('calls findRoute and evaluator with full source', async () => {
@@ -285,31 +282,11 @@ describe('processLocationUpdate', () => {
     );
   });
 
-  it('sends alarm notification with the full event when alarm fires', async () => {
-    mockFindNearestStation.mockReturnValue(mockNearestResult);
-    mockFindRoute.mockReturnValue(mockRoute);
-    mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
-
-    await call();
-
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith(mockAlarmEvent, false, true, undefined);
-  });
-
-  it('passes sleepMode and allowSpeaker to sendAlarmNotification', async () => {
-    mockFindNearestStation.mockReturnValue(mockNearestResult);
-    mockFindRoute.mockReturnValue(mockRoute);
-    mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
-
-    await call({ sleepMode: true, allowSpeaker: false });
-
-    expect(mockSendAlarmNotification).toHaveBeenCalledWith(mockAlarmEvent, true, false, undefined);
-  });
-
-  it('does not call sendAlarmNotification when no alarm', async () => {
+  it('does not call logFiredAlarm when no alarm', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
     await call();
-    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    expect(mockLogFiredAlarm).not.toHaveBeenCalled();
   });
 
   it('calls updateStationNotification with computed args', async () => {
@@ -647,19 +624,18 @@ describe('processLocationUpdate', () => {
     });
   });
 
+  // #327 — notificationSource 라벨은 #2067(D1) 이후 updateStationNotification의 마지막 인자로만
+  // 전파된다 (sendAlarmNotification 경로 자체가 삭제됨).
   describe('fusionSource 라벨 전파 (#327)', () => {
-    it('fusionSource=gps → sendAlarmNotification에 gpsOnly 전달', async () => {
+    it('fusionSource=gps → updateStationNotification에 gpsOnly 전달', async () => {
       mockFindNearestStation.mockReturnValue(mockNearestResult);
       mockFindRoute.mockReturnValue(mockRoute);
       mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
 
       await call({ fusionSource: 'gps' });
 
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith(
-        mockAlarmEvent,
-        false,
-        true,
-        'gpsOnly',
+      expect(mockUpdateStationNotification).toHaveBeenCalledWith(
+        mockStation, 150, mockDestination, mockRoute, 10, undefined, null, 'gpsOnly',
       );
     });
 
@@ -670,11 +646,8 @@ describe('processLocationUpdate', () => {
 
       await call({ fusionSource: 'position-train' });
 
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith(
-        mockAlarmEvent,
-        false,
-        true,
-        'positionTrain',
+      expect(mockUpdateStationNotification).toHaveBeenCalledWith(
+        mockStation, 150, mockDestination, mockRoute, 10, undefined, null, 'positionTrain',
       );
     });
 
@@ -685,31 +658,25 @@ describe('processLocationUpdate', () => {
 
       await call({ fusionSource: 'position-train', locationUncertain: true });
 
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith(
-        mockAlarmEvent,
-        false,
-        true,
-        'uncertain',
+      expect(mockUpdateStationNotification).toHaveBeenCalledWith(
+        mockStation, 150, mockDestination, mockRoute, 10, undefined, null, 'uncertain',
       );
     });
 
-    it('fusionSource 미지정 → sendAlarmNotification에 source 전달 안 함 (4번째 인자 undefined)', async () => {
+    it('fusionSource 미지정 → updateStationNotification에 source 전달 안 함 (마지막 인자 undefined)', async () => {
       mockFindNearestStation.mockReturnValue(mockNearestResult);
       mockFindRoute.mockReturnValue(mockRoute);
       mockEvaluateAlarmPhase.mockReturnValue(mockAlarmEvent);
 
       await call();
 
-      expect(mockSendAlarmNotification).toHaveBeenCalledWith(
-        mockAlarmEvent,
-        false,
-        true,
-        undefined,
+      expect(mockUpdateStationNotification).toHaveBeenCalledWith(
+        mockStation, 150, mockDestination, mockRoute, 10, undefined, null, undefined,
       );
     });
 
     // #2064 (Phase 1-device) — station-passed 로컬 알림 제거로 notificationSource 전파 대상도
-    // 사라짐(sendAlarmNotification 경로만 notificationSource를 계속 사용).
+    // 사라짐(updateStationNotification 경로만 notificationSource를 계속 사용).
     it('역 통과 감지에는 더 이상 notificationSource가 전달되지 않는다 (알림 자체가 없음)', async () => {
       mockFindNearestStation.mockReturnValue(mockNearestResult);
       mockFindRoute.mockReturnValue(mockRoute);
@@ -751,7 +718,7 @@ describe('processLocationUpdate', () => {
       mockGetFirstLeg.mockReturnValue({ line: '2', endName: '교대' });
     });
 
-    it('sleep ON + lock 활성 + 첫 hop transfer → sendAlarmNotification 호출 X, suppression 로그', async () => {
+    it('sleep ON + lock 활성 + 첫 hop transfer → logFiredAlarm 호출 X, suppression 로그', async () => {
       mockGetBoardingLock.mockResolvedValue(lock);
       await call({ sleepMode: true });
       expect(mockLogSuppressedSleepFirstTransfer).toHaveBeenCalledWith({
@@ -759,14 +726,14 @@ describe('processLocationUpdate', () => {
         stationName: '교대',
         phaseId: 'early',
       });
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
       expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('sleep OFF + lock 활성 + 첫 hop transfer → 정상 발사', async () => {
       mockGetBoardingLock.mockResolvedValue(lock);
       await call({ sleepMode: false });
-      expect(mockSendAlarmNotification).toHaveBeenCalled();
+      expect(mockLogFiredAlarm).toHaveBeenCalled();
       expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
     });
 
@@ -780,13 +747,13 @@ describe('processLocationUpdate', () => {
         stationName: '교대',
         phaseId: 'early',
       });
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('sleep OFF + lock null + 첫 hop transfer → 정상 발사 (sleep off 우선)', async () => {
       mockGetBoardingLock.mockResolvedValue(null);
       await call({ sleepMode: false });
-      expect(mockSendAlarmNotification).toHaveBeenCalled();
+      expect(mockLogFiredAlarm).toHaveBeenCalled();
       expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
     });
 
@@ -799,7 +766,7 @@ describe('processLocationUpdate', () => {
         stationName: '시청', // 둘째 hop
       });
       await call({ sleepMode: true });
-      expect(mockSendAlarmNotification).toHaveBeenCalled();
+      expect(mockLogFiredAlarm).toHaveBeenCalled();
       expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
     });
 
@@ -811,7 +778,7 @@ describe('processLocationUpdate', () => {
         stationName: '교대',
       });
       await call({ sleepMode: true });
-      expect(mockSendAlarmNotification).toHaveBeenCalled();
+      expect(mockLogFiredAlarm).toHaveBeenCalled();
       expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
     });
 
@@ -822,7 +789,7 @@ describe('processLocationUpdate', () => {
       mockFindRoute.mockReturnValue(null);
       mockEvaluateAlarmPhase.mockReturnValue(null);
       await call({ sleepMode: true });
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
       expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
     });
 
@@ -833,7 +800,7 @@ describe('processLocationUpdate', () => {
       mockFindRoute.mockReturnValue(null);
       mockEvaluateAlarmPhase.mockReturnValue(transferAlarm);
       await call({ sleepMode: true });
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
       expect(mockLogSuppressedSleepFirstTransfer).not.toHaveBeenCalled();
     });
   });
@@ -894,7 +861,7 @@ describe('processLocationUpdate', () => {
         kind: 'destination',
         phaseId: 'imminent',
       });
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
   });
@@ -934,7 +901,7 @@ describe('processLocationUpdate', () => {
         kind: 'destination',
         phaseId: 'imminent',
       });
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('phase 알람 발사(성수) 후 5s 안 다른 station(군자) station-passed는 trip-scoped dedup으로 차단', async () => {
@@ -947,7 +914,7 @@ describe('processLocationUpdate', () => {
       });
       mockIsStationOnRoute.mockReturnValueOnce(false);
       await call({ source: 'fg-evaluated' });
-      expect(mockSendAlarmNotification).toHaveBeenCalled();
+      expect(mockLogFiredAlarm).toHaveBeenCalled();
 
       // 2nd: 군자(다른 station) station-passed 시도 — trip-scoped cross-cat 차단.
       mockFindNearestStation.mockReturnValue({ station: passedStation, distanceKm: 0.05 });
@@ -983,7 +950,7 @@ describe('processLocationUpdate', () => {
         stationName: transferStation.name,
       });
       await call({ source: 'bg' });
-      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+      expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
 
       // 2nd: 성수(다른 station) destination phase — 3s 안 phase→phase cross-station → 차단.
       mockFindNearestStation.mockReturnValue({ station: destStation, distanceKm: 0.05 });
@@ -999,7 +966,7 @@ describe('processLocationUpdate', () => {
         kind: 'destination',
         phaseId: 'early',
       });
-      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1); // 추가 발사 없음
+      expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1); // 추가 발사 없음
     });
 
     it('같은 station 진행(건대 transfer → 건대 destination early→imminent)은 차단하지 않음', async () => {
@@ -1011,7 +978,7 @@ describe('processLocationUpdate', () => {
         stationName: transferStation.name,
       });
       await call({ source: 'bg' });
-      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+      expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
 
       // 2nd: 같은 station(건대) destination — same station이라 통과.
       mockEvaluateAlarmPhase.mockReturnValueOnce({
@@ -1051,7 +1018,7 @@ describe('processLocationUpdate', () => {
       });
       mockIsStationOnRoute.mockReturnValueOnce(false);
       await call({ source: 'fg-evaluated' });
-      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+      expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
 
       // t = 1_000_000 + 60_000 (1분 후) — 30s cross-category window는 만료, 8분 backstop은 활성.
       nowSpy.mockReturnValue(1_000_000 + 60_000);
@@ -1072,7 +1039,7 @@ describe('processLocationUpdate', () => {
         phaseId: 'imminent',
       });
       // 두 번째 발사 없음.
-      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+      expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
     });
 
     it('phase 알람 발사 후 같은 station 다른 phase는 정상 phase 진행이라 통과', async () => {
@@ -1085,7 +1052,7 @@ describe('processLocationUpdate', () => {
       });
       mockIsStationOnRoute.mockReturnValueOnce(false);
       await call({ source: 'fg-evaluated' });
-      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+      expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
 
       // 2nd: 같은 station imminent destination — 다른 phaseId라 channel-agnostic backstop 통과.
       // cross-category 30s window는 만료시켜 phase 변경만 backstop 영향 받는지 격리.
@@ -1098,7 +1065,7 @@ describe('processLocationUpdate', () => {
       mockIsStationOnRoute.mockReturnValueOnce(false);
       await call({ source: 'fg-evaluated' });
       // 두 번째 발사가 진행됨 — channel-agnostic dedup은 phase 진행 통과.
-      expect(mockSendAlarmNotification).toHaveBeenCalledTimes(2);
+      expect(mockLogFiredAlarm).toHaveBeenCalledTimes(2);
       expect(mockLogSuppressedChannelAgnosticDedup).not.toHaveBeenCalled();
     });
 
@@ -1218,7 +1185,7 @@ describe('processLocationUpdate', () => {
         sinceLng: 127.028,
       });
       const result = await call({ source: 'bg' });
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
       expect(mockLogSuppressedDismissSilence).toHaveBeenCalledWith(
         expect.objectContaining({
           source: 'bg',
@@ -1259,7 +1226,7 @@ describe('processLocationUpdate', () => {
       });
       await call({ source: 'bg' });
       expect(mockClearDismissSilence).toHaveBeenCalledTimes(1);
-      expect(mockSendAlarmNotification).toHaveBeenCalled();
+      expect(mockLogFiredAlarm).toHaveBeenCalled();
     });
 
     it('silence state 좌표 null(=GPS-less dismiss)이면 거리 평가 skip — 시간 조건만 활성', async () => {
@@ -1271,7 +1238,7 @@ describe('processLocationUpdate', () => {
       });
       // 사용자가 1km 떨어진 좌표여도 시간 조건이 silence이므로 차단.
       await call({ source: 'bg', lat: 37.6, lng: 127.1 });
-      expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+      expect(mockLogFiredAlarm).not.toHaveBeenCalled();
     });
 
     it('silence state 없음(null) → 정상 발사', async () => {
@@ -1279,7 +1246,7 @@ describe('processLocationUpdate', () => {
       mockGetDismissSilence.mockResolvedValue(null);
       await call({ source: 'bg' });
       expect(mockLogSuppressedDismissSilence).not.toHaveBeenCalled();
-      expect(mockSendAlarmNotification).toHaveBeenCalled();
+      expect(mockLogFiredAlarm).toHaveBeenCalled();
     });
 
     it('silence 활성이어도 updateStationNotification(UI)은 계속 호출 — silence는 알람만 차단', async () => {

--- a/src/features/alarm/utils/alarmLocalAuthority.ts
+++ b/src/features/alarm/utils/alarmLocalAuthority.ts
@@ -1,0 +1,150 @@
+/**
+ * AlarmLocalAuthority (#2067, Phase 2-device) — 로컬 알람 경로(TTS/진동)의 단일 진입점.
+ *
+ * 배경: 알람 배너(visible)는 원격(Phase 2-backend)이 주 채널을 담당하므로, device는 배너를
+ * 생성하지 않는다. 남는 로컬 역할은 "앱이 깨어있을 때 TTS/진동으로 소리를 보강"뿐이다
+ * (PR #2067 comment — 원격 alarm visible push는 FG에서 `shouldPlaySound`가
+ * `identifier === ALARM_NOTIFICATION_ID`일 때만 true라 auto-gen identifier인 원격 push는
+ * FG에서 무음. companion 수신 시 TTS+진동으로 소리를 보장한다).
+ *
+ * 정책 gate: sleepMode가 켜져 있을 때만 동작한다 — 스펙상 알람은 취침모드 전용.
+ * dedup: AsyncStorage 기반 persisted ledger (TTL 1h) — silentPushTask의 기존 in-memory Set과
+ * 달리 앱 재시작(cold-launch) 후에도 dedup 상태가 살아남는다.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { ALARM_LOCAL_LEDGER_KEY, SLEEP_MODE_KEY } from '../../../shared/constants/storageKeys';
+import { vibrateAlarm } from './alarmSound';
+import { speakAlarm } from './tts';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('AlarmLocalAuthority');
+
+/** ledger entry TTL — 1시간. trip 하나가 이보다 길게 이어지는 경우는 드물다. */
+export const ALARM_LOCAL_LEDGER_TTL_MS = 60 * 60 * 1000;
+
+export type AlarmLocalKind = 'transfer' | 'destination';
+
+/**
+ * 결정적 identifier 생성기 — `alarm-<tripToken>-<station>-<kind>`.
+ * ledger dedup key로 사용된다. #2089(스케줄러 통합)에서 OS 예약 identifier로도 재사용 예정.
+ */
+export function buildAlarmLocalId(
+  tripToken: string,
+  station: string,
+  kind: AlarmLocalKind,
+): string {
+  return `alarm-${tripToken}-${station}-${kind}`;
+}
+
+interface AlarmLocalLedgerEntry {
+  id: string;
+  firedAt: number;
+}
+
+async function readLedger(): Promise<AlarmLocalLedgerEntry[]> {
+  try {
+    const raw = await AsyncStorage.getItem(ALARM_LOCAL_LEDGER_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (e): e is AlarmLocalLedgerEntry =>
+        typeof e === 'object' &&
+        e !== null &&
+        typeof (e as AlarmLocalLedgerEntry).id === 'string' &&
+        typeof (e as AlarmLocalLedgerEntry).firedAt === 'number',
+    );
+  } catch {
+    return [];
+  }
+}
+
+async function writeLedger(entries: AlarmLocalLedgerEntry[]): Promise<void> {
+  try {
+    await AsyncStorage.setItem(ALARM_LOCAL_LEDGER_KEY, JSON.stringify(entries));
+  } catch (e) {
+    logger.error('ledger write 실패:', e);
+  }
+}
+
+function pruneExpired(
+  entries: AlarmLocalLedgerEntry[],
+  now: number,
+): AlarmLocalLedgerEntry[] {
+  return entries.filter((e) => now - e.firedAt < ALARM_LOCAL_LEDGER_TTL_MS);
+}
+
+/** ledger에 id가 이미 존재하는지(만료되지 않은 항목만) 확인. */
+export async function hasFiredLocally(id: string, now: number = Date.now()): Promise<boolean> {
+  const entries = pruneExpired(await readLedger(), now);
+  return entries.some((e) => e.id === id);
+}
+
+async function markFiredLocally(id: string, now: number = Date.now()): Promise<void> {
+  const entries = pruneExpired(await readLedger(), now);
+  entries.push({ id, firedAt: now });
+  await writeLedger(entries);
+}
+
+async function readSleepMode(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(SLEEP_MODE_KEY);
+    if (!raw) return false;
+    return JSON.parse(raw) === true;
+  } catch {
+    return false;
+  }
+}
+
+export interface FireCompanionAlarmParams {
+  tripToken: string;
+  station: string;
+  kind: AlarmLocalKind;
+  /** TTS로 읽을 본문. */
+  body: string;
+}
+
+export type FireCompanionAlarmSkipReason = 'not-sleep-mode' | 'dedup';
+
+export interface FireCompanionAlarmResult {
+  fired: boolean;
+  reason?: FireCompanionAlarmSkipReason;
+}
+
+/**
+ * companion silent push(kind `sleep-alarm-companion`) 수신 시 호출되는 단일 진입점.
+ *
+ * 절차:
+ *   1. sleepMode gate — off면 skip (일반 모드는 로컬 알람 0건 정책).
+ *   2. ledger dedup — 이미 발사된 id면 skip (backend retry 등으로 인한 중복 방지).
+ *   3. ledger 등록 → vibrateAlarm(repeat) + speakAlarm(강제 발화) — 알림(배너) 생성 없음.
+ *
+ * speakAlarm은 `sleepMode: false`로 호출한다 — tts.ts의 게이트 의미가 "실제 기기 취침 여부"가
+ * 아니라 "이 경로가 TTS를 원하는가"이기 때문(sendAlarmNotification 관례: sleepMode=true일 때
+ * 원래는 loud alarm.wav가 대신 소리를 낸다). companion 경로는 배너/사운드가 없으므로 TTS가
+ * 유일한 음성 신호라 항상 발화해야 한다.
+ */
+export async function fireCompanionAlarm(
+  params: FireCompanionAlarmParams,
+): Promise<FireCompanionAlarmResult> {
+  const sleepMode = await readSleepMode();
+  if (!sleepMode) {
+    return { fired: false, reason: 'not-sleep-mode' };
+  }
+
+  const id = buildAlarmLocalId(params.tripToken, params.station, params.kind);
+  if (await hasFiredLocally(id)) {
+    return { fired: false, reason: 'dedup' };
+  }
+
+  await markFiredLocally(id);
+  vibrateAlarm(true);
+  speakAlarm(params.body, { sleepMode: false, allowSpeaker: true });
+  logger.info(`companion alarm fired: id=${id}`);
+  return { fired: true };
+}
+
+/** 테스트 전용 — ledger를 비운다. production 코드에서는 호출하지 않는다. */
+export async function __resetAlarmLocalLedgerForTest(): Promise<void> {
+  await AsyncStorage.removeItem(ALARM_LOCAL_LEDGER_KEY);
+}

--- a/src/features/alarm/utils/alarmLocalAuthority.ts
+++ b/src/features/alarm/utils/alarmLocalAuthority.ts
@@ -12,7 +12,11 @@
  * 달리 앱 재시작(cold-launch) 후에도 dedup 상태가 살아남는다.
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { ALARM_LOCAL_LEDGER_KEY, SLEEP_MODE_KEY } from '../../../shared/constants/storageKeys';
+import {
+  ALARM_LOCAL_LEDGER_KEY,
+  SLEEP_MODE_KEY,
+  ALLOW_SPEAKER_KEY,
+} from '../../../shared/constants/storageKeys';
 import { vibrateAlarm } from './alarmSound';
 import { speakAlarm } from './tts';
 import { createLogger } from '../../../shared/utils/logger';
@@ -96,6 +100,20 @@ async function readSleepMode(): Promise<boolean> {
   }
 }
 
+/**
+ * 사용자 설정(허용 스피커) 값 읽기. 저장값 부재/파싱 실패는 true(허용)로 보수적 fallback —
+ * 기존 sendAlarmNotification의 `allowSpeaker = true` 기본값과 동일 semantics를 보존한다.
+ */
+async function readAllowSpeaker(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(ALLOW_SPEAKER_KEY);
+    if (!raw) return true;
+    return JSON.parse(raw) === true;
+  } catch {
+    return true;
+  }
+}
+
 export interface FireCompanionAlarmParams {
   tripToken: string;
   station: string;
@@ -117,12 +135,15 @@ export interface FireCompanionAlarmResult {
  * 절차:
  *   1. sleepMode gate — off면 skip (일반 모드는 로컬 알람 0건 정책).
  *   2. ledger dedup — 이미 발사된 id면 skip (backend retry 등으로 인한 중복 방지).
- *   3. ledger 등록 → vibrateAlarm(repeat) + speakAlarm(강제 발화) — 알림(배너) 생성 없음.
+ *   3. ledger 등록 → vibrateAlarm(repeat, 항상) + speakAlarm(사용자 allowSpeaker 설정 반영) —
+ *      알림(배너) 생성 없음.
  *
  * speakAlarm은 `sleepMode: false`로 호출한다 — tts.ts의 게이트 의미가 "실제 기기 취침 여부"가
  * 아니라 "이 경로가 TTS를 원하는가"이기 때문(sendAlarmNotification 관례: sleepMode=true일 때
  * 원래는 loud alarm.wav가 대신 소리를 낸다). companion 경로는 배너/사운드가 없으므로 TTS가
- * 유일한 음성 신호라 항상 발화해야 한다.
+ * 유일한 음성 신호이며, `allowSpeaker`(사용자 설정)만 그대로 반영한다 — 진동은 allowSpeaker
+ * 무관하게 항상 발생(#2067 리뷰 P1: 하드코딩된 true로 인해 사용자가 스피커를 껐어도 TTS가
+ * 계속 나가던 dead toggle 회귀 차단).
  */
 export async function fireCompanionAlarm(
   params: FireCompanionAlarmParams,
@@ -138,8 +159,9 @@ export async function fireCompanionAlarm(
   }
 
   await markFiredLocally(id);
+  const allowSpeaker = await readAllowSpeaker();
   vibrateAlarm(true);
-  speakAlarm(params.body, { sleepMode: false, allowSpeaker: true });
+  speakAlarm(params.body, { sleepMode: false, allowSpeaker });
   logger.info(`companion alarm fired: id=${id}`);
   return { fired: true };
 }

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -100,11 +100,11 @@ export type AlarmLogSource =
   // observabilityMetrics.locklessTripMissRatio = miss / (miss + fired) 산출.
   // lesson_silent_push_zero_is_paradigm_intent: fire 0건이 본질적 의도(paradigm)인지 miss인지 구분.
   | 'lockless-trip-end'
-  // #2036 (Issue I γ) — 취침모드 환승 알람 발사 stamp. backend가 취침 무관 발사한 sleep-transfer
-  // silent push를 device silentPushTask가 sleepMode=true 확인 후 gate 무관 로컬 알림으로 발사한
-  // 경우 1건 적재. fireCount 분모에 포함(실제 사용자에게 노출되는 알람). ADR-023 정합 —
-  // backend 필터 없이 device 결정.
-  | 'sleep-transfer-alarm';
+  // #2036 (Issue I γ) → #2067 (Phase 2-device, D3)에서 companion으로 전환. backend가 취침 무관
+  // 발사한 sleep-alarm-companion silent push를 device silentPushTask가 sleepMode=true 확인 후
+  // AlarmLocalAuthority 경유로 TTS/진동만 부가(알림 생성 없음) — 그 시점 1건 적재. fireCount
+  // 분모에 포함(실제 사용자에게 노출되는 알람). ADR-023 정합 — backend 필터 없이 device 결정.
+  | 'companion';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(#580): evaluateAlarmPhase의 firedAlarms 적중. destination/transfer phase alarm dedup
 // 발생 관찰. station-passed는 별도 메커니즘(lastNotifiedStationId)이라 'dedup-station' 사용.
@@ -1221,8 +1221,8 @@ const SILENT_PUSH_OUTCOME_SOURCES: Record<AlarmLogSource, keyof SilentPushOutcom
   'boardable-lookup': null,
   'ground-truth-response': null,
   'lockless-trip-end': null,
-  // #2036 (Issue I γ) — sleep-transfer-alarm은 device UI 발사이므로 silent push outcome 통계에서 제외.
-  'sleep-transfer-alarm': null,
+  // #2067 (Phase 2-device, D3) — companion은 device UI 발사이므로 silent push outcome 통계에서 제외.
+  companion: null,
 };
 
 export interface SilentPushOutcomeCounts {
@@ -1276,8 +1276,8 @@ const FIRED_ALARM_SOURCES: Record<AlarmLogSource, boolean> = {
   'boardable-lookup': false,
   'ground-truth-response': false,
   'lockless-trip-end': false,
-  // #2036 (Issue I γ) — sleep-transfer-alarm 은 실제 사용자에게 노출되는 알람이므로 fire 분모에 포함.
-  'sleep-transfer-alarm': true,
+  // #2067 (Phase 2-device, D3) — companion은 실제 사용자에게 노출되는 알람이므로 fire 분모에 포함.
+  companion: true,
 };
 
 /**
@@ -1733,22 +1733,22 @@ export function logBoardingPromptFired(input: { originStation: string; line: str
 }
 
 /**
- * #2036 (Issue I γ) — 취침모드 환승 알람 발사 1건 적재.
+ * #2067 (Phase 2-device, D3) — 취침모드 companion 알람(TTS/진동) 부가 1건 적재.
  *
- * device silentPushTask가 backend sleep-transfer-alarm silent push 수신 후 sleepMode=true
- * 확인 → gate 무관 로컬 알림 발사 시 호출. dashboard/observabilityMetrics는
- * `source='sleep-transfer-alarm' + outcome='fired'` 로 sleep-transfer wake count 산출.
+ * device silentPushTask가 backend sleep-alarm-companion silent push 수신 후 sleepMode=true
+ * 확인 → AlarmLocalAuthority 경유 TTS/진동 부가(알림 생성 없음) 시 호출. dashboard/observabilityMetrics는
+ * `source='companion' + outcome='fired'` 로 companion wake count 산출.
  *
  * stationName은 `${nextLine}·${nextStation}` 형태로 인코딩해 boarding-prompt 패턴과 동일.
  */
-export function logSleepTransferAlarmFired(input: {
+export function logCompanionAlarmFired(input: {
   originStation: string;
   nextStation: string;
   nextLine: string;
 }): void {
   appendAlarmLog({
     ts: Date.now(),
-    source: 'sleep-transfer-alarm',
+    source: 'companion',
     outcome: 'fired',
     stationName: `${input.nextLine}·${input.nextStation}`,
   });

--- a/src/features/alarm/utils/stationNotification.ts
+++ b/src/features/alarm/utils/stationNotification.ts
@@ -21,8 +21,7 @@ import {
   ensureLiveActivityRegistered,
   endLiveActivityWithDeregister,
 } from './liveActivityPushChannel';
-import { vibrateAlarm, stopVibration } from './alarmSound';
-import { speakAlarm } from './tts';
+import { stopVibration } from './alarmSound';
 import { createLogger } from '../../../shared/utils/logger';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
 import { getStationDisplayName, getStationDisplayNameByName } from '../../../shared/utils/stationDisplay';
@@ -545,37 +544,6 @@ export function buildAlarmContent(
   const withHint = appendQuickHint(withSide, resolveQuickHint(event));
   const withSource = appendNotificationSource(withHint, source);
   return { title, body: withSource };
-}
-
-export async function sendAlarmNotification(
-  event: AlarmEvent,
-  sleepMode: boolean = false,
-  allowSpeaker: boolean = true,
-  source?: NotificationSource,
-): Promise<void> {
-  const { title, body } = buildAlarmContent(event, source);
-
-  await scheduleNotification(ALARM_NOTIFICATION_ID, {
-    title,
-    body,
-    sound: allowSpeaker ? 'alarm.wav' : false,
-    ...(Platform.OS === 'android' && {
-      channelId: allowSpeaker ? ALARM_CHANNEL_ID : ALARM_SILENT_CHANNEL_ID,
-      priority: Notifications.AndroidNotificationPriority.MAX,
-    }),
-    // NOTE: critical Entitlement 승인 후 'critical'로 변경 → Sleep Focus 완전 관통
-    ...(Platform.OS === 'ios' && { interruptionLevel: 'timeSensitive' as const }),
-  });
-  vibrateAlarm(sleepMode);
-  speakAlarm(body, { sleepMode, allowSpeaker });
-  notifLogger.info('알람 알림:', title, body);
-  addDomainBreadcrumb('alarm', 'fire', {
-    type: event.type,
-    phase: event.phaseId,
-    station: event.stationName,
-    sleepMode,
-    source,
-  });
 }
 
 export async function clearAlarmNotification(): Promise<void> {

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -9,7 +9,7 @@
 import { findNearestStation } from '../../nearest-station/utils/findNearestStation';
 import { findRoute, calculateStaticETA, getFirstLeg, isSameStationName, isStationOnRoute, updateRouteFromPosition } from '../../../shared/utils/stationRoute';
 import { evaluateAlarmPhase, resolveAllTargets } from './stationAlarm';
-import { sendAlarmNotification, updateStationNotification } from './stationNotification';
+import { updateStationNotification } from './stationNotification';
 import { distanceMetersBetween, estimateEtaSeconds } from '../../../shared/utils/stationEta';
 import { advanceHopWindow } from './boardingLockScheduler';
 import { getBoardingLock } from './boardingLockStorage';
@@ -186,7 +186,6 @@ export interface ProcessLocationInputs {
   destination: Station;
   firedAlarms: Set<string>;
   sleepMode: boolean;
-  allowSpeaker?: boolean;
   storedRoute?: Route;
   speedMps?: number | null;
   // 알람 로그 적재 시 발사 컨텍스트 — 호출자가 명시한다.
@@ -218,7 +217,6 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
     destination,
     firedAlarms,
     sleepMode,
-    allowSpeaker = true,
     storedRoute = null,
     speedMps = null,
     source,
@@ -387,7 +385,8 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
         Date.now(),
         alarmEvent.phaseId,
       );
-      await sendAlarmNotification(alarmEvent, sleepMode, allowSpeaker, notificationSource);
+      // #2067 (Phase 2-device, D1) — sendAlarmNotification 제거. 알람 배너는 원격 visible push가
+      // 담당(Phase 2-backend). BG pipeline은 dedup ledger 기록 + alarmLog 적재만 수행한다.
       logFiredAlarm(source, alarmEvent);
     }
   }

--- a/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
@@ -178,20 +178,20 @@ function getTaskCallback(): TaskCallback {
   return (global as any).__bgTaskCallback as TaskCallback;
 }
 
-/** AsyncStorage.getItem 4개를 순서대로 모킹한다 (dest, sleep, route, allowSpeaker)
+/** AsyncStorage.getItem 3개를 순서대로 모킹한다 (dest, sleep, route).
+ *  #2067 (Phase 2-device, D1) — allowSpeaker read는 processLocationUpdate가 더 이상 소비하지
+ *  않아 backgroundLocationTask.ts에서 제거됐다(dead read cleanup).
  *  firedAlarms는 notificationState helper로 분리되어 별도 mockGetFiredAlarms로 제어한다.
  *  lastNotifiedStationId는 stationPipeline 내부에서 notificationState 모듈로 read/write 한다. */
 function mockStorageValues(
   dest: string | null,
   sleep: string | null = null,
   route: string | null = null,
-  allowSpeaker: string | null = null,
 ): void {
   (AsyncStorage.getItem as jest.Mock)
     .mockResolvedValueOnce(dest)
     .mockResolvedValueOnce(sleep)
-    .mockResolvedValueOnce(route)
-    .mockResolvedValueOnce(allowSpeaker);
+    .mockResolvedValueOnce(route);
 }
 
 describe('BACKGROUND_LOCATION_TASK 상수', () => {
@@ -293,7 +293,6 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       destination: mockDestination,
       firedAlarms: new Set(),
       sleepMode: false,
-      allowSpeaker: true,
       storedRoute: null,
     }));
     // alarmEvent가 없으므로 ALARM_EVENT_KEY는 기록되지 않는다.
@@ -331,38 +330,6 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
     expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({
       sleepMode: false,
-    }));
-  });
-
-  // ── allowSpeaker 파싱 ──
-
-  it("allowSpeakerJson이 'false'이면 allowSpeaker=false로 processLocationUpdate를 호출한다", async () => {
-    mockStorageValues(JSON.stringify(mockDestination), null, null, 'false');
-
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
-
-    await taskCallback({
-      data: { locations: [makeLocation(37.498, 127.028)] },
-      error: null,
-    });
-
-    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({
-      allowSpeaker: false,
-    }));
-  });
-
-  it("allowSpeakerJson이 'true'이면 allowSpeaker=true로 processLocationUpdate를 호출한다", async () => {
-    mockStorageValues(JSON.stringify(mockDestination), null, null, 'true');
-
-    mockProcessLocationUpdate.mockResolvedValue({ alarmEvent: null, nearest: null });
-
-    await taskCallback({
-      data: { locations: [makeLocation(37.498, 127.028)] },
-      error: null,
-    });
-
-    expect(mockProcessLocationUpdate).toHaveBeenCalledWith(expect.objectContaining({
-      allowSpeaker: true,
     }));
   });
 
@@ -607,10 +574,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   it('비현실 점프(25km/8s)면 logSuppressedGate(gate-jump)를 호출하고 processLocationUpdate를 건너뛴다', async () => {
     const prevTs = Date.now() - 8_000;
     const prevFix = { lat: 37.5390, lng: 126.9610, timestamp: prevTs };
-    // dest, sleep, route, allowSpeaker, BG_LAST_FIX_KEY (readBgLastFix 5번째 호출)
+    // dest, sleep, route, BG_LAST_FIX_KEY (readBgLastFix 4번째 호출)
     (AsyncStorage.getItem as jest.Mock)
       .mockResolvedValueOnce(JSON.stringify(mockDestination))
-      .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(JSON.stringify(prevFix));
@@ -634,7 +600,6 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       .mockResolvedValueOnce(JSON.stringify(mockDestination))
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(JSON.stringify(prevFix));
 
     await taskCallback({
@@ -650,7 +615,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
   it('BG_LAST_FIX_KEY가 없으면(콜드스타트) jump 게이트를 통과한다', async () => {
     mockStorageValues(JSON.stringify(mockDestination));
-    // mockStorageValues는 4개만 mockOnce → 5번째 호출은 default(null)
+    // mockStorageValues는 3개만 mockOnce → 4번째 호출(BG_LAST_FIX_KEY)은 default(null)
 
     await taskCallback({
       data: { locations: [makeLocation(37.498, 127.028)] },
@@ -666,7 +631,6 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       .mockResolvedValueOnce(JSON.stringify(mockDestination))
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(null)
       .mockResolvedValueOnce('not-json');
 
     await taskCallback({
@@ -680,7 +644,6 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   it('BG_LAST_FIX_KEY가 형식 불일치 객체면 prev=null로 처리하여 통과한다', async () => {
     (AsyncStorage.getItem as jest.Mock)
       .mockResolvedValueOnce(JSON.stringify(mockDestination))
-      .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(JSON.stringify({ foo: 'bar' }));
@@ -837,7 +800,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
         line: '2',
         travelSeconds: 600,
       };
-      mockStorageValues(JSON.stringify(mockDestination), null, JSON.stringify(directRoute), null);
+      mockStorageValues(JSON.stringify(mockDestination), null, JSON.stringify(directRoute));
       mockProcessLocationUpdate.mockResolvedValue({
         alarmEvent: null,
         nearest: { station: mockStation, distanceKm: 0.42 },
@@ -871,7 +834,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
         secondsToTransfer: 360,
         secondsFromTransfer: 480,
       };
-      mockStorageValues(JSON.stringify(mockDestination), null, JSON.stringify(transferRoute), null);
+      mockStorageValues(JSON.stringify(mockDestination), null, JSON.stringify(transferRoute));
       mockProcessLocationUpdate.mockResolvedValue({
         alarmEvent: null,
         nearest: { station: mockStation, distanceKm: 0.42 },
@@ -920,10 +883,10 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
   describe('#819 — backend로 position + motion 송신', () => {
     /**
-     * mockStorageValues 4번 chain 후 task code는 readBgLastFix(`getItem(BG_LAST_FIX_KEY)`)를 한 번,
-     * 그 다음 `getItem(APNS_TOKEN_KEY)`를 한 번 호출한다. 따라서 5번째에 null(=fresh fix, 점프 검사
-     * 통과), 6번째에 token을 chain한다. 안 그러면 APNS_TOKEN_KEY 자리에 BG_LAST_FIX 값이 들어가
-     * uploadPosition 호출 안 됨.
+     * mockStorageValues 3번 chain(dest/sleep/route) 후 task code는
+     * readBgLastFix(`getItem(BG_LAST_FIX_KEY)`)를 한 번, 그 다음 `getItem(APNS_TOKEN_KEY)`를 한
+     * 번 호출한다. 따라서 4번째에 null(=fresh fix, 점프 검사 통과), 5번째에 token을 chain한다.
+     * 안 그러면 APNS_TOKEN_KEY 자리에 BG_LAST_FIX 값이 들어가 uploadPosition 호출 안 됨.
      */
     function stubApnsTokenAfterStorage(token: string | null): void {
       (AsyncStorage.getItem as jest.Mock)
@@ -975,7 +938,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
     it('AsyncStorage.getItem(APNS_TOKEN_KEY) throw → 무시하고 uploadPosition 미호출', async () => {
       mockStorageValues(JSON.stringify(mockDestination));
-      // 5번째 call: BG_LAST_FIX_KEY null, 6번째 call: APNS_TOKEN_KEY에서 throw
+      // 4번째 call: BG_LAST_FIX_KEY null, 5번째 call: APNS_TOKEN_KEY에서 throw
       (AsyncStorage.getItem as jest.Mock)
         .mockResolvedValueOnce(null)
         .mockRejectedValueOnce(new Error('boom'));
@@ -1108,7 +1071,6 @@ describe('backgroundLocationTask defineTask 콜백', () => {
         .mockResolvedValueOnce(JSON.stringify(mockDestination))
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(null)  // BG_LAST_FIX_KEY
         .mockResolvedValueOnce('apns-tok-1'); // APNS_TOKEN_KEY
 
@@ -1125,7 +1087,6 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       function stubApnsToken(token: string): void {
         (AsyncStorage.getItem as jest.Mock)
           .mockResolvedValueOnce(JSON.stringify(mockDestination))
-          .mockResolvedValueOnce(null)
           .mockResolvedValueOnce(null)
           .mockResolvedValueOnce(null)
           .mockResolvedValueOnce(null) // BG_LAST_FIX_KEY
@@ -1193,7 +1154,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       expectedDurationMs: 30 * 60_000,
     };
 
-    /** mockStorageValues 4개 후 BG_LAST_FIX(null) + APNS_TOKEN을 chain. */
+    /** mockStorageValues 3개 후 BG_LAST_FIX(null) + APNS_TOKEN을 chain. */
     function stubApnsTokenAfterStorage(token: string | null): void {
       (AsyncStorage.getItem as jest.Mock)
         .mockResolvedValueOnce(null)
@@ -1271,7 +1232,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
   });
 
   describe('#1542 (ADR-016 S9) — accelerometer fingerprint BG piggyback', () => {
-    /** Phase B 전용 token chain — APNS token after storage 4 + BG_LAST_FIX null. */
+    /** Phase B 전용 token chain — APNS token after storage 3 + BG_LAST_FIX null. */
     function stubApnsTokenAfterStorage(token: string | null): void {
       (AsyncStorage.getItem as jest.Mock)
         .mockResolvedValueOnce(null) // BG_LAST_FIX_KEY — prevFix 없음

--- a/src/features/nearest-station/tasks/__tests__/foregroundBackgroundTransition.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/foregroundBackgroundTransition.test.ts
@@ -94,14 +94,28 @@ jest.mock('../../../../shared/utils/stationRoute', () => ({
   getFirstLeg: (_route: unknown, destinationName: string) => ({ line: '2', endName: destinationName }),
 }));
 
-const mockSendAlarmNotification = jest.fn((..._args: unknown[]) => Promise.resolve());
 const mockSendStationPassedNotification = jest.fn((..._args: unknown[]) => Promise.resolve());
 const mockUpdateStationNotification = jest.fn((..._args: unknown[]) => Promise.resolve());
 jest.mock('../../../alarm/utils/stationNotification', () => ({
-  sendAlarmNotification: (...args: unknown[]) => mockSendAlarmNotification(...args),
   sendStationPassedNotification: (...args: unknown[]) => mockSendStationPassedNotification(...args),
   updateStationNotification: (...args: unknown[]) => mockUpdateStationNotification(...args),
 }));
+
+// #2067 (Phase 2-device, D1) — sendAlarmNotification 제거로 "알람 발사" 관측 지점이
+// logFiredAlarm(alarmLog.ts)으로 이동. 이 파일은 stationPipeline/backgroundLocationTask의
+// dedup 결합을 실제 모듈로 검증하는 것이 목적이라, alarmLog는 requireActual로 대부분 실제
+// 구현을 유지하고 logFiredAlarm만 spy로 감싸 "발사 횟수"를 관측한다.
+const mockLogFiredAlarm = jest.fn();
+jest.mock('../../../alarm/utils/alarmLog', () => {
+  const actual = jest.requireActual('../../../alarm/utils/alarmLog');
+  return {
+    ...actual,
+    logFiredAlarm: (...args: unknown[]) => {
+      mockLogFiredAlarm(...args);
+      return actual.logFiredAlarm(...args);
+    },
+  };
+});
 
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
@@ -252,7 +266,7 @@ beforeEach(() => {
   // 기본: 'early' phase가 트리거되지 않는 multi-stop direct route — 알림 발사만 검증
   mockFindRoute.mockReturnValue(makeDirectRoute(3, '2'));
   mockSendStationPassedNotification.mockClear();
-  mockSendAlarmNotification.mockClear();
+  mockLogFiredAlarm.mockClear();
   mockUpdateStationNotification.mockClear();
   (AsyncStorage.setItem as jest.Mock).mockClear();
   // #1515 — cross-category dedup module 인메모리 상태 리셋(테스트 간 격리).
@@ -326,25 +340,25 @@ describe('FG↔BG 통합: 알람 dedup (FIRED_ALARMS_KEY 단일 출처)', () => 
 
   it('FG에서 알람 발사 후 BG가 같은 phase 조건을 받으면 evaluateAlarmPhase가 dedup한다', async () => {
     await runFgPipelineAt(fakeStation);
-    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+    expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
     expect(mockStorage.get(FIRED_ALARMS_KEY)).toBeDefined();
 
     await runBgTaskAt(fakeStation);
 
     // BG가 FIRED_ALARMS_KEY를 읽어 firedAlarms Set으로 만들고,
-    // evaluateAlarmPhase가 동일 키를 보고 null 반환 → sendAlarmNotification 무호출.
-    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+    // evaluateAlarmPhase가 동일 키를 보고 null 반환 → logFiredAlarm 무호출.
+    expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
   });
 
   it('BG에서 알람 발사 후 FG가 같은 phase 조건을 받으면 dedup된다', async () => {
     await runBgTaskAt(fakeStation);
-    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+    expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
     const firedJson = mockStorage.get(FIRED_ALARMS_KEY);
     expect(firedJson).toBeDefined();
 
     await runFgPipelineAt(fakeStation);
 
-    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+    expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -439,15 +453,15 @@ describe('FG↔BG 통합: swipe-kill 후 재진입 (AsyncStorage 영속성)', ()
   it('BG 알람 발사 후 swipe-kill을 거쳐 FG 재진입해도 firedAlarms는 영속 dedup된다', async () => {
     mockFindRoute.mockReturnValue(makeDirectRoute(1, '2'));
     await runBgTaskAt(fakeStation);
-    expect(mockSendAlarmNotification).toHaveBeenCalledTimes(1);
+    expect(mockLogFiredAlarm).toHaveBeenCalledTimes(1);
     const firedJson = mockStorage.get(FIRED_ALARMS_KEY);
     expect(firedJson).toBeDefined();
 
-    mockSendAlarmNotification.mockClear();
+    mockLogFiredAlarm.mockClear();
     expect(mockStorage.get(FIRED_ALARMS_KEY)).toBe(firedJson);
 
     await runFgPipelineAt(fakeStation);
 
-    expect(mockSendAlarmNotification).not.toHaveBeenCalled();
+    expect(mockLogFiredAlarm).not.toHaveBeenCalled();
   });
 });

--- a/src/features/nearest-station/tasks/backgroundLocationTask.ts
+++ b/src/features/nearest-station/tasks/backgroundLocationTask.ts
@@ -12,7 +12,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { processLocationUpdate } from '../../alarm/utils/stationPipeline';
 import { alarmKey } from '../../alarm/utils/stationAlarm';
 import { createLogger } from '../../../shared/utils/logger';
-import { APNS_TOKEN_KEY, DESTINATION_KEY, SLEEP_MODE_KEY, ALARM_EVENT_KEY, ROUTE_KEY, ALLOW_SPEAKER_KEY } from '../../../shared/constants/storageKeys';
+import { APNS_TOKEN_KEY, DESTINATION_KEY, SLEEP_MODE_KEY, ALARM_EVENT_KEY, ROUTE_KEY } from '../../../shared/constants/storageKeys';
 import { getFiredAlarms, setFiredAlarms } from '../../alarm/utils/notificationState';
 import { isAccuracyAcceptable, isLocationFresh, isPlausibleJump, type FixSample } from '../utils/locationGates';
 import { logSuppressedGate } from '../../alarm/utils/alarmLog';
@@ -133,11 +133,10 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   const speedMps = isValidGpsSpeedMps(speed) ? speed : null;
 
   try {
-    const [destJson, sleepJson, routeJson, allowSpeakerJson] = await Promise.all([
+    const [destJson, sleepJson, routeJson] = await Promise.all([
       AsyncStorage.getItem(DESTINATION_KEY),
       AsyncStorage.getItem(SLEEP_MODE_KEY),
       AsyncStorage.getItem(ROUTE_KEY),
-      AsyncStorage.getItem(ALLOW_SPEAKER_KEY),
     ]);
 
     // 경로(목적지) 없으면 백그라운드에서도 실시간 현황 알림을 띄우지 않는다.
@@ -164,7 +163,6 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     // 런타임 검증은 id 존재만 확인. Station 나머지 필드는 production write 시점에서 보장된다.
     const destination = destinationRaw as Station;
     const sleepMode = sleepJson ? JSON.parse(sleepJson) === true : false;
-    const allowSpeaker = allowSpeakerJson ? JSON.parse(allowSpeakerJson) === true : true;
 
     // #527: BG task 호출 간 직전 수용 fix를 AsyncStorage로 들고 시공간 일관성을 검증한다.
     // iOS deferred batch에서 stale 좌표가 섞여 들어오거나 OS가 부정확 fix를 보낼 때 발생하는
@@ -257,7 +255,6 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
       destination,
       firedAlarms,
       sleepMode,
-      allowSpeaker,
       storedRoute,
       speedMps,
       source: 'bg',

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -18,7 +18,7 @@ import { useBoardingLockStore } from '../features/alarm/store/useBoardingLockSto
 import { useUserIntentStore } from '../features/alarm/store/useUserIntentStore';
 import { useNavigationStore } from '../features/route/store/useNavigationStore';
 import { DestinationPicker } from '../features/route/components/DestinationPicker';
-import { findRouteCandidatesByCategory, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, getStationById, routeSignature, type Route, type CategorizedRoute, type RoutePreference } from '../shared/utils/stationRoute';
+import { findRouteCandidatesByCategory, findRoutes, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, getStationById, routeSignature, type Route, type CategorizedRoute, type RoutePreference } from '../shared/utils/stationRoute';
 import { pickArrivalAtOrigin } from '../features/arrival/utils/pickArrivalAtOrigin';
 import { EditorialTimeline } from '../features/arrival/components/EditorialTimeline';
 import { arrivalInfoToArrivalTrain, journeyDisplayToStops, nearestResultToNearest } from '../features/route/utils/journeyAdapter';
@@ -260,6 +260,9 @@ export default function HomeScreen() {
   const [lockCorrectionToast, setLockCorrectionToast] = useState<string | null>(null);
   // #1324 — 목적지 == 현재역(degenerate trip) 선택을 차단했을 때 노출하는 경고 toast.
   const [sameOriginToast, setSameOriginToast] = useState<string | null>(null);
+  // #2067 (Phase 2-device, D5) — 취침모드 on + 등록 구간이 1-hop이면 companion/OS 안전망 알람이
+  // 울릴 lead time이 없다. trip 등록 시점에 1회 안내(정보성 — 등록 자체는 차단하지 않음).
+  const [shortRouteToast, setShortRouteToast] = useState<string | null>(null);
   const handleConfirmStation = useCallback(
     (station: Station) => {
       setCustomOrigin(station);
@@ -453,6 +456,7 @@ export default function HomeScreen() {
     null;
   useTripOrigin(destination, effectiveOrigin, setTripOrigin, tripOrigin);
   const handleSameOriginToastDismiss = useCallback(() => setSameOriginToast(null), []);
+  const handleShortRouteToastDismiss = useCallback(() => setShortRouteToast(null), []);
   // #1324 — 목적지 선택 단일 진입점. 현재역(effectiveOrigin)과 같은 역이면 degenerate trip을
   // 만들지 않고 경고 toast만 노출한다. picker / 최근 목적지 tap 모두 이 핸들러를 거친다.
   // 반환값: 목적지를 실제로 설정했으면 true(picker가 닫아야 함), 차단했으면 false(picker 유지).
@@ -462,11 +466,19 @@ export default function HomeScreen() {
         setSameOriginToast(t('destinationPicker.sameAsOrigin'));
         return false;
       }
+      // #2067 (Phase 2-device, D5) — 취침모드 on + 1-hop 구간(전체 정거장 1개)이면 companion/OS
+      // 안전망 알람이 발화할 lead time이 없다. 등록은 그대로 진행하되 1회 안내만 덧붙인다.
+      if (sleepMode && effectiveOrigin) {
+        const totalStops = findRoutes(effectiveOrigin.id, station.id)[0]?.totalStops;
+        if (totalStops === 1) {
+          setShortRouteToast(t('home.shortRouteToast'));
+        }
+      }
       addRecentDestination(station);
       setDestination(station);
       return true;
     },
-    [effectiveOrigin, t, addRecentDestination, setDestination],
+    [effectiveOrigin, sleepMode, t, addRecentDestination, setDestination],
   );
   // #797: 환승역에서 nearest.station.line이 trip 방향과 어긋나는 회귀 차단.
   // BoardingLock(사용자 선택) > Route(구조적 SSOT) > station.line fallback.
@@ -1798,6 +1810,13 @@ export default function HomeScreen() {
         message={sameOriginToast ?? ''}
         onDismiss={handleSameOriginToastDismiss}
         testID="same-origin-toast"
+      />
+      {/* #2067 (Phase 2-device, D5) — 취침모드 1-hop 구간 안내. 5초 자동 dismiss + tap 닫기. */}
+      <Toast
+        visible={shortRouteToast !== null}
+        message={shortRouteToast ?? ''}
+        onDismiss={handleShortRouteToastDismiss}
+        testID="short-route-toast"
       />
 
       <DestinationPicker

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -208,3 +208,9 @@ export const USER_INTENT_INFO_MODE_KEY = 'subway-now:user-intent-info-mode';
 // trip 종료 시 runTripBoundCleanups에서 제거 — 이전 trip의 수신 시각이 새 trip 판정 오염 차단.
 // 형식: 숫자 (epoch ms) 문자열. 키 부재 = silent push 미수신(첫 launch or 새 trip 시작 직후).
 export const LAST_SILENT_PUSH_RECEIVED_AT_KEY = 'subway-now:last-silent-push-received-at';
+// #2067 (Phase 2-device) — AlarmLocalAuthority persisted dedup ledger.
+// 취침모드 companion silent push(kind `sleep-alarm-companion`)의 TTS/진동 부가 동작이 앱 재시작
+// (cold-launch) 후에도 중복 발사되지 않도록 in-memory Set 대신 AsyncStorage에 영속화한다.
+// entry TTL 1h — trip 하나가 1시간을 넘는 경우는 드물고, TTL이 지나면 자연 prune돼 무한 성장 방지.
+// 형식: { id: string; firedAt: number }[] JSON. id = `alarm-${tripToken}-${station}-${kind}`.
+export const ALARM_LOCAL_LEDGER_KEY = 'subway-now:alarm-local-ledger';

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -70,6 +70,7 @@
       "undo": "Undo"
     },
     "lockCorrectionToast": "Boarding train corrected: {{prev}} → {{next}}",
+    "shortRouteToast": "This trip is too short for the alarm to sound",
     "coldStartMismatch": {
       "title": "Check boarding station",
       "message": "Your boarding station does not match your current location. Please reselect.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -70,6 +70,7 @@
       "undo": "元に戻す"
     },
     "lockCorrectionToast": "乗車中の列車を {{prev}} → {{next}} に修正しました",
+    "shortRouteToast": "区間が短いためアラームは鳴りません",
     "coldStartMismatch": {
       "title": "乗車駅を確認",
       "message": "乗車駅が現在地と一致しません。再選択してください。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -70,6 +70,7 @@
       "undo": "되돌리기"
     },
     "lockCorrectionToast": "탑승 열차가 {{prev}} → {{next}}로 정정되었어요",
+    "shortRouteToast": "구간이 짧아 알람이 울리지 않아요",
     "coldStartMismatch": {
       "title": "탑승역 확인",
       "message": "탑승역이 현재 위치와 다릅니다. 다시 선택해 주세요.",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -70,6 +70,7 @@
       "undo": "撤销"
     },
     "lockCorrectionToast": "已将乘车列车修正为 {{prev}} → {{next}}",
+    "shortRouteToast": "区间太短，闹钟不会响起",
     "coldStartMismatch": {
       "title": "确认乘车站",
       "message": "乘车站与当前位置不符，请重新选择。",


### PR DESCRIPTION
Closes #2067

## Summary

축소 스코프: OS 예약 스케줄러 3종 통합(alarmScheduler/tripBoundScheduler/boardingLockScheduler → safetyNetScheduler)은 **#2089로 분리**했다. 본 PR은 하드닝(cross-channel cancel, 8분 backstop 등) 보존이 필요한 위험한 구조 변경이라 별도 검증 사이클을 거친다.

- **D1 제거**: `stationNotification.ts`의 `sendAlarmNotification` + 호출부(`useStationAlarm` FG polling, `stationPipeline` BG) 제거. 알람 배너는 원격 visible push(Phase 2-backend, #2066)가 담당 — 일반 모드에서 로컬 alarm.wav 발사 경로 자체가 사라짐.
- **D3 전환**: `silentPushTask.ts`가 소비하던 kind `sleep-transfer-alarm`(로컬 알림 생성)을 `sleep-alarm-companion` + `targetKind`로 전환. 알림(배너) 생성 없이 `AlarmLocalAuthority` 경유 TTS + Haptics 진동만 부가. 발사 성공 시 해당 station의 OS 안전망 예약(tba/bl)을 cancel(기존 cancel 헬퍼 재사용 — 스케줄러 파일 자체는 미수정).
- **AlarmLocalAuthority 신설** (`src/features/alarm/utils/alarmLocalAuthority.ts`): 로컬 알람 경로(TTS/진동)의 단일 진입점. sleepMode gate + AsyncStorage 기반 persisted dedup ledger(TTL 1h, 앱 재시작 생존) + 결정적 identifier(`alarm-<tripToken>-<station>-<kind>`).
- **1역차 UI 안내**: `HomeScreen`에서 취침모드 on + 목적지 등록 구간이 1-hop(`findRoutes(...).totalStops === 1`)이면 "구간이 짧아 알람이 울리지 않아요" 안내 toast(등록 차단 아님, 정보성 1회). i18n 4개 locale(ko/en/ja/zh) 추가.
- 부수 정리: `backgroundLocationTask.ts`의 `allowSpeaker` read/pass-through 제거(D1로 인해 dead), `alarmLog.ts` source `sleep-transfer-alarm` → `companion` 개명 + `logCompanionAlarmFired`.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass.
2. **V/X dashboard** — DebugModal alarm log에서 source 목록 fg/bg 발사 소스(sendAlarmNotification 경로)가 소멸하고 `companion` 소스가 새로 등장. `logFiredAlarm`은 여전히 dedup ledger + alarmLog 적재 목적으로 유지.
3. **의존 PR** — Phase 2-backend(#2066, `sleep-alarm-companion` payload 발사)는 이미 머지됨(dev에 포함). OS 예약 3종 통합(#2089)은 별도 — 본 PR과 독립적으로 동작(cancel 헬퍼는 기존 파일 그대로 재사용).
4. **측정 plan** — DebugModal alarm log에서 `companion` source의 `fired` 건수 관찰. 일반 모드에서 `fg`/`bg` source의 fired 건수가 0으로 떨어지는지 1주 관찰.
5. **Device verify**: 필요. 취침 trip FG 1회(companion 수신 시 TTS+진동, 배너 미생성 확인) + 취침 trip BG 1회(companion 수신 시 OS 안전망 cancel 확인) + 일반 모드 trip 1회(로컬 alarm.wav 0건 확인) + 1-hop 등록 toast 노출 확인.

## Test plan

- [x] `npm test` — 430 suites / 9168 tests pass, coverage 100%
- [x] `npm run type-check` — pass
- [x] `npm run lint:orphan` — no orphan exports
- [ ] 실기기 취침 trip FG/BG 각 1회 (사용자 검증 필요)

## Review 반영 (P1/P2)

- **P1 (allowSpeaker dead toggle)**: `alarmLocalAuthority.ts`의 `speakAlarm(body, { sleepMode: false, allowSpeaker: true })` 하드코딩을 제거. `fireCompanionAlarm`이 sleepMode를 읽듯 `ALLOW_SPEAKER_KEY`도 AsyncStorage에서 읽어 사용자 설정을 그대로 전달(기존 설정 semantics 보존 — 방향 1 채택, 토글 제거 아님). 진동은 기존대로 allowSpeaker 무관 항상 발생.
- **P2-1 (dead code)**: `useStationAlarm.ts`의 `notificationSource` useMemo + `resolveNotificationSource` import + effect deps 2곳 제거 — sendAlarmNotification 제거(D1)로 소비처가 사라진 뒤에도 "향후 재사용 보존" 주석으로 남아있던 투기적 코드. `stationPipeline.ts`의 동명 변수는 `updateStationNotification` 소비처가 있어 미변경.
- **Known limitation (P3, 범위 밖)**: `AlarmLocalAuthority`의 dedup ledger는 read-then-write 패턴이라 같은 station+kind의 companion push가 매우 짧은 간격(수백 ms 내)으로 동시 도착하면 세션 내 race로 중복 발사될 이론적 여지가 있다. backend 측 dedup(KV `alarmFireKey:`)이 1차 방어선이라 실사용 빈도는 낮을 것으로 판단 — 별도 이슈로 트래킹 필요 시 분리.

## Test plan (갱신)

- [x] `npm test` — 430 suites / 9172 tests pass, coverage 100%
- [x] `npm run type-check` — pass
- [x] `npm run lint:orphan` — no orphan exports
- [ ] 실기기 취침 trip FG/BG 각 1회 (사용자 검증 필요)
