### PR TITLE
feat(#2139): BoardingTrainList 전열차 후보 — 다음역 arrivals 역산

### DIFF
--- a/src/features/alarm/components/BoardingTrainList.tsx
+++ b/src/features/alarm/components/BoardingTrainList.tsx
@@ -21,7 +21,8 @@ import { recordLockCorrection } from '../utils/lockCorrectionMetrics';
 import { buildDirectionMeta } from '../../route/utils/trainLineDirection';
 import { parseArrivalDistance } from '../../arrival/utils/arrivalStatusDistance';
 import { LINE_COLORS } from '../../../shared/constants/lineColors';
-import { buildFallbackSequenceLabel } from '../../../shared/constants/labels';
+import { buildFallbackSequenceLabel, buildPrevTrainLabel } from '../../../shared/constants/labels';
+import type { PrevTrainCandidate } from '../hooks/usePrevTrainCandidate';
 import stationsData from '../../../data/stations.json';
 
 const allStations = stationsData as Station[];
@@ -153,6 +154,13 @@ interface Props {
    * 더 높음 (error > loading > fallback-empty > empty > data).
    */
   fallbackReason?: 'autolock-empty' | 'autolock-ambiguity' | 'autolock-station-lookup' | null;
+  /**
+   * "전열차" 후보 — #2139. 출발역을 방금 떠난(도착 예정 목록에서 이미 사라진) 열차.
+   * usePrevTrainCandidate가 다음역 arrivals 역산으로 산출해 호출자가 전달한다.
+   * null/미전달이면 기존 동작 100% 보존(전열차 row 미노출) — 식별 불가/기점 등 fallback 케이스.
+   * 탭 시 다른 row와 동일하게 onSelect(prevTrain.train) 호출 — 신규 분기 없이 기존 lock 생성 경로 재사용.
+   */
+  prevTrain?: PrevTrainCandidate | null;
 }
 
 /**
@@ -198,6 +206,7 @@ export function BoardingTrainList({
   error = null,
   onLockCorrected,
   fallbackReason = null,
+  prevTrain = null,
 }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
@@ -296,6 +305,113 @@ export function BoardingTrainList({
   // train.line은 어댑터가 subwayId로 row마다 정확히 결정한 값(#663). 일치하는 row만 표시.
   const filteredArrivals = arrivals.filter((train) => train.line === line);
 
+  /**
+   * row 렌더 — 일반 도착 row와 #2139 "전열차" row가 공유하는 Pressable 구조.
+   *
+   * @param arrivalText null이면 도착 시각 라인 자체를 생략(전열차는 다음역 ETA라 "도착 예정" 표기가
+   *   현재역 기준 사용자에게 오해를 줄 수 있어 표시하지 않음).
+   * @param testKeyPrefix testID 접두어 — 일반 row는 'boarding-train', 전열차는 'boarding-train-prev'.
+   *   같은 trainCode라도 testID가 겹치지 않게 분리(전열차는 currentArrivals에서 제외된 trainCode만
+   *   후보가 되므로 실제 충돌은 없지만, 접두어로 두 row 종류를 명확히 구분).
+   * @param isPrev true면 walkingBufferSeconds 기반 unreachable 판정을 적용하지 않는다 — 전열차는
+   *   이미 출발역을 떠난 열차라 "도보로 못 탄다" 개념이 적용되지 않는다(사용자가 이미 탑승 중인 상태).
+   */
+  const renderRow = (
+    train: ArrivalInfo,
+    sequenceText: string,
+    arrivalText: string | null,
+    testKeyPrefix: 'boarding-train' | 'boarding-train-prev',
+    isPrev = false,
+  ) => {
+    const unreachable = !isPrev && isUnreachable(train);
+    // #1165 — 다른 row가 pending이면 이 row는 disabled. 같은 row가 pending이면 highlight.
+    const isPending = pendingTrainCode === train.trainCode;
+    const isPendingBlocked = pendingTrainCode != null && !isPending;
+    const disabled = unreachable || isPendingBlocked;
+    // #792: 종착·방면 라벨을 i18n 정규화 + dedup. nextStationLabel 미전달이면 종착만.
+    const metaText = buildDirectionMeta(train.destination, nextStationLabel, allStations);
+    return (
+      <Pressable
+        key={`${testKeyPrefix}-${train.trainCode}`}
+        onPress={() => handlePress(train)}
+        disabled={disabled}
+        style={[
+          compact ? styles.rowCompact : styles.row,
+          compact ? null : { backgroundColor: colors.card },
+          { borderLeftWidth: LINE_STRIPE_WIDTH, borderLeftColor: LINE_COLORS[train.line] },
+          isPending && {
+            borderWidth: PENDING_BORDER_WIDTH,
+            borderColor: colors.accent,
+          },
+          { opacity: unreachable ? 0.4 : isPendingBlocked ? 0.5 : 1 },
+        ]}
+        testID={`${testKeyPrefix}-row-${train.trainCode}`}
+        accessibilityRole="button"
+        accessibilityLabel={t('a11y.alarm.boardingTrainSelectLabel', {
+          meta: metaText,
+          sequence: sequenceText,
+          arrival: arrivalText ?? '',
+        })}
+        accessibilityHint={t('a11y.alarm.boardingTrainSelectHint')}
+        accessibilityState={{ disabled, busy: isPending }}
+      >
+        <View style={styles.rowContent}>
+          {/* #1165 pending marker — 테스트/스크린리더 접근용. 시각적 highlight는 outline border로 처리.
+              Pressable의 accessibilityState.busy=true가 이미 스크린리더에 pending을 전달하므로
+              marker 자체는 의미 없는 0×0 View. testID만 노출. */}
+          {isPending && (
+            <View
+              style={styles.pendingMarker}
+              testID={`${testKeyPrefix}-pending-${train.trainCode}`}
+            />
+          )}
+          <View style={styles.rowMetaLine}>
+            <Text
+              style={[
+                compact ? typography.bodySm : typography.body,
+                { color: colors.ink, flex: 1 },
+              ]}
+              testID={`${testKeyPrefix}-meta-${train.trainCode}`}
+            >
+              {metaText}
+            </Text>
+            {/* trainCode/시간표 배지는 일반 모드에서만 노출. compact는 timeline hop slot 안 inline이라 정보 밀도 최소화. */}
+            {!compact &&
+              (isScheduleFallbackTrainCode(train.trainCode) ? (
+                <Text style={[typography.mono, { color: colors.subtle }]}>시간표</Text>
+              ) : (
+                <Text style={[typography.mono, { color: colors.muted }]}>{train.trainCode}</Text>
+              ))}
+          </View>
+          {/* #805: sequence(거리/상태)와 시간 라벨은 별도 라인으로 분리.
+              sequenceText가 "전역 출발"/"당역 도착"/"4번째 전" 등 어떤 길이여도 시간 라벨이
+              같은 줄에서 가려지지 않는다. sequenceText가 비어 있으면 그 라인은 미렌더하지만
+              시간 라벨 라인은 항상 표시한다. */}
+          {sequenceText.length > 0 && (
+            <View style={styles.rowSequenceLine}>
+              <Text
+                style={[typography.bodySm, { color: colors.muted }]}
+                testID={`${testKeyPrefix}-sequence-${train.trainCode}`}
+              >
+                {sequenceText}
+              </Text>
+            </View>
+          )}
+          {arrivalText != null && (
+            <View style={styles.rowArrivalLine}>
+              <Text
+                style={[typography.bodySm, { color: colors.accent, fontWeight: '600' }]}
+                testID={`${testKeyPrefix}-arrival-${train.trainCode}`}
+              >
+                {arrivalText}
+              </Text>
+            </View>
+          )}
+        </View>
+      </Pressable>
+    );
+  };
+
   // #897 Seam A: 가장 가까운 도착 ETA가 lock 시점보다 +180s 이상이면 누적 지연(분) 노출.
   // arrivals는 호출자가 도착시간 오름차순으로 전달한다는 컨벤션을 따른다(#749 카운터와 동일 가정).
   const delayMinutes = computeDelayMinutes(filteredArrivals, initialEtaSeconds);
@@ -374,7 +490,9 @@ export function BoardingTrainList({
     );
   }
 
-  if (filteredArrivals.length === 0) {
+  // #2139 — prevTrain(전열차)이 있으면 도착 예정 목록이 비어도 선택 가능한 row가 최소 1개 있으므로
+  // empty placeholder 대신 아래 정상 list 렌더(전열차 row만 노출)로 진행한다.
+  if (filteredArrivals.length === 0 && prevTrain == null) {
     return (
       <View
         style={compact ? styles.emptyCompact : styles.empty}
@@ -420,14 +538,16 @@ export function BoardingTrainList({
           </Text>
         </View>
       )}
+      {prevTrain != null &&
+        renderRow(
+          prevTrain.train,
+          buildPrevTrainLabel(prevTrain.elapsedSeconds),
+          null,
+          'boarding-train-prev',
+          true,
+        )}
       {filteredArrivals.map((train, index) => {
-        const unreachable = isUnreachable(train);
-        // #1165 — 다른 row가 pending이면 이 row는 disabled. 같은 row가 pending이면 highlight.
-        const isPending = pendingTrainCode === train.trainCode;
-        const isPendingBlocked = pendingTrainCode != null && !isPending;
-        const disabled = unreachable || isPendingBlocked;
         // #792: 종착·방면 라벨을 i18n 정규화 + dedup. nextStationLabel 미전달이면 종착만.
-        const metaText = buildDirectionMeta(train.destination, nextStationLabel, allStations);
         // #790: API arvlMsg2 기반 진짜 거리 표시. 비어있으면 mock/schedule fallback 경로 —
         // #855에서 fallback 라벨을 "약 N정거장 전 (약 M분 후)"로 단위 명시. arrivalSeconds가 0
         // 이하면 분 라벨 생략.
@@ -437,84 +557,7 @@ export function BoardingTrainList({
             ? parsedDistance
             : buildFallbackSequenceLabel(index, train.arrivalSeconds);
         const arrivalText = `${formatArrivalClock(train)} 도착 예정`;
-        return (
-          <Pressable
-            key={train.trainCode}
-            onPress={() => handlePress(train)}
-            disabled={disabled}
-            style={[
-              compact ? styles.rowCompact : styles.row,
-              compact ? null : { backgroundColor: colors.card },
-              { borderLeftWidth: LINE_STRIPE_WIDTH, borderLeftColor: LINE_COLORS[train.line] },
-              isPending && {
-                borderWidth: PENDING_BORDER_WIDTH,
-                borderColor: colors.accent,
-              },
-              { opacity: unreachable ? 0.4 : isPendingBlocked ? 0.5 : 1 },
-            ]}
-            testID={`boarding-train-row-${train.trainCode}`}
-            accessibilityRole="button"
-            accessibilityLabel={t('a11y.alarm.boardingTrainSelectLabel', {
-              meta: metaText,
-              sequence: sequenceText,
-              arrival: arrivalText,
-            })}
-            accessibilityHint={t('a11y.alarm.boardingTrainSelectHint')}
-            accessibilityState={{ disabled, busy: isPending }}
-          >
-            <View style={styles.rowContent}>
-              {/* #1165 pending marker — 테스트/스크린리더 접근용. 시각적 highlight는 outline border로 처리.
-                  Pressable의 accessibilityState.busy=true가 이미 스크린리더에 pending을 전달하므로
-                  marker 자체는 의미 없는 0×0 View. testID만 노출. */}
-              {isPending && (
-                <View
-                  style={styles.pendingMarker}
-                  testID={`boarding-train-pending-${train.trainCode}`}
-                />
-              )}
-              <View style={styles.rowMetaLine}>
-                <Text
-                  style={[
-                    compact ? typography.bodySm : typography.body,
-                    { color: colors.ink, flex: 1 },
-                  ]}
-                  testID={`boarding-train-meta-${train.trainCode}`}
-                >
-                  {metaText}
-                </Text>
-                {/* trainCode/시간표 배지는 일반 모드에서만 노출. compact는 timeline hop slot 안 inline이라 정보 밀도 최소화. */}
-                {!compact &&
-                  (isScheduleFallbackTrainCode(train.trainCode) ? (
-                    <Text style={[typography.mono, { color: colors.subtle }]}>시간표</Text>
-                  ) : (
-                    <Text style={[typography.mono, { color: colors.muted }]}>{train.trainCode}</Text>
-                  ))}
-              </View>
-              {/* #805: sequence(거리/상태)와 시간 라벨은 별도 라인으로 분리.
-                  sequenceText가 "전역 출발"/"당역 도착"/"4번째 전" 등 어떤 길이여도 시간 라벨이
-                  같은 줄에서 가려지지 않는다. sequenceText가 비어 있으면 그 라인은 미렌더하지만
-                  시간 라벨 라인은 항상 표시한다. */}
-              {sequenceText.length > 0 && (
-                <View style={styles.rowSequenceLine}>
-                  <Text
-                    style={[typography.bodySm, { color: colors.muted }]}
-                    testID={`boarding-train-sequence-${train.trainCode}`}
-                  >
-                    {sequenceText}
-                  </Text>
-                </View>
-              )}
-              <View style={styles.rowArrivalLine}>
-                <Text
-                  style={[typography.bodySm, { color: colors.accent, fontWeight: '600' }]}
-                  testID={`boarding-train-arrival-${train.trainCode}`}
-                >
-                  {arrivalText}
-                </Text>
-              </View>
-            </View>
-          </Pressable>
-        );
+        return renderRow(train, sequenceText, arrivalText, 'boarding-train');
       })}
     </View>
   );

--- a/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
@@ -5,6 +5,7 @@ import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
 import { LINE_COLORS } from '../../../../shared/constants/lineColors';
 import type { ArrivalInfo } from '../../../../shared/types/arrival';
 import type { LineNumber } from '../../../../shared/types/station';
+import type { PrevTrainCandidate } from '../../hooks/usePrevTrainCandidate';
 import {
   getLockCorrectionMetrics,
   resetLockCorrectionMetrics,
@@ -1293,6 +1294,106 @@ describe('BoardingTrainList', () => {
       jest.clearAllMocks();
       fireEvent.press(getByTestId('boarding-train-row-T-B'));
       expect(Haptics.impactAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('#2139 전열차 row', () => {
+    function makePrevTrain(overrides: Partial<ArrivalInfo> = {}, elapsedSeconds = 90): PrevTrainCandidate {
+      return {
+        train: makeTrain({ trainCode: 'T-PREV', arrivalSeconds: 40, ...overrides }),
+        elapsedSeconds,
+      };
+    }
+
+    it('prevTrain 미전달(undefined) 시 기존 렌더 100% 보존 — 전열차 row 미노출', () => {
+      const train = makeTrain({ trainCode: 'T-A' });
+      const { getByTestId, queryByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
+      );
+      expect(getByTestId('boarding-train-row-T-A')).toBeTruthy();
+      expect(queryByTestId('boarding-train-prev-row-T-PREV')).toBeNull();
+    });
+
+    it('prevTrain=null 시 기존 렌더 100% 보존 — 전열차 row 미노출', () => {
+      const train = makeTrain({ trainCode: 'T-A' });
+      const { getByTestId, queryByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} prevTrain={null} />,
+      );
+      expect(getByTestId('boarding-train-row-T-A')).toBeTruthy();
+      expect(queryByTestId('boarding-train-prev-row-T-PREV')).toBeNull();
+    });
+
+    it('prevTrain 전달 시 일반 row보다 먼저 전열차 row가 렌더된다', () => {
+      const train = makeTrain({ trainCode: 'T-A' });
+      const prevTrain = makePrevTrain();
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} prevTrain={prevTrain} />,
+      );
+      expect(getByTestId('boarding-train-prev-row-T-PREV')).toBeTruthy();
+      expect(getByTestId('boarding-train-row-T-A')).toBeTruthy();
+    });
+
+    it('전열차 row는 buildPrevTrainLabel 라벨을 sequence 라인에 노출하고, 도착 시각 라인은 생략한다', () => {
+      const train = makeTrain({ trainCode: 'T-A' });
+      const prevTrain = makePrevTrain({}, 90); // 90s → "출발 약 2분 전"
+      const { getByTestId, queryByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} prevTrain={prevTrain} />,
+      );
+      expect(getByTestId('boarding-train-prev-sequence-T-PREV').props.children).toBe('출발 약 2분 전');
+      expect(queryByTestId('boarding-train-prev-arrival-T-PREV')).toBeNull();
+    });
+
+    it('60초 미만 elapsedSeconds는 "방금 출발" 라벨', () => {
+      const prevTrain = makePrevTrain({}, 10);
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[]} line="2" onSelect={() => {}} prevTrain={prevTrain} />,
+      );
+      expect(getByTestId('boarding-train-prev-sequence-T-PREV').props.children).toBe('방금 출발');
+    });
+
+    it('전열차 row 탭 시 onSelect가 prevTrain.train으로 호출된다 (기존 lock 생성 경로 재사용)', () => {
+      const onSelect = jest.fn();
+      const prevTrain = makePrevTrain();
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[]} line="2" onSelect={onSelect} prevTrain={prevTrain} />,
+      );
+      fireEvent.press(getByTestId('boarding-train-prev-row-T-PREV'));
+      expect(onSelect).toHaveBeenCalledWith(prevTrain.train);
+    });
+
+    it('도착 예정 목록이 비어도 prevTrain이 있으면 empty placeholder 대신 전열차 row만 렌더한다', () => {
+      const prevTrain = makePrevTrain();
+      const { getByTestId, queryByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[]} line="2" onSelect={() => {}} prevTrain={prevTrain} />,
+      );
+      expect(queryByTestId('boarding-train-list-empty')).toBeNull();
+      expect(getByTestId('boarding-train-list')).toBeTruthy();
+      expect(getByTestId('boarding-train-prev-row-T-PREV')).toBeTruthy();
+    });
+
+    it('walkingBufferSeconds가 커도 전열차 row는 unreachable(disabled) 처리되지 않는다', () => {
+      // train.arrivalSeconds(40) < walkingBufferSeconds(300) → 일반 row라면 disabled였을 조건.
+      const prevTrain = makePrevTrain({ arrivalSeconds: 40 });
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[]}
+          line="2"
+          onSelect={() => {}}
+          prevTrain={prevTrain}
+          walkingBufferSeconds={300}
+        />,
+      );
+      expect(getByTestId('boarding-train-prev-row-T-PREV').props.accessibilityState.disabled).toBe(false);
+    });
+
+    it('전열차 row 탭 시 pending 낙관적 UI가 동일하게 적용된다', () => {
+      const prevTrain = makePrevTrain();
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[]} line="2" onSelect={() => {}} prevTrain={prevTrain} />,
+      );
+      fireEvent.press(getByTestId('boarding-train-prev-row-T-PREV'));
+      expect(getByTestId('boarding-train-prev-pending-T-PREV')).toBeTruthy();
+      expect(getByTestId('boarding-train-list-pending-notice')).toBeTruthy();
     });
   });
 });

