### PR TITLE
fix(#2167): context-heal(Tier1/2) ↔ register-retry(#1960) 상호 in-flight 체크

### DIFF
--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -60,6 +60,8 @@ import {
   CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION,
   CONTEXT_HEAL_TIER2_DELAY_MS,
   REGISTER_RETRY_BACKOFF_MS,
+  REGISTER_RETRY_HEAL_BUSY_MAX_RESCHEDULES,
+  REGISTER_RETRY_HEAL_BUSY_RECHECK_MS,
 } from '../../../../shared/constants/boardingLock';
 import { makeDirectRoute, makeMultiTransferRoute } from '../../../../testUtils/routeFixtures';
 import { canonicalStationName } from '../../../../testUtils/canonicalStationName';
@@ -1491,6 +1493,329 @@ describe('useApnsTripRegistration', () => {
         await Promise.resolve();
       });
       expect(mockRegister).toHaveBeenCalledTimes(4); // heal 완료 후 재예약된 재시도가 정상 발화
+    });
+
+    it('P1 (PR #2169 리뷰) — cold-start register 실패 + 지하 dead-zone 조건에서 retry가 성공할 때 Tier 2 fallback context를 함께 실어 보낸다 (영구 결손 회귀 재현)', async () => {
+      // 회귀 배경: Tier 2 fallback 타이머는 main effect의 register가 "직접" 성공했을 때만
+      // arm된다. cold-start register가 실패해 재시도가 예약되면 Tier 2는 애초에 armed되지
+      // 않고, 재시도가 나중에 성공해도(Tier 2 override 없이) currentStation이 계속 null인
+      // 지하 dead-zone 세션은 promptGeoContext/promptDisplay가 영구히 비어 있게 된다. 이
+      // 테스트는 그 결손을 재현하고, 수정 후에는 retry 자신이 Tier 2 override를 실어 보내야
+      // 한다.
+      const routeOrigin = st('3-002'); // 주엽 — origin/dest 사이 실제 3호선 역, build 항상 성공.
+      mockRegister.mockResolvedValueOnce({ ok: false, status: 500 }); // cold-start 실패
+      mockRegister.mockResolvedValueOnce({ ok: true }); // retry 성공
+
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: route3,
+          destination: dest,
+          nextStationEtaSeconds: 120,
+          currentStation: null,
+          subsurface: true,
+          routeOriginStation: routeOrigin,
+        }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1); // cold-start 실패 — 15s 재시도 예약
+
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[0]);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(2); // 재시도 성공
+
+      const retrySuccessPayload = mockRegister.mock.calls[1][0] as {
+        promptGeoContext?: { origin: { lat: number; lng: number } };
+        promptDisplay?: { originStation: string; line: string };
+      };
+      // 수정 전에는 이 두 필드가 모두 undefined(영구 결손). 수정 후엔 Tier 2 override가 함께 실린다.
+      expect(retrySuccessPayload.promptGeoContext?.origin).toEqual({
+        lat: routeOrigin.lat,
+        lng: routeOrigin.lng,
+      });
+      expect(retrySuccessPayload.promptDisplay).toEqual({
+        originStation: routeOrigin.name,
+        line: routeOrigin.line,
+      });
+
+      // 이미 이 재시도로 context를 확보했으므로(healedSessionKeyRef 잠금), Tier 2 지연 시점이
+      // 지나도 추가 register가 없어야 한다 — 중복 없이 정확히 1회로 충분.
+      await act(async () => {
+        jest.advanceTimersByTime(CONTEXT_HEAL_TIER2_DELAY_MS + 1000);
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+
+    it('P2-1 (PR #2169 리뷰) — heal-busy 재예약은 register-retry의 attempt 예산을 소모하지 않는다', async () => {
+      // 회귀 배경: heal-busy로 인한 재예약이 실제 register 실패와 동일하게 attempt를 증가시키면
+      // 실제 POST 시도가 0회인 채로 3회 상한(REGISTER_RETRY_BACKOFF_MS.length)을 태워버릴 수
+      // 있다. 이 테스트는 heal-busy 재예약 2회를 거친 뒤에도 정상 backoff 예산(15/30/60s)이
+      // 그대로 남아 있는지 검증한다.
+      //
+      // "반대 방향" 테스트와 동일한 순서로 heal을 in-flight 상태로 만든다 — retry가 pending인
+      // 동안에는 Tier 1이 스스로 발사하지 않으므로(#2167 P1 이전 가드), Tier 1이 먼저 정상
+      // 발사(retry 없는 상태)된 뒤 별개 dep(subsurface) 변경으로 main effect가 재실행돼 실패해야
+      // 그 세션에 재시도가 예약된다.
+      mockRegister.mockResolvedValueOnce({ ok: true }); // cold-start 성공(currentStation=null → context 결손)
+
+      let resolveHealRegister!: (value: { ok: boolean }) => void;
+      const healDeferred = new Promise<{ ok: boolean }>((resolve) => {
+        resolveHealRegister = resolve;
+      });
+
+      const { rerender } = renderHook(
+        ({ cs, sub }: { cs: Station | null; sub: boolean }) =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: cs,
+            subsurface: sub,
+          }),
+        { initialProps: { cs: null as Station | null, sub: false } },
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1); // cold-start 성공, context 결손 기록
+
+      // Tier 1 heal 트리거 — 응답을 오래 기다리도록 pending 상태로 둔다(healInFlightSessionKeyRef 세팅).
+      mockRegister.mockImplementationOnce(() => healDeferred);
+      rerender({ cs: origin, sub: false });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+
+      // 별개 dep(subsurface) 변경으로 main effect 재실행 — 이번엔 실패해 같은 세션에 재시도
+      // 예약(15s, attempt=1).
+      mockRegister.mockResolvedValueOnce({ ok: false, status: 500 });
+      rerender({ cs: origin, sub: true });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(3);
+
+      // 15s 경과 — retry 타이머 발화하지만 heal이 여전히 in-flight라 heal-busy 재예약(recheck,
+      // attempt 미소모) 1회차.
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[0]);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(3); // 실제 POST 없음 — recheck만 예약됨
+
+      // recheck 간격만큼 경과 — heal이 아직도 in-flight라 heal-busy 재예약 2회차.
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_HEAL_BUSY_RECHECK_MS);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(3); // 여전히 실제 POST 없음
+
+      // heal이 이제 완료(성공) — in-flight 해제.
+      resolveHealRegister({ ok: true });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // recheck 간격 경과 — 이번엔 heal이 끝났으므로 retry가 실제로 발화한다. 실패시켜 다음
+      // backoff가 REGISTER_RETRY_BACKOFF_MS[1](30s)인지 확인 — attempt가 이미 소모돼 있었다면
+      // (P2-1 버그) 상한을 넘어 이 발화 자체가 없거나 다음 backoff가 훨씬 짧아진다.
+      mockRegister.mockResolvedValueOnce({ ok: false, status: 500 });
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_HEAL_BUSY_RECHECK_MS);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(4); // heal 종료 후 실제 재시도 발화(attempt=1 그대로 소모)
+
+      // attempt가 heal-busy 재예약으로 소모되지 않았다면, 다음 backoff는 REGISTER_RETRY_BACKOFF_MS[1]
+      // (30s) — 그 이전엔 발화하지 않고, 그 시점엔 발화해야 한다.
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[1] - 100);
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(4);
+
+      mockRegister.mockResolvedValueOnce({ ok: true });
+      await act(async () => {
+        jest.advanceTimersByTime(200);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(5); // 정상적으로 backoff[1] 시점에 재시도 발화
+    });
+
+    it(`P2-1 (PR #2169 리뷰) — heal-busy 재예약 상한(${REGISTER_RETRY_HEAL_BUSY_MAX_RESCHEDULES}회) 도달 시 일반 backoff로 전환한다`, async () => {
+      // 회귀 방지: heal이 비정상적으로 오래(recheck 상한을 넘길 만큼) in-flight 상태에 머물면
+      // recheck 루프가 무한히 반복될 수 있다 — 상한 도달 시 attempt 예산을 소모하는 일반
+      // backoff로 전환해 무한 대기를 막아야 한다.
+      mockRegister.mockResolvedValueOnce({ ok: true }); // cold-start 성공(context 결손)
+
+      // 이 heal은 상한 도달 전까지는 resolve하지 않는다(heal이 "비정상적으로 오래" 걸리는
+      // 상황 재현) — 상한 전환이 실제로 적용됐는지 검증하기 위해 나중에 명시적으로 resolve한다.
+      let resolveHealForever!: (value: { ok: boolean }) => void;
+      const healForeverPending = new Promise<{ ok: boolean }>((resolve) => {
+        resolveHealForever = resolve;
+      });
+
+      const { rerender } = renderHook(
+        ({ cs, sub }: { cs: Station | null; sub: boolean }) =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: cs,
+            subsurface: sub,
+          }),
+        { initialProps: { cs: null as Station | null, sub: false } },
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // Tier 1 heal 트리거 — 영영 응답하지 않는 상태로 in-flight 유지.
+      mockRegister.mockImplementationOnce(() => healForeverPending);
+      rerender({ cs: origin, sub: false });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+
+      // 별개 dep(subsurface) 변경으로 main effect 재실행 — 실패해 재시도 예약(15s, attempt=1).
+      mockRegister.mockResolvedValueOnce({ ok: false, status: 500 });
+      rerender({ cs: origin, sub: true });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(3);
+
+      // 15s 경과 — 1번째 heal-busy 재예약(recheck).
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[0]);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // heal이 계속 in-flight인 채로 recheck 간격만큼씩 진행 — 상한(MAX_RESCHEDULES)에 도달할
+      // 때까지 반복(이미 1회 소모했으므로 나머지 상한만큼 더 진행).
+      for (let i = 1; i < REGISTER_RETRY_HEAL_BUSY_MAX_RESCHEDULES; i++) {
+        // eslint-disable-next-line no-loop-func -- REGISTER_RETRY_HEAL_BUSY_RECHECK_MS는 상수, closure 문제 없음.
+        await act(async () => {
+          jest.advanceTimersByTime(REGISTER_RETRY_HEAL_BUSY_RECHECK_MS);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+      }
+      expect(mockRegister).toHaveBeenCalledTimes(3); // 여전히 실제 POST 없음(모두 recheck로 skip)
+
+      // 상한 도달 트리거 — 이번엔 일반 backoff(REGISTER_RETRY_BACKOFF_MS[1]=30s)로 전환된다.
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_HEAL_BUSY_RECHECK_MS);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(3);
+
+      // heal을 여기서 성공시켜 in-flight를 해제 — 이제 다음 실제 시도는 recheck(2s)가 아니라
+      // 일반 backoff(30s) 시점에만 발화해야 한다(상한 전환이 실제로 적용됐는지 검증).
+      mockRegister.mockResolvedValueOnce({ ok: true });
+      resolveHealForever({ ok: true });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_HEAL_BUSY_RECHECK_MS);
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(3); // recheck 간격만으로는 아직 발화 안 함(일반 backoff 대기 중)
+
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[1]);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(4); // 일반 backoff(30s) 시점에 실제 재시도 발화
+    });
+
+    it('P2-2 (PR #2169 리뷰) — trip 종료 시 register-retry의 in-flight 추적이 초기화돼 동일 세션의 새 trip을 막지 않는다', async () => {
+      // 회귀 배경: 이전 trip의 retry가 in-flight인 채로 trip이 종료돼도
+      // registerRetryInFlightSessionKeyRef가 reset되지 않으면, 곧바로 같은 sessionKey(같은
+      // route+destination)로 시작된 새 trip의 context-heal(Tier 1)이 stale in-flight 플래그
+      // 때문에 영구히 차단된다.
+      // 이 deferred는 trip B의 heal이 성공할 때까지 resolve하지 않는다 — 만약 trip 종료 직후
+      // 바로 resolve하면 attemptRegisterRetry의 finally 블록이 sessionKey 일치를 보고
+      // registerRetryInFlightSessionKeyRef를 우연히 지워버려, "trip 종료 후에도 in-flight
+      // 플래그가 stale로 남는" 회귀 시나리오 자체가 재현되지 않는다(테스트가 우연히 통과하는
+      // false-negative). 응답이 늦게 도착하는 네트워크 상황을 시뮬레이션해 trip-end 시점의
+      // 명시적 reset(P2-2)만이 유일한 해제 경로가 되도록 한 뒤, 마지막에 resolve해 그 뒤늦은
+      // 응답이 trip B의 상태를 오염시키지 않는지(mismatch 가드)도 함께 검증한다.
+      let resolveTripARetry!: (value: { ok: boolean }) => void;
+      const retryDeferred = new Promise<{ ok: boolean }>((resolve) => {
+        resolveTripARetry = resolve;
+      });
+      mockRegister.mockResolvedValueOnce({ ok: false, status: 500 }); // trip A cold-start 실패
+
+      const { rerender } = renderHook(
+        ({ route, destination, cs }: { route: Route; destination: Station | null; cs: Station | null }) =>
+          useApnsTripRegistration({
+            route,
+            destination,
+            nextStationEtaSeconds: 120,
+            currentStation: cs,
+          }),
+        { initialProps: { route: route3 as Route, destination: dest as Station | null, cs: null as Station | null } },
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1); // trip A: cold-start 실패 — 15s 재시도 예약
+
+      // 15s 경과 — trip A의 retry가 발화해 in-flight 상태로 pending.
+      mockRegister.mockImplementationOnce(() => retryDeferred);
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[0]);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(2); // trip A retry in-flight(pending, 응답 대기)
+
+      // retry가 응답을 받기 전에 trip A 종료(route/destination → null) — retryDeferred는 아직
+      // resolve되지 않는다(위 주석, 마지막에 resolve).
+      rerender({ route: null, destination: null, cs: null });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // 동일 route+destination(같은 sessionKey)으로 새 trip B 시작 — currentStation=null로
+      // cold-start.
+      mockRegister.mockResolvedValueOnce({ ok: true }); // trip B cold-start 성공(context 결손)
+      rerender({ route: route3, destination: dest, cs: null });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(3));
+      expect(mockRegister.mock.calls[2][0].promptGeoContext).toBeUndefined();
+
+      // GPS 해소 — currentStation null→non-null 전환. trip A의 stale in-flight 플래그가 남아
+      // 있었다면(P2-2 버그) isRegisterRetryBusy가 true로 평가돼 이 heal이 영구히 skip된다.
+      rerender({ route: route3, destination: dest, cs: origin });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(4));
+      const healed = mockRegister.mock.calls[3][0] as {
+        promptGeoContext?: { origin: { lat: number; lng: number } };
+      };
+      expect(healed.promptGeoContext?.origin).toEqual({ lat: origin.lat, lng: origin.lng });
+
+      // trip A의 뒤늦은 retry 응답이 지금 도착해도(trip B가 이미 진행 중) 별다른 부작용 없이
+      // 조용히 무시돼야 한다(finally의 mismatch 가드 — trip B 시작 이후 이 ref는 이미 trip A의
+      // sessionKey와 무관한 상태다).
+      resolveTripARetry({ ok: true });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(4); // 추가 register 없음 — 뒤늦은 응답은 무해
     });
   });
 

