### PR TITLE
fix(#2283): 리뷰 P2 반영 복구 — PR #2291이 반영 커밋 이전에 머지됨

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -3542,6 +3542,81 @@ describe('POST /boarding-lock/sync (#901)', () => {
       expect(body.autoLockCandidate.expiresAt).toBeGreaterThan(Date.now());
     });
   });
+
+  // #2283 리뷰 P2-2 — trip_events 기록(sync-received/advance/hydrate-issued)이 핫패스 응답
+  // latency에 얹히지 않고 `c.executionCtx.waitUntil`로 스케줄되는지 검증.
+  describe('trip_events waitUntil wiring (#2283 리뷰 P2-2)', () => {
+    function makeExecutionContext(): ExecutionContext & { waitUntil: ReturnType<typeof vi.fn> } {
+      return {
+        waitUntil: vi.fn(),
+        passThroughOnException: () => {},
+        props: {},
+      } as unknown as ExecutionContext & { waitUntil: ReturnType<typeof vi.fn> };
+    }
+
+    async function postWithCtx(
+      path: string,
+      body: unknown,
+      env: Env,
+      ctx: ExecutionContext,
+    ): Promise<Response> {
+      return app.fetch(
+        new Request(`http://example.com${path}`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(body),
+        }),
+        env,
+        ctx,
+      );
+    }
+
+    it('sync-received/advance/hydrate-issued 3종 모두 waitUntil로 스케줄된다 (응답을 막지 않음)', async () => {
+      const env = makeKvEnv();
+      const prepare = vi.fn().mockReturnValue({
+        bind: vi.fn().mockReturnValue({ run: vi.fn().mockResolvedValue({ success: true }) }),
+      });
+      env.DB = { prepare } as unknown as Env['DB'];
+      await post('/trips', tripWithLock(), env);
+
+      const ctx = makeExecutionContext();
+      // waypoints[0]='강남' 일치 → advance 발생 + boardingLock 존재 → hydrate-issued도 발생.
+      const res = await postWithCtx(
+        '/boarding-lock/sync',
+        { token: 'tok-sync', observedStationName: '강남', observedAtMs: 1, accuracy: 5 },
+        env,
+        ctx,
+      );
+      expect(res.status).toBe(200);
+
+      // 3건(sync-received/advance/hydrate-issued) 모두 waitUntil에 넘겨졌는지 확인.
+      expect(ctx.waitUntil).toHaveBeenCalledTimes(3);
+      // waitUntil로 넘긴 프로미스가 실제로 완료되면 각 kind에 대해 D1 INSERT가 실행됐어야 한다.
+      const scheduled = ctx.waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>);
+      await Promise.all(scheduled);
+      const kinds = prepare.mock.calls
+        .map((call) => call[0] as string)
+        .filter((sql) => sql.includes('INSERT INTO trip_events'));
+      expect(kinds).toHaveLength(3);
+    });
+
+    it('executionCtx 미제공(기존 단위 테스트 관례) 시에도 throw 없이 정상 응답한다', async () => {
+      const env = makeKvEnv();
+      const prepare = vi.fn().mockReturnValue({
+        bind: vi.fn().mockReturnValue({ run: vi.fn().mockResolvedValue({ success: true }) }),
+      });
+      env.DB = { prepare } as unknown as Env['DB'];
+      await post('/trips', tripWithLock(), env);
+
+      // executionCtx 없이 기존 post() 헬퍼로 호출 — scheduleTripEvent가 graceful degrade해야 함.
+      const res = await post(
+        '/boarding-lock/sync',
+        { token: 'tok-sync', observedStationName: '강남', observedAtMs: 1, accuracy: 5 },
+        env,
+      );
+      expect(res.status).toBe(200);
+    });
+  });
 });
 
 // #1364 — verifyBoardingLockPersisted 단위 테스트 (sync handler retry/5xx 게이트의 분기).

--- a/backend/alarm-worker/src/__tests__/tripEventLog.test.ts
+++ b/backend/alarm-worker/src/__tests__/tripEventLog.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import { cleanupTripEvents, recordTripEvent, TRIP_EVENT_RETENTION_MS } from '../tripEventLog';
+import { captureXEvent } from '../sentry';
+
+vi.mock('../sentry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../sentry')>();
+  return { ...actual, captureXEvent: vi.fn() };
+});
 
 function makeMockDb(runResult: unknown = { success: true }): D1Database {
   const run = vi.fn().mockResolvedValue(runResult);
@@ -83,6 +89,20 @@ describe('recordTripEvent (#2283)', () => {
       recordTripEvent(db, { tokenHash: 'hash5', kind: 'sync-received' }),
     ).resolves.toBeUndefined();
   });
