### PR TITLE
fix(#2131): #918 intermediate continue의 boarding-prompt 평가 skip 수리 (Part A-2)

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -4292,6 +4292,30 @@ describe('runScheduled — boarding-prompt 9단 게이트 (#819)', () => {
     expect(stats.boardingPromptFired).toBe(0);
   });
 
+  // #2131 (Part A-2) — infoModeEnabled=true + intermediate waypoint 조합은 기존엔
+  // `runLocklessIntermediate` + `continue`로 곧장 빠져나가 evaluateAndMaybeFireBoardingPrompt
+  // 자체가 호출되지 않았다(boardingPromptEvaluated 영구 0 회귀). hoist 이후 두 경로가 모두 실행돼야
+  // 한다 — ADR-014 "사용자 명시 의향(C 토글 ON) trip = lock 활성과 동급 정확도 보장" 준수.
+  it('#2131 — infoModeEnabled=true + intermediate waypoint + geo 있음 → prompt 평가 도달', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({
+        infoModeEnabled: true,
+        waypoints: [
+          { stationName: '강남', line: '2', kind: 'intermediate' },
+          { stationName: '역삼', line: '2', kind: 'destination' },
+        ],
+      }),
+    );
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+
+    expect(stats.boardingPromptEvaluated).toBe(1);
+  });
+
   it('9단 통과 + APNs 200 → alert push 발사 + state.fired 영구화', async () => {
     const kv = new InMemoryKV();
     await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -1200,6 +1200,27 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
         await cleanupTripWithLa(trip, env, deps, stats, now, log, 'la-stale-backstop');
         continue;
       }
+      // #2131 (Part A-2, ADR-014 동급 보장) — boarding-prompt 9단 게이트 평가를 lockless
+      // intermediate 분기보다 앞으로 hoist. 기존엔 `trip.infoModeEnabled && waypoint.kind ===
+      // 'intermediate'`인 trip이 이 지점에 도달하지 못하고 `runLocklessIntermediate` +
+      // `continue`로 빠져나가 boarding-prompt 평가가 영구 skip되는 회귀가 있었다 — C 토글
+      // ON(사용자 명시 의향) trip이 lock 활성 trip과 동급 정확도를 보장받지 못한 것.
+      // 조건: lock 없음(바깥 `if (!isBoardingLockActive(...))`가 이미 보장) +
+      // `promptState.fired` 아님 — 두 조건 모두 `evaluateAndMaybeFireBoardingPrompt` 내부에서
+      // 이미 강제된다(F2 lock-active 방어 + 게이트 #9 already-fired dedup). 여기서는 호출
+      // 위치만 앞으로 옮기고 별도 pre-check는 두지 않는다 — 이중 게이트로 인한 관측(counter)
+      // 손실을 피하기 위함(기존 boardingPromptBlocked/already-fired 회귀 신호 보존).
+      // `runLocklessIntermediate` 호출 자체와 순서는 아래에서 불변 유지 (#1967 kill switch 의미
+      // 보존 — kill switch는 그 함수 내부에서만 게이트한다).
+      try {
+        await evaluateAndMaybeFireBoardingPrompt(trip, env, deps, stats, now, log, generatePushId);
+      } catch (e) {
+        stats.errors += 1;
+        log('boarding-prompt: evaluation error', {
+          error: String(e),
+          token: trip.token.slice(0, 8),
+        });
+      }
       // #816 C — lockless opt-in trip은 게이트 우회. lock 없이도 intermediate waypoint 통과
       // 시 station-passed push 발사. 사용자가 명시 동의(client 토글)한 trip에 한정한다.
       // intermediate kind가 아니면(transfer/destination) 여전히 skip — trainCode 없이 발사하면
@@ -1226,18 +1247,6 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
         // ADR-023: backend 발사 결정 X — device의 `shouldSuppressBySleepRule`가 실제 suppress gate.
         sleepMode: trip.sleepModeEnabled,
       });
