### PR TITLE
fix(#2261): POST /position full SSoT forward + receivedAt 기반 채택 (ADR-031 Phase 0)

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -2254,6 +2254,71 @@ describe('POST /position (#819)', () => {
     });
   });
 
+  describe('#2261 (ADR-031 Phase 0) — response embed full ssot (additive)', () => {
+    const BASE_POS = {
+      token: 'tok-ssot',
+      lat: 1,
+      lng: 2,
+      accuracy: 5,
+      ts: 1234,
+      motion: 'walking' as const,
+    };
+
+    it('SSOT 미존재 → body.ssot 누락 (graceful, 기존 originStationId/lockSuggestion 동작과 동형)', async () => {
+      const env = makeKvEnv();
+      const res = await post('/position', BASE_POS, env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.ssot).toBeUndefined();
+    });
+
+    it('SSOT 존재 (lockless·정지, lockSuggestion/alarmEvents 없음) → body.ssot에 motionState/lastAdvanceAt/passedStations forward', async () => {
+      const env = makeKvEnv();
+      const { seedSsot } = await import('../tripPositionSsot');
+      await seedSsot(env.TRIPS, BASE_POS.token, '용마산');
+      const res = await post('/position', BASE_POS, env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.ssot).toMatchObject({
+        currentStationId: '용마산',
+        motionState: expect.any(String),
+        lastAdvanceEvidence: expect.any(String),
+        lastAdvanceAt: expect.any(Number),
+        passedStations: [],
+      });
+      // lockSuggestion 부재 시 wire 자연 누락 (toSilentPushSsot 기존 정책 재사용).
+      // alarmEvents는 seedSsot 기본값이 빈 배열이라 toSilentPushSsot가 그대로 forward.
+      expect((body.ssot as Record<string, unknown>).lockSuggestion).toBeUndefined();
+      expect((body.ssot as Record<string, unknown>).alarmEvents).toEqual([]);
+      // 기존 originStationId/lockSuggestion 필드는 회귀 없이 그대로 병존 (additive).
+      expect(body.originStationId).toBe('용마산');
+    });
+
+    it('SSOT + lockSuggestion → body.ssot.lockSuggestion도 forward (silent push payload와 동일 축소)', async () => {
+      const env = makeKvEnv();
+      const { seedSsot, setLockSuggestion, writeSsot } = await import('../tripPositionSsot');
+      const ssot = await seedSsot(env.TRIPS, BASE_POS.token, '용마산');
+      setLockSuggestion(ssot, {
+        stationId: '용마산',
+        trainCode: '7246',
+        lineId: '7',
+        confidence: 'high',
+        decidedAt: 1_700_000_000_000,
+      });
+      await writeSsot(env.TRIPS, ssot);
+      const res = await post('/position', BASE_POS, env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect((body.ssot as Record<string, unknown>).lockSuggestion).toEqual({
+        stationId: '용마산',
+        trainCode: '7246',
+        lineId: '7',
+        confidence: 'high',
+        decidedAt: 1_700_000_000_000,
+      });
+    });
+  });
+
   // #2153 (리뷰 P1) — trip.promptGeoContext.originDistanceM/originAccuracyM은 device가
   // POST /trips 재등록할 때만 갱신되는 정적 스냅샷(useApnsTripRegistration.ts는 currentStation을
   // register effect deps에서 제외 — #703). "집에서 route 설정 → 재등록 트리거 없이 도보로 출발역

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -65,7 +65,7 @@ import { updateSsotMotion } from './motionState';
 import { writeMetric } from './analytics';
 import { deleteProgress, getProgress, putProgress, type TripProgress } from './progress';
 import { SeoulArrivalClient } from './seoul';
-import { runScheduled } from './scheduled';
+import { runScheduled, toSilentPushSsot } from './scheduled';
 import * as Sentry from '@sentry/cloudflare';
 import {
   addValidateRejectBreadcrumb,
@@ -1541,6 +1541,12 @@ app.post('/position', async (c) => {
       ? { originStationId: ssot.currentStationId }
       : {}),
     ...(ssot?.lockSuggestion ? { lockSuggestion: ssot.lockSuggestion } : {}),
+    // #2261 (ADR-031 Phase 0) — full SSoT additive forward. 기존 originStationId/lockSuggestion
+    // 필드는 legacy 호환을 위해 유지, 본 필드는 device가 motionState/lastAdvanceAt/passedStations/
+    // alarmEvents/currentStationLine까지 mirror에 채택할 수 있게 하는 신규 채널이다. silent push
+    // payload와 동일 `toSilentPushSsot` 축소를 재사용해 두 transport가 같은 wire 형태를 공유한다
+    // (device backendSsotMirror는 어느 채널에서 와도 동일 schema).
+    ...(ssot ? { ssot: toSilentPushSsot(ssot) } : {}),
   });
 });
 

