### PR TITLE
fix(#2231): silent-push 관측 정정 — silentPushReach 재정의 + reschedule/unk 분리 집계

### DIFF
--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -491,6 +491,28 @@ describe('silentPushTask', () => {
       ).toMatchObject({ kind: undefined });
     });
 
+    // #2231 — kind가 알려진 값과 매치되지 않을 때(계약 스큐) 원본 문자열을 kindRaw로 보존해
+    // device 관측(alarmLog pushKindRaw)까지 흘려보낸다.
+    it('kind가 알 수 없는 값이면 kindRaw에 원본 문자열 보존 (#2231)', () => {
+      expect(
+        extractPayload(bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', kind: 'foo' })),
+      ).toMatchObject({ kind: undefined, kindRaw: 'foo' });
+    });
+
+    it('kind가 알려진 값이면 kindRaw는 undefined (계약 스큐 아님, #2231)', () => {
+      expect(
+        extractPayload(
+          bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', kind: 'transfer' }),
+        ),
+      ).toMatchObject({ kindRaw: undefined });
+    });
+
+    it('kind가 미지정이면 kindRaw도 undefined (구버전 backend, 계약 스큐 아님, #2231)', () => {
+      expect(
+        extractPayload(bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early' })),
+      ).toMatchObject({ kind: undefined, kindRaw: undefined });
+    });
+
     it('sentAt이 number면 그대로 전달 (#478)', () => {
       expect(
         extractPayload(
@@ -1513,6 +1535,23 @@ describe('silentPushTask', () => {
       const arg = mockLogSilentPushReceived.mock.calls[0][0];
       expect(arg.sentAt).toBe(1_700_000_000_000);
       expect(typeof arg.receivedAt).toBe('number');
+    });
+
+    // #2231 — kind가 계약 스큐(알려지지 않은 값)면 원본 문자열이 logSilentPushReceived의
+    // rawKind로 전달되어 alarmLog pushKindRaw에 보존된다.
+    it('kind가 알 수 없는 값이면 logSilentPushReceived에 rawKind 전달 (#2231)', async () => {
+      await handleSilentPush(payload({ kind: 'future-kind', phase: 'early' }));
+      expect(mockLogSilentPushReceived).toHaveBeenCalledTimes(1);
+      const arg = mockLogSilentPushReceived.mock.calls[0][0];
+      expect(arg.kind).toBeUndefined();
+      expect(arg.rawKind).toBe('future-kind');
+    });
+
+    it('kind가 알려진 값이면 rawKind는 undefined로 전달 (#2231)', async () => {
+      await handleSilentPush(payload({ kind: 'transfer', phase: 'early' }));
+      expect(mockLogSilentPushReceived).toHaveBeenCalledTimes(1);
+      const arg = mockLogSilentPushReceived.mock.calls[0][0];
+      expect(arg.rawKind).toBeUndefined();
     });
 
     // #2045 (Signal 4) — 유효 payload 진입 시점에 last-received stamp 갱신 (kind 무관).

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -98,6 +98,12 @@ export interface SilentPushPayload {
   /** Waypoint 종류 (#416). transfer/destination/intermediate. 구 백엔드 호환 위해 optional. */
   kind?: 'transfer' | 'destination' | 'intermediate';
   /**
+   * #2231 — `kind`가 알려진 값(transfer/destination/intermediate)과 매치되지 않을 때 backend가
+   * 실제로 보낸 원본 kind 문자열. 계약 스큐(backend가 새/변경된 kind를 보냈는데 device가 모르는 값)
+   * 관측용 — 정상 kind거나 필드 자체가 없으면 undefined.
+   */
+  kindRaw?: string;
+  /**
    * 백엔드 발사 시점 epoch ms (#478 측정 인프라).
    * 종료 조건: 신 백엔드 배포 후 required로 승격.
    */
@@ -493,11 +499,16 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
   if (phase !== 'early' && phase !== 'imminent') return null;
   const validKind =
     kind === 'transfer' || kind === 'destination' || kind === 'intermediate' ? kind : undefined;
+  // #2231 — kind가 존재하지만(빈 문자열 제외) 알려진 값과 매치되지 않는 경우만 raw로 보존한다.
+  // kind 자체가 없는(구버전 backend 단순 미지정) 경우는 계약 스큐가 아니므로 kindRaw를 남기지 않는다.
+  const kindRaw =
+    typeof kind === 'string' && kind.length > 0 && validKind === undefined ? kind : undefined;
   return {
     nextWaypoint,
     etaSeconds,
     phase,
     kind: validKind,
+    kindRaw,
     sentAt: validSentAt(sentAt),
     pushId: validPushId(pushId),
     hopIndex: validHopIndex(hopIndex),
@@ -1082,6 +1093,7 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
       phaseId: payload.phase,
       sentAt: payload.sentAt,
       receivedAt,
+      rawKind: payload.kindRaw,
     });
 
     // #1438 (E5) — backend → device lock release sync. payload.lockReleasedReason이 있으면

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -73,6 +73,7 @@ import {
   countGateReasons,
   countSilentPushKindBreakdown,
   countSilentPushOutcomes,
+  computeSilentPushReach,
   summarizeAlarmLogCounters,
   countAlarmLogReasonsByWindow,
   lastNReasons,
@@ -1694,6 +1695,40 @@ describe('alarmLog', () => {
       expect(saved[0].receivedAt).toBe(1_700_000_001_000);
     });
 
+    // #2231 — kind가 알려진 값과 매치되지 않을 때(계약 스큐) rawKind를 pushKindRaw로 보존.
+    it('logSilentPushReceived: kind 매핑 실패 + rawKind 전달 시 pushKindRaw 적재 (#2231)', async () => {
+      logSilentPushReceived({
+        stationName: '강남',
+        kind: undefined,
+        phaseId: 'early',
+        sentAt: undefined,
+        receivedAt: 1_700_000_001_000,
+        rawKind: 'future-kind',
+      });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0].kind).toBeUndefined();
+      expect(saved[0].pushKindRaw).toBe('future-kind');
+    });
+
+    it('logSilentPushReceived: kind가 정상 매핑되면 rawKind가 전달돼도 pushKindRaw 미적재 (#2231)', async () => {
+      logSilentPushReceived({
+        stationName: '강남',
+        kind: 'destination',
+        phaseId: 'early',
+        sentAt: undefined,
+        receivedAt: 1_700_000_001_000,
+        rawKind: 'destination',
+      });
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      expect(saved[0].pushKindRaw).toBeUndefined();
+    });
+
     // #725 — reschedule silent push 수신 적재. source는 동일(silent-push-received)이라
     // DebugModal `lastReceivedAt`이 자동 갱신. kind/phaseId는 reschedule 의미상 미적용.
     it('logSilentPushRescheduleReceived: source=silent-push-received, kind/phaseId 미포함, sentAt/receivedAt 적재 (#725)', async () => {
@@ -1716,6 +1751,8 @@ describe('alarmLog', () => {
       });
       expect(saved[0].kind).toBeUndefined();
       expect(saved[0].phaseId).toBeUndefined();
+      // #2231 — reschedule discriminator 보존 (unknown 버킷과 분리 집계용).
+      expect(saved[0].pushKindRaw).toBe('reschedule');
     });
 
     it('logSilentPushRescheduleReceived: sentAt 누락이면 undefined로 적재 (#725)', async () => {
@@ -1754,6 +1791,8 @@ describe('alarmLog', () => {
         expect(saved[0].sentAt).toBe(sentAt);
         expect(saved[0].kind).toBeUndefined();
         expect(saved[0].phaseId).toBeUndefined();
+        // #2231 — trip-ended discriminator 보존 (unknown 버킷과 분리 집계용).
+        expect(saved[0].pushKindRaw).toBe('trip-ended');
       },
     );
 
@@ -1891,6 +1930,8 @@ describe('alarmLog', () => {
         'station-passed': 0,
         transfer: 0,
         destination: 0,
+        reschedule: 0,
+        tripEnded: 0,
         unknown: 0,
       });
     });
@@ -1907,6 +1948,8 @@ describe('alarmLog', () => {
         'station-passed': 2,
         transfer: 1,
         destination: 1,
+        reschedule: 0,
+        tripEnded: 0,
         unknown: 0,
       });
     });
@@ -1920,6 +1963,8 @@ describe('alarmLog', () => {
         'station-passed': 0,
         transfer: 1,
         destination: 0,
+        reschedule: 0,
+        tripEnded: 0,
         unknown: 1,
       });
     });
@@ -1935,8 +1980,83 @@ describe('alarmLog', () => {
         'station-passed': 0,
         transfer: 0,
         destination: 1,
+        reschedule: 0,
+        tripEnded: 0,
         unknown: 0,
       });
+    });
+
+    // #2231 — reschedule/trip-ended는 알려진 non-station 제어 push discriminator. unknown과
+    // 분리 집계해 unknown이 진짜 계약 스큐(device가 모르는 kind)만 남도록 한다.
+    it('pushKindRaw=reschedule 엔트리는 reschedule 버킷으로 집계 (unknown 아님)', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ source: 'silent-push-received', kind: undefined, pushKindRaw: 'reschedule' }),
+        makeEntry({ source: 'silent-push-received', kind: undefined, pushKindRaw: 'reschedule' }),
+        makeEntry({ source: 'silent-push-received', kind: 'transfer' }),
+      ];
+      expect(countSilentPushKindBreakdown(entries)).toEqual({
+        'station-passed': 0,
+        transfer: 1,
+        destination: 0,
+        reschedule: 2,
+        tripEnded: 0,
+        unknown: 0,
+      });
+    });
+
+    it('pushKindRaw=trip-ended 엔트리는 tripEnded 버킷으로 집계 (unknown 아님)', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ source: 'silent-push-received', kind: undefined, pushKindRaw: 'trip-ended' }),
+      ];
+      expect(countSilentPushKindBreakdown(entries)).toEqual({
+        'station-passed': 0,
+        transfer: 0,
+        destination: 0,
+        reschedule: 0,
+        tripEnded: 1,
+        unknown: 0,
+      });
+    });
+
+    it('알 수 없는 pushKindRaw(계약 스큐)는 unknown 버킷으로 집계된다', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ source: 'silent-push-received', kind: undefined, pushKindRaw: 'future-kind' }),
+      ];
+      expect(countSilentPushKindBreakdown(entries)).toEqual({
+        'station-passed': 0,
+        transfer: 0,
+        destination: 0,
+        reschedule: 0,
+        tripEnded: 0,
+        unknown: 1,
+      });
+    });
+  });
+
+  describe('computeSilentPushReach (#2231)', () => {
+    it('엔트리가 없으면 0/0', () => {
+      expect(computeSilentPushReach([])).toEqual({ visibleReceived: 0, totalReceived: 0 });
+    });
+
+    it('visibleReceived는 station-passed/transfer/destination 합, totalReceived는 전체 received', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ source: 'silent-push-received', kind: 'station-passed' }),
+        makeEntry({ source: 'silent-push-received', kind: 'transfer' }),
+        makeEntry({ source: 'silent-push-received', kind: 'destination' }),
+        makeEntry({ source: 'silent-push-received', kind: undefined, pushKindRaw: 'reschedule' }),
+        makeEntry({ source: 'silent-push-received', kind: undefined, pushKindRaw: 'trip-ended' }),
+        makeEntry({ source: 'silent-push-received', kind: undefined, pushKindRaw: 'future-kind' }),
+      ];
+      // visible station kind 3건 / 전체 수신 6건 — reschedule/trip-ended/unknown은 분모에만 포함.
+      expect(computeSilentPushReach(entries)).toEqual({ visibleReceived: 3, totalReceived: 6 });
+    });
+
+    it('silent-push-fired source는 received 집계에 포함되지 않는다 (#2064 no-op 이후 죽은 지표 배제)', () => {
+      const entries: AlarmLogEntry[] = [
+        makeEntry({ source: 'silent-push-received', kind: 'transfer' }),
+        makeEntry({ source: 'silent-push-fired', kind: 'transfer' }),
+      ];
+      expect(computeSilentPushReach(entries)).toEqual({ visibleReceived: 1, totalReceived: 1 });
     });
   });
 

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -15,6 +15,16 @@ import type { Station } from '../../../shared/types/station';
 // Buffer 크기는 ALARM_LOG_BUFFER_SIZE 상수로 분리 — 늘리려면 한 곳만 수정.
 export const ALARM_LOG_BUFFER_SIZE = 200;
 