-      // #819 — lock 미발생 trip에 boarding-prompt 9단 게이트 평가 분기. 게이트 통과 시 alert
-      // push로 "탑승 중이세요?"를 묻고, 클라이언트가 사용자 응답으로 lock을 자동 생성한다.
-      // 게이트 자체가 false positive 9중 차단 (ADR Section 2)이라 phase-based 노이즈와 분리.
-      try {
-        await evaluateAndMaybeFireBoardingPrompt(trip, env, deps, stats, now, log, generatePushId);
-      } catch (e) {
-        stats.errors += 1;
-        log('boarding-prompt: evaluation error', {
-          error: String(e),
-          token: trip.token.slice(0, 8),
-        });
-      }
       // #1826 — lock 없는 trip에서도 LA BG update heartbeat 발사.
       // ETA 미지 → newArrivalEpoch=now: ΔETA 게이트는 첫 call에서 통과(last===undefined),
       // 이후 heartbeat(90s) 게이트만 적용. putTrip dirty 여부와 무관하게 별도 persist.


### PR DESCRIPTION
Closes #2131

## 배경

#2130 RCA backend 파트 (Part A). cron 루프의 `if (trip.infoModeEnabled && waypoint.kind === 'intermediate') { …; continue; }` 분기가 `evaluateAndMaybeFireBoardingPrompt` 평가를 영구 skip시키는 회귀가 있었다 — C 토글 ON(사용자 명시 의향) trip이 intermediate waypoint에 있으면 boarding-prompt 9단 게이트가 절대 평가되지 않는다. ADR-014 "사용자 명시 의향 trip = lock 활성과 동급 정확도 보장" 위반.

독립 브랜치(dev 기준). PR A-1(#2134)과 같은 파일(`scheduled.ts`)을 건드리지만 diff 영역이 겹치지 않아 dev에서 바로 분기했다.

## 변경

- `evaluateAndMaybeFireBoardingPrompt` 호출을 lockless intermediate 분기(`trip.infoModeEnabled && waypoint.kind === 'intermediate'`) **앞**으로 hoist
- la-stale backstop 체크는 기존처럼 최우선 유지
- `runLocklessIntermediate` 호출 자체와 순서는 불변 — kill switch(#1967)는 그 함수 내부에서만 게이트한다는 기존 의미 보존
- lock 없음 / `promptState.fired` dedup 조건은 `evaluateAndMaybeFireBoardingPrompt` 내부(F2 lock-active 방어 + 게이트 #9 already-fired)에서 이미 강제되므로 hoist된 호출부에 별도 pre-check를 추가하지 않았다 — 추가했더니 기존 already-fired 시나리오의 `boardingPromptBlocked` 관측 카운터가 사라지는 회귀가 발생해(4개 기존 테스트 실패) 되돌림. 함수 내부 게이트만으로 요구된 두 조건(lock 없음 + not fired)이 모두 만족됨.
- 신규 unit test: `infoModeEnabled=true` + intermediate waypoint + geo 있음 trip에서 `boardingPromptEvaluated` 도달 검증 (회귀 이전엔 영구 0)

## Wire-completion 5단

1. **Orphan 없음** — 신규 export 없음, 기존 함수 호출 위치 이동만. N/A.
2. **V/X dashboard** — `stats.boardingPromptEvaluated` / `boardingPromptBlocked` / `boardingPromptFired`는 기존과 동일하게 `log('scheduled run complete', { ...stats })`로 cron summary에 노출(wrangler tail / Cloudflare Dashboard). PR A-1(#2134)의 `boardingPromptSkippedNoContext`도 같은 경로.
3. **의존 PR** — N/A. PR A-1(#2134)과 논리적으로 독립(다른 diff 영역), 별도 머지 가능.
4. **측정 plan** — 배포 후 1주간 infoModeEnabled=true(C 토글 ON) + intermediate trip의 `boardingPromptEvaluated` / `boardingPromptFired` 값이 0에서 벗어나는지 wrangler tail로 관찰. 이전엔 이 조합에서 항상 0이었음(구조적 dead code) — 0이 아닌 값 관측 자체가 fix 검증.
5. **Device verify** — 권장. 실기기 시나리오: C 토글 ON 상태로 trip 등록 → lock 미생성(탑승 액션 미수행) → intermediate waypoint 통과 시 boarding-prompt(alert push, "탑승 중이세요?") 수신 여부 확인. type+unit으로는 cron 로직 정확성만 검증 가능, 실제 push 수신은 실기기 필요.

## 검증

- `npx vitest run` — 70 files / 2747 tests green (기존 2746 + 신규 1)
- `npx vitest run --coverage` — All files 97.3/96.32/99.17/97.3 (ratchet floor 97/96/98/97 통과)
- `npx tsc --noEmit` — clean