### PR TITLE
feat(#2268): 탑승 이벤트 primitive 순수 함수

### DIFF
--- a/src/features/route/utils/__tests__/boardingEvents.test.ts
+++ b/src/features/route/utils/__tests__/boardingEvents.test.ts
@@ -1,0 +1,219 @@
+import { computeBoardingEvents } from '../boardingEvents';
+import { getStationsOnLine } from '../../../../shared/utils/stationRoute';
+import type { LineNumber, Station } from '../../../../shared/types/station';
+import {
+  makeDirectRoute,
+  makeMultiTransferRoute,
+  makeTransferRoute,
+} from '../../../../testUtils/routeFixtures';
+
+function stationById(line: LineNumber, id: string): Station {
+  const found = getStationsOnLine(line).find((s) => s.id === id);
+  if (!found) throw new Error(`fixture station missing: ${id}`);
+  return found;
+}
+
+describe('computeBoardingEvents', () => {
+  it('direct route → initial 이벤트 1개', () => {
+    const origin = stationById('1', '1-001'); // 소요산
+    const route = makeDirectRoute(4, '1');
+
+    const events = computeBoardingEvents(route, origin, '지행');
+
+    expect(events).toEqual([
+      {
+        index: 0,
+        kind: 'initial',
+        boardingStationId: '1-001',
+        boardingStationName: '소요산',
+        line: '1',
+        directionStationId: '1-002',
+        directionStationName: '동두천',
+      },
+    ]);
+  });
+
+  it('direct route: 출발역이 목적지 바로 다음 정거장(1정거장)이어도 방향 산출', () => {
+    const origin = stationById('1', '1-001'); // 소요산
+    const route = makeDirectRoute(1, '1');
+
+    const events = computeBoardingEvents(route, origin, '동두천');
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      kind: 'initial',
+      boardingStationId: '1-001',
+      directionStationId: '1-002',
+      directionStationName: '동두천',
+    });
+  });
+
+  it('transfer route(환승 1회) → initial(fromLine) + transfer(toLine) 2개', () => {
+    const origin = stationById('1', '1-038'); // 대방
+    const route = makeTransferRoute({
+      transferName: '신도림',
+      fromLine: '1',
+      toLine: '2',
+      stopsToTransfer: 3,
+      stopsFromTransfer: 1,
+    });
+
+    const events = computeBoardingEvents(route, origin, '문래');
+
+    expect(events).toEqual([
+      {
+        index: 0,
+        kind: 'initial',
+        boardingStationId: '1-038',
+        boardingStationName: '대방',
+        line: '1',
+        directionStationId: '1-039',
+        directionStationName: '신길',
+      },
+      {
+        index: 1,
+        kind: 'transfer',
+        boardingStationId: '2-034',
+        boardingStationName: '신도림',
+        line: '2',
+        directionStationId: '2-035',
+        directionStationName: '문래',
+      },
+    ]);
+  });
+
+  it('transfer route: 환승역=목적지(0정거장 leg)여도 transfer 이벤트는 unconditional 생성 — direction은 목적지 자신', () => {
+    const origin = stationById('1', '1-038'); // 대방
+    const route = makeTransferRoute({
+      transferName: '신도림',
+      fromLine: '1',
+      toLine: '2',
+      stopsToTransfer: 3,
+      stopsFromTransfer: 0,
+    });
+
+    const events = computeBoardingEvents(route, origin, '신도림');
+
+    expect(events).toHaveLength(2);
+    expect(events[1]).toEqual({
+      index: 1,
+      kind: 'transfer',
+      boardingStationId: '2-034',
+      boardingStationName: '신도림',
+      line: '2',
+      directionStationId: '2-034',
+      directionStationName: '신도림',
+    });
+  });
+
+  it('multi-transfer route(환승 2회) → initial + transfer 2개 = 총 3개, transfers 배열 순회로 생성', () => {
+    const origin = stationById('1', '1-039'); // 신길
+    const route = makeMultiTransferRoute({
+      transfers: [
+        { transferName: '신도림', fromLine: '1', toLine: '2', stopsToTransfer: 2 },
+        { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 11 },
+      ],
+      stopsAfterLastTransfer: 1,
+    });
+
+    const events = computeBoardingEvents(route, origin, '남부터미널(예술의전당)');
+
+    expect(events).toEqual([
+      {
+        index: 0,
+        kind: 'initial',
+        boardingStationId: '1-039',
+        boardingStationName: '신길',
+        line: '1',
+        directionStationId: '1-040',
+        directionStationName: '영등포',
+      },
+      {
+        index: 1,
+        kind: 'transfer',
+        boardingStationId: '2-034',
+        boardingStationName: '신도림',
+        line: '2',
+        directionStationId: '2-033',
+        directionStationName: '대림(구로구청)',
+      },
+      {
+        index: 2,
+        kind: 'transfer',
+        boardingStationId: '3-032',
+        boardingStationName: '교대',
+        line: '3',
+        directionStationId: '3-033',
+        directionStationName: '남부터미널(예술의전당)',
+      },
+    ]);
+  });
+
+  it('multi-transfer route: transfers 길이가 늘어나도 하드코딩 분기 없이 이벤트 수가 그만큼 늘어난다 (환승 3회)', () => {
+    const origin = stationById('1', '1-001'); // 소요산
+    const route = makeMultiTransferRoute({
+      transfers: [
+        { transferName: '신도림', fromLine: '1', toLine: '2', stopsToTransfer: 40 },
+        { transferName: '교대', fromLine: '2', toLine: '3', stopsToTransfer: 11 },
+        { transferName: '양재(서초구청)', fromLine: '3', toLine: '3', stopsToTransfer: 2 },
+      ],
+      stopsAfterLastTransfer: 1,
+    });
+
+    const events = computeBoardingEvents(route, origin, '매봉');
+
+    expect(events).toHaveLength(4);
+    expect(events.map((e) => e.kind)).toEqual(['initial', 'transfer', 'transfer', 'transfer']);
+    expect(events.map((e) => e.index)).toEqual([0, 1, 2, 3]);
+  });
+
+  it('목적지명이 해당 노선에 존재하지 않으면(malformed 입력) directionStation은 boardingStationId로 fallback', () => {
+    const origin = stationById('1', '1-001'); // 소요산
+    const route = makeDirectRoute(4, '1');
+
+    const events = computeBoardingEvents(route, origin, '존재하지않는역');
+
+    expect(events[0]).toMatchObject({
+      boardingStationId: '1-001',
+      directionStationId: '1-001',
+      directionStationName: '존재하지않는역',
+    });
+  });
+
+  it('환승역명이 toLine에 존재하지 않으면(malformed route) boardingStationId는 빈 문자열로 fallback', () => {
+    const origin = stationById('1', '1-038'); // 대방
+    const route = makeTransferRoute({
+      transferName: '소요산', // 1호선 역명 — 2호선(toLine)에는 존재하지 않는다.
+      fromLine: '1',
+      toLine: '2',
+      stopsToTransfer: 3,
+      stopsFromTransfer: 1,
+    });
+
+    const events = computeBoardingEvents(route, origin, '문래');
+
+    expect(events[1]).toMatchObject({
+      kind: 'transfer',
+      boardingStationId: '',
+      boardingStationName: '소요산',
+      line: '2',
+    });
+  });
+
+  it('환승역 표기가 노선별로 다른 경우에도 findStationByNameAndLine 정규화로 boardingStationId를 해석한다', () => {
+    const origin = stationById('7', '7-012'); // 상봉(시외버스터미널)
+    const route = makeTransferRoute({
+      transferName: '상봉',
+      fromLine: '7',
+      toLine: 'gyeongui',
+      stopsToTransfer: 3,
+      stopsFromTransfer: 2,
+    });
+
+    const events = computeBoardingEvents(route, origin, '망우');
+
+    expect(events[1].boardingStationName).toBe('상봉');
+    expect(events[1].line).toBe('gyeongui');
+    expect(events[1].boardingStationId).not.toBe('');
+  });
+});

