### PR TITLE
fix(#2363): 취침/일반 알림 경계 정합 + 일반 도착 gentle 보장

### DIFF
--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -204,14 +204,20 @@ jest.mock('../../../route/store/useDestinationStore', () => ({
 const mockAppStateHolder: { currentState: 'active' | 'background' | 'inactive' } = {
   currentState: 'background',
 };
+// #2363 — fireStationKindSkewFallback의 sleepMode × Platform.OS 4분기 커버리지를 위해
+// Platform.OS를 테스트에서 조작 가능하게 getter로 노출(AppState와 동일 패턴).
+const mockPlatformHolder: { OS: 'ios' | 'android' } = { OS: 'ios' };
 jest.mock('react-native', () => ({
   AppState: {
     get currentState() {
       return mockAppStateHolder.currentState;
     },
   },
-  // #2363 — fireStationKindSkewFallback의 sleepMode 분기가 Platform.OS를 참조.
-  Platform: { OS: 'ios' },
+  Platform: {
+    get OS() {
+      return mockPlatformHolder.OS;
+    },
+  },
 }));
 
 // #698/#918 A3 PR4 → #2089 — 옛 bl/tba 이중 채널(rescheduleHopForLock/rescheduleTripBoundAlarm +
@@ -248,10 +254,15 @@ const mockBuildAlarmContent = jest.fn((event: { phaseId: string; type: string; s
   title: `${event.phaseId}-title`,
   body: `${event.stationName}-${event.type}-body`,
 }));
+// #2363 — fireStationKindSkewFallback이 참조하는 일반모드 무음 채널 id(#2158). 실제 모듈의
+// 상수값과 동일 문자열로 mock — 값 자체가 프로덕션 코드의 SSoT이므로 여기서 재정의하지 않고
+// 그대로 재사용(리터럴 동기화는 stationNotification.test.ts가 실제 값으로 검증).
+const MOCK_ALARM_SILENT_CHANNEL_ID = 'station-alarm-silent';
 jest.mock('../../utils/stationNotification', () => ({
   mapBackendKindToLocalFireKind: (backendKind: string) =>
     ({ intermediate: 'station-passed', transfer: 'transfer', destination: 'destination' })[backendKind] ?? null,
   buildAlarmContent: (...args: unknown[]) => mockBuildAlarmContent(...(args as [never])),
+  ALARM_SILENT_CHANNEL_ID: 'station-alarm-silent',
 }));
 
 const mockAddDomainBreadcrumb = jest.fn();
@@ -417,6 +428,8 @@ describe('silentPushTask', () => {
     mockAddFiredPushId.mockResolvedValue(undefined);
     // #2018 γ' — 기본 BG로 설정해 기존 테스트가 FG 분기 진입하지 않도록.
     mockAppStateHolder.currentState = 'background';
+    // #2363 — 기본 iOS로 설정해 기존 테스트가 android 분기로 새지 않도록.
+    mockPlatformHolder.OS = 'ios';
     // clearAllMocks가 mockImplementation을 reset하지 않으므로 명시 복구.
     mockSetTripEndedSentinel.mockResolvedValue(undefined);
     mockClearTripEndedSentinel.mockResolvedValue(undefined);
@@ -1634,34 +1647,60 @@ describe('silentPushTask', () => {
         expect(mockLogSilentPushSkipped).not.toHaveBeenCalled();
       });
 
-      // #2363 — 일반모드(sleepMode OFF)에서 발사되는 station-shaped skew fallback은 loud가
-      // 아니라 gentle이어야 한다(#2158류 회귀 가드: 일반모드 loud 알람 재발 차단).
-      it('일반모드(sleepMode OFF)면 gentle(sound:false)로 발사한다 (#2363)', async () => {
-        mockReadSleepMode.mockResolvedValueOnce(false);
-        await handleSilentPush(
-          payload({ kind: 'future-station-kind', phase: 'early', nextWaypoint: '강남', pushId: 'p-skew-general' }),
-        );
-        expect(mockScheduleNotificationAsync).toHaveBeenCalledWith(
-          expect.objectContaining({
-            identifier: 'skew-fallback-강남',
-            content: expect.objectContaining({ sound: false }),
-          }),
-        );
-      });
-
-      // 취침모드(sleepMode ON)면 acceptance 표대로 도착/환승은 loud wake 유지.
-      it('취침모드(sleepMode ON)면 loud(sound:true)로 발사한다 (#2363)', async () => {
-        mockReadSleepMode.mockResolvedValueOnce(true);
-        await handleSilentPush(
-          payload({ kind: 'future-station-kind', phase: 'early', nextWaypoint: '강남', pushId: 'p-skew-sleep' }),
-        );
-        expect(mockScheduleNotificationAsync).toHaveBeenCalledWith(
-          expect.objectContaining({
-            identifier: 'skew-fallback-강남',
-            content: expect.objectContaining({ sound: true }),
-          }),
-        );
-      });
+      // #2363 — station-shaped skew fallback의 loud/gentle은 sleepMode를 따른다(#2158류 회귀
+      // 가드: 일반모드 loud 알람 재발 차단). Platform.OS × sleepMode 4개 조합 모두 단정 —
+      // Android는 channelId 유무, iOS는 interruptionLevel 유무가 분기마다 달라진다.
+      it.each<{
+        platform: 'ios' | 'android';
+        sleepMode: boolean;
+        expectedContent: Record<string, unknown>;
+      }>([
+        {
+          platform: 'android',
+          sleepMode: false,
+          expectedContent: { sound: false, channelId: MOCK_ALARM_SILENT_CHANNEL_ID },
+        },
+        {
+          platform: 'android',
+          sleepMode: true,
+          expectedContent: { sound: true },
+        },
+        {
+          platform: 'ios',
+          sleepMode: false,
+          expectedContent: { sound: false, interruptionLevel: 'timeSensitive' },
+        },
+        {
+          platform: 'ios',
+          sleepMode: true,
+          expectedContent: { sound: true, interruptionLevel: 'timeSensitive' },
+        },
+      ])(
+        'platform=$platform sleepMode=$sleepMode → content가 acceptance대로 발사된다 (#2363)',
+        async ({ platform, sleepMode, expectedContent }) => {
+          mockPlatformHolder.OS = platform;
+          mockReadSleepMode.mockResolvedValueOnce(sleepMode);
+          await handleSilentPush(
+            payload({ kind: 'future-station-kind', phase: 'early', nextWaypoint: '강남', pushId: `p-skew-${platform}-${sleepMode}` }),
+          );
+          expect(mockScheduleNotificationAsync).toHaveBeenCalledWith(
+            expect.objectContaining({
+              identifier: 'skew-fallback-강남',
+              content: expect.objectContaining(expectedContent),
+            }),
+          );
+          const [[call]] = mockScheduleNotificationAsync.mock.calls.slice(-1);
+          // android+일반모드에만 channelId, ios에만 interruptionLevel — 반대 조합에서는 키 자체가 없어야 한다.
+          if (platform === 'android' && sleepMode) {
+            expect(call.content).not.toHaveProperty('channelId');
+          }
+          if (platform === 'ios') {
+            expect(call.content).not.toHaveProperty('channelId');
+          } else {
+            expect(call.content).not.toHaveProperty('interruptionLevel');
+          }
+        },
+      );
 
       it('kind가 없으면(구버전 backend) 여전히 payload-missing-kind skip — fallback fire 아님', async () => {
         await handleSilentPush(

--- a/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
+++ b/src/features/alarm/tasks/__tests__/silentPushTask.test.ts
@@ -210,6 +210,8 @@ jest.mock('react-native', () => ({
       return mockAppStateHolder.currentState;
     },
   },
+  // #2363 — fireStationKindSkewFallback의 sleepMode 분기가 Platform.OS를 참조.
+  Platform: { OS: 'ios' },
 }));
 
 // #698/#918 A3 PR4 → #2089 — 옛 bl/tba 이중 채널(rescheduleHopForLock/rescheduleTripBoundAlarm +
@@ -1630,6 +1632,35 @@ describe('silentPushTask', () => {
         );
         // legacy-station-kind-ignored skip은 발생하지 않는다 — fallback fire 분기에서 즉시 return.
         expect(mockLogSilentPushSkipped).not.toHaveBeenCalled();
+      });
+
+      // #2363 — 일반모드(sleepMode OFF)에서 발사되는 station-shaped skew fallback은 loud가
+      // 아니라 gentle이어야 한다(#2158류 회귀 가드: 일반모드 loud 알람 재발 차단).
+      it('일반모드(sleepMode OFF)면 gentle(sound:false)로 발사한다 (#2363)', async () => {
+        mockReadSleepMode.mockResolvedValueOnce(false);
+        await handleSilentPush(
+          payload({ kind: 'future-station-kind', phase: 'early', nextWaypoint: '강남', pushId: 'p-skew-general' }),
+        );
+        expect(mockScheduleNotificationAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            identifier: 'skew-fallback-강남',
+            content: expect.objectContaining({ sound: false }),
+          }),
+        );
+      });
+
+      // 취침모드(sleepMode ON)면 acceptance 표대로 도착/환승은 loud wake 유지.
+      it('취침모드(sleepMode ON)면 loud(sound:true)로 발사한다 (#2363)', async () => {
+        mockReadSleepMode.mockResolvedValueOnce(true);
+        await handleSilentPush(
+          payload({ kind: 'future-station-kind', phase: 'early', nextWaypoint: '강남', pushId: 'p-skew-sleep' }),
+        );
+        expect(mockScheduleNotificationAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            identifier: 'skew-fallback-강남',
+            content: expect.objectContaining({ sound: true }),
+          }),
+        );
       });
 
       it('kind가 없으면(구버전 backend) 여전히 payload-missing-kind skip — fallback fire 아님', async () => {

--- a/src/features/alarm/tasks/silentPushTask.ts
+++ b/src/features/alarm/tasks/silentPushTask.ts
@@ -28,7 +28,7 @@ import * as TaskManager from 'expo-task-manager';
 import * as Location from 'expo-location';
 import * as Battery from 'expo-battery';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { AppState } from 'react-native';
+import { AppState, Platform } from 'react-native';
 import {
   persistBackendSsotMirror,
   parseAlarmEventsMirror,
@@ -79,7 +79,11 @@ import {
   cancelSafetyNetByStationKind,
 } from '../utils/safetyNetScheduler';
 import { cancelPrescheduledByStationKind } from '../utils/stationPrescheduler';
-import { mapBackendKindToLocalFireKind, buildAlarmContent } from '../utils/stationNotification';
+import {
+  mapBackendKindToLocalFireKind,
+  buildAlarmContent,
+  ALARM_SILENT_CHANNEL_ID,
+} from '../utils/stationNotification';
 import { markLocalStationFired } from '../utils/recentLocalStationFires';
 import { ROUTE_KEY } from '../../../shared/constants/storageKeys';
 import type { Route } from '../../../shared/utils/stationRoute';
@@ -1583,6 +1587,10 @@ async function fireSleepAlarmCompanion(
  * stationLike`. 어떤 세부 종류(환승/도착/통과)인지는 알 수 없지만 어느 역인지는 알고 있으므로,
  * transfer/destination 공용 문구 빌더(`buildAlarmContent`)를 `type: 'destination'`(비-환승 문구,
  * 더 일반적인 표현)으로 재사용해 generic "곧 도착" 알림을 즉시 발사한다.
+ *
+ * #2363 (ADR-033 acceptance) — loud/gentle은 sleepMode를 따른다: 취침이면 loud wake(사용자가
+ * 잠들어 있으니 도달률 우선), 일반이면 gentle(#2158류 — 일반모드 loud 알람 재발 방지).
+ * `ALARM_SILENT_CHANNEL_ID`는 이미 #2158에서 만들어진 일반모드 무음 채널을 그대로 재사용한다.
  */
 async function fireStationKindSkewFallback(payload: SilentPushPayload): Promise<void> {
   const { title, body } = buildAlarmContent({
@@ -1590,9 +1598,17 @@ async function fireStationKindSkewFallback(payload: SilentPushPayload): Promise<
     type: 'destination',
     stationName: payload.nextWaypoint,
   });
+  const sleepMode = await readSleepMode();
   await Notifications.scheduleNotificationAsync({
     identifier: `skew-fallback-${payload.nextWaypoint}`,
-    content: { title, body, sound: true },
+    content: {
+      title,
+      body,
+      sound: sleepMode,
+      ...(Platform.OS === 'android' &&
+        !sleepMode && { channelId: ALARM_SILENT_CHANNEL_ID }),
+      ...(Platform.OS === 'ios' && { interruptionLevel: 'timeSensitive' as const }),
+    },
     trigger: null,
   });
 }


### PR DESCRIPTION
Closes #2363

Part of #2361 (ADR-033 D3/A3·A4).

## 조사 결과 (red 재현)

일반 모드 도착/환승 알람의 주 채널은 backend 원격 alert push(sound:alarm.wav, #2066)이며 이는 범위 밖(backend 변경 금지). `shouldSuppressBySleepRule`(매역/환승 suppress, destination 항상 통과)도 acceptance 표와 이미 정합 상태였다.

실제 회귀 지점은 `silentPushTask.ts`의 `fireStationKindSkewFallback` (G6, #2243 ADR-029 station-shaped 계약 스큐 fallback) — backend가 `STATION_WAYPOINT_KINDS` 밖의 kind를 실은 station-shaped push를 보내면 device가 generic "곧 도착" 알림을 **sleepMode 무관 `sound:true`(loud)**로 즉시 발사하고 있었다. 이는 #2158류(일반모드 loud 알람) 회귀 패턴과 동형이었다.

- Red: 신규 테스트 "일반모드(sleepMode OFF)면 gentle(sound:false)로 발사한다 (#2363)" → 기존 코드에서 FAIL (sound:true 발사).
- Green: `fireStationKindSkewFallback`이 `readSleepMode()`를 확인해 취침이면 loud(sound:true, iOS timeSensitive), 일반이면 gentle(sound:false, Android는 기존 #2158 무음 채널 `ALARM_SILENT_CHANNEL_ID` 재사용)로 분기.

## 변경 파일
- `src/features/alarm/tasks/silentPushTask.ts` — `fireStationKindSkewFallback`에 sleepMode 분기 추가, `Platform`/`ALARM_SILENT_CHANNEL_ID` import.
- `src/features/alarm/tasks/__tests__/silentPushTask.test.ts` — 일반/취침 채널 시나리오 테스트 2건 추가, react-native mock에 `Platform.OS` 추가(신규 분기가 참조).

## 이탈 사항
이슈 스펙은 "일반 모드 도착=gentle" 전반을 다루지만, 도착의 주 채널(backend alert push)은 코드상 손댈 수 없는 범위(backend 변경 금지)라 실제 수정은 device-local fallback 경로(스큐 대응) 1곳으로 한정됨. `stationNotification.ts`의 채널 정의(59/195 무음 채널)는 이미 #2158에서 올바르게 구성돼 있어 변경 없이 재사용만 함. `shouldSuppressBySleepRule.ts`도 acceptance와 이미 정합 — 변경 없음.

## Wire-completion 5단
1. **Orphan**: `npm run lint:orphan` pass (0 orphan).
2. **V/X dashboard**: 시나리오 테스트(`silentPushTask.test.ts` #2363 describe block)로 회귀 고정. 런타임에서는 DebugModal의 silent push 진단 섹션 + `logPushContractKindSkew`(station-like skew 로그)로 관측 가능.
3. **의존 PR**: N/A — 프론트엔드 device-local 변경만, backend/타 PR 의존 없음. (A) 문구 PR과도 독립.
4. **측정 plan**: 실기기 취침/일반 구간에서 backend가 계약 스큐 push를 보내는 경우는 드물어 production 측정은 어려움 — 대신 시나리오 테스트 2건(일반=gentle/취침=loud)이 회귀 게이트 역할. 계약 스큐 발생률 자체는 `logPushContractKindSkew` category=station-like 카운트로 추적 가능.
5. **Device verify**: 필요 — loud vs gentle 실물 차이는 코드/타입 검증만으로 확인 불가. 계약 스큐 케이스가 실기기에서 드물게만 발생하므로, 검증은 유닛 테스트 sound:true/false 단정으로 대체(N/A에 가까움, 재현 조건이 backend 계약 위반 상황이라 인위적 트리거 필요).