### PR TITLE
feat(#2253): push 계약 contractVersion 런타임 스큐 방어 (ADR-029 Phase 5, G1)

### DIFF
--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -16,6 +16,7 @@ import {
   type SilentPushPayload,
 } from '../apns';
 import { TRIP_ENDED_ALERT_BODY, TRIP_ENDED_ALERT_TITLE } from '../alertContent';
+import { PUSH_CONTRACT_VERSION } from '../../../../src/shared/types/pushContract';
 
 let privateKeyPem = '';
 
@@ -1700,5 +1701,24 @@ describe('buildSilentPushData contract skew (#2243, ADR-029 Phase 1 G2)', () => 
       expect.stringContaining('fields=nextWaypoint,etaSeconds,phase'),
     );
     warnSpy.mockRestore();
+  });
+});
+
+// #2253 (ADR-029 Phase 5, G1) — buildSilentPushData가 항상 현재 계약 버전을 stamp한다.
+describe('buildSilentPushData contractVersion stamp (#2253, ADR-029 Phase 5 G1)', () => {
+  function validPayload(): SilentPushPayload {
+    return {
+      nextWaypoint: '강남',
+      etaSeconds: 60,
+      phase: 'early',
+      kind: 'destination',
+      sentAt: 1_700_000_000_000,
+      pushId: 'push-uuid-version',
+    };
+  }
+
+  it('caller가 contractVersion을 전달하지 않아도 SSoT 현재 값을 stamp한다', () => {
+    const data = buildSilentPushData(validPayload());
+    expect(data.contractVersion).toBe(PUSH_CONTRACT_VERSION);
   });
 });

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -25,6 +25,7 @@ import {
   isPushAlarmPhase,
   isValidEtaSeconds,
   isValidStationIdentifier,
+  PUSH_CONTRACT_VERSION,
 } from '../../../src/shared/types/pushContract';
 
 /**
@@ -355,6 +356,10 @@ export function buildSilentPushData(payload: SilentPushPayload): Record<string, 
     kind: payload.kind,
     sentAt: payload.sentAt,
     pushId: payload.pushId,
+    // #2253 (ADR-029 Phase 5, G1) — 계약 버전 stamp. caller가 payload에 담지 않고 이 builder가
+    // 항상 현재 SSoT 값으로 stamp한다(발신 시점 코드가 곧 backend의 실제 계약 버전이므로). 구
+    // device는 이 필드를 모르면 무시(byte-level 호환) — 신 device만 skew 비교에 사용한다.
+    contractVersion: PUSH_CONTRACT_VERSION,
     // Epic #1204 그룹 2 D3 (#1273) — payload.hopIndex가 정의된 경우에만 wire.
     // 구 backend 호환을 위해 optional이라 undefined일 땐 JSON에서 자연 누락된다.
     ...(payload.hopIndex === undefined ? {} : { hopIndex: payload.hopIndex }),

--- a/docs/decisions/ADR-029-cross-boundary-contract-drift-prevention.md
+++ b/docs/decisions/ADR-029-cross-boundary-contract-drift-prevention.md
@@ -58,10 +58,11 @@
 ### Phase 4 — 계약 변경 프로세스 강제
 - push kind 추가/은퇴 PR은 SSoT + exhaustive + 검증 + 테스트를 **한 PR에 동반**(PR 템플릿 + CI 게이트). 분리 금지.
 
-### Phase 5 — 런타임 버전 스큐 방어 (G1, 가장 큰 빈틈)
+### Phase 5 — 런타임 버전 스큐 방어 (G1, 가장 큰 빈틈) — 구현 완료 (#2253)
 - **문제**: SSoT는 *같은 git SHA*에서만 정합. device(App Store 심사 지연)와 backend(즉시 배포)는 따로 나가므로 **배포된 런타임끼리는 여전히 스큐** 가능(이번 `unk=5`의 실제 원인 = 빌드 스큐 = 런타임 스큐 증상).
-- payload에 `contractVersion` 필드 도입 → 수신 측이 자기 지원 버전과 비교해 스큐를 명시 관측.
-- **backward-compat 규칙**: backend는 구 device kind/필드를 **최소 N릴리스(제안 2)** 유지. 새 kind는 additive-only(기존 값 의미 변경 금지). Phase 4 프로세스 게이트가 이를 CI에서 강제.
+- `pushContract.ts`에 `PUSH_CONTRACT_VERSION`(SSoT, 현재 값 1) 도입. backend `apns.ts` `buildSilentPushData`가 매 standard silent push payload에 `contractVersion`으로 stamp하고, device `silentPushTask.ts`가 자신이 빌드된 시점의 `PUSH_CONTRACT_VERSION`과 비교한다.
+- device < backend(즉 `payload.contractVersion > PUSH_CONTRACT_VERSION`)면 `logPushContractVersionSkew`(P1 skew 로그 경로 재사용, source=`push-contract-skew`)로 명시 관측한 뒤, **기존 kind 처리를 막지 않는다**(fail-open, P1 G6 정책 재사용) — 알림 누락이 회귀보다 크다는 원칙 유지.
+- **backward-compat 규칙(확정)**: 계약 버전을 올리는 것은 discriminator 집합/필수 필드 semantics 자체가 바뀔 때만 — 신규 optional 필드 추가(additive-only)는 버전을 올리지 않는다. 버전을 올리는 PR은 backend가 **최소 2릴리스** 동안 구 device가 이해하는 kind/필드를 계속 발사할 수 있어야 한다. Phase 4 프로세스 게이트가 이를 CI에서 강제(추후).
 
 ---
 

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -43,6 +43,8 @@ const mockFlushAlarmLog = jest.fn().mockResolvedValue(undefined);
 // #2243 (ADR-029 Phase 1) — G6 kind skew / G2 value skew 관측 로거.
 const mockLogPushContractKindSkew = jest.fn();
 const mockLogPushContractValueSkew = jest.fn();
+// #2253 (ADR-029 Phase 5, G1) — 런타임 버전 스큐 관측 로거.
+const mockLogPushContractVersionSkew = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
   logSilentPushReceived: (...args: unknown[]) => mockLogSilentPushReceived(...args),
   logSilentPushRescheduleReceived: (...args: unknown[]) =>
@@ -55,6 +57,7 @@ jest.mock('../../utils/alarmLog', () => ({
   logCompanionAlarmFired: (...args: unknown[]) => mockLogCompanionAlarmFired(...args),
   logPushContractKindSkew: (...args: unknown[]) => mockLogPushContractKindSkew(...args),
   logPushContractValueSkew: (...args: unknown[]) => mockLogPushContractValueSkew(...args),
+  logPushContractVersionSkew: (...args: unknown[]) => mockLogPushContractVersionSkew(...args),
   flushAlarmLog: () => mockFlushAlarmLog(),
 }));
 
@@ -287,7 +290,11 @@ import {
 } from '../../../../shared/constants/storageKeys';
 // #2246 (ADR-029 Phase 2) — G6 property 테스트가 SSoT known-kind 집합과의 충돌 없는 임의 kind를
 // 생성하기 위해 참조.
-import { STATION_WAYPOINT_KINDS, CONTROL_PUSH_KINDS } from '../../../../shared/types/pushContract';
+import {
+  STATION_WAYPOINT_KINDS,
+  CONTROL_PUSH_KINDS,
+  PUSH_CONTRACT_VERSION,
+} from '../../../../shared/types/pushContract';
 
 const DEFAULT_APNS_TOKEN = 'apns-tok-hex';
 
@@ -911,6 +918,40 @@ describe('silentPushTask', () => {
           }),
         );
         expect(result).toMatchObject({ ssot: { passedStations: [] } });
+      });
+    });
+
+    describe('contractVersion (#2253, ADR-029 Phase 5 G1)', () => {
+      it('유효한 정수 contractVersion은 그대로 통과', () => {
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', kind: 'transfer', contractVersion: 2 }),
+          ),
+        ).toMatchObject({ contractVersion: 2 });
+      });
+
+      it('구버전 backend(필드 미전달)는 undefined', () => {
+        expect(
+          extractPayload(
+            bgTaskData({ nextWaypoint: 'A', etaSeconds: 1, phase: 'early', kind: 'transfer' }),
+          ),
+        ).toMatchObject({ contractVersion: undefined });
+      });
+
+      it('형식이 잘못된 값(문자열/0/음수/소수)은 undefined로 정규화', () => {
+        for (const bad of ['2', 0, -1, 1.5]) {
+          expect(
+            extractPayload(
+              bgTaskData({
+                nextWaypoint: 'A',
+                etaSeconds: 1,
+                phase: 'early',
+                kind: 'transfer',
+                contractVersion: bad,
+              }),
+            ),
+          ).toMatchObject({ contractVersion: undefined });
+        }
       });
     });
 
@@ -1657,6 +1698,44 @@ describe('silentPushTask', () => {
         await handleSilentPush({ data: bgTaskData({ trigger: 'other' }) });
         expect(mockLogPushContractKindSkew).not.toHaveBeenCalled();
         expect(mockScheduleNotificationAsync).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('#2253 (ADR-029 Phase 5, G1) — contractVersion 런타임 스큐', () => {
+      it('backend contractVersion > device 지원 버전 → skew 로그 적재 + 기존 kind는 fail-open 정상 처리(legacy-station-kind-ignored)', async () => {
+        await handleSilentPush(
+          payload({
+            kind: 'destination',
+            phase: 'imminent',
+            nextWaypoint: '강남',
+            pushId: 'p-version-skew',
+            contractVersion: 99,
+          }),
+        );
+        expect(mockLogPushContractVersionSkew).toHaveBeenCalledWith({
+          deviceVersion: PUSH_CONTRACT_VERSION,
+          backendVersion: 99,
+          stationName: '강남',
+        });
+        // fail-open — 기존 kind 처리(legacy-station-kind-ignored skip)가 그대로 진행된다.
+        expect(mockLogSilentPushSkipped).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'legacy-station-kind-ignored' }),
+        );
+        expect(mockSendPushAck).toHaveBeenCalledWith(
+          ackCall('p-version-skew', 'skipped', 'legacy-station-kind-ignored'),
+        );
+      });
+
+      it('backend contractVersion === device 버전이면 skew 로그 없음', async () => {
+        await handleSilentPush(
+          payload({ kind: 'transfer', phase: 'early', contractVersion: PUSH_CONTRACT_VERSION }),
+        );
+        expect(mockLogPushContractVersionSkew).not.toHaveBeenCalled();
+      });
+
+      it('contractVersion 미전달(구버전 backend)이면 skew 로그 없음', async () => {
+        await handleSilentPush(payload({ kind: 'transfer', phase: 'early' }));
+        expect(mockLogPushContractVersionSkew).not.toHaveBeenCalled();
       });
     });
 

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -52,6 +52,7 @@ import {
   logCompanionAlarmFired,
   logPushContractKindSkew,
   logPushContractValueSkew,
+  logPushContractVersionSkew,
   type AlarmLogReason,
 } from '../utils/alarmLog';
 import { fireCompanionAlarm, readSleepMode } from '../utils/alarmLocalAuthority';
@@ -94,7 +95,9 @@ import {
   isPushAlarmPhase,
   isSleepAlarmTargetKind,
   isStationWaypointKind,
+  isValidContractVersion,
   isValidEtaSeconds,
+  PUSH_CONTRACT_VERSION,
   type ControlPushKind,
   type SleepAlarmTargetKind,
   type StationWaypointKind,
@@ -116,6 +119,14 @@ export interface SilentPushPayload {
    * 관측용 — 정상 kind거나 필드 자체가 없으면 undefined.
    */
   kindRaw?: string;