--- a/src/features/route/utils/boardingEvents.ts
+++ b/src/features/route/utils/boardingEvents.ts
@@ -1,0 +1,106 @@
+/**
+ * 탑승 이벤트 primitive (ADR-032 #B).
+ *
+ * route = (역S, 노선L, 방향→목적지) 탑승 이벤트의 시퀀스라는 설계를 순수 함수로 구현한다.
+ * 처음 탑승 + 환승마다 하나씩 이벤트를 만든다. 순수 함수 — side effect/store 접근 없음.
+ * 소비자(device emitter 루프, #C~#E)는 이 파일이 아니라 별도 이슈에서 배선한다.
+ */
+
+import type { LineNumber, Station } from '../../../shared/types/station';
+import type { Route } from '../../../shared/utils/stationRoute';
+import { findStationByNameAndLine, getNextStationOnLine } from '../../../shared/utils/stationRoute';
+
+export interface BoardingEvent {
+  /** 0부터 시작하는 순서. */
+  index: number;
+  kind: 'initial' | 'transfer';
+  /** 타는 역. */
+  boardingStationId: string;
+  boardingStationName: string;
+  /** 타는 노선. */
+  line: LineNumber;
+  /** 이 leg에서 목적지 방향 "다음 역"(arvlCd 방향필터용). */
+  directionStationId: string;
+  directionStationName: string;
+}
+
+// leg = 한 번의 탑승(초행 or 환승 직후)부터 다음 waypoint(다음 환승역 또는 최종 목적지)까지의 구간.
+interface Leg {
+  kind: BoardingEvent['kind'];
+  boardingStationId: string;
+  boardingStationName: string;
+  line: LineNumber;
+  /** 이 leg의 종점(다음 환승역 이름 또는 최종 목적지 이름). */
+  targetName: string;
+}
+
+function legToEvent(leg: Leg, index: number): BoardingEvent {
+  const { kind, boardingStationId, boardingStationName, line, targetName } = leg;
+  // 같은 역(0정거장 leg, 예: 환승역=목적지)이면 다음 역이 없으므로 targetName 자체를 방향으로 사용.
+  const directionStationName = getNextStationOnLine(line, boardingStationName, targetName) ?? targetName;
+  const directionStation = findStationByNameAndLine(directionStationName, line);
+  return {
+    index,
+    kind,
+    boardingStationId,
+    boardingStationName,
+    line,
+    directionStationId: directionStation?.id ?? boardingStationId,
+    directionStationName,
+  };
+}
+
+function transferLeg(transferName: string, boardingLine: LineNumber, targetName: string): Leg {
+  const boardingStation = findStationByNameAndLine(transferName, boardingLine);
+  return {
+    kind: 'transfer',
+    boardingStationId: boardingStation?.id ?? '',
+    boardingStationName: transferName,
+    line: boardingLine,
+    targetName,
+  };
+}
+
+/**
+ * route를 탑승 이벤트 시퀀스로 분해한다.
+ *
+ * - direct → initial 1개(출발역, route.line, 목적지 방향)
+ * - transfer → initial(출발역, fromLine) + transfer(환승역, toLine)
+ * - multi-transfer → initial + transfers[] 순회로 transfer 이벤트 N개(환승 횟수 하드코딩 없음)
+ */
+export function computeBoardingEvents(
+  route: NonNullable<Route>,
+  originStation: Station,
+  destinationName: string,
+): BoardingEvent[] {
+  const initialLeg: Leg = {
+    kind: 'initial',
+    boardingStationId: originStation.id,
+    boardingStationName: originStation.name,
+    line: route.type === 'direct' ? route.line : route.type === 'transfer' ? route.fromLine : route.transfers[0].fromLine,
+    targetName:
+      route.type === 'direct'
+        ? destinationName
+        : route.type === 'transfer'
+          ? route.transferName
+          : route.transfers[0].transferName,
+  };
+
+  if (route.type === 'direct') {
+    return [legToEvent(initialLeg, 0)];
+  }
+
+  if (route.type === 'transfer') {
+    const legs: Leg[] = [initialLeg, transferLeg(route.transferName, route.toLine, destinationName)];
+    return legs.map(legToEvent);
+  }
+
+  // multi-transfer: transfers 배열을 순회해 환승 이벤트를 만든다.
+  const { transfers } = route;
+  const transferLegs = transfers.map((segment, i) => {
+    const nextTargetName = i + 1 < transfers.length ? transfers[i + 1].transferName : destinationName;
+    return transferLeg(segment.transferName, segment.toLine, nextTargetName);
+  });
+
+  return [initialLeg, ...transferLegs].map(legToEvent);
+}

