### PR TITLE
fix(#2122): FG 보조 발사 — APNs 전달 지연을 디바이스 자체 판정으로 우회

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -3,6 +3,15 @@
  * settings store(sleepMode/allowSpeaker)에 의존하는 분기를 검증하려면 같은 import 필요.
  * ADR Phase 5 (#890) orchestration 컨벤션.
  */
+// #2122 (FG 보조 발사) — 로컬 station-passed 배너 발사. 실제 expo-notifications 왕복 없이
+// 호출 여부/인자만 검증하기 위해 mock으로 격리.
+const mockFireFgAuxStationPassedNotification = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../utils/stationNotification', () => ({
+  fireFgAuxStationPassedNotification: (...args: unknown[]) =>
+    mockFireFgAuxStationPassedNotification(...args),
+}));
+
+import { AppState } from 'react-native';
 import { renderHook, waitFor } from '@testing-library/react-native';
 import {
   useStationAlarm,
@@ -30,6 +39,14 @@ import {
 // "결코 wire되지 않은 mock"이라 항상 통과하는 vacuous 검증이 된다. 값 자체는 유지하되 real
 // module mock은 제거해 dead jest.mock을 남기지 않는다.
 const mockSendStationPassedNotification = jest.fn().mockResolvedValue(undefined);
+
+// #2122 (FG 보조 발사) — AppState.currentState를 테스트에서 조작한다. react-native jest preset의
+// 기본 mock(`node_modules/react-native/jest/mocks/AppState.js`)은 `currentState`를 plain
+// 필드로 두므로 getter 없이 직접 대입 가능. 기본값 'background' — 기존 테스트("#2064 알림은
+// 미발사")가 FG 보조 발사 분기에 진입하지 않도록 보수적 초기화.
+function setAppState(state: 'active' | 'background' | 'inactive'): void {
+  (AppState as unknown as { currentState: string }).currentState = state;
+}
 
 const mockEvaluateAlarmPhase = jest.fn();
 jest.mock('../../utils/stationAlarm', () => {
@@ -237,6 +254,8 @@ function defaultInputs(overrides: Partial<UseStationAlarmInputs> = {}): UseStati
 describe('useStationAlarm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    setAppState('background');
+    mockFireFgAuxStationPassedNotification.mockResolvedValue(undefined);
     useSettingsStore.setState({ sleepMode: false, allowSpeaker: true });
     useAlarmEventStore.setState({ alarmEvent: null, dismissSilence: null });
     mockEvaluateAlarmPhase.mockReturnValue(null);
@@ -1665,6 +1684,81 @@ describe('useStationAlarm', () => {
         expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, station.id);
       });
       expect(mockLogFiredStationPassed).not.toHaveBeenCalled();
+    });
+
+    // #2122 — FG 보조 발사. backend APNs 전달 지연(실측 35~51s)을 FG에서 디바이스 자체 판정으로
+    // 우회. #2064 봉인은 유지하되 AppState==='active' && lock 활성일 때만 예외적으로 로컬
+    // station-passed 배너를 추가 발사한다.
+    describe('#2122 FG 보조 발사 (AppState active 한정)', () => {
+      function renderStationPassed() {
+        mockEvaluateAlarmPhase.mockReturnValue(null);
+        mockGetLastNotifiedStationId.mockResolvedValue(null);
+        mockSetLastNotifiedStationId.mockResolvedValue(undefined);
+        mockResolveNextTarget.mockReturnValue({
+          nextStationName: '강남',
+          stopsToNextStation: 1,
+          isTransfer: false,
+          stopsToDestination: 1,
+        });
+        return renderHook(() =>
+          useStationAlarm(defaultInputs({ route, destination, nearestStation: station })),
+        );
+      }
+
+      it('FG(active) + lock 활성 + 게이트 통과 → fireFgAuxStationPassedNotification 발사 + logFiredStationPassed(fg) 스탬프', async () => {
+        setAppState('active');
+
+        renderStationPassed();
+
+        await waitFor(() => {
+          expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, station.id);
+        });
+        await waitFor(() => {
+          expect(mockFireFgAuxStationPassedNotification).toHaveBeenCalledWith(station.name);
+        });
+        expect(mockLogFiredStationPassed).toHaveBeenCalledWith('fg', station.name);
+      });
+
+      it('BG(background) → fireFgAuxStationPassedNotification 미호출 (#2064 봉인 유지)', async () => {
+        setAppState('background');
+
+        renderStationPassed();
+
+        await waitFor(() => {
+          expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, station.id);
+        });
+        expect(mockFireFgAuxStationPassedNotification).not.toHaveBeenCalled();
+        expect(mockLogFiredStationPassed).not.toHaveBeenCalled();
+      });
+
+      it('lock 없음(lockless) → FG(active)여도 dispatch 자체에 도달하지 못해 미호출', async () => {
+        setAppState('active');
+        mockGetBoardingLock.mockResolvedValue(null);
+
+        renderStationPassed();
+
+        await waitFor(() => {
+          expect(mockLogSuppressedLocklessNoUserIntent).toHaveBeenCalled();
+        });
+        expect(mockFireFgAuxStationPassedNotification).not.toHaveBeenCalled();
+        expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
+      });
+
+      it('FG(active) + lock 활성이어도 fireFgAuxStationPassedNotification 실패 시 dedup bookkeeping은 유지되고 예외를 던지지 않는다', async () => {
+        setAppState('active');
+        mockFireFgAuxStationPassedNotification.mockRejectedValueOnce(new Error('schedule 실패'));
+
+        renderStationPassed();
+
+        await waitFor(() => {
+          expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, station.id);
+        });
+        await waitFor(() => {
+          expect(mockFireFgAuxStationPassedNotification).toHaveBeenCalledWith(station.name);
+        });
+        // logFiredStationPassed는 fireFgAuxStationPassedNotification 성공 후에만 호출 — 실패 시 미호출.
+        expect(mockLogFiredStationPassed).not.toHaveBeenCalled();
+      });
     });
 
     it('lastNotifiedStationId 일치로 skip 시 logSuppressedDedupStation(fg, station)을 호출한다', async () => {

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -7,6 +7,7 @@
  * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { AppState } from 'react-native';
 import {
   getFirstLeg,
   isStationOnRoute,
@@ -35,6 +36,7 @@ import { awaitInitialScheduledAlarmDrain } from '../utils/scheduledAlarmReceiver
 import { getTripStartedAt } from '../utils/tripStartStorage';
 import {
   logFiredAlarm,
+  logFiredStationPassed,
   logFiredAlarmsHydrate,
   logFiredAlarmsTripBoundaryReset,
   logHydrationTransition,
@@ -81,6 +83,7 @@ import { createLogger } from '../../../shared/utils/logger';
 import { isAccuracyAcceptable } from '../../nearest-station/utils/locationGates';
 import type { FusionConfidence, FusionSource } from '../../../shared/types/fusion';
 import { isSimpleArchEnabled } from '../../../shared/config/archFlag';
+import { fireFgAuxStationPassedNotification } from '../utils/stationNotification';
 
 const logger = createLogger('StationAlarm');
 
@@ -182,6 +185,9 @@ async function dispatchStationPassed(params: {
   capturedDestinationId: string;
   isCancelled: () => boolean;
   errorLogPrefix: string;
+  /** #2122 — FG 보조 발사 조건(AppState active && lock 활성) 판정용. 호출부가 항상 lock 활성 trip만
+   *  진입시키므로 실질적으로 non-null이지만, 타입은 방어적으로 nullable을 유지한다. */
+  lock: import('../../../shared/types/boardingLock').BoardingLock | null;
 }): Promise<void> {
   const {
     source,
@@ -189,6 +195,7 @@ async function dispatchStationPassed(params: {
     capturedDestinationId,
     isCancelled,
     errorLogPrefix,
+    lock,
   } = params;
   try {
     const lastId = await getLastNotifiedStationId(capturedDestinationId);
@@ -239,6 +246,9 @@ async function dispatchStationPassed(params: {
     // 감지는 이제 사용자 노출 알림을 발사하지 않고 cross-category dedup 윈도우 + lastNotifiedStationId
     // bookkeeping만 수행한다(다른 카테고리 알람/게이트가 여전히 이 상태를 읽는다).
     // category='station-passed' → 후속 destination/transfer 발사 차단.
+    // #2122 — 예외: FG 한정 보조 발사. backend APNs 전달 지연(실측 35~51s) 우회를 위해
+    // AppState==='active' && lock 활성일 때만 로컬 배너를 추가로 띄운다(바로 아래 블록).
+    // 봉인 자체는 유지 — BG/취침/transfer/destination 경로는 여전히 사용자 노출 알림을 발사하지 않는다.
     markStationFired(
       capturedDestinationId,
       candidateStation.name,
@@ -249,6 +259,18 @@ async function dispatchStationPassed(params: {
     // isCancelled() 체크(getLastNotifiedStationId await 직후) 이후 바뀔 수 없다. 별도 재확인 불필요
     // — await setLastNotifiedStationId 진입 시점에만 다시 확인하면 충분.
     await setLastNotifiedStationId(capturedDestinationId, candidateStation.id);
+    // #2122 (FG 보조 발사) — 위 모든 게이트(dedup/cross-category/hop-window/movement/silence/SSoT
+    // 등, 여기 도달했다는 것 자체가 전부 통과했다는 뜻)를 통과한 뒤에만, FG 한정으로 로컬
+    // station-passed 배너를 추가 발사한다. BG(AppState !=='active')는 이 블록에 도달해도 스킵 —
+    // #2064 봉인이 BG에는 그대로 유지된다.
+    if (AppState.currentState === 'active' && lock) {
+      try {
+        await fireFgAuxStationPassedNotification(candidateStation.name);
+        logFiredStationPassed(source, candidateStation.name);
+      } catch (e) {
+        logger.error('FG 보조 발사 실패:', e);
+      }
+    }
   } catch (e) {
     logger.error(errorLogPrefix, e);
   }
@@ -308,6 +330,7 @@ async function runSilenceGateAndDispatch(params: {
     capturedDestinationId: params.capturedDestinationId,
     isCancelled: params.isCancelled,
     errorLogPrefix: params.errorLogPrefix,
+    lock: params.lock,
   });
 }
 

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -16,6 +16,7 @@ import {
   getAlarmLog,
   clearAlarmLog,
   logFiredAlarm,
+  logFiredStationPassed,
   logScheduledAlarm,
   logFiredAlarmsHydrate,
   logRefMismatch,
@@ -528,6 +529,24 @@ describe('alarmLog', () => {
         kind: event.type,
         phaseId: event.phaseId,
       });
+      expect(saved[0].ts).toBeGreaterThan(0);
+    });
+
+    // #2122 (FG 보조 발사) — station-passed는 phase가 없어 logFiredAlarm(AlarmEvent 전용)을
+    // 재사용하지 않고 전용 helper로 kind='station-passed' 고정.
+    it('logFiredStationPassed: source + stationName을 outcome=fired, kind=station-passed로 적재한다', async () => {
+      logFiredStationPassed('fg', station.name);
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0]).toMatchObject({
+        source: 'fg',
+        outcome: 'fired',
+        stationName: station.name,
+        kind: 'station-passed',
+      });
+      expect(saved[0].phaseId).toBeUndefined();
       expect(saved[0].ts).toBeGreaterThan(0);
     });
 

--- a/src/features/alarm/utils/__tests__/recentLocalStationFires.test.ts
+++ b/src/features/alarm/utils/__tests__/recentLocalStationFires.test.ts
@@ -1,0 +1,201 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  markLocalStationFired,
+  hasRecentLocalStationFire,
+  RECENT_LOCAL_STATION_FIRE_TTL_MS,
+} from '../recentLocalStationFires';
+import { RECENT_LOCAL_STATION_FIRES_KEY } from '../../../../shared/constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const NOW = 1_700_000_000_000;
+
+describe('recentLocalStationFires (#2122)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  describe('markLocalStationFired', () => {
+    it('기존 storage가 없으면 단일 entry로 저장 (key = `${kind}:${stationName}`)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      await markLocalStationFired('중곡', 'station-passed', NOW);
+      const [, json] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      expect(JSON.parse(json)).toEqual({ 'station-passed:중곡': NOW });
+    });
+
+    it('기존 entry에 추가', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ 'station-passed:군자': NOW - 1000 }),
+      );
+      await markLocalStationFired('중곡', 'station-passed', NOW);
+      const [, json] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      expect(JSON.parse(json)).toEqual({
+        'station-passed:군자': NOW - 1000,
+        'station-passed:중곡': NOW,
+      });
+    });
+
+    it('TTL 초과 entry는 prune 후 저장', async () => {
+      const stale = NOW - RECENT_LOCAL_STATION_FIRE_TTL_MS - 1;
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ 'station-passed:stale': stale, 'station-passed:recent': NOW - 1000 }),
+      );
+      await markLocalStationFired('중곡', 'station-passed', NOW);
+      const [, json] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      expect(JSON.parse(json)).toEqual({
+        'station-passed:recent': NOW - 1000,
+        'station-passed:중곡': NOW,
+      });
+    });
+
+    it('손상된 JSON은 빈 map으로 초기화 후 add', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('not-json{');
+      await markLocalStationFired('중곡', 'station-passed', NOW);
+      const [, json] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      expect(JSON.parse(json)).toEqual({ 'station-passed:중곡': NOW });
+    });
+
+    it('비-객체 JSON(배열 등)도 빈 map으로 초기화', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(['a']));
+      await markLocalStationFired('중곡', 'station-passed', NOW);
+      const [, json] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      expect(JSON.parse(json)).toEqual({ 'station-passed:중곡': NOW });
+    });
+
+    it('비-숫자 ts 항목은 prune (구버전 호환)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ 'station-passed:bad': 'string', 'station-passed:good': NOW }),
+      );
+      await markLocalStationFired('중곡', 'station-passed', NOW);
+      const [, json] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      expect(JSON.parse(json)).toEqual({
+        'station-passed:good': NOW,
+        'station-passed:중곡': NOW,
+      });
+    });
+
+    it('AsyncStorage 실패 시 throw 안 함 (fire-and-forget)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      await expect(markLocalStationFired('중곡', 'station-passed', NOW)).resolves.toBeUndefined();
+    });
+
+    it('setItem 실패도 swallow', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('disk full'));
+      await expect(markLocalStationFired('중곡', 'station-passed', NOW)).resolves.toBeUndefined();
+    });
+
+    it('default now (인자 미주입)는 Date.now() 사용', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(NOW);
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      await markLocalStationFired('중곡', 'station-passed');
+      const [, json] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      expect(JSON.parse(json)['station-passed:중곡']).toBe(NOW);
+      (Date.now as jest.Mock).mockRestore?.();
+    });
+  });
+
+  describe('hasRecentLocalStationFire', () => {
+    it('TTL 내 (station,kind) entry는 true', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ 'station-passed:중곡': NOW - 1000 }),
+      );
+      expect(await hasRecentLocalStationFire('중곡', 'station-passed', NOW)).toBe(true);
+    });
+
+    it('TTL 초과 entry는 false', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({
+          'station-passed:중곡': NOW - RECENT_LOCAL_STATION_FIRE_TTL_MS - 1,
+        }),
+      );
+      expect(await hasRecentLocalStationFire('중곡', 'station-passed', NOW)).toBe(false);
+    });
+
+    it('미존재 (station,kind)는 false', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify({}));
+      expect(await hasRecentLocalStationFire('중곡', 'station-passed', NOW)).toBe(false);
+    });
+
+    it('같은 station이라도 kind가 다르면 false (kind-scoped key)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ 'transfer:중곡': NOW - 1000 }),
+      );
+      expect(await hasRecentLocalStationFire('중곡', 'station-passed', NOW)).toBe(false);
+    });
+
+    it('비-숫자 ts entry는 false (방어)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ 'station-passed:중곡': 'string' }),
+      );
+      expect(await hasRecentLocalStationFire('중곡', 'station-passed', NOW)).toBe(false);
+    });
+
+    it('AsyncStorage 실패 시 false (빈 map fallback)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      expect(await hasRecentLocalStationFire('중곡', 'station-passed', NOW)).toBe(false);
+    });
+
+    it('default now (인자 미주입)는 Date.now()', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(NOW);
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ 'station-passed:중곡': NOW - 1000 }),
+      );
+      expect(await hasRecentLocalStationFire('중곡', 'station-passed')).toBe(true);
+      (Date.now as jest.Mock).mockRestore?.();
+    });
+  });
+
+  it('RECENT_LOCAL_STATION_FIRE_TTL_MS는 2분으로 노출', () => {
+    expect(RECENT_LOCAL_STATION_FIRE_TTL_MS).toBe(2 * 60 * 1000);
+  });
+
+  it('AsyncStorage key는 storageKeys 상수', () => {
+    expect(RECENT_LOCAL_STATION_FIRES_KEY).toBe('subway-now:recent-local-station-fires');
+  });
+
+  describe('동시성 직렬화 큐', () => {
+    it('두 mark가 동시에 진입해도 두 entry 모두 저장된다 (read-modify-write race 차단)', async () => {
+      let storage: string | null = null;
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(async () => storage);
+      (AsyncStorage.setItem as jest.Mock).mockImplementation(async (_key, value) => {
+        storage = value;
+      });
+      await Promise.all([
+        markLocalStationFired('중곡', 'station-passed', NOW),
+        markLocalStationFired('군자', 'station-passed', NOW + 1),
+      ]);
+      const final = JSON.parse(storage!);
+      expect(final).toEqual({
+        'station-passed:중곡': NOW,
+        'station-passed:군자': NOW + 1,
+      });
+    });
+
+    it('mark 후 has는 same-tick에서도 직전 write를 본다', async () => {
+      let storage: string | null = null;
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(async () => storage);
+      (AsyncStorage.setItem as jest.Mock).mockImplementation(async (_key, value) => {
+        storage = value;
+      });
+      const markP = markLocalStationFired('중곡', 'station-passed', NOW);
+      const hasP = hasRecentLocalStationFire('중곡', 'station-passed', NOW);
+      await Promise.all([markP, hasP]);
+      expect(await hasP).toBe(true);
+    });
+  });
+});

