### PR TITLE
fix(#2258): 알람 비주얼 UI를 취침모드 전용으로 게이트

### DIFF
--- a/docs/decisions/ADR-024-notification-alarm-split.md
+++ b/docs/decisions/ADR-024-notification-alarm-split.md
@@ -58,6 +58,10 @@ Accepted — 이슈 #2065 (Epic #2061), 2026-07-29. 사용자 체감 회귀 2건
 - 이 리스크는 의도적으로 수용한다: outage-miss(알람이 아예 안 울림)를 막기 위한 backstop이 존재하는 한, 극히 드문 경합 창(180s 버퍼 이내 cancel 실패)에서의 중복 1회는 miss보다 훨씬 저비용이다.
 - 중복 알람이 매 trip마다 반복 재현되면(N≥3) 별도 이슈로 cancel 신뢰성을 재조사한다 — 본 ADR은 trade-off 수용만 기록한다.
 
+### 6. 알람 비주얼 UI 노출 범위 (#2258)
+
+알람 비주얼(AlarmOverlay 환승/하차 오버레이)은 **취침모드 전용**이다 — 알람 소리/TTS/companion과 동일하게 `sleepMode` 단일 게이트를 따르며, 활성 trip 여부는 노출 조건이 아니다(`useAlarmEventStore.setAlarmEvent`).
+
 ## 결과
 
 ### 긍정

--- a/src/features/alarm/store/__tests__/useAlarmEventStore.test.ts
+++ b/src/features/alarm/store/__tests__/useAlarmEventStore.test.ts
@@ -1,12 +1,10 @@
 /* eslint-disable import/no-restricted-paths --
- * #2210 — useAlarmEventStore.ts와 동일한 orchestration 사유. 테스트가 게이트 조건(sleepMode,
- * destination)을 직접 세팅하려면 해당 sibling store를 import해야 한다.
+ * #2210 — useAlarmEventStore.ts와 동일한 orchestration 사유. 테스트가 게이트 조건(sleepMode)을
+ * 직접 세팅하려면 해당 sibling store를 import해야 한다.
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useAlarmEventStore } from '../useAlarmEventStore';
 import { useSettingsStore } from '../../../settings/store/useSettingsStore';
-import { useDestinationStore } from '../../../route/store/useDestinationStore';
-import { MOCK_STATIONS } from '../../../../testUtils/fixtures';
 
 jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
@@ -15,9 +13,8 @@ jest.mock('@react-native-async-storage/async-storage', () =>
 describe('useAlarmEventStore', () => {
   beforeEach(() => {
     useAlarmEventStore.setState({ alarmEvent: null, dismissSilence: null });
-    // #2210 — setAlarmEvent 게이트가 참조하는 cross-feature 상태를 매 테스트 기본값으로 리셋.
+    // #2210 / #2258 — setAlarmEvent 게이트가 참조하는 cross-feature 상태를 매 테스트 기본값으로 리셋.
     useSettingsStore.setState({ sleepMode: false });
-    useDestinationStore.setState({ destination: null });
     jest.clearAllMocks();
   });
 
@@ -27,16 +24,17 @@ describe('useAlarmEventStore', () => {
     expect(useAlarmEventStore.getState().alarmEvent).toBeNull();
   });
 
-  it('setAlarmEvent: 활성 trip 중(destination 존재)이면 알람 이벤트를 설정한다', () => {
-    useDestinationStore.setState({ destination: MOCK_STATIONS.gangnam });
+  // #2258 — 알람 비주얼(AlarmOverlay)은 취침모드 전용. 활성 trip 중이어도 sleepMode=false면
+  // 억제한다(구 #2210 게이트는 tripActive를 우회 조건으로 통과시켰으나, 이는 취침 OFF에서도
+  // 환승/하차 오버레이가 뜨는 회귀였다). red: 게이트 변경 전에는 이 상태에서 alarmEvent가 set됐다.
+  it('setAlarmEvent: sleepMode=false면 활성 trip 중이어도 알람 이벤트를 억제한다', () => {
     const { setAlarmEvent } = useAlarmEventStore.getState();
     setAlarmEvent({ phaseId: 'early', type: 'destination', stationName: '강남' });
 
-    const { alarmEvent } = useAlarmEventStore.getState();
-    expect(alarmEvent).toEqual({ phaseId: 'early', type: 'destination', stationName: '강남' });
+    expect(useAlarmEventStore.getState().alarmEvent).toBeNull();
   });
 
-  it('setAlarmEvent: sleepMode=true면 trip 종료 상태여도 알람 이벤트를 설정한다', () => {
+  it('setAlarmEvent: sleepMode=true면 알람 이벤트를 설정한다', () => {
     useSettingsStore.setState({ sleepMode: true });
     const { setAlarmEvent } = useAlarmEventStore.getState();
     setAlarmEvent({ phaseId: 'early', type: 'destination', stationName: '강남' });
@@ -45,10 +43,9 @@ describe('useAlarmEventStore', () => {
     expect(alarmEvent).toEqual({ phaseId: 'early', type: 'destination', stationName: '강남' });
   });
 
-  // #2210 (증상③) — 비취침 + trip 종료 상태의 stale 알람 replay 억제. red: 게이트 추가 전에는
-  // sleepMode=false, destination=null 기본 상태에서도 alarmEvent가 그대로 설정돼 FG 복귀 시
-  // overlay가 떴다.
-  it('setAlarmEvent: 비취침 + trip 종료(destination=null) 상태면 알람 이벤트를 억제한다', () => {
+  // #2210 (증상③) — 비취침 상태의 stale 알람 replay 억제. red: 게이트 추가 전에는 sleepMode=false
+  // 기본 상태에서도 alarmEvent가 그대로 설정돼 FG 복귀 시 overlay가 떴다.
+  it('setAlarmEvent: 비취침 상태면 알람 이벤트를 억제한다', () => {
     const { setAlarmEvent } = useAlarmEventStore.getState();
     setAlarmEvent({ phaseId: 'early', type: 'destination', stationName: '강남' });
 
@@ -56,7 +53,7 @@ describe('useAlarmEventStore', () => {
   });
 
   it('clearAlarmEvent: 알람 이벤트를 초기화하고 AsyncStorage도 정리한다', () => {
-    useDestinationStore.setState({ destination: MOCK_STATIONS.gangnam });
+    useSettingsStore.setState({ sleepMode: true });
     const { setAlarmEvent, clearAlarmEvent } = useAlarmEventStore.getState();
     setAlarmEvent({ phaseId: 'early', type: 'transfer', stationName: '역삼' });
     clearAlarmEvent();
@@ -74,8 +71,8 @@ describe('useAlarmEventStore', () => {
     expect(useAlarmEventStore.getState().alarmEvent).toBeNull();
   });
 
-  it('loadAlarmEvent: 활성 trip 중이면 AsyncStorage에서 알람 이벤트를 복원하고 제거한다', async () => {
-    useDestinationStore.setState({ destination: MOCK_STATIONS.gangnam });
+  it('loadAlarmEvent: sleepMode=true면 AsyncStorage에서 알람 이벤트를 복원하고 제거한다', async () => {
+    useSettingsStore.setState({ sleepMode: true });
     const event = { phaseId: 'early' as const, type: 'destination' as const, stationName: '강남' };
     (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(event));
 
@@ -87,10 +84,10 @@ describe('useAlarmEventStore', () => {
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith('subway-now:alarm-event');
   });
 
-  // #2210 — BG write(backgroundLocationTask)가 sleepMode 무관하게 남긴 stale ALARM_EVENT_KEY를
-  // FG loadAlarmEvent가 replay하는 경로. 비취침 + trip 종료 상태면 in-memory alarmEvent는
+  // #2210 / #2258 — BG write(backgroundLocationTask)가 sleepMode 무관하게 남긴 stale
+  // ALARM_EVENT_KEY를 FG loadAlarmEvent가 replay하는 경로. 비취침 상태면 in-memory alarmEvent는
   // 억제되지만, storage는 무조건 drain해 재차 replay되지 않는다.
-  it('loadAlarmEvent: 비취침 + trip 종료 상태면 알람 이벤트는 억제하되 storage는 drain한다', async () => {
+  it('loadAlarmEvent: 비취침 상태면 알람 이벤트는 억제하되 storage는 drain한다', async () => {
     const event = { phaseId: 'early' as const, type: 'destination' as const, stationName: '강남' };
     (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(event));
 

--- a/src/features/alarm/store/useAlarmEventStore.ts
+++ b/src/features/alarm/store/useAlarmEventStore.ts
@@ -1,8 +1,7 @@
 /* eslint-disable import/no-restricted-paths --
- * #2210 — Cross-feature orchestration: setAlarmEvent가 sleepMode(settings)와 trip-active
- * (route destination) 상태를 함께 게이트해야 한다. 비취침 + trip 종료 상태의 stale 알람
- * (BG write → FG loadAlarmEvent replay, inApp notification writer)를 단일 진입점에서 억제.
- * useDestinationStore가 이미 이 슬라이스를 역참조(alarm 클리어)하는 것과 대칭되는 orchestration.
+ * #2210 / #2258 — Cross-feature orchestration: setAlarmEvent가 sleepMode(settings) 상태를
+ * 게이트해야 한다. 알람 비주얼(AlarmOverlay)은 취침모드 전용 — BG write → FG loadAlarmEvent
+ * replay, inApp notification writer 두 경로 모두 단일 진입점에서 억제.
  */
 import { create } from 'zustand';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -15,7 +14,6 @@ import {
   type DismissSilenceState,
 } from '../utils/dismissSilenceStorage';
 import { useSettingsStore } from '../../settings/store/useSettingsStore';
-import { useDestinationStore } from '../../route/store/useDestinationStore';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = (): void => {};
@@ -54,14 +52,14 @@ export const useAlarmEventStore = create<AlarmEventState>((set, get) => ({
   alarmEvent: null,
   dismissSilence: null,
 
-  // #2210 — sleepMode + trip-active 중앙 게이트. BG write(backgroundLocationTask) → FG
+  // #2210 / #2258 — sleepMode 중앙 게이트. BG write(backgroundLocationTask) → FG
   // loadAlarmEvent replay와 inApp writer(notificationRouter) 두 경로 모두 이 함수를 거치므로
-  // 여기서 억제하면 두 경로 모두 상속받는다. 비취침(sleepMode=false) + trip 종료(destination=null)
-  // 상태의 stale 알람만 억제 — 취침 알람과 활성 trip 중 알람은 그대로 통과시킨다.
+  // 여기서 억제하면 두 경로 모두 상속받는다. 알람 비주얼(AlarmOverlay)은 취침모드 전용 —
+  // 활성 trip 여부와 무관하게 비취침(sleepMode=false)이면 항상 억제한다. 알람 소리/TTS/companion
+  // (alarmLocalAuthority.ts)은 이미 별도로 취침 전용이며, 상시 route 표시는 이 게이트와 무관.
   setAlarmEvent: (event: AlarmEvent) => {
     const { sleepMode } = useSettingsStore.getState();
-    const tripActive = useDestinationStore.getState().destination !== null;
-    if (!sleepMode && !tripActive) {
+    if (!sleepMode) {
       return;
     }
     set({ alarmEvent: event });

--- a/src/features/route/store/__tests__/useDestinationStore.test.ts
+++ b/src/features/route/store/__tests__/useDestinationStore.test.ts
@@ -258,7 +258,11 @@ describe('useDestinationStore', () => {
   it('setDestination(#799): switch 시 alarmEvent 메모리 state도 null로 동기화', () => {
     const { setDestination } = useDestinationStore.getState();
     setDestination(mockStation);
-    useAlarmEventStore.getState().setAlarmEvent({ phaseId: 'early', type: 'destination', stationName: '시청' });
+    // #2258 — setAlarmEvent는 sleepMode 전용 게이트를 거치므로, 이 테스트가 검증하는
+    // setDestination의 alarmEvent clear 동작(alarm 게이트와 무관)은 state를 직접 세팅해 확인한다.
+    useAlarmEventStore.setState({
+      alarmEvent: { phaseId: 'early', type: 'destination', stationName: '시청' },
+    });
     expect(useAlarmEventStore.getState().alarmEvent).not.toBeNull();
 
     setDestination(mockStation2);


### PR DESCRIPTION
## 요약
"환승하세요/하차하세요" 알람 UI(AlarmOverlay)가 취침모드 OFF에서도 활성 trip이면 노출되던 회귀 수정.

## RCA
`useAlarmEventStore.setAlarmEvent` 게이트(#2210)가 `if (!sleepMode && !tripActive) return`로, 활성 trip이 sleepMode 조건을 우회시켰다. 알람 소리/TTS/companion(`alarmLocalAuthority.ts`)은 이미 취침 전용인데 비주얼만 이 우회로 새고 있었다.

## 변경
- `setAlarmEvent` 게이트를 `if (!sleepMode) return`으로 단순화 — 알람 비주얼 = 취침 전용
- unused된 `tripActive` 계산 + `useDestinationStore` import 제거, #2210 주석 갱신
- `useAlarmEventStore.test.ts`: 기존 "활성 trip 중 알람 통과" 테스트를 새 의도(취침 전용 억제)로 갱신. red-first로 게이트 변경 전 실패 확인 후 구현
- `useDestinationStore.test.ts`: setDestination의 alarmEvent clear 검증(alarm 게이트와 무관한 동작)이 `setAlarmEvent` 대신 `setState`로 직접 이벤트를 세팅하도록 수정 — 새 게이트로 인해 sleepMode=false 기본값에서 setAlarmEvent가 no-op이 되므로
- ADR-024에 "알람 비주얼 UI = 취침 전용" 절 추가

## 보존 (미변경)
- 알람 소리/TTS/companion(`alarmLocalAuthority.ts`) — 이미 취침 전용
- 상시 route 정보 표시(LA route 레이어, 매역 visible 알림)
- backend 미접촉

## Wire-completion 5단
1. **Orphan 0** — `npm run lint:orphan` pass
2. **V/X dashboard** — 취침 OFF + 활성 trip 상태에서 AlarmOverlay 미노출(실기기 관찰). DebugModal의 alarmEvent state로도 확인 가능
3. **의존 PR** — N/A
4. **측정 plan** — 다음 실탑승(취침 OFF)에서 환승/하차 오버레이 노출 0건 확인
5. **Device verify** — 실기기 필요 — 취침 OFF 상태로 trip 진행 중 환승/하차 알람 오버레이가 뜨지 않는지 확인. 취침 ON에서는 기존대로 뜨는지 확인

## 테스트
- `npm test` — 434 suites / 9295 tests pass, coverage 100%
- `npm run type-check` — pass
- `npm run lint:orphan` — pass

Closes #2258