### PR TITLE
fix(#2129): backend rotation 동시성 — 동일 token 동시 register 시 trip 이중 생존 차단

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -4274,6 +4274,27 @@ describe('POST /trips — #2019 rotateTripTokenForNewRoute wire (ADR-022 B4)', (
       const body2 = (await res2.json()) as { token: string };
       expect(body2.token).not.toBe(TOKEN);
     });
+
+    // #2129 — 2026-08-04 실탑승 evidence: 같은 device token으로 거의 동시에 도착한
+    // POST /trips 2건(waypoints 다름)이 getTrip → rotate → putTrip TOCTOU window에서
+    // interleave해 유령 trip 2개(원본 token + rotated UUID)가 모두 KV에 생존했다.
+    // withTripRegisterLock이 같은 token의 register 처리를 직렬화해 이 race를 차단한다.
+    it('#2129 동시 register 2건(같은 token, 다른 waypoints) → KV 활성 trip 정확히 1개', async () => {
+      const env = makeKvEnv();
+      await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
+      const bodyA = tripBodyFor('용마산-id', '용마산');
+      const bodyB = tripBodyFor('성수-id', '성수');
+      const [resA, resB] = await Promise.all([
+        post('/trips', bodyA, env),
+        post('/trips', bodyB, env),
+      ]);
+      expect(resA.status).toBe(200);
+      expect(resB.status).toBe(200);
+      const allTripKeys = (await env.TRIPS.list({ prefix: 'trip:' })).keys;
+      // 두 요청 모두 성공 응답을 받아도, 직렬화 덕분에 KV에는 활성 trip이 정확히 1개만 남는다
+      // (원본 TOKEN 재사용이든 rotation으로 발급된 새 UUID든 — 유령 trip 2개 생존이 회귀).
+      expect(allTripKeys.length).toBe(1);
+    });
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/trips.test.ts
+++ b/backend/alarm-worker/src/__tests__/trips.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ARCH_FLAG_KV_KEY } from '../archFlag';
 import {
+  __resetTripRegisterLocksForTest,
   cleanupPendingPushesForToken,
   clearStaleBoardingLock,
   computeRouteSignature,
@@ -10,6 +11,7 @@ import {
   putTrip,
   rotateTripTokenForNewRoute,
   tripKey,
+  withTripRegisterLock,
 } from '../trips';
 import { pendingKey, putPending, type PendingPush } from '../pendingPushes';
 import type { Trip } from '../types';
@@ -556,5 +558,91 @@ describe('trips KV CRUD', () => {
         expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).toBeNull();
       });
     });
