### PR TITLE
feat(#1967): lockless intermediate 게이트 admin kill switch (Ff-1)

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.scheduledGate.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.scheduledGate.test.ts
@@ -120,3 +120,37 @@ describe('handler.scheduled — #2073 idle-skip 게이트', () => {
     expect(await readPushActivityRecent(kv as unknown as KVNamespace)).toBe(false);
   });
 });
+
+// #1967 (Ff-1) — admin kill switch KV 상태가 runScheduled deps로 forward되는지 배선 검증.
+describe('handler.scheduled — #1967 (Ff-1) kill switch forward', () => {
+  beforeEach(() => {
+    runScheduledMock.mockReset();
+    runFallbackPushesMock.mockReset();
+    runRetryPushesMock.mockReset();
+    runScheduledMock.mockResolvedValue(baseScheduledStats({ pendingActivityPossible: false }));
+  });
+
+  it('KV 미설정 → killSwitchLocklessIntermediate=false 로 forward (dormant)', async () => {
+    const kv = new InMemoryKV();
+    await handler.scheduled(makeScheduledController(), makeEnv(kv), makeExecutionContext());
+    const [, deps] = runScheduledMock.mock.calls[0] as [unknown, { killSwitchLocklessIntermediate: boolean }];
+    expect(deps.killSwitchLocklessIntermediate).toBe(false);
+  });
+
+  it("KV='true' → killSwitchLocklessIntermediate=true 로 forward", async () => {
+    const kv = new InMemoryKV();
+    await kv.put('kill-switch:lockless-intermediate', 'true');
+    await handler.scheduled(makeScheduledController(), makeEnv(kv), makeExecutionContext());
+    const [, deps] = runScheduledMock.mock.calls[0] as [unknown, { killSwitchLocklessIntermediate: boolean }];
+    expect(deps.killSwitchLocklessIntermediate).toBe(true);
+  });
+
+  it("KV='false' → killSwitchLocklessIntermediate=false 로 forward (rollback 확인)", async () => {
+    const kv = new InMemoryKV();
+    await kv.put('kill-switch:lockless-intermediate', 'true');
+    await kv.put('kill-switch:lockless-intermediate', 'false');
+    await handler.scheduled(makeScheduledController(), makeEnv(kv), makeExecutionContext());
+    const [, deps] = runScheduledMock.mock.calls[0] as [unknown, { killSwitchLocklessIntermediate: boolean }];
+    expect(deps.killSwitchLocklessIntermediate).toBe(false);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -4850,3 +4850,191 @@ describe('GET/POST /admin/arch-flag (#1982)', () => {
     });
   });
 });
