### PR TITLE
fix(#2203): safetyNet backstop을 outage-only + fire-time position 게이트로 정비

### DIFF
--- a/src/features/alarm/hooks/__tests__/useSafetyNetScheduler.test.ts
+++ b/src/features/alarm/hooks/__tests__/useSafetyNetScheduler.test.ts
@@ -21,6 +21,11 @@ jest.mock('../../utils/tripStartStorage', () => ({
   getTripStartedAt: (...args: unknown[]) => mockGetTripStartedAt(...args),
 }));
 
+const mockUseSilentPushHealthCheck = jest.fn();
+jest.mock('../useSilentPushHealthCheck', () => ({
+  useSilentPushHealthCheck: (...args: unknown[]) => mockUseSilentPushHealthCheck(...args),
+}));
+
 const mockErrorSpy = jest.fn();
 jest.mock('../../../../shared/utils/logger', () => ({
   createLogger: () => ({
@@ -44,6 +49,9 @@ describe('useSafetyNetScheduler', () => {
     mockGetTripStartedAt.mockResolvedValue(1_000_000);
     mockRegisterSafetyNetAlarms.mockResolvedValue({ scheduled: 1 });
     mockCancelAllSafetyNetAlarms.mockResolvedValue(undefined);
+    // #2203 — 기본값은 backend outage 확인(healthy=false)으로 둬서 기존 테스트들의
+    // "등록된다" 기대를 그대로 보존. outage-only 게이트 자체 테스트는 healthy:true를 명시.
+    mockUseSilentPushHealthCheck.mockReturnValue({ healthy: false, lastReceivedAt: null });
   });
 
   it('sleepMode=false면 등록하지 않는다', async () => {
@@ -97,6 +105,7 @@ describe('useSafetyNetScheduler', () => {
         route: ROUTE,
         destinationName: GANGNAM,
         startTime: 1_000_000,
+        outageConfirmed: true,
       });
     });
   });
@@ -312,5 +321,71 @@ describe('useSafetyNetScheduler', () => {
     // stale run(OTHER1)의 register completion이 늦게 도착해도 register 호출 수는 늘지 않는다.
     expect(mockRegisterSafetyNetAlarms).toHaveBeenCalledTimes(3);
     expect(mockErrorSpy).not.toHaveBeenCalled();
+  });
+
+  describe('#2203 — outage-only 무장 (ADR-026 Decision 3)', () => {
+    it('backend 정상(healthy=true)이면 무장하지 않는다', async () => {
+      mockUseSilentPushHealthCheck.mockReturnValue({ healthy: true, lastReceivedAt: Date.now() });
+      useSettingsStore.setState({ sleepMode: true });
+      renderHook(() => useSafetyNetScheduler({ route: ROUTE, destinationName: GANGNAM }));
+
+      await waitFor(() => expect(mockGetTripStartedAt).toHaveBeenCalled());
+      expect(mockRegisterSafetyNetAlarms).not.toHaveBeenCalled();
+      expect(mockCancelAllSafetyNetAlarms).not.toHaveBeenCalled();
+    });
+
+    it('outage 확인(healthy=false)이면 무장한다', async () => {
+      mockUseSilentPushHealthCheck.mockReturnValue({ healthy: false, lastReceivedAt: null });
+      useSettingsStore.setState({ sleepMode: true });
+      renderHook(() => useSafetyNetScheduler({ route: ROUTE, destinationName: GANGNAM }));
+
+      await waitFor(() =>
+        expect(mockRegisterSafetyNetAlarms).toHaveBeenCalledWith({
+          tripToken: TRIP_TOKEN,
+          route: ROUTE,
+          destinationName: GANGNAM,
+          startTime: 1_000_000,
+          outageConfirmed: true,
+        }),
+      );
+    });
+
+    it('outage로 armed된 상태에서 backend가 회복(healthy=true)되면 armed 예약을 cancel한다', async () => {
+      mockUseSilentPushHealthCheck.mockReturnValue({ healthy: false, lastReceivedAt: null });
+      useSettingsStore.setState({ sleepMode: true });
+      const { rerender } = renderHook(
+        ({ healthy }: { healthy: boolean }) => {
+          mockUseSilentPushHealthCheck.mockReturnValue({ healthy, lastReceivedAt: null });
+          return useSafetyNetScheduler({ route: ROUTE, destinationName: GANGNAM });
+        },
+        { initialProps: { healthy: false } },
+      );
+      await waitFor(() => expect(mockRegisterSafetyNetAlarms).toHaveBeenCalledTimes(1));
+
+      rerender({ healthy: true });
+
+      await waitFor(() => expect(mockCancelAllSafetyNetAlarms).toHaveBeenCalledWith(TRIP_TOKEN));
+      // backend가 정상으로 전환된 뒤에는 재등록하지 않는다.
+      expect(mockRegisterSafetyNetAlarms).toHaveBeenCalledTimes(1);
+    });
+
+    it('healthy=true(무장 없음) 상태에서 outage로 전환(healthy=false)되면 새로 무장한다', async () => {
+      useSettingsStore.setState({ sleepMode: true });
+      const { rerender } = renderHook(
+        ({ healthy }: { healthy: boolean }) => {
+          mockUseSilentPushHealthCheck.mockReturnValue({ healthy, lastReceivedAt: null });
+          return useSafetyNetScheduler({ route: ROUTE, destinationName: GANGNAM });
+        },
+        { initialProps: { healthy: true } },
+      );
+      await waitFor(() => expect(mockGetTripStartedAt).toHaveBeenCalled());
+      expect(mockRegisterSafetyNetAlarms).not.toHaveBeenCalled();
+
+      rerender({ healthy: false });
+
+      await waitFor(() => expect(mockRegisterSafetyNetAlarms).toHaveBeenCalledTimes(1));
+      // 이전에 무장된 적이 없으므로 cancel은 호출되지 않는다.
+      expect(mockCancelAllSafetyNetAlarms).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/features/alarm/hooks/useSafetyNetScheduler.ts
+++ b/src/features/alarm/hooks/useSafetyNetScheduler.ts
@@ -16,6 +16,7 @@ import {
 } from '../utils/safetyNetScheduler';
 import { getTripStartedAt } from '../utils/tripStartStorage';
 import { useSettingsStore } from '../../settings/store/useSettingsStore';
+import { useSilentPushHealthCheck } from './useSilentPushHealthCheck';
 import { createLogger } from '../../../shared/utils/logger';
 
 const logger = createLogger('useSafetyNetScheduler');
@@ -39,13 +40,19 @@ export interface UseSafetyNetSchedulerInputs {
  *   (ACTIVE_TRIP_KEY)이 아직 없어도(register race/실패) `deviceLocalTripId`로 fallback해
  *   armed — 안전망이 "backend outage 백업"이라는 목적상 backend 등록 성공 여부에 arming을
  *   종속시키면 정작 필요한 상황에 무력화된다. tripStart조차 없으면(trip 미시작) cancel-only.
- * - identity = `${tripToken}|${routeSig}|${destinationName}|sleep:${sleepMode}`. 이전과
- *   동일하면 no-op, 다르면 이전 등록을 cancel한 뒤 새로 등록한다.
+ * - identity = `${tripToken}|${routeSig}|${destinationName}|sleep:${sleepMode}|outage:${outageConfirmed}`.
+ *   이전과 동일하면 no-op, 다르면 이전 등록을 cancel한 뒤 새로 등록한다.
+ * - **#2203 (ADR-026 Decision 3) — outage-only 무장**: `useSilentPushHealthCheck`가 silent push
+ *   수신 이력으로 판정한 `healthy`의 반대(`outageConfirmed = !healthy`)를 매 identity에 포함한다.
+ *   backend가 정상(healthy=true)이면 무장하지 않는다(이중발사 방지, backend가 단일 emitter) —
+ *   `registerSafetyNetAlarms`를 호출하지 않고, 이전에 outage로 armed됐던 예약이 있으면 backend
+ *   회복 시 identity 변경으로 cancel된다. outage가 확인(healthy=false)되는 순간에만 실제 무장.
  * - 언마운트 시에는 cancel하지 않는다 — trip 종료는 `tripBoundCleanups`가 담당(#1924/#1525
  *   defensive cancel과 동일 소유 경계).
  */
 export function useSafetyNetScheduler({ route, destinationName }: UseSafetyNetSchedulerInputs): void {
   const sleepMode = useSettingsStore((s) => s.sleepMode);
+  const { healthy: silentPushHealthy } = useSilentPushHealthCheck();
   // 마지막으로 성공 등록(또는 명시적으로 cancel-only 처리)한 identity. null이면
   // "현재 큐에 안전망 알람 없음" 상태.
   const registeredIdentityRef = useRef<string | null>(null);
@@ -86,7 +93,9 @@ export function useSafetyNetScheduler({ route, destinationName }: UseSafetyNetSc
       // device-local id로 armed(자세한 내용은 deviceLocalTripId 문서 참고).
       const tripToken = backendTripToken ?? deviceLocalTripId(tripStart);
 
-      const nextIdentity = `${tripToken}|${nextIdentityBase}`;
+      // #2203 — backend 침묵이 확인됐을 때만(outageConfirmed) 실제로 무장한다.
+      const outageConfirmed = !silentPushHealthy;
+      const nextIdentity = `${tripToken}|${nextIdentityBase}|outage:${outageConfirmed}`;
       if (registeredIdentityRef.current === nextIdentity) return;
 
       if (registeredIdentityRef.current !== null && registeredTripTokenRef.current) {
@@ -94,11 +103,21 @@ export function useSafetyNetScheduler({ route, destinationName }: UseSafetyNetSc
       }
       if (myToken !== inFlightTokenRef.current) return;
 
+      if (!outageConfirmed) {
+        // backend 정상 수신 중 — 무장하지 않는다(이중발사 방지). identity만 마킹해 매
+        // effect마다 불필요한 재판정을 막고, backend가 outage로 전환되면 identity가 바뀌어
+        // 다음 run에서 무장한다.
+        registeredIdentityRef.current = nextIdentity;
+        registeredTripTokenRef.current = null;
+        return;
+      }
+
       const result = await registerSafetyNetAlarms({
         tripToken,
         route,
         destinationName,
         startTime: tripStart,
+        outageConfirmed: true,
       });
       if (myToken !== inFlightTokenRef.current) return;
       registeredIdentityRef.current = nextIdentity;
@@ -109,5 +128,5 @@ export function useSafetyNetScheduler({ route, destinationName }: UseSafetyNetSc
     run().catch((e: unknown) => {
       logger.error('safetyNetScheduler 전환 실패:', e);
     });
-  }, [route, destinationName, sleepMode]);
+  }, [route, destinationName, sleepMode, silentPushHealthy]);
 }

--- a/src/features/alarm/utils/__tests__/safetyNetScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/safetyNetScheduler.test.ts
@@ -143,6 +143,21 @@ describe('registerSafetyNetAlarms', () => {
       route: makeDirectRoute(1, '2'),
       destinationName: GANGNAM,
       startTime: START_TIME,
+      outageConfirmed: true,
+    });
+    expect(result).toEqual({ scheduled: 0 });
+    expect(mockedSchedule).not.toHaveBeenCalled();
+  });
+
+  it('#2203 — outageConfirmed=false면 backend 정상으로 간주해 무장하지 않는다', async () => {
+    const route = makeDirectRoute(5, '2');
+    const result = await registerSafetyNetAlarms({
+      tripToken: TRIP_TOKEN,
+      route,
+      destinationName: GANGNAM,
+      startTime: START_TIME,
+      now: START_TIME,
+      outageConfirmed: false,
     });
     expect(result).toEqual({ scheduled: 0 });
     expect(mockedSchedule).not.toHaveBeenCalled();
@@ -156,6 +171,7 @@ describe('registerSafetyNetAlarms', () => {
       destinationName: GANGNAM,
       startTime: START_TIME,
       now: START_TIME,
+      outageConfirmed: true,
     });
     expect(result.scheduled).toBe(1);
     // arrival = start+600_000, earlyLeadMs = 600_000/5=120_000, fire = arrival-lead+buffer
@@ -173,6 +189,7 @@ describe('registerSafetyNetAlarms', () => {
       destinationName: GANGNAM,
       startTime: START_TIME,
       now: START_TIME + 10_000_000,
+      outageConfirmed: true,
     });
     expect(result.scheduled).toBe(0);
     expect(mockedSchedule).not.toHaveBeenCalled();
@@ -192,6 +209,7 @@ describe('registerSafetyNetAlarms', () => {
       destinationName: SEOUL_STATION,
       startTime: START_TIME,
       now: START_TIME,
+      outageConfirmed: true,
     });
     const ids = scheduledIdentifiers();
     expect(ids).toContain(`alarm-${TRIP_TOKEN}-${GANGNAM}-transfer`);
@@ -206,6 +224,7 @@ describe('registerSafetyNetAlarms', () => {
       route,
       destinationName: GANGNAM,
       startTime: START_TIME,
+      outageConfirmed: true,
     });
     expect(mockedSchedule).toHaveBeenCalledTimes(1);
     spy.mockRestore();
@@ -222,6 +241,7 @@ describe('scheduleOne content — platform 분기', () => {
       destinationName: GANGNAM,
       startTime: START_TIME,
       now: START_TIME,
+      outageConfirmed: true,
     });
     const content = mockedSchedule.mock.calls[0][0].content as Record<string, unknown>;
     expect(content.channelId).toBe('station-alarm');
@@ -237,6 +257,7 @@ describe('scheduleOne content — platform 분기', () => {
       destinationName: GANGNAM,
       startTime: START_TIME,
       now: START_TIME,
+      outageConfirmed: true,
     });
     const content = mockedSchedule.mock.calls[0][0].content as Record<string, unknown>;
     expect(content.interruptionLevel).toBe('timeSensitive');

--- a/src/features/alarm/utils/safetyNetScheduler.ts
+++ b/src/features/alarm/utils/safetyNetScheduler.ts
@@ -9,8 +9,11 @@
  * visible push / sleep-alarm-companion이 먼저 도달하므로, 본 알람은 backend가 침묵했을 때만
  * 사용자에게 도달하는 최후 안전망이다.
  *
- * 정책 gate(sleepMode 확인 / trip 등록·해제)는 호출자(`useSafetyNetScheduler` 훅, `silentPushTask`)
- * 책임 — 본 모듈은 순수 예약/취소 메커니즘만 제공한다.
+ * 정책 gate(sleepMode 확인 / trip 등록·해제 / backend outage 확인)는 호출자(`useSafetyNetScheduler`
+ * 훅, `silentPushTask`) 책임 — 본 모듈은 순수 예약/취소 메커니즘만 제공한다. 다만 outage 확인
+ * 여부({@link RegisterSafetyNetParams.outageConfirmed})만은 {@link registerSafetyNetAlarms}가
+ * 직접 강제한다(#2203, ADR-026 Decision 3) — backend가 단일 emitter인 이상 "확인 안 됐으면
+ * 무장 안 함"이 호출자 실수로 깨지면 이중발사로 직결되므로 메커니즘 레벨 방어가 필요하다.
  *
  * **보존 하드닝** (2026-07-31 매트릭스):
  *   - 중복역 occurrenceIdx 정합 (#1193) — {@link withOccurrenceIndices}.
@@ -234,6 +237,16 @@ export interface RegisterSafetyNetParams {
   destinationName: string | null;
   /** 누적 ETA 기준점(trip 시작 시각, ms epoch). */
   startTime: number;
+  /**
+   * #2203 (ADR-026 Decision 3) — backend 침묵이 **확인됐을 때만** true. false(backend 정상
+   * 수신 중)면 본 함수는 무장하지 않고 즉시 `{ scheduled: 0 }`를 반환한다.
+   *
+   * 정상 시에도 매 trip마다 무조건 armed되면 backend(단일 emitter, ADR-026)와 safety-net이
+   * 같은 waypoint를 이중 발사할 위험이 생긴다 — outage 확인 여부를 호출자(`useSafetyNetScheduler`)가
+   * silent push 수신 이력으로 판정해 넘긴다(정책 gate는 호출자 책임 원칙, 모듈 헤더 참고). 본
+   * 함수는 그 판정을 신뢰해 "확인 안 됐으면 절대 무장 안 함"을 메커니즘으로 강제한다.
+   */
+  outageConfirmed: boolean;
   /** 현재 시각(ms epoch). past-time 가드용. 기본 Date.now(). */
   now?: number;
 }
@@ -245,11 +258,20 @@ export interface RegisterSafetyNetResult {
 /**
  * trip 등록 시점(sleepMode ON 확인은 호출자 책임) 호출 — destinationName까지 모든 waypoint에
  * 단일 안전망 알람을 예약한다. 과거 시각(`fireMs <= startTime` 또는 `<= now`)은 skip.
+ *
+ * #2203 — `outageConfirmed=false`(backend 정상 수신 중)면 waypoint 산출 자체를 skip하고
+ * `{ scheduled: 0 }`을 반환한다({@link RegisterSafetyNetParams.outageConfirmed} 참고).
  */
 export async function registerSafetyNetAlarms(
   params: RegisterSafetyNetParams,
 ): Promise<RegisterSafetyNetResult> {
-  const { tripToken, route, destinationName, startTime } = params;
+  const { tripToken, route, destinationName, startTime, outageConfirmed } = params;
+  if (!outageConfirmed) {
+    logger.info(
+      `arm skip: backend healthy(no confirmed outage) tripToken=${tripToken.slice(0, 8)}`,
+    );
+    return { scheduled: 0 };
+  }
   const nowMs = params.now ?? Date.now();
   const waypoints = withOccurrenceIndices(deriveSafetyNetWaypoints(route, destinationName));
   if (waypoints.length === 0) return { scheduled: 0 };


### PR DESCRIPTION
Closes #2203

## 요약
ADR-026 Decision 3 — `stationPrescheduler` 매역 사전예약 퇴역(#2202, 다음 단계) 전에 safetyNet이
유일 backstop이 되므로 견고화.

- `registerSafetyNetAlarms`에 `outageConfirmed` 필수 파라미터 추가. `false`(backend 정상 수신 중)면
  waypoint 산출 없이 즉시 `{ scheduled: 0 }` 반환 — backend 단일 emitter와 이중발사 방지를 메커니즘
  레벨에서 강제.
- `useSafetyNetScheduler`가 기존 `useSilentPushHealthCheck`의 `healthy`를 구독해
  `outageConfirmed = !healthy`를 identity(`...|outage:${outageConfirmed}`)에 포함. outage가
  확인되는 순간 무장하고, backend가 회복되면 armed 예약을 cancel한다.
- 발사 직전 position/arvlCd 재검증은 `scheduledAlarmReceiver.ts:272`의 기존
  `evaluatePositionMismatch`(#1704)가 safety-net 채널(`revalidateSafetyNetAlarm`)에 이미 적용돼
  있음을 확인 — ADR-026 문구의 "기존 게이트 재사용"과 일치, 별도 변경 불필요.

## 금지 준수
- backend emit 로직(`backend/alarm-worker`) 미변경.
- `stationPrescheduler` 미변경(퇴역은 #2202 소관).
- #2204가 건드린 fusion/stationAlarm 파일 미변경.

## Wire-completion 5단
1. **Orphan**: `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard**: safetyNet 발사/스킵 로그가 `SafetyNetScheduler` logger(`createLogger`)로
   남는다 — DebugModal에는 별도 패널 없음, 실기기 검증 시 Xcode console / wrangler tail 로 확인
   (`arm skip: backend healthy...` / `registered N safety-net alarms...`).
3. **의존 PR**: #2201(backend 단일 emitter), #2204(device route-progress) — 모두 머지됨(N/A 추가
   의존 없음).
4. **측정 plan**: (a) 정상 시나리오 — sleepMode ON + backend 정상 수신 중 1주간 safetyNet
   armed count 0건 확인(로그 grep `registered`), (b) outage 시나리오 — silent push 60s+ 미수신
   유도 후 safetyNet이 실제로 armed되는지 확인.
5. **Device verify**: **필요 — outage 재현 실탑승.** 취침모드 ON 상태에서 backend outage(예:
   비행기 모드 전환 또는 서버 측 지연 유도)를 재현해 (i) safetyNet이 outage 중에만 무장되는지,
   (ii) 발사 직전 position 게이트가 정지/미탑승 상태에서 오발사를 막는지, (iii) backend 회복 시
   armed 알람이 cancel되는지 확인.

## 검증
- `npm test` — 9171 tests pass, coverage 100% (lines/functions/branches/statements).
- `npm run type-check` — pass.
- `npm run lint:orphan` — 0 orphan.