--- a/src/features/route/utils/boardingEvents.ts
+++ b/src/features/route/utils/boardingEvents.ts
@@ -92,7 +92,7 @@ export function computeBoardingEvents(
 
   if (route.type === 'transfer') {
     const legs: Leg[] = [initialLeg, transferLeg(route.transferName, route.toLine, destinationName)];
-    return legs.map(legToEvent);
+    return legs.map((leg, i) => legToEvent(leg, i));
   }
 
   // multi-transfer: transfers 배열을 순회해 환승 이벤트를 만든다.
@@ -102,5 +102,5 @@ export function computeBoardingEvents(
     return transferLeg(segment.transferName, segment.toLine, nextTargetName);
   });
 
-  return [initialLeg, ...transferLegs].map(legToEvent);
+  return [initialLeg, ...transferLegs].map((leg, i) => legToEvent(leg, i));
 }


### PR DESCRIPTION
## Summary
ADR-032 #B — route를 **탑승 이벤트 시퀀스**로 분해하는 순수 함수 + 타입 + 테스트. 후속 device emitter 루프(#C~#E)가 소비할 foundational 데이터 구조.

- `src/features/route/utils/boardingEvents.ts` (신규): `computeBoardingEvents(route, originStation, destinationName) → BoardingEvent[]`
- `BoardingEvent`: `{ index, kind: 'initial' | 'transfer', boardingStationId, boardingStationName, line, directionStationId, directionStationName }`
- 규칙:
  - `direct` → `initial` 1개 (출발역, route.line)
  - `transfer` → `initial`(출발역, fromLine) + `transfer`(환승역, toLine) — unconditional 2개 (환승역=목적지인 0정거장 leg여도 collapse하지 않음, `routeToWaypoints`와 다른 점)
  - `multi-transfer` → `initial` + `route.transfers` 배열 순회로 transfer 이벤트 N개 (환승 횟수 하드코딩 없음)
  - `directionStation` = 각 leg의 경계(다음 환승역 또는 최종 목적지) 방향으로 `getNextStationOnLine` 산출. 0정거장 leg(같은 역)면 target 자신으로 fallback.
