### PR TITLE
fix(#2158): stationPrescheduler 일반모드 loud 알람 발사 회귀 수정

### DIFF
--- a/src/features/alarm/utils/__tests__/stationPrescheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPrescheduler.test.ts
@@ -261,7 +261,7 @@ describe('registerPrescheduledStationAlarms', () => {
     expect((call.content as { interruptionLevel?: string }).interruptionLevel).toBeUndefined();
   });
 
-  it('station-passed kind는 sound=false, alarm kind(transfer/destination)는 sound=alarm.wav', async () => {
+  it('#2158 — station-passed/transfer/destination 모두 sound=false (일반모드는 loud 알람 금지)', async () => {
     const arc = makeArc();
     await registerPrescheduledStationAlarms({
       tripToken: TRIP_TOKEN,
@@ -272,7 +272,27 @@ describe('registerPrescheduledStationAlarms', () => {
     const calls = mockedSchedule.mock.calls;
     expect((calls[0][0].content as { sound?: unknown }).sound).toBe(false);
     const transferCallIdx = 2; // D역 transfer
-    expect((calls[transferCallIdx][0].content as { sound?: unknown }).sound).toBe('alarm.wav');
+    expect((calls[transferCallIdx][0].content as { sound?: unknown }).sound).toBe(false);
+    const destinationCallIdx = calls.length - 1; // F역 destination
+    expect((calls[destinationCallIdx][0].content as { sound?: unknown }).sound).toBe(false);
+  });
+
+  it('#2158 — ios에서 transfer/destination도 interruptionLevel=active (timeSensitive/alarm.wav 금지)', async () => {
+    jest.replaceProperty(Platform, 'OS', 'ios');
+    const arc = makeArc();
+    await registerPrescheduledStationAlarms({
+      tripToken: TRIP_TOKEN,
+      arcStations: arc,
+      currentIdx: 3, // transfer(D→E) + destination(E→F) 두 건
+      now: NOW,
+    });
+    const calls = mockedSchedule.mock.calls;
+    expect(calls.length).toBe(2);
+    for (const call of calls) {
+      const content = call[0].content as { sound?: unknown; interruptionLevel?: string };
+      expect(content.sound).toBe(false);
+      expect(content.interruptionLevel).toBe('active');
+    }
   });
 
   it('APNS_TOKEN_KEY가 있으면 collapseId를 content.data에 동봉', async () => {

--- a/src/features/alarm/utils/stationPrescheduler.ts
+++ b/src/features/alarm/utils/stationPrescheduler.ts
@@ -55,7 +55,9 @@ export const PRESCHED_ALARM_PREFIX = 'presched-';
 
 /** Android channel — 기존 station-alarm 채널 재사용(safetyNetScheduler와 동일 정책). */
 const ALARM_CHANNEL_ID = 'station-alarm';
-const INTERRUPTION_LEVEL = 'timeSensitive';
+/** #2158 — prescheduler는 일반모드 전용 채널이라 loud(alarm.wav/timeSensitive)가 존재할 이유가
+ *  없다. backend의 매역 push(`sendAlertPush` interruption-level=active, 무소리)와 동일 정책. */
+const INTERRUPTION_LEVEL = 'active';
 
 /**
  * 역별 알림 종류. 경로의 마지막 역은 'destination', line이 바뀌는 경계 역은 'transfer',
@@ -153,10 +155,13 @@ async function scheduleOne(params: {
   collapseId: string | undefined;
 }): Promise<void> {
   const { identifier, tripToken, stationName, kind, occurrenceIdx, fireMs, collapseId } = params;
-  const isAlarmKind = kind === 'transfer' || kind === 'destination';
-  const { title, body } = isAlarmKind
-    ? buildAlarmContent({ phaseId: 'imminent', type: kind, stationName } as AlarmEvent)
-    : buildStationPassedContent(stationName);
+  // #2158 — 일반모드(취침모드 OFF) 전용 채널이므로 kind와 무관하게 항상 non-loud 알림으로
+  // 예약한다. transfer/destination도 backend 매역 push와 동일한 문구를 재사용하되(정보 전달
+  // 목적은 동일), 발사는 무소리 + interruption-level=active로 통일 — loud(alarm.wav +
+  // timeSensitive)는 safetyNetScheduler(취침모드 전용)만의 권한이다.
+  const { title, body } = kind === 'station-passed'
+    ? buildStationPassedContent(stationName)
+    : buildAlarmContent({ phaseId: 'imminent', type: kind, stationName } as AlarmEvent);
   const data: PrescheduledNotificationData = {
     channel: 'presched-station',
     tripToken,
@@ -171,12 +176,12 @@ async function scheduleOne(params: {
       title,
       body,
       data: data as unknown as Record<string, unknown>,
-      sound: isAlarmKind ? 'alarm.wav' : false,
+      sound: false,
       ...(Platform.OS === 'android' && {
         channelId: ALARM_CHANNEL_ID,
         priority: Notifications.AndroidNotificationPriority.MAX,
       }),
-      ...(Platform.OS === 'ios' && isAlarmKind && { interruptionLevel: INTERRUPTION_LEVEL }),
+      ...(Platform.OS === 'ios' && { interruptionLevel: INTERRUPTION_LEVEL }),
     },
     trigger: { type: Notifications.SchedulableTriggerInputTypes.DATE, date: new Date(fireMs) },
   });


### PR DESCRIPTION
Closes #2158

## 요약
`stationPrescheduler.ts`의 `scheduleOne`이 transfer/destination kind에 `isAlarmKind` 분기로
loud content(`buildAlarmContent(imminent)` + `sound:'alarm.wav'` + iOS `interruptionLevel:'timeSensitive'`)를
OS에 예약하던 회귀(#918 도입)를 수정. prescheduler는 취침모드 OFF(일반모드) 전용 채널이므로
loud 알람이 발사될 이유가 없다 — 스펙(plan-2026-07-29 0절): loud 알람 = 취침모드 전용.

## 변경 사항 (iOS)
- `scheduleOne`에서 `isAlarmKind` 분기 자체를 제거. kind와 무관하게 항상 `sound:false`로 예약.
- iOS `interruptionLevel`을 `'timeSensitive'`에서 `'active'`로 변경(backend 매역 push
  `sendAlertPush interruption-level:'active'`와 동일 정책) — kind 무관 무조건 적용.
- transfer/destination의 title/body는 기존 `buildAlarmContent(imminent)` 문구를 그대로 유지
  (환승/도착 임박 안내 텍스트 자체는 정보성으로 적절 — loud였던 것은 사운드/인터럽션 레벨뿐).
- `silentPushTask.ts`의 reschedule 경로(`applyReschedule` sleepMode OFF 분기)는
  `reschedulePrescheduledAlarm` → 동일 `scheduleOne`을 재사용하므로 자동으로 함께 수정됨
  (별도 파일 수정 불필요).

## 변경 사항 (Android — 리뷰 P1 반영)
1차 수정에서 iOS 필드(sound/interruptionLevel)만 손봤으나, Android는 `scheduleOne`의 android
블록이 여전히 `channelId: ALARM_CHANNEL_ID('station-alarm')` + `priority: MAX`를 kind 무관
무조건 사용 중이었음 — 이 채널은 `stationNotification.ts`에서 `sound:'alarm.wav'` +
`importance MAX` + 진동 + `bypassDnd:true`로 생성된 **loud 채널**이라, Android 8+에서는 채널의
sound가 고정 속성이라 content의 `sound:false`가 무시되고 여전히 loud 발사됨(리뷰 지적).

- `stationNotification.ts`: 그동안 미사용이던 `ALARM_SILENT_CHANNEL_ID`(`'station-alarm-silent'`,
  `sound:null`)를 export. 채널 정의를 `importance: MAX→HIGH`, `bypassDnd:true` 제거로 조정.
- `stationPrescheduler.ts`: android 블록의 `channelId`를 `ALARM_SILENT_CHANNEL_ID`로,
  `priority`를 `MAX→HIGH`로 변경.
- **기존 loud 채널(`ALARM_CHANNEL_ID='station-alarm'`) 소비자는 grep으로 확인 후 무변경** —
  `safetyNetScheduler.ts`(취침모드 전용)는 별도 로컬 `ALARM_CHANNEL_ID` 상수를 자체 보유해
  본 PR의 import 변경과 무관, 손대지 않음.
- `refreshNotificationChannels()`에서 이미 `ALARM_SILENT_CHANNEL_ID` 채널을 생성 중임을 확인 —
  신규 채널 생성 코드 추가 불필요.

## 테스트 (TDD)
- Red: `station-passed kind는 sound=false, alarm kind(transfer/destination)는 sound=alarm.wav`
  테스트의 assertion을 올바른 기대값(`sound=false`)으로 먼저 뒤집어 현재 버그를 재현(fail 확인).
- Green: fix 적용 후 통과. iOS `interruptionLevel=active` 검증 테스트 신설.
- Red(2차, Android): android 채널/priority 기대값을 `station-alarm-silent`/`HIGH`로 먼저 뒤집어
  실패 확인(`stationPrescheduler.test.ts` + `stationNotification.test.ts`의 `#1224 회귀 가드`
  중복 assertion 2곳 모두).
- Green(2차): fix 적용 후 통과. 기존 `ALARM_CHANNEL_ID`(loud) 자체는 변경 없음을 검증하는
  `#1224 회귀 가드` 테스트도 그대로 pass.
- `npm test` — 425 suites / 9064 tests pass, coverage 100% (lines/functions/branches/statements)
- `npm run type-check` — pass
- `npm run lint:orphan` — No orphan exports detected

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass. 신규 export `ALARM_SILENT_CHANNEL_ID`는
   `stationPrescheduler.ts`가 즉시 소비.
2. **V/X dashboard** — `alarmLog.logScheduledPrescheduledAlarm` (station, kind별 예약 로그) +
   DebugModal에서 예약 content(sound/interruptionLevel/channelId 포함)를 계속 관측 가능.
   로그 스키마 변경 없음.
3. **의존 PR** — N/A (device-only, backend 무변경).
4. **측정 plan** — 다음 실탑승 일반모드 trip(iOS + Android 둘 다)에서 환승/도착역 loud
   (alarm.wav/강한 진동) 발사 0건을 `logScheduledPrescheduledAlarm` + 실기기 청각/촉각 확인으로 검증.
5. **Device verify** — 필요. 일반모드(취침모드 OFF) trip 1회 — iOS + Android 각각 환승역/도착역에서
   무음 알림(배너만, alarm.wav 없음, Android는 loud 채널 진동/DND 우회 없음) 수신 확인.
   취침모드 trip은 회귀 없음(safetyNetScheduler 무변경 — 회귀 아님).