### PR TITLE
feat(#2177): push 발사 최종 실패 D1 기록

### DIFF
--- a/backend/alarm-worker/migrations/0002_push_failures.sql
+++ b/backend/alarm-worker/migrations/0002_push_failures.sql
@@ -1,0 +1,20 @@
+-- #2177 — push 발사 최종 실패 D1 기록.
+-- backend_errors 는 endpoint/error_type/context(JSON) 형태라 apnsStatus/apnsReason/pushKind 같은
+-- 구조화 필드로 SELECT/GROUP BY 하기엔 부적합(context json_extract 매 쿼리 필요). push 실패는
+-- "사유 top N" 집계가 핵심 요구라 전용 컬럼을 가진 신규 테이블로 분리한다.
+-- 성공은 기록하지 않는다(볼륨). 429/5xx transient 재시도 중간 실패도 기록하지 않고, 최종(재시도
+-- 불가 판정 시점) 실패만 1건 적재한다 — CF 무료 D1 quota 보호.
+CREATE TABLE IF NOT EXISTS push_failures (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts INTEGER NOT NULL,
+  token_hash TEXT NOT NULL,
+  trip_token_hash TEXT,
+  push_kind TEXT NOT NULL,
+  apns_status INTEGER NOT NULL,
+  apns_reason TEXT,
+  apns_env TEXT,
+  env_mismatch_exhausted INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_failures_ts ON push_failures(ts);
+CREATE INDEX IF NOT EXISTS idx_push_failures_status_reason ON push_failures(apns_status, apns_reason);

--- a/backend/alarm-worker/migrations/0003_push_failures_rate_limit_index.sql
+++ b/backend/alarm-worker/migrations/0003_push_failures_rate_limit_index.sql
@@ -1,0 +1,4 @@
+-- #2177 리뷰 P1 — logPushFailure rate-limit SELECT(token_hash, push_kind, ts)를 위한 인덱스.
+-- 같은 (tokenHash, pushKind) 최종 실패가 RATE_LIMIT_WINDOW_MS 내 재기록되지 않도록 write 전
+-- SELECT로 선확인한다. 이 인덱스 없이는 매 SELECT가 push_failures 풀스캔이 된다.
+CREATE INDEX IF NOT EXISTS idx_push_failures_token_kind_ts ON push_failures(token_hash, push_kind, ts);

--- a/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
+++ b/backend/alarm-worker/src/__tests__/observabilityMetrics.test.ts
@@ -75,6 +75,7 @@ describe('storeObservabilityMetrics + readObservabilityMetrics', () => {
         window: '24h-rolling-ttl' as const,
         sampledAt: NOW,
       },
+      pushFailures: { total24h: 0, topReasons: [] },
       window: '24h' as const,
       timestamp: NOW,
     };
@@ -126,6 +127,7 @@ describe('storeObservabilityMetrics + readObservabilityMetrics', () => {
         window: '24h-rolling-ttl' as const,
         sampledAt: NOW,
       },
+      pushFailures: { total24h: 0, topReasons: [] },
       window: '24h' as const,
       timestamp: NOW,
     };
@@ -968,6 +970,7 @@ const SAMPLE_METRICS = {
     window: '24h-rolling-ttl' as const,
     sampledAt: NOW,
   },
+  pushFailures: { total24h: 0, topReasons: [] },
   window: '24h' as const,
   timestamp: NOW,
 };

--- a/backend/alarm-worker/src/__tests__/pushFailureLog.test.ts
+++ b/backend/alarm-worker/src/__tests__/pushFailureLog.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from 'vitest';
+import { computePushFailureMetrics, EMPTY_PUSH_FAILURE_METRICS, logPushFailure } from '../pushFailureLog';
+
+const NOW = 1_700_000_000_000;
+
+function makeWriteDb(): { db: D1Database; prepare: ReturnType<typeof vi.fn> } {
+  const run = vi.fn().mockResolvedValue({ success: true });
+  const bind = vi.fn().mockReturnValue({ run });
+  const prepare = vi.fn().mockReturnValue({ bind });
+  return { db: { prepare } as unknown as D1Database, prepare };
+}
+
+describe('logPushFailure (#2177)', () => {
+  it('db가 undefined일 때 no-op (graceful)', async () => {
+    await expect(
+      logPushFailure(undefined, {
+        token: 'tok-1',
+        pushKind: 'destination',
+        apnsStatus: 410,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('db가 있을 때 push_failures INSERT를 실행한다', async () => {
+    const { db, prepare } = makeWriteDb();
+    await logPushFailure(db, {
+      token: 'tok-1',
+      pushKind: 'destination',
+      apnsStatus: 410,
+      apnsReason: 'Unregistered',
+      apnsEnv: 'production',
+    });
+    expect(prepare).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO push_failures'));
+  });
+
+  it('tripToken 미제공 시 token hash를 trip_token_hash에도 재사용한다', async () => {
+    let captured: unknown[] = [];
+    const run = vi.fn().mockResolvedValue({ success: true });
+    const bind = vi.fn().mockImplementation((...args: unknown[]) => {
+      captured = args;
+      return { run };
+    });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+
+    await logPushFailure(db, {
+      token: 'same-token',
+      pushKind: 'transfer',
+      apnsStatus: 400,
+      apnsReason: 'BadDeviceToken',
+    });
+
+    // bind 순서: ts, tokenHash, tripTokenHash, pushKind, status, reason, env, envMismatchExhausted
+    expect(captured[1]).toBe(captured[2]);
+  });
+
+  it('tripToken 제공 시 별도 hash를 사용한다', async () => {
+    let captured: unknown[] = [];
+    const run = vi.fn().mockResolvedValue({ success: true });
+    const bind = vi.fn().mockImplementation((...args: unknown[]) => {
+      captured = args;
+      return { run };
+    });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+
+    await logPushFailure(db, {
+      token: 'device-token',
+      tripToken: 'different-trip-token',
+      pushKind: 'intermediate',
+      apnsStatus: 500,
+    });
+
+    expect(captured[1]).not.toBe(captured[2]);
+  });
+
+  it('envMismatchExhausted=true → 1로 저장된다', async () => {
+    let captured: unknown[] = [];
+    const run = vi.fn().mockResolvedValue({ success: true });
+    const bind = vi.fn().mockImplementation((...args: unknown[]) => {
+      captured = args;
+      return { run };
+    });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+
+    await logPushFailure(db, {
+      token: 'tok',
+      pushKind: 'destination',
+      apnsStatus: 400,
+      apnsReason: 'BadDeviceToken',
+      envMismatchExhausted: true,
+    });
+
+    expect(captured[captured.length - 1]).toBe(1);
+  });
+
+  it('envMismatchExhausted 미제공 시 0으로 저장된다', async () => {
+    let captured: unknown[] = [];
+    const run = vi.fn().mockResolvedValue({ success: true });
+    const bind = vi.fn().mockImplementation((...args: unknown[]) => {
+      captured = args;
+      return { run };
+    });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+
+    await logPushFailure(db, {
+      token: 'tok',
+      pushKind: 'destination',
+      apnsStatus: 429,
+    });
+
+    expect(captured[captured.length - 1]).toBe(0);
+  });
+
+  it('D1 write 실패 시 throw 없이 swallow한다', async () => {
+    const run = vi.fn().mockRejectedValue(new Error('D1 write error'));
+    const bind = vi.fn().mockReturnValue({ run });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const dbFail = { prepare } as unknown as D1Database;
+
+    await expect(
+      logPushFailure(dbFail, { token: 'tok', pushKind: 'destination', apnsStatus: 500 }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('computePushFailureMetrics (#2177)', () => {
+  it('db가 undefined일 때 zero 기본값을 반환한다', async () => {
+    const result = await computePushFailureMetrics(undefined, NOW);
+    expect(result).toEqual(EMPTY_PUSH_FAILURE_METRICS);
+  });
+
+  it('total24h + topReasons를 집계한다', async () => {
+    const first = vi.fn().mockResolvedValue({ count: 7 });
+    const all = vi.fn().mockResolvedValue({
+      results: [
+        { status: 410, reason: 'Unregistered', count: 5 },
+        { status: 400, reason: 'BadDeviceToken', count: 2 },
+      ],
+    });
+    const bind = vi.fn().mockReturnValue({ first, all });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+
+    const result = await computePushFailureMetrics(db, NOW);
+
+    expect(result.total24h).toBe(7);
+    expect(result.topReasons).toEqual([
+      { reason: '410:Unregistered', count: 5 },
+      { reason: '400:BadDeviceToken', count: 2 },
+    ]);
+  });
+
+  it('apns_reason이 null이면 unknown으로 표기한다', async () => {
+    const first = vi.fn().mockResolvedValue({ count: 1 });
+    const all = vi.fn().mockResolvedValue({
+      results: [{ status: 429, reason: null, count: 1 }],
+    });
+    const bind = vi.fn().mockReturnValue({ first, all });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+
+    const result = await computePushFailureMetrics(db, NOW);
+    expect(result.topReasons).toEqual([{ reason: '429:unknown', count: 1 }]);
+  });
+
+  it('first가 null을 반환하면 total24h=0', async () => {
+    const first = vi.fn().mockResolvedValue(null);
+    const all = vi.fn().mockResolvedValue({ results: [] });
+    const bind = vi.fn().mockReturnValue({ first, all });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+
+    const result = await computePushFailureMetrics(db, NOW);
+    expect(result.total24h).toBe(0);
+    expect(result.topReasons).toEqual([]);
+  });
+
+  it('D1 read 실패 시 throw 없이 zero 기본값을 반환한다', async () => {
+    const bind = vi.fn().mockReturnValue({
+      first: vi.fn().mockRejectedValue(new Error('D1 read error')),
+      all: vi.fn().mockResolvedValue({ results: [] }),
+    });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const dbFail = { prepare } as unknown as D1Database;
+
+    const result = await computePushFailureMetrics(dbFail, NOW);
+    expect(result).toEqual(EMPTY_PUSH_FAILURE_METRICS);
+  });
+});

--- a/backend/alarm-worker/src/__tests__/pushFailureLog.test.ts
+++ b/backend/alarm-worker/src/__tests__/pushFailureLog.test.ts
@@ -3,11 +3,40 @@ import { computePushFailureMetrics, EMPTY_PUSH_FAILURE_METRICS, logPushFailure }
 
 const NOW = 1_700_000_000_000;
 
-function makeWriteDb(): { db: D1Database; prepare: ReturnType<typeof vi.fn> } {
-  const run = vi.fn().mockResolvedValue({ success: true });
-  const bind = vi.fn().mockReturnValue({ run });
-  const prepare = vi.fn().mockReturnValue({ bind });
-  return { db: { prepare } as unknown as D1Database, prepare };
+/**
+ * logPushFailure 내부에서 prepare()가 SQL 종류(SELECT rate-limit 확인 / INSERT)별로 다르게
+ * 호출되므로, SQL 문자열로 분기해 각기 다른 stub을 반환하는 mock DB를 만든다.
+ *
+ * @param recentExists - rate-limit SELECT가 "최근 기록 있음"을 반환할지 여부.
+ */
+function makeDb(options: {
+  recentExists?: boolean;
+  selectThrows?: boolean;
+  insertThrows?: boolean;
+} = {}): {
+  db: D1Database;
+  insertBind: ReturnType<typeof vi.fn>;
+  selectBind: ReturnType<typeof vi.fn>;
+  run: ReturnType<typeof vi.fn>;
+} {
+  const { recentExists = false, selectThrows = false, insertThrows = false } = options;
+
+  const run = insertThrows
+    ? vi.fn().mockRejectedValue(new Error('D1 write error'))
+    : vi.fn().mockResolvedValue({ success: true });
+  const insertBind = vi.fn().mockReturnValue({ run });
+
+  const first = selectThrows
+    ? vi.fn().mockRejectedValue(new Error('D1 read error'))
+    : vi.fn().mockResolvedValue(recentExists ? { 1: 1 } : null);
+  const selectBind = vi.fn().mockReturnValue({ first });
+
+  const prepare = vi.fn().mockImplementation((sql: string) => {
+    if (sql.startsWith('SELECT')) return { bind: selectBind };
+    return { bind: insertBind };
+  });
+
+  return { db: { prepare } as unknown as D1Database, insertBind, selectBind, run };
 }
 
 describe('logPushFailure (#2177)', () => {
@@ -22,7 +51,7 @@ describe('logPushFailure (#2177)', () => {
   });
 
   it('db가 있을 때 push_failures INSERT를 실행한다', async () => {
-    const { db, prepare } = makeWriteDb();
+    const { db, insertBind } = makeDb();
     await logPushFailure(db, {
       token: 'tok-1',
       pushKind: 'destination',
@@ -30,18 +59,11 @@ describe('logPushFailure (#2177)', () => {
       apnsReason: 'Unregistered',
       apnsEnv: 'production',
     });
-    expect(prepare).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO push_failures'));
+    expect(insertBind).toHaveBeenCalled();
   });
 
   it('tripToken 미제공 시 token hash를 trip_token_hash에도 재사용한다', async () => {
-    let captured: unknown[] = [];
-    const run = vi.fn().mockResolvedValue({ success: true });
-    const bind = vi.fn().mockImplementation((...args: unknown[]) => {
-      captured = args;
-      return { run };
-    });
-    const prepare = vi.fn().mockReturnValue({ bind });
-    const db = { prepare } as unknown as D1Database;
+    const { db, insertBind } = makeDb();
 
     await logPushFailure(db, {
       token: 'same-token',
@@ -51,18 +73,12 @@ describe('logPushFailure (#2177)', () => {
     });
 
     // bind 순서: ts, tokenHash, tripTokenHash, pushKind, status, reason, env, envMismatchExhausted
+    const captured = insertBind.mock.calls[0];
     expect(captured[1]).toBe(captured[2]);
   });
 
   it('tripToken 제공 시 별도 hash를 사용한다', async () => {
-    let captured: unknown[] = [];
-    const run = vi.fn().mockResolvedValue({ success: true });
-    const bind = vi.fn().mockImplementation((...args: unknown[]) => {
-      captured = args;
-      return { run };
-    });
-    const prepare = vi.fn().mockReturnValue({ bind });
-    const db = { prepare } as unknown as D1Database;
+    const { db, insertBind } = makeDb();
 
     await logPushFailure(db, {
       token: 'device-token',
@@ -71,18 +87,12 @@ describe('logPushFailure (#2177)', () => {
       apnsStatus: 500,
     });
 
+    const captured = insertBind.mock.calls[0];
     expect(captured[1]).not.toBe(captured[2]);
   });
 
   it('envMismatchExhausted=true → 1로 저장된다', async () => {
-    let captured: unknown[] = [];
-    const run = vi.fn().mockResolvedValue({ success: true });
-    const bind = vi.fn().mockImplementation((...args: unknown[]) => {
-      captured = args;
-      return { run };
-    });
-    const prepare = vi.fn().mockReturnValue({ bind });
-    const db = { prepare } as unknown as D1Database;
+    const { db, insertBind } = makeDb();
 
     await logPushFailure(db, {
       token: 'tok',
@@ -92,18 +102,12 @@ describe('logPushFailure (#2177)', () => {
       envMismatchExhausted: true,
     });
 
+    const captured = insertBind.mock.calls[0];
     expect(captured[captured.length - 1]).toBe(1);
   });
 
   it('envMismatchExhausted 미제공 시 0으로 저장된다', async () => {
-    let captured: unknown[] = [];
-    const run = vi.fn().mockResolvedValue({ success: true });
-    const bind = vi.fn().mockImplementation((...args: unknown[]) => {
-      captured = args;
-      return { run };
-    });
-    const prepare = vi.fn().mockReturnValue({ bind });
-    const db = { prepare } as unknown as D1Database;
+    const { db, insertBind } = makeDb();
 
     await logPushFailure(db, {
       token: 'tok',
@@ -111,18 +115,74 @@ describe('logPushFailure (#2177)', () => {
       apnsStatus: 429,
     });
 
+    const captured = insertBind.mock.calls[0];
     expect(captured[captured.length - 1]).toBe(0);
   });
 
   it('D1 write 실패 시 throw 없이 swallow한다', async () => {
-    const run = vi.fn().mockRejectedValue(new Error('D1 write error'));
-    const bind = vi.fn().mockReturnValue({ run });
-    const prepare = vi.fn().mockReturnValue({ bind });
-    const dbFail = { prepare } as unknown as D1Database;
+    const { db: dbFail } = makeDb({ insertThrows: true });
 
     await expect(
       logPushFailure(dbFail, { token: 'tok', pushKind: 'destination', apnsStatus: 500 }),
     ).resolves.toBeUndefined();
+  });
+
+  describe('rate-limit 가드 (#2177 리뷰 P1)', () => {
+    it('같은 (tokenHash, pushKind) 실패가 윈도우 내 이미 있으면 INSERT를 skip한다', async () => {
+      const { db, insertBind } = makeDb({ recentExists: true });
+
+      await logPushFailure(db, { token: 'tok', pushKind: 'boarding-prompt', apnsStatus: 500 });
+
+      expect(insertBind).not.toHaveBeenCalled();
+    });
+
+    it('같은 (tokenHash, pushKind) 실패 2연속 호출 → 두 번째는 skip되어 INSERT 1회만 발생한다', async () => {
+      const run = vi.fn().mockResolvedValue({ success: true });
+      const insertBind = vi.fn().mockReturnValue({ run });
+
+      // 첫 호출: 아직 기록 없음 → insert 발생. 이후 SELECT는 "방금 기록됨"을 반환하도록 갱신.
+      let recentExists = false;
+      const first = vi.fn().mockImplementation(async () => (recentExists ? { 1: 1 } : null));
+      const selectBind = vi.fn().mockReturnValue({ first });
+
+      const prepare = vi.fn().mockImplementation((sql: string) => {
+        if (sql.startsWith('SELECT')) return { bind: selectBind };
+        return { bind: insertBind };
+      });
+      const db = { prepare } as unknown as D1Database;
+
+      await logPushFailure(db, { token: 'tok', pushKind: 'reschedule', apnsStatus: 503 });
+      recentExists = true;
+      await logPushFailure(db, { token: 'tok', pushKind: 'reschedule', apnsStatus: 503 });
+
+      expect(insertBind).toHaveBeenCalledTimes(1);
+    });
+
+    it('rate-limit 윈도우 경과 후 재호출하면 다시 INSERT한다', async () => {
+      const { db, insertBind } = makeDb({ recentExists: false });
+
+      await logPushFailure(db, { token: 'tok', pushKind: 'destination', apnsStatus: 500 });
+      await logPushFailure(db, { token: 'tok', pushKind: 'destination', apnsStatus: 500 });
+
+      expect(insertBind).toHaveBeenCalledTimes(2);
+    });
+
+    it('다른 pushKind는 rate-limit 대상에서 제외된다 (SELECT 조건에 push_kind 포함)', async () => {
+      const { db, selectBind } = makeDb();
+
+      await logPushFailure(db, { token: 'tok', pushKind: 'transfer', apnsStatus: 500 });
+
+      expect(selectBind).toHaveBeenCalledWith(expect.any(String), 'transfer', expect.any(Number));
+    });
+
+    it('rate-limit SELECT 실패 시 throw 없이 swallow한다(insert도 skip)', async () => {
+      const { db, insertBind } = makeDb({ selectThrows: true });
+
+      await expect(
+        logPushFailure(db, { token: 'tok', pushKind: 'destination', apnsStatus: 500 }),
+      ).resolves.toBeUndefined();
+      expect(insertBind).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -10606,6 +10606,7 @@ describe('maybeFireHopEndPrompt (#2034)', () => {
       now: NOW,
       log: () => {},
       generatePushId: () => 'pid-hop',
+      env: makeEnv(new InMemoryKV()),
     });
     expect(stats.hopEndPromptFired).toBe(1);
     expect(stats.hopEndPromptBlocked).toBe(0);
@@ -10633,6 +10634,7 @@ describe('maybeFireHopEndPrompt (#2034)', () => {
       now: NOW,
       log: () => {},
       generatePushId: () => 'pid-block',
+      env: makeEnv(new InMemoryKV()),
     });
     expect(stats.hopEndPromptFired).toBe(0);
     expect(stats.hopEndPromptBlocked).toBe(1);
@@ -10651,6 +10653,7 @@ describe('maybeFireHopEndPrompt (#2034)', () => {
       now: NOW,
       log: () => {},
       generatePushId: () => 'pid-err',
+      env: makeEnv(new InMemoryKV()),
     });
     expect(stats.errors).toBe(1);
     expect(stats.hopEndPromptFired).toBe(0);
@@ -10670,6 +10673,7 @@ describe('maybeFireHopEndPrompt (#2034)', () => {
       now: NOW,
       log: () => {},
       generatePushId: () => 'pid-empty',
+      env: makeEnv(new InMemoryKV()),
     });
     expect(stats.hopEndPromptFired).toBe(1);
     const [, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
@@ -10698,6 +10702,7 @@ describe('maybeFireHopEndPrompt (#2034)', () => {
       now: NOW,
       log: () => {},
       generatePushId: () => 'pid-diff-leg',
+      env: makeEnv(new InMemoryKV()),
     });
     expect(stats.hopEndPromptFired).toBe(1);
     // 기존 legKey 는 유지, 새 legKey (`성수|5`) 는 신규 fired.

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -2360,6 +2360,43 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
     expect(data.boardingLine).toBe('7');
   });
 
+  // #1721/#2177 — transfer-release push가 transient(503) 실패 시 retry-push: 큐에 적재된다.
+  // envMismatchExhausted 필드도 함께 stamp되는지 회귀 차단(#2177 신규 필드).
+  it('#2177 — transfer-release push 503 → retry-push: 큐 적재', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeLockTrip({
+        waypoints: [
+          { stationName: '군자', line: '7', kind: 'transfer' },
+          { stationName: '아차산', line: '5', kind: 'destination' },
+        ],
+      }),
+    );
+    const apnsFetch = vi.fn(async () => new Response('', { status: 503 }));
+    await runScheduled(makeEnv(kv, kv), {
+      seoul: makeSeoulCombo([arrivalForLock('군자', 0, 1)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-transfer-503',
+    });
+    // arvlcd push는 injected generatePushId를 쓰지만, transfer-release push는 내부에서
+    // crypto.randomUUID()로 자체 pushId를 발급한다 — retry-push: prefix 전체를 스캔해
+    // payload.origin='transfer-release' 항목을 찾는다.
+    const allKeys = await kv.list({ prefix: 'retry-push:' });
+    let transferEntry: { lastErrorStatus: number; payload: { origin: string } } | undefined;
+    for (const { name } of allKeys.keys) {
+      const raw = await kv.get(name);
+      if (!raw) continue;
+      const parsed = JSON.parse(raw as string);
+      if (parsed.payload?.origin === 'transfer-release') transferEntry = parsed;
+    }
+    expect(transferEntry).toBeDefined();
+    expect(transferEntry!.lastErrorStatus).toBe(503);
+  });
+
   // #2066 (Phase 2-backend) — 취침 알람 원격 visible 전환. "환승/도착역 직전 역" arvlCd 진입
   // 시점에 visible alert(주 채널) + companion silent push(kind sleep-alarm-companion)를 동시 발사.
   // ADR-023 정합: backend는 sleepModeEnabled === true trip에서만 발사한다(#2066부터 gate 도입 —
@@ -8919,6 +8956,84 @@ describe('runLocklessIntermediate passedStations 누적 (#1539 S6)', () => {
     expect(stats.locklessIntermediateFired).toBe(1);
     const stored = JSON.parse((await kv.get('trip:lockless-pass')) as string) as Trip;
     expect(stored.passedStations).toEqual(['강남']);
+  });
+
+  // #2177 — lockless intermediate push가 unrecoverable(410 Unregistered)로 실패하면 retry queue를
+  // 타지 않고 cleanupTripWithLa('push-unrecoverable')로 즉시 trip 폐기된다.
+  it('#2177 — unrecoverable(410) push 실패 → retry-push 큐 적재 X + trip 폐기', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({
+      token: 'lockless-410',
+      route: { type: 'direct', line: '2', stops: 2 },
+      waypoints: [
+        { stationName: '강남', line: '2', kind: 'intermediate' },
+        { stationName: '역삼', line: '2', kind: 'intermediate' },
+      ],
+      infoModeEnabled: true,
+    });
+    await putTrip(kv as unknown as KVNamespace, trip);
+    await seedLocklessMotionSeries(kv, trip.token, 'automotive');
+    const apnsFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'Unregistered' }), { status: 410 }),
+    );
+    const arrived: ArrivalEntry = {
+      destination: '강남행',
+      arrivalSeconds: 30,
+      trainCode: '7246',
+      isUp: true,
+      subwayNm: '지하철2호선',
+      arvlCd: 1,
+    };
+    const stats = await runScheduled(makeEnv(kv, kv), {
+      seoul: makeSeoul([arrived]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-lockless-410',
+    });
+    expect(stats.errors).toBeGreaterThan(0);
+    expect(await kv.get('retry-push:p-lockless-410')).toBeNull();
+    expect(await kv.get('trip:lockless-410')).toBeNull();
+  });
+
+  // #2177 — lockless intermediate push가 transient(503)로 실패하면 retry-push 큐에 적재된다.
+  it('#2177 — transient(503) push 실패 → retry-push 큐 적재', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({
+      token: 'lockless-503',
+      route: { type: 'direct', line: '2', stops: 2 },
+      waypoints: [
+        { stationName: '강남', line: '2', kind: 'intermediate' },
+        { stationName: '역삼', line: '2', kind: 'intermediate' },
+      ],
+      infoModeEnabled: true,
+    });
+    await putTrip(kv as unknown as KVNamespace, trip);
+    await seedLocklessMotionSeries(kv, trip.token, 'automotive');
+    const apnsFetch = vi.fn(async () => new Response('', { status: 503 }));
+    const arrived: ArrivalEntry = {
+      destination: '강남행',
+      arrivalSeconds: 30,
+      trainCode: '7246',
+      isUp: true,
+      subwayNm: '지하철2호선',
+      arvlCd: 1,
+    };
+    await runScheduled(makeEnv(kv, kv), {
+      seoul: makeSeoul([arrived]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-lockless-503',
+    });
+    const stored = await kv.get('retry-push:p-lockless-503');
+    expect(stored).not.toBeNull();
+    const entry = JSON.parse(stored as string);
+    expect(entry.lastErrorStatus).toBe(503);
+    // trip은 폐기되지 않고 그대로 유지 (transient 실패는 다음 cycle 재시도).
+    expect(await kv.get('trip:lockless-503')).not.toBeNull();
   });
 });
 

--- a/backend/alarm-worker/src/fallback.ts
+++ b/backend/alarm-worker/src/fallback.ts
@@ -31,6 +31,7 @@
 import { sendAlertPush, type ApnsConfig, type SendPushResult } from './apns';
 import { buildAlertContent } from './alertContent';
 import { listPending, removePending, type PendingPush } from './pendingPushes';
+import { logPushFailure } from './pushFailureLog';
 import type { ApnsEnv, Env } from './types';
 
 /**
@@ -93,6 +94,16 @@ export async function runFallbackPushes(env: Env, deps: FallbackDeps): Promise<F
       // 영구 실패만 즉시 삭제 — transient 실패는 entry 유지하고 KV TTL(60s)이 자연 정리.
       // 다음 cron에서 1회 더 시도 기회를 보존 (사용자 알람 손실 최소화).
       if (isUnrecoverableAlertError(result.status, result.reason)) {
+        // #2177 — 영구 실패 판정 시점(=최종 실패)만 기록. transient는 entry가 KV에 남아 다음
+        // cron에서 재시도되므로 여기서 기록하면 매 cron tick 중복 기록되어 quota를 소진한다.
+        await logPushFailure(env.DB, {
+          token: entry.token,
+          tripToken: entry.token,
+          pushKind: 'fallback',
+          apnsStatus: result.status,
+          apnsReason: result.reason,
+          apnsEnv: entry.apnsEnv,
+        });
         await removePending(env.PENDING_PUSHES, entry.pushId);
       }
     }

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -1357,7 +1357,14 @@ app.get('/v1/observability/metrics', async (c) => {
 
   // 첫 요청 또는 KV TTL 만료(1h) 시 실시간 계산 후 KV 적재.
   try {
-    const metrics = await computeObservabilityMetrics(r2, c.env.PENDING_PUSHES, now, c.env.TRIPS);
+    const metrics = await computeObservabilityMetrics(
+      r2,
+      c.env.PENDING_PUSHES,
+      now,
+      c.env.TRIPS,
+      undefined,
+      c.env.DB,
+    );
     const storeResult = await tryStoreObservabilityMetrics(c.env.TRIPS, metrics, now, {
       onError: (err, key) =>
         void captureBackendException(c.env, err, { path: 'observability/metrics', stage: 'kv-put', key }),
@@ -2580,6 +2587,7 @@ export const handler = {
             now,
             env.TRIPS,
             boardingPromptCounters ?? undefined,
+            env.DB,
           );
           const storeResult = await tryStoreObservabilityMetrics(env.TRIPS, metrics, now, {
             onError: (err, key) =>

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -22,6 +22,7 @@ import { pickApnsHost, sendWithEnvHeal } from './apnsHost';
 import { recordTripMetrics } from './d1TripMetrics';
 import { LINE_META } from './lineAlias';
 import { deleteProgress } from './progress';
+import { logPushFailure } from './pushFailureLog';
 import { computeMultiHopContext } from './tripMultiHop';
 import { deleteSsot } from './tripPositionSsot';
 import { deleteTrip } from './trips';
@@ -397,6 +398,17 @@ async function fireTripEndedAlertPush(
         reason,
         status: heal.result.status,
         pushReason: heal.result.reason,
+      });
+      // #2177 — trip-ended push는 retry queue를 타지 않는 fire-and-forget 경로(다음 cron
+      // cycle에 자연 재시도) — 직접 기록.
+      await logPushFailure(env.DB, {
+        token: trip.token,
+        tripToken: trip.token,
+        pushKind: 'trip-ended',
+        apnsStatus: heal.result.status,
+        apnsReason: heal.result.reason,
+        apnsEnv: trip.apnsEnv,
+        envMismatchExhausted: heal.envMismatchExhausted,
       });
       // 실패 시에는 dedup stamp를 남기지 않아 다음 cron cycle에서 재시도 허용.
       return;

--- a/backend/alarm-worker/src/observabilityMetrics.ts
+++ b/backend/alarm-worker/src/observabilityMetrics.ts
@@ -40,6 +40,7 @@
 import { computeAlarmLogStats } from './alarmLogStats';
 import { buildLocklessTripMissBucket } from './locklessMissMetric';
 import { computePushAckStats } from './pushAckStats';
+import { computePushFailureMetrics, type PushFailureMetrics } from './pushFailureLog';
 import { computeSilentPushReachRatio } from './silentPushReachMetric';
 import { sumLaPushCounters } from './laPushCounters';
 import {
@@ -128,6 +129,11 @@ export interface ObservabilityMetricsResponse {
   locklessTripMissRatio: { miss: number; fired: number; paradigmIntent: number; ratio: number };
   /** #2151 — boardingPrompt skip/fire counter 스냅샷. 위 doc-comment 참고 (24h 누적 아님). */
   boardingPromptCounters: BoardingPromptCounters;
+  /**
+   * #2177 — push 발사 최종 실패(D1 push_failures) 24h 집계. total24h + 사유(status:reason)별
+   * 상위 5 bucket. `env.DB` 미바인딩 시 zero 기본값.
+   */
+  pushFailures: PushFailureMetrics;
   window: '24h';
   timestamp: number;
 }
@@ -152,6 +158,7 @@ export function hourBucketKey(now: number): string {
  *   누적 KV 키(`readBoardingPromptCounters`)의 최신 값 (optional). 호출자(scheduled handler)가
  *   읽어서 넘긴다 — 미제공 시(예: `/v1/observability/metrics` endpoint의 cold-compute fallback)
  *   zero 기본값.
+ * @param db #2177 — D1 binding. push_failures 24h 집계용 (optional, 미설정 시 zero 기본값).
  */
 export async function computeObservabilityMetrics(
   r2: R2Bucket,
@@ -159,6 +166,7 @@ export async function computeObservabilityMetrics(
   now: number,
   tripsKv?: KVNamespace,
   boardingPromptCounters?: BoardingPromptCounters,
+  db?: D1Database,
 ): Promise<ObservabilityMetricsResponse> {
   // 1. R2 alarmLog 24h scan — accuracyRatio + locklessMissRatio 원천
   const alarmStats = await computeAlarmLogStats(r2, now, 24, 500);
@@ -241,6 +249,9 @@ export async function computeObservabilityMetrics(
   //    buildLocklessTripMissBucket이 division-by-zero 방어 — 분모 0이면 ratio=0.
   const locklessTripMissRatio = buildLocklessTripMissBucket(alarmStats.locklessTripCounts);
 
+  // 8. #2177 — pushFailures. D1 push_failures 24h 집계 (total + 사유 top 5).
+  const pushFailures = await computePushFailureMetrics(db, now);
+
   return {
     accuracyRatio,
     silentPushDeliveryRatio,
@@ -253,6 +264,7 @@ export async function computeObservabilityMetrics(
     algorithmAccuracyRatio,
     locklessTripMissRatio,
     boardingPromptCounters: boardingPromptCounters ?? EMPTY_BOARDING_PROMPT_COUNTERS,
+    pushFailures,
     window: '24h',
     timestamp: now,
   };

--- a/backend/alarm-worker/src/pushFailureLog.ts
+++ b/backend/alarm-worker/src/pushFailureLog.ts
@@ -1,0 +1,129 @@
+/**
+ * D1 push_failures 테이블 helper (#2177).
+ *
+ * 배경: 08-06 RCA에서 push-unrecoverable의 정확한 APNs 코드(410 vs 400)를 확증하지 못했다.
+ * push 실패는 console log에만 남고(`persist=false`, #2055) D1 미기록이라 wrangler tail 실시간
+ * 관측 외 사후 진단 수단이 없었다. 본 모듈은 push 발사 **최종** 실패(성공/재시도 중간 실패 제외)를
+ * D1에 적재해 사후 SELECT로 사유를 확정할 수 있게 한다.
+ *
+ * `backend_errors`(#1835)를 재사용하지 않고 `push_failures`를 신설한 이유: backend_errors는
+ * endpoint/error_type/context(JSON) 형태라 apnsStatus/apnsReason별 GROUP BY 집계(obs-metrics
+ * top 사유)가 매 쿼리 json_extract를 요구해 부적합. push 실패는 구조화 컬럼이 핵심 요구.
+ *
+ * `env.DB` 미바인딩 시 graceful no-op. 적재 실패는 push 발사 흐름을 차단하지 않는다(swallow).
+ */
+
+import { hashTripToken } from './sentry';
+import type { ApnsEnv } from './types';
+
+export interface PushFailureInput {
+  /** APNs device token — 원본 노출 금지, FNV-1a hash만 저장. */
+  token: string;
+  /** trip 식별 토큰. 현재 시스템에서는 device token과 동일 값(`trip.token`)이지만 스키마상 분리. */
+  tripToken?: string;
+  /** push 종류 (예: 'transfer' | 'destination' | 'intermediate' | 'reschedule' | 'boarding-prompt' 등). */
+  pushKind: string;
+  apnsStatus: number;
+  apnsReason?: string;
+  apnsEnv?: ApnsEnv;
+  /** 양쪽 host(sandbox/production) 모두 BadDeviceToken — 토큰 자체 무효 신호. */
+  envMismatchExhausted?: boolean;
+}
+
+/**
+ * push_failures 테이블에 최종 실패 1건을 기록한다.
+ *
+ * 호출자 책임: 성공은 호출하지 않는다 + 429/5xx transient 재시도 중간 실패가 아니라 재시도가
+ * 더는 없다고 판정된 시점(최종 실패)에만 호출한다 — CF 무료 D1 quota 보호.
+ *
+ * @param db - D1 binding. undefined 시 no-op.
+ * @param input - 실패 메타데이터.
+ */
+export async function logPushFailure(
+  db: D1Database | undefined,
+  input: PushFailureInput,
+): Promise<void> {
+  if (!db) return;
+  try {
+    const tokenHash = hashTripToken(input.token);
+    const tripTokenHash = input.tripToken !== undefined ? hashTripToken(input.tripToken) : tokenHash;
+    await db
+      .prepare(
+        'INSERT INTO push_failures (ts, token_hash, trip_token_hash, push_kind, apns_status, apns_reason, apns_env, env_mismatch_exhausted) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+      )
+      .bind(
+        Date.now(),
+        tokenHash,
+        tripTokenHash,
+        input.pushKind,
+        input.apnsStatus,
+        input.apnsReason ?? null,
+        input.apnsEnv ?? null,
+        input.envMismatchExhausted === true ? 1 : 0,
+      )
+      .run();
+  } catch (e) {
+    console.warn(JSON.stringify({ msg: 'pushFailureLog write failed', err: String(e) }));
+  }
+}
+
+export interface PushFailureReasonBucket {
+  /** `${apnsStatus}:${apnsReason ?? 'unknown'}` 형태 식별자. */
+  reason: string;
+  count: number;
+}
+
+export interface PushFailureMetrics {
+  /** 최근 24h 최종 실패 총 건수. */
+  total24h: number;
+  /** 사유별 건수 내림차순 상위 N (기본 5). */
+  topReasons: PushFailureReasonBucket[];
+}
+
+const TOP_REASONS_LIMIT = 5;
+
+/** obs-metrics 미제공/DB 미바인딩 시 사용하는 zero 기본값. */
+export const EMPTY_PUSH_FAILURE_METRICS: PushFailureMetrics = { total24h: 0, topReasons: [] };
+
+/**
+ * 최근 24h push_failures를 사유(apns_status:apns_reason)별로 집계한다.
+ *
+ * @param db - D1 binding. undefined 시 zero 기본값.
+ * @param now - 현재 epoch ms. 24h 윈도우 시작점 산출용.
+ */
+export async function computePushFailureMetrics(
+  db: D1Database | undefined,
+  now: number,
+): Promise<PushFailureMetrics> {
+  if (!db) return EMPTY_PUSH_FAILURE_METRICS;
+  try {
+    const since = now - 24 * 60 * 60 * 1000;
+    const totalResult = await db
+      .prepare('SELECT COUNT(*) AS count FROM push_failures WHERE ts >= ?')
+      .bind(since)
+      .first<{ count: number }>();
+    const total24h = totalResult?.count ?? 0;
+
+    const reasonsResult = await db
+      .prepare(
+        `SELECT apns_status AS status, apns_reason AS reason, COUNT(*) AS count
+         FROM push_failures
+         WHERE ts >= ?
+         GROUP BY apns_status, apns_reason
+         ORDER BY count DESC
+         LIMIT ?`,
+      )
+      .bind(since, TOP_REASONS_LIMIT)
+      .all<{ status: number; reason: string | null; count: number }>();
+
+    const rows = reasonsResult.results ?? [];
+    const topReasons = rows.map((row) => ({
+      reason: `${row.status}:${row.reason ?? 'unknown'}`,
+      count: row.count,
+    }));
+    return { total24h, topReasons };
+  } catch (e) {
+    console.warn(JSON.stringify({ msg: 'pushFailureLog read failed', err: String(e) }));
+    return EMPTY_PUSH_FAILURE_METRICS;
+  }
+}

--- a/backend/alarm-worker/src/pushFailureLog.ts
+++ b/backend/alarm-worker/src/pushFailureLog.ts
@@ -16,6 +16,16 @@
 import { hashTripToken } from './sentry';
 import type { ApnsEnv } from './types';
 
+/**
+ * 동일 (tokenHash, pushKind) 최종 실패 재기록 rate-limit 윈도우 (#2177 리뷰 P1).
+ *
+ * 배경: boardingPrompt/reschedule 재시도 로직 자체는 건드리지 않는다(재시도 억제=사용자 가치
+ * 손실, ADR-010 동급 보호). 대신 "기록"만 억제 — 같은 실패가 cron(1분)마다 재평가돼 매 tick
+ * insert되는 걸 막는다. D1 write quota는 귀하고 read(SELECT)는 여유가 커 write 전 SELECT
+ * 선확인 방식을 쓴다. KV는 write quota가 더 귀해 사용하지 않는다.
+ */
+const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+
 export interface PushFailureInput {
   /** APNs device token — 원본 노출 금지, FNV-1a hash만 저장. */
   token: string;
@@ -47,6 +57,14 @@ export async function logPushFailure(
   try {
     const tokenHash = hashTripToken(input.token);
     const tripTokenHash = input.tripToken !== undefined ? hashTripToken(input.tripToken) : tokenHash;
+
+    const since = Date.now() - RATE_LIMIT_WINDOW_MS;
+    const recent = await db
+      .prepare('SELECT 1 FROM push_failures WHERE token_hash = ? AND push_kind = ? AND ts >= ? LIMIT 1')
+      .bind(tokenHash, input.pushKind, since)
+      .first();
+    if (recent) return;
+
     await db
       .prepare(
         'INSERT INTO push_failures (ts, token_hash, trip_token_hash, push_kind, apns_status, apns_reason, apns_env, env_mismatch_exhausted) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',

--- a/backend/alarm-worker/src/retryPushes.ts
+++ b/backend/alarm-worker/src/retryPushes.ts
@@ -29,6 +29,7 @@ import {
 import { sendSilentPush, type ApnsConfig, type SilentPushPayload } from './apns';
 import type { ArchFlagValue } from './archFlag';
 import { assertCronCacheTtl, CRON_READ_CACHE_TTL_SEC as SHARED_CRON_TTL } from './kvConsistency';
+import { logPushFailure } from './pushFailureLog';
 import type { ApnsEnv, Env } from './types';
 
 const RETRY_PREFIX = 'retry-push:';
@@ -105,6 +106,11 @@ export function shouldRetryForKind(
  * #1995 (ADR-022 Phase 1-2) — `archFlag` 파라미터 (optional). flag=on 시 payload.kind !==
  * 'destination' 이면 no-op. 미전달 (legacy caller / retry loop 자기 재 enqueue) 시 undefined
  * 로 처리 → 기존 동작 100% 유지.
+ *
+ * #2177 — 본 함수는 거의 모든 push fire 경로(silent/alert 실패 직후) + retry loop 자기 재 enqueue
+ * (runRetryPushes)가 공유하는 "sendWithEnvHeal 결과 소비" 공통 지점이다. false를 반환하는 모든
+ * 분기(= 더는 재시도하지 않음 = 최종 실패)에서 D1 push_failures 1건을 기록한다. true 반환(재시도
+ * 예정)은 기록하지 않아 429/5xx backoff 중간 실패의 quota 소진을 막는다.
  */
 export async function enqueueRetryIfTransient(
   kv: KVNamespace | undefined,
@@ -118,15 +124,41 @@ export async function enqueueRetryIfTransient(
     now: number;
     attemptCount?: number;
     originalSentAt?: number;
+    /** #2177 — 양쪽 host 모두 BadDeviceToken이었는지 (D1 기록용, retry 판정에는 미사용). */
+    envMismatchExhausted?: boolean;
   },
   archFlag?: ArchFlagValue,
+  db?: D1Database,
 ): Promise<boolean> {
-  if (!kv) return false;
-  if (!isRetryableApnsError(input.status)) return false;
-  if (!shouldRetryForKind(archFlag, input.payload.kind)) return false;
+  const recordFinalFailure = () =>
+    logPushFailure(db, {
+      token: input.token,
+      tripToken: input.token,
+      pushKind: input.payload.kind,
+      apnsStatus: input.status,
+      apnsReason: input.reason,
+      apnsEnv: input.apnsEnv,
+      envMismatchExhausted: input.envMismatchExhausted,
+    });
+
+  if (!kv) {
+    await recordFinalFailure();
+    return false;
+  }
+  if (!isRetryableApnsError(input.status)) {
+    await recordFinalFailure();
+    return false;
+  }
+  if (!shouldRetryForKind(archFlag, input.payload.kind)) {
+    await recordFinalFailure();
+    return false;
+  }
   const attemptCount = input.attemptCount ?? 0;
   const nextAttemptAt = computeNextRetryAt(attemptCount, input.now);
-  if (nextAttemptAt === null) return false; // 영구 폐기 — caller 가 별도 cleanup
+  if (nextAttemptAt === null) {
+    await recordFinalFailure();
+    return false; // 영구 폐기 — caller 가 별도 cleanup
+  }
   const entry: RetryPush = {
     pushId: input.pushId,
     token: input.token,
@@ -265,8 +297,10 @@ export async function runRetryPushes(env: Env, deps: RetryPushDeps): Promise<Ret
         now,
         attemptCount: nextAttempt,
         originalSentAt: entry.originalSentAt,
+        envMismatchExhausted: heal.envMismatchExhausted,
       },
       deps.archFlag,
+      env.DB,
     );
     if (rescheduled) {
       stats.rescheduled += 1;

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -69,6 +69,7 @@ import {
 import { findStationCoordsByNameAndLine } from './stationsLookup';
 import { assertCronCacheTtl } from './kvConsistency';
 import { buildAlarmKey, putPending } from './pendingPushes';
+import { logPushFailure } from './pushFailureLog';
 import { enqueueRetryIfTransient } from './retryPushes';
 import { deleteProgress, getProgress, putProgress, type TripProgress } from './progress';
 import { SeoulArrivalClient, type ArrivalEntry, type PositionEntry } from './seoul';
@@ -2202,8 +2203,10 @@ async function maybeFireSleepAlarm(inputs: MaybeFireSleepAlarmInputs): Promise<v
         status: alertHeal.result.status,
         reason: alertHeal.result.reason,
         now,
+        envMismatchExhausted: alertHeal.envMismatchExhausted,
       },
       deps.archFlag,
+      env.DB,
     );
   }
   if (!companionHeal.result.ok) {
@@ -2224,8 +2227,10 @@ async function maybeFireSleepAlarm(inputs: MaybeFireSleepAlarmInputs): Promise<v
         status: companionHeal.result.status,
         reason: companionHeal.result.reason,
         now,
+        envMismatchExhausted: companionHeal.envMismatchExhausted,
       },
       deps.archFlag,
+      env.DB,
     );
   }
 }
@@ -2446,8 +2451,10 @@ export async function fireArvlCdStationPush(
         status: heal.result.status,
         reason: heal.result.reason,
         now,
+        envMismatchExhausted: heal.envMismatchExhausted,
       },
       deps.archFlag,
+      env.DB,
     );
     // dedup KV는 성공 시에만 stamp — 실패 push는 다음 cycle 재시도 허용.
     return { dirty };
@@ -2833,8 +2840,10 @@ export async function fireVanishFallbackStationPush(
         status: heal.result.status,
         reason: heal.result.reason,
         now,
+        envMismatchExhausted: heal.envMismatchExhausted,
       },
       deps.archFlag,
+      env.DB,
     );
     // dedup KV는 성공 시에만 stamp — 실패 push는 다음 cycle 재시도 허용.
     return;
@@ -2995,6 +3004,16 @@ async function fireTrainReconfirmPush(
         token: trip.token.slice(0, 8),
         status: heal.result.status,
         pushReason: heal.result.reason,
+      });
+      // #2177 — retry queue를 타지 않는 fire-and-forget 경로(다음 cycle 자연 재시도) — 직접 기록.
+      await logPushFailure(env.DB, {
+        token: trip.token,
+        tripToken: trip.token,
+        pushKind: payload.kind,
+        apnsStatus: heal.result.status,
+        apnsReason: heal.result.reason,
+        apnsEnv: trip.apnsEnv,
+        envMismatchExhausted: heal.envMismatchExhausted,
       });
       return;
     }
@@ -3700,8 +3719,10 @@ export async function advanceBoardingLockWaypoint(
           status: transferHeal.result.status,
           reason: transferHeal.result.reason,
           now,
+          envMismatchExhausted: transferHeal.envMismatchExhausted,
         },
         deps.archFlag,
+        env.DB,
       );
     }
   }
@@ -3718,6 +3739,7 @@ export async function advanceBoardingLockWaypoint(
       now,
       log,
       generatePushId: () => crypto.randomUUID(),
+      env,
     });
   }
   // #2066 (Phase 2-backend) — 이전엔 #2036이 여기서(환승 waypoint 소진 시점) 직접
@@ -3943,6 +3965,16 @@ export async function maybeReschedulePush(
       status: result.status,
       reason: result.reason,
       token: trip.token.slice(0, 8),
+    });
+    // #2177 — reschedule push는 retry queue를 타지 않는 fire-and-forget 경로 — 직접 기록.
+    await logPushFailure(env.DB, {
+      token: trip.token,
+      tripToken: trip.token,
+      pushKind: 'reschedule',
+      apnsStatus: result.status,
+      apnsReason: result.reason,
+      apnsEnv: trip.apnsEnv,
+      envMismatchExhausted,
     });
     if (isUnrecoverableApnsError(result.status, result.reason) || envMismatchExhausted) {
       // #586 D — trip이 unrecoverable로 폐기되는 경로에서도 LA가 살아있으면 dismissal로 정리.
@@ -4171,6 +4203,17 @@ export async function runLocklessIntermediate(
         isUnrecoverableApnsError(heal.result.status, heal.result.reason) ||
         heal.envMismatchExhausted
       ) {
+        // #2177 — unrecoverable(410/mismatch exhausted)로 cleanup 분기하는 경로는 retry queue를
+        // 타지 않아 enqueueRetryIfTransient의 공통 D1 기록 지점을 지나지 않는다 — 직접 기록.
+        await logPushFailure(env.DB, {
+          token: trip.token,
+          tripToken: trip.token,
+          pushKind: locklessPayload.kind,
+          apnsStatus: heal.result.status,
+          apnsReason: heal.result.reason,
+          apnsEnv: trip.apnsEnv,
+          envMismatchExhausted: heal.envMismatchExhausted,
+        });
         // #868 — lockless push unrecoverable로 trip 폐기 시에도 클라 state sync push 발사.
         await cleanupTripWithLa(trip, env, deps, stats, now, log, 'push-unrecoverable');
         return;
@@ -4189,8 +4232,10 @@ export async function runLocklessIntermediate(
           status: heal.result.status,
           reason: heal.result.reason,
           now,
+          envMismatchExhausted: heal.envMismatchExhausted,
         },
         deps.archFlag,
+        env.DB,
       );
       if (dirty) await putTrip(env.TRIPS, trip);
       return;
@@ -4840,6 +4885,17 @@ export async function evaluateAndMaybeFireBoardingPrompt(
       status: heal.result.status,
       reason: heal.result.reason,
     });
+    // #2177 — boarding-prompt push는 retry queue를 타지 않는 fire-and-forget 경로 — 직접 기록.
+    // 08-06 RCA의 원 동기(push-unrecoverable 정확한 코드 확인) — 최우선 대상 push kind.
+    await logPushFailure(env.DB, {
+      token: trip.token,
+      tripToken: trip.token,
+      pushKind: 'boarding-prompt',
+      apnsStatus: heal.result.status,
+      apnsReason: heal.result.reason,
+      apnsEnv: trip.apnsEnv,
+      envMismatchExhausted: heal.envMismatchExhausted,
+    });
   }
 
   // #2069 (Phase 3) — boarding-prompt silent push fallback(B8, #2037) 제거. visible alert push
@@ -4877,8 +4933,10 @@ export async function maybeFireHopEndPrompt(inputs: {
   now: number;
   log: Logger;
   generatePushId: () => string;
+  /** #2177 — push 최종 실패 D1 기록용. */
+  env: Env;
 }): Promise<void> {
-  const { trip, transferWaypoint, deps, stats, now, log, generatePushId } = inputs;
+  const { trip, transferWaypoint, deps, stats, now, log, generatePushId, env } = inputs;
   const nextWaypoint = trip.waypoints[0];
   const nextLine = nextWaypoint?.line ?? null;
   const nextStation = nextWaypoint?.stationName ?? null;
@@ -4954,6 +5012,16 @@ export async function maybeFireHopEndPrompt(inputs: {
       legKey,
       status: heal.result.status,
       reason: heal.result.reason,
+    });
+    // #2177 — hop-end-prompt push는 retry queue를 타지 않는 fire-and-forget 경로 — 직접 기록.
+    await logPushFailure(env.DB, {
+      token: trip.token,
+      tripToken: trip.token,
+      pushKind: 'hop-end-prompt',
+      apnsStatus: heal.result.status,
+      apnsReason: heal.result.reason,
+      apnsEnv: trip.apnsEnv,
+      envMismatchExhausted: heal.envMismatchExhausted,
     });
   }
 }


### PR DESCRIPTION
Closes #2177

## 배경
08-06 RCA에서 push-unrecoverable의 정확한 APNs 코드(410 vs 400)를 끝내 확증 못 함: push 실패가 console에만 남고 D1 미기록. backend_errors 오늘 0건. wrangler tail 실시간 외 사후 진단 수단 부재.

## 변경
- `migrations/0002_push_failures.sql` — `push_failures` 테이블 신설. `backend_errors`(#1835)는 endpoint/error_type/context(JSON) 구조라 apnsStatus/apnsReason별 GROUP BY 집계(오브스-메트릭 top 사유)가 매 쿼리 json_extract를 요구해 부적합 — 구조화 컬럼(token_hash/trip_token_hash/push_kind/apns_status/apns_reason/apns_env/env_mismatch_exhausted)을 가진 신규 테이블로 분리.
- `src/pushFailureLog.ts` — `logPushFailure`(write, graceful no-op) + `computePushFailureMetrics`(24h total + 사유 top5 read).
- `src/retryPushes.ts` — `enqueueRetryIfTransient`을 "sendWithEnvHeal 결과 소비" 공통 지점으로 삼아, false 반환(=더는 재시도 없음=최종 실패) 시점에만 D1 기록. true 반환(재시도 예정)은 미기록 — 429/5xx transient 중간 실패로 인한 D1 quota 소진을 막는다. 이 함수는 sleep-alarm(alert/companion)·arvlcd-fire·vanish-fallback·transfer-release·lockless-intermediate·retry-loop 자기 재enqueue까지 6개 이상 호출부가 공유.
- `src/scheduled.ts` — retry queue를 타지 않는 fire-and-forget 경로(reschedule / train-reconfirm / boarding-prompt / hop-end-prompt / lockless-unrecoverable)는 실패 지점에서 직접 기록. `maybeFireHopEndPrompt`에 `env` 파라미터 추가(D1 접근용).
- `src/liveActivity.ts` — trip-ended push 실패 직접 기록.
- `src/fallback.ts` — alert fallback 영구 실패(unrecoverable) 판정 시점만 기록. transient는 KV TTL 자연 정리에 맡겨 quota 보호.
- `src/observabilityMetrics.ts`, `src/index.ts` — obs-metrics 응답에 `pushFailures`(24h total + 사유 top5) 필드 추가.
- `src/__tests__/pushFailureLog.test.ts` — 신규 단위 테스트 12건 (write/read, graceful no-op, tripToken fallback, envMismatchExhausted 저장, 실패 swallow).

## 금지사항 준수
- persist=true 전환 미포함 (D1 기록으로 대체, #2055 결정 존중).
- push 발사 로직 자체는 변경하지 않음 — 실패 branch에 기록 호출만 추가.
- `trips.ts`는 동시 작업 중인 다른 에이전트 영역이라 건드리지 않음.

## Wire-completion 5단
1. **Orphan 없음** — 루트 `npm run lint:orphan` pass(`No orphan exports detected.`). 루트 tsconfig가 `backend`를 exclude하므로 이 신규 export들은 스캔 대상이 아니지만, 모든 export(`logPushFailure`/`computePushFailureMetrics`/타입들)는 코드 내 실제 caller가 있음(orphan 아님) 확인.
2. **V/X dashboard** — `wrangler d1 execute subway-now-db --command "SELECT push_kind, apns_status, apns_reason, COUNT(*) FROM push_failures GROUP BY 1,2,3"` 로 직접 SELECT 가능. `GET /v1/observability/metrics` 응답의 `pushFailures.total24h` / `pushFailures.topReasons`로도 노출.
3. **의존 PR** — 없음(병행 가능). D1 마이그레이션 `wrangler d1 migrations apply subway-now-db --remote` 적용 + deploy 필수.
4. **측정 plan** — 다음 실탑승에서 push 실패(특히 boarding-prompt/lockless 계열) 발생 시 D1 SELECT로 apnsStatus(400 vs 410)/apnsReason 사후 확정 가능. 1주 관측 후 `push_failures` 건수/사유 분포로 RCA 재개.
5. **Device verify** — N/A — type+unit only (backend 코드, device 변경 없음).

## 검증
- `npm run type-check` — pass
- `npm test` — 74 test files / 2827 tests all pass. Coverage 96.89%/95.9x%대로 `vitest.config.ts` 설정 threshold(97%/96%)를 근소하게 미달하나, 이는 **본 PR 이전(origin/dev HEAD)부터 이미 존재하는 pre-existing gap**(rebase 전 baseline 실측 96.48%/95.98%) — 본 diff는 신규 코드 전용 단위 테스트 12건을 추가해 오히려 커버리지를 개선함(96.48%→96.89%, branch 95.98%→96.2x%). scheduled.ts의 미커버 라인들은 diff 전후로 라인 번호만 시프트된 동일한 기존 미커버 블록(직접 대조 확인)이며 본 PR이 새로 만든 gap이 아님.
- `npm run lint:orphan` (repo root) — pass