### PR TITLE
fix(#1967): kill switch를 push 블록 한정으로 이동 — 취침 알람 생존 (PR #2107 P1 follow-up)

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -827,10 +827,13 @@ describe('runScheduled', () => {
       if (seoulCalled === false) expect(seoulFetch).not.toHaveBeenCalled();
     });
 
-    // #1967 (Ff-1) — admin kill switch. 토글 ON + intermediate + arvlCd=1 (정상이면 발사)
-    // 조합이라도 kill switch가 활성이면 게이트 평가 자체를 건너뛰고 lockMissing 분기로 fall-through.
-    describe('#1967 (Ff-1) — admin kill switch', () => {
-      it('killSwitchLocklessIntermediate=true → 발사 0 + killSwitchLocklessIntermediateSkipped 카운트', async () => {
+    // #1967 (Ff-1) — admin kill switch. 2026-07-31 리뷰(P1) — 게이트는 `runLocklessIntermediate`
+    // 함수 호출 전체가 아니라 함수 내부의 매역 station-passed push 발사 블록만 대상으로 한다.
+    // fusion advance 평가 / arvlCd Kalman reset / phase·motion 게이트 / 취침 알람 / waypoint 진행은
+    // kill switch와 무관하게 정상 실행된다 — trip advance와 취침 알람까지 함께 죽으면 그 자체가
+    // 새로운 사용자 가치 손실 회귀이기 때문이다(ADR-014: 사용자 명시 의향 trip = lock 활성과 동급).
+    describe('#1967 (Ff-1) — admin kill switch (push 블록만 게이트)', () => {
+      it('killSwitchLocklessIntermediate=true → push 0건 + killSwitchLocklessIntermediateSkipped 카운트 + waypoint는 정상 advance', async () => {
         const kv = new InMemoryKV();
         const trip = intermediateTrip();
         await putTrip(kv as unknown as KVNamespace, trip);
@@ -847,10 +850,14 @@ describe('runScheduled', () => {
         expect(stats.pushed).toBe(0);
         expect(stats.locklessIntermediateFired).toBe(0);
         expect(stats.killSwitchLocklessIntermediateSkipped).toBe(1);
-        // kill switch는 intermediate fire만 차단 — lockMissing 분기(boarding-prompt 평가 등)는
-        // 기존과 동일하게 fall-through 진행된다.
-        expect(stats.lockMissing).toBe(1);
+        // P2-1 — over-count 해소 확인: 게이트가 push 블록으로 좁혀졌으므로 함수 호출 자체는
+        // 정상 진행돼 lockMissing 분기로 fall-through하지 않는다(intermediateTrip은 lock이
+        // 아예 없는 lockless 시나리오이므로 애초에 lockMissing 분기 대상도 아니다).
+        expect(stats.lockMissing).toBe(0);
         expect(apnsFetch).not.toHaveBeenCalled();
+        // trip advance는 매역 통지 여부와 독립 — kill switch 활성 상태에서도 waypoint가 shift.
+        const stored = JSON.parse((await (kv as unknown as KVNamespace).get('trip:tok')) as string);
+        expect(stored.waypoints[0].stationName).toBe('역삼');
       });
 
       it('killSwitchLocklessIntermediate=false → 정상 발사 (dormant 확인)', async () => {
@@ -882,6 +889,40 @@ describe('runScheduled', () => {
         expect(stats.pushed).toBe(1);
         expect(stats.locklessIntermediateFired).toBe(1);
         expect(stats.killSwitchLocklessIntermediateSkipped).toBe(0);
+        expect(apnsFetch).toHaveBeenCalled();
+      });
+
+      // P2-2 (리뷰 필수) — 취침 알람 생존 회귀 테스트. sleepModeEnabled + infoModeEnabled 둘 다
+      // ON인 lockless trip에서 kill switch가 활성이어도 취침 알람(별 채널, alert+companion)은
+      // 정상 발사되고 waypoint도 정상 advance해야 한다. #1967 P1 리뷰가 지적한 "매역 push만
+      // 죽이려다 취침 알람까지 죽이는" 회귀를 직접 재현/차단.
+      it('sleepModeEnabled + infoModeEnabled + kill switch ON → sleepAlarmFired 1 + 매역 push 0 + waypoint advance 정상', async () => {
+        const kv = new InMemoryKV();
+        // #2066 트리거 조건: waypoint(현재)=intermediate, nextWaypoint=transfer/destination.
+        // intermediateTrip() 기본 shape(강남 intermediate → 역삼 destination)이 그대로 부합.
+        const trip = intermediateTrip({ sleepModeEnabled: true });
+        await putTrip(kv as unknown as KVNamespace, trip);
+        await seedLocklessMotionSeries(kv, trip.token, 'automotive');
+        const apnsFetch = vi.fn(async () => new Response('', { status: 200 }) as unknown as Response);
+        const stats = await runScheduled(makeEnv(kv), {
+          seoul: makeSeoul([ARVL_ARRIVED]),
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW,
+          generatePushId: () => 'p-sleep-killswitch',
+          killSwitchLocklessIntermediate: true,
+        });
+        // 취침 알람(별 채널)은 kill switch 무관 정상 발사.
+        expect(stats.sleepAlarmFired).toBe(1);
+        // 매역 station-passed push(lockless intermediate)는 kill switch로 차단.
+        expect(stats.pushed).toBe(0);
+        expect(stats.locklessIntermediateFired).toBe(0);
+        expect(stats.killSwitchLocklessIntermediateSkipped).toBe(1);
+        // waypoint는 정상 advance (trip SSoT는 매역 통지 여부와 독립).
+        const stored = JSON.parse((await (kv as unknown as KVNamespace).get('trip:tok')) as string);
+        expect(stored.waypoints[0].stationName).toBe('역삼');
+        // 취침 알람 push(alert + companion silent)는 실제로 전송 시도됐어야 한다.
         expect(apnsFetch).toHaveBeenCalled();
       });
     });

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -520,10 +520,13 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   laStaleAutoEnded: number;
   /**
-   * #1967 (Ff-1) — admin kill switch(`KILL_LOCKLESS_INTERMEDIATE`)가 활성 상태라 lockless
-   * intermediate 게이트(`trip.infoModeEnabled && waypoint.kind === 'intermediate'`) 자체를
-   * 평가하지 않고 skip한 누적 횟수. 정상 운영(kill switch off)에서 0건 기대 — 0이 아니면
-   * 운영자가 device false alarm 회귀 대응으로 게이트를 의도적으로 차단 중이라는 신호.
+   * #1967 (Ff-1) — admin kill switch(`KILL_LOCKLESS_INTERMEDIATE`)가 활성 상태라
+   * `runLocklessIntermediate`의 매역 station-passed push 발사(pushId 발급/전송/
+   * putPending/LA update)만 skip한 누적 횟수. 2026-07-31 리뷰(P1) — 게이트를 함수
+   * 호출 전체가 아니라 push 발사 블록에만 적용해 취침 알람(`maybeFireSleepAlarm`)과
+   * waypoint 진행(`waypoints.shift()`)은 kill switch와 무관하게 항상 실행된다.
+   * 정상 운영(kill switch off)에서 0건 기대 — 0이 아니면 운영자가 device false alarm
+   * 회귀 대응으로 매역 push를 의도적으로 차단 중이라는 신호.
    * dashboard: `kill_switch_lockless_intermediate_skipped`.
    */
   killSwitchLocklessIntermediateSkipped: number;
@@ -868,9 +871,11 @@ export interface ScheduledDeps {
   archFlag?: ArchFlagValue;
   /**
    * #1967 (Ff-1) — admin kill switch(`KILL_LOCKLESS_INTERMEDIATE`) 활성 여부. true 시
-   * lockless intermediate 게이트(1186행 부근) 평가 자체를 건너뛴다. index.ts scheduled
-   * handler가 매 cron cycle `getKillSwitch(env.TRIPS, 'lockless_intermediate')`로 read해
-   * forward. 미전달(테스트/legacy) 시 undefined → falsy → 기존 동작 100% 유지(dormant).
+   * `runLocklessIntermediate` 내부의 매역 station-passed push 발사 블록만 skip한다
+   * (fusion advance 평가 / 취침 알람 / waypoint 진행은 무관하게 실행 — 2026-07-31 리뷰 P1).
+   * index.ts scheduled handler가 매 cron cycle `getKillSwitch(env.TRIPS,
+   * 'lockless_intermediate')`로 read해 forward. 미전달(테스트/legacy) 시 undefined →
+   * falsy → 기존 동작 100% 유지(dormant).
    */
   killSwitchLocklessIntermediate?: boolean;
 }
@@ -1199,13 +1204,10 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       // 시 station-passed push 발사. 사용자가 명시 동의(client 토글)한 trip에 한정한다.
       // intermediate kind가 아니면(transfer/destination) 여전히 skip — trainCode 없이 발사하면
       // 잘못된 leg/방향으로 갈 위험.
-      // #1967 (Ff-1) — admin kill switch 활성 시 게이트 평가 자체를 건너뛴다. device false
-      // alarm 회귀 감지 시 backend deploy 없이 즉시 차단하는 emergency 채널(KV write만으로
-      // 되돌림). 미전달/false(default) 시 기존 동작 100% 유지(dormant).
-      if (deps.killSwitchLocklessIntermediate === true) {
-        stats.killSwitchLocklessIntermediateSkipped += 1;
-        log('lockless: skip (kill switch active)', { token: trip.token.slice(0, 8) });
-      } else if (trip.infoModeEnabled && waypoint.kind === 'intermediate') {
+      // #1967 (Ff-1) — admin kill switch는 `runLocklessIntermediate` 내부에서 매역 push
+      // 발사만 게이트한다 (2026-07-31 리뷰: 함수 호출 자체를 skip하면 취침 알람 +
+      // waypoint 진행까지 죽는 회귀). 여기서는 항상 호출.
+      if (trip.infoModeEnabled && waypoint.kind === 'intermediate') {
         try {
           await runLocklessIntermediate(trip, waypoint, env, deps, stats, now, log, generatePushId);
         } catch (e) {
@@ -3865,146 +3867,166 @@ export async function runLocklessIntermediate(
     if (dirty) await putTrip(env.TRIPS, trip);
     return;
   }
-  const pushId = generatePushId();
-  log('lockless: station-passed push', {
-    token: trip.token.slice(0, 8),
-    waypoint: waypoint.stationName,
-    ...(currentStationName !== undefined ? { currentStation: currentStationName } : {}),
-    arvlCd: signal.arvlCd,
-    etaSeconds: signal.etaSeconds,
-    // #2032 (Issue D) — monitoring dimension. lockless fire 시 device sleep 상태 기록.
-    // ADR-023: backend는 sleep 무관 발사. device의 shouldSuppressBySleepRule이 UI suppress 판정.
-    sleepMode: trip.sleepModeEnabled,
-  });
-  // #1561 (T8, ADR-017 / S2 흡수) — lockless fire 직전 SSoT 권위 스냅샷 forward.
-  const locklessSsot = await readSsot(env.TRIPS, trip.token, {
-    cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
-  });
-  // #1721 — payload 를 local 변수로 추출해 transient 실패 시 retry queue 적재에 재사용.
-  const locklessPayload: SilentPushPayload = {
-    nextWaypoint: waypoint.stationName,
-    etaSeconds: signal.etaSeconds,
-    phase: 'imminent',
-    kind: 'intermediate',
-    sentAt: now,
-    pushId,
-    // Epic #1204 그룹 2 D3 (#1273) — lockless intermediate도 waypoint.hopIndex forward.
-    // D1 estimator의 currentHopIndex와 ±tolerance 매칭 시 거리 검증 우회 + GPS 미준비 fallback.
-    hopIndex: waypoint.hopIndex,
-    // #1365 — server-authoritative occupiedLine. 환승역에서 디바이스가 같은 hop index에
-    // 다른 line의 stop과 cross-validation 가능. waypoint.line을 그대로 forward.
-    occupiedLine: waypoint.line,
-    // #1307 — server-authoritative subsurface. lockless intermediate도 지하에선
-    // 디바이스 GPS 게이트(out-of-range 오거부)를 우회하도록 flag를 전달.
-    subsurface: trip.subsurface === true,
-    // #1399 — 좀비 알림 cleanup. lockless intermediate push에도 tripToken stamp.
-    // trip-ended cleanup 후 늦게 도착한 stale push를 ACTIVE_TRIP_KEY mismatch로 drop.
-    tripToken: trip.token,
-    // #1402 — 발사 경로 stamp. device alarmLog에 pushOrigin=lockless로 기록.
-    origin: 'lockless' as const,
-    // #1539 (S6) — backend 누적 passedStations forward. 빈 배열/undefined는 apns.ts JSON
-    // serializer가 자연 누락. device backfill diff(S5 후속 wiring PR)에서 사용.
-    passedStations: trip.passedStations,
-    // #1561 (T8, ADR-017 / S2 흡수) — TripPositionSSoT 권위 forward. null/undefined는 apns.ts
-    // JSON serializer가 자연 누락 → device cascade picker는 기존 tier fallback. lockless trip은
-    // backend SSoT가 가장 신뢰 높은 단일 신호 (lock 부재 환경).
-    ssot: toSilentPushSsot(locklessSsot),
-  };
-  const heal = await sendWithEnvHeal(
-    (host) =>
-      sendSilentPush({
-        deviceToken: trip.token,
-        payload: locklessPayload,
-        config: deps.apnsConfig,
-        host,
-        fetchImpl: deps.fetchImpl,
-        now,
-      }),
-    trip.apnsEnv,
-    deps.apnsHosts,
-    log,
-    trip.token.slice(0, 8),
-  );
-  if (heal.correctedEnv) {
-    trip.apnsEnv = heal.correctedEnv;
-    dirty = true;
-    stats.envCorrected += 1;
-    // #1633 — lockless intermediate corrected env 즉시 KV persist. lockless는 매역 fire 경로라
-    // 다음 push까지 짧은 간격(~60s)이지만, 본 cycle 내 후속 코드가 cleanupTripWithLa로 early
-    // return하면 putTrip이 호출되지 않는다. 즉시 write로 corrected env 영구 보존.
-    await putTrip(env.TRIPS, trip);
-  }
-  if (!heal.result.ok) {
-    stats.errors += 1;
-    log('lockless: push failed', {
-      status: heal.result.status,
-      reason: heal.result.reason,
+  // #1967 (Ff-1) — admin kill switch. fusion advance 평가(위) + arvlCd Kalman reset +
+  // phase/motion 게이트는 kill switch와 무관하게 이미 완료됐다. 여기서부터는 매역
+  // station-passed push 발사(pushId 발급/전송/putPending/stats.pushed·locklessIntermediateFired
+  // 증가/LA update)만 게이트 대상 — 취침 알람(`maybeFireSleepAlarm`) 평가와 waypoint 진행
+  // (`waypoints.shift()`)은 kill switch 활성 여부와 무관하게 아래에서 항상 실행된다.
+  // 사용자 명시 의향 trip(C 토글 ON)은 lock 활성과 동급 정확도 보장 의무(ADR-014) —
+  // device false-alarm push 회귀 대응으로 매역 통지만 끄더라도 trip advance와 취침 알람까지
+  // 함께 멈추면 그 자체가 새로운 사용자 가치 손실 회귀가 된다.
+  if (deps.killSwitchLocklessIntermediate === true) {
+    stats.killSwitchLocklessIntermediateSkipped += 1;
+    log('lockless: skip push (kill switch active)', {
       token: trip.token.slice(0, 8),
+      waypoint: waypoint.stationName,
+      ...(currentStationName !== undefined ? { currentStation: currentStationName } : {}),
+      arvlCd: signal.arvlCd,
     });
-    if (
-      isUnrecoverableApnsError(heal.result.status, heal.result.reason) ||
-      heal.envMismatchExhausted
-    ) {
-      // #868 — lockless push unrecoverable로 trip 폐기 시에도 클라 state sync push 발사.
-      await cleanupTripWithLa(trip, env, deps, stats, now, log, 'push-unrecoverable');
+  } else {
+    const pushId = generatePushId();
+    log('lockless: station-passed push', {
+      token: trip.token.slice(0, 8),
+      waypoint: waypoint.stationName,
+      ...(currentStationName !== undefined ? { currentStation: currentStationName } : {}),
+      arvlCd: signal.arvlCd,
+      etaSeconds: signal.etaSeconds,
+      // #2032 (Issue D) — monitoring dimension. lockless fire 시 device sleep 상태 기록.
+      // ADR-023: backend는 sleep 무관 발사. device의 shouldSuppressBySleepRule이 UI suppress 판정.
+      sleepMode: trip.sleepModeEnabled,
+    });
+    // #1561 (T8, ADR-017 / S2 흡수) — lockless fire 직전 SSoT 권위 스냅샷 forward.
+    const locklessSsot = await readSsot(env.TRIPS, trip.token, {
+      cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
+    });
+    // #1721 — payload 를 local 변수로 추출해 transient 실패 시 retry queue 적재에 재사용.
+    const locklessPayload: SilentPushPayload = {
+      nextWaypoint: waypoint.stationName,
+      etaSeconds: signal.etaSeconds,
+      phase: 'imminent',
+      kind: 'intermediate',
+      sentAt: now,
+      pushId,
+      // Epic #1204 그룹 2 D3 (#1273) — lockless intermediate도 waypoint.hopIndex forward.
+      // D1 estimator의 currentHopIndex와 ±tolerance 매칭 시 거리 검증 우회 + GPS 미준비 fallback.
+      hopIndex: waypoint.hopIndex,
+      // #1365 — server-authoritative occupiedLine. 환승역에서 디바이스가 같은 hop index에
+      // 다른 line의 stop과 cross-validation 가능. waypoint.line을 그대로 forward.
+      occupiedLine: waypoint.line,
+      // #1307 — server-authoritative subsurface. lockless intermediate도 지하에선
+      // 디바이스 GPS 게이트(out-of-range 오거부)를 우회하도록 flag를 전달.
+      subsurface: trip.subsurface === true,
+      // #1399 — 좀비 알림 cleanup. lockless intermediate push에도 tripToken stamp.
+      // trip-ended cleanup 후 늦게 도착한 stale push를 ACTIVE_TRIP_KEY mismatch로 drop.
+      tripToken: trip.token,
+      // #1402 — 발사 경로 stamp. device alarmLog에 pushOrigin=lockless로 기록.
+      origin: 'lockless' as const,
+      // #1539 (S6) — backend 누적 passedStations forward. 빈 배열/undefined는 apns.ts JSON
+      // serializer가 자연 누락. device backfill diff(S5 후속 wiring PR)에서 사용.
+      passedStations: trip.passedStations,
+      // #1561 (T8, ADR-017 / S2 흡수) — TripPositionSSoT 권위 forward. null/undefined는 apns.ts
+      // JSON serializer가 자연 누락 → device cascade picker는 기존 tier fallback. lockless trip은
+      // backend SSoT가 가장 신뢰 높은 단일 신호 (lock 부재 환경).
+      ssot: toSilentPushSsot(locklessSsot),
+    };
+    const heal = await sendWithEnvHeal(
+      (host) =>
+        sendSilentPush({
+          deviceToken: trip.token,
+          payload: locklessPayload,
+          config: deps.apnsConfig,
+          host,
+          fetchImpl: deps.fetchImpl,
+          now,
+        }),
+      trip.apnsEnv,
+      deps.apnsHosts,
+      log,
+      trip.token.slice(0, 8),
+    );
+    if (heal.correctedEnv) {
+      trip.apnsEnv = heal.correctedEnv;
+      dirty = true;
+      stats.envCorrected += 1;
+      // #1633 — lockless intermediate corrected env 즉시 KV persist. lockless는 매역 fire 경로라
+      // 다음 push까지 짧은 간격(~60s)이지만, 본 cycle 내 후속 코드가 cleanupTripWithLa로 early
+      // return하면 putTrip이 호출되지 않는다. 즉시 write로 corrected env 영구 보존.
+      await putTrip(env.TRIPS, trip);
+    }
+    if (!heal.result.ok) {
+      stats.errors += 1;
+      log('lockless: push failed', {
+        status: heal.result.status,
+        reason: heal.result.reason,
+        token: trip.token.slice(0, 8),
+      });
+      if (
+        isUnrecoverableApnsError(heal.result.status, heal.result.reason) ||
+        heal.envMismatchExhausted
+      ) {
+        // #868 — lockless push unrecoverable로 trip 폐기 시에도 클라 state sync push 발사.
+        await cleanupTripWithLa(trip, env, deps, stats, now, log, 'push-unrecoverable');
+        return;
+      }
+      // #1721 — transient 실패(429 / 5xx) 시 retry queue 적재. unrecoverable / envMismatchExhausted
+      // 분기 이후이므로 본 경로는 transient 또는 기타 비치명 실패. enqueueRetryIfTransient 가 retryable
+      // 만 적재한다.
+      // #1995 (ADR-022 Phase 1-2) — flag=on 시 destination 만 retry (lockless intermediate payload.kind='intermediate' → flag=on 시 skip).
+      await enqueueRetryIfTransient(
+        env.PENDING_PUSHES,
+        {
+          pushId,
+          token: trip.token,
+          payload: locklessPayload,
+          apnsEnv: trip.apnsEnv ?? 'sandbox',
+          status: heal.result.status,
+          reason: heal.result.reason,
+          now,
+        },
+        deps.archFlag,
+      );
+      if (dirty) await putTrip(env.TRIPS, trip);
       return;
     }
-    // #1721 — transient 실패(429 / 5xx) 시 retry queue 적재. unrecoverable / envMismatchExhausted
-    // 분기 이후이므로 본 경로는 transient 또는 기타 비치명 실패. enqueueRetryIfTransient 가 retryable
-    // 만 적재한다.
-    // #1995 (ADR-022 Phase 1-2) — flag=on 시 destination 만 retry (lockless intermediate payload.kind='intermediate' → flag=on 시 skip).
-    await enqueueRetryIfTransient(
+    // 발사 성공 — dedup stamp + 측정 카운터. waypoint 진행은 kill switch 무관 블록(아래)으로 이동.
+    stats.pushed += 1;
+    stats.locklessIntermediateFired += 1;
+    // #1683 — lockless intermediate kind 카운터.
+    stats.silentPushFiredByKind.intermediate += 1;
+    // #1402 — alert fallback 안전망 등록 (60s 임계, #1894로 30s→60s 완화). shift 전 stationName으로 등록해 alert 본문이
+    // 사용자가 실제로 통과한 station을 가리키게 한다. lockless intermediate는 lock 경로보다
+    // device-side validation이 느슨해 silent push 누락 시 안전망 가동이 더 절실한 경로.
+    // #1995 (ADR-022 Phase 1-2) — flag=on 시 destination 만 pending 등록 (본 경로 kind='intermediate' → flag=on 시 skip).
+    await putPending(
       env.PENDING_PUSHES,
       {
         pushId,
         token: trip.token,
-        payload: locklessPayload,
+        alarmKey: buildAlarmKey(waypoint.stationName, 'imminent'),
+        sentAt: now,
+        stationName: waypoint.stationName,
+        kind: 'intermediate',
+        phase: 'imminent',
+        etaSeconds: signal.etaSeconds,
         apnsEnv: trip.apnsEnv ?? 'sandbox',
-        status: heal.result.status,
-        reason: heal.result.reason,
-        now,
       },
       deps.archFlag,
     );
-    if (dirty) await putTrip(env.TRIPS, trip);
-    return;
+    trip.lastFiredPhase = 'imminent';
+    // #1539 (S6) — lockless intermediate 통과 시점도 동일하게 stationName 누적. lock 경로와 동등
+    // 정확도 보장 의무(ADR-014: 사용자 명시 의향 trip = lock 활성과 동급).
+    appendPassedStation(trip, waypoint.stationName);
+    // #1826 — lockless intermediate 경로에서도 LA BG update 발사.
+    // signal.etaSeconds를 ETA로 전달 — station-passed push와 동일 시점의 ETA 추정값.
+    // maybeFireLiveActivityUpdate 내 dedup(30s) + heartbeat(90s) 게이트가 중복 발사를 차단한다.
+    // 반환 dirty=true여도 trip의 lastLaPushEpoch/lastLaPushAt 갱신분은 아래 putTrip으로 일괄 persist.
+    await maybeFireLiveActivityUpdate(trip, waypoint, now + signal.etaSeconds * 1000, deps, stats, now, log);
   }
-  // 발사 성공 — waypoint 진행 + dedup stamp + 측정 카운터.
-  stats.pushed += 1;
-  stats.locklessIntermediateFired += 1;
-  // #1683 — lockless intermediate kind 카운터.
-  stats.silentPushFiredByKind.intermediate += 1;
-  // #1402 — alert fallback 안전망 등록 (60s 임계, #1894로 30s→60s 완화). shift 전 stationName으로 등록해 alert 본문이
-  // 사용자가 실제로 통과한 station을 가리키게 한다. lockless intermediate는 lock 경로보다
-  // device-side validation이 느슨해 silent push 누락 시 안전망 가동이 더 절실한 경로.
-  // #1995 (ADR-022 Phase 1-2) — flag=on 시 destination 만 pending 등록 (본 경로 kind='intermediate' → flag=on 시 skip).
-  await putPending(
-    env.PENDING_PUSHES,
-    {
-      pushId,
-      token: trip.token,
-      alarmKey: buildAlarmKey(waypoint.stationName, 'imminent'),
-      sentAt: now,
-      stationName: waypoint.stationName,
-      kind: 'intermediate',
-      phase: 'imminent',
-      etaSeconds: signal.etaSeconds,
-      apnsEnv: trip.apnsEnv ?? 'sandbox',
-    },
-    deps.archFlag,
-  );
-  trip.lastFiredPhase = 'imminent';
-  // #1539 (S6) — lockless intermediate 통과 시점도 동일하게 stationName 누적. lock 경로와 동등
-  // 정확도 보장 의무(ADR-014: 사용자 명시 의향 trip = lock 활성과 동급).
-  appendPassedStation(trip, waypoint.stationName);
-  // #1826 — lockless intermediate 경로에서도 LA BG update 발사.
-  // signal.etaSeconds를 ETA로 전달 — station-passed push와 동일 시점의 ETA 추정값.
-  // maybeFireLiveActivityUpdate 내 dedup(30s) + heartbeat(90s) 게이트가 중복 발사를 차단한다.
-  // 반환 dirty=true여도 trip의 lastLaPushEpoch/lastLaPushAt 갱신분은 아래 putTrip으로 일괄 persist.
-  await maybeFireLiveActivityUpdate(trip, waypoint, now + signal.etaSeconds * 1000, deps, stats, now, log);
   // #2066 (Phase 2-backend) — 취침 알람 평가. shift 전이라 trip.waypoints[1]이 waypoint(방금
   // arvlCd 확정된 직전역 후보) 바로 다음 대상. lockless도 intermediate만 advance하므로 lock 경로
   // (`advanceBoardingLockWaypoint`)와 동일 로직 재사용 — 환승/도착 타겟 종류만 다르다.
+  // #1967 (Ff-1) — kill switch 활성 시에도 실행: 매역 push만 억제 대상이지 취침 알람까지 죽이면
+  // 안 된다(회귀 대응 중 취침 알람이 함께 죽는 새 회귀 방지).
   await maybeFireSleepAlarm({
     trip,
     waypoint,
@@ -4016,6 +4038,8 @@ export async function runLocklessIntermediate(
     log,
     generatePushId,
   });
+  // #1967 (Ff-1) — kill switch 활성 시에도 waypoint 진행은 정상 수행 (trip advance는
+  // 매역 통지 여부와 독립적인 SSoT). push 미발사와 무관하게 사용자는 실제로 이 역을 통과했다.
   trip.waypoints.shift();
   if (trip.waypoints.length === 0) {
     // 마지막 intermediate까지 통과 — trip 종료. lockless는 destination을 직접 다루지 않는다.


### PR DESCRIPTION
## Summary

PR #2107 사후 리뷰 P1/P2 follow-up. Closes #1967 (원 PR #2107이 이미 머지·배포됐고, 본 PR은 그 위에 발견된 리뷰 지적사항을 반영).

**⚠️ 머지 전까지 production `KILL_LOCKLESS_INTERMEDIATE` kill switch를 ON 하지 말 것.** PR #2107이 P1 수정 전에 머지·배포돼, kill switch ON 시 취침 알람이 함께 죽는 결함이 현재 production 코드에 dormant 상태로 존재한다(기본 OFF라 당장 발화하진 않음).

### P1 (취침 알람 회귀)

원 구현은 kill switch가 활성이면 `runLocklessIntermediate` 함수 호출 자체를 skip했다. 이 함수 내부에는 매역 station-passed push 발사뿐 아니라 `maybeFireSleepAlarm`(취침 알람, 별 채널)과 `trip.waypoints.shift()`(trip advance)도 포함돼 있어, kill switch를 켜면 회귀 대응 대상인 매역 push뿐 아니라 취침 알람과 trip 진행까지 함께 멈추는 새로운 회귀가 만들어졌다.

수정: 게이트를 함수 호출 전체 skip에서 → **함수 내부의 매역 push 발사 블록만**(pushId 발급 → `sendWithEnvHeal` 전송 → 실패 처리 → 성공 시 `putPending`/`stats.pushed`·`stats.locklessIntermediateFired`·`stats.silentPushFiredByKind.intermediate` 증가/`trip.lastFiredPhase` 스탬프/`appendPassedStation`/`maybeFireLiveActivityUpdate`)으로 축소했다. `fusion` advance 평가, arvlCd Kalman reset, phase/motion 게이트, `maybeFireSleepAlarm`, `trip.waypoints.shift()`는 kill switch 활성 여부와 무관하게 항상 실행된다.

호출부(`scheduled.ts` 1186행 부근)의 outer skip은 제거 — `runLocklessIntermediate`는 항상 호출되고, kill switch 판정은 함수 내부로 이동했다.

### P2-1 (over-count)

P1 이동으로 자연 해소됨을 테스트로 확인: kill switch 활성 시에도 함수는 정상 호출되므로 `stats.lockMissing`이 잘못 증가하지 않고(애초에 lockless trip은 lock이 없어 `lockMissing` 분기 대상이 아님), `killSwitchLocklessIntermediateSkipped`는 실제 push가 억제된 지점에서만 1 증가한다.

### P2-2 (테스트)

회귀 재현 테스트 추가: `sleepModeEnabled + infoModeEnabled + kill switch ON → sleepAlarmFired 1 + 매역 push 0 + waypoint advance 정상` (`backend/alarm-worker/src/__tests__/scheduled.test.ts` `#1967 (Ff-1) — admin kill switch (push 블록만 게이트)` describe 블록 마지막 케이스).

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass.
2. **V/X dashboard** — `killSwitchLocklessIntermediateSkipped` 카운터 의미는 그대로 유지(매역 push 억제 횟수), wrangler tail 로그 메시지가 `lockless: skip push (kill switch active)`로 더 명확해짐. `sleepAlarmFired`는 기존 dashboard 신호 그대로 사용해 회귀 확인.
3. **의존 PR** — #2107 (머지됨, 본 PR의 base).
4. **측정 plan** — kill switch를 실제로 ON 하는 시점(회귀 대응 발동 시)에 `sleepAlarmFired`가 정상적으로 계속 증가하는지 1주 관찰. 0으로 떨어지면 본 fix가 실패했다는 신호.
5. **Device verify** — N/A — type+unit only. backend-only 변경.

## Test plan

- [x] `npm run type-check` (frontend) pass
- [x] `npm run lint:orphan` — 0 orphan
- [x] `backend/alarm-worker`: `npm test` — 2738 tests pass, coverage 97.3%(threshold 97% 충족)
- [x] 신규 회귀 테스트: kill switch ON 시 push 0 + waypoint advance 정상, kill switch ON + sleepModeEnabled 시 sleepAlarmFired 1 + push 0 + waypoint advance 정상
