### PR TITLE
fix(#2093): candidate reject 로그 burst 집계화 (G)

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -1139,20 +1139,24 @@ function buildGpsDropLogSection(args: BuildDumpArgs): string[] {
  */
 function formatCandidateRejectLine(entry: CandidateRejectEntry): string {
   const time = formatTime(entry.ts);
+  // #2093 (G) — 집계 윈도우(candidateRejectBuffer.CANDIDATE_REJECT_AGGREGATION_WINDOW_MS) 안에
+  // 같은 reason이 반복 reject되면 entry.count가 2 이상 — "×N" suffix로 burst 집계를 노출.
+  // count 미설정/1은 기존 개별 entry와 동일 출력(하위 호환).
+  const suffix = entry.count != null && entry.count > 1 ? ` ×${entry.count}` : '';
   if (entry.reason === 'candidate-distance') {
     const train = entry.trainNo ?? '-';
     const station = entry.stationName ?? '-';
     const d = entry.distanceKm != null ? `${Math.round(entry.distanceKm * 1000)}m` : '-';
-    return `${time} | reject:${entry.reason} | ${train} ${station}(${entry.line}) d=${d}`;
+    return `${time} | reject:${entry.reason} | ${train} ${station}(${entry.line}) d=${d}${suffix}`;
   }
   // #1934 G3 option B + #1936 G4 — candidate-env: cascade/candidate env 비교 노출.
   if (entry.reason === 'candidate-env') {
     const station = entry.stationName ?? '-';
     const cascade = entry.cascadeEnvironment ?? '-';
     const cand = entry.candidateEnvironment ?? '-';
-    return `${time} | reject:${entry.reason} | ${station}(${entry.line}) cascade=${cascade} candidate=${cand}`;
+    return `${time} | reject:${entry.reason} | ${station}(${entry.line}) cascade=${cascade} candidate=${cand}${suffix}`;
   }
-  return `${time} | reject:${entry.reason} | line=${entry.line}`;
+  return `${time} | reject:${entry.reason} | line=${entry.line}${suffix}`;
 }
 
 function buildCandidateRejectLogSection(args: BuildDumpArgs): string[] {

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -2198,6 +2198,32 @@ describe('formatFusionDebugLine', () => {
     expect(line).toContain('d=5400m');
   });
 
+  it('#2093 (G) candidate-distance reject: count 집계 시 "×N" suffix 표시', () => {
+    const line = formatCandidateRejectLine({
+      kind: 'candidate-reject',
+      ts: new Date('2026-06-21T12:00:00Z').getTime(),
+      reason: 'candidate-distance',
+      trainNo: 'T-2099',
+      stationName: '강변',
+      line: '2',
+      distanceKm: 43,
+      count: 28,
+    });
+    expect(line).toContain('d=43000m');
+    expect(line).toContain('×28');
+  });
+
+  it('#2093 (G) candidate-reject: count=1은 기존 개별 entry와 동일 (suffix 없음, 하위 호환)', () => {
+    const line = formatCandidateRejectLine({
+      kind: 'candidate-reject',
+      ts: new Date('2026-06-21T12:00:00Z').getTime(),
+      reason: 'candidate-line',
+      line: '6',
+      count: 1,
+    });
+    expect(line).not.toContain('×');
+  });
+
   it('#1896 (RC-8) boarding-lock-drift 엔트리: branch/station/drift 포함', () => {
     const ts = new Date('2026-06-26T12:19:00Z').getTime();
     const lineWithDrift = formatBoardingLockDriftLine({

--- a/src/features/nearest-station/utils/__tests__/candidateRejectBuffer.test.ts
+++ b/src/features/nearest-station/utils/__tests__/candidateRejectBuffer.test.ts
@@ -8,6 +8,7 @@
  *   4. subscribe + clear가 fusionDebugBuffer와 분리된 채로 동작.
  */
 import {
+  CANDIDATE_REJECT_AGGREGATION_WINDOW_MS,
   CANDIDATE_REJECT_BUFFER_CAPACITY,
   clearCandidateRejectEntries,
   getCandidateRejectEntries,
@@ -86,16 +87,92 @@ describe('candidateRejectBuffer (#1902 RC-18)', () => {
     expect(entries[0].trainNo).toBeUndefined();
   });
 
-  it('CAP=50 ring buffer — overwrite로 fusion log cap 점령 회귀 차단', () => {
+  it('CAP=50 ring buffer — overwrite로 fusion log cap 점령 회귀 차단 (각 push가 서로 다른 집계 윈도우)', () => {
     expect(CANDIDATE_REJECT_BUFFER_CAPACITY).toBe(50);
+    // #2093 (G) — 같은 윈도우 안의 반복 reject는 in-place 집계되어 새 slot을 쓰지 않으므로,
+    // cap overwrite 자체(ring buffer 물리 동작)를 검증하려면 각 push를 별 윈도우로 분리한다.
     for (let i = 0; i < CANDIDATE_REJECT_BUFFER_CAPACITY + 5; i += 1) {
-      pushCandidateRejectEntry(makeDistance({ ts: i, trainNo: `T-${i}` }));
+      pushCandidateRejectEntry(
+        makeDistance({ ts: i * (CANDIDATE_REJECT_AGGREGATION_WINDOW_MS + 1), trainNo: `T-${i}` }),
+      );
     }
     const entries = getCandidateRejectEntries();
     expect(entries).toHaveLength(CANDIDATE_REJECT_BUFFER_CAPACITY);
     // 가장 오래된 5건이 evict — 최신 cap건만 유지.
     expect(entries[0].trainNo).toBe('T-5');
     expect(entries[entries.length - 1].trainNo).toBe(`T-${CANDIDATE_REJECT_BUFFER_CAPACITY + 4}`);
+  });
+
+  describe('#2093 (G) — burst rate-limit + 집계화', () => {
+    it('같은 윈도우 안 burst reject는 slot 1개로 집계 (count 누적)', () => {
+      pushCandidateRejectEntry(makeDistance({ ts: 0, stationName: '먼역1', distanceKm: 10 }));
+      pushCandidateRejectEntry(makeDistance({ ts: 100, stationName: '먼역2', distanceKm: 43 }));
+      pushCandidateRejectEntry(makeDistance({ ts: 200, stationName: '먼역3', distanceKm: 20 }));
+      const entries = getCandidateRejectEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].count).toBe(3);
+      // 최대 거리(43km)가 보존 — "최대 dist" 진단 가시성.
+      expect(entries[0].distanceKm).toBe(43);
+      // 최신 reject의 station으로 갱신.
+      expect(entries[0].stationName).toBe('먼역3');
+    });
+
+    it('윈도우 경과 후 재개 — 새 entry가 count=1부터 다시 push', () => {
+      pushCandidateRejectEntry(makeDistance({ ts: 0 }));
+      pushCandidateRejectEntry(makeDistance({ ts: 500 }));
+      expect(getCandidateRejectEntries()).toHaveLength(1);
+      expect(getCandidateRejectEntries()[0].count).toBe(2);
+
+      pushCandidateRejectEntry(
+        makeDistance({ ts: CANDIDATE_REJECT_AGGREGATION_WINDOW_MS + 1, stationName: '새윈도우역' }),
+      );
+      const entries = getCandidateRejectEntries();
+      expect(entries).toHaveLength(2);
+      expect(entries[0].count).toBe(2);
+      expect(entries[1].count).toBe(1);
+      expect(entries[1].stationName).toBe('새윈도우역');
+    });
+
+    it('첫 reject에 distanceKm 없다가 후속 reject에 생기면 maxDistanceKm이 새 값으로 채워짐', () => {
+      pushCandidateRejectEntry(makeLineReject({ ts: 0, distanceKm: undefined }));
+      pushCandidateRejectEntry(makeLineReject({ ts: 100, distanceKm: 12 }));
+      const entries = getCandidateRejectEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].count).toBe(2);
+      expect(entries[0].distanceKm).toBe(12);
+    });
+
+    it('reason별 윈도우 독립 — candidate-distance burst가 candidate-line 집계에 영향 없음', () => {
+      pushCandidateRejectEntry(makeDistance({ ts: 0 }));
+      pushCandidateRejectEntry(makeDistance({ ts: 100 }));
+      pushCandidateRejectEntry(makeLineReject({ ts: 150 }));
+      const entries = getCandidateRejectEntries();
+      expect(entries).toHaveLength(2);
+      const distanceEntry = entries.find((e) => e.reason === 'candidate-distance');
+      const lineEntry = entries.find((e) => e.reason === 'candidate-line');
+      expect(distanceEntry?.count).toBe(2);
+      expect(lineEntry?.count).toBe(1);
+    });
+
+    it('clearCandidateRejectEntries — 집계 윈도우도 리셋 (clear 후 push는 새 윈도우)', () => {
+      pushCandidateRejectEntry(makeDistance({ ts: 0 }));
+      pushCandidateRejectEntry(makeDistance({ ts: 100 }));
+      clearCandidateRejectEntries();
+      pushCandidateRejectEntry(makeDistance({ ts: 150 }));
+      const entries = getCandidateRejectEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].count).toBe(1);
+    });
+
+    it('집계 entry는 첫 push에서만 listener 호출 — 후속 burst는 notify 없이 in-place 갱신', () => {
+      const listener = jest.fn();
+      subscribeCandidateReject(listener);
+      pushCandidateRejectEntry(makeDistance({ ts: 0 }));
+      expect(listener).toHaveBeenCalledTimes(1);
+      pushCandidateRejectEntry(makeDistance({ ts: 100 }));
+      pushCandidateRejectEntry(makeDistance({ ts: 200 }));
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('subscribe — push/clear 모두 listener 호출', () => {

--- a/src/features/nearest-station/utils/candidateRejectBuffer.ts
+++ b/src/features/nearest-station/utils/candidateRejectBuffer.ts
@@ -48,12 +48,72 @@ export interface CandidateRejectEntry {
    * undefined/null인 entry는 mismatch에서 제외(보수적) — 본 필드는 채워진 케이스만 측정.
    */
   candidateEnvironment?: 'surface' | 'underground' | 'mixed' | 'unknown';
+  /**
+   * #2093 (G) — 집계 윈도우 내 reject 총 건수. 1(기본, 미설정과 동일 취급)이면 개별 entry,
+   * 2 이상이면 같은 reason이 `CANDIDATE_REJECT_AGGREGATION_WINDOW_MS` 안에 반복 reject되어
+   * 이 entry로 요약된 것 — `DebugModal.formatCandidateRejectLine`이 `×N` suffix로 표시한다.
+   */
+  count?: number;
 }
 
 const db = createDebugBuffer<CandidateRejectEntry>(CANDIDATE_REJECT_BUFFER_CAPACITY);
 
+/**
+ * #2093 (G) — candidate-distance-reject / candidate-env reject burst 집계 윈도우.
+ *
+ * 배경: 7/7·7/8 실기기 로그에서 trip 비활성 화면(먼 역 다수)에 1초 안에 distance-reject
+ * 28건, 2Hz로 env-reject 44건이 쏟아짐 — 판정 자체는 정상 동작(#1902/#1934)이지만 매 건을
+ * 개별 entry로 push하면 cap=50 ring buffer가 burst 한 번에 점령돼 다른 시점 진단 이력이
+ * evict된다(위 파일 헤더 T4 evidence와 동일 메커니즘, gpsDropBuffer/lesson_gps_drop_fusion_buffer_pollution
+ * burst dedup 패턴 재사용).
+ *
+ * 구현: reason별 슬라이딩 윈도우 상태를 유지한다. 윈도우 시작 시 첫 reject만 실제 push(count=1),
+ * 같은 윈도우 안의 후속 reject는 새 slot을 소모하지 않고 이미 push된 entry 객체를 **in-place
+ * 갱신**(count 증가, distanceKm은 최대값 유지, station/line/env는 최신값 반영)한다 — ring buffer가
+ * 참조를 그대로 들고 있으므로 추가 push 없이 `getCandidateRejectEntries()`가 항상 최신 집계를
+ * 반환한다. 윈도우 경과 후 다음 reject는 새 윈도우로 취급해 새 entry를 push한다(count=1부터 재시작).
+ */
+export const CANDIDATE_REJECT_AGGREGATION_WINDOW_MS = 10_000;
+
+interface RejectAggregationWindow {
+  windowStart: number;
+  maxDistanceKm: number | undefined;
+  /** 이번 윈도우에서 db에 push된 entry 객체 참조 — in-place 갱신 대상. */
+  entry: CandidateRejectEntry;
+}
+
+const windowByReason = new Map<CandidateRejectReason, RejectAggregationWindow>();
+
 export function pushCandidateRejectEntry(entry: CandidateRejectEntry): void {
-  db.push(entry);
+  const active = windowByReason.get(entry.reason);
+  const isNewWindow =
+    !active || entry.ts - active.windowStart >= CANDIDATE_REJECT_AGGREGATION_WINDOW_MS;
+
+  if (isNewWindow) {
+    const fresh: CandidateRejectEntry = { ...entry, count: 1 };
+    windowByReason.set(entry.reason, {
+      windowStart: entry.ts,
+      maxDistanceKm: entry.distanceKm,
+      entry: fresh,
+    });
+    db.push(fresh);
+    return;
+  }
+
+  // 같은 윈도우 내 반복 reject — 집계만 갱신, 새 slot push 없음.
+  active.maxDistanceKm =
+    entry.distanceKm === undefined
+      ? active.maxDistanceKm
+      : Math.max(active.maxDistanceKm ?? entry.distanceKm, entry.distanceKm);
+  // active.entry.count는 새 윈도우 생성 시 항상 1로 초기화되므로 non-null 단언이 안전하다.
+  active.entry.count = (active.entry.count as number) + 1;
+  active.entry.ts = entry.ts;
+  active.entry.distanceKm = active.maxDistanceKm;
+  active.entry.trainNo = entry.trainNo ?? active.entry.trainNo;
+  active.entry.stationName = entry.stationName ?? active.entry.stationName;
+  active.entry.line = entry.line;
+  active.entry.cascadeEnvironment = entry.cascadeEnvironment ?? active.entry.cascadeEnvironment;
+  active.entry.candidateEnvironment = entry.candidateEnvironment ?? active.entry.candidateEnvironment;
 }
 
 export function getCandidateRejectEntries(): readonly CandidateRejectEntry[] {
@@ -61,6 +121,7 @@ export function getCandidateRejectEntries(): readonly CandidateRejectEntry[] {
 }
 
 export function clearCandidateRejectEntries(): void {
+  windowByReason.clear();
   db.clear();
 }
 


### PR DESCRIPTION
Part of #2093

## 배경
2093 항목 **G** — trip 비활성 화면에서 candidate-distance-reject / candidate-env reject 로그가 burst로 쏟아지는 문제(7/7·7/8 evidence: 1초에 먼 역 28개 distance-reject, 2Hz로 env-reject 44건). reject 판정 자체는 정상 동작(#1902/#1934)이지만 개별 entry를 매번 push하면 candidateRejectBuffer(cap=50)가 burst 한 번에 점령되어 다른 시점 진단 이력이 evict됨.

## 변경
- `candidateRejectBuffer.ts`: reason별(`candidate-distance`/`candidate-line`/`candidate-env`) 10초 슬라이딩 윈도우 도입. 윈도우 안 첫 reject만 실제 push(count=1), 후속 reject는 새 slot 없이 이미 push된 entry를 in-place 갱신(count 누적, distanceKm은 최댓값 보존, station/line/env는 최신값 반영). 윈도우 경과 후 다음 reject는 새 entry로 재시작.
- `CandidateRejectEntry`에 옵셔널 `count` 필드 추가 — 미설정/1은 기존 개별 entry와 동일(하위 호환).
- `DebugModal.formatCandidateRejectLine` — `count > 1`일 때만 `×N` suffix 추가. 기존 포맷 문자열은 변경 없음.
- reject 판정 로직(`useFusedNearestStation.ts`)은 무변경 — 로그 채널만 수정.

## 검증
- `npm test -- --coverage` — 428 suites / 9121 tests pass, coverage 100% (lines/branches/functions/statements)
- `npm run type-check` — pass
- `npm run lint:orphan` — No orphan exports detected

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass. 신규 export(`CANDIDATE_REJECT_AGGREGATION_WINDOW_MS`)는 같은 파일 내부 함수 + 테스트에서 사용.
2. **V/X dashboard** — DebugModal의 candidate-reject 섹션에서 관측 가능. count>1 entry는 `×N` suffix로 burst 집계가 즉시 보임(예: `reject:candidate-distance | T-9001 강변(2) d=43000m ×28`).
3. **의존 PR** — N/A (device-only, 이 PR 단독으로 완결).
4. **측정 plan** — 다음 실기기 trip에서 DebugModal candidate-reject 섹션 entry 수가 burst 구간에서도 cap(50)을 소모하지 않고 다른 시점(fusion decision/sticky) 진단 이력이 유지되는지 확인. count 필드로 실제 reject 총량도 그대로 추적 가능(집계 정확성).
5. **Device verify** — N/A — type+unit only. 실기기에서 burst 시나리오(지하철 정차 중 trip 비활성 화면) 재현 시 DebugModal 덤프로 육안 확인 권장하나 로직 자체는 순수 함수 단위 테스트로 커버.

## 이슈 스펙 대비 이탈
없음. reject 판정/fusion 로직 미접촉, DebugModal 표시 포맷 하위 호환 유지.