### PR TITLE
fix(#2179): 환승 BoardingTrainList에 전열차 후보 배선

### DIFF
--- a/src/features/alarm/hooks/__tests__/usePrevTrainCandidate.test.ts
+++ b/src/features/alarm/hooks/__tests__/usePrevTrainCandidate.test.ts
@@ -337,6 +337,42 @@ describe('usePrevTrainCandidate', () => {
     expect(result.current.prevTrain).toBeNull();
   });
 
+  it('#2179 — 환승역(origin과 다른 line) currentStation을 넘겨도 동일하게 전열차를 산출한다 (재사용 검증, 복제 구현 없음)', () => {
+    const transferStation: Station = {
+      id: 'stn-transfer',
+      name: '건대입구',
+      line: '7',
+      lat: 37.54,
+      lng: 127.07,
+    } as Station;
+    const transferNextStation: Station = {
+      id: 'stn-transfer-next',
+      name: '뚝섬유원지',
+      line: '7',
+      lat: 37.531,
+      lng: 127.066,
+    } as Station;
+    mockFindStationByNameAndLine.mockReturnValue(transferNextStation);
+    const nextArrival: StationArrival = {
+      up: [],
+      down: [makeTrain({ trainCode: 'T-TRANSFER-DEPARTED', arrivalSeconds: 30, line: '7' })],
+    };
+    mockUseArrival.mockReturnValue(arrivalRet(nextArrival));
+
+    const { result } = renderHook(() =>
+      usePrevTrainCandidate({
+        route,
+        destinationName: '잠실',
+        currentStation: transferStation,
+        nextStationName: transferNextStation.name,
+        line: '7',
+        currentArrivals: [],
+      }),
+    );
+
+    expect(result.current.prevTrain?.train.trainCode).toBe('T-TRANSFER-DEPARTED');
+  });
+
   it('route/destinationName이 없으면 direction 계산 없이(null) 진행 — resolveTripDirection 미호출', () => {
     const nextArrival: StationArrival = { up: [], down: [makeTrain({ trainCode: 'T-X', arrivalSeconds: 10 })] };
     mockUseArrival.mockReturnValue(arrivalRet(nextArrival));

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -862,6 +862,27 @@ export default function HomeScreen() {
     destinationName: destination?.name ?? null,
     currentStation: result?.station ?? null,
   });
+  // #2179 — 환승 leg의 "전열차" 후보 nextStationName. origin 슬롯의 label 계산(#649)과 동일하게
+  // (환승 후 노선, 환승역, 다음 waypoint) 기준 진행 방향 바로 다음 인접역을 산출한다.
+  const transferNextStationName = useMemo(() => {
+    if (!transferContext) return null;
+    return resolveNextAdjacentStationName(
+      transferContext.nextLine,
+      transferContext.transferStationInToLine.name,
+      transferContext.nextWaypointName,
+    );
+  }, [transferContext]);
+  // #2179 — 환승 슬롯 전열차 후보. usePrevTrainCandidate는 origin/transfer 어느 leg든 (역, 노선)
+  // 파라미터만으로 동작하는 범용 hook이라(resolveTripDirection이 currentStation의 line에 맞는
+  // leg를 자동 선택) 별도 복제 구현 없이 재사용한다.
+  const { prevTrain: transferPrevTrain } = usePrevTrainCandidate({
+    route,
+    destinationName: destination?.name ?? null,
+    currentStation: transferContext?.transferStationInToLine ?? null,
+    nextStationName: transferNextStationName,
+    line: transferContext?.nextLine ?? null,
+    currentArrivals: transferArrivals,
+  });
   // #924 D1 — route 미설정 환승 자동 detect. 환승역 walking + 다른 노선 임박 ArrivalRow 신호 결합.
   // useFusedNearestStation은 NearestStationResult(단수)만 노출 — 본 hook 입력 NearestStationsResult로 재조합.
   const nearestStationsForDetect = useMemo(() => {
@@ -1576,6 +1597,9 @@ export default function HomeScreen() {
                                   onLockCorrected={handleLockCorrected}
                                   // #2115 — 환승역 도달 직후 다음 노선 첫 arrival fetch 완료 전 loading 노출.
                                   loading={transferLoading}
+                                  // #2179 — 전열차(환승역을 방금 떠난 열차) 후보. 식별 불가 시 null이라
+                                  // 기존 [현열차 | 다음열차] 렌더가 그대로 보존된다.
+                                  prevTrain={transferPrevTrain}
                                 />
                               );
                             }


### PR DESCRIPTION
Closes #2179

## 요약
#2139(PR #2143)에서 origin 슬롯 BoardingTrainList에만 배선됐던 `usePrevTrainCandidate`(전열차 후보)를 환승 슬롯에도 배선한다. 환승 리스트(`useTransferTrainList`)는 `filterByDirection`이 이미 출발한 열차(arrivalSeconds ≤ 0, #666)를 제외하므로, 환승역에서 이미 탄 열차는 리스트에서 사라져 사용자가 탑승 열차를 정확히 선택할 수 없었다(2026-08-06 건대입구 실탑승 evidence).

## 변경 사항
- `src/screens/HomeScreen.tsx`: `usePrevTrainCandidate`를 환승역(`transferContext.transferStationInToLine`)/환승 노선(`transferContext.nextLine`) 기준으로 재호출해 `transferPrevTrain` 산출, 환승 슬롯 `BoardingTrainList`에 `prevTrain` prop으로 전달. `nextStationName`은 origin 슬롯과 동일하게 `resolveNextAdjacentStationName`으로 산출.
- `usePrevTrainCandidate`는 이미 (route, destinationName, currentStation, nextStationName, line, currentArrivals) 파라미터 기반 범용 hook 이라(내부 `resolveTripDirection`이 `currentStation`의 line에 맞는 leg를 자동 선택) **복제 구현 없이 그대로 재사용**했다.
- `onSelect`는 기존 `createTransferLock` 그대로 유지 (스펙 3). D5 auto-transfer-lock(dormant) 코드는 미접근 (스펙 3/금지사항).
- `filterByDirection`의 출발열차 제외(#666) 로직은 변경하지 않음 (금지사항).
- `src/features/alarm/hooks/__tests__/usePrevTrainCandidate.test.ts`: origin과 다른 line의 currentStation(환승역 시뮬레이션)에서도 동일하게 전열차를 산출하는 재사용 회귀 테스트 추가.

## Wire-completion 5단
1. **Orphan 없음**: `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard**: HomeScreen 환승 hop slot(EditorialTimeline `stop.mark === 'transfer'`)의 BoardingTrainList UI에서 [전열차|현열차|다음열차] 렌더로 직접 확인 가능. 별도 backend/telemetry 신호 없음(UI-only).
3. **의존 PR**: N/A
4. **측정 plan**: 다음 환승 실탑승에서 실제 탄 열차가 리스트에 존재 + 선택 가능한지 확인 (Epic #2172 탑승과 공유 가능)
5. **Device verify**: 실기기 환승 1회 필요 — 환승역 도착 후 BoardingTrainList에 전열차 항목이 뜨고 탭 시 `createTransferLock`이 정상 호출되는지 확인

## 테스트
- `npm test` — 전체 9103개 pass, coverage 100%
- `npm run type-check` — pass
- `npm run lint:orphan` — 0 orphan