### PR TITLE
fix: POST /trips 멱등화 + deviceToken 역인덱스로 orphan UUID trip 회수 (#2175)

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -4505,29 +4505,69 @@ describe('POST /trips — #2019 rotateTripTokenForNewRoute wire (ADR-022 B4)', (
       expect(body2.token).not.toBe(TOKEN);
     });
 
-    // #2174 F2 — old trip 로테이션 시 D1 기록 + tripStatus sentinel(reason='rotated')이 남는다.
-    it('#2174 F2 — rotation 발동 시 old token으로 GET /trips/:token/status 가 ended(rotated)를 반환한다', async () => {
+    // #2174 F2 → #2175로 완결 — rotation 발동 후 old(실) token으로 GET /trips/:token/status를
+    // 조회하면 deviceToken 역인덱스가 새 UUID trip을 재발견해 'active'를 반환한다. 로테이션된
+    // trip은 실제로 여전히 살아있으므로(사용자가 그냥 route를 바꿨을 뿐) 'ended'로 보고하는 게
+    // 오히려 부정확했다 — #2175가 이 갭을 닫는다.
+    it('#2175 — rotation 발동 후 실 deviceToken으로 GET /trips/:token/status 조회 시 역인덱스로 새 UUID trip을 찾아 active를 반환한다', async () => {
       const env = makeKvEnv();
       await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
       await seedExistingTrip(env, '용마산-id', '용마산');
       const res = await post('/trips', tripBodyFor('성수-id', '성수'), env);
       expect(res.status).toBe(200);
+      const body = (await res.json()) as { token: string };
 
       // #2174 comment 1 — device는 로테이션 이후에도 실 deviceToken(=최초 등록 시 TOKEN)으로
-      // GET /trips/:token/status를 조회한다. old trip이 UUID로 로테이션되며 사라졌어도
-      // sentinel이 'rotated'로 사망 인지를 가능케 한다(첫 로테이션 한정 — #2175로 완전한
-      // deviceToken 역인덱스 조회는 위임).
+      // GET /trips/:token/status를 조회한다.
       const statusRes = await app.fetch(
         new Request(`http://example.com/trips/${TOKEN}/status`, { method: 'GET' }),
         env,
       );
       expect(statusRes.status).toBe(200);
       const statusBody = (await statusRes.json()) as {
+        tripToken: string;
         status: string;
         endReason: string | null;
       };
+      // 응답의 tripToken은 device가 질의한 원래 값(TOKEN)을 echo — 내부적으로는 새 UUID(body.token)
+      // trip을 참조해 active로 판정했다.
+      expect(statusBody.tripToken).toBe(TOKEN);
+      expect(statusBody.status).toBe('active');
+      expect(statusBody.endReason).toBeNull();
+      expect(body.token).not.toBe(TOKEN);
+    });
+
+    // #2175 — 로테이션된 trip이 실제로 종료(예: 만료)되면, 역인덱스가 여전히 그 UUID를 가리키는
+    // 상태에서 실 deviceToken 조회가 그 UUID의 종료 사유('rotated')를 그대로 노출한다.
+    it('#2175 — rotation 후 새 UUID trip마저 종료되면 실 deviceToken 조회가 그 종료 사유를 반환한다', async () => {
+      const env = makeKvEnv();
+      await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
+      await seedExistingTrip(env, '용마산-id', '용마산');
+      const res = await post('/trips', tripBodyFor('성수-id', '성수'), env);
+      const body = (await res.json()) as { token: string };
+      const newToken = body.token;
+      expect(newToken).not.toBe(TOKEN);
+
+      // 새 UUID trip을 직접 종료 상태로 전환 (cron 자동 종료를 시뮬레이션 — expired 사유).
+      await env.TRIPS.delete(`trip:${newToken}`);
+      await env.TRIPS.put(
+        `tripStatus:${newToken}`,
+        JSON.stringify({ endedAt: Date.now(), endReason: 'expired' }),
+      );
+
+      const statusRes = await app.fetch(
+        new Request(`http://example.com/trips/${TOKEN}/status`, { method: 'GET' }),
+        env,
+      );
+      expect(statusRes.status).toBe(200);
+      const statusBody = (await statusRes.json()) as {
+        tripToken: string;
+        status: string;
+        endReason: string | null;
+      };
+      expect(statusBody.tripToken).toBe(TOKEN);
       expect(statusBody.status).toBe('ended');
-      expect(statusBody.endReason).toBe('rotated');
+      expect(statusBody.endReason).toBe('expired');
     });
 
     // #2129 — 2026-08-04 실탑승 evidence: 같은 device token으로 거의 동시에 도착한
@@ -4550,6 +4590,115 @@ describe('POST /trips — #2019 rotateTripTokenForNewRoute wire (ADR-022 B4)', (
       // (원본 TOKEN 재사용이든 rotation으로 발급된 새 UUID든 — 유령 trip 2개 생존이 회귀).
       expect(allTripKeys.length).toBe(1);
     });
+  });
+});
+
+// #2175 — deviceToken → trip.token 역인덱스로 POST /trips 비멱등 회수 (#2184 리뷰 P1).
+//
+// Root cause(backend RCA #2175 코멘트): 같은 실토큰 재-POST + route 변경 → 매번 새 UUID trip
+// 생성, `getTrip`은 incoming.token(실토큰)으로만 조회(index.ts)라 직전 로테이션의 UUID trip을
+// 못 찾아 orphan이 누적된다. rotated UUID를 device가 채택하지 않는 것도 원인(발산 지속).
+//
+// #2184 리뷰 P1 시퀀스: (1) 실토큰 등록 → route 변경 재-POST → 로테이션(`trip:<실토큰>` 삭제 +
+// `trip:<UUID>` 생성) → (2) 클라가 또 실토큰으로 재-POST(route 동일, lock/ETA 변동 등) →
+// `getTrip(실토큰)` miss → 역인덱스 fallback 없이는 신규 `trip:<실토큰>` 생성 → `trip:<UUID>`
+// (route frozen 고아)와 `trip:<실토큰>`(현재) 둘 다 live.
+describe('POST /trips — #2175 deviceToken 역인덱스 (orphan 회수, #2184 리뷰 P1)', () => {
+  const TOKEN = 'tok-2175-real';
+
+  function tripBodyFor(destination: string, stationName: string): Record<string, unknown> {
+    return {
+      ...base(),
+      token: TOKEN,
+      destination,
+      waypoints: [{ stationName, line: '2', kind: 'destination' }],
+    };
+  }
+
+  async function activeTripKeys(env: Env): Promise<string[]> {
+    const list = await env.TRIPS.list({ prefix: 'trip:' });
+    return list.keys.map((k) => k.name);
+  }
+
+  it('P1: 실토큰 재-POST(route 동일, 로테이션 이후) → 역인덱스로 기존 UUID trip에 merge, 신규 trip:<실토큰> 미생성', async () => {
+    const env = makeKvEnv();
+    await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
+
+    // 1) 최초 등록.
+    const res1 = await post('/trips', tripBodyFor('용마산-id', '용마산'), env);
+    expect(res1.status).toBe(200);
+    expect(await activeTripKeys(env)).toEqual([`trip:${TOKEN}`]);
+
+    // 2) route 변경 재-POST → rotation 발동 (`trip:<TOKEN>` 삭제 + `trip:<UUID>` 생성).
+    const res2 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
+    expect(res2.status).toBe(200);
+    const body2 = (await res2.json()) as { token: string };
+    const uuid1 = body2.token;
+    expect(uuid1).not.toBe(TOKEN);
+    expect(await activeTripKeys(env)).toEqual([`trip:${uuid1}`]);
+
+    // 3) 클라는 rotated UUID를 채택하지 않고 계속 실토큰(TOKEN)으로 같은 route 재-POST.
+    //    수정 전: getTrip(TOKEN) miss → 신규 trip:<TOKEN> 생성 → trip:<uuid1>(고아) 동시 생존(2개).
+    //    수정 후: 역인덱스가 TOKEN → uuid1을 가리키므로 existing으로 재발견 → 같은 route → merge.
+    const res3 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
+    expect(res3.status).toBe(200);
+    const body3 = (await res3.json()) as { token: string };
+    expect(body3.token).toBe(uuid1);
+    const keysAfterMerge = await activeTripKeys(env);
+    expect(keysAfterMerge).toEqual([`trip:${uuid1}`]);
+    expect(keysAfterMerge).not.toContain(`trip:${TOKEN}`);
+  });
+
+  it('P1: 2회 연속 로테이션에도 orphan이 쌓이지 않는다 (역인덱스가 매번 최신 UUID로 갱신)', async () => {
+    const env = makeKvEnv();
+    await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
+
+    await post('/trips', tripBodyFor('용마산-id', '용마산'), env);
+    const res2 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
+    const uuid1 = ((await res2.json()) as { token: string }).token;
+
+    // 다시 실토큰으로 두 번째 route 변경 재-POST → uuid1 → uuid2 로테이션.
+    const res3 = await post('/trips', tripBodyFor('중곡-id', '중곡'), env);
+    expect(res3.status).toBe(200);
+    const uuid2 = ((await res3.json()) as { token: string }).token;
+    expect(uuid2).not.toBe(uuid1);
+    expect(uuid2).not.toBe(TOKEN);
+
+    // 두 번의 로테이션이 지나도 KV에 활성 trip은 정확히 1개 — uuid1도 orphan으로 남지 않는다.
+    expect(await activeTripKeys(env)).toEqual([`trip:${uuid2}`]);
+  });
+
+  it('#2184 리뷰 P1 안전망: 역인덱스가 가리키던 trip이 최종 확정 trip과 다르면 superseded-by-reregister로 정리하고 D1/sentinel을 남긴다', async () => {
+    const env = makeKvEnv();
+    await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
+    await post('/trips', tripBodyFor('용마산-id', '용마산'), env);
+    const res2 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
+    const uuid1 = ((await res2.json()) as { token: string }).token;
+
+    const res3 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
+    expect(res3.status).toBe(200);
+    // merge 케이스라 정리 대상이 없다 — uuid1 자체가 그대로 유지된 최종 trip이므로 sentinel 미기록.
+    expect(await env.TRIPS.get(`tripStatus:${uuid1}`)).toBeNull();
+
+    // 이어서 route 변경 재-POST → uuid1 → uuid2 로테이션. rotateTripTokenForNewRoute 자체가
+    // 'rotated' sentinel을 남기므로(#2174 F2), superseded-by-reregister 중복 기록은 없어야 한다.
+    const res4 = await post('/trips', tripBodyFor('중곡-id', '중곡'), env);
+    const uuid2 = ((await res4.json()) as { token: string }).token;
+    const uuid1Status = await env.TRIPS.get(`tripStatus:${uuid1}`);
+    expect(uuid1Status).not.toBeNull();
+    expect(JSON.parse(uuid1Status as string).endReason).toBe('rotated');
+    expect(await activeTripKeys(env)).toEqual([`trip:${uuid2}`]);
+  });
+
+  it('deviceToken 역인덱스가 최종 trip.token으로 유지된다 (raw KV 값 검증)', async () => {
+    const env = makeKvEnv();
+    await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
+    await post('/trips', tripBodyFor('용마산-id', '용마산'), env);
+    expect(await env.TRIPS.get(`device-trips:${TOKEN}`)).toBe(TOKEN);
+
+    const res2 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
+    const uuid1 = ((await res2.json()) as { token: string }).token;
+    expect(await env.TRIPS.get(`device-trips:${TOKEN}`)).toBe(uuid1);
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -6509,6 +6509,88 @@ describe('runScheduled — #1933 LA stale auto-end backstop', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #2175 — cron dedupeTripsByDeviceToken 안전망 (#2184 리뷰 P1)
+//
+// register-time deviceToken 역인덱스 merge/cleanup이 KV eventual consistency 등으로 실패해
+// 같은 deviceToken의 active trip이 순간적으로 2개 이상 KV에 동시 존재해도, cron이 orphan에
+// 대해서도 실 deviceToken으로 push를 중복 발사하지 않도록 최신(createdAt) trip만 처리한다.
+// ---------------------------------------------------------------------------
+describe('#2175 — cron dedupeTripsByDeviceToken 안전망', () => {
+  it('같은 deviceToken의 active trip 2개(오래된 것 + 최신) 존재 시 최신 1개만 scanned/push 발사', async () => {
+    const kv = new InMemoryKV();
+    // 오래된 trip(orphan) — 같은 deviceToken, 먼저 등록됨.
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'orphan-uuid',
+        deviceToken: 'dev-dup',
+        createdAt: NOW - 10 * 60_000,
+        expiresAt: NOW + 60 * 60_000,
+        alarmAtEpochMs: NOW + 60_000,
+        destination: 'dst-old',
+        waypoints: [{ stationName: '용마산', line: '7', kind: 'destination' }],
+      }),
+    );
+    // 최신 trip — 같은 deviceToken, 나중에 등록됨(진짜 active).
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'current-uuid',
+        deviceToken: 'dev-dup',
+        createdAt: NOW,
+        expiresAt: NOW + 60 * 60_000,
+        alarmAtEpochMs: NOW + 60_000,
+        destination: 'dst-new',
+        waypoints: [{ stationName: '성수', line: '2', kind: 'destination' }],
+      }),
+    );
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+
+    // 오래된 orphan은 이번 tick 처리 대상에서 제외 — scanned=1(최신만).
+    expect(stats.scanned).toBe(1);
+    // 두 trip 모두 KV에 남아있다 — cron은 register-time 정리를 대신하지 않는다(스캔 skip만).
+    const remaining: Trip[] = [];
+    for await (const t of (await import('../trips')).listTrips(kv as unknown as KVNamespace)) {
+      remaining.push(t);
+    }
+    expect(remaining.map((t) => t.token).sort()).toEqual(['current-uuid', 'orphan-uuid']);
+  });
+
+  it('deviceToken 없는(legacy) trip은 dedup 대상에서 제외되고 정상 scanned', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({
+        token: 'legacy-trip',
+        deviceToken: undefined,
+        createdAt: NOW - 10 * 60_000,
+        expiresAt: NOW + 60 * 60_000,
+        alarmAtEpochMs: NOW + 60_000,
+      }),
+    );
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+
+    expect(stats.scanned).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // #1933 — toTripStatusEndReason — la-stale-backstop external mapping
 // ---------------------------------------------------------------------------
 

--- a/backend/alarm-worker/src/__tests__/trips.test.ts
+++ b/backend/alarm-worker/src/__tests__/trips.test.ts
@@ -3,11 +3,17 @@ import { ARCH_FLAG_KV_KEY } from '../archFlag';
 import {
   __resetTripRegisterLocksForTest,
   cleanupPendingPushesForToken,
+  cleanupSupersededTrip,
   clearStaleBoardingLock,
   computeRouteSignature,
+  dedupeTripsByDeviceToken,
+  deleteDeviceTripIndex,
   deleteTrip,
+  deviceTripIndexKey,
+  getDeviceTripIndex,
   getTrip,
   listTrips,
+  putDeviceTripIndex,
   putTrip,
   resolveTripDeviceToken,
   rotateTripTokenForNewRoute,
@@ -486,6 +492,37 @@ describe('trips KV CRUD', () => {
         expect(await getTrip(kv as unknown as KVNamespace, 'tok-same')).not.toBeNull();
       });
 
+      // #2175 — deviceToken 역인덱스로 재발견한 existing은 incoming.token과 다른 값일 수 있다
+      // (ADR-022 B4 로테이션으로 이전에 UUID로 바뀐 trip). 같은 route라면 반드시 existing.token
+      // (기존 UUID)을 반환해야 한다 — incoming.token(실 deviceToken)을 반환하면 이미 존재하는
+      // UUID trip과 별개로 `trip:<incoming.token>`이 새로 생겨 유령 2개가 남는다(#2184 리뷰 P1).
+      it('#2175 — 같은 route, existing.token !== incoming.token (역인덱스 fallback): existing.token 채택', async () => {
+        const existing = makeTrip({
+          token: 'uuid-from-prior-rotation',
+          deviceToken: 'real-device-token',
+          destination: 'D-1',
+          waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
+        });
+        await putTrip(kv as unknown as KVNamespace, existing);
+        const incoming = makeTrip({
+          token: 'real-device-token',
+          deviceToken: 'real-device-token',
+          destination: 'D-1',
+          waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
+        });
+        const result = await rotateTripTokenForNewRoute(
+          kv as unknown as KVNamespace,
+          incoming,
+          existing,
+          { simpleArchEnabled: true },
+        );
+        expect(result).toEqual({ token: 'uuid-from-prior-rotation', rotated: false });
+        // 정리 대상 없음 — merge이므로 existing trip 그대로 생존.
+        expect(
+          await getTrip(kv as unknown as KVNamespace, 'uuid-from-prior-rotation'),
+        ).not.toBeNull();
+      });
+
       it('#2174 — 다른 destination: rotation 발동 (새 token 발급 + old trip:<token> delete)', async () => {
         // #2173 P0 hotfix가 이 경로를 guard로 단락시켰던 이유(push가 UUID를 APNs deviceToken으로
         // 사용해 400 BadDeviceToken 즉사, Epic #2172)는 #2174가 `Trip.deviceToken` 필드 분리 +
@@ -927,5 +964,150 @@ describe('withTripRegisterLock (#2129)', () => {
       order.push('reused');
     });
     expect(order).toEqual(['reused']);
+  });
+});
+
+// #2175 — deviceToken → 현재 trip.token 역인덱스 KV CRUD.
+describe('deviceToken → trip 역인덱스 (#2175)', () => {
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  it('deviceTripIndexKey builds prefix', () => {
+    expect(deviceTripIndexKey('abc')).toBe('device-trips:abc');
+  });
+
+  it('put + get round-trip', async () => {
+    await putDeviceTripIndex(
+      kv as unknown as KVNamespace,
+      'device-1',
+      'trip-token-A',
+      Date.now() + 60 * 60 * 1000,
+    );
+    expect(await getDeviceTripIndex(kv as unknown as KVNamespace, 'device-1')).toBe(
+      'trip-token-A',
+    );
+  });
+
+  it('get returns null for unknown deviceToken', async () => {
+    expect(await getDeviceTripIndex(kv as unknown as KVNamespace, 'missing')).toBeNull();
+  });
+
+  it('put은 최신 값으로 덮어쓴다 (로테이션마다 갱신)', async () => {
+    const future = Date.now() + 60 * 60 * 1000;
+    await putDeviceTripIndex(kv as unknown as KVNamespace, 'device-1', 'trip-A', future);
+    await putDeviceTripIndex(kv as unknown as KVNamespace, 'device-1', 'trip-B', future);
+    expect(await getDeviceTripIndex(kv as unknown as KVNamespace, 'device-1')).toBe('trip-B');
+  });
+
+  it('delete 이후 get은 null', async () => {
+    await putDeviceTripIndex(
+      kv as unknown as KVNamespace,
+      'device-1',
+      'trip-A',
+      Date.now() + 60 * 60 * 1000,
+    );
+    await deleteDeviceTripIndex(kv as unknown as KVNamespace, 'device-1');
+    expect(await getDeviceTripIndex(kv as unknown as KVNamespace, 'device-1')).toBeNull();
+  });
+
+  it('TTL은 최소 60s로 floor된다 (expiresAt이 과거/근접이어도)', async () => {
+    const putSpy = vi.spyOn(kv, 'put');
+    await putDeviceTripIndex(
+      kv as unknown as KVNamespace,
+      'device-1',
+      'trip-A',
+      Date.now() - 1000,
+    );
+    expect(putSpy).toHaveBeenCalledWith(
+      'device-trips:device-1',
+      'trip-A',
+      expect.objectContaining({ expirationTtl: 60 }),
+    );
+  });
+});
+
+// #2175 — 공유 orphan cleanup helper. rotateTripTokenForNewRoute의 route-변경 cleanup과
+// POST /trips 핸들러의 superseded-by-reregister cleanup이 공유한다.
+describe('cleanupSupersededTrip (#2175)', () => {
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  it('trip 삭제 + tripStatus sentinel 기록 + pending cleanup을 모두 수행한다', async () => {
+    const orphan = makeTrip({ token: 'orphan-1' });
+    await putTrip(kv as unknown as KVNamespace, orphan);
+    await putPending(kv as unknown as KVNamespace, {
+      pushId: 'p1',
+      token: 'orphan-1',
+      alarmKey: 'early:p1',
+      sentAt: Date.now(),
+      stationName: '강남',
+      kind: 'destination',
+      phase: 'early',
+      etaSeconds: 300,
+      apnsEnv: 'sandbox',
+    });
+    const now = Date.now();
+    await cleanupSupersededTrip(
+      kv as unknown as KVNamespace,
+      orphan,
+      'superseded-by-reregister',
+      now,
+    );
+    expect(await getTrip(kv as unknown as KVNamespace, 'orphan-1')).toBeNull();
+    expect(await kv.get(pendingKey('p1'))).toBeNull();
+    const status = await readTripEndedStatus(kv as unknown as KVNamespace, 'orphan-1');
+    expect(status?.endReason).toBe('superseded-by-reregister');
+    expect(status?.endedAt).toBe(now);
+  });
+
+  it('writeTripEndedStatus 실패해도 삭제는 진행된다 (best-effort)', async () => {
+    const orphan = makeTrip({ token: 'orphan-2' });
+    await putTrip(kv as unknown as KVNamespace, orphan);
+    const putSpy = vi.spyOn(kv, 'put').mockRejectedValueOnce(new Error('kv down'));
+    await cleanupSupersededTrip(
+      kv as unknown as KVNamespace,
+      orphan,
+      'superseded-by-reregister',
+      Date.now(),
+    );
+    putSpy.mockRestore();
+    expect(await getTrip(kv as unknown as KVNamespace, 'orphan-2')).toBeNull();
+  });
+});
+
+// #2175 — cron 안전망 pure 함수.
+describe('dedupeTripsByDeviceToken (#2175)', () => {
+  it('deviceToken 없는 trip은 그대로 통과', () => {
+    const t1 = makeTrip({ token: 'a', deviceToken: undefined });
+    const t2 = makeTrip({ token: 'b', deviceToken: undefined });
+    expect(dedupeTripsByDeviceToken([t1, t2])).toEqual([t1, t2]);
+  });
+
+  it('같은 deviceToken 그룹에서 createdAt이 최신인 trip만 유지', () => {
+    const older = makeTrip({ token: 'old', deviceToken: 'dev-1', createdAt: 1000 });
+    const newer = makeTrip({ token: 'new', deviceToken: 'dev-1', createdAt: 2000 });
+    expect(dedupeTripsByDeviceToken([older, newer])).toEqual([newer]);
+    expect(dedupeTripsByDeviceToken([newer, older])).toEqual([newer]);
+  });
+
+  it('다른 deviceToken은 서로 영향 없이 모두 유지', () => {
+    const a = makeTrip({ token: 'a', deviceToken: 'dev-a', createdAt: 1000 });
+    const b = makeTrip({ token: 'b', deviceToken: 'dev-b', createdAt: 1000 });
+    expect(dedupeTripsByDeviceToken([a, b])).toEqual([a, b]);
+  });
+
+  it('deviceToken 있는 trip과 없는 trip이 섞여도 없는 쪽은 항상 유지', () => {
+    const legacy = makeTrip({ token: 'legacy', deviceToken: undefined, createdAt: 1000 });
+    const older = makeTrip({ token: 'old', deviceToken: 'dev-1', createdAt: 1000 });
+    const newer = makeTrip({ token: 'new', deviceToken: 'dev-1', createdAt: 2000 });
+    expect(dedupeTripsByDeviceToken([legacy, older, newer])).toEqual([legacy, newer]);
+  });
+
+  it('빈 배열은 빈 배열', () => {
+    expect(dedupeTripsByDeviceToken([])).toEqual([]);
   });
 });

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -125,7 +125,15 @@ import {
   accumulateBoardingPromptCounters,
   readBoardingPromptCounters,
 } from './boardingPromptCounterAccumulator';
