### PR TITLE
feat(#2250): signal provenance registry + de-wire 감지

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,10 @@ Closes #<이슈번호>
 ## Wire-completion 5단 체크
 
 - [ ] **1. Orphan 없음** — `npm run lint:orphan` pass (CI 자동 검증). 신규 export에는 caller 존재.
+  - push/silent-push 계열 관측 지표를 새로 추가하거나 그 emitter를 은퇴시키는 PR은
+    `src/features/observability/utils/signalProvenanceRegistry.ts`도 함께 갱신 (#2250, ADR-029 Phase 3).
+    `findDewiredSignals.test.ts`가 registry의 emitterSymbol이 비-테스트 코드에서 실제 호출되는지
+    검증한다 — 호출자 없는 항목은 CI red ("de-wire").
 - [ ] **2. V/X dashboard** — DebugModal/wrangler tail/SSoT 어디서 시각화/관측 가능한지 명시.
 - [ ] **3. 의존 PR** — 이 PR이 작동하려면 머지 필요한 backend/device/infra PR 번호. 없으면 "N/A".
 - [ ] **4. 측정 plan** — 회귀 신호를 1주 안에 어떻게 측정할지(시나리오 / log query / 사용자 trip 캡처).

--- a/src/features/observability/utils/__tests__/findDewiredSignals.test.ts
+++ b/src/features/observability/utils/__tests__/findDewiredSignals.test.ts
@@ -1,0 +1,191 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { findDewiredSignals } from '../findDewiredSignals';
+import { SIGNAL_PROVENANCE_REGISTRY } from '../signalProvenanceRegistry';
+import type { SignalProvenanceEntry } from '../signalProvenanceRegistry';
+
+/**
+ * #2250 (ADR-029 Phase 3) — de-wire 감지 fixture 테스트.
+ *
+ * red-first: 정의만 있고 호출자가 없는 emitter(de-wired)는 violation을 낸다(red 재현).
+ * 정상(정의 + 호출자 존재)은 violation 없이 통과(green)한다.
+ */
+describe('findDewiredSignals — fixture 기반 de-wire 감지', () => {
+  let fixtureRoot: string;
+
+  beforeEach(() => {
+    fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dewire-fixture-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  function writeFile(relativePath: string, content: string): void {
+    const fullPath = path.join(fixtureRoot, relativePath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, content, 'utf8');
+  }
+
+  it('정의만 있고 호출자가 없는 emitter는 violation(red)을 낸다 — de-wire 재현', () => {
+    writeFile('lib/emitterDefOnly.ts', "export function deadEmitter() { return 1; }\n");
+
+    const registry: readonly SignalProvenanceEntry[] = [
+      {
+        metricKey: 'deadMetric',
+        emitterSymbol: 'deadEmitter',
+        emitterFile: 'lib/emitterDefOnly.ts',
+        description: 'fixture — 은퇴한 채널',
+      },
+    ];
+
+    const violations = findDewiredSignals(registry, { repoRoot: fixtureRoot, scanDirs: ['lib'] });
+
+    expect(violations).toEqual([
+      {
+        metricKey: 'deadMetric',
+        emitterSymbol: 'deadEmitter',
+        referenceCount: 1,
+        reason: "emitter symbol 'deadEmitter'이 정의만 있고 호출자가 없다 — 은퇴한 채널을 measure 중",
+      },
+    ]);
+  });
+
+  it('registry에 등재된 emitter 심볼이 소스에 전혀 없으면 violation(red)을 낸다', () => {
+    writeFile('lib/unrelated.ts', 'export const noop = 1;\n');
+
+    const registry: readonly SignalProvenanceEntry[] = [
+      {
+        metricKey: 'missingMetric',
+        emitterSymbol: 'missingEmitter',
+        emitterFile: 'lib/nope.ts',
+        description: 'fixture — registry 오타/삭제',
+      },
+    ];
+
+    const violations = findDewiredSignals(registry, { repoRoot: fixtureRoot, scanDirs: ['lib'] });
+
+    expect(violations).toEqual([
+      {
+        metricKey: 'missingMetric',
+        emitterSymbol: 'missingEmitter',
+        referenceCount: 0,
+        reason: "emitter symbol 'missingEmitter'을 소스에서 찾을 수 없다 (registry 오타 또는 삭제됨)",
+      },
+    ]);
+  });
+
+  it('정의 + 호출자가 존재하면 violation 없이 통과한다 (green)', () => {
+    writeFile('lib/live.ts', 'export function liveEmitter() { return 2; }\n');
+    writeFile(
+      'lib/caller.ts',
+      "import { liveEmitter } from './live';\nliveEmitter();\n",
+    );
+    // 하위 디렉토리도 재귀적으로 스캔되는지 검증
+    writeFile('lib/nested/deep.ts', "liveEmitter();\n");
+
+    const registry: readonly SignalProvenanceEntry[] = [
+      {
+        metricKey: 'liveMetric',
+        emitterSymbol: 'liveEmitter',
+        emitterFile: 'lib/live.ts',
+        description: 'fixture — 정상 배선',
+      },
+    ];
+
+    const violations = findDewiredSignals(registry, { repoRoot: fixtureRoot, scanDirs: ['lib'] });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('__tests__ / node_modules / coverage 디렉토리와 .test./.spec. 파일은 스캔에서 제외한다', () => {
+    // liveEmitter의 유일한 "호출"이 제외 대상 안에만 있으면 여전히 de-wire(red)여야 한다.
+    writeFile('lib/live.ts', 'export function liveEmitter() { return 2; }\n');
+    writeFile('lib/__tests__/shouldSkip.ts', 'liveEmitter(); liveEmitter();\n');
+    writeFile('lib/node_modules/pkg/shouldSkip.ts', 'liveEmitter();\n');
+    writeFile('lib/coverage/shouldSkip.ts', 'liveEmitter();\n');
+    writeFile('lib/caller.test.ts', 'liveEmitter();\n');
+    writeFile('lib/caller.spec.ts', 'liveEmitter();\n');
+    writeFile('lib/notes.md', 'liveEmitter liveEmitter liveEmitter\n');
+
+    const registry: readonly SignalProvenanceEntry[] = [
+      {
+        metricKey: 'liveMetric',
+        emitterSymbol: 'liveEmitter',
+        emitterFile: 'lib/live.ts',
+        description: 'fixture — 제외 디렉토리/확장자 검증',
+      },
+    ];
+
+    const violations = findDewiredSignals(registry, { repoRoot: fixtureRoot, scanDirs: ['lib'] });
+
+    expect(violations).toEqual([
+      {
+        metricKey: 'liveMetric',
+        emitterSymbol: 'liveEmitter',
+        referenceCount: 1,
+        reason: "emitter symbol 'liveEmitter'이 정의만 있고 호출자가 없다 — 은퇴한 채널을 measure 중",
+      },
+    ]);
+  });
+
+  it('registry 정의 파일(signalProvenanceRegistry.ts) 자체의 언급은 참조로 카운트하지 않는다 — 자기참조 마스킹 방지', () => {
+    // 실제 사고 재현: registry 파일이 emitterSymbol을 설명 문구에 언급하면(예: "stampSent로 …")
+    // 그 언급 자체가 "호출자 있음"으로 오카운트돼 de-wire를 못 잡는 구멍이 생긴다.
+    // 호출부(caller.ts)를 제거해 진짜 de-wire 상태를 만들고, registry 파일의 언급만으로는
+    // 여전히 violation이 나야 한다(정의 1 + registry 언급 1 ≠ green).
+    writeFile('lib/emitterDefOnly.ts', 'export function deadEmitter() { return 1; }\n');
+    writeFile(
+      'lib/signalProvenanceRegistry.ts',
+      "export const REGISTRY = [{ emitterSymbol: 'deadEmitter', description: 'deadEmitter로 무언가를 한다' }];\n",
+    );
+
+    const registry: readonly SignalProvenanceEntry[] = [
+      {
+        metricKey: 'deadMetric',
+        emitterSymbol: 'deadEmitter',
+        emitterFile: 'lib/emitterDefOnly.ts',
+        description: 'fixture — registry 자기참조 마스킹 방지 검증',
+      },
+    ];
+
+    const violations = findDewiredSignals(registry, { repoRoot: fixtureRoot, scanDirs: ['lib'] });
+
+    expect(violations).toEqual([
+      {
+        metricKey: 'deadMetric',
+        emitterSymbol: 'deadEmitter',
+        referenceCount: 1,
+        reason: "emitter symbol 'deadEmitter'이 정의만 있고 호출자가 없다 — 은퇴한 채널을 measure 중",
+      },
+    ]);
+  });
+
+  it('scanDirs 미지정 시 기본값(src, backend/alarm-worker/src)을 사용하고 존재하지 않는 디렉토리는 무시한다', () => {
+    writeFile('src/live.ts', 'export function liveEmitter() { return 2; }\nliveEmitter();\n');
+    // backend/alarm-worker/src 는 fixture에 생성하지 않음 — 존재하지 않는 dir graceful skip 검증.
+
+    const registry: readonly SignalProvenanceEntry[] = [
+      {
+        metricKey: 'liveMetric',
+        emitterSymbol: 'liveEmitter',
+        emitterFile: 'src/live.ts',
+        description: 'fixture — 기본 scanDirs 검증',
+      },
+    ];
+
+    const violations = findDewiredSignals(registry, { repoRoot: fixtureRoot });
+
+    expect(violations).toEqual([]);
+  });
+});
+
+describe('findDewiredSignals — 실제 SIGNAL_PROVENANCE_REGISTRY (통합 green 검증)', () => {
+  it('현재 등재된 지표는 모두 배선돼 있다 (violation 0) — repoRoot 기본값 사용', () => {
+    const violations = findDewiredSignals(SIGNAL_PROVENANCE_REGISTRY);
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/src/features/observability/utils/findDewiredSignals.ts
+++ b/src/features/observability/utils/findDewiredSignals.ts
@@ -1,0 +1,103 @@
+import fs from 'fs';
+import path from 'path';
+
+import type { SignalProvenanceEntry } from './signalProvenanceRegistry';
+
+/**
+ * de-wire 감지 스캐너 (#2250, ADR-029 Phase 3).
+ *
+ * `SIGNAL_PROVENANCE_REGISTRY`의 각 항목에 대해, 비-테스트 소스 트리에서 `emitterSymbol`이
+ * "정의 외에 최소 1회 이상" 참조(호출/발사)되는지 검사한다. 정의만 있고 호출자가 0이면
+ * 그 emitter는 은퇴한 채널이고, 그걸 measure하던 지표는 죽은 지표다 → violation.
+ */
+export interface DewireViolation {
+  readonly metricKey: string;
+  readonly emitterSymbol: string;
+  readonly referenceCount: number;
+  readonly reason: string;
+}
+
+export interface FindDewiredSignalsOptions {
+  /** 스캔 루트 (기본: repo root — 이 파일 기준 4단계 상위) */
+  readonly repoRoot?: string;
+  /** repoRoot 기준 스캔 대상 디렉토리 목록 */
+  readonly scanDirs?: readonly string[];
+}
+
+const DEFAULT_SCAN_DIRS = ['src', 'backend/alarm-worker/src'];
+
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx']);
+const EXCLUDED_DIR_NAMES = new Set(['__tests__', 'node_modules', 'coverage']);
+
+// registry 정의 파일 자체는 스캔에서 제외한다. 그 파일은 emitterSymbol을 문자열/설명 산문으로
+// "언급"할 뿐 실제로 호출/발사하지 않는데, 포함시키면 언급 자체가 참조로 카운트돼
+// (정의 1 + registry 언급 1 = 2) de-wire를 절대 감지 못 하는 구멍이 생긴다.
+const EXCLUDED_FILE_NAMES = new Set(['signalProvenanceRegistry.ts']);
+
+function isTestFile(fileName: string): boolean {
+  return /\.test\.tsx?$/.test(fileName) || /\.spec\.tsx?$/.test(fileName);
+}
+
+function collectSourceFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const dirEntry of entries) {
+    if (dirEntry.isDirectory()) {
+      if (EXCLUDED_DIR_NAMES.has(dirEntry.name)) continue;
+      files.push(...collectSourceFiles(path.join(dir, dirEntry.name)));
+      continue;
+    }
+
+    if (!SOURCE_EXTENSIONS.has(path.extname(dirEntry.name))) continue;
+    if (isTestFile(dirEntry.name)) continue;
+    if (EXCLUDED_FILE_NAMES.has(dirEntry.name)) continue;
+
+    files.push(path.join(dir, dirEntry.name));
+  }
+
+  return files;
+}
+
+/**
+ * registry의 각 (지표 → emitter 심볼) 쌍이 비-테스트 코드에서 실제 참조되는지 검증한다.
+ * 참조 count < 2 (정의 1회 + 호출 0회, 또는 완전히 미발견)이면 violation을 반환한다.
+ */
+export function findDewiredSignals(
+  registry: readonly SignalProvenanceEntry[],
+  options: FindDewiredSignalsOptions = {},
+): DewireViolation[] {
+  const repoRoot = options.repoRoot ?? path.resolve(__dirname, '../../../../');
+  const scanDirs = options.scanDirs ?? DEFAULT_SCAN_DIRS;
+
+  const files = scanDirs.flatMap((scanDir) => collectSourceFiles(path.join(repoRoot, scanDir)));
+  const contents = files.map((file) => fs.readFileSync(file, 'utf8'));
+
+  const violations: DewireViolation[] = [];
+
+  for (const entry of registry) {
+    const symbolPattern = new RegExp(`\\b${entry.emitterSymbol}\\b`, 'g');
+    const referenceCount = contents.reduce((total, content) => {
+      const matches = content.match(symbolPattern);
+      return total + (matches?.length ?? 0);
+    }, 0);
+
+    // 1회 미만: 정의조차 없음(등재 오타/삭제). 1회: 정의만 있고 호출자 없음(de-wire).
+    // 둘 다 "이 지표가 measure하는 채널이 죽었다"는 동일 신호.
+    if (referenceCount < 2) {
+      violations.push({
+        metricKey: entry.metricKey,
+        emitterSymbol: entry.emitterSymbol,
+        referenceCount,
+        reason:
+          referenceCount === 0
+            ? `emitter symbol '${entry.emitterSymbol}'을 소스에서 찾을 수 없다 (registry 오타 또는 삭제됨)`
+            : `emitter symbol '${entry.emitterSymbol}'이 정의만 있고 호출자가 없다 — 은퇴한 채널을 measure 중`,
+      });
+    }
+  }
+
+  return violations;
+}

--- a/src/features/observability/utils/signalProvenanceRegistry.ts
+++ b/src/features/observability/utils/signalProvenanceRegistry.ts
@@ -1,0 +1,42 @@
+/**
+ * Signal Provenance Registry — SSoT for "관측 지표 → emitter 심볼" 매핑 (#2250, ADR-029 Phase 3).
+ *
+ * 왜: 채널/emitter가 은퇴돼도 그걸 measure하던 지표는 조용히 0을 찍으며 살아남아 정상처럼 보인다
+ * (`silentPushReach`가 #2064로 no-op가 된 로컬 발사 채널을 계속 measure한 사건 — #2231에서 재정의).
+ * wire-completion(연결) 룰은 있었지만 de-wire(은퇴) 룰이 없어 이 class가 반복됐다.
+ *
+ * 등재 규약: push/silent-push 계열(사건 발생 영역) 핵심 지표부터 등재한다 — 전체 지표 과설계 금지.
+ * 새 지표 추가 시 `emitterSymbol`이 실제 신호를 만들어내는 함수/심볼 이름과 정확히 일치해야 한다.
+ * `findDewiredSignals`(같은 디렉토리)가 비-테스트 코드에서 그 심볼의 참조(정의 외 호출 지점)가
+ * 있는지 검증한다 — 참조가 없으면(정의만 있고 아무도 호출하지 않으면) CI가 fail한다.
+ */
+export interface SignalProvenanceEntry {
+  /** 관측 지표 키 (DebugModal / observabilityMetricsClient 등에 노출되는 이름) */
+  readonly metricKey: string;
+  /** 그 지표가 실제로 tracking하는 emitter 함수/심볼 이름 */
+  readonly emitterSymbol: string;
+  /** emitter가 정의된 파일 경로 (repo root 기준, 문서 참고용) */
+  readonly emitterFile: string;
+  /** 등재 배경 설명 */
+  readonly description: string;
+}
+
+export const SIGNAL_PROVENANCE_REGISTRY: readonly SignalProvenanceEntry[] = [
+  {
+    metricKey: 'silentPushReach(local)',
+    emitterSymbol: 'logSilentPushReceived',
+    emitterFile: 'src/features/alarm/utils/alarmLog.ts',
+    description:
+      '#2231 재정의 — visible station kind(station-passed/transfer/destination) silent push 수신을 ' +
+      'silentPushTask.ts가 logSilentPushReceived로 alarmLog에 적재하고, ' +
+      'computeSilentPushReach(alarmLog.ts)가 visibleReceived/totalReceived로 집계한다.',
+  },
+  {
+    metricKey: 'silentPushReachRatio',
+    emitterSymbol: 'stampSent',
+    emitterFile: 'backend/alarm-worker/src/silentPushReachMetric.ts',
+    description:
+      'backend 5min corrId-join 도달률(#1958). pendingPushes.ts가 push 발사 시 stampSent로 ' +
+      'sent stamp를 KV에 기록하고, computeSilentPushReachRatio가 received와 join해 ratio를 낸다.',
+  },
+] as const;


### PR DESCRIPTION
## Summary

Signal provenance registry(SSoT) + de-wire 감지 test 도입. 채널/emitter가 은퇴돼도 그걸 measure하던 지표가 조용히 0을 찍으며 살아남는 사고(`silentPushReach`가 #2064로 no-op가 된 로컬 발사 채널을 계속 measure한 사건, #2231에서 재정의)를 CI에서 자동 감지한다.

- `signalProvenanceRegistry.ts`: push/silent-push 계열 핵심 지표 2개 등재 (`silentPushReach(local)` → `logSilentPushReceived`, `silentPushReachRatio` → `stampSent`)
- `findDewiredSignals.ts`: registry의 각 (지표 → emitter 심볼) 쌍에 대해 비-테스트 소스에서 실제 참조(정의 외 호출)가 있는지 fs 스캔 — 참조 < 2면 violation
- registry 정의 파일 자체가 emitterSymbol을 설명 문구에 언급하는 자기참조가 스캐너를 무력화하는 함정을 code-review에서 발견 → 스캔 대상에서 registry 정의 파일 제외로 수정, 해당 시나리오 재현 fixture test 추가

Part of #2234
Closes #2250

---

## Wire-completion 5단 체크

- [x] **1. Orphan 없음** — `npm run lint:orphan` pass (로컬 확인, CI 자동 재검증).
- [x] **2. V/X dashboard** — 새 지표/emitter 노출 UI 변경 없음. de-wire violation은 `npm test`(CI `Type Check & Test`)의 `findDewiredSignals.test.ts` 통과/실패로 관측. `SIGNAL_PROVENANCE_REGISTRY` 자체가 문서화된 dashboard 역할(각 지표의 emitter/설명 명시).
- [x] **3. 의존 PR** — N/A. P0~P2(ADR-029 이전 phase는 이 issue 스코프 밖, silentPushReach 재정의 자체는 이미 머지된 #2231)에 의존하지 않는 독립 검증 인프라.
- [x] **4. 측정 plan** — 향후 채널 은퇴 PR이 registry 갱신 없이 emitter 호출부만 제거하면 `findDewiredSignals.test.ts`가 즉시 red. 1주 내 신규 de-wire PR 발생 시 CI가 그 자리에서 잡는다(측정 대상 자체가 CI red 여부).
- [x] **5. Device verify** — N/A — type+unit only. 런타임 로직/fusion 파일 미변경, fs 스캔 기반 정적 검증.

### V/X dashboard URL

N/A — 지표/UI 변경 없음. `SIGNAL_PROVENANCE_REGISTRY` (`src/features/observability/utils/signalProvenanceRegistry.ts`)가 SSoT 문서.

### 의존 PR

N/A

---

## Test plan

- [x] `npm test` 100% coverage pass (9286 tests)
- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass
- [x] red-first fixture: 정의만 있고 호출자 없는 emitter → violation 재현
- [x] green fixture: 정의 + 호출자 존재 → violation 없음
- [x] 자기참조 마스킹 방지 fixture: registry 정의 파일이 심볼을 언급해도 실제 de-wire는 여전히 감지
- [x] 통합 검증: 실제 `SIGNAL_PROVENANCE_REGISTRY` + repo 소스 트리 스캔 → violation 0 (현재 배선 정상)