### PR TITLE
fix(#2321): backend 자율 전진 4중 게이트 staleness-aware 재기저

### DIFF
--- a/backend/alarm-worker/src/__tests__/evidence_20260812_replay.test.ts
+++ b/backend/alarm-worker/src/__tests__/evidence_20260812_replay.test.ts
@@ -1,0 +1,247 @@
+/**
+ * 2026-08-12 저녁 실탑승 dump replay test (#2306 RCA → #2321).
+ *
+ * 목적: token_hash b00dd879, 18:26:49~18:51:09 KST(25분) device sync 부재(앱 suspend) 동안
+ * 7호선 4역 통과 + 용마산 목적지 알림이 0건이었던 evidence를 fixture로 재현한다.
+ * lock 활성(trainCode 보유) trip에서 arvlCd waypoint arrivals가 존재해도 backend 4중 게이트
+ * (stationary cron skip / motion 게이트 / transfer-destination 60s 신선도 / stale SSoT fire
+ * 3분 guard)가 모두 "device 최근 갱신" 전제로 설계돼 있어 25분 침묵 동안 advance/fire 둘 다
+ * 0건으로 동결됐다.
+ *
+ * 재기저 후 acceptance:
+ *  - device sync stale(#2321 DEVICE_SYNC_STALE_THRESHOLD_MS 초과) + lock 활성 + trainCode 일치
+ *    arvlCd evidence → 게이트 dormant, arvlCd ground truth로 advance + fire.
+ *  - Seoul outage(신호 자체 부재) 시에는 device stale이어도 침묵 유지(오발사 0) — 시간 적분
+ *    추정 금지 기존 룰 무회귀.
+ *  - device sync가 신선한 기존 케이스는 전부 기존 게이트 동작 그대로(무회귀) — 이 파일에서는
+ *    회귀 여부를 lifecycleStationarySkipped=1 그대로 유지되는 별도 fresh 시나리오로 확인.
+ *
+ * 동작 원칙: 관측 가능한 결과(advance/fire count, log reason)만 assert. 내부 함수 호출 여부는
+ * assert하지 않는다.
+ */
+
+import { generateKeyPair, exportPKCS8 } from 'jose';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetApnsJwtCache, type ApnsConfig } from '../apns';
+import {
+  runScheduled,
+  type ScheduledDeps,
+  type ScheduledStats,
+} from '../scheduled';
+import { SeoulArrivalClient } from '../seoul';
+import { putTrip } from '../trips';
+import { seedSsot, writeSsot } from '../tripPositionSsot';
+import type { BoardingLockMeta, Env, Trip } from '../types';
+import { InMemoryKV } from './inMemoryKv';
+
+let apnsConfig: ApnsConfig;
+
+beforeAll(async () => {
+  const { privateKey } = await generateKeyPair('ES256');
+  const pem = await exportPKCS8(privateKey);
+  apnsConfig = {
+    keyId: 'K',
+    teamId: 'T',
+    privateKeyPem: pem,
+    bundleId: 'com.example.app',
+  };
+});
+
+beforeEach(() => resetApnsJwtCache());
+
+const NOW = 1_700_000_000_000;
+const TWENTY_FIVE_MIN_MS = 25 * 60 * 1000;
+
+const APNS_HOSTS = {
+  production: 'api.push.apple.com',
+  sandbox: 'api.sandbox.push.apple.com',
+} as const;
+
+function makeEnv(kv: InMemoryKV): Env {
+  return {
+    TRIPS: kv as unknown as KVNamespace,
+    APNS_HOST: APNS_HOSTS.production,
+    APNS_HOST_SANDBOX: APNS_HOSTS.sandbox,
+    SEOUL_API_HOST: 'seoul.api',
+    SEOUL_API_KEY: 'KEY',
+    APNS_KEY_ID: 'K',
+    APNS_TEAM_ID: 'T',
+    APNS_PRIVATE_KEY: apnsConfig.privateKeyPem,
+    APNS_BUNDLE_ID: 'com.example.app',
+  };
+}
+
+// evidence trip — 7호선 용마산 lock, trainCode '7246' (2026-08-12 저녁 dump 재현).
+function makeBoardingLock(overrides: Partial<BoardingLockMeta> = {}): BoardingLockMeta {
+  return {
+    trainCode: '7246',
+    line: '7',
+    subwayId: '1007',
+    selectedDepartureTime: NOW - 30 * 60_000,
+    segmentStations: ['건대입구', '중곡', '군자', '용마산'],
+    expiresAt: NOW + 60 * 60_000,
+    ...overrides,
+  };
+}
+
+function makeArrivedSeoul(stationName: string, trainCode = '7246'): SeoulArrivalClient {
+  return new SeoulArrivalClient({
+    apiKey: 'K',
+    host: 'h',
+    now: () => NOW,
+    fetchImpl: (async () =>
+      new Response(
+        JSON.stringify({
+          realtimeArrivalList: [
+            {
+              barvlDt: '0',
+              recptnDt: '',
+              updnLine: '상행',
+              trainLineNm: stationName,
+              btrainNo: trainCode,
+              subwayNm: '지하철7호선',
+              arvlCd: 1,
+            },
+          ],
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch,
+  });
+}
+
+// Seoul outage — realtimeArrivalList 빈 응답 (신호 자체 부재).
+function makeOutageSeoul(): SeoulArrivalClient {
+  return new SeoulArrivalClient({
+    apiKey: 'K',
+    host: 'h',
+    now: () => NOW,
+    fetchImpl: (async () =>
+      new Response(JSON.stringify({ realtimeArrivalList: [] }), { status: 200 })) as unknown as typeof fetch,
+  });
+}
+
+function makeTrip(overrides: Partial<Trip> = {}): Trip {
+  return {
+    token: 'evidence-0812-tok',
+    route: { type: 'direct', line: '7', stops: 3 },
+    destination: '용마산',
+    waypoints: [{ stationName: '중곡', line: '7', kind: 'intermediate' }],
+    boardingLock: makeBoardingLock(),
+    expiresAt: NOW + 60 * 60_000,
+    createdAt: NOW - 30 * 60_000,
+    alarmAtEpochMs: NOW - 60_000,
+    ...overrides,
+  };
+}
+
+async function runOnce(
+  kv: InMemoryKV,
+  seoul: SeoulArrivalClient,
+  fetchImpl: ReturnType<typeof vi.fn>,
+): Promise<ScheduledStats> {
+  return runScheduled(makeEnv(kv), {
+    seoul,
+    apnsConfig,
+    apnsHosts: APNS_HOSTS,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+    now: () => NOW,
+    generatePushId: () => 'evidence-0812-push',
+  } satisfies ScheduledDeps);
+}
+
+describe('evidence 2026-08-12 저녁 25분 device silence — staleness-aware gates (#2321)', () => {
+  it('intermediate waypoint(중곡) — 25분 device 침묵 + lock trainCode 일치 arvlCd → advance+fire (gate #1/#2)', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({
+      waypoints: [{ stationName: '중곡', line: '7', kind: 'intermediate' }],
+    });
+    await putTrip(kv as unknown as KVNamespace, trip);
+    const ssot = await seedSsot(kv as unknown as KVNamespace, trip.token, '건대입구', {
+      expiresAt: trip.expiresAt,
+    });
+    ssot.motionState = 'stationary';
+    ssot.lastAdvanceAt = NOW - TWENTY_FIVE_MIN_MS;
+    ssot.lastAdvanceEvidence = 'arvlcd-confirmed-train';
+    // #2321 — device가 25분 전 마지막으로 /position을 보낸 뒤 침묵(앱 suspend). motionState는
+    // 그 시점의 마지막 값('stationary')에 영구 고정된 채 갱신되지 않는다.
+    ssot.lastDeviceSyncAt = NOW - TWENTY_FIVE_MIN_MS;
+    await writeSsot(kv as unknown as KVNamespace, ssot, { expiresAt: trip.expiresAt });
+
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runOnce(kv, makeArrivedSeoul('중곡'), fetchImpl);
+
+    expect(stats.arvlCdFireFired).toBe(1);
+    expect(stats.arvlCdFireSuccess).toBe(1);
+    expect(stats.lifecycleStationarySkipped).toBe(0);
+  });
+
+  it('destination waypoint(용마산) — 25분 device 침묵 + approaching + lock trainCode 일치 → advance+fire (gate #3/#4)', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({
+      destination: '용마산',
+      waypoints: [{ stationName: '용마산', line: '7', kind: 'destination' }],
+      passedStations: ['군자'],
+    });
+    await putTrip(kv as unknown as KVNamespace, trip);
+    const ssot = await seedSsot(kv as unknown as KVNamespace, trip.token, '군자', {
+      expiresAt: trip.expiresAt,
+    });
+    ssot.motionState = 'stationary';
+    ssot.lastAdvanceAt = NOW - TWENTY_FIVE_MIN_MS;
+    ssot.lastAdvanceEvidence = 'arvlcd-confirmed-train';
+    ssot.lastDeviceSyncAt = NOW - TWENTY_FIVE_MIN_MS;
+    await writeSsot(kv as unknown as KVNamespace, ssot, { expiresAt: trip.expiresAt });
+
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runOnce(kv, makeArrivedSeoul('용마산'), fetchImpl);
+
+    expect(stats.arvlCdFireFired).toBe(1);
+    expect(stats.arvlCdFireSuccess).toBe(1);
+    expect(stats.transferDestinationGateBlocked).toBe(0);
+  });
+
+  it('Seoul outage(신호 부재) + 25분 device 침묵 → 오발사 0 (침묵 유지, 시간 적분 추정 금지 무회귀)', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({
+      waypoints: [{ stationName: '중곡', line: '7', kind: 'intermediate' }],
+    });
+    await putTrip(kv as unknown as KVNamespace, trip);
+    const ssot = await seedSsot(kv as unknown as KVNamespace, trip.token, '건대입구', {
+      expiresAt: trip.expiresAt,
+    });
+    ssot.motionState = 'stationary';
+    ssot.lastAdvanceAt = NOW - TWENTY_FIVE_MIN_MS;
+    ssot.lastAdvanceEvidence = 'arvlcd-confirmed-train';
+    ssot.lastDeviceSyncAt = NOW - TWENTY_FIVE_MIN_MS;
+    await writeSsot(kv as unknown as KVNamespace, ssot, { expiresAt: trip.expiresAt });
+
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runOnce(kv, makeOutageSeoul(), fetchImpl);
+
+    expect(stats.arvlCdFireFired).toBe(0);
+    expect(stats.arvlCdFireSuccess).toBe(0);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('무회귀 — device sync 신선(정상 운행) + stationary + intermediate → 기존 stationary skip 게이트 그대로 유지', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({
+      waypoints: [{ stationName: '중곡', line: '7', kind: 'intermediate' }],
+    });
+    await putTrip(kv as unknown as KVNamespace, trip);
+    const ssot = await seedSsot(kv as unknown as KVNamespace, trip.token, '건대입구', {
+      expiresAt: trip.expiresAt,
+    });
+    ssot.motionState = 'stationary';
+    // device sync가 방금(0ms 전) 갱신됨 — fresh. 기존 V8d stationary skip 게이트가 그대로 적용돼야 한다.
+    ssot.lastDeviceSyncAt = NOW;
+    await writeSsot(kv as unknown as KVNamespace, ssot, { expiresAt: trip.expiresAt });
+
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runOnce(kv, makeArrivedSeoul('중곡'), fetchImpl);
+
+    expect(stats.lifecycleStationarySkipped).toBe(1);
+    expect(stats.arvlCdFireFired).toBe(0);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -6662,31 +6662,36 @@ describe('toTripStatusEndReason — #1933 la-stale-backstop 외부 contract 매�
 
 describe('shouldSkipStationary (pure helper)', () => {
   it('stationary + intermediate → skip', () => {
-    expect(shouldSkipStationary('stationary', 'intermediate', false)).toBe(true);
+    expect(shouldSkipStationary('stationary', 'intermediate', false, false)).toBe(true);
   });
 
   it('moving + intermediate → 평가 유지 (no skip)', () => {
-    expect(shouldSkipStationary('moving', 'intermediate', false)).toBe(false);
+    expect(shouldSkipStationary('moving', 'intermediate', false, false)).toBe(false);
   });
 
   it('unknown + intermediate → 평가 유지 (backward-compat)', () => {
-    expect(shouldSkipStationary('unknown', 'intermediate', false)).toBe(false);
+    expect(shouldSkipStationary('unknown', 'intermediate', false, false)).toBe(false);
   });
 
   it('stationary + destination → 항상 bypass (ETA 신선도 보장 불가 → 안전 방향)', () => {
-    expect(shouldSkipStationary('stationary', 'destination', false)).toBe(false);
+    expect(shouldSkipStationary('stationary', 'destination', false, false)).toBe(false);
   });
 
   it('stationary + transfer → 항상 bypass (ETA 신선도 보장 불가 → 안전 방향)', () => {
-    expect(shouldSkipStationary('stationary', 'transfer', false)).toBe(false);
+    expect(shouldSkipStationary('stationary', 'transfer', false, false)).toBe(false);
   });
 
   it('stationary + intermediate + userIntentDeclared=true → bypass (ADR-014 동급 보장)', () => {
-    expect(shouldSkipStationary('stationary', 'intermediate', true)).toBe(false);
+    expect(shouldSkipStationary('stationary', 'intermediate', true, false)).toBe(false);
   });
 
   it('stationary + intermediate + userIntentDeclared=false → skip', () => {
-    expect(shouldSkipStationary('stationary', 'intermediate', false)).toBe(true);
+    expect(shouldSkipStationary('stationary', 'intermediate', false, false)).toBe(true);
+  });
+
+  // #2321 (O1-B) — device sync stale 시 motionState 신뢰 불가 → skip하지 않음(조건부 완화).
+  it('stationary + intermediate + deviceSyncStale=true → bypass (#2321)', () => {
+    expect(shouldSkipStationary('stationary', 'intermediate', false, true)).toBe(false);
   });
 });
 

--- a/backend/alarm-worker/src/__tests__/tripPositionSsot.test.ts
+++ b/backend/alarm-worker/src/__tests__/tripPositionSsot.test.ts
@@ -146,7 +146,8 @@ describe('tripPositionSsot — seedSsot (S1 GAP A 수신부)', () => {
     expect(ssot.passedStations).toEqual([]);
     expect(ssot.userIntentDeclared).toBe(false);
     expect(ssot.seedOverrideCount).toBe(0);
-    expect(ssot.schemaVersion).toBe(2);
+    // #2321 — lastDeviceSyncAt 추가로 schemaVersion 3.
+    expect(ssot.schemaVersion).toBe(3);
     expect(ssot.lastAdvanceAt).toBe(0);
 
     const persisted = await readSsot(kv as unknown as KVNamespace, 'tok-seed');
@@ -169,12 +170,12 @@ describe('tripPositionSsot — seedSsot (S1 GAP A 수신부)', () => {
     expect(entry?.expiresAt).toBeDefined();
   });
 
-  // #1705 — currentStationLine seed + schemaVersion=2
-  it('seedSsot: line 옵션 전달 시 currentStationLine stamp + schemaVersion=2', async () => {
+  // #1705 — currentStationLine seed + schemaVersion=3 (#2321 — lastDeviceSyncAt 추가로 bump)
+  it('seedSsot: line 옵션 전달 시 currentStationLine stamp + schemaVersion=3', async () => {
     const kv = new InMemoryKV();
     const ssot = await seedSsot(kv as unknown as KVNamespace, 'tok-line', '합정', { line: '2' });
     expect(ssot.currentStationLine).toBe('2');
-    expect(ssot.schemaVersion).toBe(2);
+    expect(ssot.schemaVersion).toBe(3);
     const persisted = await readSsot(kv as unknown as KVNamespace, 'tok-line');
     expect(persisted?.currentStationLine).toBe('2');
   });

--- a/backend/alarm-worker/src/advanceTripPosition.ts
+++ b/backend/alarm-worker/src/advanceTripPosition.ts
@@ -61,6 +61,7 @@ import type { ArrivalEntry, PositionEntry } from './seoul';
 import {
   appendAlarmEvent,
   computeAlarmId,
+  isDeviceSyncStale,
   isSameLockSuggestion,
   MOTION_EVIDENCE_CAP,
   readSsot,
@@ -402,7 +403,16 @@ export async function advanceTripPosition(
   const lock = pickActiveLock(trip, evidence.ts);
 
   // #2 Motion 게이트 — userIntentDeclared trip은 명시 의향이므로 통과 (P8 acceptance).
-  if (ssot.motionState === 'stationary' && !ssot.userIntentDeclared) {
+  //
+  // #2321 (O1-B) — device sync stale(`lastDeviceSyncAt` 5분 초과 무갱신) + arvlcd-confirmed-train
+  // evidence(lock trainCode 일치, 게이트 #5가 별도로 재검증)인 cycle은 motionState 신호 자체를
+  // 신뢰하지 않는다. suspend 직전 값에 영구 고정된 stale motionState가 backend 자율 전진까지
+  // 동결시키던 회귀(#2306 RCA)를 차단 — arvlCd ground truth로만 dormant 전환, 다른 evidence
+  // type(예: arvlcd-lockless, position-train)은 기존 게이트 그대로 유지(스코프: trainCode 보유
+  // leg 자율 전진만, 환승 후 leg는 범위 밖).
+  const deviceSyncStaleBypass =
+    isDeviceSyncStale(ssot, evidence.ts) && evidence.type === 'arvlcd-confirmed-train';
+  if (ssot.motionState === 'stationary' && !ssot.userIntentDeclared && !deviceSyncStaleBypass) {
     return { result: 'blocked', blockReason: 'motion-stationary', ssot };
   }
 
@@ -497,7 +507,7 @@ export async function advanceTripPosition(
     alarmEvents: ssot.alarmEvents ? [...ssot.alarmEvents] : [],
     // #1705 — advance 시 현재 waypoint 노선으로 갱신 (cross-line confusion 차단).
     ...(candidateLine !== undefined ? { currentStationLine: candidateLine } : {}),
-    schemaVersion: 2,
+    schemaVersion: 3,
   };
 
   applyLockSuggestion(next, ssot, {

--- a/backend/alarm-worker/src/motionState.ts
+++ b/backend/alarm-worker/src/motionState.ts
@@ -178,6 +178,11 @@ export async function updateSsotMotion(
   const ssot = await readSsot(kv, token);
   if (!ssot) return null;
 
+  // #2321 (O1-B) — device sync freshness anchor. POST /position 수신 = device가 살아있다는
+  // 직접 증거이므로 매 호출마다 stamp. 게이트들이 motionState/lastAdvanceAt을 신뢰할지
+  // 판단하는 입력(`isDeviceSyncStale`)이 된다.
+  ssot.lastDeviceSyncAt = now;
+
   // device GPS sample을 evidence로 누적 (signal은 후속 maxDisplacementMeters가 lat/lng 추출).
   pushMotionEvidence(ssot, {
     source: 'device-position',

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -54,6 +54,7 @@ import {
 } from './advanceTripPosition';
 import {
   deleteSsot,
+  isDeviceSyncStale,
   readSsot,
   seedSsot,
   SSOT_CRON_READ_CACHE_TTL_SEC,
@@ -347,16 +348,25 @@ export function recordDestinationCrossCheck(
  *
  * motionState='unknown' 또는 SSoT null → skip하지 않음 (backward-compat, 평가 유지).
  *
+ * #2321 (O1-B) — `deviceSyncStale=true`(device sync 5분+ 무갱신, `isDeviceSyncStale`)이면
+ * motionState 신호 자체가 suspend 직전 값에 고정된 stale 신호일 수 있어 skip하지 않는다
+ * (배터리 절감보다 backend 자율 전진 우선 — #2306 RCA, 25분 suspend 4역+목적지 알림 0건 재발
+ * 차단). device sync가 신선하면 기존 V8d 배터리 절감 동작 그대로 유지(무회귀).
+ *
  * @returns true = skip, false = 평가 계속
  */
 export function shouldSkipStationary(
   motionState: 'moving' | 'stationary' | 'unknown',
   waypointKind: Waypoint['kind'],
   userIntentDeclared: boolean,
+  deviceSyncStale: boolean,
 ): boolean {
   if (motionState !== 'stationary') return false;
   // ADR-014 §사용자 명시 의향 trip — 동급 보장. 정지 중이어도 skip X.
   if (userIntentDeclared) return false;
+  // #2321 — device sync stale 시 motionState 신뢰 불가 → skip하지 않고 arvlCd ground truth
+  // 평가를 계속 진행(조건부 완화, V8d 전면 제거 아님).
+  if (deviceSyncStale) return false;
   // destination/transfer — 항상 bypass. ETA 신선도를 알 수 없어 skip하면 도착 알림 누락 위험.
   // intermediate만 skip 대상 (Seoul API call + push 절감 대상).
   if (waypointKind === 'destination' || waypointKind === 'transfer') return false;
@@ -1274,6 +1284,8 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
           stationarySsot.motionState,
           waypoint.kind,
           stationarySsot.userIntentDeclared,
+          // #2321 — device sync stale 시 motionState 신뢰 불가 → skip하지 않고 평가 계속.
+          isDeviceSyncStale(stationarySsot, now),
         )
       ) {
         stats.lifecycleStationarySkipped += 1;
@@ -2314,11 +2326,16 @@ export async function fireArvlCdStationPush(
   // #1614 Phase C — stale SSoT 가드. SSoT.lastAdvanceAt > 0 이고 3분 초과면 fire skip.
   // transferDestinationGate (60s) 보다 보수적이지만 intermediate 까지 보호. lazy-seed (==0) 통과.
   // SSoT 부재 trip (legacy) 도 통과 — 본 가드는 SSoT 활성화 후 stale 진단 만.
+  //
+  // #2321 (O1-B) — device sync stale일 때는 본 가드도 dormant 전환. 정상 흐름에서는 본 함수
+  // 호출 직전 advanceTripPosition이 이미 lastAdvanceAt을 방금 갱신해 staleMs≈0이 되므로
+  // 무영향이지만, defense-in-depth로 게이트 #1~#3과 동일 staleness 정책을 명시적으로 정합시킨다.
   const ssotForStale = await readSsot(env.TRIPS, trip.token, {
     cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
   });
   if (
     ssotForStale !== null &&
+    !isDeviceSyncStale(ssotForStale, now) &&
     ssotForStale.lastAdvanceAt > 0 &&
     now - ssotForStale.lastAdvanceAt > STALE_LOCK_FIRE_THRESHOLD_MS
   ) {
@@ -2617,7 +2634,10 @@ async function tryAdvanceAndFireArvlcd(inputs: {
   // 직전 1 hop 인지 (2) 마지막 advance 가 60s 이내 신선한지 확인. intermediate kind는 본 게이트
   // 우회 — T4/T5 6단 게이트만으로 충분. 정지 trip "환승임박 건대입구" false fire(N9) 차단.
   if (isTransferOrDestination(waypoint)) {
-    const transferGate = evaluateTransferDestinationGate(ssot, trip, waypoint, now);
+    const transferGate = evaluateTransferDestinationGate(ssot, trip, waypoint, now, {
+      // #2321 — device sync stale 시 60s 신선도 검사 dormant (arvlCd ground truth 신뢰).
+      deviceSyncStale: isDeviceSyncStale(ssot, now),
+    });
     if (!transferGate.pass) {
       stats.arvlCdFireBlocked += 1;
       stats.transferDestinationGateBlocked += 1;
@@ -2819,7 +2839,10 @@ export async function fireVanishFallbackStationPush(
   // ADR-017 T7 (#1560) — transfer/destination kind 발사 직전 SSoT 위치 + 신선도 일관성 검증.
   // SSoT 부재 trip(legacy)은 본 게이트 통과시켜 기존 vanish-fallback 흐름 유지 — graceful.
   if (ssot !== null && isTransferOrDestination(waypoint)) {
-    const transferGate = evaluateTransferDestinationGate(ssot, trip, waypoint, now);
+    const transferGate = evaluateTransferDestinationGate(ssot, trip, waypoint, now, {
+      // #2321 — device sync stale 시 60s 신선도 검사 dormant (arvlCd ground truth 신뢰).
+      deviceSyncStale: isDeviceSyncStale(ssot, now),
+    });
     if (!transferGate.pass) {
       stats.transferDestinationGateBlocked += 1;
       log(`${logPrefix}: transfer/destination gate blocked`, {

--- a/backend/alarm-worker/src/transferDestinationGate.ts
+++ b/backend/alarm-worker/src/transferDestinationGate.ts
@@ -117,17 +117,24 @@ export function isSsotAdvanceRecent(
  * @param waypoint 발사 후보 waypoint. kind가 transfer/destination 아닌 경우 caller가 본 함수를
  *                 호출하지 않는다 (intermediate는 통과 정책).
  * @param now epoch ms.
+ * @param options.deviceSyncStale #2321 (O1-B) — device sync stale(`isDeviceSyncStale`) 시 60s
+ *   신선도 검사(`isSsotAdvanceRecent`)를 dormant 전환한다. 이 60s 임계는 "정지 trip이 cron
+ *   wake-up만으로 시간 적분 도달"하는 false advance를 막기 위함(N9 회귀)이지, device가 정상
+ *   suspend로 침묵한 사이 backend가 arvlCd ground truth로 자율 전진한 advance까지 stale 취급할
+ *   의도는 아니었다 (#2306 RCA). `isAtOrApproachingTransferDestination`(position 일치)은
+ *   staleness와 무관한 별도 안전장치로 그대로 유지.
  */
 export function evaluateTransferDestinationGate(
   ssot: Pick<TripPositionSSoT, 'currentStationId' | 'lastAdvanceAt'>,
   trip: Pick<Trip, 'passedStations'>,
   waypoint: Pick<Waypoint, 'stationName' | 'kind'>,
   now: number,
+  options?: { deviceSyncStale?: boolean },
 ): TransferDestinationGateOutcome {
   if (!isAtOrApproachingTransferDestination(ssot, trip, waypoint)) {
     return { pass: false, blockReason: 'ssot-not-at-or-approaching' };
   }
-  if (!isSsotAdvanceRecent(ssot, now)) {
+  if (!options?.deviceSyncStale && !isSsotAdvanceRecent(ssot, now)) {
     return { pass: false, blockReason: 'ssot-stale' };
   }
   return { pass: true };

--- a/backend/alarm-worker/src/tripPositionSsot.ts
+++ b/backend/alarm-worker/src/tripPositionSsot.ts
@@ -242,16 +242,62 @@ export interface TripPositionSSoT {
    */
   currentStationLine?: string;
   /**
+   * #2321 (O1-B) — device가 마지막으로 backend에 신호를 보낸 시각 (epoch ms). `POST /position`
+   * 수신부(`updateSsotMotion`)가 매 호출마다 stamp한다.
+   *
+   * 배경: motionState/lastAdvanceAt 기반 게이트(cron stationary skip, motion 게이트,
+   * transfer/destination 신선도, stale SSoT fire guard)가 전부 "device가 최근에 신호를 보냈다"는
+   * 암묵 전제로 설계돼 있었다 — 앱 suspend로 device가 수 분~수십 분 침묵하면 motionState가
+   * suspend 직전 값에 영구 고정된 채 게이트가 계속 그 값을 신뢰해 backend 자율 전진(arvlCd ground
+   * truth)까지 함께 동결되는 회귀(#2306 RCA, 2026-08-12 저녁 25분 suspend 4역+목적지 알림 0건)가
+   * 있었다. 본 필드로 각 게이트가 "이 motionState/lastAdvanceAt 신호가 여전히 신뢰 가능한가"를
+   * 판단해, stale일 때만 arvlCd trainCode ground truth로 dormant 전환한다 (`isDeviceSyncStale`).
+   *
+   * 구 backend 호환을 위해 optional — v2 이하 row 또는 seed 직후 미stamp 상태는 undefined.
+   * undefined는 "legacy/미상"으로 다뤄 기존 게이트 동작을 그대로 유지한다(부재 시 dormant —
+   * 다른 optional SSoT 필드와 동일 backward-compat 정책).
+   */
+  lastDeviceSyncAt?: number;
+  /**
    * schemaVersion. 향후 마이그레이션 분기용.
    * v1: 최초 스키마.
    * v2: currentStationLine 추가 (#1705).
+   * v3: lastDeviceSyncAt 추가 (#2321).
    */
-  schemaVersion: 1 | 2;
+  schemaVersion: 1 | 2 | 3;
 }
 
 /** SSOT KV key 생성. */
 export function ssotKey(token: string): string {
   return `${SSOT_PREFIX}${token}`;
+}
+
+/**
+ * #2321 (O1-B) — device sync staleness 임계 (ms). `lastDeviceSyncAt`이 이 값보다 오래되면
+ * motionState/lastAdvanceAt 기반 게이트가 더 이상 신뢰할 수 없는 신호로 판정하고 arvlCd
+ * trainCode ground truth 경로로 dormant 전환한다.
+ *
+ * 5분 — 기존 코드베이스의 신선도 임계 관례(`DESTINATION_GPS_STALE_THRESHOLD_MS`,
+ * `LA_STALE_AUTO_END_MS`, `SIGNAL_STALE_MS`, `STATE_STALE_THRESHOLD_MS` 모두 5분)와 정합.
+ * cron 60s nominal interval 대비 충분히 여러 cycle 여유(false staleness 오탐 방지)를 두면서,
+ * #2306 evidence(25분 suspend)보다는 훨씬 짧게 잡아 실제 침묵을 놓치지 않는다.
+ */
+export const DEVICE_SYNC_STALE_THRESHOLD_MS = 5 * 60 * 1000;
+
+/**
+ * #2321 (O1-B) — SSoT.lastDeviceSyncAt이 stale(임계 초과)한지 판정.
+ *
+ * `lastDeviceSyncAt` 부재(구 row / seed 직후 미stamp)는 "legacy/미상"으로 다뤄 false 반환
+ * (dormant — 기존 게이트 동작 그대로 유지, backward-compat). 단순 신호 부재만으로 즉시
+ * fallback 경로를 트는 것을 막아 트립 등록 직후 race를 방지한다.
+ */
+export function isDeviceSyncStale(
+  ssot: Pick<TripPositionSSoT, 'lastDeviceSyncAt'>,
+  now: number,
+  thresholdMs: number = DEVICE_SYNC_STALE_THRESHOLD_MS,
+): boolean {
+  if (ssot.lastDeviceSyncAt === undefined) return false;
+  return now - ssot.lastDeviceSyncAt > thresholdMs;
 }
 
 /**
@@ -344,7 +390,7 @@ export async function seedSsot(
     alarmEvents: [],
     // #1705 — line 지정 시 currentStationLine 박제 (cross-line confusion 차단).
     ...(options?.line !== undefined ? { currentStationLine: options.line } : {}),
-    schemaVersion: 2,
+    schemaVersion: 3,
   };
   await writeSsot(kv, ssot, { expiresAt: options?.expiresAt });
   return ssot;


### PR DESCRIPTION
Closes #2321

## 배경
#2306 RCA — 2026-08-12 저녁 trip(token_hash b00dd879, 18:26:49~18:51:09 KST 25분 device suspend)에서 7호선 4역 + 용마산 목적지 알림 0건. backend에는 Seoul arvlCd 자율 전진 경로(cron self-poll → advanceTripPosition → fireArvlCdStationPush)가 이미 있지만, 4중 게이트가 전부 "device가 최근 신호를 보냈다"는 암묵 전제로 설계돼 있어 device suspend 시 backend도 동반 동결됐다.

## 수정 내용
- **SSoT에 `lastDeviceSyncAt` 필드 도입** — `POST /position` 수신부(`updateSsotMotion`)가 매 호출마다 stamp. `isDeviceSyncStale(ssot, now)` helper + `DEVICE_SYNC_STALE_THRESHOLD_MS`(5분, 기존 코드베이스 신선도 임계 관례와 정합) 추가.
- **게이트 #1 — cron stationary skip(V8d, `shouldSkipStationary`)**: device sync stale 시 skip하지 않음(조건부 완화, 전면 제거 아님). 신선 시 기존 배터리 절감 동작 그대로 무회귀.
- **게이트 #2 — `advanceTripPosition` motion 게이트**: device stale **+ `arvlcd-confirmed-train` evidence**(lock trainCode 일치, 게이트 #5가 별도 재검증)일 때만 bypass. 스코프를 trainCode 보유 leg 자율 전진으로 제한(이슈 명시 — 환승 후 leg는 범위 밖).
- **게이트 #3 — `evaluateTransferDestinationGate` 60s 신선도**: device stale 시 60s freshness 검사 dormant. `isAtOrApproachingTransferDestination`(position 일치)은 staleness와 무관하게 그대로 유지.
- **게이트 #4 — `fireArvlCdStationPush` 3분 stale SSoT fire guard**: device stale 시 dormant. defense-in-depth(정상 흐름에서는 advance 직후 lastAdvanceAt이 이미 신선해 무영향).
- 신규 emitter/dedup 게이트 추가 없음 — 기존 fire 함수(`fireArvlCdStationPush`) + dedup(fire-once TTL, cross-station window) 그대로 재사용.

## TDD
`src/__tests__/evidence_20260812_replay.test.ts` — red 먼저 확인 후 구현:
1. intermediate waypoint(중곡) — 25분 device 침묵 + lock trainCode 일치 arvlCd → **RED(advance/fire 0) → GREEN(advance+fire 1)** (gate #1/#2)
2. destination waypoint(용마산) — 25분 device 침묵 + approaching + lock trainCode 일치 → **RED → GREEN** (gate #3/#4)
3. Seoul outage(신호 부재) + 25분 device 침묵 → 오발사 0 유지 (시간 적분 추정 금지 기존 룰 무회귀) — 처음부터 green
4. 무회귀 — device sync 신선 + stationary + intermediate → 기존 V8d stationary skip 그대로 유지 — 처음부터 green

## Quota 증분 산정
- 게이트 #1(V8d stationary skip) 조건부 완화로, **device sync가 5분+ stale인 lock-active trip**에 한해 매 cron cycle(60s nominal)마다 Seoul API subrequest + KV read(`readSsot` cacheTtl 30s)가 재개된다.
- 상한: `BACKEND_TRIP_LIFECYCLE_SILENCE_MS`(6h)/`FORCE_END_MS`(9h) lifecycle 게이트가 이미 존재 — 무한정 폴링 아님. cronIdleGate(#2073)는 본 PR에서 미접촉.
- 정상 케이스(device sync 신선)는 quota 영향 없음 — stale(suspend 25분+ 같은 예외 상황)에만 증분 발생.

## 무회귀
- 기존 backend 전체 스위트(2993 tests, 82 files) green.
- `npx tsc --noEmit` clean.
- `shouldSkipStationary` 시그니처 변경(4번째 파라미터 `deviceSyncStale` 추가) — 기존 unit test 전부 `false`로 명시 갱신 + 신규 stale bypass 케이스 1건 추가.
- `TripPositionSSoT.schemaVersion` 2 → 3 (신규 optional 필드 추가, 마이그레이션 분기 없음 — 순수 doc 목적).

## Wire 5단
1. **Orphan 없음**: backend는 root `lint:orphan` 스캔 대상 밖(frontend `src/` 전용 스크립트) — N/A. 신규 export(`isDeviceSyncStale`, `DEVICE_SYNC_STALE_THRESHOLD_MS`)는 모두 `advanceTripPosition.ts`/`scheduled.ts` 내 실사용 caller 존재.
2. **V/X dashboard**: `lifecycleStationarySkipped`/`transferDestinationGateBlocked`/`staleLockFireSkipped`/`arvlCdFireFired` 카운터는 기존 `ScheduledStats` — Cloudflare Dashboard `wrangler tail` 또는 D1 trip_events(advance evidence=`arvlcd-confirmed-train`)로 관측 가능. 신규 `lastDeviceSyncAt` 필드는 silent push/`POST /position` 응답 SSoT mirror(`toSilentPushSsot`)로 forward돼 DebugModal에서 device 측 확인 가능.
3. **의존 PR**: 없음(N/A) — 단, **머지 후 wrangler deploy 필요**.
4. **측정 plan**: 다음 검증 탑승에서 device를 강제 suspend(백그라운드 25분+) 시킨 뒤 잠금 leg의 `fired_count > 0` + advance 연속성(중간역 skip 없음) 확인. Cloudflare 로그에서 `arvlcd-fire: stale SSoT skip`/`cron: stationary skip` 발생 0건(해당 trip 한정) 확인.
5. **Device verify**: 필요 — 잠금 leg 1개 구간, 25분+ suspend 시나리오로 실기기 검증.