### PR TITLE
fix: backend-ssot override line 정합 가드 — device 확정 노선을 backend mirror가 되감는 것 차단

### DIFF
--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -388,6 +388,12 @@ function formatFusionDebugLine(entry: FusionDebugEntry): string {
   if (entry.kind === 'display-demote') {
     return `${time} | ${entry.reason} | ${entry.stationName}(${entry.line})`;
   }
+  // #2307 — backend-ssot mirror line guard 거부 이벤트. device 확정 노선 vs mirror line 대조.
+  if (entry.kind === 'ssot-line-guard-reject') {
+    const mirror = `${entry.mirrorStationName}(${entry.mirrorLine})`;
+    const device = `${entry.deviceStationName}(${entry.deviceLine})`;
+    return `${time} | ssot-line-guard-reject | mirror=${mirror} device=${device}`;
+  }
   // #1902 (RC-18) — candidate-reject 분기는 candidateRejectBuffer로 이전(별 buffer + 별 섹션).
   // #1896 (RC-8) — boarding-lock-drift 분기는 boardingLockDriftBuffer로 이전(별 buffer + 별 섹션).
   // fusion 분기는 fusion decision entry만 처리한다.

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -2148,6 +2148,27 @@ describe('DebugModal fusion log section', () => {
     expect(entries[0].props.children).toContain('용마산(7)');
   });
 
+  // #2307 — backend-ssot mirror line guard 거부 entry (kind: 'ssot-line-guard-reject') 포맷 가드.
+  it('ssot-line-guard-reject entry를 mirror/device station(line) 포맷으로 노출한다', async () => {
+    renderWithTheme(<DebugModal onClose={jest.fn()} />);
+    await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+    act(() => {
+      pushFusionDebugEntry({
+        kind: 'ssot-line-guard-reject',
+        ts: new Date('2026-08-12T07:42:00Z').getTime(),
+        deviceStationName: '뚝섬',
+        deviceLine: '2',
+        mirrorStationName: '중곡',
+        mirrorLine: '7',
+      });
+    });
+    expect(screen.getByText('Fusion log (1)')).toBeTruthy();
+    const entries = screen.getAllByTestId('debug-fusion-log-entry');
+    expect(entries[0].props.children).toContain('ssot-line-guard-reject');
+    expect(entries[0].props.children).toContain('mirror=중곡(7)');
+    expect(entries[0].props.children).toContain('device=뚝섬(2)');
+  });
+
   it('Clear 버튼이 fusion 로그를 비운다', async () => {
     pushFusionDebugEntry({
       kind: 'gps',

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.ssotLineGuard.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.ssotLineGuard.test.ts
@@ -1,0 +1,141 @@
+/* eslint-disable import/no-restricted-paths -- cross-feature orchestration (#890) */
+
+/**
+ * #2307 — backend-ssot mirror line guard.
+ *
+ * 2026-08-12 아침 검증 탑승 evidence: device position-train이 2호선(강남) 확정 중인데 backend
+ * mirror가 7호선(용마산)으로 re-anchor → 기존 코드는 line 정합 검증 없이 mirror를 그대로 채택해
+ * 헤더·리스트가 되감겼다. ADR-010 device self-contained 원칙 — device 라이브 확정 신호
+ * (positionTrainResult, distance/arc/forward 게이트 통과)를 backend mirror가 되감을 수 없다.
+ *
+ * lockless(3-of-3 lock 합의 미충족)에서도 line-guard가 적용돼야 하므로, 본 파일은 lockless
+ * 4-signal consensus(barometer/accelerometer/cellular)를 만족시켜 positionTrainResult를
+ * non-null로 확보한 상태에서 검증한다 (`positionTrainConsensus.requiresPositionTrainConsensus`).
+ */
+
+jest.mock('../useNearestStation');
+jest.mock('../../../arrival/hooks/useArrivalInfo');
+jest.mock('../../../route/hooks/useTrainPositions');
+jest.mock('../../utils/findNearestStation', () => ({
+  findTopNearestStations: jest.fn(),
+}));
+jest.mock('../../../alarm/utils/tripStartStorage', () => ({
+  getTripStartedAt: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../../../alarm/utils/backendSsotMirror', () => ({
+  readBackendSsotMirror: jest.fn(),
+}));
+// lockless 4-signal consensus 충족 — positionTrainResult가 line-guard 검증을 위해 non-null이어야 함.
+jest.mock('../useAccelerometerFingerprint', () => ({
+  useAccelerometerFingerprint: () => 'automotive',
+}));
+jest.mock('../useCellularTech', () => ({
+  useCellularTech: () => 'surface',
+}));
+
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useFusedNearestStation } from '../useFusedNearestStation';
+import { useNearestStation } from '../useNearestStation';
+import { useArrivalInfo } from '../../../arrival/hooks/useArrivalInfo';
+import { useTrainPositions } from '../../../route/hooks/useTrainPositions';
+import { findTopNearestStations } from '../../utils/findNearestStation';
+import { findStationByNameAndLine } from '../../../../shared/utils/stationRoute';
+import { TRAIN_STATUS } from '../../../../shared/constants/trainStatus';
+import {
+  arrivalRet,
+  positionRet,
+  makeTrain as train,
+  GPS_BASE_DEFAULTS,
+} from '../../../../testUtils/positionApiFixtures';
+import {
+  BACKEND_SSOT_FIXTURE_T0 as T0,
+  flushBackendSsotMirrorTick,
+  makeBackendSsotMirrorEntry,
+} from '../../../../testUtils/backendSsotMirrorFixtures';
+import { readBackendSsotMirror } from '../../../alarm/utils/backendSsotMirror';
+
+const mockNearest = useNearestStation as jest.Mock;
+const mockArrival = useArrivalInfo as jest.Mock;
+const mockPos = useTrainPositions as jest.Mock;
+const mockFindTop = findTopNearestStations as jest.Mock;
+const mockRead = readBackendSsotMirror as jest.Mock;
+
+const yongmasan = findStationByNameAndLine('용마산', '7')!;
+const chungdam = findStationByNameAndLine('청담', '7')!;
+const gangnam2 = findStationByNameAndLine('강남', '2')!;
+
+const TRAIN_CODE = 'T-2307';
+
+function setupPositionTrainAt(station: typeof gangnam2, line: '2' | '7') {
+  const live = { station, distanceKm: 0 };
+  mockNearest.mockReturnValue({
+    result: live,
+    liveResult: live,
+    stickyDisplayOnly: null,
+    variants: [station],
+    userLocation: { lat: station.lat, lng: station.lng },
+    ...GPS_BASE_DEFAULTS,
+    accuracyMeters: 14,
+    refresh: jest.fn(),
+  });
+  mockFindTop.mockReturnValue([{ station, distanceKm: 0 }]);
+  mockArrival.mockReturnValue(arrivalRet(null));
+  mockPos.mockReturnValue(
+    positionRet({ line, trains: [train(station.name, TRAIN_STATUS.ARRIVED, { trainNo: TRAIN_CODE })] }),
+  );
+}
+
+describe('#2307 backend-ssot line guard — device 확정 노선과 mirror line 불일치 시 채택 거부', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(T0);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('device position-train이 2호선(강남) 확정 + mirror가 7호선(용마산) 주입 → line2 유지 (mirror 거부)', async () => {
+    setupPositionTrainAt(gangnam2, '2');
+    mockRead.mockResolvedValue(makeBackendSsotMirrorEntry({ currentStationId: yongmasan.name }));
+    // lockless — boardingLock/lockedTrainCode 없음. 3-of-3 lock 합의(#1646) 경로가 아니라
+    // 순수 line-guard만으로 거부되는지 검증.
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushBackendSsotMirrorTick();
+    await waitFor(() => {
+      expect(hook.result.current.source).not.toBe('backend-ssot');
+    });
+    expect(hook.result.current.result?.station.line).toBe('2');
+    expect(hook.result.current.result?.station.id).not.toBe(yongmasan.id);
+    expect(hook.result.current.ssotLineGuardRejectCount).toBeGreaterThan(0);
+  });
+
+  it('device position-train과 mirror가 같은 line(7)이면 station 달라도 기존대로 mirror 채택 (회귀 방지)', async () => {
+    // line-guard는 line 불일치만 거부한다. 같은 line 내 station 오버라이드(backend가 더 앞선
+    // station을 안다고 판단하는 기존 동작)는 보존.
+    setupPositionTrainAt(yongmasan, '7');
+    mockRead.mockResolvedValue(makeBackendSsotMirrorEntry({ currentStationId: chungdam.name }));
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushBackendSsotMirrorTick();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+    expect(hook.result.current.result?.station.id).toBe(chungdam.id);
+    expect(hook.result.current.ssotLineGuardRejectCount).toBe(0);
+  });
+
+  it('positionTrainResult 없음(consensus 미충족/mirror만 존재) → 기존대로 mirror 채택 (가드 미적용)', async () => {
+    setupPositionTrainAt(gangnam2, '2');
+    // train 없음 → candidateTrains 비어 positionTrainResult=null.
+    mockPos.mockReturnValue(positionRet(null));
+    mockRead.mockResolvedValue(makeBackendSsotMirrorEntry({ currentStationId: yongmasan.name }));
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushBackendSsotMirrorTick();
+    await waitFor(() => {
+      expect(hook.result.current.source).toBe('backend-ssot');
+    });
+    expect(hook.result.current.result?.station.id).toBe(yongmasan.id);
+    expect(hook.result.current.ssotLineGuardRejectCount).toBe(0);
+  });
+});

--- a/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.ssotLineGuard.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useFusedNearestStation.ssotLineGuard.test.ts
@@ -53,6 +53,7 @@ import {
   makeBackendSsotMirrorEntry,
 } from '../../../../testUtils/backendSsotMirrorFixtures';
 import { readBackendSsotMirror } from '../../../alarm/utils/backendSsotMirror';
+import { getFusionDebugEntries, clearFusionDebugEntries } from '../../utils/fusionDebugBuffer';
 
 const mockNearest = useNearestStation as jest.Mock;
 const mockArrival = useArrivalInfo as jest.Mock;
@@ -90,10 +91,38 @@ describe('#2307 backend-ssot line guard — device 확정 노선과 mirror line 
     jest.clearAllMocks();
     jest.useFakeTimers();
     jest.setSystemTime(T0);
+    clearFusionDebugEntries();
   });
 
   afterEach(() => {
     jest.useRealTimers();
+  });
+
+  it('DebugModal Fusion log 채널로 ssot-line-guard-reject entry가 push된다 (dedup: 지속 mismatch는 1건만)', async () => {
+    setupPositionTrainAt(gangnam2, '2');
+    mockRead.mockResolvedValue(makeBackendSsotMirrorEntry({ currentStationId: yongmasan.name }));
+    const hook = renderHook(() => useFusedNearestStation());
+    await flushBackendSsotMirrorTick();
+    await waitFor(() => {
+      expect(hook.result.current.source).not.toBe('backend-ssot');
+    });
+    const entries = getFusionDebugEntries().filter((e) => e.kind === 'ssot-line-guard-reject');
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      kind: 'ssot-line-guard-reject',
+      deviceStationName: gangnam2.name,
+      deviceLine: '2',
+      mirrorStationName: yongmasan.name,
+      mirrorLine: '7',
+    });
+
+    // 다음 mirror read cycle에서도 동일 mismatch가 지속되면 재적재하지 않는다 (dedup).
+    mockRead.mockResolvedValue(
+      makeBackendSsotMirrorEntry({ currentStationId: yongmasan.name, receivedAt: T0 + 5_000 }),
+    );
+    await flushBackendSsotMirrorTick();
+    const entriesAfter = getFusionDebugEntries().filter((e) => e.kind === 'ssot-line-guard-reject');
+    expect(entriesAfter).toHaveLength(1);
   });
 
   it('device position-train이 2호선(강남) 확정 + mirror가 7호선(용마산) 주입 → line2 유지 (mirror 거부)', async () => {

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -1140,8 +1140,15 @@ export function useFusedNearestStation(
   //      같은 line 내 다른 station(backend가 한 정거장 앞을 안다고 판단하는 케이스)은 기존대로
   //      허용 — 본 가드는 cross-line false override만 차단한다(노선 하드코딩 없이 값 비교만).
   const ssotLineGuardRejectRef = useRef(0);
-  const ssotStation = useMemo<Station | null>(() => {
-    if (!backendSsotMirror) return null;
+  // #2307 — resolve 결과 + line-guard 거부 여부를 함께 산출. 거부 여부를 별도 값으로 노출해야
+  // 아래 dedup 효과(DebugModal Fusion log push)가 "line 불일치로 거부"와 "mirror 자체가 없음/
+  // 다른 사유로 resolve 실패"를 구분할 수 있다 (그렇지 않으면 무관한 null 전이도 push 대상이 됨).
+  const ssotGuardResult = useMemo<{
+    station: Station | null;
+    lineGuardRejected: boolean;
+    mirrorLine: LineNumber | null;
+  }>(() => {
+    if (!backendSsotMirror) return { station: null, lineGuardRejected: false, mirrorLine: null };
     let resolved: Station | null;
     if (boardingLock) {
       // lock 활성: lock.boardingLine으로 단일화 (기존 동작).
@@ -1161,16 +1168,43 @@ export function useFusedNearestStation(
       // currentStationLine 부재(legacy v1 mirror) 시 name-only fallback (기존 동작).
       resolved = findStationByName(backendSsotMirror.currentStationId);
     }
+    const mirrorLine = resolved?.line ?? null;
     if (
       resolved &&
       positionTrainResult &&
       resolved.line !== positionTrainResult.station.line
     ) {
       ssotLineGuardRejectRef.current += 1;
-      return null;
+      return { station: null, lineGuardRejected: true, mirrorLine };
     }
-    return resolved;
+    return { station: resolved, lineGuardRejected: false, mirrorLine };
   }, [backendSsotMirror, boardingLock, positionTrainResult]);
+  const ssotStation = ssotGuardResult.station;
+  // #2307 — DebugModal Fusion log 관측 채널. false→true 전환 시에만 push해 동일 mismatch가
+  // 지속되는 cycle(수 분)에 매번 재적재되어 fusionDebugBuffer 500 cap을 점령하는 것을 방지
+  // (#2125 display-demote와 동일 dedup 컨벤션).
+  const wasSsotLineGuardRejectedRef = useRef(false);
+  useEffect(() => {
+    if (
+      ssotGuardResult.lineGuardRejected &&
+      !wasSsotLineGuardRejectedRef.current &&
+      positionTrainResult &&
+      backendSsotMirror &&
+      // 타입 내로잉용 — lineGuardRejected=true는 항상 resolve 성공(mirrorLine non-null) 이후에만
+      // 설정되므로(위 ssotGuardResult useMemo) 실질적으로 이 분기는 항상 통과한다.
+      ssotGuardResult.mirrorLine != null
+    ) {
+      pushFusionDebugEntry({
+        kind: 'ssot-line-guard-reject',
+        ts: Date.now(),
+        deviceStationName: positionTrainResult.station.name,
+        deviceLine: positionTrainResult.station.line,
+        mirrorStationName: backendSsotMirror.currentStationId,
+        mirrorLine: ssotGuardResult.mirrorLine,
+      });
+    }
+    wasSsotLineGuardRejectedRef.current = ssotGuardResult.lineGuardRejected;
+  }, [ssotGuardResult, positionTrainResult, backendSsotMirror]);
   const nowMsForSsot = Date.now();
   // #2261 (ADR-031 Phase 0) — freshness를 `lastAdvanceAt`(backend가 실제 advance한 시각) 대신
   // `receivedAt`(mirror가 device에 도달한 시각) 기준으로 재정의. lastAdvanceAt 기준은 지하·정지

--- a/src/features/nearest-station/hooks/useFusedNearestStation.ts
+++ b/src/features/nearest-station/hooks/useFusedNearestStation.ts
@@ -298,6 +298,12 @@ interface UseFusedNearestStationReturn {
    * 1주 tier 분포(어떤 tier가 cascade 결정에 기여) acceptance 측정용.
    */
   fusionTierAdopted: FusionTierName;
+  /**
+   * #2307 — backend-ssot mirror가 device 확정 노선(positionTrainResult.station.line)과
+   * 다른 line을 가리켜 override가 거부된 누적 횟수. DebugModal/Sentry에서 backend re-anchor
+   * drift 빈도 측정용(세션 내 in-memory 카운트, mount마다 0으로 리셋).
+   */
+  ssotLineGuardRejectCount: number;
   /** #1418 — 지상 Tier 1 SSOT(GPS+Arrival) 합의 활성 여부. */
   surfaceSSOTActive: boolean;
   /** #1418 — 지하 Tier 1 SSOT(WiFi/Position-Train + Arrival) 합의 활성 여부. */
@@ -1126,27 +1132,45 @@ export function useFusedNearestStation(
   //      cascade 채택 시 사용자 실제 위치를 뒤덮을 risk가 있어 자연 fallback.
   //   3. 노선 가드 — lock 활성 시 resolved station이 lock.boardingLine과 일치해야 채택.
   //      lockless trip은 노선 가드 없이 backend가 advance한 station을 신뢰(보조 cross-check 없음).
+  //   4. #2307 — device 확정 노선 가드 (ADR-010 device self-contained). device의
+  //      positionTrainResult(distance/arc/forward 게이트를 이미 통과한 live 확정 신호)가 존재하고
+  //      resolve된 mirror station의 line과 다르면 override를 거부한다. 2026-08-12 아침 evidence:
+  //      device가 2호선 주행 중(position-train 확정)인데 backend가 7호선 route로 re-anchor →
+  //      기존 코드는 line 정합 검증 없이 mirror를 그대로 채택해 헤더·리스트가 되감겼다.
+  //      같은 line 내 다른 station(backend가 한 정거장 앞을 안다고 판단하는 케이스)은 기존대로
+  //      허용 — 본 가드는 cross-line false override만 차단한다(노선 하드코딩 없이 값 비교만).
+  const ssotLineGuardRejectRef = useRef(0);
   const ssotStation = useMemo<Station | null>(() => {
     if (!backendSsotMirror) return null;
+    let resolved: Station | null;
     if (boardingLock) {
       // lock 활성: lock.boardingLine으로 단일화 (기존 동작).
-      return findStationByNameAndLine(
+      resolved = findStationByNameAndLine(
         backendSsotMirror.currentStationId,
         boardingLock.boardingLine,
       );
-    }
-    // #1705 — lockless trip: backend가 forward한 currentStationLine이 있으면 line 정확 매칭.
-    // 동명 환승역(합정 2/6호선, 공덕 5/6호선 등) cross-line confusion 차단.
-    // currentStationLine 부재(legacy v1 mirror) 시 name-only fallback (기존 동작).
-    // cast: backend의 Waypoint.line 어휘는 device LineNumber union과 동일 값 집합.
-    if (backendSsotMirror.currentStationLine !== undefined) {
-      return findStationByNameAndLine(
+    } else if (backendSsotMirror.currentStationLine !== undefined) {
+      // #1705 — lockless trip: backend가 forward한 currentStationLine이 있으면 line 정확 매칭.
+      // 동명 환승역(합정 2/6호선, 공덕 5/6호선 등) cross-line confusion 차단.
+      // cast: backend의 Waypoint.line 어휘는 device LineNumber union과 동일 값 집합.
+      resolved = findStationByNameAndLine(
         backendSsotMirror.currentStationId,
         backendSsotMirror.currentStationLine as LineNumber,
       );
+    } else {
+      // currentStationLine 부재(legacy v1 mirror) 시 name-only fallback (기존 동작).
+      resolved = findStationByName(backendSsotMirror.currentStationId);
     }
-    return findStationByName(backendSsotMirror.currentStationId);
-  }, [backendSsotMirror, boardingLock]);
+    if (
+      resolved &&
+      positionTrainResult &&
+      resolved.line !== positionTrainResult.station.line
+    ) {
+      ssotLineGuardRejectRef.current += 1;
+      return null;
+    }
+    return resolved;
+  }, [backendSsotMirror, boardingLock, positionTrainResult]);
   const nowMsForSsot = Date.now();
   // #2261 (ADR-031 Phase 0) — freshness를 `lastAdvanceAt`(backend가 실제 advance한 시각) 대신
   // `receivedAt`(mirror가 device에 도달한 시각) 기준으로 재정의. lastAdvanceAt 기준은 지하·정지
@@ -2323,6 +2347,7 @@ export function useFusedNearestStation(
     environmentHintReason: environmentResult.hintReason,
     // #1936 — cascade picker가 채택한 tier 이름 (DebugModal + Sentry tier 분포 측정 SSOT).
     fusionTierAdopted: adoptedTier,
+    ssotLineGuardRejectCount: ssotLineGuardRejectRef.current,
     surfaceSSOTActive: surfaceSSOT !== null,
     undergroundSSOTActive: undergroundSSOT !== null,
     // #1421 — DebugModal Auto-lock 측정 섹션이 SSOT 객체를 inferAutoLockCandidate에 직접 전달.

--- a/src/features/nearest-station/utils/fusionDebugBuffer.ts
+++ b/src/features/nearest-station/utils/fusionDebugBuffer.ts
@@ -1,4 +1,5 @@
 import type { FusionConfidence, FusionSource } from './pickFusedStation';
+import type { LineNumber } from '../../../shared/types/station';
 import { createDebugBuffer } from '../../../shared/utils/createDebugBuffer';
 
 // 측정 인프라(#443): fusion 결정/GPS fix 이벤트를 in-memory ring buffer에 보관.
@@ -121,11 +122,33 @@ export interface DisplayDemoteEntry {
   line: string;
 }
 
+/**
+ * #2307 — backend-ssot mirror line guard 거부 이벤트. device 확정 노선(positionTrainResult)과
+ * mirror가 resolve한 station의 line이 달라 override가 거부됐을 때 1건 push(dedup: false→true
+ * 전환 시에만 — 동일 mismatch 지속 cycle에서 buffer 점령 방지, #2125 display-demote와 동일 컨벤션).
+ * ADR-010 device self-contained 원칙 위반 시도(backend re-anchor drift)를 사후 재구성하기 위한
+ * 관측 채널 — fire/알람 경로는 본 entry를 읽지 않는다.
+ */
+export interface SsotLineGuardRejectEntry {
+  kind: 'ssot-line-guard-reject';
+  ts: number;
+  /** device가 확정한 현재 station/line (positionTrainResult). */
+  deviceStationName: string;
+  deviceLine: LineNumber;
+  /**
+   * 거부된 backend mirror의 station/line. push 시점에 이미 resolve된 station의 line이므로
+   * (거부는 resolve 성공 후 line mismatch 판정에서만 발생) 항상 non-null.
+   */
+  mirrorStationName: string;
+  mirrorLine: LineNumber;
+}
+
 export type FusionDebugEntry =
   | FusionDecisionEntry
   | GpsFixEntry
   | StickyStationEntry
-  | DisplayDemoteEntry;
+  | DisplayDemoteEntry
+  | SsotLineGuardRejectEntry;
 
 const db = createDebugBuffer<FusionDebugEntry>(FUSION_DEBUG_BUFFER_CAPACITY);
 


### PR DESCRIPTION
Closes #2307

## 요약
2026-08-12 아침 검증 탑승 evidence — device가 2호선 주행 중(position-train 확정, 건대입구→뚝섬 leg)인데 backend가 7호선 route로 re-anchor → `backendSsotMirror`=중곡(7)을 fusion 최상위 tier가 그대로 채택해 헤더·리스트가 되감기는 회귀. ADR-010 "device self-contained" 원칙에 따라 device 라이브 확정 신호를 backend mirror가 되감을 수 없도록 line 정합 가드를 추가.

## 변경
- `useFusedNearestStation.ts` `ssotStation` useMemo(L1129~) — mirror station을 resolve한 뒤, device의 `positionTrainResult`(distance/arc/forward 게이트를 이미 통과한 live 확정 신호)가 존재하고 그 line이 resolve된 station의 line과 다르면 override 거부(null 반환). 내부적으로 `ssotGuardResult`(station/lineGuardRejected/mirrorLine)로 확장해 거부 여부를 별도 신호로 노출.
- 같은 line 내 다른 station으로의 override(backend가 한 정거장 앞을 안다고 판단하는 기존 케이스, #1568/#1705)는 그대로 허용 — 본 가드는 **cross-line false override만** 차단(line 하드코딩 없이 값 비교만).
- `ssotLineGuardRejectCount` 카운터를 hook 반환값에 추가 — 거부 발생 누적 횟수(mount 세션 내 in-memory).
- **(follow-up 커밋)** `fusionDebugBuffer.ts`에 `SsotLineGuardRejectEntry`(kind: `ssot-line-guard-reject`) 신규 — device 확정 station/line vs 거부된 mirror station/line을 기록. dedup(false→true 전환 시만 push, #2125 display-demote와 동일 컨벤션)으로 지속 mismatch cycle의 buffer 점령 방지. `DebugModal.tsx` `formatFusionDebugLine`에 해당 kind 분기를 추가해 기존 Fusion log 섹션에서 그대로 렌더(신규 섹션 불필요) — 노출만 되고 렌더 안 되는 dead-wire 상태 해소. 기존 `fusionTierAdopted` 등 다른 미배선 필드는 별건이라 미변경.

## 테스트
- `useFusedNearestStation.ssotLineGuard.test.ts`:
  1. device line2(강남) 확정 + mirror line7(용마산) 주입 → line2 유지 + mirror 거부 확인 (재현 red → green)
  2. 같은 line(7) 내 mirror override는 기존대로 채택 (회귀 방지)
  3. positionTrainResult 없음(consensus 미충족) → 가드 미적용, 기존 mirror 채택 동작 보존
  4. DebugModal Fusion log 채널로 `ssot-line-guard-reject` entry가 실제 push되는지 + 연속 mismatch cycle에서 dedup(1건만 적재)되는지 검증
- `DebugModal.test.tsx`에 `ssot-line-guard-reject` 포맷 가드 테스트 추가.
- `useFusedNearestStation.backendSsotCascade.test.ts` 등 기존 cascade 관련 6개 테스트 파일(151 tests) 전량 green 확인 — 회귀 없음.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan)
2. **V/X dashboard** — DebugModal Fusion log 섹션에서 `ssot-line-guard-reject` entry로 직접 관측 가능(mirror station/line vs device station/line 대조 표시). `ssotLineGuardRejectCount`도 hook 반환값에 노출(세션 누적). 보조로 `fusionTierAdopted`/Sentry `fusion.tier_adopted` breadcrumb 분포에서도 `backend-ssot` tier 채택 빈도 감소 + fallback tier(`position-train`) 이동을 간접 관측 가능.
3. **의존 PR** — N/A (backend re-anchor drift 자체의 RCA/수리는 별도 이슈, 본 PR은 device 측 방어선 단독)
4. **측정 plan** — 다음 실기기 탑승(환승 trip)에서 DebugModal Fusion log의 `ssot-line-guard-reject` entry 발생 여부 + `ssotLineGuardRejectCount`로 override-거부 빈도 관측. 아침 시나리오(건대입구→뚝섬, 07:41~07:43)와 동일 경로 권장.
5. **Device verify** — 필요. 환승 trip 1회(아침 시나리오 동일 경로) 재생 시 중곡(7) 채택 0회 + DebugModal Fusion log에 거부 entry 기록 확인.
