### PR TITLE
fix(#1963): widget tripContext 빌더 2개 분기 통합

### DIFF
--- a/src/features/widget/utils/__tests__/buildTripContext.test.ts
+++ b/src/features/widget/utils/__tests__/buildTripContext.test.ts
@@ -36,6 +36,45 @@ describe('buildWidgetTripContext (#1929 RC-15 widget tripContext wire helper)', 
     });
   });
 
+  describe('#1963 allowInactive 옵션 — silent push 채널 통합', () => {
+    it('allowInactive: true + destination null → tripActive: false stamp 반환', () => {
+      const result = buildWidgetTripContext({
+        destination: null,
+        currentStation: MOCK_STATIONS.gangnam,
+        allowInactive: true,
+      });
+      expect(result).toEqual({
+        currentStationName: '강남',
+        destinationName: '',
+        tripActive: false,
+      });
+    });
+
+    it('allowInactive: true + currentStation null → undefined 반환 (안전 가드 유지)', () => {
+      expect(
+        buildWidgetTripContext({
+          destination: null,
+          currentStation: null,
+          allowInactive: true,
+        }),
+      ).toBeUndefined();
+    });
+
+    it('allowInactive: true + destination 존재 → 기존 활성 분기와 동일 (영향 없음)', () => {
+      const result = buildWidgetTripContext({
+        destination: MOCK_STATIONS.chungmuro,
+        currentStation: MOCK_STATIONS.gangnam,
+        allowInactive: true,
+      });
+      expect(result).toEqual({
+        currentStationName: '강남',
+        destinationName: '충무로',
+        nextTransferName: undefined,
+        tripActive: true,
+      });
+    });
+  });
+
   describe('활성 분기 — trip 활성 + tripActive: true stamp', () => {
     it('route undefined: nextTransferName undefined로 stamp', () => {
       const result = buildWidgetTripContext({

--- a/src/features/widget/utils/__tests__/updateWidgetFromSilentPush.test.ts
+++ b/src/features/widget/utils/__tests__/updateWidgetFromSilentPush.test.ts
@@ -146,11 +146,11 @@ describe('updateWidgetFromSilentPush', () => {
       );
     });
 
-    it('direct route + destination → nextTransferName 미포함 (직통)', async () => {
+    it('direct route + destination → nextTransferName undefined (직통)', async () => {
       await updateWidgetFromSilentPush(ssot, bgContext, destination, directRoute, 1);
       const call = mockSaveStationToWidget.mock.calls[0];
       const tripContext = call[4];
-      expect(tripContext).not.toHaveProperty('nextTransferName');
+      expect(tripContext.nextTransferName).toBeUndefined();
       expect(tripContext.tripActive).toBe(true);
     });
 
@@ -176,10 +176,10 @@ describe('updateWidgetFromSilentPush', () => {
       });
     });
 
-    it('route null + destination 있음 → nextTransferName 미포함', async () => {
+    it('route null + destination 있음 → nextTransferName undefined', async () => {
       await updateWidgetFromSilentPush(ssot, bgContext, destination, null, 1);
       const call = mockSaveStationToWidget.mock.calls[0];
-      expect(call[4]).not.toHaveProperty('nextTransferName');
+      expect(call[4].nextTransferName).toBeUndefined();
       expect(call[4].tripActive).toBe(true);
     });
   });
@@ -208,5 +208,59 @@ describe('updateWidgetFromSilentPush', () => {
       updateWidgetFromSilentPush(ssot, bgContext, destination, directRoute, 1),
     ).resolves.toBeUndefined();
     expect(mockSaveStationToWidget).not.toHaveBeenCalled();
+  });
+
+  describe('#1963 통합 전후 byte-level 동등성 (buildWidgetTripContext allowInactive 전환)', () => {
+    /**
+     * PR #1945 시점 인라인 `buildTripContext`가 실제로 산출하던 값을 golden fixture로 고정.
+     * `JSON.stringify` 비교로 undefined-키 생략 여부와 무관하게 wire 상 전달되는 payload가
+     * 통합 전후 byte-level 동일함을 증명한다 (diff 0).
+     */
+    const goldenByRoute: Array<[string, Route, Record<string, unknown>]> = [
+      [
+        'direct',
+        directRoute,
+        { currentStationName: '역삼', destinationName: '잠실', tripActive: true },
+      ],
+      [
+        'transfer',
+        transferRoute,
+        {
+          currentStationName: '역삼',
+          destinationName: '잠실',
+          nextTransferName: '건대입구',
+          tripActive: true,
+        },
+      ],
+      [
+        'multi-transfer',
+        multiTransferRoute,
+        {
+          currentStationName: '역삼',
+          destinationName: '잠실',
+          nextTransferName: '왕십리',
+          tripActive: true,
+        },
+      ],
+      [
+        'null route',
+        null,
+        { currentStationName: '역삼', destinationName: '잠실', tripActive: true },
+      ],
+    ];
+
+    it.each(goldenByRoute)('%s route → JSON.stringify diff 0', async (_label, route, golden) => {
+      await updateWidgetFromSilentPush(ssot, bgContext, destination, route, 1);
+      const tripContext = mockSaveStationToWidget.mock.calls[0][4];
+      expect(JSON.stringify(tripContext)).toBe(JSON.stringify(golden));
+    });
+
+    it('destination null (비활성) → JSON.stringify diff 0', async () => {
+      await updateWidgetFromSilentPush(ssot, bgContext, null, directRoute, 1);
+      const tripContext = mockSaveStationToWidget.mock.calls[0][4];
+      expect(JSON.stringify(tripContext)).toBe(
+        JSON.stringify({ currentStationName: '역삼', destinationName: '', tripActive: false }),
+      );
+    });
   });
 });

--- a/src/features/widget/utils/buildTripContext.ts
+++ b/src/features/widget/utils/buildTripContext.ts
@@ -35,6 +35,17 @@ export interface BuildTripContextArgs {
    * null/undefined 또는 direct 타입이면 `nextTransferName` undefined.
    */
   route?: Route | null;
+  /**
+   * #1963 — destination null일 때 undefined 대신 `tripActive: false` stamp를 반환할지 여부.
+   *
+   * default false — 기존 4 호출자(useWidgetMirror / AppState force / backgroundLocationTask /
+   * notificationRouter)는 destination null 시 undefined를 그대로 5th arg에 forward하는 계약을
+   * 유지해야 하므로 옵트인 없이는 동작 변경이 없다.
+   *
+   * true면 silent push 채널(`updateWidgetFromSilentPush`)처럼 destination 없이도 위젯이
+   * nearest-station 모드로 fallback할 수 있도록 명시적 비활성 stamp를 반환한다.
+   */
+  allowInactive?: boolean;
 }
 
 /**
@@ -51,8 +62,16 @@ function extractNextTransferName(route: Route | null | undefined): string | unde
 export function buildWidgetTripContext(
   args: BuildTripContextArgs,
 ): WidgetTripContext | undefined {
-  const { destination, currentStation, route } = args;
-  if (!destination || !currentStation) return undefined;
+  const { destination, currentStation, route, allowInactive = false } = args;
+  if (!currentStation) return undefined;
+  if (!destination) {
+    if (!allowInactive) return undefined;
+    return {
+      currentStationName: currentStation.name,
+      destinationName: '',
+      tripActive: false,
+    };
+  }
   return {
     currentStationName: currentStation.name,
     destinationName: destination.name,

--- a/src/features/widget/utils/updateWidgetFromSilentPush.ts
+++ b/src/features/widget/utils/updateWidgetFromSilentPush.ts
@@ -15,11 +15,11 @@
  */
 
 import type { Route } from '../../../shared/utils/stationRoute';
-import { getFirstLeg } from '../../../shared/utils/stationRoute';
 import type { Station } from '../../../shared/types/station';
 import type { BgLastStationContext, SsotStationInput } from '../../../shared/types/widgetRefresh';
 import { createLogger } from '../../../shared/utils/logger';
-import { saveStationToWidget, type WidgetTripContext } from '../api/widgetStorage';
+import { saveStationToWidget } from '../api/widgetStorage';
+import { buildWidgetTripContext } from './buildTripContext';
 import { lookupStationFromSsot } from './lookupStationFromSsot';
 
 const logger = createLogger('SilentPushWidget');
@@ -50,7 +50,12 @@ export async function updateWidgetFromSilentPush(
       logger.info('skip: station resolve failed (no SSoT, no BG context)');
       return;
     }
-    const tripContext = buildTripContext(resolved.station, destination, route);
+    const tripContext = buildWidgetTripContext({
+      destination,
+      currentStation: resolved.station,
+      route,
+      allowInactive: true,
+    });
     await saveStationToWidget(
       resolved.station,
       resolved.distanceKm,
@@ -58,53 +63,9 @@ export async function updateWidgetFromSilentPush(
       { force: true },
       tripContext,
     );
-    logger.info(`widget updated: ${resolved.station.name} (tripActive=${tripContext.tripActive})`);
+    // resolved.station은 항상 존재(Station) → currentStation null 분기로 undefined가 반환될 수 없다.
+    logger.info(`widget updated: ${resolved.station.name} (tripActive=${tripContext?.tripActive})`);
   } catch (e) {
     logger.warn('update failed:', e);
   }
-}
-
-/**
- * tripContext shape (#1781) — destination 부재 시 tripActive=false로 stamp.
- *
- * `nextTransferName`:
- *  - direct route → undefined (직통)
- *  - transfer / multi-transfer → 첫 환승역 이름 (`getFirstLeg`로 일관 추출)
- *
- * route helper(`getFirstLeg`)를 재사용해 route 형태별 분기를 본 모듈에서 반복하지 않는다
- * (글로벌 룰 3 — 확장성/재사용성).
- */
-function buildTripContext(
-  currentStation: Station,
-  destination: Station | null,
-  route: Route,
-): WidgetTripContext {
-  if (!destination) {
-    return {
-      currentStationName: currentStation.name,
-      destinationName: '',
-      tripActive: false,
-    };
-  }
-  const nextTransferName = resolveNextTransferName(route, destination.name);
-  return {
-    currentStationName: currentStation.name,
-    destinationName: destination.name,
-    ...(nextTransferName !== undefined ? { nextTransferName } : {}),
-    tripActive: true,
-  };
-}
-
-/**
- * direct route → undefined (직통, 환승 없음).
- * transfer / multi-transfer → 첫 환승역 이름.
- *
- * route null도 undefined (환승 정보 없음 → 위젯이 직통 표시).
- */
-function resolveNextTransferName(route: Route, destinationName: string): string | undefined {
-  if (!route) return undefined;
-  const firstLeg = getFirstLeg(route, destinationName);
-  // direct route는 endName이 destinationName 자체 → 환승 아님. undefined로 신호.
-  if (route.type === 'direct') return undefined;
-  return firstLeg.endName;
 }


### PR DESCRIPTION
Closes #1963

## 요약

`buildWidgetTripContext` (PR #1944)와 `updateWidgetFromSilentPush`의 인라인 `buildTripContext` (PR #1945)가 동일 의미(nextTransferName 추출)를 다른 구현으로 중복 보유하던 문제를 `allowInactive` 옵션으로 단일화.

- `buildWidgetTripContext`에 `allowInactive?: boolean` 옵션 추가 (default `false` — 기존 4 호출자 useWidgetMirror / AppState force / backgroundLocationTask / notificationRouter는 동작 변경 없음)
- `allowInactive: true` + `destination` null → `{ currentStationName, destinationName: '', tripActive: false }` stamp 반환
- `updateWidgetFromSilentPush.ts`의 인라인 `buildTripContext`/`resolveNextTransferName` 제거, `buildWidgetTripContext({ ..., allowInactive: true })` 호출로 일원화 (`getFirstLeg` import 제거)

## 통합 전후 동등성 검증

`updateWidgetFromSilentPush.test.ts`에 신규 `describe('#1963 통합 전후 byte-level 동등성')` 블록 추가 — PR #1945 인라인 구현이 실제로 산출하던 값을 golden fixture로 고정하고, 통합 후 `JSON.stringify(tripContext)` 결과가 byte-level로 동일함을 direct/transfer/multi-transfer/null-route/destination-null 5개 시나리오에서 검증 (diff 0).

## 검증

- `npm test` — 428 suites / 9144 tests pass, coverage 100% (lines/functions/branches/statements)
- `npm run type-check` — pass
- `npm run lint:orphan` — No orphan exports detected (신규 caller: `buildWidgetTripContext` 5th caller로 `updateWidgetFromSilentPush`)

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass. `buildWidgetTripContext` caller 4개 + 신규 caller 1개(`updateWidgetFromSilentPush`) = 5.
2. **V/X dashboard** — N/A (refactor only, 신호 변경 없음)
3. **의존 PR** — #1944, #1945 (모두 머지됨)
4. **측정 plan** — N/A — refactor only, 사용자 관측 가능 신호 변경 없음
5. **Device verify** — N/A — type+unit only

## 이슈 스펙 대비 이탈

없음 — 이슈 본문 `fix 위치` 섹션의 구현을 그대로 적용. 추가로 기존 `updateWidgetFromSilentPush.test.ts`의 `not.toHaveProperty('nextTransferName')` strict assertion 2건을 `toBeUndefined()`로 조정(통합 후 unified 구현은 항상 `nextTransferName` 키를 포함하되 값이 `undefined`이며, `saveStationToWidget` 5th arg 전달 시 JSON 직렬화 결과는 기존과 byte-level 동일함을 위 golden fixture 테스트로 증명).