### PR TITLE
fix(#2093): route-progress arc 오버슛 gate + 장기 무신호 re-seed (item C+D)

### DIFF
--- a/src/features/route/hooks/__tests__/useRouteProgress.test.ts
+++ b/src/features/route/hooks/__tests__/useRouteProgress.test.ts
@@ -4,6 +4,7 @@ import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute'
 import type { Route } from '../../../../shared/utils/stationRoute';
 import type { Station } from '../../../../shared/types/station';
 import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
+import { computeRouteArc, currentHopDistanceM } from '../../utils/routeProgress';
 
 const sagajeong = findStationByNameAndLine('사가정', '7')!;
 const childrenPark = findStationByNameAndLine('어린이대공원', '7')!;
@@ -411,5 +412,188 @@ describe('useRouteProgress', () => {
 
     expect(result.current.position?.current.id).toBe(gunja.id);
     jest.useRealTimers();
+  });
+
+  // #2093 (item C) — arc 시간적분 오버슛 gate 경계값 검증.
+  describe('arc overshoot gate (item C)', () => {
+    it('does not invalidate dead-reckoning when overshoot stays within hop x2', () => {
+      jest.useFakeTimers();
+      const startTime = 1_000_000_000;
+      jest.setSystemTime(startTime);
+
+      const arcForHop = computeRouteArc(directRoute, sagajeong, childrenPark)!;
+      const hopM = currentHopDistanceM(arcForHop, 0);
+      const speedJustUnder = (hopM * 2 - 20) / 10; // 10초 뒤 예측 이동 = hopM×2 - 20m (임계 직전)
+
+      const { result, rerender } = renderHook(
+        (p: UseRouteProgressInputs) => useRouteProgress(p),
+        {
+          initialProps: makeProps({
+            userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+            speedMps: speedJustUnder,
+            accuracyMeters: 30,
+          }),
+        },
+      );
+      const baseline = result.current.progressM!;
+
+      jest.setSystemTime(startTime + 10_000);
+      act(() => {
+        rerender(
+          makeProps({
+            // 명백히 off-route(perp > 1.5km) — dead-reckoning 예측치가 그대로 progress에 반영된다.
+            userLocation: { lat: 37.5219, lng: 126.9244 },
+            speedMps: speedJustUnder,
+            accuracyMeters: 30,
+          }),
+        );
+      });
+
+      expect(result.current.progressM!).toBeGreaterThan(baseline);
+      expect(result.current.progressM!).toBeCloseTo(baseline + speedJustUnder * 10, 0);
+      jest.useRealTimers();
+    });
+
+    it('invalidates dead-reckoning and freezes at trusted anchor when overshoot exceeds hop x2', () => {
+      jest.useFakeTimers();
+      const startTime = 1_000_000_000;
+      jest.setSystemTime(startTime);
+
+      const arcForHop = computeRouteArc(directRoute, sagajeong, childrenPark)!;
+      const hopM = currentHopDistanceM(arcForHop, 0);
+      const speedOver = (hopM * 2 + 100) / 10; // 10초 뒤 예측 이동 = hopM×2 + 100m (임계 초과)
+
+      const { result, rerender } = renderHook(
+        (p: UseRouteProgressInputs) => useRouteProgress(p),
+        {
+          initialProps: makeProps({
+            userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+            speedMps: speedOver,
+            accuracyMeters: 30,
+          }),
+        },
+      );
+      const baseline = result.current.progressM!;
+
+      jest.setSystemTime(startTime + 10_000);
+      act(() => {
+        rerender(
+          makeProps({
+            userLocation: { lat: 37.5219, lng: 126.9244 },
+            speedMps: speedOver,
+            accuracyMeters: 30,
+          }),
+        );
+      });
+
+      // 오버슛 게이트 발동 — predicted가 lastTrustedProgressM(baseline)로 무효화되어 progress 변화 없음.
+      expect(result.current.progressM).toBe(baseline);
+      jest.useRealTimers();
+    });
+  });
+
+  // #2093 (item D) — route-progress 원점 stuck 해소용 GPS 합의 지점 re-seed 검증.
+  describe('stale re-seed (item D)', () => {
+    it('re-seeds to GPS consensus point after long stale period when fix is accurate and on-route', () => {
+      jest.useFakeTimers();
+      const startTime = 1_000_000_000;
+      jest.setSystemTime(startTime);
+
+      const { result, rerender } = renderHook(
+        (p: UseRouteProgressInputs) => useRouteProgress(p),
+        {
+          initialProps: makeProps({
+            userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+            speedMps: 0,
+            accuracyMeters: 30,
+          }),
+        },
+      );
+      const baseline = result.current.progressM!;
+
+      // 70초(> ROUTE_PROGRESS_RESEED_STALE_MS) 무신호 후 정확도 좋은(< 100m) fix가 경로 위(어린이대공원)에서 재포착.
+      // implied speed 기준으로는 거부될 큰 점프지만 re-seed가 이를 우회한다.
+      jest.setSystemTime(startTime + 70_000);
+      act(() => {
+        rerender(
+          makeProps({
+            userLocation: { lat: childrenPark.lat, lng: childrenPark.lng },
+            speedMps: 0,
+            accuracyMeters: 30,
+          }),
+        );
+      });
+
+      expect(result.current.progressM!).toBeGreaterThan(baseline);
+      expect(result.current.position?.current.id).toBe(childrenPark.id);
+      jest.useRealTimers();
+    });
+
+    it('does not re-seed when stale but accuracy fails the quality gate (underground low-quality fix)', () => {
+      jest.useFakeTimers();
+      const startTime = 1_000_000_000;
+      jest.setSystemTime(startTime);
+
+      const { result, rerender } = renderHook(
+        (p: UseRouteProgressInputs) => useRouteProgress(p),
+        {
+          initialProps: makeProps({
+            userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+            speedMps: 0,
+            accuracyMeters: 30,
+          }),
+        },
+      );
+      const baseline = result.current.progressM!;
+
+      jest.setSystemTime(startTime + 70_000);
+      act(() => {
+        rerender(
+          makeProps({
+            userLocation: { lat: childrenPark.lat, lng: childrenPark.lng },
+            speedMps: 0,
+            // ROUTE_PROGRESS_RESEED_ACCURACY_M(100m) 미달 — 지하 저품질 좌표로는 re-seed 금지.
+            accuracyMeters: 150,
+          }),
+        );
+      });
+
+      // reseed 게이트 실패 → implied speed 점프 거부 경로로 빠져 progress 거의 그대로(speed 0).
+      expect(Math.abs(result.current.progressM! - baseline)).toBeLessThan(100);
+      jest.useRealTimers();
+    });
+
+    it('does not re-seed when stale and accurate but off-route (perp > MAX_PERP_M)', () => {
+      jest.useFakeTimers();
+      const startTime = 1_000_000_000;
+      jest.setSystemTime(startTime);
+
+      const { result, rerender } = renderHook(
+        (p: UseRouteProgressInputs) => useRouteProgress(p),
+        {
+          initialProps: makeProps({
+            userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+            speedMps: 0,
+            accuracyMeters: 30,
+          }),
+        },
+      );
+      const baseline = result.current.progressM!;
+
+      jest.setSystemTime(startTime + 70_000);
+      act(() => {
+        rerender(
+          makeProps({
+            // 명백히 off-route(perp > 1.5km) — 정확도가 좋아도 route 위 합의가 없어 re-seed 금지.
+            userLocation: { lat: 37.5219, lng: 126.9244 },
+            speedMps: 0,
+            accuracyMeters: 30,
+          }),
+        );
+      });
+
+      expect(Math.abs(result.current.progressM! - baseline)).toBeLessThan(100);
+      jest.useRealTimers();
+    });
   });
 });

