### PR TITLE
fix(#2195): /trips rate-limit이 route 변경 재등록(update)을 create budget에서 면제

### DIFF
--- a/backend/alarm-worker/src/__tests__/tripIdentityReplay.test.ts
+++ b/backend/alarm-worker/src/__tests__/tripIdentityReplay.test.ts
@@ -5,14 +5,14 @@
  * TDD 선행 — #2194(신원 안정화 core fix)보다 먼저 이 replay가 "현재 코드에서 실패(red)"함을
  * 증명했다(#2193, production 코드 미수정 — fixture + test만). #2194가 신원(rotation) 관련
  * `test.fails(...)` 2개를 `test(...)`로 flip했다(주석 "flipped in #2194"). 429 관련 1개는
- * rate-limit create/update 구분(#2195) 범위라 여전히 `test.fails`로 남아있다(주석 "flip in
- * #2195").
+ * rate-limit create/update 구분(#2195)이 `test(...)`로 flip했다(주석 "flipped in #2195").
  *
- * 재현 메커니즘: `POST /trips` rate-limit 게이트(`index.ts:567`, deviceToken 기준 10회/10분)가
- * route-change reset(#2194 이전엔 rotation, `index.ts:776`)보다 먼저 평가된다. #2194 이후에도
- * rate-limit 키는 여전히 원본 deviceToken이라 — 10번째 이후 재-POST는 429로 죽는다(#2195 대기).
- * 다만 신원이 더 이상 churn하지 않으므로(rotation 폐기) 성공한 요청들은 항상 같은 trip으로
- * 수렴한다(위 2개 flip된 assert가 검증).
+ * 재현 메커니즘(수리 전): `POST /trips` rate-limit 게이트(`index.ts` 상단, deviceToken 기준
+ * 10회/10분)가 route-change reset(#2194 이전엔 rotation)보다 먼저 평가되고, update 요청도
+ * create와 동일하게 카운트해 10번째 이후 재-POST는 429로 죽었다. #2195가 update(=동일
+ * deviceToken의 기존 trip 존재) 판정을 rate-limit 게이트 앞에 추가해 update는 카운터를
+ * 소진하지 않도록 면제했다. 신원도 더 이상 churn하지 않으므로(rotation 폐기, #2194) 성공한
+ * 요청들은 항상 같은 trip으로 수렴한다(아래 4개 flip된 assert가 검증).
  */
 
 import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
@@ -88,7 +88,11 @@ async function runRotationStorm(env: Env): Promise<Response[]> {
 }
 
 describe('evidence 2026-08-07 tmsi34imn — rotation storm red replay (#2193)', () => {
-  test('현재 코드: rotation storm 재-POST가 rate-limit(429)에 걸려 최신 route가 등록되지 않는다 (red 증명)', async () => {
+  // flipped in #2195 (rate-limit create/update 구분) — evidence 당시(#2193/#2194 이전)는 매
+  // route 변경 재-POST가 create budget을 소진해 마지막 요청이 429로 죽고 최신 route가 어떤
+  // trip에도 반영되지 않았다. #2195가 update(=기존 trip 존재) 요청을 create budget에서
+  // 면제해 이제 rotation storm 전체가 429 없이 성공하고 최신 route가 반영된다.
+  test('수리 후 기대치: rotation storm 재-POST가 rate-limit(429)에 걸리지 않고 최신 route가 등록된다', async () => {
     const kv = new InMemoryKV();
     await kv.put(ARCH_FLAG_KV_KEY, 'on');
     const env = makeEnv(kv);
@@ -96,15 +100,14 @@ describe('evidence 2026-08-07 tmsi34imn — rotation storm red replay (#2193)', 
     const responses = await runRotationStorm(env);
     const statuses = responses.map((r) => r.status);
 
-    // evidence: 07:37:35 / 07:37:42 / 07:37:54 / 07:38:55(x2) 다중 429 관측.
-    // ROTATION_STORM_REQUEST_COUNT(11) = TRIP_REGISTER_MAX_PER_WINDOW(10) + 1이므로
-    // 마지막 요청은 현재 코드에서 반드시 429로 죽는다.
-    expect(statuses.filter((s) => s === 429).length).toBeGreaterThan(0);
-    expect(statuses[ROTATION_STORM_REQUEST_COUNT - 1]).toBe(429);
+    // evidence(수리 전): 07:37:35 / 07:37:42 / 07:37:54 / 07:38:55(x2) 다중 429 관측.
+    // 수리 후: update 요청은 create budget을 소진하지 않으므로 429가 전혀 발생하지 않는다.
+    expect(statuses.filter((s) => s === 429).length).toBe(0);
+    expect(statuses[ROTATION_STORM_REQUEST_COUNT - 1]).toBe(200);
 
-    // 429로 막힌 마지막 route(index=10, "evidence-dst-10")는 어떤 trip에도 반영되지 않는다 —
-    // KV에 남은 활성 trip 전체 중 그 destination을 가진 것이 하나도 없어야 "새 route 등록
-    // 실패" chain-death가 증명된다.
+    // 수리 전: 429로 막힌 마지막 route(index=10, "evidence-dst-10")는 어떤 trip에도 반영되지
+    // 않아 "새 route 등록 실패" chain-death가 증명됐다. 수리 후: 마지막 요청도 성공해 최신
+    // route가 활성 trip에 반영된다.
     const allTrips = await kv.list({ prefix: 'trip:' });
     const rawValues = await Promise.all(
       allTrips.keys.map((k) => kv.get(k.name)),
@@ -112,10 +115,11 @@ describe('evidence 2026-08-07 tmsi34imn — rotation storm red replay (#2193)', 
     const destinations = rawValues
       .filter((v): v is string => v !== null)
       .map((v) => (JSON.parse(v) as { destination: string }).destination);
-    expect(destinations).not.toContain('evidence-dst-10');
+    expect(destinations).toContain('evidence-dst-10');
   });
 
-  test('현재 코드: rotation storm이 rate-limit 예산을 소진해 10회 초과 시 429 발생 (red 증명, cap SSOT 사용)', async () => {
+  // flipped in #2195 (rate-limit create/update 구분, cap SSOT 사용)
+  test('수리 후 기대치: rotation storm이 rate-limit 예산을 소진하지 않아 10회 초과에도 429가 발생하지 않는다', async () => {
     const kv = new InMemoryKV();
     await kv.put(ARCH_FLAG_KV_KEY, 'on');
     const env = makeEnv(kv);
@@ -126,8 +130,8 @@ describe('evidence 2026-08-07 tmsi34imn — rotation storm red replay (#2193)', 
     const responses = await runRotationStorm(env);
     const last = responses[responses.length - 1];
     const body = (await last.json()) as { error?: string; retryAfterSeconds?: number };
-    expect(last.status).toBe(429);
-    expect(body.error).toBe('rate_limited');
+    expect(last.status).toBe(200);
+    expect(body.error).toBeUndefined();
   });
 
   // -------------------------------------------------------------------------
@@ -153,8 +157,8 @@ describe('evidence 2026-08-07 tmsi34imn — rotation storm red replay (#2193)', 
     expect(uuidLikeKeys.length).toBe(0);
   });
 
-  // flip in #2195 (rate-limit create/update 구분 — 이 이슈 범위 밖, #2194는 신원 안정화만)
-  test.fails(
+  // flipped in #2195 (rate-limit create/update 구분)
+  test(
     '수리 후 기대치: rotation storm 재-POST가 create budget을 소진하지 않아 429 = 0',
     async () => {
       const kv = new InMemoryKV();

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -564,25 +564,44 @@ app.post('/trips', async (c) => {
   // 5~10회 POST되는 사례 차단. Cloudflare Worker quota(100K/day) 보호 + dedup state 안정.
   // 정상 사용자(<10 req/10min)는 영향 없음. checkTripRegisterRateLimit은 fixed-window KV
   // counter — best-effort atomic (KV는 strict atomic 없음). cap 근처에서만 race 가능.
-  const rateLimit = await checkTripRegisterRateLimit(
-    c.env.TRIPS,
-    incoming.token,
-    Date.now(),
-  );
-  if (!rateLimit.allowed) {
-    console.log(
-      JSON.stringify({
-        msg: 'trip-register: rate-limited (#1575 T12)',
-        tokenPrefix: tokenPrefix(incoming.token),
-        count: rateLimit.count,
-        retryAfterSeconds: rateLimit.retryAfterSeconds,
-      }),
+  //
+  // #2195 (ADR-025 Decision 3) — update 요청은 create budget에서 면제한다. 판정 = 동일
+  // deviceToken(incoming.token)의 기존 trip이 이미 존재하는가. #2194가 신원(rotation)을
+  // 폐기해 트립 레코드는 항상 같은 key(`trip:<incoming.token>`)에 in-place로 갱신되므로,
+  // 직접 조회 한 번으로 "이 POST가 route 변경 재등록(=update)인지" 판정할 수 있다(신규 UUID
+  // 발급이 없어 역인덱스 fallback도 불필요 — #2194 이전 rotation 잔재는 #2175 cooldown bypass
+  // 경로가 흡수).
+  //
+  // create 스팸 방어(Worker quota 보호)는 최초 등록(existing=null)에만 적용해 그대로 유지 —
+  // update는 스팸이 아니라 같은 device가 route를 갈아타는 정상 흐름이라 카운터를 소진하지
+  // 않는다(2026-08-07 tmsi34imn 실탑승 429 chain-death, ADR-025).
+  //
+  // client-aborted POST 카운터 선점(점검 항목): 증가는 이 시점(첫 create 시도)에만 발생하고
+  // 이후 재-POST는 전부 update 판정으로 아래 분기를 건너뛰므로, 하나의 trip 생애주기 동안
+  // 카운터를 소진하는 지점은 최초 create 1회로 줄어든다 — evidence의 다중 429는 매 route
+  // 변경이 create로 오분류되던 것이 원인이었고 그 경로가 여기서 제거된다.
+  const existingForRateLimit = await getTrip(c.env.TRIPS, incoming.token);
+  if (existingForRateLimit === null) {
+    const rateLimit = await checkTripRegisterRateLimit(
+      c.env.TRIPS,
+      incoming.token,
+      Date.now(),
     );
-    return c.json(
-      { error: 'rate_limited', retryAfterSeconds: rateLimit.retryAfterSeconds },
-      429,
-      { 'Retry-After': String(rateLimit.retryAfterSeconds) },
-    );
+    if (!rateLimit.allowed) {
+      console.log(
+        JSON.stringify({
+          msg: 'trip-register: rate-limited (#1575 T12)',
+          tokenPrefix: tokenPrefix(incoming.token),
+          count: rateLimit.count,
+          retryAfterSeconds: rateLimit.retryAfterSeconds,
+        }),
+      );
+      return c.json(
+        { error: 'rate_limited', retryAfterSeconds: rateLimit.retryAfterSeconds },
+        429,
+        { 'Retry-After': String(rateLimit.retryAfterSeconds) },
+      );
+    }
   }
 
   // #1604 — Route 미설정 trip(legacy collapse: waypoints=[destination only])에 대한 backend


### PR DESCRIPTION
Closes #2195

Part of #2192 (ADR-025). 선행 #2194(신원 안정화 core, 머지됨) 위에 rate-limit create/update 구분을 얹는다.

## 배경

2026-08-07 오전 실탑승(corrId=tmsi34imn) evidence: 같은 deviceToken으로 route 변경 재-POST가 반복될 때 `/trips` rate-limit 게이트(create budget 10/10min)가 update 요청도 create로 카운트해 429 storm 발생 → 새 route 등록 실패 chain-death.

## 변경

- `src/index.ts`: `POST /trips` 핸들러에서 rate-limit 체크 전에 `getTrip(c.env.TRIPS, incoming.token)`으로 update 판정 추가. 기존 trip이 존재하면(`existingForRateLimit !== null`) `checkTripRegisterRateLimit` 호출 자체를 skip — update는 create budget을 전혀 소진하지 않는다.
  - #2194가 rotation(UUID 신원 churn)을 폐기해 trip 레코드가 항상 같은 key(`trip:<incoming.token>`)에 in-place 갱신되므로, 직접 조회 1회로 판정 충분 (역인덱스 fallback 불필요).
  - create 스팸 방어(최초 등록, `existing===null`)는 기존 그대로 유지 — cap 완화 없음.
- `src/__tests__/tripIdentityReplay.test.ts`: rotation storm replay(#2193) 429 관련 `test.fails`를 `test`로 flip. 선행 2개의 red-proof 테스트(수리 전 429 발생을 증명하던 테스트)도 수리 후 기대치(429=0, 최신 route 반영)로 갱신.

## client-aborted POST 카운터 선점 점검

증가는 최초 create 시도 시점에만 발생하고 이후 재-POST는 전부 update 판정으로 rate-limit 게이트를 건너뛰므로, 하나의 trip 생애주기 동안 카운터를 소진하는 지점이 최초 create 1회로 줄어든다. Evidence의 다중 429는 매 route 변경이 create로 오분류되던 것이 원인이었고 그 경로가 제거된다. 별도 구조 변경(예: 성공 시점으로 증가 이동)은 이번 스코프 밖 — create 최초 등록 시 abort 자체는 여전히 발생 가능하나 별도 이슈로 분리할 사안.

## Wire-completion 5단

1. **Orphan**: `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard**: `POST /trips` 429 카운트는 `trip-register: rate-limited (#1575 T12)` 로그(wrangler tail / Cloudflare Dashboard)로 관측. 이번 PR로 update 경로의 429가 사라지는 것을 같은 쿼리로 확인 가능.
3. **의존 PR**: #2194 (머지됨, dev에 포함)
4. **측정 plan**: 실기기 1주 429=0 관측 (`#2193 429 assert green 전환`과 같은 시나리오 — route 변경 재-POST 반복 trip). D1 `trip_metrics`의 `end_reason` 계열에 rate-limit 관련 강제종료 재발 0건 확인.
5. **Device verify**: #2194와 통합 실탑승 필요 — route 변경(환승 재플랜)이 반복되는 trip에서 429 없이 최신 route가 반영되는지 확인.

## 검증

- `npm test` (backend/alarm-worker): 2889 passed, coverage ratchet floor(97/96/98/97) 통과
- `npm run type-check` (backend/alarm-worker): pass
- `npm run lint:orphan` (root): pass, 0 orphan

## 금지 준수

- create 스팸 방어(cap 10/10min)는 유지 — update만 면제
- `alarm.ts` / `scheduled.ts` 미수정 (#2201 소관)
- #2194 신원/rotation 로직 재수정 없음