### PR TITLE
fix(#2309): alarmAccuracy 지표 왜곡 — 정확 발사 후 조기 종료 시 miss 계수 차단

### DIFF
--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -20,6 +20,8 @@ import {
   FIRED_ALARM_LOG_BUFFER_SIZE,
   type FiredAlarmLogEntry,
   logFiredAlarm,
+  consumeAccurateDestinationFire,
+  _resetAccurateDestinationFireForTests,
   logFiredStationPassed,
   logScheduledAlarm,
   logFiredAlarmsHydrate,
@@ -550,6 +552,32 @@ describe('alarmLog', () => {
         phaseId: event.phaseId,
       });
       expect(saved[0].ts).toBeGreaterThan(0);
+    });
+
+    // #2309 — destination imminent 발사(fusion arrival-confirmed 신호)는 accurate-fire flag를
+    // 세운다. trip 종료 시 triggerTripGroundTruthPrompt가 소비해 수동 정답지 없이 즉시 확정.
+    describe('consumeAccurateDestinationFire (#2309)', () => {
+      beforeEach(() => {
+        _resetAccurateDestinationFireForTests();
+      });
+
+      it('destination + imminent 발사 시 flag가 true로 세워지고 1회 소비 후 리셋된다', () => {
+        expect(consumeAccurateDestinationFire()).toBe(false);
+        logFiredAlarm('fg', { phaseId: 'imminent', type: 'destination', stationName: '뚝섬' });
+        expect(consumeAccurateDestinationFire()).toBe(true);
+        // 소비 직후 리셋 — 다음 trip으로 새지 않는다.
+        expect(consumeAccurateDestinationFire()).toBe(false);
+      });
+
+      it('destination이라도 phase가 early면 flag를 세우지 않는다', () => {
+        logFiredAlarm('fg', event); // event = { phaseId: 'early', type: 'destination', ... }
+        expect(consumeAccurateDestinationFire()).toBe(false);
+      });
+
+      it('kind가 transfer/station-passed면 phaseId=imminent여도 flag를 세우지 않는다', () => {
+        logFiredAlarm('fg', { phaseId: 'imminent', type: 'transfer', stationName: '건대입구' });
+        expect(consumeAccurateDestinationFire()).toBe(false);
+      });
     });
 
     // #2122 (FG 보조 발사) — station-passed는 phase가 없어 logFiredAlarm(AlarmEvent 전용)을

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -521,6 +521,35 @@ export function logFiredAlarm(
     phaseId: event.phaseId,
     trigger,
   });
