### PR TITLE
fix(#2268): trip 종료 경로 텔레메트리 실버그 2건 수정

### DIFF
--- a/backend/alarm-worker/migrations/0004_trip_metrics_end_idempotency.sql
+++ b/backend/alarm-worker/migrations/0004_trip_metrics_end_idempotency.sql
@@ -1,0 +1,8 @@
+-- #2268 — trip_metrics 중복 insert 방지. DELETE /trips/:token이 getTrip→cleanupTripWithLa 사이
+-- 원자 가드 없이 race하면(2026-08-10 evidence: 동일 trip_token_hash 2행, 521ms차) 같은 trip 종료가
+-- recordTripMetrics를 두 번 호출한다. (trip_token_hash, started_at)는 "이 trip 인스턴스의 이 종료
+-- 이벤트"를 유일하게 식별 — 같은 trip이 재사용 토큰으로 나중에 다시 등록돼도 started_at
+-- (createdAt)이 달라 정상 신규 행은 막지 않는다. recordTripMetrics는 `INSERT OR IGNORE`로 전환해
+-- 두 번째 race 호출이 조용히 no-op되도록 한다(d1TripMetrics.ts).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_trip_metrics_token_started
+  ON trip_metrics(trip_token_hash, started_at);

--- a/backend/alarm-worker/migrations/0004_trip_metrics_end_idempotency.sql
+++ b/backend/alarm-worker/migrations/0004_trip_metrics_end_idempotency.sql
@@ -4,5 +4,13 @@
 -- 이벤트"를 유일하게 식별 — 같은 trip이 재사용 토큰으로 나중에 다시 등록돼도 started_at
 -- (createdAt)이 달라 정상 신규 행은 막지 않는다. recordTripMetrics는 `INSERT OR IGNORE`로 전환해
 -- 두 번째 race 호출이 조용히 no-op되도록 한다(d1TripMetrics.ts).
+-- 기존 중복 정리(2026-08-10 evidence: 원격 D1에 여러 (trip_token_hash, started_at) 그룹이 2행씩
+-- 존재 확인) — unique index 생성 전 필수. 그룹당 가장 작은 id 1행만 남기고 나머지 삭제.
+DELETE FROM trip_metrics
+WHERE id NOT IN (
+  SELECT MIN(id) FROM trip_metrics GROUP BY trip_token_hash, started_at
+);
+
+-- dedup 후 unique index 생성
 CREATE UNIQUE INDEX IF NOT EXISTS idx_trip_metrics_token_started
   ON trip_metrics(trip_token_hash, started_at);

--- a/backend/alarm-worker/src/__tests__/d1TripMetrics.test.ts
+++ b/backend/alarm-worker/src/__tests__/d1TripMetrics.test.ts
@@ -25,7 +25,7 @@ describe('recordTripMetrics (#1835)', () => {
     await recordTripMetrics(db2, trip, 'destination-arrived', NOW);
 
     expect(db2.prepare).toHaveBeenCalledWith(
-      expect.stringContaining('INSERT INTO trip_metrics'),
+      expect.stringContaining('INSERT OR IGNORE INTO trip_metrics'),
     );
   });
 
@@ -116,5 +116,74 @@ describe('recordTripMetrics (#1835)', () => {
     // chain_complete = 마지막 positional argument (index 12, 0-based)
     const chainComplete = capturedArgs[capturedArgs.length - 1];
     expect(chainComplete).toBe(1);
+  });
+
+  // #2268 — DELETE /trips/:token이 getTrip→cleanupTripWithLa 사이 원자 가드 없이 race하면
+  // 동일 trip 종료가 recordTripMetrics를 두 번 호출한다(evidence: 2026-08-10, 동일
+  // trip_token_hash 2행, 521ms차). migration 0004의 (trip_token_hash, started_at) UNIQUE index +
+  // `INSERT OR IGNORE`가 실제 방어선 — 아래는 그 SQLite 제약을 in-memory로 재현해 recordTripMetrics가
+  // 두 번째 race 호출에서 새 행을 만들지 않음을 검증한다.
+  describe('race idempotency (#2268)', () => {
+    /** migration 0004 UNIQUE index (trip_token_hash, started_at) + `INSERT OR IGNORE`를
+     * in-memory로 재현하는 fake D1. 실제 SQLite 제약과 동일하게 중복 키는 조용히 무시한다. */
+    function makeUniqueConstraintDb(): { db: D1Database; rows: () => unknown[][] } {
+      const rows: unknown[][] = [];
+      const seen = new Set<string>();
+      const prepare = vi.fn().mockReturnValue({
+        bind: (...args: unknown[]) => ({
+          run: async () => {
+            const [tokenHash, startedAt] = args;
+            const key = `${tokenHash}:${startedAt}`;
+            if (seen.has(key)) return { success: true }; // OR IGNORE — no-op on duplicate
+            seen.add(key);
+            rows.push(args);
+            return { success: true };
+          },
+        }),
+      });
+      return { db: { prepare } as unknown as D1Database, rows: () => rows };
+    }
+
+    it('동일 trip 종료가 race로 recordTripMetrics를 두 번 호출해도 1행만 기록된다', async () => {
+      const { db, rows } = makeUniqueConstraintDb();
+      const trip = makeTripFixture();
+
+      // 두 DELETE 요청이 거의 동시에 같은 trip을 cleanup → recordTripMetrics가 race로 2회 호출.
+      await Promise.all([
+        recordTripMetrics(db, trip, 'user-delete', NOW),
+        recordTripMetrics(db, trip, 'user-delete', NOW + 521), // evidence의 521ms 간격 재현
+      ]);
+
+      expect(rows()).toHaveLength(1);
+    });
+
+    it('같은 token이 나중에 새 trip으로 재등록되면(started_at 다름) 별도 행으로 기록된다', async () => {
+      const { db, rows } = makeUniqueConstraintDb();
+      const trip1 = makeTripFixture({ createdAt: NOW });
+      const trip2 = makeTripFixture({ createdAt: NOW + 3_600_000 });
+
+      await recordTripMetrics(db, trip1, 'destination-arrived', NOW + 60_000);
+      await recordTripMetrics(db, trip2, 'destination-arrived', NOW + 3_660_000);
+
+      expect(rows()).toHaveLength(2);
+    });
+  });
+
+  // #2268 — device가 알고 있는 실제 종료 사유(예: lockless-trip-end)도 자유 문자열로 받아
+  // end_reason에 그대로 적재한다. TripEndedReason(server-side auto-end 전용) 제약을 받지 않는다.
+  it('device가 보고한 자유 문자열 reason도 end_reason에 그대로 적재된다', async () => {
+    const trip = makeTripFixture();
+    const run = vi.fn().mockResolvedValue({ success: true });
+    let capturedArgs: unknown[] = [];
+    const bind = vi.fn().mockImplementation((...args: unknown[]) => {
+      capturedArgs = args;
+      return { run };
+    });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db2 = { prepare } as unknown as D1Database;
+
+    await recordTripMetrics(db2, trip, 'lockless-trip-end', NOW);
+
+    expect(capturedArgs).toContain('lockless-trip-end');
   });
 });

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1643,6 +1643,50 @@ describe('DELETE /trips/:token — LA dismissal (#586 D)', () => {
   });
 });
 
