### PR TITLE
fix(#2157): eta-missing 시 trip 강제종료 대신 lock 해제+lockless 강등

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -4167,6 +4167,37 @@ describe('runScheduled — trip-ended alert push (#1337)', () => {
     expect(storedTrip.boardingLock).toBeUndefined();
   });
 
+  // #2157 (PR #2162 리뷰 P1) — 같은 trip에서 두 번째 demotion이 발생해도 재확인 push가
+  // 발사돼야 한다. createdAt은 trip 재등록(isSameSession) 후에도 보존되므로 dedup 키를
+  // createdAt에 고정하면 두 번째 demotion이 첫 demotion의 dedup stamp에 막혀 조용히
+  // 미발사되는 회귀가 생긴다 — dedup은 demotion event(`etaMissingDemotedAt`) 단위여야 한다.
+  const SECOND_DEMOTION_NOW = NOW + 30 * 60_000;
+  it('fires train-reconfirm push again on a second demotion of the same trip (createdAt unchanged)', async () => {
+    const kv = new InMemoryKV();
+    // 첫 demotion이 이미 NOW 시점에 발생해 dedup stamp를 남긴 상태를 시뮬레이션.
+    // createdAt은 trip 생애 내내 불변(NOW) — 재선택 후 재등록해도 isSameSession으로 보존된다.
+    await kv.put(`trainReconfirmAlert:re-tok:${NOW}`, '1');
+    // 사용자가 재선택(boardingPrompt/직접 탭)해 lock이 재부착된 상태. 두 번째 demotion 직전:
+    // consecutiveEtaMissing이 threshold-1까지 다시 쌓인 상태로 seed.
+    await putTrip(kv as unknown as KVNamespace, makeEtaThresholdTrip('re-tok', 4));
+    const fetchImpl = makeOkFetch();
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => SECOND_DEMOTION_NOW,
+      generatePushId: () => 'p-eta-second',
+    });
+    // 두 번째 demotion은 새 event이므로 push가 발사돼야 한다 (첫 demotion의 dedup stamp에
+    // 막히면 안 된다).
+    const calls = getTrainReconfirmCalls(fetchImpl);
+    expect(calls).toHaveLength(1);
+    expect(parseTrainReconfirmData(calls[0]).sentAt).toBe(SECOND_DEMOTION_NOW);
+    // 새 demotion event 전용 dedup stamp가 남는다 (createdAt=NOW가 아니라 demotion 시점 기준).
+    expect(await kv.get(`trainReconfirmAlert:re-tok:${SECOND_DEMOTION_NOW}`)).toBe('1');
+  });
+
   it('fires trip-ended push (reason=destination-arrived) when destination waypoint ARRIVED', async () => {
     const kv = new InMemoryKV();
     await putTrip(kv as unknown as KVNamespace, makeLockedLaTrip());

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -187,6 +187,8 @@ function makeFullEmptyStats(): ScheduledStats {
     sleepAlarmFired: 0,
     sleepAlarmDedupSkipped: 0,
     sleepAlarmRolledBack: 0,
+    etaMissingDemoted: 0,
+    trainReconfirmFired: 0,
   };
 }
 
@@ -1422,12 +1424,17 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
       expect((await readStoredTrip(kv))?.consecutiveEtaMissing).toBe(4);
     });
 
