### PR TITLE
chore(#2284): fired 전용 독립 영속 링버퍼 — alarmLog rotate 절단 차단

### DIFF
--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -15,6 +15,10 @@ import {
   resetAlarmLogForTest,
   getAlarmLog,
   clearAlarmLog,
+  getFiredAlarmLog,
+  clearFiredAlarmLog,
+  FIRED_ALARM_LOG_BUFFER_SIZE,
+  type FiredAlarmLogEntry,
   logFiredAlarm,
   logFiredStationPassed,
   logScheduledAlarm,
@@ -105,7 +109,7 @@ import {
   type AlarmLogReasonCounter,
   type BoardingPromptWindowKey,
 } from '../alarmLog';
-import { ALARM_LOG_KEY } from '../../../../shared/constants/storageKeys';
+import { ALARM_LOG_KEY, FIRED_ALARM_LOG_KEY } from '../../../../shared/constants/storageKeys';
 import type { AlarmEvent } from '../stationAlarm';
 import type { Station } from '../../../../shared/types/station';
 
@@ -113,6 +117,11 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn(),
   setItem: jest.fn(),
   removeItem: jest.fn(),
+}));
+
+// #2284 — line lookup을 mock해 fired-only 버퍼 테스트를 stations.json 실데이터와 분리(결정적).
+jest.mock('../../../../shared/utils/stationLookup', () => ({
+  findLineByStationName: jest.fn((name: string) => (name === '강남' ? '2' : null)),
 }));
 
 jest.mock('../../../../shared/utils/logger', () => ({
@@ -128,11 +137,16 @@ function flushPromises(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
+// #2284 — 기본 outcome을 'suppressed'로 변경. 'fired'(+ FIRED_ALARM_SOURCES 소스)는
+// appendAlarmLog/flushAlarmLog 경로에서 독립 fired-only 버퍼(FIRED_ALARM_LOG_KEY)에도
+// 동시 write를 트리거하므로, fired 여부와 무관한 일반 배치 동작을 검증하는 기존 테스트가
+// 의도치 않게 두 번째 AsyncStorage 호출을 관측하지 않도록 한다. fired 전용 동작은
+// 'fired-only 독립 버퍼(#2284)' describe 블록에서 명시적으로 outcome: 'fired'를 지정한다.
 function makeEntry(overrides: Partial<AlarmLogEntry> = {}): AlarmLogEntry {
   return {
     ts: 1_700_000_000_000,
     source: 'bg',
-    outcome: 'fired',
+    outcome: 'suppressed',
     stationName: '강남',
     kind: 'station-passed',
     ...overrides,
@@ -3423,6 +3437,196 @@ describe('alarmLog', () => {
         { ts: 16, source: 'fg', outcome: 'fired' },
       ];
       expect(countFiredAlarms(entries)).toBe(1);
+    });
+  });
+
+  // ── #2284 fired-only 독립 영속 링버퍼 ──────────────────────────────────────
+  describe('fired-only 독립 버퍼 (#2284)', () => {
+    // AsyncStorage mock을 key별 in-memory Map으로 라우팅 — ALARM_LOG_KEY와
+    // FIRED_ALARM_LOG_KEY가 서로 다른 storage slot임을 시뮬레이션한다.
+    function makeKeyedStorage(): Map<string, string> {
+      const store = new Map<string, string>();
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(
+        async (key: string) => store.get(key) ?? null,
+      );
+      (AsyncStorage.setItem as jest.Mock).mockImplementation(
+        async (key: string, value: string) => {
+          store.set(key, value);
+        },
+      );
+      (AsyncStorage.removeItem as jest.Mock).mockImplementation(async (key: string) => {
+        store.delete(key);
+      });
+      return store;
+    }
+
+    it('outcome=fired + FIRED_ALARM_SOURCES=true 소스만 독립 버퍼에 적재된다', async () => {
+      makeKeyedStorage();
+      appendAlarmLog(
+        makeEntry({ source: 'fg', outcome: 'fired', kind: 'destination', stationName: '강남' }),
+      );
+      await flushAlarmLog();
+
+      const fired = await getFiredAlarmLog();
+      expect(fired).toEqual<FiredAlarmLogEntry[]>([
+        { ts: 1_700_000_000_000, kind: 'destination', station: '강남', line: '2', channel: 'fg' },
+      ]);
+    });
+
+    it('outcome=suppressed/received 엔트리는 독립 버퍼에 적재되지 않는다', async () => {
+      makeKeyedStorage();
+      appendAlarmLog(makeEntry({ source: 'fg', outcome: 'suppressed', reason: 'gate-age' }));
+      appendAlarmLog(makeEntry({ source: 'fg-hydrate', outcome: 'received' }));
+      await flushAlarmLog();
+
+      expect(await getFiredAlarmLog()).toEqual([]);
+      // 독립 버퍼 key에는 write 자체가 발생하지 않는다 — fired 엔트리 0건이면 no-op.
+      expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(
+        FIRED_ALARM_LOG_KEY,
+        expect.anything(),
+      );
+    });
+
+    it('metadata source(FIRED_ALARM_SOURCES=false)는 outcome=fired여도 독립 버퍼 제외', async () => {
+      makeKeyedStorage();
+      appendAlarmLog(makeEntry({ source: 'boarding-prompt', outcome: 'fired' }));
+      appendAlarmLog(makeEntry({ source: 'lifecycle-backstop', outcome: 'fired' }));
+      await flushAlarmLog();
+
+      expect(await getFiredAlarmLog()).toEqual([]);
+    });
+
+    it('kind 없는 엔트리는 line-agnostic 처리, station 미상은 unknown으로 채운다', async () => {
+      makeKeyedStorage();
+      appendAlarmLog({
+        ts: 5,
+        source: 'silent-push-fired',
+        outcome: 'fired',
+      });
+      await flushAlarmLog();
+
+      expect(await getFiredAlarmLog()).toEqual<FiredAlarmLogEntry[]>([
+        { ts: 5, kind: 'unknown', station: 'unknown', line: null, channel: 'silent-push-fired' },
+      ]);
+    });
+
+    it(
+      '#2284 핵심 회귀 — alarmLog(200-cap, 혼합 outcome) rotate로 과거 fired 기록이 밀려나도 ' +
+        '독립 버퍼는 보존한다 (2026-08-11 07:38:28 이전 fired 소실 evidence)',
+      async () => {
+        makeKeyedStorage();
+        // 오래된 fired 발사 1건 + 이후 대량 suppressed burst(200-cap 초과) — 실제 회귀 재현.
+        appendAlarmLog(
+          makeEntry({
+            ts: 1,
+            source: 'fg',
+            outcome: 'fired',
+            kind: 'station-passed',
+            stationName: '강남',
+          }),
+        );
+        for (let i = 0; i < ALARM_LOG_BUFFER_SIZE + 10; i += 1) {
+          appendAlarmLog(
+            makeEntry({ ts: i + 100, outcome: 'suppressed', reason: 'gate-age', stationName: `s${i}` }),
+          );
+        }
+        await flushAlarmLog();
+
+        // alarmLog 200-cap rotate로 가장 오래된 fired 엔트리(ts=1)는 사라진다 — 기존 동작.
+        const alarmLog = await getAlarmLog();
+        expect(alarmLog).toHaveLength(ALARM_LOG_BUFFER_SIZE);
+        expect(alarmLog.some((e) => e.ts === 1)).toBe(false);
+
+        // 그러나 fired-only 독립 버퍼는 rotate와 무관하게 그 발사 기록을 보존한다.
+        const fired = await getFiredAlarmLog();
+        expect(fired).toHaveLength(1);
+        expect(fired[0]).toMatchObject({ ts: 1, station: '강남', channel: 'fg' });
+      },
+    );
+
+    it('FIRED_ALARM_LOG_BUFFER_SIZE 초과 시 가장 오래된 fired 엔트리부터 drop (FIFO)', async () => {
+      const store = makeKeyedStorage();
+      const existing: FiredAlarmLogEntry[] = Array.from(
+        { length: FIRED_ALARM_LOG_BUFFER_SIZE },
+        (_, i) => ({ ts: i, kind: 'unknown', station: `s${i}`, line: null, channel: 'fg' }),
+      );
+      store.set(FIRED_ALARM_LOG_KEY, JSON.stringify(existing));
+
+      appendAlarmLog(makeEntry({ ts: 9999, source: 'fg', outcome: 'fired', stationName: '신규' }));
+      await flushAlarmLog();
+
+      const fired = await getFiredAlarmLog();
+      expect(fired).toHaveLength(FIRED_ALARM_LOG_BUFFER_SIZE);
+      expect(fired[0].ts).toBe(1); // ts=0인 가장 오래된 엔트리 drop
+      expect(fired.at(-1)?.station).toBe('신규'); // 새로 추가된 엔트리가 마지막
+    });
+
+    it('콜드런치 — 모듈 스코프 pending 없이도 저장된 값을 그대로 복원한다', async () => {
+      const store = makeKeyedStorage();
+      const persisted: FiredAlarmLogEntry[] = [
+        { ts: 1, kind: 'transfer', station: '강남', line: '2', channel: 'bg-scheduled' },
+      ];
+      store.set(FIRED_ALARM_LOG_KEY, JSON.stringify(persisted));
+
+      // resetAlarmLogForTest() 이후 append 없이 바로 read — 콜드런치와 동일 조건.
+      expect(await getFiredAlarmLog()).toEqual(persisted);
+    });
+
+    it('손상된 JSON이면 빈 배열을 반환한다', async () => {
+      const store = makeKeyedStorage();
+      store.set(FIRED_ALARM_LOG_KEY, 'not-json{{{');
+      expect(await getFiredAlarmLog()).toEqual([]);
+    });
+
+    it('JSON.parse 결과가 배열이 아니면 빈 배열을 반환한다', async () => {
+      const store = makeKeyedStorage();
+      store.set(FIRED_ALARM_LOG_KEY, JSON.stringify({ foo: 'bar' }));
+      expect(await getFiredAlarmLog()).toEqual([]);
+    });
+
+    it('AsyncStorage read 실패 시 빈 배열을 반환한다(throw 안 함)', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('storage 오류'));
+      await expect(getFiredAlarmLog()).resolves.toEqual([]);
+    });
+
+    it('alarmLog write 실패해도 fired-only 버퍼 적재는 별도로 시도된다', async () => {
+      const store = makeKeyedStorage();
+      (AsyncStorage.setItem as jest.Mock).mockImplementation(
+        async (key: string, value: string) => {
+          if (key === ALARM_LOG_KEY) throw new Error('alarmLog write 실패');
+          store.set(key, value);
+        },
+      );
+      appendAlarmLog(makeEntry({ source: 'fg', outcome: 'fired', stationName: '강남' }));
+      await expect(flushAlarmLog()).resolves.toBeUndefined();
+
+      expect(await getFiredAlarmLog()).toHaveLength(1);
+    });
+
+    it('fired-only 버퍼 write 실패해도 throw하지 않는다(alarmLog write는 정상 진행)', async () => {
+      const store = makeKeyedStorage();
+      (AsyncStorage.setItem as jest.Mock).mockImplementation(
+        async (key: string, value: string) => {
+          if (key === FIRED_ALARM_LOG_KEY) throw new Error('fired 버퍼 write 실패');
+          store.set(key, value);
+        },
+      );
+      appendAlarmLog(makeEntry({ source: 'fg', outcome: 'fired', stationName: '강남' }));
+      await expect(flushAlarmLog()).resolves.toBeUndefined();
+
+      // alarmLog(ALARM_LOG_KEY) write는 fired-only 버퍼 실패와 무관하게 정상 진행됐다.
+      expect(store.has(ALARM_LOG_KEY)).toBe(true);
+    });
+
+    it('clearFiredAlarmLog — removeItem 호출', async () => {
+      makeKeyedStorage();
+      await clearFiredAlarmLog();
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(FIRED_ALARM_LOG_KEY);
+    });
+
+    it('clearFiredAlarmLog — AsyncStorage 실패해도 throw 안 함', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('remove fail'));
+      await expect(clearFiredAlarmLog()).resolves.toBeUndefined();
     });
   });
 });

