### PR TITLE
chore(#2283): D1 append-only trip_events 로그 + 7일 cleanup cron

### DIFF
--- a/backend/alarm-worker/migrations/0005_trip_events.sql
+++ b/backend/alarm-worker/migrations/0005_trip_events.sql
@@ -1,0 +1,18 @@
+-- #2283 — append-only trip 이벤트 로그. KV trip 객체와 독립적으로 보존된다.
+-- user-delete(DELETE /trips/:token)가 KV trip 객체 + position series까지 삭제하면
+-- "환승 swap sync가 도달했는지 / advance가 발생했는지"를 사후 재구성할 방법이 없었다
+-- (2026-08-11 RCA blind spot, 08-11 A' 검증 판정 불가의 직접 원인).
+-- kind 최소 집합: sync-received / advance / hydrate-issued / trip-end.
+-- trip_token_hash는 trip 삭제 후에도 타임라인 조회 키로 남는다 — KV FK 없음(의도적 독립).
+CREATE TABLE IF NOT EXISTS trip_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  token_hash TEXT NOT NULL,
+  ts INTEGER NOT NULL,
+  kind TEXT NOT NULL,
+  station TEXT,
+  line TEXT,
+  meta TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_trip_events_ts ON trip_events(ts);
+CREATE INDEX IF NOT EXISTS idx_trip_events_token_hash ON trip_events(token_hash, ts);

--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -1652,11 +1652,16 @@ describe('DELETE /trips/:token — ?reason= metrics telemetry (#2268)', () => {
   it('?reason= 쿼리가 D1 trip_metrics에 device가 보낸 값 그대로 적재된다', async () => {
     let capturedArgs: unknown[] = [];
     const run = vi.fn().mockResolvedValue({ success: true });
-    const bind = vi.fn().mockImplementation((...args: unknown[]) => {
-      capturedArgs = args;
-      return { run };
-    });
-    const prepare = vi.fn().mockReturnValue({ bind });
+    // #2283 — cleanupTripWithLa가 trip_metrics INSERT 외에 trip_events INSERT(trip-end)도
+    // 함께 호출한다. 동일 bind mock을 공유하면 마지막 호출(trip_events)이 capturedArgs를
+    // 덮어써 이 테스트가 검증하려는 trip_metrics.end_reason 값을 잃는다 — SQL 문자열로 statement를
+    // 구분해 trip_metrics INSERT의 bind 인자만 캡처한다.
+    const prepare = vi.fn().mockImplementation((sql: string) => ({
+      bind: (...args: unknown[]) => {
+        if (sql.includes('trip_metrics')) capturedArgs = args;
+        return { run };
+      },
+    }));
     const env = makeKvEnv();
     env.DB = { prepare } as unknown as Env['DB'];
     await post('/trips', { ...base(), token: 'tok-reason', createdAt: CREATED }, env);
@@ -1671,11 +1676,13 @@ describe('DELETE /trips/:token — ?reason= metrics telemetry (#2268)', () => {
   it('reason 쿼리 미지정 시 기존대로 user-delete로 적재된다 (backward-compat)', async () => {
     let capturedArgs: unknown[] = [];
     const run = vi.fn().mockResolvedValue({ success: true });
-    const bind = vi.fn().mockImplementation((...args: unknown[]) => {
-      capturedArgs = args;
-      return { run };
-    });
-    const prepare = vi.fn().mockReturnValue({ bind });
+    // #2283 — 위 테스트와 동일 이유로 trip_metrics INSERT statement만 캡처.
+    const prepare = vi.fn().mockImplementation((sql: string) => ({
+      bind: (...args: unknown[]) => {
+        if (sql.includes('trip_metrics')) capturedArgs = args;
+        return { run };
+      },
+    }));
     const env = makeKvEnv();
     env.DB = { prepare } as unknown as Env['DB'];
     await post('/trips', { ...base(), token: 'tok-no-reason', createdAt: CREATED }, env);

--- a/backend/alarm-worker/src/__tests__/liveActivity.test.ts
+++ b/backend/alarm-worker/src/__tests__/liveActivity.test.ts
@@ -1187,11 +1187,16 @@ describe('cleanupTripWithLa', () => {
       await kv.put('trip:devtoken', JSON.stringify(trip));
       let capturedArgs: unknown[] = [];
       const run = vi.fn().mockResolvedValue({ success: true });
-      const bind = vi.fn().mockImplementation((...args: unknown[]) => {
-        capturedArgs = args;
-        return { run };
-      });
-      const prepare = vi.fn().mockReturnValue({ bind });
+      // #2283 — cleanupTripWithLa가 trip_metrics INSERT 외에 trip_events INSERT(trip-end)도
+      // 함께 호출한다. 동일 bind mock을 공유하면 마지막 호출(trip_events)이 capturedArgs를
+      // 덮어써 이 테스트가 검증하려는 trip_metrics.end_reason 값을 잃는다 — SQL 문자열로
+      // statement를 구분해 trip_metrics INSERT의 bind 인자만 캡처한다.
+      const prepare = vi.fn().mockImplementation((sql: string) => ({
+        bind: (...args: unknown[]) => {
+          if (sql.includes('trip_metrics')) capturedArgs = args;
+          return { run };
+        },
+      }));
       const db = { prepare } as unknown as D1Database;
       const env = { TRIPS: kv as unknown as KVNamespace, DB: db } as unknown as Env;
       await cleanupTripWithLa(
@@ -1214,11 +1219,13 @@ describe('cleanupTripWithLa', () => {
       await kv.put('trip:devtoken', JSON.stringify(trip));
       let capturedArgs: unknown[] = [];
       const run = vi.fn().mockResolvedValue({ success: true });
-      const bind = vi.fn().mockImplementation((...args: unknown[]) => {
-        capturedArgs = args;
-        return { run };
-      });
-      const prepare = vi.fn().mockReturnValue({ bind });
+      // #2283 — 위 테스트와 동일 이유로 trip_metrics INSERT statement만 캡처.
+      const prepare = vi.fn().mockImplementation((sql: string) => ({
+        bind: (...args: unknown[]) => {
+          if (sql.includes('trip_metrics')) capturedArgs = args;
+          return { run };
+        },
+      }));
       const db = { prepare } as unknown as D1Database;
       const env = { TRIPS: kv as unknown as KVNamespace, DB: db } as unknown as Env;
       await cleanupTripWithLa(

--- a/backend/alarm-worker/src/__tests__/tripEventLog.test.ts
+++ b/backend/alarm-worker/src/__tests__/tripEventLog.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest';
+import { cleanupTripEvents, recordTripEvent, TRIP_EVENT_RETENTION_MS } from '../tripEventLog';
+
+function makeMockDb(runResult: unknown = { success: true }): D1Database {
+  const run = vi.fn().mockResolvedValue(runResult);
+  const bind = vi.fn().mockReturnValue({ run });
+  const prepare = vi.fn().mockReturnValue({ bind });
+  return { prepare, run, bind } as unknown as D1Database & {
+    run: typeof run;
+    bind: typeof bind;
+  };
+}
+
+describe('recordTripEvent (#2283)', () => {
+  it('db가 undefined일 때 no-op (graceful)', async () => {
+    await expect(
+      recordTripEvent(undefined, { tokenHash: 'abc', kind: 'sync-received' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('db가 있을 때 trip_events INSERT를 실행한다', async () => {
+    const db = makeMockDb();
+    await recordTripEvent(
+      db,
+      { tokenHash: 'hash1', kind: 'sync-received', station: '강남', line: '2호선' },
+      1000,
+    );
+
+    expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO trip_events'));
+  });
+
+  it('station/line/meta가 없을 때 null로 bind한다', async () => {
+    const bind = vi.fn().mockReturnValue({ run: vi.fn().mockResolvedValue({ success: true }) });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+
+    await recordTripEvent(db, { tokenHash: 'hash2', kind: 'trip-end' }, 2000);
+
+    expect(bind).toHaveBeenCalledWith('hash2', 2000, 'trip-end', null, null, null);
+  });
+
+  it('meta가 있으면 JSON 직렬화해 bind한다', async () => {
+    const bind = vi.fn().mockReturnValue({ run: vi.fn().mockResolvedValue({ success: true }) });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+
+    await recordTripEvent(
+      db,
+      { tokenHash: 'hash3', kind: 'advance', meta: { shiftedCount: 2 } },
+      3000,
+    );
+
+    expect(bind).toHaveBeenCalledWith(
+      'hash3',
+      3000,
+      'advance',
+      null,
+      null,
+      JSON.stringify({ shiftedCount: 2 }),
+    );
+  });
+
+  it('now 미지정 시 Date.now()를 사용한다', async () => {
+    const bind = vi.fn().mockReturnValue({ run: vi.fn().mockResolvedValue({ success: true }) });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+    vi.useFakeTimers();
+    vi.setSystemTime(5000);
+
+    await recordTripEvent(db, { tokenHash: 'hash4', kind: 'hydrate-issued' });
+
+    expect(bind).toHaveBeenCalledWith('hash4', 5000, 'hydrate-issued', null, null, null);
+    vi.useRealTimers();
+  });
+
+  it('D1 write 실패 시 throw 없이 swallow한다', async () => {
+    const run = vi.fn().mockRejectedValue(new Error('D1 write error'));
+    const bind = vi.fn().mockReturnValue({ run });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+
+    await expect(
+      recordTripEvent(db, { tokenHash: 'hash5', kind: 'sync-received' }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('cleanupTripEvents (#2283)', () => {
+  it('db가 undefined일 때 0을 반환한다 (graceful)', async () => {
+    await expect(cleanupTripEvents(undefined)).resolves.toBe(0);
+  });
+
+  it('보존 기간 초과 cutoff로 DELETE를 실행하고 삭제된 행 수를 반환한다', async () => {
+    const bind = vi.fn().mockReturnValue({
+      run: vi.fn().mockResolvedValue({ success: true, meta: { changes: 3 } }),
+    });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+
+    const now = 10_000_000;
+    const deleted = await cleanupTripEvents(db, now);
+
+    expect(prepare).toHaveBeenCalledWith(expect.stringContaining('DELETE FROM trip_events'));
+    expect(bind).toHaveBeenCalledWith(now - TRIP_EVENT_RETENTION_MS);
+    expect(deleted).toBe(3);
+  });
+
+  it('meta.changes가 없으면 0을 반환한다', async () => {
+    const bind = vi.fn().mockReturnValue({ run: vi.fn().mockResolvedValue({ success: true }) });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+
+    const deleted = await cleanupTripEvents(db, 1000);
+    expect(deleted).toBe(0);
+  });
+
+  it('D1 delete 실패 시 throw 없이 0을 반환한다', async () => {
+    const run = vi.fn().mockRejectedValue(new Error('D1 delete error'));
+    const bind = vi.fn().mockReturnValue({ run });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+
+    await expect(cleanupTripEvents(db, 1000)).resolves.toBe(0);
+  });
+});

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -71,9 +71,11 @@ import * as Sentry from '@sentry/cloudflare';
 import {
   addValidateRejectBreadcrumb,
   captureBackendException,
+  hashTripToken,
   sentryInit,
   sentryOptions,
 } from './sentry';
+import { recordTripEvent } from './tripEventLog';
 import {
   recordRecallUpload,
   validateRecallUpload,
@@ -1843,6 +1845,14 @@ app.post('/boarding-lock/sync', async (c) => {
   if (!existing) return c.json({ error: 'trip_not_found' }, 404);
 
   const now = Date.now();
+  // #2283 — D1 append-only 관측. KV trip 객체와 독립적으로 sync 도달을 보존한다(user-delete 시
+  // KV가 사라져도 사후 재구성 가능해야 함). DB 미바인딩/실패는 recordTripEvent 내부 graceful no-op.
+  const tokenHash = hashTripToken(payload.token);
+  await recordTripEvent(c.env.DB, {
+    tokenHash,
+    kind: 'sync-received',
+    station: payload.observedStationName,
+  });
   const advance = computeLockSyncAdvance(existing.waypoints, payload.observedStationName);
 
   let working: Trip = existing;
@@ -1859,6 +1869,14 @@ app.post('/boarding-lock/sync', async (c) => {
     };
     // progress KV mirror — POST /trips re-register 시 같은 trainCode면 shift 진행분이 보존되도록.
     await maybeMirrorLockSyncProgress(c.env.TRIPS, working, advance.shiftedCount);
+    // #2283 — advance 이벤트 관측. 새 head waypoint를 기록해 "언제 어디로 advance했는지" 사후 조회.
+    const advancedHead = remaining[0];
+    await recordTripEvent(c.env.DB, {
+      tokenHash,
+      kind: 'advance',
+      station: advancedHead ? advancedHead.stationName : undefined,
+      meta: { shiftedCount: advance.shiftedCount },
+    });
   }
 
   // D4 (#1210) — payload trainCode가 KV lock trainCode와 다르면 환승 leg로 해석.
@@ -1911,6 +1929,16 @@ app.post('/boarding-lock/sync', async (c) => {
   }
 
   const head = working.waypoints[0];
+  if (working.boardingLock) {
+    // #2283 — hydrate-issued 관측. autoLockCandidate를 device가 실제로 받아 lock state를
+    // hydrate할 수 있는 응답임을 기록(sync-received/advance와 별도 kind — "발사됐는지"를 분리 관측).
+    await recordTripEvent(c.env.DB, {
+      tokenHash,
+      kind: 'hydrate-issued',
+      station: head ? head.stationName : undefined,
+      line: working.boardingLock.line,
+    });
+  }
   return c.json({
     ok: true,
     advanced: advance.shiftedCount > 0,

--- a/backend/alarm-worker/src/liveActivity.ts
+++ b/backend/alarm-worker/src/liveActivity.ts
@@ -23,8 +23,10 @@ import { recordTripMetrics } from './d1TripMetrics';
 import { LINE_META } from './lineAlias';
 import { deleteProgress } from './progress';
 import { logPushFailure } from './pushFailureLog';
+import { hashTripToken } from './sentry';
 import { computeMultiHopContext } from './tripMultiHop';
 import { deleteSsot } from './tripPositionSsot';
+import { recordTripEvent } from './tripEventLog';
 import {
   cleanupPendingPushesForToken,
   deleteDeviceTripIndexIfCurrent,
@@ -365,6 +367,14 @@ export async function cleanupTripWithLa(
   // cleanup 흐름 차단 없음 — recordTripMetrics 자체가 try/catch로 swallow.
   // #2268 — metricsReason이 있으면 alert-push 게이팅용 reason 대신 그 값을 적재(위 헤더 주석).
   await recordTripMetrics(env.DB, trip, metricsReason ?? reason, now);
+  // #2283 — D1 append-only 관측. KV trip 객체(위 deleteTrip)가 삭제된 후에도 trip-end 이벤트는
+  // 독립 보존된다 — trip_metrics(집계 스냅샷)와 달리 trip_events는 타임라인 재구성이 목적.
+  await recordTripEvent(env.DB, {
+    tokenHash: hashTripToken(trip.token),
+    kind: 'trip-end',
+    station: trip.destination ?? undefined,
+    meta: { reason: metricsReason ?? reason ?? 'user-delete' },
+  });
 }
 
 /**

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -120,6 +120,7 @@ import {
 } from './cronJitterAggregate';
 import { readPushActivityRecent, stampPushActivity } from './cronIdleGate';
 import { hasRescheduleFired, markRescheduleFired } from './rescheduleDedup';
+import { cleanupTripEvents } from './tripEventLog';
 
 // pickApnsHost / flipApnsEnv는 ./apnsHost로 이동 (liveActivity.ts와 공유 SSOT, #482).
 // 외부(테스트 / index.ts 등)가 scheduled.ts 경유로 import하던 호환성 유지를 위해 re-export.
@@ -1126,6 +1127,13 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     // #2073 (Issue A) — 아래 idle 판정 이후 실제 값으로 덮어쓴다. 기본 true = 보수적(항상 실행).
     pendingActivityPossible: true,
   };
+
+  // #2283 — trip_events 보존 기간(7일) 초과분 cleanup. cron이 60s마다(1440회/일) 도는데 매
+  // tick마다 DELETE를 부르면 D1 free plan write quota를 불필요하게 소진한다(#2073 lesson). 시(hour)
+  // 경계에서만 실행해 24회/일로 제한 — KV read/write 없이 `now` 값만으로 게이팅(추가 quota 0).
+  if (new Date(now).getUTCMinutes() === 0) {
+    await cleanupTripEvents(env.DB, now);
+  }
 
   // #2073 (Issue B) — listTrips 3중 호출(collectActiveLines/collectActiveStations/main loop 각자)을
   // 1회 병합. 전체 trip을 배열로 확보해 아래 파생 함수 + main loop가 모두 이 배열을 재사용한다.

--- a/backend/alarm-worker/src/tripEventLog.ts
+++ b/backend/alarm-worker/src/tripEventLog.ts
@@ -1,0 +1,91 @@
+/**
+ * D1 trip_events append-only 로그 helper (#2283).
+ *
+ * 배경: `/boarding-lock/sync`(index.ts) · `/position`(index.ts)은 KV trip 객체를 in-place
+ * mutate만 한다. trip이 user-delete(HTTP DELETE /trips/:token)되면 KV 객체 + position series까지
+ * 삭제되어, "환승 swap sync가 도달했는지 / advance가 발생했는지"를 사후 재구성할 방법이 없었다
+ * (2026-08-11 RCA blind spot — 08-11 A′ 검증 판정 불가의 직접 원인).
+ *
+ * 본 모듈은 kind 최소 집합(sync-received / advance / hydrate-issued / trip-end)을 D1
+ * `trip_events`에 append-only로 기록한다. trip 삭제와 독립 — token_hash만으로 타임라인을
+ * wrangler d1 SELECT로 재구성할 수 있다(진단 용도가 acceptance).
+ *
+ * Free plan quota 보호: KV write는 하지 않는다(#2073 lesson — cron이 사용자 0명에도 KV quota
+ * 소진). D1 write만 사용하며 이벤트당 정확히 1 insert. `cleanupTripEvents`가 보존 기간(7일)
+ * 초과분을 주기적으로 삭제한다.
+ *
+ * `env.DB` 미바인딩 시 graceful no-op. 적재 실패는 호출 흐름을 차단하지 않는다(swallow) —
+ * d1ErrorLog.ts / d1TripMetrics.ts와 동일 패턴.
+ */
+
+/** trip_events.kind 최소 집합. 데이터 주도 확장 시 이 유니온에 추가한다. */
+export type TripEventKind = 'sync-received' | 'advance' | 'hydrate-issued' | 'trip-end';
+
+export interface TripEventInput {
+  /** trip token의 해시(hashTripToken 결과). 원본 token은 D1에 남기지 않는다. */
+  tokenHash: string;
+  kind: TripEventKind;
+  station?: string;
+  line?: string;
+  meta?: object;
+}
+
+/**
+ * trip_events에 이벤트 1건을 append한다.
+ *
+ * @param db - D1 binding. undefined 시 no-op.
+ * @param input - 이벤트 메타데이터.
+ * @param now - 적재 시각(epoch ms). 기본값 Date.now() — 테스트에서 고정값 주입 가능.
+ */
+export async function recordTripEvent(
+  db: D1Database | undefined,
+  input: TripEventInput,
+  now: number = Date.now(),
+): Promise<void> {
+  if (!db) return;
+  try {
+    await db
+      .prepare(
+        'INSERT INTO trip_events (token_hash, ts, kind, station, line, meta) VALUES (?, ?, ?, ?, ?, ?)',
+      )
+      .bind(
+        input.tokenHash,
+        now,
+        input.kind,
+        input.station ?? null,
+        input.line ?? null,
+        input.meta ? JSON.stringify(input.meta) : null,
+      )
+      .run();
+  } catch (e) {
+    console.warn(
+      JSON.stringify({ msg: 'tripEventLog write failed', kind: input.kind, err: String(e) }),
+    );
+  }
+}
+
+/** 보존 기간(ms). 7일 초과분은 cron cleanup이 삭제한다. */
+export const TRIP_EVENT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * 보존 기간(`TRIP_EVENT_RETENTION_MS`)을 초과한 trip_events 행을 삭제한다.
+ *
+ * 호출자(scheduled.ts)가 호출 빈도를 throttle한다 — 매 cron tick(1분)마다 부르면 D1 write
+ * quota를 불필요하게 소진하므로, 시간 기반(예: 시 단위 1회) 게이트를 호출자 쪽에 둔다.
+ *
+ * @returns 삭제된 행 수. DB 미바인딩/실패 시 0.
+ */
+export async function cleanupTripEvents(
+  db: D1Database | undefined,
+  now: number = Date.now(),
+): Promise<number> {
+  if (!db) return 0;
+  try {
+    const cutoff = now - TRIP_EVENT_RETENTION_MS;
+    const result = await db.prepare('DELETE FROM trip_events WHERE ts < ?').bind(cutoff).run();
+    return result.meta?.changes ?? 0;
+  } catch (e) {
+    console.warn(JSON.stringify({ msg: 'tripEventLog cleanup failed', err: String(e) }));
+    return 0;
+  }
+}


### PR DESCRIPTION
Closes #2283

## 요약
`/boarding-lock/sync`·trip 종료가 KV trip 객체만 mutate하고 D1 영속이 0이라, user-delete 시 KV 객체 + position series까지 삭제되면 "sync가 도달했는지 / advance가 발생했는지"를 사후 재구성할 수 없었다(2026-08-11 RCA blind spot). D1 append-only `trip_events` 테이블 + 최소 kind 4종(`sync-received` / `advance` / `hydrate-issued` / `trip-end`)을 신규 모듈(`src/tripEventLog.ts`)로 추가하고, trip 삭제와 독립적으로 wire했다.

## 변경 사항
- `migrations/0005_trip_events.sql`: `trip_events(id, token_hash, ts, kind, station, line, meta)` append-only 테이블 + `ts`/`(token_hash, ts)` 인덱스
- `src/tripEventLog.ts` (신규): `recordTripEvent`(1 insert, `env.DB` 미바인딩 시 graceful no-op, write 실패 swallow) + `cleanupTripEvents`(7일 보존 초과분 DELETE)
- `src/index.ts` `POST /boarding-lock/sync`: `sync-received`(payload 수신 직후) / `advance`(waypoint shift 발생 시) / `hydrate-issued`(응답에 `autoLockCandidate` 포함될 때, 503 검증 실패 경로는 제외) 3종 wire
- `src/liveActivity.ts` `cleanupTripWithLa`: `recordTripMetrics` 직후 `trip-end` 이벤트 기록 (KV `deleteTrip` 이후에도 D1엔 독립 보존)
- `src/scheduled.ts` `runScheduled`: UTC 시(hour) 경계(`getUTCMinutes() === 0`)에서만 `cleanupTripEvents` 호출 — 24회/일로 throttle (매 1분 cron tick마다 DELETE를 부르면 quota 낭비)
- `d1TripMetrics.ts`는 PR #2286이 변경 중이라 **건드리지 않음** — trip-end 이벤트는 `liveActivity.ts`에서 별도 호출

## Free plan quota 계산 (필수)
가정(현재 앱 스케일 기준 보수적 상한):
- 동시 활성 lock trip ≤ 500 trips/day (성장 여유 포함 상한)
- `sync-received`는 `useBoardingLockSync`(`SYNC_DEBOUNCE_MS`=5s debounce, station 변경 시에만 발사 — 고정 polling 아님)에 의해 trip당 station 변경 횟수만큼만 발생. 1 trip 평균 구간 수 ≈ 13(환승 포함)
- `hydrate-issued`는 `sync-received`와 동일 요청 안에서 lock이 살아있을 때만 발생 → 동일 cardinality로 근사(≤13/trip)
- `advance`는 `sync-received`의 부분집합(shift 발생 시만) → ≤13/trip
- `trip-end`는 trip당 정확히 1건

**insert(write) 상한**: 500 trips/day × (13 + 13 + 13 + 1) ≈ **20,000 rows/day** — D1 free plan 100,000 rows written/day 대비 20%.

**cleanup(delete) 상한**: 정상 상태(steady state)에서 하루 유입량 ≈ 하루 삭제량이므로 7일 보존 하에 1일당 삭제되는 행도 최대 ≈20,000 rows/day(시간당 ~833 rows, 24회 DELETE로 분산). insert+delete 합산 최대 ≈**40,000 rows/day** — 여전히 100,000 rows written/day free 한도의 40% 이내, KV write는 0건(cron write 없음, #2073 lesson 준수).

- 저장 공간: 20,000 rows/day × 7일 ≈ 140,000 rows 상시 보관, row당 평균 <200 bytes → ~28MB, D1 free 5GB 대비 무시 가능.

## Wire-completion 5단
1. **Orphan 없음** — `recordTripEvent`/`cleanupTripEvents` 모두 신규 caller(`index.ts`/`liveActivity.ts`/`scheduled.ts`)에서 호출됨. `npm run lint:orphan`은 frontend 전용 스크립트라 backend에는 적용되지 않음(레포 관행) — backend는 `tsc --noEmit` + `vitest`로 caller 존재를 타입/테스트 레벨에서 강제.
2. **V/X dashboard** — `wrangler d1 execute alarm-worker-db --remote --command "SELECT * FROM trip_events WHERE token_hash = '<hash>' ORDER BY ts ASC"`로 trip 타임라인 재구성 가능. 예시: `SELECT kind, ts, station, line FROM trip_events WHERE token_hash='...' ORDER BY ts;`
3. **의존 PR** — N/A (신규 테이블 + 신규 모듈, 기존 로직 변경 없음)
4. **측정 plan** — 다음 실탑승 후 `wrangler d1 execute` 로 해당 trip의 token_hash 타임라인을 조회해 `sync-received`→`advance`→`hydrate-issued`→`trip-end` 순서와 KV 삭제 여부(trip이 이미 DELETE된 뒤에도 행이 남아있는지)를 확인
5. **Device verify** — N/A — type+unit only. 이 PR은 backend 코드/마이그레이션/테스트만 포함하며 **deploy하지 않음**(마이그레이션 적용 및 wrangler deploy는 별도 배포 승인 후 진행)

## 검증
- `npm run type-check`: pass
- `npm test` (coverage): 2970/2970 pass, `tripEventLog.ts` 100% coverage. 기존 `#2268` 테스트(`index.test.ts`/`liveActivity.test.ts`) 2건씩 총 4건이 `trip_events` INSERT 추가로 mock capture가 흔들려 SQL 문자열 기반 분리로 수정(회귀 아님 — 동일 assertion 유지)

## 배포 안내 (머지 후 별도 작업 필요)
- `wrangler d1 migrations apply` 로 `0005_trip_events.sql` 적용 필요
- `wrangler deploy`로 cron/handler 반영 필요
- 본 PR은 코드만 포함 — deploy는 사용자 승인 후 별도 진행


---

## 리뷰 P2 반영 (2026-08-11)

**P2-1 (write 실패 Sentry escalation)**: `tripEventLog.ts`의 `recordTripEvent`/`cleanupTripEvents` catch block이 `console.warn`만 하던 것을 기존 `captureXEvent('D1-write-failure', { table: 'trip_events', kind, err })`로 승격(신규 이벤트 타입 추가 없음, `d1ErrorLog.ts`와 동일 기존 유니온 재사용). `tripEventLog.test.ts`에 escalation 검증 테스트 2건 추가.

**P2-2 (핫패스 직렬 await 제거)**: `/boarding-lock/sync`의 `sync-received`/`advance`/`hydrate-issued` 3건을 `c.executionCtx.waitUntil(...)`로 스케줄해 응답 latency에서 분리(`scheduleTripEvent` 헬퍼). 기존 단위 테스트가 `app.fetch(req, env)`를 executionCtx 없이 호출하는 관례라 `c.executionCtx` 접근이 throw하는 경우 fire-and-forget으로 graceful degrade — `recordTripEvent` 자체가 내부에서 실패를 swallow하므로 unhandled rejection 없음. `index.test.ts`에 (a) 3건 모두 waitUntil로 스케줄되고 완료 후 D1 INSERT가 실행됨을 확인하는 테스트, (b) executionCtx 미제공 시에도 정상 응답하는 하위호환 테스트를 추가.

`liveActivity.ts`의 `trip-end` 기록은 그대로 `await` 유지 — `cleanupTripWithLa`는 cron(`scheduled.ts`) 13개 호출부와 `DELETE /trips/:token` 1개 호출부가 공유하는 함수라, waitUntil 스레딩을 위해 signature를 바꾸면 cron 쪽까지 영향 범위가 커진다. `DELETE /trips/:token`은 station-change마다 반복 호출되는 `/boarding-lock/sync`와 달리 trip당 1회뿐이라 같은 수준의 "핫패스"로 보지 않았다(코디네이터 지침의 "cron 경로는 그대로 둬도 됨"과 동일 결의 판단).

검증: backend `npm test` 2974/2974 pass (신규 4건), `npm run type-check` pass. head commit `84827e94`.
