### PR TITLE
fix(#2114): stale trip-ended sentinel이 살아있는 새 trip을 삭제하는 회귀 수리

### DIFF
--- a/src/features/alarm/hooks/__tests__/useDeviceSelfEnd.test.ts
+++ b/src/features/alarm/hooks/__tests__/useDeviceSelfEnd.test.ts
@@ -10,6 +10,7 @@ jest.mock('../../utils/tripEndedSentinel', () => {
   return {
     // #2114 — 순수 함수라 실제 구현 그대로 사용. storage I/O 함수만 mock.
     isTripEndedSentinelStale: actual.isTripEndedSentinelStale,
+    resolveTripEndedSentinelVerdict: actual.resolveTripEndedSentinelVerdict,
     getTripEndedSentinel: (...args: unknown[]) => mockGetSentinel(...args),
     setTripEndedSentinel: (...args: unknown[]) => mockSetSentinel(...args),
     clearTripEndedSentinel: (...args: unknown[]) => mockClearSentinel(...args),
@@ -31,7 +32,7 @@ jest.mock('../../utils/triggerTripEndRecall', () => ({
   triggerTripEndRecall: (...args: unknown[]) => mockTriggerTripEndRecall(...args),
 }));
 
-const mockGetCurrentTripCorrIdSync = jest.fn(() => null);
+const mockGetCurrentTripCorrIdSync = jest.fn<string | null, []>(() => null);
 jest.mock('../../../observability/utils/tripCorrId', () => ({
   getCurrentTripCorrIdSync: () => mockGetCurrentTripCorrIdSync(),
 }));
@@ -124,6 +125,8 @@ beforeEach(() => {
   mockGetTripStartedAt.mockResolvedValue(null);
   mockRunTripBoundCleanups.mockResolvedValue(undefined);
   mockTriggerTripEndRecall.mockResolvedValue({ uploaded: false });
+  // #2114 (방안 C′) — 기본은 null(corrId sync cache 미수화 → timestamp fallback). 각 test가 필요 시 override.
+  mockGetCurrentTripCorrIdSync.mockReturnValue(null);
 });
 
 describe('useDeviceSelfEnd', () => {
@@ -151,7 +154,7 @@ describe('useDeviceSelfEnd', () => {
   describe('idempotent guard (sentinel already recorded)', () => {
     it('sentinel non-null이면 signal trigger돼도 cleanup skip', async () => {
       mockDestinationState = DESTINATION;
-      mockGetSentinel.mockResolvedValue(T0 - 60_000);
+      mockGetSentinel.mockResolvedValue({ endedAt: T0 - 60_000, corrId: null });
       // Signal 1 트리거 조건: destination match + strong confidence + 30s 지속.
       // 각 rerender에 새 currentStation 객체를 전달해 useEffect deps 변경을 유도(production
       // 에서는 fusion result가 매 tick 새 객체).
@@ -187,7 +190,7 @@ describe('useDeviceSelfEnd', () => {
   describe('#2114 stale sentinel guard', () => {
     it('stale sentinel(활성 trip이 sentinel보다 나중 시작) → clear 후 self-end 계속 진행', async () => {
       mockDestinationState = DESTINATION;
-      mockGetSentinel.mockResolvedValue(T0 - 120_000);
+      mockGetSentinel.mockResolvedValue({ endedAt: T0 - 120_000, corrId: null });
       mockGetTripStartedAt.mockResolvedValue(T0 - 60_000); // sentinel 이후 새 trip 시작 → stale.
       const { rerender } = withDateNow(T0, () =>
         renderHook(
@@ -215,6 +218,79 @@ describe('useDeviceSelfEnd', () => {
       // sentinel stale → clear 후 self-end chain 계속 진행 (idempotent guard 우회 아님, stale 판정).
       expect(mockRunTripBoundCleanups).toHaveBeenCalled();
       expect(mockSetSentinel).toHaveBeenCalled();
+    });
+  });
+
+  describe('#2114 방안 C′ — corrId 스코프 1순위 판정', () => {
+    it('corrId 불일치 → stale 확정 (timestamp상 fresh로 보여도 corrId mismatch가 우선) → clear 후 self-end 진행', async () => {
+      mockDestinationState = DESTINATION;
+      mockGetSentinel.mockResolvedValue({
+        endedAt: T0 + 100_000, // timestamp만 보면 fresh(tripStartedAt < sentinelAt).
+        corrId: 'corr-old-trip',
+      });
+      mockGetTripStartedAt.mockResolvedValue(T0 - 60_000);
+      mockGetCurrentTripCorrIdSync.mockReturnValue('corr-new-trip');
+      const { rerender } = withDateNow(T0, () =>
+        renderHook(
+          (p: UseDeviceSelfEndInputs) => useDeviceSelfEnd(p),
+          {
+            initialProps: baseInputs({
+              currentStation: { ...DESTINATION },
+              confidence: 'backend-ssot',
+              positionStability: 'unknown',
+            }),
+          },
+        ),
+      );
+      await waitFor(() => expect(mockGetTripStartedAt).toHaveBeenCalled());
+      withDateNow(T0 + 30_000, () => {
+        rerender(
+          baseInputs({
+            currentStation: { ...DESTINATION },
+            confidence: 'backend-ssot',
+            positionStability: 'unknown',
+          }),
+        );
+      });
+      await waitFor(() => expect(mockClearSentinel).toHaveBeenCalledTimes(1));
+      expect(mockRunTripBoundCleanups).toHaveBeenCalled();
+      expect(mockSetSentinel).toHaveBeenCalled();
+    });
+
+    it('corrId 일치 → fresh 확정 (timestamp상 stale로 보여도 corrId 일치가 우선) → idempotent skip 유지', async () => {
+      mockDestinationState = DESTINATION;
+      mockGetSentinel.mockResolvedValue({
+        endedAt: T0 - 120_000, // timestamp만 보면 stale(tripStartedAt > sentinelAt).
+        corrId: 'corr-same-trip',
+      });
+      mockGetTripStartedAt.mockResolvedValue(T0 - 60_000);
+      mockGetCurrentTripCorrIdSync.mockReturnValue('corr-same-trip');
+      const { rerender } = withDateNow(T0, () =>
+        renderHook(
+          (p: UseDeviceSelfEndInputs) => useDeviceSelfEnd(p),
+          {
+            initialProps: baseInputs({
+              currentStation: { ...DESTINATION },
+              confidence: 'backend-ssot',
+              positionStability: 'unknown',
+            }),
+          },
+        ),
+      );
+      await waitFor(() => expect(mockGetTripStartedAt).toHaveBeenCalled());
+      withDateNow(T0 + 30_000, () => {
+        rerender(
+          baseInputs({
+            currentStation: { ...DESTINATION },
+            confidence: 'backend-ssot',
+            positionStability: 'unknown',
+          }),
+        );
+      });
+      await waitFor(() => expect(mockGetSentinel).toHaveBeenCalled());
+      expect(mockClearSentinel).not.toHaveBeenCalled();
+      expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+      expect(mockSetSentinel).not.toHaveBeenCalled();
     });
   });
 

--- a/src/features/alarm/hooks/__tests__/useDeviceSelfEnd.test.ts
+++ b/src/features/alarm/hooks/__tests__/useDeviceSelfEnd.test.ts
@@ -4,11 +4,17 @@ import type { Station } from '../../../../shared/types/station';
 
 const mockGetSentinel = jest.fn();
 const mockSetSentinel = jest.fn();
-jest.mock('../../utils/tripEndedSentinel', () => ({
-  getTripEndedSentinel: (...args: unknown[]) => mockGetSentinel(...args),
-  setTripEndedSentinel: (...args: unknown[]) => mockSetSentinel(...args),
-  clearTripEndedSentinel: jest.fn(),
-}));
+const mockClearSentinel = jest.fn();
+jest.mock('../../utils/tripEndedSentinel', () => {
+  const actual = jest.requireActual('../../utils/tripEndedSentinel');
+  return {
+    // #2114 — 순수 함수라 실제 구현 그대로 사용. storage I/O 함수만 mock.
+    isTripEndedSentinelStale: actual.isTripEndedSentinelStale,
+    getTripEndedSentinel: (...args: unknown[]) => mockGetSentinel(...args),
+    setTripEndedSentinel: (...args: unknown[]) => mockSetSentinel(...args),
+    clearTripEndedSentinel: (...args: unknown[]) => mockClearSentinel(...args),
+  };
+});
 
 const mockGetTripStartedAt = jest.fn();
 jest.mock('../../utils/tripStartStorage', () => ({
@@ -114,6 +120,7 @@ beforeEach(() => {
   mockDestinationState = null;
   mockGetSentinel.mockResolvedValue(null);
   mockSetSentinel.mockResolvedValue(undefined);
+  mockClearSentinel.mockResolvedValue(undefined);
   mockGetTripStartedAt.mockResolvedValue(null);
   mockRunTripBoundCleanups.mockResolvedValue(undefined);
   mockTriggerTripEndRecall.mockResolvedValue({ uploaded: false });
@@ -174,6 +181,40 @@ describe('useDeviceSelfEnd', () => {
       // sentinel 존재 → cleanup chain 미호출
       expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
       expect(mockSetSentinel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('#2114 stale sentinel guard', () => {
+    it('stale sentinel(활성 trip이 sentinel보다 나중 시작) → clear 후 self-end 계속 진행', async () => {
+      mockDestinationState = DESTINATION;
+      mockGetSentinel.mockResolvedValue(T0 - 120_000);
+      mockGetTripStartedAt.mockResolvedValue(T0 - 60_000); // sentinel 이후 새 trip 시작 → stale.
+      const { rerender } = withDateNow(T0, () =>
+        renderHook(
+          (p: UseDeviceSelfEndInputs) => useDeviceSelfEnd(p),
+          {
+            initialProps: baseInputs({
+              currentStation: { ...DESTINATION },
+              confidence: 'backend-ssot',
+              positionStability: 'unknown',
+            }),
+          },
+        ),
+      );
+      await waitFor(() => expect(mockGetTripStartedAt).toHaveBeenCalled());
+      withDateNow(T0 + 30_000, () => {
+        rerender(
+          baseInputs({
+            currentStation: { ...DESTINATION },
+            confidence: 'backend-ssot',
+            positionStability: 'unknown',
+          }),
+        );
+      });
+      await waitFor(() => expect(mockClearSentinel).toHaveBeenCalledTimes(1));
+      // sentinel stale → clear 후 self-end chain 계속 진행 (idempotent guard 우회 아님, stale 판정).
+      expect(mockRunTripBoundCleanups).toHaveBeenCalled();
+      expect(mockSetSentinel).toHaveBeenCalled();
     });
   });
 

--- a/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
@@ -17,11 +17,17 @@ jest.mock('../../api/tripStatus', () => ({
 
 const mockGetSentinel = jest.fn();
 const mockSetSentinel = jest.fn();
-jest.mock('../../utils/tripEndedSentinel', () => ({
-  getTripEndedSentinel: (...args: unknown[]) => mockGetSentinel(...args),
-  setTripEndedSentinel: (...args: unknown[]) => mockSetSentinel(...args),
-  clearTripEndedSentinel: jest.fn(),
-}));
+const mockClearSentinel = jest.fn();
+jest.mock('../../utils/tripEndedSentinel', () => {
+  const actual = jest.requireActual('../../utils/tripEndedSentinel');
+  return {
+    // #2114 — 순수 함수라 실제 구현 그대로 사용. storage I/O 함수만 mock.
+    isTripEndedSentinelStale: actual.isTripEndedSentinelStale,
+    getTripEndedSentinel: (...args: unknown[]) => mockGetSentinel(...args),
+    setTripEndedSentinel: (...args: unknown[]) => mockSetSentinel(...args),
+    clearTripEndedSentinel: (...args: unknown[]) => mockClearSentinel(...args),
+  };
+});
 
 // #2045 Signal 4 — silent push last-received stamp + trip started at.
 const mockGetLastSilentPushReceivedAt = jest.fn();
@@ -89,6 +95,7 @@ beforeEach(async () => {
   await AsyncStorage.clear();
   mockGetSentinel.mockResolvedValue(null);
   mockSetSentinel.mockResolvedValue(undefined);
+  mockClearSentinel.mockResolvedValue(undefined);
   mockTriggerTripEndRecall.mockResolvedValue({ uploaded: false });
   mockRunTripBoundCleanups.mockResolvedValue(undefined);
   mockFlushSignalDumpOutbox.mockResolvedValue({ ok: false, skipped: true });
@@ -146,6 +153,16 @@ describe('runLaunchTripReconciliation', () => {
     mockGetSentinel.mockResolvedValue(1_700_000_000_000);
     await runLaunchTripReconciliation();
     expect(mockFetchTripStatus).not.toHaveBeenCalled();
+  });
+
+  it('#2114 — stale sentinel(활성 trip이 sentinel보다 나중 시작) → clear 후 fetchTripStatus 진행', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    mockGetSentinel.mockResolvedValue(1_700_000_000_000);
+    mockGetTripStartedAt.mockResolvedValue(1_700_000_060_000); // sentinel 이후 새 trip 시작.
+    mockFetchTripStatus.mockResolvedValue({ status: 'active', endedAt: null, endReason: null });
+    await runLaunchTripReconciliation();
+    expect(mockClearSentinel).toHaveBeenCalledTimes(1);
+    expect(mockFetchTripStatus).toHaveBeenCalledWith('tk', 'https://api.test.dev');
   });
 
   it('status ended → recall + cleanup + sentinel + active trip clear (#2069 — 로컬 알림 미발사)', async () => {
@@ -354,14 +371,16 @@ describe('runLaunchTripReconciliation', () => {
       expect(mockSetSentinel).not.toHaveBeenCalled();
     });
 
-    it('sentinel 기록 있음 → Signal 4 미진입 (fetch/self-end 모두 skip)', async () => {
-      mockGetSentinel.mockResolvedValue(1_700_000_000_000);
+    it('sentinel 기록 있음(신선, 현재 trip과 동일 시점) → Signal 4 미진입 (fetch/self-end 모두 skip)', async () => {
+      // sentinel=now(활성 trip 시작 시각 이후) — stale 아님 → 기존 skip 동작 유지.
+      mockGetSentinel.mockResolvedValue(now);
       mockGetLastSilentPushReceivedAt.mockResolvedValue(now - OVER_TIMEOUT);
       mockGetTripStartedAt.mockResolvedValue(now - UNDER_KTX);
       await runLaunchTripReconciliation();
       expect(mockFetchTripStatus).not.toHaveBeenCalled();
       expect(mockTriggerTripEndRecall).not.toHaveBeenCalled();
       expect(mockSetSentinel).not.toHaveBeenCalled();
+      expect(mockClearSentinel).not.toHaveBeenCalled();
       // sentinel skip는 위 sentinel test에서도 커버 — Signal 4가 sentinel skip를 우회하지 않는지 검증.
     });
 

--- a/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
+++ b/src/features/alarm/hooks/__tests__/useLaunchTripReconciliation.test.ts
@@ -23,6 +23,7 @@ jest.mock('../../utils/tripEndedSentinel', () => {
   return {
     // #2114 — 순수 함수라 실제 구현 그대로 사용. storage I/O 함수만 mock.
     isTripEndedSentinelStale: actual.isTripEndedSentinelStale,
+    resolveTripEndedSentinelVerdict: actual.resolveTripEndedSentinelVerdict,
     getTripEndedSentinel: (...args: unknown[]) => mockGetSentinel(...args),
     setTripEndedSentinel: (...args: unknown[]) => mockSetSentinel(...args),
     clearTripEndedSentinel: (...args: unknown[]) => mockClearSentinel(...args),
@@ -71,7 +72,7 @@ jest.mock('../../utils/alarmLog', () => ({
 }));
 
 // #1597 — trip 종료 ended 경로에서 cleanup 직전에 corrId snapshot 캡처 + cleanup 후 prompt enqueue.
-const mockGetCurrentTripCorrIdSync = jest.fn(() => null);
+const mockGetCurrentTripCorrIdSync = jest.fn<string | null, []>(() => null);
 jest.mock('../../../observability/utils/tripCorrId', () => ({
   getCurrentTripCorrIdSync: () => mockGetCurrentTripCorrIdSync(),
 }));
@@ -103,6 +104,8 @@ beforeEach(async () => {
   // #2045 Signal 4 — 기본은 null(판정 skip). 각 test가 필요 시 override.
   mockGetLastSilentPushReceivedAt.mockResolvedValue(null);
   mockGetTripStartedAt.mockResolvedValue(null);
+  // #2114 (방안 C′) — 기본은 null(corrId sync cache 미수화 → timestamp fallback). 각 test가 필요 시 override.
+  mockGetCurrentTripCorrIdSync.mockReturnValue(null);
   process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
 });
 
@@ -150,19 +153,42 @@ describe('runLaunchTripReconciliation', () => {
 
   it('sentinel 기록 있음 → fetch skip', async () => {
     await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
-    mockGetSentinel.mockResolvedValue(1_700_000_000_000);
+    mockGetSentinel.mockResolvedValue({ endedAt: 1_700_000_000_000, corrId: null });
     await runLaunchTripReconciliation();
     expect(mockFetchTripStatus).not.toHaveBeenCalled();
   });
 
   it('#2114 — stale sentinel(활성 trip이 sentinel보다 나중 시작) → clear 후 fetchTripStatus 진행', async () => {
     await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
-    mockGetSentinel.mockResolvedValue(1_700_000_000_000);
+    mockGetSentinel.mockResolvedValue({ endedAt: 1_700_000_000_000, corrId: null });
     mockGetTripStartedAt.mockResolvedValue(1_700_000_060_000); // sentinel 이후 새 trip 시작.
     mockFetchTripStatus.mockResolvedValue({ status: 'active', endedAt: null, endReason: null });
     await runLaunchTripReconciliation();
     expect(mockClearSentinel).toHaveBeenCalledTimes(1);
     expect(mockFetchTripStatus).toHaveBeenCalledWith('tk', 'https://api.test.dev');
+  });
+
+  describe('#2114 방안 C′ — corrId 스코프 1순위 판정', () => {
+    it('corrId 불일치 → stale 확정 (timestamp상 fresh로 보여도 corrId mismatch가 우선)', async () => {
+      await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+      mockGetSentinel.mockResolvedValue({ endedAt: 1_700_000_100_000, corrId: 'corr-old-trip' });
+      mockGetTripStartedAt.mockResolvedValue(1_700_000_000_000); // timestamp만 보면 fresh.
+      mockGetCurrentTripCorrIdSync.mockReturnValue('corr-new-trip');
+      mockFetchTripStatus.mockResolvedValue({ status: 'active', endedAt: null, endReason: null });
+      await runLaunchTripReconciliation();
+      expect(mockClearSentinel).toHaveBeenCalledTimes(1);
+      expect(mockFetchTripStatus).toHaveBeenCalledWith('tk', 'https://api.test.dev');
+    });
+
+    it('corrId 일치 → fresh 확정 (timestamp상 stale로 보여도 corrId 일치가 우선 → skip 유지)', async () => {
+      await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+      mockGetSentinel.mockResolvedValue({ endedAt: 1_700_000_000_000, corrId: 'corr-same-trip' });
+      mockGetTripStartedAt.mockResolvedValue(1_700_000_060_000); // timestamp만 보면 stale.
+      mockGetCurrentTripCorrIdSync.mockReturnValue('corr-same-trip');
+      await runLaunchTripReconciliation();
+      expect(mockClearSentinel).not.toHaveBeenCalled();
+      expect(mockFetchTripStatus).not.toHaveBeenCalled();
+    });
   });
 
   it('status ended → recall + cleanup + sentinel + active trip clear (#2069 — 로컬 알림 미발사)', async () => {
@@ -176,7 +202,7 @@ describe('runLaunchTripReconciliation', () => {
     expect(mockFetchTripStatus).toHaveBeenCalledWith('tk', 'https://api.test.dev');
     expect(mockTriggerTripEndRecall).toHaveBeenCalledTimes(1);
     expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
-    expect(mockSetSentinel).toHaveBeenCalledWith(1_700_000_000_000);
+    expect(mockSetSentinel).toHaveBeenCalledWith(1_700_000_000_000, null);
     expect(await AsyncStorage.getItem(ACTIVE_TRIP_KEY)).toBeNull();
   });
 
@@ -211,7 +237,7 @@ describe('runLaunchTripReconciliation', () => {
       endReason: 'unknown',
     });
     await runLaunchTripReconciliation();
-    expect(mockSetSentinel).toHaveBeenCalledWith(Date.now());
+    expect(mockSetSentinel).toHaveBeenCalledWith(Date.now(), null);
     jest.useRealTimers();
   });
 
@@ -225,7 +251,7 @@ describe('runLaunchTripReconciliation', () => {
     await runLaunchTripReconciliation();
     expect(mockTriggerTripEndRecall).toHaveBeenCalledTimes(1);
     expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
-    expect(mockSetSentinel).toHaveBeenCalledWith(1);
+    expect(mockSetSentinel).toHaveBeenCalledWith(1, null);
   });
 
   it('status active → 변경 없음 + cleanup/recall 호출 안 함 (회귀 0)', async () => {
@@ -310,7 +336,7 @@ describe('runLaunchTripReconciliation', () => {
       expect(mockTriggerTripEndRecall).toHaveBeenCalledTimes(1);
       expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
       expect(mockTriggerTripGroundTruthPrompt).toHaveBeenCalledTimes(1);
-      expect(mockSetSentinel).toHaveBeenCalledWith(now);
+      expect(mockSetSentinel).toHaveBeenCalledWith(now, null);
       expect(await AsyncStorage.getItem(ACTIVE_TRIP_KEY)).toBeNull();
     });
 
@@ -373,7 +399,7 @@ describe('runLaunchTripReconciliation', () => {
 
     it('sentinel 기록 있음(신선, 현재 trip과 동일 시점) → Signal 4 미진입 (fetch/self-end 모두 skip)', async () => {
       // sentinel=now(활성 trip 시작 시각 이후) — stale 아님 → 기존 skip 동작 유지.
-      mockGetSentinel.mockResolvedValue(now);
+      mockGetSentinel.mockResolvedValue({ endedAt: now, corrId: null });
       mockGetLastSilentPushReceivedAt.mockResolvedValue(now - OVER_TIMEOUT);
       mockGetTripStartedAt.mockResolvedValue(now - UNDER_KTX);
       await runLaunchTripReconciliation();

--- a/src/features/alarm/hooks/useDeviceSelfEnd.ts
+++ b/src/features/alarm/hooks/useDeviceSelfEnd.ts
@@ -57,7 +57,9 @@ import {
 } from '../utils/deviceSelfEndSignals';
 import { getTripStartedAt } from '../utils/tripStartStorage';
 import {
+  clearTripEndedSentinel,
   getTripEndedSentinel,
+  isTripEndedSentinelStale,
   setTripEndedSentinel,
 } from '../utils/tripEndedSentinel';
 import { runTripBoundCleanups } from '../store/tripBoundCleanups';
@@ -154,10 +156,20 @@ export function useDeviceSelfEnd(inputs: UseDeviceSelfEndInputs): void {
       firedForDestinationIdRef.current = capturedDestinationId;
       try {
         // Idempotent guard: sentinel 이미 있으면 backend cleanup 완료 상태 → skip.
+        // #2114 — sentinel이 현재 활성 trip보다 이전 trip의 것이면(stale) skip하지 않고
+        // clear 후 self-end를 계속 진행한다. stale sentinel이 self-end를 영구 봉인하는
+        // 부수 결함(밤샘 trip force-end sentinel이 그 직후 등록된 새 trip의 self-end를
+        // 계속 "이미 처리됨"으로 오판) 동시 수리.
         const sentinel = await getTripEndedSentinel();
         if (sentinel !== null) {
-          logger.info(`skip — sentinel already recorded reason=${reason}`);
-          return;
+          if (!isTripEndedSentinelStale(sentinel, tripStartedAt)) {
+            logger.info(`skip — sentinel already recorded reason=${reason}`);
+            return;
+          }
+          logger.info(
+            `sentinel=${sentinel} stale (tripStartedAt=${tripStartedAt}) reason=${reason} → clear + continue`,
+          );
+          await clearTripEndedSentinel();
         }
 
         const now = Date.now();
@@ -188,7 +200,7 @@ export function useDeviceSelfEnd(inputs: UseDeviceSelfEndInputs): void {
         logger.warn('device self-end 실패 (graceful)', e);
       }
     },
-    [releaseLock],
+    [releaseLock, tripStartedAt],
   );
 
   // 매 render tick에서 fusion 신호 평가. 신호 변경마다 실행되며, 매 evaluation 시점의 fresh input으로

--- a/src/features/alarm/hooks/useDeviceSelfEnd.ts
+++ b/src/features/alarm/hooks/useDeviceSelfEnd.ts
@@ -59,7 +59,7 @@ import { getTripStartedAt } from '../utils/tripStartStorage';
 import {
   clearTripEndedSentinel,
   getTripEndedSentinel,
-  isTripEndedSentinelStale,
+  resolveTripEndedSentinelVerdict,
   setTripEndedSentinel,
 } from '../utils/tripEndedSentinel';
 import { runTripBoundCleanups } from '../store/tripBoundCleanups';
@@ -155,19 +155,29 @@ export function useDeviceSelfEnd(inputs: UseDeviceSelfEndInputs): void {
       // cleanup이 실행됐거나 진행 중이라 재발화도 스킵되어야 정합.
       firedForDestinationIdRef.current = capturedDestinationId;
       try {
+        // #1597 — clearTripCorrId가 cache를 비우기 전에 (아직 살아있는) 현재 trip의 corrId
+        // snapshot 캡처. #2114 (방안 C′) — sentinel 판정의 currentCorrId로도 재사용.
+        const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
+
         // Idempotent guard: sentinel 이미 있으면 backend cleanup 완료 상태 → skip.
-        // #2114 — sentinel이 현재 활성 trip보다 이전 trip의 것이면(stale) skip하지 않고
+        // #2114 — sentinel이 현재 활성 trip과 다른 trip의 것이면(stale) skip하지 않고
         // clear 후 self-end를 계속 진행한다. stale sentinel이 self-end를 영구 봉인하는
         // 부수 결함(밤샘 trip force-end sentinel이 그 직후 등록된 새 trip의 self-end를
-        // 계속 "이미 처리됨"으로 오판) 동시 수리.
+        // 계속 "이미 처리됨"으로 오판) 동시 수리. 판정은 corrId 1순위 + timestamp fallback
+        // (resolveTripEndedSentinelVerdict, 방안 C′).
         const sentinel = await getTripEndedSentinel();
         if (sentinel !== null) {
-          if (!isTripEndedSentinelStale(sentinel, tripStartedAt)) {
+          const verdict = resolveTripEndedSentinelVerdict(
+            sentinel,
+            tripStartedAt,
+            endedCorrIdSnapshot,
+          );
+          if (verdict !== 'stale') {
             logger.info(`skip — sentinel already recorded reason=${reason}`);
             return;
           }
           logger.info(
-            `sentinel=${sentinel} stale (tripStartedAt=${tripStartedAt}) reason=${reason} → clear + continue`,
+            `sentinel=${JSON.stringify(sentinel)} stale (tripStartedAt=${tripStartedAt}, currentCorrId=${endedCorrIdSnapshot}) reason=${reason} → clear + continue`,
           );
           await clearTripEndedSentinel();
         }
@@ -185,7 +195,6 @@ export function useDeviceSelfEnd(inputs: UseDeviceSelfEndInputs): void {
         // silent push trip-ended / lifecycle-backstop force-end 와 동일 시퀀스.
         // recall이 cleanup 전에 호출돼야 ROUTE_KEY / DESTINATION_KEY / TRIP_STARTED_AT_KEY 를 읽을 수 있다.
         await triggerTripEndRecall();
-        const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
         await runTripBoundCleanups();
         await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
         useDestinationStore.setState({
@@ -194,7 +203,8 @@ export function useDeviceSelfEnd(inputs: UseDeviceSelfEndInputs): void {
           tripOrigin: null,
         });
         await releaseLock();
-        await setTripEndedSentinel(now);
+        // #2114 (방안 C′) — sentinel에 corrId 동봉.
+        await setTripEndedSentinel(now, endedCorrIdSnapshot);
       } catch (e) {
         // graceful — 다음 tick 재평가에서 다시 시도. sentinel/refs 상태에 따라 자연 dedup.
         logger.warn('device self-end 실패 (graceful)', e);

--- a/src/features/alarm/hooks/useLaunchTripReconciliation.ts
+++ b/src/features/alarm/hooks/useLaunchTripReconciliation.ts
@@ -48,7 +48,9 @@ import {
   SIGNAL_4_SILENT_PUSH_TIMEOUT_MS,
 } from '../../../shared/constants/realtime';
 import {
+  clearTripEndedSentinel,
   getTripEndedSentinel,
+  isTripEndedSentinelStale,
   setTripEndedSentinel,
 } from '../utils/tripEndedSentinel';
 import { getLastSilentPushReceivedAt } from '../utils/lastSilentPushReceivedAt';
@@ -104,8 +106,19 @@ export async function runLaunchTripReconciliation(): Promise<void> {
 
     const sentinel = await getTripEndedSentinel();
     if (sentinel !== null) {
-      logger.info('skip — sentinel already recorded');
-      return;
+      // #2114 — sentinel이 현재 활성 trip보다 이전 trip의 것이면(stale) skip하지 않고
+      // clear 후 reconciliation을 계속 진행한다. stale sentinel이 정상 launch reconciliation을
+      // 영구히 막는 부수 결함(밤샘 trip force-end sentinel이 그 직후 등록된 새 trip을 계속
+      // "이미 처리됨"으로 오판)을 함께 수리.
+      const tripStartedAtForSentinel = await getTripStartedAt();
+      if (!isTripEndedSentinelStale(sentinel, tripStartedAtForSentinel)) {
+        logger.info('skip — sentinel already recorded');
+        return;
+      }
+      logger.info(
+        `sentinel=${sentinel} stale (tripStartedAt=${tripStartedAtForSentinel}) → clear + continue`,
+      );
+      await clearTripEndedSentinel();
     }
 
     // #2045 (Signal 4, Issue #2043 β 후속) — backend-timeout self-end 판정.

--- a/src/features/alarm/hooks/useLaunchTripReconciliation.ts
+++ b/src/features/alarm/hooks/useLaunchTripReconciliation.ts
@@ -50,7 +50,7 @@ import {
 import {
   clearTripEndedSentinel,
   getTripEndedSentinel,
-  isTripEndedSentinelStale,
+  resolveTripEndedSentinelVerdict,
   setTripEndedSentinel,
 } from '../utils/tripEndedSentinel';
 import { getLastSilentPushReceivedAt } from '../utils/lastSilentPushReceivedAt';
@@ -106,17 +106,24 @@ export async function runLaunchTripReconciliation(): Promise<void> {
 
     const sentinel = await getTripEndedSentinel();
     if (sentinel !== null) {
-      // #2114 — sentinel이 현재 활성 trip보다 이전 trip의 것이면(stale) skip하지 않고
+      // #2114 — sentinel이 현재 활성 trip과 다른 trip의 것이면(stale) skip하지 않고
       // clear 후 reconciliation을 계속 진행한다. stale sentinel이 정상 launch reconciliation을
       // 영구히 막는 부수 결함(밤샘 trip force-end sentinel이 그 직후 등록된 새 trip을 계속
-      // "이미 처리됨"으로 오판)을 함께 수리.
+      // "이미 처리됨"으로 오판)을 함께 수리. 판정은 corrId 1순위 + timestamp fallback
+      // (resolveTripEndedSentinelVerdict, 방안 C′).
       const tripStartedAtForSentinel = await getTripStartedAt();
-      if (!isTripEndedSentinelStale(sentinel, tripStartedAtForSentinel)) {
+      const currentCorrIdForSentinel = getCurrentTripCorrIdSync();
+      const sentinelVerdict = resolveTripEndedSentinelVerdict(
+        sentinel,
+        tripStartedAtForSentinel,
+        currentCorrIdForSentinel,
+      );
+      if (sentinelVerdict !== 'stale') {
         logger.info('skip — sentinel already recorded');
         return;
       }
       logger.info(
-        `sentinel=${sentinel} stale (tripStartedAt=${tripStartedAtForSentinel}) → clear + continue`,
+        `sentinel=${JSON.stringify(sentinel)} stale (tripStartedAt=${tripStartedAtForSentinel}, currentCorrId=${currentCorrIdForSentinel}) → clear + continue`,
       );
       await clearTripEndedSentinel();
     }
@@ -160,7 +167,8 @@ export async function runLaunchTripReconciliation(): Promise<void> {
       const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
       await runTripBoundCleanups();
       await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
-      await setTripEndedSentinel(now);
+      // #2114 (방안 C′) — sentinel에 corrId 동봉.
+      await setTripEndedSentinel(now, endedCorrIdSnapshot);
       await AsyncStorage.removeItem(ACTIVE_TRIP_KEY);
       return;
     }
@@ -202,7 +210,8 @@ export async function runLaunchTripReconciliation(): Promise<void> {
     await runTripBoundCleanups();
     // #1597 — trip-end 사용자 정답지 prompt enqueue (cleanup 후, corrId snapshot으로).
     await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
-    await setTripEndedSentinel(endedAt);
+    // #2114 (방안 C′) — sentinel에 corrId 동봉.
+    await setTripEndedSentinel(endedAt, endedCorrIdSnapshot);
     await AsyncStorage.removeItem(ACTIVE_TRIP_KEY);
   } catch (e) {
     logger.warn('reconciliation 실패 (graceful)', e);

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -102,7 +102,7 @@ jest.mock('../../utils/triggerTripEndRecall', () => ({
 }));
 
 // #1597 — trip-ended 경로에서 cleanup 직전에 corrId snapshot 캡처 + cleanup 후 prompt enqueue.
-const mockGetCurrentTripCorrIdSync = jest.fn(() => null);
+const mockGetCurrentTripCorrIdSync = jest.fn<string | null, []>(() => null);
 jest.mock('../../../observability/utils/tripCorrId', () => ({
   getCurrentTripCorrIdSync: () => mockGetCurrentTripCorrIdSync(),
 }));
@@ -2261,7 +2261,15 @@ describe('silentPushTask', () => {
         await handleSilentPush(tripEndedPayload({ reason: 'expired' }));
         expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
         expect(mockSetTripEndedSentinel).toHaveBeenCalledTimes(1);
-        expect(mockSetTripEndedSentinel).toHaveBeenCalledWith(expect.any(Number));
+        // #2114 (방안 C′) — 두번째 인자로 종료 trip의 corrId snapshot 동봉.
+        expect(mockSetTripEndedSentinel).toHaveBeenCalledWith(expect.any(Number), null);
+      });
+
+      // #2114 (방안 C′) — corrId snapshot이 non-null이면 sentinel에 함께 저장.
+      it('#2114 — getCurrentTripCorrIdSync가 non-null이면 setTripEndedSentinel에 corrId 동봉', async () => {
+        mockGetCurrentTripCorrIdSync.mockReturnValueOnce('corr-abc');
+        await handleSilentPush(tripEndedPayload({ reason: 'expired' }));
+        expect(mockSetTripEndedSentinel).toHaveBeenCalledWith(expect.any(Number), 'corr-abc');
       });
 
       // #2018 γ' — FG 상태(active)에서 trip-ended 수신 시 sentinel 저장 후 즉시 in-memory

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -960,7 +960,8 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
       await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
       // #899 (Seam C) — BG에서는 zustand store에 접근 불가. FG 복귀 시점에
       // useStateRehydration이 이 sentinel을 보고 destination/lock store도 reset.
-      await setTripEndedSentinel(receivedAt);
+      // #2114 (방안 C′) — sentinel에 corrId 동봉해 다음 소비 시점 trip 인스턴스 스코프 비교 가능하게.
+      await setTripEndedSentinel(receivedAt, endedCorrIdSnapshot);
       // #2018 γ' — FG 상태에서는 useStateRehydration의 AppState 'active' 이벤트가
       // 발생하지 않아 sentinel이 다음 BG/FG cycle까지 처리되지 않는다. 그동안 in-memory
       // destination store가 stale로 남아 UI가 "현재역 → 현재역 0정거장" 형태로 잔존

--- a/src/features/alarm/utils/__tests__/tripEndedSentinel.test.ts
+++ b/src/features/alarm/utils/__tests__/tripEndedSentinel.test.ts
@@ -3,6 +3,7 @@ import {
   clearTripEndedSentinel,
   getTripEndedSentinel,
   isTripEndedSentinelStale,
+  resolveTripEndedSentinelVerdict,
   setTripEndedSentinel,
 } from '../tripEndedSentinel';
 import { TRIP_ENDED_BY_BACKEND_AT_KEY } from '../../../../shared/constants/storageKeys';
@@ -27,40 +28,106 @@ describe('tripEndedSentinel', () => {
     removeItemMock.mockResolvedValue(undefined);
   });
 
-  it('setTripEndedSentinel — at 인자를 문자열로 직렬화해 sentinel 키에 저장', async () => {
-    await setTripEndedSentinel(1_700_000_000_000);
-    expect(setItemMock).toHaveBeenCalledWith(TRIP_ENDED_BY_BACKEND_AT_KEY, '1700000000000');
+  describe('setTripEndedSentinel (#2114 방안 C′ — JSON {endedAt, corrId})', () => {
+    it('at + corrId를 JSON으로 직렬화해 sentinel 키에 저장', async () => {
+      await setTripEndedSentinel(1_700_000_000_000, 'corr-abc');
+      expect(setItemMock).toHaveBeenCalledWith(
+        TRIP_ENDED_BY_BACKEND_AT_KEY,
+        JSON.stringify({ endedAt: 1_700_000_000_000, corrId: 'corr-abc' }),
+      );
+    });
+
+    it('corrId 미전달 시 null로 저장 (legacy 호출부 하위호환)', async () => {
+      await setTripEndedSentinel(1_700_000_000_000);
+      expect(setItemMock).toHaveBeenCalledWith(
+        TRIP_ENDED_BY_BACKEND_AT_KEY,
+        JSON.stringify({ endedAt: 1_700_000_000_000, corrId: null }),
+      );
+    });
+
+    it('기본값은 Date.now()', async () => {
+      const now = 1_710_000_000_000;
+      const spy = jest.spyOn(Date, 'now').mockReturnValue(now);
+      try {
+        await setTripEndedSentinel();
+      } finally {
+        spy.mockRestore();
+      }
+      expect(setItemMock).toHaveBeenCalledWith(
+        TRIP_ENDED_BY_BACKEND_AT_KEY,
+        JSON.stringify({ endedAt: now, corrId: null }),
+      );
+    });
+
+    it('AsyncStorage 실패는 흡수 (graceful)', async () => {
+      setItemMock.mockRejectedValueOnce(new Error('disk full'));
+      await expect(setTripEndedSentinel(1)).resolves.toBeUndefined();
+    });
   });
 
-  it('setTripEndedSentinel — 기본값은 Date.now()', async () => {
-    const now = 1_710_000_000_000;
-    const spy = jest.spyOn(Date, 'now').mockReturnValue(now);
-    try {
-      await setTripEndedSentinel();
-    } finally {
-      spy.mockRestore();
-    }
-    expect(setItemMock).toHaveBeenCalledWith(TRIP_ENDED_BY_BACKEND_AT_KEY, String(now));
-  });
+  describe('getTripEndedSentinel', () => {
+    it('신규 JSON 스키마 파싱 — {endedAt, corrId} 그대로 반환', async () => {
+      getItemMock.mockResolvedValueOnce(
+        JSON.stringify({ endedAt: 1_700_000_000_000, corrId: 'corr-abc' }),
+      );
+      await expect(getTripEndedSentinel()).resolves.toEqual({
+        endedAt: 1_700_000_000_000,
+        corrId: 'corr-abc',
+      });
+    });
 
-  it('setTripEndedSentinel — AsyncStorage 실패는 흡수 (graceful)', async () => {
-    setItemMock.mockRejectedValueOnce(new Error('disk full'));
-    await expect(setTripEndedSentinel(1)).resolves.toBeUndefined();
-  });
+    it('신규 JSON 스키마 + corrId=null', async () => {
+      getItemMock.mockResolvedValueOnce(
+        JSON.stringify({ endedAt: 1_700_000_000_000, corrId: null }),
+      );
+      await expect(getTripEndedSentinel()).resolves.toEqual({
+        endedAt: 1_700_000_000_000,
+        corrId: null,
+      });
+    });
 
-  it.each<[string, unknown, number | null]>([
-    ['숫자 문자열', '1700000000000', 1_700_000_000_000],
-    ['키 부재(null)', null, null],
-    ['NaN 문자열', 'abc', null],
-    ['빈 문자열은 Number("")=0이라 0 반환', '', 0],
-  ])('getTripEndedSentinel — %s → %s', async (_label, raw, expected) => {
-    getItemMock.mockResolvedValueOnce(raw);
-    await expect(getTripEndedSentinel()).resolves.toBe(expected);
-  });
+    it('legacy plain-number 문자열 — corrId=null로 fallback 파싱', async () => {
+      getItemMock.mockResolvedValueOnce('1700000000000');
+      await expect(getTripEndedSentinel()).resolves.toEqual({
+        endedAt: 1_700_000_000_000,
+        corrId: null,
+      });
+    });
 
-  it('getTripEndedSentinel — AsyncStorage 실패 시 null', async () => {
-    getItemMock.mockRejectedValueOnce(new Error('boom'));
-    await expect(getTripEndedSentinel()).resolves.toBeNull();
+    it('JSON이지만 endedAt 필드가 숫자가 아니면 legacy 숫자 파싱으로 재시도 후 실패 시 null', async () => {
+      getItemMock.mockResolvedValueOnce(JSON.stringify({ endedAt: 'not-a-number' }));
+      await expect(getTripEndedSentinel()).resolves.toBeNull();
+    });
+
+    it('JSON이지만 corrId 필드가 문자열이 아니면 null로 정규화', async () => {
+      getItemMock.mockResolvedValueOnce(
+        JSON.stringify({ endedAt: 1_700_000_000_000, corrId: 123 }),
+      );
+      await expect(getTripEndedSentinel()).resolves.toEqual({
+        endedAt: 1_700_000_000_000,
+        corrId: null,
+      });
+    });
+
+    it('키 부재(null) → null', async () => {
+      getItemMock.mockResolvedValueOnce(null);
+      await expect(getTripEndedSentinel()).resolves.toBeNull();
+    });
+
+    it('NaN 문자열(legacy도 아님) → null', async () => {
+      getItemMock.mockResolvedValueOnce('abc');
+      await expect(getTripEndedSentinel()).resolves.toBeNull();
+    });
+
+    it('빈 문자열은 legacy Number("")=0으로 파싱 (corrId=null)', async () => {
+      getItemMock.mockResolvedValueOnce('');
+      await expect(getTripEndedSentinel()).resolves.toEqual({ endedAt: 0, corrId: null });
+    });
+
+    it('AsyncStorage 실패 시 null', async () => {
+      getItemMock.mockRejectedValueOnce(new Error('boom'));
+      await expect(getTripEndedSentinel()).resolves.toBeNull();
+    });
   });
 
   it('clearTripEndedSentinel — removeItem 호출', async () => {
@@ -73,7 +140,7 @@ describe('tripEndedSentinel', () => {
     await expect(clearTripEndedSentinel()).resolves.toBeUndefined();
   });
 
-  describe('isTripEndedSentinelStale (#2114)', () => {
+  describe('isTripEndedSentinelStale (#2114 방안 A)', () => {
     it('tripStartedAt이 sentinelAt보다 나중이면 stale=true', () => {
       expect(isTripEndedSentinelStale(1_000, 2_000)).toBe(true);
     });
@@ -88,6 +155,73 @@ describe('tripEndedSentinel', () => {
 
     it('tripStartedAt이 null이면 stale=false (활성 trip 없음)', () => {
       expect(isTripEndedSentinelStale(1_000, null)).toBe(false);
+    });
+  });
+
+  describe('resolveTripEndedSentinelVerdict (#2114 방안 C′ + A fallback)', () => {
+    it('corrId 둘 다 non-null + 불일치 → stale (timestamp 무관)', () => {
+      // timestamp만 보면 fresh로 보일 상황(tripStartedAt < sentinelAt)이어도 corrId mismatch면 stale.
+      const verdict = resolveTripEndedSentinelVerdict(
+        { endedAt: 2_000, corrId: 'corr-old' },
+        1_000,
+        'corr-new',
+      );
+      expect(verdict).toBe('stale');
+    });
+
+    it('corrId 둘 다 non-null + 일치 → fresh (timestamp 무관)', () => {
+      // timestamp만 보면 stale로 보일 상황(tripStartedAt > sentinelAt)이어도 corrId 일치면 fresh.
+      const verdict = resolveTripEndedSentinelVerdict(
+        { endedAt: 1_000, corrId: 'corr-same' },
+        2_000,
+        'corr-same',
+      );
+      expect(verdict).toBe('fresh');
+    });
+
+    it('sentinel.corrId=null (legacy) → timestamp fallback (stale)', () => {
+      const verdict = resolveTripEndedSentinelVerdict(
+        { endedAt: 1_000, corrId: null },
+        2_000,
+        'corr-new',
+      );
+      expect(verdict).toBe('stale');
+    });
+
+    it('sentinel.corrId=null (legacy) → timestamp fallback (fresh)', () => {
+      const verdict = resolveTripEndedSentinelVerdict(
+        { endedAt: 2_000, corrId: null },
+        1_000,
+        'corr-new',
+      );
+      expect(verdict).toBe('fresh');
+    });
+
+    it('currentCorrId=null(sync cache 미수화) → timestamp fallback (stale)', () => {
+      const verdict = resolveTripEndedSentinelVerdict(
+        { endedAt: 1_000, corrId: 'corr-old' },
+        2_000,
+        null,
+      );
+      expect(verdict).toBe('stale');
+    });
+
+    it('currentCorrId=null(sync cache 미수화) → timestamp fallback (fresh)', () => {
+      const verdict = resolveTripEndedSentinelVerdict(
+        { endedAt: 2_000, corrId: 'corr-old' },
+        1_000,
+        null,
+      );
+      expect(verdict).toBe('fresh');
+    });
+
+    it('둘 다 null → timestamp fallback (tripStartedAt null → fresh)', () => {
+      const verdict = resolveTripEndedSentinelVerdict(
+        { endedAt: 1_000, corrId: null },
+        null,
+        null,
+      );
+      expect(verdict).toBe('fresh');
     });
   });
 });

--- a/src/features/alarm/utils/__tests__/tripEndedSentinel.test.ts
+++ b/src/features/alarm/utils/__tests__/tripEndedSentinel.test.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   clearTripEndedSentinel,
   getTripEndedSentinel,
+  isTripEndedSentinelStale,
   setTripEndedSentinel,
 } from '../tripEndedSentinel';
 import { TRIP_ENDED_BY_BACKEND_AT_KEY } from '../../../../shared/constants/storageKeys';
@@ -70,5 +71,23 @@ describe('tripEndedSentinel', () => {
   it('clearTripEndedSentinel — 실패는 흡수', async () => {
     removeItemMock.mockRejectedValueOnce(new Error('boom'));
     await expect(clearTripEndedSentinel()).resolves.toBeUndefined();
+  });
+
+  describe('isTripEndedSentinelStale (#2114)', () => {
+    it('tripStartedAt이 sentinelAt보다 나중이면 stale=true', () => {
+      expect(isTripEndedSentinelStale(1_000, 2_000)).toBe(true);
+    });
+
+    it('tripStartedAt이 sentinelAt과 같으면 stale=false', () => {
+      expect(isTripEndedSentinelStale(1_000, 1_000)).toBe(false);
+    });
+
+    it('tripStartedAt이 sentinelAt보다 이전이면 stale=false', () => {
+      expect(isTripEndedSentinelStale(2_000, 1_000)).toBe(false);
+    });
+
+    it('tripStartedAt이 null이면 stale=false (활성 trip 없음)', () => {
+      expect(isTripEndedSentinelStale(1_000, null)).toBe(false);
+    });
   });
 });

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -328,7 +328,12 @@ export type AlarmLogReason =
   // silent push kind(transfer/destination/intermediate)가 도달해도 device는 더 이상 로컬
   // 알림을 발사하지 않는다. 전환기 구버전 backend가 여전히 이 kind를 보내는 경우를 대비한
   // no-op 처리 1건 적재 — 상태 sync(lock-release/widget/LA)는 정상 진행.
-  | 'legacy-station-kind-ignored';
+  | 'legacy-station-kind-ignored'
+  // #2114 (2026-08-03 건대 트립 종료 RCA) — trip-ended sentinel이 현재 활성 trip보다 이전
+  // trip의 것으로 판정(isTripEndedSentinelStale)돼 reset을 skip하고 폐기한 1건. sentinel만
+  // clear하고 store/storage는 유지 — 밤샘 trip force-end 직후 등록된 새 trip이 FG 재진입
+  // 시 통째로 사라지는 회귀 차단. source='lifecycle-backstop'로 적재해 fire 분모 제외 유지.
+  | 'trip-sentinel-stale-discarded';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.

--- a/src/features/alarm/utils/tripEndedSentinel.ts
+++ b/src/features/alarm/utils/tripEndedSentinel.ts
@@ -42,3 +42,19 @@ export async function clearTripEndedSentinel(): Promise<void> {
     // graceful — 다음 reset 호출에서 재시도된다.
   }
 }
+
+/**
+ * sentinel이 현재 활성 trip보다 오래된(=이전 trip의) 것인지 판정 (#2114).
+ *
+ * sentinel은 timestamp만 있고 어느 trip의 종료인지 스코프가 없다. tripStartedAt이
+ * sentinelAt보다 나중이면 그 sentinel은 이미 종료 처리된 이전 trip의 잔재이고, 현재
+ * 활성 trip은 sentinel이 기록된 시점 이후 새로 시작된 것이므로 소비(reset)하면 안 된다.
+ *
+ * tripStartedAt이 null이면(활성 trip 없음) stale 판정 대상이 아니다 — 기존 reset 동작 유지.
+ */
+export function isTripEndedSentinelStale(
+  sentinelAt: number,
+  tripStartedAt: number | null,
+): boolean {
+  return tripStartedAt !== null && tripStartedAt > sentinelAt;
+}

--- a/src/features/alarm/utils/tripEndedSentinel.ts
+++ b/src/features/alarm/utils/tripEndedSentinel.ts
@@ -9,26 +9,77 @@
  *
  * 모든 함수는 AsyncStorage 실패를 graceful하게 흡수 — sentinel은 보조 채널이므로
  * 실패해도 storage cleanup 자체의 효력은 유지된다.
+ *
+ * #2114 (2026-08-03 건대 RCA) — sentinel은 원래 timestamp만 갖고 있어 "어느 trip의
+ * 종료인지" 스코프가 없었다. 밤샘 trip force-end sentinel이 그 직후 등록된 새 trip을
+ * FG 재진입 시 통째로 reset해버리는 회귀의 root cause.
+ *
+ * 결정 evolve (2026-08-03, 방안 C′) — 당초 검토한 "tripToken 스코프"는 불가능하다:
+ * 이 시스템의 tripToken은 APNs 디바이스 토큰이라 기기당 고정이고, 옛/새 trip을 구분할
+ * 수 없다 (D1 trip_metrics에서 6~8월 전 trip이 동일 hash). 진짜 trip 인스턴스
+ * 식별자는 per-trip corrId(#1597, `tripCorrId.ts`)다. 그래서 sentinel 저장값을
+ * `{ endedAt, corrId }`로 확장하고, corrId 비교를 1순위 판정으로 추가한다.
+ * timestamp 비교(`isTripEndedSentinelStale`, 방안 A)는 corrId 정보가 없는 legacy
+ * sentinel/현재 corrId 미수화 케이스의 fallback으로 유지된다.
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { TRIP_ENDED_BY_BACKEND_AT_KEY } from '../../../shared/constants/storageKeys';
 
-/** sentinel 작성. trip-ended silent push 수신 시점에 호출. */
-export async function setTripEndedSentinel(at: number = Date.now()): Promise<void> {
+/** sentinel 저장 스키마. corrId는 legacy(구버전 plain-number) sentinel에서는 null. */
+export interface TripEndedSentinel {
+  endedAt: number;
+  corrId: string | null;
+}
+
+/**
+ * sentinel 작성. trip-ended silent push 수신 / lifecycle force-end / self-end 시점에 호출.
+ *
+ * @param corrId cleanup 전에 캡처한 종료 trip의 corrId snapshot (`getCurrentTripCorrIdSync()`).
+ *   미전달 시 null — legacy 호출부 하위호환.
+ */
+export async function setTripEndedSentinel(
+  at: number = Date.now(),
+  corrId: string | null = null,
+): Promise<void> {
   try {
-    await AsyncStorage.setItem(TRIP_ENDED_BY_BACKEND_AT_KEY, String(at));
+    const sentinel: TripEndedSentinel = { endedAt: at, corrId };
+    await AsyncStorage.setItem(TRIP_ENDED_BY_BACKEND_AT_KEY, JSON.stringify(sentinel));
   } catch {
     // sentinel 실패는 graceful — storage cleanup은 이미 수행됨.
   }
 }
 
-/** sentinel epoch ms 또는 null. 값이 NaN/누락이면 null. */
-export async function getTripEndedSentinel(): Promise<number | null> {
+/**
+ * sentinel 파싱. 신규 JSON 스키마(`{endedAt, corrId}`) 우선, 실패 시 legacy plain-number
+ * 문자열(corrId=null 취급)로 fallback. 값이 없거나 둘 다 유효하지 않으면 null.
+ */
+export async function getTripEndedSentinel(): Promise<TripEndedSentinel | null> {
   try {
     const raw = await AsyncStorage.getItem(TRIP_ENDED_BY_BACKEND_AT_KEY);
     if (raw === null) return null;
-    const parsed = Number(raw);
-    return Number.isFinite(parsed) ? parsed : null;
+
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (
+        parsed !== null &&
+        typeof parsed === 'object' &&
+        'endedAt' in parsed &&
+        typeof (parsed as { endedAt: unknown }).endedAt === 'number' &&
+        Number.isFinite((parsed as { endedAt: number }).endedAt)
+      ) {
+        const corrIdField = (parsed as { corrId?: unknown }).corrId;
+        return {
+          endedAt: (parsed as { endedAt: number }).endedAt,
+          corrId: typeof corrIdField === 'string' ? corrIdField : null,
+        };
+      }
+    } catch {
+      // JSON.parse 실패 — legacy plain-number 문자열일 수 있으므로 아래에서 재시도.
+    }
+
+    // legacy — 순수 숫자 문자열(구버전 setTripEndedSentinel(at))만 저장했던 시절의 값.
+    const legacyParsed = Number(raw);
+    return Number.isFinite(legacyParsed) ? { endedAt: legacyParsed, corrId: null } : null;
   } catch {
     return null;
   }
@@ -44,11 +95,11 @@ export async function clearTripEndedSentinel(): Promise<void> {
 }
 
 /**
- * sentinel이 현재 활성 trip보다 오래된(=이전 trip의) 것인지 판정 (#2114).
+ * sentinel이 현재 활성 trip보다 오래된(=이전 trip의) 것인지 판정 (#2114 방안 A).
  *
- * sentinel은 timestamp만 있고 어느 trip의 종료인지 스코프가 없다. tripStartedAt이
- * sentinelAt보다 나중이면 그 sentinel은 이미 종료 처리된 이전 trip의 잔재이고, 현재
- * 활성 trip은 sentinel이 기록된 시점 이후 새로 시작된 것이므로 소비(reset)하면 안 된다.
+ * sentinel timestamp만으로 판정하는 fallback 가드. tripStartedAt이 sentinelAt보다
+ * 나중이면 그 sentinel은 이미 종료 처리된 이전 trip의 잔재이고, 현재 활성 trip은
+ * sentinel이 기록된 시점 이후 새로 시작된 것이므로 소비(reset)하면 안 된다.
  *
  * tripStartedAt이 null이면(활성 trip 없음) stale 판정 대상이 아니다 — 기존 reset 동작 유지.
  */
@@ -57,4 +108,25 @@ export function isTripEndedSentinelStale(
   tripStartedAt: number | null,
 ): boolean {
   return tripStartedAt !== null && tripStartedAt > sentinelAt;
+}
+
+/**
+ * sentinel 소비 시점 최종 판정 (#2114 방안 C′ + A fallback).
+ *
+ * 판정 순서:
+ *   1) sentinel.corrId ≠ null && currentCorrId ≠ null && 서로 다름 → 'stale' 확정
+ *      (다른 trip의 종료 — corrId가 trip 인스턴스의 진짜 식별자이므로 timestamp 비교 불필요).
+ *   2) 둘 중 하나라도 null(legacy sentinel 또는 corrId sync cache 미수화) → timestamp
+ *      fallback(`isTripEndedSentinelStale`, 방안 A)로 판정.
+ *   3) 그 외(둘 다 non-null && 일치) → 'fresh' — 같은 trip의 정상 종료, 기존 소비(reset) 대상.
+ */
+export function resolveTripEndedSentinelVerdict(
+  sentinel: TripEndedSentinel,
+  tripStartedAt: number | null,
+  currentCorrId: string | null,
+): 'fresh' | 'stale' {
+  if (sentinel.corrId !== null && currentCorrId !== null) {
+    return sentinel.corrId === currentCorrId ? 'fresh' : 'stale';
+  }
+  return isTripEndedSentinelStale(sentinel.endedAt, tripStartedAt) ? 'stale' : 'fresh';
 }

--- a/src/shared/hooks/__tests__/useStateRehydration.test.ts
+++ b/src/shared/hooks/__tests__/useStateRehydration.test.ts
@@ -19,6 +19,7 @@ jest.mock('../../../features/alarm/utils/tripEndedSentinel', () => {
   return {
     // #2114 — 순수 함수라 실제 구현 그대로 사용. storage I/O 함수만 mock.
     isTripEndedSentinelStale: actual.isTripEndedSentinelStale,
+    resolveTripEndedSentinelVerdict: actual.resolveTripEndedSentinelVerdict,
     getTripEndedSentinel: (...args: unknown[]) => mockGetSentinel(...args),
     clearTripEndedSentinel: (...args: unknown[]) => mockClearSentinel(...args),
     setTripEndedSentinel: (...args: unknown[]) => mockSetSentinel(...args),
@@ -56,7 +57,7 @@ jest.mock('../../../features/alarm/store/tripBoundCleanups', () => ({
 }));
 
 // #1597 — sentinel + force-end 경로에서 cleanup 직전 corrId snapshot 캡처 + cleanup 후 prompt enqueue.
-const mockGetCurrentTripCorrIdSync = jest.fn(() => null);
+const mockGetCurrentTripCorrIdSync = jest.fn<string | null, []>(() => null);
 jest.mock('../../../features/observability/utils/tripCorrId', () => ({
   getCurrentTripCorrIdSync: () => mockGetCurrentTripCorrIdSync(),
 }));
@@ -156,7 +157,7 @@ describe('useStateRehydration', () => {
   });
 
   it('sentinel 있음 — runTripBoundCleanups 직접 호출 + setState로 메모리 reset + breadcrumb + releaseLock + sentinel clear', async () => {
-    mockGetSentinel.mockResolvedValue(1_700_000_000_000);
+    mockGetSentinel.mockResolvedValue({ endedAt: 1_700_000_000_000, corrId: null });
     mockAppState();
     renderHook(() => useStateRehydration());
     await waitFor(() => expect(mockClearSentinel).toHaveBeenCalled());
@@ -178,7 +179,7 @@ describe('useStateRehydration', () => {
   it('sentinel 있음 + prev destination null (isSwitch=false) — cleanup 정상 실행 (R2 핵심 회귀)', async () => {
     // 이전 동작: setDestination(null)을 호출하면 store의 isSwitch가 false라서 cleanup chain이
     // 실행되지 않았음. 새 동작은 runTripBoundCleanups를 직접 호출하므로 prev 상태 무관 cleanup 보장.
-    mockGetSentinel.mockResolvedValue(1_700_000_000_001);
+    mockGetSentinel.mockResolvedValue({ endedAt: 1_700_000_000_001, corrId: null });
     // destination=null 기본 상태 (prev=null) 시뮬레이션 — 기본 mockReturnValue는 setDestination만
     // 갖고 있어 prev 조회 불가하지만, runTripBoundCleanups가 store에 의존하지 않고 호출되는지가 핵심.
     mockAppState();
@@ -194,7 +195,7 @@ describe('useStateRehydration', () => {
   describe('#2114 stale sentinel guard (2026-08-03 건대 RCA)', () => {
     it('stale sentinel(활성 trip이 sentinel보다 나중 시작) — reset 미실행, destination 유지, sentinel clear, stamp 적재', async () => {
       // sentinel=07:26:29 force-end, 활성 trip 시작=07:27(sentinel 이후) — 새로 등록된 trip.
-      mockGetSentinel.mockResolvedValue(1_700_000_000_000);
+      mockGetSentinel.mockResolvedValue({ endedAt: 1_700_000_000_000, corrId: null });
       mockGetTripStartedAt.mockResolvedValue(1_700_000_060_000);
       mockTripLifecyclePhase.mockReturnValue('normal');
       mockAppState();
@@ -223,7 +224,7 @@ describe('useStateRehydration', () => {
     });
 
     it('sentinel 존재 + tripStartedAt null — 기존 reset 동작 유지 (stale 아님)', async () => {
-      mockGetSentinel.mockResolvedValue(1_700_000_000_000);
+      mockGetSentinel.mockResolvedValue({ endedAt: 1_700_000_000_000, corrId: null });
       mockGetTripStartedAt.mockResolvedValue(null);
       mockAppState();
       renderHook(() => useStateRehydration());
@@ -241,7 +242,7 @@ describe('useStateRehydration', () => {
     });
 
     it('신선한 sentinel(활성 trip이 sentinel보다 이전 시작) — 기존 reset+clear 동작 유지', async () => {
-      mockGetSentinel.mockResolvedValue(1_700_000_100_000);
+      mockGetSentinel.mockResolvedValue({ endedAt: 1_700_000_100_000, corrId: null });
       mockGetTripStartedAt.mockResolvedValue(1_700_000_000_000);
       mockTripLifecyclePhase.mockReturnValue('normal');
       mockAppState();
@@ -254,6 +255,76 @@ describe('useStateRehydration', () => {
         tripOrigin: null,
       });
       expect(mockReleaseLock).toHaveBeenCalled();
+    });
+  });
+
+  describe('#2114 방안 C′ — corrId 스코프 1순위 판정', () => {
+    it('corrId 불일치 → stale 확정 (timestamp상 fresh로 보여도 corrId mismatch가 우선)', async () => {
+      // timestamp만 보면 fresh(tripStartedAt < sentinelAt)이지만 corrId가 다른 trip이면 stale.
+      mockGetSentinel.mockResolvedValue({ endedAt: 1_700_000_100_000, corrId: 'corr-old-trip' });
+      mockGetTripStartedAt.mockResolvedValue(1_700_000_000_000);
+      mockGetCurrentTripCorrIdSync.mockReturnValue('corr-new-trip');
+      mockTripLifecyclePhase.mockReturnValue('normal');
+      mockAppState();
+      renderHook(() => useStateRehydration());
+      await waitFor(() => expect(mockClearSentinel).toHaveBeenCalled());
+
+      expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+      expect(mockSetState).not.toHaveBeenCalled();
+      expect(mockReleaseLock).not.toHaveBeenCalled();
+      expect(mockAppendAlarmLog).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'trip-sentinel-stale-discarded' }),
+      );
+    });
+
+    it('corrId 일치 → fresh 확정 (timestamp상 stale로 보여도 corrId 일치가 우선)', async () => {
+      // timestamp만 보면 stale(tripStartedAt > sentinelAt)이지만 corrId가 같은 trip이면 fresh.
+      mockGetSentinel.mockResolvedValue({ endedAt: 1_700_000_000_000, corrId: 'corr-same-trip' });
+      mockGetTripStartedAt.mockResolvedValue(1_700_000_060_000);
+      mockGetCurrentTripCorrIdSync.mockReturnValue('corr-same-trip');
+      mockTripLifecyclePhase.mockReturnValue('normal');
+      mockAppState();
+      renderHook(() => useStateRehydration());
+      await waitFor(() => expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1));
+
+      expect(mockSetState).toHaveBeenCalledWith({
+        destination: null,
+        customOrigin: null,
+        tripOrigin: null,
+      });
+      expect(mockReleaseLock).toHaveBeenCalled();
+      expect(mockAppendAlarmLog).not.toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'trip-sentinel-stale-discarded' }),
+      );
+    });
+
+    it('legacy plain-number sentinel(corrId=null) → timestamp fallback (stale)', async () => {
+      mockGetSentinel.mockResolvedValue({ endedAt: 1_700_000_000_000, corrId: null });
+      mockGetTripStartedAt.mockResolvedValue(1_700_000_060_000);
+      mockGetCurrentTripCorrIdSync.mockReturnValue('corr-new-trip');
+      mockTripLifecyclePhase.mockReturnValue('normal');
+      mockAppState();
+      renderHook(() => useStateRehydration());
+      await waitFor(() => expect(mockClearSentinel).toHaveBeenCalled());
+      expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+      expect(mockAppendAlarmLog).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'trip-sentinel-stale-discarded' }),
+      );
+    });
+
+    it('currentCorrId=null(sync cache 미수화) → timestamp fallback (fresh)', async () => {
+      mockGetSentinel.mockResolvedValue({ endedAt: 1_700_000_100_000, corrId: 'corr-old-trip' });
+      mockGetTripStartedAt.mockResolvedValue(1_700_000_000_000);
+      mockGetCurrentTripCorrIdSync.mockReturnValue(null);
+      mockTripLifecyclePhase.mockReturnValue('normal');
+      mockAppState();
+      renderHook(() => useStateRehydration());
+      await waitFor(() => expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1));
+      expect(mockSetState).toHaveBeenCalledWith({
+        destination: null,
+        customOrigin: null,
+        tripOrigin: null,
+      });
     });
   });
 
@@ -442,7 +513,7 @@ describe('useStateRehydration', () => {
     expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
     expect(mockSetState).not.toHaveBeenCalled();
 
-    mockGetSentinel.mockResolvedValueOnce(1_700_000_000_001);
+    mockGetSentinel.mockResolvedValueOnce({ endedAt: 1_700_000_000_001, corrId: null });
     app.emit('active');
     await waitFor(() => expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1));
     expect(mockSetState).toHaveBeenCalledWith({

--- a/src/shared/hooks/__tests__/useStateRehydration.test.ts
+++ b/src/shared/hooks/__tests__/useStateRehydration.test.ts
@@ -14,11 +14,16 @@ import { useBoardingLockStore } from '../../../features/alarm/store/useBoardingL
 const mockGetSentinel = jest.fn();
 const mockClearSentinel = jest.fn();
 const mockSetSentinel = jest.fn();
-jest.mock('../../../features/alarm/utils/tripEndedSentinel', () => ({
-  getTripEndedSentinel: (...args: unknown[]) => mockGetSentinel(...args),
-  clearTripEndedSentinel: (...args: unknown[]) => mockClearSentinel(...args),
-  setTripEndedSentinel: (...args: unknown[]) => mockSetSentinel(...args),
-}));
+jest.mock('../../../features/alarm/utils/tripEndedSentinel', () => {
+  const actual = jest.requireActual('../../../features/alarm/utils/tripEndedSentinel');
+  return {
+    // #2114 — 순수 함수라 실제 구현 그대로 사용. storage I/O 함수만 mock.
+    isTripEndedSentinelStale: actual.isTripEndedSentinelStale,
+    getTripEndedSentinel: (...args: unknown[]) => mockGetSentinel(...args),
+    clearTripEndedSentinel: (...args: unknown[]) => mockClearSentinel(...args),
+    setTripEndedSentinel: (...args: unknown[]) => mockSetSentinel(...args),
+  };
+});
 
 const mockGetTripStartedAt = jest.fn();
 const mockTripLifecyclePhase = jest.fn();
@@ -183,6 +188,72 @@ describe('useStateRehydration', () => {
       destination: null,
       customOrigin: null,
       tripOrigin: null,
+    });
+  });
+
+  describe('#2114 stale sentinel guard (2026-08-03 건대 RCA)', () => {
+    it('stale sentinel(활성 trip이 sentinel보다 나중 시작) — reset 미실행, destination 유지, sentinel clear, stamp 적재', async () => {
+      // sentinel=07:26:29 force-end, 활성 trip 시작=07:27(sentinel 이후) — 새로 등록된 trip.
+      mockGetSentinel.mockResolvedValue(1_700_000_000_000);
+      mockGetTripStartedAt.mockResolvedValue(1_700_000_060_000);
+      mockTripLifecyclePhase.mockReturnValue('normal');
+      mockAppState();
+      renderHook(() => useStateRehydration());
+      await waitFor(() => expect(mockClearSentinel).toHaveBeenCalled());
+
+      // reset 분기(store/storage) 전체 skip.
+      expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+      expect(mockSetState).not.toHaveBeenCalled();
+      expect(mockReleaseLock).not.toHaveBeenCalled();
+      expect(mockAddDomainBreadcrumb).not.toHaveBeenCalledWith(
+        'trip',
+        'end',
+        expect.anything(),
+      );
+      // sentinel만 clear + stamp 적재.
+      expect(mockAppendAlarmLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'lifecycle-backstop',
+          outcome: 'suppressed',
+          reason: 'trip-sentinel-stale-discarded',
+        }),
+      );
+      // 항상 storage → memory hydrate는 정상 진행되어 활성 trip이 유지된다.
+      expect(mockLoadDestination).toHaveBeenCalled();
+    });
+
+    it('sentinel 존재 + tripStartedAt null — 기존 reset 동작 유지 (stale 아님)', async () => {
+      mockGetSentinel.mockResolvedValue(1_700_000_000_000);
+      mockGetTripStartedAt.mockResolvedValue(null);
+      mockAppState();
+      renderHook(() => useStateRehydration());
+      await waitFor(() => expect(mockClearSentinel).toHaveBeenCalled());
+      expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+      expect(mockSetState).toHaveBeenCalledWith({
+        destination: null,
+        customOrigin: null,
+        tripOrigin: null,
+      });
+      expect(mockReleaseLock).toHaveBeenCalled();
+      expect(mockAppendAlarmLog).not.toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'trip-sentinel-stale-discarded' }),
+      );
+    });
+
+    it('신선한 sentinel(활성 trip이 sentinel보다 이전 시작) — 기존 reset+clear 동작 유지', async () => {
+      mockGetSentinel.mockResolvedValue(1_700_000_100_000);
+      mockGetTripStartedAt.mockResolvedValue(1_700_000_000_000);
+      mockTripLifecyclePhase.mockReturnValue('normal');
+      mockAppState();
+      renderHook(() => useStateRehydration());
+      await waitFor(() => expect(mockClearSentinel).toHaveBeenCalled());
+      expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+      expect(mockSetState).toHaveBeenCalledWith({
+        destination: null,
+        customOrigin: null,
+        tripOrigin: null,
+      });
+      expect(mockReleaseLock).toHaveBeenCalled();
     });
   });
 

--- a/src/shared/hooks/useStateRehydration.ts
+++ b/src/shared/hooks/useStateRehydration.ts
@@ -12,6 +12,7 @@ import { useBoardingLockStore } from '../../features/alarm/store/useBoardingLock
 import {
   clearTripEndedSentinel,
   getTripEndedSentinel,
+  isTripEndedSentinelStale,
   setTripEndedSentinel,
 } from '../../features/alarm/utils/tripEndedSentinel';
 import { runTripBoundCleanups } from '../../features/alarm/store/tripBoundCleanups';
@@ -69,24 +70,41 @@ async function runRehydration(trigger: 'mount' | 'active'): Promise<void> {
   // sentinel 우선 — store reset이 hydrate된 stale state를 덮지 않도록 순서 보장.
   const sentinel = await getTripEndedSentinel();
   if (sentinel !== null) {
-    logger.info(`trigger=${trigger} trip-ended sentinel=${sentinel} → store reset`);
-    // #1351 R2 — 과거에는 setDestination(null)을 trigger로 사용했지만, prev=null인 경우
-    // isSwitch=false로 평가되어 cleanup chain이 실행되지 않는 버그가 있었다.
-    // isSwitch 의존 없이 storage cleanup을 직접 호출. 멱등이므로 Fix 1 / silent push handler와
-    // 중복 호출 안전. 메모리 store도 setState로 즉시 reset해 stale state가 노출되지 않게 한다.
-    // #1597 — clearTripCorrId가 cache를 비우기 전에 종료된 trip의 corrId snapshot 캡처.
-    const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
-    await runTripBoundCleanups();
-    // #1597 — trip-end 사용자 정답지 prompt enqueue (cleanup 후, corrId snapshot으로).
-    await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
-    useDestinationStore.setState({
-      destination: null,
-      customOrigin: null,
-      tripOrigin: null,
-    });
-    addDomainBreadcrumb('trip', 'end', { reason: 'sentinel-rehydration' });
-    await useBoardingLockStore.getState().releaseLock();
-    await clearTripEndedSentinel();
+    // #2114 — sentinel이 현재 활성 trip보다 이전 trip의 것이면(=활성 trip이 sentinel 기록
+    // 이후 새로 시작됐으면) reset 없이 sentinel만 폐기. 2026-08-03 건대 RCA: 밤샘 trip
+    // force-end sentinel이 그 직후 등록된 새 trip을 FG 재진입 시 통째로 삭제하던 회귀.
+    const tripStartedAt = await getTripStartedAt();
+    if (isTripEndedSentinelStale(sentinel, tripStartedAt)) {
+      logger.info(
+        `trigger=${trigger} trip-ended sentinel=${sentinel} stale (tripStartedAt=${tripStartedAt}) → discard without reset`,
+      );
+      appendAlarmLog({
+        ts: Date.now(),
+        source: 'lifecycle-backstop',
+        outcome: 'suppressed',
+        reason: 'trip-sentinel-stale-discarded',
+      });
+      await clearTripEndedSentinel();
+    } else {
+      logger.info(`trigger=${trigger} trip-ended sentinel=${sentinel} → store reset`);
+      // #1351 R2 — 과거에는 setDestination(null)을 trigger로 사용했지만, prev=null인 경우
+      // isSwitch=false로 평가되어 cleanup chain이 실행되지 않는 버그가 있었다.
+      // isSwitch 의존 없이 storage cleanup을 직접 호출. 멱등이므로 Fix 1 / silent push handler와
+      // 중복 호출 안전. 메모리 store도 setState로 즉시 reset해 stale state가 노출되지 않게 한다.
+      // #1597 — clearTripCorrId가 cache를 비우기 전에 종료된 trip의 corrId snapshot 캡처.
+      const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
+      await runTripBoundCleanups();
+      // #1597 — trip-end 사용자 정답지 prompt enqueue (cleanup 후, corrId snapshot으로).
+      await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
+      useDestinationStore.setState({
+        destination: null,
+        customOrigin: null,
+        tripOrigin: null,
+      });
+      addDomainBreadcrumb('trip', 'end', { reason: 'sentinel-rehydration' });
+      await useBoardingLockStore.getState().releaseLock();
+      await clearTripEndedSentinel();
+    }
   }
 
   // 항상 storage → memory hydrate (sentinel 분기에서 reset된 store는 빈 storage 그대로 유지).

--- a/src/shared/hooks/useStateRehydration.ts
+++ b/src/shared/hooks/useStateRehydration.ts
@@ -12,7 +12,7 @@ import { useBoardingLockStore } from '../../features/alarm/store/useBoardingLock
 import {
   clearTripEndedSentinel,
   getTripEndedSentinel,
-  isTripEndedSentinelStale,
+  resolveTripEndedSentinelVerdict,
   setTripEndedSentinel,
 } from '../../features/alarm/utils/tripEndedSentinel';
 import { runTripBoundCleanups } from '../../features/alarm/store/tripBoundCleanups';
@@ -70,13 +70,16 @@ async function runRehydration(trigger: 'mount' | 'active'): Promise<void> {
   // sentinel 우선 — store reset이 hydrate된 stale state를 덮지 않도록 순서 보장.
   const sentinel = await getTripEndedSentinel();
   if (sentinel !== null) {
-    // #2114 — sentinel이 현재 활성 trip보다 이전 trip의 것이면(=활성 trip이 sentinel 기록
-    // 이후 새로 시작됐으면) reset 없이 sentinel만 폐기. 2026-08-03 건대 RCA: 밤샘 trip
-    // force-end sentinel이 그 직후 등록된 새 trip을 FG 재진입 시 통째로 삭제하던 회귀.
+    // #2114 — sentinel이 현재 활성 trip과 다른 trip의 것이면(stale) reset 없이 sentinel만
+    // 폐기. 2026-08-03 건대 RCA: 밤샘 trip force-end sentinel이 그 직후 등록된 새 trip을
+    // FG 재진입 시 통째로 삭제하던 회귀. 판정은 corrId 1순위 + timestamp fallback
+    // (resolveTripEndedSentinelVerdict, 방안 C′).
     const tripStartedAt = await getTripStartedAt();
-    if (isTripEndedSentinelStale(sentinel, tripStartedAt)) {
+    const currentCorrId = getCurrentTripCorrIdSync();
+    const verdict = resolveTripEndedSentinelVerdict(sentinel, tripStartedAt, currentCorrId);
+    if (verdict === 'stale') {
       logger.info(
-        `trigger=${trigger} trip-ended sentinel=${sentinel} stale (tripStartedAt=${tripStartedAt}) → discard without reset`,
+        `trigger=${trigger} trip-ended sentinel=${JSON.stringify(sentinel)} stale (tripStartedAt=${tripStartedAt}, currentCorrId=${currentCorrId}) → discard without reset`,
       );
       appendAlarmLog({
         ts: Date.now(),
@@ -86,7 +89,7 @@ async function runRehydration(trigger: 'mount' | 'active'): Promise<void> {
       });
       await clearTripEndedSentinel();
     } else {
-      logger.info(`trigger=${trigger} trip-ended sentinel=${sentinel} → store reset`);
+      logger.info(`trigger=${trigger} trip-ended sentinel=${JSON.stringify(sentinel)} → store reset`);
       // #1351 R2 — 과거에는 setDestination(null)을 trigger로 사용했지만, prev=null인 경우
       // isSwitch=false로 평가되어 cleanup chain이 실행되지 않는 버그가 있었다.
       // isSwitch 의존 없이 storage cleanup을 직접 호출. 멱등이므로 Fix 1 / silent push handler와
@@ -206,7 +209,8 @@ async function runLifecycleBackstop(trigger: 'mount' | 'active'): Promise<void> 
     });
     addDomainBreadcrumb('trip', 'end', { reason: 'lifecycle-9h-force-end' });
     await useBoardingLockStore.getState().releaseLock();
-    await setTripEndedSentinel(now);
+    // #2114 (방안 C′) — sentinel에 corrId 동봉해 다음 소비 시점 trip 인스턴스 스코프 비교 가능하게.
+    await setTripEndedSentinel(now, endedCorrIdSnapshot);
   } catch (e) {
     logger.warn('lifecycle backstop 실패 (graceful)', e);
   }


### PR DESCRIPTION
Closes #2114

## 배경 (2026-08-03 실탑승 dump RCA)

용마산→뚝섬 trip(07:26~07:46 KST)에서 사용자가 열차까지 선택한 활성 trip이 건대입구 FG 재진입 시점에 통째로 사라짐. 밤샘 trip(9h+)의 lifecycle backstop force-end가 남긴 `tripEndedSentinel`이 그 직후 등록된 새 trip을 FG 재진입 시 통째로 reset해버리는 것이 root cause (sentinel은 timestamp만 있고 어느 trip의 종료인지 스코프가 없었음).

## 결정 evolve — 방안 C′ (corrId 스코프)로 근본 수리 확장

최초 수리(방안 A, timestamp 비교)로 종결하지 않고 사용자 결정으로 근본 수리까지 확장했다.

**핵심 발견**: 당초 검토한 "sentinel에 tripToken 스코프"(방안 C)는 **불가능** — 이 시스템의 tripToken은 APNs 디바이스 토큰이라 기기당 고정(D1 trip_metrics에서 6~8월 전 trip이 동일 hash). 옛/새 trip을 token으로 구분할 수 없다. 진짜 trip 인스턴스 식별자는 **per-trip corrId**(#1597, `tripCorrId.ts`)다. 그래서 sentinel 저장값을 `{endedAt, corrId}` JSON으로 확장하고, corrId 비교를 1순위 판정으로 추가했다. timestamp 비교(방안 A)는 corrId 정보가 없는 legacy sentinel / 현재 corrId 미수화 케이스의 fallback으로 유지된다.

## 변경 사항

### 방안 A (timestamp 비교, fallback으로 유지)
- `src/features/alarm/utils/tripEndedSentinel.ts` — `isTripEndedSentinelStale(sentinelAt, tripStartedAt)` 순수 헬퍼.

### 방안 C′ (corrId 스코프, 1순위 판정)
- `src/features/alarm/utils/tripEndedSentinel.ts`
  - 저장 스키마를 `{endedAt: number, corrId: string | null}` JSON으로 확장. legacy plain-number 문자열 하위호환 파싱(corrId=null 취급).
  - `setTripEndedSentinel(at, corrId)` 시그니처 확장.
  - `resolveTripEndedSentinelVerdict(sentinel, tripStartedAt, currentCorrId)` 신규: corrId 둘 다 non-null이면 1순위 비교(mismatch→stale / match→fresh), 그 외(legacy sentinel 또는 corrId sync cache 미수화)는 `isTripEndedSentinelStale`(방안 A) fallback.
- **세터 4곳** — 이미 cleanup 전 `endedCorrIdSnapshot = getCurrentTripCorrIdSync()`를 캡처 중이던 값을 sentinel에 동봉:
  - `src/features/alarm/tasks/silentPushTask.ts` trip-ended 분기
  - `src/shared/hooks/useStateRehydration.ts` lifecycle force-end
  - `src/features/alarm/hooks/useLaunchTripReconciliation.ts` Signal 4 + status=ended 두 분기
  - `src/features/alarm/hooks/useDeviceSelfEnd.ts` performSelfEnd
- **소비처 3곳** — `resolveTripEndedSentinelVerdict` 사용으로 교체 (`useStateRehydration`/`useLaunchTripReconciliation`/`useDeviceSelfEnd`). 판정이 stale이면 reset/skip 없이 clear 후 계속 진행 — 기존 A 가드/스탬프(`trip-sentinel-stale-discarded`)는 그대로 유지.

## 금지사항 준수

- sentinel 키 자체는 변경 없음 (값 스키마만 JSON으로 확장, legacy 하위호환 유지)
- `setDestination` / `TRIP_BOUND_CLEANUPS`에 clear 추가 안 함
- 기존 sentinel 정상 소비 경로(신선한 sentinel → reset) 동작 변경 없음

## 잔여 hole (별도 이슈로 분리)

corrId가 backend 계약에 없어서, 옛 trip의 trip-ended push가 새 trip 등록 후 도착하는 in-flight race는 sentinel 스코프로 못 막는다 (silentPushTask의 token mismatch 가드도 같은 기기 token이라 통과). register payload → backend Trip → trip-ended payload echo → device 대조의 계약 확장이 필요 — 후속 이슈에서 처리.

## Wire-completion 5단

1. **Orphan**: 신규 export `isTripEndedSentinelStale`/`resolveTripEndedSentinelVerdict` caller 3곳(useStateRehydration/useLaunchTripReconciliation/useDeviceSelfEnd) — `npm run lint:orphan` 0건 확인.
2. **V/X dashboard**: DebugModal Alarm log에 `trip-sentinel-stale-discarded` reason으로 관측 (dump `## Counters`에 자동 노출, source='lifecycle-backstop'이라 fire 분모 제외).
3. **의존 PR**: N/A (device-only).
4. **측정 plan**: 다음 아침 첫 trip(밤샘 trip force-end 직후 재등록) 시나리오에서 `trip-sentinel-stale-discarded` ≥1 + 건대류 FG 재진입 시 trip 생존 확인. dump 1회로 판정 가능.
5. **Device verify**: 필요 — 9h+ trip 재현은 어려워 unit + 코드 경로 검증으로 대체, 실기기는 아침 통근 1회 관찰로 확인 예정.

## 검증

- `npm test` — 420 suites / 8878 tests pass, coverage 100%
- `npm run type-check` — pass
- `npm run lint:orphan` — 0 orphan