### PR TITLE
fix(#2227): push_failures/backend_errors D1 write 무음 실패 관측 승격

### DIFF
--- a/backend/alarm-worker/src/__tests__/d1ErrorLog.test.ts
+++ b/backend/alarm-worker/src/__tests__/d1ErrorLog.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import { logBackendError } from '../d1ErrorLog';
+import { captureXEvent } from '../sentry';
+
+vi.mock('../sentry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../sentry')>();
+  return { ...actual, captureXEvent: vi.fn() };
+});
 
 function makeMockDb(): D1Database {
   const run = vi.fn().mockResolvedValue({ success: true });
@@ -46,5 +52,19 @@ describe('logBackendError (#1835)', () => {
     await expect(
       logBackendError(db, { endpoint: '/trips', errorType: 'Error' }),
     ).resolves.toBeUndefined();
+  });
+
+  it('D1 write 실패 시 무음이 아니라 captureXEvent로 관측 승격된다 (#2227)', async () => {
+    const run = vi.fn().mockRejectedValue(new Error('D1 write error'));
+    const bind = vi.fn().mockReturnValue({ run });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+
+    await logBackendError(db, { endpoint: '/trips', errorType: 'Error' });
+
+    expect(captureXEvent).toHaveBeenCalledWith(
+      'D1-write-failure',
+      expect.objectContaining({ table: 'backend_errors' }),
+    );
   });
 });

--- a/backend/alarm-worker/src/__tests__/pushFailureLog.test.ts
+++ b/backend/alarm-worker/src/__tests__/pushFailureLog.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import { computePushFailureMetrics, EMPTY_PUSH_FAILURE_METRICS, logPushFailure } from '../pushFailureLog';
+import { captureXEvent } from '../sentry';
+
+vi.mock('../sentry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../sentry')>();
+  return { ...actual, captureXEvent: vi.fn() };
+});
 
 const NOW = 1_700_000_000_000;
 
