### PR TITLE
fix(#2278): 하차 응답 후 leg-advance 로컬 stamp — 다음 leg 전환 실패 수리

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -87,6 +87,17 @@ jest.mock('../../store/useUserIntentStore', () => {
   };
 });
 
+// #2278 — useLegAdvanceStore mock. hop-end BOARDED 응답에서 stampLegAdvance 호출 검증.
+jest.mock('../../store/useLegAdvanceStore', () => {
+  const mockStampLegAdvance = jest.fn();
+  return {
+    useLegAdvanceStore: {
+      getState: () => ({ stampLegAdvance: mockStampLegAdvance }),
+    },
+    __mockStampLegAdvance: mockStampLegAdvance,
+  };
+});
+
 const { findStationByNameAndLine } = jest.requireMock('../../../../shared/utils/stationLookup');
 const {
   logBoardingPromptAutoLock,
@@ -101,6 +112,9 @@ const { __mockCreateLock: createLockMock, __mockReleaseLock: releaseLockMock } =
 );
 const { __mockSetInfoModeEnabled: setInfoModeEnabledMock } = jest.requireMock(
   '../../store/useUserIntentStore',
+);
+const { __mockStampLegAdvance: stampLegAdvanceMock } = jest.requireMock(
+  '../../store/useLegAdvanceStore',
 );
 const displayLoggerMock = jest.requireMock('../useBoardingPromptDisplayLogger');
 
