### PR TITLE
fix(#2280): trip origin 화면 재앵커 + backend origin_station null 수리

### DIFF
--- a/backend/alarm-worker/src/__tests__/d1TripMetrics.test.ts
+++ b/backend/alarm-worker/src/__tests__/d1TripMetrics.test.ts
@@ -186,4 +186,42 @@ describe('recordTripMetrics (#1835)', () => {
 
     expect(capturedArgs).toContain('lockless-trip-end');
   });
+
+  // #2280 — origin_station null RCA: passedStations는 advance 이벤트(waypoint 통과)가 한 번도
+  // 없던 trip(짧은 trip/조기 종료)에서 영구 undefined라 origin_station이 항상 null로 적재됐다
+  // (evidence: 2026-08-11 3건 + 2026-08-10 trip 50, 모두 origin_station=null). device가 등록
+  // 시점에 stamp한 `originStationName`(SSOT, trip 수명 동안 불변)을 1순위 소스로 채택해야 한다.
+  describe('origin_station 적재 (#2280)', () => {
+    /** trip_metrics INSERT의 origin_station positional arg (bind 5번째, 0-based index 4). */
+    function captureOriginStationArg(trip: Parameters<typeof makeTripFixture>[0]): Promise<unknown> {
+      return new Promise((resolve) => {
+        const run = vi.fn().mockResolvedValue({ success: true });
+        const bind = vi.fn().mockImplementation((...args: unknown[]) => {
+          resolve(args[4]);
+          return { run };
+        });
+        const prepare = vi.fn().mockReturnValue({ bind });
+        const db = { prepare } as unknown as D1Database;
+        void recordTripMetrics(db, makeTripFixture(trip), 'destination-arrived', NOW);
+      });
+    }
+
+    it('RED였던 회귀 재현: passedStations 없음(advance 이벤트 0회) + originStationName도 없으면 null', async () => {
+      const arg = await captureOriginStationArg({});
+      expect(arg).toBeNull();
+    });
+
+    it('originStationName이 있으면 passedStations 유무와 무관하게 1순위 채택', async () => {
+      const arg = await captureOriginStationArg({
+        originStationName: '건대입구',
+        passedStations: ['어린이대공원'],
+      });
+      expect(arg).toBe('건대입구');
+    });
+
+    it('originStationName이 없고 passedStations만 있으면 기존 fallback(첫 원소) 유지', async () => {
+      const arg = await captureOriginStationArg({ passedStations: ['어린이대공원', '건대입구'] });
+      expect(arg).toBe('어린이대공원');
+    });
+  });
 });

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -239,6 +239,21 @@ describe('validateTrip', () => {
     expect(validateTrip(base())?.sleepModeEnabled).toBeUndefined();
   });
 
