### PR TITLE
fix(#1965): PR #2106 사후 리뷰 P2 follow-up - 최종 leg arc 검증 + 순환선 wrap-aware

### DIFF
--- a/src/features/route/utils/__tests__/tripDirection.test.ts
+++ b/src/features/route/utils/__tests__/tripDirection.test.ts
@@ -4,6 +4,7 @@ import {
   makeMultiTransferRoute,
   makeTransferRoute,
 } from '../../../../testUtils/routeFixtures';
+import { canonicalStationName } from '../../../../testUtils/canonicalStationName';
 
 describe('resolveTripDirection', () => {
   it('direct: next waypoint index > current index → "down"', () => {
@@ -189,6 +190,103 @@ describe('resolveTripDirection', () => {
       // arc 검증 불가 → transfers[0](사당, idx25) fallback 채택.
       // 성수(idx10) → 사당(idx25) = down.
       expect(resolveTripDirection(brokenRoute, '어린이대공원(세종대)', '2-011')).toBe('down');
+    });
+
+    it('#1965 P2-1 — 최종 leg도 bounded arc 검증 대상. 리뷰 실증 시나리오(2호선→4호선(사당)→2호선) 회귀', () => {
+      // 2호선 → 4호선(사당) → 2호선(충정로(경기대입구)) multi-transfer, destination 을지로3가.
+      // 최종 leg(line 2, entry=충정로(idx42), exit=을지로3가(idx2))도 arc 검증 없이 채택하면
+      // (또는 검증에 실패하면) transfers[0](사당, idx25)로 오귀속돼 잘못된 방향이 산출된다.
+      // 사용자 위치 을지로입구(idx1)는 최종 leg의 wrap 경로(idx42→idx0→idx1→idx2) 안에 있으므로
+      // 최종 leg가 채택되어야 한다.
+      const route = makeMultiTransferRoute({
+        transfers: [
+          { transferName: canonicalStationName('사당', '2'), fromLine: '2', toLine: '4', stopsToTransfer: 10 },
+          {
+            transferName: canonicalStationName('충정로', '2'),
+            fromLine: '4',
+            toLine: '2',
+            stopsToTransfer: 3,
+          },
+        ],
+        stopsAfterLastTransfer: 2,
+      });
+      // 최종 leg 채택 시: 을지로입구(idx1) → 을지로3가(idx2) = down.
+      // (오귀속되어 transfers[0]/사당(idx25)로 채택되면 'up'이 산출된다 — 회귀 방지 대상.)
+      expect(resolveTripDirection(route, canonicalStationName('을지로3가', '2'), '2-002')).toBe('down');
+    });
+
+    it('#1965 P2-2 — 순환선 seam(시청↔충정로) 걸친 bounded leg는 wrap-aware하게 arc 검증한다', () => {
+      // 7호선 → 2호선(충정로, idx42) → 4호선(을지로3가, idx2) multi-transfer.
+      // bounded leg(i=1, entry=충정로 idx42, exit=을지로3가 idx2)가 순환선 seam(idx42↔idx0)을
+      // 걸친다. naive min/max(2, 42) 비교면 시청(idx0)은 [2,42] 밖이라 arc 검증에 실패해
+      // transfers[0](fromLine 7)도 currentLine(2)과 불일치 → 결국 getFirstLeg fallback(line 7)이
+      // 채택되고 currIdx가 line 7에 없어 null이 산출된다.
+      // wrap-aware(shortestLinePathIndices) 경로(idx42→idx0→idx1→idx2)는 idx0을 포함해
+      // 정확히 이 bounded leg(line 2, endName=을지로3가)를 채택해야 한다.
+      const route = makeMultiTransferRoute({
+        transfers: [
+          {
+            transferName: canonicalStationName('충정로', '2'),
+            fromLine: '7',
+            toLine: '2',
+            stopsToTransfer: 10,
+          },
+          {
+            transferName: canonicalStationName('을지로3가', '2'),
+            fromLine: '2',
+            toLine: '4',
+            stopsToTransfer: 3,
+          },
+        ],
+        stopsAfterLastTransfer: 2,
+      });
+      // bounded leg(line 2) 채택 시: 시청(idx0) → 을지로3가(idx2) = down.
+      // (arc 검증 실패로 fallback되면 line 7 불일치로 null이 산출된다 — 회귀 방지 대상.)
+      expect(
+        resolveTripDirection(route, canonicalStationName('동대문역사문화공원', '4'), '2-001'),
+      ).toBe('down');
+    });
+
+    it('#1965 P3-1 — bounded leg boundary 역명이 부제 없는 base name이어도 정규화로 매칭된다', () => {
+      // transfers[1].transferName을 부제 없는 base name('왕십리')으로 지정해도
+      // findStationByNameAndLine의 정규화 fallback이 stations.json 정식 표기
+      // '왕십리(성동구청)'로 흡수해 arc 검증이 정상 동작해야 한다(#1410 BLDN_NM drift 대응).
+      const route = makeMultiTransferRoute({
+        transfers: [
+          { transferName: canonicalStationName('사당', '2'), fromLine: '2', toLine: '4', stopsToTransfer: 10 },
+          { transferName: '왕십리', fromLine: '4', toLine: '2', stopsToTransfer: 3 },
+          { transferName: canonicalStationName('건대입구', '2'), fromLine: '2', toLine: '7', stopsToTransfer: 7 },
+        ],
+        stopsAfterLastTransfer: 4,
+      });
+      // 성수(idx10)는 왕십리(성동구청, idx7)~건대입구(idx11) 구간 안 → transfers[2] 채택.
+      // 성수(idx10) → 건대입구(idx11) = down.
+      expect(
+        resolveTripDirection(route, canonicalStationName('어린이대공원(세종대)', '7'), '2-011'),
+      ).toBe('down');
+    });
+
+    it('#1965 P2-1 방어 분기 — 최종 leg entry boundary 조회 실패 시 unbounded fallback으로 채택된다', () => {
+      // last.transferName이 line 2에 없는 오탈자면 최종 leg arc 검증(entry lookup)이 실패한다.
+      // 다른 bounded leg(i=1)도 fromLine 불일치, i=0도 fromLine 불일치라 매칭할 후보가 없으므로
+      // currentLine === last.toLine이라는 사실만으로 최종 leg를 unbounded fallback 채택해야 한다
+      // (arc 데이터 조회 실패 시에도 기존 동작을 보존하는 방어 분기).
+      const route = makeMultiTransferRoute({
+        transfers: [
+          {
+            transferName: canonicalStationName('동대문역사문화공원', '7'),
+            fromLine: '7',
+            toLine: '4',
+            stopsToTransfer: 5,
+          },
+          { transferName: '존재하지않는역명XYZ', fromLine: '4', toLine: '2', stopsToTransfer: 3 },
+        ],
+        stopsAfterLastTransfer: 2,
+      });
+      // 성수(idx10) → 건대입구(idx11) = down.
+      expect(
+        resolveTripDirection(route, canonicalStationName('건대입구', '2'), '2-011'),
+      ).toBe('down');
     });
   });
 });

--- a/src/features/route/utils/tripDirection.ts
+++ b/src/features/route/utils/tripDirection.ts
@@ -1,6 +1,11 @@
 import type { LineNumber } from '../../../shared/types/station';
 import type { Route } from '../../../shared/utils/stationRoute';
-import { getFirstLeg, getStationsOnLine, getStationById } from '../../../shared/utils/stationRoute';
+import {
+  getFirstLeg,
+  getStationsOnLine,
+  getStationById,
+  findStationByNameAndLine,
+} from '../../../shared/utils/stationRoute';
 import { isClosedLoopMainStation, shortestLinePathIndices } from '../../../shared/utils/lineLoopPath';
 
 export type TripDirection = 'up' | 'down';
@@ -21,10 +26,10 @@ export type TripDirection = 'up' | 'down';
  *
  * #1965 — multi-transfer route가 같은 line을 두 번 이상 지나면(예: 2호선 → 4호선 → 2호선
  * → 7호선) 단순 "첫 매칭 leg" 채택은 실제로 나중 leg에 있는 사용자를 첫 leg로 오판한다.
