### PR TITLE
feat(#2152): BoardingLock lifecycle breadcrumb — 생성/해제/trainCode DebugModal 덤프 기록

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -263,6 +263,8 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
         // #897 Seam A: auto-lock 시점의 ETA(makeArrival 기본=60s) 스냅샷.
         initialEtaSeconds: 60,
       }),
+      // #2152 — boardingPrompt 응답 경로 lifecycle breadcrumb source.
+      'boarding-prompt-response',
     );
     expect(positionUpload.dismissBoardingPrompt).not.toHaveBeenCalled();
     // #1167 — autolock-success telemetry
@@ -349,6 +351,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     // up 단일 후보 → lock 생성, trainCode = 'UP1'
     expect(createLockMock).toHaveBeenCalledWith(
       expect.objectContaining({ trainCode: 'UP1' }),
+      'boarding-prompt-response',
     );
   });
 
@@ -366,6 +369,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     // down 단일 후보 → lock 생성, trainCode = 'DOWN1'
     expect(createLockMock).toHaveBeenCalledWith(
       expect.objectContaining({ trainCode: 'DOWN1' }),
+      'boarding-prompt-response',
     );
   });
 
@@ -393,6 +397,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
     expect(createLockMock).toHaveBeenCalledWith(
       expect.objectContaining({ trainCode: 'UP1' }),
+      'boarding-prompt-response',
     );
   });
 

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -316,7 +316,7 @@ export function useBoardingLockController({
         // #897 Seam A: 탑승 시점 ETA 스냅샷. 동일 trainCode가 유지되는 동안 새 폴링의 arrivalSeconds가
         // 이 값보다 크게 늘면 그 차이가 지연(분). BoardingTrainList가 "+N분 지연" 칩으로 노출.
         initialEtaSeconds: train.arrivalSeconds,
-      }).then(() => {
+      }, 'user-tap').then(() => {
         void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       }).catch(() => {
         // store action rejection은 graceful — 다음 polling cycle에서 자연 재시도.

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -352,7 +352,7 @@ async function tryAutoLock(
       expectedDurationMs: deps.expectedDurationMs,
       // #897 Seam A: auto-lock 시점 ETA 스냅샷. 지연 신호의 기준치.
       initialEtaSeconds: chosen.arrivalSeconds,
-    });
+    }, 'boarding-prompt-response');
     logBoardingPromptAutoLock({ reason: 'autolock-success', ...telemetry });
   } catch (err) {
     // #1167 — lock 실패 시 fallback 경로. createLock는 storage/network 예외 가능.

--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -29,6 +29,10 @@ import { clearLastSilentPushReceivedAt } from '../../utils/lastSilentPushReceive
 import { useDestinationStore } from '../../../route/store/useDestinationStore';
 import { useBoardingLockStore } from '../useBoardingLockStore';
 import { useAlarmEventStore } from '../useAlarmEventStore';
+import {
+  clearLockLifecycleEntries,
+  getLockLifecycleEntries,
+} from '../../utils/boardingLockLifecycleBuffer';
 
 const mockClearWidgetStation = jest.fn().mockResolvedValue(undefined);
 const mockEndLiveActivity = jest.fn().mockResolvedValue(undefined);
@@ -467,6 +471,54 @@ describe('tripBoundCleanups', () => {
       // #2045 — clearLastSilentPushReceivedAt 1 신규 (Signal 4 판정 오염 차단).
       const MIN_ITEMS = 27;
       expect(TRIP_BOUND_CLEANUPS.length).toBeGreaterThanOrEqual(MIN_ITEMS);
+    });
+  });
+
+  // #2152 (P1 code-review) — clearTripBoundStoreMemory가 useBoardingLockStore.setState를 직접
+  // 호출해 lock을 비우면 releaseLock()의 lifecycle breadcrumb(pushLockLifecycleEntry)이 우회된다.
+  // silent push trip-ended / FG setDestination(null/switch) / useStateRehydration sentinel /
+  // cold-launch reconciliation 4개 trip 종료 경로가 모두 runTripBoundCleanups만 호출하므로,
+  // 이 경로에서 lock이 release돼도 DebugModal "BoardingLock Lifecycle" 섹션에 기록이 남지 않는
+  // 회귀였다. clearTripBoundStoreMemory는 releaseLock('trip-cleanup')을 재사용해야 한다.
+  describe('#2152 (P1) — clearTripBoundStoreMemory가 releaseLock을 경유해 lifecycle breadcrumb을 남긴다', () => {
+    beforeEach(() => {
+      clearLockLifecycleEntries();
+    });
+
+    it('lock이 활성일 때 runTripBoundCleanups 실행 시 lifecycle buffer에 release(reason=trip-cleanup) 엔트리가 적재된다', async () => {
+      useBoardingLockStore.setState({
+        lock: {
+          destinationId: 'stn-1',
+          trainCode: 'T-100',
+          boardingStationId: 'stn-0',
+          boardingLine: '7',
+          boardedAt: Date.now(),
+          expectedDurationMs: 600_000,
+        },
+      });
+
+      await runTripBoundCleanups();
+
+      // 기존 동작(메모리 정리 자체)은 유지돼야 한다.
+      expect(useBoardingLockStore.getState().lock).toBeNull();
+
+      const releaseEntries = getLockLifecycleEntries().filter((e) => e.event === 'release');
+      expect(releaseEntries).toHaveLength(1);
+      expect(releaseEntries[0]).toMatchObject({
+        kind: 'boarding-lock-lifecycle',
+        event: 'release',
+        reason: 'trip-cleanup',
+        trainCode: 'T-100',
+        line: '7',
+      });
+    });
+
+    it('lock이 없으면 lifecycle buffer에 release 엔트리가 적재되지 않는다 (noise 방지)', async () => {
+      useBoardingLockStore.setState({ lock: null });
+
+      await runTripBoundCleanups();
+
+      expect(getLockLifecycleEntries()).toHaveLength(0);
     });
   });
 