+  /**
+   * #2253 (ADR-029 Phase 5, G1) — backend가 stamp한 push 계약 버전(`pushContract.
+   * PUSH_CONTRACT_VERSION`). 구 backend는 필드 자체를 보내지 않아 undefined — 이 경우 스큐
+   * 비교를 자연 skip한다(구 backend는 device보다 앞설 수 없으므로 안전). 값 형식이 잘못된
+   * 경우(`isValidContractVersion` 실패)도 undefined로 정규화 — 파싱 시점 계약 스큐가 아니라
+   * 버전 스큐 판정 로직 자체를 오염시키지 않기 위함.
+   */
+  contractVersion?: number;
   /**
    * 백엔드 발사 시점 epoch ms (#478 측정 인프라).
    * 종료 조건: 신 백엔드 배포 후 required로 승격.
@@ -535,6 +546,7 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
     etaSeconds,
     phase,
     kind,
+    contractVersion,
     sentAt,
     pushId,
     hopIndex,
@@ -570,6 +582,7 @@ function extractStandardPayload(obj: Record<string, unknown>): SilentPushPayload
     phase,
     kind: validKind,
     kindRaw,
+    contractVersion: isValidContractVersion(contractVersion) ? contractVersion : undefined,
     sentAt: validSentAt(sentAt),
     pushId: validPushId(pushId),
     hopIndex: validHopIndex(hopIndex),
@@ -1201,6 +1214,29 @@ export async function handleSilentPush(input: NotificationBackgroundTaskData): P
       receivedAt,
       rawKind: payload.kindRaw,
     });
+
+    // #2253 (ADR-029 Phase 5, G1) — backend가 device보다 앞선 contractVersion을 stamp했으면 런타임
+    // 버전 스큐(App Store 배포 지연 등으로 device가 낡은 빌드를 실행 중). fail-open — 여기서
+    // 발사를 막거나 되돌리지 않는다. 관측만 남기고 아래 기존 kind 처리(P1 G6 등)가 그대로 진행된다.
+    // 구 backend(contractVersion 미전달)나 device가 최신/앞선 경우는 skew가 아니다.
+    if (
+      payload.contractVersion !== undefined &&
+      payload.contractVersion > PUSH_CONTRACT_VERSION
+    ) {
+      logPushContractVersionSkew({
+        deviceVersion: PUSH_CONTRACT_VERSION,
+        backendVersion: payload.contractVersion,
+        stationName: payload.nextWaypoint,
+      });
+      addDomainBreadcrumb('push', 'contract-skew', {
+        category: 'version',
+        deviceVersion: PUSH_CONTRACT_VERSION,
+        backendVersion: payload.contractVersion,
+      });
+      logger.warn(
+        `push contract skew (version, fail-open): device=${PUSH_CONTRACT_VERSION} backend=${payload.contractVersion} station=${payload.nextWaypoint}`,
+      );
+    }
 
     // #1438 (E5) — backend → device lock release sync. payload.lockReleasedReason이 있으면
     // backend가 trip.boardingLock을 release했다는 신호 → 로컬 store도 같이 release한다. fire/skip

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -98,6 +98,7 @@ import {
   countFiredAlarms,
   logPushContractKindSkew,
   logPushContractValueSkew,
+  logPushContractVersionSkew,
   ALARM_LOG_BUFFER_SIZE,
   type AlarmLogEntry,
   type AlarmLogStamp,
@@ -2441,6 +2442,19 @@ describe('alarmLog', () => {
       expect(saved[0].outcome).toBe('suppressed');
       expect(saved[0].reason).toBe('push-contract-skew-value-drift');
       expect(saved[0].pushKindRaw).toBe('etaSeconds=-5');
+      expect(saved[0].stationName).toBe('강남');
+    });
+
+    it('#2253 (ADR-029 Phase 5, G1): logPushContractVersionSkew이 version skew entry를 적재한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logPushContractVersionSkew({ deviceVersion: 1, backendVersion: 2, stationName: '강남' });
+      await flushAlarmLog();
+      const saved = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
+      expect(saved).toHaveLength(1);
+      expect(saved[0].source).toBe('push-contract-skew');
+      expect(saved[0].outcome).toBe('received');
+      expect(saved[0].reason).toBe('push-contract-skew-version-old');
+      expect(saved[0].pushKindRaw).toBe('device=1 backend=2');
       expect(saved[0].stationName).toBe('강남');
     });
 

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -377,7 +377,11 @@ export type AlarmLogReason =
   // #2243 (ADR-029 Phase 1, G2) — kind는 알려진 값인데 그 아래 값(phase/etaSeconds 등)이 도메인
   // semantics를 벗어난 drift(NaN etaSeconds, 상한 초과, 알 수 없는 phase 문자열 등)를 경계에서
   // 포착해 적재. 처리 자체는 기존과 동일하게 skip(발사 안 함) — 관측만 추가.
-  | 'push-contract-skew-value-drift';
+  | 'push-contract-skew-value-drift'
+  // #2253 (ADR-029 Phase 5, G1) — backend가 device보다 앞선 `contractVersion`을 stamp한 payload를
+  // 수신한 1건(런타임 버전 스큐). P1 G6 fail-open 정책 재사용 — 발사는 막지 않는다(기존 kind 처리가
+  // 이 skip과 별개로 정상 진행), 이 reason은 순수 관측용.
+  | 'push-contract-skew-version-old';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.
@@ -1185,6 +1189,29 @@ export function logPushContractValueSkew(input: {
     reason: 'push-contract-skew-value-drift',
     stationName: input.stationName,
     pushKindRaw: `${input.field}=${JSON.stringify(input.rawValue)}`,
+  });
+}
+
+/**
+ * push 계약 런타임 버전 스큐 1건 적재 (#2253, ADR-029 Phase 5 G1).
+ *
+ * backend가 device보다 앞선 `contractVersion`을 stamp한 payload를 수신했을 때 관측용으로만
+ * 적재한다 — 처리(발사)는 fail-open으로 기존 kind 로직이 그대로 진행하므로 outcome은 'received'
+ * (관측일 뿐 자체 skip/fire 판정이 아님). `pushKindRaw`에 두 버전을 `device=X backend=Y` 형식으로
+ * 남겨 어떤 배포 창에서 스큐가 발생했는지 바로 진단 가능하게 한다.
+ */
+export function logPushContractVersionSkew(input: {
+  deviceVersion: number;
+  backendVersion: number;
+  stationName?: string;
+}): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'push-contract-skew',
+    outcome: 'received',
+    reason: 'push-contract-skew-version-old',
+    stationName: input.stationName,
+    pushKindRaw: `device=${input.deviceVersion} backend=${input.backendVersion}`,
   });
 }
 

