### PR TITLE
fix(#2116): R2 list() customMetadata 미포함 — alarm-log-stats 항상 tripsScanned=0

### DIFF
--- a/backend/alarm-worker/src/__tests__/helpers/r2Fixtures.ts
+++ b/backend/alarm-worker/src/__tests__/helpers/r2Fixtures.ts
@@ -43,17 +43,33 @@ export function makeFakeR2(
   pageSize = Number.POSITIVE_INFINITY,
 ): R2Bucket {
   return {
-    async list({ prefix, cursor, limit }: { prefix?: string; cursor?: string; limit?: number }) {
+    async list({
+      prefix,
+      cursor,
+      limit,
+      include,
+    }: {
+      prefix?: string;
+      cursor?: string;
+      limit?: number;
+      include?: ('httpMetadata' | 'customMetadata')[];
+    }) {
       const matching = archives.filter((a) => !prefix || a.key.startsWith(prefix));
       const startIdx = cursor ? Number.parseInt(cursor, 10) : 0;
       const cap = Math.min(limit ?? matching.length, pageSize);
       const page = matching.slice(startIdx, startIdx + cap);
       const endIdx = startIdx + page.length;
       const truncated = endIdx < matching.length;
+      // #2116 — 실 Cloudflare R2 runtime은 `include: ['customMetadata']`를 명시하지
+      // 않으면 listed object에 customMetadata를 채우지 않는다. 이 mock도 동일 제약을
+      // 재현해야 alarmLogStats.ts가 include 누락 시 회귀를 테스트에서 잡을 수 있다.
+      const includeCustomMetadata = include?.includes('customMetadata') ?? false;
       return {
         objects: page.map((a) => ({
           key: a.key,
-          customMetadata: { tripEndedAt: String(a.tripEndedAt) },
+          ...(includeCustomMetadata
+            ? { customMetadata: { tripEndedAt: String(a.tripEndedAt) } }
+            : {}),
         })),
         truncated,
         cursor: truncated ? String(endIdx) : undefined,

--- a/backend/alarm-worker/src/alarmLogStats.ts
+++ b/backend/alarm-worker/src/alarmLogStats.ts
@@ -291,6 +291,13 @@ export async function computeAlarmLogStats(
       prefix: TRIP_EVIDENCE_PREFIX,
       cursor,
       limit: Math.min(safeLimit - enumerated, 1000),
+      // #2116 — R2 list()는 `include: ['customMetadata']` 없이는 listed object에
+      // customMetadata를 채우지 않는다 (Cloudflare 런타임 제약). 이게 빠지면
+      // isObjectInWindow가 항상 meta undefined로 false 반환 → tripsScanned/totalEvents
+      // 항상 0 (실제 R2 archive 존재 여부와 무관). 로컬 fake R2 mock은 include를
+      // 무시하고 항상 customMetadata를 채워 이 회귀를 가려 왔다 (테스트 mock이 런타임
+      // 제약을 검증하지 못한 사례).
+      include: ['customMetadata'],
     });
     for (const obj of result.objects) {
       if (enumerated >= safeLimit) break;

--- a/backend/alarm-worker/tsconfig.json
+++ b/backend/alarm-worker/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "lib": ["ES2022"],
-    "types": ["@cloudflare/workers-types"],
+    "types": ["@cloudflare/workers-types/latest"],
     "strict": true,
     "noImplicitAny": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
Closes #2116

## RCA (양방향 layer 추적)

**Device 측 조사**: `triggerTripEndRecall` → `triggerAlarmLogForward` → `forwardTripTelemetry` 체인을 코드로 추적한 결과, 발사 자체는 3개 분기(정상 종료 / `no-trip-start` / `route-arc-failed`) 모두에서 무조건 호출되는 구조로, device-side gate에는 문제 발견 못함. 이슈에서 인용된 "19:35 dump에 forward POST 없음" evidence는 `backendCallBuffer`(ring capacity 200, 하루 동안 arrival polling 등으로 수십~수백 회전)가 07:37 trip 이후 12시간+ 지나며 자연 eviction된 것으로 결론 — device 미발사의 증거로 보기엔 근거 불충분 (inconclusive, 미확정).

**Backend 측 조사 (root cause 확정)**: `alarmLogStats.ts:computeAlarmLogStats`가 `r2.list({ prefix, cursor, limit })`을 `include: ['customMetadata']` 없이 호출하고 있었다. Cloudflare R2 런타임은 이 옵션이 없으면 listed object에 `customMetadata`를 채우지 않는다(성능/비용 상 기본 미포함) — `isObjectInWindow`가 `meta` undefined로 항상 `false`를 반환해 **R2 archive 실제 저장 여부와 무관하게 `tripsScanned`/`totalEvents`가 항상 0**으로 집계된다. `storeAlarmLogForward`의 R2 write(`trip-evidence/` prefix) 자체는 정상 — 문제는 순수 backend scan 로직.

부수 발견: 로컬 `r2Fixtures.ts`의 fake R2 mock이 `include` 옵션을 무시하고 항상 `customMetadata`를 채워 반환해 이 런타임 제약을 테스트가 잡지 못했다 (`lesson_test_mock_must_validate_runtime` 패턴 재발).

## Fix

- `backend/alarm-worker/src/alarmLogStats.ts`: `r2.list()` 호출에 `include: ['customMetadata']` 추가.
- `backend/alarm-worker/src/__tests__/helpers/r2Fixtures.ts`: fake R2 mock이 `include` 옵션을 실제로 검사하도록 수정 — 누락 시 회귀를 테스트가 잡도록 보강. (수정 전 되돌려 확인: 기존 `alarmLogStats.test.ts` 29건 중 18건이 fail하는 것으로 이 fix의 필요성/충분성 검증 완료)
- `backend/alarm-worker/tsconfig.json`: `types: ["@cloudflare/workers-types"]`(dateless → 2021-11-03 스냅샷, `R2ListOptions.include` 미지원)를 `"@cloudflare/workers-types/latest"`로 교체 — 실제 runtime(`compatibility_date = "2024-12-01"`, R2 include는 2022-08-04 이후 지원)과 타입 표면 정합.

## 검증

- `backend/alarm-worker`에서 `npx vitest run --coverage`: 70 files / 2738 tests pass, `alarmLogStats.ts` 100% line/function/statement (기존 branch 94.28%에서 변화 없음 — 신규 미커버 분기 없음).
- `npx tsc --noEmit` (backend/alarm-worker): pass.
- 루트 `npm run type-check`: pass. `npm run lint:orphan`: 0 orphan.
- fix 제거 후 재현: `alarmLogStats.test.ts` 29건 중 18건 fail로 root cause 확정 및 fix 충분성 확인.

**머지 ≠ CF deploy — wrangler deploy는 사용자 실행.**

## Wire-completion 5단

1. **Orphan 없음**: `npm run lint:orphan` pass (0 orphan). 신규 export 없음.
2. **V/X dashboard**: `/admin/alarm-log-stats?windowHours=1|24` curl 응답의 `tripsScanned`/`totalEvents`가 관측면. 배포 후 다음 trip 종료 1건에서 두 값이 실제로 증가하는지로 즉시 검증 가능.
3. **의존 PR**: N/A — 본 PR은 backend 코드 fix이며, 작동하려면 `wrangler deploy`(사용자 실행)가 필요. 의존하는 다른 device/backend/infra PR 없음.
4. **측정 plan**: 배포 후 다음 trip 종료 1건 발생 시 `/admin/alarm-log-stats?windowHours=1`을 curl해 `tripsScanned >= 1` 확인. 기존 device forward가 정상 동작 중이었다면(가능성 높음, RCA 참고) 즉시 관측 가능해야 함.
5. **Device verify**: N/A — backend-only fix. type-check + unit(coverage)만 검증 완료. device-side forward 발사 자체의 확정 여부는 이번 fix로 해소되지 않으며(inconclusive 상태 유지), 배포 후 measurement plan(4단)으로 간접 확인.
