### PR TITLE
fix(#2308): backend route re-anchor drift — 단조 전진 불변식 + leg-aware hydrate line

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -3,9 +3,11 @@ import * as sentryModule from '../sentry';
 import {
   app,
   applyBoardingLockTrainCodeSwap,
+  applyProgress,
   computeLockSyncAdvance,
   dualWriteTripDo,
   LOCK_TTL_REFRESH_MS,
+  resolveProgressWaypoints,
   validateBoardingLockSync,
   validateLiveActivityRegister,
   validatePushAck,
@@ -18,7 +20,7 @@ import { TRIP_DO_FLAG_KV_KEY } from '../tripDoFlag';
 import { progressKey, type TripProgress } from '../progress';
 import { pendingKey, putPending, stampReceived } from '../pendingPushes';
 import { KV_MIN_CACHE_TTL_SEC } from '../kvConsistency';
-import type { AnalyticsEngineWriter, Env } from '../types';
+import type { AnalyticsEngineWriter, Env, Trip } from '../types';
 import { InMemoryKV } from './inMemoryKv';
 import { makeEmptyFakeR2 } from './helpers/r2Fixtures';
 
@@ -3616,6 +3618,123 @@ describe('POST /boarding-lock/sync (#901)', () => {
       );
       expect(res.status).toBe(200);
     });
+  });
+
+  // #2308 — hydrate-issued의 `line`은 lock.line이 아니라 head(현재 anchor waypoint)의 line이어야
+  // 한다. lock.line은 D4 trainCode swap(payload 기반) 타이밍에 갱신되는 반면 head는 이번 sync의
+  // advance 직후 값이라, 환승 직후 한 cycle 동안 두 값이 어긋나면(저녁 어린이대공원 line=2, 아침
+  // 뚝섬 line=7 evidence) hydrate가 실제 서 있는 역의 노선과 다른 값을 발행한다.
+  describe('hydrate-issued line은 leg-aware — head.line 사용 (#2308)', () => {
+    it('advance 후 head가 다른 line이어도 hydrate line은 head.line (lock.line이 아님)', async () => {
+      const env = makeKvEnv();
+      const bind = vi.fn().mockReturnValue({ run: vi.fn().mockResolvedValue({ success: true }) });
+      const prepare = vi.fn().mockReturnValue({ bind });
+      env.DB = { prepare } as unknown as Env['DB'];
+      // 다중 노선 trip: waypoints[0]='강남'(2호선), waypoints[1]='역삼'(7호선, 환승 이후 leg).
+      // lock.line은 아직 스왑 전 '2'로 등록 — D4 swap이 이번 payload에 없으면 lock.line은 '2'로 남는다.
+      await post(
+        '/trips',
+        tripWithLock({
+          waypoints: [
+            { stationName: '강남', line: '2', kind: 'transfer' },
+            { stationName: '역삼', line: '7', kind: 'destination' },
+          ],
+        }),
+        env,
+      );
+      // sync가 waypoints[0]='강남'과 일치 → advance 1 hop → head='역삼'(line=7).
+      // payload에 trainCode(D4 swap 트리거)가 없으므로 lock.line은 '2' 그대로 유지된다.
+      const res = await post(
+        '/boarding-lock/sync',
+        { token: 'tok-sync', observedStationName: '강남', observedAtMs: 1, accuracy: 5 },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const hydrateCall = bind.mock.calls.find((call) => call[2] === 'hydrate-issued');
+      expect(hydrateCall).toBeDefined();
+      // [tokenHash, ts, kind, station, line, meta] — index 3=station, 4=line.
+      expect(hydrateCall?.[3]).toBe('역삼');
+      expect(hydrateCall?.[4]).toBe('7'); // head.line — lock.line('2')이 아님.
+    });
+  });
+});
+
+// #2308 — applyProgress/resolveProgressWaypoints 단조 전진 불변식.
+// 아침 07:37~07:44 trip_events 되감김 재현: count 기반(shiftedCount) slice는 POST /trips 재등록
+// 사이 incoming.waypoints 시퀀스가 바뀌면(route 재계산) 유효 범위 안에서도 완전히 다른(구노선)
+// waypoint로 head를 재anchor한다. headHopIndex 기반 재식별이 이를 차단해야 한다.
+describe('resolveProgressWaypoints / applyProgress — 단조 전진 불변식 (#2308)', () => {
+  function wp(stationName: string, line: string, hopIndex: number): Trip['waypoints'][number] {
+    return { stationName, line, kind: 'intermediate', hopIndex };
+  }
+
+  // 이미 advance된 현재 진행분(2호선 계속 주행 중, 뚝섬이 head).
+  const base = [wp('뚝섬', '2', 1), wp('건대입구', '2', 2), wp('중곡', '7', 5)];
+
+  it(
+    'RED (fixed) — incoming이 되계산된 구노선(7호선) 재전송이라 headHopIndex(1)를 못 찾으면 ' +
+      'count(shiftedCount=1) 기반 slice로 잘못된 7호선 역(군자)에 재anchor하지 않고 base(뚝섬)를 보존한다',
+    () => {
+      // 기기가 recompute한 stale/구노선 route — 자체적으로 hopIndex 10..12로 fresh stamp됨
+      // (원본 시퀀스와 무관한 새 Dijkstra 산출, 값 자체가 원본과 겹치지 않는다).
+      // 실 progress.headHopIndex(=1, 원본 시퀀스의 '뚝섬')는 이 배열에 존재하지 않는다.
+      const incoming = [wp('어린이대공원', '7', 10), wp('군자', '7', 11), wp('중곡', '7', 12)];
+      const progress: TripProgress = { trainCode: 'T-1', shiftedCount: 1, headHopIndex: 1 };
+
+      const result = resolveProgressWaypoints(base, incoming, progress);
+
+      // 되감김 없음: base(뚝섬, 2호선)가 그대로 유지돼야 한다.
+      expect(result).toBe(base);
+      expect(result[0].stationName).toBe('뚝섬');
+      expect(result[0].line).toBe('2');
+    },
+  );
+
+  it('incoming에 headHopIndex가 존재하면(정상 route 연속) 그 지점부터 slice한다', () => {
+    // 같은 원본 시퀀스를 그대로 재전송(hopIndex 보존) — 정상 재등록 케이스.
+    const incoming = [wp('성수', '2', 0), wp('뚝섬', '2', 1), wp('건대입구', '2', 2), wp('중곡', '7', 5)];
+    const progress: TripProgress = { trainCode: 'T-1', shiftedCount: 1, headHopIndex: 1 };
+
+    const result = resolveProgressWaypoints(base, incoming, progress);
+
+    expect(result[0].stationName).toBe('뚝섬');
+    expect(result).toHaveLength(3);
+  });
+
+  it('headHopIndex 없는 legacy progress는 기존 count(shiftedCount) 기반 정책으로 fallback한다', () => {
+    const incoming = [wp('성수', '2', 0), wp('뚝섬', '2', 1), wp('건대입구', '2', 2)];
+    const progress: TripProgress = { trainCode: 'T-1', shiftedCount: 1 };
+
+    const result = resolveProgressWaypoints(base, incoming, progress);
+
+    expect(result[0].stationName).toBe('뚝섬');
+    expect(result).toHaveLength(2);
+  });
+
+  it('applyProgress가 resolveProgressWaypoints 결과를 waypoints에 반영하고 baseline은 progress SSOT를 따른다', () => {
+    const baseTrip = {
+      waypoints: base,
+    } as Trip;
+    const incoming = {
+      waypoints: [wp('어린이대공원', '7', 10), wp('군자', '7', 11), wp('중곡', '7', 12)],
+    } as Trip;
+    const progress: TripProgress = {
+      trainCode: 'T-1',
+      shiftedCount: 1,
+      headHopIndex: 1,
+      lastTrackedArrivalEpoch: 111,
+      lastLaPushEpoch: 222,
+      lastLaPushAt: 333,
+      consecutiveEtaMissing: 4,
+    };
+
+    const result = applyProgress(baseTrip, incoming, progress);
+
+    expect(result.waypoints[0].stationName).toBe('뚝섬'); // 되감김 없음.
+    expect(result.lastTrackedArrivalEpoch).toBe(111);
+    expect(result.lastLaPushEpoch).toBe(222);
+    expect(result.lastLaPushAt).toBe(333);
+    expect(result.consecutiveEtaMissing).toBe(4);
   });
 });
 

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -1959,13 +1959,18 @@ app.post('/boarding-lock/sync', async (c) => {
     // #2283 — hydrate-issued 관측. autoLockCandidate를 device가 실제로 받아 lock state를
     // hydrate할 수 있는 응답임을 기록(sync-received/advance와 별도 kind — "발사됐는지"를 분리 관측).
     // #2283 리뷰 P2-2 — waitUntil로 스케줄.
+    // #2308 — line은 `boardingLock.line`이 아니라 `head.line`(현재 anchor waypoint의 leg)을 쓴다.
+    // lock.line은 D4 trainCode swap(payload 기반) 타이밍에 갱신되는 반면 head는 이번 cycle의
+    // advance 직후 값이라, 환승 직후 한 cycle 동안 두 값이 어긋나면(저녁 어린이대공원 line=2,
+    // 아침 뚝섬 line=7 evidence) hydrate가 실제 서 있는 역의 노선과 다른 값을 발행한다.
+    // head가 있으면 head.line(다중 노선 trip의 해당 leg 노선)을 SSOT로 쓴다.
     scheduleTripEvent(
       c,
       recordTripEvent(c.env.DB, {
         tokenHash,
         kind: 'hydrate-issued',
         station: head ? head.stationName : undefined,
-        line: working.boardingLock.line,
+        line: head ? head.line : working.boardingLock.line,
       }),
     );
   }
@@ -2154,6 +2159,9 @@ async function maybeMirrorLockSyncProgress(
   const next: TripProgress = {
     trainCode,
     shiftedCount: prevShifted + shiftedDelta,
+    // #2308 — head 정체성 anchor. count 대신 hopIndex로 재등록 시 slice해 route 재계산에도
+    // 단조 전진을 보장한다 (applyProgress 참고).
+    headHopIndex: trip.waypoints[0]?.hopIndex,
     lastTrackedArrivalEpoch: trip.lastTrackedArrivalEpoch,
     lastLaPushEpoch: trip.lastLaPushEpoch,
     // #900 Seam D — heartbeat wall-clock도 mirror해 POST /trips race 후에도 보존.
@@ -2441,21 +2449,29 @@ export function isBoardingLockConsistentWithWaypoints(
 }
 
 /**
- * #705: progress KV에 기록된 shiftedCount/baseline을 incoming trip에 적용.
+ * #2308 — 단조 전진 불변식: progress에 기록된 head waypoint(`headHopIndex`)를 incoming
+ * waypoints 시퀀스에서 다시 찾아 그 지점부터 slice한다.
  *
- * - waypoints: `incoming.waypoints.slice(shiftedCount)`로 잘라 backend 진행분 반영
- *   (전부 소진된 경우는 호출부가 isSameSession 분기로 trip.waypoints를 보존하므로
- *    여기서 빈 배열로 깎이는 회귀가 발생하지 않음)
- * - baseline (lastTrackedArrivalEpoch, lastLaPushEpoch, consecutiveEtaMissing):
- *   progress가 더 최신 — POST race에 무관한 source of truth.
+ * `progress.shiftedCount`(카운트)만으로 slice하면, POST /trips 재등록 사이에 incoming의
+ * waypoints 시퀀스 자체가 바뀐 경우(route 재계산 / 환승 leg 재산출 / 기기가 origin부터 다시
+ * 산출한 full route 재전송 등) count는 유효 범위 안에 있어도 완전히 다른(구노선) waypoint를
+ * head로 재anchor한다 — 아침 07:37~07:44 trip_events 되감김(#2308 RCA) 재현 경로.
+ *
+ * `headHopIndex`는 waypoint의 원본 시퀀스 위치로 shift와 무관하게 불변(types.ts Waypoint.hopIndex
+ * 계약) — count 대신 이 값으로 incoming에서 "같은 waypoint"를 재식별하면 시퀀스가 바뀌어도 head
+ * 정체성이 보존된다. incoming에 해당 hopIndex가 없으면(진짜 다른 route로 재계산된 경우) count
+ * 기반 추정은 신뢰할 수 없으므로 slice를 포기하고 `base.waypoints`(이미 advance된 현재 진행분)를
+ * 그대로 보존한다 — 절대 뒤로 되감기지 않는다.
+ *
+ * `headHopIndex`가 없는 legacy progress(구 client / 구 progress 엔트리)는 기존 count 기반
+ * 정책으로 fallback해 하위호환을 유지한다.
  */
 export function applyProgress(
   base: Trip,
   incoming: Trip,
   progress: TripProgress,
 ): Trip {
-  const sliced = incoming.waypoints.slice(progress.shiftedCount);
-  const waypoints = sliced.length > 0 ? sliced : base.waypoints;
+  const waypoints = resolveProgressWaypoints(base.waypoints, incoming.waypoints, progress);
   return {
     ...base,
     waypoints,
@@ -2465,6 +2481,22 @@ export function applyProgress(
     lastLaPushAt: progress.lastLaPushAt,
     consecutiveEtaMissing: progress.consecutiveEtaMissing,
   };
+}
+
+export function resolveProgressWaypoints(
+  baseWaypoints: Trip['waypoints'],
+  incomingWaypoints: Trip['waypoints'],
+  progress: TripProgress,
+): Trip['waypoints'] {
+  if (progress.headHopIndex !== undefined) {
+    const idx = incomingWaypoints.findIndex((w) => w.hopIndex === progress.headHopIndex);
+    // #2308 — 단조 전진 불변식: 못 찾으면(route 시퀀스 자체가 다름) count로 추측 slice하지
+    // 않고 이미 advance된 base.waypoints를 그대로 유지 — 구노선 되감김 차단.
+    return idx >= 0 ? incomingWaypoints.slice(idx) : baseWaypoints;
+  }
+  // legacy fallback — headHopIndex 없는 구 progress 엔트리는 기존 count 기반 정책.
+  const sliced = incomingWaypoints.slice(progress.shiftedCount);
+  return sliced.length > 0 ? sliced : baseWaypoints;
 }
 
 export function validateTrip(input: unknown): Trip | null {

--- a/backend/alarm-worker/src/progress.ts
+++ b/backend/alarm-worker/src/progress.ts
@@ -31,6 +31,15 @@ export interface TripProgress {
   lockless?: true;
   /** advance로 shift한 waypoint 개수. POST의 incoming.waypoints에 slice(shiftedCount) 적용. */
   shiftedCount: number;
+  /**
+   * #2308 — advance 시점 head waypoint의 `hopIndex` (원본 시퀀스 0-based 위치, shift와 무관하게
+   * 불변). POST /trips 재등록 시 `incoming.waypoints`가 (route 재계산 등으로) shiftedCount 계산
+   * 당시와 다른 시퀀스라면 count 기반 slice가 엉뚱한 waypoint를 head로 재anchor한다(단조 전진
+   * 불변식 위반, 구노선 head 되감김). `applyProgress`는 이 값이 있으면 count 대신
+   * hopIndex 일치 위치로 slice해 head 정체성을 보존한다. 미지정(구 progress/legacy)이면 기존
+   * count 기반 정책으로 fallback.
+   */
+  headHopIndex?: number;
   /** Trip의 lastTrackedArrivalEpoch 사본 — race-isolated. */
   lastTrackedArrivalEpoch?: number;
   /** Trip의 lastLaPushEpoch 사본. */

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -1643,6 +1643,9 @@ async function mirrorProgress(
   const next: TripProgress = {
     trainCode,
     shiftedCount: prevShifted + shiftedCountDelta,
+    // #2308 — head 정체성 anchor. POST /trips 재등록 시 count 대신 hopIndex로 slice해
+    // route 재계산에도 단조 전진을 보장 (applyProgress 참고).
+    headHopIndex: trip.waypoints[0]?.hopIndex,
     lastTrackedArrivalEpoch: trip.lastTrackedArrivalEpoch,
     lastLaPushEpoch: trip.lastLaPushEpoch,
     // #900 Seam D — heartbeat wall-clock도 mirror해 POST /trips race 후에도 보존.
@@ -1665,6 +1668,8 @@ async function mirrorLocklessProgress(kv: KVNamespace, trip: Trip): Promise<void
   const next: TripProgress = {
     lockless: true,
     shiftedCount: prevShifted + 1,
+    // #2308 — head 정체성 anchor (lock 경로 mirrorProgress와 동형).
+    headHopIndex: trip.waypoints[0]?.hopIndex,
   };
   const ttlSec = Math.max(60, Math.floor((trip.expiresAt - Date.now()) / 1000));
   await putProgress(kv, trip.token, next, ttlSec);


### PR DESCRIPTION
Closes #2308

## RCA (조사 스펙 1~3)

- **item 1 (computeLockSyncAdvance / hydrate head·line 결정 소스)**: `computeLockSyncAdvance` 자체는 현재 `waypoints` 배열 안에서만 forward-only로 매칭(idx+1)해 단일 연속 배열 안에서는 이미 단조적이다. 되감김의 실질 진입점은 **POST /trips 재등록 시 `applyProgress`가 `progress.shiftedCount`(카운트)만으로 `incoming.waypoints`를 slice**하는 지점이었다 — count가 incoming 배열 범위 안에 있으면(빈 배열 fallback을 피하면) incoming 시퀀스 자체가 이전과 달라져도(route 재계산) 검증 없이 그대로 잘라 head를 재anchor한다.
- **item 2 (재등록 시 route/leg 상태 초기화 여부)**: 확인됨 — `evaluateSameSession`이 false(trainCode 상이/createdAt drift)이면 `baseTrip = {...incoming}`으로 waypoints가 incoming 기준 전면 교체되고, `progressApplies`가 true면 그 위에 `applyProgress`가 얹힌다. 이때 incoming이 device가 새로 산출한(예: FG 복귀 churn) 다른 route/leg 배열이면, 기존 `shiftedCount`는 그 배열에 대해 의미가 없다.
- **item 3 (hydrate line 라벨 소스)**: 확인됨 — hydrate-issued 이벤트의 `line` 필드는 `working.boardingLock.line`(D4 trainCode swap 타이밍에만 갱신)을 그대로 썼다. advance로 head가 새 leg로 넘어간 cycle에 swap이 아직 반영 전이면 head와 lock.line이 최대 1 cycle 어긋나 "7호선 역인데 line=2" 류 라벨 오기가 난다.

## 수리 (item 4)

1. **단조 전진 불변식**: `Waypoint.hopIndex`(원본 시퀀스 위치, shift와 무관하게 불변 — 기존 계약)를 `TripProgress.headHopIndex`로 함께 기록(`maybeMirrorLockSyncProgress`, `mirrorProgress`, `mirrorLocklessProgress`). `applyProgress`(→ 신규 `resolveProgressWaypoints`)는 count 대신 이 값으로 incoming에서 "같은 waypoint"를 재식별해 slice한다. 못 찾으면(진짜 다른 route로 재계산됨) count 기반 추정을 포기하고 이미 advance된 `base.waypoints`를 그대로 보존 — 절대 뒤로 되감기지 않는다. `headHopIndex` 없는 legacy progress 엔트리는 기존 count 기반 정책으로 fallback(하위호환).
2. **leg-aware hydrate line**: hydrate-issued 이벤트의 `line`을 `boardingLock.line` 대신 `head.line`(현재 anchor waypoint의 실제 leg)으로 변경.

ADR-017(#1553 단일 advance 진입점)과 충돌 없음 — advance 진입점(computeLockSyncAdvance/cron)은 그대로 두고, 그 결과를 POST /trips 재등록에 재적용하는 merge 단계에만 가드를 추가했다.

## 변경 범위 (surgical)

- `backend/alarm-worker/src/progress.ts` — `TripProgress.headHopIndex?: number` 추가
- `backend/alarm-worker/src/index.ts` — `maybeMirrorLockSyncProgress`에 headHopIndex 기록, `applyProgress`/신규 `resolveProgressWaypoints`(export) 단조 전진 가드, hydrate-issued `line: head.line`
- `backend/alarm-worker/src/scheduled.ts` — `mirrorProgress`/`mirrorLocklessProgress`에 headHopIndex 기록
- `backend/alarm-worker/src/__tests__/index.test.ts` — red 재현 fixture + green 단위/통합 테스트

route 재계산 로직 자체(Dijkstra/leg 산출)는 건드리지 않았다 — 전면 재설계 아님.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan`은 frontend `src/` 스코프(`scripts/check-orphan-exports.sh` IGNORE_PATTERN 확인)라 backend/alarm-worker에는 적용되지 않음. 신규 export(`resolveProgressWaypoints`)는 `applyProgress` + 테스트에서 바로 소비됨(orphan 아님).
2. **V/X dashboard** — `trip_events` D1 테이블: `advance`/`hydrate-issued` kind의 `station`/`line`/`meta.shiftedCount` 필드로 되감김 발생 여부(구노선 역 재anchor 0건) + line 라벨 정합을 `wrangler d1 execute`로 조회 가능. 기존 #2283 관측 인프라를 그대로 사용.
3. **의존 PR** — 코드 변경은 backend 단독으로 완결. **머지 후 `wrangler deploy` 필요** (배포는 별도 진행).
4. **측정 plan** — 다음 검증 탑승에서 `trip_events`를 tokenHash 단위로 재구성해 (a) advance 시퀀스가 항상 hopIndex 증가 방향인지, (b) hydrate-issued의 line이 같은 이벤트의 station 실제 노선과 일치하는지 확인. 되감김 재발 0건 + line 라벨 불일치 0건이 목표.
5. **Device verify** — N/A, backend-only. 코드는 type-check + unit(coverage 100%)만 검증됨 — 실 trip_events 재발 여부는 배포 후 실기기 탑승으로 확인 필요.

## Test plan

- [x] `npx vitest run --coverage` (backend/alarm-worker) — 100% pass, coverage 유지
- [x] `npm run type-check` (backend/alarm-worker) — clean
- [ ] 배포 후 실 trip_events로 되감김 0건 / line 라벨 정합 확인 (측정 plan 참고)