### PR TITLE
fix(#2129): device 두 register 경로 payload 단일화 — latestInputsRef 단일 출처

### DIFF
--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -294,6 +294,51 @@ export function useApnsTripRegistration({
   const lastDestinationIdRef = useRef<string | null>(null);
   const lastBoardingLockSigRef = useRef<string | null>(null);
 
+  /**
+   * #2129 — 두 register 경로(main effect / token-refresh listener)가 거의 동시에 실행돼도
+   * 동일 입력에서 동일 payload를 만들도록 `latestInputsRef` 단일 출처에서 register하는 helper.
+   *
+   * 이전에는 main effect가 closure로 캡처한 route/currentStation 등을 직접 callRegister에 넘기고,
+   * token-refresh listener만 `latestInputsRef.current`를 읽어 두 경로가 서로 다른 입력 snapshot을
+   * 쓸 수 있었다. `latestInputsRef`는 매 렌더 후 동기 effect로 갱신되므로 두 경로 모두 "그 순간의
+   * 최신 상태"라는 같은 소스를 읽게 만들면, 시점 차이로 다른 waypoints(#918 매역 확장 분기가
+   * currentStation null 여부로 갈림)를 만들어 backend register dedup hash가 어긋나고 두 건의
+   * POST /trips가 모두 통과해버리는 회귀(2026-08-04 실탑승 evidence — 유령 trip 2개, waypoints
+   * 5개 vs 2개)를 구조적으로 차단한다.
+   */
+  const registerFromLatestInputs = async (
+    token: string,
+  ): Promise<Awaited<ReturnType<typeof callRegister>> | null> => {
+    const {
+      route: r,
+      destination: d,
+      nextStationEtaSeconds: eta,
+      currentStation: cs,
+      boardingLock: bl,
+      subsurface: sub,
+      infoModeEnabled: ime,
+      sleepMode: sm,
+    } = latestInputsRef.current;
+    if (!r || !d) return null;
+    const sessionKey = `${token}:${routeSignature(r)}:${d.id}`;
+    const result = await callRegister({
+      token,
+      route: r,
+      destination: d,
+      nextStationEtaSeconds: eta,
+      currentStation: cs,
+      boardingLock: bl,
+      subsurface: sub,
+      infoModeEnabled: ime,
+      sleepMode: sm,
+      createdAt: resolveTripCreatedAt(sessionKey),
+      cachedPromptContext: lastPromptContextRef.current,
+    });
+    // #767 — 두 경로 모두 동일 기준으로 lock sig를 추적해야 다음 cycle의 release 판정 정확도 유지.
+    lastSentLockSigRef.current = lockSig(bl);
+    return result;
+  };
+
   // ── 토큰 발급 + 리스너 등록 (mount-once) ──
   useEffect(() => {
     let cancelled = false;
@@ -329,35 +374,9 @@ export function useApnsTripRegistration({
         } catch (e) {
           logger.warn('persist refreshed token failed:', e);
         }
-        // 활성 트립이 있으면 새 토큰으로 재등록한다.
-        const {
-          route: r,
-          destination: d,
-          nextStationEtaSeconds: eta,
-          currentStation: cs,
-          boardingLock: bl,
-          subsurface: sub,
-          infoModeEnabled: ime,
-          sleepMode: sm,
-        } = latestInputsRef.current;
-        if (!r || !d) return;
-        const sessionKey = `${token}:${routeSignature(r)}:${d.id}`;
-        await callRegister({
-          token,
-          route: r,
-          destination: d,
-          nextStationEtaSeconds: eta,
-          currentStation: cs,
-          boardingLock: bl,
-          subsurface: sub,
-          infoModeEnabled: ime,
-          sleepMode: sm,
-          createdAt: resolveTripCreatedAt(sessionKey),
-          cachedPromptContext: lastPromptContextRef.current,
-        });
-        // #767 — main effect와 동일 기준으로 lock sig를 추적해야 다음 cycle의 release 판정 정확도
-        // 유지. token-refresh는 deps cycle을 거치지 않는 별경로지만 backend엔 동일 POST를 보내므로.
-        lastSentLockSigRef.current = lockSig(bl);
+        // #2129 — 활성 트립이 있으면 latestInputsRef 단일 출처로 재등록 (main effect와 payload
+        // 빌드 경로 통일 — registerFromLatestInputs 내부에서 lock sig 추적까지 함께 처리).
+        await registerFromLatestInputs(token);
       })();
     });
 
@@ -433,7 +452,6 @@ export function useApnsTripRegistration({
         return;
       }
 
-      const sessionKey = `${token}:${routeSig}:${destination.id}`;
       // #1284 — buildBoardingPromptContext가 성공하면 캐시 갱신. 이후 currentStation이
       // 일시 null이 돼도 cachedPromptContext로 fallback하여 backend 9단 게이트가 계속 진입 가능.
       // #1921 — lock 동봉. cross-trip 자동 전환 시 stale stamp 차단(callRegister 분기와 동일 입력).
@@ -447,22 +465,11 @@ export function useApnsTripRegistration({
       await clearBackendSsotMirror();
       // #1628 — R11-a 차단 1건 측정. burst dedup으로 같은 site 반복은 첫 1건만 적재.
       logCrossTripMirrorSkip('register');
-      const result = await callRegister({
-        token,
-        route,
-        destination,
-        nextStationEtaSeconds,
-        currentStation,
-        boardingLock,
-        subsurface,
-        infoModeEnabled,
-        sleepMode,
-        createdAt: resolveTripCreatedAt(sessionKey),
-        cachedPromptContext: lastPromptContextRef.current,
-      });
-      // POST 발사 직후(성공/실패 무관) 송신된 lock sig를 기록 — 다음 cycle이 "직전 송신 = lock,
-      // 신규 = null" 패턴인지 판정해 race 차단.
-      lastSentLockSigRef.current = boardingLockSig;
+      // #2129 — token-refresh listener와 동일한 latestInputsRef 단일 출처로 register. 이 시점의
+      // ref는 이미 이번 render의 최신 값으로 동기화돼 있어(ref-sync effect가 이 effect보다 먼저
+      // 실행) closure의 route/currentStation을 직접 쓰는 것과 결과가 같지만, 두 register 경로가
+      // 구조적으로 같은 소스를 읽게 만들어 payload divergence를 원천 차단한다.
+      const result = await registerFromLatestInputs(token);
       // #1264 (N3) + #1704 (d) — POST 발사 직후 송신된 routeSig / destination.id / boardingLockSig
       // 를 기록. 다음 cycle이 trip 전환(어느 하나라도 변경) 시 cancel 트리거.
       lastRouteSigRef.current = routeSig;
@@ -471,7 +478,7 @@ export function useApnsTripRegistration({
       // #669: cancelled 가드 밖에서 setItem — backend register 성공이면 UI cleanup 여부와 무관하게
       // ACTIVE_TRIP_KEY를 동기화. 가드 안에 두면 nextStationEtaSeconds·currentStation 변경으로
       // useEffect cleanup이 자주 일어나 setItem이 skip되고 DebugModal activeTrip이 (none)으로 표시됨.
-      if (result.ok) {
+      if (result?.ok) {
         await AsyncStorage.setItem(ACTIVE_TRIP_KEY, token);
       }
     };


### PR DESCRIPTION
Part of #2129 (PR 2/4 — device payload unification only; see #2129 for full spec).

## 배경

2026-08-04 실탑승 evidence: 20:06:21 device가 `POST /trips` 2건을 waypoints 5개 vs 2개로 서로 다르게 발사. `src/features/alarm/hooks/useApnsTripRegistration.ts`의 두 register 경로(main effect / token-refresh listener)가 `callRegister`라는 같은 함수를 호출하긴 했지만, 입력값을 서로 다른 소스에서 가져왔다:

- main effect: 렌더 closure의 `route`/`currentStation`/... 직접 사용
- token-refresh listener: `latestInputsRef.current` 사용

`latestInputsRef`는 매 렌더 후 별도 effect로 동기화되므로 보통은 같은 값이지만, main effect는 `routeSig`/`destination.id`/`boardingLockSig`/`subsurface`/`infoModeEnabled`/`sleepMode` 변경 시에만 재실행되고 **currentStation은 deps에서 제외**(#703, 30s GPS polling churn 방지)돼 있어, GPS 갱신 이후 시점에 token-refresh 이벤트가 겹치면 두 경로가 서로 다른 `currentStation` snapshot(하나는 stale closure, 하나는 최신 ref)으로 register하게 되고 #918 매역 확장 분기(currentStation null 여부로 waypoints 개수가 갈림)가 달라졌다. 결과적으로 backend register dedup hash(payload 기반)가 어긋나 두 건의 `POST /trips`가 모두 통과했다.

## 변경 사항

- `registerFromLatestInputs(token)` helper 신설 — `latestInputsRef.current`를 유일한 입력 소스로 사용해 `callRegister`를 호출.
- main effect의 `run()`도 closure 값을 직접 넘기던 것을 `registerFromLatestInputs(token)` 호출로 교체. deps 트리거 판정(`routeSig`/`destination.id`/`boardingLockSig` 등 ref 갱신)은 기존 closure 값을 그대로 사용 — register effect가 "언제 실행되는지"는 변경 없음, "무엇을 보내는지"만 단일 소스로 통일.
- token-refresh listener도 동일 helper 사용.
- **동작 변경 없음** — 같은 렌더 내에서는 ref-sync effect가 register effect보다 먼저 실행되므로 closure 값과 ref 값이 원래 동일했다. 이번 변경은 구조적으로 "두 경로가 같은 소스를 읽는다"를 보장해 시점 차이로 인한 divergence를 원천 차단하는 것.

## 금지사항 준수

- #1960(token-refresh prompt context) 스코프 침범 없음 — payload 단일화가 자연스럽게 해소하는 부분은 없음(#1960은 별도 컨텍스트 로직).
- 알람 발사 타이밍 로직 변경 없음 (#2061 스코프 침범 없음).

## Wire-completion 5단

1. **Orphan 없음**: `npm run lint:orphan` pass — 신규 export(`registerFromLatestInputs`)는 hook 내부 전용, 외부 export 없음.
2. **V/X dashboard**: DebugModal Backend Calls 버퍼에서 동시 register 시 두 호출의 payload(특히 waypoints 개수)가 동일한지 확인 가능.
3. **의존 PR**: PR 1(#2132, backend rotation 동시성)과 함께 배포되면 방어가 이중화되지만, 독립적으로도 동작(payload가 같아지면 device측 alarmBackend.ts dedup hash도 일치해 두 번째 POST가 자체 skip됨).
4. **측정 plan**: 다음 실탑승 dump에서 GPS 갱신 직후 push token refresh가 겹치는 trip 시작 시나리오 재현 시 Backend Calls의 두 register payload가 동일한지 확인.
5. **Device verify**: 실기기 검증 권장 — token refresh 타이밍은 실기기에서만 자연 발생(테스트는 mock 이벤트로 커버). 코드 자체는 type-check + unit(coverage 100%)로 검증 완료.

## 테스트

- `npx jest src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts` — 90 tests pass, 100% coverage (기존 테스트 전부 유지, 신규 동작 없음)
- `npx tsc --noEmit` clean
- `npm run lint:orphan` clean

## 후속 PR (같은 이슈 #2129)

- PR 1: backend rotation 동시성 (#2132, 머지 완료 또는 리뷰 중)
- PR 3: 로컬 trip 종료 시 backend DELETE 발행 wire
- PR 4: `triggerTripEndRecall` 3중 실행 가드 + fireCount 오카운트 검증 (Closes #2129)