### PR TITLE
fix(#2268): BG 환승 swap이 sync 응답 autoLockCandidate로 lock hydrate (silent push 의존 제거)

### DIFF
--- a/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
@@ -102,6 +102,15 @@ const mockGetBoardingLock = jest.fn();
 jest.mock('../../../alarm/utils/boardingLockStorage', () => ({
   getBoardingLock: () => mockGetBoardingLock(),
 }));
+// #2268 — hydrateLock이 sync 응답 autoLockCandidate로 새 lock을 hydrate할 때 쓰는 store.
+// findStationByNameAndLine / allowedLinesFromRoute는 실제 shared 순수 함수를 그대로 사용한다
+// (mocking 불필요 — 결정성 있는 순수 함수, 실제 stations.json 정합성까지 함께 검증).
+const mockCreateLock = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../alarm/store/useBoardingLockStore', () => ({
+  useBoardingLockStore: {
+    getState: () => ({ createLock: (...args: unknown[]) => mockCreateLock(...args) }),
+  },
+}));
 
 // ── logger 모킹 ──
 jest.mock('../../../../shared/utils/logger', () => ({
@@ -1326,6 +1335,81 @@ describe('backgroundLocationTask defineTask 콜백', () => {
       await taskCallback({ data: { locations: [loc] }, error: null });
 
       expect(mockEvaluateBackgroundTransferSwap).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('#2268 — hydrateLock: sync 응답 autoLockCandidate로 새 lock hydrate', () => {
+    const activeLock = {
+      destinationId: 'station-2',
+      trainCode: 'T-7-old',
+      boardingStationId: '7-019',
+      boardingLine: '7' as const,
+      boardedAt: Date.now(),
+      expectedDurationMs: 30 * 60_000,
+    };
+
+    /** taskCallback을 1회 실행해 evaluateBackgroundTransferSwap에 주입된 deps.hydrateLock을 꺼낸다. */
+    async function runAndGetHydrateLock(
+      routeJson: string | null = null,
+    ): Promise<(candidate: Record<string, unknown>, context: { stationName: string }) => void> {
+      mockStorageValues(JSON.stringify(mockDestination), null, routeJson);
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null).mockResolvedValueOnce('apns-tok-1');
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      const loc = makeLocation(37.498, 127.028, { accuracy: 10 });
+      await taskCallback({ data: { locations: [loc] }, error: null });
+      const [, deps] = mockEvaluateBackgroundTransferSwap.mock.calls[0];
+      return deps.hydrateLock;
+    }
+
+    it('candidate.from이 "transfer-swap"이 아니면 createLock 미호출', async () => {
+      const hydrateLock = await runAndGetHydrateLock();
+      hydrateLock({ trainCode: 'T-2', line: '2', subwayId: '1002' }, { stationName: '건대입구' });
+      expect(mockCreateLock).not.toHaveBeenCalled();
+    });
+
+    it('역명+line 매칭 실패(무효 line)면 createLock 미호출', async () => {
+      const hydrateLock = await runAndGetHydrateLock();
+      hydrateLock(
+        { trainCode: 'T-2', line: '99', subwayId: '1099', from: 'transfer-swap' },
+        { stationName: '건대입구' },
+      );
+      expect(mockCreateLock).not.toHaveBeenCalled();
+    });
+
+    it('route에 candidate.line이 없으면(allowedLines 위반) createLock 미호출', async () => {
+      const hydrateLock = await runAndGetHydrateLock(JSON.stringify(makeDirectRoute(5, '7')));
+      hydrateLock(
+        { trainCode: 'T-2', line: '2', subwayId: '1002', from: 'transfer-swap' },
+        { stationName: '건대입구' },
+      );
+      expect(mockCreateLock).not.toHaveBeenCalled();
+    });
+
+    it('유효 candidate + route 미설정(필터 미적용) → createLock을 정정된 station으로 호출', async () => {
+      const hydrateLock = await runAndGetHydrateLock();
+      hydrateLock(
+        { trainCode: 'T-2-new', line: '2', subwayId: '1002', from: 'transfer-swap' },
+        { stationName: '건대입구' },
+      );
+      expect(mockCreateLock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          destinationId: mockDestination.id,
+          trainCode: 'T-2-new',
+          boardingStationId: '2-012',
+          boardingLine: '2',
+        }),
+      );
+    });
+
+    it('createLock이 reject해도 graceful (throw 없음)', async () => {
+      mockCreateLock.mockRejectedValueOnce(new Error('storage fail'));
+      const hydrateLock = await runAndGetHydrateLock();
+      expect(() =>
+        hydrateLock(
+          { trainCode: 'T-2-new', line: '2', subwayId: '1002', from: 'transfer-swap' },
+          { stationName: '건대입구' },
+        ),
+      ).not.toThrow();
     });
   });
 

--- a/src/features/nearest-station/tasks/backgroundLocationTask.ts
+++ b/src/features/nearest-station/tasks/backgroundLocationTask.ts
@@ -42,9 +42,14 @@ import { createArrivalProvider } from '../../arrival/providers/factory';
 import { findNearestStations } from '../utils/findNearestStation';
 import { syncBoardingLock } from '../api/boardingLockSync';
 import { getBoardingLock } from '../../alarm/utils/boardingLockStorage';
-import type { Route } from '../../../shared/utils/stationRoute';
+import { allowedLinesFromRoute, type Route } from '../../../shared/utils/stationRoute';
 import { isValidGpsSpeedMps, MAX_STATION_DISTANCE_KM } from '../../../shared/constants/location';
-import type { Station } from '../../../shared/types/station';
+import type { LineNumber, Station } from '../../../shared/types/station';
+// #2268 — BG 환승 swap sync 응답의 autoLockCandidate를 직접 hydrate하기 위한 alarm/shared 의존.
+// cross-feature import는 본 파일 헤더 file-level disable로 이미 옵트인.
+import { useBoardingLockStore } from '../../alarm/store/useBoardingLockStore';
+import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
+import { FALLBACK_BOARDING_DURATION_MINUTES } from '../../../shared/constants/boardingLock';
 // #1667 (ADR-015 strongDB wire) — WiFi SSID 매핑 역명 backend forward.
 // device가 lookup 후 역명만 송신 — backend는 stations.json 없으므로 lookup은 device 책임.
 import { getCurrentWifiSsid } from '../utils/wifiSsidNative';
@@ -342,8 +347,13 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
 
     // #1281 — BG 환승 자동 detect. 주머니 속 환승에서 FG hook 진입점이 없어 옛 노선 lock이
     // 얼어붙던 회귀를 차단한다. lock 활성 + 환승역 + 다른 노선 임박 + walking이 모두 충족될 때만
-    // 새 노선 trainCode를 backend `/boarding-lock/sync`에 통보 → W1(#1271) swap 경로로 hydrate.
+    // 새 노선 trainCode를 backend `/boarding-lock/sync`에 통보한다.
     // apnsToken 부재(트립 미등록 등)는 함수 내부 게이트가 graceful no-op 처리.
+    //
+    // #2268 (2026-08-10 실탑승 RCA) — 과거엔 sync 응답을 버리고 죽은 silent push 채널이 새 노선
+    // lock을 hydrate할 것이라 가정했다(지하 7→2 환승 시 2호선 lock이 영영 안 붙는 무보호 회귀).
+    // hydrateLock이 sync 응답의 autoLockCandidate를 직접 소비해 즉시 hydrate — FG
+    // (`useBoardingLockSync` → `hydrateLockFromCandidate`)와 동일하게 HTTP 응답을 SSOT로 쓴다.
     const swapLock = await getBoardingLock();
     if (apnsToken && swapLock) {
       await evaluateBackgroundTransferSwap(
@@ -361,6 +371,37 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
           findNearestStations: (la, ln) => findNearestStations(la, ln, MAX_STATION_DISTANCE_KM),
           arrivalProvider: createArrivalProvider(),
           syncBoardingLock,
+          hydrateLock: (candidate, context) => {
+            // backend가 'transfer-swap' evidence로 확정 발급한 candidate만 신뢰한다(3조건:
+            // 기존 lock 존재 + trainCode 제공 + trainCode 변경 — 모두 backend가 이미 검증).
+            // motion gate는 evaluateBackgroundTransferSwap이 candidate를 산출한 시점에 이미
+            // walking(motionStationary=false) 조건을 통과했으므로 여기서 재검증하지 않는다
+            // (FG hydrateLockFromCandidate Gate 2의 transfer-swap 우회와 동일 정책).
+            if (candidate.from !== 'transfer-swap') return;
+            // 역명 + candidate.line 정확 매칭 — 환승역 fusion 오류/무효 line 문자열 방어.
+            const correctedStation = findStationByNameAndLine(
+              context.stationName,
+              candidate.line as LineNumber,
+            );
+            if (!correctedStation) return;
+            const boardingLine = correctedStation.line;
+            // #1449 (ADR-015 §9) — trip route 외 line candidate reject. route 없으면 필터 미적용.
+            const allowedLines = allowedLinesFromRoute(storedRoute);
+            if (allowedLines && !allowedLines.has(boardingLine)) return;
+            useBoardingLockStore
+              .getState()
+              .createLock({
+                destinationId: destination.id,
+                trainCode: candidate.trainCode,
+                boardingStationId: correctedStation.id,
+                boardingLine,
+                boardedAt: Date.now(),
+                expectedDurationMs: FALLBACK_BOARDING_DURATION_MINUTES * 60_000,
+              })
+              .catch(() => {
+                // store action rejection은 graceful — 다음 BG tick에서 자연 재시도.
+              });
+          },
         },
       );
     }

--- a/src/features/route/utils/__tests__/backgroundTransferSwap.test.ts
+++ b/src/features/route/utils/__tests__/backgroundTransferSwap.test.ts
@@ -224,4 +224,49 @@ describe('evaluateBackgroundTransferSwap', () => {
     expect(result.fired).toBe(true);
     expect(syncSpy).toHaveBeenCalledTimes(2);
   });
+
+  // #2268 — 2026-08-10 실탑승 RCA: sync 응답의 autoLockCandidate를 버리고 죽은 silent push를
+  // 기다리던 회귀. sync 응답에 candidate가 실려오면 hydrateLock으로 직접 hydrate해야 한다.
+  it('sync 응답에 autoLockCandidate가 있으면 hydrateLock을 후보+역명 컨텍스트로 호출', async () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '성수', arrivalSeconds: 60, line: '2', trainCode: 'T-2-new' }),
+    ]);
+    const candidate = { trainCode: 'T-2-new', line: '2', subwayId: '1002', from: 'transfer-swap' as const };
+    const syncSpy = jest.fn().mockResolvedValue({ ok: true, autoLockCandidate: candidate });
+    const { deps } = makeDeps({ arrival, syncSpy });
+    const hydrateLock = jest.fn();
+
+    const result = await evaluateBackgroundTransferSwap(baseInput(), { ...deps, hydrateLock });
+
+    expect(result).toEqual({ fired: true, trainCode: 'T-2-new' });
+    expect(hydrateLock).toHaveBeenCalledTimes(1);
+    expect(hydrateLock).toHaveBeenCalledWith(candidate, { stationName: '건대입구' });
+  });
+
+  it('sync 응답에 autoLockCandidate가 없으면 hydrateLock 미호출', async () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '성수', arrivalSeconds: 60, line: '2', trainCode: 'T-2-new' }),
+    ]);
+    const syncSpy = jest.fn().mockResolvedValue({ ok: true });
+    const { deps } = makeDeps({ arrival, syncSpy });
+    const hydrateLock = jest.fn();
+
+    await evaluateBackgroundTransferSwap(baseInput(), { ...deps, hydrateLock });
+
+    expect(hydrateLock).not.toHaveBeenCalled();
+  });
+
+  it('hydrateLock 미주입이어도 sync 응답 처리는 graceful (throw 없음)', async () => {
+    const arrival = makeArrival([
+      makeArrivalInfo({ destination: '성수', arrivalSeconds: 60, line: '2', trainCode: 'T-2-new' }),
+    ]);
+    const candidate = { trainCode: 'T-2-new', line: '2', subwayId: '1002', from: 'transfer-swap' as const };
+    const syncSpy = jest.fn().mockResolvedValue({ ok: true, autoLockCandidate: candidate });
+    const { deps } = makeDeps({ arrival, syncSpy });
+
+    await expect(evaluateBackgroundTransferSwap(baseInput(), deps)).resolves.toEqual({
+      fired: true,
+      trainCode: 'T-2-new',
+    });
+  });
 });

