### PR TITLE
feat(#2201): arvlcdFireOnceTtl isSimpleArchEnabled real getArchFlag wire

### DIFF
--- a/backend/alarm-worker/src/__tests__/arvlcdFireOnceTtl.test.ts
+++ b/backend/alarm-worker/src/__tests__/arvlcdFireOnceTtl.test.ts
@@ -7,7 +7,13 @@ import {
   isSimpleArchEnabled,
   stampArvlCdFireOnce,
 } from '../arvlcdFireOnceTtl';
+import { ARCH_FLAG_KV_KEY } from '../archFlag';
+import type { Env } from '../types';
 import { InMemoryKV } from './inMemoryKv';
+
+function makeEnvWithKv(kv: InMemoryKV): Env {
+  return { TRIPS: kv as unknown as KVNamespace } as Env;
+}
 
 const NOW = 1_700_000_000_000;
 const TOKEN = 'trip-tok-1';
@@ -148,8 +154,21 @@ describe('stampArvlCdFireOnce (#1985)', () => {
   });
 });
 
-describe('isSimpleArchEnabled (#1985 임시 flag)', () => {
-  it('returns false — Phase 0 (#1982) 미머지 상태, production 무영향 default', () => {
-    expect(isSimpleArchEnabled()).toBe(false);
+describe('isSimpleArchEnabled (#2201 real getArchFlag(env.TRIPS) wire)', () => {
+  it('returns false — KV 미설정 default (getArchFlag default off)', async () => {
+    const kv = new InMemoryKV();
+    expect(await isSimpleArchEnabled(makeEnvWithKv(kv))).toBe(false);
+  });
+
+  it('returns true — remote KV flag="on"', async () => {
+    const kv = new InMemoryKV();
+    await kv.put(ARCH_FLAG_KV_KEY, 'on');
+    expect(await isSimpleArchEnabled(makeEnvWithKv(kv))).toBe(true);
+  });
+
+  it('returns false — remote KV flag="off"', async () => {
+    const kv = new InMemoryKV();
+    await kv.put(ARCH_FLAG_KV_KEY, 'off');
+    expect(await isSimpleArchEnabled(makeEnvWithKv(kv))).toBe(false);
   });
 });

--- a/backend/alarm-worker/src/__tests__/replay_20260807_storm.test.ts
+++ b/backend/alarm-worker/src/__tests__/replay_20260807_storm.test.ts
@@ -24,11 +24,11 @@
  * "단일 물리 이벤트 = 단일 backend emitter" 불변식이 remote flag=ON 상태에서도 깨져 있음을
  * 고정한다.)
  *
- * ## Assert (수리 후 기대치, 지금 red)
+ * ## Assert (수리 완료, #2201에서 green으로 flip)
  * 한 물리 도착 이벤트(같은 station의 arvlCd 0→1 monotone 진행)에 대해 backend가 실제로 발사하는
- * visible push 수 = 1 기대(현재 2). `it.fails`으로 감싸 CI green 유지 — #2201/#2202/#2204가
- * `isSimpleArchEnabled`를 real `getArchFlag(env.KV)`로 wire하면 이 assertion이 통과, 그 시점에
- * `it.fails`을 `it`로 교체한다.
+ * visible push 수 = 1 (수리 전 2). #2201이 `isSimpleArchEnabled`를 real
+ * `getArchFlag(env.TRIPS)`로 wire해 `it.fails`를 `it`로 교체 — remote flag=ON 상태에서
+ * fire-once 게이트가 실제로 관여한다.
  *
  * ## 금지
  * production 코드 수정 없음(테스트만). `scheduled.test.ts`의 fixture 패턴(`makeFullEmptyStats`,
@@ -164,57 +164,10 @@ function makeFullEmptyStats(): ScheduledStats {
 }
 
 describe('evidence 2026-08-07 07:38 뚝섬 storm — 단일 물리 이벤트 backend 중복 emit (#2200)', () => {
-  it('오늘 evidence 재현 — remote archFlag=on 상태에서도 fire-once 게이트가 관여하지 않아 같은 station에서 2회 push 발사 (회귀 확인)', async () => {
-    const kv = new InMemoryKV();
-    // dump Feature Flag 섹션: remote=on active=ON — 이 trip의 실제 KV 상태를 그대로 재현.
-    await kv.put(ARCH_FLAG_KV_KEY, 'on');
-    const trip = makeTrip();
-    await putTrip(kv as unknown as KVNamespace, trip);
-    const apnsFetch = async (): Promise<Response> => new Response('', { status: 200 });
-    const commonInputs = {
-      trip,
-      waypoint: trip.waypoints[0],
-      lock: trip.boardingLock!,
-      env: makeEnv(kv),
-      deps: {
-        apnsConfig,
-        apnsHosts: APNS_HOSTS,
-        fetchImpl: apnsFetch as unknown as typeof fetch,
-        now: () => NOW,
-      } as ScheduledDeps,
-      now: NOW,
-      log: () => undefined,
-      generatePushId: () => 'p-storm-1',
-    };
-
-    // arvlCd=0(진입) 첫 관측 — 물리 도착 이벤트의 시작.
-    const statsFirst = makeFullEmptyStats();
-    const first = await fireArvlCdStationPush({ ...commonInputs, stats: statsFirst, arvlCd: 0 });
-    expect(first.dirty).toBe(true);
-    expect(statsFirst.arvlCdFireSuccess).toBe(1);
-
-    // 같은 monotone cycle 안에서 arvlCd=1(도착) 재관측 — 물리적으로는 같은 도착 이벤트.
-    // trip은 첫 fire에서 putTrip으로 lastFiredStation이 갱신되지 않았으므로(직접 호출은 caller가
-    // trip 객체를 재사용) 두 번째 호출도 같은 in-memory trip을 그대로 전달한다.
-    const statsSecond = makeFullEmptyStats();
-    const second = await fireArvlCdStationPush({
-      ...commonInputs,
-      stats: statsSecond,
-      arvlCd: 1,
-      generatePushId: () => 'p-storm-2',
-    });
-
-    // 회귀 확인: 실제로는 2번째도 fire 된다 — 같은 물리 이벤트에 대해 backend가 push를 2회 발사.
-    expect(second.dirty).toBe(true);
-    expect(statsSecond.arvlCdFireSuccess).toBe(1);
-    expect(statsSecond.arvlCdFireOnceSkipped).toBe(0);
-  });
-
-  // Flip in #2201/#2202/#2204 — `arvlcdFireOnceTtl.ts`의 `isSimpleArchEnabled()`가 real
-  // `getArchFlag(env.KV)`로 wire되면, remote flag='on' 상태에서 같은 (token, station) cycle의
-  // 두 번째 arvlCd 관측은 fire-once 게이트로 skip돼야 한다. 그 시점 이 테스트를
-  // `it.fails` → `it`로 교체한다.
-  it.fails(
+  // #2201 수리 완료 — `isSimpleArchEnabled`가 real `getArchFlag(env.TRIPS)`로 wire되어
+  // remote flag='on' 상태에서 같은 (token, station) cycle의 두 번째 arvlCd 관측은 fire-once
+  // 게이트로 skip된다. `it.fails` → `it`로 교체 (구 "회귀 확인" 테스트는 수리로 무효화되어 제거).
+  it(
     '수리 후 기대치 — 한 물리 도착 이벤트(arvlCd 0→1 monotone) = backend push 1회만 (remote archFlag=on 존중)',
     async () => {
       const kv = new InMemoryKV();

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -8439,10 +8439,9 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
 /**
  * ADR-022 Phase 1-1 (#1985) — arvlCd fire-once TTL 게이트 (flag=ON 시).
  *
- * `isSimpleArchEnabled` 는 `arvlcdFireOnceTtl.ts` 의 임시 flag (현재 항상 false 반환). 본 describe
+ * `isSimpleArchEnabled` 는 #2201 이후 real `getArchFlag(env.TRIPS)` 로 wire 되었다. 본 describe
  * 블록은 `vi.spyOn` 으로 flag=ON 을 강제 → 동일 (trip, station, cycle) 조합의 2회 이상 fire 가
- * 차단되는지 검증. Phase 0 (#1982) 머지 후속 PR 에서 real `getArchFlag(env.KV)` 로 wire 되면
- * 본 flag mock 은 자연스럽게 KV 시드 방식으로 교체 예정.
+ * 차단되는지 검증 (spy 방식은 KV 시드와 무관하게 격리 유지 목적으로 존속).
  */
 describe('runScheduled — ADR-022 Phase 1-1 fire-once TTL (#1985)', () => {
   const TOKEN = 'arvl-fireonce-tok';
@@ -8464,7 +8463,7 @@ describe('runScheduled — ADR-022 Phase 1-1 fire-once TTL (#1985)', () => {
     // flag=ON 을 spy 로 강제. `isSimpleArchEnabled` 를 * as import 하지 않고 destructured 로
     // scheduled.ts 가 import 하지만, vitest 는 ESM live bindings 를 통해 spy 를 적용한다.
     const mod = await import('../arvlcdFireOnceTtl');
-    const spy = vi.spyOn(mod, 'isSimpleArchEnabled').mockReturnValue(true);
+    const spy = vi.spyOn(mod, 'isSimpleArchEnabled').mockResolvedValue(true);
     try {
       const kv = new InMemoryKV();
       await putTrip(kv as unknown as KVNamespace, opts.trip ?? makeLockTrip());
@@ -8544,7 +8543,7 @@ describe('runScheduled — ADR-022 Phase 1-1 fire-once TTL (#1985)', () => {
     // 검증 방식: `fireArvlCdStationPush` 를 직접 호출 (waypoint advance 부작용 격리) — 첫 호출 =
     // arvlCd=0 fire + fire-once stamp, 두 번째 호출 = arvlCd=1 통합 skip.
     const mod = await import('../arvlcdFireOnceTtl');
-    const spy = vi.spyOn(mod, 'isSimpleArchEnabled').mockReturnValue(true);
+    const spy = vi.spyOn(mod, 'isSimpleArchEnabled').mockResolvedValue(true);
     try {
       const kv = new InMemoryKV();
       const trip = makeLockTrip();
@@ -8657,7 +8656,7 @@ describe('runScheduled — ADR-022 Phase 1-1 fire-once TTL (#1985)', () => {
       // 만료 시점 진행.
       vi.setSystemTime(NOW + 10_000);
       const mod = await import('../arvlcdFireOnceTtl');
-      const spy = vi.spyOn(mod, 'isSimpleArchEnabled').mockReturnValue(true);
+      const spy = vi.spyOn(mod, 'isSimpleArchEnabled').mockResolvedValue(true);
       try {
         const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
         const stats = await runScheduled(makeEnv(kv), {

--- a/backend/alarm-worker/src/arvlcdFireOnceTtl.ts
+++ b/backend/alarm-worker/src/arvlcdFireOnceTtl.ts
@@ -27,14 +27,17 @@
  *
  * ## Feature flag
  *
- * 본 helper 자체는 flag 를 알지 않는다 — caller (`fireArvlCdStationPush`) 가 `isSimpleArchEnabled()`
- * 로 게이트한다. Phase 0 (#1982) 머지 후속 PR 에서 real `getArchFlag(env.KV)` wire.
+ * 본 helper 자체는 flag 를 알지 않는다 — caller (`fireArvlCdStationPush`) 가 `isSimpleArchEnabled(env)`
+ * 로 게이트한다. `isSimpleArchEnabled`는 real `getArchFlag(env.TRIPS)`를 조회한다 (#2201).
  *
  * ## 관측
  *
  * skip 발생 시 caller 가 `writeMetric(env, { eventType: 'suppress', reason: 'fire-once-cycle-already' })`
  * 로 wrangler tail 관측. `arvlCdFireOnceSkipped` stat 카운터도 별도 누적.
  */
+
+import { getArchFlag } from './archFlag';
+import type { Env } from './types';
 
 /**
  * 5분 (300s). Train 이 같은 station 을 5분 안에 재방문할 수 없다는 실제 운영 특성 기반.
@@ -99,14 +102,15 @@ export async function stampArvlCdFireOnce(
 }
 
 /**
- * ADR-022 Phase 1-1 임시 flag. `false` = 기존 로직 (per-arvlCd dedup) 그대로.
- * Phase 0 (#1982) 머지 후속 PR 에서 `getArchFlag(env.KV)` 로 real wire — 그 시점 이전엔
- * production 무영향.
+ * ADR-022 Phase 1-1 (#1985) → Phase 1-2 real wire (#2201, ADR-026 Decision 4).
+ *
+ * `env.TRIPS` KV 의 real `getArchFlag`를 조회 — 'on' 이면 true. 어린이대공원 13:31/13:32/13:37
+ * 재발사 (#2200 storm evidence) 는 이 flag가 remote='on' 인데도 항상 `false`를 반환하는
+ * 하드코딩 stub 이었던 것이 backend 기여분 근본 원인 — real wire 로 dormant 해제한다.
  *
  * 함수로 노출한 이유: 테스트에서 `vi.spyOn(module, 'isSimpleArchEnabled')` 로 flag=ON 시나리오
- * 검증. Phase 1-2 follow-up PR 에서 signature 를 `isSimpleArchEnabled(env: Env)` 로 확장하고
- * 내부를 `await getArchFlag(env.KV)` 로 교체 (call site 는 이미 `env` 를 갖고 있음).
+ * 검증 가능 유지.
  */
-export function isSimpleArchEnabled(): boolean {
-  return false;
+export async function isSimpleArchEnabled(env: Env): Promise<boolean> {
+  return (await getArchFlag(env.TRIPS)) === 'on';
 }

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -2300,7 +2300,7 @@ export async function fireArvlCdStationPush(
   // (0→1→2→5) 를 하나의 fire 이벤트로 통합 — 어린이대공원 반복 4회 fire (#1980) 회귀 차단.
   // flag=OFF (default, Phase 0 #1982 미머지 상태) 에서는 조기 return 으로 무영향.
   const fireOnceCycle = ARVLCD_FIRE_ONCE_CYCLE_SLOT;
-  if (isSimpleArchEnabled()) {
+  if (await isSimpleArchEnabled(env)) {
     const alreadyFired = await checkArvlCdFireOnce(
       env.TRIPS,
       trip.token,
@@ -2498,7 +2498,7 @@ export async function fireArvlCdStationPush(
   // ADR-022 Phase 1-1 (#1985) — fire-once TTL stamp (flag=ON 시에만). 성공 fire 직후 stamp
   // 해 다음 cycle 이내 arvlCd 재노출을 통합 차단. flag=OFF 시 이 write 는 실행되지 않아
   // production 무영향.
-  if (isSimpleArchEnabled()) {
+  if (await isSimpleArchEnabled(env)) {
     await stampArvlCdFireOnce(env.TRIPS, trip.token, waypoint.stationName, fireOnceCycle, now);
   }
   // #1367 — cross-station dedup용 마지막 fire 마커. 성공 시에만 stamp(실패는 다음 cycle 재시도 허용).


### PR DESCRIPTION
Closes #2201

Part of #2199 (ADR-026). ②storm green의 backend 절반 — #2200 fire red fixture 후속.

## 변경
- `arvlcdFireOnceTtl.ts`의 `isSimpleArchEnabled()` 하드코딩 stub(`() => false`)을 real
  `isSimpleArchEnabled(env: Env): Promise<boolean>` (`await getArchFlag(env.TRIPS) === 'on'`)로 wire.
- `scheduled.ts` `fireArvlCdStationPush`의 fire-once check/stamp 호출부 2곳을
  `await isSimpleArchEnabled(env)`로 교체 — remote archFlag='on' 상태에서 fire-once TTL 게이트가
  실제로 관여하도록 함 (어린이대공원 13:31/13:32/13:37, 뚝섬 07:38 재발사의 backend 기여분 근본 원인).
- `replay_20260807_storm.test.ts`: `it.fails` → `it` flip, green 확인. 구 "회귀 확인" 테스트(수리로
  assertion이 반대가 되어 무효화됨)는 제거 — 단일 "수리 후 기대치" 테스트로 통합.
- 단일샘플 권위 금지(temporal consensus + trip boarded train-identity binding)는 기존
  `consensusGate.ts`(E6/#1439) + `fireArvlCdStationPush`의 `lock.trainCode` 파라미터 바인딩으로
  기존에 이미 충족 — 본 PR에서 추가 로직 변경 없음 (device 발사 경로/safetyNet backstop 미변경).

## 파일
- `backend/alarm-worker/src/arvlcdFireOnceTtl.ts`
- `backend/alarm-worker/src/scheduled.ts`
- `backend/alarm-worker/src/__tests__/{arvlcdFireOnceTtl,scheduled,replay_20260807_storm}.test.ts`

## Wire-completion 5단
1. **Orphan**: `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard**: `arvlCdFireOnceSkipped` stat 카운터 (wrangler tail `suppress` reason
   `fire-once-cycle-already` 로그) + `writeMetric` suppress 이벤트 — Cloudflare Dashboard/tail에서
   dedup 발생 빈도 관측 가능.
3. **의존 PR**: #2192, #2199 (ADR-026 선행). #2200(red fixture) 머지됨. 병렬 소관: #2195(index.ts
   rate-limit/router, 미변경), #2204(device, 미변경).
4. **측정 plan**: 1주간 wrangler tail에서 `fire-once-cycle-already` suppress 이벤트 발생 여부 +
   같은 (token, station) 조합 `arvlCdFireSuccess` 2회 이상 발생 0건 확인. archFlag='on' KV 상태인
   trip 대상.
5. **Device verify**: 실기기 필수 — archFlag='on' 상태 trip으로 지하철 탑승, 도착 이벤트에서
   backend visible push가 station당 1회만 오는지 확인 (뚝섬/어린이대공원 재현 시나리오 재현 여부).

## 검증
- `npm test` (backend/alarm-worker): 77 test files / 2890 tests pass, red fixture green flip 확인.
- `npm run type-check` (backend/alarm-worker): pass.
- `npm run lint:orphan` (repo root): pass.