+/**
+ * #2231 — `pushKindRaw` non-station discriminator 리터럴. 생산자(`logSilentPushRescheduleReceived`/
+ * `logSilentPushTripEndedReceived`)와 소비자(`countSilentPushKindBreakdown`)가 이 상수를 공유해,
+ * 한쪽만 문자열을 바꾸면 조용히 `unknown`(계약 스큐) 버킷으로 오분류되는 회귀를 차단한다.
+ */
+const PUSH_KIND_RAW = {
+  RESCHEDULE: 'reschedule',
+  TRIP_ENDED: 'trip-ended',
+} as const;
+
 // #735 — appendAlarmLog 배치 정책.
 // 기존: 매 호출마다 AsyncStorage RMW(get → parse → push → stringify → set) → JS thread 점유 (10-50ms × N).
 // 변경: in-memory pending에 push 후 debounce + max-delay로 1회 RMW 일괄 처리.
@@ -391,6 +401,13 @@ export interface AlarmLogEntry {
   reason?: AlarmLogReason;
   stationName?: string;
   kind?: AlarmLogKind;
+  /**
+   * #2231 — silent-push-received 엔트리 중 표준 station kind(station-passed/transfer/destination)로
+   * 매핑되지 않는 discriminator를 device 관측용으로 보존한다.
+   * - 'reschedule' / 'trip-ended': 알려진 non-station 제어 push (계약 스큐 아님).
+   * - 그 외 문자열: backend가 보낸, device가 모르는 kind 원본 값 — 진짜 계약 스큐.
+   */
+  pushKindRaw?: string;
   phaseId?: AlarmPhaseId;
   location?: AlarmLogLocation;
   // #372 — 사전 예약 알람 stamp. 모두 optional (구버전/일부 caller 호환).
@@ -993,6 +1010,13 @@ export function logSilentPushReceived(input: {
   phaseId: AlarmPhaseId;
   sentAt: number | undefined;
   receivedAt: number;
+  /**
+   * #2231 — kind가 알려진 값(station-passed/transfer/destination/intermediate)과 매치되지 않을 때
+   * backend가 실제로 보낸 원본 kind 문자열. 계약 스큐(backend가 새/변경된 kind를 보냈는데 device가
+   * 모르는 값) 발생 시 즉시 관측 가능하도록 unknown 버킷과 별개로 엔트리에 보존한다.
+   * kind가 정상 매핑되면(undefined 포함 — 구버전 backend의 단순 미지정) 전달하지 않는다.
+   */
+  rawKind?: string;
 }): void {
   // 'intermediate'는 station-passed에 매핑 (#416 silent push intermediate 흐름).
   // kind 미상(구 백엔드)이면 kind 필드 자체를 비워둔다.
@@ -1007,6 +1031,7 @@ export function logSilentPushReceived(input: {
     phaseId: input.phaseId,
     sentAt: input.sentAt,
     receivedAt: input.receivedAt,
+    pushKindRaw: mappedKind === undefined ? input.rawKind : undefined,
   });
 }
 
@@ -1032,6 +1057,9 @@ export function logSilentPushRescheduleReceived(input: {
     stationName: input.nextStation,
     sentAt: input.sentAt,
     receivedAt: input.receivedAt,
+    // #2231 — reschedule은 station kind가 없는 제어용 push. unknown(=진짜 계약 스큐)과
+    // 분리 집계하기 위한 discriminator.
+    pushKindRaw: PUSH_KIND_RAW.RESCHEDULE,
   });
 }
 