--- a/src/features/route/utils/backgroundTransferSwap.ts
+++ b/src/features/route/utils/backgroundTransferSwap.ts
@@ -125,6 +125,7 @@ export function resetBackgroundTransferSwapState(): void {
  *   3) 같은 환승역 + 같은 leg lock으로 이미 발사했으면 skip (arrival 재조회 churn 차단)
  *   4) 환승역 arrival 1회 조회 → `evaluateTransferSwap`로 다른 노선 임박 + walking 결합 판정
  *   5) 단일 후보(=새 노선 trainCode)면 backend sync 발사
+ *   6) sync 응답에 autoLockCandidate가 있으면 `deps.hydrateLock`으로 직접 hydrate (#2268)
  */
 export async function evaluateBackgroundTransferSwap(
   input: BackgroundTransferSwapInput,
@@ -165,7 +166,7 @@ export async function evaluateBackgroundTransferSwap(
   // backend가 새 trainCode(≠ 현재 lock)를 관측하면 W1(#1271) swap 경로로 from='transfer-swap'
   // candidate를 발급한다. candidate.line은 boardingLine 제외 후 산출돼 항상 다른 노선 → 다른 trainCode.
   lastFiredKey = fireKey;
-  await deps.syncBoardingLock({
+  const response = await deps.syncBoardingLock({
     token: apnsToken,
     observedStationName: stationName,
     observedAtMs,
@@ -173,6 +174,12 @@ export async function evaluateBackgroundTransferSwap(
     trainCode: candidate.trainCode,
     boardingLine: candidate.line,
   });
+
+  // #2268 — 응답에 autoLockCandidate가 실려오면 직접 hydrate. silent push 채널에 더 이상 의존하지
+  // 않는다(그 채널은 지하 환경에서 도착 자체가 죽는 독립 실패 지점이었다).
+  if (response?.autoLockCandidate) {
+    deps.hydrateLock?.(response.autoLockCandidate, { stationName });
+  }
 
   return { fired: true, trainCode: candidate.trainCode };
 }

--- a/src/features/route/utils/backgroundTransferSwap.ts
+++ b/src/features/route/utils/backgroundTransferSwap.ts
@@ -8,10 +8,18 @@
  * 본 함수는 BG tick에서 동일한 `evaluateTransferSwap`(FG와 공유 pure 결정)을 돌려 환승-swap 후보를
  * 잡고, 후보가 있으면 backend `/boarding-lock/sync`에 새 노선 trainCode를 통보한다. backend가 새
  * trainCode를 관측하면 W1(#1271) 경로로 swap을 적용하고 `autoLockCandidate.from='transfer-swap'`을
- * silent push로 발급 → client store가 motion gate 우회로 hydrate. FG/BG가 같은 swap 경로를 탄다.
+ * **sync 응답에 직접** 실어 돌려준다.
  *
- * 의존성은 모두 주입한다(테스트 가능 + route 슬라이스가 nearest-station/arrival를 직접 import하지
- * 않게): 호출자(backgroundLocationTask, cross-feature 옵트인 파일)가 provider/sync/lookup을 넘긴다.
+ * #2268 (2026-08-10 실탑승 RCA) — 과거 구현은 이 응답을 버리고 "silent push가 hydrate할 것"이라
+ * 가정했으나, silent push는 autoLockCandidate를 소비하는 채널이 아니라 지하 환경에서 도착 자체가
+ * 죽는 독립 실패 지점이었다(`lesson_silent_push_ssot_forward_no_independent_channel`). 그 결과
+ * BG 환승에서 새 노선 lock이 영영 안 붙어 무보호 상태가 됐다. 본 함수는 이제 sync 응답의
+ * `autoLockCandidate`를 직접 소비해 `deps.hydrateLock`으로 lock을 hydrate한다 — FG
+ * (`useBoardingLockSync` → `hydrateLockFromCandidate`)와 동일하게 HTTP 응답을 SSOT로 쓴다.
+ *
+ * 의존성은 모두 주입한다(테스트 가능 + route 슬라이스가 nearest-station/arrival/alarm를 직접
+ * import하지 않게): 호출자(backgroundLocationTask, cross-feature 옵트인 파일)가
+ * provider/sync/lookup/hydrate를 넘긴다.
  *
  * false-positive 방어는 `evaluateTransferSwap`(=`detectTransfer`)의 기존 게이트를 그대로 재사용한다:
  *   1) 현재 최근접 역이 환승역  2) motion walking(이동 중)  3) 현재 boardingLine 제외 다른 노선의
@@ -34,13 +42,41 @@ export interface BackgroundTransferSwapSyncPayload {
   boardingLine: string;
 }
 
+/**
+ * #2268 — `nearest-station/api/boardingLockSync.ts`의 `AutoLockCandidate` 구조적 부분집합.
+ * route 슬라이스가 nearest-station의 타입을 직접 import하지 않도록(cross-feature 경계) 여기서
+ * 구조적으로 재정의한다 — 실제 호출자(backgroundLocationTask)가 넘기는 값은 그 타입 그대로다.
+ */
+export interface BackgroundTransferSwapAutoLockCandidate {
+  trainCode: string;
+  line: string;
+  subwayId: string;
+  from?: 'transfer-swap';
+}
+
+/** `syncBoardingLock` 응답에서 본 함수가 소비하는 부분집합. */
+export interface BackgroundTransferSwapSyncResult {
+  autoLockCandidate?: BackgroundTransferSwapAutoLockCandidate | null;
+}
+
 export interface BackgroundTransferSwapDeps {
   /** 좌표 → fusion 최근접 역(환승 여부 포함). nearest-station feature에서 주입. */
   findNearestStations: (lat: number, lng: number) => NearestStationsResult | null;
   /** arrival provider. 환승역 도착 정보 1회 조회용. */
   arrivalProvider: ArrivalProvider;
   /** backend sync 발사. 호출자(BG task)가 nearest-station API를 래핑해 주입. */
-  syncBoardingLock: (payload: BackgroundTransferSwapSyncPayload) => Promise<unknown>;
+  syncBoardingLock: (
+    payload: BackgroundTransferSwapSyncPayload,
+  ) => Promise<BackgroundTransferSwapSyncResult>;
+  /**
+   * #2268 — sync 응답에 `autoLockCandidate`가 실려오면 호출. 호출자(BG task)가 alarm 슬라이스의
+   * lock store로 hydrate한다. 미주입(undefined)이면 hydrate 자체를 skip — 기존 호출자/테스트가
+   * 깨지지 않도록 optional로 둔다.
+   */
+  hydrateLock?: (
+    candidate: BackgroundTransferSwapAutoLockCandidate,
+    context: { stationName: string },
+  ) => void;
 }
 
 export interface BackgroundTransferSwapInput {


### PR DESCRIPTION
## 배경 (2026-08-10 실탑승 RCA)

지하 7→2호선 환승 시 2호선 lock이 영영 안 붙는 무보호 회귀. 원인: `backgroundTransferSwap.ts`가
swap 후보를 잡아 `/boarding-lock/sync`를 발사하지만 **HTTP 응답을 버리고**, 죽은 실패 채널인
silent push가 `autoLockCandidate`로 hydrate할 것이라고 가정하고 있었다. silent push는
autoLockCandidate를 소비하는 채널이 아니며(`silentPushTask.ts` 어디에도 소비 로직 없음), 지하
환경에서는 도착 자체가 독립적으로 죽는 실패 지점이라 새 노선 lock이 영구히 hydrate되지 않았다.

FG(`useBoardingLockSync` → `hydrateLockFromCandidate`)는 이미 sync HTTP 응답의 `autoLockCandidate`를
직접 소비한다. 본 PR은 BG 경로도 동일하게 응답을 SSOT로 사용하도록 수정한다.

## 변경

- `src/features/route/utils/backgroundTransferSwap.ts`
  - `syncBoardingLock` dep 반환 타입을 `Promise<unknown>` → 응답의 `autoLockCandidate`를 노출하는
    구조적 타입으로 좁힘 (route 슬라이스가 nearest-station 타입을 직접 import하지 않도록 로컬 재정의).
  - `BackgroundTransferSwapDeps`에 `hydrateLock?` 콜백 추가.
  - sync 응답에 `autoLockCandidate`가 있으면 `deps.hydrateLock(candidate, { stationName })` 호출.
- `src/features/nearest-station/tasks/backgroundLocationTask.ts`
  - `hydrateLock` 구현 배선: `candidate.from === 'transfer-swap'` evidence만 신뢰(backend가 이미
    "기존 lock 존재 + trainCode 제공 + trainCode 변경" 3조건 검증) → 역명+line 정확 매칭
    (`findStationByNameAndLine`) → `allowedLinesFromRoute` route 범위 검증 →
    `useBoardingLockStore.getState().createLock(...)`.
  - motion gate는 재검증하지 않음 — `evaluateBackgroundTransferSwap`이 candidate를 산출한 시점에
    이미 walking 조건을 통과했다(FG `hydrateLockFromCandidate` Gate 2의 transfer-swap 우회와 동일 정책).

## 범위 밖

- **이슈3(매역 1홉 지연)은 범위 밖** — 건드리지 않았다.
- backend 변경 불필요 — 응답에 `autoLockCandidate`가 이미 있었다(device-side only fix).

## RED → GREEN 커밋

1. `f462b2b8` test(#2268): 실패 테스트 (hydrateLock 미배선 상태로 red)
2. `6bdc5b5b` fix(#2268): `backgroundTransferSwap`이 응답을 소비하도록 수정 (green)
3. `3d955f4e` fix(#2268): `backgroundLocationTask`에서 실제 hydrate 로직 배선 + 커버리지

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` 로컬 pass (0 orphan).
2. **V/X dashboard** — DebugModal의 BoardingLock 패널에서 `boardingLine`/`trainCode` 변경으로 관측
   가능. `wrangler tail`(backend)로 `/boarding-lock/sync` 요청에 실린 신규 trainCode/line과
   응답의 `autoLockCandidate` 확인 가능.
3. **의존 PR** — N/A (backend 응답에 `autoLockCandidate`가 이미 존재, device-side only).
4. **측정 plan** — 실기기 지하 환승 trip 1회로 hydrate 여부 직접 확인(아래 device verify). 이후
   1주 내 재발 여부는 다음 지하 환승 실탑승에서 boardingLine 전환 관측으로 판정.
5. **Device verify** — **필수**. 시나리오: 지하 7→2호선(또는 임의 환승역) 환승, BG(주머니 속) 상태
   유지, 환승역 통과 후 DebugModal에서 lock.boardingLine이 새 노선으로 바뀌는지 확인.

## Test plan

- [x] `npm run type-check` pass
- [x] `npm run lint` — 기존 pre-existing 실패 6건(이 PR과 무관, origin/dev에도 존재) 외 신규 위반 없음
- [x] `npm run lint:orphan` pass (0 orphan)
- [x] `npm test` — 434 suites / 9316 tests pass, coverage 100% (lines/branches/functions/statements)
- [ ] **실기기 지하 환승 재탑승 검증 필요** — 7→2호선(또는 임의 환승) BG 환승에서 2호선 lock이
      실제로 붙는지 확인. 머지는 CI green 확인 후 사용자가 진행.