### PR TITLE
fix(#2209): boarding line은 route/lock 확정값에서만 auto-lock 사전필터

### DIFF
--- a/src/features/alarm/__tests__/replay_20260807_boarding.test.ts
+++ b/src/features/alarm/__tests__/replay_20260807_boarding.test.ts
@@ -192,9 +192,9 @@ describe('#2207 건대입구(2·7) auto-lock 오노선 red fixture — flip in #
     useBoardingLockStore.setState({ lock: null });
   });
 
-  it.failing(
-    '건대입구 환승(2·7) 혼합 후보 — auto-lock이 line=2(2038) 대신 line=7(7377)을 선택 ' +
-      '(arvlCd 우선순위만으로 결정, line 미필터)',
+  it(
+    '건대입구 환승(2·7) 혼합 후보 — auto-lock이 line=7(7377) 대신 line=2(2038)을 선택 ' +
+      '(#2209: directionalArrivals가 approachLine 확정값으로 사전필터)',
     async () => {
       const createLockMock = jest.fn().mockResolvedValue(undefined);
       useBoardingLockStore.setState({ lock: null, createLock: createLockMock });

--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -1437,12 +1437,46 @@ describe('useBoardingLockController', () => {
       const createLockMock = jest.fn().mockResolvedValue(undefined);
       useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
       // route는 line 2, train은 line 7 (옆 노선 fusion 오류 시뮬레이션).
+      // #2209 — approachLine(확정, line=2) 사전필터가 line 7 후보를 originAutoLockArrivals
+      // 단계에서 먼저 걷어내(길이 0) skip. allowedLines 검증까지 도달하지 않아도 결과는 동일.
       const wrongLine: StationArrival = {
         up: [makeTrain({ trainCode: 'WRONG-LINE', arrivalCode: 1, line: '7' })],
         down: [],
       };
       renderHook(() =>
         useBoardingLockController({ ...defaultInputs, arrival: wrongLine }),
+      );
+      await waitFor(() => {
+        expect(mockGetBoardingLock).toHaveBeenCalled();
+      });
+      expect(createLockMock).not.toHaveBeenCalled();
+    });
+
+    it('#2209 — approachLine이 #1325 desync fallback(currentStation.line)으로 떨어진 off-route line이면 allowedLines에서 여전히 reject', async () => {
+      const createLockMock = jest.fn().mockResolvedValue(undefined);
+      useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+      // stations.json에 없는 가짜 역명 — approachLine.ts의 실제 findStationByNameAndLine(stationRoute)가
+      // 조회 실패해 #1325 가드로 route 후보('2') 대신 currentStation.line('9', route 외 line)으로 fallback.
+      // originAutoLockArrivals가 그 line('9')으로 사전필터되어 chosen.line='9'가 산출되고, allowedLines({2})
+      // 검증이 여전히 최종 방어선으로 reject해야 한다(line 사전필터가 이 가드를 무력화하지 않음을 보장).
+      const desyncStation: Station = {
+        id: 'stn-desync',
+        name: '__nonexistent-station-2209__',
+        line: '9',
+        lineColor: '#000',
+        lat: 0,
+        lng: 0,
+      };
+      const offRouteLine: StationArrival = {
+        up: [makeTrain({ trainCode: 'OFF-ROUTE-9', arrivalCode: 1, line: '9' })],
+        down: [],
+      };
+      renderHook(() =>
+        useBoardingLockController({
+          ...defaultInputs,
+          currentStation: desyncStation,
+          arrival: offRouteLine,
+        }),
       );
       await waitFor(() => {
         expect(mockGetBoardingLock).toHaveBeenCalled();

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -12,6 +12,7 @@ import * as Haptics from 'expo-haptics';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import { useUserIntentStore } from '../store/useUserIntentStore';
 import { resolveTripDirection } from '../../route/utils/tripDirection';
+import { getApproachLineWithConfirmation } from '../../route/utils/approachLine';
 import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import { allowedLinesFromRoute } from '../../../shared/utils/stationRoute';
 import { STATIC_SPEED_THRESHOLD_MPS } from '../../nearest-station/utils/movementGate';
@@ -263,12 +264,36 @@ export function useBoardingLockController({
   // BoardingLock store로 흘러드는 회귀를 차단한다.
   const allowedLines = useMemo(() => allowedLinesFromRoute(route), [route]);
 
+  // #2209 (ADR-027 Decision 1) — route/lock 확정값일 때만 신뢰할 수 있는 line 신호.
+  // `confirmed=false`(route/lock 후보 없음, fusion `currentStation.line` 임의값(#797))이면
+  // 어떤 candidate 필터에도 이 line을 쓰지 않는다(누락 방지) — origin auto-lock 전용
+  // `originAutoLockArrivals`(하단)에서만 소비한다.
+  const { line: approachLine, confirmed: approachLineConfirmed } = useMemo(
+    () => getApproachLineWithConfirmation(route, lock, currentStation),
+    [route, lock, currentStation],
+  );
+
   const directionalArrivals = useMemo<ArrivalInfo[]>(() => {
     if (!arrival) return [];
     if (direction === 'up') return arrival.up.filter(isReachable);
     if (direction === 'down') return arrival.down.filter(isReachable);
     return [...arrival.up, ...arrival.down].filter(isReachable);
   }, [arrival, direction]);
+
+  // #2209 (ADR-027 Decision 3) — origin leg device-side auto-lock(하단 effect) 전용 line 사전필터.
+  // `directionalArrivals`(hydrateLockFromCandidate Gate 1 / hook 반환값)는 backend가 이미
+  // evidence로 line을 신뢰한 candidate까지 line 불일치로 걷어내면 안 되므로 건드리지 않는다
+  // (예: 환승역에서 backend가 toLine candidate를 evidence 기반으로 확정 hydrate하는 케이스).
+  // 반대로 origin auto-lock effect는 device 자체 판단(source='position-train')이라 `allowedLines`
+  // (trip route 전체 line 집합, `{2,7}` 등)만으로는 옆 line 후보(예: 7377)를 걸러내지 못했던
+  // 회귀(증상④)를 approachLine(확정)으로 사전 차단한다 — `useBoardingPromptResponder.ts:314`의
+  // `sameLine` 필터와 동일 정책.
+  const originAutoLockArrivals = useMemo<ArrivalInfo[]>(() => {
+    if (approachLineConfirmed && approachLine) {
+      return directionalArrivals.filter((t) => t.line === approachLine);
+    }
+    return directionalArrivals;
+  }, [directionalArrivals, approachLine, approachLineConfirmed]);
 
   // #1326: BoardingTrainList 전용 — 방향 필터 결과가 비면 빈 목록 대신 양방향 합집합으로 폴백.
   //
@@ -462,13 +487,14 @@ export function useBoardingLockController({
     if (lock) return;
     if (!route) return;
     if (!currentStation) return;
-    if (directionalArrivals.length === 0) return;
+    if (originAutoLockArrivals.length === 0) return;
     const originKey = `${destinationId ?? FREE_TRIP_DESTINATION_SENTINEL}|${currentStation.id}`;
     if (lastOriginAutoLockKeyRef.current === originKey) return;
     // #1740 — direction이 확정된 경우 pickAutoTrainCodeFromArrivals에 전달.
-    // directionalArrivals는 이미 direction 필터 적용됐지만, helper 인자로 명시해 일관성 보장.
+    // originAutoLockArrivals는 이미 direction + (확정 시) line 필터가 적용됐지만, helper 인자로
+    // direction을 명시해 일관성 보장.
     const destinationDirection = direction === 'up' || direction === 'down' ? direction : undefined;
-    const chosen = pickAutoTrainCodeFromArrivals(directionalArrivals, destinationDirection);
+    const chosen = pickAutoTrainCodeFromArrivals(originAutoLockArrivals, destinationDirection);
     if (!chosen) return;
     // 강 evidence 게이트: arvlCd가 ENTERING/ARRIVED/DEPARTED 중 하나일 때만 진행.
     // `pickAutoTrainCodeFromArrivals`는 receivedAt 정렬 첫 후보로 fallback하지만, 본 effect는
@@ -557,7 +583,7 @@ export function useBoardingLockController({
     lock,
     route,
     currentStation,
-    directionalArrivals,
+    originAutoLockArrivals,
     destinationId,
     expectedDurationMinutes,
     allowedLines,

--- a/src/features/route/utils/approachLine.ts
+++ b/src/features/route/utils/approachLine.ts
@@ -22,20 +22,44 @@ import type { LineNumber, Station } from '../../../shared/types/station';
  * (잘못 탑승 / route 데시싱크로 다른 leg line이 샘) 현재역 라벨로 쓰지 않고 currentStation.line으로
  * fallback한다. upstream fusion(#1317)을 고치기 전에도 혼동 라벨을 차단하는 독립 가드.
  */
+export interface ApproachLineResult {
+  line: LineNumber | null;
+  /**
+   * #2209 (ADR-027 Decision 1) — true면 route/lock에서 산출된 확정값(위 우선순위 1·2번).
+   * false면 route/lock 후보가 없어 `currentStation?.line`(fusion 임의 선택, #797)로만 떨어진
+   * 상태 — boarding 후보 line 필터에 사용하면 정답 line을 통째로 지울 수 있어 미확정으로 취급한다.
+   */
+  confirmed: boolean;
+}
+
+/**
+ * #2209 (ADR-027 Decision 1) — line 필터 안전성을 위해 확정 여부를 함께 반환하는 버전.
+ * `getApproachLine`은 이 함수의 `.line`만 취하는 하위호환 wrapper.
+ */
+export function getApproachLineWithConfirmation(
+  route: Route,
+  boardingLock: BoardingLock | null,
+  currentStation: Station | null,
+): ApproachLineResult {
+  const candidate = resolveCandidateLine(route, boardingLock);
+  const confirmed = candidate !== null;
+
+  if (candidate && currentStation) {
+    const line = findStationByNameAndLine(currentStation.name, candidate)
+      ? candidate
+      : currentStation.line;
+    return { line, confirmed };
+  }
+
+  return { line: candidate ?? currentStation?.line ?? null, confirmed };
+}
+
 export function getApproachLine(
   route: Route,
   boardingLock: BoardingLock | null,
   currentStation: Station | null,
 ): LineNumber | null {
-  const candidate = resolveCandidateLine(route, boardingLock);
-
-  if (candidate && currentStation) {
-    return findStationByNameAndLine(currentStation.name, candidate)
-      ? candidate
-      : currentStation.line;
-  }
-
-  return candidate ?? currentStation?.line ?? null;
+  return getApproachLineWithConfirmation(route, boardingLock, currentStation).line;
 }
 
 /** route + BoardingLock SSOT로 우선순위에 따라 노선을 산출한다 (검증 전 raw 후보). */


### PR DESCRIPTION
Closes #2209

Part of ADR-027 boarding (증상④, epic #2206). #2207 red 머지 → 본 PR이 auto-lock 오노선 red를 green flip.

## 변경
- `approachLine.ts`: `getApproachLineWithConfirmation` 추가 — route/lock에서 산출된 확정값인지(`confirmed`) 신호를 반환. 확정값이 없으면(candidate null) 필터를 걸지 않아 누락을 방지(Decision 1).
- `useBoardingLockController.ts`: origin leg device-side auto-lock effect(#1640) 전용 `originAutoLockArrivals`를 추가해 approachLine(확정) + direction으로 `pickAutoTrainCodeFromArrivals` 입력을 사전필터. `allowedLines`(trip route 전체 line 집합, `{2,7}` 등)만으로는 환승역에서 옆 line 후보(7377)를 걸러내지 못했던 회귀(증상④)를 차단(Decision 3).
  - `hydrateLockFromCandidate`/`boardingListArrivals`가 소비하는 기존 `directionalArrivals`는 그대로 유지 — backend가 evidence로 이미 신뢰한 candidate(예: 환승역 toLine hydrate)를 line 사전필터로 다시 걷어내면 안 되기 때문(기존 테스트 "청량리 다중 line 환승역 — 양쪽 line 모두 hydrate 허용"이 이 정책을 고정).
  - `allowedLines` 최종 검증은 그대로 유지 — `#1325` desync fallback(route/lock candidate가 currentStation 실제 line과 불일치해 currentStation.line으로 fallback)이 off-route line으로 떨어지는 극단 케이스의 최종 방어선.
- `replay_20260807_boarding.test.ts`: auto-lock 오노선 red fixture green flip (`arrivalApi` truncation red는 #2208 소관, 그대로 유지).
- `useBoardingLockController.test.tsx`: #1325 desync fallback 시나리오 회귀 테스트 추가(위 최종 방어선 커버리지).

## 금지 준수
- `arrivalApi.ts` 미수정 (#2208 소관).
- `tripDirection.ts:139`의 null-direction 안전 처리는 기존 코드가 이미 만족(`currIdx===nextIdx`/미매칭 시 null → 호출자 양방향 union) — 별도 변경 불필요, 회귀 없음 확인.

## Wire-completion 5단
1. **Orphan 없음**: `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard**: `originAutoLockArrivals` 필터 결과는 `logBoardingPromptAutoLock` 경로(`reason: 'autolock-success'|'autolock-lock-failed'`)로 기존과 동일하게 DebugModal의 autoLock outcome 분포에서 관측 가능 — line 사전필터로 후보가 줄어든 케이스는 `originAutoLockArrivals.length===0` 조기 return(로그 없음, 다음 polling cycle 재시도)이라 별도 신호 추가는 범위 밖.
3. **의존 PR**: N/A (device-only 변경, backend 무관). #2208(arrivalApi truncation)과 독립 병렬.
4. **측정 plan**: 1주 production 측정 — 환승역 auto-lock 성공 시 `logBoardingPromptAutoLock({reason:'autolock-success', line})` 분포에서 line=7377류 옆 line 오선택 재발 0건 확인. replay fixture(`replay_20260807_boarding.test.ts`)로 회귀 24/7 검증.
5. **Device verify**: 실기기 환승역(건대입구 2·7호선 등) 탑승 시 auto-lock 후보 line이 실제 플랫폼 line과 일치하는지 확인 필요. 시나리오: 환승역에서 origin auto-lock 발사 시 DebugModal Auto-lock Candidate 섹션의 `line`이 사용자가 서 있는 플랫폼 line과 일치(옆 line 열차 미선택).

## 테스트/검증
- `npm test`: 430 suites / 9161 tests pass, coverage 100%(lines/functions/branches/statements).
- `npm run type-check`: pass.
- `npm run lint:orphan`: pass.