### PR TITLE
fix(#2281): hop-end/boarding prompt 발사 trip_metrics fired_count 미집계 수정

### DIFF
--- a/backend/alarm-worker/src/__tests__/d1TripMetrics.test.ts
+++ b/backend/alarm-worker/src/__tests__/d1TripMetrics.test.ts
@@ -169,6 +169,77 @@ describe('recordTripMetrics (#1835)', () => {
     });
   });
 
+  // #2281 — hop-end prompt(및 boarding-prompt) 발사가 trip.hopEndPromptState /
+  // trip.boardingPromptState에 이미 per-trip 기록되는데도 fired_count가 항상 0으로
+  // 하드코딩돼 D1에 반영되지 않던 갭. fired_count는 이 두 per-trip state에서 집계돼야 한다.
+  describe('fired_count 집계 (#2281)', () => {
+    it('hop-end prompt가 발사된 trip은 fired_count>0 이어야 한다', async () => {
+      const run = vi.fn().mockResolvedValue({ success: true });
+      let capturedArgs: unknown[] = [];
+      const bind = vi.fn().mockImplementation((...args: unknown[]) => {
+        capturedArgs = args;
+        return { run };
+      });
+      const prepare = vi.fn().mockReturnValue({ bind });
+      const db = { prepare } as unknown as D1Database;
+
+      const trip = makeTripFixture({
+        hopEndPromptState: {
+          '건대입구|7': { fired: true, lastFiredAt: NOW - 60_000, fireCount: 1 },
+        },
+      });
+
+      await recordTripMetrics(db, trip, 'destination-arrived', NOW);
+
+      // fired_count = 8번째 bind 인자 (positional index 7, 0-based) — INSERT 컬럼 순서 기준.
+      const firedCountArg = capturedArgs[7];
+      expect(firedCountArg).toBe(1);
+    });
+
+    it('boarding-prompt + hop-end prompt 둘 다 발사되면 fired_count가 합산된다', async () => {
+      const run = vi.fn().mockResolvedValue({ success: true });
+      let capturedArgs: unknown[] = [];
+      const bind = vi.fn().mockImplementation((...args: unknown[]) => {
+        capturedArgs = args;
+        return { run };
+      });
+      const prepare = vi.fn().mockReturnValue({ bind });
+      const db = { prepare } as unknown as D1Database;
+
+      const trip = makeTripFixture({
+        boardingPromptState: { fired: true, lastFiredAt: NOW - 120_000, fireCount: 2 },
+        hopEndPromptState: {
+          '건대입구|7': { fired: true, lastFiredAt: NOW - 60_000, fireCount: 1 },
+          '군자|5': { fired: true, lastFiredAt: NOW - 30_000, fireCount: 1 },
+        },
+      });
+
+      await recordTripMetrics(db, trip, 'destination-arrived', NOW);
+
+      const firedCountArg = capturedArgs[7];
+      // boardingPromptState.fireCount(2) + hopEndPromptState 2개 leg(각 1) = 4
+      expect(firedCountArg).toBe(4);
+    });
+
+    it('아무 prompt도 발사되지 않은 trip은 fired_count=0 이다', async () => {
+      const run = vi.fn().mockResolvedValue({ success: true });
+      let capturedArgs: unknown[] = [];
+      const bind = vi.fn().mockImplementation((...args: unknown[]) => {
+        capturedArgs = args;
+        return { run };
+      });
+      const prepare = vi.fn().mockReturnValue({ bind });
+      const db = { prepare } as unknown as D1Database;
+
+      const trip = makeTripFixture();
+
+      await recordTripMetrics(db, trip, 'destination-arrived', NOW);
+
+      const firedCountArg = capturedArgs[7];
+      expect(firedCountArg).toBe(0);
+    });
+  });
+
   // #2268 — device가 알고 있는 실제 종료 사유(예: lockless-trip-end)도 자유 문자열로 받아
   // end_reason에 그대로 적재한다. TripEndedReason(server-side auto-end 전용) 제약을 받지 않는다.
   it('device가 보고한 자유 문자열 reason도 end_reason에 그대로 적재된다', async () => {

--- a/backend/alarm-worker/src/d1TripMetrics.ts
+++ b/backend/alarm-worker/src/d1TripMetrics.ts
@@ -8,7 +8,7 @@
  */
 
 import { hashTripToken } from './sentry';
-import type { Trip } from './types';
+import type { BoardingPromptState, Trip } from './types';
 
 /**
  * trip_metrics 에 trip 종료 기록을 적재한다.
@@ -61,7 +61,9 @@ export async function recordTripMetrics(
         extractOriginStation(trip),
         trip.destination ?? null,
         JSON.stringify(lineList),
-        0, // fired_count: 현재 trip 객체에 누적 카운터 없음 — Phase 2 follow-up에서 추가
+        // #2281 — hop-end/boarding prompt가 trip.hopEndPromptState / trip.boardingPromptState에
+        // 이미 남기는 per-trip fireCount를 집계. 기존 컬럼(fired_count) 재사용 — 스키마 변경 없음.
+        computeFiredCount(trip),
         0, // suppressed_count: 동상
         boardingPromptState?.fired ? 1 : 0,
         0, // boarding_prompt_responded: 현재 Trip 타입에 responded 필드 없음 — Phase 2 follow-up에서 추가
@@ -94,6 +96,33 @@ function extractOriginStation(trip: Trip): string | null {
   const { passedStations } = trip;
   if (passedStations && passedStations.length > 0) return passedStations[0];
   return null;
+}
+
+/**
+ * #2281 — trip 전체에서 실제 발사된 prompt 수를 집계한다.
+ *
+ * 대상: boarding-prompt(`trip.boardingPromptState`) + hop-end prompt(`trip.hopEndPromptState`,
+ * leg별 dedup key로 여러 개 존재 가능) — 둘 다 사용자에게 응답을 요구하는 alert push이자, trip
+ * 객체에 이미 per-trip 발사 상태(`fireCount`/`fired`)를 갖고 있어 새 스키마 없이 집계 가능하다.
+ *
+ * 범위 밖(전수 감사, PR 본문 표 참조): intermediate/transfer/destination 알림, reschedule,
+ * lockless-intermediate, sleep-alarm companion, vanish release/fallback, train-reconfirm push는
+ * cron 단위(`ScheduledStats`) 집계만 있고 trip 객체에 영속 상태가 없다 — 포함하려면 Trip 스키마에
+ * 새 필드를 추가해야 해 이번 최소 변경 범위를 벗어난다(follow-up 후보).
+ */
+function computeFiredCount(trip: Trip): number {
+  const boardingFired = countPromptFires(trip.boardingPromptState);
+  const hopEndFired = Object.values(trip.hopEndPromptState ?? {}).reduce(
+    (sum, state) => sum + countPromptFires(state),
+    0,
+  );
+  return boardingFired + hopEndFired;
+}
+
+/** 단일 `BoardingPromptState`의 발사 횟수. `fireCount`(반복 발사 지원) 우선, 없으면 `fired` boolean. */
+function countPromptFires(state: BoardingPromptState | undefined): number {
+  if (state?.fireCount !== undefined) return state.fireCount;
+  return state?.fired ? 1 : 0;
 }
 
 /**


### PR DESCRIPTION
Closes #2281

## 원인

`backend/alarm-worker/src/d1TripMetrics.ts`의 `recordTripMetrics`가 `fired_count`를 항상 `0`으로 하드코딩 — trip 종료 시 D1에 실제 발사 횟수가 반영되지 않았다. hop-end prompt(`maybeFireHopEndPrompt`, `scheduled.ts:5133~5138`)는 발사 성공 시 `trip.hopEndPromptState[legKey] = markPromptFired(now)`로 **per-trip 상태는 이미 정확히 기록**하고 있었지만, `d1TripMetrics.ts`가 이 필드를 전혀 읽지 않아 D1에 반영되지 못했다. 2026-08-10 07:38 KST 건대입구 hop-end prompt 실발사가 `trip_metrics.fired_count=0`으로 남아 "device-local 발사"로 오판(2026-08-11 RCA)된 근본 원인.

## 수정

`fired_count` = `trip.boardingPromptState.fireCount` + `trip.hopEndPromptState`의 각 leg `fireCount`(합산). 기존 컬럼(`fired_count`)을 그대로 재사용 — **스키마 변경/마이그레이션 없음**, D1 write 패턴(trip 종료 시 1회 집계)도 불변.

## push kind × per-trip 집계 전수 감사

| push kind | send 함수 | 발사 위치 | trip 객체 per-trip 영속 상태 | fired_count 반영 (수정 전) | fired_count 반영 (수정 후) |
|---|---|---|---|---|---|
| boarding-prompt | `sendBoardingPromptPush` | `scheduled.ts:4951` | `trip.boardingPromptState` (`fireCount`/`fired`) | X (하드코딩 0) | **O** |
| hop-end prompt (하차 확인) | `sendBoardingPromptPush` | `scheduled.ts:5101` | `trip.hopEndPromptState[legKey]` (`fireCount`/`fired`) | X (이슈 원인) | **O** |
| intermediate/transfer/destination station-arrival alert | `sendAlertPush` | `scheduled.ts:2448` | 없음 (cron `ScheduledStats`만) | X | X — 범위 밖(아래 사유) |
| vanish release/fallback station-arrival alert | `sendAlertPush` | `scheduled.ts:2856` | 없음 | X | X — 범위 밖 |
| train-reconfirm alert | `sendAlertPush` | `scheduled.ts:3059` | 없음 | X | X — 범위 밖 |
| sleep-alarm companion push | `sendSleepAlarmCompanionPush` | `scheduled.ts:2192` | 없음 | X | X — 범위 밖 |
| transfer 갱신 silent push | `sendSilentPush` | `scheduled.ts:3783` | 없음 | X | X — 범위 밖 (원래도 non-prompt) |
| reschedule push | `sendReschedulePush` | `scheduled.ts:4036` | 없음 | X | X — 범위 밖 |
| lockless-intermediate silent push | `sendSilentPush` | `scheduled.ts:4297` | 없음 | X | X — 범위 밖 |

**범위 밖 사유**: 위 7종은 cron 사이클(`ScheduledStats`) 집계만 있고 `Trip` 객체에 발사 이력을 영속하는 필드가 없다 — 포함하려면 `Trip` 스키마에 새 카운터 필드를 추가하고 각 발사 지점에서 갱신해야 해 "스키마 변경 최소화" 요구(이슈 본문)를 벗어난다. `fired_count`는 이번 수정으로 "사용자 응답 대기 prompt"(boarding/hop-end) 발사 여부의 신뢰 가능한 신호가 된다 — 원 RCA 오판(prompt 미집계 → device-local 오판)을 해소하기에는 이 범위로 충분. 나머지 kind까지 일반화하려면 별도 이슈로 분리 권장.

## Wire-completion 5단

1. **Orphan 없음** — N/A (backend, orphan lint는 frontend 전용)
2. **V/X dashboard** — D1 `trip_metrics` 테이블을 `wrangler d1 execute`/Cloudflare Dashboard로 조회해 `SELECT fired_count FROM trip_metrics WHERE trip_token_hash = ...`로 확인 가능
3. **의존 PR** — N/A
4. **측정 plan** — 다음 실탑승에서 boarding-prompt 또는 hop-end prompt가 발사된 trip의 `trip_metrics.fired_count > 0`인지 D1 쿼리로 확인
5. **Device verify** — N/A — backend only (type-check + unit)

## 테스트

- RED: hop-end fire 후 `fired_count` 미집계 재현 3개 테스트 추가(`d1TripMetrics.test.ts`) → 수정 후 GREEN
- `backend/alarm-worker`: `npm test` 2963 tests pass, `npm run type-check` clean
- 기존 trip_metrics idempotency(#2277 UNIQUE INDEX) 회귀 없음 — 관련 테스트 그대로 pass