+  // #2309 — destination imminent 발사는 fusion이 arrival을 확인(진입/도착 감지)해야만 나가는
+  // 신호다(useStationAlarm.ts `isImminentByArrivalCode` / stationPipeline.ts 동일 phase 게이트).
+  // 즉 이 fire 자체가 "정확했다"는 객관적 ground truth. 발사 직후 사용자가 바로 trip을 종료하면
+  // (안내 종료 → user-delete) 수동 정답지 prompt가 완료되지 못해 miss로 self-report되는 왜곡이
+  // 있었다 — trip 종료 시 이 flag를 소비해 수동 응답 없이 즉시 accurate로 확정한다
+  // (triggerTripGroundTruthPrompt 참고).
+  if (event.type === 'destination' && event.phaseId === 'imminent') {
+    accurateDestinationFired = true;
+  }
+}
+
+// #2309 — 직전 destination imminent 발사가 fusion arrival-confirmed였는지 나타내는 in-memory
+// flag. trip 1개당 활성 trip은 항상 최대 1개라 corrId 매칭 없이도 안전 — trip 종료 시
+// `consumeAccurateDestinationFire`가 읽고 즉시 리셋해 다음 trip으로 새지 않는다. 다른 in-memory
+// ledger(`fireAlarmOnce`)와 동일하게 AsyncStorage roundtrip 없이 앱 lifetime 동안만 유지.
+let accurateDestinationFired = false;
+
+/**
+ * #2309 — pending 상태의 accurate destination fire flag를 읽고 즉시 리셋한다.
+ * trip 종료 흐름(`triggerTripGroundTruthPrompt`)이 정답지 prompt를 enqueue하기 직전 1회 호출.
+ */
+export function consumeAccurateDestinationFire(): boolean {
+  const value = accurateDestinationFired;
+  accurateDestinationFired = false;
+  return value;
+}
+
+export function _resetAccurateDestinationFireForTests(): void {
+  accurateDestinationFired = false;
 }
 
 /**

--- a/src/features/debug/components/__tests__/OperationDashboardSection.test.tsx
+++ b/src/features/debug/components/__tests__/OperationDashboardSection.test.tsx
@@ -70,6 +70,7 @@ function setupStore(responses: { outcome: 'accurate' | 'inaccurate' | 'unanswere
     responses: mapped,
     enqueuePrompt: jest.fn(),
     respond: jest.fn(),
+    recordAutoConfirmed: jest.fn(),
     hydrate: jest.fn(),
   };
   mockUseTripGroundTruthStore.mockImplementation((selector: (s: TripGroundTruthState) => unknown) =>

--- a/src/features/debug/store/__tests__/useTripGroundTruthStore.test.ts
+++ b/src/features/debug/store/__tests__/useTripGroundTruthStore.test.ts
@@ -174,6 +174,41 @@ describe('useTripGroundTruthStore (#1502 M2)', () => {
     });
   });
 
+  describe('recordAutoConfirmed (#2309)', () => {
+    it('pendingPrompt 없이 accurate 응답을 즉시 합류하고 persist한다', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(700);
+      await useTripGroundTruthStore.getState().recordAutoConfirmed('c-auto');
+      const state = useTripGroundTruthStore.getState();
+      expect(state.pendingPrompt).toBeNull();
+      expect(state.responses).toEqual([
+        { corrId: 'c-auto', endedAt: 700, respondedAt: 700, outcome: 'accurate' },
+      ]);
+      expect(mockSetItem).toHaveBeenCalledWith(TRIP_GROUND_TRUTH_KEY, expect.any(String));
+    });
+
+    it('logGroundTruthResult(corrId, accurate)를 forward한다', async () => {
+      await useTripGroundTruthStore.getState().recordAutoConfirmed('c-auto2');
+      expect(mockLogGroundTruthResult).toHaveBeenCalledWith({
+        corrId: 'c-auto2',
+        outcome: 'accurate',
+      });
+    });
+
+    it('기존 pendingPrompt가 있어도 그대로 보존한다 (별개 trip의 미응답 prompt 훼손 X)', async () => {
+      await useTripGroundTruthStore
+        .getState()
+        .enqueuePrompt({ corrId: 'other-trip', endedAt: 1 });
+      await useTripGroundTruthStore.getState().recordAutoConfirmed('c-auto3');
+      expect(useTripGroundTruthStore.getState().pendingPrompt).toEqual({
+        corrId: 'other-trip',
+        endedAt: 1,
+      });
+      expect(useTripGroundTruthStore.getState().responses).toEqual([
+        { corrId: 'c-auto3', endedAt: expect.any(Number), respondedAt: expect.any(Number), outcome: 'accurate' },
+      ]);
+    });
+  });
+
   describe('hydrate', () => {
     it('storage가 비어있으면 hydrated=true만 set', async () => {
       mockGetItem.mockResolvedValue(null);

--- a/src/features/debug/store/useTripGroundTruthStore.ts
+++ b/src/features/debug/store/useTripGroundTruthStore.ts
@@ -60,6 +60,12 @@ export interface TripGroundTruthState {
    * pendingPrompt 부재 시 graceful no-op (race 안전).
    */
   respond: (outcome: TripGroundTruthOutcome) => Promise<void>;
+  /**
+   * #2309 — trip 종료 시 destination imminent 발사가 fusion arrival-confirmed였던 trip을
+   * 수동 Yes/No 없이 즉시 'accurate'로 확정한다. pendingPrompt를 enqueue하지 않아 모달이
+   * 뜨지 않는다 — 발사 자체가 이미 객관적 hit 증거이므로 사용자에게 물을 필요가 없다.
+   */
+  recordAutoConfirmed: (corrId: string) => Promise<void>;
   /** AsyncStorage → memory hydrate. boot 1회. */
   hydrate: () => Promise<void>;
 }
