### PR TITLE
fix(#2210): FG 진입 stale 알람 overlay 억제 — setAlarmEvent 게이트 중앙화

### DIFF
--- a/src/features/alarm/store/__tests__/useAlarmEventStore.test.ts
+++ b/src/features/alarm/store/__tests__/useAlarmEventStore.test.ts
@@ -1,5 +1,12 @@
+/* eslint-disable import/no-restricted-paths --
+ * #2210 — useAlarmEventStore.ts와 동일한 orchestration 사유. 테스트가 게이트 조건(sleepMode,
+ * destination)을 직접 세팅하려면 해당 sibling store를 import해야 한다.
+ */
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useAlarmEventStore } from '../useAlarmEventStore';
+import { useSettingsStore } from '../../../settings/store/useSettingsStore';
+import { useDestinationStore } from '../../../route/store/useDestinationStore';
+import { MOCK_STATIONS } from '../../../../testUtils/fixtures';
 
 jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
@@ -8,6 +15,9 @@ jest.mock('@react-native-async-storage/async-storage', () =>
 describe('useAlarmEventStore', () => {
   beforeEach(() => {
     useAlarmEventStore.setState({ alarmEvent: null, dismissSilence: null });
+    // #2210 — setAlarmEvent 게이트가 참조하는 cross-feature 상태를 매 테스트 기본값으로 리셋.
+    useSettingsStore.setState({ sleepMode: false });
+    useDestinationStore.setState({ destination: null });
     jest.clearAllMocks();
   });
 
@@ -17,7 +27,8 @@ describe('useAlarmEventStore', () => {
     expect(useAlarmEventStore.getState().alarmEvent).toBeNull();
   });
 
-  it('setAlarmEvent: 알람 이벤트를 설정한다', () => {
+  it('setAlarmEvent: 활성 trip 중(destination 존재)이면 알람 이벤트를 설정한다', () => {
+    useDestinationStore.setState({ destination: MOCK_STATIONS.gangnam });
     const { setAlarmEvent } = useAlarmEventStore.getState();
     setAlarmEvent({ phaseId: 'early', type: 'destination', stationName: '강남' });
 
@@ -25,7 +36,27 @@ describe('useAlarmEventStore', () => {
     expect(alarmEvent).toEqual({ phaseId: 'early', type: 'destination', stationName: '강남' });
   });
 
+  it('setAlarmEvent: sleepMode=true면 trip 종료 상태여도 알람 이벤트를 설정한다', () => {
+    useSettingsStore.setState({ sleepMode: true });
+    const { setAlarmEvent } = useAlarmEventStore.getState();
+    setAlarmEvent({ phaseId: 'early', type: 'destination', stationName: '강남' });
+
+    const { alarmEvent } = useAlarmEventStore.getState();
+    expect(alarmEvent).toEqual({ phaseId: 'early', type: 'destination', stationName: '강남' });
+  });
+
+  // #2210 (증상③) — 비취침 + trip 종료 상태의 stale 알람 replay 억제. red: 게이트 추가 전에는
+  // sleepMode=false, destination=null 기본 상태에서도 alarmEvent가 그대로 설정돼 FG 복귀 시
+  // overlay가 떴다.
+  it('setAlarmEvent: 비취침 + trip 종료(destination=null) 상태면 알람 이벤트를 억제한다', () => {
+    const { setAlarmEvent } = useAlarmEventStore.getState();
+    setAlarmEvent({ phaseId: 'early', type: 'destination', stationName: '강남' });
+
+    expect(useAlarmEventStore.getState().alarmEvent).toBeNull();
+  });
+
   it('clearAlarmEvent: 알람 이벤트를 초기화하고 AsyncStorage도 정리한다', () => {
+    useDestinationStore.setState({ destination: MOCK_STATIONS.gangnam });
     const { setAlarmEvent, clearAlarmEvent } = useAlarmEventStore.getState();
     setAlarmEvent({ phaseId: 'early', type: 'transfer', stationName: '역삼' });
     clearAlarmEvent();
@@ -43,7 +74,8 @@ describe('useAlarmEventStore', () => {
     expect(useAlarmEventStore.getState().alarmEvent).toBeNull();
   });
 
-  it('loadAlarmEvent: AsyncStorage에서 알람 이벤트를 복원하고 제거한다', async () => {
+  it('loadAlarmEvent: 활성 trip 중이면 AsyncStorage에서 알람 이벤트를 복원하고 제거한다', async () => {
+    useDestinationStore.setState({ destination: MOCK_STATIONS.gangnam });
     const event = { phaseId: 'early' as const, type: 'destination' as const, stationName: '강남' };
     (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(event));
 
@@ -52,6 +84,20 @@ describe('useAlarmEventStore', () => {
 
     const { alarmEvent } = useAlarmEventStore.getState();
     expect(alarmEvent).toEqual(event);
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:alarm-event');
+  });
+
+  // #2210 — BG write(backgroundLocationTask)가 sleepMode 무관하게 남긴 stale ALARM_EVENT_KEY를
+  // FG loadAlarmEvent가 replay하는 경로. 비취침 + trip 종료 상태면 in-memory alarmEvent는
+  // 억제되지만, storage는 무조건 drain해 재차 replay되지 않는다.
+  it('loadAlarmEvent: 비취침 + trip 종료 상태면 알람 이벤트는 억제하되 storage는 drain한다', async () => {
+    const event = { phaseId: 'early' as const, type: 'destination' as const, stationName: '강남' };
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(event));
+
+    const { loadAlarmEvent } = useAlarmEventStore.getState();
+    await loadAlarmEvent();
+
+    expect(useAlarmEventStore.getState().alarmEvent).toBeNull();
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:alarm-event');
   });
 

--- a/src/features/alarm/store/useAlarmEventStore.ts
+++ b/src/features/alarm/store/useAlarmEventStore.ts
@@ -1,3 +1,9 @@
+/* eslint-disable import/no-restricted-paths --
+ * #2210 — Cross-feature orchestration: setAlarmEvent가 sleepMode(settings)와 trip-active
+ * (route destination) 상태를 함께 게이트해야 한다. 비취침 + trip 종료 상태의 stale 알람
+ * (BG write → FG loadAlarmEvent replay, inApp notification writer)를 단일 진입점에서 억제.
+ * useDestinationStore가 이미 이 슬라이스를 역참조(alarm 클리어)하는 것과 대칭되는 orchestration.
+ */
 import { create } from 'zustand';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { AlarmEvent } from '../../../shared/types/alarm';
@@ -8,6 +14,8 @@ import {
   getDismissSilence as getDismissSilenceStorage,
   type DismissSilenceState,
 } from '../utils/dismissSilenceStorage';
+import { useSettingsStore } from '../../settings/store/useSettingsStore';
+import { useDestinationStore } from '../../route/store/useDestinationStore';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = (): void => {};
@@ -46,7 +54,16 @@ export const useAlarmEventStore = create<AlarmEventState>((set, get) => ({
   alarmEvent: null,
   dismissSilence: null,
 
+  // #2210 — sleepMode + trip-active 중앙 게이트. BG write(backgroundLocationTask) → FG
+  // loadAlarmEvent replay와 inApp writer(notificationRouter) 두 경로 모두 이 함수를 거치므로
+  // 여기서 억제하면 두 경로 모두 상속받는다. 비취침(sleepMode=false) + trip 종료(destination=null)
+  // 상태의 stale 알람만 억제 — 취침 알람과 활성 trip 중 알람은 그대로 통과시킨다.
   setAlarmEvent: (event: AlarmEvent) => {
+    const { sleepMode } = useSettingsStore.getState();
+    const tripActive = useDestinationStore.getState().destination !== null;
+    if (!sleepMode && !tripActive) {
+      return;
+    }
     set({ alarmEvent: event });
   },
 
@@ -59,7 +76,10 @@ export const useAlarmEventStore = create<AlarmEventState>((set, get) => ({
     try {
       const raw = await AsyncStorage.getItem(ALARM_EVENT_KEY);
       if (raw) {
-        set({ alarmEvent: JSON.parse(raw) });
+        // #2210 — set() 직접 호출 대신 setAlarmEvent를 경유해 중앙 게이트를 상속받는다.
+        // storage drain(removeItem)은 게이트 결과와 무관하게 항상 수행 — 억제된 stale 항목이
+        // 다음 FG 진입에서 재차 replay되지 않도록 무조건 비운다.
+        get().setAlarmEvent(JSON.parse(raw));
         await AsyncStorage.removeItem(ALARM_EVENT_KEY);
       }
     } catch {


### PR DESCRIPTION
Closes #2210

## 근본 원인
- BG write (`backgroundLocationTask.ts:313`)가 sleepMode 무관하게 `ALARM_EVENT_KEY`를 AsyncStorage에 기록 → FG 복귀 시 `loadAlarmEvent`가 이를 replay해 stale overlay 표출 (증상③).
- 두 번째 writer(`notificationRouter.ts:115` inApp surface)가 `useAlarmEventStore.setAlarmEvent`를 직접 호출해 별도 경로로 우회.

## 수정
- `src/features/alarm/store/useAlarmEventStore.ts`의 `setAlarmEvent`에 **sleepMode(settings) + trip-active(destination) 중앙 게이트** 추가. 비취침(`sleepMode=false`) AND trip 종료(`destination=null`) 상태의 알람 이벤트만 억제 — 취침 알람과 활성 trip 중 알람은 그대로 통과.
- `loadAlarmEvent`가 `set()` 직접 호출 대신 `setAlarmEvent`를 경유하도록 변경 → BG write replay 경로가 게이트를 상속.
- inApp writer(`notificationRouter.ts`)는 기존에도 `setAlarmEvent`를 호출하므로 별도 수정 없이 자동 상속.
- storage drain(`AsyncStorage.removeItem`)은 게이트 결과와 무관하게 항상 수행 — 억제된 stale 항목이 다음 FG 진입에서 재차 replay되지 않도록 보장.
- Cross-feature 참조(`useSettingsStore`, `useDestinationStore`)는 기존 `useDestinationStore.ts`/`notificationRouter.ts`와 동일한 orchestration 사유로 파일 헤더 `eslint-disable import/no-restricted-paths` 옵트인.

## 금지 사항 준수
- `lockless-trip-end 1:intent` 진단 stamp는 손대지 않음.

## TDD
1. red: `setAlarmEvent: 비취침 + trip 종료(destination=null) 상태면 알람 이벤트를 억제한다` — 게이트 추가 전 실패 확인.
2. green: 게이트 추가 후 통과. sleepMode=true 유지 케이스, 활성 trip 중 유지 케이스도 함께 추가.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — 변경은 in-memory 게이트 로직. DebugModal의 alarmEvent 상태 관찰로 확인 가능. 별도 신규 telemetry 없음.
3. **의존 PR** — N/A (device/backend 변경 없음, 프론트 store 단독 수정).
4. **측정 plan** — 실기기에서 (a) 비취침 상태로 trip 종료 후 FG 복귀 시 overlay 미표시, (b) 취침모드 알람은 정상 표시, (c) 활성 trip 중 정상 boarding 알람 표시 3개 시나리오로 1주 재발 0건 확인.
5. **Device verify** — 필요. 시나리오: ① 비취침 + trip 종료 상태에서 앱 백그라운드 → 포그라운드 복귀 시 stale overlay 미발생 확인. ② 취침모드 ON 상태 알람 정상 표시 확인. ③ 활성 trip 중 정상 boarding/transfer 알람 정상 표시 확인.

## 검증
- `npm test`: 428 suites / 9141 tests pass, coverage 100%.
- `npm run type-check`: pass.
- `npm run lint:orphan`: 0 orphan.
- `npx eslint`: 변경 파일 clean.