### PR TITLE
chore(#2343): D1에 cron fire-attempt(성공 포함) 로그 추가

### DIFF
--- a/backend/alarm-worker/src/__tests__/scheduled.test.ts
+++ b/backend/alarm-worker/src/__tests__/scheduled.test.ts
@@ -89,7 +89,7 @@ const APNS_HOSTS = {
 // 실제 device token 길이를 반영한 별도 상수를 collapse-id 전용 테스트에서 사용한다.
 const HEX64_TOKEN = '0123456789abcdef'.repeat(4);
 
-function makeEnv(kv: InMemoryKV, pending?: InMemoryKV): Env {
+function makeEnv(kv: InMemoryKV, pending?: InMemoryKV, db?: D1Database): Env {
   return {
     TRIPS: kv as unknown as KVNamespace,
     APNS_HOST: APNS_HOSTS.production,
@@ -101,7 +101,28 @@ function makeEnv(kv: InMemoryKV, pending?: InMemoryKV): Env {
     APNS_PRIVATE_KEY: apnsConfig.privateKeyPem,
     APNS_BUNDLE_ID: 'com.example.app',
     PENDING_PUSHES: pending ? (pending as unknown as KVNamespace) : undefined,
+    DB: db,
   };
+}
+
+// #2343 — trip_events INSERT 호출을 가로채는 최소 D1 mock. `bind(...).run()` 인자를
+// `inserts` 배열에 축적해 테스트가 실제 D1 없이 fire-attempt 로그 내용을 검증한다.
+// `first()`도 no-op 응답 — pushFailureLog 등 같은 fire path에서 함께 호출되는 다른 D1
+// consumer가 mock 표면 부재로 swallow-warn 노이즈를 내지 않도록 최소 호환.
+function makeFireLogDb(): { db: D1Database; inserts: unknown[][] } {
+  const inserts: unknown[][] = [];
+  const db = {
+    prepare: () => ({
+      bind: (...args: unknown[]) => {
+        inserts.push(args);
+        return {
+          run: async () => ({ success: true }),
+          first: async () => null,
+        };
+      },
+    }),
+  } as unknown as D1Database;
+  return { db, inserts };
 }
 
 // estimateBoardingLockArrival 테스트 공용 — 단일 arvlCd 노출만 검증.
@@ -8157,12 +8178,13 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
     apnsFetch?: ReturnType<typeof vi.fn>;
     pushId?: string;
     seedKv?: (kv: InMemoryKV) => Promise<void>;
+    db?: D1Database;
   }): Promise<{ stats: ScheduledStats; kv: InMemoryKV; apnsFetch: ReturnType<typeof vi.fn> }> {
     const kv = new InMemoryKV();
     await putTrip(kv as unknown as KVNamespace, opts.trip ?? makeLockTrip());
     if (opts.seedKv) await opts.seedKv(kv);
     const apnsFetch = opts.apnsFetch ?? vi.fn(async () => new Response('', { status: 200 }));
-    const stats = await runScheduled(makeEnv(kv), {
+    const stats = await runScheduled(makeEnv(kv, undefined, opts.db), {
       seoul: opts.seoul,
       apnsConfig,
       apnsHosts: APNS_HOSTS,
@@ -8594,6 +8616,115 @@ describe('runScheduled — #917 A2 arvlCd∈{0,1} 매역 알림 발사', () => {
   });
 });
 
+/**
+ * #2343 — cron fire path(destination/transfer/station-passed 발사)를 D1 `trip_events`
+ * (kind='cron-fire-attempt')로 관측. 다음 검증 탑승에서 backend가 실제로 발사했는지를 device
+ * 로그 없이 D1 SELECT만으로 판정할 수 있게 한다(2026-08-18 검증 탑승 blind spot).
+ */
+describe('runScheduled — #2343 cron-fire-attempt D1 로그', () => {
+  const makeLockTrip = (overrides: Partial<Trip> = {}) => makeLockTripFixture('arvl-fire-log', overrides);
+  const makeArrivalSeoul = makeArvlCdFireSeoul;
+
+  it('발사 성공 → trip_events에 kind=cron-fire-attempt / outcome=sent 1건 insert', async () => {
+    const { db, inserts } = makeFireLogDb();
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    await runScheduled(makeEnv(kv, undefined, db), {
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-fire-log-sent',
+    });
+    const fireLogInserts = inserts.filter((args) => args[2] === 'cron-fire-attempt');
+    expect(fireLogInserts).toHaveLength(1);
+    const [, , kind, station, , metaJson] = fireLogInserts[0] as [
+      string,
+      number,
+      string,
+      string | null,
+      string | null,
+      string | null,
+    ];
+    expect(kind).toBe('cron-fire-attempt');
+    expect(station).toBe('중곡');
+    expect(JSON.parse(metaJson!)).toEqual({
+      waypointKind: 'station-passed',
+      phase: 'imminent',
+      outcome: 'sent',
+    });
+  });
+
+  it('발사 실패(push 400) → outcome=failed + reason 기록', async () => {
+    const { db, inserts } = makeFireLogDb();
+    const kv = new InMemoryKV();
+    await putTrip(kv as unknown as KVNamespace, makeLockTrip());
+    const apnsFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ reason: 'BadFoo' }), { status: 400 }),
+    );
+    await runScheduled(makeEnv(kv, undefined, db), {
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: apnsFetch as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-fire-log-failed',
+    });
+    const fireLogInserts = inserts.filter((args) => args[2] === 'cron-fire-attempt');
+    expect(fireLogInserts).toHaveLength(1);
+    const meta = JSON.parse(fireLogInserts[0][5] as string) as {
+      waypointKind: string;
+      phase: string;
+      outcome: string;
+      reason?: string;
+    };
+    expect(meta.outcome).toBe('failed');
+    expect(meta.reason).toBe('BadFoo');
+  });
+
+  it('trip 삭제 race(advanceTripPosition no-trip) → outcome=skipped-reason', async () => {
+    // listTrips가 trip을 읽어 처리 루프에 진입시킨 *직후*, advanceTripPosition 내부의
+    // 독립적인 getTrip 재조회 시점에 trip이 사라진 상황을 시뮬레이션한다 — 같은 trip key에
+    // 대한 2번째 kv.get 호출만 null로 응답해 "listTrips는 읽었지만 그 사이 DELETE됨" 레이스를
+    // 재현한다 (listTrips 1회 get + advanceTripPosition getTrip 1회 get = 2번째 호출).
+    class RaceDeleteKV extends InMemoryKV {
+      private tripKeyGetCount = 0;
+      constructor(private readonly raceKey: string) {
+        super();
+      }
+      async get(key: string, options?: { cacheTtl?: number }): Promise<string | null> {
+        if (key === this.raceKey) {
+          this.tripKeyGetCount += 1;
+          if (this.tripKeyGetCount === 2) return null;
+        }
+        return super.get(key, options);
+      }
+    }
+    const token = 'arvl-fire-log-race';
+    const kv = new RaceDeleteKV(`trip:${token}`);
+    await putTrip(kv as unknown as KVNamespace, makeLockTripFixture(token));
+    const { db, inserts } = makeFireLogDb();
+    await runScheduled(makeEnv(kv as unknown as InMemoryKV, undefined, db), {
+      seoul: makeArrivalSeoul('중곡', 0, 1),
+      apnsConfig,
+      apnsHosts: APNS_HOSTS,
+      fetchImpl: vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch,
+      now: () => NOW,
+      generatePushId: () => 'p-fire-log-race',
+    });
+    const fireLogInserts = inserts.filter((args) => args[2] === 'cron-fire-attempt');
+    expect(fireLogInserts).toHaveLength(1);
+    const meta = JSON.parse(fireLogInserts[0][5] as string) as {
+      waypointKind: string;
+      phase: string;
+      outcome: string;
+      reason?: string;
+    };
+    expect(meta.outcome).toBe('skipped-reason');
+    expect(meta.reason).toBe('no-trip');
+  });
+});
 
 /**
  * ADR-022 Phase 1-1 (#1985) — arvlCd fire-once TTL 게이트 (flag=ON 시).

--- a/backend/alarm-worker/src/scheduled.ts
+++ b/backend/alarm-worker/src/scheduled.ts
@@ -125,7 +125,8 @@ import {
 } from './cronJitterAggregate';
 import { readPushActivityRecent, stampPushActivity } from './cronIdleGate';
 import { hasRescheduleFired, markRescheduleFired } from './rescheduleDedup';
-import { cleanupTripEvents } from './tripEventLog';
+import { cleanupTripEvents, recordTripEvent } from './tripEventLog';
+import { hashTripToken } from './sentry';
 
 // pickApnsHost / flipApnsEnv는 ./apnsHost로 이동 (liveActivity.ts와 공유 SSOT, #482).
 // 외부(테스트 / index.ts 등)가 scheduled.ts 경유로 import하던 호환성 유지를 위해 re-export.
@@ -2370,6 +2371,50 @@ async function maybeFireSleepAlarm(inputs: MaybeFireSleepAlarmInputs): Promise<v
   }
 }
 
+/**
+ * #2343 — `Waypoint.kind`(intermediate/transfer/destination) → fire-attempt 로그 어휘
+ * (station-passed/transfer/destination) 매핑. trip_events.meta에 device/문서 어휘로 남기기 위한
+ * 얇은 변환 — `assertNever`로 신규 kind 추가 시 드리프트를 컴파일 에러로 승격.
+ */
+function fireLogWaypointKind(kind: Waypoint['kind']): 'station-passed' | 'transfer' | 'destination' {
+  switch (kind) {
+    case 'intermediate':
+      return 'station-passed';
+    case 'transfer':
+      return 'transfer';
+    case 'destination':
+      return 'destination';
+    default:
+      return assertNever(kind, 'scheduled.ts fireLogWaypointKind');
+  }
+}
+
+/**
+ * #2343 — cron 자율 fire path(destination/transfer/station-passed) 발사 시도를 D1
+ * `trip_events`(kind='cron-fire-attempt')에 1건만 append한다. 매 tick이 아니라 실제 발사
+ * 시도(성공/실패/trip 삭제 race skip) 시점에만 호출 — Free plan D1 quota 보호(#2073 lesson).
+ * `env.DB` 미바인딩 시 `recordTripEvent`가 graceful no-op.
+ */
+async function recordFireAttempt(
+  env: Env,
+  trip: Trip,
+  waypoint: Waypoint,
+  outcome: 'sent' | 'failed' | 'skipped-reason',
+  now: number,
+  reason?: string,
+): Promise<void> {
+  await recordTripEvent(
+    env.DB,
+    {
+      tokenHash: hashTripToken(trip.token),
+      kind: 'cron-fire-attempt',
+      station: waypoint.stationName,
+      meta: { waypointKind: fireLogWaypointKind(waypoint.kind), phase: 'imminent', outcome, reason },
+    },
+    now,
+  );
+}
+
 // #2063 (ADR-023 개정) — 매역 알림(station-notif) 전용 sleep mute. sleep-transfer(B4)·
 // boarding-prompt(B7/B8) 게이트와는 완전히 별개 — 이 분기는 arvlCd 기반 station-notif fire
 // path(본 함수 + fireVanishFallbackStationPush)에만 적용한다.
@@ -2601,6 +2646,8 @@ export async function fireArvlCdStationPush(
       deps.archFlag,
       env.DB,
     );
+    // #2343 — fire-attempt(실패) D1 관측. 다음 검증 탑승에서 backend 발사 판정에 사용.
+    await recordFireAttempt(env, trip, waypoint, 'failed', now, heal.result.reason);
     // dedup KV는 성공 시에만 stamp — 실패 push는 다음 cycle 재시도 허용.
     return { dirty };
   }
