### PR TITLE
fix(#2185): logPushFailure token_hash를 실 deviceToken 기준으로 통일

### DIFF
--- a/backend/alarm-worker/migrations/0002_push_failures.sql
+++ b/backend/alarm-worker/migrations/0002_push_failures.sql
@@ -7,7 +7,11 @@
 CREATE TABLE IF NOT EXISTS push_failures (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   ts INTEGER NOT NULL,
+  -- #2185 — 실 APNs 발사 주소(resolveTripDeviceToken(trip) == trip.deviceToken) 해시.
+  -- 디바이스 단위 실패 추적/조회 키.
   token_hash TEXT NOT NULL,
+  -- #2185 — trip 신원 토큰(trip.token, 로테이션 시 crypto.randomUUID()로 교체) 해시.
+  -- token_hash와 별도로 남겨 "어느 trip 레코드가 이 실패를 냈는지" 역추적 가능.
   trip_token_hash TEXT,
   push_kind TEXT NOT NULL,
   apns_status INTEGER NOT NULL,

--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -12,6 +12,7 @@ import {
   type LiveActivityDeps,
   type LiveActivityStats,
 } from '../liveActivity';
+import { hashTripToken } from '../sentry';
 import { readSsot, seedSsot } from '../tripPositionSsot';
 import { getDeviceTripIndex, putDeviceTripIndex } from '../trips';
 import type { ApnsEnv, Env, Trip, TripEndedReason, Waypoint } from '../types';
@@ -804,6 +805,47 @@ describe('cleanupTripWithLa', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
     expect(logs).toContain('trip-ended push failed');
     expect(await kv.get('trip:devtoken')).toBeNull();
+  });
+
+  // #2185 — 로테이션된 trip(token=UUID, deviceToken=실토큰) 실패 기록 시 push_failures.token_hash가
+  // 실제 APNs 발사 주소(deviceToken)의 hash여야 한다. trip.token(신원)의 hash가 아니다.
+  it('로테이션된 trip 실패 기록 시 token_hash가 실 deviceToken 해시다 (#2185)', async () => {
+    const kv = new InMemoryKV();
+    const rotatedIdentityToken = '11111111-2222-3333-4444-555555555555';
+    const realDeviceToken = 'a'.repeat(64);
+    const trip = makeTrip({
+      token: rotatedIdentityToken,
+      deviceToken: realDeviceToken,
+      activityPushToken: undefined,
+      apnsEnv: 'sandbox',
+    });
+    await kv.put(`trip:${rotatedIdentityToken}`, JSON.stringify(trip));
+    const insertBind = vi.fn().mockReturnValue({ run: vi.fn().mockResolvedValue({ success: true }) });
+    const selectBind = vi.fn().mockReturnValue({ first: vi.fn().mockResolvedValue(null) });
+    const prepare = vi.fn().mockImplementation((sql: string) =>
+      sql.startsWith('SELECT') ? { bind: selectBind } : { bind: insertBind },
+    );
+    const db = { prepare } as unknown as D1Database;
+    const env = { TRIPS: kv as unknown as KVNamespace, DB: db } as unknown as Env;
+    const fetchImpl = vi.fn(
+      async () => new Response(JSON.stringify({ reason: 'BadDeviceToken' }), { status: 400 }),
+    );
+    await cleanupTripWithLa(
+      trip,
+      env,
+      makeDeps(fetchImpl as unknown as typeof fetch),
+      makeStats(),
+      NOW,
+      () => undefined,
+      'eta-missing',
+    );
+
+    expect(insertBind).toHaveBeenCalled();
+    // bind 순서: ts, tokenHash, tripTokenHash, pushKind, status, reason, env, envMismatchExhausted
+    const [, tokenHash, tripTokenHash] = insertBind.mock.calls[0];
+    expect(tokenHash).toBe(hashTripToken(realDeviceToken));
+    expect(tokenHash).not.toBe(hashTripToken(rotatedIdentityToken));
+    expect(tripTokenHash).toBe(hashTripToken(rotatedIdentityToken));
   });
 
   // #1337 — KV `tripEndedAlert:{tripToken}:{createdAt}` set-if-absent gate. 같은 trip의 cleanup이 race로

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -410,7 +410,9 @@ async function fireTripEndedAlertPush(
       // #2177 — trip-ended push는 retry queue를 타지 않는 fire-and-forget 경로(다음 cron
       // cycle에 자연 재시도) — 직접 기록.
       await logPushFailure(env.DB, {
-        token: trip.token,
+        // #2185 — token_hash는 실 APNs 발사 주소(deviceToken) 기준. trip.token은 신원(로테이션 시 UUID)이라
+        // 별도로 trip_token_hash에 남긴다.
+        token: resolveTripDeviceToken(trip),
         tripToken: trip.token,
         pushKind: 'trip-ended',
         apnsStatus: heal.result.status,

--- a/backend/alarm-worker/src/pushFailureLog.ts
+++ b/backend/alarm-worker/src/pushFailureLog.ts
@@ -27,9 +27,17 @@ import type { ApnsEnv } from './types';
 const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
 
 export interface PushFailureInput {
-  /** APNs device token — 원본 노출 금지, FNV-1a hash만 저장. */
+  /**
+   * #2185 — 실 APNs 발사 주소(호출자가 `resolveTripDeviceToken(trip)`으로 해석한 값 전달 책임).
+   * `token_hash` 컬럼에 FNV-1a hash로 저장 — 원본 노출 금지. 디바이스 단위 실패 추적/조회 키.
+   */
   token: string;
-  /** trip 식별 토큰. 현재 시스템에서는 device token과 동일 값(`trip.token`)이지만 스키마상 분리. */
+  /**
+   * trip 신원 토큰(`trip.token`) — 로테이션(`rotateTripTokenForNewRoute`) 시 `crypto.randomUUID()`로
+   * 교체되므로 `token`(발사 주소)과 다를 수 있다. `trip_token_hash` 컬럼용. 미전달 시 `token`과
+   * 동일하게 취급(hash 재사용) — trip 객체 없이 deviceToken만 아는 caller(fallback/retry-loop
+   * 자기 재 enqueue)의 기존 동작 100% 유지.
+   */
   tripToken?: string;
   /** push 종류 (예: 'transfer' | 'destination' | 'intermediate' | 'reschedule' | 'boarding-prompt' 등). */
   pushKind: string;

--- a/backend/alarm-worker/src/retryPushes.ts
+++ b/backend/alarm-worker/src/retryPushes.ts
@@ -116,7 +116,14 @@ export async function enqueueRetryIfTransient(
   kv: KVNamespace | undefined,
   input: {
     pushId: string;
+    /** APNs 재발사 주소(deviceToken). push_failures.token_hash가 이 값으로 해시된다. */
     token: string;
+    /**
+     * #2185 — trip 신원 토큰(로테이션 시 UUID로 교체될 수 있음). push_failures.trip_token_hash용.
+     * 미전달(fallback/retry-loop 자기 재 enqueue처럼 caller가 trip 객체 없이 deviceToken만
+     * 아는 경로) 시 token과 동일하게 취급 — 기존 동작 100% 유지.
+     */
+    tripToken?: string;
     payload: SilentPushPayload;
     apnsEnv: ApnsEnv;
     status: number;
@@ -133,7 +140,7 @@ export async function enqueueRetryIfTransient(
   const recordFinalFailure = () =>
     logPushFailure(db, {
       token: input.token,
-      tripToken: input.token,
+      tripToken: input.tripToken ?? input.token,
       pushKind: input.payload.kind,
       apnsStatus: input.status,
       apnsReason: input.reason,

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -2209,6 +2209,8 @@ async function maybeFireSleepAlarm(inputs: MaybeFireSleepAlarmInputs): Promise<v
         pushId: alertPushId,
         // #2174 — pending/retry queue entry의 token은 APNs 재발사 주소. deviceToken 사용.
         token: resolveTripDeviceToken(trip),
+        // #2185 — trip_token_hash용 신원 토큰.
+        tripToken: trip.token,
         payload: buildSleepAlarmRetryPayload(alertPushId, target, targetKind, trip.token, now),
         apnsEnv: alertHeal.correctedEnv ?? trip.apnsEnv ?? 'sandbox',
         status: alertHeal.result.status,
@@ -2234,6 +2236,8 @@ async function maybeFireSleepAlarm(inputs: MaybeFireSleepAlarmInputs): Promise<v
         pushId: companionPushId,
         // #2174 — pending/retry queue entry의 token은 APNs 재발사 주소. deviceToken 사용.
         token: resolveTripDeviceToken(trip),
+        // #2185 — trip_token_hash용 신원 토큰.
+        tripToken: trip.token,
         payload: buildSleepAlarmRetryPayload(companionPushId, target, targetKind, trip.token, now),
         apnsEnv: companionHeal.correctedEnv ?? trip.apnsEnv ?? 'sandbox',
         status: companionHeal.result.status,
@@ -2461,6 +2465,8 @@ export async function fireArvlCdStationPush(
         pushId,
         // #2174 — pending/retry queue entry의 token은 APNs 재발사 주소. deviceToken 사용.
         token: resolveTripDeviceToken(trip),
+        // #2185 — trip_token_hash용 신원 토큰.
+        tripToken: trip.token,
         payload: arvlcdPayload,
         apnsEnv: trip.apnsEnv ?? 'sandbox',
         status: heal.result.status,
@@ -2853,6 +2859,8 @@ export async function fireVanishFallbackStationPush(
         pushId,
         // #2174 — pending/retry queue entry의 token은 APNs 재발사 주소. deviceToken 사용.
         token: resolveTripDeviceToken(trip),
+        // #2185 — trip_token_hash용 신원 토큰.
+        tripToken: trip.token,
         payload: vanishPayload,
         apnsEnv: trip.apnsEnv ?? 'sandbox',
         status: heal.result.status,
@@ -3027,7 +3035,9 @@ async function fireTrainReconfirmPush(
       });
       // #2177 — retry queue를 타지 않는 fire-and-forget 경로(다음 cycle 자연 재시도) — 직접 기록.
       await logPushFailure(env.DB, {
-        token: trip.token,
+        // #2185 — token_hash는 실 APNs 발사 주소(deviceToken) 기준. trip.token은 신원(로테이션 시 UUID)이라
+        // 별도로 trip_token_hash에 남긴다.
+        token: resolveTripDeviceToken(trip),
         tripToken: trip.token,
         pushKind: payload.kind,
         apnsStatus: heal.result.status,
@@ -3737,6 +3747,8 @@ export async function advanceBoardingLockWaypoint(
           pushId,
           // #2174 — pending/retry queue entry의 token은 APNs 재발사 주소. deviceToken 사용.
           token: resolveTripDeviceToken(trip),
+          // #2185 — trip_token_hash용 신원 토큰.
+          tripToken: trip.token,
           payload: transferPayload,
           apnsEnv: trip.apnsEnv ?? 'sandbox',
           status: transferHeal.result.status,
@@ -3993,7 +4005,9 @@ export async function maybeReschedulePush(
     });
     // #2177 — reschedule push는 retry queue를 타지 않는 fire-and-forget 경로 — 직접 기록.
     await logPushFailure(env.DB, {
-      token: trip.token,
+      // #2185 — token_hash는 실 APNs 발사 주소(deviceToken) 기준. trip.token은 신원(로테이션 시 UUID)이라
+      // 별도로 trip_token_hash에 남긴다.
+      token: resolveTripDeviceToken(trip),
       tripToken: trip.token,
       pushKind: 'reschedule',
       apnsStatus: result.status,
@@ -4233,7 +4247,9 @@ export async function runLocklessIntermediate(
         // #2177 — unrecoverable(410/mismatch exhausted)로 cleanup 분기하는 경로는 retry queue를
         // 타지 않아 enqueueRetryIfTransient의 공통 D1 기록 지점을 지나지 않는다 — 직접 기록.
         await logPushFailure(env.DB, {
-          token: trip.token,
+          // #2185 — token_hash는 실 APNs 발사 주소(deviceToken) 기준. trip.token은 신원(로테이션 시 UUID)이라
+          // 별도로 trip_token_hash에 남긴다.
+          token: resolveTripDeviceToken(trip),
           tripToken: trip.token,
           pushKind: locklessPayload.kind,
           apnsStatus: heal.result.status,
@@ -4255,6 +4271,8 @@ export async function runLocklessIntermediate(
           pushId,
           // #2174 — pending/retry queue entry의 token은 APNs 재발사 주소. deviceToken 사용.
           token: resolveTripDeviceToken(trip),
+          // #2185 — trip_token_hash용 신원 토큰.
+          tripToken: trip.token,
           payload: locklessPayload,
           apnsEnv: trip.apnsEnv ?? 'sandbox',
           status: heal.result.status,
@@ -4919,7 +4937,9 @@ export async function evaluateAndMaybeFireBoardingPrompt(
     // #2177 — boarding-prompt push는 retry queue를 타지 않는 fire-and-forget 경로 — 직접 기록.
     // 08-06 RCA의 원 동기(push-unrecoverable 정확한 코드 확인) — 최우선 대상 push kind.
     await logPushFailure(env.DB, {
-      token: trip.token,
+      // #2185 — token_hash는 실 APNs 발사 주소(deviceToken) 기준. trip.token은 신원(로테이션 시 UUID)이라
+      // 별도로 trip_token_hash에 남긴다.
+      token: resolveTripDeviceToken(trip),
       tripToken: trip.token,
       pushKind: 'boarding-prompt',
       apnsStatus: heal.result.status,
@@ -5048,7 +5068,9 @@ export async function maybeFireHopEndPrompt(inputs: {
     });
     // #2177 — hop-end-prompt push는 retry queue를 타지 않는 fire-and-forget 경로 — 직접 기록.
     await logPushFailure(env.DB, {
-      token: trip.token,
+      // #2185 — token_hash는 실 APNs 발사 주소(deviceToken) 기준. trip.token은 신원(로테이션 시 UUID)이라
+      // 별도로 trip_token_hash에 남긴다.
+      token: resolveTripDeviceToken(trip),
       tripToken: trip.token,
       pushKind: 'hop-end-prompt',
       apnsStatus: heal.result.status,


### PR DESCRIPTION
Closes #2185

## 원인
#2183의 push_failures.token_hash가 trip.token(신원, 로테이션 후 UUID)을 해시하도록 남아 있던 6개 직접 호출부(scheduled.ts x5, liveActivity.ts x1) 발견. #2184 이후 실제 APNs 발사 주소는 resolveTripDeviceToken(trip)이므로, 로테이션된 trip의 실패 기록이 실 디바이스와 상관관계를 잃는 문제.

## 변경
- scheduled.ts 5개소 + liveActivity.ts 1개소: `token: trip.token` → `token: resolveTripDeviceToken(trip)`
- retryPushes.ts `enqueueRetryIfTransient`에 optional `tripToken` 필드 추가 — 이미 deviceToken을 token으로 넘기던 6개 scheduled.ts 호출부가 trip.token을 identity hash용으로 별도 전달하도록 정정 (기존엔 deviceToken이 trip_token_hash에도 재사용돼 신원 구분이 사라졌음)
- push_failures 테이블 컬럼 + `PushFailureInput` 필드에 token_hash(발사 주소)/trip_token_hash(신원) 역할 주석 명시
- fallback.ts / apnsHost.ts observe 경로(#2188) / retryPushes.ts 자기 재enqueue 경로는 이미 deviceToken을 token으로 쓰고 있어 변경 불필요 확인 (PendingPush.token은 #2174에서 이미 resolveTripDeviceToken(trip) 캡처)
- #2177 rate-limit 가드 키((token_hash, push_kind))는 token_hash가 이제 deviceToken 기준이라 "디바이스당 kind별 1건/window" 의도와 정합됨

## 테스트
- red-green: 로테이션된 trip(token=UUID, deviceToken=64-hex 실토큰) 실패 기록 시 token_hash가 실토큰 해시인지 검증 (`liveActivity.test.ts`) — fix 전 revert 시 실패 확인 완료
- `npm test` 2899 passed / `npm run type-check` clean

## Wire 5단
1. Orphan 없음 — 신규 export 없음(기존 함수 시그니처 확장). N/A
2. V/X dashboard — D1 `push_failures` SELECT로 확인 가능 (token_hash가 hashTripToken(deviceToken)과 일치)
3. 의존 PR — #2175 (같은 파일 충돌 회피 권장, 병렬 진행 시 rebase 필요할 수 있음)
4. 측정 plan — 다음 실탑승 중 push 실패 발생 시 D1 조회로 디바이스 단위 추적 가능한지 확인
5. Device verify — N/A, type+unit only

## Test plan
- [x] `npm test` (2899 passed, coverage 유지)
- [x] `npm run type-check`
- [x] red-green: 로테이션 trip 시나리오 revert 시 실패 → fix 후 통과 확인