### PR TITLE
fix(#2178): pull 기반 trip 死 backstop — silentPushTask + BG location tick

### DIFF
--- a/src/features/alarm/hooks/useLaunchTripReconciliation.ts
+++ b/src/features/alarm/hooks/useLaunchTripReconciliation.ts
@@ -58,6 +58,7 @@ import { getTripStartedAt } from '../utils/tripStartStorage';
 import { fetchTripStatus } from '../api/tripStatus';
 import { triggerTripEndRecall } from '../utils/triggerTripEndRecall';
 import { runTripBoundCleanups } from '../store/tripBoundCleanups';
+import { cleanupBackendConfirmedEndedTrip } from '../utils/tripEndedCleanupSequence';
 import { flushSignalDumpOutbox } from '../api/signalDumpBackend';
 import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
 import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
@@ -204,15 +205,9 @@ export async function runLaunchTripReconciliation(): Promise<void> {
     // BG handler를 호출하지 않아 cleanup이 누락된 경우 launch backstop으로 복구.
     // recall은 cleanup이 storage를 비우기 전에 호출되어야 입력을 읽을 수 있다.
     // 두 호출 모두 멱등 — silent push handler와 중복 호출 안전.
-    await triggerTripEndRecall();
-    // #1597 — clearTripCorrId가 cache를 비우기 전에 종료된 trip의 corrId snapshot 캡처.
-    const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
-    await runTripBoundCleanups();
-    // #1597 — trip-end 사용자 정답지 prompt enqueue (cleanup 후, corrId snapshot으로).
-    await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
-    // #2114 (방안 C′) — sentinel에 corrId 동봉.
-    await setTripEndedSentinel(endedAt, endedCorrIdSnapshot);
-    await AsyncStorage.removeItem(ACTIVE_TRIP_KEY);
+    // #2178 — 5단 시퀀스(recall → cleanup → prompt → sentinel → active clear)를
+    // tripEndedCleanupSequence로 추출해 pull death backstop과 공유(중복 구현 금지).
+    await cleanupBackendConfirmedEndedTrip(endedAt);
   } catch (e) {
     logger.warn('reconciliation 실패 (graceful)', e);
   }

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -88,11 +88,26 @@ jest.mock('../../utils/tripEndedSentinel', () => ({
 
 // #2045 (Signal 4) — silent push 수신 시각 stamp. handleSilentPush가 유효 payload 진입 시점에 write.
 const mockSetLastSilentPushReceivedAt = jest.fn().mockResolvedValue(undefined);
+// #2178 — pull death backstop 트리거 조건(마지막 backend 접촉 staleness) 판정용 prior read.
+const mockGetLastSilentPushReceivedAt = jest.fn().mockResolvedValue(null);
 jest.mock('../../utils/lastSilentPushReceivedAt', () => ({
   setLastSilentPushReceivedAt: (...args: unknown[]) =>
     mockSetLastSilentPushReceivedAt(...args),
-  getLastSilentPushReceivedAt: jest.fn(),
+  getLastSilentPushReceivedAt: (...args: unknown[]) =>
+    mockGetLastSilentPushReceivedAt(...args),
   clearLastSilentPushReceivedAt: jest.fn(),
+}));
+
+// #2178 — pull 기반 trip 死 backstop. silentPushTask 처리 말미 wiring만 검증하는 것이 이 파일의
+// 책임 — 내부 판정/cleanup 로직 자체는 tripDeathPullBackstop.test.ts가 전담(중복 검증 회피).
+const mockGetTripDeathPullBackendUrl = jest.fn<string | null, []>(() => null);
+const mockShouldCheckTripDeathOnSilentPush = jest.fn<boolean, unknown[]>(() => false);
+const mockCheckTripDeathByPull = jest.fn().mockResolvedValue('skipped');
+jest.mock('../../utils/tripDeathPullBackstop', () => ({
+  getBackendUrl: () => mockGetTripDeathPullBackendUrl(),
+  shouldCheckTripDeathOnSilentPush: (...args: unknown[]) =>
+    mockShouldCheckTripDeathOnSilentPush(...args),
+  checkTripDeathByPull: (...args: unknown[]) => mockCheckTripDeathByPull(...args),
 }));
 
 // #919 — trip-ended 분기는 cleanup 직전에 recall trigger를 호출한다.
@@ -393,6 +408,12 @@ describe('silentPushTask', () => {
     // clearAllMocks가 mockImplementation을 reset하지 않으므로 명시 복구.
     mockSetTripEndedSentinel.mockResolvedValue(undefined);
     mockClearTripEndedSentinel.mockResolvedValue(undefined);
+    // #2178 — pull death backstop 기본값: baseUrl 없음(호출 안 함) + 트리거 조건 false.
+    // 개별 테스트에서 override.
+    mockGetLastSilentPushReceivedAt.mockResolvedValue(null);
+    mockGetTripDeathPullBackendUrl.mockReturnValue(null);
+    mockShouldCheckTripDeathOnSilentPush.mockReturnValue(false);
+    mockCheckTripDeathByPull.mockResolvedValue('skipped');
   });
 
   it('defineTask가 SILENT_PUSH_TASK 이름으로 콜백을 등록한다', () => {
@@ -2936,6 +2957,83 @@ describe('silentPushTask', () => {
           handleSilentPush(payload({ kind: 'destination', phase: 'imminent' })),
         ).resolves.toBeUndefined();
         expect(mockRefreshLa).toHaveBeenCalled();
+      });
+    });
+
+    // #2178 — pull 기반 trip 死 backstop wiring. 내부 판정/cleanup 로직 자체는
+    // tripDeathPullBackstop.test.ts가 전담 — 여기서는 silentPushTask가 finally 말미에서
+    // 올바른 인자로 호출/생략하는지만 검증한다.
+    describe('#2178 — pull death backstop (finally 블록)', () => {
+      it('baseUrl 미설정 → shouldCheckTripDeathOnSilentPush/checkTripDeathByPull 모두 호출 안 함', async () => {
+        mockGetTripDeathPullBackendUrl.mockReturnValue(null);
+        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+        expect(mockShouldCheckTripDeathOnSilentPush).not.toHaveBeenCalled();
+        expect(mockCheckTripDeathByPull).not.toHaveBeenCalled();
+      });
+
+      it('baseUrl 있음 + 트리거 조건 false → checkTripDeathByPull 호출 안 함', async () => {
+        mockGetTripDeathPullBackendUrl.mockReturnValue('https://api.test.dev');
+        mockShouldCheckTripDeathOnSilentPush.mockReturnValue(false);
+        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+        expect(mockShouldCheckTripDeathOnSilentPush).toHaveBeenCalledTimes(1);
+        expect(mockCheckTripDeathByPull).not.toHaveBeenCalled();
+      });
+
+      it('baseUrl 있음 + 트리거 조건 true → checkTripDeathByPull(baseUrl, "silent-push") 호출', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+          if (key === DESTINATION_KEY) return JSON.stringify(destStation);
+          if (key === APNS_TOKEN_KEY) return DEFAULT_APNS_TOKEN;
+          if (key === ACTIVE_TRIP_KEY) return 'tk-active';
+          return null;
+        });
+        mockGetTripDeathPullBackendUrl.mockReturnValue('https://api.test.dev');
+        mockShouldCheckTripDeathOnSilentPush.mockReturnValue(true);
+
+        await handleSilentPush(
+          payload({ kind: 'destination', phase: 'imminent', tripToken: 'tk-payload' }),
+        );
+
+        expect(mockShouldCheckTripDeathOnSilentPush).toHaveBeenCalledWith(
+          expect.objectContaining({
+            activeTripToken: 'tk-active',
+            payloadTripToken: 'tk-payload',
+          }),
+        );
+        expect(mockCheckTripDeathByPull).toHaveBeenCalledWith(
+          'https://api.test.dev',
+          'silent-push',
+        );
+      });
+
+      it('reschedule payload(tripToken 없음) → payloadTripToken undefined로 판정 위임', async () => {
+        mockGetTripDeathPullBackendUrl.mockReturnValue('https://api.test.dev');
+        mockShouldCheckTripDeathOnSilentPush.mockReturnValue(false);
+        await handleSilentPush({
+          data: bgTaskData({
+            kind: 'reschedule',
+            nextStation: '잠실',
+            newArrivalTimeEpoch: Date.now() + 60_000,
+            trainCode: 'T-1',
+          }),
+        });
+        expect(mockShouldCheckTripDeathOnSilentPush).toHaveBeenCalledWith(
+          expect.objectContaining({ payloadTripToken: undefined }),
+        );
+      });
+
+      it('checkTripDeathByPull throw해도 graceful (finally 흐름 차단 없음)', async () => {
+        mockGetTripDeathPullBackendUrl.mockReturnValue('https://api.test.dev');
+        mockShouldCheckTripDeathOnSilentPush.mockReturnValue(true);
+        mockCheckTripDeathByPull.mockRejectedValueOnce(new Error('backend-fail'));
+        await expect(
+          handleSilentPush(payload({ kind: 'destination', phase: 'imminent' })),
+        ).resolves.toBeUndefined();
+      });
+
+      it('invalid payload(extract null) → payload=null이라 backstop 조건도 gracefully 평가(호출 안 함 보장 아님, baseUrl 없으면 skip)', async () => {
+        mockGetTripDeathPullBackendUrl.mockReturnValue(null);
+        await handleSilentPush({ data: undefined });
+        expect(mockCheckTripDeathByPull).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -3030,6 +3030,24 @@ describe('silentPushTask', () => {
         ).resolves.toBeUndefined();
       });
 
+      // 리뷰 P1 (PR #2189) — backstop이 내부적으로 적재하는 trip-dead-pull-detected 로그가
+      // 기존 flushAlarmLog() 뒤에서 발생해 BG task suspend 시 유실될 수 있었다. appendAlarmLog
+      // 호출 여부만 mock 검증하는 방식으론 이 타이밍 결함을 못 잡으므로, flushAlarmLog 호출
+      // "횟수"와 "순서"(backstop 실행 이후에도 한 번 더 flush)를 직접 검증한다.
+      it('backstop 트리거 후 flushAlarmLog가 재호출되어 신규 로그 유실을 막는다', async () => {
+        mockGetTripDeathPullBackendUrl.mockReturnValue('https://api.test.dev');
+        mockShouldCheckTripDeathOnSilentPush.mockReturnValue(true);
+        mockCheckTripDeathByPull.mockResolvedValueOnce(undefined);
+
+        await handleSilentPush(payload({ kind: 'destination', phase: 'imminent' }));
+
+        // 기존 flush(BG 시간 예산 보호, LA/widget 이전) 1회 + backstop 이후 재flush 1회 = 2회.
+        expect(mockFlushAlarmLog).toHaveBeenCalledTimes(2);
+        const checkCallOrder = mockCheckTripDeathByPull.mock.invocationCallOrder[0];
+        const flushCallOrders = mockFlushAlarmLog.mock.invocationCallOrder;
+        expect(flushCallOrders.some((order) => order > checkCallOrder)).toBe(true);
+      });
+
       it('invalid payload(extract null) → payload=null이라 backstop 조건도 gracefully 평가(호출 안 함 보장 아님, baseUrl 없으면 skip)', async () => {
         mockGetTripDeathPullBackendUrl.mockReturnValue(null);
         await handleSilentPush({ data: undefined });

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -58,8 +58,16 @@ import {
   setTripEndedSentinel,
   clearTripEndedSentinel,
 } from '../utils/tripEndedSentinel';
-import { setLastSilentPushReceivedAt } from '../utils/lastSilentPushReceivedAt';
+import {
+  setLastSilentPushReceivedAt,
+  getLastSilentPushReceivedAt,
+} from '../utils/lastSilentPushReceivedAt';
 import { triggerTripEndRecall } from '../utils/triggerTripEndRecall';
+import {
+  checkTripDeathByPull,
+  shouldCheckTripDeathOnSilentPush,
+  getBackendUrl as getTripDeathPullBackendUrl,
+} from '../utils/tripDeathPullBackstop';
 import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
 import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
 import { addFiredPushId } from '../utils/firedPushIds';
@@ -834,6 +842,9 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
   // #1935 — finally 블록에서 widget update가 payload.ssot 또는 standard kind를 활용하려면
   // payload가 outer scope에 있어야 한다. valid extract 후 assign; invalid면 null 유지.
   let payload: ExtractedPayload | null = null;
+  // #2178 — pull death backstop 트리거 조건(마지막 backend 접촉 staleness) 판정용. 이번
+  // push의 receivedAt으로 덮어쓰기 *전* 값을 캡처해야 의미가 있어 outer scope에 둔다.
+  let priorLastReceivedAt: number | null = null;
   // #735 — BG task 시간 제약. 모든 종료 경로(early return, fire-with-gate, error)에서 적재된
   // alarmLog pending이 OS suspend로 손실되지 않도록 try/finally로 명시 flush.
   try {
@@ -848,6 +859,7 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
       return;
     }
     const receivedAt = Date.now();
+    priorLastReceivedAt = await getLastSilentPushReceivedAt();
     addDomainBreadcrumb('push', 'silent-push', { kind: payload.kind ?? 'fire' });
     // #2045 (Signal 4) — 유효 payload 진입 시점에 last-received stamp 갱신.
     // useLaunchTripReconciliation이 launch 시 read해 backend-timeout self-end 판정 (관찰 22 BG kill 커버).
@@ -1161,6 +1173,31 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
       tasks.push(refreshWidgetForPayload(payload));
     }
     await Promise.allSettled(tasks);
+
+    // #2178 — pull 기반 trip 死 backstop. 처리 말미(모든 종료 경로 공통)에서 로컬 active
+    // trip이 있는데 이번 payload의 trip 신원이 불일치하거나 마지막 backend 접촉이 오래됐으면
+    // backend에 GET trip status로 생존을 직접 확인한다. baseUrl 미설정/네트워크 실패/404는
+    // checkTripDeathByPull 내부에서 graceful skip — 이 finally 블록을 절대 막지 않는다.
+    try {
+      const baseUrl = getTripDeathPullBackendUrl();
+      if (baseUrl !== null) {
+        const activeTripToken = await AsyncStorage.getItem(ACTIVE_TRIP_KEY);
+        const payloadTripToken =
+          payload !== null && 'tripToken' in payload ? payload.tripToken : undefined;
+        if (
+          shouldCheckTripDeathOnSilentPush({
+            activeTripToken,
+            payloadTripToken,
+            priorLastReceivedAt,
+            now: Date.now(),
+          })
+        ) {
+          await checkTripDeathByPull(baseUrl, 'silent-push');
+        }
+      }
+    } catch (e) {
+      logger.warn('pull death backstop 실패 (graceful)', e);
+    }
   }
 }
 

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -1198,6 +1198,14 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     } catch (e) {
       logger.warn('pull death backstop 실패 (graceful)', e);
     }
+
+    // 리뷰 P1 (PR #2189) — backstop이 내부적으로 적재하는 alarmLog 엔트리(trip-dead-pull-detected)는
+    // appendAlarmLog의 1초 debounce pending에 걸린다. 위 flushAlarmLog()는 backstop 실행 *전*이라
+    // 이 엔트리를 못 비우고, BG task가 곧 suspend되는 시나리오(=이 backstop의 존재 목적)에서 그대로
+    // 유실될 수 있었다 — 유일한 관측 채널(V/X: DebugModal alarm log) 상실. backstop 블록을 flush
+    // 앞으로 옮기는 대신(네트워크 GET이 기존 flush를 지연시켜 지하 LA stall 회귀 재현), 기존 flush
+    // 순서는 그대로 두고 backstop 산출 로그만 한 번 더 flush한다.
+    await flushAlarmLog();
   }
 }
 

