### PR TITLE
fix(backend): boardingPrompt 15분 신선도 게이트 기준 시각 재정의 (#2153)

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -4566,6 +4566,67 @@ describe('runScheduled — boarding-prompt 9단 게이트 (#819)', () => {
     expect(stats.boardingPromptEvaluated).toBe(1);
   });
 
+  // #2153 — 신선도 게이트 기준 시각 재anchor. route 설정(createdAt) 후 20분 지나 출발역에
+  // 근접(집/사무실에서 미리 경로 설정 후 이동하는 흔한 패턴)해도 근접 관측 시각을 기준으로
+  // 15분 창을 재계산해야 한다. createdAt 기준이면 이 케이스가 SkippedStale로 막힌다(#2153 RCA).
+  it('#2153 — route 설정 20분 후 출발역 근접 관측이면 anchor 재정의로 SkippedStale 아님', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({
+        createdAt: NOW - 20 * 60 * 1000,
+        promptGeoContext: {
+          origin: { lat: 0, lng: 0 },
+          nextStation: { lat: 0, lng: 0.01 },
+          direction: 'up',
+          // 근접 관측: distance - accuracy = 40m, margin(150m) 이내.
+          originDistanceM: 50,
+          originAccuracyM: 10,
+        },
+      }),
+    );
+    await seedHappySeries(kv);
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+
+    const stats = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl));
+
+    // anchor 재정의 후 기대값: 근접 관측 시점(현재 cycle)이 anchor이므로 stale 아님.
+    expect(stats.boardingPromptSkippedStale).toBe(0);
+    expect(stats.boardingPromptEvaluated).toBe(1);
+  });
+
+  // #2153 — 근접 관측 시각(originProximityAt)이 최초 1회만 stamp되어 이후 cycle의 anchor로
+  // 보존된다. createdAt이 아니라 이 stamp 기준으로 15분 초과 시 다시 stale이어야 한다.
+  it('#2153 — 근접 관측 시각이 stamp되어 보존 — 관측 후 15분+ 경과하면 다시 SkippedStale', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeUnlockedTrip({
+        createdAt: NOW - 20 * 60 * 1000,
+        promptGeoContext: {
+          origin: { lat: 0, lng: 0 },
+          nextStation: { lat: 0, lng: 0.01 },
+          direction: 'up',
+          originDistanceM: 50,
+          originAccuracyM: 10,
+        },
+      }),
+    );
+    await seedHappySeries(kv);
+    const fetchImpl1 = vi.fn(async () => new Response(null, { status: 200 })) as unknown as typeof fetch;
+    const stats1 = await runScheduled(makeEnv(kv), makeBoardingPromptDeps(fetchImpl1));
+    expect(stats1.boardingPromptSkippedStale).toBe(0);
+
+    // 두 번째 cycle: 근접 관측 시각(첫 cycle의 NOW) 기준 16분 경과 — 여전히 근접이어도 stale.
+    await seedHappySeries(kv);
+    const fetchImpl2 = vi.fn() as unknown as typeof fetch;
+    const stats2 = await runScheduled(makeEnv(kv), {
+      ...makeBoardingPromptDeps(fetchImpl2),
+      now: () => NOW + 16 * 60 * 1000,
+    });
+    expect(stats2.boardingPromptSkippedStale).toBe(1);
+  });
+
   it('9단 통과 + APNs 200 → alert push 발사 + state.fired 영구화', async () => {
     const kv = new InMemoryKV();
     await putTrip(kv as unknown as KVNamespace, makeUnlockedTrip());

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -831,6 +831,10 @@ app.post('/trips', async (c) => {
           boardingPromptState: existing.boardingPromptState,
           // #916 follow-up B — same session에선 같은 trip이므로 그대로 보존.
           lastAutoPromptedAt: existing.lastAutoPromptedAt,
+          // #2153 — 신선도 게이트 anchor도 backend-only state. re-register마다 incoming(항상
+          // undefined — device가 보내지 않는 필드)으로 덮이면 매 재등록마다 anchor가 사라져
+          // createdAt fallback으로 되돌아가는 회귀가 생긴다. same session이면 그대로 보존.
+          originProximityAt: existing.originProximityAt,
         }
       : {
           ...incoming,

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -609,9 +609,13 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   boardingPromptSkippedNoContext: number;
   /**
-   * #2130 (Part B-be-1) — trip 등록(`createdAt`) 후 `PROMPT_FRESHNESS_MS`(15분)가 지나
-   * boarding-prompt 자격이 만료돼 skip한 누적 횟수. 오래된 lockMissing trip에 뒤늦게 발사되는
-   * stale prompt를 차단 — 0이 아니면 device 재등록 주기 또는 사용자 응답 지연 분포를 시사.
+   * #2130 (Part B-be-1) — boarding-prompt 신선도 게이트(`PROMPT_FRESHNESS_MS`, 15분) 만료로 skip한
+   * 누적 횟수. 오래된 lockMissing trip에 뒤늦게 발사되는 stale prompt를 차단 — 0이 아니면 device
+   * 재등록 주기 또는 사용자 응답 지연 분포를 시사.
+   *
+   * #2153 — 기준 시각(anchor)은 route 설정 시각(`trip.createdAt`)이 아니라 출발역 근접을 처음
+   * 관측한 시각(`trip.originProximityAt`, 근접 관측 전엔 createdAt fallback)이다. 집/사무실에서
+   * 경로를 미리 설정하고 15분 뒤 탑승하는 패턴에서 이 게이트가 오차단하던 회귀를 닫는다.
    */
   boardingPromptSkippedStale: number;
   /**
@@ -4497,29 +4501,53 @@ export async function evaluateAndMaybeFireBoardingPrompt(
     return;
   }
 
-  // #2130 (Part B-be-1) — 신선도 게이트. trip 등록 후 15분 경과 시 boarding-prompt 자격 만료.
-  if (now - trip.createdAt > PROMPT_FRESHNESS_MS) {
+  let dirty = false;
+
+  // #2153 — 근접 게이트 판정을 신선도 게이트보다 먼저 계산해 anchor 재정의에 재사용한다.
+  // distance/accuracy 둘 다 있을 때만 평가(부재 = 지하/구 클라 관대 허용). 오차 고려 보수적
+  // 판정 — distance - accuracy > 150m 이면 "너무 멀다"로 본다.
+  const { originDistanceM, originAccuracyM } = geo;
+  const hasProximityReading = originDistanceM !== undefined && originAccuracyM !== undefined;
+  const isTooFarFromOrigin =
+    originDistanceM !== undefined &&
+    originAccuracyM !== undefined &&
+    originDistanceM - originAccuracyM > PROMPT_PROXIMITY_MARGIN_M;
+  // 근접 관측 = distance/accuracy 존재 + margin 이내(=too-far 아님). 부재(지하 등)는 근접
+  // "관측"이 아니므로 anchor stamp 대상이 아니다 (기존 관대 허용 정책과는 별개 축).
+  const isNearOrigin = hasProximityReading && !isTooFarFromOrigin;
+
+  // #2153 — trip 등록 후 최초로 출발역 근접을 관측한 cycle의 시각을 1회만 stamp. 이후
+  // cycle에서는 이 anchor를 보존(재관측마다 now로 계속 갱신하면 게이트가 무력화된다).
+  if (isNearOrigin && trip.originProximityAt === undefined) {
+    trip.originProximityAt = now;
+    dirty = true;
+  }
+
+  // #2153 — 신선도 게이트 기준 시각(anchor) 재정의. route 설정 시각(`createdAt`)이 아니라
+  // "탑승 근접 시각"(`originProximityAt`) 기준으로 15분 창을 판정한다. 근접 관측 전(stamp
+  // 미존재)에는 fallback으로 createdAt을 그대로 쓴다 — 근접 전에는 아래 근접 게이트가 이미
+  // 발사를 차단하므로 창을 보수적으로 연장하는 효과가 없다(#2153 스펙).
+  const freshnessAnchor = trip.originProximityAt ?? trip.createdAt;
+  if (now - freshnessAnchor > PROMPT_FRESHNESS_MS) {
     stats.boardingPromptSkippedStale += 1;
     log('boarding-prompt: skip (stale, past freshness window)', {
       token: trip.token.slice(0, 8),
-      ageMs: now - trip.createdAt,
+      ageMs: now - freshnessAnchor,
+      anchoredToProximity: trip.originProximityAt !== undefined,
     });
+    if (dirty) await putTrip(env.TRIPS, trip);
     return;
   }
 
-  // #2130 (Part B-be-1) — 근접 게이트. distance/accuracy 둘 다 있을 때만 평가(부재 = 지하/구
-  // 클라 관대 허용). 오차 고려 보수적 차단 — distance - accuracy > 150m 이면 skip.
-  if (
-    geo.originDistanceM !== undefined &&
-    geo.originAccuracyM !== undefined &&
-    geo.originDistanceM - geo.originAccuracyM > PROMPT_PROXIMITY_MARGIN_M
-  ) {
+  // #2130 (Part B-be-1) — 근접 게이트. isTooFarFromOrigin이면 발사 skip.
+  if (isTooFarFromOrigin) {
     stats.boardingPromptSkippedTooFar += 1;
     log('boarding-prompt: skip (too far from origin)', {
       token: trip.token.slice(0, 8),
       originDistanceM: geo.originDistanceM,
       originAccuracyM: geo.originAccuracyM,
     });
+    if (dirty) await putTrip(env.TRIPS, trip);
     return;
   }
 
@@ -4543,6 +4571,7 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       token: trip.token.slice(0, 8),
       ageMs: now - trip.lastAutoPromptedAt,
     });
+    if (dirty) await putTrip(env.TRIPS, trip);
     return;
   }
 
@@ -4553,7 +4582,6 @@ export async function evaluateAndMaybeFireBoardingPrompt(
   const fusion = await runFusionStep(trip, env, now, deps.archFlag);
   // #837 P2-3 — drift 카운트는 fusion 외부 (SRP). fusion 결과 직후 동일 시점/조건으로 평가.
   maybeCountDrift(fusion.kalmanPrior, fusion.posMetrics, stats, now);
-  let dirty = false;
   // phase 분류 결과가 있으면 trip에 stamp — 다음 cycle hysteresis 입력 + lockless 가드용 상태.
   if (fusion.phaseState) {
     trip.stationPhase = fusion.phaseState;

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -277,6 +277,21 @@ export interface Trip {
    * device 쪽 null-graceful 분기(양쪽 null이면 기존 동작 100% 유지)로 자연 fallback.
    */
   corrId?: string;
+  /**
+   * #2153 — boarding-prompt 신선도 게이트의 기준 시각(anchor). `evaluateAndMaybeFireBoardingPrompt`가
+   * `trip.promptGeoContext`로 출발역 근접(§근접 게이트, distance - accuracy ≤ margin)을 처음
+   * 관측한 cron cycle의 시각을 backend가 자체 stamp한다 — device가 별도로 송신하는 필드가 아니다.
+   *
+   * 배경(#2130 RCA): 기존엔 `trip.createdAt`(route 설정 시각) 기준 15분 창을 썼다. 집/사무실에서
+   * 경로를 미리 설정하고 15분 뒤 탑승하는 흔한 패턴에서 프롬프트 발사 자격이 탑승 전에 만료됐다.
+   * `originProximityAt`은 "탑승 근접 시각"을 별도로 anchor해 이 오차단을 막는다.
+   *
+   * 최초 근접 관측 시 1회만 stamp하고 이후 cycle에도 보존(재등록 시에도 `existing` 값 유지) —
+   * 매 cycle now로 계속 갱신하면 anchor가 끝없이 밀려 게이트가 사실상 무력화된다.
+   * 근접 관측 전(부재)에는 fallback으로 `trip.createdAt` 기준을 그대로 사용 — 근접 전에는
+   * 근접 게이트가 이미 발사를 차단하므로 창을 보수적으로 연장하는 효과가 없다.
+   */
+  originProximityAt?: number;
 }
 
 /**


### PR DESCRIPTION
Closes #2153

## 배경
#2130이 도입한 boardingPrompt 신선도 게이트가 `now - trip.createdAt > 15분`이면 skip(`boardingPromptSkippedStale`)했다. `trip.createdAt`은 **route 설정 시각**이라, 집/사무실에서 경로를 미리 설정하고 15분 뒤 탑승하는 흔한 패턴에서 프롬프트 발사 자격이 탑승 전에 만료됐다. 오토락 삭제 후 프롬프트가 유일한 lock 진입점이라 이 오차단은 치명적.

## 변경 (v2 — 리뷰 P1 반영, device+backend 양단)
- `Trip.originProximityAt` 필드 추가 — 출발역 근접(distance - accuracy ≤ 150m)을 처음 관측한 시각을 backend가 1회만 stamp, 이후 재등록/재관측에도 보존.
- 신선도 게이트 anchor를 `trip.createdAt`(route 설정 시각)에서 `trip.originProximityAt ?? trip.createdAt`(탑승 근접 시각, 근접 관측 전 fallback createdAt)으로 재정의.
- **리뷰에서 지적된 P1 결함**: 최초 구현(v1)은 anchor 입력을 `trip.promptGeoContext.originDistanceM/originAccuracyM`(POST /trips register 시점 스냅샷)에만 의존했다. 이 필드는 `useApnsTripRegistration.ts`의 register effect가 `currentStation`을 deps에서 제외(#703)하기 때문에 **재등록 트리거가 없으면 갱신되지 않는 정적 스냅샷**이다 — 집에서 route 설정 후 재등록 없이 도보로 이동하는 시나리오에서 근접 관측이 영영 발생하지 않아 원래 버그가 재현될 수 있었다.
- **v2 수정(리뷰어 옵션 3 채택)**: 기존 `POST /position` 채널(10초 주기, 재등록과 무관)에도 근접 신호를 흘린다.
  - `boardingPrompt.ts`: `isNearOrigin(distanceM, accuracyM)` 순수 함수로 근접 판정을 분리 — cron 경로(`scheduled.ts`)와 `/position` 경로가 동일 로직 공유.
  - backend `index.ts`: `/position` 핸들러에 `parseOriginProximityFields` + `stampOriginProximityIfNeeded` 추가. **KV write 최소화** — 근접(margin 이내)일 때만 trip을 읽고, 이미 stamp된 trip은 재-write하지 않음(trip당 최초 1회만 write, CF KV free tier quota 보호). 매 10초 write는 발생하지 않는다.
  - device `positionUpload.ts`: `withOriginProximity` + `readTripOriginCoords` 추가. `TRIP_ORIGIN_KEY`(destination 설정 시 캡처된 고정 출발역 좌표, #700 — route 설정 후 변하지 않음)를 읽어 매 `/position` 호출마다 **신선한 GPS fix** 기준으로 거리를 재계산해 payload에 동봉. 재등록과 무관하게 실시간 anchor 입력을 backend에 공급.
  - cron 쪽 기존 stamp 로직(register/heal로 이미 갱신된 케이스)은 보조 경로로 유지.
- **device 변경 포함** — 이 결함은 device(정적 스냅샷 소스)와 backend(anchor 소비)가 같은 결함의 양단이라 별도 PR로 분리하지 않고 같은 PR에 유지(리뷰 지시).
- dead code 제거: freshness/too-far skip 분기의 도달 불가 `if (dirty) await putTrip(...)` 제거 — `dirty=true`는 `nearOrigin=true`와만 동시 성립하므로 두 skip 조건과 상호배타적이라 그 지점 도달이 불가능했다.

## 테스트 (TDD)
1. red: route 설정 20분 후 출발역 근접 관측 → 기존 코드에서 `SkippedStale`로 막히는 재현 테스트(cron 경로) 작성 후 실패 확인.
2. red: 재등록 없이 `/position`만으로 근접 도달 시 `originProximityAt`이 stamp되는 시나리오 재현 테스트(backend `/position` 핸들러) 작성 후 실패 확인.
3. red: device `withOriginProximity`가 `TRIP_ORIGIN_KEY` 좌표 대비 매 호출 신선한 거리를 계산해 첨부하는 시나리오 작성 후 실패 확인.
4. green: 세 red 모두 구현 후 통과 + anchor stamp 보존(최초 1회만, 재-write 없음) + 재만료(anchor 기준 15분+ 경과 시 다시 stale) 회귀 가드.
5. 기존 `#2130` 15분/근접 게이트 테스트 + `#834`/`#828` position 채널 테스트 전체 회귀 없음 확인.

## Wire-completion 5단
1. **Orphan** — `npm run lint:orphan` pass. 신규 export(`isNearOrigin`, `withOriginProximity`, `readTripOriginCoords`, `parseOriginProximityFields`, `stampOriginProximityIfNeeded`)는 모두 실제 caller 보유(uploadPosition / POST-/position 핸들러 / cron 경로).
2. **V/X dashboard** — `boardingPromptSkippedStale` counter(cron summary log). 로그에 `anchoredToProximity` 필드 추가해 anchor 출처(근접 관측 vs createdAt fallback) 구분 가능.
3. **의존 PR** — 없음(N/A). 이 PR 자체가 device+backend 양단을 포함한다(리뷰 지시로 분리하지 않음).
4. **측정 plan** — 배포 후 실탑승에서 `boardingPromptSkippedStale` 미출현(정상 케이스) 확인. 로그 쿼리: cron summary의 `boardingPromptSkippedStale` 값 + `anchoredToProximity` 분포.
5. **Device verify** — 경로 설정 → 재등록 트리거 없이 15분+ 도보 이동 → 출발역 도착/탑승 시나리오 1회 실기기 필요 (v1에서 놓쳤던 케이스 그대로 검증).