### PR TITLE
feat(#2246): liveness·contract property 불변식 lock (ADR-029 Phase 2)

### DIFF
--- a/backend/alarm-worker/src/__tests__/property_2246_destination_backstop_liveness.test.ts
+++ b/backend/alarm-worker/src/__tests__/property_2246_destination_backstop_liveness.test.ts
@@ -1,0 +1,207 @@
+/**
+ * #2246 (ADR-029 Phase 2 / Epic #2234) — liveness property: destination-reached trip은 임의의
+ * cron tick 시퀀스(tick 수·간격 임의)에서도 `DESTINATION_REACH_BACKSTOP_MS`(#2230, 15min) 내에
+ * 반드시 발사가 정지된다(force-cleanup).
+ *
+ * 런타임 로직은 미변경 — `scheduled.ts`의 gps-far backstop 분기(line ~3668)가 이미 성립시킨
+ * 불변식을 example fixture(`scheduled.test.ts` #2230 describe)가 아니라 **임의 tick 시퀀스**로
+ * 재확인해 재파손(2026-08-09 dump에서 관측된 9h 무기한 잔존류 회귀)을 CI에서 차단한다.
+ *
+ * hand-rolled seeded PRNG(mulberry32)로 N회 반복 — 새 의존(fast-check) 추가 회피(Simplicity).
+ * 재현성을 위해 시드 고정.
+ *
+ * 시나리오: gps-far cross-check가 매 tick 지속되는 destination trip.
+ *   - tick1 (offset 0): anchor(`destinationImminentFirstAt`)가 최초 stamp됨 — 정지되지 않는다.
+ *   - 임의 개수(0~4)의 중간 tick: anchor로부터 경과 시간이 backstop 미만 — trip 보존, force-cleanup 0건.
+ *   - 최종 tick: 경과 시간이 backstop 이상 — force-cleanup 1건, trip이 KV에서 삭제된다.
+ *
+ * 테스트 harness(InMemoryKV / makeEnv / trip fixture 형태)는 `scheduled.test.ts`의
+ * `#2230 destination-reached short backstop` describe와 동일 패턴을 재사용한다(중복 로직 없음 —
+ * 파일이 분리돼 직접 import는 불가하므로 최소 형태로 재현).
+ */
+import { generateKeyPair, exportPKCS8 } from 'jose';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetApnsJwtCache, type ApnsConfig } from '../apns';
+import {
+  DESTINATION_REACH_BACKSTOP_MS,
+  runScheduled,
+  type ScheduledDeps,
+} from '../scheduled';
+import { SeoulArrivalClient } from '../seoul';
+import { putTrip } from '../trips';
+import type { Env, Trip } from '../types';
+import { InMemoryKV } from './inMemoryKv';
+
+let apnsConfig: ApnsConfig;
+
+beforeAll(async () => {
+  const { privateKey } = await generateKeyPair('ES256');
+  const pem = await exportPKCS8(privateKey);
+  apnsConfig = {
+    keyId: 'K',
+    teamId: 'T',
+    privateKeyPem: pem,
+    bundleId: 'com.example.app',
+  };
+});
+
+beforeEach(() => resetApnsJwtCache());
+
+const APNS_HOSTS = {
+  production: 'api.push.apple.com',
+  sandbox: 'api.sandbox.push.apple.com',
+} as const;
+
+function makeEnv(kv: InMemoryKV): Env {
+  return {
+    TRIPS: kv as unknown as KVNamespace,
+    APNS_HOST: APNS_HOSTS.production,
+    APNS_HOST_SANDBOX: APNS_HOSTS.sandbox,
+    SEOUL_API_HOST: 'seoul.api',
+    SEOUL_API_KEY: 'KEY',
+    APNS_KEY_ID: 'K',
+    APNS_TEAM_ID: 'T',
+    APNS_PRIVATE_KEY: apnsConfig.privateKeyPem,
+    APNS_BUNDLE_ID: 'com.example.app',
+    PENDING_PUSHES: undefined,
+  };
+}
+
+/** 합정(line 2) destination trip — `scheduled.test.ts` #2230 fixture와 동일 shape. */
+function makeDestinationTrip(token: string, baseNow: number): Trip {
+  return {
+    token,
+    route: { type: 'direct', line: '2', stops: 1 },
+    destination: '2-038', // 합정 station id (stations.json)
+    waypoints: [{ stationName: '합정', line: '2', kind: 'destination' }],
+    // #2230 property 대상 — trip 창(최대 backstop + 여유)이 만료/lifecycle 문턱에 걸리지 않도록
+    // baseNow 기준으로 넉넉히 설정. lifecycle silence(6h)/force-end(9h) 문턱과 무관한 범위(<20min).
+    expiresAt: baseNow + 24 * 60 * 60_000,
+    createdAt: baseNow,
+    alarmAtEpochMs: baseNow - 60_000, // 이미 폴링 윈도우 진입 상태 — 매 tick 스캔 대상.
+    activityPushToken: 'la-token',
+    activityState: 'live',
+    apnsEnv: 'sandbox',
+    boardingLock: {
+      trainCode: 'T',
+      line: '2',
+      subwayId: '1002',
+      selectedDepartureTime: baseNow,
+      segmentStations: ['홍대입구', '합정'],
+      expiresAt: baseNow + 24 * 60 * 60_000,
+    },
+  };
+}
+
+function makeArrivedSeoul(nowGetter: () => number): SeoulArrivalClient {
+  return new SeoulArrivalClient({
+    apiKey: 'K',
+    host: 'h',
+    now: nowGetter,
+    fetchImpl: (async () =>
+      new Response(
+        JSON.stringify({
+          realtimeArrivalList: [
+            {
+              barvlDt: '0',
+              recptnDt: '',
+              updnLine: '내선',
+              trainLineNm: '합정',
+              btrainNo: 'T',
+              subwayNm: '지하철2호선',
+              arvlCd: 1, // ARRIVED → advance → destination cleanup 분기 진입
+            },
+          ],
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch,
+  });
+}
+
+/** 신촌 부근 GPS — 합정에서 ~1.3km, 매 tick gps-far cross-check를 트리거. */
+function seedFarGps(kv: InMemoryKV, token: string, ts: number): Promise<void> {
+  return kv.put(
+    `pos:${token}`,
+    JSON.stringify([{ lat: 37.5552, lng: 126.9368, accuracy: 15, ts, motion: 'automotive' }]),
+  );
+}
+
+// mulberry32 — 결정적 시드 PRNG. 순수 함수, 시드만으로 재현.
+function mulberry32(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+interface TickPlan {
+  /** anchor(tick1) 기준 경과 ms — 각각 backstop 미만이 되도록 오름차순 생성. */
+  intermediateOffsetsMs: number[];
+  /** anchor 기준 backstop 이상이 되는 최종 tick 경과 ms. */
+  finalOffsetMs: number;
+}
+
+/** 임의 tick 수(0~4)·간격 조합 생성. intermediate는 backstop 미만, final은 backstop 이상. */
+function genTickPlan(rng: () => number): TickPlan {
+  const intermediateCount = Math.floor(rng() * 5); // 0..4
+  const budget = DESTINATION_REACH_BACKSTOP_MS - 1_000; // 엄격히 backstop 미만 유지.
+  const fractions = Array.from({ length: intermediateCount }, () => rng()).sort((a, b) => a - b);
+  const intermediateOffsetsMs = fractions.map((f) => Math.floor(f * budget));
+  const finalOffsetMs = DESTINATION_REACH_BACKSTOP_MS + Math.floor(rng() * 120_000); // backstop ~ +2min.
+  return { intermediateOffsetsMs, finalOffsetMs };
+}
+
+describe('#2246 property — destination-reached trip은 임의 tick 시퀀스에서도 backstop 내 발사 정지', () => {
+  const PROPERTY_ITERATIONS = 20;
+  // 시드 값 자체는 임의 — 이슈 번호 기반으로 선택해 재현 시 출처를 알아보기 쉽게만 함.
+  const rng = mulberry32(0xd2230);
+
+  for (let i = 0; i < PROPERTY_ITERATIONS; i += 1) {
+    const seedNow = 1_700_000_000_000 + Math.floor(rng() * 1_000_000_000);
+    const plan = genTickPlan(rng);
+
+    it(`iteration #${i} (baseNow offset seed, ${plan.intermediateOffsetsMs.length} intermediate ticks)`, async () => {
+      const kv = new InMemoryKV();
+      const token = `prop-backstop-tok-${i}`;
+      const trip = makeDestinationTrip(token, seedNow);
+      await putTrip(kv as unknown as KVNamespace, trip);
+
+      let simulatedNow = seedNow;
+      const seoul = makeArrivedSeoul(() => simulatedNow);
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      const deps: ScheduledDeps = {
+        seoul,
+        apnsConfig,
+        apnsHosts: APNS_HOSTS,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        now: () => simulatedNow,
+      };
+
+      async function tick(offsetMs: number) {
+        simulatedNow = seedNow + offsetMs;
+        await seedFarGps(kv, token, simulatedNow - 30_000); // fresh GPS(< 5min stale) every tick.
+        return runScheduled(makeEnv(kv), { ...deps, now: () => simulatedNow });
+      }
+
+      // tick1 — anchor 최초 stamp. 정지되지 않는다.
+      let stats = await tick(0);
+      expect(await kv.get(`trip:${token}`)).not.toBeNull();
+      expect(stats.destinationBackstopForceEnded).toBe(0);
+
+      // 임의 개수의 중간 tick — anchor로부터 backstop 미만 경과. 계속 보존.
+      for (const offset of plan.intermediateOffsetsMs) {
+        stats = await tick(offset);
+        expect(await kv.get(`trip:${token}`)).not.toBeNull();
+        expect(stats.destinationBackstopForceEnded).toBe(0);
+      }
+
+      // 최종 tick — anchor로부터 backstop 이상 경과. 반드시 force-cleanup.
+      stats = await tick(plan.finalOffsetMs);
+      expect(await kv.get(`trip:${token}`)).toBeNull();
+      expect(stats.destinationBackstopForceEnded).toBe(1);
+    });
+  }
+});

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -285,6 +285,9 @@ import {
   ROUTE_KEY,
   SLEEP_MODE_KEY,
 } from '../../../../shared/constants/storageKeys';
+// #2246 (ADR-029 Phase 2) — G6 property 테스트가 SSoT known-kind 집합과의 충돌 없는 임의 kind를
+// 생성하기 위해 참조.
+import { STATION_WAYPOINT_KINDS, CONTROL_PUSH_KINDS } from '../../../../shared/types/pushContract';
 
 const DEFAULT_APNS_TOKEN = 'apns-tok-hex';
 
@@ -3569,5 +3572,82 @@ describe('silentPushTask', () => {
         expect(stored.alarmEvents).toEqual(ssotWithEvents.alarmEvents);
       });
     });
+  });
+
+  // #2246 (ADR-029 Phase 2) — G6 unknown-kind 정책(#2243)이 임의 kind 문자열에서 성립함을
+  // property로 lock. 런타임 로직은 미변경 — 이미 성립하는 불변식(station-shaped unknown →
+  // fallback-imminent-fire, control-shaped unknown → fail-closed)을 hand-rolled seeded PRNG로
+  // N회 임의 kind에 대해 재확인한다. fast-check 미사용(Simplicity, 새 의존 회피).
+  describe('#2246 property — G6 unknown-kind policy holds for arbitrary kind strings', () => {
+    // mulberry32 — 결정적 시드 PRNG. 재현성을 위해 순수 함수로 시드만 인자로 받는다.
+    function mulberry32(seed: number): () => number {
+      let s = seed >>> 0;
+      return () => {
+        s = (s + 0x6d2b79f5) | 0;
+        let t = Math.imul(s ^ (s >>> 15), 1 | s);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    }
+
+    const KIND_CHARS = 'abcdefghijklmnopqrstuvwxyz-0123456789';
+    /**
+     * SSoT(STATION_WAYPOINT_KINDS ∪ CONTROL_PUSH_KINDS)와 절대 겹치지 않는 임의 문자열을
+     * 생성한다 — 겹치면 "알려진 kind" 경로로 빠져 이 property의 대상(계약 스큐)이 아니게 된다.
+     */
+    function randomUnknownKind(rng: () => number): string {
+      const known: readonly string[] = [...STATION_WAYPOINT_KINDS, ...CONTROL_PUSH_KINDS];
+      let candidate: string;
+      do {
+        // len 최소값이 3이라 candidate.length===0은 도달 불가능 — known 집합과의 충돌만 재시도.
+        const len = 3 + Math.floor(rng() * 10);
+        candidate = Array.from({ length: len }, () => KIND_CHARS[Math.floor(rng() * KIND_CHARS.length)]).join('');
+      } while (known.includes(candidate as (typeof known)[number]));
+      return candidate;
+    }
+
+    const PROPERTY_ITERATIONS = 30;
+    // 시드 값 자체는 임의 — 이슈 번호 기반으로 선택해 재현 시 출처를 알아보기 쉽게만 함.
+    const rng = mulberry32(0x2246);
+
+    for (let i = 0; i < PROPERTY_ITERATIONS; i += 1) {
+      const rawKind = randomUnknownKind(rng);
+
+      it(`[station-shaped #${i}] unknown kind="${rawKind}" → silent drop 없이 skew 로그 + fallback-imminent-fire`, async () => {
+        const pushId = `prop-station-${i}`;
+        await handleSilentPush(
+          payload({ kind: rawKind, phase: 'early', nextWaypoint: '강남', pushId }),
+        );
+        // A2 — 조용한 drop 금지: skew가 반드시 관측된다.
+        expect(mockLogPushContractKindSkew).toHaveBeenCalledWith({
+          category: 'station-like',
+          rawKind,
+          stationName: '강남',
+        });
+        // G6 station-shaped 정책 = fallback-imminent-fire — generic 알림이 반드시 발사된다.
+        expect(mockScheduleNotificationAsync).toHaveBeenCalledTimes(1);
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          ackCall(pushId, 'fired', 'push-contract-skew-station-fallback-fired'),
+        );
+        // legacy-station-kind-ignored skip 경로로는 빠지지 않는다(#2243 회귀 대상).
+        expect(mockLogSilentPushSkipped).not.toHaveBeenCalled();
+      });
+
+      it(`[control-shaped #${i}] unknown kind="${rawKind}" → silent drop 없이 skew 로그 + fail-closed`, async () => {
+        const pushId = `prop-control-${i}`;
+        await handleSilentPush({ data: bgTaskData({ kind: rawKind, pushId }) });
+        // A2 — 조용한 drop 금지: skew가 반드시 관측된다.
+        expect(mockLogPushContractKindSkew).toHaveBeenCalledWith({
+          category: 'control-like',
+          rawKind,
+        });
+        // G6 control-shaped 정책 = fail-closed — 알림이 발사되지 않는다(schema 불명이라 state
+        // corruption 위험 — station-shaped와 달리 fallback fire 대상이 아니다).
+        expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          ackCall(pushId, 'skipped', 'push-contract-skew-control-fail-closed'),
+        );
+      });
+    }
   });
 });


