### PR TITLE
fix(#2130): boarding-prompt 근접·신선도 게이트 (Part B-be-1)

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -2415,6 +2415,57 @@ describe('validateTrip — #819 promptGeoContext / promptDisplay', () => {
     expect(trip?.promptGeoContext?.direction).toBeNull();
   });
 
+  // #2130 (Part B-be-1) — 근접 게이트 입력 필드 파싱.
+  it('originDistanceM/originAccuracyM 유효 숫자 → 보존', () => {
+    const trip = validateTrip(
+      withPrompt({
+        promptGeoContext: {
+          origin: { lat: 1, lng: 2 },
+          nextStation: { lat: 3, lng: 4 },
+          direction: 'up',
+          originDistanceM: 227,
+          originAccuracyM: 9,
+        },
+      }),
+    );
+    expect(trip?.promptGeoContext?.originDistanceM).toBe(227);
+    expect(trip?.promptGeoContext?.originAccuracyM).toBe(9);
+  });
+
+  it('originDistanceM/originAccuracyM 부재(지하/구 클라) → undefined로 graceful', () => {
+    const trip = validateTrip(
+      withPrompt({
+        promptGeoContext: {
+          origin: { lat: 1, lng: 2 },
+          nextStation: { lat: 3, lng: 4 },
+          direction: 'up',
+        },
+      }),
+    );
+    expect(trip?.promptGeoContext?.originDistanceM).toBeUndefined();
+    expect(trip?.promptGeoContext?.originAccuracyM).toBeUndefined();
+  });
+
+  it.each([
+    ['non-number', 'abc'],
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+  ])('originDistanceM 비정상 값(%s) → undefined로 graceful (나머지 필드는 보존)', (_label, bad) => {
+    const trip = validateTrip(
+      withPrompt({
+        promptGeoContext: {
+          origin: { lat: 1, lng: 2 },
+          nextStation: { lat: 3, lng: 4 },
+          direction: 'up',
+          originDistanceM: bad,
+          originAccuracyM: 9,
+        },
+      }),
+    );
+    expect(trip?.promptGeoContext?.originDistanceM).toBeUndefined();
+    expect(trip?.promptGeoContext?.originAccuracyM).toBe(9);
+  });
+
   it.each([
     ['origin coord 누락', { promptGeoContext: { nextStation: { lat: 1, lng: 2 } } }],
     ['nextStation 누락', { promptGeoContext: { origin: { lat: 1, lng: 2 } } }],

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -150,7 +150,7 @@ function makeFullEmptyStats(): ScheduledStats {
     boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
     phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
     autoLockSuccess: 0, autoLockFalsePositive: 0, boardingPromptAutoDeduped: 0,
-    boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0, boardingPromptSkippedNoContext: 0,
+    boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0, boardingPromptSkippedNoContext: 0, boardingPromptSkippedStale: 0, boardingPromptSkippedTooFar: 0,
     hopEndPromptFired: 0, hopEndPromptBlocked: 0,
     arvlCdFireSuccess: 0, arvlCdFireDedup: 0, arvlCdFireMismatch: 0,
     arvlCdFireBlocked: 0, arvlCdFireFired: 0,
@@ -4325,6 +4325,93 @@ describe('runScheduled — boarding-prompt 9단 게이트 (#819)', () => {
     const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
     expect(stats.boardingPromptSkippedNoContext).toBe(1);
     expect(stats.boardingPromptEvaluated).toBe(0);
+  });
+
+  // #2130 (Part B-be-1) — 신선도 게이트. trip 등록 후 15분 경과 시 evaluate 자체를 skip.
+  it('#2130 — trip 등록 후 15분 경과 시 boardingPromptSkippedStale +1, evaluate 미도달', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({ createdAt: NOW - 15 * 60 * 1000 - 1 }),
+    );
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+    expect(stats.boardingPromptSkippedStale).toBe(1);
+    expect(stats.boardingPromptEvaluated).toBe(0);
+    expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it('#2130 — 15분 경계(정확히 15분)는 신선도 게이트 통과', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({ createdAt: NOW - 15 * 60 * 1000 }),
+    );
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+    expect(stats.boardingPromptSkippedStale).toBe(0);
+    expect(stats.boardingPromptEvaluated).toBe(1);
+  });
+
+  // #2130 (Part B-be-1) — 근접 게이트. distance/accuracy 둘 다 있고 오차 고려해도 150m 밖이면 차단.
+  it('#2130 — originDistanceM/originAccuracyM 둘 다 존재 + 150m 초과 → boardingPromptSkippedTooFar +1', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({
+        promptGeoContext: {
+          origin: { lat: 0, lng: 0 },
+          nextStation: { lat: 0, lng: 0.01 },
+          direction: 'up',
+          originDistanceM: 227,
+          originAccuracyM: 9,
+        },
+      }),
+    );
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+    expect(stats.boardingPromptSkippedTooFar).toBe(1);
+    expect(stats.boardingPromptEvaluated).toBe(0);
+    expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it('#2130 — 경계(distance - accuracy === 150) 는 근접 게이트 통과 (150 초과만 차단)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({
+        promptGeoContext: {
+          origin: { lat: 0, lng: 0 },
+          nextStation: { lat: 0, lng: 0.01 },
+          direction: 'up',
+          originDistanceM: 300,
+          originAccuracyM: 150,
+        },
+      }),
+    );
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+    expect(stats.boardingPromptSkippedTooFar).toBe(0);
+    expect(stats.boardingPromptEvaluated).toBe(1);
+  });
+
+  it('#2130 — originDistanceM/originAccuracyM 부재(지하/구 클라) → 근접 게이트 관대 허용', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+    expect(stats.boardingPromptSkippedTooFar).toBe(0);
+    expect(stats.boardingPromptEvaluated).toBe(1);
   });
 
   it('9단 통과 + APNs 200 → alert push 발사 + state.fired 영구화', async () => {
@@ -9419,7 +9506,7 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
       boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
       phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
       autoLockSuccess: 0, autoLockFalsePositive: 0, boardingPromptAutoDeduped: 0,
-      boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0, boardingPromptSkippedNoContext: 0,
+      boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0, boardingPromptSkippedNoContext: 0, boardingPromptSkippedStale: 0, boardingPromptSkippedTooFar: 0,
       hopEndPromptFired: 0, hopEndPromptBlocked: 0,
       arvlCdFireSuccess: 0, arvlCdFireDedup: 0, arvlCdFireMismatch: 0,
       arvlCdFireBlocked: 0, arvlCdFireFired: 0,

--- a/backend/alarm-worker/src/boardingPrompt.ts
+++ b/backend/alarm-worker/src/boardingPrompt.ts
@@ -56,6 +56,16 @@ export const MIN_WINDOW_SAMPLES = 1;
 export const MIN_FUSED_SPEED_KMH = 5;
 /** 게이트 #9 — dismiss 후 silence 길이. */
 export const DISMISS_SILENCE_MS = 5 * 60 * 1000;
+/**
+ * #2130 (Part B-be-1) — 근접 게이트 임계(m). `originDistanceM - originAccuracyM`가 이 값을
+ * 넘으면 차단(오차 고려 보수적 차단). 역사 반경 실측 100~180m 근거로 150m 채택(플랜 §2 D2).
+ */
+export const PROMPT_PROXIMITY_MARGIN_M = 150;
+/**
+ * #2130 (Part B-be-1) — 신선도 게이트. trip 등록(또는 heal) 후 이 시간이 지나면 boarding-prompt
+ * 자격이 만료된다 — 오래된 trip에 뒤늦게 발사되는 stale prompt 방지 + 반복 발사(A4) 창의 상한.
+ */
+export const PROMPT_FRESHNESS_MS = 15 * 60 * 1000;
 
 export type GateOutcome =
   | { pass: true; metrics: WindowedMetrics; fusedSpeedKmh: number }

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -2294,10 +2294,22 @@ function parsePromptGeoContext(raw: unknown): PromptGeoContext | undefined {
   if (typeof nc.lng !== 'number' || !Number.isFinite(nc.lng)) return undefined;
   const direction = o.direction;
   const dir = direction === 'up' || direction === 'down' ? direction : null;
+  // #2130 (Part B-be-1) — device가 heal 시점 GPS fix로 계산해 동봉하는 근접 게이트 입력.
+  // fix가 없으면(지하 등) 필드 자체가 생략되어 undefined → backend 근접 게이트는 관대 허용.
+  const originDistanceM =
+    typeof o.originDistanceM === 'number' && Number.isFinite(o.originDistanceM)
+      ? o.originDistanceM
+      : undefined;
+  const originAccuracyM =
+    typeof o.originAccuracyM === 'number' && Number.isFinite(o.originAccuracyM)
+      ? o.originAccuracyM
+      : undefined;
   return {
     origin: { lat: oc.lat, lng: oc.lng },
     nextStation: { lat: nc.lat, lng: nc.lng },
     direction: dir,
+    ...(originDistanceM !== undefined ? { originDistanceM } : {}),
+    ...(originAccuracyM !== undefined ? { originAccuracyM } : {}),
   };
 }
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -23,6 +23,8 @@ import {
   evaluateHopEndPromptGates,
   markPromptFired,
   pickAutoTrainCode,
+  PROMPT_FRESHNESS_MS,
+  PROMPT_PROXIMITY_MARGIN_M,
   type GateSkipReason,
 } from './boardingPrompt';
 import {
@@ -606,6 +608,18 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   boardingPromptSkippedNoContext: number;
   /**
+   * #2130 (Part B-be-1) — trip 등록(`createdAt`) 후 `PROMPT_FRESHNESS_MS`(15분)가 지나
+   * boarding-prompt 자격이 만료돼 skip한 누적 횟수. 오래된 lockMissing trip에 뒤늦게 발사되는
+   * stale prompt를 차단 — 0이 아니면 device 재등록 주기 또는 사용자 응답 지연 분포를 시사.
+   */
+  boardingPromptSkippedStale: number;
+  /**
+   * #2130 (Part B-be-1) — `promptGeoContext.originDistanceM - originAccuracyM > 150m`로 근접
+   * 게이트가 차단한 누적 횟수. 자택 등록(A2) 등 실제 미승차 시나리오에서 0이 아니게 나오는 것이
+   * 정상 — 지하/구 클라(필드 부재)는 이 게이트를 거치지 않아 관대하게 허용된다.
+   */
+  boardingPromptSkippedTooFar: number;
+  /**
    * #2034 — 환승 waypoint advance 시점에 hop-end ("하차했나요?") prompt 게이트를 통과해 alert
    * push 가 발사된 누적 횟수. leg 단위 dedup 이라 같은 trip 내 여러 환승도 각각 카운트.
    * dashboard: `hop_end_prompt_fired`.
@@ -973,6 +987,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     boardingPromptSkippedEmpty: 0,
     boardingPromptSkippedLockActive: 0,
     boardingPromptSkippedNoContext: 0,
+    boardingPromptSkippedStale: 0,
+    boardingPromptSkippedTooFar: 0,
     hopEndPromptFired: 0,
     hopEndPromptBlocked: 0,
     arvlCdFireSuccess: 0,
@@ -4307,6 +4323,32 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       hasDisplay: display !== undefined,
       // #2032 (Issue D) — monitoring dimension. ADR-023: 발사 결정 X.
       sleepMode: trip.sleepModeEnabled,
+    });
+    return;
+  }
+
+  // #2130 (Part B-be-1) — 신선도 게이트. trip 등록 후 15분 경과 시 boarding-prompt 자격 만료.
+  if (now - trip.createdAt > PROMPT_FRESHNESS_MS) {
+    stats.boardingPromptSkippedStale += 1;
+    log('boarding-prompt: skip (stale, past freshness window)', {
+      token: trip.token.slice(0, 8),
+      ageMs: now - trip.createdAt,
+    });
+    return;
+  }
+
+  // #2130 (Part B-be-1) — 근접 게이트. distance/accuracy 둘 다 있을 때만 평가(부재 = 지하/구
+  // 클라 관대 허용). 오차 고려 보수적 차단 — distance - accuracy > 150m 이면 skip.
+  if (
+    geo.originDistanceM !== undefined &&
+    geo.originAccuracyM !== undefined &&
+    geo.originDistanceM - geo.originAccuracyM > PROMPT_PROXIMITY_MARGIN_M
+  ) {
+    stats.boardingPromptSkippedTooFar += 1;
+    log('boarding-prompt: skip (too far from origin)', {
+      token: trip.token.slice(0, 8),
+      originDistanceM: geo.originDistanceM,
+      originAccuracyM: geo.originAccuracyM,
     });
     return;
   }

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -299,6 +299,18 @@ export interface PromptGeoContext {
   nextStation: { lat: number; lng: number };
   /** 방향 게이트(#5)에서 어느 방향으로 가야 하는지 — Seoul API의 isUp과 정합. */
   direction: 'up' | 'down' | null;
+  /**
+   * #2130 (Part B-be-1) — device가 heal 시점에 GPS fix로 계산한 출발역까지 거리(m).
+   * fix가 있을 때만 스탬프(정확도가 나빠도 항상 동봉) — backend 근접 게이트(§단계3)의 입력.
+   * fix 자체가 없으면(지하 등) 필드 자체를 생략한다 — 부재는 게이트에서 "허용"으로 해석.
+   */
+  originDistanceM?: number;
+  /**
+   * #2130 (Part B-be-1) — 위 거리 계산에 사용된 GPS 정확도(m, `location.coords.accuracy`).
+   * backend 근접 게이트가 `originDistanceM - originAccuracyM > 150` 일 때만 차단한다
+   * (오차 고려 보수적 차단 — 정확도가 나쁜 실내 GPS의 false positive 방어).
+   */
+  originAccuracyM?: number;
 }
 
 /** boarding-prompt 사용자 표시 컨텍스트. */


### PR DESCRIPTION
Part of #2130

**stacked on #2135 — #2135(fix/#2131-prompt-eval-hoist) 먼저 머지 필요.** #2135는 아직 OPEN이라 이 브랜치를 그 위에서 분기했다. #2135 머지 후 base를 dev로 재조정(또는 rebase) 필요.

## 배경

플랜 SSoT: `tasks/plan-2026-08-04-boarding-prompt-accuracy.md` §단계 3 + §2 D2. #2130 RCA의 Part B-backend 중 근접/신선도 게이트 부분 — B-device(#2129 계열)와 파일이 달라 병렬 진행.

## 변경

- `PromptGeoContext`(types.ts)에 `originDistanceM?` / `originAccuracyM?` optional 필드 추가 — device가 heal 시점 GPS fix로 계산해 동봉하는 근접 게이트 입력.
- `index.ts` `parsePromptGeoContext`가 두 필드를 명시 파싱(통째 저장이 아니라 화이트리스트 파서라 no-op가 아니었음) — 비정상 값(NaN/Infinity/non-number)은 undefined로 graceful.
- `evaluateAndMaybeFireBoardingPrompt`(scheduled.ts)에 게이트 2종 추가:
  - **신선도**: `now - trip.createdAt > 15분` → skip (`boardingPromptSkippedStale`)
  - **근접**: `originDistanceM`/`originAccuracyM` 둘 다 존재 + `distance - accuracy > 150m` → skip (`boardingPromptSkippedTooFar`). **필드 부재(지하/구 클라)는 관대 허용** — 지하는 GPS 불가로 스탬프가 안 생겨 자연 통과, 자택은 GPS 양호로 스탬프 생겨 차단.
- 상수 `PROMPT_PROXIMITY_MARGIN_M`(150) / `PROMPT_FRESHNESS_MS`(15분)는 `boardingPrompt.ts`에 정의.

## Wire-completion 5단

1. **Orphan 없음** — 신규 export(`PROMPT_PROXIMITY_MARGIN_M`, `PROMPT_FRESHNESS_MS`)는 scheduled.ts가 즉시 import/사용. `npm run lint:orphan`은 frontend용 스크립트라 backend 디렉토리는 대상 아님 — backend는 `npx tsc --noEmit` + `npx vitest run`으로 신규 export 미사용 시 아예 컴파일/커버리지 실패로 드러남(둘 다 green).
2. **V/X dashboard** — `boardingPromptSkippedStale` / `boardingPromptSkippedTooFar`는 `scheduled run complete` cron summary log(`...stats` spread)에 자동 노출 — wrangler tail / Cloudflare Dashboard에서 조회 가능.
3. **의존 PR** — #2131(#2135 PR, 머지 전 stacked). B-device(#2129 계열, `originDistanceM`/`originAccuracyM` 실제 스탬프 송신)는 별도 PR — 이 PR은 backend 게이트만이라 필드가 없으면 관대 허용으로 자연 no-op.
4. **측정 plan** — 배포 후 1주 `boardingPromptSkippedStale`/`boardingPromptSkippedTooFar` 값을 wrangler tail로 관찰. B-device 미머지 상태에서는 두 counter 모두 0에 수렴해야 정상(필드 부재 → 관대 허용 경로). B-device 머지 후 자택 등록 대조 시나리오(A2)에서 `boardingPromptSkippedTooFar`≥1 관측이 fix 검증.
5. **Device verify** — N/A (backend-only, type+unit). B-device PR 머지 후 실기기 자택/지하 대조 시나리오로 종합 검증 예정(플랜 §5).

## 검증

- `npx vitest run` — 70 files / 2763 tests green (기존 2753 + 신규 10)
- `npx vitest run --coverage` — All files 97.32/96.34/99.18/97.32 (ratchet floor 통과)
- `npx tsc --noEmit` — clean