### PR TITLE
fix(#2322): 침묵/outage trip 생존 — auto-end 가드 보강 (O1-C)

### DIFF
--- a/backend/alarm-worker/src/__tests__/replay_20260807_storm.test.ts
+++ b/backend/alarm-worker/src/__tests__/replay_20260807_storm.test.ts
@@ -119,7 +119,7 @@ function makeTrip(overrides: Partial<Trip> = {}): Trip {
 function makeFullEmptyStats(): ScheduledStats {
   return {
     scanned: 0, polled: 0, pushed: 0, errors: 0, etaMissing: 0, envCorrected: 0,
-    lockMissing: 0, laStaleAutoEnded: 0, killSwitchLocklessIntermediateSkipped: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
+    lockMissing: 0, laStaleAutoEnded: 0, laStaleSurvivedSilence: 0, killSwitchLocklessIntermediateSkipped: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
     laPushSent: 0, laPushFailed: 0, laTokenCleared: 0,
     boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
     phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
@@ -132,7 +132,7 @@ function makeFullEmptyStats(): ScheduledStats {
     boardingLockWaypointAdvanceBlocked: 0, transferDestinationGateBlocked: 0,
     vanishFallbackFired: 0, vanishReleaseFired: 0, vanishLocklessTakeover: 0,
     vanishFallbackMotionGateBlocked: 0,
-    cronJitterMs: 0, rescheduleBlockedMotion: 0, rescheduleFallbackNoSsot: 0, rescheduleDedupSkipped: 0, destinationBackstopForceEnded: 0,
+    cronJitterMs: 0, rescheduleBlockedMotion: 0, rescheduleFallbackNoSsot: 0, rescheduleDedupSkipped: 0, destinationBackstopForceEnded: 0, destinationStaleGpsSurvivedSilence: 0,
     realtimePositionFetch: 0, selfPollCacheHit: 0, realtimePositionFetchError: 0,
     stationPollFetch: 0, stationPollCacheHit: 0, stationPollError: 0,
     staleLockFireSkipped: 0,

--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -147,7 +147,7 @@ function makeEstimateArrivalDeps(seoul: SeoulArrivalClient): ScheduledDeps {
 function makeFullEmptyStats(): ScheduledStats {
   return {
     scanned: 0, polled: 0, pushed: 0, errors: 0, etaMissing: 0, envCorrected: 0,
-    lockMissing: 0, laStaleAutoEnded: 0, killSwitchLocklessIntermediateSkipped: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
+    lockMissing: 0, laStaleAutoEnded: 0, laStaleSurvivedSilence: 0, killSwitchLocklessIntermediateSkipped: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
     laPushSent: 0, laPushFailed: 0, laTokenCleared: 0,
     boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
     phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
@@ -160,7 +160,7 @@ function makeFullEmptyStats(): ScheduledStats {
     boardingLockWaypointAdvanceBlocked: 0, transferDestinationGateBlocked: 0,
     vanishFallbackFired: 0, vanishReleaseFired: 0, vanishLocklessTakeover: 0,
     vanishFallbackMotionGateBlocked: 0,
-    cronJitterMs: 0, rescheduleBlockedMotion: 0, rescheduleFallbackNoSsot: 0, rescheduleDedupSkipped: 0, destinationBackstopForceEnded: 0,
+    cronJitterMs: 0, rescheduleBlockedMotion: 0, rescheduleFallbackNoSsot: 0, rescheduleDedupSkipped: 0, destinationBackstopForceEnded: 0, destinationStaleGpsSurvivedSilence: 0,
     realtimePositionFetch: 0, selfPollCacheHit: 0, realtimePositionFetchError: 0,
     stationPollFetch: 0, stationPollCacheHit: 0, stationPollError: 0,
     staleLockFireSkipped: 0,
@@ -6494,6 +6494,115 @@ describe('runScheduled — #1933 LA stale auto-end backstop', () => {
     expect(remaining).toHaveLength(0);
   });
 
+  // #2322 (O1-C) — 침묵(device sync stale) 중 la-stale backstop이 trip을 죽이지 않아야 한다.
+  // #2306 evidence(25분 suspend 4역+목적지 알림 0건)의 backend 측 안전망 회귀 차단.
+  it('device sync stale(25min silence) → la-stale backstop skip, laStaleSurvivedSilence++, trip 생존', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({
+      token: 'la-stale-silent',
+      createdAt: NOW - 30 * 60_000,
+      expiresAt: NOW + 60 * 60_000,
+      alarmAtEpochMs: NOW + 60_000,
+      lastLaPushAt: NOW - 6 * 60_000,
+    });
+    await putTrip(kv as unknown as KVNamespace, trip);
+    // device가 25분간 sync 없음 — DEVICE_SYNC_STALE_THRESHOLD_MS(5분) 초과.
+    const ssot = await seedSsot(kv as unknown as KVNamespace, trip.token, '강남', {
+      expiresAt: trip.expiresAt,
+    });
+    ssot.lastDeviceSyncAt = NOW - 25 * 60_000;
+    await writeSsot(kv as unknown as KVNamespace, ssot, { expiresAt: trip.expiresAt });
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+
+    expect(stats.laStaleAutoEnded).toBe(0);
+    expect(stats.laStaleSurvivedSilence).toBe(1);
+    const remaining: Trip[] = [];
+    for await (const t of (await import('../trips')).listTrips(kv as unknown as KVNamespace)) {
+      remaining.push(t);
+    }
+    expect(remaining).toHaveLength(1);
+  });
+
+  // #2322 (O1-C) — Seoul API outage(이 cron 사이클 HTTP error) 중에도 la-stale backstop이
+  // trip을 죽이지 않아야 한다. push 침묵이 backend가 아닌 Seoul API 장애의 정상 결과이기 때문.
+  it('Seoul API outage(HTTP error 관측) → la-stale backstop skip, laStaleSurvivedSilence++, trip 생존', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({
+      token: 'la-stale-outage',
+      createdAt: NOW - 30 * 60_000,
+      expiresAt: NOW + 60 * 60_000,
+      alarmAtEpochMs: NOW + 60_000,
+      lastLaPushAt: NOW - 6 * 60_000,
+    });
+    await putTrip(kv as unknown as KVNamespace, trip);
+
+    const erroredFetch = vi.fn(
+      async () => new Response('boom', { status: 500 }),
+    ) as unknown as typeof fetch;
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: erroredFetch,
+    });
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+
+    expect(stats.laStaleAutoEnded).toBe(0);
+    expect(stats.laStaleSurvivedSilence).toBe(1);
+    const remaining: Trip[] = [];
+    for await (const t of (await import('../trips')).listTrips(kv as unknown as KVNamespace)) {
+      remaining.push(t);
+    }
+    expect(remaining).toHaveLength(1);
+  });
+
+  // #2322 (O1-C) — 침묵/outage가 끝나고 device sync가 다시 신선해지면 기존 5분 backstop이
+  // 정상 재개돼야 한다 (guard가 영구 면제가 아님을 검증).
+  it('device sync 재개(fresh) 후에는 la-stale backstop이 정상 발동', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({
+      token: 'la-stale-recovered',
+      createdAt: NOW - 30 * 60_000,
+      expiresAt: NOW + 60 * 60_000,
+      alarmAtEpochMs: NOW + 60_000,
+      lastLaPushAt: NOW - 6 * 60_000,
+    });
+    await putTrip(kv as unknown as KVNamespace, trip);
+    const ssot = await seedSsot(kv as unknown as KVNamespace, trip.token, '강남', {
+      expiresAt: trip.expiresAt,
+    });
+    ssot.lastDeviceSyncAt = NOW - 10_000; // 신선 — stale 아님.
+    await writeSsot(kv as unknown as KVNamespace, ssot, { expiresAt: trip.expiresAt });
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeSeoul([]),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+
+    expect(stats.laStaleAutoEnded).toBe(1);
+    expect(stats.laStaleSurvivedSilence).toBe(0);
+  });
+
   // 회귀 가드 — #1933 review finding. cleanupTripWithLa는 내부에서 deleteSsot을 try/catch로 감싸
   // graceful swallow한다 (liveActivity.ts:322). 외부에서 추가 호출 시 비가드라 KV throw가 cron 루프를
   // break-out 해 다음 trip이 평가되지 않는 회귀 위험. 본 가드 테스트는 ssot KV가 throw해도 backstop이
@@ -10137,7 +10246,7 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
     if (opts.setupSsot) await opts.setupSsot(kv, trip);
     const stats: ScheduledStats = {
       scanned: 0, polled: 0, pushed: 0, errors: 0, etaMissing: 0, envCorrected: 0,
-      lockMissing: 0, laStaleAutoEnded: 0, killSwitchLocklessIntermediateSkipped: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
+      lockMissing: 0, laStaleAutoEnded: 0, laStaleSurvivedSilence: 0, killSwitchLocklessIntermediateSkipped: 0, locklessIntermediateFired: 0, locklessMotionGateBlocked: 0,
       laPushSent: 0, laPushFailed: 0, laTokenCleared: 0,
       boardingPromptEvaluated: 0, boardingPromptFired: 0, boardingPromptBlocked: 0,
       phaseImminentBlocked: 0, kalmanReset: 0, kalmanDriftWarning: 0,
@@ -10150,7 +10259,7 @@ describe('fireArvlCdStationPush — #1614 Phase C stale SSoT 가드', () => {
       boardingLockWaypointAdvanceBlocked: 0, transferDestinationGateBlocked: 0,
       vanishFallbackFired: 0, vanishReleaseFired: 0, vanishLocklessTakeover: 0,
       vanishFallbackMotionGateBlocked: 0,
-      cronJitterMs: 0, rescheduleBlockedMotion: 0, rescheduleFallbackNoSsot: 0, rescheduleDedupSkipped: 0, destinationBackstopForceEnded: 0,
+      cronJitterMs: 0, rescheduleBlockedMotion: 0, rescheduleFallbackNoSsot: 0, rescheduleDedupSkipped: 0, destinationBackstopForceEnded: 0, destinationStaleGpsSurvivedSilence: 0,
       realtimePositionFetch: 0, selfPollCacheHit: 0, realtimePositionFetchError: 0,
       // #1828 Phase 5 — station-level arrivals polling.
       stationPollFetch: 0, stationPollCacheHit: 0, stationPollError: 0,
@@ -10606,6 +10715,126 @@ describe('runScheduled — #1707 destination GPS cross-check integration', () =>
     expect(await kv.get(`trip:${trip.token}`)).toBeNull();
     expect(stats.destinationCrossCheck.staleGps).toBe(1);
     expect(stats.destinationCrossCheck.gpsFar).toBe(0);
+  });
+
+  // #2322 (O1-C) — stale-gps여도 device sync stale(#2321) 상태면 즉시 cleanup하지 않고
+  // gps-far와 동일한 짧은 backstop으로 trip을 보존해야 한다.
+  it('preserves trip on stale-gps when device sync is also stale (25min silence)', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeHapjeongDestTrip('user-stale-silent-tok');
+    await putTrip(kv as unknown as KVNamespace, trip);
+    await kv.put(
+      `pos:${trip.token}`,
+      JSON.stringify([
+        {
+          lat: 37.5552,
+          lng: 126.9368,
+          accuracy: 15,
+          ts: NOW - DESTINATION_GPS_STALE_THRESHOLD_MS - 1,
+          motion: 'automotive',
+        },
+      ]),
+    );
+    const ssot = await seedSsot(kv as unknown as KVNamespace, trip.token, '홍대입구', {
+      expiresAt: trip.expiresAt,
+    });
+    ssot.lastDeviceSyncAt = NOW - 25 * 60_000;
+    await writeSsot(kv as unknown as KVNamespace, ssot, { expiresAt: trip.expiresAt });
+
+    const fetchImpl = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul: makeHapjeongArrivedSeoul(),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    // trip 보존 — 즉시 cleanup되지 않는다.
+    expect(await kv.get(`trip:${trip.token}`)).not.toBeNull();
+    expect(stats.destinationCrossCheck.staleGps).toBe(1);
+    expect(stats.destinationStaleGpsSurvivedSilence).toBe(1);
+  });
+
+  // #2322 (O1-C) — Seoul API outage 중에도 stale-gps 즉시 cleanup을 skip해야 한다.
+  // decoy trip(다른 역 조회)이 이 cron 사이클에 HTTP error를 관측시켜 outage를 재현하고,
+  // 본 trip(합정)의 arrivals 조회 자체는 정상 ARRIVED 응답으로 advance된다 — 두 신호가
+  // 독립적임을 보장(같은 SeoulArrivalClient 인스턴스가 cron 1 cycle 범위로 httpErrorCount를
+  // 공유하는 기존 정책, #1663).
+  it('preserves trip on stale-gps when Seoul API outage observed this cycle (decoy trip HTTP error)', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeHapjeongDestTrip('z-user-stale-outage-tok');
+    await putTrip(kv as unknown as KVNamespace, trip);
+    await kv.put(
+      `pos:${trip.token}`,
+      JSON.stringify([
+        {
+          lat: 37.5552,
+          lng: 126.9368,
+          accuracy: 15,
+          ts: NOW - DESTINATION_GPS_STALE_THRESHOLD_MS - 1,
+          motion: 'automotive',
+        },
+      ]),
+    );
+    // decoy trip — 'a-'로 시작해 InMemoryKV.list() 정렬(localeCompare)상 본 trip보다 먼저
+    // scan돼 같은 cycle 내에서 httpErrorCount를 먼저 증가시킨다.
+    const decoyTrip = makeTrip({
+      token: 'a-decoy-outage-tok',
+      waypoints: [{ stationName: '강남', line: '2', kind: 'intermediate' }],
+      boardingLock: {
+        trainCode: 'D',
+        line: '2',
+        subwayId: '1002',
+        selectedDepartureTime: NOW,
+        segmentStations: ['교대', '강남'],
+        expiresAt: NOW + 60 * 60_000,
+      },
+    });
+    await putTrip(kv as unknown as KVNamespace, decoyTrip);
+
+    const hapjeongUrlPart = encodeURIComponent('합정');
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (String(url).includes(hapjeongUrlPart)) {
+        return new Response(
+          JSON.stringify({
+            realtimeArrivalList: [
+              {
+                barvlDt: '0',
+                recptnDt: '',
+                updnLine: '내선',
+                trainLineNm: '합정',
+                btrainNo: 'T',
+                subwayNm: '지하철2호선',
+                arvlCd: 1, // ARRIVED
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      // decoy(강남) 조회 + positions 조회 등 나머지는 모두 error → httpErrorCount 증가.
+      return new Response('boom', { status: 500 });
+    });
+    const seoul = new SeoulArrivalClient({
+      apiKey: 'K',
+      host: 'h',
+      now: () => NOW,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const apnsFetch = vi.fn(async () => new Response('', { status: 200 }));
+    const stats = await runScheduled(makeEnv(kv), {
+      seoul,
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+    });
+    // outage 관측 확인 — httpErrorCount가 실제로 늘었어야 이 테스트가 의미 있다.
+    expect(seoul.stats.httpErrorCount).toBeGreaterThan(0);
+    // trip 보존 — Seoul outage 상태에선 stale-gps로 즉시 종료되지 않는다.
+    expect(await kv.get(`trip:${trip.token}`)).not.toBeNull();
+    expect(stats.destinationStaleGpsSurvivedSilence).toBe(1);
   });
 
   /**

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -550,6 +550,14 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   laStaleAutoEnded: number;
   /**
+   * #2322 (O1-C) — la-stale backstop이 발동 조건(5분 침묵)을 만족했지만 device sync stale
+   * (#2321 `isDeviceSyncStale`) 또는 Seoul API outage(이 cron 사이클 HTTP error 관측) 상태라
+   * cleanup을 skip하고 trip을 생존시킨 누적 횟수. `laStaleAutoEnded`와 상호 배타적 — 같은
+   * 발동 조건에서 이 카운터가 늘면 그 카운터는 늘지 않는다. 침묵/outage 종료 후 정상 push가
+   * 재개되면 다음 cycle에 `lastLaPushAt`이 갱신돼 이 상태에서 벗어난다.
+   */
+  laStaleSurvivedSilence: number;
+  /**
    * #1967 (Ff-1) — admin kill switch(`KILL_LOCKLESS_INTERMEDIATE`)가 활성 상태라
    * `runLocklessIntermediate`의 매역 station-passed push 발사(pushId 발급/전송/
    * putPending/LA update)만 skip한 누적 횟수. 2026-07-31 리뷰(P1) — 게이트를 함수
@@ -900,6 +908,14 @@ export interface ScheduledStats extends LiveActivityStats {
    */
   destinationBackstopForceEnded: number;
   /**
+   * #2322 (O1-C) — destination cross-check 결과가 'stale-gps'였지만 device sync stale(#2321) 또는
+   * Seoul API outage(이 cron 사이클 HTTP error 관측) 상태라 즉시 cleanup하지 않고 'gps-far'와
+   * 동일한 짧은 backstop(`DESTINATION_REACH_BACKSTOP_MS`)으로 trip 보존을 이관한 누적 횟수.
+   * device GPS 자체가 없는 legacy stale-gps(#1707 conservative cleanup)와 구분 — 이 카운터가
+   * 늘면 destinationCrossCheck.staleGps도 같이 늘지만 즉시 cleanup은 발생하지 않는다.
+   */
+  destinationStaleGpsSurvivedSilence: number;
+  /**
    * #2073 (Issue A) — 이번 tick에 pending/retry push entry가 존재할 가능성이 있는지.
    * `병합 listTrips 결과가 비어있음 AND 직전 tick 근방 fire/retry 기록 없음`일 때만 false —
    * 그 외(활성 trip 존재 또는 최근 활동 marker 有)엔 true(보수적 기본값). `index.ts`의
@@ -1047,6 +1063,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     envCorrected: 0,
     lockMissing: 0,
     laStaleAutoEnded: 0,
+    laStaleSurvivedSilence: 0,
     killSwitchLocklessIntermediateSkipped: 0,
     locklessIntermediateFired: 0,
     locklessMotionGateBlocked: 0,
@@ -1127,6 +1144,7 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     },
     // #2230 — gps-far 보류 destination advance의 짧은 backstop force-cleanup 누적.
     destinationBackstopForceEnded: 0,
+    destinationStaleGpsSurvivedSilence: 0,
     // #2066 (Phase 2-backend) — 취침 알람(환승/도착 직전역) 발사/skip 카운터.
     sleepAlarmFired: 0,
     sleepAlarmDedupSkipped: 0,
@@ -1274,30 +1292,31 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
     // #1680 (V8d) — stationary cron skip 게이트. SSoT.motionState === 'stationary' 명시 시
     // Seoul polling + push 발사를 skip한다. motionState='unknown' 또는 SSoT null은 평가 유지.
     // destination/transfer 임박 bypass: 사용자가 환승역/목적지에 정차 중인 케이스를 보호.
-    {
-      const stationarySsot = await readSsot(env.TRIPS, trip.token, {
-        cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
+    //
+    // #2322 (O1-C) — la-stale backstop(아래)이 같은 SSoT read를 재사용해 침묵/outage 여부를
+    // 판정하므로 이 블록 밖으로 scope를 넓혔다. 결과 판정 로직 자체는 무변경.
+    const stationarySsot = await readSsot(env.TRIPS, trip.token, {
+      cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
+    });
+    if (
+      stationarySsot !== null &&
+      shouldSkipStationary(
+        stationarySsot.motionState,
+        waypoint.kind,
+        stationarySsot.userIntentDeclared,
+        // #2321 — device sync stale 시 motionState 신뢰 불가 → skip하지 않고 평가 계속.
+        isDeviceSyncStale(stationarySsot, now),
+      )
+    ) {
+      stats.lifecycleStationarySkipped += 1;
+      log('cron: stationary skip', {
+        token: trip.token.slice(0, 8),
+        station: waypoint.stationName,
+        kind: waypoint.kind,
+        // #2032 (Issue D) — monitoring dimension. ADR-023: 발사 결정 X.
+        sleepMode: trip.sleepModeEnabled,
       });
-      if (
-        stationarySsot !== null &&
-        shouldSkipStationary(
-          stationarySsot.motionState,
-          waypoint.kind,
-          stationarySsot.userIntentDeclared,
-          // #2321 — device sync stale 시 motionState 신뢰 불가 → skip하지 않고 평가 계속.
-          isDeviceSyncStale(stationarySsot, now),
-        )
-      ) {
-        stats.lifecycleStationarySkipped += 1;
-        log('cron: stationary skip', {
-          token: trip.token.slice(0, 8),
-          station: waypoint.stationName,
-          kind: waypoint.kind,
-          // #2032 (Issue D) — monitoring dimension. ADR-023: 발사 결정 X.
-          sleepMode: trip.sleepModeEnabled,
-        });
-        continue;
-      }
+      continue;
     }
 
     // #640 — BoardingLock 게이트. 사용자가 열차를 아직 선택하지 않았거나 lock이 만료된 trip은
@@ -1313,20 +1332,42 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
       // SSoT mirror cleanup은 `cleanupTripWithLa` 내부의 graceful `deleteSsot` 호출(try/catch
       // swallow, liveActivity.ts:322)에 위임 — 외부 추가 호출은 redundant + KV throw 발생 시
       // cron 루프 break-out 위험이라 두지 않는다.
+      //
+      // #2322 (O1-C) — device sync stale(#2321) 또는 Seoul API outage(이 cron 사이클 HTTP error
+      // 관측) 중에는 push 침묵이 device/API 장애의 정상 결과이지 SSoT freeze 버그의 증거가
+      // 아니다. 이 두 상태에서는 backstop을 skip하고 trip을 생존시킨다 — 무한 생존은 이미
+      // 존재하는 6h silence / 9h force-end staged lifecycle backstop(`tripLifecyclePhase`,
+      // 이 loop 상단에서 매 cycle 선행 평가됨)이 상한을 보장하므로 별도 상한 불필요.
+      const laStaleSurvivedSilence =
+        (stationarySsot !== null && isDeviceSyncStale(stationarySsot, now)) ||
+        deps.seoul.stats.httpErrorCount > 0;
       if (
         trip.lastLaPushAt !== undefined &&
         now - trip.lastLaPushAt > LA_STALE_AUTO_END_MS
       ) {
-        stats.laStaleAutoEnded += 1;
-        log('la-stale: auto-end after 5min push silence', {
-          token: trip.token.slice(0, 8),
-          elapsedMs: now - trip.lastLaPushAt,
-          station: pickActiveWaypoint(trip)?.stationName,
-          // #2032 (Issue D) — monitoring dimension. ADR-023: 발사 결정 X.
-          sleepMode: trip.sleepModeEnabled,
-        });
-        await cleanupTripWithLa(trip, env, deps, stats, now, log, { reason: 'la-stale-backstop' });
-        continue;
+        if (laStaleSurvivedSilence) {
+          stats.laStaleSurvivedSilence += 1;
+          log('la-stale: survived (device-sync-stale or seoul-outage)', {
+            token: trip.token.slice(0, 8),
+            elapsedMs: now - trip.lastLaPushAt,
+            station: pickActiveWaypoint(trip)?.stationName,
+            deviceSyncStale: stationarySsot !== null && isDeviceSyncStale(stationarySsot, now),
+            seoulHttpErrors: deps.seoul.stats.httpErrorCount,
+          });
+        } else {
+          stats.laStaleAutoEnded += 1;
+          log('la-stale: auto-end after 5min push silence', {
+            token: trip.token.slice(0, 8),
+            elapsedMs: now - trip.lastLaPushAt,
+            station: pickActiveWaypoint(trip)?.stationName,
+            // #2032 (Issue D) — monitoring dimension. ADR-023: 발사 결정 X.
+            sleepMode: trip.sleepModeEnabled,
+          });
+          await cleanupTripWithLa(trip, env, deps, stats, now, log, {
+            reason: 'la-stale-backstop',
+          });
+          continue;
+        }
       }
       // #2131 (Part A-2, ADR-014 동급 보장) — boarding-prompt 9단 게이트 평가를 lockless
       // intermediate 분기보다 앞으로 hoist. 기존엔 `trip.infoModeEnabled && waypoint.kind ===
@@ -3701,7 +3742,33 @@ export async function advanceBoardingLockWaypoint(
       kind: waypoint.kind,
       result: crossCheck,
     });
-    if (crossCheck === 'gps-far') {
+    // #2322 (O1-C) — 'stale-gps'(device GPS 5분+ 미갱신)는 기존 #1707 정책상 conservative
+    // cleanup 대상이지만, device sync 자체가 stale(#2321)하거나 Seoul API outage(이 cron
+    // 사이클 HTTP error 관측) 상태에서는 "device GPS가 잠깐 안 옴"이 아니라 "device/API
+    // 전체가 침묵 중"인 다른 상황 — 그 상태에서 destination 도착으로 잘못 판정해 종료하면
+    // 침묵 25분 fixture 같은 케이스에서 실제 도착 전에 trip이 사라진다. 이 두 상태에서는
+    // 'gps-far'와 동일하게 짧은 backstop(`DESTINATION_REACH_BACKSTOP_MS`)으로 이관한다.
+    let effectiveCrossCheck = crossCheck;
+    if (crossCheck === 'stale-gps') {
+      const staleGpsSsot = await readSsot(env.TRIPS, trip.token, {
+        cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC,
+      });
+      const silentOrOutage =
+        (staleGpsSsot !== null && isDeviceSyncStale(staleGpsSsot, now)) ||
+        deps.seoul.stats.httpErrorCount > 0;
+      if (silentOrOutage) {
+        stats.destinationStaleGpsSurvivedSilence += 1;
+        log('boarding-lock: stale-gps survived (device-sync-stale or seoul-outage)', {
+          token: trip.token.slice(0, 8),
+          station: waypoint.stationName,
+          kind: waypoint.kind,
+          deviceSyncStale: staleGpsSsot !== null && isDeviceSyncStale(staleGpsSsot, now),
+          seoulHttpErrors: deps.seoul.stats.httpErrorCount,
+        });
+        effectiveCrossCheck = 'gps-far';
+      }
+    }
+    if (effectiveCrossCheck === 'gps-far') {
       // #2230 — destination 도달이 최초로 관측된 시각 anchor. 이미 stamp돼 있으면 보존
       // (매 cycle 재stamp하면 backstop이 끝없이 밀려 9h force-end와 다를 바 없어진다).
       if (trip.destinationImminentFirstAt === undefined) {


### PR DESCRIPTION
Closes #2322

## 요약
O1-B(#2321)로 게이트가 완화되면서 침묵(device sync stale) 상태의 trip도 상시 평가 대상이 됐다. 이 상태에서 backend의 두 auto-end 가드(la-stale 5min, destination stale-gps)가 device/API 장애로 인한 정상적인 push 침묵을 "SSoT freeze 버그" 또는 "destination 도착"으로 오판해 trip을 죽이지 않도록 보강했다.

## 변경 사항
1. **la-stale backstop** (`scheduled.ts` lockMissing 분기, #1933) — device sync stale(#2321 `isDeviceSyncStale`) 또는 Seoul API outage(이 cron 사이클 HTTP error 관측) 중에는 5분 침묵 auto-end를 skip하고 trip을 생존시킨다. 신규 카운터 `laStaleSurvivedSilence`.
2. **destination cross-check stale-gps 경로** (#1707) — 같은 두 조건에서 `'stale-gps'` 결과를 `'gps-far'`와 동일하게 취급해 짧은 backstop(`DESTINATION_REACH_BACKSTOP_MS`, 15분)으로 trip 보존을 이관한다. 신규 카운터 `destinationStaleGpsSurvivedSilence`.
3. **무한 생존 방지** — 별도 상한을 신설하지 않고 기존 안전망을 재사용: la-stale은 이 loop 상단에서 매 cycle 선행 평가되는 6h silence / 9h force-end staged lifecycle backstop이, stale-gps는 기존 15분 destination backstop이 상한을 보장한다.
4. **fire 카테고리 전수 감사** — arvlCd/vanish-fallback 매역 fire 경로는 #2321에서 이미 `isDeviceSyncStale` 정합 게이트를 적용 완료(`fireArvlCdStationPush` 등). 코드 변경 없음, 감사만 수행.
5. **이중 발사 dedup 감사** — 기존 KV claim-then-send dedup(#917/#2066/#2157 등 이미 존재하는 dedup 인프라)을 그대로 재사용. 신규 dedup gate 추가 없음(dedup gate 7종 sprawl lesson 준수).

## 병렬 작업 경계 준수
scheduled.ts의 auto-end 가드 블록(la-stale, destination stale-gps)만 수정. fire/advance 경로(arvlCd fire, advanceTripPosition 호출부)와 `advanceTripPosition.ts`/`consensusGate.ts`는 건드리지 않음 — 동시 작업 중인 #2329와 파일 충돌 없음.

## TDD
- 침묵 25분 fixture(SSoT `lastDeviceSyncAt` 25분 전) → la-stale auto-end 0건, `laStaleSurvivedSilence` 1건
- Seoul outage fixture(decoy trip으로 실제 `httpErrorCount` 유발, 본 trip은 정상 ARRIVED 응답) → la-stale auto-end 0건 / stale-gps 즉시 cleanup 0건
- 침묵/outage 해소(device sync fresh) 후에는 기존 5분 backstop이 정상 재개 (영구 면제 아님을 검증하는 회귀 테스트)
- 기존 dead trip 정리 상한 케이스(4개) 전수 무회귀 확인

## 검증
- `npx vitest run` (backend/alarm-worker): 84 files / 3023 tests 전부 pass
- 커버리지 ratchet floor 통과: statements 97.33%(≥97) / branches 96.45%(≥96) / functions 99.08%(≥98) / lines 97.33%(≥97) — 신규 코드 100% 커버 확인(uncovered line 목록에 신규 로직 라인 없음)
- `npm run type-check` pass
- red-green 확인: fix 적용 전 신규 테스트 5건 실제 실패(git stash로 검증) → fix 적용 후 전부 pass

## Wire-completion 5단
1. **Orphan 없음** — 신규 export 없음(기존 `ScheduledStats` 인터페이스 필드 2개 추가만). N/A for orphan script (backend는 프론트 orphan script 스코프 밖).
2. **V/X dashboard** — `laStaleSurvivedSilence`/`destinationStaleGpsSurvivedSilence` 카운터는 cron 로그(`la-stale: survived...`, `boarding-lock: stale-gps survived...`)로 wrangler tail / Cloudflare Dashboard에서 관측 가능. 기존 `laStaleAutoEnded`/`destinationCrossCheck.staleGps`와 대조해 "발동 조건 충족 대비 실제 종료 비율" 측정.
3. **의존 PR** — #2321(O1-B, 머지됨, `isDeviceSyncStale` 의존). **머지 후 Cloudflare Workers deploy 필요** — 코드 머지만으로는 production에 반영되지 않음.
4. **측정 plan** — 다음 검증 탑승 시 침묵/outage 재현 시나리오에서 `laStaleAutoEnded`/`destinationCrossCheck.staleGps` 대비 신규 survived 카운터 로그 대조. 1주 관측 목표: 실제 침묵/outage 중 auto-end 0건.
5. **Device verify** — 다음 실기기 검증 탑승 시나리오에 포함(지하 침묵 25분+ 구간 통과 시 trip 생존 확인).