### PR TITLE
fix(#2125): 현재역 표시 고착 정직 강등 (sticky 시작역 + 전진 신호 전무)

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -346,6 +346,10 @@ function formatFusionDebugLine(entry: FusionDebugEntry): string {
     const sp = entry.speedMps != null ? `${entry.speedMps.toFixed(1)}m/s` : '-';
     return `${time} | sticky:${entry.event} | ${entry.stationName}(${entry.line}) acc=${acc} sp=${sp}`;
   }
+  // #2125 — 현재역 표시 고착 정직 강등 이벤트. 표시 계층 전용 관측.
+  if (entry.kind === 'display-demote') {
+    return `${time} | ${entry.reason} | ${entry.stationName}(${entry.line})`;
+  }
   // #1902 (RC-18) — candidate-reject 분기는 candidateRejectBuffer로 이전(별 buffer + 별 섹션).
   // #1896 (RC-8) — boarding-lock-drift 분기는 boardingLockDriftBuffer로 이전(별 buffer + 별 섹션).
   // fusion 분기는 fusion decision entry만 처리한다.

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -2044,6 +2044,25 @@ describe('DebugModal fusion log section', () => {
     expect(entries[0].props.children).toContain('gp=용마산');
   });
 
+  // #2125 — 현재역 표시 고착 정직 강등 entry (kind: 'display-demote') 포맷 가드.
+  it('display-demote entry를 reason + station(line) 포맷으로 노출한다', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    act(() => {
+      pushFusionDebugEntry({
+        kind: 'display-demote',
+        reason: 'display-demote-sticky-stale',
+        ts: new Date('2026-08-03T00:00:00Z').getTime(),
+        stationName: '용마산',
+        line: '7',
+      });
+    });
+    expect(screen.getByText('Fusion log (1)')).toBeTruthy();
+    const entries = screen.getAllByTestId('debug-fusion-log-entry');
+    expect(entries[0].props.children).toContain('display-demote-sticky-stale');
+    expect(entries[0].props.children).toContain('용마산(7)');
+  });
+
   it('Clear 버튼이 fusion 로그를 비운다', async () => {
     pushFusionDebugEntry({
       kind: 'gps',

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -27,6 +27,12 @@ import {
 import type { StationArrival, ArrivalInfo } from '../../../../shared/types/arrival';
 import type { Station } from '../../../../shared/types/station';
 import { makeDirectRoute, makeTransferRoute, makeMultiTransferRoute } from '../../../../testUtils/routeFixtures';
+import { CURRENT_STATION_STALE_DEMOTE_MS } from '../../../../shared/constants/realtime';
+import {
+  getFusionDebugEntries,
+  clearFusionDebugEntries,
+  type DisplayDemoteEntry,
+} from '../../utils/fusionDebugBuffer';
 
 jest.mock('../useNearestStation');
 jest.mock('../../../arrival/hooks/useArrivalInfo');
@@ -2029,6 +2035,162 @@ describe('useFusedNearestStation', () => {
 
       // DebugModal/UI는 stickyDisplayOnly로 sticky 정보 노출.
       expect(result.current.stickyDisplayOnly).toEqual(stickyStation);
+    });
+  });
+
+  // #2125 — 현재역 표시 고착 정직 강등 (RCA (d) 옵션 1). 표시 계층 전용 — 4조건 AND.
+  describe('#2125 현재역 표시 고착 정직 강등', () => {
+    const yongmasan = findStationByNameAndLine('용마산', '7')!;
+    const junggok = findStationByNameAndLine('중곡', '7')!;
+    const konkuk = findStationByNameAndLine('건대입구', '7')!;
+    const route = makeDirectRoute(4, '7');
+    const routeContext = { route, origin: yongmasan, destination: konkuk };
+    const T0 = 1_700_000_000_000;
+
+    beforeEach(() => {
+      clearFusionDebugEntries();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    // sticky가 tripOrigin(용마산)에 고정 + 다른 신호 미채택 상태로 렌더 후 elapsedMs만큼 경과시킨다.
+    // wifiStation을 지정하면 상위 tier(wifi) 채택 시나리오를 재현할 수 있다.
+    function renderStuckAtOrigin(opts?: { elapsedMs?: number; wifiStation?: Station | null }) {
+      const { elapsedMs = CURRENT_STATION_STALE_DEMOTE_MS, wifiStation = null } = opts ?? {};
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
+          result: { station: yongmasan, distanceKm: 0 },
+          liveResult: { station: yongmasan, distanceKm: 0 },
+          stickyDisplayOnly: yongmasan,
+          source: 'sticky' as const,
+        }),
+      );
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+      jest.useFakeTimers();
+      jest.setSystemTime(T0);
+      const { result, rerender } = renderHook(
+        (wifi: Station | null) =>
+          useFusedNearestStation(
+            undefined,
+            undefined,
+            routeContext,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            wifi,
+          ),
+        { initialProps: wifiStation },
+      );
+      jest.setSystemTime(T0 + elapsedMs);
+      rerender(wifiStation);
+      return result;
+    }
+
+    it('4조건 충족 (trip 활성 + sticky==tripOrigin + 상위 tier 부재 + 3분 경과) → 강등 true + fusion log 1건', () => {
+      const result = renderStuckAtOrigin();
+
+      expect(result.current.currentStationDisplayDemoted).toBe(true);
+      const entries = getFusionDebugEntries().filter(
+        (e): e is DisplayDemoteEntry => e.kind === 'display-demote',
+      );
+      expect(entries).toHaveLength(1);
+      expect(entries[0].reason).toBe('display-demote-sticky-stale');
+      expect(entries[0].stationName).toBe(yongmasan.name);
+      expect(entries[0].line).toBe(yongmasan.line);
+    });
+
+    it('조건1 미충족 — trip 비활성(routeContext 없음) → 강등하지 않음', () => {
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          result: { station: yongmasan, distanceKm: 0 },
+          liveResult: { station: yongmasan, distanceKm: 0 },
+          stickyDisplayOnly: yongmasan,
+          source: 'sticky' as const,
+        }),
+      );
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+
+      const { result } = renderHook(() => useFusedNearestStation());
+
+      expect(result.current.currentStationDisplayDemoted).toBe(false);
+      expect(
+        getFusionDebugEntries().filter((e) => e.kind === 'display-demote'),
+      ).toHaveLength(0);
+    });
+
+    it('조건2 미충족 — result.station이 sticky 다른 역으로 전진(실제 이동 신호) → 강등하지 않음', () => {
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          userLocation: { lat: junggok.lat, lng: junggok.lng },
+          result: { station: junggok, distanceKm: 0 },
+          liveResult: { station: junggok, distanceKm: 0 },
+          stickyDisplayOnly: yongmasan,
+          source: 'sticky' as const,
+        }),
+      );
+      mockFindTop.mockReturnValue([{ station: junggok, distanceKm: 0 }]);
+      jest.useFakeTimers();
+      jest.setSystemTime(T0);
+      const { result, rerender } = renderHook(() =>
+        useFusedNearestStation(undefined, undefined, routeContext),
+      );
+      jest.setSystemTime(T0 + CURRENT_STATION_STALE_DEMOTE_MS);
+      rerender(undefined);
+
+      expect(result.current.currentStationDisplayDemoted).toBe(false);
+    });
+
+    it('조건3 미충족 — 상위 tier(wifi) 채택 시 → 강등하지 않음', () => {
+      const result = renderStuckAtOrigin({ wifiStation: yongmasan });
+
+      expect(result.current.source).toBe('wifi-ssid');
+      expect(result.current.currentStationDisplayDemoted).toBe(false);
+    });
+
+    it('조건4 미충족 — 3분 미경과 → 강등하지 않음', () => {
+      const result = renderStuckAtOrigin({ elapsedMs: CURRENT_STATION_STALE_DEMOTE_MS - 1_000 });
+
+      expect(result.current.currentStationDisplayDemoted).toBe(false);
+    });
+
+    it('강등 해제 — 상위 tier 채택으로 전환되면 즉시 false로 복귀', () => {
+      mockUseNearest.mockReturnValue(
+        gpsBase({
+          userLocation: { lat: yongmasan.lat, lng: yongmasan.lng },
+          result: { station: yongmasan, distanceKm: 0 },
+          liveResult: { station: yongmasan, distanceKm: 0 },
+          stickyDisplayOnly: yongmasan,
+          source: 'sticky' as const,
+        }),
+      );
+      mockFindTop.mockReturnValue([{ station: yongmasan, distanceKm: 0 }]);
+      jest.useFakeTimers();
+      jest.setSystemTime(T0);
+      const { result, rerender } = renderHook(
+        (wifi: Station | null) =>
+          useFusedNearestStation(
+            undefined,
+            undefined,
+            routeContext,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            wifi,
+          ),
+        { initialProps: null as Station | null },
+      );
+      jest.setSystemTime(T0 + CURRENT_STATION_STALE_DEMOTE_MS);
+      rerender(null);
+      expect(result.current.currentStationDisplayDemoted).toBe(true);
+
+      // 상위 tier(wifi) 신호 도착 — 즉시 정상 복귀.
+      rerender(yongmasan);
+      expect(result.current.currentStationDisplayDemoted).toBe(false);
     });
   });
 });

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -85,6 +85,7 @@ import {
   CANDIDATE_ANCHOR_WINDOW_DEFAULT,
   CANDIDATE_ANCHOR_WINDOW_EXPANDED,
   CANDIDATE_REJECT_ANCHOR_EXPAND_THRESHOLD,
+  CURRENT_STATION_STALE_DEMOTE_MS,
   DETECTION_FUSED_MAX_DISTANCE_KM,
   GPS_DERIVED_ACCURACY_MAX_M,
   GPS_DERIVED_FIX_MAX_AGE_MS,
@@ -129,6 +130,17 @@ const FUSION_CANDIDATE_LIMIT = MAX_ACTIVE_LINES;
  *
  * 신규 라벨 추가 시 본 표만 갱신 — caller가 직접 string 변환 X (lint으로 단일 SSOT 강제).
  */
+/**
+ * #2125 — 현재역 표시 고착 정직 강등 판정에서 "상위 tier advance 신호"로 인정하는 tier 집합.
+ * 이 중 하나가 채택되면 사용자가 실제로 전진 중이라 판단해 강등을 건너뛴다.
+ */
+const HIGHER_TIER_ADVANCED = new Set<FusionTierName>([
+  'position-train-lock',
+  'position-train',
+  'backend-ssot',
+  'wifi',
+]);
+
 const LEGACY_TIER_LABEL_MAP: Record<FusionTierName, FusionPickerTier> = {
   'position-train-lock': 'positionTrainBoardingLockMatch',
   'gps-fast-path': 'gpsDerivedFastPath',
@@ -303,6 +315,19 @@ interface UseFusedNearestStationReturn {
    * fire path SSOT(result/confidence/source)에서 분리되어 표시 채널로만 노출된다.
    */
   stickyDisplayOnly: import('../../../shared/types/station').Station | null;
+  /**
+   * #2125 — 현재역 표시 고착 정직 강등 (RCA (d) 옵션 1). 표시 계층 전용 — fire/알람 경로 무영향.
+   *
+   * true인 조건 (AND, 매 cycle 재평가 — 상위 tier 채택/sticky unlock/trip 종료 시 즉시 false):
+   *   1. lockless trip 활성 (routeContext 제공 — destination+route 존재)
+   *   2. `result.station`이 sticky lock 상태이고 그 역이 trip 시작역(routeContext.origin)과 동일
+   *   3. 상위 tier(position-train-lock/position-train/backend-ssot/wifi) 어느 것도 현재 미채택
+   *   4. lockless trip 시작 후 CURRENT_STATION_STALE_DEMOTE_MS 경과
+   *
+   * 호출자(HomeScreen)는 본 플래그가 true면 역명 대신 "이동 중 · 현재역 확인 중" 라벨을 노출한다.
+   * effectiveOrigin/journey/도착정보 등 다른 surface의 SSOT는 무변경 — 역명 표시 문구만 대체.
+   */
+  currentStationDisplayDemoted: boolean;
   /**
    * #1621 (Phase B) — backend SSoT mirror가 fresh일 때 currentStationId, 미존재/stale일 때 null.
    *
@@ -1706,6 +1731,50 @@ export function useFusedNearestStation(
     !boardingLock && locklessTripStartRef.current != null
       ? { tripStartedAt: locklessTripStartRef.current }
       : null;
+
+  // #2125 — 현재역 표시 고착 정직 강등 (RCA (d) 옵션 1). 표시 계층 전용.
+  //
+  // 신규 추정 로직 없이 기존 산출물만 재사용:
+  //   - gps.stickyDisplayOnly: sticky lock된 station (표시 채널, #1486)
+  //   - routeContext.origin: trip 시작역(tripOrigin) — HomeScreen이 destination 설정 시 캡처.
+  //   - adoptedTier: cascade가 채택한 tier (상위 tier advance 여부 판정)
+  //   - locklessTripStartRef: lockless trip 시작 시각 (#1207 앵커, 위에서 이미 산출)
+  //
+  // lock 활성 trip은 범위 밖 — RCA 시나리오(positionTrain은 lock 필요, 즉 lockless에서만
+  // positionTrain 자체가 dormant)가 lockless 전용이라 locklessTripStartRef가 자연 게이트 역할.
+  const tripOriginForDemote = routeContext?.origin ?? null;
+  const stickyLockedStation = gps.stickyDisplayOnly;
+  const resultStuckAtStickyOrigin =
+    routeContext != null &&
+    stickyLockedStation != null &&
+    tripOriginForDemote != null &&
+    stickyLockedStation.id === tripOriginForDemote.id &&
+    result?.station.id === stickyLockedStation.id;
+  const higherTierAdvanced = HIGHER_TIER_ADVANCED.has(adoptedTier);
+  const lockedElapsedMs =
+    locklessTrip != null ? Date.now() - locklessTrip.tripStartedAt : null;
+  const currentStationDisplayDemoted =
+    resultStuckAtStickyOrigin &&
+    !higherTierAdvanced &&
+    lockedElapsedMs != null &&
+    lockedElapsedMs >= CURRENT_STATION_STALE_DEMOTE_MS;
+
+  // #2125 — 강등 진입 1회만 fusion log 스탬프 (DebugModal Fusion log 빈도 측정).
+  // dedup: false→true 전환 시에만 push — 매 polling cycle 재적재로 buffer 점령 방지.
+  const wasDemotedRef = useRef(false);
+  useEffect(() => {
+    if (currentStationDisplayDemoted && !wasDemotedRef.current && stickyLockedStation) {
+      pushFusionDebugEntry({
+        kind: 'display-demote',
+        reason: 'display-demote-sticky-stale',
+        ts: Date.now(),
+        stationName: stickyLockedStation.name,
+        line: stickyLockedStation.line,
+      });
+    }
+    wasDemotedRef.current = currentStationDisplayDemoted;
+  }, [currentStationDisplayDemoted, stickyLockedStation]);
+
   const estimate = estimateStationProgress({
     lock: boardingLock ?? null,
     locklessTrip,
@@ -2228,6 +2297,8 @@ export function useFusedNearestStation(
     // #1486 (ADR-015 §2) — sticky 표시 채널 패스스루. useNearestStation이 sticky.locked를 노출하고
     // 본 hook은 그대로 통과. fire path는 본 필드는 읽지 않는다.
     stickyDisplayOnly: gps.stickyDisplayOnly,
+    // #2125 — 표시 계층 정직 강등 플래그. fire path는 본 필드를 읽지 않는다.
+    currentStationDisplayDemoted,
     // #1621 (Phase B) — V1 mismatch 자동 측정용. silent push handler가 영속화한 backend SSoT
     // currentStationId를 그대로 노출. mirror null/stale 시 null. consumer는
     // `useV1MismatchDetector(uiCurrentStationId, ssotCurrentStationId)` 한 줄로 wire.

--- a/src/features/nearest-station/utils/fusionDebugBuffer.ts
+++ b/src/features/nearest-station/utils/fusionDebugBuffer.ts
@@ -106,10 +106,26 @@ export interface StickyStationEntry {
  * 200~500 cap을 점령하면 fusion decision/sticky/gps-fix 진단 1순위 entry가 evict된다.
  */
 
+/**
+ * #2125 — 현재역 표시 고착 정직 강등 이벤트. sticky lock이 trip 시작역에 고정된 채
+ * CURRENT_STATION_STALE_DEMOTE_MS 이상 상위 tier advance 없이 경과하면 1건 push.
+ * 표시 계층 전용 관측 — fire/알람 경로는 본 entry를 읽지 않는다.
+ */
+export type DisplayDemoteReason = 'display-demote-sticky-stale';
+
+export interface DisplayDemoteEntry {
+  kind: 'display-demote';
+  reason: DisplayDemoteReason;
+  ts: number;
+  stationName: string;
+  line: string;
+}
+
 export type FusionDebugEntry =
   | FusionDecisionEntry
   | GpsFixEntry
-  | StickyStationEntry;
+  | StickyStationEntry
+  | DisplayDemoteEntry;
 
 const db = createDebugBuffer<FusionDebugEntry>(FUSION_DEBUG_BUFFER_CAPACITY);
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -225,7 +225,7 @@ export default function HomeScreen() {
   // #1677 — silent push 60s+ 미수신 감지. FG 시 backendSsotAccepts 강제 false → device tier fallback.
   // 신규 폴링 없음 — 기존 arrival/position 30s cycle 재사용.
   const { healthy: silentPushHealthy } = useSilentPushHealthCheck();
-  const { result, liveResult, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source, currentHopIndex, arcStations, trainProgressing, estimatorIsTimeIntegration, estimatorStrategy, backendSsotCurrentStationId, environment } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal }, wifiStation, silentPushHealthy);
+  const { result, liveResult, variants, userLocation, speedMps, accuracyMeters, loading, error, permissionDenied, locationUncertain, positionStability, refresh, confidence, source, currentHopIndex, arcStations, trainProgressing, estimatorIsTimeIntegration, estimatorStrategy, backendSsotCurrentStationId, environment, currentStationDisplayDemoted } = useFusedNearestStation(undefined, undefined, routeContext, lockedTrainCode, fusionBoardingLock, motionStationary, { subsurface: barometerSubsurface, signal: barometerSignal }, wifiStation, silentPushHealthy);
 
   // #1621 Phase B — V1 mismatch 자동 측정. UI currentStation(cascade picker)이 backend SSoT
   // 권위 mirror와 일치하지 않으면 alarmLog 'v1-mismatch' reason으로 1분 dedup 적재.
@@ -1204,7 +1204,11 @@ export default function HomeScreen() {
                   ]}
                   testID="home-origin-station-name"
                 >
-                  {getStationDisplayName(effectiveOrigin)}
+                  {/* #2125 — 현재역 표시 고착 정직 강등. 역명 표시만 대체 — effectiveOrigin
+                      자체(journey/도착정보/알람 SSOT)는 무변경. */}
+                  {currentStationDisplayDemoted
+                    ? t('home.originStaleDemote')
+                    : getStationDisplayName(effectiveOrigin)}
                 </Text>
                 <TouchableOpacity
                   onPress={() =>

--- a/src/shared/constants/realtime.ts
+++ b/src/shared/constants/realtime.ts
@@ -255,3 +255,16 @@ export const SIGNAL_4_KTX_ETA_UPPER_BOUND_MS = 10 * 60 * 60_000;
  *   - reanchored-hop / default-hop은 lock 기반이므로 본 게이트는 lockless 전략에만 적용.
  */
 export const LOCKLESS_TIME_INTEGRATION_STUCK_TIMEOUT_MS = 90_000;
+
+/**
+ * #2125 — 현재역 표시 고착 정직 강등 임계 (RCA (d) 옵션 1).
+ *
+ * lockless trip에서 상위 tier(position-train/backend-ssot/wifi) advance 신호가 전멸하고
+ * sticky lock이 trip 시작역(tripOrigin)에 계속 고정된 채로 본 임계 이상 경과하면, 표시 계층이
+ * "이동 중 · 현재역 확인 중"으로 정직하게 강등한다 (표시 전용 — fire/알람 경로 무영향).
+ *
+ * 3분 임계: 인접역 평균 hop time(~90s~120s)의 1.5~2배. 정상 진행 중이면 이 시간 내 다음 역
+ * 신호(어떤 tier든)가 들어오는 것이 일반적 — 그 이상 원점 고착이면 사용자에게 "이동 중이지만
+ * 정확한 역은 모른다"고 정직하게 알리는 것이 잘못된 역명 표시보다 낫다.
+ */
+export const CURRENT_STATION_STALE_DEMOTE_MS = 3 * 60_000;

--- a/src/shared/i18n/__tests__/i18n.test.ts
+++ b/src/shared/i18n/__tests__/i18n.test.ts
@@ -84,4 +84,17 @@ describe('i18n instance', () => {
     expect(i18n.t('common.retry')).toBe('다시 시도');
     expect(i18n.t('common.close')).toBe('닫기');
   });
+
+  // #2125 — 현재역 표시 고착 정직 강등 라벨. 4언어 모두 키가 정의돼 있고 fallback(키 자체)이
+  // 아닌 실제 번역 문자열을 반환하는지 스냅샷 가드.
+  it.each(['ko', 'en', 'ja', 'zh'] as const)(
+    'resolves home.originStaleDemote for %s',
+    async (lang) => {
+      await i18n.changeLanguage(lang);
+      const label = i18n.t('home.originStaleDemote');
+      expect(label).not.toBe('home.originStaleDemote');
+      expect(typeof label).toBe('string');
+      expect(label.length).toBeGreaterThan(0);
+    },
+  );
 });

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -28,6 +28,7 @@
     "originCurrent": "Current station",
     "originNearest": "Nearest station",
     "originEstimated": "Estimated current station",
