### PR TITLE
fix(#2364): 지하 subsurface consensus 시 movement gate 오억제 우회

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -3388,6 +3388,58 @@ describe('useStationAlarm', () => {
       expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
     });
 
+    // #2364 (ADR-033 A5) — 지하(GPS speed 불명) + arvlcd-arrived 포함 ≥2 신호 합의
+    // (subsurfaceStationDetected=true, useFusedNearestStation SSoT)가 이동을 간접 확인하면
+    // 정적 misfire 가드(#727/#728/#733)가 유효 arvlCd fast-path 발사를 오억제하지 않아야 한다.
+    it('#2364 subsurfaceStationDetected=true(지하 합의) + speed 불명 → movement gate 우회, fast path 발사', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      mockGetLastNotifiedStationId.mockResolvedValue(null);
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+
+      renderHook(() =>
+        useStationAlarm(
+          fastPathInputs({
+            speedMps: null,
+            positionStability: 'static',
+            subsurfaceStationDetected: true,
+          }),
+        ),
+      );
+
+      await waitFor(() =>
+        expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, onRouteStation.id),
+      );
+      expect(mockLogSuppressedMovement).not.toHaveBeenCalledWith(
+        expect.objectContaining({ source: 'fg-arvlcd' }),
+      );
+    });
+
+    // 회귀 가드: subsurfaceStationDetected=false(합의 없음, 진짜 정적 사용자)면 기존처럼
+    // 정적 misfire 가드가 그대로 억제한다 — 통과 열차 momentary adopt 등 false positive 방어 유지.
+    it('#2364 회귀 가드 — subsurfaceStationDetected=false(합의 없음) + speed=0 → 여전히 억제', async () => {
+      mockGetBoardingLock.mockResolvedValue(activeLock);
+      mockGetLastNotifiedStationId.mockResolvedValue(onRouteStation.id);
+      mockFindFgArvlCdFireSignal.mockReturnValue({ trainCode: 'T-LOCK', arvlCd: 0 });
+
+      renderHook(() =>
+        useStationAlarm(
+          fastPathInputs({ speedMps: 0, subsurfaceStationDetected: false }),
+        ),
+      );
+
+      await waitFor(() =>
+        expect(mockLogSuppressedMovement).toHaveBeenCalledWith(
+          expect.objectContaining({
+            source: 'fg-arvlcd',
+            stationName: onRouteStation.name,
+            kind: 'station-passed',
+            reason: 'movement-static-speed',
+          }),
+        ),
+      );
+      expect(mockSetLastNotifiedStationId).not.toHaveBeenCalled();
+    });
+
     it('dismiss silence 활성 시 fast path 발사 X + logSuppressedDismissSilence(fg-arvlcd)', async () => {
       mockGetBoardingLock.mockResolvedValue(activeLock);
       mockGetLastNotifiedStationId.mockResolvedValue(onRouteStation.id);

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -1500,7 +1500,14 @@ export function useStationAlarm({
       // #727/#728/#733 — 정적 misfire 가드. arvlCd 신호가 강해도 정적 사용자(speed=0) 발사는
       // 잘못된 trainCode lock 케이스 (fusion이 통과 열차를 momentary adopt)에서 위험.
       // movement gate는 silence gate보다 먼저 평가 — 정적 사용자면 silence 만료 부수효과도 불필요.
-      if (movementSuppressionReason) {
+      // #2364 (ADR-033 A5) — subsurfaceStationDetected=true는 useFusedNearestStation이 이미
+      // subsurface(지하 진입 확정) + ≥2 신호 합의(barometer-stop/motion-stationary/arvlcd-arrived) +
+      // 역 근접 게이트를 통과시킨 상태. 지하 GPS 사멸로 speed/positionStability가 불명(motion-warmup/
+      // static-position 등)일 뿐인데 정적 misfire 가드가 이미 간접 확인된 이동을 오억제하는 회귀
+      // 차단 — trainProgressing(#1401)과 동일한 취지의 우회. false positive 방어(통과 열차
+      // momentary adopt)는 lock.trainCode 일치(findFgArvlCdFireSignal)가 1차로 이미 담당하고,
+      // subsurfaceStationDetected 자체도 근접 게이트를 포함해 GPS 좌표 기반 지하 추정과는 무관하다.
+      if (movementSuppressionReason && !subsurfaceStationDetected) {
         logSuppressedMovement({
           source: 'fg-arvlcd',
           stationName: candidateStation.name,
@@ -1593,6 +1600,8 @@ export function useStationAlarm({
     nearestStation?.line,
     currentStationArrival,
     movementSuppressionReason,
+    // #2364 — subsurfaceStationDetected 변화 시 movement gate 우회 여부 재평가.
+    subsurfaceStationDetected,
     dismissSilence,
     clearDismissSilenceAction,
     userLocation?.lat,


### PR DESCRIPTION
Closes #2364

## 요약
- `useStationAlarm.ts`의 fg-arvlcd fast-path 정적 misfire 가드(#727/#728/#733, line ~1500)가 `subsurfaceStationDetected=true`(지하 진입 확정 + barometer-stop/motion-stationary/arvlcd-arrived ≥2 신호 합의 + 역 근접 게이트를 `useFusedNearestStation`이 이미 통과시킨 SSoT 신호)일 때는 GPS speed/positionStability 불명만으로 유효 arvlCd 발사를 억제하지 않도록 보정
- 조건: `if (movementSuppressionReason && !subsurfaceStationDetected)` — trainProgressing(#1401)과 동일 취지의 우회
- false positive 방어(통과 열차 momentary adopt)는 기존 `lock.trainCode` 일치 게이트(`findFgArvlCdFireSignal`)가 계속 1차 담당. 정적 misfire 가드 자체는 삭제하지 않고 그대로 유지 — 지하+합의 케이스만 우회.
- GPS 좌표 기반 지하 추정은 사용하지 않음 (ADR 원칙 유지) — subsurfaceStationDetected는 fusion 레이어가 이미 산출한 근접 게이트 포함 합의 신호.

## 조사 결과
- `movementSuppressionReason`은 `evaluateMovement`(movementGate.ts)가 speed=null + positionStability='static' 조합에서 `'static-position'`, 또는 motion=true 조합에서 `'motion-stationary'` 등을 반환할 때 세팅됨. 지하에서 GPS speed가 미측정(-1/null)이고 위치 이력이 정적으로 보이면 이 경로로 진입 — 실제로는 이동 중(다음 역 진입)인데 오억제되는 실 케이스가 이론상 존재함을 확인.
- 기존에 이미 존재하던 `subsurfaceStationDetected` 기반 별도 경로(Path C, #1290/#1298)는 movement gate 자체를 아예 타지 않는 독립 effect라 fg-arvlcd fast-path(Path B)의 오억제는 해결하지 못하고 있었음 — 이번 수정으로 Path B에도 같은 신호로 우회를 적용.

## 테스트
- red→green: `#2364 subsurfaceStationDetected=true(지하 합의) + speed 불명 → movement gate 우회, fast path 발사` — 수정 전 fail(정적 가드가 억제) 확인 후 fix 적용, pass 전환.
- 회귀 가드: `#2364 회귀 가드 — subsurfaceStationDetected=false(합의 없음) + speed=0 → 여전히 억제` — 합의 없는 진짜 정적 사용자는 기존처럼 억제됨을 보장.
- `npx jest src/features/alarm/hooks/__tests__/useStationAlarm.test.ts` — 235/235 pass.
- `npm run type-check` — pass.
- `npm run lint:orphan` — No orphan exports detected.

## Wire-completion 5단
1. **Orphan 없음** — `npm run lint:orphan` pass, 신규 export 없음(기존 훅 내부 로직 수정).
2. **V/X dashboard** — DebugModal의 movement/fusion 로그(`logSuppressedMovement` source='fg-arvlcd')에서 억제 여부 관측 가능. subsurfaceStationDetected 값은 기존 fusion 디버그 로그에 이미 노출됨.
3. **의존 PR** — 독립. N/A.
4. **측정 plan** — 실기기 지하 탑승 시 매역 발사되는지 관측(A5+A7 동시 관측, 이슈 본문 명시). `logSuppressedMovement(fg-arvlcd, reason=movement-static-position/motion-stationary)` 발생 빈도가 지하 구간에서 감소하는지 alarmLog로 확인.
5. **Device verify** — 필요(지하 실물). 코드 변경은 movement gate 조건문 1줄 + deps 1개 추가로 범위가 작으나, GPS speed 불명 상황 자체가 지하 실측에서만 재현 가능.

## Lane 경계 준수
- `useStationAlarm.ts`의 movement 게이트 영역(1500~1511)만 수정. 270 FG aux 호출부, `stationNotification.ts`, 매역 문구/locale은 건드리지 않음.
- 정적 misfire 가드 삭제 없음. GPS 좌표 기반 지하 추정 없음. backend 변경 없음.