### PR TITLE
fix: POST /position 재발열 + 알람 busy-loop 쿨다운 (#2093 A·B)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useFgPositionUpload.test.ts
+++ b/src/features/alarm/hooks/__tests__/useFgPositionUpload.test.ts
@@ -6,7 +6,7 @@ import { act, renderHook } from '@testing-library/react-native';
 import { useFgPositionUpload } from '../useFgPositionUpload';
 import { GOOD_FIX_ACCURACY_MAX_M } from '../useBoardingLockSync';
 import { uploadPosition } from '../../../nearest-station/api/positionUpload';
-import { FG_POSITION_UPLOAD_THROTTLE_MS } from '../../../../shared/constants/location';
+import { POSITION_UPLOAD_MIN_INTERVAL_MS } from '../../../../shared/constants/location';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../../shared/constants/storageKeys';
 
 jest.mock('../../../nearest-station/api/positionUpload', () => ({
@@ -94,7 +94,7 @@ describe('useFgPositionUpload (#1280)', () => {
     expect(mockedUpload).toHaveBeenCalledTimes(1);
 
     // throttle 간격 미만에서 새 fix → 미발사
-    act(() => jest.advanceTimersByTime(FG_POSITION_UPLOAD_THROTTLE_MS - 1));
+    act(() => jest.advanceTimersByTime(POSITION_UPLOAD_MIN_INTERVAL_MS - 1));
     rerender({ userLocation: { lat: 37.51, lng: 127.01 } });
     await flushAsyncStorage();
     expect(mockedUpload).toHaveBeenCalledTimes(1);

--- a/src/features/alarm/hooks/useFgPositionUpload.ts
+++ b/src/features/alarm/hooks/useFgPositionUpload.ts
@@ -12,7 +12,7 @@
  * 으로 확인된 회귀(#1280)다.
  *
  * 사용자가 앱을 FG에서 보고 있는 동안 fix-watch가 좋은 fix를 흘리므로, 그 fix를 throttle 간격
- * (FG_POSITION_UPLOAD_THROTTLE_MS, ~10s)마다 backend로 송신해 위치 채널을 점등한다.
+ * (POSITION_UPLOAD_MIN_INTERVAL_MS, ~10s)마다 backend로 송신해 위치 채널을 점등한다.
  *
  * 게이트(useBoardingLockSync와 동형):
  *   - tripActive=false → no-op (lock 없는 좌표는 backend trip series에 의미 없음)
@@ -26,7 +26,7 @@
 import { useEffect, useRef } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
-import { FG_POSITION_UPLOAD_THROTTLE_MS } from '../../../shared/constants/location';
+import { POSITION_UPLOAD_MIN_INTERVAL_MS } from '../../../shared/constants/location';
 import { uploadPosition, type PositionMotion } from '../../nearest-station/api/positionUpload';
 import { GOOD_FIX_ACCURACY_MAX_M } from './useBoardingLockSync';
 import { createLogger } from '../../../shared/utils/logger';
@@ -57,6 +57,9 @@ export interface UseFgPositionUploadOptions {
  *
  * userLocation/accuracy가 바뀔 때마다 effect가 재실행되지만, 마지막 발사 시각을 ref로 들고
  * throttle 간격 이내의 연속 fix는 1회로 묶는다(BG보다 촘촘하되 과송신 방지).
+ *
+ * #2093 (A) — POSITION_UPLOAD_MIN_INTERVAL_MS는 BG task(`backgroundLocationTask`)와 공유하는
+ * 상수. FG는 in-memory ref, BG는 AsyncStorage 기반으로 같은 최소 간격을 각자 방식으로 강제한다.
  */
 export function useFgPositionUpload({
   userLocation,
@@ -83,7 +86,7 @@ export function useFgPositionUpload({
 
     const now = Date.now();
     const lastUploadedAt = lastUploadedAtRef.current;
-    if (lastUploadedAt !== null && now - lastUploadedAt < FG_POSITION_UPLOAD_THROTTLE_MS) return;
+    if (lastUploadedAt !== null && now - lastUploadedAt < POSITION_UPLOAD_MIN_INTERVAL_MS) return;
     lastUploadedAtRef.current = now;
 
     void fireUpload({

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -65,6 +65,7 @@ import {
   logCrossTripMirrorSkip,
   logSuppressedOriginHopLockless,
   logSuppressedPassedEventOnLockOrigin,
+  LOCK_ORIGIN_SUPPRESS_COOLDOWN_MS,
   logSuppressedLocklessNoUserIntent,
   logSuppressedSsotFireGate,
   logSuppressedTbaRevalidation,
@@ -1142,6 +1143,39 @@ describe('alarmLog', () => {
         stationName: '용마산',
         kind: 'station-passed',
       });
+    });
+
+    it('#2093 (B) logSuppressedPassedEventOnLockOrigin: 30s 쿨다운 내 같은 station 재호출은 drop', async () => {
+      const baseTs = 1_700_000_000_000;
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(baseTs);
+      try {
+        logSuppressedPassedEventOnLockOrigin({ source: 'fg', stationName: '용마산' });
+        await flushAlarmLog();
+        const callsAfterFirst = (AsyncStorage.setItem as jest.Mock).mock.calls.length;
+
+        // 쿨다운 내 재호출 (fg-arvlcd 매초 재평가 busy-loop 시뮬레이션) — drop
+        nowSpy.mockReturnValue(baseTs + LOCK_ORIGIN_SUPPRESS_COOLDOWN_MS - 1);
+        logSuppressedPassedEventOnLockOrigin({ source: 'fg-arvlcd', stationName: '용마산' });
+        await flushAlarmLog();
+        expect((AsyncStorage.setItem as jest.Mock).mock.calls.length).toBe(callsAfterFirst);
+
+        // 쿨다운 경계 통과 — 재개
+        nowSpy.mockReturnValue(baseTs + LOCK_ORIGIN_SUPPRESS_COOLDOWN_MS + 1);
+        logSuppressedPassedEventOnLockOrigin({ source: 'fg', stationName: '용마산' });
+        await flushAlarmLog();
+        expect((AsyncStorage.setItem as jest.Mock).mock.calls.length).toBe(callsAfterFirst + 1);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('#2093 (B) logSuppressedPassedEventOnLockOrigin: 다른 station은 별개 쿨다운 — drop 안 됨', async () => {
+      logSuppressedPassedEventOnLockOrigin({ source: 'fg', stationName: '용마산' });
+      logSuppressedPassedEventOnLockOrigin({ source: 'fg', stationName: '건대입구' });
+      await flushAlarmLog();
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved).toHaveLength(2);
     });
 
     it('#1816 logSuppressedLocklessNoUserIntent: reason=lockless-no-user-intent + kind/phaseId 보존', async () => {

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -739,12 +739,12 @@ export function _resetDedupAlarmWindowForTests(): void {
  * 키: `${reason}|${stationName}` — 같은 역의 같은 reason 반복 스팸 차단.
  * stationName까지 구분해야 역이 바뀌었을 때 첫 신호를 drop하지 않는다.
  */
-const lastBurstSuppressTs = new Map<string, number>();
+const lastBurstSuppressTs = new Map<string, { ts: number; windowMs: number }>();
 
 function sweepExpiredBurstEntries(now: number): void {
   if (lastBurstSuppressTs.size <= DEDUP_LOG_MAP_CAP) return;
-  for (const [k, ts] of lastBurstSuppressTs) {
-    if (now - ts >= DEDUP_LOG_WINDOW_MS) lastBurstSuppressTs.delete(k);
+  for (const [k, entry] of lastBurstSuppressTs) {
+    if (now - entry.ts >= entry.windowMs) lastBurstSuppressTs.delete(k);
   }
 }
 
@@ -752,12 +752,20 @@ function sweepExpiredBurstEntries(now: number): void {
 // site label('register'/'mismatch'/'launch')이든 자유롭게 사용한다 (#1628). 키 구성은
 // `${reason}|${discriminator}` 단순 문자열 결합으로, 호출 간 의미 차이는 reason 단위로
 // 격리되므로 같은 reason에서 일관된 차원만 쓰면 충돌하지 않는다.
-function isBurstDuplicate(reason: string, discriminator: string): boolean {
+//
+// #2093 (B) — windowMs 옵션 파라미터. 기본은 DEDUP_LOG_WINDOW_MS(5s)지만 호출자가 더 긴
+// 쿨다운(예: LOCK_ORIGIN_SUPPRESS_COOLDOWN_MS 30s)을 요구할 수 있어 per-entry windowMs를
+// 함께 저장 — sweep도 entry별 windowMs 기준으로 만료 판정한다.
+function isBurstDuplicate(
+  reason: string,
+  discriminator: string,
+  windowMs: number = DEDUP_LOG_WINDOW_MS,
+): boolean {
   const now = Date.now();
   const key = `${reason}|${discriminator}`;
   const last = lastBurstSuppressTs.get(key);
-  if (last !== undefined && now - last < DEDUP_LOG_WINDOW_MS) return true;
-  lastBurstSuppressTs.set(key, now);
+  if (last !== undefined && now - last.ts < last.windowMs) return true;
+  lastBurstSuppressTs.set(key, { ts: now, windowMs });
   sweepExpiredBurstEntries(now);
   return false;
 }
@@ -1584,11 +1592,22 @@ export function logSuppressedLocklessNoUserIntent(input: {
  *
  * 호출자는 lock 활성(lock !== null)이며 candidate.id === lock.boardingStationId일 때만 호출.
  * lockless 케이스는 'gate-origin-hop-lockless'(#1514)가 별도 담당.
+ *
+ * #2093 (B) — fg + fg-arvlcd 두 path가 매초 재평가 → 같은 (station, phase='station-passed')
+ * 조합이 suppress로 확정된 채 반복 재평가되는 busy-loop 관측(gate-passed-event-on-lock-origin
+ * 93회/70초, 2026-07-07 evidence). LOCK_ORIGIN_SUPPRESS_COOLDOWN_MS 동안은 재적재를 skip해
+ * appendAlarmLog/Sentry breadcrumb 반복 비용을 제거한다 — 호출자는 이 함수 호출 전후로 이미
+ * 항상 return하므로 fire/advance semantics는 변경되지 않는다(빈도 제한만).
  */
+export const LOCK_ORIGIN_SUPPRESS_COOLDOWN_MS = 30_000;
+
 export function logSuppressedPassedEventOnLockOrigin(input: {
   source: AlarmLogSource;
   stationName: string;
 }): void {
+  if (isBurstDuplicate('gate-passed-event-on-lock-origin', input.stationName, LOCK_ORIGIN_SUPPRESS_COOLDOWN_MS)) {
+    return;
+  }
   appendAlarmLog({
     ts: Date.now(),
     source: input.source,

--- a/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
@@ -128,7 +128,11 @@ import type { AlarmEvent } from '../../../../shared/types/alarm';
 // 모듈 import — defineTask가 이 시점에 호출되어 global에 콜백이 저장됨
 import '../../tasks/backgroundLocationTask';
 import { BACKGROUND_LOCATION_TASK } from '../backgroundLocationTask';
-import { MAX_ACCURACY_M, MAX_LOCATION_AGE_MS } from '../../../../shared/constants/location';
+import {
+  MAX_ACCURACY_M,
+  MAX_LOCATION_AGE_MS,
+  POSITION_UPLOAD_MIN_INTERVAL_MS,
+} from '../../../../shared/constants/location';
 import { ALARM_EVENT_KEY } from '../../../../shared/constants/storageKeys';
 import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
 
@@ -894,6 +898,17 @@ describe('backgroundLocationTask defineTask 콜백', () => {
         .mockResolvedValueOnce(token); // APNS_TOKEN_KEY
     }
 
+    /**
+     * #2093 (A) — BG_LAST_FIX_KEY(prevFix 없음) + APNS_TOKEN_KEY + BG_LAST_POSITION_UPLOAD_AT_KEY
+     * 3단 체인. lastUploadAt을 명시 제어해 min-interval 쿨다운 분기를 검증한다.
+     */
+    function stubApnsTokenWithLastUploadAt(token: string | null, lastUploadAt: number | null): void {
+      (AsyncStorage.getItem as jest.Mock)
+        .mockResolvedValueOnce(null) // BG_LAST_FIX_KEY — prevFix 없음
+        .mockResolvedValueOnce(token) // APNS_TOKEN_KEY
+        .mockResolvedValueOnce(lastUploadAt === null ? null : String(lastUploadAt)); // BG_LAST_POSITION_UPLOAD_AT_KEY
+    }
+
     it('APNs token 있고 motion stationary=false → uploadPosition(unknown) 호출', async () => {
       mockStorageValues(JSON.stringify(mockDestination));
       stubApnsTokenAfterStorage('apns-tok-1');
@@ -934,6 +949,78 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       await taskCallback({ data: { locations: [loc] }, error: null });
 
       expect(mockUploadPosition).not.toHaveBeenCalled();
+    });
+
+    describe('#2093 (A) — POST /position 최소 간격 가드', () => {
+      it('직전 업로드로부터 POSITION_UPLOAD_MIN_INTERVAL_MS 이내 → uploadPosition 미호출 (쿨다운)', async () => {
+        mockStorageValues(JSON.stringify(mockDestination));
+        const now = Date.now();
+        // 실행 지연(테스트 setup ↔ task 내부 Date.now() 사이 real elapsed ms)에 flaky해지지 않도록
+        // 경계값(-1ms)이 아닌 충분한 여유(-1s)를 둔다 — 여전히 min interval 이내임을 보장.
+        stubApnsTokenWithLastUploadAt('apns-tok-1', now - (POSITION_UPLOAD_MIN_INTERVAL_MS - 1_000));
+
+        const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+        await taskCallback({ data: { locations: [loc] }, error: null });
+
+        expect(mockUploadPosition).not.toHaveBeenCalled();
+        // 쿨다운 중엔 준비 비용(accel fingerprint 시작)도 함께 skip.
+        expect(mockStartAccelerometerFingerprint).not.toHaveBeenCalled();
+        expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(
+          expect.stringContaining('bg-last-position-upload-at'),
+          expect.anything(),
+        );
+      });
+
+      it('직전 업로드로부터 POSITION_UPLOAD_MIN_INTERVAL_MS 경과 → uploadPosition 재개 + 타임스탬프 갱신', async () => {
+        mockStorageValues(JSON.stringify(mockDestination));
+        const now = Date.now();
+        stubApnsTokenWithLastUploadAt('apns-tok-1', now - (POSITION_UPLOAD_MIN_INTERVAL_MS + 1));
+
+        const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+        await taskCallback({ data: { locations: [loc] }, error: null });
+
+        expect(mockUploadPosition).toHaveBeenCalledTimes(1);
+        expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+          'subway-now:bg-last-position-upload-at',
+          expect.any(String),
+        );
+      });
+
+      it('lastUploadAt 없음(최초 fix) → 즉시 업로드', async () => {
+        mockStorageValues(JSON.stringify(mockDestination));
+        stubApnsTokenWithLastUploadAt('apns-tok-1', null);
+
+        const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+        await taskCallback({ data: { locations: [loc] }, error: null });
+
+        expect(mockUploadPosition).toHaveBeenCalledTimes(1);
+      });
+
+      it('BG_LAST_POSITION_UPLOAD_AT_KEY read throw → graceful null 취급(즉시 업로드)', async () => {
+        mockStorageValues(JSON.stringify(mockDestination));
+        (AsyncStorage.getItem as jest.Mock)
+          .mockResolvedValueOnce(null) // BG_LAST_FIX_KEY
+          .mockResolvedValueOnce('apns-tok-1') // APNS_TOKEN_KEY
+          .mockRejectedValueOnce(new Error('boom')); // BG_LAST_POSITION_UPLOAD_AT_KEY
+
+        const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+        await taskCallback({ data: { locations: [loc] }, error: null });
+
+        expect(mockUploadPosition).toHaveBeenCalledTimes(1);
+      });
+
+      it('BG_LAST_POSITION_UPLOAD_AT_KEY 값이 숫자로 파싱 불가 → null 취급(즉시 업로드)', async () => {
+        mockStorageValues(JSON.stringify(mockDestination));
+        (AsyncStorage.getItem as jest.Mock)
+          .mockResolvedValueOnce(null) // BG_LAST_FIX_KEY
+          .mockResolvedValueOnce('apns-tok-1') // APNS_TOKEN_KEY
+          .mockResolvedValueOnce('not-a-number'); // BG_LAST_POSITION_UPLOAD_AT_KEY (손상값)
+
+        const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+        await taskCallback({ data: { locations: [loc] }, error: null });
+
+        expect(mockUploadPosition).toHaveBeenCalledTimes(1);
+      });
     });
 
     it('AsyncStorage.getItem(APNS_TOKEN_KEY) throw → 무시하고 uploadPosition 미호출', async () => {

--- a/src/features/nearest-station/tasks/backgroundLocationTask.ts
+++ b/src/features/nearest-station/tasks/backgroundLocationTask.ts
@@ -16,8 +16,9 @@ import { APNS_TOKEN_KEY, DESTINATION_KEY, SLEEP_MODE_KEY, ALARM_EVENT_KEY, ROUTE
 import { getFiredAlarms, setFiredAlarms } from '../../alarm/utils/notificationState';
 import { isAccuracyAcceptable, isLocationFresh, isPlausibleJump, type FixSample } from '../utils/locationGates';
 import { logSuppressedGate } from '../../alarm/utils/alarmLog';
-import { BG_LAST_FIX_KEY, BG_LAST_STATION_KEY } from '../../../shared/constants/storageKeys';
+import { BG_LAST_FIX_KEY, BG_LAST_STATION_KEY, BG_LAST_POSITION_UPLOAD_AT_KEY } from '../../../shared/constants/storageKeys';
 import { uploadPosition, type PositionMotion } from '../api/positionUpload';
+import { POSITION_UPLOAD_MIN_INTERVAL_MS } from '../../../shared/constants/location';
 import { getCurrentMotionStationary } from '../utils/motionActivity';
 import { getLatestAccelSummary } from '../utils/accelMotionState';
 // #1542 (ADR-016 S9) — CMMotionManager accelerometer fingerprint (Background Location piggyback).
@@ -80,6 +81,22 @@ export function pickMotionLabel(
 ): PositionMotion {
   if (accelPattern !== 'unknown') return accelPattern;
   return motionStationary ? 'stationary' : 'unknown';
+}
+
+/**
+ * #2093 (A) — 마지막 POST /position 발사 시각(epoch ms) 조회. 파싱 실패/키 부재는 null(첫 fix
+ * 취급 → 즉시 발사). TaskManager invocation마다 새 컨텍스트라 in-memory ref 대신 AsyncStorage로
+ * invocation 간 상태를 공유한다.
+ */
+async function readBgLastPositionUploadAt(): Promise<number | null> {
+  try {
+    const raw = await AsyncStorage.getItem(BG_LAST_POSITION_UPLOAD_AT_KEY);
+    if (!raw) return null;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
 }
 
 async function readBgLastFix(): Promise<FixSample | null> {
@@ -181,7 +198,17 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     // 본 BG task 흐름에 영향 없음 (#640: zero trip = zero push 정책은 그대로, 좌표 누락은 게이트
     // 통과 못 하게 만들 뿐).
     const apnsToken = await AsyncStorage.getItem(APNS_TOKEN_KEY).catch(() => null);
-    if (apnsToken) {
+    // #2093 (A) — POST /position 최소 간격 가드. iOS가 신호 재포착 후 배치 catch-up으로 짧은
+    // 간격에 TaskManager invocation을 연속 발동시키면 게이트 없이는 uploadPosition이 매 invocation
+    // 마다 호출돼 2Hz까지 폭주(evidence: 08:44:15~08:45:11 59회)한다. FG hook과 동일 최소 간격
+    // (POSITION_UPLOAD_MIN_INTERVAL_MS)을 AsyncStorage 기반으로 강제 — accel/wifi lookup 등
+    // 업로드 준비 비용까지 함께 skip해 발열도 완화한다.
+    const lastUploadAt = apnsToken ? await readBgLastPositionUploadAt() : null;
+    const now = Date.now();
+    const withinUploadCooldown =
+      lastUploadAt !== null && now - lastUploadAt < POSITION_UPLOAD_MIN_INTERVAL_MS;
+    if (apnsToken && !withinUploadCooldown) {
+      await AsyncStorage.setItem(BG_LAST_POSITION_UPLOAD_AT_KEY, String(now));
       // #1542 (ADR-016 S9) — Background Location piggyback: BG task가 호출될 때마다
       // accelerometer fingerprint start를 no-op 보장으로 호출. native 모듈이 isUpdating 가드를
       // 갖고 있어 한 번만 시작되며, 이후 BG location updates 활성 동안 raw 가속도 5Hz가 계속 흐른다.

--- a/src/shared/constants/location.ts
+++ b/src/shared/constants/location.ts
@@ -25,7 +25,13 @@ export const MIN_JUMP_DISTANCE_M = 100;
 // BG 위치 task가 못 도는 WhileInUse 권한에서 FG fix-watch가 ~10s마다 backend로 좌표를 송신해
 // POST /position 채널을 점등한다. BG `timeInterval`(30s)보다 짧아 FG 활성 동안은 더 촘촘히
 // 위치 지능을 먹인다. 연속 fix가 이 간격보다 자주 들어와도 1회로 묶인다.
-export const FG_POSITION_UPLOAD_THROTTLE_MS = 10_000;
+//
+// #2093 (A) — BG task(`backgroundLocationTask`)도 동일 상수를 공유한다. iOS가 신호 재포착 후
+// 배치 catch-up으로 짧은 간격에 연속 location update를 몰아 보내면 BG task invocation마다
+// 무조건 uploadPosition을 호출해 POST /position이 2Hz까지 폭주(evidence: 08:44:15~08:45:11
+// 59회)했다 — FG hook의 in-memory ref 쓰로틀과 달리 BG task는 invocation마다 새 컨텍스트라
+// AsyncStorage(`BG_LAST_POSITION_UPLOAD_AT_KEY`) 기반으로 같은 간격을 강제한다.
+export const POSITION_UPLOAD_MIN_INTERVAL_MS = 10_000;
 
 // #1313 — foreground GPS watch 샘플링 파라미터. subsurface(지하) 여부로 갈린다.
 // 지상/warmup/미지원에서는 High@2s를 그대로 유지(정확도 우선), 지하에서만 throttle.

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -208,6 +208,12 @@ export const USER_INTENT_INFO_MODE_KEY = 'subway-now:user-intent-info-mode';
 // trip 종료 시 runTripBoundCleanups에서 제거 — 이전 trip의 수신 시각이 새 trip 판정 오염 차단.
 // 형식: 숫자 (epoch ms) 문자열. 키 부재 = silent push 미수신(첫 launch or 새 trip 시작 직후).
 export const LAST_SILENT_PUSH_RECEIVED_AT_KEY = 'subway-now:last-silent-push-received-at';
+// #2093 (A) — BG task(`backgroundLocationTask`)가 마지막으로 POST /position을 발사한 시각(epoch ms).
+// TaskManager invocation마다 새 컨텍스트라 in-memory ref 쓰로틀(FG hook의 `useFgPositionUpload`
+// 패턴)을 쓸 수 없다 — AsyncStorage로 invocation 간 상태를 공유해 POSITION_UPLOAD_MIN_INTERVAL_MS
+// (10s) 미만 간격의 연속 catch-up batch 배달에서도 uploadPosition 호출을 1회로 묶는다.
+// 형식: 숫자(epoch ms) 문자열. 키 부재 = 첫 fix(즉시 발사).
+export const BG_LAST_POSITION_UPLOAD_AT_KEY = 'subway-now:bg-last-position-upload-at';
 // #2067 (Phase 2-device) — AlarmLocalAuthority persisted dedup ledger.
 // 취침모드 companion silent push(kind `sleep-alarm-companion`)의 TTS/진동 부가 동작이 앱 재시작
 // (cold-launch) 후에도 중복 발사되지 않도록 in-memory Set 대신 AsyncStorage에 영속화한다.


### PR DESCRIPTION
## 배경
Part of #2093 (현재 역 실시간성·발열 종합 개선 — A~H). 이 PR은 **A·B (ready-for-agent 판정분)**만 처리한다. 이슈는 C~H 잔여 항목으로 계속 open.

## A. POST /position 폭주 + /trips 재등록 폭주
- **BG task (`backgroundLocationTask.ts`)**: POST /position 최소 간격 가드 신설. `POSITION_UPLOAD_MIN_INTERVAL_MS`(10s, `src/shared/constants/location.ts` — 기존 FG 전용 `FG_POSITION_UPLOAD_THROTTLE_MS`를 리네임해 BG/FG 공유 상수로 승격)를 AsyncStorage(`BG_LAST_POSITION_UPLOAD_AT_KEY`) 기반으로 강제. TaskManager invocation마다 새 컨텍스트라 FG hook처럼 in-memory ref를 쓸 수 없어 AsyncStorage로 invocation 간 상태 공유. 쿨다운 중엔 accel/wifi lookup 등 업로드 준비 비용도 함께 skip.
- **/trips 재등록 (`useApnsTripRegistration`)**: 조사 결과 `src/features/alarm/api/alarmBackend.ts`의 기존 `buildRegisterHash` + `lastRegisteredHash` 2-layer dedup(#581, #701)이 이미 "payload 실질 변화 시에만 재등록" 요구사항을 구현하고 있고 광범위하게 테스트돼 있음(`alarmBackend.test.ts:118+`, dedup describe 블록). 중복 게이트를 추가로 얹는 대신 기존 구현을 그대로 재사용 — 이슈 스펙과 코드가 이미 일치하는 것을 확인했다 (이탈사항 섹션 참고).

## B. 알람 평가 busy-loop 쿨다운
`useStationAlarm.ts`의 `runSilenceGateAndDispatch`가 fg/fg-arvlcd 두 path에서 매초 재평가되며 lock origin(candidate === boardingStationId)이면 `logSuppressedPassedEventOnLockOrigin`을 호출해 suppress를 적재한다(evidence: gate-passed-event-on-lock-origin 93회/70초). `alarmLog.ts`의 기존 `isBurstDuplicate` dedup 유틸을 `windowMs` 옵션 파라미터로 일반화(기본값 유지, 기존 5s 호출부 전부 무변경)해 재사용 — `LOCK_ORIGIN_SUPPRESS_COOLDOWN_MS`(30s) 동안 같은 (station, phase='station-passed') 조합의 반복 로그 적재를 skip한다. 호출자는 이 함수 호출 전후로 항상 즉시 return하므로 **fire/advance semantics는 변경 없음** — 반복 로그 write/Sentry breadcrumb 비용만 제거.

## 이슈 스펙 대비 이탈사항
- A의 "/trips 재등록은 payload 변화 시에만" 요구사항은 신규 코드 추가 없이 기존 `alarmBackend.ts` dedup으로 이미 충족됨을 확인 — 중복 구현 대신 기존 메커니즘을 문서화. 19회/1분 evidence의 잔여 원인은 boardingLock 내용 자체가 실질적으로 자주 바뀌는 경우(Item D — route-progress tier flapping, 별도 설계 검토 대상)로 추정되며 본 PR 범위 밖.
- 그 외 이탈 없음.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — 신호 위치: DebugModal의 alarmLog Counters (`gate-passed-event-on-lock-origin` reason count 감소로 관측), `/admin/alarm-log-stats`. BG 업로드 빈도는 Cloudflare Dashboard `/position` 요청 수 감소로 관측 가능.
3. **의존 PR** — N/A (device-only 변경, backend 무변경).
4. **측정 plan** — 다음 실기기 trip에서 (a) backend `/position` calls 감소(2Hz → ≤1/10s) (b) alarmLog `gate-passed-event-on-lock-origin` count가 실제 suppress 결정 횟수가 아닌 30s 버킷 수준으로 감소 (c) 기존 fire/advance 동작 회귀 0건.
5. **Device verify** — 필요. 실기기 지하철 trip에서 BG 업로드 빈도 + 알람 발사 타이밍이 기존과 동일한지 확인 필요 (에이전트는 type-check + unit만 검증, runtime BG task 실동작은 검증 불가).

## 검증
- `npm test` — 9179/9179 pass, coverage 100% (lines/functions/branches/statements)
- `npm run type-check` — pass
- `npm run lint:orphan` — pass (0 orphan)

Closes 없음 — #2093은 C~H 잔여로 계속 open.