### PR TITLE
fix(#2362): 매역 알림 문구 '역 도착 / N정거장 남음' + count·target 배선

### DIFF
--- a/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
+++ b/src/features/alarm/hooks/__tests__/useStationAlarm.test.ts
@@ -1718,7 +1718,12 @@ describe('useStationAlarm', () => {
           expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, station.id);
         });
         await waitFor(() => {
-          expect(mockFireFgAuxStationPassedNotification).toHaveBeenCalledWith(station.name);
+          expect(mockFireFgAuxStationPassedNotification).toHaveBeenCalledWith(
+            station.name,
+            1,
+            'destination',
+            destination.name,
+          );
         });
         expect(mockLogFiredStationPassed).toHaveBeenCalledWith('fg', station.name);
       });
@@ -1758,10 +1763,159 @@ describe('useStationAlarm', () => {
           expect(mockSetLastNotifiedStationId).toHaveBeenCalledWith(destination.id, station.id);
         });
         await waitFor(() => {
-          expect(mockFireFgAuxStationPassedNotification).toHaveBeenCalledWith(station.name);
+          expect(mockFireFgAuxStationPassedNotification).toHaveBeenCalledWith(
+            station.name,
+            1,
+            'destination',
+            destination.name,
+          );
         });
         // logFiredStationPassed는 fireFgAuxStationPassedNotification 성공 후에만 호출 — 실패 시 미호출.
         expect(mockLogFiredStationPassed).not.toHaveBeenCalled();
