### PR TITLE
fix(#2342): useTransferAutoDetect 단일 후보 무탭 auto-lock 삭제

### DIFF
--- a/src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts
+++ b/src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts
@@ -4,11 +4,11 @@
  */
 /**
  * #924 — useTransferAutoDetect (D1 후속 PR — production wire).
+ * #2342 — 단일 후보 무탭 auto-lock 삭제. 후보 1개든 N개든 모달로 탭을 요구한다.
  *
  * pure 알고리즘은 transferDetect.test.ts에서 커버. 본 테스트는 hook 차원에서:
  *   - 다른 노선 arrival 수집 + boardingLine 제외
- *   - 단일 후보 → onAutoLock 호출 + idempotency
- *   - 다중 후보 → 모달 open + selectLine으로 hydrate + dismiss 처리
+ *   - 단일/다중 후보 모두 → 모달 open (무탭 onAutoLock 없음) + selectLine으로만 hydrate
  *   - planned route transfer waypoint이면 detect skip
  *   - 환승역 벗어나면 dismiss flag 리셋
  */
@@ -90,18 +90,35 @@ function renderTransferDetect(initialProps: Parameters<typeof useTransferAutoDet
 }
 
 describe('useTransferAutoDetect', () => {
-  it('단일 후보 detect → onAutoLock 호출 (현재 boardingLine 제외)', () => {
+  it('단일 후보 detect → 무탭 onAutoLock 호출 없음, 모달만 open (#2342)', () => {
     const onAutoLock = jest.fn();
     const arrival = makeArrival(
       [makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-A' })],
       [makeArrivalInfo({ destination: '잠실', arrivalSeconds: 30, line: '2', trainCode: 'T-2-A' })],
     );
-    renderHook(() =>
+    const { result } = renderHook(() =>
       useTransferAutoDetect(baseInputs({ arrival, boardingLock: makeLock(), onAutoLock })),
     );
+    expect(onAutoLock).not.toHaveBeenCalled();
+    expect(result.current.modalVisible).toBe(true);
+    expect(result.current.candidateLines).toEqual(['4']);
+  });
+
+  it('단일 후보 → 모달에서 selectLine 탭 시에만 onAutoLock 호출', () => {
+    const onAutoLock = jest.fn();
+    const arrival = makeArrival(
+      [makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-A' })],
+      [makeArrivalInfo({ destination: '잠실', arrivalSeconds: 30, line: '2', trainCode: 'T-2-A' })],
+    );
+    const { result } = renderHook(() =>
+      useTransferAutoDetect(baseInputs({ arrival, boardingLock: makeLock(), onAutoLock })),
+    );
+    expect(onAutoLock).not.toHaveBeenCalled();
+    act(() => result.current.selectLine('4'));
     expect(onAutoLock).toHaveBeenCalledTimes(1);
     const candidate: AutoLockCandidate = onAutoLock.mock.calls[0][0];
     expect(candidate).toEqual({ trainCode: 'T-4-A', line: '4', subwayId: '1004' });
+    expect(result.current.modalVisible).toBe(false);
   });
 
   it('motionStationary=true(정지) → no-op', () => {
@@ -167,18 +184,19 @@ describe('useTransferAutoDetect', () => {
     expect(result.current.modalVisible).toBe(true);
   });
 
-  it('단일 후보 idempotency — 같은 trainCode polling 반복돼도 onAutoLock 1회', () => {
+  it('단일 후보 — polling 반복돼도 무탭 onAutoLock 없음, 모달만 유지', () => {
     const onAutoLock = jest.fn();
     const arrival = makeArrival([
       makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-A' }),
     ]);
-    const { rerender } = renderTransferDetect(baseInputs({ arrival, onAutoLock }));
+    const { result, rerender } = renderTransferDetect(baseInputs({ arrival, onAutoLock }));
     rerender(baseInputs({ arrival, onAutoLock }));
     rerender(baseInputs({ arrival, onAutoLock }));
-    expect(onAutoLock).toHaveBeenCalledTimes(1);
+    expect(onAutoLock).not.toHaveBeenCalled();
+    expect(result.current.modalVisible).toBe(true);
   });
 
-  it('단일 후보 — 다른 trainCode가 들어오면 새로 hydrate', () => {
+  it('단일 후보 — 다른 trainCode로 갱신돼도 여전히 탭(selectLine) 시에만 최신 trainCode로 hydrate', () => {
     const onAutoLock = jest.fn();
     const arrivalA = makeArrival([
       makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-A' }),
@@ -186,10 +204,12 @@ describe('useTransferAutoDetect', () => {
     const arrivalB = makeArrival([
       makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-B' }),
     ]);
-    const { rerender } = renderTransferDetect(baseInputs({ arrival: arrivalA, onAutoLock }));
+    const { result, rerender } = renderTransferDetect(baseInputs({ arrival: arrivalA, onAutoLock }));
     rerender(baseInputs({ arrival: arrivalB, onAutoLock }));
-    expect(onAutoLock).toHaveBeenCalledTimes(2);
-    expect(onAutoLock.mock.calls[1][0].trainCode).toBe('T-4-B');
+    expect(onAutoLock).not.toHaveBeenCalled();
+    act(() => result.current.selectLine('4'));
+    expect(onAutoLock).toHaveBeenCalledTimes(1);
+    expect(onAutoLock.mock.calls[0][0].trainCode).toBe('T-4-B');
   });
 
   it('도착 데이터 없음 → trainCode pick 실패 → no-op', () => {
@@ -390,32 +410,34 @@ describe('useTransferAutoDetect', () => {
     expect(onAutoLock).not.toHaveBeenCalled();
   });
 
-  it('환승역에서 GPS 끊김(stationKey → null) → lastAutoLockedKey 리셋되어 재진입 시 다시 hydrate', () => {
+  it('환승역에서 GPS 끊김(stationKey → null) 후 dismiss 상태로 재진입해도 dismiss 리셋되어 모달 재오픈', () => {
     const onAutoLock = jest.fn();
-    const arrival = makeArrival([
-      makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-A' }),
-    ]);
-    const { rerender } = renderTransferDetect(baseInputs({ arrival, onAutoLock }));
-    expect(onAutoLock).toHaveBeenCalledTimes(1);
-    // GPS 끊김 — nearestStations null.
+    const arrival = multiCandidateArrival();
+    const { result, rerender } = renderTransferDetect(baseInputs({ arrival, onAutoLock }));
+    expect(result.current.modalVisible).toBe(true);
+    act(() => result.current.dismissModal());
+    expect(result.current.modalVisible).toBe(false);
+    // GPS 끊김 — nearestStations null → stationKey null 전환으로 dismiss ref 리셋.
     rerender(baseInputs({ nearestStations: null, arrival, onAutoLock }));
-    // 다시 같은 환승역 진입 — 새 trainCode 같아도 ref가 리셋되었으므로 재호출.
+    // 다시 같은 환승역 진입 — dismiss가 리셋되었으므로 모달 재오픈.
     rerender(baseInputs({ arrival, onAutoLock }));
-    expect(onAutoLock).toHaveBeenCalledTimes(2);
+    expect(result.current.modalVisible).toBe(true);
+    expect(onAutoLock).not.toHaveBeenCalled();
   });
 
-  it('단일 후보 — 같은 trainCode + 새 arrival object → key 일치로 hydrate skip', () => {
-    // 같은 station + 같은 trainCode이지만 arrival 객체 ref만 새로 → effect 재실행 + key 가드 분기.
+  it('단일 후보 — 같은 trainCode + 새 arrival object여도 무탭 onAutoLock 없음(모달만 유지)', () => {
+    // 같은 station + 같은 trainCode이지만 arrival 객체 ref만 새로 → effect 재실행돼도 무탭 hydrate 없음.
     const onAutoLock = jest.fn();
     const makeArrivalA = () =>
       makeArrival([
         makeArrivalInfo({ destination: '서울역', arrivalSeconds: 60, line: '4', trainCode: 'T-4-A' }),
       ]);
-    const { rerender } = renderTransferDetect(baseInputs({ arrival: makeArrivalA(), onAutoLock }));
-    expect(onAutoLock).toHaveBeenCalledTimes(1);
-    // 새 arrival 객체(ref만 다름, 데이터 동일) → effect 재실행하지만 ref key가 같으면 skip.
+    const { result, rerender } = renderTransferDetect(baseInputs({ arrival: makeArrivalA(), onAutoLock }));
+    expect(onAutoLock).not.toHaveBeenCalled();
+    // 새 arrival 객체(ref만 다름, 데이터 동일) → effect 재실행돼도 여전히 무탭 hydrate 없음.
     rerender(baseInputs({ arrival: makeArrivalA(), onAutoLock }));
-    expect(onAutoLock).toHaveBeenCalledTimes(1);
+    expect(onAutoLock).not.toHaveBeenCalled();
+    expect(result.current.modalVisible).toBe(true);
   });
 
   // pickImminentTrainCode가 best replace(later→earlier) 분기와 skip(earlier→later) 분기를
@@ -518,7 +540,12 @@ describe('useTransferAutoDetect', () => {
       { label: '일반정차역 only(대방) + express only → fallback', ups: [EXPRESS_60], destinationName: '대방', expectedTrainCode: 'T-1-EXPRESS' },
     ])('$label', ({ ups, destinationName, expectedTrainCode }) => {
       const onAutoLock = jest.fn();
-      renderHook(() => useTransferAutoDetect(inputs1Line(makeArrival(ups), destinationName, onAutoLock)));
+      const { result } = renderHook(() =>
+        useTransferAutoDetect(inputs1Line(makeArrival(ups), destinationName, onAutoLock)),
+      );
+      // #2342 — 단일 후보도 무탭 hydrate 없음. 모달 탭(selectLine)으로만 trainType 우선순위 적용.
+      expect(onAutoLock).not.toHaveBeenCalled();
+      act(() => result.current.selectLine('1'));
       expect(onAutoLock).toHaveBeenCalledWith({ trainCode: expectedTrainCode, line: '1', subwayId: '1001' });
     });
 

--- a/src/features/route/hooks/useTransferAutoDetect.ts
+++ b/src/features/route/hooks/useTransferAutoDetect.ts
@@ -10,9 +10,12 @@
  * pure 알고리즘(`transferDetect.ts`, #937 머지)을 런타임 신호와 묶어 다음을 한다:
  *   1) 다른 노선 ArrivalRow를 모아 `detectTransfer`로 입력 — current `boardingLine`은 제외해
  *      이미 타고 있는 노선이 후보로 잡히지 않게 한다.
- *   2) 단일 후보 → A1 자동 lock (`hydrateLockFromCandidate` 재사용, `useBoardingLockController`)
- *      — destination 미설정이면 lock 컨텍스트 부족으로 hydrate가 no-op이라 호출자 가드 불필요.
- *   3) 다중 후보 → 모달 상태를 노출 — 호출자가 F4 1탭 모달(#914) UI 트리거.
+ *   2) 후보(1개든 N개든) → 모달 상태를 노출 — 호출자가 F4 1탭 모달(#914) UI 트리거.
+ *      사용자가 모달에서 line을 선택(`selectLine`)해야만 `onAutoLock`(hydrate) 호출.
+ *
+ * #2342 — 단일 후보 무탭 자동 lock(A1) 삭제. 무탭 auto-lock 회귀(2026-08-18 검증 탑승,
+ * boardingPrompt=0인데 lock 활성) 원인이 본 hook의 "candidateLines.length === 1" 분기였다.
+ * 사용자 명시 의향(탭)만 lock을 만든다는 원칙(ADR-014)에 따라 단일 후보도 모달로 탭을 요구한다.
  *
  * 본 hook이 막는 것(no-op 조건):
  *   - 사용자가 이미 planned route의 transfer waypoint에 있다 (=`useTransferTrainList` context 활성).
@@ -46,8 +49,9 @@ export interface UseTransferAutoDetectInputs {
   /** route 도착역 이름. `findActiveTransferContext`의 입력. */
   readonly destinationName: string | null;
   /**
-   * 단일 후보 detect 시 호출 — 호출자가 `useBoardingLockController.hydrateLockFromCandidate`로
-   * lock 자동 hydrate. destination 미설정 / lock 활성 등으로 hydrate가 no-op이면 graceful.
+   * 사용자가 모달에서 line을 선택(`selectLine`)했을 때만 호출 — 호출자가
+   * `useBoardingLockController.hydrateLockFromCandidate`로 lock hydrate.
+   * destination 미설정 / lock 활성 등으로 hydrate가 no-op이면 graceful.
    */
   readonly onAutoLock: (candidate: AutoLockCandidate) => void;
 }
@@ -103,7 +107,6 @@ export function useTransferAutoDetect({
   // 같은 환승역에서 사용자가 닫아도 다음 polling에서 다시 열린다.
   const [modalVisible, setModalVisible] = useState(false);
   const dismissedAtStationRef = useRef<string | null>(null);
-  const lastAutoLockedKeyRef = useRef<string | null>(null);
 
   // #1637 — 환승역에서 station.id는 line별로 분리(예: '합정-2' vs '합정-6')되어 있어 dismiss flag
   // 추적에 부적합. fusion이 같은 환승역의 다른 line variant를 primary로 채택하면 id 변경 →
@@ -116,35 +119,17 @@ export function useTransferAutoDetect({
     if (dismissedAtStationRef.current && dismissedAtStationRef.current !== stationKey) {
       dismissedAtStationRef.current = null;
     }
-    if (lastAutoLockedKeyRef.current && !stationKey) {
-      lastAutoLockedKeyRef.current = null;
-    }
   }, [stationKey]);
 
-  const { candidate } = detection;
-
-  // detect 결과 적용 — 단일 후보면 자동 lock, 다중 후보면 모달 open.
+  // detect 결과 적용 — 후보가 1개든 N개든 모달로 사용자 탭을 요구한다(#2342, 무탭 auto-lock 삭제).
   useEffect(() => {
     if (candidateLines.length === 0 || !currentStation) {
       if (candidateLines.length === 0 && modalVisible) setModalVisible(false);
       return;
     }
-    if (candidateLines.length === 1) {
-      /* istanbul ignore next -- candidateLines가 detectTransfer로 산출되었으면 arrival에 해당 line의
-         imminent 도착이 반드시 존재 → buildAutoLockCandidate는 항상 candidate를 반환. 방어 코드. */
-      if (!candidate) return;
-      // 같은 환승역 같은 trainCode는 1회만 hydrate 시도 — onAutoLock 자체도 idempotent지만
-      // hydrateLockFromCandidate는 ETA 스냅샷이 없어 lock=null 가드만 의존 → 첫 hydrate가 race로
-      // 늦어지는 동안 매 polling tick에서 호출되는 churn을 줄인다.
-      const key = `${currentStation.id}|${candidate.trainCode}|${candidate.line}`;
-      if (lastAutoLockedKeyRef.current === key) return;
-      lastAutoLockedKeyRef.current = key;
-      onAutoLock(candidate);
-      return;
-    }
     if (dismissedAtStationRef.current === stationKey) return;
     setModalVisible(true);
-  }, [candidateLines, candidate, currentStation, onAutoLock, modalVisible, stationKey]);
+  }, [candidateLines, currentStation, modalVisible, stationKey]);
 
   const modalCandidates = useMemo<Station[]>(() => {
     if (!currentStation) return [];
@@ -164,8 +149,6 @@ export function useTransferAutoDetect({
       dismissedAtStationRef.current = stationKey;
       const candidate = buildAutoLockCandidate(line, arrival, destinationName);
       if (!candidate) return;
-      const key = `${currentStation.id}|${candidate.trainCode}|${candidate.line}`;
-      lastAutoLockedKeyRef.current = key;
       onAutoLock(candidate);
     },
     [currentStation, arrival, destinationName, onAutoLock, stationKey],


### PR DESCRIPTION
Closes #2342

## 배경
2026-08-18 검증 탑승에서 boardingPrompt=0인데 건대입구 7-019에 lock이 활성화됨. #2154(오토락 전량삭제)가 backend transfer-swap·D5·#1640·BG swap은 지웠지만 `useTransferAutoDetect`(#924) A1 경로(단일 후보 무탭 자동 lock)가 남아 있었던 것이 원인.

## 변경
- `src/features/route/hooks/useTransferAutoDetect.ts`
  - `candidateLines.length === 1`일 때 `onAutoLock(candidate)`를 즉발하던 분기 삭제. 후보가 1개든 N개든 이제 동일하게 모달을 open해 사용자 탭(`selectLine`)을 요구한다.
  - 무탭 idempotency 전용이던 `lastAutoLockedKeyRef`도 함께 제거(더 이상 자동 hydrate 경로가 없어 불필요).
  - `onAutoLock`은 이제 `selectLine`(모달에서 사용자가 line 탭)을 통해서만 호출된다.
- `src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts` — 단일 후보 시나리오 전면 재작성: 무탭 `onAutoLock` 0회 + 모달 open을 검증하고, `selectLine` 탭 시에만 hydrate가 일어남을 검증. 다중 후보 모달 경로, `#1637` dismiss 보존, `#971` trainType 우선순위 테스트는 로직 변경 없이 보존(단 trainType it.each는 selectLine 탭을 거치도록 조정).

## 보존(무회귀) 확인
- 사용자 직접 탭 경로(`createTransferLock` — `useTransferTrainList`, `BoardingTrainList onSelect`, `HomeScreen.tsx:1675`)는 건드리지 않음.
- `useTransferAutoDetect` 다중 후보 모달 경로(사용자가 모달에서 선택)는 그대로 유지.

## HomeScreen 잔존 무탭 wiring 점검 결과
- `HomeScreen.tsx:976` `onAutoLock: hydrateLockFromCandidate` — 본 PR로 `selectLine`(모달 탭) 경유로만 호출되도록 게이트됨. **수정 완료.**
- `HomeScreen.tsx:773` `onAutoLockCandidate: hydrateLockFromCandidate` (`useBoardingLockSync`, #915/#916 A1) — 이 경로는 `useTransferAutoDetect`와 무관한 **별도 backend-driven 채널**이다. `useBoardingLockSync`가 `/position` sync 응답의 `autoLockCandidate`(backend cron이 9-AND 게이트 통과 시 부착하는 lock 메타)를 콜백으로 전달하는 구조로, 프론트엔드 코드만으로는 제거할 수 없고 backend `index.ts`의 `working.boardingLock` 산출 로직까지 걷어내야 하는 별도 스코프의 변경이다. 본 이슈 스펙(`useTransferAutoDetect` A1 삭제)과 device evidence(건대입구 7-019 lock)는 명확히 `useTransferAutoDetect`를 원인으로 지목하고 있어 이 PR에서는 건드리지 않았다. 이 backend A1 채널도 ADR-014(사용자 명시 의향만 lock) 관점에서 삭제 대상일 가능성이 높으므로, 별도 이슈로 분리해 backend index.ts 변경 + 관련 테스트를 함께 다루는 것을 제안한다.

## 검증
- `npx jest src/features/route/hooks/__tests__/useTransferAutoDetect.test.ts --coverage` — 32 passed, 100% coverage (lines/branches/funcs/stmts)
- `npm run type-check` — pass
- `npm run lint:orphan` — No orphan exports detected
- `npx eslint` (변경 파일 3종) — clean

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass.
2. **V/X dashboard** — DebugModal BoardingLock Lifecycle(create 라벨)에서 lock 생성 시점 관측 가능. 무탭 create 이벤트가 0건이어야 정상.
3. **의존 PR** — #2130(탑승 프롬프트 발화) — 본 PR 삭제 후 환승에서 lock을 걸 유일한 수단이 프롬프트/모달 탭이므로 #2130과 함께 진행 필요.
4. **측정 plan** — 다음 검증 탑승에서 환승 시 무탭 lock 0건 확인 (boardingPrompt 미응답 상태에서 lock 미생성).
5. **Device verify** — 필요. 환승역에서 단일 후보 detect 시 모달이 뜨고, 탭하지 않으면 lock이 걸리지 않는지 실기기 확인 필요.