--- a/src/features/alarm/hooks/__tests__/usePrevTrainCandidate.test.ts
+++ b/src/features/alarm/hooks/__tests__/usePrevTrainCandidate.test.ts
@@ -1,0 +1,357 @@
+import { renderHook } from '@testing-library/react-native';
+import { usePrevTrainCandidate } from '../usePrevTrainCandidate';
+import { useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
+import type { ArrivalInfo, StationArrival } from '../../../../shared/types/arrival';
+import type { Station } from '../../../../shared/types/station';
+import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
+
+jest.mock('../../../arrival/hooks/useArrivalInfo');
+const mockUseArrival = useArrivalInfo as jest.Mock;
+
+const mockResolveTripDirection = jest.fn();
+jest.mock('../../../route/utils/tripDirection', () => ({
+  resolveTripDirection: (...args: unknown[]) => mockResolveTripDirection(...args),
+}));
+
+const mockFindStationByNameAndLine = jest.fn();
+const mockGetStopSeconds = jest.fn();
+jest.mock('../../../../shared/utils/stationRoute', () => ({
+  findStationByNameAndLine: (...args: unknown[]) => mockFindStationByNameAndLine(...args),
+  getStopSeconds: (...args: unknown[]) => mockGetStopSeconds(...args),
+}));
+
+function arrivalRet(arrival: StationArrival | null, loading = false) {
+  return { arrival, loading, isMock: false, refetch: jest.fn() };
+}
+
+function makeTrain(overrides: Partial<ArrivalInfo>): ArrivalInfo {
+  return {
+    destination: '종착',
+    arrivalMinutes: 2,
+    arrivalSeconds: 120,
+    statusMessage: '',
+    trainCode: 'T-NEW',
+    line: '2',
+    receivedAtMs: 0,
+    arrivalCode: -1,
+    isLastTrain: false,
+    trainType: 'normal',
+    ...overrides,
+  };
+}
+
+const currentStation: Station = {
+  id: 'stn-current',
+  name: '강남',
+  line: '2',
+  lat: 37.497,
+  lng: 127.027,
+} as Station;
+
+const nextStation: Station = {
+  id: 'stn-next',
+  name: '역삼',
+  line: '2',
+  lat: 37.5,
+  lng: 127.036,
+} as Station;
+
+const route = makeDirectRoute(5, '2');
+
+describe('usePrevTrainCandidate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseArrival.mockReturnValue(arrivalRet(null));
+    mockResolveTripDirection.mockReturnValue('down');
+    mockFindStationByNameAndLine.mockReturnValue(nextStation);
+    mockGetStopSeconds.mockReturnValue(150);
+  });
+
+  it('다음역 도착 목록에서 출발역 목록에 없는 동일 line/방향 열차 중 최소 ETA를 전열차로 채택한다', () => {
+    const currentArrivals = [makeTrain({ trainCode: 'T-STILL-AT-ORIGIN', arrivalSeconds: 200 })];
+    const nextArrival: StationArrival = {
+      up: [],
+      down: [
+        makeTrain({ trainCode: 'T-DEPARTED-FAR', arrivalSeconds: 90 }),
+        makeTrain({ trainCode: 'T-DEPARTED-CLOSE', arrivalSeconds: 30 }),
+        makeTrain({ trainCode: 'T-STILL-AT-ORIGIN', arrivalSeconds: 250 }), // 출발역 목록에도 있음 → 제외
+      ],
+    };
+    mockUseArrival.mockReturnValue(arrivalRet(nextArrival));
+
+    const { result } = renderHook(() =>
+      usePrevTrainCandidate({
+        route,
+        destinationName: '잠실',
+        currentStation,
+        nextStationName: nextStation.name,
+        line: '2',
+        currentArrivals,
+      }),
+    );
+
+    expect(result.current.prevTrain?.train.trainCode).toBe('T-DEPARTED-CLOSE');
+    // stopSeconds(150) - arrivalSeconds(30) = 120
+    expect(result.current.prevTrain?.elapsedSeconds).toBe(120);
+  });
+
+  it('candidate가 이미 최소인 상태에서 뒤 순서 후보가 더 크면 기존 min을 유지한다', () => {
+    // reduce 비교의 false 분기(cur.arrivalSeconds < min.arrivalSeconds가 거짓) 커버.
+    const nextArrival: StationArrival = {
+      up: [],
+      down: [
+        makeTrain({ trainCode: 'T-MIN-FIRST', arrivalSeconds: 20 }),
+        makeTrain({ trainCode: 'T-LARGER-LATER', arrivalSeconds: 80 }),
+      ],
+    };
+    mockUseArrival.mockReturnValue(arrivalRet(nextArrival));
+
+    const { result } = renderHook(() =>
+      usePrevTrainCandidate({
+        route,
+        destinationName: '잠실',
+        currentStation,
+        nextStationName: nextStation.name,
+        line: '2',
+        currentArrivals: [],
+      }),
+    );
+
+    expect(result.current.prevTrain?.train.trainCode).toBe('T-MIN-FIRST');
+  });
+
+  it('음수 elapsedSeconds는 0으로 clamp한다', () => {
+    mockGetStopSeconds.mockReturnValue(60);
+    const nextArrival: StationArrival = {
+      up: [],
+      down: [makeTrain({ trainCode: 'T-DEPARTED', arrivalSeconds: 200 })],
+    };
+    mockUseArrival.mockReturnValue(arrivalRet(nextArrival));
+
+    const { result } = renderHook(() =>
+      usePrevTrainCandidate({
+        route,
+        destinationName: '잠실',
+        currentStation,
+        nextStationName: nextStation.name,
+        line: '2',
+        currentArrivals: [],
+      }),
+    );
+
+    expect(result.current.prevTrain?.elapsedSeconds).toBe(0);
+  });
+
+  it('direction이 up이면 up 버킷만 candidate pool로 사용한다', () => {
+    mockResolveTripDirection.mockReturnValue('up');
+    const nextArrival: StationArrival = {
+      up: [makeTrain({ trainCode: 'T-UP', arrivalSeconds: 40 })],
+      down: [makeTrain({ trainCode: 'T-DOWN', arrivalSeconds: 10 })],
+    };
+    mockUseArrival.mockReturnValue(arrivalRet(nextArrival));
+
+    const { result } = renderHook(() =>
+      usePrevTrainCandidate({
+        route,
+        destinationName: '잠실',
+        currentStation,
+        nextStationName: nextStation.name,
+        line: '2',
+        currentArrivals: [],
+      }),
+    );
+
+    expect(result.current.prevTrain?.train.trainCode).toBe('T-UP');
+  });
+
+  it('direction을 알 수 없으면(null) up+down 합집합에서 채택한다', () => {
+    mockResolveTripDirection.mockReturnValue(null);
+    const nextArrival: StationArrival = {
+      up: [makeTrain({ trainCode: 'T-UP', arrivalSeconds: 40 })],
+      down: [makeTrain({ trainCode: 'T-DOWN', arrivalSeconds: 10 })],
+    };
+    mockUseArrival.mockReturnValue(arrivalRet(nextArrival));
+
+    const { result } = renderHook(() =>
+      usePrevTrainCandidate({
+        route,
+        destinationName: '잠실',
+        currentStation,
+        nextStationName: nextStation.name,
+        line: '2',
+        currentArrivals: [],
+      }),
+    );
+
+    expect(result.current.prevTrain?.train.trainCode).toBe('T-DOWN');
+  });
+
+  it('다른 line 열차는 후보에서 제외한다', () => {
+    const nextArrival: StationArrival = {
+      up: [],
+      down: [makeTrain({ trainCode: 'T-OTHER-LINE', arrivalSeconds: 20, line: '5' })],
+    };
+    mockUseArrival.mockReturnValue(arrivalRet(nextArrival));
+
+    const { result } = renderHook(() =>
+      usePrevTrainCandidate({
+        route,
+        destinationName: '잠실',
+        currentStation,
+        nextStationName: nextStation.name,
+        line: '2',
+        currentArrivals: [],
+      }),
+    );
+
+    expect(result.current.prevTrain).toBeNull();
+  });
+
+  it('이미 지나간(arrivalSeconds < 0) 열차는 후보에서 제외한다', () => {
+    const nextArrival: StationArrival = {
+      up: [],
+      down: [makeTrain({ trainCode: 'T-PASSED', arrivalSeconds: -5 })],
+    };
+    mockUseArrival.mockReturnValue(arrivalRet(nextArrival));
+
+    const { result } = renderHook(() =>
+      usePrevTrainCandidate({
+        route,
+        destinationName: '잠실',
+        currentStation,
+        nextStationName: nextStation.name,
+        line: '2',
+        currentArrivals: [],
+      }),
+    );
+
+    expect(result.current.prevTrain).toBeNull();
+  });
+
+  it('후보가 없으면 null', () => {
+    const nextArrival: StationArrival = { up: [], down: [] };
+    mockUseArrival.mockReturnValue(arrivalRet(nextArrival));
+
+    const { result } = renderHook(() =>
+      usePrevTrainCandidate({
+        route,
+        destinationName: '잠실',
+        currentStation,
+        nextStationName: nextStation.name,
+        line: '2',
+        currentArrivals: [],
+      }),
+    );
+
+    expect(result.current.prevTrain).toBeNull();
+  });
+
+  it('arrival이 아직 null이면(첫 폴링 전) prevTrain null', () => {
+    mockUseArrival.mockReturnValue(arrivalRet(null, true));
+
+    const { result } = renderHook(() =>
+      usePrevTrainCandidate({
+        route,
+        destinationName: '잠실',
+        currentStation,
+        nextStationName: nextStation.name,
+        line: '2',
+        currentArrivals: [],
+      }),
+    );
+
+    expect(result.current.prevTrain).toBeNull();
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('currentStation이 null이면 prevTrain null (route/destination 유무와 무관)', () => {
+    const nextArrival: StationArrival = { up: [], down: [makeTrain({ trainCode: 'T-X', arrivalSeconds: 10 })] };
+    mockUseArrival.mockReturnValue(arrivalRet(nextArrival));
+
+    const { result } = renderHook(() =>
+      usePrevTrainCandidate({
+        route,
+        destinationName: '잠실',
+        currentStation: null,
+        nextStationName: nextStation.name,
+        line: '2',
+        currentArrivals: [],
+      }),
+    );
+
+    expect(result.current.prevTrain).toBeNull();
+  });
+
+  it('nextStationName이 null이면 prevTrain null', () => {
+    const nextArrival: StationArrival = { up: [], down: [makeTrain({ trainCode: 'T-X', arrivalSeconds: 10 })] };
+    mockUseArrival.mockReturnValue(arrivalRet(nextArrival));
+
+    const { result } = renderHook(() =>
+      usePrevTrainCandidate({
+        route,
+        destinationName: '잠실',
+        currentStation,
+        nextStationName: null,
+        line: '2',
+        currentArrivals: [],
+      }),
+    );
+
+    expect(result.current.prevTrain).toBeNull();
+  });
+
+  it('line이 null이면 prevTrain null', () => {
+    const nextArrival: StationArrival = { up: [], down: [makeTrain({ trainCode: 'T-X', arrivalSeconds: 10 })] };
+    mockUseArrival.mockReturnValue(arrivalRet(nextArrival));
+
+    const { result } = renderHook(() =>
+      usePrevTrainCandidate({
+        route,
+        destinationName: '잠실',
+        currentStation,
+        nextStationName: nextStation.name,
+        line: null,
+        currentArrivals: [],
+      }),
+    );
+
+    expect(result.current.prevTrain).toBeNull();
+  });
+
+  it('nextStation lookup 실패(findStationByNameAndLine이 undefined 반환) 시 prevTrain null', () => {
+    mockFindStationByNameAndLine.mockReturnValue(undefined);
+    const nextArrival: StationArrival = { up: [], down: [makeTrain({ trainCode: 'T-X', arrivalSeconds: 10 })] };
+    mockUseArrival.mockReturnValue(arrivalRet(nextArrival));
+
+    const { result } = renderHook(() =>
+      usePrevTrainCandidate({
+        route,
+        destinationName: '잠실',
+        currentStation,
+        nextStationName: nextStation.name,
+        line: '2',
+        currentArrivals: [],
+      }),
+    );
+
+    expect(result.current.prevTrain).toBeNull();
+  });
+
+  it('route/destinationName이 없으면 direction 계산 없이(null) 진행 — resolveTripDirection 미호출', () => {
+    const nextArrival: StationArrival = { up: [], down: [makeTrain({ trainCode: 'T-X', arrivalSeconds: 10 })] };
+    mockUseArrival.mockReturnValue(arrivalRet(nextArrival));
+
+    renderHook(() =>
+      usePrevTrainCandidate({
+        route: null,
+        destinationName: null,
+        currentStation,
+        nextStationName: nextStation.name,
+        line: '2',
+        currentArrivals: [],
+      }),
+    );
+
+    expect(mockResolveTripDirection).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/alarm/hooks/usePrevTrainCandidate.ts
+++ b/src/features/alarm/hooks/usePrevTrainCandidate.ts
@@ -1,0 +1,90 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: 이 파일은 의도적으로 여러 features의 hook/util을 조합하는
+ * orchestrator 역할이라 직접 import가 본질적이다. Phase 5 enforce 모드에서 file-level disable로
+ * 옵트인 처리. 후속 PR(별도 이슈)에서 orchestration 슬라이스(예: features/fusion/, app shell)로
+ * 추출하여 disable을 제거할 예정.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+import { useMemo } from 'react';
+import { useArrivalInfo } from '../../arrival/hooks/useArrivalInfo';
+import { resolveTripDirection } from '../../route/utils/tripDirection';
+import { findStationByNameAndLine, getStopSeconds } from '../../../shared/utils/stationRoute';
+import type { Route } from '../../../shared/utils/stationRoute';
+import type { ArrivalInfo } from '../../../shared/types/arrival';
+import type { LineNumber, Station } from '../../../shared/types/station';
+import type { ArrivalProvider } from '../../../shared/types/providers';
+
+export interface UsePrevTrainCandidateInputs {
+  route: Route;
+  destinationName: string | null;
+  /** 출발역(사용자가 탑승할 역) — trip origin. */
+  currentStation: Station | null;
+  /** 출발역의 route 진행 방향 바로 다음 인접역 이름. */
+  nextStationName: string | null;
+  /** null이면(호선 미확정) 후보 산출 skip. */
+  line: LineNumber | null;
+  /** 출발역 도착 list — 이미 이 목록에 있는 trainCode는 "아직 출발 전"이라 전열차 후보에서 제외. */
+  currentArrivals: ArrivalInfo[];
+  arrivalProvider?: ArrivalProvider;
+}
+
+export interface PrevTrainCandidate {
+  train: ArrivalInfo;
+  /** 출발역을 떠난 지 대략 몇 초 지났는지(추정, 0 미만은 0으로 clamp). */
+  elapsedSeconds: number;
+}
+
+export interface UsePrevTrainCandidateResult {
+  prevTrain: PrevTrainCandidate | null;
+  /** 다음역 도착 정보 첫 폴링 완료 전 true. */
+  loading: boolean;
+}
+
+/**
+ * "전열차"(출발역을 방금 떠난 열차) 후보 도출 — #2139.
+ *
+ * 도착정보 API는 "도착 예정" 열차만 반환하므로 이미 출발한 열차는 출발역 응답에서 사라지고
+ * 다음역 응답에 나타난다. 이 성질을 이용해 다음역 arrivals를 조회하고, 동일 line + 동일 진행
+ * 방향 열차 중 출발역 arrivals(`currentArrivals`)에 없는 trainCode를 후보로 추린 뒤
+ * arrivalSeconds가 가장 작은(=다음역에 가장 먼저 닿는) 열차를 "방금 출발한 열차"로 채택한다.
+ *
+ * currentStation/nextStationName/direction 중 하나라도 산출 불가하면 null(=UI가 기존 동작 유지).
+ */
+export function usePrevTrainCandidate({
+  route,
+  destinationName,
+  currentStation,
+  nextStationName,
+  line,
+  currentArrivals,
+  arrivalProvider,
+}: UsePrevTrainCandidateInputs): UsePrevTrainCandidateResult {
+  const { arrival, loading } = useArrivalInfo(nextStationName, line, arrivalProvider);
+
+  const direction = useMemo(() => {
+    if (!route || !destinationName || !currentStation) return null;
+    return resolveTripDirection(route, destinationName, currentStation.id);
+  }, [route, destinationName, currentStation]);
+
+  const prevTrain = useMemo<PrevTrainCandidate | null>(() => {
+    if (!arrival || !currentStation || !nextStationName || !line) return null;
+    const nextStation = findStationByNameAndLine(nextStationName, line);
+    if (!nextStation) return null;
+
+    const pool =
+      direction === 'up' ? arrival.up : direction === 'down' ? arrival.down : [...arrival.up, ...arrival.down];
+    const currentCodes = new Set(currentArrivals.map((t) => t.trainCode));
+    const candidates = pool.filter(
+      (t) => t.line === line && t.arrivalSeconds >= 0 && !currentCodes.has(t.trainCode),
+    );
+    if (candidates.length === 0) return null;
+
+    const closest = candidates.reduce((min, cur) => (cur.arrivalSeconds < min.arrivalSeconds ? cur : min));
+    const stopSeconds = getStopSeconds(line, currentStation.id, nextStation.id);
+    const elapsedSeconds = Math.max(0, stopSeconds - closest.arrivalSeconds);
+    return { train: closest, elapsedSeconds };
+  }, [arrival, currentStation, nextStationName, direction, currentArrivals, line]);
+
+  return { prevTrain, loading };
+}

--- a/src/features/alarm/hooks/usePrevTrainCandidate.ts
+++ b/src/features/alarm/hooks/usePrevTrainCandidate.ts
@@ -80,7 +80,10 @@ export function usePrevTrainCandidate({
     );
     if (candidates.length === 0) return null;
 
-    const closest = candidates.reduce((min, cur) => (cur.arrivalSeconds < min.arrivalSeconds ? cur : min));
+    const closest = candidates.reduce(
+      (min, cur) => (cur.arrivalSeconds < min.arrivalSeconds ? cur : min),
+      candidates[0],
+    );
     const stopSeconds = getStopSeconds(line, currentStation.id, nextStation.id);
     const elapsedSeconds = Math.max(0, stopSeconds - closest.arrivalSeconds);
     return { train: closest, elapsedSeconds };

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -59,6 +59,7 @@ import { useSleepModeGuide } from '../features/settings/hooks/useSleepModeGuide'
 import { useSilentPushHealthCheck } from '../features/alarm/hooks/useSilentPushHealthCheck';
 import { useArrivalAutoClear } from '../features/arrival/hooks/useArrivalAutoClear';
 import { useBoardingLockController } from '../features/alarm/hooks/useBoardingLockController';
+import { usePrevTrainCandidate } from '../features/alarm/hooks/usePrevTrainCandidate';
 import { useSafetyNetScheduler } from '../features/alarm/hooks/useSafetyNetScheduler';
 import { useStationPrescheduler } from '../features/alarm/hooks/useStationPrescheduler';
 import { useBoardingLockAutoRelease } from '../features/alarm/hooks/useBoardingLockAutoRelease';
@@ -664,6 +665,17 @@ export default function HomeScreen() {
     barometerSubsurface,
     accelerometerPattern,
     cellularEnvironmentVote,
+  });
+  // #2139 — "전열차"(출발역을 방금 떠난 열차) 후보. lock이 없는 상태(=BoardingTrainList 노출 구간)에서만
+  // 의미가 있지만 Rules of Hooks 준수를 위해 항상 호출 — currentStation/nextStationName 부재 시
+  // hook 내부에서 graceful null 반환.
+  const { prevTrain } = usePrevTrainCandidate({
+    route,
+    destinationName: destination?.name ?? null,
+    currentStation: effectiveOrigin,
+    nextStationName,
+    line: approachLine ?? effectiveOrigin?.line ?? null,
+    currentArrivals: boardingListArrivals,
   });
   // #1844 — cold start mismatch 재확인: lock 해제 → 사용자가 다시 탑승 선택 가능.
   const handleColdStartMismatchReselect = useCallback(() => {
@@ -1506,6 +1518,9 @@ export default function HomeScreen() {
                                     // 계산되고도 이 prop으로 전달되지 않아 fetch 완료 전 빈 배열이 그대로
                                     // "도착 예정 열차 없음"으로 렌더됐다.
                                     loading={arrivalLoading}
+                                    // #2139 — 전열차(출발역을 방금 떠난 열차) 후보. 식별 불가 시 null이라
+                                    // 기존 [현열차 | 다음열차] 렌더가 그대로 보존된다.
+                                    prevTrain={prevTrain}
                                   />
                                 </View>
                               );

--- a/src/shared/constants/__tests__/labels.test.ts
+++ b/src/shared/constants/__tests__/labels.test.ts
@@ -1,5 +1,6 @@
 import {
   buildFallbackSequenceLabel,
+  buildPrevTrainLabel,
   buildSilentPushCountValue,
   SILENT_PUSH_LABELS,
 } from '../labels';
@@ -38,6 +39,19 @@ describe('buildFallbackSequenceLabel (#855)', () => {
     it('arrivalSeconds 음수면 분 라벨 생략 (이론상 발생 안하지만 가드)', () => {
       expect(buildFallbackSequenceLabel(1, -10)).toBe('약 2정거장 전');
     });
+  });
+});
+
+describe('buildPrevTrainLabel (#2139)', () => {
+  it('60초 미만은 "방금 출발"', () => {
+    expect(buildPrevTrainLabel(0)).toBe('방금 출발');
+    expect(buildPrevTrainLabel(59)).toBe('방금 출발');
+  });
+
+  it('60초 이상은 "출발 약 N분 전" (반올림)', () => {
+    expect(buildPrevTrainLabel(60)).toBe('출발 약 1분 전');
+    expect(buildPrevTrainLabel(90)).toBe('출발 약 2분 전');
+    expect(buildPrevTrainLabel(150)).toBe('출발 약 3분 전');
   });
 });
 

--- a/src/shared/constants/labels.ts
+++ b/src/shared/constants/labels.ts
@@ -37,6 +37,23 @@ export function buildFallbackSequenceLabel(index: number, arrivalSeconds?: numbe
 }
 
 /**
+ * BoardingTrainList "전열차" row 라벨 — #2139.
+ *
+ * 출발역을 방금 떠난 열차(도착 예정 목록에 없는 열차)를 선택 가능한 후보로 노출할 때 쓰는 라벨.
+ * elapsedSeconds는 "다음역까지 hop 소요 시간 − 다음역 도착까지 남은 초"로 추정한 경과 시간.
+ *
+ * 출력 예:
+ *   buildPrevTrainLabel(30)   → "방금 출발"      (1분 미만)
+ *   buildPrevTrainLabel(90)   → "출발 약 2분 전"  (반올림)
+ *   buildPrevTrainLabel(150)  → "출발 약 3분 전"
+ */
+export function buildPrevTrainLabel(elapsedSeconds: number): string {
+  if (elapsedSeconds < 60) return '방금 출발';
+  const minutes = Math.round(elapsedSeconds / 60);
+  return `출발 약 ${minutes}분 전`;
+}
+
+/**
  * #856 — DebugModal Silent Push 섹션 라벨.
  *
  * `lastReceivedAt`만 보고 "왜 안 울리지?" 묻는 사용자 의문 해결을 위해 received/fired


### PR DESCRIPTION
Closes #2139

## 요약

`BoardingTrainList`에 "전열차"(출발역을 방금 떠난 열차) row를 추가. 도착정보 API는 "도착 예정" 열차만 반환하므로 이미 출발한 열차는 출발역 응답에서 사라지고 다음역 응답에 나타나는 성질을 이용해 다음역 arrivals를 역산, 동일 line + 동일 진행 방향 열차 중 출발역 목록에 없는 trainCode 중 최소 ETA인 것을 "전열차" 후보로 채택한다.

## 변경 사항

- `src/features/alarm/hooks/usePrevTrainCandidate.ts` (신규) — 다음역 arrivals 폴링 + 전열차 후보 도출 hook. `resolveTripDirection`으로 진행 방향을 구해 다음역의 같은 방향 버킷에서 출발역 arrivals에 없는 trainCode 중 arrivalSeconds 최소값을 채택. `getStopSeconds`로 hop 소요시간을 역산해 "출발 후 경과 시간(elapsedSeconds)"도 함께 반환.
- `src/features/alarm/components/BoardingTrainList.tsx` — `prevTrain?: PrevTrainCandidate | null` prop 추가. 기존 row와 동일 Pressable/pending/accessibility 구조를 `renderRow` 헬퍼로 공유하되, 전열차 row는 `walkingBufferSeconds` 기반 unreachable 판정을 적용하지 않음(이미 탑승 중인 상태라 도보 개념 무의미) + 도착 시각 라인 생략(다음역 ETA라 "도착 예정" 표기가 오해를 줄 수 있음).
- `src/shared/constants/labels.ts` — `buildPrevTrainLabel(elapsedSeconds)` 추가 ("방금 출발" / "출발 약 N분 전").
- `src/screens/HomeScreen.tsx` — origin hop slot에서 `usePrevTrainCandidate`를 호출(항상 호출 — Rules of Hooks, 입력 부재 시 hook 내부에서 graceful null)하고 결과를 `BoardingTrainList`의 `prevTrain` prop으로 전달.

## Acceptance 대응

1. unit: 다음역 arrivals mock으로 전열차 도출(동일 line/방향, 출발역 리스트 제외, 최소 ETA) — `usePrevTrainCandidate.test.ts`.
2. 전열차 부재 시 기존 렌더/선택 동작 100% 보존 — `BoardingTrainList.test.tsx` "#2139 전열차 row" describe의 회귀 테스트(undefined/null prop 케이스).
3. 전열차 탭 → 기존 lock 생성 경로(`createLockFromTrain`) 재사용 — 신규 분기 없이 동일 `onSelect(train)` 호출.
4. coverage 100% + type-check + lint:orphan green (아래 검증 결과).
5. Device verify: 아래 명시.

## 금지 사항 준수

- `useApnsTripRegistration.ts` 미수정.
- backend 코드(`scheduled.ts`/`boardingPrompt.ts` 등) 미수정.

## 검증 결과

- `npm test` — 9040 passed, coverage 100% (lines/functions/branches/statements)
- `npm run type-check` — pass
- `npm run lint:orphan` — No orphan exports detected

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` 로컬 pass 확인.
2. **V/X dashboard** — 별도 신규 telemetry 없음(순수 UI 파생값). 확인은 실기기에서 BoardingTrainList 전열차 row 노출 여부로 직접 관측(DebugModal 연동 없음, 범위 밖).
3. **의존 PR** — N/A (device 단독 변경, backend/infra 의존 없음).
4. **측정 plan** — 1주 안: 09:5x 탑승 직후 앱 실행 trip에서 전열차 row 노출 여부 + 선택 후 매역 알림 정상 진행 여부를 실기기로 1회 이상 관찰. 회귀 신호는 "전열차 row가 노출됐어야 할 상황에서 미노출" 또는 "선택 후 lock이 다른 trainCode로 튐" 두 가지.
5. **Device verify** — 필요. 시나리오: 열차 탑승 직후(출발역을 막 떠난 시점) 앱 실행 → BoardingTrainList에 전열차 row 노출 확인 → 탭 → lock 생성 + 이후 매역 알림 정상 진행 확인. lock 시작점 자연 보정 여부도 함께 관찰(이슈 acceptance 5 명시).

## Test plan
- [x] `npm test` (coverage 100%)
- [x] `npm run type-check`
- [x] `npm run lint:orphan`
- [ ] 실기기 탑승 직후 앱 실행 시나리오 (사용자 검증 필요)