### PR TITLE
fix(#2319): lockless trip 환승 진행 시 legAdvance stamp 갭 해소

### DIFF
--- a/src/features/route/hooks/__tests__/useTransferTrainList.test.tsx
+++ b/src/features/route/hooks/__tests__/useTransferTrainList.test.tsx
@@ -847,6 +847,19 @@ describe('#2319 lockless trip 환승 진행 시 legAdvance stamp', () => {
     expect(mockStampLegAdvance).not.toHaveBeenCalled();
   });
 
+  it('lock=null + currentStation이 환승역이 아닌 경유역(삼각지) → resolveTransferWaypoint 매칭 실패로 stampLegAdvance 미호출', () => {
+    const samgakji = findStationByNameAndLine('삼각지', '6') as Station;
+    renderHook(() =>
+      useTransferTrainList({
+        lock: null,
+        route,
+        destinationName: '여의나루',
+        currentStation: samgakji,
+      }),
+    );
+    expect(mockStampLegAdvance).not.toHaveBeenCalled();
+  });
+
   it('lock=null + 환승역 유지 상태로 재렌더 → stampLegAdvance 중복 호출 없음', () => {
     const { rerender } = renderHook(
       (props: { currentStation: Station }) =>

--- a/src/features/route/hooks/__tests__/useTransferTrainList.test.tsx
+++ b/src/features/route/hooks/__tests__/useTransferTrainList.test.tsx
@@ -767,8 +767,13 @@ describe('#2305 durable legAdvance stamp — context 활성화 시 stamp', () =>
     expect(mockStampLegAdvance).toHaveBeenCalledTimes(1);
     // lock 해제(RCA evidence: release:user) — context는 lock=null이라 즉시 비활성화되지만
     // 이미 발생한 stamp 호출 자체(=durable 신호)는 취소되지 않는다.
+    // #2319 — lock=null 전이 시 lock-비종속 보조 경로(findLocklessTransferWaypoint)가 같은
+    // waypoint(nextLine='5')로 stamp를 다시 발화한다. 같은 값 재-stamp는 durable 신호를
+    // 무효화하지 않고(멱등), 오히려 lockless로 전환된 이후에도 stamp가 살아있음을 보강한다 —
+    // 이 재발화 자체가 #2319가 메우려는 lockless 갭의 정상 동작.
     rerender({ lock: null });
-    expect(mockStampLegAdvance).toHaveBeenCalledTimes(1);
+    expect(mockStampLegAdvance).toHaveBeenCalledTimes(2);
+    expect(mockStampLegAdvance).toHaveBeenNthCalledWith(2, '5');
   });
 
   it('context가 계속 활성 상태로 재렌더 되어도 stampLegAdvance 중복 호출 없음', () => {
@@ -797,6 +802,78 @@ describe('#2305 durable legAdvance stamp — context 활성화 시 stamp', () =>
       }),
     );
     expect(mockStampLegAdvance).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * #2319 — lockless trip(=origin lock 자체가 없는 trip) 환승 진행 시 legAdvance stamp 갭.
+ *
+ * #2305(PR #2313)의 stamp는 `findActiveTransferContext`의 null→non-null 전이에서 발화하는데,
+ * 그 함수는 `lock` 존재를 전제(`if (!lock || ...) return null`)한다. lockless trip은 애초에
+ * lock이 없으므로 context가 영원히 null → stamp가 찍히지 않고 approachLine이 동결 route
+ * `stopsToTransfer` fallback으로 남는다 (#2318 선행 검증 판정, PR #2313 Deviation 절).
+ *
+ * 기대 동작: lock 유무와 무관하게, route + destinationName + currentStation만으로 환승
+ * waypoint 도달을 판정해 stamp가 발화해야 한다.
+ */
+describe('#2319 lockless trip 환승 진행 시 legAdvance stamp', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseArrival.mockReturnValue(arrivalRet(null));
+    mockPrefetchArrival.mockResolvedValue(undefined);
+  });
+
+  it('lock=null + 환승 waypoint 도달 → stampLegAdvance(nextLine) 호출 (RED였던 lockless 갭)', () => {
+    renderHook(() =>
+      useTransferTrainList({
+        lock: null,
+        route,
+        destinationName: '여의나루',
+        currentStation: gondeokOn6,
+      }),
+    );
+    expect(mockStampLegAdvance).toHaveBeenCalledWith('5');
+  });
+
+  it('lock=null + 환승 waypoint 미도달(currentStation=null) → stampLegAdvance 미호출', () => {
+    renderHook(() =>
+      useTransferTrainList({
+        lock: null,
+        route,
+        destinationName: '여의나루',
+        currentStation: null,
+      }),
+    );
+    expect(mockStampLegAdvance).not.toHaveBeenCalled();
+  });
+
+  it('lock=null + 환승역 유지 상태로 재렌더 → stampLegAdvance 중복 호출 없음', () => {
+    const { rerender } = renderHook(
+      (props: { currentStation: Station }) =>
+        useTransferTrainList({
+          lock: null,
+          route,
+          destinationName: '여의나루',
+          currentStation: props.currentStation,
+        }),
+      { initialProps: { currentStation: gondeokOn6 } },
+    );
+    expect(mockStampLegAdvance).toHaveBeenCalledTimes(1);
+    rerender({ currentStation: gondeokOn6 });
+    expect(mockStampLegAdvance).toHaveBeenCalledTimes(1);
+  });
+
+  it('lock 존재 시(기존 경로)에는 lockless 보조 경로가 중복 stamp를 발생시키지 않음', () => {
+    renderHook(() =>
+      useTransferTrainList({
+        lock,
+        route,
+        destinationName: '여의나루',
+        currentStation: gondeokOn6,
+      }),
+    );
+    expect(mockStampLegAdvance).toHaveBeenCalledTimes(1);
+    expect(mockStampLegAdvance).toHaveBeenCalledWith('5');
   });
 });
 

--- a/src/features/route/hooks/useTransferTrainList.ts
+++ b/src/features/route/hooks/useTransferTrainList.ts
@@ -13,6 +13,7 @@ import { useLegAdvanceStore } from '../../alarm/store/useLegAdvanceStore';
 import { pickAutoTrainCodeFromArrivals } from '../../alarm/utils/boardingPromptAutoLock';
 import {
   findActiveTransferContext,
+  findLocklessTransferWaypoint,
   findUpcomingTransferPrefetch,
 } from '../utils/findActiveTransferContext';
 import { FALLBACK_BOARDING_DURATION_MINUTES } from '../../../shared/constants/boardingLock';
@@ -108,6 +109,28 @@ export function useTransferTrainList({
     }
     prevContextActiveRef.current = active;
   }, [context, refetch]);
