### PR TITLE
feat(#2243): push 계약 런타임 경계 검증(G6 unknown 정책 + G2 semantic)

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   BOARDING_PROMPT_CATEGORY,
   buildApnsJwt,
+  buildSilentPushData,
   resetApnsJwtCache,
   sendAlertPush,
   sendBoardingPromptPush,
@@ -12,6 +13,7 @@ import {
   sendSleepAlarmCompanionPush,
   sendTripEndedAlertPush,
   type ApnsConfig,
+  type SilentPushPayload,
 } from '../apns';
 import { TRIP_ENDED_ALERT_BODY, TRIP_ENDED_ALERT_TITLE } from '../alertContent';
 
@@ -1641,5 +1643,62 @@ describe('sendSleepAlarmCompanionPush (#2066)', () => {
     const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
     const headers = call[1].headers as Record<string, string>;
     expect(headers['apns-thread-id']).toBe('trip-sleep-999');
+  });
+});
+
+// #2243 (ADR-029 Phase 1, G2) — buildSilentPushData 발신 경계 값 스키마 검증.
+describe('buildSilentPushData contract skew (#2243, ADR-029 Phase 1 G2)', () => {
+  function validPayload(): SilentPushPayload {
+    return {
+      nextWaypoint: '강남',
+      etaSeconds: 60,
+      phase: 'early',
+      kind: 'destination',
+      sentAt: 1_700_000_000_000,
+      pushId: 'push-uuid-skew',
+    };
+  }
+
+  it('정상 payload면 console.warn을 호출하지 않는다', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    buildSilentPushData(validPayload());
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('etaSeconds가 음수면 console.warn(fields=etaSeconds)을 남기지만 data는 그대로 wire한다', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const data = buildSilentPushData({ ...validPayload(), etaSeconds: -5 });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('fields=etaSeconds'));
+    expect(data.etaSeconds).toBe(-5);
+    warnSpy.mockRestore();
+  });
+
+  it('nextWaypoint가 빈 문자열이면 console.warn(fields=nextWaypoint)을 남긴다', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    buildSilentPushData({ ...validPayload(), nextWaypoint: '' });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('fields=nextWaypoint'));
+    warnSpy.mockRestore();
+  });
+
+  it('phase가 SSoT 밖 값이면 console.warn(fields=phase)을 남긴다', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    buildSilentPushData({ ...validPayload(), phase: 'late' as SilentPushPayload['phase'] });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('fields=phase'));
+    warnSpy.mockRestore();
+  });
+
+  it('여러 필드가 동시에 어긋나면 fields 목록에 전부 포함된다', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    buildSilentPushData({
+      ...validPayload(),
+      nextWaypoint: '',
+      etaSeconds: NaN,
+      phase: 'late' as SilentPushPayload['phase'],
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('fields=nextWaypoint,etaSeconds,phase'),
+    );
+    warnSpy.mockRestore();
   });
 });

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -21,6 +21,11 @@ import type {
   SleepAlarmTargetKind,
   StationWaypointKind,
 } from '../../../src/shared/types/pushContract';
+import {
+  isPushAlarmPhase,
+  isValidEtaSeconds,
+  isValidStationIdentifier,
+} from '../../../src/shared/types/pushContract';
 
 /**
  * iOS UNNotificationCategory 식별자 (#819 B 슬라이스). 클라이언트는 같은 식별자로
@@ -322,7 +327,27 @@ export interface SendPushResult {
  * 동일한 optional-field omission 규칙(undefined/false/빈 배열은 자연 누락)을 공유한다 — 채널이
  * silent→alert로 바뀌어도 device 소비 코드(SSoT cascade picker 등)가 받는 wire shape은 불변.
  */
