### PR TITLE
fix(#2290): 탑승 중 ETA에서 출발 leg boarding 대기 제외

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -256,6 +256,8 @@ describe('useBoardingLockController', () => {
         boardedAt: 1_700_000_000_000,
         expectedDurationMs: 20 * 60_000,
         initialEtaSeconds: 240,
+        // #2290 P1 — user-tap은 탑승 확정 evidence가 아니므로 evidence=false가 stamp된다.
+        boardingEvidence: false,
       });
     });
 
@@ -518,6 +520,11 @@ describe('useBoardingLockController', () => {
       });
       // initialEtaSeconds는 자동 hydrate에선 미포함 (Seam A 지연 칩은 명시 탭 lock 한정).
       expect(lock.initialEtaSeconds).toBeUndefined();
+      // #2290 P1 (RCA 재현) — candidate.from이 'transfer-swap'이 아닌 이 경로(#915/#916 원거리
+      // autoLock candidate)는 Gate 2(motionStationary)가 "아직 원점 정적 대기 중"을 확인해야
+      // 통과하므로 "아직 미탑승" 가능성이 정상 케이스다. evidence로 뭉뚱그리지 않고 false —
+      // initialEtaSeconds도 없으므로 hasConsumedOriginWait는 보수적으로 대기를 유지한다.
+      expect(lock.boardingEvidence).toBe(false);
     });
 
     it('역명+line 매칭 시 boardingStationId 정정', async () => {
@@ -775,6 +782,11 @@ describe('useBoardingLockController', () => {
             });
           });
           await waitFor(() => expect(mockSetBoardingLock).toHaveBeenCalled());
+          // #2290 P1 (RCA 재현): backend가 (기존 lock + trainCode 제공 + trainCode 변경) 3조건을
+          // 모두 검증한 뒤 발급한 transfer-swap candidate는 이미 새 leg에 탑승/이동 중이라는
+          // 확정 evidence다. evidence=false로 stamp되면(수정 전 버그) initialEtaSeconds도 없는 이
+          // lock 타입에서 trip 내내 hasConsumedOriginWait가 false로 고착된다.
+          expect(mockSetBoardingLock.mock.calls[0][0].boardingEvidence).toBe(true);
         });
 
         it('from=transfer-swap이어도 Gate 1(trainCode가 directionalArrivals에 없음) 통과 못하면 no-op', async () => {
@@ -1129,6 +1141,12 @@ describe('useBoardingLockController', () => {
       expect(arg.trainCode).toBe('AUTO-1');
       expect(arg.boardingLine).toBe('2');
       // motion gate / directionalArrivals 검증 X (suggestion 채택은 우회)
+      // #2290 P1 (RCA 재현): lockSuggestion은 backend(#1534)가 arvlcd-confirmed evidence로 이미
+      // 합의한 뒤 통보한 결과라 생성 시점 자체가 탑승 evidence다. evidence=false로 stamp되면
+      // (수정 전 버그) `hasConsumedOriginWait`가 initialEtaSeconds도 없는 이 lock 타입에서 trip
+      // 내내 false로 고착돼 출발 대기가 과다 합산된다.
+      const evidence = createLockMock.mock.calls[0][1];
+      expect(evidence).toBe(true);
     });
 
     it('이미 lock 존재 → suggestion 채택 skip (idempotent)', async () => {
@@ -1300,6 +1318,9 @@ describe('useBoardingLockController', () => {
       expect(arg.trainCode).toBe('AUTO-X');
       expect(arg.boardingLine).toBe('2');
       expect(arg.initialEtaSeconds).toBe(180);
+      // #2290 P1-1 — arvlCd 강 게이트 + 4-signal consensus를 모두 통과한 뒤에만 도달하므로
+      // evidence=true.
+      expect(createLockMock.mock.calls[0][1]).toBe(true);
     });
 
     it('lock 이미 존재 → 자동 lock skip (사용자 명시 탭 / lockSuggestion 보호)', async () => {

--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -277,8 +277,8 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
         // #897 Seam A: auto-lock 시점의 ETA(makeArrival 기본=60s) 스냅샷.
         initialEtaSeconds: 60,
       }),
-      // #2290 P1 — boardingPrompt 응답 자동lock은 evidence 없음(fallback 후보 가능) → false.
-      false,
+      // #2290 P2(재검토) — BOARDED 응답 = 사용자 탑승 상태 명시 확정 → evidence true.
+      true,
       // #2152 — boardingPrompt 응답 경로 lifecycle breadcrumb source.
       'boarding-prompt-response',
     );
@@ -367,7 +367,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     // up 단일 후보 → lock 생성, trainCode = 'UP1'
     expect(createLockMock).toHaveBeenCalledWith(
       expect.objectContaining({ trainCode: 'UP1' }),
-      false,
+      true,
       'boarding-prompt-response',
     );
   });
@@ -386,7 +386,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     // down 단일 후보 → lock 생성, trainCode = 'DOWN1'
     expect(createLockMock).toHaveBeenCalledWith(
       expect.objectContaining({ trainCode: 'DOWN1' }),
-      false,
+      true,
       'boarding-prompt-response',
     );
   });
@@ -415,7 +415,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
     expect(createLockMock).toHaveBeenCalledWith(
       expect.objectContaining({ trainCode: 'UP1' }),
-      false,
+      true,
       'boarding-prompt-response',
     );
   });

--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -277,6 +277,8 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
         // #897 Seam A: auto-lock 시점의 ETA(makeArrival 기본=60s) 스냅샷.
         initialEtaSeconds: 60,
       }),
+      // #2290 P1 — boardingPrompt 응답 자동lock은 evidence 없음(fallback 후보 가능) → false.
+      false,
       // #2152 — boardingPrompt 응답 경로 lifecycle breadcrumb source.
       'boarding-prompt-response',
     );
@@ -365,6 +367,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     // up 단일 후보 → lock 생성, trainCode = 'UP1'
     expect(createLockMock).toHaveBeenCalledWith(
       expect.objectContaining({ trainCode: 'UP1' }),
+      false,
       'boarding-prompt-response',
     );
   });
@@ -383,6 +386,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     // down 단일 후보 → lock 생성, trainCode = 'DOWN1'
     expect(createLockMock).toHaveBeenCalledWith(
       expect.objectContaining({ trainCode: 'DOWN1' }),
+      false,
       'boarding-prompt-response',
     );
   });
@@ -411,6 +415,7 @@ describe('handleResponse — boarding-prompt 분기 (#819)', () => {
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, PAYLOAD, deps);
     expect(createLockMock).toHaveBeenCalledWith(
       expect.objectContaining({ trainCode: 'UP1' }),
+      false,
       'boarding-prompt-response',
     );
   });

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -240,7 +240,11 @@ export function useBoardingLockController({
             },
           }
         : {}),
-    }).catch(() => {
+      // #2290 P1 — lockSuggestion은 backend(#1534)가 arvlcd-confirmed-train evidence로 이미
+      // 합의한 뒤 device에 통보한 결과다. device-side 9-AND gate(directionalArrivals 매칭 /
+      // motion gate)를 의도적으로 우회하는 이유(위 196-200줄)와 동일 — backend가 이미 "탑승
+      // evidence"를 확인했으므로 생성 시점 자체가 evidence다.
+    }, true).catch(() => {
       // store action rejection은 graceful — 다음 polling cycle에서 자연 재시도.
     });
   }, [
@@ -345,7 +349,9 @@ export function useBoardingLockController({
         // #897 Seam A: 탑승 시점 ETA 스냅샷. 동일 trainCode가 유지되는 동안 새 폴링의 arrivalSeconds가
         // 이 값보다 크게 늘면 그 차이가 지연(분). BoardingTrainList가 "+N분 지연" 칩으로 노출.
         initialEtaSeconds: train.arrivalSeconds,
-      }, 'user-tap').then(() => {
+      // #2290 P1 — user-tap은 "미래 열차 선택"일 뿐 탑승 확정 evidence가 아니므로 evidence=false.
+      // `hasConsumedOriginWait`가 위 initialEtaSeconds 경과 여부로 별도 판정한다.
+      }, false, 'user-tap').then(() => {
         void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       }).catch(() => {
         // store action rejection은 graceful — 다음 polling cycle에서 자연 재시도.
@@ -442,7 +448,14 @@ export function useBoardingLockController({
               },
             }
           : {}),
-      }).catch(() => {
+      // #2290 P1 — `candidate.from`별로 evidence 의미가 다르다:
+      //   - 'transfer-swap': 위 Gate 2 우회와 동일 근거(backend가 기존 lock + trainCode 변경
+      //     3조건을 모두 검증) — 이미 새 leg에 탑승/이동 중이라는 확정 evidence이므로 true.
+      //   - 그 외(#915/#916 원거리 autoLock candidate): Gate 2가 motionStationary(=아직 원점에
+      //     정적 대기 중)를 확인해야 통과하는 경로라, "아직 미탑승" 가능성이 오히려 정상 케이스다.
+      //     탑승 확정 evidence로 뭉뚱그리지 않는다 — evidence=false, initialEtaSeconds도 없으므로
+      //     `hasConsumedOriginWait`가 보수적으로 false를 유지(대기 표시 유지).
+      }, candidate.from === 'transfer-swap').catch(() => {
         // store action rejection은 graceful — loadLock race / storage 일시 실패는 다음 sync에서 자연 재시도.
       });
     },