+// #2268 — DELETE /trips/:token이 device가 아는 실제 종료 사유를 ?reason= 쿼리로 받아 D1
+// trip_metrics.end_reason에 적재한다(기존엔 항상 'user-delete'로 뭉개짐). alert push 게이팅과는
+// 무관 — reason 미지정 시 기존 동작(push 없음) 그대로.
+describe('DELETE /trips/:token — ?reason= metrics telemetry (#2268)', () => {
+  const CREATED = 1_700_000_000_000;
+
+  it('?reason= 쿼리가 D1 trip_metrics에 device가 보낸 값 그대로 적재된다', async () => {
+    let capturedArgs: unknown[] = [];
+    const run = vi.fn().mockResolvedValue({ success: true });
+    const bind = vi.fn().mockImplementation((...args: unknown[]) => {
+      capturedArgs = args;
+      return { run };
+    });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const env = makeKvEnv();
+    env.DB = { prepare } as unknown as Env['DB'];
+    await post('/trips', { ...base(), token: 'tok-reason', createdAt: CREATED }, env);
+
+    const res = await del('/trips/tok-reason?reason=lockless-trip-end', env);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, deleted: true });
+    expect(capturedArgs).toContain('lockless-trip-end');
+  });
+
+  it('reason 쿼리 미지정 시 기존대로 user-delete로 적재된다 (backward-compat)', async () => {
+    let capturedArgs: unknown[] = [];
+    const run = vi.fn().mockResolvedValue({ success: true });
+    const bind = vi.fn().mockImplementation((...args: unknown[]) => {
+      capturedArgs = args;
+      return { run };
+    });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const env = makeKvEnv();
+    env.DB = { prepare } as unknown as Env['DB'];
+    await post('/trips', { ...base(), token: 'tok-no-reason', createdAt: CREATED }, env);
+
+    const res = await del('/trips/tok-no-reason', env);
+
+    expect(res.status).toBe(200);
+    expect(capturedArgs).toContain('user-delete');
+  });
+});
+
 // 리뷰 확정 P1 (#2186) — DELETE /trips/:token이 getTrip(token) 직접 키 조회만 하면, 역인덱스가
 // 직접 키와 다른 trip을 가리키는 상태(예: ADR-025 이후 존치된 APNs refresh 복구 경로, ADR-025
 // Consequences)에서 실토큰 DELETE가 miss → { ok:true, deleted:false } no-op → orphan trip이