+
+// #1967 (Ff-1) — lockless intermediate 게이트 admin kill switch endpoints.
+describe('GET/POST /admin/kill-switch (#1967 Ff-1)', () => {
+  async function getSwitch(
+    env: Env,
+    key: string | undefined,
+    authHeader?: string,
+  ): Promise<Response> {
+    const url = key
+      ? `http://example.com/admin/kill-switch?key=${encodeURIComponent(key)}`
+      : 'http://example.com/admin/kill-switch';
+    return app.fetch(
+      new Request(url, {
+        method: 'GET',
+        headers: authHeader ? { authorization: authHeader } : {},
+      }),
+      env,
+    );
+  }
+
+  async function postSwitch(
+    env: Env,
+    key: string | undefined,
+    body: unknown,
+    authHeader?: string,
+    { rawBody }: { rawBody?: string } = {},
+  ): Promise<Response> {
+    const url = key
+      ? `http://example.com/admin/kill-switch?key=${encodeURIComponent(key)}`
+      : 'http://example.com/admin/kill-switch';
+    return app.fetch(
+      new Request(url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          ...(authHeader ? { authorization: authHeader } : {}),
+        },
+        body: rawBody ?? JSON.stringify(body),
+      }),
+      env,
+    );
+  }
+
+  function makeAuthEnv(): Env {
+    return makeEnv({ TRIPS: new InMemoryKV() as unknown as Env['TRIPS'], ADMIN_TOKEN: 'secret' });
+  }
+
+  describe('GET', () => {
+    it('returns 503 when ADMIN_TOKEN not configured', async () => {
+      const env = makeKvEnv();
+      const res = await getSwitch(env, 'lockless_intermediate', 'Bearer x');
+      expect(res.status).toBe(503);
+      expect(await res.json()).toEqual({ error: 'admin_unavailable' });
+    });
+
+    it('returns 401 without bearer header', async () => {
+      const env = makeAuthEnv();
+      const res = await getSwitch(env, 'lockless_intermediate');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 with wrong token', async () => {
+      const env = makeAuthEnv();
+      const res = await getSwitch(env, 'lockless_intermediate', 'Bearer wrong');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 400 when key is missing', async () => {
+      const env = makeAuthEnv();
+      const res = await getSwitch(env, undefined, 'Bearer secret');
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'invalid_key' });
+    });
+
+    it('returns 400 when key is unsupported', async () => {
+      const env = makeAuthEnv();
+      const res = await getSwitch(env, 'unknown_gate', 'Bearer secret');
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'invalid_key' });
+    });
+
+    it('returns 503 when TRIPS binding unavailable', async () => {
+      const env = makeEnv({
+        ADMIN_TOKEN: 'secret',
+        TRIPS: undefined as unknown as Env['TRIPS'],
+      });
+      const res = await getSwitch(env, 'lockless_intermediate', 'Bearer secret');
+      expect(res.status).toBe(503);
+      expect(await res.json()).toEqual({ error: 'trips_unavailable' });
+    });
+
+    it('returns default (false) when key never set', async () => {
+      const env = makeAuthEnv();
+      const res = await getSwitch(env, 'lockless_intermediate', 'Bearer secret');
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ key: 'lockless_intermediate', value: 'false' });
+    });
+
+    it('reflects value previously written via POST', async () => {
+      const env = makeAuthEnv();
+      await postSwitch(env, 'lockless_intermediate', { value: 'true' }, 'Bearer secret');
+      const res = await getSwitch(env, 'lockless_intermediate', 'Bearer secret');
+      expect(await res.json()).toEqual({ key: 'lockless_intermediate', value: 'true' });
+    });
+  });
+
+  describe('POST', () => {
+    it('returns 503 when ADMIN_TOKEN not configured', async () => {
+      const env = makeKvEnv();
+      const res = await postSwitch(env, 'lockless_intermediate', { value: 'true' }, 'Bearer x');
+      expect(res.status).toBe(503);
+    });
+
+    it('returns 401 without bearer header', async () => {
+      const env = makeAuthEnv();
+      const res = await postSwitch(env, 'lockless_intermediate', { value: 'true' });
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 with wrong token', async () => {
+      const env = makeAuthEnv();
+      const res = await postSwitch(env, 'lockless_intermediate', { value: 'true' }, 'Bearer wrong');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 400 when key is missing', async () => {
+      const env = makeAuthEnv();
+      const res = await postSwitch(env, undefined, { value: 'true' }, 'Bearer secret');
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'invalid_key' });
+    });
+
+    it('returns 400 when key is unsupported', async () => {
+      const env = makeAuthEnv();
+      const res = await postSwitch(env, 'unknown_gate', { value: 'true' }, 'Bearer secret');
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'invalid_key' });
+    });
+
+    it('returns 503 when TRIPS binding unavailable', async () => {
+      const env = makeEnv({
+        ADMIN_TOKEN: 'secret',
+        TRIPS: undefined as unknown as Env['TRIPS'],
+      });
+      const res = await postSwitch(env, 'lockless_intermediate', { value: 'true' }, 'Bearer secret');
+      expect(res.status).toBe(503);
+    });
+
+    it('returns 400 when body is not JSON', async () => {
+      const env = makeAuthEnv();
+      const res = await postSwitch(env, 'lockless_intermediate', null, 'Bearer secret', {
+        rawBody: 'not-json',
+      });
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'invalid_body' });
+    });
+
+    it('returns 400 when body has no value field', async () => {
+      const env = makeAuthEnv();
+      const res = await postSwitch(env, 'lockless_intermediate', {}, 'Bearer secret');
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when value is invalid literal', async () => {
+      const env = makeAuthEnv();
+      const res = await postSwitch(env, 'lockless_intermediate', { value: 'on' }, 'Bearer secret');
+      expect(res.status).toBe(400);
+    });
+
+    it('accepts value=true and persists to KV', async () => {
+      const env = makeAuthEnv();
+      const res = await postSwitch(env, 'lockless_intermediate', { value: 'true' }, 'Bearer secret');
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ key: 'lockless_intermediate', value: 'true' });
+      const readBack = await getSwitch(env, 'lockless_intermediate', 'Bearer secret');
+      expect(await readBack.json()).toEqual({ key: 'lockless_intermediate', value: 'true' });
+    });
+
+    it('accepts value=false (rollback) and persists to KV', async () => {
+      const env = makeAuthEnv();
+      // 사전에 true 로 설정된 상태를 false 로 되돌리는 rollback 시나리오(회귀 대응 종료).
+      await postSwitch(env, 'lockless_intermediate', { value: 'true' }, 'Bearer secret');
+      const res = await postSwitch(env, 'lockless_intermediate', { value: 'false' }, 'Bearer secret');
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ key: 'lockless_intermediate', value: 'false' });
+    });
+  });
+});

