### PR TITLE
feat(#2194): trip 신원 안정화 — rotation 폐기 + route 변경 in-place reset

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1640,38 +1640,42 @@ describe('DELETE /trips/:token — LA dismissal (#586 D)', () => {
   });
 });
 
-// 리뷰 확정 P1 (#2186) — DELETE /trips/:token이 getTrip(token) 직접 키 조회만 해서, ADR-022 B4
-// 로테이션 이후 실토큰 DELETE가 miss → { ok:true, deleted:false } no-op → trip:<uuid> 고아가
+// 리뷰 확정 P1 (#2186) — DELETE /trips/:token이 getTrip(token) 직접 키 조회만 하면, 역인덱스가
+// 직접 키와 다른 trip을 가리키는 상태(예: ADR-025 이후 존치된 APNs refresh 복구 경로, ADR-025
+// Consequences)에서 실토큰 DELETE가 miss → { ok:true, deleted:false } no-op → orphan trip이
 // 계속 push를 발사하는 회귀. GET /trips/:token/status(#2175)와 동일한 역인덱스 fallback을 DELETE
 // 에도 배선해 사용자의 명시적 clear가 실제로 orphan trip을 회수하도록 한다.
 describe('DELETE /trips/:token — deviceToken 역인덱스 fallback (리뷰 P1, #2186)', () => {
   const TOKEN = 'tok-2186-real';
 
-  function tripBodyFor(destination: string, stationName: string): Record<string, unknown> {
-    return {
-      ...base(),
-      token: TOKEN,
-      destination,
-      waypoints: [{ stationName, line: '2', kind: 'destination' }],
-    };
-  }
-
-  it('로테이션 이후 실토큰 DELETE가 직접 키 miss여도 역인덱스로 UUID trip을 찾아 삭제한다', async () => {
+  it('직접 키 miss(역인덱스가 다른 trip을 가리킴, APNs refresh 시나리오)여도 역인덱스로 그 trip을 찾아 삭제한다', async () => {
+    // ADR-025(#2194) 하에서 신원은 rotation으로 갈리지 않지만, 역인덱스 자체는 APNs refresh
+    // 복구 용도로 존치된다(ADR-025 Consequences) — trip.token !== trip.deviceToken인 legacy
+    // 형태(과거 로테이션 시절 산물과 동일한 모양)를 raw KV put으로 직접 seed해 fallback wire를
+    // 검증한다(더 이상 rotation으로 자연 발생하지 않으므로 수동 seed).
     const env = makeKvEnv();
-    await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
-    await post('/trips', tripBodyFor('용마산-id', '용마산'), env);
-    const res2 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
-    const uuid1 = ((await res2.json()) as { token: string }).token;
-    expect(uuid1).not.toBe(TOKEN);
-    // 수정 전 회귀 재현: 직접 키(trip:TOKEN)는 로테이션이 이미 지웠고, orphan은 trip:<uuid1>에 산다.
+    const orphanToken = 'orphan-trip-token';
+    const orphanTrip = {
+      token: orphanToken,
+      deviceToken: TOKEN,
+      route: { type: 'direct', line: '2', stops: 3 },
+      destination: '성수-id',
+      waypoints: [{ stationName: '성수', line: '2', kind: 'destination' }],
+      expiresAt: FUTURE,
+      createdAt: Date.now(),
+      alarmAtEpochMs: FUTURE - 30 * 60 * 1000,
+    };
+    await env.TRIPS.put(`trip:${orphanToken}`, JSON.stringify(orphanTrip));
+    // 역인덱스 — production과 동일한 형태(key=deviceToken, value=trip.token).
+    await env.TRIPS.put(`device-trips:${TOKEN}`, orphanToken);
     expect(await env.TRIPS.get(`trip:${TOKEN}`)).toBeNull();
-    expect(await env.TRIPS.get(`trip:${uuid1}`)).not.toBeNull();
+    expect(await env.TRIPS.get(`trip:${orphanToken}`)).not.toBeNull();
 
     const res = await del(`/trips/${TOKEN}`, env);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, deleted: true });
-    // orphan UUID trip이 실제로 삭제된다 — 수정 전엔 no-op으로 계속 생존해 push를 발사했다.
-    expect(await env.TRIPS.get(`trip:${uuid1}`)).toBeNull();
+    // 역인덱스가 가리키던 trip이 실제로 삭제된다 — 수정 전엔 no-op으로 계속 생존해 push를 발사했다.
+    expect(await env.TRIPS.get(`trip:${orphanToken}`)).toBeNull();
     // 역인덱스도 함께 정리된다.
     expect(await env.TRIPS.get(`device-trips:${TOKEN}`)).toBeNull();
   });
@@ -4392,17 +4396,19 @@ describe('POST /trips — #1897 confirmedEnv echo (RC-5)', () => {
   });
 });
 
-// ADR-022 B4 (#2019 wire) — POST /trips 에서 rotateTripTokenForNewRoute 실제 호출.
+// ADR-025 (#2194) — POST /trips 에서 resetTripStateForNewRoute 실제 호출. rotation(ADR-022 B4,
+// `rotateTripTokenForNewRoute`, #2019/#1986)을 대체 — trip 신원(token)은 트립 수명 동안 불변,
+// route sig가 바뀌면 같은 key(`trip:<TOKEN>`)를 in-place로 갱신하고 구 route의 잔재 pending push만
+// 정리한다.
 //
-// #1986 이 helper 정의를 도입했지만 프로덕션 caller 0개 (테스트 파일에서만 호출) 였고 2026-07-03
-// 사용자 실기기 trip(중곡→성수)에서 이전 trip 잔재 pending push 가 계속 발사돼 device 는
-// `BoardingLock active=no + boardingPrompt(all)=0` 상태였음에도 `08:37:25 bg fired
-// station-passed 성수` 관측. 원인: 새 route 등록 시 `trip:<oldToken>` KV entry 와
-// `pending:*` 잔재가 rotation helper 호출 부재로 정리되지 않음.
+// 2026-07-03 사용자 실기기 trip(중곡→성수) 회귀(이전 trip 잔재 pending push가 계속 발사돼
+// `08:37:25 bg fired station-passed 성수` 관측)의 근본 목표("route 변경 시 이전 route의 잔재
+// 상태를 지운다")는 이 wire가 그대로 달성한다 — 메커니즘만 rotation(신원 교체)에서 in-place
+// reset(신원 유지)으로 바뀌었다.
 //