--- a/src/features/route/hooks/__tests__/useRouteProgress.test.ts
+++ b/src/features/route/hooks/__tests__/useRouteProgress.test.ts
@@ -4,7 +4,7 @@ import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute'
 import type { Route } from '../../../../shared/utils/stationRoute';
 import type { Station } from '../../../../shared/types/station';
 import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
-import { computeRouteArc, currentHopDistanceM } from '../../utils/routeProgress';
+import { computeRouteArc, currentHopDistanceM, nearestArcPoint } from '../../utils/routeProgress';
 
 const sagajeong = findStationByNameAndLine('사가정', '7')!;
 const childrenPark = findStationByNameAndLine('어린이대공원', '7')!;
@@ -490,6 +490,47 @@ describe('useRouteProgress', () => {
       expect(result.current.progressM).toBe(baseline);
       jest.useRealTimers();
     });
+
+    // review P3-1 — 오버슛 게이트가 off-route 분기뿐 아니라 on-route(blend) 분기에도 적용되는지 검증.
+    it('applies the overshoot gate on the on-route blend branch, not only off-route', () => {
+      jest.useFakeTimers();
+      const startTime = 1_000_000_000;
+      jest.setSystemTime(startTime);
+
+      const arcForHop = computeRouteArc(directRoute, sagajeong, childrenPark)!;
+      const hopM = currentHopDistanceM(arcForHop, 0);
+      // 5초 뒤 rawPredicted = speedOver × 5 가 hopM×2를 명백히 초과하도록 큰 speed 설정.
+      const speedOver = (hopM * 2 + 1000) / 5;
+
+      const { result, rerender } = renderHook(
+        (p: UseRouteProgressInputs) => useRouteProgress(p),
+        {
+          initialProps: makeProps({
+            userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+            speedMps: speedOver,
+            accuracyMeters: 300,
+          }),
+        },
+      );
+      const baseline = result.current.progressM!;
+
+      jest.setSystemTime(startTime + 5_000);
+      act(() => {
+        rerender(
+          makeProps({
+            // 같은 위치(perp≈0, on-route) — off-route 분기가 아닌 정상 blend 분기를 탄다.
+            userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+            speedMps: speedOver,
+            accuracyMeters: 300,
+          }),
+        );
+      });
+
+      // 게이트가 blend 분기에도 적용돼 predicted가 clamp됨 — 미적용 시 blended가
+      // (speedOver × 5) × 0.5 ≈ 수천 m로 튀지만, 적용 시 baseline 근처(수십 m)로 유지된다.
+      expect(Math.abs(result.current.progressM! - baseline)).toBeLessThan(100);
+      jest.useRealTimers();
+    });
   });
 
   // #2093 (item D) — route-progress 원점 stuck 해소용 GPS 합의 지점 re-seed 검증.