--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -84,6 +84,7 @@ import {
   logBoardingPromptFired,
   logBoardingPromptResponded,
   logCompanionAlarmFired,
+  logLastTrainAlarmFired,
   logLegTransition,
   BOARDING_PROMPT_WINDOWS,
   countBoardingPromptByWindow,
@@ -2415,6 +2416,17 @@ describe('alarmLog', () => {
       expect(saved[0].source).toBe('companion');
       expect(saved[0].outcome).toBe('fired');
       expect(saved[0].stationName).toBe('2·뚝섬');
+    });
+
+    it('#2284 (P1 wire matrix gap): logLastTrainAlarmFired가 last-train-alarm entry를 적재한다', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+      logLastTrainAlarmFired({ stationName: '소요산' });
+      await flushAlarmLog();
+      const saved = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
+      expect(saved).toHaveLength(1);
+      expect(saved[0].source).toBe('last-train-alarm');
+      expect(saved[0].outcome).toBe('fired');
+      expect(saved[0].stationName).toBe('소요산');
     });
 
     it('#2243 (ADR-029 Phase 1, G6): logPushContractKindSkew station-like → outcome=fired', async () => {

--- a/src/features/alarm/utils/__tests__/lastTrainAlarm.test.ts
+++ b/src/features/alarm/utils/__tests__/lastTrainAlarm.test.ts
@@ -59,6 +59,13 @@ jest.mock('../../../../shared/infra/monitoring/breadcrumb', () => ({
   addDomainBreadcrumb: (...args: unknown[]) => mockBreadcrumb(...args),
 }));
 
+// #2284 (P1 wire matrix gap) — 막차 임박 알람은 trigger:null 즉시 발사인데 fired-only 독립
+// 버퍼 집계 경로(alarmLog)를 전혀 거치지 않던 회귀. 발사 성공 시 stamp 호출을 검증한다.
+const mockLogLastTrainAlarmFired = jest.fn();
+jest.mock('../alarmLog', () => ({
+  logLastTrainAlarmFired: (...args: unknown[]) => mockLogLastTrainAlarmFired(...args),
+}));
+
 const mockResolveTripDirection = jest.fn();
 jest.mock('../../../route/utils/tripDirection', () => ({
   resolveTripDirection: (...args: unknown[]) => mockResolveTripDirection(...args),
@@ -386,6 +393,19 @@ describe('fireLastTrainAlarm', () => {
     const call = (Notifications.scheduleNotificationAsync as jest.Mock).mock.calls[0][0];
     // i18next는 기본 ko, "막차 {{minutes}}분 전" → 0이 들어가야 함
     expect(call.content.title).toMatch(/0/);
+  });
+
+  it('#2284 (P1) — 발사 성공 시 fired-only 독립 버퍼 집계용 alarmLog stamp를 호출한다', async () => {
+    Object.defineProperty(Platform, 'OS', { value: 'ios', writable: true });
+    await fireLastTrainAlarm({
+      origin: station(),
+      destination: station({ id: '1-002', name: '회기' }),
+      minutesRemaining: 10,
+      lastTrainTime: '23:55',
+    });
+    // trigger:null 즉시 발사 — origin 정규 한글 station명(로컬라이즈 X, findLineByStationName
+    // lookup 호환)으로 stamp돼야 한다.
+    expect(mockLogLastTrainAlarmFired).toHaveBeenCalledWith({ stationName: station().name });
   });
 });
 

--- a/src/features/alarm/utils/__tests__/safetyNetScheduler.test.ts
+++ b/src/features/alarm/utils/__tests__/safetyNetScheduler.test.ts
@@ -33,6 +33,14 @@ jest.mock('../stationNotification', () => ({
   }),
 }));
 
+// #2284 (P1 wire matrix gap) — #2089 리팩터로 구 3종 스케줄러(alarmScheduler 등)가 호출하던
+// logScheduledAlarm 계측이 safetyNetScheduler로 이전되지 않고 유실됐다. OS 예약(DATE trigger,
+// 취소 가능) 성공 시 예약 stamp 호출을 검증한다 — "발사"가 아닌 "예약" 시점 기록.
+const mockLogScheduledAlarm = jest.fn();
+jest.mock('../alarmLog', () => ({
+  logScheduledAlarm: (...args: unknown[]) => mockLogScheduledAlarm(...args),
+}));
+
 const mockedSchedule = Notifications.scheduleNotificationAsync as jest.MockedFunction<
   typeof Notifications.scheduleNotificationAsync
 >;
@@ -178,6 +186,25 @@ describe('registerSafetyNetAlarms', () => {
     const expectedFire = START_TIME + 600_000 - 120_000 + SAFETY_NET_BUFFER_MS;
     expect(scheduledFireMs()).toEqual([expectedFire]);
     expect(scheduledIdentifiers()).toEqual([`alarm-${TRIP_TOKEN}-${GANGNAM}-destination`]);
+  });
+
+  it('#2284 (P1) — OS 예약 성공 시 fired-only 독립 버퍼용 alarmLog 예약 stamp를 호출한다', async () => {
+    const route = makeDirectRoute(5, '2');
+    await registerSafetyNetAlarms({
+      tripToken: TRIP_TOKEN,
+      route,
+      destinationName: GANGNAM,
+      startTime: START_TIME,
+      now: START_TIME,
+      outageConfirmed: true,
+    });
+    // "예약"과 "실제 발사"가 다른 채널(OS DATE trigger, 취소 가능) — logScheduledAlarm(기존
+    // bg-scheduled 관례)로 예약 시점 기록. 취소되면 이 entry가 그대로 남는 known limitation은
+    // 구 3종 스케줄러 시절부터 존재하던 동일 특성(신규 도입 아님).
+    expect(mockLogScheduledAlarm).toHaveBeenCalledWith(
+      { phaseId: 'early', type: 'destination', stationName: GANGNAM },
+      expect.objectContaining({ expectedStationAtFire: GANGNAM }),
+    );
   });
 
   it('과거 시각(fireMs <= startTime/now)은 skip', async () => {

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -1,9 +1,10 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AppState, type AppStateStatus } from 'react-native';
-import { ALARM_LOG_KEY } from '../../../shared/constants/storageKeys';
+import { ALARM_LOG_KEY, FIRED_ALARM_LOG_KEY } from '../../../shared/constants/storageKeys';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
 import { captureXEvent } from '../../../shared/infra/monitoring/captureXEvent';
 import { createLogger } from '../../../shared/utils/logger';
+import { findLineByStationName } from '../../../shared/utils/stationLookup';
 import type { AlarmEvent } from './stationAlarm';
 import type { AlarmPhaseId } from './alarmPhases';
 import type { Station } from '../../../shared/types/station';
@@ -464,6 +465,30 @@ export interface AlarmLogEntry {
   currentHopIndex?: number;
   candidateIndex?: number;
 }
+
+/**
+ * #2284 — fired-only 독립 영속 링버퍼 entry.
+ *
+ * `alarmLog`(200-cap, 모든 outcome/source 혼합)는 suppressed/received burst가 몰리면
+ * 이전 fired 기록을 rotate로 밀어낸다(2026-08-11 덤프: 07:38:28 이전 fired 소실).
+ * DebugModal의 "Notifications fired" 파생값(`logs.filter(outcome==='fired')`)이 이 절단을
+ * 그대로 상속해 "실알람 0건" 오판을 낳았다 — 별도 key/cap으로 분리해 alarmLog rotate와
+ * 무관하게 보존한다.
+ *
+ * `line`은 stationName → 데이터 기반 최근접 노선 조회(`findLineByStationName`)로 채운다.
+ * AlarmEvent 자체에 line 필드가 없어 발사 시점 정확한 노선을 항상 보장하지 못하지만(동명이역
+ * 등 ambiguous 케이스는 null), 진단 목적에는 충분하다.
+ */
+export interface FiredAlarmLogEntry {
+  ts: number;
+  kind: AlarmLogKind | 'unknown';
+  station: string;
+  line: string | null;
+  channel: AlarmLogSource;
+}
+
+// #2284 — 별 ring cap. alarmLog(200)와 무관 — fired만 담으므로 훨씬 적은 cap으로 충분.
+export const FIRED_ALARM_LOG_BUFFER_SIZE = 100;
 
 const logger = createLogger('AlarmLog');
 
@@ -2435,6 +2460,45 @@ async function doFlushOnce(): Promise<void> {
   } catch (e) {
     logger.error('알람 로그 적재 실패:', e);
   }
+  // #2284 — 같은 flush 사이클(동일 mutex 보호 구간) 안에서 fired-only 독립 버퍼도 함께 적재.
+  // alarmLog write 실패와 독립적으로 시도 — 자체 try/catch로 격리.
+  await flushFiredAlarmLog(toFlush);
+}
+
+/**
+ * #2284 — pendingEntries 중 "실제 사용자에게 노출된" fired 엔트리만 골라 독립 버퍼에 적재.
+ *
+ * `FIRED_ALARM_SOURCES`(위 정의, countFiredAlarms가 쓰는 것과 동일 SSoT)로 metadata stamp
+ * (boarding-prompt/lifecycle-backstop/lockless-trip-end 등)를 걸러낸다 — 이 버퍼가 "발사=사용자
+ * 알림 노출"만 담아야 fired count가 다시 거짓말하지 않는다.
+ *
+ * appendAlarmLog를 거치는 모든 발사 경로(scheduleNotification/LA 계열 helper: logFiredAlarm /
+ * logFiredStationPassed / logScheduledAlarm / logCompanionFired 등)가 단일 진입점이므로 신규
+ * 발사 경로가 추가돼도 이 하나의 hook이 자동으로 커버한다 — 호출부별 개별 wiring 불필요.
+ */
+async function flushFiredAlarmLog(entries: readonly AlarmLogEntry[]): Promise<void> {
+  const fired = entries.filter(
+    (e) => e.outcome === 'fired' && FIRED_ALARM_SOURCES[e.source],
+  );
+  if (fired.length === 0) return;
+  try {
+    const raw = await AsyncStorage.getItem(FIRED_ALARM_LOG_KEY);
+    const existing: FiredAlarmLogEntry[] = raw ? safeParseFired(raw) : [];
+    const additions: FiredAlarmLogEntry[] = fired.map((e) => ({
+      ts: e.ts,
+      kind: e.kind ?? 'unknown',
+      station: e.stationName ?? 'unknown',
+      line: e.stationName ? findLineByStationName(e.stationName) : null,
+      channel: e.source,
+    }));
+    const next = [...existing, ...additions];
+    const trimmed = next.length > FIRED_ALARM_LOG_BUFFER_SIZE
+      ? next.slice(next.length - FIRED_ALARM_LOG_BUFFER_SIZE)
+      : next;
+    await AsyncStorage.setItem(FIRED_ALARM_LOG_KEY, JSON.stringify(trimmed));
+  } catch (e) {
+    logger.error('fired 알람 로그 적재 실패:', e);
+  }
 }
 
 export async function getAlarmLog(): Promise<AlarmLogEntry[]> {
@@ -2471,6 +2535,30 @@ export async function clearAlarmLog(): Promise<void> {
 }
 
 /**
+ * #2284 — fired-only 독립 버퍼 read. alarmLog와 분리된 key라 rotate와 무관하게 항상
+ * 실제 발사 기록만 반환한다. DebugModal의 "Notifications fired" 섹션/dump가 이 함수로
+ * 전환됐다 — 기존 `logs.filter(outcome==='fired')` 파생값(rotate 절단 상속) 대체.
+ */
+export async function getFiredAlarmLog(): Promise<FiredAlarmLogEntry[]> {
+  try {
+    const raw = await AsyncStorage.getItem(FIRED_ALARM_LOG_KEY);
+    return raw ? safeParseFired(raw) : [];
+  } catch (e) {
+    logger.error('fired 알람 로그 읽기 실패:', e);
+    return [];
+  }
+}
+
+/** #2284 — fired-only 독립 버퍼 clear. DebugModal handleClear가 alarmLog와 함께 초기화. */
+export async function clearFiredAlarmLog(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(FIRED_ALARM_LOG_KEY);
+  } catch (e) {
+    logger.error('fired 알람 로그 삭제 실패:', e);
+  }
+}
+
+/**
  * 테스트 전용 — 모듈 스코프 상태 초기화 (#735).
  * pendingEntries / flushTimer / oldestPendingTs를 reset해 테스트 간 격리.
  * production 호출 금지.
@@ -2495,6 +2583,21 @@ function safeParse(raw: string): AlarmLogEntry[] {
     return parsed;
   } catch {
     logger.error('알람 로그 JSON 손상 — 빈 로그로 초기화');
+    return [];
+  }
+}
+
+/** #2284 — fired-only 독립 버퍼 전용 파싱. safeParse와 동일 손상 방어 정책, 별도 로그 문구. */
+function safeParseFired(raw: string): FiredAlarmLogEntry[] {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      logger.error('fired 알람 로그 형태 손상(비배열) — 빈 로그로 초기화');
+      return [];
+    }
+    return parsed;
+  } catch {
+    logger.error('fired 알람 로그 JSON 손상 — 빈 로그로 초기화');
     return [];
   }
 }

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -120,7 +120,12 @@ export type AlarmLogSource =
   // #2243 (ADR-029 Phase 1) — push 계약 런타임 경계 위반(unknown-kind skew / semantic value
   // drift) 관측 전용 source. 기존 silent-push-received/-skipped 분포와 분리해 A2("silent
   // drop 대신 명시적 skew 로그") 달성 여부를 독립적으로 측정할 수 있게 한다.