--- a/src/features/alarm/utils/__tests__/tripDeathPullBackstop.test.ts
+++ b/src/features/alarm/utils/__tests__/tripDeathPullBackstop.test.ts
@@ -1,0 +1,285 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  ACTIVE_TRIP_KEY,
+  TRIP_DEATH_PULL_LAST_CHECK_AT_KEY,
+} from '../../../../shared/constants/storageKeys';
+import { TRIP_DEATH_PULL_BACKSTOP_THRESHOLD_MS } from '../../../../shared/constants/realtime';
+import {
+  checkTripDeathByPull,
+  shouldCheckTripDeathOnSilentPush,
+  getBackendUrl,
+} from '../tripDeathPullBackstop';
+
+const mockFetchTripStatus = jest.fn();
+jest.mock('../../api/tripStatus', () => ({
+  fetchTripStatus: (...args: unknown[]) => mockFetchTripStatus(...args),
+}));
+
+const mockCancelTripBoundOsQueue = jest.fn();
+jest.mock('../../store/tripBoundCleanups', () => ({
+  cancelTripBoundOsQueue: (...args: unknown[]) => mockCancelTripBoundOsQueue(...args),
+}));
+
+const mockCleanupBackendConfirmedEndedTrip = jest.fn();
+jest.mock('../tripEndedCleanupSequence', () => ({
+  cleanupBackendConfirmedEndedTrip: (...args: unknown[]) =>
+    mockCleanupBackendConfirmedEndedTrip(...args),
+}));
+
+const mockAppendAlarmLog = jest.fn();
+jest.mock('../alarmLog', () => ({
+  appendAlarmLog: (...args: unknown[]) => mockAppendAlarmLog(...args),
+}));
+
+const BASE_URL = 'https://api.test.dev';
+
+describe('getBackendUrl', () => {
+  afterEach(() => {
+    delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+  });
+
+  it('EXPO_PUBLIC_ALARM_BACKEND_URL 미설정 → null', () => {
+    delete process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+    expect(getBackendUrl()).toBeNull();
+  });
+
+  it('trailing slash 제거', () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    expect(getBackendUrl()).toBe('https://api.test.dev');
+  });
+});
+
+describe('shouldCheckTripDeathOnSilentPush', () => {
+  it('active trip 없으면 false', () => {
+    expect(
+      shouldCheckTripDeathOnSilentPush({
+        activeTripToken: null,
+        payloadTripToken: 'other',
+        priorLastReceivedAt: null,
+        now: 1000,
+      }),
+    ).toBe(false);
+  });
+
+  it('payload tripToken이 active와 불일치 → true', () => {
+    expect(
+      shouldCheckTripDeathOnSilentPush({
+        activeTripToken: 'tk',
+        payloadTripToken: 'other',
+        priorLastReceivedAt: null,
+        now: 1000,
+      }),
+    ).toBe(true);
+  });
+
+  it('payload tripToken이 active와 일치 → 불일치 아님(다른 조건 없으면 false)', () => {
+    expect(
+      shouldCheckTripDeathOnSilentPush({
+        activeTripToken: 'tk',
+        payloadTripToken: 'tk',
+        priorLastReceivedAt: null,
+        now: 1000,
+      }),
+    ).toBe(false);
+  });
+
+  it('payload tripToken undefined(구 backend 호환) → mismatch 판정 skip', () => {
+    expect(
+      shouldCheckTripDeathOnSilentPush({
+        activeTripToken: 'tk',
+        payloadTripToken: undefined,
+        priorLastReceivedAt: null,
+        now: 1000,
+      }),
+    ).toBe(false);
+  });
+
+  it('마지막 접촉이 threshold 이상 지남 → true', () => {
+    expect(
+      shouldCheckTripDeathOnSilentPush({
+        activeTripToken: 'tk',
+        payloadTripToken: 'tk',
+        priorLastReceivedAt: 0,
+        now: TRIP_DEATH_PULL_BACKSTOP_THRESHOLD_MS,
+      }),
+    ).toBe(true);
+  });
+
+  it('마지막 접촉이 threshold 미만 → false', () => {
+    expect(
+      shouldCheckTripDeathOnSilentPush({
+        activeTripToken: 'tk',
+        payloadTripToken: 'tk',
+        priorLastReceivedAt: 0,
+        now: TRIP_DEATH_PULL_BACKSTOP_THRESHOLD_MS - 1,
+      }),
+    ).toBe(false);
+  });
+
+  it('priorLastReceivedAt null(첫 push) → staleness 판정 skip', () => {
+    expect(
+      shouldCheckTripDeathOnSilentPush({
+        activeTripToken: 'tk',
+        payloadTripToken: 'tk',
+        priorLastReceivedAt: null,
+        now: 999_999_999,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('checkTripDeathByPull', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await AsyncStorage.clear();
+  });
+
+  it('active trip 없음 → skip, fetch 호출 안 함', async () => {
+    const result = await checkTripDeathByPull(BASE_URL, 'silent-push');
+    expect(result).toBe('skipped');
+    expect(mockFetchTripStatus).not.toHaveBeenCalled();
+  });
+
+  it('쿨다운 내 재호출 → skip (fetch 호출 안 함)', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    const now = 1_000_000;
+    await AsyncStorage.setItem(
+      TRIP_DEATH_PULL_LAST_CHECK_AT_KEY,
+      String(now - (TRIP_DEATH_PULL_BACKSTOP_THRESHOLD_MS - 1)),
+    );
+    jest.useFakeTimers().setSystemTime(now);
+
+    const result = await checkTripDeathByPull(BASE_URL, 'bg-location-tick');
+
+    expect(result).toBe('skipped');
+    expect(mockFetchTripStatus).not.toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
+  it('쿨다운 경과 후 재호출 → fetch 진행', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    const now = 1_000_000;
+    await AsyncStorage.setItem(
+      TRIP_DEATH_PULL_LAST_CHECK_AT_KEY,
+      String(now - TRIP_DEATH_PULL_BACKSTOP_THRESHOLD_MS),
+    );
+    jest.useFakeTimers().setSystemTime(now);
+    mockFetchTripStatus.mockResolvedValue({ status: 'active', endedAt: null, endReason: null });
+
+    const result = await checkTripDeathByPull(BASE_URL, 'bg-location-tick');
+
+    expect(result).toBe('alive');
+    expect(mockFetchTripStatus).toHaveBeenCalledWith('tk', BASE_URL);
+    jest.useRealTimers();
+  });
+
+  it('404/410(null) → 보수적으로 무시(alive 취급), cleanup 호출 안 함', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    mockFetchTripStatus.mockResolvedValue(null);
+
+    const result = await checkTripDeathByPull(BASE_URL, 'silent-push');
+
+    expect(result).toBe('alive');
+    expect(mockCleanupBackendConfirmedEndedTrip).not.toHaveBeenCalled();
+    expect(mockCancelTripBoundOsQueue).not.toHaveBeenCalled();
+    expect(mockAppendAlarmLog).not.toHaveBeenCalled();
+  });
+
+  it("status active → 무동작", async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    mockFetchTripStatus.mockResolvedValue({ status: 'active', endedAt: null, endReason: null });
+
+    const result = await checkTripDeathByPull(BASE_URL, 'silent-push');
+
+    expect(result).toBe('alive');
+    expect(mockCleanupBackendConfirmedEndedTrip).not.toHaveBeenCalled();
+  });
+
+  it("status ended → death 확정: OS queue cancel + cleanup + alarmLog", async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    mockFetchTripStatus.mockResolvedValue({
+      status: 'ended',
+      endedAt: 1_700_000_000_000,
+      endReason: 'expired',
+    });
+
+    const result = await checkTripDeathByPull(BASE_URL, 'silent-push');
+
+    expect(result).toBe('ended');
+    expect(mockCancelTripBoundOsQueue).toHaveBeenCalledTimes(1);
+    expect(mockCleanupBackendConfirmedEndedTrip).toHaveBeenCalledWith(1_700_000_000_000);
+    expect(mockAppendAlarmLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'lifecycle-backstop',
+        outcome: 'fired',
+        reason: 'trip-dead-pull-detected',
+      }),
+    );
+  });
+
+  it('status ended + endedAt null → Date.now() fallback', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    jest.useFakeTimers().setSystemTime(5_000_000);
+    mockFetchTripStatus.mockResolvedValue({ status: 'ended', endedAt: null, endReason: null });
+
+    await checkTripDeathByPull(BASE_URL, 'silent-push');
+
+    expect(mockCleanupBackendConfirmedEndedTrip).toHaveBeenCalledWith(5_000_000);
+    jest.useRealTimers();
+  });
+
+  it('쿨다운 저장값이 NaN(손상된 storage) → 쿨다운 무시하고 fetch 진행', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    await AsyncStorage.setItem(TRIP_DEATH_PULL_LAST_CHECK_AT_KEY, 'not-a-number');
+    mockFetchTripStatus.mockResolvedValue({ status: 'active', endedAt: null, endReason: null });
+
+    const result = await checkTripDeathByPull(BASE_URL, 'silent-push');
+
+    expect(result).toBe('alive');
+    expect(mockFetchTripStatus).toHaveBeenCalled();
+  });
+
+  it('쿨다운 read 자체가 throw(storage 장애) → graceful, fetch 진행', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    const getItemSpy = jest.spyOn(AsyncStorage, 'getItem').mockImplementation((key: string) => {
+      if (key === TRIP_DEATH_PULL_LAST_CHECK_AT_KEY) {
+        return Promise.reject(new Error('storage failure'));
+      }
+      return Promise.resolve(key === ACTIVE_TRIP_KEY ? 'tk' : null);
+    });
+    mockFetchTripStatus.mockResolvedValue({ status: 'active', endedAt: null, endReason: null });
+
+    const result = await checkTripDeathByPull(BASE_URL, 'silent-push');
+
+    expect(result).toBe('alive');
+    expect(mockFetchTripStatus).toHaveBeenCalled();
+    getItemSpy.mockRestore();
+  });
+
+  it('쿨다운 stamp write가 throw(storage 장애) → graceful, fetch는 그대로 진행', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    const setItemSpy = jest.spyOn(AsyncStorage, 'setItem').mockImplementation((key: string) => {
+      if (key === TRIP_DEATH_PULL_LAST_CHECK_AT_KEY) {
+        return Promise.reject(new Error('storage failure'));
+      }
+      return Promise.resolve();
+    });
+    mockFetchTripStatus.mockResolvedValue({ status: 'active', endedAt: null, endReason: null });
+
+    const result = await checkTripDeathByPull(BASE_URL, 'silent-push');
+
+    expect(result).toBe('alive');
+    setItemSpy.mockRestore();
+  });
+
+  it('네트워크 실패 → 무동작(오탐 금지, ADR-010)', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    mockFetchTripStatus.mockRejectedValue(new Error('network'));
+
+    const result = await checkTripDeathByPull(BASE_URL, 'silent-push');
+
+    expect(result).toBe('skipped');
+    expect(mockCleanupBackendConfirmedEndedTrip).not.toHaveBeenCalled();
+    expect(mockCancelTripBoundOsQueue).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/alarm/utils/__tests__/tripEndedCleanupSequence.test.ts
+++ b/src/features/alarm/utils/__tests__/tripEndedCleanupSequence.test.ts
@@ -1,0 +1,64 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { ACTIVE_TRIP_KEY } from '../../../../shared/constants/storageKeys';
+import { cleanupBackendConfirmedEndedTrip } from '../tripEndedCleanupSequence';
+
+const mockTriggerTripEndRecall = jest.fn();
+jest.mock('../triggerTripEndRecall', () => ({
+  triggerTripEndRecall: (...args: unknown[]) => mockTriggerTripEndRecall(...args),
+}));
+
+const mockRunTripBoundCleanups = jest.fn();
+jest.mock('../../store/tripBoundCleanups', () => ({
+  runTripBoundCleanups: (...args: unknown[]) => mockRunTripBoundCleanups(...args),
+}));
+
+const mockSetTripEndedSentinel = jest.fn();
+jest.mock('../tripEndedSentinel', () => ({
+  setTripEndedSentinel: (...args: unknown[]) => mockSetTripEndedSentinel(...args),
+}));
+
+const mockGetCurrentTripCorrIdSync = jest.fn<string | null, []>(() => null);
+jest.mock('../../../observability/utils/tripCorrId', () => ({
+  getCurrentTripCorrIdSync: () => mockGetCurrentTripCorrIdSync(),
+}));
+
+const mockTriggerTripGroundTruthPrompt = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../debug/utils/triggerTripGroundTruthPrompt', () => ({
+  triggerTripGroundTruthPrompt: (...args: unknown[]) => mockTriggerTripGroundTruthPrompt(...args),
+}));
+
+describe('cleanupBackendConfirmedEndedTrip', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockGetCurrentTripCorrIdSync.mockReturnValue(null);
+    await AsyncStorage.clear();
+  });
+
+  it('5단 시퀀스를 순서대로 호출: recall → cleanup → prompt → sentinel → active trip clear', async () => {
+    await AsyncStorage.setItem(ACTIVE_TRIP_KEY, 'tk');
+    mockGetCurrentTripCorrIdSync.mockReturnValue('corr-1');
+
+    await cleanupBackendConfirmedEndedTrip(1_700_000_000_000);
+
+    const recallOrder = mockTriggerTripEndRecall.mock.invocationCallOrder[0];
+    const cleanupOrder = mockRunTripBoundCleanups.mock.invocationCallOrder[0];
+    const promptOrder = mockTriggerTripGroundTruthPrompt.mock.invocationCallOrder[0];
+    const sentinelOrder = mockSetTripEndedSentinel.mock.invocationCallOrder[0];
+
+    expect(recallOrder).toBeLessThan(cleanupOrder);
+    expect(cleanupOrder).toBeLessThan(promptOrder);
+    expect(promptOrder).toBeLessThan(sentinelOrder);
+    expect(mockTriggerTripGroundTruthPrompt).toHaveBeenCalledWith('corr-1');
+    expect(mockSetTripEndedSentinel).toHaveBeenCalledWith(1_700_000_000_000, 'corr-1');
+    expect(await AsyncStorage.getItem(ACTIVE_TRIP_KEY)).toBeNull();
+  });
+
+  it('corrId null(미수화) → prompt/sentinel에 null 그대로 전달', async () => {
+    mockGetCurrentTripCorrIdSync.mockReturnValue(null);
+
+    await cleanupBackendConfirmedEndedTrip(42);
+
+    expect(mockTriggerTripGroundTruthPrompt).toHaveBeenCalledWith(null);
+    expect(mockSetTripEndedSentinel).toHaveBeenCalledWith(42, null);
+  });
+});

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -340,7 +340,13 @@ export type AlarmLogReason =
   // #2120 (#2114 근본 수리 Phase 2) — trip-ended push의 corrId가 device 현재 corrId와
   // 불일치해 cleanup 전체를 skip한 1건. tripToken(기기 고정)만으로는 못 막는 인스턴스 race
   // (backend 자동종료 push in-flight 중 device 재등록) 차단 evidence.