-    it('auto-ends trip when consecutiveEtaMissing reaches threshold', async () => {
-      // 임계치 -1 상태 → 한 번 더 miss → threshold 도달 → cleanup
+    // #2157 (2026-08-05 결정 A) — trip을 강제 종료하는 대신 lock만 해제 + lockless 강등.
+    it('demotes trip to lockless (lock detach, trip survives) when consecutiveEtaMissing reaches threshold', async () => {
+      // 임계치 -1 상태 → 한 번 더 miss → threshold 도달 → 강등 (trip 생존).
       const kv = new InMemoryKV();
       await seedLockTrip(kv, { consecutiveEtaMissing: MAX_CONSECUTIVE_ETA_MISSING - 1 });
       await runMissScenario(kv);
-      expect(await readStoredTrip(kv)).toBeNull();
+      const stored = await readStoredTrip(kv);
+      expect(stored).not.toBeNull();
+      expect(stored?.boardingLock).toBeUndefined();
+      expect(stored?.consecutiveEtaMissing).toBe(0);
+      expect(stored?.infoModeEnabled).toBe(true);
     });
 
     it('resets counter to 0 when arrival estimate succeeds', async () => {
@@ -4002,6 +4009,35 @@ describe('runScheduled — trip-ended alert push (#1337)', () => {
     return body.data;
   }
 
+  // #2157 — train-reconfirm alert push (APNs alert push, kind='train-reconfirm') 호출만 추출.
+  function getTrainReconfirmCalls(
+    fetchImpl: ReturnType<typeof vi.fn>,
+  ): [string, RequestInit][] {
+    return (fetchImpl.mock.calls as unknown as [string, RequestInit][]).filter((c) => {
+      const headers = (c[1]?.headers ?? {}) as Record<string, string>;
+      if (headers['apns-push-type'] !== 'alert') return false;
+      try {
+        const body = JSON.parse(c[1]?.body as string) as { data?: { kind?: string } };
+        return body?.data?.kind === 'train-reconfirm';
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  /** train-reconfirm push body의 data field 추출. */
+  function parseTrainReconfirmData(call: [string, RequestInit]): {
+    kind: string;
+    pushId: string;
+    sentAt: number;
+    tripToken: string;
+  } {
+    const body = JSON.parse(call[1].body as string) as {
+      data: { kind: string; pushId: string; sentAt: number; tripToken: string };
+    };
+    return body.data;
+  }
+
   // 본 describe 안에서만 쓰이는 fixture — makeLockTrip은 outer scope에 있어 재사용 불가.
   function makeEtaThresholdTrip(token: string, missCount: number) {
     return makeTrip({
@@ -4020,13 +4056,18 @@ describe('runScheduled — trip-ended alert push (#1337)', () => {
     });
   }
 
-  it('fires trip-ended push (reason=eta-missing) when consecutiveEtaMissing exceeds threshold', async () => {
+  // #2157 (2026-08-05 결정 A) — 순수 eta-missing(Seoul API 정상 응답, trainCode만 매칭 실패)은
+  // 더 이상 trip을 강제 종료하지 않는다. 구 동작(trip-ended push + KV 삭제)을 재현하던 테스트를
+  // "lock 해제 + lockless 강등 + 재확인 push" 신규 동작으로 교체 — 결정1(#2154)과 일관되게
+  // 백엔드가 사용자 trip을 일방 종료하는 상황 자체를 제거한다.
+  it('demotes trip to lockless (lock detach, no trip-ended) when consecutiveEtaMissing exceeds threshold', async () => {
     const kv = new InMemoryKV();
     await putTrip(kv as unknown as KVNamespace, makeEtaThresholdTrip('end-tok', 4));
     const fetchImpl = makeOkFetch();
-    // arrivals 비어 있음 → estimate=null → miss 1 더 → 5 도달 → auto-end.
+    // arrivals 비어 있음 → estimate=null → miss 1 더 → 5 도달 → 구동작이면 auto-end, 신동작은 강등.
     // top-level makeSeoul은 positions endpoint도 같은 fetchImpl을 사용 — realtimePositionList 키가
-    // 없어 빈 배열로 처리되므로 fallback도 estimate=null로 떨어진다.
+    // 없어 빈 배열로 처리되므로 fallback도 estimate=null로 떨어진다. httpErrorCount=0(ok 응답)이라
+    // endReason 판정은 'eta-missing' 경로를 탄다.
     await runScheduled(makeEnv(kv), {
       seoul: makeSeoul([]),
       apnsConfig,
@@ -4035,27 +4076,95 @@ describe('runScheduled — trip-ended alert push (#1337)', () => {
       now: () => NOW,
       generatePushId: () => 'p-eta-end',
     });
-    const calls = getTripEndedCalls(fetchImpl);
+    // trip-ended push는 더 이상 발사되지 않는다.
+    expect(getTripEndedCalls(fetchImpl)).toHaveLength(0);
+    // 재확인(train-reconfirm) alert push가 1건 발사된다.
+    const calls = getTrainReconfirmCalls(fetchImpl);
     expect(calls).toHaveLength(1);
-    const data = parseTripEndedData(calls[0]);
-    expect(data.kind).toBe('trip-ended');
-    expect(data.reason).toBe('eta-missing');
+    const data = parseTrainReconfirmData(calls[0]);
+    expect(data.kind).toBe('train-reconfirm');
     expect(data.sentAt).toBe(NOW);
     expect(typeof data.pushId).toBe('string');
     expect(data.pushId.length).toBeGreaterThan(0);
-    // #868 P1-2 race 가드 — payload에 tripToken 포함되어야 클라가 ACTIVE_TRIP_KEY와 매칭 가능.
     expect(data.tripToken).toBe('end-tok');
-    // #1337 — alert push headers + KV dedup stamp.
     const headers = (calls[0][1].headers ?? {}) as Record<string, string>;
     expect(headers['apns-push-type']).toBe('alert');
     expect(headers['apns-priority']).toBe('10');
-    const apsBody = JSON.parse(calls[0][1].body as string) as { aps: { alert: { title: string; body: string }; sound?: string } };
-    expect(apsBody.aps.alert).toEqual({ title: '안내 종료', body: '경로 안내를 종료했어요' });
-    // #2069 (Phase 3) — 무소리 배너. sound 필드 자체가 payload에서 생략된다.
-    expect('sound' in apsBody.aps).toBe(false);
-    // trip은 KV에서 삭제돼야 함 (#706 cleanup).
-    expect(await kv.get('trip:end-tok')).toBeNull();
-    expect(await kv.get(`tripEndedAlert:end-tok:${NOW}`)).toBe('1');
+    const apsBody = JSON.parse(calls[0][1].body as string) as {
+      aps: { alert: { title: string; body: string } };
+    };
+    expect(apsBody.aps.alert).toEqual({
+      title: '탑승 열차를 찾을 수 없어요',
+      body: '다시 확인해주세요',
+    });
+    // trip은 KV에서 삭제되지 않고 살아있어야 함 — lockless로 강등만 된다.
+    const stored = await kv.get('trip:end-tok');
+    expect(stored).not.toBeNull();
+    const storedTrip = JSON.parse(stored as string) as {
+      boardingLock?: unknown;
+      consecutiveEtaMissing?: number;
+      infoModeEnabled?: boolean;
+    };
+    expect(storedTrip.boardingLock).toBeUndefined();
+    expect(storedTrip.consecutiveEtaMissing).toBe(0);
+    expect(storedTrip.infoModeEnabled).toBe(true);
+    expect(await kv.get(`trainReconfirmAlert:end-tok:${NOW}`)).toBe('1');
+  });
+
+  // #2157 — seoul-outage 분기 회귀 가드. httpErrorCount>0(Seoul API HTTP error 관측)이면 기존
+  // trip auto-end + trip-ended push 경로를 그대로 유지 — 강등 로직이 seoul-outage까지 흡수하면
+  // #1425 cooldown 면제 판정이 깨진다.
+  it('still ends trip (reason=seoul-outage) when Seoul API HTTP error observed this cycle', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeEtaThresholdTrip('outage-tok', 4));
+    const erroredFetch = vi.fn(
+      async () => new Response('boom', { status: 500 }),
+    ) as unknown as typeof fetch;
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: erroredFetch,
+    });
+    const fetchImpl = makeOkFetch();
+    await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-outage-end',
+    });
+    const calls = getTripEndedCalls(fetchImpl);
+    expect(calls).toHaveLength(1);
+    const data = parseTripEndedData(calls[0]);
+    expect(data.reason).toBe('seoul-outage');
+    // 재확인 push는 발사되지 않는다 — seoul-outage는 강등 경로를 타지 않는다.
+    expect(getTrainReconfirmCalls(fetchImpl)).toHaveLength(0);
+    expect(await kv.get('trip:outage-tok')).toBeNull();
+  });
+
+  // #2157 — 재확인 push는 1 trip 1회 dedup. 같은 trip이 두 번째 cron cycle에서도 threshold를
+  // 계속 초과하면(재선택 전까지 consecutiveEtaMissing이 다시 쌓이는 상황) 중복 발사를 막는다.
+  it('does not re-fire train-reconfirm push when dedup KV already stamped', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeEtaThresholdTrip('dedup-tok', 4));
+    await kv.put(`trainReconfirmAlert:dedup-tok:${NOW}`, '1');
+    const fetchImpl = makeOkFetch();
+    await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-eta-dedup',
+    });
+    expect(getTrainReconfirmCalls(fetchImpl)).toHaveLength(0);
+    // dedup으로 push는 skip돼도 lock detach + lockless 강등 자체는 여전히 일어난다.
+    const stored = await kv.get('trip:dedup-tok');
+    expect(stored).not.toBeNull();
+    const storedTrip = JSON.parse(stored as string) as { boardingLock?: unknown };
+    expect(storedTrip.boardingLock).toBeUndefined();
   });
 
   it('fires trip-ended push (reason=destination-arrived) when destination waypoint ARRIVED', async () => {
@@ -4109,9 +4218,20 @@ describe('runScheduled — trip-ended alert push (#1337)', () => {
     expect(await kv.get('trip:la-tok')).toBeNull();
   });
 
+  // #2157 — eta-missing 자체는 더 이상 trip-ended를 발사하지 않으므로(강등 경로), 본 회귀 가드는
+  // seoul-outage(httpErrorCount>0)로 trip-ended push를 여전히 발사하는 경로를 사용해 throw
+  // 흡수 동작을 검증한다. Seoul API fetch(끊긴 상태)와 APNs push fetch(trip-ended만 reject)는
+  // 서로 다른 fetchImpl이라 독립적으로 구성 가능 — `deps.seoul`은 client 내부에 캡슐화된 fetch를
+  // 쓰고, `deps.fetchImpl`은 push 발사에만 쓰인다.
   it('#868 P2-1 — trip-ended push fetch throw해도 cleanup 흐름 계속 (trip 삭제됨)', async () => {
     const kv = new InMemoryKV();
     await putTrip(kv as unknown as KVNamespace, makeEtaThresholdTrip('thr-tok', 4));
+    const erroredSeoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: (async () => new Response('boom', { status: 500 })) as unknown as typeof fetch,
+    });
     // trip-ended push만 reject — reschedule/LA push는 정상.
     const throwingFetch = vi.fn((_url: unknown, init?: { body?: string }) => {
       const body = typeof init?.body === 'string' ? init.body : '';
@@ -4121,7 +4241,7 @@ describe('runScheduled — trip-ended alert push (#1337)', () => {
       return Promise.resolve(new Response('', { status: 200 }));
     });
     await runScheduled(makeEnv(kv), {
-      seoul: makeSeoul([]),
+      seoul: erroredSeoul,
       apnsConfig,
       apnsHosts: APNS_HOSTS,
       fetchImpl: throwingFetch as unknown as typeof fetch,
@@ -9727,6 +9847,8 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
       sleepAlarmFired: 0,
       sleepAlarmDedupSkipped: 0,
       sleepAlarmRolledBack: 0,
+      etaMissingDemoted: 0,
+      trainReconfirmFired: 0,
     };
     const { dirty } = await fireArvlCdStationPush({
       trip,

--- a/backend/alarm-worker/src/i18n.ts
+++ b/backend/alarm-worker/src/i18n.ts
@@ -64,6 +64,13 @@ interface I18nStrings {
   stationNotifTitle: (kind: StationNotifKind) => string;
   /** #2063 — 매역 알림(station-notif) body. kind별 분기 + station 삽입. */
   stationNotifBody: (kind: StationNotifKind, stationName: string) => string;
+  /**
+   * #2157 — eta-missing lock detach 시 재확인 alert push title. trip을 강제 종료하는 대신
+   * lock만 해제하고 사용자에게 재선택(boardingPrompt/직접 탭)을 유도한다.
+   */
+  trainReconfirmTitle: string;
+  /** #2157 — 재확인 alert push body. */
+  trainReconfirmBody: string;
 }
 
 /**
@@ -101,6 +108,8 @@ const I18N: Record<SupportedLocale, I18nStrings> = {
       if (kind === 'transfer') return `곧 ${stationName}에 도착합니다. 환승 준비하세요!`;
       return `곧 ${stationName}에 도착합니다. 하차 준비하세요!`;
     },
+    trainReconfirmTitle: '탑승 열차를 찾을 수 없어요',
+    trainReconfirmBody: '다시 확인해주세요',
   },
   en: {
     boardingPromptTitle: 'Are you on board?',
@@ -128,6 +137,8 @@ const I18N: Record<SupportedLocale, I18nStrings> = {
       if (kind === 'transfer') return `Arriving at ${stationName} — transfer soon!`;
       return `Arriving at ${stationName} — exit soon!`;
     },
+    trainReconfirmTitle: "We couldn't find your train",
+    trainReconfirmBody: 'Please check again',
   },
   ja: {
     boardingPromptTitle: 'ご乗車されましたか?',
@@ -155,6 +166,8 @@ const I18N: Record<SupportedLocale, I18nStrings> = {
       if (kind === 'transfer') return `まもなく${stationName}に到着します。乗換の準備をしてください!`;
       return `まもなく${stationName}に到着します。下車の準備をしてください!`;
     },
+    trainReconfirmTitle: '乗車列車が見つかりません',
+    trainReconfirmBody: 'もう一度ご確認ください',
   },
   zh: {
     boardingPromptTitle: '您已乘车了吗?',
@@ -182,6 +195,8 @@ const I18N: Record<SupportedLocale, I18nStrings> = {
       if (kind === 'transfer') return `即将到达${stationName}。请准备换乘!`;
       return `即将到达${stationName}。请准备下车!`;
     },
+    trainReconfirmTitle: '未能找到您的乘车列车',
+    trainReconfirmBody: '请重新确认',
   },
 };
 

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -2914,22 +2914,32 @@ async function attemptVanishSwap(
 }
 
 /**
- * #2157 (2026-08-05 결정 A) — eta-missing 재확인 alert push의 KV dedup 키. (tripToken, createdAt)
- * 단위 — trip-ended alert dedup(`tripEndedAlertDedupKey`)과 동일 패턴이나 trip이 살아있는 채로
- * 반복 cron cycle을 도는 경로라 TTL을 trip 최대 수명(9h+) 이상으로 넉넉히 잡는다.
+ * #2157 (2026-08-05 결정 A, PR #2162 리뷰 P1) — eta-missing 재확인 alert push의 KV dedup 키.
+ * `(tripToken, demotedAt)` 단위 — `demotedAt`은 이 demotion event가 발생한 시점
+ * (`trip.etaMissingDemotedAt`, 호출 직전에 `now`로 stamp됨)이지 `trip.createdAt`이 아니다.
+ * trip-ended alert dedup(`tripEndedAlertDedupKey`)과 겉모양은 같지만 전제가 다르다 — trip-ended는
+ * 발사 직후 trip이 삭제되는 반면 본 강등은 trip이 **생존**하고 재등록해도 `createdAt`이 보존된다
+ * (`isSameSession`). `createdAt` 기준으로 잡으면 같은 trip의 두 번째 demotion이 첫 demotion의
+ * dedup stamp에 막혀 조용히 미발사된다 — event 단위 키로 "같은 demotion 중복 tick 차단 +
+ * 새 demotion 재발사 허용"을 동시에 만족한다. TTL은 trip이 살아있는 채로 반복 cron cycle을 도는
+ * 경로라 trip 최대 수명(9h+) 이상으로 넉넉히 잡는다.
  */
 const TRAIN_RECONFIRM_ALERT_DEDUP_KEY_PREFIX = 'trainReconfirmAlert:';
 const TRAIN_RECONFIRM_ALERT_DEDUP_TTL_SEC = 12 * 60 * 60;
 
-function trainReconfirmAlertDedupKey(tripToken: string, createdAt: number): string {
-  return `${TRAIN_RECONFIRM_ALERT_DEDUP_KEY_PREFIX}${tripToken}:${createdAt}`;
+function trainReconfirmAlertDedupKey(tripToken: string, demotedAt: number): string {
+  return `${TRAIN_RECONFIRM_ALERT_DEDUP_KEY_PREFIX}${tripToken}:${demotedAt}`;
 }
 
 /**
  * #2157 — eta-missing 임계 도달로 lock을 해제할 때 "탑승 열차를 찾을 수 없어요 — 다시
- * 확인해주세요" alert push를 1 trip당 1회만 발사한다. KV set-if-absent 게이트로 cron race에
- * 의한 중복 발사를 차단(`fireTripEndedAlertPush`와 동일 패턴). 실패는 graceful — dedup stamp를
- * 남기지 않아 다음 cycle에서 재시도 허용.
+ * 확인해주세요" alert push를 1 demotion event당 1회만 발사한다. KV set-if-absent 게이트로 cron
+ * race에 의한 중복 발사를 차단(`fireTripEndedAlertPush`와 동일 패턴). 실패는 graceful — dedup
+ * stamp를 남기지 않아 다음 cycle에서 재시도 허용.
+ *
+ * 호출자(threshold 분기)가 `trip.etaMissingDemotedAt = now`를 이미 stamp한 뒤 호출한다 —
+ * 이 함수는 그 값을 그대로 dedup 키에 사용한다(직접 `now` 파라미터를 쓰지 않는 이유: 값의
+ * SSoT가 trip 객체여야 재진입/재시도 시에도 같은 demotion을 가리키는 키가 보장된다).
  */
 async function fireTrainReconfirmPush(
   trip: Trip,
@@ -2940,7 +2950,7 @@ async function fireTrainReconfirmPush(
   log: Logger,
   generatePushId: () => string,
 ): Promise<void> {
-  const dedupKey = trainReconfirmAlertDedupKey(trip.token, trip.createdAt);
+  const dedupKey = trainReconfirmAlertDedupKey(trip.token, trip.etaMissingDemotedAt ?? trip.createdAt);
   const existing = await env.TRIPS.get(dedupKey);
   if (existing !== null) {
     log('train-reconfirm: dedup skip', { token: trip.token.slice(0, 8) });
@@ -3211,7 +3221,14 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
     });
     trip.boardingLock = undefined;
     trip.consecutiveEtaMissing = 0;
+    // #1370 L3 vanishLocklessTakeover 선례와 동일 패턴 — 시스템 fallback이 lockless 인계 경로를
+    // 강제 활성화한다. 사용자가 opt-in 토글을 OFF로 둔 trip이어도 register 시 device가 보낸
+    // 실제 값으로 다음 세션에 자연 정합화되므로, 이 강제 활성화가 사용자 설정을 영구 덮어쓰지
+    // 않는다(#1370 L3 코멘트와 동일 근거).
     trip.infoModeEnabled = true;
+    // #2157 (PR #2162 리뷰 P1) — dedup 키를 이 demotion event 시점으로 고정. trip.createdAt은
+    // trip 생애 전체에 불변이라 두 번째 demotion에서 재사용하면 재확인 push가 조용히 막힌다.
+    trip.etaMissingDemotedAt = now;
     stats.etaMissingDemoted += 1;
     await deleteProgress(env.TRIPS, trip.token);
     await putTrip(env.TRIPS, trip);

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -93,6 +93,7 @@ import type {
   LineNumber,
   PositionPoint,
   StationPhaseState,
+  TrainReconfirmAlertPushPayload,
   Trip,
   Waypoint,
 } from './types';
@@ -878,6 +879,20 @@ export interface ScheduledStats extends LiveActivityStats {
    * 다음 cron tick에 재시도를 허용한다(전송 실패로 1h 동안 알람이 영구 미스되는 회귀 방지).
    */
   sleepAlarmRolledBack: number;
+  /**
+   * #2157 (2026-08-05 결정 A) — eta-missing 임계(`resolveEtaMissingThreshold`) 도달 시 trip을
+   * 강제 종료하는 대신 lock만 해제하고 lockless로 강등한 누적 횟수. seoul-outage(httpErrorCount>0)
+   * 분기는 기존대로 `cleanupTripWithLa`를 타므로 본 카운터에 집계되지 않는다 — 순수 eta-missing만.
+   * dashboard: `trip_metrics` end_reason=eta-missing 분포와 역상관 — 배포 후 이 값이 늘고
+   * end_reason=eta-missing이 0에 수렴하면 fix가 의도대로 작동 중인 신호.
+   */
+  etaMissingDemoted: number;
+  /**
+   * #2157 — eta-missing 강등 시 재확인("탑승 열차를 찾을 수 없어요") alert push가 실제 발사된
+   * 누적 횟수. KV dedup(1 trip 1회)으로 `etaMissingDemoted`보다 작거나 같아야 정상 —
+   * dedup으로 skip된 케이스는 `etaMissingDemoted`에는 잡히되 본 카운터에는 잡히지 않는다.
+   */
+  trainReconfirmFired: number;
 }
 
 /**
@@ -1067,6 +1082,9 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     sleepAlarmFired: 0,
     sleepAlarmDedupSkipped: 0,
     sleepAlarmRolledBack: 0,
+    // #2157 — eta-missing 강등 + 재확인 push 카운터.
+    etaMissingDemoted: 0,
+    trainReconfirmFired: 0,
     // #2073 (Issue A) — 아래 idle 판정 이후 실제 값으로 덮어쓴다. 기본 true = 보수적(항상 실행).
     pendingActivityPossible: true,
   };
@@ -2896,6 +2914,85 @@ async function attemptVanishSwap(
 }
 
 /**
+ * #2157 (2026-08-05 결정 A) — eta-missing 재확인 alert push의 KV dedup 키. (tripToken, createdAt)
+ * 단위 — trip-ended alert dedup(`tripEndedAlertDedupKey`)과 동일 패턴이나 trip이 살아있는 채로
+ * 반복 cron cycle을 도는 경로라 TTL을 trip 최대 수명(9h+) 이상으로 넉넉히 잡는다.
+ */
+const TRAIN_RECONFIRM_ALERT_DEDUP_KEY_PREFIX = 'trainReconfirmAlert:';
+const TRAIN_RECONFIRM_ALERT_DEDUP_TTL_SEC = 12 * 60 * 60;
+
+function trainReconfirmAlertDedupKey(tripToken: string, createdAt: number): string {
+  return `${TRAIN_RECONFIRM_ALERT_DEDUP_KEY_PREFIX}${tripToken}:${createdAt}`;
+}
+
+/**
+ * #2157 — eta-missing 임계 도달로 lock을 해제할 때 "탑승 열차를 찾을 수 없어요 — 다시
+ * 확인해주세요" alert push를 1 trip당 1회만 발사한다. KV set-if-absent 게이트로 cron race에
+ * 의한 중복 발사를 차단(`fireTripEndedAlertPush`와 동일 패턴). 실패는 graceful — dedup stamp를
+ * 남기지 않아 다음 cycle에서 재시도 허용.
+ */
+async function fireTrainReconfirmPush(
+  trip: Trip,
+  env: Env,
+  deps: ScheduledDeps,
+  stats: ScheduledStats,
+  now: number,
+  log: Logger,
+  generatePushId: () => string,
+): Promise<void> {
+  const dedupKey = trainReconfirmAlertDedupKey(trip.token, trip.createdAt);
+  const existing = await env.TRIPS.get(dedupKey);
+  if (existing !== null) {
+    log('train-reconfirm: dedup skip', { token: trip.token.slice(0, 8) });
+    return;
+  }
+  const pushId = generatePushId();
+  const strings = t(trip.locale);
+  const payload: TrainReconfirmAlertPushPayload = {
+    pushId,
+    kind: 'train-reconfirm',
+    tripToken: trip.token,
+    sentAt: now,
+  };
+  // sendAlertPush의 `data`는 Record<string, unknown> — payload를 spread해 index signature를 만족.
+  const data: Record<string, unknown> = { ...payload };
+  try {
+    const heal = await sendWithEnvHeal(
+      (host) =>
+        sendAlertPush({
+          deviceToken: trip.token,
+          title: strings.trainReconfirmTitle,
+          body: strings.trainReconfirmBody,
+          pushId,
+          tripToken: trip.token,
+          data,
+          config: deps.apnsConfig,
+          host,
+          fetchImpl: deps.fetchImpl,
+          now,
+        }),
+      trip.apnsEnv,
+      deps.apnsHosts,
+      log,
+      trip.token.slice(0, 8),
+    );
+    if (!heal.result.ok) {
+      log('train-reconfirm push failed', {
+        token: trip.token.slice(0, 8),
+        status: heal.result.status,
+        pushReason: heal.result.reason,
+      });
+      return;
+    }
+  } catch (e) {
+    log('train-reconfirm push threw', { token: trip.token.slice(0, 8), error: String(e) });
+    return;
+  }
+  stats.trainReconfirmFired += 1;
+  await env.TRIPS.put(dedupKey, '1', { expirationTtl: TRAIN_RECONFIRM_ALERT_DEDUP_TTL_SEC });
+}
+
+/**
  * estimate가 null로 끝난 cycle 처리 — etaMissing 카운터 누적 + 임계 초과 시 trip 자동 종료.
  * runTrainCodeTracking의 cognitive complexity 분담용 추출 (Sonar S3776).
  *
@@ -3085,18 +3182,40 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
     // httpErrorCount는 SeoulArrivalClient 인스턴스 수명(= cron 1 cycle) 범위라 cron scope 내에서만 유효.
     const endReason: import('./types').TripEndedReason =
       deps.seoul.stats.httpErrorCount > 0 ? 'seoul-outage' : 'eta-missing';
-    // #706 — 운행 시간대 외 무한 폴링 차단. cleanupTripWithLa가 LA dismissal + deleteTrip을 묶어 정리.
-    // #868 — 클라 state sync용 trip-ended silent push 발사.
-    log('boarding-lock: trip auto-ended (consecutiveEtaMissing exceeded)', {
+    if (endReason === 'seoul-outage') {
+      // seoul-outage 분기는 기존 유지 (#1663) — Seoul API 장애가 원인이면 trip auto-end +
+      // #1425 cooldown 면제 경로를 그대로 탄다. cleanupTripWithLa가 LA dismissal + deleteTrip을
+      // 묶어 정리하고 trip-ended alert push를 발사한다.
+      log('boarding-lock: trip auto-ended (consecutiveEtaMissing exceeded)', {
+        token: trip.token.slice(0, 8),
+        trainCode: activeLock.trainCode,
+        station: waypoint.stationName,
+        threshold,
+        subsurface: trip.subsurface === true,
+        endReason,
+        seoulHttpErrors: deps.seoul.stats.httpErrorCount,
+      });
+      await cleanupTripWithLa(trip, env, deps, stats, now, log, endReason);
+      return;
+    }
+    // #2157 (2026-08-05 결정 A) — 순수 eta-missing(Seoul API는 정상 응답, trainCode만
+    // 매칭 실패)은 더 이상 trip을 강제 종료하지 않는다. lock만 해제 + lockless로 강등해
+    // 사용자에게 재확인 alert push를 발사, boardingPrompt/직접 탭으로 재선택을 유도한다
+    // (결정1 #2154 "명시 확인 철학"과 일관 — 백엔드가 사용자 trip을 일방 종료하지 않음).
+    log('boarding-lock: eta-missing threshold — demoting to lockless (lock detached)', {
       token: trip.token.slice(0, 8),
       trainCode: activeLock.trainCode,
       station: waypoint.stationName,
       threshold,
       subsurface: trip.subsurface === true,
-      endReason,
-      seoulHttpErrors: deps.seoul.stats.httpErrorCount,
     });
-    await cleanupTripWithLa(trip, env, deps, stats, now, log, endReason);
+    trip.boardingLock = undefined;
+    trip.consecutiveEtaMissing = 0;
+    trip.infoModeEnabled = true;
+    stats.etaMissingDemoted += 1;
+    await deleteProgress(env.TRIPS, trip.token);
+    await putTrip(env.TRIPS, trip);
+    await fireTrainReconfirmPush(trip, env, deps, stats, now, log, generatePushId);
     return;
   }
   trip.consecutiveEtaMissing = nextMissCount;

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -435,6 +435,19 @@ export interface TripEndedAlertPushPayload {
   corrId?: string;
 }
 
+/**
+ * #2157 (2026-08-05 결정 A) — eta-missing lock detach 시 발사되는 재확인 alert push의 `data`
+ * 필드. trip을 강제 종료하지 않고 lock만 해제 + lockless 강등하므로 `TripEndedAlertPushPayload`와
+ * 달리 `reason` 필드가 없다 — trip은 살아있고 종료 사유가 아니다. device는 `aps.alert`로 OS가
+ * 이미 banner를 띄우므로 `data`는 pushId dedup 용도로만 소비한다(trip-ended alert와 동일 패턴).
+ */
+export interface TrainReconfirmAlertPushPayload {
+  pushId: string;
+  kind: 'train-reconfirm';
+  tripToken: string;
+  sentAt: number;
+}
+
 /** APNs 토큰 환경. sandbox는 dev/preview/internal 빌드, production은 App Store/TestFlight. */
 export type ApnsEnv = 'sandbox' | 'production';
 

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -148,6 +148,17 @@ export interface Trip {
    */
   consecutiveEtaMissing?: number;
   /**
+   * #2157 (2026-08-05 결정 A, PR #2162 리뷰 P1) — eta-missing 임계 초과로 lock을 해제하며
+   * 재확인 alert push를 발사한 시점(demotion event epoch ms). trip-ended alert의 dedup
+   * 키(`tripToken:createdAt`)를 그대로 재사용하면 안 되는 이유: trip-ended는 발사 직후 trip이
+   * 삭제되지만 본 강등은 trip이 **생존**하고 재등록해도 `createdAt`이 보존된다(`isSameSession`).
+   * `createdAt` 기준 dedup은 같은 trip에서 두 번째 demotion이 발생해도 push가 조용히
+   * 미발사되는 회귀(사용자가 lock 상실을 통지받지 못함)를 낳는다. 매 demotion마다 이 필드를
+   * 새 `now`로 갱신해 dedup 키를 event 단위로 격리 — 같은 demotion의 중복 cron tick 발사는
+   * 막고, 새 demotion(재선택 후 재차 eta-missing)에 대한 재발사는 허용한다.
+   */
+  etaMissingDemotedAt?: number;
+  /**
    * #816 C — 사용자 opt-in lockless station-passed (UI: "전체역 보기").
    * BoardingLock 없는 trip에서도 station-passed(intermediate) 알림을 발사할지 여부.
    *


### PR DESCRIPTION
## 요약
- Closes #2157

열차번호 매칭 5사이클 연속 실패(eta-missing) 시 backend가 trip을 강제 종료하던 동작을 제거. lock만 해제하고 trip은 lockless로 유지 → "탑승 열차를 찾을 수 없어요 — 다시 확인해주세요" 재확인 alert push로 재선택(boardingPrompt/직접 탭)을 유도한다. 2026-08-05 결정 A. 결정1(#2154, 명시 확인 철학)과 일관 — 백엔드가 사용자 trip을 일방 종료하는 상황 자체를 제거.

## 변경 사항
- `backend/alarm-worker/src/scheduled.ts` — `handleEtaMissing`의 임계 초과 분기를 `endReason`별로 분리
  - `seoul-outage`(httpErrorCount>0): 기존 `cleanupTripWithLa` 유지 (수정 안 함)
  - 순수 `eta-missing`: `boardingLock=undefined` + `consecutiveEtaMissing=0` + `infoModeEnabled=true`로 lockless 강등, trip은 KV에 생존. `fireTrainReconfirmPush`로 재확인 alert push 1건 발사(KV dedup, 1 demotion event 1회 — 리뷰 P1 반영 이력 참조)
- `backend/alarm-worker/src/i18n.ts` — `trainReconfirmTitle`/`trainReconfirmBody` 4언어(ko/en/ja/zh) 추가
- `backend/alarm-worker/src/types.ts` — `TrainReconfirmAlertPushPayload` (`kind: 'train-reconfirm'`) 추가, `Trip.etaMissingDemotedAt`(demotion event epoch ms) 추가
- `ScheduledStats`에 `etaMissingDemoted`/`trainReconfirmFired` 카운터 추가
- `backend/alarm-worker/src/__tests__/scheduled.test.ts` — TDD:
  1. red: 기존 "5사이클 미매칭 시 trip-ended push + KV 삭제" 테스트를 실행해 현재(구) 동작 재현 확인
  2. green: 강등 동작(lock detach + trip 생존 + 재확인 push 1회 + 카운터 reset)으로 테스트 교체
  3. seoul-outage 회귀 가드 테스트 추가 (httpErrorCount>0이면 기존 trip-ended 경로 유지)
  4. dedup 테스트 추가 (KV stamp 존재 시 재확인 push 재발사 안 함)

seoul-outage 분기 판정 로직과 쿨다운(#1425) 로직 자체는 수정하지 않음(스펙 명시).

### 리뷰 반영 (2차 커밋)
- **[P1]** `trainReconfirmAlertDedupKey`가 처음에 `trip.createdAt` 기반이었는데, trip-ended push와 달리 본 강등은 trip이 **생존**하고 재등록해도 `createdAt`이 보존(`isSameSession`)돼 같은 trip의 **두 번째 demotion**에서 재확인 push가 첫 demotion의 dedup stamp에 막혀 조용히 미발사되는 회귀가 있었다. `Trip.etaMissingDemotedAt`(demotion 시점, `now`로 stamp)을 dedup 키에 사용하도록 변경 — "같은 demotion 중복 cron tick 차단" + "새 demotion 재발사 허용"을 모두 만족.
  - red 테스트 먼저 작성해 버그 재현 확인(`fires train-reconfirm push again on a second demotion of the same trip`) → key를 `etaMissingDemotedAt`로 교체 → green
  - 기존 same-tick dedup 가드 테스트(`does not re-fire train-reconfirm push when dedup KV already stamped`)는 회귀 없이 그대로 통과
- **[P2]** `infoModeEnabled = true` 강제 라인에 `#1370 L3 vanishLocklessTakeover` 선례 인용 주석 추가 — "시스템 fallback이 lockless 인계 경로를 강제 활성화, register 시 device 실제값으로 자연 정합화" 근거 명시

## Wire-completion 5단
1. **Orphan 없음** — 신규 함수(`fireTrainReconfirmPush`)는 module-internal, 신규 export(`TrainReconfirmAlertPushPayload`)는 `scheduled.ts`가 caller로 사용. N/A (orphan 없음, backend는 별도 orphan lint 대상 아님 — frontend `npm run lint:orphan`은 이번 PR에서 불변 파일 대상)
2. **V/X dashboard** — `trip_metrics` end_reason 분포(D1) + `ScheduledStats.etaMissingDemoted`/`trainReconfirmFired` (wrangler tail cron summary log). 배포 후 end_reason=eta-missing 비중이 줄고 etaMissingDemoted가 그만큼 늘어나는지로 fix 작동 여부 관측
3. **의존 PR** — N/A (device 수신 UX는 기존 `aps.alert` OS banner 경로 재사용, 앱 코드 변경 불필요)
4. **측정 plan** — 배포 후 1주 `trip_metrics` end_reason=eta-missing 0건 확인(D1 query) + wrangler tail `boarding-lock: eta-missing threshold — demoting to lockless` 로그 발생 빈도 관측
5. **Device verify** — 필요. 시나리오: 오토락이 잘못된 trainCode를 채운 trip이 5사이클 연속 미매칭 상태에 도달했을 때, trip이 종료되지 않고 "탑승 열차를 찾을 수 없어요" 알림을 받은 뒤 boardingPrompt 또는 BoardingTrainList 직접 탭으로 재선택이 가능한지, 그리고 재선택 후 다시 5사이클 미매칭되면 재확인 알림을 **또** 받는지(두 번째 demotion) 실기기 확인 필요

## 검증
- `npm test` (backend/alarm-worker): 71 test files / 2793 tests 전부 pass. coverage ratchet floor(stmts 97 / branch 96 / funcs 98 / lines 97) 통과
- `npm run type-check` (backend/alarm-worker): pass

## 배포
배포는 하지 않음 — 사용자 결정 영역.
