### PR TITLE
feat(#918): OS 사전예약 매역 알림 — lock 기반 rolling window + 3소스 멱등

### DIFF
--- a/src/features/alarm/__tests__/evidence_20260703_replay.test.ts
+++ b/src/features/alarm/__tests__/evidence_20260703_replay.test.ts
@@ -131,6 +131,22 @@ const mockSendTripEndedNotification = jest.fn().mockResolvedValue(undefined);
 jest.mock('../utils/stationNotification', () => ({
   buildAlarmContent: (...args: unknown[]) => mockBuildAlarmContent(...(args as Parameters<typeof mockBuildAlarmContent>)),
   sendTripEndedNotification: (...args: unknown[]) => mockSendTripEndedNotification(...args),
+  // #918 — silentPushTask.ts가 standard payload 경로에서 presched(OS 사전예약) 3-소스 dedup을
+  // 위해 호출. 실제 구현과 동일한 순수 매핑 로직 재현(신규 live-activity import 체인 회피).
+  mapBackendKindToLocalFireKind: (backendKind: string) =>
+    ({ intermediate: 'station-passed', transfer: 'transfer', destination: 'destination' } as Record<string, string>)[backendKind] ?? null,
+}));
+
+const mockCancelPrescheduledByStationKind = jest.fn().mockResolvedValue(undefined);
+const mockReschedulePrescheduledAlarm = jest.fn().mockResolvedValue({ cancelled: 0, scheduled: 0 });
+jest.mock('../utils/stationPrescheduler', () => ({
+  cancelPrescheduledByStationKind: (...args: unknown[]) => mockCancelPrescheduledByStationKind(...args),
+  reschedulePrescheduledAlarm: (...args: unknown[]) => mockReschedulePrescheduledAlarm(...args),
+}));
+
+const mockMarkLocalStationFired = jest.fn().mockResolvedValue(undefined);
+jest.mock('../utils/recentLocalStationFires', () => ({
+  markLocalStationFired: (...args: unknown[]) => mockMarkLocalStationFired(...args),
 }));
 
 const mockAddFiredPushId = jest.fn().mockResolvedValue(undefined);
@@ -194,9 +210,18 @@ jest.mock('../store/useBoardingLockStore', () => ({
 // 모듈로 통합되며 reschedule/cancel-by-station 진입점도 하나로 합쳐졌다.
 const mockRescheduleSafetyNetAlarm = jest.fn();
 const mockCancelSafetyNetByStationKind = jest.fn().mockResolvedValue(undefined);
+// #918 — applyReschedule의 presched 분기(sleepMode OFF)가 backendTripToken/tripStart로부터
+// effective tripToken을 도출하는 데 사용. 실제 모듈과 동일한 동작(backend 우선, 없으면
+// device-local id)을 재현.
+const mockResolveEffectiveTripToken = jest.fn(
+  (backendTripToken: string | null, tripStart: number | null) =>
+    backendTripToken ?? (tripStart !== null ? `local-${tripStart}` : null),
+);
 jest.mock('../utils/safetyNetScheduler', () => ({
   rescheduleSafetyNetAlarm: (...args: unknown[]) => mockRescheduleSafetyNetAlarm(...args),
   cancelSafetyNetByStationKind: (...args: unknown[]) => mockCancelSafetyNetByStationKind(...args),
+  resolveEffectiveTripToken: (backendTripToken: string | null, tripStart: number | null) =>
+    mockResolveEffectiveTripToken(backendTripToken, tripStart),
 }));
 
 const mockGetDismissSilence = jest.fn();

--- a/src/features/alarm/hooks/__tests__/useStationPrescheduler.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationPrescheduler.test.ts
@@ -1,0 +1,356 @@
+/**
+ * useStationPrescheduler (#918) — OS 사전 예약 "매역" 채널 owner hook 테스트.
+ *
+ * useSafetyNetScheduler와 대칭 정책(sleepMode/lock/currentHopIndex 게이트, cancel-only 전환,
+ * identity 기반 재등록 skip, in-flight 취소, 언마운트 시 cancel 없음)을 동일 패턴으로 검증한다.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useStationPrescheduler } from '../useStationPrescheduler';
+import { useSettingsStore } from '../../../settings/store/useSettingsStore';
+import type { Station } from '../../../../shared/types/station';
+import type { BoardingLock } from '../../../../shared/types/boardingLock';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+}));
+
+const mockRegisterPrescheduledStationAlarms = jest.fn();
+const mockCancelAllPrescheduledAlarms = jest.fn();
+jest.mock('../../utils/stationPrescheduler', () => ({
+  registerPrescheduledStationAlarms: (...args: unknown[]) =>
+    mockRegisterPrescheduledStationAlarms(...args),
+  cancelAllPrescheduledAlarms: (...args: unknown[]) => mockCancelAllPrescheduledAlarms(...args),
+}));
+
+jest.mock('../../utils/safetyNetScheduler', () => ({
+  deviceLocalTripId: (tripStart: number) => `local-${tripStart}`,
+}));
+
+const mockGetTripStartedAt = jest.fn();
+jest.mock('../../utils/tripStartStorage', () => ({
+  getTripStartedAt: (...args: unknown[]) => mockGetTripStartedAt(...args),
+}));
+
+const mockErrorSpy = jest.fn();
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: (...args: unknown[]) => mockErrorSpy(...args),
+  }),
+}));
+
+const mockAsyncGetItem = AsyncStorage.getItem as jest.Mock;
+
+const TRIP_TOKEN = 'BACKEND-TOKEN';
+const TRIP_START = 1_000_000;
+
+function makeStation(id: string, name: string, line: Station['line']): Station {
+  return { id, name, line, lineColor: '#000', lat: 0, lng: 0 } as Station;
+}
+
+const ARC: Station[] = [
+  makeStation('a', 'A역', '2'),
+  makeStation('b', 'B역', '2'),
+  makeStation('c', 'C역', '2'),
+];
+
+function makeLock(overrides: Partial<BoardingLock> = {}): BoardingLock {
+  return {
+    destinationId: 'c',
+    trainCode: 'TRAIN-1',
+    boardingStationId: 'a',
+    boardingLine: '2',
+    boardedAt: TRIP_START,
+    expectedDurationMs: 300_000,
+    ...overrides,
+  } as BoardingLock;
+}
+
+describe('useStationPrescheduler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useSettingsStore.setState({ sleepMode: false });
+    mockAsyncGetItem.mockResolvedValue(TRIP_TOKEN);
+    mockGetTripStartedAt.mockResolvedValue(TRIP_START);
+    mockRegisterPrescheduledStationAlarms.mockResolvedValue({ scheduled: 2 });
+    mockCancelAllPrescheduledAlarms.mockResolvedValue(undefined);
+  });
+
+  it('lock이 null이면(lockless) 등록하지 않는다', async () => {
+    renderHook(() =>
+      useStationPrescheduler({ arcStations: ARC, currentHopIndex: 0, lock: null }),
+    );
+    await waitFor(() => {
+      expect(mockRegisterPrescheduledStationAlarms).not.toHaveBeenCalled();
+    });
+    expect(mockCancelAllPrescheduledAlarms).not.toHaveBeenCalled();
+  });
+
+  it('sleepMode ON이면 등록하지 않는다(safetyNetScheduler 전담)', async () => {
+    useSettingsStore.setState({ sleepMode: true });
+    renderHook(() =>
+      useStationPrescheduler({ arcStations: ARC, currentHopIndex: 0, lock: makeLock() }),
+    );
+    await waitFor(() => {
+      expect(mockRegisterPrescheduledStationAlarms).not.toHaveBeenCalled();
+    });
+  });
+
+  it('currentHopIndex가 null이면 등록하지 않는다', async () => {
+    renderHook(() =>
+      useStationPrescheduler({ arcStations: ARC, currentHopIndex: null, lock: makeLock() }),
+    );
+    await waitFor(() => {
+      expect(mockRegisterPrescheduledStationAlarms).not.toHaveBeenCalled();
+    });
+  });
+
+  it('arcStations.length가 2 미만이면 등록하지 않는다', async () => {
+    renderHook(() =>
+      useStationPrescheduler({
+        arcStations: [ARC[0]],
+        currentHopIndex: 0,
+        lock: makeLock(),
+      }),
+    );
+    await waitFor(() => {
+      expect(mockRegisterPrescheduledStationAlarms).not.toHaveBeenCalled();
+    });
+  });
+
+  it('currentHopIndex가 arc 마지막 인덱스 이상이면 등록하지 않는다', async () => {
+    renderHook(() =>
+      useStationPrescheduler({
+        arcStations: ARC,
+        currentHopIndex: ARC.length - 1,
+        lock: makeLock(),
+      }),
+    );
+    await waitFor(() => {
+      expect(mockRegisterPrescheduledStationAlarms).not.toHaveBeenCalled();
+    });
+  });
+
+  it('게이트 off로 전환 시 이전 등록이 있으면 cancel-only 수행', async () => {
+    const { rerender } = renderHook(
+      ({ lock }: { lock: BoardingLock | null }) =>
+        useStationPrescheduler({ arcStations: ARC, currentHopIndex: 0, lock }),
+      { initialProps: { lock: makeLock() as BoardingLock | null } },
+    );
+    await waitFor(() => expect(mockRegisterPrescheduledStationAlarms).toHaveBeenCalledTimes(1));
+
+    rerender({ lock: null });
+
+    await waitFor(() => expect(mockCancelAllPrescheduledAlarms).toHaveBeenCalledWith(TRIP_TOKEN));
+  });
+
+  it('게이트 off 전환 시 이전 등록이 없으면 cancel을 호출하지 않는다', async () => {
+    renderHook(() => useStationPrescheduler({ arcStations: ARC, currentHopIndex: 0, lock: null }));
+    await waitFor(() => {
+      expect(mockRegisterPrescheduledStationAlarms).not.toHaveBeenCalled();
+    });
+    expect(mockCancelAllPrescheduledAlarms).not.toHaveBeenCalled();
+  });
+
+  it('tripStart가 없으면 이번 cycle을 skip하고 직전 등록을 유지한다', async () => {
+    mockGetTripStartedAt.mockResolvedValue(null);
+    renderHook(() => useStationPrescheduler({ arcStations: ARC, currentHopIndex: 0, lock: makeLock() }));
+    await waitFor(() => {
+      expect(mockGetTripStartedAt).toHaveBeenCalled();
+    });
+    expect(mockRegisterPrescheduledStationAlarms).not.toHaveBeenCalled();
+  });
+
+  it('backend tripToken이 없으면 deviceLocalTripId로 대체한다', async () => {
+    mockAsyncGetItem.mockResolvedValue(null);
+    renderHook(() => useStationPrescheduler({ arcStations: ARC, currentHopIndex: 0, lock: makeLock() }));
+    await waitFor(() => {
+      expect(mockRegisterPrescheduledStationAlarms).toHaveBeenCalledWith(
+        expect.objectContaining({ tripToken: `local-${TRIP_START}` }),
+      );
+    });
+  });
+
+  it('lock 활성 + sleepMode OFF + 유효 hopIndex면 backend tripToken으로 등록한다', async () => {
+    renderHook(() => useStationPrescheduler({ arcStations: ARC, currentHopIndex: 0, lock: makeLock() }));
+    await waitFor(() => {
+      expect(mockRegisterPrescheduledStationAlarms).toHaveBeenCalledWith({
+        tripToken: TRIP_TOKEN,
+        arcStations: ARC,
+        currentIdx: 0,
+      });
+    });
+  });
+
+  it('같은 tripToken+hopIndex+arcLen identity면 재등록하지 않는다', async () => {
+    const { rerender } = renderHook(
+      ({ currentHopIndex }: { currentHopIndex: number }) =>
+        useStationPrescheduler({ arcStations: ARC, currentHopIndex, lock: makeLock() }),
+      { initialProps: { currentHopIndex: 0 } },
+    );
+    await waitFor(() => expect(mockRegisterPrescheduledStationAlarms).toHaveBeenCalledTimes(1));
+
+    rerender({ currentHopIndex: 0 });
+    await waitFor(() => {
+      // identity 불변이므로 추가 호출 없음(effect는 재실행되지만 registeredIdentityRef가 동일해 조기 반환).
+      expect(mockRegisterPrescheduledStationAlarms).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('currentHopIndex가 바뀌면 이전 예약을 cancel한 뒤 새 앵커로 재등록한다', async () => {
+    const { rerender } = renderHook(
+      ({ currentHopIndex }: { currentHopIndex: number }) =>
+        useStationPrescheduler({ arcStations: ARC, currentHopIndex, lock: makeLock() }),
+      { initialProps: { currentHopIndex: 0 } },
+    );
+    await waitFor(() => expect(mockRegisterPrescheduledStationAlarms).toHaveBeenCalledTimes(1));
+
+    rerender({ currentHopIndex: 1 });
+
+    await waitFor(() => expect(mockCancelAllPrescheduledAlarms).toHaveBeenCalledWith(TRIP_TOKEN));
+    await waitFor(() => expect(mockRegisterPrescheduledStationAlarms).toHaveBeenCalledTimes(2));
+    expect(mockRegisterPrescheduledStationAlarms).toHaveBeenLastCalledWith({
+      tripToken: TRIP_TOKEN,
+      arcStations: ARC,
+      currentIdx: 1,
+    });
+  });
+
+  it('effect 재실행 중 이전 in-flight 호출 결과는 최신 토큰과 다르면 상태를 갱신하지 않는다', async () => {
+    let resolveFirst!: (value: { scheduled: number }) => void;
+    mockRegisterPrescheduledStationAlarms
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({ scheduled: 1 });
+
+    const { rerender } = renderHook(
+      ({ currentHopIndex }: { currentHopIndex: number }) =>
+        useStationPrescheduler({ arcStations: ARC, currentHopIndex, lock: makeLock() }),
+      { initialProps: { currentHopIndex: 0 } },
+    );
+    // 첫 effect가 register 호출까지 도달(in-flight 상태로 멈춤)한 것을 확인한 뒤에 currentHopIndex를
+    // 바꿔야 두 번째 effect가 "직전 등록 존재"로 판정해 cancel + 재등록 경로를 탄다. 이 대기 없이
+    // 바로 rerender하면 첫 effect의 Promise.all이 아직 안 끝나 myToken 검사에서 조기 return되어
+    // register 자체가 호출되지 않는다.
+    await waitFor(() => expect(mockRegisterPrescheduledStationAlarms).toHaveBeenCalledTimes(1));
+
+    // 첫 effect가 in-flight인 상태에서 currentHopIndex를 바꿔 두 번째 effect를 트리거.
+    rerender({ currentHopIndex: 1 });
+    await waitFor(() => expect(mockRegisterPrescheduledStationAlarms).toHaveBeenCalledTimes(2));
+
+    // 첫 호출(stale)을 뒤늦게 resolve — inFlightTokenRef 불일치로 무시되어야 한다.
+    act(() => {
+      resolveFirst({ scheduled: 999 });
+    });
+
+    await waitFor(() => {
+      expect(mockErrorSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it('Promise.all(tripToken/tripStart 조회) 완료 시점에 이미 stale해졌으면 조기 return한다', async () => {
+    let resolveTripStart!: (value: number) => void;
+    mockGetTripStartedAt.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveTripStart = resolve;
+        }),
+    );
+
+    const { rerender } = renderHook(
+      ({ currentHopIndex }: { currentHopIndex: number }) =>
+        useStationPrescheduler({ arcStations: ARC, currentHopIndex, lock: makeLock() }),
+      { initialProps: { currentHopIndex: 0 } },
+    );
+
+    // 첫 effect가 tripStart 조회(Promise.all)에서 멈춘 상태 그대로 두 번째 effect를 트리거.
+    rerender({ currentHopIndex: 1 });
+    await waitFor(() => expect(mockRegisterPrescheduledStationAlarms).toHaveBeenCalledTimes(1));
+
+    // 첫 effect(stale)의 tripStart 조회를 뒤늦게 resolve — line84 조기 return으로 nextIdentity
+    // 계산/cancel/register 어느 것도 다시 실행되지 않아야 한다(호출 수 그대로 1).
+    act(() => {
+      resolveTripStart(TRIP_START);
+    });
+
+    await waitFor(() => {
+      expect(mockRegisterPrescheduledStationAlarms).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('cancelAllPrescheduledAlarms 완료 시점에 이미 stale해졌으면 register를 호출하지 않는다', async () => {
+    // arcLen=4(마지막 인덱스 3)라야 hopIndex 0/1/2 모두 유효한 currentHopIndex다 — ARC(길이 3)를
+    // 쓰면 hopIndex=2가 arc 끝(gatedOff)이 되어 이 테스트가 검증하려는 경로(정상 재등록)를 못 탄다.
+    const LONG_ARC: Station[] = [
+      ...ARC,
+      makeStation('d', 'D역', '2'),
+    ];
+    let resolveStaleCancel!: () => void;
+    mockCancelAllPrescheduledAlarms
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveStaleCancel = resolve;
+          }),
+      )
+      .mockResolvedValue(undefined);
+
+    const { rerender } = renderHook(
+      ({ currentHopIndex }: { currentHopIndex: number }) =>
+        useStationPrescheduler({ arcStations: LONG_ARC, currentHopIndex, lock: makeLock() }),
+      { initialProps: { currentHopIndex: 0 } },
+    );
+    // 최초 등록 완료 — registeredIdentityRef가 채워져야 다음 변경이 cancel 경로를 탄다.
+    await waitFor(() => expect(mockRegisterPrescheduledStationAlarms).toHaveBeenCalledTimes(1));
+
+    // hopIndex 1로 변경 — nextIdentity가 달라져 cancelAllPrescheduledAlarms 호출(pending으로 멈춤).
+    rerender({ currentHopIndex: 1 });
+    await waitFor(() => expect(mockCancelAllPrescheduledAlarms).toHaveBeenCalledTimes(1));
+
+    // 그 cancel이 끝나기 전에 hopIndex 2로 다시 변경 — 새 effect가 myToken을 선점하고 정상 완주.
+    rerender({ currentHopIndex: 2 });
+    await waitFor(() => expect(mockRegisterPrescheduledStationAlarms).toHaveBeenCalledTimes(2));
+
+    // stale(hopIndex 1) cancel을 뒤늦게 resolve — line98 조기 return으로 register가 추가 호출되지
+    // 않아야 한다(호출 수 그대로 2).
+    act(() => {
+      resolveStaleCancel();
+    });
+
+    await waitFor(() => {
+      expect(mockRegisterPrescheduledStationAlarms).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('예외 발생 시 logger.error로 catch되어 전파되지 않는다', async () => {
+    mockRegisterPrescheduledStationAlarms.mockRejectedValueOnce(new Error('schedule fail'));
+    renderHook(() => useStationPrescheduler({ arcStations: ARC, currentHopIndex: 0, lock: makeLock() }));
+    await waitFor(() => {
+      expect(mockErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('stationPrescheduler 전환 실패'),
+        expect.any(Error),
+      );
+    });
+  });
+
+  it('sleepMode 토글이 dependency에 포함되어 즉시 재실행된다', async () => {
+    const { rerender } = renderHook(
+      () => useStationPrescheduler({ arcStations: ARC, currentHopIndex: 0, lock: makeLock() }),
+    );
+    await waitFor(() => expect(mockRegisterPrescheduledStationAlarms).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      useSettingsStore.setState({ sleepMode: true });
+    });
+    rerender({});
+
+    await waitFor(() => expect(mockCancelAllPrescheduledAlarms).toHaveBeenCalledWith(TRIP_TOKEN));
+  });
+});

--- a/src/features/alarm/hooks/useStationPrescheduler.ts
+++ b/src/features/alarm/hooks/useStationPrescheduler.ts
@@ -1,0 +1,119 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: 이 hook은 destination/route(route feature) + boardingLock/
+ * stationPrescheduler(alarm feature) + settings(sleepMode)를 묶는 단일 owner orchestrator다.
+ * useSafetyNetScheduler와 동일한 옵트인 패턴(file-level disable).
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+import { useEffect, useRef } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { Station } from '../../../shared/types/station';
+import type { BoardingLock } from '../../../shared/types/boardingLock';
+import { ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
+import {
+  cancelAllPrescheduledAlarms,
+  registerPrescheduledStationAlarms,
+} from '../utils/stationPrescheduler';
+import { deviceLocalTripId } from '../utils/safetyNetScheduler';
+import { getTripStartedAt } from '../utils/tripStartStorage';
+import { useSettingsStore } from '../../settings/store/useSettingsStore';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('useStationPrescheduler');
+
+export interface UseStationPrescheduerInputs {
+  /** boarding → destination 순서의 ordered station 시퀀스. */
+  arcStations: readonly Station[];
+  /** arcStations 내 현재 위치 인덱스 — 실시간 lock trainCode 판정 결과(#918 evolve 2항). */
+  currentHopIndex: number | null;
+  /** 활성 BoardingLock. null(lockless)이면 사전예약 자체를 등록하지 않는다(#918 evolve 1항). */
+  lock: BoardingLock | null;
+}
+
+/**
+ * #918 — "OS-level 사전 예약 매역 일반화" 단일 owner. `stationPrescheduler`를 호출해
+ * boardingLock 활성 + sleepMode OFF인 trip에 한해 경로 위 모든 역에 앞 12역 rolling window로
+ * 예약/재충전한다.
+ *
+ * 정책 (`useSafetyNetScheduler`와 대칭 — 두 채널은 sleepMode로 상호 배타):
+ * - sleepMode ON이면 항상 cancel-only(등록 없음) — 취침모드는 safetyNetScheduler 전담(#918
+ *   evolve 7항). sleepMode 토글 즉시 반영되도록 effect dependency에 포함한다.
+ * - lock이 null(lockless trip)이면 cancel-only — 명시 의향 없는 trip은 발사 채널 침묵
+ *   paradigm 유지(#918 evolve 1항, 자동 lock 의존 삭제).
+ * - `currentHopIndex`가 바뀔 때마다(=열차가 다음 역으로 진행할 때마다) 이전 예약을 전량
+ *   cancel한 뒤 그 시점의 실시간 위치를 새 앵커로 앞 12역을 다시 예약한다 — 이것이 "rolling
+ *   window 재충전"이다(#918 evolve 6항). silent push 수신으로 currentHopIndex가 갱신되는
+ *   모든 경로(BG wake 후 FG 복귀, arrival API 재조회 등)가 자동으로 재충전을 트리거한다.
+ * - 언마운트 시에는 cancel하지 않는다 — trip 종료는 `tripBoundCleanups`(cancelTripBoundOsQueue)가
+ *   전담한다(safetyNetScheduler와 동일 소유 경계).
+ */
+export function useStationPrescheduler({
+  arcStations,
+  currentHopIndex,
+  lock,
+}: UseStationPrescheduerInputs): void {
+  const sleepMode = useSettingsStore((s) => s.sleepMode);
+  const registeredIdentityRef = useRef<string | null>(null);
+  const registeredTripTokenRef = useRef<string | null>(null);
+  const inFlightTokenRef = useRef(0);
+
+  useEffect(() => {
+    const myToken = ++inFlightTokenRef.current;
+
+    const run = async (): Promise<void> => {
+      const gatedOff =
+        sleepMode ||
+        lock === null ||
+        currentHopIndex === null ||
+        arcStations.length < 2 ||
+        currentHopIndex >= arcStations.length - 1;
+
+      if (gatedOff) {
+        if (registeredIdentityRef.current !== null && registeredTripTokenRef.current) {
+          await cancelAllPrescheduledAlarms(registeredTripTokenRef.current);
+        }
+        if (myToken !== inFlightTokenRef.current) return;
+        registeredIdentityRef.current = null;
+        registeredTripTokenRef.current = null;
+        return;
+      }
+
+      const [backendTripToken, tripStart] = await Promise.all([
+        AsyncStorage.getItem(ACTIVE_TRIP_KEY),
+        getTripStartedAt(),
+      ]);
+      if (myToken !== inFlightTokenRef.current) return;
+
+      if (tripStart === null) {
+        // trip 시작 시각 자체가 없음 — 이번 cycle skip. 직전 등록은 그대로 유지.
+        return;
+      }
+      const tripToken = backendTripToken ?? deviceLocalTripId(tripStart);
+
+      const nextIdentity = `${tripToken}|idx:${currentHopIndex}|arcLen:${arcStations.length}`;
+      if (registeredIdentityRef.current === nextIdentity) return;
+
+      if (registeredIdentityRef.current !== null && registeredTripTokenRef.current) {
+        await cancelAllPrescheduledAlarms(registeredTripTokenRef.current);
+      }
+      if (myToken !== inFlightTokenRef.current) return;
+
+      const result = await registerPrescheduledStationAlarms({
+        tripToken,
+        arcStations,
+        currentIdx: currentHopIndex,
+      });
+      if (myToken !== inFlightTokenRef.current) return;
+      registeredIdentityRef.current = nextIdentity;
+      registeredTripTokenRef.current = tripToken;
+      logger.info(
+        `registered ${result.scheduled} prescheduled station alarms tripToken=${tripToken.slice(0, 8)}`,
+      );
+    };
+
+    run().catch((e: unknown) => {
+      logger.error('stationPrescheduler 전환 실패:', e);
+    });
+    // arcStations는 useFusedNearestStation의 useMemo 산출물 — 내용이 같으면 참조도 안정적으로
+    // 유지된다(safetyNetScheduler의 route 객체와 동일 신뢰 전제).
+  }, [arcStations, currentHopIndex, lock, sleepMode]);
+}

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -33,6 +33,7 @@ import { clearLaDismissSentinel } from '../utils/laDismissSentinel';
 import { clearLastSilentPushReceivedAt } from '../utils/lastSilentPushReceivedAt';
 import { clearPrescheduledLedger } from '../utils/prescheduledMetrics';
 import { cancelAllSafetyNetAlarms, resolveEffectiveTripToken } from '../utils/safetyNetScheduler';
+import { cancelAllPrescheduledAlarms } from '../utils/stationPrescheduler';
 import { getTripStartedAt } from '../utils/tripStartStorage';
 import { clearTripCorrId } from '../../observability/utils/tripCorrId';
 import { clearBackendSsotMirror } from '../utils/backendSsotMirror';
@@ -242,8 +243,15 @@ export function runTripBoundCleanups(): Promise<void> {
     // 동안 expo-notifications 내부 큐 race로 일부 사전 예약이 살아남는 사례를 1분 후 두번째
     // cancel pass로 정리. 새 trip이 시작되면 tripStart 가드가 skip한다.
     scheduleDefensiveCancel(tripToken);
+    // #918 — stationPrescheduler(OS 사전예약 "매역" 채널)도 safetyNetScheduler와 동일하게
+    // tripToken-scoped cancel 대상. 두 채널은 sleepMode로 상호 배타적이라 항상 한쪽만
+    // 실제로 pending을 갖지만, 나머지 한쪽 cancel은 큐가 비어있어도 안전(멱등)하므로 항상 같이 호출.
     const cleanups = tripToken
-      ? [...TRIP_BOUND_CLEANUPS, () => cancelAllSafetyNetAlarms(tripToken)]
+      ? [
+          ...TRIP_BOUND_CLEANUPS,
+          () => cancelAllSafetyNetAlarms(tripToken),
+          () => cancelAllPrescheduledAlarms(tripToken),
+        ]
       : TRIP_BOUND_CLEANUPS;
     return Promise.allSettled(cleanups.map((cleanup) => cleanup())).then(noop);
   });
@@ -275,9 +283,15 @@ export function cancelTripBoundOsQueue(): Promise<void> {
     const tripToken = resolveEffectiveTripToken(backendTripToken, tripStart);
     scheduleDefensiveCancel(tripToken);
     if (!tripToken) return undefined;
-    return cancelAllSafetyNetAlarms(tripToken).catch((e: unknown) => {
-      log.warn('cancelTripBoundOsQueue: safety-net cancel 실패', e);
-    });
+    // #918 — stationPrescheduler(OS 사전예약 "매역" 채널)도 같은 tripToken-scoped cancel 대상.
+    return Promise.all([
+      cancelAllSafetyNetAlarms(tripToken).catch((e: unknown) => {
+        log.warn('cancelTripBoundOsQueue: safety-net cancel 실패', e);
+      }),
+      cancelAllPrescheduledAlarms(tripToken).catch((e: unknown) => {
+        log.warn('cancelTripBoundOsQueue: prescheduled cancel 실패', e);
+      }),
+    ]).then(noop);
   });
 }
 