-  | 'trip-ended-corr-mismatch';
+  | 'trip-ended-corr-mismatch'
+  // #2178 — pull 기반 trip 死 backstop이 backend `status: 'ended'` 명시 응답으로 death를
+  // 확정하고 cleanup을 수행한 1건. silentPushTask 처리 말미(trip 신원 불일치/접촉 staleness)
+  // 또는 BG location tick(저빈도 쿨다운) 두 진입점 공통 reason — source='lifecycle-backstop'로
+  // 적재해 기존 backstop 계열과 같은 분포로 관측한다. 404/410(trip 부재)은 death 확정이
+  // 아니므로 별도 reason 없이 무동작(ADR-010, false positive는 miss와 동급).
+  | 'trip-dead-pull-detected';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.

--- a/src/features/alarm/utils/tripDeathPullBackstop.ts
+++ b/src/features/alarm/utils/tripDeathPullBackstop.ts
@@ -1,0 +1,143 @@
+/**
+ * Pull 기반 trip 死 backstop (#2178, Part of #2172).
+ *
+ * 배경: trip 사망 통보는 push 단일 채널(trip-ended sentinel)인데, 사망 사유가 APNs 토큰
+ * 무효면 그 push 자체가 도달 불가(닭-달걀). launch reconciliation(#1339)은 cold-launch
+ * 시점에만 동작 — BG 중 사망은 다음 FG 진입까지 인지되지 않는다. 08-06 evidence: 18:11 死를
+ * 20:19 FG까지 미인지, 그 사이 로컬 OS 예약 큐가 주인 없는 조기 묶음발사(어대공/군자/중곡/용마산).
+ *
+ * 전제(#2175): backend GET `/trips/:tripToken/status`가 로테이션 발생 시에도 실토큰 기준으로
+ * 해소돼야 안전 — 그 전엔 로테이션 직후 정상 trip을 404로 오판해 죽일 위험이 있었다(이슈
+ * #2178 코멘트). #2175가 머지·배포된 뒤에만 본 모듈을 사용한다.
+ *
+ * 보수적 death 판정 (ADR-010 — false positive는 miss와 동급, 오탐으로 trip을 죽이지 않는다):
+ *   - status === 'ended' (명시 응답)만 death 확정 → cleanup 수행.
+ *   - null(404/410) / status === 'active' / 네트워크 에러 → 전부 무동작.
+ *
+ * 두 진입점이 공유:
+ *   1. silentPushTask 처리 말미 — 로컬 active trip이 있는데 수신 payload의 trip 신원과
+ *      불일치하거나, 마지막 backend 접촉이 TRIP_DEATH_PULL_BACKSTOP_THRESHOLD_MS 이상이면 호출.
+ *   2. backgroundLocationTask — 신규 폴링/타이머 없이 기존 BG location tick에 편승, 같은
+ *      상수를 호출 쿨다운으로 사용(V8 battery acceptance).
+ *
+ * death 확정 시: OS 예약 큐 cancel + launch reconciliation과 동일 cleanup 시퀀스
+ * (tripEndedCleanupSequence, 중복 구현 금지) + alarmLog `trip-dead-pull-detected` 기록.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  ACTIVE_TRIP_KEY,
+  TRIP_DEATH_PULL_LAST_CHECK_AT_KEY,
+} from '../../../shared/constants/storageKeys';
+import { TRIP_DEATH_PULL_BACKSTOP_THRESHOLD_MS } from '../../../shared/constants/realtime';
+import { fetchTripStatus } from '../api/tripStatus';
+import { cancelTripBoundOsQueue } from '../store/tripBoundCleanups';
+import { cleanupBackendConfirmedEndedTrip } from './tripEndedCleanupSequence';
+import { appendAlarmLog } from './alarmLog';
+import { createLogger } from '../../../shared/utils/logger';
+
+const logger = createLogger('tripDeathPullBackstop');
+
+/** `EXPO_PUBLIC_ALARM_BACKEND_URL` trim. 미설정 시 null — 호출자는 graceful skip 처리. */
+export function getBackendUrl(): string | null {
+  const url = process.env.EXPO_PUBLIC_ALARM_BACKEND_URL;
+  if (!url) return null;
+  return url.replace(/\/$/, '');
+}
+
+async function readLastCheckedAt(): Promise<number | null> {
+  try {
+    const raw = await AsyncStorage.getItem(TRIP_DEATH_PULL_LAST_CHECK_AT_KEY);
+    if (raw === null) return null;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function stampCheckedAt(now: number): Promise<void> {
+  try {
+    await AsyncStorage.setItem(TRIP_DEATH_PULL_LAST_CHECK_AT_KEY, String(now));
+  } catch {
+    // graceful — 쿨다운 미기록이면 다음 wake에서 재시도할 뿐, death 판정 자체는 안전.
+  }
+}
+
+/**
+ * silentPushTask 진입점 트리거 조건 (스펙 1) — 순수 함수, 테스트 용이성을 위해 분리.
+ *
+ * 로컬 active trip이 있고, (a) 수신 payload가 trip 신원(tripToken)을 담고 있는데 로컬
+ * ACTIVE_TRIP_KEY와 불일치하거나, (b) 마지막 backend 접촉(직전 silent push 수신 시각)이
+ * threshold 이상 지났으면 true.
+ */
+export function shouldCheckTripDeathOnSilentPush(input: {
+  activeTripToken: string | null;
+  payloadTripToken: string | undefined;
+  priorLastReceivedAt: number | null;
+  now: number;
+}): boolean {
+  if (input.activeTripToken === null) return false;
+  const identityMismatch =
+    input.payloadTripToken !== undefined && input.payloadTripToken !== input.activeTripToken;
+  const contactStale =
+    input.priorLastReceivedAt !== null &&
+    input.now - input.priorLastReceivedAt >= TRIP_DEATH_PULL_BACKSTOP_THRESHOLD_MS;
+  return identityMismatch || contactStale;
+}
+
+export type TripDeathPullCheckSite = 'silent-push' | 'bg-location-tick';
+export type TripDeathPullCheckOutcome = 'ended' | 'alive' | 'skipped';
+
+/**
+ * pull 기반 death 확인 1회 시도.
+ *
+ * - active trip 없으면 즉시 skip.
+ * - 쿨다운(TRIP_DEATH_PULL_BACKSTOP_THRESHOLD_MS) 내 재호출은 skip — 호출 시도 자체를
+ *   기록해 실패(네트워크 에러) 반복 재시도로 인한 hot-loop도 함께 방지한다.
+ * - status==='ended' 명시 응답에서만 death 확정 → cleanup. 그 외(404/410/active/네트워크
+ *   에러)는 전부 무동작(false positive 방지, ADR-010).
+ */
+export async function checkTripDeathByPull(
+  baseUrl: string,
+  site: TripDeathPullCheckSite,
+): Promise<TripDeathPullCheckOutcome> {
+  const activeTripToken = await AsyncStorage.getItem(ACTIVE_TRIP_KEY);
+  if (activeTripToken === null) return 'skipped';
+
+  const now = Date.now();
+  const lastCheckedAt = await readLastCheckedAt();
+  if (lastCheckedAt !== null && now - lastCheckedAt < TRIP_DEATH_PULL_BACKSTOP_THRESHOLD_MS) {
+    return 'skipped';
+  }
+  await stampCheckedAt(now);
+
+  let result;
+  try {
+    result = await fetchTripStatus(activeTripToken, baseUrl);
+  } catch (e) {
+    logger.warn(`fetchTripStatus 실패 (site=${site}) — 무동작(다음 wake에서 재시도)`, e);
+    return 'skipped';
+  }
+
+  if (result === null || result.status === 'active') {
+    // 404/410은 보수적으로 무시 — 'ended' 명시 응답에서만 정리(#2178 전제 코멘트, ADR-010).
+    return 'alive';
+  }
+
+  // status === 'ended' — death 확정.
+  logger.info(
+    `trip dead confirmed via pull (site=${site}) reason=${result.endReason ?? 'unknown'}`,
+  );
+  // #1370 L4 — OS scheduled queue burst fire 차단(lesson_bg_scheduled_queue_stale_misfire).
+  // runTripBoundCleanups가 결국 cancel하지만, recall의 네트워크 stall로 열리는 race window를
+  // silentPushTask trip-ended 분기와 동일하게 선제 cancel로 좁힌다.
+  await cancelTripBoundOsQueue();
+  await cleanupBackendConfirmedEndedTrip(result.endedAt ?? now);
+  appendAlarmLog({
+    ts: now,
+    source: 'lifecycle-backstop',
+    outcome: 'fired',
+    reason: 'trip-dead-pull-detected',
+  });
+  return 'ended';
+}

--- a/src/features/alarm/utils/tripEndedCleanupSequence.ts
+++ b/src/features/alarm/utils/tripEndedCleanupSequence.ts
@@ -1,0 +1,51 @@
+/* eslint-disable import/no-restricted-paths --
+ * Cross-feature orchestration: trip-end 시 recall(telemetry) + tripBoundCleanups(alarm/route/widget)
+ * + groundTruthPrompt(debug) + tripCorrId(observability)를 한 곳에서 묶어 호출하는 shared
+ * cleanup sequence. useLaunchTripReconciliation.ts와 동형 orchestrator라 file-level disable로
+ * 옵트인 처리.
+ *
+ * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
+ */
+/**
+ * Backend-confirmed trip-ended cleanup sequence (#2178).
+ *
+ * `useLaunchTripReconciliation`(#1339 PR2, cold-launch backstop)의 `status === 'ended'` 분기가
+ * 수행하던 5단 시퀀스를 그대로 추출한 shared 함수. 신규 pull death backstop(#2178 — silent push
+ * 처리 말미 + BG location tick에서 backend에 직접 GET trip status로 생존 확인)이 동일 cleanup을
+ * 중복 구현하지 않고 여기를 재사용한다.
+ *
+ * 호출 순서 고정: triggerTripEndRecall → runTripBoundCleanups → triggerTripGroundTruthPrompt →
+ * setTripEndedSentinel → removeItem(ACTIVE_TRIP_KEY). recall이 cleanup보다 먼저여야 한다 —
+ * cleanup이 ROUTE_KEY/DESTINATION_KEY/TRIP_ORIGIN_KEY/TRIP_STARTED_AT_KEY를 제거하므로 그 뒤에
+ * recall이 돌면 입력이 비어 'empty'/'no-trip-start'로 skip된다.
+ *
+ * 멱등: setTripEndedSentinel + removeItem(ACTIVE_TRIP_KEY) 자체가 멱등이라 silent push
+ * trip-ended handler / launch reconciliation과 중복 호출돼도 안전.
+ *
+ * caller는 backend가 명시적으로 `status: 'ended'`를 반환한 경우에만 이 함수를 호출해야 한다 —
+ * 404/410(trip 부재)은 death 확정이 아니다(ADR-010, false positive는 miss와 동급).
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
+import { setTripEndedSentinel } from './tripEndedSentinel';
+import { triggerTripEndRecall } from './triggerTripEndRecall';
+import { runTripBoundCleanups } from '../store/tripBoundCleanups';
+import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
+import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
+
+/**
+ * backend-confirmed 'ended' trip을 device 상태에 반영한다.
+ *
+ * @param endedAt backend가 보고한 종료 시각(epoch ms). 미상이면 호출자가 `Date.now()` fallback.
+ */
+export async function cleanupBackendConfirmedEndedTrip(endedAt: number): Promise<void> {
+  await triggerTripEndRecall();
+  // #1597 — clearTripCorrId가 cache를 비우기 전에 종료된 trip의 corrId snapshot 캡처.
+  const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
+  await runTripBoundCleanups();
+  // #1597 — trip-end 사용자 정답지 prompt enqueue (cleanup 후, corrId snapshot으로).
+  await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
+  // #2114 (방안 C′) — sentinel에 corrId 동봉.
+  await setTripEndedSentinel(endedAt, endedCorrIdSnapshot);
+  await AsyncStorage.removeItem(ACTIVE_TRIP_KEY);
+}

--- a/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
@@ -123,6 +123,14 @@ jest.mock('../../utils/wifiSsidLookup', () => ({
   lookupStationBySsid: (ssid: string | null | undefined) => mockLookupStationBySsid(ssid),
 }));
 
+// ── #2178 pull death backstop 모킹 — wiring만 검증(내부 판정/cleanup은 tripDeathPullBackstop.test.ts 전담) ──
+const mockGetTripDeathPullBackendUrl = jest.fn<string | null, []>(() => null);
+const mockCheckTripDeathByPull = jest.fn().mockResolvedValue('skipped');
+jest.mock('../../../alarm/utils/tripDeathPullBackstop', () => ({
+  getBackendUrl: () => mockGetTripDeathPullBackendUrl(),
+  checkTripDeathByPull: (...args: unknown[]) => mockCheckTripDeathByPull(...args),
+}));
+
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { AlarmEvent } from '../../../../shared/types/alarm';
 // 모듈 import — defineTask가 이 시점에 호출되어 global에 콜백이 저장됨
@@ -231,6 +239,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     // #1667 기본값: WiFi 미연결(null) → wifiSsidStationName undefined
     mockGetCurrentWifiSsid.mockResolvedValue(null);
     mockLookupStationBySsid.mockReturnValue(null);
+    // #2178 — pull death backstop 기본값: baseUrl 없음(호출 안 함). 개별 테스트에서 override.
+    mockGetTripDeathPullBackendUrl.mockReturnValue(null);
+    mockCheckTripDeathByPull.mockResolvedValue('skipped');
   });
 
   it('defineTask가 올바른 태스크 이름으로 등록된다', () => {
@@ -1390,6 +1401,64 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       expect(mockUploadPosition).toHaveBeenCalledWith(
         expect.objectContaining({ motion: 'unknown' }),
       );
+    });
+  });
+
+  // #2178 — pull 기반 trip 死 backstop. 내부 판정/cleanup 로직 자체는 tripDeathPullBackstop.test.ts가
+  // 전담 — 여기서는 BG location tick이 GPS 게이트와 무관하게 wiring하는지만 검증한다.
+  describe('#2178 — pull death backstop (tick 진입 즉시)', () => {
+    it('baseUrl 미설정 → checkTripDeathByPull 호출 안 함', async () => {
+      mockGetTripDeathPullBackendUrl.mockReturnValue(null);
+      const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+      await taskCallback({ data: { locations: [loc] }, error: null });
+      expect(mockCheckTripDeathByPull).not.toHaveBeenCalled();
+    });
+
+    it('baseUrl 설정 → checkTripDeathByPull(baseUrl, "bg-location-tick") 호출', async () => {
+      mockGetTripDeathPullBackendUrl.mockReturnValue('https://api.test.dev');
+      const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+      await taskCallback({ data: { locations: [loc] }, error: null });
+      expect(mockCheckTripDeathByPull).toHaveBeenCalledWith(
+        'https://api.test.dev',
+        'bg-location-tick',
+      );
+    });
+
+    it('저정확도/stale fix로 이후 게이트가 drop되는 fix라도 backstop은 호출됨(GPS 품질 무관)', async () => {
+      mockGetTripDeathPullBackendUrl.mockReturnValue('https://api.test.dev');
+      // gate-age에 걸리는 오래된 fix.
+      const staleLoc = makeLocation(37.498, 127.028, { ageMs: MAX_LOCATION_AGE_MS + 60_000 });
+      await taskCallback({ data: { locations: [staleLoc] }, error: null });
+      expect(mockCheckTripDeathByPull).toHaveBeenCalledWith(
+        'https://api.test.dev',
+        'bg-location-tick',
+      );
+      // 게이트 자체는 그대로 차단 — backstop 추가가 기존 게이트 동작을 바꾸지 않음을 함께 확인.
+      expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+    });
+
+    it('checkTripDeathByPull throw해도 graceful (기존 알람 파이프라인 차단 없음)', async () => {
+      mockGetTripDeathPullBackendUrl.mockReturnValue('https://api.test.dev');
+      mockCheckTripDeathByPull.mockRejectedValueOnce(new Error('backend-fail'));
+      mockStorageValues(JSON.stringify(mockDestination));
+      const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+
+      await expect(
+        taskCallback({ data: { locations: [loc] }, error: null }),
+      ).resolves.toBeUndefined();
+      expect(mockProcessLocationUpdate).toHaveBeenCalled();
+    });
+
+    it('error 분기 → checkTripDeathByPull 호출 안 함 (기존 early-return 유지)', async () => {
+      mockGetTripDeathPullBackendUrl.mockReturnValue('https://api.test.dev');
+      await taskCallback({ data: null, error: { message: '위치 오류' } });
+      expect(mockCheckTripDeathByPull).not.toHaveBeenCalled();
+    });
+
+    it('data 없음 분기 → checkTripDeathByPull 호출 안 함 (기존 early-return 유지)', async () => {
+      mockGetTripDeathPullBackendUrl.mockReturnValue('https://api.test.dev');
+      await taskCallback({ data: null, error: null });
+      expect(mockCheckTripDeathByPull).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/nearest-station/tasks/backgroundLocationTask.ts
+++ b/src/features/nearest-station/tasks/backgroundLocationTask.ts
@@ -49,6 +49,10 @@ import type { Station } from '../../../shared/types/station';
 // device가 lookup 후 역명만 송신 — backend는 stations.json 없으므로 lookup은 device 책임.
 import { getCurrentWifiSsid } from '../utils/wifiSsidNative';
 import { lookupStationBySsid } from '../utils/wifiSsidLookup';
+// #2178 — pull 기반 trip 死 backstop. 신규 폴링/타이머 없이 이미 깨어나는 BG location tick에
+// 편승해 저빈도(내부 쿨다운)로 backend trip status를 확인한다. alarm 슬라이스 cross-feature
+// import는 본 파일 헤더 file-level disable로 이미 옵트인.
+import { checkTripDeathByPull, getBackendUrl as getTripDeathPullBackendUrl } from '../../alarm/utils/tripDeathPullBackstop';
 
 const logger = createLogger('BackgroundLocation');
 
@@ -129,6 +133,18 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
   const { locations } = data as { locations: Location.LocationObject[] };
   const latest = locations[locations.length - 1];
   if (!latest) return;
+
+  // #2178 — pull 기반 trip 死 backstop. GPS fix 품질(age/accuracy)과 무관하게 "BG task가
+  // 깨어났다"는 사실 자체가 backend 생존 확인 기회다. fire-and-forget — 아래 알람 파이프라인의
+  // 타이밍을 막지 않는다. 내부 쿨다운(TRIP_DEATH_PULL_BACKSTOP_THRESHOLD_MS)이 매 tick마다
+  // backend를 호출하지 않도록 빈도를 제한하고, baseUrl 미설정/active trip 없음/네트워크 실패는
+  // checkTripDeathByPull 내부에서 graceful skip.
+  const tripDeathPullBackendUrl = getTripDeathPullBackendUrl();
+  if (tripDeathPullBackendUrl !== null) {
+    void checkTripDeathByPull(tripDeathPullBackendUrl, 'bg-location-tick').catch((e: unknown) => {
+      logger.warn('pull death backstop 실패 (graceful)', e);
+    });
+  }
 
   // iOS deferred 위치 배치에서 stale/저정확도 좌표가 섞여 들어올 수 있음 — 차단.
   // 측정용으로 게이트 drop을 알람 로그에 fire-and-forget 적재 (B2 인프라).

--- a/src/shared/constants/realtime.ts
+++ b/src/shared/constants/realtime.ts
@@ -235,6 +235,22 @@ export const SIGNAL_4_SILENT_PUSH_TIMEOUT_MS = 30 * 60_000;
 export const SIGNAL_4_KTX_ETA_UPPER_BOUND_MS = 10 * 60 * 60_000;
 
 /**
+ * #2178 — pull 기반 trip 死 backstop(silentPushTask 처리 말미 + BG location tick)의
+ * 판단/호출 빈도 상수.
+ *
+ * - silentPushTask: 로컬 active trip이 있는데 수신 payload의 trip 신원이 불일치하거나,
+ *   마지막 backend 접촉(직전 silent push 수신)이 이 값 이상 지났으면 GET trip status 시도.
+ * - backgroundLocationTask: 같은 값을 호출 쿨다운으로 사용 — 신규 폴링/타이머를 추가하지
+ *   않고 기존 BG location tick(이미 깨어나는 지점)에 편승하되, 매 tick마다 backend를
+ *   호출하지 않도록 저빈도로 제한한다(V8 battery acceptance).
+ *
+ * 10분 — SIGNAL_4_SILENT_PUSH_TIMEOUT_MS(30분, launch-only backstop)보다 짧게 잡아
+ * BG 중에도 더 빠르게 death를 인지한다. 너무 짧으면 status GET 빈도가 배터리/backend
+ * 부담이 되므로 10분을 하한으로 둔다(스펙 "쿨다운 ≥10분").
+ */
+export const TRIP_DEATH_PULL_BACKSTOP_THRESHOLD_MS = 10 * 60_000;
+
+/**
  * #1922 (M2) — lockless route-hop / re-anchored time-integration "stuck" 가드.
  *
  * `tryLocklessRouteHop`은 실측 신호(lastObserved) 없이 `tripStartedAt`만으로 시간 적분을 진행한다.

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -210,6 +210,12 @@ export const LAST_SILENT_PUSH_RECEIVED_AT_KEY = 'subway-now:last-silent-push-rec
 // (10s) 미만 간격의 연속 catch-up batch 배달에서도 uploadPosition 호출을 1회로 묶는다.
 // 형식: 숫자(epoch ms) 문자열. 키 부재 = 첫 fix(즉시 발사).
 export const BG_LAST_POSITION_UPLOAD_AT_KEY = 'subway-now:bg-last-position-upload-at';
+// #2178 — pull 기반 trip 死 backstop 마지막 GET trip status 시도 시각(epoch ms).
+// silentPushTask/backgroundLocationTask 양쪽이 공유하는 쿨다운 게이트(TRIP_DEATH_PULL_BACKSTOP_THRESHOLD_MS).
+// 신규 타이머 없이 기존 wake 지점(silent push 수신, BG location tick)에서만 이 키를 read/write —
+// 매 wake마다 backend를 호출하지 않도록 빈도를 제한한다(V8 battery acceptance).
+// trip 종료 시 별도 cleanup 불필요 — 다음 trip의 첫 wake에서 쿨다운을 지나면 자연 갱신.
+export const TRIP_DEATH_PULL_LAST_CHECK_AT_KEY = 'subway-now:trip-death-pull-last-check-at';
 // #2067 (Phase 2-device) — AlarmLocalAuthority persisted dedup ledger.
 // 취침모드 companion silent push(kind `sleep-alarm-companion`)의 TTS/진동 부가 동작이 앱 재시작
 // (cold-launch) 후에도 중복 발사되지 않도록 in-memory Set 대신 AsyncStorage에 영속화한다.


### PR DESCRIPTION
Closes #2178
Part of #2172

## 요약
trip 사망 통보가 push 단일 채널(trip-ended sentinel)인데 사망 사유가 APNs 토큰 무효면 그 push 자체가 도달 불가(닭-달걀). launch reconciliation(#1339)은 cold-launch에만 동작해 BG 중 사망은 다음 FG 진입까지 인지되지 않는다(08-06 evidence: 18:11 死를 20:19 FG까지 미인지, 그 사이 로컬 OS 예약 큐 조기 묶음발사).

본 PR은 이미 깨어나는 두 지점(silentPushTask 처리 말미, BG location tick)에서 신규 폴링/타이머 없이 backend `GET /trips/:tripToken/status`로 저빈도 생존 확인을 추가한다.

## 변경
- `silentPushTask.ts` 처리 말미: 로컬 active trip이 있는데 수신 payload의 trip 신원(tripToken)이 불일치하거나, 마지막 backend 접촉(직전 silent push 수신)이 `TRIP_DEATH_PULL_BACKSTOP_THRESHOLD_MS`(10분) 이상이면 GET trip status 1회 시도.
- `backgroundLocationTask.ts`: tick 진입 즉시(GPS age/accuracy 게이트와 무관하게) 같은 상수를 호출 쿨다운으로 사용해 저빈도 확인. 신규 타이머 없음 — 기존 tick에 편승.
- 보수적 death 판정(ADR-010, false positive는 miss와 동급): `status === 'ended'` 명시 응답에서만 death 확정. 404/410(null) / active / 네트워크 실패는 전부 무동작 — 이슈 코멘트 전제(#2175 실토큰 status 해소 이후에도 404 단독으로 trip 폐기 금지) 그대로 반영.
- death 확정 시: `cancelTripBoundOsQueue()` 선제 호출(OS 예약 큐 cancel, lesson_bg_scheduled_queue_stale_misfire) + `cleanupBackendConfirmedEndedTrip()` (recall → cleanup → prompt → sentinel → active trip clear) + alarmLog `trip-dead-pull-detected` 기록.
- `useLaunchTripReconciliation.ts`의 `status === 'ended'` 분기 5단 시퀀스를 `tripEndedCleanupSequence.ts`로 추출해 신규 pull backstop과 공유(스펙 요구 — 중복 구현 금지). 기존 동작/테스트 변경 없음(refactor-only).
- 신규 상수: `TRIP_DEATH_PULL_BACKSTOP_THRESHOLD_MS`(10분, `shared/constants/realtime.ts`), `TRIP_DEATH_PULL_LAST_CHECK_AT_KEY`(`shared/constants/storageKeys.ts`).

## 금지사항 준수
- 신규 폴링/타이머 없음 — 기존 wake 지점(silent push 수신, BG location tick)에만 편승.
- 등록/토큰 로직 미접근.
- backend 변경 없음 — 기존 `GET /trips/:tripToken/status`(#1339/#2175) 그대로 사용.

## 테스트 (red-green)
- `tripDeathPullBackstop.test.ts` (신규, 20 tests, 100% coverage): 트리거 조건 판정(`shouldCheckTripDeathOnSilentPush`) + 쿨다운 + 404/410/active/네트워크실패 무동작 + ended 시 death 확정 시퀀스.
- `tripEndedCleanupSequence.test.ts` (신규): 추출된 5단 시퀀스 호출 순서 검증.
- `silentPushTask.test.ts` — `#2178` describe 추가: baseUrl 미설정/트리거 false/true, tripToken 없는 payload, throw graceful.
- `backgroundLocationTask.test.ts` — `#2178` describe 추가: baseUrl 미설정/설정, GPS 게이트와 무관하게 호출됨, throw graceful, error/data-없음 분기에서는 호출 안 함.
- `useLaunchTripReconciliation.test.ts` — 기존 테스트 무변경으로 pass(refactor 검증).

## Wire-completion 5단
1. **Orphan** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — DebugModal alarm log에 `source='lifecycle-backstop', reason='trip-dead-pull-detected'` entry로 표시(entry.reason 일반 렌더링 경로, `Alarm Log Reasons (1h)` 카운터 섹션에도 자동 집계).
3. **의존 PR** — #2175(backend status 핸들러 실토큰 해소) 머지·배포 완료 후 착수(이슈 코멘트 전제). 본 PR 자체는 추가 backend 배포 불필요.
4. **측정 plan** — 다음 실탑승에서 backend 死를 유도(또는 자연 발생) 시 `trip-dead-pull-detected` alarmLog 발생 여부 + 로컬 OS 예약 큐 오발사 0건을 실기기 tail/DebugModal로 확인. Epic #2172 탑승과 공유.
5. **Device verify** — 실기기 필요. 시나리오: (a) trip 진행 중 backend가 trip을 ended 처리하도록 유도(또는 자연 만료) 후 BG 상태로 방치 → 다음 silent push 또는 BG location tick에서 pull backstop이 death를 감지해 OS 예약 큐가 정리되는지, (b) 정상 trip 진행 중에는 오탐(false positive)으로 trip이 죽지 않는지 확인.

## Test plan
- [x] `npm test` — 428 suites, 9137 tests, coverage 100%
- [x] `npm run type-check` — pass
- [x] `npm run lint:orphan` — 0 orphan
- [ ] 실기기 검증 (위 Device verify 시나리오, 사용자 담당)