--- a/src/features/alarm/utils/__tests__/stationNotifCollapseId.test.ts
+++ b/src/features/alarm/utils/__tests__/stationNotifCollapseId.test.ts
@@ -1,0 +1,28 @@
+import { buildStationNotifCollapseId, STATION_NOTIF_COLLAPSE_ID_PREFIX } from '../stationNotifCollapseId';
+
+// #2122 — backend `stationNotifCollapseId`(backend/alarm-worker/src/scheduled.ts, #2063/#2086)의
+// 실제 테스트에서 사용하는 HEX64_TOKEN 리터럴을 그대로 재사용해, device-side 구현이 backend
+// 규칙과 문자열 단위로 동일한 출력을 내는지 byte-for-byte 검증한다.
+// backend/alarm-worker/src/__tests__/scheduled.test.ts:88 참고.
+const HEX64_TOKEN = '0123456789abcdef'.repeat(4);
+
+describe('buildStationNotifCollapseId (#2122)', () => {
+  it('STATION_NOTIF_COLLAPSE_ID_PREFIX(station-) + device token slice(0,16)로 빌드한다', () => {
+    expect(buildStationNotifCollapseId(HEX64_TOKEN)).toBe(
+      `${STATION_NOTIF_COLLAPSE_ID_PREFIX}${HEX64_TOKEN.slice(0, 16)}`,
+    );
+  });
+
+  it('backend stationNotifCollapseId(#2063/#2086)와 문자열 단위로 동일한 출력 — 64 hex 토큰 → station-<16hex>', () => {
+    expect(buildStationNotifCollapseId(HEX64_TOKEN)).toBe('station-0123456789abcdef');
+  });
+
+  it('64B 이하 — apns-collapse-id 한도 준수', () => {
+    const collapseId = buildStationNotifCollapseId(HEX64_TOKEN);
+    expect(new TextEncoder().encode(collapseId).length).toBeLessThanOrEqual(64);
+  });
+
+  it('짧은 mock token(slice가 no-op)도 안전하게 처리한다', () => {
+    expect(buildStationNotifCollapseId('short-tok')).toBe('station-short-tok');
+  });
+});