--- a/backend/alarm-worker/src/__tests__/killSwitch.test.ts
+++ b/backend/alarm-worker/src/__tests__/killSwitch.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getKillSwitch,
+  isKillSwitchKey,
+  isKillSwitchValue,
+  KILL_SWITCH_DEFAULT,
+  setKillSwitch,
+} from '../killSwitch';
+import { InMemoryKV } from './inMemoryKv';
+
+describe('killSwitch (#1967 Ff-1)', () => {
+  describe('isKillSwitchKey', () => {
+    it('accepts lockless_intermediate', () => {
+      expect(isKillSwitchKey('lockless_intermediate')).toBe(true);
+    });
+
+    it('rejects unknown keys', () => {
+      expect(isKillSwitchKey('unknown_gate')).toBe(false);
+      expect(isKillSwitchKey('')).toBe(false);
+    });
+
+    it('rejects non-string values', () => {
+      expect(isKillSwitchKey(null)).toBe(false);
+      expect(isKillSwitchKey(undefined)).toBe(false);
+      expect(isKillSwitchKey(1)).toBe(false);
+      expect(isKillSwitchKey({})).toBe(false);
+    });
+  });
+
+  describe('isKillSwitchValue', () => {
+    it('accepts true / false strings', () => {
+      expect(isKillSwitchValue('true')).toBe(true);
+      expect(isKillSwitchValue('false')).toBe(true);
+    });
+
+    it('rejects other strings', () => {
+      expect(isKillSwitchValue('on')).toBe(false);
+      expect(isKillSwitchValue('TRUE')).toBe(false);
+      expect(isKillSwitchValue('')).toBe(false);
+    });
+
+    it('rejects non-string values', () => {
+      expect(isKillSwitchValue(null)).toBe(false);
+      expect(isKillSwitchValue(undefined)).toBe(false);
+      expect(isKillSwitchValue(true)).toBe(false);
+      expect(isKillSwitchValue({})).toBe(false);
+    });
+  });
+
+  describe('getKillSwitch', () => {
+    it('returns default when kv is undefined (개발 환경 호환)', async () => {
+      expect(await getKillSwitch(undefined, 'lockless_intermediate')).toBe(KILL_SWITCH_DEFAULT);
+    });
+
+    it('returns default when key is not set (dormant)', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      expect(await getKillSwitch(kv, 'lockless_intermediate')).toBe('false');
+    });
+
+    it('returns "true" when kv is set to true', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      await setKillSwitch(kv, 'lockless_intermediate', 'true');
+      expect(await getKillSwitch(kv, 'lockless_intermediate')).toBe('true');
+    });
+
+    it('returns "false" when kv is set to false', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      await setKillSwitch(kv, 'lockless_intermediate', 'true');
+      await setKillSwitch(kv, 'lockless_intermediate', 'false');
+      expect(await getKillSwitch(kv, 'lockless_intermediate')).toBe('false');
+    });
+
+    it('falls back to default when kv has invalid value (오타 방어)', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      await kv.put('kill-switch:lockless-intermediate', 'on');
+      expect(await getKillSwitch(kv, 'lockless_intermediate')).toBe(KILL_SWITCH_DEFAULT);
+    });
+
+    it('reads with cron cacheTtl convention (>= 30s) — invalid ttl would throw via KV mock', async () => {
+      // #1423 — InMemoryKV.get이 cacheTtl < 30을 throw. getKillSwitch가 정책값(30s)을 넘겨
+      // throw 없이 통과하는 것으로 컨벤션 준수를 검증한다.
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      await expect(getKillSwitch(kv, 'lockless_intermediate')).resolves.toBe('false');
+    });
+  });
+
+  describe('setKillSwitch', () => {
+    it('writes "true" to KV', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      await setKillSwitch(kv, 'lockless_intermediate', 'true');
+      expect(await kv.get('kill-switch:lockless-intermediate')).toBe('true');
+    });
+
+    it('writes "false" to KV', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      await setKillSwitch(kv, 'lockless_intermediate', 'true');
+      await setKillSwitch(kv, 'lockless_intermediate', 'false');
+      expect(await kv.get('kill-switch:lockless-intermediate')).toBe('false');
+    });
+
+    it('throws on invalid value (잘못된 KV 상태 진입 차단)', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      await expect(
+        setKillSwitch(kv, 'lockless_intermediate', 'on' as unknown as 'true'),
+      ).rejects.toThrow(/invalid value/);
+      expect(await kv.get('kill-switch:lockless-intermediate')).toBeNull();
+    });
+  });
+
+  describe('constants', () => {
+    it('default is false', () => {
+      expect(KILL_SWITCH_DEFAULT).toBe('false');
+    });
+  });
+});

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -145,7 +145,7 @@ function makeEstimateArrivalDeps(seoul: SeoulArrivalClient): ScheduledDeps {
 function makeFullEmptyStats(): ScheduledStats {
   return {
     scanned: 0, polled: 0, pushed: 0, errors: 0, etaMissing: 0, envCorrected: 0,
-    lockMissing: 0, laStaleAutoEnded: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
+    lockMissing: 0, laStaleAutoEnded: 0, killSwitchLocklessIntermediateSkipped: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
     laPushSent: 0, laPushFailed: 0, laTokenCleared: 0,
     boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
     phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
@@ -825,6 +825,65 @@ describe('runScheduled', () => {
         expect(apnsFetch).not.toHaveBeenCalled();
       }
       if (seoulCalled === false) expect(seoulFetch).not.toHaveBeenCalled();
+    });
+
+    // #1967 (Ff-1) — admin kill switch. 토글 ON + intermediate + arvlCd=1 (정상이면 발사)
+    // 조합이라도 kill switch가 활성이면 게이트 평가 자체를 건너뛰고 lockMissing 분기로 fall-through.
+    describe('#1967 (Ff-1) — admin kill switch', () => {
+      it('killSwitchLocklessIntermediate=true → 발사 0 + killSwitchLocklessIntermediateSkipped 카운트', async () => {
+        const kv = new InMemoryKV();
+        const trip = intermediateTrip();
+        await putTrip(kv as unknown as KVNamespace, trip);
+        await seedLocklessMotionSeries(kv, trip.token, 'automotive');
+        const apnsFetch = vi.fn(async () => new Response('', { status: 200 }) as unknown as Response);
+        const stats = await runScheduled(makeEnv(kv), {
+          seoul: makeSeoul([ARVL_ARRIVED]),
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW,
+          killSwitchLocklessIntermediate: true,
+        });
+        expect(stats.pushed).toBe(0);
+        expect(stats.locklessIntermediateFired).toBe(0);
+        expect(stats.killSwitchLocklessIntermediateSkipped).toBe(1);
+        // kill switch는 intermediate fire만 차단 — lockMissing 분기(boarding-prompt 평가 등)는
+        // 기존과 동일하게 fall-through 진행된다.
+        expect(stats.lockMissing).toBe(1);
+        expect(apnsFetch).not.toHaveBeenCalled();
+      });
+
+      it('killSwitchLocklessIntermediate=false → 정상 발사 (dormant 확인)', async () => {
+        const { stats, apnsFetch } = await runLocklessCycle({
+          trip: intermediateTrip(),
+          arrivals: [ARVL_ARRIVED],
+          apnsOk: true,
+        });
+        expect(stats.pushed).toBe(1);
+        expect(stats.locklessIntermediateFired).toBe(1);
+        expect(stats.killSwitchLocklessIntermediateSkipped).toBe(0);
+        expect(apnsFetch).toHaveBeenCalled();
+      });
+
+      it('killSwitchLocklessIntermediate 미전달(undefined) → 기존 동작 100% 유지 (dormant)', async () => {
+        const kv = new InMemoryKV();
+        const trip = intermediateTrip();
+        await putTrip(kv as unknown as KVNamespace, trip);
+        await seedLocklessMotionSeries(kv, trip.token, 'automotive');
+        const apnsFetch = vi.fn(async () => new Response('', { status: 200 }) as unknown as Response);
+        const stats = await runScheduled(makeEnv(kv), {
+          seoul: makeSeoul([ARVL_ARRIVED]),
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW,
+          // killSwitchLocklessIntermediate 미전달
+        });
+        expect(stats.pushed).toBe(1);
+        expect(stats.locklessIntermediateFired).toBe(1);
+        expect(stats.killSwitchLocklessIntermediateSkipped).toBe(0);
+        expect(apnsFetch).toHaveBeenCalled();
+      });
     });
 
     // Epic #1204 그룹 2 D3 (#1273)
@@ -9150,7 +9209,7 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
     if (opts.setupSsot) await opts.setupSsot(kv, trip);
     const stats: ScheduledStats = {
       scanned: 0, polled: 0, pushed: 0, errors: 0, etaMissing: 0, envCorrected: 0,
-      lockMissing: 0, laStaleAutoEnded: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
+      lockMissing: 0, laStaleAutoEnded: 0, killSwitchLocklessIntermediateSkipped: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
       laPushSent: 0, laPushFailed: 0, laTokenCleared: 0,
       boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
       phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -52,6 +52,13 @@ import {
   isArchFlagValue,
   setArchFlag,
 } from './archFlag';
+import {
+  getKillSwitch,
+  isKillSwitchKey,
+  isKillSwitchValue,
+  KILL_SWITCH_DEFAULT,
+  setKillSwitch,
+} from './killSwitch';
 import { appendPositionPoint } from './positionSeries';
 import { appendAccelSample, isAccelSummary } from './accelSeries';
 import { updateSsotMotion } from './motionState';
@@ -433,6 +440,68 @@ app.post('/admin/arch-flag', async (c) => {
   }
   await setArchFlag(kv, raw);
   return c.json({ value: raw });
+});
+
+/**
+ * #1967 (Ff-1) — 게이트 kill switch 조회 endpoint.
+ *
+ * 2026-06-28 Wave 1-4 audit: lockless intermediate 게이트가 kill switch 없이 머지돼
+ * device 측 false alarm 회귀가 감지돼도 backend deploy(10~30분) 없이는 즉시 차단 수단이
+ * 없었다. `archFlag` 와 동일한 KV read/write 어댑터 패턴 — `key` 쿼리로 대상 게이트 선택.
+ *
+ * Auth: `Authorization: Bearer <ADMIN_TOKEN>` — admin 공통 정책.
+ * Query: `key` — 현재 유효값은 `lockless_intermediate` 하나(#1967 스코프 = Ff-1).
+ * Response 200: `{ key, value: 'true' | 'false' }`
+ * Response 400: `{ error: 'invalid_key' }` — key 누락/미지원.
+ * Response 401/503: 인증/binding 정책 동일 (TRIPS 미바인딩 시 503).
+ */
+app.get('/admin/kill-switch', async (c) => {
+  const authError = checkAdminAuth(c.req.header('authorization'), c.env.ADMIN_TOKEN);
+  if (authError) return c.json({ error: authError.code }, authError.status);
+  const key = c.req.query('key');
+  if (!isKillSwitchKey(key)) {
+    return c.json({ error: 'invalid_key' }, 400);
+  }
+  const kv = c.env.TRIPS;
+  if (!kv) return c.json({ error: 'trips_unavailable' }, 503);
+  const value = await getKillSwitch(kv, key);
+  return c.json({ key, value });
+});
+
+/**
+ * #1967 (Ff-1) — 게이트 kill switch 설정 endpoint.
+ *
+ * Rollback 채널: `true` 상태에서 회귀 대응이 끝나면 `false` write 만으로 즉시 게이트를
+ * 되살린다(배포 없음). 유효 값은 `true` / `false` 만. 그 외 body 는 400 으로 거절.
+ *
+ * Auth: `Authorization: Bearer <ADMIN_TOKEN>` — admin 공통 정책.
+ * Query: `key` — 현재 유효값은 `lockless_intermediate` 하나.
+ * Body: `{ value: 'true' | 'false' }`
+ * Response 200: `{ key, value: 'true' | 'false' }`
+ * Response 400: `{ error: 'invalid_key' }` | `{ error: 'invalid_body' }`
+ * Response 401/503: 인증/binding 정책 동일.
+ */
+app.post('/admin/kill-switch', async (c) => {
+  const authError = checkAdminAuth(c.req.header('authorization'), c.env.ADMIN_TOKEN);
+  if (authError) return c.json({ error: authError.code }, authError.status);
+  const key = c.req.query('key');
+  if (!isKillSwitchKey(key)) {
+    return c.json({ error: 'invalid_key' }, 400);
+  }
+  const kv = c.env.TRIPS;
+  if (!kv) return c.json({ error: 'trips_unavailable' }, 503);
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_body' }, 400);
+  }
+  const raw = (body as { value?: unknown } | null)?.value;
+  if (!isKillSwitchValue(raw)) {
+    return c.json({ error: 'invalid_body' }, 400);
+  }
+  await setKillSwitch(kv, key, raw);
+  return c.json({ key, value: raw });
 });
 
 interface AdminAuthError {
@@ -2282,15 +2351,30 @@ export const handler = {
     // KV 미바인딩 / 미설정 케이스는 `getArchFlag` 가 default 로 fallback (dormant).
     // meta 에 우연히 같은 키가 실려 있어도 archFlag SSOT 가 이기도록 spread 순서를 뒤로 둔다.
     const archFlag = await getArchFlag(env.TRIPS).catch(() => ARCH_FLAG_DEFAULT);
+    // #1967 (Ff-1) — 매 cron cycle kill switch KV 상태를 read해 log + runScheduled deps로
+    // forward. KV 미바인딩/미설정/read 실패는 모두 default(false, dormant)로 fallback —
+    // 게이트 판정 자체가 실패해 정상 push가 막히는 회귀를 방지한다.
+    const killSwitchLocklessIntermediate = await getKillSwitch(env.TRIPS, 'lockless_intermediate')
+      .then((value) => value === 'true')
+      .catch(() => KILL_SWITCH_DEFAULT === 'true');
     const log = (msg: string, meta?: Record<string, unknown>) =>
-      console.log(JSON.stringify({ msg, ...meta, archFlag }));
+      console.log(JSON.stringify({ msg, ...meta, archFlag, killSwitchLocklessIntermediate }));
 
     let scheduledStats: Awaited<ReturnType<typeof runScheduled>>;
     try {
       // #1995 (ADR-022 Phase 1-2) — archFlag 를 runScheduled deps 로 forward.
       // 각 caller (arvlcd / vanish / transfer-release / lockless) 가 putPending / enqueueRetryIfTransient
       // 호출 시 이 값을 전달해 flag=on 시 destination 이외 kind 는 skip.
-      scheduledStats = await runScheduled(env, { seoul, apnsConfig, apnsHosts, log, archFlag });
+      // #1967 (Ff-1) — killSwitchLocklessIntermediate 를 runScheduled deps 로 forward. true 시
+      // lockless intermediate 게이트 평가를 즉시 건너뛴다(backend deploy 없는 emergency 채널).
+      scheduledStats = await runScheduled(env, {
+        seoul,
+        apnsConfig,
+        apnsHosts,
+        log,
+        archFlag,
+        killSwitchLocklessIntermediate,
+      });
     } catch (err) {
       void captureBackendException(env, err, { path: 'scheduled/runScheduled' });
       throw err;

--- a/backend/alarm-worker/src/killSwitch.ts
+++ b/backend/alarm-worker/src/killSwitch.ts
@@ -1,0 +1,80 @@
+/**
+ * Admin kill switch — 즉시 게이트 차단 인프라 (#1967 Ff-1).
+ *
+ * 2026-06-28 Wave 1-4 audit (Ff-1): lockless intermediate 게이트(`scheduled.ts` —
+ * `trip.infoModeEnabled && waypoint.kind === 'intermediate'`)가 kill switch 없이
+ * 머지됐다. device 측 false alarm 회귀가 감지돼도 backend deploy(10~30분) 없이는
+ * 즉시 차단 수단이 없었다.
+ *
+ * `archFlag.ts`(#1982 ADR-022 Phase 0)와 동일한 KV read/write 어댑터 패턴을 재사용한다.
+ * 다른 점은 kill switch가 여러 게이트를 다룰 잠재력이 있어 `key` 파라미터로 KV 키를
+ * 선택하는 데이터 주도 방식을 취한다는 것 — 새 게이트를 추가할 때 `KILL_SWITCH_KV_KEYS`에
+ * 한 줄만 추가하면 되고, admin endpoint / read / write 로직은 변경할 필요가 없다.
+ *
+ * 현재 유효한 key는 `lockless_intermediate` 하나뿐(#1967 스코프 = Ff-1). Ff-2(device 4-signal
+ * consensus 게이트)는 ADR-024 재설계로 소멸해 여기 포함하지 않는다.
+ *
+ * Rollback 정책: `true` → `false` KV write 만으로 즉시 되돌린다(배포 없음).
+ */
+
+import { assertCronCacheTtl, CRON_READ_CACHE_TTL_SEC } from './kvConsistency';
+
+/** 유효한 kill switch key — 새 게이트 추가 시 이 union + 아래 map에 한 줄 추가. */
+export type KillSwitchKey = 'lockless_intermediate';
+
+/** key → KV 키 매핑. 데이터 주도 — key 추가 시 read/write 로직 변경 불필요. */
+const KILL_SWITCH_KV_KEYS: Record<KillSwitchKey, string> = {
+  lockless_intermediate: 'kill-switch:lockless-intermediate',
+};
+
+/** 유효한 key 판정 — admin endpoint 입력 검증에 사용. */
+export function isKillSwitchKey(raw: unknown): raw is KillSwitchKey {
+  return typeof raw === 'string' && raw in KILL_SWITCH_KV_KEYS;
+}
+
+/** 두 가지 값만 허용. 그 외 값은 default(`false`, dormant)로 정규화된다. */
+export type KillSwitchValue = 'true' | 'false';
+
+/** Default 값 — 미설정 KV / 오타 / 파싱 실패 모두 이 값으로 fallback(게이트 정상 동작). */
+export const KILL_SWITCH_DEFAULT: KillSwitchValue = 'false';
+
+/** 유효 값 판정 — get/set 양쪽 공용. */
+export function isKillSwitchValue(raw: unknown): raw is KillSwitchValue {
+  return raw === 'true' || raw === 'false';
+}
+
+/**
+ * KV로부터 현재 kill switch 값을 조회. cron read 경로 전용 — `assertCronCacheTtl` +
+ * `CRON_READ_CACHE_TTL_SEC`(30s) 컨벤션을 따른다(`kvConsistency.ts`, #1402/#1423).
+ *
+ *  1. `kv` 인자가 없으면 default 반환 (개발 환경 호환).
+ *  2. KV `get` 결과가 null이면 default (미설정 시 dormant — 기존 게이트 동작 100% 유지).
+ *  3. 유효 문자열('true'/'false')이면 그 값을 반환.
+ *  4. 그 외 오타/타입 이상 값은 default로 fallback (운영자 실수 방어).
+ */
+export async function getKillSwitch(
+  kv: KVNamespace | undefined,
+  key: KillSwitchKey,
+): Promise<KillSwitchValue> {
+  if (!kv) return KILL_SWITCH_DEFAULT;
+  assertCronCacheTtl(CRON_READ_CACHE_TTL_SEC);
+  const raw = await kv.get(KILL_SWITCH_KV_KEYS[key], { cacheTtl: CRON_READ_CACHE_TTL_SEC });
+  if (raw === null) return KILL_SWITCH_DEFAULT;
+  return isKillSwitchValue(raw) ? raw : KILL_SWITCH_DEFAULT;
+}
+
+/**
+ * 관리자용 kill switch 설정. 유효하지 않은 값은 write 없이 throw — 잘못된 KV 상태 진입 차단.
+ *
+ * TTL 없음: 회귀 감지 시 즉시 반영되어야 하므로 영구 저장.
+ */
+export async function setKillSwitch(
+  kv: KVNamespace,
+  key: KillSwitchKey,
+  value: KillSwitchValue,
+): Promise<void> {
+  if (!isKillSwitchValue(value)) {
+    throw new Error(`killSwitch: invalid value ${String(value)}`);
+  }
+  await kv.put(KILL_SWITCH_KV_KEYS[key], value);
+}

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -520,6 +520,14 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   laStaleAutoEnded: number;
   /**
+   * #1967 (Ff-1) — admin kill switch(`KILL_LOCKLESS_INTERMEDIATE`)가 활성 상태라 lockless
+   * intermediate 게이트(`trip.infoModeEnabled && waypoint.kind === 'intermediate'`) 자체를
+   * 평가하지 않고 skip한 누적 횟수. 정상 운영(kill switch off)에서 0건 기대 — 0이 아니면
+   * 운영자가 device false alarm 회귀 대응으로 게이트를 의도적으로 차단 중이라는 신호.
+   * dashboard: `kill_switch_lockless_intermediate_skipped`.
+   */
+  killSwitchLocklessIntermediateSkipped: number;
+  /**
    * #816 C — lockless opt-in 토글 ON trip에서 station-passed(intermediate) push가 발사된 횟수.
    * false-positive 측정 인프라 — 사용자 dismiss/탭률은 client alarmLog로 별도 적재된다.
    * (lockMissing은 토글 OFF로 게이트 차단된 trip만 카운트되도록 유지 — 두 stat은 disjoint.)
@@ -858,6 +866,13 @@ export interface ScheduledDeps {
    * 미전달 (테스트/legacy) 시 undefined → 기존 동작 100% 유지.
    */
   archFlag?: ArchFlagValue;
+  /**
+   * #1967 (Ff-1) — admin kill switch(`KILL_LOCKLESS_INTERMEDIATE`) 활성 여부. true 시
+   * lockless intermediate 게이트(1186행 부근) 평가 자체를 건너뛴다. index.ts scheduled
+   * handler가 매 cron cycle `getKillSwitch(env.TRIPS, 'lockless_intermediate')`로 read해
+   * forward. 미전달(테스트/legacy) 시 undefined → falsy → 기존 동작 100% 유지(dormant).
+   */
+  killSwitchLocklessIntermediate?: boolean;
 }
 
 /**
@@ -927,6 +942,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     envCorrected: 0,
     lockMissing: 0,
     laStaleAutoEnded: 0,
+    killSwitchLocklessIntermediateSkipped: 0,
     locklessIntermediateFired: 0,
     locklessMotionGateBlocked: 0,
     laPushSent: 0,
@@ -1183,7 +1199,13 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       // 시 station-passed push 발사. 사용자가 명시 동의(client 토글)한 trip에 한정한다.
       // intermediate kind가 아니면(transfer/destination) 여전히 skip — trainCode 없이 발사하면
       // 잘못된 leg/방향으로 갈 위험.
-      if (trip.infoModeEnabled && waypoint.kind === 'intermediate') {
+      // #1967 (Ff-1) — admin kill switch 활성 시 게이트 평가 자체를 건너뛴다. device false
+      // alarm 회귀 감지 시 backend deploy 없이 즉시 차단하는 emergency 채널(KV write만으로
+      // 되돌림). 미전달/false(default) 시 기존 동작 100% 유지(dormant).
+      if (deps.killSwitchLocklessIntermediate === true) {
+        stats.killSwitchLocklessIntermediateSkipped += 1;
+        log('lockless: skip (kill switch active)', { token: trip.token.slice(0, 8) });
+      } else if (trip.infoModeEnabled && waypoint.kind === 'intermediate') {
         try {
           await runLocklessIntermediate(trip, waypoint, env, deps, stats, now, log, generatePushId);
         } catch (e) {


### PR DESCRIPTION
## Summary

Closes #1967 — 스코프는 Ff-1만 (2026-07-31 issue triage 확정). **Ff-2(device 4-signal consensus 게이트 kill switch)는 ADR-024 재설계로 소멸**해 본 PR에서 제외한다: ADR-024가 매역 device 발사 자체를 제거하는 방향으로 재설계되면서, "consensus reject가 legit trip을 막아 silent-push-miss로 이어지는" Ff-2의 회귀 시나리오 전제 경로 자체가 사라졌다. 후속 재설계가 새 회귀 지점을 만들면 그때 별도 이슈로 kill switch 필요성을 재평가한다.

**Ff-1 — backend lockless intermediate 게이트 admin kill switch**:
- 2026-06-28 Wave 1-4 audit (Ff-1): PR #1942(#1923 infoModeEnabled wire)가 kill switch 없이 머지돼, `scheduled.ts`의 lockless intermediate 게이트(`trip.infoModeEnabled && waypoint.kind === 'intermediate'`)에서 device 측 false alarm 회귀가 감지돼도 backend deploy(10~30분) 없이는 즉시 차단 수단이 없었다.
- `backend/alarm-worker/src/killSwitch.ts` 신규 — `archFlag.ts`(#1982 ADR-022 Phase 0)와 동일한 KV read/write 어댑터 패턴. `key` 파라미터로 대상 게이트를 선택하는 데이터 주도 설계(현재 유효 key는 `lockless_intermediate` 하나 — 새 게이트 추가 시 매핑 한 줄만 추가하면 됨).
- `POST/GET /admin/kill-switch?key=lockless_intermediate` — `Authorization: Bearer <ADMIN_TOKEN>` 인증, `{ value: 'true' | 'false' }` body/response. `true`→`false` write만으로 즉시 rollback(배포 없음).
- `scheduled.ts:1186` 부근 lockless intermediate 게이트 직전에 kill switch 검사 추가. 활성 시 게이트 평가(`runLocklessIntermediate` 호출)를 skip하고 기존 `lockMissing` 분기로 fall-through — boarding-prompt 평가 / LA heartbeat는 정상 진행(kill switch는 intermediate fire만 차단, trip 전체를 죽이지 않음).
- `ScheduledStats.killSwitchLocklessIntermediateSkipped` 카운터 추가.
- `index.ts` cron handler가 매 cycle `getKillSwitch(env.TRIPS, 'lockless_intermediate')`로 read해 `runScheduled` deps로 forward + log에 포함. KV read는 `kvConsistency.ts`의 `assertCronCacheTtl` + `CRON_READ_CACHE_TTL_SEC`(30s) 컨벤션 준수.
- KV 미바인딩/미설정/read 실패는 모두 default(`false`, dormant)로 fallback — 게이트 판정 자체가 실패해 정상 push가 막히는 회귀를 방지.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (로컬 확인).
2. **V/X dashboard** — `ScheduledStats.killSwitchLocklessIntermediateSkipped`가 wrangler tail / Cloudflare Dashboard 로그(`lockless: skip (kill switch active)`)에 노출. cron log에도 `killSwitchLocklessIntermediate` boolean이 매 cycle 포함. `GET /admin/kill-switch?key=lockless_intermediate`로 현재 KV 상태 조회 가능.
3. **의존 PR** — #1942 + #1950 (모두 머지됨). 본 PR은 독립적으로 배포 가능.
4. **측정 plan** — `killSwitchLocklessIntermediateSkipped` 카운터를 1주 추적. 정상 운영(kill switch off)에서 0건 기대 — 0이 아니면 운영자가 kill switch를 의도적으로 활성화한 상태(회귀 대응 중)라는 신호.
5. **Device verify** — N/A — type+unit only. 본 PR은 backend-only 변경(admin endpoint + cron 게이트 분기)이며 device 코드 변경 없음. kill switch 활성화 시 device 동작(lockless intermediate push 미수신)은 회귀 대응 발동 시점에 실기기로 확인 예정.

## Test plan

- [x] `npm run type-check` (frontend) pass
- [x] `npm run lint:orphan` — 0 orphan
- [x] `backend/alarm-worker`: `npm test` — 2729 tests pass, coverage 97.3%(threshold 97% 충족: statements/lines 96.8%→97.3%, branch/func 96.21%→96.35%/98.55%→99.17%)
- [x] 신규 단위 테스트: `killSwitch.ts` get/set/validation, `/admin/kill-switch` GET/POST endpoint(인증/binding/validation/rollback), `scheduled.ts` 게이트 fall-through(kill switch on/off/dormant), cron handler forward 배선(KV→deps)
