### PR TITLE
test/fix(#2176): APNs 토큰 64-hex 불변식 관측 가드 (축소 스펙)

### DIFF
--- a/backend/alarm-worker/src/__tests__/apnsHost.test.ts
+++ b/backend/alarm-worker/src/__tests__/apnsHost.test.ts
@@ -15,6 +15,25 @@ const APNS_HOSTS: Record<ApnsEnv, string> = {
   production: 'api.push.apple.com',
 };
 
+const HEX64_TOKEN = '0123456789abcdef'.repeat(4);
+const UUID_TOKEN = '550e8400-e29b-41d4-a716-446655440000';
+
+/**
+ * #2176 — logPushFailure(pushFailureLog.test.ts와 동일 패턴)의 최소 mock D1.
+ * SQL 종류(SELECT rate-limit 확인 / INSERT)별로 다른 stub을 반환한다.
+ */
+function makeDb(recentExists = false): { db: D1Database; insertBind: ReturnType<typeof vi.fn> } {
+  const run = vi.fn().mockResolvedValue({ success: true });
+  const insertBind = vi.fn().mockReturnValue({ run });
+  const first = vi.fn().mockResolvedValue(recentExists ? { 1: 1 } : null);
+  const selectBind = vi.fn().mockReturnValue({ first });
+  const prepare = vi.fn().mockImplementation((sql: string) => {
+    if (sql.startsWith('SELECT')) return { bind: selectBind };
+    return { bind: insertBind };
+  });
+  return { db: { prepare } as unknown as D1Database, insertBind };
+}
+
 describe('sendWithEnvHeal (#1931 race evidence)', () => {
   it('1차 성공 → race-evidence 라인 미발사 (정상 경로)', async () => {
     const sender = vi.fn(async (): Promise<SendPushResult> => ({ ok: true, status: 200 }));
@@ -121,5 +140,86 @@ describe('sendWithEnvHeal (#1931 race evidence)', () => {
       (call) => call[1] && (call[1] as Record<string, unknown>).reason === 'env-mismatch-race',
     );
     expect(raceLines).toHaveLength(1);
+  });
+});
+
+describe('sendWithEnvHeal — #2176 발사 전 토큰 포맷 관측 (축소 스펙: 기록만, 발사 차단 없음)', () => {
+  it('red: observe 미전달(기존 caller) — UUID 토큰이어도 아무 기록 없이 그대로 발사(기존 동작 100% 유지)', async () => {
+    const sender = vi.fn(async (): Promise<SendPushResult> => ({ ok: true, status: 200 }));
+    const log = vi.fn();
+    const { insertBind } = makeDb();
+    // observe 인자를 넘기지 않음 — 08-06 로테이션 결함 당시와 동일하게 UUID가 그대로 통과되던 상태 재현.
+    const result = await sendWithEnvHeal(sender, 'sandbox', APNS_HOSTS, log, UUID_TOKEN.slice(0, 8));
+    expect(sender).toHaveBeenCalledTimes(1);
+    expect(result.result.ok).toBe(true);
+    expect(insertBind).not.toHaveBeenCalled();
+  });
+
+  it('green: observe 전달 + 무효 포맷(UUID) → invalid-token-format 사유로 기록 + 발사는 그대로 진행(차단 없음)', async () => {
+    const sender = vi.fn(async (): Promise<SendPushResult> => ({ ok: true, status: 200 }));
+    const log = vi.fn();
+    const { db, insertBind } = makeDb();
+    const result = await sendWithEnvHeal(
+      sender,
+      'sandbox',
+      APNS_HOSTS,
+      log,
+      UUID_TOKEN.slice(0, 8),
+      { deviceToken: UUID_TOKEN, db, tripToken: UUID_TOKEN },
+    );
+    // 동작 불변 — 무효 포맷이어도 sender(APNs 호출)는 그대로 1회 실행되고 결과도 그대로 반환.
+    expect(sender).toHaveBeenCalledTimes(1);
+    expect(result.result.ok).toBe(true);
+    // 기록은 남는다 — apns_status=0(로컬 pre-flight 판정, 실제 APNs 응답 아님), reason=invalid-token-format.
+    expect(insertBind).toHaveBeenCalledTimes(1);
+    const bindArgs = insertBind.mock.calls[0];
+    // bind 순서(pushFailureLog.ts): ts, tokenHash, tripTokenHash, pushKind, status, reason, env, envMismatchExhausted
+    expect(bindArgs[4]).toBe(0);
+    expect(bindArgs[5]).toBe('invalid-token-format');
+    const observeLines = log.mock.calls.filter((call) =>
+      String(call[0]).includes('invalid token format observed'),
+    );
+    expect(observeLines).toHaveLength(1);
+  });
+
+  it('green: observe 전달 + 유효 포맷(64-hex) → 기록 없음 + 정상 회귀 없음', async () => {
+    const sender = vi.fn(async (): Promise<SendPushResult> => ({ ok: true, status: 200 }));
+    const log = vi.fn();
+    const { db, insertBind } = makeDb();
+    const result = await sendWithEnvHeal(
+      sender,
+      'sandbox',
+      APNS_HOSTS,
+      log,
+      HEX64_TOKEN.slice(0, 8),
+      { deviceToken: HEX64_TOKEN, db, tripToken: HEX64_TOKEN },
+    );
+    expect(sender).toHaveBeenCalledTimes(1);
+    expect(result.result.ok).toBe(true);
+    expect(insertBind).not.toHaveBeenCalled();
+  });
+
+  it('rate-limit 가드: 같은 (token, pushKind) 10분 윈도 내 재관측은 재기록하지 않는다(logPushFailure 내장 게이트 재사용)', async () => {
+    const sender = vi.fn(async (): Promise<SendPushResult> => ({ ok: true, status: 200 }));
+    const log = vi.fn();
+    const { db, insertBind } = makeDb(true); // recentExists=true → rate-limit SELECT가 "최근 기록 있음" 반환
+    await sendWithEnvHeal(sender, 'sandbox', APNS_HOSTS, log, UUID_TOKEN.slice(0, 8), {
+      deviceToken: UUID_TOKEN,
+      db,
+      tripToken: UUID_TOKEN,
+    });
+    expect(insertBind).not.toHaveBeenCalled();
+  });
+
+  it('db undefined(미바인딩) → graceful no-op, 발사는 그대로 진행', async () => {
+    const sender = vi.fn(async (): Promise<SendPushResult> => ({ ok: true, status: 200 }));
+    const log = vi.fn();
+    const result = await sendWithEnvHeal(sender, 'sandbox', APNS_HOSTS, log, UUID_TOKEN.slice(0, 8), {
+      deviceToken: UUID_TOKEN,
+      db: undefined,
+      tripToken: UUID_TOKEN,
+    });
+    expect(sender).toHaveBeenCalledTimes(1);
+    expect(result.result.ok).toBe(true);
   });
 });

--- a/backend/alarm-worker/src/__tests__/apnsToken.test.ts
+++ b/backend/alarm-worker/src/__tests__/apnsToken.test.ts
@@ -1,0 +1,35 @@
+/**
+ * apnsToken.ts 단위 테스트 (#2176) — APNs device token 64-hex 불변식 검증.
+ */
+import { describe, expect, it } from 'vitest';
+import { isValidApnsToken } from '../apnsToken';
+
+describe('isValidApnsToken (#2176)', () => {
+  it('64자리 소문자 hex는 유효', () => {
+    expect(isValidApnsToken('0123456789abcdef'.repeat(4))).toBe(true);
+  });
+
+  it('64자리 대문자 hex도 유효(대소문자 무관)', () => {
+    expect(isValidApnsToken('0123456789ABCDEF'.repeat(4))).toBe(true);
+  });
+
+  it('UUID(rotation된 trip.token)는 무효 — 로테이션 결함의 핵심 증상', () => {
+    expect(isValidApnsToken('550e8400-e29b-41d4-a716-446655440000')).toBe(false);
+  });
+
+  it('64자보다 짧으면 무효', () => {
+    expect(isValidApnsToken('0123456789abcdef')).toBe(false);
+  });
+
+  it('64자보다 길면 무효', () => {
+    expect(isValidApnsToken(`${'0123456789abcdef'.repeat(4)}ab`)).toBe(false);
+  });
+
+  it('hex 아닌 문자가 섞이면 무효', () => {
+    expect(isValidApnsToken(`${'0123456789abcdef'.repeat(3)}zzzzzzzzzzzzzzzz`)).toBe(false);
+  });
+
+  it('빈 문자열은 무효', () => {
+    expect(isValidApnsToken('')).toBe(false);
+  });
+});

--- a/backend/alarm-worker/src/apnsHost.ts
+++ b/backend/alarm-worker/src/apnsHost.ts
@@ -8,10 +8,30 @@
  *   sandbox로 시작했으므로 production으로 뒤집는다.
  */
 
+import { isValidApnsToken } from './apnsToken';
+import { logPushFailure } from './pushFailureLog';
 import type { ApnsEnv } from './types';
 import type { SendPushResult } from './apns';
 
 type Logger = (message: string, meta?: Record<string, unknown>) => void;
+
+/**
+ * #2176 (관측 전용, 축소 스펙) — 발사 직전 토큰 포맷 관측 컨텍스트.
+ *
+ * 08-06 로테이션 결함 RCA: `trip.token`이 UUID로 로테이션된 상태로 APNs에 발사돼도 아무도
+ * 감지하지 못했다. 이 컨텍스트를 `sendWithEnvHeal`에 넘기면 실제 발사 토큰(`deviceToken`)이
+ * 64-hex가 아닐 때 `push_failures`에 `invalid-token-format` 사유로 기록한다 — **발사 자체는
+ * 막지 않는다** (동작 불변, 1단계는 관측만). 강제 차단은 production 관측 0건 확인 후 별도 이슈.
+ */
+export interface ApnsTokenObserveContext {
+  /** 실제 APNs로 발사되는 토큰 (마스킹 없이 전체 값 — pushFailureLog가 내부에서 hash한다). */
+  deviceToken: string;
+  db: D1Database | undefined;
+  tripToken: string;
+}
+
+/** 관측 기록 시 pushFailureLog에 남기는 pushKind. 실제 push 종류와 무관 — 포맷 결함 자체를 버킷팅. */
+const TOKEN_FORMAT_OBSERVE_PUSH_KIND = 'apns-fire';
 
 export function pickApnsHost(apnsEnv: ApnsEnv | undefined, hosts: Record<ApnsEnv, string>): string {
   return hosts[apnsEnv ?? 'sandbox'];
@@ -90,7 +110,22 @@ export async function sendWithEnvHeal(
   apnsHosts: Record<ApnsEnv, string>,
   log: Logger,
   tokenForLog: string,
+  observe?: ApnsTokenObserveContext,
 ): Promise<EnvHealResult> {
+  // #2176 — 발사 전 토큰 포맷 관측 (기록만, 발사 흐름 차단 안 함). caller가 `observe`를
+  // 넘기지 않으면 완전히 no-op — 기존 caller/테스트는 동작 무변경.
+  if (observe !== undefined && !isValidApnsToken(observe.deviceToken)) {
+    log('apns invalid token format observed (#2176 — fire not blocked)', {
+      token: tokenForLog,
+    });
+    await logPushFailure(observe.db, {
+      token: observe.deviceToken,
+      tripToken: observe.tripToken,
+      pushKind: TOKEN_FORMAT_OBSERVE_PUSH_KIND,
+      apnsStatus: 0,
+      apnsReason: 'invalid-token-format',
+    });
+  }
   const initial = await sender(pickApnsHost(currentEnv, apnsHosts));
   if (initial.ok || !isApnsEnvMismatch(initial.status, initial.reason)) {
     return { result: initial, envMismatchExhausted: false };

--- a/backend/alarm-worker/src/apnsToken.ts
+++ b/backend/alarm-worker/src/apnsToken.ts
@@ -1,0 +1,16 @@
+/**
+ * APNs device token 포맷 검증 (#2176).
+ *
+ * 08-06 로테이션 결함 RCA: 코드 어디에도 "APNs 토큰은 64-hex"라는 불변식 검증이 없어
+ * `crypto.randomUUID()`로 교체된 `trip.token`이 rotation 이전 상태에서 그대로 APNs로
+ * 발사돼도 아무도 감지하지 못했다. 본 유틸은 그 불변식을 단일 지점에서 정의한다.
+ *
+ * `trips.ts`의 `resolveTripDeviceToken`이 사용하던 로컬 정규식(#2174)을 이 파일로 이전 —
+ * push 발사 경로(`apnsHost.ts`)도 동일 정의를 재사용해야 하므로 공용 모듈로 승격한다.
+ */
+const APNS_DEVICE_TOKEN_HEX64_RE = /^[0-9a-f]{64}$/i;
+
+/** 주어진 문자열이 APNs device token 포맷(64자리 hex)인지 검사한다. */
+export function isValidApnsToken(token: string): boolean {
+  return APNS_DEVICE_TOKEN_HEX64_RE.test(token);
+}

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -398,6 +398,7 @@ async function fireTripEndedAlertPush(
       deps.apnsHosts,
       log,
       trip.token.slice(0, 8),
+      { deviceToken: resolveTripDeviceToken(trip), db: env.DB, tripToken: trip.token },
     );
     if (!heal.result.ok) {
       log('trip-ended push failed', {

--- a/backend/alarm-worker/src/retryPushes.ts
+++ b/backend/alarm-worker/src/retryPushes.ts
@@ -276,6 +276,7 @@ export async function runRetryPushes(env: Env, deps: RetryPushDeps): Promise<Ret
       deps.apnsHosts,
       log,
       entry.token.slice(0, 8),
+      { deviceToken: entry.token, db: env.DB, tripToken: entry.token },
     );
     if (heal.result.ok) {
       stats.resent += 1;

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -2146,6 +2146,7 @@ async function maybeFireSleepAlarm(inputs: MaybeFireSleepAlarmInputs): Promise<v
     deps.apnsHosts,
     log,
     trip.token.slice(0, 8),
+    { deviceToken: resolveTripDeviceToken(trip), db: env.DB, tripToken: trip.token },
   );
   if (alertHeal.correctedEnv) {
     trip.apnsEnv = alertHeal.correctedEnv;
@@ -2176,6 +2177,7 @@ async function maybeFireSleepAlarm(inputs: MaybeFireSleepAlarmInputs): Promise<v
     deps.apnsHosts,
     log,
     trip.token.slice(0, 8),
+    { deviceToken: resolveTripDeviceToken(trip), db: env.DB, tripToken: trip.token },
   );
   if (companionHeal.correctedEnv) {
     trip.apnsEnv = companionHeal.correctedEnv;
@@ -2428,6 +2430,7 @@ export async function fireArvlCdStationPush(
     deps.apnsHosts,
     log,
     trip.token.slice(0, 8),
+    { deviceToken: resolveTripDeviceToken(trip), db: env.DB, tripToken: trip.token },
   );
   let dirty = false;
   if (heal.correctedEnv) {
@@ -2825,6 +2828,7 @@ export async function fireVanishFallbackStationPush(
     deps.apnsHosts,
     log,
     trip.token.slice(0, 8),
+    { deviceToken: resolveTripDeviceToken(trip), db: env.DB, tripToken: trip.token },
   );
   if (heal.correctedEnv) {
     trip.apnsEnv = heal.correctedEnv;
@@ -3013,6 +3017,7 @@ async function fireTrainReconfirmPush(
       deps.apnsHosts,
       log,
       trip.token.slice(0, 8),
+      { deviceToken: resolveTripDeviceToken(trip), db: env.DB, tripToken: trip.token },
     );
     if (!heal.result.ok) {
       log('train-reconfirm push failed', {
@@ -3708,6 +3713,7 @@ export async function advanceBoardingLockWaypoint(
       deps.apnsHosts,
       log,
       trip.token.slice(0, 8),
+      { deviceToken: resolveTripDeviceToken(trip), db: env.DB, tripToken: trip.token },
     );
     // #1633 — transfer-release fire의 corrected env capture. 종전엔 결과 discard로
     // trip.apnsEnv 가 in-memory mutate 되지 않아 line 2217 putTrip 이 OLD value 를 쓰고,
@@ -3957,6 +3963,7 @@ export async function maybeReschedulePush(
     deps.apnsHosts,
     log,
     trip.token.slice(0, 8),
+    { deviceToken: resolveTripDeviceToken(trip), db: env.DB, tripToken: trip.token },
   );
   let dirty = false;
   if (heal.correctedEnv) {
@@ -4201,6 +4208,7 @@ export async function runLocklessIntermediate(
       deps.apnsHosts,
       log,
       trip.token.slice(0, 8),
+      { deviceToken: resolveTripDeviceToken(trip), db: env.DB, tripToken: trip.token },
     );
     if (heal.correctedEnv) {
       trip.apnsEnv = heal.correctedEnv;
@@ -4869,6 +4877,7 @@ export async function evaluateAndMaybeFireBoardingPrompt(
     deps.apnsHosts,
     log,
     trip.token.slice(0, 8),
+    { deviceToken: resolveTripDeviceToken(trip), db: env.DB, tripToken: trip.token },
   );
 
   if (heal.correctedEnv) {
@@ -5009,6 +5018,7 @@ export async function maybeFireHopEndPrompt(inputs: {
     deps.apnsHosts,
     log,
     trip.token.slice(0, 8),
+    { deviceToken: resolveTripDeviceToken(trip), db: env.DB, tripToken: trip.token },
   );
   if (heal.correctedEnv) {
     trip.apnsEnv = heal.correctedEnv;

--- a/backend/alarm-worker/src/trips.ts
+++ b/backend/alarm-worker/src/trips.ts
@@ -1,4 +1,5 @@
 import { getArchFlag } from './archFlag';
+import { isValidApnsToken } from './apnsToken';
 import { recordTripMetrics } from './d1TripMetrics';
 import {
   assertCronCacheTtl,
@@ -58,9 +59,6 @@ export function tripKey(token: string): string {
   return `${TRIP_PREFIX}${token}`;
 }
 
-/** #2174 — 64-hex APNs device token 포맷 검증. */
-const DEVICE_TOKEN_HEX64_RE = /^[0-9a-f]{64}$/i;
-
 /**
  * #2174 (P1-A) — push 발사용 실 APNs deviceToken을 단일 지점에서 해석한다.
  *
@@ -74,12 +72,12 @@ const DEVICE_TOKEN_HEX64_RE = /^[0-9a-f]{64}$/i;
  * 로테이션이 막혀 있던 구간의 산물이라 존재해서는 안 되는 조합 — 그런 경우도 fallback으로
  * `trip.token`을 반환해 기존(로테이션 재활성 이전) 동작과 동일하게 유지한다(마이그레이션
  * 배치 금지, 새 회귀 없음 — 이미 무효했던 push가 계속 무효할 뿐).
+ *
+ * #2176 — 포맷 검증 로직은 `apnsToken.ts:isValidApnsToken`으로 이전(공용화). 발사 경로
+ * (`apnsHost.ts`)도 같은 정의를 재사용해 "APNs 토큰은 64-hex" 불변식을 단일 지점에서 관리한다.
  */
 export function resolveTripDeviceToken(trip: Trip): string {
-  if (
-    typeof trip.deviceToken === 'string' &&
-    DEVICE_TOKEN_HEX64_RE.test(trip.deviceToken)
-  ) {
+  if (typeof trip.deviceToken === 'string' && isValidApnsToken(trip.deviceToken)) {
     return trip.deviceToken;
   }
   return trip.token;


### PR DESCRIPTION
Closes #2176

## 배경 — 축소 스펙 (이슈 코멘트 참고)

원 스펙(등록 4xx 거부 + 발사 차단 + mock APNs 400 강제)을 그대로 구현 시, `resolveTripDeviceToken`이 미해석 시 `trip.token`으로 fallback하는 특성상 `POST /trips`/`scheduled`/`liveActivity`/`retryPushes` 테스트 4개 파일(500+ 케이스)의 기본 mock 토큰(`'tok'`, `'devtoken'` 등, 비-64hex)이 대량으로 깨지는 것을 구현 중 확인. 코디네이터 결정에 따라 **1단계 관측 전용**으로 축소:

- 등록 거부 없음 / mock APNs 강제 없음 / fixture 마이그레이션 없음 — 기존 테스트 전부 무변경으로 pass
- 발사(sender 호출) 자체는 절대 차단하지 않음 — 무효 포맷이어도 기존과 동일하게 APNs에 발사 시도
- 강제 차단(등록 거부 + APNs 호출 전 skip)은 production 관측 0건 확인 후 **별도 이슈**에서 진행

## 변경

1. `isValidApnsToken` 공용 유틸 신설 (`backend/alarm-worker/src/apnsToken.ts`) — `trips.ts:resolveTripDeviceToken`(#2174)이 쓰던 로컬 `DEVICE_TOKEN_HEX64_RE`를 이전. 등록 경로(`resolveTripDeviceToken`)와 발사 경로(`apnsHost.ts`)가 동일 정의를 재사용.
2. `sendWithEnvHeal`(`apnsHost.ts`, 발사 공통 진입점)에 optional `observe?: ApnsTokenObserveContext` 파라미터 추가.
   - **선택 근거**: "sendWithEnvHeal 호출 직전 공통 지점(wrapper 신설)" vs "sendWithEnvHeal 시그니처 확장" 중 후자를 선택. wrapper 신설은 12개 호출부 전부 함수명까지 바꿔야 하지만, 시그니처 확장은 optional 파라미터라 기존 5-arg 호출은 100% 그대로 유지되고, observe를 넘기는 곳만 6번째 인자 1줄 추가로 끝나 diff가 더 작음.
   - `observe`가 없으면 완전 no-op (기존 caller 무변경). `observe.deviceToken`이 `isValidApnsToken`으로 무효 판정되면 `logPushFailure`(기존 #2177 D1 `push_failures` 재사용)에 `apnsStatus: 0, apnsReason: 'invalid-token-format'`으로 기록 후 **그대로 sender 호출 진행**(차단 없음).
   - `pushKind`는 실제 push 종류와 무관하게 `'apns-fire'` 고정 — `computePushFailureMetrics`의 GROUP BY가 `(apns_status, apns_reason)` 기준이라 pushKind는 집계에 영향 없음, 단일 값으로 단순화.
3. `scheduled.ts`(10곳) / `liveActivity.ts`(1곳) / `retryPushes.ts`(1곳) — `sendWithEnvHeal` 호출부에 `{ deviceToken: resolveTripDeviceToken(trip), db: env.DB, tripToken: trip.token }` 배선. 기존 `tokenForLog`(마스킹된 8자 prefix) 인자는 그대로 — 로그 PII 노출 동작 무변경.
4. 신규 테스트만 추가: `apnsToken.test.ts`(unit), `apnsHost.test.ts`에 observe 전용 describe 블록(red: observe 미전달 시 UUID도 통과 / green: UUID observe 시 기록 1건 + 발사 불변 / green: 64-hex는 기록 없음 / rate-limit 가드 재사용 확인 / db undefined graceful).

## Wire-completion 5단

1. **Orphan 없음** — `isValidApnsToken`은 `trips.ts`, `apnsHost.ts`에서 호출. `ApnsTokenObserveContext`는 `sendWithEnvHeal` 파라미터 타입으로 사용. (backend/alarm-worker는 root `lint:orphan`(ts-prune) 스캔 범위 밖 — 별도 tsconfig 프로젝트, backend 자체 `tsc --noEmit`으로 미사용 export 없음 확인)
2. **V/X dashboard** — `push_failures` 테이블 SELECT `WHERE apns_reason = 'invalid-token-format'`로 Cloudflare D1 콘솔에서 즉시 식별 가능. 발사 시점 `log('apns invalid token format observed ...')`는 wrangler tail / Cloudflare Dashboard에서 실시간 관측 가능.
3. **의존 PR** — #2174(deviceToken/resolveTripDeviceToken), #2177(pushFailureLog) 머지 완료 후 위 코드가 이를 재사용. 둘 다 dev에 머지됨. 배포는 필요(이 PR 자체는 배포해야 관측 시작).
4. **측정 plan** — 배포 후 1주간 `SELECT COUNT(*) FROM push_failures WHERE apns_reason = 'invalid-token-format'` 0건 유지 확인. 0건이면 강제 차단(2단계) 이슈로 스펙 그대로 진행, 발생하면 그 trip의 root cause 먼저 규명.
5. **Device verify** — N/A — type+unit only.

## 테스트

- `npm test` — 75 test files / 2898 tests 전부 pass, coverage floor(stmts 97/branch 96/funcs 98/lines 97) 상회 유지 (실측 97.32/96.36/99.21/97.32)
- `npm run type-check` — pass
- 기존 `scheduled.test.ts`(447 tests) / `liveActivity.test.ts`(55) / `retryPushes.test.ts`(39) / `index.test.ts` 전부 무변경으로 pass — fixture 마이그레이션 없음을 실증
