### PR TITLE
fix(#2230): destination imminent 반복 발사 정지 — reschedule dedup + 짧은 backstop

### DIFF
--- a/backend/alarm-worker/src/__tests__/replay_20260807_storm.test.ts
+++ b/backend/alarm-worker/src/__tests__/replay_20260807_storm.test.ts
@@ -132,7 +132,7 @@ function makeFullEmptyStats(): ScheduledStats {
     boardingLockWaypointAdvanceBlocked: 0, transferDestinationGateBlocked: 0,
     vanishFallbackFired: 0, vanishReleaseFired: 0, vanishLocklessTakeover: 0,
     vanishFallbackMotionGateBlocked: 0,
-    cronJitterMs: 0, rescheduleBlockedMotion: 0, rescheduleFallbackNoSsot: 0,
+    cronJitterMs: 0, rescheduleBlockedMotion: 0, rescheduleFallbackNoSsot: 0, rescheduleDedupSkipped: 0, destinationBackstopForceEnded: 0,
     realtimePositionFetch: 0, selfPollCacheHit: 0, realtimePositionFetchError: 0,
     stationPollFetch: 0, stationPollCacheHit: 0, stationPollError: 0,
     staleLockFireSkipped: 0,

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -21,6 +21,7 @@ import {
   BACKEND_TRIP_LIFECYCLE_FORCE_END_MS,
   DESTINATION_GPS_CROSS_CHECK_MAX_M,
   DESTINATION_GPS_STALE_THRESHOLD_MS,
+  DESTINATION_REACH_BACKSTOP_MS,
   evaluateDestinationCrossCheck,
   recordDestinationCrossCheck,
   arvlCdFireKey,
@@ -55,6 +56,7 @@ import { ARVLCD_FIRE_ONCE_TTL_SEC, arvlCdFireOnceKey } from '../arvlcdFireOnceTt
 import { stampPushActivity, readPushActivityRecent } from '../cronIdleGate';
 import { JITTER_SAMPLE_EVERY_N_TICKS, readJitterSamples } from '../cronJitterAggregate';
 import { putTrip } from '../trips';
+import { pendingKey, putPending } from '../pendingPushes';
 import { readSsot, seedSsot, ssotKey, writeSsot, type TripPositionSSoT } from '../tripPositionSsot';
 import type { BoardingLockMeta, Env, PositionPoint, Trip, Waypoint } from '../types';
 import { InMemoryKV } from './inMemoryKv';
@@ -158,7 +160,7 @@ function makeFullEmptyStats(): ScheduledStats {
     boardingLockWaypointAdvanceBlocked: 0, transferDestinationGateBlocked: 0,
     vanishFallbackFired: 0, vanishReleaseFired: 0, vanishLocklessTakeover: 0,
     vanishFallbackMotionGateBlocked: 0,
-    cronJitterMs: 0, rescheduleBlockedMotion: 0, rescheduleFallbackNoSsot: 0,
+    cronJitterMs: 0, rescheduleBlockedMotion: 0, rescheduleFallbackNoSsot: 0, rescheduleDedupSkipped: 0, destinationBackstopForceEnded: 0,
     realtimePositionFetch: 0, selfPollCacheHit: 0, realtimePositionFetchError: 0,
     stationPollFetch: 0, stationPollCacheHit: 0, stationPollError: 0,
     staleLockFireSkipped: 0,
@@ -1291,6 +1293,49 @@ describe('runScheduled — boardingLock trainCode tracking (#585)', () => {
       generatePushId: () => 'p2',
     });
     expect(stats.pushed).toBe(1);
+  });
+
+  // #2230 — per-station once dedup. 같은 (token, station)이 여러 cron cycle에 걸쳐 delta ≥ 15s로
+  // 계속 드리프트해도(정상적인 ETA 관측 변동) 두 번째 이후 cycle은 발사되지 않아야 한다.
+  // 2026-08-09 실기기 dump: destination ETA가 매 60s cron마다 15s+ 드리프트해 6분간 6회 반복 발사.
+  it('does not fire reschedule push again for the same station across multiple cron cycles (#2230)', async () => {
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    // cycle 1 — 최초 발사 (baseline 없음).
+    const stats1 = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('중곡', 120)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'cyc1',
+    });
+    expect(stats1.pushed).toBe(1);
+    // cycle 2 — 같은 station(중곡)에 delta +30s (임계 15s 이상) 이지만 dedup TTL 내이므로 skip.
+    const stats2 = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('중곡', 150)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW + 60_000,
+      generatePushId: () => 'cyc2',
+    });
+    expect(stats2.pushed).toBe(0);
+    expect(stats2.rescheduleDedupSkipped).toBe(1);
+    // cycle 3 — 또 한 번, 여전히 TTL 내(dedup 지속).
+    const stats3 = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoulCombo([arrivalForLock('중곡', 180)], []),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW + 120_000,
+      generatePushId: () => 'cyc3',
+    });
+    expect(stats3.pushed).toBe(0);
+    expect(stats3.rescheduleDedupSkipped).toBe(1);
+    // 전체 3 cycle에 걸쳐 APNs reschedule push는 정확히 1회만 발사.
+    expect(apnsFetch).toHaveBeenCalledTimes(1);
   });
 
   it('falls back to realtimePosition when trainCode not in arrivals', async () => {
@@ -10100,7 +10145,7 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
       boardingLockWaypointAdvanceBlocked: 0, transferDestinationGateBlocked: 0,
       vanishFallbackFired: 0, vanishReleaseFired: 0, vanishLocklessTakeover: 0,
       vanishFallbackMotionGateBlocked: 0,
-      cronJitterMs: 0, rescheduleBlockedMotion: 0, rescheduleFallbackNoSsot: 0,
+      cronJitterMs: 0, rescheduleBlockedMotion: 0, rescheduleFallbackNoSsot: 0, rescheduleDedupSkipped: 0, destinationBackstopForceEnded: 0,
       realtimePositionFetch: 0, selfPollCacheHit: 0, realtimePositionFetchError: 0,
       // #1828 Phase 5 — station-level arrivals polling.
       stationPollFetch: 0, stationPollCacheHit: 0, stationPollError: 0,
@@ -10485,6 +10530,45 @@ describe('runScheduled — #1707 destination GPS cross-check integration', () =>
     expect(stats.destinationCrossCheck.gpsFar).toBe(0);
   });
 
+  // #2230 (follow-up B) — destination cleanup 시 잔여 PENDING_PUSHES entry도 정리돼야 한다.
+  // 그렇지 않으면 이미 죽은 trip에 대해 alert fallback cron이 무의미한 재발사를 시도할 수 있다.
+  it('clears PENDING_PUSHES entries for the device token on destination cleanup (#2230)', async () => {
+    const kv = new InMemoryKV();
+    const pending = new InMemoryKV();
+    const trip = makeHapjeongDestTrip('user-pending-cleanup-tok');
+    await putTrip(kv as unknown as KVNamespace, trip);
+    await kv.put(
+      `pos:${trip.token}`,
+      JSON.stringify([
+        { lat: 37.549, lng: 126.9138, accuracy: 10, ts: NOW - 10_000, motion: 'automotive' },
+      ]),
+    );
+    // 잔여 pending entry 시뮬레이션 — arvlCd fire/lockless intermediate 등이 남긴 것.
+    await putPending(pending as unknown as KVNamespace, {
+      pushId: 'stale-pending-1',
+      token: trip.token,
+      alarmKey: 'imminent:합정',
+      sentAt: NOW - 30_000,
+      stationName: '합정',
+      kind: 'destination',
+      phase: 'imminent',
+      etaSeconds: 0,
+      apnsEnv: 'sandbox',
+    });
+    expect(await pending.get(pendingKey('stale-pending-1'))).not.toBeNull();
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    await runScheduled(makeEnv(kv, pending), {
+      seoul: makeHapjeongArrivedSeoul(),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    // trip 삭제 + pending entry도 함께 삭제.
+    expect(await kv.get(`trip:${trip.token}`)).toBeNull();
+    expect(await pending.get(pendingKey('stale-pending-1'))).toBeNull();
+  });
+
   /**
    * Stale GPS (>5min) → conservative cleanup. backend가 device GPS에 종속되면 안 됨.
    */
@@ -10610,6 +10694,93 @@ describe('runScheduled — #1707 destination GPS cross-check integration', () =>
     // trip 보존 — KV에 잔존.
     expect(await kv.get(`trip:${trip.token}`)).not.toBeNull();
     expect(stats.destinationCrossCheck.gpsFar).toBe(1);
+  });
+
+  // #2230 — destination-reached 짧은 backstop. gps-far 보류가 무기한(9h force-end까지)
+  // 잔존하던 회귀(2026-08-09 실기기 dump)를 T분(DESTINATION_REACH_BACKSTOP_MS) 내로 단축한다.
+  describe('#2230 destination-reached short backstop (gps-far persisted)', () => {
+    /** 신촌 부근 GPS — 합정에서 ~1.3km, gps-far 트리거용. */
+    function seedFarGps(kv: InMemoryKV, token: string, ts: number) {
+      return kv.put(
+        `pos:${token}`,
+        JSON.stringify([
+          { lat: 37.5552, lng: 126.9368, accuracy: 15, ts, motion: 'automotive' },
+        ]),
+      );
+    }
+
+    it('does not force-cleanup before DESTINATION_REACH_BACKSTOP_MS elapses (first gps-far cycle stamps anchor only)', async () => {
+      const kv = new InMemoryKV();
+      const trip = makeHapjeongDestTrip('backstop-first-cycle-tok');
+      await putTrip(kv as unknown as KVNamespace, trip);
+      await seedFarGps(kv, trip.token, NOW - 30_000);
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeHapjeongArrivedSeoul(),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      // trip 보존 — anchor만 stamp, force-cleanup 미발동.
+      const stored = JSON.parse((await kv.get(`trip:${trip.token}`)) as string) as Trip;
+      expect(stored.destinationImminentFirstAt).toBe(NOW);
+      expect(stats.destinationBackstopForceEnded).toBe(0);
+    });
+
+    it('does not force-cleanup when elapsed since anchor is just under the threshold', async () => {
+      const kv = new InMemoryKV();
+      const anchorAt = NOW - (DESTINATION_REACH_BACKSTOP_MS - 1_000);
+      const trip = makeHapjeongDestTrip('backstop-under-tok');
+      trip.destinationImminentFirstAt = anchorAt;
+      await putTrip(kv as unknown as KVNamespace, trip);
+      await seedFarGps(kv, trip.token, NOW - 30_000);
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeHapjeongArrivedSeoul(),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      expect(await kv.get(`trip:${trip.token}`)).not.toBeNull();
+      expect(stats.destinationBackstopForceEnded).toBe(0);
+      // anchor 보존 — 재stamp되지 않아야 다음 cycle의 경과 시간 판단이 정확.
+      const stored = JSON.parse((await kv.get(`trip:${trip.token}`)) as string) as Trip;
+      expect(stored.destinationImminentFirstAt).toBe(anchorAt);
+    });
+
+    it('force-cleans up via cleanupTripWithLa once DESTINATION_REACH_BACKSTOP_MS elapses, even though gps-far persists', async () => {
+      const kv = new InMemoryKV();
+      const anchorAt = NOW - DESTINATION_REACH_BACKSTOP_MS;
+      const trip = makeHapjeongDestTrip('backstop-elapsed-tok');
+      trip.destinationImminentFirstAt = anchorAt;
+      await putTrip(kv as unknown as KVNamespace, trip);
+      await seedFarGps(kv, trip.token, NOW - 30_000);
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      const stats = await runScheduled(makeEnv(kv), {
+        seoul: makeHapjeongArrivedSeoul(),
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        now: () => NOW,
+      });
+      // trip 삭제됨 — gps-far cross-check 자체는 여전히 'gps-far'였지만 backstop이 강제 종료.
+      expect(await kv.get(`trip:${trip.token}`)).toBeNull();
+      expect(stats.destinationBackstopForceEnded).toBe(1);
+      expect(stats.destinationCrossCheck.gpsFar).toBe(1);
+      // cleanupTripWithLa('destination-arrived') 경로 — trip-ended push 발사 확인.
+      const calls = fetchImpl.mock.calls as unknown as [string, RequestInit][];
+      const tripEndedCalls = calls.filter((c) => {
+        try {
+          const body = JSON.parse(c[1]?.body as string) as { data?: { reason?: string } };
+          return body?.data?.reason === 'destination-arrived';
+        } catch {
+          return false;
+        }
+      });
+      expect(tripEndedCalls.length).toBeGreaterThan(0);
+    });
   });
 });
 

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -25,7 +25,12 @@ import { deleteProgress } from './progress';
 import { logPushFailure } from './pushFailureLog';
 import { computeMultiHopContext } from './tripMultiHop';
 import { deleteSsot } from './tripPositionSsot';
