### PR TITLE
feat: consensus-train evidence + confirmed-only alert wire (consensus-C, #2323 설계)

### DIFF
--- a/backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts
+++ b/backend/alarm-worker/src/__tests__/advanceTripPosition.test.ts
@@ -1,10 +1,11 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   POSITION_TRAIN_MAX_HOP,
   POSITION_TRAIN_STALE_THRESHOLD_MS,
   STRONG_EVIDENCE_TYPES,
   advanceTripPosition,
+  applyLegConsensusTick,
   buildSignalsFromEvidence,
   computePositionTrainHopDistance,
   consecutiveDurationMs,
@@ -91,14 +92,16 @@ describe('mapEvidenceEnvironment', () => {
 });
 
 describe('STRONG_EVIDENCE_TYPES', () => {
-  it('5종 strong evidence (arvlcd-confirmed-train / wifi / cellular / position / accel)', () => {
-    expect(STRONG_EVIDENCE_TYPES.size).toBe(5);
+  it('6종 strong evidence (arvlcd-confirmed-train / wifi / cellular / position / accel / consensus-train)', () => {
+    expect(STRONG_EVIDENCE_TYPES.size).toBe(6);
     for (const t of [
       'arvlcd-confirmed-train',
       'wifi-ssid-match',
       'cellular-tech-change',
       'position-train',
       'accel-fingerprint',
+      // #2329 (consensus-C) — transferLegConsensus 상태기계 confirmed evidence.
+      'consensus-train',
     ] as const) {
       expect(STRONG_EVIDENCE_TYPES.has(t)).toBe(true);
     }
@@ -1423,5 +1426,325 @@ describe('advanceTripPosition — gate #7 position-train jump/stale (#1665)', ()
       { gatePassed: true, lockAttachable: true },
     );
     expect(out.result).toBe('advanced');
+  });
+});
+
+describe('advanceTripPosition — gate #5b consensus-train confirmed-only (#2329, consensus-C)', () => {
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  it('legConsensus 미시작(undefined) → blocked(consensus-not-confirmed)', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '건대입구');
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: undefined }));
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence({ type: 'consensus-train', stationId: '중곡', arvlcdTrainCode: '7246' }),
+      { gatePassed: true, lockAttachable: false },
+    );
+    expect(out.result).toBe('blocked');
+    expect(out.blockReason).toBe('consensus-not-confirmed');
+  });
+
+  it.each(['tracking', 'ambiguous', 'demoted', 'suppressed'] as const)(
+    'legConsensus.status=%s (confirmed 아님) → blocked(consensus-not-confirmed)',
+    async (status) => {
+      const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '건대입구');
+      ssot.motionState = 'moving';
+      ssot.legConsensus = {
+        status,
+        t0EpochMs: NOW - 60_000,
+        transferTimeSec: 278,
+        headwaySec: 210,
+        window: {
+          earliestAllowedEpochMs: NOW,
+          coreStartEpochMs: NOW,
+          coreEndEpochMs: NOW,
+          latestAllowedEpochMs: NOW,
+        },
+        candidates: [],
+        confirmedMismatchStreak: 0,
+        updatedAt: NOW,
+      };
+      await writeSsot(kv as unknown as KVNamespace, ssot);
+      await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: undefined }));
+
+      const out = await advanceTripPosition(
+        kv as unknown as KVNamespace,
+        TOKEN,
+        '중곡',
+        makeEvidence({ type: 'consensus-train', stationId: '중곡', arvlcdTrainCode: '7246' }),
+        { gatePassed: true, lockAttachable: false },
+      );
+      expect(out.result).toBe('blocked');
+      expect(out.blockReason).toBe('consensus-not-confirmed');
+    },
+  );
+
+  it('legConsensus.status=confirmed + trainCode 일치 → advanced', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '건대입구');
+    ssot.motionState = 'moving';
+    ssot.legConsensus = {
+      status: 'confirmed',
+      t0EpochMs: NOW - 300_000,
+      transferTimeSec: 278,
+      headwaySec: 210,
+      window: {
+        earliestAllowedEpochMs: NOW,
+        coreStartEpochMs: NOW,
+        coreEndEpochMs: NOW,
+        latestAllowedEpochMs: NOW,
+      },
+      candidates: [],
+      confirmedTrainCode: '7246',
+      confirmedMismatchStreak: 0,
+      updatedAt: NOW,
+    };
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: undefined }));
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence({ type: 'consensus-train', stationId: '중곡', arvlcdTrainCode: '7246' }),
+      { gatePassed: true, lockAttachable: false },
+    );
+    expect(out.result).toBe('advanced');
+  });
+
+  it('confirmed이지만 evidence trainCode 불일치 → blocked(consensus-not-confirmed)', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '건대입구');
+    ssot.motionState = 'moving';
+    ssot.legConsensus = {
+      status: 'confirmed',
+      t0EpochMs: NOW - 300_000,
+      transferTimeSec: 278,
+      headwaySec: 210,
+      window: {
+        earliestAllowedEpochMs: NOW,
+        coreStartEpochMs: NOW,
+        coreEndEpochMs: NOW,
+        latestAllowedEpochMs: NOW,
+      },
+      candidates: [],
+      confirmedTrainCode: '7246',
+      confirmedMismatchStreak: 0,
+      updatedAt: NOW,
+    };
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: undefined }));
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence({ type: 'consensus-train', stationId: '중곡', arvlcdTrainCode: '9999' }),
+      { gatePassed: true, lockAttachable: false },
+    );
+    expect(out.result).toBe('blocked');
+    expect(out.blockReason).toBe('consensus-not-confirmed');
+  });
+
+  it('lock 활성 + consensus-train + lock.trainCode 불일치 → blocked(train-mismatch) — 게이트 #5 확장', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '건대입구');
+    ssot.motionState = 'moving';
+    ssot.legConsensus = {
+      status: 'confirmed',
+      t0EpochMs: NOW - 300_000,
+      transferTimeSec: 278,
+      headwaySec: 210,
+      window: {
+        earliestAllowedEpochMs: NOW,
+        coreStartEpochMs: NOW,
+        coreEndEpochMs: NOW,
+        latestAllowedEpochMs: NOW,
+      },
+      candidates: [],
+      confirmedTrainCode: '7246',
+      confirmedMismatchStreak: 0,
+      updatedAt: NOW,
+    };
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    // lock.trainCode(다른 값)와 consensus confirmedTrainCode(7246)가 둘 다 evidence와 일치해야
+    // gate #5b + 확장된 gate #5를 모두 통과 — lock.trainCode만 다르면 gate #5(train-mismatch)가 차단.
+    await putTrip(
+      kv as unknown as KVNamespace,
+      makeTrip({ boardingLock: makeLock({ trainCode: '1111' }) }),
+    );
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence({ type: 'consensus-train', stationId: '중곡', arvlcdTrainCode: '7246' }),
+      { gatePassed: true, lockAttachable: true },
+    );
+    expect(out.result).toBe('blocked');
+    expect(out.blockReason).toBe('train-mismatch');
+  });
+});
+
+describe('advanceTripPosition — lockSuggestion consensus confidence (#2329, consensus-C)', () => {
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  it('lockless + consensus-train confirmed → confidence=consensus suggestion (lock 승격 없음)', async () => {
+    const ssot = await seedSsot(kv as unknown as KVNamespace, TOKEN, '건대입구');
+    ssot.motionState = 'moving';
+    ssot.legConsensus = {
+      status: 'confirmed',
+      t0EpochMs: NOW - 300_000,
+      transferTimeSec: 278,
+      headwaySec: 210,
+      window: {
+        earliestAllowedEpochMs: NOW,
+        coreStartEpochMs: NOW,
+        coreEndEpochMs: NOW,
+        latestAllowedEpochMs: NOW,
+      },
+      candidates: [],
+      confirmedTrainCode: '7246',
+      confirmedMismatchStreak: 0,
+      updatedAt: NOW,
+    };
+    await writeSsot(kv as unknown as KVNamespace, ssot);
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: undefined }));
+
+    const out = await advanceTripPosition(
+      kv as unknown as KVNamespace,
+      TOKEN,
+      '중곡',
+      makeEvidence({ type: 'consensus-train', stationId: '중곡', arvlcdTrainCode: '7246' }),
+      { gatePassed: true, lockAttachable: false },
+    );
+    expect(out.result).toBe('advanced');
+
+    const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    expect(after?.lockSuggestion).toEqual({
+      stationId: '중곡',
+      trainCode: '7246',
+      lineId: '7',
+      confidence: 'consensus',
+      decidedAt: NOW,
+    });
+    // lock 승격 금지 — trip.boardingLock 자체는 본 함수가 절대 mutate하지 않는다.
+    expect(ssot.legConsensus?.status).toBe('confirmed');
+  });
+});
+
+describe('applyLegConsensusTick (#2329, consensus-C — legConsensus SSoT wire + D1 event log)', () => {
+  let kv: InMemoryKV;
+  beforeEach(() => {
+    kv = new InMemoryKV();
+  });
+
+  function makeMockDb(): D1Database {
+    const run = vi.fn().mockResolvedValue({ success: true });
+    const bind = vi.fn().mockReturnValue({ run });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    return { prepare, run, bind } as unknown as D1Database & { bind: typeof bind };
+  }
+
+  it('SSoT 부재 시 null 반환 (no-op)', async () => {
+    const out = await applyLegConsensusTick(kv as unknown as KVNamespace, undefined, TOKEN, {
+      init: { t0EpochMs: NOW, transferTimeSec: 278, headwaySec: 210, observedDepartures: [] },
+      tick: { now: NOW },
+    });
+    expect(out).toBeNull();
+  });
+
+  it('init 없음 + 기존 legConsensus 없음 → null (초기화 재료 부재)', async () => {
+    await seedSsot(kv as unknown as KVNamespace, TOKEN, '건대입구');
+    const out = await applyLegConsensusTick(kv as unknown as KVNamespace, undefined, TOKEN, {
+      tick: { now: NOW },
+    });
+    expect(out).toBeNull();
+  });
+
+  it('최초 tick — init 후 confirm 미달(단일 후보 match<2)이면 tracking 유지 + ssot.legConsensus 저장', async () => {
+    await seedSsot(kv as unknown as KVNamespace, TOKEN, '건대입구');
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: undefined }));
+
+    const out = await applyLegConsensusTick(kv as unknown as KVNamespace, undefined, TOKEN, {
+      init: {
+        t0EpochMs: NOW,
+        transferTimeSec: 278,
+        headwaySec: 210,
+        observedDepartures: [{ trainCode: '7246', departureEpochMs: NOW + 278_000 }],
+      },
+      tick: { now: NOW, observations: [{ trainCode: '7246', deltaSec: 0 }] },
+    });
+    expect(out?.record.status).toBe('tracking');
+    expect(out?.events).toEqual([]);
+
+    const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    expect(after?.legConsensus?.candidates).toHaveLength(1);
+  });
+
+  it('연속 2 match → confirmed 이벤트 + D1 consensus-confirm append', async () => {
+    await seedSsot(kv as unknown as KVNamespace, TOKEN, '건대입구');
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: undefined }));
+    const db = makeMockDb();
+
+    await applyLegConsensusTick(kv as unknown as KVNamespace, db, TOKEN, {
+      init: {
+        t0EpochMs: NOW,
+        transferTimeSec: 278,
+        headwaySec: 210,
+        observedDepartures: [{ trainCode: '7246', departureEpochMs: NOW + 278_000 }],
+      },
+      tick: { now: NOW, observations: [{ trainCode: '7246', deltaSec: 0 }] },
+      station: '중곡',
+      line: '7',
+    });
+    const out2 = await applyLegConsensusTick(kv as unknown as KVNamespace, db, TOKEN, {
+      tick: { now: NOW + 80_000, observations: [{ trainCode: '7246', deltaSec: 10 }] },
+      station: '중곡',
+      line: '7',
+    });
+
+    expect(out2?.record.status).toBe('confirmed');
+    expect(out2?.record.confirmedTrainCode).toBe('7246');
+    expect(out2?.events).toEqual([{ kind: 'consensus-confirm', trainCode: '7246' }]);
+    expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO trip_events'));
+
+    const after = await readSsot(kv as unknown as KVNamespace, TOKEN);
+    expect(after?.legConsensus?.status).toBe('confirmed');
+  });
+
+  it('db 미전달 시 D1 append 없이도 SSoT는 정상 갱신 (graceful)', async () => {
+    await seedSsot(kv as unknown as KVNamespace, TOKEN, '건대입구');
+    await putTrip(kv as unknown as KVNamespace, makeTrip({ boardingLock: undefined }));
+
+    const out = await applyLegConsensusTick(kv as unknown as KVNamespace, undefined, TOKEN, {
+      init: {
+        t0EpochMs: NOW,
+        transferTimeSec: 278,
+        headwaySec: 210,
+        observedDepartures: [
+          { trainCode: '7246', departureEpochMs: NOW + 278_000 },
+          { trainCode: '9999', departureEpochMs: NOW + 279_000 },
+        ],
+      },
+      tick: {
+        now: NOW,
+        observations: [
+          { trainCode: '7246', deltaSec: 200 },
+          { trainCode: '9999', deltaSec: 200 },
+        ],
+      },
+    });
+    // 둘 다 mismatch(|Δ|>180) → 생존 0 → suppress.
+    expect(out?.record.status).toBe('suppressed');
+    expect(out?.events[0]?.kind).toBe('consensus-suppress');
   });
 });

