### PR TITLE
fix(#2144): register 성공 시 stale tripStatus 정리

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -4108,6 +4108,54 @@ describe('POST /trips — #1425 trip-recently-ended reject', () => {
     expect(res.status).toBe(400);
     expect(await res.json()).toMatchObject({ error: 'trip-recently-ended' });
   });
+
+  // #2144 — register 성공 후 같은 token의 stale tripStatus 종료 마커 정리.
+  describe('#2144 — stale tripStatus cleanup on successful register', () => {
+    it('clears tripStatus after seoul-outage cooldown bypass succeeds (retention 윈도우 밖 진입 없이도 즉시 정리)', async () => {
+      const env = makeKvEnv();
+      seedTripEnded(env, 'tok', Date.now() - 5_000, 'seoul-outage');
+
+      const res = await post('/trips', base(), env);
+      expect(res.status).toBe(200);
+      expect(await env.TRIPS.get('tripStatus:tok')).toBeNull();
+    });
+
+    it('clears tripStatus when retention window has elapsed and re-register succeeds', async () => {
+      const env = makeKvEnv();
+      seedTripEnded(env, 'tok', Date.now() - (60 * 60 * 1000 + 1_000), 'eta-missing');
+
+      const res = await post('/trips', base(), env);
+      expect(res.status).toBe(200);
+      expect(await env.TRIPS.get('tripStatus:tok')).toBeNull();
+    });
+
+    it('does not touch a different token tripStatus when unrelated token registers', async () => {
+      const env = makeKvEnv();
+      seedTripEnded(env, 'ended-token', Date.now() - 5_000, 'destination');
+
+      const res = await post('/trips', { ...base(), token: 'fresh-token' }, env);
+      expect(res.status).toBe(200);
+      // 무관한 token의 종료 마커는 그대로 보존돼야 한다.
+      expect(await env.TRIPS.get('tripStatus:ended-token')).not.toBeNull();
+    });
+
+    it('is a no-op (no crash) when no tripStatus marker exists for the token', async () => {
+      const env = makeKvEnv();
+      const res = await post('/trips', base(), env);
+      expect(res.status).toBe(200);
+      expect(await env.TRIPS.get('tripStatus:tok')).toBeNull();
+    });
+
+    it('still rejects (cooldown preserved) before any cleanup runs — no delete attempted on reject path', async () => {
+      const env = makeKvEnv();
+      seedTripEnded(env, 'tok', Date.now() - 5_000, 'eta-missing');
+
+      const res = await post('/trips', base(), env);
+      expect(res.status).toBe(400);
+      // reject 경로에서는 cooldown 판정 유지가 우선 — 마커가 그대로 남아 재시도 시에도 reject된다.
+      expect(await env.TRIPS.get('tripStatus:tok')).not.toBeNull();
+    });
+  });
 });
 
 // #1897 (RC-5) — POST /trips 응답 confirmedEnv echo.

--- a/backend/alarm-worker/src/__tests__/tripStatus.test.ts
+++ b/backend/alarm-worker/src/__tests__/tripStatus.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   TRIP_STATUS_RETENTION_MS,
   TRIP_STATUS_TTL_SEC,
+  deleteTripEndedStatus,
   readTripEndedStatus,
   toTripStatusEndReason,
   tripStatusKey,
@@ -102,6 +103,34 @@ describe('readTripEndedStatus', () => {
       value: JSON.stringify({ endedAt: 1, endReason: 'made-up' }),
     });
     expect(await readTripEndedStatus(kv as unknown as KVNamespace, 'tok')).toBeNull();
