### PR TITLE
feat: BG location adaptive profile 인프라 + V8a 정지 시 interval 완화

### DIFF
--- a/src/features/nearest-station/hooks/__tests__/useBackgroundLocation.test.ts
+++ b/src/features/nearest-station/hooks/__tests__/useBackgroundLocation.test.ts
@@ -4,7 +4,11 @@
 import { renderHook, waitFor } from '@testing-library/react-native';
 import { Alert, Linking } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { BG_PERMISSION_DENIED_DISMISSED_KEY } from '../../../../shared/constants/storageKeys';
+import {
+  BG_PERMISSION_DENIED_DISMISSED_KEY,
+  BG_FOREGROUND_SERVICE_TEXT_KEY,
+  BG_LOCATION_PROFILE_KEY,
+} from '../../../../shared/constants/storageKeys';
 import type { Station } from '../../../../shared/types/station';
 
 // ── Alert.alert / Linking.openSettings 모킹 ──
@@ -210,6 +214,24 @@ describe('useBackgroundLocation (#1973 명시 trigger)', () => {
       notificationTitle: '지하철 위치 감지 중',
       notificationBody: '백그라운드에서 현재 역을 추적하고 있습니다',
     });
+  });
+
+  // ── #2344 (V8a) — profile 전환 인프라를 위한 foregroundService 텍스트 캐시 + profile 초기화 ──
+
+  it('#2344 — startLocationUpdatesAsync 성공 시 foregroundService 텍스트를 캐시하고 profile을 surface로 초기화한다', async () => {
+    renderHook(() => useBackgroundLocation(mockDestination));
+
+    await waitFor(() => {
+      expect(mockStartLocationUpdatesAsync).toHaveBeenCalled();
+    });
+
+    expect(await AsyncStorage.getItem(BG_FOREGROUND_SERVICE_TEXT_KEY)).toBe(
+      JSON.stringify({
+        notificationTitle: '지하철 위치 감지 중',
+        notificationBody: '백그라운드에서 현재 역을 추적하고 있습니다',
+      }),
+    );
+    expect(await AsyncStorage.getItem(BG_LOCATION_PROFILE_KEY)).toBe('surface');
   });
 
   // ── #1973 권한 단계화: WhileInUse granted + Always denied (네이버 패턴 핵심) ──

--- a/src/features/nearest-station/hooks/useBackgroundLocation.ts
+++ b/src/features/nearest-station/hooks/useBackgroundLocation.ts
@@ -12,6 +12,8 @@ import { BACKGROUND_LOCATION_TASK } from '../tasks/backgroundLocationTask';
 import { LOCATION_TRACKING_OPTIONS } from '../../../shared/constants/locationTracking';
 import { BG_PERMISSION_DENIED_DISMISSED_KEY } from '../../../shared/constants/storageKeys';
 import { createLogger } from '../../../shared/utils/logger';
+// #2344 (V8a) — BG task 콜백이 profile 전환(stop→start) 시 재사용할 foregroundService 텍스트 캐시.
+import { saveForegroundServiceNotification, resetBgLocationProfile } from '../utils/bgLocationProfile';
 // eslint-disable-next-line import/no-restricted-paths
 import { useNavigationStore } from '../../route/store/useNavigationStore';
 
@@ -100,15 +102,20 @@ export function useBackgroundLocation(destination: Station | null): void {
       const isRegistered = await TaskManager.isTaskRegisteredAsync(BACKGROUND_LOCATION_TASK);
       if (isRegistered || cancelled) return;
 
+      // foregroundService 알림 텍스트는 task 시작 시점 언어로 고정. 사용자가 추적 중 언어를
+      // 바꿔도 GPS 추적 공백을 만들지 않기 위해 i18n.language를 deps에 두지 않는다.
+      // 다음 destination 변경 시점에 자연스럽게 새 언어로 반영된다.
+      const foregroundService = {
+        notificationTitle: t('background.title'),
+        notificationBody: t('background.body'),
+      };
+      // #2344 — BG task가 profile 전환(stop→start) 시 동일 텍스트로 재시작할 수 있도록 캐시.
+      await saveForegroundServiceNotification(foregroundService);
+      // 이 hook은 항상 surface 옵션으로 시작하므로 이전 trip의 stale 'stationary' 기록을 초기화한다.
+      await resetBgLocationProfile();
       await Location.startLocationUpdatesAsync(BACKGROUND_LOCATION_TASK, {
         ...LOCATION_TRACKING_OPTIONS,
-        // foregroundService 알림 텍스트는 task 시작 시점 언어로 고정. 사용자가 추적 중 언어를
-        // 바꿔도 GPS 추적 공백을 만들지 않기 위해 i18n.language를 deps에 두지 않는다.
-        // 다음 destination 변경 시점에 자연스럽게 새 언어로 반영된다.
-        foregroundService: {
-          notificationTitle: t('background.title'),
-          notificationBody: t('background.body'),
-        },
+        foregroundService,
       });
       logger.info('백그라운드 위치 추적 시작 (navigationActive)');
     })();