+    "originStaleDemote": "Moving · confirming current station",
     "routeTo": "Route to",
     "estimatedSuffix": "EST",
     "destinationChange": "Change destination →",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -28,6 +28,7 @@
     "originCurrent": "現在駅",
     "originNearest": "最寄り駅",
     "originEstimated": "現在の推定駅",
+    "originStaleDemote": "移動中・現在駅を確認中",
     "routeTo": "目的地まで",
     "estimatedSuffix": "予想",
     "destinationChange": "目的地を変更 →",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -28,6 +28,7 @@
     "originCurrent": "현재역",
     "originNearest": "가장 가까운 역",
     "originEstimated": "현재 추정 역",
+    "originStaleDemote": "이동 중 · 현재역 확인 중",
     "routeTo": "목적지까지",
     "estimatedSuffix": "예상",
     "destinationChange": "목적지 변경 →",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -28,6 +28,7 @@
     "originCurrent": "当前站",
     "originNearest": "最近站",
     "originEstimated": "当前推定站",
+    "originStaleDemote": "行驶中 · 正在确认当前站",
     "routeTo": "前往",
     "estimatedSuffix": "预计",
     "destinationChange": "更改目的地 →",


### PR DESCRIPTION
## Closes #2125

## 배경
trip 진행 중 "현재역" 표시가 시작역에 고착되는 RCA (d)에 대한 표시 계층 정직화 (옵션 1). sticky lock/TTL/게이트, fusion cascade 순위, tripOrigin/route 저장, fire/알람 경로는 전부 무변경 — 표시 문구만 정직하게 대체한다.

