### PR TITLE
fix(client): 429 Retry-After 존중 + route 변경 재-POST 디바운스 (#2197)

### DIFF
--- a/src/features/alarm/api/__tests__/alarmBackend.test.ts
+++ b/src/features/alarm/api/__tests__/alarmBackend.test.ts
@@ -108,6 +108,71 @@ describe('alarmBackend', () => {
       expect(result).toEqual({ ok: false, status: 500 });
     });
 
+    // #2197 (ADR-025 client 절반) — 429(rate_limited) 응답의 retryAfterSeconds echo.
+    // backend index.ts:584가 `{ error: 'rate_limited', retryAfterSeconds }`를 429 body에 담아
+    // 내려준다 — device가 자체 backoff 대신 이 값을 존중해야 storm을 스스로 키우지 않는다.
+    describe('429 rate_limited retryAfterSeconds echo (#2197)', () => {
+      it('429 응답 body의 retryAfterSeconds를 결과에 echo', async () => {
+        process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+        (global.fetch as jest.Mock).mockResolvedValue({
+          ok: false,
+          status: 429,
+          json: async () => ({ error: 'rate_limited', retryAfterSeconds: 42 }),
+        } as unknown as Response);
+        const result = await registerActiveTrip(SAMPLE_PAYLOAD);
+        expect(result).toEqual({ ok: false, status: 429, retryAfterSeconds: 42 });
+      });
+
+      it('429 응답 body parse 실패 시 retryAfterSeconds 없이 graceful ok=false', async () => {
+        process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+        (global.fetch as jest.Mock).mockResolvedValue({
+          ok: false,
+          status: 429,
+          json: async () => {
+            throw new Error('parse failed');
+          },
+        } as unknown as Response);
+        const result = await registerActiveTrip(SAMPLE_PAYLOAD);
+        expect(result).toEqual({ ok: false, status: 429 });
+        expect(result.retryAfterSeconds).toBeUndefined();
+      });
+
+      it('429 응답 body에 retryAfterSeconds 필드 부재 시 graceful ok=false', async () => {
+        process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+        (global.fetch as jest.Mock).mockResolvedValue({
+          ok: false,
+          status: 429,
+          json: async () => ({ error: 'rate_limited' }),
+        } as unknown as Response);
+        const result = await registerActiveTrip(SAMPLE_PAYLOAD);
+        expect(result).toEqual({ ok: false, status: 429 });
+      });
+
+      it('429 응답 body의 retryAfterSeconds가 양수 아니면(0/음수/비-숫자) graceful 무시', async () => {
+        process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+        (global.fetch as jest.Mock).mockResolvedValue({
+          ok: false,
+          status: 429,
+          json: async () => ({ error: 'rate_limited', retryAfterSeconds: 'bogus' }),
+        } as unknown as Response);
+        const result = await registerActiveTrip(SAMPLE_PAYLOAD);
+        expect(result).toEqual({ ok: false, status: 429 });
+      });
+
+      it('429가 아닌 다른 실패 status는 retryAfterSeconds 파싱 자체를 skip', async () => {
+        process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
+        const jsonSpy = jest.fn(async () => ({ retryAfterSeconds: 99 }));
+        (global.fetch as jest.Mock).mockResolvedValue({
+          ok: false,
+          status: 503,
+          json: jsonSpy,
+        } as unknown as Response);
+        const result = await registerActiveTrip(SAMPLE_PAYLOAD);
+        expect(result).toEqual({ ok: false, status: 503 });
+        expect(jsonSpy).not.toHaveBeenCalled();
+      });
+    });
+
     it('fetch throw 시 ok=false 반환(throw 안 함)', async () => {
       process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
       (global.fetch as jest.Mock).mockRejectedValue(new Error('network'));

--- a/src/features/alarm/api/alarmBackend.ts
+++ b/src/features/alarm/api/alarmBackend.ts
@@ -168,6 +168,12 @@ export interface AlarmBackendResult {
    * undefined (graceful — device 는 다음 register 시 build env fallback 사용).
    */
   confirmedEnv?: ApnsEnv;
+  /**
+   * #2197 (ADR-025 client 절반) — status 429(rate_limited) 응답 body의 `retryAfterSeconds`
+   * echo (backend `index.ts:584`). device 는 이 값이 지날 때까지 자체 재시도/heal POST를
+   * 억제해 storm을 스스로 키우지 않는다. 구 backend/parse 실패 시 undefined (graceful).
+   */
+  retryAfterSeconds?: number;
 }
 
 /** 기본 트립 TTL — 2시간. 백엔드 KV expiration과 정렬. */
@@ -336,7 +342,15 @@ async function performRegisterFetch(
     });
     if (!res.ok) {
       log.warn(`register failed status=${res.status}`);
-      return { ok: false, status: res.status };
+      // #2197 — 429(rate_limited)는 body에 `retryAfterSeconds`를 담아 내려온다(index.ts:584).
+      // 다른 status는 body 형태가 다르므로 429일 때만 파싱 — parse 실패는 graceful undefined.
+      const retryAfterSeconds =
+        res.status === 429 ? await extractRetryAfterSeconds(res) : undefined;
+      return {
+        ok: false,
+        status: res.status,
+        ...(retryAfterSeconds != null ? { retryAfterSeconds } : {}),
+      };
     }
     lastRegisteredHash = hash;
     // #1897 (RC-5) — backend 가 echo한 `confirmedEnv` 추출 + stamp.
@@ -362,6 +376,23 @@ async function extractConfirmedEnv(res: Response): Promise<ApnsEnv | undefined> 
     const body = (await res.json()) as { confirmedEnv?: unknown };
     if (body.confirmedEnv === 'sandbox' || body.confirmedEnv === 'production') {
       return body.confirmedEnv;
+    }
+  } catch {
+    // graceful — 구 backend 응답 또는 parse 실패
+  }
+  return undefined;
+}
+
+/**
+ * #2197 (ADR-025 client 절반) — 429 register 응답에서 `retryAfterSeconds` 추출.
+ * JSON parse 실패 / 필드 부재 / 값 오류(양수 아님)는 모두 graceful undefined —
+ * 호출자는 기존 자체 backoff schedule([15/30/60s])로 fallback한다.
+ */
+async function extractRetryAfterSeconds(res: Response): Promise<number | undefined> {
+  try {
+    const body = (await res.json()) as { retryAfterSeconds?: unknown };
+    if (typeof body.retryAfterSeconds === 'number' && body.retryAfterSeconds > 0) {
+      return body.retryAfterSeconds;
     }
   } catch {
     // graceful — 구 backend 응답 또는 parse 실패

--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -62,6 +62,7 @@ import {
   REGISTER_RETRY_BACKOFF_MS,
   REGISTER_RETRY_HEAL_BUSY_MAX_RESCHEDULES,
   REGISTER_RETRY_HEAL_BUSY_RECHECK_MS,
+  ROUTE_CHANGE_DEBOUNCE_MS,
 } from '../../../../shared/constants/boardingLock';
 import { makeDirectRoute, makeMultiTransferRoute } from '../../../../testUtils/routeFixtures';
 import { canonicalStationName } from '../../../../testUtils/canonicalStationName';
@@ -574,7 +575,8 @@ describe('useApnsTripRegistration', () => {
 
     now = 1_700_000_500_000;
     rerender({ route: makeDirectRoute(6, '2') as Route });
-    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+    // #2197 — 이미 등록된 trip의 route 변경은 ROUTE_CHANGE_DEBOUNCE_MS만큼 지연 발사된다.
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2), { timeout: 3000 });
     expect(mockRegister.mock.calls[1][0].createdAt).toBe(1_700_000_500_000);
     expect(mockRegister.mock.calls[1][0].createdAt).not.toBe(first);
     (Date.now as jest.Mock).mockRestore();
@@ -594,7 +596,8 @@ describe('useApnsTripRegistration', () => {
 
     now = 1_700_000_777_777;
     rerender({ d: altStation });
-    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+    // #2197 — 이미 등록된 trip의 destination 변경도 ROUTE_CHANGE_DEBOUNCE_MS만큼 지연 발사된다.
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2), { timeout: 3000 });
     expect(mockRegister.mock.calls[1][0].createdAt).toBe(1_700_000_777_777);
     expect(mockRegister.mock.calls[1][0].createdAt).not.toBe(first);
     (Date.now as jest.Mock).mockRestore();
@@ -639,7 +642,8 @@ describe('useApnsTripRegistration', () => {
     );
     await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
     rerender({ route: makeDirectRoute(6, '2') as Route });
-    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+    // #2197 — 이미 등록된 trip의 route 변경은 ROUTE_CHANGE_DEBOUNCE_MS만큼 지연 발사된다.
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2), { timeout: 3000 });
   });
 
   describe('#622 boardingLock 송신', () => {
@@ -996,6 +1000,188 @@ describe('useApnsTripRegistration', () => {
     });
   });
 