+/**
+ * G2 (#2243, ADR-029 Phase 1) — 발신 경계 값 스키마 검증. Phase 0의 SSoT union type은 `kind` 같은
+ * discriminator 집합을 컴파일 타임에 보증하지만, 그 아래 값(nextWaypoint/etaSeconds/phase)은
+ * 타입이 `string`/`number`라 통과해도 계산 drift(NaN, 음수, 단위 착오로 인한 초대형 값, 빈
+ * 문자열 station identifier)가 런타임에 섞여 들어갈 수 있다. throw는 하지 않는다 — 발사 자체를
+ * 막는 것은 A2(silent drop 금지) 취지에 반한다. wrangler tail / Cloudflare Dashboard에서 바로
+ * 보이는 `console.warn`만 남긴다.
+ */
+function logSilentPushContractSkewIfInvalid(payload: SilentPushPayload): void {
+  const violations: string[] = [];
+  if (!isValidStationIdentifier(payload.nextWaypoint)) violations.push('nextWaypoint');
+  if (!isValidEtaSeconds(payload.etaSeconds)) violations.push('etaSeconds');
+  if (!isPushAlarmPhase(payload.phase)) violations.push('phase');
+  if (violations.length === 0) return;
+  console.warn(
+    `[push-contract-skew] buildSilentPushData value drift: fields=${violations.join(',')} nextWaypoint=${payload.nextWaypoint} etaSeconds=${payload.etaSeconds} phase=${payload.phase} pushId=${payload.pushId}`,
+  );
+}
+
 export function buildSilentPushData(payload: SilentPushPayload): Record<string, unknown> {
+  logSilentPushContractSkewIfInvalid(payload);
   return {
     nextWaypoint: payload.nextWaypoint,
     etaSeconds: payload.etaSeconds,

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -40,6 +40,9 @@ const mockLogCrossTripMirrorSkip = jest.fn();
 const mockLogBoardingPromptFired = jest.fn();
 const mockLogCompanionAlarmFired = jest.fn();
 const mockFlushAlarmLog = jest.fn().mockResolvedValue(undefined);
+// #2243 (ADR-029 Phase 1) — G6 kind skew / G2 value skew 관측 로거.
+const mockLogPushContractKindSkew = jest.fn();
+const mockLogPushContractValueSkew = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
   logSilentPushReceived: (...args: unknown[]) => mockLogSilentPushReceived(...args),
   logSilentPushRescheduleReceived: (...args: unknown[]) =>
@@ -50,6 +53,8 @@ jest.mock('../../utils/alarmLog', () => ({
   logCrossTripMirrorSkip: (...args: unknown[]) => mockLogCrossTripMirrorSkip(...args),
   logBoardingPromptFired: (...args: unknown[]) => mockLogBoardingPromptFired(...args),
   logCompanionAlarmFired: (...args: unknown[]) => mockLogCompanionAlarmFired(...args),
+  logPushContractKindSkew: (...args: unknown[]) => mockLogPushContractKindSkew(...args),
+  logPushContractValueSkew: (...args: unknown[]) => mockLogPushContractValueSkew(...args),
   flushAlarmLog: () => mockFlushAlarmLog(),
 }));
 
@@ -233,9 +238,15 @@ jest.mock('../../utils/recentLocalStationFires', () => ({
 // #918 — silentPushTask.ts가 mapBackendKindToLocalFireKind만 stationNotification.ts에서 가져온다.
 // 실제 모듈 전체를 로드하면 live-activity 네이티브 모듈 체인까지 끌려온다 — 매핑 함수만 실제
 // 구현과 동일한 순수 로직으로 재현.
+// #2243 (ADR-029 Phase 1, G6) — station-shaped skew fallback이 buildAlarmContent도 사용.
+const mockBuildAlarmContent = jest.fn((event: { phaseId: string; type: string; stationName: string }) => ({
+  title: `${event.phaseId}-title`,
+  body: `${event.stationName}-${event.type}-body`,
+}));
 jest.mock('../../utils/stationNotification', () => ({
   mapBackendKindToLocalFireKind: (backendKind: string) =>
     ({ intermediate: 'station-passed', transfer: 'transfer', destination: 'destination' })[backendKind] ?? null,
+  buildAlarmContent: (...args: unknown[]) => mockBuildAlarmContent(...(args as [never])),
 }));
 
 const mockAddDomainBreadcrumb = jest.fn();
@@ -1552,6 +1563,98 @@ describe('silentPushTask', () => {
       expect(mockLogSilentPushReceived).toHaveBeenCalledTimes(1);
       const arg = mockLogSilentPushReceived.mock.calls[0][0];
       expect(arg.rawKind).toBeUndefined();
+    });
+
+    describe('#2243 (ADR-029 Phase 1, G6) — station-shaped 계약 스큐 fallback fire', () => {
+      it('kind가 STATION_WAYPOINT_KINDS 밖의 값이면 generic imminent 알림을 즉시 발사한다', async () => {
+        await handleSilentPush(
+          payload({ kind: 'future-station-kind', phase: 'early', nextWaypoint: '강남', pushId: 'p-skew' }),
+        );
+        expect(mockScheduleNotificationAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            identifier: 'skew-fallback-강남',
+            trigger: null,
+          }),
+        );
+        expect(mockLogPushContractKindSkew).toHaveBeenCalledWith({
+          category: 'station-like',
+          rawKind: 'future-station-kind',
+          stationName: '강남',
+        });
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          ackCall('p-skew', 'fired', 'push-contract-skew-station-fallback-fired'),
+        );
+        // legacy-station-kind-ignored skip은 발생하지 않는다 — fallback fire 분기에서 즉시 return.
+        expect(mockLogSilentPushSkipped).not.toHaveBeenCalled();
+      });
+
+      it('kind가 없으면(구버전 backend) 여전히 payload-missing-kind skip — fallback fire 아님', async () => {
+        await handleSilentPush(
+          payload({ kind: undefined, phase: 'early', nextWaypoint: '강남', pushId: 'p-legacy' }),
+        );
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogPushContractKindSkew).not.toHaveBeenCalled();
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'payload-missing-kind' }),
+        );
+      });
+    });
+
+    describe('#2243 (ADR-029 Phase 1, G2) — semantic value drift skew', () => {
+      it('etaSeconds가 음수면 payload가 null(skip)이고 value-drift skew가 적재된다', async () => {
+        await handleSilentPush({
+          data: bgTaskData({ nextWaypoint: '강남', etaSeconds: -1, phase: 'early', kind: 'transfer' }),
+        });
+        expect(mockLogPushContractValueSkew).toHaveBeenCalledWith(
+          expect.objectContaining({ field: 'etaSeconds', rawValue: -1, stationName: '강남' }),
+        );
+        expect(mockLogSilentPushReceived).not.toHaveBeenCalled();
+      });
+
+      it('phase가 early/imminent가 아니면 value-drift skew가 적재된다', async () => {
+        await handleSilentPush({
+          data: bgTaskData({ nextWaypoint: '강남', etaSeconds: 10, phase: 'late', kind: 'transfer' }),
+        });
+        expect(mockLogPushContractValueSkew).toHaveBeenCalledWith(
+          expect.objectContaining({ field: 'phase', rawValue: 'late', stationName: '강남' }),
+        );
+      });
+
+      it('정상 payload면 value-drift skew가 적재되지 않는다', async () => {
+        await handleSilentPush(payload({ kind: 'transfer', phase: 'early' }));
+        expect(mockLogPushContractValueSkew).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('#2243 (ADR-029 Phase 1, G6) — control-shaped 계약 스큐 fail-closed', () => {
+      it('nextWaypoint 없이 SSoT에 없는 kind만 있으면 fail-closed(발사 없음) + skew 로그', async () => {
+        await handleSilentPush({
+          data: bgTaskData({ kind: 'future-control-kind', pushId: 'p-control-skew' }),
+        });
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockLogPushContractKindSkew).toHaveBeenCalledWith({
+          category: 'control-like',
+          rawKind: 'future-control-kind',
+        });
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          ackCall('p-control-skew', 'skipped', 'push-contract-skew-control-fail-closed'),
+        );
+      });
+
+      it('pushId가 없으면 ack 없이 skew 로그만 적재된다', async () => {
+        await handleSilentPush({ data: bgTaskData({ kind: 'future-control-kind' }) });
+        expect(mockLogPushContractKindSkew).toHaveBeenCalledWith({
+          category: 'control-like',
+          rawKind: 'future-control-kind',
+        });
+        expect(mockSendPushAck).not.toHaveBeenCalled();
+      });
+
+      it('완전히 malformed한 payload(kind 없음, nextWaypoint 없음)는 스큐 판정 없이 기존처럼 skip', async () => {
+        await handleSilentPush({ data: bgTaskData({ trigger: 'other' }) });
+        expect(mockLogPushContractKindSkew).not.toHaveBeenCalled();
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+      });
     });
 
     // #2045 (Signal 4) — 유효 payload 진입 시점에 last-received stamp 갱신 (kind 무관).

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -50,6 +50,8 @@ import {
   logSilentPushTripEndedReceived,
   logSilentPushSkipped,
   logCompanionAlarmFired,
+  logPushContractKindSkew,
+  logPushContractValueSkew,
   type AlarmLogReason,
 } from '../utils/alarmLog';
 import { fireCompanionAlarm, readSleepMode } from '../utils/alarmLocalAuthority';
@@ -76,7 +78,7 @@ import {
   cancelSafetyNetByStationKind,
 } from '../utils/safetyNetScheduler';
 import { cancelPrescheduledByStationKind } from '../utils/stationPrescheduler';
-import { mapBackendKindToLocalFireKind } from '../utils/stationNotification';
+import { mapBackendKindToLocalFireKind, buildAlarmContent } from '../utils/stationNotification';
 import { markLocalStationFired } from '../utils/recentLocalStationFires';
 import { ROUTE_KEY } from '../../../shared/constants/storageKeys';
 import type { Route } from '../../../shared/utils/stationRoute';
@@ -88,8 +90,11 @@ import { useDestinationStore } from '../../route/store/useDestinationStore';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
 import {
   assertNever,
+  isControlPushKind,
+  isPushAlarmPhase,
   isSleepAlarmTargetKind,
   isStationWaypointKind,
+  isValidEtaSeconds,
   type ControlPushKind,
   type SleepAlarmTargetKind,
   type StationWaypointKind,
@@ -428,8 +433,15 @@ function isSleepAlarmCompanionCandidate(rec: Record<string, unknown>): boolean {
   return rec.kind === 'sleep-alarm-companion';
 }
 
-function findFieldsLayer(
+/**
+ * `taskData` 안에서 `predicate`를 만족하는 첫 fields 레이어를 찾는다. 탐색 순서(level2 → level1 →
+ * root)는 `findFieldsLayer`와 동일 — layer 탐색 로직 자체는 predicate와 무관해 재사용한다
+ * (#2243, ADR-029 Phase 1 — control-shaped unknown-kind skew 탐지가 다른 predicate로 같은
+ * 탐색을 재사용).
+ */
+function findFieldsLayerBy(
   taskData: NotificationBackgroundTaskData['data'],
+  predicate: (rec: Record<string, unknown>) => boolean,
 ): Record<string, unknown> | null {
   const candidates: Array<Record<string, unknown>> = [];
   const root = asPlainObject(taskData);
@@ -443,17 +455,50 @@ function findFieldsLayer(
     candidates.push(root);
   }
   for (const rec of candidates) {
-    if (
+    if (predicate(rec)) return rec;
+  }
+  return null;
+}
+
+function findFieldsLayer(
+  taskData: NotificationBackgroundTaskData['data'],
+): Record<string, unknown> | null {
+  return findFieldsLayerBy(
+    taskData,
+    (rec) =>
       isStandardCandidate(rec) ||
       isRescheduleCandidate(rec) ||
       isTripEndedCandidate(rec) ||
       isBoardingPromptCandidate(rec) ||
-      isSleepAlarmCompanionCandidate(rec)
-    ) {
-      return rec;
-    }
-  }
-  return null;
+      isSleepAlarmCompanionCandidate(rec),
+  );
+}
+
+/**
+ * G6 (#2243, ADR-029 Phase 1) — control-shaped 계약 스큐 후보 판정. station-shaped(nextWaypoint
+ * 보유)가 아니면서 `kind`가 non-empty string인데 CONTROL_PUSH_KINDS 밖의 값인 경우만 true.
+ * `extractPayload`가 이미 알려진 control kind(reschedule/trip-ended/boarding-prompt/
+ * sleep-alarm-companion)는 먼저 처리하므로, 이 predicate는 그 분기들이 모두 실패한 뒤에만
+ * (findFieldsLayer 자체가 null을 반환한 뒤) 호출된다.
+ */
+function isUnknownControlKindCandidate(rec: Record<string, unknown>): boolean {
+  if (isStandardCandidate(rec)) return false;
+  const { kind } = rec;
+  return typeof kind === 'string' && kind.length > 0 && !isControlPushKind(kind);
+}
+
+/**
+ * `extractPayload`가 null을 반환했을 때만 호출한다 — 이미 알려진 kind(station/control 불문)는
+ * extractPayload가 먼저 처리하므로 여기 도달하는 것은 "SSoT에 없는 kind를 실은, station 형태가
+ * 아닌 payload"뿐이다. G6 정책(`pushContract.UNKNOWN_KIND_POLICY.controlLike` = fail-closed)의
+ * 판정 입력을 만든다 — 실제 fail-closed 처리(발사 안 함 + 로그)는 호출자(`handleSilentPush`)가 한다.
+ */
+function detectUnknownControlKindSkew(
+  taskData: NotificationBackgroundTaskData['data'],
+): { rawKind: string; pushId: string | undefined } | null {
+  const rec = findFieldsLayerBy(taskData, isUnknownControlKindCandidate);
+  if (!rec) return null;
+  return { rawKind: rec.kind as string, pushId: validPushId(rec.pushId) };
 }
 
 /**
@@ -503,8 +548,17 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
   } = obj as {
     nextWaypoint: string;
   } & Record<string, unknown>;
-  if (typeof etaSeconds !== 'number' || !Number.isFinite(etaSeconds)) return null;
-  if (phase !== 'early' && phase !== 'imminent') return null;
+  // G2 (#2243, ADR-029 Phase 1) — etaSeconds/phase는 SilentPushPayload에서 required 필드다.
+  // 타입은 맞아도 값이 도메인 semantics를 벗어나는 drift(NaN, 음수, 비정상 상한 초과, 알 수
+  // 없는 phase 문자열)는 조용히 drop하지 않고 skew로 관측한 뒤 기존과 동일하게 처리를 중단한다.
+  if (!isValidEtaSeconds(etaSeconds)) {
+    logPushContractValueSkew({ field: 'etaSeconds', rawValue: etaSeconds, stationName: nextWaypoint });
+    return null;
+  }
+  if (!isPushAlarmPhase(phase)) {
+    logPushContractValueSkew({ field: 'phase', rawValue: phase, stationName: nextWaypoint });
+    return null;
+  }
   const validKind = isStationWaypointKind(kind) ? kind : undefined;
   // #2231 — kind가 존재하지만(빈 문자열 제외) 알려진 값과 매치되지 않는 경우만 raw로 보존한다.
   // kind 자체가 없는(구버전 backend 단순 미지정) 경우는 계약 스큐가 아니므로 kindRaw를 남기지 않는다.
@@ -868,6 +922,25 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
 
     payload = extractPayload(input.data);
     if (!payload) {
+      // G6 (#2243, ADR-029 Phase 1) — extractPayload가 null을 반환한 것이 "완전히 malformed"인지
+      // "control-shaped인데 SSoT에 없는 kind"(계약 스큐)인지 구분한다. 후자만 fail-closed 정책
+      // 대상 — 조용한 drop 대신 skew를 명시적으로 관측한다(A2).
+      const controlSkew = detectUnknownControlKindSkew(input.data);
+      if (controlSkew) {
+        logPushContractKindSkew({ category: 'control-like', rawKind: controlSkew.rawKind });
+        addDomainBreadcrumb('push', 'contract-skew', {
+          category: 'control-like',
+          rawKind: controlSkew.rawKind,
+        });
+        logger.warn(
+          `push contract skew (control-like, fail-closed): kind=${controlSkew.rawKind}`,
+        );
+        if (controlSkew.pushId) {
+          const apnsToken = await loadApnsToken();
+          void ackOutcome(controlSkew.pushId, apnsToken, 'skipped', 'push-contract-skew-control-fail-closed');
+        }
+        return;
+      }
       logger.info('payload missing or invalid — skip');
       return;
     }
@@ -1146,6 +1219,32 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
 
     // kind 미상은 발사 불가 — 알림 본문/dedup 키 결정 불가. 구 백엔드 호환은 received 로그에만.
     if (!payload.kind) {
+      // G6 (#2243, ADR-029 Phase 1) — kindRaw가 있으면 "kind가 아예 없는" 구버전 backend 호환
+      // 케이스가 아니라 "kind는 있는데 SSoT(STATION_WAYPOINT_KINDS) 밖의 값" 계약 스큐다.
+      // station-shaped(nextWaypoint 보유) payload이므로 정책은 fallback-imminent-fire — 조용히
+      // drop하는 대신 generic imminent 알림을 즉시 발사해 안전을 우선한다.
+      if (payload.kindRaw) {
+        await fireStationKindSkewFallback(payload);
+        logPushContractKindSkew({
+          category: 'station-like',
+          rawKind: payload.kindRaw,
+          stationName: payload.nextWaypoint,
+        });
+        addDomainBreadcrumb('push', 'contract-skew', {
+          category: 'station-like',
+          rawKind: payload.kindRaw,
+        });
+        void ackOutcome(
+          payload.pushId,
+          apnsToken,
+          'fired',
+          'push-contract-skew-station-fallback-fired',
+        );
+        logger.warn(
+          `push contract skew (station-like, fallback fire): kind=${payload.kindRaw} station=${payload.nextWaypoint}`,
+        );
+        return;
+      }
       logSilentPushSkipped({
         stationName: payload.nextWaypoint,
         kind: undefined,
@@ -1411,6 +1510,25 @@ async function fireSleepAlarmCompanion(
   void ackOutcome(payload.pushId, apnsToken, 'fired', 'sleep-alarm-companion');
 }
 
+/**
+ * G6 (#2243, ADR-029 Phase 1) — station-shaped 계약 스큐(backend가 STATION_WAYPOINT_KINDS 밖의
+ * kind를 실은 standard silent push) fallback. 정책 SSoT: `pushContract.UNKNOWN_KIND_POLICY.
+ * stationLike`. 어떤 세부 종류(환승/도착/통과)인지는 알 수 없지만 어느 역인지는 알고 있으므로,
+ * transfer/destination 공용 문구 빌더(`buildAlarmContent`)를 `type: 'destination'`(비-환승 문구,
+ * 더 일반적인 표현)으로 재사용해 generic "곧 도착" 알림을 즉시 발사한다.
+ */
+async function fireStationKindSkewFallback(payload: SilentPushPayload): Promise<void> {
+  const { title, body } = buildAlarmContent({
+    phaseId: 'imminent',
+    type: 'destination',
+    stationName: payload.nextWaypoint,
+  });
+  await Notifications.scheduleNotificationAsync({
+    identifier: `skew-fallback-${payload.nextWaypoint}`,
+    content: { title, body, sound: true },
+    trigger: null,
+  });
+}
 
 /** Task 등록 — 모듈 로드 시점에 한 번 실행. */
 TaskManager.defineTask(SILENT_PUSH_TASK, handleSilentPush);

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -96,6 +96,8 @@ import {
   logGroundTruthResult,
   logLocklessTripEnd,
   countFiredAlarms,
+  logPushContractKindSkew,
+  logPushContractValueSkew,
   ALARM_LOG_BUFFER_SIZE,
   type AlarmLogEntry,
   type AlarmLogStamp,
@@ -2398,6 +2400,48 @@ describe('alarmLog', () => {
       expect(saved[0].source).toBe('companion');
       expect(saved[0].outcome).toBe('fired');
       expect(saved[0].stationName).toBe('2·뚝섬');
+    });
+
+    it('#2243 (ADR-029 Phase 1, G6): logPushContractKindSkew station-like → outcome=fired', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logPushContractKindSkew({
+        category: 'station-like',
+        rawKind: 'imminent-hop',
+        stationName: '성수',
+      });
+      await flushAlarmLog();
+      const saved = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
+      expect(saved).toHaveLength(1);
+      expect(saved[0].source).toBe('push-contract-skew');
+      expect(saved[0].outcome).toBe('fired');
+      expect(saved[0].reason).toBe('push-contract-skew-station-fallback-fired');
+      expect(saved[0].pushKindRaw).toBe('imminent-hop');
+      expect(saved[0].stationName).toBe('성수');
+    });
+
+    it('#2243 (ADR-029 Phase 1, G6): logPushContractKindSkew control-like → outcome=suppressed', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logPushContractKindSkew({ category: 'control-like', rawKind: 'new-control-kind' });
+      await flushAlarmLog();
+      const saved = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
+      expect(saved).toHaveLength(1);
+      expect(saved[0].source).toBe('push-contract-skew');
+      expect(saved[0].outcome).toBe('suppressed');
+      expect(saved[0].reason).toBe('push-contract-skew-control-fail-closed');
+      expect(saved[0].pushKindRaw).toBe('new-control-kind');
+    });
+
+    it('#2243 (ADR-029 Phase 1, G2): logPushContractValueSkew이 value drift entry를 적재한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logPushContractValueSkew({ field: 'etaSeconds', rawValue: -5, stationName: '강남' });
+      await flushAlarmLog();
+      const saved = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
+      expect(saved).toHaveLength(1);
+      expect(saved[0].source).toBe('push-contract-skew');
+      expect(saved[0].outcome).toBe('suppressed');
+      expect(saved[0].reason).toBe('push-contract-skew-value-drift');
+      expect(saved[0].pushKindRaw).toBe('etaSeconds=-5');
+      expect(saved[0].stationName).toBe('강남');
     });
 
     it('#2067 (Phase 2-device, D3): companion source는 silent push outcome 집계에서 제외 (null bucket)', () => {

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -115,7 +115,11 @@ export type AlarmLogSource =
   // 발사한 sleep-alarm-companion silent push를 device silentPushTask가 sleepMode=true 확인 후
   // AlarmLocalAuthority 경유로 TTS/진동만 부가(알림 생성 없음) — 그 시점 1건 적재. fireCount
   // 분모에 포함(실제 사용자에게 노출되는 알람). ADR-023 정합 — backend 필터 없이 device 결정.
-  | 'companion';
+  | 'companion'
+  // #2243 (ADR-029 Phase 1) — push 계약 런타임 경계 위반(unknown-kind skew / semantic value
+  // drift) 관측 전용 source. 기존 silent-push-received/-skipped 분포와 분리해 A2("silent
+  // drop 대신 명시적 skew 로그") 달성 여부를 독립적으로 측정할 수 있게 한다.
+  | 'push-contract-skew';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(#580): evaluateAlarmPhase의 firedAlarms 적중. destination/transfer phase alarm dedup
 // 발생 관찰. station-passed는 별도 메커니즘(lastNotifiedStationId)이라 'dedup-station' 사용.
@@ -360,7 +364,20 @@ export type AlarmLogReason =
   // 또는 BG location tick(저빈도 쿨다운) 두 진입점 공통 reason — source='lifecycle-backstop'로
   // 적재해 기존 backstop 계열과 같은 분포로 관측한다. 404/410(trip 부재)은 death 확정이
   // 아니므로 별도 reason 없이 무동작(ADR-010, false positive는 miss와 동급).
-  | 'trip-dead-pull-detected';
+  | 'trip-dead-pull-detected'
+  // #2243 (ADR-029 Phase 1, G6) — push 계약 unknown-kind skew 처리 결과.
+  //   'push-contract-skew-station-fallback-fired': station-shaped(nextWaypoint 보유) payload가
+  //     STATION_WAYPOINT_KINDS 밖의 kind를 실었을 때, drop 대신 generic imminent fallback을
+  //     발사한 1건. `pushContract.UNKNOWN_KIND_POLICY.stationLike` 정책 적용 결과.
+  //   'push-contract-skew-control-fail-closed': control-shaped(nextWaypoint 없음) payload가
+  //     CONTROL_PUSH_KINDS 밖의 kind를 실었을 때 거부(발사 없음)한 1건.
+  //     `pushContract.UNKNOWN_KIND_POLICY.controlLike` 정책 적용 결과.
+  | 'push-contract-skew-station-fallback-fired'
+  | 'push-contract-skew-control-fail-closed'
+  // #2243 (ADR-029 Phase 1, G2) — kind는 알려진 값인데 그 아래 값(phase/etaSeconds 등)이 도메인
+  // semantics를 벗어난 drift(NaN etaSeconds, 상한 초과, 알 수 없는 phase 문자열 등)를 경계에서
+  // 포착해 적재. 처리 자체는 기존과 동일하게 skip(발사 안 함) — 관측만 추가.
+  | 'push-contract-skew-value-drift';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -1124,6 +1141,54 @@ export function logSilentPushSkipped(input: {
 }
 
 /**
+ * push 계약 unknown-kind skew 1건 적재 (#2243, ADR-029 Phase 1 G6).
+ *
+ * `pushContract.UNKNOWN_KIND_POLICY`가 판정한 결과를 적재한다 — station-like는 fallback fire
+ * (outcome='fired'), control-like는 fail-closed(outcome='suppressed'). `source`를
+ * 'push-contract-skew'로 분리해 기존 silent-push 분포와 섞이지 않게 하고, `pushKindRaw`에
+ * backend가 실제로 보낸 원본 kind 문자열을 보존해 어떤 값이 새로 나타났는지 바로 진단 가능하게
+ * 한다(A2 — silent drop 대신 명시적 관측).
+ */
+export function logPushContractKindSkew(input: {
+  category: 'station-like' | 'control-like';
+  rawKind: string;
+  stationName?: string;
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'push-contract-skew',
+    outcome: input.category === 'station-like' ? 'fired' : 'suppressed',
+    reason:
+      input.category === 'station-like'
+        ? 'push-contract-skew-station-fallback-fired'
+        : 'push-contract-skew-control-fail-closed',
+    stationName: input.stationName,
+    pushKindRaw: input.rawKind,
+  });
+}
+
+/**
+ * push 계약 semantic value drift 1건 적재 (#2243, ADR-029 Phase 1 G2).
+ *
+ * kind는 SSoT에 있는 값인데 그 아래 값(phase/etaSeconds 등)이 도메인 범위를 벗어난 경우.
+ * 처리(발사 skip)는 기존과 동일 — 이 함수는 관측만 추가한다.
+ */
+export function logPushContractValueSkew(input: {
+  field: 'phase' | 'etaSeconds';
+  rawValue: unknown;
+  stationName?: string;
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'push-contract-skew',
+    outcome: 'suppressed',
+    reason: 'push-contract-skew-value-drift',
+    stationName: input.stationName,
+    pushKindRaw: `${input.field}=${JSON.stringify(input.rawValue)}`,
+  });
+}
+
+/**
  * 채널 2 alert fallback 발사 1건 적재 (#564).
  * 백엔드 ACK 타임아웃 후 alert push가 전달돼 발사된 경우. silent push와 다르게
  * 클라 위치 게이트 없이 OS가 즉시 표시하므로 distance/threshold는 기록하지 않는다.
@@ -1275,6 +1340,8 @@ const SILENT_PUSH_OUTCOME_SOURCES: Record<AlarmLogSource, keyof SilentPushOutcom
   'lockless-trip-end': null,
   // #2067 (Phase 2-device, D3) — companion은 device UI 발사이므로 silent push outcome 통계에서 제외.
   companion: null,
+  // #2243 (ADR-029 Phase 1) — 계약 스큐는 별도 전용 counter(countPushContractSkew)로 집계.
+  'push-contract-skew': null,
 };
 
 export interface SilentPushOutcomeCounts {
@@ -1330,6 +1397,10 @@ const FIRED_ALARM_SOURCES: Record<AlarmLogSource, boolean> = {
   'lockless-trip-end': false,
   // #2067 (Phase 2-device, D3) — companion은 실제 사용자에게 노출되는 알람이므로 fire 분모에 포함.
   companion: true,
+  // #2243 (ADR-029 Phase 1, G6) — station-shaped skew fallback은 실제 사용자에게 노출되는
+  // generic imminent 알림이므로 fire 분모에 포함(outcome='fired'인 항목만 카운트되므로
+  // control-like fail-closed 'suppressed' 항목은 자동 제외).
+  'push-contract-skew': true,
 };
 
 /**

--- a/src/shared/types/__tests__/pushContract.test.ts
+++ b/src/shared/types/__tests__/pushContract.test.ts
@@ -3,10 +3,16 @@ import {
   CONTROL_PUSH_KINDS,
   SLEEP_ALARM_TARGET_KINDS,
   STATION_WAYPOINT_KINDS,
+  PUSH_ALARM_PHASES,
+  PUSH_ETA_SECONDS_MAX,
+  UNKNOWN_KIND_POLICY,
   assertNever,
   isControlPushKind,
+  isPushAlarmPhase,
   isSleepAlarmTargetKind,
   isStationWaypointKind,
+  isValidEtaSeconds,
+  isValidStationIdentifier,
   type StationWaypointKind,
 } from '../pushContract';
 
@@ -93,5 +99,43 @@ describe('pushContract SSoT (#2235 ADR-029 Phase 0)', () => {
       // @ts-expect-error — never 파라미터에 임의 문자열을 강제 전달(context 생략 케이스).
       assertNever('no-context-case'),
     ).toThrow('pushContract: unhandled discriminator: "no-context-case"');
+  });
+});
+
+describe('pushContract G2/G6 (#2243, ADR-029 Phase 1)', () => {
+  it('UNKNOWN_KIND_POLICY — station-like는 fallback fire, control-like는 fail-closed', () => {
+    expect(UNKNOWN_KIND_POLICY.stationLike).toBe('fallback-imminent-fire');
+    expect(UNKNOWN_KIND_POLICY.controlLike).toBe('fail-closed');
+  });
+
+  it('isValidStationIdentifier — 비어있지 않고 상한 이내, 제어문자 없는 문자열만 통과', () => {
+    expect(isValidStationIdentifier('강남')).toBe(true);
+    expect(isValidStationIdentifier('동대문역사문화공원')).toBe(true);
+    expect(isValidStationIdentifier('')).toBe(false);
+    expect(isValidStationIdentifier('   ')).toBe(false);
+    expect(isValidStationIdentifier('a'.repeat(41))).toBe(false);
+    expect(isValidStationIdentifier('a'.repeat(40))).toBe(true);
+    expect(isValidStationIdentifier(`bad\nname`)).toBe(false);
+    expect(isValidStationIdentifier(123)).toBe(false);
+    expect(isValidStationIdentifier(undefined)).toBe(false);
+  });
+
+  it('PUSH_ALARM_PHASES / isPushAlarmPhase — early/imminent만 narrow', () => {
+    expect(PUSH_ALARM_PHASES).toEqual(['early', 'imminent']);
+    expect(isPushAlarmPhase('early')).toBe(true);
+    expect(isPushAlarmPhase('imminent')).toBe(true);
+    expect(isPushAlarmPhase('late')).toBe(false);
+    expect(isPushAlarmPhase(undefined)).toBe(false);
+  });
+
+  it('isValidEtaSeconds — 0 이상 PUSH_ETA_SECONDS_MAX 이하 finite number만 통과', () => {
+    expect(isValidEtaSeconds(0)).toBe(true);
+    expect(isValidEtaSeconds(120)).toBe(true);
+    expect(isValidEtaSeconds(PUSH_ETA_SECONDS_MAX)).toBe(true);
+    expect(isValidEtaSeconds(PUSH_ETA_SECONDS_MAX + 1)).toBe(false);
+    expect(isValidEtaSeconds(-1)).toBe(false);
+    expect(isValidEtaSeconds(NaN)).toBe(false);
+    expect(isValidEtaSeconds(Infinity)).toBe(false);
+    expect(isValidEtaSeconds('120')).toBe(false);
   });
 });

--- a/src/shared/types/pushContract.ts
+++ b/src/shared/types/pushContract.ts
@@ -74,3 +74,81 @@ export function isControlPushKind(value: unknown): value is ControlPushKind {
 export function isSleepAlarmTargetKind(value: unknown): value is SleepAlarmTargetKind {
   return (SLEEP_ALARM_TARGET_KINDS as readonly unknown[]).includes(value);
 }
+
+/**
+ * G6 unknown-kind 처리 정책 (ADR-029 Phase 1 / #2243) — SSoT.
+ *
+ * backend가 SSoT에 없는 새 kind를 보내는 계약 스큐 발생 시, "종류"에 따라 정책이 갈린다:
+ * - station 계열(payload가 `nextWaypoint`를 갖는 standard silent push 형태인데 kind가
+ *   STATION_WAYPOINT_KINDS 밖) → 안전 우선. 사용자 노출 알림을 조용히 누락시키지 않도록
+ *   **generic imminent fallback을 발사**한다(어떤 역인지는 알지만 kind 의미만 모르는 상황).
+ * - control 계열(payload가 station 형태가 아닌데 kind가 CONTROL_PUSH_KINDS 밖) → **fail-closed**.
+ *   control push는 schema 자체가 kind마다 달라 임의 fallback 처리가 오히려 위험(state
+ *   corruption 가능) — 거부하고 로그만 남긴다.
+ *
+ * 두 경우 모두 조용한 drop은 금지 — 소비자(device `silentPushTask.ts`)가 반드시 skew 로그를
+ * 남겨야 한다(A2). 정책 값 자체는 여기 SSoT에서만 정의하고, 소비자는 이 상수를 참조해 분기한다.
+ */
+export const UNKNOWN_KIND_POLICY = {
+  /** station-shaped unknown kind. */
+  stationLike: 'fallback-imminent-fire',
+  /** control-shaped unknown kind. */
+  controlLike: 'fail-closed',
+} as const;
+export type UnknownKindPolicyAction = (typeof UNKNOWN_KIND_POLICY)[keyof typeof UNKNOWN_KIND_POLICY];
+
+/**
+ * G2 semantic value 검증 (ADR-029 Phase 1 / #2243) — SSoT.
+ *
+ * Phase 0의 exhaustive switch/assertNever는 discriminator(kind)의 **집합**(어떤 값들이
+ * 허용되는지)을 컴파일 타임에 보증한다. 그 아래 값(stationId/phase/etaSeconds)은 타입은
+ * 맞아도(`string`/`number`) 런타임 값이 도메인 semantics를 벗어나는 drift가 가능하다
+ * (예: NaN etaSeconds, epoch를 잘못 실어보낸 초대형 값, 빈 문자열 station identifier).
+ * 이 경계에서 값을 검증해 통과 못한 값은 소비자가 skew로 관측하도록 한다.
+ */
+
+/**
+ * station identifier(표시 역명 — `nextWaypoint`/`nextStation`/`originStation` 등, stationId 형식
+ * 호환) 최소 형식 검증. 서울 지하철 최장 역명(예: "동대문역사문화공원")보다 넉넉한 길이 상한 +
+ * 제어문자 배제만 강제한다 — 다국어 역명(ko/en/ja/zh)을 전부 수용해야 하므로 문자셋 자체는
+ * 제한하지 않는다.
+ */
+const STATION_IDENTIFIER_MAX_LEN = 40;
+/** 제어문자(0x00~0x1F) 미포함 여부. regex literal escape로인한 바이트 오염을 피하기 위해 charCode 반복으로 검사.*/
+function hasNoControlChars(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code <= 0x1f) return false;
+  }
+  return true;
+}
+export function isValidStationIdentifier(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.trim().length > 0 &&
+    value.length <= STATION_IDENTIFIER_MAX_LEN &&
+    hasNoControlChars(value)
+  );
+}
+
+/** silent push discriminator `phase` — SilentPushPayload/backend AlarmPhase와 값 집합 1:1. */
+export const PUSH_ALARM_PHASES = ['early', 'imminent'] as const;
+export type PushAlarmPhase = (typeof PUSH_ALARM_PHASES)[number];
+export function isPushAlarmPhase(value: unknown): value is PushAlarmPhase {
+  return (PUSH_ALARM_PHASES as readonly unknown[]).includes(value);
+}
+
+/**
+ * `etaSeconds` 상한 — trip lifecycle 9h force-end backstop(device `TRIP_LIFECYCLE_FORCE_END_MS`
+ * / backend `BACKEND_TRIP_LIFECYCLE_FORCE_END_MS`)과 같은 자릿수(초 단위 32400s)를 상한으로
+ * 삼는다. 이보다 큰 값은 단위 실수(예: ms를 s로 착각) 또는 계산 drift로 판정한다.
+ */
+export const PUSH_ETA_SECONDS_MAX = 32_400;
+export function isValidEtaSeconds(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value >= 0 &&
+    value <= PUSH_ETA_SECONDS_MAX
+  );
+}


