### PR TITLE
fix(#2278): 리뷰 P1 반영 후속 — lockSuggestion stale 가드 + legAdvance stamp 영속화

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -6,6 +6,7 @@ import {
   type UseBoardingLockControllerInputs,
 } from '../useBoardingLockController';
 import { useBoardingLockStore } from '../../store/useBoardingLockStore';
+import { useLegAdvanceStore } from '../../store/useLegAdvanceStore';
 import type { ArrivalInfo, StationArrival } from '../../../../shared/types/arrival';
 import type { Station } from '../../../../shared/types/station';
 import type { BoardingLock } from '../../../../shared/types/boardingLock';
@@ -117,6 +118,8 @@ describe('useBoardingLockController', () => {
     // Default: lookup miss — controller falls back to currentStation.id (이전 동작 유지).
     mockFindStationByNameAndLine.mockReturnValue(null);
     useBoardingLockStore.setState({ lock: null });
+    // #2278 (PR #2287 리뷰 P1-1) — 매 테스트마다 leg-advance stamp 리셋 (zustand 모듈 싱글톤 leak 차단).
+    useLegAdvanceStore.setState({ nextLine: null, stampedAt: null });
   });
 
   it('마운트 시 loadLock 호출 → storage에서 복원', async () => {
@@ -1148,6 +1151,67 @@ describe('useBoardingLockController', () => {
       renderHook(() => useBoardingLockController(defaultInputs));
       await tickAndSettleCycle();
       expect(createLockMock).not.toHaveBeenCalled();
+    });
+
+    // #2278 (PR #2287 리뷰 P1-1) — 사용자 명시 하차 stamp(legAdvance)가 살아있는 동안 stale/
+    // 불일치 lockSuggestion으로 lock을 재-hydrate해 그 stamp를 무력화하지 않도록 하는 가드.
+    // 원 버그(#2278 RCA): lock > legAdvance 우선순위 chain에서 lockSuggestion 자동 hydrate가
+    // stale mirror(예: 이전 leg '7')로 lock을 재생성하면 stamp가 lock에 덮여 다시 fromLine으로
+    // 되돌아간다.
+    describe('#2278 P1-1 — legAdvance stamp staleness 가드', () => {
+      it('lockSuggestion.decidedAt이 stamp.stampedAt보다 이전(stale)이면 skip', async () => {
+        // SUGGESTION.decidedAt=1_700_000_000_000. stampedAt을 그보다 나중으로 설정 — 사용자가
+        // 하차 응답을 한 뒤에 backend가 그 이전 시점 기준으로 decide한 stale suggestion.
+        useLegAdvanceStore.setState({ nextLine: '2', stampedAt: SUGGESTION.decidedAt + 1_000 });
+        readSpy.mockResolvedValue(MIRROR);
+        const createLockMock = setupRejectScenario();
+        await tickAndSettleCycle();
+        expect(createLockMock).not.toHaveBeenCalled();
+      });
+
+      it('lockSuggestion.lineId가 stamp.nextLine과 다르면(불일치) stamp가 살아있는 동안 skip', async () => {
+        // 7→2 환승 route — 두 line 모두 allowedLines를 통과하므로(기존 #1449 가드와 독립적으로)
+        // P1-1 disagreement 가드 자체를 isolate해서 검증한다. stampedAt은 decidedAt보다
+        // 이전(staleness 가드는 통과) — 그러나 line이 stamp('2')와 다르므로(suggestion='7') skip.
+        const transferRoute = {
+          type: 'transfer' as const,
+          transferName: '건대입구',
+          fromLine: '7' as const,
+          toLine: '2' as const,
+          stopsToTransfer: 0,
+          stopsFromTransfer: 5,
+          secondsToTransfer: 0,
+          secondsFromTransfer: 600,
+        };
+        useLegAdvanceStore.setState({ nextLine: '2', stampedAt: SUGGESTION.decidedAt - 1_000 });
+        readSpy.mockResolvedValue({
+          ...MIRROR,
+          lockSuggestion: { ...SUGGESTION, lineId: '7' },
+        });
+        const createLockMock = setupRejectScenario({ ...defaultInputs, route: transferRoute });
+        await tickAndSettleCycle();
+        expect(createLockMock).not.toHaveBeenCalled();
+      });
+
+      it('lockSuggestion이 stamp와 일치 + fresh(decidedAt >= stampedAt)면 정상 채택 (과잉 차단 아님)', async () => {
+        useLegAdvanceStore.setState({ nextLine: '2', stampedAt: SUGGESTION.decidedAt - 1_000 });
+        readSpy.mockResolvedValue(MIRROR); // lineId='2' — stamp.nextLine과 일치.
+        const createLockMock = jest.fn().mockResolvedValue(undefined);
+        useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+        renderHook(() => useBoardingLockController(defaultInputs));
+        await tickAndSettleCycle();
+        expect(createLockMock).toHaveBeenCalled();
+      });
+
+      it('legAdvance stamp가 없으면(nextLine=null) 기존 동작 그대로 (가드 미개입)', async () => {
+        useLegAdvanceStore.setState({ nextLine: null, stampedAt: null });
+        readSpy.mockResolvedValue(MIRROR);
+        const createLockMock = jest.fn().mockResolvedValue(undefined);
+        useBoardingLockStore.setState({ lock: null, createLock: createLockMock });
+        renderHook(() => useBoardingLockController(defaultInputs));
+        await tickAndSettleCycle();
+        expect(createLockMock).toHaveBeenCalled();
+      });
     });
 
     it('lockSuggestion lineId가 trip route 허용 line이 아니면 reject', async () => {

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -16,6 +16,7 @@ import { resolveTripDirection } from '../../route/utils/tripDirection';
 import { getApproachLineWithConfirmation } from '../../route/utils/approachLine';
 import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import { allowedLinesFromRoute } from '../../../shared/utils/stationRoute';
+import { isValidLineNumber } from '../../../shared/constants/lineApiNames';
 import { STATIC_SPEED_THRESHOLD_MPS } from '../../nearest-station/utils/movementGate';
 import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival';
 import type { Route } from '../../../shared/utils/stationRoute';
@@ -110,12 +111,13 @@ export interface UseBoardingLockControllerResult {
 /**
  * #915 — backend candidate.line(string)이 LineNumber valid 값인지 narrow.
  * 미정합이면 hydrate skip — 호출자는 graceful로 lock 없는 상태 유지.
+ *
+ * #2278 (PR #2287 리뷰 P2-1) — 하드코딩 배열(구 `VALID_LINES`) 대신 shared
+ * `isValidLineNumber`(LINE_API_NAMES 데이터 주도)로 위임. `useBoardingPromptResponder`의
+ * 동등 검증과 단일 SSoT로 통합 — 신규 노선 추가 시 두 곳을 따로 갱신할 필요가 없다.
  */
-const VALID_LINES: ReadonlyArray<LineNumber> = [
-  '1', '2', '3', '4', '5', '6', '7', '8', '9', 'airport', 'gyeongui', 'bundang', 'sinbundang',
-];
 function asLineNumber(raw: string): LineNumber | null {
-  return (VALID_LINES as ReadonlyArray<string>).includes(raw) ? (raw as LineNumber) : null;
+  return isValidLineNumber(raw) ? raw : null;
 }
 
 /**
@@ -161,6 +163,13 @@ export function useBoardingLockController({
   // null이면 기존 9-AND gate fallback (`hydrateLockFromCandidate`)이 그대로 동작.
   const { suggestion: lockSuggestion } = useLockSuggestion();
 
+  // #2278 — 사용자 하차 응답 stamp. lock 해제 직후 route 진행도가 아직 못 따라온 gap을
+  // 로컬에서 즉시 메운다 (getApproachLine 우선순위: lock > legAdvance > route > fallback).
+  // #2278 (PR #2287 리뷰 P1-1) — 아래 lockSuggestion 자동 hydrate effect가 이 stamp를
+  // 무력화하지 않도록 하는 staleness 가드에도 재사용.
+  const legAdvanceLine = useLegAdvanceStore((s) => s.nextLine);
+  const legAdvanceStampedAt = useLegAdvanceStore((s) => s.stampedAt);
+
   // 마운트 시 storage hydrate.
   useEffect(() => {
     void loadLock();
@@ -205,11 +214,24 @@ export function useBoardingLockController({
   //     매칭되지 않으면 graceful skip (다음 cycle 재시도). lockSuggestion.stationId는 backend가
   //     waypoint 기반으로 산출했으므로 정상 케이스 대부분 매칭.
   //   - destinationId 없으면 free-trip sentinel으로 hydrate.
+  //   - #2278 (PR #2287 리뷰 P1-1) — legAdvance stamp(사용자 명시 하차 응답)가 살아있는 동안
+  //     stale/불일치 lockSuggestion으로 재-hydrate해 그 stamp를 무력화하지 않는다:
+  //       (a) suggestion.decidedAt < stamp.stampedAt — 사용자가 하차를 확인한 시점 *이전에*
+  //           backend가 결정한 stale suggestion. 그 사이의 최신 상황을 반영하지 못했으므로 신뢰 X.
+  //       (b) suggestion.boardingLine !== stamp.nextLine — 사용자가 확인한 다음 leg와 다른 노선을
+  //           제안 — stale mirror(이전 leg) 재생성 회귀(#2278 RCA)를 여기서 직접 차단.
+  //     stamp가 없으면(nextLine=null) 가드 미개입 — 기존 동작 그대로.
   useEffect(() => {
     if (!lockSuggestion) return;
     if (lock) return;
     const boardingLine = asLineNumber(lockSuggestion.lineId);
     if (!boardingLine) return;
+    if (legAdvanceLine !== null) {
+      const isStale =
+        legAdvanceStampedAt !== null && lockSuggestion.decidedAt < legAdvanceStampedAt;
+      const disagrees = boardingLine !== legAdvanceLine;
+      if (isStale || disagrees) return;
+    }
     const allowed = allowedLinesFromRoute(route);
     if (allowed && !allowed.has(boardingLine)) return;
     // boardingStationId 산출: lockSuggestion.stationId가 stations.json id이면 그대로,
@@ -251,6 +273,8 @@ export function useBoardingLockController({
     destinationId,
     expectedDurationMinutes,
     createLock,
+    legAdvanceLine,
+    legAdvanceStampedAt,
   ]);
 
   const direction = useMemo(() => {
@@ -269,9 +293,6 @@ export function useBoardingLockController({
   // `confirmed=false`(route/lock 후보 없음, fusion `currentStation.line` 임의값(#797))이면
   // 어떤 candidate 필터에도 이 line을 쓰지 않는다(누락 방지) — origin auto-lock 전용
   // `originAutoLockArrivals`(하단)에서만 소비한다.
-  // #2278 — 사용자 하차 응답 stamp. lock 해제 직후 route 진행도가 아직 못 따라온 gap을
-  // 로컬에서 즉시 메운다 (getApproachLine 우선순위: lock > legAdvance > route > fallback).
-  const legAdvanceLine = useLegAdvanceStore((s) => s.nextLine);
   const { line: approachLine, confirmed: approachLineConfirmed } = useMemo(
     () => getApproachLineWithConfirmation(route, lock, currentStation, legAdvanceLine),
     [route, lock, currentStation, legAdvanceLine],

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -29,8 +29,7 @@ import { dismissBoardingPrompt } from '../../nearest-station/api/positionUpload'
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import { useUserIntentStore } from '../store/useUserIntentStore';
 import { useLegAdvanceStore } from '../store/useLegAdvanceStore';
-import { LINE_API_NAMES } from '../../../shared/constants/lineApiNames';
-import type { LineNumber } from '../../../shared/types/station';
+import { isValidLineNumber } from '../../../shared/constants/lineApiNames';
 import { pickAutoTrainCodeFromArrivals } from '../utils/boardingPromptAutoLock';
 import {
   logBoardingPromptAutoLock,
@@ -272,8 +271,10 @@ async function handleHopEndResponse(
     // getApproachLine이 route의 stopsToTransfer(backend SSoT 왕복 지연 가능)에 의존하지 않고
     // 즉시 다음 leg 노선을 반환하도록 로컬에 stamp한다. nextLine이 유효한 LineNumber가 아니면
     // (구버전 backend 등 payload 누락) 기존 동작(route/lock fallback) 그대로 유지 — skip.
+    // #2278 (PR #2287 리뷰 P1-2) — trip-scoped storage 영속화도 겸하므로 releaseLock과 동일하게
+    // await(store 내부에서 실패를 swallow하므로 이 지점에서 throw되지 않는다).
     if (isValidLineNumber(payload.nextLine)) {
-      useLegAdvanceStore.getState().stampLegAdvance(payload.nextLine);
+      await useLegAdvanceStore.getState().stampLegAdvance(payload.nextLine);
     }
     if (
       actionIdentifier === Notifications.DEFAULT_ACTION_IDENTIFIER &&
@@ -288,14 +289,6 @@ async function handleHopEndResponse(
     line: payload.line,
   });
   await dismissBoardingPrompt(payload.tripToken);
-}
-
-/**
- * #2278 — payload.nextLine(string | undefined)이 유효한 LineNumber인지 narrow.
- * `LINE_API_NAMES`(shared, 노선 추가 시 이미 갱신되는 SSoT) key 집합으로 데이터 주도 검증한다.
- */
-function isValidLineNumber(value: string | undefined): value is LineNumber {
-  return value !== undefined && Object.prototype.hasOwnProperty.call(LINE_API_NAMES, value);
 }
 
 async function tryAutoLock(

--- a/src/features/alarm/store/__tests__/useLegAdvanceStore.test.ts
+++ b/src/features/alarm/store/__tests__/useLegAdvanceStore.test.ts
@@ -1,28 +1,103 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useLegAdvanceStore } from '../useLegAdvanceStore';
+import { LEG_ADVANCE_KEY } from '../../../../shared/constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
 
 describe('useLegAdvanceStore (#2278)', () => {
   beforeEach(() => {
-    useLegAdvanceStore.setState({ nextLine: null });
+    jest.clearAllMocks();
+    useLegAdvanceStore.setState({ nextLine: null, stampedAt: null });
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+    (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
   });
 
-  it('초기 상태는 nextLine=null', () => {
+  it('초기 상태는 nextLine=null, stampedAt=null', () => {
     expect(useLegAdvanceStore.getState().nextLine).toBeNull();
+    expect(useLegAdvanceStore.getState().stampedAt).toBeNull();
   });
 
-  it('stampLegAdvance — nextLine을 세팅한다', () => {
-    useLegAdvanceStore.getState().stampLegAdvance('2');
-    expect(useLegAdvanceStore.getState().nextLine).toBe('2');
+  describe('stampLegAdvance', () => {
+    it('nextLine + stampedAt(now)을 세팅하고 storage에 영속화한다', async () => {
+      const before = Date.now();
+      await useLegAdvanceStore.getState().stampLegAdvance('2');
+      const after = Date.now();
+
+      const { nextLine, stampedAt } = useLegAdvanceStore.getState();
+      expect(nextLine).toBe('2');
+      expect(stampedAt).not.toBeNull();
+      expect(stampedAt as number).toBeGreaterThanOrEqual(before);
+      expect(stampedAt as number).toBeLessThanOrEqual(after);
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        LEG_ADVANCE_KEY,
+        JSON.stringify({ nextLine: '2', stampedAt }),
+      );
+    });
+
+    it('storage write 실패해도 throw 없이 graceful (memory는 반영 유지)', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('disk full'));
+      await expect(useLegAdvanceStore.getState().stampLegAdvance('7')).resolves.toBeUndefined();
+      expect(useLegAdvanceStore.getState().nextLine).toBe('7');
+    });
   });
 
-  it('clearLegAdvance — nextLine을 null로 되돌린다', () => {
-    useLegAdvanceStore.getState().stampLegAdvance('2');
-    useLegAdvanceStore.getState().clearLegAdvance();
-    expect(useLegAdvanceStore.getState().nextLine).toBeNull();
+  describe('clearLegAdvance', () => {
+    it('nextLine/stampedAt을 null로 되돌리고 storage를 제거한다', async () => {
+      await useLegAdvanceStore.getState().stampLegAdvance('2');
+      await useLegAdvanceStore.getState().clearLegAdvance();
+
+      expect(useLegAdvanceStore.getState().nextLine).toBeNull();
+      expect(useLegAdvanceStore.getState().stampedAt).toBeNull();
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(LEG_ADVANCE_KEY);
+    });
+
+    it('storage 삭제 실패해도 throw 없이 graceful', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('disk error'));
+      await expect(useLegAdvanceStore.getState().clearLegAdvance()).resolves.toBeUndefined();
+      expect(useLegAdvanceStore.getState().nextLine).toBeNull();
+    });
   });
 
-  it('재-stamp — 이전 값을 덮어쓴다 (다음 leg로 갱신)', () => {
-    useLegAdvanceStore.getState().stampLegAdvance('2');
-    useLegAdvanceStore.getState().stampLegAdvance('8');
+  // #2278 (PR #2287 리뷰 P1-2) — 재기동 후 stamp 복원. 지하에서 앱이 kill되면 in-memory
+  // stamp(nextLine)가 사라진다 — loadLegAdvance가 storage에서 복원하지 못하면 원 버그
+  // (releaseLock 직후 route.stopsToTransfer frozen → fromLine 고착)가 그대로 재현된다.
+  describe('loadLegAdvance (cold-start hydrate, #2278 RCA 가설 1 재기동 변형 재현)', () => {
+    it('storage에 유효한 stamp가 있으면 재기동 후에도 memory state로 복원된다', async () => {
+      // "재기동" 시뮬레이션: 이전 세션이 stampLegAdvance로 storage에 남겨둔 값을 storage에서만
+      // 관찰 가능한 상태로 두고(in-memory는 모듈 재로드로 초기화된 것과 동일하게 beforeEach에서
+      // 이미 null), loadLegAdvance가 storage를 읽어 memory를 복원하는지 검증한다.
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+        JSON.stringify({ nextLine: '2', stampedAt: 1_700_000_000_000 }),
+      );
+
+      await useLegAdvanceStore.getState().loadLegAdvance();
+
+      expect(useLegAdvanceStore.getState().nextLine).toBe('2');
+      expect(useLegAdvanceStore.getState().stampedAt).toBe(1_700_000_000_000);
+    });
+
+    it('storage에 stamp가 없으면 null 유지', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      await useLegAdvanceStore.getState().loadLegAdvance();
+      expect(useLegAdvanceStore.getState().nextLine).toBeNull();
+      expect(useLegAdvanceStore.getState().stampedAt).toBeNull();
+    });
+
+    it('storage read 실패해도 throw 없이 graceful (null 유지)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('disk error'));
+      await expect(useLegAdvanceStore.getState().loadLegAdvance()).resolves.toBeUndefined();
+      expect(useLegAdvanceStore.getState().nextLine).toBeNull();
+    });
+  });
+
+  it('재-stamp — 이전 값을 덮어쓴다 (다음 leg로 갱신)', async () => {
+    await useLegAdvanceStore.getState().stampLegAdvance('2');
+    await useLegAdvanceStore.getState().stampLegAdvance('8');
     expect(useLegAdvanceStore.getState().nextLine).toBe('8');
   });
 });

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -231,9 +231,13 @@ async function clearTripBoundStoreMemory(): Promise<void> {
     useAlarmEventStore.setState({ dismissSilence: null });
   }
   // #2278 — leg-advance stamp도 trip 경계에서 클리어. 이전 trip의 hop-end 확인이 새 trip의
-  // getApproachLine 우선순위를 오염시키지 않도록 한다 (in-memory only, 별도 storage 없음).
+  // getApproachLine 우선순위를 오염시키지 않도록 한다. #2278 (PR #2287 리뷰 P1-2) — 이 stamp는
+  // 이제 trip-scoped storage(LEG_ADVANCE_KEY)로 영속화되므로, boardingLock과 동일하게 store의
+  // `clearLegAdvance()` 액션을 경유해 memory + storage 동시 제거한다(직접 setState로 memory만
+  // 비우면 storage에 stale 값이 남아 다음 launch reconciliation에서 loadLegAdvance가 이전
+  // trip의 stamp를 복원하는 회귀가 생긴다).
   if (useLegAdvanceStore.getState().nextLine !== null) {
-    useLegAdvanceStore.setState({ nextLine: null });
+    await useLegAdvanceStore.getState().clearLegAdvance();
   }
   return Promise.resolve();
 }

--- a/src/features/alarm/store/useLegAdvanceStore.ts
+++ b/src/features/alarm/store/useLegAdvanceStore.ts
@@ -1,5 +1,10 @@
 import { create } from 'zustand';
 import type { LineNumber } from '../../../shared/types/station';
+import {
+  clearLegAdvance as clearLegAdvanceStorage,
+  getLegAdvance,
+  setLegAdvance,
+} from '../utils/legAdvanceStorage';
 
 /**
  * #2278 — 환승역 하차 응답/버튼 leg-advance stamp SSoT.
@@ -15,24 +20,53 @@ import type { LineNumber } from '../../../shared/types/station';
  *
  * lifecycle:
  *  - stamp: `useBoardingPromptResponder.handleHopEndResponse`가 hop-end BOARDED/$default
- *    응답에서 payload.nextLine이 유효한 LineNumber일 때 호출.
+ *    응답에서 payload.nextLine이 유효한 LineNumber일 때 호출. memory + AsyncStorage 동시 반영.
+ *  - hydrate: `useStateRehydration`(cold start / FG 복귀 공통 진입점)이 `loadLegAdvance`를
+ *    호출해 storage → memory 재수화.
  *  - clear: `tripBoundCleanups.clearTripBoundStoreMemory`가 trip 종료 4개 진입점 공통 경로에서
- *    호출 — 이전 trip의 stamp가 새 trip에 leak되는 것을 방지.
- *  - 의도적으로 AsyncStorage 영속화하지 않는다 — 이 stamp는 backend SSoT가 따라올 때까지의
- *    임시 bridge이며, cold start 시에는 route/lock 기반 기존 우선순위로 자연 복귀해도 안전하다
- *    (앱 재시작 시점엔 GPS/route가 다시 fresh하게 계산되므로).
+ *    호출 — 이전 trip의 stamp가 새 trip에 leak되는 것을 방지 (memory + storage 모두 제거).
+ *
+ * #2278 (PR #2287 리뷰 P1-2) — 최초 구현은 AsyncStorage 영속화 없이 in-memory only였다.
+ * "cold start 시 GPS/route가 fresh 재계산되므로 안전"이라는 전제는 지하에서는 거짓이다 —
+ * 지하는 정확히 이 stamp가 메우려는 gap(backend SSoT 왕복 실패)이 발생하는 환경이고, 그 상태에서
+ * 앱이 kill되면 stamp만 사라지고 route.stopsToTransfer는 여전히 frozen이라 원 버그(#2278 가설 1)가
+ * 재기동 후에도 재현된다. 따라서 stamp는 trip-scoped로 storage에 영속화하고, `stampedAt`을 함께
+ * 저장해 `useBoardingLockController`의 stale-suggestion 가드(P1-1)에도 재사용한다.
  */
 export interface LegAdvanceState {
   /** 사용자가 마지막으로 확인한 다음 leg 노선. 미확인/이미 소비 완료 시 null. */
   nextLine: LineNumber | null;
-  /** 사용자 명시 하차 응답/버튼 시점에 다음 leg 노선을 stamp한다. */
-  stampLegAdvance: (line: LineNumber) => void;
-  /** trip 종료 등으로 stamp를 무효화한다. */
-  clearLegAdvance: () => void;
+  /**
+   * #2278 (PR #2287 리뷰 P1-1) — stamp 시각(epoch ms). `useBoardingLockController`의
+   * lockSuggestion 자동 hydrate effect가 이 stamp보다 이전에 backend가 결정한(stale)
+   * suggestion으로 lock을 재생성해 stamp를 무력화하지 않도록 하는 staleness 가드에 사용.
+   */
+  stampedAt: number | null;
+  /** 사용자 명시 하차 응답/버튼 시점에 다음 leg 노선을 stamp한다 (memory + storage 동시 반영). */
+  stampLegAdvance: (line: LineNumber) => Promise<void>;
+  /** trip 종료 등으로 stamp를 무효화한다 (memory + storage 동시 반영). */
+  clearLegAdvance: () => Promise<void>;
+  /** cold start / FG 복귀 시 storage에서 재수화 (`useStateRehydration` 공통 진입점). */
+  loadLegAdvance: () => Promise<void>;
 }
 
 export const useLegAdvanceStore = create<LegAdvanceState>((set) => ({
   nextLine: null,
-  stampLegAdvance: (line: LineNumber) => set({ nextLine: line }),
-  clearLegAdvance: () => set({ nextLine: null }),
+  stampedAt: null,
+
+  stampLegAdvance: async (line: LineNumber) => {
+    const stampedAt = Date.now();
+    set({ nextLine: line, stampedAt });
+    await setLegAdvance({ nextLine: line, stampedAt });
+  },
+
+  clearLegAdvance: async () => {
+    set({ nextLine: null, stampedAt: null });
+    await clearLegAdvanceStorage();
+  },
+
+  loadLegAdvance: async () => {
+    const stored = await getLegAdvance();
+    set({ nextLine: stored?.nextLine ?? null, stampedAt: stored?.stampedAt ?? null });
+  },
 }));

--- a/src/features/alarm/utils/__tests__/legAdvanceStorage.test.ts
+++ b/src/features/alarm/utils/__tests__/legAdvanceStorage.test.ts
@@ -1,0 +1,88 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  clearLegAdvance,
+  getLegAdvance,
+  setLegAdvance,
+} from '../legAdvanceStorage';
+import { LEG_ADVANCE_KEY } from '../../../../shared/constants/storageKeys';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+const sample = { nextLine: '2' as const, stampedAt: 1_700_000_000_000 };
+
+describe('legAdvanceStorage (#2278 P1-2)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getLegAdvance', () => {
+    it('AsyncStorage가 null이면 null 반환', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      expect(await getLegAdvance()).toBeNull();
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith(LEG_ADVANCE_KEY);
+    });
+
+    it('유효한 JSON을 그대로 반환', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(sample));
+      expect(await getLegAdvance()).toEqual(sample);
+    });
+
+    it('파싱 실패 시 null', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('not-json');
+      expect(await getLegAdvance()).toBeNull();
+    });
+
+    it('nextLine이 유효하지 않은 LineNumber면 null', async () => {
+      const broken = { nextLine: 'K', stampedAt: 1 };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(broken));
+      expect(await getLegAdvance()).toBeNull();
+    });
+
+    it('nextLine 자체가 누락(undefined)이면 null', async () => {
+      const broken = { stampedAt: 1 };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(broken));
+      expect(await getLegAdvance()).toBeNull();
+    });
+
+    it('stampedAt 누락/타입 오염 시 null', async () => {
+      const broken = { nextLine: '2' };
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(broken));
+      expect(await getLegAdvance()).toBeNull();
+    });
+
+    it('AsyncStorage.getItem reject 시 null', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      expect(await getLegAdvance()).toBeNull();
+    });
+  });
+
+  describe('setLegAdvance', () => {
+    it('JSON.stringify해 setItem 호출', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockResolvedValueOnce(undefined);
+      await setLegAdvance(sample);
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(LEG_ADVANCE_KEY, JSON.stringify(sample));
+    });
+
+    it('setItem reject해도 throw 없이 graceful', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      await expect(setLegAdvance(sample)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('clearLegAdvance', () => {
+    it('removeItem 호출', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockResolvedValueOnce(undefined);
+      await clearLegAdvance();
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(LEG_ADVANCE_KEY);
+    });
+
+    it('removeItem reject해도 throw 없이 graceful', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+      await expect(clearLegAdvance()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/features/alarm/utils/legAdvanceStorage.ts
+++ b/src/features/alarm/utils/legAdvanceStorage.ts
@@ -1,0 +1,52 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { LEG_ADVANCE_KEY } from '../../../shared/constants/storageKeys';
+import { isValidLineNumber } from '../../../shared/constants/lineApiNames';
+import type { LineNumber } from '../../../shared/types/station';
+
+/**
+ * #2278 (PR #2287 리뷰 P1-2) — leg-advance stamp의 trip-scoped 영속화 상태.
+ * `useLegAdvanceStore`가 이 storage와 in-memory state를 동기 유지한다.
+ */
+export interface LegAdvanceStorageState {
+  nextLine: LineNumber;
+  stampedAt: number;
+}
+
+/**
+ * FG/BG/cold-start 어디서든 동일하게 read 가능한 storage SSOT.
+ * parse 실패/키 부재/유효하지 않은 line 시 null — stamp 없음(또는 이미 clear됨)을 의미.
+ */
+export async function getLegAdvance(): Promise<LegAdvanceStorageState | null> {
+  try {
+    const raw = await AsyncStorage.getItem(LEG_ADVANCE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<LegAdvanceStorageState> | null;
+    if (
+      parsed &&
+      isValidLineNumber(parsed.nextLine ?? null) &&
+      typeof parsed.stampedAt === 'number'
+    ) {
+      return { nextLine: parsed.nextLine, stampedAt: parsed.stampedAt };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function setLegAdvance(state: LegAdvanceStorageState): Promise<void> {
+  try {
+    await AsyncStorage.setItem(LEG_ADVANCE_KEY, JSON.stringify(state));
+  } catch {
+    // storage 실패는 silent — in-memory stamp는 이미 반영됨. 다음 cold start는 hydrate 실패로
+    // route/lock fallback만 적용(기존 우선순위) — 안전한 degrade.
+  }
+}
+
+export async function clearLegAdvance(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(LEG_ADVANCE_KEY);
+  } catch {
+    // storage 실패는 silent — stale entry는 다음 trip 종료 cleanup에서 재시도.
+  }
+}

--- a/src/features/alarm/utils/legAdvanceStorage.ts
+++ b/src/features/alarm/utils/legAdvanceStorage.ts
@@ -21,12 +21,9 @@ export async function getLegAdvance(): Promise<LegAdvanceStorageState | null> {
     const raw = await AsyncStorage.getItem(LEG_ADVANCE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Partial<LegAdvanceStorageState> | null;
-    if (
-      parsed &&
-      isValidLineNumber(parsed.nextLine ?? null) &&
-      typeof parsed.stampedAt === 'number'
-    ) {
-      return { nextLine: parsed.nextLine, stampedAt: parsed.stampedAt };
+    const nextLine = parsed?.nextLine ?? null;
+    if (parsed && isValidLineNumber(nextLine) && typeof parsed.stampedAt === 'number') {
+      return { nextLine, stampedAt: parsed.stampedAt };
     }
     return null;
   } catch {

--- a/src/shared/constants/__tests__/lineApiNames.test.ts
+++ b/src/shared/constants/__tests__/lineApiNames.test.ts
@@ -1,4 +1,10 @@
-import { LINE_API_NAMES, getLineApiName, subwayIdToLine, lineToSubwayId } from '../lineApiNames';
+import {
+  LINE_API_NAMES,
+  getLineApiName,
+  subwayIdToLine,
+  lineToSubwayId,
+  isValidLineNumber,
+} from '../lineApiNames';
 
 describe('lineApiNames', () => {
   it('1~9호선 매핑 + 특수 노선', () => {
@@ -72,6 +78,28 @@ describe('lineApiNames', () => {
       for (const key of Object.keys(LINE_API_NAMES)) {
         expect(mappedLines.has(key)).toBe(true);
       }
+    });
+  });
+
+  // #2278 (PR #2287 리뷰 P2-1) — LineNumber 검증 단일 SSoT. 이전엔 responder(isValidLineNumber)와
+  // controller(VALID_LINES 하드코딩 배열 + asLineNumber)가 각자 중복 정의했다. LINE_API_NAMES
+  // key 집합으로 데이터 주도 검증해 신규 노선 추가 시 자동 반영되도록 통합.
+  describe('isValidLineNumber', () => {
+    it('LINE_API_NAMES에 존재하는 값은 true (모든 LineNumber)', () => {
+      for (const key of Object.keys(LINE_API_NAMES)) {
+        expect(isValidLineNumber(key)).toBe(true);
+      }
+    });
+
+    it('존재하지 않는 문자열은 false', () => {
+      expect(isValidLineNumber('K')).toBe(false);
+      expect(isValidLineNumber('mars')).toBe(false);
+      expect(isValidLineNumber('')).toBe(false);
+    });
+
+    it('undefined/null은 false', () => {
+      expect(isValidLineNumber(undefined)).toBe(false);
+      expect(isValidLineNumber(null)).toBe(false);
     });
   });
 });

--- a/src/shared/constants/lineApiNames.ts
+++ b/src/shared/constants/lineApiNames.ts
@@ -29,6 +29,19 @@ export function getLineApiName(line: LineNumber): string {
 }
 
 /**
+ * #2278 (PR #2287 리뷰 P2-1) — LineNumber 검증 단일 SSoT.
+ *
+ * `LINE_API_NAMES` key 집합(데이터 주도)으로 임의 문자열이 유효한 LineNumber인지 narrow한다.
+ * 이전엔 hop-end payload 검증(`useBoardingPromptResponder`)과 backend lockSuggestion 검증
+ * (`useBoardingLockController`)이 각자 별도 함수 + 하드코딩 배열(`VALID_LINES`)을 두어 신규
+ * 노선 추가 시 두 곳을 따로 갱신해야 하는 drift 위험이 있었다. 새 노선은 `LINE_API_NAMES`
+ * 한 줄 추가만으로 두 호출부 모두 자동 반영된다.
+ */
+export function isValidLineNumber(value: string | null | undefined): value is LineNumber {
+  return value != null && Object.prototype.hasOwnProperty.call(LINE_API_NAMES, value);
+}
+
+/**
  * 서울 열린데이터 `realtimeStationArrival` 응답 `subwayId`(예: "1001") → LineNumber 역매핑.
  * 환승역에서 같은 statnNm으로 두 노선 열차가 함께 응답되므로, 각 row의 정확한 호선 식별에 필요.
  * LINE_API_NAMES 추가 시 이 매핑도 함께 확장 — 호선 누락 시 어댑터에서 row 식별 실패.

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -228,3 +228,11 @@ export const ALARM_LOCAL_LEDGER_KEY = 'subway-now:alarm-local-ledger';
 // TTL RECENT_LOCAL_STATION_FIRE_TTL_MS(recentLocalStationFires.ts) 경과 항목은 add/read 시 cleanup.
 // 형식: { "<kind>:<stationName>": timestamp(epoch ms) } JSON.
 export const RECENT_LOCAL_STATION_FIRES_KEY = 'subway-now:recent-local-station-fires';
+// #2278 (PR #2287 리뷰 P1-2) — 환승역 하차 응답/버튼 leg-advance stamp의 trip-scoped 영속화.
+// `useLegAdvanceStore.stampLegAdvance`가 사용자 명시 하차 응답 시점에 write, `loadLegAdvance`가
+// cold start(useStateRehydration)에서 hydrate. 지하에서 앱이 kill된 뒤 재기동하면 in-memory
+// stamp가 사라져 releaseLock 직후 그대로 원 버그(#2278 RCA 가설 1)가 재현되므로, backend SSoT
+// 왕복과 무관한 device-local ground truth를 storage에도 남겨야 한다.
+// 형식: {"nextLine": LineNumber, "stampedAt": number(epoch ms)} JSON.
+// trip 종료 시 runTripBoundCleanups에서 제거 — 이전 trip의 leg-advance가 새 trip에 leak 차단.
+export const LEG_ADVANCE_KEY = 'subway-now:leg-advance';

--- a/src/shared/hooks/__tests__/useStateRehydration.test.ts
+++ b/src/shared/hooks/__tests__/useStateRehydration.test.ts
@@ -10,6 +10,7 @@ import { AppState, type AppStateStatus } from 'react-native';
 import { useStateRehydration } from '../useStateRehydration';
 import { useDestinationStore } from '../../../features/route/store/useDestinationStore';
 import { useBoardingLockStore } from '../../../features/alarm/store/useBoardingLockStore';
+import { useLegAdvanceStore } from '../../../features/alarm/store/useLegAdvanceStore';
 
 const mockGetSentinel = jest.fn();
 const mockClearSentinel = jest.fn();
@@ -78,6 +79,7 @@ const mockSetState = jest.fn();
 
 const mockReleaseLock = jest.fn();
 const mockLoadLock = jest.fn();
+const mockLoadLegAdvance = jest.fn();
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -89,6 +91,7 @@ beforeEach(() => {
   mockLoadTripOrigin.mockResolvedValue(undefined);
   mockReleaseLock.mockResolvedValue(undefined);
   mockLoadLock.mockResolvedValue(undefined);
+  mockLoadLegAdvance.mockResolvedValue(undefined);
   mockRunTripBoundCleanups.mockResolvedValue(undefined);
   mockSetSentinel.mockResolvedValue(undefined);
   // 기본은 trip 미존재(none) — 기존 테스트들이 backstop 영향 받지 않도록.
@@ -110,6 +113,9 @@ beforeEach(() => {
     releaseLock: mockReleaseLock,
     loadLock: mockLoadLock,
   } as unknown as ReturnType<typeof useBoardingLockStore.getState>);
+  jest.spyOn(useLegAdvanceStore, 'getState').mockReturnValue({
+    loadLegAdvance: mockLoadLegAdvance,
+  } as unknown as ReturnType<typeof useLegAdvanceStore.getState>);
 });
 
 function mockAppState(): {
@@ -137,6 +143,18 @@ describe('useStateRehydration', () => {
       expect(mockLoadCustomOrigin).toHaveBeenCalled();
       expect(mockLoadTripOrigin).toHaveBeenCalled();
       expect(mockLoadLock).toHaveBeenCalled();
+    });
+  });
+
+  // #2278 (PR #2287 리뷰 P1-2) — leg-advance stamp도 storage → memory 재수화 공통 진입점에
+  // 포함돼야 지하에서 앱이 kill된 뒤 재기동해도 stamp가 복원된다. 누락되면 loadLock 등은
+  // 정상 복원되지만 legAdvance만 null로 남아 원 버그(releaseLock 직후 fromLine 고착)가
+  // 재기동 후 재현된다.
+  it('마운트 시 leg-advance stamp도 재수화 (loadLegAdvance 호출)', async () => {
+    mockAppState();
+    renderHook(() => useStateRehydration());
+    await waitFor(() => {
+      expect(mockLoadLegAdvance).toHaveBeenCalled();
     });
   });
 

--- a/src/shared/hooks/useStateRehydration.ts
+++ b/src/shared/hooks/useStateRehydration.ts
@@ -9,6 +9,7 @@ import { useEffect } from 'react';
 import { AppState, type AppStateStatus } from 'react-native';
 import { useDestinationStore } from '../../features/route/store/useDestinationStore';
 import { useBoardingLockStore } from '../../features/alarm/store/useBoardingLockStore';
+import { useLegAdvanceStore } from '../../features/alarm/store/useLegAdvanceStore';
 import {
   clearTripEndedSentinel,
   getTripEndedSentinel,
@@ -37,8 +38,9 @@ const logger = createLogger('useStateRehydration');
  *
  * 책임:
  *  1) 마운트 + AppState 'active' 진입마다 trip-bound store(destination/customOrigin/
- *     tripOrigin/lock)를 storage에서 재수화 — BG 동안 다른 채널(silent push 등)이 storage를
- *     갱신했을 수 있으므로 zustand snapshot을 항상 최신화.
+ *     tripOrigin/lock/legAdvance)를 storage에서 재수화 — BG 동안 다른 채널(silent push 등)이
+ *     storage를 갱신했을 수 있으므로 zustand snapshot을 항상 최신화. legAdvance(#2278)는
+ *     지하에서 앱 kill 후 재기동해도 하차 응답 stamp가 사라지지 않도록 하는 P1-2 보강.
  *  2) trip-ended sentinel(`TRIP_ENDED_BY_BACKEND_AT_KEY`)이 있으면 destination/lock store를
  *     명시적으로 reset — BG에서 storage cleanup만 수행한 trip-ended가 in-memory zustand에
  *     stale state로 잠시 노출되는 회귀(#899)를 차단. 처리 후 sentinel 즉시 삭제.
@@ -117,6 +119,11 @@ async function runRehydration(trigger: 'mount' | 'active'): Promise<void> {
     destStore.loadCustomOrigin(),
     destStore.loadTripOrigin(),
     useBoardingLockStore.getState().loadLock(),
+    // #2278 (PR #2287 리뷰 P1-2) — leg-advance stamp도 storage → memory 재수화. 지하에서 앱이
+    // kill된 뒤 재기동하면 in-memory stamp가 사라지므로, 이 공통 hydrate chokepoint(mount +
+    // AppState 'active' 진입)에서 복원하지 않으면 원 버그(releaseLock 직후 route.stopsToTransfer
+    // frozen → fromLine 고착)가 재기동 후 그대로 재현된다.
+    useLegAdvanceStore.getState().loadLegAdvance(),
   ]);
 
   // #1573 (T10) — trip lifecycle 단계적 backstop. FG 복귀 / mount 마다 확인.


### PR DESCRIPTION
## 배경
PR #2287이 리뷰 P1 반영 전에 머지되어 후속 PR로 복구 (Part of #2278, lesson_merge_before_review_fix_push_lost 절차). 구현 에이전트 stall로 작업물을 회수해 최신 dev(#2286~#2291 머지 후) 기반 새 브랜치로 재구성.

## 내용
- **P1-1 (lockSuggestion 재hydrate가 stamp 무력화)**: legAdvance stamp에 stampedAt 추가, lockSuggestion hydrate effect에서 suggestion이 stamp보다 오래됐거나(decidedAt < stampedAt) stamp.nextLine과 노선 불일치면 skip. stamp 없으면 기존 동작 그대로. 무탭 자동 경로 신설 없음(#2154).
- **P1-2 (stamp 비영속 → 지하 앱 kill 시 원버그 재현)**: `legAdvanceStorage.ts` 신설 — AsyncStorage trip-scoped 영속화(storageKeys 데이터 주도), cold-start hydrate(useStateRehydration), runTripBoundCleanups에서 storage까지 삭제. "cold start 시 fresh 재계산이라 안전" 주석의 틀린 전제 수정.
- **P2-1**: LineNumber 검증을 `lineApiNames`의 `isValidLineNumber` 단일 함수로 통합, useBoardingLockController의 하드코딩 VALID_LINES 제거.

## 검증
- `npm test` 438 suites / **9414 tests pass, 커버리지 100%** (최신 dev 머지 5건 포함 상태)
- `npm run type-check` pass, `npm run lint:orphan` 0 orphan
- RED 테스트: stale suggestion이 stamp를 덮는 재현 + 재기동 후 stamp 복원 실패 재현 포함

## Wire-completion 5단
1. lint:orphan pass  2. V/X: DebugModal alarm log leg-advance stamp 이벤트 + AsyncStorage 키  3. 의존 PR: N/A (#2287 머지됨)  4. 측정: 다음 실탑승 7→2 환승에서 하차 응답 → 앱 kill → 재기동 후에도 2호선 유지 확인  5. Device verify: 필요 — 환승+재기동 시나리오

Part of #2278