### PR TITLE
feat(#2252): 계약 변경 프로세스 소프트 게이트 (ADR-029 Phase 4)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,6 +34,21 @@ Closes #<이슈번호>
 
 ---
 
+## 계약 변경 체크리스트 (push kind 추가/은퇴 시 — ADR-029 Phase 4 / #2252)
+
+<!--
+`src/shared/types/pushContract.ts`의 kind union(STATION_WAYPOINT_KINDS/CONTROL_PUSH_KINDS/
+ALARM_EVENT_TYPES/SLEEP_ALARM_TARGET_KINDS 등)을 추가·은퇴하는 PR만 해당. 그 외는 "N/A".
+CI가 이 파일 변경 시 리마인더 코멘트를 자동 게시한다(hard-block 아님).
+-->
+
+- [ ] SSoT(`pushContract.ts`) 갱신 — exhaustive switch/assertNever 컴파일 통과 확인
+- [ ] 경계 검증(ADR-029 Phase 1) 갱신 — zod refinement 등 런타임 검증 스키마 동기화
+- [ ] de-wire registry(ADR-029 Phase 3, `signalProvenanceRegistry.ts`) 등재/은퇴 반영
+- [ ] 테스트 동반(신규 kind 처리 경로 / 은퇴 kind 소비 제거)
+
+---
+
 ## Test plan
 
 - [ ] `npm test` 100% coverage pass

--- a/.github/workflows/contract-change-reminder.yml
+++ b/.github/workflows/contract-change-reminder.yml
@@ -1,0 +1,53 @@
+name: Contract Change Reminder
+
+# ADR-029 Phase 4 (#2252) — push 계약(pushContract.ts kind union) 추가/은퇴 PR에
+# SSoT/경계검증(P1)/de-wire registry(P3)/테스트 동반 체크리스트를 상기시키는 소프트 게이트.
+#
+# 정책: 리뷰어 상기가 목적 — hard-fail 금지. `paths` 필터가 곧 게이트이므로 별도
+# 감지 스크립트 없이 워크플로 트리거 자체로 판단한다(과설계 방지).
+# fork PR은 GITHUB_TOKEN이 read-only라 코멘트 게시가 실패할 수 있어 continue-on-error.
+
+on:
+  pull_request:
+    paths:
+      - 'src/shared/types/pushContract.ts'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  remind:
+    name: Contract Change Reminder
+    runs-on: ubuntu-latest
+    steps:
+      - name: 리마인더 코멘트 게시/갱신
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- adr-029-phase4-contract-reminder -->';
+            const body = [
+              marker,
+              '### push 계약(`pushContract.ts`) 변경 감지 — ADR-029 Phase 4',
+              '',
+              'kind union이 변경된 PR입니다. 아래를 함께 갱신했는지 확인해 주세요 (PR 본문 "계약 변경 체크리스트" 참고):',
+              '',
+              '- SSoT(`pushContract.ts`) exhaustive switch/assertNever 갱신',
+              '- 경계 검증(Phase 1, zod refinement) 갱신',
+              '- de-wire registry(Phase 3, `signalProvenanceRegistry.ts`) 등재/은퇴 반영',
+              '- 테스트 동반',
+              '',
+              '_이 코멘트는 리뷰어 상기용 소프트 게이트입니다 — CI를 막지 않습니다._',
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.data.find((c) => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/docs/decisions/ADR-029-cross-boundary-contract-drift-prevention.md
+++ b/docs/decisions/ADR-029-cross-boundary-contract-drift-prevention.md
@@ -55,8 +55,9 @@
 ### Phase 3 — de-wire lint
 - 채널/이벤트 은퇴 시 그에 묶인 지표/소비자 orphan 감지 룰(`scripts/check-orphan-exports.sh` 확장 or 신규). `silentPushReach` 같은 죽은 지표가 lint fail.
 
-### Phase 4 — 계약 변경 프로세스 강제
+### Phase 4 — 계약 변경 프로세스 강제 (구현: #2252)
 - push kind 추가/은퇴 PR은 SSoT + exhaustive + 검증 + 테스트를 **한 PR에 동반**(PR 템플릿 + CI 게이트). 분리 금지.
+- 구현: `.github/PULL_REQUEST_TEMPLATE.md` "계약 변경 체크리스트" 섹션 + `.github/workflows/contract-change-reminder.yml`(`pushContract.ts` 변경 시 리뷰어 상기 코멘트, soft gate — hard-fail 없음).
 
 ### Phase 5 — 런타임 버전 스큐 방어 (G1, 가장 큰 빈틈)
 - **문제**: SSoT는 *같은 git SHA*에서만 정합. device(App Store 심사 지연)와 backend(즉시 배포)는 따로 나가므로 **배포된 런타임끼리는 여전히 스큐** 가능(이번 `unk=5`의 실제 원인 = 빌드 스큐 = 런타임 스큐 증상).


### PR DESCRIPTION
## Summary

Part of #2234 — ADR-029 Phase 4. push kind(pushContract.ts kind union) 추가/은퇴 PR이 SSoT·경계검증(P1)·de-wire registry(P3)·테스트를 함께 갱신하도록 상기시키는 **soft gate**를 추가한다. hard-fail 없음 — 리뷰어 상기가 목적.

Closes #2252

- `.github/PULL_REQUEST_TEMPLATE.md`에 "계약 변경 체크리스트 (push kind 추가/은퇴 시)" 섹션 추가
- `.github/workflows/contract-change-reminder.yml` 신규: PR diff에 `src/shared/types/pushContract.ts` 변경이 있으면 리뷰어 상기 코멘트를 게시/갱신 (`paths` 트리거 자체가 감지 로직 — 별도 스크립트 없이 과설계 방지, `continue-on-error: true`로 fork PR에서도 CI를 막지 않음)
- `docs/decisions/ADR-029-cross-boundary-contract-drift-prevention.md` Phase 4 섹션에 구현 링크 한 줄 추가

## 스코프

`.github/*` + 문서만 변경. contract source(`pushContract.ts`/`apns.ts`/`silentPushTask.ts`, P5 트랙 소유)·fusion 로직 미접촉.

---

## Wire-completion 5단 체크

- [x] **1. Orphan 없음** — `npm run lint:orphan` pass (신규 export/코드 변경 없음, workflow+doc만).
- [x] **2. V/X dashboard** — 코멘트는 해당 PR 본문 하단(GitHub PR 타임라인)에서 직접 시각화. 별도 대시보드 불필요(soft reminder).
- [x] **3. 의존 PR** — N/A (선행 P0~P3 이미 머지됨: #2232/#2233/#2243/#2251 계열).
- [x] **4. 측정 plan** — 다음 계약 변경 PR(`pushContract.ts` 수정 포함)에서 이 워크플로가 실제로 코멘트를 게시하는지 확인. 1주 내 계약 변경 PR 발생 시 코멘트 노출 여부 관찰.
- [x] **5. Device verify** — N/A — type+unit only (`.github/*` + 문서 변경, 런타임 코드 미변경).

### V/X dashboard URL

GitHub PR 타임라인 코멘트 (예: 이 워크플로 트리거 후 PR 코멘트).

### 의존 PR

N/A

---

## Test plan

- [x] `npm run type-check` pass
- [x] `npm run lint:orphan` pass (0 orphan)
- [x] YAML 문법 검증 (`js-yaml`로 파싱 확인)
- [ ] 코드 변경 없음 — `npm test` 커버리지 영향 없음 (collectCoverageFrom이 `src/**`만 대상, `.github/*` 미포함)