+
+  it('D1 write 실패 시 무음이 아니라 captureXEvent로 관측 승격된다 (#2283 리뷰 P2-1)', async () => {
+    const run = vi.fn().mockRejectedValue(new Error('D1 write error'));
+    const bind = vi.fn().mockReturnValue({ run });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+
+    await recordTripEvent(db, { tokenHash: 'hash6', kind: 'sync-received' });
+
+    expect(captureXEvent).toHaveBeenCalledWith(
+      'D1-write-failure',
+      expect.objectContaining({ table: 'trip_events', kind: 'sync-received' }),
+    );
+  });
 });
 
 describe('cleanupTripEvents (#2283)', () => {
@@ -121,5 +141,19 @@ describe('cleanupTripEvents (#2283)', () => {
     const db = { prepare } as unknown as D1Database;
 
     await expect(cleanupTripEvents(db, 1000)).resolves.toBe(0);
+  });
+
+  it('D1 delete 실패 시 무음이 아니라 captureXEvent로 관측 승격된다 (#2283 리뷰 P2-1)', async () => {
+    const run = vi.fn().mockRejectedValue(new Error('D1 delete error'));
+    const bind = vi.fn().mockReturnValue({ run });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+
+    await cleanupTripEvents(db, 1000);
+
+    expect(captureXEvent).toHaveBeenCalledWith(
+      'D1-write-failure',
+      expect.objectContaining({ table: 'trip_events', kind: 'cleanup' }),
+    );
   });
 });

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -11,7 +11,7 @@
  *   cron every 1 min — 활성 트립 폴링 + 알람 발사
  */
 
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { AUTO_PROMPT_DEDUP_WINDOW_MS } from './autoLock';
 import { isNearOrigin, markPromptSilenced } from './boardingPrompt';
 import {
@@ -175,6 +175,24 @@ function makeLaStats(): LiveActivityStats {
 }
 
 export const app = new Hono<{ Bindings: Env }>();
+
+/**
+ * #2283 리뷰 P2-2 — trip_events 기록(핫패스 `/boarding-lock/sync` 내 telemetry)이 응답 latency에
+ * 얹히지 않도록 `c.executionCtx.waitUntil`로 응답 반환 이후에 완료시킨다.
+ *
+ * Workers 런타임은 fetch handler에 항상 ExecutionContext를 제공하지만, 기존 단위 테스트 관례
+ * (`app.fetch(req, env)` — executionCtx 3번째 인자 생략, index.test.ts 전역)에서는
+ * `c.executionCtx` 접근 자체가 throw한다(Hono context.js). `recordTripEvent`는 내부에서 실패를
+ * 이미 swallow하므로, executionCtx 부재 시 fire-and-forget으로 degrade해도 unhandled rejection
+ * 위험이 없다 — 프로덕션 동작(waitUntil로 완료 보장)에는 영향 없이 테스트 하위호환만 흡수한다.
+ */
+function scheduleTripEvent(c: Context<{ Bindings: Env }>, promise: Promise<void>): void {
+  try {
+    c.executionCtx.waitUntil(promise);
+  } catch {
+    void promise;
+  }
+}
 
 /**
  * #1578 — Sentry init 미들웨어. DSN 미설정 시 graceful no-op (idempotent).
@@ -1847,12 +1865,16 @@ app.post('/boarding-lock/sync', async (c) => {
   const now = Date.now();
   // #2283 — D1 append-only 관측. KV trip 객체와 독립적으로 sync 도달을 보존한다(user-delete 시
   // KV가 사라져도 사후 재구성 가능해야 함). DB 미바인딩/실패는 recordTripEvent 내부 graceful no-op.
+  // #2283 리뷰 P2-2 — 핫패스 응답 latency에 얹지 않도록 waitUntil로 스케줄(scheduleTripEvent 참고).
   const tokenHash = hashTripToken(payload.token);
-  await recordTripEvent(c.env.DB, {
-    tokenHash,
-    kind: 'sync-received',
-    station: payload.observedStationName,
-  });
+  scheduleTripEvent(
+    c,
+    recordTripEvent(c.env.DB, {
+      tokenHash,
+      kind: 'sync-received',
+      station: payload.observedStationName,
+    }),
+  );
   const advance = computeLockSyncAdvance(existing.waypoints, payload.observedStationName);
 
   let working: Trip = existing;
@@ -1870,13 +1892,17 @@ app.post('/boarding-lock/sync', async (c) => {
     // progress KV mirror — POST /trips re-register 시 같은 trainCode면 shift 진행분이 보존되도록.
     await maybeMirrorLockSyncProgress(c.env.TRIPS, working, advance.shiftedCount);
     // #2283 — advance 이벤트 관측. 새 head waypoint를 기록해 "언제 어디로 advance했는지" 사후 조회.
+    // #2283 리뷰 P2-2 — waitUntil로 스케줄.
     const advancedHead = remaining[0];
-    await recordTripEvent(c.env.DB, {
-      tokenHash,
-      kind: 'advance',
-      station: advancedHead ? advancedHead.stationName : undefined,
-      meta: { shiftedCount: advance.shiftedCount },
-    });
+    scheduleTripEvent(
+      c,
+      recordTripEvent(c.env.DB, {
+        tokenHash,
+        kind: 'advance',
+        station: advancedHead ? advancedHead.stationName : undefined,
+        meta: { shiftedCount: advance.shiftedCount },
+      }),
+    );
   }
 
   // D4 (#1210) — payload trainCode가 KV lock trainCode와 다르면 환승 leg로 해석.
@@ -1932,12 +1958,16 @@ app.post('/boarding-lock/sync', async (c) => {
   if (working.boardingLock) {
     // #2283 — hydrate-issued 관측. autoLockCandidate를 device가 실제로 받아 lock state를
     // hydrate할 수 있는 응답임을 기록(sync-received/advance와 별도 kind — "발사됐는지"를 분리 관측).
-    await recordTripEvent(c.env.DB, {
-      tokenHash,
-      kind: 'hydrate-issued',
-      station: head ? head.stationName : undefined,
-      line: working.boardingLock.line,
-    });
+    // #2283 리뷰 P2-2 — waitUntil로 스케줄.
+    scheduleTripEvent(
+      c,
+      recordTripEvent(c.env.DB, {
+        tokenHash,
+        kind: 'hydrate-issued',
+        station: head ? head.stationName : undefined,
+        line: working.boardingLock.line,
+      }),
+    );
   }
   return c.json({
     ok: true,

--- a/backend/alarm-worker/src/tripEventLog.ts
+++ b/backend/alarm-worker/src/tripEventLog.ts
@@ -16,7 +16,13 @@
  *
  * `env.DB` 미바인딩 시 graceful no-op. 적재 실패는 호출 흐름을 차단하지 않는다(swallow) —
  * d1ErrorLog.ts / d1TripMetrics.ts와 동일 패턴.
+ *
+ * #2283 리뷰 P2-1 — write/cleanup 실패는 console.warn만으로 무음 처리하지 않고
+ * `captureXEvent('D1-write-failure', ...)`(sentry.ts, d1ErrorLog.ts와 동일 기존 이벤트 재사용,
+ * 신규 유니온 추가 없음)로 관측 승격한다.
  */
+
+import { captureXEvent } from './sentry';
 
 /** trip_events.kind 최소 집합. 데이터 주도 확장 시 이 유니온에 추가한다. */
 export type TripEventKind = 'sync-received' | 'advance' | 'hydrate-issued' | 'trip-end';
@@ -61,6 +67,9 @@ export async function recordTripEvent(
     console.warn(
       JSON.stringify({ msg: 'tripEventLog write failed', kind: input.kind, err: String(e) }),
     );
+    // #2283 리뷰 P2-1 — D1 write 자체가 실패한 상황이라 D1 sink(trip_events)로는 escalate할 수
+    // 없어 Sentry-only(d1ErrorLog.ts와 동일 패턴).
+    captureXEvent('D1-write-failure', { table: 'trip_events', kind: input.kind, err: String(e) });
   }
 }
 
