### PR TITLE
fix(#2120): trip-ended push corrId 왕복 — 같은 기기 token 인스턴스 race 차단

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -1389,6 +1389,7 @@ describe('sendTripEndedAlertPush (#1337)', () => {
     reason: TripEndedReason;
     sentAt: number;
     tripToken: string;
+    corrId: string;
   }>;
   const runTripEndedAlertPush = (fetchImpl: ReturnType<typeof vi.fn>, o: TripEndedOverrides = {}) =>
     sendTripEndedAlertPush({
@@ -1397,6 +1398,7 @@ describe('sendTripEndedAlertPush (#1337)', () => {
       reason: o.reason ?? 'expired',
       sentAt: o.sentAt ?? 0,
       tripToken: o.tripToken ?? 'trip-x',
+      corrId: o.corrId,
       config: makeConfig(),
       host: TEST_HOST,
       fetchImpl: fetchImpl as unknown as typeof fetch,
@@ -1473,6 +1475,23 @@ describe('sendTripEndedAlertPush (#1337)', () => {
     const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
     const headers = call[1].headers as Record<string, string>;
     expect(headers['apns-thread-id']).toBe('trip-ended-tok');
+  });
+
+  // #2120 — corrId echo (#2114 근본 수리 Phase 2).
+  it('corrId 지정 시 data.corrId로 echo된다', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await runTripEndedAlertPush(fetchImpl, { corrId: 'corr-xyz' });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.data.corrId).toBe('corr-xyz');
+  });
+
+  it('corrId 미지정 시 data에 corrId 필드 자체가 없다 (구 레코드/legacy 호환)', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await runTripEndedAlertPush(fetchImpl);
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect('corrId' in body.data).toBe(false);
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -153,6 +153,17 @@ describe('validateTrip', () => {
     expect(validateTrip(base())?.apnsEnv).toBeUndefined();
   });
 
+  // #2120 (#2114 근본 수리 Phase 2) — device trip 인스턴스 corrId 저장.
+  it('preserves valid corrId', () => {
+    expect(validateTrip({ ...base(), corrId: 'corr-abc' })?.corrId).toBe('corr-abc');
+  });
+
+  it('drops missing/non-string/empty corrId', () => {
+    expect(validateTrip(base())?.corrId).toBeUndefined();
+    expect(validateTrip({ ...base(), corrId: 42 })?.corrId).toBeUndefined();
+    expect(validateTrip({ ...base(), corrId: '' })?.corrId).toBeUndefined();
+  });
+
   it('rejects missing alarmAtEpochMs', () => {
     const b = base();
     delete b.alarmAtEpochMs;
@@ -735,6 +746,31 @@ describe('POST /trips (#578 — preserve advance progress on re-register)', () =
     expect(finalTrip.waypoints).toHaveLength(2);
     expect(finalTrip.waypoints[0].stationName).toBe('군자');
     expect(finalTrip.lastEtaSeconds).toBe(42);
+  });
+
+  // #2120 (#2114 근본 수리 Phase 2) — corrId는 재등록마다 incoming 값으로 교체된다.
+  it('replaces corrId with incoming value on re-register (same session)', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripBody({ corrId: 'corr-1' }), env);
+    let stored = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    expect(stored.corrId).toBe('corr-1');
+    // 같은 세션(createdAt 동일) 재등록 — corrId 변경 없음 시나리오는 사실상 발생하지 않지만
+    // (같은 trip 동안 corrId 안정) 회귀 가드로 값이 유지되는지 확인.
+    await post('/trips', tripBody({ corrId: 'corr-1' }), env);
+    stored = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    expect(stored.corrId).toBe('corr-1');
+  });
+
+  it('replaces corrId with new value on new session register (different createdAt)', async () => {
+    const env = makeKvEnv();
+    await post('/trips', tripBody({ corrId: 'corr-old' }), env);
+    await post(
+      '/trips',
+      tripBody({ createdAt: CREATED + 10_000, corrId: 'corr-new' }),
+      env,
+    );
+    const stored = JSON.parse((await env.TRIPS.get('trip:tok-578')) as string);
+    expect(stored.corrId).toBe('corr-new');
   });
 
   it('replaces trip entirely when createdAt differs (new session)', async () => {

--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -687,6 +687,51 @@ describe('cleanupTripWithLa', () => {
     expect(await kv.get('trip:devtoken')).toBeNull();
   });
 
+  // #2120 (#2114 근본 수리 Phase 2) — trip.corrId가 trip-ended push payload에 echo된다.
+  it('trip.corrId 보유 시 trip-ended push data.corrId로 echo된다', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({ activityPushToken: undefined, corrId: 'corr-live-1' });
+    await kv.put('trip:devtoken', JSON.stringify(trip));
+    const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+    let capturedBody: string | undefined;
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      capturedBody = init.body as string;
+      return new Response('', { status: 200 });
+    });
+    await cleanupTripWithLa(
+      trip,
+      env,
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      makeStats(),
+      NOW,
+      () => undefined,
+      'eta-missing',
+    );
+    expect(JSON.parse(capturedBody ?? '{}').data.corrId).toBe('corr-live-1');
+  });
+
+  it('trip.corrId 미보유(구 레코드) 시 trip-ended push data에 corrId 필드가 없다', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({ activityPushToken: undefined, corrId: undefined });
+    await kv.put('trip:devtoken', JSON.stringify(trip));
+    const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+    let capturedBody: string | undefined;
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      capturedBody = init.body as string;
+      return new Response('', { status: 200 });
+    });
+    await cleanupTripWithLa(
+      trip,
+      env,
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      makeStats(),
+      NOW,
+      () => undefined,
+      'eta-missing',
+    );
+    expect('corrId' in JSON.parse(capturedBody ?? '{}').data).toBe(false);
+  });
+
   it('trip-ended push logs failure when both hosts reject (env mismatch exhausted)', async () => {
     const kv = new InMemoryKV();
     const trip = makeTrip({ activityPushToken: undefined, apnsEnv: 'sandbox' });

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -630,6 +630,11 @@ export interface SendTripEndedAlertPushOptions {
   sentAt: number;
   /** 종료된 trip의 token — 클라가 현재 ACTIVE_TRIP_KEY와 비교해 race 차단(#868 P1-2). */
   tripToken: string;
+  /**
+   * #2120 — 종료된 trip의 인스턴스 corrId. 있으면 payload에 echo — device가 자신의 현재
+   * corrId와 대조해 tripToken(기기 고정) 단독으로는 못 막는 인스턴스 race를 차단한다.
+   */
+  corrId?: string;
   config: ApnsConfig;
   host: string;
   fetchImpl?: typeof fetch;
@@ -649,6 +654,8 @@ export async function sendTripEndedAlertPush(
     tripToken: options.tripToken,
     reason: options.reason,
     sentAt: options.sentAt,
+    // #2120 — corrId 보유 trip만 echo. 미보유(구 레코드/legacy client)는 필드 생략.
+    ...(options.corrId ? { corrId: options.corrId } : {}),
   };
 
   const body = JSON.stringify({

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -2258,6 +2258,11 @@ export function validateTrip(input: unknown): Trip | null {
     // Legacy client (필드 미송신) 또는 비boolean은 undefined로 graceful — 기존 동작 완전 보존.
     sleepModeEnabled:
       typeof obj.sleepModeEnabled === 'boolean' ? obj.sleepModeEnabled : undefined,
+    // #2120 — device trip 인스턴스 corrId. 재등록마다 incoming 값으로 교체(다음 POST /trips
+    // 핸들러가 baseTrip을 `{...incoming, ...}`로 spread하며 corrId를 별도 보존하지 않으므로
+    // 자연스럽게 최신 값으로 갱신). 미송신/비string이면 undefined — trip-ended payload에서
+    // 필드 생략으로 이어져 구버전 client 호환 유지.
+    corrId: typeof obj.corrId === 'string' && obj.corrId.length > 0 ? obj.corrId : undefined,
   };
 }
 

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -379,6 +379,8 @@ async function fireTripEndedAlertPush(
           sentAt: now,
           // race 가드(#868 P1-2) — push 도착 시점에 클라가 trip 갈아탔으면 ACTIVE_TRIP_KEY 불일치로 cleanup skip.
           tripToken: trip.token,
+          // #2120 — 인스턴스 corrId 동봉. trip.corrId 미보유(구 레코드)는 undefined → payload 필드 생략.
+          corrId: trip.corrId,
           config: deps.apnsConfig,
           host,
           fetchImpl: deps.fetchImpl,

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -253,6 +253,19 @@ export interface Trip {
    * `infoModeEnabled` / `subsurface` / `locale`과 동일 저장 전용 패턴.
    */
   sleepModeEnabled?: boolean;
+  /**
+   * #2120 — trip 인스턴스 식별자 (device `tripCorrId`, `${epoch ms}-${8 hex}` 형식).
+   * tripToken(APNs device token)은 기기당 고정이라 backend가 보낸 옛 trip의 trip-ended push가
+   * 새 trip 등록 후 도착해도 token mismatch 가드(index.ts trip-token 비교)를 통과한다 — #2114
+   * RCA 잔여 hole. corrId는 trip **인스턴스** 단위로 매 등록마다 새로 발급되므로, trip-ended
+   * push payload에 echo해 device가 현재 진행 중인 trip의 corrId와 대조하면 이 race를 막을 수
+   * 있다. register 시 저장, 재등록(같은 세션 포함) 시 incoming 값으로 교체 — 클라가 매 register
+   * 마다 최신 corrId를 보내므로 trip.corrId는 항상 device의 현재 corrId와 정렬된다.
+   *
+   * 미송신(구버전 client)이면 undefined — trip-ended payload에서 필드 자체가 생략되어
+   * device 쪽 null-graceful 분기(양쪽 null이면 기존 동작 100% 유지)로 자연 fallback.
+   */
+  corrId?: string;
 }
 
 /**
@@ -403,6 +416,11 @@ export interface TripEndedAlertPushPayload {
   tripToken: string;
   reason: TripEndedReason;
   sentAt: number;
+  /**
+   * #2120 — 종료된 trip의 인스턴스 corrId echo. trip이 corrId를 보유하지 않은(구버전 client
+   * 또는 corrId 미수화) 경우 필드 자체를 생략한다 — device 쪽 null-graceful 분기와 정렬.
+   */
+  corrId?: string;
 }
 
 /** APNs 토큰 환경. sandbox는 dev/preview/internal 빌드, production은 App Store/TestFlight. */

--- a/src/features/alarm/api/alarmBackend.ts
+++ b/src/features/alarm/api/alarmBackend.ts
@@ -138,6 +138,15 @@ export interface RegisterTripPayload {
    * 미설정/false: 필드 미송신(graceful) — backend Trip.sleepModeEnabled는 undefined 유지.
    */
   sleepModeEnabled?: boolean;
+  /**
+   * #2120 (#2114 근본 수리 Phase 2) — trip 인스턴스 corrId (`getCurrentTripCorrIdSync()`).
+   * backend가 Trip에 저장했다가 trip-ended push payload에 echo — device가 대조해 같은
+   * tripToken(기기 고정)의 옛 trip 종료 push가 새 trip 등록 후 도착하는 race를 차단한다.
+   * null 허용 — sync cache 미수화 시점(cold start 등)에는 null 그대로 송신해 backend가
+   * corrId 없는 trip으로 저장하고, 이후 정상 register부터 값이 채워진다(graceful). optional —
+   * 기존 register 호출자(테스트 등)는 미지정 시 undefined로 자연 생략.
+   */
+  corrId?: string | null;
 }
 
 export interface AlarmBackendResult {
@@ -290,6 +299,9 @@ async function performRegisterFetch(
     expiresAt,
     alarmAtEpochMs: payload.alarmAtEpochMs,
     apnsEnv: payload.apnsEnv,
+    // #2120 — trip 인스턴스 corrId. null 허용 그대로 항상 동봉(sync cache 미수화 시 null) —
+    // backend는 string이 아니면 undefined로 저장해 trip-ended payload에서 필드를 생략한다.
+    corrId: payload.corrId ?? null,
     // boardingLock은 있을 때만 송신 (없으면 backend는 기존 anchor 폴링).
     ...(payload.boardingLock ? { boardingLock: payload.boardingLock } : {}),
     // #819 — boarding-prompt 평가 컨텍스트. 좌표/표시 둘 중 하나라도 없으면 backend는 자동 skip.

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -35,6 +35,7 @@ import { BOARDING_LOCK_RELEASE_DEBOUNCE_MS } from '../../../shared/constants/boa
 import { createLogger } from '../../../shared/utils/logger';
 import { getRegisteringApnsEnv, warmupConfirmedApnsEnv } from '../../../shared/utils/apnsEnv';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
+import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
 
 /**
  * #1895 — i18next.language를 backend가 인식하는 SupportedLocale로 정규화.
@@ -212,6 +213,8 @@ async function callRegister(input: RegisterCallInputs) {
     alarmAtEpochMs: deriveAlarmAtEpochMs(input.nextStationEtaSeconds, Date.now()),
     apnsEnv,
     createdAt: input.createdAt,
+    // #2120 — trip 인스턴스 corrId. null 허용 — sync cache 미수화 시점에도 register 자체는 진행.
+    corrId: getCurrentTripCorrIdSync(),
     ...(boardingLockMeta ? { boardingLock: boardingLockMeta } : {}),
     // #819 / #1028 — boarding-prompt 평가/표시 컨텍스트. 짝으로만 송신.
     ...(promptContext

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -2272,6 +2272,60 @@ describe('silentPushTask', () => {
         expect(mockSetTripEndedSentinel).toHaveBeenCalledWith(expect.any(Number), 'corr-abc');
       });
 
+      // #2120 (#2114 근본 수리 Phase 2) — corrId 인스턴스 가드.
+      describe('#2120 — corrId 인스턴스 가드', () => {
+        it('payload.corrId와 device corrId가 둘 다 있는데 불일치하면 cleanup 전체 skip + reason=trip-ended-corr-mismatch', async () => {
+          mockGetCurrentTripCorrIdSync.mockReturnValueOnce('device-corr');
+          await handleSilentPush(
+            tripEndedPayload({ pushId: 'te-corr', reason: 'expired', corrId: 'payload-corr' }),
+          );
+          expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+          expect(mockCancelTripBoundOsQueue).not.toHaveBeenCalled();
+          expect(mockTriggerTripEndRecall).not.toHaveBeenCalled();
+          expect(mockSetTripEndedSentinel).not.toHaveBeenCalled();
+          expect(mockLogSilentPushSkipped).toHaveBeenCalledWith({
+            stationName: 'trip-ended:expired',
+            kind: undefined,
+            reason: 'trip-ended-corr-mismatch',
+          });
+          expect(mockSendPushAck).toHaveBeenCalledWith({
+            pushId: 'te-corr',
+            token: DEFAULT_APNS_TOKEN,
+            outcome: 'skipped',
+            reason: expect.stringContaining('corr-mismatch') as unknown as string,
+            permissionMode: 'always',
+          });
+        });
+
+        it('payload.corrId와 device corrId가 일치하면 cleanup 정상 진행', async () => {
+          mockGetCurrentTripCorrIdSync.mockReturnValue('same-corr');
+          await handleSilentPush(
+            tripEndedPayload({ reason: 'expired', corrId: 'same-corr' }),
+          );
+          expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+        });
+
+        it('payload.corrId가 없으면(구버전 backend) device corrId 조회 없이 cleanup 진행', async () => {
+          mockGetCurrentTripCorrIdSync.mockReturnValueOnce('device-corr-unused');
+          await handleSilentPush(tripEndedPayload({ reason: 'expired' }));
+          expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+          // 게이트 자체가 device corrId를 조회하지 않으므로 endedCorrIdSnapshot 캡처용
+          // mockReturnValueOnce가 그대로 소비돼 sentinel에 전달된다 (혼동 방지 검증).
+          expect(mockSetTripEndedSentinel).toHaveBeenCalledWith(
+            expect.any(Number),
+            'device-corr-unused',
+          );
+        });
+
+        it('payload.corrId는 있지만 device corrId가 null이면(cache 미수화) cleanup 진행', async () => {
+          mockGetCurrentTripCorrIdSync.mockReturnValue(null);
+          await handleSilentPush(
+            tripEndedPayload({ reason: 'expired', corrId: 'payload-corr' }),
+          );
+          expect(mockRunTripBoundCleanups).toHaveBeenCalledTimes(1);
+        });
+      });
+
       // #2018 γ' — FG 상태(active)에서 trip-ended 수신 시 sentinel 저장 후 즉시 in-memory
       // store를 reset해야 한다. useStateRehydration은 AppState 'active' 이벤트 시에만 실행되므로
       // FG dogfood 시나리오(관찰 20, 성수→성수)에서 sentinel이 저장돼도 재수화가 트리거되지 않아

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -322,6 +322,14 @@ export interface TripEndedSilentPushPayload {
    * ACTIVE_TRIP_KEY와 비교해 불일치 시 cleanup skip. 구버전 backend 호환을 위해 optional.
    */
   tripToken?: string;
+  /**
+   * #2120 — 종료된 trip 인스턴스 corrId echo. tripToken(APNs 기기 토큰)은 기기당 고정이라
+   * 같은 기기의 옛 trip 종료 push가 새 trip 등록 후 도착해도 token 비교만으로는 못 막는다
+   * (#2114 RCA 잔여 hole). corrId는 trip 인스턴스 단위로 매 등록마다 새로 발급되므로, 클라의
+   * 현재 corrId(`getCurrentTripCorrIdSync()`)와 대조해 불일치 시 cleanup을 skip한다.
+   * 양쪽 중 하나라도 없으면(구버전 backend / cache 미수화) 기존 동작 100% 유지.
+   */
+  corrId?: string;
 }
 
 /**
@@ -628,13 +636,15 @@ function validOccurrenceIdx(value: unknown): number | undefined {
 function extractTripEndedPayload(
   obj: Record<string, unknown>,
 ): TripEndedSilentPushPayload | null {
-  const { reason, sentAt, pushId, tripToken } = obj;
+  const { reason, sentAt, pushId, tripToken, corrId } = obj;
   return {
     kind: 'trip-ended',
     reason: normalizeTripEndedReason(reason),
     sentAt: validSentAt(sentAt),
     pushId: validPushId(pushId),
     tripToken: typeof tripToken === 'string' && tripToken.length > 0 ? tripToken : undefined,
+    // #2120 — corrId echo. 구버전 backend는 필드 미송신 → undefined (null-graceful).
+    corrId: typeof corrId === 'string' && corrId.length > 0 ? corrId : undefined,
   };
 }
 
@@ -932,6 +942,30 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
             `trip-ended skip: tripToken mismatch payload=${payload.tripToken.slice(0, 8)} active=${activeTripToken.slice(0, 8)}`,
           );
           void ackOutcome(payload.pushId, apnsToken, 'fired', `trip-ended:${payload.reason}:token-mismatch`);
+          return;
+        }
+      }
+      // #2120 (#2114 근본 수리 Phase 2) — corrId 인스턴스 가드. tripToken(APNs 기기 토큰)은
+      // 기기당 고정이라 위 token 비교는 "같은 기기의 다른 trip" race를 못 잡는다. backend
+      // 자동종료(la-stale/eta-missing 등) push가 in-flight인 수 초 사이 device가 재등록하면,
+      // 새 trip의 ACTIVE_TRIP_KEY(=같은 token)를 그대로 통과해 옛 trip 종료 push가 새 trip을
+      // 즉시 cleanup해버린다. corrId는 register마다 새로 발급되는 trip 인스턴스 식별자이므로
+      // payload와 device 현재 값이 둘 다 있는데 다르면 그 사이 재등록이 있었다는 뜻 — cleanup
+      // 전체를 skip한다. 어느 한쪽이라도 없으면(구버전 backend / cache 미수화) 기존 동작 유지.
+      // payload.corrId가 없는(구버전 backend) 경로는 device corrId를 조회할 필요조차 없다 —
+      // 불필요한 sync cache read를 피해 이후 endedCorrIdSnapshot 캡처 시점과의 혼동도 방지한다.
+      if (payload.corrId !== undefined) {
+        const deviceCorrId = getCurrentTripCorrIdSync();
+        if (deviceCorrId !== null && payload.corrId !== deviceCorrId) {
+          logger.warn(
+            `trip-ended skip: corrId mismatch payload=${payload.corrId} device=${deviceCorrId}`,
+          );
+          logSilentPushSkipped({
+            stationName: `trip-ended:${payload.reason}`,
+            kind: undefined,
+            reason: 'trip-ended-corr-mismatch',
+          });
+          void ackOutcome(payload.pushId, apnsToken, 'skipped', `trip-ended:${payload.reason}:corr-mismatch`);
           return;
         }
       }

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -333,7 +333,11 @@ export type AlarmLogReason =
   // trip의 것으로 판정(isTripEndedSentinelStale)돼 reset을 skip하고 폐기한 1건. sentinel만
   // clear하고 store/storage는 유지 — 밤샘 trip force-end 직후 등록된 새 trip이 FG 재진입
   // 시 통째로 사라지는 회귀 차단. source='lifecycle-backstop'로 적재해 fire 분모 제외 유지.
-  | 'trip-sentinel-stale-discarded';
+  | 'trip-sentinel-stale-discarded'
+  // #2120 (#2114 근본 수리 Phase 2) — trip-ended push의 corrId가 device 현재 corrId와
+  // 불일치해 cleanup 전체를 skip한 1건. tripToken(기기 고정)만으로는 못 막는 인스턴스 race
+  // (backend 자동종료 push in-flight 중 device 재등록) 차단 evidence.
+  | 'trip-ended-corr-mismatch';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -1029,11 +1033,15 @@ export function logSilentPushTripEndedReceived(input: {
  * silent push 위치 게이트 실패 → 발사 skip 한 1건 (#478 PR 1-2).
  * reason은 게이트 사유: gate-unknown-station / gate-no-location /
  * gate-stale-location / gate-out-of-range.
+ *
+ * phaseId는 대부분 호출부가 payload.phase를 그대로 넘기지만, trip-ended 분기(#2120)처럼
+ * phase 개념이 없는 skip 사유는 undefined로 생략한다 — appendAlarmLog 자체가 optional로
+ * 받으므로 여기서도 optional화해 호출부 강제 없이 자연 전달한다.
  */
 export function logSilentPushSkipped(input: {
   stationName: string;
   kind: AlarmLogKind | undefined;
-  phaseId: AlarmPhaseId;
+  phaseId?: AlarmPhaseId;
   reason: AlarmLogReason;
   distanceM?: number;
   thresholdM?: number;


### PR DESCRIPTION
Closes #2120

## 배경
#2114 RCA의 잔여 hole. tripToken(APNs 기기 토큰)은 기기당 고정이라, backend가 보낸 옛 trip의 trip-ended push가 새 trip 등록 후 도착하면 device `silentPushTask` trip-ended 분기가 이를 새 trip의 종료로 오인해 즉시 cleanup한다 (token mismatch 가드는 같은 기기 token이라 통과). #2118(sentinel corrId 스코프)은 sentinel 소비 시점만 보호 — trip-ended 핸들러의 즉시 cleanup 경로 자체는 인스턴스 식별자가 payload에 없어 못 막았다.

## 변경 사항
- **Device**: `useApnsTripRegistration` register payload에 `corrId: getCurrentTripCorrIdSync()` 동봉 (null 허용)
- **Backend**: `Trip.corrId` 저장 필드 추가. `validateTrip`이 파싱하고, register/재등록(same/new session 모두) 시 incoming 값으로 자연 교체
- **Backend**: `sendTripEndedAlertPush` payload에 `trip.corrId` echo — corrId 미보유 trip(구 레코드)은 필드 자체 생략
- **Device**: `silentPushTask.ts` trip-ended 분기에 corrId 인스턴스 가드 추가 — `payload.corrId`와 device 현재 corrId(`getCurrentTripCorrIdSync()`)가 둘 다 있는데 불일치하면 cleanup 전체(OS queue cancel/recall/storage cleanup/sentinel) skip + `logSilentPushSkipped(reason='trip-ended-corr-mismatch')` 적재 + ack `'skipped'`
- 어느 한쪽이라도 없으면(구버전 backend / cache 미수화) 기존 동작 100% 유지
- `logSilentPushSkipped`의 `phaseId`를 optional화 — trip-ended처럼 phase 개념이 없는 skip 사유도 자연스럽게 지원

## 금지사항 준수
- tripToken 스키마/키 변경 없음
- corrId 부재 시 동작 변경 없음 (양쪽 null-graceful)
- station-passed 등 다른 push kind에는 corrId 추가하지 않음 (trip-ended 한정)

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard** — DebugModal Alarm log에서 `trip-ended-corr-mismatch` reason 카운트 확인 가능 / wrangler tail(또는 Cloudflare Dashboard)의 trip-ended push 로그에 `corrId` 필드 노출
3. **의존 PR** — #2118 머지 선행 필수 (같은 파일 `silentPushTask.ts`/`tripCorrId` 접점) — 이미 dev에 머지됨, 본 브랜치는 origin/dev 기준으로 그 위에서 작업
4. **측정 plan** — 다음 1주 trip에서 `trip-ended-corr-mismatch` 발생 시 = race 실증 차단 evidence. 0건이어도 가드는 dormant 방어선으로 유지
5. **Device verify** — 필요. 정상 trip 종료 push가 여전히 cleanup되는지(corrId 일치 경로) 실탑승 1회 확인 필요. backend fix는 머지 ≠ CF deploy — wrangler deploy 사용자 실행 필요

## 검증
- `npm test -- --coverage`: 8885 tests pass, 프론트 커버리지 100% (lines/branches/functions/statements)
- `backend/alarm-worker`: `npx vitest run --coverage`: 2746 tests pass, ratchet 게이트 통과 (신규 corrId 라인 100% 커버)
- `npm run type-check`: pass (프론트 + 백엔드)
- `npm run lint:orphan`: 0 orphan

## Test plan
- [x] Device: corrId 일치 → cleanup 실행
- [x] Device: corrId 불일치 → skip + alarmLog stamp
- [x] Device: payload.corrId 없음 → 기존 동작 (device corrId 조회 자체를 스킵)
- [x] Device: device corrId null(cache 미수화) → 기존 동작
- [x] Backend: register가 corrId 저장 (`validateTrip`)
- [x] Backend: 재등록(same/new session)이 corrId를 incoming 값으로 교체
- [x] Backend: trip-ended payload에 corrId echo
- [x] Backend: corrId 없는 trip은 payload 필드 생략