--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -2943,6 +2943,52 @@ describe('useApnsTripRegistration', () => {
         });
         expect(mockRegister).toHaveBeenCalledTimes(1);
       });
+
+      it('(#2167 재적용, 원래 c18bbac6/#2164 리뷰 P1) Tier 2 register 실패({ok:false}) 시 세션을 잠그지 않아 이후 Tier 1 heal이 재발동할 수 있다', async () => {
+        // 회귀 배경: c18bbac6(#2164 리뷰 P1)가 이 증상을 이미 고쳤으나, #2166 머지(21:48Z) 이후
+        // push돼 dev에 유실됐다 — #2167 작업 중 runTier2Heal을 재구성하며 "await 이전 무조건
+        // 잠금"으로 되돌아갔다. Tier 2 POST가 네트워크 레벨에서 실패하면(build/override context는
+        // 성공했지만 backend 전달에 실패) 세션이 잠기면 안 된다 — 잠기면 이후 Tier 1이 진짜
+        // currentStation을 해소해도 다시 시도할 수 없어 영구 결손으로 고착된다.
+        const { rerender } = renderHook(
+          ({ cs }: { cs: Station | null }) =>
+            useApnsTripRegistration({
+              route: route3,
+              destination: dest,
+              nextStationEtaSeconds: 120,
+              currentStation: cs,
+              subsurface: true,
+              routeOriginStation: origin,
+            }),
+          { initialProps: { cs: null as Station | null } },
+        );
+        await act(async () => {
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(1); // cold-start 성공, context 결손
+
+        // Tier 2 POST가 네트워크 레벨에서 실패.
+        mockRegister.mockResolvedValueOnce({ ok: false, status: 500 });
+        await act(async () => {
+          jest.advanceTimersByTime(CONTEXT_HEAL_TIER2_DELAY_MS);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(mockRegister).toHaveBeenCalledTimes(2); // Tier 2 시도했지만 실패
+
+        // 세션이 잠기지 않았어야 하므로, currentStation이 실제로 해소되면(Tier 1) heal이
+        // 재시도돼 정상적으로 성공해야 한다. 버그(await 이전 무조건 잠금)가 있으면 이 register가
+        // 발사되지 않아 call count가 2에서 멈춘다.
+        mockRegister.mockResolvedValue({ ok: true });
+        rerender({ cs: origin });
+        await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(3));
+        const healed = mockRegister.mock.calls[2][0] as {
+          promptGeoContext?: { origin: { lat: number; lng: number } };
+          promptDisplay?: { originStation: string; line: string };
+        };
+        expect(healed.promptGeoContext?.origin).toEqual({ lat: origin.lat, lng: origin.lng });
+        expect(healed.promptDisplay).toEqual({ originStation: '대화', line: '3' });
+      });
     });
 
     describe('B-2 — GPS 근접 스탬프 (originDistanceM / originAccuracyM)', () => {

--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -1551,6 +1551,65 @@ describe('useApnsTripRegistration', () => {
       expect(mockRegister).toHaveBeenCalledTimes(2);
     });
 
+    it('P1 (재검증 리뷰) — override 적용 + POST 실패 반복 → 세션 미잠금 → 이후 Tier 1 재발동 가능', async () => {
+      // 회귀 배경: attemptRegisterRetry가 tier2Override를 적용할 때 await 이전(attempt 기준)에
+      // healedSessionKeyRef를 잠그면, backend 장애(Seoul outage류)로 register-retry 예산
+      // (3회)이 전부 network 실패로 소진될 때 "잠금은 걸려 있고 context는 한 번도 안 실린" 상태로
+      // 고착된다 — 이후 지상 재진입으로 currentStation이 다시 잡혀도 Tier 1이 이 잠금에 막혀
+      // 영구 결손이 재발한다(#2166이 Tier 1에서 이미 고친 것과 동일 클래스의 회귀).
+      const routeOrigin = st('3-002'); // 주엽 — routeOriginStation(Tier 2 override 기준).
+      const onRouteStation = origin; // 대화 — 이후 실제 GPS 해소로 Tier 1이 사용할 역(override와 다른 역).
+
+      mockRegister.mockResolvedValue({ ok: false, status: 500 }); // cold-start + 모든 재시도 network 실패
+
+      const { rerender } = renderHook(
+        ({ cs }: { cs: Station | null }) =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: cs,
+            subsurface: true,
+            routeOriginStation: routeOrigin,
+          }),
+        { initialProps: { cs: null as Station | null } },
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1); // cold-start 실패 — 15s 재시도 예약
+
+      // REGISTER_RETRY_BACKOFF_MS 전체(3회)를 모두 network 실패로 소진 — 매 시도마다
+      // tier2Override 조건은 충족되지만(override != null) POST 자체가 실패한다.
+      for (const delay of REGISTER_RETRY_BACKOFF_MS) {
+        // eslint-disable-next-line no-loop-func -- delay는 매 반복 고정값 캡처, closure 문제 없음.
+        await act(async () => {
+          jest.advanceTimersByTime(delay);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+      }
+      // 최초 1회 + backoff 배열 길이(3)만큼 재시도 = 4회, 전부 실패 — 재시도 예산 소진.
+      expect(mockRegister).toHaveBeenCalledTimes(1 + REGISTER_RETRY_BACKOFF_MS.length);
+
+      // 재시도 예산이 소진된 뒤, GPS가 실제로 해소돼(같은 hook 인스턴스에서) currentStation이
+      // null→non-null로 전환. 버그(attempt 기준 잠금)가 있다면 healedSessionKeyRef가 이미
+      // 잠겨 있어 Tier 1이 skip — 수정 후에는 한 번도 성공하지 못했으므로 잠금이 없어 Tier 1이
+      // 정상 발동해야 한다.
+      mockRegister.mockResolvedValueOnce({ ok: true });
+      rerender({ cs: onRouteStation });
+      await waitFor(() =>
+        expect(mockRegister).toHaveBeenCalledTimes(1 + REGISTER_RETRY_BACKOFF_MS.length + 1),
+      );
+      const healedPayload = mockRegister.mock.calls[mockRegister.mock.calls.length - 1][0] as {
+        promptGeoContext?: { origin: { lat: number; lng: number } };
+      };
+      expect(healedPayload.promptGeoContext?.origin).toEqual({
+        lat: onRouteStation.lat,
+        lng: onRouteStation.lng,
+      });
+    });
+
     it('P2-1 (PR #2169 리뷰) — heal-busy 재예약은 register-retry의 attempt 예산을 소모하지 않는다', async () => {
       // 회귀 배경: heal-busy로 인한 재예약이 실제 register 실패와 동일하게 attempt를 증가시키면
       // 실제 POST 시도가 0회인 채로 3회 상한(REGISTER_RETRY_BACKOFF_MS.length)을 태워버릴 수

--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -1300,6 +1300,200 @@ describe('useApnsTripRegistration', () => {
     });
   });
 
+  describe('#2167 — context-heal(Tier 1) ↔ register-retry(#1960) 상호 조율', () => {
+    // 단조 3호선 대화(3-001) → 정발산(3-003): buildBoardingPromptContext non-null 반환 보장.
+    const origin: Station = {
+      id: '3-001',
+      name: '대화',
+      line: '3',
+      lat: 37.676087,
+      lng: 126.747569,
+      lineColor: '#EF7C1C',
+    };
+    const dest: Station = {
+      id: '3-003',
+      name: '정발산',
+      line: '3',
+      lat: 37.659477,
+      lng: 126.773359,
+      lineColor: '#EF7C1C',
+    };
+    const route3 = makeDirectRoute(2, '3');
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('register-retry 대기 중 currentStation이 null→non-null로 전환되면 Tier 1 heal이 별도 POST를 쏘지 않고 대기 중인 재시도에 위임한다', async () => {
+      // 2167 회귀 재현: cold-start register 실패 → 15s 재시도 예약. 그 대기 창 안에서
+      // GPS/fusion이 currentStation을 해소하면(#2130 Tier 1 heal 트리거 조건 충족) 이전에는
+      // Tier 1이 재시도와 무관하게 즉시 독립 POST를 쏴 거의 동일 payload가 겹쳤다.
+      mockRegister.mockResolvedValueOnce({ ok: false, status: 500 });
+      mockRegister.mockResolvedValueOnce({ ok: true });
+
+      const { rerender } = renderHook(
+        ({ cs }: { cs: Station | null }) =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: cs,
+          }),
+        { initialProps: { cs: null as Station | null } },
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1); // 실패 — 15s 재시도 예약 + context 결손 기록
+
+      // 재시도 backoff(15s) 전에 currentStation이 해소(null→origin, on-route) — Tier 1 heal
+      // 트리거 조건(전환 + context 결손 + 세션 미heal)을 모두 충족하지만, 대기 중인 재시도가
+      // 있으므로 heal은 자체 POST를 쏘지 않고 skip해야 한다.
+      rerender({ cs: origin });
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[0] - 100);
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1); // heal이 독립 발사했다면 여기서 2가 됨(회귀)
+
+      // 재시도가 예정대로 발화 — latestInputsRef가 이미 해소된 origin을 반영하므로 이 한 건의
+      // POST가 재시도와 heal 목적을 동시에 달성한다(fresh context 포함, 이중 POST 없음).
+      await act(async () => {
+        jest.advanceTimersByTime(200);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+      const healedViaRetry = mockRegister.mock.calls[1][0] as {
+        promptGeoContext?: { origin: { lat: number; lng: number } };
+        promptDisplay?: { originStation: string; line: string };
+      };
+      expect(healedViaRetry.promptGeoContext?.origin).toEqual({ lat: origin.lat, lng: origin.lng });
+      expect(healedViaRetry.promptDisplay).toEqual({ originStation: '대화', line: '3' });
+
+      // 이후 시간이 더 지나도(Tier 2 지연 포함) 추가 POST 없음 — 재시도 성공으로 양쪽 loop 모두 해소.
+      await act(async () => {
+        jest.advanceTimersByTime(CONTEXT_HEAL_TIER2_DELAY_MS + 1000);
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+
+    it('합산 POST 상한 회귀 가드 — 재시도 대기 중 currentStation이 여러 번 흔들려도 heal이 추가 POST를 쌓지 않는다', async () => {
+      mockRegister.mockResolvedValueOnce({ ok: false, status: 500 });
+      mockRegister.mockResolvedValue({ ok: true });
+      const anotherOnRouteStation: Station = { ...origin, id: '3-002', name: '주엽' };
+
+      const { rerender } = renderHook(
+        ({ cs }: { cs: Station | null }) =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: cs,
+          }),
+        { initialProps: { cs: null as Station | null } },
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1); // 실패 — 재시도 예약
+
+      // 재시도 대기 중 currentStation이 두 번 더 흔들림(GPS jitter) — 매번 Tier 1 heal 트리거
+      // 조건은 충족되지만 재시도 in-flight/pending 상태라 추가 POST가 쌓이면 안 된다.
+      rerender({ cs: origin });
+      await act(async () => {
+        jest.advanceTimersByTime(2000);
+        await Promise.resolve();
+      });
+      rerender({ cs: anotherOnRouteStation });
+      await act(async () => {
+        jest.advanceTimersByTime(2000);
+        await Promise.resolve();
+      });
+      // 15s 예약 시점 전 — 합산 POST는 여전히 1건.
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[0]);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // 재시도 1건만 추가 — 합산 2건 상한(초기 1 + 재시도 1) 준수. heal 폭주로 3건 이상 되지 않는다.
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+
+    it('반대 방향 — Tier 1 heal POST가 in-flight인 동안 register-retry 타이머가 발화하면 겹쳐 쏘지 않고 다음 backoff로 재예약한다', async () => {
+      // 위 테스트가 "재시도 대기 중 heal 트리거"를 재현했다면, 이 테스트는 그 반대 순서를 재현한다:
+      // Tier 1 heal이 먼저 시작(retry가 아직 없던 시점이라 heal이 정상 발사)해 네트워크 응답을
+      // 기다리는 도중, 별개 dep(subsurface) 변경으로 main effect가 재실행되며 실패해 같은 세션에
+      // 대해 새 재시도가 예약된다. 그 backoff가 heal이 아직 응답을 못 받은 채로 발화하면, 이전에는
+      // attemptRegisterRetry가 heal과 무관하게 즉시 겹쳐 POST했다.
+      mockRegister.mockResolvedValueOnce({ ok: true }); // cold-start(성공하지만 currentStation=null → context 결손)
+
+      let resolveHealRegister!: (value: { ok: boolean }) => void;
+      const healDeferred = new Promise<{ ok: boolean }>((resolve) => {
+        resolveHealRegister = resolve;
+      });
+
+      const { rerender } = renderHook(
+        ({ cs, sub }: { cs: Station | null; sub: boolean }) =>
+          useApnsTripRegistration({
+            route: route3,
+            destination: dest,
+            nextStationEtaSeconds: 120,
+            currentStation: cs,
+            subsurface: sub,
+          }),
+        { initialProps: { cs: null as Station | null, sub: false } },
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1); // cold-start 성공, context 결손 기록
+
+      // Tier 1 heal 트리거 — 이 시점엔 대기 중인 재시도가 없으므로 heal이 정상 발사되고,
+      // registerActiveTrip 응답을 기다리며 pending 상태에 머문다(healInFlightSessionKeyRef 세팅).
+      mockRegister.mockImplementationOnce(() => healDeferred);
+      rerender({ cs: origin, sub: false });
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+
+      // 별개 dep(subsurface) 변경으로 main effect 재실행 — 이번엔 실패해 같은 세션에 재시도 예약(15s).
+      mockRegister.mockResolvedValueOnce({ ok: false, status: 500 });
+      rerender({ cs: origin, sub: true });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(3);
+
+      // 15s 경과 — 재시도 타이머 발화 시점에도 heal(2번째 호출)은 여전히 응답 대기 중(in-flight).
+      // 겹쳐 쏘지 않고 다음 backoff(30s)로 재예약해야 한다 — 아직 register 호출 없음.
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[0]);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(3); // heal in-flight 동안 겹쳐 쏘지 않음(회귀라면 4)
+
+      // heal이 완료(성공)되면 in-flight가 풀린다 — 재예약된 backoff(30s)가 도래하면 그때 재시도.
+      mockRegister.mockResolvedValueOnce({ ok: true });
+      resolveHealRegister({ ok: true });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[1]);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(4); // heal 완료 후 재예약된 재시도가 정상 발화
+    });
+  });
+
   // #903 (Seam G) — 기압계 subsurface 전달
   describe('subsurface (#903)', () => {
     const baseInputs = (subsurface?: boolean) => ({
@@ -1814,6 +2008,11 @@ describe('useApnsTripRegistration', () => {
       // build는 매번 성공하지만 backend POST가 계속 실패({ok:false})하는 상황 — 폭주 방지
       // 백스톱(CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION)이 station 전환이 반복돼도 세션당
       // heal POST 횟수를 제한해야 한다.
+      // #2167 — cold-start의 main effect register 자체는 성공(ok:true)시켜 register-retry(#1960)가
+      // 예약되지 않게 한다. retry가 pending 상태면 Tier 1 heal이 그쪽에 위임하며 skip하므로
+      // (본 이슈의 상호 조율 가드), 이 테스트가 검증하려는 "heal 자체의 세션당 POST 상한"과는
+      // 별개 관심사 — 순수하게 heal POST만 반복 실패하는 상황으로 격리한다.
+      mockRegister.mockResolvedValueOnce({ ok: true });
       mockRegister.mockResolvedValue({ ok: false, status: 500 });
       const mid = st('3-002'); // 주엽 — origin/dest 사이 실제 3호선 역, build 항상 성공.
       const alternating = [origin, mid];

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -559,13 +559,20 @@ export function useApnsTripRegistration({
     if (isRegisterRetryBusy(sessionKey)) return;
     const overrideContext = buildTier2FallbackOverride(sessionKey);
     if (overrideContext == null) return; // 조건 미충족 또는 route 구조상 빌드 실패 — graceful skip
-    healedSessionKeyRef.current = sessionKey;
+    // #2164 (리뷰 P1, c18bbac6 — PR #2166 머지 이후 push돼 dev에 유실됐다가 #2167에서 재적용) —
+    // 세션 잠금은 heal이 **성공**(context build + POST 네트워크 모두 성공)했을 때만 건다.
+    // 이전에는(#2167 재작업 과정에서 재발) await 이전에 무조건 세팅해, 지하(네트워크 최악
+    // 구간)에서 POST가 실패해도 세션이 영구 잠기고 이후 Tier 1 heal이 재발동하지 못하는 회귀가
+    // Tier 2 경로로 존속했다 — Tier 1은 이미 성공 기준(#2164)이므로 Tier 2도 대칭 적용한다.
     // #2167 — Tier 1과 동일하게 in-flight를 표시해야 register-retry(#1960)의 반대 방향 가드
     // (attemptRegisterRetry의 healInFlightSessionKeyRef 체크)가 Tier 2의 진행 중 POST도 감지해
     // 겹쳐 쏘지 않는다.
     healInFlightSessionKeyRef.current = sessionKey;
     try {
-      await registerFromLatestInputs(token, { promptContextOverride: overrideContext });
+      const result = await registerFromLatestInputs(token, { promptContextOverride: overrideContext });
+      if (result?.ok && result.hadPromptContext) {
+        healedSessionKeyRef.current = sessionKey;
+      }
     } finally {
       /* istanbul ignore else -- Tier 2는 세션당 1회만 실행되고(healedSessionKeyRef 가드) 이
        * 함수 안에서 sessionKey를 다른 값으로 바꿔치기하는 경로가 없어, 이 finally 시점엔 항상

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -401,6 +401,32 @@ export function useApnsTripRegistration({
     attempt: number;
     timer: ReturnType<typeof setTimeout> | null;
   }>({ sessionKey: null, attempt: 0, timer: null });
+  // #2167 — register-retry(#1960)의 실제 네트워크 호출이 진행 중인 세션. registerRetryRef의
+  // timer는 backoff 타이머가 발화하는 순간 즉시 null로 비워지므로(그 시점부터 실제 POST가 끝날
+  // 때까지의 창), "타이머 대기 중" 여부만으로는 이 창을 감지할 수 없다 — 별도 플래그로 추적한다.
+  const registerRetryInFlightSessionKeyRef = useRef<string | null>(null);
+
+  /**
+   * #2167 — context-heal(Tier 1/2)과 register-retry(#1960)는 같은 원인("register가 backend에
+   * context를 전달하지 못함")에 반응하는 독립 루프다. 서로의 in-flight를 모르면 재시도가
+   * 대기/진행 중인 세션에 heal이 겹쳐 거의 동일한 payload로 POST가 두 번 나간다(합산 시
+   * backend rate limit(10/10min) 여유 소진 — 이슈 #2167 배경).
+   *
+   * 스케줄러 단일화 대신 상호 in-flight 체크를 택했다: 이미 3개(main effect / Tier 1 / Tier 2)로
+   * 나뉜 register 트리거 경로를 하나의 스케줄러로 합치면 각 트리거의 고유 조건(라우트 전환,
+   * currentStation 결과 상태, subsurface fallback 지연)을 모두 흡수하는 범용 스케줄러가 필요해
+   * diff가 커지고 재시도 루프 sprawl을 오히려 늘린다(fire-path 통합 lesson과 충돌). 반면 in-flight
+   * 체크는 기존 세 루프의 구조를 그대로 두고 "발사 직전 한 줄 가드"만 추가하면 된다 — 더 작고
+   * 안전한 diff.
+   *
+   * register-retry가 세션에 대해 대기(backoff 타이머 armed) 또는 실행 중이면 heal은 스스로
+   * POST하지 않고 skip한다: 재시도가 실제 발화할 때 `registerFromLatestInputs`가 그 시점의
+   * 최신 `currentStation`(이미 heal이 해소하려던 값)을 그대로 사용해 context를 함께 실어
+   * 보내므로, 재시도 1건이 재시도 목적과 heal 목적을 동시에 달성한다.
+   */
+  const isRegisterRetryBusy = (sessionKey: string): boolean =>
+    registerRetryInFlightSessionKeyRef.current === sessionKey ||
+    (registerRetryRef.current.sessionKey === sessionKey && registerRetryRef.current.timer !== null);
 
   /**
    * #2129 — 두 register 경로(main effect / token-refresh listener)가 거의 동시에 실행돼도
@@ -487,6 +513,18 @@ export function useApnsTripRegistration({
      * 살아남는 경로가 현재 코드에 없다. 향후 리팩터로 그 보장이 깨질 경우를 대비한 방어적 가드
      * (#2164 폭주 방지 belt-and-suspenders). */
     if (healInFlightSessionKeyRef.current === sessionKey) return;
+    /* istanbul ignore next -- #2167: Tier 2 fallback 타이머는 main effect의 직전 register가
+     * **성공**(ok:true)했을 때만 arm되고(위 주석 참조), main effect가 재실행될 때마다(deps 변경)
+     * 그 cleanup이 무조건 tier2TimerRef를 clearTimeout한다. register-retry(#1960)는 오직 main
+     * effect 자신의 register가 **실패**할 때만 예약되므로, "이 세션의 Tier 2 타이머가 여전히
+     * armed 상태"와 "이 세션에 재시도가 대기/진행 중"이 동시에 참인 경로가 현재 코드에 없다
+     * (재시도를 만든 실행이 반드시 Tier 2 타이머를 먼저 지운다). register-retry(#1960) ↔
+     * context-heal(Tier 1)의 실제 회귀 재현은 위 Tier 1 가드(및 그 반대 방향, attemptRegisterRetry의
+     * healInFlightSessionKeyRef 체크)로 커버된다 — 이 체크는 향후 Tier 2 스케줄링이 독립화될
+     * 경우를 대비한 belt-and-suspenders. */
+    // #2167 — register-retry(#1960)가 이 세션에 대해 대기/진행 중이면 Tier 2도 자체 POST를
+    // 쏘지 않는다. 재시도가 발화하면 latestInputsRef 기준 최신 context를 함께 실어 보낸다.
+    if (isRegisterRetryBusy(sessionKey)) return;
     const overrideContext = buildBoardingPromptContext({
       route: r,
       currentStation: origin,
@@ -496,7 +534,21 @@ export function useApnsTripRegistration({
     });
     if (overrideContext == null) return; // route 구조상 빌드 실패 — graceful skip
     healedSessionKeyRef.current = sessionKey;
-    await registerFromLatestInputs(token, { promptContextOverride: overrideContext });
+    // #2167 — Tier 1과 동일하게 in-flight를 표시해야 register-retry(#1960)의 반대 방향 가드
+    // (attemptRegisterRetry의 healInFlightSessionKeyRef 체크)가 Tier 2의 진행 중 POST도 감지해
+    // 겹쳐 쏘지 않는다.
+    healInFlightSessionKeyRef.current = sessionKey;
+    try {
+      await registerFromLatestInputs(token, { promptContextOverride: overrideContext });
+    } finally {
+      /* istanbul ignore else -- Tier 2는 세션당 1회만 실행되고(healedSessionKeyRef 가드) 이
+       * 함수 안에서 sessionKey를 다른 값으로 바꿔치기하는 경로가 없어, 이 finally 시점엔 항상
+       * 자신이 세팅한 sessionKey 그대로다. 다른 트립의 Tier 1이 그 사이 다른 sessionKey로 이
+       * ref를 덮어쓰는 극단적 교차 시나리오를 대비한 방어적 mismatch 분기. */
+      if (healInFlightSessionKeyRef.current === sessionKey) {
+        healInFlightSessionKeyRef.current = null;
+      }
+    }
   };
 
   /** #1960 — 대기 중인 register 재시도 타이머/상태를 모두 초기화. */
@@ -551,18 +603,37 @@ export function useApnsTripRegistration({
      * (위 runTier2Heal)와 같은 방어적 처리. */
     if (!r || !d || `${routeSignature(r)}:${d.id}` !== sessionKey) return; // trip 종료/전환됨 — 재시도 대상 아님
 
+    // #2167 — 같은 세션에 대해 context-heal(Tier 1) POST가 이미 in-flight면 이번 backoff는
+    // 건너뛰고 다음 backoff로 재예약한다. heal의 결과(성공 시 context 확보 + lastRegisterMissingContextRef
+    // 갱신)를 본 뒤 재시도하면 heal과 동일 payload를 겹쳐 쏘지 않는다.
+    if (healInFlightSessionKeyRef.current === sessionKey) {
+      scheduleRegisterRetry(sessionKey);
+      return;
+    }
+
     const token = await AsyncStorage.getItem(APNS_TOKEN_KEY);
     if (!token) {
       // 토큰 여전히 미가용 — 다음 backoff 예약.
       scheduleRegisterRetry(sessionKey);
       return;
     }
-    const result = await registerFromLatestInputs(token);
-    if (result?.ok) {
-      clearRegisterRetry();
-      await AsyncStorage.setItem(ACTIVE_TRIP_KEY, token);
-    } else {
-      scheduleRegisterRetry(sessionKey);
+    registerRetryInFlightSessionKeyRef.current = sessionKey;
+    try {
+      const result = await registerFromLatestInputs(token);
+      if (result?.ok) {
+        clearRegisterRetry();
+        await AsyncStorage.setItem(ACTIVE_TRIP_KEY, token);
+      } else {
+        scheduleRegisterRetry(sessionKey);
+      }
+    } finally {
+      /* istanbul ignore else -- registerRetryRef는 단일 타이머라 attemptRegisterRetry가
+       * 동시에 둘 이상 실행 중일 수 없고, 이 함수 안에서 sessionKey를 다른 값으로 바꿔치기하는
+       * 경로도 없어 이 finally 시점엔 항상 자신이 세팅한 sessionKey 그대로다. 향후 리팩터로 그
+       * 보장이 깨질 경우를 대비한 방어적 mismatch 분기. */
+      if (registerRetryInFlightSessionKeyRef.current === sessionKey) {
+        registerRetryInFlightSessionKeyRef.current = null;
+      }
     }
   };
 
@@ -836,6 +907,12 @@ export function useApnsTripRegistration({
      * body보다 먼저 동기 실행한다. 따라서 이 effect 스스로 인해 in-flight가 살아있는 채로 다시
      * 진입하는 경로가 현재 코드에 없다(Tier 2의 in-flight 체크와 동일 성격의 방어적 가드). */
     if (healInFlightSessionKeyRef.current === sessionKey) return; // 동일 세션 heal 진행 중.
+    // #2167 — register-retry(#1960)가 이 세션에 대해 대기(backoff armed) 또는 진행 중이면
+    // heal은 자체 POST를 쏘지 않고 skip한다. 재시도가 발화하면 이 시점의 최신 currentStation
+    // (지금 heal이 해소하려는 값)을 latestInputsRef를 통해 그대로 실어 보내 재시도 1건이 재시도
+    // 목적과 heal 목적을 함께 달성한다 — 두 루프가 겹쳐 거의 동일 payload를 두 번 POST하는
+    // 회귀(#2167 배경) 차단.
+    if (isRegisterRetryBusy(sessionKey)) return;
 
     // #2164 — build 성공 여부를 먼저 확인 — 실패하면 POST 자체를 내지 않는다(세션 미잠금,
     // 상한도 소비하지 않음 — 다음 전환에서 다시 시도).

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -40,6 +40,8 @@ import {
   CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION,
   CONTEXT_HEAL_TIER2_DELAY_MS,
   REGISTER_RETRY_BACKOFF_MS,
+  REGISTER_RETRY_HEAL_BUSY_MAX_RESCHEDULES,
+  REGISTER_RETRY_HEAL_BUSY_RECHECK_MS,
 } from '../../../shared/constants/boardingLock';
 import { createLogger } from '../../../shared/utils/logger';
 import { getRegisteringApnsEnv, warmupConfirmedApnsEnv } from '../../../shared/utils/apnsEnv';
@@ -405,6 +407,13 @@ export function useApnsTripRegistration({
   // timer는 backoff 타이머가 발화하는 순간 즉시 null로 비워지므로(그 시점부터 실제 POST가 끝날
   // 때까지의 창), "타이머 대기 중" 여부만으로는 이 창을 감지할 수 없다 — 별도 플래그로 추적한다.
   const registerRetryInFlightSessionKeyRef = useRef<string | null>(null);
+  // #2167 (P2-1, PR #2169 리뷰) — register-retry가 heal-busy로 인해 recheck 목적으로 재예약한
+  // 횟수. `registerRetryRef.current.attempt`(실제 backoff 예산)와 분리해 추적한다 — heal이 잠깐
+  // in-flight라 건너뛴 것은 실제 register 실패가 아니므로 attempt 예산을 소모하면 안 된다.
+  const registerRetryHealBusyRef = useRef<{ sessionKey: string | null; count: number }>({
+    sessionKey: null,
+    count: 0,
+  });
 
   /**
    * #2167 — context-heal(Tier 1/2)과 register-retry(#1960)는 같은 원인("register가 backend에
@@ -487,6 +496,39 @@ export function useApnsTripRegistration({
   };
 
   /**
+   * #2167 (P1, PR #2169 리뷰) — Tier 2 지하 fallback 발동 조건(currentStation 미해소 +
+   * subsurface + route 출발역 가용 + 세션 미heal)을 확인하고, 충족하면 override context를
+   * 빌드해 반환한다. Tier 2 자신의 setTimeout 콜백(`runTier2Heal`)뿐 아니라
+   * register-retry(#1960, `attemptRegisterRetry`)가 성공적으로 register를 완료하는 시점에도
+   * 이 조건을 함께 확인해야 한다 — Tier 2 타이머는 오직 main effect `run()`의 register가
+   * **직접** 성공했을 때만 arm되므로, 세션의 첫 register가 (실패 후) retry를 통해서만 성공하면
+   * Tier 2가 애초에 armed될 기회가 없어 지하 dead-zone 세션이 영구히 context 결손 상태로
+   * 고착되는 회귀가 있었다.
+   */
+  const buildTier2FallbackOverride = (sessionKey: string): BoardingPromptContext | null => {
+    const { route: r, destination: d, currentStation: cs, subsurface: sub, boardingLock: bl, routeOriginStation: origin } =
+      latestInputsRef.current;
+    /* istanbul ignore next -- route/destination이 null로 바뀌는 모든 경로(deps: routeSig,
+     * destination?.id)는 main register effect의 cleanup이 트립 종료 시점에 tier2TimerRef를
+     * 이미 clearTimeout하므로, Tier 2 콜백 경로에서 이 지점에 trip 종료 상태로 도달할 경로가
+     * 없다. register-retry(#1960) 경로(attemptRegisterRetry)는 자체적으로 route/destination
+     * null을 이미 상위에서 검증하고 리턴하므로 여기까지 오지 않는다. 향후 리팩터로 그 보장이
+     * 깨질 경우를 대비한 방어적 가드. */
+    if (!r || !d) return null; // trip 종료됨
+    if (cs != null) return null; // 이미 GPS로 해소됨 — Tier 2 대상 아님
+    if (!sub) return null; // 지하 판정 아님
+    if (origin == null) return null; // fallback 대상 route 출발역 없음
+    if (healedSessionKeyRef.current === sessionKey) return null; // 이미 heal 성공(Tier 1 포함)
+    return buildBoardingPromptContext({
+      route: r,
+      currentStation: origin,
+      destination: d,
+      lock: bl,
+      // gpsFix 미전달 — Tier 2 fallback은 스탬프 없이 송신(currentStation 자체가 GPS 미해소 상태).
+    });
+  };
+
+  /**
    * #2130 (B-1 Tier 2) — 지하 fallback heal. 등록 후 `CONTEXT_HEAL_TIER2_DELAY_MS` 시점에
    * currentStation이 여전히 미해소 + subsurface 판정이면 route 출발역(`routeOriginStation`)
    * 기준으로 promptContext를 빌드해 스탬프 없이 재등록한다.
@@ -495,44 +537,28 @@ export function useApnsTripRegistration({
    * 판정, 사용자가 route 미확정(routeOriginStation 없음) 등은 모두 정상 상태다.
    */
   const runTier2Heal = async (token: string, sessionKey: string): Promise<void> => {
-    const { route: r, destination: d, currentStation: cs, subsurface: sub, boardingLock: bl, routeOriginStation: origin } =
-      latestInputsRef.current;
-    /* istanbul ignore next -- route/destination이 null로 바뀌는 모든 경로(deps: routeSig,
-     * destination?.id)는 이 effect의 cleanup이 트립 종료 시점에 tier2TimerRef를 이미
-     * clearTimeout하므로, 이 콜백 자체가 trip 종료 후 실행될 도달 경로가 없다. 향후 리팩터로
-     * 그 보장이 깨질 경우를 대비한 방어적 가드. */
-    if (!r || !d) return; // trip 종료됨
-    if (cs != null) return; // 이미 GPS로 해소됨 — Tier 2 대상 아님
-    if (!sub) return; // 지하 판정 아님
-    if (origin == null) return; // fallback 대상 route 출발역 없음
-    if (healedSessionKeyRef.current === sessionKey) return; // 이미 heal 성공(Tier 1 포함)
     /* istanbul ignore next -- Tier 1은 currentStation이 non-null로 전환될 때만 in-flight를
-     * 세팅하는데, 바로 위 `cs != null` 가드가 이미 그 경우를 걸러낸다(이 지점 도달 시 cs는
-     * 항상 null). 또한 Tier 1의 effect cleanup은 currentStation.id가 바뀌는 매 렌더마다
-     * 동기적으로 in-flight를 지우므로, cs가 null로 유지되는 한 Tier 1의 in-flight가 이 시점까지
-     * 살아남는 경로가 현재 코드에 없다. 향후 리팩터로 그 보장이 깨질 경우를 대비한 방어적 가드
-     * (#2164 폭주 방지 belt-and-suspenders). */
+     * 세팅하는데, buildTier2FallbackOverride의 `cs != null` 가드가 이미 그 경우를 걸러낸다
+     * (이 지점 도달 시 cs는 항상 null). 또한 Tier 1의 effect cleanup은 currentStation.id가
+     * 바뀌는 매 렌더마다 동기적으로 in-flight를 지우므로, cs가 null로 유지되는 한 Tier 1의
+     * in-flight가 이 시점까지 살아남는 경로가 현재 코드에 없다. 향후 리팩터로 그 보장이 깨질
+     * 경우를 대비한 방어적 가드(#2164 폭주 방지 belt-and-suspenders). */
     if (healInFlightSessionKeyRef.current === sessionKey) return;
     /* istanbul ignore next -- #2167: Tier 2 fallback 타이머는 main effect의 직전 register가
-     * **성공**(ok:true)했을 때만 arm되고(위 주석 참조), main effect가 재실행될 때마다(deps 변경)
-     * 그 cleanup이 무조건 tier2TimerRef를 clearTimeout한다. register-retry(#1960)는 오직 main
-     * effect 자신의 register가 **실패**할 때만 예약되므로, "이 세션의 Tier 2 타이머가 여전히
-     * armed 상태"와 "이 세션에 재시도가 대기/진행 중"이 동시에 참인 경로가 현재 코드에 없다
-     * (재시도를 만든 실행이 반드시 Tier 2 타이머를 먼저 지운다). register-retry(#1960) ↔
-     * context-heal(Tier 1)의 실제 회귀 재현은 위 Tier 1 가드(및 그 반대 방향, attemptRegisterRetry의
-     * healInFlightSessionKeyRef 체크)로 커버된다 — 이 체크는 향후 Tier 2 스케줄링이 독립화될
-     * 경우를 대비한 belt-and-suspenders. */
+     * **성공**(ok:true)했을 때만 arm되고(buildTier2FallbackOverride 주석 참조), main effect가
+     * 재실행될 때마다(deps 변경) 그 cleanup이 무조건 tier2TimerRef를 clearTimeout한다.
+     * register-retry(#1960)는 오직 main effect 자신의 register가 **실패**할 때만 예약되므로,
+     * "이 세션의 Tier 2 타이머가 여전히 armed 상태"와 "이 세션에 재시도가 대기/진행 중"이
+     * 동시에 참인 경로가 현재 코드에 없다(재시도를 만든 실행이 반드시 Tier 2 타이머를 먼저
+     * 지운다). register-retry(#1960) ↔ context-heal(Tier 1)의 실제 회귀 재현은 위 Tier 1
+     * 가드(및 그 반대 방향, attemptRegisterRetry의 healInFlightSessionKeyRef 체크)로 커버된다
+     * — 이 체크는 향후 Tier 2 스케줄링이 독립화될 경우를 대비한 belt-and-suspenders. */
     // #2167 — register-retry(#1960)가 이 세션에 대해 대기/진행 중이면 Tier 2도 자체 POST를
-    // 쏘지 않는다. 재시도가 발화하면 latestInputsRef 기준 최신 context를 함께 실어 보낸다.
+    // 쏘지 않는다. 재시도가 발화하면 buildTier2FallbackOverride를 자체적으로 확인해(P1) 같은
+    // context를 함께 실어 보낸다.
     if (isRegisterRetryBusy(sessionKey)) return;
-    const overrideContext = buildBoardingPromptContext({
-      route: r,
-      currentStation: origin,
-      destination: d,
-      lock: bl,
-      // gpsFix 미전달 — Tier 2는 스탬프 없이 송신(currentStation 자체가 GPS 미해소 상태).
-    });
-    if (overrideContext == null) return; // route 구조상 빌드 실패 — graceful skip
+    const overrideContext = buildTier2FallbackOverride(sessionKey);
+    if (overrideContext == null) return; // 조건 미충족 또는 route 구조상 빌드 실패 — graceful skip
     healedSessionKeyRef.current = sessionKey;
     // #2167 — Tier 1과 동일하게 in-flight를 표시해야 register-retry(#1960)의 반대 방향 가드
     // (attemptRegisterRetry의 healInFlightSessionKeyRef 체크)가 Tier 2의 진행 중 POST도 감지해
@@ -590,6 +616,45 @@ export function useApnsTripRegistration({
   };
 
   /**
+   * #2167 (P2-1, PR #2169 리뷰) — register-retry가 같은 세션의 context-heal(Tier 1/2) POST와
+   * in-flight로 겹쳐 이번 backoff를 건너뛸 때 전용 recheck 예약. `scheduleRegisterRetry`(실제
+   * register 실패 전용, attempt 예산 소모)와 분리해 attempt를 소모하지 않는다 — heal-busy는
+   * register가 실패한 게 아니라 "잠깐 다른 루프가 같은 목적으로 이미 POST 중"이라는 신호일
+   * 뿐이라 backoff 예산을 태우면 안 된다(P2-1). heal이 비정상적으로 오래 걸리는 상황에 대비해
+   * 재예약 횟수 자체엔 별도 상한(`REGISTER_RETRY_HEAL_BUSY_MAX_RESCHEDULES`)을 둔다 — 상한
+   * 도달 시엔 일반 backoff(`scheduleRegisterRetry`, attempt 소모)로 전환해 무한 대기를 막는다.
+   */
+  const rescheduleRegisterRetryForHealBusy = (sessionKey: string): void => {
+    if (registerRetryHealBusyRef.current.sessionKey !== sessionKey) {
+      registerRetryHealBusyRef.current = { sessionKey, count: 0 };
+    }
+    if (registerRetryHealBusyRef.current.count >= REGISTER_RETRY_HEAL_BUSY_MAX_RESCHEDULES) {
+      logger.info(
+        `register retry: heal-busy 재예약 상한(${REGISTER_RETRY_HEAL_BUSY_MAX_RESCHEDULES}) 도달 — 일반 backoff로 전환`,
+        sessionKey,
+      );
+      scheduleRegisterRetry(sessionKey);
+      return;
+    }
+    registerRetryHealBusyRef.current.count += 1;
+    /* istanbul ignore next -- 이 함수는 attemptRegisterRetry 내부에서만 호출되고,
+     * attemptRegisterRetry는 오직 scheduleRegisterRetry 또는 이 함수 자신의 setTimeout
+     * 콜백을 통해서만 실행된다 — 두 콜백 모두 `attemptRegisterRetry` 호출 직전에 동기적으로
+     * `registerRetryRef.current.timer = null`을 세팅하므로, 이 지점에 도달했을 때 timer가
+     * non-null인 경로가 현재 코드에 없다. scheduleRegisterRetry의 동일 성격 가드와 같은
+     * 방어적 처리(향후 호출 경로가 늘어날 경우를 대비). */
+    if (registerRetryRef.current.timer !== null) {
+      clearTimeout(registerRetryRef.current.timer);
+    }
+    // sessionKey/attempt는 건드리지 않는다 — 이 재예약은 attempt 예산과 무관한 recheck다.
+    registerRetryRef.current.sessionKey = sessionKey;
+    registerRetryRef.current.timer = setTimeout(() => {
+      registerRetryRef.current.timer = null;
+      void attemptRegisterRetry(sessionKey);
+    }, REGISTER_RETRY_HEAL_BUSY_RECHECK_MS);
+  };
+
+  /**
    * #1960 — 예약된 재시도 실행. 활성 trip이 여전히 같은 세션인지 재검증(trip 전환/종료 시
    * self-cancel) 후 token을 다시 조회해 register를 재시도한다. 성공(`ok:true`, dedup skip
    * 포함)하면 재시도 상태를 초기화, 실패하면 다음 backoff를 예약한다.
@@ -603,12 +668,18 @@ export function useApnsTripRegistration({
      * (위 runTier2Heal)와 같은 방어적 처리. */
     if (!r || !d || `${routeSignature(r)}:${d.id}` !== sessionKey) return; // trip 종료/전환됨 — 재시도 대상 아님
 
-    // #2167 — 같은 세션에 대해 context-heal(Tier 1) POST가 이미 in-flight면 이번 backoff는
-    // 건너뛰고 다음 backoff로 재예약한다. heal의 결과(성공 시 context 확보 + lastRegisterMissingContextRef
-    // 갱신)를 본 뒤 재시도하면 heal과 동일 payload를 겹쳐 쏘지 않는다.
+    // #2167 — 같은 세션에 대해 context-heal(Tier 1/2) POST가 이미 in-flight면 이번 backoff는
+    // 건너뛰고 recheck를 예약한다(P2-1 — attempt 예산은 소모하지 않는다). heal의 결과(성공 시
+    // context 확보 + lastRegisterMissingContextRef 갱신)를 본 뒤 재시도하면 heal과 동일
+    // payload를 겹쳐 쏘지 않는다.
     if (healInFlightSessionKeyRef.current === sessionKey) {
-      scheduleRegisterRetry(sessionKey);
+      rescheduleRegisterRetryForHealBusy(sessionKey);
       return;
+    }
+    // heal-busy 대기가 끝나고 정상 진행하는 경로 — 이 세션의 recheck 카운터를 리셋해, 나중에
+    // 별개의 heal-busy 에피소드가 다시 생겨도 이전 에피소드의 재예약 횟수와 합산되지 않게 한다.
+    if (registerRetryHealBusyRef.current.sessionKey === sessionKey) {
+      registerRetryHealBusyRef.current = { sessionKey: null, count: 0 };
     }
 
     const token = await AsyncStorage.getItem(APNS_TOKEN_KEY);
@@ -619,7 +690,21 @@ export function useApnsTripRegistration({
     }
     registerRetryInFlightSessionKeyRef.current = sessionKey;
     try {
-      const result = await registerFromLatestInputs(token);
+      // #2167 (P1) — Tier 2 지하 fallback 조건이 충족되면 override를 함께 실어 보낸다. 세션의
+      // 첫 register가 (Tier 2를 arm하는) main effect run()이 아니라 이 retry로만 성공하면
+      // Tier 2 자체가 armed될 기회가 없어 지하 dead-zone 세션이 영구히 context 결손 상태로
+      // 고착되는 회귀를 막는다 — buildTier2FallbackOverride가 조건 미충족/이미 heal 시 null을
+      // 반환하므로 해당 없는 세션에는 영향 없다.
+      const tier2Override = buildTier2FallbackOverride(sessionKey);
+      if (tier2Override != null) {
+        // Tier 2와 동일하게 성공 여부와 무관하게 즉시 세션을 잠근다(#2130 Tier 2 정책과 일치) —
+        // POST 네트워크가 계속 실패하는 상황에서 매 재시도마다 override 시도가 반복되지 않게.
+        healedSessionKeyRef.current = sessionKey;
+      }
+      const result = await registerFromLatestInputs(
+        token,
+        tier2Override != null ? { promptContextOverride: tier2Override } : undefined,
+      );
       if (result?.ok) {
         clearRegisterRetry();
         await AsyncStorage.setItem(ACTIVE_TRIP_KEY, token);
@@ -627,10 +712,6 @@ export function useApnsTripRegistration({
         scheduleRegisterRetry(sessionKey);
       }
     } finally {
-      /* istanbul ignore else -- registerRetryRef는 단일 타이머라 attemptRegisterRetry가
-       * 동시에 둘 이상 실행 중일 수 없고, 이 함수 안에서 sessionKey를 다른 값으로 바꿔치기하는
-       * 경로도 없어 이 finally 시점엔 항상 자신이 세팅한 sessionKey 그대로다. 향후 리팩터로 그
-       * 보장이 깨질 경우를 대비한 방어적 mismatch 분기. */
       if (registerRetryInFlightSessionKeyRef.current === sessionKey) {
         registerRetryInFlightSessionKeyRef.current = null;
       }
@@ -727,6 +808,13 @@ export function useApnsTripRegistration({
         prevCurrentStationIdRef.current = null;
         // #1960: trip 종료 시 register 재시도 상태도 초기화 — 다음 trip이 새로 재시도 3회 기회를 갖는다.
         clearRegisterRetry();
+        // #2167 (P2-2, PR #2169 리뷰) — healInFlightSessionKeyRef와 대칭으로 register-retry의
+        // in-flight/heal-busy 추적도 초기화. 초기화하지 않으면 이 trip의 retry가 여전히
+        // in-flight인 채로 trip이 종료되고, 곧바로 동일 sessionKey(같은 route+destination)로
+        // 새 trip이 시작될 때 stale in-flight 플래그가 `isRegisterRetryBusy`를 통해 새 trip의
+        // context-heal(Tier 1/2)을 영구히 차단하는 회귀가 있었다.
+        registerRetryInFlightSessionKeyRef.current = null;
+        registerRetryHealBusyRef.current = { sessionKey: null, count: 0 };
         return;
       }
 

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -696,15 +696,20 @@ export function useApnsTripRegistration({
       // 고착되는 회귀를 막는다 — buildTier2FallbackOverride가 조건 미충족/이미 heal 시 null을
       // 반환하므로 해당 없는 세션에는 영향 없다.
       const tier2Override = buildTier2FallbackOverride(sessionKey);
-      if (tier2Override != null) {
-        // Tier 2와 동일하게 성공 여부와 무관하게 즉시 세션을 잠근다(#2130 Tier 2 정책과 일치) —
-        // POST 네트워크가 계속 실패하는 상황에서 매 재시도마다 override 시도가 반복되지 않게.
-        healedSessionKeyRef.current = sessionKey;
-      }
       const result = await registerFromLatestInputs(
         token,
         tier2Override != null ? { promptContextOverride: tier2Override } : undefined,
       );
+      // #2167 (P1, 재검증 리뷰) — 세션 잠금은 override가 **실제로 backend에 전달됐을 때만**
+      // 건다(Tier 1/Tier 2와 동일한 성공 기준). attempt(시도) 기준으로 await 이전에 잠그면,
+      // backend 장애로 register-retry 예산(3회)이 전부 network 실패로 소진될 때 세션이
+      // 잠긴 채 context는 한 번도 전달되지 못하고 retry도 끝나버려 — 이후 지상 재진입으로
+      // currentStation이 다시 잡혀도 Tier 1이 이 잠금에 막혀 영구 결손이 재발한다(#2166이
+      // Tier 1에서 이미 고친 것과 동일 클래스의 회귀). 실패 시에는 잠그지 않아 다음 재시도/
+      // Tier 1 전환에서 다시 시도할 수 있게 둔다.
+      if (tier2Override != null && result?.ok && result.hadPromptContext) {
+        healedSessionKeyRef.current = sessionKey;
+      }
       if (result?.ok) {
         clearRegisterRetry();
         await AsyncStorage.setItem(ACTIVE_TRIP_KEY, token);

--- a/src/shared/constants/boardingLock.ts
+++ b/src/shared/constants/boardingLock.ts
@@ -166,3 +166,21 @@ export const REGISTER_RETRY_BACKOFF_MS: readonly number[] = [15_000, 30_000, 60_
  * 내지 않으므로 backend 부담이 없고, 다음 전환에서 다시 시도할 기회를 줘야 하기 때문이다.
  */
 export const CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION = 3;
+
+/**
+ * #2167 (P2-1, PR #2169 리뷰) — register-retry(#1960)가 발화했으나 같은 세션의
+ * context-heal(Tier 1/2) POST가 in-flight라 이번 backoff를 건너뛰고 재예약하는 경우 전용
+ * recheck 지연(ms) + 재예약 횟수 상한.
+ *
+ * 배경: 이 재예약은 실제 register 실패가 아니라 "잠깐 heal이 끝날 때까지 대기"일 뿐이므로
+ * `REGISTER_RETRY_BACKOFF_MS`의 attempt 예산을 소모하면 실제 POST 시도가 0회인 채로 3회
+ * 상한을 태워버릴 수 있다(P2-1). attempt와 분리된 짧은 recheck 간격을 쓰고, 그 recheck 자체도
+ * heal이 비정상적으로 오래 걸리는 상황(POST 응답 지연/네트워크 hang)에 대비해 별도 상한을 둔다
+ * — 상한 도달 시엔 일반 backoff(`scheduleRegisterRetry`, attempt 소모)로 전환해 무한 대기를
+ * 방지한다.
+ *
+ * 2s로 둔 이유: 일반적인 register POST 왕복(수백 ms~1~2s)을 커버하면서도 배터리 소모가
+ * 미미한 짧은 간격.
+ */
+export const REGISTER_RETRY_HEAL_BUSY_RECHECK_MS = 2_000;
+export const REGISTER_RETRY_HEAL_BUSY_MAX_RESCHEDULES = 5;


### PR DESCRIPTION
Closes #2167

## 배경

`useApnsTripRegistration.ts`에 "register가 backend에 context를 전달 못함"이라는 같은
원인에 반응하는 독립 재시도 루프가 3개 존재했다: main effect(성공 시 clear/실패 시
register-retry(#1960, 15/30/60s backoff)), context-heal Tier 1(currentStation 전환
트리거), Tier 2(60s 지하 fallback). 서로의 in-flight를 몰라 retry가 대기/진행 중인
세션에 heal이 겹쳐 거의 동일한 payload로 POST가 두 번 나갈 수 있었다.

## 변경 사항

- `isRegisterRetryBusy(sessionKey)` — register-retry가 해당 세션에 대해 대기
  (backoff armed) 또는 실행 중(`registerRetryInFlightSessionKeyRef`)이면 true.
  Tier 1 heal effect와 Tier 2(`runTier2Heal`)가 발사 직전 이 가드를 확인해 in-flight
  세션이면 스스로 POST하지 않고 skip한다. retry가 발화하면
  `registerFromLatestInputs`가 그 시점의 최신 `currentStation`을 그대로 실어
  보내므로, 재시도 1건이 재시도 목적과 heal 목적을 동시에 달성한다.
- 반대 방향 — `attemptRegisterRetry`도 발사 직전 `healInFlightSessionKeyRef`를
  확인해 context-heal(Tier 1/2)이 같은 세션에 in-flight면 이번 backoff를 건너뛰고
  다음 backoff로 재예약한다. Tier 2도 Tier 1과 동일하게 자신의 POST 구간 동안
  `healInFlightSessionKeyRef`를 세팅하도록 맞춰 두 방향 모두 대칭적으로 보호한다.

## 설계 판단 — 상호 in-flight 체크 vs 스케줄러 단일화

**상호 in-flight 체크를 채택했다.** 스케줄러 단일화(3개 트리거를 하나의 범용
스케줄러로 합치는 안)는 각 트리거의 고유 조건(route/destination/lock 변경,
currentStation 결과 상태 전환, subsurface 60s fallback 지연)을 모두 흡수해야 해서
diff가 훨씬 커지고, "재시도 루프 sprawl을 늘리지 말 것"이라는 fire-path 통합
lesson과 충돌한다. 반면 in-flight 체크는 기존 세 루프의 구조를 그대로 두고
"발사 직전 한 줄 가드"만 추가하면 되어 diff가 작고 각 루프의 검증된 개별 동작을
보존한다.

## Backend isSameSession dedup 전제 확인

`backend/alarm-worker/src/index.ts`의 `evaluateSameSession`(trainCode 일치 또는
`SESSION_DRIFT_WINDOW_MS` 이내 createdAt)이 중복 POST를 **상태 corruption 관점에서는**
무해화한다 — progress/waypoints/`lastAutoPromptedAt` 등이 보존되며 trip 본체가
깨지지 않는다. 다만 `tripRegisterRateLimit.ts`(V8 (b), 10회/10min 토큰별 cap) 주석이
명시하듯 dedup은 KV read/write + validate 자체를 막지 않는다 — 즉 **rate limit
소진 관점에서는 무해화되지 않는다**. 이슈 배경의 "합산 시 backend rate limit 여유가
줄어듦" 우려가 정확했고, 이번 in-flight 체크가 그 여유 소진을 실제로 줄인다.

## TDD

- red: "register-retry 대기 중 currentStation 전환 → Tier 1이 별도 POST" 시나리오
  재현(수정 전 실패 확인) → 가드 추가로 green.
- red: 반대 방향(heal in-flight 중 retry 타이머 발화) 시나리오도 동일하게 재현 →
  green.
- 회귀 가드: 재시도 대기 중 currentStation이 여러 번 흔들려도 합산 POST가
  상한(초기 1 + 재시도 1 = 2)을 넘지 않는지 검증하는 테스트 추가.
- 기존 "Tier 1 세션당 POST 상한(3회)" 테스트는 cold-start register 자체를 성공
  (ok:true)시키도록 조정 — 본 PR의 가드로 인해 register-retry가 함께 예약되면
  heal이 그쪽에 위임하며 skip하는 게 정상 동작이라, 그 테스트가 검증하려는
  "heal 자체의 세션당 상한"과는 분리해야 함.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan). 신규 export 없음(내부
   ref/helper만 추가).
2. **V/X dashboard** — 변경은 프론트 register 호출 타이밍 조율뿐, 신규 관측
   신호는 추가하지 않음. 기존 `DebugModal`의 activeTrip/register 로그로 간접
   관측 가능(POST 횟수 감소는 backend `wrangler tail`의 `/trips` 호출 빈도로
   확인 가능).
3. **의존 PR** — N/A (프론트 전용, backend 변경 없음. backend
   `tripRegisterRateLimit.ts`/`evaluateSameSession`은 기존 동작 그대로 활용).
4. **측정 plan** — 1주 안에 backend `wrangler tail` 또는 Cloudflare Dashboard에서
   같은 토큰의 `/trips` POST가 15초 이내 간격으로 2회 이상 찍히는 사례(이중 POST
   패턴)가 발생하는지 관찰. 발생 0건이면 회귀 재발 없음으로 판단.
5. **Device verify** — N/A — type+unit only. 실기기에서 재현하려면 register 실패
   (네트워크 blip)와 GPS station 해소가 거의 동시에 일어나야 하는 낮은 확률의
   race라 코드 레벨 테스트로 대체.

## 리뷰 반영 (P1 + P2-1 + P2-2)

### P1 — Tier 2 fallback 영구 결손 (register-retry가 override 없이 성공하는 경우)

**지적**: `runTier2Heal`이 `isRegisterRetryBusy`로 skip하면 위임 전제가 깨진다 —
이후 retry는 override 없이 `registerFromLatestInputs(token)`을 호출하는데, Tier 2
대상 케이스(지하 dead-zone)는 정의상 `currentStation`이 계속 null이라 retry가
성공해도 context 결손이 유지된다. 게다가 Tier 2 fallback 타이머는 main effect
`run()`의 register가 **직접** 성공했을 때만 armed되므로, 세션의 첫 register가
실패 후 retry로만 성공하면 Tier 2 자체가 애초에 armed될 기회조차 없어 지하
dead-zone 세션이 **영구히** context 결손 상태로 고착된다.

**수정**: `buildTier2FallbackOverride(sessionKey)` 헬퍼를 신설해 Tier 2 발동
조건(currentStation 미해소 + subsurface + routeOriginStation 가용 + 세션 미heal)을
한 곳에서 판정하고, `runTier2Heal`뿐 아니라 `attemptRegisterRetry`도 성공 직전 이
헬퍼를 호출해 조건이 맞으면 override context를 함께 실어 보낸다. Tier 2와 동일하게
override를 사용하기로 결정한 순간 `healedSessionKeyRef`를 즉시 잠가(성공 여부 무관)
반복 시도를 막는다.

**red 테스트**: "cold-start register 실패 + 지하 dead-zone 조건에서 retry가 성공할 때
Tier 2 fallback context를 함께 실어 보낸다 (영구 결손 회귀 재현)" — 수정 전에는
`promptGeoContext`/`promptDisplay`가 `undefined`로 남아 실패, 수정 후 green.

### P2-1 — heal-busy 재예약이 attempt 예산을 소모하던 문제

**지적**: `attemptRegisterRetry`의 heal-busy 분기가 `scheduleRegisterRetry` 재예약
시 attempt를 실제 register 실패와 동일하게 증가시켜, 실제 POST 시도가 0회인 채로
3회 상한을 소진할 수 있다.

**수정**: `rescheduleRegisterRetryForHealBusy` 전용 함수를 신설 — `attempt`(백오프
예산)는 건드리지 않고 별도 recheck 지연(`REGISTER_RETRY_HEAL_BUSY_RECHECK_MS`=2s)만
사용한다. heal이 비정상적으로 오래 걸리는 상황을 대비해 재예약 횟수 자체에 별도
상한(`REGISTER_RETRY_HEAL_BUSY_MAX_RESCHEDULES`=5)을 두고, 상한 도달 시 일반
backoff(attempt 소모)로 전환해 무한 대기를 방지한다.

**red 테스트**: heal-busy 재예약 2회를 거친 뒤에도 attempt 예산이 그대로(다음 실제
실패 시 backoff[1]=30s가 정확히 적용됨)인지 검증. 추가로 상한(5회) 도달 시 실제로
일반 backoff로 전환되는지 별도 테스트로 확인.

### P2-2 — trip 종료 시 register-retry in-flight 추적 미초기화

**지적**: `registerRetryInFlightSessionKeyRef`가 trip 종료 분기에서 명시적으로
reset되지 않아 `healInFlightSessionKeyRef`와 비대칭 — 이전 trip의 retry가
in-flight인 채로 trip이 끝나면, 곧바로 같은 sessionKey(같은 route+destination)로
시작된 새 trip의 context-heal이 stale in-flight 플래그 때문에 영구 차단될 수 있다.

**수정**: trip 종료 분기에 `registerRetryInFlightSessionKeyRef` /
`registerRetryHealBusyRef` reset을 추가해 `healInFlightSessionKeyRef`와 대칭 처리.

**red 테스트**: trip A의 retry가 응답 없이 pending인 채로 trip A가 종료되고, 곧바로
같은 route+destination으로 trip B가 시작되는 시나리오. reset이 없으면 trip B의
GPS 해소 후 Tier 1 heal이 영구히 skip된다. trip A의 뒤늦은 응답이 나중에 도착해도
trip B 상태를 오염시키지 않는지(finally mismatch 가드)도 함께 검증.

### 검증

`npm test`(9092개, coverage 100%) / `npm run type-check` / `npm run lint:orphan`
모두 pass. 3건 모두 fix 적용 전 상태로 되돌려 실제로 red임을 확인한 뒤 fix.


## 재검증 리뷰 반영 (신규 P1)

### P1 — retry의 Tier2 override 잠금이 attempt 기준이라 network 실패 반복 시 영구 고착

**지적**: `attemptRegisterRetry`가 tier2Override를 적용할 때 **await 이전**에
`healedSessionKeyRef.current = sessionKey`로 잠갔다 — attempt(시도) 기준 잠금.
backend 장애(Seoul outage류 실제 이력 있음)로 register-retry 예산 3회가 전부
network 실패로 소진되면: 잠금은 걸려 있고 context는 한 번도 안 실렸고(ok:true
0회) retry도 끝남 → 이후 지상 재진입으로 currentStation이 잡혀도 Tier 1이
잠금에 막힌다 — **#2166이 Tier 1(#2164)에서 이미 고친 것과 동일 클래스의
영구 고착**.

**수정**: 잠금을 `result?.ok && result.hadPromptContext` 확인 후(Tier 1/Tier 2와
동일한 성공 기준)로 이동. 실패 시에는 잠그지 않아 다음 재시도 또는 Tier 1
전환에서 다시 시도할 수 있다.

**red 테스트**: "override 적용 + POST 실패 반복(cold-start + 3회 재시도 전부
network 실패) → 세션 미잠금 → 이후 currentStation 해소 시 Tier 1 재발동"
시나리오. 수정 전 상태로 되돌려 실제로 red(4회에서 멈춤, 5번째 Tier 1 호출
없음)임을 `git stash`로 확인 후 fix 적용.

### 추가 확인 — runTier2Heal의 잠금 기준 (dev 대조)

재검증 리뷰어가 "runTier2Heal 자체는 원래부터 attempt-기준 잠금(#2166에서 변경
안 됨)"이라 서술했는데, 실제로 **#2166은 Tier 1(#2164, promptGeoContext heal
가드)만 성공 기준으로 전환**한 PR이었다(`git log`로 확인: 제목
"fix(#2164): promptGeoContext Tier1 heal 가드 — 시도 기준→성공 기준 전환").
`git diff origin/dev -- src/features/alarm/hooks/useApnsTripRegistration.ts`로
대조한 결과 `origin/dev`의 `runTier2Heal`은 지금도 attempt 기준
(`healedSessionKeyRef.current = sessionKey;`가 await 이전)이며, 본 브랜치도
동일하게 유지하고 있다 — merge 과정에서 되돌아간 것은 없다. 재검증 리뷰어의
서술이 오류였을 뿐이라 `runTier2Heal` 자체는 변경하지 않았다(Tier 2는 원래
성공 기준으로 바뀐 적이 없으므로 "되돌림"이 아니다).

### 검증

`npm test`(9093개, coverage 100%) / `npm run type-check` / `npm run lint:orphan`
모두 pass.


## 유실된 #2166 Tier2 수정 재적용 (조사 결과 정정)

이전 코멘트에서 "재검증 리뷰어의 `runTier2Heal`이 attempt 기준으로 수정 안 됐다는
서술은 오류"라고 판단했으나, **재조사 결과 이 판단이 틀렸다**: PR #2166은
21:48Z에 머지됐고, `runTier2Heal`을 성공 기준으로 고친 커밋 `c18bbac6`(제목:
"fix(#2164): 리뷰 P1/P2-1 — Tier2 heal도 성공 기준 잠금 + 대칭 in-flight 가드")은
그 **머지 시점 이후에 push**돼 PR #2166의 머지(head=`63f09703`)에 반영되지
못하고 dev에서 유실됐다. 즉 "runTier2Heal은 원래부터 attempt 기준"이 아니라
**"이미 고쳐졌던 수정이 유실된 것"**이다.

`git show c18bbac6:src/features/alarm/hooks/useApnsTripRegistration.ts`의
`runTier2Heal`을 참고해 동일 의미론으로 재적용:

- `healedSessionKeyRef.current = sessionKey`를 await 이전 무조건 세팅 →
  await 이후 `result?.ok && result.hadPromptContext` 확인 후로 이동. Tier 2
  POST가 network 레벨에서 실패해도(override context build는 성공) 세션이
  영구 잠기지 않아 이후 Tier 1 heal이 재발동할 수 있다.
- c18bbac6 시점엔 없었던 #2167의 `isRegisterRetryBusy`/in-flight try-finally
  구조와 정합하게 통합 — `healInFlightSessionKeyRef` set/clear 위치는 그대로
  유지하고, 잠금 조건만 성공 기준으로 교체.

**red 테스트** (c18bbac6의 테스트도 dev에서 함께 유실됐으므로 재작성): "Tier 2
register 실패({ok:false}) 시 세션을 잠그지 않아 이후 Tier 1 heal이 재발동할 수
있다" — `git stash`로 수정 전 상태를 재현해 실제로 red(2회에서 멈추고 Tier 1의
3번째 register가 발사되지 않음)임을 확인한 뒤 fix 적용, green 전환 확인.

### 검증

`npm test`(9094개, coverage 100%) / `npm run type-check` / `npm run lint:orphan`
모두 pass.
