### PR TITLE
perf(#2100): 지하 GPS Balanced 강등 + 지상 복귀 eager 원복

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
@@ -1822,7 +1822,8 @@ describe('useNearestStation — #2076 GPS 품질 게이트 후속 (absence 독�
     });
 
     // 게이트 통과 fix 1회만으로 watch 프로파일은 즉시 원복된다(공개 gpsQualityDegraded는 아직
-    // hysteresis 미충족이라 true로 남을 수 있음 — 별개 신호, 아래 별도 describe에서 검증).
+    // hysteresis 미충족이라 true로 남을 수 있음 — 별개 신호. 이 divergence(profile=High +
+    // gpsQualityDegraded=true 동시 상태)는 아래 '#2100 divergence' 테스트에서 직접 assert한다).
     simulateGps(37.498, 127.0277, { accuracy: 50 });
 
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(3));
@@ -1831,6 +1832,39 @@ describe('useNearestStation — #2076 GPS 품질 게이트 후속 (absence 독�
       distanceInterval: 0,
       timeInterval: FG_WATCH_SURFACE_TIME_INTERVAL_MS,
     });
+  });
+
+  // #2100 divergence — watch 프로파일(eager 1회 release)과 공개 gpsQualityDegraded(hysteresis
+  // 2연속 release)는 서로 다른 신호라 일시적으로 어긋날 수 있다: 게이트 통과 fix 1회만 들어온
+  // 시점에는 watch가 이미 High로 선원복됐지만 gpsQualityDegraded는 아직 true(hysteresis 미충족)로
+  // 남는다. inferEnvironment 등 gpsQualityDegraded 소비자가 이 시점에도 여전히 "품질 저하"로
+  // 판정하는 것은 의도된 동작(품질 게이트/fusion 로직 불변 — #2100 "하지 말 것") — 두 신호가 같은
+  // fix 이벤트에서 동시에 diverge할 수 있음을 회귀 방지용으로 고정한다.
+  it('divergence: 게이트 통과 fix 1회 후 watch profile=High 이면서 공개 gpsQualityDegraded=true를 동시에 유지한다', async () => {
+    const { result } = renderHook(() => useNearestStation());
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1));
+
+    simulateGps(37.4979, 127.0276, { accuracy: 50 });
+    // 연속 통과 카운터를 0으로 리셋(이후 hysteresis 카운트를 1부터 검증하기 위해 — 다른 #2076
+    // 테스트와 동일 패턴).
+    simulateGps(37.51, 127.05, { accuracy: 300 });
+    act(() => {
+      jest.advanceTimersByTime(40_000);
+    });
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(2));
+    expect(result.current.gpsQualityDegraded).toBe(true);
+
+    // 게이트 통과 fix 1회 — watch profile은 즉시 High로 원복되지만, gpsQualityDegraded는
+    // hysteresis(연속 2회) 미충족이라 여전히 true.
+    simulateGps(37.498, 127.0277, { accuracy: 50 });
+
+    await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(3));
+    expect(lastWatchOptionsAt()).toEqual({
+      accuracy: Location.Accuracy.High,
+      distanceInterval: 0,
+      timeInterval: FG_WATCH_SURFACE_TIME_INTERVAL_MS,
+    });
+    expect(result.current.gpsQualityDegraded).toBe(true);
   });
 
   it('barometerSubsurface=true가 이미 활성이면 gpsQualityDegraded 변화만으로는 재시작하지 않는다 (이미 지하 프로파일)', async () => {

--- a/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts
@@ -1467,15 +1467,16 @@ describe('useNearestStation — #903 Seam G barometer→sticky', () => {
 });
 
 describe('useNearestStation — #1313 subsurface GPS throttle', () => {
-  // 지상 기본값: High@2s. 지하 throttle: High@12s (#1983 ADR-022 A3 — Balanced→High 통일).
-  // accuracy는 지상/지하 동일 High, interval만 subsurface에서 확장. 상수에서 가져와 매직넘버 회피.
+  // 지상 기본값: High@2s. 지하 throttle: Balanced@12s (#2100 — #1983 High 통일에서 재전환.
+  // #2074 품질 게이트가 지하 fix를 전량 폐기하는 게 확인돼 지하 accuracy를 다시 Balanced로 낮춘다).
+  // 상수에서 가져와 매직넘버 회피.
   const SURFACE_OPTIONS = {
     accuracy: Location.Accuracy.High,
     distanceInterval: 0,
     timeInterval: FG_WATCH_SURFACE_TIME_INTERVAL_MS,
   };
   const SUBSURFACE_OPTIONS = {
-    accuracy: Location.Accuracy.High,
+    accuracy: Location.Accuracy.Balanced,
     distanceInterval: 0,
     timeInterval: FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS,
   };
@@ -1510,12 +1511,12 @@ describe('useNearestStation — #1313 subsurface GPS throttle', () => {
   });
 
   // 마운트 시 subsurface 값에 따른 초기 watch 옵션 — undefined/false는 절대 throttle하지 않는다(안전 기본값).
-  // #1983 (ADR-022 A3): subsurface=true도 accuracy=High로 통일. 이전엔 Balanced였으나 지상 fix까지
-  // 1000~1600m 오염 회귀로 High 통일. subsurface 차이는 timeInterval만(2s→12s).
+  // #2100: subsurface=true는 accuracy=Balanced@12s (#1983 High 통일에서 재전환 — 상세 근거는
+  // useNearestStation.ts FG_WATCH_OPTIONS_SUBSURFACE 주석 참고).
   it.each([
     { label: 'subsurface 미전달(undefined) → High@2s', props: {}, expected: () => SURFACE_OPTIONS },
     { label: 'subsurface=false → High@2s', props: { barometerSubsurface: false }, expected: () => SURFACE_OPTIONS },
-    { label: 'subsurface=true → High@12s (#1983 Balanced→High 통일)', props: { barometerSubsurface: true }, expected: () => SUBSURFACE_OPTIONS },
+    { label: 'subsurface=true → Balanced@12s (#2100)', props: { barometerSubsurface: true }, expected: () => SUBSURFACE_OPTIONS },
   ])('마운트 $label', async ({ props, expected }) => {
     renderHook(() => useNearestStation(props));
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
@@ -1524,7 +1525,7 @@ describe('useNearestStation — #1313 subsurface GPS throttle', () => {
     expect(lastWatchOptions()).toEqual(expected());
   });
 
-  it('subsurface false→true flip 시 watch를 teardown 후 High@12s로 재시작한다 (#1983)', async () => {
+  it('subsurface false→true flip 시 watch를 teardown 후 Balanced@12s로 재시작한다 (#2100)', async () => {
     const { rerender } = renderHook(
       ({ sub }: { sub: boolean }) => useNearestStation({ barometerSubsurface: sub }),
       { initialProps: { sub: false } },
@@ -1583,34 +1584,35 @@ describe('useNearestStation — #1313 subsurface GPS throttle', () => {
     expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1);
     expect(mockSubscription.remove).not.toHaveBeenCalled();
 
-    // FG 복귀 시 'active' 핸들러 refresh→startWatch가 throttledRef를 읽어 High@12s로 반영.
+    // FG 복귀 시 'active' 핸들러 refresh→startWatch가 throttledRef를 읽어 Balanced@12s로 반영.
     (AppState as { currentState: string }).currentState = 'active';
     await act(async () => { appStateCallback?.('active'); });
     await waitFor(() => expect(lastWatchOptions()).toEqual(SUBSURFACE_OPTIONS));
   });
 
-  // #1983 (ADR-022 A3) — subsurface에서도 accuracy=High. Balanced로 회귀하면 지상 fix까지
-  // 1000~1600m 저정확도로 오염되므로 accuracy 값 자체를 pin해 회귀를 조기 차단한다.
+  // #2100 — 지상은 accuracy=High, 지하(subsurface 확정)는 accuracy=Balanced로 갈린다.
+  // 지상 accuracy가 실수로 Balanced로 떨어지는 회귀(#1983이 막으려던 문제)를 조기 차단하기 위해
+  // accuracy 값 자체를 pin한다.
   it.each([
-    { label: 'surface(subsurface=false)', props: { barometerSubsurface: false } },
-    { label: 'subsurface(subsurface=true)', props: { barometerSubsurface: true } },
-  ])('#1983 $label 에서 watch accuracy는 High (Balanced 회귀 차단)', async ({ props }) => {
+    { label: 'surface(subsurface=false)', props: { barometerSubsurface: false }, expectedAccuracy: () => Location.Accuracy.High },
+    { label: 'subsurface(subsurface=true)', props: { barometerSubsurface: true }, expectedAccuracy: () => Location.Accuracy.Balanced },
+  ])('#2100 $label 에서 watch accuracy가 pin된 값과 일치한다', async ({ props, expectedAccuracy }) => {
     renderHook(() => useNearestStation(props));
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalled());
-    expect(lastWatchOptions().accuracy).toBe(Location.Accuracy.High);
+    expect(lastWatchOptions().accuracy).toBe(expectedAccuracy());
   });
 });
 
 describe('useNearestStation — #2070 GPS 품질 게이트 (결정 tier 입력)', () => {
-  // 지상 기본값: High@2s. 지하 throttle: High@12s. #1313 describe와 동일 값 — 매직넘버 회피 위해
-  // 상수에서 가져온다(#2070은 barometerSubsurface OR gpsQualityDegraded로 트리거를 확장).
+  // 지상 기본값: High@2s. 지하 throttle: Balanced@12s(#2100). #1313 describe와 동일 값 — 매직넘버
+  // 회피 위해 상수에서 가져온다(#2070은 barometerSubsurface OR profileWatchDegraded로 트리거를 확장).
   const SURFACE_OPTIONS = {
     accuracy: Location.Accuracy.High,
     distanceInterval: 0,
     timeInterval: FG_WATCH_SURFACE_TIME_INTERVAL_MS,
   };
   const SUBSURFACE_OPTIONS = {
-    accuracy: Location.Accuracy.High,
+    accuracy: Location.Accuracy.Balanced,
     distanceInterval: 0,
     timeInterval: FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS,
   };
@@ -1794,7 +1796,10 @@ describe('useNearestStation — #2076 GPS 품질 게이트 후속 (absence 독�
     expect(result.current.gpsQualityDegraded).toBe(false);
   });
 
-  it('degraded 발생(absence) 시 FG watch가 지하 프로파일(High@12s)로 전환되고, hysteresis 해제 시 지상으로 원복된다', async () => {
+  // #2100 — watch 프로파일 release는 eager(단 1회 통과 fix)라 공개 gpsQualityDegraded의 hysteresis
+  // (연속 2회)보다 먼저 지상 프로파일로 원복된다. Balanced 지하 프로파일에서 hysteresis 2연속
+  // 달성 자체가 지연되는 악순환을 끊기 위함(#2100 "선원복 후 fix 대기").
+  it('degraded 발생(absence) 시 FG watch가 지하 프로파일(Balanced@12s)로 전환되고, 게이트 통과 fix 1회만으로 즉시 지상으로 원복된다', async () => {
     renderHook(() => useNearestStation());
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1));
     expect(lastWatchOptionsAt()).toEqual({
@@ -1811,13 +1816,14 @@ describe('useNearestStation — #2076 GPS 품질 게이트 후속 (absence 독�
 
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(2));
     expect(lastWatchOptionsAt()).toEqual({
-      accuracy: Location.Accuracy.High,
+      accuracy: Location.Accuracy.Balanced,
       distanceInterval: 0,
       timeInterval: FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS,
     });
 
+    // 게이트 통과 fix 1회만으로 watch 프로파일은 즉시 원복된다(공개 gpsQualityDegraded는 아직
+    // hysteresis 미충족이라 true로 남을 수 있음 — 별개 신호, 아래 별도 describe에서 검증).
     simulateGps(37.498, 127.0277, { accuracy: 50 });
-    simulateGps(37.4981, 127.0278, { accuracy: 50 }); // 연속 2회 통과 → hysteresis 해제
 
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(3));
     expect(lastWatchOptionsAt()).toEqual({
@@ -1834,7 +1840,7 @@ describe('useNearestStation — #2076 GPS 품질 게이트 후속 (absence 독�
     );
     await waitFor(() => expect(Location.watchPositionAsync).toHaveBeenCalledTimes(1));
     expect(lastWatchOptionsAt()).toEqual({
-      accuracy: Location.Accuracy.High,
+      accuracy: Location.Accuracy.Balanced,
       distanceInterval: 0,
       timeInterval: FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS,
     });

--- a/src/features/nearest-station/hooks/useNearestStation.ts
+++ b/src/features/nearest-station/hooks/useNearestStation.ts
@@ -66,18 +66,24 @@ const GPS_DROP_WINDOW_MS = 1000;
 // useStationAlarm effect short-circuit으로 별개 layer에서 해소됐으므로 GPS callback throttle을
 // 제거해도 cascade가 재발하지 않는다.
 // subsurface는 동일하게 distanceInterval=0 — 지하 indoor positioning 보강 동안에는 매 fix가 필요.
-// #1983 (ADR-022 A3) — subsurface에서도 Accuracy.High. 이전엔 Balanced로 배터리 세이빙(#1313)
-// 이었으나 Balanced(100m~수km, cellular triangulation)는 지상 fix까지 1000~1600m 저정확도로
-// 오염시키는 회귀(7/1 오후, 6/30 여러 로그) 발생. subsurface는 timeInterval 12s로만 throttle하고
-// accuracy는 High 통일 — 지하에서 GPS fix 자체가 없을 땐 OS가 자연스레 fallback하므로 High도
-// 배터리 부담 크지 않다. 배터리 실측 회귀 시 별도 이슈로 대응.
+// #1983 (ADR-022 A3) — subsurface에서도 한때 Accuracy.High로 통일했었다. 원 근거: Balanced(100m~
+// 수km, cellular triangulation)는 지상 fix까지 1000~1600m 저정확도로 오염시키는 회귀(7/1 오후,
+// 6/30 여러 로그) 발생 — "지하 fix가 있을 때 정확도 확보"가 목적이었다(당시 결정 코멘트 원문).
+// #2100 (#2093 F) — 그 후 #2074 품질 게이트(100m/15s)가 지하 fix를 SSOT/알람 어디에도 쓰지 않고
+// 전량 폐기하는 것이 실측으로 확인(7/7 로그 gps-drop 84건, 최대 3,467m) — Balanced가 지하 구간에서
+// 만드는 저정확도 fix는 애초에 게이트가 다 버리므로 #1983의 "지하 fix 정확도 확보" 근거가 지하
+// 구간 자체에는 더 이상 적용되지 않는다. #1983이 막으려던 "지상 fix 오염"은 지상 복귀를 GPS 게이트
+// 통과 fix 재등장(hysteresis)에만 의존하지 않고 즉시 원복(아래 profileWatchDegraded eager release +
+// barometerSubsurface)하는 것으로 차단한다 — Balanced의 느린/부정확 첫 fix로 원복 감지 자체가
+// 늦어지는 악순환을 끊는다. subsurface는 timeInterval 12s throttle 유지, accuracy만 Balanced로
+// 재전환해 지하 무의미 GPS 삼각측량 재시도(발열 주범)를 낮춘다.
 const FG_WATCH_OPTIONS_SURFACE: Location.LocationOptions = {
   accuracy: Location.Accuracy.High,
   distanceInterval: 0,
   timeInterval: FG_WATCH_SURFACE_TIME_INTERVAL_MS,
 };
 const FG_WATCH_OPTIONS_SUBSURFACE: Location.LocationOptions = {
-  accuracy: Location.Accuracy.High,
+  accuracy: Location.Accuracy.Balanced,
   distanceInterval: 0,
   timeInterval: FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS,
 };
@@ -264,6 +270,14 @@ export function useNearestStation(
   // 어떤 사유든)가 한 번이라도 끼면 0으로 리셋된다.
   const qualityGateConsecutivePassRef = useRef(0);
   const [gpsQualityDegraded, setGpsQualityDegraded] = useState(false);
+  // #2100 — FG watch 프로파일(High/Balanced) 선택 전용 신호. 공개 gpsQualityDegraded(위)는
+  // inferEnvironment(useFusedNearestStation)가 소비하므로 hysteresis(연속 2회 통과) 해제를 그대로
+  // 유지한다 — 품질 게이트/fusion 판정 로직은 손대지 않는다(#2100 "하지 말 것"). 반면 지하에서
+  // accuracy를 Balanced로 낮추면 Balanced fix는 100m/15s 게이트를 잘 통과하지 못해 hysteresis 2연속
+  // 달성이 사실상 막혀 watch 프로파일이 영구 Balanced에 고착되는 악순환이 생긴다. profileWatchDegraded는
+  // 진입(degrade)은 gpsQualityDegraded와 동일 신호(absence 30s)를 공유하되, 해제는 게이트 통과 fix
+  // 단 1회만으로 즉시 반영(eager release)해 High로 선원복시킨 뒤 후속 fix로 실제 지상 복귀를 확인한다.
+  const [profileWatchDegraded, setProfileWatchDegraded] = useState(false);
 
   // #2076 — 게이트 통과/미달 판정 자체는 applyLocation(표시 게이트 통과 fix)과 watch 콜백의
   // 표시 게이트 drop 분기(>250m fix) 양쪽에서 공유한다. 표시 상태(setUserLocation 등)는 절대
@@ -293,6 +307,10 @@ export function useNearestStation(
         if (isGpsQualityHysteresisReleased(qualityGateConsecutivePassRef.current)) {
           setGpsQualityDegraded((prev) => (prev ? false : prev));
         }
+        // #2100 — watch 프로파일 전용 eager release. 게이트 통과 fix가 단 1회만 등장해도 즉시
+        // High로 선원복(위 gpsQualityDegraded의 2연속 hysteresis와 별개) — Balanced 지하 프로파일에서
+        // hysteresis 2연속 달성이 막혀 원복 자체가 지연되는 악순환을 끊는다.
+        setProfileWatchDegraded((prev) => (prev ? false : prev));
         return;
       }
       // #2076 결함2 — 급락 여부는 진단 로그에만 반영. degraded 상태를 직접 바꾸지 않는다.
@@ -320,6 +338,10 @@ export function useNearestStation(
   usePolling(() => {
     if (isGpsQualityAbsenceDegraded(qualityGateLastPassAtRef.current, Date.now())) {
       setGpsQualityDegraded((prev) => (prev ? prev : true));
+      // #2100 — watch 프로파일 진입(degrade) 신호는 공개 gpsQualityDegraded와 동일 absence 판정을
+      // 공유한다(품질 게이트 판정 로직 자체는 변경하지 않는다). 해제(release)만 위 evaluateGpsQuality의
+      // eager 경로로 분리된다.
+      setProfileWatchDegraded((prev) => (prev ? prev : true));
     }
   }, GPS_QUALITY_GATE_TIMER_INTERVAL_MS);
 
@@ -476,10 +498,12 @@ export function useNearestStation(
       //  좌표를 최대한 자주 흘려보낸다 (foreground 한정, 화면 켜진 동안만).
       //  High는 GPS hardware fix가 없으면 WiFi BSSID / Cell tower triangulation으로 fallback
       //  → 지하 구간에서도 ~50~100m 위치가 들어옴 (BestForNavigation은 fallback 없이 stale).
-      // 지하(subsurface 확정, #1313 + #1983): High + timeInterval:12000으로 throttle. accuracy는
-      //  지상과 동일하게 High 유지 (#1983 ADR-022 A3) — Balanced는 지상 fix까지 1000~1600m로
-      //  오염시키는 회귀 발생. GPS fix 자체가 없을 때는 OS가 자연 fallback하므로 High도 지하 배터리
-      //  부담 크지 않다. throttledRef가 현재 throttle 여부를 들고 있어 flip 시 effect가
+      // 지하(subsurface 확정, #1313 + #2100): Balanced + timeInterval:12000으로 throttle.
+      //  #1983 이후 한동안 High를 썼으나(지하 fix 정확도 확보 목적), #2074 품질 게이트가 지하 fix를
+      //  전량 폐기하는 게 실측 확인돼(7/7 gps-drop 84건) Balanced로 재전환 — 지하 무의미 GPS
+      //  삼각측량 재시도(발열 주범)를 낮춘다. 지상 복귀는 GPS 게이트 hysteresis에만 기대지 않고
+      //  profileWatchDegraded eager release + barometerSubsurface 즉시 원복으로 보강(아래 참고).
+      //  throttledRef가 현재 throttle 여부를 들고 있어 flip 시 effect가
       //  stopWatch→startWatch로 재구성한다(아래 useEffect).
       // 참고: pausesUpdatesAutomatically / activityType은 expo-location foreground 옵션에
       //  노출되지 않아 적용 불가. background task 옵션에서만 사용 가능.
@@ -649,18 +673,24 @@ export function useNearestStation(
   //  - AppState 'active'일 때만 재시작 → BG 중 flip이 FG watch를 켜 'background'→stopWatch 규약을 깨는 것 방지.
   //    (FG 복귀 시 'active' 핸들러의 refresh→startWatch가 ref를 읽어 현재 옵션으로 자연 반영.)
   //
-  // #2070 — 지하 프로파일 트리거를 barometerSubsurface OR gpsQualityDegraded로 확장. 기존
+  // #2070 — 지하 프로파일 트리거를 barometerSubsurface OR profileWatchDegraded로 확장. 기존
   // FG_WATCH_OPTIONS_SUBSURFACE를 그대로 재사용한다(barometer 확정 지하와 배터리 절감 목적이
-  // 동일 — 신규 profile 값을 중복 정의하지 않는다). gpsQualityDegraded가 false로 복귀하면(품질
-  // 게이트 통과 fix 재등장) barometerSubsurface도 true가 아닌 한 지상 프로파일로 원복된다.
+  // 동일 — 신규 profile 값을 중복 정의하지 않는다).
+  // #2100 — gpsQualityDegraded(hysteresis 2연속 해제, inferEnvironment 공용 SSOT) 대신
+  // profileWatchDegraded(eager 1회 해제)를 사용한다 — accuracy가 Balanced로 낮아진 지하에서는
+  // hysteresis 2연속 통과 fix 확보 자체가 어려워 원복이 지연/고착되는 것을 막기 위함(#2100 "선원복
+  // 후 fix 대기"). barometerSubsurface가 명시 지상(false)으로 바뀌는 것도 동일하게 즉시 반영된다
+  // (기존부터 hysteresis 없이 즉시 OR 입력).
+  // 재시작 skip 가드(next === throttledRef.current)는 #2080에서 도입된 churn 방지 로직을 그대로
+  // 재사용 — 동일 프로파일로 판정되면 stopWatch/startWatch를 호출하지 않는다.
   useEffect(() => {
-    const next = inputs.barometerSubsurface === true || gpsQualityDegraded;
+    const next = inputs.barometerSubsurface === true || profileWatchDegraded;
     if (next === throttledRef.current) return;
     throttledRef.current = next;
     if (AppState.currentState !== 'active') return;
     stopWatch();
     void startWatch();
-  }, [inputs.barometerSubsurface, gpsQualityDegraded, startWatch, stopWatch]);
+  }, [inputs.barometerSubsurface, profileWatchDegraded, startWatch, stopWatch]);
 
   // #876 — 매 fix를 sticky 훅에 전달. lock된 역이 있으면 result를 그것으로 override.
   // fusion candidates는 useFusedNearestStation에서 userLocation 기반으로 별도 계산하므로 영향 없음.

--- a/src/features/nearest-station/hooks/useNearestStation.ts
+++ b/src/features/nearest-station/hooks/useNearestStation.ts
@@ -683,6 +683,20 @@ export function useNearestStation(
   // (기존부터 hysteresis 없이 즉시 OR 입력).
   // 재시작 skip 가드(next === throttledRef.current)는 #2080에서 도입된 churn 방지 로직을 그대로
   // 재사용 — 동일 프로파일로 판정되면 stopWatch/startWatch를 호출하지 않는다.
+  //
+  // #2100 스펙 이탈 명시 — 이슈는 지상 복귀 트리거 3종(barometer surface 판정 / environment 전환 /
+  // 게이트 통과 fix 재등장)을 명시했으나, 이 훅은 inferEnvironment.ts의 Environment 라벨을 입력으로
+  // 받지 않는다(useFusedNearestStation이 gps.gpsQualityDegraded를 inferEnvironment에 넘겨 라벨을
+  // 산출하는 순서라 여기서 라벨을 역참조하면 순환 의존이 생긴다 — 이슈가 명시적으로 inferEnvironment.ts
+  // 접촉을 금지한 이유이기도 하다). 따라서 "environment 전환" 트리거는 이 훅이 이미 들고 있는 두
+  // 로컬 proxy로 대체했다: barometerSubsurface(명시 지상 판정)와 profileWatchDegraded(게이트 통과
+  // fix 재등장, eager). inferEnvironment의 라벨 산출 자체가 이 두 신호(+ SSOT)로 구성되므로 실질적
+  // 커버리지 손실은 없다고 판단했다.
+  // 잔여 케이스: barometer가 warmup/미지원(subsurface===undefined)이고 SSOT도 무판정인 채로
+  // backend position-SSOT만으로 지상 복귀가 먼저 확정되는 경우, 이 훅은 그 사실을 알 방법이 없어
+  // watch 프로파일이 즉시 반응하지 않는다 — 다만 이 경로도 지상에 실제로 진입하면 곧 High-등급
+  // GPS fix가 표시 게이트(250m)를 통과하게 되므로, profileWatchDegraded의 게이트 통과 fix
+  // eager-release로 짧은 지연 후 self-heal된다(별도 트리거 불필요).
   useEffect(() => {
     const next = inputs.barometerSubsurface === true || profileWatchDegraded;
     if (next === throttledRef.current) return;

--- a/src/shared/constants/location.ts
+++ b/src/shared/constants/location.ts
@@ -45,6 +45,9 @@ export const FG_WATCH_SURFACE_TIME_INTERVAL_MS = 2_000;
 //  별도 차단) — 표시 전용. 위치 지능은 WiFi SSID/기압계/backend dead-reckoning이 담당하므로
 //  FG watch는 12s로 늦춰 배터리를 아낀다. WiFi 역 DB가 ~19개 역만 커버해 표시 공백을 피하려고
 //  완전 정지가 아닌 보수적 throttle을 택했다. High→Balanced로 고정밀 측위 시도도 줄인다.
+//  #1983~#2100 히스토리: 한때 accuracy를 High로 통일(#1983, 지하 fix 정확도 확보 목적)했으나
+//  #2074 품질 게이트가 지하 fix를 전량 폐기하는 게 확인돼(#2100) Balanced로 재전환 — 상세 근거는
+//  useNearestStation.ts의 FG_WATCH_OPTIONS_SUBSURFACE 주석 참고.
 export const FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS = 12_000;
 
 // iOS CoreLocation은 속도를 측정할 수 없을 때 음수(보통 -1)를 반환한다.


### PR DESCRIPTION
Closes #2100

## 배경
지하 판정 중에도 FG watch가 Accuracy.High 유지(#1983) → OS가 WiFi/cell 삼각측량 연속 시도 = 발열 주범. 그렇게 얻은 좌표는 품질 게이트(#2074)가 전부 폐기(7/7 로그 gps-drop 84건, 최대 3,467m).

## 선행 확인 — #1983이 High를 유지한 원 근거 (이슈 지시 항목)

#1983 이슈 본문 인용:
> ## Why Balanced was used (git blame 확인)
> - `useNearestStation.ts` (#1313 perf): "subsurface 시 FG GPS watch throttle" — 지하 GPS 무의미 구간에서 배터리 세이빙 목적으로 Balanced 채택. 그러나 지상 fix에서 accuracy 1000~1600m 오염 발생 (Balanced는 100m~수km 범위)
>
> ## 결정
> 배터리 트레이드오프보다 GPS 정확도 회귀 종결이 우선 (ADR-022 첫 line 원칙). subsurface 구간에서도 High를 씀으로써 **지하 fix가 있을 때 정확도 확보**. 배터리 실측 회귀 시 별도 이슈로 대응.

즉 #1983의 원 근거는 "지상 복귀 재포착 속도"가 아니라 (1) 지하에서 Balanced fix가 지상 fix까지 1000~1600m로 오염시키는 회귀 차단, (2) 지하에서 fix가 잡힐 때 그 fix 자체의 정확도 확보였다.

## 완화책이 원 근거를 커버하는가 — 판정: 커버함 (옵션 1 진행)

- **근거 (1) 지상 오염**: 이번 PR은 지상 복귀를 GPS 게이트 hysteresis(연속 2회 통과)에만 의존하지 않고, **watch 프로파일 전용 eager release**(게이트 통과 fix 단 1회로 즉시 High 선원복) + barometerSubsurface 즉시 반영으로 보강했다. 오염 경로는 "지하에서 Balanced로 낮춘 채 지상에 진입해도 한동안 Balanced 상태가 유지되는 것"인데, eager release가 이 창을 최소화한다.
- **근거 (2) 지하 fix 정확도**: #2074 품질 게이트(100m/15s)가 지하 fix를 SSOT/알람 어디에도 쓰지 않고 **전량 폐기**하는 것이 실측 확인됐다(7/7 로그 gps-drop 84건, 최대 3,467m). 지하 구간에서 Balanced가 만드는 저정확도 fix는 애초에 게이트가 다 버리므로, "지하 fix 정확도 확보"라는 근거는 지하 구간 자체에는 더 이상 적용되지 않는다.

두 근거 모두 완화책으로 커버된다고 판단해 **옵션 1(지하 Balanced 강등)로 진행**했다. 옵션 2(High 유지 + 간격 12→30s) 후퇴는 필요 없음.

## 변경 사항

- `src/features/nearest-station/hooks/useNearestStation.ts`
  - `FG_WATCH_OPTIONS_SUBSURFACE.accuracy`: `Location.Accuracy.High` → `Location.Accuracy.Balanced` (timeInterval 12s 유지, 지상 프로파일 불변)
  - 신규 `profileWatchDegraded` state 추가 — FG watch 프로파일 선택 전용 eager-release 신호. 공개 `gpsQualityDegraded`(useFusedNearestStation → inferEnvironment 소비, hysteresis 2연속 유지)는 **변경하지 않음** — 품질 게이트/fusion 로직 불가침 원칙 준수.
    - 진입(degrade): `gpsQualityDegraded`와 동일한 absence(30s) 타이머 신호 공유
    - 해제(release): 게이트 통과 fix **단 1회**로 즉시 반영(hysteresis 없음) — Balanced 지하 프로파일에서 hysteresis 2연속 달성 자체가 막혀 원복이 지연/고착되는 악순환 차단
  - watch 프로파일 결정 effect: `gpsQualityDegraded` → `profileWatchDegraded` 참조로 교체. 재시작 skip 가드(#2080 도입 로직 재사용)는 그대로 유지 — 동일 프로파일이면 stopWatch/startWatch 호출 없음
  - `inferEnvironment.ts`, BG task, 품질 게이트 판정 로직(`gpsQualityGate.ts`)은 접촉하지 않음(#2099 병렬 작업 영역 비접촉, 이슈 지시 준수)
- `src/shared/constants/location.ts`: `FG_WATCH_SUBSURFACE_TIME_INTERVAL_MS` 주석에 #1983~#2100 히스토리 갱신(코드 값 변경 없음, 문서만)
- `src/features/nearest-station/hooks/__tests__/useNearestStation.test.ts`: 지하 accuracy pin을 Balanced로 갱신 + eager release(1회 통과) 검증 테스트 추가 + profile/gpsQualityDegraded divergence 동시 상태 assert 테스트 추가. 기존 공개 `gpsQualityDegraded` hysteresis(2연속) 테스트는 그대로 보존(값 불변 확인).

## 하지 않은 것 (이슈 "하지 말 것" 준수)
- 지상 프로파일(High@2s) 변경 없음
- 품질 게이트(`gpsQualityGate.ts`)/fusion 로직 변경 없음 — 공개 `gpsQualityDegraded`의 hysteresis 의미론 그대로 보존
- BG task(`backgroundLocationTask` 등) 접촉 없음
- `inferEnvironment.ts` 접촉 없음 (#2099 병렬 작업 영역)

## 스펙 이탈 명시 (리뷰 반영)

이슈가 명시한 지상 복귀 트리거 3종(barometer surface 판정 / environment 전환 / 게이트 통과 fix 재등장) 중 **"environment 전환"은 그대로 구현하지 않았다**:

- `inferEnvironment.ts`의 `Environment` 라벨은 `useFusedNearestStation`이 `gps.gpsQualityDegraded`(이 훅의 출력)를 입력으로 넘겨 산출하는 순서라, 이 훅이 그 라벨을 다시 입력받으면 순환 의존이 생긴다 — 이슈가 `inferEnvironment.ts` 접촉을 명시적으로 금지한 이유이기도 하다.
- 대신 이 훅이 이미 들고 있는 두 로컬 proxy로 대체했다: `barometerSubsurface`(명시 지상 판정)와 `profileWatchDegraded`(게이트 통과 fix 재등장, eager). `inferEnvironment`의 라벨 산출 자체가 이 두 신호(+ SSOT)로 구성되므로 실질적 커버리지 손실은 없다고 판단.
- **잔여 케이스**: barometer가 warmup/미지원이고 SSOT도 무판정인 채로 backend position-SSOT만으로 지상 복귀가 먼저 확정되는 경로는 이 훅이 알 방법이 없어 watch 프로파일이 즉시 반응하지 않는다. 다만 지상에 실제로 진입하면 곧 High-등급 GPS fix가 표시 게이트(250m)를 통과하므로, `profileWatchDegraded`의 게이트 통과 fix eager-release로 짧은 지연 후 self-heal된다(별도 트리거 불필요로 판단, 코드 주석에도 명시).

## 관측성 갭 (리뷰 반영, 미반영 결정)

`profileWatchDegraded`를 DebugModal에 노출하는 안을 검토했으나, 노출 체인이 `useNearestStation` return → `useFusedNearestStation` 관통 → `DebugModal` props/렌더까지 3단으로 이어져("useNearestStation return + DebugModal 표기 1줄" 수준의 단순 케이스가 아님) 반영하지 않았다. 현재 관측 가능한 대체 경로:
- watch 프로파일 자체(accuracy/interval)는 실기기에서 직접 관측 불가(내부 `Location.watchPositionAsync` 옵션) — 간접적으로 gps-drop 로그 빈도/accuracy 분포 변화로 추정
- 공개 `gpsQualityDegraded`는 여전히 DebugModal에 직접 노출되어 있지 않음(기존부터 `inferEnvironment` 내부 소비만, 이번 PR 범위 밖)

후속 이슈에서 DebugModal GPS 섹션에 `profileWatchDegraded` + `gpsQualityDegraded`를 함께 노출하는 관측성 보강을 고려할 수 있음.

## 테스트
```
npm test          # 428 suites / 9122 tests pass, coverage 100%
npm run type-check # clean
npm run lint:orphan # No orphan exports detected.
```

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (신규 export 없음, 기존 export만 값 변경)
2. **V/X dashboard** — DebugModal GPS 섹션에서 watch accuracy/interval 확인 가능(기존 계측 그대로, 값만 바뀜). `profileWatchDegraded`는 내부 state로 별도 노출 없음 — 관측은 실제 watch 옵션(`lastWatchOptions`)과 기존 `gpsQualityDegraded`(공개, 현재 DebugModal 미표시)로 간접 확인. 위 "관측성 갭" 섹션 참고
3. **의존 PR** — N/A (device-only 코드 변경, backend/infra 의존 없음)
4. **측정 plan** — 실기기 지하 trip 1주 관찰: (a) 지하 구간 체감 발열 감소 여부, (b) gps-drop 로그 수 변화(현재 baseline 7/7 84건), (c) 지하→지상 복귀 시 station 재포착까지 걸리는 시간 체감(eager release로 인한 개선 여부)
5. **Device verify 필요** — 지하→지상 복귀 구간 재포착 시간 체감. 코드/unit 테스트만으로는 실제 OS Balanced/High 전환 시 fix 도착 패턴(속도/정확도)을 검증할 수 없음.
   - **잔존 표시창 측정 항목 추가(리뷰 반영)**: 표시 게이트(250m)는 이번 PR로 변경되지 않았고, watch profile eager release는 **<100m 통과 fix**에서만 발동한다. barometer가 lag(warmup/미지원 구간)일 때 100~250m 정확도의 surface-Balanced fix가 들어오면 표시(userLocation/result)는 갱신되지만 watch profile은 아직 Balanced에 머무는 창이 잔존한다. 실기기 검증 시 이 창의 **체감 지속 시간**을 함께 측정하고, 재포착 지연이 사용자 체감상 문제가 될 정도로 확인되면 이슈 #2100 후퇴선(옵션 2: 지하 accuracy를 다시 High로 유지 + timeInterval만 12s→30s로 늘리는 안)으로 전환을 검토한다.