-import { deleteDeviceTripIndexIfCurrent, deleteTrip, resolveTripDeviceToken } from './trips';
+import {
+  cleanupPendingPushesForToken,
+  deleteDeviceTripIndexIfCurrent,
+  deleteTrip,
+  resolveTripDeviceToken,
+} from './trips';
 import type { ApnsEnv, Env, Trip, TripEndedReason, Waypoint } from './types';
 import { writeTripEndedStatus } from './tripStatus';
 
@@ -319,6 +324,20 @@ export async function cleanupTripWithLa(
   // #705 — trip을 폐기할 때 progress entry도 함께 제거. TTL이 자연 만료를 보장하지만
   // 즉시 cleanup해야 새 동일 token trip 등록 시 stale shiftedCount가 끼지 않는다.
   await deleteProgress(env.TRIPS, trip.token);
+  // #2230 — trip 종료 시 잔여 PENDING_PUSHES entry도 함께 정리. arvlCd fire/lockless intermediate
+  // push 등이 남긴 pending entry가 trip 삭제 후에도 KV에 잔존하면, 이미 죽은 trip에 대해 다음
+  // alert fallback cron이 무의미한 재발사를 시도할 수 있다(RCA #2230 follow-up B: destination
+  // cleanup 경로에서 PENDING_PUSHES 미정리). KV 미바인딩/실패는 graceful — cleanup 흐름 차단 X.
+  if (env.PENDING_PUSHES) {
+    try {
+      await cleanupPendingPushesForToken(env.PENDING_PUSHES, resolveTripDeviceToken(trip));
+    } catch (e) {
+      log('pending-pushes cleanup failed', {
+        token: trip.token.slice(0, 8),
+        error: String(e),
+      });
+    }
+  }
   // #1701 — SSoT mirror row(`ssot:<token>`)도 함께 제거. trip TTL(최대 9h+)이 자연 만료를
   // 보장하지만, 같은 token 새 trip 등록 시 lazy-seed가 `ssot === null` 조건이라 옛 SSoT가
   // 살아있으면 새 trip의 stationName이 아닌 옛 trip stationName이 그대로 device로 forward되어

--- a/backend/alarm-worker/src/rescheduleDedup.ts
+++ b/backend/alarm-worker/src/rescheduleDedup.ts
@@ -1,0 +1,46 @@
+/**
+ * #2230 — `maybeReschedulePush` per-station once dedup.
+ *
+ * 선결 조사 결론: #2202는 sleepMode OFF(매역 사전예약) 소비자만 퇴역시켰다. reschedule push의
+ * 나머지 소비자(`silentPushTask.applyReschedule` → sleepMode ON → `rescheduleSafetyNetAlarm`)는
+ * #2202 이후에도 실제로 안전망 알람을 재조정하므로 vestigial이 아니다 — reschedule push 자체를
+ * 제거하면 취침모드 안전망 정정 채널이 사라진다. 따라서 발사 경로는 보존하고 dedup만 보강한다.
+ *
+ * RCA(2026-08-09 실기기 dump): 기존 억제는 motion=stationary 게이트 + `lastTrackedArrivalEpoch`
+ * 15s 델타 임계뿐이었다. destination ETA가 매 cron(60s)마다 15s+ 드리프트하면 무한 반복
+ * 발사한다(불광 도착 후 15:57~16:03 6회). 같은 (tripToken, stationName) 조합은 TTL 동안 1회만
+ * 발사하도록 KV once-dedup을 추가한다.
+ *
+ * TTL은 `scheduled.ts`의 `POLLING_WINDOW_MS`(5분)와 같은 5분 값을 사용한다(독립 상수 — 두 값이
+ * 의미적으로 결합돼 있지는 않다). 그 안에서는 이미 한 번 정정 신호를 보냈으므로 추가 발사 가치가
+ * 낮고, 5분 밖에서는 여전히 ETA가 크게 벌어져 있다면 재발사를 허용한다.
+ */
+
+const RESCHEDULE_FIRE_PREFIX = 'reschedule-fire:';
+
+/** `scheduled.ts`의 `POLLING_WINDOW_MS`와 같은 5분(300s) — 별도 정의된 독립 상수. */
+export const RESCHEDULE_FIRE_DEDUP_TTL_SEC = 300;
+
+export function rescheduleFireKey(tripToken: string, stationName: string): string {
+  return `${RESCHEDULE_FIRE_PREFIX}${tripToken}|${stationName}`;
+}
+
+/** 같은 (tripToken, stationName)에 TTL 내 이미 reschedule push를 발사했는지 확인. */
+export async function hasRescheduleFired(
+  kv: KVNamespace,
+  tripToken: string,
+  stationName: string,
+): Promise<boolean> {
+  return (await kv.get(rescheduleFireKey(tripToken, stationName))) !== null;
+}
+
+/** 발사 직후 dedup marker stamp. */
+export async function markRescheduleFired(
+  kv: KVNamespace,
+  tripToken: string,
+  stationName: string,
+): Promise<void> {
+  await kv.put(rescheduleFireKey(tripToken, stationName), '1', {
+    expirationTtl: RESCHEDULE_FIRE_DEDUP_TTL_SEC,
+  });
+}

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -118,6 +118,7 @@ import {
   stampHeartbeat,
 } from './cronJitterAggregate';
 import { readPushActivityRecent, stampPushActivity } from './cronIdleGate';
+import { hasRescheduleFired, markRescheduleFired } from './rescheduleDedup';
 
 // pickApnsHost / flipApnsEnv는 ./apnsHost로 이동 (liveActivity.ts와 공유 SSOT, #482).
 // 외부(테스트 / index.ts 등)가 scheduled.ts 경유로 import하던 호환성 유지를 위해 re-export.
@@ -253,6 +254,19 @@ export const BACKEND_TRIP_LIFECYCLE_FORCE_END_MS = 9 * 60 * 60 * 1000;
  */
 export const DESTINATION_GPS_CROSS_CHECK_MAX_M = 500;
 export const DESTINATION_GPS_STALE_THRESHOLD_MS = 5 * 60 * 1000;
+
+/**
+ * #2230 — destination-reached 짧은 backstop.
+ *
+ * 배경: gps-far cross-check(#1707)가 destination advance를 무기한 보류하면(trip 보존 의도)
+ * `BACKEND_TRIP_LIFECYCLE_FORCE_END_MS`(9h)까지 trip이 잔존해 그 사이 매 cron 사이클
+ * destination imminent 평가가 반복된다(2026-08-09 실기기 dump). 9h force-end 자체는 다른
+ * 케이스(Seoul outage / lockless 정적 등)의 안전망이라 유지하되, destination 도달 신호가
+ * 최초 관측된 시각(`trip.destinationImminentFirstAt`) 기준 이 임계를 넘으면 gps-far 보류
+ * 상태라도 강제 cleanup한다. 9h보다 훨씬 짧게 — 15분(사용자가 실제 하차 후 GPS 갱신이
+ * 없거나 backend cross-check가 계속 어긋나는 경우를 위한 상한).
+ */
+export const DESTINATION_REACH_BACKSTOP_MS = 15 * 60 * 1000;
 
 /** #1707 destination GPS cross-check 결과. log/stats에 1:1로 매핑. */
 export type DestinationCrossCheckResult =
@@ -750,6 +764,13 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   rescheduleFallbackNoSsot: number;
   /**
+   * #2230 — `maybeReschedulePush` per-station once dedup으로 억제된 발사 누적 횟수.
+   * 같은 (token, station)에 TTL(5분) 내 이미 reschedule push를 발사한 경우 재발사를 skip한다.
+   * destination ETA가 매 cron마다 15s+ 드리프트해 60s마다 무한 반복 발사하던 회귀
+   * (2026-08-09 실기기 dump: 불광 도착 후 6분간 6회)를 닫는 카운터.
+   */
+  rescheduleDedupSkipped: number;
+  /**
    * #1614 Phase A (S4 #1537) — cron 진입부 self-poll realtimePosition fetch 횟수.
    * 활성 trip line union에 대해 Seoul API를 1회 호출(KV cache miss). 호선당 30s TTL.
    * positionTrainAgreement strongCB wire의 입력 단(端) 카운터.
@@ -859,6 +880,13 @@ export interface ScheduledStats extends LiveActivityStats {
     noGps: number;
     stationUnknown: number;
   };
+  /**
+   * #2230 — gps-far cross-check로 destination advance가 보류된 채 `DESTINATION_REACH_BACKSTOP_MS`
+   * (15분)를 초과해 강제 cleanup된 누적 횟수. 9h force-end(`lifecycleForceEnded`)보다 훨씬 짧은
+   * 시간 내에 발동하는 별도 카운터 — 정상 운영에서 0에 가까워야 한다(gps-far가 다음 cycle에
+   * 자연 해소되는 것이 정상 경로).
+   */
+  destinationBackstopForceEnded: number;
   /**
    * #2073 (Issue A) — 이번 tick에 pending/retry push entry가 존재할 가능성이 있는지.
    * `병합 listTrips 결과가 비어있음 AND 직전 tick 근방 fire/retry 기록 없음`일 때만 false —
@@ -1048,6 +1076,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     // #1559 (T6) — reschedule push motion 게이트 차단/fallback 누적.
     rescheduleBlockedMotion: 0,
     rescheduleFallbackNoSsot: 0,
+    // #2230 — reschedule push per-station once dedup 차단 누적.
+    rescheduleDedupSkipped: 0,
     // #1614 Phase A (S4) — backend self-poll realtimePosition stats.
     realtimePositionFetch: 0,
     selfPollCacheHit: 0,
@@ -1083,6 +1113,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       noGps: 0,
       stationUnknown: 0,
     },
+    // #2230 — gps-far 보류 destination advance의 짧은 backstop force-cleanup 누적.
+    destinationBackstopForceEnded: 0,
     // #2066 (Phase 2-backend) — 취침 알람(환승/도착 직전역) 발사/skip 카운터.
     sleepAlarmFired: 0,
     sleepAlarmDedupSkipped: 0,
@@ -3618,12 +3650,34 @@ export async function advanceBoardingLockWaypoint(
       result: crossCheck,
     });
     if (crossCheck === 'gps-far') {
+      // #2230 — destination 도달이 최초로 관측된 시각 anchor. 이미 stamp돼 있으면 보존
+      // (매 cycle 재stamp하면 backstop이 끝없이 밀려 9h force-end와 다를 바 없어진다).
+      if (trip.destinationImminentFirstAt === undefined) {
+        trip.destinationImminentFirstAt = now;
+      }
+      const backstopElapsedMs = now - trip.destinationImminentFirstAt;
+      if (backstopElapsedMs >= DESTINATION_REACH_BACKSTOP_MS) {
+        // #2230 — gps-far 보류가 짧은 backstop을 초과 — 9h force-end보다 훨씬 짧게 강제 cleanup.
+        // gps-far cross-check(#1707) 자체(trip 보존 의도)는 유지 — 상한 시간만 단축한다.
+        stats.destinationBackstopForceEnded += 1;
+        log('boarding-lock: destination backstop force-cleanup (gps-far persisted)', {
+          token: trip.token.slice(0, 8),
+          station: waypoint.stationName,
+          kind: waypoint.kind,
+          backstopElapsedMs,
+        });
+        await cleanupTripWithLa(trip, env, deps, stats, now, log, 'destination-arrived');
+        await deleteSsot(env.TRIPS, trip.token);
+        return;
+      }
       // trip 보존 — advance 자체를 abort. trip.waypoints 미변동 → 다음 cycle 재평가 진입.
-      // 9h 도달 시 `tripLifecyclePhase`의 force-end 가 자연 cleanup (legacy 안전망).
+      // anchor stamp(신규 stamp된 경우)를 persist해 다음 cycle이 경과 시간을 정확히 판단하게 한다.
+      await putTrip(env.TRIPS, trip);
       log('boarding-lock: cleanup deferred (gps-far)', {
         token: trip.token.slice(0, 8),
         station: waypoint.stationName,
         kind: waypoint.kind,
+        backstopElapsedMs,
       });
       return;
     }
@@ -3940,6 +3994,18 @@ export async function maybeReschedulePush(
     return { cleanedUp: false };
   }
 
+  // #2230 — per-station once dedup. 위 임계(15s)만으로는 destination ETA가 매 cron(60s)마다
+  // 15s+ 드리프트하는 정상적인 관측 변동을 매번 "새 발사"로 취급해 무한 반복한다
+  // (2026-08-09 실기기 dump: 불광 도착 후 6분간 6회). 같은 (token, station)은 TTL 동안 1회만.
+  if (await hasRescheduleFired(env.TRIPS, trip.token, waypoint.stationName)) {
+    log('reschedule push: dedup-skip (already fired for station)', {
+      token: trip.token.slice(0, 8),
+      nextStation: waypoint.stationName,
+    });
+    stats.rescheduleDedupSkipped += 1;
+    return { cleanedUp: false };
+  }
+
   const pushId = generatePushId();
   log('reschedule push', {
     token: trip.token.slice(0, 8),
@@ -3996,6 +4062,9 @@ export async function maybeReschedulePush(
     stats.silentPushFiredByKind.reschedule += 1;
     trip.lastTrackedArrivalEpoch = newArrivalEpoch;
     dirty = true;
+    // #2230 — 발사 직후 per-station dedup marker stamp. 다음 cron부터 TTL 동안 같은 station
+    // reschedule는 dedup-skip으로 억제된다.
+    await markRescheduleFired(env.TRIPS, trip.token, waypoint.stationName);
   } else {
     stats.errors += 1;
     log('reschedule push failed', {

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -306,6 +306,21 @@ export interface Trip {
    * 근접 게이트가 이미 발사를 차단하므로 창을 보수적으로 연장하는 효과가 없다.
    */
   originProximityAt?: number;
+  /**
+   * #2230 — destination(또는 마지막 intermediate = effective destination) 도착 advance가 최초로
+   * 평가된 시각(epoch ms). `advanceBoardingLockWaypoint`의 cleanup-advance 분기(gps-far
+   * cross-check 대상) 진입 시점에 최초 1회만 stamp된다.
+   *
+   * 배경(2026-08-09 실기기 dump RCA): gps-far cross-check(#1707)가 destination advance를
+   * 무기한 보류하면(trip 보존 의도) 종전엔 9h force-end까지 trip이 살아남았다. 본 필드로
+   * "destination 도달 신호가 처음 관측된 시각"을 anchor해, T분(짧은 backstop, 9h force-end와
+   * 별개) 경과 시 gps-far 보류 상태라도 강제 cleanup한다.
+   *
+   * 정상 종료(within/stale-gps/no-gps/station-unknown)로 즉시 cleanup되는 trip은 이 필드가
+   * 참조되기 전에 삭제되므로 무관. gps-far가 반복되지 않으면(다음 cycle에 within 등으로 해소)
+   * 자연스럽게 trip이 삭제되며 이 필드도 함께 사라진다.
+   */
+  destinationImminentFirstAt?: number;
 }
 
 /**


### PR DESCRIPTION
Closes #2230

## 선결 조사 결론 (A 항목 필수 조사)

이슈가 지시한 "reschedule push가 #2202 이후 vestigial인지" 조사 결과: **vestigial 아님 — dedup 채택** (제거 아님).

- `#2202`(PR #2225)는 device `stationPrescheduler`(매역 사전예약, sleepMode OFF 경로)만 퇴역시켰다.
- device `silentPushTask.applyReschedule`(`src/features/alarm/tasks/silentPushTask.ts:1243`)는 **sleepMode ON** 경로에서 여전히 `rescheduleSafetyNetAlarm`을 호출해 취침모드 안전망 알람을 정정한다 — 함수 헤더 주석(`#2202 (ADR-026 Decision 2)`)이 이를 명시: "본 함수는 이제 sleepMode ON(safetyNetScheduler, backend-outage 안전망) 전용".
- 따라서 reschedule push 발사 경로(`maybeReschedulePush` / `sendReschedulePush` / device `applyReschedule`)를 제거하면 취침모드 안전망 정정 채널 자체가 사라지는 새 회귀가 된다. **소비자 있음 → per-station once dedup 보강**으로 진행.

## 변경 사항

### A. reschedule 60s 스팸 정지 (dedup 채택)
- `backend/alarm-worker/src/rescheduleDedup.ts` 신규 — `maybeReschedulePush`용 per-(tripToken, stationName) once dedup. KV, TTL 300s(5분).
- 기존 `RESCHEDULE_THRESHOLD_MS`(15s ETA delta) 게이트만으로는 destination ETA가 매 cron(60s)마다 15s+ 자연 드리프트할 때마다 "새 발사"로 오인해 무한 반복 발사(2026-08-09 실기기 dump: 불광 도착 후 15:57~16:03 6회)했다. 같은 station엔 5분 내 1회만.

### B. destination-reached 짧은 backstop
- `Trip.destinationImminentFirstAt` 필드 추가 — `advanceBoardingLockWaypoint`의 gps-far cross-check(#1707) 보류 진입 시각 anchor.
- `DESTINATION_REACH_BACKSTOP_MS`(15분) 경과 시 gps-far 보류 상태라도 `cleanupTripWithLa('destination-arrived')`로 강제 종료. 9h force-end(`BACKEND_TRIP_LIFECYCLE_FORCE_END_MS`)는 그대로 유지 — 추가 backstop.
- `cleanupTripWithLa`(liveActivity.ts)가 trip 종료 시 `cleanupPendingPushesForToken`으로 `PENDING_PUSHES` 잔여 entry도 함께 정리.

## 금지 사항 준수
- 9h force-end 자체 미제거 (다른 케이스 안전망 유지) — backstop은 추가.
- device 코드(`src/`) 무변경 — `backend/alarm-worker/src/` 만 수정.
- gps-far cross-check(#1707) 로직 미제거 — trip 보존 의도 유지, 상한 시간만 단축.

## 테스트 (issue 4항목 충족)
1. `arrived=false` 유지 시 reschedule가 여러 cron에서 같은 station 재발사 안 함 — 3-cycle 시뮬레이션, APNs 호출 총 1회 확인.
2. gps-far 보류 상태에서 T분(15분) 경과 시 `cleanupTripWithLa` 호출됨 (T분 이전엔 미호출) — 경계값(직전/직후) 모두 테스트.
3. destination cleanup 시 `PENDING_PUSHES` 비워짐.
4. coverage — 전체 97.25%/96.29%(branch)/99.21%(funcs)/97.25%, 기존 ratchet floor(97/96/98/97) 초과. 신규 파일 `rescheduleDedup.ts` 100%. 신규 코드 라인 전부 커버(미커버 라인은 기존 pre-existing gap과 무관).

## Wire-completion 5단
1. **Orphan**: N/A — backend 전용 변경(orphan 스크립트는 frontend `src/` 대상). `npm run lint:orphan`(root) pass 확인.
2. **V/X dashboard**: Cloudflare Workers Logs에서 `reschedule push: dedup-skip (already fired for station)` 로그(A) / `boarding-lock: destination backstop force-cleanup (gps-far persisted)` 로그(B) 관측 가능. `ScheduledStats.rescheduleDedupSkipped` / `destinationBackstopForceEnded` 카운터로 heartbeat 집계.
3. **의존 PR**: N/A — device 관측 트랙(follow-up: `DELETE /trips` 피드백 배선)과 독립.
4. **측정 plan**: 다음 실탑승 dump에서 destination 도착 후 60s 반복 0건 확인 + backend trip이 gps-far 보류 시 15분 내 정리되는지 cron tail로 확인.
5. **Device verify**: 실기기 1탑승(destination 도착 후 반복 푸시 관측 + gps-far 시나리오는 재현 어려워 코드 리뷰로 대체). **backend deploy 필요** (`wrangler deploy`) — 머지≠배포.