### PR TITLE
fix(#2164): promptGeoContext Tier1 heal 가드 — 시도 기준→성공 기준 전환

### DIFF
--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -57,6 +57,7 @@ import type { Route } from '../../../../shared/utils/stationRoute';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../../shared/constants/storageKeys';
 import {
   BOARDING_LOCK_RELEASE_DEBOUNCE_MS,
+  CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION,
   CONTEXT_HEAL_TIER2_DELAY_MS,
   REGISTER_RETRY_BACKOFF_MS,
 } from '../../../../shared/constants/boardingLock';
@@ -1722,8 +1723,9 @@ describe('useApnsTripRegistration', () => {
       expect(healed.promptDisplay).toEqual({ originStation: '대화', line: '3' });
     });
 
-    it('Tier 1 — heal이 실패(context 여전히 결손)해도 같은 세션에서 재시도하지 않는다 (1회 가드)', async () => {
-      // currentStation === destination이면 buildBoardingPromptContext가 null 반환(기존 동작).
+    it('Tier 1 (#2164) — register 발사는 context build 성공 시에만: build 실패(off-route) 전환은 POST 없이 skip, 세션도 잠기지 않는다', async () => {
+      // currentStation === destination이면 buildBoardingPromptContext가 null 반환(기존 동작) —
+      // "off-route" 전환의 fixture로 재사용.
       const { rerender } = renderHook(
         ({ cs }: { cs: Station | null }) =>
           useApnsTripRegistration({
@@ -1736,14 +1738,68 @@ describe('useApnsTripRegistration', () => {
       );
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
 
-      // null → dest(=destination, context 여전히 결손) 전환 — heal 1회 시도
+      // null → dest(=destination, context 빌드 실패) 전환 — build 실패로 POST 자체가 나가지
+      // 않아야 한다(#2164 이전에는 build 실패에도 무조건 register를 쐈다).
       rerender({ cs: dest });
-      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
-      expect(mockRegister.mock.calls[1][0].promptGeoContext).toBeUndefined();
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
 
-      // 같은 세션 안에서 다시 null → origin(context 빌드 가능한 station) 전환이 와도
-      // 세션당 1회 가드로 추가 heal 없음.
-      rerender({ cs: null });
+      // dest → 강남(2호선, route 밖 — build 실패) 전환도 마찬가지로 POST 없이 skip.
+      rerender({ cs: station });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+    });
+
+    it('Tier 1 (#2164) — off-route→off-route→on-route 전환에도 heal이 발동한다 (실패 시 세션 미잠금, 회귀 재현)', async () => {
+      // #2164 배경 재현: cold-start 이후 첫 실질 전환이 다시 off-route 역이면(GPS 흔들림 등)
+      // 구 코드는 그 1회 실패 "시도"만으로 세션을 영구 잠가, 이후 진짜 탑승역(on-route) 전환에
+      // heal이 재발동하지 않았다. 새 코드는 실패 시 세션을 잠그지 않아 이후 on-route 전환에서
+      // 정상적으로 heal이 성공해야 한다.
+      const { rerender } = renderHook(
+        ({ cs }: { cs: Station | null }) =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: cs,
+          }),
+        { initialProps: { cs: null as Station | null } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockRegister.mock.calls[0][0].promptGeoContext).toBeUndefined();
+
+      // off-route 전환 1: null → dest(=destination, build 실패) — POST 없이 skip.
+      rerender({ cs: dest });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // off-route 전환 2: dest → 강남(2호선, route 밖, build 실패) — 여전히 POST 없이 skip.
+      rerender({ cs: station });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // on-route 전환: 강남 → origin(route 위, build 성공) — heal이 정상 발동해 context를 포함한
+      // register가 발사돼야 한다. #2164 이전에는 위 두 실패 시도 중 첫 번째에서 이미 세션이
+      // 영구 잠겨 이 register가 발생하지 않았다.
+      rerender({ cs: origin });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      const healed = mockRegister.mock.calls[1][0] as {
+        promptGeoContext?: { origin: { lat: number; lng: number } };
+        promptDisplay?: { originStation: string; line: string };
+      };
+      expect(healed.promptGeoContext?.origin).toEqual({ lat: origin.lat, lng: origin.lng });
+      expect(healed.promptDisplay).toEqual({ originStation: '대화', line: '3' });
+
+      // 성공 후 세션이 잠겨 추가 전환에도 재heal 없음(기존 보장 보존).
+      rerender({ cs: dest });
       await act(async () => {
         await Promise.resolve();
       });
@@ -1752,6 +1808,47 @@ describe('useApnsTripRegistration', () => {
         await Promise.resolve();
       });
       expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+
+    it(`Tier 1 (#2164) — 세션당 POST 상한(${CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION}회) 도달 시 추가 heal 중단 (POST 네트워크 실패 반복)`, async () => {
+      // build는 매번 성공하지만 backend POST가 계속 실패({ok:false})하는 상황 — 폭주 방지
+      // 백스톱(CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION)이 station 전환이 반복돼도 세션당
+      // heal POST 횟수를 제한해야 한다.
+      mockRegister.mockResolvedValue({ ok: false, status: 500 });
+      const mid = st('3-002'); // 주엽 — origin/dest 사이 실제 3호선 역, build 항상 성공.
+      const alternating = [origin, mid];
+
+      const { rerender } = renderHook(
+        ({ cs }: { cs: Station | null }) =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: cs,
+          }),
+        { initialProps: { cs: null as Station | null } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1)); // cold-start, context 결손
+
+      // 상한만큼 heal POST 시도 — build는 매번 성공하지만 POST 네트워크는 계속 실패.
+      for (let i = 0; i < CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION; i++) {
+        const nextCallCount = i + 2; // cold-start(1) + 이번까지의 heal 시도 수
+        rerender({ cs: alternating[i % alternating.length] });
+        // eslint-disable-next-line no-loop-func -- nextCallCount는 매 반복 고정값 캡처, closure 문제 없음.
+        await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(nextCallCount));
+      }
+      const cappedCallCount = CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION + 1;
+
+      // 상한 도달 — 이후 전환은 build가 성공해도 추가 POST 없음.
+      rerender({ cs: alternating[CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION % alternating.length] });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      rerender({ cs: alternating[(CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION + 1) % alternating.length] });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(cappedCallCount);
     });
 
     it('Tier 1 — heal 성공 후 station이 다시 흔들려도(null→non-null 재전환) 추가 heal 없음 (context 이미 보유)', async () => {
@@ -1875,6 +1972,123 @@ describe('useApnsTripRegistration', () => {
       });
       // cancelled 가드로 unmount 후 register가 추가로 발사되지 않는다.
       expect(mockRegister).toHaveBeenCalledTimes(1);
+    });
+
+    it('Tier 1 (#2164) — heal 시도 시 APNs token 미가용이면 in-flight만 해제하고 조용히 skip', async () => {
+      let tokenAvailable = true;
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+        if (key === APNS_TOKEN_KEY) return tokenAvailable ? 'token-abc' : null;
+        return null;
+      });
+
+      const { rerender } = renderHook(
+        ({ cs }: { cs: Station | null }) =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: cs,
+          }),
+        { initialProps: { cs: null as Station | null } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1)); // cold-start, context 결손
+
+      // heal 시도 시점에 token이 미가용해지면(예: 토큰 만료/재발급 지연) build는 성공해도
+      // register 자체가 나가지 않고 in-flight 표시만 해제돼야 한다(세션 미잠금 유지).
+      tokenAvailable = false;
+      rerender({ cs: origin });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1); // token 없음 — heal register 미발사
+
+      // token이 다시 가용해지고 새 전환이 오면 heal이 정상 재시도된다(세션이 잠기지 않았으므로).
+      tokenAvailable = true;
+      rerender({ cs: dest });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      rerender({ cs: origin });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      expect(mockRegister.mock.calls[1][0].promptGeoContext).toBeDefined();
+    });
+
+    it('Tier 1 (#2164) — heal register 완료 직전 unmount되면 세션 잠금 등 부작용 없이 조용히 종료 (cancelled 가드)', async () => {
+      let resolveRegister!: (value: { ok: boolean }) => void;
+      const deferred = new Promise<{ ok: boolean }>((resolve) => {
+        resolveRegister = resolve;
+      });
+      mockRegister.mockResolvedValueOnce({ ok: true }); // cold-start
+      mockRegister.mockImplementationOnce(() => deferred); // heal 시도 — pending 상태로 멈춤.
+
+      const { rerender, unmount } = renderHook(
+        ({ cs }: { cs: Station | null }) =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: cs,
+          }),
+        { initialProps: { cs: null as Station | null } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+
+      rerender({ cs: origin }); // heal 시도 시작 — registerActiveTrip이 deferred라 결과 대기.
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+
+      // register 완료(resolve) 이전에 unmount — effect cleanup이 cancelled=true를 세팅.
+      unmount();
+      resolveRegister({ ok: true });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // cancelled 가드로 unmount 이후 추가 register/크래시 없이 조용히 종료.
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+
+    it('Tier 1 (#2164) — 이미 heal 성공한 세션은 이후 register가 다시 실패해도 재heal하지 않는다 (성공 잠금 영속)', async () => {
+      const { rerender } = renderHook(
+        ({ cs }: { cs: Station | null }) =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: cs,
+          }),
+        { initialProps: { cs: null as Station | null } },
+      );
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1)); // cold-start, context 결손
+
+      // heal 성공 — 세션 잠금.
+      rerender({ cs: origin });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      expect(mockRegister.mock.calls[1][0].promptGeoContext).toBeDefined();
+
+      // 이후 push token 갱신 경로(#2129)로 같은 입력이 재register되는데, 이번엔 backend가
+      // 일시 실패({ok:false})한다 — lastRegisterMissingContextRef가 다시 "결손"으로 flip된다.
+      mockRegister.mockResolvedValueOnce({ ok: false, status: 500 });
+      const pushTokenHandler = mockAddPushTokenListener.mock.calls[0][0] as (event: {
+        data: string;
+      }) => void;
+      await act(async () => {
+        pushTokenHandler({ data: 'token-refreshed' });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(3);
+
+      // 다른 station으로 전환해도 이미 이 세션은 heal에 성공한 적이 있으므로(healedSessionKeyRef
+      // 잠금 영속) 추가 heal register가 발사되지 않는다.
+      rerender({ cs: dest });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      rerender({ cs: origin });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(3);
     });
 
     describe('Tier 2 — 지하 fallback (route 출발역, 스탬프 없이)', () => {

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -37,6 +37,7 @@ import {
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
 import {
   BOARDING_LOCK_RELEASE_DEBOUNCE_MS,
+  CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION,
   CONTEXT_HEAL_TIER2_DELAY_MS,
   REGISTER_RETRY_BACKOFF_MS,
 } from '../../../shared/constants/boardingLock';
@@ -371,9 +372,22 @@ export function useApnsTripRegistration({
   // #2130 (B-1) — 직전 register가 promptContext 없이 나갔는지 여부. Tier 1 heal 트리거의
   // SSoT — registerFromLatestInputs가 매 호출마다 callRegister의 실제 결과로 갱신한다.
   const lastRegisterMissingContextRef = useRef(false);
-  // #2130 (B-1) — 이미 heal을 수행한 세션 key(`routeSig:destinationId`). Tier 1/Tier 2가
-  // 공유해 세션당 heal이 정확히 1회만 발동하도록 가드한다.
+  // #2130 (B-1) / #2164 — heal에 **성공**(context가 backend에 실제로 전달)한 세션
+  // key(`routeSig:destinationId`). Tier 1/Tier 2가 공유. #2164 이전에는 heal **시도**만으로
+  // (성공 여부 무관) 이 값을 세팅해, 실패한 시도가 세션을 영구 잠가 이후 진짜 탑승역 전환에도
+  // heal이 재발동하지 않는 회귀가 있었다 — 반드시 성공했을 때만 세팅한다.
   const healedSessionKeyRef = useRef<string | null>(null);
+  // #2164 — 세션당 heal POST 시도가 in-flight 중인지 추적. build 성공 후 register 완료까지의
+  // 짧은 창에서 같은 세션에 대해 Tier 1(currentStation 전환)과 Tier 2(60s 타이머)가 동시에
+  // 중복 발사하는 것을 막는다(healedSessionKeyRef는 완료 후에만 세팅되므로 그 사이엔 무방비).
+  const healInFlightSessionKeyRef = useRef<string | null>(null);
+  // #2164 — 세션당 heal POST 발사 횟수 백스톱. build는 성공했지만 POST 네트워크가 계속
+  // 실패하는 상황에서 station이 반복 전환돼도 무한 재시도로 backend rate limit(10/10min)을
+  // 위협하지 않도록 상한(`CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION`)을 둔다.
+  const healAttemptRef = useRef<{ sessionKey: string | null; count: number }>({
+    sessionKey: null,
+    count: 0,
+  });
   // #2130 (B-1 Tier 1) — 직전 렌더의 currentStation.id. null→non-null 전환 감지에 사용.
   // lazy init으로 mount 시점 값을 그대로 캡처 — 이미 non-null로 시작한 trip은 전환 대상이 아니다.
   const prevCurrentStationIdRef = useRef<string | null>(currentStation?.id ?? null);
@@ -434,9 +448,11 @@ export function useApnsTripRegistration({
     });
     // #767 — 두 경로 모두 동일 기준으로 lock sig를 추적해야 다음 cycle의 release 판정 정확도 유지.
     lastSentLockSigRef.current = lockSig(bl);
-    // #2130 (B-1) — 이번 register가 실제로 promptContext를 포함했는지 기록. 다음 currentStation
-    // null→non-null 전환 시 Tier 1 heal이 필요한지 판정하는 SSoT.
-    lastRegisterMissingContextRef.current = !result.hadPromptContext;
+    // #2130 (B-1) / #2164 — 이번 register가 실제로 context를 backend에 성공적으로 전달했는지
+    // 기록. 다음 currentStation 전환 시 Tier 1 heal이 필요한지 판정하는 SSoT. "성공"은 context
+    // build 성공(hadPromptContext) **+** POST 네트워크 성공(ok) 둘 다를 요구 — build만 성공하고
+    // 네트워크가 실패하면 backend는 여전히 context가 없으므로 다음 전환에서 재시도가 필요하다.
+    lastRegisterMissingContextRef.current = !(result.hadPromptContext && result.ok);
     // #2130 (B-1) — 성공한 context(fresh/override 무관)를 캐시에 반영. Tier 2 heal의 route-origin
     // 근사 context도 이 캐시를 통해 이후 정상 register(currentStation 여전히 null)에 이어져
     // "heal 직후 다음 register가 다시 결손"되는 회귀를 막는다.
@@ -463,7 +479,14 @@ export function useApnsTripRegistration({
     if (cs != null) return; // 이미 GPS로 해소됨 — Tier 2 대상 아님
     if (!sub) return; // 지하 판정 아님
     if (origin == null) return; // fallback 대상 route 출발역 없음
-    if (healedSessionKeyRef.current === sessionKey) return; // 이미 heal 완료(Tier 1 포함)
+    if (healedSessionKeyRef.current === sessionKey) return; // 이미 heal 성공(Tier 1 포함)
+    /* istanbul ignore next -- Tier 1은 currentStation이 non-null로 전환될 때만 in-flight를
+     * 세팅하는데, 바로 위 `cs != null` 가드가 이미 그 경우를 걸러낸다(이 지점 도달 시 cs는
+     * 항상 null). 또한 Tier 1의 effect cleanup은 currentStation.id가 바뀌는 매 렌더마다
+     * 동기적으로 in-flight를 지우므로, cs가 null로 유지되는 한 Tier 1의 in-flight가 이 시점까지
+     * 살아남는 경로가 현재 코드에 없다. 향후 리팩터로 그 보장이 깨질 경우를 대비한 방어적 가드
+     * (#2164 폭주 방지 belt-and-suspenders). */
+    if (healInFlightSessionKeyRef.current === sessionKey) return;
     const overrideContext = buildBoardingPromptContext({
       route: r,
       currentStation: origin,
@@ -626,6 +649,10 @@ export function useApnsTripRegistration({
         // 시점에 cancel했다 — 여기서 다시 clear할 필요 없음.)
         lastRegisterMissingContextRef.current = false;
         healedSessionKeyRef.current = null;
+        // #2164 — trip 종료 시 heal in-flight/attempt 상한 추적도 초기화 — 다음 trip이 새로
+        // 세션당 상한(CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION) 전체를 갖는다.
+        healInFlightSessionKeyRef.current = null;
+        healAttemptRef.current = { sessionKey: null, count: 0 };
         prevCurrentStationIdRef.current = null;
         // #1960: trip 종료 시 register 재시도 상태도 초기화 — 다음 trip이 새로 재시도 3회 기회를 갖는다.
         clearRegisterRetry();
@@ -786,8 +813,13 @@ export function useApnsTripRegistration({
   // 아니라 **결과 상태**(직전 register에 context 없었음 + currentStation이 바뀌어 non-null) 기준으로
   // 재정의한다.
   //
-  // 조건: 활성 trip + currentStation.id가 실제로 바뀜 + 새 값이 non-null + 직전 register에
-  // promptContext 없었음 + 세션당 미heal.
+  // 조건: 활성 trip + currentStation.id가 실제로 바뀜 + 새 값이 non-null + 직전 register가
+  // context를 backend에 성공적으로 전달하지 못함(build 실패 또는 POST 네트워크 실패) + 세션
+  // 미성공 + 세션당 POST 상한 미도달.
+  //
+  // #2164 — register 발사는 **context build가 성공할 때만**. build 실패(off-route 역 등)면
+  // POST 자체를 내지 않고 세션도 잠그지 않아 다음 전환에서 재시도를 허용한다(성공 기준 가드).
+  // 다만 build 성공 후 POST가 반복 실패하는 상황을 대비해 세션당 POST 발사 횟수에 상한을 둔다.
   useEffect(() => {
     const prevStationId = prevCurrentStationIdRef.current;
     prevCurrentStationIdRef.current = currentStation?.id ?? null;
@@ -795,21 +827,66 @@ export function useApnsTripRegistration({
     if (!route || !destination) return; // trip 없음 — heal 대상 아님(trip-end 분기가 별도 reset).
     if (currentStation == null) return; // 결과가 non-null인 전환만 대상.
     if (prevStationId === currentStation.id) return; // 실질적 전환 없음(mount 시 lazy init 포함).
-    if (!lastRegisterMissingContextRef.current) return; // 직전 register에 이미 context 있었음.
+    if (!lastRegisterMissingContextRef.current) return; // 직전 register가 이미 context 전달 성공.
 
     const sessionKey = `${routeSig}:${destination.id}`;
-    if (healedSessionKeyRef.current === sessionKey) return; // 세션당 1회 가드.
+    if (healedSessionKeyRef.current === sessionKey) return; // 세션 이미 heal 성공.
+    /* istanbul ignore next -- currentStation.id가 바뀌어야만 이 effect가 재실행되는데, React는
+     * deps 변경 시 이전 effect의 cleanup(이 함수 하단, in-flight를 항상 지움)을 새 effect
+     * body보다 먼저 동기 실행한다. 따라서 이 effect 스스로 인해 in-flight가 살아있는 채로 다시
+     * 진입하는 경로가 현재 코드에 없다(Tier 2의 in-flight 체크와 동일 성격의 방어적 가드). */
+    if (healInFlightSessionKeyRef.current === sessionKey) return; // 동일 세션 heal 진행 중.
+
+    // #2164 — build 성공 여부를 먼저 확인 — 실패하면 POST 자체를 내지 않는다(세션 미잠금,
+    // 상한도 소비하지 않음 — 다음 전환에서 다시 시도).
+    const healContext = buildBoardingPromptContext({
+      route,
+      currentStation,
+      destination,
+      lock: boardingLock,
+      gpsFix: latestInputsRef.current.gpsFix,
+    });
+    if (healContext == null) return; // build 실패 — graceful skip.
+
+    // #2164 — 세션당 POST 상한 백스톱(backend rate limit 보호).
+    if (healAttemptRef.current.sessionKey !== sessionKey) {
+      healAttemptRef.current = { sessionKey, count: 0 };
+    }
+    if (healAttemptRef.current.count >= CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION) {
+      logger.info(
+        `context-heal: 세션당 POST 상한(${CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION}) 도달 — 중단`,
+        sessionKey,
+      );
+      return;
+    }
 
     let cancelled = false;
+    healInFlightSessionKeyRef.current = sessionKey;
     void (async () => {
       const token = await AsyncStorage.getItem(APNS_TOKEN_KEY);
-      if (cancelled || !token) return;
-      // 가드를 먼저 세팅 — in-flight 중 동일 세션의 중복 heal 방지.
-      healedSessionKeyRef.current = sessionKey;
-      await registerFromLatestInputs(token);
+      if (cancelled) return;
+      if (!token) {
+        healInFlightSessionKeyRef.current = null;
+        return;
+      }
+      healAttemptRef.current.count += 1;
+      const result = await registerFromLatestInputs(token, { promptContextOverride: healContext });
+      if (cancelled) return;
+      healInFlightSessionKeyRef.current = null;
+      // #2164 — heal이 실제로 성공(context build + POST 네트워크 모두 성공)했을 때만 세션 잠금.
+      // 실패하면 잠그지 않아 다음 전환에서 재시도(상한까지) 허용.
+      if (result?.ok && result.hadPromptContext) {
+        healedSessionKeyRef.current = sessionKey;
+      }
     })();
     return () => {
       cancelled = true;
+      // #2164 — in-flight 도중 같은 세션의 다음 station 전환이 도착해 이 effect가 재실행/
+      // unmount되면, 아직 완료되지 않은 이번 시도의 in-flight 표시를 지워 다음 시도가 영구히
+      // 막히지 않게 한다(다른 세션으로 이미 갈아탄 값이면 조건 불일치로 건드리지 않음).
+      if (healInFlightSessionKeyRef.current === sessionKey) {
+        healInFlightSessionKeyRef.current = null;
+      }
     };
     // currentStation.id 전환만이 이 effect의 트리거 — route/destination 등은 closure로 최신값
     // 참조(gate 조건 평가용)하되 deps에는 넣지 않는다: 위 main effect가 이미 그 변경들을

--- a/src/shared/constants/boardingLock.ts
+++ b/src/shared/constants/boardingLock.ts
@@ -147,3 +147,22 @@ export const CONTEXT_HEAL_TIER2_DELAY_MS = 60_000;
  * 트리거하지 않아 #703(POST 폭주 방지) 의도를 보존한다.
  */
 export const REGISTER_RETRY_BACKOFF_MS: readonly number[] = [15_000, 30_000, 60_000];
+
+/**
+ * #2164 — Tier 1 context-heal(useApnsTripRegistration) 세션당 POST 상한 백스톱.
+ *
+ * 배경: #2130/#2150의 "세션당 1회 가드"는 heal **시도**(성공 여부 무관) 자체로 세션을 영구
+ * 잠갔다. 그 결과 cold-start 이후 첫 실질 전환이 또 다른 off-route 역(GPS 흔들림/인접역
+ * 플립)이면 그 1회 실패 시도로 잠기고, 이후 진짜 탑승역(on-route) 전환에도 heal이 재발동하지
+ * 않아 context 결손이 trip 내내 지속됐다.
+ *
+ * #2164 fix: 가드를 "성공 기준"으로 전환 — heal이 context 등록에 실제로 성공했을 때만 세션을
+ * 잠근다. 실패(build 실패 또는 POST 네트워크 실패) 시 다음 station 전환에서 재시도를 허용한다.
+ * 다만 무제한 재시도는 backend rate limit(10/10min)을 위협하므로, 세션당 heal POST 발사
+ * 횟수에 상한을 둔다. `REGISTER_RETRY_BACKOFF_MS.length`(3)와 동일한 상한으로 통일 — 실제
+ * 장애 상황이면 다음 정상 effect cycle(route/destination/lock 변경)에 맡긴다.
+ *
+ * context build 자체가 실패(off-route 역 등)한 경우는 이 상한에 포함하지 않는다 — POST를
+ * 내지 않으므로 backend 부담이 없고, 다음 전환에서 다시 시도할 기회를 줘야 하기 때문이다.
+ */
+export const CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION = 3;


### PR DESCRIPTION
Closes #2164

## 배경
`useApnsTripRegistration.ts`의 Tier 1 context-heal(#2130/#2150)은 heal **시도**(성공 여부 무관)만으로 세션을 영구 잠갔다. #2163으로 heal 트리거가 넓어진 뒤, cold-start 이후 첫 실질 전환이 또 다른 off-route 역(GPS 흔들림/인접역 플립)이면 그 1회 실패 시도로 잠기고, 이후 진짜 탑승역(on-route) 전환에도 heal이 재발동하지 않아 context 결손이 trip 내내 지속될 수 있었다.

## 변경
- `healedSessionKeyRef`: heal이 **성공**(context build 성공 + POST 네트워크 성공)했을 때만 세팅. 실패 시 세션을 잠그지 않아 다음 station 전환에서 재시도를 허용.
- register 발사는 **context build 성공 시에만**: `buildBoardingPromptContext`가 null을 반환하면(off-route 역 등) POST 자체를 내지 않고 세션도 미잠금 — 다음 전환에서 재시도.
- 신규 상수 `CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION`(=3, `src/shared/constants/boardingLock.ts`): build는 성공하지만 POST 네트워크가 반복 실패하는 상황에서 세션당 heal POST 발사 횟수를 제한 — backend rate limit(10/10min) 보호 백스톱.
- 신규 `healInFlightSessionKeyRef`: heal이 in-flight인 동안 Tier1 자기 자신 및 Tier2(60s fallback)와의 중복 발사 방지.
- `lastRegisterMissingContextRef` 판정 기준 확장: `hadPromptContext` 단독 → `hadPromptContext && ok` (build 성공했지만 네트워크가 실패하면 backend는 여전히 context가 없는 상태이므로 "결손"으로 간주).
- 기존 "세션당 1회 가드" 테스트를 새 의미론(off-route→off-route→on-route 재시도 허용 + 상한 백스톱)으로 교체, TDD red 확인 후 구현.

## 테스트 (TDD)
- red: off-route→off-route→on-route 전환에서 heal 미재발동 재현 테스트 작성 → 구현 전 fail 확인.
- green: 위 시나리오 + 세션당 POST 상한(3회) 테스트 + token 미가용/in-flight unmount/이미 heal 성공한 세션 영속 잠금 등 엣지 케이스 추가, `npm test` 커버리지 100%.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — DebugModal의 activeTrip/promptGeoContext 필드 + #2151 카운터에서 heal 성공/실패, 세션당 POST 상한 도달 로그(`context-heal: 세션당 POST 상한(3) 도달`)를 logger를 통해 관측 가능.
3. **의존 PR** — #2163(heal 트리거 확대) 머지 후 이 PR이 그 위에 쌓임. 그 외 backend/device 의존 없음.
4. **측정 plan** — 실탑승에서 `SkippedNoContext` 0 확인(이슈 스펙 명시). 추가로 off-route 경유 탑승 시나리오에서 heal 성공률 관찰(로그 기반).
5. **Device verify** — 필요. 인접 off-route 역 경유 후 실제 탑승역 도달 시나리오(예: GPS 흔들림으로 인접역이 먼저 잡혔다가 실제 탑승역으로 정정)에서 promptGeoContext가 정상 stamp되는지 실기기 확인.

## 검증
- `npm test` — 9085/9085 pass, 커버리지 100%(lines/branches/functions/statements).
- `npm run type-check` — pass.
- `npm run lint:orphan` — pass (0 orphan).

## 리뷰 반영 (P1 / P2-1)
- **P1** — `runTier2Heal`이 여전히 시도 기준 잠금(`healedSessionKeyRef.current = sessionKey`를 await **이전** 무조건 세팅)이었다. 지하(네트워크 최악 구간)에서 Tier2 POST가 실패하면 세션이 영구 잠겨 이후 Tier1 heal이 재발동 불가 — #2164가 고치려던 증상이 Tier2 경로로 존속. 수정: Tier1과 동일하게 `await registerFromLatestInputs(...)` 결과를 받아 `result?.ok && result.hadPromptContext`일 때만 세팅.
- **P2-1** — Tier2가 `healInFlightSessionKeyRef`를 검사만 하고 자신은 세팅하지 않아, Tier2 await 중 Tier1이 동시 발사될 수 있었다. Tier1과 대칭으로 시작 시 세팅 + 완료 시 해제하도록 수정. 재arm된 두 번째 Tier2 타이머가 첫 register 완료 전에 도착해도 자기 자신에 대해 skip하도록 커버.
- **P2-2**(heal ↔ register-retry #1960 상호 조율)는 리뷰에서 범위 밖으로 명시돼 이번 PR에서 다루지 않음 — 별도 이슈 필요.
- TDD: red 2건 선행(Tier2 실패 시 세션 미잠금 / Tier2 in-flight 중 Tier1 동시 발사) → fix → green. 재arm 시나리오의 Tier2 자기 재진입 방지도 커버리지 테스트로 추가.

## 검증 (갱신)
- `npm test` — 9088/9088 pass, 커버리지 100%(lines/branches/functions/statements).
- `npm run type-check` — pass.
- `npm run lint:orphan` — pass (0 orphan).