@@ -2645,6 +2692,8 @@ export async function fireArvlCdStationPush(
     hopIndex: waypoint.hopIndex,
     staleMs: ssotForStale?.lastAdvanceAt ? now - ssotForStale.lastAdvanceAt : undefined,
   });
+  // #2343 — fire-attempt(성공) D1 관측. 다음 검증 탑승에서 backend 발사 판정에 사용.
+  await recordFireAttempt(env, trip, waypoint, 'sent', now);
   return { dirty };
 }
 
@@ -2758,6 +2807,12 @@ async function tryAdvanceAndFireArvlcd(inputs: {
       environment: deriveEvidenceEnvironment(trip),
       hopIndex: waypoint.hopIndex,
     });
+    // #2343 — trip 삭제 race(advanceTripPosition 게이트 #5 `no-trip`)만 fire-attempt D1 관측
+    // 대상. 다른 blockReason(모션 정지/env 불일치 등)은 정상 게이트 동작이라 발사 시도 자체가
+    // 아니므로 quota 절약을 위해 로깅하지 않는다.
+    if (outcome.blockReason === 'no-trip') {
+      await recordFireAttempt(env, trip, waypoint, 'skipped-reason', now, 'no-trip');
+    }
     return { dirty: false };
   }
   stats.arvlCdFireFired += 1;