## 변경 사항
- `src/shared/constants/realtime.ts`: `CURRENT_STATION_STALE_DEMOTE_MS`(3분) 신규 상수
- `useFusedNearestStation.ts`: 아래 4조건 AND 충족 시 `currentStationDisplayDemoted: boolean` 노출
  1. lockless trip 활성 (routeContext 제공)
  2. `result.station`이 sticky lock 상태이고 그 역이 trip 시작역(routeContext.origin)과 동일
  3. 상위 tier(position-train-lock/position-train/backend-ssot/wifi) 어느 것도 미채택
  4. lockless trip 시작 후 `CURRENT_STATION_STALE_DEMOTE_MS` 경과
  - 기존 산출물(`stickyDisplayOnly`, `liveResult`, `fusionTierAdopted`, `locklessTripStartRef`)만 재사용 — 신규 추정 로직 없음
- `fusionDebugBuffer.ts`: `DisplayDemoteEntry`(`kind: 'display-demote'`, `reason: 'display-demote-sticky-stale'`) 추가, 강등 진입 1회만 push (dedup)
- `DebugModal.tsx`: `display-demote` entry 포맷 지원 (Fusion log 섹션에서 그대로 노출)
- `HomeScreen.tsx`: `currentStationDisplayDemoted=true`일 때 현재역 카드 역명을 `home.originStaleDemote`("이동 중 · 현재역 확인 중")로 대체. `effectiveOrigin`(journey/도착정보/알람 SSOT)은 무변경 — 역명 표시 문구만 대체
- i18n 4언어(ko/en/ja/zh) `home.originStaleDemote` 키 추가

