### PR TITLE
fix(#2175): DELETE /trips 역인덱스 fallback + 인덱스 정리 배선 — #2186 리뷰 P1 복구

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1627,6 +1627,69 @@ describe('DELETE /trips/:token — LA dismissal (#586 D)', () => {
     expect(await res.json()).toEqual({ ok: true, deleted: true });
     expect(await env.TRIPS.get('trip:tok-d')).toBeNull();
   });
+
+  // 리뷰 P1 (#2186) — 직접 삭제 성공 시에도 deviceToken 역인덱스를 함께 정리한다.
+  it('직접 삭제 시 deviceToken 역인덱스도 함께 정리한다', async () => {
+    const env = makeKvEnv();
+    await post('/trips', { ...base(), token: 'tok-direct', createdAt: CREATED }, env);
+    expect(await env.TRIPS.get('device-trips:tok-direct')).toBe('tok-direct');
+    const res = await del('/trips/tok-direct', env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, deleted: true });
+    expect(await env.TRIPS.get('device-trips:tok-direct')).toBeNull();
+  });
+});
+
+// 리뷰 확정 P1 (#2186) — DELETE /trips/:token이 getTrip(token) 직접 키 조회만 해서, ADR-022 B4
+// 로테이션 이후 실토큰 DELETE가 miss → { ok:true, deleted:false } no-op → trip:<uuid> 고아가
+// 계속 push를 발사하는 회귀. GET /trips/:token/status(#2175)와 동일한 역인덱스 fallback을 DELETE
+// 에도 배선해 사용자의 명시적 clear가 실제로 orphan trip을 회수하도록 한다.
+describe('DELETE /trips/:token — deviceToken 역인덱스 fallback (리뷰 P1, #2186)', () => {
+  const TOKEN = 'tok-2186-real';
+
+  function tripBodyFor(destination: string, stationName: string): Record<string, unknown> {
+    return {
+      ...base(),
+      token: TOKEN,
+      destination,
+      waypoints: [{ stationName, line: '2', kind: 'destination' }],
+    };
+  }
+
+  it('로테이션 이후 실토큰 DELETE가 직접 키 miss여도 역인덱스로 UUID trip을 찾아 삭제한다', async () => {
+    const env = makeKvEnv();
+    await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
+    await post('/trips', tripBodyFor('용마산-id', '용마산'), env);
+    const res2 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
+    const uuid1 = ((await res2.json()) as { token: string }).token;
+    expect(uuid1).not.toBe(TOKEN);
+    // 수정 전 회귀 재현: 직접 키(trip:TOKEN)는 로테이션이 이미 지웠고, orphan은 trip:<uuid1>에 산다.
+    expect(await env.TRIPS.get(`trip:${TOKEN}`)).toBeNull();
+    expect(await env.TRIPS.get(`trip:${uuid1}`)).not.toBeNull();
+
+    const res = await del(`/trips/${TOKEN}`, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, deleted: true });
+    // orphan UUID trip이 실제로 삭제된다 — 수정 전엔 no-op으로 계속 생존해 push를 발사했다.
+    expect(await env.TRIPS.get(`trip:${uuid1}`)).toBeNull();
+    // 역인덱스도 함께 정리된다.
+    expect(await env.TRIPS.get(`device-trips:${TOKEN}`)).toBeNull();
+  });
+
+  it('역인덱스도 없으면 기존대로 idempotent 200 deleted:false', async () => {
+    const env = makeKvEnv();
+    const res = await del('/trips/never-registered', env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, deleted: false });
+  });
+
+  it('역인덱스는 있지만 가리키는 trip도 이미 사라졌으면 idempotent 200 deleted:false', async () => {
+    const env = makeKvEnv();
+    await env.TRIPS.put(`device-trips:${TOKEN}`, 'ghost-uuid');
+    const res = await del(`/trips/${TOKEN}`, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, deleted: false });
+  });
 });
 
 describe('Live Activity endpoints (#586 C)', () => {

--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -13,6 +13,7 @@ import {
   type LiveActivityStats,
 } from '../liveActivity';
 import { readSsot, seedSsot } from '../tripPositionSsot';
+import { getDeviceTripIndex, putDeviceTripIndex } from '../trips';
 import type { ApnsEnv, Env, Trip, TripEndedReason, Waypoint } from '../types';
 import { InMemoryKV } from './inMemoryKv';
 
@@ -654,6 +655,55 @@ describe('cleanupTripWithLa', () => {
     );
     expect(fetchImpl).not.toHaveBeenCalled();
     expect(await kv.get('trip:devtoken')).toBeNull();
+  });
+
+  // 리뷰 P1 (#2175/#2186) — trip이 소유한 deviceToken 역인덱스도 함께 정리돼야 종료 후 인덱스가
+  // 죽은 token을 계속 가리키는 고아로 남지 않는다.
+  it('trip.deviceToken이 있고 인덱스가 여전히 이 trip.token을 가리키면 인덱스도 함께 삭제한다', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({ deviceToken: 'device-devtoken' });
+    await kv.put('trip:devtoken', JSON.stringify(trip));
+    await putDeviceTripIndex(
+      kv as unknown as KVNamespace,
+      'device-devtoken',
+      'devtoken',
+      NOW + 3_600_000,
+    );
+    const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+    await cleanupTripWithLa(
+      trip,
+      env,
+      makeDeps(vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch),
+      makeStats(),
+      NOW,
+      () => undefined,
+    );
+    expect(await getDeviceTripIndex(kv as unknown as KVNamespace, 'device-devtoken')).toBeNull();
+  });
+
+  it('인덱스가 이미 다른(최신) token을 가리키면 지우지 않는다 (race guard)', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({ deviceToken: 'device-devtoken' });
+    await kv.put('trip:devtoken', JSON.stringify(trip));
+    // 다른 요청이 이미 로테이션된 새 trip으로 인덱스를 갱신한 상태를 시뮬레이션.
+    await putDeviceTripIndex(
+      kv as unknown as KVNamespace,
+      'device-devtoken',
+      'newer-uuid-token',
+      NOW + 3_600_000,
+    );
+    const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+    await cleanupTripWithLa(
+      trip,
+      env,
+      makeDeps(vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch),
+      makeStats(),
+      NOW,
+      () => undefined,
+    );
+    expect(await getDeviceTripIndex(kv as unknown as KVNamespace, 'device-devtoken')).toBe(
+      'newer-uuid-token',
+    );
   });
 
   // #1283 — trip-ended push도 다른 push 경로와 동일하게 env-heal 적용.