--- a/src/shared/types/__tests__/pushContract.test.ts
+++ b/src/shared/types/__tests__/pushContract.test.ts
@@ -5,12 +5,14 @@ import {
   STATION_WAYPOINT_KINDS,
   PUSH_ALARM_PHASES,
   PUSH_ETA_SECONDS_MAX,
+  PUSH_CONTRACT_VERSION,
   UNKNOWN_KIND_POLICY,
   assertNever,
   isControlPushKind,
   isPushAlarmPhase,
   isSleepAlarmTargetKind,
   isStationWaypointKind,
+  isValidContractVersion,
   isValidEtaSeconds,
   isValidStationIdentifier,
   type StationWaypointKind,
@@ -137,5 +139,23 @@ describe('pushContract G2/G6 (#2243, ADR-029 Phase 1)', () => {
     expect(isValidEtaSeconds(NaN)).toBe(false);
     expect(isValidEtaSeconds(Infinity)).toBe(false);
     expect(isValidEtaSeconds('120')).toBe(false);
+  });
+});
+
+describe('pushContract PUSH_CONTRACT_VERSION / isValidContractVersion (#2253, ADR-029 Phase 5 G1)', () => {
+  it('PUSH_CONTRACT_VERSION은 1 이상 정수 SSoT 값이다', () => {
+    expect(Number.isInteger(PUSH_CONTRACT_VERSION)).toBe(true);
+    expect(PUSH_CONTRACT_VERSION).toBeGreaterThanOrEqual(1);
+  });
+
+  it('isValidContractVersion — 1 이상 정수만 통과', () => {
+    expect(isValidContractVersion(1)).toBe(true);
+    expect(isValidContractVersion(2)).toBe(true);
+    expect(isValidContractVersion(0)).toBe(false);
+    expect(isValidContractVersion(-1)).toBe(false);
+    expect(isValidContractVersion(1.5)).toBe(false);
+    expect(isValidContractVersion(NaN)).toBe(false);
+    expect(isValidContractVersion('1')).toBe(false);
+    expect(isValidContractVersion(undefined)).toBe(false);
   });
 });

