### PR TITLE
fix(#2129): triggerTripEndRecall 동시 호출 가드 — trip당 1회

### DIFF
--- a/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
+++ b/src/features/alarm/utils/__tests__/triggerTripEndRecall.test.ts
@@ -116,7 +116,10 @@ jest.mock('../backendSsotMirror', () => ({
   readBackendSsotMirror: (...args: unknown[]) => mockReadBackendSsotMirror(...args),
 }));
 
-import { triggerTripEndRecall } from '../triggerTripEndRecall';
+import {
+  triggerTripEndRecall,
+  _resetTripEndRecallGuardForTests,
+} from '../triggerTripEndRecall';
 import {
   APNS_TOKEN_KEY,
   DESTINATION_KEY,
@@ -162,6 +165,9 @@ function setupHappyPath(): void {
 
 describe('triggerTripEndRecall', () => {
   beforeEach(() => {
+    // #2129 — in-memory 동시 호출 가드 초기화. tripStart 값을 여러 it 블록이 재사용하므로
+    // 매 테스트 시작 전 리셋하지 않으면 두 번째 이후 호출이 'duplicate'로 오탐된다.
+    _resetTripEndRecallGuardForTests();
     mockGetItem.mockReset();
     mockSetItem.mockReset();
     mockComputeAndUploadTripRecall.mockReset();
@@ -239,6 +245,39 @@ describe('triggerTripEndRecall', () => {
 
     expect(result).toEqual({ uploaded: false, skipped: 'duplicate' });
     expect(mockComputeAndUploadTripRecall).not.toHaveBeenCalled();
+  });
+
+  // #2129 — 18:05 hydration storm evidence: 여러 독립 호출자(force-end 경로)가 같은 trip에 대해
+  // 거의 동시에 triggerTripEndRecall을 호출하면, AsyncStorage 기반 duplicate 체크만으로는
+  // read-then-write async window에서 race가 발생해 3중 실행됐다. 동기 in-memory 가드로 차단.
+  it('#2129 — 동일 tripStart 동시 호출 2건 → 1건만 실제 실행, 나머지는 duplicate skip', async () => {
+    setupHappyPath();
+
+    const [resultA, resultB] = await Promise.all([
+      triggerTripEndRecall(),
+      triggerTripEndRecall(),
+    ]);
+
+    // 둘 중 정확히 하나만 실제로 upload/stamp 경로를 탔다.
+    const results = [resultA, resultB];
+    const duplicates = results.filter((r) => r.skipped === 'duplicate');
+    const executed = results.filter((r) => r.skipped !== 'duplicate');
+    expect(duplicates).toHaveLength(1);
+    expect(executed).toHaveLength(1);
+    expect(mockComputeAndUploadTripRecall).toHaveBeenCalledTimes(1);
+    expect(mockLogLocklessTripEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('#2129 — 다른 tripStart의 동시 호출은 서로 차단하지 않는다', async () => {
+    setupHappyPath();
+    // 두 번째 호출은 다른 tripStart를 갖도록 순차 mock 전환.
+    mockGetTripStartedAt
+      .mockResolvedValueOnce(100)
+      .mockResolvedValueOnce(200);
+
+    await Promise.all([triggerTripEndRecall(), triggerTripEndRecall()]);
+
+    expect(mockComputeAndUploadTripRecall).toHaveBeenCalledTimes(2);
   });
 
   it('route/origin/destination 누락 시 skip (route-arc-failed)', async () => {

--- a/src/features/alarm/utils/triggerTripEndRecall.ts
+++ b/src/features/alarm/utils/triggerTripEndRecall.ts
@@ -67,6 +67,29 @@ import { useUserIntentStore } from '../store/useUserIntentStore';
 
 const log = createLogger('triggerTripEndRecall');
 
+/**
+ * #2129 — trip당 1회 in-flight/완료 가드 (tripStart 기준, in-memory).
+ *
+ * 배경: 4개 독립 호출자(silent push trip-ended / useLaunchTripReconciliation Signal 4 +
+ * status=ended 분기 / useDeviceSelfEnd 3-signal / useDestinationStore FG setDestination(null))가
+ * 각자 인스턴스/cycle 가드만 갖고 공유 가드는 없었다. 18:05 hydration storm(FG 직후 3 cycle)에서
+ * 서로 다른 force-end 경로가 같은 trip에 대해 거의 동시에 진입하면, 기존 AsyncStorage 기반
+ * duplicate 체크(`LAST_UPLOADED_RECALL_TRIP_START_KEY`)는 read(await) → write(await) 사이 race
+ * window가 넓어(네트워크 upload를 포함한 전체 async 체인) 3건 모두 통과, `lockless-trip-end`
+ * stamp가 3중 적재됐다(#2129 evidence).
+ *
+ * 이 Set은 tripStart를 안 뒤 **동기적으로** 즉시 체크+등록한다 — 두 호출이 거의 동시에
+ * `getTripStartedAt()` await에서 깨어나도, 먼저 재개된 쪽이 add()까지 await 없이 끝내므로
+ * 뒤에 재개되는 쪽은 반드시 갱신된 Set을 본다(JS 단일 스레드 특성). AsyncStorage 기반
+ * duplicate 체크는 앱 재시작 간 지속성을 위해 그대로 유지 — 이 in-memory 가드는 같은 세션 내
+ * 동시 호출만 추가로 차단한다.
+ */
+const guardedTripStarts = new Set<number>();
+
+export function _resetTripEndRecallGuardForTests(): void {
+  guardedTripStarts.clear();
+}
+
 export type TriggerTripEndRecallSkipReason =
   | 'no-trip-start'
   | 'no-route'
@@ -99,6 +122,13 @@ export async function triggerTripEndRecall(): Promise<TriggerTripEndRecallResult
       await triggerAlarmLogForward(Date.now() - 24 * 60 * 60 * 1000);
       return { uploaded: false, skipped: 'no-trip-start' };
     }
+
+    // #2129 — 동시 호출 가드. AsyncStorage 기반 duplicate 체크보다 먼저, 동기적으로 체크+등록.
+    if (guardedTripStarts.has(tripStart)) {
+      log.info(`concurrent duplicate trip-end recall skip: tripStart=${tripStart}`);
+      return { uploaded: false, skipped: 'duplicate' };
+    }
+    guardedTripStarts.add(tripStart);
 
     // Idempotency 가드 (P2-2). silent push trip-ended → FG 복귀 → useStateRehydration의
     // setDestination(null) 재호출 같은 race에서도 중복 upload 차단.


### PR DESCRIPTION
Closes #2129 (PR 4/4 — recall 3중 실행 가드 + fireCount 오카운트 검증).

## 배경

2026-08-04 실탑승 evidence: 18:05:08 / 09 / 14 `lockless-trip-end | fired | 2:paradigm`이 3회 stamp됐다(같은 trip 1건에 대해). RCA 4: "18:05 hydration storm(FG 직후 3 cycle)에서 force-end 경로가 인스턴스/cycle 가드 없이 각각 recall 실행".

`triggerTripEndRecall`은 4개 독립 호출자(silent push trip-ended handler / `useLaunchTripReconciliation`의 Signal 4·status=ended 두 분기 / `useDeviceSelfEnd` 3-signal / FG `useDestinationStore.setDestination(null)`)를 갖는다. 각 호출자는 자기 자신의 재호출은 막지만(예: `useDeviceSelfEnd`의 `firedForDestinationIdRef`), 서로 다른 호출자 간 공유 가드는 없었다. 기존 AsyncStorage 기반 idempotency(`LAST_UPLOADED_RECALL_TRIP_START_KEY`)는 read(`getItem`) → (network upload 포함한 전체 async 체인) → write(`setItem`) 사이 race window가 넓어, 거의 동시에 도착한 여러 호출이 모두 read 시점에 "아직 upload 안 됨"으로 보고 통과했다.

## 변경 사항

- `src/features/alarm/utils/triggerTripEndRecall.ts`: tripStart 기준 module-scope in-memory `Set` 가드(`guardedTripStarts`) 추가. `getTripStartedAt()` await 직후, 다른 어떤 await도 거치지 않고 동기적으로 체크+등록(`has` → `add`)한다. JS 단일 스레드 특성상 두 호출이 거의 동시에 재개돼도 먼저 재개된 쪽이 add()까지 끝낸 뒤에야 다른 마이크로태스크로 양보하므로, 뒤에 재개되는 호출은 반드시 갱신된 Set을 보고 즉시 `{ uploaded: false, skipped: 'duplicate' }`로 skip한다.
- AsyncStorage 기반 duplicate 체크는 그대로 유지 — 앱 재시작(새 세션, in-memory Set 초기화) 간 지속성 담당. 두 가드는 서로 다른 시간축(세션 내 동시성 vs 세션 간 지속성)을 커버해 상호 보완.
- `_resetTripEndRecallGuardForTests()` export — 기존 `_resetXxxForTests` 패턴(alarmLog.ts) 재사용, 테스트 격리용.

## fireCount 오카운트 검증 (acceptance 4 후반부)

`countFiredAlarms`(alarmLog.ts:1303)의 `FIRED_ALARM_SOURCES` Record를 확인한 결과 `'lockless-trip-end': false`로 이미 정확히 분류돼 있었다. `alarmLog.test.ts:3245`의 기존 테스트("metadata source... lockless-trip-end 등은 분모 제외")가 `outcome='fired'`인 `lockless-trip-end` entry를 포함한 15개 metadata entry + 실제 fire 1건 케이스로 이미 이 분기를 커버하고 있어 회귀 없음을 확인했다. **코드 변경 없음** — 이슈의 "추가 의혹" 항목은 검증 결과 이미 정확했다.

## 금지사항 준수

- 알람 발사 타이밍 로직 변경 없음 (#2061 스코프 침범 없음).
- fireCount ring scan 로직(`countFiredAlarms`) 자체는 변경하지 않음 — 검증만 수행.

## Wire-completion 5단

1. **Orphan 없음**: `npm run lint:orphan` pass. `_resetTripEndRecallGuardForTests`는 테스트 전용 export — 프로덕션 orphan 아님(테스트 파일에서 사용).
2. **V/X dashboard**: `alarmLog`의 `lockless-trip-end` source entry 수가 trip 종료당 정확히 1건인지 DebugModal Alarm Log 섹션 또는 backend `/admin/alarm-log-stats`(`obs-metrics locklessTripMissRatio` 산출 분모)에서 확인 가능.
3. **의존 PR**: N/A — 독립 동작. PR 1(#2132)/2(#2133)/3(#2136)과 겹치는 파일 없음.
4. **측정 plan**: 다음 실탑승 dump에서 force-end/trip 종료 시나리오 재현 시 alarmLog에 `lockless-trip-end` stamp가 trip당 정확히 1건인지 확인. obs-metrics `locklessTripMissRatio` 분모(fired+miss) 오염 여부 1주 관찰.
5. **Device verify**: 실기기 검증 권장 — hydration storm(FG 직후 3 cycle)은 실기기 자연 발생 타이밍 의존. 코드 자체는 동시성 테스트(`Promise.all`)로 race를 결정적으로 재현해 type-check + unit(coverage 100%)로 검증 완료.

## 테스트

- `npm test` — 424 suites / 9011 tests pass, 100% coverage (신규 2 테스트: 동시 호출 dedup + 다른 tripStart 비차단)
- `npm run type-check` clean
- `npm run lint:orphan` clean

## 선행 PR (같은 이슈 #2129)

- PR 1: #2132 (머지됨) — backend rotation 동시성
- PR 2: #2133 (머지됨) — device payload 단일화
- PR 3: #2136 — 로컬 trip 종료 시 backend DELETE wire