--- a/backend/alarm-worker/src/__tests__/trips.test.ts
+++ b/backend/alarm-worker/src/__tests__/trips.test.ts
@@ -8,6 +8,7 @@ import {
   computeRouteSignature,
   dedupeTripsByDeviceToken,
   deleteDeviceTripIndex,
+  deleteDeviceTripIndexIfCurrent,
   deleteTrip,
   deviceTripIndexKey,
   getDeviceTripIndex,
@@ -1076,6 +1077,91 @@ describe('cleanupSupersededTrip (#2175)', () => {
     );
     putSpy.mockRestore();
     expect(await getTrip(kv as unknown as KVNamespace, 'orphan-2')).toBeNull();
+  });
+
+  // 리뷰 P1 — deviceToken 역인덱스도 함께 정리돼야 orphan 종료 후 인덱스가 죽은 token을
+  // 계속 가리키지 않는다.
+  it('orphan.deviceToken이 있고 인덱스가 여전히 orphan.token을 가리키면 인덱스도 함께 삭제한다', async () => {
+    const orphan = makeTrip({ token: 'orphan-3', deviceToken: 'device-3' });
+    await putTrip(kv as unknown as KVNamespace, orphan);
+    await putDeviceTripIndex(
+      kv as unknown as KVNamespace,
+      'device-3',
+      'orphan-3',
+      Date.now() + 60 * 60 * 1000,
+    );
+    await cleanupSupersededTrip(
+      kv as unknown as KVNamespace,
+      orphan,
+      'rotated',
+      Date.now(),
+    );
+    expect(await getDeviceTripIndex(kv as unknown as KVNamespace, 'device-3')).toBeNull();
+  });
+
+  it('인덱스가 이미 다른(최신) token을 가리키면 지우지 않는다 (race guard)', async () => {
+    const orphan = makeTrip({ token: 'orphan-4', deviceToken: 'device-4' });
+    await putTrip(kv as unknown as KVNamespace, orphan);
+    // 다른 요청이 이미 새 trip으로 인덱스를 갱신한 상태를 시뮬레이션.
+    await putDeviceTripIndex(
+      kv as unknown as KVNamespace,
+      'device-4',
+      'newer-token',
+      Date.now() + 60 * 60 * 1000,
+    );
+    await cleanupSupersededTrip(
+      kv as unknown as KVNamespace,
+      orphan,
+      'rotated',
+      Date.now(),
+    );
+    expect(await getDeviceTripIndex(kv as unknown as KVNamespace, 'device-4')).toBe(
+      'newer-token',
+    );
+  });
+});
+
+describe('deleteDeviceTripIndexIfCurrent (#2175 리뷰 P1)', () => {
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  it('trip.deviceToken이 undefined면 no-op', async () => {
+    const trip = makeTrip({ token: 'legacy-1', deviceToken: undefined });
+    await deleteDeviceTripIndexIfCurrent(kv as unknown as KVNamespace, trip);
+    expect(await getDeviceTripIndex(kv as unknown as KVNamespace, 'legacy-1')).toBeNull();
+  });
+
+  it('인덱스가 없으면 no-op (에러 없이 통과)', async () => {
+    const trip = makeTrip({ token: 'tok-x', deviceToken: 'device-x' });
+    await expect(
+      deleteDeviceTripIndexIfCurrent(kv as unknown as KVNamespace, trip),
+    ).resolves.toBeUndefined();
+  });
+
+  it('인덱스가 이 trip.token을 가리키면 삭제한다', async () => {
+    const trip = makeTrip({ token: 'tok-y', deviceToken: 'device-y' });
+    await putDeviceTripIndex(
+      kv as unknown as KVNamespace,
+      'device-y',
+      'tok-y',
+      Date.now() + 60 * 60 * 1000,
+    );
+    await deleteDeviceTripIndexIfCurrent(kv as unknown as KVNamespace, trip);
+    expect(await getDeviceTripIndex(kv as unknown as KVNamespace, 'device-y')).toBeNull();
+  });
+
+  it('인덱스가 다른 token을 가리키면 보존한다', async () => {
+    const trip = makeTrip({ token: 'tok-z', deviceToken: 'device-z' });
+    await putDeviceTripIndex(
+      kv as unknown as KVNamespace,
+      'device-z',
+      'tok-other',
+      Date.now() + 60 * 60 * 1000,
+    );
+    await deleteDeviceTripIndexIfCurrent(kv as unknown as KVNamespace, trip);
+    expect(await getDeviceTripIndex(kv as unknown as KVNamespace, 'device-z')).toBe('tok-other');
   });
 });
 

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -2277,9 +2277,23 @@ app.get('/trips/:tripToken/status', async (c) => {
 app.delete('/trips/:token', async (c) => {
   const token = c.req.param('token');
   if (!token) return c.json({ error: 'missing_token' }, 400);
-  const existing = await getTrip(c.env.TRIPS, token);
+  const directExisting = await getTrip(c.env.TRIPS, token);
+
+  // 리뷰 P1 (#2186) — deviceToken 역인덱스 fallback. ADR-022 B4 로테이션 이후 device는 계속
+  // 실 deviceToken(=여기 token)으로 호출하지만 실제 trip은 rotated UUID 아래 살아있다
+  // (GET /trips/:token/status와 동일한 패턴, #2175 comment). 직접 키 조회가 miss일 때만
+  // 역인덱스로 재발견 — 직접 조회가 성공하면(대부분) 역인덱스 조회를 건너뛴다. 재발견 못하면
+  // (역인덱스도 없거나 이미 정리됨) 기존대로 idempotent 200 deleted:false.
+  const existing =
+    directExisting ??
+    (await (async () => {
+      const indexedToken = await getDeviceTripIndex(c.env.TRIPS, token);
+      if (indexedToken === null || indexedToken === token) return null;
+      return getTrip(c.env.TRIPS, indexedToken);
+    })());
   if (!existing) return c.json({ ok: true, deleted: false });
-  // 활성 LA가 있으면 dismissal push 발사 후 KV 삭제. cleanupTripWithLa가 두 동작을 묶는다.
+  // 활성 LA가 있으면 dismissal push 발사 후 KV 삭제. cleanupTripWithLa가 두 동작을 묶는다
+  // (deviceToken 역인덱스 정리도 그 안에서 함께 처리된다, 리뷰 P1).
   // logger는 worker console.log로 직결 — HTTP-driven cleanup의 dismissal 실패가 silent loss로
   // 사라지지 않게 운영 가시성 확보.
   await cleanupTripWithLa(

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -25,7 +25,7 @@ import { deleteProgress } from './progress';
 import { logPushFailure } from './pushFailureLog';
 import { computeMultiHopContext } from './tripMultiHop';
 import { deleteSsot } from './tripPositionSsot';
-import { deleteTrip, resolveTripDeviceToken } from './trips';
+import { deleteDeviceTripIndexIfCurrent, deleteTrip, resolveTripDeviceToken } from './trips';
 import type { ApnsEnv, Env, Trip, TripEndedReason, Waypoint } from './types';
 import { writeTripEndedStatus } from './tripStatus';
 
@@ -310,6 +310,12 @@ export async function cleanupTripWithLa(
     }
   }
   await deleteTrip(env.TRIPS, trip.token);
+  // 리뷰 P1 (#2175) — 이 trip이 소유한 deviceToken 역인덱스도 함께 정리(현재도 이 trip.token을
+  // 가리킬 때만, race guard는 `deleteDeviceTripIndexIfCurrent` 참고). 정리하지 않으면 로테이션
+  // 이후 trip이 이 경로(만료/도착/HTTP DELETE 등)로 종료될 때마다 인덱스가 이미 사라진
+  // token을 계속 가리켜, 다음 재등록의 직접 키 조회 miss 시 무의미한 역인덱스 조회 1회가
+  // 추가된다(기능 회귀는 아니지만 방치된 고아 인덱스 — 명시 정리로 SSoT를 맞춘다).
+  await deleteDeviceTripIndexIfCurrent(env.TRIPS, trip);
   // #705 — trip을 폐기할 때 progress entry도 함께 제거. TTL이 자연 만료를 보장하지만
   // 즉시 cleanup해야 새 동일 token trip 등록 시 stale shiftedCount가 끼지 않는다.
   await deleteProgress(env.TRIPS, trip.token);

--- a/backend/alarm-worker/src/trips.ts
+++ b/backend/alarm-worker/src/trips.ts
@@ -173,6 +173,28 @@ export async function deleteDeviceTripIndex(kv: KVNamespace, deviceToken: string
   await kv.delete(deviceTripIndexKey(deviceToken));
 }
 
+/**
+ * #2175 (리뷰 P1) — trip 삭제 시 그 trip이 소유한 deviceToken 역인덱스를 함께 정리한다.
+ *
+ * 모든 trip 종료 경로(`cleanupSupersededTrip`, `cleanupTripWithLa`)가 공유하는 단일 지점.
+ * `trip.deviceToken`이 없으면(legacy trip) no-op — 애초에 인덱스가 만들어지지 않았다.
+ *
+ * Race guard: 인덱스가 **지금도** 이 trip의 token을 가리킬 때만 삭제한다. 삭제 사이 다른 요청이
+ * 이미 같은 deviceToken으로 새로 등록해 인덱스를 새 token으로 갱신했다면(`POST /trips`가 매
+ * 등록마다 `putDeviceTripIndex`로 덮어씀) 그 갱신을 덮어쓰지 않는다 — 방금 등록된 활성 trip을
+ * 가리키는 인덱스를 지우면 그 trip이 역인덱스 fallback으로 재발견 불가능해지는 새 회귀가 된다.
+ */
+export async function deleteDeviceTripIndexIfCurrent(
+  kv: KVNamespace,
+  trip: Trip,
+): Promise<void> {
+  if (trip.deviceToken === undefined) return;
+  const current = await getDeviceTripIndex(kv, trip.deviceToken);
+  if (current === trip.token) {
+    await deleteDeviceTripIndex(kv, trip.deviceToken);
+  }
+}
+
 export async function* listTrips(kv: KVNamespace): AsyncGenerator<Trip> {
   let cursor: string | undefined;
   do {
@@ -368,6 +390,9 @@ export async function cleanupSupersededTrip(
   }
   await deleteTrip(kv, orphan.token);
   await cleanupPendingPushesForToken(kv, orphan.token);
+  // 리뷰 P1 — orphan trip이 소유한 deviceToken 역인덱스도 함께 정리(현재도 orphan.token을
+  // 가리킬 때만, race guard는 `deleteDeviceTripIndexIfCurrent` 참고).
+  await deleteDeviceTripIndexIfCurrent(kv, orphan);
 }
 
 /**


### PR DESCRIPTION
## 복구 PR

PR #2186이 리뷰 P1 수정 push 전에 머지되어(3차 재발, lesson_merge_before_review_fix_push_lost) 유실된 수정을 재적용.

Part of #2172 · 관련 #2175 (CLOSED — 본 PR은 리뷰 P1 잔여분)

## 내용 (#2186 리뷰 P1)
- `DELETE /trips/:token`에 deviceToken 역인덱스 fallback — 로테이션 후 사용자 명시 clear가 no-op이 되어 고아 UUID trip이 계속 push를 쏘던 갭 봉쇄. 직접 키 miss 시 `getDeviceTripIndex` 재조회 → `cleanupTripWithLa`로 정상 삭제.
- `deleteDeviceTripIndexIfCurrent` (race-safe guard) 신설, `cleanupSupersededTrip` + `cleanupTripWithLa`에 배선 — cron 종료 경로의 인덱스 누락도 함께 해소 (조사 중 발견).

## Wire 5단
1. Orphan: lint pass (backend-only)
2. V/X: KV device-trips: 인덱스 정합 / D1 end_reason user-delete
3. 의존 PR: 없음. **머지 후 wrangler deploy 필수** (#2184~#2186과 함께 2차 배포 대상)
4. 측정: 다음 실탑승에서 로테이션 후 알람 해제 → push 중단 확인
5. Device verify: Epic #2172 검증 탑승과 공유

## 검증
- red-green: fix 되돌린 상태에서 DELETE 테스트 `{deleted:false}` 실패 재현 → 복원 후 green
- backend 2886 tests pass, 커버리지 97.32/96.36 (게이트 유지), tsc pass