@@ -86,6 +95,8 @@ export async function cleanupTripEvents(
     return result.meta?.changes ?? 0;
   } catch (e) {
     console.warn(JSON.stringify({ msg: 'tripEventLog cleanup failed', err: String(e) }));
+    // #2283 리뷰 P2-1 — cleanup(DELETE) 실패도 동일하게 Sentry escalation.
+    captureXEvent('D1-write-failure', { table: 'trip_events', kind: 'cleanup', err: String(e) });
     return 0;
   }
 }


### PR DESCRIPTION
## 배경
PR #2291이 리뷰 P2 반영 커밋(84827e94)이 PR에 반영되기 전 상태(469093bf)로 머지됨 → 반영분 유실. 본 PR은 그 커밋을 dev 위로 cherry-pick한 복구 PR (lesson_merge_before_review_fix_push_lost 절차).

## 내용 (원 커밋 그대로)
- P2-1: tripEventLog write/cleanup 실패 시 `captureXEvent('D1-write-failure')` Sentry escalation (기존 이벤트 타입 재사용)
- P2-2: `/boarding-lock/sync` 관측 insert 3건을 `scheduleTripEvent` helper 경유 `executionCtx.waitUntil`로 전환 (핫패스 직렬 await 제거)
- 테스트 4건 추가 (RED/GREEN은 #2291 재검토에서 실증됨)

## Wire-completion 5단
1. orphan N/A(backend) 2. V/X: Sentry D1-write-failure 이벤트 3. 의존 PR: N/A (#2291 머지됨) 4. 측정: 다음 trip에서 trip_events 기록 + Sentry 무이벤트 확인 5. Device verify: N/A — backend only

검증: backend 2982 tests pass, type-check pass (dev 최신 머지 5건 포함 상태에서 재실행).
Part of #2283.