--- a/src/features/alarm/utils/__tests__/stationNotification.test.ts
+++ b/src/features/alarm/utils/__tests__/stationNotification.test.ts
@@ -7,7 +7,10 @@ import {
   clearStationNotification,
   clearAlarmNotification,
   buildAlarmContent,
+  fireFgAuxStationPassedNotification,
 } from '../stationNotification';
+import { buildStationNotifCollapseId } from '../stationNotifCollapseId';
+import { APNS_TOKEN_KEY } from '../../../../shared/constants/storageKeys';
 import { Station } from '../../../../shared/types/station';
 import {
   makeDirectRoute,
@@ -64,6 +67,15 @@ import { ACTIVE_TRIP_KEY } from '../../../../shared/constants/storageKeys';
 const mockHasFiredPushId = jest.fn();
 jest.mock('../firedPushIds', () => ({
   hasFiredPushId: (...args: unknown[]) => mockHasFiredPushId(...args),
+}));
+
+// #2122 (FG 보조 발사) — 로컬 station-passed 발사 기록/조회 store. 2b 억제 판정과
+// fireFgAuxStationPassedNotification 후처리 stamp를 분리 검증하기 위해 mock으로 격리.
+const mockMarkLocalStationFired = jest.fn().mockResolvedValue(undefined);
+const mockHasRecentLocalStationFire = jest.fn().mockResolvedValue(false);
+jest.mock('../recentLocalStationFires', () => ({
+  markLocalStationFired: (...args: unknown[]) => mockMarkLocalStationFired(...args),
+  hasRecentLocalStationFire: (...args: unknown[]) => mockHasRecentLocalStationFire(...args),
 }));
 
 const mockSaveStationToWidget = jest.fn().mockResolvedValue(undefined);
@@ -218,6 +230,80 @@ describe('stationNotification', () => {
       });
       expect(emptyPushId.shouldShowAlert).toBe(true);
       expect(mockHasFiredPushId).not.toHaveBeenCalled();
+    });
+
+    // #2122 (FG 보조 발사) — 2차 방어선. backend alert push data.nextWaypoint/kind가 최근 로컬
+    // 발사(station-passed)와 일치하면 표시를 억제한다(1차 방어선은 apns-collapse-id 문자열 일치).
+    describe('#2122 — 최근 로컬 발사(station,kind) 표시 억제 (2b)', () => {
+      it('data.kind=intermediate + hasRecentLocalStationFire=true → 표시 억제', async () => {
+        mockHasRecentLocalStationFire.mockResolvedValueOnce(true);
+        setupNotificationHandler();
+        const { handleNotification } = (Notifications.setNotificationHandler as jest.Mock).mock.calls[0][0];
+        const result = await handleNotification({
+          request: {
+            identifier: 'station-notif-abc',
+            content: { sound: null, data: { nextWaypoint: '중곡', kind: 'intermediate' } },
+          },
+        });
+        expect(mockHasRecentLocalStationFire).toHaveBeenCalledWith('중곡', 'station-passed');
+        expect(result).toEqual({
+          shouldShowAlert: false,
+          shouldShowBanner: false,
+          shouldShowList: false,
+          shouldPlaySound: false,
+          shouldSetBadge: false,
+        });
+      });
+
+      it('data.kind=intermediate + hasRecentLocalStationFire=false → 정상 표시', async () => {
+        mockHasRecentLocalStationFire.mockResolvedValueOnce(false);
+        setupNotificationHandler();
+        const { handleNotification } = (Notifications.setNotificationHandler as jest.Mock).mock.calls[0][0];
+        const result = await handleNotification({
+          request: {
+            identifier: 'station-notif-abc',
+            content: { sound: null, data: { nextWaypoint: '중곡', kind: 'intermediate' } },
+          },
+        });
+        expect(result.shouldShowAlert).toBe(true);
+      });
+
+      it('data.kind가 매핑 대상(intermediate) 외이면 hasRecentLocalStationFire 호출 안 함 (정상 표시)', async () => {
+        setupNotificationHandler();
+        const { handleNotification } = (Notifications.setNotificationHandler as jest.Mock).mock.calls[0][0];
+        const result = await handleNotification({
+          request: {
+            identifier: 'station-alarm',
+            content: { sound: null, data: { nextWaypoint: '중곡', kind: 'transfer' } },
+          },
+        });
+        expect(mockHasRecentLocalStationFire).not.toHaveBeenCalled();
+        expect(result.shouldShowAlert).toBe(true);
+      });
+
+      it('data 없거나 nextWaypoint/kind 누락이면 hasRecentLocalStationFire 호출 안 함 (정상 표시)', async () => {
+        setupNotificationHandler();
+        const { handleNotification } = (Notifications.setNotificationHandler as jest.Mock).mock.calls[0][0];
+        const noData = await handleNotification({
+          request: { identifier: 'station-notif-abc', content: { sound: null } },
+        });
+        expect(noData.shouldShowAlert).toBe(true);
+        const noKind = await handleNotification({
+          request: {
+            identifier: 'station-notif-abc',
+            content: { sound: null, data: { nextWaypoint: '중곡' } },
+          },
+        });
+        expect(noKind.shouldShowAlert).toBe(true);
+        const emptyStation = await handleNotification({
+          request: {
+            identifier: 'station-notif-abc',
+            content: { sound: null, data: { nextWaypoint: '', kind: 'intermediate' } },
+          },
+        });
+        expect(emptyStation.shouldShowAlert).toBe(true);
+        expect(mockHasRecentLocalStationFire).not.toHaveBeenCalled();
+      });
     });
   });
 
