### PR TITLE
fix: device self-end이 목적지 backend push를 선점하는 race 차단 (#2341)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useDeviceSelfEnd.test.ts
+++ b/src/features/alarm/hooks/__tests__/useDeviceSelfEnd.test.ts
@@ -44,8 +44,10 @@ jest.mock('../../../debug/utils/triggerTripGroundTruthPrompt', () => ({
 }));
 
 const mockAppendAlarmLog = jest.fn();
+const mockGetAlarmLog = jest.fn();
 jest.mock('../../utils/alarmLog', () => ({
   appendAlarmLog: (...args: unknown[]) => mockAppendAlarmLog(...args),
+  getAlarmLog: (...args: unknown[]) => mockGetAlarmLog(...args),
 }));
 
 const mockAddDomainBreadcrumb = jest.fn();
@@ -125,6 +127,13 @@ beforeEach(() => {
   mockGetTripStartedAt.mockResolvedValue(null);
   mockRunTripBoundCleanups.mockResolvedValue(undefined);
   mockTriggerTripEndRecall.mockResolvedValue({ uploaded: false });
+  // #2341 — 기본값은 "destination push 이미 관측됨" — Signal 1을 다루는 기존 테스트들이
+  // 게이트에 막히지 않고 기존 타이밍대로 동작하게 한다. ts를 충분히 미래로 잡아 어떤
+  // destination-match 시작 시각(재trip 포함)과 비교해도 sinceTs 이후로 판정되게 한다.
+  // 게이트 자체를 검증하는 테스트는 이 mock을 빈 배열/특정 ts로 override.
+  mockGetAlarmLog.mockResolvedValue([
+    { ts: T0 + 10 * 60_000, source: 'silent-push-received', kind: 'destination' },
+  ]);
   // #2114 (방안 C′) — 기본은 null(corrId sync cache 미수화 → timestamp fallback). 각 test가 필요 시 override.
   mockGetCurrentTripCorrIdSync.mockReturnValue(null);
 });
@@ -362,6 +371,125 @@ describe('useDeviceSelfEnd', () => {
       });
       await Promise.resolve();
       expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('#2341 destination push gate — Signal 1이 backend destination push를 선점하는 race 차단', () => {
+    it('destination push 미관측 + 타임아웃 미도달 → 30s 지속 충족돼도 cleanup 보류 (race 재현, red)', async () => {
+      mockDestinationState = DESTINATION;
+      mockGetAlarmLog.mockResolvedValue([]); // destination push 미도달.
+      const { rerender } = withDateNow(T0, () =>
+        renderHook(
+          (p: UseDeviceSelfEndInputs) => useDeviceSelfEnd(p),
+          {
+            initialProps: baseInputs({
+              currentStation: { ...DESTINATION },
+              confidence: 'backend-ssot',
+              positionStability: 'unknown',
+            }),
+          },
+        ),
+      );
+      // 08-18 저녁 evidence — 도착 +2.4초 tick. destination-match는 30s 이전부터 지속됐다고
+      // 가정(실제로는 T0가 match 시작, +30s tick에서 30s 조건 충족).
+      withDateNow(T0 + 30_000, () => {
+        rerender(
+          baseInputs({
+            currentStation: { ...DESTINATION },
+            confidence: 'backend-ssot',
+            positionStability: 'unknown',
+          }),
+        );
+      });
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      // gate가 push 미관측 + 타임아웃 미도달로 막아 cleanup이 아직 발화하지 않아야 한다.
+      expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+      expect(mockSetSentinel).not.toHaveBeenCalled();
+    });
+
+    it('destination push 관측되면 즉시 cleanup 발화 (push가 늦게 도달해도 관측 즉시 진행)', async () => {
+      mockDestinationState = DESTINATION;
+      mockGetAlarmLog.mockResolvedValue([]); // 처음엔 미도달.
+      const { rerender } = withDateNow(T0, () =>
+        renderHook(
+          (p: UseDeviceSelfEndInputs) => useDeviceSelfEnd(p),
+          {
+            initialProps: baseInputs({
+              currentStation: { ...DESTINATION },
+              confidence: 'backend-ssot',
+              positionStability: 'unknown',
+            }),
+          },
+        ),
+      );
+      withDateNow(T0 + 30_000, () => {
+        rerender(
+          baseInputs({
+            currentStation: { ...DESTINATION },
+            confidence: 'backend-ssot',
+            positionStability: 'unknown',
+          }),
+        );
+      });
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+
+      // backend destination push 도달 (T0+40s, 실측 35~51s 지연대) — 다음 신호 tick에서 관측.
+      mockGetAlarmLog.mockResolvedValue([
+        { ts: T0 + 40_000, source: 'silent-push-received', kind: 'destination' },
+      ]);
+      withDateNow(T0 + 40_000, () => {
+        rerender(
+          baseInputs({
+            currentStation: { ...DESTINATION },
+            confidence: 'backend-ssot',
+            positionStability: 'static', // deps 변경 유도.
+          }),
+        );
+      });
+      await waitFor(() => expect(mockRunTripBoundCleanups).toHaveBeenCalled());
+      expect(mockSetSentinel).toHaveBeenCalled();
+    });
+
+    it('push 계속 미관측 + 4분 타임아웃 경과 → stale-trip 방지 백스톱으로 강제 종료', async () => {
+      mockDestinationState = DESTINATION;
+      mockGetAlarmLog.mockResolvedValue([]); // backend 완전 침묵.
+      const { rerender } = withDateNow(T0, () =>
+        renderHook(
+          (p: UseDeviceSelfEndInputs) => useDeviceSelfEnd(p),
+          {
+            initialProps: baseInputs({
+              currentStation: { ...DESTINATION },
+              confidence: 'backend-ssot',
+              positionStability: 'unknown',
+            }),
+          },
+        ),
+      );
+      withDateNow(T0 + 30_000, () => {
+        rerender(
+          baseInputs({
+            currentStation: { ...DESTINATION },
+            confidence: 'backend-ssot',
+            positionStability: 'unknown',
+          }),
+        );
+      });
+      await waitFor(() => expect(mockGetAlarmLog).toHaveBeenCalled());
+      expect(mockRunTripBoundCleanups).not.toHaveBeenCalled();
+
+      // destination-match 시작(T0) + 4분 타임아웃 경과.
+      withDateNow(T0 + 4 * 60_000, () => {
+        rerender(
+          baseInputs({
+            currentStation: { ...DESTINATION },
+            confidence: 'backend-ssot',
+            positionStability: 'static',
+          }),
+        );
+      });
+      await waitFor(() => expect(mockRunTripBoundCleanups).toHaveBeenCalled());
+      expect(mockSetSentinel).toHaveBeenCalled();
     });
   });
 

--- a/src/features/alarm/hooks/useDeviceSelfEnd.ts
+++ b/src/features/alarm/hooks/useDeviceSelfEnd.ts
@@ -24,6 +24,10 @@
  *
  *   Signal 4 backend-timeout은 silentPushTask.ts 4-way 편집 충돌 회피로 후속 이슈 분리.
  *
+ * #2341 — Signal 1(fusion-destination)은 backend destination push(실측 지연 35~51s) 발사보다
+ * 먼저 trip을 삭제해버리는 race가 있어, destination push 관측 OR 백스톱 타임아웃
+ * (DESTINATION_PUSH_TIMEOUT_MS) 게이트를 통과해야만 발화한다 (evaluateDestinationPushGate).
+ *
  * Idempotent guard:
  *   - trigger 전 `getTripEndedSentinel()` 확인 → non-null 이면 이미 backend cleanup 실행 → skip.
  *   - trigger 시 `runTripBoundCleanups()` + `setTripEndedSentinel(now)` 호출 → backend가 뒤늦게
@@ -53,6 +57,8 @@ import {
   arcCompletionSignal,
   etaBackstopSignal,
   shouldTriggerSelfEnd,
+  hasObservedDestinationPush,
+  destinationPushGatePassed,
   type SelfEndSignalReason,
 } from '../utils/deviceSelfEndSignals';
 import { getTripStartedAt } from '../utils/tripStartStorage';
@@ -66,7 +72,7 @@ import { runTripBoundCleanups } from '../store/tripBoundCleanups';
 import { triggerTripEndRecall } from '../utils/triggerTripEndRecall';
 import { getCurrentTripCorrIdSync } from '../../observability/utils/tripCorrId';
 import { triggerTripGroundTruthPrompt } from '../../debug/utils/triggerTripGroundTruthPrompt';
-import { appendAlarmLog } from '../utils/alarmLog';
+import { appendAlarmLog, getAlarmLog } from '../utils/alarmLog';
 import { useDestinationStore } from '../../route/store/useDestinationStore';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import { addDomainBreadcrumb } from '../../../shared/infra/monitoring/breadcrumb';
@@ -126,6 +132,13 @@ export function useDeviceSelfEnd(inputs: UseDeviceSelfEndInputs): void {
   // 불필요 storage/log I/O 회피).
   const firedForDestinationIdRef = useRef<string | null>(null);
 
+  // #2341 — destination push 게이트 평가가 in-flight인 동안 겹쳐 들어오는 effect tick이
+  // evaluateDestinationPushGate를 중복 호출하는 것을 방지. firedForDestinationIdRef는
+  // performSelfEnd 진입 시에만 stamp되므로(게이트 통과 전) 게이트 평가 자체의 재진입은
+  // 별도 ref로 막는다. 게이트가 아직 통과 못 한 상태(push 미관측 + 타임아웃 전)에서는
+  // 다음 tick 재평가를 허용해야 하므로 완료 시 항상 false로 되돌린다.
+  const destinationGatePendingRef = useRef<boolean>(false);
+
   // destination id 변경 감지 → tripStartedAt 재로드 + ref 리셋 (새 trip은 카운트 처음부터).
   const destinationId = destination?.id ?? null;
   useEffect(() => {
@@ -133,6 +146,7 @@ export function useDeviceSelfEnd(inputs: UseDeviceSelfEndInputs): void {
     stationaryStartedAtRef.current = null;
     stationary5minStartedAtRef.current = null;
     firedForDestinationIdRef.current = null;
+    destinationGatePendingRef.current = false;
     if (destinationId === null) {
       setTripStartedAt_(null);
       return;
@@ -213,6 +227,23 @@ export function useDeviceSelfEnd(inputs: UseDeviceSelfEndInputs): void {
     [releaseLock, tripStartedAt],
   );
 
+  // #2341 — Signal 1(fusion-destination)의 destination 도착 판정이 backend destination push
+  // 발사(실측 지연 35~51s)를 선점해 trip을 삭제해버리는 race 방지 게이트. destination-match
+  // 시작 이후 destination push가 alarmLog에 관측됐으면 즉시 통과, 아니면 DESTINATION_PUSH_TIMEOUT_MS
+  // 백스톱 경과 시에만 통과 (backend 완전 침묵 trip이 self-end를 영구 대기하는 stale 방지).
+  const evaluateDestinationPushGate = useCallback(
+    async (matchStartedAt: number | null, now: number): Promise<boolean> => {
+      /* istanbul ignore next -- 호출부는 s1.trigger===true(reason='fusion-destination')일 때만
+       * 진입하며, fusionDestinationSignal은 destinationMatchStartedAt!==null일 때만 trigger를
+       * 반환하므로 matchStartedAt null은 도달 불가. 타입 시그니처 방어용. */
+      if (matchStartedAt === null) return false;
+      const entries = await getAlarmLog();
+      const pushObserved = hasObservedDestinationPush(entries, matchStartedAt);
+      return destinationPushGatePassed(matchStartedAt, now, pushObserved);
+    },
+    [],
+  );
+
   // 매 render tick에서 fusion 신호 평가. 신호 변경마다 실행되며, 매 evaluation 시점의 fresh input으로
   // 3-signal OR 판정. 첫 진입 tick의 ts는 ref에 저장하고 다음 tick부터 elapsed 누적 계산.
   useEffect(() => {
@@ -276,7 +307,21 @@ export function useDeviceSelfEnd(inputs: UseDeviceSelfEndInputs): void {
 
     const verdict = shouldTriggerSelfEnd([s1, s2, s3]);
     if (verdict.trigger && verdict.reason !== null) {
-      void performSelfEnd(verdict.reason, destinationId);
+      const reason = verdict.reason;
+      if (reason === 'fusion-destination') {
+        // #2341 — destination push 관측 또는 백스톱 타임아웃 게이트 통과 후에만 발화.
+        // in-flight 평가 중이면 이번 tick은 skip (완료 시 pending 플래그가 풀려 다음 tick 재평가).
+        if (!destinationGatePendingRef.current) {
+          destinationGatePendingRef.current = true;
+          const matchStartedAt = destinationMatchStartedAtRef.current;
+          void evaluateDestinationPushGate(matchStartedAt, now).then((allowed) => {
+            destinationGatePendingRef.current = false;
+            if (allowed) void performSelfEnd(reason, destinationId);
+          });
+        }
+      } else {
+        void performSelfEnd(reason, destinationId);
+      }
     }
   }, [
     destinationId,
@@ -287,5 +332,6 @@ export function useDeviceSelfEnd(inputs: UseDeviceSelfEndInputs): void {
     inputs.expectedTripDurationMs,
     tripStartedAt,
     performSelfEnd,
+    evaluateDestinationPushGate,
   ]);
 }

--- a/src/features/alarm/utils/__tests__/deviceSelfEndSignals.test.ts
+++ b/src/features/alarm/utils/__tests__/deviceSelfEndSignals.test.ts
@@ -4,6 +4,9 @@ import {
   etaBackstopSignal,
   shouldTriggerSelfEnd,
   isStrongFusionConfidenceForSelfEnd,
+  hasObservedDestinationPush,
+  destinationPushGatePassed,
+  DESTINATION_PUSH_TIMEOUT_MS,
 } from '../deviceSelfEndSignals';
 import type { FusionConfidence } from '../../../../shared/types/fusion';
 
@@ -327,5 +330,87 @@ describe('shouldTriggerSelfEnd', () => {
       { trigger: true, reason: 'eta-backstop' },
     ]);
     expect(v).toEqual({ trigger: true, reason: 'fusion-destination' });
+  });
+});
+
+describe('#2341 hasObservedDestinationPush', () => {
+  it('빈 배열 → false', () => {
+    expect(hasObservedDestinationPush([], NOW)).toBe(false);
+  });
+
+  it('destination kind + silent-push-received + sinceTs 이후 → true', () => {
+    expect(
+      hasObservedDestinationPush(
+        [{ ts: NOW + 1, source: 'silent-push-received', kind: 'destination' }],
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it('ts === sinceTs (경계값) → true', () => {
+    expect(
+      hasObservedDestinationPush(
+        [{ ts: NOW, source: 'silent-push-received', kind: 'destination' }],
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it('ts가 sinceTs 이전 → false (destination-match 시작 이전 push는 이 trip 것 아님)', () => {
+    expect(
+      hasObservedDestinationPush(
+        [{ ts: NOW - 1, source: 'silent-push-received', kind: 'destination' }],
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it('kind가 station-passed/transfer면 destination 아니라 false', () => {
+    expect(
+      hasObservedDestinationPush(
+        [
+          { ts: NOW + 1, source: 'silent-push-received', kind: 'station-passed' },
+          { ts: NOW + 1, source: 'silent-push-received', kind: 'transfer' },
+        ],
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it('source가 silent-push-received 아니면 false (kind만 destination이어도)', () => {
+    expect(
+      hasObservedDestinationPush(
+        [{ ts: NOW + 1, source: 'lifecycle-backstop', kind: 'destination' }],
+        NOW,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('#2341 destinationPushGatePassed', () => {
+  it('push 관측됨 → matchStartedAt/timeout 무관 즉시 true', () => {
+    expect(destinationPushGatePassed(null, NOW, true)).toBe(true);
+    expect(destinationPushGatePassed(NOW, NOW, true)).toBe(true);
+  });
+
+  it('push 미관측 + matchStartedAt null → false', () => {
+    expect(destinationPushGatePassed(null, NOW, false)).toBe(false);
+  });
+
+  it('push 미관측 + 타임아웃 미도달 → false (race 차단)', () => {
+    expect(
+      destinationPushGatePassed(NOW, NOW + DESTINATION_PUSH_TIMEOUT_MS - 1, false),
+    ).toBe(false);
+  });
+
+  it('push 미관측 + 타임아웃 도달 → true (stale-trip 방지 백스톱)', () => {
+    expect(
+      destinationPushGatePassed(NOW, NOW + DESTINATION_PUSH_TIMEOUT_MS, false),
+    ).toBe(true);
+  });
+
+  it('timeoutMs override', () => {
+    expect(destinationPushGatePassed(NOW, NOW + 1_000, false, 1_000)).toBe(true);
+    expect(destinationPushGatePassed(NOW, NOW + 999, false, 1_000)).toBe(false);
   });
 });

--- a/src/features/alarm/utils/deviceSelfEndSignals.ts
+++ b/src/features/alarm/utils/deviceSelfEndSignals.ts
@@ -167,3 +167,54 @@ export function shouldTriggerSelfEnd(
   }
   return { trigger: false, reason: null };
 }
+
+/**
+ * #2341 — Signal 1(fusion-destination)의 destination-match 30s 지속 요구가 backend destination
+ * push(실측 도달 지연 35~51s) 발사보다 먼저 self-end로 trip을 삭제해버리는 race 차단 게이트.
+ *
+ * destination push(source='silent-push-received', kind='destination')가 destination-match
+ * 시작 이후 관측되면 즉시 통과. 관측 안 됐으면 DESTINATION_PUSH_TIMEOUT_MS(기본 4분 — 실측
+ * 지연 35~51s 대비 충분한 여유이면서, backend가 완전 침묵하는 trip이 self-end를 영구히
+ * 대기하는 stale-trip 방지 백스톱) 경과해야만 통과.
+ */
+export const DESTINATION_PUSH_TIMEOUT_MS = 4 * 60_000;
+
+export interface DestinationPushObservationEntry {
+  source: string;
+  kind?: string;
+  ts: number;
+}
+
+/**
+ * alarmLog ring buffer entries에서 destination-match 시작(sinceTs) 이후 도달한 destination
+ * push(visible station kind) 관측 여부를 판정한다. alarmLog.ts의 computeSilentPushReach와
+ * 동일한 '도달=received station kind' 정의를 destination에 한정해 재사용한다.
+ */
+export function hasObservedDestinationPush(
+  entries: readonly DestinationPushObservationEntry[],
+  sinceTs: number,
+): boolean {
+  return entries.some(
+    (entry) =>
+      entry.source === 'silent-push-received' &&
+      entry.kind === 'destination' &&
+      entry.ts >= sinceTs,
+  );
+}
+
+/**
+ * @param destinationMatchStartedAt Signal 1 destination-match 최초 진입 tick의 epoch ms.
+ * @param now                        기준 시각.
+ * @param pushObserved               destination push 관측 여부 (hasObservedDestinationPush 결과).
+ * @param timeoutMs                  백스톱 타임아웃 (기본 DESTINATION_PUSH_TIMEOUT_MS).
+ */
+export function destinationPushGatePassed(
+  destinationMatchStartedAt: number | null,
+  now: number,
+  pushObserved: boolean,
+  timeoutMs: number = DESTINATION_PUSH_TIMEOUT_MS,
+): boolean {
+  if (pushObserved) return true;
+  if (destinationMatchStartedAt === null) return false;
+  return now - destinationMatchStartedAt >= timeoutMs;
+}


### PR DESCRIPTION
Closes #2341

## 요약
목적지 도착 시 device `useDeviceSelfEnd`의 Signal 1(fusion-destination, 30초 지속)이 backend
destination push(실측 도달 지연 35~51s) 발사보다 먼저 trip을 삭제해버리는 race를 수정한다.
2026-08-18 저녁 검증 탑승(용마산 도착 → +2.4초 self-end)에서 확인된 회귀.

## 변경 사항
- `src/features/alarm/utils/deviceSelfEndSignals.ts`
  - `hasObservedDestinationPush(entries, sinceTs)` — alarmLog entries에서 destination-match
    시작 이후 도달한 destination push(`source='silent-push-received'`, `kind='destination'`)
    관측 여부 판정 (읽기 전용 — alarmLog.ts는 수정하지 않음).
  - `destinationPushGatePassed(matchStartedAt, now, pushObserved, timeoutMs)` — push 관측 시
    즉시 통과, 미관측 시 `DESTINATION_PUSH_TIMEOUT_MS`(기본 4분) 백스톱 경과해야 통과.
- `src/features/alarm/hooks/useDeviceSelfEnd.ts`
  - Signal 1(`fusion-destination`) 발화 시 `evaluateDestinationPushGate`로 게이트한 뒤에만
    `performSelfEnd` 호출. Signal 2/3(arc-completion/eta-backstop)는 이번 RCA에서 race가
    확인되지 않아 무변경(별도 이슈 스코프).
  - `destinationGatePendingRef`로 게이트 평가 in-flight 상태의 중복 호출 방지.
- 테스트: 08-18 저녁 시나리오 replay(destination push 미도달 시 30s 지속만으로 cleanup
  보류 확인, push 관측 시 즉시 발화, 4분 타임아웃 백스톱 발화) + 순수 함수 단위 테스트.

## 회귀 방지
- backend가 완전 침묵하는 trip이 self-end를 영구 대기하지 않도록 4분 타임아웃 백스톱 필수
  포함 (stale-trip 방지, lesson_stale_sentinel_kills_new_trip).
- lock 활성 leg도 Signal 1이 `boarding-lock`/`boarding-lock-interp` confidence를 강 신호로
  취급하므로 동일 게이트 적용 — 게이트는 발화를 지연시킬 뿐 차단하지 않아 무회귀.
- 기존 idempotent guard(sentinel)/stale sentinel 판정/same-trip 재발화 억제 로직은 미변경.

## Wire 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — DebugModal Notifications fired 지표 + alarmLog `lifecycle-backstop`
   source(`trip-device-self-end-fusion-destination` reason) 발사 시각으로 게이트 지연/타임아웃
   백스톱 발동 여부 관측 가능.
3. **의존 PR** — N/A.
4. **측정 plan** — 다음 검증 탑승에서 목적지 도착 시 destination imminent 알람 발사 여부 +
   self-end 발화 시각과 backend destination push 도달 시각 순서 확인.
5. **Device verify** — 필요 — BG 환승 trip 목적지 도착 시나리오 실기기 검증.

## 검증
- `npx jest src/features/alarm/utils/__tests__/deviceSelfEndSignals.test.ts src/features/alarm/hooks/__tests__/useDeviceSelfEnd.test.ts --coverage` — 74 passed, 100% coverage (statements/branches/functions/lines)
- `npm run type-check` — pass
- `npm run lint:orphan` — pass (0 orphan)