+  });
+});
+
+// #2129 — per-token in-flight 직렬화. 2026-08-04 실탑승 evidence: 같은 device token으로
+// 거의 동시에 도착한 POST /trips 2건이 getTrip → rotate → putTrip TOCTOU window에서 interleave해
+// 유령 trip 2개(원본 token + rotated UUID)가 모두 KV에 생존했다. withTripRegisterLock은 같은
+// token의 register 처리를 큐로 직렬화해 두 번째 요청이 첫 번째 요청의 read-rotate-write 사이클이
+// 완전히 끝난 뒤에만 시작하도록 보장한다.
+describe('withTripRegisterLock (#2129)', () => {
+  beforeEach(() => {
+    __resetTripRegisterLocksForTest();
+  });
+
+  it('같은 token의 두 번째 호출은 첫 번째 fn이 settle된 뒤에만 시작된다', async () => {
+    const order: string[] = [];
+    let resolveFirst: () => void = () => {};
+    const firstGate = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+
+    const p1 = withTripRegisterLock('tok-race', async () => {
+      order.push('first-start');
+      await firstGate;
+      order.push('first-end');
+      return 'A';
+    });
+    const p2 = withTripRegisterLock('tok-race', async () => {
+      order.push('second-start');
+      return 'B';
+    });
+
+    // microtask 몇 tick을 흘려보내도 first가 아직 안 끝났으면 second는 시작하면 안 된다.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(order).toEqual(['first-start']);
+
+    resolveFirst();
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(order).toEqual(['first-start', 'first-end', 'second-start']);
+    expect(r1).toBe('A');
+    expect(r2).toBe('B');
+  });
+
+  it('다른 token은 서로 대기하지 않고 병렬 실행된다', async () => {
+    const order: string[] = [];
+    const [rA, rB] = await Promise.all([
+      withTripRegisterLock('tok-a', async () => {
+        order.push('a');
+        return 1;
+      }),
+      withTripRegisterLock('tok-b', async () => {
+        order.push('b');
+        return 2;
+      }),
+    ]);
+    expect(order.sort()).toEqual(['a', 'b']);
+    expect(rA).toBe(1);
+    expect(rB).toBe(2);
+  });
+
+  it('첫 fn이 reject해도 큐는 끊기지 않고 두 번째 fn이 정상 실행된다', async () => {
+    const order: string[] = [];
+    const p1 = withTripRegisterLock('tok-reject', async () => {
+      order.push('first');
+      throw new Error('boom');
+    });
+    const p2 = withTripRegisterLock('tok-reject', async () => {
+      order.push('second');
+      return 'ok';
+    });
+    await expect(p1).rejects.toThrow('boom');
+    await expect(p2).resolves.toBe('ok');
+    expect(order).toEqual(['first', 'second']);
+  });
+
+  it('큐 소진 후 같은 token을 재사용해도 Map 누적 없이 다시 즉시 실행된다', async () => {
+    await withTripRegisterLock('tok-cleanup', async () => 'first');
+    // 첫 체인이 settle + cleanup(microtask)까지 흘러가도록 tick 확보.
+    await Promise.resolve();
+    await Promise.resolve();
+    const order: string[] = [];
+    await withTripRegisterLock('tok-cleanup', async () => {
+      order.push('reused');
+    });
+    expect(order).toEqual(['reused']);
   });
 });

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -121,7 +121,7 @@ import {
   readObservabilityMetrics,
   tryStoreObservabilityMetrics,
 } from './observabilityMetrics';