## 금지사항 준수
- sticky 게이트/TTL 무변경, fusion cascade 순위 무변경
- fire/알람 경로는 강등 플래그를 참조하지 않음 (표시 전용)
- tripOrigin/route 저장 로직 무변경

## 테스트
- `npm test`: 8936 passed, 커버리지 100% (lines/branches/functions/statements)
- `npm run type-check`: pass
- `npm run lint:orphan`: 0 orphan
- 신규 테스트: 4조건 AND 각 미충족 케이스(조건1~4) + 강등 해제(즉시 복귀) + fusion log 1건 적재 + DebugModal `display-demote` 포맷 + i18n 4언어 스냅샷

## Wire-completion 5단
1. **Orphan**: `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard**: DebugModal "Fusion log" 섹션에서 `display-demote-sticky-stale` entry로 강등 발생 빈도 관측 가능
3. **의존 PR**: #918 PR이 `HomeScreen.tsx`(현재역 카드 렌더 영역)를 동시에 건드릴 수 있어 머지 충돌 가능 — **늦게 머지되는 쪽이 rebase**
4. **측정 plan**: 다음 지하 lockless trip에서 시작역 오표기 재발 0건(강등 라벨 또는 정상 전진 라벨만 허용)을 DebugModal Fusion log `display-demote-sticky-stale` 빈도 + 실기기 화면으로 1주 확인
5. **Device verify**: 필요 — 지하 구간 lockless trip 1회에서 시작역 고착 대신 "이동 중 · 현재역 확인 중" 강등 라벨 노출 확인