--- a/src/shared/types/pushContract.ts
+++ b/src/shared/types/pushContract.ts
@@ -152,3 +152,35 @@ export function isValidEtaSeconds(value: unknown): value is number {
     value <= PUSH_ETA_SECONDS_MAX
   );
 }
+
+/**
+ * 런타임 버전 스큐 방어 (ADR-029 Phase 5 / G1, #2253) — SSoT.
+ *
+ * backend와 device는 이 파일(SSoT)을 각자 별도 빌드에 컴파일해 넣는다 — **같은 git SHA로 배포된
+ * 경우에만** 완전히 정합하다. App Store 심사 지연 등으로 device가 backend보다 낡은 빌드를
+ * 실행 중이면, 두 런타임이 별도로 배포됐기 때문에 컴파일 타임 exhaustive switch(Phase 0)로도
+ * 못 잡는 **런타임 스큐**가 발생한다(2026-08-09 dump `unk=5`의 실제 원인 중 하나로 추정).
+ *
+ * backend `apns.ts` `buildSilentPushData`가 매 standard silent push payload에 이 값을
+ * `contractVersion`으로 stamp하고, device `silentPushTask.ts`가 자신이 빌드된 시점의
+ * `PUSH_CONTRACT_VERSION`(같은 SSoT를 import한 값)과 비교한다. device 값보다 backend 값이 크면
+ * device가 낡은 것 — **skew 관측(P1 skew 로그 경로 재사용) + 기존 kind는 fail-open으로 정상
+ * 발사**(P1 G6 정책 재사용, ADR-029 A5). 발사를 막는 것은 A2(silent drop 금지) 취지에 반한다.
+ *
+ * **backward-compat 규칙(additive-only)**: 이 값을 올리는 것은 discriminator 집합/필수 필드
+ * semantics 자체가 바뀔 때만 — 신규 optional 필드 추가는 버전을 올리지 않는다. 값을 올리는 PR은
+ * backend가 **최소 2릴리스** 동안 구 device가 이해하는 kind/필드를 계속 발사할 수 있어야 한다
+ * (ADR-029 Phase 5 본문).
+ *
+ * **관측 범위(#2253 최초 구현)**: stamp/비교는 backend `buildSilentPushData`(standard silent
+ * push — station waypoint kind + unknown-kind fallback 경로 포함)에 한정된다. reschedule/
+ * trip-ended/boarding-prompt/sleep-alarm-companion 등 별도 control payload builder는 아직
+ * stamp하지 않는다 — 이번 dump(`unk=5`)의 원인이 standard 경로였기 때문에 그쪽부터 닫았다.
+ * control 채널까지 확장은 후속 스코프.
+ */
+export const PUSH_CONTRACT_VERSION = 1;
+
+/** `contractVersion` 값 형식 검증 — 1 이상 정수만 유효. */
+export function isValidContractVersion(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 1;
+}