@@ -1054,6 +1082,9 @@ export function logSilentPushTripEndedReceived(input: {
     stationName: `trip-ended:${input.reason}`,
     sentAt: input.sentAt,
     receivedAt: input.receivedAt,
+    // #2231 — trip-ended는 station kind가 없는 제어용 push. unknown(=진짜 계약 스큐)과
+    // 분리 집계하기 위한 discriminator.
+    pushKindRaw: PUSH_KIND_RAW.TRIP_ENDED,
   });
 }
 
@@ -1321,15 +1352,20 @@ export function countFiredAlarms(entries: readonly AlarmLogEntry[]): number {
 
 /**
  * #1683 — silent push received 엔트리를 kind별로 집계.
+ * #2231 — reschedule/trip-ended(알려진 non-station 제어 push discriminator)를 unknown과
+ * 분리 집계. unknown은 진짜 계약 스큐(device가 모르는 kind)만 남는다.
  *
  * `silent-push-received` 소스의 엔트리만 추출해 kind 분포를 반환.
- * kind가 없는(구버전 backend / 미지정) 엔트리는 `unknown` 버킷에 포함.
+ * kind가 station kind로도, reschedule/trip-ended로도 식별되지 않는(구버전 backend 단순 미지정
+ * 포함) 엔트리만 `unknown` 버킷에 포함.
  * DebugModal Silent Push 섹션에서 "received by kind" 분포로 시각화한다.
  */
 export interface SilentPushKindBreakdown {
   'station-passed': number;
   transfer: number;
   destination: number;
+  reschedule: number;
+  tripEnded: number;
   unknown: number;
 }
 
@@ -1340,18 +1376,55 @@ export function countSilentPushKindBreakdown(
     'station-passed': 0,
     transfer: 0,
     destination: 0,
+    reschedule: 0,
+    tripEnded: 0,
     unknown: 0,
   };
   for (const entry of entries) {
     if (entry.source !== 'silent-push-received') continue;
-    const { kind } = entry;
+    const { kind, pushKindRaw } = entry;
     if (kind === 'station-passed' || kind === 'transfer' || kind === 'destination') {
       counts[kind] += 1;
+    } else if (pushKindRaw === PUSH_KIND_RAW.RESCHEDULE) {
+      counts.reschedule += 1;
+    } else if (pushKindRaw === PUSH_KIND_RAW.TRIP_ENDED) {
+      counts.tripEnded += 1;
     } else {
       counts.unknown += 1;
     }
   }
   return counts;
+}
+
+/**
+ * #2231 — silentPushReach(local) 재정의.
+ *
+ * #2064(Phase 1-device)로 device 로컬 발사(`silent-push-fired` source)가 구조적으로 no-op
+ * (`legacy-station-kind-ignored`)가 되어, 기존 fired/received 비율은 분자가 항상 0인 죽은 지표였다.
+ *
+ * 현 아키텍처(#2063/#2092)에서 매역 알림은 backend visible alert push가 `content-available`을
+ * 동봉해 보내고, device는 이를 `silent-push-received`(kind=station-passed/transfer/destination)로
+ * 수신한다 — 즉 "받은 station kind" 자체가 이제 "visible push가 device에 도달했다"는 신호다.
+ * reschedule/trip-ended 등 제어용 data-only push는 사용자에게 보이지 않으므로 분모(전체 수신)에는
+ * 포함하되 분자(visible 도달)에서는 제외한다.
+ *
+ * - visibleReceived: 사용자에게 실제로 노출되는 station 알림 kind로 도달한 silent push 수.
+ * - totalReceived:   `silent-push-received` 전체(제어용 push 포함) — device가 수신한 모든 silent data push.
+ */
+export interface SilentPushReachCounts {
+  visibleReceived: number;
+  totalReceived: number;
+}
+
+export function computeSilentPushReach(
+  entries: readonly AlarmLogEntry[],
+): SilentPushReachCounts {
+  const breakdown = countSilentPushKindBreakdown(entries);
+  const { received } = countSilentPushOutcomes(entries);
+  return {
+    visibleReceived: breakdown['station-passed'] + breakdown.transfer + breakdown.destination,
+    totalReceived: received,
+  };
 }
 
 export function logSuppressedGate(

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -48,6 +48,7 @@ import {
   countAutoLockReasonsByWindow,
   countBoardingPromptByWindow,
   countGateReasons,
+  computeSilentPushReach,
   countSilentPushKindBreakdown,
   countSilentPushOutcomes,
   formatFusionPickerTierDistribution,
@@ -312,6 +313,9 @@ function formatLogLine(entry: AlarmLogEntry): string {
   ];
   if (entry.reason) parts.push(entry.reason);
   if (entry.kind) parts.push(entry.kind);
+  // #2231 — kind가 표준 station kind로 매핑되지 않을 때 backend가 실제로 보낸 원본 값을
+  // raw 로그에 보존 — 계약 스큐(device가 모르는 신규 kind) 발생 즉시 관측 가능하게 한다.
+  if (entry.pushKindRaw) parts.push(`rawKind=${entry.pushKindRaw}`);
   if (entry.phaseId) parts.push(entry.phaseId);
   if (entry.stationName) parts.push(entry.stationName);
   if (entry.location) {
@@ -443,8 +447,10 @@ function silentPushDiagRows(
   // received가 안 늘어남"을 한눈에 보고 측정할 수 있게 한다.
   const lowPowerValue = lowPowerMode ? 'ON' : 'off';
   // #1683 — received kind 분포. backend fired vs device received 갭 분석용.
+  // #2231 — reschedule/trip-ended(알려진 non-station 제어 push)를 unknown과 분리 표기 —
+  // unk는 이제 진짜 계약 스큐(device가 모르는 kind)만 남는다.
   const kindBreakdown = countSilentPushKindBreakdown(logs);
-  const receivedKindValue = `stn=${kindBreakdown['station-passed']} xfer=${kindBreakdown.transfer} dst=${kindBreakdown.destination} unk=${kindBreakdown.unknown}`;
+  const receivedKindValue = `stn=${kindBreakdown['station-passed']} xfer=${kindBreakdown.transfer} dst=${kindBreakdown.destination} resched=${kindBreakdown.reschedule} tripEnd=${kindBreakdown.tripEnded} unk=${kindBreakdown.unknown}`;
   return [
     { uiLabel: 'permission', dumpKey: 'permission', value: d.permissionStatus ?? '(unknown)' },
     { uiLabel: 'apnsToken', dumpKey: 'apnsToken', value: formatTokenTail(d.apnsToken) },
@@ -694,7 +700,7 @@ interface BuildDumpArgs {
    *
    * 노출 metric:
    *  - alarmAccuracy (local): tripGroundTruth store `responses` accurate/answered 비율
-   *  - silentPushReach (local): `countSilentPushOutcomes(logs)` fired/received
+   *  - silentPushReach (local): `computeSilentPushReach(logs)` visibleReceived/totalReceived (#2231)
    *
    * 미전달 시 (n/a) — DebugModalInner 이 store snapshot 을 주입하지 않은 케이스 graceful.
    */
@@ -927,17 +933,19 @@ function buildFeatureFlagSection(args: BuildDumpArgs): string[] {
  *
  * 노출 metric:
  *  - alarmAccuracy (local): tripGroundTruth store `responses` accurate/answered 비율
- *  - silentPushReach (local): `countSilentPushOutcomes(logs)` fired/received
+ *  - silentPushReach (local): `computeSilentPushReach(logs)` visibleReceived/totalReceived (#2231)
  *
  * 미전달 시 (n/a) — DebugModalInner 가 store snapshot 을 주입하지 않은 호출자 graceful.
  */
 function buildOperationDashboardSection(args: BuildDumpArgs): string[] {
   const op = args.operationDashboard;
   if (!op) return ['(n/a)'];
-  const silentCounts = countSilentPushOutcomes(args.logs);
+  // #2231 — #2064 이후 device 로컬 발사(fired)는 구조적으로 no-op이라 fired/received 비율은
+  // 항상 0인 죽은 지표였다. visible station kind로 도달한 수 / 전체 수신 수로 재정의.
+  const reach = computeSilentPushReach(args.logs);
   return [
     `alarmAccuracy(local)=${op.groundTruthAccurateCount}/${op.groundTruthAnsweredCount}`,
-    `silentPushReach(local)=${silentCounts.fired}/${silentCounts.received}`,
+    `silentPushReach(local)=${reach.visibleReceived}/${reach.totalReceived}`,
     '(backend metrics: locklessMiss/boardableMiss/accelPattern/pushLatency/laPush — see Modal UI, not dumped)',
   ];
 }

--- a/src/features/debug/components/OperationDashboardSection.tsx
+++ b/src/features/debug/components/OperationDashboardSection.tsx
@@ -19,7 +19,7 @@
  *   - metric row 클릭 → MetricDrillDownView expanded view (corrId join)
  *
  * Metric 1 — 알람 정확성: useTripGroundTruthStore(M2 구현) 기반
- * Metric 2 — Silent push 도달률: countSilentPushOutcomes (received vs fired)
+ * Metric 2 — Silent push 도달률: computeSilentPushReach (visible station kind / total received, #2231)
  * Metric 3 — Lockless miss: backend polling (ADMIN_TOKEN 미설정 시 mock 유지)
  * Metric 4 — Boardable train miss: backend polling (backend placeholder: 0/0)
  */
@@ -27,7 +27,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useTheme, spacing, typography } from '../../../shared/theme';
 import { useTripGroundTruthStore } from '../store/useTripGroundTruthStore';
-import { countSilentPushOutcomes, type AlarmLogEntry } from '../../alarm/utils/alarmLog';
+import { computeSilentPushReach, type AlarmLogEntry } from '../../alarm/utils/alarmLog';
 import {
   fetchObservabilityMetrics,
   type ObservabilityMetricsBucket,
@@ -391,14 +391,17 @@ export function OperationDashboardSection({ logs, onMetricClick }: OperationDash
           isMock: backendState.kind !== 'ok',
         };
 
-  // Metric 2 — Silent push 도달률 (received 중 fired 비율)
-  const silentCounts = countSilentPushOutcomes(logs);
+  // Metric 2 — Silent push 도달률 (#2231 재정의: 전체 수신 중 visible station kind 비율).
+  // #2064 이후 device 로컬 발사(fired)는 구조적으로 no-op이라 과거 fired/received 비율은
+  // 항상 0인 죽은 지표였다 — visibleReceived(station-passed/transfer/destination으로 도달)
+  // / totalReceived(reschedule/trip-ended 등 제어용 push 포함 전체 수신)로 재정의.
+  const reach = computeSilentPushReach(logs);
   const silentPushReach: MetricData = {
     key: 'silentPushReach',
     label: 'silentPushReach',
-    ratio: computeRatio(silentCounts.fired, silentCounts.received),
-    numerator: silentCounts.fired,
-    denominator: silentCounts.received,
+    ratio: computeRatio(reach.visibleReceived, reach.totalReceived),
+    numerator: reach.visibleReceived,
+    denominator: reach.totalReceived,
   };
 
   // Metric 3 — Lockless miss (backend polling 결과 또는 mock 유지)
@@ -437,7 +440,8 @@ export function OperationDashboardSection({ logs, onMetricClick }: OperationDash
       : { key: 'locklessMiss', label: 'laPushDelivery', ratio: null, numerator: 0, denominator: 0, isMock: true };
 
   // Metric 8 — #1958 silent push 5min corrId join 도달률 (backend SSoT).
-  // 기존 client-side `silentPushReach`(local fired/received)와 별도 — backend가 `sent`를 권위 분모로 보유.
+  // 기존 client-side `silentPushReach`(local visibleReceived/totalReceived, #2231)와 별도 —
+  // backend가 `sent`를 권위 분모로 보유.
   // backend가 silentPushReachRatio 필드를 응답하지 않으면(구 backend) placeholder.
   const silentPushReachBackend: MetricData =
     backendState.kind === 'ok' && backendState.silentPushReach !== null

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -908,6 +908,28 @@ describe('DebugModal helpers', () => {
     expect(line).toContain('age=1500ms');
   });
 
+  // #2231 — pushKindRaw가 있으면 계약 스큐(device가 모르는 kind) 원본 문자열을 raw 로그 라인에 보존.
+  it('formatLogLine: pushKindRaw가 있으면 rawKind=... 표기 (#2231)', () => {
+    const entry: AlarmLogEntry = {
+      ts: Date.now(),
+      source: 'silent-push-received',
+      outcome: 'received',
+      pushKindRaw: 'future-kind',
+    };
+    const line = __test__.formatLogLine(entry);
+    expect(line).toContain('rawKind=future-kind');
+  });
+
+  it('formatLogLine: pushKindRaw 미존재면 rawKind 토큰이 붙지 않는다 (#2231)', () => {
+    const entry: AlarmLogEntry = {
+      ts: Date.now(),
+      source: 'silent-push-received',
+      outcome: 'received',
+    };
+    const line = __test__.formatLogLine(entry);
+    expect(line).not.toContain('rawKind');
+  });
+
   it('formatLogLine: 최소 fired 엔트리', () => {
     const entry: AlarmLogEntry = {
       ts: Date.now(),
@@ -5379,12 +5401,14 @@ describe('DebugModal share dump — 누락 3 섹션 wire (#2044-scope)', () => {
       expect(result[0]).toBe('alarmAccuracy(local)=3/5');
     });
 
-    it('silentPushReach(local) 은 args.logs 로 계산 — fired/received 반영', () => {
+    // #2231 — silentPushReach(local) 재정의: visible station kind로 도달한 수 / 전체 수신 수.
+    // #2064 이후 device 로컬 발사(fired)는 구조적으로 no-op이라 과거 fired 기준은 항상 0인 죽은 지표였다.
+    it('silentPushReach(local) 은 args.logs 로 계산 — visibleReceived/totalReceived 반영 (#2231)', () => {
       const result = __test__.buildOperationDashboardSection(
         makeArgs({
           operationDashboard: { groundTruthAccurateCount: 0, groundTruthAnsweredCount: 0 },
           logs: [
-            { ts: 1, source: 'silent-push-received', outcome: 'received' },
+            { ts: 1, source: 'silent-push-received', outcome: 'received', kind: 'transfer' },
             { ts: 2, source: 'silent-push-received', outcome: 'received' },
             { ts: 3, source: 'silent-push-fired', outcome: 'fired' },
           ],
@@ -5461,7 +5485,7 @@ describe('DebugModal share dump — 누락 3 섹션 wire (#2044-scope)', () => {
         makeArgs({
           operationDashboard: { groundTruthAccurateCount: 2, groundTruthAnsweredCount: 3 },
           logs: [
-            { ts: 1, source: 'silent-push-received', outcome: 'received' },
+            { ts: 1, source: 'silent-push-received', outcome: 'received', kind: 'destination' },
             { ts: 2, source: 'silent-push-fired', outcome: 'fired' },
           ],
         }),


### PR DESCRIPTION
Closes #2231

## 요약
- `silentPushReach(local)` — #2064 이후 device 로컬 발사(`silent-push-fired`)가 구조적으로 no-op(`legacy-station-kind-ignored`)라 fired/received 비율은 분자가 항상 0인 죽은 지표였음. `computeSilentPushReach` 신설 → `visibleReceived(station-passed/transfer/destination) / totalReceived`로 재정의.
- `countSilentPushKindBreakdown`의 `unknown` 버킷을 `reschedule` / `tripEnded` / `unknown`(진짜 계약 스큐) 3종으로 분리. reschedule/trip-ended discriminator 문자열은 `PUSH_KIND_RAW` 상수로 생산자·소비자 SSoT화.
- `AlarmLogEntry.pushKindRaw` 필드 신설 — backend가 보낸, device가 모르는 kind 원본 문자열을 보존(`silentPushTask.ts`의 `extractStandardPayload`에서 캡처 → `handleSilentPush`가 `rawKind`로 전달). `DebugModal.formatLogLine`이 `rawKind=...`로 노출.
- backend 코드는 변경하지 않음. `legacy-station-kind-ignored` no-op 게이트 로직도 변경하지 않음 — 관측/집계만 정정.

## 테스트 (jest, red-first)
1. reschedule kind 수신 시 `unknown` 버킷이 아니라 `reschedule` 버킷으로 분리 집계 — `alarmLog.test.ts`.
2. 알 수 없는 kind 문자열 수신 시 `unknown` 집계 + raw kind가 `pushKindRaw`/`kindRaw`로 디버그 로그(alarmLog entry, formatLogLine)에 보존 — `alarmLog.test.ts`, `silentPushTask.test.ts`, `DebugModal.test.tsx`.
3. `silentPushReach` 재정의 지표가 visible-push(station-passed/transfer/destination) 도달 기준으로 계산 — `alarmLog.test.ts`(`computeSilentPushReach`), `DebugModal.test.tsx`, `OperationDashboardSection.test.tsx`.
4. coverage 100% 유지 확인 (`npm test`).

## Wire-completion 5단
1. **Orphan**: `npm run lint:orphan` → 0 orphan.
2. **V/X dashboard**: DebugModal Silent Push 섹션의 `recvKind`(stn/xfer/dst/resched/tripEnd/unk)와 Operation Dashboard의 `silentPushReach`가 정정된 값으로 표기됨 — 실기기 dump로 확인 예정.
3. **의존 PR**: #2230 (backend reschedule push 제거 여부에 따라 unk 원인 자체가 소멸할 수 있음). 독립 머지 가능, 결과 해석만 연동.
4. **측정 plan**: 다음 실탑승 dump에서 unk가 실제 계약 스큐일 때만 집계되는지, `silentPushReach(local)`이 오해 없이 읽히는지 확인.
5. **Device verify**: 실기기 1탑승 후 DebugModal 확인 필요. 코드 자체는 type+unit로 대부분 검증됨, 최종 라벨/집계 값 표기만 device 확인 필요.
