### PR TITLE
fix(#2150): promptGeoContext Tier1 heal 갭 — non-null→non-null 전환도 heal 대상

### DIFF
--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -532,6 +532,11 @@ describe('useApnsTripRegistration', () => {
   });
 
   it('#703 — currentStation만 바뀌면 register 재호출 안 함', async () => {
+    // #2150 — cold-start currentStation을 route 위 유효 station(선릉, 2-020)으로 세팅해 첫
+    // register부터 promptContext를 확보한다(lastRegisterMissingContextRef=false 고정). 이렇게
+    // 하면 Tier 1 context-heal(별도 effect, #2130/#2150)이 전혀 발동하지 않아 이 테스트가 검증하려는
+    // "currentStation은 main register effect의 deps가 아니다" 항목만 순수하게 검증된다.
+    const initialStation: Station = { ...station, id: '2-020', name: '선릉' };
     const altStation: Station = { ...station, id: '2-023', name: '역삼' };
     const { rerender } = renderHook(
       ({ cs }: { cs: Station | null }) =>
@@ -541,9 +546,10 @@ describe('useApnsTripRegistration', () => {
           nextStationEtaSeconds: 120,
           currentStation: cs,
         }),
-      { initialProps: { cs: null as Station | null } },
+      { initialProps: { cs: initialStation as Station | null } },
     );
     await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+    expect(mockRegister.mock.calls[0][0].promptGeoContext).toBeDefined();
     rerender({ cs: station });
     rerender({ cs: altStation });
     await act(async () => {
@@ -1153,14 +1159,18 @@ describe('useApnsTripRegistration', () => {
     it('재시도 대기 중 다른 세션으로 실패 전환되면 옛 세션의 타이머를 clear하고 새 세션 attempt 0부터 시작', async () => {
       mockRegister.mockResolvedValue({ ok: false, status: 500 });
       const otherDestination: Station = { ...station, id: '2-023', name: '역삼' };
-
+      // #2150 — currentStation을 destination과 분리해 고정 null로 둔다. 이전에는 currentStation
+      // 이 destination(d)과 같은 값으로 묶여 있어, destination 전환이 곧 currentStation.id 전환도
+      // 발생시켜 Tier 1 context-heal effect가 추가 register를 유발했다(재시도 카운트 assertion과
+      // 무관한 관심사 충돌). 이 테스트의 목적은 순수 register-retry 세션 전환 검증이므로
+      // currentStation을 고정(null)해 Tier 1 heal effect 자체가 재실행되지 않게 한다.
       const { rerender } = renderHook(
         ({ d }: { d: Station }) =>
           useApnsTripRegistration({
             route: directRoute,
             destination: d,
             nextStationEtaSeconds: 120,
-            currentStation: d,
+            currentStation: null,
           }),
         { initialProps: { d: station } },
       );
@@ -1776,6 +1786,36 @@ describe('useApnsTripRegistration', () => {
       expect(mockRegister).toHaveBeenCalledTimes(2);
     });
 
+    it('Tier 1 — #2150 off-route(non-null, context 결손) → on-route(non-null) 전환에도 heal 발동', async () => {
+      // 최초 등록 시 currentStation이 route 밖(=destination과 동일, getNextStationName이 null을
+      // 반환하는 기존 fixture 패턴 재사용)이라 context 결손 → 이후 실제 탑승역(origin, route 위)으로
+      // non-null→non-null 전환. #2150 이전에는 prevWasNull 게이트가 이 전환을 무시해 heal이
+      // 영구히 발동하지 않았다(promptContext 결손 영속).
+      const { rerender } = renderHook(
+        ({ cs }: { cs: Station | null }) =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: cs,
+          }),
+        { initialProps: { cs: dest as Station | null } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      // cold-start 첫 register: currentStation === destination → context 결손(기존 동작)
+      expect(mockRegister.mock.calls[0][0].promptGeoContext).toBeUndefined();
+
+      // 실제 탑승역(route 위 유효 station)으로 non-null → non-null 전환
+      rerender({ cs: origin });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      const healed = mockRegister.mock.calls[1][0] as {
+        promptGeoContext?: { origin: { lat: number; lng: number } };
+        promptDisplay?: { originStation: string; line: string };
+      };
+      expect(healed.promptGeoContext?.origin).toEqual({ lat: origin.lat, lng: origin.lng });
+      expect(healed.promptDisplay).toEqual({ originStation: '대화', line: '3' });
+    });
+
     it('Tier 1 — currentStation이 이미 non-null로 시작한 trip은 heal 대상 아님(정상 등록 경로)', async () => {
       renderHook(() =>
         useApnsTripRegistration({
@@ -1790,6 +1830,50 @@ describe('useApnsTripRegistration', () => {
       await act(async () => {
         await Promise.resolve();
       });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+    });
+
+    it('Tier 1 — heal in-flight 중 unmount되면 후속 register 미발사 (cancelled 가드)', async () => {
+      const { rerender, unmount } = renderHook(
+        ({ cs }: { cs: Station | null }) =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: cs,
+          }),
+        { initialProps: { cs: null as Station | null } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+
+      // 첫 register(cold-start) 이후부터 APNS_TOKEN_KEY 조회를 의도적으로 지연시켜, heal의
+      // async IIFE가 `await AsyncStorage.getItem` 시점에 멈춰 있는 동안 unmount(cleanup)가
+      // 먼저 발생하도록 만든다.
+      let resolveToken!: (value: string) => void;
+      const deferredToken = new Promise<string>((resolve) => {
+        resolveToken = resolve;
+      });
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+        if (key === APNS_TOKEN_KEY) return deferredToken;
+        return null;
+      });
+
+      // null → origin(context 빌드 가능) 전환 — heal의 async IIFE가 시작돼 token 조회 시점에서
+      // 대기(deferredToken 미resolve)한다.
+      rerender({ cs: origin });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1); // 아직 heal register는 발사 안 됨(token 대기 중)
+
+      // heal의 token 조회가 완료되기 전에 unmount — effect cleanup이 cancelled=true를 세팅.
+      unmount();
+      resolveToken('token-abc');
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // cancelled 가드로 unmount 후 register가 추가로 발사되지 않는다.
       expect(mockRegister).toHaveBeenCalledTimes(1);
     });
 

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -772,21 +772,29 @@ export function useApnsTripRegistration({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [routeSig, destination?.id, boardingLockSig, subsurface, infoModeEnabled, sleepMode]);
 
-  // ── #2130 (B-1 Tier 1) — context-heal on currentStation null→non-null 전환 ──
+  // ── #2130 (B-1 Tier 1) — context-heal on currentStation 전환 (#2150: 결과 상태 기준) ──
   //
   // 위 main register effect는 #703 의도(POST 폭주 방지)로 currentStation을 deps에서 제외한다.
-  // 그 결과 cold-start register가 currentStation=null로 나가면(promptContext 결손) 이후
-  // GPS/fusion이 station을 해소해도 재등록 트리거가 없어 결손이 trip 내내 지속된다(#2130 근본
-  // 원인). 이 effect는 currentStation만을 deps로 갖는 별도 effect로 그 트리거를 신설한다 —
-  // main effect의 raw-deps 정책 자체는 건드리지 않는다.
+  // 그 결과 cold-start register가 currentStation=null(또는 route 밖 역)로 나가면(promptContext
+  // 결손) 이후 GPS/fusion이 station을 해소해도 재등록 트리거가 없어 결손이 trip 내내 지속된다
+  // (#2130 근본 원인). 이 effect는 currentStation만을 deps로 갖는 별도 effect로 그 트리거를
+  // 신설한다 — main effect의 raw-deps 정책 자체는 건드리지 않는다.
   //
-  // 조건: 활성 trip + 직전 register에 promptContext 없었음 + null→non-null 전환 + 세션당 미heal.
+  // #2150 — 최초 조건은 "null→non-null 전환"만 대상이었으나, 최초 등록 시 currentStation이
+  // route 밖 역(집 근처역 등, non-null이지만 context 빌드 실패)이면 이후 실제 탑승역(route 위,
+  // non-null)으로 전환돼도 non-null→non-null이라 heal이 영구히 미발동했다. 트리거를 "전환 종류"가
+  // 아니라 **결과 상태**(직전 register에 context 없었음 + currentStation이 바뀌어 non-null) 기준으로
+  // 재정의한다.
+  //
+  // 조건: 활성 trip + currentStation.id가 실제로 바뀜 + 새 값이 non-null + 직전 register에
+  // promptContext 없었음 + 세션당 미heal.
   useEffect(() => {
-    const prevWasNull = prevCurrentStationIdRef.current == null;
+    const prevStationId = prevCurrentStationIdRef.current;
     prevCurrentStationIdRef.current = currentStation?.id ?? null;
 
     if (!route || !destination) return; // trip 없음 — heal 대상 아님(trip-end 분기가 별도 reset).
-    if (!prevWasNull || currentStation == null) return; // null→non-null 전환만 대상.
+    if (currentStation == null) return; // 결과가 non-null인 전환만 대상.
+    if (prevStationId === currentStation.id) return; // 실질적 전환 없음(mount 시 lazy init 포함).
     if (!lastRegisterMissingContextRef.current) return; // 직전 register에 이미 context 있었음.
 
     const sessionKey = `${routeSig}:${destination.id}`;


### PR DESCRIPTION
Closes #2150

## 배경
boardingPrompt 7일 연속 displayed=0 원인 중 device 측 갭. backend `evaluateAndMaybeFireBoardingPrompt`는 `trip.promptGeoContext && trip.promptDisplay`가 없으면 게이트 평가 전 hard return한다.

## 결함
`useApnsTripRegistration.ts`의 Tier1 context-heal effect가 `prevWasNull && currentStation != null`(null→non-null 전환)에서만 발동했다. 최초 등록 시 currentStation이 route 밖 역(집 근처역)이면 context가 결손된 채로 저장되고, 이후 실제 탑승역(route 위, non-null)으로 전환돼도 non-null→non-null이라 heal이 미발동 — context 결손이 trip 내내 영속됐다.

## 수정
- Tier1 heal 트리거를 "전환 종류"가 아니라 **결과 상태** 기준으로 재정의: `prevStationId !== currentStation.id`(실질적 전환) + `currentStation`이 non-null + 직전 register가 context 결손이었으면 heal 시도.
- `buildBoardingPromptContext` 호출 조건은 변경하지 않음(surgical).
- 기존 Tier2(subsurface) heal 경로 변경 없음.

## 테스트 (TDD)
1. 재현 red: off-route(non-null, context 결손) → on-route(non-null) 전환 시 heal 미발동을 먼저 확인(수정 전 fail).
2. green: 수정 후 pass. 기존 null→non-null / Tier2 케이스 회귀 가드 유지.
3. 기존 pre-existing 테스트 2건(`#703 — currentStation만 바뀌면 register 재호출 안 함`, `재시도 대기 중 다른 세션으로 실패 전환` 회귀)이 새 heal 트리거 범위 확장과 우연히 충돌 — 두 테스트 모두 currentStation을 heal과 무관한 값으로 조정해 원래 검증 의도만 순수하게 유지.
4. Tier1 heal in-flight 중 unmount(cancelled 가드) 커버리지 테스트 추가.
5. 커버리지 100% 유지, `npm run type-check` pass.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (신규 export 없음).
2. **V/X dashboard** — DebugModal Boarding Prompt 섹션(promptGeoContext/promptDisplay 존재 여부) + backend wrangler tail `boardingPromptSkippedNoContext` counter(별도 카운터 노출 이슈와 연동).
3. **의존 PR** — N/A (device-only).
4. **측정 plan** — 다음 실탑승 시 register payload에 promptGeoContext 포함 여부 확인 + wrangler tail에서 SkippedNoContext 미출현 확인.
5. **Device verify** — 실기기 1 trip 필요 — route 설정 후 off-route 위치(집 근처역)에서 시작해 탑승역으로 이동하는 시나리오.

## Test plan
- [x] `npm test` — 425 suites, 9065 tests pass, coverage 100%
- [x] `npm run type-check` — pass
- [x] `npm run lint:orphan` — 0 orphan
- [ ] 실기기 1 trip 검증 (사용자 담당)