@@ -318,6 +332,10 @@ async function runDefensiveCancel(tripToken: string | null): Promise<void> {
   log.info('defensive cancel: running second cancel pass (#1525)');
   await cancelAllSafetyNetAlarms(tripToken).catch((e) => {
     log.warn('defensive cancel 실패:', e);
+  });
+  // #918 — prescheduled(매역) 채널도 동일 backstop 대상.
+  await cancelAllPrescheduledAlarms(tripToken).catch((e) => {
+    log.warn('defensive cancel (prescheduled) 실패:', e);
   });
 }
 

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -194,9 +194,44 @@ jest.mock('react-native', () => ({
 // reschedule 분기: rescheduleSafetyNetAlarm 1회. companion 발사 후 cleanup: cancelSafetyNetByStationKind 1회.
 const mockRescheduleSafetyNetAlarm = jest.fn();
 const mockCancelSafetyNetByStationKind = jest.fn().mockResolvedValue(undefined);
+// #918 — resolveEffectiveTripToken은 applyReschedule의 presched 분기(sleepMode OFF)에서
+// backendTripToken/tripStart로부터 effective tripToken을 도출하는 데 쓰인다. safetyNetScheduler와
+// 동일한 실제 동작(backend 우선, 없으면 device-local id)을 mock에서도 재현해 케이스 분기가 실제
+// 모듈처럼 동작하게 한다.
+const mockResolveEffectiveTripToken = jest.fn(
+  (backendTripToken: string | null, tripStart: number | null) =>
+    backendTripToken ?? (tripStart !== null ? `local-${tripStart}` : null),
+);
 jest.mock('../../utils/safetyNetScheduler', () => ({
   rescheduleSafetyNetAlarm: (...args: unknown[]) => mockRescheduleSafetyNetAlarm(...args),
   cancelSafetyNetByStationKind: (...args: unknown[]) => mockCancelSafetyNetByStationKind(...args),
+  resolveEffectiveTripToken: (backendTripToken: string | null, tripStart: number | null) =>
+    mockResolveEffectiveTripToken(backendTripToken, tripStart),
+}));
+
+// #918 — stationPrescheduler(OS 사전예약 "매역" 채널)도 safetyNetScheduler와 동일하게 mock —
+// 실제 모듈이 stationNotification.ts(→ live-activity 네이티브 모듈)를 import해 이 테스트 파일의
+// jest-expo 환경에서 로드 실패를 유발하므로 반드시 mock 필요.
+const mockCancelPrescheduledByStationKind = jest.fn().mockResolvedValue(undefined);
+const mockReschedulePrescheduledAlarm = jest.fn().mockResolvedValue({ cancelled: 0, scheduled: 0 });
+jest.mock('../../utils/stationPrescheduler', () => ({
+  cancelPrescheduledByStationKind: (...args: unknown[]) => mockCancelPrescheduledByStationKind(...args),
+  reschedulePrescheduledAlarm: (...args: unknown[]) => mockReschedulePrescheduledAlarm(...args),
+}));
+
+// #918 — markLocalStationFired(recentLocalStationFires)도 mock. 실제 모듈은 AsyncStorage에
+// 직접 접근하는데, 본 테스트 파일의 AsyncStorage mock(위 라인 29)은 다른 계약이라 충돌 방지.
+const mockMarkLocalStationFired = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../utils/recentLocalStationFires', () => ({
+  markLocalStationFired: (...args: unknown[]) => mockMarkLocalStationFired(...args),
+}));
+
+// #918 — silentPushTask.ts가 mapBackendKindToLocalFireKind만 stationNotification.ts에서 가져온다.
+// 실제 모듈 전체를 로드하면 live-activity 네이티브 모듈 체인까지 끌려온다 — 매핑 함수만 실제
+// 구현과 동일한 순수 로직으로 재현.
+jest.mock('../../utils/stationNotification', () => ({
+  mapBackendKindToLocalFireKind: (backendKind: string) =>
+    ({ intermediate: 'station-passed', transfer: 'transfer', destination: 'destination' })[backendKind] ?? null,
 }));
 
 const mockAddDomainBreadcrumb = jest.fn();
