### PR TITLE
chore(#2311): accel spike 로거 GPS accuracy 필드 명시화

### DIFF
--- a/src/features/debug/utils/__tests__/accelSpikeLogger.test.ts
+++ b/src/features/debug/utils/__tests__/accelSpikeLogger.test.ts
@@ -251,7 +251,7 @@ describe('accelSpikeLogger (SPIKE 영구 캡처 도구 승격, #2268)', () => {
       const written = mockFileWrite.mock.calls[0][0] as string;
       const lines = written.split('\n');
       const sampleLine = JSON.parse(lines[1]);
-      expect(sampleLine.gps).toEqual([1, 2, -1]);
+      expect(sampleLine.gps).toEqual({ lat: 1, lng: 2, accuracy: -1 });
       expect(uri).toContain('mock-file://');
     });
 

--- a/src/features/debug/utils/accelSpikeLogger.ts
+++ b/src/features/debug/utils/accelSpikeLogger.ts
@@ -16,7 +16,7 @@
  *
  * 로그 스키마 (JSONL, 분석 에이전트와 공유 — 임의 변경 금지):
  *   메타: {"meta":{"ride","placement","line","startedAt"}}
- *   샘플: {"t","ua":[x,y,z],"rr":[x,y,z],"g":[x,y,z],"rms","pat","cm","cmc","hpa","gps":[lat,lng,acc]|null}
+ *   샘플: {"t","ua":[x,y,z],"rr":[x,y,z],"g":[x,y,z],"rms","pat","cm","cmc","hpa","gps":{"lat","lng","accuracy"}|null}
  *   마크: {"t","mark":"arrive"|"depart"}
  */
 
@@ -53,7 +53,14 @@ export interface SpikeSample {
   cm: string | null;
   cmc: number | null;
   hpa: number | null;
-  gps: [number, number, number] | null;
+  gps: SpikeGpsFix | null;
+}
+
+/** GPS fix — horizontal accuracy(m) 포함, 지하 구간 coarse fix 판별용(#2311). */
+export interface SpikeGpsFix {
+  lat: number;
+  lng: number;
+  accuracy: number;
 }
 
 export interface SpikeMark {
@@ -80,7 +87,7 @@ let meta: (SpikeMeta & { startedAt: number }) | null = null;
 let active = false;
 let deviceMotionSub: { remove(): void } | null = null;
 let locationSub: { remove(): void } | null = null;
-let latestFix: [number, number, number] | null = null;
+let latestFix: SpikeGpsFix | null = null;
 let motionActivityStarted = false;
 
 function pushEvent(event: SpikeEvent): void {
@@ -171,7 +178,11 @@ export function startSpikeLogging(input: SpikeMeta): void {
       locationSub = await Location.watchPositionAsync(
         { accuracy: Location.Accuracy.BestForNavigation, timeInterval: 1000, distanceInterval: 0 },
         (loc) => {
-          latestFix = [loc.coords.latitude, loc.coords.longitude, loc.coords.accuracy ?? -1];
+          latestFix = {
+            lat: loc.coords.latitude,
+            lng: loc.coords.longitude,
+            accuracy: loc.coords.accuracy ?? -1,
+          };
         },
       );
     } catch {


### PR DESCRIPTION
Closes #2311

## 배경
2026-08-12 spike 판정(#2269 코멘트): 지하 7호선 구간 캡처에서 GPS accuracy 여부 판별 불가로 재캡처 필요.

## 실제 코드 확인 결과 (스펙 대비 이탈)
이슈 본문은 "기존 [lat,lng,alt] → accuracy 포함"을 전제로 했으나, `accelSpikeLogger.ts`는 최초 커밋(49e0d840, 2026-08-10)부터 `gps` 3번째 슬롯에 이미 `loc.coords.accuracy`를 기록 중이었다 (`alt`는 애초에 읽힌 적 없음). 즉 accuracy 값 자체는 이미 기록되고 있었다.

다만 포지셔널 튜플(`[lat, lng, acc]`)이라 스키마 doc 주석을 참조하지 않으면 3번째 값이 accuracy인지 다른 신호인지 분석 시점에 모호했을 가능성이 있고, 이것이 "accuracy 필드 미로깅으로 coarse fix 여부 판별 불가" 판정의 근본 원인으로 추정된다.

## 변경 사항
- `gps`를 `[lat,lng,acc]` 배열에서 `{ lat, lng, accuracy }` named object로 변경 — 값 자체는 동일(`loc.coords.accuracy ?? -1`), 표현만 명시화
- `SpikeGpsFix` 타입 export + 스키마 doc 주석 갱신
- in-repo 소비자 전수 확인 — `gps` 배열을 포지셔널로 인덱싱하는 코드 없음(DebugModal의 `entry.gps.accM` 등은 별개의 무관한 객체). 하위호환 영향 없음
- `accelSpikeLogger.test.ts`의 gps assertion을 object 형태로 갱신

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard** — 캡처 JSONL(`accel-spike-*.jsonl`)의 `gps.accuracy` 필드로 확인. 오프라인 분석 에이전트가 직접 읽음(별도 대시보드 없음, 스파이크 계측 스크립트)
3. **의존 PR** — N/A
4. **측정 plan** — 다음 재캡처(pocket/bag, 지하 구간 포함) 1회로 `gps.accuracy` 값이 기록되는지 확인
5. **Device verify** — 필요. 시뮬레이터 또는 실기기 1회 캡처로 `gps: {lat, lng, accuracy}` 형태 확인 (이슈 본문 Acceptance와 동일)

## 검증
- `npx jest src/features/debug/utils/__tests__/accelSpikeLogger.test.ts` — 39/39 pass, 100% coverage
- `npm run type-check` — pass
- `npm run lint:orphan` — 0 orphan