### PR TITLE
fix(#2160): boardingPrompt counter를 trip-활성 tick 누적으로 교체

### DIFF
--- a/backend/alarm-worker/src/__tests__/boardingPromptCounterAccumulator.test.ts
+++ b/backend/alarm-worker/src/__tests__/boardingPromptCounterAccumulator.test.ts
@@ -1,0 +1,172 @@
+/**
+ * boardingPromptCounterAccumulator.test.ts — #2160 (follow-up of #2151 / PR #2156 P2 리뷰).
+ */
+import { describe, expect, it } from 'vitest';
+import { InMemoryKV } from './inMemoryKv';
+import {
+  BOARDING_PROMPT_COUNTER_KEY,
+  EMPTY_BOARDING_PROMPT_COUNTERS,
+  accumulateBoardingPromptCounters,
+  readBoardingPromptCounters,
+  type BoardingPromptCounterDelta,
+} from '../boardingPromptCounterAccumulator';
+
+const NOW = 1_700_000_000_000;
+
+const ZERO_DELTA: BoardingPromptCounterDelta = {
+  evaluated: 0,
+  fired: 0,
+  blocked: 0,
+  skippedNoContext: 0,
+  skippedStale: 0,
+  skippedTooFar: 0,
+  skippedTrainDuplicate: 0,
+};
+
+describe('readBoardingPromptCounters', () => {
+  it('키 없음 → null', async () => {
+    const kv = new InMemoryKV();
+    const result = await readBoardingPromptCounters(kv as unknown as KVNamespace);
+    expect(result).toBeNull();
+  });
+
+  it('malformed JSON → null', async () => {
+    const kv = new InMemoryKV();
+    kv.store.set(BOARDING_PROMPT_COUNTER_KEY, { value: '{not-json' });
+    const result = await readBoardingPromptCounters(kv as unknown as KVNamespace);
+    expect(result).toBeNull();
+  });
+
+  it('cacheTtl >= 30s로 KV read — 런타임 제약(cacheTtl<30 throw) 위반하지 않는다', async () => {
+    // #2160 — lesson_cron_cachettl_runtime_constraint: Cloudflare KV는 cacheTtl<30을 400으로
+    // throw한다. InMemoryKV가 동일하게 시뮬레이션 — 이 호출이 throw하지 않으면 cacheTtl>=30.
+    const kv = new InMemoryKV();
+    await expect(readBoardingPromptCounters(kv as unknown as KVNamespace)).resolves.not.toThrow();
+  });
+});
+
+describe('accumulateBoardingPromptCounters — idle tick 0 write (#2160)', () => {
+  it('delta 전부 0(활성 trip 0인 idle tick) → KV write 없음', async () => {
+    const kv = new InMemoryKV();
+    const result = await accumulateBoardingPromptCounters(kv as unknown as KVNamespace, ZERO_DELTA, NOW);
+    expect(result).toBeNull();
+    expect(kv.store.size).toBe(0);
+  });
+
+  it('idle tick 반복 호출해도 write 누적 0 (quota burn 재발 방지 시뮬레이션)', async () => {
+    const kv = new InMemoryKV();
+    for (let i = 0; i < 100; i++) {
+      await accumulateBoardingPromptCounters(kv as unknown as KVNamespace, ZERO_DELTA, NOW + i * 60_000);
+    }
+    expect(kv.store.size).toBe(0);
+  });
+});
+
+describe('accumulateBoardingPromptCounters — 활성 trip tick 누적', () => {
+  it('첫 활성 tick — delta 그대로 저장 + self-describing window/sampledAt', async () => {
+    const kv = new InMemoryKV();
+    const result = await accumulateBoardingPromptCounters(
+      kv as unknown as KVNamespace,
+      { ...ZERO_DELTA, evaluated: 1, fired: 1 },
+      NOW,
+    );
+    expect(result).toEqual({
+      evaluated: 1,
+      fired: 1,
+      blocked: 0,
+      skippedNoContext: 0,
+      skippedStale: 0,
+      skippedTooFar: 0,
+      skippedTrainDuplicate: 0,
+      window: '24h',
+      sampledAt: NOW,
+    });
+    const stored = await readBoardingPromptCounters(kv as unknown as KVNamespace);
+    expect(stored).toEqual(result);
+  });
+
+  it('여러 활성 tick — read-modify-write로 누적(1틱 스냅샷 아님)', async () => {
+    const kv = new InMemoryKV();
+    await accumulateBoardingPromptCounters(
+      kv as unknown as KVNamespace,
+      { ...ZERO_DELTA, evaluated: 3, blocked: 1 },
+      NOW,
+    );
+    await accumulateBoardingPromptCounters(
+      kv as unknown as KVNamespace,
+      { ...ZERO_DELTA, evaluated: 2, fired: 1, skippedTrainDuplicate: 1 },
+      NOW + 60_000,
+    );
+    const result = await readBoardingPromptCounters(kv as unknown as KVNamespace);
+    expect(result).toEqual({
+      evaluated: 5,
+      fired: 1,
+      blocked: 1,
+      skippedNoContext: 0,
+      skippedStale: 0,
+      skippedTooFar: 0,
+      skippedTrainDuplicate: 1,
+      window: '24h',
+      sampledAt: NOW + 60_000,
+    });
+  });
+
+  it('idle tick이 활성 tick 사이에 끼어도 누적치를 훼손하지 않는다', async () => {
+    const kv = new InMemoryKV();
+    await accumulateBoardingPromptCounters(
+      kv as unknown as KVNamespace,
+      { ...ZERO_DELTA, evaluated: 4 },
+      NOW,
+    );
+    // idle tick — no-op
+    await accumulateBoardingPromptCounters(kv as unknown as KVNamespace, ZERO_DELTA, NOW + 60_000);
+    await accumulateBoardingPromptCounters(
+      kv as unknown as KVNamespace,
+      { ...ZERO_DELTA, evaluated: 1 },
+      NOW + 120_000,
+    );
+    const result = await readBoardingPromptCounters(kv as unknown as KVNamespace);
+    expect(result?.evaluated).toBe(5);
+  });
+
+  it('TTL 24h로 KV put', async () => {
+    const kv = new InMemoryKV();
+    const before = Date.now();
+    await accumulateBoardingPromptCounters(
+      kv as unknown as KVNamespace,
+      { ...ZERO_DELTA, evaluated: 1 },
+      NOW,
+    );
+    const after = Date.now();
+    const entry = kv.store.get(BOARDING_PROMPT_COUNTER_KEY);
+    expect(entry?.expiresAt).toBeGreaterThan(before + 23 * 60 * 60 * 1000);
+    expect(entry?.expiresAt).toBeLessThanOrEqual(after + 25 * 60 * 60 * 1000);
+  });
+
+  it('malformed 기존 값 위에 누적 시 0부터 다시 시작(throw 없이 복구)', async () => {
+    const kv = new InMemoryKV();
+    kv.store.set(BOARDING_PROMPT_COUNTER_KEY, { value: '{not-json' });
+    const result = await accumulateBoardingPromptCounters(
+      kv as unknown as KVNamespace,
+      { ...ZERO_DELTA, evaluated: 2 },
+      NOW,
+    );
+    expect(result?.evaluated).toBe(2);
+  });
+});
+
+describe('EMPTY_BOARDING_PROMPT_COUNTERS', () => {
+  it('zero 기본값 + self-describing 필드 포함', () => {
+    expect(EMPTY_BOARDING_PROMPT_COUNTERS).toEqual({
+      evaluated: 0,
+      fired: 0,
+      blocked: 0,
+      skippedNoContext: 0,
+      skippedStale: 0,
+      skippedTooFar: 0,
+      skippedTrainDuplicate: 0,
+      window: '24h',
+      sampledAt: 0,
+    });
+  });
+});

--- a/backend/alarm-worker/src/__tests__/boardingPromptCounterAccumulator.test.ts
+++ b/backend/alarm-worker/src/__tests__/boardingPromptCounterAccumulator.test.ts
@@ -46,7 +46,7 @@ describe('readBoardingPromptCounters', () => {
 });
 
 describe('accumulateBoardingPromptCounters — idle tick 0 write (#2160)', () => {
-  it('delta 전부 0(활성 trip 0인 idle tick) → KV write 없음', async () => {
+  it('delta 전부 0(lock 미형성 trip이 활성인 tick 없음 — idle tick 포함) → KV write 없음', async () => {
     const kv = new InMemoryKV();
     const result = await accumulateBoardingPromptCounters(kv as unknown as KVNamespace, ZERO_DELTA, NOW);
     expect(result).toBeNull();
@@ -78,7 +78,7 @@ describe('accumulateBoardingPromptCounters — 활성 trip tick 누적', () => {
       skippedStale: 0,
       skippedTooFar: 0,
       skippedTrainDuplicate: 0,
-      window: '24h',
+      window: '24h-rolling-ttl',
       sampledAt: NOW,
     });
     const stored = await readBoardingPromptCounters(kv as unknown as KVNamespace);
@@ -106,7 +106,7 @@ describe('accumulateBoardingPromptCounters — 활성 trip tick 누적', () => {
       skippedStale: 0,
       skippedTooFar: 0,
       skippedTrainDuplicate: 1,
-      window: '24h',
+      window: '24h-rolling-ttl',
       sampledAt: NOW + 60_000,
     });
   });
@@ -165,7 +165,7 @@ describe('EMPTY_BOARDING_PROMPT_COUNTERS', () => {
       skippedStale: 0,
       skippedTooFar: 0,
       skippedTrainDuplicate: 0,
-      window: '24h',
+      window: '24h-rolling-ttl',
       sampledAt: 0,
     });
   });

--- a/backend/alarm-worker/src/__tests__/index.boardingPromptCounterWiring.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.boardingPromptCounterWiring.test.ts
@@ -1,0 +1,150 @@
+/**
+ * #2160 (follow-up of #2151) — `handler.scheduled`가 매 tick의 `scheduledStats` boardingPrompt
+ * 계열 delta를 누적 KV 키(`boardingPromptCounterAccumulator`)에 read-modify-write하는지,
+ * idle tick(delta 전부 0)에서 KV write가 발생하지 않는지 검증.
+ *
+ * `runScheduled`를 모킹해 index.ts의 배선(wiring)만 단위 격리 테스트한다 — 누적 로직 자체는
+ * boardingPromptCounterAccumulator.test.ts가 커버한다.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../types';
+import { InMemoryKV } from './inMemoryKv';
+import {
+  BOARDING_PROMPT_COUNTER_KEY,
+  readBoardingPromptCounters,
+} from '../boardingPromptCounterAccumulator';
+
+const runScheduledMock = vi.fn();
+const runFallbackPushesMock = vi.fn();
+const runRetryPushesMock = vi.fn();
+
+vi.mock('../scheduled', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../scheduled')>();
+  return { ...actual, runScheduled: (...args: unknown[]) => runScheduledMock(...args) };
+});
+vi.mock('../fallback', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../fallback')>();
+  return { ...actual, runFallbackPushes: (...args: unknown[]) => runFallbackPushesMock(...args) };
+});
+vi.mock('../retryPushes', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../retryPushes')>();
+  return { ...actual, runRetryPushes: (...args: unknown[]) => runRetryPushesMock(...args) };
+});
+
+const { handler } = await import('../index');
+
+function makeEnv(kv: InMemoryKV): Env {
+  return {
+    TRIPS: kv as unknown as Env['TRIPS'],
+    APNS_HOST: 'api.push.apple.com',
+    APNS_HOST_SANDBOX: 'api.sandbox.push.apple.com',
+    SEOUL_API_HOST: 'h',
+    SEOUL_API_KEY: 'k',
+    APNS_KEY_ID: 'k',
+    APNS_TEAM_ID: 't',
+    APNS_PRIVATE_KEY: 'p',
+    APNS_BUNDLE_ID: 'b',
+    // TELEMETRY_R2 미설정 — obs-metrics hourly 집계 블록은 no-op, 누적 write는 독립적으로 발생해야 함.
+  };
+}
+
+function makeExecutionContext(): ExecutionContext {
+  return {
+    waitUntil: () => {},
+    passThroughOnException: () => {},
+    props: {},
+  } as unknown as ExecutionContext;
+}
+
+function makeScheduledController(): ScheduledController {
+  return {
+    scheduledTime: Date.now(),
+    cron: '*/1 * * * *',
+    noRetry: () => {},
+  } as unknown as ScheduledController;
+}
+
+function boardingPromptStats(
+  overrides: Partial<{
+    boardingPromptEvaluated: number;
+    boardingPromptFired: number;
+    boardingPromptBlocked: number;
+    boardingPromptSkippedNoContext: number;
+    boardingPromptSkippedStale: number;
+    boardingPromptSkippedTooFar: number;
+    boardingPromptSkippedTrainDuplicate: number;
+  }> = {},
+) {
+  return {
+    scanned: 0,
+    pendingActivityPossible: false,
+    boardingPromptEvaluated: 0,
+    boardingPromptFired: 0,
+    boardingPromptBlocked: 0,
+    boardingPromptSkippedNoContext: 0,
+    boardingPromptSkippedStale: 0,
+    boardingPromptSkippedTooFar: 0,
+    boardingPromptSkippedTrainDuplicate: 0,
+    ...overrides,
+  };
+}
+
+describe('handler.scheduled — #2160 boardingPrompt counter 누적 배선', () => {
+  beforeEach(() => {
+    runScheduledMock.mockReset();
+    runFallbackPushesMock.mockReset();
+    runRetryPushesMock.mockReset();
+    runFallbackPushesMock.mockResolvedValue({ scanned: 0, pushed: 0, errors: 0, deferred: 0 });
+    runRetryPushesMock.mockResolvedValue({
+      scanned: 0,
+      deferred: 0,
+      resent: 0,
+      rescheduled: 0,
+      exhausted: 0,
+    });
+  });
+
+  it('idle tick(모든 boardingPrompt 계열 stat 0) — 누적 KV 키 write 없음', async () => {
+    const kv = new InMemoryKV();
+    runScheduledMock.mockResolvedValue(boardingPromptStats());
+    await handler.scheduled(makeScheduledController(), makeEnv(kv), makeExecutionContext());
+    expect(kv.store.has(BOARDING_PROMPT_COUNTER_KEY)).toBe(false);
+  });
+
+  it('활성 tick(evaluated/fired > 0) — 누적 KV 키에 write', async () => {
+    const kv = new InMemoryKV();
+    runScheduledMock.mockResolvedValue(
+      boardingPromptStats({ boardingPromptEvaluated: 1, boardingPromptFired: 1 }),
+    );
+    await handler.scheduled(makeScheduledController(), makeEnv(kv), makeExecutionContext());
+    const stored = await readBoardingPromptCounters(kv as unknown as KVNamespace);
+    expect(stored).not.toBeNull();
+    expect(stored?.evaluated).toBe(1);
+    expect(stored?.fired).toBe(1);
+  });
+
+  it('연속 활성 tick 2회 — 누적(스냅샷 덮어쓰기 아님)', async () => {
+    const kv = new InMemoryKV();
+    runScheduledMock.mockResolvedValue(
+      boardingPromptStats({ boardingPromptEvaluated: 2, boardingPromptBlocked: 1 }),
+    );
+    await handler.scheduled(makeScheduledController(), makeEnv(kv), makeExecutionContext());
+    runScheduledMock.mockResolvedValue(
+      boardingPromptStats({ boardingPromptEvaluated: 3, boardingPromptFired: 1 }),
+    );
+    await handler.scheduled(makeScheduledController(), makeEnv(kv), makeExecutionContext());
+    const stored = await readBoardingPromptCounters(kv as unknown as KVNamespace);
+    expect(stored?.evaluated).toBe(5);
+    expect(stored?.blocked).toBe(1);
+    expect(stored?.fired).toBe(1);
+  });
+
+  it('runScheduled 결과가 boardingPrompt 필드를 포함하지 않아도(구 mock 호환) throw 없이 완주', async () => {
+    const kv = new InMemoryKV();
+    runScheduledMock.mockResolvedValue({ scanned: 0, pendingActivityPossible: false });
+    await expect(
+      handler.scheduled(makeScheduledController(), makeEnv(kv), makeExecutionContext()),
+    ).resolves.not.toThrow();
+    expect(kv.store.has(BOARDING_PROMPT_COUNTER_KEY)).toBe(false);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
+++ b/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
@@ -72,7 +72,7 @@ describe('storeObservabilityMetrics + readObservabilityMetrics', () => {
         skippedStale: 0,
         skippedTooFar: 0,
         skippedTrainDuplicate: 1,
-        window: '24h' as const,
+        window: '24h-rolling-ttl' as const,
         sampledAt: NOW,
       },
       window: '24h' as const,
@@ -123,7 +123,7 @@ describe('storeObservabilityMetrics + readObservabilityMetrics', () => {
         skippedStale: 0,
         skippedTooFar: 0,
         skippedTrainDuplicate: 0,
-        window: '24h' as const,
+        window: '24h-rolling-ttl' as const,
         sampledAt: NOW,
       },
       window: '24h' as const,
@@ -913,7 +913,7 @@ describe('computeObservabilityMetrics — boardingPromptCounters (#2151 → #216
       skippedStale: 0,
       skippedTooFar: 0,
       skippedTrainDuplicate: 0,
-      window: '24h',
+      window: '24h-rolling-ttl',
       sampledAt: 0,
     });
   });
@@ -928,7 +928,7 @@ describe('computeObservabilityMetrics — boardingPromptCounters (#2151 → #216
       skippedStale: 1,
       skippedTooFar: 2,
       skippedTrainDuplicate: 1,
-      window: '24h' as const,
+      window: '24h-rolling-ttl' as const,
       sampledAt: NOW,
     };
     const result = await computeObservabilityMetrics(r2, undefined, NOW, undefined, counters);
@@ -965,7 +965,7 @@ const SAMPLE_METRICS = {
     skippedStale: 0,
     skippedTooFar: 0,
     skippedTrainDuplicate: 0,
-    window: '24h' as const,
+    window: '24h-rolling-ttl' as const,
     sampledAt: NOW,
   },
   window: '24h' as const,

--- a/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
+++ b/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
@@ -72,6 +72,8 @@ describe('storeObservabilityMetrics + readObservabilityMetrics', () => {
         skippedStale: 0,
         skippedTooFar: 0,
         skippedTrainDuplicate: 1,
+        window: '24h' as const,
+        sampledAt: NOW,
       },
       window: '24h' as const,
       timestamp: NOW,
@@ -121,6 +123,8 @@ describe('storeObservabilityMetrics + readObservabilityMetrics', () => {
         skippedStale: 0,
         skippedTooFar: 0,
         skippedTrainDuplicate: 0,
+        window: '24h' as const,
+        sampledAt: NOW,
       },
       window: '24h' as const,
       timestamp: NOW,
@@ -897,7 +901,7 @@ describe('computeObservabilityMetrics — locklessTripMissRatio (#1972)', () => 
 // computeObservabilityMetrics — boardingPromptCounters (#2151)
 // ──────────────────────────────────────────────────────────────────────────────
 
-describe('computeObservabilityMetrics — boardingPromptCounters (#2151)', () => {
+describe('computeObservabilityMetrics — boardingPromptCounters (#2151 → #2160)', () => {
   it('boardingPromptCounters 미제공 → zero 기본값', async () => {
     const r2 = makeEmptyFakeR2();
     const result = await computeObservabilityMetrics(r2, undefined, NOW);
@@ -909,6 +913,8 @@ describe('computeObservabilityMetrics — boardingPromptCounters (#2151)', () =>
       skippedStale: 0,
       skippedTooFar: 0,
       skippedTrainDuplicate: 0,
+      window: '24h',
+      sampledAt: 0,
     });
   });
 
@@ -922,6 +928,8 @@ describe('computeObservabilityMetrics — boardingPromptCounters (#2151)', () =>
       skippedStale: 1,
       skippedTooFar: 2,
       skippedTrainDuplicate: 1,
+      window: '24h' as const,
+      sampledAt: NOW,
     };
     const result = await computeObservabilityMetrics(r2, undefined, NOW, undefined, counters);
     expect(result.boardingPromptCounters).toEqual(counters);
@@ -957,6 +965,8 @@ const SAMPLE_METRICS = {
     skippedStale: 0,
     skippedTooFar: 0,
     skippedTrainDuplicate: 0,
+    window: '24h' as const,
+    sampledAt: NOW,
   },
   window: '24h' as const,
   timestamp: NOW,

--- a/backend/alarm-worker/src/boardingPromptCounterAccumulator.ts
+++ b/backend/alarm-worker/src/boardingPromptCounterAccumulator.ts
@@ -1,5 +1,5 @@
 /**
- * boardingPrompt counter 24h 누적 (#2160, follow-up of #2151 / PR #2156 P2 리뷰).
+ * boardingPrompt counter 24h-rolling-ttl 누적 (#2160, follow-up of #2151 / PR #2156 P2 리뷰).
  *
  * 배경
  * ====
@@ -7,14 +7,32 @@
  * 스냅샷**으로 노출했다 — 특정 trip의 프롬프트 평가가 그 1분 tick에 걸릴 확률이 ~1/60이라,
  * 원 이슈(#2151)의 목적인 "특정 trip 사후 RCA 판별"을 사실상 충족하지 못했다.
  *
- * 본 모듈은 trip이 1개 이상 활성인 tick(=아래 delta 중 하나라도 >0인 tick)에서만 단일 KV
- * 키를 read-modify-write로 누적한다. idle tick(활성 trip 0 → delta 전부 0)은 read/write 모두
+ * write 조건 (정확한 서술)
+ * ======================
+ * 본 모듈은 아래 delta 중 하나라도 >0인 tick에서만 단일 KV 키를 read-modify-write로
+ * 누적한다. delta는 boardingPrompt 게이트 평가/발사/스킵이 실제로 일어난 tick에만 채워지므로
+ * "활성 trip 0"이 아니라 **"lock 미형성 trip이 활성 tick에 존재"**가 정확한 write 조건이다.
+ * lockless 상태로 유지되는 trip(예: C 토글=infoMode ON 구간)은 trip 전체 구간이 lockless라
+ * 매 tick delta>0이 정상이며, 그 trip 하나가 활성인 30~60분 내내 매분 write가 발생하는 것도
+ * 정상 케이스다(X10 정상 패턴). idle tick(활성 trip 0 → delta 전부 0)은 read/write 모두
  * 발생하지 않는다 — CF 무료 quota cron burn 재발 방지
  * ([[lesson_cf_free_quota_cron_kv_burn]]).
  *
+ * 주의 — X11(persistent lockless) 회귀 상관관계: X11(원인 불명 장기 lockless 고착, 정상
+ * 5~10분 초과 지속)이 발생하면 이 accumulator write도 함께 폭증한다(같은 trip이 수 시간
+ * 연속 매분 write). write 급증 자체가 X11 조기 탐지 신호가 될 수 있다 — 정상 시나리오(C
+ * 토글 30~60분)와 구분하려면 `sampledAt` 간격 + trip 수명을 함께 봐야 한다.
+ *
+ * quota 안전성: 단독 사용자 기준 최악(하루 종일 지속 lockless trip 1개 반복)도 write는
+ * 하루 120~180건 수준(무료 quota 1000 writes/day 대비 여유) — idle-skip이 아니라 "lock
+ * 미형성 tick만 write"라는 게이트 자체가 quota 안전의 근거다.
+ *
  * TTL은 매 write마다 24h로 갱신되는 rolling window — 마지막 활성 tick으로부터 24h 동안
  * 누적치가 유지된다(엄밀한 "지난 24h만" 슬라이딩 윈도우는 아니지만, 단독 사용자 기준 하루 수십
- * 회의 활성 tick이 지속적으로 TTL을 갱신하므로 실질적으로 최근 활동을 반영한다).
+ * 회의 활성 tick이 지속적으로 TTL을 갱신하므로 실질적으로 최근 활동을 반영한다). 이 의미가
+ * `ObservabilityMetricsResponse.window`(진짜 R2 24h scan 윈도우)와 다르므로, 아래
+ * `BoardingPromptCounters.window` 필드값은 `'24h-rolling-ttl'`로 구분한다 — 같은 필드명
+ * `window`에 같은 `'24h'` 리터럴을 쓰면 소비자가 두 의미를 혼동한다(#2168 리뷰 P2-2).
  *
  * cacheTtl 런타임 제약(Cloudflare KV는 cacheTtl < 30을 throw, [[lesson_cron_cachettl_runtime_constraint]])
  * 준수를 위해 read 시 `CRON_READ_CACHE_TTL_SEC`(30s)를 명시한다.
@@ -41,12 +59,15 @@ export interface BoardingPromptCounterDelta {
 
 /**
  * 누적된 boardingPrompt counter. self-describing 필드로 `window`(누적 의미: rolling 24h TTL
- * 기반이라 정확한 "지난 24h 합"은 아니고 "마지막 활성 tick까지의 누적치"임을 명시)와
- * `sampledAt`(마지막 누적 write epoch ms)을 포함해 obs-metrics 응답 소비자가 이 값이
- * PR #2156의 1분 스냅샷이 아님을 오독하지 않도록 한다.
+ * 기반이라 정확한 "지난 24h 합"은 아니고 "마지막 write tick부터 24h간 비활동해야 소멸하는
+ * 누적치"임을 명시 — 값이 `'24h-rolling-ttl'` 리터럴인 이유는 top-level
+ * `ObservabilityMetricsResponse.window`('24h', 진짜 R2 24h scan 윈도우)와 필드명이 같아
+ * 같은 `'24h'` 리터럴을 쓰면 소비자가 두 의미를 혼동하기 때문이다)와 `sampledAt`(마지막
+ * 누적 write epoch ms)을 포함해 obs-metrics 응답 소비자가 이 값이 PR #2156의 1분 스냅샷이
+ * 아님을 오독하지 않도록 한다.
  */
 export interface BoardingPromptCounters extends BoardingPromptCounterDelta {
-  window: '24h';
+  window: '24h-rolling-ttl';
   sampledAt: number;
 }
 
@@ -59,7 +80,7 @@ export const EMPTY_BOARDING_PROMPT_COUNTERS: BoardingPromptCounters = {
   skippedStale: 0,
   skippedTooFar: 0,
   skippedTrainDuplicate: 0,
-  window: '24h',
+  window: '24h-rolling-ttl',
   sampledAt: 0,
 };
 
@@ -84,8 +105,11 @@ export async function readBoardingPromptCounters(
 /**
  * 이번 tick의 delta를 누적 KV 키에 read-modify-write.
  *
- * delta 전부 0이면(=idle tick, 활성 trip 0) KV read/write 모두 skip하고 null 반환 —
- * 이 gate가 "idle tick write 0" 불변식의 유일한 강제 지점이다.
+ * delta 전부 0이면(=lock 미형성 trip이 활성인 tick이 이번엔 없음 — 활성 trip 자체가 0인
+ * idle tick 포함) KV read/write 모두 skip하고 null 반환 — 이 gate가 "idle tick write 0"
+ * 불변식의 유일한 강제 지점이다. 반대로 lockless trip이 활성인 tick(정상: C 토글 30~60분
+ * 구간 / 비정상: X11 회귀로 장기 고착)에서는 매 tick write가 발생한다 — 파일 상단 doc-comment
+ * "write 조건" / "X11 회귀 상관관계" 참고.
  *
  * @returns 누적 후 최신 counters. idle-skip 시 null.
  */
@@ -113,7 +137,7 @@ export async function accumulateBoardingPromptCounters(
     skippedStale: (existing?.skippedStale ?? 0) + delta.skippedStale,
     skippedTooFar: (existing?.skippedTooFar ?? 0) + delta.skippedTooFar,
     skippedTrainDuplicate: (existing?.skippedTrainDuplicate ?? 0) + delta.skippedTrainDuplicate,
-    window: '24h',
+    window: '24h-rolling-ttl',
     sampledAt: now,
   };
   await tripsKv.put(BOARDING_PROMPT_COUNTER_KEY, JSON.stringify(merged), {

--- a/backend/alarm-worker/src/boardingPromptCounterAccumulator.ts
+++ b/backend/alarm-worker/src/boardingPromptCounterAccumulator.ts
@@ -1,0 +1,123 @@
+/**
+ * boardingPrompt counter 24h 누적 (#2160, follow-up of #2151 / PR #2156 P2 리뷰).
+ *
+ * 배경
+ * ====
+ * PR #2156은 boardingPrompt skip/fire counter를 obs-metrics 갱신 tick(1h 주기)의 **1분
+ * 스냅샷**으로 노출했다 — 특정 trip의 프롬프트 평가가 그 1분 tick에 걸릴 확률이 ~1/60이라,
+ * 원 이슈(#2151)의 목적인 "특정 trip 사후 RCA 판별"을 사실상 충족하지 못했다.
+ *
+ * 본 모듈은 trip이 1개 이상 활성인 tick(=아래 delta 중 하나라도 >0인 tick)에서만 단일 KV
+ * 키를 read-modify-write로 누적한다. idle tick(활성 trip 0 → delta 전부 0)은 read/write 모두
+ * 발생하지 않는다 — CF 무료 quota cron burn 재발 방지
+ * ([[lesson_cf_free_quota_cron_kv_burn]]).
+ *
+ * TTL은 매 write마다 24h로 갱신되는 rolling window — 마지막 활성 tick으로부터 24h 동안
+ * 누적치가 유지된다(엄밀한 "지난 24h만" 슬라이딩 윈도우는 아니지만, 단독 사용자 기준 하루 수십
+ * 회의 활성 tick이 지속적으로 TTL을 갱신하므로 실질적으로 최근 활동을 반영한다).
+ *
+ * cacheTtl 런타임 제약(Cloudflare KV는 cacheTtl < 30을 throw, [[lesson_cron_cachettl_runtime_constraint]])
+ * 준수를 위해 read 시 `CRON_READ_CACHE_TTL_SEC`(30s)를 명시한다.
+ */
+
+import { CRON_READ_CACHE_TTL_SEC } from './kvConsistency';
+
+/** 누적 KV 키. hourly bucket이 아닌 단일 rolling 키. */
+export const BOARDING_PROMPT_COUNTER_KEY = 'boarding-prompt-counters:v1';
+
+/** TTL — 24h. 매 활성 tick write마다 갱신(rolling). */
+const BOARDING_PROMPT_COUNTER_TTL_SEC = 24 * 60 * 60;
+
+/** 한 tick에서 발생한 boardingPrompt counter 증분(delta). */
+export interface BoardingPromptCounterDelta {
+  evaluated: number;
+  fired: number;
+  blocked: number;
+  skippedNoContext: number;
+  skippedStale: number;
+  skippedTooFar: number;
+  skippedTrainDuplicate: number;
+}
+
+/**
+ * 누적된 boardingPrompt counter. self-describing 필드로 `window`(누적 의미: rolling 24h TTL
+ * 기반이라 정확한 "지난 24h 합"은 아니고 "마지막 활성 tick까지의 누적치"임을 명시)와
+ * `sampledAt`(마지막 누적 write epoch ms)을 포함해 obs-metrics 응답 소비자가 이 값이
+ * PR #2156의 1분 스냅샷이 아님을 오독하지 않도록 한다.
+ */
+export interface BoardingPromptCounters extends BoardingPromptCounterDelta {
+  window: '24h';
+  sampledAt: number;
+}
+
+/** `boardingPromptCounters` 미제공 시(cold-compute) 사용하는 zero 기본값. */
+export const EMPTY_BOARDING_PROMPT_COUNTERS: BoardingPromptCounters = {
+  evaluated: 0,
+  fired: 0,
+  blocked: 0,
+  skippedNoContext: 0,
+  skippedStale: 0,
+  skippedTooFar: 0,
+  skippedTrainDuplicate: 0,
+  window: '24h',
+  sampledAt: 0,
+};
+
+/**
+ * 누적 KV 키에서 현재까지 누적된 boardingPrompt counter를 읽는다.
+ * 키가 없거나(첫 누적 전) malformed JSON이면 null.
+ */
+export async function readBoardingPromptCounters(
+  tripsKv: KVNamespace,
+): Promise<BoardingPromptCounters | null> {
+  const raw = await tripsKv.get(BOARDING_PROMPT_COUNTER_KEY, {
+    cacheTtl: CRON_READ_CACHE_TTL_SEC,
+  });
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as BoardingPromptCounters;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 이번 tick의 delta를 누적 KV 키에 read-modify-write.
+ *
+ * delta 전부 0이면(=idle tick, 활성 trip 0) KV read/write 모두 skip하고 null 반환 —
+ * 이 gate가 "idle tick write 0" 불변식의 유일한 강제 지점이다.
+ *
+ * @returns 누적 후 최신 counters. idle-skip 시 null.
+ */
+export async function accumulateBoardingPromptCounters(
+  tripsKv: KVNamespace,
+  delta: BoardingPromptCounterDelta,
+  now: number,
+): Promise<BoardingPromptCounters | null> {
+  const hasDelta =
+    delta.evaluated > 0 ||
+    delta.fired > 0 ||
+    delta.blocked > 0 ||
+    delta.skippedNoContext > 0 ||
+    delta.skippedStale > 0 ||
+    delta.skippedTooFar > 0 ||
+    delta.skippedTrainDuplicate > 0;
+  if (!hasDelta) return null;
+
+  const existing = await readBoardingPromptCounters(tripsKv);
+  const merged: BoardingPromptCounters = {
+    evaluated: (existing?.evaluated ?? 0) + delta.evaluated,
+    fired: (existing?.fired ?? 0) + delta.fired,
+    blocked: (existing?.blocked ?? 0) + delta.blocked,
+    skippedNoContext: (existing?.skippedNoContext ?? 0) + delta.skippedNoContext,
+    skippedStale: (existing?.skippedStale ?? 0) + delta.skippedStale,
+    skippedTooFar: (existing?.skippedTooFar ?? 0) + delta.skippedTooFar,
+    skippedTrainDuplicate: (existing?.skippedTrainDuplicate ?? 0) + delta.skippedTrainDuplicate,
+    window: '24h',
+    sampledAt: now,
+  };
+  await tripsKv.put(BOARDING_PROMPT_COUNTER_KEY, JSON.stringify(merged), {
+    expirationTtl: BOARDING_PROMPT_COUNTER_TTL_SEC,
+  });
+  return merged;
+}

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -2438,9 +2438,16 @@ export const handler = {
       throw err;
     }
     // #2160 (follow-up of #2151) — boardingPrompt counter를 이번 tick의 delta로 누적 KV 키에
-    // read-modify-write. delta 전부 0(=활성 trip 0인 idle tick)이면 accumulate 함수 내부에서
-    // KV read/write 자체를 skip한다 — obs-metrics 1h 갱신 게이트와 독립적으로 매분 호출해야
-    // tick 간 delta 유실이 없다(scheduledStats는 tick마다 새로 생성되는 로컬 객체).
+    // read-modify-write. delta 전부 0이면 accumulate 함수 내부에서 KV read/write 자체를 skip
+    // 한다 — obs-metrics 1h 갱신 게이트와 독립적으로 매분 호출해야 tick 간 delta 유실이 없다
+    // (scheduledStats는 tick마다 새로 생성되는 로컬 객체).
+    //
+    // write 조건 정확한 서술: "활성 trip 0" 이 아니라 "lock 미형성 trip이 활성 tick에 존재".
+    // lockless 구간(C 토글=infoMode ON 등)이 유지되는 trip은 그 30~60분 내내 매분 write가
+    // 정상 케이스. X11(persistent lockless 회귀)이 발생하면 이 write도 함께 폭증하므로
+    // write 급증 자체가 X11 조기 탐지 신호가 될 수 있다(boardingPromptCounterAccumulator.ts
+    // 상단 doc-comment 참고). 단독 사용자 기준 최악 케이스도 하루 120~180 write 수준으로
+    // 무료 quota(1000 writes/day) 내 안전.
     try {
       await accumulateBoardingPromptCounters(
         env.TRIPS,

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -121,6 +121,10 @@ import {
   readObservabilityMetrics,
   tryStoreObservabilityMetrics,
 } from './observabilityMetrics';
+import {
+  accumulateBoardingPromptCounters,
+  readBoardingPromptCounters,
+} from './boardingPromptCounterAccumulator';
 import { getTrip, putTrip, rotateTripTokenForNewRoute, withTripRegisterLock } from './trips';
 import { inferWaypointsFromOriginAndDestination } from './dijkstraRoute';
 import { checkTripRegisterRateLimit } from './tripRegisterRateLimit';
@@ -2433,6 +2437,28 @@ export const handler = {
       void captureBackendException(env, err, { path: 'scheduled/runScheduled' });
       throw err;
     }
+    // #2160 (follow-up of #2151) — boardingPrompt counter를 이번 tick의 delta로 누적 KV 키에
+    // read-modify-write. delta 전부 0(=활성 trip 0인 idle tick)이면 accumulate 함수 내부에서
+    // KV read/write 자체를 skip한다 — obs-metrics 1h 갱신 게이트와 독립적으로 매분 호출해야
+    // tick 간 delta 유실이 없다(scheduledStats는 tick마다 새로 생성되는 로컬 객체).
+    try {
+      await accumulateBoardingPromptCounters(
+        env.TRIPS,
+        {
+          evaluated: scheduledStats.boardingPromptEvaluated,
+          fired: scheduledStats.boardingPromptFired,
+          blocked: scheduledStats.boardingPromptBlocked,
+          skippedNoContext: scheduledStats.boardingPromptSkippedNoContext,
+          skippedStale: scheduledStats.boardingPromptSkippedStale,
+          skippedTooFar: scheduledStats.boardingPromptSkippedTooFar,
+          skippedTrainDuplicate: scheduledStats.boardingPromptSkippedTrainDuplicate,
+        },
+        Date.now(),
+      );
+    } catch (err) {
+      // KV read/put 실패 — swallow + Sentry forward. cron 자체는 throw 없이 다음 minute에 재시도.
+      void captureBackendException(env, err, { path: 'scheduled/boardingPromptCounterAccumulate' });
+    }
     // #2073 (Issue A) — 진짜 idle tick(활성 trip 0 + 직전 tick 근방 fire/retry 기록 없음)엔
     // pending/retry push가 존재할 수 없으므로 listPending/listRetryPushes KV list 호출 자체를
     // skip한다(2026-07-29 quota audit: KV list 720%/write 144% 초과, idle-skip이 로그만
@@ -2472,24 +2498,18 @@ export const handler = {
       try {
         const existing = await readObservabilityMetrics(env.TRIPS, now);
         if (!existing) {
-          // #2151 — 같은 tick의 runScheduled 결과(scheduledStats)에서 boardingPrompt 계열
-          // counter 스냅샷을 그대로 실어 obs-metrics 응답에 노출. 신규 KV 키/write 없이 기존
-          // obs-metrics 갱신 tick에 필드만 추가(CF 무료 quota 보호).
-          const boardingPromptCounters = {
-            evaluated: scheduledStats.boardingPromptEvaluated,
-            fired: scheduledStats.boardingPromptFired,
-            blocked: scheduledStats.boardingPromptBlocked,
-            skippedNoContext: scheduledStats.boardingPromptSkippedNoContext,
-            skippedStale: scheduledStats.boardingPromptSkippedStale,
-            skippedTooFar: scheduledStats.boardingPromptSkippedTooFar,
-            skippedTrainDuplicate: scheduledStats.boardingPromptSkippedTrainDuplicate,
-          };
+          // #2160 (follow-up of #2151) — 별도 누적 KV 키(`boardingPromptCounterAccumulator`)에서
+          // 최신 누적치를 읽어 obs-metrics 응답에 노출한다. 이전(#2151/#2156)엔 같은 tick의
+          // scheduledStats 스냅샷을 그대로 실었으나, 그 tick에 우연히 활성 trip이 없으면 0으로
+          // 덮여써 누적이 유실되는 문제가 있었다 — 누적은 위 accumulateBoardingPromptCounters
+          // 호출이 전담하고, 여기선 read-only로 최신 값을 가져온다.
+          const boardingPromptCounters = await readBoardingPromptCounters(env.TRIPS);
           const metrics = await computeObservabilityMetrics(
             env.TELEMETRY_R2,
             env.PENDING_PUSHES,
             now,
             env.TRIPS,
-            boardingPromptCounters,
+            boardingPromptCounters ?? undefined,
           );
           const storeResult = await tryStoreObservabilityMetrics(env.TRIPS, metrics, now, {
             onError: (err, key) =>

--- a/backend/alarm-worker/src/observabilityMetrics.ts
+++ b/backend/alarm-worker/src/observabilityMetrics.ts
@@ -42,6 +42,10 @@ import { buildLocklessTripMissBucket } from './locklessMissMetric';
 import { computePushAckStats } from './pushAckStats';
 import { computeSilentPushReachRatio } from './silentPushReachMetric';
 import { sumLaPushCounters } from './laPushCounters';
+import {
+  EMPTY_BOARDING_PROMPT_COUNTERS,
+  type BoardingPromptCounters,
+} from './boardingPromptCounterAccumulator';
 
 /** 집계 KV 키 prefix. */
 const METRICS_KEY_PREFIX = 'obs-metrics:24h:';
@@ -64,43 +68,14 @@ const METRICS_LAST_SUCCESS_KEY = 'obs-metrics:last-success';
 const METRICS_LAST_SUCCESS_TTL_SEC = 24 * 60 * 60;
 
 /**
- * #2151 — boardingPrompt skip/fire counter obs-metrics 노출.
+ * #2151 → #2160 — boardingPrompt skip/fire counter obs-metrics 노출.
  *
- * `runScheduled`(scheduled.ts) 가 매 cron tick 마다 `ScheduledStats`에 누적하는
- * boardingPrompt 계열 counter 중, obs-metrics 갱신 tick(1h 주기)의 스냅샷 값을 그대로 실어
- * 사후 판별(evaluated=0인데 이유를 알 수 없는 관측 공백, #2130/#2131) 가능하게 한다.
- *
- * 24h 누적이 아니라 **obs-metrics 갱신이 발동된 그 1분 tick의 스냅샷**이다 — 다른 metric처럼
- * R2 24h scan 기반 누적 집계가 아님(신규 KV 키/write 증가 없이 기존 tick에 필드만 추가하는
- * 제약 때문). 다음 obs-metrics 갱신(최대 1h 후)까지 값이 유지된다.
+ * `BoardingPromptCounters` 타입 + zero 기본값은 `boardingPromptCounterAccumulator.ts`가 SSoT다.
+ * #2156이 도입한 "obs-metrics 갱신 tick(1h 주기)의 1분 스냅샷" 방식은 특정 trip의 프롬프트
+ * 평가가 그 1분에 걸릴 확률이 ~1/60이라 사후 RCA 판별 목적(#2130/#2131)을 충족하지 못해
+ * (#2156 P2 리뷰), trip이 1개 이상 활성인 tick마다 별도 KV 키에 read-modify-write로 누적하는
+ * 방식으로 교체됐다 — `boardingPromptCounterAccumulator.ts` 참고.
  */
-export interface BoardingPromptCounters {
-  /** `stats.boardingPromptEvaluated` — 9단 게이트 평가가 시도된 누적 횟수. */
-  evaluated: number;
-  /** `stats.boardingPromptFired` — alert push 발사 성공 누적 횟수. */
-  fired: number;
-  /** `stats.boardingPromptBlocked` — 게이트 차단 누적 횟수 (no-arvlcd / ambiguity 포함). */
-  blocked: number;
-  /** `stats.boardingPromptSkippedNoContext` — geo/display context 부재로 skip. */
-  skippedNoContext: number;
-  /** `stats.boardingPromptSkippedStale` — 15분 신선도 게이트로 skip. */
-  skippedStale: number;
-  /** `stats.boardingPromptSkippedTooFar` — 근접 게이트로 skip. */
-  skippedTooFar: number;
-  /** `stats.boardingPromptSkippedTrainDuplicate` — 같은 trainCode 반복 발사 dedup. */
-  skippedTrainDuplicate: number;
-}
-
-/** `boardingPromptCounters` 미제공 시(예: endpoint cold-compute) 사용하는 zero 기본값. */
-const EMPTY_BOARDING_PROMPT_COUNTERS: BoardingPromptCounters = {
-  evaluated: 0,
-  fired: 0,
-  blocked: 0,
-  skippedNoContext: 0,
-  skippedStale: 0,
-  skippedTooFar: 0,
-  skippedTrainDuplicate: 0,
-};
 
 /** accel pattern 4종 분포 bucket. */
 export interface AccelPatternBucket {
@@ -173,9 +148,10 @@ export function hourBucketKey(now: number): string {
  * @param pendingPushesKv PENDING_PUSHES KV namespace (optional)
  * @param now 현재 epoch ms
  * @param tripsKv TRIPS KV namespace — laPushDeliveryRatio 산출용 (optional, 미설정 시 placeholder)
- * @param boardingPromptCounters #2151 — 같은 cron tick의 `ScheduledStats` boardingPrompt 계열
- *   counter 스냅샷 (optional). 호출자(scheduled handler)가 같은 tick에서 이미 산출한 값을 넘긴다
- *   — 미제공 시(예: `/v1/observability/metrics` endpoint의 cold-compute fallback) zero 기본값.
+ * @param boardingPromptCounters #2151 → #2160 — `boardingPromptCounterAccumulator`가 관리하는
+ *   누적 KV 키(`readBoardingPromptCounters`)의 최신 값 (optional). 호출자(scheduled handler)가
+ *   읽어서 넘긴다 — 미제공 시(예: `/v1/observability/metrics` endpoint의 cold-compute fallback)
+ *   zero 기본값.
  */
 export async function computeObservabilityMetrics(
   r2: R2Bucket,


### PR DESCRIPTION
Closes #2160

## 배경
PR #2156이 도입한 boardingPrompt counter는 obs-metrics 갱신 tick(1h 주기)의 **1분 스냅샷**이라, 특정 trip의 프롬프트 평가가 그 1분에 걸릴 확률이 ~1/60 — 원 이슈(#2151)의 목적인 "특정 trip 사후 RCA 판별"을 사실상 충족하지 못했다(#2156 P2 리뷰).

## 변경
- `boardingPromptCounterAccumulator.ts` 신규: 단일 KV 키(`boarding-prompt-counters:v1`)에 read-modify-write 누적, TTL 24h rolling.
  - **write 조건(정정)**: "활성 trip 0"이 아니라 **"lock 미형성 trip이 활성 tick에 존재"**할 때만 write. C 토글(infoMode) ON 등으로 전 구간 lockless인 trip은 그 trip이 활성인 30~60분 내내 매분 write가 발생하는 게 정상 케이스다. delta 전부 0(=lock 미형성 trip 자체가 없는 tick, idle tick 포함)이면 KV read/write 자체를 skip — 이 gate가 quota 안전의 근거(정량 계산상 단독 사용자 최악 케이스도 하루 120~180 write 수준, 무료 quota 1000 writes/day 대비 안전).
  - **X11 상관관계 주의**: X11(persistent lockless 회귀, 정상 5~10분을 넘는 장기 고착)이 발생하면 이 accumulator write도 함께 폭증한다(같은 trip이 수 시간 연속 매분 write) — write 급증 자체가 X11 조기 탐지 신호가 될 수 있으나, 정상 시나리오(C 토글 30~60분)와는 `sampledAt` 간격 + trip 수명을 함께 봐야 구분 가능.
  - KV read는 `CRON_READ_CACHE_TTL_SEC`(30s) 명시 — Cloudflare KV cacheTtl<30 런타임 throw 제약 준수.
- `index.ts`: 매 cron tick마다 `scheduledStats`의 boardingPrompt 계열 delta를 누적 함수에 전달(obs-metrics 1h 게이트와 독립적으로 매분 실행 — scheduledStats가 tick마다 새로 생성되는 로컬 객체라 매 tick 누적하지 않으면 델타가 유실됨). obs-metrics 계산 시엔 누적 KV를 read-only로 조회해 응답에 실음.
- `observabilityMetrics.ts`: `BoardingPromptCounters` 타입/zero 기본값 SSoT를 `boardingPromptCounterAccumulator.ts`로 이전, `window`/`sampledAt` self-describing 필드 추가.
  - **`window` 리터럴을 `'24h-rolling-ttl'`로 분리**(리뷰 P2-2 반영): top-level `ObservabilityMetricsResponse.window`는 `'24h'`(진짜 R2 24h scan 윈도우)인데, 같은 필드명 `window`에 같은 `'24h'` 리터럴을 쓰면 "마지막 write tick부터 24h간 비활동해야 소멸하는 rolling TTL 누적치"라는 다른 의미를 소비자가 오독할 수 있어 별도 리터럴로 구분했다.
- 테스트: 누적/idle-skip 반복(quota burn 시뮬레이션)/TTL/malformed 복구 + index.ts 배선 wiring 테스트.

## Wire-completion 5단
1. **Orphan 없음** — 신규 export(`accumulateBoardingPromptCounters`, `readBoardingPromptCounters`, `BoardingPromptCounters` 등)는 모두 `index.ts` / `observabilityMetrics.ts` 캘러 존재. backend는 프론트 orphan 스크립트 스캔 대상 아님(기존 backend 관례).
2. **V/X dashboard** — `wrangler kv key get boarding-prompt-counters:v1 --binding TRIPS --remote` 로 누적치 직접 확인 가능 + `/v1/observability/metrics` 응답의 `boardingPromptCounters.{evaluated,fired,...,window,sampledAt}`.
3. **의존 PR** — #2156 머지됨(전제 충족). N/A 그 외.
4. **측정 plan** — 다음 실탑승 trip에서 `wrangler kv key get boarding-prompt-counters:v1` 조회 → evaluated/fired 값이 0이 아닌 non-zero로 기록되는지 확인. 기존 1분 스냅샷 대비 누적 유실 없음을 24h 관찰로 확인. write 빈도가 C 토글 정상 범위(30~60분 연속)를 벗어나면 X11 회귀 의심 신호로 참고.
5. **Device verify** — N/A — backend only (deploy 필요, 배포는 별도).

## 테스트
- `npm test` (backend/alarm-worker): 73 files / 2810 tests pass
- `npm run type-check` (backend/alarm-worker): pass

## 리뷰 반영 (2168 리뷰 P2 2건 — 같은 브랜치에서 처리)
- P2-2: `boardingPromptCounters.window` 리터럴 `'24h'` → `'24h-rolling-ttl'` 변경 + 타입/EMPTY 기본값/누적 함수/테스트/doc-comment 전체 동기화. 프론트 소비자 0개 확인(하위 호환 부담 없음).
- P2-1: write 조건 서술을 "활성 trip 0"에서 "lock 미형성 trip이 활성 tick에 존재"로 정정, C 토글 lockless trip의 30~60분 연속 write가 정상 케이스임을 명시, X11 회귀 시 write 폭증 상관관계 주석 추가(코드 상단 + index.ts callsite), quota 안전(최악 120~180 write/일) 결론 인용.
