### PR TITLE
fix(#2339): gate-accuracy/gate-age suppress 로그 burst dedup

### DIFF
--- a/src/features/alarm/utils/__tests__/alarmLog.test.ts
+++ b/src/features/alarm/utils/__tests__/alarmLog.test.ts
@@ -1526,6 +1526,39 @@ describe('alarmLog', () => {
       });
     });
 
+    // #2339 — 지하 BG trip에서 같은 gate reason이 fix마다 반복 suppress되어도 burst dedup으로
+    // 첫 1건만 적재하고 이후 반복은 append/breadcrumb/flush를 skip해야 한다 (배터리 절감).
+    it('#2339 logSuppressedGate: burst dedup applies — same reason repeated within window dropped', async () => {
+      _resetBurstSuppressWindowForTests();
+      const location = { lat: 37.5, lng: 127.0, accuracy: 250, ageMs: 30_000 };
+      logSuppressedGate('gate-accuracy', location);
+      logSuppressedGate('gate-accuracy', location);
+      logSuppressedGate('gate-accuracy', location);
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      const matching = saved.filter((e) => e.reason === 'gate-accuracy');
+      expect(matching).toHaveLength(1);
+    });
+
+    it('#2339 logSuppressedGate: different reasons are NOT deduped against each other', async () => {
+      _resetBurstSuppressWindowForTests();
+      const location = { lat: 37.5, lng: 127.0, accuracy: 250, ageMs: 30_000 };
+      logSuppressedGate('gate-accuracy', location);
+      logSuppressedGate('gate-age', location);
+      logSuppressedGate('gate-jump', location);
+      logSuppressedGate('gate-motion-stationary', location);
+      await flushAlarmLog();
+
+      const [, savedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+      const saved: AlarmLogEntry[] = JSON.parse(savedJson);
+      const matching = saved.filter((e) =>
+        ['gate-accuracy', 'gate-age', 'gate-jump', 'gate-motion-stationary'].includes(e.reason ?? ''),
+      );
+      expect(matching).toHaveLength(4);
+    });
+
     // #727 — 정적 misfire 가드(movementGate.ts)가 차단한 발사. source/stationName/kind/phaseId 보존.
     it('logSuppressedMovement: 모든 필드 지정 시 그대로 적재', async () => {
       logSuppressedMovement({

--- a/src/features/alarm/utils/alarmLog.ts
+++ b/src/features/alarm/utils/alarmLog.ts
@@ -1594,10 +1594,19 @@ export function computeSilentPushReach(
   };
 }
 
+/**
+ * #2339 — 지하 BG trip에서 같은 gate reason이 fix마다 반복 suppress되어 burst dedup 없이
+ * 매 append(ring buffer write + Sentry breadcrumb + AsyncStorage flush)를 유발하던 배터리
+ * 소모 차단. 형제 suppress 함수와 동일하게 isBurstDuplicate로 같은 reason 연속 발생은
+ * DEDUP_LOG_WINDOW_MS 안에서 count만 유지(신규 append 생략)하고 최초 1건만 적재한다.
+ * DebugModal Gates 집계는 summarizeAlarmLogByReason이 엔트리 수를 세므로, 반복 suppress를
+ * count 없이 그냥 버려도 "gate 발생 자체는 있었다"는 신호(count > 0)는 보존된다.
+ */
 export function logSuppressedGate(
   reason: 'gate-age' | 'gate-accuracy' | 'gate-jump' | 'gate-motion-stationary',
   location: AlarmLogLocation,
 ): void {
+  if (isBurstDuplicate('gate', reason)) return;
   appendAlarmLog({
     ts: Date.now(),
     source: 'bg',


### PR DESCRIPTION
Closes #2339

## 요약
- 2026-08-18 검증 탑승 배터리 조사에서 지목된 문제: `logSuppressedGate`(gate-accuracy/gate-age/gate-jump/gate-motion-stationary)가 burst dedup 없이 지하 fix마다 1건씩 append — 매 append가 alarmLog ring buffer write + Sentry breadcrumb + AsyncStorage flush(debounce)를 유발해 배터리/디스크IO 소모.
- 형제 suppress 함수들과 동일하게 `isBurstDuplicate`를 `logSuppressedGate`에 적용. 같은 gate reason이 `DEDUP_LOG_WINDOW_MS` 안에서 연속 발생하면 첫 1건만 적재하고 이후는 append/breadcrumb/flush를 skip.
- `lockless-no-user-intent`(alarmLog.ts:1820)는 진단가치(통과 역이름)가 있어 본 이슈 범위 밖 — 건드리지 않음.

## 변경
- `src/features/alarm/utils/alarmLog.ts`: `logSuppressedGate`에 `isBurstDuplicate('gate', reason)` 가드 추가.
- `src/features/alarm/utils/__tests__/alarmLog.test.ts`: burst dedup 재현(red→green) 테스트 2건 추가 — 같은 reason 반복 시 1건 적재, 서로 다른 reason은 dedup 안 됨.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — DebugModal Gates 섹션(`DebugModal.tsx:1871` 부근)은 ring buffer 집계 count만 사용. 본 변경 후에도 reason별 dedup 버킷이 독립이라 count>0 신호(gate 발생 자체 evidence)는 무회귀.
3. **의존 PR** — N/A.
4. **측정 plan** — 다음 지하 검증 탑승 덤프에서 gate-accuracy/gate-age append 건수 급감(기존 17건/8분 수준 → 대폭 감소) 확인.
5. **Device verify** — N/A — 로그 집계 로직, type+unit only.

## 검증
- `npx jest src/features/alarm/utils/__tests__/alarmLog.test.ts --coverage --collectCoverageFrom='src/features/alarm/utils/alarmLog.ts'` — 277 passed, 신규 branch 미커버 없음(pre-existing 99.2%/1379라인 baseline과 동일, 본 PR로 새로 생긴 갭 아님).
- `npm run type-check` — pass.
- `npm run lint:orphan` — pass.