### PR TITLE
feat(#2151): boardingPrompt skip/fire counter obs-metrics 노출

### DIFF
--- a/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
+++ b/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
@@ -64,6 +64,15 @@ describe('storeObservabilityMetrics + readObservabilityMetrics', () => {
       silentPushReachRatio: { sent: 0, received: 0, joined: 0, ratio: 0 },
       algorithmAccuracyRatio: { value: 7, total: 9, ratio: 7 / 9, answeredTotal: 12 },
       locklessTripMissRatio: { miss: 0, fired: 0, paradigmIntent: 0, ratio: 0 },
+      boardingPromptCounters: {
+        evaluated: 4,
+        fired: 2,
+        blocked: 1,
+        skippedNoContext: 0,
+        skippedStale: 0,
+        skippedTooFar: 0,
+        skippedTrainDuplicate: 1,
+      },
       window: '24h' as const,
       timestamp: NOW,
     };
@@ -104,6 +113,15 @@ describe('storeObservabilityMetrics + readObservabilityMetrics', () => {
       silentPushReachRatio: { sent: 0, received: 0, joined: 0, ratio: 0 },
       algorithmAccuracyRatio: { value: 0, total: 0, ratio: 0, answeredTotal: 0 },
       locklessTripMissRatio: { miss: 0, fired: 0, paradigmIntent: 0, ratio: 0 },
+      boardingPromptCounters: {
+        evaluated: 0,
+        fired: 0,
+        blocked: 0,
+        skippedNoContext: 0,
+        skippedStale: 0,
+        skippedTooFar: 0,
+        skippedTrainDuplicate: 0,
+      },
       window: '24h' as const,
       timestamp: NOW,
     };
@@ -876,6 +894,41 @@ describe('computeObservabilityMetrics — locklessTripMissRatio (#1972)', () => 
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
+// computeObservabilityMetrics — boardingPromptCounters (#2151)
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('computeObservabilityMetrics — boardingPromptCounters (#2151)', () => {
+  it('boardingPromptCounters 미제공 → zero 기본값', async () => {
+    const r2 = makeEmptyFakeR2();
+    const result = await computeObservabilityMetrics(r2, undefined, NOW);
+    expect(result.boardingPromptCounters).toEqual({
+      evaluated: 0,
+      fired: 0,
+      blocked: 0,
+      skippedNoContext: 0,
+      skippedStale: 0,
+      skippedTooFar: 0,
+      skippedTrainDuplicate: 0,
+    });
+  });
+
+  it('boardingPromptCounters 제공 시 응답에 그대로 노출', async () => {
+    const r2 = makeEmptyFakeR2();
+    const counters = {
+      evaluated: 12,
+      fired: 5,
+      blocked: 6,
+      skippedNoContext: 3,
+      skippedStale: 1,
+      skippedTooFar: 2,
+      skippedTrainDuplicate: 1,
+    };
+    const result = await computeObservabilityMetrics(r2, undefined, NOW, undefined, counters);
+    expect(result.boardingPromptCounters).toEqual(counters);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
 // tryStoreObservabilityMetrics + readLastSuccessfulMetrics (#1889 RC-19)
 // ──────────────────────────────────────────────────────────────────────────────
 
@@ -896,6 +949,15 @@ const SAMPLE_METRICS = {
   silentPushReachRatio: { sent: 0, received: 0, joined: 0, ratio: 0 },
   algorithmAccuracyRatio: { value: 0, total: 0, ratio: 0, answeredTotal: 0 },
   locklessTripMissRatio: { miss: 0, fired: 0, paradigmIntent: 0, ratio: 0 },
+  boardingPromptCounters: {
+    evaluated: 0,
+    fired: 0,
+    blocked: 0,
+    skippedNoContext: 0,
+    skippedStale: 0,
+    skippedTooFar: 0,
+    skippedTrainDuplicate: 0,
+  },
   window: '24h' as const,
   timestamp: NOW,
 };

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -2468,7 +2468,25 @@ export const handler = {
       try {
         const existing = await readObservabilityMetrics(env.TRIPS, now);
         if (!existing) {
-          const metrics = await computeObservabilityMetrics(env.TELEMETRY_R2, env.PENDING_PUSHES, now, env.TRIPS);
+          // #2151 — 같은 tick의 runScheduled 결과(scheduledStats)에서 boardingPrompt 계열
+          // counter 스냅샷을 그대로 실어 obs-metrics 응답에 노출. 신규 KV 키/write 없이 기존
+          // obs-metrics 갱신 tick에 필드만 추가(CF 무료 quota 보호).
+          const boardingPromptCounters = {
+            evaluated: scheduledStats.boardingPromptEvaluated,
+            fired: scheduledStats.boardingPromptFired,
+            blocked: scheduledStats.boardingPromptBlocked,
+            skippedNoContext: scheduledStats.boardingPromptSkippedNoContext,
+            skippedStale: scheduledStats.boardingPromptSkippedStale,
+            skippedTooFar: scheduledStats.boardingPromptSkippedTooFar,
+            skippedTrainDuplicate: scheduledStats.boardingPromptSkippedTrainDuplicate,
+          };
+          const metrics = await computeObservabilityMetrics(
+            env.TELEMETRY_R2,
+            env.PENDING_PUSHES,
+            now,
+            env.TRIPS,
+            boardingPromptCounters,
+          );
           const storeResult = await tryStoreObservabilityMetrics(env.TRIPS, metrics, now, {
             onError: (err, key) =>
               void captureBackendException(env, err, { path: 'scheduled/observabilityMetrics', stage: 'kv-put', key }),

--- a/backend/alarm-worker/src/observabilityMetrics.ts
+++ b/backend/alarm-worker/src/observabilityMetrics.ts
@@ -63,6 +63,45 @@ const METRICS_LAST_SUCCESS_KEY = 'obs-metrics:last-success';
 /** 마지막 성공 캐시 TTL — 24h. day-limit 초과로 1h 연속 실패해도 fail-open 보장. */
 const METRICS_LAST_SUCCESS_TTL_SEC = 24 * 60 * 60;
 
+/**
+ * #2151 — boardingPrompt skip/fire counter obs-metrics 노출.
+ *
+ * `runScheduled`(scheduled.ts) 가 매 cron tick 마다 `ScheduledStats`에 누적하는
+ * boardingPrompt 계열 counter 중, obs-metrics 갱신 tick(1h 주기)의 스냅샷 값을 그대로 실어
+ * 사후 판별(evaluated=0인데 이유를 알 수 없는 관측 공백, #2130/#2131) 가능하게 한다.
+ *
+ * 24h 누적이 아니라 **obs-metrics 갱신이 발동된 그 1분 tick의 스냅샷**이다 — 다른 metric처럼
+ * R2 24h scan 기반 누적 집계가 아님(신규 KV 키/write 증가 없이 기존 tick에 필드만 추가하는
+ * 제약 때문). 다음 obs-metrics 갱신(최대 1h 후)까지 값이 유지된다.
+ */
+export interface BoardingPromptCounters {
+  /** `stats.boardingPromptEvaluated` — 9단 게이트 평가가 시도된 누적 횟수. */
+  evaluated: number;
+  /** `stats.boardingPromptFired` — alert push 발사 성공 누적 횟수. */
+  fired: number;
+  /** `stats.boardingPromptBlocked` — 게이트 차단 누적 횟수 (no-arvlcd / ambiguity 포함). */
+  blocked: number;
+  /** `stats.boardingPromptSkippedNoContext` — geo/display context 부재로 skip. */
+  skippedNoContext: number;
+  /** `stats.boardingPromptSkippedStale` — 15분 신선도 게이트로 skip. */
+  skippedStale: number;
+  /** `stats.boardingPromptSkippedTooFar` — 근접 게이트로 skip. */
+  skippedTooFar: number;
+  /** `stats.boardingPromptSkippedTrainDuplicate` — 같은 trainCode 반복 발사 dedup. */
+  skippedTrainDuplicate: number;
+}
+
+/** `boardingPromptCounters` 미제공 시(예: endpoint cold-compute) 사용하는 zero 기본값. */
+const EMPTY_BOARDING_PROMPT_COUNTERS: BoardingPromptCounters = {
+  evaluated: 0,
+  fired: 0,
+  blocked: 0,
+  skippedNoContext: 0,
+  skippedStale: 0,
+  skippedTooFar: 0,
+  skippedTrainDuplicate: 0,
+};
+
 /** accel pattern 4종 분포 bucket. */
 export interface AccelPatternBucket {
   automotive: { count: number; ratio: number };
@@ -112,6 +151,8 @@ export interface ObservabilityMetricsResponse {
    * trip-level userIntent 분기 측정 ([[feedback_user_intent_equal_protection]]).
    */
   locklessTripMissRatio: { miss: number; fired: number; paradigmIntent: number; ratio: number };
+  /** #2151 — boardingPrompt skip/fire counter 스냅샷. 위 doc-comment 참고 (24h 누적 아님). */
+  boardingPromptCounters: BoardingPromptCounters;
   window: '24h';
   timestamp: number;
 }
@@ -132,12 +173,16 @@ export function hourBucketKey(now: number): string {
  * @param pendingPushesKv PENDING_PUSHES KV namespace (optional)
  * @param now 현재 epoch ms
  * @param tripsKv TRIPS KV namespace — laPushDeliveryRatio 산출용 (optional, 미설정 시 placeholder)
+ * @param boardingPromptCounters #2151 — 같은 cron tick의 `ScheduledStats` boardingPrompt 계열
+ *   counter 스냅샷 (optional). 호출자(scheduled handler)가 같은 tick에서 이미 산출한 값을 넘긴다
+ *   — 미제공 시(예: `/v1/observability/metrics` endpoint의 cold-compute fallback) zero 기본값.
  */
 export async function computeObservabilityMetrics(
   r2: R2Bucket,
   pendingPushesKv: KVNamespace | undefined,
   now: number,
   tripsKv?: KVNamespace,
+  boardingPromptCounters?: BoardingPromptCounters,
 ): Promise<ObservabilityMetricsResponse> {
   // 1. R2 alarmLog 24h scan — accuracyRatio + locklessMissRatio 원천
   const alarmStats = await computeAlarmLogStats(r2, now, 24, 500);
@@ -231,6 +276,7 @@ export async function computeObservabilityMetrics(
     silentPushReachRatio,
     algorithmAccuracyRatio,
     locklessTripMissRatio,
+    boardingPromptCounters: boardingPromptCounters ?? EMPTY_BOARDING_PROMPT_COUNTERS,
     window: '24h',
     timestamp: now,
   };


### PR DESCRIPTION
Closes #2151

## 배경

2026-08-05 trip RCA에서 boardingPrompt 미발화 원인 판별용 counter(`boardingPromptEvaluated / SkippedNoContext / SkippedStale / SkippedTooFar / Blocked / SkippedTrainDuplicate / boardingPromptFired`, #2130/#2131)가 per-cron `console.log`에만 존재해 사후 조회가 불가능했다(`observability.logs persist=false`, #2055). 본 PR은 이 counter들을 기존 `obs-metrics:24h` KV 스냅샷 응답에 노출한다.

## 변경 사항

- `ObservabilityMetricsResponse`에 `boardingPromptCounters` 필드 추가: `{ evaluated, fired, blocked, skippedNoContext, skippedStale, skippedTooFar, skippedTrainDuplicate }`
- `computeObservabilityMetrics`가 optional `boardingPromptCounters` 파라미터를 받아 응답에 그대로 실음 (미제공 시 zero 기본값 — 기존 caller/endpoint 호환)
- cron `scheduled` handler(`index.ts`)에서 **같은 tick**의 `runScheduled` 결과(`scheduledStats`)에서 boardingPrompt 계열 값을 뽑아 obs-metrics 계산에 전달
- unit test 추가 (미제공 시 zero 기본값 / 제공 시 그대로 노출)

### 설계 노트 — 24h 누적이 아니라 tick 스냅샷

다른 metric(accuracyRatio 등)은 R2 24h ndjson scan으로 진짜 24시간 누적을 계산한다. boardingPrompt counter는 `ScheduledStats`가 cron tick(1분)마다 메모리에서 생성/폐기되는 값이라 영구 저장소가 없다 — 이슈 스펙이 "신규 KV 키 추가 금지"를 명시했으므로, R2 로그화나 별도 누적 KV 버킷(예: `la-push-counters` 패턴)을 새로 만들지 않고 **obs-metrics 1h 갱신이 실제로 발동된 그 1분 tick의 스냅샷**만 싣는다. 다음 갱신(최대 1h 후)까지 값이 유지된다. R2 24h 누적 대비 표본이 성기지만(60 tick 중 1개), "counter가 0건도 조회 불가"였던 현재 상태 대비 사후 판별 공백을 해소한다.

## Wire-completion 5단

1. **Orphan** — backend에는 `lint:orphan` 스크립트가 없음(frontend 전용). `boardingPromptCounters`는 `ObservabilityMetricsResponse` 필드로 응답 객체를 통해 자연 소비됨.
2. **V/X dashboard** — `wrangler kv key get obs-metrics:24h:{bucket} --binding=TRIPS --remote` 또는 `GET /v1/observability/metrics?window=24h` (admin 인증)로 `boardingPromptCounters` 필드 직접 조회. DebugModal Operation Dashboard는 필드가 명시적 hardcoded 렌더 방식이라 자동 노출되지 않음 — 노출하려면 별도 프론트엔드 PR 필요(본 PR 범위 밖, backend-only 이슈).
3. **의존 PR** — N/A
4. **측정 plan** — 배포 후 다음 실탑승 1회에서 `boardingPromptCounters`가 어느 skip 사유를 찍는지 wrangler kv get으로 확인 → heal 갭 fix 검증과 연동
5. **Device verify** — N/A — backend only (배포 필수: 머지≠deploy, `wrangler deploy` + curl/kv get evidence 사용자 수행 필요)

## Test plan

- [x] `npm test` — 71 test files / 2790 tests pass (backend/alarm-worker)
- [x] `npm run type-check` pass
- [ ] 배포 후 `wrangler kv key get` 로 필드 노출 확인 (사용자)