### PR TITLE
fix(#2279): 알람 ETA를 hop 시간 실측 상한으로 clamp

### DIFF
--- a/src/features/alarm/__tests__/replay_20260807_phantom.test.ts
+++ b/src/features/alarm/__tests__/replay_20260807_phantom.test.ts
@@ -45,6 +45,7 @@ const mockUpdateRouteFromPosition = jest.fn();
 const mockIsStationOnRoute = jest.fn();
 const mockIsSameStationName = jest.fn((a: string, b: string) => a === b);
 const mockGetFirstLeg = jest.fn((..._args: unknown[]) => ({ line: '2', endName: '' }));
+const mockGetRouteRemainingSeconds = jest.fn((..._args: unknown[]) => 120);
 jest.mock('../../../shared/utils/stationRoute', () => ({
   findRoute: (...args: unknown[]) => mockFindRoute(...args),
   calculateStaticETA: (...args: unknown[]) => mockCalculateStaticETA(...args),
@@ -52,6 +53,8 @@ jest.mock('../../../shared/utils/stationRoute', () => ({
   isStationOnRoute: (...args: unknown[]) => mockIsStationOnRoute(...args),
   isSameStationName: (a: string, b: string) => mockIsSameStationName(a, b),
   getFirstLeg: (...args: unknown[]) => mockGetFirstLeg(...args),
+  // #2279 — stationPipeline이 route 존재 시 estimateTransitEtaSeconds의 hop-time 상한으로 사용.
+  getRouteRemainingSeconds: (...args: unknown[]) => mockGetRouteRemainingSeconds(...args),
 }));
 
 const mockEvaluateAlarmPhase = jest.fn();

--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -693,7 +693,11 @@ describe('useStationAlarm', () => {
     });
   });
 
-  it('passes null etaSeconds when speed is null', async () => {
+  // #2279 — speed가 null이면 distance/speed 나눗셈 자체를 폐기하고 route의 실측 hop 시간 합
+  // (getRouteRemainingSeconds)으로 fallback한다. makeDirectRoute(3, '2')는 3 stops ×
+  // STOP_FALLBACK_SECONDS(120) = 360s. 과거엔 speed null → etaSeconds null(정보 없음)이었으나,
+  // hop 기반 값이 항상 계산 가능해졌으므로 더 이상 null을 반환하지 않는다.
+  it('falls back to hop-based etaSeconds when speed is null', async () => {
     const route = makeDirectRoute(3, '2');
     renderHook(() =>
       useStationAlarm(
@@ -702,7 +706,7 @@ describe('useStationAlarm', () => {
     );
     await waitFor(() =>
       expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
-        expect.objectContaining({ etaSeconds: null }),
+        expect.objectContaining({ etaSeconds: 360 }),
         expect.any(Set),
         undefined,
         expect.any(Array),

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { AppState } from 'react-native';
 import {
   getFirstLeg,
+  getRouteRemainingSeconds,
   isStationOnRoute,
   isSameStationName,
   isStationWithinHopWindow,
@@ -20,7 +21,7 @@ import type { Route } from '../../../shared/utils/stationRoute';
 import type { Station } from '../../../shared/types/station';
 import { alarmKey, parseAlarmKey, evaluateAlarmPhase, type AlarmEvent } from '../utils/stationAlarm';
 import { resolveAlarmDirection } from '../utils/alarmDirection';
-import { distanceMetersBetween, estimateEtaSeconds } from '../../../shared/utils/stationEta';
+import { distanceMetersBetween, estimateTransitEtaSeconds } from '../../../shared/utils/stationEta';
 import { isImminentByArrivalCode } from '../../arrival/utils/imminentArrivalSignal';
 import { findFgArvlCdFireSignal } from '../utils/fgArvlCdFastPath';
 import type { StationArrival } from '../../../shared/types/arrival';
@@ -1093,7 +1094,9 @@ export function useStationAlarm({
         destination.lat,
         destination.lng,
       );
-      etaSeconds = estimateEtaSeconds(distM, speedMps);
+      // #2279 — route는 이 effect 상단(!route return)에서 이미 non-null 보장.
+      // haversine 직선거리÷순간속도의 정거장수-무관 과대추정을 실측 hop 시간 합으로 clamp.
+      etaSeconds = estimateTransitEtaSeconds(distM, speedMps, getRouteRemainingSeconds(route));
     }
 
     const suppressed: AlarmEvent[] = [];

--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -18,6 +18,7 @@ const mockUpdateRouteFromPosition = jest.fn();
 const mockIsStationOnRoute = jest.fn();
 const mockIsSameStationName = jest.fn((a: string, b: string) => a === b);
 const mockGetFirstLeg = jest.fn((..._args: unknown[]) => ({ line: '2', endName: '' }));
+const mockGetRouteRemainingSeconds = jest.fn((..._args: unknown[]) => 360);
 jest.mock('../../../../shared/utils/stationRoute', () => ({
   findRoute: (...args: unknown[]) => mockFindRoute(...args),
   calculateStaticETA: (...args: unknown[]) => mockCalculateStaticETA(...args),
@@ -25,6 +26,8 @@ jest.mock('../../../../shared/utils/stationRoute', () => ({
   isStationOnRoute: (...args: unknown[]) => mockIsStationOnRoute(...args),
   isSameStationName: (a: string, b: string) => mockIsSameStationName(a, b),
   getFirstLeg: (...args: unknown[]) => mockGetFirstLeg(...args),
+  // #2279 — processLocationUpdate가 route 존재 시 estimateTransitEtaSeconds의 hop-time 상한으로 사용.
+  getRouteRemainingSeconds: (...args: unknown[]) => mockGetRouteRemainingSeconds(...args),
 }));
 
 const mockEvaluateAlarmPhase = jest.fn();
@@ -272,14 +275,17 @@ describe('processLocationUpdate', () => {
     });
   });
 
-  it('passes null etaSeconds when speedMps is not provided', async () => {
+  // #2279 — route가 있으면(nearest 탐색 성공) speedMps 부재 시에도 distance/speed 나눗셈을
+  // 폐기하고 route의 실측 hop 시간 합(getRouteRemainingSeconds, 여기선 mock 360s)으로
+  // fallback한다. 과거엔 null(정보 없음)이었으나 hop 기반 값이 항상 계산 가능해졌다.
+  it('falls back to hop-based etaSeconds when speedMps is not provided', async () => {
     mockFindNearestStation.mockReturnValue(mockNearestResult);
     mockFindRoute.mockReturnValue(mockRoute);
 
     await call();
 
     expect(mockEvaluateAlarmPhase).toHaveBeenCalledWith(
-      expect.objectContaining({ etaSeconds: null }),
+      expect.objectContaining({ etaSeconds: 360 }),
       expect.any(Set),
       undefined,
       expect.any(Array),

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -7,10 +7,10 @@
  * ADR Roadmap "Feature-based + Ports & Adapters 디렉토리 재정비" Phase 5 (#890).
  */
 import { findNearestStation } from '../../nearest-station/utils/findNearestStation';
-import { findRoute, calculateStaticETA, getFirstLeg, isSameStationName, isStationOnRoute, updateRouteFromPosition } from '../../../shared/utils/stationRoute';
+import { findRoute, calculateStaticETA, getFirstLeg, getRouteRemainingSeconds, isSameStationName, isStationOnRoute, updateRouteFromPosition } from '../../../shared/utils/stationRoute';
 import { evaluateAlarmPhase, resolveAllTargets } from './stationAlarm';
 import { updateStationNotification } from './stationNotification';
-import { distanceMetersBetween, estimateEtaSeconds } from '../../../shared/utils/stationEta';
+import { distanceMetersBetween, estimateEtaSeconds, estimateTransitEtaSeconds } from '../../../shared/utils/stationEta';
 import { cancelSafetyNetByStationKind } from './safetyNetScheduler';
 import { getBoardingLock } from './boardingLockStorage';
 import { getLastNotifiedStationId, setLastNotifiedStationId } from './notificationState';
@@ -244,7 +244,12 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   }
 
   const distanceToDestM = distanceMetersBetween(lat, lng, destination.lat, destination.lng);
-  const etaSeconds = estimateEtaSeconds(distanceToDestM, speedMps);
+  // #2279 — route가 있으면 실측 hop 시간 합(getRouteRemainingSeconds)을 상한으로 clamp해
+  // haversine 직선거리÷순간속도가 정거장수와 무관하게 부풀지 않도록 한다. route 없으면
+  // (경로 미탐색) 기존 distance/speed 산식으로 graceful fallback.
+  const etaSeconds = route
+    ? estimateTransitEtaSeconds(distanceToDestM, speedMps, getRouteRemainingSeconds(route))
+    : estimateEtaSeconds(distanceToDestM, speedMps);
 
   // #2204 (ADR-026 ①잔여, 적대적 검증 HOLE 대응) — BG 채널 movement 가드 누락 수정.
   // FG(`useStationAlarm`/evaluateMovement)는 정적 misfire 가드(movement-static-speed /

--- a/src/features/nearest-station/tasks/__tests__/foregroundBackgroundTransition.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/foregroundBackgroundTransition.test.ts
@@ -92,6 +92,8 @@ jest.mock('../../../../shared/utils/stationRoute', () => ({
   isSameStationName: (a: string, b: string) => a === b,
   // direct route 테스트만 사용 — 첫 leg endName은 항상 destinationName.
   getFirstLeg: (_route: unknown, destinationName: string) => ({ line: '2', endName: destinationName }),
+  // #2279 — stationPipeline이 route 존재 시 estimateTransitEtaSeconds의 hop-time 상한으로 사용.
+  getRouteRemainingSeconds: jest.fn(() => 120),
 }));
 
 const mockSendStationPassedNotification = jest.fn((..._args: unknown[]) => Promise.resolve());

--- a/src/shared/utils/__tests__/stationEta.test.ts
+++ b/src/shared/utils/__tests__/stationEta.test.ts
@@ -48,6 +48,19 @@ describe('estimateTransitEtaSeconds', () => {
   it('falls back to hop-time only when speed is below the minimum valid threshold', () => {
     expect(estimateTransitEtaSeconds(1000, 0.4, 120)).toBe(120);
   });
+
+  // #2288 리뷰 P3-1 — 경계 케이스. evaluateAlarmPhase의 imminent 게이트(IMMINENT_ETA_SECONDS=10s,
+  // src/features/alarm/utils/alarmPhases.ts)보다 hopBasedSeconds가 작은 경우, 이 함수는 특별
+  // 취급 없이 그대로 통과시킨다(min-clamp 로직에 10s 문턱값 자체가 없음). stationTravelTimes.json
+  // 실측 최솟값은 현재 60s(stationEta.ts 주석 참조)라 이 경로는 production에서 발생하지 않지만,
+  // 향후 데이터에 <10s 이상치가 유입되면 imminent 게이트가 매 hop 조기 발화할 수 있다 — 그 가정
+  // 붕괴를 이 테스트가 드러낸다.
+  it('passes hopBasedSeconds through unmodified even below the imminent-gate threshold (10s)', () => {
+    // speed 없음 → hop 기반 값(5s, 10s 미만) 그대로 통과.
+    expect(estimateTransitEtaSeconds(1000, null, 5)).toBe(5);
+    // distance/speed(500s)가 hop 기반(5s)보다 크면 여전히 5s로 clamp — 10s 문턱과 무관.
+    expect(estimateTransitEtaSeconds(1000, 2, 5)).toBe(5);
+  });
 });
 
 describe('distanceMetersBetween', () => {

--- a/src/shared/utils/__tests__/stationEta.test.ts
+++ b/src/shared/utils/__tests__/stationEta.test.ts
@@ -1,4 +1,4 @@
-import { estimateEtaSeconds, distanceMetersBetween } from '../stationEta';
+import { estimateEtaSeconds, distanceMetersBetween, estimateTransitEtaSeconds } from '../stationEta';
 
 describe('estimateEtaSeconds', () => {
   it('returns null when speed is null', () => {
@@ -21,6 +21,32 @@ describe('estimateEtaSeconds', () => {
   it('matches typical subway speed', () => {
     // 200m at 20 m/s (72 km/h) → 10s
     expect(estimateEtaSeconds(200, 20)).toBe(10);
+  });
+});
+
+describe('estimateTransitEtaSeconds', () => {
+  // #2279 RED: 성수→뚝섬 1정거장, 직선거리 1000m ÷ 순간속도 2m/s = 500s(≈9분) — 실소요(hop 시간
+  // 실측 테이블 기준 120s≈2분)와 정거장수 무관하게 산출되던 버그. hop 시간 상한으로 clamp되어야 한다.
+  it('clamps distance/speed overestimate to the hop-time based ceiling (성수→뚝섬 evidence)', () => {
+    const distanceMeters = 1000; // haversine 직선거리(감속 구간 저속 샘플)
+    const speedMps = 2; // 역 진입 감속 구간 순간 속도
+    const hopBasedSeconds = 120; // getRouteRemainingSeconds(route) 실측 hop 시간(1정거장)
+    expect(estimateEtaSeconds(distanceMeters, speedMps)).toBe(500); // 버그였던 산식(회귀 방지용 대조)
+    expect(estimateTransitEtaSeconds(distanceMeters, speedMps, hopBasedSeconds)).toBe(120);
+  });
+
+  it('uses the smaller distance/speed estimate when it undercuts the hop ceiling (imminent 근접 유지)', () => {
+    // 역 진입 직전 근접 감속 — distance/speed(20s)가 hop 기반(120s)보다 짧으면 그대로 사용해
+    // imminent phase 반응성을 보존한다(9-2 대비 회귀 없음).
+    expect(estimateTransitEtaSeconds(20, 1, 120)).toBe(20);
+  });
+
+  it('falls back to hop-time only when speed is null (division 자체를 폐기)', () => {
+    expect(estimateTransitEtaSeconds(1000, null, 120)).toBe(120);
+  });
+
+  it('falls back to hop-time only when speed is below the minimum valid threshold', () => {
+    expect(estimateTransitEtaSeconds(1000, 0.4, 120)).toBe(120);
   });
 });
 

--- a/src/shared/utils/stationEta.ts
+++ b/src/shared/utils/stationEta.ts
@@ -23,6 +23,16 @@ export function estimateEtaSeconds(
  *
  * speed가 null이거나 임계 미만(`estimateEtaSeconds`가 null 반환)이면 나눗셈 자체를 폐기하고
  * hop 기반 값만 사용한다.
+ *
+ * `stationTravelTimes.json` 실측 최솟값은 현재 60s — hopBasedSeconds가 evaluateAlarmPhase의
+ * imminent 게이트 문턱(`IMMINENT_ETA_SECONDS`=10s, `src/features/alarm/utils/alarmPhases.ts`)
+ * 미만으로 들어오는 경로는 없다는 데이터 불변식에 의존한다(붕괴 시 회귀 테스트 참고:
+ * `__tests__/stationEta.test.ts` "passes hopBasedSeconds through unmodified…").
+ *
+ * 반환값은 **표시 텍스트(알림/화면 "약 N분")가 아니라** `evaluateAlarmPhase`의 destination
+ * imminent 게이트 입력(`AlarmContext.etaSeconds`)으로만 소비된다. 알림 body의 표시 ETA는
+ * `calculateStaticETA`(`stationRoute.ts`)가 별도 산출하며, 탑승 중에도 다음 열차 대기시간을
+ * 합산하는 결함은 이 함수의 범위 밖 — #2290이 담당한다.
  */
 export function estimateTransitEtaSeconds(
   distanceMeters: number,

--- a/src/shared/utils/stationEta.ts
+++ b/src/shared/utils/stationEta.ts
@@ -11,6 +11,28 @@ export function estimateEtaSeconds(
   return distanceMeters / speedMps;
 }
 
+/**
+ * #2279 — 열차 탑승 중 ETA. haversine 직선거리 ÷ 순간속도는 정거장수와 무관하게 산출되어
+ * 역 진입 감속 구간(저속 샘플)에서 실제 1정거장(~2분)인데도 9분처럼 크게 부풀 수 있다
+ * (성수→뚝섬 evidence: 1000m ÷ 2m/s = 500s).
+ *
+ * `hopBasedSeconds`(호출자가 `getRouteRemainingSeconds(route)`로 구한, 잔여 정거장수 ×
+ * 실측 hop 시간 합)를 상한으로 clamp한다 — distance/speed 추정이 이를 초과하면(감속·우회
+ * 등으로 과대추정) hop 기반 값을 대신 쓴다. distance/speed 추정이 hop 기반보다 짧으면(역
+ * 진입 직전 근접 감속) 그대로 사용해 imminent phase 반응성을 보존한다.
+ *
+ * speed가 null이거나 임계 미만(`estimateEtaSeconds`가 null 반환)이면 나눗셈 자체를 폐기하고
+ * hop 기반 값만 사용한다.
+ */
+export function estimateTransitEtaSeconds(
+  distanceMeters: number,
+  speedMps: number | null,
+  hopBasedSeconds: number,
+): number {
+  const distanceEstimate = estimateEtaSeconds(distanceMeters, speedMps);
+  return distanceEstimate !== null ? Math.min(distanceEstimate, hopBasedSeconds) : hopBasedSeconds;
+}
+
 export function distanceMetersBetween(
   fromLat: number,
   fromLng: number,

--- a/src/shared/utils/stationRoute.ts
+++ b/src/shared/utils/stationRoute.ts
@@ -836,20 +836,24 @@ export function buildJourneyDisplay(
 // 전환했고 본 상수는 데이터 부재 시 회귀 방지 fallback 역할.
 const DEFAULT_WAIT_MINUTES = 3;
 
-// 반환값은 항상 정수 분. 호출처(메인 ETA 카운터/알림 body/Live Activity etaMinutes Swift Int? 디코딩)가
-// 정수 분 contract에 의존하므로, 구간별 실측 운행시간(초)과 환승역별 실측 환승시간(초)을 합산해
-// 분으로 환산한 결과를 마지막에 반올림한다. 환승 시간은 getTransferSeconds.
-function getTravelMinutes(route: NonNullable<Route>): number {
+/**
+ * 잔여 경로 전체(현재 위치 이후 모든 hop + 환승 대기)의 실측 hop 시간 합(초). #2279 —
+ * 알람/알림 ETA가 haversine 직선거리÷순간속도(정거장수와 독립)로 산출되던 것을
+ * hop 시간(실측 테이블) 기반 상한으로 clamp하는 데 사용한다. `route`는 findRoute/
+ * updateRouteFromPosition이 매 위치 갱신마다 nIdx(현재 인접역)→dIdx(목적지)로 재계산하므로
+ * 반환값은 "지금부터 남은" 시간이다(호출 시점 스냅샷, 실시간 갱신은 호출자 책임).
+ */
+export function getRouteRemainingSeconds(route: NonNullable<Route>): number {
   if (route.type === 'direct') {
-    return Math.round(route.travelSeconds / 60);
+    return route.travelSeconds;
   }
 
   if (route.type === 'transfer') {
-    const totalSeconds =
+    return (
       route.secondsToTransfer +
       route.secondsFromTransfer +
-      getTransferSeconds(route.fromLine, route.toLine, route.transferName);
-    return Math.round(totalSeconds / 60);
+      getTransferSeconds(route.fromLine, route.toLine, route.transferName)
+    );
   }
 
   const segmentSecondsSum = route.transfers.reduce(
@@ -860,9 +864,14 @@ function getTravelMinutes(route: NonNullable<Route>): number {
     (sum, t) => sum + getTransferSeconds(t.fromLine, t.toLine, t.transferName),
     0,
   );
-  const totalSeconds =
-    segmentSecondsSum + route.secondsAfterLastTransfer + transferSecSum;
-  return Math.round(totalSeconds / 60);
+  return segmentSecondsSum + route.secondsAfterLastTransfer + transferSecSum;
+}
+
+// 반환값은 항상 정수 분. 호출처(메인 ETA 카운터/알림 body/Live Activity etaMinutes Swift Int? 디코딩)가
+// 정수 분 contract에 의존하므로, 구간별 실측 운행시간(초)과 환승역별 실측 환승시간(초)을 합산해
+// 분으로 환산한 결과를 마지막에 반올림한다. 환승 시간은 getTransferSeconds.
+function getTravelMinutes(route: NonNullable<Route>): number {
+  return Math.round(getRouteRemainingSeconds(route) / 60);
 }
 
 /** lat/lng만 추출한 좌표 — Station 전체를 넘기지 않아 결합도를 낮춘다. */


### PR DESCRIPTION
Closes #2279

관계: #2290 (알림 body 표시 텍스트 "1정거장 · 약 9분"의 실원인 — 탑승 중 다음 열차 대기시간 오합산. 본 PR과는 별개 결함, 본 PR 리뷰 과정에서 실경로가 규명되어 분리됨)

## 문제
`stationEta.ts`의 `estimateEtaSeconds`(haversine 직선거리 ÷ 순간속도)가 정거장수와 완전히 독립적으로 산출되어, 역 진입 감속 구간(저속 샘플)에서 실제 1정거장(hop 시간 실측 ~2분)인데도 값이 9분 근처까지 부풀 수 있었다(성수→뚝섬 evidence: 1000m ÷ 2m/s = 500s).

**본 PR이 고치는 것 / 안 고치는 것 (리뷰에서 명확화):**
- 이 값(`etaSeconds`)은 **표시 텍스트가 아니라** `evaluateAlarmPhase`의 destination imminent 게이트 입력(`AlarmContext.etaSeconds`, `IMMINENT_ETA_SECONDS`=10s 문턱 판정용)으로만 소비된다. 즉 본 PR은 "언제 imminent phase로 전환할지" 판정 정확도를 고친다.
- evidence 스크린샷의 알림 body "약 9분" 표시 텍스트는 `calculateStaticETA`(`stationRoute.ts`)가 별도로 산출하며, 탑승 중에도 leg당 다음 열차 대기시간(`DEFAULT_WAIT_MINUTES` 등)을 합산하는 결함이 원인이다 — 이는 **#2290**의 범위. 본 PR 단독으로는 evidence 스크린샷의 "9분" 문구 자체가 사라지지 않는다.

## 수정
- `estimateTransitEtaSeconds(distanceMeters, speedMps, hopBasedSeconds)` 신설(`src/shared/utils/stationEta.ts`) — distance/speed 추정이 hop 기반 상한(`hopBasedSeconds`)을 초과하면 clamp, 미달(역 진입 직전 근접 감속)이면 그대로 사용해 imminent phase 반응성 보존. speed가 null이거나 임계(0.5m/s) 미만이면 나눗셈 자체를 폐기하고 hop 기반 값만 사용.
- `getRouteRemainingSeconds(route)` export 추가(`src/shared/utils/stationRoute.ts`) — 잔여 경로 전체(현재 위치 이후 모든 hop + 환승 대기)의 실측 hop 시간 합(초). 기존 `getTravelMinutes`(분 단위 static ETA)가 이 함수를 재사용하도록 리팩터해 로직 중복 제거.
- 알람 ETA 소비처 2곳(`stationPipeline.ts`의 `evaluateAlarmPhase` 입력, `useStationAlarm.ts`의 phase ETA effect)을 새 clamp 산식으로 교체. route가 없을 때만(경로 미탐색) 기존 distance/speed 단독 산식으로 graceful fallback.
- `calculateWalkingMinutes`(도보 ETA, `stationRoute.ts`)는 원래 `estimateEtaSeconds`를 그대로 사용 — 열차 hop과 무관한 도보 계산이라 변경 범위 밖.

## RED → GREEN
성수→뚝섬 1정거장(직선거리 1000m) + speed 2m/s 입력:
- 기존 산식(`estimateEtaSeconds`): 500s(≈9분) — 회귀 방지용 대조 테스트로 유지
- 신규 산식(`estimateTransitEtaSeconds`, hop 기반 상한 120s): 120s(≈2분) — GREEN

`src/shared/utils/__tests__/stationEta.test.ts`에 5개 케이스(overestimate clamp / imminent 근접 유지 / speed null fallback / 저속 fallback / **imminent 문턱(10s) 미만 hopBasedSeconds 경계 케이스** — 리뷰 P3-1, `stationTravelTimes.json` 실측 최솟값 60s 데이터 불변식이 향후 붕괴하면 이 테스트가 드러낸다).

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard** — `etaSeconds`(imminent 게이트 입력)는 DebugModal alarm log의 발사 이벤트 payload(`etaSeconds` 필드)로 관측 가능. 알림 body 표시 ETA는 #2290 범위이며 그쪽 PR에서 별도 V/X 명시 예정.
3. **의존 PR** — N/A (device 코드만 변경, backend/infra 의존 없음)
4. **측정 plan** — 다음 실탑승 시 destination imminent phase가 실제 도착 ~10초 전 근접 구간에서 정확히 전환되는지(과거처럼 감속 구간에서 조기/지연 전환되지 않는지) 확인. 알림 body 표시 텍스트 자체의 회귀 측정은 #2290이 담당.
5. **Device verify** — 코드+unit 우선. 실탑승 1회로 imminent phase 전환 타이밍(발사 로그의 phaseId early→imminent 전환 시점)이 실제 도착 근접 구간과 맞는지 확인 필요.

## 검증
- `npm test` — 9372 tests pass, coverage 100% (lines/functions/branches/statements)
- `npm run type-check` — pass
- `npm run lint:orphan` — pass (0 orphan)
