### PR TITLE
fix(#1960): register 실패/token 미가용 시 활성 trip 재시도

### DIFF
--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -58,6 +58,7 @@ import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../../shared/constants/st
 import {
   BOARDING_LOCK_RELEASE_DEBOUNCE_MS,
   CONTEXT_HEAL_TIER2_DELAY_MS,
+  REGISTER_RETRY_BACKOFF_MS,
 } from '../../../../shared/constants/boardingLock';
 import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
 
@@ -974,6 +975,308 @@ describe('useApnsTripRegistration', () => {
       );
       expect(refreshed?.[0].boardingLock).toBeDefined();
       expect(refreshed?.[0].boardingLock.trainCode).toBe('7246');
+    });
+  });
+
+  describe('#1960 (2026-08-04 RCA 보강) — register 실패/token 미가용 재시도', () => {
+    const lock = {
+      destinationId: station.id,
+      trainCode: '7246',
+      boardingStationId: station.id,
+      boardingLine: '2' as const,
+      boardedAt: 1_700_000_000_000,
+      expectedDurationMs: 600_000,
+    };
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('POST 실패({ok:false}) 시 backoff 후 재시도 — lock 활성 trip이 이후 lock 동봉으로 성공한다', async () => {
+      // 2026-08-04 아침 evidence 재현: lock 활성 중 첫 POST 실패 → 이전에는 재시도가 없어
+      // 다음 정상 register(주로 lock 해제 직후)에야 처음 backend에 도달했다.
+      mockRegister.mockResolvedValueOnce({ ok: false, status: 500 });
+      mockRegister.mockResolvedValueOnce({ ok: true });
+
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+          currentStation: station,
+          boardingLock: lock,
+        }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // 첫 backoff(15s) 전에는 재시도 없음.
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[0] - 100);
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // 15s 경과 → 재시도 발사, lock이 여전히 동봉된 채로 성공.
+      await act(async () => {
+        jest.advanceTimersByTime(200);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+      expect(mockRegister.mock.calls[1][0].boardingLock.trainCode).toBe('7246');
+
+      // 성공 후 재시도 상태가 초기화돼 추가 backoff가 지나도 3번째 호출 없음.
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[1] + 1000);
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+
+    it('APNs token 미가용 skip 시 재시도 — 토큰 발급 후 lock 동봉 register 성공', async () => {
+      let tokenAvailable = false;
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+        if (key === APNS_TOKEN_KEY) return tokenAvailable ? 'token-late' : null;
+        return null;
+      });
+
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+          currentStation: station,
+          boardingLock: lock,
+        }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).not.toHaveBeenCalled(); // 토큰 없음 — graceful skip
+
+      tokenAvailable = true;
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[0]);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+      expect(mockRegister.mock.calls[0][0].token).toBe('token-late');
+      expect(mockRegister.mock.calls[0][0].boardingLock.trainCode).toBe('7246');
+    });
+
+    it('상한(sessionKey당 3회) 도달 후 추가 재시도 없음 — 다음 정상 effect cycle에 위임', async () => {
+      mockRegister.mockResolvedValue({ ok: false, status: 500 });
+
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+          currentStation: station,
+        }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      for (const delay of REGISTER_RETRY_BACKOFF_MS) {
+        await act(async () => {
+          jest.advanceTimersByTime(delay);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+      }
+      // 최초 1회 + backoff 배열 길이(3)만큼 재시도 = 4회.
+      expect(mockRegister).toHaveBeenCalledTimes(1 + REGISTER_RETRY_BACKOFF_MS.length);
+
+      // 상한 도달 후 추가 시간이 지나도 더 이상 호출 없음.
+      await act(async () => {
+        jest.advanceTimersByTime(120_000);
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1 + REGISTER_RETRY_BACKOFF_MS.length);
+    });
+
+    it('재시도 대기 중 trip 전환(destination 변경)되면 예약된 재시도는 self-cancel', async () => {
+      mockRegister.mockResolvedValueOnce({ ok: false, status: 500 });
+      mockRegister.mockResolvedValue({ ok: true });
+      const otherDestination: Station = { ...station, id: '2-023', name: '역삼' };
+
+      const { rerender } = renderHook(
+        ({ d }: { d: Station }) =>
+          useApnsTripRegistration({
+            route: directRoute,
+            destination: d,
+            nextStationEtaSeconds: 120,
+            currentStation: d,
+          }),
+        { initialProps: { d: station } },
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1); // 실패 — 재시도 예약됨
+
+      // trip 전환 — 새 destination으로 즉시 register(성공).
+      rerender({ d: otherDestination });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      const callsAfterSwitch = mockRegister.mock.calls.length;
+      expect(callsAfterSwitch).toBeGreaterThanOrEqual(2);
+
+      // 옛 세션의 backoff가 지나도 추가 register 없음(self-cancel) — 구 trip으로의 stale register 차단.
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[0] + 1000);
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(callsAfterSwitch);
+    });
+
+    it('재시도 대기 중 다른 세션으로 실패 전환되면 옛 세션의 타이머를 clear하고 새 세션 attempt 0부터 시작', async () => {
+      mockRegister.mockResolvedValue({ ok: false, status: 500 });
+      const otherDestination: Station = { ...station, id: '2-023', name: '역삼' };
+
+      const { rerender } = renderHook(
+        ({ d }: { d: Station }) =>
+          useApnsTripRegistration({
+            route: directRoute,
+            destination: d,
+            nextStationEtaSeconds: 120,
+            currentStation: d,
+          }),
+        { initialProps: { d: station } },
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1); // 세션 A 실패 — 15s 재시도 예약
+
+      // 세션 A의 재시도가 발화하기 전에 세션 B로 전환 — B도 즉시 실패.
+      rerender({ d: otherDestination });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(2); // 세션 B 실패 — 새 15s 재시도 예약(attempt 0부터)
+
+      // 세션 A의 원래 15s 시점이 지나도 추가 호출 없음(A의 타이머는 세션 전환 시 clear됨) —
+      // 세션 B의 15s 재시도만 발화 — 총 3회.
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[0]);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(3);
+    });
+
+    it('token이 여러 backoff를 넘겨도 계속 미가용이면 재시도를 이어간다', async () => {
+      let tokenAvailable = false;
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+        if (key === APNS_TOKEN_KEY) return tokenAvailable ? 'token-late2' : null;
+        return null;
+      });
+
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+          currentStation: station,
+        }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).not.toHaveBeenCalled();
+
+      // 첫 backoff(15s) 시점에도 토큰 여전히 없음 — 두 번째 backoff(30s)를 예약.
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[0]);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).not.toHaveBeenCalled();
+
+      tokenAvailable = true;
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[1]);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+      expect(mockRegister.mock.calls[0][0].token).toBe('token-late2');
+    });
+
+    it('대기 중인 재시도 타이머가 있는 상태에서 같은 세션이 다시 실패하면 타이머를 갈아치운다', async () => {
+      mockRegister.mockResolvedValue({ ok: false, status: 500 });
+      const { rerender } = renderHook(
+        ({ sub }: { sub: boolean }) =>
+          useApnsTripRegistration({
+            route: directRoute,
+            destination: station,
+            nextStationEtaSeconds: 120,
+            currentStation: station,
+            subsurface: sub,
+          }),
+        { initialProps: { sub: false } },
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1); // 실패 — 15s 재시도 예약
+
+      // 첫 backoff가 발화하기 전, 같은 세션에서 subsurface 토글로 즉시 재실행 → 다시 실패.
+      rerender({ sub: true });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(2); // 실패 — 기존 15s 타이머를 clear하고 다음 backoff(30s)로 재schedule
+
+      // 원래 예정이던 첫 backoff(15s) 시점엔 아직 발화 안 함 — 옛 타이머가 clear되고
+      // attempt가 이미 1로 진행돼 있어 다음 예약은 backoff[1](30s) 기준.
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[0] + 100);
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[1]);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(3);
+    });
+
+    it('register 성공(ok:true)은 재시도를 트리거하지 않음 — dedup 폭주 방지(#703) 보존', async () => {
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+          currentStation: station,
+        }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        jest.advanceTimersByTime(
+          REGISTER_RETRY_BACKOFF_MS[REGISTER_RETRY_BACKOFF_MS.length - 1] * 5,
+        );
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -38,6 +38,7 @@ import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../shared/constants/stora
 import {
   BOARDING_LOCK_RELEASE_DEBOUNCE_MS,
   CONTEXT_HEAL_TIER2_DELAY_MS,
+  REGISTER_RETRY_BACKOFF_MS,
 } from '../../../shared/constants/boardingLock';
 import { createLogger } from '../../../shared/utils/logger';
 import { getRegisteringApnsEnv, warmupConfirmedApnsEnv } from '../../../shared/utils/apnsEnv';
@@ -379,6 +380,14 @@ export function useApnsTripRegistration({
   // #2130 (B-1 Tier 2) — 지하 fallback 타이머 핸들.
   const tier2TimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // #1960 (2026-08-04 RCA 보강) — register 실패/token 미가용 skip 재시도 상태. sessionKey는
+  // `${routeSig}:${destination.id}` — trip 전환/종료 시 무효화되도록 attempt 시점에 재검증한다.
+  const registerRetryRef = useRef<{
+    sessionKey: string | null;
+    attempt: number;
+    timer: ReturnType<typeof setTimeout> | null;
+  }>({ sessionKey: null, attempt: 0, timer: null });
+
   /**
    * #2129 — 두 register 경로(main effect / token-refresh listener)가 거의 동시에 실행돼도
    * 동일 입력에서 동일 payload를 만들도록 `latestInputsRef` 단일 출처에서 register하는 helper.
@@ -467,6 +476,73 @@ export function useApnsTripRegistration({
     await registerFromLatestInputs(token, { promptContextOverride: overrideContext });
   };
 
+  /** #1960 — 대기 중인 register 재시도 타이머/상태를 모두 초기화. */
+  const clearRegisterRetry = (): void => {
+    if (registerRetryRef.current.timer !== null) {
+      clearTimeout(registerRetryRef.current.timer);
+    }
+    registerRetryRef.current = { sessionKey: null, attempt: 0, timer: null };
+  };
+
+  /**
+   * #1960 — `sessionKey`(activeTrip 세션) 기준으로 다음 backoff 시점에 재시도를 예약한다.
+   * 상한(`REGISTER_RETRY_BACKOFF_MS.length`) 도달 시 조용히 중단 — 다음 정상 effect cycle
+   * (route/destination/lock 변경)이 처리한다.
+   */
+  const scheduleRegisterRetry = (sessionKey: string): void => {
+    if (registerRetryRef.current.sessionKey !== sessionKey) {
+      // 다른 세션(트립 전환)으로 갈아탈 때 옛 세션의 대기 타이머가 살아남아 나중에 무의미하게
+      // 발화하지 않도록 명시적으로 clear — tier2TimerRef와 동일한 위생.
+      if (registerRetryRef.current.timer !== null) {
+        clearTimeout(registerRetryRef.current.timer);
+      }
+      registerRetryRef.current = { sessionKey, attempt: 0, timer: null };
+    }
+    const { attempt } = registerRetryRef.current;
+    if (attempt >= REGISTER_RETRY_BACKOFF_MS.length) {
+      logger.info(`register retry: 상한(${REGISTER_RETRY_BACKOFF_MS.length}) 도달 — 중단`, sessionKey);
+      return;
+    }
+    if (registerRetryRef.current.timer !== null) {
+      clearTimeout(registerRetryRef.current.timer);
+    }
+    const delay = REGISTER_RETRY_BACKOFF_MS[attempt];
+    registerRetryRef.current.attempt = attempt + 1;
+    registerRetryRef.current.timer = setTimeout(() => {
+      registerRetryRef.current.timer = null;
+      void attemptRegisterRetry(sessionKey);
+    }, delay);
+  };
+
+  /**
+   * #1960 — 예약된 재시도 실행. 활성 trip이 여전히 같은 세션인지 재검증(trip 전환/종료 시
+   * self-cancel) 후 token을 다시 조회해 register를 재시도한다. 성공(`ok:true`, dedup skip
+   * 포함)하면 재시도 상태를 초기화, 실패하면 다음 backoff를 예약한다.
+   */
+  const attemptRegisterRetry = async (sessionKey: string): Promise<void> => {
+    const { route: r, destination: d } = latestInputsRef.current;
+    /* istanbul ignore next -- trip 종료 경로("트립 없음" 분기, mount-once cleanup)와 trip 전환
+     * 경로(scheduleRegisterRetry의 세션 교체 분기) 모두 이 타이머 콜백이 실행되기 전에
+     * 대기 타이머를 동기적으로 clear하므로, 이 콜백 자체가 route/destination null 또는 세션
+     * 불일치 상태로 진입할 도달 경로가 현재 코드에 없다. Tier 2 heal의 동일 성격 가드
+     * (위 runTier2Heal)와 같은 방어적 처리. */
+    if (!r || !d || `${routeSignature(r)}:${d.id}` !== sessionKey) return; // trip 종료/전환됨 — 재시도 대상 아님
+
+    const token = await AsyncStorage.getItem(APNS_TOKEN_KEY);
+    if (!token) {
+      // 토큰 여전히 미가용 — 다음 backoff 예약.
+      scheduleRegisterRetry(sessionKey);
+      return;
+    }
+    const result = await registerFromLatestInputs(token);
+    if (result?.ok) {
+      clearRegisterRetry();
+      await AsyncStorage.setItem(ACTIVE_TRIP_KEY, token);
+    } else {
+      scheduleRegisterRetry(sessionKey);
+    }
+  };
+
   // ── 토큰 발급 + 리스너 등록 (mount-once) ──
   useEffect(() => {
     let cancelled = false;
@@ -511,6 +587,8 @@ export function useApnsTripRegistration({
     return () => {
       cancelled = true;
       subscription?.remove();
+      // #1960 — 컴포넌트 unmount 시 대기 중인 register 재시도 타이머 정리(메모리 누수/좀비 POST 방지).
+      clearRegisterRetry();
     };
   }, []);
 
@@ -549,6 +627,8 @@ export function useApnsTripRegistration({
         lastRegisterMissingContextRef.current = false;
         healedSessionKeyRef.current = null;
         prevCurrentStationIdRef.current = null;
+        // #1960: trip 종료 시 register 재시도 상태도 초기화 — 다음 trip이 새로 재시도 3회 기회를 갖는다.
+        clearRegisterRetry();
         return;
       }
 
@@ -583,6 +663,9 @@ export function useApnsTripRegistration({
       // 트립 있음 → 토큰 없으면 graceful skip.
       if (!token) {
         logger.info('apns token not yet available — skip register');
+        // #1960 — deps(routeSig/destination.id/boardingLockSig 등) 불변이면 다음 재기회가
+        // 없으므로, 활성 trip 한정으로 token 재발급을 기다리며 재시도 예약.
+        scheduleRegisterRetry(`${routeSig}:${destination.id}`);
         return;
       }
 
@@ -620,6 +703,11 @@ export function useApnsTripRegistration({
       // useEffect cleanup이 자주 일어나 setItem이 skip되고 DebugModal activeTrip이 (none)으로 표시됨.
       if (result?.ok) {
         await AsyncStorage.setItem(ACTIVE_TRIP_KEY, token);
+        // #1960 — 성공(dedup skip 포함, ok:true)했으면 이 세션에 대한 대기 재시도가 있다면 정리.
+        clearRegisterRetry();
+      } else {
+        // #1960 — register 실패({ok:false}) — deps 불변이면 재기회가 없으므로 활성 trip 한정 재시도.
+        scheduleRegisterRetry(`${routeSig}:${destination.id}`);
       }
       // #2130 (B-1 Tier 2) — 이번 register가 성공했으면 60초 타이머를 arm. 이 effect의
       // cleanup이 매 re-execution 전에 이전 타이머를 이미 cancel하므로(아래), 여기 도달한

--- a/src/shared/constants/boardingLock.ts
+++ b/src/shared/constants/boardingLock.ts
@@ -125,3 +125,25 @@ export const FREE_TRIP_DESTINATION_SENTINEL = '__free-trip-sentinel__';
  *  - 너무 길면(예: 5분) 사용자가 이미 열차에 탑승한 뒤에야 prompt 평가가 시작돼 A1(≤3분) 위반.
  */
 export const CONTEXT_HEAL_TIER2_DELAY_MS = 60_000;
+
+/**
+ * #1960 (2026-08-04 RCA 보강) — trip register 실패({ok:false}) 또는 APNs token 미가용 skip 시
+ * 재시도 backoff 스케줄(ms). 활성 trip(route+destination 존재) 한정으로만 사용된다.
+ *
+ * 배경: `useApnsTripRegistration`의 register useEffect는 #703 의도(POST 폭주 방지)로
+ * `nextStationEtaSeconds`/`currentStation`을 deps에서 제외한다. 그 결과 register가 실패하거나
+ * token이 아직 발급 전이면 deps가 그대로인 한 재시도 기회 자체가 없어, lock이 활성인 짧은
+ * window(예: 2026-08-04 아침 trip evidence — lock 활성 07:26:33~07:30:10, 첫 register 성공은
+ * lock 해제 직후인 07:30:20) 동안 register가 한 번도 backend에 도달하지 못하면 그 trip은
+ * silent push 채널 전체가 하루 종일 비활성으로 남는다.
+ *
+ * 15s → 30s → 60s로 둔 이유:
+ *  - 15s는 APNs 토큰 발급(`getDevicePushTokenAsync`)이 완료되기까지의 전형적 지연을 커버.
+ *  - 30s/60s는 backend 일시 장애(cold start, 네트워크 hiccup) 복구 여유를 늘려가며 확인.
+ *  - 3회 상한(약 105s 총 대기) 이상 실패하면 실제 장애 가능성이 높아 무한 재시도로 배터리를
+ *    소모하기보다 다음 정상 effect cycle(route/destination/lock 변경)에 맡긴다.
+ *
+ * dedup hash 경로는 불변 — 성공한 register(`ok:true`, `skipped:true` 포함)는 재시도를
+ * 트리거하지 않아 #703(POST 폭주 방지) 의도를 보존한다.
+ */
+export const REGISTER_RETRY_BACKOFF_MS: readonly number[] = [15_000, 30_000, 60_000];


### PR DESCRIPTION
Part of #1960

## 배경 (2026-08-04 RCA 보강 코멘트)

#1960 이슈 코멘트의 심야 RCA — 아침 trip(D1 `b00dd879`) evidence: device BoardingLock이
07:26:33~07:30:10 활성이었는데, 첫 register 성공은 lock 해제 직후인 07:30:20. lock 활성 4분간
register가 backend에 한 번도 도달하지 못해 그 trip은 silent push 채널이 하루 종일 `sent=0`.

RC 후보 2가지:
1. APNs token 미가용 skip (`apns token not yet available — skip register`)
2. `registerActiveTrip`이 POST 실패 시 `{ok:false}` 반환 후 재시도 없음 — main register effect의
   deps(`routeSig, destination?.id, boardingLockSig, subsurface, infoModeEnabled, sleepMode`)가
   불변이면 다음 재기회 자체가 없음(#703 의도로 `currentStation`/`nextStationEtaSeconds`는 deps 제외).

## 실제 메커니즘 (코드/테스트로 확정)

`src/features/alarm/api/alarmBackend.ts`의 `registerActiveTrip`을 직접 대조:
- **dedup skip은 `{ok:true, skipped:true}`** (hash 동일 시) — 성공으로 간주, 재시도 트리거 안 함.
- **실패는 항상 `{ok:false}`** — URL 미설정(`skip register`), non-2xx status, fetch 예외 3가지 모두.

즉 위 RC ①·② 모두 device 코드에서 관측 가능한 `{ok:false}` 또는 `!token` skip 경로로 수렴하며,
본 PR은 이 두 경로 모두에 재시도를 건다(이슈 스펙 그대로 — 신호 자체를 세분화해 우선순위를 매기지
않고 "활성 trip이면 재시도"로 통일). 실제 프로덕션에서 ①/②의 상대 빈도는 device 로그만으로는
분리 확정이 어려움(1건 evidence) — 재시도가 두 경로 모두를 커버하므로 원인 불문 lock 부착 갭을
닫는다.

## 변경 사항

- `useApnsTripRegistration.ts`: register `{ok:false}` 또는 token 미가용 skip 시, **활성
  trip(route+destination 존재) 한정**으로 backoff 재시도(15s→30s→60s, 세션당 최대 3회).
  - 재시도는 세션(`routeSig:destination.id`) 단위로 추적하는 `registerRetryRef`.
  - trip 종료(route/destination → null) 또는 unmount 시 `clearRegisterRetry()`로 즉시 취소.
  - trip 전환(다른 세션의 register 실패)이 발생하면 옛 세션의 대기 타이머를 명시적으로 clear —
    stale 세션으로의 무의미한 재시도 발화를 방지(tier2TimerRef와 동일 위생).
  - 성공(`ok:true`, dedup skip 포함)하면 즉시 재시도 상태 초기화 — **#703 POST 폭주 방지 의도
    보존**: 정상 성공한 register는 추가 재시도를 트리거하지 않는다.
- `src/shared/constants/boardingLock.ts`: `REGISTER_RETRY_BACKOFF_MS` 상수 추가(근거 문서화).
- `__tests__/useApnsTripRegistration.test.ts`: 신규 케이스 8건
  - POST 실패 → backoff 재시도 → lock 동봉 성공 (2026-08-04 evidence 재현)
  - token 미가용 skip → 발급 후 lock 동봉 재시도 성공
  - 상한(3회) 도달 후 중단
  - trip 전환 시 stale 재시도 self-cancel / 옛 타이머 clear
  - token이 여러 backoff를 넘겨도 계속 미가용이면 재시도 지속
  - 성공 시 재시도 미트리거(#703 회귀 가드)

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (신규 export 없음, 내부 helper만 추가).
2. **V/X dashboard** — DebugModal `activeTrip`(ACTIVE_TRIP_KEY 갱신 시점)으로 성공 여부 관측 가능.
   재시도 자체는 device 로그(`ApnsTripRegistration` logger `info`)로 관측 — 별도 대시보드 신호 추가는
   범위 밖(이슈 스펙에 명시 없음).
3. **의존 PR** — N/A. backend 변경 없음(device-only).
4. **측정 plan** — 1주 production: 다음 실탑승에서 register 실패/token skip 발생 시 재시도가
   `registerActiveTrip` 재호출로 이어지는지 device 로그로 확인. 재현 빈도가 낮아(1건 evidence)
   test scenario 신뢰가 주 검증 수단.
5. **Device verify** — 다음 실탑승에서 D1 `lock_attached=1` + `silent_push_received≥1` 확인
   (PR #1960-token-refresh-context와 함께 검증 예정).

## 참고

`#2141`(context-heal, Tier 1/2) merge 이후 base — 같은 파일(`useApnsTripRegistration.ts`)의
`registerFromLatestInputs`/`callRegister` 통합 경로를 그대로 재사용해 재시도도 동일 payload
빌드 경로를 탄다. 충돌/공존 검증: 전체 테스트(9062건) green, Tier 1/2 heal 테스트 전부 통과.