### PR TITLE
fix(#2115): BoardingTrainList 재등록 직후 loading 미구분 수정

### DIFF
--- a/src/features/route/hooks/__tests__/useTransferTrainList.test.tsx
+++ b/src/features/route/hooks/__tests__/useTransferTrainList.test.tsx
@@ -71,8 +71,8 @@ const route = makeTransferRoute({
 });
 const gondeokOn6 = findStationByNameAndLine('공덕', '6') as Station;
 
-function arrivalRet(arrival: StationArrival | null) {
-  return { arrival, loading: false, isMock: false, refetch: mockRefetch };
+function arrivalRet(arrival: StationArrival | null, loading = false) {
+  return { arrival, loading, isMock: false, refetch: mockRefetch };
 }
 
 function makeTrain(overrides: Partial<ArrivalInfo>): ArrivalInfo {
@@ -655,6 +655,63 @@ describe('사용자 trip 2026-06-12 회귀 가드', () => {
       }),
     );
     expect(mockCreateLock).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * #2115 — 환승 leg 재진입 직후 첫 arrival fetch 완료 전 loading이 그대로 노출되는지 검증.
+ *
+ * 근본 원인은 useArrivalInfo 자체(이미 useArrivalInfo.test.ts에서 키 변경 → loading 전이 검증됨)가
+ * 아니라, HomeScreen이 BoardingTrainList에 loading을 아예 전달하지 않던 wiring 누락이었다.
+ * 본 describe는 useTransferTrainList가 useArrivalInfo의 loading을 그대로 result에 노출하는지,
+ * 즉 wiring이 끊기지 않는지를 박제한다.
+ */
+describe('#2115 loading passthrough', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPrefetchArrival.mockResolvedValue(undefined);
+  });
+
+  it('키 변경(환승역 진입) 직후 첫 fetch 미완료 → loading=true', () => {
+    mockUseArrival.mockReturnValue(arrivalRet(null, true));
+    const { result } = renderHook(() =>
+      useTransferTrainList({
+        lock,
+        route,
+        destinationName: '여의나루',
+        currentStation: gondeokOn6,
+      }),
+    );
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('fetch 완료 + 진짜 empty(도착 열차 없음) → loading=false', () => {
+    mockUseArrival.mockReturnValue(arrivalRet({ up: [], down: [] }, false));
+    const { result } = renderHook(() =>
+      useTransferTrainList({
+        lock,
+        route,
+        destinationName: '여의나루',
+        currentStation: gondeokOn6,
+      }),
+    );
+    expect(result.current.loading).toBe(false);
+    expect(result.current.arrivals).toEqual([]);
+  });
+
+  it('fetch 완료 + data 도착 → loading=false + arrivals populated', () => {
+    const trains = [makeTrain({ trainCode: 'T-1' })];
+    mockUseArrival.mockReturnValue(arrivalRet({ up: trains, down: [] }, false));
+    const { result } = renderHook(() =>
+      useTransferTrainList({
+        lock,
+        route,
+        destinationName: '여의나루',
+        currentStation: gondeokOn6,
+      }),
+    );
+    expect(result.current.loading).toBe(false);
+    expect(result.current.arrivals.length).toBeGreaterThanOrEqual(1);
   });
 });
 

--- a/src/features/route/hooks/useTransferTrainList.ts
+++ b/src/features/route/hooks/useTransferTrainList.ts
@@ -37,6 +37,12 @@ export interface UseTransferTrainListResult {
   context: ActiveTransferContext | null;
   /** 다음 노선 + 환승역 기준 도착 list, direction으로 필터된 결과. */
   arrivals: ArrivalInfo[];
+  /**
+   * #2115 — (환승역, 다음 노선) 키의 첫 arrival fetch가 아직 완료되지 않았는지 여부.
+   * true인 동안 호출자(BoardingTrainList)는 "도착 예정 열차 없음" 대신 loading skeleton을
+   * 노출해야 한다. context 비활성(currentStation=null 등)이면 useArrivalInfo 자체가 idle이라 false.
+   */
+  loading: boolean;
   /** 사용자가 다음 열차 탭 시 호출 — 새 BoardingLock 생성 (기존 lock 자동 교체). */
   createTransferLock: (train: ArrivalInfo) => void;
 }
@@ -63,7 +69,7 @@ export function useTransferTrainList({
 
   const transferStationName = context?.transferStationInToLine.name ?? null;
   const transferLine = context?.nextLine ?? null;
-  const { arrival, refetch } = useArrivalInfo(transferStationName, transferLine, arrivalProvider);
+  const { arrival, loading, refetch } = useArrivalInfo(transferStationName, transferLine, arrivalProvider);
 
   // #814 — 환승 알람 imminent 시점부터 다음 노선 arrival을 사전 폴링한다.
   // findUpcomingTransferPrefetch는 lock 활성 + transfer 라우트 + 다음 환승까지 잔여 stops ≤ 1
@@ -172,7 +178,7 @@ export function useTransferTrainList({
     createTransferLock(chosen);
   }, [transferKey, arrivals, createTransferLock]);
 
-  return { context, arrivals, createTransferLock };
+  return { context, arrivals, loading, createTransferLock };
 }
 
 /** 테스트 노출용. 외부 호출자는 useTransferTrainList의 result.arrivals를 사용. */

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -832,6 +832,7 @@ export default function HomeScreen() {
   const {
     context: transferContext,
     arrivals: transferArrivals,
+    loading: transferLoading,
     createTransferLock,
   } = useTransferTrainList({
     lock: boardingLock,
@@ -1486,6 +1487,11 @@ export default function HomeScreen() {
                                     // pending 일치/정정 effect가 발화한다. fusionBoardingLock 기반 SSOT 사용.
                                     lockedTrainCode={lockedTrainCode}
                                     onLockCorrected={handleLockCorrected}
+                                    // #2115 — trip 재등록/origin 변경 직후 첫 arrival fetch 완료 전에는
+                                    // loading skeleton 노출. 이전에는 arrivalLoading이 useArrivalInfo에서
+                                    // 계산되고도 이 prop으로 전달되지 않아 fetch 완료 전 빈 배열이 그대로
+                                    // "도착 예정 열차 없음"으로 렌더됐다.
+                                    loading={arrivalLoading}
                                   />
                                 </View>
                               );
@@ -1529,6 +1535,8 @@ export default function HomeScreen() {
                                   // round-trip 정정 시 동일 toast UX 적용.
                                   lockedTrainCode={lockedTrainCode}
                                   onLockCorrected={handleLockCorrected}
+                                  // #2115 — 환승역 도달 직후 다음 노선 첫 arrival fetch 완료 전 loading 노출.
+                                  loading={transferLoading}
                                 />
                               );
                             }


### PR DESCRIPTION
Closes #2115

## 원인 검증 결과

이슈의 "의심 원인" 3개 경로를 코드로 검증한 결과, **실제 원인은 의심 경로와 다르다**:

1. `useArrivalInfo`의 (station,line) 키 변경 시 state 전이 — **정상 동작 확인**. 키 변경 시
   캐시 miss면 `loading=true`로 전이되는 로직이 이미 존재하고, `useArrivalInfo.test.ts`에서
   해당 시나리오(캐시 없는 새 역 → loading=true → data/empty)가 이미 광범위하게 커버되어 있음.
2. `useBoardingLockController.ts:280`의 `boardingListArrivals` — arrival/loading 신호 자체는
   정상 계산되지만, **HomeScreen이 이 loading 신호를 BoardingTrainList의 `loading` prop으로
   아예 전달하지 않고 있었다.** `HomeScreen.tsx`에는 `arrivalLoading`이 이미 `useArrivalInfo`에서
   구조분해되어 존재했지만(1667번 라인의 별도 arrival 표시 영역에서만 사용), origin/transfer 두
   `BoardingTrainList` 인스턴스에는 `loading` prop 자체가 누락되어 있어 `loading = false`
   (컴포넌트 기본값)로 항상 렌더되고 있었다.
3. 잘못된 (station,line) 키로 조회하는 경로 — 확인 결과 `effectiveOrigin?.name` / `approachLine`
   키가 정확히 사용되고 있어 문제 없음.

**결론**: 버그는 훅의 상태 전이 로직이 아니라 **HomeScreen의 wiring 누락**. `BoardingTrainList`는
`loading` prop을 받아 skeleton을 렌더하는 기능을 이미 갖추고 있었지만(#1177), 두 호출 지점 모두
prop을 전달하지 않아 사문화되어 있었다.

## 변경 사항

- `src/screens/HomeScreen.tsx`: origin hop `BoardingTrainList`에 `loading={arrivalLoading}`,
  transfer hop `BoardingTrainList`에 `loading={transferLoading}` 전달 추가.
- `src/features/route/hooks/useTransferTrainList.ts`: 내부 `useArrivalInfo`의 `loading`을
  구조분해해 `UseTransferTrainListResult.loading`으로 신규 노출 (기존에는 반환하지 않음).
- `src/features/route/hooks/__tests__/useTransferTrainList.test.tsx`: 키 변경 → loading=true /
  fetch 완료 후 진짜 empty(loading=false) / fetch 완료 후 data(loading=false) 3개 시나리오 테스트 추가.

기존 empty/fallback-empty/error 경로는 변경하지 않음 (surgical — loading 미구분 wiring만 수정).

## Wire-completion 5단

1. **Orphan 없음**: `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard**: 코드-only UI 상태 변경이라 dump에서 직접 관측되진 않음. 대신 테스트
   시나리오(`useTransferTrainList.test.tsx` `#2115 loading passthrough` describe)로 대체 —
   키 변경 직후 loading=true, fetch 완료 후 data/empty에서 loading=false 검증.
3. **의존 PR**: N/A.
4. **측정 plan**: 다음 실탑승 환승/재등록 시 BoardingTrainList가 재등록 직후 "불러오는 중"
   skeleton을 먼저 보이고 수 초 내(폴링 완료) 실제 열차 리스트로 전환되는지 관찰. 이전처럼
   즉시 "도착 예정 열차 없음"이 보이면 회귀.
5. **Device verify**: 필요 — 환승역 재등록 직후(또는 origin 변경 직후) BoardingTrainList가
   skeleton → 실제 리스트로 전환되는지 실기기(또는 시뮬레이터 mock)로 확인.

## 테스트

- `npm test`: 8851/8851 pass, 커버리지 100% (lines/functions/branches/statements)
- `npm run type-check`: pass
- `npm run lint:orphan`: 0 orphan