### PR TITLE
feat(#2327): transferLegConsensus 후보 엔진 + 상태기계 (consensus-A)

### DIFF
--- a/backend/alarm-worker/src/__tests__/transferLegConsensus.test.ts
+++ b/backend/alarm-worker/src/__tests__/transferLegConsensus.test.ts
@@ -1,0 +1,386 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeCandidateWindow,
+  DEMOTE_MISMATCH_STREAK,
+  initLegConsensus,
+  isDepartureEligible,
+  MISSED_TICK_MISMATCH_COUNT,
+  stepLegConsensus,
+  SUPPRESS_HOPS_TO_TERMINUS,
+  type LegConsensusRecord,
+} from '../transferLegConsensus';
+
+// 08-12 저녁 페이퍼 시뮬레이션 (design SSoT #2323 코멘트 (7)): W=278s(건대입구 2→7),
+// H=210s, hop 80s×4. T0=epoch 0 기준으로 상대 offset만 사용(절대 시각 무관, 순수 엔진).
+const T0 = 0;
+const TRANSFER_TIME_SEC = 278;
+const HEADWAY_SEC = 210;
+const HOP_MS = 80_000;
+
+describe('computeCandidateWindow / isDepartureEligible', () => {
+  it('core 창 = [T0+W, T0+W+H], 허용 범위 = [T0+0.5W, T0+1.5W+H]', () => {
+    const window = computeCandidateWindow(T0, TRANSFER_TIME_SEC, HEADWAY_SEC);
+    expect(window.coreStartEpochMs).toBe(278_000);
+    expect(window.coreEndEpochMs).toBe(488_000);
+    expect(window.earliestAllowedEpochMs).toBe(139_000);
+    expect(window.latestAllowedEpochMs).toBe(627_000);
+  });
+
+  it('0.5W 이전 출발(앞차/반대방향) → hard reject', () => {
+    const window = computeCandidateWindow(T0, TRANSFER_TIME_SEC, HEADWAY_SEC);
+    expect(isDepartureEligible(window, 100_000)).toBe(false);
+  });
+
+  it('1.5W+H 이후 출발 → hard reject', () => {
+    const window = computeCandidateWindow(T0, TRANSFER_TIME_SEC, HEADWAY_SEC);
+    expect(isDepartureEligible(window, 950_000)).toBe(false);
+  });
+
+  it('core 창 내부 출발 → eligible', () => {
+    const window = computeCandidateWindow(T0, TRANSFER_TIME_SEC, HEADWAY_SEC);
+    expect(isDepartureEligible(window, 300_000)).toBe(true);
+  });
+});
+
+describe('initLegConsensus', () => {
+  it('단일 eligible 후보 → tracking', () => {
+    const record = initLegConsensus(
+      T0,
+      TRANSFER_TIME_SEC,
+      HEADWAY_SEC,
+      [{ trainCode: '장암행-1', departureEpochMs: 300_000 }],
+      T0,
+    );
+    expect(record.status).toBe('tracking');
+    expect(record.candidates).toHaveLength(1);
+  });
+
+  it('0.5W 이전 출발 후보 → 후보 자체가 필터링(candidates 0)', () => {
+    const record = initLegConsensus(
+      T0,
+      TRANSFER_TIME_SEC,
+      HEADWAY_SEC,
+      [{ trainCode: '앞차', departureEpochMs: 100_000 }],
+      T0,
+    );
+    expect(record.candidates).toHaveLength(0);
+    expect(record.status).toBe('tracking');
+  });
+
+  it('동시 창 2 eligible 후보 → ambiguous', () => {
+    const record = initLegConsensus(
+      T0,
+      TRANSFER_TIME_SEC,
+      HEADWAY_SEC,
+      [
+        { trainCode: 'A', departureEpochMs: 300_000 },
+        { trainCode: 'B', departureEpochMs: 320_000 },
+      ],
+      T0,
+    );
+    expect(record.status).toBe('ambiguous');
+  });
+});
+
+/** acceptance ①: 2 waypoint 정합 내 단일 confirm. */
+describe('acceptance ① — 단일 후보 2 waypoint 정합 → confirm', () => {
+  it('연속 2 tick match(|Δ|≤90s) → confirmed', () => {
+    let record: LegConsensusRecord = initLegConsensus(
+      T0,
+      TRANSFER_TIME_SEC,
+      HEADWAY_SEC,
+      [{ trainCode: '장암행-1', departureEpochMs: 300_000 }],
+      T0,
+    );
+    expect(record.status).toBe('tracking');
+
+    let result = stepLegConsensus(record, {
+      now: HOP_MS,
+      observations: [{ trainCode: '장암행-1', deltaSec: 10 }],
+    });
+    record = result.record;
+    expect(record.status).toBe('tracking');
+    expect(result.events).toHaveLength(0);
+
+    result = stepLegConsensus(record, {
+      now: HOP_MS * 2,
+      observations: [{ trainCode: '장암행-1', deltaSec: -5 }],
+    });
+    record = result.record;
+    expect(record.status).toBe('confirmed');
+    expect(record.confirmedTrainCode).toBe('장암행-1');
+    expect(result.events).toEqual([{ kind: 'consensus-confirm', trainCode: '장암행-1' }]);
+  });
+});
+
+/** acceptance ②: 반대방향/앞차(0.5W 이전 출발) → confirm 0 (hard reject, 후보 진입 자체 불가). */
+describe('acceptance ② — 반대방향/앞차 hard reject → confirm 0', () => {
+  it('window 밖 후보는 candidates에 진입하지 않아 아무리 tick을 진행해도 confirmed가 될 수 없다', () => {
+    let record: LegConsensusRecord = initLegConsensus(
+      T0,
+      TRANSFER_TIME_SEC,
+      HEADWAY_SEC,
+      [{ trainCode: '앞차', departureEpochMs: 100_000 }],
+      T0,
+    );
+    expect(record.candidates).toHaveLength(0);
+
+    for (let i = 1; i <= 4; i++) {
+      const result = stepLegConsensus(record, {
+        now: HOP_MS * i,
+        observations: [{ trainCode: '앞차', deltaSec: 0 }],
+      });
+      record = result.record;
+      expect(record.status).not.toBe('confirmed');
+    }
+  });
+});
+
+/** acceptance ③: 동시 창 2후보 → ambiguous 유지 → 종점 2hop 전 suppress. */
+describe('acceptance ③ — 동시 창 2후보 ambiguous → 종점 임박 suppress', () => {
+  it('두 후보 모두 match 유지 시 ambiguous 지속, hopsRemainingToTerminus<=2에서 suppress + floor 공급', () => {
+    let record: LegConsensusRecord = initLegConsensus(
+      T0,
+      TRANSFER_TIME_SEC,
+      HEADWAY_SEC,
+      [
+        { trainCode: 'A', departureEpochMs: 300_000 },
+        { trainCode: 'B', departureEpochMs: 320_000 },
+      ],
+      T0,
+    );
+    expect(record.status).toBe('ambiguous');
+
+    let result = stepLegConsensus(record, {
+      now: HOP_MS,
+      hopsRemainingToTerminus: 4,
+      observations: [
+        { trainCode: 'A', deltaSec: 0 },
+        { trainCode: 'B', deltaSec: 5 },
+      ],
+    });
+    record = result.record;
+    expect(record.status).toBe('ambiguous');
+    expect(result.events).toHaveLength(0);
+
+    result = stepLegConsensus(record, {
+      now: HOP_MS * 2,
+      hopsRemainingToTerminus: SUPPRESS_HOPS_TO_TERMINUS,
+      observations: [
+        { trainCode: 'A', deltaSec: 0 },
+        { trainCode: 'B', deltaSec: 5 },
+      ],
+    });
+    record = result.record;
+    expect(record.status).toBe('suppressed');
+    expect(record.suppressFloorEpochMs).toBe(320_000); // 최후 생존 후보 중 최늦 T_dep
+    expect(result.events).toEqual([
+      { kind: 'consensus-suppress', meta: { reason: 'ambiguous-near-terminus' } },
+    ]);
+  });
+});
+
+/** acceptance ④: outage fixture — confidence hold(소멸 유예), mismatch 미집계. */
+describe('acceptance ④ — outage tick → confidence hold, mismatch 미집계', () => {
+  it('outage tick은 카운트를 전혀 변경하지 않고, 이후 정상 tick으로 confirm까지 정상 도달한다', () => {
+    let record: LegConsensusRecord = initLegConsensus(
+      T0,
+      TRANSFER_TIME_SEC,
+      HEADWAY_SEC,
+      [{ trainCode: '장암행-1', departureEpochMs: 300_000 }],
+      T0,
+    );
+
+    let result = stepLegConsensus(record, {
+      now: HOP_MS,
+      observations: [{ trainCode: '장암행-1', deltaSec: 10 }],
+    });
+    record = result.record;
+    expect(record.candidates[0].matchCount).toBe(1);
+
+    // outage tick: mismatch 미집계 + missedTicks 증가 없음(hold)
+    result = stepLegConsensus(record, { now: HOP_MS * 2, outage: true });
+    record = result.record;
+    expect(record.candidates[0].matchCount).toBe(1);
+    expect(record.candidates[0].mismatchCount).toBe(0);
+    expect(record.candidates[0].missedTicks).toBe(0);
+    expect(record.status).toBe('tracking');
+    expect(result.events).toHaveLength(0);
+
+    // fetchedAt age>30s 도 동일하게 미집계
+    result = stepLegConsensus(record, {
+      now: HOP_MS * 3,
+      observations: [{ trainCode: '장암행-1', deltaSec: 200, fetchedAtAgeSec: 45 }],
+    });
+    record = result.record;
+    expect(record.candidates[0].mismatchCount).toBe(0);
+
+    result = stepLegConsensus(record, {
+      now: HOP_MS * 4,
+      observations: [{ trainCode: '장암행-1', deltaSec: -5 }],
+    });
+    record = result.record;
+    expect(record.status).toBe('confirmed');
+  });
+});
+
+/** acceptance ⑤: confirmed 후 mismatch 2연속 → demote. */
+describe('acceptance ⑤ — confirmed 후 mismatch 2연속 → demote', () => {
+  it('confirmed 상태에서 연속 mismatch(|Δ|>180s) 2회 시 즉시 demoted', () => {
+    let record: LegConsensusRecord = initLegConsensus(
+      T0,
+      TRANSFER_TIME_SEC,
+      HEADWAY_SEC,
+      [{ trainCode: '장암행-1', departureEpochMs: 300_000 }],
+      T0,
+    );
+    record = stepLegConsensus(record, {
+      now: HOP_MS,
+      observations: [{ trainCode: '장암행-1', deltaSec: 10 }],
+    }).record;
+    record = stepLegConsensus(record, {
+      now: HOP_MS * 2,
+      observations: [{ trainCode: '장암행-1', deltaSec: -5 }],
+    }).record;
+    expect(record.status).toBe('confirmed');
+
+    record = stepLegConsensus(record, {
+      now: HOP_MS * 3,
+      observations: [{ trainCode: '장암행-1', deltaSec: 200 }],
+    }).record;
+    expect(record.status).toBe('confirmed');
+    expect(record.confirmedMismatchStreak).toBe(1);
+
+    const result = stepLegConsensus(record, {
+      now: HOP_MS * 4,
+      observations: [{ trainCode: '장암행-1', deltaSec: -220 }],
+    });
+    record = result.record;
+    expect(record.status).toBe('demoted');
+    expect(record.confirmedMismatchStreak).toBe(DEMOTE_MISMATCH_STREAK);
+    expect(result.events).toEqual([{ kind: 'consensus-demote', trainCode: '장암행-1' }]);
+
+    // demoted는 terminal — 이후 tick도 상태 불변
+    const after = stepLegConsensus(record, {
+      now: HOP_MS * 5,
+      observations: [{ trainCode: '장암행-1', deltaSec: 0 }],
+    });
+    expect(after.record.status).toBe('demoted');
+    expect(after.events).toHaveLength(0);
+  });
+});
+
+describe('전 후보 mismatch → 자연 suppress (fail mode 6: route 오등록)', () => {
+  it('단일 후보가 mismatch(>180s) 1회만 겪어도 생존자 0 → suppressed', () => {
+    let record: LegConsensusRecord = initLegConsensus(
+      T0,
+      TRANSFER_TIME_SEC,
+      HEADWAY_SEC,
+      [{ trainCode: 'X', departureEpochMs: 300_000 }],
+      T0,
+    );
+    const result = stepLegConsensus(record, {
+      now: HOP_MS,
+      observations: [{ trainCode: 'X', deltaSec: 300 }],
+    });
+    record = result.record;
+    expect(record.status).toBe('suppressed');
+    expect(result.events).toEqual([
+      { kind: 'consensus-suppress', meta: { reason: 'all-mismatch' } },
+    ]);
+    expect(record.suppressFloorEpochMs).toBe(300_000);
+  });
+});
+
+describe('neutral zone (90s < |Δ| ≤ 180s) — match도 mismatch도 아님', () => {
+  it('tracking/ambiguous 단계에서 neutral delta는 카운트를 변경하지 않는다', () => {
+    let record: LegConsensusRecord = initLegConsensus(
+      T0,
+      TRANSFER_TIME_SEC,
+      HEADWAY_SEC,
+      [{ trainCode: 'Z', departureEpochMs: 300_000 }],
+      T0,
+    );
+    const result = stepLegConsensus(record, {
+      now: HOP_MS,
+      observations: [{ trainCode: 'Z', deltaSec: 120 }],
+    });
+    record = result.record;
+    expect(record.candidates[0].matchCount).toBe(0);
+    expect(record.candidates[0].mismatchCount).toBe(0);
+    expect(record.status).toBe('tracking');
+  });
+
+  it('confirmed 단계에서 neutral delta는 mismatch streak을 변경하지 않는다', () => {
+    let record: LegConsensusRecord = initLegConsensus(
+      T0,
+      TRANSFER_TIME_SEC,
+      HEADWAY_SEC,
+      [{ trainCode: 'Z', departureEpochMs: 300_000 }],
+      T0,
+    );
+    record = stepLegConsensus(record, {
+      now: HOP_MS,
+      observations: [{ trainCode: 'Z', deltaSec: 10 }],
+    }).record;
+    record = stepLegConsensus(record, {
+      now: HOP_MS * 2,
+      observations: [{ trainCode: 'Z', deltaSec: -5 }],
+    }).record;
+    expect(record.status).toBe('confirmed');
+
+    const result = stepLegConsensus(record, {
+      now: HOP_MS * 3,
+      observations: [{ trainCode: 'Z', deltaSec: 120 }],
+    });
+    expect(result.record.status).toBe('confirmed');
+    expect(result.record.confirmedMismatchStreak).toBe(0);
+  });
+
+  it('confirmed 단계에서 confirmedTrainCode 관측이 없으면(observations 빈 배열) streak을 유지한다', () => {
+    let record: LegConsensusRecord = initLegConsensus(
+      T0,
+      TRANSFER_TIME_SEC,
+      HEADWAY_SEC,
+      [{ trainCode: 'Z', departureEpochMs: 300_000 }],
+      T0,
+    );
+    record = stepLegConsensus(record, {
+      now: HOP_MS,
+      observations: [{ trainCode: 'Z', deltaSec: 10 }],
+    }).record;
+    record = stepLegConsensus(record, {
+      now: HOP_MS * 2,
+      observations: [{ trainCode: 'Z', deltaSec: -5 }],
+    }).record;
+    expect(record.status).toBe('confirmed');
+
+    const result = stepLegConsensus(record, { now: HOP_MS * 3, observations: [] });
+    expect(result.record.status).toBe('confirmed');
+    expect(result.record.confirmedMismatchStreak).toBe(0);
+  });
+});
+
+describe('3-tick 건너뜀 → mismatch 집계 (fail mode: API stale/무관측)', () => {
+  it(`관측 없는 tick이 ${MISSED_TICK_MISMATCH_COUNT}회 연속되면 mismatch로 집계된다`, () => {
+    let record: LegConsensusRecord = initLegConsensus(
+      T0,
+      TRANSFER_TIME_SEC,
+      HEADWAY_SEC,
+      [{ trainCode: 'Y', departureEpochMs: 300_000 }],
+      T0,
+    );
+    for (let i = 1; i < MISSED_TICK_MISMATCH_COUNT; i++) {
+      const result = stepLegConsensus(record, { now: HOP_MS * i, observations: [] });
+      record = result.record;
+      expect(record.status).not.toBe('suppressed');
+    }
+    const result = stepLegConsensus(record, {
+      now: HOP_MS * MISSED_TICK_MISMATCH_COUNT,
+      observations: [],
+    });
+    record = result.record;
+    expect(record.candidates[0].mismatchCount).toBe(1);
+    expect(record.status).toBe('suppressed');
+  });
+});