+  // #2280 — originStationName 필드 (trip 등록 시점 SSOT 출발역명, d1TripMetrics.origin_station
+  // null 회귀 fix의 device→backend wire 절반).
+  it('preserves non-empty string originStationName (#2280)', () => {
+    expect(validateTrip({ ...base(), originStationName: '건대입구' })?.originStationName).toBe(
+      '건대입구',
+    );
+  });
+
+  it('drops non-string/empty originStationName and absent field stays undefined (#2280, legacy client graceful)', () => {
+    expect(validateTrip({ ...base(), originStationName: '' })?.originStationName).toBeUndefined();
+    expect(validateTrip({ ...base(), originStationName: 42 })?.originStationName).toBeUndefined();
+    // Legacy client (필드 미송신) — 기존 동작 완전 보존.
+    expect(validateTrip(base())?.originStationName).toBeUndefined();
+  });
+
   // #1193 — 중복역 trip의 waypoint occurrenceIdx stamping.
   describe('occurrenceIdx stamping (#1193)', () => {
     it('단일 등장 waypoints는 모두 occurrenceIdx=0', () => {

--- a/backend/alarm-worker/src/d1TripMetrics.ts
+++ b/backend/alarm-worker/src/d1TripMetrics.ts
@@ -90,8 +90,12 @@ function extractLineList(trip: Trip): string[] {
 
 /** trip route의 출발 노선 첫 waypoint 이름을 원본 역으로 추정한다. */
 function extractOriginStation(trip: Trip): string | null {
-  // waypoints는 남은 경유지 배열. 종료 시점에는 비어 있을 수 있어 passedStations 활용.
-  const { passedStations } = trip;
+  // #2280 — device가 등록 시점에 stamp한 SSOT 출발역명을 1순위로 채택. 이 필드가 없는(구 client)
+  // 경우에만 passedStations[0]로 fallback — waypoints는 남은 경유지 배열이라 종료 시점에는
+  // 비어 있을 수 있고, passedStations 역시 advance 이벤트가 한 번도 없던 trip(짧은 trip/조기
+  // 종료)에서는 영구 undefined라 origin_station null 회귀의 원인이었다.
+  const { originStationName, passedStations } = trip;
+  if (originStationName) return originStationName;
   if (passedStations && passedStations.length > 0) return passedStations[0];
   return null;
 }

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -2524,6 +2524,12 @@ export function validateTrip(input: unknown): Trip | null {
     // Legacy client (필드 미송신) 또는 비boolean은 undefined로 graceful — 기존 동작 완전 보존.
     sleepModeEnabled:
       typeof obj.sleepModeEnabled === 'boolean' ? obj.sleepModeEnabled : undefined,
+    // #2280 — trip 등록 시점 SSOT 출발역명. 비어있지 않은 string만 채택 — 그 외(구 client
+    // 미송신 등)는 undefined로 graceful, d1TripMetrics가 기존 passedStations fallback을 사용한다.
+    originStationName:
+      typeof obj.originStationName === 'string' && obj.originStationName.length > 0
+        ? obj.originStationName
+        : undefined,
     // #2120 — device trip 인스턴스 corrId. 재등록마다 incoming 값으로 교체(다음 POST /trips
     // 핸들러가 baseTrip을 `{...incoming, ...}`로 spread하며 corrId를 별도 보존하지 않으므로
     // 자연스럽게 최신 값으로 갱신). 미송신/비string이면 undefined — trip-ended payload에서

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -257,6 +257,15 @@ export interface Trip {
    */
   passedStations?: string[];
   /**
+   * #2280 — device가 등록 시점에 고정한 SSOT 출발역명 (device `tripOrigin.name`). trip 수명 동안
+   * 재등록해도 device는 동일 값을 계속 보내므로 backend 입장에서도 사실상 불변.
+   * `promptDisplay.originStation`(boarding-prompt 표시용, currentStation 기준이라 흔들릴 수 있음)과
+   * 달리 `trip_metrics.origin_station` 적재(`d1TripMetrics.extractOriginStation`)의 1순위 소스 —
+   * 기존 `passedStations[0]` fallback은 advance 이벤트가 한 번도 없던 trip(짧은 trip/조기 종료)에서
+   * 영구 null이 되는 회귀가 있었다. 부재(구 client / 캡처 전)면 undefined.
+   */
+  originStationName?: string;
+  /**
    * #1895 — 사용자 device locale (ko / en / ja / zh). 디바이스 register 시점에 송신.
    * backend는 push 본문 생성 시 `t(trip.locale)`로 4언어 분기한다. 부재/비지원이면 ko
    * fallback (한국 운영 기본). 본 필드는 alert push(boarding-prompt) 본문 생성에만 사용 —

--- a/src/features/alarm/api/__tests__/alarmBackend.test.ts
+++ b/src/features/alarm/api/__tests__/alarmBackend.test.ts
@@ -385,6 +385,20 @@ describe('alarmBackend', () => {
         expect(global.fetch).toHaveBeenCalledTimes(1);
       });
 
+      // #2280 — SSOT 출발역명 forward. backend trip_metrics.origin_station null 회귀의
+      // device-side wire 절반 (frontend가 애초에 값을 안 보내면 backend가 채택할 게 없다).
+      it('#2280 originStationName 있으면 body에 포함', async () => {
+        await registerActiveTrip({ ...SAMPLE_PAYLOAD, originStationName: '건대입구' });
+        const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+        expect(body.originStationName).toBe('건대입구');
+      });
+
+      it('#2280 originStationName 미설정이면 body에 미포함 (graceful, 캡처 전 cold-start)', async () => {
+        await registerActiveTrip(SAMPLE_PAYLOAD);
+        const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+        expect(body.originStationName).toBeUndefined();
+      });
+
       it('#701 in-flight dedup: 동일 페이로드 동시 호출 시 fetch는 1번만 발사된다', async () => {
         let resolveFetch: ((v: Response) => void) | null = null;
         (global.fetch as jest.Mock).mockImplementationOnce(

--- a/src/features/alarm/api/alarmBackend.ts
+++ b/src/features/alarm/api/alarmBackend.ts
@@ -155,6 +155,15 @@ export interface RegisterTripPayload {
    * 기존 register 호출자(테스트 등)는 미지정 시 undefined로 자연 생략.
    */
   corrId?: string | null;
+  /**
+   * #2280 — trip 등록 시점에 고정된 SSOT 출발역명 (device `tripOrigin.name`). backend
+   * `trip_metrics.origin_station`이 passedStations[0](advance 이벤트가 없으면 영구 null)로만
+   * 추론되어 null로 적재되는 회귀가 있었다 — 명시 송신해 backend가 우선 채택하도록 한다.
+   * `promptDisplay.originStation`(boarding-prompt 표시용, currentStation 기준으로 매 register마다
+   * 흔들릴 수 있음)과는 다른 값 — 이 필드는 trip 전체 수명 동안 불변이어야 한다.
+   * 캡처 전(undefined)이면 필드 자체 생략(graceful) — backend는 기존 passedStations fallback.
+   */
+  originStationName?: string;
 }
 
 export interface AlarmBackendResult {
@@ -332,6 +341,9 @@ async function performRegisterFetch(
     // #2032 (Issue D) — device 취침모드 상태. ON일 때만 송신. backend는 monitoring 전용 저장 (ADR-023).
     // 미송신 시 backend Trip.sleepModeEnabled는 undefined 유지 — 기존 동작 완전 보존.
     ...(payload.sleepModeEnabled === true ? { sleepModeEnabled: true } : {}),
+    // #2280 — SSOT 출발역명. trip 전체 수명 동안 불변이라 dedup hash에는 포함하지 않는다
+    // (같은 trip 재등록마다 값이 같아 hash 갱신을 유발할 필요가 없다). 캡처 전(undefined)이면 생략.
+    ...(payload.originStationName ? { originStationName: payload.originStationName } : {}),
   };
 
   try {

--- a/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
+++ b/src/features/alarm/hooks/__tests__/useApnsTripRegistration.test.ts
@@ -2290,6 +2290,50 @@ describe('useApnsTripRegistration', () => {
     });
   });
 
+  // #2280 — trip 등록 시점 SSOT 출발역명 forward. backend trip_metrics.origin_station null
+  // 회귀의 device-side 절반 — payload에 값이 실려야 backend가 passedStations fallback 없이
+  // 채택할 수 있다.
+  describe('originStationName (#2280)', () => {
+    const baseInputs = (originStationName?: string) => ({
+      route: directRoute,
+      destination: station,
+      nextStationEtaSeconds: 120,
+      ...(originStationName === undefined ? {} : { originStationName }),
+    });
+    const renderOrigin = (initial?: string) =>
+      renderHook(
+        ({ osn }: { osn?: string }) => useApnsTripRegistration(baseInputs(osn)),
+        { initialProps: { osn: initial } },
+      );
+
+    it('originStationName 있으면 payload에 그대로 포함', async () => {
+      renderOrigin('건대입구');
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockRegister.mock.calls[0][0].originStationName).toBe('건대입구');
+    });
+
+    it('originStationName 미지정(캡처 전 cold-start)이면 payload에 미포함 (graceful)', async () => {
+      renderOrigin(undefined);
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      expect(mockRegister.mock.calls[0][0].originStationName).toBeUndefined();
+    });
+
+    it('token refresh 경로도 최신 originStationName 값을 송신', async () => {
+      const { rerender } = renderOrigin('건대입구');
+      await waitFor(() => expect(mockRegister).toHaveBeenCalledTimes(1));
+      const listener = mockAddPushTokenListener.mock.calls[0][0];
+      await act(async () => {
+        listener({ data: 'token-ORIGIN-NEW' });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const refreshed = mockRegister.mock.calls.find(
+        (c) => (c[0] as { token: string }).token === 'token-ORIGIN-NEW',
+      );
+      expect(refreshed?.[0].originStationName).toBe('건대입구');
+    });
+  });
+
   describe('#1895 i18n locale 송신 (4언어 boarding-prompt)', () => {
     const baseInputs = {
       route: directRoute,

--- a/src/features/alarm/hooks/useApnsTripRegistration.ts
+++ b/src/features/alarm/hooks/useApnsTripRegistration.ts
@@ -113,6 +113,14 @@ export interface UseApnsTripRegistrationInputs {
    * 그대로 전달한다.
    */
   routeOriginStation?: Station | null;
+  /**
+   * #2280 — trip 등록 시점에 고정된 SSOT 출발역명 (`useDestinationStore.tripOrigin.name`).
+   * backend trip_metrics.origin_station이 passedStations[0](advance 이벤트가 없으면 영구 null)로만
+   * 추론되어 null로 적재되는 회귀가 있었다 — 명시 송신해 backend가 우선 채택하도록 한다.
+   * tripOrigin이 아직 캡처 전(cold-start)이면 undefined로 생략(graceful) — backend는 기존
+   * passedStations fallback으로 동작.
+   */
+  originStationName?: string;
 }
 
 /**
@@ -156,6 +164,8 @@ interface RegisterCallInputs {
   promptContextOverride?: BoardingPromptContext | null;
   /** #2130 (B-2) — 등록 시점 GPS fix. promptGeoContext 근접 스탬프 입력. */
   gpsFix?: GpsFix | null;
+  /** #2280 — trip 등록 시점에 고정된 SSOT 출발역명. 미제공(undefined)이면 필드 송신 자체 생략. */
+  originStationName?: string;
 }
 
 /**
@@ -283,6 +293,8 @@ async function callRegister(
     // #2032 (Issue D) — device 취침모드 상태. ON일 때만 송신. backend는 monitoring 전용으로 저장(ADR-023).
     // false/미설정은 필드 누락(graceful) — backend Trip.sleepModeEnabled=undefined 유지.
     ...(input.sleepMode ? { sleepModeEnabled: true } : {}),
+    // #2280 — SSOT 출발역명. 캡처 전(undefined)이면 필드 자체 생략(graceful).
+    ...(input.originStationName ? { originStationName: input.originStationName } : {}),
   });
   // #2130 (B-1) — 이번 register가 실제로 promptContext를 포함했는지 + 그 내용을 호출자에게 노출.
   // Tier 1 heal 판정의 SSoT이자, 캐시(`lastPromptContextRef`) 갱신 입력.
@@ -300,6 +312,7 @@ export function useApnsTripRegistration({
   sleepMode = false,
   gpsFix = null,
   routeOriginStation = null,
+  originStationName,
 }: UseApnsTripRegistrationInputs): void {
   // route 객체 reference가 categorized recompute로 자주 바뀌므로 내용 기반 signature로
   // 메모화 — register useEffect deps에 사용해 동일 경로 재등록(POST /trips 폭주) 방지.
@@ -319,6 +332,7 @@ export function useApnsTripRegistration({
     sleepMode,
     gpsFix,
     routeOriginStation,
+    originStationName,
   });
   useEffect(() => {
     latestInputsRef.current = {
@@ -332,6 +346,7 @@ export function useApnsTripRegistration({
       sleepMode,
       gpsFix,
       routeOriginStation,
+      originStationName,
     };
   });
 
@@ -479,6 +494,7 @@ export function useApnsTripRegistration({
       infoModeEnabled: ime,
       sleepMode: sm,
       gpsFix: gf,
+      originStationName: osn,
     } = latestInputsRef.current;
     if (!r || !d) return null;
     const sessionKey = `${token}:${routeSignature(r)}:${d.id}`;
@@ -512,6 +528,7 @@ export function useApnsTripRegistration({
       cachedPromptContext: lastPromptContextRef.current,
       promptContextOverride: options?.promptContextOverride,
       gpsFix: gf,
+      originStationName: osn,
     });
     // #2197 — 429(rate_limited) 응답이면 서버가 지시한 시간까지 이후 register/heal 호출을
     // 억제한다. backend가 매 429 응답에 최신 window를 다시 계산해 내려주므로 항상 최신값으로

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -565,9 +565,16 @@ export default function HomeScreen() {
     return () => interaction.cancel();
   }, [effectiveOrigin?.id, destination?.id, routePreference, variantIds]);
 
+  // #2280 — journey(화면 route/stop 목록) fromName은 trip 등록 시점에 고정된 tripOrigin을
+  // SSOT로 사용해야 한다. effectiveOrigin은 GPS/현재역이 바뀔 때마다 흔들리는 라이브 값이라
+  // (arrival/congestion/nextStationName 등 "현재 위치" 표시용) 여기에 그대로 넘기면 trip 진행
+  // 중 화면에 표시되는 출발역이 현재역을 따라 재앵커되는 회귀가 있었다(evidence: 07:32
+  // 어린이대공원 → 07:34 건대입구). tripOrigin이 아직 캡처 전(cold-start)이면 effectiveOrigin으로
+  // 1회 fallback — useTripOrigin이 곧 캡처하면 이후 렌더부터는 tripOrigin으로 고정된다.
+  const journeyOrigin = tripOrigin ?? effectiveOrigin;
   const journey = useMemo(
-    () => (route && effectiveOrigin && destination ? buildJourneyDisplay(route, effectiveOrigin, destination) : null),
-    [route, effectiveOrigin?.id, destination?.id],
+    () => (route && journeyOrigin && destination ? buildJourneyDisplay(route, journeyOrigin, destination) : null),
+    [route, journeyOrigin?.id, destination?.id],
   );
   const nextTrainMinutes = useMemo(() => {
     if (!arrival || arrivalIsMock) return null;
@@ -943,6 +950,11 @@ export default function HomeScreen() {
     // customOrigin/lastFusedStation/boardingLockStation/tripOrigin 순으로 fallback해 currentStation이
     // GPS dead zone으로 null일 때도 trip의 출발역을 그대로 보존한다(#1379).
     routeOriginStation: effectiveOrigin,
+    // #2280 — trip 등록 시점에 고정된 SSOT 출발역명. backend가 trip_metrics.origin_station을
+    // passedStations[0](advance 이벤트가 없으면 영구 null)로만 추론해 origin_station null 회귀가
+    // 있었다 — tripOrigin을 명시 송신해 backend가 우선 채택하도록 한다. 캡처 전(cold-start)이면
+    // undefined로 생략(graceful) — backend는 기존 passedStations fallback으로 동작.
+    originStationName: tripOrigin?.name,
   });
 
   useEffect(() => {


### PR DESCRIPTION
Closes #2280

## RCA — 가설 a/b/c 판정

- **(b) 확정** — `src/screens/HomeScreen.tsx`의 `journey`(화면 route/stop 목록을 만드는 `buildJourneyDisplay` 호출부)가 trip 등록 시점에 고정되는 `tripOrigin`(`useTripOrigin` 훅 SSOT) 대신 GPS/현재역이 바뀔 때마다 흔들리는 `effectiveOrigin`을 그대로 넘기고 있었다. 이 memo는 2026-06-10(#1072, `useTripOrigin` 도입 이전)부터 있던 코드로, tripOrigin 개념 도입 후에도 이 호출부만 갱신되지 않았다.
- **(a) 배제** — destination 재설정(새 trip 등록) 시 재캡처는 `useTripOrigin`의 설계된 정상 동작이며, evidence(07:32→07:34, 단일 trip 내 9분)와 무관. 기존 `useTripOrigin.test.ts`가 이 경로를 충분히 검증.
- **(c) 배제** — cold-start 영속 hydration도 `useTripOrigin.test.ts`("persistedTripOrigin이 있으면 마운트 시 effectiveOrigin으로 덮어쓰지 않는다" 외 다수)로 이미 커버되어 정상 동작 확인.

## 수정

- `HomeScreen.tsx`: `journey` memo가 `tripOrigin`(캡처 전 cold-start만 `effectiveOrigin` 1회 fallback)을 사용하도록 수정.
- backend `trip_metrics.origin_station` null 회귀: `d1TripMetrics.extractOriginStation`이 `passedStations[0]`에만 의존했는데, advance 이벤트(waypoint 통과)가 한 번도 없던 trip(짧은 trip/조기 종료)에서는 `passedStations`가 영구 `undefined`라 항상 null로 적재됐다(evidence: 08-11 3건 + 08-10 trip 50, 모두 origin_station=null). device가 등록 시점에 고정한 `originStationName`(tripOrigin 기반)을 POST /trips로 명시 송신하고 backend가 1순위로 채택하도록 wire:
  - frontend: `alarmBackend.ts`(RegisterTripPayload 필드 + body), `useApnsTripRegistration.ts`(hook 입력 → callRegister 전달), `HomeScreen.tsx`(register 호출에 `tripOrigin?.name` 전달)
  - backend: `types.ts`(Trip.originStationName), `index.ts`(`validateTrip` 파싱), `d1TripMetrics.ts`(`extractOriginStation` 1순위 채택)

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — 화면: 앱 route/stop 리스트(HomeScreen 상단 여정 카드)에서 trip 진행 중 출발역이 고정되는지 육안 확인. backend: Cloudflare D1 `trip_metrics.origin_station` 컬럼(대시보드/wrangler d1 execute)에서 다음 trip부터 non-null 확인. `validateTrip reject` 로그(wrangler tail)로 파싱 실패 여부도 확인 가능.
3. **의존 PR** — N/A (frontend+backend 동일 PR, 배포는 별도 `wrangler deploy` 필요 — device verify에 명시).
4. **측정 plan** — 다음 실탑승 trip에서 (1) 화면 route 첫 역이 GPS 이동에도 고정되는지, (2) D1 `SELECT origin_station FROM trip_metrics ORDER BY started_at DESC LIMIT 5`로 non-null 확인.
5. **Device verify** — 필요. 실탑승 1회: (a) trip 등록 후 여러 역 이동하며 화면 route 카드의 출발역 표기가 안 바뀌는지, (b) trip 종료 후 D1 `trip_metrics.origin_station`이 채워졌는지 교차 확인. backend 배포(`cd backend/alarm-worker && wrangler deploy`)가 선행돼야 (b) 효과가 나타난다.

## 검증

- `npm test` — 9372 tests pass, coverage 100% (lines/branches/functions/statements).
- `npm run type-check` — pass.
- `npm run lint:orphan` — 0 orphan.
- backend: `npm run type-check` — pass. `npx vitest run --coverage` — 479 tests pass (기존 baseline 커버리지 유지, 신규 라인 100%).