### PR TITLE
fix(#2371): 명시 의향 시점에 navigationActive 켜기 — 잠금 시 BG GPS 미시작 (ADR-014 옵션1)

### DIFF
--- a/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
+++ b/src/features/alarm/hooks/__tests__/useBoardingLockController.test.tsx
@@ -62,6 +62,22 @@ const { __mockSetInfoModeEnabled: setInfoModeEnabledMock } = jest.requireMock(
   '../../store/useUserIntentStore',
 );
 
+// #2371 — useNavigationStore mock. createLockFromTrain(user-tap) 진입 시 startNavigation()
+// 호출 검증 + hydrateLockFromCandidate(무탭 fusion auto-lock)에서는 호출 안 됨을 검증
+// (#2306 RCA — 잠금 시 BG GPS 미시작 회귀 fix + 무탭 auto-lock BG 시작 금지 회귀 방지).
+jest.mock('../../../route/store/useNavigationStore', () => {
+  const mockStartNavigation = jest.fn();
+  return {
+    useNavigationStore: {
+      getState: () => ({ startNavigation: mockStartNavigation }),
+    },
+    __mockStartNavigation: mockStartNavigation,
+  };
+});
+const { __mockStartNavigation: startNavigationMock } = jest.requireMock(
+  '../../../route/store/useNavigationStore',
+);
+
 // #2330 (consensus-D) — 탭 vs consensus-confirmed 불일치 telemetry mock.
 const mockRecordConsensusMismatch = jest.fn();
 jest.mock('../../utils/consensusMismatchMetrics', () => ({
@@ -494,6 +510,42 @@ describe('useBoardingLockController', () => {
       });
     });
 
+    // #2371 (Part of #2306) — BoardingTrainList 직접 탭(user-tap)도 boardingPrompt 응답과 동급
+    // 명시 의향 표명이므로 navigationActive도 함께 켠다. hydrateLockFromCandidate(무탭 fusion
+    // auto-lock 경로)에서는 절대 켜지면 안 됨(#1973 "명시 trigger 없이 자동 BG 금지") — 회귀
+    // 방지 assertion은 아래 hydrateLockFromCandidate describe에 배치.
+    describe('#2371 navigationActive wire (BG GPS 시작 트리거)', () => {
+      beforeEach(() => {
+        startNavigationMock.mockClear();
+      });
+
+      it('createLockFromTrain 성공 시 startNavigation() 1회 호출', async () => {
+        const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+        await act(async () => {
+          result.current.createLockFromTrain(makeTrain({ trainCode: 'T-NAV' }));
+        });
+        expect(startNavigationMock).toHaveBeenCalledTimes(1);
+      });
+
+      it('destinationId null이면 startNavigation 호출 안 함 (createLock 진입 전 early return)', async () => {
+        const { result } = renderHook(() =>
+          useBoardingLockController({ ...defaultInputs, destinationId: null }),
+        );
+        await act(async () => {
+          result.current.createLockFromTrain(makeTrain());
+        });
+        expect(startNavigationMock).not.toHaveBeenCalled();
+      });
+
+      it('#1449 trip route 외 line은 startNavigation 호출 안 함 (createLock 진입 전 line filter reject)', async () => {
+        const { result } = renderHook(() => useBoardingLockController(defaultInputs));
+        await act(async () => {
+          result.current.createLockFromTrain(makeTrain({ trainCode: 'T-WRONG', line: '9' }));
+        });
+        expect(startNavigationMock).not.toHaveBeenCalled();
+      });
+    });
+
     // #2330 (consensus-D, 설계 SSoT #2323 (3)) — 탭은 항상 우선(SSoT). consensus-confirmed
     // 제안과 다른 열차를 탭하면 mismatch telemetry가 기록되지만 lock 채택 자체는 차단되지 않는다.
     describe('#2330 consensus-mismatch telemetry', () => {
@@ -604,6 +656,19 @@ describe('useBoardingLockController', () => {
       // 통과하므로 "아직 미탑승" 가능성이 정상 케이스다. evidence로 뭉뚱그리지 않고 false —
       // initialEtaSeconds도 없으므로 hasConsumedOriginWait는 보수적으로 대기를 유지한다.
       expect(lock.boardingEvidence).toBe(false);
+    });
+
+    // #2371 (Part of #2306) 회귀 방지 — hydrateLockFromCandidate는 무탭 fusion auto-lock
+    // 경로이므로 startNavigation()이 절대 호출되면 안 된다(#1973 "명시 trigger 없이 자동 BG
+    // 금지"). createLockFromTrain(user-tap)에서만 startNavigation을 호출하는지 대칭 검증.
+    it('#2371: hydrateLockFromCandidate(무탭)는 startNavigation() 호출 안 함', async () => {
+      startNavigationMock.mockClear();
+      const { result } = renderHook(() => useBoardingLockController(hydrateInputs));
+      await act(async () => {
+        result.current.hydrateLockFromCandidate({ trainCode: 'AUTO-7', line: '2', subwayId: '1002' });
+      });
+      await waitFor(() => expect(mockSetBoardingLock).toHaveBeenCalled());
+      expect(startNavigationMock).not.toHaveBeenCalled();
     });
 
     it('역명+line 매칭 시 boardingStationId 정정', async () => {

--- a/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
+++ b/src/features/alarm/hooks/__tests__/useBoardingPromptResponder.test.ts
@@ -89,6 +89,18 @@ jest.mock('../../store/useUserIntentStore', () => {
   };
 });
 
+// #2371 — useNavigationStore mock. boarded path 진입 시 startNavigation() 호출 검증
+// (#2306 RCA — 잠금 시 BG GPS 미시작 회귀 fix).
+jest.mock('../../../route/store/useNavigationStore', () => {
+  const mockStartNavigation = jest.fn();
+  return {
+    useNavigationStore: {
+      getState: () => ({ startNavigation: mockStartNavigation }),
+    },
+    __mockStartNavigation: mockStartNavigation,
+  };
+});
+
 // #2278 — useLegAdvanceStore mock. hop-end BOARDED 응답에서 stampLegAdvance 호출 검증.
 jest.mock('../../store/useLegAdvanceStore', () => {
   const mockStampLegAdvance = jest.fn();
@@ -114,6 +126,9 @@ const { __mockCreateLock: createLockMock, __mockReleaseLock: releaseLockMock } =
 );
 const { __mockSetInfoModeEnabled: setInfoModeEnabledMock } = jest.requireMock(
   '../../store/useUserIntentStore',
+);
+const { __mockStartNavigation: startNavigationMock } = jest.requireMock(
+  '../../../route/store/useNavigationStore',
 );
 const { __mockStampLegAdvance: stampLegAdvanceMock } = jest.requireMock(
   '../../store/useLegAdvanceStore',
@@ -731,6 +746,32 @@ describe('handleResponse — #1923 infoModeEnabled stamp (사용자 명시 의�
     const deps = makeHandleResponseDeps({ destinationId: null });
     await handleResponse(BOARDING_PROMPT_ACTION_BOARDED, HANDLE_RESPONSE_PAYLOAD, deps);
     expect(setInfoModeEnabledMock).toHaveBeenCalledWith(true);
+  });
+});
+
+// #2371 (Part of #2306) — boardingPrompt "탑승" 응답도 navigationActive를 켠다. 잠금 시 BG GPS
+// 세션이 navigationActive에만 걸려 있어, 명시 의향을 표명해도 화면을 잠그면 BG GPS가 시작되지
+// 않던 회귀(#2306 RCA)의 fix — infoMode stamp와 정확히 대칭으로 wire.
+describe('handleResponse — #2371 navigationActive wire (BG GPS 시작 트리거)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each<[string, string]>([
+    ['[탑승] 액션', BOARDING_PROMPT_ACTION_BOARDED],
+    ['기본 탭 ($default)', Notifications.DEFAULT_ACTION_IDENTIFIER],
+  ])('%s → useNavigationStore.startNavigation() 호출', async (_label, action) => {
+    (findStationByNameAndLine as jest.Mock).mockReturnValue({ id: 'S1', line: '2', name: '강남' });
+    await handleResponse(action, HANDLE_RESPONSE_PAYLOAD, makeHandleResponseDeps());
+    expect(startNavigationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each<[string, string]>([
+    ['[미탑승] 액션', BOARDING_PROMPT_ACTION_NOT_BOARDED],
+    ['알 수 없는 액션', 'SOME_OTHER_ACTION'],
+  ])('%s → startNavigation 호출 안 함 (dismissed path는 의향 표명 없음)', async (_label, action) => {
+    await handleResponse(action, HANDLE_RESPONSE_PAYLOAD, makeHandleResponseDeps());
+    expect(startNavigationMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/features/alarm/hooks/useBoardingLockController.ts
+++ b/src/features/alarm/hooks/useBoardingLockController.ts
@@ -11,6 +11,7 @@ import { AppState, type AppStateStatus } from 'react-native';
 import * as Haptics from 'expo-haptics';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import { useUserIntentStore } from '../store/useUserIntentStore';
+import { useNavigationStore } from '../../route/store/useNavigationStore';
 import { useLegAdvanceStore } from '../store/useLegAdvanceStore';
 import { resolveTripDirection } from '../../route/utils/tripDirection';
 import { findStationByNameAndLine } from '../../../shared/utils/stationLookup';
@@ -321,6 +322,12 @@ export function useBoardingLockController({
       // lock 활성 trip은 backend가 boardingLock 분기로 처리하므로 본 stamp는 graceful surplus,
       // 단 lock이 실패/만료해 lockless 전환되면 즉시 lockless intermediate gate 활성화 보장.
       void useUserIntentStore.getState().setInfoModeEnabled(true);
+      // #2371 (Part of #2306) — BoardingTrainList 직접 탭(user-tap)도 boardingPrompt 응답과
+      // 동급 명시 의향 표명이므로 navigationActive도 함께 켠다(#2306 RCA — 화면 잠금 시 BG GPS
+      // 미시작 → leg 알림 전멸). hydrateLockFromCandidate(무탭 fusion auto-lock 경로)는 의도적으로
+      // 건드리지 않는다 — 사용자 명시 탭이 아닌 candidate 채택까지 BG GPS를 켜면 #1973
+      // "명시 trigger 없이 자동 BG 금지" 원칙 위반.
+      useNavigationStore.getState().startNavigation();
       const durationMin = expectedDurationMinutes ?? FALLBACK_BOARDING_DURATION_MINUTES;
       // #663: boardingLine은 사용자가 실제로 탭한 train의 line을 사용. currentStation.line은 fusion
       // 추정이라 환승역에서 옆 노선으로 잘못 잠긴 상태일 수 있다 (#662). train.line은 어댑터가 subwayId로

--- a/src/features/alarm/hooks/useBoardingPromptResponder.ts
+++ b/src/features/alarm/hooks/useBoardingPromptResponder.ts
@@ -28,6 +28,7 @@ import type { ArrivalInfo, StationArrival } from '../../../shared/types/arrival'
 import { dismissBoardingPrompt } from '../../nearest-station/api/positionUpload';
 import { useBoardingLockStore } from '../store/useBoardingLockStore';
 import { useUserIntentStore } from '../store/useUserIntentStore';
+import { useNavigationStore } from '../../route/store/useNavigationStore';
 import { useLegAdvanceStore } from '../store/useLegAdvanceStore';
 import { isValidLineNumber } from '../../../shared/constants/lineApiNames';
 import { pickAutoTrainCodeFromArrivals } from '../utils/boardingPromptAutoLock';
@@ -218,6 +219,13 @@ export async function handleResponse(
     // ADR-014 §X "사용자 명시 의향 trip = lock 활성과 동급 정확도 보장 의무" 정합.
     // setInfoModeEnabled는 memory + storage atomic — graceful 실패(다음 cycle에서 재시도).
     void useUserIntentStore.getState().setInfoModeEnabled(true);
+    // #2371 (Part of #2306) — 잠금 시 BG GPS 세션이 navigationActive(useNavigationStore)에만
+    // 걸려 있어, boardingPrompt "탑승" 응답처럼 명시 의향을 표명해도 화면을 잠그면 BG GPS가
+    // 시작되지 않는 회귀(#2306 RCA, 25분 leg 알림 전멸). ADR-014 "사용자 명시 의향 trip = lock
+    // 활성과 동급 정확도 보장 의무"를 BG 시작 트리거까지 실제 확장 — infoMode와 정확히 대칭으로
+    // navigationActive도 함께 켠다. startNavigation은 set만 수행(비동기 아님), infoMode를
+    // 건드리지 않으므로 위 stamp와 중복되지 않는다.
+    useNavigationStore.getState().startNavigation();
     await tryAutoLock(payload, deps);
     // #1888 (RC-13) — banner 탭($default) 케이스만 home 화면으로 navigate. 사용자가 list를 보고 싶다는
     // 명시 의향(action button BOARDED는 silent autolock으로 끝, navigation은 surplus).

--- a/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
+++ b/src/features/alarm/store/__tests__/tripBoundCleanups.test.ts
@@ -501,6 +501,19 @@ describe('tripBoundCleanups', () => {
       expect(AsyncStorage.removeItem).toHaveBeenCalled();
     });
 
+    // #2371 (Part of #2306) — navigationActive는 사용자 "일시정지" 버튼(stopNavigation)에만
+    // false로 복귀했다. backend auto-end / silent push trip-ended 등 버튼을 거치지 않는 종료
+    // 경로에서도 이 배열을 거쳐 memory-only navigationActive가 stale true로 남지 않아야
+    // useBackgroundLocation이 다음 trip 시작 전까지 불필요하게 BG GPS를 유지하지 않는다.
+    it('#2371: runTripBoundCleanups 실행 시 navigationActive가 false로 reset된다 (stale true 방지)', async () => {
+      useNavigationStore.setState({ navigationActive: true, pausedAt: null });
+      (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+
+      await runTripBoundCleanups();
+
+      expect(useNavigationStore.getState().navigationActive).toBe(false);
+    });
+
     it('S12-8: enumeration 가드 — TRIP_BOUND_CLEANUPS 길이가 baseline 이하로 떨어지면 회귀', () => {
       // 새 cleanup 항목이 추가될 때마다 baseline을 한 줄로 갱신. 누군가 실수로 항목을 제거하면
       // 본 assertion이 빨갛게 깨져 의도된 제거인지 코드리뷰에서 확인하도록 강제한다.
@@ -513,7 +526,8 @@ describe('tripBoundCleanups', () => {
       // #1892 / #1885 — endLiveActivityCleanup 1 신규 (RC-9 LA orphan 26분 cascade fix).
       // #2045 — clearLastSilentPushReceivedAt 1 신규 (Signal 4 판정 오염 차단).
       // #2293 — clearNavigationPausedAt 1 신규 (일시정지 stamp leak 차단).
-      const MIN_ITEMS = 28;
+      // #2371 — resetNavigationActive 1 신규 (navigationActive stale true 방지, BG GPS 배터리).
+      const MIN_ITEMS = 29;
       expect(TRIP_BOUND_CLEANUPS.length).toBeGreaterThanOrEqual(MIN_ITEMS);
     });
   });

--- a/src/features/alarm/store/tripBoundCleanups.ts
+++ b/src/features/alarm/store/tripBoundCleanups.ts
@@ -181,6 +181,16 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
   // useStateRehydration sentinel / useLaunchTripReconciliation cold-launch / pause-auto-end
   // backstop 자체)가 모두 이 배열을 거치므로, 여기 한 줄 추가로 두 채널 모두 자동 wire된다.
   clearNavigationPauseState,
+  // #2371 (Part of #2306) — trip 종료 시 navigationActive stale true 방지. navigationActive는
+  // 사용자 "일시정지" 버튼(HomeScreen.handleStopNavigation → stopNavigation)에만 false로
+  // 복귀했다. 하지만 backend auto-end / silent push trip-ended / launch reconciliation 등
+  // 버튼을 거치지 않는 trip 종료 경로는 navigationActive를 건드리지 않아, 다음 trip 시작
+  // 전까지 useBackgroundLocation이 stale true를 보고 불필요하게 BG GPS를 유지한다(배터리).
+  // stopNavigation을 그대로 재사용하지 않는 이유: stopNavigation은 pausedAt에 Date.now()를
+  // stamp하는데("일시정지" 배지 의미), 바로 위 clearNavigationPauseState가 pausedAt을 null로
+  // 되돌리는 것과 순서에 의존하게 된다 — navigationActive만 직접 false로 set해 pausedAt과
+  // 독립적으로 처리한다.
+  resetNavigationActive,
 ];
 
 /**
@@ -193,6 +203,15 @@ export const TRIP_BOUND_CLEANUPS: ReadonlyArray<() => Promise<void>> = [
 function clearNavigationPauseState(): Promise<void> {
   useNavigationStore.getState().clearPausedAt();
   return clearNavigationPausedAt();
+}
+
+/**
+ * #2371 (Part of #2306) — navigationActive를 trip 종료 시 false로 되돌린다.
+ * memory-only 값(persist 미적용)이라 storage clear가 필요 없어 Promise.resolve로 즉시 완료.
+ */
+function resetNavigationActive(): Promise<void> {
+  useNavigationStore.setState({ navigationActive: false });
+  return Promise.resolve();
 }
 
 /**


### PR DESCRIPTION
Part of #2306

## 배경

#2306 RCA(2026-08-23) 결과: 잠금 시 BG GPS 세션이 "안내 시작" 버튼(`navigationActive`)에만 걸려 있어, 사용자가 lock을 잡거나 boardingPrompt에 응답해도 화면 잠그면 BG GPS 미시작 → leg 알림 전멸(08-12 뚝섬→건대환승→용마산 evidence, 25분 침묵).

**결정(사용자 확정)**: 옵션1 — 명시 의향 행위 시점에 `navigationActive`도 함께 켠다. ADR-014를 BG 시작 트리거까지 실제 확장.

## 변경

두 핸들러, 기존 `setInfoModeEnabled(true)` 바로 옆에 `useNavigationStore.getState().startNavigation()` 추가:

1. `src/features/alarm/hooks/useBoardingPromptResponder.ts` — boardingPrompt "탑승" 응답
2. `src/features/alarm/hooks/useBoardingLockController.ts` (`createLockFromTrain`) — BoardingTrainList 직접 탭 / lock 생성

`hydrateLockFromCandidate`(무탭 fusion auto-lock 경로)는 의도적으로 건드리지 않음 — #1973 "명시 trigger 없이 자동 BG 금지" 원칙 유지.

### 필수 검증 체크 결과

1. **auto-lock 가드** — `createLockFromTrain`은 user-tap 전용, `hydrateLockFromCandidate`(무탭 fusion)는 미변경. 회귀 방지 테스트로 고정(무탭 lock이면 navigationActive 안 켜짐).
2. **lifecycle reset** — 코드 확인 결과 `TRIP_BOUND_CLEANUPS`(trip 종료 단일 chokepoint, 4개 진입 경로 공유)에 `navigationActive` reset 항목이 **없었음**. 버튼을 거치지 않는 trip 종료(backend auto-end / silent push trip-ended / launch reconciliation)에서 stale true가 다음 trip까지 남아 BG GPS를 불필요하게 지속시키는 배터리 회귀가 실재해 `resetNavigationActive`를 신규 추가·wire함(`stopNavigation` 재사용 X — pausedAt stamp 부작용 회피, navigationActive만 독립적으로 false set).
3. **destination 존재** — `useBackgroundLocation` 게이트는 `destination && navigationActive` 둘 다 필요. #2306 케이스는 destination 존재 확인됨(RCA 근거) — 본 PR 범위 밖.

## Wire-completion 5단

1. **Orphan**: `npm run lint:orphan` pass — 기존 export(`startNavigation`) 재사용, 신규 export(`resetNavigationActive`)는 모듈 내부 함수(비export)로 배열에만 wire.
2. **V/X dashboard**: DebugModal Raw Signal — 잠금 후 fusion cycle 지속 여부 관측. `useBackgroundLocation.ts:120` BG 시작 로그.
3. **의존 PR**: N/A (device-only frontend).
4. **측정 plan**: 다음 검증 탑승 — lock/프롬프트 응답 후 화면 잠금 → fusion cycle이 잠금 구간에도 지속되는지(전 대비 25분 침묵 재발 0).
5. **Device verify**: 필요 — 잠금 상태 leg 1구간. type+unit으로는 navigationActive 세팅만 검증, BG GPS 실제 지속 및 trip 종료 후 stale 미잔류는 실기기 전용.

## 테스트

- `useBoardingPromptResponder.test.ts`: boarded/$default 응답 시 `startNavigation()` 호출, dismissed 경로는 미호출.
- `useBoardingLockController.test.tsx`: `createLockFromTrain`(user-tap) 성공/early-return/line-filter-reject 케이스, `hydrateLockFromCandidate`(무탭)에서 미호출 회귀 방지.
- `tripBoundCleanups.test.ts`: trip 종료 시 `navigationActive` false reset + enumeration baseline 갱신(28→29).
- 관련 파일 3종 100% coverage(stmts/branch/funcs/lines) 로컬 확인. `npm run type-check` pass. `npm run lint:orphan` pass.

Closes 아님 — Part of #2306
