### PR TITLE
fix(#2131): boarding-prompt 무음 skip 관측성 (Part A-1)

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -150,7 +150,7 @@ function makeFullEmptyStats(): ScheduledStats {
     boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
     phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
     autoLockSuccess: 0, autoLockFalsePositive: 0, boardingPromptAutoDeduped: 0,
-    boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0,
+    boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0, boardingPromptSkippedNoContext: 0,
     hopEndPromptFired: 0, hopEndPromptBlocked: 0,
     arvlCdFireSuccess: 0, arvlCdFireDedup: 0, arvlCdFireMismatch: 0,
     arvlCdFireBlocked: 0, arvlCdFireFired: 0,
@@ -4290,6 +4290,17 @@ describe('runScheduled — boarding-prompt 9단 게이트 (#819)', () => {
     const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
     expect(stats.boardingPromptEvaluated).toBe(0);
     expect(stats.boardingPromptFired).toBe(0);
+  });
+
+  // #2131 (Part A-1) — geo/display 부재 무음 skip 관측성. 기존 테스트는 boardingPromptEvaluated
+  // 미증가만 검증 — 본 테스트는 신규 counter로 "왜" evaluate에 못 미쳤는지 명시 관측.
+  it('#2131 — promptGeoContext/promptDisplay 부재 시 boardingPromptSkippedNoContext +1', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ token: 'no-geo' }));
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+    expect(stats.boardingPromptSkippedNoContext).toBe(1);
+    expect(stats.boardingPromptEvaluated).toBe(0);
   });
 
   it('9단 통과 + APNs 200 → alert push 발사 + state.fired 영구화', async () => {
@@ -9384,7 +9395,7 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
       boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
       phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
       autoLockSuccess: 0, autoLockFalsePositive: 0, boardingPromptAutoDeduped: 0,
-      boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0,
+      boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0, boardingPromptSkippedNoContext: 0,
       hopEndPromptFired: 0, hopEndPromptBlocked: 0,
       arvlCdFireSuccess: 0, arvlCdFireDedup: 0, arvlCdFireMismatch: 0,
       arvlCdFireBlocked: 0, arvlCdFireFired: 0,

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -598,6 +598,14 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   boardingPromptSkippedLockActive: number;
   /**
+   * #2131 (Part A-1) — `evaluateAndMaybeFireBoardingPrompt`가 `trip.promptGeoContext` 또는
+   * `trip.promptDisplay` 부재로 게이트 평가 자체를 시도하지 못하고 무음 return한 누적 횟수.
+   * 기존엔 counter/log 없이 조용히 skip돼 "boardingPromptEvaluated=0인데 이유를 알 수 없는" 관측
+   * 공백이 있었다 — F1(frontend geo/display stamp)가 아직 도달하지 않은 trip 비율 측정용.
+   * dashboard: `scheduled run complete` cron summary log (persist=false 환경에서도 조회 가능).
+   */
+  boardingPromptSkippedNoContext: number;
+  /**
    * #2034 — 환승 waypoint advance 시점에 hop-end ("하차했나요?") prompt 게이트를 통과해 alert
    * push 가 발사된 누적 횟수. leg 단위 dedup 이라 같은 trip 내 여러 환승도 각각 카운트.
    * dashboard: `hop_end_prompt_fired`.
@@ -964,6 +972,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     boardingPromptAutoDeduped: 0,
     boardingPromptSkippedEmpty: 0,
     boardingPromptSkippedLockActive: 0,
+    boardingPromptSkippedNoContext: 0,
     hopEndPromptFired: 0,
     hopEndPromptBlocked: 0,
     arvlCdFireSuccess: 0,
@@ -4281,7 +4290,17 @@ export async function evaluateAndMaybeFireBoardingPrompt(
 
   const geo = trip.promptGeoContext;
   const display = trip.promptDisplay;
-  if (!geo || !display) return;
+  if (!geo || !display) {
+    stats.boardingPromptSkippedNoContext += 1;
+    log('boarding-prompt: skip (no geo/display context)', {
+      token: trip.token.slice(0, 8),
+      hasGeo: geo !== undefined,
+      hasDisplay: display !== undefined,
+      // #2032 (Issue D) — monitoring dimension. ADR-023: 발사 결정 X.
+      sleepMode: trip.sleepModeEnabled,
+    });
+    return;
+  }
 
   // #916 follow-up B — fired+clear 분기 회복. 직전 auto-prompt 발사 윈도우 안에 다시 들어왔다면
   // 평가 자체를 skip — boardingPromptState가 isSameSession=false로 리셋됐거나 lock이 클리어된


### PR DESCRIPTION
Part of #2131

## 배경

#2130 RCA backend 파트 (Part A). `evaluateAndMaybeFireBoardingPrompt`의 무음 skip 경로를 전수 감사해, counter/log 없이 조용히 return하던 지점 1건(`if (!geo || !display) return;`)에 관측성을 부여한다.

## 변경

- `ScheduledStats`에 `boardingPromptSkippedNoContext: number` 필드 추가 (+ 문서 주석)
- `runScheduled` 초기값에 0으로 초기화
- `evaluateAndMaybeFireBoardingPrompt`의 `!geo || !display` 분기에서 counter +1 + `log('boarding-prompt: skip (no geo/display context)', ...)` 추가 (hasGeo/hasDisplay/sleepMode 포함)
- 함수 내 나머지 return 경로는 이미 각자 counter를 보유하고 있음을 확인 (전수 감사 결과 — 추가 조치 불필요)
- unit test 추가: geo/display 부재 시 `boardingPromptSkippedNoContext` +1 검증

## Wire-completion 5단

1. **Orphan 없음** — 신규 export 없음 (기존 `ScheduledStats` 인터페이스 필드 추가 + 함수 내부 로직만). N/A.
2. **V/X dashboard** — `stats.boardingPromptSkippedNoContext`는 cron 루프 종료 시 `log('scheduled run complete', { ...stats, ... })`가 spread로 자동 노출 → wrangler tail / Cloudflare Dashboard 실시간 로그에서 조회 가능. persist(R2/KV) 없이도 사후 조회 가능(로그 라인 자체가 evidence).
3. **의존 PR** — N/A (backend-only, device 코드 미수정).
4. **측정 plan** — 배포 후 1주간 `boardingPromptSkippedNoContext` 값이 0에 수렴하는지(F1 frontend geo/display stamp가 정상 도달) wrangler tail로 관찰. 0이 아니면 promptGeoContext/promptDisplay를 stamp하지 않는 trip 비율 회귀 신호.
5. **Device verify** — N/A — type+unit only. 코드-only 변경(counter/log 추가), device 동작 변화 없음.

## 검증

- `npx vitest run` — 70 files / 2747 tests green
- `npx vitest run --coverage` — All files 97.3/96.32/99.17/97.3 (ratchet floor 97/96/98/97 통과)
- `npx tsc --noEmit` — clean

Closes 없음 — #2131은 Part A-2(PR)까지 머지되어야 close.