-// 본 describe 는 wire 완결(POST handler 가 helper 호출) 을 검증한다. Helper 자체의 rotation
-// 로직 (route sig 계산 / KV delete / pending cleanup) 은 `trips.test.ts` 에서 커버.
-describe('POST /trips — #2019 rotateTripTokenForNewRoute wire (ADR-022 B4)', () => {
+// 본 describe 는 wire 완결(POST handler 가 helper 호출) 을 검증한다. Helper 자체의 reset 로직
+// (route sig 계산 / pending cleanup) 은 `trips.test.ts` 에서 커버.
+describe('POST /trips — #2194 resetTripStateForNewRoute wire (ADR-025)', () => {
   const TOKEN = 'tok-2019';
   const ARCH_FLAG_KV_KEY = 'arch:simple-arrival-v1';
 
@@ -4449,13 +4455,13 @@ describe('POST /trips — #2019 rotateTripTokenForNewRoute wire (ADR-022 B4)', (
   }
 
   describe('archFlag=off (default) — dormant', () => {
-    it('existing + 다른 destination → 회전 없음 (`trip:<TOKEN>` 유지 + 응답 token 동일)', async () => {
+    it('existing + 다른 destination → reset 없음 (`trip:<TOKEN>` 유지 + 응답 token 동일)', async () => {
       const env = makeKvEnv();
       await seedExistingTrip(env, '용마산-id', '용마산');
       // KV 에 archFlag 미설정 → getArchFlag 는 default 'off' 반환.
       const res = await post('/trips', tripBodyFor('성수-id', '성수'), env);
       expect(res.status).toBe(200);
-      // 응답 token 은 그대로 (rotation 미발동).
+      // 응답 token 은 그대로 (신원 불변, reset 미발동 무관하게 항상 동일).
       expect(await res.json()).toEqual({
         ok: true,
         token: TOKEN,
@@ -4479,12 +4485,8 @@ describe('POST /trips — #2019 rotateTripTokenForNewRoute wire (ADR-022 B4)', (
     });
   });
 
-  describe('archFlag=on — rotation active', () => {
-    beforeEach(async () => {
-      // 각 테스트는 자체 env 를 만들고 setup 에서 flag 를 KV 에 set 한다.
-    });
-
-    it('existing 없음 (신규 trip) → 회전 없음, incoming token 유지', async () => {
+  describe('archFlag=on — in-place reset active', () => {
+    it('existing 없음 (신규 trip) → reset 없음, incoming token 유지', async () => {
       const env = makeKvEnv();
       await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
       const res = await post('/trips', tripBodyFor('성수-id', '성수'), env);
@@ -4497,13 +4499,13 @@ describe('POST /trips — #2019 rotateTripTokenForNewRoute wire (ADR-022 B4)', (
       expect(await env.TRIPS.get(`trip:${TOKEN}`)).not.toBeNull();
     });
 
-    it('existing + 같은 route (destination/waypoints 동일) → 회전 없음', async () => {
+    it('existing + 같은 route (destination/waypoints 동일) → reset 없음', async () => {
       const env = makeKvEnv();
       await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
       await seedExistingTrip(env, '성수-id', '성수');
       const res = await post('/trips', tripBodyFor('성수-id', '성수'), env);
       expect(res.status).toBe(200);
-      // 같은 route sig → rotation dormant → token 유지.
+      // 같은 route sig → reset dormant → token 유지.
       expect(await res.json()).toEqual({
         ok: true,
         token: TOKEN,
@@ -4512,11 +4514,9 @@ describe('POST /trips — #2019 rotateTripTokenForNewRoute wire (ADR-022 B4)', (
       expect(await env.TRIPS.get(`trip:${TOKEN}`)).not.toBeNull();
     });
 
-    it('#2174 P1-A — existing + 다른 destination: rotation 발동으로 응답에 새 UUID token + old trip:<TOKEN> 삭제', async () => {
-      // #2173 P0 hotfix가 guard로 이 경로를 단락시켰던 이유(crypto.randomUUID() 가 APNs
-      // deviceToken 자리에 저장돼 400 BadDeviceToken 즉사, Epic #2172)는 #2174의
-      // `Trip.deviceToken` 필드 분리로 해소됐다 — 모든 push 발사 사이트가 `resolveTripDeviceToken`
-      // 을 사용하므로 trip.token(신원) 로테이션이 더 이상 push 발사 주소에 영향을 주지 않는다.
+    it('#2194 — existing + 다른 destination: reset 발동해도 응답 token은 신원 불변(같은 TOKEN) + `trip:<TOKEN>` in-place 갱신 (삭제 없음)', async () => {
+      // ADR-025 핵심 — rotation(ADR-022 B4)이 새 UUID 발급 + old trip:<TOKEN> delete로
+      // 해결하던 문제를, 신원을 그대로 유지한 채 같은 key를 그 자리에서 갱신하는 방식으로 해결한다.
       const env = makeKvEnv();
       await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
       await seedExistingTrip(env, '용마산-id', '용마산');
@@ -4524,17 +4524,15 @@ describe('POST /trips — #2019 rotateTripTokenForNewRoute wire (ADR-022 B4)', (
       expect(res.status).toBe(200);
       const body = (await res.json()) as { ok: true; token: string; confirmedEnv: string };
       expect(body.ok).toBe(true);
-      // rotation 발동 — 응답 token은 새 UUID (incoming token과 다름).
-      expect(body.token).not.toBe(TOKEN);
-      expect(body.token).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
-      // old trip:<TOKEN> 은 삭제되고 새 trip:<newToken> 이 생성된다.
-      expect(await env.TRIPS.get(`trip:${TOKEN}`)).toBeNull();
-      const stored = await env.TRIPS.get(`trip:${body.token}`);
+      // 신원 불변 — 응답 token은 항상 원본 TOKEN.
+      expect(body.token).toBe(TOKEN);
+      // `trip:<TOKEN>` 레코드는 삭제되지 않고 그 자리에서 새 destination으로 갱신된다.
+      const stored = await env.TRIPS.get(`trip:${TOKEN}`);
       expect(stored).not.toBeNull();
       expect(JSON.parse(stored as string).destination).toBe('성수-id');
     });
 
-    it('#2174 P1-A — 이전 trip pending push 잔재 존재 상태에서 새 route 등록: old token 소유 cleanup 발동', async () => {
+    it('#2194 — 이전 trip pending push 잔재 존재 상태에서 새 route 등록: TOKEN 소유 cleanup 발동 (다른 device 소유는 보존)', async () => {
       const env = makeKvEnv();
       await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
       await seedExistingTrip(env, '용마산-id', '용마산');
@@ -4545,16 +4543,16 @@ describe('POST /trips — #2019 rotateTripTokenForNewRoute wire (ADR-022 B4)', (
       const res = await post('/trips', tripBodyFor('성수-id', '성수'), env);
       expect(res.status).toBe(200);
 
-      // rotation 발동 → old token 소유 pending은 cleanup, 다른 device 소유는 보존.
+      // reset 발동 → TOKEN 소유 pending은 cleanup, 다른 device 소유는 보존.
       expect(await env.TRIPS.get('pending:p-old-1')).toBeNull();
       expect(await env.TRIPS.get('pending:p-old-2')).toBeNull();
       expect(await env.TRIPS.get('pending:p-other-device')).not.toBeNull();
     });
 
-    it('#2174 P1-A — archFlag off→on 전환 시 두 번째 등록만 rotation 발동', async () => {
+    it('#2194 — archFlag off→on 전환과 무관하게 두 라운드 모두 같은 TOKEN으로 등록된다', async () => {
       const env = makeKvEnv();
       await seedExistingTrip(env, '용마산-id', '용마산');
-      // Round 1: flag 미설정 → default off → 회전 없음.
+      // Round 1: flag 미설정 → default off → reset 없음, 신원 유지.
       const res1 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
       const body1 = (await res1.json()) as { token: string };
       expect(body1.token).toBe(TOKEN);
@@ -4562,26 +4560,22 @@ describe('POST /trips — #2019 rotateTripTokenForNewRoute wire (ADR-022 B4)', (
       // Reset: 새 existing 을 다시 seed 하고 flag on.
       await seedExistingTrip(env, '용마산-id', '용마산');
       await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
-      // Round 2: flag on → rotation 발동 → token 변경.
+      // Round 2: flag on → reset 발동해도 신원은 여전히 같은 TOKEN.
       const res2 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
       const body2 = (await res2.json()) as { token: string };
-      expect(body2.token).not.toBe(TOKEN);
+      expect(body2.token).toBe(TOKEN);
     });
 
-    // #2174 F2 → #2175로 완결 — rotation 발동 후 old(실) token으로 GET /trips/:token/status를
-    // 조회하면 deviceToken 역인덱스가 새 UUID trip을 재발견해 'active'를 반환한다. 로테이션된
-    // trip은 실제로 여전히 살아있으므로(사용자가 그냥 route를 바꿨을 뿐) 'ended'로 보고하는 게
-    // 오히려 부정확했다 — #2175가 이 갭을 닫는다.
-    it('#2175 — rotation 발동 후 실 deviceToken으로 GET /trips/:token/status 조회 시 역인덱스로 새 UUID trip을 찾아 active를 반환한다', async () => {
+    // ADR-025 하에서 GET /trips/:token/status는 항상 직접 키(trip:<TOKEN>)로 조회에 성공한다 —
+    // 신원이 rotation으로 바뀌지 않으므로 #2175 deviceToken 역인덱스 fallback(APNs refresh 복구
+    // 용도로 존치)이 이 경로에서 발동할 필요가 없다.
+    it('reset 발동 후 실 deviceToken(=TOKEN)으로 GET /trips/:token/status 조회 시 active를 반환한다', async () => {
       const env = makeKvEnv();
       await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
       await seedExistingTrip(env, '용마산-id', '용마산');
       const res = await post('/trips', tripBodyFor('성수-id', '성수'), env);
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { token: string };
 
-      // #2174 comment 1 — device는 로테이션 이후에도 실 deviceToken(=최초 등록 시 TOKEN)으로
-      // GET /trips/:token/status를 조회한다.
       const statusRes = await app.fetch(
         new Request(`http://example.com/trips/${TOKEN}/status`, { method: 'GET' }),
         env,
@@ -4592,51 +4586,15 @@ describe('POST /trips — #2019 rotateTripTokenForNewRoute wire (ADR-022 B4)', (
         status: string;
         endReason: string | null;
       };
-      // 응답의 tripToken은 device가 질의한 원래 값(TOKEN)을 echo — 내부적으로는 새 UUID(body.token)
-      // trip을 참조해 active로 판정했다.
       expect(statusBody.tripToken).toBe(TOKEN);
       expect(statusBody.status).toBe('active');
       expect(statusBody.endReason).toBeNull();
-      expect(body.token).not.toBe(TOKEN);
-    });
-
-    // #2175 — 로테이션된 trip이 실제로 종료(예: 만료)되면, 역인덱스가 여전히 그 UUID를 가리키는
-    // 상태에서 실 deviceToken 조회가 그 UUID의 종료 사유('rotated')를 그대로 노출한다.
-    it('#2175 — rotation 후 새 UUID trip마저 종료되면 실 deviceToken 조회가 그 종료 사유를 반환한다', async () => {
-      const env = makeKvEnv();
-      await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
-      await seedExistingTrip(env, '용마산-id', '용마산');
-      const res = await post('/trips', tripBodyFor('성수-id', '성수'), env);
-      const body = (await res.json()) as { token: string };
-      const newToken = body.token;
-      expect(newToken).not.toBe(TOKEN);
-
-      // 새 UUID trip을 직접 종료 상태로 전환 (cron 자동 종료를 시뮬레이션 — expired 사유).
-      await env.TRIPS.delete(`trip:${newToken}`);
-      await env.TRIPS.put(
-        `tripStatus:${newToken}`,
-        JSON.stringify({ endedAt: Date.now(), endReason: 'expired' }),
-      );
-
-      const statusRes = await app.fetch(
-        new Request(`http://example.com/trips/${TOKEN}/status`, { method: 'GET' }),
-        env,
-      );
-      expect(statusRes.status).toBe(200);
-      const statusBody = (await statusRes.json()) as {
-        tripToken: string;
-        status: string;
-        endReason: string | null;
-      };
-      expect(statusBody.tripToken).toBe(TOKEN);
-      expect(statusBody.status).toBe('ended');
-      expect(statusBody.endReason).toBe('expired');
     });
 
     // #2129 — 2026-08-04 실탑승 evidence: 같은 device token으로 거의 동시에 도착한
-    // POST /trips 2건(waypoints 다름)이 getTrip → rotate → putTrip TOCTOU window에서
-    // interleave해 유령 trip 2개(원본 token + rotated UUID)가 모두 KV에 생존했다.
-    // withTripRegisterLock이 같은 token의 register 처리를 직렬화해 이 race를 차단한다.
+    // POST /trips 2건(waypoints 다름)이 getTrip → reset → putTrip TOCTOU window에서
+    // interleave하면 유령 trip이 KV에 중복 생존할 수 있다. withTripRegisterLock이 같은 token의
+    // register 처리를 직렬화해 이 race를 차단한다.
     it('#2129 동시 register 2건(같은 token, 다른 waypoints) → KV 활성 trip 정확히 1개', async () => {
       const env = makeKvEnv();
       await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
@@ -4649,24 +4607,19 @@ describe('POST /trips — #2019 rotateTripTokenForNewRoute wire (ADR-022 B4)', (
       expect(resA.status).toBe(200);
       expect(resB.status).toBe(200);
       const allTripKeys = (await env.TRIPS.list({ prefix: 'trip:' })).keys;
-      // 두 요청 모두 성공 응답을 받아도, 직렬화 덕분에 KV에는 활성 trip이 정확히 1개만 남는다
-      // (원본 TOKEN 재사용이든 rotation으로 발급된 새 UUID든 — 유령 trip 2개 생존이 회귀).
+      // 두 요청 모두 성공 응답을 받아도, 직렬화 덕분에 KV에는 활성 trip이 정확히 1개만 남는다 —
+      // 신원이 항상 같은 TOKEN이므로 두 요청은 결국 같은 key로 수렴한다.
       expect(allTripKeys.length).toBe(1);
+      expect(allTripKeys[0]?.name).toBe(`trip:${TOKEN}`);
     });
   });
 });
 
-// #2175 — deviceToken → trip.token 역인덱스로 POST /trips 비멱등 회수 (#2184 리뷰 P1).
-//
-// Root cause(backend RCA #2175 코멘트): 같은 실토큰 재-POST + route 변경 → 매번 새 UUID trip
-// 생성, `getTrip`은 incoming.token(실토큰)으로만 조회(index.ts)라 직전 로테이션의 UUID trip을
-// 못 찾아 orphan이 누적된다. rotated UUID를 device가 채택하지 않는 것도 원인(발산 지속).
-//
-// #2184 리뷰 P1 시퀀스: (1) 실토큰 등록 → route 변경 재-POST → 로테이션(`trip:<실토큰>` 삭제 +
-// `trip:<UUID>` 생성) → (2) 클라가 또 실토큰으로 재-POST(route 동일, lock/ETA 변동 등) →
-// `getTrip(실토큰)` miss → 역인덱스 fallback 없이는 신규 `trip:<실토큰>` 생성 → `trip:<UUID>`
-// (route frozen 고아)와 `trip:<실토큰>`(현재) 둘 다 live.
-describe('POST /trips — #2175 deviceToken 역인덱스 (orphan 회수, #2184 리뷰 P1)', () => {
+// #2175 — deviceToken → trip.token 역인덱스. ADR-025(#2194) 하에서 신원이 트립 수명 동안 불변이라
+// 일반 route 변경 경로는 항상 직접 key 조회(`trip:<incoming.token>`)로 성공하므로, 이 역인덱스의
+// 값은 이제 늘 그 key(deviceToken) 자신과 같다(예전 rotation 시절엔 UUID로 갈라졌다). ADR-025
+// Consequences에 명시된 대로 "APNs token refresh 복구 용도로만 축소 존치" — 삭제는 #2196 소관.
+describe('POST /trips — #2175 deviceToken 역인덱스 (ADR-025 이후 항상 자기 자신을 가리킴, 축소 존치)', () => {
   const TOKEN = 'tok-2175-real';
 
   function tripBodyFor(destination: string, stationName: string): Record<string, unknown> {
@@ -4678,90 +4631,23 @@ describe('POST /trips — #2175 deviceToken 역인덱스 (orphan 회수, #2184 �
     };
   }
 
-  async function activeTripKeys(env: Env): Promise<string[]> {
-    const list = await env.TRIPS.list({ prefix: 'trip:' });
-    return list.keys.map((k) => k.name);
-  }
-
-  it('P1: 실토큰 재-POST(route 동일, 로테이션 이후) → 역인덱스로 기존 UUID trip에 merge, 신규 trip:<실토큰> 미생성', async () => {
-    const env = makeKvEnv();
-    await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
-
-    // 1) 최초 등록.
-    const res1 = await post('/trips', tripBodyFor('용마산-id', '용마산'), env);
-    expect(res1.status).toBe(200);
-    expect(await activeTripKeys(env)).toEqual([`trip:${TOKEN}`]);
-
-    // 2) route 변경 재-POST → rotation 발동 (`trip:<TOKEN>` 삭제 + `trip:<UUID>` 생성).
-    const res2 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
-    expect(res2.status).toBe(200);
-    const body2 = (await res2.json()) as { token: string };
-    const uuid1 = body2.token;
-    expect(uuid1).not.toBe(TOKEN);
-    expect(await activeTripKeys(env)).toEqual([`trip:${uuid1}`]);
-
-    // 3) 클라는 rotated UUID를 채택하지 않고 계속 실토큰(TOKEN)으로 같은 route 재-POST.
-    //    수정 전: getTrip(TOKEN) miss → 신규 trip:<TOKEN> 생성 → trip:<uuid1>(고아) 동시 생존(2개).
-    //    수정 후: 역인덱스가 TOKEN → uuid1을 가리키므로 existing으로 재발견 → 같은 route → merge.
-    const res3 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
-    expect(res3.status).toBe(200);
-    const body3 = (await res3.json()) as { token: string };
-    expect(body3.token).toBe(uuid1);
-    const keysAfterMerge = await activeTripKeys(env);
-    expect(keysAfterMerge).toEqual([`trip:${uuid1}`]);
-    expect(keysAfterMerge).not.toContain(`trip:${TOKEN}`);
-  });
-
-  it('P1: 2회 연속 로테이션에도 orphan이 쌓이지 않는다 (역인덱스가 매번 최신 UUID로 갱신)', async () => {
-    const env = makeKvEnv();
-    await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
-
-    await post('/trips', tripBodyFor('용마산-id', '용마산'), env);
-    const res2 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
-    const uuid1 = ((await res2.json()) as { token: string }).token;
-
-    // 다시 실토큰으로 두 번째 route 변경 재-POST → uuid1 → uuid2 로테이션.
-    const res3 = await post('/trips', tripBodyFor('중곡-id', '중곡'), env);
-    expect(res3.status).toBe(200);
-    const uuid2 = ((await res3.json()) as { token: string }).token;
-    expect(uuid2).not.toBe(uuid1);
-    expect(uuid2).not.toBe(TOKEN);
-
-    // 두 번의 로테이션이 지나도 KV에 활성 trip은 정확히 1개 — uuid1도 orphan으로 남지 않는다.
-    expect(await activeTripKeys(env)).toEqual([`trip:${uuid2}`]);
-  });
-
-  it('#2184 리뷰 P1 안전망: 역인덱스가 가리키던 trip이 최종 확정 trip과 다르면 superseded-by-reregister로 정리하고 D1/sentinel을 남긴다', async () => {
-    const env = makeKvEnv();
-    await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
-    await post('/trips', tripBodyFor('용마산-id', '용마산'), env);
-    const res2 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
-    const uuid1 = ((await res2.json()) as { token: string }).token;
-
-    const res3 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
-    expect(res3.status).toBe(200);
-    // merge 케이스라 정리 대상이 없다 — uuid1 자체가 그대로 유지된 최종 trip이므로 sentinel 미기록.
-    expect(await env.TRIPS.get(`tripStatus:${uuid1}`)).toBeNull();
-
-    // 이어서 route 변경 재-POST → uuid1 → uuid2 로테이션. rotateTripTokenForNewRoute 자체가
-    // 'rotated' sentinel을 남기므로(#2174 F2), superseded-by-reregister 중복 기록은 없어야 한다.
-    const res4 = await post('/trips', tripBodyFor('중곡-id', '중곡'), env);
-    const uuid2 = ((await res4.json()) as { token: string }).token;
-    const uuid1Status = await env.TRIPS.get(`tripStatus:${uuid1}`);
-    expect(uuid1Status).not.toBeNull();
-    expect(JSON.parse(uuid1Status as string).endReason).toBe('rotated');
-    expect(await activeTripKeys(env)).toEqual([`trip:${uuid2}`]);
-  });
-
-  it('deviceToken 역인덱스가 최종 trip.token으로 유지된다 (raw KV 값 검증)', async () => {
+  it('등록 시 deviceToken 역인덱스가 즉시 생성되고 값은 항상 TOKEN 자신이다', async () => {
     const env = makeKvEnv();
     await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
     await post('/trips', tripBodyFor('용마산-id', '용마산'), env);
     expect(await env.TRIPS.get(`device-trips:${TOKEN}`)).toBe(TOKEN);
+  });
 
-    const res2 = await post('/trips', tripBodyFor('성수-id', '성수'), env);
-    const uuid1 = ((await res2.json()) as { token: string }).token;
-    expect(await env.TRIPS.get(`device-trips:${TOKEN}`)).toBe(uuid1);
+  it('route 변경 재-POST를 반복해도(신원 불변) 역인덱스 값은 계속 TOKEN 자신을 가리킨다', async () => {
+    const env = makeKvEnv();
+    await env.TRIPS.put(ARCH_FLAG_KV_KEY, 'on');
+    await post('/trips', tripBodyFor('용마산-id', '용마산'), env);
+    await post('/trips', tripBodyFor('성수-id', '성수'), env);
+    await post('/trips', tripBodyFor('중곡-id', '중곡'), env);
+    expect(await env.TRIPS.get(`device-trips:${TOKEN}`)).toBe(TOKEN);
+    // 활성 trip은 항상 정확히 1개, 항상 같은 key.
+    const keys = (await env.TRIPS.list({ prefix: 'trip:' })).keys.map((k) => k.name);
+    expect(keys).toEqual([`trip:${TOKEN}`]);
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/tripIdentityReplay.test.ts
+++ b/backend/alarm-worker/src/__tests__/tripIdentityReplay.test.ts
@@ -2,17 +2,17 @@
  * 2026-08-07 오전 실탑승(corrId=tmsi34imn) rotation storm replay (Issue #2193,
  * Part of #2192 / ADR-025).
  *
- * TDD 선행 — #A1(신원 안정화 core fix)보다 먼저 이 replay가 "현재 코드에서 실패(red)"함을
- * 증명한다. #A1이 머지되면 아래 `test.fails(...)` 블록을 `test(...)`로 flip해 green
- * 전환을 검증한다 (각 블록에 "flip in #2194" 주석).
+ * TDD 선행 — #2194(신원 안정화 core fix)보다 먼저 이 replay가 "현재 코드에서 실패(red)"함을
+ * 증명했다(#2193, production 코드 미수정 — fixture + test만). #2194가 신원(rotation) 관련
+ * `test.fails(...)` 2개를 `test(...)`로 flip했다(주석 "flipped in #2194"). 429 관련 1개는
+ * rate-limit create/update 구분(#2195) 범위라 여전히 `test.fails`로 남아있다(주석 "flip in
+ * #2195").
  *
  * 재현 메커니즘: `POST /trips` rate-limit 게이트(`index.ts:567`, deviceToken 기준 10회/10분)가
- * route-change rotation(`index.ts:776`, `rotateTripTokenForNewRoute`)보다 먼저 평가된다.
- * 매 route 변경 재-POST가 rotation을 유발해도 rate-limit 키는 항상 원본 deviceToken —
- * 10번째 이후 재-POST는 429로 죽고 새 route trip이 등록되지 않는다.
- *
- * 금지: 이 이슈는 production 코드를 수정하지 않는다 (`src/index.ts` / `src/trips.ts` /
- * `src/tripRegisterRateLimit.ts` 등). Fixture + test만.
+ * route-change reset(#2194 이전엔 rotation, `index.ts:776`)보다 먼저 평가된다. #2194 이후에도
+ * rate-limit 키는 여전히 원본 deviceToken이라 — 10번째 이후 재-POST는 429로 죽는다(#2195 대기).
+ * 다만 신원이 더 이상 churn하지 않으므로(rotation 폐기) 성공한 요청들은 항상 같은 trip으로
+ * 수렴한다(위 2개 flip된 assert가 검증).
  */
 
 import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
@@ -132,31 +132,28 @@ describe('evidence 2026-08-07 tmsi34imn — rotation storm red replay (#2193)', 
 
   // -------------------------------------------------------------------------
   // 아래 3개는 "수리 후 기대치" — ADR-025(#2192) #A1 신원 안정화 적용 후 green이 되어야
-  // 한다. 지금은 버그가 존재하므로 assert가 실패해야 정상 — `test.fails`로 감싸 CI green을
-  // 유지한다(#2194에서 `test.fails` → `test`로 flip).
+  // 한다. #2194가 신원(rotation) 관련 2개를 green으로 flip했다. 429 관련 1개는 여전히
+  // `test.fails`로 감싸 CI green을 유지한다(#2195에서 rate-limit create/update 구분 후 flip).
   // -------------------------------------------------------------------------
 
-  // flip in #2194
-  test.fails(
-    '수리 후 기대치: route 변경 재-POST에서 rotated 발생 0 (신규 UUID trip 키 생성 없음)',
-    async () => {
-      const kv = new InMemoryKV();
-      await kv.put(ARCH_FLAG_KV_KEY, 'on');
-      const env = makeEnv(kv);
+  // flipped in #2194 (ADR-025 신원 안정화 — resetTripStateForNewRoute)
+  test('수리 후 기대치: route 변경 재-POST에서 rotated 발생 0 (신규 UUID trip 키 생성 없음)', async () => {
+    const kv = new InMemoryKV();
+    await kv.put(ARCH_FLAG_KV_KEY, 'on');
+    const env = makeEnv(kv);
 
-      await runRotationStorm(env);
+    await runRotationStorm(env);
 
-      const allTrips = await kv.list({ prefix: 'trip:' });
-      const uuidLikeKeys = allTrips.keys.filter(
-        (k) => k.name !== `trip:${DEVICE_TOKEN}`,
-      );
-      // 수리 후: route 변경은 rotation(새 UUID 키) 없이 같은 신원(deviceToken 키) update로
-      // 처리되어야 한다 — 지금은 매 route 변경마다 새 UUID 키가 생성되어 실패한다.
-      expect(uuidLikeKeys.length).toBe(0);
-    },
-  );
+    const allTrips = await kv.list({ prefix: 'trip:' });
+    const uuidLikeKeys = allTrips.keys.filter(
+      (k) => k.name !== `trip:${DEVICE_TOKEN}`,
+    );
+    // 수리 후: route 변경은 rotation(새 UUID 키) 없이 같은 신원(deviceToken 키) update로
+    // 처리된다 — #2194가 rotateTripTokenForNewRoute를 resetTripStateForNewRoute로 대체.
+    expect(uuidLikeKeys.length).toBe(0);
+  });
 
-  // flip in #2194
+  // flip in #2195 (rate-limit create/update 구분 — 이 이슈 범위 밖, #2194는 신원 안정화만)
   test.fails(
     '수리 후 기대치: rotation storm 재-POST가 create budget을 소진하지 않아 429 = 0',
     async () => {
@@ -172,21 +169,19 @@ describe('evidence 2026-08-07 tmsi34imn — rotation storm red replay (#2193)', 
     },
   );
 
-  // flip in #2194
-  test.fails(
-    '수리 후 기대치: 트립 1건이 동일 신원(deviceToken 키)으로 지속 등록된다 (route 변경 = update)',
-    async () => {
-      const kv = new InMemoryKV();
-      await kv.put(ARCH_FLAG_KV_KEY, 'on');
-      const env = makeEnv(kv);
+  // flipped in #2194 (ADR-025 신원 안정화 — resetTripStateForNewRoute)
+  test('수리 후 기대치: 트립 1건이 동일 신원(deviceToken 키)으로 지속 등록된다 (route 변경 = update)', async () => {
+    const kv = new InMemoryKV();
+    await kv.put(ARCH_FLAG_KV_KEY, 'on');
+    const env = makeEnv(kv);
 
-      await runRotationStorm(env);
+    await runRotationStorm(env);
 
-      const allTrips = await kv.list({ prefix: 'trip:' });
-      // 수리 후: 활성 trip은 정확히 1개, 그리고 그 키는 항상 원본 deviceToken이어야 한다 —
-      // 지금은 rotation이 매번 새 UUID 키로 옮겨가 이 조건을 만족하지 못한다.
-      expect(allTrips.keys.length).toBe(1);
-      expect(allTrips.keys[0]?.name).toBe(`trip:${DEVICE_TOKEN}`);
-    },
-  );
+    const allTrips = await kv.list({ prefix: 'trip:' });
+    // 수리 후: 활성 trip은 정확히 1개, 그리고 그 키는 항상 원본 deviceToken이다 — 11번째
+    // 요청은 여전히 429로 막히지만(#2195 대기), 그 요청은 어떤 trip도 mutate하지 않으므로
+    // 나머지 10건이 모두 같은 key로 수렴한 결과는 영향받지 않는다.
+    expect(allTrips.keys.length).toBe(1);
+    expect(allTrips.keys[0]?.name).toBe(`trip:${DEVICE_TOKEN}`);
+  });
 });

--- a/backend/alarm-worker/src/__tests__/trips.test.ts
+++ b/backend/alarm-worker/src/__tests__/trips.test.ts
@@ -16,8 +16,8 @@ import {
   listTrips,
   putDeviceTripIndex,
   putTrip,
+  resetTripStateForNewRoute,
   resolveTripDeviceToken,
-  rotateTripTokenForNewRoute,
   tripKey,
   withTripRegisterLock,
 } from '../trips';
@@ -259,8 +259,9 @@ describe('trips KV CRUD', () => {
     expect(yielded[0].boardingLock).toBeUndefined();
   });
 
-  // ADR-022 B4 — 새 route = 새 token 강제 (#1986).
-  describe('ADR-022 B4 — trip token rotation (#1986)', () => {
+  // ADR-025 (#2194) — trip 신원 안정화. rotation(새 token 발급, ADR-022 B4/#1986) 폐기 +
+  // route 변경 = in-place reset.
+  describe('ADR-025 — resetTripStateForNewRoute (#2194)', () => {
     function makePending(overrides: Partial<PendingPush> = {}): PendingPush {
       return {
         pushId: 'push-1',
@@ -277,17 +278,17 @@ describe('trips KV CRUD', () => {
     }
 
     describe('arch flag default (Phase 1-3, #2002 real helper wire)', () => {
-      it('KV 미설정 → default OFF: `rotateTripTokenForNewRoute` 기존 동작 유지', async () => {
-        // KV 에 arch flag 미설정 → getArchFlag 는 default 'off' 반환 → rotation 없음.
+      it('KV 미설정 → default OFF: `resetTripStateForNewRoute` 기존 동작 유지 (existing 그대로, reset 없음)', async () => {
+        // KV 에 arch flag 미설정 → getArchFlag 는 default 'off' 반환 → reset 없음.
         const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
         await putTrip(kv as unknown as KVNamespace, existing);
         const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
-        const result = await rotateTripTokenForNewRoute(
+        const result = await resetTripStateForNewRoute(
           kv as unknown as KVNamespace,
           incoming,
           existing,
         );
-        expect(result).toEqual({ token: 'tok-old', rotated: false });
+        expect(result).toEqual({ existing, reset: false });
       });
     });
 
@@ -388,29 +389,29 @@ describe('trips KV CRUD', () => {
       });
     });
 
-    describe('rotateTripTokenForNewRoute (flag OFF)', () => {
-      it('flag OFF (KV 미설정 default): 항상 incoming token 그대로 반환 + KV 변경 없음', async () => {
+    describe('resetTripStateForNewRoute (flag OFF)', () => {
+      it('flag OFF (KV 미설정 default): existing 그대로 반환 + KV 변경 없음', async () => {
         const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
         await putTrip(kv as unknown as KVNamespace, existing);
         const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
-        const result = await rotateTripTokenForNewRoute(
+        const result = await resetTripStateForNewRoute(
           kv as unknown as KVNamespace,
           incoming,
           existing,
         );
-        expect(result).toEqual({ token: 'tok-old', rotated: false });
+        expect(result).toEqual({ existing, reset: false });
         // KV cleanup 없음
         expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).not.toBeNull();
       });
 
-      it('flag OFF: existing null이어도 동일 (incoming 그대로)', async () => {
+      it('flag OFF: existing null이어도 동일 (null 그대로)', async () => {
         const incoming = makeTrip({ token: 'tok-new' });
-        const result = await rotateTripTokenForNewRoute(
+        const result = await resetTripStateForNewRoute(
           kv as unknown as KVNamespace,
           incoming,
           null,
         );
-        expect(result).toEqual({ token: 'tok-new', rotated: false });
+        expect(result).toEqual({ existing: null, reset: false });
       });
 
       it('flag OFF: deps.simpleArchEnabled=false 명시도 동일 (DI 우선)', async () => {
@@ -418,59 +419,43 @@ describe('trips KV CRUD', () => {
         await kv.put(ARCH_FLAG_KV_KEY, 'on');
         const existing = makeTrip({ token: 'tok-A', destination: 'D-1' });
         const incoming = makeTrip({ token: 'tok-A', destination: 'D-2' });
-        const result = await rotateTripTokenForNewRoute(
+        const result = await resetTripStateForNewRoute(
           kv as unknown as KVNamespace,
           incoming,
           existing,
           { simpleArchEnabled: false },
         );
-        expect(result).toEqual({ token: 'tok-A', rotated: false });
+        expect(result).toEqual({ existing, reset: false });
       });
 
       it('flag OFF: KV value 오타 (default fallback)도 OFF 동작', async () => {
-        // #2002 — getArchFlag 는 'on' | 'off' 외 값을 default 'off' 로 정규화 → rotation 없음.
+        // #2002 — getArchFlag 는 'on' | 'off' 외 값을 default 'off' 로 정규화 → reset 없음.
         await kv.put(ARCH_FLAG_KV_KEY, 'invalid-value');
         const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
         await putTrip(kv as unknown as KVNamespace, existing);
         const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
-        const result = await rotateTripTokenForNewRoute(
+        const result = await resetTripStateForNewRoute(
           kv as unknown as KVNamespace,
           incoming,
           existing,
         );
-        expect(result).toEqual({ token: 'tok-old', rotated: false });
+        expect(result).toEqual({ existing, reset: false });
       });
     });
 
-    describe('rotateTripTokenForNewRoute (flag ON, #2174 P1-A — TOKEN_ROTATION_DISABLED guard 해제로 rotation 재활성)', () => {
-      it('deps.rotationDisabled: true 명시 override — emergency 재차단 경로 보존 (coverage)', async () => {
-        // #2174가 production 상수(TOKEN_ROTATION_DISABLED)를 false로 되돌렸지만, #2173이
-        // 도입한 emergency override 자체는 삭제하지 않는다 — 재발 시 즉시 재차단 가능해야 한다.
-        const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
-        await putTrip(kv as unknown as KVNamespace, existing);
-        const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
-        const result = await rotateTripTokenForNewRoute(
-          kv as unknown as KVNamespace,
-          incoming,
-          existing,
-          { simpleArchEnabled: true, rotationDisabled: true, generateToken: () => 'new-uuid' },
-        );
-        expect(result).toEqual({ token: 'tok-old', rotated: false });
-        expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).not.toBeNull();
-      });
-
-      it('existing 없음 (신규 trip): incoming 그대로 (rotated=false)', async () => {
+    describe('resetTripStateForNewRoute (flag ON)', () => {
+      it('existing 없음 (신규 trip): existing null 그대로 (reset=false)', async () => {
         const incoming = makeTrip({ token: 'tok-new' });
-        const result = await rotateTripTokenForNewRoute(
+        const result = await resetTripStateForNewRoute(
           kv as unknown as KVNamespace,
           incoming,
           null,
           { simpleArchEnabled: true },
         );
-        expect(result).toEqual({ token: 'tok-new', rotated: false });
+        expect(result).toEqual({ existing: null, reset: false });
       });
 
-      it('같은 route (시그니처 일치): incoming token 유지 (rotated=false)', async () => {
+      it('같은 route (시그니처 일치): existing 그대로 (reset=false)', async () => {
         const existing = makeTrip({
           token: 'tok-same',
           destination: 'D-1',
@@ -482,69 +467,35 @@ describe('trips KV CRUD', () => {
           destination: 'D-1',
           waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
         });
-        const result = await rotateTripTokenForNewRoute(
+        const result = await resetTripStateForNewRoute(
           kv as unknown as KVNamespace,
           incoming,
           existing,
           { simpleArchEnabled: true },
         );
-        expect(result).toEqual({ token: 'tok-same', rotated: false });
-        // 같은 route → cleanup 없음
+        expect(result).toEqual({ existing, reset: false });
+        // 같은 route → cleanup 없음, trip 그대로 생존.
         expect(await getTrip(kv as unknown as KVNamespace, 'tok-same')).not.toBeNull();
       });
 
-      // #2175 — deviceToken 역인덱스로 재발견한 existing은 incoming.token과 다른 값일 수 있다
-      // (ADR-022 B4 로테이션으로 이전에 UUID로 바뀐 trip). 같은 route라면 반드시 existing.token
-      // (기존 UUID)을 반환해야 한다 — incoming.token(실 deviceToken)을 반환하면 이미 존재하는
-      // UUID trip과 별개로 `trip:<incoming.token>`이 새로 생겨 유령 2개가 남는다(#2184 리뷰 P1).
-      it('#2175 — 같은 route, existing.token !== incoming.token (역인덱스 fallback): existing.token 채택', async () => {
-        const existing = makeTrip({
-          token: 'uuid-from-prior-rotation',
-          deviceToken: 'real-device-token',
-          destination: 'D-1',
-          waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
-        });
+      it('다른 destination: in-place reset 발동 (existing null 반환, token/KV 레코드는 불변 — 별도 index.ts putTrip이 갱신)', async () => {
+        // ADR-025 — trip 신원(token)은 트립 수명 동안 불변. rotation처럼 새 token을 발급하거나
+        // `trip:<token>` 레코드를 삭제하지 않는다 — helper는 오직 "reset 여부"만 판정한다.
+        const existing = makeTrip({ token: 'tok-old', deviceToken: 'a'.repeat(64), destination: 'D-1' });
         await putTrip(kv as unknown as KVNamespace, existing);
-        const incoming = makeTrip({
-          token: 'real-device-token',
-          deviceToken: 'real-device-token',
-          destination: 'D-1',
-          waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
-        });
-        const result = await rotateTripTokenForNewRoute(
+        const incoming = makeTrip({ token: 'tok-old', deviceToken: 'a'.repeat(64), destination: 'D-2' });
+        const result = await resetTripStateForNewRoute(
           kv as unknown as KVNamespace,
           incoming,
           existing,
           { simpleArchEnabled: true },
         );
-        expect(result).toEqual({ token: 'uuid-from-prior-rotation', rotated: false });
-        // 정리 대상 없음 — merge이므로 existing trip 그대로 생존.
-        expect(
-          await getTrip(kv as unknown as KVNamespace, 'uuid-from-prior-rotation'),
-        ).not.toBeNull();
+        expect(result).toEqual({ existing: null, reset: true });
+        // token 신원은 유지 — 어떤 key도 새로 생성/삭제되지 않는다(helper 범위 밖, index.ts가 담당).
+        expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).not.toBeNull();
       });
 
-      it('#2174 — 다른 destination: rotation 발동 (새 token 발급 + old trip:<token> delete)', async () => {
-        // #2173 P0 hotfix가 이 경로를 guard로 단락시켰던 이유(push가 UUID를 APNs deviceToken으로
-        // 사용해 400 BadDeviceToken 즉사, Epic #2172)는 #2174가 `Trip.deviceToken` 필드 분리 +
-        // 모든 push 발사 사이트의 `resolveTripDeviceToken(trip)` 전환으로 해소했다 — guard 해제.
-        const existing = makeTrip({ token: 'tok-old', deviceToken: 'a'.repeat(64), destination: 'D-1' });
-        await putTrip(kv as unknown as KVNamespace, existing);
-        const incoming = makeTrip({ token: 'tok-old', deviceToken: 'a'.repeat(64), destination: 'D-2' });
-        const result = await rotateTripTokenForNewRoute(
-          kv as unknown as KVNamespace,
-          incoming,
-          existing,
-          {
-            simpleArchEnabled: true,
-            generateToken: () => 'new-uuid',
-          },
-        );
-        expect(result).toEqual({ token: 'new-uuid', rotated: true });
-        expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).toBeNull();
-      });
-
-      it('#2174 — 다른 waypoints (같은 destination): rotation 발동 (rotated=true)', async () => {
+      it('다른 waypoints (같은 destination): reset 발동 (reset=true)', async () => {
         const existing = makeTrip({
           token: 'tok-old',
           destination: 'D-1',
@@ -559,20 +510,17 @@ describe('trips KV CRUD', () => {
             { stationName: 'A', line: '2', kind: 'destination' },
           ],
         });
-        const result = await rotateTripTokenForNewRoute(
+        const result = await resetTripStateForNewRoute(
           kv as unknown as KVNamespace,
           incoming,
           existing,
-          {
-            simpleArchEnabled: true,
-            generateToken: () => 'new-token-xyz',
-          },
+          { simpleArchEnabled: true },
         );
-        expect(result.rotated).toBe(true);
-        expect(result.token).toBe('new-token-xyz');
+        expect(result.reset).toBe(true);
+        expect(result.existing).toBeNull();
       });
 
-      it('#2174 — 다른 route: old token 소유 pending push cleanup (다른 token 소유는 보존)', async () => {
+      it('다른 route: incoming.token 소유 pending push cleanup (다른 token 소유는 보존)', async () => {
         const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
         await putTrip(kv as unknown as KVNamespace, existing);
         await putPending(
@@ -589,14 +537,11 @@ describe('trips KV CRUD', () => {
         );
 
         const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
-        await rotateTripTokenForNewRoute(
+        await resetTripStateForNewRoute(
           kv as unknown as KVNamespace,
           incoming,
           existing,
-          {
-            simpleArchEnabled: true,
-            generateToken: () => 'new-token',
-          },
+          { simpleArchEnabled: true },
         );
 
         expect(await kv.get(pendingKey('p-old-1'))).toBeNull();
@@ -604,41 +549,22 @@ describe('trips KV CRUD', () => {
         expect(await kv.get(pendingKey('p-other'))).not.toBeNull();
       });
 
-      it('#2174 — generateToken 미지정: crypto.randomUUID로 새 token 생성 (default)', async () => {
-        const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
-        await putTrip(kv as unknown as KVNamespace, existing);
-        const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
-        const spy = vi.spyOn(crypto, 'randomUUID');
-        const result = await rotateTripTokenForNewRoute(
-          kv as unknown as KVNamespace,
-          incoming,
-          existing,
-          { simpleArchEnabled: true },
-        );
-        expect(spy).toHaveBeenCalledOnce();
-        expect(result.rotated).toBe(true);
-        spy.mockRestore();
-      });
-
-      it('#2002 — deps.simpleArchEnabled 미지정 + KV `arch:simple-arrival-v1`=on: getArchFlag fallback으로 rotation 발동', async () => {
+      it('#2002 — deps.simpleArchEnabled 미지정 + KV `arch:simple-arrival-v1`=on: getArchFlag fallback으로 reset 발동', async () => {
         await kv.put(ARCH_FLAG_KV_KEY, 'on');
         const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
         await putTrip(kv as unknown as KVNamespace, existing);
         const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
-        const result = await rotateTripTokenForNewRoute(
+        const result = await resetTripStateForNewRoute(
           kv as unknown as KVNamespace,
           incoming,
           existing,
-          { generateToken: () => 'new-token-from-kv-flag' },
         );
-        expect(result).toEqual({ token: 'new-token-from-kv-flag', rotated: true });
-        expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).toBeNull();
+        expect(result).toEqual({ existing: null, reset: true });
       });
 
-      // #2174 F1 — 로테이션은 등록 시점 한정이 아니라 mid-trip route 변경(환승 waypoint trim
-      // 재-POST, 목적지 변경 등) 재-POST에서도 발동한다. 이 red 시나리오는 "실토큰 trip 활성 중
-      // route 변경 재-POST → 로테이션 → deviceToken이 여전히 실토큰"을 보장한다.
-      it('#2174 F1 — mid-trip route 변경 재-POST 로테이션 시에도 새 trip의 deviceToken은 실토큰 그대로', async () => {
+      // mid-trip route 변경(환승 waypoint trim 재-POST, 목적지 변경 등) 재-POST에서도 신원은
+      // 불변 — deviceToken도 rotation과 무관하게 항상 실토큰 그대로 보존된다.
+      it('mid-trip route 변경 재-POST에도 incoming.deviceToken은 실토큰 그대로', async () => {
         const realDeviceToken = 'b'.repeat(64);
         const existing = makeTrip({
           token: realDeviceToken,
@@ -647,246 +573,30 @@ describe('trips KV CRUD', () => {
           waypoints: [{ stationName: 'A', line: '2', kind: 'destination' }],
         });
         await putTrip(kv as unknown as KVNamespace, existing);
-        // 환승 후 waypoint trim + 새 목적지로 재-POST — deviceToken은 client가 매번 실 토큰을 보낸다.
         const incoming = makeTrip({
           token: realDeviceToken,
           deviceToken: realDeviceToken,
           destination: 'D-2',
           waypoints: [{ stationName: 'C', line: '7', kind: 'destination' }],
         });
-        const result = await rotateTripTokenForNewRoute(
+        const result = await resetTripStateForNewRoute(
           kv as unknown as KVNamespace,
           incoming,
           existing,
-          { simpleArchEnabled: true, generateToken: () => 'rotated-uuid' },
+          { simpleArchEnabled: true },
         );
-        expect(result).toEqual({ token: 'rotated-uuid', rotated: true });
-        // 로테이션은 trip.token(신원)만 교체 — incoming.deviceToken은 rotation 결과와 무관하게
-        // 실토큰 그대로 보존된다(index.ts가 baseTrip = {...incoming, ...}으로 그대로 carry).
+        expect(result).toEqual({ existing: null, reset: true });
         expect(incoming.deviceToken).toBe(realDeviceToken);
-      });
-
-      // #2174 F2 — old trip 삭제가 관측 blind hole이었다. 로테이션 시 old trip에 D1 기록 +
-      // tripStatus sentinel(reason='rotated')을 남겨야 한다.
-      describe('#2174 F2 — old trip 로테이션 관측 기록 (D1 + tripStatus sentinel)', () => {
-        it('rotation 시 old trip token으로 tripStatus sentinel이 reason=rotated로 기록된다', async () => {
-          const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
-          await putTrip(kv as unknown as KVNamespace, existing);
-          const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
-          const now = 1_700_000_000_000;
-          await rotateTripTokenForNewRoute(
-            kv as unknown as KVNamespace,
-            incoming,
-            existing,
-            { simpleArchEnabled: true, generateToken: () => 'new-uuid', now },
-          );
-          const sentinel = await readTripEndedStatus(kv as unknown as KVNamespace, 'tok-old');
-          expect(sentinel).toEqual({ endedAt: now, endReason: 'rotated' });
-        });
-
-        it('rotation 시 D1 binding 이 있으면 recordTripMetrics 가 old trip 기준으로 호출된다', async () => {
-          const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
-          await putTrip(kv as unknown as KVNamespace, existing);
-          const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
-          const run = vi.fn().mockResolvedValue(undefined);
-          const bind = vi.fn().mockReturnValue({ run });
-          const prepare = vi.fn().mockReturnValue({ bind });
-          const db = { prepare } as unknown as D1Database;
-          await rotateTripTokenForNewRoute(
-            kv as unknown as KVNamespace,
-            incoming,
-            existing,
-            { simpleArchEnabled: true, generateToken: () => 'new-uuid', db, now: 1_700_000_000_000 },
-          );
-          expect(prepare).toHaveBeenCalled();
-          // end_reason 인자(4번째 bind 인자, 0-based idx 3)가 'rotated' — SQL 컬럼 순서(d1TripMetrics.ts) 참고.
-          expect(bind).toHaveBeenCalledOnce();
-          expect(bind.mock.calls[0][3]).toBe('rotated');
-        });
-
-        it('db 미지정 시 recordTripMetrics no-op이어도 rotation 자체는 정상 완료', async () => {
-          const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
-          await putTrip(kv as unknown as KVNamespace, existing);
-          const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
-          const result = await rotateTripTokenForNewRoute(
-            kv as unknown as KVNamespace,
-            incoming,
-            existing,
-            { simpleArchEnabled: true, generateToken: () => 'new-uuid' },
-          );
-          expect(result).toEqual({ token: 'new-uuid', rotated: true });
-        });
-
-        it('tripStatus sentinel 기록(KV put) 실패해도 rotation 자체는 정상 완료 (best-effort)', async () => {
-          const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
-          await putTrip(kv as unknown as KVNamespace, existing);
-          const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
-          const failingKv = {
-            ...kv,
-            put: vi.fn(async (key: string, value: string, options?: unknown) => {
-              if (key.startsWith('tripStatus:')) throw new Error('KV put failed');
-              return kv.put(key, value, options as { expirationTtl?: number } | undefined);
-            }),
-            get: kv.get.bind(kv),
-            delete: kv.delete.bind(kv),
-            list: kv.list.bind(kv),
-          };
-          const result = await rotateTripTokenForNewRoute(
-            failingKv as unknown as KVNamespace,
-            incoming,
-            existing,
-            { simpleArchEnabled: true, generateToken: () => 'new-uuid' },
-          );
-          expect(result).toEqual({ token: 'new-uuid', rotated: true });
-          // rotation은 sentinel 기록 실패와 무관하게 old trip을 정상 삭제한다.
-          expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).toBeNull();
-        });
-      });
-    });
-
-    describe('#2174 P1-A — deps.rotationDisabled:false 명시 override (기존 default와 동치, 명시적 coverage 보존)', () => {
-      // #2173 스펙 잔재: "로테이션 로직 자체는 삭제하지 않음(#P1-A에서 구조 수리 후 재활성)".
-      // #2174가 TOKEN_ROTATION_DISABLED 상수를 false로 되돌려 이 override는 이제 default와
-      // 동치이지만, 테스트가 deps DI 경로 자체를 명시적으로 계속 검증하도록 보존한다.
-      it('flag OFF (KV 미설정 default) + rotationDisabled:false: flagEnabled=false 분기로 incoming 그대로', async () => {
-        // 리뷰 P2 — flagEnabled false 분기(line 235-236)는 guard(TOKEN_ROTATION_DISABLED)가 먼저
-        // return하는 기존 '#2173 guard' 스위트에서는 도달 불가. rotationDisabled:false로 guard를
-        // 우회해야만 이 분기가 실행된다.
-        const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
-        await putTrip(kv as unknown as KVNamespace, existing);
-        const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
-        const result = await rotateTripTokenForNewRoute(
-          kv as unknown as KVNamespace,
-          incoming,
-          existing,
-          { rotationDisabled: false },
-        );
-        expect(result).toEqual({ token: 'tok-old', rotated: false });
-        expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).not.toBeNull();
-      });
-
-      it('existing 없음 (신규 trip): incoming 그대로 (rotated=false)', async () => {
-        const incoming = makeTrip({ token: 'tok-new' });
-        const result = await rotateTripTokenForNewRoute(
-          kv as unknown as KVNamespace,
-          incoming,
-          null,
-          { simpleArchEnabled: true, rotationDisabled: false },
-        );
-        expect(result).toEqual({ token: 'tok-new', rotated: false });
-      });
-
-      it('같은 route (시그니처 일치): incoming token 유지 (rotated=false)', async () => {
-        const existing = makeTrip({
-          token: 'tok-same',
-          destination: 'D-1',
-          waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
-        });
-        await putTrip(kv as unknown as KVNamespace, existing);
-        const incoming = makeTrip({
-          token: 'tok-same',
-          destination: 'D-1',
-          waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
-        });
-        const result = await rotateTripTokenForNewRoute(
-          kv as unknown as KVNamespace,
-          incoming,
-          existing,
-          { simpleArchEnabled: true, rotationDisabled: false },
-        );
-        expect(result).toEqual({ token: 'tok-same', rotated: false });
-        expect(await getTrip(kv as unknown as KVNamespace, 'tok-same')).not.toBeNull();
-      });
-
-      it('다른 destination: 새 token 발급 + old trip:<token> delete + rotated=true', async () => {
-        const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
-        await putTrip(kv as unknown as KVNamespace, existing);
-        const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
-        const result = await rotateTripTokenForNewRoute(
-          kv as unknown as KVNamespace,
-          incoming,
-          existing,
-          {
-            simpleArchEnabled: true,
-            generateToken: () => 'new-uuid',
-            rotationDisabled: false,
-          },
-        );
-        expect(result).toEqual({ token: 'new-uuid', rotated: true });
-        expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).toBeNull();
-      });
-
-      it('deps.simpleArchEnabled 미지정 + KV `arch:simple-arrival-v1`=on: getArchFlag fallback으로 rotation 발동', async () => {
-        // 리뷰 P2 — `flagEnabled = deps?.simpleArchEnabled ?? ((await getArchFlag(kv)) === 'on')`의
-        // `??` 우변(getArchFlag 실호출)이 기존 스위트에서 전혀 실행되지 않던 gap. 여기서는
-        // simpleArchEnabled를 생략해 KV flag 실조회 경로를 태운다.
-        await kv.put(ARCH_FLAG_KV_KEY, 'on');
-        const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
-        await putTrip(kv as unknown as KVNamespace, existing);
-        const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
-        const result = await rotateTripTokenForNewRoute(
-          kv as unknown as KVNamespace,
-          incoming,
-          existing,
-          { generateToken: () => 'new-uuid-from-kv-flag', rotationDisabled: false },
-        );
-        expect(result).toEqual({ token: 'new-uuid-from-kv-flag', rotated: true });
-        expect(await getTrip(kv as unknown as KVNamespace, 'tok-old')).toBeNull();
-      });
-
-      it('다른 route: old token 소유 pending push cleanup (다른 token 보존)', async () => {
-        const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
-        await putTrip(kv as unknown as KVNamespace, existing);
-        await putPending(
-          kv as unknown as KVNamespace,
-          makePending({ pushId: 'p-old-1', token: 'tok-old' }),
-        );
-        await putPending(
-          kv as unknown as KVNamespace,
-          makePending({ pushId: 'p-other', token: 'tok-different-device' }),
-        );
-        const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
-        await rotateTripTokenForNewRoute(
-          kv as unknown as KVNamespace,
-          incoming,
-          existing,
-          {
-            simpleArchEnabled: true,
-            generateToken: () => 'new-token',
-            rotationDisabled: false,
-          },
-        );
-        expect(await kv.get(pendingKey('p-old-1'))).toBeNull();
-        expect(await kv.get(pendingKey('p-other'))).not.toBeNull();
-      });
-
-      it('generateToken 미지정: crypto.randomUUID로 생성 (default)', async () => {
-        const existing = makeTrip({ token: 'tok-old', destination: 'D-1' });
-        await putTrip(kv as unknown as KVNamespace, existing);
-        const incoming = makeTrip({ token: 'tok-old', destination: 'D-2' });
-        const spy = vi.spyOn(crypto, 'randomUUID');
-        const result = await rotateTripTokenForNewRoute(
-          kv as unknown as KVNamespace,
-          incoming,
-          existing,
-          { simpleArchEnabled: true, rotationDisabled: false },
-        );
-        expect(spy).toHaveBeenCalledOnce();
-        expect(result.token).toMatch(
-          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-        );
-        expect(result.rotated).toBe(true);
-        spy.mockRestore();
       });
     });
   });
 });
 
 // #2129 — per-token in-flight 직렬화. 2026-08-04 실탑승 evidence: 같은 device token으로
-// 거의 동시에 도착한 POST /trips 2건이 getTrip → rotate → putTrip TOCTOU window에서 interleave해
-// 유령 trip 2개(원본 token + rotated UUID)가 모두 KV에 생존했다. withTripRegisterLock은 같은
-// token의 register 처리를 큐로 직렬화해 두 번째 요청이 첫 번째 요청의 read-rotate-write 사이클이
-// 완전히 끝난 뒤에만 시작하도록 보장한다.
+// 거의 동시에 도착한 POST /trips 2건이 getTrip → reset → putTrip TOCTOU window에서 interleave해
+// 유령 trip이 KV에 중복 생존했다. withTripRegisterLock은 같은 token의 register 처리를 큐로
+// 직렬화해 두 번째 요청이 첫 번째 요청의 read-reset-write 사이클이 완전히 끝난 뒤에만 시작하도록
+// 보장한다.
 describe('withTripRegisterLock (#2129)', () => {
   beforeEach(() => {
     __resetTripRegisterLocksForTest();
@@ -1029,8 +739,8 @@ describe('deviceToken → trip 역인덱스 (#2175)', () => {
   });
 });
 
-// #2175 — 공유 orphan cleanup helper. rotateTripTokenForNewRoute의 route-변경 cleanup과
-// POST /trips 핸들러의 superseded-by-reregister cleanup이 공유한다.
+// #2175 — 공유 orphan cleanup helper. POST /trips 핸들러의 superseded-by-reregister cleanup이
+// 사용한다.
 describe('cleanupSupersededTrip (#2175)', () => {
   let kv: InMemoryKV;
   beforeEach(() => {

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -131,7 +131,7 @@ import {
   getTrip,
   putDeviceTripIndex,
   putTrip,
-  rotateTripTokenForNewRoute,
+  resetTripStateForNewRoute,
   withTripRegisterLock,
 } from './trips';
 import { inferWaypointsFromOriginAndDestination } from './dijkstraRoute';
@@ -728,11 +728,11 @@ app.post('/trips', async (c) => {
     }
   }
 
-  // #2129 — per-token in-flight 직렬화. `getTrip → rotateTripTokenForNewRoute → putTrip` 사이
-  // TOCTOU window에서 같은 token의 동시 POST가 interleave하면 유령 trip 2개(원본 token +
-  // rotated UUID)가 모두 KV에 생존하는 회귀(2026-08-04 실탑승 evidence)가 발생한다. 이 구간
-  // 전체를 원본 incoming token 기준으로 직렬화 — rotation이 token을 바꿔도 lock key는 요청
-  // 도착 시점의 원본 token으로 고정해 같은 device의 두 요청이 반드시 같은 큐에서 대기한다.
+  // #2129 — per-token in-flight 직렬화. `getTrip → resetTripStateForNewRoute → putTrip` 사이
+  // TOCTOU window에서 같은 token의 동시 POST가 interleave하면 유령 trip이 KV에 중복 생존하는
+  // 회귀(2026-08-04 실탑승 evidence)가 발생한다. ADR-025(#2194) 하에서도 신원은 불변이지만
+  // 이 구간을 여전히 원본 incoming token 기준으로 직렬화 — 같은 device의 두 요청이 반드시 같은
+  // 큐에서 대기해 read-reset-write 사이클이 겹치지 않게 한다.
   const registerLockToken = incoming.token;
   const { trip, isSameSession, staleIndexedToken } = await withTripRegisterLock(
     registerLockToken,
@@ -754,47 +754,32 @@ app.post('/trips', async (c) => {
           ? await getTrip(c.env.TRIPS, priorIndexedToken)
           : null);
 
-      // ADR-022 B4 (#2019 wire, #1986 rotation helper) — 새 route 감지 시 token rotation.
+      // ADR-025 (#2194) — route 변경 시 in-place reset. trip 신원(`incoming.token`, 트립 수명
+      // 동안 불변)은 유지한 채, route sig(`computeRouteSignature`)가 달라지면 구 route의 잔재
+      // pending push만 제거(helper 내부 `cleanupPendingPushesForToken`)하고 downstream이
+      // `existing=null`로 세션을 새로 취급(dedup/notification state 리셋)하도록 한다.
       //
-      // archFlag=on + existing 있음 + route sig 다름 → 새 UUID 발급 + `trip:<oldToken>` delete +
-      // `pending:*` 중 oldToken 소유 entry cleanup (helper 내부 로직).
-      //
-      // archFlag=off (default): helper 는 `{ token: incoming.token, rotated: false }` no-op 반환
+      // archFlag=off (default): helper 는 `{ existing: rawExisting, reset: false }` no-op 반환
       // → 기존 동작 100% 유지 (Phase 1-3 dormant).
       //
-      // rotated=true 케이스 처리:
-      //   - `existing = null` 로 강등해 downstream `isSameSession=false` + progress skip 경로 진입
-      //     (helper 가 이미 `trip:<oldToken>` 을 delete 했으므로 same-session merge 는 무의미).
-      //   - `incoming.token` 을 새 UUID(또는 #2175: 역인덱스로 재발견한 existing.token)로 갱신 →
-      //     후속 `putTrip` 이 그 키로 쓴다.
-      //   - progress/SSoT KV(oldToken 키) 는 TTL 로 자연 만료 — 후속 cron push 는 새 token trip
-      //     기준 waypoints/destination 을 참조하므로 사용자에게 이전 목적지 push 재발사 없음.
+      // ADR-022 B4의 token rotation(`rotateTripTokenForNewRoute`, 새 UUID 발급 + `trip:<oldToken>`
+      // delete)은 폐기됐다 — 신원 churn이 rate-limit/역인덱스/dedup 키 전체를 sync 대상으로 만들어
+      // 실패 표면을 늘렸다(2026-08-07 실탑승 tmsi34imn RCA, ADR-025). `trip:<incoming.token>`
+      // 레코드는 항상 같은 key로 `putTrip`이 그 자리에서 갱신한다.
       //
       // 오늘 evidence(2026-07-03): 사용자 중곡→성수 trip 시작 시 이전 trip(중곡→용마산) 잔재
-      // pending push 가 계속 발사돼 `08:37:25 bg fired station-passed 성수` 관측. rotation 이
+      // pending push 가 계속 발사돼 `08:37:25 bg fired station-passed 성수` 관측. route reset이
       // helper 의 `cleanupPendingPushesForToken` 을 실제 호출해 잔재 pending 제거.
-      const rotation = await rotateTripTokenForNewRoute(
-        c.env.TRIPS,
-        incoming,
-        rawExisting,
-        // #2174 F2 — old trip 로테이션 관측 기록(D1 + tripStatus sentinel, reason='rotated').
-        // env.DB 미바인딩 시 recordTripMetrics 내부에서 graceful no-op.
-        { db: c.env.DB, now: Date.now() },
-      );
-      if (rotation.rotated) {
+      const routeReset = await resetTripStateForNewRoute(c.env.TRIPS, incoming, rawExisting);
+      if (routeReset.reset) {
         console.log(
           JSON.stringify({
-            msg: 'trip-register: route rotation (#2019, ADR-022 B4)',
-            oldTokenPrefix: tokenPrefix(incoming.token),
-            newTokenPrefix: tokenPrefix(rotation.token),
+            msg: 'trip-register: route reset in-place (ADR-025, #2194)',
+            tokenPrefix: tokenPrefix(incoming.token),
           }),
         );
       }
-      // #2175 — merge 분기(같은 route, `rawExisting`을 역인덱스로 재발견)도 이제
-      // `rotation.token === existing.token`을 반환하므로 항상 채택한다. brand-new 등록/
-      // 직접 키 매치처럼 `existing`이 `incoming`과 동일 token이면 무변화.
-      incoming.token = rotation.token;
-      const existing = rotation.rotated ? null : rawExisting;
+      const existing = routeReset.existing;
       const isSameSession = existing !== null && evaluateSameSession(existing, incoming);
     // #916 follow-up B — auto-prompt dedup 마커 보존. isSameSession=true(같은 trip 재등록)인 경우만
     // window 안이면 보존한다. 사용자가 lock 클리어 후 같은 trip context로 재등록하는 케이스에서
@@ -2443,9 +2428,10 @@ export function validateTrip(input: unknown): Trip | null {
 
   return {
     token: tokenRaw,
-    // #2174 — 등록 시점의 실 device token을 rotation-불변 필드로 고정. `incoming.token`은
-    // 이후 `rotateTripTokenForNewRoute`가 rotated=true 시 UUID로 덮어쓰지만, 이 필드는
-    // baseTrip이 `...incoming` spread로 그대로 carry한다 (POST /trips 핸들러 참고).
+    // #2174 — 등록 시점의 실 device token을 고정. ADR-025(#2194) 하에서 `incoming.token`은
+    // 트립 수명 동안 불변(이 값과 항상 동일)이지만, 레이어 명확성(신원 vs push 주소)을 위해
+    // 필드 분리는 유지한다. baseTrip이 `...incoming` spread로 그대로 carry한다 (POST /trips
+    // 핸들러 참고).
     deviceToken: tokenRaw,
     route: obj.route as Trip['route'],
     destination: obj.destination as string,

--- a/backend/alarm-worker/src/trips.ts
+++ b/backend/alarm-worker/src/trips.ts
@@ -254,120 +254,76 @@ export function computeRouteSignature(trip: Trip): string {
 }
 
 /**
- * ADR-022 B4 — 새 route = 새 token 강제 결정.
+ * ADR-025 (#2194) — trip 신원 안정화: route 변경은 rotation(새 token 발급) 대신 in-place reset.
  *
- * `POST /trips`가 호출하는 진입점. incoming trip과 existing trip의 route/destination
- * 시그니처를 비교해 다르면 새 token 발급 + old token cleanup, 같으면 incoming token 유지.
+ * ADR-022 B4가 채택했던 `rotateTripTokenForNewRoute`(새 route = 새 token 강제)를 대체한다.
+ * trip 식별자(`trip.token`)는 트립 수명 동안 **불변**(deviceToken 유도 안정값) — route가 바뀌어도
+ * 신원은 그대로 유지된다. `POST /trips`가 호출하는 진입점.
  *
- * Flag OFF (default, KV `arch:simple-arrival-v1` !== 'on'): 기존 동작 유지 — incoming.token
- * 그대로 반환, KV cleanup 없음. Phase 1-3 인프라만 병존.
+ * Flag OFF (default, KV `arch:simple-arrival-v1` !== 'on'): 기존 동작 유지 — existing 그대로
+ * 반환(`reset: false`), KV 변경 없음. downstream(index.ts)이 기존 `evaluateSameSession` 판정으로
+ * 세션 유지/교체를 결정한다. Phase 1-3 인프라만 병존.
  *
- * Flag ON (Phase 2+, KV `arch:simple-arrival-v1` === 'on'): existing 있고 route sig 다르면
- *   1. `crypto.randomUUID()`로 새 token 생성
- *   2. `trip:<oldToken>` KV delete
- *   3. `pending:*` 중 `entry.token === oldToken` 인 entry 모두 delete
- *   4. 새 token 반환 (`rotated: true`)
+ * Flag ON: existing 있고 route sig(`computeRouteSignature`) 다르면
+ *   1. `cleanupPendingPushesForToken(incoming.token)` 호출 — rotation의 유일한 실질 가치를 그대로
+ *      이관(구 route의 잔재 pending push 제거. incoming.token은 신원 불변 하에 항상 existing.token과
+ *      동일하므로 어느 쪽을 써도 같은 값).
+ *   2. `existing: null` 반환(`reset: true`) — downstream이 새 세션으로 취급해 trip-scoped dedup/
+ *      notification state(SSoT mirror 포함)를 리셋한다. `trip:<incoming.token>` 레코드 자체는
+ *      index.ts가 incoming 기준으로 그 자리에서 갱신(같은 key `putTrip`) — 새 key 생성/구 key 삭제
+ *      없음.
  *
- * existing 없음 또는 같은 route: incoming.token 그대로 반환 (`rotated: false`).
+ * existing 없음 또는 같은 route: existing 그대로 반환(`reset: false`).
  *
- * Testability: `deps.simpleArchEnabled` / `deps.generateToken` DI로 flag 강제 + token 결정성
- * 확보. 기본은 real helper `getArchFlag(kv)` + `crypto.randomUUID`. 테스트가 옵션 명시.
+ * Testability: `deps.simpleArchEnabled` DI로 flag 강제. 기본은 real helper `getArchFlag(kv)`.
  * #2002 — 임시 상수 대신 real helper wire. KV 미바인딩 / 미설정 견해는 `getArchFlag` 가
  * default `'off'` 로 fallback → 기존 동작 유지.
  */
-export interface TokenRotationResult {
-  token: string;
-  rotated: boolean;
+export interface RouteResetResult {
+  /** null이면 downstream이 새 세션(dedup/notification state 전면 리셋)으로 취급한다. */
+  existing: Trip | null;
+  /** true면 route sig 변경으로 in-place reset(pending purge)이 수행됐다. */
+  reset: boolean;
 }
 
-export interface TokenRotationDeps {
+export interface RouteResetDeps {
   /** flag override — 미지정 시 `getArchFlag(kv) === 'on'` 조회. */
   simpleArchEnabled?: boolean;
-  /** 새 token 발급 함수 — 미지정 시 `crypto.randomUUID`. */
-  generateToken?: () => string;
-  /**
-   * #2173 — `TOKEN_ROTATION_DISABLED` guard override. 미지정 시 production 상수(`true`)를
-   * 그대로 사용한다. rotation 로직 자체(existing/route sig 비교, cleanup)는 삭제하지 않고
-   * 보존해야 하므로, 그 경로를 테스트가 커버할 수 있도록 기존 `simpleArchEnabled`/`generateToken`
-   * 과 동일한 DI 패턴으로 노출한다. 실제 호출부(`POST /trips`)는 이 값을 지정하지 않는다.
-   */
-  rotationDisabled?: boolean;
-  /** #2174 — F2 old-trip 관측 기록용 D1 binding. 미지정/undefined는 `recordTripMetrics` 내부 no-op. */
-  db?: D1Database;
-  /** #2174 — old-trip sentinel/D1 기록 시각(epoch ms). 미지정 시 `Date.now()`. */
-  now?: number;
 }
 
-/**
- * #2174 (P1-A) — token rotation 재활성 guard.
- *
- * #2173 P0 hotfix가 `deviceToken` 필드 분리 전까지 rotation을 전면 차단했다 — 로테이션이
- * `trip.token`(APNs 발사 주소 겸용)을 UUID로 교체하면 이후 모든 push가 400 BadDeviceToken으로
- * 즉사했기 때문(Epic #2172 물증). 이제 `Trip.deviceToken`이 로테이션과 무관하게 실 토큰을
- * 보존하므로(모든 push 발사 사이트가 `resolveTripDeviceToken(trip)` 사용) rotation을 안전하게
- * 재활성한다.
- *
- * `arch:simple-arrival-v1` 플래그가 여전히 최종 on/off 스위치 — 이 상수는 그 앞단의 이중 guard였고
- * 이제 flag 판정에 그대로 위임한다(false = guard 해제).
- */
-const TOKEN_ROTATION_DISABLED = false;
-
-export async function rotateTripTokenForNewRoute(
+export async function resetTripStateForNewRoute(
   kv: KVNamespace,
   incoming: Trip,
   existing: Trip | null,
-  deps?: TokenRotationDeps,
-): Promise<TokenRotationResult> {
-  // #2173 — rotation 전면 guard. flag 상태와 무관하게 항상 incoming token 유지.
-  if (deps?.rotationDisabled ?? TOKEN_ROTATION_DISABLED) {
-    return { token: incoming.token, rotated: false };
-  }
+  deps?: RouteResetDeps,
+): Promise<RouteResetResult> {
   // #2002 — real helper wire. deps.simpleArchEnabled DI 명시가 우선; 미지정 시 KV 조회.
   // `getArchFlag` 는 KV 미바인딩/미설정/오타 모두 default `'off'` 로 fallback (dormant).
-  // 명시적 괄호: `??` 가 `===` 보다 tighter 로 파싱되므로 DI boolean 값 우선 사용을 보장한다.
-  const flagEnabled =
-    deps?.simpleArchEnabled ?? ((await getArchFlag(kv)) === 'on');
-  // Flag OFF: 기존 동작 유지. incoming token 그대로.
+  const flagEnabled = deps?.simpleArchEnabled ?? ((await getArchFlag(kv)) === 'on');
+  // Flag OFF: 기존 동작 유지. existing 그대로.
   if (!flagEnabled) {
-    return { token: incoming.token, rotated: false };
+    return { existing, reset: false };
   }
-  // existing 없음 (신규 trip): incoming token 그대로 등록.
+  // existing 없음 (신규 trip): reset 대상 없음.
   if (existing === null) {
-    return { token: incoming.token, rotated: false };
+    return { existing: null, reset: false };
   }
-  // 같은 route (destination + waypoints 시그니처 일치): existing token으로 merge.
-  //
-  // #2175 — 과거엔 여기서 `incoming.token`을 그대로 반환했다. `existing`이 항상 직접 키 조회
-  // (`getTrip(incoming.token)`)로만 발견되던 시절엔 `existing.token === incoming.token`이 항상
-  // 성립해 무해했지만, `POST /trips` 핸들러가 이제 deviceToken 역인덱스로 `existing`을 재발견할
-  // 수 있어(직접 키 조회 miss 시 fallback) 이 경우 `existing.token`(예: 이전 로테이션 UUID)이
-  // `incoming.token`(원본 실 deviceToken)과 달라진다. `incoming.token`을 반환하면 실 deviceToken
-  // 키로 새 trip이 또 생성돼 이미 존재하는 UUID trip과 함께 유령 2개가 남는다 — `existing.token`을
-  // 반환해 항상 같은 KV 레코드로 merge되도록 고정한다.
+  // 같은 route (destination + waypoints 시그니처 일치): 변화 없음 — 정상 merge 경로로 위임.
   const existingSig = computeRouteSignature(existing);
   const incomingSig = computeRouteSignature(incoming);
   if (existingSig === incomingSig) {
-    return { token: existing.token, rotated: false };
+    return { existing, reset: false };
   }
-  // 다른 route: 새 token 발급 + old 정리.
-  const generateToken = deps?.generateToken ?? (() => crypto.randomUUID());
-  const newToken = generateToken();
-  const rotatedAt = deps?.now ?? Date.now();
-  // #2174 F2 — old trip 삭제가 관측 blind hole이었다(raw KV delete, D1/sentinel 미기록 →
-  // 사후 RCA 완전 비가시, 2026-08-06 진단 지연 직접 원인). cleanupTripWithLa(liveActivity.ts)를
-  // 재사용하지 않는다 — 그 helper는 사용자향 trip-ended alert push를 함께 발사하는데, mid-trip
-  // route 변경(F1: 환승 waypoint trim/목적지 변경 재-POST)마다 로테이션이 발동하므로 매번 종료
-  // alert가 뜨면 사용자 경험 회귀다. 여기서는 push-unrecoverable/user-delete와 구분되는 관측
-  // 전용 사유 'rotated'로 D1 기록 + tripStatus sentinel만 남긴다(alert push 없음).
-  await cleanupSupersededTrip(kv, existing, 'rotated', rotatedAt, deps?.db);
-  return { token: newToken, rotated: true };
+  // 다른 route: 신원(token)은 그대로 유지, 구 route의 잔재 pending push만 제거.
+  await cleanupPendingPushesForToken(kv, incoming.token);
+  return { existing: null, reset: true };
 }
 
 /**
  * #2175 — 다른(superseded) trip의 관측 기록 + KV 정리 단일 지점.
  *
- * `rotateTripTokenForNewRoute`의 route-변경 cleanup과, `POST /trips` 핸들러가 deviceToken 역인덱스로
- * 발견한 orphan trip(같은 deviceToken의 다른 active trip, `superseded-by-reregister`)이 공유한다.
+ * `POST /trips` 핸들러가 deviceToken 역인덱스로 발견한 orphan trip(같은 deviceToken의 다른 active
+ * trip, `superseded-by-reregister`) 정리가 사용한다.
  * D1 기록(`recordTripMetrics`) → tripStatus sentinel(`writeTripEndedStatus`, best-effort) →
  * `trip:<token>` delete → `pending:*` 잔재 cleanup 순서로 동작한다. alert push는 발사하지 않는다
  * (관측 전용 — `cleanupTripWithLa`와 달리 사용자향 UX 신호 없음, 두 호출자 모두 device 관점에서는


### PR DESCRIPTION
Closes #2194

## 내용

ADR-025 Decision 채택 — `rotateTripTokenForNewRoute` → `resetTripStateForNewRoute` 대체.

- trip 식별자(`trip.token`)는 트립 수명 동안 **불변**(deviceToken 유도 안정값). route가 바뀌어도
  신원은 유지된다. `crypto.randomUUID()` 발급 경로 제거.
- route sig(`computeRouteSignature`) 변경 시:
  1. `trip:<stableToken>` 레코드를 **in-place**로 갱신(waypoints/destination/routeSig 교체) — 새 키
     생성/구 키 삭제 없음.
  2. `cleanupPendingPushesForToken(stableToken)` 호출 — rotation의 유일한 실질 가치를 그대로 이관.
  3. `existing: null` 반환 → downstream이 trip-scoped dedup/notification state를 리셋.
- `arch:simple-arrival-v1` flag 게이팅 유지 (Phase 1-3 dormant 시 기존 동작 100% 보존).

## 범위 밖 (금지 사항 그대로 준수)

- `/trips` rate-limit 로직 미수정 → #2195.
- `device-trips:<deviceToken>` 역인덱스(#2175) / `trip.deviceToken`(#2174) / `rotated` sentinel
  미삭제 → #2196 (cleanup). 역인덱스는 ADR-025 Consequences에 따라 "APNs token refresh 복구
  용도로만 축소 존치" 문서화 + 관련 테스트를 그 시나리오로 재작성.

## #2193 red fixture flip

`tripIdentityReplay.test.ts`의 신원/rotation 관련 `test.fails` 2개를 `test`로 전환(green 확인):

- "route 변경 재-POST에서 rotated 발생 0 (신규 UUID trip 키 생성 없음)"
- "트립 1건이 동일 신원(deviceToken 키)으로 지속 등록된다 (route 변경 = update)"

429 관련 1개("rotation storm 재-POST가 create budget을 소진하지 않아 429 = 0")는 rate-limit
create/update 구분(#2195) 범위라 `test.fails`로 유지 — 이 PR은 rate-limit 로직을 건드리지 않는다.

## Wire-completion

1. **Orphan 없음** — 신규 export(`resetTripStateForNewRoute`, `RouteResetResult`,
   `RouteResetDeps`)는 `index.ts` POST /trips 핸들러 + `trips.test.ts`/`index.test.ts`가 호출.
   backend는 `lint:orphan` 스캔 범위 밖(frontend `src/` 전용)이라 프론트 `npm run lint:orphan`은
   무변화 확인(pass).
2. **V/X dashboard** — `trip_metrics`에서 route 변경이 새 row가 아닌 update로 관측(D1, 기존
   `trip_metrics` 스키마 그대로 재사용, 새 row 생성 경로 자체가 제거됨). 런타임 로그는
   `trip-register: route reset in-place (ADR-025, #2194)` — wrangler tail / Cloudflare Dashboard
   Logs에서 관측 가능(과거 `trip-register: route rotation` 로그를 대체).
3. **의존 PR** — #2192(ADR-025 epic), #2193(red fixture, 이미 머지됨, #2212). N/A 이외 없음.
4. **측정 plan** — #2193 replay fixture green 확인(본 PR에 포함, `npm test` 결과 참고). 실탑승
   tail에서 `end_reason=rotated` 발생 0건 + `trip_metrics`에 같은 corrId 트립의 `trip_token_hash`
   불변(더 이상 로테이션으로 여러 값으로 안 갈림)을 1주 관찰.
5. **Device verify: 필수** — 용마산7 → 건대2 → 성수 → 뚝섬 유형(2026-08-07 tmsi34imn evidence
   재현 시나리오)의 실탑승 트립으로, route 변경 시 재-POST가 새 trip이 아닌 update로 흡수되는지
   + `rotated` 로그가 더 이상 발생하지 않는지 확인 필요.

## 검증

- `cd backend/alarm-worker && npm test` — 76 files / 2887 tests pass. coverage ratchet(stmts
  97.24% / branch 96.22% / funcs 99.21% / lines 97.24%, floor 97/96/98/97) 통과.
- `cd backend/alarm-worker && npm run type-check` — clean.
- 루트 `npm run lint:orphan` — "No orphan exports detected." (frontend 변경 없음, 무변화 확인).