- 기존 유틸 재사용: `findStationByNameAndLine`, `getNextStationOnLine` (`shared/utils/stationRoute.ts`) — 신규 노선/역 lookup 로직 없음.
- 순수 함수 — side effect/store 접근 없음.

## 왜 orphan-gated 머지가 아닌가
**이번 PR은 primitive만 추가한다.** `computeBoardingEvents`를 호출하는 알람/emitter 소비자 코드는 이 PR 범위 밖(스펙 지시 — "이번 PR은 순수 primitive만, 알람/발사/backend 배선은 하지 마라"). `npm run lint:orphan`은 로컬에서 orphan 0건으로 통과했지만(현재 스크립트가 이 export 패턴을 아직 못 잡을 수 있음), 실제 caller는 #C(device emitter 루프)에서 추가된다. 머지 순서는 #C와 함께 진행하거나, 필요 시 ignore-pattern을 그때 갱신한다 — 본 PR에서는 손대지 않았다.

## Wire-completion 5단
1. **Orphan** — `npm run lint:orphan` 로컬 pass (0 orphan). 소비자는 #C에서 배선.
2. **V/X dashboard** — N/A. 순수 함수 primitive, 아직 관측 가능한 signal 없음 (소비자 배선 후 해당).
3. **의존 PR** — N/A. 본 PR 자체로 type-check + unit 완결.
4. **측정 plan** — N/A. 소비자(#C) 배선 후 해당 이슈에서 측정 plan 명시.
5. **Device verify** — N/A — type+unit only. 순수 함수, side effect 없음.

## Test plan
- [x] `npm run type-check` pass
- [x] `npm test` — 435 suites / 9310 tests pass, coverage 100% (신규 파일 100% lines/branches/functions/statements)
- [x] `npx eslint` clean
- [x] direct / transfer / multi-transfer(환승 2회, 3회) 커버
- [x] edge: 0정거장 leg(환승역=목적지), malformed input(존재하지 않는 역명 — direction/boardingId fallback), 노선별 표기 다른 환승역(정규화)