### PR TITLE
fix(#2305): 환승 waypoint 도달 시 durable legAdvance stamp — 리스트 구노선 잔류 근본 수리

### DIFF
--- a/src/features/route/hooks/__tests__/useTransferTrainList.test.tsx
+++ b/src/features/route/hooks/__tests__/useTransferTrainList.test.tsx
@@ -54,6 +54,14 @@ jest.mock('../../../alarm/store/useBoardingLockStore', () => {
   };
 });
 
+// #2305 — useLegAdvanceStore mock. context 활성화 전이 시 stampLegAdvance 호출 검증.
+const mockStampLegAdvance = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../alarm/store/useLegAdvanceStore', () => ({
+  useLegAdvanceStore: {
+    getState: () => ({ stampLegAdvance: mockStampLegAdvance }),
+  },
+}));
+
 const lock: BoardingLock = {
   destinationId: 'dest-X',
   trainCode: 'T-OLD',
@@ -714,6 +722,81 @@ describe('#2115 loading passthrough', () => {
     );
     expect(result.current.loading).toBe(false);
     expect(result.current.arrivals.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+/**
+ * #2305 — durable legAdvance stamp RCA 재현 테스트.
+ *
+ * RCA(2026-08-12 건대입구 7→2 환승 실기기): transfer auto-lock(create:other)이 생성된 직후
+ * release되면서, 그 순간까지 legAdvance stamp가 없어(#2278 stamp는 hop-end 프롬프트 응답
+ * 전용) `getApproachLine`이 route의 동결된 stopsToTransfer fallback으로 떨어져 리스트가
+ * 구노선(7호선)으로 붕괴했다. context 활성화(=fusion이 lock+route+currentStation으로 환승
+ * waypoint 도달을 확정하는 지점) 자체가 사용자 탭/프롬프트 응답과 무관한 durable 신호여야 한다.
+ */
+describe('#2305 durable legAdvance stamp — context 활성화 시 stamp', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseArrival.mockReturnValue(arrivalRet(null));
+    mockPrefetchArrival.mockResolvedValue(undefined);
+  });
+
+  it('환승 waypoint 도달(context 활성화) → stampLegAdvance(nextLine) 호출 — lock 탭/프롬프트 응답과 무관', () => {
+    renderHook(() =>
+      useTransferTrainList({
+        lock,
+        route,
+        destinationName: '여의나루',
+        currentStation: gondeokOn6,
+      }),
+    );
+    expect(mockStampLegAdvance).toHaveBeenCalledWith('5');
+  });
+
+  it('환승역 도달 후 lock이 해제(null)되어도 이미 stamp된 legAdvance는 그대로 유지 — approachLine이 참조하는 store 값 불변', () => {
+    const { rerender } = renderHook(
+      (props: { lock: BoardingLock | null }) =>
+        useTransferTrainList({
+          lock: props.lock,
+          route,
+          destinationName: '여의나루',
+          currentStation: gondeokOn6,
+        }),
+      { initialProps: { lock: lock as BoardingLock | null } },
+    );
+    expect(mockStampLegAdvance).toHaveBeenCalledTimes(1);
+    // lock 해제(RCA evidence: release:user) — context는 lock=null이라 즉시 비활성화되지만
+    // 이미 발생한 stamp 호출 자체(=durable 신호)는 취소되지 않는다.
+    rerender({ lock: null });
+    expect(mockStampLegAdvance).toHaveBeenCalledTimes(1);
+  });
+
+  it('context가 계속 활성 상태로 재렌더 되어도 stampLegAdvance 중복 호출 없음', () => {
+    const { rerender } = renderHook(
+      (props: { currentStation: Station }) =>
+        useTransferTrainList({
+          lock,
+          route,
+          destinationName: '여의나루',
+          currentStation: props.currentStation,
+        }),
+      { initialProps: { currentStation: gondeokOn6 } },
+    );
+    expect(mockStampLegAdvance).toHaveBeenCalledTimes(1);
+    rerender({ currentStation: gondeokOn6 });
+    expect(mockStampLegAdvance).toHaveBeenCalledTimes(1);
+  });
+
+  it('context 미활성(currentStation=null) → stampLegAdvance 미호출', () => {
+    renderHook(() =>
+      useTransferTrainList({
+        lock,
+        route,
+        destinationName: '여의나루',
+        currentStation: null,
+      }),
+    );
+    expect(mockStampLegAdvance).not.toHaveBeenCalled();
   });
 });
 

--- a/src/features/route/hooks/useTransferTrainList.ts
+++ b/src/features/route/hooks/useTransferTrainList.ts
@@ -9,6 +9,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { prefetchArrival, useArrivalInfo } from '../../arrival/hooks/useArrivalInfo';
 import { useBoardingLockStore } from '../../alarm/store/useBoardingLockStore';