-import { getTrip, putTrip, rotateTripTokenForNewRoute, withTripRegisterLock } from './trips';
+import {
+  cleanupSupersededTrip,
+  getDeviceTripIndex,
+  getTrip,
+  putDeviceTripIndex,
+  putTrip,
+  rotateTripTokenForNewRoute,
+  withTripRegisterLock,
+} from './trips';
 import { inferWaypointsFromOriginAndDestination } from './dijkstraRoute';
 import { checkTripRegisterRateLimit } from './tripRegisterRateLimit';
 import {
@@ -681,12 +689,24 @@ app.post('/trips', async (c) => {
     // #1663 — Seoul outage로 강제 종료된 trip은 cooldown 면제. 사용자가 재등록하면 즉시 허용.
     // 원래 #1425 cooldown 목적(device race/자동 재시도 차단)과 충돌 없음 — outage false-end는
     // 사용자 명시 재등록이며, 같은 token의 device race가 아니다.
-    if (recentlyEnded.endReason === 'seoul-outage') {
+    //
+    // #2175 — 'rotated'/'superseded-by-reregister'도 같은 이유로 면제한다. ADR-022 B4 로테이션은
+    // `trip.token`(신원)만 UUID로 바꿀 뿐 device는 계속 실 deviceToken(=여기 incoming.token)으로
+    // 정상 재등록한다(#2174 comment 1) — 이건 device race/자동 재시도가 아니라 매 route 변경마다
+    // 발생하는 예상된 흐름이다. 면제하지 않으면 rotation이 스스로 남긴 'rotated' sentinel이 다음
+    // 실토큰 재-POST를 1시간 동안 400으로 차단해, 애초 이 이슈가 막으려는 "orphan 누적"보다 더
+    // 나쁜 "재등록 완전 차단" 회귀가 생긴다.
+    if (
+      recentlyEnded.endReason === 'seoul-outage' ||
+      recentlyEnded.endReason === 'rotated' ||
+      recentlyEnded.endReason === 'superseded-by-reregister'
+    ) {
       console.log(
         JSON.stringify({
-          msg: 'trip-recently-ended: bypass cooldown (seoul-outage) (#1663)',
+          msg: 'trip-recently-ended: bypass cooldown (#1663/#2175)',
           tokenPrefix: tokenPrefix(incoming.token),
           endedAt: recentlyEnded.endedAt,
+          endReason: recentlyEnded.endReason,
           ageMs: Date.now() - recentlyEnded.endedAt,
         }),
       );
@@ -714,10 +734,25 @@ app.post('/trips', async (c) => {
   // 전체를 원본 incoming token 기준으로 직렬화 — rotation이 token을 바꿔도 lock key는 요청
   // 도착 시점의 원본 token으로 고정해 같은 device의 두 요청이 반드시 같은 큐에서 대기한다.
   const registerLockToken = incoming.token;
-  const { trip, isSameSession } = await withTripRegisterLock(
+  const { trip, isSameSession, staleIndexedToken } = await withTripRegisterLock(
     registerLockToken,
     async () => {
-      const rawExisting = await getTrip(c.env.TRIPS, incoming.token);
+      const directExisting = await getTrip(c.env.TRIPS, incoming.token);
+
+      // #2175 — deviceToken 역인덱스 fallback. ADR-022 B4 로테이션이 `trip.token`을 UUID로
+      // 교체하면 직접 키 조회(`trip:<incoming.token>`, incoming.token은 항상 실 deviceToken)는
+      // 더 이상 그 trip을 찾지 못한다(#2174 comment: device가 응답의 rotated UUID를 채택하지
+      // 않고 계속 실 deviceToken으로 재-POST). 직접 조회가 miss일 때만 역인덱스로 재발견 —
+      // 직접 조회가 이미 성공했으면(대부분의 등록) 역인덱스 조회를 건너뛰어 오버헤드가 없다.
+      const priorIndexedToken =
+        directExisting === null && incoming.deviceToken !== undefined
+          ? await getDeviceTripIndex(c.env.TRIPS, incoming.deviceToken)
+          : null;
+      const rawExisting =
+        directExisting ??
+        (priorIndexedToken !== null && priorIndexedToken !== incoming.token
+          ? await getTrip(c.env.TRIPS, priorIndexedToken)
+          : null);
 
       // ADR-022 B4 (#2019 wire, #1986 rotation helper) — 새 route 감지 시 token rotation.
       //
@@ -730,7 +765,8 @@ app.post('/trips', async (c) => {
       // rotated=true 케이스 처리:
       //   - `existing = null` 로 강등해 downstream `isSameSession=false` + progress skip 경로 진입
       //     (helper 가 이미 `trip:<oldToken>` 을 delete 했으므로 same-session merge 는 무의미).
-      //   - `incoming.token` 을 새 UUID 로 갱신 → 후속 `putTrip` 이 `trip:<newToken>` 키로 쓴다.
+      //   - `incoming.token` 을 새 UUID(또는 #2175: 역인덱스로 재발견한 existing.token)로 갱신 →
+      //     후속 `putTrip` 이 그 키로 쓴다.
       //   - progress/SSoT KV(oldToken 키) 는 TTL 로 자연 만료 — 후속 cron push 는 새 token trip
       //     기준 waypoints/destination 을 참조하므로 사용자에게 이전 목적지 push 재발사 없음.
       //
@@ -753,8 +789,11 @@ app.post('/trips', async (c) => {
             newTokenPrefix: tokenPrefix(rotation.token),
           }),
         );
-        incoming.token = rotation.token;
       }
+      // #2175 — merge 분기(같은 route, `rawExisting`을 역인덱스로 재발견)도 이제
+      // `rotation.token === existing.token`을 반환하므로 항상 채택한다. brand-new 등록/
+      // 직접 키 매치처럼 `existing`이 `incoming`과 동일 token이면 무변화.
+      incoming.token = rotation.token;
       const existing = rotation.rotated ? null : rawExisting;
       const isSameSession = existing !== null && evaluateSameSession(existing, incoming);
     // #916 follow-up B — auto-prompt dedup 마커 보존. isSameSession=true(같은 trip 재등록)인 경우만
@@ -865,9 +904,47 @@ app.post('/trips', async (c) => {
 
       await putTrip(c.env.TRIPS, trip);
 
-      return { trip, isSameSession };
+      // #2175 — deviceToken 역인덱스를 이번에 확정된 trip.token으로 갱신. 다음 등록(같은 route
+      // merge든 새 route rotation이든)이 이 값으로 직접 키 조회 miss를 해소한다. deviceToken이
+      // 없는(손상 payload) 경우는 기록하지 않는다 — index는 always-valid 64-hex 여부와 무관하게
+      // "등록 시점의 실 토큰"만 추적하면 되므로 `resolveTripDeviceToken`의 legacy fallback은
+      // 여기 적용하지 않는다.
+      if (trip.deviceToken !== undefined) {
+        await putDeviceTripIndex(c.env.TRIPS, trip.deviceToken, trip.token, trip.expiresAt);
+      }
+
+      // #2175 (P1-A #2184 리뷰) — 등록 성공 전 역인덱스가 가리키던 trip이 이번 확정 trip과
+      // 다르면(merge/rotation 모두 이미 그 trip을 채택하거나 정리했을 것이므로 정상 경로에선
+      // 이 시점에 이미 삭제돼 있다) 안전망으로 한 번 더 조회 후 잔존 시 정리한다. 스코프는
+      // 항상 같은 deviceToken(이 역인덱스 자체가 그 deviceToken 소유)이라 다른 device trip은
+      // 건드리지 않는다.
+      const staleIndexedToken =
+        priorIndexedToken !== null && priorIndexedToken !== trip.token ? priorIndexedToken : null;
+
+      return { trip, isSameSession, staleIndexedToken };
     },
   );
+
+  if (staleIndexedToken !== null) {
+    const staleTrip = await getTrip(c.env.TRIPS, staleIndexedToken);
+    if (staleTrip !== null) {
+      console.log(
+        JSON.stringify({
+          msg: 'trip-register: superseded orphan cleanup (#2175)',
+          deviceTokenPrefix: tokenPrefix(registerLockToken),
+          staleTokenPrefix: tokenPrefix(staleIndexedToken),
+          finalTokenPrefix: tokenPrefix(trip.token),
+        }),
+      );
+      await cleanupSupersededTrip(
+        c.env.TRIPS,
+        staleTrip,
+        'superseded-by-reregister',
+        Date.now(),
+        c.env.DB,
+      );
+    }
+  }
 
   // #2144 — register 성공(putTrip 완료) 후 같은 token의 옛 tripStatus 종료 마커를 정리한다.
   // 위 cooldown 판정(#1425 reject / #1663 seoul-outage bypass)이 이미 끝난 뒤라 cooldown 의미는
@@ -2151,6 +2228,33 @@ app.get('/trips/:tripToken/status', async (c) => {
       endedAt: null,
       endReason: null,
     });
+  }
+
+  // #2175 — device는 항상 실 deviceToken(=최초 등록 시 token)으로 조회한다(#2174 comment 1).
+  // 직접 키 조회가 miss여도 ADR-022 B4 로테이션으로 trip.token이 UUID로 바뀌었을 수 있다.
+  // deviceToken 역인덱스가 "현재 실제 trip.token"을 추적하므로 그 값으로 재조회해 2회차 이상
+  // 로테이션(oldToken이 이미 UUID)에서도 active/ended를 정확히 해소한다(#2174 comment 2 escape
+  // hatch, PR #2184 P1 완결 지점).
+  const indexedToken = await getDeviceTripIndex(c.env.TRIPS, tripToken);
+  if (indexedToken !== null && indexedToken !== tripToken) {
+    const indexedTrip = await getTrip(c.env.TRIPS, indexedToken);
+    if (indexedTrip) {
+      return c.json({
+        tripToken,
+        status: 'active' as const,
+        endedAt: null,
+        endReason: null,
+      });
+    }
+    const indexedEnded = await readTripEndedStatus(c.env.TRIPS, indexedToken);
+    if (indexedEnded && now - indexedEnded.endedAt <= TRIP_STATUS_RETENTION_MS) {
+      return c.json({
+        tripToken,
+        status: 'ended' as const,
+        endedAt: indexedEnded.endedAt,
+        endReason: indexedEnded.endReason,
+      });
+    }
   }
 
   const ended = await readTripEndedStatus(c.env.TRIPS, tripToken);

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -80,7 +80,7 @@ import {
   readFreshSelfPollPosition,
 } from './selfPollPosition';
 import { phaseAllowsImminentFiring, runStationPhaseStep } from './stationPhase';
-import { listTrips, putTrip, resolveTripDeviceToken } from './trips';
+import { dedupeTripsByDeviceToken, listTrips, putTrip, resolveTripDeviceToken } from './trips';
 import {
   evaluateTransferDestinationGate,
   isTransferOrDestination,
@@ -1097,10 +1097,16 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
   // #2073 (Issue B) — listTrips 3중 호출(collectActiveLines/collectActiveStations/main loop 각자)을
   // 1회 병합. 전체 trip을 배열로 확보해 아래 파생 함수 + main loop가 모두 이 배열을 재사용한다.
   // 감축: list 5→3/tick, 활성 시 trip get 3N→N.
-  const trips: Trip[] = [];
+  const scannedTrips: Trip[] = [];
   for await (const trip of listTrips(env.TRIPS)) {
-    trips.push(trip);
+    scannedTrips.push(trip);
   }
+  // #2175 — register-time deviceToken 역인덱스 merge/cleanup(#2184 리뷰 P1)에 대한 cron
+  // 안전망. KV eventual consistency 등으로 같은 deviceToken의 active trip이 순간적으로 2개 이상
+  // 존재해도, cron이 orphan에 대해서도 실 deviceToken으로 push를 발사(#2184 resolveTripDeviceToken)
+  // 하는 중복 발송을 막기 위해 매 tick 최신(createdAt) trip만 처리 대상으로 남긴다. deviceToken이
+  // 없는(legacy) trip은 그대로 통과.
+  const trips: Trip[] = dedupeTripsByDeviceToken(scannedTrips);
 
   // #2073 (Issue A) — 진짜 idle 판정. 활성 trip이 하나도 없고, 직전 tick 근방 fire/retry 기록도
   // 없으면 pending/retry push가 존재할 수 없다(모든 fire 경로가 trip 기반이므로 trip 부재 tick엔

--- a/backend/alarm-worker/src/tripStatus.ts
+++ b/backend/alarm-worker/src/tripStatus.ts
@@ -25,7 +25,10 @@ const TRIP_STATUS_PREFIX = 'tripStatus:';
  *   실 deviceToken으로 GET /trips/:token/status를 조회하는 device가(#2174 comment 1: 로테이션 직후
  *   trip.token이 바뀌어도 device는 여전히 실 deviceToken으로 조회) 첫 로테이션 한정으로 이 사유를
  *   확인해 'ended'로 사망 인지할 수 있다 — 2회차 이상 로테이션(oldToken이 이미 UUID)의 완전한
- *   deviceToken 역인덱스 조회는 #2175로 위임.
+ *   deviceToken 역인덱스 조회는 #2175가 `GET /trips/:token/status` 핸들러에 배선(trips.ts
+ *   `getDeviceTripIndex`)해 완결한다.
+ * `superseded-by-reregister` (#2175) — deviceToken 역인덱스로 발견한 같은 deviceToken의 다른
+ *   active trip을 신규 등록 성공 시 정리한 사유.
  */
 export type TripStatusEndReason =
   | 'expired'
@@ -33,7 +36,8 @@ export type TripStatusEndReason =
   | 'seoul-outage'
   | 'destination'
   | 'push-unrecoverable'
-  | 'rotated';
+  | 'rotated'
+  | 'superseded-by-reregister';
 
 export interface TripStatusRecord {
   endedAt: number;
@@ -119,7 +123,8 @@ export async function readTripEndedStatus(
       parsed.endReason !== 'seoul-outage' &&
       parsed.endReason !== 'destination' &&
       parsed.endReason !== 'push-unrecoverable' &&
-      parsed.endReason !== 'rotated'
+      parsed.endReason !== 'rotated' &&
+      parsed.endReason !== 'superseded-by-reregister'
     ) {
       return null;
     }

--- a/backend/alarm-worker/src/trips.ts
+++ b/backend/alarm-worker/src/trips.ts
@@ -7,7 +7,7 @@ import {
 } from './kvConsistency';
 import { listPending, pendingKey } from './pendingPushes';
 import { writeTripEndedStatus } from './tripStatus';
-import type { Trip } from './types';
+import type { Trip, TripEndedReason } from './types';
 
 /**
  * KV CRUD for active trips.
@@ -126,6 +126,51 @@ export async function getTrip(
 
 export async function deleteTrip(kv: KVNamespace, token: string): Promise<void> {
   await kv.delete(tripKey(token));
+}
+
+/**
+ * #2175 — deviceToken → 현재 trip.token 역인덱스.
+ *
+ * ADR-022 B4 로테이션이 `trip.token`을 `crypto.randomUUID()`로 교체하면, `POST /trips`가
+ * `getTrip(incoming.token)`(incoming.token은 항상 실 deviceToken — 클라는 응답의 rotated UUID를
+ * 채택하지 않는다, #2174 코멘트)로 직전 로테이션의 UUID trip을 찾지 못해 매번 새 trip이 생성되고
+ * old UUID trip은 orphan으로 남는다. 이 역인덱스가 "실 deviceToken이 가리키는 현재 trip.token"을
+ * 별도 KV entry(`device-trips:<deviceToken>`)로 추적해, 직접 키 조회가 실패해도 로테이션된 trip을
+ * 재발견할 수 있게 한다.
+ *
+ * Key: `device-trips:<deviceToken>` (raw deviceToken을 그대로 키 접미사로 사용 — `trip:<token>`이
+ * 이미 raw token을 KV 키로 사용하는 기존 정책과 동일. `hashTripToken`(FNV-1a 32bit)은 Sentry/D1
+ * PII 마스킹 목적의 비가역 축약이라 KV lookup key로 쓰면 충돌 시 다른 device의 trip을 잘못
+ * 반환할 위험이 있어 부적합 — exact match가 필요한 이 경로는 raw 값을 쓴다).
+ * Value: 최신 trip.token (plain string, JSON 아님 — 단일 스칼라라 파싱 오버헤드 불필요).
+ *
+ * TTL은 가리키는 trip의 `expiresAt`과 정렬 — trip이 자연 만료되면 역인덱스도 함께 사라진다.
+ */
+const DEVICE_TRIP_INDEX_PREFIX = 'device-trips:';
+
+export function deviceTripIndexKey(deviceToken: string): string {
+  return `${DEVICE_TRIP_INDEX_PREFIX}${deviceToken}`;
+}
+
+export async function putDeviceTripIndex(
+  kv: KVNamespace,
+  deviceToken: string,
+  tripToken: string,
+  expiresAt: number,
+): Promise<void> {
+  const ttlSec = Math.max(60, Math.floor((expiresAt - Date.now()) / 1000));
+  await kv.put(deviceTripIndexKey(deviceToken), tripToken, { expirationTtl: ttlSec });
+}
+
+export async function getDeviceTripIndex(
+  kv: KVNamespace,
+  deviceToken: string,
+): Promise<string | null> {
+  return kv.get(deviceTripIndexKey(deviceToken));
+}
+
+export async function deleteDeviceTripIndex(kv: KVNamespace, deviceToken: string): Promise<void> {
+  await kv.delete(deviceTripIndexKey(deviceToken));
 }
 
 export async function* listTrips(kv: KVNamespace): AsyncGenerator<Trip> {
@@ -270,16 +315,23 @@ export async function rotateTripTokenForNewRoute(
   if (existing === null) {
     return { token: incoming.token, rotated: false };
   }
-  // 같은 route (destination + waypoints 시그니처 일치): incoming token 유지 → same-session merge.
+  // 같은 route (destination + waypoints 시그니처 일치): existing token으로 merge.
+  //
+  // #2175 — 과거엔 여기서 `incoming.token`을 그대로 반환했다. `existing`이 항상 직접 키 조회
+  // (`getTrip(incoming.token)`)로만 발견되던 시절엔 `existing.token === incoming.token`이 항상
+  // 성립해 무해했지만, `POST /trips` 핸들러가 이제 deviceToken 역인덱스로 `existing`을 재발견할
+  // 수 있어(직접 키 조회 miss 시 fallback) 이 경우 `existing.token`(예: 이전 로테이션 UUID)이
+  // `incoming.token`(원본 실 deviceToken)과 달라진다. `incoming.token`을 반환하면 실 deviceToken
+  // 키로 새 trip이 또 생성돼 이미 존재하는 UUID trip과 함께 유령 2개가 남는다 — `existing.token`을
+  // 반환해 항상 같은 KV 레코드로 merge되도록 고정한다.
   const existingSig = computeRouteSignature(existing);
   const incomingSig = computeRouteSignature(incoming);
   if (existingSig === incomingSig) {
-    return { token: incoming.token, rotated: false };
+    return { token: existing.token, rotated: false };
   }
   // 다른 route: 새 token 발급 + old 정리.
   const generateToken = deps?.generateToken ?? (() => crypto.randomUUID());
   const newToken = generateToken();
-  const oldToken = existing.token;
   const rotatedAt = deps?.now ?? Date.now();
   // #2174 F2 — old trip 삭제가 관측 blind hole이었다(raw KV delete, D1/sentinel 미기록 →
   // 사후 RCA 완전 비가시, 2026-08-06 진단 지연 직접 원인). cleanupTripWithLa(liveActivity.ts)를
@@ -287,15 +339,61 @@ export async function rotateTripTokenForNewRoute(
   // route 변경(F1: 환승 waypoint trim/목적지 변경 재-POST)마다 로테이션이 발동하므로 매번 종료
   // alert가 뜨면 사용자 경험 회귀다. 여기서는 push-unrecoverable/user-delete와 구분되는 관측
   // 전용 사유 'rotated'로 D1 기록 + tripStatus sentinel만 남긴다(alert push 없음).
-  await recordTripMetrics(deps?.db, existing, 'rotated', rotatedAt);
-  try {
-    await writeTripEndedStatus(kv, oldToken, 'rotated', rotatedAt);
-  } catch {
-    // best-effort — sentinel 기록 실패가 rotation 자체를 막지 않는다(다른 tripStatus 호출자와 동일 정책).
-  }
-  await deleteTrip(kv, oldToken);
-  await cleanupPendingPushesForToken(kv, oldToken);
+  await cleanupSupersededTrip(kv, existing, 'rotated', rotatedAt, deps?.db);
   return { token: newToken, rotated: true };
+}
+
+/**
+ * #2175 — 다른(superseded) trip의 관측 기록 + KV 정리 단일 지점.
+ *
+ * `rotateTripTokenForNewRoute`의 route-변경 cleanup과, `POST /trips` 핸들러가 deviceToken 역인덱스로
+ * 발견한 orphan trip(같은 deviceToken의 다른 active trip, `superseded-by-reregister`)이 공유한다.
+ * D1 기록(`recordTripMetrics`) → tripStatus sentinel(`writeTripEndedStatus`, best-effort) →
+ * `trip:<token>` delete → `pending:*` 잔재 cleanup 순서로 동작한다. alert push는 발사하지 않는다
+ * (관측 전용 — `cleanupTripWithLa`와 달리 사용자향 UX 신호 없음, 두 호출자 모두 device 관점에서는
+ * "정상 재등록"이지 사용자에게 알릴 종료가 아니다).
+ */
+export async function cleanupSupersededTrip(
+  kv: KVNamespace,
+  orphan: Trip,
+  reason: TripEndedReason,
+  now: number,
+  db?: D1Database,
+): Promise<void> {
+  await recordTripMetrics(db, orphan, reason, now);
+  try {
+    await writeTripEndedStatus(kv, orphan.token, reason, now);
+  } catch {
+    // best-effort — sentinel 기록 실패가 cleanup 자체를 막지 않는다.
+  }
+  await deleteTrip(kv, orphan.token);
+  await cleanupPendingPushesForToken(kv, orphan.token);
+}
+
+/**
+ * #2175 — cron 안전망. register-time deviceToken 역인덱스 merge/cleanup이 실패하거나(KV
+ * eventual consistency, 예상 못한 race) 실행 전이라 같은 deviceToken의 active trip이 KV에 2개
+ * 이상 동시 존재하는 경우, cron이 둘 다에 push를 발사(#2184 `resolveTripDeviceToken`가 orphan도
+ * 실 deviceToken으로 발사)하는 회귀를 막는다. deviceToken 없는(legacy) trip은 그룹핑 대상에서
+ * 제외하고 그대로 통과시킨다 — 하위호환.
+ *
+ * 정책: 같은 deviceToken 그룹에서 `createdAt`이 가장 최신인 trip만 유지, 나머지는 이번 cron
+ * tick 처리에서 제외한다(스캔 skip — cron 자체가 KV를 수정하지는 않는다, register-time 경로가
+ * 최종 정리를 담당).
+ */
+export function dedupeTripsByDeviceToken(trips: readonly Trip[]): Trip[] {
+  const latestByDevice = new Map<string, Trip>();
+  for (const trip of trips) {
+    if (trip.deviceToken === undefined) continue;
+    const current = latestByDevice.get(trip.deviceToken);
+    if (!current || trip.createdAt > current.createdAt) {
+      latestByDevice.set(trip.deviceToken, trip);
+    }
+  }
+  return trips.filter((trip) => {
+    if (trip.deviceToken === undefined) return true;
+    return latestByDevice.get(trip.deviceToken) === trip;
+  });
 }
 
 /**

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -442,6 +442,10 @@ export interface ReschedulePushPayload {
  *                       old trip을 폐기한 사유. push-unrecoverable/user-delete와 구분되는 관측
  *                       전용 사유 — alert push는 발사하지 않는다(사용자 명시 route 변경 자체가
  *                       trip 전환의 정상 신호라 종료 알림 UX가 불필요).
+ *   - 'superseded-by-reregister' (#2175) — deviceToken 역인덱스로 재발견한 같은 deviceToken의
+ *                       다른 active trip을 신규 등록 성공 시 정리한 사유. `push-unrecoverable`
+ *                       (APNs 영구 실패)과 구분되는 관측 전용 사유 — 이 경로도 'rotated'와 동일하게
+ *                       alert push를 발사하지 않는다.
  *
  * 클라가 명시적으로 trip을 끝낸 경로(HTTP DELETE /trips/:token)는 발사 대상이 아님 —
  * 사용자가 destination을 clear하면 이미 클라이언트 store가 정리된 상태이기 때문.
@@ -453,7 +457,8 @@ export type TripEndedReason =
   | 'expired'
   | 'push-unrecoverable'
   | 'la-stale-backstop'
-  | 'rotated';
+  | 'rotated'
+  | 'superseded-by-reregister';
 
 /**
  * Trip ended alert push payload (#1337). server-side trip 자동 종료 시 발사되는 alert push의


### PR DESCRIPTION
Closes #2175 · Part of #2172 · #2184 리뷰 P1 해소

## 요약

`POST /trips`는 `getTrip(incoming.token)`(incoming.token=실 deviceToken)으로만 기존 trip을 조회한다(index.ts:718 부근). ADR-022 B4 로테이션(`rotateTripTokenForNewRoute`)이 route 변경 시 `trip.token`을 `crypto.randomUUID()`로 교체하면, 이후 같은 실토큰으로 재-POST해도 직접 키 조회는 새 UUID trip을 찾지 못해 **매번 새 trip이 생성되고 직전 로테이션의 UUID trip은 orphan으로 누적**된다(08-06 하루 4건 관측). device가 POST 응답의 rotated UUID를 채택하지 않는 것도 확인됨(발산 지속 원인).

#2184 리뷰 P1 시퀀스로 재현·검증:
1. 실토큰 등록 → route 변경 재-POST → 로테이션(`trip:<실토큰>` 삭제 + `trip:<UUID>` 생성)
2. 클라가 또 실토큰으로 재-POST(route 동일, lock/ETA 변동 등) → `getTrip(실토큰)` miss
3. 수정 전: rotation 로직을 건너뛰고 신규 `trip:<실토큰>` 생성 → `trip:<UUID>`(고아)와 `trip:<실토큰>`(현재) 둘 다 live → cron이 둘 다 같은 실 deviceToken으로 push 중복 발사(#2129가 막았던 유령 2개 증상의 key-space 재도입)

## 변경 사항

1. **`trips.ts`** — `deviceToken → trip.token` 역인덱스 신설(`device-trips:<deviceToken>`, raw 키 — `trip:<token>`이 이미 raw token을 키로 쓰는 기존 정책과 동일. `hashTripToken`은 PII 마스킹용 비가역 축약이라 exact-match가 필요한 이 경로엔 부적합).
   - `putDeviceTripIndex`/`getDeviceTripIndex`/`deleteDeviceTripIndex`
   - `rotateTripTokenForNewRoute`의 같은-route merge 분기를 `incoming.token` 대신 **`existing.token`** 반환으로 수정 — 역인덱스로 재발견한 `existing`이 `incoming`과 다른 토큰(직전 로테이션 UUID)일 때 기존 코드는 `incoming.token`으로 새 KV entry를 또 만들어 유령 2개를 재도입했다.
   - `cleanupSupersededTrip` 공유 helper — rotation의 old-trip cleanup과 신규 `superseded-by-reregister` cleanup이 공유(D1 기록 → sentinel → delete → pending cleanup 순서 통일).
   - `dedupeTripsByDeviceToken` — cron 안전망 pure 함수(아래 5번).
2. **`index.ts` `POST /trips`** — 직접 키 조회(`getTrip(incoming.token)`) miss 시 deviceToken 역인덱스로 existing을 재발견(fallback). 등록 성공 시 역인덱스를 최종 확정 `trip.token`으로 갱신하고, 역인덱스가 가리키던 이전 trip이 최종 trip과 다르면(정상 경로에선 이미 rotation이 정리했을 것) 안전망으로 `superseded-by-reregister` 사유로 재정리한다.
3. **`index.ts` `POST /trips` — #1425 쿨다운 면제 확장**: rotation이 남기는 `'rotated'` sentinel이 다음 실토큰 재-POST를 1시간 동안 400으로 막는 회귀를 새 테스트로 발견 — `'rotated'`/`'superseded-by-reregister'`도 `'seoul-outage'`와 같은 이유(사용자 명시 액션, device race 아님)로 쿨다운 면제.
4. **`index.ts` `GET /trips/:tripToken/status`** — 직접 키 조회 miss 시 deviceToken 역인덱스로 현재/최근 trip을 재조회. 2회차 이상 로테이션(oldToken이 이미 UUID)에서도 실토큰 조회로 active/ended를 정확히 해소(#2174 코멘트 2 escape hatch 완결, #2178 device pull 백스톱의 전제 충족).
5. **`scheduled.ts`** — cron 안전망 `dedupeTripsByDeviceToken`: register-time merge/cleanup이 KV eventual consistency 등으로 실패해 같은 deviceToken의 active trip이 순간적으로 2개 이상 존재해도, 매 tick 최신(createdAt) trip만 처리해 orphan에 대한 중복 push 발사를 차단. deviceToken 없는 legacy trip은 그대로 통과.
6. **`types.ts`/`tripStatus.ts`** — `TripEndedReason`/`TripStatusEndReason`에 `'superseded-by-reregister'` 추가.

## 금지사항 준수

- 다른 device trip 접근 금지 — 스코프는 항상 역인덱스 자신이 소유한 동일 deviceToken.
- cleanup 사유 재사용 금지 — `'rotated'`(기존)와 구분되는 신규 `'superseded-by-reregister'` 상수 도입.
- 디바이스 측(Tier1 heal double-POST) 수정 없음 — backend만 변경.

## 테스트 (red-green)

- red: "로테이션 후 실 토큰 재등록 → active trip 2개 병존" 재현 → green: 옛 trip superseded 회수(`trips.test.ts` `#2175 — 같은 route, existing.token !== incoming.token`, `index.test.ts` P1 시나리오 3종).
- 동일 토큰 재등록(기존 경로) 회귀 없음 — 기존 rotation/merge 테스트 전량 pass.
- `index.test.ts`: P1 시퀀스 재현(고아 미생성, 2회 연속 로테이션 무누적, superseded 안전망 sentinel), GET status 2회+ 로테이션 active/ended 해소 2건.
- `trips.test.ts`: 역인덱스 CRUD, `cleanupSupersededTrip`, `dedupeTripsByDeviceToken` 단위 테스트.
- `scheduled.test.ts`: cron dedup 안전망 2건(중복 스캔 제외, legacy trip 통과).
- `#1425` 쿨다운 면제 확장 발견 및 회귀 테스트 포함(면제 없이는 재등록이 1시간 400으로 막힘).

## Wire-completion 5단

1. **Orphan**: `npm run lint:orphan` 0건(frontend 전용 스캔이라 backend 파일은 대상 아님 — PR #2184와 동일). 신규 export(`putDeviceTripIndex` 등) 전부 `index.ts`/`scheduled.ts`/테스트가 즉시 소비.
2. **V/X dashboard**: wrangler tail/Cloudflare Dashboard에서 `trip-register: superseded orphan cleanup (#2175)` 로그로 회수 빈도 관측. D1 `trip_metrics` 테이블 `end_reason='superseded-by-reregister'` row로 orphan 회수 건수 확인 가능(Cloudflare D1 dashboard 쿼리).
3. **의존 PR**: #2174(머지됨) 이후 순서. **머지 후 wrangler deploy 필수**.
4. **측정 plan**: 배포 후 1주 — D1에서 동일 deviceToken 동시 active trip 0건 확인(KV list `device-trips:*` vs `trip:*` cross-check), `end_reason='superseded-by-reregister'`/`'rotated'` row 추이로 로테이션 빈도 대비 orphan 회수율 확인.
5. **Device verify**: N/A — backend unit + D1 확인. Epic #2172 close 조건과 공유 — 로테이션 재활성 상태에서 환승 mid-trip route 변경 실탑승 검증 필요.
