### PR TITLE
fix(#2310): trip 종료 후 LA register 재시도 루프 cancel wire 배선

### DIFF
--- a/src/features/alarm/utils/__tests__/liveActivityPushChannel.test.ts
+++ b/src/features/alarm/utils/__tests__/liveActivityPushChannel.test.ts
@@ -292,6 +292,25 @@ describe('liveActivityPushChannel', () => {
       expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(3);
     });
 
+    // #2310 — trip 종료(cleanup) 후 진행 중이던 backoff 재시도가 그대로 발화하면
+    // 이미 사라진 trip에 계속 register POST를 쏴 backend에 404 storm을 만든다.
+    // cleanup(teardown) 시 in-flight 재시도 루프도 함께 cancel되어야 한다.
+    it('trip cleanup 후 진행 중이던 register 재시도는 발화하지 않음', async () => {
+      const handle = setupListener();
+      mockRegisterLiveActivityToken.mockResolvedValue({ ok: false, status: 503 });
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      handle.emit('tok');
+      // 첫 호출 동기 발사 — 실패 → 500ms backoff 대기 중
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(1);
+
+      // backoff 대기 중 trip이 종료됨(cleanup)
+      await endLiveActivityWithDeregister('trip-1');
+
+      // 대기하던 backoff가 지나도 재시도가 발화하면 안 된다
+      await jest.advanceTimersByTimeAsync(2000);
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(1);
+    });
+
     // 회귀 가드 — throw가 났을 때 lastStatus는 undefined로 reset되어 기본 backoff(500ms) 사용.
     // 404 backoff가 stale하게 다음 throw 시 적용되면 graceful 보장 깨짐.
     it('register throw 후 다음 attempt는 기본 500ms backoff (404 stale 안 됨)', async () => {

--- a/src/features/alarm/utils/__tests__/liveActivityPushChannel.test.ts
+++ b/src/features/alarm/utils/__tests__/liveActivityPushChannel.test.ts
@@ -311,6 +311,45 @@ describe('liveActivityPushChannel', () => {
       expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(1);
     });
 
+    // #2310 — 마지막(3번째) attempt가 진행 중일 때 trip이 종료되면, 그 attempt의
+    // 네트워크 응답이 돌아온 시점엔 이미 session.cancelled=true다. 이 경우 루프는
+    // attempt 3까지 이미 소진했으므로 loop-start cancel 체크(attempt 1~3 진입 시)는
+    // 전부 통과하고, "재시도 소진 — giving up" 로그만 스킵해야 한다(종료된 trip에
+    // 대한 불필요한 warn 로그 방지).
+    it('마지막 attempt 처리 중 trip cleanup되면 exhausted 로그 없이 조용히 종료', async () => {
+      const handle = setupListener();
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      let callCount = 0;
+      mockRegisterLiveActivityToken.mockImplementation(async () => {
+        callCount += 1;
+        if (callCount === 3) {
+          // 3번째 attempt가 backend 응답을 기다리는 동안 trip이 종료됨(teardown).
+          void endLiveActivityWithDeregister('trip-1');
+        }
+        return { ok: false, status: 503 };
+      });
+      await startLiveActivityWithRegistration('trip-1', SAMPLE_DATA);
+      handle.emit('tok');
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(1);
+      await jest.advanceTimersByTimeAsync(500);
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(2);
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(mockRegisterLiveActivityToken).toHaveBeenCalledTimes(3);
+
+      // trip cleanup(endLiveActivityWithDeregister)이 완료됨 — subscription/backend 정리.
+      expect(handle.remove).toHaveBeenCalledTimes(1);
+      expect(mockClearLiveActivityToken).toHaveBeenCalledWith('trip-1');
+      // "재시도 소진 — giving up" 로그는 남기지 않는다 (cancelled 세션이라 이미 정리됨).
+      expect(
+        warnSpy.mock.calls.some((call) =>
+          call.some(
+            (arg) => typeof arg === 'string' && arg.includes('exhausted retries'),
+          ),
+        ),
+      ).toBe(false);
+      warnSpy.mockRestore();
+    });
+
     // 회귀 가드 — throw가 났을 때 lastStatus는 undefined로 reset되어 기본 backoff(500ms) 사용.
     // 404 backoff가 stale하게 다음 throw 시 적용되면 graceful 보장 깨짐.
     it('register throw 후 다음 attempt는 기본 500ms backoff (404 stale 안 됨)', async () => {

--- a/src/features/alarm/utils/liveActivityPushChannel.ts
+++ b/src/features/alarm/utils/liveActivityPushChannel.ts
@@ -58,16 +58,29 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** LA 세션 단위 재시도 취소 플래그(#2310). teardown 시 in-flight 재시도 루프를 중단한다. */
+interface RetrySession {
+  cancelled: boolean;
+}
+
 /**
  * backend `registerLiveActivityToken`을 exponential backoff로 재시도(#1288).
  * 모든 시도 실패 시 silent log — caller(subscription 콜백)는 throw하지 않는다.
+ *
+ * trip이 cleanup(teardown)되면 `session.cancelled`가 true로 바뀐다(#2310) — 종료된 trip에
+ * 계속 register POST를 쏘는 404 storm을 막기 위해 매 attempt 전에 취소 여부를 확인한다.
  */
 async function registerWithRetry(
   tripToken: string,
   activityPushToken: string,
+  session: RetrySession,
 ): Promise<void> {
   let lastStatus: number | undefined;
   for (let attempt = 1; attempt <= REGISTER_RETRY_MAX_ATTEMPTS; attempt += 1) {
+    if (session.cancelled) {
+      log.info('LA register retry cancelled — trip ended');
+      return;
+    }
     try {
       const result = await registerLiveActivityToken(tripToken, activityPushToken);
       if (result.ok) return;
@@ -84,6 +97,7 @@ async function registerWithRetry(
       await sleep(base * 2 ** (attempt - 1));
     }
   }
+  if (session.cancelled) return;
   log.warn('LA register exhausted retries — giving up (will retry on next token emit)');
 }
 
@@ -103,6 +117,7 @@ export async function startLiveActivityWithRegistration(
   }
   activeTripToken = tripToken;
 
+  const session: RetrySession = { cancelled: false };
   let lastToken: string | null = null;
   let firstEmitTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -116,7 +131,7 @@ export async function startLiveActivityWithRegistration(
       return;
     }
     lastToken = event.token;
-    void registerWithRetry(tripToken, event.token);
+    void registerWithRetry(tripToken, event.token, session);
   });
 
   firstEmitTimer = setTimeout(() => {
@@ -126,6 +141,9 @@ export async function startLiveActivityWithRegistration(
   }, PUSH_TOKEN_FIRST_EMIT_TIMEOUT_MS);
 
   const teardown = (): void => {
+    // #2310 — 진행 중인 register 재시도 루프도 함께 cancel. 종료된 trip에 대한
+    // 404 storm(불필요 네트워크/배터리/로그 오염)을 막는다.
+    session.cancelled = true;
     subscription.remove();
     if (firstEmitTimer) {
       clearTimeout(firstEmitTimer);


### PR DESCRIPTION
Closes #2310

## 요약
trip 종료(DELETE /trips) 후에도 device가 진행 중이던 LA `POST /live-activity/register` backoff 재시도를 계속 발화 — backend는 trip이 없으니 404가 정상 응답이지만, device 쪽에 종료된 trip에 대한 register 재시도를 끊는 wire가 없었다(#2310 07:46:12 종료 후 07:46:30~07:47:05 반복 404).

## 원인
`liveActivityPushChannel.ts`의 `registerWithRetry`는 `void registerWithRetry(...)`로 fire-and-forget 실행되며, exponential backoff(500ms~8s) 동안 sleep 중이었다. `endLiveActivityWithDeregister` / teardown은 push token subscription과 first-emit timer만 정리했고, 이미 시작된 `registerWithRetry` 루프는 cancel되지 않아 backoff 이후 계속 register POST를 쐈다.

## 수정
- 세션 단위 `RetrySession { cancelled: boolean }`을 도입해 `registerWithRetry`에 전달.
- `startLiveActivityWithRegistration`의 `teardown()`(trip 종료/세션 교체 시 호출)에서 `session.cancelled = true`로 설정.
- `registerWithRetry`는 매 attempt 전 `session.cancelled`를 확인해 cancel되면 즉시 return — 종료된 trip에 대한 추가 POST 없음.

## 스펙 3번(다른 채널 유사 post-end 잔류 호출 스캔) — findings only, 미수정
결함 1개 = PR 1개 원칙에 따라 이번 PR에서는 수정하지 않고 스캔 결과만 기록:
- `src/features/widget/api/widgetStorage.ts` — 위젯 forward 경로. trip 종료 시 별도 pending 재시도 타이머는 발견되지 않음(단발 write 호출 위주). 후속 확인 필요.
- silent push ack 관련 재시도 루프는 이번 스캔 범위(`src/features/alarm/`) 내에서 `liveActivityPushChannel.ts`의 register 루프 외에 발견되지 않았음.
- 별도 이슈로 스폰 권장 — 이번 PR 범위 아님.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — backend `trip_events`/Cloudflare 로그에서 trip 종료 이후 `POST /live-activity/register` 404 카운트로 관측. 로컬은 신규 테스트 `trip cleanup 후 진행 중이던 register 재시도는 발화하지 않음`로 검증.
3. **의존 PR** — N/A (device-only 변경, backend 변경 없음).
4. **측정 plan** — 다음 검증 탑승 종료 후 backend 로그에서 종료 시각 이후 `register` 404 발생 건수를 확인. 목표: 0건.
5. **Device verify** — 필요. trip 시작 → 종료 1회 후 backend tail/Dashboard에서 종료 시각 이후 register 호출이 없는지 덤프로 확인.

## 검증
- `npx jest src/features/alarm/utils/__tests__/liveActivityPushChannel.test.ts` — 27/27 pass (신규 red→green 1건 포함)
- `npm run type-check` — pass
- `npm run lint:orphan` — 0 orphan
