### PR TITLE
feat(#2264): TripDO per-trip scaffold (ADR-031 Phase 1, shadow dual-write)

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -4,6 +4,7 @@ import {
   app,
   applyBoardingLockTrainCodeSwap,
   computeLockSyncAdvance,
+  dualWriteTripDo,
   LOCK_TTL_REFRESH_MS,
   validateBoardingLockSync,
   validateLiveActivityRegister,
@@ -12,6 +13,8 @@ import {
   verifyBoardingLockPersisted,
 } from '../index';
 import { ARCH_FLAG_KV_KEY } from '../archFlag';
+import { TripDO } from '../tripDO';
+import { TRIP_DO_FLAG_KV_KEY } from '../tripDoFlag';
 import { progressKey, type TripProgress } from '../progress';
 import { pendingKey, putPending, stampReceived } from '../pendingPushes';
 import { KV_MIN_CACHE_TTL_SEC } from '../kvConsistency';
@@ -5511,5 +5514,151 @@ describe('GET/POST /admin/kill-switch (#1967 Ff-1)', () => {
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ key: 'lockless_intermediate', value: 'false' });
     });
+  });
+});
+
+/**
+ * #2264 (Epic #2260, ADR-031 Phase 1) — TripDO shadow dual-write acceptance.
+ *
+ * - flag off(default) 또는 env.TRIP_DO 미바인딩 → 완전 no-op (기존 KV write 경로 무영향)
+ * - flag on → DO seed(shadow write) + 기존 row와의 divergence 로그
+ * - DO stub이 throw해도 trip 등록 응답은 차단되지 않는다(graceful)
+ */
+describe('dualWriteTripDo (#2264, ADR-031 Phase 1)', () => {
+  /** 실 `TripDO` 클래스를 Map 기반 fake storage 위에서 재사용 — production 로직과 동형. */
+  function makeFakeTripDoNamespace(): {
+    ns: DurableObjectNamespace;
+    instances: Map<string, TripDO>;
+  } {
+    const instances = new Map<string, TripDO>();
+    const ns = {
+      idFromName: (name: string) => ({ toString: () => name }) as unknown as DurableObjectId,
+      get: (id: DurableObjectId) => {
+        const name = id.toString();
+        let inst = instances.get(name);
+        if (!inst) {
+          const storage = new Map<string, unknown>();
+          const state = {
+            storage: {
+              get: async <T>(key: string) => storage.get(key) as T | undefined,
+              put: async (key: string, value: unknown) => {
+                storage.set(key, value);
+              },
+            },
+          } as unknown as DurableObjectState;
+          inst = new TripDO(state);
+          instances.set(name, inst);
+        }
+        return inst as unknown as DurableObjectStub;
+      },
+    } as unknown as DurableObjectNamespace;
+    return { ns, instances };
+  }
+
+  it('flag off(default): env.TRIP_DO가 있어도 no-op (fetch 호출 없음)', async () => {
+    const env = makeKvEnv();
+    const { ns } = makeFakeTripDoNamespace();
+    const fetchSpy = vi.spyOn(ns, 'get');
+    const trip = validateTrip({ ...base(), token: 'tok-do-1' })!;
+    await dualWriteTripDo({ ...env, TRIP_DO: ns }, trip);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('env.TRIP_DO 미바인딩: flag on이어도 no-op', async () => {
+    const env = makeKvEnv();
+    await env.TRIPS.put(TRIP_DO_FLAG_KV_KEY, 'on');
+    const trip = validateTrip({ ...base(), token: 'tok-do-2' })!;
+    // TRIP_DO undefined — 예외 없이 그냥 반환되는지만 확인.
+    await expect(dualWriteTripDo(env, trip)).resolves.toBeUndefined();
+  });
+
+  it('flag on: DO에 trip이 seed되고 GET /trip으로 조회 가능', async () => {
+    const env = makeKvEnv();
+    await env.TRIPS.put(TRIP_DO_FLAG_KV_KEY, 'on');
+    const { ns, instances } = makeFakeTripDoNamespace();
+    const trip = validateTrip({ ...base(), token: 'tok-do-3' })!;
+    await dualWriteTripDo({ ...env, TRIP_DO: ns }, trip);
+
+    const stub = instances.get('tok-do-3')!;
+    const res = await stub.fetch(new Request('https://trip-do/trip'));
+    const body = (await res.json()) as { trip: unknown };
+    expect(body.trip).toEqual(trip);
+  });
+
+  it('flag on: 기존 DO row와 신규 trip이 다르면 divergence 로그를 남긴다', async () => {
+    const env = makeKvEnv();
+    await env.TRIPS.put(TRIP_DO_FLAG_KV_KEY, 'on');
+    const { ns } = makeFakeTripDoNamespace();
+    const tripV1 = validateTrip({ ...base(), token: 'tok-do-4', destination: 'dst-v1' })!;
+    await dualWriteTripDo({ ...env, TRIP_DO: ns }, tripV1);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const tripV2 = validateTrip({ ...base(), token: 'tok-do-4', destination: 'dst-v2' })!;
+    await dualWriteTripDo({ ...env, TRIP_DO: ns }, tripV2);
+    const divergenceLog = logSpy.mock.calls
+      .map((c) => String(c[0]))
+      .find((s) => s.includes('trip-do: shadow-compare divergence'));
+    expect(divergenceLog).toBeDefined();
+    logSpy.mockRestore();
+  });
+
+  it('flag on: 첫 seed(기존 row 없음)는 divergence 로그를 남기지 않는다', async () => {
+    const env = makeKvEnv();
+    await env.TRIPS.put(TRIP_DO_FLAG_KV_KEY, 'on');
+    const { ns } = makeFakeTripDoNamespace();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const trip = validateTrip({ ...base(), token: 'tok-do-5' })!;
+    await dualWriteTripDo({ ...env, TRIP_DO: ns }, trip);
+    const divergenceLog = logSpy.mock.calls
+      .map((c) => String(c[0]))
+      .find((s) => s.includes('trip-do: shadow-compare divergence'));
+    expect(divergenceLog).toBeUndefined();
+    logSpy.mockRestore();
+  });
+
+  it('DO stub이 throw해도 dualWriteTripDo는 삼키고 로그만 남긴다 (graceful)', async () => {
+    const env = makeKvEnv();
+    await env.TRIPS.put(TRIP_DO_FLAG_KV_KEY, 'on');
+    const throwingNs = {
+      idFromName: (name: string) => ({ toString: () => name }) as unknown as DurableObjectId,
+      get: () =>
+        ({
+          fetch: async () => {
+            throw new Error('do down');
+          },
+        }) as unknown as DurableObjectStub,
+    } as unknown as DurableObjectNamespace;
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const trip = validateTrip({ ...base(), token: 'tok-do-6' })!;
+    await expect(dualWriteTripDo({ ...env, TRIP_DO: throwingNs }, trip)).resolves.toBeUndefined();
+    const failureLog = logSpy.mock.calls
+      .map((c) => String(c[0]))
+      .find((s) => s.includes('trip-do: dual-write failed'));
+    expect(failureLog).toBeDefined();
+    logSpy.mockRestore();
+  });
+
+  it('POST /trips 통합: flag off(default)면 TRIP_DO가 바인딩돼 있어도 DO에 아무것도 쓰지 않는다', async () => {
+    const env = makeKvEnv();
+    const { ns, instances } = makeFakeTripDoNamespace();
+    const res = await post('/trips', { ...base(), token: 'tok-do-7' }, { ...env, TRIP_DO: ns });
+    expect(res.status).toBe(200);
+    expect(instances.size).toBe(0);
+  });
+
+  it('POST /trips 통합: flag on이면 응답 성공 + DO에 trip이 shadow-seed된다', async () => {
+    const env = makeKvEnv();
+    await env.TRIPS.put(TRIP_DO_FLAG_KV_KEY, 'on');
+    const { ns, instances } = makeFakeTripDoNamespace();
+    const res = await post('/trips', { ...base(), token: 'tok-do-8' }, { ...env, TRIP_DO: ns });
+    expect(res.status).toBe(200);
+    const stub = instances.get('tok-do-8');
+    expect(stub).toBeDefined();
+    const doRes = await stub!.fetch(new Request('https://trip-do/trip'));
+    const doBody = (await doRes.json()) as { trip: { token: string } | null };
+    expect(doBody.trip?.token).toBe('tok-do-8');
+    // KV 경로(SSoT/기존 로직)는 dual-write와 무관하게 그대로 성공했는지 확인.
+    const kvTrip = JSON.parse((await env.TRIPS.get('trip:tok-do-8')) as string);
+    expect(kvTrip.token).toBe('tok-do-8');
   });
 });

--- a/backend/alarm-worker/src/__tests__/tripDO.test.ts
+++ b/backend/alarm-worker/src/__tests__/tripDO.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import {
+  TripDO,
+  getSsotRow,
+  getTripRow,
+  seedSsotRow,
+  seedTripRow,
+  type TripDoStorage,
+} from '../tripDO';
+import type { Trip } from '../types';
+import type { TripPositionSSoT } from '../tripPositionSsot';
+
+/**
+ * TripDO scaffold acceptance (#2264, Epic #2260, ADR-031 Phase 1).
+ *
+ * - trip/ssot row CRUD round-trip (pure function level, Map 기반 fake storage)
+ * - persist-first: put이 완료된 후에만 이후 get이 값을 반환 (fake storage 자체가 순차 보장)
+ * - `TripDO.fetch()` 라우팅: GET/POST /trip, GET/POST /ssot, 404 fallback
+ * - fire 로직 없음 — 본 스코프는 state 보관/조회만 (assert로 명시)
+ */
+
+const FUTURE = Date.now() + 60 * 60 * 1000;
+
+function makeTrip(overrides?: Partial<Trip>): Trip {
+  return {
+    token: 'tok-abc',
+    route: { type: 'direct', line: '2', stops: 3 },
+    destination: 'dst',
+    waypoints: [{ stationName: '강남', line: '2', kind: 'destination' }],
+    expiresAt: FUTURE,
+    createdAt: Date.now(),
+    alarmAtEpochMs: FUTURE - 30 * 60 * 1000,
+    ...overrides,
+  } as Trip;
+}
+
+function makeSsot(overrides?: Partial<TripPositionSSoT>): TripPositionSSoT {
+  return {
+    tripToken: 'tok-abc',
+    currentStationId: '0228',
+    motionState: 'unknown',
+    motionEvidence: [],
+    lastAdvanceAt: 0,
+    lastAdvanceEvidence: 'seed-override',
+    passedStations: [],
+    userIntentDeclared: false,
+    seedOverrideCount: 0,
+    alarmEvents: [],
+    schemaVersion: 1,
+    ...overrides,
+  };
+}
+
+/** Map 기반 fake — `DurableObjectState.storage`의 최소 부분집합 (KV 스타일 API). */
+function makeFakeStorage(): TripDoStorage {
+  const map = new Map<string, unknown>();
+  return {
+    get: async <T>(key: string) => map.get(key) as T | undefined,
+    put: async (key: string, value: unknown) => {
+      map.set(key, value);
+    },
+  };
+}
+
+describe('tripDO row helpers — pure function CRUD', () => {
+  it('getTripRow: 신규 storage는 undefined', async () => {
+    const storage = makeFakeStorage();
+    expect(await getTripRow(storage)).toBeUndefined();
+  });
+
+  it('seedTripRow → getTripRow round-trip', async () => {
+    const storage = makeFakeStorage();
+    const trip = makeTrip();
+    await seedTripRow(storage, trip);
+    expect(await getTripRow(storage)).toEqual(trip);
+  });
+
+  it('seedTripRow는 두 번째 seed로 덮어쓴다 (idempotent overwrite)', async () => {
+    const storage = makeFakeStorage();
+    await seedTripRow(storage, makeTrip({ destination: 'a' }));
+    await seedTripRow(storage, makeTrip({ destination: 'b' }));
+    expect((await getTripRow(storage))?.destination).toBe('b');
+  });
+
+  it('getSsotRow: 신규 storage는 undefined', async () => {
+    const storage = makeFakeStorage();
+    expect(await getSsotRow(storage)).toBeUndefined();
+  });
+
+  it('seedSsotRow → getSsotRow round-trip', async () => {
+    const storage = makeFakeStorage();
+    const ssot = makeSsot();
+    await seedSsotRow(storage, ssot);
+    expect(await getSsotRow(storage)).toEqual(ssot);
+  });
+
+  it('trip row와 ssot row는 독립 — 하나만 seed해도 다른 쪽은 영향 없음', async () => {
+    const storage = makeFakeStorage();
+    await seedTripRow(storage, makeTrip());
+    expect(await getSsotRow(storage)).toBeUndefined();
+  });
+});
+
+describe('TripDO — fetch() 라우팅', () => {
+  function makeDO(): TripDO {
+    const state = { storage: makeFakeStorage() } as unknown as DurableObjectState;
+    return new TripDO(state);
+  }
+
+  it('GET /trip: 신규 인스턴스는 { trip: null }', async () => {
+    const doInstance = makeDO();
+    const res = await doInstance.fetch(new Request('https://trip-do/trip'));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ trip: null });
+  });
+
+  it('POST /trip → GET /trip: seed 후 조회 round-trip', async () => {
+    const doInstance = makeDO();
+    const trip = makeTrip();
+    const postRes = await doInstance.fetch(
+      new Request('https://trip-do/trip', { method: 'POST', body: JSON.stringify(trip) }),
+    );
+    expect(postRes.status).toBe(204);
+
+    const getRes = await doInstance.fetch(new Request('https://trip-do/trip'));
+    expect(await getRes.json()).toEqual({ trip });
+  });
+
+  it('GET /ssot: 신규 인스턴스는 { ssot: null }', async () => {
+    const doInstance = makeDO();
+    const res = await doInstance.fetch(new Request('https://trip-do/ssot'));
+    expect(await res.json()).toEqual({ ssot: null });
+  });
+
+  it('POST /ssot → GET /ssot: seed 후 조회 round-trip', async () => {
+    const doInstance = makeDO();
+    const ssot = makeSsot();
+    const postRes = await doInstance.fetch(
+      new Request('https://trip-do/ssot', { method: 'POST', body: JSON.stringify(ssot) }),
+    );
+    expect(postRes.status).toBe(204);
+
+    const getRes = await doInstance.fetch(new Request('https://trip-do/ssot'));
+    expect(await getRes.json()).toEqual({ ssot });
+  });
+
+  it('알 수 없는 route는 404 — fire/판정 로직 없음(Phase 2 스코프 외)', async () => {
+    const doInstance = makeDO();
+    const res = await doInstance.fetch(new Request('https://trip-do/alarm', { method: 'POST' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('trip row와 ssot row가 같은 DO 인스턴스에 독립 공존', async () => {
+    const doInstance = makeDO();
+    const trip = makeTrip();
+    const ssot = makeSsot();
+    await doInstance.fetch(
+      new Request('https://trip-do/trip', { method: 'POST', body: JSON.stringify(trip) }),
+    );
+    await doInstance.fetch(
+      new Request('https://trip-do/ssot', { method: 'POST', body: JSON.stringify(ssot) }),
+    );
+    const tripRes = await doInstance.fetch(new Request('https://trip-do/trip'));
+    const ssotRes = await doInstance.fetch(new Request('https://trip-do/ssot'));
+    expect(await tripRes.json()).toEqual({ trip });
+    expect(await ssotRes.json()).toEqual({ ssot });
+  });
+});

--- a/backend/alarm-worker/src/__tests__/tripDoFlag.test.ts
+++ b/backend/alarm-worker/src/__tests__/tripDoFlag.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+  TRIP_DO_FLAG_DEFAULT,
+  TRIP_DO_FLAG_KV_KEY,
+  getTripDoFlag,
+  isTripDoFlagValue,
+  setTripDoFlag,
+} from '../tripDoFlag';
+import { InMemoryKV } from './inMemoryKv';
+
+describe('tripDoFlag (Phase 1, ADR-031 / #2264)', () => {
+  describe('isTripDoFlagValue', () => {
+    it('accepts on / off', () => {
+      expect(isTripDoFlagValue('on')).toBe(true);
+      expect(isTripDoFlagValue('off')).toBe(true);
+    });
+
+    it('rejects other strings', () => {
+      expect(isTripDoFlagValue('true')).toBe(false);
+      expect(isTripDoFlagValue('ON')).toBe(false);
+      expect(isTripDoFlagValue('')).toBe(false);
+    });
+
+    it('rejects non-string values', () => {
+      expect(isTripDoFlagValue(null)).toBe(false);
+      expect(isTripDoFlagValue(undefined)).toBe(false);
+      expect(isTripDoFlagValue(1)).toBe(false);
+      expect(isTripDoFlagValue({})).toBe(false);
+    });
+  });
+
+  describe('getTripDoFlag', () => {
+    it('returns default when kv is undefined (개발 환경 호환)', async () => {
+      expect(await getTripDoFlag(undefined)).toBe(TRIP_DO_FLAG_DEFAULT);
+    });
+
+    it('returns default when key is not set (dormant)', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      expect(await getTripDoFlag(kv)).toBe('off');
+    });
+
+    it('returns "on" when kv is set to on', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      await kv.put(TRIP_DO_FLAG_KV_KEY, 'on');
+      expect(await getTripDoFlag(kv)).toBe('on');
+    });
+
+    it('returns "off" when kv is set to off', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      await kv.put(TRIP_DO_FLAG_KV_KEY, 'off');
+      expect(await getTripDoFlag(kv)).toBe('off');
+    });
+
+    it('normalizes typo/invalid stored value to default', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      await kv.put(TRIP_DO_FLAG_KV_KEY, 'ON');
+      expect(await getTripDoFlag(kv)).toBe('off');
+    });
+  });
+
+  describe('setTripDoFlag', () => {
+    it('writes valid value', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      await setTripDoFlag(kv, 'on');
+      expect(await getTripDoFlag(kv)).toBe('on');
+    });
+
+    it('throws on invalid value without writing', async () => {
+      const kv = new InMemoryKV() as unknown as KVNamespace;
+      await expect(
+        setTripDoFlag(kv, 'invalid' as unknown as 'on' | 'off'),
+      ).rejects.toThrow('tripDoFlag: invalid value invalid');
+      expect(await getTripDoFlag(kv)).toBe(TRIP_DO_FLAG_DEFAULT);
+    });
+  });
+});

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -59,6 +59,7 @@ import {
   KILL_SWITCH_DEFAULT,
   setKillSwitch,
 } from './killSwitch';
