### PR TITLE
fix(#2352): backend autoLockCandidate 무탭 채널 삭제 (전량삭제 완결)

### DIFF
--- a/backend/alarm-worker/src/__tests__/index.test.ts
+++ b/backend/alarm-worker/src/__tests__/index.test.ts
@@ -3081,18 +3081,13 @@ describe('POST /boarding-lock/sync (#901)', () => {
       advanced: boolean;
       currentWaypoint: string | null;
       nextStation: string | null;
-      autoLockCandidate: { trainCode: string; line: string; subwayId: string; expiresAt: number };
     };
     expect(body.ok).toBe(true);
     expect(body.advanced).toBe(true);
     expect(body.currentWaypoint).toBe('역삼');
     expect(body.nextStation).toBe('역삼');
-    // #916 — tripWithLock fixture에 boardingLock이 미리 설정돼 있으므로 candidate로 노출.
-    // #1364 P1 — expiresAt도 함께 노출 (client local store 동기화용).
-    expect(body.autoLockCandidate.trainCode).toBe('T-1');
-    expect(body.autoLockCandidate.line).toBe('2');
-    expect(body.autoLockCandidate.subwayId).toBe('1002');
-    expect(typeof body.autoLockCandidate.expiresAt).toBe('number');
+    // #2352 — autoLockCandidate 필드는 삭제됐다(구 #916). 응답에 재등장하지 않는지 확인.
+    expect(body).not.toHaveProperty('autoLockCandidate');
     const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
     expect(stored.waypoints.map((w: { stationName: string }) => w.stationName)).toEqual([
       '역삼',
@@ -3254,9 +3249,9 @@ describe('POST /boarding-lock/sync (#901)', () => {
     expect(res.status).toBe(200);
   });
 
-  // #916 A1 — boardingLock이 있으면 autoLockCandidate로 노출, 없으면 null.
-  // client는 이 필드를 보고 자동 lock이 부착됐는지 알 수 있다.
-  it('boardingLock 있는 trip → autoLockCandidate에 trainCode/line/subwayId 노출', async () => {
+  // #2352 — 구 #916 A1 autoLockCandidate 노출은 삭제됐다. boardingLock 존재 여부와 무관하게
+  // 응답에 그 필드가 재등장하지 않는지 확인 (무탭 hydrate 채널 완전 제거 확인).
+  it('boardingLock 있는 trip → autoLockCandidate 필드 없음', async () => {
     const env = makeKvEnv();
     await post('/trips', tripWithLock(), env);
     const res = await post(
@@ -3265,17 +3260,11 @@ describe('POST /boarding-lock/sync (#901)', () => {
       env,
     );
     expect(res.status).toBe(200);
-    const body = (await res.json()) as {
-      autoLockCandidate: { trainCode: string; line: string; subwayId: string; expiresAt: number } | null;
-    };
-    // #1364 P1 — autoLockCandidate에 expiresAt 포함 (client TTL 동기화).
-    expect(body.autoLockCandidate?.trainCode).toBe('T-1');
-    expect(body.autoLockCandidate?.line).toBe('2');
-    expect(body.autoLockCandidate?.subwayId).toBe('1002');
-    expect(typeof body.autoLockCandidate?.expiresAt).toBe('number');
+    const body = await res.json();
+    expect(body).not.toHaveProperty('autoLockCandidate');
   });
 
-  it('boardingLock 없는 trip → autoLockCandidate=null', async () => {
+  it('boardingLock 없는 trip → autoLockCandidate 필드 없음', async () => {
     const env = makeKvEnv();
     const tripNoLock = tripWithLock();
     delete tripNoLock.boardingLock;
@@ -3286,18 +3275,16 @@ describe('POST /boarding-lock/sync (#901)', () => {
       env,
     );
     expect(res.status).toBe(200);
-    const body = (await res.json()) as {
-      autoLockCandidate: unknown;
-    };
-    expect(body.autoLockCandidate).toBeNull();
+    const body = await res.json();
+    expect(body).not.toHaveProperty('autoLockCandidate');
   });
 
-  // #1364 — read-after-write verification + expiresAt response field.
+  // #1364 — read-after-write verification.
   //
   // sync handler가 putTrip 후 cacheTtl=0으로 KV propagation을 확인한다. 정상 path는 1회로
   // 통과해야 하며, verification failure 경로는 verifyBoardingLockPersisted 단위 테스트로 커버.
   describe('read-after-write verification (#1364)', () => {
-    it('정상 path → 200 + autoLockCandidate.expiresAt 노출', async () => {
+    it('정상 path → 200 + KV boardingLock.expiresAt이 refresh 이상으로 propagate', async () => {
       const env = makeKvEnv();
       await post('/trips', tripWithLock(), env);
       const res = await post(
@@ -3306,15 +3293,13 @@ describe('POST /boarding-lock/sync (#901)', () => {
         env,
       );
       expect(res.status).toBe(200);
-      const body = (await res.json()) as {
-        autoLockCandidate: { expiresAt: number };
-      };
-      // refresh 후 expiresAt이 LOCK_TTL_REFRESH_MS 이상 미래 (P1 response sync).
-      expect(body.autoLockCandidate.expiresAt).toBeGreaterThan(Date.now());
+      const stored = JSON.parse((await env.TRIPS.get('trip:tok-sync')) as string);
+      // refresh 후 expiresAt이 LOCK_TTL_REFRESH_MS 이상 미래 (KV propagation 확인).
+      expect(stored.boardingLock.expiresAt).toBeGreaterThan(Date.now());
     });
   });
 
-  // #2283 리뷰 P2-2 — trip_events 기록(sync-received/advance/hydrate-issued)이 핫패스 응답
+  // #2283 리뷰 P2-2 — trip_events 기록(sync-received/advance)이 핫패스 응답
   // latency에 얹히지 않고 `c.executionCtx.waitUntil`로 스케줄되는지 검증.
   describe('trip_events waitUntil wiring (#2283 리뷰 P2-2)', () => {
     function makeExecutionContext(): ExecutionContext & { waitUntil: ReturnType<typeof vi.fn> } {
@@ -3342,7 +3327,7 @@ describe('POST /boarding-lock/sync (#901)', () => {
       );
     }
 
-    it('sync-received/advance/hydrate-issued 3종 모두 waitUntil로 스케줄된다 (응답을 막지 않음)', async () => {
+    it('sync-received/advance 2종 모두 waitUntil로 스케줄된다 (응답을 막지 않음)', async () => {
       const env = makeKvEnv();
       const prepare = vi.fn().mockReturnValue({
         bind: vi.fn().mockReturnValue({ run: vi.fn().mockResolvedValue({ success: true }) }),
@@ -3351,7 +3336,8 @@ describe('POST /boarding-lock/sync (#901)', () => {
       await post('/trips', tripWithLock(), env);
 
       const ctx = makeExecutionContext();
-      // waypoints[0]='강남' 일치 → advance 발생 + boardingLock 존재 → hydrate-issued도 발생.
+      // waypoints[0]='강남' 일치 → advance 발생. #2352 — hydrate-issued 관측(autoLockCandidate
+      // 응답 필드 삭제와 함께 제거)은 더 이상 발생하지 않는다.
       const res = await postWithCtx(
         '/boarding-lock/sync',
         { token: 'tok-sync', observedStationName: '강남', observedAtMs: 1, accuracy: 5 },
@@ -3360,15 +3346,15 @@ describe('POST /boarding-lock/sync (#901)', () => {
       );
       expect(res.status).toBe(200);
 
-      // 3건(sync-received/advance/hydrate-issued) 모두 waitUntil에 넘겨졌는지 확인.
-      expect(ctx.waitUntil).toHaveBeenCalledTimes(3);
+      // 2건(sync-received/advance) 모두 waitUntil에 넘겨졌는지 확인.
+      expect(ctx.waitUntil).toHaveBeenCalledTimes(2);
       // waitUntil로 넘긴 프로미스가 실제로 완료되면 각 kind에 대해 D1 INSERT가 실행됐어야 한다.
       const scheduled = ctx.waitUntil.mock.calls.map((call) => call[0] as Promise<unknown>);
       await Promise.all(scheduled);
       const kinds = prepare.mock.calls
         .map((call) => call[0] as string)
         .filter((sql) => sql.includes('INSERT INTO trip_events'));
-      expect(kinds).toHaveLength(3);
+      expect(kinds).toHaveLength(2);
     });
 
     it('executionCtx 미제공(기존 단위 테스트 관례) 시에도 throw 없이 정상 응답한다', async () => {
@@ -3389,43 +3375,6 @@ describe('POST /boarding-lock/sync (#901)', () => {
     });
   });
 
-  // #2308 — hydrate-issued의 `line`은 lock.line이 아니라 head(현재 anchor waypoint)의 line이어야
-  // 한다. lock.line은 D4 trainCode swap(payload 기반) 타이밍에 갱신되는 반면 head는 이번 sync의
-  // advance 직후 값이라, 환승 직후 한 cycle 동안 두 값이 어긋나면(저녁 어린이대공원 line=2, 아침
-  // 뚝섬 line=7 evidence) hydrate가 실제 서 있는 역의 노선과 다른 값을 발행한다.
-  describe('hydrate-issued line은 leg-aware — head.line 사용 (#2308)', () => {
-    it('advance 후 head가 다른 line이어도 hydrate line은 head.line (lock.line이 아님)', async () => {
-      const env = makeKvEnv();
-      const bind = vi.fn().mockReturnValue({ run: vi.fn().mockResolvedValue({ success: true }) });
-      const prepare = vi.fn().mockReturnValue({ bind });
-      env.DB = { prepare } as unknown as Env['DB'];
-      // 다중 노선 trip: waypoints[0]='강남'(2호선), waypoints[1]='역삼'(7호선, 환승 이후 leg).
-      // lock.line은 아직 스왑 전 '2'로 등록 — D4 swap이 이번 payload에 없으면 lock.line은 '2'로 남는다.
-      await post(
-        '/trips',
-        tripWithLock({
-          waypoints: [
-            { stationName: '강남', line: '2', kind: 'transfer' },
-            { stationName: '역삼', line: '7', kind: 'destination' },
-          ],
-        }),
-        env,
-      );
-      // sync가 waypoints[0]='강남'과 일치 → advance 1 hop → head='역삼'(line=7).
-      // payload에 trainCode(D4 swap 트리거)가 없으므로 lock.line은 '2' 그대로 유지된다.
-      const res = await post(
-        '/boarding-lock/sync',
-        { token: 'tok-sync', observedStationName: '강남', observedAtMs: 1, accuracy: 5 },
-        env,
-      );
-      expect(res.status).toBe(200);
-      const hydrateCall = bind.mock.calls.find((call) => call[2] === 'hydrate-issued');
-      expect(hydrateCall).toBeDefined();
-      // [tokenHash, ts, kind, station, line, meta] — index 3=station, 4=line.
-      expect(hydrateCall?.[3]).toBe('역삼');
-      expect(hydrateCall?.[4]).toBe('7'); // head.line — lock.line('2')이 아님.
-    });
-  });
 });
 
 // #2308 — applyProgress/resolveProgressWaypoints 단조 전진 불변식.

--- a/backend/alarm-worker/src/index.ts
+++ b/backend/alarm-worker/src/index.ts
@@ -1836,13 +1836,16 @@ app.post('/metrics/boarding-prompt', async (c) => {
  *
  * Body: { token, observedStationName, observedAtMs, accuracy, subsurface? }
  * Response 200:
- *   { ok, advanced, currentWaypoint, nextStation, autoLockCandidate }
+ *   { ok, advanced, currentWaypoint, nextStation }
  *   - advanced: 이번 sync로 waypoints가 shift됐는지 (1+ hop)
  *   - currentWaypoint: 정정 후 first waypoint stationName (없으면 null — destination 도착)
  *   - nextStation: 정정 후 first waypoint = 다음 알람 대상 (currentWaypoint와 동일, 의미상 alias)
- *   - autoLockCandidate (#916 A1): cron이 자동 lock을 부착했을 때 그 lock 메타.
- *     클라는 이 값을 보고 사용자가 직접 탭하지 않아도 boardingLock state를 hydrate 가능.
- *     없으면 null. 후속 PR에서 클라이언트가 이 필드를 처리한다.
+ *   - #2352 — `autoLockCandidate` 필드는 삭제됐다(구 #916 A1). 사용자가 직접 탭하지 않은
+ *     trainCode를 client가 무탭으로 hydrate하는 채널은 사용자 "무탭 오토락 전량 삭제" 결정(#2342)의
+ *     backend-driven 잔존분이었다 — client가 이미 lock을 갖고 있으면 no-op이지만, client local
+ *     store가 비어 있는데 backend Trip에 boardingLock이 남아있는 edge case(재설치/storage race
+ *     등)에서 사용자 명시 없이 lock을 재생성했다. 명시 탭(createLockFromTrain) / boardingPrompt
+ *     응답 lock 경로는 이 endpoint와 무관하게 그대로 유지된다.
  * Response 404: { error: 'trip_not_found' } — 클라는 다음 fix에서 자연 retry
  *
  * Trip 부재 시 lock 재생성 책임은 본 endpoint가 지지 않음 — 클라가 useApnsTripRegistration으로
@@ -1934,42 +1937,14 @@ app.post('/boarding-lock/sync', async (c) => {
   }
 
   const head = working.waypoints[0];
-  if (working.boardingLock) {
-    // #2283 — hydrate-issued 관측. autoLockCandidate를 device가 실제로 받아 lock state를
-    // hydrate할 수 있는 응답임을 기록(sync-received/advance와 별도 kind — "발사됐는지"를 분리 관측).
-    // #2283 리뷰 P2-2 — waitUntil로 스케줄.
-    // #2308 — line은 `boardingLock.line`이 아니라 `head.line`(현재 anchor waypoint의 leg)을 쓴다.
-    // head는 이번 cycle의 advance 직후 값이라, lock.line이 아직 옛 leg에 머무는 한 cycle 동안
-    // (저녁 어린이대공원 line=2, 아침 뚝섬 line=7 evidence) hydrate가 실제 서 있는 역의 노선과
-    // 다른 값을 발행하는 것을 막는다. head가 있으면 head.line(다중 노선 trip의 해당 leg 노선)을
-    // SSOT로 쓴다.
-    scheduleTripEvent(
-      c,
-      recordTripEvent(c.env.DB, {
-        tokenHash,
-        kind: 'hydrate-issued',
-        station: head ? head.stationName : undefined,
-        line: head ? head.line : working.boardingLock.line,
-      }),
-    );
-  }
+  // #2352 — 구 hydrate-issued D1 관측(#2283/#2308)은 autoLockCandidate 응답 필드 노출을 전제로
+  // 한 계측이었다. 필드 삭제로 "hydrate 받을 수 있는 응답이 나갔다"는 사실 자체가 더 이상 발생하지
+  // 않으므로 함께 제거 — 없는 채널을 있다고 관측하는 오탐 신호를 막는다.
   return c.json({
     ok: true,
     advanced: advance.shiftedCount > 0,
     currentWaypoint: head ? head.stationName : null,
     nextStation: head ? head.stationName : null,
-    // #916 A1 — cron auto-lock(또는 사용자 명시 lock)이 trip에 부착돼 있으면 그 메타를
-    // candidate로 노출. client가 이 값으로 boardingLock UI/state를 hydrate한다.
-    // segmentStations/expiresAt 등 내부 필드는 client가 트래킹할 필요가 없어 공개 표면 최소화.
-    // #1364 P1 — `expiresAt`을 노출해 client local store가 backend 갱신값과 동기화되도록 한다.
-    autoLockCandidate: working.boardingLock
-      ? {
-          trainCode: working.boardingLock.trainCode,
-          line: working.boardingLock.line,
-          subwayId: working.boardingLock.subwayId,
-          expiresAt: working.boardingLock.expiresAt,
-        }
-      : null,
   });
 });
 

--- a/src/features/alarm/hooks/__tests__/useBoardingLockSync.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockSync.test.ts
@@ -289,114 +289,28 @@ describe('useBoardingLockSync (#901)', () => {
     expect(mockedSync).toHaveBeenCalledTimes(1);
   });
 
-  // #915/#916 — backend autoLockCandidate를 호출자 콜백으로 전달.
-  describe('onAutoLockCandidate (#915/#916)', () => {
-    it('응답에 autoLockCandidate 있음 → 콜백 호출', async () => {
-      mockedSync.mockResolvedValueOnce({
-        ok: true,
-        advanced: false,
-        currentWaypoint: '역삼',
-        nextStation: '역삼',
-        autoLockCandidate: { trainCode: 'AUTO-7', line: '2', subwayId: '1002' },
-      });
-      const onAutoLockCandidate = jest.fn();
-      renderHook(() =>
-        useBoardingLockSync({
-          currentStationName: '강남',
-          accuracyMeters: 10,
-          tripActive: true,
-          onAutoLockCandidate,
-        }),
-      );
-      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
-      await flushAsyncStorage();
-      expect(onAutoLockCandidate).toHaveBeenCalledWith({
-        trainCode: 'AUTO-7',
-        line: '2',
-        subwayId: '1002',
-      });
+  // #2352 — 구 #915/#916 onAutoLockCandidate 무탭 hydrate 채널은 삭제됐다. 옵션 자체가 더 이상
+  // 존재하지 않으므로, backend 응답에 (구버전/캐시 등으로) autoLockCandidate가 섞여 와도 아무
+  // 콜백도 없이 graceful하게 무시되는지 확인 — RED였던 "탭 없이 lock 생성"이 이제 발생 불가함을
+  // 회귀 방지 차원에서 명시.
+  it('#2352 — 응답에 autoLockCandidate가 섞여 있어도 콜백 채널 자체가 없어 무시(throw 없음)', async () => {
+    mockedSync.mockResolvedValueOnce({
+      ok: true,
+      advanced: false,
+      currentWaypoint: '역삼',
+      nextStation: '역삼',
+      // @ts-expect-error — 구버전 backend 잔존 필드 시뮬레이션. 현재 응답 타입엔 없다.
+      autoLockCandidate: { trainCode: 'AUTO-7', line: '2', subwayId: '1002' },
     });
-
-    it('응답에 autoLockCandidate 없음(null) → 콜백 미호출', async () => {
-      mockedSync.mockResolvedValueOnce({
-        ok: true,
-        advanced: false,
-        currentWaypoint: '역삼',
-        nextStation: '역삼',
-        autoLockCandidate: null,
-      });
-      const onAutoLockCandidate = jest.fn();
-      renderHook(() =>
-        useBoardingLockSync({
-          currentStationName: '강남',
-          accuracyMeters: 10,
-          tripActive: true,
-          onAutoLockCandidate,
-        }),
-      );
-      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
-      await flushAsyncStorage();
-      expect(onAutoLockCandidate).not.toHaveBeenCalled();
-    });
-
-    it('ok=false 응답 → autoLockCandidate 있어도 콜백 미호출 (graceful)', async () => {
-      mockedSync.mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        autoLockCandidate: { trainCode: 'AUTO-7', line: '2', subwayId: '1002' },
-      });
-      const onAutoLockCandidate = jest.fn();
-      renderHook(() =>
-        useBoardingLockSync({
-          currentStationName: '강남',
-          accuracyMeters: 10,
-          tripActive: true,
-          onAutoLockCandidate,
-        }),
-      );
-      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
-      await flushAsyncStorage();
-      expect(onAutoLockCandidate).not.toHaveBeenCalled();
-    });
-
-    it('force-trigger 경로도 콜백 호출', async () => {
-      mockedSync.mockResolvedValueOnce({
-        ok: true,
-        autoLockCandidate: { trainCode: 'AUTO-X', line: '2', subwayId: '1002' },
-      });
-      const onAutoLockCandidate = jest.fn();
-      renderHook(() =>
-        useBoardingLockSync({
-          currentStationName: '강남',
-          accuracyMeters: 10,
-          tripActive: true,
-          forceTriggerKey: 'k1',
-          onAutoLockCandidate,
-        }),
-      );
-      await flushAsyncStorage();
-      expect(onAutoLockCandidate).toHaveBeenCalledWith({
-        trainCode: 'AUTO-X',
-        line: '2',
-        subwayId: '1002',
-      });
-    });
-
-    it('콜백 미제공 + autoLockCandidate 응답 → graceful (throw 없음)', async () => {
-      mockedSync.mockResolvedValueOnce({
-        ok: true,
-        autoLockCandidate: { trainCode: 'AUTO-7', line: '2', subwayId: '1002' },
-      });
-      renderHook(() =>
-        useBoardingLockSync({
-          currentStationName: '강남',
-          accuracyMeters: 10,
-          tripActive: true,
-        }),
-      );
-      act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
-      await expect(flushAsyncStorage()).resolves.toBeUndefined();
-    });
+    renderHook(() =>
+      useBoardingLockSync({
+        currentStationName: '강남',
+        accuracyMeters: 10,
+        tripActive: true,
+      }),
+    );
+    act(() => jest.advanceTimersByTime(SYNC_DEBOUNCE_MS + 100));
+    await expect(flushAsyncStorage()).resolves.toBeUndefined();
   });
 
   // D4 (#1210) — 활성 lock trainCode/line forward + 환승 leg trainCode 변경 시 재발사.

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -77,9 +77,12 @@ export interface UseBoardingLockControllerResult {
   /** 사용자가 도착 list에서 열차 탭 시 호출. lock 생성을 위한 컨텍스트가 부족하면 no-op. */
   createLockFromTrain: (train: ArrivalInfo) => void;
   /**
-   * #915/#916 — backend `/boarding-lock/sync` 응답의 autoLockCandidate로 lock을 hydrate.
-   * destination-only baseline UX에서 사용자가 명시 탭하지 않아도 backend cron이 trainCode를
-   * 결정하면 client store에 반영해 lock UX 활성화한다.
+   * candidate(trainCode/line/subwayId)로 lock을 hydrate.
+   *
+   * #2352 — 구 #915/#916 backend `/boarding-lock/sync` 응답 autoLockCandidate 채널은 삭제됐다
+   * ("무탭 오토락 전량 삭제" 결정, #2342). 현재 유일한 호출자는 `useTransferAutoDetect`(#924)의
+   * device-side 단일 후보 환승 자동 detect — planned route 없이 환승역에서 다른 노선 임박 열차가
+   * 정확히 1개 감지될 때만 발동하는 별개 기능이다.
    *
    * idempotent: 이미 같은 trainCode + boardingLine으로 활성 lock이 있으면 no-op.
    * lock 생성을 위한 컨텍스트(destinationId / currentStation / line valid) 부족 시 no-op.
@@ -352,20 +355,19 @@ export function useBoardingLockController({
     void releaseLock();
   }, [releaseLock]);
 
-  // #915/#916 — backend autoLockCandidate를 받아 client BoardingLock store hydrate.
+  // candidate(현재는 useTransferAutoDetect의 device-side 단일 후보 detect, #924)를 받아 client
+  // BoardingLock store hydrate. #2352 — 구 backend #915/#916 autoLockCandidate 채널은 삭제됨.
   // hydrate 정책: lock이 이미 존재하면 항상 no-op.
-  //  - 사용자가 BoardingTrainList에서 명시 탭한 lock을 backend cron candidate(다른 trainCode 가능)가
+  //  - 사용자가 BoardingTrainList에서 명시 탭한 lock을 candidate(다른 trainCode 가능)가
   //    silently overwrite하지 않게 보호 (#915 self code-review).
   //  - destination 변경 시 controller의 stale-lock release effect가 lock=null로 만든 후에야 hydrate.
-  //  - 자동 lock도 한 번 잡히면 변경 X (Seam F swap은 backend cron이 trip.boardingLock을 갱신하고
-  //    silent push로 client store가 hydrate되는 별 경로).
+  //  - 자동 lock도 한 번 잡히면 변경 X.
   // #1014 RC2 acceptance gate — 두 조건 모두 통과해야 hydrate:
   //  1) candidate.trainCode가 directionalArrivals(현재 역 + 방향 필터)에 있는지 확인
   //     → origin을 이미 지난 열차(arrival list 없음)는 자동 차단.
   //     → 방향 불일치 열차도 동시에 차단 (directionalArrivals가 direction 필터 적용됨).
   //  2) 사용자가 origin에서 정적 대기 중인지 확인 — motionStationary 우선, speedMps fallback.
-  //     → 이미 열차에 탑승해 이동 중인 상태에서 backend가 autoLockCandidate를 지연 응답하는
-  //        false positive를 차단.
+  //     → 이미 열차에 탑승해 이동 중인 상태에서 candidate가 지연 발생하는 false positive를 차단.
   const hydrateLockFromCandidate = useCallback(
     (candidate: AutoLockCandidate) => {
       if (!currentStation) return;

--- a/src/features/alarm/hooks/useBoardingLockSync.ts
+++ b/src/features/alarm/hooks/useBoardingLockSync.ts
@@ -21,7 +21,7 @@
 import { useEffect, useRef } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { APNS_TOKEN_KEY, ACTIVE_TRIP_KEY } from '../../../shared/constants/storageKeys';
-import { syncBoardingLock, type AutoLockCandidate } from '../../nearest-station/api/boardingLockSync';
+import { syncBoardingLock } from '../../nearest-station/api/boardingLockSync';
 import { createLogger } from '../../../shared/utils/logger';
 
 const logger = createLogger('useBoardingLockSync');
@@ -71,14 +71,6 @@ export interface UseBoardingLockSyncOptions {
    * trainCode 없이 단독 전송은 backend에서 무시 (trainCode가 동일성 판정의 primary key).
    */
   boardingLockLine?: string | null;
-  /**
-   * #915/#916 A1 — backend 응답에서 autoLockCandidate를 받으면 호출. 호출자는 이 콜백에서
-   * useBoardingLockStore.createLock으로 hydrate해 사용자 명시 탭 없이 lock UX 활성화한다.
-   *
-   * candidate가 null인 응답은 콜백 호출 안 함(콜백은 candidate 존재 신호 전용).
-   * 같은 trainCode 중복 hydrate는 호출자가 store level에서 idempotent 판단.
-   */
-  onAutoLockCandidate?: (candidate: AutoLockCandidate) => void;
 }
 
 /**
@@ -94,7 +86,6 @@ export function useBoardingLockSync({
   stationFromWifi,
   boardingLockTrainCode,
   boardingLockLine,
-  onAutoLockCandidate,
 }: UseBoardingLockSyncOptions): void {
   // 이미 보낸 currentStation을 기억해 debounce 안의 중복 발사를 방지.
   const lastSentStationRef = useRef<string | null>(null);
@@ -104,11 +95,6 @@ export function useBoardingLockSync({
   const lastSentTrainCodeRef = useRef<string | null>(null);
   // forceTriggerKey 이전 값 — 같은 key 재전달 시 no-op 판정용.
   const lastForceKeyRef = useRef<string | null>(null);
-  // #915 — 매 렌더 새 함수일 가능성 → ref로 latest 보관해 effect deps churn 회피.
-  const onAutoLockCandidateRef = useRef(onAutoLockCandidate);
-  useEffect(() => {
-    onAutoLockCandidateRef.current = onAutoLockCandidate;
-  }, [onAutoLockCandidate]);
 
   // tripActive false → true 전환 시 lastSent ref들을 리셋. 새 trip의 첫 currentStationName이
   // 이전 trip의 마지막 station과 같아도 첫 sync가 발사되도록 보장 (#915 self code-review C4).
@@ -151,7 +137,6 @@ export function useBoardingLockSync({
         trainCode: boardingLockTrainCode ?? null,
         boardingLine: boardingLockLine ?? null,
         reason: 'station-change',
-        onAutoLockCandidate: onAutoLockCandidateRef.current,
       });
     }, SYNC_DEBOUNCE_MS);
 
@@ -191,7 +176,6 @@ export function useBoardingLockSync({
       trainCode: boardingLockTrainCode ?? null,
       boardingLine: boardingLockLine ?? null,
       reason: 'force-trigger',
-      onAutoLockCandidate: onAutoLockCandidateRef.current,
     });
   }, [
     tripActive,
@@ -214,13 +198,12 @@ interface FireSyncInput {
   /** D4 (#1210) — 호출 시점 lock 노선. trainCode와 페어로만 의미. */
   boardingLine?: string | null;
   reason: 'station-change' | 'force-trigger';
-  onAutoLockCandidate?: (candidate: AutoLockCandidate) => void;
 }
 
 /**
  * AsyncStorage에서 token을 읽어 syncBoardingLock 호출. token/trip 부재는 graceful no-op.
- * 응답의 autoLockCandidate(#916)는 호출자 콜백으로 전달 — 정정 자체(currentWaypoint)는
- * cron silent push 경로가 별도로 client store를 mutate한다.
+ * 정정 자체(currentWaypoint)는 cron silent push 경로가 별도로 client store를 mutate한다.
+ * #2352 — 구 autoLockCandidate(#916) 무탭 hydrate forward 로직은 삭제됐다.
  */
 async function fireSync(input: FireSyncInput): Promise<void> {
   const token = await AsyncStorage.getItem(APNS_TOKEN_KEY);
@@ -244,11 +227,6 @@ async function fireSync(input: FireSyncInput): Promise<void> {
     trainCode: input.trainCode ?? null,
     advanced: res.advanced ?? false,
     currentWaypoint: res.currentWaypoint ?? null,
-    autoLockCandidate: res.autoLockCandidate?.trainCode ?? null,
     ok: res.ok,
   });
-  // #915/#916 — backend가 자동/명시 lock 메타를 노출했으면 호출자에 전달. null이면 미호출.
-  if (res.ok && res.autoLockCandidate) {
-    input.onAutoLockCandidate?.(res.autoLockCandidate);
-  }
 }

--- a/src/features/nearest-station/api/__tests__/boardingLockSync.test.ts
+++ b/src/features/nearest-station/api/__tests__/boardingLockSync.test.ts
@@ -54,7 +54,6 @@ describe('syncBoardingLock (#901)', () => {
       advanced: true,
       currentWaypoint: '역삼',
       nextStation: '역삼',
-      autoLockCandidate: null,
     });
     const [url, init] = (globalThis.fetch as jest.Mock).mock.calls[0];
     expect(url).toBe('https://api.test.dev/boarding-lock/sync');
@@ -62,7 +61,9 @@ describe('syncBoardingLock (#901)', () => {
     expect(JSON.parse(init.body)).toEqual(basePayload);
   });
 
-  it('#915/#916 — autoLockCandidate 응답 forward', async () => {
+  // #2352 — 구 #915/#916 autoLockCandidate 응답 필드는 backend에서 삭제됐다. 응답에 있어도
+  // (구버전 backend 잔존/캐시) client가 forward하지 않는지 확인 — 무탭 hydrate 채널 완전 제거.
+  it('#2352 — 응답에 autoLockCandidate가 있어도 forward하지 않음', async () => {
     process.env.EXPO_PUBLIC_ALARM_BACKEND_URL = 'https://api.test.dev';
     (globalThis.fetch as jest.Mock).mockResolvedValue({
       ok: true,
@@ -77,7 +78,7 @@ describe('syncBoardingLock (#901)', () => {
         }),
     });
     const r = await syncBoardingLock(basePayload);
-    expect(r.autoLockCandidate).toEqual({ trainCode: '7246', line: '2', subwayId: '1002' });
+    expect(r).not.toHaveProperty('autoLockCandidate');
   });
 
   it('subsurface 옵션 필드 forward', async () => {
@@ -158,7 +159,6 @@ describe('syncBoardingLock (#901)', () => {
       advanced: false,
       currentWaypoint: null,
       nextStation: null,
-      autoLockCandidate: null,
     });
   });
 
@@ -176,7 +176,6 @@ describe('syncBoardingLock (#901)', () => {
       advanced: false,
       currentWaypoint: null,
       nextStation: null,
-      autoLockCandidate: null,
     });
   });
 

--- a/src/features/nearest-station/api/boardingLockSync.ts
+++ b/src/features/nearest-station/api/boardingLockSync.ts
@@ -41,9 +41,11 @@ export interface BoardingLockSyncPayload {
 }
 
 /**
- * #916 A1 — backend cron이 자동 lock을 부착했을 때 노출하는 후보 메타.
- * Client는 이 값으로 boardingLock store를 hydrate해 사용자가 직접 BoardingTrainList에서
- * 열차를 탭하지 않아도 trainCode 추적이 활성화된다 (#915 destination-only baseline UX).
+ * #2352 — 구 #916 A1 backend cron 자동 lock 후보 메타(`/boarding-lock/sync` 응답 필드)는
+ * 삭제됐다("무탭 오토락 전량 삭제" 결정, #2342). 본 type은 device-side 별개 채널
+ * (`transferSwap.ts`/`useTransferAutoDetect`의 환승 자동 detect, #924)이 동일 shape을 재사용해
+ * 계속 존재 — 두 채널은 서로 독립적이며 이 type은 이제 순수 shape 정의일 뿐 backend 응답과
+ * 1:1이 아니다.
  */
 export interface AutoLockCandidate {
   trainCode: string;
@@ -63,11 +65,6 @@ export interface BoardingLockSyncResponse {
   currentWaypoint?: string | null;
   /** currentWaypoint와 동일 — 의미상 alias (다음 알람 대상). */
   nextStation?: string | null;
-  /**
-   * #916 A1 — backend가 trip에 부착한 자동/명시 lock 메타. 없으면 null.
-   * Client는 이 값을 useBoardingLockStore에 hydrate해 사용자 명시 탭 없이도 lock UX 활성화.
-   */
-  autoLockCandidate?: AutoLockCandidate | null;
   /** HTTP 실패/skip을 호출자가 진단할 수 있게 노출 — graceful (throw 아님). */
   skipped?: boolean;
   status?: number;
@@ -106,7 +103,6 @@ export async function syncBoardingLock(
       advanced: json?.advanced ?? false,
       currentWaypoint: json?.currentWaypoint ?? null,
       nextStation: json?.nextStation ?? null,
-      autoLockCandidate: json?.autoLockCandidate ?? null,
     };
   } catch (e) {
     log.warn('boarding-lock sync error', e);

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -756,8 +756,8 @@ export default function HomeScreen() {
     releaseBoardingLock?.();
   }, [releaseBoardingLock]);
   // #915 (C1 destination-only baseline UX) — destination 설정 직후 backend로 좋은 fix sync 발사.
-  // backend cron이 9단 게이트 통과 시 autoLockCandidate 응답에 부착(#916) → 사용자 명시 탭 없이
-  // boardingLock hydrate. lock 활성 여부와 무관하게 trip 활성 동안 폴링.
+  // lock 활성 여부와 무관하게 trip 활성 동안 폴링. #2352 — backend가 응답에 부착하던
+  // autoLockCandidate(#916) 무탭 hydrate 채널은 삭제됐다("무탭 오토락 전량 삭제" 결정, #2342).
   // D4 (#1210) — 활성 lock의 trainCode + 노선을 동봉해 환승 leg 진입 시 backend가
   // 새 trainCode로 추적을 갱신하도록 한다 (consecutiveEtaMissing 자동 종료 차단).
   useBoardingLockSync({
@@ -770,7 +770,6 @@ export default function HomeScreen() {
     stationFromWifi: confidence === 'wifi-ssid',
     boardingLockTrainCode: boardingLock?.trainCode ?? null,
     boardingLockLine: boardingLock?.boardingLine ?? null,
-    onAutoLockCandidate: hydrateLockFromCandidate,
   });
   // #1280 — FG(WhileInUse) 위치 채널. BG task가 안 도는 WhileInUse 권한에서 FG fix-watch가
   // ~10s throttle로 좌표를 backend에 송신해 POST /position 0건 회귀를 메운다. useBoardingLockSync와


### PR DESCRIPTION
Closes #2352

## 배경
#2342(PR #2349)가 프론트 `useTransferAutoDetect` A1 무탭 auto-lock 관련 정리를 진행했으나, **backend-driven 무탭 채널이 잔존**했다. backend가 `POST /boarding-lock/sync` 응답에 `autoLockCandidate`를 붙이고, 프론트 `HomeScreen.tsx:773 onAutoLockCandidate: hydrateLockFromCandidate`(`useBoardingLockSync`)가 **탭 없이** lock을 hydrate하는 경로였다. 사용자 "무탭 오토락 전량 삭제" 결정의 미완 잔존분을 마감한다.

## 변경
- **backend** `backend/alarm-worker/src/index.ts` — `POST /boarding-lock/sync` 응답에서 `autoLockCandidate` 필드 발급 제거. 함께 붙어있던 `hydrate-issued` D1 관측(#2283/#2308)도 제거 — 삭제된 응답 필드를 전제로 한 계측이라, 없는 채널을 있다고 기록하는 오탐 신호를 막기 위함.
  - 실제 "9-AND gate"(자동 lock 산출 로직)는 이미 #1729에서 삭제되어 있었음 — `working.boardingLock`을 그대로 응답에 echo하는 것만 남아 있었고, 이번 PR로 그 echo 경로 자체를 제거.
- **frontend** `src/screens/HomeScreen.tsx:773` — `useBoardingLockSync`에 넘기던 `onAutoLockCandidate: hydrateLockFromCandidate` 배선 제거.
- **frontend** `src/features/alarm/hooks/useBoardingLockSync.ts` — `onAutoLockCandidate` 옵션/콜백 채널 전체 삭제 (ref, effect, fireSync 파라미터, 로깅 필드).
- **frontend** `src/features/nearest-station/api/boardingLockSync.ts` — 응답 타입/파싱에서 `autoLockCandidate` 필드 제거. `AutoLockCandidate` 타입 자체는 유지 — device-side `useTransferAutoDetect`(#924, 환승 자동 detect)가 독립적으로 재사용 중이라 보존.

## 보존 (무회귀 확인)
- 사용자 직접 탭(`createLockFromTrain`) 경로 — 무변경.
- boardingPrompt 응답 lock 경로 — 무변경 (`useBoardingPromptResponder`는 이 채널과 무관한 별도 hook).
- `useBoardingLockController.hydrateLockFromCandidate` 함수 자체는 보존 — 현재 유일한 호출자는 `useTransferAutoDetect`의 device-side 단일 후보 환승 자동 detect(#924)로, 이번 이슈(backend #915/#916) scope 밖의 별개 기능. 함수를 통째로 삭제하면 그 기능이 깨지므로 최소 접점으로 backend 채널 wiring만 제거.

## TDD
- RED: `/boarding-lock/sync`가 `autoLockCandidate`를 반환하면 프론트가 탭 없이 lock을 생성하는 경로가 존재 (구 `onAutoLockCandidate` 옵션 + `useBoardingLockController.hydrateLockFromCandidate` 자동 호출).
- GREEN: 채널 제거 후 `autoLockCandidate` 필드/콜백 자체가 존재하지 않아 무탭 lock 생성 불가. backend가 (구버전 잔존 등으로) 필드를 여전히 보내도 프론트가 forward하지 않음을 회귀 테스트로 고정 (`useBoardingLockSync.test.ts`, `boardingLockSync.test.ts`).

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard** — 회귀 신호는 "무탭 lock 생성 이벤트 0건"이 정상. DebugModal BoardingLock 섹션에서 lock 생성 시 `hydratedFromSentinel`/trainCode 출처를 확인 가능. backend D1 `trip_events`에서 (구) `hydrate-issued` kind는 이제 절대 기록되지 않아야 함 — `sync-received`/`advance` 2종만 남는지 Cloudflare D1/wrangler tail로 확인 가능.
3. **의존 PR** — backend + frontend가 이 PR 하나에 함께 포함됨. **머지 후 backend deploy 필수** (`wrangler deploy` 별도 실행 — 이 PR은 코드만 포함, 배포는 미실행).
4. **측정 plan** — 다음 실기기 검증 탑승에서 "탭하지 않은 상태에서 lock이 저절로 잡히는 사례" 0건 확인. backend 배포 후 1주간 D1 `trip_events`에 `hydrate-issued` kind가 더 이상 적재되지 않는지 확인.
5. **Device verify** — 필요. 환승 trip 시나리오로 (a) 명시 탭 lock 정상 동작, (b) boardingPrompt 응답 lock 정상 동작, (c) 아무 탭 없이 lock이 생기지 않는지 확인.

## 검증
- `npx jest` (변경 3개 테스트 파일, coverage 100%: `useBoardingLockController.ts`/`useBoardingLockSync.ts`/`boardingLockSync.ts` 모두 100%)
- `cd backend/alarm-worker && npx vitest run src/__tests__/index.test.ts` — 453 passed
- `npx tsc --noEmit` (frontend) — clean
- `cd backend/alarm-worker && npx tsc --noEmit` — clean
- `npm run lint:orphan` — 0 orphan