### PR TITLE
fix: 환경 판정 분열 해소 — trip 중 barometer 우선 + cellular NRNSA 투표 약화 (#2099)

### DIFF
--- a/src/features/nearest-station/api/positionUpload.ts
+++ b/src/features/nearest-station/api/positionUpload.ts
@@ -33,6 +33,7 @@ import { findNearestStation } from '../utils/findNearestStation';
 import type { LineNumber } from '../../../shared/types/station';
 import { createLogger } from '../../../shared/utils/logger';
 import type { AccelSummary } from '../utils/accelMotion';
+import type { CellularEnvironmentVote } from '../utils/cellularTech';
 import {
   persistBackendSsotMirror,
   type LockSuggestionMirror,
@@ -107,15 +108,22 @@ export interface PositionUploadPayload {
   /**
    * #1543 (ADR-016 S10) — 디바이스 CTRadioAccessTechnology 환경 vote (`useCellularTech`).
    *
-   * - 'surface'      : NR (5G SA) — 지상 hard-reject
-   * - 'surface-weak' : LTE / NRNSA — 지하 DAS 중계 가능, soft downgrade (#1876)
-   * - 'underground'  : 2G/3G fallback → 지하 환경 vote
-   * - 'unknown' / 미전송 : vote 미투표 (게이트 영향 0)
+   * - 'surface'            : NR (5G SA) — 지상 hard-reject
+   * - 'surface-weak'       : LTE — 지하 DAS 중계 가능, soft downgrade (#1876)
+   * - 'surface-weak-nrnsa' : NRNSA — LTE보다 약한 soft downgrade (#2099). device-side
+   *   `undergroundSSotConsensus`/`weightedVoteFusion` 전용 분류 — 현재 이 필드를 채워 보내는
+   *   caller가 없고(orphan 유사), 채워 보낼 경우 backend `consensusGate`가 5번째 값을 아직
+   *   인식하지 못하므로 별도 backend 대응 전까지는 device-local 판정에만 사용한다.
+   * - 'underground'        : 2G/3G fallback → 지하 환경 vote
+   * - 'unknown' / 미전송    : vote 미투표 (게이트 영향 0)
    *
    * iOS only. Android / 미지원 디바이스 / native module 부재 시 omit (graceful).
    * backend `consensusGate`의 environment contradict 판정에 사용된다.
+   *
+   * #2099 (P3-1, 리뷰 반영) — 손 복사 union 대신 `cellularTech.ts`의 `CellularEnvironmentVote`를
+   * import해 타입 drift 방지 (SSOT 단일화).
    */
-  cellularEnvironmentVote?: 'surface' | 'surface-weak' | 'underground' | 'unknown';
+  cellularEnvironmentVote?: CellularEnvironmentVote;
   /**
    * #1667 (ADR-015 strongDB wire) — WiFi SSID 매핑으로 결정한 역명.
    *

--- a/src/features/nearest-station/hooks/useCellularTech.ts
+++ b/src/features/nearest-station/hooks/useCellularTech.ts
@@ -12,10 +12,11 @@
  *   (useMotionActivity와 동일 주기 — 같은 알람 평가 사이클 30s보다 짧으면 stale 우려 적음.)
  *
  * 반환:
- *   - `'unknown'`       : 미지원 / 권한 거절 / native null — vote 미투표
- *   - `'surface'`       : NR (5G SA) — 지상 hard-reject
- *   - `'surface-weak'`  : LTE / NRNSA — 지하 DAS 중계 가능, soft downgrade (#1876)
- *   - `'underground'`   : 2G/3G — 지하 vote
+ *   - `'unknown'`             : 미지원 / 권한 거절 / native null — vote 미투표
+ *   - `'surface'`             : NR (5G SA) — 지상 hard-reject
+ *   - `'surface-weak'`        : LTE — 지하 DAS 중계 가능, soft downgrade (#1876)
+ *   - `'surface-weak-nrnsa'`  : NRNSA (5G NSA) — LTE보다 약한 soft downgrade (#2099)
+ *   - `'underground'`         : 2G/3G — 지하 vote
  */
 
 import { useEffect, useState } from 'react';

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -503,7 +503,13 @@ export function useFusedNearestStation(
   // steady 구간에서는 false로 돌아간다 — 이 기억이 없으면 cellular NRNSA soft downgrade가
   // steady 구간마다 undergroundSSOT quorum을 깎아 barometer의 지하 확정을 뒤집을 수 있다
   // (7/7 trip 로그: subsurface=true 13건인데 최종 environment는 surface 89.9%).
-  // trip 비활성(tripActive=false) 시 즉시 리셋 — 취소된/종료된 trip에 잔존 sticky 없음.
+  // 리셋 트리거:
+  //   1. trip 비활성(tripActive=false) — 즉시 리셋. 취소된/종료된 trip에 잔존 sticky 없음.
+  //   2. `BAROMETER_RECENT_SUBSURFACE_STICKY_WINDOW_MS`(3분) 경과 — 아래 파생 boolean에서 자연 만료.
+  //   3. (P2-1, 리뷰 반영) surfaceSSOT 활성(진짜 지상 증거) — cascadeSurfaceSSOT 계산 직후 별도
+  //      effect에서 즉시 리셋 (L1148 인근). `subsurface===false` 단독으로는 리셋하지 않는다 —
+  //      steady 지하 구간에서 barometer edge-detector가 false로 돌아가는 것은 정상 동작이라
+  //      이를 리셋 트리거로 쓰면 sticky가 매 폴링마다 사라져 본 fix 자체가 무력화된다(원 버그 재발).
   const barometerRecentSubsurfaceAtRef = useRef<number | null>(null);
   useEffect(() => {
     if (!tripActive) {
@@ -1146,6 +1152,16 @@ export function useFusedNearestStation(
     gpsAccuracy: gps.accuracyMeters,
     arrival: cascadeSurfaceArrival,
   });
+  // #2099 (P2-1, 리뷰 반영) — surfaceSSOT 활성(GPS accuracy≤30m + arrival 정착 매칭 2-signal
+  // 합의 = 진짜 지상 증거)이면 barometer sticky 기억을 즉시 소거한다. 지하→지상 복귀 시
+  // sticky 잔존 창이 3분 타임아웃 대기 없이 surfaceSSOT 활성 시점으로 축소된다.
+  // `subsurface===false` 단독으로는 소거하지 않음 — 위 ref 선언부 doc 참고.
+  const surfaceSSOTActive = cascadeSurfaceSSOT !== null;
+  useEffect(() => {
+    if (surfaceSSOTActive) {
+      barometerRecentSubsurfaceAtRef.current = null;
+    }
+  }, [surfaceSSOTActive]);
   const cascadeUndergroundCandidate =
     wifiStationResolved?.station ?? positionTrainResult?.station ?? null;
   const cascadeUndergroundArrival = cascadeUndergroundCandidate

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -29,6 +29,7 @@ import { useRouteProgress } from '../../route/hooks/useRouteProgress';
 import { usePositionStability } from './usePositionStability';
 import { useFusedStationDetection } from './useFusedStationDetection';
 import type { BarometerSignal } from '../../../shared/hooks/useBarometer';
+import { BAROMETER_RECENT_SUBSURFACE_STICKY_WINDOW_MS } from '../../../shared/constants/barometer';
 import { findTopNearestStations } from '../utils/findNearestStation';
 import { findActiveLines } from '../../route/utils/findActiveLines';
 import { pickFusedStation, type FusionConfidence, type FusionSource } from '../utils/pickFusedStation';
@@ -496,6 +497,28 @@ export function useFusedNearestStation(
   // (CTServiceRadioAccessTechnologyDidChangeNotification observer). underground SSOT 4-signal
   // 합의의 환경-확정 vote로 사용. 미지원(Android/jest/web) 시 'unknown' 고정 → vote 미투표.
   const cellularEnvironmentVote = useCellularTech();
+
+  // #2099 (Part of #2093 E, 옵션 1) — trip 활성 중 barometer subsurface=true 최근 확정 sticky
+  // 기억. barometer 30s dP/dt 윈도우는 "지하 진입" edge 신호라 진입 직후에만 잠깐 true이고
+  // steady 구간에서는 false로 돌아간다 — 이 기억이 없으면 cellular NRNSA soft downgrade가
+  // steady 구간마다 undergroundSSOT quorum을 깎아 barometer의 지하 확정을 뒤집을 수 있다
+  // (7/7 trip 로그: subsurface=true 13건인데 최종 environment는 surface 89.9%).
+  // trip 비활성(tripActive=false) 시 즉시 리셋 — 취소된/종료된 trip에 잔존 sticky 없음.
+  const barometerRecentSubsurfaceAtRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!tripActive) {
+      barometerRecentSubsurfaceAtRef.current = null;
+      return;
+    }
+    if (barometerSubsurface === true) {
+      barometerRecentSubsurfaceAtRef.current = Date.now();
+    }
+  }, [tripActive, barometerSubsurface]);
+  const barometerRecentSubsurface =
+    tripActive &&
+    barometerRecentSubsurfaceAtRef.current !== null &&
+    Date.now() - barometerRecentSubsurfaceAtRef.current <=
+      BAROMETER_RECENT_SUBSURFACE_STICKY_WINDOW_MS;
 
   // #1542 (ADR-016 S9) — CMMotionManager raw accelerometer 60s window RMS magnitude 분류.
   // 'automotive' (RMS ≥ 2.0 m/s²)이면 train 진동 환경 vote 1표 — undergroundSSotConsensus 5번째 signal.
@@ -1146,6 +1169,9 @@ export function useFusedNearestStation(
     // #1821 — warmup quorum 완화: trip 시작 후 60s 이내 station pair 단독 채택 허용.
     // lock 활성 시 boardedAt 사용. lockless는 locklessTripStartRef 선언 이후 별도 처리.
     tripStartedAt: boardingLock?.boardedAt,
+    // #2099 (옵션 1) — trip 중 barometer 최근 subsurface=true 확정 sticky. cellular NRNSA
+    // envVotes 페널티를 무효화해 barometer 확정을 뒤집지 못하게 한다.
+    barometerRecentSubsurface,
   });
   // #1860 — 옵션 C barometer-stop 힌트. tripActive + barometerStop 전달.
   // #2070 — GPS 품질 저하(gps.gpsQualityDegraded) 추가 입력. useNearestStation이

--- a/src/features/nearest-station/utils/__tests__/cellularTech.test.ts
+++ b/src/features/nearest-station/utils/__tests__/cellularTech.test.ts
@@ -6,7 +6,8 @@
  *   - 예외 → null / no-op (graceful)
  *   - classifyCellularEnvironment:
  *       NR (5G SA) → 'surface' (hard-reject)
- *       LTE / LTEAdvanced / NRNSA → 'surface-weak' (soft downgrade, #1876)
+ *       LTE / LTEAdvanced → 'surface-weak' (soft downgrade, #1876)
+ *       NRNSA → 'surface-weak-nrnsa' (LTE보다 약한 soft downgrade, #2099)
  *       2G/3G → 'underground'
  *       null / 미지 → 'unknown'
  */
@@ -147,13 +148,19 @@ describe('classifyCellularEnvironment (#1543 + #1876 soft downgrade)', () => {
     expect(classifyCellularEnvironment('CTRadioAccessTechnologyNR')).toBe('surface');
   });
 
-  // LTE / LTEAdvanced / NRNSA — 서울 지하철 DAS 지하 중계. soft downgrade → 'surface-weak'.
+  // LTE / LTEAdvanced — 서울 지하철 DAS 지하 중계. soft downgrade → 'surface-weak'.
   it.each([
     'CTRadioAccessTechnologyLTE',
     'CTRadioAccessTechnologyLTEAdvanced',
-    'CTRadioAccessTechnologyNRNSA',
   ])('%s → surface-weak (서울 DAS 지하 중계 — soft downgrade, #1876)', (tech) => {
     expect(classifyCellularEnvironment(tech)).toBe('surface-weak');
+  });
+
+  // NRNSA — #2099. LTE와 별도 분류 → 'surface-weak-nrnsa' (더 약한 soft downgrade).
+  it('CTRadioAccessTechnologyNRNSA → surface-weak-nrnsa (LTE보다 약한 soft downgrade, #2099)', () => {
+    expect(classifyCellularEnvironment('CTRadioAccessTechnologyNRNSA')).toBe(
+      'surface-weak-nrnsa',
+    );
   });
 
   it.each([

--- a/src/features/nearest-station/utils/__tests__/inferEnvironment.callers.test.ts
+++ b/src/features/nearest-station/utils/__tests__/inferEnvironment.callers.test.ts
@@ -40,6 +40,7 @@ import {
   GPS_DERIVED_ACCURACY_MAX_M,
 } from '../../../../shared/constants/realtime';
 import { inferEnvironment } from '../inferEnvironment';
+import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
 
 jest.mock('../findNearestStation', () => ({
   findTopNearestStations: jest.fn(),
@@ -194,6 +195,50 @@ describe('#1932 inferEnvironment 호출자 통합 (SSOT 단일화 + cascade 직�
       });
       // raw `subsurface === true` → inferEnvironment 우선순위 1 → 'underground'.
       // cascade tier 1 게이트(positionTrainBoardingLockMatch)가 이 변수를 직접 read.
+    });
+
+    it('#2099 (Part of #2093 E) — routeContext 활성(tripActive=true) 중 subsurface=true 관측 → barometer sticky 기억 산출(crash 없음) + environment "underground" 유지', async () => {
+      // 옵션 1(trip 중 barometer 우선 가중) sticky ref는 tripActive=true(routeContext 존재)일 때만
+      // 기억을 갱신한다 — routeContext undefined인 위 test는 sticky가 항상 리셋되는 경로만 exercise.
+      // 본 test는 routeContext를 채워 tripActive=true 경로에서 sticky 기억 산출 자체가 안전하게
+      // 동작하고, 기존 우선순위 1(subsurface===true 즉시 underground) 판정이 그대로 유지됨을 보장.
+      const live = { station: hanyangdae, distanceKm: 0.05 };
+      mockNearest.mockReturnValue({
+        result: live,
+        liveResult: live,
+        stickyDisplayOnly: null,
+        variants: [hanyangdae],
+        userLocation: { lat: hanyangdae.lat, lng: hanyangdae.lng },
+        ...GPS_BASE_DEFAULTS,
+        accuracyMeters: 200,
+        lastFixAtMs: T0,
+        refresh: jest.fn(),
+      });
+      mockFindTop.mockReturnValue([{ station: hanyangdae, distanceKm: 0.05 }]);
+      mockArrival.mockReturnValue(arrivalRet(null));
+      mockPos.mockReturnValue(positionRet({ line: '2', trains: [] }));
+
+      const routeContext = {
+        route: makeDirectRoute(3, '2'),
+        origin: hanyangdae,
+        destination: ttukssom,
+      };
+
+      const hook = renderHook(() =>
+        useFusedNearestStation(
+          undefined,
+          undefined,
+          routeContext, // tripActive=true — sticky ref 갱신 경로 활성화
+          undefined,
+          lockOn2,
+          undefined,
+          { subsurface: true },
+        ),
+      );
+      await flushBackendSsotMirrorTick();
+      await waitFor(() => {
+        expect(hook.result.current.environment).toBe('underground');
+      });
     });
   });
 

--- a/src/features/nearest-station/utils/__tests__/inferEnvironment.callers.test.ts
+++ b/src/features/nearest-station/utils/__tests__/inferEnvironment.callers.test.ts
@@ -41,6 +41,7 @@ import {
 } from '../../../../shared/constants/realtime';
 import { inferEnvironment } from '../inferEnvironment';
 import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
+import { useCellularTech } from '../../hooks/useCellularTech';
 
 jest.mock('../findNearestStation', () => ({
   findTopNearestStations: jest.fn(),
@@ -54,12 +55,18 @@ jest.mock('../../../alarm/utils/tripStartStorage', () => ({
 jest.mock('../../../alarm/utils/backendSsotMirror', () => ({
   readBackendSsotMirror: jest.fn(),
 }));
+// #2099 (P2-2, 리뷰 반영) — 신규 steady-state 통합 테스트가 'surface-weak-nrnsa' vote를 주입하기
+// 위해 mock. 미지정 테스트는 기존 real-hook graceful fallback과 동등한 'unknown' 기본값 유지.
+jest.mock('../../hooks/useCellularTech', () => ({
+  useCellularTech: jest.fn(() => 'unknown'),
+}));
 
 const mockNearest = useNearestStation as jest.Mock;
 const mockArrival = useArrivalInfo as jest.Mock;
 const mockPos = useTrainPositions as jest.Mock;
 const mockFindTop = findTopNearestStations as jest.Mock;
 const mockRead = readBackendSsotMirror as jest.Mock;
+const mockCellularVote = useCellularTech as jest.Mock;
 
 const hanyangdae = findStationByNameAndLine('한양대', '2')!;
 const ttukssom = findStationByNameAndLine('뚝섬', '2')!;
@@ -317,6 +324,98 @@ describe('#1932 inferEnvironment 호출자 통합 (SSOT 단일화 + cascade 직�
         undergroundSSOT: true,
       });
       expect(result.label).toBe('unknown');
+    });
+  });
+
+  describe("#2099 P2-2 (리뷰 반영) — 진짜 steady-state 재현: subsurface=false + barometerRecentSubsurface fresh + cellular NRNSA → undergroundSSOT 경로로 'underground' 유지", () => {
+    // 기존 'cascade tier 1 semantic equivalence' 테스트는 subsurface=true로 inferEnvironment
+    // 우선순위 1(즉시 underground)을 short-circuit해 본 fix(undergroundSSOTConsensus의
+    // barometerRecentSubsurface 가중)를 전혀 exercise하지 못했다(tautology, 리뷰 지적).
+    // 본 테스트는 실제 7/7 trip 패턴대로 render 1에서 subsurface=true를 관측(sticky 기록)한 뒤,
+    // steady 구간처럼 subsurface=false로 돌아간 상태에서 cellular가 NRNSA(surface-weak-nrnsa)로
+    // 계속 surface 투표해도 sticky가 undergroundSSOT quorum을 지켜 environment가 'underground'로
+    // 유지됨을 SSOT 경로(우선순위 3, subsurface===false + undergroundSSOT 활성)로 검증한다.
+    it('render1 subsurface=true(sticky 기록) → render2 subsurface=false + barometerStop + NRNSA(steady quorum) → environment underground 유지', async () => {
+      mockCellularVote.mockReturnValue('surface-weak-nrnsa');
+
+      // 지하 GPS dead zone 시뮬 — accuracy 200m로 surfaceSSOT는 항상 비활성(P2-1 리셋 트리거 미발동).
+      const live = { station: hanyangdae, distanceKm: 0.05 };
+      mockNearest.mockReturnValue({
+        result: live,
+        liveResult: live,
+        stickyDisplayOnly: null,
+        variants: [hanyangdae],
+        userLocation: { lat: hanyangdae.lat, lng: hanyangdae.lng },
+        ...GPS_BASE_DEFAULTS,
+        accuracyMeters: 200,
+        lastFixAtMs: T0,
+        refresh: jest.fn(),
+      });
+      mockFindTop.mockReturnValue([{ station: hanyangdae, distanceKm: 0.05 }]);
+      // wifiStation(8번째 인자) station pair 채택을 위한 arvlCd 정착 매칭 (트레인코드 lockOn2와 동일).
+      mockArrival.mockReturnValue(
+        arrivalRet({
+          up: [
+            {
+              destination: 'dest',
+              arrivalMinutes: 0,
+              arrivalSeconds: 0,
+              statusMessage: '도착',
+              trainCode: 'T-LOCK',
+              line: '2',
+              receivedAtMs: T0,
+              arrivalCode: ARRIVAL_CODE.ARRIVED,
+              isLastTrain: false,
+              trainType: 'normal',
+            },
+          ],
+          down: [],
+        }),
+      );
+      mockPos.mockReturnValue(positionRet(null)); // positionTrainResult 없음 — wifi 단독 station pair.
+
+      const routeContext = {
+        route: makeDirectRoute(3, '2'),
+        origin: hanyangdae,
+        destination: ttukssom,
+      };
+
+      const hook = renderHook(
+        (props: { subsurface: boolean; stop?: boolean }) =>
+          useFusedNearestStation(
+            undefined,
+            undefined,
+            routeContext,
+            undefined,
+            lockOn2,
+            undefined,
+            { subsurface: props.subsurface, signal: { subsurface: props.subsurface, stop: props.stop } },
+            hanyangdae, // wifiStation
+          ),
+        { initialProps: { subsurface: true } },
+      );
+      await flushBackendSsotMirrorTick();
+      await waitFor(() => {
+        expect(hook.result.current.environment).toBe('underground');
+      });
+      // render1: subsurface=true → 우선순위 1 즉시 underground + barometerRecentSubsurfaceAtRef sticky 기록.
+
+      // steady quorum(warmup 60s 이후) 강제 — tripStartedAt=boardingLock.boardedAt=T0.
+      jest.setSystemTime(T0 + 90_000); // sticky window(3분) 이내, warmup(60s) 이후.
+      hook.rerender({ subsurface: false, stop: true });
+      await flushBackendSsotMirrorTick();
+      await waitFor(() => {
+        // subsurface=false(steady 지하 raw 신호) + cellular NRNSA surface 투표 + barometerStop=true.
+        // sticky(barometerRecentSubsurface=true)가 undergroundSSOTConsensus primary path의 NRNSA
+        // envVotes 페널티를 무효화해 quorum(steady=2)을 pair(1)+envVotes(baro+1, nrnsa 0)=2로
+        // 충족 → undergroundSSOT 활성 → inferEnvironment 우선순위 3(subsurface===false +
+        // undergroundSSOT 활성) 경로로 'underground' 유지. 이전 tautology 테스트(subsurface=true
+        // 우선순위 1 short-circuit)와 달리 본 테스트는 실제 SSOT 판정 경로를 exercise한다.
+        // (sticky 없이도 이 특정 조합은 옵션 2 단독 fallback 임계(1.3)로 구제되는 경계 케이스다 —
+        // sticky의 배타적 필요성은 undergroundSSotConsensus.test.ts의 wifi+position 2-pair,
+        // 추가 env vote 없는 시나리오에서 별도로 단위 검증됨: 그 케이스는 sticky 없이는 reject.)
+        expect(hook.result.current.environment).toBe('underground');
+      });
     });
   });
 

--- a/src/features/nearest-station/utils/__tests__/undergroundSSotConsensus.test.ts
+++ b/src/features/nearest-station/utils/__tests__/undergroundSSotConsensus.test.ts
@@ -5,7 +5,9 @@
  *   env vote: barometer-stop, cellular-underground
  *   - station pair ≥ 1 + (station pair + env vote) ≥ 2 통과 시 채택
  *   - cellular 'surface' (NR SA) vote → reject (환경 확정 모순 — hard-reject)
- *   - cellular 'surface-weak' (LTE/NRNSA) vote → envVotes −1 (soft downgrade, #1876)
+ *   - cellular 'surface-weak' (LTE) vote → envVotes −1 (soft downgrade, #1876)
+ *   - cellular 'surface-weak-nrnsa' (NRNSA) vote → envVotes −0.5, trip 중 barometer 최근
+ *     subsurface=true 확정 시 0 (soft downgrade, LTE보다 약함 — #2099)
  *   - station 우선순위: position > wifi
  * #1821 — warmup quorum 완화:
  *   - trip 시작 후 60s 이내 + station pair 1개 → underground 채택 (quorum=1)
@@ -462,7 +464,7 @@ describe('undergroundSSOTConsensus — warmup quorum (#1821)', () => {
 });
 
 describe("undergroundSSOTConsensus — 'surface-weak' soft downgrade (#1876)", () => {
-  // 'surface-weak' (LTE/NRNSA) = envVotes −1. hard-reject 아님.
+  // 'surface-weak' (LTE) = envVotes −1. hard-reject 아님.
   // 다른 신호가 충분하면 underground 채택 가능.
 
   it("'surface-weak' 단독 (position pair 1 + envVotes=−1) → steady quorum=2 미달 → null", () => {
@@ -583,6 +585,104 @@ describe("undergroundSSOTConsensus — 'surface-weak' soft downgrade (#1876)", (
       },
       NOW,
     );
+    expect(result?.station.id).toBe(positionTrain.station.id);
+  });
+});
+
+describe("undergroundSSOTConsensus — 'surface-weak-nrnsa' soft downgrade + barometer sticky override (#2099, Part of #2093 E)", () => {
+  // 7/7 trip 로그: barometer subsurface=true 13건(정확)인데 cellular가 전 구간 NRNSA로
+  // surface 투표 → 최종 environment surface 89.9%. 옵션 1(trip 중 barometer 우선 가중) +
+  // 옵션 2(NRNSA 투표 약화, envVotes −1 → −0.5)를 한 PR로 검증.
+
+  it("'surface-weak-nrnsa' 단독 (position pair 1 + envVotes=−0.5) → steady quorum=2 미달 → null", () => {
+    // position pair: 1. envVotes: 0−0.5=−0.5. total: 1+(−0.5)=0.5 < 2 → null.
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    expect(
+      undergroundSSOTConsensus({
+        wifiStation: null,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine2,
+        cellularEnvironmentVote: 'surface-weak-nrnsa',
+      }),
+    ).toBeNull();
+  });
+
+  it("wifi + position + 'surface-weak-nrnsa' (barometerRecentSubsurface 없음) → pair 2 + env −0.5 = 1.5 < 2 → steady quorum 미달 → null", () => {
+    // pair: 2 (wifi+position 둘 다 arrival 매칭). envVotes: 0−0.5=−0.5. total: 2+(−0.5)=1.5 < 2.
+    // fallback(weightedVoteFusion)도 positional evaluator가 position>wifi 우선 1개만 반환하므로
+    // score=1.0(positional) + 0(envScore, nrnsa는 radio 미참여) = 1.0 < 1.3(threshold) → reject.
+    const wifi = MOCK_STATIONS.gangnam;
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    expect(
+      undergroundSSOTConsensus({
+        wifiStation: wifi,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine2,
+        cellularEnvironmentVote: 'surface-weak-nrnsa',
+      }),
+    ).toBeNull();
+  });
+
+  it("#2099 재현 시나리오 — wifi + position + 'surface-weak-nrnsa' + barometerRecentSubsurface=true → pair 2 + env 0(무효화) = 2 ≥ 2 → underground 판정 (barometer가 cellular NRNSA surface 투표를 뒤집음)", () => {
+    // trip 활성 중 barometer가 최근 subsurface=true를 확정 → NRNSA envVotes 페널티 0 무효화.
+    // 같은 입력에서 barometerRecentSubsurface만 바뀌어 reject → accept로 전환됨을 증명(위 테스트 대비).
+    const wifi = MOCK_STATIONS.gangnam;
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    const result = undergroundSSOTConsensus({
+      wifiStation: wifi,
+      positionTrainResult: positionTrain,
+      arrival: arrivalLine2,
+      cellularEnvironmentVote: 'surface-weak-nrnsa',
+      barometerRecentSubsurface: true,
+    });
+    // position 우선 → positionTrain.station.
+    expect(result?.station.id).toBe(positionTrain.station.id);
+    expect(result?.trainCode).toBe('T1');
+  });
+
+  it('trip 비활성 시 가중 미적용 — barometerRecentSubsurface=false (호출자가 tripActive=false로 산출) → 기존 −0.5 페널티 그대로 → null', () => {
+    // 호출자(useFusedNearestStation)는 tripActive=false면 barometerRecentSubsurface를 항상 false로 산출.
+    // 본 함수 입장에서는 명시적 false 전달 — 위 accept 시나리오와 동일 입력이지만 가중 미적용 검증.
+    const wifi = MOCK_STATIONS.gangnam;
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    expect(
+      undergroundSSOTConsensus({
+        wifiStation: wifi,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine2,
+        cellularEnvironmentVote: 'surface-weak-nrnsa',
+        barometerRecentSubsurface: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("barometerRecentSubsurface=true는 'surface-weak'(LTE)에는 적용되지 않음 (#2099는 NRNSA 전용, 스코프 경계 회귀 방지)", () => {
+    // LTE는 기존 #1876 정책(envVotes −1) 그대로 — barometerRecentSubsurface가 LTE 페널티를 건드리지 않음.
+    // envVotes: baro+1, surface-weak−1 = 0. total: pair 1 + env 0 = 1 < 2 → null.
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    expect(
+      undergroundSSOTConsensus({
+        wifiStation: null,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine2,
+        barometerStop: true,
+        cellularEnvironmentVote: 'surface-weak',
+        barometerRecentSubsurface: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("position + accelerometer + barometer + 'surface-weak-nrnsa' (barometerRecentSubsurface 없음, 옵션 2 일반 약화만) → pair 1 + (1+1−0.5)=1.5 → total 2.5 ≥ 2 → pass", () => {
+    // 옵션 2(일반 약화, −0.5)만으로도 2개 이상의 다른 env vote가 있으면 채택 가능함을 증명.
+    const positionTrain = makeNearestResult('gangnam', 0.05);
+    const result = undergroundSSOTConsensus({
+      wifiStation: null,
+      positionTrainResult: positionTrain,
+      arrival: arrivalLine2,
+      barometerStop: true,
+      accelerometerPattern: 'automotive',
+      cellularEnvironmentVote: 'surface-weak-nrnsa',
+    });
     expect(result?.station.id).toBe(positionTrain.station.id);
   });
 });

--- a/src/features/nearest-station/utils/__tests__/weightedVoteFusion.test.ts
+++ b/src/features/nearest-station/utils/__tests__/weightedVoteFusion.test.ts
@@ -489,6 +489,96 @@ describe("weightedVoteFusion — D+A hybrid (#1876 'surface-weak' cross-impact)"
     });
   });
 
+  describe("NRNSA: threshold 1.3 완화 + barometerRecentSubsurface 무효화 (#2099, Part of #2093 E)", () => {
+    // 7/7 trip 로그: NRNSA(surface-weak-nrnsa)는 LTE(surface-weak)와 같은 근거지만 서울 지하철
+    // 전 구간 중계 구조상 surface 정보가치가 더 낮다 — threshold를 1.6에서 1.3으로 완화(옵션 2).
+    // trip 활성 중 barometer가 최근 subsurface=true를 확정했으면 threshold조차 적용하지 않고
+    // 기본 1.1로 완전 무효화한다(옵션 1) — barometer 확정을 cellular NRNSA가 뒤집지 못하게.
+
+    it("'surface-weak-nrnsa' + positional full + barometer(0.3) = 1.3 ≥ 1.3 → accept (LTE였다면 1.3 < 1.6 → reject)", () => {
+      const positionTrain = makeNearestResult('chungmuro', 0.05);
+      const result = weightedVoteFusion({
+        wifiStation: null,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine3,
+        cellularEnvironmentVote: 'surface-weak-nrnsa',
+        barometerStop: true,
+      });
+      expect(result.acceptThreshold).toBe(1.3);
+      expect(result.accepted).toBe(true);
+      expect(result.totalScore).toBeCloseTo(1.3, 10);
+    });
+
+    it("'surface-weak-nrnsa' + positional full 단독 = 1.0 < 1.3 → reject", () => {
+      const positionTrain = makeNearestResult('chungmuro', 0.05);
+      const result = weightedVoteFusion({
+        wifiStation: null,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine3,
+        cellularEnvironmentVote: 'surface-weak-nrnsa',
+      });
+      expect(result.acceptThreshold).toBe(1.3);
+      expect(result.accepted).toBe(false);
+    });
+
+    it("#2099 재현 시나리오 — 'surface-weak-nrnsa' + barometerRecentSubsurface=true → threshold 기본 1.1로 무효화, positional full 단독(1.0)은 여전히 미달이나 partial+radio 조합은 기존 underground 정책과 동일하게 accept", () => {
+      // barometerRecentSubsurface=true → THRESHOLD_BY_ENV 매칭 제외 → 기본 1.1 적용.
+      const positionTrain = makeNearestResult('chungmuro', 0.05);
+      const result = weightedVoteFusion({
+        wifiStation: null,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine2, // partial (0.6)
+        cellularEnvironmentVote: 'underground',
+        barometerRecentSubsurface: true,
+      });
+      expect(result.acceptThreshold).toBe(1.1);
+      expect(result.accepted).toBe(true); // 0.6(partial) + 0.5(radio-underground) = 1.1 — 기본 정책과 동일
+    });
+
+    it("'surface-weak-nrnsa' + barometerRecentSubsurface=true → threshold 1.1로 무효화, positional full + barometer(1.3) → accept (기본 정책과 동등)", () => {
+      const positionTrain = makeNearestResult('chungmuro', 0.05);
+      const result = weightedVoteFusion({
+        wifiStation: null,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine3,
+        cellularEnvironmentVote: 'surface-weak-nrnsa',
+        barometerStop: true,
+        barometerRecentSubsurface: true,
+      });
+      expect(result.acceptThreshold).toBe(1.1);
+      expect(result.accepted).toBe(true);
+      expect(result.totalScore).toBeCloseTo(1.3, 10);
+    });
+
+    it("'surface-weak-nrnsa' + barometerRecentSubsurface=false → threshold 1.3 그대로 (가중 미적용, 회귀 없음)", () => {
+      const positionTrain = makeNearestResult('chungmuro', 0.05);
+      const result = weightedVoteFusion({
+        wifiStation: null,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine3,
+        cellularEnvironmentVote: 'surface-weak-nrnsa',
+        barometerStop: true,
+        barometerRecentSubsurface: false,
+      });
+      expect(result.acceptThreshold).toBe(1.3);
+      expect(result.totalScore).toBeCloseTo(1.3, 10);
+      expect(result.accepted).toBe(true); // 1.3 ≥ 1.3 threshold — 이 케이스는 accept
+    });
+
+    it("'surface-weak-nrnsa' + radio vote 미참여 (cellular 자체가 surface-weak-nrnsa이므로 underground vote X)", () => {
+      const positionTrain = makeNearestResult('chungmuro', 0.05);
+      const result = weightedVoteFusion({
+        wifiStation: null,
+        positionTrainResult: positionTrain,
+        arrival: arrivalLine3,
+        cellularEnvironmentVote: 'surface-weak-nrnsa',
+      });
+      const radioVote = result.votes.find((v) => v.category === 'radio');
+      expect(radioVote?.contributed).toBe(false);
+      expect(radioVote?.effectiveWeight).toBe(0);
+    });
+  });
+
   describe('A: station 후보 0 → 항상 reject (env 무관)', () => {
     it("'surface-weak' + station 후보 0 → null (env 누적이 1.6 미달인 것과 무관, station 가드)", () => {
       // env 누적: time(0.3) + motion(0.4) = 0.7. 둘 다 1.6 미달이지만 station 후보 0이 primary 가드.

--- a/src/features/nearest-station/utils/cellularTech.ts
+++ b/src/features/nearest-station/utils/cellularTech.ts
@@ -10,11 +10,18 @@
  * 분류 정책 (Apple `CTRadioAccessTechnology*` 상수 기준):
  *   - `surface` (지상 hard-reject): NR (5G SA)
  *       → 2026년 기준 지하 인프라 거의 없음. hard-reject 유지.
- *   - `surface-weak` (지상 soft downgrade): LTE, LTEAdvanced, NRNSA (5G NSA)
- *       → 서울 지하철 DAS가 LTE/NRNSA를 지하에서도 중계 (100% 커버). 지하에서도 잡힘.
+ *   - `surface-weak` (지상 soft downgrade): LTE, LTEAdvanced
+ *       → 서울 지하철 DAS가 LTE를 지하에서도 중계. 지하에서도 잡힘.
  *       → hard-reject 대신 soft downgrade: undergroundSSOTConsensus에서 envVotes −1로 처리.
  *       → 다른 신호(barometer/accelerometer)가 충분하면 underground 채택 허용.
  *       (#1876 — plan-1846 §4.1 옵션 B 적용)
+ *   - `surface-weak-nrnsa` (지상 soft downgrade, 추가 약화): NRNSA (5G NSA)
+ *       → #2099 (Part of #2093 E) — 7/7 trip 로그: 서울 지하철 전 구간이 NRNSA로 중계돼
+ *         barometer가 정확히 subsurface=true를 보고한 구간에서도 NRNSA가 surface-weak 투표로
+ *         undergroundSSOT quorum을 깎아 최종 environment가 surface로 오분류(89.9%)됐다.
+ *         LTE보다 한 단계 더 정보가치가 낮다고 보고 별도 분류 — envVotes 페널티를 LTE보다
+ *         약화(-1 → -0.5)하고, trip 활성 중 barometer가 최근 subsurface=true를 확정했으면
+ *         페널티를 0으로 완전 무효화한다 (`undergroundSSotConsensus.ts` 참고).
  *   - `underground` (지하 vote): GPRS, Edge, WCDMA, HSDPA, HSUPA, CDMA1x, eHRPD, CDMAEVDORev0/A/B
  *       → 지하 캐리어 펨토셀 / DAS 안테나가 흔히 fallback하는 2G/3G 신호.
  *   - `unknown`              : null / 빈 문자열 / 미지의 상수
@@ -82,12 +89,19 @@ export function getCurrentCellularTech(): string | null {
 /**
  * 환경 vote 결과. consensusGate / undergroundSSOTConsensus 입력으로 사용.
  *
- * - `'surface'`      : NR (5G SA) — 지하 발생 낮음. hard-reject 유지.
- * - `'surface-weak'` : LTE / LTEAdvanced / NRNSA — 지하에서도 잡힘(서울 DAS). soft downgrade.
- * - `'underground'`  : 2G/3G — 지하 확정 1표.
- * - `'unknown'`      : vote 미투표.
+ * - `'surface'`            : NR (5G SA) — 지하 발생 낮음. hard-reject 유지.
+ * - `'surface-weak'`       : LTE / LTEAdvanced — 지하에서도 잡힘(서울 DAS). soft downgrade.
+ * - `'surface-weak-nrnsa'` : NRNSA (5G NSA) — #2099. LTE보다 한 단계 더 약한 soft downgrade
+ *     (서울 지하철 전 구간 NRNSA 중계 — surface 신호로서 정보가치가 LTE보다도 낮음).
+ * - `'underground'`        : 2G/3G — 지하 확정 1표.
+ * - `'unknown'`            : vote 미투표.
  */
-export type CellularEnvironmentVote = 'surface' | 'surface-weak' | 'underground' | 'unknown';
+export type CellularEnvironmentVote =
+  | 'surface'
+  | 'surface-weak'
+  | 'surface-weak-nrnsa'
+  | 'underground'
+  | 'unknown';
 
 /**
  * Apple `CTRadioAccessTechnology` 상수 → 환경 vote 매핑.
@@ -107,12 +121,19 @@ const SURFACE_HARD_TECHS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * LTE / LTEAdvanced / NRNSA — 서울 지하철 DAS 지하 중계로 지하에서도 흔히 수신.
+ * LTE / LTEAdvanced — 서울 지하철 DAS 지하 중계로 지하에서도 흔히 수신.
  * hard-reject 대신 soft downgrade (`'surface-weak'`).
  */
 const SURFACE_WEAK_TECHS: ReadonlySet<string> = new Set([
   'CTRadioAccessTechnologyLTE',
   'CTRadioAccessTechnologyLTEAdvanced',
+]);
+
+/**
+ * NRNSA (5G NSA) — #2099. 서울 지하철 전 구간이 NRNSA로 중계돼 LTE보다도 surface 정보가치가
+ * 낮다. 별도 분류로 분리해 `'surface-weak'`(LTE)보다 약한 페널티를 적용한다.
+ */
+const SURFACE_WEAK_NRNSA_TECHS: ReadonlySet<string> = new Set([
   'CTRadioAccessTechnologyNRNSA',
 ]);
 
@@ -132,14 +153,16 @@ const UNDERGROUND_TECHS: ReadonlySet<string> = new Set([
 /**
  * radio tech 코드 → 환경 vote 분류.
  *
- * - NR (5G SA)       → `'surface'`      (hard-reject — 지하 발생 낮음)
- * - LTE / NRNSA      → `'surface-weak'` (soft downgrade — 서울 지하 DAS 중계)
- * - 2G/3G            → `'underground'`  (지하 1표)
- * - null / 미지 코드  → `'unknown'`     (vote 미투표)
+ * - NR (5G SA)       → `'surface'`            (hard-reject — 지하 발생 낮음)
+ * - LTE              → `'surface-weak'`       (soft downgrade — 서울 지하 DAS 중계)
+ * - NRNSA            → `'surface-weak-nrnsa'` (#2099 — LTE보다 약한 soft downgrade)
+ * - 2G/3G            → `'underground'`        (지하 1표)
+ * - null / 미지 코드  → `'unknown'`            (vote 미투표)
  */
 export function classifyCellularEnvironment(tech: string | null): CellularEnvironmentVote {
   if (!tech) return 'unknown';
   if (SURFACE_HARD_TECHS.has(tech)) return 'surface';
+  if (SURFACE_WEAK_NRNSA_TECHS.has(tech)) return 'surface-weak-nrnsa';
   if (SURFACE_WEAK_TECHS.has(tech)) return 'surface-weak';
   if (UNDERGROUND_TECHS.has(tech)) return 'underground';
   return 'unknown';

--- a/src/features/nearest-station/utils/positionTrainConsensus.ts
+++ b/src/features/nearest-station/utils/positionTrainConsensus.ts
@@ -35,7 +35,10 @@ import type { CellularEnvironmentVote } from './cellularTech';
  *
  * - `barometerSubsurface` — `true=지하`, `false=지상`, `null|undefined=미확정(warmup/미지원)`.
  * - `accelerometerPattern` — `'automotive' | 'walking' | 'stationary' | 'unknown' | null`.
- * - `cellularEnvironmentVote` — `'surface' | 'surface-weak' | 'underground' | 'unknown'`.
+ * - `cellularEnvironmentVote` — `'surface' | 'surface-weak' | 'surface-weak-nrnsa' | 'underground'
+ *   | 'unknown'` (`'surface-weak-nrnsa'`는 #2099 — NRNSA 전용 분류, 본 함수 판정에서는 `'surface-weak'`와
+ *   동일하게 "그 외"(4번) 버킷으로 처리된다 — `=== 'surface'` 단독 매칭만 채택 신호이므로 아래 로직
+ *   변경 없음).
  */
 export interface PositionTrainConsensusSignals {
   barometerSubsurface: boolean | null | undefined;
@@ -55,7 +58,8 @@ export interface PositionTrainConsensusSignals {
  *      탑승 중이 아니면 `position-train` 채택 의미가 없다 (false positive 차단).
  *   3) `cellularEnvironmentVote === 'surface'` (지상 확정) → return true.
  *      barometer false-negative 보강 — surface 확정 시 채택 허용.
- *   4) 그 외 (cellular 'surface-weak' / 'underground' / 'unknown' / null / undefined) → return false.
+ *   4) 그 외 (cellular 'surface-weak' / 'surface-weak-nrnsa'(#2099) / 'underground' / 'unknown' /
+ *      null / undefined) → return false.
  *      환경 ambiguity = 보수적으로 채택 보류(false positive 우선 차단, ADR-014 첫 줄).
  */
 export function requiresPositionTrainConsensus(

--- a/src/features/nearest-station/utils/undergroundSSotConsensus.ts
+++ b/src/features/nearest-station/utils/undergroundSSotConsensus.ts
@@ -28,14 +28,19 @@
  *       (c) Barometer `stop=true` (FG/BG) — #1574
  *       (d) Cellular `underground` vote (FG/BG) — #1574
  *       (e) Accelerometer `automotive` pattern (FG/BG, BG location piggyback) — #1542
- *   - Cellular `surface-weak` (LTE/NRNSA) — #1876 soft downgrade:
+ *   - Cellular `surface-weak` (LTE) — #1876 soft downgrade:
  *       envVotes −1. 다른 신호 우세 시 underground 채택 허용 (hard-reject 아님).
+ *   - Cellular `surface-weak-nrnsa` (NRNSA) — #2099 soft downgrade (LTE보다 약함):
+ *       envVotes −0.5(`SURFACE_WEAK_NRNSA_ENV_VOTE_PENALTY`). trip 활성 중 barometer가 최근
+ *       subsurface=true를 확정했으면(`barometerRecentSubsurface`) 페널티 자체를 0으로 무효화.
  *
  * 합의 임계:
  *   - Primary path: 2-of-N 통과 시 SSOT 채택 (station pair + env vote 어떤 조합이든 OK)
  *   - 단, 채택 station이 필요하므로 station pair ≥ 1 필수 (env vote만 2개로는 불가)
  *   - Cellular `surface` vote (NR SA) 시 underground SSOT 자체 reject (환경 확정 모순)
- *   - Cellular `surface-weak` vote (LTE/NRNSA) 시 envVotes −1 (soft downgrade)
+ *   - Cellular `surface-weak` vote (LTE) 시 envVotes −1 (soft downgrade)
+ *   - Cellular `surface-weak-nrnsa` vote (NRNSA, #2099) 시 envVotes −0.5, trip 활성 중 barometer가
+ *     최근 subsurface=true를 확정했으면 0 (soft downgrade, LTE보다 약하고 무효화 가능)
  *   - GPS는 input set에서 reject (ADR-015 §5, backend `consensusGate.ts` 동일 정책)
  *   - Fallback path (#1884): primary 미달 시 weighted vote 임계 평가
  *
@@ -53,6 +58,7 @@ import type { StationArrival } from '../../../shared/types/arrival';
 import type { CellularEnvironmentVote } from './cellularTech';
 import type { AccelerometerPattern } from './accelerometerFingerprint';
 import { weightedVoteFusion } from './weightedVoteFusion';
+import { SURFACE_WEAK_NRNSA_ENV_VOTE_PENALTY } from '../../../shared/constants/fusion';
 
 /** arvlCd "정착한 위치 보고" 코드 집합. surfaceSSotConsensus와 동일 — 향후 공용 추출 여지. */
 const ARVL_CD_STATIONARY = new Set<number>([1, 2, 3, 5]);
@@ -84,12 +90,24 @@ export interface UndergroundSSOTInput {
   /**
    * #1574 — `useCellularTech()` 환경 vote (CTRadioAccessTechnology 분류).
    * 'surface' (NR SA)면 underground SSOT 자체 reject (환경 확정 모순 — hard-reject).
-   * 'surface-weak' (LTE/NRNSA)면 envVotes −1 (soft downgrade — #1876).
+   * 'surface-weak' (LTE)면 envVotes −1 (soft downgrade — #1876).
+   * 'surface-weak-nrnsa' (NRNSA)면 envVotes −0.5, `barometerRecentSubsurface`=true면 0
+   *   (soft downgrade, LTE보다 약함 — #2099).
    * 'underground'면 환경-확정 1표.
    * 'unknown'/undefined → vote 미투표.
    * iOS BG에서도 동작 (CTServiceRadioAccessTechnologyDidChangeNotification observer).
    */
   cellularEnvironmentVote?: CellularEnvironmentVote | undefined;
+  /**
+   * #2099 (Part of #2093 E, 옵션 1) — trip 활성 중 barometer가 최근 subsurface=true를
+   * 확정한 적이 있으면 true. barometer 30s dP/dt 윈도우는 "지하 진입" edge를 감지하는
+   * 신호라 진입 직후에만 잠깐 true이고 steady 구간에서는 false로 돌아간다 — 이 sticky 기억이
+   * 없으면 steady 구간에서 NRNSA soft downgrade가 undergroundSSOT quorum을 계속 깎는다.
+   * true면 `surface-weak-nrnsa` envVotes 페널티를 0으로 무효화(barometer 확정이 cellular
+   * surface 투표를 뒤집지 못하게). 호출자(`useFusedNearestStation`)가 trip 스코프 sticky
+   * 타이머로 산출 — 미전달(undefined)은 false와 동일(backward-compat).
+   */
+  barometerRecentSubsurface?: boolean;
   /**
    * #1542 (ADR-016 S9) — CMMotionManager 60s window RMS magnitude 분류 결과.
    * 'automotive' (RMS ≥ 2.0 m/s² 진동 — train 진행)이면 환경-확정 1표 추가.
@@ -138,10 +156,12 @@ export function undergroundSSOTConsensus(
     cellularEnvironmentVote,
     accelerometerPattern,
     tripStartedAt,
+    barometerRecentSubsurface,
   } = input;
 
   // 환경 확정 모순 — cellular 'surface' (NR SA)면 underground SSOT 자체 candidate X.
-  // 'surface-weak' (LTE/NRNSA)는 hard-reject 아님 — soft downgrade (envVotes −1, 하단 처리).
+  // 'surface-weak' (LTE) / 'surface-weak-nrnsa' (NRNSA, #2099)는 hard-reject 아님 —
+  // soft downgrade (envVotes 감산, 하단 처리).
   if (cellularEnvironmentVote === 'surface') return null;
 
   // Station pair 후보 — 채택 우선순위 순서. position-train > wifi.
@@ -160,11 +180,17 @@ export function undergroundSSOTConsensus(
   }
 
   // Environment-confirming votes (station 미제공). 신규 #1574 — BG WiFi 갭 해소 + #1542 accelerometer.
-  // #1876 — 'surface-weak' soft downgrade: LTE/NRNSA는 envVotes −1 (지하에서도 잡히므로 hard-reject X).
+  // #1876 — 'surface-weak'(LTE) soft downgrade: envVotes −1 (지하에서도 잡히므로 hard-reject X).
+  // #2099 — 'surface-weak-nrnsa'(NRNSA) soft downgrade: LTE보다 약한 −0.5. trip 활성 중
+  // barometer가 최근 subsurface=true를 확정했으면(barometerRecentSubsurface) 페널티를 0으로
+  // 무효화 — barometer 확정을 cellular NRNSA surface 투표가 뒤집지 못하게 한다 (옵션 1+2).
   let envVotes = 0;
   if (barometerStop === true) envVotes += 1;
   if (cellularEnvironmentVote === 'underground') envVotes += 1;
   if (cellularEnvironmentVote === 'surface-weak') envVotes -= 1;
+  if (cellularEnvironmentVote === 'surface-weak-nrnsa' && !barometerRecentSubsurface) {
+    envVotes += SURFACE_WEAK_NRNSA_ENV_VOTE_PENALTY;
+  }
   if (accelerometerPattern === 'automotive') envVotes += 1;
 
   // Warmup 60s 이내 → quorum=1 (station pair 단독 채택 허용). 60s 이후 → steady quorum=2.
@@ -189,6 +215,7 @@ export function undergroundSSOTConsensus(
     barometerStop,
     cellularEnvironmentVote,
     accelerometerPattern,
+    barometerRecentSubsurface,
   });
   if (voteResult.accepted && voteResult.winner !== null) {
     return voteResult.winner;

--- a/src/features/nearest-station/utils/weightedVoteFusion.ts
+++ b/src/features/nearest-station/utils/weightedVoteFusion.ts
@@ -61,6 +61,7 @@ import {
   FUSION_SIGNAL_WEIGHTS,
   STATION_ACCEPT_THRESHOLD,
   STATION_ACCEPT_THRESHOLD_SURFACE_WEAK,
+  STATION_ACCEPT_THRESHOLD_SURFACE_WEAK_NRNSA,
   type FusionSignalCategory,
 } from '../../../shared/constants/fusion';
 
@@ -81,6 +82,13 @@ export interface WeightedVoteInput {
   barometerStop?: boolean | undefined;
   cellularEnvironmentVote?: CellularEnvironmentVote | undefined;
   accelerometerPattern?: AccelerometerPattern | undefined;
+  /**
+   * #2099 — trip 활성 중 barometer가 최근 subsurface=true를 확정한 적이 있으면 true.
+   * `cellularEnvironmentVote === 'surface-weak-nrnsa'`일 때 채택 임계를 완화된
+   * `STATION_ACCEPT_THRESHOLD_SURFACE_WEAK_NRNSA`(1.3)조차 적용하지 않고 기본
+   * `STATION_ACCEPT_THRESHOLD`(1.1)로 무효화한다 (`selectAcceptThreshold` 참고).
+   */
+  barometerRecentSubsurface?: boolean | undefined;
 }
 
 /**
@@ -241,7 +249,10 @@ const EVALUATORS: ReadonlyArray<CategoryEvaluator> = [
  * 환경별 채택 임계 표 — 데이터 주도(CLAUDE.md §3): 신규 환경 분기는 표에 한 줄 추가.
  *
  * 매칭 우선순위 = 배열 순서. 첫 매칭 항목의 threshold 사용.
- *   - 'surface-weak' (LTE/NRNSA, #1876 D+A hybrid) → 1.6 (강한 multi-source 강제).
+ *   - 'surface-weak' (LTE, #1876 D+A hybrid) → 1.6 (강한 multi-source 강제).
+ *   - 'surface-weak-nrnsa' (NRNSA) + barometerRecentSubsurface=true (#2099 옵션 1) →
+ *     매칭 제외 → 기본 1.1로 완전 무효화 (barometer 확정을 cellular NRNSA가 뒤집지 못하게).
+ *   - 'surface-weak-nrnsa' (NRNSA, #2099 옵션 2) → 1.3 (LTE보다 완화된 축소).
  *   - 그 외 → 1.1 (기본 underground).
  */
 const THRESHOLD_BY_ENV: ReadonlyArray<{
@@ -251,6 +262,12 @@ const THRESHOLD_BY_ENV: ReadonlyArray<{
   {
     matches: (input) => input.cellularEnvironmentVote === 'surface-weak',
     threshold: STATION_ACCEPT_THRESHOLD_SURFACE_WEAK,
+  },
+  {
+    matches: (input) =>
+      input.cellularEnvironmentVote === 'surface-weak-nrnsa' &&
+      !input.barometerRecentSubsurface,
+    threshold: STATION_ACCEPT_THRESHOLD_SURFACE_WEAK_NRNSA,
   },
 ];
 

--- a/src/shared/constants/barometer.ts
+++ b/src/shared/constants/barometer.ts
@@ -139,3 +139,21 @@ export const BAROMETER_STOP_CONFIRM_SAMPLES = 3;
  *     평가되더라도 mismatch 트리거 X (false positive 차단).
  */
 export const BAROMETER_MISMATCH_QUORUM_READINGS = 30;
+
+/**
+ * #2099 (Part of #2093 E) — trip 활성 중 barometer subsurface=true "최근 확정" sticky 기억
+ * 윈도우.
+ *
+ * 단위: ms.
+ *
+ * 근거:
+ *   - barometer subsurface는 30s dP/dt 윈도우 기반 "지하 진입 edge" 감지 신호다 — 지하철이
+ *     진입 직후 짧게 true를 보고하고 steady 구간(터널 내 정속 주행)에서는 다시 false로
+ *     돌아간다. 7/7 trip 로그도 이 패턴과 일치(subsurface=true 13건, 나머지 다수는 false).
+ *   - steady 구간에서 cellular NRNSA soft downgrade가 undergroundSSOT quorum을 계속 깎으면
+ *     barometer가 이미 확정한 지하 판정이 매 폴링마다 뒤집힐 수 있다.
+ *   - 인접 역간 평균 운행시간은 60~150s(`BAROMETER_ETA_TOLERANCE_SEC` 근거 참고). 3분(180s)은
+ *     한 hop 전체를 포괄하고도 여유가 있어, 사용자가 실제로 지상으로 나온 뒤에도 과도하게
+ *     오래 "지하 sticky" 상태를 유지하지 않는 균형점.
+ */
+export const BAROMETER_RECENT_SUBSURFACE_STICKY_WINDOW_MS = 180_000;

--- a/src/shared/constants/fusion.ts
+++ b/src/shared/constants/fusion.ts
@@ -118,3 +118,29 @@ export const STATION_ACCEPT_THRESHOLD = 1.1;
  *   - radio 카테고리는 입력 자체가 `surface-weak`이므로 weightedVoteFusion에서 vote 미참여.
  */
 export const STATION_ACCEPT_THRESHOLD_SURFACE_WEAK = 1.6;
+
+/**
+ * Station 채택 임계 (`'surface-weak-nrnsa'` cellular = NRNSA, #2099).
+ *
+ * 배경 (Part of #2093 E): 7/7 trip 로그 — 서울 지하철 전 구간이 NRNSA로 중계되며 barometer가
+ * 정확히 지하를 확정한 구간에서도 NRNSA가 LTE와 동일한 임계(1.6)로 station 채택을 과도하게
+ * 억제해 environment가 surface로 최종 오분류(89.9%)됐다.
+ *
+ * `STATION_ACCEPT_THRESHOLD`(1.1) < 본 값(1.3) < `STATION_ACCEPT_THRESHOLD_SURFACE_WEAK`(1.6):
+ *   - NRNSA는 서울 지하철 구조상 지하에서도 100% 중계되므로 surface 신호로서의 정보가치가
+ *     LTE보다 낮다 — 임계를 완화(1.6→1.3)해 "축소"(#2099 옵션 2) 적용.
+ *   - trip 활성 중 barometer가 최근 subsurface=true를 확정한 경우(`barometerRecentSubsurface`)는
+ *     본 임계조차 적용하지 않고 기본 `STATION_ACCEPT_THRESHOLD`(1.1)로 완전 무효화한다
+ *     (#2099 옵션 1 — 매칭 순서는 `weightedVoteFusion.ts`의 `THRESHOLD_BY_ENV` 참고).
+ */
+export const STATION_ACCEPT_THRESHOLD_SURFACE_WEAK_NRNSA = 1.3;
+
+/**
+ * `undergroundSSOTConsensus` envVotes 페널티 (`'surface-weak-nrnsa'` cellular = NRNSA, #2099).
+ *
+ * `'surface-weak'`(LTE)는 envVotes −1 (#1876). NRNSA는 서울 지하철 전 구간 중계 구조상 surface
+ * 신호로서의 정보가치가 LTE보다 낮으므로 페널티를 절반으로 축소한다 — "정보가 아니다" 원칙과
+ * 완전 무효화(0) 사이의 절충. trip 활성 중 barometer가 최근 subsurface=true를 확정했으면
+ * 본 페널티 자체를 0으로 무효화한다 (`barometerRecentSubsurface`, undergroundSSotConsensus.ts).
+ */
+export const SURFACE_WEAK_NRNSA_ENV_VOTE_PENALTY = -0.5;


### PR DESCRIPTION
Closes #2099

## 배경 (Part of #2093, 옵션 1+2)

7/7 trip 로그: barometer는 지하 구간에서 `sub=true` 13건으로 정확했으나, cellular가 전 구간 NRNSA 상태로 undergroundSSOT quorum을 깎아 최종 Environment Distribution이 surface 89.9% / underground 0.0%로 오분류됐다.

## 환경 투표/합성 지점 audit (구현 전 코드 추적 결과)

- `src/features/nearest-station/hooks/useFusedNearestStation.ts:1144` — `cascadeSurfaceSSOT = surfaceSSOTConsensus(...)` (GPS+Arrival, cellular 미관여)
- `src/features/nearest-station/hooks/useFusedNearestStation.ts:1158` — `cascadeUndergroundSSOT = undergroundSSOTConsensus(...)` — **cellular NRNSA가 실제로 투표를 약화시키는 지점**
- `src/features/nearest-station/hooks/useFusedNearestStation.ts:1183` — `cascadeEnvironmentResult = inferEnvironment(...)` — 최종 판정 호출부(우선순위 1~8 구조 **미접촉**)
- `src/features/nearest-station/utils/inferEnvironment.ts` — 우선순위 1~9 판정 로직. **본 PR에서 0줄 변경**
- `src/features/nearest-station/utils/undergroundSSotConsensus.ts:187-193` — `envVotes` 누적 지점 (cellular surface-weak/-nrnsa 페널티가 실제로 적용되는 곳)
- `src/features/nearest-station/utils/weightedVoteFusion.ts:258-271` — quorum 미달 시 fallback 채택 임계 표 (`THRESHOLD_BY_ENV`)
- `src/features/nearest-station/utils/cellularTech.ts:162-168` — cellular 신호 소스, radio tech → vote 분류

## 수정 내용

1. **[옵션 2] NRNSA를 LTE와 분리 재분류**: `cellularTech.ts`에서 `NRNSA`를 기존 `'surface-weak'`(LTE와 동일 취급)에서 신규 `'surface-weak-nrnsa'`로 분리. 서울 지하철 전 구간이 NRNSA로 중계되는 구조적 사실을 반영해 LTE보다 약한 페널티 적용:
   - `undergroundSSotConsensus.ts` envVotes 페널티: LTE `-1` → NRNSA `-0.5`(`SURFACE_WEAK_NRNSA_ENV_VOTE_PENALTY`)
   - `weightedVoteFusion.ts` fallback 채택 임계: LTE `1.6` → NRNSA `1.3`(`STATION_ACCEPT_THRESHOLD_SURFACE_WEAK_NRNSA`)
2. **[옵션 1] trip 중 barometer 우선 가중**: `useFusedNearestStation.ts`에 trip 스코프 sticky ref(`barometerRecentSubsurfaceAtRef`)를 추가 — barometer가 trip 활성 중 `subsurface===true`를 관측하면 3분(`BAROMETER_RECENT_SUBSURFACE_STICKY_WINDOW_MS`) 동안 "최근 지하 확정" 기억을 유지. 이 sticky가 true면 NRNSA 페널티를 완전히 0으로 무효화(primary path envVotes, fallback threshold 둘 다) — barometer의 지하 확정을 cellular NRNSA surface 투표가 뒤집지 못하게 한다.
   - barometer/미지원 기기(subsurface 항상 undefined)는 sticky가 절대 set되지 않으므로 기존 로직 그대로 fallback 보존.
3. `inferEnvironment.ts`는 **0줄 변경** — 우선순위 1~8 구조는 그대로 두고, 그 판정 입력값(`surfaceSSOT`/`undergroundSSOT` boolean)을 만드는 상류 vote 함수만 가중치를 조정.

## 하지 말 것 준수

- `inferEnvironment.ts` 우선순위 1~8 구조 변경 없음 (git diff 0줄)
- barometer/GPS 품질 게이트(#2080·#2076) 로직 미접촉
- 알림/알람 경로(`useBoardingLockController.ts`, `positionUpload.ts` 등) 미접촉 — `CellularEnvironmentVote` 유니온에 새 값이 추가됐지만 두 파일 모두 exhaustive switch가 없어 타입 에러 없이 pass-through 유지 (기능 변경 0)
- `useNearestStation.ts` 미접촉 (#2100과의 병렬 작업 충돌 회피)

## 테스트 (coverage 100%)

- `cellularTech.test.ts` — NRNSA가 `'surface-weak-nrnsa'`로 분리 분류됨을 검증
- `undergroundSSotConsensus.test.ts` — 7/7 재현 시나리오(barometer sub=true 확정 + cellular NRNSA → underground 판정), barometer 미확정 시 회귀 없음, trip 비활성 시 가중 미적용, LTE 스코프 경계(NRNSA 전용 회귀 방지)
- `weightedVoteFusion.test.ts` — NRNSA 임계 1.3 완화 + barometerRecentSubsurface에 의한 1.1 무효화
- `inferEnvironment.callers.test.ts` — hook 레벨 통합 테스트로 tripActive 경로 sticky ref 갱신 회귀 없음 확인

## Wire 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard** — DebugModal Environment Distribution + `cellular: cellularForDump`(tech+vote) 덤프에 신규 `'surface-weak-nrnsa'` 값이 자동 노출. env reject 로그(`candidateRejectBuffer`)도 기존 채널 그대로.
3. **의존 PR** — N/A (device/backend 변경 없음, 순수 device-side 로직)
4. **측정 plan** — 다음 실기기 지하 trip에서 DebugModal Environment Distribution의 underground % 상승 + `surface-weak-nrnsa` vote 발생 시 environment 판정 유지 여부 확인. env-reject 스팸(44건/2Hz 수준) 감소 여부 로그로 확인.
5. **Device verify** — 필요. 지하 구간 실기기 trip에서 barometer subsurface 확정 후 environment가 steady 구간에서도 underground로 유지되는지, NRNSA 상태에서 subsurface flag 플래핑이 줄었는지 확인.

## 검증

- `npm test` — 428 suites / 9134 tests pass, coverage 100%
- `npm run type-check` — pass
- `npm run lint:orphan` — pass (0 orphan)


---

## 리뷰 반영 (2026-07-31)

PR 리뷰에서 지적된 3건을 같은 브랜치에 수정 커밋으로 반영:

**P2-1 (sticky 지상 리셋 강화)**: `barometerRecentSubsurfaceAtRef` sticky를 `cascadeSurfaceSSOT` 활성(GPS accuracy≤30m + arrival 정착 매칭 2-signal 합의 = 진짜 지상 증거) 시 즉시 소거하는 effect를 `useFusedNearestStation.ts`에 추가. `subsurface===false` 단독으로는 소거하지 않는다 — steady 지하 구간에서 barometer edge-detector가 false로 돌아가는 것은 정상 동작이라 이를 소거 트리거로 쓰면 원 버그(steady 구간마다 sticky가 사라져 NRNSA가 다시 이김)가 재발한다. 지하→지상 복귀 시 sticky 잔존 창이 기존 3분 타임아웃 대기에서 surfaceSSOT 활성 시점으로 축소됨.

**P2-2 (tautology 테스트 교체)**: 기존 `inferEnvironment.callers.test.ts`의 `subsurface: true` 재현 테스트는 `inferEnvironment` 우선순위 1(subsurface===true 즉시 underground)로 short-circuit해 본 PR의 실제 수정(undergroundSSOTConsensus의 NRNSA 가중)을 전혀 검증하지 못했다. `subsurface: false`(steady-state) + `barometerRecentSubsurface` fresh(render1에서 subsurface=true 관측 후 3분 이내) + cellular `'surface-weak-nrnsa'` 조합이 undergroundSSOT 경로(우선순위 3)로 `environment==='underground'`를 유지함을 검증하는 hook 레벨 통합 테스트로 교체. (참고: 이 특정 조합은 옵션 2 단독 fallback 임계(1.3)로도 구제되는 경계 케이스라 sticky의 배타적 필요성 자체는 `undergroundSSotConsensus.test.ts`의 wifi+position 2-pair·추가 env vote 없는 단위 테스트에서 별도로 검증됨 — 테스트 내 주석에 명시)

**P3-1 (타입 drift 제거)**: `positionUpload.ts`의 `cellularEnvironmentVote` 손 복사 union(`'surface' | 'surface-weak' | 'underground' | 'unknown'`)을 `cellularTech.ts`의 `CellularEnvironmentVote` import로 교체. `positionTrainConsensus.ts` 도크스트링에 `'surface-weak-nrnsa'` 반영(판정 로직은 `=== 'surface'` 단독 매칭이라 변경 없음).

검증: `npm test` 428 suites / 9135 tests pass, coverage 100%. `npm run type-check` pass. `npm run lint:orphan` pass (0 orphan).