@@ -511,9 +552,10 @@ describe('useRouteProgress', () => {
       );
       const baseline = result.current.progressM!;
 
-      // 70초(> ROUTE_PROGRESS_RESEED_STALE_MS) 무신호 후 정확도 좋은(< 100m) fix가 경로 위(어린이대공원)에서 재포착.
-      // implied speed 기준으로는 거부될 큰 점프지만 re-seed가 이를 우회한다.
-      jest.setSystemTime(startTime + 70_000);
+      // 130초(> ROUTE_PROGRESS_RESEED_STALE_MS) 무신호 후 정확도 좋은(< 100m) fix가 경로 위(어린이대공원)에서
+      // 재포착. sagajeong→childrenPark 거리(~3,871m) ÷ 130s ≈ 29.8 m/s로 ROUTE_PROGRESS_RESEED_MAX_PLAUSIBLE_MPS
+      // (35 m/s) 이내라 물리적으로 타당 — implied speed(55 m/s) 기준으로는 거부될 큰 점프지만 re-seed가 우회한다.
+      jest.setSystemTime(startTime + 130_000);
       act(() => {
         rerender(
           makeProps({
@@ -527,6 +569,123 @@ describe('useRouteProgress', () => {
       expect(result.current.progressM!).toBeGreaterThan(baseline);
       expect(result.current.position?.current.id).toBe(childrenPark.id);
       jest.useRealTimers();
+    });
+
+    // review P2-1 — re-seed 물리적 타당성 가드 경계값 + 후진 multipath 시나리오.
+    describe('physical plausibility guard (review P2-1)', () => {
+      it('re-seeds when implied speed is just under the plausibility limit', () => {
+        jest.useFakeTimers();
+        const startTime = 1_000_000_000;
+        jest.setSystemTime(startTime);
+
+        const arcForHop = computeRouteArc(directRoute, sagajeong, childrenPark)!;
+        const gunjaProj = nearestArcPoint(arcForHop, gunja.lat, gunja.lng);
+        // 81초: maxPlausibleM = 35 × 81 = 2,835m > gunja 거리(~2,800.66m) — 임계 직전(허용).
+        const staleSec = 81;
+
+        const { result, rerender } = renderHook(
+          (p: UseRouteProgressInputs) => useRouteProgress(p),
+          {
+            initialProps: makeProps({
+              userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+              speedMps: 0,
+              accuracyMeters: 30,
+            }),
+          },
+        );
+
+        jest.setSystemTime(startTime + staleSec * 1000);
+        act(() => {
+          rerender(
+            makeProps({
+              userLocation: { lat: gunja.lat, lng: gunja.lng },
+              speedMps: 0,
+              accuracyMeters: 30,
+            }),
+          );
+        });
+
+        // re-seed가 발동하면 progressM이 GPS 사영점(proj.arcM)에 정확히 snap된다(blend가 아님).
+        expect(result.current.progressM!).toBeCloseTo(gunjaProj.arcM, 0);
+        expect(result.current.position?.current.id).toBe(gunja.id);
+        jest.useRealTimers();
+      });
+
+      it('does not re-seed when implied speed is just over the plausibility limit (falls back to normal blend)', () => {
+        jest.useFakeTimers();
+        const startTime = 1_000_000_000;
+        jest.setSystemTime(startTime);
+
+        const arcForHop = computeRouteArc(directRoute, sagajeong, childrenPark)!;
+        const gunjaProj = nearestArcPoint(arcForHop, gunja.lat, gunja.lng);
+        // 79초: maxPlausibleM = 35 × 79 = 2,765m < gunja 거리(~2,800.66m) — 임계 직후(거부).
+        const staleSec = 79;
+
+        const { result, rerender } = renderHook(
+          (p: UseRouteProgressInputs) => useRouteProgress(p),
+          {
+            initialProps: makeProps({
+              userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+              speedMps: 0,
+              accuracyMeters: 30,
+            }),
+          },
+        );
+
+        jest.setSystemTime(startTime + staleSec * 1000);
+        act(() => {
+          rerender(
+            makeProps({
+              userLocation: { lat: gunja.lat, lng: gunja.lng },
+              speedMps: 0,
+              accuracyMeters: 30,
+            }),
+          );
+        });
+
+        // re-seed skip → 기존 dead-reckoning/blend 경로로 처리되어 proj.arcM에 정확히 snap되지 않는다
+        // (predicted=0과 blend되어 gunjaProj.arcM보다 뚜렷이 작다 — implied speed 55m/s 미만이라
+        // jump-reject에는 안 걸리고 blend는 진행된다).
+        expect(result.current.progressM!).toBeLessThan(gunjaProj.arcM - 10);
+        jest.useRealTimers();
+      });
+
+      it('does not re-seed for backward multipath projection onto an already-passed station', () => {
+        jest.useFakeTimers();
+        const startTime = 1_000_000_000;
+        jest.setSystemTime(startTime);
+
+        const { result, rerender } = renderHook(
+          (p: UseRouteProgressInputs) => useRouteProgress(p),
+          {
+            initialProps: makeProps({
+              userLocation: { lat: childrenPark.lat, lng: childrenPark.lng },
+              speedMps: 0,
+              accuracyMeters: 30,
+            }),
+          },
+        );
+        const baseline = result.current.progressM!;
+
+        // 61초(> ROUTE_PROGRESS_RESEED_STALE_MS) 뒤 accuracy<100m·on-route인 multipath fix가
+        // 이미 지나온 sagajeong(원점)에 사영 — 물리적 타당성 가드(35 m/s × 61s ≈ 2,135m)가
+        // 실제 거리(~3,871m)를 초과 판정해 re-seed를 skip한다. 표시가 뒤로 튀는 사고 방지.
+        jest.setSystemTime(startTime + 61_000);
+        act(() => {
+          rerender(
+            makeProps({
+              userLocation: { lat: sagajeong.lat, lng: sagajeong.lng },
+              speedMps: 0,
+              accuracyMeters: 30,
+            }),
+          );
+        });
+
+        // re-seed skip + implied speed(63.5 m/s)도 55 m/s 초과라 jump-reject까지 이중으로 막혀
+        // dead-reckoning(predicted, speed 0)만 적용 — progress가 baseline 근처에 머문다.
+        expect(Math.abs(result.current.progressM! - baseline)).toBeLessThan(100);
+        jest.useRealTimers();
+      });
     });
 
     it('does not re-seed when stale but accuracy fails the quality gate (underground low-quality fix)', () => {

--- a/src/features/route/hooks/useRouteProgress.ts
+++ b/src/features/route/hooks/useRouteProgress.ts
@@ -17,6 +17,7 @@ import {
   ARC_OVERSHOOT_HOP_MULTIPLIER,
   ROUTE_PROGRESS_RESEED_STALE_MS,
   ROUTE_PROGRESS_RESEED_ACCURACY_M,
+  ROUTE_PROGRESS_RESEED_MAX_PLAUSIBLE_MPS,
 } from '../../../shared/constants/routeProgress';
 
 /**
@@ -136,12 +137,24 @@ export function useRouteProgress({
     // 8분 stuck류 회귀(원점=탑승역에 고착돼 표시가 플래핑)를 GPS 합의 지점 재앵커로 해소.
     // 저품질(지하) 좌표로는 re-seed하지 않는다 — accuracyMeters 게이트가 GPS 결정 권한을 지상 고품질
     // fix로만 제한(feedback_no_gps_for_decision).
+    //
+    // review P2-1 — 물리적 타당성 가드. accuracy<100m 게이트를 통과해도 역 근처 multipath로
+    // "지나온 역"의 arc에 사영되면 re-seed가 표시를 뒤로 튕기는 사고(이 PR이 잡으려는 증상 그 자체)로
+    // 이어질 수 있다. |proj.arcM - lastTrustedProgressM|가 ROUTE_PROGRESS_RESEED_MAX_PLAUSIBLE_MPS ×
+    // stale 경과초를 넘으면 물리적으로 불가능한 이동이므로 re-seed를 skip — 전진/후진 양방향 대칭 가드.
+    // dead-reckoning 과전진의 정당한 후진 보정(작은 Δ)은 통과한다.
+    // review P3-2 — ROUTE_PROGRESS_RESEED_MAX_PLAUSIBLE_MPS(35)는 아래 jump-reject의 MAX_PLAUSIBLE_MPS(55)보다
+    // 보수적이다: re-seed는 jump-reject 자체를 우회하는 경로라 같은 임계를 쓰면 의미가 없다.
     const staleMs = now - current.lastTrustedTickMs;
+    const reseedDeltaM = Math.abs(proj.arcM - current.lastTrustedProgressM);
+    const reseedMaxPlausibleM =
+      ROUTE_PROGRESS_RESEED_MAX_PLAUSIBLE_MPS * (staleMs / 1000);
     const reseedEligible =
       staleMs > ROUTE_PROGRESS_RESEED_STALE_MS &&
       accuracyMeters != null &&
       accuracyMeters < ROUTE_PROGRESS_RESEED_ACCURACY_M &&
-      proj.perpDistanceM <= MAX_PERP_M;
+      proj.perpDistanceM <= MAX_PERP_M &&
+      reseedDeltaM <= reseedMaxPlausibleM;
     if (reseedEligible) {
       stateRef.current = {
         progressM: proj.arcM,

--- a/src/features/route/hooks/useRouteProgress.ts
+++ b/src/features/route/hooks/useRouteProgress.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   computeRouteArc,
+  currentHopDistanceM,
   nearestArcPoint,
   stationAtProgress,
   type RouteArc,
@@ -13,6 +14,9 @@ import {
   MAX_PLAUSIBLE_MPS,
   ACCURACY_WEIGHT_SCALE_M,
   DEFAULT_ACCURACY_WEIGHT,
+  ARC_OVERSHOOT_HOP_MULTIPLIER,
+  ROUTE_PROGRESS_RESEED_STALE_MS,
+  ROUTE_PROGRESS_RESEED_ACCURACY_M,
 } from '../../../shared/constants/routeProgress';
 
 /**
@@ -126,9 +130,44 @@ export function useRouteProgress({
       return;
     }
 
+    // #2093 (item D) — 장기 무신호(마지막 신뢰 관측 이후 ROUTE_PROGRESS_RESEED_STALE_MS 이상 경과) 후
+    // 재기동 시, 정확도가 좋고(< ROUTE_PROGRESS_RESEED_ACCURACY_M) 경로 위에서 합의(perp ≤ MAX_PERP_M)되는
+    // fix라면 dead-reckoning/jump-reject 판정을 우회하고 그 지점으로 즉시 re-seed한다. lock_position_tier
+    // 8분 stuck류 회귀(원점=탑승역에 고착돼 표시가 플래핑)를 GPS 합의 지점 재앵커로 해소.
+    // 저품질(지하) 좌표로는 re-seed하지 않는다 — accuracyMeters 게이트가 GPS 결정 권한을 지상 고품질
+    // fix로만 제한(feedback_no_gps_for_decision).
+    const staleMs = now - current.lastTrustedTickMs;
+    const reseedEligible =
+      staleMs > ROUTE_PROGRESS_RESEED_STALE_MS &&
+      accuracyMeters != null &&
+      accuracyMeters < ROUTE_PROGRESS_RESEED_ACCURACY_M &&
+      proj.perpDistanceM <= MAX_PERP_M;
+    if (reseedEligible) {
+      stateRef.current = {
+        progressM: proj.arcM,
+        lastTickMs: now,
+        lastTrustedProgressM: proj.arcM,
+        lastTrustedTickMs: now,
+        speedMps: nextSpeed,
+        initialized: true,
+      };
+      setProgressM(proj.arcM);
+      return;
+    }
+
     // 모션 모델: 직전 tick부터 dead reckoning.
     const dt = (now - current.lastTickMs) / 1000;
-    const predicted = current.progressM + current.speedMps * dt;
+    const rawPredicted = current.progressM + current.speedMps * dt;
+
+    // #2093 (item C) — arc 시간적분 오버슛 gate. lastTrustedProgressM 대비 dead-reckoning 예측치가
+    // 현재 hop 거리 × ARC_OVERSHOOT_HOP_MULTIPLIER를 초과하면 무효화 — trusted anchor로 되돌려 재적분.
+    // 정지 상태에서도 시간 적분만 계속 누적되는 회귀(lesson_arc_time_integration_overshoot) 차단.
+    const hopDistanceM = currentHopDistanceM(arc, current.lastTrustedProgressM);
+    const overshotM = Math.abs(rawPredicted - current.lastTrustedProgressM);
+    const predicted =
+      hopDistanceM > 0 && overshotM > hopDistanceM * ARC_OVERSHOOT_HOP_MULTIPLIER
+        ? current.lastTrustedProgressM
+        : rawPredicted;
 
     // 경로 이탈: 관측 무시, dead reckoning만 적용. trusted baseline은 그대로.
     if (proj.perpDistanceM > MAX_PERP_M) {

--- a/src/features/route/utils/__tests__/routeProgress.test.ts
+++ b/src/features/route/utils/__tests__/routeProgress.test.ts
@@ -1,5 +1,6 @@
 import {
   computeRouteArc,
+  currentHopDistanceM,
   nearestArcPoint,
   stationAtProgress,
   type RouteArc,
@@ -319,5 +320,40 @@ describe('stationAtProgress', () => {
     const info = stationAtProgress(arc, arc.arcM[1]);
     expect(info.current.id).toBe(arc.stations[1].id);
     expect(info.distanceToNextM).toBe(arc.arcM[2] - arc.arcM[1]);
+  });
+});
+
+describe('currentHopDistanceM (#2093 item C)', () => {
+  const route = makeDirectRoute(4, '7');
+  const arc = computeRouteArc(route, sagajeong, childrenPark)!;
+
+  it('returns 0 for single-station arc (no hop)', () => {
+    const single = computeRouteArc(makeDirectRoute(0, '7'), gunja, gunja)!;
+    expect(currentHopDistanceM(single, 0)).toBe(0);
+  });
+
+  it('returns the segment length containing progressM=0', () => {
+    expect(currentHopDistanceM(arc, 0)).toBe(arc.arcM[1] - arc.arcM[0]);
+  });
+
+  it('returns the segment length for a mid-arc progress', () => {
+    const p = arc.arcM[2] + (arc.arcM[3] - arc.arcM[2]) * 0.3;
+    expect(currentHopDistanceM(arc, p)).toBe(arc.arcM[3] - arc.arcM[2]);
+  });
+
+  it('returns the last segment length when progress is at totalLengthM', () => {
+    expect(currentHopDistanceM(arc, arc.totalLengthM)).toBe(
+      arc.arcM[arc.arcM.length - 1] - arc.arcM[arc.arcM.length - 2],
+    );
+  });
+
+  it('clamps progress below 0 to the first segment', () => {
+    expect(currentHopDistanceM(arc, -5000)).toBe(arc.arcM[1] - arc.arcM[0]);
+  });
+
+  it('clamps progress above totalLengthM to the last segment', () => {
+    expect(currentHopDistanceM(arc, arc.totalLengthM + 5000)).toBe(
+      arc.arcM[arc.arcM.length - 1] - arc.arcM[arc.arcM.length - 2],
+    );
   });
 });

--- a/src/features/route/utils/routeProgress.ts
+++ b/src/features/route/utils/routeProgress.ts
@@ -178,6 +178,26 @@ export function nearestArcPoint(arc: RouteArc, lat: number, lng: number): ArcPro
 }
 
 /**
+ * #2093 (item C) — progressM이 속한 현재 hop(인접 두 역 사이) 거리(m).
+ * arc time-integration overshoot gate가 "예측치가 현재 hop 거리 × N배 초과"를 판정할 때 사용.
+ *
+ * progressM을 포함하는 segment [arcM[i], arcM[i+1]]를 찾아 그 길이를 반환. progressM이 arc
+ * 범위를 벗어나면 clamp. stations.length < 2(단일 역 arc)면 hop 자체가 없으므로 0.
+ */
+export function currentHopDistanceM(arc: RouteArc, progressM: number): number {
+  const { arcM, totalLengthM } = arc;
+  if (arcM.length < 2) return 0;
+  // p는 [0, totalLengthM]로 clamp되고 arcM[arcM.length-1] === totalLengthM이므로
+  // 루프는 항상 마지막 인덱스(i = arcM.length-2) 이전에 조건을 만족해 반환한다 — fallthrough 없음.
+  const p = Math.max(0, Math.min(progressM, totalLengthM));
+  for (let i = 0; i < arcM.length - 1; i++) {
+    if (p <= arcM[i + 1]) return arcM[i + 1] - arcM[i];
+  }
+  /* istanbul ignore next -- 위 주석대로 도달 불가. TS 반환 타입 보장을 위한 방어 코드. */
+  return arcM[arcM.length - 1] - arcM[arcM.length - 2];
+}
+
+/**
  * progressM(경로 시작점부터 누적거리)에 해당하는 현재/다음/이전 역 정보.
  * current = arc 기준 최단 거리 역. next/prev = 해당 역의 다음/이전 인덱스 역(경로 진행 방향).
  */

--- a/src/shared/constants/routeProgress.ts
+++ b/src/shared/constants/routeProgress.ts
@@ -33,3 +33,12 @@ export const ARC_OVERSHOOT_HOP_MULTIPLIER = 2;
 // (feedback_no_gps_for_decision 원칙 — GPS는 지상 고품질 fix일 때만 결정 권한).
 export const ROUTE_PROGRESS_RESEED_STALE_MS = 60_000;
 export const ROUTE_PROGRESS_RESEED_ACCURACY_M = 100;
+
+// #2093 (item D, review P2-1) — re-seed 물리적 타당성 가드. 서울 지하철 최고 영업속도(9호선 급행
+// ~100km/h ≈ 28 m/s)에 가속/정차 여유를 더해 ~35 m/s로 설정. accuracy<100m 게이트를 통과해도
+// 역 근처 multipath로 "지나온 역"의 arc에 사영되면 re-seed가 표시를 뒤로 튕기는 사고
+// (이 PR이 원래 잡으려던 증상 그 자체)가 날 수 있다 — |proj.arcM - lastTrustedProgressM|가
+// 이 속도 × stale 경과초를 넘으면 물리적으로 불가능한 이동이므로 re-seed를 skip하고 기존
+// jump-reject/dead-reckoning 경로를 유지한다. 전진·후진 양방향 대칭 가드 — dead-reckoning
+// 과전진의 정당한 후진 보정(작은 Δ)은 이 가드를 통과한다.
+export const ROUTE_PROGRESS_RESEED_MAX_PLAUSIBLE_MPS = 35;

--- a/src/shared/constants/routeProgress.ts
+++ b/src/shared/constants/routeProgress.ts
@@ -18,3 +18,18 @@ export const DEFAULT_ACCURACY_WEIGHT = 0.3;
 // defense-in-depth 가드. 실제 수도권 역간 최대 거리는 수인분당선 달월→사리 ~14km 정도이므로
 // 그 이상(예: 데이터 손상으로 다른 도시 좌표가 섞이는 경우)만 거른다.
 export const MAX_INTER_STATION_M = 20_000;
+
+// #2093 (item C) — arc 시간적분(dead-reckoning) 오버슛 gate 배수.
+// lesson_arc_time_integration_overshoot: 지하 등 무신호 구간에서 정지 상태여도 시간 적분(speed × dt)만
+// 계속 누적되어 실제 hop 거리를 훨씬 초과(evidence: 3,981→4,877m, 걷는 중)하는 회귀.
+// 마지막 신뢰 관측(lastTrustedProgressM) 대비 예측치가 "현재 hop 거리 × 이 배수"를 넘으면 무효화하고
+// trusted anchor로 되돌려 재적분한다.
+export const ARC_OVERSHOOT_HOP_MULTIPLIER = 2;
+
+// #2093 (item D) — route-progress 원점 stuck 해소용 re-seed 조건.
+// estimator가 장기 무신호(마지막 신뢰 관측 이후 이 시간 이상 경과) 후 재기동될 때, GPS가 이 정확도보다
+// 정밀하고(accuracy < 값) 경로 위에서 합의(perp ≤ MAX_PERP_M)되면 dead-reckoning/jump-reject를 우회해
+// 그 지점으로 즉시 re-seed한다. 저품질(지하) 좌표로는 re-seed하지 않기 위한 정확도 게이트
+// (feedback_no_gps_for_decision 원칙 — GPS는 지상 고품질 fix일 때만 결정 권한).
+export const ROUTE_PROGRESS_RESEED_STALE_MS = 60_000;
+export const ROUTE_PROGRESS_RESEED_ACCURACY_M = 100;


### PR DESCRIPTION
Part of #2093

## 요약
이슈 #2093의 항목 **C(arc 시간적분 오버슛 gate)** + **D(route-progress tier 원점 stuck 해소)** 구현.

### C. arc 시간적분 오버슛 gate
- `useRouteProgress`의 dead-reckoning 예측치(`progressM + speedMps × dt`)가 마지막 신뢰 관측
  (`lastTrustedProgressM`) 대비 **현재 hop 거리 × 2**를 초과하면 무효화하고 trusted anchor로
  되돌려 재적분한다. off-route 분기뿐 아니라 on-route(blend) 분기에도 동일하게 적용.
- `currentHopDistanceM` (routeProgress.ts) 신규 유틸 — progressM이 속한 현재 hop 구간 길이 산출.
- 상수: `ARC_OVERSHOOT_HOP_MULTIPLIER = 2` (`shared/constants/routeProgress.ts`).
- evidence: 7/7 로그 — 지하 내내 arc 0.00 동결 → 지상 재포착 후 3,981→4,877m 폭주(걷는 중,
  `lesson_arc_time_integration_overshoot` 재현).

### D. route-progress tier 원점 stuck 해소
- `useRouteProgress`가 마지막 신뢰 관측 이후 `ROUTE_PROGRESS_RESEED_STALE_MS`(60s) 이상 무신호
  상태였다가, 정확도 좋고(`< ROUTE_PROGRESS_RESEED_ACCURACY_M` 100m) 경로 위에서 합의
  (`perpDistanceM ≤ MAX_PERP_M`)되는 fix가 재포착되면 jump-reject/dead-reckoning 판정을
  우회해 그 지점으로 즉시 re-seed한다.
- 저품질(지하) 좌표는 정확도 게이트로 배제 — `feedback_no_gps_for_decision` 원칙(GPS는 지상
  고품질 fix일 때만 결정 권한) 준수.
- evidence: GPS=건대입구인데 rt=용마산(idx 0)을 1분+ 고집 → 표시 플래핑.
- 구현 규모는 `useRouteProgress.ts` 단일 hook 내 조건 분기 추가로 제한적 — fusion tier 우선순위
  구조(`pickFusionTier.ts`)나 알람 경로는 접촉하지 않았다.

### 리뷰 반영 (P2-1 / P3-1 / P3-2)
- **P2-1 (물리적 타당성 가드)**: item D의 re-seed가 `proj.arcM`을 무조건 채택하면, 역 근처
  multipath로 accuracy<100m 게이트를 통과한 좌표가 **지나온 역**의 arc에 사영될 때 표시가
  뒤로 튀는 사고(이 PR이 원래 잡으려는 증상 그 자체)가 날 수 있음을 지적받음. 수정: re-seed 조건에
  `|proj.arcM - lastTrustedProgressM| ≤ ROUTE_PROGRESS_RESEED_MAX_PLAUSIBLE_MPS(35 m/s) × staleSec`
  가드 추가 — 서울 지하철 최고 영업속도 + 가속/정차 여유 기준. 위반 시 re-seed skip + 기존
  jump-reject/dead-reckoning 경로 유지. 전진·후진 양방향 대칭 가드라 dead-reckoning 과전진의
  정당한 후진 보정(작은 Δ)은 통과한다.
- **P3-1**: 오버슛 게이트(item C)가 off-route 분기뿐 아니라 on-route(blend) 분기에도 적용되는지
  검증하는 테스트 추가.
- **P3-2**: re-seed 임계(35 m/s)와 기존 jump-reject 임계(`MAX_PLAUSIBLE_MPS` 55 m/s)의 관계를
  설명하는 코드 주석 추가 — re-seed는 jump-reject를 우회하는 경로라 같은 임계를 쓰면 가드
  무의미해지기 때문에 더 보수적인 값을 쓴다.

## 변경 파일
- `src/features/route/utils/routeProgress.ts` — `currentHopDistanceM` 추가
- `src/features/route/hooks/useRouteProgress.ts` — 오버슛 gate + stale re-seed(물리 타당성
  가드 포함) 분기 추가
- `src/shared/constants/routeProgress.ts` — 상수 4개 추가(`ARC_OVERSHOOT_HOP_MULTIPLIER`,
  `ROUTE_PROGRESS_RESEED_STALE_MS`, `ROUTE_PROGRESS_RESEED_ACCURACY_M`,
  `ROUTE_PROGRESS_RESEED_MAX_PLAUSIBLE_MPS`)
- 테스트 2개 파일 — 오버슛 경계값(×2 직전/직후, on-route blend 분기 포함) + re-seed 조건
  (합의 성립/불성립: stale·정확도·off-route·물리 타당성 가드 경계값·후진 multipath skip)
  각 분기 추가

## 주의사항 준수
- fusion tier 우선순위 구조 변경 없음
- 알람 경로(`useStationAlarm`, `stationNotification`) 접촉 없음
- 기존 route-progress 테스트 전부 green 유지

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard** — DebugModal의 route-progress arc/progressM 표시 및 `wrangler tail` 없이도
   device 로그(`arc=`, `rt=`)로 관측 가능. 기존 로그 포인트 그대로 재사용(신규 로그 추가 없음).
3. **의존 PR** — N/A
4. **측정 plan** — 다음 실기기 trip에서 (a) 정지 구간 arc 값이 hop 거리 × 2를 넘지 않는지 (b) 지하
   장기 무신호 후 재포착 시 route-progress가 GPS와 즉시 합의하는지(1분+ 원점 고착 재발 0건,
   역행 오탐 0건)를 DebugModal Estimator/Fusion 로그로 확인.
5. **Device verify** — 필요. 지하 구간 포함 실기기 trip에서 (a) 정지 상태 arc 값 미동결 검증
   (b) 지하 진입~재포착 구간 route-progress 플래핑 재발 여부 (c) multipath로 인한 역행 표시
   재발 여부 확인 필요. 코드 변경 자체는 type-check + unit(coverage 100%)만 검증됨.

## 검증
- `npm test` — 430 suites / 9187 tests pass, coverage 100% (lines/branches/functions/statements)
- `npm run type-check` — pass
- `npm run lint:orphan` — pass, 0 orphan

## 이슈 스펙 대비 이탈
없음. (D는 "반나절 이상 규모 시 분리" 조건에 해당하지 않아 C와 함께 완결. 리뷰 P2/P3 반영도
item D 범위 내 물리 타당성 가드 보강으로 스펙 이탈 아님)
