### PR TITLE
fix(#2282): hop-end 하차 프롬프트 DISEMBARK 전용 카테고리 + 버튼 i18n

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -26,6 +26,7 @@ import { stopVibration } from '../src/features/alarm/utils/alarmSound';
 import {
   setupAlarmCategory,
   setupBoardingPromptCategory,
+  setupDisembarkPromptCategory,
   setupTripEndedCategory,
 } from '../src/features/alarm/utils/notificationCategory';
 import { useBoardingPromptResponder } from '../src/features/alarm/hooks/useBoardingPromptResponder';
@@ -66,6 +67,10 @@ registerSilentPushTask().catch((e) => layoutLogger.warn('silent push task 등록
 // #819 — "탑승했냐?" 푸시의 BOARDING_PROMPT category 등록. 액션 [탑승]/[미탑승]을 노출.
 setupBoardingPromptCategory().catch((e) =>
   layoutLogger.warn('boarding-prompt category 등록 실패(#819):', e),
+);
+// #2282 — hop-end "하차했냐?" 푸시의 DISEMBARK_PROMPT category 등록. 액션 [하차했어요]/[아직이요]를 노출.
+setupDisembarkPromptCategory().catch((e) =>
+  layoutLogger.warn('disembark-prompt category 등록 실패(#2282):', e),
 );
 // #1798 P2 — transfer/destination 알람 ALARM_CATEGORY 등록. 액션 [확인]/[trip 종료]을 노출.
 setupAlarmCategory().catch((e) =>

--- a/backend/alarm-worker/src/__tests__/apns.test.ts
+++ b/backend/alarm-worker/src/__tests__/apns.test.ts
@@ -2,6 +2,7 @@ import { generateKeyPair, exportPKCS8 } from 'jose';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   BOARDING_PROMPT_CATEGORY,
+  DISEMBARK_PROMPT_CATEGORY,
   buildApnsJwt,
   buildSilentPushData,
   resetApnsJwtCache,
@@ -1355,6 +1356,30 @@ describe('sendBoardingPromptPush (#819)', () => {
     // 기존 필드는 그대로 유지
     expect(body.data.kind).toBe('boarding-prompt');
     expect(body.data.originStation).toBe('성수');
+  });
+
+  // #2282 — hop-end(disembark) 질문은 BOARDING_PROMPT 재사용이 아니라 전용 category로 발사돼야
+  // iOS가 질문에 맞는 버튼([하차했어요]/[아직이요])을 노출한다.
+  it('hopEndKind=disembark 시 DISEMBARK_PROMPT category로 발사 (#2282)', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    await sendBoardingPromptPush({
+      deviceToken: 'device-hex',
+      pushId: 'p-hop-end-cat',
+      title: '성수에서 하차하셨나요?',
+      body: '2호선 성수에서 내려주세요.',
+      originStation: '성수',
+      line: '2',
+      tripToken: 'trip-hop',
+      sentAt: 0,
+      hopEndKind: 'disembark',
+      config: makeConfig(),
+      host: TEST_HOST,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.aps.category).toBe(DISEMBARK_PROMPT_CATEGORY);
+    expect(body.aps.category).not.toBe(BOARDING_PROMPT_CATEGORY);
   });
 
   it('hopEndKind 미지정 시 payload 에서 hop-end 필드 자연 누락 (#2034)', async () => {

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -1,6 +1,6 @@
 import { generateKeyPair, exportPKCS8 } from 'jose';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { resetApnsJwtCache, type ApnsConfig } from '../apns';
+import { DISEMBARK_PROMPT_CATEGORY, resetApnsJwtCache, type ApnsConfig } from '../apns';
 import { computeNextRetryAt, isRetryableApnsError } from '../apnsHost';
 import { DRIFT_WARNING_THRESHOLD_KMH, R_LOW, readKalmanState, type KalmanState } from '../kalmanFilter';
 import type { WindowedMetrics } from '../positionSeries';
@@ -10986,6 +10986,8 @@ describe('maybeFireHopEndPrompt (#2034)', () => {
     expect(body.data.hopEndKind).toBe('disembark');
     expect(body.data.nextLine).toBe('K');
     expect(body.data.nextStation).toBe('왕십리');
+    // #2282 — hop-end fire는 BOARDING_PROMPT가 아닌 전용 DISEMBARK_PROMPT category로 나가야 한다.
+    expect(body.aps.category).toBe(DISEMBARK_PROMPT_CATEGORY);
   });
 
   it('promptState.fired=true → blocked 카운터 증가 + push 미발사', async () => {

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -36,6 +36,14 @@ import {
 export const BOARDING_PROMPT_CATEGORY = 'BOARDING_PROMPT';
 
 /**
+ * #2282 — hop-end (환승역 하차) 전용 UNNotificationCategory 식별자. 승차 질문과 버튼 의미가
+ * 달라("하차했어요"/"아직이요") BOARDING_PROMPT 재사용 시 iOS category-고정 버튼 제약으로
+ * 버튼 텍스트가 질문과 불일치했다. `sendBoardingPromptPush`가 `hopEndKind: 'disembark'`일 때
+ * 이 category로 발사한다. 클라이언트는 `setupDisembarkPromptCategory`로 동일 식별자를 등록.
+ */
+export const DISEMBARK_PROMPT_CATEGORY = 'DISEMBARK_PROMPT';
+
+/**
  * APNs JWT는 1시간 이내 재사용 가능. Worker 인스턴스 메모리에 캐시한다.
  * JWT는 host와 독립적(keyId/teamId 만으로 서명)이므로 self-heal에서
  * sandbox↔production host를 바꿔도 동일 JWT를 재사용한다.
@@ -908,7 +916,11 @@ export async function sendBoardingPromptPush(
         ...(options.subtitle !== undefined ? { subtitle: options.subtitle } : {}),
       },
       sound: 'default',
-      category: BOARDING_PROMPT_CATEGORY,
+      // #2282 — hop-end(disembark) 질문은 승차 질문과 버튼 의미가 달라 전용 category로 분기.
+      category:
+        options.hopEndKind === 'disembark'
+          ? DISEMBARK_PROMPT_CATEGORY
+          : BOARDING_PROMPT_CATEGORY,
       // #2069 리뷰 P1-1 — B8(로컬 timeSensitive) 제거로 단일 채널이 된 원격 prompt가
       // Focus/DND/Sleep Focus를 관통하도록 time-sensitive를 병기한다. prompt 응답은
       // 사용자 확정 flow의 chain 전제라 도달성이 최우선 (결정 3-B와 동일 근거).

--- a/src/features/alarm/hooks/__tests__/useBoardingPromptDisplayLogger.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptDisplayLogger.test.ts
@@ -11,7 +11,7 @@ import {
   markBoardingPromptDisplayed,
   __resetBoardingPromptDisplayedDedup,
 } from '../useBoardingPromptDisplayLogger';
-import { BOARDING_PROMPT_CATEGORY } from '../../utils/notificationCategory';
+import { BOARDING_PROMPT_CATEGORY, DISEMBARK_PROMPT_CATEGORY } from '../../utils/notificationCategory';
 
 jest.mock('expo-notifications', () => ({
   addNotificationReceivedListener: jest.fn(),
@@ -123,6 +123,15 @@ describe('useBoardingPromptDisplayLogger (#1385 / #1419)', () => {
     registeredHandler!(makeNotification({ identifier: 'n-1' }));
     registeredHandler!(makeNotification({ identifier: 'n-2' }));
     expect(logBoardingPromptFired).toHaveBeenCalledTimes(2);
+  });
+
+  // #2282 — hop-end 는 DISEMBARK_PROMPT_CATEGORY로 분리 발사되므로 fired 적재도 인정해야 한다.
+  it('DISEMBARK_PROMPT category notification 수신 시에도 logBoardingPromptFired 호출', () => {
+    renderHook(() => useBoardingPromptDisplayLogger());
+    registeredHandler!(
+      makeNotification({ identifier: 'n-disembark', categoryIdentifier: DISEMBARK_PROMPT_CATEGORY }),
+    );
+    expect(logBoardingPromptFired).toHaveBeenCalledTimes(1);
   });
 
   it('다른 categoryIdentifier → no-op', () => {

--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -1088,15 +1088,16 @@ describe('handleResponse — #2034 hop-end', () => {
     );
   });
 
-  // #2282 RED — 구 BOARDING_PROMPT_ACTION_BOARDED 식별자는 더 이상 hop-end 확정으로 인식되지
-  // 않는다(DISEMBARK 전용 식별자로 분리). $default(배너 탭)만 이 identifier 없이도 confirm.
-  it('구 BOARDING_PROMPT_ACTION_BOARDED 는 하차 확정으로 인식되지 않는다 (dismiss path)', async () => {
+  // #2282 리뷰 P1 — 구 backend(DISEMBARK 카테고리 배포 전)는 hop-end를 BOARDING_PROMPT
+  // 카테고리 + 구 BOARDED 식별자로 쏜다. payload.hopEndKind가 이미 hop-end로 분류하므로
+  // 과도기 호환으로 구 식별자도 하차 확정으로 인식해야 한다(배포 순서 종속 회귀 차단).
+  it('구 BOARDING_PROMPT_ACTION_BOARDED 도 하차 확정으로 인식된다 (과도기 호환)', async () => {
     await handleResponse(
       BOARDING_PROMPT_ACTION_BOARDED,
       HOP_END_PAYLOAD,
       makeHandleResponseDeps(),
     );
-    expect(releaseLockMock).not.toHaveBeenCalled();
-    expect(positionUpload.dismissBoardingPrompt).toHaveBeenCalledWith('tok-hop');
+    expect(releaseLockMock).toHaveBeenCalled();
+    expect(positionUpload.dismissBoardingPrompt).not.toHaveBeenCalled();
   });
 });

--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -15,6 +15,8 @@ import {
 import {
   BOARDING_PROMPT_ACTION_BOARDED,
   BOARDING_PROMPT_ACTION_NOT_BOARDED,
+  DISEMBARK_ACTION_DISEMBARKED,
+  DISEMBARK_ACTION_NOT_YET,
 } from '../../utils/notificationCategory';
 import * as positionUpload from '../../../nearest-station/api/positionUpload';
 import { renderHook } from '@testing-library/react-native';
@@ -935,9 +937,11 @@ describe('handleResponse — #2034 hop-end', () => {
     expect(r?.hopEndKind).toBeUndefined();
   });
 
-  it('[하차함] (BOARDED action) → releaseLock 호출 + tryAutoLock 진입 X + logBoardingPromptResponded(boarded)', async () => {
+  // #2282 — hop-end 는 DISEMBARK_PROMPT category(DISEMBARK_ACTION_DISEMBARKED/NOT_YET)로 발사되므로
+  // handleHopEndResponse 는 이 식별자를 [하차함]으로 인식해야 한다.
+  it('[하차함] (DISEMBARKED action) → releaseLock 호출 + tryAutoLock 진입 X + logBoardingPromptResponded(boarded)', async () => {
     await handleResponse(
-      BOARDING_PROMPT_ACTION_BOARDED,
+      DISEMBARK_ACTION_DISEMBARKED,
       HOP_END_PAYLOAD,
       makeHandleResponseDeps(),
     );
@@ -950,9 +954,9 @@ describe('handleResponse — #2034 hop-end', () => {
     expect(positionUpload.dismissBoardingPrompt).not.toHaveBeenCalled();
   });
 
-  it('[아직] (NOT_BOARDED action) → dismissBoardingPrompt POST + logBoardingPromptResponded(dismissed)', async () => {
+  it('[아직] (NOT_YET action) → dismissBoardingPrompt POST + logBoardingPromptResponded(dismissed)', async () => {
     await handleResponse(
-      BOARDING_PROMPT_ACTION_NOT_BOARDED,
+      DISEMBARK_ACTION_NOT_YET,
       HOP_END_PAYLOAD,
       makeHandleResponseDeps(),
     );
@@ -991,9 +995,9 @@ describe('handleResponse — #2034 hop-end', () => {
     nextLine: '2',
   };
 
-  it('[하차함] (BOARDED action) + 유효한 nextLine → useLegAdvanceStore.stampLegAdvance(nextLine) 호출', async () => {
+  it('[하차함] (DISEMBARKED action) + 유효한 nextLine → useLegAdvanceStore.stampLegAdvance(nextLine) 호출', async () => {
     await handleResponse(
-      BOARDING_PROMPT_ACTION_BOARDED,
+      DISEMBARK_ACTION_DISEMBARKED,
       HOP_END_PAYLOAD_VALID_NEXT_LINE,
       makeHandleResponseDeps(),
     );
@@ -1001,18 +1005,18 @@ describe('handleResponse — #2034 hop-end', () => {
     expect(stampLegAdvanceMock).toHaveBeenCalledWith('2');
   });
 
-  it('[하차함] (BOARDED action) + 유효하지 않은 nextLine("K") → stampLegAdvance 호출 안 함 (기존 동작 유지)', async () => {
+  it('[하차함] (DISEMBARKED action) + 유효하지 않은 nextLine("K") → stampLegAdvance 호출 안 함 (기존 동작 유지)', async () => {
     await handleResponse(
-      BOARDING_PROMPT_ACTION_BOARDED,
+      DISEMBARK_ACTION_DISEMBARKED,
       HOP_END_PAYLOAD,
       makeHandleResponseDeps(),
     );
     expect(stampLegAdvanceMock).not.toHaveBeenCalled();
   });
 
-  it('[아직] (NOT_BOARDED action) → stampLegAdvance 호출 안 함', async () => {
+  it('[아직] (NOT_YET action) → stampLegAdvance 호출 안 함', async () => {
     await handleResponse(
-      BOARDING_PROMPT_ACTION_NOT_BOARDED,
+      DISEMBARK_ACTION_NOT_YET,
       HOP_END_PAYLOAD_VALID_NEXT_LINE,
       makeHandleResponseDeps(),
     );
@@ -1021,20 +1025,20 @@ describe('handleResponse — #2034 hop-end', () => {
 
   it('breadcrumb "boarding_prompt_interactive_tap" 에 hopEndKind=disembark 스탬프', async () => {
     await handleResponse(
-      BOARDING_PROMPT_ACTION_BOARDED,
+      DISEMBARK_ACTION_DISEMBARKED,
       HOP_END_PAYLOAD,
       makeHandleResponseDeps(),
     );
     expect(addDomainBreadcrumb).toHaveBeenCalledWith(
       'boarding',
       'boarding_prompt_interactive_tap',
-      { action: BOARDING_PROMPT_ACTION_BOARDED, line: '2', hopEndKind: 'disembark' },
+      { action: DISEMBARK_ACTION_DISEMBARKED, line: '2', hopEndKind: 'disembark' },
     );
   });
 
   it('breadcrumb "hop_end_prompt_confirmed" ([하차함] 시)', async () => {
     await handleResponse(
-      BOARDING_PROMPT_ACTION_BOARDED,
+      DISEMBARK_ACTION_DISEMBARKED,
       HOP_END_PAYLOAD,
       makeHandleResponseDeps(),
     );
@@ -1047,7 +1051,7 @@ describe('handleResponse — #2034 hop-end', () => {
 
   it('breadcrumb "hop_end_prompt_dismissed" ([아직] 시)', async () => {
     await handleResponse(
-      BOARDING_PROMPT_ACTION_NOT_BOARDED,
+      DISEMBARK_ACTION_NOT_YET,
       HOP_END_PAYLOAD,
       makeHandleResponseDeps(),
     );
@@ -1062,7 +1066,7 @@ describe('handleResponse — #2034 hop-end', () => {
     releaseLockMock.mockImplementationOnce(() => Promise.reject(new Error('release failed')));
     await expect(
       handleResponse(
-        BOARDING_PROMPT_ACTION_BOARDED,
+        DISEMBARK_ACTION_DISEMBARKED,
         HOP_END_PAYLOAD,
         makeHandleResponseDeps(),
       ),
@@ -1073,7 +1077,7 @@ describe('handleResponse — #2034 hop-end', () => {
   it('nextLine 없음 → breadcrumb 에 nextLine="" 로 stamp (undefined 회피)', async () => {
     const payloadNoNext = { ...HOP_END_PAYLOAD, nextLine: undefined };
     await handleResponse(
-      BOARDING_PROMPT_ACTION_BOARDED,
+      DISEMBARK_ACTION_DISEMBARKED,
       payloadNoNext,
       makeHandleResponseDeps(),
     );
@@ -1082,5 +1086,17 @@ describe('handleResponse — #2034 hop-end', () => {
       'hop_end_prompt_confirmed',
       { line: '2', nextLine: '' },
     );
+  });
+
+  // #2282 RED — 구 BOARDING_PROMPT_ACTION_BOARDED 식별자는 더 이상 hop-end 확정으로 인식되지
+  // 않는다(DISEMBARK 전용 식별자로 분리). $default(배너 탭)만 이 identifier 없이도 confirm.
+  it('구 BOARDING_PROMPT_ACTION_BOARDED 는 하차 확정으로 인식되지 않는다 (dismiss path)', async () => {
+    await handleResponse(
+      BOARDING_PROMPT_ACTION_BOARDED,
+      HOP_END_PAYLOAD,
+      makeHandleResponseDeps(),
+    );
+    expect(releaseLockMock).not.toHaveBeenCalled();
+    expect(positionUpload.dismissBoardingPrompt).toHaveBeenCalledWith('tok-hop');
   });
 });

--- a/src/features/alarm/hooks/useBoardingPromptDisplayLogger.ts
+++ b/src/features/alarm/hooks/useBoardingPromptDisplayLogger.ts
@@ -28,7 +28,7 @@
 import { useEffect } from 'react';
 import { AppState, type AppStateStatus } from 'react-native';
 import * as Notifications from 'expo-notifications';
-import { BOARDING_PROMPT_CATEGORY } from '../utils/notificationCategory';
+import { BOARDING_PROMPT_CATEGORY, DISEMBARK_PROMPT_CATEGORY } from '../utils/notificationCategory';
 import { logBoardingPromptFired } from '../utils/alarmLog';
 import { extractBoardingPromptPayload } from './useBoardingPromptResponder';
 import { createLogger } from '../../../shared/utils/logger';
@@ -74,7 +74,12 @@ function tryLogDisplayed(notification: Notifications.Notification): void {
   try {
     const request = notification.request;
     const content = request.content;
-    if (content.categoryIdentifier !== BOARDING_PROMPT_CATEGORY) return;
+    // #2282 — hop-end 는 DISEMBARK_PROMPT_CATEGORY로 분리 발사되므로 두 category 모두 displayed 적재.
+    if (
+      content.categoryIdentifier !== BOARDING_PROMPT_CATEGORY &&
+      content.categoryIdentifier !== DISEMBARK_PROMPT_CATEGORY
+    )
+      return;
     const payload = extractBoardingPromptPayload(content.data);
     if (!payload) return;
     const identifier = request.identifier;

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -40,6 +40,8 @@ import {
   BOARDING_PROMPT_ACTION_BOARDED,
   BOARDING_PROMPT_ACTION_NOT_BOARDED,
   BOARDING_PROMPT_CATEGORY,
+  DISEMBARK_ACTION_DISEMBARKED,
+  DISEMBARK_PROMPT_CATEGORY,
 } from '../utils/notificationCategory';
 import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
 import { createLogger } from '../../../shared/utils/logger';
@@ -145,8 +147,10 @@ export function useBoardingPromptResponder(deps: UseBoardingPromptResponderDeps)
       // notification.request.identifier 기준 — FG receive가 먼저 적재했으면 skip.
       const identifier = request.identifier;
       if (typeof identifier === 'string' && identifier.length > 0) {
+        // #2282 — hop-end 는 DISEMBARK_PROMPT_CATEGORY로 분리 발사되므로 fired 적재도 두 category 모두 인정.
         const isBoardingPromptCategory =
-          request.content.categoryIdentifier === BOARDING_PROMPT_CATEGORY;
+          request.content.categoryIdentifier === BOARDING_PROMPT_CATEGORY ||
+          request.content.categoryIdentifier === DISEMBARK_PROMPT_CATEGORY;
         // categoryIdentifier 미수신 OS(예: Android)에서도 payload schema가 일치하면 fired 적재.
         const shouldLog =
           (isBoardingPromptCategory || request.content.categoryIdentifier == null) &&
@@ -248,8 +252,11 @@ async function handleHopEndResponse(
   payload: BoardingPromptPayload,
   deps: HandleDeps,
 ): Promise<void> {
+  // #2282 — hop-end 는 DISEMBARK_PROMPT_CATEGORY의 DISEMBARK_ACTION_DISEMBARKED로 발사되므로
+  // 이 식별자를 [하차함] 확정으로 인식한다. 배너 탭($default)은 category 미등록 구 device를
+  // 포함해 항상 확정으로 처리(기존 동작 유지).
   if (
-    actionIdentifier === BOARDING_PROMPT_ACTION_BOARDED ||
+    actionIdentifier === DISEMBARK_ACTION_DISEMBARKED ||
     actionIdentifier === Notifications.DEFAULT_ACTION_IDENTIFIER
   ) {
     logBoardingPromptResponded({ outcome: 'boarded' });

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -257,6 +257,10 @@ async function handleHopEndResponse(
   // 포함해 항상 확정으로 처리(기존 동작 유지).
   if (
     actionIdentifier === DISEMBARK_ACTION_DISEMBARKED ||
+    // #2282 과도기 호환 — 구 backend(DISEMBARK 카테고리 배포 전)는 hop-end를 BOARDING_PROMPT
+    // 카테고리로 쏘므로 [Boarded] 탭이 이 구 식별자로 도착한다. payload.hopEndKind가 이미
+    // hop-end로 분류했으니 확정으로 인식해도 안전. 신 backend 전면 배포 후 deprecate.
+    actionIdentifier === BOARDING_PROMPT_ACTION_BOARDED ||
     actionIdentifier === Notifications.DEFAULT_ACTION_IDENTIFIER
   ) {
     logBoardingPromptResponded({ outcome: 'boarded' });

--- a/src/features/alarm/utils/__tests__/notificationCategory.test.ts
+++ b/src/features/alarm/utils/__tests__/notificationCategory.test.ts
@@ -1,4 +1,5 @@
 import * as Notifications from 'expo-notifications';
+import i18next from 'i18next';
 import {
   ALARM_ACTION_ACKNOWLEDGE,
   ALARM_ACTION_END_TRIP,
@@ -6,8 +7,12 @@ import {
   BOARDING_PROMPT_ACTION_BOARDED,
   BOARDING_PROMPT_ACTION_NOT_BOARDED,
   BOARDING_PROMPT_CATEGORY,
+  DISEMBARK_ACTION_DISEMBARKED,
+  DISEMBARK_ACTION_NOT_YET,
+  DISEMBARK_PROMPT_CATEGORY,
   setupAlarmCategory,
   setupBoardingPromptCategory,
+  setupDisembarkPromptCategory,
   setupTripEndedCategory,
   TRIP_ENDED_ACTION_NEXT_TRIP,
   TRIP_ENDED_CATEGORY,
@@ -39,11 +44,56 @@ describe('setupBoardingPromptCategory (#819)', () => {
     );
   });
 
+  // #2282 — 버튼 라벨이 영어로 하드코딩돼 한국어 질문에도 "Boarded"/"Not boarded"로 표시되던 결함.
+  it('버튼 라벨이 i18next 번역 키로 로컬라이즈된다 (#2282)', async () => {
+    await setupBoardingPromptCategory();
+    const [, actions] = (Notifications.setNotificationCategoryAsync as jest.Mock).mock
+      .calls[0] as [string, { identifier: string; buttonTitle: string }[]];
+    const boarded = actions.find((a) => a.identifier === BOARDING_PROMPT_ACTION_BOARDED);
+    const notBoarded = actions.find((a) => a.identifier === BOARDING_PROMPT_ACTION_NOT_BOARDED);
+    expect(boarded?.buttonTitle).toBe(i18next.t('notifications.actions.boardingConfirm'));
+    expect(notBoarded?.buttonTitle).toBe(i18next.t('notifications.actions.notYet'));
+    expect(boarded?.buttonTitle).not.toBe('Boarded');
+    expect(notBoarded?.buttonTitle).not.toBe('Not boarded');
+  });
+
   it('Notifications가 throw해도 graceful (no throw)', async () => {
     (Notifications.setNotificationCategoryAsync as jest.Mock).mockRejectedValueOnce(
       new Error('not supported'),
     );
     await expect(setupBoardingPromptCategory()).resolves.toBeUndefined();
+  });
+});
+
+describe('setupDisembarkPromptCategory (#2282)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('DISEMBARK_PROMPT 식별자로 [하차했어요]/[아직이요] 액션 등록', async () => {
+    await setupDisembarkPromptCategory();
+    expect(Notifications.setNotificationCategoryAsync).toHaveBeenCalledWith(
+      DISEMBARK_PROMPT_CATEGORY,
+      expect.arrayContaining([
+        expect.objectContaining({
+          identifier: DISEMBARK_ACTION_DISEMBARKED,
+          buttonTitle: i18next.t('notifications.actions.disembarkConfirm'),
+          options: expect.objectContaining({ opensAppToForeground: true }),
+        }),
+        expect.objectContaining({
+          identifier: DISEMBARK_ACTION_NOT_YET,
+          buttonTitle: i18next.t('notifications.actions.notYet'),
+          options: expect.objectContaining({ opensAppToForeground: false, isDestructive: true }),
+        }),
+      ]),
+    );
+  });
+
+  it('Notifications가 throw해도 graceful (no throw)', async () => {
+    (Notifications.setNotificationCategoryAsync as jest.Mock).mockRejectedValueOnce(
+      new Error('not supported'),
+    );
+    await expect(setupDisembarkPromptCategory()).resolves.toBeUndefined();
   });
 });
 

--- a/src/features/alarm/utils/notificationCategory.ts
+++ b/src/features/alarm/utils/notificationCategory.ts
@@ -1,5 +1,5 @@
 /**
- * iOS UNNotificationCategory 등록 (#819 B 슬라이스, #1798 P2 카테고리 분리).
+ * iOS UNNotificationCategory 등록 (#819 B 슬라이스, #1798 P2 카테고리 분리, #2282 DISEMBARK 분리).
  *
  * APNs alert payload의 `aps.category`가 식별자와 매칭되면 푸시 알림에 우리가 등록한
  * 액션 버튼이 노출된다. 사용자가 액션을 탭하면 `Notifications.addNotificationResponseReceivedListener`가
@@ -7,13 +7,19 @@
  *
  * Android는 expo-notifications가 category를 무시 — graceful no-op.
  *
- * 카테고리 3종:
- *   - BOARDING_PROMPT  : "탑승했냐?" 푸시 (기존)
- *   - ALARM_CATEGORY   : transfer / destination 알람 — "확인" / "trip 종료" (#1798 P2)
+ * 카테고리 4종:
+ *   - BOARDING_PROMPT   : "탑승했냐?" 푸시 (기존)
+ *   - DISEMBARK_PROMPT  : "하차했냐?" (hop-end) 푸시 — BOARDING_PROMPT 재사용 시 iOS category-고정
+ *     버튼 제약으로 질문-버튼 불일치가 발생해 분리 (#2282)
+ *   - ALARM_CATEGORY    : transfer / destination 알람 — "확인" / "trip 종료" (#1798 P2)
  *   - TRIP_ENDED_CATEGORY: trip 종료 알림 — "다음 여정 시작" 딥링크 (#1798 P2)
+ *
+ * 버튼 라벨은 i18next.t()로 로컬라이즈한다(#2282) — 등록 시점(앱 부팅)의 현재 언어로 고정되며
+ * 다른 파일의 `lastTrainAlarm.ts` 등과 동일 패턴(react-i18next 훅이 아닌 `i18next` default import).
  */
 
 import * as Notifications from 'expo-notifications';
+import i18next from 'i18next';
 
 /** APNs payload `aps.category`와 1:1 매칭. backend `BOARDING_PROMPT_CATEGORY`와 동기. */
 export const BOARDING_PROMPT_CATEGORY = 'BOARDING_PROMPT';
@@ -22,6 +28,17 @@ export const BOARDING_PROMPT_CATEGORY = 'BOARDING_PROMPT';
 export const BOARDING_PROMPT_ACTION_BOARDED = 'BOARDING_PROMPT_BOARDED';
 /** [미탑승] 액션 식별자. */
 export const BOARDING_PROMPT_ACTION_NOT_BOARDED = 'BOARDING_PROMPT_NOT_BOARDED';
+
+/**
+ * #2282 — hop-end(환승역 하차) 전용 카테고리. APNs payload `aps.category`와 1:1 매칭.
+ * backend `DISEMBARK_PROMPT_CATEGORY`와 동기.
+ */
+export const DISEMBARK_PROMPT_CATEGORY = 'DISEMBARK_PROMPT';
+
+/** [하차했어요] 액션 식별자. */
+export const DISEMBARK_ACTION_DISEMBARKED = 'DISEMBARK_PROMPT_DISEMBARKED';
+/** [아직이요] 액션 식별자. */
+export const DISEMBARK_ACTION_NOT_YET = 'DISEMBARK_PROMPT_NOT_YET';
 
 /** #1798 P2 — transfer / destination 알람 카테고리. backend `ALARM_CATEGORY`와 동기. */
 export const ALARM_CATEGORY = 'ALARM_CATEGORY';
@@ -45,14 +62,44 @@ export async function setupBoardingPromptCategory(): Promise<void> {
     await Notifications.setNotificationCategoryAsync(BOARDING_PROMPT_CATEGORY, [
       {
         identifier: BOARDING_PROMPT_ACTION_BOARDED,
-        buttonTitle: 'Boarded',
+        buttonTitle: i18next.t('notifications.actions.boardingConfirm'),
         options: {
           opensAppToForeground: true,
         },
       },
       {
         identifier: BOARDING_PROMPT_ACTION_NOT_BOARDED,
-        buttonTitle: 'Not boarded',
+        buttonTitle: i18next.t('notifications.actions.notYet'),
+        options: {
+          // FG로 열지 않음 — 사용자가 푸시만 닫고 silent dismiss POST가 backend로 가게 한다.
+          opensAppToForeground: false,
+          isDestructive: true,
+        },
+      },
+    ]);
+  } catch {
+    // graceful — Android/예외 시 기본 동작으로 폴백.
+  }
+}
+
+/**
+ * #2282 — DISEMBARK_PROMPT category 등록. 앱 부팅 시 1회 호출.
+ * 실패는 graceful — category 미등록 시 알림이 평범한 alert로 표시되지만 사용자가 탭하면
+ * 같은 listener가 default action으로 호출되니 `handleHopEndResponse`는 계속 동작.
+ */
+export async function setupDisembarkPromptCategory(): Promise<void> {
+  try {
+    await Notifications.setNotificationCategoryAsync(DISEMBARK_PROMPT_CATEGORY, [
+      {
+        identifier: DISEMBARK_ACTION_DISEMBARKED,
+        buttonTitle: i18next.t('notifications.actions.disembarkConfirm'),
+        options: {
+          opensAppToForeground: true,
+        },
+      },
+      {
+        identifier: DISEMBARK_ACTION_NOT_YET,
+        buttonTitle: i18next.t('notifications.actions.notYet'),
         options: {
           // FG로 열지 않음 — 사용자가 푸시만 닫고 silent dismiss POST가 backend로 가게 한다.
           opensAppToForeground: false,

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -231,7 +231,10 @@
     "actions": {
       "acknowledge": "OK",
       "endTrip": "End trip",
-      "nextTrip": "Start next trip"
+      "nextTrip": "Start next trip",
+      "boardingConfirm": "Boarded",
+      "disembarkConfirm": "Got off",
+      "notYet": "Not yet"
     }
   },
   "journey": {

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -231,7 +231,10 @@
     "actions": {
       "acknowledge": "確認",
       "endTrip": "trip終了",
-      "nextTrip": "次の旅程を開始"
+      "nextTrip": "次の旅程を開始",
+      "boardingConfirm": "乗車しました",
+      "disembarkConfirm": "降車しました",
+      "notYet": "まだです"
     }
   },
   "journey": {

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -231,7 +231,10 @@
     "actions": {
       "acknowledge": "확인",
       "endTrip": "trip 종료",
-      "nextTrip": "다음 여정 시작"
+      "nextTrip": "다음 여정 시작",
+      "boardingConfirm": "탑승했어요",
+      "disembarkConfirm": "하차했어요",
+      "notYet": "아직이요"
     }
   },
   "journey": {

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -231,7 +231,10 @@
     "actions": {
       "acknowledge": "确认",
       "endTrip": "结束旅程",
-      "nextTrip": "开始下一段旅程"
+      "nextTrip": "开始下一段旅程",
+      "boardingConfirm": "已上车",
+      "disembarkConfirm": "已下车",
+      "notYet": "还没"
     }
   },
   "journey": {


### PR DESCRIPTION
Closes #2282

## 요약
"하차하셨나요?" hop-end 푸시가 승차 질문과 같은 `BOARDING_PROMPT` 카테고리를 재사용해 iOS category-고정 버튼 제약으로 질문-버튼이 불일치하고, 버튼 라벨이 영어로 하드코딩돼 한국어 질문에도 "Boarded"/"Not boarded"가 표시되던 결함 수정.

### 변경
- backend `apns.ts`: `sendBoardingPromptPush`가 `hopEndKind==='disembark'`일 때 신설 `DISEMBARK_PROMPT_CATEGORY`로 발사(기존 `BOARDING_PROMPT_CATEGORY` 분기). 일반 승차 프롬프트는 기존 카테고리 유지(byte-level 호환).
- device `notificationCategory.ts`: `setupDisembarkPromptCategory` 신설([하차했어요]/[아직이요] 액션). `setupBoardingPromptCategory` 버튼도 하드코딩 영어("Boarded"/"Not boarded") 대신 `i18next.t()`로 4언어(ko/en/ja/zh) 로컬라이즈.
- `app/_layout.tsx`: 부팅 시 `setupDisembarkPromptCategory` 등록(기존 카테고리 등록 패턴과 동일).
- `useBoardingPromptResponder.ts`: `handleHopEndResponse`가 새 `DISEMBARK_ACTION_DISEMBARKED` 식별자를 [하차함] 확정으로 인식(구 `BOARDING_PROMPT_ACTION_BOARDED`는 더 이상 hop-end 확정 매칭 안 됨 — 실제로 그 식별자는 hop-end 알림엔 등장하지 않으므로 영향 없음). fired 로깅(`categoryIdentifier` 체크)이 두 카테고리 모두 인정.
- `useBoardingPromptDisplayLogger.ts`: displayed 적재도 두 카테고리 모두 인정.
- `src/shared/i18n/locales/{ko,en,ja,zh}.json`: `notifications.actions.boardingConfirm` / `disembarkConfirm` / `notYet` 키 추가.
- responder는 `hopEndKind` payload 필드로 분기하므로(카테고리와 무관) 구버전 device(카테고리 미등록 → 일반 alert 폴백)에서도 배너 탭(`$default`) 응답은 기존과 동일하게 동작 — 다만 long-press 버튼은 노출되지 않음(카테고리 미등록이라 원래도 노출 안 됨).

## RED → GREEN
- backend: `apns.test.ts`에 "hopEndKind=disembark 시 DISEMBARK_PROMPT category로 발사" RED 테스트 추가(기존 코드는 BOARDING_PROMPT로 나가 실패) → 구현 후 GREEN. `scheduled.test.ts`의 `maybeFireHopEndPrompt` 테스트에도 category 어서션 추가.
- device: `notificationCategory.test.ts`에 "버튼 라벨이 i18next 번역 키로 로컬라이즈된다" + `setupDisembarkPromptCategory` RED 테스트 추가 → GREEN. `useBoardingPromptResponder.test.ts`에 "구 BOARDING_PROMPT_ACTION_BOARDED는 하차 확정으로 인식되지 않는다" RED 테스트 추가(기존 코드는 confirm 처리 — 신규 카테고리 도입 전 잠재 버그 재현) → GREEN.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (신규 export `setupDisembarkPromptCategory`, `DISEMBARK_PROMPT_CATEGORY` 등은 `app/_layout.tsx` / responder / display logger에서 즉시 소비).
2. **V/X dashboard** — 실기기 long-press 버튼 문구(하차했어요/아직이요, 4언어). `boarding_prompt_interactive_tap` breadcrumb의 `hopEndKind=disembark` 응답률로 dedup 카테고리 채택 여부 간접 관측 가능(Sentry breadcrumb).
3. **의존 PR** — N/A (backend + device 동일 PR로 스택).
4. **측정 plan** — 1주 production: `boarding_prompt_interactive_tap`(hopEndKind=disembark) 응답률과 hop-end fired count(`logBoardingPromptFired`, 두 카테고리 통합)를 비교해 버튼 노출 후 응답률 상승 여부 확인.
5. **Device verify** — 필요. 실기기에서 환승역 하차 시 "하차하셨나요?" 알림 long-press → [하차했어요]/[아직이요] 버튼이 한국어(기기 언어별)로 노출되는지 확인. 구 앱 버전(카테고리 미등록) fallback도 별도 확인 권장.

## 계약 갱신 (#2234)
`sendBoardingPromptPush`의 `aps.category` 출력이 `hopEndKind` 값에 따라 분기되도록 계약이 변경됨 — `backend/alarm-worker/src/__tests__/apns.test.ts` / `scheduled.test.ts`에 해당 분기 계약 테스트를 이번 PR에서 함께 추가함(별도 PR 불필요).

## 검증
- `npx jest <변경 파일>` — 전부 GREEN, 대상 파일 coverage 100% (lines/branches/funcs/stmts)
- `npx tsc --noEmit` — clean
- `npm run lint:orphan` — 0 orphan
- `cd backend/alarm-worker && npm test` — 81 files / 2983 tests 전부 pass
- **전체 프론트 스위트(`npm test`)는 미실행** — 메인 세션에서 검증 예정