+
+  // #2319 — lockless trip(=origin lock 자체가 없는 trip) 환승 진행 시 durable legAdvance stamp 갭.
+  // 위 effect는 `context`(lock-bound `findActiveTransferContext`)의 null→non-null 전이에서만
+  // 발화하므로 lock이 아예 없는 trip은 영원히 stamp되지 않는다 (#2318 선행 검증 판정, PR #2313
+  // Deviation 절). lock이 있으면 위 effect가 이미 stamp를 책임지므로(lock 존재 시 `context`가
+  // 동일 waypoint에서 활성화됨), 이 effect는 lock=null 상태에서만 lock-비종속 신호
+  // (`findLocklessTransferWaypoint`)로 같은 stamp를 보완 발화한다. arrivals/refetch/autoLock은
+  // 여전히 lock-bound `context`만 사용 — stamp 전용 보완 경로다.
+  const locklessWaypoint = useMemo(
+    () => (lock ? null : findLocklessTransferWaypoint(route, destinationName, currentStation)),
+    [lock, route, destinationName, currentStation],
+  );
+  const prevLocklessWaypointKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    const key = locklessWaypoint
+      ? `${locklessWaypoint.transferStationInToLine.id}|${locklessWaypoint.nextLine}`
+      : null;
+    if (key && key !== prevLocklessWaypointKeyRef.current) {
+      void useLegAdvanceStore.getState().stampLegAdvance(locklessWaypoint!.nextLine);
+    }
+    prevLocklessWaypointKeyRef.current = key;
+  }, [locklessWaypoint]);
 
   const arrivals = useMemo<ArrivalInfo[]>(
     () => filterByDirection(arrival, context?.direction ?? null),

--- a/src/features/route/utils/findActiveTransferContext.ts
+++ b/src/features/route/utils/findActiveTransferContext.ts
@@ -54,6 +54,74 @@ export function findActiveTransferContext(
 ): ActiveTransferContext | null {
   if (!lock || !route || !destinationName || !currentStation) return null;
 
+  const matched = resolveTransferWaypoint(route, destinationName, currentStation);
+  if (!matched) return null;
+
+  const { nextLine, transferStationInToLine, nextWaypointName, matchedIdx } = matched;
+  // lock이 이미 nextLine으로 교체된 상태(=환승 완료)면 context 재노출하지 않음.
+  // 사용자가 새 열차 탭 → createTransferLock → boardingLine=nextLine 갱신되었지만 GPS는 아직
+  // 환승역에 머무는 경우, 가드 없으면 같은 list가 다시 노출되어 lock 중복 생성 가능.
+  if (lock.boardingLine === nextLine) return null;
+
+  const direction = resolveDirectionInLine(
+    nextLine,
+    transferStationInToLine.id,
+    nextWaypointName,
+  );
+
+  return {
+    transferStationInToLine,
+    nextLine,
+    nextWaypointName,
+    direction,
+    completedTransferIdx: matchedIdx,
+  };
+}
+
+export interface LocklessTransferWaypoint {
+  /** toLine 기준의 환승역 Station 객체 — legAdvance stamp의 nextLine 근거. */
+  transferStationInToLine: Station;
+  /** 환승 후 탑승할 노선. */
+  nextLine: LineNumber;
+}
+
+/**
+ * #2319 — lock 유무와 무관하게 route + destinationName + currentStation만으로 환승 waypoint
+ * 도달을 판정한다. `findActiveTransferContext`는 lock 존재를 전제(#584 PR E 원 설계 — BoardingLock
+ * SSOT 기반 환승 list/autoLock)해 lockless trip(origin lock 자체가 없는 trip)에서는 영원히 null을
+ * 반환한다. `useTransferTrainList`의 durable legAdvance stamp(#2305)는 이 함수로 lock-비종속
+ * 신호를 얻어, lockless trip 환승 진행 시에도 approachLine이 동결 route fallback으로 남지 않도록
+ * 한다. arrivals list/autoLock(#1211 D5)은 여전히 lock-bound `findActiveTransferContext`만 사용
+ * — 이 함수는 stamp 전용 lock-비종속 신호다.
+ */
+export function findLocklessTransferWaypoint(
+  route: Route,
+  destinationName: string | null,
+  currentStation: Station | null,
+): LocklessTransferWaypoint | null {
+  if (!route || !destinationName || !currentStation) return null;
+  const matched = resolveTransferWaypoint(route, destinationName, currentStation);
+  if (!matched) return null;
+  return { transferStationInToLine: matched.transferStationInToLine, nextLine: matched.nextLine };
+}
+
+interface ResolvedTransferWaypoint {
+  transferStationInToLine: Station;
+  nextLine: LineNumber;
+  nextWaypointName: string;
+  matchedIdx: number;
+}
+
+/**
+ * `findActiveTransferContext`와 `findLocklessTransferWaypoint`가 공유하는 core 매칭 로직
+ * (lock 무관). resolveAllTargets로 waypoint 목록 산출 후 currentStation.name과 매칭되는
+ * transfer target을 탐색한다.
+ */
+function resolveTransferWaypoint(
+  route: NonNullable<Route>,
+  destinationName: string,
+  currentStation: Station,
+): ResolvedTransferWaypoint | null {
   const targets = resolveAllTargets(route, destinationName);
   const matchedIdx = targets.findIndex((t) => isSameStationName(t.name, currentStation.name));
   if (matchedIdx === -1) return null;
@@ -68,26 +136,10 @@ export function findActiveTransferContext(
   if (!next) return null;
 
   const nextLine = next.approachLine;
-  // lock이 이미 nextLine으로 교체된 상태(=환승 완료)면 context 재노출하지 않음.
-  // 사용자가 새 열차 탭 → createTransferLock → boardingLine=nextLine 갱신되었지만 GPS는 아직
-  // 환승역에 머무는 경우, 가드 없으면 같은 list가 다시 노출되어 lock 중복 생성 가능.
-  if (lock.boardingLine === nextLine) return null;
   const transferStationInToLine = findStationByNameAndLine(matched.name, nextLine);
   if (!transferStationInToLine) return null;
 
-  const direction = resolveDirectionInLine(
-    nextLine,
-    transferStationInToLine.id,
-    next.name,
-  );
-
-  return {
-    transferStationInToLine,
-    nextLine,
-    nextWaypointName: next.name,
-    direction,
-    completedTransferIdx: matchedIdx,
-  };
+  return { transferStationInToLine, nextLine, nextWaypointName: next.name, matchedIdx };
 }
 
 /** prefetch 트리거에 사용 — 환승 imminent로 판정하는 잔여 stops 임계값 (#814). */


### PR DESCRIPTION
Closes #2319

## 배경

#2305(PR #2313)의 durable legAdvance stamp는 `findActiveTransferContext`의 null→non-null 전이에서 발화하는데, 그 함수는 `lock` 존재를 전제(`if (!lock || ...) return null`)한다. lockless trip(origin lock 자체가 없는 trip)은 애초에 lock이 없어 context가 영원히 null → stamp가 찍히지 않고 approachLine이 동결 route `stopsToTransfer` fallback으로 남는다 (#2318 선행 검증 판정, PR #2313 Deviation 절).

## 선택안 vs 기각안

이슈 본문 두 방향 중 코드 조사 후 **Option 1(stamp 트리거를 lock 컨텍스트 외에도 발화하도록 확장, lock-비종속 경로 추가)**을 선택했다.

- **선택: stamp 트리거 lock-비종속 확장**
  - `findActiveTransferContext`의 core 매칭 로직(`resolveTransferWaypoint`)을 lock-무관 helper로 추출하고, 신규 `findLocklessTransferWaypoint`(lock 없이 route+destinationName+currentStation만으로 환승 waypoint 판정)를 export.
  - `useTransferTrainList`에 lock=null 전용 보조 stamp effect를 추가(additive) — 기존 lock-bound stamp effect / arrivals list(useArrivalInfo) / D5 autoLock effect는 완전히 미변경.
  - 블라스트 반경이 stamp 발화 지점 하나로 국한되고, arrivals list·autoLock의 기존 lock-gated 정확도 게이트를 건드리지 않는다.
- **기각: approachLine의 동결 fallback 제거 + fusion hop 기반 산출(#2305 스펙 2 완성)**
  - fusion hop 이벤트 기반 재설계는 `getApproachLine`의 우선순위 로직(lock > legAdvance > route > fallback) 전체를 새 신호로 대체해야 해 블라스트 반경이 넓고, 검증에 실기기 fusion hop 캡처가 추가로 필요하다. 이번 이슈의 목표(lockless stamp gap 해소)에는 과도한 범위 확장이라 판단해 기각. 향후 fusion hop SSoT 전환이 필요하면 별도 이슈로 분리 권장.

## #2318(오토락 삭제, 머지 대기)과의 충돌 회피

`useTransferTrainList.ts`의 D5 auto-lock effect 블록(`#1211 D5 — 환승 leg autoLock 트리거` 주석 이하)은 이번 PR에서 **전혀 건드리지 않음**. 새 lockless stamp effect는 기존 stamp effect 바로 다음(D5 auto-lock effect 이전)에 독립적으로 삽입했다.

## 변경 파일

- `src/features/route/utils/findActiveTransferContext.ts` — `resolveTransferWaypoint`(공유 core) 추출 + `findLocklessTransferWaypoint`(신규 export) 추가. 기존 `findActiveTransferContext`/`findUpcomingTransferPrefetch`의 동작은 리팩토링 전과 동일(순수 함수 추출).
- `src/features/route/hooks/useTransferTrainList.ts` — lock=null 시 `findLocklessTransferWaypoint` 기반 stamp effect 추가.
- `src/features/route/hooks/__tests__/useTransferTrainList.test.tsx` — TDD red→green: lockless 재현 테스트 4건 추가 + 기존 lock-release 테스트 기대값 갱신(같은 nextLine 재-stamp는 멱등이며 lockless 전환 후 stamp 보강이 의도된 동작임을 주석으로 명시).

## Acceptance

- [x] red: lockless trip 환승 진행 시 approachLine이 구노선 유지되는 재현 테스트 → green (`#2319 lockless trip 환승 진행 시 legAdvance stamp` describe).
- [ ] 실기기: lockless 환승 trip 1회에서 리스트/ETA가 환승 노선 전환 — 아래 Wire 5단 참고.

## Wire-completion 5단

1. **Orphan 없음** — `npm run lint:orphan` pass (로컬 실행 확인, "No orphan exports detected").
2. **V/X dashboard** — DebugModal fusion 로그(기존 legAdvance stamp 관측 경로와 동일 — `useLegAdvanceStore` state는 DebugModal에서 이미 노출 중인 fusion/lock 섹션에서 관측 가능). 별도 신규 로그 추가는 이번 PR 범위 밖(stamp 호출 자체가 기존 store action 재사용).
3. **의존 PR: #2318과의 머지 순서** — **#2318(오토락 삭제)이 먼저 머지되어야 한다.** 본 PR은 D5 auto-lock effect 블록을 건드리지 않으므로 #2318이 먼저 머지되어 해당 블록이 삭제/변경되더라도 본 PR의 diff(별도 effect 삽입)는 독립적으로 rebase 가능 — 단, #2318이 나중에 머지되면 두 PR이 같은 파일(`useTransferTrainList.ts`)의 인접 라인을 건드려 conflict 가능성이 있으므로 **#2318 → 본 PR 순서 권장**.
4. **측정 plan** — 다음 lockless 환승 trip에서 `useLegAdvanceStore`의 `nextLine`/`stampedAt`이 환승역 도달 즉시(lock 없이도) 갱신되는지 실기기 dump로 확인. `getApproachLine`이 반환하는 line이 환승 후 리스트/ETA에 반영되는지 교차 검증.
5. **Device verify** — 필요. lockless 환승 trip 1회(예: 건대입구 7→2 환승, lock 미생성 상태)로 BoardingTrainList/ETA가 환승 노선(2호선)으로 전환되는지 실기기 검증 필요.