-  | 'push-contract-skew';
+  | 'push-contract-skew'
+  // #2284 (P1 wire matrix gap) — 막차 임박 알람(lastTrainAlarm.ts fireLastTrainAlarm) 즉시
+  // 발사 stamp. `expo-notifications`에 `trigger: null`로 예약하므로 스케줄 호출 자체가 곧
+  // 사용자 노출 확정 시점 — bg-scheduled(OS DATE trigger, 취소 가능한 미래 예약)와 달리
+  // "예약≠발사" 갭이 없는 확정 발사다.
+  | 'last-train-alarm';
 export type AlarmLogOutcome = 'fired' | 'suppressed' | 'received';
 // 'dedup-alarm'(#580): evaluateAlarmPhase의 firedAlarms 적중. destination/transfer phase alarm dedup
 // 발생 관찰. station-passed는 별도 메커니즘(lastNotifiedStationId)이라 'dedup-station' 사용.
@@ -1394,6 +1399,8 @@ const SILENT_PUSH_OUTCOME_SOURCES: Record<AlarmLogSource, keyof SilentPushOutcom
   companion: null,
   // #2243 (ADR-029 Phase 1) — 계약 스큐는 별도 전용 counter(countPushContractSkew)로 집계.
   'push-contract-skew': null,
+  // #2284 — 막차 알람은 silent push와 무관한 device 로컬 채널이므로 이 counter 제외.
+  'last-train-alarm': null,
 };
 
 export interface SilentPushOutcomeCounts {
@@ -1453,6 +1460,8 @@ const FIRED_ALARM_SOURCES: Record<AlarmLogSource, boolean> = {
   // generic imminent 알림이므로 fire 분모에 포함(outcome='fired'인 항목만 카운트되므로
   // control-like fail-closed 'suppressed' 항목은 자동 제외).
   'push-contract-skew': true,
+  // #2284 (P1) — 즉시 발사(trigger: null) 확정 알람. 실제 사용자 노출이므로 fire 분모 포함.
+  'last-train-alarm': true,
 };
 
 /**
@@ -2002,6 +2011,25 @@ export function logCompanionAlarmFired(input: {
     source: 'companion',
     outcome: 'fired',
     stationName: `${input.nextLine}·${input.nextStation}`,
+  });
+}
+
+/**
+ * #2284 (P1 wire matrix gap) — 막차 임박 알람 즉시 발사(`lastTrainAlarm.ts fireLastTrainAlarm`)
+ * 1건 적재. `trigger: null`로 스케줄하므로 호출 시점이 곧 확정 발사 시점이다(OS 사전예약과
+ * 달리 "예약≠발사" 갭 없음) — `appendAlarmLog`를 거쳐 fired-only 독립 버퍼(#2284)에도
+ * genuine fire로 자동 반영된다.
+ *
+ * stationName은 로컬라이즈된 표시명이 아닌 origin의 정규 한글 station명이어야 한다 —
+ * fired-only 버퍼가 `findLineByStationName`으로 line을 조회할 때 stations.json 원본과
+ * 매칭돼야 하기 때문.
+ */
+export function logLastTrainAlarmFired(input: { stationName: string }): void {
+  appendAlarmLog({
+    ts: Date.now(),
+    source: 'last-train-alarm',
+    outcome: 'fired',
+    stationName: input.stationName,
   });
 }
 

--- a/src/features/alarm/utils/lastTrainAlarm.ts
+++ b/src/features/alarm/utils/lastTrainAlarm.ts
@@ -20,6 +20,8 @@ import { getStationDisplayName } from '../../../shared/utils/stationDisplay';
 import { createLogger } from '../../../shared/utils/logger';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
 import { resolveTripDirection } from '../../route/utils/tripDirection';
+// #2284 (P1 wire matrix gap) — 즉시 발사(trigger:null) fired-only 독립 버퍼 집계 stamp.
+import { logLastTrainAlarmFired } from './alarmLog';
 import {
   classifyDayTypeKst,
   getLastTrainTime,
@@ -171,6 +173,8 @@ export async function fireLastTrainAlarm(input: FireLastTrainAlarmInput): Promis
     minutesRemaining: input.minutesRemaining,
     lastTrainTime: input.lastTrainTime,
   });