### PR DESCRIPTION
Part of #2234
Closes #2253

## 무엇을
ADR-029 Phase 5 (G1) — backend↔device SSoT는 같은 git SHA에서만 정합하다. App Store 심사 지연 등으로 device가 낡은 빌드를 실행 중이면 backend가 먼저 새 계약으로 넘어가는 **런타임 스큐**가 생긴다(2026-08-09 dump `unk=5`의 실제 원인 중 하나). `contractVersion` 필드로 이를 명시 관측한다.

- `src/shared/types/pushContract.ts`: `PUSH_CONTRACT_VERSION`(SSoT, 현재 1) + `isValidContractVersion` 추가.
- `backend/alarm-worker/src/apns.ts`: `buildSilentPushData`가 매 standard silent push payload에 `contractVersion`을 stamp(caller 무관, builder가 항상 현재 SSoT 값 사용).
- `src/features/alarm/tasks/silentPushTask.ts`: payload에서 `contractVersion` 추출/검증 후 device 자신의 `PUSH_CONTRACT_VERSION`과 비교. `backend > device`면 skew를 관측(`logPushContractVersionSkew`, P1 skew 로그 경로 재사용)하지만 **기존 kind 처리는 그대로 진행**(fail-open, P1 G6 정책 재사용) — 알림 발사를 막지 않는다.
- `src/features/alarm/utils/alarmLog.ts`: `logPushContractVersionSkew` 추가. `source='push-contract-skew'`(기존 채널 재사용), `outcome='received'`(순수 관측, skip/fire 판정 아님), `reason='push-contract-skew-version-old'`.
- `docs/decisions/ADR-029-cross-boundary-contract-drift-prevention.md`: Phase 5 backward-compat 규칙 확정("최소 2릴리스" 확정 문구) + 관측 범위(standard/unknown-kind station 경로 한정, control push 채널은 후속 스코프) 명시.