+import { getTripDoFlag, TRIP_DO_FLAG_DEFAULT } from './tripDoFlag';
 import { appendPositionPoint } from './positionSeries';
 import { appendAccelSample, isAccelSummary } from './accelSeries';
 import { updateSsotMotion } from './motionState';
@@ -547,6 +548,56 @@ function parseQueryNumber(raw: string | undefined): number | undefined {
   return Number.isFinite(n) ? n : undefined;
 }
 
+/**
+ * `POST /trips` dual-write — TripDO shadow seed (#2264, Epic #2260, ADR-031 Phase 1).
+ *
+ * flag off(default) 또는 `env.TRIP_DO` 미바인딩(개발/테스트 환경)이면 완전 no-op —
+ * 기존 KV write 경로는 이 함수 호출 전에 이미 끝나 있으므로 영향 없음.
+ *
+ * flag on이면:
+ *  1. 기존 DO row를 읽어 신규 `trip`과 다르면(divergence) 로그로 관측 — Phase 1은 cron이
+ *     여전히 authoritative이므로 여기서는 관측만 하고 fire/판정에 관여하지 않는다.
+ *  2. 신규 `trip`을 DO에 seed(shadow write). cron/KV 경로는 이 결과와 무관하게 그대로 진행.
+ *
+ * DO 호출 실패(네트워크/eviction 등)는 삼켜서 로그만 남긴다 — trip 등록 응답을 절대 차단하지
+ * 않는다(archFlag/killSwitch와 동일 graceful 원칙).
+ */
+export async function dualWriteTripDo(env: Env, trip: Trip): Promise<void> {
+  const flag = await getTripDoFlag(env.TRIPS).catch(() => TRIP_DO_FLAG_DEFAULT);
+  if (flag !== 'on' || !env.TRIP_DO) return;
+
+  try {
+    const id = env.TRIP_DO.idFromName(trip.token);
+    const stub = env.TRIP_DO.get(id);
+
+    const priorRes = await stub.fetch(new Request('https://trip-do/trip'));
+    const prior = (await priorRes.json()) as { trip: Trip | null };
+    if (prior.trip !== null && JSON.stringify(prior.trip) !== JSON.stringify(trip)) {
+      console.log(
+        JSON.stringify({
+          msg: 'trip-do: shadow-compare divergence (#2264)',
+          tokenPrefix: tokenPrefix(trip.token),
+        }),
+      );
+    }
+
+    await stub.fetch(
+      new Request('https://trip-do/trip', {
+        method: 'POST',
+        body: JSON.stringify(trip),
+      }),
+    );
+  } catch (e) {
+    console.log(
+      JSON.stringify({
+        msg: 'trip-do: dual-write failed (graceful, #2264)',
+        tokenPrefix: tokenPrefix(trip.token),
+        error: String(e),
+      }),
+    );
+  }
+}
+
 app.post('/trips', async (c) => {
   let body: unknown;
   try {
@@ -953,6 +1004,10 @@ app.post('/trips', async (c) => {
     reason: trip.boardingLock ? 'lock-active' : 'lockless',
     hopIndex: trip.waypoints[0]?.hopIndex,
   });
+
+  // #2264 (Epic #2260, ADR-031 Phase 1) — TripDO shadow dual-write. flag off(default)면
+  // no-op. KV write(putTrip)는 이미 위에서 완료됐으므로 실패해도 trip 등록에 영향 없다.
+  await dualWriteTripDo(c.env, trip);
 
   // #1897 (RC-5) — KV에 박힌 권위 apnsEnv 를 device로 echo. device 는 이를 stamp 해 다음
   // register 시 build env 대신 송신 → backend self-heal(envCorrected) 발동을 0에 수렴.
@@ -2705,3 +2760,10 @@ export const handler = {
  * SENTRY_DSN secret 등록 즉시 자동 활성 (redeploy 필요 없음 — wrangler secret은 실시간 반영).
  */
 export default Sentry.withSentry(sentryOptions, handler);
+
+/**
+ * #2264 (Epic #2260, ADR-031 Phase 1) — `TripDO` class export. wrangler는 `main`
+ * module(본 파일)에서 `wrangler.toml`의 `durable_objects.bindings.class_name = "TripDO"`와
+ * 이름이 일치하는 top-level export를 찾는다. 재-export만 — 구현은 `tripDO.ts` 참조.
+ */
+export { TripDO } from './tripDO';

--- a/backend/alarm-worker/src/tripDO.ts
+++ b/backend/alarm-worker/src/tripDO.ts
@@ -1,0 +1,131 @@
+/**
+ * TripDO — per-trip Durable Object scaffold (ADR-031 Phase 1, 이슈 #2264, Epic #2260).
+ *
+ * 배경
+ * ====
+ * ADR-031(https://.../ADR-031-scalable-fire-ssot-architecture.md)은 글로벌 cron
+ * O(N) 스캔(`scheduled.ts:1207` `for trip of listTrips()`)을 per-trip DO + self-alarm
+ * 이벤트 구동으로 재설계한다. Phase 1(본 파일)은 **scaffold만** — DO는 KV와 shadow
+ * 병존하며 cron이 여전히 authoritative, fire 동작 delta 0.
+ *
+ * 스코프 (본 PR, Phase 1)
+ * =======================
+ * - `TripDO` 클래스: trip row + SSoT row를 DO storage(SQLite-backed, `new_sqlite_classes`
+ *   migration)에 보관. **fire 로직 없음**(Phase 2 스코프) — state 보관/조회만.
+ * - `POST /trips`(`index.ts`)가 flag on일 때만 dual-write(seed) — `tripDoFlag.ts` 게이트.
+ * - shadow-compare divergence telemetry — DO 기존 state vs 신규 trip 불일치 로그.
+ *
+ * 설계 노트 — 왜 raw SQL(`ctx.storage.sql`)이 아닌 storage KV API(`ctx.storage.get/put`)인가
+ * ==============================================================================
+ * `new_sqlite_classes` migration은 DO의 **storage backend**를 SQLite로 지정한다. 이 backend
+ * 위에서 `ctx.storage.get/put`(KV 스타일 API)과 `ctx.storage.sql.exec`(raw SQL) 둘 다 완전히
+ * 유효하며 동일 backend를 공유한다(durable-objects 스킬 참조). 본 PR은 row 2개(trip/ssot)를
+ * 통째로 저장하는 단순 유스케이스라 KV 스타일 API로 충분 — raw SQL 스키마는 Phase 1 스코프
+ * 밖(정교한 쿼리/인덱스가 필요해지는 시점, 예: Phase 3 이후)으로 미룬다.
+ *
+ * `TripDoStorage` 포트로 `ctx.storage`를 추상화해 `TripDO` 클래스는 얇은 어댑터로 유지하고,
+ * row read/write 로직은 순수 함수로 분리했다 — 기존 `tripPositionSsot.ts`(KV read/write
+ * helper 분리 패턴)와 동형이며, `cloudflare:workers`/`cloudflare:test` 런타임 의존 없이
+ * plain vitest로 단위 테스트 가능하다(repo 기존 `InMemoryKV` 테스트 컨벤션과 동형).
+ *
+ * `DurableObject`(from `cloudflare:workers`)를 extend하지 않고 전통적 `fetch()` 핸들러
+ * 패턴(pre-RPC-helper style, 여전히 완전 유효)을 쓴 이유도 동일 — `cloudflare:workers`는
+ * Workers 런타임(miniflare/vitest-pool-workers)에서만 resolve되는 가상 모듈이며, 본 repo는
+ * 그 pool을 아직 구성하지 않았다(plain vitest node 환경). `DurableObject`/`DurableObjectState`
+ * 등 타입은 `@cloudflare/workers-types`의 ambient global이라 import 없이 사용 가능.
+ */
+
+import type { Trip } from './types';
+import type { TripPositionSSoT } from './tripPositionSsot';
+
+/** DO storage row key — trip 본체. */
+const TRIP_ROW_KEY = 'trip';
+/** DO storage row key — trip row 마지막 write epoch ms. */
+const TRIP_ROW_UPDATED_AT_KEY = 'tripUpdatedAt';
+/** DO storage row key — SSoT 본체. */
+const SSOT_ROW_KEY = 'ssot';
+/** DO storage row key — SSoT row 마지막 write epoch ms. */
+const SSOT_ROW_UPDATED_AT_KEY = 'ssotUpdatedAt';
+
+/**
+ * `DurableObjectState.storage`의 최소 부분집합 포트. 실제 프로덕션에서는
+ * `ctx.storage`(SQLite-backed)가 이 인터페이스를 만족한다. 테스트는 Map 기반 fake로 대체.
+ */
+export interface TripDoStorage {
+  get<T = unknown>(key: string): Promise<T | undefined>;
+  put(key: string, value: unknown): Promise<void>;
+}
+
+/** trip row read. 미존재 시 undefined (신규 DO 인스턴스). */
+export async function getTripRow(storage: TripDoStorage): Promise<Trip | undefined> {
+  return storage.get<Trip>(TRIP_ROW_KEY);
+}
+
+/** trip row write — persist-first(단일 컬럼 값이므로 put 자체가 atomic write). */
+export async function seedTripRow(storage: TripDoStorage, trip: Trip): Promise<void> {
+  await storage.put(TRIP_ROW_KEY, trip);
+  await storage.put(TRIP_ROW_UPDATED_AT_KEY, Date.now());
+}
+
+/** SSoT row read. 미존재 시 undefined. */
+export async function getSsotRow(
+  storage: TripDoStorage,
+): Promise<TripPositionSSoT | undefined> {
+  return storage.get<TripPositionSSoT>(SSOT_ROW_KEY);
+}
+
+/** SSoT row write — persist-first. */
+export async function seedSsotRow(
+  storage: TripDoStorage,
+  ssot: TripPositionSSoT,
+): Promise<void> {
+  await storage.put(SSOT_ROW_KEY, ssot);
+  await storage.put(SSOT_ROW_UPDATED_AT_KEY, Date.now());
+}
+
+/**
+ * TripDO — 1 trip = 1 DO 인스턴스(`env.TRIP_DO.idFromName(tripToken)`로 결정적 라우팅).
+ *
+ * `fetch()` 라우트:
+ *  - `GET  /trip` → `{ trip: Trip | null }`
+ *  - `POST /trip` → body `Trip` 그대로 seed, `204`
+ *  - `GET  /ssot` → `{ ssot: TripPositionSSoT | null }`
+ *  - `POST /ssot` → body `TripPositionSSoT` 그대로 seed, `204`
+ *
+ * **fire 없음** — Phase 2(#2260 후속 이슈) 스코프. 본 클래스는 state 보관/조회만 수행한다.
+ */
+export class TripDO implements DurableObject {
+  private readonly storage: TripDoStorage;
+
+  constructor(state: DurableObjectState) {
+    this.storage = state.storage;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method === 'GET' && url.pathname === '/trip') {
+      const trip = await getTripRow(this.storage);
+      return Response.json({ trip: trip ?? null });
+    }
+
+    if (request.method === 'POST' && url.pathname === '/trip') {
+      const trip = (await request.json()) as Trip;
+      await seedTripRow(this.storage, trip);
+      return new Response(null, { status: 204 });
+    }
+
+    if (request.method === 'GET' && url.pathname === '/ssot') {
+      const ssot = await getSsotRow(this.storage);
+      return Response.json({ ssot: ssot ?? null });
+    }
+
+    if (request.method === 'POST' && url.pathname === '/ssot') {
+      const ssot = (await request.json()) as TripPositionSSoT;
+      await seedSsotRow(this.storage, ssot);
+      return new Response(null, { status: 204 });
+    }
+
+    return new Response('not found', { status: 404 });
+  }
+}

--- a/backend/alarm-worker/src/tripDoFlag.ts
+++ b/backend/alarm-worker/src/tripDoFlag.ts
@@ -1,0 +1,59 @@
+/**
+ * TripDO shadow write Feature Flag (Phase 1, ADR-031 / 이슈 #2264, Epic #2260).
+ *
+ * ADR-031은 글로벌 cron O(N) 스캔을 per-trip Durable Object + self-alarm 이벤트 구동으로
+ * 재설계한다. Phase 1은 `TripDO` scaffold만 배포하고 cron은 여전히 authoritative — DO는
+ * shadow(no-op 기본)로 병존한다.
+ *
+ * 본 모듈은 `archFlag.ts`(#1982 ADR-022 Phase 0)와 동일한 KV read/write 어댑터 패턴을
+ * 재사용한다. flag가 'off'(default)인 동안 `POST /trips`의 DO dual-write 경로는 완전히
+ * no-op — 기존 cron/KV 동작 100% 유지(Phase 1-3 dormant).
+ *
+ * Rollback 정책: `on` → `off` KV write 만으로 즉시 되돌린다(배포 없음).
+ */
+
+/** 신규 TripDO shadow write 활성 KV 키. 값은 `on` 또는 `off` 만 유효. */
+export const TRIP_DO_FLAG_KV_KEY = 'arch:trip-do-shadow-v1';
+
+/** 두 가지 값만 허용 — enum literal union. 다른 값은 default(`off`) 로 정규화된다. */
+export type TripDoFlagValue = 'on' | 'off';
+
+/** Default 값 — 미설정 KV / 오타 / 파싱 실패 모두 이 값으로 fallback. */
+export const TRIP_DO_FLAG_DEFAULT: TripDoFlagValue = 'off';
+
+/** 유효 값 판정 — set / get 양쪽 공용. */
+export function isTripDoFlagValue(raw: unknown): raw is TripDoFlagValue {
+  return raw === 'on' || raw === 'off';
+}
+
+/**
+ * KV로부터 현재 flag 값을 조회. 값 부재 / 오타 / KV 미바인딩 견해에서 이견을 없애기 위해
+ * 다음 순서로 정규화한다:
+ *  1. `kv` 인자가 없으면 default 반환 (개발 환경 호환).
+ *  2. KV `get` 결과가 null이면 default (미설정 시 dormant).
+ *  3. 유효 문자열('on' / 'off')이면 그 값을 반환.
+ *  4. 그 외 오타/타입 이상 값은 default로 fallback (KV를 조작한 운영자 실수 방어).
+ */
+export async function getTripDoFlag(
+  kv: KVNamespace | undefined,
+): Promise<TripDoFlagValue> {
+  if (!kv) return TRIP_DO_FLAG_DEFAULT;
+  const raw = await kv.get(TRIP_DO_FLAG_KV_KEY);
+  if (raw === null) return TRIP_DO_FLAG_DEFAULT;
+  return isTripDoFlagValue(raw) ? raw : TRIP_DO_FLAG_DEFAULT;
+}
+
+/**
+ * 관리자용 flag 설정. 유효하지 않은 값은 write 없이 throw — 잘못된 KV 상태 진입 차단.
+ *
+ * TTL 없음: rollback 시 즉시 반영되어야 하므로 영구 저장.
+ */
+export async function setTripDoFlag(
+  kv: KVNamespace,
+  value: TripDoFlagValue,
+): Promise<void> {
+  if (!isTripDoFlagValue(value)) {
+    throw new Error(`tripDoFlag: invalid value ${String(value)}`);
+  }
+  await kv.put(TRIP_DO_FLAG_KV_KEY, value);
+}

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -861,4 +861,12 @@ export interface Env {
    *   + 90일 lifecycle 룰은 Cloudflare Dashboard에서 운영자가 수동 설정.
    */
   TELEMETRY_R2?: R2Bucket;
+  /**
+   * Per-trip Durable Object namespace — `TripDO` (#2264, Epic #2260, ADR-031 Phase 1).
+   * `POST /trips`가 `tripDoFlag.ts` 게이트(flag on)일 때만 dual-write(shadow seed)한다.
+   * Phase 1은 cron이 여전히 authoritative — 본 binding은 fire에 관여하지 않는다.
+   * 미바인딩 시(로컬/개발 환경) dual-write 경로는 graceful no-op.
+   * 생성: `wrangler.toml`의 `[[durable_objects.bindings]]` + `[[migrations]]` 참조.
+   */
+  TRIP_DO?: DurableObjectNamespace;
 }

--- a/backend/alarm-worker/wrangler.toml
+++ b/backend/alarm-worker/wrangler.toml
@@ -104,6 +104,19 @@ binding = "DB"
 database_name = "subway-now-db"
 database_id = "a2c04254-6bde-4b70-a31f-97ada2940b50"
 
+# Durable Object — TripDO scaffold (#2264, Epic #2260, ADR-031 Phase 1).
+# 1 trip = 1 DO(`env.TRIP_DO.idFromName(tripToken)`). Phase 1은 shadow(no-op 기본,
+# `tripDoFlag.ts` KV 게이트 off) — cron이 여전히 authoritative, fire 로직 없음(state 보관만).
+# SQLite storage backend는 Workers Free plan에서도 가용(요청 100K/day, 행 read 5M/day,
+# 행 write 100K/day, storage 5GB 한도 — 2026-08-09 durable-objects 스킬 문서 확인, blocker 아님).
+[[durable_objects.bindings]]
+name = "TRIP_DO"
+class_name = "TripDO"
+
+[[migrations]]
+tag = "v1-trip-do"
+new_sqlite_classes = ["TripDO"]
+
 # 1분마다 활성 트립 폴링
 [triggers]
 crons = ["*/1 * * * *"]


### PR DESCRIPTION
Part of #2260
Closes #2264

## 요약

ADR-031 Phase 1 — per-trip Durable Object(`TripDO`) scaffold. **cron은 여전히 authoritative, DO는 shadow(no-op 기본)로 병존. fire 동작 delta 0.**

## 선검증 — DO SQLite 가용성

`durable-objects` 스킬 + Cloudflare 공식 문서(Pricing) 확인 결과: **DO SQLite storage backend는 Workers Free plan에서도 가용** (blocker 아님).
- Free plan 한도: 요청 100,000/day, 컴퓨트 13,000 GB-s/day, 행 read 5,000,000/day, 행 write 100,000/day, storage 5GB.
- 본 repo가 Analytics Engine/D1 등에서 겪은 "binding 선언만으로 deploy 실패"(Cloudflare API 10089)는 **Paid 전용 기능**(Analytics Engine)에 국한된 제약이며 DO SQLite에는 적용되지 않음.
- `wrangler deploy --dry-run`으로 binding/migration 구성 정상 인식 확인(아래 Device verify 참조). **실 배포는 수행하지 않음.**

## 변경 사항

- `backend/alarm-worker/src/tripDO.ts` — `TripDO` 클래스. DO storage(SQLite-backed, `new_sqlite_classes` migration)에 trip row + SSoT row를 KV 스타일 API(`ctx.storage.get/put`)로 보관. **fire 로직 없음**(Phase 2 스코프) — state 보관/조회만. `fetch()` 라우팅: `GET/POST /trip`, `GET/POST /ssot`.
  - `cloudflare:workers`의 `DurableObject` 헬퍼 클래스를 extend하지 않고 전통적 `fetch()` 핸들러 패턴 사용 — 그 가상 모듈은 `vitest-pool-workers` 런타임에서만 resolve되는데 본 repo는 plain vitest(node 환경)라 도입 시 새 테스트 인프라가 필요해짐. row read/write는 순수 함수로 분리해 기존 `InMemoryKV` 테스트 컨벤션과 동형으로 100% 커버.
- `backend/alarm-worker/src/tripDoFlag.ts` — `archFlag.ts`(#1982)와 동일한 KV read/write 게이트 패턴. 키 `arch:trip-do-shadow-v1`, default `'off'`(dormant). `on → off` KV write만으로 즉시 롤백.
- `backend/alarm-worker/wrangler.toml` — `[[durable_objects.bindings]]`(`TRIP_DO` → `TripDO`) + `[[migrations]]`(`new_sqlite_classes`) 추가.
- `backend/alarm-worker/src/types.ts` — `Env.TRIP_DO?: DurableObjectNamespace`(optional, graceful — 미바인딩 시 no-op).
- `backend/alarm-worker/src/index.ts`:
  - `dualWriteTripDo(env, trip)` 추가, `POST /trips` 핸들러에서 `putTrip` 이후 호출.
  - flag off(default) 또는 `TRIP_DO` 미바인딩 → 완전 no-op.
  - flag on → 기존 DO row read → `trip`과 불일치 시 divergence 로그 → 신규 `trip` shadow seed.
  - DO 호출 실패는 삼켜서 로그만 남김 — trip 등록 응답을 절대 차단하지 않음.
  - `export { TripDO } from './tripDO'` — wrangler가 main module에서 `class_name` 탐색하는 요건 충족.

## 금지 사항 준수

- fire를 DO로 이동하지 않음(Phase 2 스코프 아님) — `TripDO`는 state 보관/조회 메서드만 보유.
- cron 로직(`scheduled.ts`)·단일 emitter·Phase 0 채택 로직(`useFusedNearestStation` 등) 미변경.
- device 코드 미접촉.
- DO 생성 flag 기본 off — `tripDoFlag.ts` default `'off'`.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan). `dualWriteTripDo`/`TripDO`/`tripDoFlag` 전부 caller 존재.
2. **V/X dashboard** — `trip-do: shadow-compare divergence (#2264)` / `trip-do: dual-write failed (graceful, #2264)` 로그를 Cloudflare Workers Logs(`wrangler tail` 또는 Dashboard)에서 관측 가능. flag on 이후에만 발생(off 시 완전 무음).
3. **의존 PR** — Phase 0(#2261) 머지됨. N/A(추가 의존 없음).
4. **측정 plan** — flag를 KV로 `on` 전환한 뒤 1주간 `trip-do: shadow-compare divergence` 로그 발생률을 관측해 DO seed가 KV 기준과 shadow-일치하는지 확인(divergence 목표 0). off 상태에서는 측정 대상 이벤트 자체가 발생하지 않음(no-op 확인).
5. **Device verify** — N/A, backend infra. 단 **DO deploy 후 wrangler 검증 필요**: `wrangler deploy --dry-run` 로컬 확인 완료(binding `env.TRIP_DO (TripDO) — Durable Object` 정상 인식). **실 production 배포는 사용자 담당**(free-quota/변경 승인 필요, 이번 PR은 실배포 안 함) — 배포 후 `wrangler d1`/`wrangler tail`이 아닌 DO는 `wrangler durable-objects` CLI 부재이므로 `POST /trips` 실호출 후 로그로 seed 성공 여부 관측.

## 검증

- `cd backend/alarm-worker && npx vitest run --coverage`: **80 files / 2952 tests 전부 pass**. `tripDO.ts`/`tripDoFlag.ts` 100%/100%/100%/100%. 전체 ratchet(97/96/98/97) 충족 — 실측 97.25/96.33/99.23/97.25.
- `npx tsc --noEmit`: 통과.
- `npm run lint:orphan`(repo root): `No orphan exports detected.`
- `npx wrangler deploy --dry-run`: binding/migration 구성 정상 인식, 실 배포 없음.

## 이슈 스펙 대비 이탈

없음. 단, SSoT row(`seedSsotRow`/`getSsotRow`)는 `TripDO` 스키마에 구현했지만 `POST /trips` dual-write는 이슈 본문 명시대로 **trip row만** 배선했다(SSoT는 `POST /trips`에서 직접 seed되지 않는 기존 구조 — `seedSsot`는 별도 경로). SSoT row 배선은 후속 Phase(예: `/position` 경로)에서 다룰 스코프로 판단.