+  // #2284 (P1) — trigger:null 즉시 발사 확정. fired-only 독립 버퍼 집계용 stamp.
+  logLastTrainAlarmFired({ stationName: input.origin.name });
 }
 
 export interface RunLastTrainAlarmCycleInput extends LastTrainEvaluationInput {

--- a/src/features/alarm/utils/safetyNetScheduler.ts
+++ b/src/features/alarm/utils/safetyNetScheduler.ts
@@ -46,6 +46,9 @@ import { HOP_TIME_MS } from '../../../shared/constants/boardingLock';
 import { SAFETY_NET_MAX_WAYPOINTS } from '../../../shared/constants/iosScheduledLimit';
 import { createLogger } from '../../../shared/utils/logger';
 import { recordScheduledAlarm } from './prescheduledMetrics';
+// #2284 (P1 wire matrix gap) — #2089 리팩터로 구 3종 스케줄러가 호출하던 logScheduledAlarm
+// stamp가 safetyNetScheduler로 이전되지 않고 유실됐다. bg-scheduled 관례를 그대로 재사용.
+import { logScheduledAlarm } from './alarmLog';
 
 const logger = createLogger('SafetyNetScheduler');
 
@@ -229,6 +232,17 @@ async function scheduleOne(params: {
   // 무영향(prescheduledMetrics 내부에서 흡수) — fire-and-forget이 아니라 await하는 이유는
   // register 호출 순서를 보존해 ledger idx 갱신 race를 피하기 위함.
   await recordScheduledAlarm({ identifier, scheduledFireMs: fireMs, stationName });
+  // #2284 (P1 wire matrix gap) — 구 3종 스케줄러가 호출하던 alarmLog 예약 stamp가 #2089
+  // 리팩터로 유실됐던 것을 복원. OS DATE trigger(미래 예약, 취소 가능)라 "발사"가 아닌
+  // "예약" 시점 기록 — bg-scheduled 관례(logScheduledAlarm) 그대로 재사용. safetyNetScheduler는
+  // direction/trainCode/직전 notified station 정보를 갖지 않아 해당 필드는 null.
+  logScheduledAlarm(event, {
+    direction: null,
+    usedTrainCode: null,
+    selectedArrivalSeconds: null,
+    expectedStationAtFire: stationName,
+    actualLastNotifiedStation: null,
+  });
 }
 
 export interface RegisterSafetyNetParams {

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -46,6 +46,7 @@ import {
 import {
   BOARDING_PROMPT_WINDOWS,
   clearAlarmLog,
+  clearFiredAlarmLog,
   countAlarmLogReasonsByWindow,
   countAutoLockReasonsByWindow,
   countBoardingPromptByWindow,
@@ -55,6 +56,7 @@ import {
   countSilentPushOutcomes,
   formatFusionPickerTierDistribution,
   getAlarmLog,
+  getFiredAlarmLog,
   getFusionTierLog,
   summarizeAlarmLogByReason,
   summarizeAlarmLogBySource,
@@ -62,6 +64,7 @@ import {
   type AlarmLogEntry,
   type AlarmLogReason,
   type AlarmLogReasonCounter,
+  type FiredAlarmLogEntry,
   type FusionTierLogEntry,
 } from '../../../features/alarm/utils/alarmLog';
 import {
@@ -321,9 +324,12 @@ function formatTime(ts: number): string {
   return d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
 }
 
-// #1626 — outcome filter helper. AlarmLogOutcome union 값 변경 시 grep이 흩어지지 않게
-// 한 곳에서 표현. SHARE_SECTIONS suffix / section builder / UI 컴포넌트 3곳 공유.
-const isFired = (e: AlarmLogEntry): boolean => e.outcome === 'fired';
+// #2284 — fired-only 독립 버퍼(FiredAlarmLogEntry) 1건 포맷. alarmLog의 formatLogLine과 달리
+// (ts, kind, station, line, channel) 5필드만 담는 별도 스키마라 전용 포매터를 둔다.
+function formatFiredLogLine(entry: FiredAlarmLogEntry): string {
+  const linePart = entry.line ?? UNKNOWN_LABEL;
+  return `${formatTime(entry.ts)} ${entry.channel} ${entry.kind} ${entry.station} (${linePart})`;
+}
 
 function formatLogLine(entry: AlarmLogEntry): string {
   const parts: string[] = [
@@ -610,6 +616,11 @@ interface BuildDumpArgs {
    */
   backendSsotMirror?: BackendSsotMirrorEntry | null;
   logs: AlarmLogEntry[];
+  /**
+   * #2284 — fired-only 독립 영속 링버퍼 스냅샷. alarmLog 200-cap rotate와 무관하게 보존되는
+   * 발사 기록 SSoT. 미전달 시 (empty) — 단위 테스트 호환.
+   */
+  firedAlarmLog?: readonly FiredAlarmLogEntry[];
   // #1308: iOS 저전력 모드. optional — 미전달 시 false(off). silent push 측정용.
   lowPowerMode?: boolean;
   // #756: OS 큐 dump. 미전달/null = DebugModal에서 한 번도 Refresh 안 한 상태.
@@ -1056,12 +1067,19 @@ function buildGatesSection(args: BuildDumpArgs): string[] {
   return reasonLine ? [reasonLine] : [];
 }
 
-// #1626 — AlarmLog 중 outcome='fired'만 시간순 reverse. baseline 측정 fidelity 향상:
-// backend `/admin/alarm-log-stats` 호출 없이 device DebugModal에서 V4 발사 시점 즉시 확인.
-// 30s 미만 trip (R2 forward skip)에도 device-local 보존 — 사용자 자가 진단용.
+// #2284 — args.firedAlarmLog optional 기본값 helper. build/suffix 양쪽이 공유해 동일 branch를
+// 재사용 — build()가 omitIfEmpty 판정 이전에 항상 호출되므로 undefined/defined 두 branch
+// 모두 이 한 곳에서 커버된다(suffix는 body 비었을 때 호출 자체가 안 됨, buildDumpText 참고).
+function getFiredEntries(args: BuildDumpArgs): readonly FiredAlarmLogEntry[] {
+  return args.firedAlarmLog ?? [];
+}
+
+// #1626 — V4 발사 시점 dump. baseline 측정 fidelity 향상:
+// backend `/admin/alarm-log-stats` 호출 없이 device DebugModal에서 발사 시점 즉시 확인.
+// #2284 — alarmLog(200-cap, 모든 outcome 혼합) 파생값 대신 독립 fired-only 버퍼를 SSoT로
+// 사용. rotate 절단(2026-08-11 덤프 evidence)으로 오래된 fired 기록이 사라지던 회귀 차단.
 function buildNotificationsFiredSection(args: BuildDumpArgs): string[] {
-  const fired = args.logs.filter(isFired);
-  return [...fired].reverse().map(formatLogLine);
+  return [...getFiredEntries(args)].reverse().map(formatFiredLogLine);
 }
 
 function buildAlarmLogSection(args: BuildDumpArgs): string[] {
@@ -1729,7 +1747,7 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
     title: 'Notifications fired',
     build: buildNotificationsFiredSection,
     omitIfEmpty: true,
-    suffix: (args) => ` (${args.logs.filter(isFired).length})`,
+    suffix: (args) => ` (${getFiredEntries(args).length})`,
   },
   {
     title: 'Alarm log',
@@ -2148,6 +2166,9 @@ function DebugModalInner({
   }, []);
 
   const [logs, setLogs] = useState<AlarmLogEntry[]>([]);
+  // #2284 — fired-only 독립 영속 버퍼 스냅샷. alarmLog(200-cap, 모든 outcome 혼합) rotate와
+  // 무관하게 보존되는 fired count SSoT.
+  const [firedAlarmLog, setFiredAlarmLog] = useState<FiredAlarmLogEntry[]>([]);
   // #1706 — fusion picker tier 별 ring buffer snapshot. alarmLog ring 점령 회귀 차단으로
   // 분리된 채널 (alarmLog와 다른 200 cap). refresh 사이클에 함께 snapshot.
   const [fusionTierLogs, setFusionTierLogs] = useState<readonly FusionTierLogEntry[]>(() =>
@@ -2260,6 +2281,8 @@ function DebugModalInner({
     // #1706 — fusion picker tier 별 ring buffer 동시 snapshot. AsyncStorage 없는 in-memory ring
     // 이라 동기 read. logs와 함께 refresh되어 UI/share dump 정합성 유지.
     setFusionTierLogs(getFusionTierLog());
+    // #2284 — fired-only 독립 버퍼도 동시 refresh. alarmLog와 별도 key라 별도 read 필요.
+    setFiredAlarmLog(await getFiredAlarmLog());
   }, []);
 
   useEffect(() => {
@@ -2273,6 +2296,7 @@ function DebugModalInner({
   const handleClear = useCallback(async () => {
     await Promise.all([
       clearAlarmLog(),
+      clearFiredAlarmLog(),
       clearEstimatorEntries(),
       clearFusionDebugEntries(),
       clearGpsDropEntries(),
@@ -2332,6 +2356,8 @@ function DebugModalInner({
       // #1568 (T8b, Epic ADR-017 #1553) — backend SSoT 권위 mirror.
       backendSsotMirror,
       logs,
+      // #2284 — fired-only 독립 버퍼 entries를 share dump에 포함. alarmLog rotate와 무관 보존.
+      firedAlarmLog,
       lowPowerMode,
       scheduledDump,
       barometerSubsurface,
@@ -2882,7 +2908,7 @@ function DebugModalInner({
             <ScheduledQueueBody dump={scheduledDump} colors={colors} />
           </Section>
 
-          <NotificationsFiredSection logs={logs} colors={colors} />
+          <NotificationsFiredSection firedLog={firedAlarmLog} colors={colors} />
 
           <Section
             title={`Alarm log (${logs.length})`}
@@ -3091,28 +3117,28 @@ function ScheduledQueueBody({
 // #1626 — V4 발사된 notification만 시간순 reverse. baseline 측정 fidelity 향상.
 // fired 0건이면 섹션 자체를 노출하지 않는다 — 사용자 노이즈 최소화 (fired 없으면 Alarm log
 // Section만 보면 충분).
+// #2284 — alarmLog 파생값(rotate 절단 상속) 대신 독립 fired-only 버퍼를 SSoT로 사용.
 function NotificationsFiredSection({
-  logs,
+  firedLog,
   colors,
 }: Readonly<{
-  logs: readonly AlarmLogEntry[];
+  firedLog: readonly FiredAlarmLogEntry[];
   colors: ReturnType<typeof useTheme>['colors'];
 }>) {
-  const fired = logs.filter(isFired);
-  if (fired.length === 0) return null;
+  if (firedLog.length === 0) return null;
   return (
     <Section
-      title={`Notifications fired (${fired.length})`}
+      title={`Notifications fired (${firedLog.length})`}
       colors={colors}
       testID="notifications-fired-section"
     >
-      {[...fired].reverse().map((entry, idx) => (
+      {[...firedLog].reverse().map((entry, idx) => (
         <MonoEntry
           key={`fired-${entry.ts}-${idx}`}
           testID="debug-notifications-fired-entry"
           colors={colors}
         >
-          {formatLogLine(entry)}
+          {formatFiredLogLine(entry)}
         </MonoEntry>
       ))}
     </Section>

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -21,6 +21,12 @@ const mockGetAlarmLog = jest.fn();
 const mockClearAlarmLog = jest.fn();
 // #1706 — fusion picker tier 별 ring buffer mock. alarmLog ring과 분리된 채널.
 const mockGetFusionTierLog = jest.fn();
+// #2284 — fired-only 독립 버퍼 mock. alarmLog rotate와 분리된 별도 채널.
+// 기본 resolved value를 선언 시점에 고정 — 파일 전체에 수십 개의 독립 describe/beforeEach가
+// 있고 각각 jest.clearAllMocks()만 호출(mockReset은 안 함)하므로, 여기서 설정한 구현체는
+// clearAllMocks 이후에도 유지된다. 개별 describe가 매번 명시적으로 재설정할 필요 없음.
+const mockGetFiredAlarmLog = jest.fn().mockResolvedValue([]);
+const mockClearFiredAlarmLog = jest.fn().mockResolvedValue(undefined);
 const mockUseBarometer = jest.fn();
 const mockUseLowPowerMode = jest.fn();
 // #1235 (D9 wire) — DebugModal이 destinationStore + tripStartStorage SSOT로 trip props 도출.
@@ -73,6 +79,9 @@ jest.mock('../../../alarm/utils/alarmLog', () => {
     clearAlarmLog: () => mockClearAlarmLog(),
     // #1706 — 별 ring buffer reader mock. test가 명시적으로 entries 주입.
     getFusionTierLog: () => mockGetFusionTierLog(),
+    // #2284 — fired-only 독립 버퍼 mock. alarmLog와 분리된 채널이라 별도 mock 필요.
+    getFiredAlarmLog: () => mockGetFiredAlarmLog(),
+    clearFiredAlarmLog: () => mockClearFiredAlarmLog(),
   };
 });
 
@@ -212,6 +221,9 @@ const setupHookDefaults = () => {
   mockClearAlarmLog.mockResolvedValue(undefined);
   // #1706 — 별 ring 기본 빈 배열. fusion-picker-tier 테스트는 명시 주입.
   mockGetFusionTierLog.mockReturnValue([]);
+  // #2284 — fired-only 독립 버퍼 기본 빈 배열. 개별 테스트가 명시 주입.
+  mockGetFiredAlarmLog.mockResolvedValue([]);
+  mockClearFiredAlarmLog.mockResolvedValue(undefined);
   mockDumpScheduledNotifications.mockResolvedValue([]);
   // #1215 (D9) — 기본은 subsurface=false (지상).
   mockUseBarometer.mockReturnValue({ subsurface: false, stop: undefined });
@@ -390,12 +402,11 @@ describe('DebugModal', () => {
     expect(screen.queryByTestId('debug-log-source-counts')).toBeNull();
   });
 
-  it('Notifications fired 섹션은 outcome=fired만 시간순 reverse로 표시한다 (#1626)', async () => {
-    mockGetAlarmLog.mockResolvedValue([
-      { ts: 1, source: 'fg', outcome: 'fired', stationName: '강남' },
-      { ts: 2, source: 'boarding-prompt', outcome: 'suppressed', reason: 'cooldown' },
-      { ts: 3, source: 'silent-push-received', outcome: 'received' },
-      { ts: 4, source: 'bg-scheduled', outcome: 'fired', stationName: '면목' },
+  it('Notifications fired 섹션은 fired-only 독립 버퍼를 시간순 reverse로 표시한다 (#1626, #2284)', async () => {
+    // #2284 — alarmLog 파생값 대신 독립 fired-only 버퍼(getFiredAlarmLog)가 SSoT.
+    mockGetFiredAlarmLog.mockResolvedValue([
+      { ts: 1, kind: 'destination', station: '강남', line: '2', channel: 'fg' },
+      { ts: 4, kind: 'transfer', station: '면목', line: '7', channel: 'bg-scheduled' },
     ]);
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     expect(await screen.findByText('Notifications fired (2)')).toBeTruthy();
@@ -405,13 +416,30 @@ describe('DebugModal', () => {
     expect(entries[1].props.children).toContain('강남');
   });
 
-  it('fired 0건이면 Notifications fired 섹션 자체를 렌더링하지 않는다 (#1626)', async () => {
+  it('fired 0건이면 Notifications fired 섹션 자체를 렌더링하지 않는다 (#1626, #2284)', async () => {
     mockGetAlarmLog.mockResolvedValue([
       { ts: 1, source: 'fg', outcome: 'suppressed', reason: 'distance-gate' },
     ]);
+    mockGetFiredAlarmLog.mockResolvedValue([]);
     renderWithTheme(<DebugModal onClose={jest.fn()} />);
     await screen.findByText('Alarm log (1)');
     expect(screen.queryByTestId('notifications-fired-section')).toBeNull();
+  });
+
+  it('#2284 — alarmLog가 rotate로 fired 기록을 잃어도 fired-only 버퍼는 독립적으로 count를 유지한다', async () => {
+    // alarmLog 쪽엔 fired 엔트리가 전혀 없어도(rotate로 밀려난 상태 시뮬레이션),
+    // 독립 버퍼에 남아있으면 그대로 노출돼야 한다 — 2026-08-11 07:38:28 이전 fired 소실 회귀 재현.
+    mockGetAlarmLog.mockResolvedValue([
+      { ts: 100, source: 'fg', outcome: 'suppressed', reason: 'gate-age' },
+    ]);
+    mockGetFiredAlarmLog.mockResolvedValue([
+      { ts: 1, kind: 'station-passed', station: '용마산', line: '7', channel: 'fg' },
+    ]);
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    expect(await screen.findByText('Notifications fired (1)')).toBeTruthy();
+    expect(screen.getByTestId('debug-notifications-fired-entry').props.children).toContain(
+      '용마산',
+    );
   });
 
   it('userLocation이 null이면 "no location"을 표시한다', () => {
@@ -612,7 +640,7 @@ describe('DebugModal', () => {
     await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalledTimes(2));
   });
 
-  it('Clear all logs 버튼이 6개 buffer를 모두 비우고 재조회한다', async () => {
+  it('Clear all logs 버튼이 7개 buffer를 모두 비우고 재조회한다 (#2284 fired-only 버퍼 포함)', async () => {
     const estimatorMod = jest.requireActual('../../../route/utils/estimatorDebugBuffer') as typeof import('../../../route/utils/estimatorDebugBuffer');
     const fusionMod = jest.requireActual('../../../nearest-station/utils/fusionDebugBuffer') as typeof import('../../../nearest-station/utils/fusionDebugBuffer');
     const gpsDropMod = jest.requireActual('../../../nearest-station/utils/gpsDropBuffer') as typeof import('../../../nearest-station/utils/gpsDropBuffer');
@@ -632,6 +660,7 @@ describe('DebugModal', () => {
     });
 
     expect(mockClearAlarmLog).toHaveBeenCalledTimes(1);
+    expect(mockClearFiredAlarmLog).toHaveBeenCalledTimes(1);
     expect(spyEstimator).toHaveBeenCalledTimes(1);
     expect(spyFusion).toHaveBeenCalledTimes(1);
     expect(spyGpsDrop).toHaveBeenCalledTimes(1);
@@ -3383,6 +3412,32 @@ describe('DebugModal share SSOT (#1346)', () => {
     expect(dump).toContain('## Fusion Tier (1h)');
     // suppressed reason 없으면 Gates 헤더 자체 생략(omitIfEmpty=true).
     expect(dump).not.toContain('## Gates');
+  });
+
+  // #2284 — fired-only 독립 버퍼 share dump wire. alarmLog 파생값 대신 firedAlarmLog가 SSoT.
+  it('Notifications fired: firedAlarmLog 미전달/빈 배열이면 섹션 자체를 생략(omitIfEmpty)', () => {
+    const dump = __test__.buildDumpText(makeSsotArgs());
+    expect(dump).not.toContain('## Notifications fired');
+  });
+
+  it('Notifications fired: firedAlarmLog entries를 시간순 reverse로 (ts channel kind station (line)) 포맷 출력', () => {
+    const dump = __test__.buildDumpText(
+      makeSsotArgs({
+        firedAlarmLog: [
+          { ts: 1, kind: 'destination', station: '강남', line: '2', channel: 'fg' },
+          { ts: 2, kind: 'unknown', station: 'unknown', line: null, channel: 'silent-push-fired' },
+        ],
+      }),
+    );
+    expect(dump).toContain('## Notifications fired (2)');
+    const sectionStart = dump.indexOf('## Notifications fired');
+    const sectionEnd = dump.indexOf('## Alarm log');
+    const section = dump.slice(sectionStart, sectionEnd);
+    // 역순(최신 ts=2가 먼저) + line=null은 UNKNOWN_LABEL('—')로 표기.
+    const line2Idx = section.indexOf('silent-push-fired unknown unknown (—)');
+    const line1Idx = section.indexOf('fg destination 강남 (2)');
+    expect(line2Idx).toBeGreaterThan(-1);
+    expect(line1Idx).toBeGreaterThan(line2Idx);
   });
 
   it('Fusion log 섹션이 Alarm log 섹션 *다음*에 위치한다', () => {

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -18,6 +18,9 @@ export const ACCESSIBILITY_MODE_KEY = 'subway-now:accessibility-mode';
 export const SLEEP_MODE_GUIDE_SHOWN_KEY = 'subway-now:sleep-mode-guide-shown';
 export const LOCALE_PREFERENCE_KEY = 'subway-now:locale-preference';
 export const ALARM_LOG_KEY = 'subway-now:alarm-log';
+// #2284 — fired-only 독립 영속 링버퍼. alarmLog(200-cap, 모든 outcome 혼합)와 분리된 key라
+// alarmLog rotate(다른 outcome 엔트리 과다 유입)로 fired 기록이 절단되지 않는다.
+export const FIRED_ALARM_LOG_KEY = 'subway-now:fired-alarm-log';
 export const APNS_TOKEN_KEY = 'subway-now:apns-token';
 // #1897 (RC-5) — 마지막으로 backend가 confirm한 APNs env(sandbox/production).
 // register 응답에서 backend가 `existing.apnsEnv ?? incoming.apnsEnv`로 결정한 KV 값을 echo →


### PR DESCRIPTION
Closes #2284

## 배경

2026-08-11 덤프에서 "Notifications fired (2)"로 표시됐으나 실제로는 07:31 역 통과 알림 등이 추가 발사됨 — alarmLog 200-cap rotate로 07:38:28 이전 fired 기록이 소실됐다. `DebugModal.tsx`의 "Notifications fired" 섹션이 `logs.filter(outcome==='fired')` **파생값**이라 같은 절단을 그대로 상속 → "실알람 0건" 오판의 직접 원인이었다.

## 변경

- `alarmLog.ts`: `FiredAlarmLogEntry { ts, kind, station, line, channel }` + 독립 AsyncStorage key(`FIRED_ALARM_LOG_KEY`, 100-cap FIFO) 신설.
- `doFlushOnce`(alarmLog의 기존 batched-write mutex 보호 구간) 안에서 같은 flush 사이클로 `outcome==='fired' && FIRED_ALARM_SOURCES[source]===true`(= `countFiredAlarms`가 쓰는 것과 동일 "실제 사용자 노출" SSoT)인 엔트리만 골라 독립 버퍼에 적재. alarmLog 200-cap rotate와 완전히 분리된 key라 무관하게 보존.
- `line`은 `findLineByStationName(stationName)` 데이터 조회로 채움(동명이역 ambiguous 시 null).
- `getFiredAlarmLog` / `clearFiredAlarmLog` export. `DebugModal.tsx`의 "Notifications fired" UI 섹션 + share dump를 이 독립 버퍼 SSoT로 전환(기존 `logs.filter(...)` 파생값 제거). "Clear all logs"에도 wiring.
- `storageKeys.ts`: `FIRED_ALARM_LOG_KEY` 추가.

## Wire matrix — fired 판정 경로 전수

`appendAlarmLog`가 모든 발사/억제 이벤트의 **단일 진입점**이라, 이 PR은 개별 발사 경로를 하나씩 wiring하지 않고 `appendAlarmLog → doFlushOnce`에 1곳만 hook했다. 아래 표는 그 단일 진입점을 거치는 실제 "사용자 노출 발사"(`FIRED_ALARM_SOURCES=true`) 경로 전수와, 신규 독립 버퍼 적재 여부다.

| source | 호출 경로 | FIRED_ALARM_SOURCES | 독립 버퍼 적재 |
| --- | --- | --- | --- |
| `fg` | `useStationAlarm.ts:984` `logFiredAlarm('fg', ...)`, `stationPipeline.ts:417` `logFiredAlarm(source, ...)` | true | O |
| `fg-arvlcd` | `useStationAlarm.ts:1505/1528` (A2 fast path arvlCd) | true | O |
| `bg` | `stationPipeline.ts:417` (`logFiredAlarm(source, ...)`, source가 bg인 BG 경로) | true | O |
| `fg-evaluated` | `stationPipeline.ts:417` (FG evaluated 분기) | true | O |
| `bg-scheduled` | `logScheduledAlarm` (사전예약 stamp — 현재 프로덕션 호출자 없음, export만 유지) | true | O(호출 시) |
| `silent-push-fired` | 없음(#2064 이후 device 로컬 발사는 구조적 no-op — 죽은 경로, enum/FIRED_ALARM_SOURCES만 하위호환 유지) | true | O(호출 시, 현재 미발생) |
| `alert-fallback-fired` | `logAlertFallbackFired` (현재 프로덕션 호출자 없음, export만 유지) | true | O(호출 시) |
| `companion` | `silentPushTask.ts:1564` `logCompanionAlarmFired(...)` | true | O |
| `push-contract-skew` (station-fallback-fired) | `silentPushTask.ts:1295` `logPushContractKindSkew(...)` — station-shaped fallback만 outcome=fired, control-like은 suppressed로 자동 제외 | true(outcome=fired만) | O |
| `station-passed`(kind, 여러 source) | `useStationAlarm.ts:271` `logFiredStationPassed(source, ...)` | source에 따름(위 표 포함) | O |
| `lifecycle-backstop` (전 site: `tripDeathPullBackstop.ts`, `useDeviceSelfEnd.ts`, `useStateRehydration.ts`) | 측정/진단 stamp, 실제 사용자 알림 아님 | **false** | X (의도적 제외 — `countFiredAlarms`와 동일 SSoT) |
| `boarding-prompt` / `lockless-trip-end` / `leg-transition` 등 metadata source | 각 helper | **false** | X (의도적 제외) |

신규 발사 경로가 추가돼도 `appendAlarmLog`를 거치는 한 자동으로 이 hook을 통과한다 — 개별 호출부 wiring 누락 리스크 없음.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — DebugModal "Notifications fired" 섹션(UI) + share dump `## Notifications fired (N)` 섹션에서 즉시 시각화. 콜드런치 재현 없이도 다음 Refresh/dump에서 확인 가능.
3. **의존 PR** — N/A (device 전용 변경, backend/infra 의존 없음).
4. **측정 plan** — 다음 실기기 trip에서 share dump의 "Notifications fired" 목록과 사용자 실제 수신 알림(배너/Live Activity) 개수를 대조. alarmLog 200-cap rotate가 발생하는 긴 trip(다수 suppressed burst 포함)에서도 fired count가 절단 없이 유지되는지 확인.
5. **Device verify** — 필요. 실기기에서 (a) 짧은 trip으로 fired 1~2건 발사 후 dump에 정확히 반영되는지, (b) 긴 trip에서 alarmLog가 rotate된 뒤에도 앞선 fired 기록이 "Notifications fired" 섹션에 남아있는지 확인.

## 테스트

- `alarmLog.test.ts`: genuine-source 필터링(FIRED_ALARM_SOURCES), metadata source 제외, FIFO rotate(100-cap), 콜드런치 복원, 손상 JSON, write 실패 격리(alarmLog write 실패해도 독립 버퍼 write는 별도 시도 + 역방향), clear, **200-cap rotate 회귀 재현 테스트(2026-08-11 evidence 직접 대응)**.
- `DebugModal.test.tsx`: UI 섹션 fired-only 버퍼 SSoT 전환, alarmLog에서 rotate로 fired가 사라져도 독립 버퍼는 유지되는 회귀 테스트, share dump(`buildDumpText`) SSOT 섹션 omitIfEmpty/포맷 검증, Clear all logs가 7개 buffer(신규 포함)를 모두 비우는지 검증.
- `npm test` coverage 100% / `npm run type-check` pass / `npm run lint:orphan` pass.


---

## 리뷰 P1 반영 (ebfa80d6) — wire matrix 정정 + 누락 2채널 wire

이전 본문의 "appendAlarmLog = 단일 진입점" 주장은 부정확했음 (리뷰 지적). 실제 알림 채널 전수 matrix:

| 채널 | 발사 방식 | 기록 시점/의미 | fired 버퍼 반영 |
|---|---|---|---|
| station/transfer/destination 알람 (fg/bg) | 즉시 로컬 | logFiredAlarm — 발사 확정 | ✅ (기존) |
| boarding/hop-end prompt | backend push | received/responded 로그 | 해당 없음 (backend fire, #2281이 backend 집계) |
| **막차 임박 알람** (`lastTrainAlarm.ts`) | `trigger: null` 즉시 발사 | **신규 `last-train-alarm` source, fired** — 호출=노출 확정이라 fired 정당 | ✅ **이번 커밋 wire** |
| **취침 안전망** (`safetyNetScheduler.ts`) | OS DATE trigger 사전예약 (취소 가능) | **`logScheduledAlarm` 예약 stamp 복원** (#2089 리팩터에서 유실됐던 것) — 기존 bg-scheduled 관례대로 `outcome:'fired'`로 기록됨(예약 성공 시점) | ✅ fired 버퍼에 포함됨. **known limitation**: 예약 후 취소/미발사돼도 fired로 남는 과대집계 가능(기존 bg-scheduled 관례의 pre-existing 특성, 저빈도 백업 채널이라 영향 소) — 실발사 여부는 OS 소관 |
| LA 갱신 | backend LA push | 해당 없음 (알림 아님) | 해당 없음 |
| 'fg' fired 의미론 (#2067) | — | "발사 의도 확정" (실노출은 backend push) — 기존 갭, 스코프 밖 | 비고 |

검증: 관련 3개 스위트 344 tests + 전체 스위트 438 suites/9409 tests 100% (메인 세션 실행), type-check/lint:orphan pass.
