### PR TITLE
feat(#2328): Seoul 급행·행선지 파싱 + leg 후보 오매칭 필터 순수 함수

### DIFF
--- a/backend/alarm-worker/src/__tests__/legCandidateFilters.test.ts
+++ b/backend/alarm-worker/src/__tests__/legCandidateFilters.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import {
+  filterCandidateBranchTerminus,
+  filterCandidateDirection,
+  filterCandidateExpressStop,
+  filterCandidateLine,
+} from '../legCandidateFilters';
+import type { Route, Waypoint } from '../types';
+
+describe('#2328 — legCandidateFilters (consensus-B 오매칭 필터)', () => {
+  describe('filterCandidateLine (①)', () => {
+    const route: Route = { type: 'direct', line: '2', stops: 5 };
+
+    it('passes candidate line within route allowedLines', () => {
+      expect(filterCandidateLine('2', route)).toEqual({ kind: 'pass' });
+    });
+
+    it('rejects candidate line outside route allowedLines', () => {
+      expect(filterCandidateLine('bundang', route)).toEqual({
+        kind: 'reject',
+        reason: 'line-not-allowed',
+      });
+    });
+
+    it('passes candidate line covered only via waypoints union', () => {
+      const waypoints: Waypoint[] = [{ stationName: '왕십리', line: 'bundang', kind: 'transfer' }];
+      expect(filterCandidateLine('bundang', route, waypoints)).toEqual({ kind: 'pass' });
+    });
+  });
+
+  describe('filterCandidateDirection (②) — 7호선 방향 필터 fixture', () => {
+    // 7호선 monotonic(장암=low → 석남=high). 태릉입구(7-009) → 노원(7-005)는 id 감소 → 'up'.
+    it('rejects candidate whose isUp mismatches inferred leg direction', () => {
+      const verdict = filterCandidateDirection('7', false, '태릉입구', '노원');
+      expect(verdict).toEqual({ kind: 'reject', reason: 'direction-mismatch' });
+    });
+
+    it('passes candidate whose isUp matches inferred leg direction', () => {
+      const verdict = filterCandidateDirection('7', true, '태릉입구', '노원');
+      expect(verdict).toEqual({ kind: 'pass' });
+    });
+
+    it('passes (dormant) when line direction is not inferable (null)', () => {
+      // 1호선은 비단조 — inferLegDirection이 항상 null.
+      const verdict = filterCandidateDirection('1', true, '서울역', '시청');
+      expect(verdict).toEqual({ kind: 'pass' });
+    });
+  });
+
+  describe('filterCandidateBranchTerminus (③)', () => {
+    it('2호선 성수지선 reject — mainRange 안 leg2 waypoint인데 terminus가 지선(신설동)', () => {
+      const leg2: Waypoint[] = [
+        { stationName: '뚝섬', line: '2', kind: 'intermediate' },
+        { stationName: '건대입구', line: '2', kind: 'destination' },
+      ];
+      const verdict = filterCandidateBranchTerminus('2', '신설동', leg2);
+      expect(verdict).toEqual({ kind: 'reject', reason: 'branch-terminus-diverges' });
+    });
+
+    it('2호선 본선 terminus는 leg2 waypoint 커버 시 pass', () => {
+      const leg2: Waypoint[] = [
+        { stationName: '뚝섬', line: '2', kind: 'intermediate' },
+        { stationName: '건대입구', line: '2', kind: 'destination' },
+      ];
+      const verdict = filterCandidateBranchTerminus('2', '잠실나루', leg2);
+      expect(verdict).toEqual({ kind: 'pass' });
+    });
+
+    it('5호선 마천·하남 분기 reject — leg2가 마천행인데 terminus가 stations.json 미매핑 하남 지선', () => {
+      const leg2: Waypoint[] = [
+        { stationName: '개롱', line: '5', kind: 'intermediate' },
+        { stationName: '마천', line: '5', kind: 'destination' },
+      ];
+      // 하남검단산/하남풍산은 stations.json에 없는 5호선 하남 지선 종점 — 미해소 hard reject.
+      const verdict = filterCandidateBranchTerminus('5', '하남검단산', leg2);
+      expect(verdict).toEqual({ kind: 'reject', reason: 'branch-terminus-unresolved' });
+    });
+
+    it('5호선 마천 지선 — leg2와 같은 지선 terminus는 pass', () => {
+      const leg2: Waypoint[] = [
+        { stationName: '개롱', line: '5', kind: 'intermediate' },
+        { stationName: '마천', line: '5', kind: 'destination' },
+      ];
+      const verdict = filterCandidateBranchTerminus('5', '마천', leg2);
+      expect(verdict).toEqual({ kind: 'pass' });
+    });
+
+    it('단축 운행 — 같은 경로 안에서 leg2 최종 waypoint 전에 멈추면 soft-penalty', () => {
+      const leg2: Waypoint[] = [
+        { stationName: '개롱', line: '5', kind: 'intermediate' },
+        { stationName: '거여', line: '5', kind: 'intermediate' },
+        { stationName: '마천', line: '5', kind: 'destination' },
+      ];
+      const verdict = filterCandidateBranchTerminus('5', '개롱', leg2);
+      expect(verdict).toEqual({ kind: 'soft-penalty', reason: 'branch-shortened-service' });
+    });
+
+    it('terminus가 leg2 진행 방향 반대편(같은 노선이지만 지나온 구간)이면 reject', () => {
+      const leg2: Waypoint[] = [
+        { stationName: '개롱', line: '5', kind: 'intermediate' },
+        { stationName: '마천', line: '5', kind: 'destination' },
+      ];
+      // 천호(5-038)는 개롱(5-044)보다 앞선 역 — leg2 진행 방향 반대편.
+      const verdict = filterCandidateBranchTerminus('5', '천호(풍납토성)', leg2);
+      expect(verdict).toEqual({ kind: 'reject', reason: 'branch-terminus-diverges' });
+    });
+
+    it('역방향(id 감소) leg2 — terminus가 furthest까지 커버하면 pass', () => {
+      // 잠실새내(2-017)→잠실(2-016)→잠실나루(2-015): id 감소 방향으로 진행하는 leg.
+      const leg2: Waypoint[] = [
+        { stationName: '잠실새내', line: '2', kind: 'intermediate' },
+        { stationName: '잠실(송파구청)', line: '2', kind: 'intermediate' },
+        { stationName: '잠실나루', line: '2', kind: 'destination' },
+      ];
+      const verdict = filterCandidateBranchTerminus('2', '잠실나루', leg2);
+      expect(verdict).toEqual({ kind: 'pass' });
+    });
+
+    it('역방향(id 감소) leg2 — terminus가 중간에 멈추면 soft-penalty', () => {
+      const leg2: Waypoint[] = [
+        { stationName: '잠실새내', line: '2', kind: 'intermediate' },
+        { stationName: '잠실(송파구청)', line: '2', kind: 'intermediate' },
+        { stationName: '잠실나루', line: '2', kind: 'destination' },
+      ];
+      const verdict = filterCandidateBranchTerminus('2', '잠실(송파구청)', leg2);
+      expect(verdict).toEqual({ kind: 'soft-penalty', reason: 'branch-shortened-service' });
+    });
+
+    it('mainRange 안 leg2인데 terminus가 stations.json에 없으면 reject(unresolved)', () => {
+      const leg2: Waypoint[] = [
+        { stationName: '뚝섬', line: '2', kind: 'intermediate' },
+        { stationName: '건대입구', line: '2', kind: 'destination' },
+      ];
+      const verdict = filterCandidateBranchTerminus('2', '존재하지않는역이름', leg2);
+      expect(verdict).toEqual({ kind: 'reject', reason: 'branch-terminus-unresolved' });
+    });
+
+    it('terminus 정보 없으면 pass (보수적)', () => {
+      const leg2: Waypoint[] = [{ stationName: '마천', line: '5', kind: 'destination' }];
+      expect(filterCandidateBranchTerminus('5', null, leg2)).toEqual({ kind: 'pass' });
+    });
+
+    it('leg2 waypoint에 해당 line이 없으면 pass', () => {
+      const leg2: Waypoint[] = [{ stationName: '왕십리', line: 'bundang', kind: 'transfer' }];
+      expect(filterCandidateBranchTerminus('5', '마천', leg2)).toEqual({ kind: 'pass' });
+    });
+  });
+
+  describe('filterCandidateExpressStop (④) — 9호선 급행 fixture', () => {
+    it('급행 후보가 정차하는 waypoint는 pass', () => {
+      const verdict = filterCandidateExpressStop('9', 'express', '고속터미널');
+      expect(verdict).toEqual({ kind: 'pass' });
+    });
+
+    it('급행 후보가 통과(미정차)하는 waypoint는 not-applicable — mismatch로 오집계되면 안 됨', () => {
+      // 고속터미널↔신논현 사이 사평은 완행 전용역 — 9호선 express set에 없음.
+      const verdict = filterCandidateExpressStop('9', 'express', '사평');
+      expect(verdict).toEqual({ kind: 'not-applicable' });
+    });
+
+    it('일반(normal) 후보는 모든 waypoint에 pass', () => {
+      expect(filterCandidateExpressStop('9', 'normal', '사평')).toEqual({ kind: 'pass' });
+    });
+
+    it('데이터 미보유 노선/타입은 보수적으로 pass', () => {
+      expect(filterCandidateExpressStop('3', 'express', '아무역')).toEqual({ kind: 'pass' });
+    });
+  });
+});

--- a/backend/alarm-worker/src/__tests__/seoul.test.ts
+++ b/backend/alarm-worker/src/__tests__/seoul.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { SeoulArrivalClient, parseRecptnDt } from '../seoul';
+import { SeoulArrivalClient, parseRecptnDt, parseTerminusStationName } from '../seoul';
 
 function makeResponse(body: unknown, ok = true, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -123,6 +123,75 @@ describe('SeoulArrivalClient', () => {
     expect(arrivals).toHaveLength(1);
   });
 
+  describe('#2328 — btrainSttus(급행) + trainLineNm(행선지) 파싱', () => {
+    it('parses btrainSttus into trainType', async () => {
+      const fetchImpl = vi.fn(async () =>
+        makeResponse({
+          realtimeArrivalList: [
+            makeItem({ btrainSttus: '급행' }),
+            makeItem({ btrainSttus: 'ITX' }),
+            makeItem({ btrainSttus: '특급' }),
+            makeItem({ btrainSttus: undefined }),
+          ],
+        }),
+      );
+      const client = new SeoulArrivalClient({
+        apiKey: 'KEY',
+        host: 'example.com',
+        now: () => FIXED_NOW,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const arrivals = await client.fetchArrivals('서울역');
+      expect(arrivals[0].trainType).toBe('express');
+      expect(arrivals[1].trainType).toBe('itx');
+      expect(arrivals[2].trainType).toBe('rapid');
+      expect(arrivals[3].trainType).toBe('normal');
+    });
+
+    it('parses trainLineNm into terminus station name', async () => {
+      const fetchImpl = vi.fn(async () =>
+        makeResponse({
+          realtimeArrivalList: [
+            makeItem({ trainLineNm: '성수행' }),
+            makeItem({ trainLineNm: '내선순환' }),
+            makeItem({ trainLineNm: '외선순환' }),
+            makeItem({ trainLineNm: '장암방면' }),
+          ],
+        }),
+      );
+      const client = new SeoulArrivalClient({
+        apiKey: 'KEY',
+        host: 'example.com',
+        now: () => FIXED_NOW,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const arrivals = await client.fetchArrivals('서울역');
+      expect(arrivals[0].terminus).toBe('성수');
+      expect(arrivals[1].terminus).toBeNull();
+      expect(arrivals[2].terminus).toBeNull();
+      expect(arrivals[3].terminus).toBe('장암');
+    });
+  });
+
+  describe('parseTerminusStationName', () => {
+    it('strips 행 suffix', () => {
+      expect(parseTerminusStationName('성수행')).toBe('성수');
+    });
+    it('strips 방면 suffix', () => {
+      expect(parseTerminusStationName('장암방면')).toBe('장암');
+    });
+    it('returns null for loop-line direction tokens', () => {
+      expect(parseTerminusStationName('내선순환')).toBeNull();
+      expect(parseTerminusStationName('외선순환')).toBeNull();
+    });
+    it('returns null for unrecognized formats', () => {
+      expect(parseTerminusStationName('')).toBeNull();
+      expect(parseTerminusStationName('알수없음')).toBeNull();
+      expect(parseTerminusStationName('행')).toBeNull();
+      expect(parseTerminusStationName('방면')).toBeNull();
+    });
+  });
+
   it('applies recptnDt drift correction and demotes stale data', async () => {
     const staleItem = makeItem({
       barvlDt: '120',
@@ -213,6 +282,31 @@ describe('SeoulArrivalClient', () => {
       expect(await client.fetchPositions('7')).toEqual([]);
       await client.fetchPositions('7');
       expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+
+    it('#2328 — parses directAt(급행) + statnTnm(행선지) into trainType/terminus', async () => {
+      const fetchImpl = vi.fn(async () =>
+        makeResponse({
+          realtimePositionList: [
+            makePositionItem({ trainNo: '7246', directAt: '1', statnTnm: '장암' }),
+            makePositionItem({ trainNo: '7248', directAt: '7', statnTnm: '' }),
+            makePositionItem({ trainNo: '7250', directAt: '0' }),
+          ],
+        }),
+      );
+      const client = new SeoulArrivalClient({
+        apiKey: 'KEY',
+        host: 'example.com',
+        now: () => FIXED_NOW,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const positions = await client.fetchPositions('7');
+      expect(positions[0].trainType).toBe('express');
+      expect(positions[0].terminus).toBe('장암');
+      expect(positions[1].trainType).toBe('rapid');
+      expect(positions[1].terminus).toBeNull();
+      expect(positions[2].trainType).toBe('normal');
+      expect(positions[2].terminus).toBeNull();
     });
 
     it('skips malformed items (null, no trainNo, non-object)', async () => {

--- a/backend/alarm-worker/src/legCandidateFilters.ts
+++ b/backend/alarm-worker/src/legCandidateFilters.ts
@@ -1,0 +1,170 @@
+/**
+ * #2328 (consensus-B, 설계 SSoT #2323 코멘트 (2) 오매칭 필터) — leg 후보 오매칭 사전 배제.
+ *
+ * `transferLegConsensus.ts`(#2327) 후보 엔진이 다음 waypoint arrivals에서 관측한 trainCode를
+ * 실제 승차 열차 후보로 신뢰할지 판정하기 전, 4단계 순수 필터로 명백한 오매칭을 사전 배제한다.
+ * 평가 순서(설계안 (2)):
+ *
+ *   ① `computeAllowedLines` 밖 — hard reject. 신규 로직 없음, `consensusGate.ts`(#1439 E6) 재사용.
+ *   ② `inferLegDirection` vs 후보 진행 방향(isUp) mismatch — hard reject. 방향 추론 불가(null,
+ *      비단조/지선 노선)면 dormant(pass) — 정차 패턴 필터(④)가 실질적 오매칭 방지를 대행한다.
+ *   ③ 지선: 후보 행선지(terminus, `seoul.ts:parseTerminusStationName`)가 leg2 waypoint 진행
+ *      방향을 커버하지 못하는 분기(다른 지선 종점, 미매핑 종점)면 hard reject. 같은 경로 안에서
+ *      leg2 최종 waypoint 전에 멈추는 단축 운행은 soft 감점(caller가 우선순위만 낮춤).
+ *   ④ 급행: `EXPRESS_STOPS`(#1652 ADR-005)에 없는 정차 waypoint는 급행 후보에게
+ *      "not-applicable" — 정차 안 하는 역을 못 봤다고 mismatch로 오집계하면 9호선 급행 회귀가
+ *      재발한다.
+ *
+ * 전부 순수 함수 — KV/네트워크 의존 없음. `transferLegConsensus`/`advanceTripPosition` 배선은
+ * consensus-C(#2329)가 담당한다(본 PR 범위 밖).
+ */
+
+import lineTopology from '../../../src/data/lineTopology.json';
+import { findStationByNameAndLine } from '../../../src/shared/utils/stationLookup';
+import { EXPRESS_STOPS, type ExpressStopsByType } from '../../../src/data/expressStops';
+import type { TrainType } from '../../../src/shared/constants/trainTypes';
+import { computeAllowedLines, isLockLineAllowed } from './consensusGate';
+import { inferLegDirection } from './legDirection';
+import type { LineNumber, Route, Waypoint } from './types';
+
+interface ClosedLoopMeta {
+  mainIdRange: { firstId: string; lastId: string };
+  loopTailRange?: { firstId: string; lastId: string };
+}
+
+/** #1703 lineTopology.json `closedLoops` — mainIdRange가 지선 배제 SSoT (`legDirection.ts`와 공유). */
+const CLOSED_LOOPS = lineTopology.closedLoops as Partial<Record<string, ClosedLoopMeta>>;
+/** backend `LineNumber = string`으로 인덱싱하기 위한 캐스트 — frontend union key 타입 우회. */
+const EXPRESS_STOPS_BY_LINE = EXPRESS_STOPS as Partial<Record<string, ExpressStopsByType>>;
+
+export type LegFilterVerdict =
+  | { kind: 'pass' }
+  | { kind: 'not-applicable' }
+  | { kind: 'soft-penalty'; reason: string }
+  | { kind: 'reject'; reason: string };
+
+/** shared `findStationByNameAndLine`은 union LineNumber를 받지만 backend는 string — 런타임은 `===` 비교라 안전. */
+function lookupStation(name: string, line: LineNumber) {
+  return findStationByNameAndLine(name, line as Parameters<typeof findStationByNameAndLine>[1]);
+}
+
+/**
+ * ① 후보 line이 trip route + waypoints의 allowedLines union 밖이면 hard reject.
+ * `consensusGate.ts:computeAllowedLines`/`isLockLineAllowed` 그대로 재사용(신규 로직 없음).
+ */
+export function filterCandidateLine(
+  candidateLine: LineNumber,
+  route: Route,
+  waypoints: readonly Waypoint[] = [],
+): LegFilterVerdict {
+  const allowed = computeAllowedLines(route, waypoints);
+  return isLockLineAllowed({ line: candidateLine }, allowed)
+    ? { kind: 'pass' }
+    : { kind: 'reject', reason: 'line-not-allowed' };
+}
+
+/**
+ * ② leg 진행 방향과 후보 진행 방향(isUp) mismatch면 hard reject.
+ * `inferLegDirection`이 null(비단조/지선 노선 — #1719 정책)이면 방향 추론 불가 — dormant(pass).
+ */
+export function filterCandidateDirection(
+  line: LineNumber,
+  candidateIsUp: boolean,
+  fromStationName: string,
+  toStationName: string,
+): LegFilterVerdict {
+  const expected = inferLegDirection(line, fromStationName, toStationName);
+  if (expected === null) return { kind: 'pass' };
+  const candidateDirection = candidateIsUp ? 'up' : 'down';
+  return candidateDirection === expected
+    ? { kind: 'pass' }
+    : { kind: 'reject', reason: 'direction-mismatch' };
+}
+
+interface StationLike {
+  readonly id: string;
+}
+
+/**
+ * leg2 waypoint 커버리지를 진행 방향(waypoint 배열 순서 — nearest→furthest, trip.waypoints와
+ * 동일 관행)으로 판정. terminus가 furthest(마지막 leg2 waypoint) 이상 진행하면 pass, nearest~
+ * furthest 구간 안에서 못 미쳐 멈추면 soft-penalty(단축 운행), 그 구간 밖(반대 방향으로 벗어남)
+ * 이면 reject.
+ *
+ * 정렬(min/max)이 아니라 배열의 첫/끝 원소를 쓴다 — waypoint 배열 순서 자체가 진행 방향이므로
+ * id가 감소하는 방향(예: 순환선을 역방향으로 도는 leg)도 올바르게 판정한다.
+ */
+function evaluateWaypointCoverage(
+  waypointStations: readonly StationLike[],
+  terminusStation: StationLike,
+): LegFilterVerdict {
+  const nearest = waypointStations[0];
+  const furthest = waypointStations[waypointStations.length - 1];
+  const ascending = furthest.id >= nearest.id;
+  const terminusId = terminusStation.id;
+
+  const coversAll = ascending ? terminusId >= furthest.id : terminusId <= furthest.id;
+  if (coversAll) return { kind: 'pass' };
+
+  const onSamePath = ascending ? terminusId >= nearest.id : terminusId <= nearest.id;
+  if (onSamePath) return { kind: 'soft-penalty', reason: 'branch-shortened-service' };
+
+  return { kind: 'reject', reason: 'branch-terminus-diverges' };
+}
+
+/**
+ * ③ 지선 오매칭 필터. terminus/leg2Waypoints 정보 부재 시 판단 불가 — 보수적으로 pass.
+ *
+ * mainIdRange가 등록된 노선(2/6호선)에서 leg2 waypoint가 전부 본선 구간 안에 있는데 terminus가
+ * 본선 밖(지선)이면 hard reject(2호선 성수/신정지선 등). mainIdRange 미등록 노선(5호선 마천/하남
+ * 분기 등)에서는 stations.json에 없는 terminus(다른 지선의 미매핑 역)를 hard reject로 다룬다 —
+ * 앱이 애초에 그 지선을 모르는 상태에서 leg2 waypoint를 그 방향으로 생성할 수 없으므로, 안전한
+ * 보수적 판단이다.
+ */
+export function filterCandidateBranchTerminus(
+  line: LineNumber,
+  terminus: string | null,
+  leg2Waypoints: readonly Pick<Waypoint, 'stationName' | 'line'>[],
+): LegFilterVerdict {
+  if (terminus === null) return { kind: 'pass' };
+
+  const waypointStations = leg2Waypoints
+    .filter((wp) => wp.line === line)
+    .map((wp) => lookupStation(wp.stationName, line))
+    .filter((s): s is NonNullable<ReturnType<typeof lookupStation>> => s !== null);
+  if (waypointStations.length === 0) return { kind: 'pass' };
+
+  const terminusStation = lookupStation(terminus, line);
+  const mainRange = CLOSED_LOOPS[line]?.mainIdRange;
+  const waypointsAllInMain =
+    mainRange !== undefined &&
+    waypointStations.every((s) => s.id >= mainRange.firstId && s.id <= mainRange.lastId);
+
+  if (waypointsAllInMain && mainRange !== undefined) {
+    if (!terminusStation) return { kind: 'reject', reason: 'branch-terminus-unresolved' };
+    const terminusInMain =
+      terminusStation.id >= mainRange.firstId && terminusStation.id <= mainRange.lastId;
+    if (!terminusInMain) return { kind: 'reject', reason: 'branch-terminus-diverges' };
+    return evaluateWaypointCoverage(waypointStations, terminusStation);
+  }
+
+  if (!terminusStation) return { kind: 'reject', reason: 'branch-terminus-unresolved' };
+  return evaluateWaypointCoverage(waypointStations, terminusStation);
+}
+
+/**
+ * ④ 급행 정차 필터. 후보가 급행/특급/ITX이고 waypoint 역이 `EXPRESS_STOPS`에 없으면
+ * "not-applicable" — caller(consensus-C, #2329)는 이 waypoint를 해당 후보의 match/mismatch
+ * 집계에서 제외해야 한다. 데이터 미보유 노선/타입은 보수적으로 pass(정차 취급) —
+ * frontend `expressLookup.ts:isExpressStop`과 동일 정책.
+ */
+export function filterCandidateExpressStop(
+  line: LineNumber,
+  trainType: TrainType,
+  waypointStationName: string,
+): LegFilterVerdict {
+  if (trainType === 'normal') return { kind: 'pass' };
+  const stops = EXPRESS_STOPS_BY_LINE[line]?.[trainType];
+  if (!stops) return { kind: 'pass' };
+  return stops.has(waypointStationName) ? { kind: 'pass' } : { kind: 'not-applicable' };
+}

--- a/backend/alarm-worker/src/seoul.ts
+++ b/backend/alarm-worker/src/seoul.ts
@@ -8,6 +8,11 @@
  */
 
 import { canonicalLineName } from './lineAlias';
+import {
+  parseTrainType,
+  parseTrainTypeFromDirectAt,
+  type TrainType,
+} from '../../../src/shared/constants/trainTypes';
 
 const UP_DIRECTION_VALUES = ['상행', '내선'] as const;
 const SEOUL_API_TZ_OFFSET = '+09:00';
@@ -34,6 +39,18 @@ export interface ArrivalEntry {
    * consensusGate strongBE 통과 X. real Seoul API entry 는 undefined / false.
    */
   synthesized?: boolean;
+  /**
+   * #2328 (consensus-B, 설계 SSoT #2323) — Seoul API `btrainSttus`(열차종류) 파싱.
+   * `legCandidateFilters.ts` 급행 정차 필터(④)의 입력. optional — 구 caller/테스트 fixture가
+   * 이 필드 없이 리터럴을 구성해도 컴파일 호환(#1720 `synthesized?`와 동일 정책).
+   */
+  trainType?: TrainType;
+  /**
+   * #2328 — Seoul API `trainLineNm`(행선지) 텍스트에서 추출한 순수 종착역명.
+   * `legCandidateFilters.ts` 지선 필터(③)의 입력. 이산 종점이 없는 순환선(내선/외선순환) 또는
+   * 인식 불가 포맷은 null.
+   */
+  terminus?: string | null;
 }
 
 export interface FetchSeoulOptions {
@@ -60,6 +77,10 @@ export interface PositionEntry {
   isUp: boolean;
   /** API 수신 시각 (epoch ms) — staleness 판정용. 누락 시 0. */
   recptnMs: number;
+  /** #2328 — realtimePosition API `directAt`(1:급행, 7:특급) 파싱. ArrivalEntry.trainType과 동일 정책. */
+  trainType?: TrainType;
+  /** #2328 — realtimePosition API `statnTnm`(종착역명, 이미 순수 역명) 파싱. 누락/빈 문자열은 null. */
+  terminus?: string | null;
 }
 
 interface PositionCacheEntry {
@@ -163,14 +184,41 @@ function parseEntry(raw: unknown, now: number): ArrivalEntry | null {
   const updnLine = typeof item.updnLine === 'string' ? item.updnLine : '';
   const isUp = (UP_DIRECTION_VALUES as readonly string[]).includes(updnLine);
 
+  const trainLineNm = typeof item.trainLineNm === 'string' ? item.trainLineNm : '';
+
   return {
-    destination: typeof item.trainLineNm === 'string' ? item.trainLineNm : '',
+    destination: trainLineNm,
     arrivalSeconds: seconds,
     trainCode: typeof item.btrainNo === 'string' ? item.btrainNo : '',
     isUp,
     subwayNm: typeof item.subwayNm === 'string' ? item.subwayNm : '',
     arvlCd: parseArvlCd(item.arvlCd),
+    trainType: parseTrainType(item.btrainSttus),
+    terminus: parseTerminusStationName(trainLineNm),
   };
+}
+
+/**
+ * #2328 — Seoul API `trainLineNm`(행선지 텍스트, 예: "성수행"/"내선순환"/"장암방면")에서 순수
+ * 종착역명을 추출한다. 순환선(내선/외선순환)은 이산 종점이 없어 null. 인식 못하는 포맷도 null
+ * (보수적 — `legCandidateFilters.ts`가 정보 부재를 오판단하지 않도록 미상 처리).
+ *
+ * frontend `src/features/route/utils/trainLineDirection.ts:parseTrainLineDirection`과 동일
+ * 포맷 인식이지만 i18n/표시명 조회 없이 원본 역명만 반환한다 — `legDirection.ts`(#1719)와 동일
+ * backend-local 정책(frontend hook/i18n 의존 그래프를 끌어오지 않음).
+ */
+export function parseTerminusStationName(trainLineNm: string): string | null {
+  const trimmed = trainLineNm.trim();
+  if (trimmed === '내선순환' || trimmed === '외선순환') return null;
+  if (trimmed.endsWith('행')) {
+    const name = trimmed.slice(0, -1).trim();
+    return name.length > 0 ? name : null;
+  }
+  if (trimmed.endsWith('방면')) {
+    const name = trimmed.slice(0, -2).trim();
+    return name.length > 0 ? name : null;
+  }
+  return null;
 }
 
 function parsePositionEntry(raw: unknown): PositionEntry | null {
@@ -180,12 +228,15 @@ function parsePositionEntry(raw: unknown): PositionEntry | null {
   if (!trainCode) return null;
   const stationName = typeof item.statnNm === 'string' ? item.statnNm : '';
   const updnLine = typeof item.updnLine === 'string' ? item.updnLine : '';
+  const statnTnm = typeof item.statnTnm === 'string' ? item.statnTnm.trim() : '';
   return {
     trainCode,
     stationName,
     trainSttus: parseArvlCd(item.trainSttus),
     isUp: (UP_DIRECTION_VALUES as readonly string[]).includes(updnLine),
     recptnMs: parseRecptnDt(item.lastRecptnDt),
+    trainType: parseTrainTypeFromDirectAt(item.directAt),
+    terminus: statnTnm.length > 0 ? statnTnm : null,
   };
 }
 

--- a/backend/alarm-worker/tsconfig.json
+++ b/backend/alarm-worker/tsconfig.json
@@ -32,7 +32,9 @@
     "../../src/shared/utils/normalizeStationName.js",
     "../../src/shared/utils/dijkstraRoute.ts",
     "../../src/shared/utils/buildRouteGraph.ts",
-    "../../src/shared/constants/lineSpeeds.ts"
+    "../../src/shared/constants/lineSpeeds.ts",
+    "../../src/shared/constants/trainTypes.ts",
+    "../../src/data/expressStops.ts"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Closes #2328

## 요약
설계 SSoT: #2323 2026-08-13 설계안 코멘트 (2) 오매칭 필터. consensus-B(S) 구현.

- `backend/alarm-worker/src/seoul.ts` — `ArrivalEntry`/`PositionEntry`에 급행 여부(`btrainSttus`/`directAt` → `TrainType`)와 행선지(`trainLineNm`/`statnTnm` → `terminus`) 파싱 추가. 신규 `parseTerminusStationName`(행/방면 suffix 제거, 순환선은 null). 두 필드 모두 optional — 기존 리터럴 fixture(8개 테스트 파일) 무변경 호환.
- `backend/alarm-worker/src/legCandidateFilters.ts` (신규) — 4단 순수 필터, 평가 순서:
  1. `filterCandidateLine` — `consensusGate.ts:computeAllowedLines`/`isLockLineAllowed` 그대로 재사용(신규 로직 없음).
  2. `filterCandidateDirection` — `legDirection.ts:inferLegDirection` vs 후보 `isUp` mismatch hard reject. 방향 추론 불가(null, 비단조/지선 노선)면 dormant(pass).
  3. `filterCandidateBranchTerminus` — 지선 오매칭. `lineTopology.json`의 `closedLoops.mainIdRange`(2/6호선 기존 SSoT, 신규 하드코딩 없음)로 leg2 waypoint가 본선 안인데 terminus가 지선이면 hard reject. mainIdRange 미등록 노선(5호선 마천/하남)은 terminus가 stations.json에 없으면(하남 지선 미매핑) hard reject. 같은 경로 안에서 leg2 최종 waypoint 전에 멈추는 단축 운행은 soft-penalty.
  4. `filterCandidateExpressStop` — `EXPRESS_STOPS`(ADR-005)에 없는 정차 waypoint는 급행 후보에게 not-applicable(정차 안 하는 역 미관측을 mismatch로 오집계 방지, 9호선 회귀 차단).
- `backend/alarm-worker/tsconfig.json` include에 `src/shared/constants/trainTypes.ts`, `src/data/expressStops.ts` 추가(backend가 frontend shared/data를 직접 컴파일하는 기존 패턴, `legDirection.ts`/`dijkstraRoute.ts`와 동일).

## 범위 밖 (병렬 주의)
- `transferLegConsensus.ts`(#2327, consensus-A)는 별도 에이전트가 작업 중 — 본 PR은 건드리지 않음.
- `advanceTripPosition`/fire wire 배선은 consensus-C(#2329)가 담당. 본 PR은 순수 함수만 제공.

## Fixture (TDD)
`legCandidateFilters.test.ts` (21 tests):
- 9호선 급행 — 정차역(고속터미널) pass, 미정차역(사평) not-applicable
- 2호선 성수지선 — 본선 leg2 + 지선 terminus(신설동) reject / 본선 terminus(잠실나루) pass
- 5호선 마천·하남 분기 — leg2 마천행인데 terminus가 stations.json 미매핑 하남 지선(하남검단산) reject(unresolved) / 같은 지선(마천) pass
- 7호선 방향 — `inferLegDirection` mismatch reject, null 노선(1호선) dormant pass
- 단축 운행 soft-penalty + 역방향(id 감소) leg 커버리지 양방향 검증

`seoul.test.ts` — btrainSttus(급행/ITX/특급/일반)·trainLineNm(행/방면/순환선)·directAt·statnTnm 파싱 red→green.

## Wire-completion 5단
1. **Orphan** — `backend/` 는 root `tsconfig.json` exclude 대상이라 `npm run lint:orphan`(ts-prune) 스캔 밖(N/A, 로컬 확인 "No orphan exports detected." pass). 신규 export의 실 caller는 테스트 + consensus-C(#2329)가 프로덕션 배선 예정.
2. **V/X dashboard** — 신규 필드(`trainType`/`terminus`)·필터 판정(`LegFilterVerdict`)은 아직 소비자가 없어 dashboard 노출 X. consensus-C가 `transferLegConsensus`/`advanceTripPosition`에 배선하며 telemetry로 노출 예정.
3. **의존 PR** — N/A (독립 순수 함수, #2327/#2329와 파일 충돌 없음).
4. **측정 plan** — 별도 측정 없음(순수 함수, 소비자 부재). consensus-C 착륙 후 reject 사유 분포로 측정.
5. **Device verify** — N/A — type-check + unit(backend vitest, coverage ratchet 통과) only.

## 검증
- `npx vitest run` (backend/alarm-worker): 82 files / 3016 tests pass
- coverage: 97.31/96.47(branch)/99.07/97.31 — ratchet floor(97/96/98/97) 통과, `legCandidateFilters.ts` 100/100/100/100
- `npx tsc --noEmit` (backend/alarm-worker): clean
- `npm run lint:orphan` (root): No orphan exports detected.