### PR TITLE
fix(#2355): Seoul API subwayNm=null → subwayId 역파생으로 matchLine 전량탈락 차단

### DIFF
--- a/backend/alarm-worker/src/__tests__/evidence_20260812_replay.test.ts
+++ b/backend/alarm-worker/src/__tests__/evidence_20260812_replay.test.ts
@@ -99,7 +99,11 @@ function makeArrivedSeoul(stationName: string, trainCode = '7246'): SeoulArrival
               updnLine: '상행',
               trainLineNm: stationName,
               btrainNo: trainCode,
-              subwayNm: '지하철7호선',
+              // #2355 — 실 Seoul API는 subwayNm=null, subwayId만 유효값으로 보낸다. subwayId만
+              // 남겨 seoul.ts:parseEntry가 subwayId→line 역파생 경로를 타도록 fixture 교정
+              // (masking 제거).
+              subwayNm: null,
+              subwayId: '1007',
               arvlCd: 1,
             },
           ],

--- a/backend/alarm-worker/src/__tests__/evidence_20260812_replay_consensus.test.ts
+++ b/backend/alarm-worker/src/__tests__/evidence_20260812_replay_consensus.test.ts
@@ -81,7 +81,9 @@ function makeConsensusSeoul(now: number, etaSeconds: number): SeoulArrivalClient
               updnLine: '상행',
               trainLineNm: '중곡',
               btrainNo: '8801',
-              subwayNm: '지하철7호선',
+              // #2355 — 실 Seoul API는 subwayNm=null, subwayId만 유효값으로 보낸다.
+              subwayNm: null,
+              subwayId: '1007',
               arvlCd: 3,
             },
           ],

