### PR TITLE
fix(#2303): 위젯 딥링크 current-station route alias + scheme 오기 수정 + 재발 가드

### DIFF
--- a/app/current-station.tsx
+++ b/app/current-station.tsx
@@ -1,0 +1,7 @@
+// expo-router route entry — 위젯 딥링크(subway-now://current-station) alias.
+// 홈(현재 역 탭)으로 redirect. thin route 컨벤션(redirect 전용).
+import { Redirect } from 'expo-router';
+
+export default function CurrentStationRedirect() {
+  return <Redirect href="/" />;
+}

--- a/app/current-station.tsx
+++ b/app/current-station.tsx
@@ -1,4 +1,4 @@
-// expo-router route entry — 위젯 딥링크(subway-now://current-station) alias.
+// expo-router route entry — 위젯 딥링크(subwaynow://current-station) alias.
 // 홈(현재 역 탭)으로 redirect. thin route 컨벤션(redirect 전용).
 import { Redirect } from 'expo-router';
 

--- a/src/shared/__tests__/deeplinkRoutes.test.ts
+++ b/src/shared/__tests__/deeplinkRoutes.test.ts
@@ -1,0 +1,91 @@
+/**
+ * #2303 재발 차단 가드.
+ *
+ * 네이티브(위젯/Live Activity)·알림 코드가 앱 커스텀 스킴(`subwaynow://...`) 딥링크
+ * URL 문자열을 만들면, 그 path에 대응하는 expo-router route 파일(`app/**`)이 실재해야
+ * 한다. producer(SubwayWidget.swift 등)가 새 딥링크를 추가해도 이 테스트가 자동으로
+ * 스캔 대상에 포함되므로 하드코딩된 path 목록을 유지할 필요가 없다(글로벌 규칙 3).
+ *
+ * 원본 결함(#2303): SubwayWidget.swift가 `subwaynow://current-station`을 위젯 탭 시
+ * 딥링크로 방출했지만 `app/current-station.tsx` route가 없어 expo-router가
+ * "Unmatched Route"를 표출했다.
+ */
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.resolve(__dirname, '../../..');
+
+/** app.config.js에서 등록된 커스텀 URL scheme을 읽는다 (하드코딩 금지, SSoT 참조). */
+function readAppScheme(): string {
+  const configSrc = fs.readFileSync(path.join(ROOT, 'app.config.js'), 'utf8');
+  const match = configSrc.match(/scheme:\s*['"]([a-zA-Z0-9+.-]+)['"]/);
+  if (!match) throw new Error('app.config.js에서 scheme 필드를 찾지 못했습니다.');
+  return match[1];
+}
+
+/** 디렉토리를 재귀 순회하며 주어진 확장자의 파일 경로를 모두 수집한다. */
+function collectFiles(dir: string, extensions: string[]): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) return collectFiles(fullPath, extensions);
+    if (extensions.some((ext) => entry.name.endsWith(ext))) return [fullPath];
+    return [];
+  });
+}
+
+/** 네이티브/알림 producer 코드가 위치할 수 있는 디렉토리 전수 — 새 producer 추가 시 여기만 확장. */
+const PRODUCER_DIRS = [
+  path.join(ROOT, 'targets'),
+  path.join(ROOT, 'modules'),
+  path.join(ROOT, 'src', 'features', 'alarm'),
+  path.join(ROOT, 'src', 'features', 'widget'),
+];
+const PRODUCER_EXTENSIONS = ['.swift', '.ts', '.tsx'];
+
+type DeepLink = { file: string; scheme: string; routePath: string };
+
+/** producer 파일들에서 `scheme://path` 형태의 커스텀 딥링크 URL 문자열을 전수 추출한다. */
+function extractDeepLinks(appScheme: string): DeepLink[] {
+  const urlPattern = new RegExp(`${appScheme}://([a-zA-Z0-9\\-_/]*)`, 'g');
+  const links: DeepLink[] = [];
+
+  for (const dir of PRODUCER_DIRS) {
+    for (const file of collectFiles(dir, PRODUCER_EXTENSIONS)) {
+      if (file.includes(`${path.sep}__tests__${path.sep}`)) continue;
+      const content = fs.readFileSync(file, 'utf8');
+      for (const match of content.matchAll(urlPattern)) {
+        links.push({ file, scheme: appScheme, routePath: match[1] });
+      }
+    }
+  }
+  return links;
+}
+
+/** routePath(예: "current-station")에 대응하는 expo-router route 파일 후보가 실재하는지 확인. */
+function routeExists(routePath: string): boolean {
+  if (routePath === '') return true; // scheme://만 있는 경우 = 앱 루트, 항상 존재
+  const candidates = [
+    path.join(ROOT, 'app', `${routePath}.tsx`),
+    path.join(ROOT, 'app', routePath, 'index.tsx'),
+    path.join(ROOT, 'app', '(tabs)', `${routePath}.tsx`),
+  ];
+  return candidates.some((candidate) => fs.existsSync(candidate));
+}
+
+describe('딥링크 producer ↔ expo-router route 대응 (#2303 재발 차단)', () => {
+  const appScheme = readAppScheme();
+  const deepLinks = extractDeepLinks(appScheme);
+
+  it('앱 scheme으로 최소 1개의 딥링크 producer가 스캔되어야 한다 (가드 자체의 무의미화 방지)', () => {
+    expect(deepLinks.length).toBeGreaterThan(0);
+  });
+
+  it.each(deepLinks.map((link) => [`${link.scheme}://${link.routePath} (${path.relative(ROOT, link.file)})`, link] as const))(
+    '%s → app/ route가 실재해야 한다',
+    (_label, link) => {
+      expect(routeExists(link.routePath)).toBe(true);
+    },
+  );
+});