+      });
+
+      // #2362 — transfer/multi-transfer route에서 count/target(환승역|도착역) 배선.
+      it('transfer route + 환승 전(candidate.line===fromLine) → targetKind=transfer + stopsToTransfer 전달', async () => {
+        setAppState('active');
+        const transferRoute = makeTransferRoute({
+          transferName: '시청',
+          fromLine: '2',
+          toLine: '1',
+          stopsToTransfer: 4,
+          stopsFromTransfer: 6,
+        });
+        mockEvaluateAlarmPhase.mockReturnValue(null);
+        mockGetLastNotifiedStationId.mockResolvedValue(null);
+        mockSetLastNotifiedStationId.mockResolvedValue(undefined);
+        mockResolveNextTarget.mockReturnValue({
+          nextStationName: '강남',
+          stopsToNextStation: 1,
+          isTransfer: false,
+          stopsToDestination: 1,
+        });
+
+        renderHook(() =>
+          useStationAlarm(
+            defaultInputs({ route: transferRoute, destination, nearestStation: station }),
+          ),
+        );
+
+        await waitFor(() => {
+          expect(mockFireFgAuxStationPassedNotification).toHaveBeenCalledWith(
+            station.name,
+            4,
+            'transfer',
+            '시청',
+          );
+        });
+      });
+
+      it('transfer route + 환승 후(candidate.line===toLine) → targetKind=destination + stopsFromTransfer 전달', async () => {
+        setAppState('active');
+        const transferRoute = makeTransferRoute({
+          transferName: '시청',
+          fromLine: '1',
+          toLine: '2',
+          stopsToTransfer: 4,
+          stopsFromTransfer: 6,
+        });
+        mockEvaluateAlarmPhase.mockReturnValue(null);
+        mockGetLastNotifiedStationId.mockResolvedValue(null);
+        mockSetLastNotifiedStationId.mockResolvedValue(undefined);
+        mockResolveNextTarget.mockReturnValue({
+          nextStationName: '강남',
+          stopsToNextStation: 1,
+          isTransfer: false,
+          stopsToDestination: 1,
+        });
+
+        // candidate(station)는 line '2' 고정 — toLine과 일치시켜 "환승 후" 분기를 탄다.
+        renderHook(() =>
+          useStationAlarm(
+            defaultInputs({ route: transferRoute, destination, nearestStation: station }),
+          ),
+        );
+
+        await waitFor(() => {
+          expect(mockFireFgAuxStationPassedNotification).toHaveBeenCalledWith(
+            station.name,
+            6,
+            'destination',
+            destination.name,
+          );
+        });
+      });
+
+      it('multi-transfer route + candidate가 첫 leg fromLine과 일치 → 그 leg의 환승역 대상', async () => {
+        setAppState('active');
+        const multiRoute = makeMultiTransferRoute({
+          transfers: [
+            { transferName: '시청', fromLine: '2', toLine: '1', stopsToTransfer: 2 },
+            { transferName: '충무로', fromLine: '1', toLine: '4', stopsToTransfer: 5 },
+          ],
+          stopsAfterLastTransfer: 3,
+        });
+        mockEvaluateAlarmPhase.mockReturnValue(null);
+        mockGetLastNotifiedStationId.mockResolvedValue(null);
+        mockSetLastNotifiedStationId.mockResolvedValue(undefined);
+        mockResolveNextTarget.mockReturnValue({
+          nextStationName: '강남',
+          stopsToNextStation: 1,
+          isTransfer: false,
+          stopsToDestination: 1,
+        });
+
+        renderHook(() =>
+          useStationAlarm(
+            defaultInputs({ route: multiRoute, destination, nearestStation: station }),
+          ),
+        );
+
+        await waitFor(() => {
+          expect(mockFireFgAuxStationPassedNotification).toHaveBeenCalledWith(
+            station.name,
+            2,
+            'transfer',
+            '시청',
+          );
+        });
+      });
+
+      it('multi-transfer route + candidate가 어느 leg의 fromLine과도 불일치(마지막 환승 이후) → destination 대상 + stopsAfterLastTransfer', async () => {
+        setAppState('active');
+        const multiRoute = makeMultiTransferRoute({
+          transfers: [
+            { transferName: '시청', fromLine: '1', toLine: '3', stopsToTransfer: 2 },
+            { transferName: '충무로', fromLine: '3', toLine: '2', stopsToTransfer: 5 },
+          ],
+          stopsAfterLastTransfer: 3,
+        });
+        mockEvaluateAlarmPhase.mockReturnValue(null);
+        mockGetLastNotifiedStationId.mockResolvedValue(null);
+        mockSetLastNotifiedStationId.mockResolvedValue(undefined);
+        mockResolveNextTarget.mockReturnValue({
+          nextStationName: '강남',
+          stopsToNextStation: 1,
+          isTransfer: false,
+          stopsToDestination: 1,
+        });
+
+        // candidate(station)는 line '2' 고정 — 마지막 leg의 toLine과 일치해 isStationOnRoute는
+        // 통과하지만, 두 leg의 fromLine('1'/'3') 어디에도 걸리지 않아 destination 분기로 떨어진다.
+        renderHook(() =>
+          useStationAlarm(
+            defaultInputs({ route: multiRoute, destination, nearestStation: station }),
+          ),
+        );
+
+        await waitFor(() => {
+          expect(mockFireFgAuxStationPassedNotification).toHaveBeenCalledWith(
+            station.name,
+            3,
+            'destination',
+            destination.name,
+          );
+        });
       });
     });
 

--- a/src/features/alarm/hooks/useStationAlarm.ts
+++ b/src/features/alarm/hooks/useStationAlarm.ts
@@ -85,7 +85,10 @@ import { isAccuracyAcceptable } from '../../nearest-station/utils/locationGates'
 import type { FusionConfidence, FusionSource } from '../../../shared/types/fusion';
 import { isStrongFusionSource } from '../../../shared/constants/fusionSourceStrength';
 import { isSimpleArchEnabled } from '../../../shared/config/archFlag';
-import { fireFgAuxStationPassedNotification } from '../utils/stationNotification';
+import {
+  fireFgAuxStationPassedNotification,
+  type StationPassedTargetKind,
+} from '../utils/stationNotification';
 
 const logger = createLogger('StationAlarm');
 
@@ -172,6 +175,62 @@ function logSuppressedStationPassedLockless(stationName: string): void {
   });
 }
 
