### PR TITLE
feat: 안내 일시정지/종료 UX 명확화 — 라벨·확인 다이얼로그·일시정지 배지 + 15분 backstop (#2293)

### DIFF
--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -28,6 +28,7 @@ import { clearBackendSsotMirror } from '../../utils/backendSsotMirror';
 import { clearLastSilentPushReceivedAt } from '../../utils/lastSilentPushReceivedAt';
 import { clearNavigationPausedAt } from '../../utils/navigationPauseStorage';
 import { useDestinationStore } from '../../../route/store/useDestinationStore';
+import { useNavigationStore } from '../../../route/store/useNavigationStore';
 import { useBoardingLockStore } from '../useBoardingLockStore';
 import { useLegAdvanceStore } from '../useLegAdvanceStore';
 import { useAlarmEventStore } from '../useAlarmEventStore';
@@ -61,6 +62,9 @@ describe('tripBoundCleanups', () => {
     // #918 A3 PR4 — cancelTripBoundAlarms는 OS 큐 enumerate가 필요. auto-mock default가
     // undefined를 반환하면 for..of에서 throw → cleanup 흐름이 막힌다. 빈 큐로 graceful 통과.
     (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue([]);
+    // #2293 (PR #2301 리뷰 P1) — zustand 모듈 싱글톤이라 pausedAt 테스트가 다른 테스트로
+    // leak되지 않도록 매 테스트마다 reset.
+    useNavigationStore.setState({ navigationActive: false, pausedAt: null });
   });
 
   it('TRIP_BOUND_CLEANUPS는 비어있지 않다 (메타 배열 self-check)', () => {
@@ -468,10 +472,33 @@ describe('tripBoundCleanups', () => {
       expect(TRIP_BOUND_CLEANUPS).toContain(clearLastSilentPushReceivedAt);
     });
 
-    // #2293 — "일시정지" stamp도 trip 종료 전체 경로에서 함께 제거돼야 이전 trip의 pausedAt이
-    // 새 trip에 leak되지 않는다.
-    it('#2293: clearNavigationPausedAt가 TRIP_BOUND_CLEANUPS에 포함된다 (일시정지 stamp leak 차단)', () => {
-      expect(TRIP_BOUND_CLEANUPS).toContain(clearNavigationPausedAt);
+    // #2293 (PR #2301 리뷰 P1) — "일시정지" stamp의 두 채널(storage + memory)이 항상 같은
+    // chokepoint에서 함께 제거돼야 한다. 일시정지 상태에서 재개/종료 버튼 없이 바로 새
+    // 목적지를 선택(handleSelectDestination)해도 runTripBoundCleanups가 이 배열을 거치므로
+    // memory pausedAt이 stale로 남지 않는다(RED였던 회귀: startNavigation에서만 memory
+    // clear해 storage만 지워지고 memory는 남는 문제).
+    it('#2293 P1: runTripBoundCleanups 실행 시 storage(clearNavigationPausedAt)와 memory(useNavigationStore.pausedAt) 모두 clear', async () => {
+      useNavigationStore.setState({ navigationActive: false, pausedAt: 1_700_000_000_000 });
+      (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+
+      await runTripBoundCleanups();
+
+      const removedKeys = (AsyncStorage.removeItem as jest.Mock).mock.calls.map(
+        (c) => c[0] as string,
+      );
+      // storage 채널: clearNavigationPausedAt이 실제로 호출됐는지는 키 제거 여부로 검증
+      // (함수 reference 자체는 더 이상 배열에 직접 노출되지 않음 — 조합 함수로 감쌈).
+      expect(removedKeys).toContain(
+        jest.requireActual('../../../../shared/constants/storageKeys').NAVIGATION_PAUSED_AT_KEY,
+      );
+      // memory 채널: useNavigationStore.pausedAt이 함께 clear됐는지 직접 검증.
+      expect(useNavigationStore.getState().pausedAt).toBeNull();
+    });
+
+    it('#2293 P1: clearNavigationPausedAt(storage helper)는 여전히 실제 AsyncStorage 제거를 수행한다 (import 참조 회귀 가드)', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+      await clearNavigationPausedAt();
+      expect(AsyncStorage.removeItem).toHaveBeenCalled();
     });
 
     it('S12-8: enumeration 가드 — TRIP_BOUND_CLEANUPS 길이가 baseline 이하로 떨어지면 회귀', () => {

--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -26,6 +26,7 @@ import { resetAlarmBackendDedup } from '../../api/alarmBackend';
 import * as alarmBackend from '../../api/alarmBackend';
 import { clearBackendSsotMirror } from '../../utils/backendSsotMirror';
 import { clearLastSilentPushReceivedAt } from '../../utils/lastSilentPushReceivedAt';
+import { clearNavigationPausedAt } from '../../utils/navigationPauseStorage';
 import { useDestinationStore } from '../../../route/store/useDestinationStore';
 import { useBoardingLockStore } from '../useBoardingLockStore';
 import { useLegAdvanceStore } from '../useLegAdvanceStore';
@@ -467,6 +468,12 @@ describe('tripBoundCleanups', () => {
       expect(TRIP_BOUND_CLEANUPS).toContain(clearLastSilentPushReceivedAt);
     });
 
+    // #2293 — "일시정지" stamp도 trip 종료 전체 경로에서 함께 제거돼야 이전 trip의 pausedAt이
+    // 새 trip에 leak되지 않는다.
+    it('#2293: clearNavigationPausedAt가 TRIP_BOUND_CLEANUPS에 포함된다 (일시정지 stamp leak 차단)', () => {
+      expect(TRIP_BOUND_CLEANUPS).toContain(clearNavigationPausedAt);
+    });
+
     it('S12-8: enumeration 가드 — TRIP_BOUND_CLEANUPS 길이가 baseline 이하로 떨어지면 회귀', () => {
       // 새 cleanup 항목이 추가될 때마다 baseline을 한 줄로 갱신. 누군가 실수로 항목을 제거하면
       // 본 assertion이 빨갛게 깨져 의도된 제거인지 코드리뷰에서 확인하도록 강제한다.
@@ -478,7 +485,8 @@ describe('tripBoundCleanups', () => {
       // useLaunchTripReconciliation/useStateRehydration sentinel+force-end)에서 명시 호출.
       // #1892 / #1885 — endLiveActivityCleanup 1 신규 (RC-9 LA orphan 26분 cascade fix).
       // #2045 — clearLastSilentPushReceivedAt 1 신규 (Signal 4 판정 오염 차단).
-      const MIN_ITEMS = 27;
+      // #2293 — clearNavigationPausedAt 1 신규 (일시정지 stamp leak 차단).
+      const MIN_ITEMS = 28;
       expect(TRIP_BOUND_CLEANUPS.length).toBeGreaterThanOrEqual(MIN_ITEMS);
     });
   });

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -43,6 +43,7 @@ import { clearAlarmLogWindows } from '../utils/alarmLog';
 import { clearActiveTrip, resetAlarmBackendDedup } from '../api/alarmBackend';
 import { getNotificationRouter } from '../api/notificationRouter';
 import { useDestinationStore } from '../../route/store/useDestinationStore';
+import { useNavigationStore } from '../../route/store/useNavigationStore';
 import { useBoardingLockStore } from './useBoardingLockStore';
 import { useLegAdvanceStore } from './useLegAdvanceStore';
 import { useAlarmEventStore } from './useAlarmEventStore';
@@ -170,12 +171,29 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   // (직전 trip이 정상 종료 후 새 trip 시작 X → 앱 launch) → 새 trip 판정 오염 방지.
   // 새 trip 등록 후 첫 silent push 수신 시점부터 stamp 재갱신 → clean baseline.
   clearLastSilentPushReceivedAt,
-  // #2293 — "일시정지" stamp 제거. trip 종료 전체 경로(FG setDestination(null/switch) /
-  // silent push trip-ended / useStateRehydration sentinel / useLaunchTripReconciliation
-  // cold-launch / pause-auto-end backstop 자체)가 모두 이 배열을 거치므로, 여기 한 줄
-  // 추가로 이전 trip의 pausedAt이 새 trip에 leak되지 않도록 자동 wire된다.
-  clearNavigationPausedAt,
+  // #2293 (PR #2301 리뷰 P1) — "일시정지" stamp 제거. storage 채널(NAVIGATION_PAUSED_AT_KEY,
+  // cold-start backstop 판정용)과 memory 채널(useNavigationStore.pausedAt, FG 배지 카운트다운
+  // 소스)을 반드시 같은 chokepoint에서 함께 지운다 — 산발 호출(startNavigation에서만 memory
+  // clear) 시 "일시정지 상태에서 재개/종료 버튼 없이 새 목적지 바로 선택"
+  // (handleSelectDestination, navigationActive 무검사 진입점) 경로에서 memory pausedAt만
+  // stale로 남아 새 trip에 잔여 배지 + 조기 자동종료가 발생하는 회귀가 있었다.
+  // trip 종료 전체 경로(FG setDestination(null/switch) / silent push trip-ended /
+  // useStateRehydration sentinel / useLaunchTripReconciliation cold-launch / pause-auto-end
+  // backstop 자체)가 모두 이 배열을 거치므로, 여기 한 줄 추가로 두 채널 모두 자동 wire된다.
+  clearNavigationPauseState,
 ];
+
+/**
+ * #2293 (PR #2301 리뷰 P1) — 일시정지 storage stamp + memory pausedAt을 한 호출로 동시 clear.
+ *
+ * 두 채널(navigationPauseStorage의 AsyncStorage stamp / useNavigationStore.pausedAt 메모리)이
+ * 서로 다른 시점에 개별 clear되면 한쪽만 지워진 채 새 trip이 시작될 수 있다 — 단일
+ * chokepoint(TRIP_BOUND_CLEANUPS)에서 항상 함께 처리해 drift를 원천 차단한다.
+ */
+function clearNavigationPauseState(): Promise<void> {
+  useNavigationStore.getState().clearPausedAt();
+  return clearNavigationPausedAt();
+}
 
 /**
  * #1892 / #1885 — Live Activity 인스턴스 dismiss helper.

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -35,6 +35,7 @@ import { clearPrescheduledLedger } from '../utils/prescheduledMetrics';
 import { cancelAllSafetyNetAlarms, resolveEffectiveTripToken } from '../utils/safetyNetScheduler';
 import { cancelAllPrescheduledAlarms } from '../utils/stationPrescheduler';
 import { getTripStartedAt } from '../utils/tripStartStorage';
+import { clearNavigationPausedAt } from '../utils/navigationPauseStorage';
 import { clearTripCorrId } from '../../observability/utils/tripCorrId';
 import { clearBackendSsotMirror } from '../utils/backendSsotMirror';
 import { clearCrossCategoryDedup } from '../utils/crossCategoryStationDedup';
@@ -169,6 +170,11 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   // (직전 trip이 정상 종료 후 새 trip 시작 X → 앱 launch) → 새 trip 판정 오염 방지.
   // 새 trip 등록 후 첫 silent push 수신 시점부터 stamp 재갱신 → clean baseline.
   clearLastSilentPushReceivedAt,
+  // #2293 — "일시정지" stamp 제거. trip 종료 전체 경로(FG setDestination(null/switch) /
+  // silent push trip-ended / useStateRehydration sentinel / useLaunchTripReconciliation
+  // cold-launch / pause-auto-end backstop 자체)가 모두 이 배열을 거치므로, 여기 한 줄
+  // 추가로 이전 trip의 pausedAt이 새 trip에 leak되지 않도록 자동 wire된다.
+  clearNavigationPausedAt,
 ];
 
 /**

--- a/src/features/alarm/utils/__tests__/navigationPauseStorage.test.ts
+++ b/src/features/alarm/utils/__tests__/navigationPauseStorage.test.ts
@@ -1,0 +1,115 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  setNavigationPausedAt,
+  getNavigationPausedAt,
+  clearNavigationPausedAt,
+  isPauseAutoEndDue,
+} from '../navigationPauseStorage';
+import { NAVIGATION_PAUSED_AT_KEY } from '../../../../shared/constants/storageKeys';
+import { PAUSE_AUTO_END_MS } from '../../../../shared/constants/realtime';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    setItem: jest.fn(),
+    getItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+const mockSetItem = AsyncStorage.setItem as jest.Mock;
+const mockGetItem = AsyncStorage.getItem as jest.Mock;
+const mockRemoveItem = AsyncStorage.removeItem as jest.Mock;
+
+describe('navigationPauseStorage (#2293)', () => {
+  beforeEach(() => {
+    mockSetItem.mockReset();
+    mockGetItem.mockReset();
+    mockRemoveItem.mockReset();
+  });
+
+  describe('setNavigationPausedAt', () => {
+    it('주어진 시각을 NAVIGATION_PAUSED_AT_KEY 에 기록한다', async () => {
+      mockSetItem.mockResolvedValue(undefined);
+      await setNavigationPausedAt(123456);
+      expect(mockSetItem).toHaveBeenCalledWith(NAVIGATION_PAUSED_AT_KEY, '123456');
+    });
+
+    it('인자 미지정 시 Date.now() 사용', async () => {
+      const NOW = 999_999;
+      jest.spyOn(Date, 'now').mockReturnValue(NOW);
+      mockSetItem.mockResolvedValue(undefined);
+      await setNavigationPausedAt();
+      expect(mockSetItem).toHaveBeenCalledWith(NAVIGATION_PAUSED_AT_KEY, String(NOW));
+      (Date.now as jest.Mock).mockRestore();
+    });
+
+    it('AsyncStorage 실패 시 graceful (throw 안 함)', async () => {
+      mockSetItem.mockRejectedValue(new Error('fail'));
+      await expect(setNavigationPausedAt(1)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getNavigationPausedAt', () => {
+    it('숫자 문자열을 number로 파싱해서 반환', async () => {
+      mockGetItem.mockResolvedValue('42');
+      await expect(getNavigationPausedAt()).resolves.toBe(42);
+    });
+
+    it('키 부재 시 null', async () => {
+      mockGetItem.mockResolvedValue(null);
+      await expect(getNavigationPausedAt()).resolves.toBeNull();
+    });
+
+    it('NaN/비숫자 raw 는 null', async () => {
+      mockGetItem.mockResolvedValue('not-a-number');
+      await expect(getNavigationPausedAt()).resolves.toBeNull();
+    });
+
+    it('AsyncStorage 실패 시 graceful null', async () => {
+      mockGetItem.mockRejectedValue(new Error('fail'));
+      await expect(getNavigationPausedAt()).resolves.toBeNull();
+    });
+  });
+
+  describe('clearNavigationPausedAt', () => {
+    it('NAVIGATION_PAUSED_AT_KEY 를 제거한다', async () => {
+      mockRemoveItem.mockResolvedValue(undefined);
+      await clearNavigationPausedAt();
+      expect(mockRemoveItem).toHaveBeenCalledWith(NAVIGATION_PAUSED_AT_KEY);
+    });
+
+    it('AsyncStorage 실패 시 graceful (throw 안 함)', async () => {
+      mockRemoveItem.mockRejectedValue(new Error('fail'));
+      await expect(clearNavigationPausedAt()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('isPauseAutoEndDue', () => {
+    it('pausedAt=null → false', () => {
+      expect(isPauseAutoEndDue(null, 1_000_000)).toBe(false);
+    });
+
+    it('경과 < PAUSE_AUTO_END_MS → false', () => {
+      const now = 1_000_000;
+      expect(isPauseAutoEndDue(now - (PAUSE_AUTO_END_MS - 1), now)).toBe(false);
+    });
+
+    it('경과 = PAUSE_AUTO_END_MS 경계 → true', () => {
+      const now = 1_000_000;
+      expect(isPauseAutoEndDue(now - PAUSE_AUTO_END_MS, now)).toBe(true);
+    });
+
+    it('경과 > PAUSE_AUTO_END_MS → true', () => {
+      const now = 1_000_000;
+      expect(isPauseAutoEndDue(now - PAUSE_AUTO_END_MS - 60_000, now)).toBe(true);
+    });
+
+    it('now 기본값은 Date.now()', () => {
+      const NOW = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(NOW);
+      expect(isPauseAutoEndDue(NOW - 60_000)).toBe(false);
+      (Date.now as jest.Mock).mockRestore();
+    });
+  });
+});

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -387,7 +387,12 @@ export type AlarmLogReason =
   // #2253 (ADR-029 Phase 5, G1) — backend가 device보다 앞선 `contractVersion`을 stamp한 payload를
   // 수신한 1건(런타임 버전 스큐). P1 G6 fail-open 정책 재사용 — 발사는 막지 않는다(기존 kind 처리가
   // 이 skip과 별개로 정상 진행), 이 reason은 순수 관측용.
-  | 'push-contract-skew-version-old';
+  | 'push-contract-skew-version-old'
+  // #2293 (Part of #2285 결정 ①+③) — "일시정지"(navigationActive=false && destination 존재)
+  // 상태가 PAUSE_AUTO_END_MS(15분) 경과해 자동 종료된 1건. FG useCountdown 만료 /
+  // cold-start rehydration backstop 두 진입점 공통 reason — source='lifecycle-backstop'로
+  // 적재해 기존 backstop 계열과 같은 분포로 관측(fire 분모 제외 유지).
+  | 'trip-paused-auto-ended';
 export type AlarmLogKind = 'destination' | 'transfer' | 'station-passed';
 export type AlarmLogDirection = 'up' | 'down';
 // #396 — imminent 발사 신호 출처. 'api'는 도착정보 arrivalCode 신호, 'eta'는 기존 ETA 임계.

--- a/src/features/alarm/utils/navigationPauseStorage.ts
+++ b/src/features/alarm/utils/navigationPauseStorage.ts
@@ -1,0 +1,63 @@
+/**
+ * 안내 "일시정지" 진입 시각 storage (#2293, Part of #2285 결정 ①+③).
+ *
+ * "일시정지" 버튼(HomeScreen.handleStopNavigation)을 탭한 시각을 영속화한다. 목적은
+ * cold-start backstop(useStateRehydration)이 앱이 kill된 채로 PAUSE_AUTO_END_MS(15분)가
+ * 경과했는지 다음 mount/AppState 'active' 진입 시 판정하는 것 — FG 배지 카운트다운(메모리
+ * 전용 useNavigationStore.pausedAt)과는 별개 채널이다. 두 값은 handleStopNavigation/
+ * handleStartNavigation 호출 시점에 함께 stamp/clear되지만, 서로 다른 목적(FG 표시 vs
+ * cold-start 판정)의 독립 판정에만 쓰이고 서로 비교되지 않는다.
+ *
+ * Writers: HomeScreen.handleStopNavigation (일시정지 진입).
+ * Readers: useStateRehydration (cold-start/FG 복귀 backstop 판정).
+ * Cleanup: HomeScreen.handleStartNavigation(재개) + tripBoundCleanups(trip 종료 전체 경로 —
+ *   FG setDestination(null/switch) / silent push trip-ended / useStateRehydration sentinel /
+ *   useLaunchTripReconciliation cold-launch / 본 backstop 자체의 force-cleanup 모두 포함).
+ *
+ * 모든 함수는 AsyncStorage 실패를 graceful 흡수 — 기록 실패는 배지/backstop 정확도에만
+ * 영향, 알람 발사 흐름에는 무영향.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { NAVIGATION_PAUSED_AT_KEY } from '../../../shared/constants/storageKeys';
+import { PAUSE_AUTO_END_MS } from '../../../shared/constants/realtime';
+
+/** 일시정지 진입 시각 기록. */
+export async function setNavigationPausedAt(at: number = Date.now()): Promise<void> {
+  try {
+    await AsyncStorage.setItem(NAVIGATION_PAUSED_AT_KEY, String(at));
+  } catch {
+    // graceful — stamp 실패는 backstop이 다음 wake에서 재시도할 뿐, trip 흐름에는 무영향.
+  }
+}
+
+/** 일시정지 진입 epoch ms 또는 null. 키 부재/NaN 모두 null. */
+export async function getNavigationPausedAt(): Promise<number | null> {
+  try {
+    const raw = await AsyncStorage.getItem(NAVIGATION_PAUSED_AT_KEY);
+    if (raw === null) return null;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** 일시정지 stamp 제거. 재개 또는 trip 종료(tripBoundCleanups) 시 호출. */
+export async function clearNavigationPausedAt(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(NAVIGATION_PAUSED_AT_KEY);
+  } catch {
+    // graceful — 다음 cleanup에서 재시도.
+  }
+}
+
+/**
+ * 순수 판정 함수 — pausedAt 존재 + PAUSE_AUTO_END_MS 이상 경과 시 true.
+ *
+ * 신규 타이머 대신 기존 값(pausedAt) 비교만 추가 — FG(HomeScreen이 useCountdown 만료 시 동일
+ * 조건을 파생) / cold-start backstop(useStateRehydration) 양쪽이 같은 임계를 공유한다.
+ */
+export function isPauseAutoEndDue(pausedAt: number | null, now: number = Date.now()): boolean {
+  if (pausedAt === null) return false;
+  return now - pausedAt >= PAUSE_AUTO_END_MS;
+}

--- a/src/features/route/components/PausedNavigationBadge.tsx
+++ b/src/features/route/components/PausedNavigationBadge.tsx
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useTheme, typography, spacing, radius } from '../../../shared/theme';
+import { withAlpha } from '../../../shared/theme/colorUtils';
+import { useCountdown } from '../../../shared/hooks/useCountdown';
+import { PAUSE_AUTO_END_MS } from '../../../shared/constants/realtime';
+
+interface Props {
+  /** useNavigationStore.pausedAt — 일시정지 진입 시각(epoch ms). */
+  pausedAt: number;
+  /** PAUSE_AUTO_END_MS 경과 시(카운트다운 만료) 1회 호출. 확인 다이얼로그 없이 즉시 종료. */
+  onExpire: () => void;
+}
+
+/**
+ * "일시정지" 상태(navigationActive=false && destination 존재)임을 알리는 배지
+ * (#2293, Part of #2285 결정 ①+③).
+ *
+ * 기존 `useCountdown`(신규 타이머 아님, `src/shared/hooks/useCountdown.ts` 재사용)으로
+ * pausedAt + PAUSE_AUTO_END_MS까지 남은 시간을 표시하고, 만료(countdown.done) 시 onExpire를
+ * 호출해 자동 종료 cleanup chain을 발사한다. 이 컴포넌트는 호출자(HomeScreen)가 일시정지
+ * 상태일 때만 마운트하므로, 재개/trip 종료 시 자연히 unmount되어 interval도 함께 정리된다.
+ */
+export function PausedNavigationBadge({ pausedAt, onExpire }: Props) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const countdown = useCountdown(pausedAt + PAUSE_AUTO_END_MS);
+
+  useEffect(() => {
+    if (countdown.done) onExpire();
+  }, [countdown.done, onExpire]);
+
+  const minutesRemaining = Math.max(0, Math.ceil(countdown.totalSec / 60));
+  const label = t('navigation.pausedBadge', { minutes: minutesRemaining });
+
+  return (
+    <View
+      style={[styles.badge, { backgroundColor: withAlpha(colors.muted, 0.13), borderColor: colors.muted }]}
+      testID="paused-navigation-badge"
+      accessibilityLabel={label}
+      accessible
+    >
+      <Text style={[typography.bodySm, { color: colors.muted, fontWeight: '600' }]}>{label}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    borderWidth: 1,
+    borderRadius: radius.pill,
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.md,
+    alignSelf: 'flex-start',
+  },
+});

--- a/src/features/route/components/__tests__/PausedNavigationBadge.test.tsx
+++ b/src/features/route/components/__tests__/PausedNavigationBadge.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { screen, act } from '@testing-library/react-native';
+import { renderWithTheme } from '../../../../testUtils/renderWithTheme';
+import { PausedNavigationBadge } from '../PausedNavigationBadge';
+import { PAUSE_AUTO_END_MS } from '../../../../shared/constants/realtime';
+
+describe('PausedNavigationBadge (#2293)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('일시정지됨 배지 렌더 + 남은 분 표시 (15분 전체)', () => {
+    const onExpire = jest.fn();
+    renderWithTheme(<PausedNavigationBadge pausedAt={1_000_000} onExpire={onExpire} />);
+    expect(screen.getByTestId('paused-navigation-badge')).toBeTruthy();
+    expect(screen.getByText('일시정지됨 · 경로 유지 · 15분 후 자동 종료')).toBeTruthy();
+  });
+
+  it('경과 시간에 따라 남은 분이 줄어듦', () => {
+    const onExpire = jest.fn();
+    // 5분 전 일시정지 → 10분 남음.
+    renderWithTheme(
+      <PausedNavigationBadge pausedAt={1_000_000 - 5 * 60_000} onExpire={onExpire} />,
+    );
+    expect(screen.getByText('일시정지됨 · 경로 유지 · 10분 후 자동 종료')).toBeTruthy();
+  });
+
+  it('PAUSE_AUTO_END_MS 경과 시 onExpire 1회 호출 (RED: cleanup chain 발사 트리거)', () => {
+    const onExpire = jest.fn();
+    renderWithTheme(<PausedNavigationBadge pausedAt={1_000_000} onExpire={onExpire} />);
+    expect(onExpire).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.spyOn(Date, 'now').mockReturnValue(1_000_000 + PAUSE_AUTO_END_MS);
+      jest.advanceTimersByTime(1_000);
+    });
+
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('만료 전에는 onExpire 호출 안 함', () => {
+    const onExpire = jest.fn();
+    renderWithTheme(<PausedNavigationBadge pausedAt={1_000_000} onExpire={onExpire} />);
+
+    act(() => {
+      jest.spyOn(Date, 'now').mockReturnValue(1_000_000 + PAUSE_AUTO_END_MS - 1_000);
+      jest.advanceTimersByTime(1_000);
+    });
+
+    expect(onExpire).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/route/store/__tests__/useNavigationStore.test.ts
+++ b/src/features/route/store/__tests__/useNavigationStore.test.ts
@@ -67,6 +67,28 @@ describe('useNavigationStore (#1973)', () => {
     });
   });
 
+  describe('clearPausedAt (#2293 PR #2301 리뷰 P1)', () => {
+    it('pausedAt만 null로 clear, navigationActive는 건드리지 않음', () => {
+      useNavigationStore.setState({ navigationActive: false, pausedAt: 12_345 });
+      useNavigationStore.getState().clearPausedAt();
+      expect(useNavigationStore.getState().pausedAt).toBeNull();
+      expect(useNavigationStore.getState().navigationActive).toBe(false);
+    });
+
+    it('navigationActive=true 상태에서도 pausedAt만 clear (state 변형 없음)', () => {
+      useNavigationStore.setState({ navigationActive: true, pausedAt: 99_999 });
+      useNavigationStore.getState().clearPausedAt();
+      expect(useNavigationStore.getState().pausedAt).toBeNull();
+      expect(useNavigationStore.getState().navigationActive).toBe(true);
+    });
+
+    it('이미 null 상태에서 호출 시 idempotent', () => {
+      useNavigationStore.setState({ navigationActive: false, pausedAt: null });
+      useNavigationStore.getState().clearPausedAt();
+      expect(useNavigationStore.getState().pausedAt).toBeNull();
+    });
+  });
+
   describe('start → stop 사이클', () => {
     it('startNavigation → stopNavigation 사이클 정합 (사용자 안내 시작 후 중단)', () => {
       const { startNavigation, stopNavigation } = useNavigationStore.getState();
@@ -86,8 +108,15 @@ describe('useNavigationStore (#1973)', () => {
   // 노출함을 pin해 간접적으로 확인 (sleepMode / setSleepMode / vibration 등 어떤 필드가
   // 추가되어도 fail). 사용자 여정 수준의 결합 검증은 HomeScreen 통합 테스트에서 담당.
   describe('#1987 (B6) — store shape에 sleepMode 결합 없음', () => {
-    // #2293 — pausedAt(일시정지 배지 카운트다운 메모리 값) 추가로 4개 필드로 확장.
-    const EXPECTED_KEYS = ['navigationActive', 'pausedAt', 'startNavigation', 'stopNavigation'].sort();
+    // #2293 — pausedAt(일시정지 배지 카운트다운 메모리 값) + clearPausedAt(PR #2301 리뷰 P1)
+    // 추가로 5개 필드로 확장.
+    const EXPECTED_KEYS = [
+      'navigationActive',
+      'pausedAt',
+      'startNavigation',
+      'stopNavigation',
+      'clearPausedAt',
+    ].sort();
 
     it('initial state shape이 정확히 3개 필드만 노출 (sleepMode 등 leak 방지)', () => {
       expect(Object.keys(useNavigationStore.getState()).sort()).toEqual(EXPECTED_KEYS);

--- a/src/features/route/store/__tests__/useNavigationStore.test.ts
+++ b/src/features/route/store/__tests__/useNavigationStore.test.ts
@@ -12,12 +12,16 @@ import { useNavigationStore } from '../useNavigationStore';
 describe('useNavigationStore (#1973)', () => {
   beforeEach(() => {
     // zustand는 모듈 싱글톤 — 매 테스트마다 state reset.
-    useNavigationStore.setState({ navigationActive: false });
+    useNavigationStore.setState({ navigationActive: false, pausedAt: null });
   });
 
   describe('initial state', () => {
     it('navigationActive default false (cold start 시 명시 trigger 필요)', () => {
       expect(useNavigationStore.getState().navigationActive).toBe(false);
+    });
+
+    it('pausedAt default null', () => {
+      expect(useNavigationStore.getState().pausedAt).toBeNull();
     });
   });
 
@@ -32,6 +36,13 @@ describe('useNavigationStore (#1973)', () => {
       useNavigationStore.getState().startNavigation();
       expect(useNavigationStore.getState().navigationActive).toBe(true);
     });
+
+    // #2293 — 재개 시 이전 일시정지 stamp가 leak되지 않도록 pausedAt clear.
+    it('startNavigation 호출 시 pausedAt null로 clear', () => {
+      useNavigationStore.setState({ navigationActive: false, pausedAt: 1_000 });
+      useNavigationStore.getState().startNavigation();
+      expect(useNavigationStore.getState().pausedAt).toBeNull();
+    });
   });
 
   describe('stopNavigation', () => {
@@ -44,6 +55,15 @@ describe('useNavigationStore (#1973)', () => {
     it('이미 false 상태에서 stopNavigation 호출 시 idempotent (false 유지)', () => {
       useNavigationStore.getState().stopNavigation();
       expect(useNavigationStore.getState().navigationActive).toBe(false);
+    });
+
+    // #2293 — 일시정지 진입 시각을 memory에 stamp (FG 배지 카운트다운 소스).
+    it('stopNavigation 호출 시 pausedAt epoch ms로 stamp', () => {
+      jest.spyOn(Date, 'now').mockReturnValue(5_000_000);
+      useNavigationStore.setState({ navigationActive: true, pausedAt: null });
+      useNavigationStore.getState().stopNavigation();
+      expect(useNavigationStore.getState().pausedAt).toBe(5_000_000);
+      jest.restoreAllMocks();
     });
   });
 
@@ -66,7 +86,8 @@ describe('useNavigationStore (#1973)', () => {
   // 노출함을 pin해 간접적으로 확인 (sleepMode / setSleepMode / vibration 등 어떤 필드가
   // 추가되어도 fail). 사용자 여정 수준의 결합 검증은 HomeScreen 통합 테스트에서 담당.
   describe('#1987 (B6) — store shape에 sleepMode 결합 없음', () => {
-    const EXPECTED_KEYS = ['navigationActive', 'startNavigation', 'stopNavigation'].sort();
+    // #2293 — pausedAt(일시정지 배지 카운트다운 메모리 값) 추가로 4개 필드로 확장.
+    const EXPECTED_KEYS = ['navigationActive', 'pausedAt', 'startNavigation', 'stopNavigation'].sort();
 
     it('initial state shape이 정확히 3개 필드만 노출 (sleepMode 등 leak 방지)', () => {
       expect(Object.keys(useNavigationStore.getState()).sort()).toEqual(EXPECTED_KEYS);

--- a/src/features/route/store/useNavigationStore.ts
+++ b/src/features/route/store/useNavigationStore.ts
@@ -57,6 +57,14 @@ export interface NavigationState {
    * + infoMode reset wire.
    */
   stopNavigation: () => void;
+  /**
+   * #2293 PR #2301 리뷰 P1 — pausedAt memory만 clear(navigationActive는 건드리지 않음).
+   * trip 종료 전체 경로(`tripBoundCleanups`)의 단일 chokepoint에서 storage 채널
+   * (`clearNavigationPausedAt`)과 함께 호출된다. 일시정지 상태에서 재개/종료 버튼을
+   * 거치지 않고 새 목적지를 바로 선택(`handleSelectDestination`)해도 이전 trip의
+   * pausedAt이 새 trip에 stale로 남아 배지+조기 자동종료를 유발하던 회귀를 차단.
+   */
+  clearPausedAt: () => void;
 }
 
 export const useNavigationStore = create<NavigationState>((set) => ({
@@ -69,5 +77,9 @@ export const useNavigationStore = create<NavigationState>((set) => ({
 
   stopNavigation: () => {
     set({ navigationActive: false, pausedAt: Date.now() });
+  },
+
+  clearPausedAt: () => {
+    set({ pausedAt: null });
   },
 }));

--- a/src/features/route/store/useNavigationStore.ts
+++ b/src/features/route/store/useNavigationStore.ts
@@ -38,25 +38,36 @@ export interface NavigationState {
    */
   navigationActive: boolean;
   /**
+   * #2293 (Part of #2285 결정 ①+③) — "일시정지" 진입 시각(epoch ms), FG 배지 카운트다운
+   * 표시 전용 메모리 값. stopNavigation에서 stamp, startNavigation에서 clear.
+   * cold-start 자동 종료 판정은 이 값이 아니라 별도 영속 채널(alarm feature
+   * `navigationPauseStorage`, `NAVIGATION_PAUSED_AT_KEY`)을 쓴다 — 이 store는 의도적으로
+   * 휘발성이라 cross-feature AsyncStorage 부작용을 담지 않는다(HomeScreen이
+   * handleStopNavigation/handleStartNavigation에서 두 채널을 같은 호출 지점에 wire).
+   */
+  pausedAt: number | null;
+  /**
    * 안내 시작. 사용자가 HomeScreen "안내 시작" 버튼을 탭할 때 호출.
-   * memory state만 true로 set (persist 미적용).
+   * memory state만 true로 set (persist 미적용). pausedAt도 함께 clear.
    */
   startNavigation: () => void;
   /**
-   * 안내 중단. 사용자가 HomeScreen "안내 중단" 버튼을 탭할 때 호출.
-   * memory state false로 set. HomeScreen이 useBackgroundLocation cleanup + infoMode reset wire.
+   * 안내 중단(일시정지). 사용자가 HomeScreen "일시정지" 버튼을 탭할 때 호출.
+   * memory state false로 set + pausedAt stamp. HomeScreen이 useBackgroundLocation cleanup
+   * + infoMode reset wire.
    */
   stopNavigation: () => void;
 }
 
 export const useNavigationStore = create<NavigationState>((set) => ({
   navigationActive: false,
+  pausedAt: null,
 
   startNavigation: () => {
-    set({ navigationActive: true });
+    set({ navigationActive: true, pausedAt: null });
   },
 
   stopNavigation: () => {
-    set({ navigationActive: false });
+    set({ navigationActive: false, pausedAt: Date.now() });
   },
 }));

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { AppState, InteractionManager, Pressable, RefreshControl, ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, AppState, InteractionManager, Pressable, RefreshControl, ScrollView, StyleSheet, Switch, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as SplashScreen from 'expo-splash-screen';
 import { useTranslation } from 'react-i18next';
@@ -19,6 +19,11 @@ import { useUserIntentStore } from '../features/alarm/store/useUserIntentStore';
 import { useLegAdvanceStore } from '../features/alarm/store/useLegAdvanceStore';
 import { useNavigationStore } from '../features/route/store/useNavigationStore';
 import { DestinationPicker } from '../features/route/components/DestinationPicker';
+import { PausedNavigationBadge } from '../features/route/components/PausedNavigationBadge';
+import {
+  setNavigationPausedAt,
+  clearNavigationPausedAt,
+} from '../features/alarm/utils/navigationPauseStorage';
 import { findRouteCandidatesByCategory, findRoutes, buildJourneyDisplay, calculateETA, calculateStaticETA, getNextStationName, getStationById, routeSignature, type Route, type CategorizedRoute, type RoutePreference } from '../shared/utils/stationRoute';
 import { hasConsumedOriginWait } from '../shared/utils/boardingWait';
 import { pickArrivalAtOrigin } from '../features/arrival/utils/pickArrivalAtOrigin';
@@ -148,6 +153,9 @@ export default function HomeScreen() {
   // #1973 — 안내 시작/중단 명시 trigger SSoT. WhileInUse 권한 사용자도 안내 시작 후
   // BG GPS 지속 가능 (네이버 패턴). startNavigation은 setInfoModeEnabled(true) 자동 wire.
   const navigationActive = useNavigationStore((s) => s.navigationActive);
+  // #2293 — 일시정지 배지 카운트다운 소스(메모리, FG 전용). cold-start 자동 종료 판정은
+  // useStateRehydration이 별도 영속 채널(NAVIGATION_PAUSED_AT_KEY)로 처리.
+  const navigationPausedAt = useNavigationStore((s) => s.pausedAt);
   const startNavigation = useNavigationStore((s) => s.startNavigation);
   const stopNavigation = useNavigationStore((s) => s.stopNavigation);
   // #746: 알람 dismiss → silence 시작점 기록. 같은 컴포넌트의 userLocation을 같이 캡처.
@@ -402,21 +410,42 @@ export default function HomeScreen() {
   const handleStartNavigation = useCallback(() => {
     startNavigation();
     void setInfoModeEnabled(true);
+    // #2293 — 재개 시 일시정지 stamp 제거(cold-start backstop이 재개된 trip을 잘못 종료하지 않도록).
+    void clearNavigationPausedAt();
   }, [startNavigation, setInfoModeEnabled]);
+  // #2293 (Part of #2285 결정 ①+③) — "일시정지" 진입. navigationActive off + BG GPS 중단은
+  // 유지하되(#1973), destination/trip은 보존한다. pausedAt을 함께 stamp해 배지 카운트다운 +
+  // PAUSE_AUTO_END_MS(15분) 경과 시 자동 종료 backstop의 기준점으로 쓴다.
   const handleStopNavigation = useCallback(() => {
     stopNavigation();
     void setInfoModeEnabled(false);
+    void setNavigationPausedAt();
   }, [stopNavigation, setInfoModeEnabled]);
-  // #2238 — "안내 종료" 명시 trigger. "안내 중단"(navigationActive만 off, BG GPS 토글)과 달리
+  // #2238 — "안내 종료" 명시 trigger. "일시정지"(navigationActive만 off, BG GPS 토글)와 달리
   // trip 자체를 종료한다: setDestination(null)이 기존 cleanup chain(runTripBoundCleanups →
   // #2129 backend DELETE /trips wire, tripBoundCleanups.ts:259)을 그대로 태워 로컬 정리 +
-  // backend trip 삭제(best-effort, 실패해도 15분 backstop #2230이 안전망) 양쪽을 처리한다.
-  // navigationActive/infoModeEnabled도 함께 reset해 trip 없는 상태에 stale 의향 플래그가
-  // 남지 않도록 한다.
+  // backend trip 삭제(best-effort, 실패해도 9h force-end backstop이 안전망) 양쪽을 처리한다.
+  // navigationActive/infoModeEnabled/pausedAt도 함께 reset해 trip 없는 상태에 stale 의향
+  // 플래그가 남지 않도록 한다(pausedAt은 tripBoundCleanups에서 storage 채널도 함께 제거).
+  //
+  // #2293 — FG 일시정지 카운트다운 만료(PausedNavigationBadge.onExpire)에서도 확인 다이얼로그
+  // 없이 이 함수를 그대로 호출한다. 확인이 필요한 건 "사용자가 직접 종료 버튼을 탭"하는
+  // 경우뿐(handleEndNavigationPress) — 만료는 이미 15분 전 배지로 예고된 자동 처리.
   const handleEndNavigation = useCallback(() => {
     handleStopNavigation();
     setDestination(null);
   }, [handleStopNavigation, setDestination]);
+  // #2293 — "안내 종료" 버튼 탭 시 확인 다이얼로그. 취소 시 아무 것도 하지 않는다(경로/알람 유지).
+  const handleEndNavigationPress = useCallback(() => {
+    Alert.alert(
+      t('navigation.endConfirmTitle'),
+      t('navigation.endConfirmMessage'),
+      [
+        { text: t('navigation.endConfirmCancel'), style: 'cancel' },
+        { text: t('navigation.endConfirmConfirm'), style: 'destructive', onPress: handleEndNavigation },
+      ],
+    );
+  }, [t, handleEndNavigation]);
   const { arrivedBanner } = useArrivalAutoClear({
     currentStationName: result?.station.name,
     distanceKm: result?.distanceKm,
@@ -1363,6 +1392,15 @@ export default function HomeScreen() {
               </View>
             )}
 
+            {/* #2293 (Part of #2285 결정 ①+③) — 일시정지 배지: navigationActive=false && destination
+                 존재 상태를 사용자에게 명확히 알린다("일시정지" ≠ "안내 종료" 구분). 카운트다운 만료 시
+                 handleEndNavigation을 확인 다이얼로그 없이 호출(15분 전 배지로 이미 예고됨). */}
+            {destination && !navigationActive && navigationPausedAt !== null && (
+              <View style={{ paddingHorizontal: spacing.xxl, paddingBottom: spacing.md }}>
+                <PausedNavigationBadge pausedAt={navigationPausedAt} onExpire={handleEndNavigation} />
+              </View>
+            )}
+
             {/* #1844 (Phase 6.1 Sub-step 5) — cold start mismatch 재확인 배너.
                  lock 활성 + mismatch 감지 시 노출. 탑승역 재선택 → lock 해제. */}
             {boardingLock && coldStartMismatch.detected && (
@@ -1468,16 +1506,17 @@ export default function HomeScreen() {
                       </Text>
                     </Pressable>
                   )}
-                  {/* #2238 — "안내 종료" 버튼. "안내 시작"과 대칭 배치, 활성 trip(destination 존재)일
-                       때만 노출. 탭 시 trip 자체를 종료(setDestination(null))해 backend DELETE
-                       /trips까지 배선(runTripBoundCleanups → #2129)한다. */}
+                  {/* #2238 — "안내 종료" 버튼. "일시정지"와 대칭 배치, 활성 trip(destination 존재)일
+                       때만 노출. 탭 시 확인 다이얼로그(#2293) 후 trip 자체를 종료
+                       (setDestination(null))해 backend DELETE /trips까지 배선
+                       (runTripBoundCleanups → #2129)한다. */}
                   {destination !== null && (
                     <Pressable
                       testID="home-navigation-end"
                       style={[styles.navigationButton, { borderColor: colors.danger, borderWidth: 1 }]}
                       accessibilityRole="button"
                       accessibilityLabel={t('navigation.end')}
-                      onPress={handleEndNavigation}
+                      onPress={handleEndNavigationPress}
                     >
                       <Text style={[typography.label, { color: colors.danger, fontWeight: '700' }]}>
                         {t('navigation.end')}

--- a/src/shared/constants/realtime.ts
+++ b/src/shared/constants/realtime.ts
@@ -284,3 +284,15 @@ export const LOCKLESS_TIME_INTEGRATION_STUCK_TIMEOUT_MS = 90_000;
  * 정확한 역은 모른다"고 정직하게 알리는 것이 잘못된 역명 표시보다 낫다.
  */
 export const CURRENT_STATION_STALE_DEMOTE_MS = 3 * 60_000;
+
+/**
+ * #2293 (Part of #2285 결정 ①+③) — "일시정지"(navigationActive=false && destination 존재)
+ * 상태 경과 후 자동 종료까지의 임계.
+ *
+ * backend `DESTINATION_REACH_BACKSTOP_MS`(scheduled.ts, destination gps-far cross-check
+ * 전용 15분 backstop)와는 목적·트리거 조건이 전혀 다른 **독립 상수**다 — 우연히 같은
+ * 15분 값을 쓸 뿐, 서로 참조하거나 대체하지 않는다(혼동 방지로 의도적으로 분리 유지).
+ * 이 상수는 오직 device-side "일시정지" 판정(FG useCountdown 만료 / cold-start rehydration
+ * backstop)에서만 사용된다.
+ */
+export const PAUSE_AUTO_END_MS = 15 * 60_000;

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -239,3 +239,10 @@ export const RECENT_LOCAL_STATION_FIRES_KEY = 'subway-now:recent-local-station-f
 // 형식: {"nextLine": LineNumber, "stampedAt": number(epoch ms)} JSON.
 // trip 종료 시 runTripBoundCleanups에서 제거 — 이전 trip의 leg-advance가 새 trip에 leak 차단.
 export const LEG_ADVANCE_KEY = 'subway-now:leg-advance';
+// #2293 — "일시정지" 진입 시각(epoch ms). HomeScreen.handleStopNavigation이 stamp,
+// useStateRehydration의 cold-start/FG 복귀 backstop이 PAUSE_AUTO_END_MS(15분) 경과 여부
+// 판정에 사용한다. FG 배지 카운트다운은 별도 메모리 채널(useNavigationStore.pausedAt)을
+// 쓰므로 이 키는 앱이 kill된 경우의 자동 종료 판정 전용. 재개(handleStartNavigation) 또는
+// trip 종료(runTripBoundCleanups) 시 제거.
+// 형식: 숫자(epoch ms) 문자열.
+export const NAVIGATION_PAUSED_AT_KEY = 'subway-now:navigation-paused-at';

--- a/src/shared/hooks/__tests__/useStateRehydration.test.ts
+++ b/src/shared/hooks/__tests__/useStateRehydration.test.ts
@@ -11,6 +11,7 @@ import { useStateRehydration } from '../useStateRehydration';
 import { useDestinationStore } from '../../../features/route/store/useDestinationStore';
 import { useBoardingLockStore } from '../../../features/alarm/store/useBoardingLockStore';
 import { useLegAdvanceStore } from '../../../features/alarm/store/useLegAdvanceStore';
+import { PAUSE_AUTO_END_MS } from '../../constants/realtime';
 
 const mockGetSentinel = jest.fn();
 const mockClearSentinel = jest.fn();
@@ -33,6 +34,16 @@ jest.mock('../../../features/alarm/utils/tripStartStorage', () => ({
   getTripStartedAt: (...args: unknown[]) => mockGetTripStartedAt(...args),
   tripLifecyclePhase: (...args: unknown[]) => mockTripLifecyclePhase(...args),
 }));
+
+// #2293 — 일시정지 15분 backstop. isPauseAutoEndDue는 순수 함수라 실제 구현 그대로 사용.
+const mockGetNavigationPausedAt = jest.fn();
+jest.mock('../../../features/alarm/utils/navigationPauseStorage', () => {
+  const actual = jest.requireActual('../../../features/alarm/utils/navigationPauseStorage');
+  return {
+    isPauseAutoEndDue: actual.isPauseAutoEndDue,
+    getNavigationPausedAt: (...args: unknown[]) => mockGetNavigationPausedAt(...args),
+  };
+});
 
 const mockAppendAlarmLog = jest.fn();
 jest.mock('../../../features/alarm/utils/alarmLog', () => ({
@@ -97,6 +108,8 @@ beforeEach(() => {
   // 기본은 trip 미존재(none) — 기존 테스트들이 backstop 영향 받지 않도록.
   mockGetTripStartedAt.mockResolvedValue(null);
   mockTripLifecyclePhase.mockReturnValue('none');
+  // #2293 — 기본은 일시정지 미존재 — 기존 테스트들이 pause backstop 영향 받지 않도록.
+  mockGetNavigationPausedAt.mockResolvedValue(null);
   // 기본 mirror 미존재 — 기존 테스트들이 mirror backstop 영향 받지 않도록.
   mockReadBackendSsotMirror.mockResolvedValue(null);
   mockClearBackendSsotMirror.mockResolvedValue(undefined);
@@ -467,6 +480,68 @@ describe('useStateRehydration', () => {
       mockGetTripStartedAt.mockRejectedValue(new Error('io'));
       mockAppState();
       // throw가 새지 않아 hook 자체는 정상 마운트.
+      expect(() => renderHook(() => useStateRehydration())).not.toThrow();
+      await waitFor(() => expect(mockLoadDestination).toHaveBeenCalled());
+    });
+  });
+
+  describe('#2293 (Part of #2285 결정 ①+③) — 일시정지 15분 backstop', () => {
+    it('pausedAt=null — backstop early return (회귀 0)', async () => {
+      mockGetNavigationPausedAt.mockResolvedValue(null);
+      mockAppState();
+      renderHook(() => useStateRehydration());
+      await waitFor(() => expect(mockLoadDestination).toHaveBeenCalled());
+      expect(mockAppendAlarmLog).not.toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'trip-paused-auto-ended' }),
+      );
+      expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+    });
+
+    it('pausedAt 존재 + 경과 < PAUSE_AUTO_END_MS — 아무 동작 안 함', async () => {
+      const now = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+      mockGetNavigationPausedAt.mockResolvedValue(now - (PAUSE_AUTO_END_MS - 1_000));
+      mockAppState();
+      renderHook(() => useStateRehydration());
+      await waitFor(() => expect(mockLoadDestination).toHaveBeenCalled());
+      expect(mockAppendAlarmLog).not.toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'trip-paused-auto-ended' }),
+      );
+      expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+      (Date.now as jest.Mock).mockRestore();
+    });
+
+    it('pausedAt 존재 + 경과 ≥ PAUSE_AUTO_END_MS — runTripBoundCleanups + setState reset + releaseLock + alarmLog fired (RED: cold-start 자동 종료)', async () => {
+      const now = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+      mockGetNavigationPausedAt.mockResolvedValue(now - PAUSE_AUTO_END_MS);
+      mockAppState();
+      renderHook(() => useStateRehydration());
+      await waitFor(() =>
+        expect(mockAppendAlarmLog).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: 'lifecycle-backstop',
+            outcome: 'fired',
+            reason: 'trip-paused-auto-ended',
+          }),
+        ),
+      );
+      expect(mockRunTripBoundCleanups).toHaveBeenCalled();
+      expect(mockSetState).toHaveBeenCalledWith({
+        destination: null,
+        customOrigin: null,
+        tripOrigin: null,
+      });
+      expect(mockReleaseLock).toHaveBeenCalled();
+      expect(mockAddDomainBreadcrumb).toHaveBeenCalledWith('trip', 'end', {
+        reason: 'navigation-pause-auto-end',
+      });
+      (Date.now as jest.Mock).mockRestore();
+    });
+
+    it('backstop 실패는 graceful (다음 launch 영향 X)', async () => {
+      mockGetNavigationPausedAt.mockRejectedValue(new Error('io'));
+      mockAppState();
       expect(() => renderHook(() => useStateRehydration())).not.toThrow();
       await waitFor(() => expect(mockLoadDestination).toHaveBeenCalled());
     });

--- a/src/shared/hooks/useStateRehydration.ts
+++ b/src/shared/hooks/useStateRehydration.ts
@@ -21,6 +21,10 @@ import {
   getTripStartedAt,
   tripLifecyclePhase,
 } from '../../features/alarm/utils/tripStartStorage';
+import {
+  getNavigationPausedAt,
+  isPauseAutoEndDue,
+} from '../../features/alarm/utils/navigationPauseStorage';
 import { appendAlarmLog } from '../../features/alarm/utils/alarmLog';
 import {
   clearBackendSsotMirror,
@@ -135,6 +139,12 @@ async function runRehydration(trigger: 'mount' | 'active'): Promise<void> {
   // share dump에서 lifecycle-backstop source 카운트로 측정.
   await runLifecycleBackstop(trigger);
 
+  // #2293 (Part of #2285 결정 ①+③) — "일시정지" 15분 경과 자동 종료 backstop. 신규 타이머
+  // 대신 이 chokepoint(mount + AppState 'active' 진입)에 편승 — 앱이 kill된 채로 15분이
+  // 지나도 다음 진입 시 정리된다. known limitation: 앱이 계속 kill 상태면 backend trip은
+  // 다음 진입까지 생존(backend-side pause 인지는 ADR-031 Phase 2, 본 PR 스코프 밖).
+  await runNavigationPauseBackstop(trigger);
+
   // #1598 — app boot / FG 복귀 시 active trip이 없는데 Backend SSoT mirror가 잔존하면 즉시 clear.
   // 2026-06-20 trip dump evidence: 사용자 위치 용마산 / activeTrip=(none) / mirror=건대입구.
   // TRIP_BOUND_CLEANUPS는 trip 종료 경로(setDestination(null)/silent push trip-ended/sentinel/
@@ -220,5 +230,46 @@ async function runLifecycleBackstop(trigger: 'mount' | 'active'): Promise<void> 
     await setTripEndedSentinel(now, endedCorrIdSnapshot);
   } catch (e) {
     logger.warn('lifecycle backstop 실패 (graceful)', e);
+  }
+}
+
+/**
+ * #2293 (Part of #2285 결정 ①+③) — "일시정지"(navigationActive=false && destination 존재)
+ * 상태 PAUSE_AUTO_END_MS(15분) 경과 시 자동 종료. throw 없음 — launch 차단 금지.
+ *
+ * pausedAt은 trip 종료 전체 경로(TRIP_BOUND_CLEANUPS)에서 항상 함께 제거되므로, 이 값이
+ * 남아있다는 것 자체가 "아직 어떤 종료 경로도 거치지 않은 활성 일시정지"를 의미한다 —
+ * destination 존재 여부를 별도로 재확인할 필요 없음(force-end backstop과 동일 불변식).
+ *
+ * force-end(9h+) 분기와 동일한 cleanup 시퀀스를 재사용한다(silent push trip-ended와 동형) —
+ * setDestination 호출 대신 runTripBoundCleanups + setState 직접 호출은 #1351 R2와 동일 이유.
+ */
+async function runNavigationPauseBackstop(trigger: 'mount' | 'active'): Promise<void> {
+  try {
+    const pausedAt = await getNavigationPausedAt();
+    const now = Date.now();
+    if (!isPauseAutoEndDue(pausedAt, now)) return;
+
+    appendAlarmLog({
+      ts: now,
+      source: 'lifecycle-backstop',
+      outcome: 'fired',
+      reason: 'trip-paused-auto-ended',
+    });
+    logger.info(`trigger=${trigger} pause auto-end (pausedAt=${pausedAt}) → cleanup`);
+    // #1597 — clearTripCorrId가 cache를 비우기 전에 종료된 trip의 corrId snapshot 캡처.
+    const endedCorrIdSnapshot = getCurrentTripCorrIdSync();
+    await runTripBoundCleanups();
+    // #1597 — trip-end 사용자 정답지 prompt enqueue (cleanup 후, corrId snapshot으로).
+    await triggerTripGroundTruthPrompt(endedCorrIdSnapshot);
+    useDestinationStore.setState({
+      destination: null,
+      customOrigin: null,
+      tripOrigin: null,
+    });
+    addDomainBreadcrumb('trip', 'end', { reason: 'navigation-pause-auto-end' });
+    await useBoardingLockStore.getState().releaseLock();
+  } catch (e) {
+    logger.warn('navigation pause backstop 실패 (graceful)', e);
   }
 }

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -209,9 +209,14 @@
   },
   "navigation": {
     "start": "Start guidance",
-    "stop": "Stop guidance",
+    "stop": "Pause",
     "end": "End guidance",
-    "permissionPrompt": "Location permission is required to start guidance"
+    "permissionPrompt": "Location permission is required to start guidance",
+    "endConfirmTitle": "End guidance?",
+    "endConfirmMessage": "Your route and alarms will be deleted.",
+    "endConfirmConfirm": "End",
+    "endConfirmCancel": "Cancel",
+    "pausedBadge": "Paused · route kept · auto-ends in {{minutes}} min"
   },
   "arrival": {
     "upbound": "Upbound",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -209,9 +209,14 @@
   },
   "navigation": {
     "start": "案内を開始",
-    "stop": "案内を停止",
+    "stop": "一時停止",
     "end": "案内を終了",
-    "permissionPrompt": "案内を開始するには位置情報の権限が必要です"
+    "permissionPrompt": "案内を開始するには位置情報の権限が必要です",
+    "endConfirmTitle": "案内を終了しますか?",
+    "endConfirmMessage": "経路とアラームが削除されます。",
+    "endConfirmConfirm": "終了",
+    "endConfirmCancel": "キャンセル",
+    "pausedBadge": "一時停止中・経路は保持・{{minutes}}分後に自動終了"
   },
   "arrival": {
     "upbound": "上り",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -209,9 +209,14 @@
   },
   "navigation": {
     "start": "안내 시작",
-    "stop": "안내 중단",
+    "stop": "일시정지",
     "end": "안내 종료",
-    "permissionPrompt": "안내를 시작하려면 위치 권한이 필요합니다"
+    "permissionPrompt": "안내를 시작하려면 위치 권한이 필요합니다",
+    "endConfirmTitle": "안내를 종료할까요?",
+    "endConfirmMessage": "경로와 알람이 삭제됩니다.",
+    "endConfirmConfirm": "종료",
+    "endConfirmCancel": "취소",
+    "pausedBadge": "일시정지됨 · 경로 유지 · {{minutes}}분 후 자동 종료"
   },
   "arrival": {
     "upbound": "상행",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -209,9 +209,14 @@
   },
   "navigation": {
     "start": "开始导航",
-    "stop": "停止导航",
+    "stop": "暂停",
     "end": "结束导航",
-    "permissionPrompt": "开始导航需要位置权限"
+    "permissionPrompt": "开始导航需要位置权限",
+    "endConfirmTitle": "要结束导航吗?",
+    "endConfirmMessage": "路线和提醒将被删除。",
+    "endConfirmConfirm": "结束",
+    "endConfirmCancel": "取消",
+    "pausedBadge": "已暂停 · 保留路线 · {{minutes}}分钟后自动结束"
   },
   "arrival": {
     "upbound": "上行",


### PR DESCRIPTION
## 배경

Closes #2293. Part of #2285 결정 ①+③ (④ backend pause는 ADR-031 Phase 2, 본 PR 스코프 밖).

`HomeScreen.tsx` "안내 중단"(navigationActive off, trip 생존) vs "안내 종료"(trip 자체 종료)를 사용자가 구분하기 어려웠던 문제 대응.

## 중단 후 재개 — 스펙 확정 경위

최초 구현 착수 시 "기존 15분 backstop(#2230)"이 실제로는 backend `DESTINATION_REACH_BACKSTOP_MS`(destination gps-far cross-check 전용, 일시정지 상태와 무관)임을 확인하고 구현을 중단·보고했습니다. 코디네이터 결정: **옵션 1 (FG `useCountdown` 재사용 + cold-start rehydration chokepoint 경과 검사)**로 진행 — "신규 타이머 금지"는 "새 BG 폴링/네이티브 타이머 인프라 금지"로 해석, 기존 hook 재사용은 허용.

## 변경 사항

1. **라벨(4언어)**: `navigation.stop` → "일시정지"(ko) / "Pause"(en) / "一時停止"(ja) / "暂停"(zh). `navigation.end`는 유지하되 종료 확인 다이얼로그 키(`endConfirmTitle/Message/Confirm/Cancel`) + 배지 문구(`pausedBadge`, `{{minutes}}` 보간) 4언어 추가.
2. **종료 확인 다이얼로그**: "안내 종료" 버튼 탭 → `Alert.alert`("경로와 알람이 삭제됩니다") 확인 후 `handleEndNavigation` 실행(`handleEndNavigationPress`). 일시정지 버튼은 다이얼로그 없이 즉시 처리.
3. **일시정지 배지**: `PausedNavigationBadge`(신규, `src/features/route/components/`) — `navigationActive=false && destination 존재` 상태에서 노출. 기존 `useCountdown` 재사용(신규 타이머 아님)해 "일시정지됨 · 경로 유지 · N분 후 자동 종료" 표시.
4. **자동 종료 backstop 연동**:
   - `PAUSE_AUTO_END_MS = 15 * 60_000`(`src/shared/constants/realtime.ts`) 신규 독립 상수 — backend `DESTINATION_REACH_BACKSTOP_MS`와 우연히 같은 15분 값이지만 목적·트리거가 달라 명시적으로 분리.
   - `navigationPauseStorage.ts`(신규, `src/features/alarm/utils/`) — `NAVIGATION_PAUSED_AT_KEY` 영속 stamp(cold-start 판정용) + `isPauseAutoEndDue` 순수 판정 함수. `useNavigationStore.pausedAt`(메모리 전용, FG 배지용)과는 별개 채널.
   - (a) FG: `PausedNavigationBadge`의 `useCountdown.done` → `onExpire` → `handleEndNavigation`(확인 다이얼로그 없이).
   - (b) cold-start/FG 복귀: `useStateRehydration`에 `runNavigationPauseBackstop` 추가 — mount/AppState 'active' 진입 시 `pausedAt` 경과 ≥ 15분이면 force-end 분기와 동일 cleanup 시퀀스(`runTripBoundCleanups` + store reset + `releaseLock` + breadcrumb) 즉시 실행.
   - `tripBoundCleanups.ts`에 `clearNavigationPausedAt` 추가 — trip 종료 전체 경로에서 pausedAt leak 차단.
   - **known limitation**(코드 주석 + 본 PR 본문 명시): 앱이 15분 내내 kill 상태면 backend trip은 다음 device 진입까지 생존. backend-side pause 인지는 ADR-031 Phase 2(#2285 결정 ④) 편입, 본 PR 스코프 밖.

## 테스트 (RED 먼저)

- `navigationPauseStorage.test.ts`: stamp/get/clear + `isPauseAutoEndDue` 경계값(정확히 15분 포함).
- `PausedNavigationBadge.test.tsx`: 배지 렌더/남은 분 표시/만료 시 `onExpire` 1회 발사/만료 전 미발사.
- `useNavigationStore.test.ts`: `pausedAt` stamp(stopNavigation)/clear(startNavigation), store shape pin 갱신(3→4 필드).
- `useStateRehydration.test.ts`: `pausedAt=null` 무동작 / 경과<15분 무동작 / 경과≥15분 → cleanup+setState+releaseLock+alarmLog(`trip-paused-auto-ended`) 발사 / 실패 graceful.
- `tripBoundCleanups.test.ts`: `clearNavigationPausedAt` 배열 포함 확인 + enumeration 가드 baseline 갱신.
- HomeScreen 다이얼로그 확인/취소 분기는 `src/screens/**`가 프로젝트 정책상 coverage 제외(E2E+수동 검증) 대상이라 별도 유닛 테스트 없음 — 기존 프로젝트 컨벤션(다른 모든 screens 동일)과 동형.

## Wire-completion 5단

1. **Orphan**: `npm run lint:orphan` pass(0 orphan) — 로컬 확인 완료.
2. **V/X dashboard**: `alarmLog` reason `trip-paused-auto-ended`(source=`lifecycle-backstop`)가 `/admin/alarm-log-stats` 및 DebugModal에서 기존 backstop 계열과 동일 분포로 관측 가능. 배지 자체는 홈 화면에서 직접 육안 확인.
3. **의존 PR**: N/A — #2287(HomeScreen isInTrip/excludeOriginWait) 이미 origin/dev에 머지되어 그 위에서 충돌 없이 작업.
4. **측정 plan**: 다음 1주 `trip-paused-auto-ended` alarmLog 카운트 + 실기기 시나리오(일시정지 후 15분 방치 재현) 관측.
5. **Device verify**: 필요. (a) 일시정지 → 15분 대기 → FG에서 자동 종료 확인, (b) 일시정지 → 앱 kill → 15분+ 후 재실행 → cold-start 즉시 종료 확인, (c) "안내 종료" 버튼 확인/취소 다이얼로그 분기, (d) 일시정지 배지 카운트다운 표시.

## Test plan

- [x] `npx jest <변경 파일>` — 386 tests pass, 신규/변경 파일 100% coverage
- [x] `npx tsc --noEmit` — pass
- [x] `npm run lint:orphan` — 0 orphan
- [ ] 실기기 검증 (사용자)

## 리뷰 반영 (P1)

**P1 (수정 완료, commit `72a68dee`)**: 일시정지 상태에서 재개/종료 버튼을 거치지 않고 새 목적지를 바로 선택(`handleSelectDestination` — navigationActive 무검사 진입점)하면, `runTripBoundCleanups`가 storage 채널(`clearNavigationPausedAt`)만 지우고 `useNavigationStore.pausedAt`(메모리, 배지 카운트다운 소스)은 지우지 않아(그건 `startNavigation`에서만 clear) 새 trip에 stale 배지 + 잔여 시간 후 조기 자동종료가 발생하는 문제.

수정:
- `useNavigationStore`에 `clearPausedAt` 액션 추가(memory `pausedAt`만 clear, `navigationActive`는 건드리지 않음).
- `tripBoundCleanups.ts`의 `TRIP_BOUND_CLEANUPS` 배열에서 단독 `clearNavigationPausedAt` 참조를 `clearNavigationPauseState` 조합 함수로 교체 — storage(`NAVIGATION_PAUSED_AT_KEY`)와 memory(`useNavigationStore.pausedAt`)를 **단일 chokepoint**에서 항상 함께 clear. 산발 호출 제거.
- RED: 일시정지 stamp → `runTripBoundCleanups` 실행 → memory `pausedAt` 잔존 재현 → GREEN: 두 채널 모두 clear 확인(`tripBoundCleanups.test.ts` 통합 테스트 + `useNavigationStore.test.ts` `clearPausedAt` 단위 테스트 3건).
- 검증: 관련 테스트(tripBoundCleanups/useNavigationStore/useStateRehydration, 85 tests) pass, `npx tsc --noEmit` pass, `npm run lint:orphan` 0 orphan. 전체 스위트 미실행(stall 방지).