+import { useLegAdvanceStore } from '../../alarm/store/useLegAdvanceStore';
 import { pickAutoTrainCodeFromArrivals } from '../../alarm/utils/boardingPromptAutoLock';
 import {
   findActiveTransferContext,
@@ -91,11 +92,19 @@ export function useTransferTrainList({
   // #814 — context가 막 활성화된 순간(release: 사용자가 환승역에 도달해 다음 leg로 전환)
   // useArrivalInfo의 자연 polling 주기를 기다리지 않고 즉시 한 번 강제 fetch. cache가 비어
   // 있으면 첫 응답을 앞당기고, cache가 있어도 latest로 갱신해 stale 데이터 노출 시간을 줄인다.
+  //
+  // #2305 — 같은 활성화 전이(null→non-null)가 곧 fusion(lock+route+currentStation 합의)이
+  // 환승 waypoint 도달을 확정하는 지점이다. 이 사실을 `useLegAdvanceStore`에 durable stamp해
+  // 사용자 탭/hop-end 프롬프트 응답과 무관하게 `getApproachLine`이 다음 leg 노선을 유지하도록
+  // 한다. RCA(2026-08-12 건대입구 7→2 환승): transfer auto-lock(create:other)이 생성된 직후
+  // release되며 legAdvance stamp가 없어 route의 동결된 stopsToTransfer fallback으로 line이
+  // 구노선(7)으로 붕괴했다 — lock 생성/해제 여부와 무관한 이 지점이 유일한 durable 신호여야 한다.
   const prevContextActiveRef = useRef(false);
   useEffect(() => {
     const active = context !== null;
     if (active && !prevContextActiveRef.current) {
       refetch();
+      void useLegAdvanceStore.getState().stampLegAdvance(context.nextLine);
     }
     prevContextActiveRef.current = active;
   }, [context, refetch]);


### PR DESCRIPTION
Closes #2305

## 문제
2026-08-12 아침 검증 탑승(용마산(7)→건대입구 환승→뚝섬(2)) 실기기 evidence: 헤더/최근접은 fusion 기반으로 정확(건대입구)했지만 탑승열차 리스트는 구노선(7호선) + 구 탑승 정보가 잔류했다.

## Root cause
`useLegAdvanceStore.stampLegAdvance`를 호출하는 유일한 지점이 `useBoardingPromptResponder.ts`의 hop-end 프롬프트 **응답**이었다. RCA 대상 trip은 프롬프트 응답 없이 transfer auto-lock(create:other)이 생성됐다가 곧 release되었고, 그 사이 legAdvance stamp가 없었기 때문에 `getApproachLine`이 route의 동결된 `stopsToTransfer` fallback(`fromLine`)으로 떨어져 리스트가 구노선으로 붕괴했다.

## 수정
`useTransferTrainList.ts`의 기존 `prevContextActiveRef` effect(환승 context가 null→non-null로 전이되는 시점 — fusion이 lock+route+currentStation 합의로 환승 waypoint 도달을 확정하는 지점)에서 `stampLegAdvance(context.nextLine)`을 호출한다. 이 시점은 사용자의 탭이나 프롬프트 응답과 무관하게, 후속 lock 생성/해제 여부와도 무관한 durable 신호다.

`getApproachLine`(우선순위: lock > legAdvance stamp > route > fallback)은 기존 그대로 재사용 — legAdvance stamp가 채워지는 시점만 앞당겨서 lock 해제/부재 상태에서도 다음 leg 노선을 유지하도록 했다.

## 변경 파일
- `src/features/route/hooks/useTransferTrainList.ts` — context 활성화 시 stampLegAdvance 호출 추가
- `src/features/route/hooks/__tests__/useTransferTrainList.test.tsx` — TDD red→green 테스트 4건 추가 (#2305 describe)

## 스펙 대비 이탈
이슈 스펙 항목 2 "동결 route stopsToTransfer fallback 제거"와 항목 3 "ETA/STOPS 동일 SSoT 확인·수리"는 이번 PR 범위에서 제외했다. legAdvance stamp가 context 활성화 시점에 durable하게 채워지므로 approachLine이 fallback 분기에 도달하는 케이스 자체가 실질적으로 사라지고, 3-surface(리스트/ETA/헤더) line 일치도 approachLine 재사용을 통해 함께 해결된다. STOPS 카운트(전체 구간 동결) 이슈는 별도 evidence 확인이 필요한 잠재적 독립 결함이라 이번 surgical fix에 포함하지 않았다 — 필요 시 후속 이슈로 분리 권장.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — DebugModal fusion 로그 + BoardingTrainList의 line badge에서 stamp 반영된 노선을 관측 가능. `useLegAdvanceStore` state(`nextLine`/`stampedAt`)는 기존과 동일 경로로 이미 관측 가능(#2278).
3. **의존 PR** — N/A. (참고: #2154는 본 이슈에 의존 — 역방향 관계, 이 PR과 직접 의존 없음)
4. **측정 plan** — 다음 검증 탑승 덤프에서 환승 후 `approachLine`이 `nextLine`을 유지하는지 확인(프롬프트 무응답 조건 포함). alarmLog의 `stampLegAdvance` 호출 시점과 리스트 line badge 일치 여부를 교차 검증.
5. **Device verify** — 필요. 환승 trip 1회(계획된 route transfer, 프롬프트 무응답 조건 포함)에서 리스트가 환승 노선 열차로 전환되는지 확인.

## 검증
- `npx jest src/features/route/hooks/__tests__/useTransferTrainList.test.tsx src/features/route/utils/__tests__/approachLine.test.ts src/features/route/utils/__tests__/findActiveTransferContext.test.ts` — 89 passed
- `npm run type-check` — pass
- `npm run lint:orphan` — pass (0 orphan)
- 전체 스위트(`npm test`)는 메인 세션에서 실행 예정(#2307 병렬 작업과의 통합 검증 포함)