+/** #2362 — 매역 알림 본문에 배선할 "남은 정거장 수 + 다음 대상(환승역|도착역)". */
+interface StationPassedTarget {
+  count: number;
+  targetKind: StationPassedTargetKind;
+  targetName: string;
+}
+
+/**
+ * #2362 — route(direct/transfer/multi-transfer)가 이미 들고 있는 남은 정거장 수 필드
+ * (`stops`/`stopsToTransfer`/`stopsFromTransfer`/`stopsAfterLastTransfer`)에서 다음 hop
+ * 대상(환승역 또는 최종 도착역)과 count를 그대로 읽어온다. 이 필드들은 매 폴링 주기마다
+ * `updateRouteFromPosition`(stationRoute.ts)이 현재 위치 기준 정수 hop count로 갱신한
+ * SSoT — Live Activity route subtext(`buildLiveActivityData`)도 동일 필드를 읽는다.
+ * 별도 GPS 좌표 기반 추정이나 station id lookup을 추가하지 않는다.
+ *
+ * transfers 배열은 인덱스 하드코딩 없이 순회 — candidate가 아직 도달하지 않은 첫 leg의
+ * fromLine과 일치하면 그 leg의 환승역이 대상. 어느 leg에도 걸리지 않으면(마지막 환승 이후)
+ * 최종 destination이 대상.
+ */
+function deriveStationPassedTarget(
+  route: NonNullable<Route>,
+  destination: Station,
+  candidateStation: Station,
+): StationPassedTarget {
+  if (route.type === 'direct') {
+    return { count: route.stops, targetKind: 'destination', targetName: destination.name };
+  }
+  if (route.type === 'transfer') {
+    if (candidateStation.line === route.fromLine) {
+      return {
+        count: route.stopsToTransfer,
+        targetKind: 'transfer',
+        targetName: route.transferName,
+      };
+    }
+    return {
+      count: route.stopsFromTransfer,
+      targetKind: 'destination',
+      targetName: destination.name,
+    };
+  }
+  for (const segment of route.transfers) {
+    if (candidateStation.line !== segment.fromLine) continue;
+    return {
+      count: segment.stopsToTransfer,
+      targetKind: 'transfer',
+      targetName: segment.transferName,
+    };
+  }
+  return {
+    count: route.stopsAfterLastTransfer,
+    targetKind: 'destination',
+    targetName: destination.name,
+  };
+}
+
 /**
  * #917 follow-up — station-passed 알림 dedup → resolve → send → setLast → log 시퀀스 추출.
  * GPS station-passed effect와 FG arvlCd fast-path effect가 동일한 5단 시퀀스를 반복하던 것
@@ -190,6 +249,10 @@ async function dispatchStationPassed(params: {
   /** #2122 — FG 보조 발사 조건(AppState active && lock 활성) 판정용. 호출부가 항상 lock 활성 trip만
    *  진입시키므로 실질적으로 non-null이지만, 타입은 방어적으로 nullable을 유지한다. */
   lock: import('../../../shared/types/boardingLock').BoardingLock | null;
