### PR TITLE
docs: ADR-032 device emitter 탑승 루프 설계 + spike

### DIFF
--- a/docs/decisions/ADR-032-device-primary-emitter-boarding-loop.md
+++ b/docs/decisions/ADR-032-device-primary-emitter-boarding-loop.md
@@ -1,0 +1,99 @@
+# ADR-032 — Fire emitter를 device primary + backend safetyNet backstop으로 개정 (route+arvlCd 탑승 이벤트 루프)
+
+- **Status**: Proposed. tracer-bullet (플래그 게이트, per-trip 원자 전환).
+- **부분 개정**: ADR-026(단일 emitter = backend) — **단일 emitter 원칙은 불변, primary 권위만 backend→device로 이동**. **Builds on**: ADR-010(miss=오발사 동급), ADR-022(flag), ADR-031(silent push deadlock), feedback_device_self_contained_fusion.
+- **분석**: 2026-08-10 오전 실탑승 덤프(`텍스트-885C779A95BA-1.txt`) + backend D1 trip `b00dd879` 교차 RCA.
+- **관련 plan**: `tasks/plan-2026-08-10-device-boarding-emitter.md`
+
+---
+
+## Context — backend 단일 emitter 전제의 붕괴
+
+ADR-026은 iOS 플랫폼 제약(로컬 identifier vs push collapse-id는 서로 못 합침 → 둘 다 쏘면 이중발사 물리적 불가피)으로 **emitter를 정확히 1개**로 강제했고, ADR-022(flag-ON) 정합상 그 1개를 **backend**로 정했다. ADR-026 스스로 비용을 경고했다: *"매역 backstop을 없애므로 backend outage/APNs 지연 시 miss. 트립이 등록조차 안 되면 backend가 못 쏜다. miss=오발사 동급."*
+
+### 2026-08-10 evidence — 그 경고의 현실화
+7호선→2호선 환승 trip(용마산→건대입구 환승→뚝섬, trip `b00dd879`):
+- 사용자가 **7호선 탑승열차를 직접 선택**(명시 의향)했음에도 **2호선 전 구간 무보호** — `lockless-no-user-intent` 100회.
+- **backend fired=0** (`scheduled.ts:1286`: `isBoardingLockActive || infoModeEnabled`만 발사. 2호선 leg lock 없음 → 매 tick skip). push_failures=0(발사 시도조차 0), silent push received=0.
+- **매역 알림은 1홉 늦고 "통과"뿐** (`advanceTripPosition.ts:510`: "다음역 도착 확인 시 직전역 통과" 발사 + Seoul API 지연 + cron 1분 + APNs 35~51s).
+
+### Pinned 원인 (재탑승 불필요, 코드+데이터로 특정)
+BG 환승 swap(`backgroundTransferSwap.ts:73`)이 새 노선 lock을 **silent push로만** hydrate — `/boarding-lock/sync` HTTP 응답에 `autoLockCandidate`가 담겨 반환(`index.ts:1923`)되는데도 BG는 이를 **폐기**(`Promise<unknown>`)하고 silent push 발급을 기다린다. silent push는 구조적 deadlock으로 死(ADR-031, received=0) → 2호선 lock 영영 안 생김. **FG는 응답 직접 hydrate(`useTransferAutoDetect`), BG만 push 의존** — 지하 탑승=화면 꺼짐=BG이므로 정확히 실패.
+
+### 이미 존재하는 지렛대
+- **즉시발사 로컬알림 경로 존재**: `fireFgAuxStationPassedNotification`(#2122, `stationNotification.ts:603`)이 `scheduleNotificationAsync({trigger:null})`로 즉시 발사. 단 `AppState==='active' && lock` 게이트로 FG+lock에만 묶임. **시각 예약(사전예약) 아님 → #2202가 지운 stale 큐 문제와 무관.**
+- **route에 탑승 이벤트 정보 완비**: `journey.ts` fromLine/toLine/transfer.
+- **arvlCd forward 신호 존재**: `arrivalCodes.ts` — 진입(0)/전역출발(3)/전역도착(5). 현재 backend는 이를 "직전역 통과 확정(backward)"에만 사용.
+- **backend safetyNet backstop 존재**: `safetyNetScheduler.ts`(ADR-026:36) — device 침묵 확인 시에만 무장.
+
+---
+
+## Decision — 분업: backend=위치권위/plan, device=발사/보정
+
+### 원칙
+**단일 emitter 원칙(ADR-026)은 유지(발사는 device만)하되, 역할을 각자 강한 쪽에 분업한다:**
+- **위치/타이밍 권위 = backend** — trainCode를 Seoul arrival API로 서버측 추적(GPS 무관, 지하 robust). backend는 "쏘는" 게 아니라 **위치를 추적해 plan(역별 예상시각+탑승 이벤트)을 산출**한다.
+- **발사/전달 = device** — plan을 받아 즉시 로컬알림 발사(APNs 지연 0, BG), live 신호로 보정.
+- backend는 발사 안 함 → 이 이벤트 push 끄고 **safetyNet backstop만**. 이중발사 방지는 identifier가 아니라 **per-trip 플래그 + temporal 조정**으로.
+
+이유: 순수 device는 W1a(지하 위치) 약하고, 순수 backend는 W1b(push 배달 지연/deadlock) 약하다. 분업이 양쪽 강점을 취한다.
+
+### (a) transport — backend plan → device
+backend가 연결 창(신호 잡히는 순간, 대부분 승차 전후 존재)에 device로 **plan** 전달: 역별 예상 도착시각 + 탑승 이벤트 시퀀스. **plan은 blind OS 사전예약이 아니라 device의 "언제 쏠지" 판단 입력** — device가 live 신호(arvlCd/motion)로 시각 보정 + 연결 복구 시 재-sync해 지연 열차 drift를 흡수. 즉시발사(`trigger:null`)라 OS 미래 예약 큐 미사용 → stale 큐 문제 없음.
+
+### (b) 탑승 이벤트 primitive
+route = 탑승 이벤트 시퀀스: `(역 S, 노선 L, 방향=→D)`. 처음 탑승 = (출발역, L1), 환승 k = (환승역, L(k+1)). 각 이벤트에서 **plan의 S 도착 예상 + motion-resume(가속도계 출발 가속) consensus** → **로컬 "탑승하셨나요?" 프롬프트 즉시발사**. 지하 위치는 backend train-tracking이 권위, device는 발사 앵커만 motion으로.
+
+### (b) 응답 → intent → leg 추적
+프롬프트 응답 = device-local intent 등록 → 그 leg 매역 forward 알림(다음역 arvlCd 진입 즉시발사, 방향 필터). **무응답 시 optimistic**: 가속도계 지속 이동 + route 방향 역 전진 consensus면 탭 없이 추적 진입(guard: 역이 반대로 가면 중단).
+
+### (c) 매역 forward (증상 3)
+"통과(backward, 도착 확인 후)" → "진입/접근(forward, arvlCd 3/5/0)" 로컬발사. 완행 우선, 급행은 역간시간/arvlCd consensus로 skip 감지 → 보수적 suppress(오발사 대신 침묵), 정확 급행은 follow-up.
+
+### (d) 단일 emitter 전환 — `emitter=device` 플래그
+trip 등록 페이로드에 `emitter=device`. backend 분기: **ON** → station/prompt push suppress + safetyNet backstop만 무장. **OFF**(구 앱/롤백) → 기존 backend 발사. per-trip 등록 시점 확정 → 동시 primary 창 없음.
+
+### (e) backstop (miss 방지, W4)
+backend safetyNet 유지. **temporal 조정**: device 로컬 발사 시 경량 ACK(또는 backend가 position 전진 대비 device-fire 부재로 침묵 추론) → backstop은 device 침묵 확인 + 발사 직전 재검증 시에만 1회. device 깨어나 발사=잠잠, 침묵=backstop 발사.
+
+---
+
+### transport 잔여 2개의 해결 (계층 + motion-gate)
+- **연결 창 필요** → **1B 등록 시 full plan 프리페치 + 1A 창마다 재-sync + 1C static timetable 오프라인 floor** (3층 방어). 3층 다 뚫림 = "등록 전부터 끝까지 무신호 + timetable 없음" = 사실상 없음.
+- **지연 열차 drift** → **2B motion-gated 발사(주축) + 2A live arvlCd 재-anchor + 2C stop-count dead-reckoning**. 핵심 전환: **plan 시각으로 blind 발사 금지 — 발사 트리거는 가속도계 감속→정차(실제 도착).** plan은 "다음 역+대략 언제"만, 발사는 motion. 지연은 motion 게이트가 자동 흡수.
+- **공통 귀결**: 두 잔여 모두 "**motion=ground-truth 발사 게이트, plan=맥락, arvlCd=신호 시 보정**"으로 수렴 → 리스크가 **가속도계 train-fingerprint 신뢰성** 한 곳에 집중. 이게 설계 단일 급소(아래 검증 1순위).
+
+---
+
+## 왜 이 방향인가 (ADR-026 대비)
+
+ADR-026은 "backend가 신뢰성 있게 쏜다"를 전제로 backend를 emitter로 택했으나, silent push deadlock(ADR-031)으로 그 전제가 붕괴. 본 ADR은 **위치=backend(train-tracking, GPS 무관 지하 robust), 발사=device(즉시 로컬, 배달 지연 0)** 로 분업 → 순수 backend(배달 약함)·순수 device(지하 위치 약함) 둘 다의 약점을 회피. device도 완전 무신호 극단엔 실패하므로 backend backstop을 남겨 miss를 막는다. feedback_device_self_contained_fusion 패러다임과 정합.
+
+---
+
+## 트레이드오프 / 리스크
+
+- **⚠️ 단일 급소 = 가속도계 신뢰성** — 두 transport 잔여를 "motion-gated fire"로 풀면서 리스크가 가속도계 train-fingerprint 신뢰성 한 곳에 집중. `lesson_motion_activity_intermittent_signal`(CMMotionActivity 5~10분 뒤집힘)이 정통으로 걸림 → **실기기 spike 1순위**. 불안정하면 설계 척추 재검토.
+- **W1 지하 위치** — backend train-tracking으로 **구조적 해결**(미해결 아님). 잔여는 transport(위 2개, 완화).
+- **급행 정확도(W2)** — MVP 완행 가정. 급행 매역 정확은 follow-up. 단 "건너뛴 역 오발사"는 skip 감지로 0 보장.
+- **BG 웨이크 의존(숙제1)** — 즉시발사는 발사 순간 BG tick 필요. motion-resume 앵커로 확률 높이나 실기기 검증 항목.
+- **이중발사(W5)** — per-trip 플래그로 원자 전환. flag-OFF 롤백 시 기존 backend 동작(안전).
+- **ADR-026 개정** — 단일 emitter 원칙 불변, primary만 이동. flag-OFF로 즉시 롤백 가능.
+- **N=1 미검증** — 2026-08-10 단일 trip 기반. 실탑승 다회(노선/급행/지상지하)로 일반화 검증 필요.
+- **backend + device 양 코드베이스** 수정 → 같은 파일 직렬 머지, 실기기 재검증 필수.
+
+---
+
+## Acceptance / 검증
+
+- **red replay**: 2026-08-10 덤프로 (a) 환승 후 2호선 무보호, (b) 매역 1홉 lag를 재현(red) → device emitter 적용 후 green(환승 프롬프트 발사, forward 1홉 빠름).
+- **field verify**: 실탑승 1주 — 환승 프롬프트 재발 0 + 미탑승/정지/반대방향 오발사 0 + device 침묵 시 backstop 1회 도달 + 이중발사 0.
+- **관측**: `boardingPrompt(local)` / forward fire / emitter 분기 카운터를 DebugModal·backend 로그 노출.
+- **Close 조건**: PR 머지 ≠ close. 위 field verify 1주 충족.
+
+---
+
+## 선행 조건
+
+- **BoardingLock lifecycle 로깅 복구** — 이번 덤프에서 lifecycle/drift 버퍼가 비어 lock 유실 순간 미포착(#2152 미탑 추정). 다음 실탑승부터 emitter 전환 효과를 로그로 판정하려면 lifecycle breadcrumb가 실기기 덤프에 확실히 남아야 함.
+- **ADR-031 Phase 0**(deadlock 완화) 진행 상태 확인 — 본 ADR은 silent push를 primary에서 배제하므로 ADR-031과 상호 정합(backend는 backstop만).

--- a/tasks/plan-2026-08-10-device-boarding-emitter.md
+++ b/tasks/plan-2026-08-10-device-boarding-emitter.md
@@ -1,0 +1,189 @@
+# Plan — Device 단일 emitter 탑승 이벤트 루프 (route+arvlCd 즉시발사)
+
+- 작성: 2026-08-10
+- 근거 evidence: 2026-08-10 오전 실탑승 덤프(`텍스트-885C779A95BA-1.txt`) + backend D1 trip `b00dd879`
+- 신규 ADR: **ADR-032** (fire emitter를 backend 단일 → device primary + backend safetyNet backstop으로 개정. ADR-026 부분 개정)
+- 관련: ADR-026(단일 emitter), ADR-031(silent push deadlock), ADR-022(flag-ON backend 권위)
+
+---
+
+## 1. 문제 (pinned root cause)
+
+2026-08-10 오전 7호선→2호선 환승 trip(용마산→건대입구 환승→뚝섬)에서 관측된 3개 증상은 **하나의 구조적 원인**으로 수렴:
+
+1. **2호선 전 구간 무보호** (`lockless-no-user-intent` 100회) — 사용자가 7호선 탑승열차를 직접 선택했음에도 2호선 lock이 안 걸림.
+2. **backend fired=0** — cron은 `isBoardingLockActive || infoModeEnabled`일 때만 발사(`scheduled.ts:1286`). 2호선 leg는 lock 없음 → 매 tick skip.
+3. **매역 알림이 1홉 늦고 "통과"뿐** — `advanceTripPosition.ts:510`이 "다음역 도착 확인 시 직전역 통과" 발사. Seoul API 지연 + cron 1분 + APNs 35~51s 누적.
+
+**Pinned 원인**: BG 환승 swap(`backgroundTransferSwap.ts:73`)이 새 노선 lock을 **silent push로만** hydrate(HTTP sync 응답의 `autoLockCandidate`를 폐기) → silent push는 구조적으로 죽음(received=0, ADR-031) → 2호선 lock 영영 안 생김. 매역 알림은 backend 단일 emitter(ADR-026)가 push 못 하니 miss. **backend 단일 emitter 전제(신뢰성 있게 쏜다)가 지하 push deadlock으로 붕괴.**
+
+증거: silent push received=0/fired=0, backend lock_attached=0/fired=0, push_failures=0(발사 시도조차 0), 2호선 100x lockless. 코드: FG는 sync 응답 직접 hydrate(`useTransferAutoDetect`), BG는 폐기 후 push 대기(`backgroundTransferSwap:73`).
+
+---
+
+## 2. 설계 — 분업 (backend=위치권위/plan, device=발사/보정)
+
+### 핵심 분업
+"위치를 아는 것"과 "제때 알리는 것"을 각자 잘하는 쪽에 맡긴다:
+
+| 역할 | 담당 | 이유 |
+|---|---|---|
+| **위치/타이밍 권위** | **backend** | trainCode를 Seoul arrival API로 **서버측 추적** — GPS 무관, 지하 robust. (2026-08-10 trip도 07:32~07:38 지하서 backend-ssot 역 전진 관측) |
+| **발사/전달** | **device** | 즉시 로컬알림, BG, APNs 지연 0 |
+| **다리(transport)** | backend가 연결 창에 **plan(역별 예상 도착시각 + 탑승 이벤트)** 을 device에 내려줌 → device가 로컬 발사 + **live 신호로 보정** | push per-event(지연/deadlock) 대신 plan 1회 + 재조정 |
+
+**순수 device도(지하 위치 약함), 순수 backend도(push 배달 약함) 아닌 분업**이 W1의 구조적 답. backend는 "쏘는" 게 아니라 "위치를 추적해 plan을 준다".
+
+### 탑승 이벤트 primitive
+route = 탑승 이벤트 시퀀스:
+```
+탑승 이벤트 = (역 S, 노선 L, 방향 =목적지쪽)
+- 처음 탑승 : (출발역, L1, →D)
+- 환승 k    : (환승역k, L(k+1), →D)
+```
+backend가 각 이벤트/역의 **예상 시각을 plan으로 산출·전달**. device는 그 plan을 들고:
+- **탑승 이벤트**: plan의 S 도착 예상 + **motion-resume(가속도계 출발 가속)** consensus → 로컬 "탑승하셨나요?" 즉시발사(`trigger:null`).
+- **매역 forward**: plan의 다음역 예상 + live arvlCd 진입(신호 잡힐 때) 보정 → "곧 X" 즉시발사.
+- 응답/optimistic motion = intent → leg 추적 → 다음 탑승 이벤트 반복.
+
+### 원칙
+- **단일 emitter 유지** — 발사는 device만. backend는 plan 전달 + safetyNet backstop만(발사 안 함). 이중발사는 `emitter=device` per-trip 플래그로 원자 차단.
+- **plan은 blind 사전예약 아님** — device가 live 신호(arvlCd/motion)로 시각 보정 + 연결 복구 시 재-sync. 지연 열차 drift 흡수.
+- **즉시발사(`trigger:null`, #2122 경로)** — OS 미래 시각 예약 큐 미사용 → stale 큐 문제 없음. plan은 "언제 쏠지 판단 입력"이지 OS 예약이 아님.
+
+세 증상이 하나의 루프로 접힘:
+```
+backend: trainCode 추적 → plan(역별 예상시각) ──연결 창──▶ device
+device:
+  [탑승 이벤트] plan S예상 + motion-resume → 로컬 프롬프트 "탑승?"   (= 증상 1·2 해결)
+     │ 응답/optimistic = intent
+     ▼
+  [leg 추적] plan 다음역 + live arvlCd 보정 → 로컬 forward 알림       (= 증상 3 해결)
+     │
+     ▼
+  [다음 탑승 이벤트 = 환승] 반복
+backend: device 침묵 확인 시에만 safetyNet backstop 1회(W4)
+```
+
+---
+
+## 3. 약점 + 대응 (adversarial)
+
+**공통 척추**: 모든 W의 해법은 **가속도계 motion(지하서도 동작) + route 방향 consensus**로 수렴한다. GPS/push가 죽어도 이 둘로 발사·추적·guard를 세운다. 완전 무신호 극단만 backend backstop(W4)이 받는다.
+
+### W1. 지하 위치 검출 (분업으로 구조적 해결)
+- 문제 분해: **W1a 위치를 아는 것** + **W1b device에 전달하는 것**. device 단독이 약한 건 W1a(지하 GPS 동결).
+- **W1a → backend가 권위**: trainCode를 Seoul arrival API로 서버측 추적 = GPS 무관, 지하 robust. device가 지하 위치를 검출할 필요 없음 — backend가 열차를 따라감(아침 trip 07:32~07:38 지하 backend-ssot 전진이 증거).
+- **W1b → device가 담당**: backend가 연결 창에 **plan(역별 예상시각)** 을 내려주면, device는 즉시 로컬알림으로 전달(APNs 지연 0, BG). "backend가 쏜다"가 아니라 "backend가 위치→plan, device가 발사".
+- device는 plan을 **live 신호로 보정**: 발사 앵커는 **가속도계 motion-resume**(정지→출발 가속, 지하 동작) + 신호 잡힐 때 arvlCd. plan 예상 + live consensus.
+- **잔여 + 해결**:
+  - (1) **plan 수신 연결 창** → 계층 방어: **1B 등록 시 full plan 프리페치 + 1A 창마다 재-sync + 1C static timetable 오프라인 floor**. 3층 다 뚫림 = 등록 전부터 무신호+timetable 없음 = 사실상 없음.
+  - (2) **지연 열차 drift** → **2B motion-gated 발사(주축) + 2A live arvlCd 재-anchor + 2C stop-count**. 핵심: plan 시각 blind 발사 금지, **발사는 가속도계 감속-정차(실제 도착)** 로. 지연 자동 흡수.
+  - (3) 공통 귀결 = "**motion=발사 게이트, plan=맥락, arvlCd=보정**" → 리스크가 **가속도계 신뢰성** 한 곳 집중(단일 급소, `lesson_motion_activity_intermittent_signal`). **실기기 spike 1순위.**
+  - (4) 완전 실패 시 → W4 backend backstop 최종 방어.
+
+### W2. 급행/완행 (완행 우선 + 감지 follow-up)
+- 문제: trainCode 없으면 급행 탑승 시 건너뛴 역 오발사.
+- MVP: **완행 가정**, route 매역 forward 발사.
+- 급행 감지: 탑승 후 **역간 시간 + arvlCd 패턴** 관측. 우리 열차가 X를 건너뜀(X 도착 arvlCd 없이 X+1 도착) → X를 skip 표기 → **X forward 알림 suppress**(오발사 대신 침묵).
+- → 급행이어도 "건너뛴 역 오발사" 0. 정확한 급행 매역은 follow-up(#G).
+
+### W3. 무응답 = 무추적 (optimistic motion consensus)
+- 응답 있으면 → 확정 intent → 완전 추적.
+- **무응답 시**: (a) 가속도계 train 지속 이동 + (b) route 방향대로 역 전진 → **탭 없이도 "탑승 추정" → 매역 추적 진입.** 탭은 정확도만 강화, 필수 아님.
+- **guard**: 역이 route 반대로 가거나 정지 지속 → 우리 trip 아님 → 추적 안 함(오발사 차단).
+
+### W4. backstop 상실 = miss (temporal 조정)
+- 문제: backend를 끄면 device가 BG서 못 깨어날 때 backstop 0 → miss(ADR-026 "miss=오발사 동급").
+- backend safetyNet(`safetyNetScheduler.ts`) **유지**, ADR-026:36 그대로.
+- **이중발사 방지는 identifier가 아니라 시간으로** — device 로컬 발사 시 backend에 경량 ACK(또는 backend가 position 전진 대비 device-fire 부재로 침묵 추론). backstop은 **device 침묵 확인 + 발사 직전 재검증** 시에만 무장.
+- → device 깨어나 발사 = backstop 잠잠. device 침묵(BG 미웨이크) = backstop 1회. miss 방지 + 중복 없음.
+
+### W5. 마이그레이션 이중발사 (per-trip 원자 플래그)
+- 문제: device ON·backend OFF가 원자적이 아니면 둘 다 쏘는 창 = ADR-026 재발.
+- trip 등록 `emitter=device` 플래그. backend 분기:
+  - **ON**(신규 앱): 그 trip station/prompt push **suppress**, safetyNet backstop만.
+  - **OFF**(구 앱/롤백): 기존대로 backend 발사.
+- 플래그가 **등록 시점 per-trip** 확정 → 같은 trip이 device·backend primary 동시인 창 **없음**. device 발사 코드와 backend suppress가 **같은 앱 버전** → 항상 정합.
+
+**정직한 메타 약점**: 이 설계는 "지하에서 내 위치·도착정보를 안다"를 마법으로 풀지 않는다. silent-push deadlock + APNs 지연을 제거하고 device-local 신호(motion/기압계/즉시 로컬알림)를 활용할 뿐. 지하 무신호 극단에선 device도 실패 → 그래서 **backend safetyNet backstop이 필수**.
+
+---
+
+## 4. 숙제 3개 해법
+
+1. **BG 웨이크** → **motion-resume 앵커.** 도착 정시가 아니라 정지→이동 전환(탑승해 열차 출발) 시점 발사. iOS significant-motion/location이 깨움. "탔냐?"는 열차 이동 시점이 도착 순간보다 정확 → 약점의 기능적 반전. 기존 `backgroundLocationTask` + CMMotionActivity 재사용.
+2. **복수 열차** → **탑승 이벤트당 1회 발사** + dismiss/cooldown 재무장(기존 `dismissSilence`). 급행/완행은 완행 우선 + 급행 감지 follow-up.
+3. **backend push-off** → trip 등록 `emitter=device` 플래그 → backend가 그 trip station/prompt push suppress + safetyNet backstop만.
+
+---
+
+## 5. 확정된 결정 (추천 default 채택)
+
+- **D1. backstop**: device primary + **backend safetyNet backstop 유지**. (순수 device 미채택 — W4 miss)
+- **D2. 급행/완행**: **완행 우선 + 급행 감지 follow-up.** (지금 막지 않음)
+
+> 사용자 override 가능. override 시 4·6절 acceptance/이슈 재조정.
+
+---
+
+## 6. Acceptance (V/X) — 사용자 가치 기준
+
+정의 순서: 사용자 가치 → acceptance → 코드. 권한 매트릭스(WhileInUse/Always × FG/BG/취침) × 환경(지상/지하/환승) 커버.
+
+- **V1 처음 탑승 프롬프트** — 출발역서 방향 맞는 열차 탑승(motion-resume) 시 로컬 프롬프트 발사. FG/BG 모두. 지상/지하 모두(지하는 backstop 포함).
+- **V2 환승 탑승 프롬프트** — 환승역서 새 노선 탑승 시 로컬 프롬프트. **silent push 0건에도 발사**(핵심 회귀 방어).
+- **V3 매역 forward 알림** — 다음역 arvlCd 진입 시 "곧 X" 로컬발사. "통과(backward)" 대비 1홉 빠름.
+- **V4 단일 emitter** — 동일 이벤트 이중발사 0건(device 발사 시 backend suppress 확인).
+- **V5 backstop** — device 침묵(BG 미웨이크) 시 backend safetyNet 1회 도달.
+- **X1 오발사 0** — 미탑승/정지 중, 반대방향/급행 오탑승 프롬프트 0건.
+- **X2 무응답 graceful** — 프롬프트 무응답 시 spam 0(cooldown), optimistic 추적은 motion consensus 충족 시만.
+
+**Close 조건**: 실탑승 1주 — V2(환승 프롬프트) 재발 0 + X1 오발사 0 + V5 backstop 도달 확인. (PR 머지 ≠ close.)
+
+---
+
+## 7. Wire Matrix
+
+| 신호 | 생성 | 소비/관측 | Dead 금지 검증 |
+|---|---|---|---|
+| 탑승 이벤트 감지(motion-resume+S+L) | `backgroundLocationTask` / FG detector | 로컬 프롬프트 발사 | 발사 카운터 DebugModal 노출 |
+| 로컬 프롬프트 발사 | `fireLocalBoardingPrompt`(신규, #2122 확장) | 알림센터 + alarmLog | `boardingPrompt(local)` 카운터 |
+| 프롬프트 응답 | 사용자 탭 | intent store → leg 추적 진입 | 응답률 DebugModal |
+| 매역 forward(arvlCd 진입) | leg 추적기 | 로컬발사 + alarmLog | forward fire 카운터 |
+| `emitter=device` 플래그 | trip 등록 페이로드 | backend push suppress + safetyNet 무장 | backend 로그 `emitter` 분기 |
+| safetyNet backstop | backend(device 침묵 시) | APNs 1회 | backend fire-once 카운터 |
+
+---
+
+## 8. 이슈 분해 (tracer-bullet 수직 슬라이스, 각 결함=PR 1개)
+
+- **#0 [SPIKE] 가속도계 train-fingerprint 신뢰성 실기기 검증** ★1순위 — 감속-정차/출발-가속 검출 정확도 + CMMotionActivity flip 빈도(`lesson_motion_activity_intermittent_signal`). **설계 단일 급소** — 여기 깨지면 척추 재검토. spike 후 본구현.
+- **#A ADR-032 작성** — 분업(backend=위치/plan, device=발사) 개정. 결정 D1/D2 근거. (docs-only) ✅작성됨
+- **#B 탑승 이벤트 primitive 추출** — route → 탑승 이벤트 시퀀스 pure 함수 + 테스트. (shared/route util)
+- **#H backend plan endpoint** — trainCode train-tracking → plan(역별 예상시각+탑승 이벤트) 산출 + 연결 창 전달. 등록 시 full plan 프리페치(1B). (backend)
+- **#I device plan 수신/캐시/재-sync + static floor** — 1B 수신 + 1A 창마다 재-sync + 1C static timetable 오프라인 floor. (device)
+- **#C 로컬 프롬프트 즉시발사(BG)** — #2122 `fireFgAux…`를 route/plan 기반·BG 허용으로 확장. FG+lock 게이트 제거, **motion-gated 발사(2B)**. Part of ADR-032.
+- **#D 프롬프트 응답 → intent → leg 추적** — 응답 시 device-local intent 등록, 매역 forward 진입. optimistic(무응답+motion consensus) 포함.
+- **#E 매역 forward 트리거** — plan 다음역 + **motion 감속-정차 게이트(2B)** + live arvlCd 보정(2A). "통과(backward)" → "진입/접근(forward)". 방향 필터.
+- **#J stop-count dead-reckoning** — 정차 사이클 카운트로 창-사이 역 전진 추정(2C). #E 보조.
+- **#F backend `emitter=device` suppress + safetyNet 유지** — backend가 플래그 trip의 station/prompt push 끔, safetyNet backstop만(temporal 조정). (backend)
+- **#G 급행 감지 (follow-up)** — 역간 시간/arvlCd consensus로 급행 판정 → 매역 forward 보정. (D2 후속)
+
+의존: **#0 spike가 #C·#E·#J 선행(급소 검증).** #B는 #H·#I·#C·#D·#E 선행. #H↔#I 짝. #C·#D·#E는 #B·#I 선행. #F는 #C와 원자 배포(이중발사 창 차단). #A 병행(작성됨).
+
+---
+
+## 9. Wire-completion 5단 (모든 PR)
+
+1. **Orphan 없음** — `npm run lint:orphan` pass. 신규 export caller 존재.
+2. **V/X dashboard** — 신규 카운터(`boardingPrompt(local)`, forward fire, emitter 분기)를 DebugModal / backend 로그에 노출.
+3. **의존 PR** — #C↔#F 원자 배포. 각 PR 본문 명시.
+4. **측정 plan** — 실탑승 1주 시나리오 캡처(환승 프롬프트 발사, 이중발사 0, backstop 도달) + backend `emitter` 로그 query.
+5. **Device verify** — 실기기 필수(BG 웨이크/지하/환승은 device-only). 시나리오: 처음탑승·환승·급행·무응답·지하.
+
+---
+
+## 10. 남은 검증 인프라 (선행 권장)
+
+- **BoardingLock lifecycle 로깅 복구** — 이번 덤프에서 `BoardingLock Lifecycle`/`Drift` 버퍼가 비어 lock 유실 순간을 못 잡았음(#2152가 아침 빌드에 없었거나 미탑). 재현 진단 위해 lifecycle breadcrumb가 실기기 덤프에 확실히 남도록 검증 → 다음 실탑승부터 emitter 전환 효과를 로그로 판정 가능.

--- a/tasks/plan-2026-08-10-device-boarding-emitter.md
+++ b/tasks/plan-2026-08-10-device-boarding-emitter.md
@@ -186,4 +186,5 @@ backend: device 침묵 확인 시에만 safetyNet backstop 1회(W4)
 
 ## 10. 남은 검증 인프라 (선행 권장)
 
-- **BoardingLock lifecycle 로깅 복구** — 이번 덤프에서 `BoardingLock Lifecycle`/`Drift` 버퍼가 비어 lock 유실 순간을 못 잡았음(#2152가 아침 빌드에 없었거나 미탑). 재현 진단 위해 lifecycle breadcrumb가 실기기 덤프에 확실히 남도록 검증 → 다음 실탑승부터 emitter 전환 효과를 로그로 판정 가능.
+- **BoardingLock lifecycle 버퍼 영속화** (전제 정정 2026-08-10 감사) — 이번 덤프의 `BoardingLock Lifecycle`/`Drift` (0)은 **로깅 결함이 아님**: #2152 배선 정상(`DebugModal.tsx:2101/2166`, 로깅 호출부 정상). 원인은 **모든 debug ring buffer(`createDebugBuffer`)가 in-memory 비영속 → 앱 kill·BG 재기동(silent push)·OTA 리로드 시 리셋**. 07:33 lock 이벤트 ~ 13h 뒤 덤프 사이 프로세스 재기동으로 증발. → **고칠 것 = 복구가 아니라 lifecycle/drift 버퍼 영속화(AsyncStorage) 또는 최소 "launch 이후 버퍼 age" 마커**로 (0)의 "이벤트 없음 vs 재기동 증발"을 구분. 다음 실탑승 RCA 인프라 직결.
+- **DebugModal share 신뢰성 + coverage gap** (2026-08-10 감사) — (a) share `void Share.share()` 무음 실패 → try/catch+Alert+Clipboard fallback+사이즈 가드. (b) `getLockCorrectionMetrics` 섹션 미배선(주석은 노출 주장) → SHARE_SECTIONS 배선. (c) `computeTripRecall` 요약 라인(선택).

--- a/tasks/spike-2026-08-10-accel-train-fingerprint.md
+++ b/tasks/spike-2026-08-10-accel-train-fingerprint.md
@@ -1,0 +1,76 @@
+# SPIKE #0 — 가속도계 train-fingerprint 신뢰성 검증
+
+- 작성: 2026-08-10
+- 상위: ADR-032 / `tasks/plan-2026-08-10-device-boarding-emitter.md` §8 #0
+- 성격: **throwaway 실험** (dev 미머지 feature 아님). 설계 단일 급소 de-risk 후 폐기/흡수.
+
+---
+
+## 왜 이 spike (급소)
+ADR-032의 두 transport 잔여(연결 창 / 지연 drift) 해결이 전부 **"motion-gated 발사"**(시계 blind 금지, 가속도계 감속-정차로 발사)에 수렴한다. 즉 **가속도계가 지하서 역별 정차/출발을 신뢰성 있게 잡느냐**가 설계 전체의 단일 실패점. 메모리 `lesson_motion_activity_intermittent_signal`(CMMotionActivity 5~10분 flip)가 정통으로 걸림 → 7개 이슈 짓기 전에 실기기로 찌른다.
+
+**기존 인프라 한계(spike가 넘어야 할 것)**: `accelerometerFingerprint.ts`는 60s window @5Hz + RMS 3분류(`stationary/walking/automotive`). ~15s 정차/출발 이벤트엔 너무 거칠고, cruise vs 감속을 RMS만으로 구분 불가(방향축 적분 필요).
+
+---
+
+## 가설 (go/no-go 대상)
+- **H1 검출성** — raw userAcceleration(중력제거)에서 역별 **지속 감속(제동=도착)** 과 **지속 가속(출발)** 이 cruise 진동과 구분되게 잡힌다.
+- **H2 지연** — 정차 이벤트를 실제 정지 후 **≤8s** 내 검출.
+- **H3 거치 위치 robust** — 주머니/손/가방 모두서 검출(고정축 X → 수평면 주성분/magnitude).
+- **H4 CMMotionActivity 불충분** — automotive/stationary 전환이 >30s 지연 or flip → raw accel 필요 확증(거친 3분류로는 불가).
+
+## 측정 신호 (FG, 화면 ON 허용 — 신호 검출성 먼저)
+타임스탬프 동기화해 로깅:
+- **expo-sensors DeviceMotion @~20Hz**: userAcceleration(x,y,z) + rotationRate + gravity. (spike는 native 안 건드리고 JS 스트림으로 충분)
+- 기존 `getLatestAccelerometerSnapshot()`(rmsMagnitude, patternClass) 매 cycle.
+- CMMotionActivity(`modules/motion-activity`) activity + confidence.
+- Barometer(hPa) — subsurface + 승강장 압력 시그니처 교차검증.
+- GPS(잡힐 때) — 지상 구간 ground-truth 앵커.
+
+## Ground truth (역별 실제 도착/출발)
+- 라이더가 **실제 문열림(도착) / 문닫힘·출발 순간에 "MARK" 버튼 탭** → 타임스탬프 적재. 이벤트당 1탭, 저부하.
+- 폴백: 지상/고가 구간은 GPS + 시간표로 재구성.
+
+## 검출 후보 (오프라인, 로깅 raw에 적용)
+- **C1 주성분 적분** — 수평면 PCA로 진행축 추출 → |지속 진행축 가속| > θ, > T초 = 출발 / 지속 감속 = 도착.
+- **C2 RMS floor 브라케팅** — RMS가 dwell floor로 떨어짐(정차) 을 앞뒤 RMS burst로 감쌈 = 정차 사이클. (단순·거치 robust)
+- **C3 CMMotionActivity 전환** — automotive→stationary(baseline, 이길 대상).
+- C1/C2/C3를 ground truth와 대조.
+
+## 지표 + go/no-go 임계
+| 지표 | GO 임계 |
+|---|---|
+| 정차(도착) recall | ≥ 90% (10역 중 miss ≤1) |
+| 정차 precision | ≥ 85% (false stop 적음) |
+| 검출 지연 median | ≤ 8s |
+| 출발 검출 recall(프롬프트 앵커) | ≥ 90% |
+| CMMotionActivity 지연 | 측정(>30s 예상 → H4 확증) |
+
+- **GO**: C1 or C2가 임계 충족 → 그 알고리즘을 #E/#J 기반으로 확정, 본구현 진행.
+- **PIVOT**: 무거운 튜닝/거치위치 한정으로만 충족 → barometer+accel consensus 추가, 지연 완화, 거치 가이드 등 조정 후 재spike.
+- **KILL**: 어떤 후보도 recall 90% 미달 → motion-gate 불신뢰 → ADR-032가 **backend plan ETA + arvlCd에 더 의존**(drift 일부 수용)하도록 재설계, 또는 device-fire 방향 재검토.
+
+## 라이드 매트릭스 (N≥5, 이상적 8)
+| 조건 | 목적 |
+|---|---|
+| 지하 노선(7호선) | 지하 무GPS 핵심 |
+| 지상/고가(2호선 지상 구간) | GPS ground-truth 대조 |
+| 환승 라이드(7→2) | leg 경계 검출 |
+| 급행+완행(9호선) | 급행 skip 패턴(W2 참고데이터) |
+| 거치: 주머니/손/가방 각 ≥2 | H3 |
+
+> N≥5는 `lesson_n1_root_cause_bias` 최소선. 조건별 최소 1, 지하는 ≥2.
+
+## 빌드 범위 (최소·throwaway)
+- DebugModal에 **"SPIKE 로깅 시작/종료" + "MARK 도착/출발"** 버튼. DeviceMotion@20Hz + 기존 snapshot을 in-memory ring에 적재 → 종료 시 `/signals/dump`(RAW_SIGNALS) 또는 파일 export. 기존 `rawSignalBuffer`/observability 덤프 경로 재사용.
+- **오프라인 분석 스크립트**(JS 또는 Python notebook): export 로그 → C1/C2/C3 실행 → 지표 산출.
+- 프로덕션 배선 X, coverage 테스트 X (spike 브랜치, dev 미머지).
+
+## 산출물
+- 조건별 recall/precision/latency 표 + go/no-go 판정 + (GO 시) 확정 검출 알고리즘 파라미터(θ, T, window).
+
+## 페어 spike (#0b, 별개 실패모드)
+**#0는 "신호가 존재하나"(FG). "iOS가 도착 순간 BG로 앱을 깨워 그 신호를 잡나"(숙제1)는 별도 #0b**: BG location task cadence 로깅 → 정차 순간 tick 발생률 측정. #0 GO여도 #0b 실패면 발사 못 함 → 둘 다 통과해야 척추 확정. #0 먼저(더 쌈), GO면 #0b.
+
+## 효과 추정
+로거 ~0.5d + N회 라이드(실통근 passive) + 분석 ~0.5d.

--- a/tasks/spike-2026-08-10-accel-train-fingerprint.md
+++ b/tasks/spike-2026-08-10-accel-train-fingerprint.md
@@ -50,27 +50,39 @@ ADR-032의 두 transport 잔여(연결 창 / 지연 drift) 해결이 전부 **"m
 - **PIVOT**: 무거운 튜닝/거치위치 한정으로만 충족 → barometer+accel consensus 추가, 지연 완화, 거치 가이드 등 조정 후 재spike.
 - **KILL**: 어떤 후보도 recall 90% 미달 → motion-gate 불신뢰 → ADR-032가 **backend plan ETA + arvlCd에 더 의존**(drift 일부 수용)하도록 재설계, 또는 device-fire 방향 재검토.
 
-## 라이드 매트릭스 (N≥5, 이상적 8)
-| 조건 | 목적 |
-|---|---|
-| 지하 노선(7호선) | 지하 무GPS 핵심 |
-| 지상/고가(2호선 지상 구간) | GPS ground-truth 대조 |
-| 환승 라이드(7→2) | leg 경계 검출 |
-| 급행+완행(9호선) | 급행 skip 패턴(W2 참고데이터) |
-| 거치: 주머니/손/가방 각 ≥2 | H3 |
+## 실탑승 최소화 — 캡처 1회 → fixture → CI replay (재설계 2026-08-10)
 
-> N≥5는 `lesson_n1_root_cause_bias` 최소선. 조건별 최소 1, 지하는 ≥2.
+**원칙**: raw accel 신호 품질(물리)과 iOS BG 웨이크(OS)는 실기기서만 관측된다 → **실탑승 0은 불가능**. 하지만 **한 번 캡처하면 fixture가 되어 이후 전부 CI replay**(`lesson_fixture_replay_verification_infrastructure` 패러다임). 그래서 "N≥5 반복 탑승"이 아니라 **"대표 캡처 1~2회 → fixture 심고 → 나머지는 CI"**.
 
-## 빌드 범위 (최소·throwaway)
-- DebugModal에 **"SPIKE 로깅 시작/종료" + "MARK 도착/출발"** 버튼. DeviceMotion@20Hz + 기존 snapshot을 in-memory ring에 적재 → 종료 시 `/signals/dump`(RAW_SIGNALS) 또는 파일 export. 기존 `rawSignalBuffer`/observability 덤프 경로 재사용.
-- **오프라인 분석 스크립트**(JS 또는 Python notebook): export 로그 → C1/C2/C3 실행 → 지표 산출.
-- 프로덕션 배선 X, coverage 테스트 X (spike 브랜치, dev 미머지).
+### CI/시나리오가 대체 가능 ✅ (탑승 불필요)
+- **검출 알고리즘 정확도** — 캡처한 fixture를 C1/C2/C3에 replay → recall/precision/latency. 반복·회귀·파라미터 스윕 전부 CI.
+- **로직·배선** — 탑승이벤트→프롬프트→forward(#C~#F) 결정 로직은 mock/시나리오로 검증.
+- **파라미터 튜닝** — θ/T/window 그리드 스윕을 fixture 위에서 자동 탐색(analyzer `--sweep`).
+
+### CI가 대체 **불가** ❌ (실기기 캡처 불가결, 최초 1회)
+1. 실제 지하철 accel이 **검출 가능한 패턴을 담고 있나**(물리) — 합성 selftest 통과 ≠ 실신호 보장.
+2. **iOS BG 웨이크(#0b)** — 시뮬레이터가 BG 스케줄링/신호상실/모션웨이크 재현 못 함.
+
+### 캡처 계획 (최소)
+| 캡처 | 조건 | 목적 | 방식 |
+|---|---|---|---|
+| **1 (필수)** | 지하 노선 + 환승 1회(예: 7→2), 거치 주머니 | 핵심 신호 존재 + leg 경계 | 실탑승 로거+MARK |
+| 2 (권장) | 급행 포함 노선, 거치 손/가방 | 급행 skip + 거치 robust 대조 | 실탑승 로거+MARK |
+| CI (탑승 X) | 위 fixture로 조건 파생(노이즈 주입/리샘플/거치각 회전) + 파라미터 스윕 | H1·H2·H3 커버리지 확장 | replay |
+
+> 즉 **실탑승은 1~2회로 축소**. N≥5 커버리지는 fixture augmentation + CI로 확보. 원래 `lesson_n1_root_cause_bias`의 N≥5는 "실탑승 5회"가 아니라 "검증 조건 5개" — CI replay로 충족 가능.
+
+## 빌드 범위
+- **[캡처 도구] DebugModal SPIKE 로거** — DeviceMotion@20Hz + 기존 snapshot + MARK 버튼 → JSONL export. (BG-B에서 구현, PR #2272)
+- **[replay 하네스] 분석 스크립트** `tools/spike/analyzeAccelFingerprint.mjs` — fixture → C1/C2/C3 지표 + go/no-go. `--selftest` + **`--sweep`(파라미터 그리드)** 추가. (BG-C 기반, PR #2271)
+- **[CI 회귀] fixture replay 테스트** — 캡처 fixture를 리포에 커밋(정제·익명화) → 분석기가 임계(recall≥90% 등)를 assert하는 CI job. 이후 알고리즘 변경 회귀 방어. ← **캡처 후 추가**.
+- 프로덕션 배선 X (로거/분석은 spike 성격, dev 미머지). CI replay 테스트만 dev 머지 대상.
 
 ## 산출물
-- 조건별 recall/precision/latency 표 + go/no-go 판정 + (GO 시) 확정 검출 알고리즘 파라미터(θ, T, window).
+- fixture(캡처 JSONL) + 조건별 recall/precision/latency 표 + go/no-go 판정 + (GO 시) 스윕으로 확정한 파라미터(θ, T, window) + CI replay job.
 
-## 페어 spike (#0b, 별개 실패모드)
-**#0는 "신호가 존재하나"(FG). "iOS가 도착 순간 BG로 앱을 깨워 그 신호를 잡나"(숙제1)는 별도 #0b**: BG location task cadence 로깅 → 정차 순간 tick 발생률 측정. #0 GO여도 #0b 실패면 발사 못 함 → 둘 다 통과해야 척추 확정. #0 먼저(더 쌈), GO면 #0b.
+## 페어 spike (#0b, 별개 실패모드 — 유일하게 CI 불가)
+**#0는 "신호가 존재하나". #0b는 "iOS가 도착 순간 BG로 앱을 깨우나"(숙제1)** — BG location task cadence 로깅 → 정차 순간 tick 발생률. **CI로 절대 대체 불가**(OS 런타임) → 실기기 필수. #0 GO 후 진행(캡처 1과 함께 묶어 라이드 1회로 병합 가능하면 병합).
 
 ## 효과 추정
-로거 ~0.5d + N회 라이드(실통근 passive) + 분석 ~0.5d.
+로거✅ + 분석기✅(스윕 추가 ~0.3d) + **실탑승 1~2회**(원래 N≥5 → 축소) + CI replay job ~0.3d. 실탑승 부담이 핵심 감소분.


### PR DESCRIPTION
## Summary

2026-08-10 오전 실탑승 RCA(환승 후 2호선 무보호 + 매역 1홉 lag)에서 도출한 설계 문서 3건. **코드 변경 없음.**

- `docs/decisions/ADR-032-device-primary-emitter-boarding-loop.md` — fire emitter를 backend 단일(ADR-026) → **device primary + backend safetyNet backstop**으로 개정. BG 환승 swap이 새 lock을 silent push로만 hydrate하는데 silent push가 구조적으로 죽어있어(ADR-031) lock이 영영 안 생기는 pinned root cause 분석 + 분업 설계(backend=위치 추적/plan 산출, device=발사/보정).
- `tasks/plan-2026-08-10-device-boarding-emitter.md` — 위 ADR의 구현 plan. 약점 5개(W1~W5) adversarial 대응, acceptance(V1~V5/X1~X2), Wire Matrix, 이슈 분해(#0 spike + #A~#J).
- `tasks/spike-2026-08-10-accel-train-fingerprint.md` — 설계의 단일 급소(가속도계 motion-gated 발사 신뢰성)를 실기기로 검증하는 throwaway spike 설계. go/no-go 임계(정차 recall≥90%/precision≥85%/지연≤8s) + 라이드 매트릭스.

## Test plan

- [x] 문서 전용 변경 — type-check/test 영향 없음
- [x] 코드 diff 0 (docs/, tasks/ 만 변경)