@@ -125,6 +131,17 @@ describe('logPushFailure (#2177)', () => {
     await expect(
       logPushFailure(dbFail, { token: 'tok', pushKind: 'destination', apnsStatus: 500 }),
     ).resolves.toBeUndefined();
+  });
+
+  it('D1 write 실패 시 무음이 아니라 captureXEvent로 관측 승격된다 (#2227)', async () => {
+    const { db: dbFail } = makeDb({ insertThrows: true });
+
+    await logPushFailure(dbFail, { token: 'tok', pushKind: 'destination', apnsStatus: 500 });
+
+    expect(captureXEvent).toHaveBeenCalledWith(
+      'D1-write-failure',
+      expect.objectContaining({ table: 'push_failures' }),
+    );
   });
 
   describe('rate-limit 가드 (#2177 리뷰 P1)', () => {

--- a/backend/alarm-worker/src/d1ErrorLog.ts
+++ b/backend/alarm-worker/src/d1ErrorLog.ts
@@ -5,7 +5,13 @@
  * `env.DB` 미바인딩 시 graceful no-op — 모든 caller는 `if (env.DB)` 분기 불필요.
  *
  * 오류 적재가 실패해도 cron/request 흐름을 차단하지 않는다 (try/catch로 swallow).
+ *
+ * #2227 — write 자체가 throw할 때는 `captureXEvent`(Sentry-only, D1 미의존)로 escalate한다.
+ * `sentry.ts`가 이 모듈의 `logBackendError`를 D1 sink로 사용하므로, write 실패 escalate에
+ * D1을 다시 타는 `captureBackendException`은 순환 재시도라 부적합 — Sentry-only 경로를 쓴다.
  */
+
+import { captureXEvent } from './sentry';
 
 export interface BackendErrorInput {
   endpoint: string;
@@ -42,5 +48,7 @@ export async function logBackendError(
       .run();
   } catch (e) {
     console.warn(JSON.stringify({ msg: 'd1ErrorLog write failed', err: String(e) }));
+    // #2227 — D1 write 무음 실패 관측 승격. D1 자체가 실패했으므로 Sentry-only 경로로 escalate.
+    captureXEvent('D1-write-failure', { table: 'backend_errors', err: String(e) });
   }
 }

--- a/backend/alarm-worker/src/pushFailureLog.ts
+++ b/backend/alarm-worker/src/pushFailureLog.ts
@@ -13,7 +13,7 @@
  * `env.DB` 미바인딩 시 graceful no-op. 적재 실패는 push 발사 흐름을 차단하지 않는다(swallow).
  */
 
-import { hashTripToken } from './sentry';
+import { captureXEvent, hashTripToken } from './sentry';
 import type { ApnsEnv } from './types';
 
 /**
@@ -90,6 +90,8 @@ export async function logPushFailure(
       .run();
   } catch (e) {
     console.warn(JSON.stringify({ msg: 'pushFailureLog write failed', err: String(e) }));
+    // #2227 — D1 write 무음 실패 관측 승격. D1 자체가 실패했으므로 Sentry-only 경로로 escalate.
+    captureXEvent('D1-write-failure', { table: 'push_failures', err: String(e) });
   }
 }
 

--- a/backend/alarm-worker/src/sentry.ts
+++ b/backend/alarm-worker/src/sentry.ts
@@ -34,7 +34,13 @@ export type BackendXEventName =
   | 'X4-spam-suppress'
   | 'X6-late-alarm'
   | 'X8-zombie-trip'
-  | 'X11-bg-scheduled-leak';
+  | 'X11-bg-scheduled-leak'
+  /**
+   * #2227 — push_failures/backend_errors D1 write 무음 실패 관측 승격.
+   * `pushFailureLog.ts` / `d1ErrorLog.ts`의 write catch block에서 사용. D1 write 자체가
+   * 실패한 상황이라 D1 sink(logBackendError)로는 escalate할 수 없어 Sentry-only.
+   */
+  | 'D1-write-failure';
 
 export type BackendXEventContext = Record<
   string,


### PR DESCRIPTION
## 배경
push_failures/backend_errors D1 write가 try/catch + `console.warn`만이라(`pushFailureLog.ts:91`, `d1ErrorLog.ts:43`) 스키마/권한 오류가 나도 **무음** — 어느 테이블이 안 써지는지 탐지 불가.

## 구현
- `logPushFailure`(`pushFailureLog.ts`) D1 INSERT throw catch에 `captureXEvent('D1-write-failure', { table: 'push_failures', err })` 추가.
- `logBackendError`(`d1ErrorLog.ts`) 동일 패턴으로 `captureXEvent('D1-write-failure', { table: 'backend_errors', err })` 추가.
- `sentry.ts`의 `BackendXEventName`에 `'D1-write-failure'` 신규 추가.
- 기존 `console.warn`은 유지(local/tail 가시성 보존) — Sentry escalate를 **더한** 것.

### 왜 captureXEvent(Sentry-only)인가
D1 write 자체가 throw한 상황이라, D1을 다시 쓰는 `captureBackendException`(D1 sink 포함)으로 escalate하면 같은 실패를 반복 시도하는 구조. `captureXEvent`는 Sentry-only(D1 미의존)라 이 상황에 안전.

## 금지 준수
push 발사/재시도 로직은 건드리지 않음(surgical). #2185 재배포는 다루지 않음(사용자 배포 액션).

## TDD
- `d1ErrorLog.test.ts`, `pushFailureLog.test.ts`에 "D1 write 실패 시 captureXEvent 호출" 케이스 추가 (red→green 확인).

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` 0건 확인.
2. **V/X dashboard** — Sentry(DSN 설정 시 실시간 alert) + `console.warn`(wrangler tail). `captureXEvent`는 기존 X1/X3/X4/X6/X8/X11과 동일 채널(Sentry `captureMessage`, tag `xEvent`).
3. **의존 PR** — N/A. #2185(token_hash 재배포)는 본 PR과 무관한 별건.
4. **측정 plan** — 다음 D1 write 실패(스키마/권한/quota 오류) 발생 시 Sentry에서 `D1-write-failure` 태그 이벤트 수신 여부로 확인. 발생 0건이면 측정 불가 상태 유지(정상 — 무음 실패가 없다는 뜻).
5. **Device verify** — N/A — type+unit only (백엔드 관측 코드).

## 검증
- `npm test` (backend/alarm-worker): 2888/2888 pass, coverage ratchet 통과 (exit 0).
- `npx tsc --noEmit` (backend/alarm-worker): pass.
- `npm run lint:orphan` (root): 0 orphan.

Closes #2227