### PR TITLE
fix(#2256): A1 exhaustiveness 비대칭 보완 — control kind 컴파일-타임 커버리지

### DIFF
--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -395,6 +395,37 @@ export type ExtractedPayload =
   | SleepAlarmCompanionSilentPushPayload;
 
 /**
+ * A1 exhaustiveness 비대칭 보완 (#2256, ADR-029 Phase 0 후속) — control kind 컴파일-타임
+ * 커버리지 단언.
+ *
+ * `CONTROL_PUSH_KINDS`(SSoT, `pushContract.ts`)의 각 kind는 station kind와 달리 서로 다른
+ * payload schema를 가져 `Extract<ControlPushKind, '<literal>'>`로 각 payload interface에
+ * 핀되어 있다. 그 결과 기존 exhaustive switch(`handleSilentPush`의 control-kind switch)는
+ * *기존* payload union만 기준으로 exhaustive해 — `CONTROL_PUSH_KINDS`에 새 kind를 추가하고
+ * 대응 payload variant를 `ExtractedPayload`에 등록하지 않아도 switch 자체는 여전히 컴파일
+ * 통과한다(런타임 P1 fail-closed만 잡음). 아래 타입이 그 gap을 컴파일 타임으로 승격한다.
+ *
+ * `HandledControlPushKind`는 `ExtractedPayload`의 모든 variant가 실제로 제공하는 `kind` 리터럴
+ * 중 `ControlPushKind`에 속하는 것들의 합집합이다. `CONTROL_PUSH_KINDS`에 새 kind를 추가하고
+ * 대응 payload variant(및 `ExtractedPayload` union 등록)를 빠뜨리면
+ * `Exclude<ControlPushKind, HandledControlPushKind>`가 더 이상 `never`가 아니게 되고,
+ * `_ControlPushKindCoverageCheck`가 `never`로 좁혀져 아래 대입문이 컴파일 에러가 난다
+ * (`pushContract.test.ts`의 `@ts-expect-error` 데모가 동일 원리를 재현).
+ *
+ * **전제**: 각 control payload interface가 `kind: Extract<ControlPushKind, '<literal>'>`처럼
+ * 좁은 리터럴로 고정돼 있어야 한다. 이 필드가 `any`로 widen되면(`string`은 안전 — `Extract`가
+ * 걸러낸다) `Extract<any, ControlPushKind>`가 `any`로 흘러 `Exclude<ControlPushKind, any>`가
+ * `never`로 collapse해 본 단언이 무력화된다. 현재 4개 variant 모두 리터럴로 고정돼 있어 해당
+ * 없음 — 향후 payload interface 작성 시 이 전제를 깨지 않아야 한다.
+ */
+type HandledControlPushKind = Extract<ExtractedPayload['kind'], ControlPushKind>;
+type ControlPushKindCoverageAssert<T extends never> = T;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- 타입 전용 컴파일-타임 단언, 값 사용처 없음.
+type _ControlPushKindCoverageCheck = ControlPushKindCoverageAssert<
+  Exclude<ControlPushKind, HandledControlPushKind>
+>;
+
+/**
  * expo-notifications iOS의 `BackgroundEventTransformer.swift`가 APNs payload를
  * 다음과 같이 변환해 task 콜백에 전달한다:
  *   { data: { ...non-aps fields, dataString }, notification: <aps.alert | null>, aps: {...} }

--- a/src/shared/types/__tests__/pushContract.test.ts
+++ b/src/shared/types/__tests__/pushContract.test.ts
@@ -15,6 +15,7 @@ import {
   isValidContractVersion,
   isValidEtaSeconds,
   isValidStationIdentifier,
+  type ControlPushKind,
   type StationWaypointKind,
 } from '../pushContract';
 
@@ -139,6 +140,43 @@ describe('pushContract G2/G6 (#2243, ADR-029 Phase 1)', () => {
     expect(isValidEtaSeconds(NaN)).toBe(false);
     expect(isValidEtaSeconds(Infinity)).toBe(false);
     expect(isValidEtaSeconds('120')).toBe(false);
+  });
+});
+
+describe('pushContract A1 control-kind coverage assertion (#2256, ADR-029 Phase 0 후속)', () => {
+  /**
+   * 실제 프로덕션 단언은 `src/features/alarm/tasks/silentPushTask.ts`의
+   * `_ControlPushKindCoverageCheck`(`ExtractedPayload` 기준)가 수행한다 — 그 파일은 features
+   * 슬라이스라 여기(`shared/`)에서 직접 import할 수 없다(`import/no-restricted-paths`:
+   * shared는 features를 모른다). 여기서는 동일 메커니즘의 최소 재현으로 A1 실증을 남긴다:
+   * "payload variant 목록(HandledKind)이 `CONTROL_PUSH_KINDS` 전체를 커버하지 못하면 컴파일
+   * 에러가 난다"는 것을 `@ts-expect-error`로 증명한다.
+   */
+  it(
+    '컴파일-타임 실증 — 소비자(HandledKind)가 CONTROL_PUSH_KINDS 중 하나를 빠뜨리면 ' +
+      '커버리지 단언이 깨진다 (새 control kind를 union에만 추가하고 소비자를 안 만든 드리프트의 재현)',
+    () => {
+      // 'sleep-alarm-companion' payload variant를 깜빡 빠뜨렸다고 가정한 소비자 union.
+      type IncompleteHandledKind = Exclude<ControlPushKind, 'sleep-alarm-companion'>;
+      type IncompleteCoverage =
+        Exclude<ControlPushKind, IncompleteHandledKind> extends never ? true : never;
+
+      // @ts-expect-error — IncompleteCoverage는 'sleep-alarm-companion'이 빠져 Exclude 결과가
+      // never가 아니게 되고, 조건부 타입이 never로 좁혀져 true를 대입할 수 없다. 실제 코드에서
+      // CONTROL_PUSH_KINDS에 새 kind를 추가하고 대응 payload variant를 안 만들면 동일 원리
+      // (`ControlPushKindCoverageAssert`, silentPushTask.ts)로 컴파일이 깨진다 — 이 데모는
+      // `T extends never` generic 제약 대신 조건부 타입 대입으로 같은 Exclude 연산 결과를
+      // 재현한 것으로, 실제 구현과 동일한 컴파일 실패 메커니즘(constraint violation)은 아니다.
+      const demo: IncompleteCoverage = true;
+      expect(demo).toBe(true);
+    },
+  );
+
+  it('정상 케이스 — 소비자가 CONTROL_PUSH_KINDS 전체를 커버하면 단언이 통과한다(회귀 없음)', () => {
+    type FullHandledKind = ControlPushKind;
+    type FullCoverage = Exclude<ControlPushKind, FullHandledKind> extends never ? true : never;
+    const demo: FullCoverage = true;
+    expect(demo).toBe(true);
   });
 });
 