--- a/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/backgroundLocationTask.test.ts
@@ -58,6 +58,12 @@ jest.mock('../../utils/motionActivity', () => ({
   getCurrentMotionStationary: () => mockGetCurrentMotionStationary(),
 }));
 
+// ── bgLocationProfile 모킹 (#2344 V8a profile 전환) ──
+const mockApplyBgLocationProfile = jest.fn();
+jest.mock('../../utils/bgLocationProfile', () => ({
+  applyBgLocationProfile: (...args: unknown[]) => mockApplyBgLocationProfile(...args),
+}));
+
 // ── accelMotionState 모킹 (#823 가속도 latest 첨부) ──
 const mockGetLatestAccelSummary = jest.fn();
 jest.mock('../../utils/accelMotionState', () => ({
@@ -217,6 +223,7 @@ describe('backgroundLocationTask defineTask 콜백', () => {
     // #2178 — pull death backstop 기본값: baseUrl 없음(호출 안 함). 개별 테스트에서 override.
     mockGetTripDeathPullBackendUrl.mockReturnValue(null);
     mockCheckTripDeathByPull.mockResolvedValue('skipped');
+    mockApplyBgLocationProfile.mockResolvedValue(undefined);
   });
 
   it('defineTask가 올바른 태스크 이름으로 등록된다', () => {
@@ -1154,6 +1161,48 @@ describe('backgroundLocationTask defineTask 콜백', () => {
 
       expect(mockUploadPosition).toHaveBeenCalledWith(expect.objectContaining({ motion: 'stationary' }));
       expect(mockProcessLocationUpdate).not.toHaveBeenCalled();
+    });
+
+    describe('#2344 (V8a) — BG location profile 전환', () => {
+      it('motionStationary=true → applyBgLocationProfile(TASK, "stationary") 호출', async () => {
+        mockGetCurrentMotionStationary.mockReturnValue(true);
+        mockStorageValues(JSON.stringify(mockDestination));
+
+        await taskCallback({
+          data: { locations: [makeLocation(37.498, 127.028, { accuracy: 30 })] },
+          error: null,
+        });
+
+        expect(mockApplyBgLocationProfile).toHaveBeenCalledWith(
+          BACKGROUND_LOCATION_TASK,
+          'stationary',
+        );
+      });
+
+      it('motionStationary=false → applyBgLocationProfile(TASK, "surface") 호출', async () => {
+        mockGetCurrentMotionStationary.mockReturnValue(false);
+        mockStorageValues(JSON.stringify(mockDestination));
+
+        await taskCallback({
+          data: { locations: [makeLocation(37.498, 127.028, { accuracy: 30 })] },
+          error: null,
+        });
+
+        expect(mockApplyBgLocationProfile).toHaveBeenCalledWith(BACKGROUND_LOCATION_TASK, 'surface');
+      });
+
+      it('applyBgLocationProfile이 reject해도 태스크는 크래시하지 않는다 (graceful)', async () => {
+        mockGetCurrentMotionStationary.mockReturnValue(true);
+        mockApplyBgLocationProfile.mockRejectedValueOnce(new Error('restart failed'));
+        mockStorageValues(JSON.stringify(mockDestination));
+
+        await expect(
+          taskCallback({
+            data: { locations: [makeLocation(37.498, 127.028, { accuracy: 30 })] },
+            error: null,
+          }),
+        ).resolves.toBeUndefined();
+      });
     });
 
     describe('#1667 (ADR-015 strongDB wire) — wifiSsidStationName forward', () => {

--- a/src/features/nearest-station/tasks/__tests__/foregroundBackgroundTransition.test.ts
+++ b/src/features/nearest-station/tasks/__tests__/foregroundBackgroundTransition.test.ts
@@ -48,7 +48,18 @@ jest.mock('expo-task-manager', () => ({
   },
 }));
 
-jest.mock('expo-location', () => ({}));
+// #2344 — locationTracking.ts(BASE_TRACKING_OPTIONS)가 모듈 로드 시점에 Location.Accuracy /
+// Location.LocationActivityType을 참조한다. 이 파일은 backgroundLocationTask → bgLocationProfile
+// → locationTracking을 실제 모듈로 로드하므로(상단 헤더 주석 "외부 boundary만 mock" 참고) 해당
+// enum 값이 mock에 있어야 import 체인이 깨지지 않는다. stopLocationUpdatesAsync /
+// startLocationUpdatesAsync는 bgLocationProfile의 프로파일 전환 경로가 호출할 수 있어 결정적
+// no-op으로 제공한다(이 테스트는 프로파일 전환 자체를 검증 대상으로 삼지 않는다).
+jest.mock('expo-location', () => ({
+  Accuracy: { High: 6, Balanced: 3 },
+  LocationActivityType: { AutomotiveNavigation: 2 },
+  stopLocationUpdatesAsync: jest.fn(() => Promise.resolve()),
+  startLocationUpdatesAsync: jest.fn(() => Promise.resolve()),
+}));
 
 // ── 외부 boundary fake: 결정적 동작 ──
 const fakeStation = {

--- a/src/features/nearest-station/tasks/backgroundLocationTask.ts
+++ b/src/features/nearest-station/tasks/backgroundLocationTask.ts
@@ -20,6 +20,7 @@ import { BG_LAST_FIX_KEY, BG_LAST_STATION_KEY, BG_LAST_POSITION_UPLOAD_AT_KEY } 
 import { uploadPosition, type PositionMotion } from '../api/positionUpload';
 import { POSITION_UPLOAD_MIN_INTERVAL_MS } from '../../../shared/constants/location';
 import { getCurrentMotionStationary } from '../utils/motionActivity';
+import { applyBgLocationProfile } from '../utils/bgLocationProfile';
 import { getLatestAccelSummary } from '../utils/accelMotionState';
 // #1542 (ADR-016 S9) — CMMotionManager accelerometer fingerprint (Background Location piggyback).
 // BG location updates 활성 동안 raw 가속도 5Hz sampling 시작 — 정적 native module (no-op if already
@@ -261,6 +262,17 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     // BG에서는 motion 신선도를 별도로 관리할 수 없으므로 getCurrentMotionStationary()의 graceful
     // fallback(미지원/권한 거절 → false)에 의존한다. false이면 게이트를 건너뛰고 기존 경로를 유지.
     const motionStationary = getCurrentMotionStationary();
+
+    // #2344 (V8a) — 정지 확정 시 BG location interval을 완화(stationary 프리셋)하고, 이동 재개
+    // 시 surface로 즉시 복귀한다. fire-and-forget — stop→start 재시작이 이번 tick의 알람 파이프라인
+    // 처리를 막지 않는다(다음 tick부터 새 interval 적용). accuracy는 미접촉, timeInterval만 전환.
+    void applyBgLocationProfile(
+      BACKGROUND_LOCATION_TASK,
+      motionStationary === true ? 'stationary' : 'surface',
+    ).catch((e: unknown) => {
+      logger.warn('BG location profile 전환 실패 (graceful)', e);
+    });
+
     const motionSignal = evaluateMovement(
       { timestamp: latest.timestamp, accuracyM: accuracy ?? undefined, speedMps: speedMps ?? undefined },
       Date.now(),

--- a/src/features/nearest-station/utils/__tests__/bgLocationProfile.test.ts
+++ b/src/features/nearest-station/utils/__tests__/bgLocationProfile.test.ts
@@ -1,0 +1,230 @@
+const mockStopLocationUpdatesAsync = jest.fn();
+const mockStartLocationUpdatesAsync = jest.fn();
+jest.mock('expo-location', () => ({
+  Accuracy: { High: 6, Balanced: 3 },
+  LocationActivityType: { AutomotiveNavigation: 2 },
+  stopLocationUpdatesAsync: (...args: unknown[]) => mockStopLocationUpdatesAsync(...args),
+  startLocationUpdatesAsync: (...args: unknown[]) => mockStartLocationUpdatesAsync(...args),
+}));
+
+const mockGetItem = jest.fn();
+const mockSetItem = jest.fn();
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: (...args: unknown[]) => mockGetItem(...args),
+  setItem: (...args: unknown[]) => mockSetItem(...args),
+}));
+
+jest.mock('../../../../shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import {
+  applyBgLocationProfile,
+  saveForegroundServiceNotification,
+  resetBgLocationProfile,
+} from '../bgLocationProfile';
+import {
+  BG_LOCATION_PROFILE_KEY,
+  BG_LOCATION_PROFILE_FLIP_COUNT_KEY,
+  BG_FOREGROUND_SERVICE_TEXT_KEY,
+} from '../../../../shared/constants/storageKeys';
+import { LOCATION_TRACKING_OPTIONS_STATIONARY } from '../../../../shared/constants/locationTracking';
+
+const TASK_NAME = 'background-location-task';
+
+describe('bgLocationProfile', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetItem.mockResolvedValue(null);
+    mockSetItem.mockResolvedValue(undefined);
+    mockStopLocationUpdatesAsync.mockResolvedValue(undefined);
+    mockStartLocationUpdatesAsync.mockResolvedValue(undefined);
+  });
+
+  describe('applyBgLocationProfile', () => {
+    it('현재 프로파일과 desiredProfile이 같으면(default surface) 재시작하지 않는다', async () => {
+      mockGetItem.mockImplementation((key: string) =>
+        key === BG_LOCATION_PROFILE_KEY ? Promise.resolve(null) : Promise.resolve(null),
+      );
+
+      await applyBgLocationProfile(TASK_NAME, 'surface');
+
+      expect(mockStopLocationUpdatesAsync).not.toHaveBeenCalled();
+      expect(mockStartLocationUpdatesAsync).not.toHaveBeenCalled();
+    });
+
+    it('surface → stationary 전환 시 stop→start로 재시작하고 flip count를 증가시킨다', async () => {
+      mockGetItem.mockImplementation((key: string) => {
+        if (key === BG_LOCATION_PROFILE_KEY) return Promise.resolve(null); // surface
+        if (key === BG_LOCATION_PROFILE_FLIP_COUNT_KEY) return Promise.resolve('2');
+        if (key === BG_FOREGROUND_SERVICE_TEXT_KEY)
+          return Promise.resolve(
+            JSON.stringify({ notificationTitle: '제목', notificationBody: '본문' }),
+          );
+        return Promise.resolve(null);
+      });
+
+      await applyBgLocationProfile(TASK_NAME, 'stationary');
+
+      expect(mockStopLocationUpdatesAsync).toHaveBeenCalledWith(TASK_NAME);
+      expect(mockStartLocationUpdatesAsync).toHaveBeenCalledWith(TASK_NAME, {
+        ...LOCATION_TRACKING_OPTIONS_STATIONARY,
+        foregroundService: { notificationTitle: '제목', notificationBody: '본문' },
+      });
+      expect(mockSetItem).toHaveBeenCalledWith(BG_LOCATION_PROFILE_KEY, 'stationary');
+      expect(mockSetItem).toHaveBeenCalledWith(BG_LOCATION_PROFILE_FLIP_COUNT_KEY, '3');
+    });
+
+    it('stationary → surface(이동 재개) 전환도 즉시 재시작한다', async () => {
+      mockGetItem.mockImplementation((key: string) => {
+        if (key === BG_LOCATION_PROFILE_KEY) return Promise.resolve('stationary');
+        return Promise.resolve(null);
+      });
+
+      await applyBgLocationProfile(TASK_NAME, 'surface');
+
+      expect(mockStopLocationUpdatesAsync).toHaveBeenCalledWith(TASK_NAME);
+      expect(mockStartLocationUpdatesAsync).toHaveBeenCalledWith(
+        TASK_NAME,
+        expect.objectContaining({ timeInterval: 30_000 }),
+      );
+      expect(mockSetItem).toHaveBeenCalledWith(BG_LOCATION_PROFILE_KEY, 'surface');
+    });
+
+    it('foregroundService 텍스트 캐시 부재 시 폴백 텍스트를 사용한다', async () => {
+      mockGetItem.mockResolvedValue(null);
+
+      await applyBgLocationProfile(TASK_NAME, 'stationary');
+
+      expect(mockStartLocationUpdatesAsync).toHaveBeenCalledWith(
+        TASK_NAME,
+        expect.objectContaining({
+          foregroundService: { notificationTitle: 'Subway Now', notificationBody: 'Tracking your location' },
+        }),
+      );
+    });
+
+    it('foregroundService 텍스트 캐시가 파싱 불가면 폴백 텍스트를 사용한다', async () => {
+      mockGetItem.mockImplementation((key: string) => {
+        if (key === BG_FOREGROUND_SERVICE_TEXT_KEY) return Promise.resolve('not-json');
+        return Promise.resolve(null);
+      });
+
+      await applyBgLocationProfile(TASK_NAME, 'stationary');
+
+      expect(mockStartLocationUpdatesAsync).toHaveBeenCalledWith(
+        TASK_NAME,
+        expect.objectContaining({
+          foregroundService: { notificationTitle: 'Subway Now', notificationBody: 'Tracking your location' },
+        }),
+      );
+    });
+
+    it('foregroundService 텍스트 캐시 shape이 잘못되면 폴백 텍스트를 사용한다', async () => {
+      mockGetItem.mockImplementation((key: string) => {
+        if (key === BG_FOREGROUND_SERVICE_TEXT_KEY) return Promise.resolve(JSON.stringify({ foo: 'bar' }));
+        return Promise.resolve(null);
+      });
+
+      await applyBgLocationProfile(TASK_NAME, 'stationary');
+
+      expect(mockStartLocationUpdatesAsync).toHaveBeenCalledWith(
+        TASK_NAME,
+        expect.objectContaining({
+          foregroundService: { notificationTitle: 'Subway Now', notificationBody: 'Tracking your location' },
+        }),
+      );
+    });
+
+    it('AsyncStorage.getItem(profile) 예외 시 surface로 graceful fallback한다', async () => {
+      mockGetItem.mockImplementation((key: string) => {
+        if (key === BG_LOCATION_PROFILE_KEY) return Promise.reject(new Error('storage down'));
+        return Promise.resolve(null);
+      });
+
+      await applyBgLocationProfile(TASK_NAME, 'surface');
+
+      // fallback profile('surface') === desiredProfile('surface') → 재시작 없음
+      expect(mockStopLocationUpdatesAsync).not.toHaveBeenCalled();
+    });
+
+    it('flip count 파싱 실패 시 0에서 시작해 1로 증가시킨다', async () => {
+      mockGetItem.mockImplementation((key: string) => {
+        if (key === BG_LOCATION_PROFILE_KEY) return Promise.resolve(null);
+        if (key === BG_LOCATION_PROFILE_FLIP_COUNT_KEY) return Promise.resolve('not-a-number');
+        return Promise.resolve(null);
+      });
+
+      await applyBgLocationProfile(TASK_NAME, 'stationary');
+
+      expect(mockSetItem).toHaveBeenCalledWith(BG_LOCATION_PROFILE_FLIP_COUNT_KEY, '1');
+    });
+
+    it('flip count 저장 실패 시 graceful하게 0을 반환하고 계속 진행한다', async () => {
+      mockGetItem.mockImplementation((key: string) => {
+        if (key === BG_LOCATION_PROFILE_KEY) return Promise.resolve(null);
+        return Promise.resolve(null);
+      });
+      mockSetItem.mockImplementation((key: string) => {
+        if (key === BG_LOCATION_PROFILE_FLIP_COUNT_KEY) return Promise.reject(new Error('fail'));
+        return Promise.resolve(undefined);
+      });
+
+      await expect(applyBgLocationProfile(TASK_NAME, 'stationary')).resolves.toBeUndefined();
+    });
+
+    it('stopLocationUpdatesAsync 실패 시 예외를 흡수한다(graceful)', async () => {
+      mockGetItem.mockImplementation((key: string) => {
+        if (key === BG_LOCATION_PROFILE_KEY) return Promise.resolve(null);
+        return Promise.resolve(null);
+      });
+      mockStopLocationUpdatesAsync.mockRejectedValue(new Error('stop failed'));
+
+      await expect(applyBgLocationProfile(TASK_NAME, 'stationary')).resolves.toBeUndefined();
+      expect(mockStartLocationUpdatesAsync).not.toHaveBeenCalled();
+      // 재시작이 실패했으므로 프로파일 키를 갱신하지 않는다.
+      expect(mockSetItem).not.toHaveBeenCalledWith(BG_LOCATION_PROFILE_KEY, 'stationary');
+    });
+  });
+
+  describe('saveForegroundServiceNotification', () => {
+    it('AsyncStorage에 JSON으로 저장한다', async () => {
+      await saveForegroundServiceNotification({
+        notificationTitle: '제목',
+        notificationBody: '본문',
+      });
+
+      expect(mockSetItem).toHaveBeenCalledWith(
+        BG_FOREGROUND_SERVICE_TEXT_KEY,
+        JSON.stringify({ notificationTitle: '제목', notificationBody: '본문' }),
+      );
+    });
+
+    it('저장 실패는 graceful하게 흡수한다', async () => {
+      mockSetItem.mockRejectedValue(new Error('fail'));
+
+      await expect(
+        saveForegroundServiceNotification({ notificationTitle: 'a', notificationBody: 'b' }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('resetBgLocationProfile', () => {
+    it('BG_LOCATION_PROFILE_KEY를 surface로 초기화한다', async () => {
+      await resetBgLocationProfile();
+
+      expect(mockSetItem).toHaveBeenCalledWith(BG_LOCATION_PROFILE_KEY, 'surface');
+    });
+
+    it('저장 실패는 graceful하게 흡수한다', async () => {
+      mockSetItem.mockRejectedValue(new Error('fail'));
+
+      await expect(resetBgLocationProfile()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/features/nearest-station/utils/bgLocationProfile.ts
+++ b/src/features/nearest-station/utils/bgLocationProfile.ts
@@ -1,0 +1,133 @@
+/**
+ * #2344 (V8a) — BG location 추적 프로파일 전환 인프라.
+ *
+ * expo-location은 옵션 라이브 변경이 불가하다 — 프로파일(surface↔stationary)을 바꾸려면
+ * stopLocationUpdatesAsync → startLocationUpdatesAsync 재시작뿐이다. BG task는 React tree
+ * 밖에서 도는 TaskManager 콜백이라, 이 재시작을 콜백 내부에서 자기호출로 수행한다
+ * (코드베이스 선례 없음 — 실기기 검증 필요).
+ *
+ * 전환 지점을 이 모듈 하나로 일반화해 ②(accuracy 강등, #2345)가 동일 mechanism을 재사용한다.
+ */
+import * as Location from 'expo-location';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { createLogger } from '../../../shared/utils/logger';
+import {
+  locationTrackingOptionsForProfile,
+  type BgLocationProfile,
+} from '../../../shared/constants/locationTracking';
+import {
+  BG_LOCATION_PROFILE_KEY,
+  BG_LOCATION_PROFILE_FLIP_COUNT_KEY,
+  BG_FOREGROUND_SERVICE_TEXT_KEY,
+} from '../../../shared/constants/storageKeys';
+
+const logger = createLogger('BgLocationProfile');
+
+// i18n `t()`에 접근할 수 없는 콜백 컨텍스트를 위한 폴백. 정상 흐름에서는 useBackgroundLocation이
+// 항상 BG_FOREGROUND_SERVICE_TEXT_KEY를 먼저 적재하므로 이 값은 방어용으로만 쓰인다.
+const FALLBACK_FOREGROUND_SERVICE_NOTIFICATION = {
+  notificationTitle: 'Subway Now',
+  notificationBody: 'Tracking your location',
+} as const;
+
+interface ForegroundServiceNotification {
+  notificationTitle: string;
+  notificationBody: string;
+}
+
+/**
+ * useBackgroundLocation이 startLocationUpdatesAsync(surface 옵션)를 직접 호출해 task를 시작할
+ * 때, 이전 trip에서 남은 stale 'stationary' 기록을 지운다. 이 초기화가 없으면 새 trip의 실제
+ * 실행 옵션(surface)과 저장된 프로파일('stationary')이 어긋나 applyBgLocationProfile이 첫 tick에
+ * 재시작을 건너뛰는(no-op 오판) 회귀가 생긴다.
+ */
+export async function resetBgLocationProfile(): Promise<void> {
+  try {
+    await AsyncStorage.setItem(BG_LOCATION_PROFILE_KEY, 'surface');
+  } catch (e) {
+    logger.warn('BG location profile 초기화 실패', e);
+  }
+}
+
+/** useBackgroundLocation이 startLocationUpdatesAsync 호출 시 사용한 알림 텍스트를 저장한다. */
+export async function saveForegroundServiceNotification(
+  notification: ForegroundServiceNotification,
+): Promise<void> {
+  try {
+    await AsyncStorage.setItem(BG_FOREGROUND_SERVICE_TEXT_KEY, JSON.stringify(notification));
+  } catch (e) {
+    logger.warn('foregroundService 텍스트 저장 실패', e);
+  }
+}
+
+async function readForegroundServiceNotification(): Promise<ForegroundServiceNotification> {
+  try {
+    const raw = await AsyncStorage.getItem(BG_FOREGROUND_SERVICE_TEXT_KEY);
+    if (!raw) return FALLBACK_FOREGROUND_SERVICE_NOTIFICATION;
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof (parsed as ForegroundServiceNotification).notificationTitle === 'string' &&
+      typeof (parsed as ForegroundServiceNotification).notificationBody === 'string'
+    ) {
+      return parsed as ForegroundServiceNotification;
+    }
+    return FALLBACK_FOREGROUND_SERVICE_NOTIFICATION;
+  } catch {
+    return FALLBACK_FOREGROUND_SERVICE_NOTIFICATION;
+  }
+}
+
+async function readCurrentProfile(): Promise<BgLocationProfile> {
+  try {
+    const raw = await AsyncStorage.getItem(BG_LOCATION_PROFILE_KEY);
+    return raw === 'stationary' ? 'stationary' : 'surface';
+  } catch {
+    return 'surface';
+  }
+}
+
+async function bumpFlipCount(): Promise<number> {
+  try {
+    const raw = await AsyncStorage.getItem(BG_LOCATION_PROFILE_FLIP_COUNT_KEY);
+    const parsed = Number(raw);
+    const next = (Number.isFinite(parsed) ? parsed : 0) + 1;
+    await AsyncStorage.setItem(BG_LOCATION_PROFILE_FLIP_COUNT_KEY, String(next));
+    return next;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * motion 신호로 결정된 desiredProfile을 현재 영속 프로파일과 비교해 다르면 stop→start로
+ * 재시작한다. 같으면 no-op(매 tick 불필요한 재시작 방지 — 재시작 자체가 짧은 GPS 공백을 만든다).
+ *
+ * hysteresis: "정지 확정"은 motionStationary(CMMotionActivity) 신호가 이미 확정치를 제공하므로
+ * 별도 debounce를 추가하지 않는다. "이동 재개 시 즉시 surface 복귀"도 동일 신호를 그대로
+ * 반영하는 것으로 자연히 만족된다(비대칭 debounce가 필요 없음).
+ */
+export async function applyBgLocationProfile(
+  taskName: string,
+  desiredProfile: BgLocationProfile,
+): Promise<void> {
+  const currentProfile = await readCurrentProfile();
+  if (currentProfile === desiredProfile) return;
+
+  try {
+    await Location.stopLocationUpdatesAsync(taskName);
+    const foregroundService = await readForegroundServiceNotification();
+    await Location.startLocationUpdatesAsync(taskName, {
+      ...locationTrackingOptionsForProfile(desiredProfile),
+      foregroundService,
+    });
+    await AsyncStorage.setItem(BG_LOCATION_PROFILE_KEY, desiredProfile);
+    const flipCount = await bumpFlipCount();
+    logger.info(
+      `BG location profile 전환: ${currentProfile} → ${desiredProfile} (flip #${flipCount})`,
+    );
+  } catch (e) {
+    logger.error('BG location profile 전환 실패', e);
+  }
+}

--- a/src/shared/constants/__tests__/locationTracking.test.ts
+++ b/src/shared/constants/__tests__/locationTracking.test.ts
@@ -1,0 +1,23 @@
+import {
+  LOCATION_TRACKING_OPTIONS,
+  LOCATION_TRACKING_OPTIONS_STATIONARY,
+  locationTrackingOptionsForProfile,
+} from '../locationTracking';
+
+describe('locationTracking profiles', () => {
+  it('surface 프로파일은 기본 LOCATION_TRACKING_OPTIONS(30s)를 반환한다', () => {
+    expect(locationTrackingOptionsForProfile('surface')).toBe(LOCATION_TRACKING_OPTIONS);
+    expect(LOCATION_TRACKING_OPTIONS.timeInterval).toBe(30_000);
+  });
+
+  it('stationary 프로파일은 완화된 timeInterval을 반환하고 accuracy는 동일(High)하다', () => {
+    expect(locationTrackingOptionsForProfile('stationary')).toBe(LOCATION_TRACKING_OPTIONS_STATIONARY);
+    expect(LOCATION_TRACKING_OPTIONS_STATIONARY.timeInterval).toBeGreaterThan(
+      LOCATION_TRACKING_OPTIONS.timeInterval,
+    );
+    expect(LOCATION_TRACKING_OPTIONS_STATIONARY.accuracy).toBe(LOCATION_TRACKING_OPTIONS.accuracy);
+    expect(LOCATION_TRACKING_OPTIONS_STATIONARY.distanceInterval).toBe(
+      LOCATION_TRACKING_OPTIONS.distanceInterval,
+    );
+  });
+});

--- a/src/shared/constants/locationTracking.ts
+++ b/src/shared/constants/locationTracking.ts
@@ -4,9 +4,14 @@ import * as Location from 'expo-location';
 const TRACKING_DISTANCE_INTERVAL_M = 20;
 // 거리 변화 없어도 30s마다 콜백 강제 (Android 약신호 환경 보강).
 const TRACKING_TIME_INTERVAL_MS = 30_000;
+// #2344 (V8a) — 정지 확정(motion stationary) 구간의 완화 interval. surface(30s) 대비 3배.
+// accuracy/distanceInterval은 미접촉(정지 중엔 거리 변화 자체가 거의 없어 distanceInterval
+// 트리거는 의미가 작다) — 배터리 절감은 timeInterval 완화만으로 충분하고, 이동 재개 감지는
+// getCurrentMotionStationary()가 매 tick 재평가하므로 별도 폴링 공백이 생기지 않는다.
+const TRACKING_STATIONARY_TIME_INTERVAL_MS = 90_000;
 
-// 백그라운드 위치 추적 옵션 — 플랫폼 공통 설정.
-// i18n 의존이 있는 `foregroundService`만 호출부에서 인라인으로 결합한다.
+// 백그라운드 위치 추적 프로파일. `foregroundService`는 i18n 의존이 있어 호출부에서 인라인으로
+// 결합한다.
 //
 // - `timeInterval`: Android에서 거리 변화가 없어도 주기적 콜백 보장 (지하/터널 약신호 환경).
 // - `pausesUpdatesAutomatically: false`: iOS의 stationary 오판으로 인한 업데이트 중단 차단.
@@ -21,11 +26,33 @@ const TRACKING_TIME_INTERVAL_MS = 30_000;
 //   GPS 부정확도를 보정 — 표시는 가능, 알람은 별도 엄격 게이트로 차단). 배터리 영향도 BestForNavigation
 //   대비 낮다. 본 앱은 차량 내비가 아니라 지하철 추적이므로 정확도 vs 배터리 vs 지하 가용성 균형이
 //   High가 최적.
-export const LOCATION_TRACKING_OPTIONS = {
+// #2344 — profile object 인프라. accuracy는 두 프로파일 모두 High로 유지(미접촉) — interval만
+// stationary에서 완화한다. accuracy 강등은 별 이슈(#2345)가 이 인프라(전환 지점 일반화)를 재사용.
+const BASE_TRACKING_OPTIONS = {
   accuracy: Location.Accuracy.High,
   activityType: Location.LocationActivityType.AutomotiveNavigation,
   pausesUpdatesAutomatically: false,
   distanceInterval: TRACKING_DISTANCE_INTERVAL_M,
-  timeInterval: TRACKING_TIME_INTERVAL_MS,
   showsBackgroundLocationIndicator: true,
 } as const;
+
+export const LOCATION_TRACKING_OPTIONS = {
+  ...BASE_TRACKING_OPTIONS,
+  timeInterval: TRACKING_TIME_INTERVAL_MS,
+} as const;
+
+export const LOCATION_TRACKING_OPTIONS_STATIONARY = {
+  ...BASE_TRACKING_OPTIONS,
+  timeInterval: TRACKING_STATIONARY_TIME_INTERVAL_MS,
+} as const;
+
+/** BG location 추적 프로파일. 'surface'=기본(30s), 'stationary'=정지 확정 시 완화(90s). */
+export type BgLocationProfile = 'surface' | 'stationary';
+
+/**
+ * profile → 추적 옵션 매핑의 SSoT. 신규 프로파일이 추가돼도(#2345 accuracy 강등 등) 이 함수
+ * 한 곳만 확장하면 되도록 전환 지점을 일반화한다.
+ */
+export function locationTrackingOptionsForProfile(profile: BgLocationProfile) {
+  return profile === 'stationary' ? LOCATION_TRACKING_OPTIONS_STATIONARY : LOCATION_TRACKING_OPTIONS;
+}

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -246,3 +246,17 @@ export const LEG_ADVANCE_KEY = 'subway-now:leg-advance';
 // trip 종료(runTripBoundCleanups) 시 제거.
 // 형식: 숫자(epoch ms) 문자열.
 export const NAVIGATION_PAUSED_AT_KEY = 'subway-now:navigation-paused-at';
+// #2344 (V8a) — BG location task가 현재 적용 중인 추적 프로파일('surface'|'stationary').
+// TaskManager invocation마다 새 컨텍스트라 in-memory ref로 유지할 수 없어 AsyncStorage로
+// invocation 간 상태를 공유한다. 키 부재 = 'surface'(기본값, 첫 tick 재시작 skip).
+export const BG_LOCATION_PROFILE_KEY = 'subway-now:bg-location-profile';
+// #2344 — profile 전환(stop→start 재시작) 발생 횟수 누적. 진동(surface↔stationary 반복) 없이
+// 수렴하는지 관측하기 위한 카운터. trip 종료 시 별도 cleanup 불필요 — 다음 trip 첫 전환에서
+// 자연스럽게 이어서 누적된다(누적값 자체가 진단 목적이라 trip 경계로 reset할 필요가 없음).
+// 형식: 숫자 문자열.
+export const BG_LOCATION_PROFILE_FLIP_COUNT_KEY = 'subway-now:bg-location-profile-flip-count';
+// #2344 — useBackgroundLocation이 startLocationUpdatesAsync 호출 시 사용한 foregroundService
+// 알림 텍스트(title/body) 캐시. BG task 콜백은 React tree 밖이라 i18n `t()`에 접근할 수 없어,
+// profile 전환 시 stop→start 자기 재시작에 동일 텍스트를 재사용하기 위해 FG(hook)가 미리 적재한다.
+// 형식: {"notificationTitle": string, "notificationBody": string} JSON. 키 부재 = 폴백 텍스트 사용.
+export const BG_FOREGROUND_SERVICE_TEXT_KEY = 'subway-now:bg-foreground-service-text';


### PR DESCRIPTION
Closes #2344

## 요약
- `src/shared/constants/locationTracking.ts` — BG location 추적 profile 인프라. `surface`(High/30s, 기존 기본값) / `stationary`(High/90s, V8a 완화) 프리셋 + `locationTrackingOptionsForProfile()` 전환 지점 일반화. **accuracy는 두 프로파일 모두 High로 미접촉** — interval만 완화.
- `src/features/nearest-station/utils/bgLocationProfile.ts`(신규) — profile 전환 mechanism. expo-location은 옵션 라이브 변경이 불가해 `stop→start` 재시작으로 전환한다. TaskManager 콜백 내부 자기호출(코드베이스 선례 없음).
  - `applyBgLocationProfile(taskName, desiredProfile)`: 현재 영속 프로파일과 다르면 재시작 + flip count 증가 로깅.
  - `saveForegroundServiceNotification()` / 폴백 텍스트: BG task는 React tree 밖이라 i18n에 접근 불가 — FG hook이 시작 시 캐시해둔 알림 텍스트를 재사용.
  - `resetBgLocationProfile()`: 신규 trip 시작 시 이전 trip의 stale 'stationary' 기록을 초기화(실제 실행 옵션과 저장된 프로파일 어긋남 방지).
- `src/features/nearest-station/tasks/backgroundLocationTask.ts` — `getCurrentMotionStationary()`(CMMotionActivity) 확정 신호로 `applyBgLocationProfile` 호출: 정지 확정 시 stationary로, 이동 재개 시 surface로 즉시 복귀(비대칭 debounce 불필요 — 신호 자체가 확정치).
- `src/features/nearest-station/hooks/useBackgroundLocation.ts` — task 시작 시 foregroundService 텍스트 캐시 + profile surface 초기화.
- `src/shared/constants/storageKeys.ts` — `BG_LOCATION_PROFILE_KEY` / `BG_LOCATION_PROFILE_FLIP_COUNT_KEY` / `BG_FOREGROUND_SERVICE_TEXT_KEY` 추가.

## 이슈 스펙 대비 이탈
없음 — 스펙 그대로 구현(profile object 인프라 + V8a interval만, accuracy 미접촉, cronIdleGate #2073 미접촉).

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — profile flip은 `logger.info`(BG_LOCATION_PROFILE_FLIP_COUNT_KEY 누적)로 관측. DebugModal UI 확장은 이번 PR 범위 밖(이슈 스펙: interval 인프라만) — 실기기 검증 시 device log(Xcode console) tail로 flip 이벤트 + fix 간격(TaskManager invocation timestamp)을 직접 관측한다.
3. **의존 PR** — N/A
4. **측정 plan** — 다음 검증 탑승에서 정지 구간(플랫폼 대기 등) BG location tick 간격이 stationary 프리셋(90s)으로 완화되는지, 이동 재개 시 즉시 surface(30s)로 복귀하는지 device log로 확인.
5. **Device verify** — **필요**. TaskManager 콜백 내부 자기 재시작(stop→start)은 코드베이스 선례가 없어 실기기(정지 구간 GPS 공백 없이 재시작되는지, foregroundService 알림이 재시작 중 끊기지 않는지, 이동 재개 감지 지연 0인지) 검증 필수.

## 검증
- `npx jest` (관련 4개 파일: locationTracking.test.ts, bgLocationProfile.test.ts, backgroundLocationTask.test.ts, useBackgroundLocation.test.ts) — 125 tests pass, 각 파일 커버리지 100%
- `npm run type-check` — pass
- `npm run lint:orphan` — pass (0 orphan)