@@ -554,11 +567,6 @@ export function useBoardingLockController({
       // 동급으로 신뢰(arvlCd 우선순위 단일 후보 + arrival API 가용)하므로 지연 칩이 backend SSoT hydrate와
       // 다르게 활성화돼야 자연스럽다.
       initialEtaSeconds: chosen.arrivalSeconds,
-      // #2290 P1-1 — 이 effect는 arvlCd(ENTERING/ARRIVED/DEPARTED) 강 게이트(위 507-511) +
-      // 4-signal consensus(위 525-536)를 모두 통과한 뒤에만 도달하므로, lock 생성 시점 자체가
-      // "이미 탑승/곧 탑승" evidence다. `hasConsumedOriginWait`가 이 flag를 보고 initialEtaSeconds
-      // 경과를 기다리지 않고 즉시 출발 대기를 소진 처리한다(ETA 표시에서 origin wait 제외).
-      boardingEvidence: true,
       ...(isSentinel
         ? {
             hydratedFromSentinel: {
@@ -567,7 +575,11 @@ export function useBoardingLockController({
             },
           }
         : {}),
-    })
+    // #2290 P1-1 — 이 effect는 arvlCd(ENTERING/ARRIVED/DEPARTED) 강 게이트(위 507-511) +
+    // 4-signal consensus(위 525-536)를 모두 통과한 뒤에만 도달하므로, lock 생성 시점 자체가
+    // "이미 탑승/곧 탑승" evidence다. `hasConsumedOriginWait`가 이 값을 보고 initialEtaSeconds
+    // 경과를 기다리지 않고 즉시 출발 대기를 소진 처리한다(ETA 표시에서 origin wait 제외).
+    }, true)
       .then(() => {
         // V/X 측정 — `source='boarding-prompt'` 재사용해 DebugModal/autoLock outcome 분포에서 한 화면에서 가시화.
         // backend push 응답 path(useBoardingPromptResponder)와 같은 reason 라벨을 쓰되, alarm log entry에는

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -554,6 +554,11 @@ export function useBoardingLockController({
       // 동급으로 신뢰(arvlCd 우선순위 단일 후보 + arrival API 가용)하므로 지연 칩이 backend SSoT hydrate와
       // 다르게 활성화돼야 자연스럽다.
       initialEtaSeconds: chosen.arrivalSeconds,
+      // #2290 P1-1 — 이 effect는 arvlCd(ENTERING/ARRIVED/DEPARTED) 강 게이트(위 507-511) +
+      // 4-signal consensus(위 525-536)를 모두 통과한 뒤에만 도달하므로, lock 생성 시점 자체가
+      // "이미 탑승/곧 탑승" evidence다. `hasConsumedOriginWait`가 이 flag를 보고 initialEtaSeconds
+      // 경과를 기다리지 않고 즉시 출발 대기를 소진 처리한다(ETA 표시에서 origin wait 제외).
+      boardingEvidence: true,
       ...(isSentinel
         ? {
             hydratedFromSentinel: {

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -370,11 +370,12 @@ async function tryAutoLock(
       expectedDurationMs: deps.expectedDurationMs,
       // #897 Seam A: auto-lock 시점 ETA 스냅샷. 지연 신호의 기준치.
       initialEtaSeconds: chosen.arrivalSeconds,
-    // #2290 P1 — boardingPrompt 응답으로 사용자가 "탑승했다"고 확인은 했지만, chosen train은
-    // `pickAutoTrainCodeFromArrivals`의 fallback 후보(evidence 없는 코드)일 수 있어 트레인 자체의
-    // 탑승 확정 evidence는 아니다. user-tap과 동일하게 evidence=false — `hasConsumedOriginWait`가
-    // 위 initialEtaSeconds 경과 여부로 판정한다.
-    }, false, 'boarding-prompt-response');
+    // #2290 P2(재검토) — 이 경로는 BOARDED 응답에서만 도달: 사용자가 "지금 탑승한 상태"를 방금
+    // 명시했으므로 탑승 상태 evidence는 확정이다(ADR-014 사용자 명시 의향 동급). chosen train이
+    // fallback 후보일 수 있다는 건 trainCode 신뢰도의 불확실성이지 탑승 여부의 불확실성이 아님 —
+    // evidence는 후자(출발 대기 소진)를 답하는 flag이므로 true. 미래 열차 "선택"인 user-tap과
+    // 시제가 다르다.
+    }, true, 'boarding-prompt-response');
     logBoardingPromptAutoLock({ reason: 'autolock-success', ...telemetry });
   } catch (err) {
     // #1167 — lock 실패 시 fallback 경로. createLock는 storage/network 예외 가능.

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -370,7 +370,11 @@ async function tryAutoLock(
       expectedDurationMs: deps.expectedDurationMs,
       // #897 Seam A: auto-lock 시점 ETA 스냅샷. 지연 신호의 기준치.
       initialEtaSeconds: chosen.arrivalSeconds,
-    }, 'boarding-prompt-response');
+    // #2290 P1 — boardingPrompt 응답으로 사용자가 "탑승했다"고 확인은 했지만, chosen train은
+    // `pickAutoTrainCodeFromArrivals`의 fallback 후보(evidence 없는 코드)일 수 있어 트레인 자체의
+    // 탑승 확정 evidence는 아니다. user-tap과 동일하게 evidence=false — `hasConsumedOriginWait`가
+    // 위 initialEtaSeconds 경과 여부로 판정한다.
+    }, false, 'boarding-prompt-response');
     logBoardingPromptAutoLock({ reason: 'autolock-success', ...telemetry });
   } catch (err) {
     // #1167 — lock 실패 시 fallback 경로. createLock는 storage/network 예외 가능.

--- a/src/features/alarm/store/__tests__/useBoardingLockStore.test.ts
+++ b/src/features/alarm/store/__tests__/useBoardingLockStore.test.ts
@@ -53,34 +53,36 @@ describe('useBoardingLockStore', () => {
   describe('createLock', () => {
     it('state + storage 양쪽 갱신', async () => {
       await act(async () => {
-        await useBoardingLockStore.getState().createLock(sample);
+        await useBoardingLockStore.getState().createLock(sample, false);
       });
-      expect(useBoardingLockStore.getState().lock).toEqual(sample);
-      expect(mockSetBoardingLock).toHaveBeenCalledWith(sample);
+      // #2290 P1 — createLock이 evidence 인자를 lock.boardingEvidence로 합성해 저장한다.
+      expect(useBoardingLockStore.getState().lock).toEqual({ ...sample, boardingEvidence: false });
+      expect(mockSetBoardingLock).toHaveBeenCalledWith({ ...sample, boardingEvidence: false });
     });
 
     it('기존 Lock을 새 Lock으로 교체 (multi-transfer 전환 대비)', async () => {
       await act(async () => {
-        await useBoardingLockStore.getState().createLock(sample);
+        await useBoardingLockStore.getState().createLock(sample, false);
       });
       const next: BoardingLock = { ...sample, trainCode: 'T-200', boardingLine: '7' };
       await act(async () => {
-        await useBoardingLockStore.getState().createLock(next);
+        await useBoardingLockStore.getState().createLock(next, true);
       });
-      expect(useBoardingLockStore.getState().lock).toEqual(next);
-      expect(mockSetBoardingLock).toHaveBeenLastCalledWith(next);
+      // evidence=true로 생성 — boardingEvidence:true가 합성돼야 한다.
+      expect(useBoardingLockStore.getState().lock).toEqual({ ...next, boardingEvidence: true });
+      expect(mockSetBoardingLock).toHaveBeenLastCalledWith({ ...next, boardingEvidence: true });
     });
 
     it('#746 — createLock은 dismissSilence storage를 즉시 클리어', async () => {
       await act(async () => {
-        await useBoardingLockStore.getState().createLock(sample);
+        await useBoardingLockStore.getState().createLock(sample, false);
       });
       expect(mockClearDismissSilence).toHaveBeenCalledTimes(1);
     });
 
     it('#2152 — source 미전달 시 lifecycle buffer에 create 엔트리 source=other로 적재', async () => {
       await act(async () => {
-        await useBoardingLockStore.getState().createLock(sample);
+        await useBoardingLockStore.getState().createLock(sample, false);
       });
       const entries = getLockLifecycleEntries();
       expect(entries).toHaveLength(1);
@@ -96,7 +98,7 @@ describe('useBoardingLockStore', () => {
 
     it('#2152 — source 전달 시 lifecycle buffer에 그대로 stamp', async () => {
       await act(async () => {
-        await useBoardingLockStore.getState().createLock(sample, 'user-tap');
+        await useBoardingLockStore.getState().createLock(sample, false, 'user-tap');
       });
       const entries = getLockLifecycleEntries();
       expect(entries).toHaveLength(1);
@@ -184,7 +186,7 @@ describe('useBoardingLockStore', () => {
   describe('breadcrumb', () => {
     it('createLock 시 lock-create breadcrumb 추가', async () => {
       await act(async () => {
-        await useBoardingLockStore.getState().createLock(sample);
+        await useBoardingLockStore.getState().createLock(sample, false);
       });
       expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('boarding', 'lock-create', {
         trainCode: sample.trainCode,
@@ -270,15 +272,15 @@ describe('useBoardingLockStore', () => {
 
       it('boardingStationId만 다른 createLock도 기존 lock을 교체한다', async () => {
         await act(async () => {
-          await useBoardingLockStore.getState().createLock(sample);
+          await useBoardingLockStore.getState().createLock(sample, false);
         });
         const swapped: BoardingLock = { ...sample, boardingStationId: 'stn-DIFFERENT' };
         await act(async () => {
-          await useBoardingLockStore.getState().createLock(swapped);
+          await useBoardingLockStore.getState().createLock(swapped, false);
         });
         // flag OFF → 기존 동작 (교체 발생).
-        expect(useBoardingLockStore.getState().lock).toEqual(swapped);
-        expect(mockSetBoardingLock).toHaveBeenLastCalledWith(swapped);
+        expect(useBoardingLockStore.getState().lock).toEqual({ ...swapped, boardingEvidence: false });
+        expect(mockSetBoardingLock).toHaveBeenLastCalledWith({ ...swapped, boardingEvidence: false });
       });
     });
 
@@ -289,18 +291,18 @@ describe('useBoardingLockStore', () => {
 
       it('동일 destination/trainCode/boardingLine에서 boardingStationId만 다른 createLock은 skip한다', async () => {
         await act(async () => {
-          await useBoardingLockStore.getState().createLock(sample);
+          await useBoardingLockStore.getState().createLock(sample, false);
         });
         mockSetBoardingLock.mockClear();
         mockAddDomainBreadcrumb.mockClear();
 
         const attemptedSwap: BoardingLock = { ...sample, boardingStationId: 'stn-DIFFERENT' };
         await act(async () => {
-          await useBoardingLockStore.getState().createLock(attemptedSwap);
+          await useBoardingLockStore.getState().createLock(attemptedSwap, false);
         });
 
         // 기존 lock은 그대로 유지, storage write 없음.
-        expect(useBoardingLockStore.getState().lock).toEqual(sample);
+        expect(useBoardingLockStore.getState().lock).toEqual({ ...sample, boardingEvidence: false });
         expect(useBoardingLockStore.getState().lock?.boardingStationId).toBe('stn-A');
         expect(mockSetBoardingLock).not.toHaveBeenCalled();
 
@@ -315,7 +317,7 @@ describe('useBoardingLockStore', () => {
 
       it('trainCode 변경(정당한 환승 leg)은 boardingStationId 변경을 허용한다', async () => {
         await act(async () => {
-          await useBoardingLockStore.getState().createLock(sample);
+          await useBoardingLockStore.getState().createLock(sample, false);
         });
         const legitimateTransfer: BoardingLock = {
           ...sample,
@@ -323,14 +325,14 @@ describe('useBoardingLockStore', () => {
           boardingStationId: 'stn-TRANSFER',
         };
         await act(async () => {
-          await useBoardingLockStore.getState().createLock(legitimateTransfer);
+          await useBoardingLockStore.getState().createLock(legitimateTransfer, false);
         });
-        expect(useBoardingLockStore.getState().lock).toEqual(legitimateTransfer);
+        expect(useBoardingLockStore.getState().lock).toEqual({ ...legitimateTransfer, boardingEvidence: false });
       });
 
       it('boardingLine 변경(다른 노선 leg)은 boardingStationId 변경을 허용한다', async () => {
         await act(async () => {
-          await useBoardingLockStore.getState().createLock(sample);
+          await useBoardingLockStore.getState().createLock(sample, false);
         });
         const transferLeg: BoardingLock = {
           ...sample,
@@ -338,14 +340,14 @@ describe('useBoardingLockStore', () => {
           boardingStationId: 'stn-TRANSFER',
         };
         await act(async () => {
-          await useBoardingLockStore.getState().createLock(transferLeg);
+          await useBoardingLockStore.getState().createLock(transferLeg, false);
         });
-        expect(useBoardingLockStore.getState().lock).toEqual(transferLeg);
+        expect(useBoardingLockStore.getState().lock).toEqual({ ...transferLeg, boardingEvidence: false });
       });
 
       it('destinationId 변경(다른 trip)은 boardingStationId 변경을 허용한다', async () => {
         await act(async () => {
-          await useBoardingLockStore.getState().createLock(sample);
+          await useBoardingLockStore.getState().createLock(sample, false);
         });
         const differentTrip: BoardingLock = {
           ...sample,
@@ -353,34 +355,34 @@ describe('useBoardingLockStore', () => {
           boardingStationId: 'stn-DIFFERENT',
         };
         await act(async () => {
-          await useBoardingLockStore.getState().createLock(differentTrip);
+          await useBoardingLockStore.getState().createLock(differentTrip, false);
         });
-        expect(useBoardingLockStore.getState().lock).toEqual(differentTrip);
+        expect(useBoardingLockStore.getState().lock).toEqual({ ...differentTrip, boardingEvidence: false });
       });
 
       it('boardingStationId가 동일하면 다른 필드 갱신 시 정상 교체', async () => {
         await act(async () => {
-          await useBoardingLockStore.getState().createLock(sample);
+          await useBoardingLockStore.getState().createLock(sample, false);
         });
         // 같은 leg 안에서 expectedDurationMs 등 다른 필드 갱신은 정당한 use case.
         const sameStationUpdate: BoardingLock = { ...sample, expectedDurationMs: 999_999 };
         await act(async () => {
-          await useBoardingLockStore.getState().createLock(sameStationUpdate);
+          await useBoardingLockStore.getState().createLock(sameStationUpdate, false);
         });
-        expect(useBoardingLockStore.getState().lock).toEqual(sameStationUpdate);
+        expect(useBoardingLockStore.getState().lock).toEqual({ ...sameStationUpdate, boardingEvidence: false });
       });
 
       it('첫 lock 생성(기존 lock 없음)은 정상 처리', async () => {
         // lock=null 상태에서 createLock — 비교 대상이 없으므로 정책 우회 + 정상 생성.
         await act(async () => {
-          await useBoardingLockStore.getState().createLock(sample);
+          await useBoardingLockStore.getState().createLock(sample, false);
         });
-        expect(useBoardingLockStore.getState().lock).toEqual(sample);
+        expect(useBoardingLockStore.getState().lock).toEqual({ ...sample, boardingEvidence: false });
       });
 
       it('다수 tick 동안 auto-swap 시도해도 boardingStationId 변경 시도 0건', async () => {
         await act(async () => {
-          await useBoardingLockStore.getState().createLock(sample);
+          await useBoardingLockStore.getState().createLock(sample, false);
         });
         mockSetBoardingLock.mockClear();
 
@@ -390,7 +392,7 @@ describe('useBoardingLockStore', () => {
           await act(async () => {
             await useBoardingLockStore
               .getState()
-              .createLock({ ...sample, boardingStationId: stnId });
+              .createLock({ ...sample, boardingStationId: stnId }, false);
           });
         }
 

--- a/src/features/alarm/store/useBoardingLockStore.ts
+++ b/src/features/alarm/store/useBoardingLockStore.ts
@@ -39,6 +39,15 @@ export type LockReleaseReason =
   | 'trip-cleanup';
 
 /**
+ * #2290 P1 (PR #2295 리뷰 2회차) — `createLock` 호출부가 만드는 lock payload. `boardingEvidence`는
+ * 이 타입에서 의도적으로 제외된다 — 호출자가 lock 객체 안에 산발적으로 stamp하면 새 lock 생성
+ * 경로가 추가될 때 stamp를 빠뜨려도 컴파일이 통과해버린다(P1-1 회귀의 재발 형태). 대신
+ * `createLock`의 별도 필수 인자 `evidence`로 강제해, 신규 호출부가 이 값을 명시하지 않으면
+ * 컴파일이 실패하도록 한다.
+ */
+export type BoardingLockInput = Omit<BoardingLock, 'boardingEvidence'>;
+
+/**
  * BoardingLock 전역 store (#584 PR A).
  *
  * Single Lock only — trip 1개에 leg 1개. multi-transfer는 createLock으로 교체(PR E).
@@ -53,8 +62,23 @@ export interface BoardingLockState {
    * #2152 — source는 lifecycle breadcrumb에 stamp되는 생성 경로 식별자. 사용자 명시 탭
    * (BoardingTrainList)과 boardingPrompt 응답을 구분해 오토락 범인 특정을 소거법으로 가능하게
    * 한다. 미전달(그 외 경로 — 자동 lock/backend suggestion 등)은 'other'로 기록.
+   *
+   * #2290 P1 — `evidence`는 필수 인자다(기본값 없음). "탑승했다/곧 탑승한다"는 device-side 또는
+   * backend-confirmed evidence가 이 lock 생성 시점에 실제로 있었는지를 호출자가 명시해야 한다:
+   *   - `true` — arvlCd 강 게이트 + consensus를 통과한 device-side auto-lock, backend가 이미
+   *     arvlcd-confirmed evidence로 합의한 lockSuggestion(#1534), 또는 backend가 (기존 lock +
+   *     trainCode 변경) 3조건을 모두 검증한 transfer-swap candidate처럼 "생성 시점 자체가 탑승
+   *     evidence"인 경로.
+   *   - `false` — user-tap(BoardingTrainList 직접 탭), boardingPrompt 응답 자동lock, 환승 leg
+   *     device auto-lock(D5), backend가 evidence 없이 발급한 autoLock candidate처럼 "미래 열차
+   *     선택/의향"만 있고 탑승 확정 evidence가 없는 경로. `hasConsumedOriginWait`가 이 경우
+   *     `initialEtaSeconds` 경과 여부로 별도 판정한다(부재 시 보수적으로 대기 유지).
    */
-  createLock: (lock: BoardingLock, source?: LockLifecycleCreateSource) => Promise<void>;
+  createLock: (
+    lock: BoardingLockInput,
+    evidence: boolean,
+    source?: LockLifecycleCreateSource,
+  ) => Promise<void>;
   /**
    * 사용자가 "하차" 탭하거나 trip 종료 시 호출.
    *
@@ -75,7 +99,15 @@ export interface BoardingLockState {
 export const useBoardingLockStore = create<BoardingLockState>((set, get) => ({
   lock: null,
 
-  createLock: async (lock: BoardingLock, source: LockLifecycleCreateSource = 'other') => {
+  createLock: async (
+    lockInput: BoardingLockInput,
+    evidence: boolean,
+    source: LockLifecycleCreateSource = 'other',
+  ) => {
+    // #2290 P1 — evidence를 별도 필수 인자로 받아 여기서 한 곳에서만 lock 객체에 합성한다.
+    // 호출부가 lock 객체 리터럴 안에 산발적으로 boardingEvidence를 stamp하던 방식(P1-1)은
+    // 새 생성 경로가 추가돼도 stamp를 빠뜨리면 컴파일이 통과했다 — 이 지점 하나로 강제한다.
+    const lock: BoardingLock = { ...lockInput, boardingEvidence: evidence };
     // #1996 (Phase 1-7, ADR-022 A4) — boardingStationId 불변 정책 (flag ON 시).
     //
     // route 등록 시 확정된 boardingStationId는 절대 자동 변경 금지 (auto-swap / reanchored /

--- a/src/features/alarm/utils/__tests__/stationPipeline.test.ts
+++ b/src/features/alarm/utils/__tests__/stationPipeline.test.ts
@@ -328,6 +328,9 @@ describe('processLocationUpdate', () => {
     expect(mockCalculateStaticETA).toHaveBeenCalledWith(mockRoute, {
       currentLocation: { lat: 37.498, lng: 127.028 },
       originStation: { lat: mockStation.lat, lng: mockStation.lng },
+      arrivalAtOrigin: undefined,
+      arrivalsAtTransfers: undefined,
+      excludeOriginWait: false,
     });
   });
 

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -14,6 +14,7 @@ import { distanceMetersBetween, estimateEtaSeconds, estimateTransitEtaSeconds } 
 import { cancelSafetyNetByStationKind } from './safetyNetScheduler';
 import { getBoardingLock } from './boardingLockStorage';
 import { getLastNotifiedStationId, setLastNotifiedStationId } from './notificationState';
+import { useLegAdvanceStore } from '../store/useLegAdvanceStore';
 import {
   logFiredAlarm,
   logSuppressedChannelAgnosticDedup,
@@ -546,11 +547,15 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   // 일치하므로 도보 0이 자명. 사용자 좌표를 별도로 보유하게 되면 destination/destinationStation 추가.
   // #777: arrivalAtOrigin 호출자가 제공 시 calculateStaticETA가 다음 열차 대기를 동적으로 계산.
   // #778: arrivalsAtTransfers 호출자가 제공 시 환승 leg마다 동적, 미제공 시 leg당 DEFAULT_WAIT_MINUTES.
+  // #2290 — in-trip(boardingLock 활성 또는 legAdvance stamp)이면 출발 leg의 boarding 대기를
+  // 제외한다. lockForLineGuard는 위에서 이미 조회한 boardingLock(신규 감지 경로 아님, 재사용).
+  const isInTrip = Boolean(lockForLineGuard) || useLegAdvanceStore.getState().nextLine !== null;
   const eta = calculateStaticETA(route, {
     currentLocation: { lat, lng },
     originStation: { lat: nearest.station.lat, lng: nearest.station.lng },
     arrivalAtOrigin,
     arrivalsAtTransfers,
+    excludeOriginWait: isInTrip,
   });
   // #746 — silence로 차단된 phase 알람은 sleep overlay에 노출하지 않음 (alarmEvent → null).
   const effectiveAlarmEvent = suppressedAlarmEvent ? null : alarmEvent;

--- a/src/features/alarm/utils/stationPipeline.ts
+++ b/src/features/alarm/utils/stationPipeline.ts
@@ -8,6 +8,7 @@
  */
 import { findNearestStation } from '../../nearest-station/utils/findNearestStation';
 import { findRoute, calculateStaticETA, getFirstLeg, getRouteRemainingSeconds, isSameStationName, isStationOnRoute, updateRouteFromPosition } from '../../../shared/utils/stationRoute';
+import { hasConsumedOriginWait } from '../../../shared/utils/boardingWait';
 import { evaluateAlarmPhase, resolveAllTargets } from './stationAlarm';
 import { updateStationNotification } from './stationNotification';
 import { distanceMetersBetween, estimateEtaSeconds, estimateTransitEtaSeconds } from '../../../shared/utils/stationEta';
@@ -547,9 +548,14 @@ export async function processLocationUpdate(inputs: ProcessLocationInputs): Prom
   // 일치하므로 도보 0이 자명. 사용자 좌표를 별도로 보유하게 되면 destination/destinationStation 추가.
   // #777: arrivalAtOrigin 호출자가 제공 시 calculateStaticETA가 다음 열차 대기를 동적으로 계산.
   // #778: arrivalsAtTransfers 호출자가 제공 시 환승 leg마다 동적, 미제공 시 leg당 DEFAULT_WAIT_MINUTES.
-  // #2290 — in-trip(boardingLock 활성 또는 legAdvance stamp)이면 출발 leg의 boarding 대기를
-  // 제외한다. lockForLineGuard는 위에서 이미 조회한 boardingLock(신규 감지 경로 아님, 재사용).
-  const isInTrip = Boolean(lockForLineGuard) || useLegAdvanceStore.getState().nextLine !== null;
+  // #2290 — in-trip(출발 leg의 boarding 대기 소진 evidence)이면 대기를 제외한다.
+  // P1-1 (PR #2295 리뷰): `Boolean(lockForLineGuard)`만으로 판정하면 user-tap lock이 승강장
+  // 대기 중에도 "이미 탑승"으로 오판했다 — `hasConsumedOriginWait`로 일반화(device-side evidence
+  // 즉시 소진 / user-tap은 initialEtaSeconds 경과분만). lockForLineGuard는 위에서 이미 조회한
+  // boardingLock(신규 감지 경로 아님, 재사용). legAdvance stamp는 하차 응답=확정 evidence라 그대로 유지.
+  const isInTrip =
+    hasConsumedOriginWait(lockForLineGuard, Date.now()) ||
+    useLegAdvanceStore.getState().nextLine !== null;
   const eta = calculateStaticETA(route, {
     currentLocation: { lat, lng },
     originStation: { lat: nearest.station.lat, lng: nearest.station.lng },

--- a/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
@@ -1398,6 +1398,9 @@ describe('backgroundLocationTask defineTask 콜백', () => {
           boardingStationId: '2-012',
           boardingLine: '2',
         }),
+        // #2290 P1 — 이 진입점은 candidate.from === 'transfer-swap' 가드를 통과해야만 도달하므로
+        // evidence=true로 호출돼야 한다(backend가 3조건 검증한 transfer-swap evidence).
+        true,
       );
     });
 

--- a/src/features/nearest-station/tasks/backgroundLocationTask.ts
+++ b/src/features/nearest-station/tasks/backgroundLocationTask.ts
@@ -390,14 +390,21 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
             if (allowedLines && !allowedLines.has(boardingLine)) return;
             useBoardingLockStore
               .getState()
-              .createLock({
-                destinationId: destination.id,
-                trainCode: candidate.trainCode,
-                boardingStationId: correctedStation.id,
-                boardingLine,
-                boardedAt: Date.now(),
-                expectedDurationMs: FALLBACK_BOARDING_DURATION_MINUTES * 60_000,
-              })
+              .createLock(
+                {
+                  destinationId: destination.id,
+                  trainCode: candidate.trainCode,
+                  boardingStationId: correctedStation.id,
+                  boardingLine,
+                  boardedAt: Date.now(),
+                  expectedDurationMs: FALLBACK_BOARDING_DURATION_MINUTES * 60_000,
+                },
+                // #2290 P1 — 위 380줄 가드로 이 지점 도달 시 candidate.from은 항상
+                // 'transfer-swap'이다(backend가 3조건 검증 완료한 evidence) — 이미 새 leg에
+                // 탑승/이동 중이므로 evidence=true. FG hydrateLockFromCandidate의 동일 분기와
+                // 정책 일치.
+                true,
+              )
               .catch(() => {
                 // store action rejection은 graceful — 다음 BG tick에서 자연 재시도.
               });

--- a/src/features/route/hooks/__tests__/useTransferTrainList.test.tsx
+++ b/src/features/route/hooks/__tests__/useTransferTrainList.test.tsx
@@ -164,6 +164,7 @@ describe('useTransferTrainList', () => {
         expectedDurationMs: 6 * 60_000,
         initialEtaSeconds: 240,
       }),
+      false,
     );
   });
 
@@ -351,7 +352,7 @@ describe('#1211 D5 환승 leg autoLock 트리거', () => {
       }),
     );
     expect(mockCreateLock).toHaveBeenCalledTimes(1);
-    expect(mockCreateLock).toHaveBeenCalledWith(expectedAutoLock('T-ARRIVED', 30));
+    expect(mockCreateLock).toHaveBeenCalledWith(expectedAutoLock('T-ARRIVED', 30), false);
   });
 
   it('arvlCd 우선순위 — DEPARTED(2) 단일이면 ENTERING(0) 무시하고 DEPARTED 선택', () => {
@@ -366,7 +367,7 @@ describe('#1211 D5 환승 leg autoLock 트리거', () => {
         currentStation: gondeokOn6,
       }),
     );
-    expect(mockCreateLock).toHaveBeenCalledWith(expectedAutoLock('T-DEP', 10));
+    expect(mockCreateLock).toHaveBeenCalledWith(expectedAutoLock('T-DEP', 10), false);
   });
 
   it('ambiguity (같은 우선순위 train 2대) → autoLock skip — manual fallback', () => {
@@ -490,7 +491,7 @@ describe('#1211 D5 환승 leg autoLock 트리거', () => {
     expect(mockCreateLock).not.toHaveBeenCalled();
     act(() => result.current.createTransferLock(makeTrain({ trainCode: 'T-A', arrivalSeconds: 30 })));
     expect(mockCreateLock).toHaveBeenCalledTimes(1);
-    expect(mockCreateLock).toHaveBeenCalledWith(expectedAutoLock('T-A', 30));
+    expect(mockCreateLock).toHaveBeenCalledWith(expectedAutoLock('T-A', 30), false);
   });
 
   it('환승역에서 벗어나면(currentStation null로 전환) idempotency ref 리셋 — 다음 진입 시 재시도', () => {
@@ -536,7 +537,7 @@ describe('#1211 D5 환승 leg autoLock 트리거', () => {
       }),
     );
     expect(mockCreateLock).toHaveBeenCalledTimes(1);
-    expect(mockCreateLock).toHaveBeenCalledWith(expect.objectContaining({ trainCode: 'T-DIR-NULL' }));
+    expect(mockCreateLock).toHaveBeenCalledWith(expect.objectContaining({ trainCode: 'T-DIR-NULL' }), false);
   });
 });
 
@@ -596,6 +597,7 @@ describe('#2016 (autoLock dormant) archFlag ON 시 D5 autoLock skip', () => {
         expectedDurationMs: 6 * 60_000,
         initialEtaSeconds: 240,
       }),
+      false,
     );
   });
 

--- a/src/features/route/hooks/useTransferTrainList.ts
+++ b/src/features/route/hooks/useTransferTrainList.ts
@@ -150,7 +150,11 @@ export function useTransferTrainList({
         expectedDurationMs: durationMin * 60_000,
         // #897 Seam A: 환승 leg 탑승 시점 ETA 스냅샷. 새 폴 응답이 이보다 +180s 이상이면 지연 신호.
         initialEtaSeconds: train.arrivalSeconds,
-      });
+      // #2290 P1 — 이 함수는 사용자가 BoardingTrainList에서 직접 탭한 경우와 D5 dormant device
+      // auto-lock(아래 effect, `pickAutoTrainCodeFromArrivals` fallback 후보 포함 가능이라 강
+      // 게이트 없음) 양쪽에서 호출된다. 둘 다 탑승 확정 evidence가 아니므로 evidence=false —
+      // `hasConsumedOriginWait`가 위 initialEtaSeconds 경과 여부로 판정한다.
+      }, false);
     },
     [context, lock, route, createLock],
   );

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -600,6 +600,11 @@ export default function HomeScreen() {
   // P2 관찰(리뷰 (2)): cold-start hydration 창(앱 재시작 직후 storage에서 lock을 아직 못 읽어온
   // 수백ms)에는 fusionBoardingLock이 일시 null이라 이 조건이 false로 떨어진다. 방향은 "과다표시"
   // (원래 소진됐어야 할 대기를 잠깐 더 표시)라 과소표시보다 안전 — 별도 수정 없이 관찰만 유지.
+  // P3 관찰(리뷰 (4)): `hasConsumedOriginWait`는 렌더 시점 `Date.now()`로 평가되므로, 화면
+  // 갱신은 이 컴포넌트가 다시 렌더되는 다음 계기(위치/arrival 폴링 주기, 최대 ~30s)까지 지연될
+  // 수 있다 — user-tap lock의 initialEtaSeconds 경과 시점을 넘겨도 최대 30초간 origin wait가
+  // 계속 표시될 수 있다는 뜻. 방향은 여전히 "과다표시"(과소표시보다 안전)이므로 코드 변경 없이
+  // 관찰만 유지 — 실시간 1Hz 재평가가 필요해지면 useCountdown류 tick과 연결을 고려.
   const isInTrip = hasConsumedOriginWait(fusionBoardingLock, Date.now()) || legAdvanceLine !== null;
   const etaMinutes = route && nextTrainMinutes !== null && nextTrainMinutes !== Infinity
     ? calculateETA(nextTrainMinutes, route, { excludeOriginWait: isInTrip })

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -20,6 +20,7 @@ import { useLegAdvanceStore } from '../features/alarm/store/useLegAdvanceStore';
 import { useNavigationStore } from '../features/route/store/useNavigationStore';
 import { DestinationPicker } from '../features/route/components/DestinationPicker';
 import { findRouteCandidatesByCategory, findRoutes, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, getStationById, routeSignature, type Route, type CategorizedRoute, type RoutePreference } from '../shared/utils/stationRoute';
+import { hasConsumedOriginWait } from '../shared/utils/boardingWait';
 import { pickArrivalAtOrigin } from '../features/arrival/utils/pickArrivalAtOrigin';
 import { EditorialTimeline } from '../features/arrival/components/EditorialTimeline';
 import { arrivalInfoToArrivalTrain, journeyDisplayToStops, nearestResultToNearest } from '../features/route/utils/journeyAdapter';
@@ -588,10 +589,18 @@ export default function HomeScreen() {
     });
     return Math.min(...minutes);
   }, [arrival, arrivalIsMock]);
-  // #2290 — in-trip 판정: boardingLock 활성 또는 legAdvance stamp(#2278, 사용자 하차 응답)
-  // 존재 시 이미 탑승 중이므로 출발 leg의 boarding 대기(nextTrainMinutes)를 표시 ETA에서 제외한다.
+  // #2290 — in-trip 판정: 출발 leg의 boarding 대기를 표시 ETA에서 제외할지 여부.
+  // P1-1 (PR #2295 리뷰): `Boolean(lock)`만으로 판정하면 user-tap lock(BoardingTrainList 직접
+  // 탭)이 승강장에서 다음 열차를 기다리는 중에도 "이미 탑승"으로 오판했다. `hasConsumedOriginWait`가
+  // "lock 존재"가 아니라 "탑승 evidence가 실제로 있는가"(device-side auto-lock evidence 즉시 소진 /
+  // user-tap은 initialEtaSeconds 경과분만 소진)로 일반화해 판정한다.
+  // legAdvance stamp(#2278, 사용자 하차 응답)는 별도로 유지 — 하차 응답은 그 자체로 "이미 다음
+  // leg로 이동 중"이라는 확정 evidence이므로 lock 상태와 무관하게 즉시 true.
   // 새 자동 감지 경로 신설 금지(#2154) — 기존 신호(fusionBoardingLock/legAdvanceLine)만 재사용.
-  const isInTrip = Boolean(fusionBoardingLock) || legAdvanceLine !== null;
+  // P2 관찰(리뷰 (2)): cold-start hydration 창(앱 재시작 직후 storage에서 lock을 아직 못 읽어온
+  // 수백ms)에는 fusionBoardingLock이 일시 null이라 이 조건이 false로 떨어진다. 방향은 "과다표시"
+  // (원래 소진됐어야 할 대기를 잠깐 더 표시)라 과소표시보다 안전 — 별도 수정 없이 관찰만 유지.
+  const isInTrip = hasConsumedOriginWait(fusionBoardingLock, Date.now()) || legAdvanceLine !== null;
   const etaMinutes = route && nextTrainMinutes !== null && nextTrainMinutes !== Infinity
     ? calculateETA(nextTrainMinutes, route, { excludeOriginWait: isInTrip })
     : null;

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -588,8 +588,12 @@ export default function HomeScreen() {
     });
     return Math.min(...minutes);
   }, [arrival, arrivalIsMock]);
+  // #2290 — in-trip 판정: boardingLock 활성 또는 legAdvance stamp(#2278, 사용자 하차 응답)
+  // 존재 시 이미 탑승 중이므로 출발 leg의 boarding 대기(nextTrainMinutes)를 표시 ETA에서 제외한다.
+  // 새 자동 감지 경로 신설 금지(#2154) — 기존 신호(fusionBoardingLock/legAdvanceLine)만 재사용.
+  const isInTrip = Boolean(fusionBoardingLock) || legAdvanceLine !== null;
   const etaMinutes = route && nextTrainMinutes !== null && nextTrainMinutes !== Infinity
-    ? calculateETA(nextTrainMinutes, route)
+    ? calculateETA(nextTrainMinutes, route, { excludeOriginWait: isInTrip })
     : null;
   // #784: rawArrival(useArrivalInfo)을 직접 사용 — useArrivalCountdown(1Hz tick)은 receivedAtMs를
   // 원본으로 유지하면서 arrivalSeconds만 차감해 60s 후 항상 stale로 판정되는 회귀 회피(옵션 B).
@@ -602,6 +606,7 @@ export default function HomeScreen() {
           ? { lat: effectiveOrigin.lat, lng: effectiveOrigin.lng }
           : undefined,
         arrivalAtOrigin: pickArrivalAtOrigin(rawArrival),
+        excludeOriginWait: isInTrip,
       })
     : null;
   const isRealtimeEta = etaMinutes !== null && !arrivalIsMock && arrival !== null;

--- a/src/shared/types/boardingLock.ts
+++ b/src/shared/types/boardingLock.ts
@@ -51,6 +51,21 @@ export interface BoardingLock {
     /** sentinel-hydrate 시각(ms epoch). */
     sentinelAt: number;
   };
+  /**
+   * #2290 P1-1 — 생성 시점에 이미 "탑승했다/곧 탑승한다"는 device-side evidence가 있었는지.
+   *
+   * `useBoardingLockController`의 origin auto-lock effect(문서상 `position-train`)만 true로
+   * stamp한다 — arvlCd(ENTERING/ARRIVED/DEPARTED) 강 게이트 + 4-signal consensus를 모두 통과한
+   * 뒤에만 lock을 생성하므로, 그 시점 자체가 곧 탑승 evidence다.
+   *
+   * user-tap(BoardingTrainList 직접 탭, `createLockFromTrain`)은 "미래 열차 선택"일 뿐 탑승
+   * evidence가 아니므로 이 필드를 stamp하지 않는다(undefined) — `hasConsumedOriginWait`가
+   * `initialEtaSeconds` 경과 여부로 별도 판정한다. boardingPrompt 응답 자동lock/환승 leg
+   * device auto-lock(`pickAutoTrainCodeFromArrivals`)은 fallback 후보(evidence 없는 코드)도
+   * 채택 가능해 이 게이트를 만족하지 않으므로 마찬가지로 undefined — 동일한 시간 경과 판정으로
+   * graceful하게 처리된다.
+   */
+  boardingEvidence?: boolean;
 }
 
 /** 자동 만료 안전 계수 — 예상 소요시간이 50% 초과되면 잘못된 Lock으로 보고 해제. */

--- a/src/shared/utils/__tests__/boardingWait.test.ts
+++ b/src/shared/utils/__tests__/boardingWait.test.ts
@@ -1,0 +1,53 @@
+import { hasConsumedOriginWait } from '../boardingWait';
+import type { BoardingLock } from '../../types/boardingLock';
+
+const baseLock: BoardingLock = {
+  destinationId: 'dest-1',
+  trainCode: 'T-1',
+  boardingStationId: 'station-1',
+  boardingLine: '2',
+  boardedAt: 1_700_000_000_000,
+  expectedDurationMs: 600_000,
+};
+
+describe('hasConsumedOriginWait', () => {
+  it('lock이 null이면 false를 반환한다', () => {
+    expect(hasConsumedOriginWait(null, 1_700_000_100_000)).toBe(false);
+  });
+
+  // #2290 P1-1 RCA: user-tap lock(BoardingTrainList 직접 탭)은 "미래 열차 선택"일 뿐 탑승
+  // evidence가 아니다. 생성 직후(initialEtaSeconds 미경과)에는 여전히 승강장 대기 중이므로 false여야
+  // 한다 — 기존 `Boolean(lock)`만으로 판정하던 버그가 여기서 true를 반환해 ETA를 과소표시했다.
+  it('user-tap lock(boardingEvidence 없음) 생성 직후에는 false를 반환한다(RCA 회귀)', () => {
+    const lock: BoardingLock = { ...baseLock, initialEtaSeconds: 420 }; // 7분 후 도착 예정 train을 탭
+    // now === boardedAt (생성 직후, 0초 경과) — 아직 대기 중.
+    expect(hasConsumedOriginWait(lock, lock.boardedAt)).toBe(false);
+  });
+
+  it('user-tap lock은 initialEtaSeconds 경과 전까지 false를 유지한다', () => {
+    const lock: BoardingLock = { ...baseLock, initialEtaSeconds: 420 };
+    expect(hasConsumedOriginWait(lock, lock.boardedAt + 419_000)).toBe(false);
+  });
+
+  it('user-tap lock은 initialEtaSeconds 경과 시점부터 true를 반환한다', () => {
+    const lock: BoardingLock = { ...baseLock, initialEtaSeconds: 420 };
+    expect(hasConsumedOriginWait(lock, lock.boardedAt + 420_000)).toBe(true);
+    expect(hasConsumedOriginWait(lock, lock.boardedAt + 500_000)).toBe(true);
+  });
+
+  it('initialEtaSeconds가 없으면(레거시/evidence 없는 자동 lock) 시간이 지나도 보수적으로 false를 반환한다', () => {
+    expect(hasConsumedOriginWait(baseLock, baseLock.boardedAt + 10 * 60_000)).toBe(false);
+  });
+
+  // device-side origin auto-lock(arvlCd 강 게이트 + consensus 통과)은 생성 시점 자체가 탑승
+  // evidence이므로 initialEtaSeconds 경과와 무관하게 즉시 true.
+  it('boardingEvidence=true인 lock은 생성 직후에도 즉시 true를 반환한다', () => {
+    const lock: BoardingLock = { ...baseLock, initialEtaSeconds: 420, boardingEvidence: true };
+    expect(hasConsumedOriginWait(lock, lock.boardedAt)).toBe(true);
+  });
+
+  it('boardingEvidence=true이고 initialEtaSeconds가 없어도 true를 반환한다', () => {
+    const lock: BoardingLock = { ...baseLock, boardingEvidence: true };
+    expect(hasConsumedOriginWait(lock, lock.boardedAt)).toBe(true);
+  });
+});

--- a/src/shared/utils/__tests__/stationRoute.test.ts
+++ b/src/shared/utils/__tests__/stationRoute.test.ts
@@ -438,6 +438,39 @@ describe('calculateETA', () => {
     expect(calculateETA(5, null)).toBe(5);
   });
 
+  // #2290: 탑승 중(in-trip)에는 출발 leg의 boarding 대기(nextTrainMinutes)를 이미 소진했으므로
+  // excludeOriginWait: true로 호출 시 원본 대기 성분을 제외하고 주행 시간만 반환해야 한다.
+  // evidence: 성수→뚝섬 1정거장 남음 + nextTrainMinutes=7일 때 9분(7+2)이 아닌 2분(주행만) 기대.
+  it('#2290 excludeOriginWait 옵션 시 출발 대기를 제외하고 주행 시간만 반환한다(DirectRoute)', () => {
+    const route: DirectRoute = makeDirectRoute(1, '2');
+    // 주행만: round(1*2) = 2분. 출발 대기 7분은 제외.
+    expect(calculateETA(7, route, { excludeOriginWait: true })).toBe(2);
+  });
+
+  it('#2290 excludeOriginWait: false(기본값)는 기존 동작과 동치다', () => {
+    const route: DirectRoute = makeDirectRoute(1, '2');
+    expect(calculateETA(7, route)).toBe(9);
+    expect(calculateETA(7, route, { excludeOriginWait: false })).toBe(9);
+  });
+
+  it('#2290 excludeOriginWait 시에도 환승 leg 대기는 유지한다(TransferRoute)', () => {
+    const route: TransferRoute = makeTransferRoute({
+      transferName: '교대(법원.검찰청)',
+      fromLine: '2',
+      toLine: '3',
+      stopsToTransfer: 1,
+      stopsFromTransfer: 5,
+    });
+    const t = getTransferSeconds('2', '3', '교대');
+    // 출발 대기 0(제외) + 운행 + 환승 leg 대기(3, 유지)
+    const expected = Math.round((1 + 5) * 2 + t / 60) + 3;
+    expect(calculateETA(2, route, { excludeOriginWait: true })).toBe(expected);
+  });
+
+  it('#2290 route가 null이고 excludeOriginWait이면 0을 반환한다', () => {
+    expect(calculateETA(5, null, { excludeOriginWait: true })).toBe(0);
+  });
+
   // #851 회귀: 용마산(7) → 건대입구 환승 → 성수(2) 실측 데이터 기반
   // 7호선 용마산→건대입구 320s(5.33min) + 환승 7|2|건대입구 64s(1.07min)
   // + 2호선 건대입구→성수 90s(1.5min) = 474s ≈ 7.9 → round 8min 운행.
@@ -492,6 +525,33 @@ describe('calculateStaticETA', () => {
 
   it('route가 null이면 null을 반환한다', () => {
     expect(calculateStaticETA(null)).toBeNull();
+  });
+
+  // #2290: 탑승 중에는 출발 leg의 boarding 대기(DEFAULT_WAIT_MINUTES fallback 포함)를 제외한다.
+  it('#2290 excludeOriginWait 옵션 시 출발 대기(fallback 3분)를 제외한다(DirectRoute)', () => {
+    const route: DirectRoute = makeDirectRoute(1, '2');
+    // 주행만: round(1*2) = 2분. 출발 대기 fallback 3분 제외.
+    expect(calculateStaticETA(route, { excludeOriginWait: true })).toBe(2);
+  });
+
+  it('#2290 excludeOriginWait 시에도 환승 leg 대기(fallback)는 유지한다(TransferRoute)', () => {
+    const route: TransferRoute = makeTransferRoute({
+      transferName: '교대(법원.검찰청)',
+      fromLine: '2',
+      toLine: '3',
+      stopsToTransfer: 1,
+      stopsFromTransfer: 5,
+    });
+    const t = getTransferSeconds('2', '3', '교대');
+    // 출발 대기 0(제외) + 환승 leg 대기(3, 유지) + 운행
+    const expected = 3 + Math.round((1 + 5) * 2 + t / 60);
+    expect(calculateStaticETA(route, { excludeOriginWait: true })).toBe(expected);
+  });
+
+  it('#2290 excludeOriginWait 미지정(기본값)은 기존 동작과 동치다', () => {
+    const route: DirectRoute = makeDirectRoute(5, '2');
+    expect(calculateStaticETA(route)).toBe(13);
+    expect(calculateStaticETA(route, { excludeOriginWait: false })).toBe(13);
   });
 });
 

--- a/src/shared/utils/boardingWait.ts
+++ b/src/shared/utils/boardingWait.ts
@@ -1,0 +1,27 @@
+import type { BoardingLock } from '../types/boardingLock';
+
+/**
+ * #2290 P1-1 — 출발 leg의 boarding 대기(다음 열차 대기)가 이미 소진됐는지 판정.
+ *
+ * RCA (PR #2295 리뷰): 원래 구현은 `Boolean(lock)`만으로 in-trip을 판정해 ETA에서 출발 대기를
+ * 제외했다. 하지만 user-tap lock(BoardingTrainList 직접 탭, `createLockFromTrain`)은 생성
+ * 시점에 "미래 열차를 선택"했을 뿐 실제 탑승 evidence가 없다 — 승강장에서 열차를 기다리는 중에도
+ * "이미 탑승"으로 오판해 ETA를 과소표시했다(알림/LA/화면 3곳 공통 회귀).
+ *
+ * 일반 조건 — "lock 존재 여부"가 아니라 "출발 대기를 실제로 소진했는가":
+ * - `lock.boardingEvidence === true` (device-side auto-lock: arvlCd ENTERING/ARRIVED/DEPARTED
+ *   강 게이트 + 4-signal consensus 통과) → 생성 시점 자체가 탑승 evidence이므로 즉시 소진.
+ * - 그 외(user-tap 등 "미래 열차 선택"만 있는 lock) → `initialEtaSeconds`(#897 탑승 시점 ETA
+ *   스냅샷) 경과 여부로 판정한다: `(now - boardedAt) >= initialEtaSeconds`.
+ * - `initialEtaSeconds` 부재(레거시 lock/evidence 없는 자동 lock 등) → 보수적으로 false
+ *   (대기 유지 — 과다표시가 과소표시보다 안전, ADR-014 첫 줄 정합).
+ *
+ * @param lock - 현재 활성 BoardingLock. null이면 lock 미활성 → false.
+ * @param now - 판정 시각(ms epoch). 호출자가 `Date.now()`를 주입(테스트에서 monkeypatch 가능).
+ */
+export function hasConsumedOriginWait(lock: BoardingLock | null, now: number): boolean {
+  if (!lock) return false;
+  if (lock.boardingEvidence) return true;
+  if (lock.initialEtaSeconds == null) return false;
+  return now - lock.boardedAt >= lock.initialEtaSeconds * 1000;
+}

--- a/src/shared/utils/stationRoute.ts
+++ b/src/shared/utils/stationRoute.ts
@@ -924,6 +924,13 @@ export interface StaticEtaOptions {
   timetableBoardableWaitSecondsByLeg?: ReadonlyArray<number | null>;
   /** freshness 계산용 현재 시각(ms). 미지정 시 Date.now() — 테스트에서 monkeypatch. */
   nowMs?: number;
+  /**
+   * #2290 — 탑승 중(in-trip: boardingLock 활성 / legAdvance stamp / trip 진행 evidence)에는
+   * 출발 leg의 boarding 대기(originWaitMinutes)를 이미 소진한 상태이므로 0으로 제외한다.
+   * 잔여 환승 leg의 대기(transferWaitMinutes)는 유지 — 아직 타지 않은 leg의 대기는 실재한다.
+   * 미지정 시 기존 동작(대기+주행 합산) 동치.
+   */
+  excludeOriginWait?: boolean;
 }
 
 // 한 페어(사용자 좌표 + 역 좌표)의 도보 시간(분). 누락 시 0.
@@ -1027,7 +1034,10 @@ export function calculateStaticETA(
   const walkingMinutes =
     calculateWalkingMinutes(options.currentLocation, options.originStation) +
     calculateWalkingMinutes(options.destinationStation, options.destination);
-  const originWaitMinutes = resolveWaitMinutes(options.arrivalAtOrigin, nowMs);
+  // #2290 — in-trip이면 출발 leg 대기는 이미 소진했으므로 0.
+  const originWaitMinutes = options.excludeOriginWait
+    ? 0
+    : resolveWaitMinutes(options.arrivalAtOrigin, nowMs);
   const transferWaitMinutes = resolveTransferWaitMinutes(
     options.arrivalsAtTransfers,
     options.timetableBoardableWaitSecondsByLeg,
@@ -1142,11 +1152,21 @@ export function routeSignature(route: Route): string {
  * 첫 열차 대기는 호출자가 실시간으로 측정해 `nextTrainMinutes`로 주입한다.
  * 환승 leg 대기는 환승역별 폴링 인프라가 없으므로 fallback만 사용 — 후속에서 동적화 시
  * `calculateStaticETA`의 `arrivalsAtTransfers`와 동일한 옵션 시그니처로 확장.
+ *
+ * #2290 — `options.excludeOriginWait: true`(in-trip: boardingLock 활성 / legAdvance stamp /
+ * trip 진행 evidence)면 `nextTrainMinutes`(출발 leg boarding 대기)를 0으로 제외하고 주행 +
+ * 잔여 환승 leg 대기만 반환한다. 이미 탑승 중이므로 "다음 열차를 기다렸다 탄다"는 가정이 틀렸던
+ * 회귀(evidence: 성수→뚝섬 1정거장 남음인데 9분 표시) 수정. 탑승 전(기본값)에는 기존 동작 유지.
  */
-export function calculateETA(nextTrainMinutes: number, route: Route): number {
-  if (!route) return nextTrainMinutes;
+export function calculateETA(
+  nextTrainMinutes: number,
+  route: Route,
+  options: { excludeOriginWait?: boolean } = {},
+): number {
+  const originWait = options.excludeOriginWait ? 0 : nextTrainMinutes;
+  if (!route) return originWait;
   const transferWait = getTransferCount(route) * DEFAULT_WAIT_MINUTES;
-  return nextTrainMinutes + getTravelMinutes(route) + transferWait;
+  return originWait + getTravelMinutes(route) + transferWait;
 }
 
 export function getNextStationOnLine(


### PR DESCRIPTION
Closes #2290

## 요약
탑승 중(in-trip)에도 표시 ETA가 "현재 역 다음 열차를 기다렸다 탄다"는 가정으로 `nextTrainMinutes`(또는 fallback 대기)를 계산에 합산해, "성수 → 뚝섬 · 1정거장 남음 · 약 9분" 같은 잘못된 표시가 발생했습니다(실제로는 이미 탑승 중이라 주행 시간(~2분)만 남음).

## 변경 사항
- `src/shared/utils/stationRoute.ts`
  - `calculateETA(nextTrainMinutes, route, options?)`에 `excludeOriginWait` 옵션 추가. `true`면 출발 leg 대기(`nextTrainMinutes`)를 0으로 제외하고 주행 + 잔여 환승 leg 대기만 반환. 미지정(기본값) 시 기존 동작과 동치.
  - `calculateStaticETA`의 `StaticEtaOptions`에도 동일한 `excludeOriginWait` 옵션 추가(출발 대기 fallback 3분도 제외). 환승 leg 대기(`transferWaitMinutes`)는 옵션과 무관하게 그대로 유지 — 아직 타지 않은 leg의 대기는 실재하기 때문.
- `src/screens/HomeScreen.tsx`
  - `isInTrip = Boolean(fusionBoardingLock) || legAdvanceLine !== null` — 기존 신호(boardingLock 활성 / legAdvance stamp #2278)만 재사용, 신규 자동 감지 경로 없음(#2154 준수).
  - `etaMinutes`/`staticEtaMinutes` 계산에 `excludeOriginWait: isInTrip` 전달.
- `src/features/alarm/utils/stationPipeline.ts`
  - 알림 `etaSuffix`(`updateStationNotification`에 넘기는 `eta`)도 동일 in-trip 신호(`lockForLineGuard` boardingLock + `useLegAdvanceStore.getState().nextLine`)로 `excludeOriginWait` 전달.
- 테스트: `stationRoute.test.ts`에 RED→GREEN 유닛 테스트 추가(DirectRoute/TransferRoute/null route), `stationPipeline.test.ts` 기존 호출 인자 검증 업데이트.

## 스펙 대비 이탈
없음. 탑승 전(대기 상태) 케이스는 `excludeOriginWait` 미전달 시 기존 동작과 완전 동치이며 회귀 테스트로 확인.

## 검증
- `npm test` — 437 suites / 9396 tests 전부 pass, coverage 100%(lines/functions/branches/statements)
- `npm run type-check` — pass
- `npm run lint:orphan` — No orphan exports detected

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (신규 export 없음, 기존 함수 시그니처 확장만).
2. **V/X dashboard** — 알림 `etaSuffix`(`stationNotification.ts` buildContent 경유) + HomeScreen `displayEta`(메인 화면 상단 ETA 텍스트) + LA `etaText`(동일 `eta` 값을 `updateStationNotification` 경유로 공유)에서 육안 확인 가능. DebugModal에서 route/boardingLock/legAdvance 상태 확인 가능.
3. **의존 PR** — N/A. #2287(legAdvance stamp)/#2288(hop time clamp)/#2289(tripOrigin)는 이미 origin/dev에 머지됨(본 브랜치가 그 위에서 분기).
4. **측정 plan** — 다음 실탑승 시 destination 알림/LA의 ETA 표시값을 실제 남은 소요와 비교(탑승 중 표시 ETA가 정거장 수 대비 과대하지 않은지). alarmLog/DebugModal fusion state로 boardingLock/legAdvance 활성 여부와 displayEta 값 교차 확인.
5. **Device verify** — 필요. 실탑승 1회로 lock 활성 + 1정거장 잔여 시나리오에서 표시 ETA가 주행시간 수준(~2분대)으로 나오는지 확인. 코드 자체는 type+unit으로 검증됨.

---

## 리뷰 반영: P1-1 (head `feb96106`)

**지적**: `isInTrip = Boolean(lock) || legAdvance`가 user-tap lock(BoardingTrainList 직접 탭 — GPS/arrivalCode 게이트 없이 생성, `createLockFromTrain` `useBoardingLockController.ts:311`)의 "승강장 대기 중" 상태를 "이미 탑승"으로 오판 → origin 대기를 잘못 제외해 ETA 과소표시(알림/LA/화면 3곳).

**수정**: "lock 존재"가 아니라 **"출발 leg 대기가 실제로 소진됐는가"**를 일반 조건으로 판정하는 공용 헬퍼로 교체.

- `src/shared/types/boardingLock.ts` — `BoardingLock`에 `boardingEvidence?: boolean` 필드 추가(최소 신규 필드). `useBoardingLockController.ts`의 origin auto-lock effect(문서상 `position-train` — arvlCd ENTERING/ARRIVED/DEPARTED 강 게이트 + 4-signal consensus 통과)만 생성 시 `true`로 stamp. user-tap/boardingPrompt 응답/환승 device auto-lock은 stamp하지 않음(undefined).
- `src/shared/utils/boardingWait.ts` — `hasConsumedOriginWait(lock, now)` 신설(shared, HomeScreen/stationPipeline 공용):
  1. `lock.boardingEvidence === true` → 생성 시점 자체가 탑승 evidence → 즉시 소진(`true`).
  2. 그 외 → `lock.initialEtaSeconds`(#897 탑승 시점 ETA 스냅샷)와 `boardedAt`으로 `(now - boardedAt) >= initialEtaSeconds * 1000`일 때만 `true`.
  3. `initialEtaSeconds` 없음(레거시/evidence 없는 자동 lock) → 보수적으로 `false`(대기 유지 — 과다표시가 과소표시보다 안전).
- `HomeScreen.tsx` / `stationPipeline.ts` — `isInTrip` 판정을 `Boolean(lock) || legAdvance` → `hasConsumedOriginWait(lock, Date.now()) || legAdvance`로 교체. legAdvance stamp(하차 응답=확정 evidence)는 그대로 유지.
- 테스트: `src/shared/utils/__tests__/boardingWait.test.ts` 신설. RED 시나리오("user-tap lock 생성 직후(initialEta 미경과) → 기존 `Boolean(lock)` 로직이면 true가 되던 것") → GREEN(`false` 확인) 포함, 경과 후 `true`, `boardingEvidence=true` 즉시 `true`, `initialEtaSeconds` 부재 시 항상 `false` 커버.
- 리뷰 (2) cold-start hydration 창(앱 재시작 직후 lock storage hydrate 전 수백ms `isInTrip=false`)은 **과다표시 방향**이라 안전 — `HomeScreen.tsx`/`stationPipeline.ts` 주석으로 P2 관찰만 명시, 별도 수정 없음.

**검증**: `npm test`(438 suites / 9403 tests, 전부 pass, coverage 100%) / `npm run type-check` pass / `npm run lint:orphan` — No orphan exports detected.

머지되지 않음(draft 유지) — 사용자 최종 결정.


---

## 리뷰 반영: P1 재검토 (head `93820a09`)

**지적**: `boardingEvidence: true`가 device-side position-train 자동 lock 1곳에만 stamp돼, 아래 3곳은 "이미 탑승/이동 중" evidence인데도 stamp도 `initialEtaSeconds`도 없어 `hasConsumedOriginWait`가 trip 내내 `false`로 고착(원래 P1-1 버그가 그 lock 타입들에서 지속):
1. `useBoardingLockController.ts` lockSuggestion backend hydrate (#1534 — arvlcd-confirmed evidence)
2. `useBoardingLockController.ts` `hydrateLockFromCandidate`의 `candidate.from === 'transfer-swap'` 분기
3. `backgroundLocationTask.ts` BG hydrateLock transfer-swap (동일 성격의 BG판)

**구조적 수정**(산발 stamp 금지 요구 반영): `useBoardingLockStore.createLock`의 시그니처를 `(lock: BoardingLockInput, evidence: boolean, source?) => Promise<void>`로 변경 — `boardingEvidence`를 lock payload 타입(`BoardingLockInput = Omit<BoardingLock, 'boardingEvidence'>`)에서 제외하고 별도 **필수** 인자로 승격했다. 이제 새 `createLock` 호출부가 추가될 때 evidence를 명시하지 않으면 컴파일이 실패한다(기존엔 lock 객체 안에 optional 필드로 산발 stamp — 빠뜨려도 컴파일 통과).

- `src/features/alarm/store/useBoardingLockStore.ts` — 시그니처 변경 + evidence를 단일 지점(`createLock` 본문)에서 `lock.boardingEvidence`로 합성.
- 호출부 7곳 전수 갱신 + evidence 의미 명시:
  - `lockSuggestion` hydrate(#1534) → `true` (backend가 이미 arvlcd-confirmed evidence로 합의).
  - origin auto-lock(#1640, arvlCd 강게이트+consensus) → `true` (기존 산발 stamp를 evidence 인자로 이동).
  - `hydrateLockFromCandidate` → `candidate.from === 'transfer-swap'`일 때만 `true`, 그 외(#915/#916 원거리 autoLock candidate)는 **`false`로 명시** — Gate 2가 motionStationary(원점 정적 대기)를 확인해야 통과하는 경로라 "아직 미탑승"이 정상 케이스이므로 evidence로 뭉뚱그리지 않는다(리뷰 지적 반영).
  - BG `hydrateLock` transfer-swap(`backgroundLocationTask.ts`) → `true` (가드가 이미 `'transfer-swap'`만 통과시킴).
  - `createLockFromTrain`(user-tap) → `false`.
  - `useBoardingPromptResponder.tryAutoLock`(boardingPrompt 응답, fallback 후보 가능) → `false`.
  - `useTransferTrainList.createTransferLock`(사용자 탭 + D5 dormant 공용) → `false`.
- 테스트: 3개 회귀 지점 각각에 RED→GREEN 재현 assertion 추가(evidence=true 확인) + `hydrateLockFromCandidate` 비-transfer-swap 분기는 evidence=false 명시 검증. `useBoardingLockStore.test.ts`는 필수 인자화로 기존 호출부 전수 갱신 + 기대값에 `boardingEvidence` 합성.
- P3 관찰(리뷰 (4)): `hasConsumedOriginWait`는 렌더 시점 `Date.now()`로 평가되므로 화면 갱신은 다음 렌더 계기(최대 ~30s)까지 지연될 수 있다 — 방향은 과다표시(안전)라 `HomeScreen.tsx` 주석으로만 명시, 코드 변경 없음.

**검증**: 변경 파일 관련 테스트 8개 스위트(`useBoardingLockController`/`useBoardingPromptResponder`/`useBoardingLockStore`/`backgroundLocationTask`/`useTransferTrainList`/`boardingWait`/`replay_20260807_boarding`/`tripBoundCleanupsAudit`) 353 tests 전부 pass, `npx tsc --noEmit` pass, `npm run lint:orphan` — No orphan exports detected. **전체 스위트(`npm test`, coverage 100% 포함)는 stall 방지를 위해 이번 세션에서 미실행 — 메인 세션이 별도 수행.**

머지되지 않음(draft 유지) — 사용자 최종 결정.
