### PR TITLE
fix(#2158): Android loud 채널 수정 재적용 — PR #2161 머지 시점 유실 복구

### DIFF
--- a/src/features/alarm/utils/__tests__/stationNotification.test.ts
+++ b/src/features/alarm/utils/__tests__/stationNotification.test.ts
@@ -343,14 +343,16 @@ describe('stationNotification', () => {
         bypassDnd: true,
       });
       expect(Notifications.deleteNotificationChannelAsync).toHaveBeenCalledWith('station-alarm-silent');
+      // #2158 P1 — stationPrescheduler(일반모드)가 이 채널을 재사용하므로 MAX+bypassDnd(취침용
+      // 강제 알림 속성)를 제거하고 HIGH 이하로 낮춘다. Android 8+에서는 채널 속성이 고정이라
+      // per-notification content.sound=false만으로는 loud를 막을 수 없다(채널 자체가 무음이어야 함).
       expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledWith('station-alarm-silent', {
         name: '하차/환승 알림 (무음)',
-        importance: Notifications.AndroidImportance.MAX,
+        importance: Notifications.AndroidImportance.HIGH,
         sound: null,
         enableVibrate: true,
         vibrationPattern: [0, 1000, 500, 1000],
         lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
-        bypassDnd: true,
       });
       expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledWith('station-passed', {
         name: '역 도착 알림',
@@ -923,18 +925,17 @@ describe('stationNotification', () => {
       });
     });
 
-    it('ALARM_SILENT_CHANNEL_ID는 sound: null + enableVibrate: true 유지', async () => {
+    it('#2158 P1 — ALARM_SILENT_CHANNEL_ID는 sound: null + importance HIGH, bypassDnd 없음(stationPrescheduler 일반모드 재사용)', async () => {
       jest.replaceProperty(Platform, 'OS', 'android');
       (Notifications.deleteNotificationChannelAsync as jest.Mock).mockResolvedValue(undefined);
       await initStationNotification();
       expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledWith('station-alarm-silent', {
         name: '하차/환승 알림 (무음)',
-        importance: Notifications.AndroidImportance.MAX,
+        importance: Notifications.AndroidImportance.HIGH,
         sound: null,
         enableVibrate: true,
         vibrationPattern: [0, 1000, 500, 1000],
         lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
-        bypassDnd: true,
       });
     });
 

--- a/src/features/alarm/utils/__tests__/stationPrescheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPrescheduler.test.ts
@@ -46,6 +46,7 @@ jest.mock('../stationNotification', () => ({
     title: 'passed-title',
     body: `passed:${stationName}`,
   }),
+  ALARM_SILENT_CHANNEL_ID: 'station-alarm-silent',
 }));
 
 jest.mock('../stationNotifCollapseId', () => ({
@@ -244,7 +245,7 @@ describe('registerPrescheduledStationAlarms', () => {
     expect(ids[2]).toBe(`${PRESCHED_ALARM_PREFIX}${TRIP_TOKEN.slice(0, 16)}-A역-station-passed#1`);
   });
 
-  it('AndroidNotificationPriority.MAX + channelId를 android에서 설정, ios에서는 interruptionLevel 설정(alarm kind)', async () => {
+  it('#2158 — android에서 무음 채널(station-alarm-silent) + HIGH priority 설정, ios에서는 interruptionLevel 설정', async () => {
     jest.replaceProperty(Platform, 'OS', 'android');
     const arc = makeArc();
     await registerPrescheduledStationAlarms({
@@ -254,9 +255,12 @@ describe('registerPrescheduledStationAlarms', () => {
       now: NOW,
     });
     const call = mockedSchedule.mock.calls[0][0];
-    expect((call.content as { channelId?: string }).channelId).toBe('station-alarm');
+    // #2158 P1 — 'station-alarm'(loud, sound:'alarm.wav' 채널 고정 속성)을 쓰면 Android 8+에서
+    // content.sound=false가 무시되고 여전히 loud 발사된다. 일반모드 전용 채널이므로 무음 채널을
+    // 써야 한다.
+    expect((call.content as { channelId?: string }).channelId).toBe('station-alarm-silent');
     expect((call.content as { priority?: number }).priority).toBe(
-      Notifications.AndroidNotificationPriority.MAX,
+      Notifications.AndroidNotificationPriority.HIGH,
     );
     expect((call.content as { interruptionLevel?: string }).interruptionLevel).toBeUndefined();
   });

--- a/src/features/alarm/utils/stationNotification.ts
+++ b/src/features/alarm/utils/stationNotification.ts
@@ -55,7 +55,8 @@ const liveActivityLogger = createLogger('LiveActivity');
 export const NOTIFICATION_ID = 'current-station';
 export const ALARM_NOTIFICATION_ID = 'station-alarm';
 const ALARM_CHANNEL_ID = 'station-alarm';
-const ALARM_SILENT_CHANNEL_ID = 'station-alarm-silent';
+/** #2158 — 일반모드 stationPrescheduler가 재사용하는 무음 채널(sound:null, bypassDnd 없음). */
+export const ALARM_SILENT_CHANNEL_ID = 'station-alarm-silent';
 export const STATION_PASSED_NOTIFICATION_ID = 'station-passed';
 const STATION_PASSED_CHANNEL_ID = 'station-passed';
 
@@ -185,14 +186,16 @@ export async function refreshNotificationChannels(): Promise<void> {
     bypassDnd: true,
   });
   await Notifications.deleteNotificationChannelAsync(ALARM_SILENT_CHANNEL_ID).catch(() => {});
+  // #2158 P1 — stationPrescheduler(일반모드, sleepMode OFF)가 이 채널을 재사용한다. Android 8+는
+  // 채널의 sound/importance/bypassDnd가 고정 속성이라 per-notification content.sound=false만으로
+  // loud를 막을 수 없다 — MAX+bypassDnd(취침용 강제 알림 속성)를 제거하고 HIGH 이하로 낮춘다.
   await Notifications.setNotificationChannelAsync(ALARM_SILENT_CHANNEL_ID, {
     name: i18next.t('notifications.channelTransferAlarmSilent'),
-    importance: Notifications.AndroidImportance.MAX,
+    importance: Notifications.AndroidImportance.HIGH,
     sound: null,
     enableVibrate: true,
     vibrationPattern: [0, 1000, 500, 1000],
     lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
-    bypassDnd: true,
   });
   await Notifications.deleteNotificationChannelAsync(STATION_PASSED_CHANNEL_ID).catch(() => {});
   // #1224 — 매역 알림은 잠을 깨우지 말 것: 진동 0 / 사운드 0 / 배너만

--- a/src/features/alarm/utils/stationPrescheduler.ts
+++ b/src/features/alarm/utils/stationPrescheduler.ts
@@ -37,7 +37,7 @@ import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { Station, LineNumber } from '../../../shared/types/station';
-import { buildAlarmContent, buildStationPassedContent } from './stationNotification';
+import { buildAlarmContent, buildStationPassedContent, ALARM_SILENT_CHANNEL_ID } from './stationNotification';
 import { buildStationNotifCollapseId } from './stationNotifCollapseId';
 import { cancelIdentifiersWithRetry } from './safetyNetScheduler';
 import { hopTimeMsAt } from '../../route/utils/hopTime';
@@ -53,8 +53,11 @@ const logger = createLogger('StationPrescheduler');
 /** OS 예약 identifier 접두 — `presched-<tripToken.slice(0,16)>-<station>-<kind>#<occurrence>`. */
 export const PRESCHED_ALARM_PREFIX = 'presched-';
 
-/** Android channel — 기존 station-alarm 채널 재사용(safetyNetScheduler와 동일 정책). */
-const ALARM_CHANNEL_ID = 'station-alarm';
+/** #2158 P1 — prescheduler는 일반모드 전용 채널이라 loud가 존재할 이유가 없다. Android 8+에서는
+ *  채널의 sound/importance/bypassDnd가 고정 속성이라 content.sound=false만으로는 loud를 막을 수
+ *  없으므로, safetyNetScheduler(취침 전용)가 쓰는 loud 채널('station-alarm', sound:'alarm.wav'
+ *  고정)이 아니라 무음 채널('station-alarm-silent')을 재사용한다. */
+const ANDROID_CHANNEL_ID = ALARM_SILENT_CHANNEL_ID;
 /** #2158 — prescheduler는 일반모드 전용 채널이라 loud(alarm.wav/timeSensitive)가 존재할 이유가
  *  없다. backend의 매역 push(`sendAlertPush` interruption-level=active, 무소리)와 동일 정책. */
 const INTERRUPTION_LEVEL = 'active';
@@ -178,8 +181,8 @@ async function scheduleOne(params: {
       data: data as unknown as Record<string, unknown>,
       sound: false,
       ...(Platform.OS === 'android' && {
-        channelId: ALARM_CHANNEL_ID,
-        priority: Notifications.AndroidNotificationPriority.MAX,
+        channelId: ANDROID_CHANNEL_ID,
+        priority: Notifications.AndroidNotificationPriority.HIGH,
       }),
       ...(Platform.OS === 'ios' && { interruptionLevel: INTERRUPTION_LEVEL }),
     },


### PR DESCRIPTION
Part of #2158 — PR #2161이 5b1d367 push 전 머지되어 유실된 리뷰 수정 재적용

## 배경
PR #2161 리뷰에서 지적된 P1 수정(commit `5b1d367`, 브랜치 `fix/#2158-presched-loud-leak`)이 push되기 전에 PR #2161이 머지되어 dev에 반영되지 못했다. 이미 코드리뷰 재검증까지 통과한 내용을 cherry-pick으로 복구한다.

## 변경 사항
- `stationNotification.ts`: 미사용이던 `ALARM_SILENT_CHANNEL_ID`('station-alarm-silent') export. 채널 정의 importance MAX→HIGH, bypassDnd:true 제거 (sound:null 기존 유지)
- `stationPrescheduler.ts`: android channelId를 `ALARM_SILENT_CHANNEL_ID`로, priority를 MAX→HIGH로 변경
- 관련 테스트(`stationNotification.test.ts`, `stationPrescheduler.test.ts`) 동기화
- 기존 loud 채널(`ALARM_CHANNEL_ID`='station-alarm')의 다른 소비자(safetyNetScheduler, 취침모드 전용)는 무변경 유지

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass, 0 orphan.
2. **V/X dashboard** — Android 기기의 실제 알림 채널/사운드 동작으로 관측 (DebugModal 알람 로그 + 기기 알림 설정 화면에서 채널 importance 확인).
3. **의존 PR** — N/A (이미 머지됐어야 할 수정의 복구, 신규 의존 없음).
4. **측정 plan** — 다음 Android 실기기 prescheduled 알람 발화 시 loud 사운드/DND 우회 재발 여부 확인 (1주 관찰, 재발 0건이 목표).
5. **Device verify** — 필요. Android 실기기에서 prescheduled 알람이 silent 채널(HIGH priority, bypassDnd 없음)로 발화하는지 확인 필요.

Closes 없음 (#2158은 원본 이슈, 이 PR은 유실 복구 목적이라 Part of로 연결)