+  // #2197 (ADR-025 client 절반) — "이미 등록된 trip"의 route/destination 변경 재-POST를
+  // coalesce. 신규 목적지 최초 등록(이전 성공 register 없음)은 즉시성 유지 — debounce 미적용.
+  describe('#2197 route/destination 변경 debounce (이미 등록된 trip)', () => {
+    const altStation: Station = { ...station, id: '2-023', name: '역삼' };
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    const flushMicrotasks = async () => {
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    };
+
+    it('신규 목적지 최초 등록은 debounce 없이 즉시 발사', async () => {
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+        }),
+      );
+      await flushMicrotasks();
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+    });
+
+    it('이미 등록된 trip의 route 변경은 debounce window 안에 POST 발사 안 함', async () => {
+      const { rerender } = renderHook(
+        ({ route }: { route: Route }) =>
+          useApnsTripRegistration({ route, destination: station, nextStationEtaSeconds: 120 }),
+        { initialProps: { route: makeDirectRoute(5, '2') as Route } },
+      );
+      await flushMicrotasks();
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      rerender({ route: makeDirectRoute(6, '2') as Route });
+      await flushMicrotasks();
+      // debounce window 안 — 아직 발사 안 됨.
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        jest.advanceTimersByTime(ROUTE_CHANGE_DEBOUNCE_MS - 100);
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+    });
+
+    it('이미 등록된 trip의 route 변경은 debounce window 경과 후 발사', async () => {
+      const { rerender } = renderHook(
+        ({ route }: { route: Route }) =>
+          useApnsTripRegistration({ route, destination: station, nextStationEtaSeconds: 120 }),
+        { initialProps: { route: makeDirectRoute(5, '2') as Route } },
+      );
+      await flushMicrotasks();
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      rerender({ route: makeDirectRoute(6, '2') as Route });
+      act(() => {
+        jest.advanceTimersByTime(ROUTE_CHANGE_DEBOUNCE_MS + 100);
+      });
+      await flushMicrotasks();
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+
+    it('debounce window 안에 route가 다시 바뀌면 coalesce — 최종 route만 1회 발사', async () => {
+      const { rerender } = renderHook(
+        ({ route }: { route: Route }) =>
+          useApnsTripRegistration({ route, destination: station, nextStationEtaSeconds: 120 }),
+        { initialProps: { route: makeDirectRoute(5, '2') as Route } },
+      );
+      await flushMicrotasks();
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      rerender({ route: makeDirectRoute(6, '2') as Route });
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+      // 아직 window 안 — 다시 route 변경 (연쇄 갱신 흡수 시나리오)
+      rerender({ route: makeDirectRoute(7, '2') as Route });
+      act(() => {
+        jest.advanceTimersByTime(ROUTE_CHANGE_DEBOUNCE_MS + 200);
+      });
+      await flushMicrotasks();
+
+      // 중간 route(6)는 POST 안 나가고 최종 route(7)만 발사 — 총 2회(최초 + coalesced 1회).
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+
+    it('이미 등록된 trip의 destination 변경도 debounce', async () => {
+      const { rerender } = renderHook(
+        ({ d }: { d: Station }) =>
+          useApnsTripRegistration({ route: directRoute, destination: d, nextStationEtaSeconds: 120 }),
+        { initialProps: { d: station } },
+      );
+      await flushMicrotasks();
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      rerender({ d: altStation });
+      await flushMicrotasks();
+      expect(mockRegister).toHaveBeenCalledTimes(1); // 아직 debounce window 안
+
+      act(() => {
+        jest.advanceTimersByTime(ROUTE_CHANGE_DEBOUNCE_MS + 100);
+      });
+      await flushMicrotasks();
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+
+    it('첫 register가 실패({ok:false})했으면 아직 "등록된 trip" 아님 — 다음 destination 변경은 즉시 발사', async () => {
+      mockRegister.mockResolvedValueOnce({ ok: false, status: 500 });
+      mockRegister.mockResolvedValue({ ok: true });
+      const { rerender } = renderHook(
+        ({ d }: { d: Station }) =>
+          useApnsTripRegistration({ route: directRoute, destination: d, nextStationEtaSeconds: 120 }),
+        { initialProps: { d: station } },
+      );
+      await flushMicrotasks();
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      rerender({ d: altStation });
+      await flushMicrotasks();
+      // 첫 register가 실패했으므로 "이미 등록된 trip"이 아니다 — 즉시 발사.
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+
+    it('trip 종료 후 새 trip 시작은 debounce 미적용 (성공 기준 추적도 reset)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+        if (key === APNS_TOKEN_KEY) return 'token-abc';
+        if (key === ACTIVE_TRIP_KEY) return 'token-abc';
+        return null;
+      });
+      const { rerender } = renderHook(
+        ({ route, destination }: { route: Route | null; destination: Station | null }) =>
+          useApnsTripRegistration({ route, destination, nextStationEtaSeconds: 120 }),
+        { initialProps: { route: directRoute as Route | null, destination: station as Station | null } },
+      );
+      await flushMicrotasks();
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // trip 종료
+      rerender({ route: null, destination: null });
+      await flushMicrotasks();
+
+      // 새 trip 시작 — 성공 기준 추적도 reset되어 즉시 발사.
+      rerender({ route: makeDirectRoute(7, '2'), destination: altStation });
+      await flushMicrotasks();
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+
+    it('boardingLock만 변경(route/destination 동일)은 debounce 미적용 — 즉시 발사', async () => {
+      const lockA = {
+        destinationId: station.id,
+        trainCode: '7246',
+        boardingStationId: station.id,
+        boardingLine: '2' as const,
+        boardedAt: 1_700_000_000_000,
+        expectedDurationMs: 600_000,
+      };
+      const { rerender } = renderHook(
+        ({ lock }: { lock: typeof lockA | null }) =>
+          useApnsTripRegistration({
+            route: directRoute,
+            destination: station,
+            nextStationEtaSeconds: 120,
+            currentStation: station,
+            boardingLock: lock,
+          }),
+        { initialProps: { lock: null as typeof lockA | null } },
+      );
+      await flushMicrotasks();
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      rerender({ lock: lockA });
+      await flushMicrotasks();
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('#1960 (2026-08-04 RCA 보강) — register 실패/token 미가용 재시도', () => {
     const lock = {
       destinationId: station.id,
@@ -1299,6 +1485,81 @@ describe('useApnsTripRegistration', () => {
         await Promise.resolve();
       });
       expect(mockRegister).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // #2197 (ADR-025 client 절반) — 429(rate_limited) 응답의 retryAfterSeconds를 존중해 device가
+  // 자체 재시도/heal POST로 storm을 스스로 키우지 않게 억제.
+  describe('#2197 429 retryAfterSeconds 존중 — register/재시도 억제', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('429 응답 후 retryAfterSeconds 이내 재시도는 네트워크 호출 없이 skip', async () => {
+      mockRegister.mockResolvedValueOnce({ ok: false, status: 429, retryAfterSeconds: 20 });
+      mockRegister.mockResolvedValue({ ok: true });
+
+      renderHook(() =>
+        useApnsTripRegistration({
+          route: directRoute,
+          destination: station,
+          nextStationEtaSeconds: 120,
+        }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // 첫 backoff(15s)는 REGISTER_RETRY_BACKOFF_MS[0]지만, 서버가 20s를 지시했으므로
+      // 15s 시점엔 아직 재시도 네트워크 호출이 없어야 한다.
+      await act(async () => {
+        jest.advanceTimersByTime(REGISTER_RETRY_BACKOFF_MS[0] + 500);
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // 20s 경과 후에는 재시도가 실제로 발화.
+      await act(async () => {
+        jest.advanceTimersByTime(20_000);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(2);
+    });
+
+    it('429 억제 구간 중 route 변경이 와도 register 네트워크 호출 없이 skip(재시도 예약)', async () => {
+      mockRegister.mockResolvedValueOnce({ ok: false, status: 429, retryAfterSeconds: 30 });
+      mockRegister.mockResolvedValue({ ok: true });
+
+      const { rerender } = renderHook(
+        ({ d }: { d: Station }) =>
+          useApnsTripRegistration({ route: directRoute, destination: d, nextStationEtaSeconds: 120 }),
+        { initialProps: { d: station } },
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      // 첫 register가 429로 실패했으므로 "이미 등록된 trip" 아님 — route 변경은 즉시 시도되지만
+      // registerFromLatestInputs 내부에서 억제 구간이라 실제 네트워크(mockRegister)는 호출 안 됨.
+      const otherDestination: Station = { ...station, id: '2-023', name: '역삼' };
+      rerender({ d: otherDestination });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        jest.advanceTimersByTime(30_000);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockRegister).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -3062,7 +3323,8 @@ describe('useApnsTripRegistration', () => {
 
       // route 내용 변경 — routeSig 전환
       rerender({ route: makeDirectRoute(6, '2'), destination: station });
-      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      // #2197 — 이미 등록된 trip의 route 변경은 ROUTE_CHANGE_DEBOUNCE_MS만큼 지연 발사된다.
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2), { timeout: 3000 });
       expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1);
     });
 
@@ -3089,7 +3351,8 @@ describe('useApnsTripRegistration', () => {
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
 
       rerender({ route: makeDirectRoute(6, '2'), destination: station });
-      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      // #2197 — 이미 등록된 trip의 route 변경은 ROUTE_CHANGE_DEBOUNCE_MS만큼 지연 발사된다.
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2), { timeout: 3000 });
       expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1);
       // register는 그대로 발사됨
       expect(mockRegister.mock.calls[1][0]).toMatchObject({ destination: station.id });
@@ -3126,7 +3389,8 @@ describe('useApnsTripRegistration', () => {
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
 
       rerender({ route: makeDirectRoute(6, '2'), destination: altStation });
-      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      // #2197 — 이미 등록된 trip의 route/destination 변경은 ROUTE_CHANGE_DEBOUNCE_MS만큼 지연 발사된다.
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2), { timeout: 3000 });
       expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1);
     });
 
@@ -3147,7 +3411,8 @@ describe('useApnsTripRegistration', () => {
       await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
 
       rerender({ route: makeDirectRoute(6, '2'), destination: station });
-      await waitFor(() => expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1));
+      // #2197 — 이미 등록된 trip의 route 변경은 ROUTE_CHANGE_DEBOUNCE_MS만큼 지연 발사된다.
+      await waitFor(() => expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1), { timeout: 3000 });
       // unmount 직후 cancel resolve — cancelled 가드로 후속 register 진행 안 함
       unmount();
       mockRegister.mockClear();
@@ -3217,7 +3482,8 @@ describe('useApnsTripRegistration', () => {
       // routeSig 동일 (같은 line·stops) + destination만 다른 역으로 변경.
       // 기존 #1264 게이트는 routeSig만 검사라 trigger 안 됐지만 #1704 (d)는 destination 변경도 잡는다.
       rerender({ route: makeDirectRoute(5, '2'), destination: altStation });
-      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      // #2197 — 이미 등록된 trip의 destination 변경은 ROUTE_CHANGE_DEBOUNCE_MS만큼 지연 발사된다.
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2), { timeout: 3000 });
       expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1);
     });
 
@@ -3307,7 +3573,8 @@ describe('useApnsTripRegistration', () => {
         destination: altStation,
         boardingLock: lockB,
       });
-      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2));
+      // #2197 — 이미 등록된 trip의 route/destination 변경은 ROUTE_CHANGE_DEBOUNCE_MS만큼 지연 발사된다.
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(2), { timeout: 3000 });
       // cancel은 한 effect cycle 안에 1회만.
       expect(mockCancelTripBoundAlarms).toHaveBeenCalledTimes(1);
     });

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -42,6 +42,7 @@ import {
   REGISTER_RETRY_BACKOFF_MS,
   REGISTER_RETRY_HEAL_BUSY_MAX_RESCHEDULES,
   REGISTER_RETRY_HEAL_BUSY_RECHECK_MS,
+  ROUTE_CHANGE_DEBOUNCE_MS,
 } from '../../../shared/constants/boardingLock';
 import { createLogger } from '../../../shared/utils/logger';
 import { getRegisteringApnsEnv, warmupConfirmedApnsEnv } from '../../../shared/utils/apnsEnv';
@@ -371,6 +372,16 @@ export function useApnsTripRegistration({
   const lastDestinationIdRef = useRef<string | null>(null);
   const lastBoardingLockSigRef = useRef<string | null>(null);
 
+  // #2197 (ADR-025 client 절반) — 직전 register가 **성공**(ok:true)했을 때만 갱신되는
+  // routeSig/destination.id. lastRouteSigRef/lastDestinationIdRef(위)는 성공 여부와 무관하게
+  // "마지막으로 시도한" 값을 기록해 #1264/#1704 cancel 판정에 쓰인다 — 그 refs를 그대로 재사용하면
+  // "trip 등록이 한 번도 성공하지 못한 채 route/destination만 바뀌는" 케이스(예: register-retry
+  // 대기 중 사용자가 다른 destination으로 바로 전환)까지 "이미 등록된 trip의 변경"으로 오판해
+  // 불필요하게 debounce가 걸린다 — 아직 성공 등록이 없으면 즉시성을 유지해야 한다(신규 등록과
+  // 동일 취급). 성공 기준으로 별도 추적해야 "이미 등록된 trip"의 정의가 정확해진다.
+  const lastSuccessfulRouteSigRef = useRef<string | null>(null);
+  const lastSuccessfulDestinationIdRef = useRef<string | null>(null);
+
   // #2130 (B-1) — 직전 register가 promptContext 없이 나갔는지 여부. Tier 1 heal 트리거의
   // SSoT — registerFromLatestInputs가 매 호출마다 callRegister의 실제 결과로 갱신한다.
   const lastRegisterMissingContextRef = useRef(false);
@@ -414,6 +425,11 @@ export function useApnsTripRegistration({
     sessionKey: null,
     count: 0,
   });
+  // #2197 (ADR-025 client 절반) — 서버가 429(rate_limited)로 내려준 `retryAfterSeconds`까지
+  // register/heal POST를 억제할 epoch ms. 0이면 억제 없음. `registerFromLatestInputs`가
+  // 유일한 register 진입점이므로 여기 한 곳에서만 체크/갱신하면 main effect / token-refresh /
+  // Tier 1 / Tier 2 / register-retry 모든 경로가 일관되게 서버 힌트를 존중한다.
+  const registerSuppressedUntilRef = useRef<number>(0);
 
   /**
    * #2167 — context-heal(Tier 1/2)과 register-retry(#1960)는 같은 원인("register가 backend에
@@ -466,6 +482,22 @@ export function useApnsTripRegistration({
     } = latestInputsRef.current;
     if (!r || !d) return null;
     const sessionKey = `${token}:${routeSignature(r)}:${d.id}`;
+
+    // #2197 — 서버가 지시한 억제 구간이면 네트워크 호출 자체를 내지 않는다. 모든 register
+    // 경로(main effect / token-refresh / Tier 1 / Tier 2 / register-retry)가 이 함수를 통해서만
+    // 실제 POST를 발사하므로, 여기 한 곳의 skip이 storm 자기유발 억제를 전체 경로에 적용한다.
+    const suppressedRemainingMs = registerSuppressedUntilRef.current - Date.now();
+    if (suppressedRemainingMs > 0) {
+      logger.info(`register: 429 retryAfter 억제 중 — ${Math.ceil(suppressedRemainingMs / 1000)}s 남음`);
+      return {
+        ok: false,
+        status: 429,
+        retryAfterSeconds: Math.ceil(suppressedRemainingMs / 1000),
+        hadPromptContext: false,
+        promptContext: null,
+      };
+    }
+
     const result = await callRegister({
       token,
       route: r,
@@ -481,6 +513,12 @@ export function useApnsTripRegistration({
       promptContextOverride: options?.promptContextOverride,
       gpsFix: gf,
     });
+    // #2197 — 429(rate_limited) 응답이면 서버가 지시한 시간까지 이후 register/heal 호출을
+    // 억제한다. backend가 매 429 응답에 최신 window를 다시 계산해 내려주므로 항상 최신값으로
+    // 덮어쓴다(연장/단축 모두 반영).
+    if (result.status === 429 && typeof result.retryAfterSeconds === 'number') {
+      registerSuppressedUntilRef.current = Date.now() + result.retryAfterSeconds * 1000;
+    }
     // #767 — 두 경로 모두 동일 기준으로 lock sig를 추적해야 다음 cycle의 release 판정 정확도 유지.
     lastSentLockSigRef.current = lockSig(bl);
     // #2130 (B-1) / #2164 — 이번 register가 실제로 context를 backend에 성공적으로 전달했는지
@@ -614,7 +652,12 @@ export function useApnsTripRegistration({
     if (registerRetryRef.current.timer !== null) {
       clearTimeout(registerRetryRef.current.timer);
     }
-    const delay = REGISTER_RETRY_BACKOFF_MS[attempt];
+    // #2197 — 서버 429 억제 구간이 기존 backoff보다 더 길게 남아 있으면 그 구간을 우선한다.
+    // (억제가 없거나 이미 만료된 정상 케이스는 음수/0이 되어 기존 backoff가 그대로 쓰인다.)
+    const delay = Math.max(
+      REGISTER_RETRY_BACKOFF_MS[attempt],
+      registerSuppressedUntilRef.current - Date.now(),
+    );
     registerRetryRef.current.attempt = attempt + 1;
     registerRetryRef.current.timer = setTimeout(() => {
       registerRetryRef.current.timer = null;
@@ -805,6 +848,10 @@ export function useApnsTripRegistration({
         lastRouteSigRef.current = null;
         lastDestinationIdRef.current = null;
         lastBoardingLockSigRef.current = null;
+        // #2197 — 성공 기준 추적도 함께 reset — 다음 trip의 첫 register는 "신규 목적지 최초
+        // 등록"으로 취급되어 route-change debounce가 적용되지 않는다.
+        lastSuccessfulRouteSigRef.current = null;
+        lastSuccessfulDestinationIdRef.current = null;
         // #1284: trip 종료 시 prompt context 캐시 reset — 다음 trip이 이전 trip의
         // 출발역 컨텍스트를 stamp하는 오염 방지.
         lastPromptContextRef.current = null;
@@ -903,6 +950,10 @@ export function useApnsTripRegistration({
         await AsyncStorage.setItem(ACTIVE_TRIP_KEY, token);
         // #1960 — 성공(dedup skip 포함, ok:true)했으면 이 세션에 대한 대기 재시도가 있다면 정리.
         clearRegisterRetry();
+        // #2197 — 성공 기준 추적 갱신. 다음 cycle의 route-change debounce 판정이 "이미 등록된
+        // trip"인지 정확히 알 수 있도록 실제 성공한 routeSig/destination.id만 기록한다.
+        lastSuccessfulRouteSigRef.current = routeSig;
+        lastSuccessfulDestinationIdRef.current = destination.id;
       } else {
         // #1960 — register 실패({ok:false}) — deps 불변이면 재기회가 없으므로 활성 trip 한정 재시도.
         scheduleRegisterRetry(`${routeSig}:${destination.id}`);
@@ -929,10 +980,31 @@ export function useApnsTripRegistration({
     // 가드가 AsyncStorage.getItem 직후 추가 작업을 차단한다 (이중 방어).
     const isLockReleaseTransition =
       lastSentLockSigRef.current !== null && boardingLockSig === null && route !== null && destination !== null;
-    if (isLockReleaseTransition) {
+
+    // #2197 (ADR-025 client 절반) — "이미 등록된 trip"의 route/destination 변경만 debounce.
+    // lastSuccessfulRouteSigRef/lastSuccessfulDestinationIdRef는 직전 **성공** register에서만
+    // 갱신된다(lastRouteSigRef 등은 성공 여부와 무관하게 "마지막 시도"를 기록해 #1264/#1704 cancel
+    // 판정에 쓰이므로 재사용하지 않는다) — 아직 한 번도 성공하지 못한 trip(예: register-retry 대기
+    // 중 destination 전환)은 "이미 등록된 trip"이 아니므로 즉시성을 유지한다. 둘 다 null이면 이번이
+    // 신규 목적지 최초 등록 — debounce하지 않는다. lock-release 전환과는 상호 배타적으로 둔다
+    // (lock-release가 우선 처리되도록 위에서 이미 판정 완료).
+    const hasSuccessfullyRegisteredTrip =
+      lastSuccessfulRouteSigRef.current !== null || lastSuccessfulDestinationIdRef.current !== null;
+    const isRouteChangeForExistingTrip =
+      !isLockReleaseTransition &&
+      hasSuccessfullyRegisteredTrip &&
+      route !== null &&
+      destination !== null &&
+      (lastSuccessfulRouteSigRef.current !== routeSig ||
+        lastSuccessfulDestinationIdRef.current !== destination.id);
+
+    if (isLockReleaseTransition || isRouteChangeForExistingTrip) {
+      const debounceMs = isLockReleaseTransition
+        ? BOARDING_LOCK_RELEASE_DEBOUNCE_MS
+        : ROUTE_CHANGE_DEBOUNCE_MS;
       debounceTimer = setTimeout(() => {
         void run();
-      }, BOARDING_LOCK_RELEASE_DEBOUNCE_MS);
+      }, debounceMs);
     } else {
       void run();
     }

--- a/src/shared/constants/boardingLock.ts
+++ b/src/shared/constants/boardingLock.ts
@@ -184,3 +184,21 @@ export const CONTEXT_HEAL_MAX_ATTEMPTS_PER_SESSION = 3;
  */
 export const REGISTER_RETRY_HEAL_BUSY_RECHECK_MS = 2_000;
 export const REGISTER_RETRY_HEAL_BUSY_MAX_RESCHEDULES = 5;
+
+/**
+ * #2197 (ADR-025 client 절반) — 이미 등록된 trip의 route/destination 변경 재-POST를
+ * coalesce하는 debounce(ms).
+ *
+ * 배경: `useApnsTripRegistration`은 route/destination 변경을 즉시 발사한다(#767 lock-release
+ * debounce와 달리 미적용). GPS/fusion 재계산이 짧은 시간 안에 route를 연속 갱신하면(환승 hop
+ * 진입 직후 store 업데이트 race 등) 같은 세션에 대해 여러 POST /trips가 연쇄 발사되어 자체
+ * rate-limit(10/10min) 소진을 device가 스스로 가속한다.
+ *
+ * `BOARDING_LOCK_RELEASE_DEBOUNCE_MS`(1500ms)와 동일한 값을 사용 — 같은 성격의 "짧은 창의
+ * 연쇄 재등록을 흡수" 목적이며 근거(GPS 1 tick 이상 흡수)도 동일하다.
+ *
+ * **최초 등록(이전 trip 없음)에는 적용하지 않는다** — 신규 목적지 설정은 즉시성이 우선.
+ * `lastRouteSigRef`/`lastDestinationIdRef`가 모두 null(이전 register 없음)인 경우가 이에
+ * 해당하며, 이 상수는 오직 "이미 등록된 trip"의 이후 변경에만 쓰인다.
+ */
+export const ROUTE_CHANGE_DEBOUNCE_MS = 1500;


### PR DESCRIPTION
Closes #2197

## 내용
Part of #2192 (ADR-025). Device가 `/trips` rate-limit storm을 스스로 키우지 않게 client 측 억제 2건:

1. **429 Retry-After 존중** — 서버가 429 응답 body에 내려주는 `retryAfterSeconds`(backend `index.ts:584`)를 `alarmBackend.ts`가 `AlarmBackendResult.retryAfterSeconds`로 surface. `useApnsTripRegistration.ts`의 유일한 register 진입점(`registerFromLatestInputs`)에서 이 값을 억제 window로 stamp — main effect / token-refresh listener / Tier 1·Tier 2 context-heal / register-retry(#1960) 모든 경로가 이 한 곳을 통해서만 실제 네트워크를 발사하므로, 억제 구간 안에는 어떤 경로도 POST를 내지 않는다. `scheduleRegisterRetry`의 backoff도 억제 구간이 기존 backoff보다 길면 그 값을 우선한다.
2. **route/destination 변경 재-POST 디바운스** — 이미 등록된 trip(직전 register가 **성공**한 세션)의 route/destination 변경만 `ROUTE_CHANGE_DEBOUNCE_MS`(1500ms, `#767` lock-release debounce와 동일 값)로 coalesce. **신규 목적지 최초 등록(이전 성공 register 없음)은 즉시성 유지** — "이미 등록된 trip"의 판정은 새로 추가한 `lastSuccessfulRouteSigRef`/`lastSuccessfulDestinationIdRef`(성공 기준)로, 기존 `lastRouteSigRef` 등(성공 여부 무관 "마지막 시도" 기준, #1264/#1704 cancel 판정용)과는 별도 추적이다 — register-retry 대기 중인 미확정 trip까지 debounce 대상으로 오판하지 않기 위함.

## 변경 파일
- `src/features/alarm/api/alarmBackend.ts` — `retryAfterSeconds` 추출/echo
- `src/features/alarm/hooks/useApnsTripRegistration.ts` — 429 억제 + route-change debounce
- `src/shared/constants/boardingLock.ts` — `ROUTE_CHANGE_DEBOUNCE_MS` 상수
- 테스트 2개 파일 — 신규 10건 추가(429 억제 2건, debounce 8건) + 기존 route/destination 즉시 발사 가정 테스트 9건을 debounce 반영해 업데이트(fake timer advance 또는 waitFor timeout 확장)

## 금지 준수
- backend 코드 무변경 (client-only)
- 신규 목적지 최초 등록은 debounce 미적용 확인 — 테스트 `신규 목적지 최초 등록은 debounce 없이 즉시 발사`

## Wire-completion 5단
1. **Orphan**: `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard**: Backend Calls 재-POST 빈도는 DebugModal(alarmBackend instrumentation buffer)에서 관측 가능. 429 발생 시 `register: 429 retryAfter 억제 중` 로그가 device logger에 남는다.
3. **의존 PR**: 없음 (#2192 client 절반, backend #2194와 독립)
4. **측정 plan**: 실탑승에서 backend `trip-register: rate-limited (#1575 T12)` 로그 발생 빈도 + 그 이후 device 재-POST 간격이 `retryAfterSeconds` 이상으로 벌어지는지 wrangler tail/Cloudflare Dashboard로 확인. 1주 관측.
5. **Device verify**: 실탑승 필수 — 환승 연속 route 변경 시 재-POST 빈도 감소, 429 발생 시 재시도 간격이 서버 힌트를 따르는지 실기기에서 확인 필요.

## 검증
- `npm test`: 9156 tests passed, coverage 100%
- `npm run type-check`: pass
- `npm run lint:orphan`: pass