### PR DESCRIPTION
Part of #2234 — ADR-029 Phase 1. Closes #2243. (BG 에이전트 2회 stall 후 메인 세션이 worktree에서 검증·마무리)

## 변경 (계약 파일만 — DebugModal/fusion 미접촉)
- **`pushContract.ts`**: `UNKNOWN_KIND_POLICY` SSoT 상수 — station-shaped unknown → `fallback-imminent-fire`, control-shaped unknown → `fail-closed`(G6). `isValidStationIdentifier`/`isPushAlarmPhase` 값 검증기(G2).
- **`silentPushTask.ts`**: 수신 경계 검증. unknown station kind → generic imminent fallback 발사(안전 알림 누락 방지), control unknown → fail-closed(발사 안 함+로그).
- **`alarmLog.ts`**: `logPushContractKindSkew`/`logPushContractValueSkew` — SSoT 위반 명시 관측(silent drop 대신). 기존 alarmLog 경로로 노출(DebugModal 미편집).
- **backend `apns.ts`**: `buildSilentPushData` 발신 경계 검증.
- **검증 라이브러리**: zod 미도입 — 경량 hand-rolled predicate(새 의존 0).

## 검증
- `npm run type-check` ✅ · device `npm test` 430 suites / **9169 tests 100% cov** ✅ · `npm run lint:orphan` 0 ✅ · backend vitest 2898 ✅.

## Wire 5단
1. Orphan 0. 2. V/X: skew 로그가 alarmLog·Sentry로 노출(DebugModal 렌더 기존 경로). 3. 의존: #2237(머지됨). 4. 측정: unknown 수신 시 fallback/fail-closed 분기 + skew 로그. 5. Device verify: 경계 로직=type+unit 충분, 실기기 N/A.