### PR TITLE
feat(#2330): 명시 탭 전환 + shadow telemetry + 배지/확정정보 UI (consensus-D)

### DIFF
--- a/src/features/alarm/components/BoardingTrainList.tsx
+++ b/src/features/alarm/components/BoardingTrainList.tsx
@@ -52,6 +52,13 @@ const PENDING_TIMEOUT_MS_DEFAULT = 5000;
 const PENDING_BORDER_WIDTH = 2;
 
 /**
+ * consensus-confirmed 매칭 row 하이라이트 테두리 두께 — #2330. PENDING_BORDER_WIDTH(2)보다
+ * 얇게 잡아 "탭 확정 진행 중"(pending)과 "backend 추정 표시"(consensus)를 시각적으로 구분한다.
+ * 둘 다 동시에 true면 pending이 우선(더 두꺼운 표시) — 사용자 명시 탭이 항상 SSoT.
+ */
+const CONSENSUS_HIGHLIGHT_BORDER_WIDTH = 1;
+
+/**
  * #1366 Layer 1 — release-after-tap 보호 윈도우(ms).
  *
  * 사용자가 하차/재탑승을 짧은 간격으로 반복할 때(item 4 8:33 환승역 trip) lockedTrainCode가
@@ -161,6 +168,17 @@ interface Props {
    * 탭 시 다른 row와 동일하게 onSelect(prevTrain.train) 호출 — 신규 분기 없이 기존 lock 생성 경로 재사용.
    */
   prevTrain?: PrevTrainCandidate | null;
+  /**
+   * #2330 (consensus-D, 설계 SSoT #2323 2026-08-13 (3)(6)) — backend legConsensus 엔진이
+   * confirmed(confidence='consensus')한 다음 열차. 매칭되는 row에 "추정" 배지 + "직접 선택" 병기
+   * + 하이라이트를 노출한다. 매칭되는 row가 아직 list에 없으면(도착 목록 지연 등) list-level
+   * "다음 열차 추적 중" 배지만 노출한다.
+   *
+   * **어떤 상태도 "선택됨" 표기 금지** — 오토락 부활 오해(consensus는 lock 승격 금지) 차단.
+   * null/미전달이면 배지/하이라이트 전혀 미노출(기본값) — backend consensus wire(#2329) 결합 전
+   * 상태와 동일한 기존 렌더 100% 보존.
+   */
+  consensusSuggestion?: { trainCode: string } | null;
 }
 
 /**
@@ -207,6 +225,7 @@ export function BoardingTrainList({
   onLockCorrected,
   fallbackReason = null,
   prevTrain = null,
+  consensusSuggestion = null,
 }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
@@ -330,6 +349,10 @@ export function BoardingTrainList({
     const disabled = unreachable || isPendingBlocked;
     // #792: 종착·방면 라벨을 i18n 정규화 + dedup. nextStationLabel 미전달이면 종착만.
     const metaText = buildDirectionMeta(train.destination, nextStationLabel, allStations);
+    // #2330 — consensusSuggestion이 이 row와 매칭되면 하이라이트 + "추정" 배지 + "직접 선택" 병기.
+    // "선택됨" 표기는 절대 사용하지 않는다(오토락 부활 오해 차단) — pending(탭 확정 진행 중)과
+    // 시각적으로 구분되는 별개의 하이라이트 색(accent border, PENDING_BORDER_WIDTH보다 얇게).
+    const isConsensusMatch = consensusSuggestion?.trainCode === train.trainCode;
     return (
       <Pressable
         key={`${testKeyPrefix}-${train.trainCode}`}
@@ -343,6 +366,11 @@ export function BoardingTrainList({
             borderWidth: PENDING_BORDER_WIDTH,
             borderColor: colors.accent,
           },
+          !isPending &&
+            isConsensusMatch && {
+              borderWidth: CONSENSUS_HIGHLIGHT_BORDER_WIDTH,
+              borderColor: colors.accent,
+            },
           { opacity: unreachable ? 0.4 : isPendingBlocked ? 0.5 : 1 },
         ]}
         testID={`${testKeyPrefix}-row-${train.trainCode}`}
@@ -383,6 +411,23 @@ export function BoardingTrainList({
                 <Text style={[typography.mono, { color: colors.muted }]}>{train.trainCode}</Text>
               ))}
           </View>
+          {/* #2330 — consensus-confirmed 매칭 row 전용: "추정" 배지 + "직접 선택" 병기.
+              "선택됨" 텍스트는 절대 사용하지 않는다(오토락 부활 오해 차단, 설계 SSoT #2323 (6)). */}
+          {isConsensusMatch && (
+            <View style={styles.rowConsensusLine}>
+              <View
+                style={[styles.consensusBadge, { borderColor: colors.accent }]}
+                testID={`${testKeyPrefix}-consensus-badge-${train.trainCode}`}
+              >
+                <Text style={[typography.micro, { color: colors.accent, fontWeight: '700' }]}>
+                  {t('home.consensusEstimatedBadge')}
+                </Text>
+              </View>
+              <Text style={[typography.micro, { color: colors.subtle }]}>
+                {t('home.consensusManualSelectHint')}
+              </Text>
+            </View>
+          )}
           {/* #805: sequence(거리/상태)와 시간 라벨은 별도 라인으로 분리.
               sequenceText가 "전역 출발"/"당역 도착"/"4번째 전" 등 어떤 길이여도 시간 라벨이
               같은 줄에서 가려지지 않는다. sequenceText가 비어 있으면 그 라인은 미렌더하지만
@@ -415,6 +460,15 @@ export function BoardingTrainList({
   // #897 Seam A: 가장 가까운 도착 ETA가 lock 시점보다 +180s 이상이면 누적 지연(분) 노출.
   // arrivals는 호출자가 도착시간 오름차순으로 전달한다는 컨벤션을 따른다(#749 카운터와 동일 가정).
   const delayMinutes = computeDelayMinutes(filteredArrivals, initialEtaSeconds);
+
+  // #2330 — consensusSuggestion이 현재 렌더될 row(전열차 포함) 중 매칭되는지 판정.
+  // 매칭되면 해당 row가 "추정" 배지로 상태를 전달하므로 list-level 추적 배지는 생략(중복 방지).
+  // 매칭 안 되면(도착 목록 아직 미도달 등) 추적 중임을 알리는 list-level 배지만 노출.
+  const consensusMatchedInList =
+    consensusSuggestion != null &&
+    (filteredArrivals.some((t) => t.trainCode === consensusSuggestion.trainCode) ||
+      prevTrain?.train.trainCode === consensusSuggestion.trainCode);
+  const showConsensusTrackingBadge = consensusSuggestion != null && !consensusMatchedInList;
 
   // #1177: 4가지 state 구분 — error > loading > empty > data. 낙관적 UI 도입(#1165) 후
   // 빈 list/loading의 의미를 사용자에게 명확히 전달한다.
@@ -522,6 +576,20 @@ export function BoardingTrainList({
           testID="boarding-train-delay-chip"
         >
           <Text style={[styles.delayChipText, { color: colors.danger }]}>{`+${delayMinutes}분 지연`}</Text>
+        </View>
+      )}
+      {/* #2330 — consensus 엔진이 아직 confirmed 매칭 row를 노출하지 못한 동안(도착 목록 지연 등)
+          "다음 열차 추적 중" 배지로 백그라운드 추적 사실을 알린다. 직접 선택 CTA를 겸용 —
+          사용자는 이 배지와 무관하게 아래 list에서 언제든 직접 탭할 수 있다. */}
+      {showConsensusTrackingBadge && (
+        <View
+          style={[styles.consensusTrackingBadge, { borderColor: colors.accent }]}
+          testID="boarding-train-list-consensus-tracking"
+          accessibilityLabel={t('a11y.alarm.consensusTrackingLabel')}
+        >
+          <Text style={[typography.bodySm, { color: colors.accent, fontWeight: '600' }]}>
+            {t('home.consensusTrackingBadge')}
+          </Text>
         </View>
       )}
       {/* #1177 — pending lock state list-level 안내. row outline highlight와 별도로 list 헤더 영역에
@@ -637,6 +705,26 @@ const styles = StyleSheet.create({
   rowArrivalLine: {
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  // #2330 — consensus-confirmed row 내 "추정" 배지 + "직접 선택" 병기 라인.
+  rowConsensusLine: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  consensusBadge: {
+    paddingHorizontal: spacing.xs,
+    paddingVertical: 1,
+    borderRadius: 3,
+    borderWidth: 1,
+  },
+  // #2330 — list-level "다음 열차 추적 중" 배지(직접 선택 CTA 겸용).
+  consensusTrackingBadge: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs / 2,
+    borderRadius: radius.pill,
+    borderWidth: 1,
   },
   empty: {
     padding: spacing.lg,

--- a/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
+++ b/src/features/alarm/components/__tests__/BoardingTrainList.test.tsx
@@ -1396,4 +1396,106 @@ describe('BoardingTrainList', () => {
       expect(getByTestId('boarding-train-list-pending-notice')).toBeTruthy();
     });
   });
+
+  // #2330 (consensus-D, 설계 SSoT #2323 2026-08-13 (3)(6)) — 배지+확정정보 조합 UI.
+  // 어떤 상태도 "선택됨" 표기 금지(오토락 부활 오해 차단) — "추정" + "직접 선택" 병기만 사용.
+  describe('#2330 consensusSuggestion 배지/하이라이트', () => {
+    it('consensusSuggestion 미전달(기본값) → 배지/하이라이트 전혀 미노출', () => {
+      const train = makeTrain({ trainCode: 'T-A' });
+      const { queryByTestId } = renderWithTheme(
+        <BoardingTrainList arrivals={[train]} line="2" onSelect={() => {}} />,
+      );
+      expect(queryByTestId('boarding-train-list-consensus-tracking')).toBeNull();
+      expect(queryByTestId('boarding-train-consensus-badge-T-A')).toBeNull();
+    });
+
+    it('consensusSuggestion.trainCode가 현재 list 어느 row와도 매칭 안 되면 추적 중 배지만 노출', () => {
+      const train = makeTrain({ trainCode: 'T-A' });
+      const { getByTestId, queryByTestId } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={() => {}}
+          consensusSuggestion={{ trainCode: 'NOT-IN-LIST' }}
+        />,
+      );
+      expect(getByTestId('boarding-train-list-consensus-tracking')).toBeTruthy();
+      expect(queryByTestId('boarding-train-consensus-badge-T-A')).toBeNull();
+    });
+
+    it('consensusSuggestion.trainCode가 매칭되는 row → "추정" 배지 + "직접 선택" 병기, 추적 배지는 생략', () => {
+      const train = makeTrain({ trainCode: 'T-A' });
+      const { getByTestId, queryByTestId, getByText } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={() => {}}
+          consensusSuggestion={{ trainCode: 'T-A' }}
+        />,
+      );
+      expect(getByTestId('boarding-train-consensus-badge-T-A')).toBeTruthy();
+      expect(getByText('추정')).toBeTruthy();
+      expect(getByText('직접 선택')).toBeTruthy();
+      expect(queryByTestId('boarding-train-list-consensus-tracking')).toBeNull();
+    });
+
+    it('어떤 상태도 "선택됨" 텍스트를 렌더하지 않는다 (오토락 부활 오해 차단)', () => {
+      const train = makeTrain({ trainCode: 'T-A' });
+      const { queryByText } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={() => {}}
+          consensusSuggestion={{ trainCode: 'T-A' }}
+        />,
+      );
+      expect(queryByText('선택됨')).toBeNull();
+    });
+
+    it('탭은 consensusSuggestion과 무관하게 그대로 onSelect 발화 (탭 우선)', () => {
+      const train = makeTrain({ trainCode: 'T-A' });
+      const onSelect = jest.fn();
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={onSelect}
+          consensusSuggestion={{ trainCode: 'OTHER' }}
+        />,
+      );
+      fireEvent.press(getByTestId('boarding-train-row-T-A'));
+      expect(onSelect).toHaveBeenCalledWith(train);
+    });
+
+    it('compact 모드에서도 매칭 row 배지 노출', () => {
+      const train = makeTrain({ trainCode: 'T-A' });
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[train]}
+          line="2"
+          onSelect={() => {}}
+          compact
+          consensusSuggestion={{ trainCode: 'T-A' }}
+        />,
+      );
+      expect(getByTestId('boarding-train-consensus-badge-T-A')).toBeTruthy();
+    });
+
+    it('전열차(prevTrain) row도 매칭되면 배지 노출', () => {
+      const prevTrain: PrevTrainCandidate = {
+        train: makeTrain({ trainCode: 'T-PREV', arrivalSeconds: 40 }),
+        elapsedSeconds: 90,
+      };
+      const { getByTestId } = renderWithTheme(
+        <BoardingTrainList
+          arrivals={[]}
+          line="2"
+          onSelect={() => {}}
+          prevTrain={prevTrain}
+          consensusSuggestion={{ trainCode: 'T-PREV' }}
+        />,
+      );
+      expect(getByTestId('boarding-train-prev-consensus-badge-T-PREV')).toBeTruthy();
+    });
+  });
 });

--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -62,6 +62,12 @@ const { __mockSetInfoModeEnabled: setInfoModeEnabledMock } = jest.requireMock(
   '../../store/useUserIntentStore',
 );
 
+// #2330 (consensus-D) — 탭 vs consensus-confirmed 불일치 telemetry mock.
+const mockRecordConsensusMismatch = jest.fn();
+jest.mock('../../utils/consensusMismatchMetrics', () => ({
+  recordConsensusMismatch: (...args: unknown[]) => mockRecordConsensusMismatch(...args),
+}));
+
 function makeTrain(overrides: Partial<ArrivalInfo> = {}): ArrivalInfo {
   return {
     destination: '종착',
@@ -485,6 +491,82 @@ describe('useBoardingLockController', () => {
           result.current.createLockFromTrain(makeTrain({ trainCode: 'T-WRONG', line: '9' }));
         });
         expect(setInfoModeEnabledMock).not.toHaveBeenCalled();
+      });
+    });
+
+    // #2330 (consensus-D, 설계 SSoT #2323 (3)) — 탭은 항상 우선(SSoT). consensus-confirmed
+    // 제안과 다른 열차를 탭하면 mismatch telemetry가 기록되지만 lock 채택 자체는 차단되지 않는다.
+    describe('#2330 consensus-mismatch telemetry', () => {
+      let readSpy: jest.SpyInstance;
+      const CONSENSUS_SUGGESTION = {
+        stationId: '강남',
+        trainCode: 'CONSENSUS-1',
+        lineId: '2',
+        confidence: 'consensus' as const,
+        decidedAt: 1_700_000_000_000,
+      };
+      const MIRROR_WITH_CONSENSUS = {
+        currentStationId: '강남',
+        motionState: 'moving' as const,
+        lastAdvanceEvidence: 'arvlcd-confirmed-train',
+        lastAdvanceAt: 1_700_000_000_000,
+        passedStations: [],
+        receivedAt: Date.now(),
+        lockSuggestion: CONSENSUS_SUGGESTION,
+      };
+
+      beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(1_700_000_000_000);
+        mockRecordConsensusMismatch.mockClear();
+        const mirror = jest.requireActual('../../utils/backendSsotMirror');
+        readSpy = jest.spyOn(mirror, 'readBackendSsotMirror');
+      });
+
+      afterEach(() => {
+        jest.useRealTimers();
+        readSpy.mockRestore();
+      });
+
+      it('탭한 trainCode가 consensus 제안과 다르면 recordConsensusMismatch 호출 + lock은 탭이 채택', async () => {
+        readSpy.mockResolvedValue(MIRROR_WITH_CONSENSUS);
+        const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+        await act(async () => {
+          jest.advanceTimersByTime(5_000);
+        });
+        await waitFor(() => {
+          expect(result.current.lockSuggestion?.confidence).toBe('consensus');
+        });
+        await act(async () => {
+          result.current.createLockFromTrain(makeTrain({ trainCode: 'TAPPED-1' }));
+        });
+        expect(mockRecordConsensusMismatch).toHaveBeenCalledWith('CONSENSUS-1', 'TAPPED-1');
+        expect(mockSetBoardingLock).toHaveBeenCalledWith(
+          expect.objectContaining({ trainCode: 'TAPPED-1' }),
+        );
+      });
+
+      it('탭한 trainCode가 consensus 제안과 같으면 recordConsensusMismatch 미호출', async () => {
+        readSpy.mockResolvedValue(MIRROR_WITH_CONSENSUS);
+        const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+        await act(async () => {
+          jest.advanceTimersByTime(5_000);
+        });
+        await waitFor(() => {
+          expect(result.current.lockSuggestion?.confidence).toBe('consensus');
+        });
+        await act(async () => {
+          result.current.createLockFromTrain(makeTrain({ trainCode: 'CONSENSUS-1' }));
+        });
+        expect(mockRecordConsensusMismatch).not.toHaveBeenCalled();
+      });
+
+      it('lockSuggestion 없으면 recordConsensusMismatch 미호출 (기존 동작)', async () => {
+        const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+        await act(async () => {
+          result.current.createLockFromTrain(makeTrain({ trainCode: 'ANY' }));
+        });
+        expect(mockRecordConsensusMismatch).not.toHaveBeenCalled();
       });
     });
   });
@@ -1277,6 +1359,34 @@ describe('useBoardingLockController', () => {
       });
       await tickAndSettleCycle();
       expect(createLockMock).not.toHaveBeenCalled();
+    });
+
+    // #2330 (consensus-D, 설계 SSoT #2323 (3)) — confidence='consensus'는 lock 승격 금지.
+    // backend legConsensus는 UI 표시/floor 힌트 전용으로만 forward — 자동 hydrate 경로가
+    // 이 값을 다른 confidence(high/medium/low)와 동일하게 채택하면 "오토락 부활" 오해를 준다.
+    it('confidence=consensus → createLock 미호출 (lock 승격 금지, UI 표시 전용)', async () => {
+      readSpy.mockResolvedValue({
+        ...MIRROR,
+        lockSuggestion: { ...SUGGESTION, confidence: 'consensus' as const },
+      });
+      const createLockMock = setupRejectScenario();
+      await tickAndSettleCycle();
+      expect(createLockMock).not.toHaveBeenCalled();
+    });
+
+    it('confidence=consensus 여도 result.lockSuggestion에는 노출 (UI consumer 진입점)', async () => {
+      readSpy.mockResolvedValue({
+        ...MIRROR,
+        lockSuggestion: { ...SUGGESTION, confidence: 'consensus' as const },
+      });
+      useBoardingLockStore.setState({ lock: null });
+      const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+      });
+      await waitFor(() => {
+        expect(result.current.lockSuggestion?.confidence).toBe('consensus');
+      });
     });
   });
 

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -28,6 +28,7 @@ import {
 import type { AutoLockCandidate } from '../../nearest-station/api/boardingLockSync';
 import { useLockSuggestion } from '../api/useLockSuggestion';
 import type { LockSuggestionMirror } from '../utils/backendSsotMirror';
+import { recordConsensusMismatch } from '../utils/consensusMismatchMetrics';
 
 export interface UseBoardingLockControllerInputs {
   destinationId: string | null;
@@ -201,6 +202,10 @@ export function useBoardingLockController({
   useEffect(() => {
     if (!lockSuggestion) return;
     if (lock) return;
+    // #2330 (consensus-D, 설계 SSoT #2323 (3)) — confidence='consensus'는 lock 승격 금지.
+    // legConsensus는 UI 표시(배지/하이라이트)/floor 힌트 전용 forward라 high/medium/low(9-AND
+    // gate 기반 evidence)와 달리 자동 hydrate 대상이 아니다. "오토락 부활" 오해를 구조적으로 차단.
+    if (lockSuggestion.confidence === 'consensus') return;
     const boardingLine = asLineNumber(lockSuggestion.lineId);
     if (!boardingLine) return;
     if (legAdvanceLine !== null) {
@@ -298,6 +303,15 @@ export function useBoardingLockController({
       // train arrival을 directionalArrivals에 섞어 노출한 경우 lock 채택을 차단한다.
       // allowedLines === undefined는 trip 비활성 → 필터 미적용(free-trip 등 기존 UX 유지).
       if (allowedLines && !allowedLines.has(train.line)) return;
+      // #2330 (consensus-D, 설계 SSoT #2323 (3)) — 명시 탭이 항상 우선. backend consensus
+      // engine이 confirmed(confidence='consensus')한 제안과 다른 열차를 탭하면 mismatch telemetry
+      // 기록 — lock 채택 자체는 아래 기존 흐름 그대로(탭이 SSoT, consensus는 표시 전용이라 차단하지 않음).
+      if (
+        lockSuggestion?.confidence === 'consensus' &&
+        lockSuggestion.trainCode !== train.trainCode
+      ) {
+        recordConsensusMismatch(lockSuggestion.trainCode, train.trainCode);
+      }
       // #1923 — 사용자 명시 의향 stamp. BoardingTrainList 직접 탭은 lock 활성과 동급 의향 표명.
       // ADR-014 §X "사용자 명시 의향 trip = lock 활성과 동급 정확도 보장 의무" 정합.
       // setInfoModeEnabled는 memory + storage atomic — graceful 실패(다음 cycle에서 자연 재시도).
@@ -331,7 +345,7 @@ export function useBoardingLockController({
         // store action rejection은 graceful — 다음 polling cycle에서 자연 재시도.
       });
     },
-    [destinationId, currentStation, expectedDurationMinutes, createLock, allowedLines],
+    [destinationId, currentStation, expectedDurationMinutes, createLock, allowedLines, lockSuggestion],
   );
 
   const release = useCallback(() => {

--- a/src/features/alarm/utils/__tests__/backendSsotMirror.test.ts
+++ b/src/features/alarm/utils/__tests__/backendSsotMirror.test.ts
@@ -76,6 +76,22 @@ describe('readBackendSsotMirror lockSuggestion parse (#1534 S1 T9b)', () => {
     expect(got?.lockSuggestion).toBeUndefined();
   });
 
+  // #2330 (consensus-D, 설계 SSoT #2323 (1)) — confidence='consensus' forward-compat.
+  // backend consensus-C(#2329, 머지 대기)가 legConsensus confirmed 시 이 값을 forward한다.
+  // 아직 backend가 이 값을 보내지 않아도 device parse가 미리 허용해야 결합 시 즉시 동작.
+  it('confidence=consensus 도 유효 lockSuggestion으로 파싱 (#2330 forward-compat)', async () => {
+    const lockSuggestion = {
+      stationId: '건대입구',
+      trainCode: '2246',
+      lineId: '7',
+      confidence: 'consensus' as const,
+      decidedAt: 1_700_000_005_000,
+    };
+    mockGetItem.mockResolvedValue(JSON.stringify({ ...baseEntry, lockSuggestion }));
+    const got = await readBackendSsotMirror();
+    expect(got?.lockSuggestion).toEqual(lockSuggestion);
+  });
+
   it.each([
     ['stationId missing', { trainCode: 'X', lineId: '2', confidence: 'high', decidedAt: 1 }],
     [

--- a/src/features/alarm/utils/__tests__/consensusMismatchMetrics.test.ts
+++ b/src/features/alarm/utils/__tests__/consensusMismatchMetrics.test.ts
@@ -1,0 +1,50 @@
+import {
+  getConsensusMismatchMetrics,
+  recordConsensusMismatch,
+  resetConsensusMismatchMetrics,
+} from '../consensusMismatchMetrics';
+
+describe('consensusMismatchMetrics (#2330, design SSoT #2323 (3))', () => {
+  beforeEach(() => {
+    resetConsensusMismatchMetrics();
+  });
+
+  it('초기 상태는 fired=0, lastFiredAtMs=0', () => {
+    const m = getConsensusMismatchMetrics();
+    expect(m.fired).toBe(0);
+    expect(m.lastFiredAtMs).toBe(0);
+  });
+
+  it('recordConsensusMismatch 호출 시 fired 누적 + lastFiredAtMs 갱신', () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    try {
+      recordConsensusMismatch('A', 'B');
+      let m = getConsensusMismatchMetrics();
+      expect(m.fired).toBe(1);
+      expect(m.lastFiredAtMs).toBe(1_000_000);
+
+      nowSpy.mockReturnValue(2_000_000);
+      recordConsensusMismatch('B', 'C');
+      m = getConsensusMismatchMetrics();
+      expect(m.fired).toBe(2);
+      expect(m.lastFiredAtMs).toBe(2_000_000);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('reset 후 counter는 다시 0', () => {
+    recordConsensusMismatch('A', 'B');
+    resetConsensusMismatchMetrics();
+    const m = getConsensusMismatchMetrics();
+    expect(m.fired).toBe(0);
+    expect(m.lastFiredAtMs).toBe(0);
+  });
+
+  it('getConsensusMismatchMetrics는 호출자가 mutate해도 내부 상태 보호 (복사본 반환)', () => {
+    recordConsensusMismatch('A', 'B');
+    const m = getConsensusMismatchMetrics() as { fired: number; lastFiredAtMs: number };
+    m.fired = 999;
+    expect(getConsensusMismatchMetrics().fired).toBe(1);
+  });
+});

--- a/src/features/alarm/utils/backendSsotMirror.ts
+++ b/src/features/alarm/utils/backendSsotMirror.ts
@@ -20,12 +20,18 @@ import { BACKEND_SSOT_MIRROR_KEY } from '../../../shared/constants/storageKeys';
  * `useBoardingLockController`에 1순위 candidate로 forward해 9-AND gate 우회.
  *
  * confidence 'low'는 향후 단일 cellular/accel 채택 slot. 현재는 high/medium만 backend가 set.
+ *
+ * confidence 'consensus' — #2330 (consensus-D, 설계 SSoT #2323 (1)(3)). backend legConsensus
+ * 엔진이 environment confirmed(core 창 단일 생존 + match≥2 + mismatch=0)한 transfer leg 다음
+ * 열차를 forward. high/medium/low(9-AND gate 기반)와 달리 **lock 승격 금지** — device
+ * (`useBoardingLockController`)는 이 값을 UI 표시(배지/하이라이트)/floor 힌트 전용으로만 소비하고
+ * 자동 lock 채택 경로에서는 명시적으로 제외한다.
  */
 export interface LockSuggestionMirror {
   stationId: string;
   trainCode: string;
   lineId: string;
-  confidence: 'high' | 'medium' | 'low';
+  confidence: 'high' | 'medium' | 'low' | 'consensus';
   decidedAt: number;
 }
 
@@ -220,7 +226,14 @@ function parseLockSuggestion(raw: unknown): LockSuggestionMirror | null {
   if (typeof o.stationId !== 'string' || o.stationId.length === 0) return null;
   if (typeof o.trainCode !== 'string' || o.trainCode.length === 0) return null;
   if (typeof o.lineId !== 'string' || o.lineId.length === 0) return null;
-  if (o.confidence !== 'high' && o.confidence !== 'medium' && o.confidence !== 'low') return null;
+  if (
+    o.confidence !== 'high' &&
+    o.confidence !== 'medium' &&
+    o.confidence !== 'low' &&
+    o.confidence !== 'consensus'
+  ) {
+    return null;
+  }
   if (typeof o.decidedAt !== 'number' || !Number.isFinite(o.decidedAt)) return null;
   return {
     stationId: o.stationId,

--- a/src/features/alarm/utils/consensusMismatchMetrics.ts
+++ b/src/features/alarm/utils/consensusMismatchMetrics.ts
@@ -1,0 +1,53 @@
+/**
+ * Consensus mismatch metric — #2330 (consensus-D, 설계 SSoT #2323 2026-08-13 (3)).
+ *
+ * 명시 탭이 backend consensus engine이 confirmed한 lockSuggestion(confidence='consensus')과
+ * 다른 trainCode를 선택했을 때 발화. 탭이 항상 우선하며(consensus는 lock 승격 금지, UI 표시/floor
+ * forward 전용), 본 counter는 그 불일치 빈도를 측정해 향후 consensus engine 정확도 튜닝에 쓰인다.
+ *
+ * 단순 in-memory counter — `lockCorrectionMetrics.ts`(#1166)와 동일 패턴. logger emit으로
+ * 디버그/로컬 분석은 즉시 가능하다(`createLogger('consensusMismatch')`).
+ *
+ * 동작 변경 없음 — 순수 측정. 호출 실패가 탭 UX를 차단하지 않는다.
+ */
+import { createLogger } from '../../../shared/utils/logger';
+
+const log = createLogger('consensusMismatch');
+
+interface Counters {
+  /** consensus-confirmed 제안과 다른 탭 fire 누적 횟수(앱 lifetime). */
+  fired: number;
+  /** 마지막 fire 시각(epoch ms). 호출 전 0. */
+  lastFiredAtMs: number;
+}
+
+const counters: Counters = { fired: 0, lastFiredAtMs: 0 };
+
+/**
+ * consensus 제안(A)과 사용자가 실제 탭한 열차(B)가 다를 때 호출. log emit + counter 적재.
+ *
+ * @param suggestedTrainCode backend consensus engine이 confirmed한 train code (A).
+ * @param tappedTrainCode 사용자가 BoardingTrainList에서 실제 탭한 train code (B). A와 같을 수 없다 —
+ *   호출자가 mismatch만 호출하도록 가드한다.
+ */
+export function recordConsensusMismatch(
+  suggestedTrainCode: string,
+  tappedTrainCode: string,
+): void {
+  counters.fired += 1;
+  counters.lastFiredAtMs = Date.now();
+  log.info(
+    `consensus mismatch fired suggested=${suggestedTrainCode} tapped=${tappedTrainCode} total=${counters.fired}`,
+  );
+}
+
+/** 현재 누적 counter 스냅샷. DebugModal/테스트 노출. */
+export function getConsensusMismatchMetrics(): Readonly<Counters> {
+  return { ...counters };
+}
+
+/** 테스트 격리용 reset. production code에서 호출하지 않는다. */
+export function resetConsensusMismatchMetrics(): void {
+  counters.fired = 0;
+  counters.lastFiredAtMs = 0;
+}

--- a/src/features/debug/components/DebugModal.tsx
+++ b/src/features/debug/components/DebugModal.tsx
@@ -75,6 +75,7 @@ import { useBoardingLockStore } from '../../../features/alarm/store/useBoardingL
 // #2268 (C1) — pending→confirmed lock 정정 measurement infra(#1166). fired count 는
 // BoardingTrainList가 이미 기록하지만 DebugModal에 섹션이 없어 관측 불가했다.
 import { getLockCorrectionMetrics } from '../../alarm/utils/lockCorrectionMetrics';
+import { getConsensusMismatchMetrics } from '../../alarm/utils/consensusMismatchMetrics';
 import {
   BOARDING_LOCK_EXPIRY_FACTOR,
   isBoardingLockExpired,
@@ -662,6 +663,11 @@ interface BuildDumpArgs {
    * 미전달 시 (n/a) 표기.
    */
   lockCorrection?: ReturnType<typeof getLockCorrectionMetrics>;
+  /**
+   * #2330 (consensus-D, 설계 SSoT #2323 (3)) — 명시 탭이 backend consensus-confirmed 제안과
+   * 다른 열차를 선택했을 때 fire하는 counter(`consensusMismatchMetrics.ts`). 미전달 시 (n/a) 표기.
+   */
+  consensusMismatch?: ReturnType<typeof getConsensusMismatchMetrics>;
   /**
    * #1413 — BoardingLock 섹션 dump 입력. lock 활성/trainCode/boardingLine/expiresAt.
    * 미전달이면 lock=null과 동일(active=no)로 출력.
@@ -1316,6 +1322,23 @@ function buildLockCorrectionSection(args: BuildDumpArgs): string[] {
 }
 
 /**
+ * #2330 (consensus-D, 설계 SSoT #2323 (3)) — Consensus Mismatch 섹션. 명시 탭이 backend
+ * consensus-confirmed 제안과 다른 열차를 선택한 빈도를 dump/UI 양쪽에 노출.
+ * `computeLockCorrectionLines`와 동일 패턴 — 미전달 시 (n/a).
+ */
+function computeConsensusMismatchLines(
+  metrics: ReturnType<typeof getConsensusMismatchMetrics> | undefined,
+): string[] {
+  if (!metrics) return ['(n/a)'];
+  const lastFiredLine = metrics.lastFiredAtMs === 0 ? '(never)' : formatTime(metrics.lastFiredAtMs);
+  return [`fired=${metrics.fired}`, `lastFiredAt=${lastFiredLine}`];
+}
+
+function buildConsensusMismatchSection(args: BuildDumpArgs): string[] {
+  return computeConsensusMismatchLines(args.consensusMismatch);
+}
+
+/**
  * #1518 — Backend call ring buffer 1줄 포맷. call/response/error를 한 줄에 압축해
  * dump 분량을 줄인다. host 부분만 노출하고 path는 trim 안 함(진단 시 endpoint 식별).
  */
@@ -1741,6 +1764,8 @@ const SHARE_SECTIONS: ReadonlyArray<ShareSectionSpec> = [
   { title: 'BoardingLock', build: buildBoardingLockSection },
   // #2268 (C1) — pending→confirmed lock 정정 counter(#1166). BoardingLock 섹션 직후 배치.
   { title: 'Lock Correction', build: buildLockCorrectionSection },
+  // #2330 (consensus-D) — 명시 탭 vs consensus-confirmed 제안 불일치 counter. Lock Correction 직후 배치.
+  { title: 'Consensus Mismatch', build: buildConsensusMismatchSection },
   // #1413 — Estimator buffer. lockless trip 진행도 사후 재구성용.
   {
     title: 'Estimator State',
@@ -2330,6 +2355,10 @@ function DebugModalInner({
   // 스냅샷 산출 값들 — autoLockMeta/envDistribution — 과 동일 패턴).
   const lockCorrectionMetrics = getLockCorrectionMetrics();
 
+  // #2330 (consensus-D) — 명시 탭 vs consensus-confirmed 불일치 counter. 동일 module-level
+  // singleton getter 패턴(위 lockCorrectionMetrics와 동일 render-time 스냅샷 근거).
+  const consensusMismatchMetrics = getConsensusMismatchMetrics();
+
   const nearestDistanceM = result ? Math.round(result.distanceKm * 1000) : null;
   const variantNames = variants.map((v) => `${v.name}(${v.line})`);
 
@@ -2415,6 +2444,8 @@ function DebugModalInner({
       fusionTierLog: fusionTierLogs,
       // #2268 (C1) — Lock Correction counter. Modal render와 동일 SSOT(getLockCorrectionMetrics).
       lockCorrection: lockCorrectionMetrics,
+      // #2330 (consensus-D) — Consensus Mismatch counter. Modal render와 동일 SSOT.
+      consensusMismatch: consensusMismatchMetrics,
     });
     // #2268 (S1+S2) — 이전엔 `void Share.share(...)`로 실패가 완전 무음이었다(catch 없음).
     // Share 시트를 뜨는 순간 취소돼도 reject 하는 OS 조합이 있어 사용자가 "왜 안 되지"만
@@ -2495,6 +2526,8 @@ function DebugModalInner({
     fusionTierLogs,
     // #2268 (C1) — Lock Correction counter 변경 시 dump 텍스트 자동 갱신.
     lockCorrectionMetrics,
+    // #2330 (consensus-D) — Consensus Mismatch counter 변경 시 dump 텍스트 자동 갱신.
+    consensusMismatchMetrics,
   ]);
 
   return (
@@ -2796,6 +2829,10 @@ function DebugModalInner({
           {/* #2268 (C1) — Lock Correction: pending→confirmed 정정 fired count / lastFiredAt.
               buildLockCorrectionSection과 동일 SSOT (내부 helper 재사용). */}
           <LockCorrectionSection metrics={lockCorrectionMetrics} colors={colors} />
+
+          {/* #2330 (consensus-D) — Consensus Mismatch: 탭 vs consensus-confirmed 불일치 fired count.
+              buildConsensusMismatchSection과 동일 SSOT (내부 helper 재사용). */}
+          <ConsensusMismatchSection metrics={consensusMismatchMetrics} colors={colors} />
 
           <DebugLogSection
             title="Estimator State"
@@ -3649,6 +3686,27 @@ function LockCorrectionSection({
 }
 
 /**
+ * #2330 (consensus-D) — Consensus Mismatch UI section. computeConsensusMismatchLines helper를
+ * dump builder와 공유.
+ */
+function ConsensusMismatchSection({
+  metrics,
+  colors,
+}: Readonly<{
+  metrics: ReturnType<typeof getConsensusMismatchMetrics> | undefined;
+  colors: ReturnType<typeof useTheme>['colors'];
+}>) {
+  return (
+    <DumpTextSection
+      title="Consensus Mismatch"
+      lines={computeConsensusMismatchLines(metrics)}
+      entryTestId="debug-consensus-mismatch"
+      colors={colors}
+    />
+  );
+}
+
+/**
  * #2049 (#1421) — Auto-lock Candidate UI section. computeAutoLockLines helper를 dump builder와 공유.
  */
 function AutoLockCandidateSection({
@@ -3826,6 +3884,9 @@ export const __test__ = {
   // #2268 (C1) — Lock Correction section builder/helper. 단위 테스트에서 직접 검증.
   computeLockCorrectionLines,
   buildLockCorrectionSection,
+  // #2330 (consensus-D) — Consensus Mismatch section builder/helper. 단위 테스트에서 직접 검증.
+  computeConsensusMismatchLines,
+  buildConsensusMismatchSection,
 };
 
 const styles = StyleSheet.create({

--- a/src/features/debug/components/__tests__/DebugModal.test.tsx
+++ b/src/features/debug/components/__tests__/DebugModal.test.tsx
@@ -5062,6 +5062,52 @@ describe('DebugModal — #1501 Raw Signal 섹션', () => {
       resetLockCorrectionMetrics();
     });
 
+    // #2330 (consensus-D, 설계 SSoT #2323 (3)) — getConsensusMismatchMetrics()는
+    // useBoardingLockController가 기록하는데 DebugModal에 섹션이 없으면 관측 불가하다(orphan getter).
+    // Lock Correction과 동일 패턴 검증.
+    it('computeConsensusMismatchLines / buildConsensusMismatchSection: n/a + fired/lastFiredAt 표기 (#2330)', () => {
+      const { computeConsensusMismatchLines, buildConsensusMismatchSection } = __test__;
+      expect(computeConsensusMismatchLines(undefined)).toEqual(['(n/a)']);
+      expect(computeConsensusMismatchLines({ fired: 0, lastFiredAtMs: 0 })).toEqual([
+        'fired=0',
+        'lastFiredAt=(never)',
+      ]);
+      const withTs = computeConsensusMismatchLines({ fired: 3, lastFiredAtMs: 1_700_000_000_000 });
+      expect(withTs[0]).toBe('fired=3');
+      expect(withTs[1]).toMatch(/^lastFiredAt=\d{2}:\d{2}:\d{2}$/);
+      const built = buildConsensusMismatchSection({
+        ...baselineDumpArgs,
+        consensusMismatch: { fired: 2, lastFiredAtMs: 1000 },
+      });
+      expect(built[0]).toBe('fired=2');
+      expect(built[1]).toMatch(/^lastFiredAt=\d{2}:\d{2}:\d{2}$/);
+    });
+
+    it('Consensus Mismatch 섹션이 share dump에 포함된다 (#2330)', () => {
+      const dump = buildDumpText(
+        makeDumpArgs({ consensusMismatch: { fired: 5, lastFiredAtMs: 2000 } }),
+      );
+      expect(dump).toContain('## Consensus Mismatch');
+      const section = dump.slice(dump.indexOf('## Consensus Mismatch'));
+      expect(section).toContain('fired=5');
+      expect(section).toMatch(/lastFiredAt=\d{2}:\d{2}:\d{2}/);
+    });
+
+    it('Consensus Mismatch 섹션이 UI에 노출된다 (#2330)', async () => {
+      const {
+        getConsensusMismatchMetrics,
+        resetConsensusMismatchMetrics,
+        recordConsensusMismatch,
+      } = jest.requireActual('../../../alarm/utils/consensusMismatchMetrics');
+      resetConsensusMismatchMetrics();
+      recordConsensusMismatch('T-1', 'T-2');
+      renderWithTheme(<DebugModal onClose={jest.fn()} />);
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      expect(screen.getByText(/fired=1/)).toBeTruthy();
+      expect(getConsensusMismatchMetrics().fired).toBe(1);
+      resetConsensusMismatchMetrics();
+    });
+
     it('UI: 비어있으면 (0) 표시, push 시 entry 노출, Clear가 비운다', async () => {
       const {
         clearCandidateRejectEntries,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -729,6 +729,17 @@ export default function HomeScreen() {
     motionStationary,
     speedMps,
   });
+  // #2330 (consensus-D, 설계 SSoT #2323 (3)(6)) — backend legConsensus가 confirmed한 제안만
+  // BoardingTrainList 배지/하이라이트로 forward. high/medium/low(9-AND gate 기반)는 이미
+  // useBoardingLockController가 자동 lock으로 채택하므로 UI 표시 대상이 아니다(lockSuggestion=null로
+  // 이어지는 정상 경로). lockSuggestion 부재/비-consensus면 null — 기존 렌더 100% 보존.
+  const consensusSuggestion = useMemo(
+    () =>
+      lockSuggestion?.confidence === 'consensus'
+        ? { trainCode: lockSuggestion.trainCode }
+        : null,
+    [lockSuggestion],
+  );
   // #2139 — "전열차"(출발역을 방금 떠난 열차) 후보. lock이 없는 상태(=BoardingTrainList 노출 구간)에서만
   // 의미가 있지만 Rules of Hooks 준수를 위해 항상 호출 — currentStation/nextStationName 부재 시
   // hook 내부에서 graceful null 반환.
@@ -1637,6 +1648,8 @@ export default function HomeScreen() {
                                     // #2139 — 전열차(출발역을 방금 떠난 열차) 후보. 식별 불가 시 null이라
                                     // 기존 [현열차 | 다음열차] 렌더가 그대로 보존된다.
                                     prevTrain={prevTrain}
+                                    // #2330 — backend legConsensus confirmed 제안. null이면 배지 미노출.
+                                    consensusSuggestion={consensusSuggestion}
                                   />
                                 </View>
                               );
@@ -1685,6 +1698,8 @@ export default function HomeScreen() {
                                   // #2179 — 전열차(환승역을 방금 떠난 열차) 후보. 식별 불가 시 null이라
                                   // 기존 [현열차 | 다음열차] 렌더가 그대로 보존된다.
                                   prevTrain={transferPrevTrain}
+                                  // #2330 — 환승 leg도 동일 legConsensus SSOT(lockSuggestion)를 공유.
+                                  consensusSuggestion={consensusSuggestion}
                                 />
                               );
                             }

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -65,6 +65,9 @@
     "boardingTrainListPending": "Registering boarding...",
     "boardingTrainListError": "Couldn't load arrivals",
     "boardingTrainListErrorHint": "We'll retry automatically in a moment.",
+    "consensusTrackingBadge": "Tracking next train",
+    "consensusEstimatedBadge": "Estimated",
+    "consensusManualSelectHint": "Select manually",
     "misBoardingToast": "Can't find your train. Please reselect.",
     "autoDisembarkToast": {
       "message": "Arrived at {{name}} — destination cleared",
@@ -356,6 +359,7 @@
       "boardingTrainListFallbackLabel": "No boarding candidates",
       "boardingTrainListPendingLabel": "Registering boarding",
       "boardingTrainListErrorLabel": "Couldn't load arrivals",
+      "consensusTrackingLabel": "Tracking next train in the background",
       "boardingLockReleaseLabel": "Get off",
       "boardingLockReleaseHint": "Ends the current boarding session"
     },

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -65,6 +65,9 @@
     "boardingTrainListPending": "乗車を登録中...",
     "boardingTrainListError": "到着情報を読み込めませんでした",
     "boardingTrainListErrorHint": "しばらくしてから自動で再試行します。",
+    "consensusTrackingBadge": "次の列車を追跡中",
+    "consensusEstimatedBadge": "推定",
+    "consensusManualSelectHint": "直接選択",
     "misBoardingToast": "乗車中の列車が見つかりません。もう一度選択してください。",
     "autoDisembarkToast": {
       "message": "{{name}}に到着し、目的地を解除しました",
@@ -356,6 +359,7 @@
       "boardingTrainListFallbackLabel": "乗車候補なし",
       "boardingTrainListPendingLabel": "乗車を登録中",
       "boardingTrainListErrorLabel": "到着情報を読み込めません",
+      "consensusTrackingLabel": "次の列車をバックグラウンドで追跡中",
       "boardingLockReleaseLabel": "降車",
       "boardingLockReleaseHint": "現在の乗車を終了します"
     },

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -65,6 +65,9 @@
     "boardingTrainListPending": "탑승 등록 중...",
     "boardingTrainListError": "도착 정보를 불러올 수 없어요",
     "boardingTrainListErrorHint": "잠시 후 자동으로 다시 시도합니다.",
+    "consensusTrackingBadge": "다음 열차 추적 중",
+    "consensusEstimatedBadge": "추정",
+    "consensusManualSelectHint": "직접 선택",
     "misBoardingToast": "탑승 열차를 찾을 수 없어요. 다시 선택해주세요.",
     "autoDisembarkToast": {
       "message": "{{name}}에 도착해 목적지를 해제했어요",
@@ -356,6 +359,7 @@
       "boardingTrainListFallbackLabel": "탑승 후보 없음",
       "boardingTrainListPendingLabel": "탑승 등록을 처리하는 중",
       "boardingTrainListErrorLabel": "도착 정보를 불러올 수 없음",
+      "consensusTrackingLabel": "다음 열차를 백그라운드에서 추적하는 중",
       "boardingLockReleaseLabel": "하차",
       "boardingLockReleaseHint": "현재 탑승 상태를 종료합니다"
     },

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -65,6 +65,9 @@
     "boardingTrainListPending": "正在登记乘车...",
     "boardingTrainListError": "无法加载到达信息",
     "boardingTrainListErrorHint": "稍后将自动重试。",
+    "consensusTrackingBadge": "正在追踪下一班列车",
+    "consensusEstimatedBadge": "推测",
+    "consensusManualSelectHint": "直接选择",
     "misBoardingToast": "找不到乘坐的列车,请重新选择。",
     "autoDisembarkToast": {
       "message": "已到达{{name}},已清除目的地",
@@ -356,6 +359,7 @@
       "boardingTrainListFallbackLabel": "无乘车候选",
       "boardingTrainListPendingLabel": "正在登记乘车",
       "boardingTrainListErrorLabel": "无法加载到达信息",
+      "consensusTrackingLabel": "正在后台追踪下一班列车",
       "boardingLockReleaseLabel": "下车",
       "boardingLockReleaseHint": "结束当前乘车状态"
     },


### PR DESCRIPTION
## Summary
Closes #2330

consensus-D (설계 SSoT #2323 2026-08-13 코멘트 (3)·(6)) 구현. 2026-08-13 사용자 확정 UI 결정 — **배지+확정정보 조합**: 추적 중 '다음 열차 추적 중' 배지(직접 선택 CTA 겸용), confirmed 시 리스트 상단 하이라이트 + '추정' 배지 + '직접 선택' 병기. **어떤 상태도 '선택됨' 표기하지 않는다** (오토락 부활 오해 차단).

- `backendSsotMirror.ts`: `LockSuggestionMirror.confidence` union에 `'consensus'` 추가(forward-compat parse). backend consensus-C(#2329, 아직 dev 미병합)가 이 값을 forward하기 전에도 device가 미리 형식을 허용해 결합 시 즉시 동작하도록 준비.
- `useBoardingLockController`: `confidence === 'consensus'`는 자동 lock 승격 경로에서 명시적으로 제외(9-AND gate 우회 경로와 별개 — "consensus는 lock 승격 금지" 설계 원칙). 명시 탭이 consensus-confirmed 제안과 다른 trainCode를 선택하면 `recordConsensusMismatch` telemetry 발화(탭이 항상 우선 SSoT, lock 채택 자체는 차단하지 않음).
- `consensusMismatchMetrics.ts` 신규 — `lockCorrectionMetrics.ts`(#1166)와 동일한 순수 in-memory counter 패턴.
- `BoardingTrainList`: `consensusSuggestion?: { trainCode: string } | null` prop 추가. 매칭 row는 하이라이트 + "추정" 배지 + "직접 선택" 병기, 미매칭이면(도착 목록 아직 미도달) list-level "다음 열차 추적 중" 배지. 미전달(null)이면 배지·하이라이트 전혀 미노출 — 기존 렌더 100% 보존.
- `HomeScreen`: 현재역/환승 두 `BoardingTrainList` 인스턴스 모두에 `consensusSuggestion` wire (동일 `lockSuggestion` SSoT에서 파생).
- `DebugModal`: "Consensus Mismatch" 섹션(dump text + UI) 추가 — Lock Correction 섹션과 동일 SSoT 패턴.
- i18n 4개 locale(ko/en/ja/zh) — `consensusTrackingBadge` / `consensusEstimatedBadge` / `consensusManualSelectHint` / a11y `consensusTrackingLabel`.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` 로컬 pass (0 orphan).
2. **V/X dashboard** — DebugModal "Consensus Mismatch" 섹션(dump + UI, `fired`/`lastFiredAt`)에서 명시 탭 vs consensus-confirmed 불일치 빈도 관측 가능. 배지/하이라이트 자체는 실기기 BoardingTrainList 화면에서 시각 확인.
3. **의존 PR** — consensus-C **#2329 (`feat/#2329-consensus-fire-wire`, 아직 dev 미병합)**. 본 PR은 device 소비 측 forward-compat 준비만 완료한 상태 — #2329가 머지·배포되기 전까지는 `confidence='consensus'`가 실제로 device에 도달하지 않아 배지/게이팅 로직이 idle(기존 렌더 100% 보존)이다. #2329 머지 후 실제 결합 검증 필요.
4. **측정 plan** — 다음 검증 탑승(환승 trip)에서 DebugModal Consensus Mismatch counter + Lock Correction counter를 함께 캡처해 탭 vs consensus 판정 일치율을 측정한다.
5. **Device verify** — 필요. 환승 trip 1회로 (a) consensus 미확정 구간에서 "다음 열차 추적 중" 배지, (b) confirmed 후 매칭 row 하이라이트/배지/"직접 선택" 병기, (c) 다른 열차 명시 탭 시 탭이 우선하고 mismatch counter가 오르는지 확인. #2329 미병합 상태에서는 (a)(b)가 발현되지 않으므로 #2329 머지 후 재검증.

## Deviation from spec
없음. UI 결정(배지+확정정보 조합, '선택됨' 표기 금지)을 그대로 구현했고, backend consensus-C 의존 갭은 이슈 지시대로 device측 optional 필드 정의 + 미수신 시 배지 미표시 기본값으로 처리했다.

## Test plan
- [x] `npx jest src/features/alarm/utils/__tests__/consensusMismatchMetrics.test.ts` — pass, 100% coverage
- [x] `npx jest src/features/alarm/utils/__tests__/backendSsotMirror.test.ts` — pass (40 tests)
- [x] `npx jest src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx` — pass (82 tests)
- [x] `npx jest src/features/alarm/components/__tests__/BoardingTrainList.test.tsx` — pass, 100% coverage (106 tests)
- [x] `npx jest src/features/debug/components/__tests__/DebugModal.test.tsx` — pass, 100% coverage (410 tests)
- [x] `npm run type-check` — pass
- [x] `npm run lint:orphan` — pass (0 orphan)