--- a/backend/alarm-worker/src/__tests__/consensusGate.test.ts
+++ b/backend/alarm-worker/src/__tests__/consensusGate.test.ts
@@ -96,6 +96,37 @@ describe('evaluateConsensusGate (ADR-015 §3/§4)', () => {
         }).pass,
       ).toBe(false);
     });
+
+    // #2329 (consensus-C, 설계 SSoT #2323) — consensusConfirmed는 lockAttachable(strong E)
+    // surrogate. arrival(B)/lockAttachable 없이도 단독으로 통과시킨다.
+    it('consensusConfirmed=true 단독(arrival/lockAttachable 모두 없음) → 통과 (strong G surrogate)', () => {
+      expect(
+        runGate('underground', {
+          gateOutcome: FAIL_GATE,
+          arrivalSignalPresent: false,
+          lockAttachable: false,
+          consensusConfirmed: true,
+        }).pass,
+      ).toBe(true);
+    });
+
+    it('consensusConfirmed=false/undefined → 기존 정책 무영향(다른 신호 없으면 reject)', () => {
+      expect(
+        runGate('underground', {
+          gateOutcome: FAIL_GATE,
+          arrivalSignalPresent: false,
+          lockAttachable: false,
+          consensusConfirmed: false,
+        }).pass,
+      ).toBe(false);
+      expect(
+        runGate('underground', {
+          gateOutcome: FAIL_GATE,
+          arrivalSignalPresent: false,
+          lockAttachable: false,
+        }).pass,
+      ).toBe(false);
+    });
   });
 
   describe('environment=mixed (보수적)', () => {

--- a/backend/alarm-worker/src/__tests__/evidence_20260812_replay_consensus.test.ts
+++ b/backend/alarm-worker/src/__tests__/evidence_20260812_replay_consensus.test.ts
@@ -1,0 +1,195 @@
+/**
+ * 2026-08-12 저녁 25분 침묵 evidence의 leg2 공백 replay — consensus-C(#2329, 설계 SSoT #2323).
+ *
+ * `evidence_20260812_replay.test.ts`(#2321)가 다룬 것은 lock 활성 trip의 device-sync-stale
+ * 4중 게이트 회귀였다. 본 파일은 그 evidence의 다른 절반 — 오토락 재부착이 삭제된(#2154) 이후
+ * 환승 직후 leg2가 진짜 lockless가 되는 구조 자체를 재현한다: C 토글(infoModeEnabled) OFF인
+ * lockless trip은 `runLocklessIntermediate`(C 토글 전용 경로)로 진입하지 못해 종전엔
+ * `stats.lockMissing`만 누적된 채 advance/fire가 영구 0이었다(08-12 실측: 25분 침묵 + 알림 0건).
+ *
+ * 08-12 저녁 페이퍼 시뮬레이션(#2323 설계안 (7)) 파라미터를 그대로 사용한다:
+ *   W(transferTimeSec)=278s(건대입구 2→7), hop 80s. 두 cron cycle(80s 간격) 연속 match로
+ *   confirmed에 도달 — CONFIRM_MIN_MATCH_COUNT=2.
+ *
+ * acceptance:
+ *  - confirmed 전(cycle 1, match=1) → advance/fire 0.
+ *  - confirmed 후(cycle 2, match=2) → advance 1 + 기존 `fireArvlCdStationPush` 재사용 발사 1건
+ *    (신규 emitter 없음 — dedup/APNs 전송 경로 전부 arvlCd fire path 그대로).
+ */
+
+import { generateKeyPair, exportPKCS8 } from 'jose';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetApnsJwtCache, type ApnsConfig } from '../apns';
+import { runScheduled, type ScheduledDeps, type ScheduledStats } from '../scheduled';
+import { SeoulArrivalClient } from '../seoul';
+import { putTrip } from '../trips';
+import { seedSsot, writeSsot } from '../tripPositionSsot';
+import type { Env, Trip } from '../types';
+import { InMemoryKV } from './inMemoryKv';
+
+let apnsConfig: ApnsConfig;
+
+beforeAll(async () => {
+  const { privateKey } = await generateKeyPair('ES256');
+  const pem = await exportPKCS8(privateKey);
+  apnsConfig = {
+    keyId: 'K',
+    teamId: 'T',
+    privateKeyPem: pem,
+    bundleId: 'com.example.app',
+  };
+});
+
+beforeEach(() => resetApnsJwtCache());
+
+const T0 = 1_700_000_000_000;
+const HOP_MS = 80_000;
+
+const APNS_HOSTS = {
+  production: 'api.push.apple.com',
+  sandbox: 'api.sandbox.push.apple.com',
+} as const;
+
+function makeEnv(kv: InMemoryKV): Env {
+  return {
+    TRIPS: kv as unknown as KVNamespace,
+    APNS_HOST: APNS_HOSTS.production,
+    APNS_HOST_SANDBOX: APNS_HOSTS.sandbox,
+    SEOUL_API_HOST: 'seoul.api',
+    SEOUL_API_KEY: 'KEY',
+    APNS_KEY_ID: 'K',
+    APNS_TEAM_ID: 'T',
+    APNS_PRIVATE_KEY: apnsConfig.privateKeyPem,
+    APNS_BUNDLE_ID: 'com.example.app',
+  };
+}
+
+// 장암행 후보 trainCode '8801' — 7호선 상행(중곡 방향), ETA는 cycle마다 80s씩 카운트다운
+// (실제 열차가 일관되게 접근 중이라는 신호. 예측 절대 도착시각은 두 cycle 모두 T0+300s로 동일).
+function makeConsensusSeoul(now: number, etaSeconds: number): SeoulArrivalClient {
+  return new SeoulArrivalClient({
+    apiKey: 'K',
+    host: 'h',
+    now: () => now,
+    fetchImpl: (async () =>
+      new Response(
+        JSON.stringify({
+          realtimeArrivalList: [
+            {
+              barvlDt: String(etaSeconds),
+              recptnDt: '',
+              updnLine: '상행',
+              trainLineNm: '중곡',
+              btrainNo: '8801',
+              subwayNm: '지하철7호선',
+              arvlCd: 3,
+            },
+          ],
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch,
+  });
+}
+
+function makeTrip(overrides: Partial<Trip> = {}): Trip {
+  return {
+    token: 'evidence-0812-consensus-tok',
+    route: { type: 'direct', line: '7', stops: 4 },
+    destination: '중곡',
+    waypoints: [{ stationName: '중곡', line: '7', kind: 'intermediate' }],
+    boardingLock: undefined,
+    infoModeEnabled: false,
+    subsurface: true,
+    expiresAt: T0 + 60 * 60_000,
+    createdAt: T0 - 30 * 60_000,
+    alarmAtEpochMs: T0 - 60_000,
+    ...overrides,
+  };
+}
+
+async function runOnce(
+  kv: InMemoryKV,
+  seoul: SeoulArrivalClient,
+  fetchImpl: ReturnType<typeof vi.fn>,
+  now: number,
+): Promise<ScheduledStats> {
+  return runScheduled(makeEnv(kv), {
+    seoul,
+    apnsConfig,
+    apnsHosts: APNS_HOSTS,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+    now: () => now,
+    generatePushId: () => 'evidence-0812-consensus-push',
+  } satisfies ScheduledDeps);
+}
+
+describe('evidence 2026-08-12 leg2 공백 replay — consensus-train confirmed-only fire (#2329)', () => {
+  it('T0 → cycle1(match=1, confirmed 전) fire 0 → cycle2(match=2, confirmed) 중곡 imminent 1회 발사', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip();
+    await putTrip(kv as unknown as KVNamespace, trip);
+    const ssot = await seedSsot(kv as unknown as KVNamespace, trip.token, '건대입구', {
+      expiresAt: trip.expiresAt,
+    });
+    ssot.motionState = 'moving';
+    ssot.lastAdvanceAt = T0;
+    ssot.lastDeviceSyncAt = T0;
+    await writeSsot(kv as unknown as KVNamespace, ssot, { expiresAt: trip.expiresAt });
+
+    // cycle 1 — T0+80s. 후보 최초 관측(init). match=1(<CONFIRM_MIN_MATCH_COUNT=2) → confirmed 전.
+    const now1 = T0 + HOP_MS;
+    const fetchImpl1 = vi.fn(async () => new Response('', { status: 200 }));
+    const stats1 = await runOnce(kv, makeConsensusSeoul(now1, 220), fetchImpl1, now1);
+    expect(stats1.arvlCdFireFired).toBe(0);
+    expect(fetchImpl1).not.toHaveBeenCalled(); // confirmed 전 — 기존 fire path(APNs 전송) 미도달.
+
+    const afterCycle1 = await ((await import('../tripPositionSsot')).readSsot(
+      kv as unknown as KVNamespace,
+      trip.token,
+    ));
+    expect(afterCycle1?.legConsensus?.status).toBe('tracking');
+
+    // cycle 2 — T0+160s. 같은 실차가 80s만큼 더 카운트다운(ETA 220→140, 절대 도착시각 동일)
+    // → deltaSec≈0 → match=2 → confirmed. confirmed 후에만 advance+fire 1회.
+    const now2 = T0 + 2 * HOP_MS;
+    const fetchImpl2 = vi.fn(async () => new Response('', { status: 200 }));
+    const stats2 = await runOnce(kv, makeConsensusSeoul(now2, 140), fetchImpl2, now2);
+
+    expect(stats2.arvlCdFireFired).toBe(1);
+    expect(stats2.arvlCdFireSuccess).toBe(1);
+    expect(fetchImpl2).toHaveBeenCalled(); // 기존 arvlCd alert push 경로(신규 emitter 없음) 재사용.
+
+    const afterCycle2 = await ((await import('../tripPositionSsot')).readSsot(
+      kv as unknown as KVNamespace,
+      trip.token,
+    ));
+    expect(afterCycle2?.legConsensus?.status).toBe('confirmed');
+    expect(afterCycle2?.legConsensus?.confirmedTrainCode).toBe('8801');
+    expect(afterCycle2?.lockSuggestion?.confidence).toBe('consensus');
+    // lock 승격 금지 — trip.boardingLock은 여전히 미부착.
+    const storedTrip = JSON.parse((await kv.get(`trip:${trip.token}`)) ?? 'null') as Trip | null;
+    expect(storedTrip?.boardingLock).toBeUndefined();
+  });
+
+  it('무회귀 — infoModeEnabled=true(C 토글 ON) trip은 기존 runLocklessIntermediate 경로 그대로(consensus 미개입)', async () => {
+    const kv = new InMemoryKV();
+    const trip = makeTrip({ infoModeEnabled: true });
+    await putTrip(kv as unknown as KVNamespace, trip);
+    const ssot = await seedSsot(kv as unknown as KVNamespace, trip.token, '건대입구', {
+      expiresAt: trip.expiresAt,
+    });
+    ssot.motionState = 'moving';
+    await writeSsot(kv as unknown as KVNamespace, ssot, { expiresAt: trip.expiresAt });
+
+    const now1 = T0 + HOP_MS;
+    const fetchImpl1 = vi.fn(async () => new Response('', { status: 200 }));
+    await runOnce(kv, makeConsensusSeoul(now1, 220), fetchImpl1, now1);
+
+    const after = await ((await import('../tripPositionSsot')).readSsot(
+      kv as unknown as KVNamespace,
+      trip.token,
+    ));
+    // consensus 경로가 개입하지 않았으므로 legConsensus는 여전히 미설정.
+    expect(after?.legConsensus).toBeUndefined();
+  });
+});

--- a/backend/alarm-worker/src/advanceTripPosition.ts
+++ b/backend/alarm-worker/src/advanceTripPosition.ts
@@ -57,7 +57,17 @@
 
 import type { ArchFlagValue } from './archFlag';
 import { evaluateConsensusGate, type StationEnvironment } from './consensusGate';
+import { hashTripToken } from './sentry';
 import type { ArrivalEntry, PositionEntry } from './seoul';
+import {
+  initLegConsensus,
+  stepLegConsensus,
+  type LegConsensusEvent,
+  type LegConsensusRecord,
+  type LegConsensusTick,
+  type ObservedDeparture,
+} from './transferLegConsensus';
+import { recordTripEvent } from './tripEventLog';
 import {
   appendAlarmEvent,
   computeAlarmId,
@@ -94,6 +104,10 @@ export const STRONG_EVIDENCE_TYPES: ReadonlySet<EvidenceType> = new Set<Evidence
   'cellular-tech-change',
   'position-train',
   'accel-fingerprint',
+  // #2329 (consensus-C) — transferLegConsensus 상태기계가 confirmed로 수렴한 evidence.
+  // gate #5b가 legConsensus.status==='confirmed'를 별도로 강제하므로 seedOverride 등에서
+  // strong 취급해도 false positive 우려 없음(이미 2+ waypoint match 확정 신호).
+  'consensus-train',
 ]);
 
 /**
@@ -163,7 +177,8 @@ export type AdvanceBlockReason =
   | 'lockless-arvlcd-alone'
   | 'position-train-jump'
   | 'position-train-stale'
-  | 'arc-overshoot';
+  | 'arc-overshoot'
+  | 'consensus-not-confirmed';
 
 /** advance 호출 결과 — caller가 SSoT 후속 작업(fire 발사 등)을 진행할지 결정. */
 export interface AdvanceOutcome {
@@ -336,6 +351,10 @@ export function buildSignalsFromEvidence(
     positionTrainAgreement: evidence.type === 'position-train' ? true : undefined,
     wifiSsidMatch: evidence.type === 'wifi-ssid-match' ? true : undefined,
     cellularEnvironmentVote: evidence.cellularTechVote,
+    // #2329 (consensus-C) — consensus-train evidence는 그 자체가 underground lockAttachable
+    // surrogate(strong G, consensusGate.ts). gate #5b가 legConsensus confirmed를 이미 강제하므로
+    // 여기서는 evidence.type만으로 forward — 이중 확인 불필요.
+    consensusConfirmed: evidence.type === 'consensus-train' ? true : undefined,
   };
 }
 
@@ -433,10 +452,32 @@ export async function advanceTripPosition(
     return { result: 'blocked', blockReason: 'time-only-forbidden', ssot };
   }
 
-  // #5 Train identity 게이트
-  if (lock !== undefined && evidence.type === 'arvlcd-confirmed-train') {
+  // #5 Train identity 게이트 — lock 활성 시 arvlcd-confirmed-train과 consensus-train
+  // (#2329, consensus-C) 모두 lock.trainCode 일치를 강제한다.
+  if (
+    lock !== undefined &&
+    (evidence.type === 'arvlcd-confirmed-train' || evidence.type === 'consensus-train')
+  ) {
     if (evidence.arvlcdTrainCode !== lock.trainCode) {
       return { result: 'blocked', blockReason: 'train-mismatch', ssot };
+    }
+  }
+
+  // #5b consensus-train 게이트 (#2329, consensus-C, 설계 SSoT #2323) — legConsensus 상태기계가
+  // 'confirmed'로 수렴했을 때만 통과. tracking/ambiguous/demoted/suppressed 또는 상태기계
+  // 미시작(undefined)은 전부 blocked — "confirmed에서만 alert 발사" 정책의 SSoT 강제 지점.
+  // confirmedTrainCode와 evidence.arvlcdTrainCode가 둘 다 있으면 일치까지 확인(caller가 다른
+  // trainCode를 잘못 forward하는 회귀 방지). demote 발생 직후(status='demoted')는 발사권을
+  // 즉시 회수 — 이 게이트가 재평가마다 항상 재검증하므로 별도 revoke 로직 불필요.
+  if (evidence.type === 'consensus-train') {
+    const consensus = ssot.legConsensus;
+    const confirmed =
+      consensus !== undefined &&
+      consensus.status === 'confirmed' &&
+      (evidence.arvlcdTrainCode === undefined ||
+        evidence.arvlcdTrainCode === consensus.confirmedTrainCode);
+    if (!confirmed) {
+      return { result: 'blocked', blockReason: 'consensus-not-confirmed', ssot };
     }
   }
 
@@ -607,6 +648,18 @@ function deriveLockSuggestion(input: {
       decidedAt: evidence.ts,
     };
   }
+  // consensus (#2329, consensus-C) — legConsensus 상태기계 confirmed. gate #5b가 이미 confirmed +
+  // trainCode 일치를 강제했으므로 여기 도달한 evidence.arvlcdTrainCode는 신뢰 가능. lock 승격은
+  // 하지 않는다 — confidence='consensus'는 device 측에서 high/medium과 별도로 다뤄지는 표식.
+  if (evidence.type === 'consensus-train' && evidence.arvlcdTrainCode) {
+    return {
+      stationId: candidateStationId,
+      trainCode: evidence.arvlcdTrainCode,
+      lineId: waypointLine,
+      confidence: 'consensus',
+      decidedAt: evidence.ts,
+    };
+  }
   return null;
 }
 
@@ -660,4 +713,77 @@ function appendUnique(arr: readonly string[], next: string): string[] {
   // motionEvidence와 동일한 ring buffer cap을 적용해 KV row 폭주 방지.
   while (copy.length > MOTION_EVIDENCE_CAP) copy.shift();
   return copy;
+}
+
+/**
+ * #2329 (consensus-C, 설계 SSoT #2323) — `transferLegConsensus.ts`(#2327) 상태기계 1 tick 진행 +
+ * SSoT 영속 + D1 trip_events(`consensus-confirm`/`consensus-demote`/`consensus-suppress`) 기록을
+ * 한 곳에 묶는 wire 진입점. caller(scheduled.ts)는 매 cron cycle 관측치를 `LegConsensusTick`으로
+ * forward하기만 하면 된다 — 상태기계 mutate/write/D1 append는 본 함수가 전담한다(ADR-017 §단일
+ * mutation 진입점 정신을 legConsensus 서브필드에도 동일 적용).
+ *
+ * `ssot.legConsensus`가 없으면 `init`으로 최초 상태기계를 만든다(caller가 T0/W(transferTimeSec)/
+ * H(headwaySec)/observedDepartures를 데이터 주도로 산출해 전달). 이미 있으면 `init`은 무시.
+ *
+ * `suppressFloorEpochMs`(#2155 floor 공급)는 별도 write 없이 `record` 자체(=ssot.legConsensus)에
+ * 이미 포함되어 있다 — apns.ts silent push payload가 ssot 전체를 forward할 때 함께 실려 device로
+ * 전달된다(consumption은 #2155 범위, 본 함수는 supply만).
+ *
+ * trip 부재(getTrip null)면 expiresAt 힌트 없이 write — 이론상 SSoT는 있는데 trip이 사라진 경우는
+ * 발생하지 않지만(trip 삭제 시 SSoT도 함께 삭제), defense-in-depth로 graceful 처리.
+ */
+export async function applyLegConsensusTick(
+  kv: KVNamespace,
+  db: D1Database | undefined,
+  token: string,
+  input: {
+    init?: {
+      t0EpochMs: number;
+      transferTimeSec: number;
+      headwaySec: number;
+      observedDepartures: readonly ObservedDeparture[];
+    };
+    tick: LegConsensusTick;
+    /** D1 trip_events meta stamp용 — 관측 대상 station/line. */
+    station?: string;
+    line?: string;
+  },
+): Promise<{ record: LegConsensusRecord; events: LegConsensusEvent[] } | null> {
+  const ssot = await readSsot(kv, token);
+  if (ssot === null) return null;
+
+  const existing = ssot.legConsensus;
+  const seed = existing ?? (input.init ? initLegConsensus(
+    input.init.t0EpochMs,
+    input.init.transferTimeSec,
+    input.init.headwaySec,
+    input.init.observedDepartures,
+    input.tick.now,
+  ) : undefined);
+  if (seed === undefined) return null;
+
+  const { record, events } = stepLegConsensus(seed, input.tick);
+  const next: TripPositionSSoT = { ...ssot, legConsensus: record };
+
+  const trip = await getTrip(kv, token);
+  await writeSsot(kv, next, trip ? { expiresAt: trip.expiresAt } : undefined);
+
+  if (db) {
+    const tokenHash = hashTripToken(token);
+    for (const event of events) {
+      await recordTripEvent(
+        db,
+        {
+          tokenHash,
+          kind: event.kind,
+          station: input.station,
+          line: input.line,
+          meta: { trainCode: event.trainCode, ...event.meta },
+        },
+        input.tick.now,
+      );
+    }
+  }
+
+  return { record, events };
 }

--- a/backend/alarm-worker/src/apns.ts
+++ b/backend/alarm-worker/src/apns.ts
@@ -231,6 +231,14 @@ export interface SilentPushSsotPayload {
    * 두 번 발사되는 X1/X2/X6 회귀 차단.
    */
   alarmEvents?: ReadonlyArray<AlarmEventPayload>;
+  /**
+   * #2329 (consensus-C, 설계 SSoT #2323) — legConsensus suppress 시 최후 생존 후보 최늦 T_dep
+   * 기반 도착 추정(epoch ms). #2155(OS 사전예약 최후 안전망 1건 축소)가 소비할 floor 입력 —
+   * 본 필드는 supply만 담당하며 device 측 consumption은 #2155 범위(별도 이슈, 미착륙).
+   *
+   * 부재 시 wire 자연 누락(legConsensus 미시작 / suppress 아닌 상태 / 구 backend 호환).
+   */
+  legConsensusFloorEpochMs?: number;
 }
 
 /**
@@ -257,7 +265,7 @@ export interface LockSuggestionPayload {
   stationId: string;
   trainCode: string;
   lineId: string;
-  confidence: 'high' | 'medium' | 'low';
+  confidence: 'high' | 'medium' | 'low' | 'consensus';
   decidedAt: number;
 }
 

--- a/backend/alarm-worker/src/consensusGate.ts
+++ b/backend/alarm-worker/src/consensusGate.ts
@@ -68,6 +68,13 @@ export type StationEnvironment = 'surface' | 'underground' | 'mixed' | 'unknown'
  *     - 'surface'      : 4G/5G 잡힘 → 지상 환경 vote (strong F)
  *     - 'underground'  : 2G/3G fallback → 지하 환경 vote (strong F)
  *     - 'unknown'/미전송 : vote 미투표 (정책 영향 0)
+ *
+ * - `consensusConfirmed`: #2329 (consensus-C, 설계 SSoT #2323) — `transferLegConsensus.ts`
+ *   상태기계가 'confirmed'로 수렴했다는 surrogate 신호(strong G). underground 분기에서
+ *   `lockAttachable`(=lock 부착, strong E)의 대체 surrogate로 취급한다 — 2+ waypoint 연속
+ *   match(±90s) + mismatch=0 확정은 실제 lock 부착과 동급의 강 신호이기 때문이다(설계 SSoT
+ *   (1) "confirmed = lockAttachable surrogate"). true일 때만 의미 있고, false/undefined는
+ *   기존 정책 무영향(다른 OR 분기가 그대로 평가된다).
  */
 export interface ConsensusSignals {
   gateOutcome: GateOutcome;
@@ -76,6 +83,7 @@ export interface ConsensusSignals {
   positionTrainAgreement?: boolean;
   wifiSsidMatch?: boolean;
   cellularEnvironmentVote?: 'surface' | 'underground' | 'unknown';
+  consensusConfirmed?: boolean;
 }
 
 /**
@@ -162,7 +170,11 @@ export function evaluateConsensusGate(
     const strongBE = signals.arrivalSignalPresent && signals.lockAttachable;
     const strongCB = (signals.positionTrainAgreement ?? false) && signals.arrivalSignalPresent;
     const strongDB = (signals.wifiSsidMatch ?? false) && signals.arrivalSignalPresent;
-    if (strongBE || strongCB || strongDB) return { pass: true, environment };
+    // #2329 (consensus-C) — consensusConfirmed는 lockAttachable(strong E) surrogate.
+    // arrival(B) 없이도 confirmed 단독으로 통과시킨다 — 상태기계 자체가 이미 다중 waypoint
+    // match(±90s)/mismatch=0 확정이라 arrival 신호 재요구는 이중 게이트(설계 SSoT (1)).
+    const strongG = signals.consensusConfirmed === true;
+    if (strongBE || strongCB || strongDB || strongG) return { pass: true, environment };
     return { pass: false, environment, reason: 'environment-no-gps-consensus' };
   }
   // mixed/unknown: 보수적 — base 9단 + arrival + lockAttachable 모두 통과 시에만.

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -45,8 +45,12 @@ import {
 import { matchLine } from './lineAlias';
 import { computeAllowedLines, type StationEnvironment } from './consensusGate';
 import { attachTrainCodeForLeg } from './lockSwap';
+import { filterCandidateDirection, filterCandidateLine } from './legCandidateFilters';
+import { getTransferSeconds } from '../../../src/shared/utils/transferTimes';
+import type { ObservedDeparture } from './transferLegConsensus';
 import {
   advanceTripPosition,
+  applyLegConsensusTick,
   mapEvidenceEnvironment,
   type AdvanceBlockReason,
   type AdvanceEvidence,
@@ -1365,6 +1369,18 @@ export async function runScheduled(env: Env, deps: ScheduledDeps): Promise<Sched
         }
         continue;
       }
+      // #2329 (consensus-C, 설계 SSoT #2323) — C 토글 OFF(infoModeEnabled=false) lockless leg는
+      // `runLocklessIntermediate`(위 분기)로 진입하지 못해 종전엔 이 지점에서 아무 진행/발사 없이
+      // `lockMissing`만 누적됐다(08-12 25분 침묵 evidence의 leg2 공백). `!trip.infoModeEnabled`
+      // 조건으로 위 분기와 상호 배타적 — 이중 발사 경로가 겹치지 않는다.
+      if (!trip.infoModeEnabled && waypoint.kind === 'intermediate') {
+        try {
+          await tryFireConsensusTrainLeg(trip, waypoint, env, deps, stats, now, log, generatePushId);
+        } catch (e) {
+          stats.errors += 1;
+          log('consensus-fire: poll error', { error: String(e), token: trip.token.slice(0, 8) });
+        }
+      }
       stats.lockMissing += 1;
       log('boarding-lock: skip cycle (lock missing or expired)', {
         token: trip.token.slice(0, 8),
@@ -1888,6 +1904,10 @@ export function toSilentPushSsot(
     // #1705 — currentStationLine forward. 부재(legacy v1 row) 시 wire 자연 누락.
     ...(ssot.currentStationLine !== undefined
       ? { currentStationLine: ssot.currentStationLine }
+      : {}),
+    // #2329 (consensus-C) — legConsensus suppress floor forward (#2155 소비 대상, supply만).
+    ...(ssot.legConsensus?.suppressFloorEpochMs !== undefined
+      ? { legConsensusFloorEpochMs: ssot.legConsensus.suppressFloorEpochMs }
       : {}),
   };
 }
@@ -4150,6 +4170,155 @@ export async function maybeReschedulePush(
     await putTrip(env.TRIPS, trip);
   }
   return { cleanedUp: false };
+}
+
+/** #2329 (consensus-C) — legConsensus 미 wire 시 headway 데이터 부재 conservative fallback (초). */
+export const CONSENSUS_DEFAULT_HEADWAY_SEC = 300;
+
+/**
+ * #2329 (consensus-C, 설계 SSoT #2323) — lock 없는 leg(환승 직후, 오토락 재부착 미실행 — #2154
+ * 삭제 대상 chain)에서 `transferLegConsensus` 상태기계로 후보 열차를 추적하고, confirmed 상태에
+ * 도달했을 때만 기존 `fireArvlCdStationPush`(dedup 포함)를 재사용해 imminent alert를 발사한다.
+ *
+ * 신규 emitter 없음 — 확정된 trainCode를 `BoardingLockMeta` 모양의 synthetic lock으로 감싸
+ * 기존 arvlCd fire path에 그대로 위임한다(dedup key도 trainCode 기반이라 자연 중복 방지).
+ * `runLocklessIntermediate`(C 토글 ON 전용)와는 caller가 `!trip.infoModeEnabled`로 상호
+ * 배타적으로 호출해 이중 발사 경로가 원천적으로 겹치지 않는다.
+ *
+ * candidate 관측: waypoint arrivals(이미 이 cycle에서 필요한 신규 fetch — lockMissing 분기는
+ * 기존에 Seoul 호출이 0건이었다)를 line/direction 필터(#2328, legCandidateFilters)로 사전 배제한
+ * 뒤 `transferLegConsensus` 상태기계에 forward한다. 각 candidate의 departureEpochMs는 상태기계
+ * 최초 관측 시점의 예측 도착 epoch로 고정되고(engine이 재기록하지 않음), 이후 tick의 deltaSec은
+ * "이번 tick 예측 - 최초 예측"으로 산출 — 같은 실차가 일관되게 카운트다운하면 0에 수렴(match),
+ * 후보가 바뀌거나 사라지면 발산(mismatch/missed)한다.
+ *
+ * confirmed 이벤트가 발생한 tick에서만 advance+fire를 시도한다(매 tick 재발사 방지 — dedup으로도
+ * 막히지만 SSoT write/advance 비용을 아낀다).
+ */
+async function tryFireConsensusTrainLeg(
+  trip: Trip,
+  waypoint: Waypoint,
+  env: Env,
+  deps: ScheduledDeps,
+  stats: ScheduledStats,
+  now: number,
+  log: Logger,
+  generatePushId: () => string,
+): Promise<void> {
+  if (waypoint.kind !== 'intermediate') return;
+
+  const ssot = await readSsot(env.TRIPS, trip.token, { cacheTtl: SSOT_CRON_READ_CACHE_TTL_SEC });
+  if (ssot === null || !ssot.currentStationId) return;
+
+  const arrivals = await deps.seoul.fetchArrivals(waypoint.stationName);
+  if (arrivals.length === 0) return;
+
+  const candidates: { trainCode: string; arvlCd: number; arrivalSeconds: number }[] = [];
+  for (const a of arrivals) {
+    if (a.arvlCd === null) continue;
+    if (!matchLine(a.subwayNm, waypoint.line)) continue;
+    if (filterCandidateLine(waypoint.line, trip.route, trip.waypoints).kind === 'reject') continue;
+    if (
+      filterCandidateDirection(waypoint.line, a.isUp, ssot.currentStationId, waypoint.stationName)
+        .kind === 'reject'
+    ) {
+      continue;
+    }
+    candidates.push({ trainCode: a.trainCode, arvlCd: a.arvlCd, arrivalSeconds: a.arrivalSeconds });
+  }
+  if (candidates.length === 0) return;
+
+  const observedDepartures: ObservedDeparture[] = candidates.map((c) => ({
+    trainCode: c.trainCode,
+    departureEpochMs: now + c.arrivalSeconds * 1000,
+  }));
+
+  const existingBaseline = new Map(
+    (ssot.legConsensus?.candidates ?? []).map((c) => [c.trainCode, c.departureEpochMs]),
+  );
+  const observations = observedDepartures.map((d) => {
+    const baseline = existingBaseline.get(d.trainCode);
+    return {
+      trainCode: d.trainCode,
+      deltaSec: baseline !== undefined ? (d.departureEpochMs - baseline) / 1000 : 0,
+    };
+  });
+
+  // frontend LineNumber(엄격 union)와 backend LineNumber(=string) 어휘 차이 — legDirection.ts/
+  // legCandidateFilters.ts와 동일한 caster 패턴(런타임은 `===` 비교라 안전).
+  const transferTimeSec = getTransferSeconds(
+    (ssot.currentStationLine ?? waypoint.line) as Parameters<typeof getTransferSeconds>[0],
+    waypoint.line as Parameters<typeof getTransferSeconds>[1],
+    ssot.currentStationId,
+  );
+
+  const outcome = await applyLegConsensusTick(env.TRIPS, env.DB, trip.token, {
+    init: ssot.legConsensus
+      ? undefined
+      : {
+          t0EpochMs: ssot.lastAdvanceAt > 0 ? ssot.lastAdvanceAt : now,
+          transferTimeSec,
+          headwaySec: CONSENSUS_DEFAULT_HEADWAY_SEC,
+          observedDepartures,
+        },
+    tick: { now, observations },
+    station: waypoint.stationName,
+    line: waypoint.line,
+  });
+  if (outcome === null) return;
+
+  const justConfirmed = outcome.events.some((e) => e.kind === 'consensus-confirm');
+  if (!justConfirmed || outcome.record.confirmedTrainCode === undefined) return;
+
+  const confirmedEntry = candidates.find((c) => c.trainCode === outcome.record.confirmedTrainCode);
+  if (!confirmedEntry) return;
+
+  const advanceOutcome = await advanceTripPosition(
+    env.TRIPS,
+    trip.token,
+    waypoint.stationName,
+    {
+      type: 'consensus-train',
+      stationId: waypoint.stationName,
+      ts: now,
+      environment: deriveEvidenceEnvironment(trip),
+      arvlcdTrainCode: outcome.record.confirmedTrainCode,
+      arvlCd: confirmedEntry.arvlCd,
+    },
+    { gatePassed: true, lockAttachable: false, archFlag: deps.archFlag },
+  );
+  if (advanceOutcome.result !== 'advanced') {
+    stats.arvlCdFireBlocked += 1;
+    log('consensus-fire: blocked', {
+      token: trip.token.slice(0, 8),
+      trainCode: outcome.record.confirmedTrainCode,
+      station: waypoint.stationName,
+      reason: advanceOutcome.blockReason satisfies AdvanceBlockReason | undefined,
+    });
+    return;
+  }
+  stats.arvlCdFireFired += 1;
+
+  const syntheticLock: BoardingLockMeta = {
+    trainCode: outcome.record.confirmedTrainCode,
+    line: waypoint.line,
+    subwayId: '',
+    selectedDepartureTime: now,
+    segmentStations: [waypoint.stationName],
+    expiresAt: trip.expiresAt,
+  };
+  await fireArvlCdStationPush({
+    trip,
+    waypoint,
+    lock: syntheticLock,
+    arvlCd: confirmedEntry.arvlCd,
+    env,
+    deps,
+    stats,
+    now,
+    log,
+    generatePushId,
+  });
 }
 
 /**

--- a/backend/alarm-worker/src/tripPositionSsot.ts
+++ b/backend/alarm-worker/src/tripPositionSsot.ts
@@ -34,6 +34,7 @@
  */
 
 import { assertKvCacheTtl, CRON_READ_CACHE_TTL_SEC } from './kvConsistency';
+import type { LegConsensusRecord } from './transferLegConsensus';
 import type { Trip } from './types';
 
 /**
@@ -65,7 +66,8 @@ export type EvidenceType =
   | 'accel-fingerprint'
   | 'time-only'
   | 'manual-user-intent'
-  | 'seed-override';
+  | 'seed-override'
+  | 'consensus-train';
 
 /**
  * Evidence가 어느 데이터 출처에서 왔는지. T2 합의 게이트가 source 분산을 평가할 때 사용.
@@ -167,9 +169,13 @@ export async function computeAlarmId(
  * device는 기존 9-AND gate fallback으로 동작 (graceful, backward-compat).
  *
  * confidence:
- *   - 'high'   : arvlcd-confirmed-train evidence (trainCode/line 명확)
- *   - 'medium' : position-train / wifi-ssid-match evidence (train 후보 좁힘 + 정합)
- *   - 'low'    : 향후 cellular/accel single signal 채택 (현재 미사용 — 미래 확장 slot)
+ *   - 'high'      : arvlcd-confirmed-train evidence (trainCode/line 명확)
+ *   - 'medium'    : position-train / wifi-ssid-match evidence (train 후보 좁힘 + 정합)
+ *   - 'consensus' : #2329 (consensus-C) — transferLegConsensus 상태기계가 confirmed로 수렴한
+ *                   trainCode. lock 승격은 절대 하지 않는다 — device `useLockSuggestion`이
+ *                   기존 high/medium과 동일하게 reader-only 채택하되, 오토락 부활(#2154에서
+ *                   삭제 대상인 자동 lock 부착 chain)과 구조적으로 구분되는 confidence 값이다.
+ *   - 'low'       : 향후 cellular/accel single signal 채택 (현재 미사용 — 미래 확장 slot)
  */
 export interface LockSuggestion {
   /** 추론된 출발/현재 station identifier. */
@@ -179,7 +185,7 @@ export interface LockSuggestion {
   /** 노선 (Waypoint.line / BoardingLockMeta.line과 동일 표기). */
   lineId: string;
   /** 추론 신뢰도 — device가 채택 정책에 사용 가능 (현 PR은 high/medium 모두 채택). */
-  confidence: 'high' | 'medium' | 'low';
+  confidence: 'high' | 'medium' | 'low' | 'consensus';
   /** 추론 결정 시각 (epoch ms). device가 staleness 판단 가능. */
   decidedAt: number;
 }
@@ -258,6 +264,18 @@ export interface TripPositionSSoT {
    * 다른 optional SSoT 필드와 동일 backward-compat 정책).
    */
   lastDeviceSyncAt?: number;
+  /**
+   * #2329 (consensus-C, 설계 SSoT #2323) — `transferLegConsensus.ts`(#2327) 상태기계 스냅샷.
+   *
+   * lockless leg(환승 직후 lock 미부착 구간)에서 후보 열차 관측/판정 진행 상태를 trip KV 객체
+   * 내부에 보존한다(별도 KV row 금지 — #2073 cron KV quota lesson). caller(scheduled.ts)가
+   * `stepLegConsensus`로 매 tick 갱신 후 write. `status==='confirmed'`일 때만
+   * `advanceTripPosition`의 'consensus-train' evidence 게이트가 통과한다.
+   *
+   * 구 backend 호환을 위해 optional — v3 이하 row 또는 leg에 consensus 추적이 시작되지 않은
+   * trip은 undefined.
+   */
+  legConsensus?: LegConsensusRecord;
   /**
    * schemaVersion. 향후 마이그레이션 분기용.
    * v1: 최초 스키마.


### PR DESCRIPTION
## Summary

Closes #2329

설계 SSoT: #2323 2026-08-13 설계안 코멘트 (1)·(4). consensus-A(#2327 엔진)·consensus-B(#2328 필터)를 소비해 `advanceTripPosition`/`consensusGate`/fire path에 wire한다.

- `tripPositionSsot.ts`: 신규 `EvidenceType='consensus-train'` + `legConsensus?: LegConsensusRecord` 필드(trip KV 객체 내부, 별도 row 금지 — #2073). `LockSuggestion.confidence`에 `'consensus'` 추가.
- `advanceTripPosition.ts`: `STRONG_EVIDENCE_TYPES += consensus-train`. 게이트 #5(train identity) 확장 — lock 활성 시 `consensus-train`도 `lock.trainCode` 일치 강제. 신규 게이트 #5b — `legConsensus.status==='confirmed'`일 때만 통과(confirmed 전 fire 0, demote 시 발사권 즉시 회수). `deriveLockSuggestion`에 `confidence='consensus'` 분기(lock 승격 절대 금지 — `trip.boardingLock` mutate 없음). `applyLegConsensusTick` — 상태기계 1 tick 진행 + SSoT 영속 + D1 `trip_events`(consensus-confirm/demote/suppress) 기록 단일 wire 진입점.
- `consensusGate.ts`: `ConsensusSignals.consensusConfirmed`(strong G) 추가. underground 분기에서 confirmed를 lockAttachable(strong E) surrogate로 취급해 arrival/lockAttachable 없이도 단독 통과.
- `apns.ts`: `SilentPushSsotPayload.legConsensusFloorEpochMs` 추가(#2155 floor 공급 — consumption은 별도 이슈, 미착륙). `LockSuggestionPayload.confidence`에 `'consensus'` 추가.
- `scheduled.ts`: `toSilentPushSsot`이 `legConsensus.suppressFloorEpochMs`를 forward. 신규 `tryFireConsensusTrainLeg` — C 토글 OFF lockless leg(오토락 재부착 미실행 시 진짜 lockless가 되는 leg2 공백, 08-12 25분 침묵 evidence)에서 `legCandidateFilters`(#2328)로 후보를 필터링해 `transferLegConsensus` 상태기계에 공급하고, confirmed 시에만 **기존** `fireArvlCdStationPush`(dedup 포함)를 재사용해 발사(신규 emitter 없음). `runLocklessIntermediate`(C 토글 ON)와 `!trip.infoModeEnabled`로 상호 배타적 — 이중 발사 경로 없음. **auto-end 가드 블록(#2322 영역)은 미접촉** — diff는 순수 추가(+169 lines, 0 deletions)만.

## TDD red/green

- 신규 게이트 #5/#5b 양방향 시나리오(confirmed 전/후, demote, trainCode 불일치) — `advanceTripPosition.test.ts`
- consensusGate underground surrogate(strong G 단독 통과, false/undefined 무영향) — `consensusGate.test.ts`
- `applyLegConsensusTick` SSoT 저장 + D1 event append — `advanceTripPosition.test.ts`
- 08-12 저녁 evidence replay 확장(`evidence_20260812_replay_consensus.test.ts`, 신규 파일): T0 → cycle1(match=1, confirmed 전) fire 0 → cycle2(match=2, confirmed) 중곡 imminent 1회 발사. C 토글 ON trip은 기존 `runLocklessIntermediate` 경로 그대로(consensus 미개입, 무회귀).
- `npx tsc --noEmit` clean. `npx vitest run --coverage` 전체 3036 tests green(all files coverage threshold pass 확인 완료).

## Wire-completion 5단

1. **Orphan 없음** — 신규 export(`applyLegConsensusTick`, `CONSENSUS_DEFAULT_HEADWAY_SEC`)는 각각 `scheduled.ts`/`advanceTripPosition.test.ts`에서 호출·검증됨.
2. **V/X dashboard** — D1 `trip_events` kind `consensus-confirm/demote/suppress`(wrangler d1 SELECT), `arvlCdFireFired`/`arvlCdFireBlocked` stats(reason=`consensus-not-confirmed` 등, wrangler tail / Cloudflare Dashboard).
3. **의존 PR** — consensus-A #2327(머지됨), consensus-B #2328(머지됨). 둘 다 origin/dev에 이미 포함.
4. **측정 plan** — 다음 검증 탑승에서 잠금 없는 환승 leg(C 토글 OFF)의 `trip_events` consensus 상태전이 재구성 + `arvlCdFireFired` fired>0 + FP 0 확인.
5. **Device verify** — 필요. 검증 탑승 시 lock 없는 환승 leg2(오토락 재부착 미실행 구간)에서 imminent alert 발사 확인. **머지 후 `wrangler deploy` 필요** — device verify는 deploy 이후 다음 검증 탑승에서 진행.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx vitest run --coverage` (backend/alarm-worker) — 3036 passed
- [ ] 머지 후 `wrangler deploy` (backend/alarm-worker)
- [ ] 배포 후 검증 탑승 — 잠금 없는 환승 leg에서 consensus 상태전이 + fire 관측