### PR TITLE
refactor(#2196): rotation 잔재 정리 — guard/rotated sentinel/역인덱스 축소

### DIFF
--- a/backend/alarm-worker/src/__tests__/trips.test.ts
+++ b/backend/alarm-worker/src/__tests__/trips.test.ts
@@ -3,7 +3,6 @@ import { ARCH_FLAG_KV_KEY } from '../archFlag';
 import {
   __resetTripRegisterLocksForTest,
   cleanupPendingPushesForToken,
-  cleanupSupersededTrip,
   clearStaleBoardingLock,
   computeRouteSignature,
   dedupeTripsByDeviceToken,
@@ -22,7 +21,6 @@ import {
   withTripRegisterLock,
 } from '../trips';
 import { pendingKey, putPending, type PendingPush } from '../pendingPushes';
-import { readTripEndedStatus } from '../tripStatus';
 import type { Trip } from '../types';
 import { InMemoryKV } from './inMemoryKv';
 
@@ -735,98 +733,6 @@ describe('deviceToken → trip 역인덱스 (#2175)', () => {
       'device-trips:device-1',
       'trip-A',
       expect.objectContaining({ expirationTtl: 60 }),
-    );
-  });
-});
-
-// #2175 — 공유 orphan cleanup helper. POST /trips 핸들러의 superseded-by-reregister cleanup이
-// 사용한다.
-describe('cleanupSupersededTrip (#2175)', () => {
-  let kv: InMemoryKV;
-  beforeEach(() => {
-    kv = new InMemoryKV();
-  });
-
-  it('trip 삭제 + tripStatus sentinel 기록 + pending cleanup을 모두 수행한다', async () => {
-    const orphan = makeTrip({ token: 'orphan-1' });
-    await putTrip(kv as unknown as KVNamespace, orphan);
-    await putPending(kv as unknown as KVNamespace, {
-      pushId: 'p1',
-      token: 'orphan-1',
-      alarmKey: 'early:p1',
-      sentAt: Date.now(),
-      stationName: '강남',
-      kind: 'destination',
-      phase: 'early',
-      etaSeconds: 300,
-      apnsEnv: 'sandbox',
-    });
-    const now = Date.now();
-    await cleanupSupersededTrip(
-      kv as unknown as KVNamespace,
-      orphan,
-      'superseded-by-reregister',
-      now,
-    );
-    expect(await getTrip(kv as unknown as KVNamespace, 'orphan-1')).toBeNull();
-    expect(await kv.get(pendingKey('p1'))).toBeNull();
-    const status = await readTripEndedStatus(kv as unknown as KVNamespace, 'orphan-1');
-    expect(status?.endReason).toBe('superseded-by-reregister');
-    expect(status?.endedAt).toBe(now);
-  });
-
-  it('writeTripEndedStatus 실패해도 삭제는 진행된다 (best-effort)', async () => {
-    const orphan = makeTrip({ token: 'orphan-2' });
-    await putTrip(kv as unknown as KVNamespace, orphan);
-    const putSpy = vi.spyOn(kv, 'put').mockRejectedValueOnce(new Error('kv down'));
-    await cleanupSupersededTrip(
-      kv as unknown as KVNamespace,
-      orphan,
-      'superseded-by-reregister',
-      Date.now(),
-    );
-    putSpy.mockRestore();
-    expect(await getTrip(kv as unknown as KVNamespace, 'orphan-2')).toBeNull();
-  });
-
-  // 리뷰 P1 — deviceToken 역인덱스도 함께 정리돼야 orphan 종료 후 인덱스가 죽은 token을
-  // 계속 가리키지 않는다.
-  it('orphan.deviceToken이 있고 인덱스가 여전히 orphan.token을 가리키면 인덱스도 함께 삭제한다', async () => {
-    const orphan = makeTrip({ token: 'orphan-3', deviceToken: 'device-3' });
-    await putTrip(kv as unknown as KVNamespace, orphan);
-    await putDeviceTripIndex(
-      kv as unknown as KVNamespace,
-      'device-3',
-      'orphan-3',
-      Date.now() + 60 * 60 * 1000,
-    );
-    await cleanupSupersededTrip(
-      kv as unknown as KVNamespace,
-      orphan,
-      'rotated',
-      Date.now(),
-    );
-    expect(await getDeviceTripIndex(kv as unknown as KVNamespace, 'device-3')).toBeNull();
-  });
-
-  it('인덱스가 이미 다른(최신) token을 가리키면 지우지 않는다 (race guard)', async () => {
-    const orphan = makeTrip({ token: 'orphan-4', deviceToken: 'device-4' });
-    await putTrip(kv as unknown as KVNamespace, orphan);
-    // 다른 요청이 이미 새 trip으로 인덱스를 갱신한 상태를 시뮬레이션.
-    await putDeviceTripIndex(
-      kv as unknown as KVNamespace,
-      'device-4',
-      'newer-token',
-      Date.now() + 60 * 60 * 1000,
-    );
-    await cleanupSupersededTrip(
-      kv as unknown as KVNamespace,
-      orphan,
-      'rotated',
-      Date.now(),
-    );
-    expect(await getDeviceTripIndex(kv as unknown as KVNamespace, 'device-4')).toBe(
-      'newer-token',
     );
   });
 });

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -126,7 +126,6 @@ import {
   readBoardingPromptCounters,
 } from './boardingPromptCounterAccumulator';
 import {
-  cleanupSupersededTrip,
   getDeviceTripIndex,
   getTrip,
   putDeviceTripIndex,
@@ -709,20 +708,14 @@ app.post('/trips', async (c) => {
     // 원래 #1425 cooldown 목적(device race/자동 재시도 차단)과 충돌 없음 — outage false-end는
     // 사용자 명시 재등록이며, 같은 token의 device race가 아니다.
     //
-    // #2175 — 'rotated'/'superseded-by-reregister'도 같은 이유로 면제한다. ADR-022 B4 로테이션은
-    // `trip.token`(신원)만 UUID로 바꿀 뿐 device는 계속 실 deviceToken(=여기 incoming.token)으로
-    // 정상 재등록한다(#2174 comment 1) — 이건 device race/자동 재시도가 아니라 매 route 변경마다
-    // 발생하는 예상된 흐름이다. 면제하지 않으면 rotation이 스스로 남긴 'rotated' sentinel이 다음
-    // 실토큰 재-POST를 1시간 동안 400으로 차단해, 애초 이 이슈가 막으려는 "orphan 누적"보다 더
-    // 나쁜 "재등록 완전 차단" 회귀가 생긴다.
-    if (
-      recentlyEnded.endReason === 'seoul-outage' ||
-      recentlyEnded.endReason === 'rotated' ||
-      recentlyEnded.endReason === 'superseded-by-reregister'
-    ) {
+    // #2196 (ADR-025 cleanup) — 'rotated'/'superseded-by-reregister' 면제 분기는 rotation 폐기
+    // (#2194)로 두 사유의 발생부 자체가 사라져 제거했다. 남은 legacy KV 엔트리는
+    // `readTripEndedStatus`가 unknown value로 null 반환해 이 cooldown 블록 자체를 타지 않는다
+    // (아래 `if (recentlyEnded && ...)` 진입 전에 이미 걸러짐) — 별도 회귀 없이 동등하게 degrade.
+    if (recentlyEnded.endReason === 'seoul-outage') {
       console.log(
         JSON.stringify({
-          msg: 'trip-recently-ended: bypass cooldown (#1663/#2175)',
+          msg: 'trip-recently-ended: bypass cooldown (#1663)',
           tokenPrefix: tokenPrefix(incoming.token),
           endedAt: recentlyEnded.endedAt,
           endReason: recentlyEnded.endReason,
@@ -753,33 +746,26 @@ app.post('/trips', async (c) => {
   // 이 구간을 여전히 원본 incoming token 기준으로 직렬화 — 같은 device의 두 요청이 반드시 같은
   // 큐에서 대기해 read-reset-write 사이클이 겹치지 않게 한다.
   const registerLockToken = incoming.token;
-  const { trip, isSameSession, staleIndexedToken } = await withTripRegisterLock(
+  const { trip, isSameSession } = await withTripRegisterLock(
     registerLockToken,
     async () => {
       const directExisting = await getTrip(c.env.TRIPS, incoming.token);
 
-      // #2175 — deviceToken 역인덱스 fallback. ADR-022 B4 로테이션이 `trip.token`을 UUID로
-      // 교체하면 직접 키 조회(`trip:<incoming.token>`, incoming.token은 항상 실 deviceToken)는
-      // 더 이상 그 trip을 찾지 못한다(#2174 comment: device가 응답의 rotated UUID를 채택하지
-      // 않고 계속 실 deviceToken으로 재-POST). 직접 조회가 miss일 때만 역인덱스로 재발견 —
-      // 직접 조회가 이미 성공했으면(대부분의 등록) 역인덱스 조회를 건너뛰어 오버헤드가 없다.
-      const priorIndexedToken =
-        directExisting === null && incoming.deviceToken !== undefined
-          ? await getDeviceTripIndex(c.env.TRIPS, incoming.deviceToken)
-          : null;
-      const rawExisting =
-        directExisting ??
-        (priorIndexedToken !== null && priorIndexedToken !== incoming.token
-          ? await getTrip(c.env.TRIPS, priorIndexedToken)
-          : null);
-
+      // #2196 (ADR-025 cleanup) — deviceToken 역인덱스 register-time fallback을 제거했다.
+      // ADR-025(#2194) 하에서 `incoming.deviceToken`은 항상 `incoming.token`과 같은 값으로
+      // 고정되고(`validateTrip`), 역인덱스도 항상 자기 자신(같은 token)을 가리킨다(#2175 describe
+      // block, index.test.ts "ADR-025 이후 항상 자기 자신을 가리킴"). 즉 `directExisting===null`이면
+      // 역인덱스 조회도 구조적으로 같은 miss만 재확인할 뿐 — 로테이션이 있던 시절(trip.token이
+      // UUID로 갈라짐)에만 의미가 있던 트립-단위 소비자였다. 역인덱스 자체(쓰기 + GET/DELETE
+      // 핸들러의 legacy 조회)는 APNs token refresh 복구 용도로 그대로 존치한다(ADR-025 Consequences).
+      //
       // ADR-025 (#2194) — route 변경 시 in-place reset. trip 신원(`incoming.token`, 트립 수명
       // 동안 불변)은 유지한 채, route sig(`computeRouteSignature`)가 달라지면 구 route의 잔재
       // pending push만 제거(helper 내부 `cleanupPendingPushesForToken`)하고 downstream이
       // `existing=null`로 세션을 새로 취급(dedup/notification state 리셋)하도록 한다.
       //
-      // archFlag=off (default): helper 는 `{ existing: rawExisting, reset: false }` no-op 반환
-      // → 기존 동작 100% 유지 (Phase 1-3 dormant).
+      // archFlag=off (default): helper 는 `{ existing: directExisting, reset: false }` no-op
+      // 반환 → 기존 동작 100% 유지 (Phase 1-3 dormant).
       //
       // ADR-022 B4의 token rotation(`rotateTripTokenForNewRoute`, 새 UUID 발급 + `trip:<oldToken>`
       // delete)은 폐기됐다 — 신원 churn이 rate-limit/역인덱스/dedup 키 전체를 sync 대상으로 만들어
@@ -789,7 +775,7 @@ app.post('/trips', async (c) => {
       // 오늘 evidence(2026-07-03): 사용자 중곡→성수 trip 시작 시 이전 trip(중곡→용마산) 잔재
       // pending push 가 계속 발사돼 `08:37:25 bg fired station-passed 성수` 관측. route reset이
       // helper 의 `cleanupPendingPushesForToken` 을 실제 호출해 잔재 pending 제거.
-      const routeReset = await resetTripStateForNewRoute(c.env.TRIPS, incoming, rawExisting);
+      const routeReset = await resetTripStateForNewRoute(c.env.TRIPS, incoming, directExisting);
       if (routeReset.reset) {
         console.log(
           JSON.stringify({
@@ -908,47 +894,17 @@ app.post('/trips', async (c) => {
 
       await putTrip(c.env.TRIPS, trip);
 
-      // #2175 — deviceToken 역인덱스를 이번에 확정된 trip.token으로 갱신. 다음 등록(같은 route
-      // merge든 새 route rotation이든)이 이 값으로 직접 키 조회 miss를 해소한다. deviceToken이
-      // 없는(손상 payload) 경우는 기록하지 않는다 — index는 always-valid 64-hex 여부와 무관하게
-      // "등록 시점의 실 토큰"만 추적하면 되므로 `resolveTripDeviceToken`의 legacy fallback은
-      // 여기 적용하지 않는다.
+      // #2175 — deviceToken 역인덱스를 이번에 확정된 trip.token으로 갱신. ADR-025(#2194) 하에서
+      // 신원=deviceToken이라 이 값은 항상 trip.token 자기 자신을 가리키지만(#2196), APNs token
+      // refresh로 deviceToken 자체가 바뀌는 드문 이벤트를 GET/DELETE 핸들러가 복구할 수 있도록
+      // 역인덱스는 그대로 존치·갱신한다. deviceToken이 없는(손상 payload) 경우는 기록하지 않는다.
       if (trip.deviceToken !== undefined) {
         await putDeviceTripIndex(c.env.TRIPS, trip.deviceToken, trip.token, trip.expiresAt);
       }
 
-      // #2175 (P1-A #2184 리뷰) — 등록 성공 전 역인덱스가 가리키던 trip이 이번 확정 trip과
-      // 다르면(merge/rotation 모두 이미 그 trip을 채택하거나 정리했을 것이므로 정상 경로에선
-      // 이 시점에 이미 삭제돼 있다) 안전망으로 한 번 더 조회 후 잔존 시 정리한다. 스코프는
-      // 항상 같은 deviceToken(이 역인덱스 자체가 그 deviceToken 소유)이라 다른 device trip은
-      // 건드리지 않는다.
-      const staleIndexedToken =
-        priorIndexedToken !== null && priorIndexedToken !== trip.token ? priorIndexedToken : null;
-
-      return { trip, isSameSession, staleIndexedToken };
+      return { trip, isSameSession };
     },
   );
-
-  if (staleIndexedToken !== null) {
-    const staleTrip = await getTrip(c.env.TRIPS, staleIndexedToken);
-    if (staleTrip !== null) {
-      console.log(
-        JSON.stringify({
-          msg: 'trip-register: superseded orphan cleanup (#2175)',
-          deviceTokenPrefix: tokenPrefix(registerLockToken),
-          staleTokenPrefix: tokenPrefix(staleIndexedToken),
-          finalTokenPrefix: tokenPrefix(trip.token),
-        }),
-      );
-      await cleanupSupersededTrip(
-        c.env.TRIPS,
-        staleTrip,
-        'superseded-by-reregister',
-        Date.now(),
-        c.env.DB,
-      );
-    }
-  }
 
   // #2144 — register 성공(putTrip 완료) 후 같은 token의 옛 tripStatus 종료 마커를 정리한다.
   // 위 cooldown 판정(#1425 reject / #1663 seoul-outage bypass)이 이미 끝난 뒤라 cooldown 의미는
@@ -2235,10 +2191,10 @@ app.get('/trips/:tripToken/status', async (c) => {
   }
 
   // #2175 — device는 항상 실 deviceToken(=최초 등록 시 token)으로 조회한다(#2174 comment 1).
-  // 직접 키 조회가 miss여도 ADR-022 B4 로테이션으로 trip.token이 UUID로 바뀌었을 수 있다.
-  // deviceToken 역인덱스가 "현재 실제 trip.token"을 추적하므로 그 값으로 재조회해 2회차 이상
-  // 로테이션(oldToken이 이미 UUID)에서도 active/ended를 정확히 해소한다(#2174 comment 2 escape
-  // hatch, PR #2184 P1 완결 지점).
+  // #2196(ADR-025 cleanup) 이후 이 fallback은 legacy(로테이션 시절 UUID 신원) trip 잔재 흡수 +
+  // APNs token refresh로 deviceToken 자체가 바뀌는 드문 이벤트 복구 용도로만 존치한다.
+  // deviceToken 역인덱스가 "현재 실제 trip.token"을 추적하므로 그 값으로 재조회해 active/ended를
+  // 정확히 해소한다(#2174 comment 2 escape hatch, PR #2184 P1 완결 지점).
   const indexedToken = await getDeviceTripIndex(c.env.TRIPS, tripToken);
   if (indexedToken !== null && indexedToken !== tripToken) {
     const indexedTrip = await getTrip(c.env.TRIPS, indexedToken);
@@ -2283,8 +2239,8 @@ app.delete('/trips/:token', async (c) => {
   if (!token) return c.json({ error: 'missing_token' }, 400);
   const directExisting = await getTrip(c.env.TRIPS, token);
 
-  // 리뷰 P1 (#2186) — deviceToken 역인덱스 fallback. ADR-022 B4 로테이션 이후 device는 계속
-  // 실 deviceToken(=여기 token)으로 호출하지만 실제 trip은 rotated UUID 아래 살아있다
+  // 리뷰 P1 (#2186) — deviceToken 역인덱스 fallback. #2196(ADR-025 cleanup) 이후 이 fallback은
+  // legacy(로테이션 시절 UUID 신원) trip 잔재 흡수 + APNs token refresh 복구 용도로만 존치한다
   // (GET /trips/:token/status와 동일한 패턴, #2175 comment). 직접 키 조회가 miss일 때만
   // 역인덱스로 재발견 — 직접 조회가 성공하면(대부분) 역인덱스 조회를 건너뛴다. 재발견 못하면
   // (역인덱스도 없거나 이미 정리됨) 기존대로 idempotent 200 deleted:false.

--- a/backend/alarm-worker/src/tripStatus.ts
+++ b/backend/alarm-worker/src/tripStatus.ts
@@ -21,23 +21,17 @@ const TRIP_STATUS_PREFIX = 'tripStatus:';
 /**
  * 외부 응답에 노출하는 endReason — `destination-arrived` → `destination`로 축약 (contract).
  * `seoul-outage` (#1663) — Seoul API HTTP error로 인한 false-end. #1425 cooldown 면제 대상.
- * `rotated` (#2174 F2) — route sig 변경으로 token 로테이션되며 old trip이 폐기된 사유.
- *   실 deviceToken으로 GET /trips/:token/status를 조회하는 device가(#2174 comment 1: 로테이션 직후
- *   trip.token이 바뀌어도 device는 여전히 실 deviceToken으로 조회) 첫 로테이션 한정으로 이 사유를
- *   확인해 'ended'로 사망 인지할 수 있다 — 2회차 이상 로테이션(oldToken이 이미 UUID)의 완전한
- *   deviceToken 역인덱스 조회는 #2175가 `GET /trips/:token/status` 핸들러에 배선(trips.ts
- *   `getDeviceTripIndex`)해 완결한다.
- * `superseded-by-reregister` (#2175) — deviceToken 역인덱스로 발견한 같은 deviceToken의 다른
- *   active trip을 신규 등록 성공 시 정리한 사유.
+ *
+ * #2196 (ADR-025 cleanup) — 'rotated'(#2174)/'superseded-by-reregister'(#2175)는 rotation 폐기
+ * (#2194)로 발생부가 없어져 제거. 남은 legacy KV 엔트리(TTL 7일 내 자연 만료)는
+ * `readTripEndedStatus`가 unknown value로 처리해 null 반환 — "trip 미발견"과 동등하게 degrade된다.
  */
 export type TripStatusEndReason =
   | 'expired'
   | 'eta-missing'
   | 'seoul-outage'
   | 'destination'
-  | 'push-unrecoverable'
-  | 'rotated'
-  | 'superseded-by-reregister';
+  | 'push-unrecoverable';
 
 export interface TripStatusRecord {
   endedAt: number;
@@ -122,9 +116,7 @@ export async function readTripEndedStatus(
       parsed.endReason !== 'eta-missing' &&
       parsed.endReason !== 'seoul-outage' &&
       parsed.endReason !== 'destination' &&
-      parsed.endReason !== 'push-unrecoverable' &&
-      parsed.endReason !== 'rotated' &&
-      parsed.endReason !== 'superseded-by-reregister'
+      parsed.endReason !== 'push-unrecoverable'
     ) {
       return null;
     }

--- a/backend/alarm-worker/src/trips.ts
+++ b/backend/alarm-worker/src/trips.ts
@@ -1,14 +1,12 @@
 import { getArchFlag } from './archFlag';
 import { isValidApnsToken } from './apnsToken';
-import { recordTripMetrics } from './d1TripMetrics';
 import {
   assertCronCacheTtl,
   assertKvCacheTtl,
   CRON_READ_CACHE_TTL_SEC as SHARED_CRON_TTL,
 } from './kvConsistency';
 import { listPending, pendingKey } from './pendingPushes';
-import { writeTripEndedStatus } from './tripStatus';
-import type { Trip, TripEndedReason } from './types';
+import type { Trip } from './types';
 
 /**
  * KV CRUD for active trips.
@@ -129,12 +127,13 @@ export async function deleteTrip(kv: KVNamespace, token: string): Promise<void> 
 /**
  * #2175 — deviceToken → 현재 trip.token 역인덱스.
  *
- * ADR-022 B4 로테이션이 `trip.token`을 `crypto.randomUUID()`로 교체하면, `POST /trips`가
- * `getTrip(incoming.token)`(incoming.token은 항상 실 deviceToken — 클라는 응답의 rotated UUID를
- * 채택하지 않는다, #2174 코멘트)로 직전 로테이션의 UUID trip을 찾지 못해 매번 새 trip이 생성되고
- * old UUID trip은 orphan으로 남는다. 이 역인덱스가 "실 deviceToken이 가리키는 현재 trip.token"을
- * 별도 KV entry(`device-trips:<deviceToken>`)로 추적해, 직접 키 조회가 실패해도 로테이션된 trip을
- * 재발견할 수 있게 한다.
+ * #2196 (ADR-025 cleanup) — ADR-022 B4 로테이션(폐기, #2194) 시절엔 `trip.token`이
+ * `crypto.randomUUID()`로 갈라져 `POST /trips`의 직접 키 조회(`getTrip(incoming.token)`)가 로테이션된
+ * trip을 못 찾는 문제를 이 역인덱스가 해소했다. ADR-025 하에서 신원은 트립 수명 동안 불변(항상
+ * deviceToken 자신)이라 그 register-time 소비자는 제거됐다(index.ts POST /trips 핸들러 참고) —
+ * 역인덱스는 이제 **APNs token refresh 복구 용도로만** 존치한다: OS가 deviceToken 자체를 드물게
+ * 갈아치우는 이벤트에서 `GET /trips/:token/status`·`DELETE /trips/:token` 핸들러가 옛 식별자로도
+ * 살아있는 trip을 재발견하도록 한다.
  *
  * Key: `device-trips:<deviceToken>` (raw deviceToken을 그대로 키 접미사로 사용 — `trip:<token>`이
  * 이미 raw token을 KV 키로 사용하는 기존 정책과 동일. `hashTripToken`(FNV-1a 32bit)은 Sentry/D1
@@ -174,7 +173,7 @@ export async function deleteDeviceTripIndex(kv: KVNamespace, deviceToken: string
 /**
  * #2175 (리뷰 P1) — trip 삭제 시 그 trip이 소유한 deviceToken 역인덱스를 함께 정리한다.
  *
- * 모든 trip 종료 경로(`cleanupSupersededTrip`, `cleanupTripWithLa`)가 공유하는 단일 지점.
+ * trip 종료 경로(`cleanupTripWithLa`)가 공유하는 단일 지점.
  * `trip.deviceToken`이 없으면(legacy trip) no-op — 애초에 인덱스가 만들어지지 않았다.
  *
  * Race guard: 인덱스가 **지금도** 이 trip의 token을 가리킬 때만 삭제한다. 삭제 사이 다른 요청이
@@ -317,36 +316,6 @@ export async function resetTripStateForNewRoute(
   // 다른 route: 신원(token)은 그대로 유지, 구 route의 잔재 pending push만 제거.
   await cleanupPendingPushesForToken(kv, incoming.token);
   return { existing: null, reset: true };
-}
-
-/**
- * #2175 — 다른(superseded) trip의 관측 기록 + KV 정리 단일 지점.
- *
- * `POST /trips` 핸들러가 deviceToken 역인덱스로 발견한 orphan trip(같은 deviceToken의 다른 active
- * trip, `superseded-by-reregister`) 정리가 사용한다.
- * D1 기록(`recordTripMetrics`) → tripStatus sentinel(`writeTripEndedStatus`, best-effort) →
- * `trip:<token>` delete → `pending:*` 잔재 cleanup 순서로 동작한다. alert push는 발사하지 않는다
- * (관측 전용 — `cleanupTripWithLa`와 달리 사용자향 UX 신호 없음, 두 호출자 모두 device 관점에서는
- * "정상 재등록"이지 사용자에게 알릴 종료가 아니다).
- */
-export async function cleanupSupersededTrip(
-  kv: KVNamespace,
-  orphan: Trip,
-  reason: TripEndedReason,
-  now: number,
-  db?: D1Database,
-): Promise<void> {
-  await recordTripMetrics(db, orphan, reason, now);
-  try {
-    await writeTripEndedStatus(kv, orphan.token, reason, now);
-  } catch {
-    // best-effort — sentinel 기록 실패가 cleanup 자체를 막지 않는다.
-  }
-  await deleteTrip(kv, orphan.token);
-  await cleanupPendingPushesForToken(kv, orphan.token);
-  // 리뷰 P1 — orphan trip이 소유한 deviceToken 역인덱스도 함께 정리(현재도 orphan.token을
-  // 가리킬 때만, race guard는 `deleteDeviceTripIndexIfCurrent` 참고).
-  await deleteDeviceTripIndexIfCurrent(kv, orphan);
 }
 
 /**

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -438,17 +438,14 @@ export interface ReschedulePushPayload {
  *   - 'la-stale-backstop' (#1933) — LA push가 LA_STALE_AUTO_END_MS(5분) 이상 침묵 시 자동 종료
  *                       (Dynamic Island content-state freeze 차단). 외부 contract는 'expired'로
  *                       매핑 (backward-compat) — `toTripStatusEndReason`이 처리한다.
- *   - 'rotated' (#2174 F2) — `rotateTripTokenForNewRoute`가 route sig 변경으로 new UUID를 발급하며
- *                       old trip을 폐기한 사유. push-unrecoverable/user-delete와 구분되는 관측
- *                       전용 사유 — alert push는 발사하지 않는다(사용자 명시 route 변경 자체가
- *                       trip 전환의 정상 신호라 종료 알림 UX가 불필요).
- *   - 'superseded-by-reregister' (#2175) — deviceToken 역인덱스로 재발견한 같은 deviceToken의
- *                       다른 active trip을 신규 등록 성공 시 정리한 사유. `push-unrecoverable`
- *                       (APNs 영구 실패)과 구분되는 관측 전용 사유 — 이 경로도 'rotated'와 동일하게
- *                       alert push를 발사하지 않는다.
  *
  * 클라가 명시적으로 trip을 끝낸 경로(HTTP DELETE /trips/:token)는 발사 대상이 아님 —
  * 사용자가 destination을 clear하면 이미 클라이언트 store가 정리된 상태이기 때문.
+ *
+ * #2196 (ADR-025 cleanup) — 'rotated'(#2174)/'superseded-by-reregister'(#2175)는 rotation 폐기
+ * (#2194)로 발생부 자체가 사라져 제거했다. 두 값 모두 마지막 소비자(cooldown 면제 분기, register-time
+ * deviceToken 역인덱스 fallback)까지 함께 정리 — 남은 legacy KV 엔트리는 `readTripEndedStatus`가
+ * unknown value로 처리(null 반환)해 "trip 미발견"과 동등하게 degrade, 별도 회귀 없음.
  */
 export type TripEndedReason =
   | 'eta-missing'
@@ -456,9 +453,7 @@ export type TripEndedReason =
   | 'destination-arrived'
   | 'expired'
   | 'push-unrecoverable'
-  | 'la-stale-backstop'
-  | 'rotated'
-  | 'superseded-by-reregister';
+  | 'la-stale-backstop';
 
 /**
  * Trip ended alert push payload (#1337). server-side trip 자동 종료 시 발사되는 alert push의


### PR DESCRIPTION
Closes #2196

## 내용

ADR-025 Consequences 대로, 신원 안정화(#2194)가 orphan으로 만든 것만 surgical 제거.

- **`TOKEN_ROTATION_DISABLED` guard(#2173)**: 확인 결과 이미 #2194가 `rotateTripTokenForNewRoute` 자체를 `resetTripStateForNewRoute`로 대체하며 guard도 함께 제거됨 — 이번 PR에서 추가 조치 불필요(grep 0건 확인).
- **`rotated`/`superseded-by-reregister` end_reason**: 마지막 소비자(index.ts 쿨다운 면제 분기, register-time deviceToken 역인덱스 fallback)까지 확인 후 발생부 전체 제거 (`types.ts` `TripEndedReason`, `tripStatus.ts` `TripStatusEndReason`, `index.ts` 쿨다운 면제 체크). 남은 legacy KV 엔트리는 `readTripEndedStatus`가 unknown value로 처리해 null 반환 — "trip 미발견"과 동등하게 degrade, 별도 회귀 없음.
- **`device-trips:<deviceToken>` 역인덱스**: register-time(POST /trips)의 트립-단위 소비자만 제거. ADR-025(#2194) 하에서 `incoming.deviceToken`은 항상 `incoming.token`과 같은 값으로 고정되므로(`validateTrip`), 이 fallback은 `priorIndexedToken`이 non-null이면 항상 `incoming.token`과 동일해 조건이 구조적으로 항상 false — 실질적으로 no-op였음을 코드로 확인. 이 제거로 유일 호출자를 잃은 `cleanupSupersededTrip`도 함께 제거.
  - 역인덱스 자체(쓰기 + `GET /trips/:token/status`, `DELETE /trips/:token` 핸들러의 legacy 조회)는 **APNs token refresh 복구 + legacy KV 흡수 용도로 그대로 존치**.

## 존치 확인 (금지 사항 준수)

- `trip.deviceToken`(#2174) — 그대로 유지.
- `dedupeTripsByDeviceToken` cron 안전망(#2175) — legacy UUID trip + 신규 real-token trip이 같은 deviceToken으로 공존할 수 있는 마이그레이션 윈도우에 여전히 유효해 유지.
- legacy KV 호환 경로(UUID-신원 old 레코드 TTL 자연 만료 흡수) — 삭제하지 않음.

## Wire-completion

1. **Orphan 없음**: `npm run lint:orphan` — "No orphan exports detected." (frontend 변경 없음). backend는 스캔 범위 밖이나, 제거로 생긴 모든 backend import/export(`cleanupSupersededTrip`, `recordTripMetrics`/`writeTripEndedStatus` unused import 등)는 `tsc --noEmit`으로 확인 완료.
2. **V/X dashboard**: 코드 축소 diff. 런타임 로그 `trip-register: superseded orphan cleanup (#2175)`가 더 이상 발생하지 않음 — wrangler tail/Cloudflare Dashboard에서 확인 가능(발생 자체가 없어짐이 정상).
3. **의존 PR**: #2194, #2195 (모두 머지됨). N/A 이외 없음.
4. **측정 plan**: CI `Type Check & Test` pass. 실탑승 tail에서 `end_reason=rotated`/`superseded-by-reregister` 발생 0건(이미 #2194 이후 발생 안 함, 이번 PR은 코드 정리이므로 런타임 신호 변화 없음).
5. **Device verify**: N/A — 정적 + unit only.

## 검증

- `cd backend/alarm-worker && npm test` — 77 files / 2886 tests pass. coverage ratchet(stmts 97.28% / branch 96.31% / funcs 99.21% / lines 97.28%, floor 97/96/98/97) 통과.
- `cd backend/alarm-worker && npm run type-check` — clean.
- 루트 `npm run lint:orphan` — "No orphan exports detected."