### PR TITLE
fix(#2374): 언어 변경 시 알림 카테고리 라벨 재등록 + 하드코딩 한국어 i18n 전환

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -59,6 +59,15 @@ getCurrentTripCorrId().catch((e) =>
   layoutLogger.warn('tripCorrId hydrate 실패(#1501):', e),
 );
 
+// #2374 — 4개 알림 카테고리 setup 함수 배열. 부팅 시 개별 호출(아래, 기존 유지)과 별도로
+// RootContent 내부의 언어 변경 재등록 useEffect가 이 배열을 순회 호출한다(하드코딩 나열 방지).
+const NOTIFICATION_CATEGORY_SETUP_FNS = [
+  setupBoardingPromptCategory,
+  setupDisembarkPromptCategory,
+  setupAlarmCategory,
+  setupTripEndedCategory,
+];
+
 SplashScreen.preventAutoHideAsync();
 setupNotificationHandler();
 // iOS silent push BG task 등록 — APNs payload 수신용.
@@ -181,6 +190,15 @@ function RootContent() {
   // 언어 전환 시 Android 알림 채널 이름을 새 언어로 갱신 (권한 다이얼로그 트리거 없이 채널만)
   useEffect(() => {
     refreshNotificationChannels().catch((e) => layoutLogger.error('알림 채널 갱신 실패:', e));
+  }, [i18nInstance.language]);
+
+  // #2374 — iOS 알림 카테고리 액션 버튼 라벨 재등록. 부팅 시 모듈 톱레벨 1회 등록만으로는
+  // i18next.changeLanguage() 이후 버튼 라벨이 옛 언어로 남는다. 위 refreshNotificationChannels
+  // effect와 동일 패턴으로 언어 변경마다 4개 카테고리를 재등록한다.
+  useEffect(() => {
+    NOTIFICATION_CATEGORY_SETUP_FNS.forEach((setup) => {
+      setup().catch((e) => layoutLogger.warn('알림 카테고리 재등록 실패(#2374):', e));
+    });
   }, [i18nInstance.language]);
 
   // #1780 — 첫 실행 온보딩 redirect.

--- a/src/features/alarm/utils/__tests__/notificationCategory.test.ts
+++ b/src/features/alarm/utils/__tests__/notificationCategory.test.ts
@@ -1,5 +1,6 @@
 import * as Notifications from 'expo-notifications';
 import i18next from 'i18next';
+import { setLang, installLanguageRestoreHook } from '../../../../testUtils/i18nLanguageOverride';
 import {
   ALARM_ACTION_ACKNOWLEDGE,
   ALARM_ACTION_END_TRIP,
@@ -21,6 +22,8 @@ import {
 jest.mock('expo-notifications', () => ({
   setNotificationCategoryAsync: jest.fn(),
 }));
+
+installLanguageRestoreHook();
 
 describe('setupBoardingPromptCategory (#819)', () => {
   beforeEach(() => {
@@ -119,6 +122,18 @@ describe('setupAlarmCategory (#1798 P2)', () => {
     );
   });
 
+  // #2374 — 하드코딩 한국어('확인'/'trip 종료')를 i18next.t() 키로 전환. 언어별 라벨 검증.
+  it.each(['ko', 'en', 'ja', 'zh'])('%s 언어에서 버튼 라벨이 i18next 번역 키로 로컬라이즈된다 (#2374)', async (lang) => {
+    setLang(lang);
+    await setupAlarmCategory();
+    const [, actions] = (Notifications.setNotificationCategoryAsync as jest.Mock).mock
+      .calls[0] as [string, { identifier: string; buttonTitle: string }[]];
+    const acknowledge = actions.find((a) => a.identifier === ALARM_ACTION_ACKNOWLEDGE);
+    const endTrip = actions.find((a) => a.identifier === ALARM_ACTION_END_TRIP);
+    expect(acknowledge?.buttonTitle).toBe(i18next.t('notifications.actions.acknowledge'));
+    expect(endTrip?.buttonTitle).toBe(i18next.t('notifications.actions.endTrip'));
+  });
+
   it('Notifications가 throw해도 graceful (no throw)', async () => {
     (Notifications.setNotificationCategoryAsync as jest.Mock).mockRejectedValueOnce(
       new Error('not supported'),
@@ -143,6 +158,16 @@ describe('setupTripEndedCategory (#1798 P2)', () => {
         }),
       ]),
     );
+  });
+
+  // #2374 — 하드코딩 한국어('다음 여정 시작')를 i18next.t() 키로 전환. 언어별 라벨 검증.
+  it.each(['ko', 'en', 'ja', 'zh'])('%s 언어에서 버튼 라벨이 i18next 번역 키로 로컬라이즈된다 (#2374)', async (lang) => {
+    setLang(lang);
+    await setupTripEndedCategory();
+    const [, actions] = (Notifications.setNotificationCategoryAsync as jest.Mock).mock
+      .calls[0] as [string, { identifier: string; buttonTitle: string }[]];
+    const nextTrip = actions.find((a) => a.identifier === TRIP_ENDED_ACTION_NEXT_TRIP);
+    expect(nextTrip?.buttonTitle).toBe(i18next.t('notifications.actions.nextTrip'));
   });
 
   it('Notifications가 throw해도 graceful (no throw)', async () => {

--- a/src/features/alarm/utils/notificationCategory.ts
+++ b/src/features/alarm/utils/notificationCategory.ts
@@ -121,14 +121,14 @@ export async function setupAlarmCategory(): Promise<void> {
     await Notifications.setNotificationCategoryAsync(ALARM_CATEGORY, [
       {
         identifier: ALARM_ACTION_ACKNOWLEDGE,
-        buttonTitle: '확인',
+        buttonTitle: i18next.t('notifications.actions.acknowledge'),
         options: {
           opensAppToForeground: false,
         },
       },
       {
         identifier: ALARM_ACTION_END_TRIP,
-        buttonTitle: 'trip 종료',
+        buttonTitle: i18next.t('notifications.actions.endTrip'),
         options: {
           opensAppToForeground: false,
           isDestructive: true,
@@ -149,7 +149,7 @@ export async function setupTripEndedCategory(): Promise<void> {
     await Notifications.setNotificationCategoryAsync(TRIP_ENDED_CATEGORY, [
       {
         identifier: TRIP_ENDED_ACTION_NEXT_TRIP,
-        buttonTitle: '다음 여정 시작',
+        buttonTitle: i18next.t('notifications.actions.nextTrip'),
         options: {
           opensAppToForeground: true,
         },

--- a/src/shared/i18n/__tests__/i18n.test.ts
+++ b/src/shared/i18n/__tests__/i18n.test.ts
@@ -97,4 +97,19 @@ describe('i18n instance', () => {
       expect(label.length).toBeGreaterThan(0);
     },
   );
+
+  // #2374 — notificationCategory.ts 하드코딩 한국어 → i18n 전환분. 4언어 모두 키 정의됨을 가드.
+  it.each([
+    'notifications.actions.acknowledge',
+    'notifications.actions.endTrip',
+    'notifications.actions.nextTrip',
+  ] as const)('resolves %s for all supported languages (#2374)', async (key) => {
+    for (const lang of ['ko', 'en', 'ja', 'zh'] as const) {
+      await i18n.changeLanguage(lang);
+      const label: string = i18n.t(key);
+      expect(label).not.toBe(key);
+      expect(typeof label).toBe('string');
+      expect(label.length).toBeGreaterThan(0);
+    }
+  });
 });


### PR DESCRIPTION
## 배경

언어 변경 시 알림 카테고리 액션 버튼 라벨이 옛 언어로 남는 결함 (4개 카테고리 공통). RCA는 이슈 #2374 참조.

## 변경

1. `app/_layout.tsx` — 기존 `refreshNotificationChannels()` 재등록 `useEffect(() => {...}, [i18nInstance.language])` 패턴과 대칭으로, 4개 `setup*Category()` 함수를 배열(`NOTIFICATION_CATEGORY_SETUP_FNS`)로 묶어 언어 변경 시 순회 재호출하는 useEffect 추가. 기존 부팅 시 모듈 톱레벨 개별 호출은 그대로 유지(idempotent).
2. `notificationCategory.ts` — `setupAlarmCategory`/`setupTripEndedCategory`의 하드코딩 한국어(`'확인'`/`'trip 종료'`/`'다음 여정 시작'`)를 `i18next.t('notifications.actions.*')`로 전환. locale 키(`acknowledge`/`endTrip`/`nextTrip`)는 ko/en/ja/zh 4언어 모두 이미 존재해 신규 키 추가는 불필요했음.

## 테스트

- `src/features/alarm/utils/__tests__/notificationCategory.test.ts` — 언어별(ko/en/ja/zh) `setupAlarmCategory`/`setupTripEndedCategory` 버튼 라벨이 `i18next.t()` 값과 일치하는지 검증 추가.
- `src/shared/i18n/__tests__/i18n.test.ts` — `notifications.actions.{acknowledge,endTrip,nextTrip}` 키가 4언어 모두 정의돼 있고 fallback(키 자체) 아닌 실제 문자열을 반환하는지 가드 추가.
- `app/_layout.tsx`는 coverage 범위 밖(route entry) — 재등록 useEffect 자체는 type-check로만 검증.

## Wire-completion 5단

1. **Orphan 없음**: 기존 export(`setupBoardingPromptCategory` 등) 재사용, 신규 export 없음. `npm run lint:orphan` pass.
2. **V/X dashboard**: DebugModal에 "카테고리 최종 등록 언어" 관측 필드 없음 — 이슈 본문에 명시된 gap 그대로. 회귀 재발 시 device 로그로만 확인 가능. 신규 관측 필드 추가는 범위 밖.
3. **의존 PR**: N/A.
4. **측정 plan**: 언어 변경 후 알림 배너 액션 버튼 라벨이 새 언어로 표시되는지 실기기에서 확인 (설정 > 언어 변경 → long-press로 알림 액션 노출 확인).
5. **Device verify**: 필요 — 알림 카테고리 버튼은 실제 푸시 배너 long-press로만 육안 확인 가능. 본 PR은 type+unit(재등록 호출 + 라벨 값)만 검증.

Closes #2374