+  /** #2362 — count/target 도출용. 호출부의 effect가 이미 `!route || !destination` 가드를
+   *  통과했으므로 non-null이지만, 방어적으로 nullable 유지. */
+  route: Route;
+  destination: Station | null;
 }): Promise<void> {
   const {
     source,
@@ -198,6 +261,8 @@ async function dispatchStationPassed(params: {
     isCancelled,
     errorLogPrefix,
     lock,
+    route,
+    destination,
   } = params;
   try {
     const lastId = await getLastNotifiedStationId(capturedDestinationId);
@@ -265,9 +330,17 @@ async function dispatchStationPassed(params: {
     // 등, 여기 도달했다는 것 자체가 전부 통과했다는 뜻)를 통과한 뒤에만, FG 한정으로 로컬
     // station-passed 배너를 추가 발사한다. BG(AppState !=='active')는 이 블록에 도달해도 스킵 —
     // #2064 봉인이 BG에는 그대로 유지된다.
-    if (AppState.currentState === 'active' && lock) {
+    // #2362 — count/target(환승역|도착역) 배선. route/destination은 호출부 effect가 이미
+    // `!route || !destination` 가드로 non-null을 보장한 뒤에만 여기 도달한다.
+    if (AppState.currentState === 'active' && lock && route && destination) {
       try {
-        await fireFgAuxStationPassedNotification(candidateStation.name);
+        const target = deriveStationPassedTarget(route, destination, candidateStation);
+        await fireFgAuxStationPassedNotification(
+          candidateStation.name,
+          target.count,
+          target.targetKind,
+          target.targetName,
+        );
         logFiredStationPassed(source, candidateStation.name);
       } catch (e) {
         logger.error('FG 보조 발사 실패:', e);
@@ -296,6 +369,9 @@ async function runSilenceGateAndDispatch(params: {
   clearDismissSilenceAction: () => Promise<void>;
   /** #1816 — lock 활성 trip만 진입. gate-passed-event-on-lock-origin에서 boardingStationId 비교. */
   lock: import('../../../shared/types/boardingLock').BoardingLock | null;
+  /** #2362 — dispatchStationPassed로 그대로 전달 → count/target 도출. */
+  route: Route;
+  destination: Station | null;
 }): Promise<void> {
   // #1599 — boardingLock active 시 candidate가 lock origin(= boardingStationId)이면 station-passed 차단.
   // 2026-06-20 용마산 evidence: lock 활성 1초 후 lock origin 자체에 station-passed fire (X1).
@@ -333,6 +409,8 @@ async function runSilenceGateAndDispatch(params: {
     isCancelled: params.isCancelled,
     errorLogPrefix: params.errorLogPrefix,
     lock: params.lock,
+    route: params.route,
+    destination: params.destination,
   });
 }
 
@@ -1426,6 +1504,8 @@ export function useStationAlarm({
           userLocation,
           clearDismissSilenceAction,
           lock,
+          route,
+          destination,
         });
       })();
     }
@@ -1577,6 +1657,8 @@ export function useStationAlarm({
         userLocation,
         clearDismissSilenceAction,
         lock,
+        route,
+        destination,
       });
     })();
 
@@ -1656,6 +1738,8 @@ export function useStationAlarm({
         userLocation,
         clearDismissSilenceAction,
         lock,
+        route,
+        destination,
       });
     })();
 

--- a/src/features/alarm/utils/__tests__/stationNotification.test.ts
+++ b/src/features/alarm/utils/__tests__/stationNotification.test.ts
@@ -1,5 +1,6 @@
 import * as Notifications from 'expo-notifications';
 import { Platform, Vibration } from 'react-native';
+import i18next from 'i18next';
 import {
   setupNotificationHandler,
   initStationNotification,
@@ -7,6 +8,7 @@ import {
   clearStationNotification,
   clearAlarmNotification,
   buildAlarmContent,
+  buildStationPassedContent,
   fireFgAuxStationPassedNotification,
 } from '../stationNotification';
 import { buildStationNotifCollapseId } from '../stationNotifCollapseId';
@@ -954,23 +956,23 @@ describe('stationNotification', () => {
     });
   });
 
-  describe('fireFgAuxStationPassedNotification (#2122 FG 보조 발사)', () => {
+  describe('fireFgAuxStationPassedNotification (#2122 FG 보조 발사, #2362 count/target 배선)', () => {
     beforeEach(async () => {
       await AsyncStorage.clear();
     });
 
-    it('device token 보유 시 backend collapse-id와 동일한 identifier로 로컬 알림을 발사하고 markLocalStationFired를 stamp한다', async () => {
+    it('device token 보유 시 backend collapse-id와 동일한 identifier로 "역 도착 / N정거장 남음" 로컬 알림을 발사하고 markLocalStationFired를 stamp한다', async () => {
       await AsyncStorage.setItem(APNS_TOKEN_KEY, 'a'.repeat(64));
 
-      await fireFgAuxStationPassedNotification('중곡');
+      await fireFgAuxStationPassedNotification('중곡', 1, 'destination', '강남');
 
       const expectedId = buildStationNotifCollapseId('a'.repeat(64));
       expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
         expect.objectContaining({
           identifier: expectedId,
           content: expect.objectContaining({
-            title: '역 통과',
-            body: '중곡역을 지나고 있어요',
+            title: '중곡역 도착',
+            body: '강남까지 1정거장 남음',
             sound: false,
           }),
           trigger: null,
@@ -979,17 +981,69 @@ describe('stationNotification', () => {
       expect(mockMarkLocalStationFired).toHaveBeenCalledWith('중곡', 'station-passed');
     });
 
+    it('targetKind=transfer 전달 시에도 동일 템플릿으로 환승역명이 대상에 채워진다', async () => {
+      await AsyncStorage.setItem(APNS_TOKEN_KEY, 'c'.repeat(64));
+
+      await fireFgAuxStationPassedNotification('중곡', 2, 'transfer', '홍대입구');
+
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({
+            body: '홍대입구까지 2정거장 남음',
+          }),
+        }),
+      );
+    });
+
     it('기존 동일 identifier 알림을 dismiss한 뒤 재발사한다 (scheduleNotification 공용 helper 재사용)', async () => {
       await AsyncStorage.setItem(APNS_TOKEN_KEY, 'b'.repeat(64));
-      await fireFgAuxStationPassedNotification('군자');
+      await fireFgAuxStationPassedNotification('강남', 3, 'destination', '홍대입구');
       const expectedId = buildStationNotifCollapseId('b'.repeat(64));
       expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith(expectedId);
     });
 
     it('device token 미보유 시(등록 전) 스킵 — 알림 발사/stamp 모두 안 함', async () => {
-      await fireFgAuxStationPassedNotification('중곡');
+      await fireFgAuxStationPassedNotification('중곡', 1, 'destination', '강남');
       expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
       expect(mockMarkLocalStationFired).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('buildStationPassedContent (#2362 — 역 도착 + N정거장 남음)', () => {
+    afterEach(async () => {
+      await i18next.changeLanguage('ko');
+    });
+
+    // 강남/중곡 모두 stations.json에 동일 노선 중복 항목이 있어도 nameEn/nameJa/nameHanja가
+    // 일치하는 안정적 실역명 — 4개 locale × count 단수/복수(destination target).
+    it.each([
+      ['ko', 1, '강남까지 1정거장 남음'],
+      ['ko', 3, '강남까지 3정거장 남음'],
+      ['en', 1, '1 stop to Gangnam'],
+      ['en', 3, '3 stops to Gangnam'],
+      ['ja', 1, 'カンナムまで残り1駅'],
+      ['ja', 3, 'カンナムまで残り3駅'],
+      ['zh', 1, '距江南还有1站'],
+      ['zh', 3, '距江南还有3站'],
+    ])('locale=%s, count=%s(destination target) → %s', async (lang, count, expectedBody) => {
+      await i18next.changeLanguage(lang);
+      const { body } = buildStationPassedContent('중곡', count as number, 'destination', '강남');
+      expect(body).toBe(expectedBody);
+    });
+
+    // 환승 전(targetKind='transfer')도 동일 템플릿 — 대상만 환승역명으로 바뀐다.
+    it.each([
+      ['ko', '홍대입구까지 2정거장 남음'],
+      ['en', '2 stops to Hongik Univ.'],
+    ])('locale=%s, 환승 전(targetKind=transfer) → %s', async (lang, expectedBody) => {
+      await i18next.changeLanguage(lang);
+      const { body } = buildStationPassedContent('중곡', 2, 'transfer', '홍대입구');
+      expect(body).toBe(expectedBody);
+    });
+
+    it('title은 targetKind와 무관하게 "{{역}}역 도착" 고정', () => {
+      const { title } = buildStationPassedContent('중곡', 1, 'destination', '강남');
+      expect(title).toBe('중곡역 도착');
     });
   });
 

--- a/src/features/alarm/utils/stationNotification.ts
+++ b/src/features/alarm/utils/stationNotification.ts
@@ -574,16 +574,34 @@ export async function clearAlarmNotification(): Promise<void> {
   } catch { /* 무시 */ }
 }
 
+/** 매역 알림 대상 종류 — 다음 환승역인지 최종 도착역인지. `StationWaypointKind`의 subset
+ *  (backend push discriminator SSoT 재사용. 'intermediate'는 이 맥락에 해당 없음). */
+export type StationPassedTargetKind = Extract<StationWaypointKind, 'transfer' | 'destination'>;
+
 /**
- * #918 — "역 통과" 알림 title/body 빌더. #2122 FG 보조 발사(`fireFgAuxStationPassedNotification`)와
+ * #918 → #2362 — "역 통과" 알림 title/body 빌더. #2122 FG 보조 발사(`fireFgAuxStationPassedNotification`)와
  * `stationPrescheduler`(#918 OS 사전예약, station-passed kind)가 동일 카피를 공유한다 —
  * 발사 채널(FG 즉시 발사 vs OS 사전 예약)이 달라도 사용자가 보는 문구는 항상 같아야 한다.
+ *
+ * #2362 — "OO역 통과/지나고 있어요" → "OO역 도착 / {대상}까지 N정거장 남음"으로 교체.
+ * `targetKind`는 title/body 문구 자체를 바꾸지 않는다(환승 전/후 모두 동일 "{{target}}까지
+ * N정거장" 템플릿) — 호출자가 어느 대상(환승역/도착역)을 넘기는지 명시하는 타입 계약이다
+ * (backend waypoint kind와 정합). 기존 locale 키 재사용: `route.stationPassed`(title) +
+ * `route.stopsRemainingToDestination`(body, "destination" 파라미터에 환승역명도 그대로 대입 가능).
  */
-export function buildStationPassedContent(stationName: string): { title: string; body: string } {
+export function buildStationPassedContent(
+  stationName: string,
+  count: number,
+  targetKind: StationPassedTargetKind,
+  targetName: string,
+): { title: string; body: string } {
   return {
-    title: i18next.t('route.intermediatePassedTitle'),
-    body: i18next.t('route.intermediatePassedBody', {
+    title: i18next.t('route.stationPassed', {
       name: getStationDisplayNameByName(stationName, allStations),
+    }),
+    body: i18next.t('route.stopsRemainingToDestination', {
+      count,
+      destination: getStationDisplayNameByName(targetName, allStations),
     }),
   };
 }
@@ -599,12 +617,20 @@ export function buildStationPassedContent(stationName: string): { title: string;
  *
  * device token(APNS_TOKEN_KEY) 미보유 시(등록 전) backend와 동일한 collapse-id를 만들 수 없어
  * 발사를 스킵한다 — 이 경우 사용자는 기존처럼 backend push만 받는다(회귀 아님).
+ *
+ * #2362 — count/targetKind/targetName은 caller(`useStationAlarm.dispatchStationPassed`)가
+ * route hopIndex/waypoint 기반 정수로 도출해 전달한다(GPS 좌표 추정 금지).
  */
-export async function fireFgAuxStationPassedNotification(stationName: string): Promise<void> {
+export async function fireFgAuxStationPassedNotification(
+  stationName: string,
+  count: number,
+  targetKind: StationPassedTargetKind,
+  targetName: string,
+): Promise<void> {
   const deviceToken = await AsyncStorage.getItem(APNS_TOKEN_KEY);
   if (!deviceToken) return;
   const identifier = buildStationNotifCollapseId(deviceToken);
-  const { title, body } = buildStationPassedContent(stationName);
+  const { title, body } = buildStationPassedContent(stationName, count, targetKind, targetName);
   await scheduleNotification(identifier, { title, body, sound: false });
   await markLocalStationFired(stationName, 'station-passed');
 }

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -274,8 +274,6 @@
     "atCurrentStation": "Currently at {{name}}",
     "approximateDistance": "~{{m}}m",
     "stationPassed": "Arrived at {{name}}",
-    "intermediatePassedTitle": "Passing station",
-    "intermediatePassedBody": "Passing through {{name}}",
     "tripEndedArrivedTitle": "Arrived at destination",
     "tripEndedTitle": "Guidance ended",
     "tripEndedBody": "Route guidance has ended",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -274,8 +274,6 @@
     "atCurrentStation": "現在 {{name}}",
     "approximateDistance": "約{{m}}m",
     "stationPassed": "{{name}}駅に到着",
-    "intermediatePassedTitle": "駅通過",
-    "intermediatePassedBody": "{{name}}駅を通過しています",
     "tripEndedArrivedTitle": "目的地に到着",
     "tripEndedTitle": "案内終了",
     "tripEndedBody": "ルート案内を終了しました",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -274,8 +274,6 @@
     "atCurrentStation": "현재 {{name}}역",
     "approximateDistance": "약 {{m}}m",
     "stationPassed": "{{name}}역 도착",
-    "intermediatePassedTitle": "역 통과",
-    "intermediatePassedBody": "{{name}}역을 지나고 있어요",
     "tripEndedArrivedTitle": "목적지 도착",
     "tripEndedTitle": "안내 종료",
     "tripEndedBody": "경로 안내를 종료했어요",

--- a/src/shared/i18n/locales/zh.json
+++ b/src/shared/i18n/locales/zh.json
@@ -274,8 +274,6 @@
     "atCurrentStation": "当前 {{name}}",
     "approximateDistance": "约{{m}}m",
     "stationPassed": "已到达{{name}}",
-    "intermediatePassedTitle": "经过站点",
-    "intermediatePassedBody": "正在经过{{name}}站",
     "tripEndedArrivedTitle": "已到达目的地",
     "tripEndedTitle": "导航结束",
     "tripEndedBody": "路线导航已结束",


### PR DESCRIPTION
## 요약
Closes #2362

매역 진행 알림 문구를 "OO역 통과 / 지나고 있어요" → "**OO역 도착 / {환승역|도착역}까지 N정거장 남음**"으로 교체하고, 남은 정거장 수(count)와 대상(환승역/도착역)을 발사 시점에 배선한다. Part of #2361 (ADR-033 D2/A1·A2).

## 변경 사항
- `buildStationPassedContent(stationName, count, targetKind, targetName)`로 시그니처 확장. 기존 `route.intermediatePassedTitle`/`intermediatePassedBody` 대신 이미 존재하는 `route.stationPassed`(제목) + `route.stopsRemainingToDestination`(본문, 환승역/도착역 공용 템플릿) 재사용.
- `fireFgAuxStationPassedNotification`에 count/targetKind/targetName 파라미터 추가.
- `useStationAlarm.ts`에 `deriveStationPassedTarget` 헬퍼 추가 — route(direct/transfer/multi-transfer)가 매 폴링 주기 `updateRouteFromPosition`으로 이미 갱신해둔 `stops`/`stopsToTransfer`/`stopsFromTransfer`/`stopsAfterLastTransfer` 필드에서 다음 hop 대상(환승역|도착역)과 count를 그대로 읽는다. GPS 좌표 기반 추정 없음. `transfers` 배열은 인덱스 하드코딩 없이 순회.
- 폐기된 `route.intermediatePassedTitle`/`intermediatePassedBody` locale 키를 ko/en/ja/zh 4개 파일에서 제거(코드 사용처 0건 확인 후 제거).
- `buildStationPassedContent` 4개국 locale × count 단수/복수 × 환승 전/후 target 테스트, `fireFgAuxStationPassedNotification`/`useStationAlarm` count·target 전달 경로(direct/transfer/multi-transfer 전 분기) 테스트 추가.

## Wire-completion 5단
1. **Orphan**: `npm run lint:orphan` pass. 신규 export(`buildStationPassedContent` 확장, `StationPassedTargetKind`) 모두 caller 존재(정적 import).
2. **V/X dashboard**: FG 상태에서 실제 발사되는 로컬 배너 문구이므로 DebugModal 알림 프리뷰 또는 로컬 발사 로그(`logFiredStationPassed`)로 확인 가능. 코드 레벨로는 신규 유닛 테스트가 4개국 locale × target 조합 문구를 전수 검증.
3. **의존 PR**: N/A (독립, 프론트엔드 전용 변경).
4. **측정 plan**: 실기기 FG 매역 진입 1회 캡처로 배너 문구가 "OO역 도착 / N정거장 남음"으로 바뀌었는지 확인. 회귀 시 `logFiredStationPassed` 로그의 stationName과 실제 배너 문구 비교.
5. **Device verify**: 필요 — 문구가 실물 배너에 어떻게 렌더링되는지(줄바꿈, 4개국 로케일)는 코드 검증만으로 확정 불가. 시나리오 = FG 상태에서 lock 활성 trip으로 매역 1개 이상 통과.

## 검증
- `npx jest src/features/alarm/utils/__tests__/stationNotification.test.ts src/features/alarm/hooks/__tests__/useStationAlarm.test.ts` — 339 passed, 100% coverage(두 대상 파일)
- `npm run type-check` — pass
- `npm run lint:orphan` — No orphan exports detected