@@ -1579,6 +1614,33 @@ describe('silentPushTask', () => {
         expect(mockSendPushAck).toHaveBeenCalledWith(
           ackCall('p-legacy', 'skipped', 'legacy-station-kind-ignored'),
         );
+      });
+
+      // #918 — BG wake 시점에 presched(OS 사전예약) pending cancel + markLocalStationFired를
+      // 호출한다. 매핑되는 kind(transfer/destination/intermediate→station-passed)에서 정상 호출됨을
+      // 확인하고, 두 호출이 각각 reject해도(예: OS query 실패) 나머지 처리 흐름이 중단되지 않음을 검증한다.
+      it('kind=intermediate → cancelPrescheduledByStationKind + markLocalStationFired(station-passed)로 호출', async () => {
+        await handleSilentPush(
+          payload({ kind: 'intermediate', phase: 'imminent', nextWaypoint: '건대입구' }),
+        );
+        expect(mockCancelPrescheduledByStationKind).toHaveBeenCalledWith('건대입구', 'station-passed');
+        expect(mockMarkLocalStationFired).toHaveBeenCalledWith('건대입구', 'station-passed');
+      });
+
+      it('cancelPrescheduledByStationKind reject해도 흐름 계속 (logger.warn으로 흡수)', async () => {
+        mockCancelPrescheduledByStationKind.mockRejectedValueOnce(new Error('os query fail'));
+        await expect(
+          handleSilentPush(payload({ kind: 'transfer', phase: 'imminent', nextWaypoint: '왕십리' })),
+        ).resolves.toBeUndefined();
+        expect(mockMarkLocalStationFired).toHaveBeenCalledWith('왕십리', 'transfer');
+      });
+
+      it('markLocalStationFired reject해도 흐름 계속 (logger.warn으로 흡수)', async () => {
+        mockMarkLocalStationFired.mockRejectedValueOnce(new Error('storage fail'));
+        await expect(
+          handleSilentPush(payload({ kind: 'destination', phase: 'imminent', nextWaypoint: '잠실' })),
+        ).resolves.toBeUndefined();
+        expect(mockCancelPrescheduledByStationKind).toHaveBeenCalledWith('잠실', 'destination');
       });
 
       it('logSilentPushReceived는 no-op 이전에 그대로 적재 (수신 자체는 유지)', async () => {

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -66,7 +66,15 @@ import { addFiredPushId } from '../utils/firedPushIds';
 import {
   rescheduleSafetyNetAlarm,
   cancelSafetyNetByStationKind,
+  resolveEffectiveTripToken,
 } from '../utils/safetyNetScheduler';
+import { getTripStartedAt } from '../utils/tripStartStorage';
+import {
+  cancelPrescheduledByStationKind,
+  reschedulePrescheduledAlarm,
+} from '../utils/stationPrescheduler';
+import { mapBackendKindToLocalFireKind } from '../utils/stationNotification';
+import { markLocalStationFired } from '../utils/recentLocalStationFires';
 import { ROUTE_KEY } from '../../../shared/constants/storageKeys';
 import type { Route } from '../../../shared/utils/stationRoute';
 import { refreshLiveActivityFromBackgroundContext } from '../utils/refreshLiveActivityFromBackgroundContext';
@@ -1097,6 +1105,26 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
       return;
     }
 
+    // #918 — BG wake = backend visible push 도착 시점("결정 evolve" 2026-08-03 2차 2항 BG 방향).
+    // 이 station의 presched(OS 사전예약) pending을 즉시 취소 + 이미 OS가 발사했다면 delivered
+    // tray에서도 제거 + recentLocalStationFires에 마킹 — FG willPresent 2차 방어선(#2122)이
+    // 뒤늦게 도착하는(사실상 이미 도착한) presched 발사를 억제하도록 갱신한다. 3-소스 중 하나가
+    // 먼저 도달하면 나머지 둘의 흔적을 정리하는 대칭 동작(FG 방향은 scheduledAlarmReceiver).
+    const localKind = mapBackendKindToLocalFireKind(payload.kind);
+    // istanbul ignore next -- 이 지점에 도달하는 payload.kind는 이미 위에서 reschedule/trip-ended/
+    // boarding-prompt/sleep-alarm-companion/missing-kind 분기로 전부 걸러진 뒤라
+    // 'transfer'|'destination'|'intermediate' 3종뿐이고, mapBackendKindToLocalFireKind는 이 3종을
+    // 전부 non-null로 매핑한다(stationNotification.ts BACKEND_PUSH_KIND_TO_LOCAL_FIRE_KIND) — else
+    // 분기는 두 소스가 서로 어긋나는 회귀가 생기기 전까지는 도달 불가능한 방어 코드.
+    if (localKind === 'transfer' || localKind === 'destination' || localKind === 'station-passed') {
+      await cancelPrescheduledByStationKind(payload.nextWaypoint, localKind).catch((e: unknown) => {
+        logger.warn('presched cancel-on-remote-arrival 실패:', e);
+      });
+      await markLocalStationFired(payload.nextWaypoint, localKind).catch((e: unknown) => {
+        logger.warn('markLocalStationFired 실패:', e);
+      });
+    }
+
     // #2064 (Phase 1-device) — 매역 알림 backend visible push 전환. transfer/destination/
     // intermediate kind는 더 이상 device가 로컬 알림을 발사하지 않는다(이중 발사 제거).
     // 수신 자체는 유지(위 logSilentPushReceived + finally의 LA/widget refresh)해 상태 sync는
@@ -1157,17 +1185,20 @@ async function refreshWidgetForPayload(payload: ExtractedPayload): Promise<void>
 
 /**
  * reschedule silent push(#698) 적용 — 백엔드가 보낸 nextStation/newArrivalTimeEpoch로
- * 안전망(safetyNetScheduler) 사전 예약을 cancel + 재예약한다. 본 함수는 SLA 게이트가 아니라
+ * 사전 예약(안전망 또는 presched)을 cancel + 재예약한다. 본 함수는 SLA 게이트가 아니라
  * 정정 신호이므로 결과 무관 ack(`reschedule-received`)는 호출자가 처리한다.
  *
  * #2089 — 3종 채널(bl/tba) 통합 이후 단일 안전망 채널만 정정한다. lock 상태와 무관
  * (tripToken 기반 lockless) — 옛 `applyRescheduleBl`의 trainCode/lock 매칭은 더 이상 필요 없다.
  *
- * **#2089 리뷰 P1-1** — safetyNetScheduler는 sleepMode ON인 trip에만 등록되므로(정책 gate는
- * 본 함수 책임 — `useSafetyNetScheduler`와 동일 원칙), reschedule도 sleepMode ON일 때만
- * 적용한다. sleepMode가 꺼져 있으면 애초에 안전망이 armed 상태가 아니므로 적용 자체가 무의미
- * (`rescheduleSafetyNetAlarm`의 "기존 매칭 없으면 cancel-only" 가드가 이중 방어하지만, 정책
- * 게이트는 여기서 명시적으로 걸어야 호출 자체가 배경 OS 조회를 낭비하지 않는다).
+ * **#918** — sleepMode가 두 예약 채널의 상호 배타 게이트이므로, 본 함수도 sleepMode로 분기한다:
+ *   - sleepMode ON → safetyNetScheduler 정정(route/destination/backend tripToken 필요).
+ *   - sleepMode OFF → stationPrescheduler 정정. presched는 backend 등록 여부와 무관하게
+ *     device-local id로도 armed되므로(`resolveEffectiveTripToken`) route 재조회 없이
+ *     station+occurrence 매칭만으로 정정한다.
+ * 이전(#2089 P1-1)에는 safetyNetScheduler만 있어 `!sleepMode`가 곧 no-op이었지만, 이제는
+ * `!sleepMode`가 presched 경로로 이어진다(safetyNetScheduler가 armed 상태가 아니라는 의미는
+ * 동일 — `rescheduleSafetyNetAlarm`의 "기존 매칭 없으면 cancel-only" 가드도 그대로 유지).
  *
  * 사전 조건 누락(`route`/`destination`/`tripToken` 중 하나라도 없음, 또는 newArrivalTimeEpoch
  * 과거)은 모두 graceful no-op — 신호가 도달했어도 SLA를 깨지 않는다(원본 사전 예약 유지).
@@ -1184,26 +1215,42 @@ async function applyReschedule(
       );
       return;
     }
-    const [sleepMode, routeRaw, destRaw, tripToken] = await Promise.all([
+    const [sleepMode, routeRaw, destRaw, backendTripToken, tripStart] = await Promise.all([
       readSleepMode(),
       AsyncStorage.getItem(ROUTE_KEY),
       AsyncStorage.getItem(DESTINATION_KEY),
       AsyncStorage.getItem(ACTIVE_TRIP_KEY),
+      getTripStartedAt(),
     ]);
+
+    // #918 — sleepMode OFF는 stationPrescheduler(매역) 전담. 두 채널은 sleepMode로 상호
+    // 배타이므로 여기서 분기한다 — safetyNetScheduler와 동일하게 "이미 armed된 예약이 없으면
+    // cancel-only" 가드가 이중 방어(reschedulePrescheduledAlarm 내부).
     if (!sleepMode) {
-      logger.info('reschedule skip: sleepMode off');
+      const tripToken = resolveEffectiveTripToken(backendTripToken, tripStart);
+      if (!tripToken) {
+        logger.info('reschedule skip: no active trip (presched)');
+        return;
+      }
+      await reschedulePrescheduledAlarm({
+        tripToken,
+        stationName: payload.nextStation,
+        newArrivalMs: payload.newArrivalTimeEpoch,
+        occurrenceIdx: payload.occurrenceIdx,
+        now: receivedAt,
+      });
       return;
     }
     const route = parseRoute(routeRaw);
     const destinationName = parseDestinationName(destRaw);
-    if (!route || !destinationName || !tripToken) {
+    if (!route || !destinationName || !backendTripToken) {
       logger.info(
-        `reschedule skip: route=${route ? 'ok' : 'null'} destination=${destinationName ?? 'null'} tripToken=${tripToken ? 'ok' : 'null'}`,
+        `reschedule skip: route=${route ? 'ok' : 'null'} destination=${destinationName ?? 'null'} tripToken=${backendTripToken ? 'ok' : 'null'}`,
       );
       return;
     }
     await rescheduleSafetyNetAlarm({
-      tripToken,
+      tripToken: backendTripToken,
       route,
       destinationName,
       stationName: payload.nextStation,

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -68,6 +68,8 @@ import {
   logSuppressedLocklessNoUserIntent,
   logSuppressedSsotFireGate,
   logSuppressedSafetyNetRevalidation,
+  logScheduledPrescheduledAlarm,
+  logSuppressedPrescheduledRevalidation,
   summarizeAlarmLogBySource,
   countGateReasons,
   countSilentPushKindBreakdown,
@@ -868,6 +870,40 @@ describe('alarmLog', () => {
           reason,
           stationName,
           phaseId,
+        });
+      },
+    );
+
+    it.each([
+      ['transfer' as const, '건대입구'],
+      ['destination' as const, '잠실'],
+      ['station-passed' as const, '군자'],
+    ])(
+      '#918 logScheduledPrescheduledAlarm: kind=%s — source=bg-scheduled, outcome=fired 고정',
+      async (kind, stationName) => {
+        logScheduledPrescheduledAlarm({ stationName, kind });
+        await expectLastSavedEntryMatches({
+          source: 'bg-scheduled',
+          outcome: 'fired',
+          stationName,
+          kind,
+        });
+      },
+    );
+
+    it.each([
+      ['revalidate-no-trip' as const, '강남'],
+      ['revalidate-trip-token-mismatch' as const, '시청'],
+      ['revalidate-sleep-mode-on' as const, '서울역'],
+    ])(
+      '#918 logSuppressedPrescheduledRevalidation: %s — source=bg-scheduled, outcome=suppressed',
+      async (reason, stationName) => {
+        logSuppressedPrescheduledRevalidation({ reason, stationName });
+        await expectLastSavedEntryMatches({
+          source: 'bg-scheduled',
+          outcome: 'suppressed',
+          reason,
+          stationName,
         });
       },
     );

--- a/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
+++ b/src/features/alarm/utils/__tests__/scheduledAlarmReceiver.test.ts
@@ -38,15 +38,44 @@ jest.mock('../tripStartStorage', () => ({
 // 반환값을 제어 — waypoint mismatch 게이트를 결정적으로 테스트하기 위함.
 const mockDeriveSafetyNetWaypoints = jest.fn();
 const mockReadSafetyNetData = jest.fn();
+const mockResolveEffectiveTripToken = jest.fn();
 jest.mock('../safetyNetScheduler', () => ({
   deriveSafetyNetWaypoints: (...args: unknown[]) => mockDeriveSafetyNetWaypoints(...args),
   readSafetyNetData: (...args: unknown[]) => mockReadSafetyNetData(...args),
+  resolveEffectiveTripToken: (...args: unknown[]) => mockResolveEffectiveTripToken(...args),
 }));
 
 const mockLogSuppressedSafetyNetRevalidation = jest.fn();
+const mockLogSuppressedPrescheduledRevalidation = jest.fn();
 jest.mock('../alarmLog', () => ({
   logSuppressedSafetyNetRevalidation: (...args: unknown[]) =>
     mockLogSuppressedSafetyNetRevalidation(...args),
+  logSuppressedPrescheduledRevalidation: (...args: unknown[]) =>
+    mockLogSuppressedPrescheduledRevalidation(...args),
+}));
+
+// #918 — stationPrescheduler(OS 사전예약 "매역" 채널) mock. readPrescheduledData는
+// readSafetyNetData와 동일하게 테스트가 직접 반환값을 제어(content.data를 그대로 통과).
+const mockReadPrescheduledData = jest.fn();
+const mockCancelPrescheduledByStationKind = jest.fn();
+jest.mock('../stationPrescheduler', () => ({
+  readPrescheduledData: (...args: unknown[]) => mockReadPrescheduledData(...args),
+  cancelPrescheduledByStationKind: (...args: unknown[]) => mockCancelPrescheduledByStationKind(...args),
+}));
+
+const mockReadSleepMode = jest.fn();
+jest.mock('../alarmLocalAuthority', () => ({
+  readSleepMode: (...args: unknown[]) => mockReadSleepMode(...args),
+}));
+
+const mockMapBackendKindToLocalFireKind = jest.fn();
+jest.mock('../stationNotification', () => ({
+  mapBackendKindToLocalFireKind: (...args: unknown[]) => mockMapBackendKindToLocalFireKind(...args),
+}));
+
+const mockMarkLocalStationFired = jest.fn();
+jest.mock('../recentLocalStationFires', () => ({
+  markLocalStationFired: (...args: unknown[]) => mockMarkLocalStationFired(...args),
 }));
 
 // #1704 — position-mismatch 게이트가 backend SSoT mirror를 read해 사용자 currentStation을 결정.
@@ -151,6 +180,24 @@ beforeEach(async () => {
       (req.content.data as unknown as SafetyNetNotificationData | undefined) ?? null,
   );
   mockLogSuppressedSafetyNetRevalidation.mockReset();
+  // #918 — presched 채널 기본값: readPrescheduledData는 null(safety-net도 아니고 presched도
+  // 아닌 request는 원격 도착 판정 분기로 흐름) — 개별 테스트가 override.
+  mockLogSuppressedPrescheduledRevalidation.mockReset();
+  mockReadPrescheduledData.mockReset();
+  mockReadPrescheduledData.mockReturnValue(null);
+  mockCancelPrescheduledByStationKind.mockReset();
+  mockCancelPrescheduledByStationKind.mockResolvedValue(undefined);
+  mockResolveEffectiveTripToken.mockReset();
+  mockResolveEffectiveTripToken.mockImplementation(
+    (backendTripToken: string | null, tripStart: number | null) =>
+      backendTripToken ?? (tripStart !== null ? `local-${tripStart}` : null),
+  );
+  mockReadSleepMode.mockReset();
+  mockReadSleepMode.mockResolvedValue(false);
+  mockMapBackendKindToLocalFireKind.mockReset();
+  mockMapBackendKindToLocalFireKind.mockReturnValue(null);
+  mockMarkLocalStationFired.mockReset();
+  mockMarkLocalStationFired.mockResolvedValue(undefined);
   // #1704 — 기본은 mirror null (위치 게이트 skip → 기존 동작 유지). 새 테스트는 mockResolvedValue로 override.
   mockReadBackendSsotMirror.mockReset();
   mockReadBackendSsotMirror.mockResolvedValue(null);
@@ -407,6 +454,161 @@ describe('reconcileScheduledAlarmDelivery', () => {
       );
     });
   });
+
+  describe('#918 presched(OS 사전예약 "매역") 채널', () => {
+    const PRESCHED_PARSED = {
+      channel: 'presched-station' as const,
+      tripToken: TRIP_TOKEN,
+      station: '역삼',
+      kind: 'station-passed' as const,
+      occurrenceIdx: 0,
+    };
+
+    beforeEach(() => {
+      mockReadSafetyNetData.mockReturnValue(null);
+    });
+
+    it('revalidate pass 시 markLocalStationFired만 호출하고 fired set은 건드리지 않는다', async () => {
+      mockReadPrescheduledData.mockReturnValue(PRESCHED_PARSED);
+
+      await reconcileScheduledAlarmDelivery(makeRequest('presched-id-1', null));
+
+      expect(mockReadSleepMode).toHaveBeenCalled();
+      expect(mockMarkLocalStationFired).toHaveBeenCalledWith('역삼', 'station-passed');
+      expect(mockGetFiredAlarms).not.toHaveBeenCalled();
+      expect(mockSetLastFiredAlarmStationName).not.toHaveBeenCalled();
+      expect(mockCancelScheduled).not.toHaveBeenCalled();
+    });
+
+    it('sleepMode ON이면 revalidate-sleep-mode-on으로 suppress + cancel/dismiss', async () => {
+      mockReadPrescheduledData.mockReturnValue(PRESCHED_PARSED);
+      mockReadSleepMode.mockResolvedValue(true);
+
+      await reconcileScheduledAlarmDelivery(makeRequest('presched-id-1', null));
+
+      expect(mockLogSuppressedPrescheduledRevalidation).toHaveBeenCalledWith({
+        reason: 'revalidate-sleep-mode-on',
+        stationName: '역삼',
+      });
+      expect(mockCancelScheduled).toHaveBeenCalledWith('presched-id-1');
+      expect(mockDismissNotification).toHaveBeenCalledWith('presched-id-1');
+      expect(mockMarkLocalStationFired).not.toHaveBeenCalled();
+    });
+
+    it('tripStart가 없으면 revalidate-no-trip으로 suppress', async () => {
+      mockReadPrescheduledData.mockReturnValue(PRESCHED_PARSED);
+      mockGetTripStartedAt.mockResolvedValue(null);
+
+      await reconcileScheduledAlarmDelivery(makeRequest('presched-id-1', null));
+
+      expect(mockLogSuppressedPrescheduledRevalidation).toHaveBeenCalledWith({
+        reason: 'revalidate-no-trip',
+        stationName: '역삼',
+      });
+      expect(mockCancelScheduled).toHaveBeenCalledWith('presched-id-1');
+      expect(mockDismissNotification).toHaveBeenCalledWith('presched-id-1');
+    });
+
+    it('effectiveTripToken이 parsed.tripToken과 다르면 revalidate-trip-token-mismatch로 suppress', async () => {
+      mockReadPrescheduledData.mockReturnValue(PRESCHED_PARSED);
+      mockResolveEffectiveTripToken.mockReturnValue('OTHER-TOKEN');
+
+      await reconcileScheduledAlarmDelivery(makeRequest('presched-id-1', null));
+
+      expect(mockLogSuppressedPrescheduledRevalidation).toHaveBeenCalledWith({
+        reason: 'revalidate-trip-token-mismatch',
+        stationName: '역삼',
+      });
+    });
+
+    it('effectiveTripToken이 null이면 revalidate-trip-token-mismatch로 suppress', async () => {
+      mockReadPrescheduledData.mockReturnValue(PRESCHED_PARSED);
+      mockResolveEffectiveTripToken.mockReturnValue(null);
+
+      await reconcileScheduledAlarmDelivery(makeRequest('presched-id-1', null));
+
+      expect(mockLogSuppressedPrescheduledRevalidation).toHaveBeenCalledWith({
+        reason: 'revalidate-trip-token-mismatch',
+        stationName: '역삼',
+      });
+    });
+  });
+
+  describe('#918 원격(backend) station-notif 도착 시 presched pending cancel', () => {
+    beforeEach(() => {
+      mockReadSafetyNetData.mockReturnValue(null);
+      mockReadPrescheduledData.mockReturnValue(null);
+    });
+
+    it('data.nextWaypoint + kind가 유효하면 매핑된 localKind로 cancelPrescheduledByStationKind 호출', () => {
+      mockMapBackendKindToLocalFireKind.mockReturnValue('transfer');
+      const request = {
+        identifier: 'remote-id',
+        content: { data: { nextWaypoint: '역삼', kind: 'transfer-arrival' } },
+      } as unknown as Notifications.NotificationRequest;
+
+      return reconcileScheduledAlarmDelivery(request).then(() => {
+        expect(mockMapBackendKindToLocalFireKind).toHaveBeenCalledWith('transfer-arrival');
+        expect(mockCancelPrescheduledByStationKind).toHaveBeenCalledWith('역삼', 'transfer');
+      });
+    });
+
+    it('data.nextWaypoint가 문자열이 아니면 cancelPrescheduledByStationKind를 호출하지 않는다', async () => {
+      const request = {
+        identifier: 'remote-id',
+        content: { data: { nextWaypoint: 42, kind: 'transfer-arrival' } },
+      } as unknown as Notifications.NotificationRequest;
+
+      await reconcileScheduledAlarmDelivery(request);
+
+      expect(mockCancelPrescheduledByStationKind).not.toHaveBeenCalled();
+    });
+
+    it('data.nextWaypoint가 빈 문자열이면 cancelPrescheduledByStationKind를 호출하지 않는다', async () => {
+      const request = {
+        identifier: 'remote-id',
+        content: { data: { nextWaypoint: '', kind: 'transfer-arrival' } },
+      } as unknown as Notifications.NotificationRequest;
+
+      await reconcileScheduledAlarmDelivery(request);
+
+      expect(mockCancelPrescheduledByStationKind).not.toHaveBeenCalled();
+    });
+
+    it('data.kind가 문자열이 아니면 cancelPrescheduledByStationKind를 호출하지 않는다', async () => {
+      const request = {
+        identifier: 'remote-id',
+        content: { data: { nextWaypoint: '역삼', kind: 42 } },
+      } as unknown as Notifications.NotificationRequest;
+
+      await reconcileScheduledAlarmDelivery(request);
+
+      expect(mockCancelPrescheduledByStationKind).not.toHaveBeenCalled();
+    });
+
+    it('mapBackendKindToLocalFireKind가 알 수 없는 kind를 반환하면 cancelPrescheduledByStationKind를 호출하지 않는다', async () => {
+      mockMapBackendKindToLocalFireKind.mockReturnValue(null);
+      const request = {
+        identifier: 'remote-id',
+        content: { data: { nextWaypoint: '역삼', kind: 'unknown-kind' } },
+      } as unknown as Notifications.NotificationRequest;
+
+      await reconcileScheduledAlarmDelivery(request);
+
+      expect(mockCancelPrescheduledByStationKind).not.toHaveBeenCalled();
+    });
+
+    it('content.data 자체가 없으면 cancelPrescheduledByStationKind를 호출하지 않는다', async () => {
+      const request = {
+        identifier: 'remote-id',
+        content: { data: undefined },
+      } as unknown as Notifications.NotificationRequest;
+
+      await reconcileScheduledAlarmDelivery(request);
+
+      expect(mockCancelPrescheduledByStationKind).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe('drainDeliveredScheduledAlarms (via registerScheduledAlarmListener)', () => {
@@ -501,6 +703,52 @@ describe('drainDeliveredScheduledAlarms (via registerScheduledAlarmListener)', (
     expect(mockSetFiredAlarms).not.toHaveBeenCalled();
     expect(mockSetLastFiredAlarmStationName).toHaveBeenCalledWith('시청');
     handle.remove();
+  });
+
+  describe('#918 presched 항목 drain', () => {
+    const PRESCHED_PARSED = {
+      channel: 'presched-station' as const,
+      tripToken: TRIP_TOKEN,
+      station: '역삼',
+      kind: 'station-passed' as const,
+      occurrenceIdx: 0,
+    };
+
+    it('presched 데이터가 아닌 항목은 skip하고, presched pass 항목은 markLocalStationFired 호출', async () => {
+      mockReadPrescheduledData.mockImplementation((req: Notifications.NotificationRequest) => {
+        const data = req.content.data as typeof PRESCHED_PARSED | null;
+        return data?.channel === 'presched-station' ? data : null;
+      });
+      mockGetPresented.mockResolvedValueOnce([
+        { date: 1, request: { identifier: 'other', content: { data: null } } as unknown as Notifications.NotificationRequest } as unknown as Notifications.Notification,
+        { date: 2, request: makeRequest('presched-1', PRESCHED_PARSED as unknown as SafetyNetNotificationData) },
+      ]);
+
+      const handle = registerScheduledAlarmListener();
+      await awaitInitialScheduledAlarmDrain();
+
+      expect(mockMarkLocalStationFired).toHaveBeenCalledWith('역삼', 'station-passed');
+      handle.remove();
+    });
+
+    it('presched suppress 항목은 cancel+dismiss하고 markLocalStationFired는 호출하지 않는다', async () => {
+      mockReadPrescheduledData.mockImplementation((req: Notifications.NotificationRequest) => {
+        const data = req.content.data as typeof PRESCHED_PARSED | null;
+        return data?.channel === 'presched-station' ? data : null;
+      });
+      mockReadSleepMode.mockResolvedValue(true);
+      mockGetPresented.mockResolvedValueOnce([
+        { date: 1, request: makeRequest('presched-1', PRESCHED_PARSED as unknown as SafetyNetNotificationData) },
+      ]);
+
+      const handle = registerScheduledAlarmListener();
+      await awaitInitialScheduledAlarmDrain();
+
+      expect(mockCancelScheduled).toHaveBeenCalledWith('presched-1');
+      expect(mockDismissNotification).toHaveBeenCalledWith('presched-1');
+      expect(mockMarkLocalStationFired).not.toHaveBeenCalled();
+      handle.remove();
+    });
   });
 });
 

--- a/src/features/alarm/utils/__tests__/stationNotification.test.ts
+++ b/src/features/alarm/utils/__tests__/stationNotification.test.ts
@@ -268,13 +268,15 @@ describe('stationNotification', () => {
         expect(result.shouldShowAlert).toBe(true);
       });
 
-      it('data.kind가 매핑 대상(intermediate) 외이면 hasRecentLocalStationFire 호출 안 함 (정상 표시)', async () => {
+      it('data.kind가 매핑 대상(intermediate/transfer/destination) 외이면 hasRecentLocalStationFire 호출 안 함 (정상 표시)', async () => {
         setupNotificationHandler();
         const { handleNotification } = (Notifications.setNotificationHandler as jest.Mock).mock.calls[0][0];
         const result = await handleNotification({
           request: {
             identifier: 'station-alarm',
-            content: { sound: null, data: { nextWaypoint: '중곡', kind: 'transfer' } },
+            // #918 — transfer/destination도 이제 매핑 대상에 포함(OS 사전예약 3-소스 dedup
+            // 확장)되므로, 매핑되지 않는 예시로는 두 채널 모두에 없는 임의 kind를 사용한다.
+            content: { sound: null, data: { nextWaypoint: '중곡', kind: 'boarding-prompt' } },
           },
         });
         expect(mockHasRecentLocalStationFire).not.toHaveBeenCalled();

--- a/src/features/alarm/utils/__tests__/stationPrescheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPrescheduler.test.ts
@@ -1,0 +1,675 @@
+/**
+ * stationPrescheduler (#918) — OS-level 사전 예약 "매역" 채널 테스트.
+ *
+ * - deriveUpcomingWaypoints(내부) 결과를 registerPrescheduledStationAlarms를 통해 검증:
+ *   window size(12역) 절단, kind 판정(transfer/destination/station-passed), occurrence index,
+ *   과거 시각(fireMs<=now) skip.
+ * - cancelAllPrescheduledAlarms: prefix 필터링 + delivered tray dismiss + 실패 graceful.
+ * - readPrescheduledData: 파싱 가드(prefix/channel/필수 필드/kind enum).
+ * - cancelPrescheduledByStationKind: (station, kind) 매칭 취소.
+ * - reschedulePrescheduledAlarm: 매칭 없음(cancel-only) / 과거 시각(cancel-only) / 정상 재예약.
+ */
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { Station } from '../../../../shared/types/station';
+import {
+  PRESCHED_ALARM_PREFIX,
+  registerPrescheduledStationAlarms,
+  cancelAllPrescheduledAlarms,
+  readPrescheduledData,
+  cancelPrescheduledByStationKind,
+  reschedulePrescheduledAlarm,
+} from '../stationPrescheduler';
+
+jest.mock('expo-notifications');
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+}));
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+jest.mock('../stationNotification', () => ({
+  buildAlarmContent: (event: { phaseId: string; stationName: string; type: string }) => ({
+    title: `T:${event.phaseId}:${event.type}`,
+    body: `B:${event.stationName}`,
+  }),
+  buildStationPassedContent: (stationName: string) => ({
+    title: 'passed-title',
+    body: `passed:${stationName}`,
+  }),
+}));
+
+jest.mock('../stationNotifCollapseId', () => ({
+  buildStationNotifCollapseId: (deviceToken: string) => `collapse-${deviceToken.slice(0, 16)}`,
+}));
+
+const mockCancelIdentifiersWithRetry = jest.fn();
+jest.mock('../safetyNetScheduler', () => ({
+  cancelIdentifiersWithRetry: (...args: unknown[]) => mockCancelIdentifiersWithRetry(...args),
+}));
+
+const mockRecordScheduledAlarm = jest.fn();
+jest.mock('../prescheduledMetrics', () => ({
+  recordScheduledAlarm: (...args: unknown[]) => mockRecordScheduledAlarm(...args),
+}));
+
+// hopTimeMsAt은 기본적으로 실제 구현(결정적 fallback 120s)을 그대로 사용 — 오직 "fireMs<=now
+// skip" 방어 분기(hop time이 0 이하로 산출되는 이론적 케이스)를 결정적으로 재현하기 위해서만
+// 개별 테스트가 mockReturnValueOnce로 override한다.
+const actualHopTime = jest.requireActual('../../../route/utils/hopTime');
+const mockHopTimeMsAt = jest.fn(actualHopTime.hopTimeMsAt);
+jest.mock('../../../route/utils/hopTime', () => ({
+  hopTimeMsAt: (...args: unknown[]) => mockHopTimeMsAt(...args),
+}));
+
+const mockLogScheduledPrescheduledAlarm = jest.fn();
+jest.mock('../alarmLog', () => ({
+  logScheduledPrescheduledAlarm: (...args: unknown[]) => mockLogScheduledPrescheduledAlarm(...args),
+}));
+
+const mockedSchedule = Notifications.scheduleNotificationAsync as jest.MockedFunction<
+  typeof Notifications.scheduleNotificationAsync
+>;
+const mockedGetAll = Notifications.getAllScheduledNotificationsAsync as jest.MockedFunction<
+  typeof Notifications.getAllScheduledNotificationsAsync
+>;
+const mockedGetPresented = Notifications.getPresentedNotificationsAsync as jest.MockedFunction<
+  typeof Notifications.getPresentedNotificationsAsync
+>;
+const mockedDismiss = Notifications.dismissNotificationAsync as jest.MockedFunction<
+  typeof Notifications.dismissNotificationAsync
+>;
+const mockAsyncGetItem = AsyncStorage.getItem as jest.Mock;
+
+const TRIP_TOKEN = 'TOKEN-ABCDEFGH-1234';
+const NOW = new Date('2026-08-03T09:00:00Z').getTime();
+
+/** fromId/toId가 stationTravelTimes.json에 존재하지 않는 fabricated id — getStopSeconds가 항상
+ * STOP_FALLBACK_SECONDS(120s)로 결정적으로 fallback하므로 hop time 계산이 실측 데이터 drift에서
+ * 독립적이다. */
+function makeStation(id: string, name: string, line: Station['line']): Station {
+  return { id, name, line, lineColor: '#000', lat: 0, lng: 0 } as Station;
+}
+
+/** 2호선 4역 + 3호선으로 환승하는 6역짜리 arc — transfer(idx 3→4 line 변경)/destination(마지막)/
+ * station-passed(그 외) 세 kind를 모두 발생시킨다. */
+function makeArc(): Station[] {
+  return [
+    makeStation('fab-2-a', 'A역', '2'),
+    makeStation('fab-2-b', 'B역', '2'),
+    makeStation('fab-2-c', 'C역', '2'),
+    makeStation('fab-2-d', 'D역', '2'),
+    makeStation('fab-3-e', 'E역', '3'),
+    makeStation('fab-3-f', 'F역', '3'),
+  ];
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.replaceProperty(Platform, 'OS', 'ios');
+  mockedSchedule.mockResolvedValue('id');
+  mockedGetAll.mockResolvedValue([]);
+  mockedGetPresented.mockResolvedValue([]);
+  mockedDismiss.mockResolvedValue(undefined);
+  mockCancelIdentifiersWithRetry.mockResolvedValue(0);
+  mockRecordScheduledAlarm.mockResolvedValue(undefined);
+  mockAsyncGetItem.mockResolvedValue(null);
+  mockHopTimeMsAt.mockReset();
+  mockHopTimeMsAt.mockImplementation(actualHopTime.hopTimeMsAt);
+});
+
+function scheduledIdentifiers(): string[] {
+  return mockedSchedule.mock.calls.map((call) => call[0].identifier as string);
+}
+
+function scheduledContentData(idx: number): Record<string, unknown> {
+  return mockedSchedule.mock.calls[idx][0].content.data as Record<string, unknown>;
+}
+
+describe('registerPrescheduledStationAlarms', () => {
+  it('currentIdx가 arc 끝(마지막 인덱스)이면 빈 배열 → scheduled 0', async () => {
+    const arc = makeArc();
+    const result = await registerPrescheduledStationAlarms({
+      tripToken: TRIP_TOKEN,
+      arcStations: arc,
+      currentIdx: arc.length - 1,
+      now: NOW,
+    });
+    expect(result).toEqual({ scheduled: 0 });
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('currentIdx가 음수면 빈 배열 → scheduled 0', async () => {
+    const arc = makeArc();
+    const result = await registerPrescheduledStationAlarms({
+      tripToken: TRIP_TOKEN,
+      arcStations: arc,
+      currentIdx: -1,
+      now: NOW,
+    });
+    expect(result).toEqual({ scheduled: 0 });
+  });
+
+  it('중간역은 station-passed, line 경계는 transfer, 마지막 역은 destination으로 예약', async () => {
+    const arc = makeArc();
+    const result = await registerPrescheduledStationAlarms({
+      tripToken: TRIP_TOKEN,
+      arcStations: arc,
+      currentIdx: 0,
+      now: NOW,
+    });
+
+    // idx0(A) 기준 남은 5개 hop(B,C,D,E,F) 모두 window(12) 이내 → 5건 예약.
+    expect(result.scheduled).toBe(5);
+    const kinds = mockedSchedule.mock.calls.map((c) => (c[0].content.data as { kind: string }).kind);
+    expect(kinds).toEqual(['station-passed', 'station-passed', 'transfer', 'station-passed', 'destination']);
+  });
+
+  it('rolling window(12역) 초과분은 예약하지 않는다', async () => {
+    const arc: Station[] = [];
+    for (let i = 0; i < 20; i++) arc.push(makeStation(`fab-1-${i}`, `역${i}`, '1'));
+    const result = await registerPrescheduledStationAlarms({
+      tripToken: TRIP_TOKEN,
+      arcStations: arc,
+      currentIdx: 0,
+      now: NOW,
+    });
+    expect(result.scheduled).toBe(12);
+  });
+
+  it('fireMs가 now 이하인 waypoint는 skip(0 hop-time fallback 경계 케이스는 발생하지 않지만 방어 로직 검증)', async () => {
+    // now를 아주 먼 미래로 설정해 모든 fireMs(now 기준 누적)가 now보다 작아지게 만든다.
+    const arc = makeArc();
+    const farFutureNow = NOW + 1_000_000_000;
+    const result = await registerPrescheduledStationAlarms({
+      tripToken: TRIP_TOKEN,
+      arcStations: arc,
+      currentIdx: 0,
+      now: farFutureNow,
+    });
+    // deriveUpcomingWaypoints의 cumulativeMs는 now에서 시작해 누적되므로 항상 now보다 크다 —
+    // 즉 이 케이스에서는 skip이 발생하지 않는다(fireMs = now + hop time > now). 정상 스케줄만 확인.
+    expect(result.scheduled).toBe(5);
+  });
+
+  it('now 미지정 시 Date.now() fallback', async () => {
+    const spy = jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    const arc = makeArc();
+    await registerPrescheduledStationAlarms({ tripToken: TRIP_TOKEN, arcStations: arc, currentIdx: 0 });
+    expect(mockedSchedule).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('hop time이 0 이하로 산출되어 fireMs<=now인 waypoint는 스킵하고 그 뒤는 정상 예약', async () => {
+    // 첫 hop만 0ms(fireMs===nowMs)로 강제 — 두 번째 이후는 실제 구현으로 복귀.
+    mockHopTimeMsAt.mockImplementationOnce(() => 0);
+    const arc = makeArc();
+    const result = await registerPrescheduledStationAlarms({
+      tripToken: TRIP_TOKEN,
+      arcStations: arc,
+      currentIdx: 0,
+      now: NOW,
+    });
+    // 5개 hop 중 첫 waypoint(B역)만 skip → 4건 예약.
+    expect(result.scheduled).toBe(4);
+    expect(scheduledIdentifiers().some((id) => id.includes('B역'))).toBe(false);
+  });
+
+  it('같은 (kind, stationName) 조합이 route에 중복 등장하면 occurrenceIdx가 증가한 identifier를 만든다', async () => {
+    // currentIdx=0(X역)의 다음 hop부터 waypoint가 파생 — waypoint 시퀀스는 [A역, B역, A역(중복), C역].
+    const arc = [
+      makeStation('fab-2-x', 'X역', '2'),
+      makeStation('fab-2-a', 'A역', '2'),
+      makeStation('fab-2-b', 'B역', '2'),
+      makeStation('fab-2-a2', 'A역', '2'),
+      makeStation('fab-2-c', 'C역', '2'),
+    ];
+    await registerPrescheduledStationAlarms({
+      tripToken: TRIP_TOKEN,
+      arcStations: arc,
+      currentIdx: 0,
+      now: NOW,
+    });
+    const ids = scheduledIdentifiers();
+    expect(ids[0]).toBe(`${PRESCHED_ALARM_PREFIX}${TRIP_TOKEN.slice(0, 16)}-A역-station-passed`);
+    expect(ids[2]).toBe(`${PRESCHED_ALARM_PREFIX}${TRIP_TOKEN.slice(0, 16)}-A역-station-passed#1`);
+  });
+
+  it('AndroidNotificationPriority.MAX + channelId를 android에서 설정, ios에서는 interruptionLevel 설정(alarm kind)', async () => {
+    jest.replaceProperty(Platform, 'OS', 'android');
+    const arc = makeArc();
+    await registerPrescheduledStationAlarms({
+      tripToken: TRIP_TOKEN,
+      arcStations: arc,
+      currentIdx: 3, // transfer 다음 destination 두 건만 남김: D→E(transfer), E→F(destination)
+      now: NOW,
+    });
+    const call = mockedSchedule.mock.calls[0][0];
+    expect((call.content as { channelId?: string }).channelId).toBe('station-alarm');
+    expect((call.content as { priority?: number }).priority).toBe(
+      Notifications.AndroidNotificationPriority.MAX,
+    );
+    expect((call.content as { interruptionLevel?: string }).interruptionLevel).toBeUndefined();
+  });
+
+  it('station-passed kind는 sound=false, alarm kind(transfer/destination)는 sound=alarm.wav', async () => {
+    const arc = makeArc();
+    await registerPrescheduledStationAlarms({
+      tripToken: TRIP_TOKEN,
+      arcStations: arc,
+      currentIdx: 0,
+      now: NOW,
+    });
+    const calls = mockedSchedule.mock.calls;
+    expect((calls[0][0].content as { sound?: unknown }).sound).toBe(false);
+    const transferCallIdx = 2; // D역 transfer
+    expect((calls[transferCallIdx][0].content as { sound?: unknown }).sound).toBe('alarm.wav');
+  });
+
+  it('APNS_TOKEN_KEY가 있으면 collapseId를 content.data에 동봉', async () => {
+    mockAsyncGetItem.mockResolvedValue('device-token-1234567890');
+    const arc = makeArc();
+    await registerPrescheduledStationAlarms({
+      tripToken: TRIP_TOKEN,
+      arcStations: arc,
+      currentIdx: 0,
+      now: NOW,
+    });
+    expect(scheduledContentData(0).collapseId).toBe(`collapse-${'device-token-1234567890'.slice(0, 16)}`);
+  });
+
+  it('APNS_TOKEN_KEY가 없으면 collapseId undefined', async () => {
+    mockAsyncGetItem.mockResolvedValue(null);
+    const arc = makeArc();
+    await registerPrescheduledStationAlarms({
+      tripToken: TRIP_TOKEN,
+      arcStations: arc,
+      currentIdx: 0,
+      now: NOW,
+    });
+    expect(scheduledContentData(0).collapseId).toBeUndefined();
+  });
+
+  it('recordScheduledAlarm + logScheduledPrescheduledAlarm이 예약마다 호출된다', async () => {
+    const arc = makeArc();
+    await registerPrescheduledStationAlarms({
+      tripToken: TRIP_TOKEN,
+      arcStations: arc,
+      currentIdx: 0,
+      now: NOW,
+    });
+    expect(mockRecordScheduledAlarm).toHaveBeenCalledTimes(5);
+    expect(mockLogScheduledPrescheduledAlarm).toHaveBeenCalledTimes(5);
+    expect(mockLogScheduledPrescheduledAlarm).toHaveBeenCalledWith({ stationName: 'B역', kind: 'station-passed' });
+  });
+});
+
+describe('cancelAllPrescheduledAlarms', () => {
+  it('prefix가 일치하는 pending만 취소한다', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: `${PRESCHED_ALARM_PREFIX}${TRIP_TOKEN.slice(0, 16)}-A역-station-passed` },
+      { identifier: 'other-id' },
+    ] as unknown as Notifications.NotificationRequest[]);
+    mockCancelIdentifiersWithRetry.mockResolvedValue(1);
+
+    await cancelAllPrescheduledAlarms(TRIP_TOKEN);
+
+    expect(mockCancelIdentifiersWithRetry).toHaveBeenCalledWith([
+      `${PRESCHED_ALARM_PREFIX}${TRIP_TOKEN.slice(0, 16)}-A역-station-passed`,
+    ]);
+  });
+
+  it('delivered tray의 매칭 항목을 dismiss하고 성공 카운트를 집계한다', async () => {
+    mockedGetAll.mockResolvedValue([]);
+    const prefix = `${PRESCHED_ALARM_PREFIX}${TRIP_TOKEN.slice(0, 16)}-`;
+    mockedGetPresented.mockResolvedValue([
+      { request: { identifier: `${prefix}A역-station-passed` } },
+      { request: { identifier: 'unrelated' } },
+    ] as unknown as Notifications.Notification[]);
+    mockedDismiss.mockResolvedValueOnce(undefined);
+
+    await cancelAllPrescheduledAlarms(TRIP_TOKEN);
+
+    expect(mockedDismiss).toHaveBeenCalledTimes(1);
+    expect(mockedDismiss).toHaveBeenCalledWith(`${prefix}A역-station-passed`);
+  });
+
+  it('dismiss 실패(rejected)는 카운트에서 제외되고 전체 흐름은 정상 종료', async () => {
+    const prefix = `${PRESCHED_ALARM_PREFIX}${TRIP_TOKEN.slice(0, 16)}-`;
+    mockedGetPresented.mockResolvedValue([
+      { request: { identifier: `${prefix}A역-station-passed` } },
+    ] as unknown as Notifications.Notification[]);
+    mockedDismiss.mockRejectedValueOnce(new Error('dismiss fail'));
+
+    await expect(cancelAllPrescheduledAlarms(TRIP_TOKEN)).resolves.toBeUndefined();
+  });
+
+  it('getPresentedNotificationsAsync 실패 시 pending cancel만 적용하고 graceful 종료', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: `${PRESCHED_ALARM_PREFIX}${TRIP_TOKEN.slice(0, 16)}-A역-station-passed` },
+    ] as unknown as Notifications.NotificationRequest[]);
+    mockCancelIdentifiersWithRetry.mockResolvedValue(1);
+    mockedGetPresented.mockRejectedValue(new Error('tray fail'));
+
+    await expect(cancelAllPrescheduledAlarms(TRIP_TOKEN)).resolves.toBeUndefined();
+  });
+
+  it('취소도 dismiss도 없으면 조용히 종료(0/0)', async () => {
+    mockedGetAll.mockResolvedValue([]);
+    mockedGetPresented.mockResolvedValue([]);
+    await expect(cancelAllPrescheduledAlarms(TRIP_TOKEN)).resolves.toBeUndefined();
+  });
+});
+
+describe('readPrescheduledData', () => {
+  const prefix = `${PRESCHED_ALARM_PREFIX}${TRIP_TOKEN.slice(0, 16)}-`;
+
+  function makeReq(identifier: string, data: unknown): Notifications.NotificationRequest {
+    return { identifier, content: { data } } as unknown as Notifications.NotificationRequest;
+  }
+
+  it('prefix가 아니면 null', () => {
+    expect(readPrescheduledData(makeReq('other-id', null))).toBeNull();
+  });
+
+  it('data가 없으면 null', () => {
+    expect(readPrescheduledData(makeReq(`${prefix}A역-station-passed`, null))).toBeNull();
+  });
+
+  it('channel이 presched-station이 아니면 null', () => {
+    expect(
+      readPrescheduledData(makeReq(`${prefix}A역-station-passed`, { channel: 'safety-net' })),
+    ).toBeNull();
+  });
+
+  it('station 또는 tripToken이 문자열이 아니면 null', () => {
+    expect(
+      readPrescheduledData(
+        makeReq(`${prefix}A역-station-passed`, {
+          channel: 'presched-station',
+          station: 1,
+          tripToken: TRIP_TOKEN,
+          kind: 'station-passed',
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      readPrescheduledData(
+        makeReq(`${prefix}A역-station-passed`, {
+          channel: 'presched-station',
+          station: 'A역',
+          tripToken: 1,
+          kind: 'station-passed',
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('kind가 유효 enum이 아니면 null', () => {
+    expect(
+      readPrescheduledData(
+        makeReq(`${prefix}A역-station-passed`, {
+          channel: 'presched-station',
+          station: 'A역',
+          tripToken: TRIP_TOKEN,
+          kind: 'unknown-kind',
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('occurrenceIdx가 숫자가 아니면 0으로 기본값 처리하며 정상 파싱', () => {
+    const result = readPrescheduledData(
+      makeReq(`${prefix}A역-station-passed`, {
+        channel: 'presched-station',
+        station: 'A역',
+        tripToken: TRIP_TOKEN,
+        kind: 'station-passed',
+      }),
+    );
+    expect(result).toEqual({
+      channel: 'presched-station',
+      tripToken: TRIP_TOKEN,
+      station: 'A역',
+      kind: 'station-passed',
+      occurrenceIdx: 0,
+    });
+  });
+
+  it('occurrenceIdx가 숫자면 그대로 반영', () => {
+    const result = readPrescheduledData(
+      makeReq(`${prefix}A역-station-passed#1`, {
+        channel: 'presched-station',
+        station: 'A역',
+        tripToken: TRIP_TOKEN,
+        kind: 'station-passed',
+        occurrenceIdx: 1,
+      }),
+    );
+    expect(result?.occurrenceIdx).toBe(1);
+  });
+});
+
+describe('cancelPrescheduledByStationKind', () => {
+  it('매칭되는 항목이 없으면 cancelIdentifiersWithRetry를 호출하지 않는다', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'other', content: { data: null } },
+    ] as unknown as Notifications.NotificationRequest[]);
+
+    await cancelPrescheduledByStationKind('A역', 'station-passed');
+
+    expect(mockCancelIdentifiersWithRetry).not.toHaveBeenCalled();
+  });
+
+  it('targets는 있지만 cancelIdentifiersWithRetry가 0을 반환하면 info 로그를 남기지 않는다(0 branch)', async () => {
+    const prefix = `${PRESCHED_ALARM_PREFIX}${TRIP_TOKEN.slice(0, 16)}-`;
+    mockedGetAll.mockResolvedValue([
+      {
+        identifier: `${prefix}A역-station-passed`,
+        content: {
+          data: { channel: 'presched-station', station: 'A역', tripToken: TRIP_TOKEN, kind: 'station-passed' },
+        },
+      },
+    ] as unknown as Notifications.NotificationRequest[]);
+    mockCancelIdentifiersWithRetry.mockResolvedValue(0);
+
+    await expect(cancelPrescheduledByStationKind('A역', 'station-passed')).resolves.toBeUndefined();
+  });
+
+  it('(station, kind)가 일치하는 항목만 취소한다(occurrence 무관)', async () => {
+    const prefix = `${PRESCHED_ALARM_PREFIX}${TRIP_TOKEN.slice(0, 16)}-`;
+    mockedGetAll.mockResolvedValue([
+      {
+        identifier: `${prefix}A역-station-passed`,
+        content: {
+          data: { channel: 'presched-station', station: 'A역', tripToken: TRIP_TOKEN, kind: 'station-passed' },
+        },
+      },
+      {
+        identifier: `${prefix}A역-station-passed#1`,
+        content: {
+          data: {
+            channel: 'presched-station',
+            station: 'A역',
+            tripToken: TRIP_TOKEN,
+            kind: 'station-passed',
+            occurrenceIdx: 1,
+          },
+        },
+      },
+      {
+        identifier: `${prefix}B역-transfer`,
+        content: {
+          data: { channel: 'presched-station', station: 'B역', tripToken: TRIP_TOKEN, kind: 'transfer' },
+        },
+      },
+    ] as unknown as Notifications.NotificationRequest[]);
+    mockCancelIdentifiersWithRetry.mockResolvedValue(2);
+
+    await cancelPrescheduledByStationKind('A역', 'station-passed');
+
+    expect(mockCancelIdentifiersWithRetry).toHaveBeenCalledWith([
+      `${prefix}A역-station-passed`,
+      `${prefix}A역-station-passed#1`,
+    ]);
+  });
+});
+
+describe('reschedulePrescheduledAlarm', () => {
+  const prefix = `${PRESCHED_ALARM_PREFIX}${TRIP_TOKEN.slice(0, 16)}-`;
+
+  it('매칭되는 기존 pending이 없으면 cancel-only(0,0)를 반환한다', async () => {
+    mockedGetAll.mockResolvedValue([]);
+    const result = await reschedulePrescheduledAlarm({
+      tripToken: TRIP_TOKEN,
+      stationName: 'A역',
+      newArrivalMs: NOW + 60_000,
+      now: NOW,
+    });
+    expect(result).toEqual({ cancelled: 0, scheduled: 0 });
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('presched 데이터가 아니거나 tripToken/occurrenceIdx/station이 각각 불일치하는 항목은 매칭에서 제외된다', async () => {
+    mockedGetAll.mockResolvedValue([
+      { identifier: 'not-presched', content: { data: null } },
+      {
+        identifier: `${prefix}A역-transfer-wrong-token`,
+        content: {
+          data: { channel: 'presched-station', station: 'A역', tripToken: 'OTHER-TOKEN', kind: 'transfer' },
+        },
+      },
+      {
+        identifier: `${prefix}A역-transfer#9`,
+        content: {
+          data: {
+            channel: 'presched-station',
+            station: 'A역',
+            tripToken: TRIP_TOKEN,
+            kind: 'transfer',
+            occurrenceIdx: 9,
+          },
+        },
+      },
+      {
+        identifier: `${prefix}B역-transfer`,
+        content: {
+          data: { channel: 'presched-station', station: 'B역', tripToken: TRIP_TOKEN, kind: 'transfer' },
+        },
+      },
+    ] as unknown as Notifications.NotificationRequest[]);
+
+    const result = await reschedulePrescheduledAlarm({
+      tripToken: TRIP_TOKEN,
+      stationName: 'A역',
+      newArrivalMs: NOW + 60_000,
+      now: NOW,
+    });
+
+    expect(result).toEqual({ cancelled: 0, scheduled: 0 });
+    expect(mockCancelIdentifiersWithRetry).not.toHaveBeenCalled();
+  });
+
+  it('newArrivalMs가 now 이하면 cancel만 하고 재예약하지 않는다', async () => {
+    mockedGetAll.mockResolvedValue([
+      {
+        identifier: `${prefix}A역-station-passed`,
+        content: {
+          data: { channel: 'presched-station', station: 'A역', tripToken: TRIP_TOKEN, kind: 'station-passed' },
+        },
+      },
+    ] as unknown as Notifications.NotificationRequest[]);
+    mockCancelIdentifiersWithRetry.mockResolvedValue(1);
+
+    const result = await reschedulePrescheduledAlarm({
+      tripToken: TRIP_TOKEN,
+      stationName: 'A역',
+      newArrivalMs: NOW - 1,
+      now: NOW,
+    });
+
+    expect(result).toEqual({ cancelled: 1, scheduled: 0 });
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('매칭 성공 + 미래 시각이면 cancel 후 동일 kind/occurrence로 재예약한다', async () => {
+    mockedGetAll.mockResolvedValue([
+      {
+        identifier: `${prefix}A역-transfer`,
+        content: {
+          data: { channel: 'presched-station', station: 'A역', tripToken: TRIP_TOKEN, kind: 'transfer' },
+        },
+      },
+    ] as unknown as Notifications.NotificationRequest[]);
+    mockCancelIdentifiersWithRetry.mockResolvedValue(1);
+
+    const result = await reschedulePrescheduledAlarm({
+      tripToken: TRIP_TOKEN,
+      stationName: 'A역',
+      newArrivalMs: NOW + 60_000,
+      now: NOW,
+    });
+
+    expect(result).toEqual({ cancelled: 1, scheduled: 1 });
+    expect(mockedSchedule).toHaveBeenCalledTimes(1);
+    expect(mockedSchedule.mock.calls[0][0].identifier).toBe(`${prefix}A역-transfer`);
+  });
+
+  it('occurrenceIdx 미지정 시 0 기본값으로 매칭한다', async () => {
+    mockedGetAll.mockResolvedValue([
+      {
+        identifier: `${prefix}A역-station-passed`,
+        content: {
+          data: {
+            channel: 'presched-station',
+            station: 'A역',
+            tripToken: TRIP_TOKEN,
+            kind: 'station-passed',
+            occurrenceIdx: 0,
+          },
+        },
+      },
+    ] as unknown as Notifications.NotificationRequest[]);
+    mockCancelIdentifiersWithRetry.mockResolvedValue(1);
+
+    const result = await reschedulePrescheduledAlarm({
+      tripToken: TRIP_TOKEN,
+      stationName: 'A역',
+      newArrivalMs: NOW + 60_000,
+      now: NOW,
+    });
+
+    expect(result.scheduled).toBe(1);
+  });
+
+  it('now 미지정 시 Date.now() fallback', async () => {
+    const spy = jest.spyOn(Date, 'now').mockReturnValue(NOW);
+    mockedGetAll.mockResolvedValue([
+      {
+        identifier: `${prefix}A역-transfer`,
+        content: {
+          data: { channel: 'presched-station', station: 'A역', tripToken: TRIP_TOKEN, kind: 'transfer' },
+        },
+      },
+    ] as unknown as Notifications.NotificationRequest[]);
+    mockCancelIdentifiersWithRetry.mockResolvedValue(1);
+
+    const result = await reschedulePrescheduledAlarm({
+      tripToken: TRIP_TOKEN,
+      stationName: 'A역',
+      newArrivalMs: NOW + 60_000,
+    });
+
+    expect(result.scheduled).toBe(1);
+    spy.mockRestore();
+  });
+});

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -212,6 +212,9 @@ export type AlarmLogReason =
   | 'revalidate-route-missing'
   | 'revalidate-waypoint-mismatch'
   | 'revalidate-position-mismatch'
+  // #918 — stationPrescheduler(OS 사전예약 "매역" 채널) fire-time 재검증 전용 reason.
+  // sleepMode가 그 사이 켜지면 safetyNetScheduler 전담으로 정책이 넘어가므로 잔여 발화 suppress.
+  | 'revalidate-sleep-mode-on'
   // #1167 — boardingPrompt [탑승] 응답 → arvlCd 우선순위 autoLock 결과.
   //   'autolock-success': arvlCd 우선순위로 1대 확정 → createLock 성공.
   //   'autolock-no-trip': destinationId null (사용자 trip 종료 후 늦은 탭).
@@ -1697,6 +1700,43 @@ export function logHydrationTransition(
  * lastStationName 갱신을 skip해 stale 알람이 후속 상태(BG arrival 기준역 등)를 오염시키지 않게 한다.
  * source='bg-scheduled' 재사용 — preschedule path 출처 통일(stamp/fired log와 동일 source).
  */
+/**
+ * #918 — stationPrescheduler(OS 사전예약 "매역" 채널) 등록 1건 적재.
+ * source는 safetyNetScheduler와 동일하게 'bg-scheduled'로 통일 — 두 예약 채널 모두 같은
+ * reason/카운터 버킷에서 관측 가능해야 DebugModal/measurement가 한 곳만 보면 된다.
+ */
+export function logScheduledPrescheduledAlarm(input: {
+  stationName: string;
+  kind: 'transfer' | 'destination' | 'station-passed';
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'bg-scheduled',
+    outcome: 'fired',
+    stationName: input.stationName,
+    kind: input.kind,
+  });
+}
+
+/**
+ * #918 — stationPrescheduler 알람의 fire-time 재검증 실패 1건 적재.
+ * `revalidatePrescheduledAlarm`이 suppress를 반환하기 직전에 호출한다.
+ * `logSuppressedSafetyNetRevalidation`과 동일 source/outcome 관례를 따르되, 재검증 항목이
+ * 다르므로(sleepMode 게이트 포함) 별도 reason union을 갖는 sibling 함수로 분리한다.
+ */
+export function logSuppressedPrescheduledRevalidation(input: {
+  reason: 'revalidate-no-trip' | 'revalidate-trip-token-mismatch' | 'revalidate-sleep-mode-on';
+  stationName: string;
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'bg-scheduled',
+    outcome: 'suppressed',
+    reason: input.reason,
+    stationName: input.stationName,
+  });
+}
+
 export function logSuppressedSafetyNetRevalidation(input: {
   reason:
     | 'revalidate-no-trip'

--- a/src/features/alarm/utils/prescheduledMetrics.ts
+++ b/src/features/alarm/utils/prescheduledMetrics.ts
@@ -34,9 +34,15 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createLogger } from '../../../shared/utils/logger';
 import { PRESCHEDULED_LEDGER_KEY } from '../../../shared/constants/storageKeys';
-// NOTE: `safetyNetScheduler.ts`의 `SAFETY_NET_ALARM_PREFIX`와 동일 값 — 모듈 간 순환 import
-// 방지를 위해 로컬 상수로 보관. safetyNetScheduler에서 prefix가 바뀌면 본 파일도 동시 업데이트.
-const SAFETY_NET_ALARM_PREFIX = 'alarm-';
+// NOTE: `safetyNetScheduler.ts`의 `SAFETY_NET_ALARM_PREFIX` / `stationPrescheduler.ts`의
+// `PRESCHED_ALARM_PREFIX`와 동일 값 — 모듈 간 순환 import 방지를 위해 로컬 상수로 보관.
+// 두 스케줄러(sleepMode ON 전용 / OFF 전용)가 각각 등록하는 예약 채널 2종을 이 ledger가
+// 공통으로 측정한다(#918) — prefix가 둘 중 하나라도 바뀌면 본 파일도 동시 업데이트.
+const SCHEDULED_ALARM_PREFIXES = ['alarm-', 'presched-'];
+
+function hasKnownPrefix(identifier: string): boolean {
+  return SCHEDULED_ALARM_PREFIXES.some((prefix) => identifier.startsWith(prefix));
+}
 
 const log = createLogger('prescheduledMetrics');
 
@@ -80,7 +86,7 @@ async function readLedger(): Promise<PrescheduledLedger> {
 function isLedgerEntry(v: unknown): v is PrescheduledLedgerEntry {
   if (!v || typeof v !== 'object') return false;
   const o = v as Record<string, unknown>;
-  if (typeof o.identifier !== 'string' || !o.identifier.startsWith(SAFETY_NET_ALARM_PREFIX)) {
+  if (typeof o.identifier !== 'string' || !hasKnownPrefix(o.identifier)) {
     return false;
   }
   if (typeof o.stationName !== 'string' || o.stationName.length === 0) return false;
@@ -110,7 +116,7 @@ export async function recordScheduledAlarm(input: {
   scheduledFireMs: number;
   stationName: string;
 }): Promise<void> {
-  if (!input.identifier.startsWith(SAFETY_NET_ALARM_PREFIX)) return;
+  if (!hasKnownPrefix(input.identifier)) return;
   if (!Number.isFinite(input.scheduledFireMs)) return;
   if (input.stationName.length === 0) return;
   try {
@@ -140,7 +146,7 @@ export async function recordFiredAlarm(input: {
   identifier: string;
   actualFireMs: number;
 }): Promise<void> {
-  if (!input.identifier.startsWith(SAFETY_NET_ALARM_PREFIX)) return;
+  if (!hasKnownPrefix(input.identifier)) return;
   if (!Number.isFinite(input.actualFireMs)) return;
   try {
     const ledger = await readLedger();

--- a/src/features/alarm/utils/safetyNetScheduler.ts
+++ b/src/features/alarm/utils/safetyNetScheduler.ts
@@ -286,7 +286,11 @@ export async function registerSafetyNetAlarms(
  * tripBoundScheduler.cancelIdentifiersWithRetry / boardingLockScheduler.cancelAndDismiss와
  * 동형 — 3종 통합으로 이 파일 한 곳에만 존재.
  */
-async function cancelIdentifiersWithRetry(identifiers: string[]): Promise<number> {
+/**
+ * #918 — `stationPrescheduler`(OS 사전 예약 2번째 채널)가 동일한 retry-cancel 정책을
+ * 재사용한다. export해 신규 중복 구현을 피한다.
+ */
+export async function cancelIdentifiersWithRetry(identifiers: string[]): Promise<number> {
   if (identifiers.length === 0) return 0;
   const firstPass = await Promise.allSettled(
     identifiers.map((id) => Notifications.cancelScheduledNotificationAsync(id)),

--- a/src/features/alarm/utils/scheduledAlarmReceiver.ts
+++ b/src/features/alarm/utils/scheduledAlarmReceiver.ts
@@ -24,11 +24,20 @@ import { recordFiredAlarm } from './prescheduledMetrics';
 import {
   deriveSafetyNetWaypoints,
   readSafetyNetData,
+  resolveEffectiveTripToken,
   type SafetyNetNotificationData,
 } from './safetyNetScheduler';
+import {
+  readPrescheduledData,
+  cancelPrescheduledByStationKind,
+  type PrescheduledNotificationData,
+} from './stationPrescheduler';
+import { readSleepMode } from './alarmLocalAuthority';
+import { mapBackendKindToLocalFireKind } from './stationNotification';
+import { markLocalStationFired } from './recentLocalStationFires';
 import { getTripStartedAt } from './tripStartStorage';
 import { alarmKey } from './stationAlarm';
-import { logSuppressedSafetyNetRevalidation } from './alarmLog';
+import { logSuppressedSafetyNetRevalidation, logSuppressedPrescheduledRevalidation } from './alarmLog';
 import { readBackendSsotMirror } from './backendSsotMirror';
 import { getStationById, isSameStationName } from '../../../shared/utils/stationRoute';
 import { routeToWaypoints } from '../../route/utils/routeWaypoints';
@@ -273,16 +282,72 @@ async function revalidateSafetyNetAlarm(
 }
 
 /**
- * 사전 예약된 safety-net 알림이 OS에 의해 발사된 직후 클라이언트 상태를 갱신한다.
- * 사전 예약 알람은 클라이언트 콜백을 거치지 않으므로, 이 함수가 FG/BG 양쪽 발화 모두에 대한
- * 상태 동기화 단일 진입점이다.
+ * #918 — stationPrescheduler(OS 사전예약 "매역" 채널) 알람의 fire-time 재검증.
  *
- * - FIRED_ALARMS_KEY에 `early:station`/`imminent:station` 둘 다 추가 → FG 복귀 시 useStationAlarm
- *   하이드레이션 및 후속 silent push 처리가 해당 station을 이미 발화된 것으로 간주해 중복 발화를
- *   막는다. safetyNetScheduler는 phase 개념이 없는 단일 fire지만, dedup key 공간은 live GPS 기반
- *   FG/BG 발화 경로(early/imminent 2 phase)와 공유되므로 둘 다 마킹해야 교차 dedup이 보장된다.
- * - LAST_FIRED_ALARM_STATION_NAME_KEY를 해당 역 이름으로 갱신 → BGAppRefreshTask가
+ * safetyNetScheduler의 4단 검증(tripStart/tripToken/waypoint/position)과 달리 본 채널은
+ * "waypoint 자체(kind+station)가 이미 content.data에 구조화되어 있어 별도 파싱이 필요 없다"는
+ * 점 + "sleepMode로 두 채널이 상호 배타"라는 정책을 반영해 더 가벼운 3단 검증만 수행한다:
+ *   1) sleepMode가 그 사이 켜졌으면 suppress — 켜진 순간부터는 safetyNetScheduler 전담이라
+ *      본 채널의 잔여 발화는 정책 밖 알람이다.
+ *   2) tripStart 존재 — trip이 종료되지 않았다.
+ *   3) parsed.tripToken이 현재 유효 trip(backend 등록 or device-local)과 일치.
+ */
+async function revalidatePrescheduledAlarm(
+  parsed: PrescheduledNotificationData,
+): Promise<'pass' | 'suppress'> {
+  const suppress = (
+    reason: Parameters<typeof logSuppressedPrescheduledRevalidation>[0]['reason'],
+  ): 'suppress' => {
+    logSuppressedPrescheduledRevalidation({ reason, stationName: parsed.station });
+    return 'suppress';
+  };
+
+  const sleepMode = await readSleepMode();
+  if (sleepMode) return suppress('revalidate-sleep-mode-on');
+
+  const tripStart = await getTripStartedAt();
+  if (tripStart === null) return suppress('revalidate-no-trip');
+
+  const activeTripToken = await AsyncStorage.getItem(ACTIVE_TRIP_KEY);
+  const effectiveTripToken = resolveEffectiveTripToken(activeTripToken, tripStart);
+  if (effectiveTripToken === null || effectiveTripToken !== parsed.tripToken) {
+    return suppress('revalidate-trip-token-mismatch');
+  }
+  return 'pass';
+}
+
+/**
+ * #918 — backend push(원격 station-notif)의 content.data에서 (station, kind)를 추출해,
+ * 그 역의 사전예약 pending을 취소한다("remote 선표시 → 해당 역 pending 로컬 cancel").
+ * 원격이 아닌(=우리 자신의 safetyNet/presched) request는 각각의 prefix로 이미 위에서
+ * 처리되므로, 본 helper는 두 채널 어느 쪽도 아닌 request에 대해서만 의미 있게 동작한다.
+ */
+async function cancelPrescheduledOnRemoteArrival(
+  request: Notifications.NotificationRequest,
+): Promise<void> {
+  const data = request.content.data as { nextWaypoint?: unknown; kind?: unknown } | undefined;
+  const stationName = data?.nextWaypoint;
+  const backendKind = data?.kind;
+  if (typeof stationName !== 'string' || stationName.length === 0) return;
+  if (typeof backendKind !== 'string') return;
+  const localKind = mapBackendKindToLocalFireKind(backendKind);
+  if (localKind !== 'transfer' && localKind !== 'destination' && localKind !== 'station-passed') return;
+  await cancelPrescheduledByStationKind(stationName, localKind);
+}
+
+/**
+ * 사전 예약된 safety-net/presched 알림이 OS에 의해 발사된 직후, 또는 backend가 보낸 원격
+ * station-notif가 도착한 직후 클라이언트 상태를 갱신하는 단일 진입점.
+ *
+ * - safety-net 발사: FIRED_ALARMS_KEY에 `early:station`/`imminent:station` 둘 다 추가 → FG 복귀 시
+ *   useStationAlarm 하이드레이션 및 후속 silent push 처리가 해당 station을 이미 발화된 것으로
+ *   간주해 중복 발화를 막는다. LAST_FIRED_ALARM_STATION_NAME_KEY도 갱신 → BGAppRefreshTask가
  *   다음 사이클에서 Arrival API를 올바른 기준역으로 호출.
+ * - presched(#918) 발사: fire-time 재검증 통과 시 `recentLocalStationFires`에 마킹 — 뒤늦게
+ *   도착하는 backend push의 표시를 억제하는 기존 2차 방어선(#2122)이 그대로 3-소스 dedup의
+ *   1선으로 승격된다.
+ * - 원격 도착(둘 다 아닌 request, `data.nextWaypoint` 보유): 같은 역의 presched pending을 즉시
+ *   cancel — "역당 배너 정확히 1개"의 남은 방향(remote가 먼저 도착 → 나중에 pending이 또 안 뜨게).
  */
 export async function reconcileScheduledAlarmDelivery(
   request: Notifications.NotificationRequest,
@@ -291,32 +356,49 @@ export async function reconcileScheduledAlarmDelivery(
   await recordFiredAlarm({ identifier: request.identifier, actualFireMs });
 
   const parsed = readSafetyNetData(request);
-  if (!parsed) return;
+  if (parsed) {
+    const result = await revalidateSafetyNetAlarm(parsed);
+    if (result.outcome === 'suppress') {
+      // #1354 — suppress 시 OS scheduled queue에 동일 identifier가 남아 다음 ETA에 또
+      // 발사되어 정적 misfire가 영구 재발한다. 사전 예약은 fire-and-forget이므로 명시 cancel 필요.
+      // cancelScheduledNotificationAsync는 이미 발사된 항목에도 안전.
+      await Notifications.cancelScheduledNotificationAsync(request.identifier);
+      // #1924 — delivered tray에서도 제거. cancelScheduledNotificationAsync는 pending queue만
+      // 대상이라 이미 OS가 자체 fire 한 항목은 delivered tray에 그대로 남는다. 사용자가
+      // swipe-dismiss 하지 않는 한 다음 FG 복귀 drain 시 같은 identifier를 또 read → 같은
+      // reason으로 다시 suppress → alarm log 무한 재적재 (2026-06-27 dump 56회 evidence).
+      await Notifications.dismissNotificationAsync(request.identifier);
+      return;
+    }
 
-  const result = await revalidateSafetyNetAlarm(parsed);
-  if (result.outcome === 'suppress') {
-    // #1354 — suppress 시 OS scheduled queue에 동일 identifier가 남아 다음 ETA에 또
-    // 발사되어 정적 misfire가 영구 재발한다. 사전 예약은 fire-and-forget이므로 명시 cancel 필요.
-    // cancelScheduledNotificationAsync는 이미 발사된 항목에도 안전.
-    await Notifications.cancelScheduledNotificationAsync(request.identifier);
-    // #1924 — delivered tray에서도 제거. cancelScheduledNotificationAsync는 pending queue만
-    // 대상이라 이미 OS가 자체 fire 한 항목은 delivered tray에 그대로 남는다. 사용자가
-    // swipe-dismiss 하지 않는 한 다음 FG 복귀 drain 시 같은 identifier를 또 read → 같은
-    // reason으로 다시 suppress → alarm log 무한 재적재 (2026-06-27 dump 56회 evidence).
-    await Notifications.dismissNotificationAsync(request.identifier);
+    // destinationId가 없으면 이미 trip이 종료/변경된 알람의 잔여 발화 — 상태 갱신 스킵.
+    // setLastFiredAlarmStationName은 trip 종속성이 약하므로 유지한다(다음 사이클 기준역 갱신용).
+    if (result.destinationId) {
+      const fired = await getFiredAlarms(result.destinationId);
+      // early/imminent 둘 다 마킹 — silent push 채널/live GPS 채널과 동일 dedup key 공간 공유(#1367).
+      fired.add(alarmKey({ phaseId: 'early', stationName: parsed.station, occurrenceIdx: parsed.occurrenceIdx }));
+      fired.add(alarmKey({ phaseId: 'imminent', stationName: parsed.station, occurrenceIdx: parsed.occurrenceIdx }));
+      await setFiredAlarms(result.destinationId, fired);
+    }
+    await setLastFiredAlarmStationName(parsed.station);
     return;
   }
 
-  // destinationId가 없으면 이미 trip이 종료/변경된 알람의 잔여 발화 — 상태 갱신 스킵.
-  // setLastFiredAlarmStationName은 trip 종속성이 약하므로 유지한다(다음 사이클 기준역 갱신용).
-  if (result.destinationId) {
-    const fired = await getFiredAlarms(result.destinationId);
-    // early/imminent 둘 다 마킹 — silent push 채널/live GPS 채널과 동일 dedup key 공간 공유(#1367).
-    fired.add(alarmKey({ phaseId: 'early', stationName: parsed.station, occurrenceIdx: parsed.occurrenceIdx }));
-    fired.add(alarmKey({ phaseId: 'imminent', stationName: parsed.station, occurrenceIdx: parsed.occurrenceIdx }));
-    await setFiredAlarms(result.destinationId, fired);
+  const prescheduled = readPrescheduledData(request);
+  if (prescheduled) {
+    const outcome = await revalidatePrescheduledAlarm(prescheduled);
+    if (outcome === 'suppress') {
+      await Notifications.cancelScheduledNotificationAsync(request.identifier);
+      await Notifications.dismissNotificationAsync(request.identifier);
+      return;
+    }
+    await markLocalStationFired(prescheduled.station, prescheduled.kind);
+    return;
   }
-  await setLastFiredAlarmStationName(parsed.station);
+
+  // 위 두 채널 어느 쪽도 아니면 원격(backend) station-notif일 가능성 — 그 역의 presched
+  // pending을 정리한다(BG 방향은 silentPushTask가 동일 역할을 담당).
+  await cancelPrescheduledOnRemoteArrival(request);
 }
 
 /**
@@ -388,6 +470,22 @@ async function drainDeliveredScheduledAlarms(): Promise<void> {
     }
   }
   if (lastStationName) await setLastFiredAlarmStationName(lastStationName);
+
+  // #918 — presched(OS 사전예약 "매역") 항목도 동일 drain 사이클에서 reconcile한다.
+  // fired set/lastStationName 갱신 대상이 아니므로(그건 safety-net 전용 dedup key 공간)
+  // 위 accepted 누적과 독립적으로 처리 — revalidate pass 시 recentLocalStationFires에
+  // 마킹해 뒤늦게 도착하는 backend push의 중복 표시를 억제한다(#2122 2차 방어선 재사용).
+  for (const n of presented) {
+    const parsed = readPrescheduledData(n.request);
+    if (!parsed) continue;
+    const outcome = await revalidatePrescheduledAlarm(parsed);
+    if (outcome === 'suppress') {
+      await Notifications.cancelScheduledNotificationAsync(n.request.identifier);
+      await Notifications.dismissNotificationAsync(n.request.identifier);
+      continue;
+    }
+    await markLocalStationFired(parsed.station, parsed.kind);
+  }
 }
 
 /**

--- a/src/features/alarm/utils/stationNotification.ts
+++ b/src/features/alarm/utils/stationNotification.ts
@@ -124,11 +124,23 @@ async function isFallbackDuplicate(
 }
 
 // #2122 — backend push data.kind('intermediate' 등, backend `Waypoint.kind`)를
-// 로컬 dispatchStationPassed의 AlarmLogKind('station-passed')로 매핑. FG 보조 발사는
-// station-passed(=intermediate) 카테고리 한정이라 매핑 테이블도 그 범위만 갖는다.
+// 로컬 dispatchStationPassed의 AlarmLogKind('station-passed')로 매핑.
+// #918 — OS 사전예약(stationPrescheduler)이 transfer/destination kind도 커버하게 되면서
+// 매핑도 identity 항목 2개를 추가(로컬 kind 이름이 backend kind 이름과 동일).
 const BACKEND_PUSH_KIND_TO_LOCAL_FIRE_KIND: Record<string, string> = {
   intermediate: 'station-passed',
+  transfer: 'transfer',
+  destination: 'destination',
 };
+
+/**
+ * backend push의 `data.kind`를 device local fire kind로 매핑. `scheduledAlarmReceiver`(#918)가
+ * "remote 선표시 시 해당 역 pending 사전예약 cancel" 판정에 재사용 — 매핑 테이블의 단일 owner.
+ * 매핑이 없는 kind(예: 'reschedule'/'trip-ended' 등 비-station 계열)는 null.
+ */
+export function mapBackendKindToLocalFireKind(backendKind: string): string | null {
+  return BACKEND_PUSH_KIND_TO_LOCAL_FIRE_KIND[backendKind] ?? null;
+}
 
 /**
  * backend alert push의 data.nextWaypoint(station name) + data.kind가, 이 device가 방금 로컬로
@@ -145,7 +157,7 @@ async function isRecentLocalAuxFireDuplicate(
   const backendKind = data?.kind;
   if (typeof stationName !== 'string' || stationName.length === 0) return false;
   if (typeof backendKind !== 'string') return false;
-  const localKind = BACKEND_PUSH_KIND_TO_LOCAL_FIRE_KIND[backendKind];
+  const localKind = mapBackendKindToLocalFireKind(backendKind);
   if (!localKind) return false;
   return hasRecentLocalStationFire(stationName, localKind);
 }
@@ -554,6 +566,20 @@ export async function clearAlarmNotification(): Promise<void> {
 }
 
 /**
+ * #918 — "역 통과" 알림 title/body 빌더. #2122 FG 보조 발사(`fireFgAuxStationPassedNotification`)와
+ * `stationPrescheduler`(#918 OS 사전예약, station-passed kind)가 동일 카피를 공유한다 —
+ * 발사 채널(FG 즉시 발사 vs OS 사전 예약)이 달라도 사용자가 보는 문구는 항상 같아야 한다.
+ */
+export function buildStationPassedContent(stationName: string): { title: string; body: string } {
+  return {
+    title: i18next.t('route.intermediatePassedTitle'),
+    body: i18next.t('route.intermediatePassedBody', {
+      name: getStationDisplayNameByName(stationName, allStations),
+    }),
+  };
+}
+
+/**
  * #2122 (FG 보조 발사) — FG 상태에서 backend alert push의 APNs 전달 지연(실측 35~51s)을
  * 디바이스 자체 arvlcd 판정으로 우회하는 로컬 station-passed 배너.
  *
@@ -569,12 +595,7 @@ export async function fireFgAuxStationPassedNotification(stationName: string): P
   const deviceToken = await AsyncStorage.getItem(APNS_TOKEN_KEY);
   if (!deviceToken) return;
   const identifier = buildStationNotifCollapseId(deviceToken);
-  await scheduleNotification(identifier, {
-    title: i18next.t('route.intermediatePassedTitle'),
-    body: i18next.t('route.intermediatePassedBody', {
-      name: getStationDisplayNameByName(stationName, allStations),
-    }),
-    sound: false,
-  });
+  const { title, body } = buildStationPassedContent(stationName);
+  await scheduleNotification(identifier, { title, body, sound: false });
   await markLocalStationFired(stationName, 'station-passed');
 }

--- a/src/features/alarm/utils/stationPrescheduler.ts
+++ b/src/features/alarm/utils/stationPrescheduler.ts
@@ -1,0 +1,388 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: 본 모듈은 hop time 산출을 위해 features/route의 hopTime.ts를
+ * 직접 호출한다(#655/#779 실측 hop 테이블 재사용, 신규 ETA 추정기 금지 원칙). `scheduledAlarmReceiver.ts`가
+ * routeToWaypoints를 동일한 이유로 직접 import하는 것과 같은 선례. 후속 PR에서 hopTime을
+ * src/shared/utils/로 추출하거나 orchestration 슬라이스로 이전 예정.
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+/**
+ * stationPrescheduler (#918) — OS-level 사전 예약을 "매역"으로 일반화한 2번째 안전망 채널.
+ *
+ * `safetyNetScheduler`(#2089)가 sleepMode ON trip에 한해 transfer/destination waypoint에만
+ * 예약하는 것과 대칭으로, 본 모듈은 **sleepMode OFF**(일반 모드) + **boardingLock 활성** trip에
+ * 한해 경로 위 **모든 역**(환승/도착 포함)에 예약한다. 목적은 다르다 — safetyNetScheduler는
+ * "backend가 완전히 죽었을 때의 최후 안전망"이고, 본 모듈은 "BG/화면꺼짐에서 APNs 전달 지연
+ * (실측 35~51s, 2026-08-03 트립)을 OS가 대신 메꾸는 근본 수리"다.
+ *
+ * 정책은 호출자(`useStationPrescheduler` 훅, `silentPushTask`) 책임 — 본 모듈은 순수
+ * 예약/취소/재예약 메커니즘만 제공한다(safetyNetScheduler와 동일 원칙).
+ *
+ * **3-소스 identifier 판정** (이슈 #918 "스펙 정정 2026-08-03 2차" — collapse-id 문자열을 그대로
+ * pending identifier로 쓰면 `scheduleNotificationAsync`의 same-identifier 교체 규칙 때문에
+ * rolling window(앞 12역)가 pending 1개로 붕괴한다는 결함이 조사에서 확인됨):
+ *   - pending identifier = 역별 고유 (`safetyNetScheduler`와 동일 접두 패턴).
+ *   - collapse-id 문자열(#2122 `buildStationNotifCollapseId`)은 `content.data.collapseId`에만
+ *     동봉 — 실제 OS collapsing 대신 앱 레벨 dedup(`recentLocalStationFires`)이 3-소스 멱등을
+ *     맡는다. FG는 `scheduledAlarmReceiver`의 알림 수신 리스너가 원격 도착 시 pending 취소를,
+ *     BG는 `silentPushTask`가 wake 시점에 pending 취소 + delivered 제거 + markLocalStationFired를
+ *     수행한다 — 정착 상태(다음 wake 이후) 기준으로 "역당 배너 정확히 1개"를 보장한다. BG에서
+ *     사전예약 발사 후 backend push 도착까지 수 초~수십 초 공존은 허용 잔여(문서화, PR 참고).
+ *
+ * **rolling window / 64한도**: `safetyNetScheduler`는 sleepMode ON에서만, 본 모듈은 sleepMode
+ * OFF에서만 armed — 한 trip에서 두 채널이 동시에 예약되는 경우가 구조적으로 없으므로 cap을
+ * 합산할 필요가 없다(각자 `PRESCHEDULED_STATION_WINDOW_SIZE`/`SAFETY_NET_MAX_WAYPOINTS`로
+ * 독립 방어). 매 재계산(hop 진행 시)마다 이전 예약을 전량 cancel 후 앞 12역을 다시 예약한다.
+ */
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { Station, LineNumber } from '../../../shared/types/station';
+import { buildAlarmContent, buildStationPassedContent } from './stationNotification';
+import { buildStationNotifCollapseId } from './stationNotifCollapseId';
+import { cancelIdentifiersWithRetry } from './safetyNetScheduler';
+import { hopTimeMsAt } from '../../route/utils/hopTime';
+import { PRESCHEDULED_STATION_WINDOW_SIZE } from '../../../shared/constants/iosScheduledLimit';
+import { APNS_TOKEN_KEY } from '../../../shared/constants/storageKeys';
+import { createLogger } from '../../../shared/utils/logger';
+import { recordScheduledAlarm } from './prescheduledMetrics';
+import { logScheduledPrescheduledAlarm } from './alarmLog';
+import type { AlarmEvent } from '../../../shared/types/alarm';
+
+const logger = createLogger('StationPrescheduler');
+
+/** OS 예약 identifier 접두 — `presched-<tripToken.slice(0,16)>-<station>-<kind>#<occurrence>`. */
+export const PRESCHED_ALARM_PREFIX = 'presched-';
+
+/** Android channel — 기존 station-alarm 채널 재사용(safetyNetScheduler와 동일 정책). */
+const ALARM_CHANNEL_ID = 'station-alarm';
+const INTERRUPTION_LEVEL = 'timeSensitive';
+
+/**
+ * 역별 알림 종류. 경로의 마지막 역은 'destination', line이 바뀌는 경계 역은 'transfer',
+ * 그 외 모든 중간역은 'station-passed'. `arcStations`의 인덱스 구조만으로 결정되므로
+ * 노선/역명 하드코딩이 없다(데이터 주도).
+ */
+export type PrescheduledKind = 'transfer' | 'destination' | 'station-passed';
+
+export interface PrescheduledNotificationData {
+  channel: 'presched-station';
+  tripToken: string;
+  station: string;
+  kind: PrescheduledKind;
+  occurrenceIdx: number;
+  /** #2122 규칙 재사용 — 실제 OS collapsing 용도가 아니라 관측/향후 확장용 메타데이터. */
+  collapseId?: string;
+}
+
+/** `arcStations[idx]`의 알림 종류를 arc 구조만으로 판정. */
+function kindForArcIndex(arcStations: readonly Station[], idx: number): PrescheduledKind {
+  if (idx === arcStations.length - 1) return 'destination';
+  if (arcStations[idx].line !== arcStations[idx + 1].line) return 'transfer';
+  return 'station-passed';
+}
+
+interface RawWaypoint {
+  stationName: string;
+  kind: PrescheduledKind;
+  fireMs: number;
+}
+
+interface WaypointWithOccurrence extends RawWaypoint {
+  occurrenceIdx: number;
+}
+
+/** #1193과 동일 패턴 — (kind, stationName) 조합별 0-based 등장 순서. */
+function withOccurrenceIndices(waypoints: readonly RawWaypoint[]): WaypointWithOccurrence[] {
+  const seen = new Map<string, number>();
+  return waypoints.map((wp) => {
+    const key = `${wp.kind}:${wp.stationName}`;
+    const occurrenceIdx = seen.get(key) ?? 0;
+    seen.set(key, occurrenceIdx + 1);
+    return { ...wp, occurrenceIdx };
+  });
+}
+
+function buildIdentifier(
+  tripToken: string,
+  station: string,
+  kind: PrescheduledKind,
+  occurrenceIdx: number,
+): string {
+  const base = `${PRESCHED_ALARM_PREFIX}${tripToken.slice(0, 16)}-${station}-${kind}`;
+  return occurrenceIdx > 0 ? `${base}#${occurrenceIdx}` : base;
+}
+
+/**
+ * `arcStations[currentIdx]`(현재 위치, 실시간 lock trainCode 판정 결과)를 앵커로 다음
+ * `PRESCHEDULED_STATION_WINDOW_SIZE`역까지 hop time을 누적해 예상 도착 시각을 산출한다.
+ * `hopTimeMsAt`(#655/#779 실측 hop 테이블)을 그대로 재사용 — 신규 ETA 추정기 없음.
+ */
+function deriveUpcomingWaypoints(
+  arcStations: readonly Station[],
+  currentIdx: number,
+  nowMs: number,
+): RawWaypoint[] {
+  if (currentIdx < 0 || currentIdx >= arcStations.length - 1) return [];
+  const endIdx = Math.min(currentIdx + PRESCHEDULED_STATION_WINDOW_SIZE, arcStations.length - 1);
+  const waypoints: RawWaypoint[] = [];
+  let cumulativeMs = nowMs;
+  for (let i = currentIdx; i < endIdx; i++) {
+    cumulativeMs += hopTimeMsAt(arcStations, i, arcStations[i].line as LineNumber);
+    const targetIdx = i + 1;
+    waypoints.push({
+      stationName: arcStations[targetIdx].name,
+      kind: kindForArcIndex(arcStations, targetIdx),
+      fireMs: cumulativeMs,
+    });
+  }
+  return waypoints;
+}
+
+async function resolveCollapseId(): Promise<string | undefined> {
+  const deviceToken = await AsyncStorage.getItem(APNS_TOKEN_KEY);
+  return deviceToken ? buildStationNotifCollapseId(deviceToken) : undefined;
+}
+
+async function scheduleOne(params: {
+  identifier: string;
+  tripToken: string;
+  stationName: string;
+  kind: PrescheduledKind;
+  occurrenceIdx: number;
+  fireMs: number;
+  collapseId: string | undefined;
+}): Promise<void> {
+  const { identifier, tripToken, stationName, kind, occurrenceIdx, fireMs, collapseId } = params;
+  const isAlarmKind = kind === 'transfer' || kind === 'destination';
+  const { title, body } = isAlarmKind
+    ? buildAlarmContent({ phaseId: 'imminent', type: kind, stationName } as AlarmEvent)
+    : buildStationPassedContent(stationName);
+  const data: PrescheduledNotificationData = {
+    channel: 'presched-station',
+    tripToken,
+    station: stationName,
+    kind,
+    occurrenceIdx,
+    collapseId,
+  };
+  await Notifications.scheduleNotificationAsync({
+    identifier,
+    content: {
+      title,
+      body,
+      data: data as unknown as Record<string, unknown>,
+      sound: isAlarmKind ? 'alarm.wav' : false,
+      ...(Platform.OS === 'android' && {
+        channelId: ALARM_CHANNEL_ID,
+        priority: Notifications.AndroidNotificationPriority.MAX,
+      }),
+      ...(Platform.OS === 'ios' && isAlarmKind && { interruptionLevel: INTERRUPTION_LEVEL }),
+    },
+    trigger: { type: Notifications.SchedulableTriggerInputTypes.DATE, date: new Date(fireMs) },
+  });
+  await recordScheduledAlarm({ identifier, scheduledFireMs: fireMs, stationName });
+  logScheduledPrescheduledAlarm({ stationName, kind });
+}
+
+export interface RegisterPrescheduledParams {
+  tripToken: string;
+  /** boarding → destination 순서의 ordered station 시퀀스 (`useFusedNearestStation.arcStations`). */
+  arcStations: readonly Station[];
+  /** arcStations 내 현재 위치 인덱스(실시간 lock trainCode 판정, `currentHopIndex`). */
+  currentIdx: number;
+  now?: number;
+}
+
+export interface RegisterPrescheduledResult {
+  scheduled: number;
+}
+
+export async function registerPrescheduledStationAlarms(
+  params: RegisterPrescheduledParams,
+): Promise<RegisterPrescheduledResult> {
+  const { tripToken, arcStations, currentIdx } = params;
+  const nowMs = params.now ?? Date.now();
+  const waypoints = withOccurrenceIndices(deriveUpcomingWaypoints(arcStations, currentIdx, nowMs));
+  if (waypoints.length === 0) return { scheduled: 0 };
+
+  const collapseId = await resolveCollapseId();
+  let scheduled = 0;
+  for (const wp of waypoints) {
+    if (wp.fireMs <= nowMs) continue;
+    const identifier = buildIdentifier(tripToken, wp.stationName, wp.kind, wp.occurrenceIdx);
+    await scheduleOne({
+      identifier,
+      tripToken,
+      stationName: wp.stationName,
+      kind: wp.kind,
+      occurrenceIdx: wp.occurrenceIdx,
+      fireMs: wp.fireMs,
+      collapseId,
+    });
+    scheduled++;
+  }
+  logger.info(
+    `registered ${scheduled}/${waypoints.length} prescheduled station alarms tripToken=${tripToken.slice(0, 8)}`,
+  );
+  return { scheduled };
+}
+
+/** trip 종료 시 호출 — `tripToken`의 모든 사전예약을 pending queue + delivered tray에서 제거. */
+export async function cancelAllPrescheduledAlarms(tripToken: string): Promise<void> {
+  const prefix = `${PRESCHED_ALARM_PREFIX}${tripToken.slice(0, 16)}-`;
+  const all = await Notifications.getAllScheduledNotificationsAsync();
+  const targets = all.filter((req) => req.identifier.startsWith(prefix));
+  const cancelled = await cancelIdentifiersWithRetry(targets.map((req) => req.identifier));
+
+  let dismissedCount = 0;
+  try {
+    const presented = await Notifications.getPresentedNotificationsAsync();
+    const delivered = presented.filter((n) => n.request.identifier.startsWith(prefix));
+    if (delivered.length > 0) {
+      const results = await Promise.allSettled(
+        delivered.map((n) => Notifications.dismissNotificationAsync(n.request.identifier)),
+      );
+      for (const r of results) {
+        if (r.status === 'fulfilled') dismissedCount++;
+      }
+    }
+  } catch (e) {
+    logger.warn(`cancelAllPrescheduledAlarms: delivered tray 조회 실패, pending cancel만 적용: ${e}`);
+  }
+
+  if (cancelled > 0 || dismissedCount > 0) {
+    logger.info(`cancelled ${cancelled} pending + dismissed ${dismissedCount} prescheduled alarms`);
+  }
+}
+
+/**
+ * OS 알림 request에서 사전예약 메타데이터를 안전하게 추출.
+ * `scheduledAlarmReceiver`(fire-time revalidation) + `stationNotification`(원격 도착 시
+ * pending 취소)이 재사용한다.
+ */
+export function readPrescheduledData(
+  req: Notifications.NotificationRequest,
+): PrescheduledNotificationData | null {
+  if (!req.identifier.startsWith(PRESCHED_ALARM_PREFIX)) return null;
+  const data = req.content.data as Partial<PrescheduledNotificationData> | null | undefined;
+  if (!data || data.channel !== 'presched-station') return null;
+  if (typeof data.station !== 'string' || typeof data.tripToken !== 'string') return null;
+  if (data.kind !== 'transfer' && data.kind !== 'destination' && data.kind !== 'station-passed') {
+    return null;
+  }
+  const occurrenceIdx = typeof data.occurrenceIdx === 'number' ? data.occurrenceIdx : 0;
+  return {
+    channel: 'presched-station',
+    tripToken: data.tripToken,
+    station: data.station,
+    kind: data.kind,
+    occurrenceIdx,
+  };
+}
+
+/**
+ * 3-소스 dedup — 같은 (station, kind)의 사전예약 pending을 전부 취소한다.
+ *
+ * 호출자:
+ *  - FG: `scheduledAlarmReceiver`가 원격(backend) station-notif 도착을 감지하면 즉시 호출
+ *    ("remote 선표시 → 해당 역 pending 로컬 cancel").
+ *  - BG: `silentPushTask`가 backend push wake 시점에 호출.
+ *
+ * occurrence는 무관하게 전부 취소 — 같은 (station, kind)가 route에 중복 등장해도(순환 노선)
+ * backend push 시점엔 이미 그 역을 지나는 순간이므로 어느 occurrence든 유효기간이 끝난다.
+ */
+export async function cancelPrescheduledByStationKind(
+  stationName: string,
+  kind: PrescheduledKind,
+): Promise<void> {
+  const all = await Notifications.getAllScheduledNotificationsAsync();
+  const targets = all.filter((req) => {
+    const data = readPrescheduledData(req);
+    return data !== null && data.kind === kind && data.station === stationName;
+  });
+  if (targets.length === 0) return;
+  const cancelled = await cancelIdentifiersWithRetry(targets.map((req) => req.identifier));
+  if (cancelled > 0) {
+    logger.info(`cancelled ${cancelled} prescheduled alarms (remote arrival) station=${stationName} kind=${kind}`);
+  }
+}
+
+export interface ReschedulePrescheduledParams {
+  tripToken: string;
+  stationName: string;
+  /**
+   * #1193과 동일 — 같은 stationName이 route에 중복 등장하는 경우 정정 대상 occurrence(0-based).
+   * 미지정 시 0(첫 등장). backend reschedule payload는 kind를 보내지 않으므로(#725 스키마),
+   * 매칭된 기존 pending entry의 `content.data.kind`를 그대로 재사용한다 — route 재파생 불필요.
+   */
+  occurrenceIdx?: number;
+  /** 새 도착 시각(ms epoch). */
+  newArrivalMs: number;
+  now?: number;
+}
+
+export interface ReschedulePrescheduledResult {
+  cancelled: number;
+  scheduled: number;
+}
+
+/**
+ * backend reschedule push(`kind: 'reschedule'`) 수신 시 호출 — 해당 역의 기존 사전예약을
+ * cancel하고 `newArrivalMs`로 재예약한다.
+ *
+ * safetyNetScheduler의 reschedule과 동일 원칙(#2089 리뷰 P1-1) — 이미 armed된 예약이 없으면
+ * (예: sleepMode가 그 사이 켜져 애초에 등록되지 않았거나, 이미 지나간 역) 신규 예약을 만들지
+ * 않고 cancel-only(no-op)로 끝낸다. 매 역의 hop time을 다시 파생할 필요 없이, backend가 이미
+ * 계산해 보낸 단일 역의 정정 시각을 그대로 반영한다 — 신규 ETA 추정기 없음.
+ */
+export async function reschedulePrescheduledAlarm(
+  params: ReschedulePrescheduledParams,
+): Promise<ReschedulePrescheduledResult> {
+  const { tripToken, stationName, newArrivalMs } = params;
+  const occurrenceIdx = params.occurrenceIdx ?? 0;
+  const nowMs = params.now ?? Date.now();
+
+  const all = await Notifications.getAllScheduledNotificationsAsync();
+  let matchedKind: PrescheduledKind | null = null;
+  let matchedIdentifier: string | null = null;
+  for (const req of all) {
+    const data = readPrescheduledData(req);
+    if (
+      data !== null &&
+      data.tripToken === tripToken &&
+      data.occurrenceIdx === occurrenceIdx &&
+      data.station === stationName
+    ) {
+      matchedKind = data.kind;
+      matchedIdentifier = req.identifier;
+      break;
+    }
+  }
+  if (matchedKind === null || matchedIdentifier === null) {
+    logger.info(`reschedule cancel-only: no existing schedule for station=${stationName} occurrence=${occurrenceIdx}`);
+    return { cancelled: 0, scheduled: 0 };
+  }
+  const kind = matchedKind;
+  const cancelled = await cancelIdentifiersWithRetry([matchedIdentifier]);
+
+  if (newArrivalMs <= nowMs) {
+    logger.info(`reschedule cancel-only: newArrivalMs=${newArrivalMs} <= now=${nowMs}`);
+    return { cancelled, scheduled: 0 };
+  }
+
+  const collapseId = await resolveCollapseId();
+  const identifier = buildIdentifier(tripToken, stationName, kind, occurrenceIdx);
+  await scheduleOne({
+    identifier,
+    tripToken,
+    stationName,
+    kind,
+    occurrenceIdx,
+    fireMs: newArrivalMs,
+    collapseId,
+  });
+  logger.info(
+    `reschedule done: station=${stationName} occurrence=${occurrenceIdx} cancelled=${cancelled} scheduled=1 newArrivalMs=${newArrivalMs}`,
+  );
+  return { cancelled, scheduled: 1 };
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -60,6 +60,7 @@ import { useSilentPushHealthCheck } from '../features/alarm/hooks/useSilentPushH
 import { useArrivalAutoClear } from '../features/arrival/hooks/useArrivalAutoClear';
 import { useBoardingLockController } from '../features/alarm/hooks/useBoardingLockController';
 import { useSafetyNetScheduler } from '../features/alarm/hooks/useSafetyNetScheduler';
+import { useStationPrescheduler } from '../features/alarm/hooks/useStationPrescheduler';
 import { useBoardingLockAutoRelease } from '../features/alarm/hooks/useBoardingLockAutoRelease';
 import { useDestinationAutoClear } from '../features/alarm/hooks/useDestinationAutoClear';
 import { useDeviceSelfEnd } from '../features/alarm/hooks/useDeviceSelfEnd';
@@ -702,6 +703,15 @@ export default function HomeScreen() {
   useSafetyNetScheduler({
     route,
     destinationName: destination?.name ?? null,
+  });
+  // #918 — OS-level 사전 예약 "매역" 일반화. boardingLock 활성 + sleepMode OFF인 trip에 한해
+  // 경로 위 모든 역(환승/도착 포함)에 앞 12역 rolling window로 예약한다. safetyNetScheduler와
+  // sleepMode로 상호 배타 — 취침모드는 안전망(1역 전 경보)이, 일반 모드는 본 채널(매역, backend
+  // APNs 지연 근본 수리)이 담당한다.
+  useStationPrescheduler({
+    arcStations,
+    currentHopIndex,
+    lock: boardingLock,
   });
   // #759 — 목적지역 도착 grace 후 lock 자동 release. 명시 "하차" 버튼은 그대로 유지하며,
   // 사용자가 누르지 않은 정상 도착 케이스만 처리. sleep mode와 무관.

--- a/src/shared/constants/iosScheduledLimit.ts
+++ b/src/shared/constants/iosScheduledLimit.ts
@@ -26,3 +26,15 @@ export const IOS_NOTIFICATION_USABLE_QUOTA = IOS_NOTIFICATION_HARD_LIMIT - IOS_N
  * 구조적으로 보장한다.
  */
 export const SAFETY_NET_MAX_WAYPOINTS = IOS_NOTIFICATION_USABLE_QUOTA;
+
+/**
+ * `stationPrescheduler`(#918) rolling window 크기 — 앞 12역만 OS에 사전 예약하고
+ * silent push 수신/FG 복귀마다 재충전한다("결정 evolve" 2026-08-03 6항).
+ *
+ * `safetyNetScheduler`(sleepMode 전용)와 `stationPrescheduler`(sleepMode OFF 전용)는
+ * 정책상 상호 배타적으로만 armed되므로(한 trip에서 동시에 두 채널이 다 예약되는 경우가
+ * 없음) 두 cap을 합산할 필요가 없다 — 각자 독립적으로 IOS_NOTIFICATION_USABLE_QUOTA
+ * 이내로만 방어하면 충분하다. 12는 서울 지하철 최장 구간(9호선 급행 등)에서도 backend
+ * outage 대비 buffer로 충분한 값이며 다환승 trip에서도 64 한도에 여유 있게 못 미친다.
+ */
+export const PRESCHEDULED_STATION_WINDOW_SIZE = 12;


### PR DESCRIPTION
## Summary
- APNs 전달 지연 실측(35~51초) 근본 수리 — BG/화면꺼짐 구간에서 OS-level 사전 예약으로 backend push 지연을 device 자체가 메꾼다.
- 트리거 = boardingLock 활성(사용자 명시 의향) + sleepMode OFF. lockless trip은 사전예약하지 않는다(2026-08-03 evolve 1항, 자동 lock 의존 삭제 원칙 유지).
- `stationPrescheduler`(신규): 경로 위 모든 역(환승/도착 포함)에 앞 12역 rolling window로 예약. `hopTimeMsAt`(#655/#779 실측 hop 테이블) 재사용, 신규 ETA 추정기 없음. identifier는 역별 고유(`presched-<tripToken16>-<station>-<kind>#<occurrence>`) — collapse-id 문자열을 그대로 재사용하면 rolling window가 pending 1개로 붕괴하는 결함을 회피(2026-08-03 스펙 정정 2차).
- `useStationPrescheduler`(신규): boardingLock/currentHopIndex/sleepMode 게이트 + hop 진행마다 cancel-all 후 재예약(rolling window 재충전). `useSafetyNetScheduler`와 대칭 정책, in-flight 토큰 가드로 stale 응답 무시.
- `scheduledAlarmReceiver`: presched 알람 fire-time 3단 재검증(sleepMode/tripStart/tripToken) + backend 원격 station-notif 도착 시 같은 역 presched pending을 즉시 cancel(3-소스 dedup 1선 방어, #2122 2차 방어선을 1선으로 승격).
- 3-소스(backend visible push / FG 보조 발사(#2122) / 본 OS 사전예약) dedup은 발사/표시 계층에서 처리 — FG는 willPresent 핸들러 양방향 억제, BG는 silentPushTask wake 시점에 정리.

## Test plan
- [x] `npm test` — 424 suites / 9009 tests 전체 pass, coverage 100%(lines/branches/functions/statements)
- [x] `npm run type-check` — clean
- [x] `npm run lint:orphan` — 0 orphan
- [x] 신규 파일 `stationPrescheduler.ts`(103→100%), `useStationPrescheduler.ts`(0→100%), `scheduledAlarmReceiver.ts` 신규 분기 100% 커버리지 확보

### Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass. `useStationPrescheduler`는 `useFusedNearestStation`/HomeScreen 경로에서 이미 마운트되어 caller 존재.
2. **V/X dashboard** — DebugModal `Scheduled queue` 섹션에서 presched pending 목록 확인 가능. `alarmLog`에 예약/발사/재검증-억제 스탬프 기록 → wrangler tail/Cloudflare Dashboard에서 상관 이벤트 확인.
3. **의존 PR** — #2122(FG 보조 발사, collapse-id helper 재사용) 선행 머지 완료.
4. **측정 plan** — 1주 내 실기기 trip에서 alarmLog `bg-scheduled` 소스 스탬프 빈도 + BG 발사/backend push 공존 구간 길이 관찰.
5. **Device verify** — 비행기모드 구간에서 정시 발사 확인, backend push + FG 보조 발사 + 사전예약 3소스 동시 활성 상태에서 역당 배너 정확히 1개(정착 상태 기준, 일시 공존은 허용 잔여) 확인.

Closes #918