@@ -862,6 +948,45 @@ describe('stationNotification', () => {
     it('dismiss 실패해도 에러를 던지지 않는다', async () => {
       (Notifications.dismissNotificationAsync as jest.Mock).mockRejectedValueOnce(new Error('없음'));
       await expect(clearAlarmNotification()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('fireFgAuxStationPassedNotification (#2122 FG 보조 발사)', () => {
+    beforeEach(async () => {
+      await AsyncStorage.clear();
+    });
+
+    it('device token 보유 시 backend collapse-id와 동일한 identifier로 로컬 알림을 발사하고 markLocalStationFired를 stamp한다', async () => {
+      await AsyncStorage.setItem(APNS_TOKEN_KEY, 'a'.repeat(64));
+
+      await fireFgAuxStationPassedNotification('중곡');
+
+      const expectedId = buildStationNotifCollapseId('a'.repeat(64));
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          identifier: expectedId,
+          content: expect.objectContaining({
+            title: '역 통과',
+            body: '중곡역을 지나고 있어요',
+            sound: false,
+          }),
+          trigger: null,
+        }),
+      );
+      expect(mockMarkLocalStationFired).toHaveBeenCalledWith('중곡', 'station-passed');
+    });
+
+    it('기존 동일 identifier 알림을 dismiss한 뒤 재발사한다 (scheduleNotification 공용 helper 재사용)', async () => {
+      await AsyncStorage.setItem(APNS_TOKEN_KEY, 'b'.repeat(64));
+      await fireFgAuxStationPassedNotification('군자');
+      const expectedId = buildStationNotifCollapseId('b'.repeat(64));
+      expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith(expectedId);
+    });
+
+    it('device token 미보유 시(등록 전) 스킵 — 알림 발사/stamp 모두 안 함', async () => {
+      await fireFgAuxStationPassedNotification('중곡');
+      expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+      expect(mockMarkLocalStationFired).not.toHaveBeenCalled();
     });
   });
 

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -438,6 +438,22 @@ export function logFiredAlarm(
 }
 
 /**
+ * #2122 (FG 보조 발사) — station-passed 로컬 발사 stamp.
+ * `logFiredAlarm`은 `AlarmEvent`(destination/transfer 전용, phaseId 필수)를 받는데
+ * station-passed는 phase 개념이 없어 재사용 대신 전용 helper로 kind 고정.
+ * DebugModal Alarm log `fg / fired` + `/admin/alarm-log-stats` `sources.fg`가 이 stamp를 관측한다.
+ */
+export function logFiredStationPassed(source: AlarmLogSource, stationName: string): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source,
+    outcome: 'fired',
+    stationName,
+    kind: 'station-passed',
+  });
+}
+
+/**
  * 사전 예약(BG) 알람 1건의 stamp 컨텍스트를 적재한다 (#372).
  * source는 항상 'bg-scheduled', outcome은 'fired'(사전 예약된 발사 예정 기록).
  * 발사 자체는 expo-notifications가 처리하므로 별도 fire-time 로그는 없다.

--- a/src/features/alarm/utils/recentLocalStationFires.ts
+++ b/src/features/alarm/utils/recentLocalStationFires.ts
@@ -1,0 +1,85 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { RECENT_LOCAL_STATION_FIRES_KEY } from '../../../shared/constants/storageKeys';
+import { createLogger } from '../../../shared/utils/logger';
+
+// #2122 — FG 보조 발사(로컬 station-passed 알림) 직후, 뒤늦게 도착하는 backend alert push가
+// 같은 (station, kind)를 표시하려 하면 foreground 표시 핸들러(stationNotification.ts
+// setupNotificationHandler)가 이 기록을 참조해 중복 배너를 억제한다.
+//
+// collapse-id 문자열 일치(stationNotifCollapseId, 2a)가 1차 방어선이고, 본 store는 2차
+// 방어선(2b) — iOS가 로컬↔원격 알림을 항상 동일 identifier로 교체한다는 보장이 없어(#2122
+// PR 본문 "알려진 잔여 윈도우" 참고) 별도 문자열 기반 신호로 이중 방어한다.
+//
+// firedPushIds.ts(#574 P2e)와 동일한 write-queue 직렬화 패턴 — read-modify-write race로
+// entry가 유실되면 본 게이트의 목적(중복 표시 차단) 자체가 깨지므로 add를 chain한다.
+
+const logger = createLogger('RecentLocalStationFires');
+
+/** backend alert push 실측 지연 35~51s(#2122) + 안전 마진. */
+export const RECENT_LOCAL_STATION_FIRE_TTL_MS = 2 * 60 * 1000;
+
+type FireMap = Record<string, number>;
+
+function keyOf(stationName: string, kind: string): string {
+  return `${kind}:${stationName}`;
+}
+
+async function read(): Promise<FireMap> {
+  try {
+    const raw = await AsyncStorage.getItem(RECENT_LOCAL_STATION_FIRES_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    return parsed as FireMap;
+  } catch {
+    return {};
+  }
+}
+
+function prune(map: FireMap, now: number): FireMap {
+  const out: FireMap = {};
+  for (const [key, ts] of Object.entries(map)) {
+    if (typeof ts === 'number' && now - ts < RECENT_LOCAL_STATION_FIRE_TTL_MS) {
+      out[key] = ts;
+    }
+  }
+  return out;
+}
+
+let writeQueue: Promise<unknown> = Promise.resolve();
+
+function enqueue<T>(task: () => Promise<T>): Promise<T> {
+  const next = writeQueue.then(task);
+  writeQueue = next;
+  return next;
+}
+
+export function markLocalStationFired(
+  stationName: string,
+  kind: string,
+  now: number = Date.now(),
+): Promise<void> {
+  return enqueue(async () => {
+    try {
+      const current = await read();
+      const pruned = prune(current, now);
+      pruned[keyOf(stationName, kind)] = now;
+      await AsyncStorage.setItem(RECENT_LOCAL_STATION_FIRES_KEY, JSON.stringify(pruned));
+    } catch (e) {
+      logger.warn('markLocalStationFired 실패 — FG 표시 중복억제 한 사이클 손실:', e);
+    }
+  });
+}
+
+export function hasRecentLocalStationFire(
+  stationName: string,
+  kind: string,
+  now: number = Date.now(),
+): Promise<boolean> {
+  return enqueue(async () => {
+    const current = await read();
+    const ts = current[keyOf(stationName, kind)];
+    if (typeof ts !== 'number') return false;
+    return now - ts < RECENT_LOCAL_STATION_FIRE_TTL_MS;
+  });
+}

--- a/src/features/alarm/utils/stationNotifCollapseId.ts
+++ b/src/features/alarm/utils/stationNotifCollapseId.ts
@@ -1,0 +1,17 @@
+/**
+ * #2122 (FG 보조 발사) — 로컬 notification identifier 빌더.
+ *
+ * backend `stationNotifCollapseId`(backend/alarm-worker/src/scheduled.ts, #2063/#2086)와
+ * **문자열 단위로 동일한 규칙**을 device에서 재현한다. 뒤늦게 도착하는 backend alert push의
+ * `apns-collapse-id`가 이 로컬 알림과 같은 identifier면, iOS가 알림센터에서 이 로컬 알림을
+ * remote로 교체한다(같은 trip 내 station-notif는 collapse-id가 trip 단위 — station 무관).
+ *
+ * device token(64 hex)을 통째로 넣으면 apns-collapse-id 64B 한도를 초과할 수 있어(#2086과
+ * 동일 사유) `slice(0, 16)`로 축약한다. backend와 축약 길이(16)가 다르면 문자열이 어긋나
+ * collapse가 성립하지 않으므로 **절대 변경 금지** — 변경 시 backend 규칙과 함께 조정해야 한다.
+ */
+export const STATION_NOTIF_COLLAPSE_ID_PREFIX = 'station-';
+
+export function buildStationNotifCollapseId(deviceToken: string): string {
+  return `${STATION_NOTIF_COLLAPSE_ID_PREFIX}${deviceToken.slice(0, 16)}`;
+}

--- a/src/features/alarm/utils/stationNotification.ts
+++ b/src/features/alarm/utils/stationNotification.ts
@@ -15,7 +15,7 @@ import { DirectRoute, TransferRoute, MultiTransferRoute, normalizeStationName } 
 import type { AlarmEvent } from './stationAlarm';
 import * as LiveActivity from 'live-activity';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
+import { ACTIVE_TRIP_KEY, APNS_TOKEN_KEY } from '../../../shared/constants/storageKeys';
 import {
   ensureLiveActivityRegistered,
   endLiveActivityWithDeregister,
@@ -36,6 +36,8 @@ import {
   shouldDiscloseNotificationSource,
   type NotificationSource,
 } from './notificationSource';
+import { buildStationNotifCollapseId } from './stationNotifCollapseId';
+import { markLocalStationFired, hasRecentLocalStationFire } from './recentLocalStationFires';
 
 /** 알람/통과 본문 끝에 데이터 출처를 자백하는 라벨을 부착한다.
  *  - source 미지정 → 라벨 생략 (기존 caller 회귀 안전)
@@ -82,13 +84,12 @@ export function setupNotificationHandler(): void {
       // #574 P2e — silent push가 이미 fired한 pushId의 alert fallback이 race로 도달했을 때
       // FG에서 중복 표시 차단. BG에선 iOS가 직접 표시해 JS 개입 불가(P2e 한계 명시).
       if (await isFallbackDuplicate(notification)) {
-        return {
-          shouldShowAlert: false,
-          shouldShowBanner: false,
-          shouldShowList: false,
-          shouldPlaySound: false,
-          shouldSetBadge: false,
-        };
+        return SUPPRESSED_NOTIFICATION_BEHAVIOR;
+      }
+      // #2122 — FG 보조 발사(로컬 station-passed 알림) 직후 뒤늦게 도착한 backend alert push가
+      // 같은 (station, kind)면 2차 방어선으로 표시 억제(1차는 apns-collapse-id 문자열 일치).
+      if (await isRecentLocalAuxFireDuplicate(notification)) {
+        return SUPPRESSED_NOTIFICATION_BEHAVIOR;
       }
       return {
         shouldShowAlert: true,
@@ -101,6 +102,14 @@ export function setupNotificationHandler(): void {
   });
 }
 
+const SUPPRESSED_NOTIFICATION_BEHAVIOR: Notifications.NotificationBehavior = {
+  shouldShowAlert: false,
+  shouldShowBanner: false,
+  shouldShowList: false,
+  shouldPlaySound: false,
+  shouldSetBadge: false,
+};
+
 /**
  * notification.request.content.data.pushId가 silent에서 이미 처리한 pushId면 true.
  * APNs alert payload data 형식: `{ pushId: string }` (#572 sendAlertPush).
@@ -112,6 +121,33 @@ async function isFallbackDuplicate(
   const pushId = data?.pushId;
   if (typeof pushId !== 'string' || pushId.length === 0) return false;
   return hasFiredPushId(pushId);
+}
+
+// #2122 — backend push data.kind('intermediate' 등, backend `Waypoint.kind`)를
+// 로컬 dispatchStationPassed의 AlarmLogKind('station-passed')로 매핑. FG 보조 발사는
+// station-passed(=intermediate) 카테고리 한정이라 매핑 테이블도 그 범위만 갖는다.
+const BACKEND_PUSH_KIND_TO_LOCAL_FIRE_KIND: Record<string, string> = {
+  intermediate: 'station-passed',
+};
+
+/**
+ * backend alert push의 data.nextWaypoint(station name) + data.kind가, 이 device가 방금 로컬로
+ * 발사한 (station, kind)와 일치하면 true. apns-collapse-id 문자열 일치(1차 방어선)가
+ * 성립하지 않는 케이스를 위한 2차 방어선(#2122 스펙 2b).
+ */
+async function isRecentLocalAuxFireDuplicate(
+  notification: Notifications.Notification,
+): Promise<boolean> {
+  const data = notification.request.content.data as
+    | { nextWaypoint?: unknown; kind?: unknown }
+    | undefined;
+  const stationName = data?.nextWaypoint;
+  const backendKind = data?.kind;
+  if (typeof stationName !== 'string' || stationName.length === 0) return false;
+  if (typeof backendKind !== 'string') return false;
+  const localKind = BACKEND_PUSH_KIND_TO_LOCAL_FIRE_KIND[backendKind];
+  if (!localKind) return false;
+  return hasRecentLocalStationFire(stationName, localKind);
 }
 
 const STATION_CHANNEL_ID = 'station';
@@ -515,4 +551,30 @@ export async function clearAlarmNotification(): Promise<void> {
   try {
     await Notifications.dismissNotificationAsync(ALARM_NOTIFICATION_ID);
   } catch { /* 무시 */ }
+}
+
+/**
+ * #2122 (FG 보조 발사) — FG 상태에서 backend alert push의 APNs 전달 지연(실측 35~51s)을
+ * 디바이스 자체 arvlcd 판정으로 우회하는 로컬 station-passed 배너.
+ *
+ * identifier는 backend `stationNotifCollapseId`(backend/alarm-worker/src/scheduled.ts)와
+ * 동일한 문자열 규칙(#2063/#2086)으로 빌드한다 — 뒤늦게 도착하는 backend push가 이 로컬 알림을
+ * 알림센터에서 최신으로 교체하도록 유도한다(1차 방어선. 실기기 검증 항목, PR 본문 "알려진
+ * 잔여 윈도우" 참고. 2차 방어선은 setupNotificationHandler의 isRecentLocalAuxFireDuplicate).
+ *
+ * device token(APNS_TOKEN_KEY) 미보유 시(등록 전) backend와 동일한 collapse-id를 만들 수 없어
+ * 발사를 스킵한다 — 이 경우 사용자는 기존처럼 backend push만 받는다(회귀 아님).
+ */
+export async function fireFgAuxStationPassedNotification(stationName: string): Promise<void> {
+  const deviceToken = await AsyncStorage.getItem(APNS_TOKEN_KEY);
+  if (!deviceToken) return;
+  const identifier = buildStationNotifCollapseId(deviceToken);
+  await scheduleNotification(identifier, {
+    title: i18next.t('route.intermediatePassedTitle'),
+    body: i18next.t('route.intermediatePassedBody', {
+      name: getStationDisplayNameByName(stationName, allStations),
+    }),
+    sound: false,
+  });
+  await markLocalStationFired(stationName, 'station-passed');
 }

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -216,3 +216,9 @@ export const BG_LAST_POSITION_UPLOAD_AT_KEY = 'subway-now:bg-last-position-uploa
 // entry TTL 1h — trip 하나가 1시간을 넘는 경우는 드물고, TTL이 지나면 자연 prune돼 무한 성장 방지.
 // 형식: { id: string; firedAt: number }[] JSON. id = `alarm-${tripToken}-${station}-${kind}`.
 export const ALARM_LOCAL_LEDGER_KEY = 'subway-now:alarm-local-ledger';
+// #2122 — FG 보조 발사(로컬 station-passed 알림) 직후 (station, kind) 발사 기록.
+// setupNotificationHandler(FG 표시 핸들러)가 뒤늦게 도착한 backend alert push를 렌더하기 전
+// 이 기록을 참조해 같은 (station, kind)가 최근 로컬 발사됐으면 표시를 억제한다(2중 방어의 2b).
+// TTL RECENT_LOCAL_STATION_FIRE_TTL_MS(recentLocalStationFires.ts) 경과 항목은 add/read 시 cleanup.
+// 형식: { "<kind>:<stationName>": timestamp(epoch ms) } JSON.
+export const RECENT_LOCAL_STATION_FIRES_KEY = 'subway-now:recent-local-station-fires';


### PR DESCRIPTION
## 요약

Closes #2122

매역 알림의 유일한 배너 채널이던 backend alert push의 APNs 전달 구간이 실측 **35~51초**(R2 trip-evidence)로 지연되는 문제를, FG 상태에서 디바이스가 이미 보유한 arvlcd 판정을 재사용해 로컬 배너로 보조 발사하도록 우회했다. 정책·게이트·dedup 판정은 기존 `useStationAlarm` 체계 그대로 — 바뀐 것은 "FG에서 발사 소스 1개 추가"뿐.

- `useStationAlarm.ts` `dispatchStationPassed`: #2064 봉인은 그대로 유지하되, `AppState.currentState === 'active' && lock 활성 && 기존 게이트(dedup/cross-category/hop-window/movement/silence/SSoT) 전부 통과` 조건에서만 로컬 station-passed 배너를 추가 발사. BG/취침/transfer/destination 경로는 한 줄도 변경하지 않음.
- `stationNotifCollapseId.ts` (신규): backend `stationNotifCollapseId`(backend/alarm-worker/src/scheduled.ts, #2063/#2086 — `station-${tripToken.slice(0,16)}`)와 문자열 단위로 동일한 로컬 notification identifier 빌더. backend 코드는 읽기만 했고 수정하지 않음.
- `stationNotification.ts`: `fireFgAuxStationPassedNotification` 신설(위 collapse-id를 identifier로 로컬 알림 스케줄) + `setupNotificationHandler`에 2차 방어선 추가 — 최근 로컬 발사한 (station, kind)와 일치하는 backend push 도착 시 표시 억제.
- `recentLocalStationFires.ts` (신규): FG 보조 발사 (station, kind) 최근 기록 store (`firedPushIds.ts`와 동일한 write-queue 직렬화 패턴).
- `alarmLog.ts`: `logFiredStationPassed` 신설 — station-passed 전용 `outcome='fired'` stamp (AlarmEvent는 phaseId 필수라 재사용 불가).
- `storageKeys.ts`: `RECENT_LOCAL_STATION_FIRES_KEY` 추가.

## 금지사항 준수
- BG 발사 재개 없음 — `AppState.currentState === 'active'` 조건으로 엄격히 FG 한정.
- backend 발사/판정 로직 무변경 (읽기만 함).
- 취침 알람·transfer·destination 경로 무변경.
- 기존 게이트 완화 없음 — 신규 정책 분기 없이 기존 게이트를 모두 통과한 뒤에만 추가 발사.

## 테스트 (커버리지 100%)
- FG(active) + lock + 게이트 통과 → 로컬 발사 + `logFiredStationPassed('fg', ...)` 스탬프
- BG(background) → 발사 안 함 (#2064 봉인 유지)
- lock 없음(lockless) → dispatch 자체 도달 불가로 미발사
- `fireFgAuxStationPassedNotification` 실패 시 dedup bookkeeping은 유지, stamp는 스킵, throw 없음
- collapse identifier가 backend HEX64_TOKEN 리터럴 기준 문자열 일치 (`buildStationNotifCollapseId`)
- FG 핸들러: 최근 로컬 발사 (station,kind) remote 도착 → 표시 억제 / 미발사 → 정상 표시 / kind 미매핑·데이터 누락 → 정상 표시

## Wire-completion 5단
1. **Orphan** — `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard** — DebugModal Alarm log `fg / fired` (kind=station-passed) + `/admin/alarm-log-stats` `sources.fg`에서 FG 보조 발사 수 관측 가능
3. **의존 PR** — N/A (device-only. backend collapse-id 규칙은 읽기만 하고 수정 없음)
4. **측정 plan** — 다음 실탑승 FG 구간에서 배너 표시 시각 ≈ 역 통과 시각(체감) + `fg fired` ≥ 1 + 중복 배너 0건을 alarmLog/DebugModal로 확인
5. **Device verify** — 필요. ① FG 탑승 시 즉시 배너 표시 ② backend push가 뒤늦게 도착했을 때 중복 배너 여부 ③ 로컬↔remote 알림이 동일 identifier(apns-collapse-id)로 실제 교체되는지(iOS 알림센터 동작, 코드로 보장 불가한 OS 레벨 동작) — 실기기 미검증 시 잔여 윈도우에서 중복 배너 1회 가능(acceptance 허용, PR 스펙 명시)

## 알려진 잔여 윈도우
로컬 발사 직후 앱이 BG 전환된 뒤 backend push가 도착하면 collapse-id 일치에 의존한다. iOS가 로컬 delivered 알림을 remote collapse-id로 실제 교체하는지는 실기기 검증 항목 — 교체 실패 시 그 좁은 윈도우에서 중복 배너 1회 가능(acceptance에서 허용, 후속 측정으로 판단).