### PR TITLE
fix(#1960): token-refresh 경로 lock 갱신 cross-trip stamp 검증 (Acceptance 4)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -60,7 +60,9 @@ import {
   CONTEXT_HEAL_TIER2_DELAY_MS,
   REGISTER_RETRY_BACKOFF_MS,
 } from '../../../../shared/constants/boardingLock';
-import { makeDirectRoute } from '../../../../testUtils/routeFixtures';
+import { makeDirectRoute, makeMultiTransferRoute } from '../../../../testUtils/routeFixtures';
+import { canonicalStationName } from '../../../../testUtils/canonicalStationName';
+import { getStationById } from '../../../../shared/utils/stationRoute';
 
 const station: Station = {
   // stations.json 강남(2호선)과 id 일치 — #622 buildBoardingLockMeta가 boardingStationId로 조회.
@@ -73,6 +75,13 @@ const station: Station = {
 };
 
 const directRoute: Route = makeDirectRoute(5, '2');
+
+/** #1960 Acceptance 4 — stations.json 실제 역 조회 (없으면 fixture 오류로 즉시 fail). */
+function st(id: string): Station {
+  const s = getStationById(id);
+  if (!s) throw new Error(`fixture station not found: ${id}`);
+  return s;
+}
 
 describe('useApnsTripRegistration', () => {
   let listenerRemove: jest.Mock;
@@ -2374,6 +2383,79 @@ describe('useApnsTripRegistration', () => {
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
       // cancel은 한 effect cycle 안에 1회만.
       expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('#1960 Acceptance 4 — token refresh 경로도 lock 갱신 직후 cross-trip stamp 반영', () => {
+    // boardingPromptContext.test.ts #1921 cross-trip 시나리오와 동일 fixture: route 원본
+    // line=3 multi-transfer(3호선 → 2호선), lock.boardingLine=2로 갱신되면 promptDisplay가
+    // route 원본(line=3)이 아닌 lock line(2)을 stamp해야 한다(#1921 회귀 차단).
+    // 본 테스트는 그 갱신이 main effect뿐 아니라 token-refresh listener 경로에도 동일하게
+    // 반영되는지 검증 — #2129 payload 단일화(registerFromLatestInputs)로 두 경로가 같은
+    // buildBoardingPromptContext 재빌드를 타므로, token rotation이 lock 갱신 직후 발생해도
+    // stale route-line(3) stamp가 새지 않는다(#1960 원 스펙 Acceptance 1~2).
+    it('lock 갱신 직후 token refresh가 발생해도 lock line 기준 fresh context를 재빌드해 송신', async () => {
+      const current = st('2-024'); // 서초 (line 2)
+      const dest = st('2-022'); // 강남 (line 2)
+      const crossTripRoute = makeMultiTransferRoute({
+        transfers: [
+          { transferName: canonicalStationName('교대', '3'), fromLine: '3', toLine: '2', stopsToTransfer: 31 },
+          { transferName: '강남', fromLine: '2', toLine: 'sinbundang', stopsToTransfer: 1 },
+        ],
+        stopsAfterLastTransfer: 0,
+      });
+      const lockLine2 = {
+        destinationId: dest.id,
+        trainCode: '7246',
+        boardingStationId: current.id,
+        boardingLine: '2' as const,
+        boardedAt: 1_700_000_000_000,
+        expectedDurationMs: 600_000,
+      };
+
+      const { rerender } = renderHook(
+        ({ lock }: { lock: typeof lockLine2 | null }) =>
+          useApnsTripRegistration({
+            route: crossTripRoute,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: current,
+            boardingLock: lock,
+          }),
+        { initialProps: { lock: null as typeof lockLine2 | null } },
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // cross-trip 자동 전환 — lock=line2 부여. main effect가 lock line 기준으로 재stamp.
+      rerender({ lock: lockLine2 });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+      const mainEffectArgs = mockRegister.mock.calls[1][0] as {
+        promptDisplay?: { originStation: string; line: string };
+      };
+      expect(mainEffectArgs.promptDisplay).toEqual({ originStation: '서초', line: '2' });
+
+      // lock 갱신 직후 token rotation 발생 — token-refresh listener가 stale(route 원본 line=3)
+      // context를 forward하지 않고, 동일한 lock-aware fresh context를 재빌드해야 한다.
+      const listener = mockAddPushTokenListener.mock.calls[0][0];
+      await act(async () => {
+        listener({ data: 'token-ROTATED' });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const refreshed = mockRegister.mock.calls.find(
+        (c) => (c[0] as { token: string }).token === 'token-ROTATED',
+      );
+      expect(refreshed).toBeDefined();
+      const refreshedArgs = refreshed?.[0] as {
+        promptDisplay?: { originStation: string; line: string };
+      };
+      expect(refreshedArgs.promptDisplay).toEqual({ originStation: '서초', line: '2' });
     });
   });
 });


### PR DESCRIPTION
Closes #1960

**Stacked on #2148** (`fix/#1960-register-retry`) — 같은 파일(`useApnsTripRegistration.ts`,
`__tests__/useApnsTripRegistration.test.ts`)을 다루므로 순차 진행. **#2148이 머지되면 즉시
`gh pr edit --base dev`로 base를 dev로 retarget할 예정** — 지금은 diff에 #2148 커밋이 함께
보이는 것이 정상.

## 원 스펙 대비 실제 코드 상태 (조사 결과 — 코드 변경 없음, 테스트로 확정)

이슈 원 스펙(#1960 본문)은 `useApnsTripRegistration.ts:314-340`의 token-refresh handler가
`cachedPromptContext: lastPromptContextRef.current`를 그대로 forward하고 `buildBoardingPromptContext`를
재빌드하지 않아 cross-trip stale stamp가 샐 수 있다고 지적했다.

`dev`를 fetch해 현재 코드를 대조한 결과, **이 결함은 이미 #2129(payload 단일화, "device 두 register
경로 payload 단일화 — latestInputsRef 단일 출처", 2026-08-04 머지)의 리팩터로 구조적으로 해소되어
있다**:

- token-refresh listener(`addPushTokenListener` 콜백)는 더 이상 자체적으로 payload를 만들지 않고
  `registerFromLatestInputs(token)`을 호출한다.
- `registerFromLatestInputs`는 내부적으로 `callRegister`를 호출하며, `callRegister`는
  `promptContextOverride`가 없는 한(token-refresh 경로는 전달하지 않음) **매 호출마다**
  `buildBoardingPromptContext({ route, currentStation, destination, lock: input.boardingLock, gpsFix })`를
  `latestInputsRef.current`의 최신 lock으로 재빌드한다 — main effect와 완전히 동일한 코드 경로.
- 재빌드 성공 시 `lastPromptContextRef.current`도 갱신된다(`registerFromLatestInputs` 내부,
  `if (result.promptContext) lastPromptContextRef.current = result.promptContext;`).

즉 **Acceptance 1·2·3은 #2129로 이미 충족**되어 있었다 — 원 스펙이 지적한 "token-refresh가
main effect와 다른 payload 빌드 경로를 탄다"는 구조 자체가 #2129로 제거됨.

## 본 PR이 하는 일 — Acceptance 4 (신규 테스트로 회귀 잠금)

이슈가 요구한 "token-refresh handler가 lock 갱신 직후 cross-trip stamp 검증" 테스트가 기존
스위트에 없었다. `boardingPromptContext.test.ts`의 #1921 cross-trip 시나리오(route 원본
line=3 multi-transfer, lock.boardingLine=2로 갱신)와 동일 fixture를 사용해 hook 레벨에서
재현:

1. multi-transfer route(3호선→2호선) + lock=null로 mount → main effect가 route 원본(line=3)
   또는 lock 없는 경로로 첫 register.
2. cross-trip 자동 전환 — `boardingLock`을 line=2 lock으로 갱신 → main effect가 lock line(2)
   기준으로 재stamp(`promptDisplay.line === '2'`, `originStation === '서초'`) 확인.
3. lock 갱신 직후 APNs token rotation 발생(`addPushTokenListener` 콜백 트리거) → token-refresh
   경로도 동일하게 lock line(2) 기준 fresh context를 재송신하는지 확인(stale route-line(3)
   stamp가 새지 않음).

파일: `src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts` — 신규 describe
`#1960 Acceptance 4` 1건 + `makeMultiTransferRoute`/`canonicalStationName`/`getStationById`
import 3건.

## #2141(context-heal Tier 1/2) 공존 검증

#2141이 이미 머지되어 base(dev)에 포함된 상태에서 작업 — 본 PR과 #2148 모두 전체 스위트
(9063 tests) green, `lastRegisterMissingContextRef`/`healedSessionKeyRef` 관련 Tier 1/2
테스트 전부 회귀 없음 확인. 본 PR의 신규 테스트는 heal 로직을 건드리지 않음(lock 갱신 +
token-refresh 조합만 검증).

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (신규 export 없음, 테스트 전용 변경).
2. **V/X dashboard** — DebugModal `activeTrip` + backend 측 `boarding-prompt: skipped empty
   candidates` wrangler tail 로그로 promptContext 존재 여부 관측 가능(기존 채널, 변경 없음).
3. **의존 PR** — #2148 (`fix/#1960-register-retry`, 같은 파일). 머지 후 본 PR retarget.
4. **측정 plan** — token rotation은 며칠 단위로 드묾(이슈 본문 명시) — production 측정보다
   본 회귀 테스트가 1주 내내 CI에서 지속 검증하는 것이 주 신뢰 수단.
5. **Device verify** — 다음 실탑승에서 D1 `lock_attached=1` + `silent_push_received≥1`
   확인(#2148과 함께, register retry가 발동하는 실패 시나리오와 lock stamp 정확도를 함께
   관찰). 코드 자체는 회귀 테스트 확정 — device verify는 #2148의 재시도 로직과 함께 통합
   검증 예정.

## 이슈 스펙 대비 이탈

원 스펙이 제시한 "수정 예시" 코드 패치(`freshCtx`를 token-refresh handler에 직접 인라인)는
적용하지 않음 — #2129가 이미 더 강한 형태(두 경로 완전 단일화)로 동일 목적을 달성했기
때문에 중복 코드 추가를 피함(surgical, CLAUDE.md "인접 코드 개선 금지" 원칙).