## 이탈 사항 없음
- 파일 경계 준수: `pushContract.ts` / `apns.ts` / `silentPushTask.ts` / `alarmLog.ts` (+ 각 테스트) + ADR 문서만 변경. `.github/*`, fusion 미접촉.
- additive-only: 기존 kind 의미/필드 변경 없음. 신규 optional 필드만 추가.
- 새 npm 의존 없음.

## Wire 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — 신규 skew는 device alarmLog ring buffer(`source='push-contract-skew'`, DebugModal에서 조회 가능) + backend는 stamp 시점 값을 wire에 그대로 실어 wrangler tail/Cloudflare Dashboard에서 payload 확인 가능. 기존 `push-contract-skew` source 분포에 `reason='push-contract-skew-version-old'`로 추가 집계됨(기존 kind/value skew와 동일 채널, DebugModal이 이미 소비 중인 채널이라 신규 wiring 불필요).
3. **의존 PR** — P0~P1(#2235, #2243 계열) 머지됨. 본 PR은 그 위에 additive. N/A(추가 의존 없음).
4. **측정 plan** — 배포 롤아웃 창(App Store 심사 지연 기간)에서 `push-contract-skew` + `reason=push-contract-skew-version-old` 건수가 0보다 크게 나타나는지 alarmLog 집계로 관측. 정상 상황(같은 SHA 배포 직후)엔 0건이어야 함 — 1주 내 비정상 지속 발생 시 회귀로 판정.
5. **Device verify** — 코드 로직 자체는 type+unit(100% cov)으로 검증됨. 실제 버전 스큐 재현(구 device + 신 backend 조합)은 다음 App Store 배포 창에서만 자연 발생 — 그 전까지는 N/A. 필요 시 수동 검증은 device 빌드에서 `PUSH_CONTRACT_VERSION`을 임시로 낮춰 backend payload와 스큐를 강제 재현하는 방식으로 가능(코드 변경 없이 로컬 override).

## 테스트
- `npm test`: device 100% coverage 유지, 신규 skew 케이스(TP: backend>device / equal / undefined) 전부 pass.
- `cd backend/alarm-worker && npx vitest run`: 78 files / 2919 tests pass (ratchet 유지, contractVersion stamp 테스트 포함).
- `npm run type-check`, `npm run lint:orphan`: pass.