@@ -131,6 +137,19 @@ export const useTripGroundTruthStore = create<TripGroundTruthState>((set, get) =
     // #1957 — 응답 1건을 alarmLog로 stamp해 backend algorithmAccuracyRatio metric의 원천 신호로
     // forward. AsyncStorage persist와 무관하게 best-effort (graceful, throw 없음).
     logGroundTruthResult({ corrId: pendingPrompt.corrId, outcome });
+  },
+
+  recordAutoConfirmed: async (corrId) => {
+    const { responses } = get();
+    const now = Date.now();
+    const nextResponses = trimResponses([
+      ...responses,
+      { corrId, endedAt: now, respondedAt: now, outcome: 'accurate' },
+    ]);
+    set({ responses: nextResponses });
+    await persist({ pendingPrompt: get().pendingPrompt, responses: nextResponses });
+    // #1957과 동일 — accurate 확정 1건을 alarmLog로 stamp해 backend algorithmAccuracyRatio에도 반영.
+    logGroundTruthResult({ corrId, outcome: 'accurate' });
   },
 
   hydrate: async () => {

--- a/src/features/debug/utils/__tests__/triggerTripGroundTruthPrompt.test.ts
+++ b/src/features/debug/utils/__tests__/triggerTripGroundTruthPrompt.test.ts
@@ -7,6 +7,10 @@
  */
 import { triggerTripGroundTruthPrompt } from '../triggerTripGroundTruthPrompt';
 import { useTripGroundTruthStore } from '../../store/useTripGroundTruthStore';
+import {
+  logFiredAlarm,
+  _resetAccurateDestinationFireForTests,
+} from '../../../alarm/utils/alarmLog';
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn().mockResolvedValue(null),
@@ -21,6 +25,7 @@ describe('triggerTripGroundTruthPrompt (#1502 M2 / #1597)', () => {
       pendingPrompt: null,
       responses: [],
     });
+    _resetAccurateDestinationFireForTests();
   });
 
   it('corrId가 null이면 prompt enqueue X (graceful skip)', async () => {
@@ -34,6 +39,44 @@ describe('triggerTripGroundTruthPrompt (#1502 M2 / #1597)', () => {
     expect(useTripGroundTruthStore.getState().pendingPrompt).toEqual({
       corrId: 'trip-abc',
       endedAt: 12345,
+    });
+  });
+
+  // #2309 — 07:46:09 destination imminent 발사(정확) → 3초 뒤 사용자 안내 종료 시 정답지
+  // 확정 창이 완료되지 못해 miss로 self-report되던 회귀. imminent fire는 fusion arrival-confirmed
+  // 신호이므로 trip 종료 즉시 수동 응답 없이 accurate로 확정돼야 한다.
+  it('#2309 — destination imminent 발사 직후(3초 내) user-delete 시 accurate로 즉시 확정, modal(prompt) 미노출', async () => {
+    jest.spyOn(Date, 'now').mockReturnValueOnce(1000); // fire 시각
+    logFiredAlarm('fg', { phaseId: 'imminent', type: 'destination', stationName: '뚝섬' }, 'api');
+
+    jest.spyOn(Date, 'now').mockReturnValue(3000); // 3초 뒤 user-delete → trip end
+    await triggerTripGroundTruthPrompt('trip-2309');
+
+    const state = useTripGroundTruthStore.getState();
+    // 수동 응답 대기 modal이 뜨지 않아야 한다 — pendingPrompt는 null 그대로.
+    expect(state.pendingPrompt).toBeNull();
+    // 정답지는 이미 accurate 1건으로 확정 — alarmAccuracy(local) 1/1.
+    expect(state.responses).toEqual([
+      { corrId: 'trip-2309', endedAt: 3000, respondedAt: 3000, outcome: 'accurate' },
+    ]);
+  });
+
+  it('#2309 — 정확한 발사가 없었던 trip 종료는 기존과 동일하게 수동 prompt enqueue', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(4000);
+    await triggerTripGroundTruthPrompt('trip-no-fire');
+    const state = useTripGroundTruthStore.getState();
+    expect(state.pendingPrompt).toEqual({ corrId: 'trip-no-fire', endedAt: 4000 });
+    expect(state.responses).toEqual([]);
+  });
+
+  it('#2309 — destination 이외 kind(transfer) imminent 발사는 auto-confirm 대상 아님', async () => {
+    jest.spyOn(Date, 'now').mockReturnValueOnce(1000);
+    logFiredAlarm('fg', { phaseId: 'imminent', type: 'transfer', stationName: '건대입구' }, 'api');
+    jest.spyOn(Date, 'now').mockReturnValue(2000);
+    await triggerTripGroundTruthPrompt('trip-transfer-only');
+    expect(useTripGroundTruthStore.getState().pendingPrompt).toEqual({
+      corrId: 'trip-transfer-only',
+      endedAt: 2000,
     });
   });
 

--- a/src/features/debug/utils/triggerTripGroundTruthPrompt.ts
+++ b/src/features/debug/utils/triggerTripGroundTruthPrompt.ts
@@ -2,6 +2,7 @@
  * Cross-feature orchestration: debug feature가 trip 종료 경로에서 prompt enqueue trigger를
  * 노출한다. setDestination(switch) / silentPushTask(trip-ended) / useLaunchTripReconciliation /
  * useStateRehydration(sentinel/force-end) 4 종료 경로의 호출 entry-point이므로 본질적 cross-feature.
+ * #2309 — 같은 이유로 alarm 슬라이스의 `consumeAccurateDestinationFire`도 여기서 직접 참조한다.
  */
 /**
  * Trip ground truth (#1502 M2) — trip 종료 시 사용자 정답지 prompt enqueue trigger.
@@ -15,11 +16,21 @@
  * 본 함수는 trip-end 경로에서만 호출된다. 호출자가 종료 시점의 corrId snapshot을 캡처해서
  * 넘기면 trigger는 그 snapshot으로 enqueue한다. `corrId === null`이면 graceful skip — prompt
  * 미발사 (측정 가치 없는 trip에 noise 응답 합류 차단).
+ *
+ * #2309 — destination imminent 발사가 fusion arrival-confirmed였다면(`consumeAccurateDestinationFire`)
+ * 수동 Yes/No 없이 즉시 'accurate'로 확정한다. 발사 직후 사용자가 바로 "안내 종료"를 눌러 정답지
+ * 응답 창이 완료되지 못해 miss로 self-report되던 지표 왜곡의 fix — 이미 객관적으로 정확했던
+ * 발사를 굳이 다시 물어서 사용자의 즉흥 오답/미응답에 노출시키지 않는다.
  */
 import { useTripGroundTruthStore } from '../store/useTripGroundTruthStore';
+import { consumeAccurateDestinationFire } from '../../alarm/utils/alarmLog';
 
 export async function triggerTripGroundTruthPrompt(corrId: string | null): Promise<void> {
   if (corrId === null) return;
+  if (consumeAccurateDestinationFire()) {
+    await useTripGroundTruthStore.getState().recordAutoConfirmed(corrId);
+    return;
+  }
   await useTripGroundTruthStore.getState().enqueuePrompt({
     corrId,
     endedAt: Date.now(),


### PR DESCRIPTION
Closes #2309

## 문제
2026-08-12 아침 실기기 trip: 07:46:09 destination imminent 발사(뚝섬 34m — 정확) → 3초 뒤
07:46:12 사용자 "안내 종료"(user-delete) → 정답지(ground truth) 확정 창이 완료되지 못해
miss로 self-report되어 dump `alarmAccuracy(local)=0/1`. 08-10에도 동일 패턴 관찰. 정확한
발사를 실패로 계수하는 지표 왜곡.

## 옵션 검토 (이슈 지정 2개 + 조사 결과)
1. **user-delete 시 미확정 알람을 분모에서 제외** — 구현은 간단하지만 결과가 `0/0`(무응답
   제외)이 된다. 이슈 Acceptance("다음 검증 탑승에서 동일 행동 시 alarmAccuracy 1/1")를 만족
   시키지 못한다 (기각).
2. **발사 시점에 fusion arrival-confirmed 상태였으면 hit로 즉시 확정** — 채택. 코드 조사 결과
   destination `imminent` phase 발사(`useStationAlarm.ts` `isImminentByArrivalCode` /
   `stationPipeline.ts` 동일 phase 게이트) 자체가 이미 arrival-code 기반 fusion 확인 신호라,
   발사 성공 = 객관적 hit 증거다. 사용자에게 다시 물을 필요가 없고, 정확도 확정 창을 기다리다
   조기 종료로 미완료되는 구조적 결함도 함께 제거된다. 결과가 acceptance(`1/1`)와 정확히 일치.

## 변경
- `src/features/alarm/utils/alarmLog.ts`: `logFiredAlarm`에서 `kind==='destination' &&
  phaseId==='imminent'` 발사 시 in-memory flag(`accurateDestinationFired`) stamp.
  `consumeAccurateDestinationFire()`로 1회 읽고 즉시 리셋(trip 간 leak 방지). 활성 trip은
  항상 최대 1개이므로 corrId 매칭 없이 안전(기존 `fireAlarmOnce` in-memory ledger와 동일 패턴).
- `src/features/debug/utils/triggerTripGroundTruthPrompt.ts`: trip 종료 시 flag가 서 있으면
  기존 수동 Yes/No 정답지 modal(`enqueuePrompt`)을 건너뛰고 `recordAutoConfirmed`로 즉시
  'accurate' 확정. 이 함수는 4개 trip-end 경로(setDestination/silent push/launch
  reconciliation/state rehydration)의 단일 gateway라 호출부 변경 없이 전체 적용.
- `src/features/debug/store/useTripGroundTruthStore.ts`: `recordAutoConfirmed` 액션 추가 —
  responses에 직접 accurate 1건 append + persist + `logGroundTruthResult` forward(backend
  algorithmAccuracyRatio 동일 반영), 기존 pendingPrompt(다른 trip 미응답분)는 보존.

## 소급 왜곡 주의사항
08-10 / 08-12 dump의 `alarmAccuracy(local)=0/1`은 실제 miss가 아니라 본 버그(정답지 확정 창
미완료)로 인한 오분류였다 — 두 값 모두 해석 시 무시할 것.

## TDD
`triggerTripGroundTruthPrompt.test.ts`에 red 테스트 선행: imminent 발사(1000ms) → 3초 뒤
(3000ms) user-delete 시나리오 → `pendingPrompt`는 null 유지, `responses`는 즉시 accurate
1건으로 확정됨을 검증. 대조군(발사 없음 → 기존처럼 prompt enqueue, transfer kind는 auto-confirm
대상 아님)도 함께 추가.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — DebugModal Operation Dashboard `alarmAccuracy` (local + backend
   `algorithmAccuracyRatio` 동일 반영, `logGroundTruthResult` forward 경유).
3. **의존 PR** — N/A (device-only 로직, backend 변경 없음).
4. **측정 plan** — 다음 검증 탑승에서 "알림 확인 후 즉시 종료" 시나리오 재현 → dump
   `alarmAccuracy(local)` 값이 즉시 1/1로 반영되는지 확인.
5. **Device verify** — 필요. 알림(destination imminent) 수신 직후 안내 종료 1회 실기기 검증.

## 테스트
- `npx jest src/features/alarm/utils/__tests__/alarmLog.test.ts
  src/features/debug/utils/__tests__/triggerTripGroundTruthPrompt.test.ts
  src/features/debug/store/__tests__/useTripGroundTruthStore.test.ts
  src/features/debug/components/__tests__/OperationDashboardSection.test.tsx` — 전부 pass
- 연관 trip-end 경로 테스트(`useDestinationStore` / `silentPushTask` / `tripEndedCleanupSequence`
  / `useLaunchTripReconciliation` / `tripBoundCleanups(Audit)` / `useDeviceSelfEnd` /
  `useStateRehydration`) 전부 pass (540 tests) — 회귀 없음.
- `npm run type-check` pass
- `npm run lint:orphan` pass
