### PR TITLE
refactor(#2235): push 계약 SSoT 모듈 + exhaustive switch/assertNever (ADR-029 Phase 0)

### DIFF
--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -16,6 +16,11 @@ import type {
   TripEndedAlertPushPayload,
   TripEndedReason,
 } from './types';
+import type {
+  AlarmEventType,
+  SleepAlarmTargetKind,
+  StationWaypointKind,
+} from '../../../src/shared/types/pushContract';
 
 /**
  * iOS UNNotificationCategory 식별자 (#819 B 슬라이스). 클라이언트는 같은 식별자로
@@ -50,7 +55,7 @@ export interface SilentPushPayload {
   etaSeconds: number;
   phase: AlarmPhase;
   /** Waypoint 종류. 클라가 intermediate일 때만 즉시 알림 발사하도록 분기 (#416). */
-  kind: 'transfer' | 'destination' | 'intermediate';
+  kind: StationWaypointKind;
   /**
    * 백엔드 발사 시점 epoch ms (#478 측정 인프라).
    * 클라 수신 시각과 비교해 silent push 도달 지연 분포 측정용.
@@ -223,7 +228,7 @@ export interface SilentPushSsotPayload {
 export interface AlarmEventPayload {
   alarmId: string;
   stationId: string;
-  type: 'station-passed' | 'transfer' | 'destination' | 'imminent';
+  type: AlarmEventType;
   decidedAt: number;
 }
 
@@ -928,7 +933,7 @@ export interface SendSleepAlarmCompanionPushOptions {
    * #2066 — 알람 대상이 환승역인지 도착역인지. device가 문구/UI를 분기하는 데 사용.
    * 환승/도착은 target 종류만 다르고 로직은 동일하다(하드코딩 분기 최소화).
    */
-  targetKind: 'transfer' | 'destination';
+  targetKind: SleepAlarmTargetKind;
   /** 알람 대상 역의 노선. 알림 본문 노출용. */
   nextLine: string;
   /** 알람 대상 역(환승역 또는 도착역). 알림 본문 + dedup key. */

--- a/backend/alarm-worker/src/pendingPushes.ts
+++ b/backend/alarm-worker/src/pendingPushes.ts
@@ -17,6 +17,7 @@ import type { ArchFlagValue } from './archFlag';
 import { assertCronCacheTtl, CRON_READ_CACHE_TTL_SEC as SHARED_CRON_TTL } from './kvConsistency';
 import { stampSent } from './silentPushReachMetric';
 import type { ApnsEnv } from './types';
+import type { StationWaypointKind } from '../../../src/shared/types/pushContract';
 
 const PENDING_PREFIX = 'pending:';
 /**
@@ -47,7 +48,7 @@ export interface PendingPush {
   sentAt: number;
   /** alert fallback 본문 생성용 메타 (P2c/P2d에서 사용). */
   stationName: string;
-  kind: 'transfer' | 'destination' | 'intermediate';
+  kind: StationWaypointKind;
   phase: AlarmPhase;
   etaSeconds: number;
   /** APNs host 선택 (sandbox/production). silent push가 self-heal로 정정된 경우 정정된 값을 보관. */

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -99,6 +99,7 @@ import type {
   Waypoint,
 } from './types';
 import { RESCHEDULE_CHANNELS_DEFAULT } from './types';
+import { assertNever } from '../../../src/shared/types/pushContract';
 import { writeMetric } from './analytics';
 import { accumulateLaPushCounters } from './laPushCounters';
 import { t, type SupportedLocale } from './i18n';
@@ -2515,12 +2516,20 @@ export async function fireArvlCdStationPush(
   stats.arvlCdFireSuccess += 1;
   stats.pushed += 1;
   // #1683 — kind별 발사 카운터. 'intermediate'는 station-passed 경로, 그 외 그대로.
-  if (waypoint.kind === 'intermediate') {
-    stats.silentPushFiredByKind.intermediate += 1;
-  } else if (waypoint.kind === 'transfer') {
-    stats.silentPushFiredByKind.transfer += 1;
-  } else if (waypoint.kind === 'destination') {
-    stats.silentPushFiredByKind.destination += 1;
+  // #2235 (ADR-029 Phase 0) — exhaustive switch + assertNever: StationWaypointKind에 새 값이
+  // 추가되면 이 switch가 default 분기로 떨어져 컴파일 에러가 난다(드리프트 = 빌드 실패).
+  switch (waypoint.kind) {
+    case 'intermediate':
+      stats.silentPushFiredByKind.intermediate += 1;
+      break;
+    case 'transfer':
+      stats.silentPushFiredByKind.transfer += 1;
+      break;
+    case 'destination':
+      stats.silentPushFiredByKind.destination += 1;
+      break;
+    default:
+      assertNever(waypoint.kind, 'scheduled.ts arvlCd silentPushFiredByKind');
   }
   // #2063 (ADR-023 개정) — visible alert push 직접 발사이므로 60s ACK 기반 alert fallback
   // 안전망(runFallbackPushes)은 더 이상 필요 없다 — PENDING_PUSHES 등록을 생략한다
@@ -2913,12 +2922,19 @@ export async function fireVanishFallbackStationPush(
     stats.vanishFallbackFired += 1;
   }
   // #1683 — kind별 발사 카운터. vanish 경로는 waypoint.kind로 분류.
-  if (waypoint.kind === 'intermediate') {
-    stats.silentPushFiredByKind.intermediate += 1;
-  } else if (waypoint.kind === 'transfer') {
-    stats.silentPushFiredByKind.transfer += 1;
-  } else if (waypoint.kind === 'destination') {
-    stats.silentPushFiredByKind.destination += 1;
+  // #2235 (ADR-029 Phase 0) — exhaustive switch + assertNever(위 arvlCd 발사기와 동일 근거).
+  switch (waypoint.kind) {
+    case 'intermediate':
+      stats.silentPushFiredByKind.intermediate += 1;
+      break;
+    case 'transfer':
+      stats.silentPushFiredByKind.transfer += 1;
+      break;
+    case 'destination':
+      stats.silentPushFiredByKind.destination += 1;
+      break;
+    default:
+      assertNever(waypoint.kind, 'scheduled.ts vanish silentPushFiredByKind');
   }
   // P0-1 (#1577) — Site 4 of 6: vanish fire 적재 (transfer/destination imminent 포함).
   writeMetric(env, {

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -5,6 +5,8 @@
  * 앱과 백엔드는 별도 빌드이므로 import 대신 구조적 호환을 유지한다.
  */
 
+import type { ControlPushKind, StationWaypointKind } from '../../../src/shared/types/pushContract';
+
 export type LineNumber = string;
 
 export interface DirectRoute {
@@ -44,7 +46,7 @@ export interface Waypoint {
   /** 노선 키 (정확히 어느 호선에서 도착을 봐야 하는지) */
   line: LineNumber;
   /** "transfer" — 환승 안내 / "destination" — 최종 도착 / "intermediate" — 중간역 통과 */
-  kind: 'transfer' | 'destination' | 'intermediate';
+  kind: StationWaypointKind;
   /**
    * #1193 — 같은 stationName이 trip 원본 waypoint 시퀀스에 중복 등장(순환선/회차)할 때,
    * 이 waypoint가 몇 번째 등장인지(0-based). reschedule push의 `occurrenceIdx`로 전달돼
@@ -428,7 +430,7 @@ export const RESCHEDULE_CHANNELS_DEFAULT: ReadonlyArray<RescheduleChannel> = ['b
  */
 export interface ReschedulePushPayload {
   pushId: string;
-  kind: 'reschedule';
+  kind: Extract<ControlPushKind, 'reschedule'>;
   trainCode: string;
   nextStation: string;
   newArrivalTimeEpoch: number;
@@ -484,7 +486,7 @@ export type TripEndedReason =
  */
 export interface TripEndedAlertPushPayload {
   pushId: string;
-  kind: 'trip-ended';
+  kind: Extract<ControlPushKind, 'trip-ended'>;
   tripToken: string;
   reason: TripEndedReason;
   sentAt: number;
@@ -670,7 +672,7 @@ export interface BoardingPromptCandidate {
  */
 export interface BoardingPromptPushPayload {
   pushId: string;
-  kind: 'boarding-prompt';
+  kind: Extract<ControlPushKind, 'boarding-prompt'>;
   /**
    * 사용자 출발역. hop-end 프롬프트(#2034) 일 때는 "환승 지점 역명" 으로 재해석되며 (=사용자가
    * 하차해야 하는 station). 일반 boarding-prompt 시엔 boardingStation 으로 그대로 사용.

--- a/backend/alarm-worker/tsconfig.json
+++ b/backend/alarm-worker/tsconfig.json
@@ -27,6 +27,7 @@
     "../../src/data/stationAliases.js",
     "../../src/data/lineTopology.json",
     "../../src/shared/types/station.ts",
+    "../../src/shared/types/pushContract.ts",
     "../../src/shared/utils/stationLookup.ts",
     "../../src/shared/utils/normalizeStationName.js",
     "../../src/shared/utils/dijkstraRoute.ts",

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -86,6 +86,14 @@ import { readWidgetRefreshContext } from '../utils/widgetRefreshContext';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import { useDestinationStore } from '../../route/store/useDestinationStore';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
+import {
+  assertNever,
+  isSleepAlarmTargetKind,
+  isStationWaypointKind,
+  type ControlPushKind,
+  type SleepAlarmTargetKind,
+  type StationWaypointKind,
+} from '../../../shared/types/pushContract';
 
 const logger = createLogger('SilentPushTask');
 
@@ -96,7 +104,7 @@ export interface SilentPushPayload {
   etaSeconds: number;
   phase: 'early' | 'imminent';
   /** Waypoint 종류 (#416). transfer/destination/intermediate. 구 백엔드 호환 위해 optional. */
-  kind?: 'transfer' | 'destination' | 'intermediate';
+  kind?: StationWaypointKind;
   /**
    * #2231 — `kind`가 알려진 값(transfer/destination/intermediate)과 매치되지 않을 때 backend가
    * 실제로 보낸 원본 kind 문자열. 계약 스큐(backend가 새/변경된 kind를 보냈는데 device가 모르는 값)
@@ -203,7 +211,7 @@ export {
  * 대상에서 제외해도 안전(추가 프로퍼티는 destructuring에서 자연 무시).
  */
 export interface RescheduleSilentPushPayload {
-  kind: 'reschedule';
+  kind: Extract<ControlPushKind, 'reschedule'>;
   nextStation: string;
   newArrivalTimeEpoch: number;
   trainCode: string;
@@ -234,7 +242,7 @@ export interface RescheduleSilentPushPayload {
  * 이전 trip의 prompt는 재발사되지 않는다(pushId 기준 backend가 이미 정지).
  */
 export interface BoardingPromptSilentPushPayload {
-  kind: 'boarding-prompt';
+  kind: Extract<ControlPushKind, 'boarding-prompt'>;
   /**
    * 사용자 출발역. hop-end 분기(#2034) 에서는 "환승 지점 역명" (=사용자가 하차해야 하는 station)
    * 으로 재해석. hopEndKind 필드로 분기 처리.
@@ -292,11 +300,11 @@ export interface BoardingPromptSilentPushPayload {
  * targetKind — 알람 대상이 환승역인지 도착역인지(#2066). device는 문구/식별자 분기에 사용.
  */
 export interface SleepAlarmCompanionSilentPushPayload {
-  kind: 'sleep-alarm-companion';
+  kind: Extract<ControlPushKind, 'sleep-alarm-companion'>;
   /** 사용자가 지금 있는 역(직전 역, arvlCd 진입/도착 확정 시점). 사용자 컨텍스트/식별자 기록용. */
   originStation: string;
   /** 알람 대상이 환승역인지 도착역인지. device 문구/식별자 분기용. */
-  targetKind: 'transfer' | 'destination';
+  targetKind: SleepAlarmTargetKind;
   /** 알람 대상 역의 노선. 알림 본문에 노출. */
   nextLine: string;
   /** 알람 대상 역(환승역 또는 도착역). 알림 본문 + 식별자로 사용. */
@@ -330,7 +338,7 @@ export interface SleepAlarmCompanionSilentPushPayload {
  * (구버전 backend 호환 + 신규 reason 추가 시 회귀 없음.)
  */
 export interface TripEndedSilentPushPayload {
-  kind: 'trip-ended';
+  kind: Extract<ControlPushKind, 'trip-ended'>;
   reason: TripEndedReason;
   sentAt?: number;
   pushId?: string;
@@ -497,8 +505,7 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
   } & Record<string, unknown>;
   if (typeof etaSeconds !== 'number' || !Number.isFinite(etaSeconds)) return null;
   if (phase !== 'early' && phase !== 'imminent') return null;
-  const validKind =
-    kind === 'transfer' || kind === 'destination' || kind === 'intermediate' ? kind : undefined;
+  const validKind = isStationWaypointKind(kind) ? kind : undefined;
   // #2231 — kind가 존재하지만(빈 문자열 제외) 알려진 값과 매치되지 않는 경우만 raw로 보존한다.
   // kind 자체가 없는(구버전 backend 단순 미지정) 경우는 계약 스큐가 아니므로 kindRaw를 남기지 않는다.
   const kindRaw =
@@ -732,7 +739,7 @@ function extractSleepAlarmCompanionPayload(
   const { originStation, targetKind, nextLine, nextStation, tripToken, pushId, sentAt, title, body } =
     obj;
   if (typeof originStation !== 'string' || originStation.length === 0) return null;
-  if (targetKind !== 'transfer' && targetKind !== 'destination') return null;
+  if (!isSleepAlarmTargetKind(targetKind)) return null;
   if (typeof nextLine !== 'string' || nextLine.length === 0) return null;
   if (typeof nextStation !== 'string' || nextStation.length === 0) return null;
   if (typeof tripToken !== 'string' || tripToken.length === 0) return null;
@@ -935,151 +942,177 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
     //
     // 사전 예약 자체의 시각 조정은 별도 follow-up에서 다룬다 — 본 PR은 schema mismatch로 drop되던
     // 수신을 회복시키는 것이 범위.
-    if (payload.kind === 'reschedule') {
-      logger.info(
-        `reschedule received: trainCode=${payload.trainCode} nextStation=${payload.nextStation} newEpoch=${payload.newArrivalTimeEpoch} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
-      );
-      logSilentPushRescheduleReceived({
-        nextStation: payload.nextStation,
-        sentAt: payload.sentAt,
-        receivedAt,
-      });
-      await applyReschedule(payload, receivedAt);
-      void ackOutcome(payload.pushId, apnsToken, 'fired', 'reschedule-received');
-      return;
-    }
-
-    // trip-ended 분기 (#868) — backend가 server-side trip 자동 종료를 알리는 신호.
-    // route/destination/lock 등 trip-bound storage를 일괄 cleanup해 다음 FG 진입 시
-    // store hydrate가 stale state를 그대로 재현하지 않도록 한다.
     //
-    // ack outcome='fired'는 backend pendingPushes 입장에서는 "처리 완료, alert fallback 발사 마라"
-    // 신호. trip-ended는 alert fallback 대상이 아니지만 호환을 위해 일반 silent push와 같은 의미로 ack.
-    if (payload.kind === 'trip-ended') {
-      logger.info(
-        `trip-ended received: reason=${payload.reason} tripToken=${payload.tripToken?.slice(0, 8) ?? 'unknown'} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
-      );
-      // race 가드(#868 P1-2). 신규 backend는 tripToken을 항상 보냄. 구버전(undefined)은
-      // 호환 위해 cleanup 진행 — race 가능성은 있지만 backend 배포 후 사라짐.
-      if (payload.tripToken !== undefined) {
-        const activeTripToken = await AsyncStorage.getItem(ACTIVE_TRIP_KEY);
-        if (activeTripToken !== null && activeTripToken !== payload.tripToken) {
-          logger.warn(
-            `trip-ended skip: tripToken mismatch payload=${payload.tripToken.slice(0, 8)} active=${activeTripToken.slice(0, 8)}`,
-          );
-          void ackOutcome(payload.pushId, apnsToken, 'fired', `trip-ended:${payload.reason}:token-mismatch`);
-          return;
-        }
+    // #2235 (ADR-029 Phase 0) — control-kind 분기를 if-체인에서 exhaustive switch + assertNever로
+    // 전환. ExtractedPayload는 `kind`를 discriminant로 하는 union이라 각 case에서 payload가
+    // 해당 payload 타입으로 narrow된다. station waypoint kind(transfer/destination/intermediate)와
+    // undefined(kind 미상)는 이 switch에서 처리하지 않고 break로 아래 standard 처리로 넘어간다.
+    // CONTROL_PUSH_KINDS에 새 값이 추가되면 이 switch의 default가 컴파일 에러를 낸다(A1 실증).
+    switch (payload.kind) {
+      case 'reschedule': {
+        logger.info(
+          `reschedule received: trainCode=${payload.trainCode} nextStation=${payload.nextStation} newEpoch=${payload.newArrivalTimeEpoch} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
+        );
+        logSilentPushRescheduleReceived({
+          nextStation: payload.nextStation,
+          sentAt: payload.sentAt,
+          receivedAt,
+        });
+        await applyReschedule(payload, receivedAt);
+        void ackOutcome(payload.pushId, apnsToken, 'fired', 'reschedule-received');
+        return;
       }
-      // #2120 (#2114 근본 수리 Phase 2) — corrId 인스턴스 가드. tripToken(APNs 기기 토큰)은
-      // 기기당 고정이라 위 token 비교는 "같은 기기의 다른 trip" race를 못 잡는다. backend
-      // 자동종료(la-stale/eta-missing 등) push가 in-flight인 수 초 사이 device가 재등록하면,
-      // 새 trip의 ACTIVE_TRIP_KEY(=같은 token)를 그대로 통과해 옛 trip 종료 push가 새 trip을
-      // 즉시 cleanup해버린다. corrId는 register마다 새로 발급되는 trip 인스턴스 식별자이므로
-      // payload와 device 현재 값이 둘 다 있는데 다르면 그 사이 재등록이 있었다는 뜻 — cleanup
-      // 전체를 skip한다. 어느 한쪽이라도 없으면(구버전 backend / cache 미수화) 기존 동작 유지.
-      // payload.corrId가 없는(구버전 backend) 경로는 device corrId를 조회할 필요조차 없다 —
-      // 불필요한 sync cache read를 피해 이후 endedCorrIdSnapshot 캡처 시점과의 혼동도 방지한다.
-      if (payload.corrId !== undefined) {
-        const deviceCorrId = getCurrentTripCorrIdSync();
-        if (deviceCorrId !== null && payload.corrId !== deviceCorrId) {
-          logger.warn(
-            `trip-ended skip: corrId mismatch payload=${payload.corrId} device=${deviceCorrId}`,
-          );
-          logSilentPushSkipped({
-            stationName: `trip-ended:${payload.reason}`,
-            kind: undefined,
-            reason: 'trip-ended-corr-mismatch',
-          });
-          void ackOutcome(payload.pushId, apnsToken, 'skipped', `trip-ended:${payload.reason}:corr-mismatch`);
-          return;
-        }
-      }
-      logSilentPushTripEndedReceived({
-        reason: payload.reason,
-        sentAt: payload.sentAt,
-        receivedAt,
-      });
-      // #1370 L4 — OS scheduled queue burst fire 차단. 종착역 도착 시 backend trip-ended push가
-      // 도달할 때 device 로컬 OS queue(`bl:`/`tba:`)에 잔존한 사전 예약 알람이 동시에 발사돼
-      // 사용자가 "용마산 도착 후 한꺼번에 받음"으로 인지하는 회귀.
+
+      // trip-ended 분기 (#868) — backend가 server-side trip 자동 종료를 알리는 신호.
+      // route/destination/lock 등 trip-bound storage를 일괄 cleanup해 다음 FG 진입 시
+      // store hydrate가 stale state를 그대로 재현하지 않도록 한다.
       //
-      // runTripBoundCleanups가 결국 OS queue를 cancel하지만, 그 전에 triggerTripEndRecall이
-      // routeStops 구성 + network upload로 수 초 stall할 수 있어 race window가 열린다.
-      // OS queue cancel만 별도 helper로 분리해 trip-ended 진입 즉시 호출 — recall/cleanup 흐름은
-      // 그대로 유지. cancel 자체는 멱등하므로 runTripBoundCleanups의 중복 cancel은 안전 통과.
-      await cancelTripBoundOsQueue();
-      // #919 — trip-end recall KPI upload. *반드시* cleanup 전에 호출해야 한다 — trigger가
-      // ROUTE_KEY/DESTINATION_KEY/TRIP_STARTED_AT_KEY를 읽어 routeStops를 구성하기 때문.
-      // trigger는 throw하지 않으므로 후속 cleanup/sentinel 흐름 차단 없음.
-      await triggerTripEndRecall();
-      // #1597 — clearTripCorrId가 cache를 비우기 전에 종료된 trip의 corrId snapshot 캡처.
-      const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
-      await runTripBoundCleanups();
-      // #1597 — trip-end 사용자 정답지 prompt enqueue (cleanup 후, corrId snapshot으로).
-      await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
-      // #899 (Seam C) — BG에서는 zustand store에 접근 불가. FG 복귀 시점에
-      // useStateRehydration이 이 sentinel을 보고 destination/lock store도 reset.
-      // #2114 (방안 C′) — sentinel에 corrId 동봉해 다음 소비 시점 trip 인스턴스 스코프 비교 가능하게.
-      await setTripEndedSentinel(receivedAt, endedCorrIdSnapshot);
-      // #2018 γ' — FG 상태에서는 useStateRehydration의 AppState 'active' 이벤트가
-      // 발생하지 않아 sentinel이 다음 BG/FG cycle까지 처리되지 않는다. 그동안 in-memory
-      // destination store가 stale로 남아 UI가 "현재역 → 현재역 0정거장" 형태로 잔존
-      // (2026-07-02 dogfood 관찰 20 성수→성수 evidence). FG 진행 중이면 setState를
-      // 여기서 즉시 수행해 store를 정리하고 sentinel을 그 자리에서 clear한다.
-      // BG 상태에서는 zustand runtime 접근이 불확실하므로 sentinel만 남기고 기존
-      // useStateRehydration 경로에 의존 — 기존 회귀 표면 없음.
-      if (AppState.currentState === 'active') {
-        try {
-          useDestinationStore.setState({
-            destination: null,
-            customOrigin: null,
-            tripOrigin: null,
-          });
-          addDomainBreadcrumb('trip', 'end', {
-            reason: 'silent-push-fg-immediate',
-          });
-          await useBoardingLockStore.getState().releaseLock();
-          await clearTripEndedSentinel();
-        } catch (e) {
-          logger.warn('FG 즉시 store reset 실패 (graceful — sentinel 유지):', e);
+      // ack outcome='fired'는 backend pendingPushes 입장에서는 "처리 완료, alert fallback 발사 마라"
+      // 신호. trip-ended는 alert fallback 대상이 아니지만 호환을 위해 일반 silent push와 같은 의미로 ack.
+      case 'trip-ended': {
+        logger.info(
+          `trip-ended received: reason=${payload.reason} tripToken=${payload.tripToken?.slice(0, 8) ?? 'unknown'} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
+        );
+        // race 가드(#868 P1-2). 신규 backend는 tripToken을 항상 보냄. 구버전(undefined)은
+        // 호환 위해 cleanup 진행 — race 가능성은 있지만 backend 배포 후 사라짐.
+        if (payload.tripToken !== undefined) {
+          const activeTripToken = await AsyncStorage.getItem(ACTIVE_TRIP_KEY);
+          if (activeTripToken !== null && activeTripToken !== payload.tripToken) {
+            logger.warn(
+              `trip-ended skip: tripToken mismatch payload=${payload.tripToken.slice(0, 8)} active=${activeTripToken.slice(0, 8)}`,
+            );
+            void ackOutcome(payload.pushId, apnsToken, 'fired', `trip-ended:${payload.reason}:token-mismatch`);
+            return;
+          }
         }
+        // #2120 (#2114 근본 수리 Phase 2) — corrId 인스턴스 가드. tripToken(APNs 기기 토큰)은
+        // 기기당 고정이라 위 token 비교는 "같은 기기의 다른 trip" race를 못 잡는다. backend
+        // 자동종료(la-stale/eta-missing 등) push가 in-flight인 수 초 사이 device가 재등록하면,
+        // 새 trip의 ACTIVE_TRIP_KEY(=같은 token)를 그대로 통과해 옛 trip 종료 push가 새 trip을
+        // 즉시 cleanup해버린다. corrId는 register마다 새로 발급되는 trip 인스턴스 식별자이므로
+        // payload와 device 현재 값이 둘 다 있는데 다르면 그 사이 재등록이 있었다는 뜻 — cleanup
+        // 전체를 skip한다. 어느 한쪽이라도 없으면(구버전 backend / cache 미수화) 기존 동작 유지.
+        // payload.corrId가 없는(구버전 backend) 경로는 device corrId를 조회할 필요조차 없다 —
+        // 불필요한 sync cache read를 피해 이후 endedCorrIdSnapshot 캡처 시점과의 혼동도 방지한다.
+        if (payload.corrId !== undefined) {
+          const deviceCorrId = getCurrentTripCorrIdSync();
+          if (deviceCorrId !== null && payload.corrId !== deviceCorrId) {
+            logger.warn(
+              `trip-ended skip: corrId mismatch payload=${payload.corrId} device=${deviceCorrId}`,
+            );
+            logSilentPushSkipped({
+              stationName: `trip-ended:${payload.reason}`,
+              kind: undefined,
+              reason: 'trip-ended-corr-mismatch',
+            });
+            void ackOutcome(payload.pushId, apnsToken, 'skipped', `trip-ended:${payload.reason}:corr-mismatch`);
+            return;
+          }
+        }
+        logSilentPushTripEndedReceived({
+          reason: payload.reason,
+          sentAt: payload.sentAt,
+          receivedAt,
+        });
+        // #1370 L4 — OS scheduled queue burst fire 차단. 종착역 도착 시 backend trip-ended push가
+        // 도달할 때 device 로컬 OS queue(`bl:`/`tba:`)에 잔존한 사전 예약 알람이 동시에 발사돼
+        // 사용자가 "용마산 도착 후 한꺼번에 받음"으로 인지하는 회귀.
+        //
+        // runTripBoundCleanups가 결국 OS queue를 cancel하지만, 그 전에 triggerTripEndRecall이
+        // routeStops 구성 + network upload로 수 초 stall할 수 있어 race window가 열린다.
+        // OS queue cancel만 별도 helper로 분리해 trip-ended 진입 즉시 호출 — recall/cleanup 흐름은
+        // 그대로 유지. cancel 자체는 멱등하므로 runTripBoundCleanups의 중복 cancel은 안전 통과.
+        await cancelTripBoundOsQueue();
+        // #919 — trip-end recall KPI upload. *반드시* cleanup 전에 호출해야 한다 — trigger가
+        // ROUTE_KEY/DESTINATION_KEY/TRIP_STARTED_AT_KEY를 읽어 routeStops를 구성하기 때문.
+        // trigger는 throw하지 않으므로 후속 cleanup/sentinel 흐름 차단 없음.
+        await triggerTripEndRecall();
+        // #1597 — clearTripCorrId가 cache를 비우기 전에 종료된 trip의 corrId snapshot 캡처.
+        const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
+        await runTripBoundCleanups();
+        // #1597 — trip-end 사용자 정답지 prompt enqueue (cleanup 후, corrId snapshot으로).
+        await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
+        // #899 (Seam C) — BG에서는 zustand store에 접근 불가. FG 복귀 시점에
+        // useStateRehydration이 이 sentinel을 보고 destination/lock store도 reset.
+        // #2114 (방안 C′) — sentinel에 corrId 동봉해 다음 소비 시점 trip 인스턴스 스코프 비교 가능하게.
+        await setTripEndedSentinel(receivedAt, endedCorrIdSnapshot);
+        // #2018 γ' — FG 상태에서는 useStateRehydration의 AppState 'active' 이벤트가
+        // 발생하지 않아 sentinel이 다음 BG/FG cycle까지 처리되지 않는다. 그동안 in-memory
+        // destination store가 stale로 남아 UI가 "현재역 → 현재역 0정거장" 형태로 잔존
+        // (2026-07-02 dogfood 관찰 20 성수→성수 evidence). FG 진행 중이면 setState를
+        // 여기서 즉시 수행해 store를 정리하고 sentinel을 그 자리에서 clear한다.
+        // BG 상태에서는 zustand runtime 접근이 불확실하므로 sentinel만 남기고 기존
+        // useStateRehydration 경로에 의존 — 기존 회귀 표면 없음.
+        if (AppState.currentState === 'active') {
+          try {
+            useDestinationStore.setState({
+              destination: null,
+              customOrigin: null,
+              tripOrigin: null,
+            });
+            addDomainBreadcrumb('trip', 'end', {
+              reason: 'silent-push-fg-immediate',
+            });
+            await useBoardingLockStore.getState().releaseLock();
+            await clearTripEndedSentinel();
+          } catch (e) {
+            logger.warn('FG 즉시 store reset 실패 (graceful — sentinel 유지):', e);
+          }
+        }
+        // #2069 (Phase 3) — B12 원격 alert push 단일 채널. iOS가 시스템 banner를 직접 표시하므로
+        // 로컬 알림 재생성(D11, 구 `surfaceTripEnded`)은 제거. dedup store에는 그대로 기록해 같은
+        // pushId의 backend retry가 도달해도(FIRED_PUSH_IDS 공유) 중복 처리를 막는다.
+        if (payload.pushId) await addFiredPushId(payload.pushId);
+        void ackOutcome(payload.pushId, apnsToken, 'fired', `trip-ended:${payload.reason}`);
+        return;
       }
-      // #2069 (Phase 3) — B12 원격 alert push 단일 채널. iOS가 시스템 banner를 직접 표시하므로
-      // 로컬 알림 재생성(D11, 구 `surfaceTripEnded`)은 제거. dedup store에는 그대로 기록해 같은
-      // pushId의 backend retry가 도달해도(FIRED_PUSH_IDS 공유) 중복 처리를 막는다.
-      if (payload.pushId) await addFiredPushId(payload.pushId);
-      void ackOutcome(payload.pushId, apnsToken, 'fired', `trip-ended:${payload.reason}`);
-      return;
-    }
 
-    // boarding-prompt 분기 (#2069 Phase 3) — B7 원격 alert push 단일 채널로 정리되며 B8(silent
-    // fallback) 이 제거됐다. 이 kind 는 이 BG task 로 더 이상 발사되지 않지만, 롤아웃 중 구버전
-    // backend 재시도가 도달할 가능성에 대비해 no-op + 로그만 남긴다 (로컬 알림 재구성 X).
-    // 응답 버튼(BOARDING_PROMPT_CATEGORY)은 원격 alert push 자체의 category 로 노출되며, 등록은
-    // 앱 초기화(`app/_layout.tsx` → `setupBoardingPromptCategory`)에서 로컬 발사와 무관하게 이뤄진다.
-    if (payload.kind === 'boarding-prompt') {
-      logger.info(
-        `boarding-prompt received (remote-only, no local notification): originStation=${payload.originStation} line=${payload.line} tripToken=${payload.tripToken.slice(0, 8)} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
-      );
-      void ackOutcome(payload.pushId, apnsToken, 'skipped', 'boarding-prompt-remote-only');
-      return;
-    }
+      // boarding-prompt 분기 (#2069 Phase 3) — B7 원격 alert push 단일 채널로 정리되며 B8(silent
+      // fallback) 이 제거됐다. 이 kind 는 이 BG task 로 더 이상 발사되지 않지만, 롤아웃 중 구버전
+      // backend 재시도가 도달할 가능성에 대비해 no-op + 로그만 남긴다 (로컬 알림 재구성 X).
+      // 응답 버튼(BOARDING_PROMPT_CATEGORY)은 원격 alert push 자체의 category 로 노출되며, 등록은
+      // 앱 초기화(`app/_layout.tsx` → `setupBoardingPromptCategory`)에서 로컬 발사와 무관하게 이뤄진다.
+      case 'boarding-prompt': {
+        logger.info(
+          `boarding-prompt received (remote-only, no local notification): originStation=${payload.originStation} line=${payload.line} tripToken=${payload.tripToken.slice(0, 8)} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
+        );
+        void ackOutcome(payload.pushId, apnsToken, 'skipped', 'boarding-prompt-remote-only');
+        return;
+      }
 
-    // sleep-alarm-companion 분기 (#2036 Issue I γ → #2067 Phase 2-device D3) — 취침모드 companion
-    // 알람. 알림(배너) 생성 없이 TTS/진동만 부가하고 OS 안전망 예약을 cancel한다.
-    //
-    // 정책 (ADR-023 정합):
-    //  - Backend는 취침 무관 발사 (기존 arvlCd/vanish 경로는 sleep 조회 없음).
-    //  - Device가 `AlarmLocalAuthority.fireCompanionAlarm`이 sleepMode=true 확인 후에만 발사.
-    //  - sleepMode=false면 일반모드 = 원격 visible push(#2066)가 주 채널 담당 → 본 분기는 no-op skip.
-    //  - dedup: `AlarmLocalAuthority`의 persisted ledger(TTL 1h) — 앱 재시작 생존.
-    if (payload.kind === 'sleep-alarm-companion') {
-      logger.info(
-        `sleep-alarm-companion received: originStation=${payload.originStation} targetKind=${payload.targetKind} nextLine=${payload.nextLine} nextStation=${payload.nextStation} tripToken=${payload.tripToken.slice(0, 8)} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
-      );
-      await fireSleepAlarmCompanion(payload, apnsToken);
-      return;
+      // sleep-alarm-companion 분기 (#2036 Issue I γ → #2067 Phase 2-device D3) — 취침모드 companion
+      // 알람. 알림(배너) 생성 없이 TTS/진동만 부가하고 OS 안전망 예약을 cancel한다.
+      //
+      // 정책 (ADR-023 정합):
+      //  - Backend는 취침 무관 발사 (기존 arvlCd/vanish 경로는 sleep 조회 없음).
+      //  - Device가 `AlarmLocalAuthority.fireCompanionAlarm`이 sleepMode=true 확인 후에만 발사.
+      //  - sleepMode=false면 일반모드 = 원격 visible push(#2066)가 주 채널 담당 → 본 분기는 no-op skip.
+      //  - dedup: `AlarmLocalAuthority`의 persisted ledger(TTL 1h) — 앱 재시작 생존.
+      case 'sleep-alarm-companion': {
+        logger.info(
+          `sleep-alarm-companion received: originStation=${payload.originStation} targetKind=${payload.targetKind} nextLine=${payload.nextLine} nextStation=${payload.nextStation} tripToken=${payload.tripToken.slice(0, 8)} sentAt=${payload.sentAt ?? 'unknown'} pushId=${payload.pushId ?? 'unknown'}`,
+        );
+        await fireSleepAlarmCompanion(payload, apnsToken);
+        return;
+      }
+
+      // station waypoint kind(standard silent push)와 kind 미상(구 백엔드)은 이 switch가 다루지
+      // 않는다 — 아래 standard 처리 경로로 넘어간다.
+      case 'transfer':
+      case 'destination':
+      case 'intermediate':
+      case undefined:
+        break;
+
+      /* istanbul ignore next -- 위 case들이 ExtractedPayload['kind']의 모든 값을 exhaustive하게
+       * 나열하므로(reschedule/trip-ended/boarding-prompt/sleep-alarm-companion/transfer/destination/
+       * intermediate/undefined) default는 컴파일 타임에만 의미가 있는 방어 코드다. CONTROL_PUSH_KINDS
+       * 또는 STATION_WAYPOINT_KINDS(pushContract SSoT)에 새 값이 추가되고 이 switch가 갱신되지
+       * 않으면 여기 도달 전에 이미 컴파일 에러가 난다(A1 실증) — 런타임 도달은 타입 시스템이 깨진
+       * 경우(예: any 캐스팅)뿐이라 테스트 불가능한 순수 방어 코드.
+       */
+      default:
+        assertNever(payload, 'handleSilentPush control-kind dispatch');
     }
 
     logger.info(

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -7,6 +7,7 @@ import { createLogger } from '../../../shared/utils/logger';
 import type { AlarmEvent } from './stationAlarm';
 import type { AlarmPhaseId } from './alarmPhases';
 import type { Station } from '../../../shared/types/station';
+import type { StationWaypointKind } from '../../../shared/types/pushContract';
 
 // 알람 발사/억제 이벤트를 AsyncStorage ring buffer로 적재한다.
 // false alarm 인지(B2) 및 차후 임계값 측정 기반 재조정(A)·GPS+Arrival fusion(C)의
@@ -1006,7 +1007,7 @@ export function clearAlarmLogWindows(): Promise<void> {
  */
 export function logSilentPushReceived(input: {
   stationName: string;
-  kind: AlarmLogKind | 'intermediate' | undefined;
+  kind: StationWaypointKind | undefined;
   phaseId: AlarmPhaseId;
   sentAt: number | undefined;
   receivedAt: number;

--- a/src/features/alarm/utils/stationNotification.ts
+++ b/src/features/alarm/utils/stationNotification.ts
@@ -38,6 +38,7 @@ import {
 } from './notificationSource';
 import { buildStationNotifCollapseId } from './stationNotifCollapseId';
 import { markLocalStationFired, hasRecentLocalStationFire } from './recentLocalStationFires';
+import type { StationWaypointKind } from '../../../shared/types/pushContract';
 
 /** 알람/통과 본문 끝에 데이터 출처를 자백하는 라벨을 부착한다.
  *  - source 미지정 → 라벨 생략 (기존 caller 회귀 안전)
@@ -128,7 +129,10 @@ async function isFallbackDuplicate(
 // 로컬 dispatchStationPassed의 AlarmLogKind('station-passed')로 매핑.
 // #918 — OS 사전예약(stationPrescheduler)이 transfer/destination kind도 커버하게 되면서
 // 매핑도 identity 항목 2개를 추가(로컬 kind 이름이 backend kind 이름과 동일).
-const BACKEND_PUSH_KIND_TO_LOCAL_FIRE_KIND: Record<string, string> = {
+// #2235 (ADR-029 Phase 0) — 키를 pushContract SSoT `StationWaypointKind`로 타입해 exhaustive
+// 하게 강제한다. STATION_WAYPOINT_KINDS에 새 값이 추가되면 이 Record 리터럴이 컴파일 에러를 낸다
+// (키 누락 = 드리프트 = 빌드 실패).
+const BACKEND_PUSH_KIND_TO_LOCAL_FIRE_KIND: Record<StationWaypointKind, string> = {
   intermediate: 'station-passed',
   transfer: 'transfer',
   destination: 'destination',
@@ -137,10 +141,12 @@ const BACKEND_PUSH_KIND_TO_LOCAL_FIRE_KIND: Record<string, string> = {
 /**
  * backend push의 `data.kind`를 device local fire kind로 매핑. `scheduledAlarmReceiver`(#918)가
  * "remote 선표시 시 해당 역 pending 사전예약 cancel" 판정에 재사용 — 매핑 테이블의 단일 owner.
- * 매핑이 없는 kind(예: 'reschedule'/'trip-ended' 등 비-station 계열)는 null.
+ * 매핑이 없는 kind(예: 'reschedule'/'trip-ended' 등 비-station 계열, 또는 런타임 미검증 문자열)는
+ * null. 입력은 검증되지 않은 원본 문자열일 수 있어(#2122 `isRecentLocalAuxFireDuplicate` 호출부)
+ * 파라미터 타입은 `string`으로 유지 — 룩업 테이블 자체(키 집합)만 SSoT로 타입한다.
  */
 export function mapBackendKindToLocalFireKind(backendKind: string): string | null {
-  return BACKEND_PUSH_KIND_TO_LOCAL_FIRE_KIND[backendKind] ?? null;
+  return BACKEND_PUSH_KIND_TO_LOCAL_FIRE_KIND[backendKind as StationWaypointKind] ?? null;
 }
 
 /**

--- a/src/shared/types/__tests__/pushContract.test.ts
+++ b/src/shared/types/__tests__/pushContract.test.ts
@@ -1,0 +1,97 @@
+import {
+  ALARM_EVENT_TYPES,
+  CONTROL_PUSH_KINDS,
+  SLEEP_ALARM_TARGET_KINDS,
+  STATION_WAYPOINT_KINDS,
+  assertNever,
+  isControlPushKind,
+  isSleepAlarmTargetKind,
+  isStationWaypointKind,
+  type StationWaypointKind,
+} from '../pushContract';
+
+/**
+ * #2235 (ADR-029 Phase 0) — device 측 exhaustive switch 데모. backend/device 양쪽이 이 파일과
+ * 동일한 SSoT(`StationWaypointKind`)를 참조한다고 가정한 최소 재현. 실제 소비 지점은
+ * `src/features/alarm/tasks/silentPushTask.ts`의 `handleSilentPush` control-kind switch.
+ */
+function exhaustiveStationKindSwitch(kind: StationWaypointKind): string {
+  switch (kind) {
+    case 'transfer':
+      return 'transfer';
+    case 'destination':
+      return 'destination';
+    case 'intermediate':
+      return 'intermediate';
+    default:
+      return assertNever(kind, 'pushContract.test demo');
+  }
+}
+
+describe('pushContract SSoT (#2235 ADR-029 Phase 0)', () => {
+  it('STATION_WAYPOINT_KINDS 각 값을 exhaustive switch가 정상 처리한다', () => {
+    for (const kind of STATION_WAYPOINT_KINDS) {
+      expect(exhaustiveStationKindSwitch(kind)).toBe(kind);
+    }
+  });
+
+  it('isStationWaypointKind는 SSoT 배열에 있는 값만 narrow한다', () => {
+    expect(isStationWaypointKind('transfer')).toBe(true);
+    expect(isStationWaypointKind('destination')).toBe(true);
+    expect(isStationWaypointKind('intermediate')).toBe(true);
+    expect(isStationWaypointKind('unknown-kind')).toBe(false);
+    expect(isStationWaypointKind(undefined)).toBe(false);
+  });
+
+  it('isControlPushKind는 CONTROL_PUSH_KINDS 배열에 있는 값만 narrow한다', () => {
+    for (const kind of CONTROL_PUSH_KINDS) {
+      expect(isControlPushKind(kind)).toBe(true);
+    }
+    expect(isControlPushKind('not-a-control-kind')).toBe(false);
+  });
+
+  it('isSleepAlarmTargetKind는 SLEEP_ALARM_TARGET_KINDS 배열에 있는 값만 narrow한다', () => {
+    for (const kind of SLEEP_ALARM_TARGET_KINDS) {
+      expect(isSleepAlarmTargetKind(kind)).toBe(true);
+    }
+    expect(isSleepAlarmTargetKind('intermediate')).toBe(false);
+  });
+
+  it('ALARM_EVENT_TYPES SSoT 배열이 backend AlarmEventPayload.type과 정렬된 4종을 갖는다', () => {
+    expect(ALARM_EVENT_TYPES).toEqual([
+      'station-passed',
+      'transfer',
+      'destination',
+      'imminent',
+    ]);
+  });
+
+  it(
+    'A1 실증 — SSoT에 없는 값을 exhaustive switch에 강제로 전달하면 컴파일 에러가 난다. ' +
+      '이는 "backend가 새 kind를 추가했는데 device exhaustive switch가 갱신되지 않은" 드리프트 ' +
+      '시나리오의 최소 재현이다: 아래 @ts-expect-error가 없으면 `npm run type-check`가 실패한다.',
+    () => {
+      expect(() => {
+        // @ts-expect-error — 'imminent-hop'은 StationWaypointKind(SSoT)에 없는 값. 새 discriminator를
+        // pushContract에 추가하지 않고 소비 지점에 억지로 통과시키면, switch의 어떤 case에도 매치되지
+        // 않아 default(assertNever)로 떨어지고 assertNever의 파라미터 타입(never)과 불일치해 컴파일
+        // 에러가 난다 — 드리프트가 런타임 사고가 아니라 빌드 실패로 전환됨을 실증한다(ADR-029).
+        exhaustiveStationKindSwitch('imminent-hop');
+      }).toThrow(/pushContract: unhandled discriminator/);
+    },
+  );
+
+  it('assertNever는 런타임에 도달하면(타입 시스템 우회 시) 명시적으로 throw한다', () => {
+    expect(() =>
+      // @ts-expect-error — never 파라미터에 임의 문자열을 강제 전달(런타임 방어 동작 검증용).
+      assertNever('not-a-real-discriminator'),
+    ).toThrow(/pushContract: unhandled discriminator/);
+  });
+
+  it('assertNever는 context가 없어도 throw 메시지를 생성한다', () => {
+    expect(() =>
+      // @ts-expect-error — never 파라미터에 임의 문자열을 강제 전달(context 생략 케이스).
+      assertNever('no-context-case'),
+    ).toThrow('pushContract: unhandled discriminator: "no-context-case"');
+  });
+});

--- a/src/shared/types/pushContract.ts
+++ b/src/shared/types/pushContract.ts
@@ -1,0 +1,76 @@
+/**
+ * Cross-boundary push 계약 SSoT (ADR-029 Phase 0 / #2235).
+ *
+ * backend(Cloudflare Worker, `backend/alarm-worker`)와 device(RN, `src/`)는 untyped JSON push
+ * payload로 통신한다. 두 런타임이 별도 빌드라 discriminator(kind/type/targetKind) union이 여러
+ * 벌 복제·드리프트되던 문제(2026-08-09 dump RCA)를 이 모듈 하나로 통합한다.
+ *
+ * - 모든 discriminator를 `as const` 배열 + 파생 union type으로 정의(SSoT).
+ * - backend/device 양쪽 소비 지점은 이 모듈을 import하고, exhaustive `switch` + `assertNever`로
+ *   소비해 새 discriminator 추가 시 컴파일 에러가 나도록 한다.
+ * - 순수 타입/상수 모듈 — 런타임 동작을 갖지 않는다(assertNever 예외 throw 제외).
+ *
+ * 원천 정의는 이 파일 하나. backend/device 각 벌 union을 "SSoT를 re-export"로 남기는 것은
+ * 허용되지만(호출부 광범위 변경 최소화), 값의 집합 자체는 여기서만 바뀐다.
+ */
+
+/**
+ * station waypoint 종류. backend `Waypoint.kind` / silent push payload `kind` 필드의 원천.
+ * - 'transfer' — 환승 안내
+ * - 'destination' — 최종 도착
+ * - 'intermediate' — 중간역 통과
+ */
+export const STATION_WAYPOINT_KINDS = ['transfer', 'destination', 'intermediate'] as const;
+export type StationWaypointKind = (typeof STATION_WAYPOINT_KINDS)[number];
+
+/**
+ * standard station push와 별개로 존재하는 "제어용" silent/alert push discriminator.
+ * 각 값은 서로 다른 payload schema를 가진 별도 채널이다(backend `apns.ts` sender 함수 1:1).
+ */
+export const CONTROL_PUSH_KINDS = [
+  'reschedule',
+  'trip-ended',
+  'boarding-prompt',
+  'sleep-alarm-companion',
+] as const;
+export type ControlPushKind = (typeof CONTROL_PUSH_KINDS)[number];
+
+/**
+ * alarm-event ring buffer(`TripPositionSSoT.alarmEvents`) 항목의 `type`. backend `apns.ts`
+ * `AlarmEventPayload.type` / device `backendSsotMirror`의 alarmEvents entry와 1:1.
+ */
+export const ALARM_EVENT_TYPES = ['station-passed', 'transfer', 'destination', 'imminent'] as const;
+export type AlarmEventType = (typeof ALARM_EVENT_TYPES)[number];
+
+/**
+ * 취침 알람 companion push의 `targetKind` — 알람 대상이 환승역인지 도착역인지.
+ * station waypoint kind의 부분집합(intermediate 제외 — companion은 임박 도착/환승만 대상).
+ */
+export const SLEEP_ALARM_TARGET_KINDS = ['transfer', 'destination'] as const;
+export type SleepAlarmTargetKind = (typeof SLEEP_ALARM_TARGET_KINDS)[number];
+
+/**
+ * exhaustive switch용 헬퍼. 모든 case를 처리한 뒤 남은 타입이 `never`가 아니면 컴파일 에러가 난다
+ * (drift = 빌드 실패). 런타임에 도달하면 SSoT에 없는 미지 discriminator를 만난 것 — 개발 중
+ * 새 discriminator를 SSoT에 추가하지 않고 소비 지점만 늘렸을 때만 발생 가능하다.
+ */
+export function assertNever(value: never, context?: string): never {
+  throw new Error(
+    `pushContract: unhandled discriminator${context ? ` (${context})` : ''}: ${JSON.stringify(value)}`,
+  );
+}
+
+/** `STATION_WAYPOINT_KINDS`에 속하는 값인지. 런타임 미검증 문자열(JSON payload)의 narrowing에 사용. */
+export function isStationWaypointKind(value: unknown): value is StationWaypointKind {
+  return (STATION_WAYPOINT_KINDS as readonly unknown[]).includes(value);
+}
+
+/** `CONTROL_PUSH_KINDS`에 속하는 값인지. */
+export function isControlPushKind(value: unknown): value is ControlPushKind {
+  return (CONTROL_PUSH_KINDS as readonly unknown[]).includes(value);
+}
+
+/** `SLEEP_ALARM_TARGET_KINDS`에 속하는 값인지. */
+export function isSleepAlarmTargetKind(value: unknown): value is SleepAlarmTargetKind {
+  return (SLEEP_ALARM_TARGET_KINDS as readonly unknown[]).includes(value);
+}


### PR DESCRIPTION
Part of #2234
Closes #2235

## 요약

backend↔device push 계약을 `src/shared/types/pushContract.ts` 단일 SSoT로 통합하고, 모든 discriminator 소비 지점을 exhaustive `switch` + `assertNever`로 전환했다(ADR-029 Phase 0). **순수 타입 통합 + exhaustive화 — 런타임 동작 변경 없음.**

### SSoT로 통합한 discriminator

- `STATION_WAYPOINT_KINDS` — `transfer` | `destination` | `intermediate` (backend `Waypoint.kind` / device silent push `kind`)
- `CONTROL_PUSH_KINDS` — `reschedule` | `trip-ended` | `boarding-prompt` | `sleep-alarm-companion`
- `ALARM_EVENT_TYPES` — `station-passed` | `transfer` | `destination` | `imminent` (`AlarmEventPayload.type`)
- `SLEEP_ALARM_TARGET_KINDS` — `transfer` | `destination` (`targetKind`)

각 값은 `as const` 배열 + 파생 union type + `assertNever`/`isXxxKind` narrowing 헬퍼로 export.

### 변경 파일

- **신규**: `src/shared/types/pushContract.ts` (SSoT), `src/shared/types/__tests__/pushContract.test.ts`
- **backend**: `apns.ts`(53/226/931), `types.ts`(Waypoint.kind + Reschedule/TripEndedAlert/BoardingPrompt payload의 kind를 `Extract<ControlPushKind, 'X'>`로), `pendingPushes.ts`(50), `scheduled.ts`(silentPushFiredByKind 카운터 if-체인 2곳 → switch+assertNever), `tsconfig.json`(include 추가)
- **device**: `silentPushTask.ts`(SilentPushPayload.kind + 4개 control payload interface의 kind + sleep companion targetKind + `handleSilentPush`의 control-kind if-체인 → switch+assertNever), `alarmLog.ts`(`logSilentPushReceived` kind 파라미터), `stationNotification.ts`(`BACKEND_PUSH_KIND_TO_LOCAL_FIRE_KIND`를 `Record<StationWaypointKind, string>`로 타입)

### A1 실증 (type-test)

`src/shared/types/__tests__/pushContract.test.ts`에 `@ts-expect-error`로 SSoT에 없는 값(`'imminent-hop'`)을 exhaustive switch에 강제 전달하면 컴파일 에러가 남을 실증. `npm run type-check`가 clean으로 통과하는 것 자체가 이 directive가 실제 타입 에러를 정확히 잡아냈다는 증거(unused directive면 tsc가 별도 에러를 낸다).

### 스코프 경계 (알려진 잔여 — 별도 이슈로 다룰 후속)

`AlarmEventType`과 같은 값 집합을 정의하는 backend `tripPositionSsot.ts`, device `backendSsotMirror.ts`의 인라인 union은 이번 PR 스코프 밖(호출부 광범위 변경 최소화 원칙, 이슈 본문 "허용" 조항). 동작 영향 없음(값 동일) — Phase 4(계약 변경 프로세스 강제) 이전에 정리 후보로 남긴다.

## Wire 5단

1. **Orphan**: `npm run lint:orphan` pass (0 orphan). pushContract 신규 export 전부 backend/device 양쪽에서 실제 import됨.
2. **V/X dashboard**: type-check CI(`Type Check & Test`)가 SSoT 위반을 컴파일 에러로 잡는다 — 데모는 `@ts-expect-error` type-test로 실증(위). 별도 런타임 dashboard 신호 없음(순수 타입 레이어).
3. **의존 PR**: #2232, #2233 (선행 머지 완료 확인 — 본 브랜치는 origin/dev의 두 PR 머지 커밋을 포함한 상태에서 분기).
4. **측정 plan**: 이후 push kind 변경 PR에서 backend/device 한쪽만 수정하면 반대쪽 exhaustive switch 컴파일 에러 → CI red로 즉시 드러남. 별도 런타임 측정 불필요(컴파일 타임 가드).
5. **Device verify**: N/A — type+unit only (순수 타입 통합, 런타임 무변).

## 검증

- `npm run type-check` — clean (device root tsconfig, `@ts-expect-error` 정합 확인 포함)
- `npm test` — 430 suites / 9154 tests pass, coverage 100%(statements/branches/functions/lines)
- `cd backend/alarm-worker && npx vitest run --coverage` — 77 suites / 2893 tests pass, ratchet floor 충족(statements 97.22%/branches 96.24%/functions 99.21%/lines 97.22%, floor 97/96/98/97)
- `npm run lint:orphan` — 0 orphan
- `npx eslint` on changed files — clean
- 자체 code-review(서브에이전트) — 런타임 동작 변경 없음 확인, P1 없음