### PR TITLE
fix(#2238): 안내 종료 버튼 + backend DELETE /trips 배선 검증

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -405,6 +405,16 @@ export default function HomeScreen() {
     stopNavigation();
     void setInfoModeEnabled(false);
   }, [stopNavigation, setInfoModeEnabled]);
+  // #2238 — "안내 종료" 명시 trigger. "안내 중단"(navigationActive만 off, BG GPS 토글)과 달리
+  // trip 자체를 종료한다: setDestination(null)이 기존 cleanup chain(runTripBoundCleanups →
+  // #2129 backend DELETE /trips wire, tripBoundCleanups.ts:259)을 그대로 태워 로컬 정리 +
+  // backend trip 삭제(best-effort, 실패해도 15분 backstop #2230이 안전망) 양쪽을 처리한다.
+  // navigationActive/infoModeEnabled도 함께 reset해 trip 없는 상태에 stale 의향 플래그가
+  // 남지 않도록 한다.
+  const handleEndNavigation = useCallback(() => {
+    handleStopNavigation();
+    setDestination(null);
+  }, [handleStopNavigation, setDestination]);
   const { arrivedBanner } = useArrivalAutoClear({
     currentStationName: result?.station.name,
     distanceKm: result?.distanceKm,
@@ -1421,6 +1431,22 @@ export default function HomeScreen() {
                     >
                       <Text style={[typography.label, { color: colors.warn, fontWeight: '700' }]}>
                         {t('navigation.stop')}
+                      </Text>
+                    </Pressable>
+                  )}
+                  {/* #2238 — "안내 종료" 버튼. "안내 시작"과 대칭 배치, 활성 trip(destination 존재)일
+                       때만 노출. 탭 시 trip 자체를 종료(setDestination(null))해 backend DELETE
+                       /trips까지 배선(runTripBoundCleanups → #2129)한다. */}
+                  {destination !== null && (
+                    <Pressable
+                      testID="home-navigation-end"
+                      style={[styles.navigationButton, { borderColor: colors.danger, borderWidth: 1 }]}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('navigation.end')}
+                      onPress={handleEndNavigation}
+                    >
+                      <Text style={[typography.label, { color: colors.danger, fontWeight: '700' }]}>
+                        {t('navigation.end')}
                       </Text>
                     </Pressable>
                   )}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -210,6 +210,7 @@
   "navigation": {
     "start": "Start guidance",
     "stop": "Stop guidance",
+    "end": "End guidance",
     "permissionPrompt": "Location permission is required to start guidance"
   },
   "arrival": {

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -210,6 +210,7 @@
   "navigation": {
     "start": "案内を開始",
     "stop": "案内を停止",
+    "end": "案内を終了",
     "permissionPrompt": "案内を開始するには位置情報の権限が必要です"
   },
   "arrival": {

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -210,6 +210,7 @@
   "navigation": {
     "start": "안내 시작",
     "stop": "안내 중단",
+    "end": "안내 종료",
     "permissionPrompt": "안내를 시작하려면 위치 권한이 필요합니다"
   },
   "arrival": {

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -210,6 +210,7 @@
   "navigation": {
     "start": "开始导航",
     "stop": "停止导航",
+    "end": "结束导航",
     "permissionPrompt": "开始导航需要位置权限"
   },
   "arrival": {


### PR DESCRIPTION
Closes #2238

## 요약
"안내 종료" 버튼을 HomeScreen의 기존 "안내 시작/중단" 명시 trigger(#1973) 영역에 대칭 배치. 활성 trip(destination 존재) 시에만 노출되며, 탭하면 로컬 trip 종료 + backend `DELETE /trips` 통지를 함께 처리한다.

## 배경
tactical #2230이 desync를 9h→15분으로 줄였지만, device가 로컬로만 trip을 종료하면 backend KV trip이 계속 남아 발사하는 근본 문제가 남아 있었다(ADR-029 "알려진 빈틈" G3). 스코프 확정 코멘트(2026-08-09)에 따라 이번 PR은 (1) 종료 버튼 UX 명시화 + (2) 기존 DELETE /trips 배선 검증으로 범위를 좁혔다. backend reconcile(원래 이슈 본문 작업 2)은 스코프 확정 코멘트에서 제외됨 — 별도 후속 이슈로 남겨둠.

## 변경 사항
- `src/screens/HomeScreen.tsx`: `handleEndNavigation` 콜백 추가(`handleStopNavigation()` + `setDestination(null)`) + `home-navigation-end` 테스트ID를 가진 Pressable 버튼을 안내 시작/중단 버튼 블록 바로 아래 배치. `destination !== null`일 때만 노출.
- **DELETE /trips 배선**: 신규 코드 아님 — 기존 경로 확인 결과, `setDestination(null)` → `useDestinationStore`의 cleanup chain → `runTripBoundCleanups()`(`src/features/alarm/store/tripBoundCleanups.ts:259-274`, #2129에서 이미 구현) → `clearActiveTrip(backendTripToken)`(`src/features/alarm/api/alarmBackend.ts:509`, `DELETE /trips/:token`)가 이미 fire-and-forget best-effort로 연결되어 있음을 확인. 별도 배선 코드를 추가하지 않고 기존 경로를 재사용.
- `src/shared/i18n/locales/{ko,en,ja,zh}.json`: `navigation.end` 키 추가.

## 금지 사항 준수
- backend 15분 backstop(#2230) 미변경.
- fire 로직 / ADR-031 DO track / `backend/alarm-worker/**` scheduled.ts 미접촉 — DELETE 핸들러는 기존 구현 그대로 사용, device 배선만 확인.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — DELETE /trips 호출은 `wrangler tail`(backend)에서 `DELETE /trips/:token` 요청 로그로 관측 가능. 성공/실패는 `clearActiveTrip`의 `AlarmBackendResult`(`{ok, status}`)로 device 측 로그(`createLogger('alarmBackend')`)에도 남는다.
3. **의존 PR** — N/A (기존 #2129에서 backend DELETE 핸들러 + 배선이 이미 머지됨. 본 PR은 UI trigger만 추가).
4. **측정 plan** — 다음 실탑승에서 "안내 종료" 탭 후 `wrangler tail`로 `DELETE /trips/:token` 200 수신 확인 + 이후 cron에서 해당 trip 관련 발사 0건 확인.
5. **Device verify** — 필요. 시나리오: 활성 trip 중 "안내 종료" 탭 → (a) 화면이 즉시 trip-free 상태로 복귀 (b) `wrangler tail`에 DELETE 200 로그 (c) 오프라인 상태에서 탭해도 로컬 종료는 즉시 완료되고 backend는 15분 backstop이 정리하는지 확인.

## 테스트
- `npm run type-check` pass
- `npm test` — 434 suites / 9301 tests pass, coverage 100% 유지 (src/screens/**는 기존 coverage 제외 대상)
- `npm run lint:orphan` — 0 orphan
- code-review(medium effort) 수행 — 발견된 항목은 cosmetic(중복 가드) 수준, 기능 결함 없음