### PR DESCRIPTION
Part of #2234.
Closes #2256.

## 요약
A1 exhaustiveness는 station kind(transfer/destination/intermediate)에는 완전 방어를 제공하지만, control kind(reschedule/trip-ended/boarding-prompt/sleep-alarm-companion)는 각 payload가 `Extract<ControlPushKind, '<literal>'>`로 개별 핀되어 있어 `CONTROL_PUSH_KINDS`에 새 kind를 추가해도 기존 payload union 기준 switch가 여전히 exhaustive해 컴파일 에러가 나지 않는 gap이 있었다. 순수 type-level + 테스트로 이 비대칭을 보완했다. **런타임 로직·fusion 미접촉.**

## 변경
- `src/features/alarm/tasks/silentPushTask.ts`: `ExtractedPayload` 정의 직후 `HandledControlPushKind = Extract<ExtractedPayload['kind'], ControlPushKind>` + `ControlPushKindCoverageAssert<T extends never>` + `_ControlPushKindCoverageCheck` 추가. `CONTROL_PUSH_KINDS`에 새 kind를 추가하고 대응 payload variant(및 `ExtractedPayload` union 등록)를 빠뜨리면 `Exclude<ControlPushKind, HandledControlPushKind>`가 `never`가 아니게 되어 컴파일 에러.
- `src/shared/types/__tests__/pushContract.test.ts`: `@ts-expect-error` 데모 2건 추가 (소비자가 kind 하나를 빠뜨리면 단언이 깨지는 것 / 전체 커버 시 통과하는 것). `shared/`는 `features/`를 import할 수 없어(`import/no-restricted-paths`) 실제 `ExtractedPayload`를 참조하지 못하므로 동일 원리를 로컬 재현.

## 검증
- 수동 회귀 확인: `HandledControlPushKind`에서 `'trip-ended'`를 임시로 빼고 `npm run type-check` 실행 → 실제 `tsc` 에러(`Type '"trip-ended"' does not satisfy the constraint 'never'`) 발생 확인 후 원복.
- `npm run type-check` — pass
- `npm test` — 434 suites / 9297 tests pass, coverage 100% (lines/functions/branches/statements)
- `npm run lint:orphan` — 0 orphan
- code-review 에이전트 리뷰 완료 — P0/P1 없음, P2 3건(문서 보강) 전부 반영

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass 확인 완료. 신규 타입(`HandledControlPushKind` 등)은 export 없음(파일 내부 전용).
2. **V/X dashboard** — 이 신호는 컴파일 타임 전용(런타임 관측 대상 아님). CI `Type Check & Test` job이 drift 발생 시 즉시 red로 잡는다.
3. **의존 PR** — N/A (P0/#2235 이미 머지됨).
4. **측정 plan** — 의도적으로 `CONTROL_PUSH_KINDS`에 새 kind를 추가하고 대응 payload variant를 빠뜨리는 시나리오로 CI가 red가 되는지가 측정 지표. 본 PR의 회귀 신호 자체가 "컴파일 실패"이므로 production 측정과 무관.
5. **Device verify** — N/A — type+unit only.