### PR TITLE
fix(#1966): silentPushLocationGate maxAge 60s vs FG 15s 근거 doc 정합

### DIFF
--- a/src/features/alarm/utils/silentPushLocationGate.ts
+++ b/src/features/alarm/utils/silentPushLocationGate.ts
@@ -11,9 +11,13 @@ import {
 
 const logger = createLogger('SilentPushLocationGate');
 
-// 위치 캐시 신뢰 TTL — 초과 시 stale로 간주하고 보수적 skip.
-// silent push imminent 알림은 도착 직전이라 60초 이상 stale 캐시로 발사하면
-// 사용자가 이미 통과/이전 역에 있을 위험.
+// silent push 채널 전용 GPS cache stale 임계.
+// FG `useNearestStation` (MAX_LOCATION_AGE_MS=15s, src/shared/constants/location.ts)보다
+// longer threshold(60s) 채택 사유 (#1966):
+// - BG silent push 도달 시 OS BG task scheduling 지연 가능 (fresh GPS 시도 자체가 어려움).
+// - silent push 분기 판정(sleep mode, station-passed 게이트)은 FG 대비 정확도 요구치가 낮음.
+// 단, 60초 이상 stale 캐시로 발사하면 사용자가 이미 통과/이전 역에 있을 위험이 있어
+// 초과 시에는 stale로 간주하고 보수적으로 skip한다.
 export const LOCATION_CACHE_TTL_MS = 60_000;
 
 // 콜드 GPS fetch 타임아웃 — BG 깨움 시 OS가 즉답 못 하면 보수적 skip.


### PR DESCRIPTION
## 요약

`silentPushLocationGate.ts:17`의 `LOCATION_CACHE_TTL_MS`(60s)와 `useNearestStation.ts:463`의 `MAX_LOCATION_AGE_MS`(15s)가 동일한 OS API(`getLastKnownPositionAsync`의 `maxAge`)를 서로 다른 임계로 사용하는 데 대해, 이슈 #1966이 제시한 3옵션(A: 15s 통일 / B: 60s 유지+doc / C: 상수 분리) 중 **이슈 본문이 명시적으로 권장한 옵션 B**를 채택했다.

## 판단 근거

- 이슈 본문 "옵션 평가" 섹션이 B를 권장하며 정확한 fix 위치(`silentPushLocationGate.ts:17`)와 목표 주석 문구를 코드 블록으로 명시 — 이는 "명확한 결정"에 해당하므로 이를 그대로 따름.
- 값 자체는 이미 의도된 차이(BG silent push는 OS 스케줄링 지연으로 fresh GPS 시도가 어렵고, sleep mode/station-passed 분기의 정확도 요구치가 FG 대비 낮음)이므로 값 변경(옵션 A) 또는 상수 분리(옵션 C)는 불필요 — doc만으로 두 caller의 의도 차이가 명확해짐.
- `MAX_LOCATION_AGE_MS`(`src/shared/constants/location.ts`)를 옮기거나 새 상수를 만들지 않음 — surgical change 원칙 + 이슈가 지정한 fix 위치를 벗어나지 않기 위함.

## 변경 사항

- `src/features/alarm/utils/silentPushLocationGate.ts`: `LOCATION_CACHE_TTL_MS` 주석을 확장 — FG `MAX_LOCATION_AGE_MS`(15s) 대비 60s를 채택한 이유(BG 스케줄링 지연 + 낮은 정확도 요구치) + stale 시 보수적 skip 정책을 명시.

Closes #1966

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan). 신규 export 없음 (주석만 변경).
2. **V/X dashboard** — N/A. 값 변경 없이 doc만 정리 — 관측 가능한 런타임 신호 변화 없음.
3. **의존 PR** — N/A.
4. **측정 plan** — N/A. 코드 동작 변화가 없는 doc-only 변경이라 회귀 측정 대상 없음.
5. **Device verify** — N/A — doc-only, type+unit only.

## 검증

- `npm test` — 428 suites / 9136 tests pass, coverage 100% (lines/branches/functions/statements)
- `npm run type-check` — pass
- `npm run lint:orphan` — 0 orphan