--- a/backend/alarm-worker/src/tripEventLog.ts
+++ b/backend/alarm-worker/src/tripEventLog.ts
@@ -31,6 +31,13 @@ import { captureXEvent } from './sentry';
  * `transferLegConsensus.ts` 상태기계가 산출하는 `LegConsensusEvent`를 D1에 append할 때 쓰는
  * kind. 실제 insert 호출(엔진 이벤트 → 본 kind로 write하는 wire)은 #2329(consensus-C) 범위 —
  * 본 파일은 kind 유니온만 선반영한다.
+ *
+ * `cron-fire-attempt` (#2343) — cron 자율 fire path(`tryAdvanceAndFireArvlcd` /
+ * `fireArvlCdStationPush`, scheduled.ts)가 destination/transfer/station-passed(intermediate)
+ * push를 실제로 발사 시도한 시점에만 append. 매 tick이 아니라 발사 시도(성공/실패/trip 삭제
+ * race skip) 시점 1건만 write — Free plan D1 quota 보호(#2073 lesson). `meta`에
+ * `{ waypointKind, phase, outcome, reason? }`을 싣는다 — 새 kind를 추가하지 않고 기존
+ * trip_events 스키마를 재사용(quota 증분 최소화).
  */
 export type TripEventKind =
   | 'sync-received'
@@ -39,7 +46,8 @@ export type TripEventKind =
   | 'trip-end'
   | 'consensus-confirm'
   | 'consensus-demote'
-  | 'consensus-suppress';
+  | 'consensus-suppress'
+  | 'cron-fire-attempt';
 
 export interface TripEventInput {
   /** trip token의 해시(hashTripToken 결과). 원본 token은 D1에 남기지 않는다. */


### PR DESCRIPTION
## 배경
2026-08-18 검증 탑승에서 backend가 destination imminent를 실제로 쐈는지 판정할 결정타가 D1 어디에도 없어 device 로그로만 추정해야 했다. cron 자율 fire/advance는 trip_events(HTTP sync만 기록)에 안 남고, 성공 발사 카운터(Analytics Engine)는 Free plan에서 비활성이라 backend 발사 판정이 구조적으로 blind했다.

## 변경 사항
- `tripEventLog.ts`: `trip_events.kind` 유니온에 `cron-fire-attempt` 추가. 신규 테이블 없이 기존 append-only 스키마(`token_hash`/`station`/`meta`) 재사용 — quota 증분 최소화.
- `scheduled.ts`:
  - `fireArvlCdStationPush` 성공 직후 → `outcome: 'sent'` 1건 append.
  - 같은 함수의 push 실패 분기 → `outcome: 'failed'` + `reason`(APNs 실패 사유) 1건 append.
  - `tryAdvanceAndFireArvlcd`에서 `advanceTripPosition` 게이트 #5(`blockReason === 'no-trip'`, trip이 listTrips 읽은 시점 이후 삭제된 race)일 때만 → `outcome: 'skipped-reason'` + `reason: 'no-trip'` 1건 append. 다른 gate block(motion-stationary 등)은 정상 게이트 동작이라 로깅하지 않음 — quota 보호.
  - `meta`에 `{ waypointKind: 'destination'|'transfer'|'station-passed', phase: 'imminent', outcome, reason? }` 기록.
- Free plan 제약 준수: 매 cron tick이 아니라 실제 발사 시도(성공/실패/race skip) 시점에만, trip당 소수(1건) write.

## Wire 5단
1. **Orphan 없음** — 신규 export 없음(`recordFireAttempt`/`fireLogWaypointKind`는 module-private). 프론트 변경 없어 `lint:orphan` 대상 아님.
2. **V/X dashboard** — `wrangler d1 execute alarm-worker-db --command "SELECT * FROM trip_events WHERE kind='cron-fire-attempt' ORDER BY ts DESC LIMIT 50"`로 관측. `token_hash`로 특정 trip 타임라인 재구성 가능.
3. **의존 PR** — N/A.
4. **측정 plan** — 다음 검증 탑승에서 destination imminent 구간을 위 쿼리로 직접 조회해 backend 발사 여부를 device 로그 없이 D1만으로 판정한다.
5. **Device verify** — backend-only, code-only. type-check + unit(vitest coverage ratchet)만 검증. **머지 후 `wrangler deploy` 필요** — deploy 전까지는 로그가 남지 않는다.

Closes #2343