### PR TITLE
fix(#2124): 열차 리스트 로딩 창 근본 제거 — same-station line-flip 시 직전 도착 데이터 유지

### DIFF
--- a/src/features/arrival/hooks/__tests__/useArrivalInfo.test.ts
+++ b/src/features/arrival/hooks/__tests__/useArrivalInfo.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { AppState } from 'react-native';
 import { prefetchArrival, useArrivalInfo, __resetArrivalCacheForTests } from '../useArrivalInfo';
 import * as arrivalApiModule from '../../api/arrivalApi';
+import type { LineNumber } from '../../../../shared/types/station';
 
 jest.mock('../../api/arrivalApi');
 
@@ -554,6 +555,102 @@ describe('useArrivalInfo', () => {
       // fetch 완료 후 line=3 데이터로 표시.
       await act(async () => { resolveLine3(mockArrival); });
       expect(result.current.arrival).toEqual(mockArrival);
+    });
+  });
+
+  // #2124 — 건대입구 재등록 시 `건대입구|7 → 건대입구|2` 키 flip으로 arrival이 null 리셋되며
+  // 열차 리스트가 순간적으로 비는 회귀(#2115 RCA (a)) 차단. BFF 응답은 line-무관이므로 직전
+  // realtime arrival을 유지한 채 refetch만 트리거해 스켈레톤 창을 없앤다.
+  describe('same-station line-flip keeps previous arrival (#2124)', () => {
+    it('같은 역에서 line만 바뀌고 직전 데이터가 realtime이면 arrival을 유지한 채 refetch한다', async () => {
+      const realtimeLine7 = { ...mockArrival, source: 'realtime' as const };
+      (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(realtimeLine7);
+
+      const { result, rerender } = renderHook(
+        ({ line }: { line: LineNumber | null }) => useArrivalInfo('건대입구', line),
+        { initialProps: { line: '7' as LineNumber | null } },
+      );
+
+      await waitFor(() => expect(result.current.arrival).toEqual(realtimeLine7));
+      expect(result.current.loading).toBe(false);
+
+      // line flip: 7호선 → 2호선, 같은 역. refetch는 pending 상태로 둬 유지 여부를 관찰한다.
+      let resolveLine2!: (value: typeof realtimeLine7) => void;
+      (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockImplementation(
+        () => new Promise((r) => { resolveLine2 = r; }),
+      );
+      rerender({ line: '2' });
+
+      // 직전 arrival 유지 — null 리셋 없음. loading도 기존 semantics(false) 유지 → 리스트 즉시 렌더.
+      expect(result.current.arrival).toEqual(realtimeLine7);
+      expect(result.current.loading).toBe(false);
+
+      // 새 (station, line) 키로 refetch가 실제로 트리거됐는지 확인.
+      await waitFor(() =>
+        expect(arrivalApiModule.fetchArrivalInfo).toHaveBeenCalledWith('건대입구', { lineHint: '2' }),
+      );
+
+      // refetch 완료 시 새 데이터로 교체된다.
+      const realtimeLine2 = {
+        up: [{ destination: '까치산행', arrivalMinutes: 1, arrivalSeconds: 60, statusMessage: '', trainCode: 'L2-X', receivedAtMs: 0, arrivalCode: -1, isLastTrain: false, trainType: 'normal' }],
+        down: [],
+        source: 'realtime' as const,
+      };
+      await act(async () => { resolveLine2(realtimeLine2); });
+      expect(result.current.arrival).toEqual(realtimeLine2);
+    });
+
+    it('직전 데이터가 schedule fallback 출처면 line flip 시 유지하지 않고 기존대로 reset한다', async () => {
+      const scheduleFallback = { ...mockArrival, source: 'schedule' as const };
+      (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(scheduleFallback);
+
+      const { result, rerender } = renderHook(
+        ({ line }: { line: LineNumber | null }) => useArrivalInfo('교대', line),
+        { initialProps: { line: '2' as LineNumber | null } },
+      );
+
+      await waitFor(() => expect(result.current.arrival).toEqual(scheduleFallback));
+
+      rerender({ line: '3' });
+
+      // fallback 출처는 이월되지 않음 — 기존 null reset 동작 유지.
+      expect(result.current.arrival).toBeNull();
+      expect(result.current.loading).toBe(true);
+    });
+
+    it('직전 데이터가 isMock이면 line flip 시 유지하지 않고 기존대로 reset한다', async () => {
+      const mockRealtimeShaped = { ...mockArrival, source: 'realtime' as const, isMock: true };
+      (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(mockRealtimeShaped);
+
+      const { result, rerender } = renderHook(
+        ({ line }: { line: LineNumber | null }) => useArrivalInfo('교대', line),
+        { initialProps: { line: '2' as LineNumber | null } },
+      );
+
+      await waitFor(() => expect(result.current.arrival).toEqual(mockRealtimeShaped));
+
+      rerender({ line: '3' });
+
+      expect(result.current.arrival).toBeNull();
+      expect(result.current.loading).toBe(true);
+    });
+
+    it('station이 바뀌면(line도 함께) 직전 arrival을 유지하지 않고 reset한다 — 다른 역 데이터 이월 금지', async () => {
+      const realtimeArrival = { ...mockArrival, source: 'realtime' as const };
+      (arrivalApiModule.fetchArrivalInfo as jest.Mock).mockResolvedValue(realtimeArrival);
+
+      const { result, rerender } = renderHook(
+        ({ name, line }: { name: string; line: LineNumber | null }) => useArrivalInfo(name, line),
+        { initialProps: { name: '건대입구', line: '7' as LineNumber | null } },
+      );
+
+      await waitFor(() => expect(result.current.arrival).toEqual(realtimeArrival));
+
+      // 역과 line이 동시에 바뀜 — station 변경이므로 line-flip 유지 로직 적용 대상 아님.
+      rerender({ name: '성수', line: '2' });
+
+      expect(result.current.arrival).toBeNull();
+      expect(result.current.loading).toBe(true);
     });
   });
 });

--- a/src/features/arrival/hooks/useArrivalInfo.ts
+++ b/src/features/arrival/hooks/useArrivalInfo.ts
@@ -104,6 +104,11 @@ export function useArrivalInfo(
   // fallback이 다르므로 (현재역 도착정보가 잘못된 호선/방면을 표시하는 회귀 차단).
   const lineHintRef = useRef(lineHint);
   lineHintRef.current = lineHint;
+  // #2124 — 키 변경 reset 분기가 "동일 station, line만 변경" 케이스를 구분하기 위한 직전 값.
+  const prevKeyRef = useRef<{ stationName: string | null; lineHint: LineNumber | null | undefined }>({
+    stationName: null,
+    lineHint: undefined,
+  });
 
   const updateArrival = useCallback((data: StationArrival) => {
     if (!arrivalEqual(arrivalRef.current, data)) {
@@ -113,6 +118,9 @@ export function useArrivalInfo(
   }, []);
 
   useEffect(() => {
+    const prevKey = prevKeyRef.current;
+    prevKeyRef.current = { stationName, lineHint };
+
     if (!stationName) {
       arrivalRef.current = null;
       setArrival(null);
@@ -124,11 +132,27 @@ export function useArrivalInfo(
     if (cached) {
       updateArrival(cached);
       setLoading(false);
-    } else {
-      arrivalRef.current = null;
-      setArrival(null);
-      setLoading(true);
+      return;
     }
+
+    // #2124 — station은 동일하고 line만 바뀐 경우(fusion 슬롯의 호선 재선정 등), BFF 실시간
+    // 응답은 호선 무관으로 전 호선 도착정보를 포함하므로 직전 realtime arrival을 그대로 유지한 채
+    // refetch만 트리거한다. arrival===null 순간(스켈레톤 창)을 없애 열차 리스트 선택 불가 구간을 제거.
+    // 직전 데이터가 mock/schedule fallback 출처면(호선별로 값이 달라짐) 유지하지 않고 기존 reset.
+    const sameStationLineFlip =
+      prevKey.stationName === stationName &&
+      prevKey.lineHint !== lineHint &&
+      arrivalRef.current !== null &&
+      arrivalRef.current.source === 'realtime' &&
+      !arrivalRef.current.isMock;
+
+    if (sameStationLineFlip) {
+      return;
+    }
+
+    arrivalRef.current = null;
+    setArrival(null);
+    setLoading(true);
     // lineHint가 바뀌면 새 (station, line) 키로 캐시 lookup. fusion 슬롯 교체 시 직전 호선
     // 캐시가 잔존해 잘못된 도착정보로 표시되는 회귀 차단(#1400).
   }, [stationName, lineHint, updateArrival]);


### PR DESCRIPTION
Closes #2124

## 변경 사항

`useArrivalInfo.ts:115-134`(키 변경 reset 분기)에서 station이 동일하고 line만 바뀐 경우, 직전 realtime arrival을 유지한 채 refetch만 트리거하도록 변경했습니다.

- BFF 실시간 응답은 line-무관(같은 역의 전 호선 도착정보 포함)이므로, 직전 `건대입구|7` 조회 결과에 이미 2호선 도착정보가 들어 있습니다. 이를 버리지 않고 재사용합니다.
- station이 바뀐 경우는 기존 null reset 동작 100% 유지 — 다른 역으로의 데이터 이월 없음.
- 직전 데이터가 mock/schedule fallback 출처(`source !== 'realtime'` 또는 `isMock`)면 유지하지 않고 기존 reset — 호선별로 값이 다르기 때문.
- 캐시 키 재설계 없음, polling 주기/캐시 TTL 변경 없음, feed 계층 line filter 추가 없음(소비처가 이미 필터링).

## Wire-completion 5단

1. **Orphan**: `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard**: 코드-only 변경. `etaProviderConsistency.test.ts` 게이트 통과로 대체 확인 완료(50/50 pass)
3. **의존 PR**: N/A
4. **측정 plan**: 다음 환승/재등록 시 열차 리스트 즉시 표시(체감) — 실기기 trip에서 재등록 순간 리스트가 비지 않는지 확인
5. **Device verify**: 환승역 재등록 직후 리스트 즉시 표시 1회 확인 필요 (실기기)

## 테스트

- 같은 역 line flip → arrival 유지 + refetch 발생 + 리스트 즉시 렌더 (loading 유지)
- 역 변경 → null reset 기존 동작 유지 (line도 함께 바뀐 경우 포함)
- 직전 데이터가 schedule fallback / isMock 출처 → line flip 시 reset
- refetch 완료 시 새 데이터로 교체

`npm test` (422 suites / 8925 tests, 100% coverage), `npm run type-check`, `npm run lint:orphan` 모두 pass.