-import { getTrip, putTrip, rotateTripTokenForNewRoute } from './trips';
+import { getTrip, putTrip, rotateTripTokenForNewRoute, withTripRegisterLock } from './trips';
 import { inferWaypointsFromOriginAndDestination } from './dijkstraRoute';
 import { checkTripRegisterRateLimit } from './tripRegisterRateLimit';
 import {
@@ -703,146 +703,159 @@ app.post('/trips', async (c) => {
     }
   }
 
-  const rawExisting = await getTrip(c.env.TRIPS, incoming.token);
+  // #2129 — per-token in-flight 직렬화. `getTrip → rotateTripTokenForNewRoute → putTrip` 사이
+  // TOCTOU window에서 같은 token의 동시 POST가 interleave하면 유령 trip 2개(원본 token +
+  // rotated UUID)가 모두 KV에 생존하는 회귀(2026-08-04 실탑승 evidence)가 발생한다. 이 구간
+  // 전체를 원본 incoming token 기준으로 직렬화 — rotation이 token을 바꿔도 lock key는 요청
+  // 도착 시점의 원본 token으로 고정해 같은 device의 두 요청이 반드시 같은 큐에서 대기한다.
+  const registerLockToken = incoming.token;
+  const { trip, isSameSession } = await withTripRegisterLock(
+    registerLockToken,
+    async () => {
+      const rawExisting = await getTrip(c.env.TRIPS, incoming.token);
 
-  // ADR-022 B4 (#2019 wire, #1986 rotation helper) — 새 route 감지 시 token rotation.
-  //
-  // archFlag=on + existing 있음 + route sig 다름 → 새 UUID 발급 + `trip:<oldToken>` delete +
-  // `pending:*` 중 oldToken 소유 entry cleanup (helper 내부 로직).
-  //
-  // archFlag=off (default): helper 는 `{ token: incoming.token, rotated: false }` no-op 반환
-  // → 기존 동작 100% 유지 (Phase 1-3 dormant).
-  //
-  // rotated=true 케이스 처리:
-  //   - `existing = null` 로 강등해 downstream `isSameSession=false` + progress skip 경로 진입
-  //     (helper 가 이미 `trip:<oldToken>` 을 delete 했으므로 same-session merge 는 무의미).
-  //   - `incoming.token` 을 새 UUID 로 갱신 → 후속 `putTrip` 이 `trip:<newToken>` 키로 쓴다.
-  //   - progress/SSoT KV(oldToken 키) 는 TTL 로 자연 만료 — 후속 cron push 는 새 token trip
-  //     기준 waypoints/destination 을 참조하므로 사용자에게 이전 목적지 push 재발사 없음.
-  //
-  // 오늘 evidence(2026-07-03): 사용자 중곡→성수 trip 시작 시 이전 trip(중곡→용마산) 잔재
-  // pending push 가 계속 발사돼 `08:37:25 bg fired station-passed 성수` 관측. rotation 이
-  // helper 의 `cleanupPendingPushesForToken` 을 실제 호출해 잔재 pending 제거.
-  const rotation = await rotateTripTokenForNewRoute(
-    c.env.TRIPS,
-    incoming,
-    rawExisting,
-  );
-  if (rotation.rotated) {
-    console.log(
-      JSON.stringify({
-        msg: 'trip-register: route rotation (#2019, ADR-022 B4)',
-        oldTokenPrefix: tokenPrefix(incoming.token),
-        newTokenPrefix: tokenPrefix(rotation.token),
-      }),
-    );
-    incoming.token = rotation.token;
-  }
-  const existing = rotation.rotated ? null : rawExisting;
-  const isSameSession = existing !== null && evaluateSameSession(existing, incoming);
-  // #916 follow-up B — auto-prompt dedup 마커 보존. isSameSession=true(같은 trip 재등록)인 경우만
-  // window 안이면 보존한다. 사용자가 lock 클리어 후 같은 trip context로 재등록하는 케이스에서
-  // 중복 prompt 재발사를 차단 (fired+clear 분기 회복).
-  //
-  // #1886 RC-2 옵션 D — trip-scoped dedup reset.
-  // isSameSession=false(새 trip 등록: 다른 경로/목적지)는 lastAutoPromptedAt을 보존하지 않는다.
-  // T1→T2 연속 trip에서 T1의 dedup이 T2로 carry-over하던 회귀 차단.
-  // 윈도우 만료/필드 부재면 undefined로 자연 리셋.
-  const preservedLastAutoPromptedAt =
-    isSameSession &&
-    existing?.lastAutoPromptedAt !== undefined &&
-    incoming.createdAt - existing.lastAutoPromptedAt < AUTO_PROMPT_DEDUP_WINDOW_MS
-      ? existing.lastAutoPromptedAt
-      : undefined;
-  // #705: progress KV 우선 참조. 같은 trainCode면 shift된 waypoints를 incoming에 적용.
-  // 다른 trainCode/none이면 progress 폐기.
-  // #1285: lockless opt-in trip(boardingLock 없음 + infoModeEnabled===true)은
-  // token 기준 lockless progress로 보존 — trainCode 없이 lockless===true 마커로 매칭.
-  const progress = existing !== null ? await getProgress(c.env.TRIPS, incoming.token) : null;
-  const progressApplies =
-    progress !== null &&
-    ((incoming.boardingLock !== undefined &&
-      progress.trainCode === incoming.boardingLock.trainCode) ||
-      (progress.lockless === true && incoming.infoModeEnabled === true));
-  if (progress !== null && !progressApplies) {
-    await deleteProgress(c.env.TRIPS, incoming.token);
-  }
-  const baseTrip = isSameSession
-    ? {
-        ...incoming,
-        waypoints: existing.waypoints,
-        lastFiredPhase: existing.lastFiredPhase,
-        // #1367 — cross-station dedup marker는 token 단위로 보존돼야 같은 trip 재등록 race에서
-        // 윈도우 안 fire가 다시 통과하지 않는다.
-        lastFiredStation: existing.lastFiredStation,
-        lastEtaSeconds: existing.lastEtaSeconds,
-        apnsEnv: existing.apnsEnv ?? incoming.apnsEnv,
-        // #916 follow-up A — server-set auto-lock 보존.
-        // 9단 게이트 통과로 backend가 합성한 lock(autoLockedAt 마커 보유)은 client가 lock 필드
-        // 없이 재등록해도 silent하게 drop되지 않아야 한다 (cron 추적이 끊기는 회귀 차단).
-        // 마커가 없는 사용자 명시 lock은 기존 정책대로 incoming.boardingLock===undefined일 때 drop —
-        // 사용자가 명시적으로 lock을 해제했다는 신호로 간주.
-        // incoming.boardingLock이 truthy면 (사용자가 다른 trainCode 선택 또는 client가 같은 lock
-        // 재송신) 그대로 채택돼 swap 경로가 동작.
-        boardingLock:
-          incoming.boardingLock ??
-          (existing.boardingLock?.autoLockedAt !== undefined
-            ? existing.boardingLock
-            : undefined),
-        // boardingLock이 바뀌면(예: 환승 후 새 trainCode) 추적 baseline도 리셋.
-        // 양쪽 모두 boardingLock이 있고 trainCode가 같을 때만 baseline 유지 — 둘 다 undefined인
-        // 경우 비교가 true로 평가돼 stale epoch이 살아남는 회귀를 막는다.
-        //
-        // #916 follow-up A — incoming.boardingLock===undefined + existing auto-lock 보존 케이스도
-        // 같은 lock이 유지되므로 baseline 유지 (cron 추적 연속성). 사용자 명시 lock drop 케이스는
-        // 기존 정책대로 undefined로 리셋.
-        lastTrackedArrivalEpoch:
-          (incoming.boardingLock &&
-            existing.boardingLock?.trainCode === incoming.boardingLock.trainCode) ||
-          (incoming.boardingLock === undefined &&
-            existing.boardingLock?.autoLockedAt !== undefined)
-            ? existing.lastTrackedArrivalEpoch
-            : undefined,
-        // #586 C: Live Activity token/state는 별도 endpoint(`/live-activity/register`)로 관리.
-        // 디바이스가 trip을 re-POST해도 register/deregister로 채워둔 값을 유지한다.
-        activityPushToken: existing.activityPushToken,
-        activityState: existing.activityState,
-        // #706: 연속 etaMissing 카운터는 backend-only state — 디바이스가 같은 세션으로 re-register해도
-        // 누적치를 보존해야 자동 종료가 정상 동작 (re-register마다 0으로 초기화되면 무한 폴링 회귀).
-        // #903 (Seam G) — 지상 복귀(subsurface true→false) 시 누적 카운터 리셋. 지하 인내 임계(10)로
-        // 누적된 값이 지상 임계(5)에 곧장 걸려 trip이 즉시 자동 종료되는 회귀 방지. 신호 회복 = trust restored.
-        consecutiveEtaMissing:
-          existing.subsurface === true && incoming.subsurface !== true
-            ? 0
-            : existing.consecutiveEtaMissing,
-        // #819: boarding-prompt 발사 카운터는 backend-only state — 디바이스가 같은 세션으로
-        // re-register하더라도 trip당 1회 + 5분 silence 정책을 유지해야 한다 (re-register마다
-        // reset되면 spam 회귀). promptGeoContext / promptDisplay는 incoming이 최신이라 그대로 받음.
-        boardingPromptState: existing.boardingPromptState,
-        // #916 follow-up B — same session에선 같은 trip이므로 그대로 보존.
-        lastAutoPromptedAt: existing.lastAutoPromptedAt,
+      // ADR-022 B4 (#2019 wire, #1986 rotation helper) — 새 route 감지 시 token rotation.
+      //
+      // archFlag=on + existing 있음 + route sig 다름 → 새 UUID 발급 + `trip:<oldToken>` delete +
+      // `pending:*` 중 oldToken 소유 entry cleanup (helper 내부 로직).
+      //
+      // archFlag=off (default): helper 는 `{ token: incoming.token, rotated: false }` no-op 반환
+      // → 기존 동작 100% 유지 (Phase 1-3 dormant).
+      //
+      // rotated=true 케이스 처리:
+      //   - `existing = null` 로 강등해 downstream `isSameSession=false` + progress skip 경로 진입
+      //     (helper 가 이미 `trip:<oldToken>` 을 delete 했으므로 same-session merge 는 무의미).
+      //   - `incoming.token` 을 새 UUID 로 갱신 → 후속 `putTrip` 이 `trip:<newToken>` 키로 쓴다.
+      //   - progress/SSoT KV(oldToken 키) 는 TTL 로 자연 만료 — 후속 cron push 는 새 token trip
+      //     기준 waypoints/destination 을 참조하므로 사용자에게 이전 목적지 push 재발사 없음.
+      //
+      // 오늘 evidence(2026-07-03): 사용자 중곡→성수 trip 시작 시 이전 trip(중곡→용마산) 잔재
+      // pending push 가 계속 발사돼 `08:37:25 bg fired station-passed 성수` 관측. rotation 이
+      // helper 의 `cleanupPendingPushesForToken` 을 실제 호출해 잔재 pending 제거.
+      const rotation = await rotateTripTokenForNewRoute(
+        c.env.TRIPS,
+        incoming,
+        rawExisting,
+      );
+      if (rotation.rotated) {
+        console.log(
+          JSON.stringify({
+            msg: 'trip-register: route rotation (#2019, ADR-022 B4)',
+            oldTokenPrefix: tokenPrefix(incoming.token),
+            newTokenPrefix: tokenPrefix(rotation.token),
+          }),
+        );
+        incoming.token = rotation.token;
       }
-    : {
-        ...incoming,
-        // #916 follow-up B — 새 세션(createdAt drift > 5s)으로 판정돼 incoming으로 전면 교체되더라도
-        // 같은 token + window 안이면 auto-prompt dedup 마커는 보존. backend가 직전에 auto-lock 시도/
-        // 발사한 trip 컨텍스트의 재발사 ping-pong을 차단한다.
-        lastAutoPromptedAt: preservedLastAutoPromptedAt,
-        // #1370 L1 — corrected apnsEnv 보존. 같은 token = 같은 디바이스 = 같은 APNs env이므로
-        // session 경계(환승 후 새 trainCode 등)와 무관하게 self-heal로 정정된 env가 유지돼야 한다.
-        // 보존 안 하면 새 session 첫 push마다 mismatch retry가 반복돼 첫 push latency + 일부 drop 위험
-        // (#1370 evidence: 환승 후 7호선 매역 silent push 손실).
-        // existing 부재(brand-new token) 또는 existing.apnsEnv 부재(legacy trip)면 incoming 값으로 자연 fallback.
-        apnsEnv: existing?.apnsEnv ?? incoming.apnsEnv,
-      };
+      const existing = rotation.rotated ? null : rawExisting;
+      const isSameSession = existing !== null && evaluateSameSession(existing, incoming);
+    // #916 follow-up B — auto-prompt dedup 마커 보존. isSameSession=true(같은 trip 재등록)인 경우만
+    // window 안이면 보존한다. 사용자가 lock 클리어 후 같은 trip context로 재등록하는 케이스에서
+    // 중복 prompt 재발사를 차단 (fired+clear 분기 회복).
+    //
+    // #1886 RC-2 옵션 D — trip-scoped dedup reset.
+    // isSameSession=false(새 trip 등록: 다른 경로/목적지)는 lastAutoPromptedAt을 보존하지 않는다.
+    // T1→T2 연속 trip에서 T1의 dedup이 T2로 carry-over하던 회귀 차단.
+    // 윈도우 만료/필드 부재면 undefined로 자연 리셋.
+    const preservedLastAutoPromptedAt =
+      isSameSession &&
+      existing?.lastAutoPromptedAt !== undefined &&
+      incoming.createdAt - existing.lastAutoPromptedAt < AUTO_PROMPT_DEDUP_WINDOW_MS
+        ? existing.lastAutoPromptedAt
+        : undefined;
+    // #705: progress KV 우선 참조. 같은 trainCode면 shift된 waypoints를 incoming에 적용.
+    // 다른 trainCode/none이면 progress 폐기.
+    // #1285: lockless opt-in trip(boardingLock 없음 + infoModeEnabled===true)은
+    // token 기준 lockless progress로 보존 — trainCode 없이 lockless===true 마커로 매칭.
+    const progress = existing !== null ? await getProgress(c.env.TRIPS, incoming.token) : null;
+    const progressApplies =
+      progress !== null &&
+      ((incoming.boardingLock !== undefined &&
+        progress.trainCode === incoming.boardingLock.trainCode) ||
+        (progress.lockless === true && incoming.infoModeEnabled === true));
+    if (progress !== null && !progressApplies) {
+      await deleteProgress(c.env.TRIPS, incoming.token);
+    }
+    const baseTrip = isSameSession
+      ? {
+          ...incoming,
+          waypoints: existing.waypoints,
+          lastFiredPhase: existing.lastFiredPhase,
+          // #1367 — cross-station dedup marker는 token 단위로 보존돼야 같은 trip 재등록 race에서
+          // 윈도우 안 fire가 다시 통과하지 않는다.
+          lastFiredStation: existing.lastFiredStation,
+          lastEtaSeconds: existing.lastEtaSeconds,
+          apnsEnv: existing.apnsEnv ?? incoming.apnsEnv,
+          // #916 follow-up A — server-set auto-lock 보존.
+          // 9단 게이트 통과로 backend가 합성한 lock(autoLockedAt 마커 보유)은 client가 lock 필드
+          // 없이 재등록해도 silent하게 drop되지 않아야 한다 (cron 추적이 끊기는 회귀 차단).
+          // 마커가 없는 사용자 명시 lock은 기존 정책대로 incoming.boardingLock===undefined일 때 drop —
+          // 사용자가 명시적으로 lock을 해제했다는 신호로 간주.
+          // incoming.boardingLock이 truthy면 (사용자가 다른 trainCode 선택 또는 client가 같은 lock
+          // 재송신) 그대로 채택돼 swap 경로가 동작.
+          boardingLock:
+            incoming.boardingLock ??
+            (existing.boardingLock?.autoLockedAt !== undefined
+              ? existing.boardingLock
+              : undefined),
+          // boardingLock이 바뀌면(예: 환승 후 새 trainCode) 추적 baseline도 리셋.
+          // 양쪽 모두 boardingLock이 있고 trainCode가 같을 때만 baseline 유지 — 둘 다 undefined인
+          // 경우 비교가 true로 평가돼 stale epoch이 살아남는 회귀를 막는다.
+          //
+          // #916 follow-up A — incoming.boardingLock===undefined + existing auto-lock 보존 케이스도
+          // 같은 lock이 유지되므로 baseline 유지 (cron 추적 연속성). 사용자 명시 lock drop 케이스는
+          // 기존 정책대로 undefined로 리셋.
+          lastTrackedArrivalEpoch:
+            (incoming.boardingLock &&
+              existing.boardingLock?.trainCode === incoming.boardingLock.trainCode) ||
+            (incoming.boardingLock === undefined &&
+              existing.boardingLock?.autoLockedAt !== undefined)
+              ? existing.lastTrackedArrivalEpoch
+              : undefined,
+          // #586 C: Live Activity token/state는 별도 endpoint(`/live-activity/register`)로 관리.
+          // 디바이스가 trip을 re-POST해도 register/deregister로 채워둔 값을 유지한다.
+          activityPushToken: existing.activityPushToken,
+          activityState: existing.activityState,
+          // #706: 연속 etaMissing 카운터는 backend-only state — 디바이스가 같은 세션으로 re-register해도
+          // 누적치를 보존해야 자동 종료가 정상 동작 (re-register마다 0으로 초기화되면 무한 폴링 회귀).
+          // #903 (Seam G) — 지상 복귀(subsurface true→false) 시 누적 카운터 리셋. 지하 인내 임계(10)로
+          // 누적된 값이 지상 임계(5)에 곧장 걸려 trip이 즉시 자동 종료되는 회귀 방지. 신호 회복 = trust restored.
+          consecutiveEtaMissing:
+            existing.subsurface === true && incoming.subsurface !== true
+              ? 0
+              : existing.consecutiveEtaMissing,
+          // #819: boarding-prompt 발사 카운터는 backend-only state — 디바이스가 같은 세션으로
+          // re-register하더라도 trip당 1회 + 5분 silence 정책을 유지해야 한다 (re-register마다
+          // reset되면 spam 회귀). promptGeoContext / promptDisplay는 incoming이 최신이라 그대로 받음.
+          boardingPromptState: existing.boardingPromptState,
+          // #916 follow-up B — same session에선 같은 trip이므로 그대로 보존.
+          lastAutoPromptedAt: existing.lastAutoPromptedAt,
+        }
+      : {
+          ...incoming,
+          // #916 follow-up B — 새 세션(createdAt drift > 5s)으로 판정돼 incoming으로 전면 교체되더라도
+          // 같은 token + window 안이면 auto-prompt dedup 마커는 보존. backend가 직전에 auto-lock 시도/
+          // 발사한 trip 컨텍스트의 재발사 ping-pong을 차단한다.
+          lastAutoPromptedAt: preservedLastAutoPromptedAt,
+          // #1370 L1 — corrected apnsEnv 보존. 같은 token = 같은 디바이스 = 같은 APNs env이므로
+          // session 경계(환승 후 새 trainCode 등)와 무관하게 self-heal로 정정된 env가 유지돼야 한다.
+          // 보존 안 하면 새 session 첫 push마다 mismatch retry가 반복돼 첫 push latency + 일부 drop 위험
+          // (#1370 evidence: 환승 후 7호선 매역 silent push 손실).
+          // existing 부재(brand-new token) 또는 existing.apnsEnv 부재(legacy trip)면 incoming 값으로 자연 fallback.
+          apnsEnv: existing?.apnsEnv ?? incoming.apnsEnv,
+        };
 
-  // #705 — progress KV가 우선. 같은 trainCode면 incoming.waypoints에서 shift된 만큼 잘라낸다.
-  // existing trip이 사라졌더라도(KV TTL 만료 등) progress가 살아 있으면 진행분을 그대로 복원.
-  const trip = progressApplies
-    ? applyProgress(baseTrip, incoming, progress)
-    : baseTrip;
+    // #705 — progress KV가 우선. 같은 trainCode면 incoming.waypoints에서 shift된 만큼 잘라낸다.
+    // existing trip이 사라졌더라도(KV TTL 만료 등) progress가 살아 있으면 진행분을 그대로 복원.
+    const trip = progressApplies
+      ? applyProgress(baseTrip, incoming, progress)
+      : baseTrip;
 
-  await putTrip(c.env.TRIPS, trip);
+      await putTrip(c.env.TRIPS, trip);
+
+      return { trip, isSameSession };
+    },
+  );
 
   // #1701 — 새 세션 분기에서는 SSoT mirror도 강제 cleanup. cleanupTripWithLa가 이미 4 종료
   // 경로에서 deleteSsot를 호출하지만, 종료 후 KV TTL 자연 만료를 기다리는 동안 같은 token으로

--- a/backend/alarm-worker/src/trips.ts
+++ b/backend/alarm-worker/src/trips.ts
@@ -245,3 +245,50 @@ export async function cleanupPendingPushesForToken(
   }
   return removed;
 }
+
+/**
+ * #2129 — per-token in-flight 직렬화.
+ *
+ * `POST /trips`가 device의 같은 token으로 거의 동시에 2건 도착하면(2026-08-04 실탑승 evidence:
+ * 20:06:21 `msejyvj91`/`msejyvmt2` 2개 register), 각 요청이 독립적으로
+ * `getTrip → rotateTripTokenForNewRoute → putTrip` TOCTOU window를 통과하며 interleave할 수
+ * 있다: 요청 A가 `existing=null`로 읽어(rotated=false) 원본 token으로 진행하는 도중, 요청 B가
+ * A의 이미 landed된 write를 `existing`으로 읽고 route sig 차이로 새 UUID를 발급 +
+ * `trip:<oldToken>` delete까지 완료 → 그 뒤에 A의 원래 `putTrip`이 착지해 오히려 A가 방금 지워진
+ * 키를 되살린다. 결과: 유령 trip 2개(원본 token + rotated UUID) 모두 KV에 생존.
+ *
+ * 같은 isolate 안에서 같은 token의 register 처리를 순차 큐로 직렬화해 두 번째 요청이 첫 번째
+ * 요청의 read-rotate-write 사이클이 완전히 끝난 뒤에야 자신의 `getTrip`을 수행하도록 보장한다.
+ * `previous.then(fn, fn)` — 직전 요청이 성공/실패 무관하게 정착(settle)한 뒤 `fn`이 실행되며,
+ * 호출자는 자신의 `fn` 결과/에러를 그대로 받는다(큐 자체의 실패가 전파되지 않음).
+ *
+ * 한계: Cloudflare Workers는 요청을 여러 isolate로 분산할 수 있어 cross-isolate 완전 보장은
+ * 아니다 — 같은 device의 거의 동시 POST는 대개 같은 isolate/colo로 라우팅되므로 실질적 방어선.
+ * 완전한 분산 lock(Durable Object 등)은 #2129 금지사항(rotation 자체 재작성 금지) 범위 밖이며
+ * 별도 이슈 후보. 메모리 누적 방지를 위해 자신이 마지막 queued entry였으면 Map에서 제거한다.
+ */
+const registerLocks = new Map<string, Promise<void>>();
+
+export function withTripRegisterLock<T>(
+  token: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previous = registerLocks.get(token) ?? Promise.resolve();
+  const run = previous.then(fn, fn);
+  const settled = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  registerLocks.set(token, settled);
+  void settled.finally(() => {
+    if (registerLocks.get(token) === settled) {
+      registerLocks.delete(token);
+    }
+  });
+  return run;
+}
+
+/** 테스트용 — register lock Map 상태 초기화. production 호출자 없음. */
+export function __resetTripRegisterLocksForTest(): void {
+  registerLocks.clear();
+}


### PR DESCRIPTION
Part of #2129 (PR 1/4 — backend rotation concurrency only; see #2129 for full spec).

## 배경

2026-08-04 실탑승 evidence: 20:06:21 같은 device token으로 `POST /trips` 2건이 거의 동시에 도착(waypoints 5개 vs 2개). 각 요청이 독립적으로 `getTrip → rotateTripTokenForNewRoute → putTrip` TOCTOU window를 통과하며 interleave해, 유령 trip 2개(원본 token + rotated UUID)가 모두 KV에 생존했다. 이후 backend cron이 두 trip 모두를 대상으로 유령 arrival 폴링을 수행(KV quota 소모 + 유령 push 위험).

## 변경 사항

- `backend/alarm-worker/src/trips.ts`: `withTripRegisterLock(token, fn)` 추가 — 같은 token의 register 처리를 queue-per-key 방식으로 직렬화하는 in-memory mutex. 직전 요청이 성공/실패 무관하게 정착(settle)한 뒤 다음 요청이 실행되며, 서로 다른 token은 대기 없이 병렬 실행. 큐 소진 시 Map에서 자동 제거.
- `backend/alarm-worker/src/index.ts`: `POST /trips` 핸들러의 `getTrip → rotateTripTokenForNewRoute → putTrip` 구간 전체를 원본 `incoming.token`(rotation 발생 전 값) 기준으로 `withTripRegisterLock`에 감쌌다. rotation 자체 로직은 변경 없음(#2019 ADR-022 B4 의도 보존).

## 한계 (명시)

Cloudflare Workers는 요청을 여러 isolate로 분산할 수 있어 cross-isolate 완전 보장은 아니다. 같은 device의 거의 동시 POST는 대개 같은 isolate/colo로 라우팅되므로 실질적 방어선. 완전한 분산 lock(Durable Object 등)은 이번 PR 스코프 밖 — 별도 이슈 후보로 남겨둔다.

## 금지사항 준수

- `rotateTripTokenForNewRoute`의 rotation 로직 자체는 건드리지 않음 — 동시성만 수리 (#2019 ADR-022 B4 의도 보존).
- 알람 발사 타이밍 로직 변경 없음 (#2061 스코프 침범 없음).

## Wire-completion 5단

1. **Orphan 없음**: `withTripRegisterLock`은 `index.ts`에서 즉시 호출 — orphan 아님.
2. **V/X dashboard**: `wrangler kv key list --binding TRIPS`로 register 직후 KV 활성 trip 개수 확인 가능. Cloudflare Dashboard 로그에 `trip-register: route rotation` 메시지로 rotation 발생 여부 관측 가능.
3. **의존 PR**: N/A — 이 PR만으로 독립 동작.
4. **측정 plan**: 다음 실탑승 dump에서 (a) 동시 register 유발 trip 시작 시 KV 활성 trip 정확히 1개인지 `wrangler kv key list --binding TRIPS`로 확인 (b) cron 로그에 유령 trip 대상 폴링이 없는지 확인.
5. **Device verify**: N/A — backend-only 변경, type-check + unit(coverage) only. 이 PR 자체는 device 코드 변경 없음.

## 테스트

- `cd backend/alarm-worker && npx vitest run` — 70 files / 2751 tests pass (신규 4 unit test + 1 integration test 포함)
- `npx tsc --noEmit` clean

## 후속 PR (같은 이슈 #2129)

- PR 2: device 두 register 경로 payload 단일화
- PR 3: 로컬 trip 종료 시 backend DELETE 발행 wire
- PR 4: `triggerTripEndRecall` 3중 실행 가드 + fireCount 오카운트 검증 (Closes #2129)