### PR TITLE
fix(#2092): lock-active 매역 alert push에 content-available 병기

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -923,6 +923,58 @@ describe('sendAlertPush (#572 P2c)', () => {
       const body = JSON.parse(call[1].body as string);
       expect(body.data).toEqual({ pushId: 'p' });
     });
+
+    // #2092 — content-available 병기 (SSoT mirror·BG 위젯 채널 복원).
+    it('contentAvailable=true 지정 시 aps.alert와 content-available이 동시 wire', async () => {
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      await sendAlertPush({
+        deviceToken: 't',
+        title: 'T',
+        body: 'B',
+        pushId: 'p',
+        contentAvailable: true,
+        config: makeConfig(),
+        host: TEST_HOST_2,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+      const body = JSON.parse(call[1].body as string);
+      expect(body.aps.alert).toEqual({ title: 'T', body: 'B' });
+      expect(body.aps['content-available']).toBe(1);
+    });
+
+    it('contentAvailable 미지정 시 aps[content-available] 필드 omit (backward compat)', async () => {
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      await sendAlertPush({
+        deviceToken: 't',
+        title: 'T',
+        body: 'B',
+        pushId: 'p',
+        config: makeConfig(),
+        host: TEST_HOST_2,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+      const body = JSON.parse(call[1].body as string);
+      expect('content-available' in body.aps).toBe(false);
+    });
+
+    it('contentAvailable=false 지정 시 aps[content-available] 필드 omit', async () => {
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      await sendAlertPush({
+        deviceToken: 't',
+        title: 'T',
+        body: 'B',
+        pushId: 'p',
+        contentAvailable: false,
+        config: makeConfig(),
+        host: TEST_HOST_2,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+      const body = JSON.parse(call[1].body as string);
+      expect('content-available' in body.aps).toBe(false);
+    });
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1972,6 +1972,17 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
         expect('lockReleasedReason' in body.data).toBe(false);
       });
 
+      // #2092 — vanish-fallback 매역 push도 aps.alert + content-available 동시 병기.
+      it('#2092 vanish-fallback push는 aps.alert + content-available===1 동시 wire (SSoT mirror·BG 위젯 채널)', async () => {
+        const body = (await capturePushBody({
+          hopElapsed: true,
+          pushId: 'p2092-vf-content-available',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        })) as any;
+        expect(body.aps.alert).toBeDefined();
+        expect(body.aps['content-available']).toBe(1);
+      });
+
       it('hop 시간 미경과 + motion=stationary → release floor fire 보류 + lock release 유지', async () => {
         // #1402 — release 경로도 ADR-010 "false positive / miss 동급" 게이트를 통과해야 fire.
         // motion=stationary이면 floor fire는 보류(motion gate 증가)되지만, lock release는
@@ -8393,6 +8404,22 @@ describe('silent push SSoT forward (#1561 T8 / S2 흡수)', () => {
     expect(arvlcdBody!.data.ssot).toBeDefined();
     expect(arvlcdBody!.data.ssot.currentStationId).toBe('중곡');
     expect(arvlcdBody!.data.ssot.motionState).toBe('unknown');
+  });
+
+  // #2092 — arvlcd-fire 매역 push도 aps.alert + content-available 동시 병기 + data.ssot 잔존.
+  it('#2092 arvlcd-fire push는 aps.alert + content-available===1 동시 wire (SSoT mirror·BG 위젯 채널)', async () => {
+    const { arvlcdBody } = await runArvlcdSsotFireScenario({
+      token: 'ssot-arvlcd-content-available',
+      waypoints: [
+        { stationName: '중곡', line: '7', kind: 'intermediate' },
+        { stationName: '용마산', line: '7', kind: 'destination' },
+      ],
+      seedSsotStation: '중곡',
+    });
+    expect(arvlcdBody).toBeDefined();
+    expect(arvlcdBody!.aps.alert).toBeDefined();
+    expect(arvlcdBody!.aps['content-available']).toBe(1);
+    expect(arvlcdBody!.data.ssot).toBeDefined();
   });
 
   it('arvlcd-fire lazy-seeds SSoT from waypoint when absent (T4 #1557)', async () => {

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -471,6 +471,13 @@ export interface SendAlertPushOptions {
    * picker 등)가 영향받지 않게 한다. 미지정 시 `data`는 `{ pushId }` 그대로(구 caller backward compat).
    */
   data?: Record<string, unknown>;
+  /**
+   * #2092 — true면 `aps['content-available'] = 1`을 alert payload에 병기한다. iOS는 alert +
+   * content-available 동시 전달을 허용하며, 이 조합으로 device의 `handleSilentPush` background
+   * task가 깨어나 SSoT mirror(`persistBackendSsotMirror`)와 BG 위젯 갱신(`updateWidgetFromSilentPush`)이
+   * lock-active 매역 push에서도 계속 동작한다. 미지정 시 필드 생략 (구 caller backward compat).
+   */
+  contentAvailable?: boolean;
   config: ApnsConfig;
   host: string;
   fetchImpl?: typeof fetch;
@@ -493,6 +500,9 @@ export async function sendAlertPush(options: SendAlertPushOptions): Promise<Send
       ...(options.interruptionLevel !== undefined
         ? { 'interruption-level': options.interruptionLevel }
         : {}),
+      // #2092 — content-available은 true일 때만 wire. alert와 동시 병기해 device background
+      // task(handleSilentPush)를 깨워 SSoT mirror·BG 위젯 갱신을 유지한다.
+      ...(options.contentAvailable === true ? { 'content-available': 1 } : {}),
     },
     data: { pushId: options.pushId, ...options.data },
   });

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -2273,6 +2273,9 @@ export async function fireArvlCdStationPush(
   // apns-collapse-id로 같은 trip의 매역 알림을 알림센터에서 최신으로 교체(스택 방지) + apns-expiration
   // 90s로 지하 데이터 순단 후 stale 알림 늦은 표시를 방지한다. data는 기존 silent payload를 그대로
   // forward해 device SSoT/게이트 소비 코드(cascade picker 등)가 영향받지 않게 한다.
+  // #2092 — contentAvailable:true를 병기해 alert와 동시에 device background task
+  // (handleSilentPush)를 깨운다. station kind는 배너 no-op(#2088)이라 이중 배너 없이 SSoT
+  // mirror(persistBackendSsotMirror)·BG 위젯 갱신(updateWidgetFromSilentPush)만 수행한다.
   const stationNotifContent = buildStationNotifContent(waypoint, trip.locale);
   const heal = await sendWithEnvHeal(
     (host) =>
@@ -2287,6 +2290,7 @@ export async function fireArvlCdStationPush(
         collapseId: stationNotifCollapseId(trip.token),
         expirationEpochSec: Math.floor((now + STATION_NOTIF_EXPIRATION_MS) / 1000),
         data: buildSilentPushData(arvlcdPayload),
+        contentAvailable: true,
         config: deps.apnsConfig,
         host,
         fetchImpl: deps.fetchImpl,
@@ -2663,6 +2667,8 @@ export async function fireVanishFallbackStationPush(
     archFlag: deps.archFlag,
   });
   // #2063 (ADR-023 개정) — silent → visible alert push 직접 발사 (fireArvlCdStationPush와 동일 정책).
+  // #2092 — contentAvailable:true 병기로 device background task(handleSilentPush)를 깨워
+  // SSoT mirror·BG 위젯 갱신을 fireArvlCdStationPush와 동일하게 유지한다.
   const vanishStationNotifContent = buildStationNotifContent(waypoint, trip.locale);
   const heal = await sendWithEnvHeal(
     (host) =>
@@ -2677,6 +2683,7 @@ export async function fireVanishFallbackStationPush(
         collapseId: stationNotifCollapseId(trip.token),
         expirationEpochSec: Math.floor((now + STATION_NOTIF_EXPIRATION_MS) / 1000),
         data: buildSilentPushData(vanishPayload),
+        contentAvailable: true,
         config: deps.apnsConfig,
         host,
         fetchImpl: deps.fetchImpl,

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -3539,6 +3539,9 @@ describe('silentPushTask', () => {
       const stored = JSON.parse(mirrorCall![1] as string);
       expect(stored).toMatchObject(validSsot);
       expect(typeof stored.receivedAt).toBe('number');
+      // #2092 — station kind는 no-op skip(#2064)이므로 로컬 배너 0건. alert는 OS가 직접
+      // 렌더하고, task는 content-available로 깨어나 mirror write만 수행한다 (이중 배너 없음).
+      expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
     });
 
     it('handleSilentPush does not persist mirror when payload.ssot is absent', async () => {


### PR DESCRIPTION
Closes #2092

## 배경

#2063이 lock-active 매역 push를 sendSilentPush→sendAlertPush로 전환하면서 `content-available`이 빠져 iOS가 background task(`handleSilentPush`)를 깨우지 않게 됐다. 그 결과 `persistBackendSsotMirror`(화면 현재역 cascade tier 4 입력)와 `updateWidgetFromSilentPush`(BG 위젯)가 lock-active trip에서 매역 갱신 두절 상태였다. 본 PR은 alert payload에 `content-available`을 병기해 두 채널을 동시에 살린다.

## 변경 사항

- `backend/alarm-worker/src/apns.ts` — `sendAlertPush`에 `contentAvailable?: boolean` 옵션 추가. `true`일 때만 `aps['content-available'] = 1`을 alert payload에 병기(opt-in), 미지정 시 기존 caller 무영향(backward compat).
- `backend/alarm-worker/src/scheduled.ts` — `fireArvlCdStationPush` / `fireVanishFallbackStationPush`의 `sendAlertPush` 호출부에 `contentAvailable: true` 추가. 기존 `data`(SSoT 포함, `buildSilentPushData` forward)는 그대로 유지.
- `scheduled.ts:2274` 인근 주석을 "data forward로 SSoT 소비 영향 없음"에서 실제 메커니즘(content-available로 device background task 기동)으로 갱신.
- 취침 알람(companion), lockless silent 경로(`runLocklessIntermediate`)는 스펙대로 접촉하지 않음.

## 테스트

- `apns.test.ts` — `contentAvailable=true`(alert+content-available 동시 wire) / `false` / 미지정(둘 다 omit, backward compat) 3케이스.
- `scheduled.test.ts` — arvlcd-fire, vanish-fallback 매역 push 각각에서 `aps.alert` + `aps['content-available']===1` 동시 존재 + `data.ssot` 잔존 assert.
- `silentPushTask.test.ts` — station kind(`intermediate`) 수신 시 `scheduleNotificationAsync` 미호출(로컬 배너 0) + `persistBackendSsotMirror`(mirror write) 동시 assert 보강. device 코드 자체는 무수정(스펙대로).

## 검증

- `backend/alarm-worker`: `npm run test` (2697 tests pass) / `npm run type-check` (clean)
- `npm test` (frontend 9172 tests, coverage 100%) / `npm run type-check` (clean) / `npm run lint:orphan` (0 orphan)

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — DebugModal Raw Signal의 backend-ssot tier 채택 로그(`persistBackendSsotMirror` write 시점) + iOS 홈 위젯 BG 갱신(`updateWidgetFromSilentPush` 호출)에서 관측 가능. wrangler tail/Cloudflare Dashboard로 `apns-push-type: alert` + payload에 `content-available:1` 동시 존재 확인 가능.
3. **의존 PR** — N/A.
4. **측정 plan** — 실기기 lock trip 1회: 매역 push 수신 시 화면 현재역(useFusedNearestStation cascade)이 알림 배너와 동시에 전진하는지, BG 위젯이 앱 kill 상태에서도 갱신되는지 확인.
5. **Device verify** — 필요. lock trip 1회(FG 화면 + BG 위젯 동시 관찰), 이중 배너 발생 여부 확인.

## 테스트 플랜

- [ ] `backend/alarm-worker` 테스트 + type-check pass 확인 (완료, 본 PR CI)
- [ ] frontend 테스트 + type-check + lint:orphan pass 확인 (완료, 본 PR CI)
- [ ] 실기기 lock trip 1회 — 화면 현재역 전진 + BG 위젯 갱신 + 이중 배너 없음 확인 (사용자 검증 필요)