--- a/src/features/nearest-station/api/__tests__/positionUpload.test.ts
+++ b/src/features/nearest-station/api/__tests__/positionUpload.test.ts
@@ -713,6 +713,39 @@ describe('uploadPosition response embed (#1534 S1 T9b, ADR-016)', () => {
     const stored = await AsyncStorage.getItem(BACKEND_SSOT_MIRROR_KEY);
     expect(stored).toBeNull();
   });
+
+  it('#2261 (ADR-031 Phase 0): response body에 full ssot(지하·정지, lockSuggestion 없음) → 그대로 mirror write', async () => {
+    process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev/';
+    (globalThis.fetch as jest.Mock).mockResolvedValue(
+      makeFetchResponse({
+        ok: true,
+        ssot: {
+          currentStationId: '용마산',
+          motionState: 'stationary',
+          lastAdvanceEvidence: 'arvlcd-arrived',
+          lastAdvanceAt: 1_699_999_000_000, // trip이 오래전에 advance한 이후 정지 — non-advancing.
+          passedStations: ['중곡'],
+        },
+      }),
+    );
+    await uploadPosition({
+      token: 'tok-full-ssot',
+      lat: 37.5,
+      lng: 127,
+      accuracy: 10,
+      ts: 0,
+      motion: 'stationary',
+    });
+    const stored = await AsyncStorage.getItem(BACKEND_SSOT_MIRROR_KEY);
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored as string);
+    expect(parsed.currentStationId).toBe('용마산');
+    expect(parsed.motionState).toBe('stationary');
+    expect(parsed.lastAdvanceAt).toBe(1_699_999_000_000);
+    expect(parsed.passedStations).toEqual(['중곡']);
+    // receivedAt은 호출 시각(Date.now())으로 stamp — full ssot의 stale lastAdvanceAt과 별개로 fresh.
+    expect(typeof parsed.receivedAt).toBe('number');
+  });
 });
 
 describe('persistFromPositionResponse (#1534 S1 T9b)', () => {
@@ -770,5 +803,50 @@ describe('persistFromPositionResponse (#1534 S1 T9b)', () => {
     // originStationId 우선 (lockSuggestion.stationId '용마산' fallback X)
     expect(parsed.currentStationId).toBe('강변');
     expect(parsed.lockSuggestion).toEqual(SUGGESTION);
+  });
+
+  describe('#2261 (ADR-031 Phase 0) — body.ssot 우선 채택', () => {
+    it('body.ssot 존재 → legacy 부분 합성 대신 그대로 채택 (motionState/lastAdvanceAt/passedStations 전체 forward)', async () => {
+      await persistFromPositionResponse(
+        {
+          // legacy 필드도 동시에 있어도 ssot가 우선.
+          originStationId: '무시될값',
+          ssot: {
+            currentStationId: '용마산',
+            motionState: 'stationary',
+            lastAdvanceEvidence: 'arvlcd-arrived',
+            lastAdvanceAt: 1_699_999_000_000,
+            passedStations: ['중곡'],
+            lockSuggestion: SUGGESTION,
+          },
+        },
+        1_700_000_010_000,
+      );
+      const stored = await AsyncStorage.getItem(BACKEND_SSOT_MIRROR_KEY);
+      const parsed = JSON.parse(stored as string);
+      expect(parsed.currentStationId).toBe('용마산');
+      expect(parsed.motionState).toBe('stationary');
+      expect(parsed.lastAdvanceAt).toBe(1_699_999_000_000);
+      expect(parsed.passedStations).toEqual(['중곡']);
+      expect(parsed.lockSuggestion).toEqual(SUGGESTION);
+      expect(parsed.receivedAt).toBe(1_700_000_010_000);
+    });
+
+    it('body.ssot.currentStationId 빈 문자열 → write skip (graceful)', async () => {
+      await persistFromPositionResponse(
+        {
+          ssot: {
+            currentStationId: '',
+            motionState: 'unknown',
+            lastAdvanceEvidence: 'seed-override',
+            lastAdvanceAt: 0,
+            passedStations: [],
+          },
+        },
+        1_700_000_010_000,
+      );
+      const stored = await AsyncStorage.getItem(BACKEND_SSOT_MIRROR_KEY);
+      expect(stored).toBeNull();
+    });
   });
 });