--- a/backend/alarm-worker/src/transferLegConsensus.ts
+++ b/backend/alarm-worker/src/transferLegConsensus.ts
@@ -1,0 +1,325 @@
+/**
+ * transferLegConsensus — 환승 leg 후보 열차 consensus 엔진 + 상태기계 (#2327, consensus-A).
+ *
+ * 설계 SSoT: #2323 2026-08-13 설계안 코멘트 (판정식·창 산출·상태전이·fail mode 방어).
+ * 08-12 실탑승(중곡 25분 침묵) 사후 페이퍼 시뮬레이션이 본 엔진의 파라미터 기준선이다:
+ * W=278s(건대입구 2→7 transferTimes), H=210s(lineHeadways), hop 80s×4(stationTravelTimes).
+ *
+ * 본 모듈은 **순수 함수 + 상태기계**만 제공한다. Seoul API 신규 호출, D1/KV write, fire/advance
+ * wire(#2329 consensus-C 범위)는 포함하지 않는다 — `pollStationsAndStamp`/`pollLinesAndStamp`
+ * 산출물(관측된 열차 출발/도착 시각)을 caller가 넘겨주는 소비자 역할만 한다.
+ *
+ * ## 판정식
+ * - T0 = transfer waypoint 통과 확정 시각. 후보 = toLine 환승역 출발 관측 열차 중
+ *   `T_dep ∈ [T0+0.5W, T0+1.5W+H]` (핵심 창 [T0+W, T0+W+H], 폭=headway→기대 1대).
+ *   0.5W 이전 출발(앞차/반대방향)은 hard reject — 애초에 candidates에 진입시키지 않는다.
+ * - confidence: 후속 waypoint 관측에서 후보 trainCode 시각 |Δ|≤90s → match+1,
+ *   |Δ|>180s 또는 3-tick 연속 미관측 → mismatch+1. `fetchedAt` age>30s(outage)인 tick은
+ *   미집계 — confidence hold(소멸 유예), match/mismatch/missedTicks 모두 동결.
+ * - confirmed ⟺ core 창 단일 생존(mismatch=0) ∧ match≥2. ambiguous(생존 2+)는
+ *   `hopsRemainingToTerminus`가 SUPPRESS_HOPS_TO_TERMINUS 이하로 좁혀질 때까지 미해소 시 suppress.
+ * - confirmed 후 mismatch 2연속 → demote(발사권 즉시 회수, terminal).
+ * - 전 후보 mismatch(생존 0) → 자연 suppress (fail mode: route 오등록 대비).
+ * - suppress 시 최후 생존 후보 중 최늦 T_dep을 `suppressFloorEpochMs`로 반환 —
+ *   #2155 floor 위임(조기 발사 불가 방향 정합)은 caller(consensus-C) 책임.
+ *
+ * `LegConsensusRecord`는 trip KV 객체 내 `legConsensus` 필드로 저장된다(별도 KV row 금지 —
+ * #2073 cron KV quota lesson). D1 `trip_events` kind `consensus-confirm/demote/suppress`는
+ * `tripEventLog.ts`의 `TripEventKind` 유니온에 추가되어 있다 — 실제 insert 호출(wire)은
+ * consensus-C(#2329) 범위.
+ */
+
+/** 판정식 임계값 — 데이터 주도 확장 시 이 상수만 변경한다(코드 분기 하드코딩 금지). */
+export const MATCH_THRESHOLD_SEC = 90;
+export const MISMATCH_THRESHOLD_SEC = 180;
+export const STALE_AGE_THRESHOLD_SEC = 30;
+export const MISSED_TICK_MISMATCH_COUNT = 3;
+export const CONFIRM_MIN_MATCH_COUNT = 2;
+export const DEMOTE_MISMATCH_STREAK = 2;
+export const SUPPRESS_HOPS_TO_TERMINUS = 2;
+
+/** 후보 창(candidate window) — T0/transferTimeSec(W)/headwaySec(H)로 산출. */
+export interface CandidateWindow {
+  /** 0.5W 이전 하한 — 이보다 이른 출발은 hard reject (앞차/반대방향). */
+  earliestAllowedEpochMs: number;
+  /** T0+W — 핵심 창 시작. */
+  coreStartEpochMs: number;
+  /** T0+W+H — 핵심 창 끝(폭=headway). */
+  coreEndEpochMs: number;
+  /** 1.5W+H 이후 상한 — 이보다 늦은 출발은 hard reject. */
+  latestAllowedEpochMs: number;
+}
+
+/**
+ * 후보 창 산출. transferTimeSec(W)/headwaySec(H)는 caller가 transferTimes/lineHeadways
+ * 데이터셋에서 조회해 전달한다(본 엔진은 역/노선별 하드코딩 분기를 두지 않는다).
+ */
+export function computeCandidateWindow(
+  t0EpochMs: number,
+  transferTimeSec: number,
+  headwaySec: number,
+): CandidateWindow {
+  const wMs = transferTimeSec * 1000;
+  const hMs = headwaySec * 1000;
+  return {
+    earliestAllowedEpochMs: t0EpochMs + 0.5 * wMs,
+    coreStartEpochMs: t0EpochMs + wMs,
+    coreEndEpochMs: t0EpochMs + wMs + hMs,
+    latestAllowedEpochMs: t0EpochMs + 1.5 * wMs + hMs,
+  };
+}
+
+/** 관측된 출발 시각이 후보 창 안인지(hard reject 여부). */
+export function isDepartureEligible(window: CandidateWindow, departureEpochMs: number): boolean {
+  return (
+    departureEpochMs >= window.earliestAllowedEpochMs &&
+    departureEpochMs <= window.latestAllowedEpochMs
+  );
+}
+
+/** 상태기계 상태. tracking(생존 1, match 축적중)/ambiguous(생존 2+)/confirmed/demoted/suppressed. */
+export type LegConsensusStatus = 'tracking' | 'ambiguous' | 'confirmed' | 'demoted' | 'suppressed';
+
+/** 개별 후보 열차의 누적 관측 카운트. */
+export interface LegConsensusCandidateState {
+  trainCode: string;
+  departureEpochMs: number;
+  matchCount: number;
+  mismatchCount: number;
+  /** 연속 미관측 tick 수 — MISSED_TICK_MISMATCH_COUNT 도달 시 mismatch로 집계 후 0으로 리셋. */
+  missedTicks: number;
+}
+
+/** trip KV 객체 내 `legConsensus` 필드로 영속되는 상태기계 스냅샷. */
+export interface LegConsensusRecord {
+  status: LegConsensusStatus;
+  t0EpochMs: number;
+  transferTimeSec: number;
+  headwaySec: number;
+  window: CandidateWindow;
+  candidates: LegConsensusCandidateState[];
+  confirmedTrainCode?: string;
+  /** confirmed 상태에서의 연속 mismatch 카운트 — DEMOTE_MISMATCH_STREAK 도달 시 demote. */
+  confirmedMismatchStreak: number;
+  /** suppress 시 최후 생존 후보 중 최늦 T_dep 기반 도착 추정 — #2155 floor 위임 입력(consensus-C). */
+  suppressFloorEpochMs?: number;
+  updatedAt: number;
+}
+
+/** T0 시점에 관측된 toLine 환승역 출발 열차. */
+export interface ObservedDeparture {
+  trainCode: string;
+  departureEpochMs: number;
+}
+
+/**
+ * 상태기계 초기화. 창 밖 출발 관측은 candidates에서 필터링되어 애초에 진입하지 못한다
+ * (반대방향/앞차 hard reject → 어떤 tick을 진행해도 confirmed 불가, acceptance ②).
+ */
+export function initLegConsensus(
+  t0EpochMs: number,
+  transferTimeSec: number,
+  headwaySec: number,
+  observedDepartures: readonly ObservedDeparture[],
+  now: number = t0EpochMs,
+): LegConsensusRecord {
+  const window = computeCandidateWindow(t0EpochMs, transferTimeSec, headwaySec);
+  const candidates: LegConsensusCandidateState[] = observedDepartures
+    .filter((d) => isDepartureEligible(window, d.departureEpochMs))
+    .map((d) => ({
+      trainCode: d.trainCode,
+      departureEpochMs: d.departureEpochMs,
+      matchCount: 0,
+      mismatchCount: 0,
+      missedTicks: 0,
+    }));
+  return {
+    status: candidates.length >= 2 ? 'ambiguous' : 'tracking',
+    t0EpochMs,
+    transferTimeSec,
+    headwaySec,
+    window,
+    candidates,
+    confirmedMismatchStreak: 0,
+    updatedAt: now,
+  };
+}
+
+/** 한 tick의 후보별 관측. deltaSec 미지정 = 이번 tick에 관측되지 않음(missed). */
+export interface CandidateObservation {
+  trainCode: string;
+  /** 관측 시각 - 예측 시각 (초). |Δ|≤90 → match, |Δ|>180 → mismatch, 그 사이는 중립. */
+  deltaSec?: number;
+  /** poll 데이터의 fetchedAt 나이(초). STALE_AGE_THRESHOLD_SEC 초과 시 미집계(outage 준용). */
+  fetchedAtAgeSec?: number;
+}
+
+export interface LegConsensusTick {
+  now: number;
+  /** 전체 outage(API 장애 등) — true면 이 tick은 모든 후보에 대해 완전 무집계(confidence hold). */
+  outage?: boolean;
+  observations?: readonly CandidateObservation[];
+  /** 종점까지 남은 hop 수 — ambiguous suppress 데드라인 판정에만 사용. */
+  hopsRemainingToTerminus?: number;
+}
+
+export type LegConsensusEventKind = 'consensus-confirm' | 'consensus-demote' | 'consensus-suppress';
+
+/** caller(consensus-C)가 D1 trip_events에 append할 이벤트 descriptor. 본 모듈은 write하지 않는다. */
+export interface LegConsensusEvent {
+  kind: LegConsensusEventKind;
+  trainCode?: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface LegConsensusStepResult {
+  record: LegConsensusRecord;
+  events: LegConsensusEvent[];
+}
+
+function evaluateDelta(deltaSec: number): 'match' | 'mismatch' | 'neutral' {
+  const absDelta = Math.abs(deltaSec);
+  if (absDelta <= MATCH_THRESHOLD_SEC) return 'match';
+  if (absDelta > MISMATCH_THRESHOLD_SEC) return 'mismatch';
+  return 'neutral';
+}
+
+function isStale(obs: CandidateObservation | undefined): boolean {
+  return obs?.fetchedAtAgeSec !== undefined && obs.fetchedAtAgeSec > STALE_AGE_THRESHOLD_SEC;
+}
+
+function stepConfirmed(record: LegConsensusRecord, tick: LegConsensusTick): LegConsensusStepResult {
+  const obs = record.confirmedTrainCode
+    ? (tick.observations ?? []).find((o) => o.trainCode === record.confirmedTrainCode)
+    : undefined;
+
+  let streak = record.confirmedMismatchStreak;
+  if (obs && !isStale(obs) && obs.deltaSec !== undefined) {
+    const outcome = evaluateDelta(obs.deltaSec);
+    if (outcome === 'mismatch') streak += 1;
+    else if (outcome === 'match') streak = 0;
+  }
+
+  if (streak >= DEMOTE_MISMATCH_STREAK) {
+    return {
+      record: { ...record, status: 'demoted', confirmedMismatchStreak: streak, updatedAt: tick.now },
+      events: [{ kind: 'consensus-demote', trainCode: record.confirmedTrainCode }],
+    };
+  }
+  return {
+    record: { ...record, confirmedMismatchStreak: streak, updatedAt: tick.now },
+    events: [],
+  };
+}
+
+function stepTrackingOrAmbiguous(
+  record: LegConsensusRecord,
+  tick: LegConsensusTick,
+): LegConsensusStepResult {
+  const observationsByCode = new Map((tick.observations ?? []).map((o) => [o.trainCode, o]));
+
+  const nextCandidates = record.candidates.map((c) => {
+    const obs = observationsByCode.get(c.trainCode);
+    if (!obs) {
+      const missedTicks = c.missedTicks + 1;
+      if (missedTicks >= MISSED_TICK_MISMATCH_COUNT) {
+        return { ...c, missedTicks: 0, mismatchCount: c.mismatchCount + 1 };
+      }
+      return { ...c, missedTicks };
+    }
+    if (isStale(obs) || obs.deltaSec === undefined) {
+      // outage/stale 개별 관측 — 미집계(hold), missedTicks도 동결.
+      return c;
+    }
+    const outcome = evaluateDelta(obs.deltaSec);
+    if (outcome === 'match') return { ...c, matchCount: c.matchCount + 1, missedTicks: 0 };
+    if (outcome === 'mismatch') return { ...c, mismatchCount: c.mismatchCount + 1, missedTicks: 0 };
+    return { ...c, missedTicks: 0 };
+  });
+
+  const survivors = nextCandidates.filter((c) => c.mismatchCount === 0);
+  const latestDeparture = (list: LegConsensusCandidateState[]): number | undefined =>
+    list.length === 0
+      ? undefined
+      : list.reduce((max, c) => Math.max(max, c.departureEpochMs), -Infinity);
+
+  if (survivors.length === 0) {
+    return {
+      record: {
+        ...record,
+        candidates: nextCandidates,
+        status: 'suppressed',
+        suppressFloorEpochMs: latestDeparture(nextCandidates),
+        updatedAt: tick.now,
+      },
+      events: [{ kind: 'consensus-suppress', meta: { reason: 'all-mismatch' } }],
+    };
+  }
+
+  if (survivors.length === 1) {
+    const [survivor] = survivors;
+    if (survivor.matchCount >= CONFIRM_MIN_MATCH_COUNT) {
+      return {
+        record: {
+          ...record,
+          candidates: nextCandidates,
+          status: 'confirmed',
+          confirmedTrainCode: survivor.trainCode,
+          confirmedMismatchStreak: 0,
+          updatedAt: tick.now,
+        },
+        events: [{ kind: 'consensus-confirm', trainCode: survivor.trainCode }],
+      };
+    }
+    return {
+      record: { ...record, candidates: nextCandidates, status: 'tracking', updatedAt: tick.now },
+      events: [],
+    };
+  }
+
+  // survivors.length >= 2 → ambiguous. 종점 임박 시에만 suppress로 해소.
+  if (
+    tick.hopsRemainingToTerminus !== undefined &&
+    tick.hopsRemainingToTerminus <= SUPPRESS_HOPS_TO_TERMINUS
+  ) {
+    return {
+      record: {
+        ...record,
+        candidates: nextCandidates,
+        status: 'suppressed',
+        suppressFloorEpochMs: latestDeparture(survivors),
+        updatedAt: tick.now,
+      },
+      events: [{ kind: 'consensus-suppress', meta: { reason: 'ambiguous-near-terminus' } }],
+    };
+  }
+
+  return {
+    record: { ...record, candidates: nextCandidates, status: 'ambiguous', updatedAt: tick.now },
+    events: [],
+  };
+}
+
+/**
+ * 상태기계 1 tick 진행. `demoted`/`suppressed`는 terminal — 이후 tick은 timestamp만 갱신하고
+ * 카운트/상태는 불변이다.
+ */
+export function stepLegConsensus(
+  record: LegConsensusRecord,
+  tick: LegConsensusTick,
+): LegConsensusStepResult {
+  if (record.status === 'demoted' || record.status === 'suppressed') {
+    return { record: { ...record, updatedAt: tick.now }, events: [] };
+  }
+
+  if (tick.outage) {
+    // §(4) fail mode 방어: outage=confidence hold(소멸 유예), mismatch 미집계.
+    return { record: { ...record, updatedAt: tick.now }, events: [] };
+  }
+
+  if (record.status === 'confirmed') {
+    return stepConfirmed(record, tick);
+  }
+
+  return stepTrackingOrAmbiguous(record, tick);
+}

--- a/backend/alarm-worker/src/tripEventLog.ts
+++ b/backend/alarm-worker/src/tripEventLog.ts
@@ -24,8 +24,22 @@
 
 import { captureXEvent } from './sentry';
 
-/** trip_events.kind 최소 집합. 데이터 주도 확장 시 이 유니온에 추가한다. */
-export type TripEventKind = 'sync-received' | 'advance' | 'hydrate-issued' | 'trip-end';
+/**
+ * trip_events.kind 최소 집합. 데이터 주도 확장 시 이 유니온에 추가한다.
+ *
+ * `consensus-confirm` / `consensus-demote` / `consensus-suppress` (#2327, consensus-A) —
+ * `transferLegConsensus.ts` 상태기계가 산출하는 `LegConsensusEvent`를 D1에 append할 때 쓰는
+ * kind. 실제 insert 호출(엔진 이벤트 → 본 kind로 write하는 wire)은 #2329(consensus-C) 범위 —
+ * 본 파일은 kind 유니온만 선반영한다.
+ */
+export type TripEventKind =
+  | 'sync-received'
+  | 'advance'
+  | 'hydrate-issued'
+  | 'trip-end'
+  | 'consensus-confirm'
+  | 'consensus-demote'
+  | 'consensus-suppress';
 
 export interface TripEventInput {
   /** trip token의 해시(hashTripToken 결과). 원본 token은 D1에 남기지 않는다. */

--- a/backend/alarm-worker/src/types.ts
+++ b/backend/alarm-worker/src/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ControlPushKind, StationWaypointKind } from '../../../src/shared/types/pushContract';
+import type { LegConsensusRecord } from './transferLegConsensus';
 
 export type LineNumber = string;
 
@@ -332,6 +333,16 @@ export interface Trip {
    * 자연스럽게 trip이 삭제되며 이 필드도 함께 사라진다.
    */
   destinationImminentFirstAt?: number;
+  /**
+   * #2327 (consensus-A) — 환승 leg 후보 열차 consensus 상태기계 스냅샷
+   * (`transferLegConsensus.ts:LegConsensusRecord`). 별도 KV row가 아닌 trip 객체 내부 필드로
+   * 저장한다(#2073 cron KV quota lesson — 새 row는 free plan quota를 소진한다).
+   *
+   * 본 필드는 순수 상태 저장소다. 실제 confirmed/demoted 상태를 fire/advance 판단에 연결하는
+   * wire(consensus-train evidence, confirmed-only alert, suppress→floor 공급)는 #2329
+   * (consensus-C) 범위 — 본 이슈(#2327)는 엔진+상태기계+본 필드까지만 제공한다.
+   */
+  legConsensus?: LegConsensusRecord;
 }
 
 /**


### PR DESCRIPTION
Closes #2327

## 요약
#2323 2026-08-13 설계안(consensus-A) 그대로 구현 — 환승 leg 후보 열차 consensus 엔진 + 상태기계.
순수 엔진 + KV 필드 타입 + D1 kind 유니온만. fire/advance wire는 #2329(consensus-C) 범위 — 본 PR에 포함하지 않음.

- `backend/alarm-worker/src/transferLegConsensus.ts` 신규
  - `computeCandidateWindow` — 후보 창 산출: 핵심 창 `[T0+W, T0+W+H]`, 허용 범위 `[T0+0.5W, T0+1.5W+H]` (0.5W 이전 출발=hard reject)
  - match(|Δ|≤90s)/mismatch(|Δ|>180s) 스코어러, `fetchedAt` age>30s 미집계(outage/stale hold), 3-tick 연속 미관측 시 mismatch 집계
  - 상태기계: `tracking → confirmed`(단일 생존 + match≥2) / `ambiguous`(생존 2+, 종점 2hop 전 미해소 시 `suppressed`) / `confirmed → demoted`(mismatch 2연속) / 전 후보 mismatch 시 자연 `suppressed`
  - suppress 시 최후 생존 후보 최늦 T_dep을 `suppressFloorEpochMs`로 반환 (#2155 floor 위임은 consensus-C 책임)
- `Trip.legConsensus?: LegConsensusRecord` 필드 추가(`types.ts`) — 별도 KV row 금지(#2073 quota lesson)
- `tripEventLog.ts` `TripEventKind`에 `consensus-confirm` / `consensus-demote` / `consensus-suppress` 추가(#2283 패턴). kind 유니온만 — 실제 D1 insert 호출은 consensus-C 범위.

## 범위 밖 (의도적)
- Seoul API 신규 호출 없음 — `pollStationsAndStamp`/`pollLinesAndStamp` 산출물 소비만 가정.
- `seoul.ts` 미변경 (#2328 병렬 작업 충돌 방지).
- fire/advance wire(`advanceTripPosition` 연결, confirmed-only alert, lockSuggestion forward) = #2329.

## 테스트
08-12 저녁 페이퍼 시뮬레이션 fixture(W=278s, H=210s, hop 80s×4) 기반 5종 acceptance:
1. 2 waypoint 정합 내 단일 confirm
2. 반대방향/앞차(0.5W 이전 출발) → confirm 0 (hard reject)
3. 동시 창 2후보 → ambiguous 유지 → 종점 2hop 전 suppress
4. outage → confidence hold, mismatch 미집계
5. confirmed 후 mismatch 2연속 → demote

+ neutral zone(90~180s)/3-tick skip mismatch/전 후보 mismatch 자연 suppress 방어 테스트.

## Wire 5단
1. **Orphan** — 루트 `tsconfig.json`이 `backend`를 exclude하여 `npm run lint:orphan`(ts-prune) 스코프 밖. `Trip.legConsensus` 필드 + `TripEventKind` 유니온 확장을 통해 신규 export(`transferLegConsensus.ts`)는 타입 레벨로 즉시 소비됨(orphan 아님).
2. **V/X dashboard** — 상태전이는 `LegConsensusRecord`가 trip KV 객체에 저장되므로 KV read(예: wrangler kv 조회) 또는 향후 DebugModal 노출로 관측 가능. D1 kind 3종(`consensus-confirm/demote/suppress`)은 consensus-C 머지 후 wrangler tail / Cloudflare Dashboard D1 쿼리로 관측.
3. **의존 PR** — 없음(엔진 단독). #2329(consensus-C)가 본 PR 머지 후 fire/advance에 연결.
4. **측정 plan** — consensus-C 착륙 후 검증 탑승 trip_events에서 consensus 상태전이(confirm/demote/suppress) 재구성해 confirmed 도달 시간(목표: 탑승 3~5분 내) 측정.
5. **Device verify** — N/A — type+unit only. 본 PR은 순수 함수 엔진 + 타입 추가만, fire/advance wire가 없어 device 동작 변화 없음. 실기기 검증은 consensus-C(#2329) 착륙 후.

## Test plan
- [x] `npx vitest run --coverage` (backend/alarm-worker) — 3005 passed, coverage ratchet(97%+/96%+/98%+/97%+) pass
- [x] `npx tsc --noEmit` (backend/alarm-worker) — clean
- [x] 프론트엔드 스위트 미실행(백엔드 전용 변경)