--- a/src/features/alarm/store/__tests__/useBoardingLockStore.test.ts
+++ b/src/features/alarm/store/__tests__/useBoardingLockStore.test.ts
@@ -1,6 +1,10 @@
 import { act } from '@testing-library/react-native';
 import { useBoardingLockStore } from '../useBoardingLockStore';
 import type { BoardingLock } from '../../../../shared/types/boardingLock';
+import {
+  clearLockLifecycleEntries,
+  getLockLifecycleEntries,
+} from '../../utils/boardingLockLifecycleBuffer';
 
 const mockGetBoardingLock = jest.fn();
 const mockSetBoardingLock = jest.fn();
@@ -39,6 +43,7 @@ describe('useBoardingLockStore', () => {
     mockClearBoardingLock.mockResolvedValue(undefined);
     mockClearDismissSilence.mockResolvedValue(undefined);
     useBoardingLockStore.setState({ lock: null });
+    clearLockLifecycleEntries();
   });
 
   it('초기 상태는 lock=null', () => {
@@ -72,6 +77,31 @@ describe('useBoardingLockStore', () => {
       });
       expect(mockClearDismissSilence).toHaveBeenCalledTimes(1);
     });
+
+    it('#2152 — source 미전달 시 lifecycle buffer에 create 엔트리 source=other로 적재', async () => {
+      await act(async () => {
+        await useBoardingLockStore.getState().createLock(sample);
+      });
+      const entries = getLockLifecycleEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        kind: 'boarding-lock-lifecycle',
+        event: 'create',
+        source: 'other',
+        trainCode: sample.trainCode,
+        line: sample.boardingLine,
+        stationId: sample.boardingStationId,
+      });
+    });
+
+    it('#2152 — source 전달 시 lifecycle buffer에 그대로 stamp', async () => {
+      await act(async () => {
+        await useBoardingLockStore.getState().createLock(sample, 'user-tap');
+      });
+      const entries = getLockLifecycleEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({ event: 'create', source: 'user-tap' });
+    });
   });
 
   describe('releaseLock', () => {
@@ -101,6 +131,29 @@ describe('useBoardingLockStore', () => {
         await useBoardingLockStore.getState().releaseLock();
       });
       expect(mockAddDomainBreadcrumb).not.toHaveBeenCalled();
+    });
+
+    it('#2152 — lock이 있을 때만 lifecycle buffer에 release 엔트리 적재 (reason 포함)', async () => {
+      useBoardingLockStore.setState({ lock: sample });
+      await act(async () => {
+        await useBoardingLockStore.getState().releaseLock('transfer');
+      });
+      const entries = getLockLifecycleEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        kind: 'boarding-lock-lifecycle',
+        event: 'release',
+        reason: 'transfer',
+        trainCode: sample.trainCode,
+        line: sample.boardingLine,
+      });
+    });
+
+    it('#2152 — lock이 없으면 lifecycle buffer에도 적재 안 됨', async () => {
+      await act(async () => {
+        await useBoardingLockStore.getState().releaseLock();
+      });
+      expect(getLockLifecycleEntries()).toHaveLength(0);
     });
 
     it('#1438 (E5) — reason 인자가 breadcrumb 메타에 stamp된다 (transfer)', async () => {

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -197,18 +197,28 @@ function endLiveActivityCleanup(): Promise<void> {
  * useDestinationStore.customOrigin / useBoardingLockStore.lock / useAlarmEventStore.alarmEvent /
  * useAlarmEventStore.dismissSilence를 한 번에 동기화한다. setState는 sync — Promise.resolve로
  * 반환해 TRIP_BOUND_CLEANUPS의 () => Promise<void> shape에 맞춘다.
+ *
+ * #2152 (P1 code-review) — boardingLock은 직접 `setState({ lock: null })`로 비우지 않고
+ * `useBoardingLockStore.releaseLock('trip-cleanup')`을 경유한다. 이 함수는 silent push
+ * trip-ended / FG setDestination(null/switch) / useStateRehydration sentinel /
+ * cold-launch reconciliation 4개 trip 종료 경로가 모두 거치는 사실상 유일한 lock release
+ * chokepoint인데, 직접 setState는 releaseLock 내부의 lifecycle breadcrumb
+ * (`pushLockLifecycleEntry`) + Sentry breadcrumb(`addDomainBreadcrumb`)을 우회해 DebugModal
+ * "BoardingLock Lifecycle" 섹션에 가장 흔한 release 경로가 전혀 기록되지 않는 관측 공백이었다.
+ * releaseLock은 멱등(호출 시점 lock=null이면 no-op)이고 storage clearBoardingLock 재호출도
+ * AsyncStorage.removeItem 멱등이라 이 배열의 다른 `BOARDING_LOCK_KEY` removeItem 항목과
+ * 병렬 실행돼도 안전하다.
  */
-function clearTripBoundStoreMemory(): Promise<void> {
+async function clearTripBoundStoreMemory(): Promise<void> {
   const destState = useDestinationStore.getState();
   // customOrigin: setDestination 경로는 이미 null로 동기화하지만, BG silent push 경로는
   // 누락. 사용자가 직접 지정한 출발역이 새 trip에 leak되지 않도록 비운다.
   if (destState.customOrigin !== null) {
     useDestinationStore.setState({ customOrigin: null });
   }
-  // boardingLock: storage(BOARDING_LOCK_KEY)는 이미 removeItem 됐지만 zustand snapshot이
-  // 메모리에 lock을 갖고 있으면 FG UI가 stale lock UI를 일시 노출한다.
+  // boardingLock: releaseLock을 경유해 lifecycle breadcrumb을 남긴다 (#2152 P1).
   if (useBoardingLockStore.getState().lock !== null) {
-    useBoardingLockStore.setState({ lock: null });
+    await useBoardingLockStore.getState().releaseLock('trip-cleanup');
   }
   // alarmEvent / dismissSilence: storage(ALARM_EVENT_KEY/dismissSilenceStorage)도 위에서
   // 이미 cleanup. 메모리만 추가 동기화 — 새 trip UI에 이전 alarm overlay/silence가 leak 차단.

--- a/src/features/alarm/store/useBoardingLockStore.ts
+++ b/src/features/alarm/store/useBoardingLockStore.ts
@@ -9,6 +9,10 @@ import {
 import { clearDismissSilence } from '../utils/dismissSilenceStorage';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
 import { isSimpleArchEnabled } from '../../../shared/config/archFlag';
+import {
+  pushLockLifecycleEntry,
+  type LockLifecycleCreateSource,
+} from '../utils/boardingLockLifecycleBuffer';
 
 /**
  * #1438 (E5) — release 사유 식별자.
@@ -37,8 +41,14 @@ export type LockReleaseReason =
  */
 export interface BoardingLockState {
   lock: BoardingLock | null;
-  /** Trip 진입 또는 환승 전환 시 호출. 기존 Lock은 자동 교체. */
-  createLock: (lock: BoardingLock) => Promise<void>;
+  /**
+   * Trip 진입 또는 환승 전환 시 호출. 기존 Lock은 자동 교체.
+   *
+   * #2152 — source는 lifecycle breadcrumb에 stamp되는 생성 경로 식별자. 사용자 명시 탭
+   * (BoardingTrainList)과 boardingPrompt 응답을 구분해 오토락 범인 특정을 소거법으로 가능하게
+   * 한다. 미전달(그 외 경로 — 자동 lock/backend suggestion 등)은 'other'로 기록.
+   */
+  createLock: (lock: BoardingLock, source?: LockLifecycleCreateSource) => Promise<void>;
   /**
    * 사용자가 "하차" 탭하거나 trip 종료 시 호출.
    *
@@ -59,7 +69,7 @@ export interface BoardingLockState {
 export const useBoardingLockStore = create<BoardingLockState>((set, get) => ({
   lock: null,
 
-  createLock: async (lock: BoardingLock) => {
+  createLock: async (lock: BoardingLock, source: LockLifecycleCreateSource = 'other') => {
     // #1996 (Phase 1-7, ADR-022 A4) — boardingStationId 불변 정책 (flag ON 시).
     //
     // route 등록 시 확정된 boardingStationId는 절대 자동 변경 금지 (auto-swap / reanchored /
@@ -102,6 +112,17 @@ export const useBoardingLockStore = create<BoardingLockState>((set, get) => ({
       trainCode: lock.trainCode,
       line: lock.boardingLine,
     });
+    // #2152 — lifecycle breadcrumb ring buffer. addDomainBreadcrumb(Sentry)는 device 밖 관측용,
+    // 본 push는 DebugModal 덤프(1차 evidence)에서 사후 재구성 가능하게 하는 별 채널.
+    pushLockLifecycleEntry({
+      kind: 'boarding-lock-lifecycle',
+      event: 'create',
+      ts: Date.now(),
+      source,
+      trainCode: lock.trainCode,
+      line: lock.boardingLine,
+      stationId: lock.boardingStationId,
+    });
   },
 
   releaseLock: async (reason: LockReleaseReason = 'user') => {
@@ -113,6 +134,15 @@ export const useBoardingLockStore = create<BoardingLockState>((set, get) => ({
         trainCode: prev.trainCode,
         line: prev.boardingLine,
         reason,
+      });
+      // #2152 — lifecycle breadcrumb ring buffer.
+      pushLockLifecycleEntry({
+        kind: 'boarding-lock-lifecycle',
+        event: 'release',
+        ts: Date.now(),
+        reason,
+        trainCode: prev.trainCode,
+        line: prev.boardingLine,
       });
     }
   },

--- a/src/features/alarm/store/useBoardingLockStore.ts
+++ b/src/features/alarm/store/useBoardingLockStore.ts
@@ -23,6 +23,11 @@ import {
  * - 'destination-change' — 화면에서 destination이 바뀌어 stale lock 자동 release (controller).
  * - 'expired'         — 자동 만료(`checkExpiry`).
  * - 'train-code-mismatch' — 같은 노선에서 다른 trainCode가 90s 지속 관찰 (useTrainCodeMismatchDetector, #1659).
+ * - 'trip-cleanup'    — #2152 (P1) `tripBoundCleanups.clearTripBoundStoreMemory`가 trip 종료
+ *   시 store 메모리를 정리하며 releaseLock을 경유하는 generic 사유. silent push trip-ended /
+ *   FG setDestination(null/switch) / useStateRehydration sentinel / cold-launch reconciliation
+ *   4개 진입점이 모두 `runTripBoundCleanups`만 호출하므로 개별 사유를 구분할 수 없다 — 그 지점에서
+ *   lock이 살아있었다는 사실 자체가 진단 가치(오토락 범인 소거법).
  */
 export type LockReleaseReason =
   | 'user'
@@ -30,7 +35,8 @@ export type LockReleaseReason =
   | 'vanish'
   | 'destination-change'
   | 'expired'
-  | 'train-code-mismatch';
+  | 'train-code-mismatch'
+  | 'trip-cleanup';
 
 /**
  * BoardingLock 전역 store (#584 PR A).

--- a/src/features/alarm/utils/__tests__/boardingLockLifecycleBuffer.test.ts
+++ b/src/features/alarm/utils/__tests__/boardingLockLifecycleBuffer.test.ts
@@ -1,0 +1,94 @@
+/**
+ * #2152 — BoardingLock lifecycle breadcrumb 전용 buffer 단위 테스트.
+ *
+ * 검증:
+ *   1. push/get — create/release 엔트리 양쪽
+ *   2. clear — entries 비움
+ *   3. subscribe — push/clear 시 listener 호출, unsubscribe 후 호출 안 됨
+ *   4. cap=BOARDING_LOCK_LIFECYCLE_BUFFER_CAPACITY ring buffer overwrite (점령 회귀 차단)
+ */
+import {
+  BOARDING_LOCK_LIFECYCLE_BUFFER_CAPACITY,
+  clearLockLifecycleEntries,
+  getLockLifecycleEntries,
+  pushLockLifecycleEntry,
+  subscribeLockLifecycle,
+  type LockLifecycleEntry,
+} from '../boardingLockLifecycleBuffer';
+
+function makeCreateEntry(
+  overrides: Partial<LockLifecycleEntry> = {},
+): LockLifecycleEntry {
+  return {
+    kind: 'boarding-lock-lifecycle',
+    event: 'create',
+    ts: 1_700_000_000_000,
+    source: 'user-tap',
+    trainCode: 'T-100',
+    line: '2',
+    stationId: 'stn-A',
+    ...overrides,
+  } as LockLifecycleEntry;
+}
+
+function makeReleaseEntry(
+  overrides: Partial<LockLifecycleEntry> = {},
+): LockLifecycleEntry {
+  return {
+    kind: 'boarding-lock-lifecycle',
+    event: 'release',
+    ts: 1_700_000_001_000,
+    reason: 'user',
+    trainCode: 'T-100',
+    line: '2',
+    ...overrides,
+  } as LockLifecycleEntry;
+}
+
+describe('boardingLockLifecycleBuffer (#2152)', () => {
+  beforeEach(() => {
+    clearLockLifecycleEntries();
+  });
+
+  it('pushes create/release entries in order and exposes fields', () => {
+    pushLockLifecycleEntry(makeCreateEntry({ source: 'boarding-prompt-response' }));
+    pushLockLifecycleEntry(makeReleaseEntry({ reason: 'vanish' }));
+    const entries = getLockLifecycleEntries();
+    expect(entries).toHaveLength(2);
+    expect(entries[0].kind).toBe('boarding-lock-lifecycle');
+    expect(entries[0].event).toBe('create');
+    expect((entries[0] as { source: string }).source).toBe('boarding-prompt-response');
+    expect(entries[1].event).toBe('release');
+    expect((entries[1] as { reason: string }).reason).toBe('vanish');
+  });
+
+  it('clears entries', () => {
+    pushLockLifecycleEntry(makeCreateEntry());
+    clearLockLifecycleEntries();
+    expect(getLockLifecycleEntries()).toHaveLength(0);
+  });
+
+  it('caps at BOARDING_LOCK_LIFECYCLE_BUFFER_CAPACITY, dropping oldest', () => {
+    for (let i = 0; i < BOARDING_LOCK_LIFECYCLE_BUFFER_CAPACITY + 3; i++) {
+      pushLockLifecycleEntry(makeCreateEntry({ ts: i, trainCode: `T-${i}` }));
+    }
+    const entries = getLockLifecycleEntries();
+    expect(entries).toHaveLength(BOARDING_LOCK_LIFECYCLE_BUFFER_CAPACITY);
+    // 가장 오래된 3개(T-0/T-1/T-2)는 evict, 가장 오래된 잔존 entry는 T-3.
+    expect((entries[0] as { trainCode: string }).trainCode).toBe('T-3');
+  });
+
+  it('notifies subscribers on push and clear, unsubscribe stops notifications', () => {
+    const listener = jest.fn();
+    const unsub = subscribeLockLifecycle(listener);
+    pushLockLifecycleEntry(makeCreateEntry());
+    expect(listener).toHaveBeenCalledTimes(1);
+    pushLockLifecycleEntry(makeReleaseEntry());
+    expect(listener).toHaveBeenCalledTimes(2);
+    clearLockLifecycleEntries();
+    expect(listener).toHaveBeenCalledTimes(3);
+    unsub();
+    pushLockLifecycleEntry(makeCreateEntry({ ts: 3 }));
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/features/alarm/utils/boardingLockLifecycleBuffer.ts
+++ b/src/features/alarm/utils/boardingLockLifecycleBuffer.ts
@@ -1,0 +1,64 @@
+import { createDebugBuffer } from '../../../shared/utils/createDebugBuffer';
+import type { LockReleaseReason } from '../store/useBoardingLockStore';
+
+/**
+ * #2152 — BoardingLock lifecycle breadcrumb 전용 ring buffer.
+ *
+ * 배경 (2026-08-05 trip RCA): lock의 생성 경로(source)/해제 사유(reason)/trainCode가 덤프에도
+ * 백엔드에도 안 남아 오토락 범인 특정에 소거법이 필요했다. backend는 sync payload 미적재 + trip
+ * KV DELETE로 소멸 → device 덤프가 유일한 1차 증거인데 lifecycle 기록이 없었다.
+ *
+ * `boardingLockDriftBuffer`(#1896, RC-8)와 동일 패턴 — fusionDebugBuffer(cap=500) 점령 자기 파괴
+ * 회귀(lesson: 단일 ring buffer가 고빈도 진단 entry로 저빈도 evidence를 evict)를 차단하기 위해
+ * 별 buffer로 분리한다.
+ *
+ * cap=50: lock create/release는 trip 1개당 수 건(환승 leg마다 1쌍) 수준의 저빈도 이벤트라
+ * fusionDebugBuffer(500)보다 훨씬 작은 cap으로 충분 — 여러 trip에 걸친 lifecycle history를
+ * 오래 보존하는 게 오히려 유용(오토락 삭제 이슈 검증의 "무탭 create 0건" 증명 등).
+ */
+export const BOARDING_LOCK_LIFECYCLE_BUFFER_CAPACITY = 50;
+
+/** lock create 경로 — 소거법으로 오토락 범인 특정하기 위한 최소 분류. */
+export type LockLifecycleCreateSource =
+  | 'user-tap'
+  | 'boarding-prompt-response'
+  | 'other';
+
+export interface LockLifecycleCreateEntry {
+  kind: 'boarding-lock-lifecycle';
+  event: 'create';
+  ts: number;
+  source: LockLifecycleCreateSource;
+  trainCode: string;
+  line: string;
+  stationId: string;
+}
+
+export interface LockLifecycleReleaseEntry {
+  kind: 'boarding-lock-lifecycle';
+  event: 'release';
+  ts: number;
+  reason: LockReleaseReason;
+  trainCode: string;
+  line: string;
+}
+
+export type LockLifecycleEntry = LockLifecycleCreateEntry | LockLifecycleReleaseEntry;
+
+const db = createDebugBuffer<LockLifecycleEntry>(BOARDING_LOCK_LIFECYCLE_BUFFER_CAPACITY);
+
+export function pushLockLifecycleEntry(entry: LockLifecycleEntry): void {
+  db.push(entry);
+}
+
+export function getLockLifecycleEntries(): readonly LockLifecycleEntry[] {
+  return db.get();
+}
+
+export function clearLockLifecycleEntries(): void {
+  db.clear();
+}
+
+export function subscribeLockLifecycle(listener: () => void): () => void {
+  return db.subscribe(listener);
+}

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -107,6 +107,14 @@ import {
   subscribeBoardingLockDrift,
   type BoardingLockDriftEntry,
 } from '../../../features/nearest-station/utils/boardingLockDriftBuffer';
+// #2152 — BoardingLock lifecycle(생성 source/해제 reason) 전용 buffer. drift buffer와 동일 패턴
+// (fusionDebugBuffer 점령 회귀 차단 위해 소형 cap 별도 buffer).
+import {
+  clearLockLifecycleEntries,
+  getLockLifecycleEntries,
+  subscribeLockLifecycle,
+  type LockLifecycleEntry,
+} from '../../../features/alarm/utils/boardingLockLifecycleBuffer';
 // #1518 — device → backend HTTP 호출 ring buffer. 모든 backend fetch chokepoint가 entry를 push.
 import {
   clearBackendCallEntries,
@@ -598,6 +606,8 @@ interface BuildDumpArgs {
   fusionLog?: readonly FusionDebugEntry[];
   /** #1896 (RC-8) — boarding-lock-drift 별 buffer entries. 미전달/빈 배열은 (empty). */
   boardingLockDriftLog?: readonly BoardingLockDriftEntry[];
+  /** #2152 — BoardingLock lifecycle(create/release) 별 buffer entries. 미전달/빈 배열은 (empty). */
+  lockLifecycleLog?: readonly LockLifecycleEntry[];
   /**
    * #1413 — BoardingLock 섹션 dump 입력. lock 활성/trainCode/boardingLine/expiresAt.
    * 미전달이면 lock=null과 동일(active=no)로 출력.
@@ -1186,6 +1196,25 @@ function buildBoardingLockDriftLogSection(args: BuildDumpArgs): string[] {
 }
 
 /**
+ * #2152 — BoardingLock lifecycle 1줄 포맷.
+ * create: `time | lock-create:source | trainCode(line) station=stationId`
+ * release: `time | lock-release:reason | trainCode(line)`
+ */
+function formatLockLifecycleLine(entry: LockLifecycleEntry): string {
+  const time = formatTime(entry.ts);
+  if (entry.event === 'create') {
+    return `${time} | lock-create:${entry.source} | ${entry.trainCode}(${entry.line}) station=${entry.stationId}`;
+  }
+  return `${time} | lock-release:${entry.reason} | ${entry.trainCode}(${entry.line})`;
+}
+
+function buildLockLifecycleSection(args: BuildDumpArgs): string[] {
+  const entries = args.lockLifecycleLog ?? [];
+  if (entries.length === 0) return ['(empty)'];
+  return [...entries].reverse().map(formatLockLifecycleLine);
+}
+
+/**
  * #1518 — Backend call ring buffer 1줄 포맷. call/response/error를 한 줄에 압축해
  * dump 분량을 줄인다. host 부분만 노출하고 path는 trim 안 함(진단 시 endpoint 식별).
  */
@@ -1658,6 +1687,12 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
     build: buildBoardingLockDriftLogSection,
     suffix: (args) => ` (${args.boardingLockDriftLog?.length ?? 0})`,
   },
+  // #2152 — BoardingLock lifecycle 별 buffer (생성 source / 해제 reason / trainCode).
+  {
+    title: 'BoardingLock Lifecycle',
+    build: buildLockLifecycleSection,
+    suffix: (args) => ` (${args.lockLifecycleLog?.length ?? 0})`,
+  },
   // #1518 — device → backend HTTP 호출 ring buffer. 직전 trip의 register/sync/telemetry 호출
   // 흔적이 dump만 보고 재구성 가능해야 #622 transfer-leg sync 같은 회귀 진단이 가능하다.
   {
@@ -2048,6 +2083,10 @@ function DebugModalInner({
   const [boardingLockDriftLog, setBoardingLockDriftLog] = useState<readonly BoardingLockDriftEntry[]>(() =>
     getBoardingLockDriftEntries(),
   );
+  // #2152 — BoardingLock lifecycle ring buffer. boardingLockDriftLog와 동일 패턴.
+  const [lockLifecycleLog, setLockLifecycleLog] = useState<readonly LockLifecycleEntry[]>(() =>
+    getLockLifecycleEntries(),
+  );
   const [estimatorLogs, setEstimatorLogs] = useState<readonly EstimatorDebugEntry[]>(() =>
     getEstimatorEntries(),
   );
@@ -2105,6 +2144,13 @@ function DebugModalInner({
   useEffect(() => {
     return subscribeBoardingLockDrift(() =>
       setBoardingLockDriftLog([...getBoardingLockDriftEntries()]),
+    );
+  }, []);
+
+  // #2152 — BoardingLock lifecycle buffer 구독. boardingLockDrift와 동일 패턴.
+  useEffect(() => {
+    return subscribeLockLifecycle(() =>
+      setLockLifecycleLog([...getLockLifecycleEntries()]),
     );
   }, []);
 
@@ -2212,6 +2258,8 @@ function DebugModalInner({
       candidateRejectLog: candidateRejectLogs,
       // #2049 (#1896 RC-8) — boarding-lock-drift entries를 share에 포함. 별 buffer라 fusion log와 동시 dump.
       boardingLockDriftLog,
+      // #2152 — BoardingLock lifecycle entries를 share에 포함. 별 buffer라 fusion log와 동시 dump.
+      lockLifecycleLog,
       // #1413 — UI에만 노출되던 BoardingLock/Estimator/Boarding Prompt(+Acceptance)/Counters를 share에 포함.
       boardingLock: lock,
       estimatorLog: estimatorLogs,
@@ -2282,6 +2330,8 @@ function DebugModalInner({
     candidateRejectLogs,
     // #2049 (#1896 RC-8) — boarding-lock-drift entries 변경 시 share 텍스트 자동 갱신.
     boardingLockDriftLog,
+    // #2152 — BoardingLock lifecycle entries 변경 시 share 텍스트 자동 갱신.
+    lockLifecycleLog,
     // #1413 — BoardingLock/Estimator 신규 캡쳐.
     lock,
     estimatorLogs,
@@ -2667,6 +2717,20 @@ function DebugModalInner({
             }}
             clearTestId="debug-boarding-lock-drift-log-clear"
             entryTestId="debug-boarding-lock-drift-log-entry"
+            colors={colors}
+          />
+
+          {/* #2152 — BoardingLock lifecycle(생성 source / 해제 reason) 별 buffer. drift와 동일 표시 패턴. */}
+          <DebugLogSection
+            title="BoardingLock Lifecycle"
+            logs={lockLifecycleLog}
+            formatLine={formatLockLifecycleLine}
+            onClear={() => {
+              clearLockLifecycleEntries();
+              setLockLifecycleLog([]);
+            }}
+            clearTestId="debug-lock-lifecycle-log-clear"
+            entryTestId="debug-lock-lifecycle-log-entry"
             colors={colors}
           />
 
@@ -3535,6 +3599,8 @@ export const __test__ = {
   formatFusionDebugLine,
   formatBoardingLockDriftLine,
   buildBoardingLockDriftLogSection,
+  formatLockLifecycleLine,
+  buildLockLifecycleSection,
   formatTokenTail,
   formatAt,
   formatSourceCountsLine,

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -2270,6 +2270,34 @@ describe('formatFusionDebugLine', () => {
     expect(lineNullDrift).toContain('drift=-');
   });
 
+  it('#2152 BoardingLock lifecycle 엔트리: create/release 포맷', () => {
+    const { formatLockLifecycleLine } = __test__;
+    const ts = new Date('2026-08-05T09:00:00Z').getTime();
+    const createLine = formatLockLifecycleLine({
+      kind: 'boarding-lock-lifecycle',
+      event: 'create',
+      ts,
+      source: 'user-tap',
+      trainCode: 'T-100',
+      line: '2',
+      stationId: 'stn-A',
+    });
+    expect(createLine).toContain('lock-create:user-tap');
+    expect(createLine).toContain('T-100(2)');
+    expect(createLine).toContain('station=stn-A');
+
+    const releaseLine = formatLockLifecycleLine({
+      kind: 'boarding-lock-lifecycle',
+      event: 'release',
+      ts,
+      reason: 'transfer',
+      trainCode: 'T-100',
+      line: '2',
+    });
+    expect(releaseLine).toContain('lock-release:transfer');
+    expect(releaseLine).toContain('T-100(2)');
+  });
+
   it('#1902 (RC-18) candidate-line reject: line만 포함 (enumerate 단계 reject)', () => {
     const line = formatCandidateRejectLine({
       kind: 'candidate-reject',
@@ -4787,6 +4815,42 @@ describe('DebugModal — #1501 Raw Signal 섹션', () => {
       expect(dump).toContain('## Boarding-Lock Drift (2)');
     });
 
+    it('buildLockLifecycleSection: 빈/entries cover + share dump 포함 (#2152)', () => {
+      const { buildLockLifecycleSection } = __test__;
+      expect(buildLockLifecycleSection(baselineDumpArgs)).toEqual(['(empty)']);
+      expect(
+        buildLockLifecycleSection({ ...baselineDumpArgs, lockLifecycleLog: [] }),
+      ).toEqual(['(empty)']);
+      const entries = [
+        {
+          kind: 'boarding-lock-lifecycle' as const,
+          event: 'create' as const,
+          ts: 1000,
+          source: 'user-tap' as const,
+          trainCode: 'T-100',
+          line: '2',
+          stationId: 'stn-A',
+        },
+        {
+          kind: 'boarding-lock-lifecycle' as const,
+          event: 'release' as const,
+          ts: 2000,
+          reason: 'transfer' as const,
+          trainCode: 'T-100',
+          line: '2',
+        },
+      ];
+      const result = buildLockLifecycleSection({
+        ...baselineDumpArgs,
+        lockLifecycleLog: entries,
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0]).toContain('lock-release:transfer');
+      expect(result[1]).toContain('lock-create:user-tap');
+      const dump = buildDumpText(makeDumpArgs({ lockLifecycleLog: entries }));
+      expect(dump).toContain('## BoardingLock Lifecycle (2)');
+    });
+
     it('UI: 비어있으면 (0) 표시, push 시 entry 노출, Clear가 비운다', async () => {
       const {
         clearCandidateRejectEntries,
@@ -5626,6 +5690,42 @@ describe('DebugModal — #2049 UI 누락 4 섹션 render', () => {
       fireEvent.press(screen.getByTestId('debug-boarding-lock-drift-log-clear'));
     });
     expect(getBoardingLockDriftEntries().length).toBe(0);
+  });
+
+  it('BoardingLock Lifecycle 섹션이 UI에 노출된다 (buffer 비어 있으면 (empty))', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    expect(screen.getByText(/BoardingLock Lifecycle \(\d+\)/)).toBeTruthy();
+  });
+
+  it('BoardingLock Lifecycle buffer push → UI 반영 + clear 버튼이 buffer를 비운다', async () => {
+    // buffer는 module-level singleton. 매 테스트 시작 시 clear로 격리.
+    const {
+      pushLockLifecycleEntry,
+      clearLockLifecycleEntries,
+      getLockLifecycleEntries,
+    } = jest.requireActual('../../../alarm/utils/boardingLockLifecycleBuffer');
+    clearLockLifecycleEntries();
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    // buffer push → subscribe listener 트리거 → setLockLifecycleLog 콜백 실행.
+    await act(async () => {
+      pushLockLifecycleEntry({
+        kind: 'boarding-lock-lifecycle',
+        event: 'create',
+        ts: Date.now(),
+        source: 'user-tap',
+        trainCode: 'T-100',
+        line: '2',
+        stationId: 'stn-A',
+      });
+    });
+    expect(getLockLifecycleEntries().length).toBe(1);
+    // clear 버튼 press → clearLockLifecycleEntries + setLockLifecycleLog([]) 실행.
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('debug-lock-lifecycle-log-clear'));
+    });
+    expect(getLockLifecycleEntries().length).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- 2026-08-05 trip RCA: lock 생성 경로(source)/해제 사유(reason)/trainCode가 덤프에도 백엔드에도 안 남아 오토락 범인 특정에 소거법이 필요했던 관측 공백을 메운다.
- `boardingLockLifecycleBuffer.ts` 신규 — cap=50 별도 ring buffer. `fusionDebugBuffer` 점령 회귀 lesson(`boardingLockDriftBuffer` #1896 RC-8과 동일 패턴)에 따라 저빈도 lifecycle 이벤트를 fusionDebugBuffer(500)와 분리.
- `useBoardingLockStore.createLock`/`releaseLock` 단일 chokepoint(모든 create/release 경로가 통과)에서 lifecycle entry를 push — 개별 호출부를 일일이 wiring할 필요 없이 소거법 증거를 자동 수집.
- `createLock`에 optional `source` 인자(`user-tap` / `boarding-prompt-response` / `other`) 추가 — 사용자 명시 탭(`BoardingTrainList`)과 boardingPrompt 응답 경로만 명시 stamp, 그 외 자동 경로(backend suggestion / auto-candidate / device-side origin auto-lock / transfer auto-lock)는 기존 시그니처 그대로 `other`로 자동 분류(하위 호환, 다른 call site 변경 없음).
- release `reason`은 기존 `LockReleaseReason`(transfer/vanish/train-code-mismatch/destination-change/expired/user)을 그대로 재사용 — 이미 store가 처리하는 값이라 신규 타입 불필요.
- DebugModal에 "BoardingLock Lifecycle" 섹션 추가 — 기존 "Boarding-Lock Drift" 섹션과 동일 UI/공유 dump 패턴(최신이 위, `(empty)` 표기, clear 버튼, share text에 포함).

## Wire-completion 5단
1. **Orphan**: `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard**: DebugModal "BoardingLock Lifecycle" 섹션(UI 실시간 표시 + Share dump `## BoardingLock Lifecycle` 텍스트) — lock create 시 `lock-create:<source> | trainCode(line) station=stationId`, release 시 `lock-release:<reason> | trainCode(line)` 1줄씩 노출.
3. **의존 PR**: N/A.
4. **측정 plan**: 다음 실탑승 덤프에서 "BoardingLock Lifecycle" 섹션에 create/release 라인이 존재하는지 확인. 오토락 삭제 이슈(후속) 검증 시 "무탭 create 0건"을 본 breadcrumb으로 증명하는 선행 인프라로 사용.
5. **Device verify**: 실기기 1 trip — 열차 직접 탭 → `lock-create:user-tap` 기록 확인, trip 종료(도착/환승/하차) → `lock-release:<reason>` 기록 확인.

## Test plan
- [x] `npm test` — 426 suites / 9075 tests pass, coverage 100% (lines/branches/functions/statements)
- [x] `npm run type-check` — pass
- [x] `npm run lint:orphan` — 0 orphan
- [x] 신규 `boardingLockLifecycleBuffer.test.ts` — push/get/clear/subscribe + cap overwrite
- [x] `useBoardingLockStore.test.ts` — createLock source default/explicit stamp, releaseLock reason stamp (lock 유/무 양쪽)
- [x] `DebugModal.test.tsx` — format/build 함수 + UI 섹션 노출/push/clear (DebugModal.tsx 파일 단독 100% coverage 확인)

Closes #2152