--- a/src/features/nearest-station/api/positionUpload.ts
+++ b/src/features/nearest-station/api/positionUpload.ts
@@ -323,7 +323,10 @@ export async function uploadPosition(
     // res.json() 실패는 try/catch가 catch — 응답 자체는 ok=true로 caller에 회신.
     try {
       const body = (await res.json()) as Partial<PositionResponseBody> | null;
-      if (body && (body.lockSuggestion || body.originStationId)) {
+      // #2261 (ADR-031 Phase 0) — body.ssot도 트리거 조건에 추가. lockless·정지 trip은
+      // lockSuggestion/originStationId 없이 ssot만 forward될 수 있다(예: currentStationId는
+      // 있으나 아직 lock 합의 전).
+      if (body && (body.lockSuggestion || body.originStationId || body.ssot)) {
         await persistFromPositionResponse(body, Date.now());
       }
     } catch {
@@ -347,6 +350,15 @@ export interface PositionResponseBody {
   originStationId?: string;
   /** backend가 추론한 lock 제안. lockless trip + 강 evidence 합의 시 set. */
   lockSuggestion?: LockSuggestionMirror;
+  /**
+   * #2261 (ADR-031 Phase 0) — full SSoT (backend `toSilentPushSsot` 축소, silent push payload와
+   * 동일 schema). additive 필드 — 기존 originStationId/lockSuggestion과 병존.
+   *
+   * 존재 시 `persistFromPositionResponse`가 이 값을 그대로 mirror로 채택한다(motionState/
+   * lastAdvanceAt/passedStations/alarmEvents/currentStationLine까지 전체 forward) — legacy
+   * fallback(originStationId/lockSuggestion만으로 부분 mirror 합성)보다 우선.
+   */
+  ssot?: SilentPushSsotMirror;
 }
 
 /**
@@ -363,8 +375,19 @@ export async function persistFromPositionResponse(
   body: Partial<PositionResponseBody>,
   receivedAt: number,
 ): Promise<void> {
-  // currentStationId는 originStationId fallback. 둘 다 부재면 빈 문자열로 두는 게 적절하나
-  // SilentPushSsotMirror 형식 검증이 빈 문자열을 reject하므로 lockSuggestion.stationId fallback 시도.
+  // #2261 (ADR-031 Phase 0) — body.ssot(full SSoT)가 있으면 그대로 채택한다. 이전에는
+  // lockSuggestion 부재 시 lastAdvanceAt이 0으로 고정돼(never fresh) lockless·정지 trip이 이
+  // 채널만으로는 영원히 mirror를 갱신할 수 없었다(deadlock의 절반). full ssot는 backend가 실제
+  // 추적 중인 motionState/lastAdvanceAt/passedStations/alarmEvents/currentStationLine을 그대로
+  // 담고 있어 legacy 부분 합성보다 우선한다.
+  if (body.ssot) {
+    if (body.ssot.currentStationId.length === 0) return;
+    await persistBackendSsotMirror(body.ssot, receivedAt);
+    return;
+  }
+  // legacy fallback — 구 backend(ssot 필드 미forward) 호환. currentStationId는 originStationId
+  // fallback. 둘 다 부재면 빈 문자열로 두는 게 적절하나 SilentPushSsotMirror 형식 검증이 빈
+  // 문자열을 reject하므로 lockSuggestion.stationId fallback 시도.
   const currentStationId =
     body.originStationId ?? body.lockSuggestion?.stationId ?? '';
   if (currentStationId.length === 0) return;

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.backendSsotCascade.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.backendSsotCascade.test.ts
@@ -6,7 +6,8 @@
  * 시나리오:
  *   1. backend SSoT mirror 존재 + fresh → cascade 1순위 채택, confidence/source='backend-ssot'.
  *   2. mirror 미존재 → 기존 tier(WiFi/position-train/...) fallback.
- *   3. mirror stale(lastAdvanceAt 180s 초과, #1573 T10) → cascade 채택 거부 → 기존 tier fallback.
+ *   3. mirror stale(receivedAt 180s 초과, #1573 T10 / #2261 ADR-031 Phase 0 receivedAt 재정의)
+ *      → cascade 채택 거부 → 기존 tier fallback.
  *   4. mirror lock 활성 + line mismatch → station resolve null → 채택 거부.
  *   5. mirror lockless + resolve 가능 → cascade 채택 (lockless도 lock과 동급 우선순위).
  *
@@ -134,17 +135,36 @@ describe('#1568 (T8b) cascade picker — backend-ssot tier', () => {
     expect(hook.result.current.confidence).not.toBe('backend-ssot');
   });
 
-  it('mirror stale(lastAdvanceAt > 180s) → 채택 거부 (#1573 T10 60s → 180s)', async () => {
+  it('mirror stale(receivedAt > 180s) → 채택 거부 (#1573 T10 60s → 180s, #2261 receivedAt 재정의)', async () => {
     setupBaselineGpsAt('청담');
     mockRead.mockResolvedValue(
       makeMirror({
         currentStationId: yongmasan.name,
-        lastAdvanceAt: T0 - 240_000, // 4분 전 — staleness 180s 초과
+        receivedAt: T0 - 240_000, // 4분 전 — staleness 180s 초과
       }),
     );
     const hook = renderHook(() => useFusedNearestStation());
     await flushSsotRead();
     expect(hook.result.current.source).not.toBe('backend-ssot');
+  });
+
+  it('#2261 mirror lastAdvanceAt stale(지하·정지 non-advancing)이어도 receivedAt fresh면 채택 (deadlock 해소)', async () => {
+    // 지하·정지 trip: backend가 advance를 전혀 못 해 lastAdvanceAt이 옛날 값에 고정돼 있어도
+    // FG position pull이 방금 mirror를 갱신했다면(receivedAt fresh) 채택돼야 한다.
+    setupBaselineGpsAt('청담');
+    mockRead.mockResolvedValue(
+      makeMirror({
+        currentStationId: yongmasan.name,
+        lastAdvanceAt: T0 - 10 * 60_000, // 10분 전 advance — non-advancing trip
+        receivedAt: T0, // 방금 pull로 갱신
+      }),
+    );
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushSsotRead();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+    expect(hook.result.current.result?.station.id).toBe(yongmasan.id);
   });
 
   it('mirror lock 활성 + line mismatch → station resolve 실패 → 채택 거부', async () => {
@@ -413,7 +433,8 @@ describe('#1705 ssotStation — lockless + currentStationLine line-matched resol
 
 describe('#1773 (E) SSoT mirror staleness × stale GPS 겹침 회귀 가드', () => {
   // GPS lastFixAtMs=T0-200_000: 200s old. GPS_FALLBACK_STALE_MAX_AGE_MS(300s) 이내라 GPS 게이트 통과.
-  // BACKEND_SSOT_MIRROR_MAX_AGE_MS = 180s. lastAdvanceAt으로 SSoT mirror 신선도 판정.
+  // BACKEND_SSOT_MIRROR_MAX_AGE_MS = 180s. #2261 (ADR-031 Phase 0) 이후 receivedAt으로 SSoT
+  // mirror 신선도 판정 (기존 lastAdvanceAt 기준에서 재정의).
   //
   // 시나리오:
   //   E1. mirror 60s old (fresh) + GPS 200s old → backend-ssot 채택 OK.
@@ -450,14 +471,14 @@ describe('#1773 (E) SSoT mirror staleness × stale GPS 겹침 회귀 가드', ()
   });
 
   it('E1: mirror 60s old(fresh) + GPS 200s old → backend-ssot 채택 OK', async () => {
-    // lastAdvanceAt = T0 - 60_000 (60s old). 60s < BACKEND_SSOT_MIRROR_MAX_AGE_MS(180s) → fresh.
+    // receivedAt = T0 - 60_000 (60s old). 60s < BACKEND_SSOT_MIRROR_MAX_AGE_MS(180s) → fresh.
     // GPS 200s old는 GPS_FALLBACK_STALE_MAX_AGE_MS(300s) 이내 → GPS 게이트 통과.
     // 결과: backend-ssot가 cascade 1순위로 채택됨.
     setupBaselineGpsWithLastFix('청담', T0 - 200_000);
     (readBackendSsotMirror as jest.Mock).mockResolvedValue(
       makeBackendSsotMirrorEntry({
         currentStationId: yongmasan.name,
-        lastAdvanceAt: T0 - 60_000,
+        receivedAt: T0 - 60_000,
       }),
     );
     const hook = renderHook(() => useFusedNearestStation());
@@ -470,13 +491,13 @@ describe('#1773 (E) SSoT mirror staleness × stale GPS 겹침 회귀 가드', ()
   });
 
   it('E2: mirror 170s old(한계 직전, still fresh) + GPS 200s old → backend-ssot 채택 OK', async () => {
-    // lastAdvanceAt = T0 - 170_000 (170s old). 170s < 180s → 아직 fresh(경계 직전).
+    // receivedAt = T0 - 170_000 (170s old). 170s < 180s → 아직 fresh(경계 직전).
     // 이 edge case는 stale 직전 구간 — 채택 허용 확인.
     setupBaselineGpsWithLastFix('청담', T0 - 200_000);
     (readBackendSsotMirror as jest.Mock).mockResolvedValue(
       makeBackendSsotMirrorEntry({
         currentStationId: yongmasan.name,
-        lastAdvanceAt: T0 - 170_000,
+        receivedAt: T0 - 170_000,
       }),
     );
     const hook = renderHook(() => useFusedNearestStation());
@@ -488,14 +509,14 @@ describe('#1773 (E) SSoT mirror staleness × stale GPS 겹침 회귀 가드', ()
   });
 
   it('E3: mirror 200s old(stale, >180s) + GPS 200s old → backend-ssot 채택 거부 → GPS fallback', async () => {
-    // lastAdvanceAt = T0 - 200_000 (200s old). 200s > 180s → stale → ssotFresh=false → 채택 거부.
+    // receivedAt = T0 - 200_000 (200s old). 200s > 180s → stale → ssotFresh=false → 채택 거부.
     // GPS 200s old는 GPS gate 통과 → GPS fallback으로 cascade 진행 (source='gps').
     // mirror stale + GPS not stale → fusion이 GPS tier로 fallback (source != 'backend-ssot').
     setupBaselineGpsWithLastFix('청담', T0 - 200_000);
     (readBackendSsotMirror as jest.Mock).mockResolvedValue(
       makeBackendSsotMirrorEntry({
         currentStationId: yongmasan.name,
-        lastAdvanceAt: T0 - 200_000,
+        receivedAt: T0 - 200_000,
       }),
     );
     const hook = renderHook(() => useFusedNearestStation());

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.silentPushFallback.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.silentPushFallback.test.ts
@@ -2,12 +2,18 @@
 
 /**
  * #1677 — silent push FG fallback: cascade `silentPushHealthy=false` 시 backend-ssot 강등.
+ * #2261 (ADR-031 Phase 0) — 위 게이트를 제거. freshness가 `receivedAt`(FG position pull이
+ * mirror에 도달한 시각) 기준으로 재정의되면서, push 건강도와 무관하게 backend 생존이 이미
+ * 증명되므로 silentPushHealthy AND-gate가 지하·정지(non-advancing) trip을 영구 미채택시키는
+ * deadlock을 유발했다 (RCA 2026-08-09). 본 파일은 게이트 소멸을 회귀 가드로 검증한다.
  *
  * 시나리오:
- *   1. silentPushHealthy=false + mirror fresh → backend-ssot 거부 → GPS fallback.
+ *   1. silentPushHealthy=false + mirror fresh(receivedAt) → backend-ssot **채택** (게이트 소멸,
+ *      #2261 핵심 회귀 가드 — deadlock 해소).
  *   2. silentPushHealthy=true + mirror fresh → 기존대로 backend-ssot 채택.
  *   3. silentPushHealthy=undefined(미전달) + mirror fresh → 기존대로 backend-ssot 채택.
- *   4. silentPushHealthy=false + mirror stale → 기존 stale 거부 그대로 (부작용 없음).
+ *   4. silentPushHealthy=false + mirror stale(receivedAt) → 기존 stale 거부 그대로 (staleness는
+ *      push 건강도와 독립적으로 여전히 적용).
  *   5. silentPushHealthy=false + mirror 없음 → 기존 GPS fallback (변화 없음).
  */
 
@@ -71,7 +77,7 @@ function setupGpsAt(stationName: string) {
   mockPos.mockReturnValue(positionRet(null));
 }
 
-describe('#1677 cascade — silentPushHealthy gate', () => {
+describe('#1677 / #2261 cascade — silentPushHealthy gate 소멸 회귀 가드', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
@@ -82,8 +88,10 @@ describe('#1677 cascade — silentPushHealthy gate', () => {
     jest.useRealTimers();
   });
 
-  it('시나리오 1: silentPushHealthy=false + mirror fresh → backend-ssot 거부, GPS fallback', async () => {
-    // GPS는 청담, mirror는 용마산을 권위 산출 — healthy=false 시 mirror 무시 → GPS(청담) 채택.
+  it('#2261 핵심: silentPushHealthy=false + mirror fresh(receivedAt) → backend-ssot 채택 (deadlock 해소)', async () => {
+    // GPS는 청담, mirror는 용마산을 권위 산출 — receivedAt이 fresh하면 push 건강도 무관하게 채택.
+    // 지하·정지(non-advancing) trip에서 push 60s 미수신이어도 FG pull이 mirror를 계속 갱신한다면
+    // 이 케이스가 실제 동작이다.
     setupGpsAt('청담');
     mockRead.mockResolvedValue(makeBackendSsotMirrorEntry({ currentStationId: yongmasan.name }));
 
@@ -95,11 +103,10 @@ describe('#1677 cascade — silentPushHealthy gate', () => {
       ),
     );
     await flushBackendSsotMirrorTick();
-    // backend-ssot가 아닌 GPS fallback.
     await waitFor(() => {
-      expect(hook.result.current.source).not.toBe('backend-ssot');
+      expect(hook.result.current.source).toBe('backend-ssot');
     });
-    expect(hook.result.current.result?.station.name).toBe(chungang.name);
+    expect(hook.result.current.result?.station.id).toBe(yongmasan.id);
   });
 
   it('시나리오 2: silentPushHealthy=true + mirror fresh → backend-ssot 채택', async () => {
@@ -134,12 +141,12 @@ describe('#1677 cascade — silentPushHealthy gate', () => {
     expect(hook.result.current.result?.station.id).toBe(yongmasan.id);
   });
 
-  it('시나리오 4: silentPushHealthy=false + mirror stale → GPS fallback (부작용 없음)', async () => {
+  it('시나리오 4: silentPushHealthy=false + mirror stale(receivedAt) → GPS fallback (staleness는 여전히 적용)', async () => {
     setupGpsAt('청담');
     mockRead.mockResolvedValue(
       makeBackendSsotMirrorEntry({
         currentStationId: yongmasan.name,
-        lastAdvanceAt: T0 - 240_000, // 4분 전 — stale
+        receivedAt: T0 - 240_000, // 4분 전 — stale
       }),
     );
 

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -499,16 +499,12 @@ export function useFusedNearestStation(
   /**
    * #1677 — silent push 건강 상태 (useSilentPushHealthCheck 출력).
    *
-   * false 시 `backendSsotAccepts` 강제 false — backend SSoT mirror tier를 cascade에서 제거.
-   * 기존 tier(wifi / positionTrain / fused / gps)가 자연 fallback.
-   *
-   * 미전달(undefined) = 기존 동작 유지(healthy로 간주).
-   * true 또는 undefined = `backendSsotAccepts` 판정에 영향 없음.
-   *
-   * 정책 정합:
-   * - 신규 폴링 추가 없음 — 기존 arrival/position 30s cycle 그대로.
-   * - FG 상태에서만 효과 — BG에서는 silentPushHealthy를 true로 유지(호출자 책임).
-   * - backendSsotAccepts=false이므로 backend mirror가 fresh여도 cascade 채택 안 함.
+   * #2261 (ADR-031 Phase 0) — `backendSsotAccepts`의 AND-gate에서 제거됨. receivedAt 기반
+   * freshness(FG position pull이 ~10s마다 backend 생존을 증명)가 이미 push 건강 여부와
+   * 무관하게 mirror 신뢰도를 보장하므로, silentPushHealthy=false + push 미도달(60s) +
+   * lastAdvanceAt stale(180s) 이중 조건이 지하·정지(non-advancing) trip에서 backend-ssot를
+   * 영구 미채택시키는 deadlock을 유발했다(RCA 2026-08-09, ADR-031). 파라미터 자체는 호출부
+   * 호환을 위해 유지 — 향후 BG 전용 게이트로 재도입 시 이 자리를 재사용한다.
    */
   silentPushHealthy?: boolean,
 ): UseFusedNearestStationReturn {
@@ -1152,15 +1148,20 @@ export function useFusedNearestStation(
     return findStationByName(backendSsotMirror.currentStationId);
   }, [backendSsotMirror, boardingLock]);
   const nowMsForSsot = Date.now();
+  // #2261 (ADR-031 Phase 0) — freshness를 `lastAdvanceAt`(backend가 실제 advance한 시각) 대신
+  // `receivedAt`(mirror가 device에 도달한 시각) 기준으로 재정의. lastAdvanceAt 기준은 지하·정지
+  // (non-advancing) trip에서 advance가 전혀 일어나지 않아 영구 stale에 빠지는 deadlock의 절반
+  // 원인이었다 — backend가 trip을 여전히 추적 중이라는 사실은 FG position pull(~10s cycle)이
+  // 응답을 받아 mirror를 갱신했다는 것 자체(receivedAt)로 이미 증명된다. 상한(180s)은 그대로
+  // 재사용 — 무한 stale 채택을 허용하지 않기 위해 동일 캡을 건다(RCA 2026-08-09, ADR-031).
   const ssotFresh =
     backendSsotMirror !== null &&
-    nowMsForSsot - backendSsotMirror.lastAdvanceAt <= BACKEND_SSOT_MIRROR_MAX_AGE_MS;
-  // #1677 — silent push 60s+ 미수신 시 backend SSoT mirror tier 강제 비활성.
-  // silentPushHealthy=false → backend가 silent push를 전달 못 하는 환경이므로
-  // mirror가 fresh여도 cascade에서 제거 → wifi/positionTrain/fused 등 device tier fallback.
-  // silentPushHealthy=undefined는 기존 동작 유지(healthy로 간주).
-  const backendSsotAccepts =
-    ssotStation !== null && ssotFresh && silentPushHealthy !== false;
+    nowMsForSsot - backendSsotMirror.receivedAt <= BACKEND_SSOT_MIRROR_MAX_AGE_MS;
+  // #2261 (ADR-031 Phase 0) — silentPushHealthy AND-gate 제거. 위 receivedAt 기반 freshness가
+  // 이미 backend 생존 + pull 채널 정상 도달을 증명하므로, silent push 건강도와 별개로 채택한다.
+  // 기존 게이트(#1677)는 "push 60s 미수신 + advance 180s 미갱신"의 이중 조건이 지하·정지 trip을
+  // 영구 미채택시키는 deadlock을 유발했다 — 단일 조건(pull receivedAt 180s)으로 통합해 해소.
+  const backendSsotAccepts = ssotStation !== null && ssotFresh;
 
   // #1932 (Epic #1927 G2) — environment SSOT 단일화 + cascade 직전 산출.
   //


### PR DESCRIPTION
Part of #2260
Closes #2261

## 요약
ADR-031 Phase 0 (DO 없음, 저위험) — silent SSoT-forward deadlock 즉시 완화.

**RCA**: 지하·정지 trip → fire 게이트 차단 → push 0(60s 뒤 `silentPushHealthy=false`) + advance 0(180s 뒤 `lastAdvanceAt` stale) → backend-ssot 영구 미채택. 기존 `POST /position` 응답은 SSoT 일부만 embed(`originStationId`/`lockSuggestion`)했고, `lockSuggestion` 부재 시 device mirror의 `lastAdvanceAt`이 항상 0으로 고정돼 never fresh였다.

## 변경
1. **backend** `index.ts:1536` 인근 — `POST /position` 응답에 `ssot: toSilentPushSsot(ssot)` full SSoT를 additive로 추가(`motionState`/`lastAdvanceAt`/`passedStations`/`alarmEvents`/`currentStationLine`). 기존 `originStationId`/`lockSuggestion` 필드는 그대로 유지.
2. **device** `positionUpload.ts` `persistFromPositionResponse` — `body.ssot` 존재 시 그대로 mirror write(legacy 부분 합성 fallback은 `ssot` 부재 시에만 동작).
3. **device** `useFusedNearestStation.ts` `backendSsotAccepts` — freshness를 `lastAdvanceAt` 대신 **`receivedAt`**(mirror가 device에 도달한 시각) 기준으로 재정의. 동일 상한(`BACKEND_SSOT_MIRROR_MAX_AGE_MS`=180s)을 재사용해 무한 stale 채택은 여전히 차단. **`silentPushHealthy !== false` AND-gate 제거** — receivedAt 기반 freshness가 이미 backend 생존을 증명하므로 push 건강도와 무관하게 채택(호출부는 HomeScreen뿐이라 BG 영향 없음, 파라미터는 향후 재사용을 위해 시그니처 유지).

## 금지 준수
- Durable Object 도입 없음(Phase 1+ 대상 아님).
- fire/단일 emitter 로직 미변경.
- #2230/#2243 게이트 미변경.

## 테스트 (red-first)
- 게이트 제거 전 상태로 되돌려 신규 테스트 3건이 실제로 실패(red)하는지 확인 후 복구(green) — deadlock 시나리오(lockless·정지·`silentPushHealthy=false` + mirror `receivedAt` fresh → backend-ssot 채택)가 실제 회귀 가드로 동작함을 검증.
- surface trip 기존 채택 경로 회귀 0 (전체 스위트 그린).
- receivedAt 상한(180s) 초과 stale mirror는 여전히 미채택(E1~E3 케이스 유지 + 신규 상한 케이스).
- backend `index.test.ts`에 `POST /position` 응답 `ssot` 필드 additive 검증 3건 추가.

검증 결과:
- `npm test` — 434 suites / 9299 tests pass, 100% coverage.
- `npm run type-check` — 통과.
- `cd backend/alarm-worker && npx vitest run` — 78 files / 2922 tests pass.
- `npm run lint:orphan` — orphan 0.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass.
2. **V/X dashboard** — "silentPushHealthy=false reject" telemetry가 device 측 cascade picker 로그(DebugModal `source`/`confidence`='backend-ssot')에서 소멸 확인 가능. backend 측은 wrangler tail로 `/position` 응답에 `ssot` 필드 존재 확인 가능.
3. **의존 PR** — 없음(N/A, DO 무관).
4. **측정 plan** — 다음 실기기 지하 trip dump에서 backend-ssot 채택 + fused signal 존재 확인(지하·정지 구간에서 `source`='backend-ssot' 유지 여부).
5. **Device verify** — 필요. 실기기 지하 trip에서 fused=backend-ssot 채택 확인 시나리오(지하 진입 후 정차 상태 유지하며 push 미도달 구간에서도 fusion이 backend mirror를 계속 신뢰하는지).