### PR TITLE
test(#2200): 2026-08-07 phantom+storm red replay fixture

### DIFF
--- a/backend/alarm-worker/src/__tests__/replay_20260807_storm.test.ts
+++ b/backend/alarm-worker/src/__tests__/replay_20260807_storm.test.ts
@@ -1,0 +1,260 @@
+/**
+ * 2026-08-07 07:38 KST 뚝섬 storm(동일 알림 반복 발사) replay test — backend side (Issue #2200,
+ * ADR-026 #2199). TDD 선행 red fixture — 하위 fix 이슈(#2201/#2202/#2204)가 green으로 flip.
+ *
+ * ## 재현 대상 (오늘 실기기 dump evidence)
+ * dump 상단 Feature Flag 섹션: `env=false remote=on active=ON` — 이 trip은 remote KV
+ * `arch:simple-arrival-v1`(ADR-022 Phase 0, #1982)가 **실제로 ON**이다. 그런데 같은 뚝섬 도착
+ * 이벤트(arvlCd 0→1 monotone cycle)에 대해 backend visible push + device 로컬 OS 사전예약이
+ * 병렬로 발사돼 사용자 체감 배너 3~4회(Alarm log L168~308 dedup-alarm/dedup-station/
+ * dedup-channel-agnostic suppressed ~10건 + 실제 fired 2건 이상).
+ *
+ * ## RCA (backend 기여분)
+ * `arvlcdFireOnceTtl.ts`의 `isSimpleArchEnabled()`는 ADR-022 Phase 1-1(#1985) 도입 당시
+ * "Phase 0(#1982) 머지 후속 PR에서 real `getArchFlag(env.KV)`로 wire" 예정으로 남겨진 **하드코딩
+ * stub**이다(항상 `false` 반환, env/KV 인자 자체가 없음). `archFlag.ts`의 real `getArchFlag(kv)`는
+ * 이미 존재하고 이 trip의 remote 값도 실제로 'on'이지만, `fireArvlCdStationPush`의 fire-once
+ * cycle 게이트는 이 real flag를 전혀 참조하지 않는다 — 그 결과 같은 (token, station) 조합에서
+ * arvlCd가 0→1로 monotone 진행하는 동안(기존 `arvlCdFireKey`는 arvlCd 값마다 별도 entry로 stamp)
+ * **두 번 다른 push가 발사**된다. 이것이 storm의 backend 기여분: 물리적으로 한 번뿐인 도착
+ * 이벤트에 대해 backend 스스로 2개의 독립적인 visible alert push를 내보낸다.
+ *
+ * (device 기여분 — OS 사전예약과의 경합 — 은 device 로컬 dedup 계층(crossCategoryStationDedup 등)이
+ * 이미 대부분 억제하고 있음을 오늘 dump에서 확인했다(suppressed ~10건). 본 backend 테스트는
+ * "단일 물리 이벤트 = 단일 backend emitter" 불변식이 remote flag=ON 상태에서도 깨져 있음을
+ * 고정한다.)
+ *
+ * ## Assert (수리 후 기대치, 지금 red)
+ * 한 물리 도착 이벤트(같은 station의 arvlCd 0→1 monotone 진행)에 대해 backend가 실제로 발사하는
+ * visible push 수 = 1 기대(현재 2). `it.fails`으로 감싸 CI green 유지 — #2201/#2202/#2204가
+ * `isSimpleArchEnabled`를 real `getArchFlag(env.KV)`로 wire하면 이 assertion이 통과, 그 시점에
+ * `it.fails`을 `it`로 교체한다.
+ *
+ * ## 금지
+ * production 코드 수정 없음(테스트만). `scheduled.test.ts`의 fixture 패턴(`makeFullEmptyStats`,
+ * `fireArvlCdStationPush` 직접 호출)을 최소 subset으로 재사용해 격리 — vi.spyOn으로 flag=ON을
+ * 강제하지 않는다(그 방식은 이미 기존 테스트가 커버). 본 테스트는 real KV에 실제 flag 값을 심어
+ * production wiring 자체의 갭을 검증한다.
+ */
+
+import { generateKeyPair, exportPKCS8 } from 'jose';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { resetApnsJwtCache, type ApnsConfig } from '../apns';
+import { fireArvlCdStationPush, type ScheduledDeps, type ScheduledStats } from '../scheduled';
+import { ARCH_FLAG_KV_KEY } from '../archFlag';
+import { putTrip } from '../trips';
+import type { BoardingLockMeta, Env, Trip } from '../types';
+import { InMemoryKV } from './inMemoryKv';
+
+let apnsConfig: ApnsConfig;
+
+beforeAll(async () => {
+  const { privateKey } = await generateKeyPair('ES256');
+  const pem = await exportPKCS8(privateKey);
+  apnsConfig = {
+    keyId: 'K',
+    teamId: 'T',
+    privateKeyPem: pem,
+    bundleId: 'com.example.app',
+  };
+});
+
+beforeEach(() => resetApnsJwtCache());
+
+// 오늘 dump 명시 시각 — 07:38 KST 뚝섬 phantom/storm evidence.
+const NOW = 1_785_887_901_000; // 2026-08-07T07:38:21+09:00 (KST) = 2026-08-06T22:38:21.000Z
+
+const APNS_HOSTS = {
+  production: 'api.push.apple.com',
+  sandbox: 'api.sandbox.push.apple.com',
+} as const;
+
+const TOKEN = 'ddeukseom-storm-tok';
+
+function makeEnv(kv: InMemoryKV): Env {
+  return {
+    TRIPS: kv as unknown as KVNamespace,
+    APNS_HOST: APNS_HOSTS.production,
+    APNS_HOST_SANDBOX: APNS_HOSTS.sandbox,
+    SEOUL_API_HOST: 'seoul.api',
+    SEOUL_API_KEY: 'KEY',
+    APNS_KEY_ID: 'K',
+    APNS_TEAM_ID: 'T',
+    APNS_PRIVATE_KEY: apnsConfig.privateKeyPem,
+    APNS_BUNDLE_ID: 'com.example.app',
+  };
+}
+
+function makeBoardingLock(overrides: Partial<BoardingLockMeta> = {}): BoardingLockMeta {
+  return {
+    trainCode: '2043',
+    line: '2',
+    subwayId: '1002',
+    selectedDepartureTime: NOW,
+    segmentStations: ['건대입구', '뚝섬'],
+    expiresAt: NOW + 60 * 60_000,
+    ...overrides,
+  };
+}
+
+function makeTrip(overrides: Partial<Trip> = {}): Trip {
+  return {
+    token: TOKEN,
+    route: { type: 'direct', line: '2', stops: 1 },
+    destination: '뚝섬',
+    waypoints: [{ stationName: '뚝섬', line: '2', kind: 'destination' }],
+    expiresAt: NOW + 60 * 60_000,
+    createdAt: NOW,
+    alarmAtEpochMs: NOW + 60_000,
+    boardingLock: makeBoardingLock(),
+    ...overrides,
+  };
+}
+
+/**
+ * `fireArvlCdStationPush` 직접 호출 테스트용 full-shape stats — `scheduled.test.ts`의
+ * `makeFullEmptyStats` 재사용(최소 subset, 이 파일 격리 목적으로 복제). `ScheduledStats` 필드
+ * 추가 시 두 사이트가 drift 하지 않도록 원본과 동기화 필요.
+ */
+function makeFullEmptyStats(): ScheduledStats {
+  return {
+    scanned: 0, polled: 0, pushed: 0, errors: 0, etaMissing: 0, envCorrected: 0,
+    lockMissing: 0, laStaleAutoEnded: 0, killSwitchLocklessIntermediateSkipped: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
+    laPushSent: 0, laPushFailed: 0, laTokenCleared: 0,
+    boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
+    phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
+    autoLockSuccess: 0, autoLockFalsePositive: 0, boardingPromptAutoDeduped: 0,
+    boardingPromptSkippedEmpty: 0, boardingPromptSkippedLockActive: 0, boardingPromptSkippedNoContext: 0, boardingPromptSkippedStale: 0, boardingPromptSkippedTooFar: 0,
+    boardingPromptSkippedMinInterval: 0, boardingPromptSkippedMaxFires: 0, boardingPromptSkippedTrainDuplicate: 0,
+    hopEndPromptFired: 0, hopEndPromptBlocked: 0,
+    arvlCdFireSuccess: 0, arvlCdFireDedup: 0, arvlCdFireMismatch: 0,
+    arvlCdFireBlocked: 0, arvlCdFireFired: 0,
+    boardingLockWaypointAdvanceBlocked: 0, transferDestinationGateBlocked: 0,
+    vanishFallbackFired: 0, vanishReleaseFired: 0, vanishLocklessTakeover: 0,
+    vanishFallbackMotionGateBlocked: 0,
+    cronJitterMs: 0, rescheduleBlockedMotion: 0, rescheduleFallbackNoSsot: 0,
+    realtimePositionFetch: 0, selfPollCacheHit: 0, realtimePositionFetchError: 0,
+    stationPollFetch: 0, stationPollCacheHit: 0, stationPollError: 0,
+    staleLockFireSkipped: 0,
+    arvlCdFireOnceSkipped: 0,
+    lifecycleSilenceSkipped: 0, lifecycleForceEnded: 0,
+    lifecycleStationarySkipped: 0,
+    silentPushFiredByKind: {
+      intermediate: 0,
+      transfer: 0,
+      destination: 0,
+      boardingPrompt: 0,
+      reschedule: 0,
+    },
+    scheduleEtaFallback: 0,
+    destinationCrossCheck: {
+      within: 0,
+      gpsFar: 0,
+      staleGps: 0,
+      noGps: 0,
+      stationUnknown: 0,
+    },
+    pendingActivityPossible: true,
+    sleepAlarmFired: 0,
+    sleepAlarmDedupSkipped: 0,
+    sleepAlarmRolledBack: 0,
+    etaMissingDemoted: 0,
+    trainReconfirmFired: 0,
+  };
+}
+
+describe('evidence 2026-08-07 07:38 뚝섬 storm — 단일 물리 이벤트 backend 중복 emit (#2200)', () => {
+  it('오늘 evidence 재현 — remote archFlag=on 상태에서도 fire-once 게이트가 관여하지 않아 같은 station에서 2회 push 발사 (회귀 확인)', async () => {
+    const kv = new InMemoryKV();
+    // dump Feature Flag 섹션: remote=on active=ON — 이 trip의 실제 KV 상태를 그대로 재현.
+    await kv.put(ARCH_FLAG_KV_KEY, 'on');
+    const trip = makeTrip();
+    await putTrip(kv as unknown as KVNamespace, trip);
+    const apnsFetch = async (): Promise<Response> => new Response('', { status: 200 });
+    const commonInputs = {
+      trip,
+      waypoint: trip.waypoints[0],
+      lock: trip.boardingLock!,
+      env: makeEnv(kv),
+      deps: {
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: apnsFetch as unknown as typeof fetch,
+        now: () => NOW,
+      } as ScheduledDeps,
+      now: NOW,
+      log: () => undefined,
+      generatePushId: () => 'p-storm-1',
+    };
+
+    // arvlCd=0(진입) 첫 관측 — 물리 도착 이벤트의 시작.
+    const statsFirst = makeFullEmptyStats();
+    const first = await fireArvlCdStationPush({ ...commonInputs, stats: statsFirst, arvlCd: 0 });
+    expect(first.dirty).toBe(true);
+    expect(statsFirst.arvlCdFireSuccess).toBe(1);
+
+    // 같은 monotone cycle 안에서 arvlCd=1(도착) 재관측 — 물리적으로는 같은 도착 이벤트.
+    // trip은 첫 fire에서 putTrip으로 lastFiredStation이 갱신되지 않았으므로(직접 호출은 caller가
+    // trip 객체를 재사용) 두 번째 호출도 같은 in-memory trip을 그대로 전달한다.
+    const statsSecond = makeFullEmptyStats();
+    const second = await fireArvlCdStationPush({
+      ...commonInputs,
+      stats: statsSecond,
+      arvlCd: 1,
+      generatePushId: () => 'p-storm-2',
+    });
+
+    // 회귀 확인: 실제로는 2번째도 fire 된다 — 같은 물리 이벤트에 대해 backend가 push를 2회 발사.
+    expect(second.dirty).toBe(true);
+    expect(statsSecond.arvlCdFireSuccess).toBe(1);
+    expect(statsSecond.arvlCdFireOnceSkipped).toBe(0);
+  });
+
+  // Flip in #2201/#2202/#2204 — `arvlcdFireOnceTtl.ts`의 `isSimpleArchEnabled()`가 real
+  // `getArchFlag(env.KV)`로 wire되면, remote flag='on' 상태에서 같은 (token, station) cycle의
+  // 두 번째 arvlCd 관측은 fire-once 게이트로 skip돼야 한다. 그 시점 이 테스트를
+  // `it.fails` → `it`로 교체한다.
+  it.fails(
+    '수리 후 기대치 — 한 물리 도착 이벤트(arvlCd 0→1 monotone) = backend push 1회만 (remote archFlag=on 존중)',
+    async () => {
+      const kv = new InMemoryKV();
+      await kv.put(ARCH_FLAG_KV_KEY, 'on');
+      const trip = makeTrip();
+      await putTrip(kv as unknown as KVNamespace, trip);
+      const apnsFetch = async (): Promise<Response> => new Response('', { status: 200 });
+      const commonInputs = {
+        trip,
+        waypoint: trip.waypoints[0],
+        lock: trip.boardingLock!,
+        env: makeEnv(kv),
+        deps: {
+          apnsConfig,
+          apnsHosts: APNS_HOSTS,
+          fetchImpl: apnsFetch as unknown as typeof fetch,
+          now: () => NOW,
+        } as ScheduledDeps,
+        now: NOW,
+        log: () => undefined,
+        generatePushId: () => 'p-storm-fix-1',
+      };
+
+      const statsFirst = makeFullEmptyStats();
+      await fireArvlCdStationPush({ ...commonInputs, stats: statsFirst, arvlCd: 0 });
+      expect(statsFirst.arvlCdFireSuccess).toBe(1);
+
+      const statsSecond = makeFullEmptyStats();
+      const second = await fireArvlCdStationPush({
+        ...commonInputs,
+        stats: statsSecond,
+        arvlCd: 1,
+        generatePushId: () => 'p-storm-fix-2',
+      });
+
+      // 수리 후: 같은 물리 이벤트의 두 번째 관측은 fire-once 게이트가 remote flag=on을 존중해
+      // skip해야 한다 — 두 번째 push가 발사되지 않는다(dirty=false, arvlCdFireOnceSkipped=1).
+      expect(second.dirty).toBe(false);
+      expect(statsSecond.arvlCdFireSuccess).toBe(0);
+      expect(statsSecond.arvlCdFireOnceSkipped).toBe(1);
+    },
+  );
+});

--- a/src/features/alarm/__tests__/fixtures/replay_20260807_phantom.ts
+++ b/src/features/alarm/__tests__/fixtures/replay_20260807_phantom.ts
@@ -1,0 +1,56 @@
+/**
+ * 2026-08-07 07:38 KST 건대입구→뚝섬 phantom fire evidence fixture (Issue #2200, ADR-026 #2199).
+ *
+ * 출처: 2026-08-07 실기기 debug dump (텍스트 export).
+ *   - Raw Signal (dump L826~868): 07:38:19 gps(43m/22.1m/s) automotive 스파이크 1개 →
+ *     07:38:25~07:40:01 급격히 감속(16.4 → 12.7 → 9.4 → 0.0 m/s), arc는 4712.51 → 5637.41 로
+ *     route-progress time-integration이 계속 전진.
+ *   - Alarm log (dump L168~308): 07:38:21 `bg | fired | destination | early | 뚝섬` (phantom fire).
+ *     같은 구간 `fg`는 movement-static-speed / movement-motion-stationary / lockless-no-user-intent
+ *     로 반복 suppressed — FG 채널만 movementGate.ts(evaluateMovement/isStaticSpeedSignal) 보호를
+ *     받고 BG 채널(stationPipeline.processLocationUpdate)은 이 gate를 아예 import하지 않는다.
+ *
+ * 본 fixture는 evidence의 "정지 상태(GPS speed 급감 + accel stationary)"를 device 로컬 유닛 레벨로
+ * 재현한다 — processLocationUpdate에 speedMps=0(정지 확정)을 직접 주입해 BG 채널이 movement 신호를
+ * 전혀 참조하지 않음을 증명한다.
+ */
+
+import type { Station } from '../../../../shared/types/station';
+import type { AlarmEvent } from '../../utils/stationAlarm';
+
+/** evidence L863~865 — 스파이크 직후 승객 기준 위치(건대입구, 2-011). */
+export const PHANTOM_NEAREST_STATION: Station = {
+  id: '2-011',
+  name: '건대입구',
+  line: '2',
+  lineColor: '#00A84D',
+  lat: 37.5404,
+  lng: 127.07,
+};
+
+/** evidence 목적지 — 뚝섬(2-010 방면), destination-early phase가 오발사된 대상. */
+export const PHANTOM_DESTINATION: Station = {
+  id: '2-010',
+  name: '뚝섬',
+  line: '2',
+  lineColor: '#00A84D',
+  lat: 37.5474,
+  lng: 127.0472,
+};
+
+/** Alarm log L252 — `bg | fired | destination | early | 뚝섬`. */
+export const PHANTOM_ALARM_EVENT: AlarmEvent = {
+  phaseId: 'early',
+  type: 'destination',
+  stationName: PHANTOM_DESTINATION.name,
+};
+
+/**
+ * evidence 재현 — 07:39:56 이후 GPS speed=0.0m/s 구간(dump L841~845) + accel pattern=stationary
+ * (dump 상단 Accel Fingerprint 섹션, 07:38:56/07:39:xx 다수 관측)을 결합한 "정지 확정" 신호.
+ * processLocationUpdate 호출 시점의 speedMps로 직접 주입한다.
+ */
+export const PHANTOM_STATIONARY_SPEED_MPS = 0;
+
+// evidence L864 — 스파이크 순간 값(참고, 22.1 m/s). 본 fixture의 assert 대상은 항상
+// PHANTOM_STATIONARY_SPEED_MPS(정지 확정)이므로 별도 export는 두지 않는다.

--- a/src/features/alarm/__tests__/replay_20260807_phantom.test.ts
+++ b/src/features/alarm/__tests__/replay_20260807_phantom.test.ts
@@ -1,0 +1,201 @@
+/**
+ * 2026-08-07 07:38 KST 건대입구→뚝섬 phantom fire replay test — device side (Issue #2200,
+ * ADR-026 #2199). TDD 선행 red fixture — 하위 fix 이슈(#2201/#2202/#2204)가 green으로 flip.
+ *
+ * ## 재현 대상 (오늘 실기기 dump evidence — fixtures/replay_20260807_phantom.ts 참고)
+ * 07:38:19 GPS 22.1m/s automotive 스파이크 1개 후 급감(정지)했는데도 07:38:21
+ * `bg | fired | destination | early | 뚝섬` (phantom fire) — Raw Signal L826~868, Alarm log L168~308.
+ *
+ * ## RCA
+ * `stationPipeline.processLocationUpdate` (BG 채널)는 `movementGate.ts`의 `evaluateMovement`/
+ * `isStaticSpeedSignal`을 전혀 import하지 않는다. `useStationAlarm.ts`(FG 채널)만 이 gate로
+ * 'movement-static-speed'/'movement-motion-stationary' suppress를 적용하며, 오늘 dump에서도 fg는
+ * 반복 suppressed되는 반면 bg는 무방비로 fired — evidence L177~250 `fg | suppressed |
+ * movement-static-speed / movement-motion-stationary` vs L252 `bg | fired`.
+ *
+ * ## Assert (수리 후 기대치, 지금 red)
+ * 정지(GPS speed=0 + accel stationary) 상태에서 destination-early 발사 시도 → fire=0 기대
+ * (현재 fire=1). `it.failing`으로 감싸 CI green 유지 — 이슈 fix가 movement gate를 BG 채널에
+ * 연결하면 이 assertion이 통과하게 되고, 그 시점에 `it.failing`을 `it`로 교체한다.
+ *
+ * ## 금지
+ * production 코드 수정 없음(테스트+fixture만). 아래 stationPipeline.test.ts의 mock 패턴을
+ * 최소 subset으로 재사용해 격리.
+ */
+
+import type { Station, NearestStationResult } from '../../../shared/types/station';
+import type { DirectRoute } from '../../../shared/utils/stationRoute';
+import { makeDirectRoute } from '../../../testUtils/routeFixtures';
+import {
+  PHANTOM_NEAREST_STATION,
+  PHANTOM_DESTINATION,
+  PHANTOM_ALARM_EVENT,
+  PHANTOM_STATIONARY_SPEED_MPS,
+} from './fixtures/replay_20260807_phantom';
+
+// ==========================================================================
+// Mock 정의 — stationPipeline.test.ts 의 mock 패턴을 그대로 재사용해 격리.
+// ==========================================================================
+
+const mockFindNearestStation = jest.fn();
+jest.mock('../../nearest-station/utils/findNearestStation', () => ({
+  findNearestStation: (...args: unknown[]) => mockFindNearestStation(...args),
+}));
+
+const mockFindRoute = jest.fn();
+const mockCalculateStaticETA = jest.fn();
+const mockUpdateRouteFromPosition = jest.fn();
+const mockIsStationOnRoute = jest.fn();
+const mockIsSameStationName = jest.fn((a: string, b: string) => a === b);
+const mockGetFirstLeg = jest.fn((..._args: unknown[]) => ({ line: '2', endName: '' }));
+jest.mock('../../../shared/utils/stationRoute', () => ({
+  findRoute: (...args: unknown[]) => mockFindRoute(...args),
+  calculateStaticETA: (...args: unknown[]) => mockCalculateStaticETA(...args),
+  updateRouteFromPosition: (...args: unknown[]) => mockUpdateRouteFromPosition(...args),
+  isStationOnRoute: (...args: unknown[]) => mockIsStationOnRoute(...args),
+  isSameStationName: (a: string, b: string) => mockIsSameStationName(a, b),
+  getFirstLeg: (...args: unknown[]) => mockGetFirstLeg(...args),
+}));
+
+const mockEvaluateAlarmPhase = jest.fn();
+const mockResolveAllTargets = jest.fn(
+  (..._args: unknown[]) =>
+    [] as Array<{ name: string; stops: number; alarmType: 'destination' | 'transfer'; approachLine: string }>,
+);
+jest.mock('../utils/stationAlarm', () => ({
+  evaluateAlarmPhase: (...args: unknown[]) => mockEvaluateAlarmPhase(...args),
+  resolveAllTargets: (...args: unknown[]) => mockResolveAllTargets(...args),
+}));
+
+const mockGetBoardingLock = jest.fn();
+jest.mock('../utils/boardingLockStorage', () => ({
+  getBoardingLock: () => mockGetBoardingLock(),
+}));
+
+const mockGetDismissSilence = jest.fn();
+const mockClearDismissSilence = jest.fn();
+jest.mock('../utils/dismissSilenceStorage', () => ({
+  getDismissSilence: (...args: unknown[]) => mockGetDismissSilence(...args),
+  clearDismissSilence: (...args: unknown[]) => mockClearDismissSilence(...args),
+}));
+
+const mockCancelSafetyNetByStationKind = jest.fn().mockResolvedValue(undefined);
+jest.mock('../utils/safetyNetScheduler', () => ({
+  cancelSafetyNetByStationKind: (...args: unknown[]) => mockCancelSafetyNetByStationKind(...args),
+}));
+
+const mockUpdateStationNotification = jest.fn();
+jest.mock('../utils/stationNotification', () => ({
+  updateStationNotification: (...args: unknown[]) => mockUpdateStationNotification(...args),
+}));
+
+const mockGetLastNotifiedStationId = jest.fn();
+const mockSetLastNotifiedStationId = jest.fn();
+jest.mock('../utils/notificationState', () => ({
+  getLastNotifiedStationId: (...args: unknown[]) => mockGetLastNotifiedStationId(...args),
+  setLastNotifiedStationId: (...args: unknown[]) => mockSetLastNotifiedStationId(...args),
+}));
+
+const mockLogFiredAlarm = jest.fn();
+const mockLogFiredStationPassed = jest.fn();
+const mockLogSuppressedDedupStation = jest.fn();
+const mockLogSuppressedDedupAlarm = jest.fn();
+const mockLogSuppressedSleepFirstTransfer = jest.fn();
+const mockLogSuppressedSleepStationPassed = jest.fn();
+const mockLogSuppressedDismissSilence = jest.fn();
+const mockLogSuppressedCrossCategoryDedup = jest.fn();
+const mockLogSuppressedCrossCategoryRecent = jest.fn();
+const mockLogSuppressedPhaseToPhaseDedup = jest.fn();
+const mockLogSuppressedChannelAgnosticDedup = jest.fn();
+jest.mock('../utils/alarmLog', () => ({
+  logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
+  logFiredStationPassed: (...args: unknown[]) => mockLogFiredStationPassed(...args),
+  logSuppressedDedupStation: (...args: unknown[]) => mockLogSuppressedDedupStation(...args),
+  logSuppressedDedupAlarm: (...args: unknown[]) => mockLogSuppressedDedupAlarm(...args),
+  logSuppressedSleepFirstTransfer: (...args: unknown[]) =>
+    mockLogSuppressedSleepFirstTransfer(...args),
+  logSuppressedSleepStationPassed: (...args: unknown[]) =>
+    mockLogSuppressedSleepStationPassed(...args),
+  logSuppressedDismissSilence: (...args: unknown[]) => mockLogSuppressedDismissSilence(...args),
+  logSuppressedCrossCategoryDedup: (...args: unknown[]) =>
+    mockLogSuppressedCrossCategoryDedup(...args),
+  logSuppressedCrossCategoryRecent: (...args: unknown[]) =>
+    mockLogSuppressedCrossCategoryRecent(...args),
+  logSuppressedPhaseToPhaseDedup: (...args: unknown[]) =>
+    mockLogSuppressedPhaseToPhaseDedup(...args),
+  logSuppressedChannelAgnosticDedup: (...args: unknown[]) =>
+    mockLogSuppressedChannelAgnosticDedup(...args),
+}));
+
+// ==========================================================================
+// Import (mocks after setup)
+// ==========================================================================
+import { processLocationUpdate } from '../utils/stationPipeline';
+
+const mockNearestResult: NearestStationResult = {
+  station: PHANTOM_NEAREST_STATION,
+  distanceKm: 0.15,
+};
+
+const mockRoute: DirectRoute = makeDirectRoute(3, '2');
+
+describe('evidence 2026-08-07 07:38 device replay — 정지 상태 destination-early phantom fire (#2200)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('../utils/crossCategoryStationDedup')._resetCrossCategoryDedupForTests();
+    mockUpdateStationNotification.mockResolvedValue(undefined);
+    mockCalculateStaticETA.mockReturnValue(10);
+    mockIsStationOnRoute.mockReturnValue(true);
+    mockGetLastNotifiedStationId.mockResolvedValue(null);
+    mockSetLastNotifiedStationId.mockResolvedValue(undefined);
+    mockGetBoardingLock.mockResolvedValue(null);
+    mockResolveAllTargets.mockReturnValue([
+      { name: PHANTOM_DESTINATION.name, stops: 1, alarmType: 'destination', approachLine: '2' },
+    ]);
+    mockGetFirstLeg.mockReturnValue({ line: '2', endName: PHANTOM_DESTINATION.name });
+    mockGetDismissSilence.mockResolvedValue(null);
+    mockClearDismissSilence.mockResolvedValue(undefined);
+    mockFindNearestStation.mockReturnValue(mockNearestResult);
+    mockFindRoute.mockReturnValue(mockRoute);
+    mockEvaluateAlarmPhase.mockReturnValue(PHANTOM_ALARM_EVENT);
+  });
+
+  it('오늘 evidence 재현 — BG 채널은 movement 신호와 무관하게 fire (회귀 확인)', async () => {
+    // evidence: 07:39:56 이후 GPS speed=0.0m/s(정지 확정) 구간 + accel pattern=stationary.
+    // processLocationUpdate는 movementGate.ts를 참조하지 않으므로 speedMps=0(정지)을 넣어도
+    // evaluateAlarmPhase 결과(destination/early)가 그대로 fire까지 통과한다 — 오늘 evidence의
+    // "bg fired destination early 뚝섬" (dump L252) 재현.
+    await processLocationUpdate({
+      lat: PHANTOM_NEAREST_STATION.lat,
+      lng: PHANTOM_NEAREST_STATION.lng,
+      destination: PHANTOM_DESTINATION,
+      firedAlarms: new Set(),
+      sleepMode: false,
+      source: 'bg',
+      speedMps: PHANTOM_STATIONARY_SPEED_MPS,
+    });
+
+    expect(mockLogFiredAlarm).toHaveBeenCalledWith('bg', PHANTOM_ALARM_EVENT);
+  });
+
+  // Flip in #2201/#2202/#2204 — stationPipeline.processLocationUpdate가 movementGate.ts
+  // (evaluateMovement/isStaticSpeedSignal)를 참조해 정지 상태에서 destination-early fire를
+  // 차단하면, 아래 assertion이 통과하며 이 테스트를 `it.failing` → `it`로 교체한다.
+  it.failing('수리 후 기대치 — 정지(GPS speed=0 + accel stationary) 상태에서 destination-early fire=0', async () => {
+    await processLocationUpdate({
+      lat: PHANTOM_NEAREST_STATION.lat,
+      lng: PHANTOM_NEAREST_STATION.lng,
+      destination: PHANTOM_DESTINATION,
+      firedAlarms: new Set(),
+      sleepMode: false,
+      source: 'bg',
+      speedMps: PHANTOM_STATIONARY_SPEED_MPS,
+    });
+
+    // 수리 후: 정지 상태에서는 movement gate가 fire를 차단해 logFiredAlarm이 호출되지 않아야 한다.
+    // 현재(red): BG 채널에 movement gate가 없어 이 assertion이 실패한다(logFiredAlarm 호출됨) —
+    // it.failing이 그 실패를 삼켜 CI green 유지.
+    expect(mockLogFiredAlarm).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #2200

## 배경

2026-08-07 실기기 dump 재현. ADR-026(#2199)의 TDD 선행 red fixture — 아래 fix 이슈들보다 먼저 red 확인 목적.

- **① phantom**: 07:38:19 GPS 22.1m/s automotive 스파이크 1개 후 급감(정지)했는데도 07:38:21 `bg | fired | destination | early | 뚝섬`. Raw Signal L826~868, Alarm log L168~308.
- **② storm**: 같은 뚝섬 도착 이벤트에 대해 dedup 억제 ~10건 + 실제 fired 2건 이상(backend push + OS 사전예약 병렬) = 사용자 체감 배너 3~4회.

## RCA

- **①(device)**: `src/features/alarm/utils/stationPipeline.ts`의 `processLocationUpdate`(BG 채널)는 `movementGate.ts`의 `evaluateMovement`/`isStaticSpeedSignal`을 전혀 import하지 않는다. `useStationAlarm.ts`(FG 채널)만 이 gate로 `movement-static-speed`/`movement-motion-stationary` suppress를 적용 — 오늘 dump에서도 fg는 반복 suppressed되지만 bg는 무방비로 fired.
- **②(backend)**: `backend/alarm-worker/src/arvlcdFireOnceTtl.ts`의 `isSimpleArchEnabled()`는 ADR-022 Phase 1-1(#1985) 도입 당시 "Phase 0 머지 후속 PR에서 real `getArchFlag(env.KV)`로 wire" 예정으로 남겨진 하드코딩 stub(항상 `false`). 오늘 dump의 Feature Flag 섹션은 `remote=on active=ON`이지만, `fireArvlCdStationPush`의 fire-once cycle 게이트는 이 real flag를 전혀 참조하지 않아 같은 (token, station) 조합에서 arvlCd 0→1 monotone 진행 동안 backend가 push를 2회 발사한다.

## 변경 파일

- `src/features/alarm/__tests__/replay_20260807_phantom.test.ts` + `fixtures/replay_20260807_phantom.ts` (device, jest)
- `backend/alarm-worker/src/__tests__/replay_20260807_storm.test.ts` (backend, vitest)

각 파일에 "오늘 evidence 재현" 테스트(현재 동작 그대로, green) + "수리 후 기대치" 테스트(`it.failing`/`it.fails`로 감싸 CI green 유지, 로컬에서 감싸지 않고 실행하면 fail 확인함 — 아래 로컬 검증 출력 참고) 두 벌 구성. 각 assert에 "flip in #2201/#2202/#2204" 주석 포함.

## 로컬 검증 — "감싼 green + 풀면 fail" 확인

**감싼 상태(현재 PR 그대로, green):**
```
# device
Test Suites: 1 passed, 1 total / Tests: 2 passed, 2 total (replay_20260807_phantom.test.ts)

# backend
Test Files  1 passed (1) / Tests  2 passed (2) (replay_20260807_storm.test.ts)
```

**`it.failing`/`it.fails`를 일반 `it`로 바꿔 로컬 재실행 시(수리 전이라 fail 확인):**
```
# device — "수리 후 기대치" 테스트를 it로 바꾸면:
● 수리 후 기대치 — 정지(GPS speed=0 + accel stationary) 상태에서 destination-early fire=0
  expect(mockLogFiredAlarm).not.toHaveBeenCalled()
  Expected number of calls: 0
  Received number of calls: 1

# backend — it.fails를 it로 바꾸면:
● 수리 후 기대치 — 한 물리 도착 이벤트(arvlCd 0→1 monotone) = backend push 1회만
  expect(second.dirty).toBe(false) // Received: true
  expect(statsSecond.arvlCdFireSuccess).toBe(0) // Received: 1
```

버그가 실제로 존재함을 증명 — 위 두 케이스 모두 현재 코드에서 fail(=red)한다.

## 검증 결과

- `npm test` (frontend): 429 suites / 9140 tests 전체 pass, coverage 100% 유지
- `backend/alarm-worker`: `npx vitest run --coverage` 76 files / 2901 tests 전체 pass
- `npm run type-check`: pass
- `npm run lint:orphan`: No orphan exports detected

## 이슈 스펙 대비 이탈 사항

- 이슈 본문은 backend storm 테스트를 "단일 emitter 후 사전예약 emit 경로 0 assert"로 프레이밍했으나, "사전예약(OS local preschedule)"은 device 전용 개념이라 backend 유닛 테스트로 직접 검증할 수 없다. RCA 결과 backend 자체에도 독립적인 storm 기여분(remote archFlag=on을 무시하는 dormant `isSimpleArchEnabled()` stub으로 인한 backend 자체 2회 발사)이 확인되어, 이를 backend 테스트의 검증 대상으로 삼았다. device 기여분(OS 사전예약과의 race)은 오늘 dump에서 device 로컬 dedup이 이미 대부분 억제하고 있음을 확인했고 별도 device 테스트(①)로 커버한다.
- 그 외 스펙 그대로: production 코드 수정 없음, 파일 위치/네이밍 이슈 스펙과 일치.

## Wire-completion 5단

1. **Orphan**: N/A — `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard**: 테스트 리포트(CI `Type Check & Test` job) + 로컬 vitest/jest 출력(위 첨부)
3. **의존 PR**: #2199 (ADR-026 상위 이슈). green 전환은 #2201/#2202/#2204
4. **측정 plan**: CI red→green 전환 시점을 #2201/#2202/#2204 각 PR의 diff로 추적(`it.failing`/`it.fails` → `it` 교체 여부)
5. **Device verify**: N/A — type+unit only (테스트+fixture만, production 코드 변경 없음)