### PR TITLE
fix: [P1-A] Trip.deviceToken 필드 분리 — push 발사는 실 APNs 토큰, trip.token은 신원 전용

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -4449,10 +4449,11 @@ describe('POST /trips — #2019 rotateTripTokenForNewRoute wire (ADR-022 B4)', (
       expect(await env.TRIPS.get(`trip:${TOKEN}`)).not.toBeNull();
     });
 
-    it('#2173 guard — existing + 다른 destination: rotation 단락으로 응답 token 유지 + trip:<TOKEN> 보존', async () => {
-      // #2173 P0 hotfix — TOKEN_ROTATION_DISABLED guard가 flag ON이어도 rotation을 단락시킨다.
-      // guard 적용 전에는 이 경로가 crypto.randomUUID() 를 APNs deviceToken 자리에 저장해
-      // 400 BadDeviceToken 즉사를 유발했다 (Epic #2172).
+    it('#2174 P1-A — existing + 다른 destination: rotation 발동으로 응답에 새 UUID token + old trip:<TOKEN> 삭제', async () => {
+      // #2173 P0 hotfix가 guard로 이 경로를 단락시켰던 이유(crypto.randomUUID() 가 APNs
+      // deviceToken 자리에 저장돼 400 BadDeviceToken 즉사, Epic #2172)는 #2174의
+      // `Trip.deviceToken` 필드 분리로 해소됐다 — 모든 push 발사 사이트가 `resolveTripDeviceToken`
+      // 을 사용하므로 trip.token(신원) 로테이션이 더 이상 push 발사 주소에 영향을 주지 않는다.
       const env = makeKvEnv();
       await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
       await seedExistingTrip(env, '용마산-id', '용마산');
@@ -4460,16 +4461,17 @@ describe('POST /trips — #2019 rotateTripTokenForNewRoute wire (ADR-022 B4)', (
       expect(res.status).toBe(200);
       const body = (await res.json()) as { ok: true; token: string; confirmedEnv: string };
       expect(body.ok).toBe(true);
-      // guard 로 인해 응답 token 은 incoming token 그대로 (rotation 미발동).
-      expect(body.token).toBe(TOKEN);
-      // 기존 KV entry 도 보존 — 같은 key 에 새 destination 으로 덮어씀.
-      const stored = await env.TRIPS.get(`trip:${TOKEN}`);
+      // rotation 발동 — 응답 token은 새 UUID (incoming token과 다름).
+      expect(body.token).not.toBe(TOKEN);
+      expect(body.token).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+      // old trip:<TOKEN> 은 삭제되고 새 trip:<newToken> 이 생성된다.
+      expect(await env.TRIPS.get(`trip:${TOKEN}`)).toBeNull();
+      const stored = await env.TRIPS.get(`trip:${body.token}`);
       expect(stored).not.toBeNull();
       expect(JSON.parse(stored as string).destination).toBe('성수-id');
     });
 
-    it('#2173 guard — 이전 trip pending push 잔재 존재 상태에서 새 route 등록: cleanup도 미발동', async () => {
-      // guard가 rotation 자체를 단락하므로 `cleanupPendingPushesForToken` 도 호출되지 않는다.
+    it('#2174 P1-A — 이전 trip pending push 잔재 존재 상태에서 새 route 등록: old token 소유 cleanup 발동', async () => {
       const env = makeKvEnv();
       await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
       await seedExistingTrip(env, '용마산-id', '용마산');
@@ -4480,13 +4482,13 @@ describe('POST /trips — #2019 rotateTripTokenForNewRoute wire (ADR-022 B4)', (
       const res = await post('/trips', tripBodyFor('성수-id', '성수'), env);
       expect(res.status).toBe(200);
 
-      // rotation 단락 → pending 잔재도 그대로.
-      expect(await env.TRIPS.get('pending:p-old-1')).not.toBeNull();
-      expect(await env.TRIPS.get('pending:p-old-2')).not.toBeNull();
+      // rotation 발동 → old token 소유 pending은 cleanup, 다른 device 소유는 보존.
+      expect(await env.TRIPS.get('pending:p-old-1')).toBeNull();
+      expect(await env.TRIPS.get('pending:p-old-2')).toBeNull();
       expect(await env.TRIPS.get('pending:p-other-device')).not.toBeNull();
     });
 
-    it('#2173 guard — archFlag=on 이어도 guard가 우선하여 회전 미발동 (읽기 지점 검증)', async () => {
+    it('#2174 P1-A — archFlag off→on 전환 시 두 번째 등록만 rotation 발동', async () => {
       const env = makeKvEnv();
       await seedExistingTrip(env, '용마산-id', '용마산');
       // Round 1: flag 미설정 → default off → 회전 없음.
@@ -4497,10 +4499,35 @@ describe('POST /trips — #2019 rotateTripTokenForNewRoute wire (ADR-022 B4)', (
       // Reset: 새 existing 을 다시 seed 하고 flag on.
       await seedExistingTrip(env, '용마산-id', '용마산');
       await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
-      // Round 2: flag on 이어도 guard가 단락 → token 동일.
+      // Round 2: flag on → rotation 발동 → token 변경.
       const res2 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
       const body2 = (await res2.json()) as { token: string };
-      expect(body2.token).toBe(TOKEN);
+      expect(body2.token).not.toBe(TOKEN);
+    });
+
+    // #2174 F2 — old trip 로테이션 시 D1 기록 + tripStatus sentinel(reason='rotated')이 남는다.
+    it('#2174 F2 — rotation 발동 시 old token으로 GET /trips/:token/status 가 ended(rotated)를 반환한다', async () => {
+      const env = makeKvEnv();
+      await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
+      await seedExistingTrip(env, '용마산-id', '용마산');
+      const res = await post('/trips', tripBodyFor('성수-id', '성수'), env);
+      expect(res.status).toBe(200);
+
+      // #2174 comment 1 — device는 로테이션 이후에도 실 deviceToken(=최초 등록 시 TOKEN)으로
+      // GET /trips/:token/status를 조회한다. old trip이 UUID로 로테이션되며 사라졌어도
+      // sentinel이 'rotated'로 사망 인지를 가능케 한다(첫 로테이션 한정 — #2175로 완전한
+      // deviceToken 역인덱스 조회는 위임).
+      const statusRes = await app.fetch(
+        new Request(`http://example.com/trips/${TOKEN}/status`, { method: 'GET' }),
+        env,
+      );
+      expect(statusRes.status).toBe(200);
+      const statusBody = (await statusRes.json()) as {
+        status: string;
+        endReason: string | null;
+      };
+      expect(statusBody.status).toBe('ended');
+      expect(statusBody.endReason).toBe('rotated');
     });
 
     // #2129 — 2026-08-04 실탑승 evidence: 같은 device token으로 거의 동시에 도착한

--- a/backend/alarm-worker/src/__tests__/trips.test.ts
+++ b/backend/alarm-worker/src/__tests__/trips.test.ts
@@ -9,11 +9,13 @@ import {
   getTrip,
   listTrips,
   putTrip,
+  resolveTripDeviceToken,
   rotateTripTokenForNewRoute,
   tripKey,
   withTripRegisterLock,
 } from '../trips';
 import { pendingKey, putPending, type PendingPush } from '../pendingPushes';
+import { readTripEndedStatus } from '../tripStatus';
 import type { Trip } from '../types';
 import { InMemoryKV } from './inMemoryKv';
 
@@ -38,6 +40,32 @@ describe('trips KV CRUD', () => {
 
   it('tripKey builds prefix', () => {
     expect(tripKey('abc')).toBe('trip:abc');
+  });
+
+  // #2174 (P1-A) — push 발사용 실 deviceToken 단일 해석 지점.
+  describe('resolveTripDeviceToken (#2174)', () => {
+    it('deviceToken이 유효한 64-hex면 그대로 반환', () => {
+      const hex64 = 'a'.repeat(64);
+      const trip = makeTrip({ token: 'uuid-after-rotation', deviceToken: hex64 });
+      expect(resolveTripDeviceToken(trip)).toBe(hex64);
+    });
+
+    it('deviceToken 부재(legacy KV 레코드) + token이 64-hex면 token으로 fallback', () => {
+      const hex64 = 'b'.repeat(64);
+      const trip = makeTrip({ token: hex64, deviceToken: undefined });
+      expect(resolveTripDeviceToken(trip)).toBe(hex64);
+    });
+
+    it('deviceToken 부재 + token도 64-hex 아님(로테이션된 UUID legacy 레코드)이면 token을 그대로 반환 (기존 무효 상태 유지, 새 회귀 없음)', () => {
+      const trip = makeTrip({ token: 'not-a-hex-token-uuid', deviceToken: undefined });
+      expect(resolveTripDeviceToken(trip)).toBe('not-a-hex-token-uuid');
+    });
+
+    it('deviceToken이 64-hex 아닌 값이면(손상 데이터) token으로 fallback', () => {
+      const hex64 = 'c'.repeat(64);
+      const trip = makeTrip({ token: hex64, deviceToken: 'malformed' });
+      expect(resolveTripDeviceToken(trip)).toBe(hex64);
+    });
   });
 
   it('put + get round-trip', async () => {
@@ -407,7 +435,23 @@ describe('trips KV CRUD', () => {
       });
     });
 
-    describe('rotateTripTokenForNewRoute (flag ON, #2173 TOKEN_ROTATION_DISABLED guard가 단락)', () => {
+    describe('rotateTripTokenForNewRoute (flag ON, #2174 P1-A — TOKEN_ROTATION_DISABLED guard 해제로 rotation 재활성)', () => {
+      it('deps.rotationDisabled: true 명시 override — emergency 재차단 경로 보존 (coverage)', async () => {
+        // #2174가 production 상수(TOKEN_ROTATION_DISABLED)를 false로 되돌렸지만, #2173이
+        // 도입한 emergency override 자체는 삭제하지 않는다 — 재발 시 즉시 재차단 가능해야 한다.
+        const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
+        await putTrip(kv as unknown as KVNamespace, existing);
+        const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
+        const result = await rotateTripTokenForNewRoute(
+          kv as unknown as KVNamespace,
+          incoming,
+          existing,
+          { simpleArchEnabled: true, rotationDisabled: true, generateToken: () => 'new-uuid' },
+        );
+        expect(result).toEqual({ token: 'tok-old', rotated: false });
+        expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).not.toBeNull();
+      });
+
       it('existing 없음 (신규 trip): incoming 그대로 (rotated=false)', async () => {
         const incoming = makeTrip({ token: 'tok-new' });
         const result = await rotateTripTokenForNewRoute(
@@ -442,13 +486,13 @@ describe('trips KV CRUD', () => {
         expect(await getTrip(kv as unknown as KVNamespace, 'tok-same')).not.toBeNull();
       });
 
-      it('#2173 guard — 다른 destination: rotation 단락으로 incoming token 유지, old KV 보존', async () => {
-        // Guard 적용 전(회귀) 재현: 이 경로가 crypto.randomUUID() 로 trip.token을 교체해
-        // 이후 push가 UUID를 APNs deviceToken으로 사용 → 400 BadDeviceToken 즉사 (Epic #2172).
-        // TOKEN_ROTATION_DISABLED guard가 flag ON이어도 rotation을 단락시켜 incoming token을 유지한다.
-        const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
+      it('#2174 — 다른 destination: rotation 발동 (새 token 발급 + old trip:<token> delete)', async () => {
+        // #2173 P0 hotfix가 이 경로를 guard로 단락시켰던 이유(push가 UUID를 APNs deviceToken으로
+        // 사용해 400 BadDeviceToken 즉사, Epic #2172)는 #2174가 `Trip.deviceToken` 필드 분리 +
+        // 모든 push 발사 사이트의 `resolveTripDeviceToken(trip)` 전환으로 해소했다 — guard 해제.
+        const existing = makeTrip({ token: 'tok-old', deviceToken: 'a'.repeat(64), destination: 'D-1' });
         await putTrip(kv as unknown as KVNamespace, existing);
-        const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
+        const incoming = makeTrip({ token: 'tok-old', deviceToken: 'a'.repeat(64), destination: 'D-2' });
         const result = await rotateTripTokenForNewRoute(
           kv as unknown as KVNamespace,
           incoming,
@@ -458,12 +502,11 @@ describe('trips KV CRUD', () => {
             generateToken: () => 'new-uuid',
           },
         );
-        expect(result).toEqual({ token: 'tok-old', rotated: false });
-        // guard로 rotation 자체가 단락되므로 old KV entry cleanup도 발생하지 않는다.
-        expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).not.toBeNull();
+        expect(result).toEqual({ token: 'new-uuid', rotated: true });
+        expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).toBeNull();
       });
 
-      it('#2173 guard — 다른 waypoints (같은 destination): rotation 단락 (rotated=false)', async () => {
+      it('#2174 — 다른 waypoints (같은 destination): rotation 발동 (rotated=true)', async () => {
         const existing = makeTrip({
           token: 'tok-old',
           destination: 'D-1',
@@ -487,11 +530,11 @@ describe('trips KV CRUD', () => {
             generateToken: () => 'new-token-xyz',
           },
         );
-        expect(result.rotated).toBe(false);
-        expect(result.token).toBe('tok-old');
+        expect(result.rotated).toBe(true);
+        expect(result.token).toBe('new-token-xyz');
       });
 
-      it('#2173 guard — 다른 route: pending push cleanup도 미발생 (rotation 단락)', async () => {
+      it('#2174 — 다른 route: old token 소유 pending push cleanup (다른 token 소유는 보존)', async () => {
         const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
         await putTrip(kv as unknown as KVNamespace, existing);
         await putPending(
@@ -518,13 +561,12 @@ describe('trips KV CRUD', () => {
           },
         );
 
-        // rotation이 단락되므로 old token 소유 pending push도 건드리지 않는다.
-        expect(await kv.get(pendingKey('p-old-1'))).not.toBeNull();
-        expect(await kv.get(pendingKey('p-old-2'))).not.toBeNull();
+        expect(await kv.get(pendingKey('p-old-1'))).toBeNull();
+        expect(await kv.get(pendingKey('p-old-2'))).toBeNull();
         expect(await kv.get(pendingKey('p-other'))).not.toBeNull();
       });
 
-      it('#2173 guard — generateToken 미지정이어도 crypto.randomUUID 호출되지 않음', async () => {
+      it('#2174 — generateToken 미지정: crypto.randomUUID로 새 token 생성 (default)', async () => {
         const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
         await putTrip(kv as unknown as KVNamespace, existing);
         const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
@@ -535,13 +577,12 @@ describe('trips KV CRUD', () => {
           existing,
           { simpleArchEnabled: true },
         );
-        expect(spy).not.toHaveBeenCalled();
-        expect(result).toEqual({ token: 'tok-old', rotated: false });
+        expect(spy).toHaveBeenCalledOnce();
+        expect(result.rotated).toBe(true);
         spy.mockRestore();
       });
 
-      it('#2002/#2173 — deps 미지정 + KV `arch:simple-arrival-v1`=on 이어도 guard가 우선 → rotation 없음', async () => {
-        // #2002 — real helper `getArchFlag(kv)` wire. #2173 — guard가 flag 판정보다 먼저 단락.
+      it('#2002 — deps.simpleArchEnabled 미지정 + KV `arch:simple-arrival-v1`=on: getArchFlag fallback으로 rotation 발동', async () => {
         await kv.put(ARCH_FLAG_KV_KEY, 'on');
         const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
         await putTrip(kv as unknown as KVNamespace, existing);
@@ -552,15 +593,123 @@ describe('trips KV CRUD', () => {
           existing,
           { generateToken: () => 'new-token-from-kv-flag' },
         );
-        expect(result).toEqual({ token: 'tok-old', rotated: false });
-        expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).not.toBeNull();
+        expect(result).toEqual({ token: 'new-token-from-kv-flag', rotated: true });
+        expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).toBeNull();
+      });
+
+      // #2174 F1 — 로테이션은 등록 시점 한정이 아니라 mid-trip route 변경(환승 waypoint trim
+      // 재-POST, 목적지 변경 등) 재-POST에서도 발동한다. 이 red 시나리오는 "실토큰 trip 활성 중
+      // route 변경 재-POST → 로테이션 → deviceToken이 여전히 실토큰"을 보장한다.
+      it('#2174 F1 — mid-trip route 변경 재-POST 로테이션 시에도 새 trip의 deviceToken은 실토큰 그대로', async () => {
+        const realDeviceToken = 'b'.repeat(64);
+        const existing = makeTrip({
+          token: realDeviceToken,
+          deviceToken: realDeviceToken,
+          destination: 'D-1',
+          waypoints: [{ stationName: 'A', line: '2', kind: 'destination' }],
+        });
+        await putTrip(kv as unknown as KVNamespace, existing);
+        // 환승 후 waypoint trim + 새 목적지로 재-POST — deviceToken은 client가 매번 실 토큰을 보낸다.
+        const incoming = makeTrip({
+          token: realDeviceToken,
+          deviceToken: realDeviceToken,
+          destination: 'D-2',
+          waypoints: [{ stationName: 'C', line: '7', kind: 'destination' }],
+        });
+        const result = await rotateTripTokenForNewRoute(
+          kv as unknown as KVNamespace,
+          incoming,
+          existing,
+          { simpleArchEnabled: true, generateToken: () => 'rotated-uuid' },
+        );
+        expect(result).toEqual({ token: 'rotated-uuid', rotated: true });
+        // 로테이션은 trip.token(신원)만 교체 — incoming.deviceToken은 rotation 결과와 무관하게
+        // 실토큰 그대로 보존된다(index.ts가 baseTrip = {...incoming, ...}으로 그대로 carry).
+        expect(incoming.deviceToken).toBe(realDeviceToken);
+      });
+
+      // #2174 F2 — old trip 삭제가 관측 blind hole이었다. 로테이션 시 old trip에 D1 기록 +
+      // tripStatus sentinel(reason='rotated')을 남겨야 한다.
+      describe('#2174 F2 — old trip 로테이션 관측 기록 (D1 + tripStatus sentinel)', () => {
+        it('rotation 시 old trip token으로 tripStatus sentinel이 reason=rotated로 기록된다', async () => {
+          const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
+          await putTrip(kv as unknown as KVNamespace, existing);
+          const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
+          const now = 1_700_000_000_000;
+          await rotateTripTokenForNewRoute(
+            kv as unknown as KVNamespace,
+            incoming,
+            existing,
+            { simpleArchEnabled: true, generateToken: () => 'new-uuid', now },
+          );
+          const sentinel = await readTripEndedStatus(kv as unknown as KVNamespace, 'tok-old');
+          expect(sentinel).toEqual({ endedAt: now, endReason: 'rotated' });
+        });
+
+        it('rotation 시 D1 binding 이 있으면 recordTripMetrics 가 old trip 기준으로 호출된다', async () => {
+          const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
+          await putTrip(kv as unknown as KVNamespace, existing);
+          const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
+          const run = vi.fn().mockResolvedValue(undefined);
+          const bind = vi.fn().mockReturnValue({ run });
+          const prepare = vi.fn().mockReturnValue({ bind });
+          const db = { prepare } as unknown as D1Database;
+          await rotateTripTokenForNewRoute(
+            kv as unknown as KVNamespace,
+            incoming,
+            existing,
+            { simpleArchEnabled: true, generateToken: () => 'new-uuid', db, now: 1_700_000_000_000 },
+          );
+          expect(prepare).toHaveBeenCalled();
+          // end_reason 인자(4번째 bind 인자, 0-based idx 3)가 'rotated' — SQL 컬럼 순서(d1TripMetrics.ts) 참고.
+          expect(bind).toHaveBeenCalledOnce();
+          expect(bind.mock.calls[0][3]).toBe('rotated');
+        });
+
+        it('db 미지정 시 recordTripMetrics no-op이어도 rotation 자체는 정상 완료', async () => {
+          const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
+          await putTrip(kv as unknown as KVNamespace, existing);
+          const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
+          const result = await rotateTripTokenForNewRoute(
+            kv as unknown as KVNamespace,
+            incoming,
+            existing,
+            { simpleArchEnabled: true, generateToken: () => 'new-uuid' },
+          );
+          expect(result).toEqual({ token: 'new-uuid', rotated: true });
+        });
+
+        it('tripStatus sentinel 기록(KV put) 실패해도 rotation 자체는 정상 완료 (best-effort)', async () => {
+          const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
+          await putTrip(kv as unknown as KVNamespace, existing);
+          const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
+          const failingKv = {
+            ...kv,
+            put: vi.fn(async (key: string, value: string, options?: unknown) => {
+              if (key.startsWith('tripStatus:')) throw new Error('KV put failed');
+              return kv.put(key, value, options as { expirationTtl?: number } | undefined);
+            }),
+            get: kv.get.bind(kv),
+            delete: kv.delete.bind(kv),
+            list: kv.list.bind(kv),
+          };
+          const result = await rotateTripTokenForNewRoute(
+            failingKv as unknown as KVNamespace,
+            incoming,
+            existing,
+            { simpleArchEnabled: true, generateToken: () => 'new-uuid' },
+          );
+          expect(result).toEqual({ token: 'new-uuid', rotated: true });
+          // rotation은 sentinel 기록 실패와 무관하게 old trip을 정상 삭제한다.
+          expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).toBeNull();
+        });
       });
     });
 
-    describe('#2173 — 보존된 rotation 로직 (deps.rotationDisabled:false, #P1-A 재활성 대비 coverage)', () => {
-      // #2173 스펙: "로테이션 로직 자체는 삭제하지 않음(#P1-A에서 구조 수리 후 재활성)".
-      // production 호출부(`POST /trips`)는 이 deps를 절대 지정하지 않는다 — TOKEN_ROTATION_DISABLED
-      // 상수가 항상 우선한다. 아래는 guard를 우회한 underlying 로직 자체의 동작 검증(+coverage 보존)이다.
+    describe('#2174 P1-A — deps.rotationDisabled:false 명시 override (기존 default와 동치, 명시적 coverage 보존)', () => {
+      // #2173 스펙 잔재: "로테이션 로직 자체는 삭제하지 않음(#P1-A에서 구조 수리 후 재활성)".
+      // #2174가 TOKEN_ROTATION_DISABLED 상수를 false로 되돌려 이 override는 이제 default와
+      // 동치이지만, 테스트가 deps DI 경로 자체를 명시적으로 계속 검증하도록 보존한다.
       it('flag OFF (KV 미설정 default) + rotationDisabled:false: flagEnabled=false 분기로 incoming 그대로', async () => {
         // 리뷰 P2 — flagEnabled false 분기(line 235-236)는 guard(TOKEN_ROTATION_DISABLED)가 먼저
         // return하는 기존 '#2173 guard' 스위트에서는 도달 불가. rotationDisabled:false로 guard를

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -741,6 +741,9 @@ app.post('/trips', async (c) => {
         c.env.TRIPS,
         incoming,
         rawExisting,
+        // #2174 F2 — old trip 로테이션 관측 기록(D1 + tripStatus sentinel, reason='rotated').
+        // env.DB 미바인딩 시 recordTripMetrics 내부에서 graceful no-op.
+        { db: c.env.DB, now: Date.now() },
       );
       if (rotation.rotated) {
         console.log(
@@ -2315,6 +2318,10 @@ export function validateTrip(input: unknown): Trip | null {
 
   return {
     token: tokenRaw,
+    // #2174 — 등록 시점의 실 device token을 rotation-불변 필드로 고정. `incoming.token`은
+    // 이후 `rotateTripTokenForNewRoute`가 rotated=true 시 UUID로 덮어쓰지만, 이 필드는
+    // baseTrip이 `...incoming` spread로 그대로 carry한다 (POST /trips 핸들러 참고).
+    deviceToken: tokenRaw,
     route: obj.route as Trip['route'],
     destination: obj.destination as string,
     waypoints: stampedWaypoints,

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -24,7 +24,7 @@ import { LINE_META } from './lineAlias';
 import { deleteProgress } from './progress';
 import { computeMultiHopContext } from './tripMultiHop';
 import { deleteSsot } from './tripPositionSsot';
-import { deleteTrip } from './trips';
+import { deleteTrip, resolveTripDeviceToken } from './trips';
 import type { ApnsEnv, Env, Trip, TripEndedReason, Waypoint } from './types';
 import { writeTripEndedStatus } from './tripStatus';
 
@@ -373,7 +373,8 @@ async function fireTripEndedAlertPush(
     const heal = await sendWithEnvHeal(
       (host) =>
         sendTripEndedAlertPush({
-          deviceToken: trip.token,
+          // #2174 — 로테이션 이후에도 실 토큰 발사를 보장. trip.token은 신원 전용(로테이션 시 UUID로 교체).
+          deviceToken: resolveTripDeviceToken(trip),
           pushId,
           reason: externalReason,
           sentAt: now,

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -79,7 +79,7 @@ import {
   readFreshSelfPollPosition,
 } from './selfPollPosition';
 import { phaseAllowsImminentFiring, runStationPhaseStep } from './stationPhase';
-import { listTrips, putTrip } from './trips';
+import { listTrips, putTrip, resolveTripDeviceToken } from './trips';
 import {
   evaluateTransferDestinationGate,
   isTransferOrDestination,
@@ -2121,7 +2121,8 @@ async function maybeFireSleepAlarm(inputs: MaybeFireSleepAlarmInputs): Promise<v
   const alertHeal = await sendWithEnvHeal(
     (host) =>
       sendAlertPush({
-        deviceToken: trip.token,
+        // #2174 — 로테이션 이후에도 실 토큰 발사를 보장. trip.token은 신원 전용(로테이션 시 UUID로 교체).
+        deviceToken: resolveTripDeviceToken(trip),
         title: content.title,
         body: content.body,
         pushId: alertPushId,
@@ -2148,7 +2149,8 @@ async function maybeFireSleepAlarm(inputs: MaybeFireSleepAlarmInputs): Promise<v
   const companionHeal = await sendWithEnvHeal(
     (host) =>
       sendSleepAlarmCompanionPush({
-        deviceToken: trip.token,
+        // #2174 — 로테이션 이후에도 실 토큰 발사를 보장. trip.token은 신원 전용(로테이션 시 UUID로 교체).
+        deviceToken: resolveTripDeviceToken(trip),
         pushId: companionPushId,
         originStation: waypoint.stationName,
         targetKind,
@@ -2196,7 +2198,8 @@ async function maybeFireSleepAlarm(inputs: MaybeFireSleepAlarmInputs): Promise<v
       env.PENDING_PUSHES,
       {
         pushId: alertPushId,
-        token: trip.token,
+        // #2174 — pending/retry queue entry의 token은 APNs 재발사 주소. deviceToken 사용.
+        token: resolveTripDeviceToken(trip),
         payload: buildSleepAlarmRetryPayload(alertPushId, target, targetKind, trip.token, now),
         apnsEnv: alertHeal.correctedEnv ?? trip.apnsEnv ?? 'sandbox',
         status: alertHeal.result.status,
@@ -2218,7 +2221,8 @@ async function maybeFireSleepAlarm(inputs: MaybeFireSleepAlarmInputs): Promise<v
       env.PENDING_PUSHES,
       {
         pushId: companionPushId,
-        token: trip.token,
+        // #2174 — pending/retry queue entry의 token은 APNs 재발사 주소. deviceToken 사용.
+        token: resolveTripDeviceToken(trip),
         payload: buildSleepAlarmRetryPayload(companionPushId, target, targetKind, trip.token, now),
         apnsEnv: companionHeal.correctedEnv ?? trip.apnsEnv ?? 'sandbox',
         status: companionHeal.result.status,
@@ -2392,7 +2396,8 @@ export async function fireArvlCdStationPush(
   const heal = await sendWithEnvHeal(
     (host) =>
       sendAlertPush({
-        deviceToken: trip.token,
+        // #2174 — 로테이션 이후에도 실 토큰 발사를 보장. trip.token은 신원 전용(로테이션 시 UUID로 교체).
+        deviceToken: resolveTripDeviceToken(trip),
         title: stationNotifContent.title,
         body: stationNotifContent.body,
         pushId,
@@ -2440,7 +2445,8 @@ export async function fireArvlCdStationPush(
       env.PENDING_PUSHES,
       {
         pushId,
-        token: trip.token,
+        // #2174 — pending/retry queue entry의 token은 APNs 재발사 주소. deviceToken 사용.
+        token: resolveTripDeviceToken(trip),
         payload: arvlcdPayload,
         apnsEnv: trip.apnsEnv ?? 'sandbox',
         status: heal.result.status,
@@ -2785,7 +2791,8 @@ export async function fireVanishFallbackStationPush(
   const heal = await sendWithEnvHeal(
     (host) =>
       sendAlertPush({
-        deviceToken: trip.token,
+        // #2174 — 로테이션 이후에도 실 토큰 발사를 보장. trip.token은 신원 전용(로테이션 시 UUID로 교체).
+        deviceToken: resolveTripDeviceToken(trip),
         title: vanishStationNotifContent.title,
         body: vanishStationNotifContent.body,
         pushId,
@@ -2827,7 +2834,8 @@ export async function fireVanishFallbackStationPush(
       env.PENDING_PUSHES,
       {
         pushId,
-        token: trip.token,
+        // #2174 — pending/retry queue entry의 token은 APNs 재발사 주소. deviceToken 사용.
+        token: resolveTripDeviceToken(trip),
         payload: vanishPayload,
         apnsEnv: trip.apnsEnv ?? 'sandbox',
         status: heal.result.status,
@@ -2974,7 +2982,8 @@ async function fireTrainReconfirmPush(
     const heal = await sendWithEnvHeal(
       (host) =>
         sendAlertPush({
-          deviceToken: trip.token,
+          // #2174 — 로테이션 이후에도 실 토큰 발사를 보장. trip.token은 신원 전용(로테이션 시 UUID로 교체).
+          deviceToken: resolveTripDeviceToken(trip),
           title: strings.trainReconfirmTitle,
           body: strings.trainReconfirmBody,
           pushId,
@@ -3662,7 +3671,8 @@ export async function advanceBoardingLockWaypoint(
     const transferHeal = await sendWithEnvHeal(
       (host) =>
         sendSilentPush({
-          deviceToken: trip.token,
+          // #2174 — 로테이션 이후에도 실 토큰 발사를 보장. trip.token은 신원 전용(로테이션 시 UUID로 교체).
+          deviceToken: resolveTripDeviceToken(trip),
           payload: transferPayload,
           config: deps.apnsConfig,
           host,
@@ -3694,7 +3704,8 @@ export async function advanceBoardingLockWaypoint(
         env.PENDING_PUSHES,
         {
           pushId,
-          token: trip.token,
+          // #2174 — pending/retry queue entry의 token은 APNs 재발사 주소. deviceToken 사용.
+          token: resolveTripDeviceToken(trip),
           payload: transferPayload,
           apnsEnv: trip.apnsEnv ?? 'sandbox',
           status: transferHeal.result.status,
@@ -3895,7 +3906,8 @@ export async function maybeReschedulePush(
   const heal = await sendWithEnvHeal(
     (host) =>
       sendReschedulePush({
-        deviceToken: trip.token,
+        // #2174 — 로테이션 이후에도 실 토큰 발사를 보장. trip.token은 신원 전용(로테이션 시 UUID로 교체).
+        deviceToken: resolveTripDeviceToken(trip),
         pushId,
         trainCode: lock.trainCode,
         nextStation: waypoint.stationName,
@@ -4139,7 +4151,8 @@ export async function runLocklessIntermediate(
     const heal = await sendWithEnvHeal(
       (host) =>
         sendSilentPush({
-          deviceToken: trip.token,
+          // #2174 — 로테이션 이후에도 실 토큰 발사를 보장. trip.token은 신원 전용(로테이션 시 UUID로 교체).
+          deviceToken: resolveTripDeviceToken(trip),
           payload: locklessPayload,
           config: deps.apnsConfig,
           host,
@@ -4183,7 +4196,8 @@ export async function runLocklessIntermediate(
         env.PENDING_PUSHES,
         {
           pushId,
-          token: trip.token,
+          // #2174 — pending/retry queue entry의 token은 APNs 재발사 주소. deviceToken 사용.
+          token: resolveTripDeviceToken(trip),
           payload: locklessPayload,
           apnsEnv: trip.apnsEnv ?? 'sandbox',
           status: heal.result.status,
@@ -4208,7 +4222,8 @@ export async function runLocklessIntermediate(
       env.PENDING_PUSHES,
       {
         pushId,
-        token: trip.token,
+        // #2174 — pending/retry queue entry의 token은 APNs 재발사 주소. deviceToken 사용.
+        token: resolveTripDeviceToken(trip),
         alarmKey: buildAlarmKey(waypoint.stationName, 'imminent'),
         sentAt: now,
         stationName: waypoint.stationName,
@@ -4772,7 +4787,8 @@ export async function evaluateAndMaybeFireBoardingPrompt(
   const heal = await sendWithEnvHeal(
     (host) =>
       sendBoardingPromptPush({
-        deviceToken: trip.token,
+        // #2174 — 로테이션 이후에도 실 토큰 발사를 보장. trip.token은 신원 전용(로테이션 시 UUID로 교체).
+        deviceToken: resolveTripDeviceToken(trip),
         pushId,
         title,
         body,
@@ -4905,7 +4921,8 @@ export async function maybeFireHopEndPrompt(inputs: {
   const heal = await sendWithEnvHeal(
     (host) =>
       sendBoardingPromptPush({
-        deviceToken: trip.token,
+        // #2174 — 로테이션 이후에도 실 토큰 발사를 보장. trip.token은 신원 전용(로테이션 시 UUID로 교체).
+        deviceToken: resolveTripDeviceToken(trip),
         pushId,
         title,
         body,

--- a/backend/alarm-worker/src/tripStatus.ts
+++ b/backend/alarm-worker/src/tripStatus.ts
@@ -21,8 +21,19 @@ const TRIP_STATUS_PREFIX = 'tripStatus:';
 /**
  * 외부 응답에 노출하는 endReason — `destination-arrived` → `destination`로 축약 (contract).
  * `seoul-outage` (#1663) — Seoul API HTTP error로 인한 false-end. #1425 cooldown 면제 대상.
+ * `rotated` (#2174 F2) — route sig 변경으로 token 로테이션되며 old trip이 폐기된 사유.
+ *   실 deviceToken으로 GET /trips/:token/status를 조회하는 device가(#2174 comment 1: 로테이션 직후
+ *   trip.token이 바뀌어도 device는 여전히 실 deviceToken으로 조회) 첫 로테이션 한정으로 이 사유를
+ *   확인해 'ended'로 사망 인지할 수 있다 — 2회차 이상 로테이션(oldToken이 이미 UUID)의 완전한
+ *   deviceToken 역인덱스 조회는 #2175로 위임.
  */
-export type TripStatusEndReason = 'expired' | 'eta-missing' | 'seoul-outage' | 'destination' | 'push-unrecoverable';
+export type TripStatusEndReason =
+  | 'expired'
+  | 'eta-missing'
+  | 'seoul-outage'
+  | 'destination'
+  | 'push-unrecoverable'
+  | 'rotated';
 
 export interface TripStatusRecord {
   endedAt: number;
@@ -107,7 +118,8 @@ export async function readTripEndedStatus(
       parsed.endReason !== 'eta-missing' &&
       parsed.endReason !== 'seoul-outage' &&
       parsed.endReason !== 'destination' &&
-      parsed.endReason !== 'push-unrecoverable'
+      parsed.endReason !== 'push-unrecoverable' &&
+      parsed.endReason !== 'rotated'
     ) {
       return null;
     }

--- a/backend/alarm-worker/src/trips.ts
+++ b/backend/alarm-worker/src/trips.ts
@@ -1,10 +1,12 @@
 import { getArchFlag } from './archFlag';
+import { recordTripMetrics } from './d1TripMetrics';
 import {
   assertCronCacheTtl,
   assertKvCacheTtl,
   CRON_READ_CACHE_TTL_SEC as SHARED_CRON_TTL,
 } from './kvConsistency';
 import { listPending, pendingKey } from './pendingPushes';
+import { writeTripEndedStatus } from './tripStatus';
 import type { Trip } from './types';
 
 /**
@@ -54,6 +56,33 @@ const CRON_READ_CACHE_TTL_SEC = SHARED_CRON_TTL;
 
 export function tripKey(token: string): string {
   return `${TRIP_PREFIX}${token}`;
+}
+
+/** #2174 — 64-hex APNs device token 포맷 검증. */
+const DEVICE_TOKEN_HEX64_RE = /^[0-9a-f]{64}$/i;
+
+/**
+ * #2174 (P1-A) — push 발사용 실 APNs deviceToken을 단일 지점에서 해석한다.
+ *
+ * 로테이션(`rotateTripTokenForNewRoute`)이 `trip.token`을 `crypto.randomUUID()`로 교체해도
+ * `trip.deviceToken`은 등록 시점의 실 토큰을 그대로 보존하므로(index.ts `validateTrip`이
+ * `incoming.deviceToken`을 rotation 이전에 고정), 정상 경로는 항상 `trip.deviceToken`을 반환한다.
+ *
+ * 하위호환(#2174 스펙 4): 본 필드 도입 이전 KV에 남은 legacy trip 레코드는 `deviceToken`이
+ * 없을 수 있다 — `trip.token`이 유효한 64-hex 포맷(로테이션 전 실토큰)일 때만 그 값으로
+ * fallback한다. `trip.token`이 UUID(로테이션된 신원, deviceToken 부재)면 애초에 P0 guard로
+ * 로테이션이 막혀 있던 구간의 산물이라 존재해서는 안 되는 조합 — 그런 경우도 fallback으로
+ * `trip.token`을 반환해 기존(로테이션 재활성 이전) 동작과 동일하게 유지한다(마이그레이션
+ * 배치 금지, 새 회귀 없음 — 이미 무효했던 push가 계속 무효할 뿐).
+ */
+export function resolveTripDeviceToken(trip: Trip): string {
+  if (
+    typeof trip.deviceToken === 'string' &&
+    DEVICE_TOKEN_HEX64_RE.test(trip.deviceToken)
+  ) {
+    return trip.deviceToken;
+  }
+  return trip.token;
 }
 
 export async function putTrip(kv: KVNamespace, trip: Trip): Promise<void> {
@@ -198,22 +227,25 @@ export interface TokenRotationDeps {
    * 과 동일한 DI 패턴으로 노출한다. 실제 호출부(`POST /trips`)는 이 값을 지정하지 않는다.
    */
   rotationDisabled?: boolean;
+  /** #2174 — F2 old-trip 관측 기록용 D1 binding. 미지정/undefined는 `recordTripMetrics` 내부 no-op. */
+  db?: D1Database;
+  /** #2174 — old-trip sentinel/D1 기록 시각(epoch ms). 미지정 시 `Date.now()`. */
+  now?: number;
 }
 
 /**
- * #2173 P0 hotfix — token rotation 전면 비활성 guard.
+ * #2174 (P1-A) — token rotation 재활성 guard.
  *
- * `rotateTripTokenForNewRoute`가 route sig 변경 시 `crypto.randomUUID()`로 trip.token을
- * 교체 → 이후 모든 push가 UUID를 APNs deviceToken으로 사용해 400 BadDeviceToken →
- * 첫 due push에서 push-unrecoverable 즉사 (Epic #2172 물증).
+ * #2173 P0 hotfix가 `deviceToken` 필드 분리 전까지 rotation을 전면 차단했다 — 로테이션이
+ * `trip.token`(APNs 발사 주소 겸용)을 UUID로 교체하면 이후 모든 push가 400 BadDeviceToken으로
+ * 즉사했기 때문(Epic #2172 물증). 이제 `Trip.deviceToken`이 로테이션과 무관하게 실 토큰을
+ * 보존하므로(모든 push 발사 사이트가 `resolveTripDeviceToken(trip)` 사용) rotation을 안전하게
+ * 재활성한다.
  *
- * `arch:simple-arrival-v1` 플래그를 OFF로 끄는 방식은 금지 — 오토락 봉인 등 다른 게이트까지
- * 함께 풀린다. 그래서 rotation 경로만 독립적으로 단락하는 전용 상수 guard를 둔다.
- * KV/env 신규 플래그는 추가하지 않는다 (파생 복잡도 방지) — 배포 시점 코드 상수로만 제어.
- *
- * 로테이션 로직 자체는 삭제하지 않는다 — #P1-A에서 구조 수리 후 이 상수를 false로 되돌려 재활성.
+ * `arch:simple-arrival-v1` 플래그가 여전히 최종 on/off 스위치 — 이 상수는 그 앞단의 이중 guard였고
+ * 이제 flag 판정에 그대로 위임한다(false = guard 해제).
  */
-const TOKEN_ROTATION_DISABLED = true;
+const TOKEN_ROTATION_DISABLED = false;
 
 export async function rotateTripTokenForNewRoute(
   kv: KVNamespace,
@@ -248,6 +280,19 @@ export async function rotateTripTokenForNewRoute(
   const generateToken = deps?.generateToken ?? (() => crypto.randomUUID());
   const newToken = generateToken();
   const oldToken = existing.token;
+  const rotatedAt = deps?.now ?? Date.now();
+  // #2174 F2 — old trip 삭제가 관측 blind hole이었다(raw KV delete, D1/sentinel 미기록 →
+  // 사후 RCA 완전 비가시, 2026-08-06 진단 지연 직접 원인). cleanupTripWithLa(liveActivity.ts)를
+  // 재사용하지 않는다 — 그 helper는 사용자향 trip-ended alert push를 함께 발사하는데, mid-trip
+  // route 변경(F1: 환승 waypoint trim/목적지 변경 재-POST)마다 로테이션이 발동하므로 매번 종료
+  // alert가 뜨면 사용자 경험 회귀다. 여기서는 push-unrecoverable/user-delete와 구분되는 관측
+  // 전용 사유 'rotated'로 D1 기록 + tripStatus sentinel만 남긴다(alert push 없음).
+  await recordTripMetrics(deps?.db, existing, 'rotated', rotatedAt);
+  try {
+    await writeTripEndedStatus(kv, oldToken, 'rotated', rotatedAt);
+  } catch {
+    // best-effort — sentinel 기록 실패가 rotation 자체를 막지 않는다(다른 tripStatus 호출자와 동일 정책).
+  }
   await deleteTrip(kv, oldToken);
   await cleanupPendingPushesForToken(kv, oldToken);
   return { token: newToken, rotated: true };

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -72,8 +72,22 @@ export interface Waypoint {
 }
 
 export interface Trip {
-  /** APNs device token (hex) */
+  /**
+   * trip 신원 / KV 키 전용 (`trip:<token>`). #2174 이전에는 APNs device token과 겸용이었으나,
+   * 로테이션(ADR-022 B4)이 route 변경 시 이 값을 `crypto.randomUUID()`로 교체하므로 더 이상
+   * APNs 발사 주소로 사용할 수 없다. push 발사는 반드시 `deviceToken`을 사용할 것.
+   */
   token: string;
+  /**
+   * #2174 — 실 APNs device token (64-hex). 로테이션(`rotateTripTokenForNewRoute`)이 발생해도
+   * 이 값은 등록 시점의 실 토큰으로 불변 — 모든 push 발사 사이트는 `trip.token`이 아닌 이
+   * 필드를 deviceToken 인자로 사용해야 한다.
+   *
+   * optional인 이유: 본 필드 도입(#2174) 이전에 KV에 기록된 legacy trip 레코드는 이 필드가
+   * 없다. `trips.ts:resolveTripDeviceToken`이 read 경로에서 `deviceToken ?? token`(token이
+   * 64-hex일 때만) fallback을 적용한다 — 마이그레이션 배치는 하지 않는다(#2174 금지사항).
+   */
+  deviceToken?: string;
   route: Route;
   /** 목적지 역 ID (예: "0228" 같은 stations.json id) */
   destination: string;
@@ -424,6 +438,10 @@ export interface ReschedulePushPayload {
  *   - 'la-stale-backstop' (#1933) — LA push가 LA_STALE_AUTO_END_MS(5분) 이상 침묵 시 자동 종료
  *                       (Dynamic Island content-state freeze 차단). 외부 contract는 'expired'로
  *                       매핑 (backward-compat) — `toTripStatusEndReason`이 처리한다.
+ *   - 'rotated' (#2174 F2) — `rotateTripTokenForNewRoute`가 route sig 변경으로 new UUID를 발급하며
+ *                       old trip을 폐기한 사유. push-unrecoverable/user-delete와 구분되는 관측
+ *                       전용 사유 — alert push는 발사하지 않는다(사용자 명시 route 변경 자체가
+ *                       trip 전환의 정상 신호라 종료 알림 UX가 불필요).
  *
  * 클라가 명시적으로 trip을 끝낸 경로(HTTP DELETE /trips/:token)는 발사 대상이 아님 —
  * 사용자가 destination을 clear하면 이미 클라이언트 store가 정리된 상태이기 때문.
@@ -434,7 +452,8 @@ export type TripEndedReason =
   | 'destination-arrived'
   | 'expired'
   | 'push-unrecoverable'
-  | 'la-stale-backstop';
+  | 'la-stale-backstop'
+  | 'rotated';
 
 /**
  * Trip ended alert push payload (#1337). server-side trip 자동 종료 시 발사되는 alert push의


### PR DESCRIPTION
Closes #2174
Part of #2172

## 요약

로테이션이 `trip.token`(신원)과 APNs 발사 주소를 겸용하던 근본 결함을 해소한다. `Trip.deviceToken` 필드를 신설해 push 발사는 항상 이 필드를 쓰고, `trip.token`은 신원/KV 키 전용으로 정리했다. 이로써 #2173 P0 hotfix가 걸어둔 token rotation 비활성 guard를 안전하게 해제(재활성)했다.

## 변경 사항

1. **타입** (`types.ts`): `Trip.deviceToken?: string` 추가(64-hex, 로테이션 불변). `token` 필드 주석을 "신원/KV 키 전용"으로 갱신. optional인 이유: #2174 이전 KV에 남은 legacy trip 레코드는 이 필드가 없을 수 있어 하위호환 fallback이 필요.
2. **등록** (`index.ts` `validateTrip`): 등록 시점의 실 device token을 `deviceToken`으로 고정 — rotation이 `incoming.token`을 UUID로 덮어써도 `deviceToken`은 영향받지 않는다(baseTrip이 `...incoming` spread로 그대로 carry).
3. **단일 해석 지점** (`trips.ts` `resolveTripDeviceToken`): `deviceToken`이 유효한 64-hex면 그 값을, 아니면(legacy 레코드) `token`이 64-hex일 때만 fallback. 모든 push 발사 사이트(`scheduled.ts`/`liveActivity.ts`)와 pending/retry queue 등록(`token:` 필드)이 `trip.token` 대신 이 함수를 사용하도록 전수 전환.
4. **P0 guard 해제**: `TOKEN_ROTATION_DISABLED`를 `false`로 되돌려 rotation 재활성. deviceToken이 로테이션과 무관하게 보존되므로 이제 안전.
5. **F1 (mid-trip rotation deviceToken carry)**: 로테이션은 등록 시점 한정이 아니라 환승 waypoint trim 재-POST/목적지 변경 등 mid-trip route 변경 재-POST에서도 발동한다(`computeRouteSignature` 변경 감지). deviceToken은 rotation과 완전히 독립적으로 `incoming` 객체에 실려 있어 mid-trip 로테이션에도 carry됨을 red→green 테스트로 보장.
6. **F2 (old trip 로테이션 관측 기록)**: `rotateTripTokenForNewRoute`가 old trip을 raw KV delete로 지우던 것을 D1 기록(`recordTripMetrics`) + `tripStatus` sentinel(`reason='rotated'`)로 보강. `cleanupTripWithLa`는 재사용하지 않음 — 그 helper는 사용자향 trip-ended alert push를 함께 발사하는데, mid-trip 로테이션마다(F1) 매번 종료 alert가 뜨면 UX 회귀이기 때문.
7. **Pull 인지 무력화 보강**: `tripStatus.ts`의 `TripStatusEndReason`에 `'rotated'`를 추가. `GET /trips/:token/status`는 코드 변경 없이도 첫 로테이션에 한해 이 sentinel을 그대로 노출한다 — device가 실 deviceToken(=최초 등록 시 실토큰)으로 조회하면 old trip이 사라졌어도 `'ended'`/`'rotated'`로 사망을 인지할 수 있다. 2회차 이상 로테이션(oldToken이 이미 UUID)의 완전한 deviceToken 역인덱스 조회는 **#2175로 위임**(이슈 본문 명시 escape hatch).

## 스펙 대비 이탈 사항

- `deviceToken`을 이슈 원문의 `string`(required)이 아니라 `deviceToken?: string`(optional)로 구현. 이유: 이슈 자체가 "기존 KV trip 레코드에 deviceToken 부재 시 fallback"을 요구(하위호환) — required 타입은 이 전제와 모순되고, required로 강제할 경우 테스트 fixture 전수 개정(surgical 위반)이 필요해 optional + `resolveTripDeviceToken` 단일 해석 지점으로 대체. 런타임 동작(fallback 로직)은 스펙 문구 그대로 구현.
- GET `/trips/:token/status`의 deviceToken 기반 완전한 역인덱스 조회(2회차+ 로테이션)는 이슈 코멘트가 명시한 escape hatch대로 **#2175로 위임**.

## Wire-completion 5단

1. **Orphan**: `npm run lint:orphan` pass(0 orphan) — 단, 본 스크립트는 backend/를 스캔 대상에 포함하지 않음(frontend `src/` 전용 툴). `resolveTripDeviceToken`은 `scheduled.ts`/`liveActivity.ts`가 즉시 소비하므로 orphan 아님.
2. **V/X dashboard**: wrangler tail에서 push 발사 로그의 `trip-register: route rotation (#2019, ADR-022 B4)` 이벤트로 rotation 발동 확인 가능. 배포 후 `oldTokenPrefix`/`newTokenPrefix` 로그로 rotation 빈도 관측. D1 `trip_metrics` 테이블에서 `end_reason='rotated'` row로 F2 old-trip 기록 확인 가능(Cloudflare D1 dashboard 쿼리).
3. **의존 PR**: #2173(P0 hotfix, 머지됨) 이후 순서. **머지 후 wrangler deploy 필수**.
4. **측정 plan**: 배포 후 실탑승 1회 — mid-trip route 변경(환승) 시 D1 `end_reason='rotated'` row 생성 확인 + 로테이션 발생 trip에서도 push 도달(BadDeviceToken 0건, D1 `push-unrecoverable` 0건 유지) 확인.
5. **Device verify**: Epic #2172 close 조건 탑승과 공유 — 로테이션이 재활성된 상태에서 환승 mid-trip route 변경 실탑승 검증 필요.

## 테스트 (red-green)

- red: "로테이션 후 발사되는 push의 APNs deviceToken이 UUID다" 재현 실패 테스트 → `resolveTripDeviceToken` 도입 후 실 토큰으로 green.
- 발사 사이트별(silent/alert/trip-ended/reschedule/boardingPrompt/sleep-alarm/fallback/retry) deviceToken 소스 단위 테스트.
- 하위호환: deviceToken 부재 레코드 fallback 경로(64-hex 검증 포함, 손상 데이터 케이스 포함).
- F1: mid-trip route 변경 재-POST 로테이션 시나리오 — deviceToken carry 보장.
- F2: rotation 시 tripStatus sentinel(reason='rotated') 기록 + D1 `recordTripMetrics` 호출(`end_reason='rotated'`) + best-effort(KV put 실패해도 rotation 자체는 완료) 검증.
- #2173 guard 테스트(3건, index.test.ts) + rotation 단락 검증(6건, trips.test.ts)을 guard 해제에 맞춰 rotation-active 기대값으로 재작성.

## 검증 결과

- `npx vitest run --coverage`: 2833 passed, 0 failed. Coverage: stmts 97.14 / branch 96.31 / funcs 99.19 / lines 97.14 (ratchet floor 97/96/98/97 — pass, `trips.ts` 100% stmts/lines)
- `npm run type-check` (backend/alarm-worker): pass, 0 error
- `npm run lint:orphan` (repo root): 0 orphan

## 금지사항 준수

- KV 키 스킴 변경 없음(트립 키 여전히 `trip:<token>`).
- 디바이스 클라이언트 계약 변경 없음 — POST /trips 응답의 `token` 필드는 여전히 `trip.token`(rotation 이후 값)을 그대로 echo.
- 오토락/프롬프트 로직 미접근 — `sendBoardingPromptPush` 등 push 발사 호출부의 `deviceToken` 인자만 교체, 판정 로직(9단 게이트 등) 무변경.
- `backend/alarm-worker`의 pushFailureLog/retryPushes 신규 파일(PR #2183 작업 중)은 생성/참조하지 않음. `retryPushes.ts`/`fallback.ts` 자체는 무수정 — 호출부(`scheduled.ts`)의 토큰 인자만 교체.