+  });
+});
+
+describe('deleteTripEndedStatus (#2144)', () => {
+  it('removes an existing record', async () => {
+    const kv = new InMemoryKV();
+    await writeTripEndedStatus(kv as unknown as KVNamespace, 'tok', 'expired', 1000);
+    expect(await readTripEndedStatus(kv as unknown as KVNamespace, 'tok')).not.toBeNull();
+
+    await deleteTripEndedStatus(kv as unknown as KVNamespace, 'tok');
+    expect(await readTripEndedStatus(kv as unknown as KVNamespace, 'tok')).toBeNull();
+  });
+
+  it('is a no-op when no record exists', async () => {
+    const kv = new InMemoryKV();
+    await expect(
+      deleteTripEndedStatus(kv as unknown as KVNamespace, 'never-existed'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('does not affect a different token', async () => {
+    const kv = new InMemoryKV();
+    await writeTripEndedStatus(kv as unknown as KVNamespace, 'tok-a', 'expired', 1000);
+    await writeTripEndedStatus(kv as unknown as KVNamespace, 'tok-b', 'expired', 1000);
+
+    await deleteTripEndedStatus(kv as unknown as KVNamespace, 'tok-a');
+    expect(await readTripEndedStatus(kv as unknown as KVNamespace, 'tok-a')).toBeNull();
+    expect(await readTripEndedStatus(kv as unknown as KVNamespace, 'tok-b')).not.toBeNull();
   });
 });
 

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -127,6 +127,7 @@ import { checkTripRegisterRateLimit } from './tripRegisterRateLimit';
 import {
   TRIP_STATUS_RETENTION_MS,
   readTripEndedStatus,
+  deleteTripEndedStatus,
 } from './tripStatus';
 import type {
   AccelSummary,
@@ -856,6 +857,25 @@ app.post('/trips', async (c) => {
       return { trip, isSameSession };
     },
   );
+
+  // #2144 — register 성공(putTrip 완료) 후 같은 token의 옛 tripStatus 종료 마커를 정리한다.
+  // 위 cooldown 판정(#1425 reject / #1663 seoul-outage bypass)이 이미 끝난 뒤라 cooldown 의미는
+  // 보존된다. 정리하지 않으면 새 trip이 활성 중에도 옛 endedAt 기록이 TTL까지 KV에 남아
+  // 진단 혼선(활성 trip + '종료됨' 기록 공존)을 유발한다. KV delete 실패는 graceful —
+  // register 응답을 차단하지 않는다.
+  if (recentlyEnded !== null) {
+    try {
+      await deleteTripEndedStatus(c.env.TRIPS, registerLockToken);
+    } catch (e) {
+      console.log(
+        JSON.stringify({
+          msg: 'trip-status delete on register success failed (#2144)',
+          tokenPrefix: tokenPrefix(registerLockToken),
+          error: String(e),
+        }),
+      );
+    }
+  }
 
   // #1701 — 새 세션 분기에서는 SSoT mirror도 강제 cleanup. cleanupTripWithLa가 이미 4 종료
   // 경로에서 deleteSsot를 호출하지만, 종료 후 KV TTL 자연 만료를 기다리는 동안 같은 token으로

--- a/backend/alarm-worker/src/tripStatus.ts
+++ b/backend/alarm-worker/src/tripStatus.ts
@@ -81,6 +81,15 @@ export async function writeTripEndedStatus(
 }
 
 /**
+ * #2144 — 같은 token으로 새 trip이 성공 등록되면 옛 종료 마커는 더 이상 유효하지 않다.
+ * 호출은 register 성공 경로에서 cooldown 판정(bypass 분기 포함) **뒤**에 실행해야 한다 —
+ * 먼저 지우면 `readTripEndedStatus` 기반 #1425 cooldown/#1663 bypass 판정이 무력화된다.
+ */
+export async function deleteTripEndedStatus(kv: KVNamespace, token: string): Promise<void> {
+  await kv.delete(tripStatusKey(token));
+}
+
+/**
  * 저장된 trip 종료 마커 조회. JSON parse 실패 또는 schema 불일치 시 null 반환 — KV 손상 엔트리는
  * 미존재와 동일하게 처리(launch reconciliation은 best-effort, fail-soft).
  */


### PR DESCRIPTION
Closes #2144

## 요약
`POST /trips` register 성공 경로(putTrip 완료)에서 같은 token의 기존 `tripStatus:<token>` 종료 마커를 삭제한다. 삭제는 cooldown 판정(#1425 reject / #1663 seoul-outage bypass)이 끝난 **뒤**에 실행 — cooldown 의미는 그대로 보존된다.

## 배경 (Evidence, 이슈 #2144)
아침 trip 종료 기록(`endedAt: 08:47:11`, `endReason: expired`)이 같은 token의 새 trip이 20:06에 활성 등록된 뒤에도 KV에 잔존. register handler는 `readTripEndedStatus`로 read만 하고 성공 등록 후 clear하지 않았음. 저위험(오판 없음, stale sentinel 위험은 #2118/#2121로 이미 차단)이나 진단 혼선(활성 trip + '종료됨' 기록 공존) 유발.

## 변경
- `backend/alarm-worker/src/tripStatus.ts`: `deleteTripEndedStatus(kv, token)` 헬퍼 추가 (기존 `deleteProgress`/`deleteSsot` 컨벤션 따름).
- `backend/alarm-worker/src/index.ts`: `withTripRegisterLock` 블록의 `putTrip` 성공 후, `recentlyEnded !== null`일 때만 `deleteTripEndedStatus` 호출 (원본 token 기준, rotation 발생 여부와 무관). KV delete 실패는 graceful catch — register 응답을 차단하지 않음.
- 테스트: `index.test.ts`에 `#2144 — stale tripStatus cleanup on successful register` describe 5건(성공 시 정리 / retention 경과 후 정리 / 다른 token 미영향 / 마커 없을 때 no-op / reject 경로에서는 정리 안 함 — cooldown 유지 확인). `tripStatus.test.ts`에 `deleteTripEndedStatus` 단위 테스트 3건.

## Wire-completion 5단
1. **Orphan 없음** — 신규 export `deleteTripEndedStatus`는 `index.ts`에서 즉시 호출. N/A for frontend lint:orphan (backend 전용 변경).
2. **V/X dashboard** — `tripStatus:<token>` KV 키는 wrangler tail 로그(`msg: 'trip-status delete on register success failed (#2144)'` — 실패 시에만 로그) 또는 Cloudflare Dashboard KV 브라우저에서 직접 확인 가능. 성공 삭제는 무음(성공 경로는 로그 없음, 필요 시 KV get으로 부재 확인).
3. **의존 PR** — N/A. backend 단독 변경, device 코드 미변경.
4. **측정 plan** — 1주간 동일 token 재등록 케이스에서 `tripStatus:<token>` 잔존 건수를 KV 샘플링(`wrangler kv key list --prefix tripStatus:`)으로 확인. 활성 trip(`trip:<token>` 존재) + `tripStatus:<token>` 공존 건수가 0으로 수렴하면 성공.
5. **Device verify** — N/A — type+unit only. Backend-only 변경으로 디바이스 코드 경로에 영향 없음.

## 검증
- `npx vitest run` — 70 files / 2780 tests all green (신규 8건 포함).
- `npx tsc --noEmit` — clean.