### PR TITLE
docs(#1961): ADR-014 'C 토글' 표현 drift 정정

### DIFF
--- a/docs/decisions/ADR-014-decision-process-rules.md
+++ b/docs/decisions/ADR-014-decision-process-rules.md
@@ -23,6 +23,10 @@ Accepted (2026-06-12)
 | 2026-06-11 | ADR-013 B3 — lockless 면제 | "강제 100% vs 면제" false binary → 사용자 면제 선택 → ADR-010 첫 줄 위반 |
 | 2026-06-11 | B1 — C 토글 "정보용" 격하 | 정확성 게이트 의무 면제 |
 
+(\*) "C 토글"은 2026-06-11 당시 결정 명칭 표기이며 별도 UI 토글로 구현된 적이 없다. 실제
+코드 stamp 진입점은 boardingPrompt [탑승] 응답 / BoardingTrainList 직접 탭 2개이며,
+`useUserIntentStore.infoModeEnabled`가 SSoT다 (#1961 정정, ADR-024 정합).
+
 **진짜 원인**: AI(이전 세션)가 결정 옵션 제시 시 **"현재 코드 능력 범위" 기준으로 옵션을 좁힘**. "정확성 게이트 보강 (신규 작업 필요)" 같은 제3의 옵션이 결정 테이블에 없어 사용자가 false binary에 갇혀 면제 선택.
 
 → **단기 코드 상태가 acceptance를 정의함**. ADR-010 첫 줄 "두 실패 모드 동급" 원칙이 acceptance까지 못 내려옴.
@@ -54,7 +58,7 @@ Accepted (2026-06-12)
 1. lockless 100% 강제 → false positive 폭증 (현 코드)
 2. 정확성 게이트 보강 후 100% → hop window + estimator cascade + sticky 유지 (신규 2주)
 3. lockless 면제 (사용자 선택) → miss 허용, ADR-010 첫 줄 위반
-4. 부분 적용 → C 토글 ON일 때만 100% 보장
+4. 부분 적용 → 사용자 명시 의향 stamp(boardingPrompt 응답/직접 탭) 상태일 때만 100% 보장
 ```
 
 ### 2. Epic close 조건 룰 — PR 머지 ≠ close
@@ -78,7 +82,7 @@ Epic close 조건에 다음 둘 중 하나 필수:
 
 **회귀 정의 점검 5가지**:
 1. lock 활성 / lockless 둘 다 카테고리에 들어 있는가?
-2. 사용자 명시 의향(C 토글 ON / boardingPrompt 응답 / 직접 탭) trip이 lock 활성과 동급으로 다뤄지는가?
+2. 사용자 명시 의향(boardingPrompt 응답 / BoardingTrainList 직접 탭) trip이 lock 활성과 동급으로 다뤄지는가?
 3. ADR 첫 줄 원칙(예: ADR-010 "두 실패 모드 동급")이 acceptance까지 적용되는가?
 4. 권한 매트릭스(WhileInUse/Always × FG/BG/취침) 모두 커버?
 5. 환경 매트릭스(지하/지상/환승) 모두 커버?
@@ -87,11 +91,18 @@ Epic close 조건에 다음 둘 중 하나 필수:
 
 ### 4. 사용자 명시 의향 trip 동급 보장 룰
 
-**사용자 명시 의향 정의**:
-- C 토글(`locklessStationPassed=true`) ON 상태에서 trip 활성
-- boardingPrompt push [탑승] 응답
-- BoardingTrainList에서 사용자 직접 탭
+**사용자 명시 의향 정의** (실제 코드 stamp 진입점 — "C 토글"이라는 별도 UI는 존재하지 않는다,
+#1961 정정):
+- boardingPrompt push [탑승] 응답 (`useBoardingPromptResponder.ts`)
+- BoardingTrainList에서 사용자 직접 탭 (`useBoardingLockController.ts` createLockFromTrain)
 - 목적지 설정 + 경로 등록
+
+두 stamp 진입점 모두 `useUserIntentStore.infoModeEnabled=true`로 수렴한다. 이 값은
+`RegisterTripPayload.infoModeEnabled`로 backend에 전달되어 lockless intermediate 게이트
+(`trip.infoModeEnabled && waypoint.kind === 'intermediate'`)의 opt-in 신호로 쓰이며,
+lock 없는 trip의 매역 station-passed silent push 발사를 허용한다. 이 게이트는 admin kill
+switch(#1967, `killSwitchLocklessIntermediate`)로 backend deploy 없이 즉시 우회 가능하다.
+ADR-024가 정의하는 알림/알람 원격 visible 채널과는 별개 경로다.
 
 **원칙**:
 - 사용자 명시 의향 trip은 **lock 활성 trip과 동급 정확도 보장 의무**
@@ -105,7 +116,7 @@ Epic close 조건에 다음 둘 중 하나 필수:
 
 **권장 표현**:
 - "사용자 명시 의향 trip은 lock 활성과 동급 정확도 보장"
-- "C 토글 ON / boardingPrompt 응답 / 직접 탭 → station-passed에 trip 진행도 게이트 + estimator cascade + sticky 유지 동일 적용"
+- "boardingPrompt 응답 / BoardingTrainList 직접 탭 → station-passed에 trip 진행도 게이트 + estimator cascade + sticky 유지 동일 적용"
 
 ### 5. ADR 첫 줄 원칙 적용 룰
 
@@ -127,13 +138,17 @@ ADR 첫 줄 원칙을 한 영역에서만 면제하는 결정 (예: ADR-010 첫 
 1. **Epic #1008 §7.1 회귀 7개 → 12개 확장 PR** — 회귀 8~12 (lockless over-fire / 지하 GPS sticky / 환승 trainCode 상실 / silent push fire=0 / 환승 leg autoLock) 추가
 2. **ADR-013 B3 면제 폐기 PR** — "lockless trip 게이트 미통과 = 위반 아님" 삭제, "사용자 명시 의향 trip 동급 보장" 추가
 3. **Epic #896 reopen 또는 후속 epic** — close 조건에 본문 evidence 시나리오 실기기 재발 0건 추가
-4. **B1 C 토글 정의 갱신** — "정보용 토글" 텍스트 유지 + "정확성 게이트는 lock 활성과 동급 적용" 명시
+4. ~~B1 C 토글 정의 갱신~~ — #1961에서 완료. "C 토글" UI 표현 제거, 실제 stamp 진입점 2개
+   (boardingPrompt 응답 / BoardingTrainList 직접 탭)로 정정 + ADR-024 정합 (2026-07-31)
 5. **결정 PR 템플릿 추가** — 옵션 3개 이상 자동 점검 체크리스트 포함
 
 ## References
 
 - ADR-010 §배경 첫 줄 — "두 실패 모드는 비대칭이 아니라 동급"
 - ADR-013 §B3 — 본 ADR로 면제 폐기 대상
+- ADR-024 — 알림(Notification) ≠ 알람(Alarm) 분리 스펙. `infoModeEnabled` 게이트가 다루는
+  lockless intermediate station-passed silent push는 ADR-024가 재정의한 알림/알람 원격
+  visible 채널과 별개 경로임을 명시
 - Epic #1008 SSOT (`tasks/epic-lockless-overfire-guard.md`)
 - Memory:
   - `lesson_2026_06_11_b3_false_binary.md` — 사고 evidence
@@ -146,3 +161,7 @@ ADR 첫 줄 원칙을 한 영역에서만 면제하는 결정 (예: ADR-010 첫 
 ## 변경 이력
 
 - 2026-06-12: 신규 작성 (2026-06-11 narrow-down 사고 + 2026-06-12 사용자 trip 11건 손실 evidence)
+- 2026-07-31 (#1961): "C 토글" 표현 drift 정정. 코드상 존재하지 않는 별도 토글 UI로 오독되던
+  표현을 실제 stamp 진입점 2개(boardingPrompt 응답 / BoardingTrainList 직접 탭)로 교체하고,
+  `infoModeEnabled`가 다루는 lockless intermediate 게이트와 kill switch(#1967)를 ADR-024
+  정합 하에 명시. 로직 변경 없음(doc-only)

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -69,10 +69,12 @@ export interface UseApnsTripRegistrationInputs {
    */
   subsurface?: boolean;
   /**
-   * #1923 — 사용자 명시 의향 토글 (C 토글 ON / boardingPrompt [탑승] 응답 /
-   * BoardingTrainList 직접 탭 중 하나라도 행하면 true). `useUserIntentStore`에서
-   * 읽어 전달. backend가 lockless intermediate station-passed silent push 발사
-   * 분기에 사용 (`trip.infoModeEnabled && waypoint.kind === 'intermediate'`).
+   * #1923 — 사용자 명시 의향 토글 (boardingPrompt [탑승] 응답 / BoardingTrainList
+   * 직접 탭 중 하나라도 행하면 true; "C 토글"이라는 별도 UI는 존재하지 않는다,
+   * #1961 정정). `useUserIntentStore`에서 읽어 전달. backend가 lockless
+   * intermediate station-passed silent push 발사 분기에 사용
+   * (`trip.infoModeEnabled && waypoint.kind === 'intermediate'`). admin kill
+   * switch(#1967)로 이 게이트 자체를 backend deploy 없이 우회 가능.
    * 미지정/false: 기존 동작 그대로 — boardingLock 부재 시 `lockMissing` skip.
    */
   infoModeEnabled?: boolean;

--- a/src/features/alarm/store/useUserIntentStore.ts
+++ b/src/features/alarm/store/useUserIntentStore.ts
@@ -1,12 +1,17 @@
 /**
  * #1923 — 사용자 명시 의향 토글 (infoModeEnabled) SSoT store.
  *
+ * 별도 "C 토글" UI는 존재하지 않는다 — ADR-014가 그 표현을 쓰던 시절의 doc 잔재이며
+ * #1961에서 정정됨. 실제 stamp 진입점은 2개뿐이다.
+ *
  * paradigm Phase 6 (단독 사용자 모드) device-only chain의 진원지. 사용자가
  * boardingPrompt [탑승] 응답 / BoardingTrainList 직접 탭 중 하나라도 행하면
  * 본 store에 `infoModeEnabled=true`로 stamp된다. `useApnsTripRegistration`이 이
  * 값을 읽어 `RegisterTripPayload.infoModeEnabled`로 backend에 송신하며, backend는
  * cron lockless intermediate gate(`trip.infoModeEnabled && waypoint.kind === 'intermediate'`)
- * 가 통과되어 station-passed silent push를 발사한다.
+ * 가 통과되어 station-passed silent push를 발사한다. admin kill switch(#1967,
+ * `killSwitchLocklessIntermediate`)로 이 게이트 자체를 backend deploy 없이 즉시
+ * 우회할 수 있다. ADR-024가 정의하는 알림/알람 원격 visible 채널과는 별개 경로다.
  *
  * ADR-014 §X "사용자 명시 의향 trip = lock 활성과 동급 정확도 보장 의무" 정합.
  *


### PR DESCRIPTION
Closes #1961

## 배경

2026-06-28 Wave 1-4 audit(Cl-2) 박제. ADR-014 / `feedback_user_intent_equal_protection`이
"C 토글 ON"을 사용자 명시 의향 surface 3개 중 하나로 명시했으나, 실제 코드에는 이 이름의
UI 토글이 존재하지 않는다(`grep -rn "infoMode\|C 토글" src/screens/ src/features/settings/` 0건).
실제 stamp 진입점은 2개뿐 — `useBoardingPromptResponder.ts:189`(boardingPrompt 응답),
`useBoardingLockController.ts:299`(BoardingTrainList 직접 탭 → createLockFromTrain).

## 옵션 평가 (false binary 금지, 이슈 본문 3옵션 표 그대로)

| 옵션 | 내용 | 채택 |
| --- | --- | --- |
| A | ADR-014 + 코드 주석 문구 정정 (doc-only) | **채택** |
| B | settings UI에 명시 토글 신규 추가 | 보류 — epic-level 결정, 본 이슈 범위 외 |
| C | A+B 동시 | 보류 — B가 보류되므로 함께 보류 |

A 채택 근거: stamp 진입점 2개가 이미 "사용자 명시 의향 = lock 활성과 동급" 원칙을 코드
레벨에서 커버한다(`useUserIntentStore.infoModeEnabled`). "C 토글"이라는 문구만 doc 잔재로
남아 reviewer/agent 혼란을 유발하던 상태.

## 추가 반영 — ADR-024 정합 (이슈 접수 이후 확정된 ADR)

이슈 접수 시점 이후 ADR-024(알림≠알람 분리, #2065)가 Accepted 되어, 단순 표현 삭제가 아니라
"C 토글"(infoModeEnabled)이 **현재 아키텍처에서 무엇을 의미하는지** 사실대로 재기술했다:

- `infoModeEnabled`는 backend lockless intermediate 게이트
  (`trip.infoModeEnabled && waypoint.kind === 'intermediate'`)의 opt-in 신호이며,
  lock 없는 trip의 매역 station-passed **silent push** 발사를 허용한다.
- 이 게이트는 admin kill switch(#1967, `killSwitchLocklessIntermediate`)로 backend deploy
  없이 즉시 우회 가능하다.
- ADR-024가 정의하는 알림/알람 원격 visible 채널과는 별개 경로임을 명시(혼동 방지).

## 변경 파일

- `docs/decisions/ADR-014-decision-process-rules.md` — "C 토글" 표현 6곳 정정 + 변경 이력 추가
  + ADR-024 References 추가
- `src/features/alarm/hooks/useApnsTripRegistration.ts:72` JSDoc 정정
- `src/features/alarm/store/useUserIntentStore.ts` 헤더 JSDoc 정정

**로직 변경 없음** — docs + 주석만 (`git diff` 확인, non-comment 코드 라인 diff 0).

## 검증

- `npm test` — 428 suites / 9147 tests pass, coverage 100% 유지
- `npm run type-check` — pass
- `npm run lint:orphan` — No orphan exports detected

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (N/A, doc/comment only, no new export)
2. **V/X dashboard** — N/A. 코드 동작 신호 변경 없음(문서/주석만)
3. **의존 PR** — N/A
4. **측정 plan** — N/A — doc-only fix, 회귀 신호 없음
5. **Device verify** — N/A — type-check + unit only. 로직 변경 없음

## 이슈 스펙 대비 이탈

- 이슈 본문의 fix 위치 목록에 `.claude/projects/.../memory/feedback_user_intent_equal_protection.md`
  갱신이 포함되어 있으나, 이는 저장소 밖 사용자 홈 디렉토리 파일(git 추적 대상 아님)이라
  본 PR 범위에서 제외. 필요 시 메인 세션에서 별도 memory 갱신 필요.
- 이슈 접수 이후 ADR-024가 확정되어, 브리핑 지시대로 단순 문구 삭제가 아니라 ADR-024/023과
  정합되게 현재 아키텍처 사실을 반영해 재기술함(옵션 A의 범위 내 확장, 로직 변경 없음).
