### PR TITLE
fix(#2208): arrivalApi line 필터 slice 전 적용 + fetch window 확대

### DIFF
--- a/src/features/alarm/__tests__/replay_20260807_boarding.test.ts
+++ b/src/features/alarm/__tests__/replay_20260807_boarding.test.ts
@@ -94,7 +94,7 @@ describe('#2207 건대입구(2·7) arrivalApi truncation red fixture — flip in
     jest.restoreAllMocks();
   });
 
-  it.failing(
+  it(
     '건대입구 전노선(2·7) 혼합 realtimeArrivalList — 상행 line-2 후보가 slice(0,2) truncation으로 0건',
     async () => {
       // evidence 재구성: Seoul API가 상행 방향에 7호선 3대 → 2호선 2대 순서로 응답. 앱은

--- a/src/features/arrival/api/arrivalApi.ts
+++ b/src/features/arrival/api/arrivalApi.ts
@@ -42,6 +42,14 @@ const SEOUL_API_TZ_OFFSET = '+09:00';
 const MAX_RECPTN_DRIFT_SEC = 120;
 
 /**
+ * Seoul Open API 조회 window 크기 (startIndex=0 기준 endIndex).
+ * 환승역(예: 건대입구 2·7호선)은 한 응답에 여러 line의 row가 함께 온다. window가 좁으면
+ * 한 line의 row가 앞쪽을 채워 다른 line의 row 자체가 API 응답에서부터 빠질 수 있다
+ * (ADR-027 / #2208, evidence: 건대입구 실탑승 dump).
+ */
+const SEOUL_API_FETCH_WINDOW = 20;
+
+/**
  * recptnDt("YYYY-MM-DD HH:mm:ss", KST)를 epoch ms로 변환한다.
  * 파싱 실패/누락 시 0(=알 수 없음)을 반환한다.
  */
@@ -82,6 +90,32 @@ export function getFallbackArrival(
   return result;
 }
 
+/**
+ * 방향(up/down)별 후보를 line으로 그룹핑한 뒤 line별로 `maxPerDirection`을 적용한다
+ * (ADR-027 / #2208). 환승역에서 한 line의 row가 API 응답 앞쪽을 채우면 line 구분 없는
+ * 전역 `slice(0, maxPerDirection)`이 다른 line 후보를 통째로 truncation한다 — 건대입구
+ * (2·7호선) 실탑승 evidence. line별로 슬라이스한 뒤 합치면 각 line이 최소 노출을 보장받는다.
+ *
+ * 단일 line 역(환승역이 아닌 대다수)에서는 그룹이 하나뿐이라 기존 전역 slice와 동일한
+ * 결과를 낸다 — 일반 arrival 표시(비환승역)는 무영향.
+ */
+function sliceMaxPerLine(items: ArrivalInfo[], maxPerDirection: number): ArrivalInfo[] {
+  const byLine = new Map<LineNumber, ArrivalInfo[]>();
+  for (const item of items) {
+    const group = byLine.get(item.line);
+    if (group) {
+      group.push(item);
+    } else {
+      byLine.set(item.line, [item]);
+    }
+  }
+  const result: ArrivalInfo[] = [];
+  for (const group of byLine.values()) {
+    result.push(...group.slice(0, maxPerDirection));
+  }
+  return result;
+}
+
 export interface FetchArrivalOptions {
   timeoutMs?: number;
   maxPerDirection?: number;
@@ -103,7 +137,7 @@ export async function fetchArrivalInfo(
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const url = `http://swopenapi.seoul.go.kr/api/subway/${apiKey}/json/realtimeStationArrival/0/10/${encodeURIComponent(stationName)}`;
+    const url = `http://swopenapi.seoul.go.kr/api/subway/${apiKey}/json/realtimeStationArrival/0/${SEOUL_API_FETCH_WINDOW}/${encodeURIComponent(stationName)}`;
 
     const response = await fetch(url, { signal: controller.signal });
     if (!response.ok) {
@@ -167,8 +201,8 @@ export async function fetchArrivalInfo(
     }
 
     const sliced: StationArrival = {
-      up: up.slice(0, maxPerDirection),
-      down: down.slice(0, maxPerDirection),
+      up: sliceMaxPerLine(up, maxPerDirection),
+      down: sliceMaxPerLine(down, maxPerDirection),
       source: 'realtime',
     };
     if (sliced.up.length === 0 && sliced.down.length === 0) {


### PR DESCRIPTION
Closes #2208

## 배경
ADR-027 (#2206) boarding. #2207 red fixture(`replay_20260807_boarding.test.ts`) 머지 완료.
건대입구(2·7호선) 환승역 실탑승 evidence: Seoul API `/0/10/` 응답이 line-7 row로 앞쪽을 채우면
line 구분 없는 전역 `slice(0, maxPerDirection=2)`가 line-2 후보를 통째로 truncation.

## 변경
- `src/features/arrival/api/arrivalApi.ts`
  - `sliceMaxPerLine()` 추가: 방향(up/down)별 후보를 line으로 그룹핑 후 line별 `maxPerDirection` 슬라이스, 이후 병합. `:169` 전역 slice를 대체.
  - Seoul API 조회 window `SEOUL_API_FETCH_WINDOW`(0/10 → 0/20)로 확대 — API 레벨에서부터 다른 line row가 빠지는 것 방지.
  - 단일 line 역(비환승역, 대다수)에서는 그룹이 1개뿐이라 기존 결과와 동일 — `useArrivalInfo`의 line-independent cache invariant(`useArrivalInfo.ts:16-21`) 및 일반 arrival 표시는 무영향. BFF 경로(`BffArrivalProvider`, 미사용)는 수정하지 않음.
- `src/features/alarm/__tests__/replay_20260807_boarding.test.ts`
  - fetchArrivalInfo truncation red fixture `it.failing` → `it`로 flip, green 확인.
  - auto-lock 오선택 케이스(`useBoardingLockController`)는 `it.failing` 그대로 유지 — #2209 소관.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — DebugModal의 arrival 후보 리스트(boarding 후보 섹션)에서 line별 후보 노출 확인 가능. line truncation 재발 시 해당 리스트에서 즉시 관측됨.
3. **의존 PR** — N/A (device/backend/infra 의존 없음, arrival feature 내부 변경).
4. **측정 plan** — `replay_20260807_boarding.test.ts` fixture green이 회귀 gate. 1주 내 실기기 환승역(건대입구 등) trip에서 boarding 후보 리스트에 두 line 모두 노출되는지 재확인.
5. **Device verify** — 필요. 시나리오: 건대입구(2·7호선) 또는 유사 환승역 실탑승 시 BoardingTrainList/boardingPrompt에 두 line 후보가 모두 노출되는지 확인.