### PR TITLE
fix(#2204): route-progress fire 권위 제거 + BG movement 가드 wire (ADR-026 ①잔여)

### DIFF
--- a/src/features/alarm/__tests__/replay_20260807_phantom.test.ts
+++ b/src/features/alarm/__tests__/replay_20260807_phantom.test.ts
@@ -1,6 +1,7 @@
 /**
  * 2026-08-07 07:38 KST 건대입구→뚝섬 phantom fire replay test — device side (Issue #2200,
- * ADR-026 #2199). TDD 선행 red fixture — 하위 fix 이슈(#2201/#2202/#2204)가 green으로 flip.
+ * ADR-026 #2199). TDD 선행 red fixture였음 — #2204가 movement gate를 BG 채널(stationPipeline)에
+ * 연결해 green으로 flip.
  *
  * ## 재현 대상 (오늘 실기기 dump evidence — fixtures/replay_20260807_phantom.ts 참고)
  * 07:38:19 GPS 22.1m/s automotive 스파이크 1개 후 급감(정지)했는데도 07:38:21
@@ -8,19 +9,15 @@
  *
  * ## RCA
  * `stationPipeline.processLocationUpdate` (BG 채널)는 `movementGate.ts`의 `evaluateMovement`/
- * `isStaticSpeedSignal`을 전혀 import하지 않는다. `useStationAlarm.ts`(FG 채널)만 이 gate로
- * 'movement-static-speed'/'movement-motion-stationary' suppress를 적용하며, 오늘 dump에서도 fg는
+ * `isStaticSpeedSignal`을 전혀 import하지 않았다. `useStationAlarm.ts`(FG 채널)만 이 gate로
+ * 'movement-static-speed'/'movement-motion-stationary' suppress를 적용해, 오늘 dump에서도 fg는
  * 반복 suppressed되는 반면 bg는 무방비로 fired — evidence L177~250 `fg | suppressed |
  * movement-static-speed / movement-motion-stationary` vs L252 `bg | fired`.
  *
- * ## Assert (수리 후 기대치, 지금 red)
- * 정지(GPS speed=0 + accel stationary) 상태에서 destination-early 발사 시도 → fire=0 기대
- * (현재 fire=1). `it.failing`으로 감싸 CI green 유지 — 이슈 fix가 movement gate를 BG 채널에
- * 연결하면 이 assertion이 통과하게 되고, 그 시점에 `it.failing`을 `it`로 교체한다.
- *
- * ## 금지
- * production 코드 수정 없음(테스트+fixture만). 아래 stationPipeline.test.ts의 mock 패턴을
- * 최소 subset으로 재사용해 격리.
+ * ## Fix (#2204)
+ * stationPipeline.processLocationUpdate가 이제 `evaluateMovement`를 speedMps 단독 입력으로
+ * 호출해 destination/transfer phase-fire와 station-passed 발사 직전에 게이팅한다(FG와 동등).
+ * 정지(GPS speed=0) 상태에서 destination-early 발사 시도 → fire=0 (green).
  */
 
 import type { Station, NearestStationResult } from '../../../shared/types/station';
@@ -107,6 +104,7 @@ const mockLogSuppressedCrossCategoryDedup = jest.fn();
 const mockLogSuppressedCrossCategoryRecent = jest.fn();
 const mockLogSuppressedPhaseToPhaseDedup = jest.fn();
 const mockLogSuppressedChannelAgnosticDedup = jest.fn();
+const mockLogSuppressedMovement = jest.fn();
 jest.mock('../utils/alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
   logFiredStationPassed: (...args: unknown[]) => mockLogFiredStationPassed(...args),
@@ -117,6 +115,7 @@ jest.mock('../utils/alarmLog', () => ({
   logSuppressedSleepStationPassed: (...args: unknown[]) =>
     mockLogSuppressedSleepStationPassed(...args),
   logSuppressedDismissSilence: (...args: unknown[]) => mockLogSuppressedDismissSilence(...args),
+  logSuppressedMovement: (...args: unknown[]) => mockLogSuppressedMovement(...args),
   logSuppressedCrossCategoryDedup: (...args: unknown[]) =>
     mockLogSuppressedCrossCategoryDedup(...args),
   logSuppressedCrossCategoryRecent: (...args: unknown[]) =>
@@ -161,11 +160,10 @@ describe('evidence 2026-08-07 07:38 device replay — 정지 상태 destination-
     mockEvaluateAlarmPhase.mockReturnValue(PHANTOM_ALARM_EVENT);
   });
 
-  it('오늘 evidence 재현 — BG 채널은 movement 신호와 무관하게 fire (회귀 확인)', async () => {
-    // evidence: 07:39:56 이후 GPS speed=0.0m/s(정지 확정) 구간 + accel pattern=stationary.
-    // processLocationUpdate는 movementGate.ts를 참조하지 않으므로 speedMps=0(정지)을 넣어도
-    // evaluateAlarmPhase 결과(destination/early)가 그대로 fire까지 통과한다 — 오늘 evidence의
-    // "bg fired destination early 뚝섬" (dump L252) 재현.
+  // #2204 — 수리 후 기대치. 정지(GPS speed=0) 상태에서는 movement gate가 destination-early
+  // fire를 차단한다. (구) `it.failing` red 테스트를 여기 green으로 교체 — "BG는 movement 신호와
+  // 무관하게 fire"라는 회귀 재현 테스트는 fix로 더 이상 참이 아니므로 제거.
+  it('정지(GPS speed=0) 상태에서 destination-early fire=0 (뚝섬 phantom fire 회귀 차단)', async () => {
     await processLocationUpdate({
       lat: PHANTOM_NEAREST_STATION.lat,
       lng: PHANTOM_NEAREST_STATION.lng,
@@ -176,26 +174,6 @@ describe('evidence 2026-08-07 07:38 device replay — 정지 상태 destination-
       speedMps: PHANTOM_STATIONARY_SPEED_MPS,
     });
 
-    expect(mockLogFiredAlarm).toHaveBeenCalledWith('bg', PHANTOM_ALARM_EVENT);
-  });
-
-  // Flip in #2201/#2202/#2204 — stationPipeline.processLocationUpdate가 movementGate.ts
-  // (evaluateMovement/isStaticSpeedSignal)를 참조해 정지 상태에서 destination-early fire를
-  // 차단하면, 아래 assertion이 통과하며 이 테스트를 `it.failing` → `it`로 교체한다.
-  it.failing('수리 후 기대치 — 정지(GPS speed=0 + accel stationary) 상태에서 destination-early fire=0', async () => {
-    await processLocationUpdate({
-      lat: PHANTOM_NEAREST_STATION.lat,
-      lng: PHANTOM_NEAREST_STATION.lng,
-      destination: PHANTOM_DESTINATION,
-      firedAlarms: new Set(),
-      sleepMode: false,
-      source: 'bg',
-      speedMps: PHANTOM_STATIONARY_SPEED_MPS,
-    });
-
-    // 수리 후: 정지 상태에서는 movement gate가 fire를 차단해 logFiredAlarm이 호출되지 않아야 한다.
-    // 현재(red): BG 채널에 movement gate가 없어 이 assertion이 실패한다(logFiredAlarm 호출됨) —
-    // it.failing이 그 실패를 삼켜 CI green 유지.
     expect(mockLogFiredAlarm).not.toHaveBeenCalled();
   });
 });

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -82,6 +82,7 @@ import { useAlarmEventStore } from '../store/useAlarmEventStore';
 import { createLogger } from '../../../shared/utils/logger';
 import { isAccuracyAcceptable } from '../../nearest-station/utils/locationGates';
 import type { FusionConfidence, FusionSource } from '../../../shared/types/fusion';
+import { isStrongFusionSource } from '../../../shared/constants/fusionSourceStrength';
 import { isSimpleArchEnabled } from '../../../shared/config/archFlag';
 import { fireFgAuxStationPassedNotification } from '../utils/stationNotification';
 
@@ -584,6 +585,13 @@ export function useStationAlarm({
   estimatorIsTimeIntegration = false,
   currentHopStrategy = null,
 }: UseStationAlarmInputs): void {
+  // #2204 — 직전 GPS 샘플의 speedMps. evaluateMovement의 단일샘플 속도 plausibility 가드 입력.
+  // useEffect([speedMps])에서 렌더 완료 후 갱신되므로 runMovementGate 호출 시점엔 항상 "직전" 값.
+  const prevSpeedMpsRef = useRef<number | null>(null);
+  useEffect(() => {
+    prevSpeedMpsRef.current = speedMps ?? null;
+  }, [speedMps]);
+
   // #1405 — 동일 5-arg evaluateMovement 호출 helper. Phase ETA / API imminent / movementSuppressionReason
   // 3곳에서 같은 인자로 호출돼 SonarCloud CPD가 dup 검출. helper로 추출해 회피.
   // 매 render에 새 클로저지만, callback 내부에서만 호출되므로 reference 안정성 불필요.
@@ -597,6 +605,7 @@ export function useStationAlarm({
       positionStability,
       motionStationary,
       trainProgressing,
+      prevSpeedMpsRef.current,
     );
 
   const firedAlarmsRef = useRef<Set<string>>(new Set());
@@ -1060,9 +1069,18 @@ export function useStationAlarm({
     // fusion station이 GPS 실관측 station과 다를 수 있다. destination/transfer early는
     // fusion station 기반 ETA 계산을 사용하므로, GPS station과 mismatch인 상황에서 조기 fire를
     // 차단한다. Day 1 evidence: fu=마장 gp=왕십리 → 왕십리 대기 중 마장 destination early false fire.
-    // 실관측(boarding-lock / backend-ssot / position-train / wifi-ssid / fused / route-progress)
+    // 실관측(boarding-lock / backend-ssot / position-train / wifi-ssid / fused)
     // 기반 advance만 phase fire 허용 — #1813과 동일 원칙의 phase alarm 확장.
-    if (estimatorIsTimeIntegration) {
+    //
+    // #2204 (ADR-026 ①잔여 적대적 검증 HOLE) — estimator 전략(#1817)만 보는 게이트는 fusion
+    // source가 route-progress/gps(추정, GPS 좌표 기반)인데 estimator strategy는 시간 적분이
+    // 아닌 조합을 놓친다. `fusionSource`(호출자가 전달한 이번 cycle의 실제 판정 source) 기준으로
+    // 게이팅 — source가 명시 전달되면 그 강/약 판정이 estimator 전략보다 우선(SSOT). route-progress
+    // 화이트리스트 제거: route-progress는 이제 약(추정) source로 분류돼 phase fire 차단 대상.
+    // fusionSource 미전달(레거시 호출자/테스트)이면 estimatorIsTimeIntegration으로 graceful fallback.
+    const phaseGateBlockedByWeakSource =
+      fusionSource !== undefined ? !isStrongFusionSource(fusionSource) : estimatorIsTimeIntegration;
+    if (phaseGateBlockedByWeakSource) {
       logSuppressedPhaseGate('gate-phase-time-integration', destination.name);
       return;
     }
@@ -1173,6 +1191,8 @@ export function useStationAlarm({
     arrivalConfidence,
     // #1817 — 시간 적분 → 실관측 전환 시(estimatorIsTimeIntegration false→true→false) 즉시 재평가.
     estimatorIsTimeIntegration,
+    // #2204 — fusionSource 전환(약→강/강→약) 시 즉시 재평가.
+    fusionSource,
   ]);
 
   // #396: 도착정보 API 신호로 imminent 발사.

--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -80,6 +80,7 @@ const mockLogSuppressedCrossCategoryDedup = jest.fn();
 const mockLogSuppressedCrossCategoryRecent = jest.fn();
 const mockLogSuppressedPhaseToPhaseDedup = jest.fn();
 const mockLogSuppressedChannelAgnosticDedup = jest.fn();
+const mockLogSuppressedMovement = jest.fn();
 jest.mock('../alarmLog', () => ({
   logFiredAlarm: (...args: unknown[]) => mockLogFiredAlarm(...args),
   logFiredStationPassed: (...args: unknown[]) => mockLogFiredStationPassed(...args),
@@ -90,6 +91,7 @@ jest.mock('../alarmLog', () => ({
   logSuppressedSleepStationPassed: (...args: unknown[]) =>
     mockLogSuppressedSleepStationPassed(...args),
   logSuppressedDismissSilence: (...args: unknown[]) => mockLogSuppressedDismissSilence(...args),
+  logSuppressedMovement: (...args: unknown[]) => mockLogSuppressedMovement(...args),
   logSuppressedCrossCategoryDedup: (...args: unknown[]) =>
     mockLogSuppressedCrossCategoryDedup(...args),
   logSuppressedCrossCategoryRecent: (...args: unknown[]) =>

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -145,6 +145,9 @@ export type AlarmLogReason =
   | 'movement-static-position'
   | 'movement-motion-stationary'
   | 'movement-motion-warmup'
+  // #2204 — 직전 샘플 대비 비현실적 순간 속도 점프(예: 22.1m/s 단일 스파이크) 단독으로는
+  // "이동 확정" license를 주지 않는다. prevSpeedMps를 전달하는 호출자(FG)에서만 평가.
+  | 'movement-implausible-speed-spike'
   // #750 — 공통 sleep 룰 게이트(shouldSuppressBySleepRule)가 차단한 발사.
   // scheduler/FG/BG 3개 path 어디서든 같은 reason으로 적재 — 정책 단일 출처.
   | 'sleep-first-transfer'

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -23,10 +23,12 @@ import {
   logSuppressedDedupAlarm,
   logSuppressedDedupStation,
   logSuppressedDismissSilence,
+  logSuppressedMovement,
   logSuppressedSleepFirstTransfer,
   logSuppressedSleepStationPassed,
   type AlarmLogSource,
 } from './alarmLog';
+import { evaluateMovement, MOVEMENT_TO_ALARM_LOG_REASON } from '../../nearest-station/utils/movementGate';
 import {
   isAnyChannelRecentlyFired,
   isStationRecentlyFired,
@@ -244,6 +246,16 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   const distanceToDestM = distanceMetersBetween(lat, lng, destination.lat, destination.lng);
   const etaSeconds = estimateEtaSeconds(distanceToDestM, speedMps);
 
+  // #2204 (ADR-026 ①잔여, 적대적 검증 HOLE 대응) — BG 채널 movement 가드 누락 수정.
+  // FG(`useStationAlarm`/evaluateMovement)는 정적 misfire 가드(movement-static-speed /
+  // movement-motion-stationary 등)를 destination/transfer/station-passed 발사 전에 적용하지만,
+  // 이 파일(BG 채널 SSOT)은 movementGate.ts를 전혀 참조하지 않아 무가드로 발사했다 —
+  // 2026-08-07 07:38:21 `bg | fired | destination | early | 뚝섬` phantom fire evidence
+  // (같은 구간 fg는 movement-static-speed로 반복 suppressed).
+  // BG는 accuracyM/positionStability/motionStationary/trainProgressing/prevSpeedMps를
+  // 이 함수 입력으로 갖지 않으므로 speedMps 단독으로만 평가(graceful — 미제공 신호는 자동 skip).
+  const movementSignal = evaluateMovement({ speedMps: speedMps ?? undefined });
+
   // #707: BoardingLock 활성 시 currentLine을 lock.boardingLine으로 강등.
   // BG path는 fusion이 없어 nearest.station.line(raw GPS 최근접)이 환승역에서 옆 노선으로
   // 잘못 잡힐 수 있다. 사용자가 명시 탭한 lock.boardingLine을 source of truth로 신뢰 —
@@ -306,7 +318,17 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
       sleepMode,
       isFirstHop,
     });
-    if (suppressBySleep) {
+    if (!movementSignal.reliable) {
+      // #2204 — FG와 동일 정적 misfire 가드. destination/transfer early가 정적 사용자에게
+      // 발사되던 phantom fire(뚝섬 evidence)를 차단.
+      logSuppressedMovement({
+        source,
+        stationName: alarmEvent.stationName,
+        kind: alarmEvent.type,
+        phaseId: alarmEvent.phaseId,
+        reason: MOVEMENT_TO_ALARM_LOG_REASON[movementSignal.reason],
+      });
+    } else if (suppressBySleep) {
       logSuppressedSleepFirstTransfer({
         source,
         stationName: alarmEvent.stationName,
@@ -409,7 +431,15 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
     // dedup(lastNotifiedStationId) 위에 위치 — sleep으로 차단되면 lastNotifiedStationId 갱신 안 함
     // → sleep OFF 토글 후 정상 첫 hop 알림이 재발사 가능.
     // Sleep rule 단일 gate (ADR-023). transfer/station-passed 첫 hop만 suppress. destination은 항상 fire.
-    if (
+    if (!movementSignal.reliable) {
+      // #2204 — FG와 동일 정적 misfire 가드. 정적 사용자에게 station-passed가 발사되던 회귀 차단.
+      logSuppressedMovement({
+        source,
+        stationName: nearest.station.name,
+        kind: 'station-passed',
+        reason: MOVEMENT_TO_ALARM_LOG_REASON[movementSignal.reason],
+      });
+    } else if (
       shouldSuppressBySleepRule({
         lock: lockForLineGuard,
         event: { type: 'station-passed', stationName: nearest.station.name },

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.test.ts
@@ -6,7 +6,7 @@
  *
  * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
  */
-import { renderHook } from '@testing-library/react-native';
+import { act, renderHook } from '@testing-library/react-native';
 import {
   useFusedNearestStation,
   pickArrivalForStationName,
@@ -214,13 +214,22 @@ describe('useFusedNearestStation', () => {
       { station: MOCK_STATIONS.yeouinaru, distanceKm: 0.5 },
     ]);
 
-    // 후보 0,1,2 순서대로 useArrivalInfo 호출됨
+    // 후보 0,1,2 순서대로 useArrivalInfo 호출됨. 같은 station(청무로)이 연속 2 cycle ARRIVED를
+    // 관측해야 #2204 temporal consensus가 'arrival-confirmed'로 확정한다 — 4개 mockReturnValueOnce는
+    // 렌더 1회차 + rerender 2회차 각각의 a0/a1/a2 호출을 순서대로 채운다.
     mockUseArrival
+      .mockReturnValueOnce(arrivalRet({ up: [info(ARRIVAL_CODE.RUNNING)], down: [] }))
+      .mockReturnValueOnce(arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }))
+      .mockReturnValueOnce(arrivalRet(null))
       .mockReturnValueOnce(arrivalRet({ up: [info(ARRIVAL_CODE.RUNNING)], down: [] }))
       .mockReturnValueOnce(arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }))
       .mockReturnValueOnce(arrivalRet(null));
 
-    const { result } = renderHook(() => useFusedNearestStation());
+    const { result, rerender } = renderHook(() => useFusedNearestStation());
+    expect(result.current.confidence).toBe('arrival-arriving');
+    act(() => {
+      rerender({});
+    });
 
     expect(result.current.result?.station.id).toBe(MOCK_STATIONS.chungmuro.id);
     expect(result.current.confidence).toBe('arrival-confirmed');
@@ -379,12 +388,19 @@ describe('useFusedNearestStation', () => {
       // arrival만 있는 케이스 — boarding-lock은 position-train 채택 전제
       mockUseNearest.mockReturnValue(gpsBase());
       mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
-      mockUseArrival.mockReturnValue(arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }));
+      // #2204 — mockImplementation으로 매 호출 새 객체 반환. temporal consensus가 연속 2 cycle
+      // 같은 station의 ARRIVED를 요구하므로 rerender로 두 번째 cycle을 재현한다.
+      mockUseArrival.mockImplementation(() =>
+        arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }),
+      );
       mockUsePositions.mockReturnValue(positionRet(null));
 
-      const { result } = renderHook(() =>
+      const { result, rerender } = renderHook(() =>
         useFusedNearestStation(undefined, undefined, undefined, 'T-LOCKED'),
       );
+      act(() => {
+        rerender({});
+      });
       expect(result.current.confidence).toBe('arrival-confirmed');
       expect(result.current.source).toBe('arrival');
     });
@@ -536,10 +552,17 @@ describe('useFusedNearestStation', () => {
     mockUseNearest.mockReturnValue(gpsBase());
     mockFindTop.mockReturnValue([{ station: MOCK_STATIONS.gangnam, distanceKm: 0.1 }]);
 
-    mockUseArrival.mockReturnValue(arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }));
+    // #2204 — mockImplementation으로 매 호출 새 객체 반환. temporal consensus가 연속 2 cycle
+    // 같은 station의 ARRIVED를 요구하므로 rerender로 두 번째 cycle을 재현한다.
+    mockUseArrival.mockImplementation(() =>
+      arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }),
+    );
     mockUsePositions.mockReturnValue(positionRet(null));
 
-    const { result } = renderHook(() => useFusedNearestStation());
+    const { result, rerender } = renderHook(() => useFusedNearestStation());
+    act(() => {
+      rerender({});
+    });
     expect(result.current.confidence).toBe('arrival-confirmed');
     expect(result.current.source).toBe('arrival');
   });
@@ -1594,8 +1617,15 @@ describe('useFusedNearestStation', () => {
 
     it('subsurface=true이지만 confidence가 arrival-confirmed면 강등하지 않음', () => {
       // arrival-confirmed는 자체 검증 신호 — 기압계로 강등하지 않는다.
-      mockUseArrival.mockReturnValue(arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }));
-      const { result } = renderWithSub(true);
+      // #2204 — mockImplementation으로 매 호출 새 객체 반환. temporal consensus가 연속 2 cycle
+      // 같은 station의 ARRIVED를 요구하므로 rerender로 두 번째 cycle을 재현한다.
+      mockUseArrival.mockImplementation(() =>
+        arrivalRet({ up: [info(ARRIVAL_CODE.ARRIVED)], down: [] }),
+      );
+      const { result, rerender } = renderWithSub(true);
+      act(() => {
+        rerender({});
+      });
       expect(result.current.confidence).toBe('arrival-confirmed');
     });
   });

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -34,6 +34,7 @@ import { findTopNearestStations } from '../utils/findNearestStation';
 import { findActiveLines } from '../../route/utils/findActiveLines';
 import { pickFusedStation, type FusionConfidence, type FusionSource } from '../utils/pickFusedStation';
 import { shouldDowngradeFusion } from '../utils/movementGate';
+import { isStrongFusionSource } from '../../../shared/constants/fusionSourceStrength';
 import type { PositionStability } from '../utils/positionStaticDetector';
 import { pickCandidateTrains, type CandidateTrain } from '../../arrival/utils/pickCandidateTrains';
 import { trackTrainProgress } from '../../route/utils/trackTrainProgress';
@@ -648,6 +649,11 @@ export function useFusedNearestStation(
   const p1 = useTrainPositions(l1, positionProvider);
   const p2 = useTrainPositions(l2, positionProvider);
 
+  // #2204 — arrival-confirmed temporal consensus 추적. 직전 cycle의 highPriorityStationId를
+  // 다음 cycle의 pickFusedStation 호출에 그대로 전달 — 연속 2 cycle 합의가 있어야 확정.
+  // useEffect([fused])에서 렌더 완료 후 갱신되므로 이 memo 실행 시점엔 항상 "직전" 값.
+  const prevHighPriorityStationIdRef = useRef<string | null>(null);
+
   const fused = useMemo(() => {
     if (candidates.length === 0) return null;
     const arrivals = [a0.arrival, a1.arrival, a2.arrival];
@@ -658,8 +664,13 @@ export function useFusedNearestStation(
         arrival: arrivals[i] ?? null,
         positionMatches: matchPositionsForCandidate(cand, positions),
       })),
+      prevHighPriorityStationIdRef.current,
     );
   }, [candidates, a0.arrival, a1.arrival, a2.arrival, p0.positions, p1.positions, p2.positions]);
+
+  useEffect(() => {
+    prevHighPriorityStationIdRef.current = fused?.highPriorityStationId ?? null;
+  }, [fused]);
 
   // Phase 1C: Position-first fusion.
   // 후보 trainNo들(pickCandidateTrains) → trackTrainProgress로 단일 trainNo·현재역 결정.
@@ -1828,8 +1839,15 @@ export function useFusedNearestStation(
   // #1808 — 시간 적분 strategy(lockless-route-hop / default-hop / reanchored-hop) 활성 시
   // trainProgressing=false 강제. 실측 신호 없이 시간 적분만 active일 때 GPS 좌표 jitter로
   // arc idx가 advance하면 trainProgressing=true가 되어 motion-stationary 가드가 우회 →
-  // ADR-014 §4 위반(fire path 진입). 실관측(boarding-lock / backend-ssot / position-train /
-  // wifi-ssid / fused / route-progress) 기반 advance만 trainProgressing=true 허용.
+  // ADR-014 §4 위반(fire path 진입).
+  //
+  // #2204 (ADR-026 ①잔여 적대적 검증 HOLE) — estimator 전략(#1808)만 보는 게이트는 fusion
+  // `source`가 route-progress/gps(추정)인데 estimator strategy가 시간 적분이 아닌 조합(예:
+  // hop 추정은 live-position이지만 station fix 자체는 cascade weak-tier fallback)을 놓친다.
+  // 실제 이번 cycle의 station fix에 쓰인 신호인 `source`로 직접 게이팅 — estimator 전략보다
+  // SSOT. route-progress 화이트리스트 제거: route-progress는 GPS 좌표 기반 1D 추정일 뿐 실관측이
+  // 아니므로 더 이상 trainProgressing=true를 허용하는 강 신호 목록에 없다. 실관측(boarding-lock /
+  // backend-ssot / position-train / wifi-ssid / position / arrival) 기반 advance만 허용.
   const currentResultArcIdx =
     result != null && arcStations.length > 0
       ? arcIndexOfStation(arcStations, result.station)
@@ -1837,7 +1855,7 @@ export function useFusedNearestStation(
   const prevArcIdxRef = useRef<number>(-1);
   const prevArcKeyForProgressRef = useRef<string | null>(null);
   const trainProgressing =
-    !estimatorIsTimeIntegration &&
+    isStrongFusionSource(source) &&
     arcStations.length > 0 &&
     arcKey === prevArcKeyForProgressRef.current &&
     prevArcIdxRef.current !== -1 &&

--- a/src/features/nearest-station/utils/__tests__/movementGate.test.ts
+++ b/src/features/nearest-station/utils/__tests__/movementGate.test.ts
@@ -344,6 +344,54 @@ describe('movementGate', () => {
     });
   });
 
+  describe('#2204 — 단일샘플 속도 plausibility 가드 (isImplausibleSpeedSpike)', () => {
+    it('직전 정적(0) → 이번 22.1m/s 스파이크(evidence) → reliable=false implausible-speed-spike', () => {
+      const m = evaluateMovement(
+        { speedMps: 22.1 },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        0,
+      );
+      expect(m.reliable).toBe(false);
+      if (!m.reliable) expect(m.reason).toBe('implausible-speed-spike');
+    });
+
+    it('prevSpeedMps 미제공(undefined) → 가드 skip (기존 동작 유지, graceful)', () => {
+      const m = evaluateMovement({ speedMps: 22.1 }, undefined, undefined, undefined, undefined, undefined);
+      expect(m.reliable).toBe(true);
+    });
+
+    it('직전 speed가 이미 이동 중(정적 아님)이면 큰 점프도 스파이크로 보지 않음', () => {
+      const m = evaluateMovement({ speedMps: 30 }, undefined, undefined, undefined, undefined, 10);
+      expect(m.reliable).toBe(true);
+    });
+
+    it('점프가 임계값(IMPLAUSIBLE_SPEED_JUMP_MPS=15) 미달이면 스파이크 아님', () => {
+      const m = evaluateMovement({ speedMps: 14.9 }, undefined, undefined, undefined, undefined, 0);
+      expect(m.reliable).toBe(true);
+    });
+
+    it('trainProgressing=true여도 스파이크 가드는 우회 불가 (stale/low-accuracy와 동급)', () => {
+      const m = evaluateMovement(
+        { speedMps: 22.1 },
+        undefined,
+        undefined,
+        undefined,
+        true,
+        0,
+      );
+      expect(m.reliable).toBe(false);
+      if (!m.reliable) expect(m.reason).toBe('implausible-speed-spike');
+    });
+
+    it('speedMps 미측정(null)이면 스파이크 판정 skip', () => {
+      const m = evaluateMovement({}, undefined, undefined, undefined, undefined, 0);
+      expect(m.reliable).toBe(true);
+    });
+  });
+
   describe('#733 — evaluateMovement positionStability fallback', () => {
     it('speed 없음 + positionStability=static이면 reliable=false reason=static-position', () => {
       const m = evaluateMovement({ accuracyM: 50 }, undefined, 'static');

--- a/src/features/nearest-station/utils/__tests__/pickFusionTier.test.ts
+++ b/src/features/nearest-station/utils/__tests__/pickFusionTier.test.ts
@@ -42,6 +42,8 @@ function makeFused(
     result: makeResult(stationOverrides, distanceKm),
     confidence: 'arrival-confirmed',
     source: 'arrival',
+    // #2204 — temporal consensus 추적 필드. 이 테스트는 tier 선택 로직만 검증하므로 무관(null).
+    highPriorityStationId: null,
   };
 }
 

--- a/src/features/nearest-station/utils/movementGate.ts
+++ b/src/features/nearest-station/utils/movementGate.ts
@@ -88,7 +88,12 @@ export type MovementReason =
   // #1013 — fg-hydrate 직후 warmup window(~30s) 동안 motion 신호가 아직 초기화되지 않은 상태.
   // motionStationary=undefined + speedMps=null + positionStability='unknown' 동시 발생 시 신호 부재
   // 구간으로 차단. positionStability 60s 수집 또는 motion 초기화 완료 후 자연 해소.
-  | 'motion-warmup';
+  | 'motion-warmup'
+  // #2204 (ADR-026 ①잔여 적대적 검증 HOLE) — 직전 샘플이 정적(< STATIC_SPEED_THRESHOLD_MPS)이었는데
+  // 이번 샘플이 IMPLAUSIBLE_SPEED_JUMP_MPS 이상 급증한 단일 스파이크. 2026-08-07 07:38:19 GPS
+  // 22.1m/s automotive 스파이크 1개 후 급감(정지) evidence — 실제 이동이 아니라 GPS/센서 노이즈일
+  // 가능성이 높으므로 이 샘플 단독으로는 "이동 확정" 발사 license를 주지 않는다.
+  | 'implausible-speed-spike';
 
 interface MovementSignalShared {
   speedMps?: number;
@@ -146,7 +151,29 @@ export const MOVEMENT_TO_ALARM_LOG_REASON = {
   'static-position': 'movement-static-position',
   'motion-stationary': 'movement-motion-stationary',
   'motion-warmup': 'movement-motion-warmup',
+  'implausible-speed-spike': 'movement-implausible-speed-spike',
 } as const satisfies Record<MovementReason, string>;
+
+/**
+ * #2204 — 직전 샘플 대비 비현실적 속도 점프 임계값(m/s). 22.1 m/s 단일 스파이크 evidence 기준으로
+ * 정지(직전 샘플 < STATIC_SPEED_THRESHOLD_MPS) 상태에서 이 값 이상 급증하면 실제 이동이 아니라
+ * GPS/센서 노이즈로 간주한다. 도보/지하철 정상 가속으로는 GPS 폴링 간격 안에 이 정도 점프가
+ * 발생하지 않는다.
+ */
+export const IMPLAUSIBLE_SPEED_JUMP_MPS = 15;
+
+/**
+ * 단일샘플 속도 plausibility 판정 — 직전 샘플이 정적이었는데 이번 샘플이 비현실적으로 급증했는지.
+ * prevSpeedMps 미제공(undefined)이면 항상 false — 이력 없는 호출자는 기존 동작 유지(graceful).
+ */
+function isImplausibleSpeedSpike(
+  speedMps: number | null | undefined,
+  prevSpeedMps: number | null | undefined,
+): boolean {
+  if (speedMps == null || prevSpeedMps == null) return false;
+  if (prevSpeedMps >= STATIC_SPEED_THRESHOLD_MPS) return false;
+  return speedMps - prevSpeedMps >= IMPLAUSIBLE_SPEED_JUMP_MPS;
+}
 
 /**
  * fusion downgrade(#727)용 빠른 정지 판정.
@@ -276,18 +303,22 @@ export interface LocationSignalInput {
  *   1. loc === null → 'no-location'
  *   2. timestamp 있으면서 (now - timestamp) > STALE_AGE_MS → 'stale-timestamp'
  *   3. accuracyM 있으면서 > MAX_ACCURACY_M → 'low-accuracy'
- *   4. (#1401) trainProgressing === true → 정적 가드 3종(4·5·6) 우회. fusion arc advance가 확인되면
+ *   4. (#2204) prevSpeedMps 제공 + 직전 샘플이 정적이었는데 이번 샘플이 비현실적으로 급증
+ *      (IMPLAUSIBLE_SPEED_JUMP_MPS 이상) → 'implausible-speed-spike'. trainProgressing으로도
+ *      우회 불가 — 단일 스파이크 샘플 자체가 오염됐을 가능성이 높은 물리적 신뢰성 분기라
+ *      stale/low-accuracy와 동급으로 취급.
+ *   5. (#1401) trainProgressing === true → 정적 가드 3종(6·7·8) 우회. fusion arc advance가 확인되면
  *      device 모션/GPS speed 정적 신호는 noise로 간주.
- *   5. (#728) motionStationary === true → 'motion-stationary'
+ *   6. (#728) motionStationary === true → 'motion-stationary'
  *      - speed/position 신호보다 우선. 16:14:22 회귀(speed=0.69 임계 우회)와
  *        destination/transfer 카테고리 무방비를 동시 차단하는 핵심 신호.
- *   6. speedMps 있으면서 < STATIC_SPEED_THRESHOLD_MPS → 'static-speed'
- *   7. (#733) speedMps 없고 positionStability='static' → 'static-position'
- *   8. (#1013) motionStationary=undefined + speedMps=null + positionStability='unknown' → 'motion-warmup'
+ *   7. speedMps 있으면서 < STATIC_SPEED_THRESHOLD_MPS → 'static-speed'
+ *   8. (#733) speedMps 없고 positionStability='static' → 'static-position'
+ *   9. (#1013) motionStationary=undefined + speedMps=null + positionStability='unknown' → 'motion-warmup'
  *      - fg-hydrate 직후 warmup window. 모든 신호가 부재할 때 한시적 차단.
- *      - trainProgressing=true여도 평가 도달 X — 평가 순서상 (4)에서 정적 가드만 우회되고
+ *      - trainProgressing=true여도 평가 도달 X — 평가 순서상 (5)에서 정적 가드만 우회되고
  *        warmup은 신호 부재(GPS lock도 안 잡힘) 분기라 별도 유지.
- *   9. 그 외 → reliable=true
+ *   10. 그 외 → reliable=true
  *
  * 호출자는 결과의 reason으로 logSuppressedGate/logSilentPushSkipped 등 적재.
  */
@@ -310,6 +341,11 @@ export function evaluateMovement(
    * fusion advance와 무관한 GPS 자체 신뢰성 분기라 그대로 유지.
    */
   trainProgressing?: boolean,
+  /**
+   * #2204 — 직전 GPS 샘플의 speedMps. 단일샘플 속도 plausibility 가드(isImplausibleSpeedSpike)
+   * 입력. 미제공(undefined)이면 가드 skip — 이력을 추적하지 않는 호출자는 기존 동작 유지(graceful).
+   */
+  prevSpeedMps?: number | null,
 ): MovementSignal {
   // ADR-022 Phase 4-3 (#2005) — arrival API SSoT flag ON 시 motion gate 전면 bypass.
   // fire 판정을 backend arvlCd 로 단일화하므로 device motion / GPS speed / warmup 게이트가
@@ -329,6 +365,13 @@ export function evaluateMovement(
 
   if (loc.accuracyM != null && loc.accuracyM > MAX_ACCURACY_M) {
     return { reliable: false, reason: 'low-accuracy', accuracyM: loc.accuracyM };
+  }
+
+  // #2204 — 단일샘플 속도 plausibility 가드. stale/low-accuracy와 동급으로 trainProgressing 우회
+  // 대상 밖에 둔다 — 스파이크 샘플 자체가 오염됐을 가능성이 높아, arc advance(trainProgressing)가
+  // 같은 오염된 fusion 결과에서 파생됐어도 이 샘플로 발사 license를 주면 안 된다.
+  if (isImplausibleSpeedSpike(loc.speedMps, prevSpeedMps)) {
+    return { reliable: false, reason: 'implausible-speed-spike', speedMps: loc.speedMps };
   }
 
   // #1401 — 열차 진행 확정 시 device 정적 신호 우회. fusion advance가 device 모션/GPS speed보다

--- a/src/features/nearest-station/utils/pickFusedStation.ts
+++ b/src/features/nearest-station/utils/pickFusedStation.ts
@@ -17,6 +17,13 @@ export interface FusedStationResult {
   result: NearestStationResult;
   confidence: FusionConfidence;
   source: FusionSource;
+  /**
+   * #2204 — 이번 cycle의 winning priority가 ARRIVED 임계(100) 이상이었던 station id.
+   * `confidence`는 temporal consensus 결과(1회차 관측은 'arrival-arriving')라 원시 신호 판별에
+   * 쓸 수 없다 — 호출자가 다음 cycle의 `prevHighPriorityStationId`로 그대로 전달해 이력을 추적한다.
+   * priority<100(GPS-only 포함)이면 null.
+   */
+  highPriorityStationId: string | null;
 }
 
 export interface FusionCandidate {
@@ -62,9 +69,26 @@ function bestPriorityForPosition(
 /**
  * priority > 0 케이스만 호출됨 — gps-only(=priority 0)는 호출자가 early-return으로 처리.
  * 100점 이상은 ARRIVED(도착 확정) 신호, 그외는 진입/전역 신호로 분류.
+ *
+ * #2204 (ADR-026 ①잔여 적대적 검증 HOLE) — temporal consensus. 이전엔 단일 폴링에서
+ * priority>=100(arvlCd=1/ARRIVED)만 관측되면 즉시 'arrival-confirmed'로 확정했다. 단일 폴링은
+ * API/센서 순간 noise에 취약 — 최소 연속 2 cycle(직전 cycle에도 같은 station이 priority>=100)
+ * 관측돼야 확정한다.
+ *
+ * `prevHighPriorityStationId` 미제공(undefined)이면 이력을 추적하지 않는 호출자(기존 단위 테스트
+ * 등) — 기존 단일 폴링 즉시 확정 동작을 그대로 유지한다(backward compat, graceful).
+ * `null`로 명시 전달되면(호출자가 이력 추적 중, 직전 cycle엔 확정 후보 없음) 첫 관측은 아직
+ * 'arrival-arriving'만 반환 — 다음 cycle에 같은 station이 다시 priority>=100이면 확정된다.
  */
-function confidenceFromPriority(priority: number): FusionConfidence {
-  return priority >= 100 ? 'arrival-confirmed' : 'arrival-arriving';
+function confidenceFromPriority(
+  priority: number,
+  winnerStationId: string,
+  prevHighPriorityStationId: string | null | undefined,
+): FusionConfidence {
+  if (priority < 100) return 'arrival-arriving';
+  const consensusReached =
+    prevHighPriorityStationId === undefined || prevHighPriorityStationId === winnerStationId;
+  return consensusReached ? 'arrival-confirmed' : 'arrival-arriving';
 }
 
 /**
@@ -79,9 +103,14 @@ function confidenceFromPriority(priority: number): FusionConfidence {
  *    같은 점수라도 신호원이 다르면 정확도 순(position > arrival)으로 source 라벨 결정.
  * 4) 모두 0이면 GPS 최근접 사용.
  * 5) 후보가 비어있으면 null.
+ *
+ * @param prevHighPriorityStationId #2204 — temporal consensus 추적용. 호출자가 직전 cycle
+ *   결과의 `highPriorityStationId`를 그대로 넘기면 arrival-confirmed 확정에 연속 2 cycle 합의를
+ *   요구한다. 미제공(undefined)이면 기존 단일 폴링 즉시 확정 동작 유지(backward compat).
  */
 export function pickFusedStation(
   candidates: FusionCandidate[],
+  prevHighPriorityStationId?: string | null,
 ): FusedStationResult | null {
   if (candidates.length === 0) return null;
 
@@ -107,6 +136,7 @@ export function pickFusedStation(
       result: candidates[0].candidate,
       confidence: 'gps-only',
       source: 'gps',
+      highPriorityStationId: null,
     };
     logger.debug('decided', {
       tier: tierFor(fallback.source, fallback.confidence),
@@ -117,16 +147,23 @@ export function pickFusedStation(
     return fallback;
   }
 
+  const winnerStationId = candidates[winnerIdx].candidate.station.id;
+
   // R-10 (#1168): source 라벨을 explicit FUSION_TIER_PRIORITY로 결정.
   // 기존 `winnerPosScore >= winnerArrScore`와 동치(position이 arrival보다 상위 tier)지만,
   // SSOT를 단일 표(`fusionTierPriority.ts`)로 두어 신호 추가/재배열 시 호출 사이트 수정 불필요.
-  const confidence = confidenceFromPriority(winnerPriority);
+  const confidence = confidenceFromPriority(
+    winnerPriority,
+    winnerStationId,
+    prevHighPriorityStationId,
+  );
   const source = pickHigherTrustSource(winnerPosScore, winnerArrScore, confidence);
 
   const decided: FusedStationResult = {
     result: candidates[winnerIdx].candidate,
     confidence,
     source,
+    highPriorityStationId: winnerPriority >= 100 ? winnerStationId : null,
   };
   logger.debug('decided', {
     tier: tierFor(decided.source, decided.confidence),

--- a/src/shared/constants/fusionSourceStrength.ts
+++ b/src/shared/constants/fusionSourceStrength.ts
@@ -1,0 +1,31 @@
+/**
+ * #2204 (ADR-026 ①잔여, 적대적 검증 HOLE 대응) — fusion "실관측 신호" 게이트.
+ *
+ * `fusionConfidenceStrength.ts`(#1541)와 같은 원칙을 `FusionSource`(신호 *출처*) 축에 적용한다.
+ * 실관측(강) source: backend-ssot / boarding-lock / boarding-lock-interp / position-train /
+ * position(station 단위 trainSttus 직접 매칭) / arrival(도착 API 매칭) / wifi-ssid — 모두 GPS
+ * 좌표 자체가 아닌 독립 신호(트랙 위치, 도착 API, SSID 매칭, 사용자 명시 의향)로 확정된 출처.
+ * 약(추정) source: gps(거리 기반 최근접) / route-progress(1D map matching 시간 적분) — 둘 다
+ * GPS 좌표만으로 산출되며 실측 검증이 없다.
+ *
+ * 이전 게이트(`useStationAlarm.ts` phase 게이트, `useFusedNearestStation.ts` trainProgressing)는
+ * `estimator 전략`(stationProgressEstimator.strategy가 시간 적분인지)으로 게이팅했다. 그런데
+ * fusion `source`가 route-progress/gps인데 estimator strategy는 시간 적분이 아닌 조합(예:
+ * live-position 실패 후 cascade가 route-progress로 fallback)이 가능해 estimator 전략만 보는
+ * 게이트는 이 조합을 놓친다 — 실제로 판정에 쓰인 신호(`source`)를 직접 보는 것이 SSOT.
+ */
+import type { FusionSource } from '../types/fusion';
+
+export const STRONG_FUSION_SOURCE: ReadonlySet<FusionSource> = new Set<FusionSource>([
+  'backend-ssot',
+  'boarding-lock',
+  'boarding-lock-interp',
+  'position-train',
+  'position',
+  'arrival',
+  'wifi-ssid',
+]);
+
+export function isStrongFusionSource(source: FusionSource | undefined | null): boolean {
+  return source != null && STRONG_FUSION_SOURCE.has(source);
+}


### PR DESCRIPTION
Closes #2204

## 배경
ADR-026 ①phantom device 잔여. #2200 fire red 머지됨. 적대적 검증 HOLE(estimator 전략 기반 게이팅의 빈틈, 단일샘플 속도 스파이크, 단일 폴링 즉시 arrival-confirmed, BG 채널 movement 가드 누락) 4건 대응.

## 변경
- **FusionSource → useStationAlarm phase 게이트 실사용**: `useStationAlarm.ts` phase 게이트(destination/transfer early fire 차단)를 `estimatorIsTimeIntegration`(estimator 전략) 대신 `fusionSource`(실제 판정에 쓰인 source)로 게이팅. `fusionSource` 미전달 시(레거시 테스트/호출자) 기존 `estimatorIsTimeIntegration` fallback — graceful.
- **trainProgressing 게이팅 source 전환**: `useFusedNearestStation.ts`의 `trainProgressing`을 `!estimatorIsTimeIntegration` 대신 `isStrongFusionSource(source)`로 게이팅. **route-progress 화이트리스트 제거** — route-progress는 GPS 좌표 기반 1D 추정일 뿐 실관측이 아니므로 더 이상 device 정적 신호 우회 license를 얻지 못함.
- **단일샘플 속도 plausibility 가드**: `movementGate.evaluateMovement`에 `prevSpeedMps` 파라미터 + `IMPLAUSIBLE_SPEED_JUMP_MPS`(15 m/s) 가드 추가. 직전 샘플이 정적인데 이번 샘플이 비현실적으로 급증(22.1m/s 스파이크 evidence)하면 `implausible-speed-spike`로 즉시 차단 — stale/low-accuracy와 동급으로 trainProgressing 우회 대상 밖에 배치(오염된 샘플 자체가 발사 license가 될 수 없음). FG(`useStationAlarm`)에 ref 기반으로 연결.
- **arrival-confirmed temporal consensus**: `pickFusedStation`의 `confidenceFromPriority`를 단일 폴링 즉시 확정에서 연속 2 cycle 합의로 재정의. `prevHighPriorityStationId` 미제공 시 기존 동작(backward compat) 유지 — `useFusedNearestStation`에서 ref로 실제 연결.
- **BG 채널 movement 가드 wire**: `stationPipeline.processLocationUpdate`가 `evaluateMovement`를 전혀 참조하지 않아 무가드로 발사하던 결함(2026-08-07 07:38:21 `bg | fired | destination | early | 뚝섬` phantom fire, 같은 구간 FG는 movement-static-speed로 반복 suppressed) 수정. destination/transfer phase-fire와 station-passed 발사 직전에 speedMps 기반 `evaluateMovement` 게이트를 FG와 동등하게 적용.
- `src/shared/constants/fusionSourceStrength.ts` 신설 — `STRONG_FUSION_SOURCE` SSOT(기존 `fusionConfidenceStrength.ts`와 동일 원칙을 source 축에 적용).

## Red → Green
`src/features/alarm/__tests__/replay_20260807_phantom.test.ts`의 `it.failing`(정지 상태 destination-early fire 차단 기대)을 `it`로 flip — green 확인. 현재 buggy 동작(BG가 movement 무관 fire)을 재현하던 첫 테스트는 fix로 더 이상 참이 아니므로 제거.

## 금지 준수
backend 코드 미변경(#2201 소관). rate-limit 미변경(#2195 소관). `stationPrescheduler` 미변경(#2202 소관).

## Wire-completion 5단
1. **Orphan**: `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard**: 신규 `movement-implausible-speed-spike` reason은 기존 `movement-*` 계열과 동일하게 alarmLog → DebugModal(Gates 탭)/`/admin/alarm-log-stats`에서 관측 가능. `gate-phase-time-integration`(기존 reason 문자열 유지, 트리거 조건만 source 기반으로 변경) 동일 경로. BG 채널 movement suppress는 `logSuppressedMovement(source='bg', ...)`로 alarmLog에 적재되어 기존 FG와 동일 dashboard에서 구분 가능.
3. **의존 PR**: #2199 (ADR-026), #2200 (fire red, 머지됨). N/A 추가 의존 없음.
4. **측정 plan**: 1주 production — (a) `alarm-log-stats`에서 `movement-implausible-speed-spike` / BG `movement-*` suppress count > 0 (게이트 작동 evidence), (b) 뚝섬류 destination-early bg phantom fire 재발 0건, (c) `arrival-confirmed` 단일 폴링 즉시 확정 케이스 감소(온셋 지연 1 cycle, 오탐 감소) 확인.
5. **Device verify: 필수.** 실기기 BG 구간에서 정지 상태로 목적지 근접 시 destination-early phantom fire 미발생 확인, 정상 이동 시 station-passed/phase 알람이 지연 없이 정상 발사되는지(과차단 회귀 없음) 확인 필요.

## 검증
- `npm test`: 430 suites / 9165 tests pass, coverage 100% (lines/branches/functions/statements).
- `npm run type-check`: pass.
- `npm run lint:orphan`: 0 orphan.