--- a/backend/alarm-worker/src/__tests__/seoul.test.ts
+++ b/backend/alarm-worker/src/__tests__/seoul.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { SeoulArrivalClient, parseRecptnDt, parseTerminusStationName } from '../seoul';
+import { matchLine } from '../lineAlias';
 
 function makeResponse(body: unknown, ok = true, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -10,6 +11,9 @@ function makeResponse(body: unknown, ok = true, status = 200): Response {
 
 const FIXED_NOW = Date.parse('2025-01-15T10:30:00+09:00');
 
+// #2355 — 실 Seoul API `realtimeStationArrival`은 subwayNm=null, subwayId만 유효값으로 보낸다
+// (rca-2351로 확증). 기존 fixture가 subwayNm 텍스트를 손주입해 empty-pool 회귀를 마스킹했던
+// 문제를 실 shape로 교정.
 function makeItem(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
   return {
     barvlDt: '120',
@@ -17,7 +21,8 @@ function makeItem(overrides: Partial<Record<string, unknown>> = {}): Record<stri
     updnLine: '상행',
     trainLineNm: '서울행',
     btrainNo: 'T-001',
-    subwayNm: '지하철1호선',
+    subwayNm: null,
+    subwayId: '1001',
     ...overrides,
   };
 }
@@ -49,6 +54,42 @@ describe('SeoulArrivalClient', () => {
     expect(arrivals[0].isUp).toBe(true);
     expect(arrivals[1].isUp).toBe(false);
     expect(arrivals[0].arrivalSeconds).toBe(120);
+  });
+
+  it('#2355 — subwayNm=null(실 API shape)이어도 subwayId로 line 복원 → matchLine 통과', async () => {
+    const fetchImpl = vi.fn(async () =>
+      makeResponse({
+        realtimeArrivalList: [makeItem({ subwayNm: null, subwayId: '1007' })],
+      }),
+    );
+    const client = new SeoulArrivalClient({
+      apiKey: 'KEY',
+      host: 'example.com',
+      now: () => FIXED_NOW,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const arrivals = await client.fetchArrivals('건대입구');
+    expect(arrivals).toHaveLength(1);
+    expect(arrivals[0].subwayNm).toBe('7호선');
+    expect(arrivals[0].subwayId).toBe('1007');
+    // 회귀 재현: 수정 전에는 subwayNm=''로 남아 matchLine이 전량 false.
+    expect(matchLine(arrivals[0].subwayNm, '7')).toBe(true);
+  });
+
+  it('#2355 — subwayNm이 실값으로 오면 그대로 유지(subwayId 파생 우회 X)', async () => {
+    const fetchImpl = vi.fn(async () =>
+      makeResponse({
+        realtimeArrivalList: [makeItem({ subwayNm: '지하철1호선', subwayId: '1001' })],
+      }),
+    );
+    const client = new SeoulArrivalClient({
+      apiKey: 'KEY',
+      host: 'example.com',
+      now: () => FIXED_NOW,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const arrivals = await client.fetchArrivals('서울역');
+    expect(arrivals[0].subwayNm).toBe('지하철1호선');
   });
 
   it('arvlCd 파싱 — number / numeric string / 누락 (#409)', async () => {

--- a/backend/alarm-worker/src/lineAlias.ts
+++ b/backend/alarm-worker/src/lineAlias.ts
@@ -69,6 +69,18 @@ export function subwayIdForLine(line: string): string | null {
 }
 
 /**
+ * #2355 — `subwayIdForLine`의 역방향. subwayId로 client line code(LINE_META의 key,
+ * `canonicalLineName`의 입력 형식)를 조회한다. Seoul API `realtimeStationArrival`이
+ * subwayNm=null, subwayId만 보내는 실 shape에서 line canonical name을 복원할 때
+ * `canonicalLineName(lineNameBySubwayId(item.subwayId))` 형태로 사용
+ * (`seoul.ts:parseEntry`). LINE_META에서 파생 — 매핑 없는 subwayId면 null.
+ */
+export function lineNameBySubwayId(subwayId: string): string | null {
+  const entry = Object.entries(LINE_META).find(([, meta]) => meta.subwayId === subwayId);
+  return entry?.[0] ?? null;
+}
+
+/**
  * 기존 호환성 — LINE_META에서 파생되는 alias 목록. 신규 코드는 LINE_META를 직접 사용 권장.
  */
 export const LINE_ALIAS_MAP: Record<string, readonly string[]> = Object.fromEntries(

--- a/backend/alarm-worker/src/seoul.ts
+++ b/backend/alarm-worker/src/seoul.ts
@@ -7,7 +7,7 @@
  *   동일 사이클 내 중복 호출 차단이 주 목적)
  */
 
-import { canonicalLineName } from './lineAlias';
+import { canonicalLineName, lineNameBySubwayId } from './lineAlias';
 import {
   parseTrainType,
   parseTrainTypeFromDirectAt,
@@ -26,8 +26,19 @@ export interface ArrivalEntry {
   trainCode: string;
   /** "상행"/"내선" 인지 여부 */
   isUp: boolean;
-  /** 노선명 (예: "지하철1호선") — Seoul API의 subwayNm */
+  /**
+   * 노선명 (예: "지하철1호선") — Seoul API의 subwayNm. #2355: 실 API는 이 필드를 null로
+   * 보내는 경우가 있어(subwayId만 유효), 그런 경우 `subwayId`에서 역파생한 canonical
+   * line name으로 대체된다 (`parseEntry` 참고) — 원본 raw subwayNm이 아닐 수 있다.
+   */
   subwayNm: string;
+  /**
+   * #2355 — Seoul API `subwayId` (예: "1007" = 7호선). `subwayNm`이 null인 실 API shape에서
+   * `lineNameBySubwayId`로 line을 복원하기 위해 파싱. optional — 구 caller/합성 entry
+   * (`arrivalsFromPositions.ts`)/테스트 fixture가 이 필드 없이 리터럴을 구성해도 컴파일 호환
+   * (#1720 `synthesized?`와 동일 정책).
+   */
+  subwayId?: string;
   /**
    * 도착 코드 (Seoul API arvlCd, #409): 0:진입, 1:도착, 2:출발, 3:전역출발,
    * 4:전역진입, 5:전역도착, 99:운행중. 누락/파싱 실패 시 null.
@@ -185,13 +196,20 @@ function parseEntry(raw: unknown, now: number): ArrivalEntry | null {
   const isUp = (UP_DIRECTION_VALUES as readonly string[]).includes(updnLine);
 
   const trainLineNm = typeof item.trainLineNm === 'string' ? item.trainLineNm : '';
+  const subwayId = typeof item.subwayId === 'string' ? item.subwayId : '';
+  // #2355 — 실 Seoul API는 subwayNm=null, subwayId만 보낸다. subwayNm 부재 시 subwayId에서
+  // canonical line name을 역파생 — matchLine('', line)이 전량 false로 떨어져 arrival pool이
+  // 통째로 비는 회귀 차단.
+  const rawSubwayNm = typeof item.subwayNm === 'string' ? item.subwayNm : '';
+  const subwayNm = rawSubwayNm || (canonicalLineName(lineNameBySubwayId(subwayId) ?? '') ?? '');
 
   return {
     destination: trainLineNm,
     arrivalSeconds: seconds,
     trainCode: typeof item.btrainNo === 'string' ? item.btrainNo : '',
     isUp,
-    subwayNm: typeof item.subwayNm === 'string' ? item.subwayNm : '',
+    subwayNm,
+    subwayId,
     arvlCd: parseArvlCd(item.arvlCd),
     trainType: parseTrainType(item.btrainSttus),
     terminus: parseTerminusStationName(trainLineNm),


### PR DESCRIPTION
Closes #2355

## 근본 원인
서울 API `realtimeStationArrival`이 모든 row에서 `subwayNm=null`을 보내는데 (노선 정보는 `subwayId`에만 존재), `seoul.ts:parseEntry`가 이를 `''`로 파싱하고 `lineAlias.ts:matchLine('', line)`이 전량 false를 반환 — backend `fetchArrivals` 소비자(boardingPrompt pool, hop-end 환승 candidate, pickAutoTrainCode, pickBestArrivalSignal, lockSwap cross-check) 전체가 empty pool로 broken이었다 (rca-2351 확증).

## 수정 (최소 blast, arrivalsFromPositions와 대칭)
1. `lineAlias.ts`에 `subwayIdForLine`의 역방향 helper `lineNameBySubwayId(subwayId)` 추가 — LINE_META에서 역맵 파생.
2. `seoul.ts` `parseEntry`: `item.subwayNm` 부재/null 시 `canonicalLineName(lineNameBySubwayId(item.subwayId))`로 subwayNm을 합성. `ArrivalEntry.subwayId`(optional) 필드도 신규 파싱.
3. **fixture 위생**: `seoul.test.ts`의 `makeItem` 기본값 + `evidence_20260812_replay.test.ts` / `evidence_20260812_replay_consensus.test.ts`의 raw fetch mock을 실 API shape(`subwayNm: null`, `subwayId: '1007'` 등)로 교정 — subwayNm 손주입 마스킹 제거.
4. TDD red→green 테스트 2건 추가(`seoul.test.ts`): 실 shape에서 matchLine 통과 확인 + subwayNm 실값 우선 유지 확인.

소스 변경 1곳(`parseEntry`), 소비자(scheduled.ts/boardingPrompt.ts/lockSwap.ts 등) call-site churn 0.

## 검증
- `npx vitest run` — 85 files / 3043 tests pass (backend/alarm-worker)
- `npx tsc --noEmit` — pass
- `npx vitest run --coverage` — exit 0, ratchet 유지 (seoul.ts 신규 분기는 red→green 테스트로 커버, 나머지 미커버 라인은 기존 pre-existing)

## Wire-completion 5단
1. **Orphan 없음** — 신규 export `lineNameBySubwayId`는 `seoul.ts`에서 즉시 소비. backend는 lint:orphan(ts-prune) 대상 밖(별도 npm 프로젝트) — 프론트 orphan 스크립트는 이 PR 범위 밖(코드 변경 없음).
2. **V/X dashboard** — KV `boarding-prompt-counters`의 `skippedEmpty` 카운터 급감으로 관측(Cloudflare Dashboard/DebugModal). D1 `trip_events`에서 candidateTrains>0 회복도 확인 가능.
3. **의존 PR** — #2350(proximity, backend 무탭채널)과 상보. 둘 다 있어야 boardingPrompt가 실제 발사됨. 병렬 작업 중이라 index.ts는 건드리지 않음. **머지 후 wrangler deploy 필요.**
4. **측정 plan** — 배포 후 1주 KV `skippedEmpty` reason별 카운터 추이 + D1 trip_events의 `candidateTrains` 분포로 empty-pool 재발 0건 확인.
5. **Device verify** — 필요. 다음 검증 탑승에서 `boarding_prompt_displayed>=1` 관측 필수(#2350과 함께 배포 후).