### PR TITLE
fix(#2130): boarding-prompt context-heal (Tier 1/2) + GPS 근접 스탬프

### DIFF
--- a/src/features/alarm/api/alarmBackend.ts
+++ b/src/features/alarm/api/alarmBackend.ts
@@ -90,6 +90,14 @@ export interface RegisterTripPayload {
     nextStation: { lat: number; lng: number };
     /** 출발역에서 trip 방향 (Seoul API의 isUp과 정합). 모르면 null — 양방향 허용. */
     direction: 'up' | 'down' | null;
+    /**
+     * #2130 (B-2) — origin과 등록 시점 GPS fix 사이 거리(m). backend 근접 게이트(B-backend,
+     * 별도 PR)가 원거리 오탑승 후보를 걸러내는 입력. GPS fix가 아예 없을 때만 생략 — backend는
+     * 부재를 관대하게(지하/구 클라 호환) 통과시킨다.
+     */
+    originDistanceM?: number;
+    /** #2130 (B-2) — GPS fix 정확도(m). originDistanceM과 항상 짝으로만 존재. */
+    originAccuracyM?: number;
   };
   /**
    * #819 — boarding-prompt push 본문에 노출할 출발역/노선 표시명.

--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -55,7 +55,10 @@ import { useApnsTripRegistration } from '../useApnsTripRegistration';
 import type { Station } from '../../../../shared/types/station';
 import type { Route } from '../../../../shared/utils/stationRoute';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../../shared/constants/storageKeys';
-import { BOARDING_LOCK_RELEASE_DEBOUNCE_MS } from '../../../../shared/constants/boardingLock';
+import {
+  BOARDING_LOCK_RELEASE_DEBOUNCE_MS,
+  CONTEXT_HEAL_TIER2_DELAY_MS,
+} from '../../../../shared/constants/boardingLock';
 import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
 
 const station: Station = {
@@ -1345,6 +1348,447 @@ describe('useApnsTripRegistration', () => {
         // 캐시가 reset됐으므로 이전 origin 컨텍스트가 누출 안 됨
         expect(secondArgs.promptGeoContext).toBeUndefined();
         expect(secondArgs.promptDisplay).toBeUndefined();
+      });
+    });
+  });
+
+  // #2130 — context-heal (B-1 Tier 1/2) + GPS 근접 스탬프 (B-2)
+  describe('#2130 — context-heal 조건부 재등록 + GPS 근접 스탬프', () => {
+    // 단조 3호선 대화(3-001) → 정발산(3-003): buildBoardingPromptContext non-null 반환 보장.
+    const origin: Station = {
+      id: '3-001',
+      name: '대화',
+      line: '3',
+      lat: 37.676087,
+      lng: 126.747569,
+      lineColor: '#EF7C1C',
+    };
+    const dest: Station = {
+      id: '3-003',
+      name: '정발산',
+      line: '3',
+      lat: 37.659477,
+      lng: 126.773359,
+      lineColor: '#EF7C1C',
+    };
+    const route3 = makeDirectRoute(2, '3');
+
+    it('Tier 1 — cold-start(캐시 empty + currentStation=null)로 등록 후 station 해소 시 context를 포함해 재등록', async () => {
+      const { rerender } = renderHook(
+        ({ cs }: { cs: Station | null }) =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: cs,
+          }),
+        { initialProps: { cs: null as Station | null } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      // cold-start 첫 register: 캐시도 없고 currentStation도 null → context 결손
+      expect(mockRegister.mock.calls[0][0].promptGeoContext).toBeUndefined();
+      expect(mockRegister.mock.calls[0][0].promptDisplay).toBeUndefined();
+
+      // GPS/fusion이 station을 해소 — null → non-null 전환
+      rerender({ cs: origin });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      const healed = mockRegister.mock.calls[1][0] as {
+        promptGeoContext?: { origin: { lat: number; lng: number } };
+        promptDisplay?: { originStation: string; line: string };
+      };
+      expect(healed.promptGeoContext?.origin).toEqual({ lat: origin.lat, lng: origin.lng });
+      expect(healed.promptDisplay).toEqual({ originStation: '대화', line: '3' });
+    });
+
+    it('Tier 1 — heal이 실패(context 여전히 결손)해도 같은 세션에서 재시도하지 않는다 (1회 가드)', async () => {
+      // currentStation === destination이면 buildBoardingPromptContext가 null 반환(기존 동작).
+      const { rerender } = renderHook(
+        ({ cs }: { cs: Station | null }) =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: cs,
+          }),
+        { initialProps: { cs: null as Station | null } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+
+      // null → dest(=destination, context 여전히 결손) 전환 — heal 1회 시도
+      rerender({ cs: dest });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      expect(mockRegister.mock.calls[1][0].promptGeoContext).toBeUndefined();
+
+      // 같은 세션 안에서 다시 null → origin(context 빌드 가능한 station) 전환이 와도
+      // 세션당 1회 가드로 추가 heal 없음.
+      rerender({ cs: null });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      rerender({ cs: origin });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+
+    it('Tier 1 — heal 성공 후 station이 다시 흔들려도(null→non-null 재전환) 추가 heal 없음 (context 이미 보유)', async () => {
+      const { rerender } = renderHook(
+        ({ cs }: { cs: Station | null }) =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: cs,
+          }),
+        { initialProps: { cs: null as Station | null } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockRegister.mock.calls[0][0].promptGeoContext).toBeUndefined();
+
+      // 첫 heal 성공 — context 확보.
+      rerender({ cs: origin });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      expect(mockRegister.mock.calls[1][0].promptGeoContext).toBeDefined();
+
+      // GPS가 다시 흔들려 null이 됐다가 다른 유효 station으로 재전환돼도, 직전 register가
+      // 이미 context를 포함했으므로(lastRegisterMissingContextRef=false) heal을 재시도하지 않는다.
+      rerender({ cs: null });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      rerender({ cs: dest });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+
+    it('Tier 1 — currentStation이 이미 non-null로 시작한 trip은 heal 대상 아님(정상 등록 경로)', async () => {
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: route3,
+          destination: dest,
+          nextStationEtaSeconds: 120,
+          currentStation: origin,
+        }),
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockRegister.mock.calls[0][0].promptGeoContext).toBeDefined();
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+    });
+
+    describe('Tier 2 — 지하 fallback (route 출발역, 스탬프 없이)', () => {
+      beforeEach(() => {
+        jest.useFakeTimers();
+      });
+      afterEach(() => {
+        jest.useRealTimers();
+      });
+
+      it('60초 내 currentStation 미해소 + subsurface=true → route 출발역 기준 heal', async () => {
+        renderHook(() =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: null,
+            subsurface: true,
+            routeOriginStation: origin,
+          }),
+        );
+        await act(async () => {
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(1);
+        expect(mockRegister.mock.calls[0][0].promptGeoContext).toBeUndefined();
+
+        await act(async () => {
+          jest.advanceTimersByTime(CONTEXT_HEAL_TIER2_DELAY_MS);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(2);
+        const healed = mockRegister.mock.calls[1][0] as {
+          promptGeoContext?: { origin: { lat: number; lng: number }; originDistanceM?: number };
+          promptDisplay?: { originStation: string; line: string };
+        };
+        expect(healed.promptGeoContext?.origin).toEqual({ lat: origin.lat, lng: origin.lng });
+        // Tier 2는 스탬프 없이 송신 — GPS fix 여부와 무관하게 항상 생략.
+        expect(healed.promptGeoContext?.originDistanceM).toBeUndefined();
+        expect(healed.promptDisplay).toEqual({ originStation: '대화', line: '3' });
+      });
+
+      it('60초 후 currentStation이 이미 해소돼 있으면 Tier 2 heal 미발동', async () => {
+        const { rerender } = renderHook(
+          ({ cs }: { cs: Station | null }) =>
+            useApnsTripRegistration({
+              route: route3,
+              destination: dest,
+              nextStationEtaSeconds: 120,
+              currentStation: cs,
+              subsurface: true,
+              routeOriginStation: origin,
+            }),
+          { initialProps: { cs: null as Station | null } },
+        );
+        await act(async () => {
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(1);
+
+        // Tier 1이 먼저 정상 해소 (currentStation resolve) — Tier 2는 그 뒤로 발동할 필요 없음.
+        rerender({ cs: origin });
+        await act(async () => {
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(2);
+
+        await act(async () => {
+          jest.advanceTimersByTime(CONTEXT_HEAL_TIER2_DELAY_MS);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        // currentStation이 non-null이므로 Tier 2 조건(cs 미해소) 불충족 — 추가 register 없음.
+        expect(mockRegister).toHaveBeenCalledTimes(2);
+      });
+
+      it('subsurface=false면 60초가 지나도 Tier 2 heal 미발동', async () => {
+        renderHook(() =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: null,
+            subsurface: false,
+            routeOriginStation: origin,
+          }),
+        );
+        await act(async () => {
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+          jest.advanceTimersByTime(CONTEXT_HEAL_TIER2_DELAY_MS);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(1);
+      });
+
+      it('트립 종료가 60초 전에 일어나면 대기 중인 Tier 2 타이머를 cancel', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === APNS_TOKEN_KEY) return 'token-abc';
+          if (key === ACTIVE_TRIP_KEY) return 'token-abc';
+          return null;
+        });
+        const { rerender } = renderHook(
+          ({ r, d }: { r: Route | null; d: Station | null }) =>
+            useApnsTripRegistration({
+              route: r,
+              destination: d,
+              nextStationEtaSeconds: 120,
+              currentStation: null,
+              subsurface: true,
+              routeOriginStation: origin,
+            }),
+          { initialProps: { r: route3 as Route | null, d: dest as Station | null } },
+        );
+        await act(async () => {
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(1);
+
+        // 타이머가 발화하기 전에 trip 종료
+        rerender({ r: null, d: null });
+        await waitFor(() => expect(mockClear).toHaveBeenCalled());
+
+        await act(async () => {
+          jest.advanceTimersByTime(CONTEXT_HEAL_TIER2_DELAY_MS);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        // trip이 이미 종료돼 register가 추가로 호출되지 않는다 (타이머 cancel 확인).
+        expect(mockRegister).toHaveBeenCalledTimes(1);
+      });
+
+      it('60초 전에 같은 trip이 재등록되면 직전 Tier 2 타이머를 clear하고 재arm', async () => {
+        const { rerender } = renderHook(
+          ({ sub }: { sub: boolean }) =>
+            useApnsTripRegistration({
+              route: route3,
+              destination: dest,
+              nextStationEtaSeconds: 120,
+              currentStation: null,
+              subsurface: sub,
+              routeOriginStation: origin,
+            }),
+          { initialProps: { sub: true } },
+        );
+        await act(async () => {
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(1);
+
+        // subsurface deps 변경 → run() 재실행 → 이미 armed된 타이머를 clear 후 재arm.
+        act(() => {
+          jest.advanceTimersByTime(1000);
+        });
+        rerender({ sub: false });
+        await act(async () => {
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(2);
+
+        // 재arm된 타이머 기준으로 CONTEXT_HEAL_TIER2_DELAY_MS 경과해야 발동 — subsurface가
+        // 이제 false이므로 Tier 2 조건 자체는 불충족(추가 register 없음)이지만, 옛 타이머가
+        // clear됐다면 이 시점(원래 예정보다 1000ms 늦게 도착)에 register가 정확히 몇 번인지로
+        // "clear+재arm"이 실제로 일어났음을 간접 확인한다.
+        await act(async () => {
+          jest.advanceTimersByTime(CONTEXT_HEAL_TIER2_DELAY_MS);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(2);
+      });
+
+      it('이미 heal된 세션에서 타이머가 다시 도착해도 재heal하지 않는다 (세션 공유 가드)', async () => {
+        const { rerender } = renderHook(
+          ({ ime }: { ime: boolean }) =>
+            useApnsTripRegistration({
+              route: route3,
+              destination: dest,
+              nextStationEtaSeconds: 120,
+              currentStation: null,
+              subsurface: true,
+              infoModeEnabled: ime,
+              routeOriginStation: origin,
+            }),
+          { initialProps: { ime: false } },
+        );
+        await act(async () => {
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(1);
+
+        // 첫 Tier 2 heal 발동
+        await act(async () => {
+          jest.advanceTimersByTime(CONTEXT_HEAL_TIER2_DELAY_MS);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(2);
+
+        // infoModeEnabled 토글로 register가 다시 발생(deps 변경) — currentStation은 여전히
+        // null, subsurface도 여전히 true이므로 새 Tier 2 타이머가 재arm된다.
+        rerender({ ime: true });
+        await act(async () => {
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(3);
+
+        // 재arm된 타이머가 도착해도 이미 healedSessionKeyRef가 이 세션으로 세팅돼 있어 skip.
+        await act(async () => {
+          jest.advanceTimersByTime(CONTEXT_HEAL_TIER2_DELAY_MS);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(3);
+      });
+
+      it('route 출발역 기준 context 빌드가 실패하면(예: origin===destination) heal을 조용히 skip', async () => {
+        renderHook(() =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: null,
+            subsurface: true,
+            // buildBoardingPromptContext는 currentStation===destination이면 null을 반환한다
+            // (기존 동작) — Tier 2가 이 케이스를 override context 빌드 실패로 만나는 fixture.
+            routeOriginStation: dest,
+          }),
+        );
+        await act(async () => {
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+          jest.advanceTimersByTime(CONTEXT_HEAL_TIER2_DELAY_MS);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        // context 빌드 실패 — heal POST 없이 조용히 skip.
+        expect(mockRegister).toHaveBeenCalledTimes(1);
+      });
+
+      it('routeOriginStation이 없으면 60초가 지나도 Tier 2 heal 미발동 (fallback 대상 없음)', async () => {
+        renderHook(() =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: null,
+            subsurface: true,
+            routeOriginStation: null,
+          }),
+        );
+        await act(async () => {
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+          jest.advanceTimersByTime(CONTEXT_HEAL_TIER2_DELAY_MS);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('B-2 — GPS 근접 스탬프 (originDistanceM / originAccuracyM)', () => {
+      it('gpsFix 제공 시 promptGeoContext에 originDistanceM/originAccuracyM 동봉', async () => {
+        renderHook(() =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: origin,
+            gpsFix: { lat: origin.lat, lng: origin.lng, accuracyM: 12 },
+          }),
+        );
+        await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+        const args = mockRegister.mock.calls[0][0] as {
+          promptGeoContext?: { originDistanceM?: number; originAccuracyM?: number };
+        };
+        // gpsFix가 origin과 동일 좌표이므로 거리는 0에 수렴.
+        expect(args.promptGeoContext?.originDistanceM).toBe(0);
+        expect(args.promptGeoContext?.originAccuracyM).toBe(12);
+      });
+
+      it('gpsFix가 아예 없으면(null) originDistanceM/originAccuracyM 필드 자체를 생략', async () => {
+        renderHook(() =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: origin,
+            gpsFix: null,
+          }),
+        );
+        await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+        const args = mockRegister.mock.calls[0][0] as {
+          promptGeoContext?: { originDistanceM?: number; originAccuracyM?: number };
+        };
+        expect(args.promptGeoContext).toBeDefined();
+        expect(args.promptGeoContext?.originDistanceM).toBeUndefined();
+        expect(args.promptGeoContext?.originAccuracyM).toBeUndefined();
       });
     });
   });

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -29,9 +29,16 @@ import { buildBoardingLockMeta } from '../utils/buildBoardingLockMeta';
 import { cancelAllSafetyNetAlarms } from '../utils/safetyNetScheduler';
 import { clearBackendSsotMirror } from '../utils/backendSsotMirror';
 import { logCrossTripMirrorSkip } from '../utils/alarmLog';
-import { buildBoardingPromptContext, type BoardingPromptContext } from '../utils/boardingPromptContext';
+import {
+  buildBoardingPromptContext,
+  type BoardingPromptContext,
+  type GpsFix,
+} from '../utils/boardingPromptContext';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
-import { BOARDING_LOCK_RELEASE_DEBOUNCE_MS } from '../../../shared/constants/boardingLock';
+import {
+  BOARDING_LOCK_RELEASE_DEBOUNCE_MS,
+  CONTEXT_HEAL_TIER2_DELAY_MS,
+} from '../../../shared/constants/boardingLock';
 import { createLogger } from '../../../shared/utils/logger';
 import { getRegisteringApnsEnv, warmupConfirmedApnsEnv } from '../../../shared/utils/apnsEnv';
 import type { BoardingLock } from '../../../shared/types/boardingLock';
@@ -87,6 +94,20 @@ export interface UseApnsTripRegistrationInputs {
    * 미지정/false: 필드 미송신 (graceful) — backend 저장값 undefined 유지.
    */
   sleepMode?: boolean;
+  /**
+   * #2130 (B-2) — 등록 시점 GPS fix (lat/lng + accuracy). boarding-prompt 근접 게이트
+   * (backend B-backend, 별도 PR)의 입력으로 promptGeoContext에 동봉된다. GPS fix가 아예
+   * 없으면(GPS 미해소/권한 거절) 필드 자체를 생략 — backend는 부재를 관대하게(지하/구 클라
+   * 호환) 통과시킨다.
+   */
+  gpsFix?: GpsFix | null;
+  /**
+   * #2130 (B-1 Tier 2) — 등록 후 60초 내 `currentStation`이 여전히 미해소(지하 dead zone
+   * 등)이고 subsurface 판정일 때 fallback으로 사용할 route 출발역. 사용자가 역사 안에서
+   * route를 잡았다는 가정 — GPS 무관 persist 값(예: `useDestinationStore.tripOrigin`)을
+   * 그대로 전달한다.
+   */
+  routeOriginStation?: Station | null;
 }
 
 /**
@@ -122,6 +143,14 @@ interface RegisterCallInputs {
    * backend cron 진입 시점에 컨텍스트가 반드시 존재하도록 보장한다.
    */
   cachedPromptContext: BoardingPromptContext | null;