- * bounded leg(양 끝 경계가 모두 알려진 i>=1)는 진입/이탈 boundary 사이에 currentStationId가
- * 실제로 있는지(arc 범위) 검증해 뒤(나중 leg)에서부터 먼저 매칭을 시도한다. i=0은 시작
- * 경계(trip origin)를 알 수 없어 arc 검증이 불가능하므로 bounded leg 중 매칭이 없을 때만
- * 마지막 fallback으로 채택한다.
+ * bounded leg(양 끝 경계가 모두 알려진, 최종 leg 포함 i>=1)는 진입/이탈 boundary 사이에
+ * currentStationId가 실제로 있는지(arc 범위) 검증해 뒤(나중 leg. 최종 leg가 가장 나중)에서부터
+ * 먼저 매칭을 시도한다. i=0(첫 leg)만 시작 경계(trip origin)를 알 수 없어 arc 검증이 불가능하므로
+ * bounded leg 전부(최종 leg 포함) 매칭이 없을 때만 마지막 fallback으로 채택한다.
  */
 function isStationInLegArc(
   line: LineNumber,
@@ -34,12 +39,22 @@ function isStationInLegArc(
 ): boolean {
   const lineStations = getStationsOnLine(line);
   const currIdx = lineStations.findIndex((s) => s.id === currentStationId);
-  const entryIdx = lineStations.findIndex((s) => s.name === entryBoundaryName);
-  const exitIdx = lineStations.findIndex((s) => s.name === exitBoundaryName);
-  if (currIdx < 0 || entryIdx < 0 || exitIdx < 0) return false;
-  const lo = Math.min(entryIdx, exitIdx);
-  const hi = Math.max(entryIdx, exitIdx);
-  return currIdx >= lo && currIdx <= hi;
+  // #1965 P3-1 — 정확 일치 대신 findStationByNameAndLine(정규화 fallback 내장)로 조회해
+  // stations.json BLDN_NM drift(#1410)를 흡수한다.
+  const entryStation = findStationByNameAndLine(entryBoundaryName, line);
+  const exitStation = findStationByNameAndLine(exitBoundaryName, line);
+  if (currIdx < 0 || !entryStation || !exitStation) return false;
+  const entryIdx = lineStations.findIndex((s) => s.id === entryStation.id);
+  const exitIdx = lineStations.findIndex((s) => s.id === exitStation.id);
+  /* istanbul ignore next -- findStationByNameAndLine과 getStationsOnLine은 같은
+     getLineStationsCached(line) 캐시를 공유하므로 entryStation/exitStation이 발견되면
+     lineStations 안에 항상 존재한다는 invariant (lineLoopPath.ts:65-66과 동일 패턴). */
+  if (entryIdx < 0 || exitIdx < 0) return false;
+  // #1965 P2-2 — naive min/max index 비교는 2호선 본선 closed loop seam(시청↔충정로)에서
+  // wraparound 실구간을 놓친다. resolveTripDirection과 동일하게 shortestLinePathIndices로
+  // wrap-aware 경로를 산출해 그 path 위에 currIdx가 있는지 검증한다.
+  const path = shortestLinePathIndices(lineStations, entryIdx, exitIdx, line);
+  return path.includes(currIdx);
 }
 
 function pickLegForCurrentLine(
@@ -57,8 +72,19 @@ function pickLegForCurrentLine(
     }
     return { line: route.fromLine, endName: route.transferName };
   }
-  // multi-transfer — bounded leg(i>=1)를 뒤에서부터 먼저 arc 검증.
+  // multi-transfer — bounded leg(최종 leg 포함, i>=1)를 뒤에서부터 먼저 arc 검증.
   const { transfers } = route;
+  const last = transfers[transfers.length - 1];
+
+  // #1965 P2-1 — 최종 leg(진입=last.transferName, 이탈=destinationName)도 양 끝 boundary가
+  // 모두 알려진 bounded leg다. 가장 나중 leg이므로 다른 bounded leg보다 먼저 arc 검증한다.
+  if (
+    currentLine === last.toLine &&
+    isStationInLegArc(last.toLine, currentStationId, last.transferName, destinationName)
+  ) {
+    return { line: last.toLine, endName: destinationName };
+  }
+
   for (let i = transfers.length - 1; i >= 1; i--) {
     if (currentLine !== transfers[i].fromLine) continue;
     const entryBoundaryName = transfers[i - 1].transferName;
@@ -71,7 +97,7 @@ function pickLegForCurrentLine(
   if (currentLine === transfers[0].fromLine) {
     return { line: transfers[0].fromLine, endName: transfers[0].transferName };
   }
-  const last = transfers[transfers.length - 1];
+  // 최종 leg — arc 데이터 조회 실패(boundary 역명 미존재 등) 방어용 unbounded fallback.
   if (currentLine === last.toLine) {
     return { line: last.toLine, endName: destinationName };
   }


### PR DESCRIPTION
PR #2106 사후 리뷰 P2 follow-up (Reopens 없음, #1965 참조)

## 배경

PR #2106(#1965 — tripDirection multi-transfer 첫 매칭 leg false positive 차단)이 코드 리뷰에서 지적된 P2/P3 수정 반영 전에 머지됐다. 본 PR은 그 코드 리뷰 지적사항(P2-1, P2-2, P3-1, P3-2)을 이미 머지된 코드 위에 follow-up으로 반영한다. 이슈 재오픈 없음 — #1965는 종료 상태 유지, 본 PR은 순수 follow-up.

## 1차 리뷰(PR #2106) 지적 사항과 반영 내용

**P2-1 (최종 leg 오귀속 — 실증됨)**
- 머지된 코드는 multi-transfer의 bounded leg(i>=1)만 arc 검증했고, 최종 leg(진입=`last.transferName`, 이탈=`destinationName`)는 arc 검증 없이 무조건 채택했다.
- 최종 leg도 양 끝 boundary가 모두 알려진 bounded leg이므로, 다른 bounded leg들과 함께 뒤→앞 순서로(가장 나중 leg이므로 최우선) arc 검증하도록 수정.
- 리뷰 실증 시나리오(2호선 → 4호선(사당) → 2호선, 사용자 위치가 최종 leg 구간인데 최종 leg가 arc 검증 없이 채택되지 않아 transfers[0](사당)로 오귀속되던 케이스)를 회귀 테스트로 고정.

**P2-2 (순환선 wrap)**
- `isStationInLegArc`의 naive min/max index 비교가 2호선 본선 closed loop seam(시청↔충정로)의 wraparound 실구간을 놓치는 문제.
- 같은 파일 `resolveTripDirection`이 이미 쓰던 `shortestLinePathIndices`(closed loop wrap-aware) 로직을 재사용해 파일 내 규약을 통일.
- 2호선 seam(시청↔충정로)을 넘어가는 bounded leg를 별도 route로 격리한 wrap 회귀 테스트 추가.

**P3-1**
- boundary 이름 exact match(`s.name === name`)를 `findStationByNameAndLine`(정규화 fallback 내장)로 교체 — stations.json BLDN_NM drift(#1410) 흡수.
- base name(부제 없는 역명)으로 boundary를 지정해도 정규화로 매칭됨을 검증하는 테스트 추가.

**P3-2**
- 테스트의 부제(괄호) 있는 역명 하드코딩을 `canonicalStationName(base, line)`으로 교체.

## 변경 사항

- `src/features/route/utils/tripDirection.ts`
  - `isStationInLegArc`: wrap-aware(`shortestLinePathIndices`) 경로 포함 검증 + `findStationByNameAndLine` 정규화 조회로 교체.
  - `pickLegForCurrentLine`: 최종 leg를 bounded 후보에 포함해 다른 bounded leg보다 먼저 arc 검증.
- `src/features/route/utils/__tests__/tripDirection.test.ts`
  - P2-1 회귀 테스트(리뷰 실증 시나리오) + 방어 분기(entry boundary 조회 실패 시 unbounded fallback) 테스트.
  - P2-2 순환선 seam wrap-aware 회귀 테스트(naive 비교였다면 miss했을 case를 격리).
  - P3-1 base name 정규화 매칭 테스트.
  - P3-2 기존 #1965 테스트의 부제 있는 역명 리터럴을 `canonicalStationName`으로 교체.

## 검증

- `npm test` — 428 suites / 9151 tests 전체 pass, coverage 100% (lines/branches/functions/statements)
- `npm run type-check` — pass
- `npm run lint:orphan` — No orphan exports detected
- 신규 P2-1/P2-2 회귀 테스트는 수정 전 코드로 되돌려 **fail을 직접 확인**한 뒤 수정 코드로 복원해 **pass**로 전환됨을 검증 완료(테스트가 실제로 회귀를 catch함을 증명).

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass 확인.
2. **V/X dashboard** — `resolveTripDirection`은 boardingPrompt direction stamp의 입력. DebugModal의 direction trace 로그(#1922 계열 기존 관측 경로)에서 동일하게 관측 가능. 신규 시각화 채널 추가 없음.
3. **의존 PR** — N/A (PR #2106은 이미 머지됨, 본 PR은 그 위 순수 follow-up).
4. **측정 plan** — 실제 회귀 빈도가 매우 낮은 시나리오(multi-transfer + line 재사용 + 순환선 seam)라 production 측정으로 신호 포착이 어려움. unit test로 회귀 방지 신뢰.
5. **Device verify** — N/A — type+unit only (순수 유틸 함수 변경, 실기기 검증 불필요).

## 테스트 플랜

- [x] `npm test` (coverage 100%)
- [x] `npm run type-check`
- [x] `npm run lint:orphan`
- [x] 신규 P2-1/P2-2 회귀 테스트가 수정 전 코드에서 실제로 fail함을 직접 확인