--- a/targets/subway-widget/SubwayWidget.swift
+++ b/targets/subway-widget/SubwayWidget.swift
@@ -203,7 +203,7 @@ struct SubwayWidgetView: View {
     }
 
     // P4: 위젯 탭 시 앱 딥링크 — 현재역 상세 화면 진입.
-    private var deepLink: URL { URL(string: "subway-now://current-station")! }
+    private var deepLink: URL { URL(string: "subwaynow://current-station")! }
 
     var body: some View {
         // iOS 17+는 위젯이 containerBackground를 채택하지 않으면


### PR DESCRIPTION
Closes #2303

## 스킴 확정
- 등록된 앱 scheme: `subwaynow` (`app.config.js:131`, 2026-05-11부터 고정, 하이픈 없음)
- **추가 발견**: `targets/subway-widget/SubwayWidget.swift:206`(#2303 원인 섹션이 인용한 그 라인)의 `deepLink`가 `subway-now://current-station`(하이픈 있음)으로 되어 있어 등록된 scheme과 불일치했다. widgetURL P4 기능 도입 커밋(06-25, #1797)부터 존재하던 별개 오기. **scheme이 안 맞으면 route alias를 아무리 추가해도 위젯 탭이 애초에 앱에 도달하지 못한다** — 그래서 `subwaynow`로 이 PR에서 같이 수정했다(같은 producer/같은 라인이므로 "결함 1개=PR 1개"의 새 결함이 아니라 원 결함의 근본 원인 보강으로 판단).
- `app/current-station.tsx` 헤더 주석의 scheme 표기(하이픈)도 동기화.

## 딥링크 producer ↔ route 매트릭스 (Phase 1 전수 감사)

| Producer | 위치 | URL / 트리거 | Route 매칭 (수정 전) | Route 매칭 (수정 후) |
| --- | --- | --- | --- | --- |
| 홈 위젯 탭 (`widgetURL`) | `targets/subway-widget/SubwayWidget.swift:206,215,218` | `subwaynow://current-station` (scheme 수정 후) | X — `app/current-station.tsx` 부재 + scheme 불일치 이중 결함 | O — `app/current-station.tsx`(`<Redirect href="/" />`) |
| Live Activity 탭 (잠금화면/Dynamic Island) | `modules/live-activity/**/*.swift` | 없음 — Live Activity는 `widgetURL`/딥링크 URL을 사용하지 않음(전수 grep 0건) | N/A | N/A |
| 알림(boardingPrompt 등) 탭 | `src/features/alarm/hooks/useBoardingPromptResponder.ts`, `notificationCategory.ts`, `src/shared/hooks/useDeferredNavigate.ts` | `router.navigate('/')` 직접 호출 — URL 스킴 문자열 생성 없음 | N/A (route 부재 위험 자체가 없는 설계) | N/A |
| Universal link | 코드베이스 전수 grep 0건 (미구현) | — | N/A | N/A |

→ **`current-station`이 유일한 dead route였고, 이 PR로 완전히 닫힘. 추가 dead route/producer 없음** — Phase 1 산출로 별도 이슈 생성 없음.

## 랜딩 검증 (cold/warm start)
- `app/current-station.tsx`는 root `Stack`(`app/_layout.tsx`)의 형제 route로 렌더되고 `<Redirect href="/" />`를 즉시 반환한다.
- `app/(tabs)/_layout.tsx`에서 `(tabs)/index`가 첫 번째 `Tabs.Screen`(`tabs.current`, 🚇)이며 expo-router group 라우팅 규칙상 `/`는 `(tabs)/index`로 해석된다 — redirect 대상이 정확히 "현재 역" 탭.
- cold start(앱 종료 → 위젯 탭 → initial URL)와 warm start(백그라운드 → 위젯 탭 → Linking) 모두 동일한 route tree 해석 경로(`current-station` 매칭 → `<Redirect>` 컴포넌트 렌더) — expo-router 6(`~6.0.23`) 표준 alias 패턴, 두 케이스 분기 없음.

## 재발 차단 가드 (Phase 2)
- `src/shared/__tests__/deeplinkRoutes.test.ts` 신설.
- `app.config.js`의 `scheme` 필드를 정규식으로 읽어 SSoT로 삼고, `targets/`·`modules/`·`src/features/alarm`·`src/features/widget` 하위 `.swift`/`.ts`/`.tsx` 파일을 재귀 스캔해 `scheme://path` 패턴을 전수 추출한다.
- 추출된 각 path에 대해 `app/<path>.tsx` / `app/<path>/index.tsx` / `app/(tabs)/<path>.tsx` 후보 존재를 `fs.existsSync`로 assert.
- 하드코딩된 path 목록 없음 — 새 producer가 새 딥링크를 추가하면 자동으로 스캔·검증 대상에 포함된다(글로벌 규칙 3 준수).
- 이 가드는 scheme 문자열 자체의 정합성(예: 이번에 발견한 하이픈 오기)까지는 강제하지 않는다 — producer가 앱 scheme과 정확히 일치하는 문자열을 쓴 경우에 한해 path→route 존재만 검증한다. scheme 오기 자체는 이번 PR에서 코드로 직접 수정해 근본 해결했다.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (app/ IGNORE_PATTERN 기 포함, 무변경)
2. **V/X dashboard** — 위젯 탭 실기기 동작으로 확인. route/scheme 정합성은 이번에 추가한 Jest 가드(`deeplinkRoutes.test.ts`)가 CI에서 상시 관측
3. **의존 PR** — N/A. `SubwayWidget.swift` scheme 문자열 변경은 **네이티브 리빌드 필요**(위젯 익스텐션 재컴파일) — JS-only였던 최초 커밋(12d7d965)의 "네이티브 리빌드 불필요" 설명은 이 두 번째 커밋(scheme 수정) 이후로는 더 이상 유효하지 않음. 다음 로컬 `npm run ios`/EAS 빌드에서 반영됨
4. **측정 plan** — N/A(정적 라우팅 + scheme 매칭, 런타임 신호 없음). 재발 여부는 `deeplinkRoutes.test.ts` CI 상시 게이트로 측정
5. **Device verify** — 필요. 시나리오: 네이티브 리빌드 후 홈 위젯 탭 1회 → `subwaynow://current-station` 진입 → 홈(현재 역) 화면 정상 랜딩 확인 (기존 Unmatched Route 재현 안 됨, scheme mismatch로 인한 무반응도 재현 안 됨)

## 검증
- `npx tsc --noEmit` pass
- `npm run lint:orphan` pass (0 orphan)
- `npx jest src/shared/__tests__/deeplinkRoutes.test.ts` pass (2/2)
- app/ route는 coverage 제외 컨벤션 — redirect 대상(`/` → `(tabs)/index`) 코드 레벨 확인 완료
