### PR TITLE
fix(#2153): /position 근접 stamp 경로 재적용 — PR #2165 머지 시점 유실 복구

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -2186,6 +2186,144 @@ describe('POST /position (#819)', () => {
       expect(body.originStationId).toBeUndefined();
     });
   });
+
+  // #2153 (리뷰 P1) — trip.promptGeoContext.originDistanceM/originAccuracyM은 device가
+  // POST /trips 재등록할 때만 갱신되는 정적 스냅샷(useApnsTripRegistration.ts는 currentStation을
+  // register effect deps에서 제외 — #703). "집에서 route 설정 → 재등록 트리거 없이 도보로 출발역
+  // 근접" 시나리오에서 cron 경로(scheduled.ts)만으로는 anchor stamp 기회가 영영 안 올 수 있다.
+  // POST /position(10초 주기, 재등록과 무관)에도 근접 신호를 흘려 매 cycle 신선한 GPS 기준으로
+  // stamp 기회를 준다 — 이 describe가 그 경로를 검증한다.
+  describe('#2153 — /position originDistanceM/originAccuracyM → originProximityAt stamp', () => {
+    const CREATED = 1_700_000_000_000;
+    function tripBody(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+      return {
+        token: 'tok-prox',
+        route: { type: 'direct', line: '2', stops: 3 },
+        destination: 'dst',
+        waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
+        expiresAt: CREATED + 60 * 60_000,
+        alarmAtEpochMs: CREATED + 30 * 60_000,
+        createdAt: CREATED,
+        ...overrides,
+      };
+    }
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('red → green: 재등록 없이 /position만으로 근접(margin 이내) 관측 시 originProximityAt stamp', async () => {
+      vi.useFakeTimers();
+      // route 설정(createdAt) 20분 후 — 재등록 없이 이 시각에 처음 /position이 근접을 보고한다.
+      const observedAt = CREATED + 20 * 60 * 1000;
+      vi.setSystemTime(observedAt);
+      const env = makeKvEnv();
+      await post('/trips', tripBody(), env);
+
+      const res = await post(
+        '/position',
+        {
+          token: 'tok-prox',
+          lat: 1,
+          lng: 2,
+          accuracy: 10,
+          ts: observedAt,
+          motion: 'walking',
+          // margin(150m) 이내 근접 관측: distance - accuracy = 40m.
+          originDistanceM: 50,
+          originAccuracyM: 10,
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const stored = JSON.parse((await env.TRIPS.get('trip:tok-prox')) as string);
+      expect(stored.originProximityAt).toBe(observedAt);
+    });
+
+    it('margin 초과(멀리 있음) → originProximityAt stamp 안 함', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(CREATED);
+      const env = makeKvEnv();
+      await post('/trips', tripBody(), env);
+      await post(
+        '/position',
+        {
+          token: 'tok-prox',
+          lat: 1,
+          lng: 2,
+          accuracy: 9,
+          ts: CREATED,
+          motion: 'walking',
+          // distance - accuracy = 218m > 150m margin → 근접 아님.
+          originDistanceM: 227,
+          originAccuracyM: 9,
+        },
+        env,
+      );
+      const stored = JSON.parse((await env.TRIPS.get('trip:tok-prox')) as string);
+      expect(stored.originProximityAt).toBeUndefined();
+    });
+
+    it('originDistanceM/originAccuracyM 부재 → stamp 안 함(기존 nearestStationDistanceM과 무관)', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(CREATED);
+      const env = makeKvEnv();
+      await post('/trips', tripBody(), env);
+      await post(
+        '/position',
+        { token: 'tok-prox', lat: 1, lng: 2, accuracy: 5, ts: CREATED, motion: 'walking' },
+        env,
+      );
+      const stored = JSON.parse((await env.TRIPS.get('trip:tok-prox')) as string);
+      expect(stored.originProximityAt).toBeUndefined();
+    });
+
+    it('trip 미존재 → no-op (KV에 trip:<token> 생성 안 됨, 200 응답)', async () => {
+      const env = makeKvEnv();
+      const res = await post(
+        '/position',
+        {
+          token: 'no-such-trip',
+          lat: 1,
+          lng: 2,
+          accuracy: 10,
+          ts: CREATED,
+          motion: 'walking',
+          originDistanceM: 50,
+          originAccuracyM: 10,
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await env.TRIPS.get('trip:no-such-trip')).toBeNull();
+    });
+
+    it('이미 stamp된 trip은 재관측해도 최초 시각을 보존(계속 갱신 금지)', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(CREATED);
+      const env = makeKvEnv();
+      await post('/trips', tripBody(), env);
+      const nearPayload = {
+        token: 'tok-prox',
+        lat: 1,
+        lng: 2,
+        accuracy: 10,
+        ts: CREATED,
+        motion: 'walking' as const,
+        originDistanceM: 50,
+        originAccuracyM: 10,
+      };
+      await post('/position', nearPayload, env);
+      const firstStamp = JSON.parse((await env.TRIPS.get('trip:tok-prox')) as string).originProximityAt;
+      expect(firstStamp).toBe(CREATED);
+
+      // 5분 뒤 재관측(여전히 근접) — anchor가 최초 시각(CREATED)으로 그대로 유지돼야 한다.
+      vi.setSystemTime(CREATED + 5 * 60 * 1000);
+      await post('/position', { ...nearPayload, ts: CREATED + 5 * 60 * 1000 }, env);
+      const secondStamp = JSON.parse((await env.TRIPS.get('trip:tok-prox')) as string).originProximityAt;
+      expect(secondStamp).toBe(CREATED);
+    });
+  });
 });
 
 describe('POST /boarding-prompt/dismiss (#819)', () => {

--- a/backend/alarm-worker/src/boardingPrompt.ts
+++ b/backend/alarm-worker/src/boardingPrompt.ts
@@ -62,6 +62,18 @@ export const DISMISS_SILENCE_MS = 5 * 60 * 1000;
  */
 export const PROMPT_PROXIMITY_MARGIN_M = 150;
 /**
+ * #2153 — 근접 게이트 판정을 순수 함수로 분리(cron `evaluateAndMaybeFireBoardingPrompt`와
+ * `/position` 핸들러 양쪽이 재사용). distance/accuracy 둘 다 있고 오차 고려 후 margin 이내면
+ * "근접"으로 본다 — 부재(지하/구 클라)는 "근접 관측"이 아니므로 false(anchor stamp 대상 아님).
+ */
+export function isNearOrigin(
+  originDistanceM: number | undefined,
+  originAccuracyM: number | undefined,
+): boolean {
+  if (originDistanceM === undefined || originAccuracyM === undefined) return false;
+  return originDistanceM - originAccuracyM <= PROMPT_PROXIMITY_MARGIN_M;
+}
+/**
  * #2130 (Part B-be-1) — 신선도 게이트. trip 등록(또는 heal) 후 이 시간이 지나면 boarding-prompt
  * 자격이 만료된다 — 오래된 trip에 뒤늦게 발사되는 stale prompt 방지 + 반복 발사(A4) 창의 상한.
  */

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -13,7 +13,7 @@
 
 import { Hono } from 'hono';
 import { AUTO_PROMPT_DEDUP_WINDOW_MS } from './autoLock';
-import { markPromptSilenced } from './boardingPrompt';
+import { isNearOrigin, markPromptSilenced } from './boardingPrompt';
 import {
   recordBoardingPromptOutcome,
   validateBoardingPromptOutcome,
@@ -1435,6 +1435,20 @@ app.post('/position', async (c) => {
   if (!payload) return c.json({ error: 'invalid_payload' }, 400);
 
   await appendPositionPoint(c.env.TRIPS, payload.token, payload.point);
+  // #2153 (리뷰 P1) — boarding-prompt 신선도 게이트 anchor(`originProximityAt`)의 실시간 입력.
+  // `trip.promptGeoContext.originDistanceM/originAccuracyM`는 POST /trips 재등록 시에만 갱신되는
+  // 정적 스냅샷이라(useApnsTripRegistration.ts는 currentStation을 register effect deps에서 제외),
+  // 재등록 트리거가 안 오면 anchor stamp 기회가 영영 안 올 수 있다(#2153 RCA). 이 10초 주기
+  // /position 채널은 재등록과 무관하게 매 cycle 신선한 GPS 기준 근접 신호를 흘려 stamp 기회를
+  // 보강한다 — position series/point 저장과는 독립된 side-effect(series에는 적재하지 않음).
+  const { originDistanceM, originAccuracyM } = parseOriginProximityFields(body);
+  await stampOriginProximityIfNeeded(
+    c.env.TRIPS,
+    payload.token,
+    originDistanceM,
+    originAccuracyM,
+    Date.now(),
+  );
   // #823 Phase 3 E1 — 가속도 옵션 필드. 부재 또는 invalid 시 skip (positionSeries는 이미 적재됨).
   if (payload.accelSummary) {
     await appendAccelSample(c.env.TRIPS, payload.token, payload.accelSummary);
@@ -1478,6 +1492,55 @@ app.post('/position', async (c) => {
     ...(ssot?.lockSuggestion ? { lockSuggestion: ssot.lockSuggestion } : {}),
   });
 });
+
+/**
+ * #2153 — POST /position body에서 origin 근접 필드(distance/accuracy)만 별도로 뽑는다.
+ * `parsePromptGeoContext`(POST /trips)의 originDistanceM/originAccuracyM 파싱과 동일 규칙
+ * (finite number만 허용, 둘 중 하나라도 무효면 둘 다 생략) — 두 경로가 같은 개념을 다른 채널로
+ * 보내므로 검증 규칙을 분기하지 않는다. 이 값은 position series(`PositionPoint`)에는 적재되지
+ * 않는다 — anchor stamp 판단에만 쓰이는 휘발성 입력이다.
+ */
+export function parseOriginProximityFields(input: unknown): {
+  originDistanceM?: number;
+  originAccuracyM?: number;
+} {
+  if (!input || typeof input !== 'object') return {};
+  const o = input as Record<string, unknown>;
+  const originDistanceM =
+    typeof o.originDistanceM === 'number' && Number.isFinite(o.originDistanceM)
+      ? o.originDistanceM
+      : undefined;
+  const originAccuracyM =
+    typeof o.originAccuracyM === 'number' && Number.isFinite(o.originAccuracyM)
+      ? o.originAccuracyM
+      : undefined;
+  if (originDistanceM === undefined || originAccuracyM === undefined) return {};
+  return { originDistanceM, originAccuracyM };
+}
+
+/**
+ * #2153 (리뷰 P1) — `trip.originProximityAt`(신선도 게이트 anchor)를 `/position` 채널에서도
+ * stamp할 수 있게 하는 진입점. cron(`scheduled.ts`)의 stamp 로직과 같은 `isNearOrigin` 판정을
+ * 공유하되, 이 경로는 근접이 아니면(멀거나 값 부재) trip을 아예 읽지 않는다 — 매 10초 호출되는
+ * 채널이므로 KV read/write 낭비를 근접 관측이 실제로 발생하는 순간으로 최소화한다.
+ *
+ * **KV write 최소화**: 이미 stamp된 trip(`originProximityAt !== undefined`)은 재관측해도
+ * write하지 않는다 — trip당 최초 1회만 write (CF KV free tier quota 보호, #2073 lesson).
+ * trip 미존재(register 전/만료)는 graceful no-op.
+ */
+export async function stampOriginProximityIfNeeded(
+  kv: KVNamespace,
+  token: string,
+  originDistanceM: number | undefined,
+  originAccuracyM: number | undefined,
+  now: number,
+): Promise<void> {
+  if (!isNearOrigin(originDistanceM, originAccuracyM)) return;
+  const trip = await getTrip(kv, token);
+  if (!trip) return;
+  if (trip.originProximityAt !== undefined) return;
+  await putTrip(kv, { ...trip, originProximityAt: now });
+}
 
 interface PositionUploadPayload {
   token: string;

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -21,10 +21,10 @@ import { AUTO_PROMPT_DEDUP_WINDOW_MS } from './autoLock';
 import {
   evaluateBoardingPromptGates,
   evaluateHopEndPromptGates,
+  isNearOrigin,
   markPromptFired,
   pickAutoTrainCode,
   PROMPT_FRESHNESS_MS,
-  PROMPT_PROXIMITY_MARGIN_M,
   type GateSkipReason,
 } from './boardingPrompt';
 import {
@@ -4503,22 +4503,23 @@ export async function evaluateAndMaybeFireBoardingPrompt(
 
   let dirty = false;
 
-  // #2153 — 근접 게이트 판정을 신선도 게이트보다 먼저 계산해 anchor 재정의에 재사용한다.
-  // distance/accuracy 둘 다 있을 때만 평가(부재 = 지하/구 클라 관대 허용). 오차 고려 보수적
-  // 판정 — distance - accuracy > 150m 이면 "너무 멀다"로 본다.
+  // #2153 — 근접 게이트 판정(`isNearOrigin`, boardingPrompt.ts 공용 함수 — `/position` 핸들러와
+  // 재사용)을 신선도 게이트보다 먼저 계산해 anchor 재정의에 재사용한다. distance/accuracy 둘 다
+  // 있을 때만 "너무 멀다" 판정 가능 — 부재(지하/구 클라)는 관대 허용(too-far 아님).
   const { originDistanceM, originAccuracyM } = geo;
   const hasProximityReading = originDistanceM !== undefined && originAccuracyM !== undefined;
-  const isTooFarFromOrigin =
-    originDistanceM !== undefined &&
-    originAccuracyM !== undefined &&
-    originDistanceM - originAccuracyM > PROMPT_PROXIMITY_MARGIN_M;
-  // 근접 관측 = distance/accuracy 존재 + margin 이내(=too-far 아님). 부재(지하 등)는 근접
-  // "관측"이 아니므로 anchor stamp 대상이 아니다 (기존 관대 허용 정책과는 별개 축).
-  const isNearOrigin = hasProximityReading && !isTooFarFromOrigin;
+  const nearOrigin = isNearOrigin(originDistanceM, originAccuracyM);
+  const isTooFarFromOrigin = hasProximityReading && !nearOrigin;
 
   // #2153 — trip 등록 후 최초로 출발역 근접을 관측한 cycle의 시각을 1회만 stamp. 이후
   // cycle에서는 이 anchor를 보존(재관측마다 now로 계속 갱신하면 게이트가 무력화된다).
-  if (isNearOrigin && trip.originProximityAt === undefined) {
+  //
+  // #2153 (리뷰 P1) — 이 cron 경로는 `trip.promptGeoContext`가 register 시점의 정적 스냅샷이라
+  // 재등록 트리거(currentStation null→non-null 등)가 안 오면 값이 절대 갱신되지 않는 구조적
+  // 한계가 있다(집에서 route 설정 후 재등록 없이 도보 이동하는 케이스). 실시간 anchor의 주 경로는
+  // `/position`(10초 주기, index.ts stampOriginProximityIfNeeded) — 이 cron 분기는 register/heal로
+  // 이미 갱신된 케이스를 추가로 커버하는 보조 경로로 유지.
+  if (nearOrigin && trip.originProximityAt === undefined) {
     trip.originProximityAt = now;
     dirty = true;
   }
@@ -4535,7 +4536,10 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       ageMs: now - freshnessAnchor,
       anchoredToProximity: trip.originProximityAt !== undefined,
     });
-    if (dirty) await putTrip(env.TRIPS, trip);
+    // #2153 (리뷰 P1) — dirty는 이 cycle에 `nearOrigin`이 true일 때만 set되고(위 stamp 블록),
+    // 그 경우 freshnessAnchor는 방금 stamp된 `now`라 age=0 — 이 stale 분기는 같은 cycle에
+    // 도달 불가하다. dirty=true로 이 지점에 도달하는 경로가 없어 putTrip 호출을 넣지 않는다
+    // (도달 불가 dead code 방지).
     return;
   }
 
@@ -4547,7 +4551,8 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       originDistanceM: geo.originDistanceM,
       originAccuracyM: geo.originAccuracyM,
     });
-    if (dirty) await putTrip(env.TRIPS, trip);
+    // #2153 (리뷰 P1) — 위와 동일 이유. isTooFarFromOrigin=true는 nearOrigin=false를 함의하므로
+    // dirty=true(=nearOrigin true였던 cycle)와 동시에 성립할 수 없다 — dead code 방지.
     return;
   }
 

--- a/src/features/nearest-station/api/__tests__/positionUpload.test.ts
+++ b/src/features/nearest-station/api/__tests__/positionUpload.test.ts
@@ -4,13 +4,16 @@ import {
   dismissBoardingPrompt,
   persistFromPositionResponse,
   readActiveBoardingLine,
+  readTripOriginCoords,
   uploadPosition,
   withMapMatched,
   withNearestStationDistance,
+  withOriginProximity,
 } from '../positionUpload';
 import {
   ACTIVE_BOARDING_LINE_KEY,
   BACKEND_SSOT_MIRROR_KEY,
+  TRIP_ORIGIN_KEY,
 } from '../../../../shared/constants/storageKeys';
 import type { LockSuggestionMirror } from '../../../alarm/utils/backendSsotMirror';
 
@@ -405,6 +408,107 @@ describe('withNearestStationDistance (#834)', () => {
       const mod = require('../positionUpload');
       expect(mod.defaultNearestStationResolver(0, 0)).toBeUndefined();
     });
+  });
+});
+
+// #2153 (리뷰 P1) — backend가 신선도 게이트 anchor(originProximityAt)를 real-time으로 stamp하려면
+// device가 매 /position cycle 신선한 GPS 기준 origin 근접 거리를 계산해 흘려야 한다. 기존
+// promptGeoContext.originDistanceM은 POST /trips 재등록 시점의 정적 스냅샷이라(useApnsTripRegistration
+// register effect deps에 currentStation 미포함 — #703), 재등록 트리거가 안 오면 그 값이 영원히
+// "route 설정 시점 거리"로 고정된다. TRIP_ORIGIN_KEY(#700, destination 설정 시 캡처된 고정 출발역)의
+// 좌표는 route 설정 후 바뀌지 않으므로, 매 cycle 이 좌표 대비 최신 GPS fix 거리를 재계산하면
+// "역에 실제로 근접했는가"를 항상 최신값으로 판정할 수 있다.
+describe('withOriginProximity (#2153)', () => {
+  it('red → green: TRIP_ORIGIN_KEY 좌표 대비 매 호출 신선한 거리를 계산해 첨부', async () => {
+    await AsyncStorage.setItem(
+      TRIP_ORIGIN_KEY,
+      JSON.stringify({ id: 'origin', name: '강남', line: '2', lat: 37.4979, lng: 127.0276 }),
+    );
+    // 같은 좌표(강남역) 근처 fix → distance는 작은 양수(수십 m 이내), accuracy는 payload.accuracy.
+    const out = await withOriginProximity({
+      token: 'tok',
+      lat: 37.498,
+      lng: 127.0277,
+      accuracy: 12,
+      ts: 0,
+      motion: 'walking',
+    });
+    expect(out.originDistanceM).toBeDefined();
+    expect(out.originDistanceM).toBeGreaterThanOrEqual(0);
+    expect(out.originDistanceM).toBeLessThan(200);
+    expect(out.originAccuracyM).toBe(12);
+  });
+
+  it('명시 originDistanceM/originAccuracyM이 이미 있으면 그대로 반환 (resolver 미호출)', async () => {
+    const resolver = jest.fn();
+    const out = await withOriginProximity(
+      {
+        token: 'tok',
+        lat: 37.4979,
+        lng: 127.0276,
+        accuracy: 5,
+        ts: 0,
+        motion: 'walking',
+        originDistanceM: 10,
+        originAccuracyM: 5,
+      },
+      resolver,
+    );
+    expect(out.originDistanceM).toBe(10);
+    expect(out.originAccuracyM).toBe(5);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('resolver가 null 반환(원본 미설정/파싱 실패) → 두 필드 모두 omit (graceful)', async () => {
+    const payload = {
+      token: 'tok',
+      lat: 37.4979,
+      lng: 127.0276,
+      accuracy: 5,
+      ts: 0,
+      motion: 'walking' as const,
+    };
+    const out = await withOriginProximity(payload, async () => null);
+    expect(out).toEqual(payload);
+    expect(out.originDistanceM).toBeUndefined();
+    expect(out.originAccuracyM).toBeUndefined();
+  });
+
+  it('resolver 주입 — 호출자가 지정한 origin 좌표로 계산 (확장성)', async () => {
+    const out = await withOriginProximity(
+      { token: 'tok', lat: 37.4979, lng: 127.0276, accuracy: 8, ts: 0, motion: 'walking' },
+      async () => ({ lat: 37.4979, lng: 127.0276 }),
+    );
+    expect(out.originDistanceM).toBe(0);
+    expect(out.originAccuracyM).toBe(8);
+  });
+});
+
+describe('readTripOriginCoords (#2153)', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('TRIP_ORIGIN_KEY 부재 → null', async () => {
+    expect(await readTripOriginCoords()).toBeNull();
+  });
+
+  it('유효한 Station JSON → { lat, lng }만 추출', async () => {
+    await AsyncStorage.setItem(
+      TRIP_ORIGIN_KEY,
+      JSON.stringify({ id: 'x', name: '강남', line: '2', lat: 1, lng: 2 }),
+    );
+    expect(await readTripOriginCoords()).toEqual({ lat: 1, lng: 2 });
+  });
+
+  it('lat/lng 누락된 형식 → null (graceful)', async () => {
+    await AsyncStorage.setItem(TRIP_ORIGIN_KEY, JSON.stringify({ name: '강남' }));
+    expect(await readTripOriginCoords()).toBeNull();
+  });
+
+  it('JSON 파싱 실패 → null (graceful)', async () => {
+    await AsyncStorage.setItem(TRIP_ORIGIN_KEY, '{invalid');
+    expect(await readTripOriginCoords()).toBeNull();
   });
 });
 

--- a/src/features/nearest-station/api/positionUpload.ts
+++ b/src/features/nearest-station/api/positionUpload.ts
@@ -26,12 +26,13 @@
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { fetchWithTimeout, getBackendUrl } from './backendHttp';
-import { ACTIVE_BOARDING_LINE_KEY } from '../../../shared/constants/storageKeys';
+import { ACTIVE_BOARDING_LINE_KEY, TRIP_ORIGIN_KEY } from '../../../shared/constants/storageKeys';
 import { snapToLinePolyline } from '../../route/utils/linePolyline';
 import { isLineNumber } from '../../route/utils/lineGuard';
 import { findNearestStation } from '../utils/findNearestStation';
 import type { LineNumber } from '../../../shared/types/station';
 import { createLogger } from '../../../shared/utils/logger';
+import { haversine } from '../../../shared/utils/haversine';
 import type { AccelSummary } from '../utils/accelMotion';
 import type { CellularEnvironmentVote } from '../utils/cellularTech';
 import {
@@ -135,6 +136,21 @@ export interface PositionUploadPayload {
    * - `reference_ios_wifi_api_constraint.md` — 사용자가 5G/LTE 전용 시 undefined (graceful).
    */
   wifiSsidStationName?: string;
+  /**
+   * #2153 (리뷰 P1) — 이 fix와 고정 출발역(`TRIP_ORIGIN_KEY`, #700) 사이 거리(m). backend
+   * boarding-prompt 신선도 게이트 anchor(`trip.originProximityAt`)의 실시간 입력.
+   *
+   * `promptGeoContext.originDistanceM`(POST /trips register 시점 스냅샷)과 달리, 이 필드는
+   * `withOriginProximity`가 **매 /position 호출마다** 신선한 GPS fix 기준으로 재계산한다 —
+   * 재등록 트리거(currentStation 전환 등)가 안 와도 "실제로 역에 근접했는가"가 항상 최신값으로
+   * backend에 전달된다(#2153 RCA: 집에서 route 설정 후 재등록 없이 도보 이동하는 케이스에서
+   * 정적 스냅샷이 anchor stamp 기회를 영구히 막던 회귀).
+   *
+   * TRIP_ORIGIN_KEY 부재(route 미설정) → undefined (graceful, position series 자체는 계속 적재).
+   */
+  originDistanceM?: number;
+  /** #2153 — 위 거리 계산에 쓰인 GPS 정확도(m) — 항상 `accuracy`와 동일값, origin 짝 필드. */
+  originAccuracyM?: number;
 }
 
 export interface PositionUploadResult {
@@ -218,6 +234,61 @@ export function withNearestStationDistance(
   };
 }
 
+/**
+ * #2153 — 고정 출발역 좌표를 반환하는 전략 함수. 기본 구현(`readTripOriginCoords`)은
+ * `TRIP_ORIGIN_KEY`(destination 설정 시점에 캡처된 route origin, #700)를 읽는다. 호출자는
+ * multi-trip / 측정 fixture 확장을 위해 자기만의 resolver를 주입할 수 있다.
+ * null 반환 시 근접 계산을 skip(graceful) — `withMapMatched`/`withNearestStationDistance`와 동형.
+ */
+export type OriginResolver = () => Promise<{ lat: number; lng: number } | null>;
+
+/**
+ * 기본 resolver — `TRIP_ORIGIN_KEY`에서 destination 설정 시점 캡처된 `Station`을 읽어
+ * lat/lng만 추출한다. 키 부재 / JSON 파싱 실패 / lat·lng 형식 불일치는 null(graceful).
+ */
+export const readTripOriginCoords: OriginResolver = async () => {
+  try {
+    const raw = await AsyncStorage.getItem(TRIP_ORIGIN_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { lat?: unknown; lng?: unknown };
+    if (typeof parsed.lat !== 'number' || typeof parsed.lng !== 'number') return null;
+    return { lat: parsed.lat, lng: parsed.lng };
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * #2153 (리뷰 P1) — resolver가 반환한 고정 출발역 좌표 대비 이 fix의 거리를 계산해 payload에
+ * 첨부한다. `withMapMatched`/`withNearestStationDistance`와 동형 패턴(override 우선, resolver
+ * 주입 가능, 실패 시 graceful omit) — 매 호출마다 신선한 GPS 기준으로 재계산되므로 route 설정
+ * 시점 스냅샷(promptGeoContext.originDistanceM)과 달리 실시간성이 보장된다.
+ *
+ * - 호출자가 `originDistanceM` + `originAccuracyM`을 명시 전달했으면 그대로 사용(override).
+ * - resolver가 null 반환(route 미설정 등) → 두 필드 모두 omit (graceful).
+ * - accuracy는 항상 이 fix의 `payload.accuracy` — origin 계산 자체의 오차가 아니라 GPS fix
+ *   정확도이므로 backend `isNearOrigin`의 margin 계산과 register 경로(promptGeoContext)가 동일
+ *   의미로 소비한다.
+ */
+export async function withOriginProximity(
+  payload: PositionUploadPayload,
+  resolveOrigin: OriginResolver = readTripOriginCoords,
+): Promise<PositionUploadPayload> {
+  if (payload.originDistanceM !== undefined && payload.originAccuracyM !== undefined) {
+    return payload;
+  }
+  const origin = await resolveOrigin();
+  if (!origin) return payload;
+  const originDistanceM = Math.round(
+    haversine(payload.lat, payload.lng, origin.lat, origin.lng) * METERS_PER_KM,
+  );
+  return {
+    ...payload,
+    originDistanceM,
+    originAccuracyM: payload.accuracy,
+  };
+}
+
 export async function uploadPosition(
   payload: PositionUploadPayload,
 ): Promise<PositionUploadResult> {
@@ -227,7 +298,9 @@ export async function uploadPosition(
     return { ok: false, skipped: true };
   }
   const mapMatched = await withMapMatched(payload);
-  const enriched = withNearestStationDistance(mapMatched);
+  const withNearest = withNearestStationDistance(mapMatched);
+  // #2153 — origin 근접 실시간 anchor 입력. AsyncStorage 1회 read 추가(다른 with* 헬퍼와 동일 비용).
+  const enriched = await withOriginProximity(withNearest);
   try {
     const res = await fetchWithTimeout(`${base}/position`, {
       method: 'POST',


### PR DESCRIPTION
Part of #2153 — PR #2165가 8087b52f push 전 머지되어 유실된 리뷰 P1 수정 재적용

## 배경

PR #2165(base fc8c23a8) 머지 시점(head=9cb22c64)에, 리뷰 P1 대응 커밋 8087b52f가 브랜치 `fix/#2153-prompt-freshness-anchor`에 커밋되어 있었으나 push 및 PR 반영 전에 머지가 완료되어 dev에 유실되었다. 8087b52f는 이미 코드리뷰 재검증을 통과한 내용이며, `git cherry-pick 8087b52f`로 충돌 없이 dev(HEAD=d91a4237) 위에 재적용했다.

## 유실됐던 내용 (복구 범위)

- `src/features/nearest-station/api/positionUpload.ts`: `withOriginProximity` — 매 `/position` 호출(10초 주기)마다 `TRIP_ORIGIN_KEY`(고정 출발역 좌표, #700) 대비 신선한 GPS fix 거리를 재계산해 payload에 동봉. 재등록 트리거와 무관하게 실시간 anchor 입력 공급.
- `backend/alarm-worker/src/index.ts`: POST `/position` 핸들러에 `parseOriginProximityFields` + `stampOriginProximityIfNeeded` 추가 — 근접(margin 이내)일 때만 trip을 read, 이미 stamp된 trip은 재-write하지 않음 (trip당 최초 1회 write, CF KV free tier quota 보호).
- `backend/alarm-worker/src/boardingPrompt.ts`: `isNearOrigin(distance, accuracy)` 순수 함수 추출 — `scheduled.ts` cron 경로와 `index.ts` `/position` 경로가 동일 근접 판정 로직 공유.
- `backend/alarm-worker/src/scheduled.ts`: cron 경로는 register/heal로 이미 갱신된 케이스의 보조 stamp 경로로 유지. 도달 불가능했던 dead code(freshness/too-far skip 분기의 putTrip 호출) 제거.
- 테스트: index.test.ts에 `/position`-only 근접 stamp 시나리오(재등록 없이 stamp 발화) red→green 추가, positionUpload.test.ts에 `withOriginProximity` red→green 추가.

## 왜 필요한가

dev의 #2165 구현(`originProximityAt` anchor)은 이 stamp 발화 경로(#2153 P1 수정)가 없으면 `originProximityAt`을 세팅할 발화 지점이 cron 경로 하나뿐이다. 그런데 cron 경로는 register/heal 트리거에 의존하므로, 재등록 없이 도보로 출발역에 근접하는 케이스에서는 stamp 기회가 영영 오지 않는다. 즉 이 PR 없이는 #2165의 anchor 로직이 실질적으로 무효화된다.

## 변경 파일

- `backend/alarm-worker/src/__tests__/index.test.ts`
- `backend/alarm-worker/src/boardingPrompt.ts`
- `backend/alarm-worker/src/index.ts`
- `backend/alarm-worker/src/scheduled.ts`
- `src/features/nearest-station/api/__tests__/positionUpload.test.ts`
- `src/features/nearest-station/api/positionUpload.ts`

Closes 없음(#2153는 진행 중 epic 성격 sub-thread, 별도 close 없음 — Part of #2153)

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — `originProximityAt` stamp 여부는 DebugModal(BoardingLock/promptGeoContext 패널) 및 wrangler tail/Cloudflare Dashboard 로그(`stampOriginProximityIfNeeded` 호출 시 emit되는 구조화 로그)로 관측 가능.
3. **의존 PR** — 없음(N/A). #2165가 이미 머지되어 있고, 이 PR은 그 머지 시점에 유실된 조각을 복구하는 것.
4. **측정 plan** — 재등록 없이 도보로 출발역 근접 후 boardingPrompt 신선도 게이트 발화 여부를 1주 내 실기기 trip으로 확인. backend 로그에서 `stampOriginProximityIfNeeded` write 1회 발생 + 이후 재-write 없음(quota 보호) 확인.
5. **Device verify** — 필요. 시나리오: 목적지 설정 후 재등록 트리거 없이 도보로 출발역 반경 근접 → boardingPrompt가 정상 신선도로 발화하는지 실기기 확인.