+  /**
+   * #2130 (B-1 Tier 2) — 미리 빌드된 context를 그대로 사용(currentStation 기반 fresh 빌드
+   * 및 cache fallback을 모두 건너뜀). `undefined`면 기존 fresh-build 경로, `null`이면
+   * "빌드 실패로 이번 사이클은 context 없음"을 명시.
+   */
+  promptContextOverride?: BoardingPromptContext | null;
+  /** #2130 (B-2) — 등록 시점 GPS fix. promptGeoContext 근접 스탬프 입력. */
+  gpsFix?: GpsFix | null;
 }
 
 /**
@@ -159,7 +188,16 @@ export function isLockConsistentWithRoute(lock: BoardingLock | null, route: Rout
 }
 
 /** 두 호출처(token refresh / main effect)의 register 페이로드 빌드를 단일화. */
-async function callRegister(input: RegisterCallInputs) {
+async function callRegister(
+  input: RegisterCallInputs,
+): Promise<
+  Awaited<ReturnType<typeof registerActiveTrip>> & {
+    hadPromptContext: boolean;
+    /** #2130 (B-1) — 실제로 송신된 context(있으면). 호출자가 캐시(`lastPromptContextRef`)에
+     * 반영해 Tier 1/Tier 2 heal 결과가 이후 register에도 이어지도록 한다. */
+    promptContext: BoardingPromptContext | null;
+  }
+> {
   // #622: BoardingLock metadata 빌드. lock의 boardingStationId로 station name 조회 후 schema 변환.
   // 조회/추론 실패 시 null → backend는 anchor waypoint 폴링으로 fallback (기존 동작).
   //
@@ -189,13 +227,21 @@ async function callRegister(input: RegisterCallInputs) {
   //
   // #1921 — lock 활성 시 lock.boardingLine + currentStation 우선 stamp. cross-trip 자동 전환에서
   // route 원본 line이 현재 leg와 어긋나도 stale stamp 회귀 차단.
-  const freshContext = buildBoardingPromptContext({
-    route: input.route,
-    currentStation: input.currentStation,
-    destination: input.destination,
-    lock: input.boardingLock,
-  });
-  const promptContext = freshContext ?? input.cachedPromptContext;
+  // #2130 (B-1 Tier 2) — 미리 빌드된 override가 있으면 fresh 빌드/cache fallback을 모두
+  // 건너뛰고 그대로 사용 (route 출발역 기준 heal — GPS 스탬프 없이 송신).
+  let promptContext: BoardingPromptContext | null;
+  if (input.promptContextOverride !== undefined) {
+    promptContext = input.promptContextOverride;
+  } else {
+    const freshContext = buildBoardingPromptContext({
+      route: input.route,
+      currentStation: input.currentStation,
+      destination: input.destination,
+      lock: input.boardingLock,
+      gpsFix: input.gpsFix,
+    });
+    promptContext = freshContext ?? input.cachedPromptContext;
+  }
 
   // #1895 — i18next.language를 backend가 인식하는 SupportedLocale로 정규화.
   // backend는 미송신 시 ko fallback이므로 비지원 locale은 송신 자체 skip.
@@ -205,7 +251,7 @@ async function callRegister(input: RegisterCallInputs) {
   // (`resolveApnsEnv()`)로 자연 fallback. self-heal 발동 횟수를 0에 수렴시키는 핵심 wire.
   const apnsEnv = await getRegisteringApnsEnv();
 
-  return registerActiveTrip({
+  const result = await registerActiveTrip({
     token: input.token,
     route: input.route,
     destination: input.destination.id,
@@ -233,6 +279,9 @@ async function callRegister(input: RegisterCallInputs) {
     // false/미설정은 필드 누락(graceful) — backend Trip.sleepModeEnabled=undefined 유지.
     ...(input.sleepMode ? { sleepModeEnabled: true } : {}),
   });
+  // #2130 (B-1) — 이번 register가 실제로 promptContext를 포함했는지 + 그 내용을 호출자에게 노출.
+  // Tier 1 heal 판정의 SSoT이자, 캐시(`lastPromptContextRef`) 갱신 입력.
+  return { ...result, hadPromptContext: promptContext != null, promptContext };
 }
 
 export function useApnsTripRegistration({
@@ -244,6 +293,8 @@ export function useApnsTripRegistration({
   subsurface = false,
   infoModeEnabled = false,
   sleepMode = false,
+  gpsFix = null,
+  routeOriginStation = null,
 }: UseApnsTripRegistrationInputs): void {
   // route 객체 reference가 categorized recompute로 자주 바뀌므로 내용 기반 signature로
   // 메모화 — register useEffect deps에 사용해 동일 경로 재등록(POST /trips 폭주) 방지.
@@ -252,9 +303,31 @@ export function useApnsTripRegistration({
   // alarmBackend dedup hash와 동일 필드 사용 (trainCode + line + boardedAt).
   const boardingLockSig = lockSig(boardingLock);
   // 최신 트립 입력을 ref에 보관 — pushTokenListener가 갱신 시 재등록에 사용한다.
-  const latestInputsRef = useRef({ route, destination, nextStationEtaSeconds, currentStation, boardingLock, subsurface, infoModeEnabled, sleepMode });
+  const latestInputsRef = useRef({
+    route,
+    destination,
+    nextStationEtaSeconds,
+    currentStation,
+    boardingLock,
+    subsurface,
+    infoModeEnabled,
+    sleepMode,
+    gpsFix,
+    routeOriginStation,
+  });
   useEffect(() => {
-    latestInputsRef.current = { route, destination, nextStationEtaSeconds, currentStation, boardingLock, subsurface, infoModeEnabled, sleepMode };
+    latestInputsRef.current = {
+      route,
+      destination,
+      nextStationEtaSeconds,
+      currentStation,
+      boardingLock,
+      subsurface,
+      infoModeEnabled,
+      sleepMode,
+      gpsFix,
+      routeOriginStation,
+    };
   });
 
   // #589 — backend `isSameSession`(token+createdAt) 판정용. 같은 trip(같은
@@ -294,6 +367,18 @@ export function useApnsTripRegistration({
   const lastDestinationIdRef = useRef<string | null>(null);
   const lastBoardingLockSigRef = useRef<string | null>(null);
 
+  // #2130 (B-1) — 직전 register가 promptContext 없이 나갔는지 여부. Tier 1 heal 트리거의
+  // SSoT — registerFromLatestInputs가 매 호출마다 callRegister의 실제 결과로 갱신한다.
+  const lastRegisterMissingContextRef = useRef(false);
+  // #2130 (B-1) — 이미 heal을 수행한 세션 key(`routeSig:destinationId`). Tier 1/Tier 2가
+  // 공유해 세션당 heal이 정확히 1회만 발동하도록 가드한다.
+  const healedSessionKeyRef = useRef<string | null>(null);
+  // #2130 (B-1 Tier 1) — 직전 렌더의 currentStation.id. null→non-null 전환 감지에 사용.
+  // lazy init으로 mount 시점 값을 그대로 캡처 — 이미 non-null로 시작한 trip은 전환 대상이 아니다.
+  const prevCurrentStationIdRef = useRef<string | null>(currentStation?.id ?? null);
+  // #2130 (B-1 Tier 2) — 지하 fallback 타이머 핸들.
+  const tier2TimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   /**
    * #2129 — 두 register 경로(main effect / token-refresh listener)가 거의 동시에 실행돼도
    * 동일 입력에서 동일 payload를 만들도록 `latestInputsRef` 단일 출처에서 register하는 helper.
@@ -308,6 +393,7 @@ export function useApnsTripRegistration({
    */
   const registerFromLatestInputs = async (
     token: string,
+    options?: { promptContextOverride?: BoardingPromptContext | null },
   ): Promise<Awaited<ReturnType<typeof callRegister>> | null> => {
     const {
       route: r,
@@ -318,6 +404,7 @@ export function useApnsTripRegistration({
       subsurface: sub,
       infoModeEnabled: ime,
       sleepMode: sm,
+      gpsFix: gf,
     } = latestInputsRef.current;
     if (!r || !d) return null;
     const sessionKey = `${token}:${routeSignature(r)}:${d.id}`;
@@ -333,10 +420,51 @@ export function useApnsTripRegistration({
       sleepMode: sm,
       createdAt: resolveTripCreatedAt(sessionKey),
       cachedPromptContext: lastPromptContextRef.current,
+      promptContextOverride: options?.promptContextOverride,
+      gpsFix: gf,
     });
     // #767 — 두 경로 모두 동일 기준으로 lock sig를 추적해야 다음 cycle의 release 판정 정확도 유지.
     lastSentLockSigRef.current = lockSig(bl);
+    // #2130 (B-1) — 이번 register가 실제로 promptContext를 포함했는지 기록. 다음 currentStation
+    // null→non-null 전환 시 Tier 1 heal이 필요한지 판정하는 SSoT.
+    lastRegisterMissingContextRef.current = !result.hadPromptContext;
+    // #2130 (B-1) — 성공한 context(fresh/override 무관)를 캐시에 반영. Tier 2 heal의 route-origin
+    // 근사 context도 이 캐시를 통해 이후 정상 register(currentStation 여전히 null)에 이어져
+    // "heal 직후 다음 register가 다시 결손"되는 회귀를 막는다.
+    if (result.promptContext) lastPromptContextRef.current = result.promptContext;
     return result;
+  };
+
+  /**
+   * #2130 (B-1 Tier 2) — 지하 fallback heal. 등록 후 `CONTEXT_HEAL_TIER2_DELAY_MS` 시점에
+   * currentStation이 여전히 미해소 + subsurface 판정이면 route 출발역(`routeOriginStation`)
+   * 기준으로 promptContext를 빌드해 스탬프 없이 재등록한다.
+   *
+   * 발동 조건이 모두 충족되지 않으면 조용히 skip(graceful) — trip 종료, GPS 정상 해소, 지상
+   * 판정, 사용자가 route 미확정(routeOriginStation 없음) 등은 모두 정상 상태다.
+   */
+  const runTier2Heal = async (token: string, sessionKey: string): Promise<void> => {
+    const { route: r, destination: d, currentStation: cs, subsurface: sub, boardingLock: bl, routeOriginStation: origin } =
+      latestInputsRef.current;
+    /* istanbul ignore next -- route/destination이 null로 바뀌는 모든 경로(deps: routeSig,
+     * destination?.id)는 이 effect의 cleanup이 트립 종료 시점에 tier2TimerRef를 이미
+     * clearTimeout하므로, 이 콜백 자체가 trip 종료 후 실행될 도달 경로가 없다. 향후 리팩터로
+     * 그 보장이 깨질 경우를 대비한 방어적 가드. */
+    if (!r || !d) return; // trip 종료됨
+    if (cs != null) return; // 이미 GPS로 해소됨 — Tier 2 대상 아님
+    if (!sub) return; // 지하 판정 아님
+    if (origin == null) return; // fallback 대상 route 출발역 없음
+    if (healedSessionKeyRef.current === sessionKey) return; // 이미 heal 완료(Tier 1 포함)
+    const overrideContext = buildBoardingPromptContext({
+      route: r,
+      currentStation: origin,
+      destination: d,
+      lock: bl,
+      // gpsFix 미전달 — Tier 2는 스탬프 없이 송신(currentStation 자체가 GPS 미해소 상태).
+    });
+    if (overrideContext == null) return; // route 구조상 빌드 실패 — graceful skip
+    healedSessionKeyRef.current = sessionKey;
+    await registerFromLatestInputs(token, { promptContextOverride: overrideContext });
   };
 
   // ── 토큰 발급 + 리스너 등록 (mount-once) ──
@@ -415,6 +543,12 @@ export function useApnsTripRegistration({
         // #1284: trip 종료 시 prompt context 캐시 reset — 다음 trip이 이전 trip의
         // 출발역 컨텍스트를 stamp하는 오염 방지.
         lastPromptContextRef.current = null;
+        // #2130 (B-1): trip 종료 시 context-heal tracking 전부 reset — 다음 trip이 새로
+        // heal 1회 기회를 갖도록. (Tier 2 타이머는 이 effect의 cleanup이 이미 이전 execution
+        // 시점에 cancel했다 — 여기서 다시 clear할 필요 없음.)
+        lastRegisterMissingContextRef.current = false;
+        healedSessionKeyRef.current = null;
+        prevCurrentStationIdRef.current = null;
         return;
       }
 
@@ -455,7 +589,13 @@ export function useApnsTripRegistration({
       // #1284 — buildBoardingPromptContext가 성공하면 캐시 갱신. 이후 currentStation이
       // 일시 null이 돼도 cachedPromptContext로 fallback하여 backend 9단 게이트가 계속 진입 가능.
       // #1921 — lock 동봉. cross-trip 자동 전환 시 stale stamp 차단(callRegister 분기와 동일 입력).
-      const freshCtx = buildBoardingPromptContext({ route, currentStation, destination, lock: boardingLock });
+      const freshCtx = buildBoardingPromptContext({
+        route,
+        currentStation,
+        destination,
+        lock: boardingLock,
+        gpsFix: latestInputsRef.current.gpsFix,
+      });
       if (freshCtx) lastPromptContextRef.current = freshCtx;
       // R11-a (#1612): trip register 직전 backend SSoT mirror 강제 clean.
       // 스펙 docs/requirements/15-trip-alarm-notification.md:89 명시 요구사항 — "trip 등록(new)
@@ -481,6 +621,19 @@ export function useApnsTripRegistration({
       if (result?.ok) {
         await AsyncStorage.setItem(ACTIVE_TRIP_KEY, token);
       }
+      // #2130 (B-1 Tier 2) — 이번 register가 성공했으면 60초 타이머를 arm. 이 effect의
+      // cleanup이 매 re-execution 전에 이전 타이머를 이미 cancel하므로(아래), 여기 도달한
+      // 시점엔 tier2TimerRef가 항상 비어 있다 — "가장 최근 성공 register로부터 60초"가 기준.
+      if (result?.ok) {
+        // #2130 (B-1) — Tier 1과 동일한 `${routeSig}:${destination.id}` 포맷을 써야
+        // `healedSessionKeyRef` 가드가 두 tier에 걸쳐 세션당 1회를 정확히 보장한다(토큰은
+        // refresh로 바뀔 수 있어 세션 정체성에 포함하지 않는다).
+        const healSessionKey = `${routeSig}:${destination.id}`;
+        tier2TimerRef.current = setTimeout(() => {
+          tier2TimerRef.current = null;
+          void runTier2Heal(token, healSessionKey);
+        }, CONTEXT_HEAL_TIER2_DELAY_MS);
+      }
     };
 
     // #767 — lock 해제(non-null → null) 전환만 debounce. 다음 cycle이 새 lock을 들고 오면
@@ -503,6 +656,12 @@ export function useApnsTripRegistration({
       if (debounceTimer !== null) {
         clearTimeout(debounceTimer);
       }
+      // #2130 (B-1 Tier 2) — 이 effect cycle이 재실행(route/destination/lock 등 전환)되거나
+      // unmount되면 stale 세션 기준으로 예약된 타이머를 취소. 새 cycle의 run()이 필요 시 재arm.
+      if (tier2TimerRef.current !== null) {
+        clearTimeout(tier2TimerRef.current);
+        tier2TimerRef.current = null;
+      }
     };
     // route는 routeSig(내용 기반)로 비교 — 동일 경로 재등록으로 백엔드 trip
     // state(waypoints shift)가 reset되거나 워커 POST /trips가 분당 폭주하는 것을 방지.
@@ -524,4 +683,41 @@ export function useApnsTripRegistration({
     // suppress 판정. 토글 빈도는 사용자 명시 설정 시점만이므로 deps churn 위험 낮음.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [routeSig, destination?.id, boardingLockSig, subsurface, infoModeEnabled, sleepMode]);
+
+  // ── #2130 (B-1 Tier 1) — context-heal on currentStation null→non-null 전환 ──
+  //
+  // 위 main register effect는 #703 의도(POST 폭주 방지)로 currentStation을 deps에서 제외한다.
+  // 그 결과 cold-start register가 currentStation=null로 나가면(promptContext 결손) 이후
+  // GPS/fusion이 station을 해소해도 재등록 트리거가 없어 결손이 trip 내내 지속된다(#2130 근본
+  // 원인). 이 effect는 currentStation만을 deps로 갖는 별도 effect로 그 트리거를 신설한다 —
+  // main effect의 raw-deps 정책 자체는 건드리지 않는다.
+  //
+  // 조건: 활성 trip + 직전 register에 promptContext 없었음 + null→non-null 전환 + 세션당 미heal.
+  useEffect(() => {
+    const prevWasNull = prevCurrentStationIdRef.current == null;
+    prevCurrentStationIdRef.current = currentStation?.id ?? null;
+
+    if (!route || !destination) return; // trip 없음 — heal 대상 아님(trip-end 분기가 별도 reset).
+    if (!prevWasNull || currentStation == null) return; // null→non-null 전환만 대상.
+    if (!lastRegisterMissingContextRef.current) return; // 직전 register에 이미 context 있었음.
+
+    const sessionKey = `${routeSig}:${destination.id}`;
+    if (healedSessionKeyRef.current === sessionKey) return; // 세션당 1회 가드.
+
+    let cancelled = false;
+    void (async () => {
+      const token = await AsyncStorage.getItem(APNS_TOKEN_KEY);
+      if (cancelled || !token) return;
+      // 가드를 먼저 세팅 — in-flight 중 동일 세션의 중복 heal 방지.
+      healedSessionKeyRef.current = sessionKey;
+      await registerFromLatestInputs(token);
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // currentStation.id 전환만이 이 effect의 트리거 — route/destination 등은 closure로 최신값
+    // 참조(gate 조건 평가용)하되 deps에는 넣지 않는다: 위 main effect가 이미 그 변경들을
+    // 처리하므로 이 effect까지 반응하면 heal 판정이 중복 실행된다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentStation?.id]);
 }

--- a/src/features/alarm/utils/boardingPromptContext.ts
+++ b/src/features/alarm/utils/boardingPromptContext.ts
@@ -37,15 +37,30 @@ import {
   getNextStationName,
   getNextStationOnLine,
 } from '../../../shared/utils/stationRoute';
+import { haversine } from '../../../shared/utils/haversine';
 import { resolveTravelDirection } from '../../route/utils/travelDirection';
 import { inferLoopDirection } from '../../route/utils/loopDirection';
 import { findSegmentEndStationName } from './buildBoardingLockMeta';
+
+/** #2130 (B-2) — 등록 시점 GPS fix. 근접 스탬프 입력. */
+export interface GpsFix {
+  lat: number;
+  lng: number;
+  accuracyM: number;
+}
 
 export interface BoardingPromptContext {
   promptGeoContext: {
     origin: { lat: number; lng: number };
     nextStation: { lat: number; lng: number };
     direction: 'up' | 'down' | null;
+    /**
+     * #2130 (B-2) — origin과 GPS fix 사이 거리(m). backend 근접 게이트(B-backend, 별도 PR)의
+     * 입력. GPS fix가 아예 없을 때만 생략 — backend는 부재를 관대하게(지하/구 클라) 통과시킨다.
+     */
+    originDistanceM?: number;
+    /** #2130 (B-2) — GPS fix 정확도(m). originDistanceM과 항상 짝으로만 존재. */
+    originAccuracyM?: number;
   };
   promptDisplay: {
     originStation: string;
@@ -70,6 +85,21 @@ interface BuildInputs {
    * 담당하고 본 컨텍스트는 prompt 전용 stamp만 갱신한다.
    */
   lock?: BoardingLock | null;
+  /**
+   * #2130 (B-2) — 등록 시점 GPS fix. 제공되면 origin과의 거리를 계산해 promptGeoContext에
+   * 동봉한다. 미제공(undefined/null)이면 필드 자체를 생략(GPS fix 없음 — 지하/권한거절 graceful).
+   */
+  gpsFix?: GpsFix | null;
+}
+
+/** #2130 (B-2) — GPS fix가 있을 때만 origin 근접 스탬프 필드를 만든다. */
+function buildOriginGpsStamp(
+  origin: { lat: number; lng: number },
+  gpsFix: GpsFix | null | undefined,
+): { originDistanceM: number; originAccuracyM: number } | Record<string, never> {
+  if (gpsFix == null) return {};
+  const originDistanceM = Math.round(haversine(gpsFix.lat, gpsFix.lng, origin.lat, origin.lng) * 1000);
+  return { originDistanceM, originAccuracyM: gpsFix.accuracyM };
 }
 
 export function buildBoardingPromptContext({
@@ -77,13 +107,14 @@ export function buildBoardingPromptContext({
   currentStation,
   destination,
   lock,
+  gpsFix,
 }: BuildInputs): BoardingPromptContext | null {
   if (!route || !currentStation || !destination) return null;
 
   // #1921 — lock 활성 분기. route 원본 line이 lock leg와 어긋난 cross-trip 자동 전환에서
   // currentStation 기준으로 lock.boardingLine 위의 다음 역 좌표 + direction을 stamp.
   if (lock != null) {
-    return buildLockActiveContext({ route, currentStation, destination, lock });
+    return buildLockActiveContext({ route, currentStation, destination, lock, gpsFix });
   }
 
   // lock 미활성 — 기존 first-leg 기반 path 보존.
@@ -102,11 +133,13 @@ export function buildBoardingPromptContext({
     resolveTravelDirection(leg.line, currentStation.name, leg.endName)?.direction ??
     inferLoopDirection(leg.line, currentStation.name, leg.endName);
 
+  const origin = { lat: currentStation.lat, lng: currentStation.lng };
   return {
     promptGeoContext: {
-      origin: { lat: currentStation.lat, lng: currentStation.lng },
+      origin,
       nextStation: { lat: nextStation.lat, lng: nextStation.lng },
       direction,
+      ...buildOriginGpsStamp(origin, gpsFix),
     },
     promptDisplay: {
       originStation: currentStation.name,
@@ -130,11 +163,13 @@ function buildLockActiveContext({
   currentStation,
   destination,
   lock,
+  gpsFix,
 }: {
   route: NonNullable<Route>;
   currentStation: Station;
   destination: Station;
   lock: BoardingLock;
+  gpsFix?: GpsFix | null;
 }): BoardingPromptContext | null {
   const segmentEndName = findSegmentEndStationName(route, lock.boardingLine, destination.name);
   if (segmentEndName == null) return null;
@@ -150,11 +185,13 @@ function buildLockActiveContext({
     resolveTravelDirection(lock.boardingLine, currentStation.name, segmentEndName)?.direction ??
     inferLoopDirection(lock.boardingLine, currentStation.name, segmentEndName);
 
+  const origin = { lat: currentStation.lat, lng: currentStation.lng };
   return {
     promptGeoContext: {
-      origin: { lat: currentStation.lat, lng: currentStation.lng },
+      origin,
       nextStation: { lat: nextStation.lat, lng: nextStation.lng },
       direction,
+      ...buildOriginGpsStamp(origin, gpsFix),
     },
     promptDisplay: {
       originStation: currentStation.name,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -900,6 +900,16 @@ export default function HomeScreen() {
     // #2032 (Issue D) — device 취침모드 상태. backend monitoring 전용 저장 (ADR-023 결정 gate 미사용).
     // skip 원인 분류 + evidence 재구성 자동화용. Device의 `shouldSuppressBySleepRule`이 실제 suppress gate.
     sleepMode,
+    // #2130 (B-2) — 등록 시점 GPS fix. boarding-prompt 근접 게이트(backend B-backend) 입력.
+    // fix 없으면(GPS 미해소/권한거절) undefined 대신 null로 명시 전달 — 필드 자체 생략은 hook이 처리.
+    gpsFix:
+      userLocation && accuracyMeters != null
+        ? { lat: userLocation.lat, lng: userLocation.lng, accuracyM: accuracyMeters }
+        : null,
+    // #2130 (B-1 Tier 2) — 지하 fallback heal의 route 출발역. effectiveOrigin은 GPS pause에도
+    // customOrigin/lastFusedStation/boardingLockStation/tripOrigin 순으로 fallback해 currentStation이
+    // GPS dead zone으로 null일 때도 trip의 출발역을 그대로 보존한다(#1379).
+    routeOriginStation: effectiveOrigin,
   });
 
   useEffect(() => {

--- a/src/shared/constants/boardingLock.ts
+++ b/src/shared/constants/boardingLock.ts
@@ -114,3 +114,14 @@ export const BOARDING_LOCK_RELEASE_DEBOUNCE_MS = 1500;
  * 값은 일반 destination id(`stn-*`, UUID 등)와 충돌하지 않도록 `__` prefix.
  */
 export const FREE_TRIP_DESTINATION_SENTINEL = '__free-trip-sentinel__';
+
+/**
+ * #2130 (B-1 Tier 2) — 지하 fallback context-heal 대기 시간(ms).
+ *
+ * trip 등록 후 이 시간 동안 `currentStation`이 여전히 미해소(GPS dead zone)이고 지하 판정
+ * (subsurface)이면 route 출발역 기준으로 boarding-prompt context를 heal한다. 60s로 둔 이유:
+ *  - GPS/fusion 폴링 주기(30s)의 2 tick — 일시적 fix 지연을 최소 1~2회 흡수한 뒤에만 fallback.
+ *  - 너무 짧으면(예: 15s) 정상 GPS 해소 중인 trip까지 route-origin 근사치로 stamp해 정밀도 손실.
+ *  - 너무 길면(예: 5분) 사용자가 이미 열차에 탑승한 뒤에야 prompt 평가가 시작돼 A1(≤3분) 위반.
+ */
+export const CONTEXT_HEAL_TIER2_DELAY_MS = 60_000;


### PR DESCRIPTION
## 요약

Part of #2130 — Part B-device 구현. 플랜 SSoT: `tasks/plan-2026-08-04-boarding-prompt-accuracy.md` §단계 1 (B-1, B-2).

Cold-start register에서 `currentStation=null` closure로 `promptGeoContext`가 backend에 영원히 도달하지 못하는 근본 결손을 두 단계 fallback으로 해소한다.

- **B-1 Tier 1**: 활성 trip + 직전 register에 promptContext 없음 + `currentStation` null→non-null 전환 시 **세션당 정확히 1회** context-heal 재등록. `useApnsTripRegistration.ts`의 #703 의도(main register effect는 currentStation을 raw deps에서 계속 제외)를 보존 — `currentStation`만을 deps로 갖는 **별도 effect**를 신설해 트리거를 추가했다.
- **B-1 Tier 2 (지하 fallback, A7)**: 등록 후 60초 내 `currentStation`이 여전히 미해소 + `subsurface` 판정이면 route 출발역(`routeOriginStation` — HomeScreen의 `effectiveOrigin`, GPS pause에도 tripOrigin까지 4단 fallback하는 기존 값) 기준으로 컨텍스트를 빌드해 **스탬프 없이** heal. Tier 1과 `healedSessionKeyRef`(세션 = `routeSig:destination.id`, 토큰 무관)를 공유해 두 tier를 합쳐 세션당 1회만 heal.
- **B-2**: `gpsFix`(lat/lng/accuracyM) 제공 시 `promptGeoContext`에 `originDistanceM`/`originAccuracyM`을 haversine으로 계산해 동봉. GPS fix가 아예 없을 때만 두 필드를 생략(backend 관대 통과 — B-backend가 부재를 허용하도록 설계됨, 별도 PR).
- 부수: `callRegister`가 실제 송신된 promptContext를 `lastPromptContextRef` 캐시에 반영하도록 수정 — Tier 2 heal(route-origin 근사치)도 캐시에 남아 heal 직후 다음 정상 register가 다시 결손되는 회귀를 막는다.

## 변경 파일

- `src/features/alarm/hooks/useApnsTripRegistration.ts` — Tier 1/2 heal 로직, `gpsFix`/`routeOriginStation` 입력 추가
- `src/features/alarm/utils/boardingPromptContext.ts` — `gpsFix` 파라미터 + `originDistanceM`/`originAccuracyM` 스탬프
- `src/features/alarm/api/alarmBackend.ts` — `RegisterTripPayload.promptGeoContext` 타입 확장 (fetch body는 기존에 `promptGeoContext` 객체를 통째로 전달하므로 로직 변경 없음)
- `src/shared/constants/boardingLock.ts` — `CONTEXT_HEAL_TIER2_DELAY_MS`(60s) 상수
- `src/screens/HomeScreen.tsx` — `gpsFix`(userLocation+accuracyMeters), `routeOriginStation`(effectiveOrigin) 배선
- `src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts` — cold-start heal, 1회 가드(Tier1/Tier2 공유), Tier2 fallback 4종, 캐시 반영 회귀, GPS 스탬프 유무 unit

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` 로컬 pass (0 orphan). 신규 export(`GpsFix` 타입 등)는 모두 기존 호출자(`useApnsTripRegistration`, `HomeScreen`)에서 사용.
2. **V/X dashboard** — 신규 필드(`originDistanceM`/`originAccuracyM`)는 DebugModal에서 별도 노출은 아직 없음(B-backend PR에서 backend 게이트 판정 로그와 함께 추가 예정). 현재는 `instrumentBackendFetch` 진단 buffer(DebugModal의 백엔드 호출 로그)에서 POST body 전체가 이미 노출되므로 간접 관측 가능.
3. **의존 PR** — 없음(N/A) — 코드는 필드를 추가만 하고 backend는 아직 이 필드를 읽지 않아(#2130 B-backend, 준비 중) 무해하게 무시됨. B-backend PR이 머지돼야 근접 게이트가 실제로 이 값을 사용한다.
4. **측정 plan** — 다음 실탑승 dump에서 KV 활성 trip의 `promptGeoContext`에 `originDistanceM`/`originAccuracyM` 필드가 채워지는지 확인. cold-start 시나리오(역에서 앱 실행) 1회 재현해 첫 register 대비 heal 여부를 `instrumentBackendFetch` 로그로 대조.
5. **Device verify** — 필요. 시나리오: (a) 지상에서 앱을 cold-start로 켜고 GPS가 station을 늦게 해소하는 경우 heal이 발동하는지, (b) 지하 역사 안에서 trip을 시작해 60초간 GPS가 안 잡히는 경우 Tier 2 heal이 route 출발역으로 발동하는지. 두 시나리오 모두 KV `promptGeoContext` 유무로 확인 가능.

## 검증

- `npm test` — 424 suites / 9023 tests pass, coverage 100% (lines/branches/functions/statements)
- `npm run type-check` — pass
- `npm run lint:orphan` — pass (0 orphan)
- `npx eslint` (변경 파일 대상) — 0 errors

## 이슈 스펙 대비 이탈 사항

없음. Acceptance 1(cold-start 회귀 테스트), 2(#703 의도 보존), 4(infoModeEnabled/#918 관련 backend 변경)는 각각 A-2(#2131, 이미 머지) / B-backend(#2130, 준비 중)가 담당 범위라 본 PR 범위 밖.