### PR TITLE
fix(#2268): DebugModal 진단 덤프 신뢰성 수리 (S1+S2, C1, C2)

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
+  Alert,
   AppState,
   Modal,
   Pressable,
@@ -12,6 +13,7 @@ import {
 } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { createLogger } from '../../../shared/utils/logger';
 import { useSettingsStore } from '../../settings/store/useSettingsStore';
 import { useDestinationStore } from '../../route/store/useDestinationStore';
 import { ROUTE_KEY } from '../../../shared/constants/storageKeys';
@@ -259,6 +261,12 @@ export interface AutoLockDebugMeta {
 }
 
 const UNKNOWN_LABEL = '—';
+
+/**
+ * #2268 (S1+S2) — Share dump 실패 관측용 logger. `handleShare`의 성공/실패 + 총 길이를
+ * 기록해 무음 실패(void Share.share만 호출하던 이전 구현)를 방지한다.
+ */
+const shareLog = createLogger('debugModalShare');
 
 /**
  * #1881 — DebugLogSection UI 표시 기본 cap. buffer 전체(최대 300~500)를 한 번에 렌더하면
@@ -2228,7 +2236,7 @@ function DebugModalInner({
   // fusedSpeed prop을 null로 정규화해 buildGpsRows/buildDumpText 양쪽에서 동일 분기 사용.
   const fusedSpeedSignal: FusedSpeedSignal | null = fusedSpeed ?? null;
 
-  const handleShare = useCallback(() => {
+  const handleShare = useCallback(async () => {
     const message = buildDumpText({
       userLocation,
       speedMps,
@@ -2304,7 +2312,23 @@ function DebugModalInner({
       // Fusion Tier (1h) — Modal render 와 동일 별 ring buffer(alarmLog 점령 회귀 차단).
       fusionTierLog: fusionTierLogs,
     });
-    void Share.share({ message });
+    // #2268 (S1+S2) — 이전엔 `void Share.share(...)`로 실패가 완전 무음이었다(catch 없음).
+    // Share 시트를 뜨는 순간 취소돼도 reject 하는 OS 조합이 있어 사용자가 "왜 안 되지"만
+    // 겪고 재시도 방법을 몰랐다. 길이를 항상 로그로 남기고, 실패 시 Alert로 안내한다.
+    // Clipboard fallback: expo-clipboard 등 클립보드 패키지가 프로젝트에 설치돼 있지 않아
+    // (package.json 확인 완료) 자동 클립보드 복사는 도입하지 않았다 — Alert가 실패/길이
+    // 안내를 대신한다(PR 본문에 결정 명시).
+    shareLog.info(`dump length=${message.length} chars`);
+    try {
+      await Share.share({ message });
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      shareLog.error(`share failed: ${reason}`);
+      Alert.alert(
+        '공유 실패',
+        `진단 덤프 공유에 실패했습니다 (길이 ${message.length}자).\n다시 시도하거나 잠시 후 재시도해 주세요.\n\n오류: ${reason}`,
+      );
+    }
   }, [
     userLocation,
     speedMps,

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -269,6 +269,13 @@ const UNKNOWN_LABEL = '—';
 const shareLog = createLogger('debugModalShare');
 
 /**
+ * #2268 (C2) — DebugModal이 최초 로드된 시각. `app/_layout.tsx`가 static import하므로
+ * 사실상 앱 launch 시각의 근사치로 쓸 수 있다. 앱 kill/BG 재기동 시 모듈이 새로
+ * 로드되며 값도 리셋 — Lifecycle/Drift 버퍼 age 계산의 기준점(C2).
+ */
+const DEBUG_MODAL_LOAD_AT_MS = Date.now();
+
+/**
  * #1881 — DebugLogSection UI 표시 기본 cap. buffer 전체(최대 300~500)를 한 번에 렌더하면
  * ScrollView 성능 저하. 100건이면 약 50분 분량 — 진단에 충분하고 UI 스크롤 부담도 적다.
  * "더 보기" 버튼 탭 시 expanded state로 전환해 buffer 전체 표시.
@@ -641,6 +648,13 @@ interface BuildDumpArgs {
    * 미전달 시 `Date.now()` 사용. 테스트에서 결정적 출력 확보용.
    */
   nowMs?: number;
+  /**
+   * #2268 (C2) — DebugModal 모듈이 로드된 시각(≈ 앱 launch). 미전달 시
+   * `DEBUG_MODAL_LOAD_AT_MS`(모듈 상수) 사용 — 테스트에서 결정적 출력 확보용.
+   * Lifecycle/Drift 버퍼는 in-memory라 앱 kill/BG 재기동 시 리셋된다. 두 섹션이 (0)일 때
+   * "이벤트 없음"과 "재기동으로 증발"을 구분할 수 없는 문제(C2)를 이 값 기준 age 표기로 완화한다.
+   */
+  launchAtMs?: number;
   /**
    * #1421 — Auto-lock Candidate 측정 스냅샷. 미전달 시 섹션은 (n/a) 표기.
    * DebugModalInner가 매 render에서 useFusedNearestStation SSOT + stability buffer + direction을
@@ -1210,6 +1224,18 @@ function formatBoardingLockDriftLine(entry: BoardingLockDriftEntry): string {
   return `${time} | boarding-lock-drift:${entry.branch} | ${entry.lockStationName}(${entry.lockStationLine}) drift=${d}`;
 }
 
+/**
+ * #2268 (C2) — Lifecycle/Drift ring buffer가 in-memory 비영속이라 (0)이 "이벤트 없음"인지
+ * "앱 kill/BG 재기동으로 증발"인지 dump만으로 구분 불가능했다. launch 이후 경과 초를 헤더
+ * suffix로 노출해, "(0) + age 짧음"과 "(0) + age 김"을 사용자가 판정할 수 있게 한다.
+ */
+function formatBufferAgeSuffix(args: BuildDumpArgs): string {
+  const now = args.nowMs ?? Date.now();
+  const launchAtMs = args.launchAtMs ?? DEBUG_MODAL_LOAD_AT_MS;
+  const ageSec = Math.max(0, Math.round((now - launchAtMs) / 1000));
+  return ` (buffer age since launch = ${ageSec}s)`;
+}
+
 function buildBoardingLockDriftLogSection(args: BuildDumpArgs): string[] {
   const entries = args.boardingLockDriftLog ?? [];
   if (entries.length === 0) return ['(empty)'];
@@ -1703,16 +1729,18 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
     suffix: (args) => ` (${args.candidateRejectLog?.length ?? 0})`,
   },
   // #1896 (RC-8) — boarding-lock-drift 별 buffer (GPS displacement gate trigger). fusionDebugBuffer 점령 회귀 차단.
+  // #2268 (C2) — buffer age suffix 추가: (0)이 "이벤트 없음"인지 "재기동 증발"인지 구분.
   {
     title: 'Boarding-Lock Drift',
     build: buildBoardingLockDriftLogSection,
-    suffix: (args) => ` (${args.boardingLockDriftLog?.length ?? 0})`,
+    suffix: (args) => ` (${args.boardingLockDriftLog?.length ?? 0})${formatBufferAgeSuffix(args)}`,
   },
   // #2152 — BoardingLock lifecycle 별 buffer (생성 source / 해제 reason / trainCode).
+  // #2268 (C2) — buffer age suffix 추가.
   {
     title: 'BoardingLock Lifecycle',
     build: buildLockLifecycleSection,
-    suffix: (args) => ` (${args.lockLifecycleLog?.length ?? 0})`,
+    suffix: (args) => ` (${args.lockLifecycleLog?.length ?? 0})${formatBufferAgeSuffix(args)}`,
   },
   // #1518 — device → backend HTTP 호출 ring buffer. 직전 trip의 register/sync/telemetry 호출
   // 흔적이 dump만 보고 재구성 가능해야 #622 transfer-leg sync 같은 회귀 진단이 가능하다.
@@ -1858,6 +1886,11 @@ function DebugModalInner({
   // #458: RN Modal 안에서는 SafeAreaView가 안 먹는다(portal로 inset 컨텍스트 분리).
   // 루트 SafeAreaProvider의 insets를 hook으로 직접 받아 헤더에 manual padding.
   const insets = useSafeAreaInsets();
+  // #2268 (C2) — Lifecycle/Drift 섹션 헤더에 표시할 launch 이후 경과 초. render마다 재계산.
+  const debugModalBufferAgeSec = Math.max(
+    0,
+    Math.round((Date.now() - DEBUG_MODAL_LOAD_AT_MS) / 1000),
+  );
   // #1982 (ADR-022 Phase 0) — arrival-api-ssot-v1 Feature Flag remote 조회.
   // ADMIN_TOKEN / ALARM_BACKEND_URL 미설정 환경은 kind=unconfigured 로 그대로 표시.
   const archFlagRemote = useArchFlagRemote();
@@ -2744,8 +2777,10 @@ function DebugModalInner({
           />
 
           {/* #2049 (#1896 RC-8) — boarding-lock-drift 별 buffer. candidate-reject와 동일 표시 패턴. */}
+          {/* #2268 (C2) — 헤더에 launch 이후 경과 초를 표시해 (0)이 "이벤트 없음"인지
+              "앱 재기동으로 버퍼 증발"인지 판정 가능하게 한다. */}
           <DebugLogSection
-            title="Boarding-Lock Drift"
+            title={`Boarding-Lock Drift (buffer age since launch = ${debugModalBufferAgeSec}s)`}
             logs={boardingLockDriftLog}
             formatLine={formatBoardingLockDriftLine}
             onClear={() => {
@@ -2758,8 +2793,9 @@ function DebugModalInner({
           />
 
           {/* #2152 — BoardingLock lifecycle(생성 source / 해제 reason) 별 buffer. drift와 동일 표시 패턴. */}
+          {/* #2268 (C2) — 헤더에 launch 이후 경과 초를 표시(위 Drift 섹션과 동일 근거). */}
           <DebugLogSection
-            title="BoardingLock Lifecycle"
+            title={`BoardingLock Lifecycle (buffer age since launch = ${debugModalBufferAgeSec}s)`}
             logs={lockLifecycleLog}
             formatLine={formatLockLifecycleLine}
             onClear={() => {
@@ -3684,6 +3720,9 @@ export const __test__ = {
   computeAutoLockLines,
   computeEnvironmentDistributionLines,
   computeAlarmLogReasonsLines,
+  // #2268 (C2) — Lifecycle/Drift buffer age suffix. 단위 테스트에서 launchAtMs/nowMs 조합 검증.
+  formatBufferAgeSuffix,
+  DEBUG_MODAL_LOAD_AT_MS,
 };
 
 const styles = StyleSheet.create({

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -69,6 +69,9 @@ import {
   exportRecentDays,
 } from '../../../features/alarm/utils/boardingPromptMonitor';
 import { useBoardingLockStore } from '../../../features/alarm/store/useBoardingLockStore';
+// #2268 (C1) — pending→confirmed lock 정정 measurement infra(#1166). fired count 는
+// BoardingTrainList가 이미 기록하지만 DebugModal에 섹션이 없어 관측 불가했다.
+import { getLockCorrectionMetrics } from '../../alarm/utils/lockCorrectionMetrics';
 import {
   BOARDING_LOCK_EXPIRY_FACTOR,
   isBoardingLockExpired,
@@ -634,6 +637,12 @@ interface BuildDumpArgs {
   boardingLockDriftLog?: readonly BoardingLockDriftEntry[];
   /** #2152 — BoardingLock lifecycle(create/release) 별 buffer entries. 미전달/빈 배열은 (empty). */
   lockLifecycleLog?: readonly LockLifecycleEntry[];
+  /**
+   * #2268 (C1) — pending(A)→confirmed(B) lock 정정 counter(#1166). `BoardingTrainList`가
+   * `recordLockCorrection`으로 기록하지만 DebugModal에 섹션이 없어 dump로 관측 불가했다.
+   * 미전달 시 (n/a) 표기.
+   */
+  lockCorrection?: ReturnType<typeof getLockCorrectionMetrics>;
   /**
    * #1413 — BoardingLock 섹션 dump 입력. lock 활성/trainCode/boardingLine/expiresAt.
    * 미전달이면 lock=null과 동일(active=no)로 출력.
@@ -1262,6 +1271,25 @@ function buildLockLifecycleSection(args: BuildDumpArgs): string[] {
 }
 
 /**
+ * #2268 (C1) — Lock Correction 섹션. `getLockCorrectionMetrics()`(#1166)가 기록하는
+ * fired count / lastFiredAtMs를 dump/UI 양쪽에 노출. 미전달 시 (n/a) — 호출자가 metrics를
+ * 주입하지 않은 테스트 호환용.
+ *
+ * #2049 패턴을 따라 dump builder와 UI section이 이 helper를 공유한다.
+ */
+function computeLockCorrectionLines(
+  metrics: ReturnType<typeof getLockCorrectionMetrics> | undefined,
+): string[] {
+  if (!metrics) return ['(n/a)'];
+  const lastFiredLine = metrics.lastFiredAtMs === 0 ? '(never)' : formatTime(metrics.lastFiredAtMs);
+  return [`fired=${metrics.fired}`, `lastFiredAt=${lastFiredLine}`];
+}
+
+function buildLockCorrectionSection(args: BuildDumpArgs): string[] {
+  return computeLockCorrectionLines(args.lockCorrection);
+}
+
+/**
  * #1518 — Backend call ring buffer 1줄 포맷. call/response/error를 한 줄에 압축해
  * dump 분량을 줄인다. host 부분만 노출하고 path는 trim 안 함(진단 시 endpoint 식별).
  */
@@ -1685,6 +1713,8 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
   { title: 'Gates', build: buildGatesSection, omitIfEmpty: true },
   // #1413 — BoardingLock dump. lock vs lockless 구분이 dump 본문만으로 확인 가능해야 한다.
   { title: 'BoardingLock', build: buildBoardingLockSection },
+  // #2268 (C1) — pending→confirmed lock 정정 counter(#1166). BoardingLock 섹션 직후 배치.
+  { title: 'Lock Correction', build: buildLockCorrectionSection },
   // #1413 — Estimator buffer. lockless trip 진행도 사후 재구성용.
   {
     title: 'Estimator State',
@@ -2263,6 +2293,11 @@ function DebugModalInner({
     return `${upText}\n${downText}`;
   })();
 
+  // #2268 (C1) — pending→confirmed lock 정정 counter. lockCorrectionMetrics.ts는 순수
+  // module-level singleton getter라 render마다 직접 호출해도 안전(다른 render-time
+  // 스냅샷 산출 값들 — autoLockMeta/envDistribution — 과 동일 패턴).
+  const lockCorrectionMetrics = getLockCorrectionMetrics();
+
   const nearestDistanceM = result ? Math.round(result.distanceKm * 1000) : null;
   const variantNames = variants.map((v) => `${v.name}(${v.line})`);
 
@@ -2344,6 +2379,8 @@ function DebugModalInner({
       },
       // Fusion Tier (1h) — Modal render 와 동일 별 ring buffer(alarmLog 점령 회귀 차단).
       fusionTierLog: fusionTierLogs,
+      // #2268 (C1) — Lock Correction counter. Modal render와 동일 SSOT(getLockCorrectionMetrics).
+      lockCorrection: lockCorrectionMetrics,
     });
     // #2268 (S1+S2) — 이전엔 `void Share.share(...)`로 실패가 완전 무음이었다(catch 없음).
     // Share 시트를 뜨는 순간 취소돼도 reject 하는 OS 조합이 있어 사용자가 "왜 안 되지"만
@@ -2422,6 +2459,8 @@ function DebugModalInner({
     groundTruthResponses,
     // Fusion Tier (1h) — fusion picker tier 별 ring buffer 변경 시 dump 텍스트 자동 갱신.
     fusionTierLogs,
+    // #2268 (C1) — Lock Correction counter 변경 시 dump 텍스트 자동 갱신.
+    lockCorrectionMetrics,
   ]);
 
   return (
@@ -2719,6 +2758,10 @@ function DebugModalInner({
           </Section>
 
           <BoardingLockSection lock={lock} colors={colors} />
+
+          {/* #2268 (C1) — Lock Correction: pending→confirmed 정정 fired count / lastFiredAt.
+              buildLockCorrectionSection과 동일 SSOT (내부 helper 재사용). */}
+          <LockCorrectionSection metrics={lockCorrectionMetrics} colors={colors} />
 
           <DebugLogSection
             title="Estimator State"
@@ -3549,6 +3592,26 @@ function DumpTextSection({
 }
 
 /**
+ * #2268 (C1) — Lock Correction UI section. computeLockCorrectionLines helper를 dump builder와 공유.
+ */
+function LockCorrectionSection({
+  metrics,
+  colors,
+}: Readonly<{
+  metrics: ReturnType<typeof getLockCorrectionMetrics> | undefined;
+  colors: ReturnType<typeof useTheme>['colors'];
+}>) {
+  return (
+    <DumpTextSection
+      title="Lock Correction"
+      lines={computeLockCorrectionLines(metrics)}
+      entryTestId="debug-lock-correction"
+      colors={colors}
+    />
+  );
+}
+
+/**
  * #2049 (#1421) — Auto-lock Candidate UI section. computeAutoLockLines helper를 dump builder와 공유.
  */
 function AutoLockCandidateSection({
@@ -3723,6 +3786,9 @@ export const __test__ = {
   // #2268 (C2) — Lifecycle/Drift buffer age suffix. 단위 테스트에서 launchAtMs/nowMs 조합 검증.
   formatBufferAgeSuffix,
   DEBUG_MODAL_LOAD_AT_MS,
+  // #2268 (C1) — Lock Correction section builder/helper. 단위 테스트에서 직접 검증.
+  computeLockCorrectionLines,
+  buildLockCorrectionSection,
 };
 
 const styles = StyleSheet.create({

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -4944,6 +4944,48 @@ describe('DebugModal — #1501 Raw Signal 섹션', () => {
       expect(dump).toContain('## BoardingLock Lifecycle (0) (buffer age since launch = 5s)');
     });
 
+    // #2268 (C1) — getLockCorrectionMetrics()(#1166)는 BoardingTrainList가 기록하는데
+    // DebugModal에 섹션이 없어 관측 불가했다(orphan getter). 섹션 배선 검증.
+    it('computeLockCorrectionLines / buildLockCorrectionSection: n/a + fired/lastFiredAt 표기 (#2268)', () => {
+      const { computeLockCorrectionLines, buildLockCorrectionSection } = __test__;
+      expect(computeLockCorrectionLines(undefined)).toEqual(['(n/a)']);
+      expect(computeLockCorrectionLines({ fired: 0, lastFiredAtMs: 0 })).toEqual([
+        'fired=0',
+        'lastFiredAt=(never)',
+      ]);
+      const withTs = computeLockCorrectionLines({ fired: 3, lastFiredAtMs: 1_700_000_000_000 });
+      expect(withTs[0]).toBe('fired=3');
+      expect(withTs[1]).toMatch(/^lastFiredAt=\d{2}:\d{2}:\d{2}$/);
+      const built = buildLockCorrectionSection({
+        ...baselineDumpArgs,
+        lockCorrection: { fired: 2, lastFiredAtMs: 1000 },
+      });
+      expect(built[0]).toBe('fired=2');
+      expect(built[1]).toMatch(/^lastFiredAt=\d{2}:\d{2}:\d{2}$/);
+    });
+
+    it('Lock Correction 섹션이 share dump에 포함된다 (#2268)', () => {
+      const dump = buildDumpText(
+        makeDumpArgs({ lockCorrection: { fired: 5, lastFiredAtMs: 2000 } }),
+      );
+      expect(dump).toContain('## Lock Correction');
+      const section = dump.slice(dump.indexOf('## Lock Correction'));
+      expect(section).toContain('fired=5');
+      expect(section).toMatch(/lastFiredAt=\d{2}:\d{2}:\d{2}/);
+    });
+
+    it('Lock Correction 섹션이 UI에 노출된다 (#2268)', async () => {
+      const { getLockCorrectionMetrics, resetLockCorrectionMetrics, recordLockCorrection } =
+        jest.requireActual('../../../alarm/utils/lockCorrectionMetrics');
+      resetLockCorrectionMetrics();
+      recordLockCorrection('T-1', 'T-2');
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      expect(screen.getByText(/fired=1/)).toBeTruthy();
+      expect(getLockCorrectionMetrics().fired).toBe(1);
+      resetLockCorrectionMetrics();
+    });
+
     it('UI: 비어있으면 (0) 표시, push 시 entry 노출, Clear가 비운다', async () => {
       const {
         clearCandidateRejectEntries,

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -4923,6 +4923,27 @@ describe('DebugModal — #1501 Raw Signal 섹션', () => {
       expect(dump).toContain('## BoardingLock Lifecycle (2)');
     });
 
+    // #2268 (C2) — Lifecycle/Drift buffer가 in-memory 비영속이라 (0)이 "이벤트 없음"인지
+    // "앱 kill/BG 재기동으로 증발"인지 dump만으로 구분 불가능했다. launch 이후 경과 초를
+    // 헤더에 표기해 판정 가능하게 한다.
+    it('formatBufferAgeSuffix: launchAtMs/nowMs 기준 경과 초를 헤더 suffix로 표기 (#2268)', () => {
+      const { formatBufferAgeSuffix } = __test__;
+      expect(
+        formatBufferAgeSuffix({ ...baselineDumpArgs, launchAtMs: 1_000, nowMs: 1_000 }),
+      ).toBe(' (buffer age since launch = 0s)');
+      expect(
+        formatBufferAgeSuffix({ ...baselineDumpArgs, launchAtMs: 1_000, nowMs: 61_000 }),
+      ).toBe(' (buffer age since launch = 60s)');
+    });
+
+    it('Boarding-Lock Drift / BoardingLock Lifecycle 헤더에 buffer age suffix가 포함된다 (#2268)', () => {
+      const dump = buildDumpText(
+        makeDumpArgs({ launchAtMs: 1_000, nowMs: 6_000, boardingLockDriftLog: [], lockLifecycleLog: [] }),
+      );
+      expect(dump).toContain('## Boarding-Lock Drift (0) (buffer age since launch = 5s)');
+      expect(dump).toContain('## BoardingLock Lifecycle (0) (buffer age since launch = 5s)');
+    });
+
     it('UI: 비어있으면 (0) 표시, push 시 entry 노출, Clear가 비운다', async () => {
       const {
         clearCandidateRejectEntries,
@@ -5733,8 +5754,11 @@ describe('DebugModal — #2049 UI 누락 4 섹션 render', () => {
   it('Boarding-Lock Drift 섹션이 UI에 노출된다 (buffer 비어 있으면 (empty))', async () => {
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
-    // DebugLogSection은 header에 count(0) suffix를 붙임 → 'Boarding-Lock Drift (0)' 존재 확인.
-    expect(screen.getByText(/Boarding-Lock Drift \(\d+\)/)).toBeTruthy();
+    // DebugLogSection은 header에 count(0) suffix를 붙임. #2268 (C2)로 title 자체에 launch 이후
+    // 경과 초(buffer age)가 먼저 붙고 count가 그 뒤에 온다 → '...age since launch = Ns) (0)'.
+    expect(
+      screen.getByText(/Boarding-Lock Drift \(buffer age since launch = \d+s\) \(\d+\)/),
+    ).toBeTruthy();
   });
 
   it('Boarding-Lock Drift buffer push → UI 반영 + clear 버튼이 buffer를 비운다', async () => {
@@ -5769,7 +5793,10 @@ describe('DebugModal — #2049 UI 누락 4 섹션 render', () => {
   it('BoardingLock Lifecycle 섹션이 UI에 노출된다 (buffer 비어 있으면 (empty))', async () => {
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
-    expect(screen.getByText(/BoardingLock Lifecycle \(\d+\)/)).toBeTruthy();
+    // #2268 (C2) — buffer age suffix 포함 title.
+    expect(
+      screen.getByText(/BoardingLock Lifecycle \(buffer age since launch = \d+s\) \(\d+\)/),
+    ).toBeTruthy();
   });
 
   it('BoardingLock Lifecycle buffer push → UI 반영 + clear 버튼이 buffer를 비운다', async () => {

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AppState, Share } from 'react-native';
+import { Alert, AppState, Share } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react-native';
 import { DebugModal, __test__ } from '../DebugModal';
@@ -658,9 +658,42 @@ describe('DebugModal', () => {
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
     fireEvent.press(screen.getByTestId('debug-share-dump'));
-    expect(shareSpy).toHaveBeenCalled();
+    await waitFor(() => expect(shareSpy).toHaveBeenCalled());
     expect(shareSpy.mock.calls[0][0].message).toContain('Subway debug');
     shareSpy.mockRestore();
+  });
+
+  // #2268 (S1) — Share.share가 reject 하면 이전엔 무음 실패였다(void 호출, catch 없음).
+  // 사용자에게 Alert로 실패 + 덤프 길이를 안내해야 한다.
+  it('Share.share가 실패하면 Alert로 사용자에게 안내한다', async () => {
+    const shareSpy = jest
+      .spyOn(Share, 'share')
+      .mockRejectedValue(new Error('share sheet dismissed'));
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    fireEvent.press(screen.getByTestId('debug-share-dump'));
+    await waitFor(() => expect(alertSpy).toHaveBeenCalled());
+    const [title, body] = alertSpy.mock.calls[0];
+    expect(title).toBe('공유 실패');
+    expect(body).toContain('share sheet dismissed');
+    expect(body).toMatch(/길이 \d+자/);
+    shareSpy.mockRestore();
+    alertSpy.mockRestore();
+  });
+
+  // #2268 (S1) — reject 값이 Error 인스턴스가 아닌 경우(String(e) fallback 분기) 커버.
+  it('Share.share가 non-Error 값으로 reject 되어도 Alert에 String(e)를 안내한다', async () => {
+    const shareSpy = jest.spyOn(Share, 'share').mockRejectedValue('share sheet unavailable');
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    fireEvent.press(screen.getByTestId('debug-share-dump'));
+    await waitFor(() => expect(alertSpy).toHaveBeenCalled());
+    const [, body] = alertSpy.mock.calls[0];
+    expect(body).toContain('share sheet unavailable');
+    shareSpy.mockRestore();
+    alertSpy.mockRestore();
   });
 
   it('AppState active 복귀 시 로그를 다시 불러온다', async () => {


### PR DESCRIPTION
## 배경

DebugModal 진단 덤프 감사 결과 발견된 3개 결함 수리.

## 변경 사항 (3 커밋)

### 커밋 1 — Share 견고화 (S1+S2)
- `handleShare`가 `void Share.share(...)`로 실패를 완전 무음 처리하던 문제 수리. async 전환 + try/catch + `Alert.alert`로 실패/덤프 길이 안내.
- 성공/실패 모두 dump 총 길이를 `createLogger('debugModalShare')`로 기록 (Sentry breadcrumb 경유로 관측 가능).
- **Clipboard fallback 결정**: `package.json` 확인 결과 `expo-clipboard` 등 클립보드 패키지가 프로젝트에 설치돼 있지 않음. 신규 네이티브 의존성 추가 대신, 실패 시 Alert에 덤프 길이를 안내하는 것으로 대체(태스크 스펙의 "총 길이 Alert 안내" 옵션 채택).

### 커밋 2 — Lifecycle/Drift 버퍼 (0) 모호성 제거 (C2)
- `BoardingLock Lifecycle` / `Boarding-Lock Drift` 섹션은 in-memory ring buffer(`createDebugBuffer`)라 앱 kill/BG 재기동 시 리셋된다. (0)이 "이벤트 없음"인지 "재기동으로 증발"인지 dump만으로 구분 불가능했다.
- `DEBUG_MODAL_LOAD_AT_MS` 모듈 상수(`app/_layout.tsx`가 static import 하므로 앱 launch 시각의 근사치) 도입.
- 두 섹션 헤더에 `(buffer age since launch = Ns)` suffix 추가 — share dump / UI 양쪽 동일 SSOT(`formatBufferAgeSuffix`).

### 커밋 3 — Lock Correction 섹션 배선 (C1)
- `getLockCorrectionMetrics()`(#1166, `lockCorrectionMetrics.ts`)는 `BoardingTrainList`가 이미 `recordLockCorrection`으로 fired count를 기록하고 있었지만, DebugModal에 섹션이 없어 관측 불가능한 orphan getter였다.
- `computeLockCorrectionLines`/`buildLockCorrectionSection` + `LockCorrectionSection` UI 컴포넌트 추가, `SHARE_SECTIONS`의 `BoardingLock` 섹션 직후에 등록.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` 로컬 pass 확인. `getLockCorrectionMetrics`가 이번 PR로 DebugModal에서 호출돼 orphan 해소.
2. **V/X dashboard** — 3개 신호 전부 **DebugModal 자체**가 관측 지점. Lock Correction은 신규 섹션(UI testID `debug-lock-correction-section`), buffer age는 Lifecycle/Drift 섹션 헤더, share 실패는 Alert(즉시 표시) + `debugModalShare` logger tag(Sentry breadcrumb).
3. **의존 PR** — N/A (프로덕션 로직 변경 없음, DebugModal 관측 계층만).
4. **측정 plan** — 다음 실기기 세션에서 DebugModal을 열어 (a) Share 버튼 강제 실패(비행기 모드 등) 시 Alert 노출 확인, (b) 앱 kill 후 재실행 직후 Lifecycle/Drift 헤더의 age 값이 작게 표시되는지 확인, (c) lock correction 발생 후(pending→confirmed) `fired` 값이 증가하는지 확인.
5. **Device verify** — 필요. Share.share 실패 경로(OS 시트 취소/거부)와 Alert 렌더는 실기기/시뮬레이터에서 1회 확인 권장. 타입/유닛 테스트는 전부 통과했으나 RN `Share`/`Alert` 네이티브 브릿지 동작 자체는 CI 범위 밖.

## 제약 준수
- 알람/fusion 등 프로덕션 로직 변경 없음 — DebugModal 관측 계층만 수정.
- `npm run type-check`, `npm test`(coverage 100%), `npm run lint:orphan` 모두 로컬 pass.

## Test plan
- [x] `npm run type-check`
- [x] `npm test` (coverage 100% — lines/functions/branches/statements)
- [x] `npm run lint:orphan`
- [ ] 실기기: Share 실패 → Alert 노출
- [ ] 실기기: 앱 kill 후 재기동 → Lifecycle/Drift buffer age 짧게 표시
- [ ] 실기기: lock correction 발생 → DebugModal에 fired count 반영

Closes #2268