### PR DESCRIPTION
Part of #2234
Closes #2246

## 요약
ADR-029 Phase 2 — 최근 fix(#2230 destination backstop, #2243 unknown-kind G6 정책)가 성립시킨 불변식을 property 테스트로 lock해 재파손을 CI에서 차단한다. **런타임 로직은 미변경** — property 테스트 신규 추가만.

- `backend/alarm-worker/src/__tests__/property_2246_destination_backstop_liveness.test.ts` (신규)
  - liveness 불변식: destination-reached trip은 임의 cron tick 시퀀스(임의 tick 수 0~4·간격)에서도 `DESTINATION_REACH_BACKSTOP_MS`(15min, #2230) 내에 force-cleanup된다.
  - hand-rolled seeded PRNG(mulberry32, 시드 `0xd2230`) 20 iteration. `scheduled.test.ts`의 `#2230 destination-reached short backstop` describe와 동일 harness 패턴(InMemoryKV/runScheduled/trip fixture) 재사용 — 원본 helper가 파일 스코프 로컬이라 export 불가해 최소 형태로 재현.
- `src/features/alarm/tasks/__tests__/silentPushTask.test.ts` (기존 파일 말미에 신규 describe 추가 — 기존 대량 jest.mock() 설정 재사용)
  - contract 불변식(#2243 G6): 임의 kind 문자열은 silent drop 없이 skew 로그를 남기고, station-shaped(payload에 `nextWaypoint` 보유)는 generic imminent fallback 발사, control-shaped는 fail-closed(발사 없음)로 분기된다.
  - hand-rolled seeded PRNG(mulberry32, 시드 `0x2246`) 30 iteration × 2 shape = 60 케이스.

두 property 테스트 모두 mutation 검증(백스톱 조건을 강제로 뒤집어봄) 결과 실제 불변식 위반을 잡아내는 것을 확인 — tautological assertion 아님.

## 금지 준수
- 런타임 코드(`scheduled.ts`, `silentPushTask.ts`, `pushContract.ts`) 미변경 — property 테스트 파일 2개만 변경 (`git diff --stat` 확인됨).
- fusion(`nearest-station/*`)·DebugModal 미접촉.
- 새 npm 의존 추가 없음(fast-check 회피, mulberry32 hand-roll — Simplicity).
- 미해결 버그(#2180)는 스코프 밖 — 손대지 않음.

## 검증
- `npm run type-check` — pass
- `npm test` — 9276 tests, 100% coverage 유지
- `cd backend/alarm-worker && npx vitest run` — 2918 tests pass (78 files, 신규 20건 포함)
- `npm run lint:orphan` — 0 orphan

## Wire 5단
1. **Orphan 없음** — `npm run lint:orphan` pass.
2. **V/X dashboard** — 신규 property 테스트는 CI `Type Check & Test`(device) + backend vitest ratchet에 포함되어 매 PR마다 실행. 불변식 위반 시 해당 job이 red.
3. **의존 PR** — #2243(머지됨), #2230(머지됨). 추가 의존 없음.
4. **측정 plan** — CI red 여부 자체가 측정 신호. 의도적으로 backstop 조건/G6 분기를 되돌리는 회귀 PR이 있으면 이 테스트가 즉시 fail.
5. **Device verify** — N/A — property/unit only (코드-only, 런타임 미변경).