### PR TITLE
test(#1964): F2 defense + LA backstop lockMissing 통합 시나리오 test

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -4441,6 +4441,135 @@ describe('runScheduled — boarding-prompt 9단 게이트 (#819)', () => {
       });
     });
   });
+
+  // #1964 (Cl-5) — PR #1941(F2 defense) + PR #1946(LA backstop)이 같은 lockMissing 분기
+  // 진입점을 mutate. 이슈 원문은 "F2가 lockMissing을 즉시 return해 LA backstop을 막는다"고
+  // 가정했으나, 현재 dev 코드(scheduled.ts:1157~1180)는 lockMissing 분기 진입 시 LA backstop을
+  // 먼저 평가하고(#1946), 그 continue를 통과해야만 `evaluateAndMaybeFireBoardingPrompt`가
+  // 호출돼 F2(#1941)가 평가된다 — 즉 LA backstop이 항상 F2보다 먼저 평가되는 순서.
+  // 본 describe는 이 실제 우선순위를 SSoT로 고정하고, 두 stat이 1 cycle에서 동시 증가하지
+  // 않음을 검증한다.
+  describe('#1964 (Cl-5) — lockMissing 통합: LA backstop vs F2 defense 우선순위', () => {
+    const CL5_ARRIVAL: ArrivalEntry = {
+      destination: '성수',
+      arrivalSeconds: 60,
+      trainCode: 'T1',
+      isUp: true,
+      subwayNm: '2호선',
+      arvlCd: 2,
+    };
+
+    function expiredLock(overrides: Partial<BoardingLockMeta> = {}): BoardingLockMeta {
+      return {
+        trainCode: 'T-expired',
+        line: '2',
+        subwayId: '1002',
+        selectedDepartureTime: NOW - 60_000,
+        segmentStations: ['역삼', '강남'],
+        expiresAt: NOW - 1, // 만료 → isBoardingLockActive=false, lockMissing 분기 진입
+        ...overrides,
+      };
+    }
+
+    it('case 1: boardingLock 존재(만료) + lastLaPushAt 6분 침묵 → LA backstop 우선 발동, F2 미평가', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeUnlockedTrip({
+          boardingLock: expiredLock(),
+          lastLaPushAt: NOW - 6 * 60_000,
+        }),
+      );
+      await seedHappySeries(kv);
+      const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+      const deps = makeBoardingPromptDeps(fetchImpl, makeSeoul([CL5_ARRIVAL]));
+
+      const stats = await runScheduled(makeEnv(kv), deps);
+
+      expect(stats.laStaleAutoEnded).toBe(1);
+      // LA backstop이 continue로 cycle을 종료 — evaluateAndMaybeFireBoardingPrompt 자체가
+      // 호출되지 않으므로 F2 defense도 평가되지 않는다.
+      expect(stats.boardingPromptSkippedLockActive).toBe(0);
+      expect(stats.boardingPromptEvaluated).toBe(0);
+    });
+
+    it('case 2: boardingLock 존재(만료) + lastLaPushAt 4분(비침묵) → LA backstop 미발동, F2 발동', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeUnlockedTrip({
+          boardingLock: expiredLock(),
+          lastLaPushAt: NOW - 4 * 60_000,
+        }),
+      );
+      await seedHappySeries(kv);
+      const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+      const deps = makeBoardingPromptDeps(fetchImpl, makeSeoul([CL5_ARRIVAL]));
+
+      const stats = await runScheduled(makeEnv(kv), deps);
+
+      expect(stats.laStaleAutoEnded).toBe(0);
+      expect(stats.boardingPromptSkippedLockActive).toBe(1);
+      // F2가 evaluateAndMaybeFireBoardingPrompt 진입 직후 즉시 return — 9단 게이트 미평가.
+      expect(stats.boardingPromptEvaluated).toBe(0);
+    });
+
+    it('case 3: boardingLock 완전 release(undefined) + lastLaPushAt 6분 침묵 → LA backstop 발동 (F2 무관)', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(
+        kv as unknown as KVNamespace,
+        makeUnlockedTrip({
+          lastLaPushAt: NOW - 6 * 60_000,
+        }),
+      );
+      await seedHappySeries(kv);
+      const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+      const deps = makeBoardingPromptDeps(fetchImpl, makeSeoul([CL5_ARRIVAL]));
+
+      const stats = await runScheduled(makeEnv(kv), deps);
+
+      expect(stats.laStaleAutoEnded).toBe(1);
+      expect(stats.boardingPromptSkippedLockActive).toBe(0);
+      expect(stats.boardingPromptEvaluated).toBe(0);
+    });
+
+    it('case 4: boardingLock 완전 release + lastLaPushAt 침묵 없음 → 두 분기 모두 미발동, 9단 게이트 진입/발사', async () => {
+      const kv = new InMemoryKV();
+      await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());
+      await seedHappySeries(kv);
+      const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+      const deps = makeBoardingPromptDeps(fetchImpl, makeSeoul([CL5_ARRIVAL]));
+
+      const stats = await runScheduled(makeEnv(kv), deps);
+
+      expect(stats.laStaleAutoEnded).toBe(0);
+      expect(stats.boardingPromptSkippedLockActive).toBe(0);
+      expect(stats.boardingPromptEvaluated).toBe(1);
+      expect(stats.boardingPromptFired).toBe(1);
+    });
+
+    it.each([
+      ['case1 (lock 만료 + LA 침묵)', { boardingLock: expiredLock(), lastLaPushAt: NOW - 6 * 60_000 }],
+      ['case2 (lock 만료 + LA 비침묵)', { boardingLock: expiredLock(), lastLaPushAt: NOW - 4 * 60_000 }],
+      ['case3 (lock release + LA 침묵)', { lastLaPushAt: NOW - 6 * 60_000 }],
+      ['case4 (lock release + LA 비침묵)', {}],
+    ] as [string, Partial<Trip>][])(
+      '%s — laStaleAutoEnded / boardingPromptSkippedLockActive 동시 증가 0건 (acceptance #2)',
+      async (_label, overrides) => {
+        const kv = new InMemoryKV();
+        await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip(overrides));
+        await seedHappySeries(kv);
+        const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+        const deps = makeBoardingPromptDeps(fetchImpl, makeSeoul([CL5_ARRIVAL]));
+
+        const stats = await runScheduled(makeEnv(kv), deps);
+
+        const bothIncrementedSameCycle =
+          stats.laStaleAutoEnded > 0 && stats.boardingPromptSkippedLockActive > 0;
+        expect(bothIncrementedSameCycle).toBe(false);
+      },
+    );
+  });
 });
 
 /**


### PR DESCRIPTION
## 배경

Closes #1964

2026-06-28 Wave 1-4 audit (Cl-5). PR #1941 (F2 defense, `scheduled.ts` 내 `evaluateAndMaybeFireBoardingPrompt`)와 PR #1946 (LA backstop, `scheduled.ts` lockMissing 분기)이 같은 lockMissing 분기 진입점을 mutate한다. 두 PR이 상호작용하는 통합 시나리오 test가 부재했다.

## 발견 — 이슈 원문 가정과 현재 dev 동작 차이

이슈 원문은 "F2가 lockMissing 진입 시 즉시 return하여 LA backstop을 막는다"고 가정했다. 그러나 현재 dev 코드(`scheduled.ts:1157~1180`)를 실측한 결과 순서가 반대다:

1. `!isBoardingLockActive(trip, now)` → lockMissing 분기 진입 (lock 미존재 **또는** 만료 모두 해당).
2. 분기 진입 직후 **LA backstop이 먼저 평가**된다 (`trip.lastLaPushAt` 5분 침묵 검사) — `trip.boardingLock`이 정의돼 있는지 여부와 무관하게 평가.
3. LA backstop이 발동하면 `cleanupTripWithLa` + `continue` — 이 cycle에서 `evaluateAndMaybeFireBoardingPrompt` 자체가 호출되지 않으므로 **F2도 평가되지 않는다**.
4. LA backstop이 발동하지 않을 때만 `evaluateAndMaybeFireBoardingPrompt`가 호출되고, 그 내부에서 F2(`trip.boardingLock !== undefined` 체크)가 평가된다.

즉 F2와 LA backstop은 이슈가 우려한 "race"가 아니라 **결정적 순서(LA backstop → F2)**를 갖는 disjoint 분기다. 이슈가 6월 말 작성 시점 이후 재설계(ADR-024 등)로 주변 코드가 바뀌었을 가능성이 있어, 지시대로 이슈의 시나리오 *의도*(두 stat이 동시 발동하지 않는지 검증)만 유지하고 **현재 dev 실제 동작을 SSoT로 테스트를 작성**했다.

## 변경 사항 (test-only, 프로덕션 코드 무변경)

`backend/alarm-worker/src/__tests__/scheduled.test.ts`에 `#1964 (Cl-5) — lockMissing 통합: LA backstop vs F2 defense 우선순위` describe 블록 추가:

- case 1: lock 만료 + `lastLaPushAt` 6분 침묵 → LA backstop 발동(`laStaleAutoEnded` +1), F2 미평가(`boardingPromptSkippedLockActive` 0, `boardingPromptEvaluated` 0)
- case 2: lock 만료 + `lastLaPushAt` 4분(비침묵) → LA backstop 미발동, F2 발동(`boardingPromptSkippedLockActive` +1)
- case 3: lock 완전 release + `lastLaPushAt` 6분 침묵 → LA backstop 발동 (boardingLock 상태 무관 확인)
- case 4: lock 완전 release + `lastLaPushAt` 침묵 없음 → 두 분기 모두 미발동, 9단 게이트 진입/발사(`boardingPromptFired` 1)
- `it.each` 4케이스 전수: `laStaleAutoEnded`와 `boardingPromptSkippedLockActive`가 1 cron cycle에서 동시 증가하지 않음 검증 (acceptance #2)

## 검증

- `npm test` (backend/alarm-worker): 2696/2696 pass, coverage 유지 (scheduled.ts 94.83%/91.93%/98.24%/94.83% — 기존 baseline과 동일, 신규 케이스는 이미 커버된 라인만 재조합)
- `npm run type-check` (backend/alarm-worker): pass
- `npm run lint:orphan` (root): "No orphan exports detected."

## Wire-completion 5단

1. **Orphan 없음** — N/A (test only, 신규 export 없음). `npm run lint:orphan` pass 확인.
2. **V/X dashboard** — 변경 없음. 기존 `stats.boardingPromptSkippedLockActive` / `stats.laStaleAutoEnded`는 Cloudflare Dashboard에서 이미 관측 가능 (본 PR은 test 추가만).
3. **의존 PR** — #1941, #1946 (모두 머지됨). N/A for new deps.
4. **측정 plan** — N/A (test-only, production 신호 변경 없음). 회귀 가드는 CI 테스트 자체.
5. **Device verify** — N/A — backend test only.