### PR TITLE
fix(#2129): lockless trip 종료 시 backend DELETE wire

### DIFF
--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -23,6 +23,7 @@ import {
 } from '../../utils/crossCategoryStationDedup';
 import { clearAlarmLogWindows } from '../../utils/alarmLog';
 import { resetAlarmBackendDedup } from '../../api/alarmBackend';
+import * as alarmBackend from '../../api/alarmBackend';
 import { clearBackendSsotMirror } from '../../utils/backendSsotMirror';
 import { clearLastSilentPushReceivedAt } from '../../utils/lastSilentPushReceivedAt';
 import { useDestinationStore } from '../../../route/store/useDestinationStore';
@@ -487,6 +488,69 @@ describe('tripBoundCleanups', () => {
     (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
     await expect(runTripBoundCleanups()).resolves.toBeUndefined();
     expect(mockEndLiveActivity).toHaveBeenCalledTimes(1);
+  });
+
+  // #2129 — lockless trip 종료 경로(silent push trip-ended / useStateRehydration sentinel /
+  // useLaunchTripReconciliation / useDeviceSelfEnd)가 runTripBoundCleanups만 호출하고 별도로
+  // backend DELETE를 발행하지 않아, ACTIVE_TRIP_KEY가 removeItem으로 지워진 뒤 어떤 후속 호출자도
+  // backend token을 읽을 수 없는 회귀(2026-08-04 유령 trip evidence). runTripBoundCleanups가
+  // ACTIVE_TRIP_KEY 제거 전에 이미 읽어둔 token으로 clearActiveTrip을 직접 발행해야 한다.
+  describe('#2129 — runTripBoundCleanups가 backend DELETE /trips를 발행한다', () => {
+    it('ACTIVE_TRIP_KEY(backend token)가 있으면 clearActiveTrip(token)을 호출한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((k: string) =>
+        Promise.resolve(k === ACTIVE_TRIP_KEY ? 'backend-tok-2129' : null),
+      );
+      const clearActiveTripSpy = jest
+        .spyOn(alarmBackend, 'clearActiveTrip')
+        .mockResolvedValue({ ok: true });
+
+      await runTripBoundCleanups();
+
+      expect(clearActiveTripSpy).toHaveBeenCalledWith('backend-tok-2129');
+      clearActiveTripSpy.mockRestore();
+    });
+
+    it('ACTIVE_TRIP_KEY가 없으면(활성 backend trip 없음) clearActiveTrip을 호출하지 않는다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      const clearActiveTripSpy = jest
+        .spyOn(alarmBackend, 'clearActiveTrip')
+        .mockResolvedValue({ ok: true });
+
+      await runTripBoundCleanups();
+
+      expect(clearActiveTripSpy).not.toHaveBeenCalled();
+      clearActiveTripSpy.mockRestore();
+    });
+
+    it('backend token 없이 device-local tripToken만 있으면(backend 등록 전 armed) clearActiveTrip을 호출하지 않는다', async () => {
+      // ACTIVE_TRIP_KEY(backend token)는 없지만 TRIP_STARTED_AT_KEY는 있어
+      // resolveEffectiveTripToken이 device-local synthetic id를 만드는 케이스.
+      // backend가 애초에 이 trip을 모르므로 DELETE 대상이 아니다.
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((k: string) =>
+        Promise.resolve(k === TRIP_STARTED_AT_KEY ? String(Date.now()) : null),
+      );
+      const clearActiveTripSpy = jest
+        .spyOn(alarmBackend, 'clearActiveTrip')
+        .mockResolvedValue({ ok: true });
+
+      await runTripBoundCleanups();
+
+      expect(clearActiveTripSpy).not.toHaveBeenCalled();
+      clearActiveTripSpy.mockRestore();
+    });
+
+    it('clearActiveTrip이 실패해도(네트워크 불가 등) runTripBoundCleanups는 graceful 종료한다 (BG force-end 안전망)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((k: string) =>
+        Promise.resolve(k === ACTIVE_TRIP_KEY ? 'backend-tok-2129' : null),
+      );
+      const clearActiveTripSpy = jest
+        .spyOn(alarmBackend, 'clearActiveTrip')
+        .mockRejectedValue(new Error('network unavailable'));
+
+      await expect(runTripBoundCleanups()).resolves.toBeUndefined();
+
+      clearActiveTripSpy.mockRestore();
+    });
   });
 
   it('runTripBoundCleanups: 한 항목이 reject해도 나머지 항목이 모두 실행된다', async () => {

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -39,7 +39,7 @@ import { clearTripCorrId } from '../../observability/utils/tripCorrId';
 import { clearBackendSsotMirror } from '../utils/backendSsotMirror';
 import { clearCrossCategoryDedup } from '../utils/crossCategoryStationDedup';
 import { clearAlarmLogWindows } from '../utils/alarmLog';
-import { resetAlarmBackendDedup } from '../api/alarmBackend';
+import { clearActiveTrip, resetAlarmBackendDedup } from '../api/alarmBackend';
 import { getNotificationRouter } from '../api/notificationRouter';
 import { useDestinationStore } from '../../route/store/useDestinationStore';
 import { useBoardingLockStore } from './useBoardingLockStore';
@@ -246,11 +246,21 @@ export function runTripBoundCleanups(): Promise<void> {
     // #918 — stationPrescheduler(OS 사전예약 "매역" 채널)도 safetyNetScheduler와 동일하게
     // tripToken-scoped cancel 대상. 두 채널은 sleepMode로 상호 배타적이라 항상 한쪽만
     // 실제로 pending을 갖지만, 나머지 한쪽 cancel은 큐가 비어있어도 안전(멱등)하므로 항상 같이 호출.
+    // #2129 — backend DELETE /trips wire. 이 배열의 ACTIVE_TRIP_KEY removeItem 항목이 먼저 돌면
+    // 이후 아무 호출자도 backend token을 읽을 수 없어 DELETE가 영구히 발행되지 않는 회귀
+    // (lockless trip 종료 경로 전부 — silent push trip-ended / useStateRehydration sentinel /
+    // useLaunchTripReconciliation / useDeviceSelfEnd — 모두 본 함수만 호출하고 별도로
+    // clearActiveTrip을 부르지 않았다). removeItem 전에 이미 읽어둔 backendTripToken(위)을
+    // 그대로 사용 — device-local synthetic id(tripToken)는 backend가 모르는 값이라 제외.
+    // fire-and-forget + 실패해도 흡수(allSettled) — backend TTL이 최종 안전망(현행 유지).
     const cleanups = tripToken
       ? [
           ...TRIP_BOUND_CLEANUPS,
           () => cancelAllSafetyNetAlarms(tripToken),
           () => cancelAllPrescheduledAlarms(tripToken),
+          ...(backendTripToken
+            ? [() => clearActiveTrip(backendTripToken).then(noop)]
+            : []),
         ]
       : TRIP_BOUND_CLEANUPS;
     return Promise.allSettled(cleanups.map((cleanup) => cleanup())).then(noop);


### PR DESCRIPTION
Part of #2129 (PR 3/4 — 로컬 trip 종료 시 backend DELETE wire only; see #2129 for full spec).

## 배경

2026-08-04 실탑승 evidence: 20:06:23 trip이 로컬에서 lockless 종료됐지만, device Backend Calls 버퍼(20:06:21~33)에 `DELETE /trips` 호출이 없었다. `clearActiveTrip`은 route-clear deps 경로(`useApnsTripRegistration.ts` L385)에만 wire돼 있었고, `runTripBoundCleanups`(lockless trip 종료 — silent push trip-ended / useStateRehydration sentinel / useLaunchTripReconciliation / useDeviceSelfEnd 등 모든 경로가 호출)는 backend DELETE를 발행하지 않았다. 결과적으로 KV에 유령 trip이 잔존해 backend cron이 유령 arrival 폴링을 계속 수행했다.

## 변경 사항

- `src/features/alarm/store/tripBoundCleanups.ts`: `runTripBoundCleanups`가 `ACTIVE_TRIP_KEY` removeItem 이전에 이미 읽어둔 `backendTripToken`을 사용해 `clearActiveTrip(backendTripToken)`을 cleanup 배열에 추가. fire-and-forget(`.then(noop)`) + `Promise.allSettled`로 실패를 흡수 — backend TTL이 최종 안전망(현행 유지).
- device-local synthetic id(`tripToken`, backend가 모르는 값)는 DELETE 대상에서 제외 — `backendTripToken`(AsyncStorage `ACTIVE_TRIP_KEY`)이 있을 때만 호출.

## 금지사항 준수

- Downstream matrix(BG force-end 시 네트워크 불가 케이스): fire-and-forget + backend TTL 안전망 — 별도 재시도 sweep 신규 구현 없음(#2129 acceptance 3 명시 허용 범위).
- 알람 발사 타이밍 로직 변경 없음 (#2061 스코프 침범 없음).

## Wire-completion 5단

1. **Orphan 없음**: `npm run lint:orphan` pass. `clearActiveTrip`은 기존 export — 신규 호출자만 추가.
2. **V/X dashboard**: DebugModal Backend Calls 버퍼에서 trip 종료 직후 `DELETE /trips` 호출 확인 가능. `wrangler kv key list --binding TRIPS`로 종료 후 활성 trip 0 확인 가능.
3. **의존 PR**: #2132(backend rotation 동시성) — 이미 머지됨. 독립적으로도 동작.
4. **측정 plan**: 다음 실탑승 dump에서 lockless trip 종료 시 (a) Backend Calls에 DELETE 발행 확인 (b) `wrangler kv key list --binding TRIPS`로 KV 활성 trip 0 확인.
5. **Device verify**: 실기기 검증 권장 — lockless 종료 4개 경로(silent push trip-ended / sentinel / reconciliation / self-end) 각각 실기기에서만 자연 발생. 코드 자체는 type-check + unit(coverage 100%)로 검증 완료.

## 테스트

- `npm test` — 424 suites / 9013 tests pass, 100% coverage
- `npm run type-check` clean
- `npm run lint:orphan` clean

## 후속 PR (같은 이슈 #2129)

- PR 4: `triggerTripEndRecall` 3중 실행 가드 + fireCount 오카운트 검증 (Closes #2129)