--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -730,7 +730,7 @@ describe('cleanupTripWithLa', () => {
       makeStats(),
       NOW,
       () => undefined,
-      'eta-missing',
+      { reason: 'eta-missing' },
     );
     expect(fetchImpl).toHaveBeenCalledTimes(2);
     expect(calls[0]).toContain(APNS_HOSTS.sandbox);
@@ -756,7 +756,7 @@ describe('cleanupTripWithLa', () => {
       makeStats(),
       NOW,
       () => undefined,
-      'eta-missing',
+      { reason: 'eta-missing' },
     );
     expect(JSON.parse(capturedBody ?? '{}').data.corrId).toBe('corr-live-1');
   });
@@ -778,7 +778,7 @@ describe('cleanupTripWithLa', () => {
       makeStats(),
       NOW,
       () => undefined,
-      'eta-missing',
+      { reason: 'eta-missing' },
     );
     expect('corrId' in JSON.parse(capturedBody ?? '{}').data).toBe(false);
   });
@@ -799,7 +799,7 @@ describe('cleanupTripWithLa', () => {
       makeStats(),
       NOW,
       (msg) => logs.push(msg),
-      'eta-missing',
+      { reason: 'eta-missing' },
     );
     // 1차 + retry 모두 호출, 둘 다 실패 → 'trip-ended push failed' 로그.
     expect(fetchImpl).toHaveBeenCalledTimes(2);
@@ -837,7 +837,7 @@ describe('cleanupTripWithLa', () => {
       makeStats(),
       NOW,
       () => undefined,
-      'eta-missing',
+      { reason: 'eta-missing' },
     );
 
     expect(insertBind).toHaveBeenCalled();
@@ -872,7 +872,7 @@ describe('cleanupTripWithLa', () => {
         makeStats(),
         atNow,
         log,
-        reason,
+        { reason },
       );
 
     it('success 시 dedup stamp 저장 → 동일 trip 재 cleanup 호출 시 alert push skip', async () => {
@@ -961,7 +961,7 @@ describe('cleanupTripWithLa', () => {
           makeStats(),
           NOW,
           () => undefined,
-          reason,
+          { reason },
         );
         const raw = kv.store.get('tripStatus:devtoken');
         expect(raw).toBeDefined();
@@ -1004,7 +1004,7 @@ describe('cleanupTripWithLa', () => {
         makeStats(),
         NOW,
         () => undefined,
-        'la-stale-backstop',
+        { reason: 'la-stale-backstop' },
       );
       expect(fetchImpl).toHaveBeenCalledTimes(1);
       const call = fetchImpl.mock.calls[0] as unknown as [string, { body: string }];
@@ -1034,7 +1034,7 @@ describe('cleanupTripWithLa', () => {
           makeStats(),
           NOW,
           () => undefined,
-          reason,
+          { reason },
         );
         const call = fetchImpl.mock.calls[0] as unknown as [string, { body: string }];
         const body = JSON.parse(call[1].body) as { data: { reason: string } };
@@ -1065,7 +1065,7 @@ describe('cleanupTripWithLa', () => {
         makeStats(),
         NOW,
         (msg) => logs.push(msg),
-        'expired',
+        { reason: 'expired' },
       );
       expect(logs).toContain('trip-status write failed');
     });
@@ -1100,7 +1100,7 @@ describe('cleanupTripWithLa', () => {
           makeStats(),
           NOW,
           () => undefined,
-          reason,
+          { reason },
         );
         // trip + SSoT 모두 KV에서 제거됨.
         expect(await kv.get('trip:devtoken')).toBeNull();
@@ -1149,7 +1149,7 @@ describe('cleanupTripWithLa', () => {
         makeStats(),
         NOW,
         (msg) => logs.push(msg),
-        'expired',
+        { reason: 'expired' },
       );
       // ssot delete 실패 로그가 남고, trip 정리는 정상 완료.
       expect(logs).toContain('ssot delete failed');
@@ -1174,8 +1174,7 @@ describe('cleanupTripWithLa', () => {
         makeStats(),
         NOW,
         () => undefined,
-        undefined,
-        'lockless-trip-end',
+        { metricsReason: 'lockless-trip-end' },
       );
       // reason이 undefined였으므로 fireTripEndedAlertPush 자체가 스킵 — fetch(APNs) 호출 없음.
       expect(fetchImpl).not.toHaveBeenCalled();
@@ -1202,8 +1201,7 @@ describe('cleanupTripWithLa', () => {
         makeStats(),
         NOW,
         () => undefined,
-        undefined,
-        'lockless-trip-end',
+        { metricsReason: 'lockless-trip-end' },
       );
       expect(capturedArgs).toContain('lockless-trip-end');
       // alert push용 reason이 아니라 'user-delete' 폴백도 아님 — device가 보낸 값이 우선.

--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -1156,4 +1156,82 @@ describe('cleanupTripWithLa', () => {
       expect(await kv.get('trip:devtoken')).toBeNull();
     });
   });
+
+  // #2268 — DELETE /trips/:token이 device가 아는 실제 종료 사유(reason)를 D1 trip_metrics에
+  // 적재할 수 있도록 metricsReason 파라미터를 추가했다. 이 값이 alert-push 게이팅용 reason과
+  // 완전히 분리되는지(= push를 새로 트리거하지 않는지) + D1 bind에는 정확히 반영되는지 검증.
+  describe('metricsReason (#2268 — D1 telemetry decoupled from alert-push reason)', () => {
+    it('reason 미지정 + metricsReason만 있으면 alert push는 발사되지 않는다', async () => {
+      const kv = new InMemoryKV();
+      const trip = makeTrip({ activityPushToken: undefined });
+      await kv.put('trip:devtoken', JSON.stringify(trip));
+      const env = { TRIPS: kv as unknown as KVNamespace } as Env;
+      const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+      await cleanupTripWithLa(
+        trip,
+        env,
+        makeDeps(fetchImpl as unknown as typeof fetch),
+        makeStats(),
+        NOW,
+        () => undefined,
+        undefined,
+        'lockless-trip-end',
+      );
+      // reason이 undefined였으므로 fireTripEndedAlertPush 자체가 스킵 — fetch(APNs) 호출 없음.
+      expect(fetchImpl).not.toHaveBeenCalled();
+      expect(await kv.get('trip:devtoken')).toBeNull();
+    });
+
+    it('metricsReason이 D1 trip_metrics end_reason에 device가 보낸 값 그대로 적재된다', async () => {
+      const kv = new InMemoryKV();
+      const trip = makeTrip({ activityPushToken: undefined });
+      await kv.put('trip:devtoken', JSON.stringify(trip));
+      let capturedArgs: unknown[] = [];
+      const run = vi.fn().mockResolvedValue({ success: true });
+      const bind = vi.fn().mockImplementation((...args: unknown[]) => {
+        capturedArgs = args;
+        return { run };
+      });
+      const prepare = vi.fn().mockReturnValue({ bind });
+      const db = { prepare } as unknown as D1Database;
+      const env = { TRIPS: kv as unknown as KVNamespace, DB: db } as unknown as Env;
+      await cleanupTripWithLa(
+        trip,
+        env,
+        makeDeps(vi.fn() as unknown as typeof fetch),
+        makeStats(),
+        NOW,
+        () => undefined,
+        undefined,
+        'lockless-trip-end',
+      );
+      expect(capturedArgs).toContain('lockless-trip-end');
+      // alert push용 reason이 아니라 'user-delete' 폴백도 아님 — device가 보낸 값이 우선.
+      expect(capturedArgs).not.toContain('user-delete');
+    });
+
+    it('metricsReason 미지정 시 기존대로 user-delete로 D1에 적재된다 (backward-compat)', async () => {
+      const kv = new InMemoryKV();
+      const trip = makeTrip({ activityPushToken: undefined });
+      await kv.put('trip:devtoken', JSON.stringify(trip));
+      let capturedArgs: unknown[] = [];
+      const run = vi.fn().mockResolvedValue({ success: true });
+      const bind = vi.fn().mockImplementation((...args: unknown[]) => {
+        capturedArgs = args;
+        return { run };
+      });
+      const prepare = vi.fn().mockReturnValue({ bind });
+      const db = { prepare } as unknown as D1Database;
+      const env = { TRIPS: kv as unknown as KVNamespace, DB: db } as unknown as Env;
+      await cleanupTripWithLa(
+        trip,
+        env,
+        makeDeps(vi.fn() as unknown as typeof fetch),
+        makeStats(),
+        NOW,
+        () => undefined,
+      );
+      expect(capturedArgs).toContain('user-delete');
+    });
+  });
 });

--- a/backend/alarm-worker/src/d1TripMetrics.ts
+++ b/backend/alarm-worker/src/d1TripMetrics.ts
@@ -15,13 +15,16 @@ import type { Trip, TripEndedReason } from './types';
  *
  * @param db - D1 binding. undefined 시 no-op.
  * @param trip - 종료된 trip 객체.
- * @param reason - 종료 사유. undefined = 사용자 명시 DELETE (HTTP DELETE /trips/:token).
+ * @param reason - 종료 사유. undefined = 사용자 명시 DELETE (HTTP DELETE /trips/:token, reason
+ *   미전달 시). `TripEndedReason`(server-side auto-end)뿐 아니라 device가 보고하는 자유
+ *   문자열(예: 'lockless-trip-end', 'user-tap')도 받는다(#2268) — alert push 발사 여부와는
+ *   무관한 순수 telemetry 값이라 push payload 타입(`TripEndedReason`)으로 제약하지 않는다.
  * @param endedAt - 종료 epoch ms.
  */
 export async function recordTripMetrics(
   db: D1Database | undefined,
   trip: Trip,
-  reason: TripEndedReason | undefined,
+  reason: TripEndedReason | string | undefined,
   endedAt: number,
 ): Promise<void> {
   if (!db) return;
@@ -32,9 +35,15 @@ export async function recordTripMetrics(
     const lineList = extractLineList(trip);
     const chainComplete = isChainComplete(trip);
 
+    // #2268 — INSERT OR IGNORE + migration 0004의 (trip_token_hash, started_at) UNIQUE index.
+    // DELETE /trips/:token이 getTrip→cleanupTripWithLa 사이 race하면 동일 trip 종료가
+    // recordTripMetrics를 두 번 호출할 수 있다(evidence: 2026-08-10, 동일 trip_token_hash 2행,
+    // 521ms차). D1(SQLite)의 UNIQUE 제약이 실제 원자성을 보장 — KV는 compare-and-swap이 없어
+    // app-level "먼저 읽고 나만 지웠으면 진행" 가드로는 이 race를 완전히 닫을 수 없다. 두 번째
+    // race 호출은 조용히 no-op(0 rows affected) — try/catch에 걸리지 않고 정상 흐름 유지.
     await db
       .prepare(
-        `INSERT INTO trip_metrics (
+        `INSERT OR IGNORE INTO trip_metrics (
           trip_token_hash, started_at, ended_at, end_reason,
           origin_station, destination_station, line_list,
           fired_count, suppressed_count,

--- a/backend/alarm-worker/src/d1TripMetrics.ts
+++ b/backend/alarm-worker/src/d1TripMetrics.ts
@@ -8,7 +8,7 @@
  */
 
 import { hashTripToken } from './sentry';
-import type { Trip, TripEndedReason } from './types';
+import type { Trip } from './types';
 
 /**
  * trip_metrics 에 trip 종료 기록을 적재한다.
@@ -19,12 +19,14 @@ import type { Trip, TripEndedReason } from './types';
  *   미전달 시). `TripEndedReason`(server-side auto-end)뿐 아니라 device가 보고하는 자유
  *   문자열(예: 'lockless-trip-end', 'user-tap')도 받는다(#2268) — alert push 발사 여부와는
  *   무관한 순수 telemetry 값이라 push payload 타입(`TripEndedReason`)으로 제약하지 않는다.
+ *   타입은 `string` 단독 — `TripEndedReason | string`은 리터럴이 string에 흡수돼 자동완성
+ *   효과가 없다(Sonar maintainability). `TripEndedReason` 값도 문자열이라 그대로 대입 가능.
  * @param endedAt - 종료 epoch ms.
  */
 export async function recordTripMetrics(
   db: D1Database | undefined,
   trip: Trip,
-  reason: TripEndedReason | string | undefined,
+  reason: string | undefined,
   endedAt: number,
 ): Promise<void> {
   if (!db) return;

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -2331,8 +2331,7 @@ app.delete('/trips/:token', async (c) => {
     makeLaStats(),
     Date.now(),
     (msg, meta) => console.log(JSON.stringify({ msg, ...meta })),
-    undefined,
-    metricsReason,
+    { metricsReason },
   );
   return c.json({ ok: true, deleted: true });
 });

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -2313,6 +2313,13 @@ app.delete('/trips/:token', async (c) => {
       return getTrip(c.env.TRIPS, indexedToken);
     })());
   if (!existing) return c.json({ ok: true, deleted: false });
+  // #2268 — device가 실제 종료 사유(예: lockless-trip-end, 사용자 탭)를 알고 있으면 optional
+  // ?reason= 쿼리로 전달, D1 trip_metrics의 end_reason에 그대로 적재한다(6번째 인자
+  // metricsReason, cleanupTripWithLa 참고). 기존 alert-push 게이팅용 reason(5번째 인자)은 그대로
+  // undefined 유지 — DELETE 경로는 여전히 push를 새로 트리거하지 않는다(회귀 금지).
+  // 길이 제한(64자)은 자유 문자열이 D1 컬럼을 오염시키는 걸 막는 최소 방어 — 값 자체 검증(allowlist)은
+  // 하지 않는다(telemetry only, 분기 로직 없음).
+  const metricsReason = c.req.query('reason')?.trim().slice(0, 64) || undefined;
   // 활성 LA가 있으면 dismissal push 발사 후 KV 삭제. cleanupTripWithLa가 두 동작을 묶는다
   // (deviceToken 역인덱스 정리도 그 안에서 함께 처리된다, 리뷰 P1).
   // logger는 worker console.log로 직결 — HTTP-driven cleanup의 dismissal 실패가 silent loss로
@@ -2324,6 +2331,8 @@ app.delete('/trips/:token', async (c) => {
     makeLaStats(),
     Date.now(),
     (msg, meta) => console.log(JSON.stringify({ msg, ...meta })),
+    undefined,
+    metricsReason,
   );
   return c.json({ ok: true, deleted: true });
 });

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -292,6 +292,9 @@ function tripEndedAlertDedupKey(tripToken: string, createdAt: number): string {
  * 게이팅하는 기존 계약(위 주석)을 그대로 유지 — HTTP DELETE 경로가 metrics 정확도 개선을 위해
  * 종료 사유를 함께 보내더라도 이 값이 alert push를 새로 트리거하면 안 된다(기존 "DELETE 경로는
  * push 불필요" 동작 회귀 금지). `metricsReason` 미지정 시 `reason`을 그대로 D1에 적재(기존 동작).
+ *
+ * Sonar maintainability(파라미터 수 ≤7) — `reason`/`metricsReason`을 `options` 객체로 묶었다.
+ * 둘의 분리 목적(위 문단)은 그대로 유지, 파라미터 개수만 축소.
  */
 export async function cleanupTripWithLa(
   trip: Trip,
@@ -300,9 +303,9 @@ export async function cleanupTripWithLa(
   stats: LiveActivityStats,
   now: number,
   log: Logger,
-  reason?: TripEndedReason,
-  metricsReason?: string,
+  options?: { reason?: TripEndedReason; metricsReason?: string },
 ): Promise<void> {
+  const { reason, metricsReason } = options ?? {};
   await fireLiveActivityDismissal(trip, deps, stats, now, log);
   if (reason) {
     await fireTripEndedAlertPush(trip, reason, env, deps, now, log);

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -287,6 +287,11 @@ function tripEndedAlertDedupKey(tripToken: string, createdAt: number): string {
  *
  * push는 LA dismissal과 별개의 budget(분당 0~1건 trip 종료 수준)이라 LA push와 직렬 발사로 충분.
  * 실패 시 graceful — log만 남기고 cleanup 흐름은 계속 진행한다.
+ *
+ * #2268 — `metricsReason`은 `reason`과 분리된 D1 전용 파라미터. `reason`은 alert push 발사 여부를
+ * 게이팅하는 기존 계약(위 주석)을 그대로 유지 — HTTP DELETE 경로가 metrics 정확도 개선을 위해
+ * 종료 사유를 함께 보내더라도 이 값이 alert push를 새로 트리거하면 안 된다(기존 "DELETE 경로는
+ * push 불필요" 동작 회귀 금지). `metricsReason` 미지정 시 `reason`을 그대로 D1에 적재(기존 동작).
  */
 export async function cleanupTripWithLa(
   trip: Trip,
@@ -296,6 +301,7 @@ export async function cleanupTripWithLa(
   now: number,
   log: Logger,
   reason?: TripEndedReason,
+  metricsReason?: string,
 ): Promise<void> {
   await fireLiveActivityDismissal(trip, deps, stats, now, log);
   if (reason) {
@@ -354,7 +360,8 @@ export async function cleanupTripWithLa(
   }
   // #1835 — D1 trip_metrics 적재. 미바인딩(env.DB undefined) 시 내부에서 graceful no-op.
   // cleanup 흐름 차단 없음 — recordTripMetrics 자체가 try/catch로 swallow.
-  await recordTripMetrics(env.DB, trip, reason, now);
+  // #2268 — metricsReason이 있으면 alert-push 게이팅용 reason 대신 그 값을 적재(위 헤더 주석).
+  await recordTripMetrics(env.DB, trip, metricsReason ?? reason, now);
 }
 
 /**

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -1211,7 +1211,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     if (trip.expiresAt <= now) {
       // #586 D — trip 만료 시 활성 LA가 남아 있으면 dismissal push로 정리하고 KV에서 제거.
       // #868 — 클라 state sync용 trip-ended silent push도 함께 발사 (reason=expired).
-      await cleanupTripWithLa(trip, env, deps, stats, now, log, 'expired');
+      await cleanupTripWithLa(trip, env, deps, stats, now, log, { reason: 'expired' });
       continue;
     }
 
@@ -1231,7 +1231,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
         // ADR-023: backend는 이 값으로 발사 결정 X (log 전용).
         sleepMode: trip.sleepModeEnabled,
       });
-      await cleanupTripWithLa(trip, env, deps, stats, now, log, 'expired');
+      await cleanupTripWithLa(trip, env, deps, stats, now, log, { reason: 'expired' });
       continue;
     }
     if (lifecyclePhase === 'silence') {
@@ -1305,7 +1305,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
           // #2032 (Issue D) — monitoring dimension. ADR-023: 발사 결정 X.
           sleepMode: trip.sleepModeEnabled,
         });
-        await cleanupTripWithLa(trip, env, deps, stats, now, log, 'la-stale-backstop');
+        await cleanupTripWithLa(trip, env, deps, stats, now, log, { reason: 'la-stale-backstop' });
         continue;
       }
       // #2131 (Part A-2, ADR-014 동급 보장) — boarding-prompt 9단 게이트 평가를 lockless
@@ -3306,7 +3306,7 @@ async function handleEtaMissing(inputs: HandleEtaMissingInputs): Promise<void> {
         endReason,
         seoulHttpErrors: deps.seoul.stats.httpErrorCount,
       });
-      await cleanupTripWithLa(trip, env, deps, stats, now, log, endReason);
+      await cleanupTripWithLa(trip, env, deps, stats, now, log, { reason: endReason });
       return;
     }
     // #2157 (2026-08-05 결정 A) — 순수 eta-missing(Seoul API는 정상 응답, trainCode만
@@ -3682,7 +3682,7 @@ export async function advanceBoardingLockWaypoint(
           kind: waypoint.kind,
           backstopElapsedMs,
         });
-        await cleanupTripWithLa(trip, env, deps, stats, now, log, 'destination-arrived');
+        await cleanupTripWithLa(trip, env, deps, stats, now, log, { reason: 'destination-arrived' });
         await deleteSsot(env.TRIPS, trip.token);
         return;
       }
@@ -3701,7 +3701,7 @@ export async function advanceBoardingLockWaypoint(
 
   if (waypoint.kind === 'destination') {
     // #868 — destination 도착으로 trip 종료. 클라 state sync용 trip-ended silent push 발사.
-    await cleanupTripWithLa(trip, env, deps, stats, now, log, 'destination-arrived');
+    await cleanupTripWithLa(trip, env, deps, stats, now, log, { reason: 'destination-arrived' });
     // ADR-017 T5 (#1558) — trip 종료 시 SSoT 도 cleanup. cleanupTripWithLa 가 throw 하면
     // SSoT 가 남아있을 수 있으나 본 PR 스코프 외 (다음 cron 의 stale 정리 path 는 후속 PR).
     await deleteSsot(env.TRIPS, trip.token);
@@ -3866,7 +3866,7 @@ export async function advanceBoardingLockWaypoint(
     // #1707 — 본 분기 진입 전 상단 isCleanupAdvance 게이트가 cross-check 완료. gps-far 케이스는
     // 이미 early return으로 차단됐다. 여기 도달 = within / stale-gps / no-gps / station-unknown
     // 중 하나 = 정상 cleanup 진행.
-    await cleanupTripWithLa(trip, env, deps, stats, now, log, 'destination-arrived');
+    await cleanupTripWithLa(trip, env, deps, stats, now, log, { reason: 'destination-arrived' });
     // ADR-017 T5 (#1558) — trip 종료 시 SSoT cleanup.
     await deleteSsot(env.TRIPS, trip.token);
     return;
@@ -4105,7 +4105,7 @@ export async function maybeReschedulePush(
       // #868 — 클라 state sync용 trip-ended silent push도 발사 (reason=push-unrecoverable).
       // 단, 토큰 자체가 unrecoverable이면 push도 같은 이유로 실패할 가능성이 높음 — fireTripEndedPush
       // 내부에서 graceful log만 남기고 cleanup 흐름은 계속 진행한다.
-      await cleanupTripWithLa(trip, env, deps, stats, now, log, 'push-unrecoverable');
+      await cleanupTripWithLa(trip, env, deps, stats, now, log, { reason: 'push-unrecoverable' });
       return { cleanedUp: true };
     }
   }
@@ -4343,7 +4343,7 @@ export async function runLocklessIntermediate(
           envMismatchExhausted: heal.envMismatchExhausted,
         });
         // #868 — lockless push unrecoverable로 trip 폐기 시에도 클라 state sync push 발사.
-        await cleanupTripWithLa(trip, env, deps, stats, now, log, 'push-unrecoverable');
+        await cleanupTripWithLa(trip, env, deps, stats, now, log, { reason: 'push-unrecoverable' });
         return;
       }
       // #1721 — transient 실패(429 / 5xx) 시 retry queue 적재. unrecoverable / envMismatchExhausted
@@ -4428,7 +4428,7 @@ export async function runLocklessIntermediate(
   if (trip.waypoints.length === 0) {
     // 마지막 intermediate까지 통과 — trip 종료. lockless는 destination을 직접 다루지 않는다.
     // #868 — lockless trip의 effective destination-arrived도 동일 reason.
-    await cleanupTripWithLa(trip, env, deps, stats, now, log, 'destination-arrived');
+    await cleanupTripWithLa(trip, env, deps, stats, now, log, { reason: 'destination-arrived' });
     return;
   }
   // 다음 waypoint를 위해 dedup stamp reset (위 shift 직후 첫 waypoint는 새 발사 대상).


### PR DESCRIPTION
Part of #2268 (2026-08-10 RCA에서 식별된 telemetry 실버그 2건). backend `alarm-worker` trip 종료 경로만 수정 — 알람/fire 로직 변경 없음.

## 버그 1 — trip_metrics 중복 insert (race, idempotency 없음)

**Evidence**: 2026-08-10 trip이 `trip_metrics`에 동일 `trip_token_hash`로 2행(id 50/51, 521ms차) 기록.

**원인**: `DELETE /trips/:token`(`src/index.ts`)이 `getTrip` → `cleanupTripWithLa` 사이 원자 가드 없음. 두 DELETE가 race하면 둘 다 통과 → `cleanupTripWithLa`(`src/liveActivity.ts`)가 `recordTripMetrics`를 두 번 호출.

**수정 방식**: Cloudflare KV는 compare-and-swap/조건부 delete가 없어 "먼저 읽고 나만 지웠으면 진행" 같은 app-level 가드로는 서로 다른 isolate에서 도는 두 요청의 race를 실제로 닫을 수 없다(fake atomicity). 대신 D1(SQLite)이 제공하는 진짜 트랜잭션 원자성을 사용:
- `migrations/0004_trip_metrics_end_idempotency.sql`: `trip_metrics(trip_token_hash, started_at)` UNIQUE index 추가. `(trip_token_hash, started_at)`은 "이 trip 인스턴스의 이 종료 이벤트"를 유일 식별 — 같은 token이 나중에 새 trip으로 재등록되면 `started_at`(createdAt)이 달라 정상 신규 행은 막히지 않는다.
- `src/d1TripMetrics.ts`: `INSERT` → `INSERT OR IGNORE`. 두 번째 race 호출은 조용히 no-op(0 rows affected), 기존 try/catch에 걸리지 않고 정상 흐름 유지.

**재현 테스트**: `src/__tests__/d1TripMetrics.test.ts` `race idempotency (#2268)` — in-memory로 UNIQUE 제약을 재현한 fake D1에 동일 trip을 521ms 간격으로 동시 `recordTripMetrics` 호출 → 1행만 기록됨을 검증. 새 trip(`started_at` 다름)은 별도 행으로 기록됨도 함께 검증(회귀 방지).

## 버그 2 — end_reason 뭉갬

**증거**: `d1TripMetrics.ts`의 `reason ?? 'user-delete'` — HTTP DELETE 경로는 항상 `reason=undefined`로 호출돼 **모든 종료가 `user-delete`로 붕괴**. device의 lockless-trip-end/사용자 탭 등을 D1에서 구분 불가.

**수정 방식(backward-compat)**:
- `src/liveActivity.ts`: `cleanupTripWithLa`에 `metricsReason?: string` 파라미터 추가 — 기존 `reason`(alert push 발사 게이팅용, DELETE 경로는 지금도 `undefined` 유지)과 **완전히 분리**. `metricsReason`이 있으면 D1 적재 시 그 값을 우선 사용, 없으면 기존 `reason` 폴백(기존 동작 100% 보존).
- `src/index.ts`: `DELETE /trips/:token`이 optional `?reason=` 쿼리 파라미터를 받아 `metricsReason`으로 전달(길이 64자 캡, telemetry only — 값 검증/분기 없음). 미전달 시 기존 `'user-delete'` 폴백 그대로.

**프론트 wiring**: **follow-up으로 미룸.** `clearActiveTrip(token)`(`src/features/alarm/api/alarmBackend.ts`)은 `runTripBoundCleanups`(`src/features/alarm/store/tripBoundCleanups.ts`) 단일 경로에서 호출되며, 이 경로는 silent push trip-ended / 사용자 탭 / `useStateRehydration` sentinel / `useLaunchTripReconciliation` / `useDeviceSelfEnd` 등 서로 다른 다수 호출자가 공유한다. 각 호출자별 실제 종료 사유 컨텍스트가 현재 어디에도 없어, 제대로 배선하려면 `runTripBoundCleanups`부터 모든 호출자까지 reason 파라미터를 스레딩하는 별도 리팩터가 필요(간단한 단일 호출부 수정이 아님) — 이번 PR 스코프 밖. 별도 이슈로 분리 예정.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan`은 프론트 대상. backend 변경분(신규 export `metricsReason` 파라미터, migration)은 기존 `cleanupTripWithLa`/`recordTripMetrics` 호출부에 옵션 추가 — 신규 orphan export 없음.
2. **V/X dashboard** — `trip_metrics` 테이블은 Cloudflare D1 Dashboard(`alarm-worker` DB) 및 `src/queries/vxAcceptanceQueries.ts` 기반 쿼리로 직접 조회 가능. `end_reason` 컬럼 값 분포 확인으로 버그 2 회귀 여부 관측.
3. **의존 PR** — N/A (device 프론트 wiring은 별도 후속 이슈로 분리, 이 PR은 backend만으로 완결).
4. **측정 plan** — 머지 후 1주: D1 `SELECT trip_token_hash, COUNT(*) FROM trip_metrics GROUP BY trip_token_hash, started_at HAVING COUNT(*) > 1` 쿼리로 중복 행 재발 0건 확인. `end_reason='user-delete'` 비율이 `?reason=` 미전달 프론트 상태(이번 PR엔 프론트 변경 없음) 그대로이므로 즉시 변화는 없음 — follow-up PR 머지 후 비율 하락을 측정.
5. **Device verify** — N/A, type+unit only. 알람/fire 로직 변경 없음, KV/D1 read/write 경로만 수정.

## 검증
- `npm run type-check` pass
- `npm test`(vitest + coverage) — 80 files, 2966 tests pass. coverage ratchet floor(97/96/98/97) 통과.

머지는 CI green 확인 후 결정 권한자가 진행.