### PR TITLE
fix(#2130): boarding-prompt 근접·신선도 게이트 (Part B-be-1, dev 재타겟)

### DIFF
--- a/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
+++ b/backend/alarm-worker/src/__tests__/boardingPrompt.test.ts
@@ -68,7 +68,9 @@ describe('evaluateBoardingPromptGates — 9단 AND 게이트', () => {
     }
   });
 
-  it('#9: 이미 fired된 trip은 차단', () => {
+  // #2130 (Part B-be-2) — "trip당 1회(fired 영구 차단)" 정책 폐기. `fired` 자체는 더 이상
+  // 검사하지 않고 `lastFiredAt` 기준 최소 발사 간격(5분)으로 dedup한다.
+  it('#9: 최근(5분 미만) 발사된 trip은 fired-too-recently로 차단', () => {
     const r = evaluateBoardingPromptGates({
       series: happySeries(now),
       origin: ORIGIN,
@@ -76,7 +78,29 @@ describe('evaluateBoardingPromptGates — 9단 AND 게이트', () => {
       now,
       promptState: { fired: true, lastFiredAt: now - 1000 },
     });
-    expect(r).toEqual(expect.objectContaining({ pass: false, reason: 'already-fired' }));
+    expect(r).toEqual(expect.objectContaining({ pass: false, reason: 'fired-too-recently' }));
+  });
+
+  it('#9: fired=true 여도 최소 간격(5분) 경과 + 최대 횟수 미달이면 통과 (반복 발사 A4)', () => {
+    const r = evaluateBoardingPromptGates({
+      series: happySeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      promptState: { fired: true, lastFiredAt: now - 5 * 60 * 1000, fireCount: 1 },
+    });
+    expect(r.pass).toBe(true);
+  });
+
+  it('#9: fireCount가 최대 발사 횟수(3)에 도달하면 max-fires-reached로 차단', () => {
+    const r = evaluateBoardingPromptGates({
+      series: happySeries(now),
+      origin: ORIGIN,
+      nextStation: NEXT,
+      now,
+      promptState: { fired: true, lastFiredAt: now - 10 * 60 * 1000, fireCount: 3 },
+    });
+    expect(r).toEqual(expect.objectContaining({ pass: false, reason: 'max-fires-reached' }));
   });
 
   it('#9: silencedUntil이 미래면 silenced 차단', () => {
@@ -449,7 +473,9 @@ describe('evaluateBoardingPromptGates — #1536 (S3) 환경 분기', () => {
     if (!r.pass) expect(r.reason).toBe('motion-stationary');
   });
 
-  it('underground: 이미 fired = already-fired (게이트 #9 우선 평가)', () => {
+  // #2130 (Part B-be-2) — "trip당 1회" 정책 폐기. underground 분기에서도 반복 발사 게이트
+  // (fired-too-recently)가 #9로 우선 평가된다.
+  it('underground: 최근 발사(5분 미만) = fired-too-recently (게이트 #9 우선 평가)', () => {
     const r = evaluateBoardingPromptGates({
       series: staleGpsSeries(now),
       origin: ORIGIN,
@@ -459,7 +485,7 @@ describe('evaluateBoardingPromptGates — #1536 (S3) 환경 분기', () => {
       promptState: { fired: true, lastFiredAt: now - 1000 },
     });
     expect(r.pass).toBe(false);
-    if (!r.pass) expect(r.reason).toBe('already-fired');
+    if (!r.pass) expect(r.reason).toBe('fired-too-recently');
   });
 
   it('mixed: GPS 의존 게이트 byPass (underground 와 동일 분기)', () => {
@@ -641,7 +667,9 @@ describe('evaluateBoardingPromptGates — #2014 (ADR-022 B8) archFlag', () => {
     expect(r.pass).toBe(true);
   });
 
-  it('archFlag=on: 이미 fired = already-fired (게이트 #9 는 여전히 평가)', () => {
+  // #2130 (Part B-be-2) — "trip당 1회" 정책 폐기. archFlag=on 에서도 반복 발사 게이트
+  // (fired-too-recently)가 #9로 여전히 평가된다.
+  it('archFlag=on: 최근 발사(5분 미만) = fired-too-recently (게이트 #9 는 여전히 평가)', () => {
     const r = evaluateBoardingPromptGates({
       series: happySeries(now),
       origin: ORIGIN,
@@ -651,7 +679,7 @@ describe('evaluateBoardingPromptGates — #2014 (ADR-022 B8) archFlag', () => {
       archFlag: 'on',
     });
     expect(r.pass).toBe(false);
-    if (!r.pass) expect(r.reason).toBe('already-fired');
+    if (!r.pass) expect(r.reason).toBe('fired-too-recently');
   });
 
   it('archFlag=on: silencedUntil 미래 = silenced (게이트 #9 는 여전히 평가)', () => {
@@ -694,8 +722,27 @@ describe('evaluateBoardingPromptGates — #2014 (ADR-022 B8) archFlag', () => {
 });
 
 describe('markPromptFired / markPromptSilenced', () => {
-  it('markPromptFired는 fired=true + lastFiredAt 설정', () => {
-    expect(markPromptFired(1234)).toEqual({ fired: true, lastFiredAt: 1234 });
+  it('markPromptFired는 fired=true + lastFiredAt 설정 (prev/trainCode 없으면 fireCount=1, firedTrainCodes 생략)', () => {
+    expect(markPromptFired(1234)).toEqual({ fired: true, lastFiredAt: 1234, fireCount: 1 });
+  });
+
+  // #2130 (Part B-be-2) — 반복 발사(A4) 상태 누적.
+  it('markPromptFired: prev + trainCode 전달 시 firedTrainCodes append + fireCount 증가', () => {
+    const prev = { fired: true, lastFiredAt: 1000, fireCount: 1, firedTrainCodes: ['A1'] };
+    const r = markPromptFired(2000, prev, 'B2');
+    expect(r).toEqual({
+      fired: true,
+      lastFiredAt: 2000,
+      fireCount: 2,
+      firedTrainCodes: ['A1', 'B2'],
+    });
+  });
+
+  it('markPromptFired: trainCode=null 이면 firedTrainCodes는 prev 그대로(append 없음)', () => {
+    const prev = { fired: true, lastFiredAt: 1000, fireCount: 1, firedTrainCodes: ['A1'] };
+    const r = markPromptFired(2000, prev, null);
+    expect(r.firedTrainCodes).toEqual(['A1']);
+    expect(r.fireCount).toBe(2);
   });
   it('markPromptSilenced는 silencedUntil = now + DISMISS_SILENCE_MS', () => {
     const r = markPromptSilenced(undefined, 1000);

--- a/backend/alarm-worker/src/__tests__/evidence_20260703_replay.test.ts
+++ b/backend/alarm-worker/src/__tests__/evidence_20260703_replay.test.ts
@@ -400,7 +400,10 @@ describe('boardingPrompt gate archFlag 매트릭스 — 회귀 방어', () => {
   /**
    * Wave 1 완결 후에도 archFlag=off 회귀는 없어야 함 (기존 9단 gate 유지).
    */
-  it('archFlag=off 시 기존 9단 gate 평가 (already-fired promptState 는 차단)', () => {
+  // #2130 (Part B-be-2) — "trip당 1회" 정책 폐기. makeBoardingPromptFiredState()는
+  // lastFiredAt=FIXTURE_NOW-60_000(1분 전)이라 최소 발사 간격(5분) 게이트로 여전히 차단된다 —
+  // reason만 already-fired → fired-too-recently로 바뀐다.
+  it('archFlag=off 시 기존 9단 gate 평가 (최근 발사 promptState 는 fired-too-recently로 차단)', () => {
     const firedState = makeBoardingPromptFiredState();
     const outcome = evaluateBoardingPromptGates({
       series: [],
@@ -411,10 +414,10 @@ describe('boardingPrompt gate archFlag 매트릭스 — 회귀 방어', () => {
       // archFlag 미지정 = 기존 동작
     });
     expect(outcome.pass).toBe(false);
-    if (!outcome.pass) expect(outcome.reason).toBe('already-fired');
+    if (!outcome.pass) expect(outcome.reason).toBe('fired-too-recently');
   });
 
-  it('archFlag=on 시 already-fired 상태는 여전히 차단 (dedup 정책 유지)', () => {
+  it('archFlag=on 시 최근 발사 상태는 여전히 차단 (반복 발사 최소 간격 정책 유지)', () => {
     const firedState = makeBoardingPromptFiredState();
     const outcome = evaluateBoardingPromptGates({
       series: [],
@@ -425,6 +428,6 @@ describe('boardingPrompt gate archFlag 매트릭스 — 회귀 방어', () => {
       archFlag: 'on',
     });
     expect(outcome.pass).toBe(false);
-    if (!outcome.pass) expect(outcome.reason).toBe('already-fired');
+    if (!outcome.pass) expect(outcome.reason).toBe('fired-too-recently');
   });
 });

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -2415,6 +2415,57 @@ describe('validateTrip — #819 promptGeoContext / promptDisplay', () => {
     expect(trip?.promptGeoContext?.direction).toBeNull();
   });
 
+  // #2130 (Part B-be-1) — 근접 게이트 입력 필드 파싱.
+  it('originDistanceM/originAccuracyM 유효 숫자 → 보존', () => {
+    const trip = validateTrip(
+      withPrompt({
+        promptGeoContext: {
+          origin: { lat: 1, lng: 2 },
+          nextStation: { lat: 3, lng: 4 },
+          direction: 'up',
+          originDistanceM: 227,
+          originAccuracyM: 9,
+        },
+      }),
+    );
+    expect(trip?.promptGeoContext?.originDistanceM).toBe(227);
+    expect(trip?.promptGeoContext?.originAccuracyM).toBe(9);
+  });
+
+  it('originDistanceM/originAccuracyM 부재(지하/구 클라) → undefined로 graceful', () => {
+    const trip = validateTrip(
+      withPrompt({
+        promptGeoContext: {
+          origin: { lat: 1, lng: 2 },
+          nextStation: { lat: 3, lng: 4 },
+          direction: 'up',
+        },
+      }),
+    );
+    expect(trip?.promptGeoContext?.originDistanceM).toBeUndefined();
+    expect(trip?.promptGeoContext?.originAccuracyM).toBeUndefined();
+  });
+
+  it.each([
+    ['non-number', 'abc'],
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+  ])('originDistanceM 비정상 값(%s) → undefined로 graceful (나머지 필드는 보존)', (_label, bad) => {
+    const trip = validateTrip(
+      withPrompt({
+        promptGeoContext: {
+          origin: { lat: 1, lng: 2 },
+          nextStation: { lat: 3, lng: 4 },
+          direction: 'up',
+          originDistanceM: bad,
+          originAccuracyM: 9,
+        },
+      }),
+    );
+    expect(trip?.promptGeoContext?.originDistanceM).toBeUndefined();
+    expect(trip?.promptGeoContext?.originAccuracyM).toBe(9);
+  });
+
   it.each([
     ['origin coord 누락', { promptGeoContext: { nextStation: { lat: 1, lng: 2 } } }],
     ['nextStation 누락', { promptGeoContext: { origin: { lat: 1, lng: 2 } } }],

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -151,6 +151,7 @@ function makeFullEmptyStats(): ScheduledStats {
     phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
     autoLockSuccess: 0, autoLockFalsePositive: 0, boardingPromptAutoDeduped: 0,
     boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0, boardingPromptSkippedNoContext: 0, boardingPromptSkippedStale: 0, boardingPromptSkippedTooFar: 0,
+    boardingPromptSkippedMinInterval: 0, boardingPromptSkippedMaxFires: 0, boardingPromptSkippedTrainDuplicate: 0,
     hopEndPromptFired: 0, hopEndPromptBlocked: 0,
     arvlCdFireSuccess: 0, arvlCdFireDedup: 0, arvlCdFireMismatch: 0,
     arvlCdFireBlocked: 0, arvlCdFireFired: 0,
@@ -4443,7 +4444,14 @@ describe('runScheduled — boarding-prompt 9단 게이트 (#819)', () => {
     expect(alertBody.data.line).toBe('2');
 
     const persisted = JSON.parse((await kv.get('trip:bp-tok'))!);
-    expect(persisted.boardingPromptState).toEqual({ fired: true, lastFiredAt: NOW });
+    // #2130 (Part B-be-2) — "trip당 1회" 정책 폐기. 반복 발사(A4) 상태(firedTrainCodes/fireCount)가
+    // 함께 stamp된다. DEFAULT_BP_ARRIVAL(arvlCd=2, trainCode='T1')이 단일 후보라 dedup 없이 선택된다.
+    expect(persisted.boardingPromptState).toEqual({
+      fired: true,
+      lastFiredAt: NOW,
+      fireCount: 1,
+      firedTrainCodes: ['T1'],
+    });
   });
 
   it('이미 fired된 trip은 미발사 + blocked 카운트', async () => {
@@ -4458,6 +4466,169 @@ describe('runScheduled — boarding-prompt 9단 게이트 (#819)', () => {
     const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
     expect(stats.boardingPromptFired).toBe(0);
     expect(stats.boardingPromptBlocked).toBe(1);
+    expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  // #2130 (Part B-be-2, A4) — 반복 발사. "trip당 1회" 정책 폐기 후 5분 최소 간격을 넘긴
+  // 새 trainCode는 재발사한다.
+  // #2130 (Part B-be-2) — AUTO_PROMPT_DEDUP_WINDOW_MS(30분) 게이트는 `boardingPromptState`가
+  // undefined(리셋)일 때만 발동해야 한다. 같은 trip 안에서 반복 발사 중(boardingPromptState
+  // 존재)이면 이 30분 게이트가 겹쳐 걸려 2번째 열차조차 못 쏘는 회귀를 방지한다.
+  it('#2130 — lastAutoPromptedAt이 30분 이내라도 boardingPromptState 존재 시 auto-dedup 미적용', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({
+        lastAutoPromptedAt: NOW - 5 * 60 * 1000,
+        boardingPromptState: {
+          fired: true,
+          lastFiredAt: NOW - 5 * 60 * 1000,
+          fireCount: 1,
+          firedTrainCodes: ['T1'],
+        },
+      }),
+    );
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+    const nextTrainArrival: ArrivalEntry = {
+      destination: '성수',
+      arrivalSeconds: 30,
+      trainCode: 'T2',
+      isUp: true,
+      subwayNm: '2호선',
+      arvlCd: 2,
+    };
+
+    const stats = await runScheduled(
+      makeEnv(kv),
+      makeBoardingPromptDeps(fetchImpl, makeSeoul([nextTrainArrival])),
+    );
+    expect(stats.boardingPromptAutoDeduped).toBe(0);
+    expect(stats.boardingPromptFired).toBe(1);
+  });
+
+  it('#2130 A4 — 5분 경과 + 새 trainCode 관측 시 재발사 + collapse-id 고정', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({
+        boardingPromptState: {
+          fired: true,
+          lastFiredAt: NOW - 5 * 60 * 1000,
+          fireCount: 1,
+          firedTrainCodes: ['T1'],
+        },
+      }),
+    );
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+    const nextTrainArrival: ArrivalEntry = {
+      destination: '성수',
+      arrivalSeconds: 30,
+      trainCode: 'T2',
+      isUp: true,
+      subwayNm: '2호선',
+      arvlCd: 2,
+    };
+
+    const stats = await runScheduled(
+      makeEnv(kv),
+      makeBoardingPromptDeps(fetchImpl, makeSeoul([nextTrainArrival])),
+    );
+    expect(stats.boardingPromptFired).toBe(1);
+    expect(stats.boardingPromptSkippedMinInterval).toBe(0);
+    expect(stats.boardingPromptSkippedTrainDuplicate).toBe(0);
+
+    const fetchMock = fetchImpl as unknown as ReturnType<typeof vi.fn>;
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init as RequestInit).headers).toMatchObject({
+      'apns-collapse-id': 'boarding-prompt-bp-tok',
+    });
+
+    const persisted = JSON.parse((await kv.get('trip:bp-tok'))!);
+    expect(persisted.boardingPromptState).toEqual({
+      fired: true,
+      lastFiredAt: NOW,
+      fireCount: 2,
+      firedTrainCodes: ['T1', 'T2'],
+    });
+  });
+
+  it('#2130 A4 — 5분 미달이면 새 trainCode여도 boardingPromptSkippedMinInterval로 차단', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({
+        boardingPromptState: {
+          fired: true,
+          lastFiredAt: NOW - 60_000,
+          fireCount: 1,
+          firedTrainCodes: ['T1'],
+        },
+      }),
+    );
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const nextTrainArrival: ArrivalEntry = {
+      destination: '성수',
+      arrivalSeconds: 30,
+      trainCode: 'T2',
+      isUp: true,
+      subwayNm: '2호선',
+      arvlCd: 2,
+    };
+
+    const stats = await runScheduled(
+      makeEnv(kv),
+      makeBoardingPromptDeps(fetchImpl, makeSeoul([nextTrainArrival])),
+    );
+    expect(stats.boardingPromptFired).toBe(0);
+    expect(stats.boardingPromptSkippedMinInterval).toBe(1);
+    expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it('#2130 A4 — 5분 경과했지만 같은 trainCode면 boardingPromptSkippedTrainDuplicate로 차단', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({
+        boardingPromptState: {
+          fired: true,
+          lastFiredAt: NOW - 5 * 60 * 1000,
+          fireCount: 1,
+          firedTrainCodes: ['T1'],
+        },
+      }),
+    );
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+
+    // DEFAULT_BP_ARRIVAL(trainCode='T1') 그대로 재관측 — 같은 열차가 cron 여러 tick에 걸림.
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+    expect(stats.boardingPromptFired).toBe(0);
+    expect(stats.boardingPromptSkippedTrainDuplicate).toBe(1);
+    expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it('#2130 A4 — fireCount가 최대 발사 횟수(3)에 도달하면 boardingPromptSkippedMaxFires로 차단', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({
+        boardingPromptState: {
+          fired: true,
+          lastFiredAt: NOW - 10 * 60 * 1000,
+          fireCount: 3,
+          firedTrainCodes: ['T1', 'T2', 'T3'],
+        },
+      }),
+    );
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+    expect(stats.boardingPromptFired).toBe(0);
+    expect(stats.boardingPromptSkippedMaxFires).toBe(1);
     expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
   });
 
@@ -4860,7 +5031,14 @@ describe('runScheduled — #2014 (ADR-022 B8) archFlag=on 배선', () => {
     // #2069 (Phase 3) — B8(silent fallback) 제거. B7 원격 alert push 단일 채널 — 1회 fetch.
     expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
     const persisted = JSON.parse((await kv.get('trip:b8-tok'))!);
-    expect(persisted.boardingPromptState).toEqual({ fired: true, lastFiredAt: NOW });
+    // #2130 (Part B-be-2) — 반복 발사(A4) 상태 동시 stamp. ARVL_ARRIVED_SINGLE(arvlCd=1,
+    // trainCode='B8-T1')이 단일 후보라 dedup 없이 선택된다.
+    expect(persisted.boardingPromptState).toEqual({
+      fired: true,
+      lastFiredAt: NOW,
+      fireCount: 1,
+      firedTrainCodes: ['B8-T1'],
+    });
   });
 
   it('archFlag=off + series=[] → 기존 no-candidates 차단 유지 (회귀 방어)', async () => {
@@ -9507,6 +9685,7 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
       phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
       autoLockSuccess: 0, autoLockFalsePositive: 0, boardingPromptAutoDeduped: 0,
       boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0, boardingPromptSkippedNoContext: 0, boardingPromptSkippedStale: 0, boardingPromptSkippedTooFar: 0,
+    boardingPromptSkippedMinInterval: 0, boardingPromptSkippedMaxFires: 0, boardingPromptSkippedTrainDuplicate: 0,
       hopEndPromptFired: 0, hopEndPromptBlocked: 0,
       arvlCdFireSuccess: 0, arvlCdFireDedup: 0, arvlCdFireMismatch: 0,
       arvlCdFireBlocked: 0, arvlCdFireFired: 0,

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -150,7 +150,7 @@ function makeFullEmptyStats(): ScheduledStats {
     boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
     phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
     autoLockSuccess: 0, autoLockFalsePositive: 0, boardingPromptAutoDeduped: 0,
-    boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0, boardingPromptSkippedNoContext: 0,
+    boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0, boardingPromptSkippedNoContext: 0, boardingPromptSkippedStale: 0, boardingPromptSkippedTooFar: 0,
     hopEndPromptFired: 0, hopEndPromptBlocked: 0,
     arvlCdFireSuccess: 0, arvlCdFireDedup: 0, arvlCdFireMismatch: 0,
     arvlCdFireBlocked: 0, arvlCdFireFired: 0,
@@ -4325,6 +4325,93 @@ describe('runScheduled — boarding-prompt 9단 게이트 (#819)', () => {
     const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
     expect(stats.boardingPromptSkippedNoContext).toBe(1);
     expect(stats.boardingPromptEvaluated).toBe(0);
+  });
+
+  // #2130 (Part B-be-1) — 신선도 게이트. trip 등록 후 15분 경과 시 evaluate 자체를 skip.
+  it('#2130 — trip 등록 후 15분 경과 시 boardingPromptSkippedStale +1, evaluate 미도달', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({ createdAt: NOW - 15 * 60 * 1000 - 1 }),
+    );
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+    expect(stats.boardingPromptSkippedStale).toBe(1);
+    expect(stats.boardingPromptEvaluated).toBe(0);
+    expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it('#2130 — 15분 경계(정확히 15분)는 신선도 게이트 통과', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({ createdAt: NOW - 15 * 60 * 1000 }),
+    );
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+    expect(stats.boardingPromptSkippedStale).toBe(0);
+    expect(stats.boardingPromptEvaluated).toBe(1);
+  });
+
+  // #2130 (Part B-be-1) — 근접 게이트. distance/accuracy 둘 다 있고 오차 고려해도 150m 밖이면 차단.
+  it('#2130 — originDistanceM/originAccuracyM 둘 다 존재 + 150m 초과 → boardingPromptSkippedTooFar +1', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({
+        promptGeoContext: {
+          origin: { lat: 0, lng: 0 },
+          nextStation: { lat: 0, lng: 0.01 },
+          direction: 'up',
+          originDistanceM: 227,
+          originAccuracyM: 9,
+        },
+      }),
+    );
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+    expect(stats.boardingPromptSkippedTooFar).toBe(1);
+    expect(stats.boardingPromptEvaluated).toBe(0);
+    expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it('#2130 — 경계(distance - accuracy === 150) 는 근접 게이트 통과 (150 초과만 차단)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({
+        promptGeoContext: {
+          origin: { lat: 0, lng: 0 },
+          nextStation: { lat: 0, lng: 0.01 },
+          direction: 'up',
+          originDistanceM: 300,
+          originAccuracyM: 150,
+        },
+      }),
+    );
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+    expect(stats.boardingPromptSkippedTooFar).toBe(0);
+    expect(stats.boardingPromptEvaluated).toBe(1);
+  });
+
+  it('#2130 — originDistanceM/originAccuracyM 부재(지하/구 클라) → 근접 게이트 관대 허용', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+    expect(stats.boardingPromptSkippedTooFar).toBe(0);
+    expect(stats.boardingPromptEvaluated).toBe(1);
   });
 
   it('9단 통과 + APNs 200 → alert push 발사 + state.fired 영구화', async () => {
@@ -9419,7 +9506,7 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
       boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
       phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
       autoLockSuccess: 0, autoLockFalsePositive: 0, boardingPromptAutoDeduped: 0,
-      boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0, boardingPromptSkippedNoContext: 0,
+      boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0, boardingPromptSkippedNoContext: 0, boardingPromptSkippedStale: 0, boardingPromptSkippedTooFar: 0,
       hopEndPromptFired: 0, hopEndPromptBlocked: 0,
       arvlCdFireSuccess: 0, arvlCdFireDedup: 0, arvlCdFireMismatch: 0,
       arvlCdFireBlocked: 0, arvlCdFireFired: 0,

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -805,6 +805,12 @@ export interface SendBoardingPromptPushOptions {
   nextLine?: string;
   /** #2034 — hop-end 시 다음 leg 출발역. 미지정이면 device UI 에서 next-line 만 표시. */
   nextStation?: string;
+  /**
+   * #2130 (Part B-be-2) — `apns-collapse-id` 헤더. 반복 발사(A4)로 새 열차의 prompt가 이전
+   * 무응답 배너를 알림센터에서 최신으로 교체(스택 방지). 미지정 시 헤더 생략(구 caller /
+   * hop-end 호출부 backward compat — hop-end는 leg별 1회라 collapse 불필요).
+   */
+  collapseId?: string;
   config: ApnsConfig;
   host: string;
   fetchImpl?: typeof fetch;
@@ -886,6 +892,9 @@ export async function sendBoardingPromptPush(
       'content-type': 'application/json',
       // #1788 — thread-id groups notifications by trip.
       'apns-thread-id': options.tripToken,
+      // #2130 (Part B-be-2) — apns-collapse-id: 반복 발사(A4)로 새 열차 prompt가 이전 무응답
+      // 배너를 알림센터에서 최신으로 교체(스택 방지).
+      ...(options.collapseId !== undefined ? { 'apns-collapse-id': options.collapseId } : {}),
     },
     body,
   });

--- a/backend/alarm-worker/src/boardingPrompt.ts
+++ b/backend/alarm-worker/src/boardingPrompt.ts
@@ -56,6 +56,16 @@ export const MIN_WINDOW_SAMPLES = 1;
 export const MIN_FUSED_SPEED_KMH = 5;
 /** 게이트 #9 — dismiss 후 silence 길이. */
 export const DISMISS_SILENCE_MS = 5 * 60 * 1000;
+/**
+ * #2130 (Part B-be-1) — 근접 게이트 임계(m). `originDistanceM - originAccuracyM`가 이 값을
+ * 넘으면 차단(오차 고려 보수적 차단). 역사 반경 실측 100~180m 근거로 150m 채택(플랜 §2 D2).
+ */
+export const PROMPT_PROXIMITY_MARGIN_M = 150;
+/**
+ * #2130 (Part B-be-1) — 신선도 게이트. trip 등록(또는 heal) 후 이 시간이 지나면 boarding-prompt
+ * 자격이 만료된다 — 오래된 trip에 뒤늦게 발사되는 stale prompt 방지 + 반복 발사(A4) 창의 상한.
+ */
+export const PROMPT_FRESHNESS_MS = 15 * 60 * 1000;
 
 export type GateOutcome =
   | { pass: true; metrics: WindowedMetrics; fusedSpeedKmh: number }

--- a/backend/alarm-worker/src/boardingPrompt.ts
+++ b/backend/alarm-worker/src/boardingPrompt.ts
@@ -66,6 +66,18 @@ export const PROMPT_PROXIMITY_MARGIN_M = 150;
  * 자격이 만료된다 — 오래된 trip에 뒤늦게 발사되는 stale prompt 방지 + 반복 발사(A4) 창의 상한.
  */
 export const PROMPT_FRESHNESS_MS = 15 * 60 * 1000;
+/**
+ * #2130 (Part B-be-2, 2026-08-04 사용자 결정) — 반복 발사(A4) 최소 발사 간격.
+ * 직전 발사로부터 이 시간 미만이면 새 열차(arvlCd=1)가 도착해도 재발사하지 않는다
+ * (배차 2~3분 역에서 연발 방지). `DISMISS_SILENCE_MS`와 값은 같지만 의미가 달라 별도 상수로 분리.
+ */
+export const MIN_FIRE_INTERVAL_MS = 5 * 60 * 1000;
+/**
+ * #2130 (Part B-be-2, 2026-08-04 사용자 결정) — trip당 boarding-prompt 최대 발사 횟수 hard cap.
+ * "15분 창 ÷ 5분 간격 = 실효 최대 3회"와 정합 — `promptState.fireCount`가 이 값에 도달하면
+ * 신선도 게이트(15분) 만료 전이라도 즉시 skip한다.
+ */
+export const MAX_FIRE_COUNT = 3;
 
 export type GateOutcome =
   | { pass: true; metrics: WindowedMetrics; fusedSpeedKmh: number }
@@ -82,7 +94,9 @@ export type GateSkipReason =
   | 'motion-not-moving'
   | 'motion-stationary'
   | 'silenced'
-  | 'already-fired';
+  | 'already-fired'
+  | 'fired-too-recently'
+  | 'max-fires-reached';
 
 export interface OriginCoord {
   lat: number;
@@ -142,6 +156,10 @@ export interface EvaluateBoardingPromptInputs {
 
 /**
  * 게이트 #9 — silence / 1회 발사 dedup. promptState 부재 = 첫 시도, 통과 (null 반환).
+ *
+ * hop-end 전용(`evaluateHopEndPromptGates`)이 사용한다 — leg당 1회 정책은 불변.
+ * boarding-prompt는 #2130 Part B-be-2부터 `evaluateBoardingPromptRepeatGate`를 대신 사용한다
+ * (아래) — "trip당 1회(fired 영구 차단)" 정책 폐기.
  */
 function evaluateSilenceGate(
   promptState: BoardingPromptState | undefined,
@@ -156,6 +174,43 @@ function evaluateSilenceGate(
     promptState.silencedUntil > now
   ) {
     return { pass: false, reason: 'silenced' };
+  }
+  return null;
+}
+
+/**
+ * 게이트 #9 (boarding-prompt 전용, #2130 Part B-be-2, 2026-08-04 사용자 결정) — 반복 발사 정책.
+ *
+ * "trip당 1회(`fired` 영구 차단)" 정책 폐기 — 15분 창 내 arvlCd=1 열차 도착마다 재발사를
+ * 허용하되 다음 정지 조건으로 스팸을 막는다:
+ *   ① 응답 — caller(scheduled.ts)의 F2 defense(`trip.boardingLock !== undefined`)가 별도 차단.
+ *   ② 15분 신선도 만료 — caller가 `trip.createdAt` 기준으로 별도 게이트(Part B-be-1).
+ *   ③ dismiss 후 silence — `silencedUntil` (기존 `DISMISS_SILENCE_MS` 유지).
+ *   [신규] 최대 발사 횟수 hard cap(3회) — `promptState.fireCount`.
+ *   ④ 최소 발사 간격(5분) — `promptState.lastFiredAt`.
+ * `fired` 필드 자체는 더 이상 검사하지 않는다 — 관측 전용 플래그로만 유지된다(d1TripMetrics 등).
+ *
+ * hop-end는 여전히 `evaluateSilenceGate`(1회 정책)를 사용 — 이 함수는 boarding-prompt 전용.
+ */
+function evaluateBoardingPromptRepeatGate(
+  promptState: BoardingPromptState | undefined,
+  now: number,
+): GateOutcome | null {
+  if (!promptState) return null;
+  if (
+    promptState.silencedUntil !== undefined &&
+    promptState.silencedUntil > now
+  ) {
+    return { pass: false, reason: 'silenced' };
+  }
+  if ((promptState.fireCount ?? 0) >= MAX_FIRE_COUNT) {
+    return { pass: false, reason: 'max-fires-reached' };
+  }
+  if (
+    promptState.lastFiredAt !== undefined &&
+    now - promptState.lastFiredAt < MIN_FIRE_INTERVAL_MS
+  ) {
+    return { pass: false, reason: 'fired-too-recently' };
   }
   return null;
 }
@@ -256,8 +311,8 @@ function isGpsDependentBypassEnv(env: StationEnvironment | undefined): boolean {
 export function evaluateBoardingPromptGates(
   inputs: EvaluateBoardingPromptInputs,
 ): GateOutcome {
-  // #9 — silence / 1회 발사 dedup (가장 cheap한 가드 우선).
-  const silenceOutcome = evaluateSilenceGate(inputs.promptState, inputs.now);
+  // #9 — 반복 발사 정책(#2130 Part B-be-2, 가장 cheap한 가드 우선).
+  const silenceOutcome = evaluateBoardingPromptRepeatGate(inputs.promptState, inputs.now);
   if (silenceOutcome) return silenceOutcome;
 
   // #833 — 호출자가 동일 series/now로 이미 evaluateWindow를 돌렸다면 결과 재사용.
@@ -318,9 +373,28 @@ export function evaluateBoardingPromptGates(
 /**
  * trip의 boarding-prompt state를 발사 시점 또는 dismiss 시점에 갱신해 반환.
  * caller는 결과를 trip에 set 후 KV 저장.
+ *
+ * #2130 (Part B-be-2) — `prev` + `trainCode`를 전달하면 반복 발사(A4) 상태를 누적한다:
+ *   - `firedTrainCodes`: trainCode가 주어지면 prev 배열에 append (같은 trainCode 재추가는
+ *     caller가 사전에 dedup 체크로 걸러내므로 여기서는 단순 append).
+ *   - `fireCount`: 매 호출마다 +1 (최대 발사 횟수 hard cap 게이트의 입력).
+ * hop-end 호출부(`maybeFireHopEndPrompt`)는 `prev`/`trainCode` 없이 `markPromptFired(now)`만
+ * 호출한다 — 이 경우 `firedTrainCodes`는 생략되고 `fireCount`는 1로 시작(hop-end는 leg당 1회라
+ * 게이트에서 참조되지 않음, 값 존재 자체는 무해).
  */
-export function markPromptFired(now: number): BoardingPromptState {
-  return { fired: true, lastFiredAt: now };
+export function markPromptFired(
+  now: number,
+  prev?: BoardingPromptState,
+  trainCode?: string | null,
+): BoardingPromptState {
+  const firedTrainCodes =
+    trainCode != null ? [...(prev?.firedTrainCodes ?? []), trainCode] : prev?.firedTrainCodes;
+  return {
+    fired: true,
+    lastFiredAt: now,
+    fireCount: (prev?.fireCount ?? 0) + 1,
+    ...(firedTrainCodes !== undefined ? { firedTrainCodes } : {}),
+  };
 }
 
 export function markPromptSilenced(

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -2294,10 +2294,22 @@ function parsePromptGeoContext(raw: unknown): PromptGeoContext | undefined {
   if (typeof nc.lng !== 'number' || !Number.isFinite(nc.lng)) return undefined;
   const direction = o.direction;
   const dir = direction === 'up' || direction === 'down' ? direction : null;
+  // #2130 (Part B-be-1) — device가 heal 시점 GPS fix로 계산해 동봉하는 근접 게이트 입력.
+  // fix가 없으면(지하 등) 필드 자체가 생략되어 undefined → backend 근접 게이트는 관대 허용.
+  const originDistanceM =
+    typeof o.originDistanceM === 'number' && Number.isFinite(o.originDistanceM)
+      ? o.originDistanceM
+      : undefined;
+  const originAccuracyM =
+    typeof o.originAccuracyM === 'number' && Number.isFinite(o.originAccuracyM)
+      ? o.originAccuracyM
+      : undefined;
   return {
     origin: { lat: oc.lat, lng: oc.lng },
     nextStation: { lat: nc.lat, lng: nc.lng },
     direction: dir,
+    ...(originDistanceM !== undefined ? { originDistanceM } : {}),
+    ...(originAccuracyM !== undefined ? { originAccuracyM } : {}),
   };
 }
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -620,6 +620,24 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   boardingPromptSkippedTooFar: number;
   /**
+   * #2130 (Part B-be-2, 2026-08-04 사용자 결정) — 반복 발사(A4) 최소 발사 간격(5분) 미달로
+   * `evaluateBoardingPromptGates`가 차단한 누적 횟수(`boardingPromptBlocked`의 부분집합을
+   * reason별로 재분류). 배차가 촘촘한 역에서 연발이 억제되고 있는지 관측.
+   */
+  boardingPromptSkippedMinInterval: number;
+  /**
+   * #2130 (Part B-be-2, 2026-08-04 사용자 결정) — trip당 최대 발사 횟수(3회) hard cap 도달로
+   * `evaluateBoardingPromptGates`가 차단한 누적 횟수(`boardingPromptBlocked`의 부분집합).
+   * 0이 아니면 15분 창 내내 사용자가 무응답으로 3회 모두 소진한 케이스가 존재한다는 신호.
+   */
+  boardingPromptSkippedMaxFires: number;
+  /**
+   * #2130 (Part B-be-2, 2026-08-04 사용자 결정) — 이번 cycle에 관측된 arvlCd=1 우선순위
+   * trainCode가 이미 `promptState.firedTrainCodes`에 있어 발사를 skip한 누적 횟수. 같은 열차가
+   * 플랫폼에 정차 중 cron 여러 tick에 걸쳐 재관측돼도 중복 발사하지 않는다는 방증.
+   */
+  boardingPromptSkippedTrainDuplicate: number;
+  /**
    * #2034 — 환승 waypoint advance 시점에 hop-end ("하차했나요?") prompt 게이트를 통과해 alert
    * push 가 발사된 누적 횟수. leg 단위 dedup 이라 같은 trip 내 여러 환승도 각각 카운트.
    * dashboard: `hop_end_prompt_fired`.
@@ -989,6 +1007,9 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     boardingPromptSkippedNoContext: 0,
     boardingPromptSkippedStale: 0,
     boardingPromptSkippedTooFar: 0,
+    boardingPromptSkippedMinInterval: 0,
+    boardingPromptSkippedMaxFires: 0,
+    boardingPromptSkippedTrainDuplicate: 0,
     hopEndPromptFired: 0,
     hopEndPromptBlocked: 0,
     arvlCdFireSuccess: 0,
@@ -1887,6 +1908,18 @@ export const STATION_NOTIF_COLLAPSE_ID_PREFIX = 'station-';
  */
 export function stationNotifCollapseId(tripToken: string): string {
   return `${STATION_NOTIF_COLLAPSE_ID_PREFIX}${tripToken.slice(0, 16)}`;
+}
+
+/**
+ * #2130 (Part B-be-2) — boarding-prompt(반복 발사, A4) apns-collapse-id prefix.
+ * 새 열차의 prompt가 이전 무응답 배너를 알림센터에서 최신으로 교체(스택 금지) — #2086 규칙
+ * (`stationNotifCollapseId`/`sleepAlarmCollapseId`와 동일하게 `slice(0, 16)`로 64B 한도 방어).
+ */
+export const BOARDING_PROMPT_COLLAPSE_ID_PREFIX = 'boarding-prompt-';
+
+/** #2130 — boarding-prompt apns-collapse-id 빌더. */
+export function boardingPromptCollapseId(tripToken: string): string {
+  return `${BOARDING_PROMPT_COLLAPSE_ID_PREFIX}${tripToken.slice(0, 16)}`;
 }
 
 /**
@@ -4279,7 +4312,8 @@ export function hasArrivedSignal(pool: readonly ArrivalEntry[]): boolean {
  *
  * 발사 성공:
  *   - alert push (BOARDING_PROMPT category)로 [탑승]/[미탑승] 액션 노출
- *   - trip.boardingPromptState = markPromptFired(now) → KV 저장 (게이트 #9 1회 정책)
+ *   - trip.boardingPromptState = markPromptFired(now, prev, trainCode) → KV 저장. #2130
+ *     (Part B-be-2) 이후 "trip당 1회" 정책 폐기 — 15분 창 내 trainCode별 반복 발사(A4).
  *   - boardingPromptFired stat +1
  *
  * 차단:
@@ -4357,7 +4391,14 @@ export async function evaluateAndMaybeFireBoardingPrompt(
   // 평가 자체를 skip — boardingPromptState가 isSameSession=false로 리셋됐거나 lock이 클리어된
   // 직후 같은 trip token이 lockMissing으로 돌아온 케이스. 같은 trip 컨텍스트의 중복 auto-prompt
   // 시도/푸시를 차단한다 (윈도우 만료 후엔 자연 재평가 — 새 leg/새 trip은 fresh).
+  //
+  // #2130 (Part B-be-2) — `trip.boardingPromptState !== undefined`(=같은 trip 내 반복 발사 상태가
+  // 살아있음)면 이 30분 게이트를 적용하지 않는다. 반복 발사(A4)는 그보다 촘촘한
+  // `evaluateBoardingPromptRepeatGate`(최소 간격 5분 + 최대 3회 + dismiss silence)가 이미 스팸을
+  // 막으므로, 이 게이트가 겹쳐 걸리면 같은 trip 안에서 2번째 열차조차 30분간 완전히 못 쏜다.
+  // 이 게이트는 원래 목적(boardingPromptState가 undefined로 리셋된 케이스)에서만 발동한다.
   if (
+    trip.boardingPromptState === undefined &&
     trip.lastAutoPromptedAt !== undefined &&
     now - trip.lastAutoPromptedAt < AUTO_PROMPT_DEDUP_WINDOW_MS
   ) {
@@ -4407,6 +4448,9 @@ export async function evaluateAndMaybeFireBoardingPrompt(
 
   if (!outcome.pass) {
     stats.boardingPromptBlocked += 1;
+    // #2130 (Part B-be-2) — 반복 발사 게이트가 차단한 두 신규 reason은 전용 counter로도 집계.
+    if (outcome.reason === 'fired-too-recently') stats.boardingPromptSkippedMinInterval += 1;
+    if (outcome.reason === 'max-fires-reached') stats.boardingPromptSkippedMaxFires += 1;
     log('boarding-prompt: gate blocked', {
       token: trip.token.slice(0, 8),
       reason: outcome.reason satisfies GateSkipReason,
@@ -4492,11 +4536,15 @@ export async function evaluateAndMaybeFireBoardingPrompt(
   // pool 이 비어 있으면 (Seoul API 실패 / 매칭 0건) 아래 candidateTrains 0건 guard 로 skip 됨 —
   // 여기서는 pool.length > 0 인데 pickAutoTrainCode 가 null 인 케이스만 명시 차단해 counter 로
   // 가시화한다.
-  if (
-    deps.archFlag === 'on' &&
-    poolForArchFlagCheck.length > 0 &&
-    pickAutoTrainCode(poolForArchFlagCheck, display.line, geo.direction) === null
-  ) {
+  //
+  // #2130 (Part B-be-2) — 같은 호출로 산출한 selectedTrainCode를 아래 trainCode dedup(반복
+  // 발사, A4)에도 재사용한다. archFlag 무관(off 포함)하게 항상 계산 — GPS 9단 게이트로 발사되는
+  // legacy 경로도 같은 trainCode dedup 혜택을 받는다(pool이 비어 있으면 자연히 null).
+  const selectedTrainCode =
+    poolForArchFlagCheck.length > 0
+      ? pickAutoTrainCode(poolForArchFlagCheck, display.line, geo.direction)
+      : null;
+  if (deps.archFlag === 'on' && poolForArchFlagCheck.length > 0 && selectedTrainCode === null) {
     stats.boardingPromptBlocked += 1;
     log('boarding-prompt: skipped ambiguity (#2014 archFlag=on)', {
       token: trip.token.slice(0, 8),
@@ -4518,6 +4566,24 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       line: display.line,
       originStation: display.originStation,
       direction: geo.direction,
+    });
+    if (dirty) await putTrip(env.TRIPS, trip);
+    return;
+  }
+
+  // #2130 (Part B-be-2, A4) — 반복 발사 trainCode dedup. 이번 cycle에 선택된 trainCode가 이미
+  // 발사된 열차면 skip — 같은 열차가 cron 여러 tick에 걸쳐 재관측돼도 중복 발사하지 않는다.
+  // selectedTrainCode===null(ambiguity 기각 없이 통과한 archFlag=off 경로 등)이면 dedup 대상이
+  // 없어 자연 통과 — 기존 GPS 9단 게이트 기반 fire 는 이 신규 게이트로 인한 회귀가 없다.
+  if (
+    selectedTrainCode !== null &&
+    trip.boardingPromptState?.firedTrainCodes?.includes(selectedTrainCode)
+  ) {
+    stats.boardingPromptSkippedTrainDuplicate += 1;
+    log('boarding-prompt: skipped train duplicate (#2130 A4)', {
+      token: trip.token.slice(0, 8),
+      trainCode: selectedTrainCode,
+      firedTrainCodes: trip.boardingPromptState?.firedTrainCodes,
     });
     if (dirty) await putTrip(env.TRIPS, trip);
     return;
@@ -4556,6 +4622,8 @@ export async function evaluateAndMaybeFireBoardingPrompt(
             : undefined,
         // #1888 (RC-13) — 후보 train 목록 동봉. device fallback 렌더.
         candidateTrains,
+        // #2130 (Part B-be-2, A4) — 반복 발사 시 이전 무응답 배너를 최신으로 교체(스택 방지).
+        collapseId: boardingPromptCollapseId(trip.token),
         config: deps.apnsConfig,
         host,
         fetchImpl: deps.fetchImpl,
@@ -4580,7 +4648,9 @@ export async function evaluateAndMaybeFireBoardingPrompt(
     stats.boardingPromptFired += 1;
     // #1683 — boardingPrompt kind 카운터.
     stats.silentPushFiredByKind.boardingPrompt += 1;
-    trip.boardingPromptState = markPromptFired(now);
+    // #2130 (Part B-be-2, A4) — prev state + selectedTrainCode를 전달해 firedTrainCodes/fireCount를
+    // 누적한다(반복 발사 dedup + hard cap 입력).
+    trip.boardingPromptState = markPromptFired(now, trip.boardingPromptState, selectedTrainCode);
     // #916 follow-up B — prompt push도 같은 dedup 마커를 stamp한다. dismiss + 클리어 후
     // isSameSession=false 분기로 boardingPromptState가 사라져도 window 안에서 재발사 차단.
     trip.lastAutoPromptedAt = now;

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -23,6 +23,8 @@ import {
   evaluateHopEndPromptGates,
   markPromptFired,
   pickAutoTrainCode,
+  PROMPT_FRESHNESS_MS,
+  PROMPT_PROXIMITY_MARGIN_M,
   type GateSkipReason,
 } from './boardingPrompt';
 import {
@@ -606,6 +608,18 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   boardingPromptSkippedNoContext: number;
   /**
+   * #2130 (Part B-be-1) — trip 등록(`createdAt`) 후 `PROMPT_FRESHNESS_MS`(15분)가 지나
+   * boarding-prompt 자격이 만료돼 skip한 누적 횟수. 오래된 lockMissing trip에 뒤늦게 발사되는
+   * stale prompt를 차단 — 0이 아니면 device 재등록 주기 또는 사용자 응답 지연 분포를 시사.
+   */
+  boardingPromptSkippedStale: number;
+  /**
+   * #2130 (Part B-be-1) — `promptGeoContext.originDistanceM - originAccuracyM > 150m`로 근접
+   * 게이트가 차단한 누적 횟수. 자택 등록(A2) 등 실제 미승차 시나리오에서 0이 아니게 나오는 것이
+   * 정상 — 지하/구 클라(필드 부재)는 이 게이트를 거치지 않아 관대하게 허용된다.
+   */
+  boardingPromptSkippedTooFar: number;
+  /**
    * #2034 — 환승 waypoint advance 시점에 hop-end ("하차했나요?") prompt 게이트를 통과해 alert
    * push 가 발사된 누적 횟수. leg 단위 dedup 이라 같은 trip 내 여러 환승도 각각 카운트.
    * dashboard: `hop_end_prompt_fired`.
@@ -973,6 +987,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     boardingPromptSkippedEmpty: 0,
     boardingPromptSkippedLockActive: 0,
     boardingPromptSkippedNoContext: 0,
+    boardingPromptSkippedStale: 0,
+    boardingPromptSkippedTooFar: 0,
     hopEndPromptFired: 0,
     hopEndPromptBlocked: 0,
     arvlCdFireSuccess: 0,
@@ -4307,6 +4323,32 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       hasDisplay: display !== undefined,
       // #2032 (Issue D) — monitoring dimension. ADR-023: 발사 결정 X.
       sleepMode: trip.sleepModeEnabled,
+    });
+    return;
+  }
+
+  // #2130 (Part B-be-1) — 신선도 게이트. trip 등록 후 15분 경과 시 boarding-prompt 자격 만료.
+  if (now - trip.createdAt > PROMPT_FRESHNESS_MS) {
+    stats.boardingPromptSkippedStale += 1;
+    log('boarding-prompt: skip (stale, past freshness window)', {
+      token: trip.token.slice(0, 8),
+      ageMs: now - trip.createdAt,
+    });
+    return;
+  }
+
+  // #2130 (Part B-be-1) — 근접 게이트. distance/accuracy 둘 다 있을 때만 평가(부재 = 지하/구
+  // 클라 관대 허용). 오차 고려 보수적 차단 — distance - accuracy > 150m 이면 skip.
+  if (
+    geo.originDistanceM !== undefined &&
+    geo.originAccuracyM !== undefined &&
+    geo.originDistanceM - geo.originAccuracyM > PROMPT_PROXIMITY_MARGIN_M
+  ) {
+    stats.boardingPromptSkippedTooFar += 1;
+    log('boarding-prompt: skip (too far from origin)', {
+      token: trip.token.slice(0, 8),
+      originDistanceM: geo.originDistanceM,
+      originAccuracyM: geo.originAccuracyM,
     });
     return;
   }

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -299,6 +299,18 @@ export interface PromptGeoContext {
   nextStation: { lat: number; lng: number };
   /** 방향 게이트(#5)에서 어느 방향으로 가야 하는지 — Seoul API의 isUp과 정합. */
   direction: 'up' | 'down' | null;
+  /**
+   * #2130 (Part B-be-1) — device가 heal 시점에 GPS fix로 계산한 출발역까지 거리(m).
+   * fix가 있을 때만 스탬프(정확도가 나빠도 항상 동봉) — backend 근접 게이트(§단계3)의 입력.
+   * fix 자체가 없으면(지하 등) 필드 자체를 생략한다 — 부재는 게이트에서 "허용"으로 해석.
+   */
+  originDistanceM?: number;
+  /**
+   * #2130 (Part B-be-1) — 위 거리 계산에 사용된 GPS 정확도(m, `location.coords.accuracy`).
+   * backend 근접 게이트가 `originDistanceM - originAccuracyM > 150` 일 때만 차단한다
+   * (오차 고려 보수적 차단 — 정확도가 나쁜 실내 GPS의 false positive 방어).
+   */
+  originAccuracyM?: number;
 }
 
 /** boarding-prompt 사용자 표시 컨텍스트. */

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -549,8 +549,25 @@ export interface BoardingPromptState {
   lastFiredAt?: number;
   /** 사용자가 dismiss/미탑승으로 silence 요청한 시각 (epoch ms). */
   silencedUntil?: number;
-  /** 이 trip에 이미 발사 후 사용자 응답을 받았는지 — 한 trip 1회 정책. */
+  /**
+   * 이 trip에 최소 1회 발사됐는지 — 관측/D1 acceptance 전용 플래그.
+   *
+   * #2130 (Part B-be-2) 이후 boarding-prompt는 이 필드로 게이트하지 않는다("trip당 1회" 정책
+   * 폐기 — 반복 발사로 전환, `firedTrainCodes` + `fireCount` + `lastFiredAt` 참조). hop-end
+   * prompt(`evaluateHopEndPromptGates`)는 여전히 이 필드로 leg당 1회를 게이트한다(불변).
+   */
   fired?: boolean;
+  /**
+   * #2130 (Part B-be-2) — boarding-prompt 반복 발사(A4) trainCode dedup. arvlCd=1 관측마다
+   * 발사하되 같은 trainCode는 1회만 — 열차가 플랫폼에 정차 중 cron 여러 tick에 걸쳐도
+   * 재발사하지 않는다. hop-end prompt는 사용하지 않는다.
+   */
+  firedTrainCodes?: string[];
+  /**
+   * #2130 (Part B-be-2, 2026-08-04 사용자 결정) — boarding-prompt 누적 발사 횟수.
+   * `MAX_FIRE_COUNT`(3)에 도달하면 15분 신선도 창이 남아 있어도 즉시 skip한다.
+   */
+  fireCount?: number;
 }
 
 /**


### PR DESCRIPTION
## 정정 PR

#2138이 base를 `fix/#2131-prompt-eval-hoist`(#2135의 브랜치)로 잡은 상태에서 #2135가 먼저 dev에 머지됐고, 이후 #2138 머지가 **이미 dead-end가 된 사이드 브랜치로 들어가 dev에 반영되지 않았다** (`git merge-base --is-ancestor` 검증: proximity commit NOT in dev). 본 PR이 같은 커밋(1641e24b)을 dev로 재타겟한다. 내용/리뷰는 #2138과 동일 — diff 1 commit.

- freshness 게이트: 등록 15분 경과 → skip (`boardingPromptSkippedStale`)
- 근접 게이트: `originDistanceM − originAccuracyM > 150m` → skip (`boardingPromptSkippedTooFar`), 필드 부재=허용(지하 관대)
- `parsePromptGeoContext` whitelist에 두 필드 추가

Part of #2130. Wire 5단·테스트 세부는 #2138 본문 참조 (동일 커밋). #2140(반복 발사)은 본 PR 머지 후 base 자동/수동 retarget.

⚠️ 재발 방지: stacked PR은 base PR 머지 즉시 dev로 retarget 필요 — 안 하면 이번처럼 사이드 브랜치로 머지된다.