@@ -962,6 +976,42 @@ describe('handleResponse — #2034 hop-end', () => {
     );
     expect(positionUpload.dismissBoardingPrompt).toHaveBeenCalledWith('tok-hop');
     expect(releaseLockMock).not.toHaveBeenCalled();
+  });
+
+  // #2278 — 건대입구 7→2 환승 실기기 RCA. HOP_END_PAYLOAD.nextLine='K'는 유효한 LineNumber가
+  // 아니므로(테스트 placeholder) 위 케이스들에서는 stampLegAdvance가 호출되지 않는다 — 유효한
+  // nextLine('2')을 가진 payload로 stamp 발사를 별도 검증한다.
+  const HOP_END_PAYLOAD_VALID_NEXT_LINE = {
+    ...HOP_END_PAYLOAD,
+    nextLine: '2',
+  };
+
+  it('[하차함] (BOARDED action) + 유효한 nextLine → useLegAdvanceStore.stampLegAdvance(nextLine) 호출', async () => {
+    await handleResponse(
+      BOARDING_PROMPT_ACTION_BOARDED,
+      HOP_END_PAYLOAD_VALID_NEXT_LINE,
+      makeHandleResponseDeps(),
+    );
+    expect(stampLegAdvanceMock).toHaveBeenCalledTimes(1);
+    expect(stampLegAdvanceMock).toHaveBeenCalledWith('2');
+  });
+
+  it('[하차함] (BOARDED action) + 유효하지 않은 nextLine("K") → stampLegAdvance 호출 안 함 (기존 동작 유지)', async () => {
+    await handleResponse(
+      BOARDING_PROMPT_ACTION_BOARDED,
+      HOP_END_PAYLOAD,
+      makeHandleResponseDeps(),
+    );
+    expect(stampLegAdvanceMock).not.toHaveBeenCalled();
+  });
+
+  it('[아직] (NOT_BOARDED action) → stampLegAdvance 호출 안 함', async () => {
+    await handleResponse(
+      BOARDING_PROMPT_ACTION_NOT_BOARDED,
+      HOP_END_PAYLOAD_VALID_NEXT_LINE,
+      makeHandleResponseDeps(),
+    );
+    expect(stampLegAdvanceMock).not.toHaveBeenCalled();
   });
 
   it('breadcrumb "boarding_prompt_interactive_tap" 에 hopEndKind=disembark 스탬프', async () => {

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -11,6 +11,7 @@ import { AppState, type AppStateStatus } from 'react-native';
 import * as Haptics from 'expo-haptics';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import { useUserIntentStore } from '../store/useUserIntentStore';
+import { useLegAdvanceStore } from '../store/useLegAdvanceStore';
 import { resolveTripDirection } from '../../route/utils/tripDirection';
 import { getApproachLineWithConfirmation } from '../../route/utils/approachLine';
 import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
@@ -268,9 +269,12 @@ export function useBoardingLockController({
   // `confirmed=false`(route/lock 후보 없음, fusion `currentStation.line` 임의값(#797))이면
   // 어떤 candidate 필터에도 이 line을 쓰지 않는다(누락 방지) — origin auto-lock 전용
   // `originAutoLockArrivals`(하단)에서만 소비한다.
+  // #2278 — 사용자 하차 응답 stamp. lock 해제 직후 route 진행도가 아직 못 따라온 gap을
+  // 로컬에서 즉시 메운다 (getApproachLine 우선순위: lock > legAdvance > route > fallback).
+  const legAdvanceLine = useLegAdvanceStore((s) => s.nextLine);
   const { line: approachLine, confirmed: approachLineConfirmed } = useMemo(
-    () => getApproachLineWithConfirmation(route, lock, currentStation),
-    [route, lock, currentStation],
+    () => getApproachLineWithConfirmation(route, lock, currentStation, legAdvanceLine),
+    [route, lock, currentStation, legAdvanceLine],
   );
 
   const directionalArrivals = useMemo<ArrivalInfo[]>(() => {

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -28,6 +28,9 @@ import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival'
 import { dismissBoardingPrompt } from '../../nearest-station/api/positionUpload';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import { useUserIntentStore } from '../store/useUserIntentStore';
+import { useLegAdvanceStore } from '../store/useLegAdvanceStore';
+import { LINE_API_NAMES } from '../../../shared/constants/lineApiNames';
+import type { LineNumber } from '../../../shared/types/station';
 import { pickAutoTrainCodeFromArrivals } from '../utils/boardingPromptAutoLock';
 import {
   logBoardingPromptAutoLock,
@@ -265,6 +268,13 @@ async function handleHopEndResponse(
     } catch (err) {
       log.warn('hop-end releaseLock failed', err as Error);
     }
+    // #2278 — 사용자 명시 [하차함] 응답 = ground truth. releaseLock으로 lock이 사라진 뒤
+    // getApproachLine이 route의 stopsToTransfer(backend SSoT 왕복 지연 가능)에 의존하지 않고
+    // 즉시 다음 leg 노선을 반환하도록 로컬에 stamp한다. nextLine이 유효한 LineNumber가 아니면
+    // (구버전 backend 등 payload 누락) 기존 동작(route/lock fallback) 그대로 유지 — skip.
+    if (isValidLineNumber(payload.nextLine)) {
+      useLegAdvanceStore.getState().stampLegAdvance(payload.nextLine);
+    }
     if (
       actionIdentifier === Notifications.DEFAULT_ACTION_IDENTIFIER &&
       deps.onBannerTap !== undefined
@@ -278,6 +288,14 @@ async function handleHopEndResponse(
     line: payload.line,
   });
   await dismissBoardingPrompt(payload.tripToken);
+}
+
+/**
+ * #2278 — payload.nextLine(string | undefined)이 유효한 LineNumber인지 narrow.
+ * `LINE_API_NAMES`(shared, 노선 추가 시 이미 갱신되는 SSoT) key 집합으로 데이터 주도 검증한다.
+ */
+function isValidLineNumber(value: string | undefined): value is LineNumber {
+  return value !== undefined && Object.prototype.hasOwnProperty.call(LINE_API_NAMES, value);
 }
 
 async function tryAutoLock(

--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -28,6 +28,7 @@ import { clearBackendSsotMirror } from '../../utils/backendSsotMirror';
 import { clearLastSilentPushReceivedAt } from '../../utils/lastSilentPushReceivedAt';
 import { useDestinationStore } from '../../../route/store/useDestinationStore';
 import { useBoardingLockStore } from '../useBoardingLockStore';
+import { useLegAdvanceStore } from '../useLegAdvanceStore';
 import { useAlarmEventStore } from '../useAlarmEventStore';
 import {
   clearLockLifecycleEntries,
@@ -445,6 +446,14 @@ describe('tripBoundCleanups', () => {
       expect(useBoardingLockStore.getState().lock).toBeNull();
       expect(useAlarmEventStore.getState().alarmEvent).toBeNull();
       expect(useAlarmEventStore.getState().dismissSilence).toBeNull();
+    });
+
+    it('#2278: leg-advance stamp도 trip 경계에서 클리어된다 (이전 trip 하차 확인이 새 trip에 leak 차단)', async () => {
+      useLegAdvanceStore.setState({ nextLine: '2' });
+
+      await runTripBoundCleanups();
+
+      expect(useLegAdvanceStore.getState().nextLine).toBeNull();
     });
 
     it('#1573 (T10): clearBackendSsotMirror가 TRIP_BOUND_CLEANUPS에 포함된다 (Mirror leak #3 가드)', () => {

--- a/src/features/alarm/store/__tests__/useLegAdvanceStore.test.ts
+++ b/src/features/alarm/store/__tests__/useLegAdvanceStore.test.ts
@@ -1,0 +1,28 @@
+import { useLegAdvanceStore } from '../useLegAdvanceStore';
+
+describe('useLegAdvanceStore (#2278)', () => {
+  beforeEach(() => {
+    useLegAdvanceStore.setState({ nextLine: null });
+  });
+
+  it('초기 상태는 nextLine=null', () => {
+    expect(useLegAdvanceStore.getState().nextLine).toBeNull();
+  });
+
+  it('stampLegAdvance — nextLine을 세팅한다', () => {
+    useLegAdvanceStore.getState().stampLegAdvance('2');
+    expect(useLegAdvanceStore.getState().nextLine).toBe('2');
+  });
+
+  it('clearLegAdvance — nextLine을 null로 되돌린다', () => {
+    useLegAdvanceStore.getState().stampLegAdvance('2');
+    useLegAdvanceStore.getState().clearLegAdvance();
+    expect(useLegAdvanceStore.getState().nextLine).toBeNull();
+  });
+
+  it('재-stamp — 이전 값을 덮어쓴다 (다음 leg로 갱신)', () => {
+    useLegAdvanceStore.getState().stampLegAdvance('2');
+    useLegAdvanceStore.getState().stampLegAdvance('8');
+    expect(useLegAdvanceStore.getState().nextLine).toBe('8');
+  });
+});

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -43,6 +43,7 @@ import { clearActiveTrip, resetAlarmBackendDedup } from '../api/alarmBackend';
 import { getNotificationRouter } from '../api/notificationRouter';
 import { useDestinationStore } from '../../route/store/useDestinationStore';
 import { useBoardingLockStore } from './useBoardingLockStore';
+import { useLegAdvanceStore } from './useLegAdvanceStore';
 import { useAlarmEventStore } from './useAlarmEventStore';
 import { resetUserIntentInfoMode } from './useUserIntentStore';
 import { createLogger } from '../../../shared/utils/logger';
@@ -228,6 +229,11 @@ async function clearTripBoundStoreMemory(): Promise<void> {
   }
   if (alarmState.dismissSilence !== null) {
     useAlarmEventStore.setState({ dismissSilence: null });
+  }
+  // #2278 — leg-advance stamp도 trip 경계에서 클리어. 이전 trip의 hop-end 확인이 새 trip의
+  // getApproachLine 우선순위를 오염시키지 않도록 한다 (in-memory only, 별도 storage 없음).
+  if (useLegAdvanceStore.getState().nextLine !== null) {
+    useLegAdvanceStore.setState({ nextLine: null });
   }
   return Promise.resolve();
 }

--- a/src/features/alarm/store/useLegAdvanceStore.ts
+++ b/src/features/alarm/store/useLegAdvanceStore.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand';
+import type { LineNumber } from '../../../shared/types/station';
+
+/**
+ * #2278 — 환승역 하차 응답/버튼 leg-advance stamp SSoT.
+ *
+ * RCA(2026-08-11 건대입구 7→2 환승 실기기 dump): `useBoardingPromptResponder`의
+ * hop-end 응답(`handleHopEndResponse`)이 `releaseLock('user')`만 수행하고 leg advance를
+ * 로컬에 stamp하지 않아, `getApproachLine`이 그 다음으로 route의 `stopsToTransfer` 진행도에
+ * 의존했다. 그 진행도는 backend `/boarding-lock/sync` 왕복(SSoT)로만 갱신되는데 지하 실패 시
+ * frozen 상태로 남아 BoardingTrainList가 계속 이전 노선(7호선) 열차만 노출했다(가설 1 확정).
+ *
+ * 사용자의 명시 하차 응답/버튼 = ground truth(ADR-032) → 이 store가 그 사실을 로컬에서 즉시
+ * 반영해 `getApproachLine`이 backend 왕복과 무관하게 다음 leg 노선을 반환하도록 한다.
+ *
+ * lifecycle:
+ *  - stamp: `useBoardingPromptResponder.handleHopEndResponse`가 hop-end BOARDED/$default
+ *    응답에서 payload.nextLine이 유효한 LineNumber일 때 호출.
+ *  - clear: `tripBoundCleanups.clearTripBoundStoreMemory`가 trip 종료 4개 진입점 공통 경로에서
+ *    호출 — 이전 trip의 stamp가 새 trip에 leak되는 것을 방지.
+ *  - 의도적으로 AsyncStorage 영속화하지 않는다 — 이 stamp는 backend SSoT가 따라올 때까지의
+ *    임시 bridge이며, cold start 시에는 route/lock 기반 기존 우선순위로 자연 복귀해도 안전하다
+ *    (앱 재시작 시점엔 GPS/route가 다시 fresh하게 계산되므로).
+ */
+export interface LegAdvanceState {
+  /** 사용자가 마지막으로 확인한 다음 leg 노선. 미확인/이미 소비 완료 시 null. */
+  nextLine: LineNumber | null;
+  /** 사용자 명시 하차 응답/버튼 시점에 다음 leg 노선을 stamp한다. */
+  stampLegAdvance: (line: LineNumber) => void;
+  /** trip 종료 등으로 stamp를 무효화한다. */
+  clearLegAdvance: () => void;
+}
+
+export const useLegAdvanceStore = create<LegAdvanceState>((set) => ({
+  nextLine: null,
+  stampLegAdvance: (line: LineNumber) => set({ nextLine: line }),
+  clearLegAdvance: () => set({ nextLine: null }),
+}));

--- a/src/features/route/utils/__tests__/approachLine.test.ts
+++ b/src/features/route/utils/__tests__/approachLine.test.ts
@@ -146,6 +146,33 @@ describe('getApproachLine', () => {
     });
   });
 
+  describe('legAdvance override (#2278 RCA — 가설 1 확정: releaseLock 후 stopsToTransfer 미갱신)', () => {
+    it('가설 1 재현: lock 해제 + route.stopsToTransfer 미갱신(frozen) → legAdvance 없이는 여전히 fromLine(구 노선) 반환', () => {
+      // 건대입구 7→2 환승: 사용자가 하차 응답 후 releaseLock(lock=null)했지만 route의 진행도
+      // (stopsToTransfer)는 backend SSoT 갱신 지연으로 아직 3(환승 전)에 머물러 있다.
+      // legAdvance 힌트 없이는 route가 여전히 fromLine('7')을 반환 — 이것이 BoardingTrainList가
+      // 7호선 열차만 보여준 회귀의 근본 원인(가설 1 확정).
+      const route = makeTransfer('7', '2', 3);
+      expect(getApproachLine(route, null, null)).toBe('7');
+    });
+
+    it('사용자 명시 하차 응답 stamp(legAdvance) 존재 시 lock=null + stale route라도 nextLine 반환', () => {
+      const route = makeTransfer('7', '2', 3);
+      expect(getApproachLine(route, null, null, '2')).toBe('2');
+    });
+
+    it('legAdvance가 있어도 lock이 여전히 존재하면 lock.boardingLine이 최우선', () => {
+      const route = makeTransfer('7', '2', 3);
+      const lock = makeLock('7');
+      expect(getApproachLine(route, lock, null, '2')).toBe('7');
+    });
+
+    it('legAdvance 없음(undefined)이면 기존 동작(route 기반) 그대로', () => {
+      const route = makeTransfer('7', '2', 0);
+      expect(getApproachLine(route, null, null, null)).toBe('2');
+    });
+  });
+
   describe('현재역 line 검증 가드 (#1325)', () => {
     it('후보 line을 현재역이 실제 서비스하면 그대로 반환', () => {
       // 신당은 2,6호선 정차 → boardingLine 6호선이면 검증 통과.

--- a/src/features/route/utils/approachLine.ts
+++ b/src/features/route/utils/approachLine.ts
@@ -11,8 +11,11 @@ import type { LineNumber, Station } from '../../../shared/types/station';
  *
  * 우선순위:
  *   1. **BoardingLock 존재** → `boardingLock.boardingLine` (사용자가 명시 선택한 leg, 가장 강한 신호)
- *   2. **Route + segment 진행도** → 다음 환승 전이면 fromLine, 환승 도착(stopsToTransfer===0)이면 toLine
- *   3. **fallback** → `currentStation?.line ?? null`
+ *   2. **legAdvance stamp** → 사용자가 환승역 하차 응답/버튼으로 명시 확인한 다음 leg 노선
+ *      (#2278). lock은 해제 직후 null이 되지만 route의 `stopsToTransfer` 진행도는 backend SSoT
+ *      갱신 지연으로 즉시 따라오지 못한다(RCA 가설 1 확정) — 그 gap을 메우는 로컬 ground truth.
+ *   3. **Route + segment 진행도** → 다음 환승 전이면 fromLine, 환승 도착(stopsToTransfer===0)이면 toLine
+ *   4. **fallback** → `currentStation?.line ?? null`
  *
  * stopsToTransfer===0의 의미 모호성(환승역 정확 도착 vs 환승 완료)은 BoardingLock이 있으면 1번에서
  * 해소된다. lock 없는 케이스는 "transferring or transferred"로 추정 → toLine 안내가 더 유용
@@ -40,8 +43,14 @@ export function getApproachLineWithConfirmation(
   route: Route,
   boardingLock: BoardingLock | null,
   currentStation: Station | null,
+  /**
+   * #2278 — 사용자가 환승역 하차 응답/버튼으로 명시 확인한 다음 leg 노선.
+   * `useLegAdvanceStore`가 SSoT. lock=null이고 route 진행도가 아직 못 따라온 구간을
+   * 로컬에서 즉시 메운다. 미전달(undefined) 또는 null이면 기존 동작(우선순위 3~4) 그대로.
+   */
+  legAdvanceLine?: LineNumber | null,
 ): ApproachLineResult {
-  const candidate = resolveCandidateLine(route, boardingLock);
+  const candidate = resolveCandidateLine(route, boardingLock, legAdvanceLine ?? null);
   const confirmed = candidate !== null;
 
   if (candidate && currentStation) {
@@ -58,13 +67,19 @@ export function getApproachLine(
   route: Route,
   boardingLock: BoardingLock | null,
   currentStation: Station | null,
+  legAdvanceLine?: LineNumber | null,
 ): LineNumber | null {
-  return getApproachLineWithConfirmation(route, boardingLock, currentStation).line;
+  return getApproachLineWithConfirmation(route, boardingLock, currentStation, legAdvanceLine).line;
 }
 
 /** route + BoardingLock SSOT로 우선순위에 따라 노선을 산출한다 (검증 전 raw 후보). */
-function resolveCandidateLine(route: Route, boardingLock: BoardingLock | null): LineNumber | null {
+function resolveCandidateLine(
+  route: Route,
+  boardingLock: BoardingLock | null,
+  legAdvanceLine: LineNumber | null,
+): LineNumber | null {
   if (boardingLock) return boardingLock.boardingLine;
+  if (legAdvanceLine) return legAdvanceLine;
 
   if (route) {
     if (route.type === 'direct') return route.line;

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -16,6 +16,7 @@ import { useDestinationStore } from '../features/route/store/useDestinationStore
 import { useAlarmEventStore } from '../features/alarm/store/useAlarmEventStore';
 import { useBoardingLockStore } from '../features/alarm/store/useBoardingLockStore';
 import { useUserIntentStore } from '../features/alarm/store/useUserIntentStore';
+import { useLegAdvanceStore } from '../features/alarm/store/useLegAdvanceStore';
 import { useNavigationStore } from '../features/route/store/useNavigationStore';
 import { DestinationPicker } from '../features/route/components/DestinationPicker';
 import { findRouteCandidatesByCategory, findRoutes, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, getStationById, routeSignature, type Route, type CategorizedRoute, type RoutePreference } from '../shared/utils/stationRoute';
@@ -490,8 +491,10 @@ export default function HomeScreen() {
     [effectiveOrigin, sleepMode, t, addRecentDestination, setDestination],
   );
   // #797: 환승역에서 nearest.station.line이 trip 방향과 어긋나는 회귀 차단.
-  // BoardingLock(사용자 선택) > Route(구조적 SSOT) > station.line fallback.
-  const approachLine = getApproachLine(route, fusionBoardingLock, effectiveOrigin);
+  // BoardingLock(사용자 선택) > legAdvance(#2278, 사용자 하차 응답 stamp) > Route(구조적 SSOT) >
+  // station.line fallback.
+  const legAdvanceLine = useLegAdvanceStore((s) => s.nextLine);
+  const approachLine = getApproachLine(route, fusionBoardingLock, effectiveOrigin, legAdvanceLine);
   // D7 (#1213) ETA provider SSOT — 현재역 BoardingTrainList(via boardingListArrivals)와
   // 정상 Arrival 표시(EditorialArrivalRow via ArrivalDirectionGroup)는 둘 다 아래 `arrival`을
   // 출처로 사용한다. 절대 시각 anchor도 arrivalAt(item)으로 통일(#897 Seam A). 따라서 두 surface의


### PR DESCRIPTION
Closes #2278

## RCA — 가설 1~3 배제/확정 (RED test 선행)

- **가설 1 (확정)**: `releaseLock` 후에도 `route.stopsToTransfer`가 backend `/boarding-lock/sync` 왕복 지연으로 frozen 상태를 유지 → `getApproachLine`이 계속 `fromLine`(구 노선)을 반환. `src/features/route/utils/__tests__/approachLine.test.ts`의 "가설 1 재현" 테스트로 재현(RED) 후 fix로 GREEN 전환.
- **가설 2 (배제)**: lock 재-hydrate 루프는 이 결함의 원인이 아님 — `releaseLock` 후 lock은 그대로 null 유지되며(재현 테스트에서 lock=null 고정), 문제는 lock이 없는 상태에서 route 진행도 하나에만 의존하는 fallback 설계에 있었다.
- **가설 3 (배제)**: `releaseLock` 자체는 실패하지 않는다(`try/catch`로 이미 방어됨, 기존 테스트 "releaseLock 실패해도 응답 처리 계속 진행" pass). silent catch가 원인이 아님.

## 수정 방향 (ADR-032 정합)

사용자의 하차 응답/버튼 = ground truth. 신규 `useLegAdvanceStore`가 hop-end BOARDED/\$default 응답의 `payload.nextLine`을 로컬에 stamp하고, `getApproachLine`이 backend 왕복과 무관하게 즉시 다음 leg 노선을 반환하도록 우선순위에 삽입했다 (BoardingLock > legAdvance > route 진행도 > fallback). 무탭 자동 lock 경로는 추가하지 않았다(#2154 준수) — 오직 사용자 명시 응답(BOARDED/\$default)만 stamp를 발사한다. trip 종료 시 `tripBoundCleanups`에서 stamp를 클리어해 다음 trip으로 leak되지 않는다.

## 변경 파일
- `src/features/alarm/store/useLegAdvanceStore.ts` (신규)
- `src/features/route/utils/approachLine.ts` — `legAdvanceLine` 파라미터 추가
- `src/features/alarm/hooks/useBoardingPromptResponder.ts` — hop-end BOARDED/\$default에서 stamp
- `src/features/alarm/hooks/useBoardingLockController.ts` / `src/screens/HomeScreen.tsx` — legAdvanceLine 전달
- `src/features/alarm/store/tripBoundCleanups.ts` — trip 경계 stamp 클리어
- 대응 테스트 4개 파일 (approachLine / useBoardingPromptResponder / tripBoundCleanups / useLegAdvanceStore 신규)

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (로컬 확인 완료).
2. **V/X dashboard** — 신규 신호 없음(순수 로컬 store 우선순위 삽입). 기존 `hop_end_prompt_confirmed` breadcrumb(Sentry)에서 hop-end 응답 자체는 이미 관측 가능. 필요 시 DebugModal "BoardingLock Lifecycle" 섹션과 별개로 `stampLegAdvance` 발사 여부는 실기기 BoardingTrainList 노선 전환 결과로 간접 관측.
3. **의존 PR** — N/A (단독, device-local fix, backend 비종속이 이 fix의 핵심).
4. **측정 plan** — 다음 실탑승 7→2(또는 임의 환승역)에서 하차 응답/버튼 후 BoardingTrainList가 즉시 다음 leg 노선 열차를 노출하는지 확인. 회귀 시 `approachLine.test.ts`의 가설 1 재현 테스트가 다시 RED로 전환되는지로 1차 코드 레벨 가드.
5. **Device verify** — 필요. 7→2 환승(또는 임의 환승역) 실기기 시나리오: 환승역 hop-end 알림 [하차함] 응답 또는 수동 "하차" 버튼 탭 → BoardingTrainList가 다음 leg 노선으로 즉시 전환되는지 확인.

## 검증
- `npm test` — 437 suites / 9379 tests pass, coverage 100% (lines/branches/functions/statements)
- `npm run type-check` — pass
- `npm run lint:orphan` — pass (orphan 0건)
